### PR TITLE
[CBRD-24743] change broker_monitor.c - from ncurses to tinfo functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ set(WITH_LIBEXPAT_URL "https://github.com/libexpat/libexpat/releases/download/R_
 set(WITH_LIBJANSSON_URL "http://www.digip.org/jansson/releases/jansson-2.10.tar.gz")
 
 # editline library sources URL
-set(WITH_LIBEDIT_URL "https://github.com/CUBRID/libedit/archive/refs/tags/libedit_v1.tar.gz")
+set(WITH_LIBEDIT_URL "https://github.com/CUBRID/libedit/archive/refs/tags/csql_v1.1.tar.gz")
 
 # rapidjson library sources URL
 set(WITH_RAPIDJSON_URL "https://github.com/Tencent/rapidjson/archive/v1.1.0.tar.gz")
@@ -155,13 +155,11 @@ set(WITH_SYSTEM_PREFIX "SYSTEM" CACHE STRING "System library prefix (default: SY
 set(WITH_LIBEXPAT     "${WITH_EXTERNAL_PREFIX}" CACHE STRING "Build with expat library (default: EXTERNAL)")
 set(WITH_LIBJANSSON   "${WITH_EXTERNAL_PREFIX}" CACHE STRING "Build with jansson library (default: EXTERNAL)")
 set(WITH_LIBEDIT      "${WITH_EXTERNAL_PREFIX}" CACHE STRING "Build with editline library (default: EXTERNAL)")
-set(WITH_LIBNCURSES   "${WITH_SYSTEM_PREFIX}" CACHE STRING "Build with ncurses library (default: SYSTEM)")
 set(WITH_LIBOPENSSL   "${WITH_EXTERNAL_PREFIX}" CACHE STRING "Build with openssl library (default: EXTERNAL)")
 set(WITH_LIBUNIXODBC  "${WITH_EXTERNAL_PREFIX}" CACHE STRING "Build with unixODBC library (default: EXTERNAL)")
 set(WITH_RE2          "${WITH_EXTERNAL_PREFIX}" CACHE STRING "Build with re2 library (default: EXTERNAL)")
 
 
-message(STATUS "Build with Curses library: ${WITH_LIBNCURSES}")
 message(STATUS "Build with editline library: ${WITH_LIBEDIT}")
 message(STATUS "Build with expat library: ${WITH_LIBEXPAT}")
 message(STATUS "Build with jansson library: ${WITH_LIBJANSSON}")
@@ -1007,38 +1005,6 @@ endif()
 list(APPEND EP_INCLUDES ${LIBJANSSON_INCLUDES})
 list(APPEND EP_LIBS ${LIBJANSSON_LIBS})
 
-# WITH_LIBNCURSES can have multiple values with different meanings
-# on Linux:
-# * "SYSTEM"   - uses ncurses installed in the system (for more info check https://cmake.org/cmake/help/v3.10/module/FindCurses.html)
-set(LIBNCURSES_TARGET libncurses)
-if(UNIX)
-  if(WITH_LIBNCURSES STREQUAL "SYSTEM")
-    include(FindCurses)
-    find_package(Curses REQUIRED)
-    CHECK_LIBRARY_EXISTS("${CURSES_LIBRARIES}" wtimeout "" LIBNCURSES_HAS_WTIMEOUT)
-    set(LIBNCURSES_INCLUDES "${CURSES_INCLUDE_DIRS}")
-    set(LIBNCURSES_LIBS "${CURSES_LIBRARIES}")
-
-    if(NOT LIBNCURSES_HAS_WTIMEOUT)
-      message(STATUS "search for tinfo library")
-      find_library(TINFO_LIBRARY NAMES tinfo)
-      if(TINFO_LIBRARY)
-        message(STATUS "found tinfo library")
-        CHECK_LIBRARY_EXISTS("${TINFO_LIBRARY}" wtimeout "" TINFO_HAS_WTIMEOUT)
-        if(TINFO_HAS_WTIMEOUT)
-          set(CURSES_LIBRARIES ${CURSES_LIBRARIES} ${TINFO_LIBRARY})
-        else(TINFO_HAS_WTIMEOUT)
-          message(FATAL_ERROR "tinfo library does not have wtimeout")
-        endif(TINFO_HAS_WTIMEOUT)
-      else(TINFO_LIBRARY)
-        message(FATAL_ERROR "no tinfo library")
-      endif(TINFO_LIBRARY)
-    endif(NOT LIBNCURSES_HAS_WTIMEOUT)
-  else(WITH_LIBNCURSES STREQUAL "SYSTEM")
-    message(FATAL_ERROR "Invalid WITH_LIBNCURSES option value ${WITH_LIBNCURSES}")
-  endif(WITH_LIBNCURSES STREQUAL "SYSTEM")
-endif(UNIX)
-
 # WITH_LIBEDIT can have multiple values with different meanings
 # on Linux:
 # * "EXTERNAL" - (default) builds editline library from URL stored in ${WITH_LIBEDIT_URL} uses the library created by the build
@@ -1060,7 +1026,7 @@ if(UNIX)
       LOG_INSTALL          TRUE
       TIMEOUT              600
       DOWNLOAD_NO_PROGRESS 1
-      CONFIGURE_COMMAND    "LDFLAGS=-L${CMAKE_CURRENT_BINARY_DIR}/external/lib" ${DEFAULT_CONFIGURE_OPTS}
+      CONFIGURE_COMMAND    "LDFLAGS=-L${CMAKE_CURRENT_BINARY_DIR}/external/lib" ${DEFAULT_CONFIGURE_OPTS} LIBS=-ldl
       BUILD_COMMAND        make all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       INSTALL_COMMAND      make install AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       "${LIBEDIT_BYPRODUCTS}"

--- a/src/broker/broker_monitor.c
+++ b/src/broker/broker_monitor.c
@@ -341,6 +341,7 @@ static const char *get_sql_log_mode_string (T_SQL_LOG_MODE_VALUE mode);
 static const char *get_status_string (T_APPL_SERVER_INFO * as_info_p, char appl_server);
 static void get_cpu_usage_string (char *buf_p, float usage);
 
+
 static void move (int x, int y);
 static void refresh ();
 static void clear ();
@@ -1983,24 +1984,28 @@ endwin ()
 static void
 refresh ()
 {
+  fflush (stdout);
 }
 
 static void
 move (int x, int y)
 {
   tputs (tgoto (cm, x, y), 1, putchar);
+  fflush (stdout);
 }
 
 static void
 clrtobot ()
 {
   tputs (cd, 1, putchar);
+  fflush (stdout);
 }
 
 static void
 clrtoeol ()
 {
   tputs (ce, 1, putchar);
+  fflush (stdout);
 }
 
 static void
@@ -2065,6 +2070,7 @@ static void
 clear ()
 {
   tputs (cl, 1, putchar);
+  fflush (stdout);
 }
 
 static int

--- a/src/broker/broker_monitor.c
+++ b/src/broker/broker_monitor.c
@@ -357,7 +357,7 @@ static void *initscr ();
 static void noecho ();
 static void timeout (int delay);
 static void addstr (const char *);
-static int stdin_noblock (void);
+static int tty_noblock (void);
 static int get_timeout (void);
 
 typedef char *(*tgoto_func_t) (const char *cap, int col, int row);
@@ -2068,7 +2068,7 @@ clear ()
 }
 
 static int
-stdin_noblock ()
+tty_noblock ()
 {
   struct termios term;
 
@@ -2169,7 +2169,7 @@ initscr ()
   ce = tgetstr ("ce", NULL);
   cl = tgetstr ("cl", NULL);
 
-  if ((ret = stdin_noblock ()) < 0)
+  if ((ret = tty_noblock ()) < 0)
     {
       fprintf (stderr, "ERROR: Cannot set terminal: error = %d", ret);
       return NULL;

--- a/src/broker/broker_monitor.c
+++ b/src/broker/broker_monitor.c
@@ -2170,10 +2170,29 @@ initscr ()
       return NULL;
     }
 
-  cm = tgetstr ("cm", NULL);
-  cd = tgetstr ("cd", NULL);
-  ce = tgetstr ("ce", NULL);
-  cl = tgetstr ("cl", NULL);
+  if ((cm = tgetstr ("cm", NULL)) == NULL)
+    {
+      fprintf (stderr, "ERROR: Cannot find 'cursor motion (cm)' capability for the terminal\n");
+      return NULL;
+    }
+
+  if ((cd = tgetstr ("cd", NULL)) == NULL)
+    {
+      fprintf (stderr, "ERROR: Cannot find 'clear to end of screen (cd)' capability for the terminal\n");
+      return NULL;
+    }
+
+  if ((ce = tgetstr ("ce", NULL)) == NULL)
+    {
+      fprintf (stderr, "ERROR: Cannot find 'Clear to end of line (ce)' capability for the terminal\n");
+      return NULL;
+    }
+
+  if ((cl = tgetstr ("cl", NULL)) == NULL)
+    {
+      fprintf (stderr, "ERROR: Cannot find 'Clear screen and cursor home (cl)' capability for the terminal\n");
+      return NULL;
+    }
 
   if ((ret = tty_noblock ()) < 0)
     {

--- a/src/broker/broker_monitor.c
+++ b/src/broker/broker_monitor.c
@@ -2033,9 +2033,9 @@ addstr (const char *str)
 {
   /* line# starts at 0 */
   if (str == NULL || currentY >= tty_Lines)
-   {
+    {
       return;
-   }
+    }
 
   currentY += num_newlines (str);
 

--- a/src/broker/broker_monitor.c
+++ b/src/broker/broker_monitor.c
@@ -547,6 +547,11 @@ main (int argc, char **argv)
 #else
       if ((win = initscr ()) == NULL)
 	{
+	  if (dl_handle != NULL)
+	    {
+	      dlclose (dl_handle);
+	      dl_handle = NULL;
+	    }
 	  fprintf (stderr, "fail to initialize tinfo library\n");
 	  return 127;
 	}

--- a/src/broker/broker_monitor.c
+++ b/src/broker/broker_monitor.c
@@ -2172,7 +2172,6 @@ initscr ()
   if ((ret = stdin_noblock ()) < 0)
     {
       fprintf (stderr, "ERROR: Cannot set terminal: error = %d", ret);
-      dlclose (dl_handle);
       return NULL;
     }
 

--- a/src/broker/broker_monitor.c
+++ b/src/broker/broker_monitor.c
@@ -2030,7 +2030,7 @@ addstr (const char *str)
       return;
     }
 
-  fprintf (stdout, str);
+  fprintf (stdout, "%s", str);
   fflush (stdout);
 }
 

--- a/src/broker/broker_monitor.c
+++ b/src/broker/broker_monitor.c
@@ -2116,10 +2116,10 @@ num_newlines (const char *str)
         }
 
       if (num_Chars == tty_Cols)
-        {
-          num_nl++;
-          num_Chars = 0;
-        }
+	{
+	  num_nl++;
+	  num_Chars = 0;
+	}
     }
 
   return num_nl;

--- a/src/broker/broker_monitor.c
+++ b/src/broker/broker_monitor.c
@@ -1998,6 +1998,18 @@ refresh ()
 static void
 move (int x, int y)
 {
+  int lines = -1;
+  int cols = -1;
+
+  if (tgetent (NULL, term) == 1)
+    {
+      lines = tgetnum ("li");
+      cols = tgetnum ("co");
+    }
+
+  tty_Lines = lines < 0 ? tty_Lines : lines;
+  tty_Cols = cols < 0 ? tty_Cols : cols;
+
   currentY = y;
   tputs (tgoto (cm, x, y), 1, putchar);
   fflush (stdout);

--- a/src/broker/broker_monitor.c
+++ b/src/broker/broker_monitor.c
@@ -2106,14 +2106,14 @@ num_newlines (const char *str)
   while (str[i])
     {
       if (str[i++] == '\n')
-        {
-          num_nl++;
-          num_Chars = 0;
-        }
+	{
+	  num_nl++;
+	  num_Chars = 0;
+	}
       else
-        {
-          num_Chars++;
-        }
+	{
+	  num_Chars++;
+	}
 
       if (num_Chars == tty_Cols)
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24743

**Purpose**
* removing ncurses version dependancy from CUBRID binaries
* same way as we did for csql
* same behavior with previous 'cubrid broker status -s' but do not use ncurses and uses tinfo

**Implementation**
* rewrite following curses funtions using tinfo functions
  * move ()
  * clrtobot ()
  * clrtoeol ()
  * endwin ()
  * addstr ()
* implementing the gtch() function without using ncurses
* dynamic binding of following tinfo functions at run time
  * tgetent ()
  * tgoto ()
  * tgetstr ()
  * tputs ()

**Remarks**
* CUBRID binaries will search libtinfo.so.x from the user's LIB paths
* CMakeLists.txt is just rolled back from previous 81046b
* **addstr** () will print as many lines as **LINES** from the beginning.
* Even if you resize your terminal, the command below will output the actual number of LINES and COLUMNS.
`$ echo $LINES $COLUMNS`
* And, tgetnum ("li") returns the actual line number of the current terminal.
* this PR can respond to **LINE** and **COLUMNS**
* this PR can respond to **terminal resize**.