### PR TITLE
[CBRD-24746] Query with non-existent shard_id causes coredump

### DIFF
--- a/src/broker/shard_proxy_function.c
+++ b/src/broker/shard_proxy_function.c
@@ -1227,8 +1227,7 @@ relay_prepare_request:
       proxy_event_free (event_p);
       event_p = NULL;
 
-      if (ctx_p->shard_id != PROXY_INVALID_SHARD
-	  && (ctx_p->shard_id >= 0 && ctx_p->shard_id < proxy_Shard_io.max_shard))
+      if (ctx_p->shard_id != PROXY_INVALID_SHARD)
 	{
 	  EXIT_FUNC ();
 	  goto free_context;

--- a/src/broker/shard_proxy_function.c
+++ b/src/broker/shard_proxy_function.c
@@ -1227,7 +1227,8 @@ relay_prepare_request:
       proxy_event_free (event_p);
       event_p = NULL;
 
-      if (ctx_p->shard_id != PROXY_INVALID_SHARD)
+      if (ctx_p->shard_id != PROXY_INVALID_SHARD
+	  && (ctx_p->shard_id >= 0 && ctx_p->shard_id < proxy_Shard_io.max_shard))
 	{
 	  EXIT_FUNC ();
 	  goto free_context;

--- a/src/broker/shard_proxy_handler.c
+++ b/src/broker/shard_proxy_handler.c
@@ -727,6 +727,10 @@ end:
 
   if (ctx_p->free_context)
     {
+      if (proxy_context_direct_send_error (ctx_p) < 0)
+	{
+	  PROXY_LOG (PROXY_LOG_MODE_ERROR, "Failed to send error message");
+	}
       proxy_context_free (ctx_p);
     }
 

--- a/src/broker/shard_proxy_io.c
+++ b/src/broker/shard_proxy_io.c
@@ -4919,6 +4919,32 @@ proxy_convert_error_code (int error_ind, int error_code, char *driver_info, T_BR
   return error_code;
 }
 
+int
+proxy_context_direct_send_error (T_PROXY_CONTEXT * ctx_p)
+{
+  T_CLIENT_IO *cli_io_p = NULL;
+  T_SOCKET_IO *sock_io_p = NULL;
+
+  cli_io_p = proxy_client_io_find_by_ctx (ctx_p->client_id, ctx_p->cid, ctx_p->uid);
+  if (cli_io_p == NULL)
+    {
+      PROXY_LOG (PROXY_LOG_MODE_ERROR, "Failed to find client. " "(client_id:%d, context id:%d, context uid:%u).",
+		 ctx_p->client_id, ctx_p->cid, ctx_p->uid);
+
+      return -1;
+    }
+
+  sock_io_p = proxy_socket_io_find (cli_io_p->fd);
+  if (sock_io_p == NULL)
+    {
+      PROXY_LOG (PROXY_LOG_MODE_ERROR, "Failed to find socket entry. (fd:%d).", cli_io_p->fd);
+      return -1;
+    }
+
+  proxy_socket_io_write (sock_io_p);
+  return 0;
+}
+
 #if defined(LINUX)
 static int
 proxy_get_max_socket (void)

--- a/src/broker/shard_proxy_io.c
+++ b/src/broker/shard_proxy_io.c
@@ -3626,8 +3626,6 @@ proxy_cas_alloc_by_ctx (int client_id, int shard_id, int cas_id, int ctx_cid, un
       PROXY_LOG (PROXY_LOG_MODE_ERROR, "Invalid shard/CAS id is requested. " "(shard_id:%d, cas_id:%d). ", shard_id,
 		 cas_id);
 
-      assert (false);
-
       return NULL;
     }
 

--- a/src/broker/shard_proxy_io.h
+++ b/src/broker/shard_proxy_io.h
@@ -160,4 +160,6 @@ extern char *proxy_get_driver_info_by_fd (T_SOCKET_IO * sock_io_p);
 extern void proxy_available_cas_wait_timer (void);
 extern int proxy_convert_error_code (int error_ind, int error_code, char *driver_info, T_BROKER_VERSION client_version,
 				     bool to_new);
+
+extern int proxy_context_direct_send_error (T_PROXY_CONTEXT * ctx_p);
 #endif /* _SHARD_PROXY_IO_H_ */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24746

Purpose
In the Debug version, performing a query with a non-existent shard_id causes a coredump.
And, in the Release version, "Request timed out" occurs.

Implementation
N/A

Remarks
N/A