### PR TITLE
[CBRD-24704] demodb is not installed when installing CUBRID engine with msi file for windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1326,9 +1326,12 @@ if(USE_CUBRID_ENV)
     ${CMAKE_SOURCE_DIR}/README
     ${CMAKE_SOURCE_DIR}/contrib/readme/README_TAR_INSTALL
     DESTINATION ${CUBRID_PREFIXDIR})
-  install(FILES
-    ${CMAKE_SOURCE_DIR}/contrib/readme/databases.txt
-    DESTINATION ${CUBRID_DATABASES})
+# on Windows, databases.txt is create from 'make_cubrid_demo.bat' because databases.txt is deleted in MSI file for install.
+  if(UNIX)
+    install(FILES
+      ${CMAKE_SOURCE_DIR}/contrib/readme/databases.txt
+      DESTINATION ${CUBRID_DATABASES})
+  endif(UNIX)
   install(FILES
     ${CMAKE_SOURCE_DIR}/contrib/readme/README_SOCK.txt
     DESTINATION ${CUBRID_VARDIR}/${CUBRID_SOCK}

--- a/cmake/CPackWixPatch.cmake.in
+++ b/cmake/CPackWixPatch.cmake.in
@@ -70,7 +70,8 @@
     <InstallExecuteSequence>
       <Custom Action="RegisterService" After="InstallFiles"><![CDATA[NOT Installed]]></Custom>
       <Custom Action="CreateScheduledTask" After="RegisterService"><![CDATA[NOT Installed]]></Custom>
-      <Custom Action="CreateDemodb" After="CreateScheduledTask"><![CDATA[NOT Installed AND INSTALLWITHDEMODB]]></Custom>
+      <Custom Action="CreateforDatabases" After="CreateScheduledTask"><![CDATA[NOT Installed]]></Custom>
+      <Custom Action="CreateDemodb" After="CreateforDatabases"><![CDATA[NOT Installed AND INSTALLWITHDEMODB]]></Custom>
       <Custom Action="DeleteScheduledTask" After="InstallInitialize"><![CDATA[Installed]]></Custom>
       <Custom Action="KillTray" Before="DeleteScheduledTask"><![CDATA[Installed]]></Custom>
     </InstallExecuteSequence>
@@ -91,9 +92,12 @@
 <!-- Kill Tray before uninstall -->
     <SetProperty Id="KillTray" Before="KillTray" Sequence="execute" Value="&quot;[SystemFolder]TASKKILL.EXE&quot; /F /IM CUBRID_Service_Tray.exe"/>
     <CustomAction Id="KillTray" Return="ignore" Impersonate="no" Execute="deferred" BinaryKey="WixCA" DllEntry="WixQuietExec"/>
+<!-- Create Databases folder and databases.txt -->
+    <SetProperty Id="CreateforDatabases" Before="CreateforDatabases" Sequence="execute" Value="&quot;[SystemFolder]CMD.EXE&quot; /C &quot;[#CM_FP_Unspecified.share.scripts_for_msi.create_for_databases.bat] [INSTALL_ROOT]&quot;"/>
+    <CustomAction Id="CreateforDatabases" BinaryKey="WixCA" DllEntry="CAQuietExec" Execute="deferred" Return="ignore"/>
 <!-- Create demodb -->
     <Property Id="INSTALLWITHDEMODB" Value="1"/>
-    <SetProperty Id="CreateDemodb" Before="CreateDemodb" Sequence="execute" Value="&quot;[SystemFolder]CMD.EXE&quot; /C &quot;[#CM_FP_Unspecified.demo.make_cubrid_demo.bat] demodb [INSTALL_ROOT]&quot;"/>
+    <SetProperty Id="CreateDemodb" Before="CreateDemodb" Sequence="execute" Value="&quot;[SystemFolder]CMD.EXE&quot; /C &quot;[#CM_FP_Unspecified.share.scripts_for_msi.make_demo_msi.bat] demodb [INSTALL_ROOT]&quot;"/>
     <CustomAction Id="CreateDemodb" BinaryKey="WixCA" DllEntry="CAQuietExec" Execute="deferred" Return="ignore"/>
 <!-- Start Tray after install -->
     <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" Value="1"/>

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -89,6 +89,14 @@ if(WIN32)
     DESTINATION ${CUBRID_DATADIR}/windows_scripts/)
 endif(WIN32)
 
+# msi scripts for windows
+if(WIN32)
+  install(FILES
+    ${CMAKE_SOURCE_DIR}/contrib/scripts_for_msi/make_demo_msi.bat
+    ${CMAKE_SOURCE_DIR}/contrib/scripts_for_msi/create_for_databases.bat
+    DESTINATION ${CUBRID_DATADIR}/scripts_for_msi/)
+endif(WIN32)
+
 # scripts for setup
 if(UNIX)
   install(PROGRAMS

--- a/contrib/scripts_for_msi/create_for_databases.bat
+++ b/contrib/scripts_for_msi/create_for_databases.bat
@@ -1,0 +1,28 @@
+@echo off
+
+REM
+REM  Copyright 2008 Search Solution Corporation
+REM  Copyright 2016 CUBRID Corporation
+REM 
+REM   Licensed under the Apache License, Version 2.0 (the "License");
+REM   you may not use this file except in compliance with the License.
+REM   You may obtain a copy of the License at
+REM 
+REM       http://www.apache.org/licenses/LICENSE-2.0
+REM 
+REM   Unless required by applicable law or agreed to in writing, software
+REM   distributed under the License is distributed on an "AS IS" BASIS,
+REM   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM   See the License for the specific language governing permissions and
+REM   limitations under the License.
+REM 
+
+if not "%1"=="" (
+  set CUBRID=%1
+  set CUBRID_DATABASES=%1\Databases
+)
+
+if NOT exist %CUBRID_DATABASES% md %CUBRID_DATABASES%
+if NOT exist %CUBRID_DATABASES%\databases.txt type NUL > %CUBRID_DATABASES%\databases.txt
+
+:exit

--- a/contrib/scripts_for_msi/make_demo_msi.bat
+++ b/contrib/scripts_for_msi/make_demo_msi.bat
@@ -1,0 +1,56 @@
+@echo off
+
+REM
+REM  Copyright 2008 Search Solution Corporation
+REM  Copyright 2016 CUBRID Corporation
+REM 
+REM   Licensed under the Apache License, Version 2.0 (the "License");
+REM   you may not use this file except in compliance with the License.
+REM   You may obtain a copy of the License at
+REM 
+REM       http://www.apache.org/licenses/LICENSE-2.0
+REM 
+REM   Unless required by applicable law or agreed to in writing, software
+REM   distributed under the License is distributed on an "AS IS" BASIS,
+REM   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM   See the License for the specific language governing permissions and
+REM   limitations under the License.
+REM 
+
+set CUBRID_DISABLE_JAVA_STORED_PROCEDURE=1
+set DBNAME=demodb
+if not "%1"=="" (
+        set DBNAME=%1
+
+        if exist "%2" (
+                set CUBRID=%2
+                set CUBRID_DATABASES=%2\Databases
+        )
+)
+
+if exist %DBNAME% goto done
+
+if NOT exist %CUBRID_DATABASES%\demodb (
+  md %CUBRID_DATABASES%\demodb 
+) else (
+  del /Q %CUBRID_DATABASES%\demodb\demodb_vinf
+  del /Q %CUBRID_DATABASES%\demodb\demodb_lginf
+  del /Q %CUBRID_DATABASES%\demodb\demodb_lgat
+  del /Q %CUBRID_DATABASES%\demodb\demodb
+)
+
+set PATH=%PATH%;%CUBRID%\cci\bin;
+cd %CUBRID_DATABASES%\demodb
+
+echo ********** Creating database %DBNAME% ...
+%CUBRID%\bin\cub_admin createdb --db-volume-size=100M --log-volume-size=100M --replace %DBNAME% en_US.utf8
+echo ********** Loading objects ...
+%CUBRID%\bin\cub_admin loaddb %DBNAME% --schema-file=%CUBRID%\demo\demodb_schema --data-file=%CUBRID%\demo\demodb_objects --no-user-specified-name -u dba
+echo ********** Makedemo complete.
+goto exit
+
+:done
+echo The %DBNAME% database has already been created.
+echo Use %CUBRID%\cubrid deletedb %DBNAME% to remove it.
+
+:exit


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24704

Purpose
Reopen Issue (If datatabases.txt is not exist and demodb is exist, demodb is not created.)

Implementation
- add 'make_demo_msi.bat' script for msi installer
- add batch file for 'databases' folder and 'databases.txt'

Remark
for backport
