### PR TITLE
[CBRD-24535] [11.2] change cubrid.[sh|csh] for ncurses links

### DIFF
--- a/contrib/scripts/cubrid.sh
+++ b/contrib/scripts/cubrid.sh
@@ -21,48 +21,25 @@ export CUBRID_DATABASES=$CUBRID/databases
 LD_LIBRARY_PATH=$CUBRID/lib:$CUBRID/cci/lib:$LD_LIBRARY_PATH
 SHLIB_PATH=$LD_LIBRARY_PATH
 LIBPATH=$LD_LIBRARY_PATH
-PATH=$CUBRID/bin:$PATH
+PATH=$CUBRID/bin:/usr/sbin:$PATH
 export LD_LIBRARY_PATH SHLIB_PATH LIBPATH PATH
 
-
-LIB=$CUBRID/lib
-
-if [ -f /etc/redhat-release ];then
-	OS=$(cat /etc/system-release-cpe | cut -d':' -f'3-3')
-elif [ -f /etc/os-release ];then
-	OS=$(cat /etc/os-release | egrep "^ID=" | cut -d'=' -f2-2)
+is_ncurses5=$(ldconfig -p)
+if [ $? -ne 0 ];then
+  echo "ldconfig: Command not found or permission denied, please check it."
+  exit 1
 fi
 
-case $OS in
-	fedoraproject | centos | redhat | rocky | oracle)
-		if [ ! -h /lib64/libncurses.so.5 ] && [ ! -h $LIB/libncurses.so.5 ];then
-			ln -s /lib64/libncurses.so.6 $LIB/libncurses.so.5
-			ln -s /lib64/libform.so.6 $LIB/libform.so.5
-			ln -s /lib64/libtinfo.so.6 $LIB/libtinfo.so.5
-		fi
-		;;
-	prolinux)
-		if [ ! -h /usr/lib64/libncurses.so.5 ] && [ ! -h $LIB/libncurses.so.5 ];then
-			ln -s /usr/lib64/libncurses.so.6 $LIB/libncurses.so.5
-			ln -s /usr/lib64/libform.so.6 $LIB/libform.so.5
-			ln -s /usr/lib64/libtinfo.so.6 $LIB/libtinfo.so.5
-		fi
-		;;
-	ubuntu)
-		if [ ! -h /lib/x86_64-linux-gnu/libncurses.so.5 ] && [ ! -h $LIB/libncurses.so.5 ];then
-			ln -s /lib/x86_64-linux-gnu/libncurses.so.6 $LIB/libncurses.so.5
-			ln -s /lib/x86_64-linux-gnu/libform.so.6 $LIB/libform.so.5
-			ln -s /lib/x86_64-linux-gnu/libtinfo.so.6 $LIB/libtinfo.so.5
-		fi
-		;;
-	debian)
-		if [ ! -h /lib/x86_64-linux-gnu/libncurses.so.5 ] && [ ! -h $LIB/libncurses.so.5 ];then
-			ln -s /lib/x86_64-linux-gnu/libncurses.so.6 $LIB/libncurses.so.5
-			ln -s /lib/x86_64-linux-gnu/libtinfo.so.6 $LIB/libtinfo.so.5
-			ln -s /usr/lib/x86_64-linux-gnu/libform.so.6 $LIB/libform.so.5
-		fi
-		;;
-	*)
-		echo "CUBRID requires the ncurses package. Make sure the ncurses package is installed"
-		;;
-esac
+is_ncurses5=$(ldconfig -p | grep libncurses.so.5 | wc -l)
+
+if [ $is_ncurses5 -eq 0 ] && [ ! -f $CUBRID/lib/libncurses.so.5 ];then
+  for lib in libncurses libform libtinfo
+  do
+    curses_lib=$(ldconfig -p | grep $lib.so | grep -v "so.[1-4]" | sort -h | tail -1 | awk '{print $4}')
+    if [ -z "$curses_lib" ];then
+      echo "$lib.so: CUBRID requires the ncurses package. Make sure the ncurses package is installed"
+      break
+    fi
+    ln -s $curses_lib $CUBRID/lib/$lib.so.5
+  done
+fi


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24535

**Description**
* this is backport of #3915 to release/11.2

**Remarks**
* **cubrid.sh** and **cubrid.csh** were copied from CUBRID/cubrid 0a08e0073.