### PR TITLE
[CBRD-24756] Fix the crash while reading a log record for CDC/Flashback

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -12230,8 +12230,7 @@ cdc_get_overflow_recdes (THREAD_ENTRY * thread_p, LOG_PAGE * log_page_p, RECDES 
 
   if (((current_log_record->type == LOG_UNDO_DATA) && (rcvindex == RVOVF_PAGE_UPDATE) && is_redo)
       || ((current_log_record->type == LOG_REDO_DATA) && (rcvindex == RVOVF_PAGE_UPDATE) && !is_redo)
-      || rcvindex == RVOVF_CHANGE_LINK
-      || rcvindex == RVOVF_NEWPAGE_LINK)
+      || rcvindex == RVOVF_CHANGE_LINK || rcvindex == RVOVF_NEWPAGE_LINK)
     {
       /* start to traverse with prev_transla log record */
       LSA_COPY (&current_lsa, &current_log_record->prev_tranlsa);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -11205,6 +11205,42 @@ cdc_get_undo_record (THREAD_ENTRY * thread_p, LOG_PAGE * log_page_p, LOG_LSA lsa
   return scan_code;
 }
 
+/*
+ * cdc_log_read_advance_and_preserve_if_needed () - Fetch the next log page and preserve the existing one,
+ *                                                  if the (lsa.offset + size) exceeds the log page size
+ *
+ * return                     : error code
+ * thread_p (in)              : thread entry
+ * size (in)                  : size to read in log page
+ * lsa (in/out)               : log address to read
+ * log_page_p (in/out)        : fetch the next log page if needed
+ * preserved  (in/out)        : preserve existing log page if needed
+ */
+
+static int
+cdc_log_read_advance_and_preserve_if_needed (THREAD_ENTRY * thread_p, size_t size, LOG_LSA * lsa, LOG_PAGE * log_page_p,
+					     LOG_PAGE * preserved)
+{
+  if (lsa->offset + size >= (int) LOGAREA_SIZE)
+    {
+      /* Before fetching the next page, current log page is required to be preserved */
+      memcpy (preserved, log_page_p, IO_MAX_PAGE_SIZE);
+
+      lsa->pageid++;
+
+      if (logpb_fetch_page (thread_p, lsa, LOG_CS_FORCE_USE, log_page_p) != NO_ERROR)
+	{
+	  logpb_fatal_error (thread_p, true, ARG_FILE_LINE,
+			     "log page fetch in cdc_log_read_advance_and_preserve_if_needed ()");
+	  return ER_FAILED;
+	}
+
+      lsa->offset = 0;
+    }
+
+  return NO_ERROR;
+}
+
 int
 cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recdes, LOG_LSA * redo_lsa,
 		RECDES * redo_recdes, bool is_flashback)
@@ -11213,9 +11249,9 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
   int tmpbuf_index;
 
   char *log_pgbuf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
-  char *reserve_log_pgbuf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
+  char *preserved_log_pgbuf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
   LOG_PAGE *log_page_p = NULL;	// log_page for process_lsa : when process_lsa is advanced, then next log_page can be fetched into this buffer
-  LOG_PAGE *reserve_log_page_p = NULL;	// log_page for redo/undo lsa
+  LOG_PAGE *preserved_log_page_p = NULL;	// log_page for redo/undo lsa
 
   LOG_LSA process_lsa = LSA_INITIALIZER;
   LOG_LSA current_logrec_lsa = LSA_INITIALIZER;
@@ -11244,7 +11280,7 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
   int error_code = NO_ERROR;
 
   log_page_p = (LOG_PAGE *) PTR_ALIGN (log_pgbuf, MAX_ALIGNMENT);
-  reserve_log_page_p = (LOG_PAGE *) PTR_ALIGN (reserve_log_pgbuf, MAX_ALIGNMENT);
+  preserved_log_page_p = (LOG_PAGE *) PTR_ALIGN (preserved_log_pgbuf, MAX_ALIGNMENT);
 
   /* Get UNDO RECDES from undo lsa */
 
@@ -11265,8 +11301,6 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 	      goto error;
 	    }
 	}
-
-      memcpy (reserve_log_page_p, log_page_p, IO_MAX_PAGE_SIZE);
 
       LSA_COPY (&process_lsa, undo_lsa);
       LSA_COPY (&current_logrec_lsa, undo_lsa);
@@ -11322,7 +11356,12 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 	  {
 	    LOG_REC_UNDOREDO *undoredo = NULL;
 
-	    LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (*undoredo), &process_lsa, log_page_p);
+	    if ((error_code =
+		 cdc_log_read_advance_and_preserve_if_needed (thread_p, sizeof (*undoredo), &process_lsa, log_page_p,
+							      preserved_log_page_p)) != NO_ERROR)
+	      {
+		goto error;
+	      }
 
 	    undoredo = (LOG_REC_UNDOREDO *) (log_page_p->area + process_lsa.offset);
 	    rcvindex = undoredo->data.rcvindex;
@@ -11338,9 +11377,12 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 	      }
 	    else if (rcvindex == RVOVF_CHANGE_LINK || rcvindex == RVOVF_NEWPAGE_LINK)
 	      {
+		/* if the next log page is fetched into log_page_p, then use the preserved_log_page_p */
+		log_page_p = process_lsa.pageid == undo_lsa->pageid ? log_page_p : preserved_log_page_p;
+
 		/* GET OVF UNDO IMAGE */
 		if ((error_code =
-		     cdc_get_overflow_recdes (thread_p, log_page_p, undo_recdes, prev_lsa, RVOVF_PAGE_UPDATE,
+		     cdc_get_overflow_recdes (thread_p, log_page_p, undo_recdes, *undo_lsa, rcvindex,
 					      false)) != NO_ERROR)
 		  {
 		    goto error;
@@ -11354,15 +11396,24 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 	  {
 	    LOG_REC_UNDO *undo = NULL;
 
-	    LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (*undo), &process_lsa, log_page_p);
+	    if ((error_code =
+		 cdc_log_read_advance_and_preserve_if_needed (thread_p, sizeof (*undo), &process_lsa, log_page_p,
+							      preserved_log_page_p)) != NO_ERROR)
+	      {
+		goto error;
+	      }
+
 	    undo = (LOG_REC_UNDO *) (log_page_p->area + process_lsa.offset);
 	    rcvindex = undo->data.rcvindex;
 
 	    if (rcvindex == RVOVF_PAGE_UPDATE)
 	      {
+		/* if the next log page is fetched into log_page_p, then use the preserved_log_page_p */
+		log_page_p = process_lsa.pageid == undo_lsa->pageid ? log_page_p : preserved_log_page_p;
+
 		/* GET OVF UNDO IMAGE */
 		if ((error_code =
-		     cdc_get_overflow_recdes (thread_p, reserve_log_page_p, undo_recdes, *undo_lsa, rcvindex,
+		     cdc_get_overflow_recdes (thread_p, log_page_p, undo_recdes, *undo_lsa, rcvindex,
 					      false)) != NO_ERROR)
 		  {
 		    goto error;
@@ -11388,16 +11439,24 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 	    LOG_REC_REDO *redo = NULL;
 	    LOG_RCVINDEX rcvindex;
 
-	    LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (*redo), &process_lsa, log_page_p);
+	    if ((error_code =
+		 cdc_log_read_advance_and_preserve_if_needed (thread_p, sizeof (*redo), &process_lsa, log_page_p,
+							      preserved_log_page_p)) != NO_ERROR)
+	      {
+		goto error;
+	      }
 
 	    redo = (LOG_REC_REDO *) (log_page_p->area + process_lsa.offset);
 	    rcvindex = redo->data.rcvindex;
 
 	    if (rcvindex == RVOVF_PAGE_UPDATE)
 	      {
+		/* if the next log page is fetched into log_page_p, then use the preserved_log_page_p */
+		log_page_p = process_lsa.pageid == undo_lsa->pageid ? log_page_p : preserved_log_page_p;
+
 		/* GET OVF UNDO IMAGE */
 		if ((error_code =
-		     cdc_get_overflow_recdes (thread_p, reserve_log_page_p, undo_recdes, *undo_lsa, rcvindex,
+		     cdc_get_overflow_recdes (thread_p, log_page_p, undo_recdes, *undo_lsa, rcvindex,
 					      false)) != NO_ERROR)
 		  {
 		    goto error;
@@ -11438,8 +11497,6 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 		}
 	    }
 	}
-
-      memcpy (reserve_log_page_p, log_page_p, IO_MAX_PAGE_SIZE);
 
       LSA_COPY (&process_lsa, redo_lsa);
       LSA_COPY (&current_logrec_lsa, redo_lsa);
@@ -11678,7 +11735,12 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 	  {
 	    LOG_REC_UNDOREDO *undoredo = NULL;
 
-	    LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (*undoredo), &process_lsa, log_page_p);
+	    if ((error_code =
+		 cdc_log_read_advance_and_preserve_if_needed (thread_p, sizeof (*undoredo), &process_lsa, log_page_p,
+							      preserved_log_page_p)) != NO_ERROR)
+	      {
+		goto error;
+	      }
 
 	    undoredo = (LOG_REC_UNDOREDO *) (log_page_p->area + process_lsa.offset);
 	    rcvindex = undoredo->data.rcvindex;
@@ -11891,9 +11953,12 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 	      }
 	    else if (rcvindex == RVOVF_CHANGE_LINK || rcvindex == RVOVF_NEWPAGE_LINK)
 	      {
-		/* GET OVF UNDO IMAGE */
+		/* if the next log page is fetched into log_page_p, then use the preserved_log_page_p */
+		log_page_p = process_lsa.pageid == redo_lsa->pageid ? log_page_p : preserved_log_page_p;
+
+		/* GET OVF REDO IMAGE */
 		if ((error_code =
-		     cdc_get_overflow_recdes (thread_p, reserve_log_page_p, redo_recdes, prev_lsa, RVOVF_PAGE_UPDATE,
+		     cdc_get_overflow_recdes (thread_p, log_page_p, redo_recdes, *redo_lsa, rcvindex,
 					      true)) != NO_ERROR)
 		  {
 		    goto error;
@@ -11908,16 +11973,24 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 	    LOG_REC_REDO *redo = NULL;
 	    LOG_RCVINDEX rcvindex;
 
-	    LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (*redo), &process_lsa, log_page_p);
+	    if ((error_code =
+		 cdc_log_read_advance_and_preserve_if_needed (thread_p, sizeof (*redo), &process_lsa, log_page_p,
+							      preserved_log_page_p)) != NO_ERROR)
+	      {
+		goto error;
+	      }
 
 	    redo = (LOG_REC_REDO *) (log_page_p->area + process_lsa.offset);
 	    rcvindex = redo->data.rcvindex;
 
 	    if (rcvindex == RVOVF_NEWPAGE_INSERT || rcvindex == RVOVF_PAGE_UPDATE)
 	      {
+		/* if the next log page is fetched into log_page_p, then use the preserved_log_page_p */
+		log_page_p = process_lsa.pageid == redo_lsa->pageid ? log_page_p : preserved_log_page_p;
+
 		/* GET OVF REDO IMAGE */
 		if ((error_code =
-		     cdc_get_overflow_recdes (thread_p, reserve_log_page_p, redo_recdes, *redo_lsa, rcvindex,
+		     cdc_get_overflow_recdes (thread_p, log_page_p, redo_recdes, *redo_lsa, rcvindex,
 					      true)) != NO_ERROR)
 		  {
 		    goto error;
@@ -11932,15 +12005,23 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 	    LOG_REC_UNDO *undo = NULL;
 	    LOG_RCVINDEX rcvindex;
 
-	    LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (*undo), &process_lsa, log_page_p);
+	    if ((error_code =
+		 cdc_log_read_advance_and_preserve_if_needed (thread_p, sizeof (*undo), &process_lsa, log_page_p,
+							      preserved_log_page_p)) != NO_ERROR)
+	      {
+		goto error;
+	      }
 
 	    undo = (LOG_REC_UNDO *) (log_page_p->area + process_lsa.offset);
 	    rcvindex = undo->data.rcvindex;
 
 	    if (rcvindex == RVOVF_PAGE_UPDATE)
 	      {
+		/* if the next log page is fetched into log_page_p, then use the preserved_log_page_p */
+		log_page_p = process_lsa.pageid == redo_lsa->pageid ? log_page_p : preserved_log_page_p;
+
 		if ((error_code =
-		     cdc_get_overflow_recdes (thread_p, reserve_log_page_p, redo_recdes, *redo_lsa, rcvindex,
+		     cdc_get_overflow_recdes (thread_p, log_page_p, redo_recdes, *redo_lsa, rcvindex,
 					      true)) != NO_ERROR)
 		  {
 		    goto error;
@@ -12147,10 +12228,12 @@ cdc_get_overflow_recdes (THREAD_ENTRY * thread_p, LOG_PAGE * log_page_p, RECDES 
 
   trid = current_log_record->trid;
 
-  if (((current_log_record->type == LOG_UNDO_DATA)
-       && (rcvindex == RVOVF_PAGE_UPDATE) && is_redo)
-      || ((current_log_record->type == LOG_REDO_DATA) && (rcvindex == RVOVF_PAGE_UPDATE) && !is_redo))
+  if (((current_log_record->type == LOG_UNDO_DATA) && (rcvindex == RVOVF_PAGE_UPDATE) && is_redo)
+      || ((current_log_record->type == LOG_REDO_DATA) && (rcvindex == RVOVF_PAGE_UPDATE) && !is_redo)
+      || rcvindex == RVOVF_CHANGE_LINK
+      || rcvindex == RVOVF_NEWPAGE_LINK)
     {
+      /* start to traverse with prev_transla log record */
       LSA_COPY (&current_lsa, &current_log_record->prev_tranlsa);
 
       if (current_lsa.pageid != lsa.pageid)

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -11904,6 +11904,8 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 	    LOG_REC_REDO *redo = NULL;
 	    LOG_RCVINDEX rcvindex;
 
+	    LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (*redo), &process_lsa, log_page_p);
+
 	    redo = (LOG_REC_REDO *) (log_page_p->area + process_lsa.offset);
 	    rcvindex = redo->data.rcvindex;
 
@@ -11925,6 +11927,8 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 	  {
 	    LOG_REC_UNDO *undo = NULL;
 	    LOG_RCVINDEX rcvindex;
+
+	    LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (*undo), &process_lsa, log_page_p);
 
 	    undo = (LOG_REC_UNDO *) (log_page_p->area + process_lsa.offset);
 	    rcvindex = undo->data.rcvindex;

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -11216,7 +11216,6 @@ cdc_get_undo_record (THREAD_ENTRY * thread_p, LOG_PAGE * log_page_p, LOG_LSA lsa
  * log_page_p (in/out)        : fetch the next log page if needed
  * preserved  (in/out)        : preserve existing log page if needed
  */
-
 static int
 cdc_log_read_advance_and_preserve_if_needed (THREAD_ENTRY * thread_p, size_t size, LOG_LSA * lsa, LOG_PAGE * log_page_p,
 					     LOG_PAGE * preserved)

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -11303,7 +11303,6 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 
 	    mvcc_undoredo = (LOG_REC_MVCC_UNDOREDO *) (log_page_p->area + process_lsa.offset);
 	    rcvindex = mvcc_undoredo->undoredo.data.rcvindex;
-	    undo_length = mvcc_undoredo->undoredo.ulength;
 
 	    if (rcvindex == RVHF_MVCC_DELETE_MODIFY_HOME || rcvindex == RVHF_UPDATE_NOTIFY_VACUUM)
 	      {
@@ -11327,7 +11326,6 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 
 	    undoredo = (LOG_REC_UNDOREDO *) (log_page_p->area + process_lsa.offset);
 	    rcvindex = undoredo->data.rcvindex;
-	    undo_length = undoredo->ulength;
 
 	    if (rcvindex == RVHF_DELETE || rcvindex == RVHF_UPDATE)
 	      {
@@ -11359,7 +11357,6 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 	    LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (*undo), &process_lsa, log_page_p);
 	    undo = (LOG_REC_UNDO *) (log_page_p->area + process_lsa.offset);
 	    rcvindex = undo->data.rcvindex;
-	    undo_length = undo->length;
 
 	    if (rcvindex == RVOVF_PAGE_UPDATE)
 	      {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24756

Purpose

If (offset + log record size) is greater than the log page size, 
the log record to be read is located on the next page. 
To read the corresponding log record,  the pointer to read is required to be adjusted.

Implementation
1. Add macro to read appropriate log record header
   -  `LOG_READ_ADVANCE_WHEN_DOESNT_FIT`
2.  Stored log page buffer which contains the log record header at redo/undo lsa
    -  `cdc_get_overflow_recdes()` requires a log page that contains the log record header pointed to by the redo_lsa
    -   https://github.com/CUBRID/cubrid/pull/4281#discussion_r1163623777
    -   Stored existing log page only if needed (`cdc_log_read_advance_and_preserve_if_needed ()`)
3. Fix trivial bugs
   -  `redo_recdes`, `undo_recdes` can be null in `error` label (`cdc_get_recdes ()`)
   -  handle the rcvindex RVOVF_CHANGE_LINK and  RVOVF_NEWPAGE_LINK
      -  https://github.com/CUBRID/cubrid/pull/4281#discussion_r1168359155