### PR TITLE
[CBRD-24705] When attempting a covered index scan in a connect by query, encountering 'Execute: Query execution failure' (#4237)

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -15603,9 +15603,9 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 	  /* close current list and start a new one */
 	  qfile_close_scan (thread_p, isidp->indx_cov.lsid);
 	  qfile_destroy_list (thread_p, isidp->indx_cov.list_id);
+	  QFILE_FREE_AND_INIT_LIST_ID (isidp->indx_cov.list_id);
 	  isidp->indx_cov.list_id =
-	    qfile_open_list (thread_p, isidp->indx_cov.type_list, NULL, isidp->indx_cov.query_id, 0,
-			     isidp->indx_cov.list_id);
+	    qfile_open_list (thread_p, isidp->indx_cov.type_list, NULL, isidp->indx_cov.query_id, 0);
 	  if (isidp->indx_cov.list_id == NULL)
 	    {
 	      GOTO_EXIT_ON_ERROR;

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -15596,6 +15596,22 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 
       qfile_close_scan (thread_p, &lfscan_id);
 
+      if (xasl->spec_list->s_id.type == S_INDX_SCAN && SCAN_IS_INDEX_COVERED (&xasl->spec_list->s_id.s.isid))
+	{
+	  INDX_SCAN_ID *isidp = &xasl->spec_list->s_id.s.isid;
+
+	  /* close current list and start a new one */
+	  qfile_close_scan (thread_p, isidp->indx_cov.lsid);
+	  qfile_destroy_list (thread_p, isidp->indx_cov.list_id);
+	  isidp->indx_cov.list_id =
+	    qfile_open_list (thread_p, isidp->indx_cov.type_list, NULL, isidp->indx_cov.query_id, 0,
+			     isidp->indx_cov.list_id);
+	  if (isidp->indx_cov.list_id == NULL)
+	    {
+	      GOTO_EXIT_ON_ERROR;
+	    }
+	}
+
       if (qp_lfscan != S_END)
 	{
 	  GOTO_EXIT_ON_ERROR;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24705

backport #4237