### PR TITLE
[CBRD-24664] [PL/CSQL] Use JavaCompiler instead of javac utility

### DIFF
--- a/src/jsp/com/cubrid/jsp/ExecuteThread.java
+++ b/src/jsp/com/cubrid/jsp/ExecuteThread.java
@@ -324,7 +324,7 @@ public class ExecuteThread extends Thread {
                     "-classpath", cubrid_env_root + "/java/jspserver.jar", file.getPath()
                 };
 
-                if (compiler.run(null, System.out, System.out, javacOpts) != 0) {
+                if (compiler.run(null, null, null, javacOpts) != 0) {
                     String command =
                             "javac "
                                     + javaFilePath

--- a/src/jsp/com/cubrid/jsp/ExecuteThread.java
+++ b/src/jsp/com/cubrid/jsp/ExecuteThread.java
@@ -51,14 +51,15 @@ import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.Socket;
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
 import java.sql.SQLException;
 import java.util.List;
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
 
 public class ExecuteThread extends Thread {
 
@@ -306,25 +307,30 @@ public class ExecuteThread extends Thread {
         try {
             info = TestMain.compilePLCSQL(inSource, verbose);
             if (info.errCode == 0) {
+                /* Save Java file */
                 String javaFilePath =
                         StoredProcedureClassLoader.ROOT_PATH + info.className + ".java";
                 File file = new File(javaFilePath);
-                FileOutputStream fos = new FileOutputStream(file, false);
-                fos.write(info.translated.getBytes(Charset.forName("UTF-8")));
-                fos.close();
+                new FileWriter(file).append(info.translated).close();
+
+                JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+                if (compiler == null) {
+                    throw new IllegalStateException(
+                            "Cannot find the system Java compiler. Check that your class path includes tools.jar");
+                }
 
                 String cubrid_env_root = Server.getRootPath();
-                String command =
-                        "javac " + javaFilePath + " -cp " + cubrid_env_root + "/java/jspserver.jar";
+                String javacOpts[] = {
+                    "-classpath", cubrid_env_root + "/java/jspserver.jar", file.getPath()
+                };
 
-                Process proc = Runtime.getRuntime().exec(command);
-                proc.getErrorStream().close();
-                proc.getInputStream().close();
-                proc.getOutputStream().close();
-                proc.waitFor();
-
-                if (proc.exitValue() != 0) {
-                    // TODO
+                if (compiler.run(null, System.out, System.out, javacOpts) != 0) {
+                    String command =
+                            "javac "
+                                    + javaFilePath
+                                    + " -cp "
+                                    + cubrid_env_root
+                                    + "/java/jspserver.jar";
                     throw new RuntimeException(command);
                 }
             }

--- a/src/method/method_invoke_java.cpp
+++ b/src/method/method_invoke_java.cpp
@@ -491,6 +491,12 @@ namespace cubmethod
 
     cubmem::block blk = std::move (mcon_pack_data_block (METHOD_RESPONSE_SUCCESS, info));
     error = mcon_send_data_to_java (m_group->get_socket (), get_next_java_header (m_java_header), std::move (blk));
+    if (blk.is_valid ())
+      {
+	delete [] blk.ptr;
+	blk.ptr = NULL;
+	blk.dim = 0;
+      }
     return error;
   }
 

--- a/src/method/method_struct_query.cpp
+++ b/src/method/method_struct_query.cpp
@@ -616,6 +616,13 @@ namespace cubmethod
 
   execute_info::~execute_info ()
   {
+#if defined (SERVER_MODE)
+    // call_info is only allocated by unpack() in cub_server
+    if (call_info != nullptr)
+      {
+	delete call_info;
+      }
+#endif
     call_info = nullptr;
   }
 
@@ -672,6 +679,10 @@ namespace cubmethod
     if (has_call_info)
       {
 	call_info = new prepare_call_info (); // need to be freed;
+      }
+    else
+      {
+	call_info = nullptr;
       }
   }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24664

- JavaCompiler supports API equivalent to `javac` utility. Instead of calling `javac` by using Process, I've changed to use JavaCompiler
- In manual testing of CBRD-24664, fixed some memory leak code found.