### PR TITLE
[CBRD-24726] In demodb_schema, add a synonym for the public user's tables to the dba user

### DIFF
--- a/demo/demodb_objects
+++ b/demo/demodb_objects
@@ -1,14 +1,14 @@
-%id stadium 21
-%id code 23
-%id nation 24
-%id "event" 27
-%id athlete 29
-%id participant 46
-%id olympic 47
-%id game 48
-%id record 49
-%id history 50
-%class stadium (code nation_code "name" area seats address)
+%id public.stadium 21
+%id public.code 23
+%id public.nation 24
+%id public.[event] 27
+%id public.athlete 29
+%id public.participant 46
+%id public.olympic 47
+%id public.game 48
+%id public.record 49
+%id public.history 50
+%class public.stadium (code nation_code [name] area seats address)
 30000 'AUS' 'Blacktown Olympic Centre Aquilina Reserve' 75000.00 12000 'Blacktown'
 30001 'AUS' 'Baseball Stadium' 85000.00 21000 'Sydney Olympic Park, Homebush Bay'
 30002 'AUS' 'Beach Volleyball centre, Bondi' 34000.00 10000 'Bondi Beach'
@@ -160,14 +160,14 @@
 30138 'GRE' 'Athens Olympic Tennis Centre' 12800.00 3200 'Athens, Greece'
 30139 'GRE' 'Goudi Olympic Hall' 21000.00 5000 'Athens, Greece'
 30140 'GRE' 'Vouliagmeni Olympic Centre' 7024.00 3400 'Athens, Greece'
-%class code (s_name f_name)
+%class public.code (s_name f_name)
 'G' 'Gold'
 'S' 'Silver'
 'B' 'Bronze'
 'M' 'Man'
 'W' 'Woman'
 'X' 'Mixed'
-%class nation (code "name" continent capital)
+%class public.nation (code [name] continent capital)
 'AFG' 'Afghanistan' 'Asia' 'Kabul'
 'AHO' 'Netherlands Antilles' 'Americas' 'Willemstad'
 'ALB' 'Albania' 'Europe' 'Tirana'
@@ -393,7 +393,7 @@
 'SCG' 'Serbia and Montenegro' 'Europe' 'Beograd'
 'KIR' 'Kiribati' 'Oceania' 'Tarawa'
 'SRB' 'Serbia' 'Europe' 'Beograd'
-%class "event" (code sports "name" gender players)
+%class public.[event] (code sports [name] gender players)
 20358 'Wrestling' 'Freestyle 48kg' 'W' 1
 20359 'Wrestling' 'Freestyle -48kg' 'M' 1
 20360 'Wrestling' 'Freestyle 52kg' 'M' 1
@@ -816,7 +816,7 @@
 20419 'Wrestling' 'Greco-Roman 90kg' 'M' 1
 20420 'Wrestling' 'Greco-Roman 96kg' 'M' 1
 20421 'Wrestling' 'Greco-Roman 97kg' 'M' 1
-%class athlete (code "name" gender nation_code "event")
+%class public.athlete (code [name] gender nation_code [event])
 10000 'Aardewijn Pepijn' 'M' 'NED' 'Rowing'
 10001 'Aarones Ann Kristin' 'W' 'NOR' 'Football'
 10002 'Abanda Patrice' 'M' 'CMR' 'Football'
@@ -7513,7 +7513,7 @@
 16690 'Zimmermann Kathrin' 'W' 'GDR' 'Swimming'
 16691 'Zuelow Andreas' 'M' 'GDR' 'Boxing'
 16692 'Zulianello Clavdio F' 'M' 'ARG' 'Volleyball'
-%class participant (host_year nation_code gold silver bronze)
+%class public.participant (host_year nation_code gold silver bronze)
 1988 'URS' 55 31 46
 1988 'GDR' 37 35 30
 1988 'USA' 36 31 27
@@ -8430,7 +8430,7 @@
 2004 'ISV' 0 0 0
 2004 'YEM' 0 0 0
 2004 'ZAM' 0 0 0
-%class olympic (host_year host_nation host_city opening_date closing_date mascot slogan introduction)
+%class public.olympic (host_year host_nation host_city opening_date closing_date mascot slogan introduction)
 1896 'Greece' 'Athens' date '04/06/1896' date '04/15/1896' NULL NULL 'Thirteen countries participated at the 1896 Athens Games with around 3'+
  '00 athletes taking part in the competition. There were 43 events conte'+
  'sted which fell into the following categories; athletics (track and fi'+
@@ -8578,7 +8578,7 @@
  'in both the 800m and the 1,500m. In team play, Argentina won the men'+
  '''s football tournament without giving up a goal, and the U.S. sof'+
  'tball team won by outscoring their opponents 51-1.'
-%class game (host_year event_code athlete_code stadium_code nation_code medal game_date)
+%class public.game (host_year event_code athlete_code stadium_code nation_code medal game_date)
 2004 20116 14666 30121 'ESP' 'S' date '08/20/2004'
 2004 20116 14870 30121 'ESP' 'S' date '08/20/2004'
 2004 20116 14915 30121 'GER' 'G' date '08/20/2004'
@@ -17232,7 +17232,7 @@
 1988 20114 15779 30067 'USA' 'S' date '10/02/1988'
 1988 20114 15923 30067 'FRA' 'G' date '10/02/1988'
 1988 20114 16066 30067 'FRG' 'B' date '10/02/1988'
-%class record (host_year event_code athlete_code medal score unit)
+%class public.record (host_year event_code athlete_code medal score unit)
 1988 20287 11551 'B' '04:39.8' 'Time'
 1988 20287 16253 'S' '04:39.5' 'Time'
 1988 20288 10333 'G' '22.14' 'Time'
@@ -19236,7 +19236,7 @@
 2004 20338 15008 'S' '342.5' 'kg'
 2004 20344 15258 'B' '365' 'kg'
 2004 20344 15362 'G' '375' 'kg'
-%class history (event_code athlete host_year score unit)
+%class public.history (event_code athlete host_year score unit)
 20283 'Vollmer Dana' 2004 '07:53.0' 'time'
 20283 'Sandeno Kaitlin' 2004 '07:53.0' 'time'
 20281 'Rooney Giaan' 2004 '03:57.0' 'time'

--- a/demo/demodb_schema
+++ b/demo/demodb_schema
@@ -26,7 +26,7 @@ call change_owner('code', 'PUBLIC') on class db_root;
 CREATE CLASS nation dont_reuse_oid;
 call change_owner('nation', 'PUBLIC') on class db_root;
 
-CREATE CLASS event dont_reuse_oid;
+CREATE CLASS [event] dont_reuse_oid;
 call change_owner('event', 'PUBLIC') on class db_root;
 
 CREATE CLASS athlete dont_reuse_oid;
@@ -48,9 +48,19 @@ CREATE CLASS history dont_reuse_oid;
 call change_owner('history', 'PUBLIC') on class db_root;
 
 
+CREATE PRIVATE SYNONYM athlete FOR public.athlete;
+CREATE PRIVATE SYNONYM code FOR public.code;
+CREATE PRIVATE SYNONYM [event] FOR public.[event];
+CREATE PRIVATE SYNONYM game FOR public.game;
+CREATE PRIVATE SYNONYM history FOR public.history;
+CREATE PRIVATE SYNONYM nation FOR public.nation;
+CREATE PRIVATE SYNONYM olympic FOR public.olympic;
+CREATE PRIVATE SYNONYM participant FOR public.participant;
+CREATE PRIVATE SYNONYM record FOR public.record;
+CREATE PRIVATE SYNONYM stadium FOR public.stadium;
 
 
-ALTER CLASS stadium ADD ATTRIBUTE
+ALTER CLASS public.stadium ADD ATTRIBUTE
        code integer NOT NULL,
        nation_code character(3) NOT NULL,
        [name] character varying(50) NOT NULL,
@@ -59,27 +69,27 @@ ALTER CLASS stadium ADD ATTRIBUTE
        address character varying(100);
 
 
-ALTER CLASS stadium ADD ATTRIBUTE
+ALTER CLASS public.stadium ADD ATTRIBUTE
        CONSTRAINT [pk_stadium_code] PRIMARY KEY(code);
 
-ALTER CLASS code ADD ATTRIBUTE
+ALTER CLASS public.code ADD ATTRIBUTE
        s_name character(1),
        f_name character varying(6);
 
-ALTER CLASS code ADD ATTRIBUTE
+ALTER CLASS public.code ADD ATTRIBUTE
        CONSTRAINT [pk_code] PRIMARY KEY(s_name);
 
-ALTER CLASS nation ADD ATTRIBUTE
+ALTER CLASS public.nation ADD ATTRIBUTE
        code character(3) NOT NULL,
        [name] character varying(40) NOT NULL,
        continent character varying(10),
        capital character varying(30);
 
 
-ALTER CLASS nation ADD ATTRIBUTE
+ALTER CLASS public.nation ADD ATTRIBUTE
        CONSTRAINT [pk_nation_code] PRIMARY KEY(code);
 
-ALTER CLASS event ADD ATTRIBUTE
+ALTER CLASS public.[event] ADD ATTRIBUTE
        code integer NOT NULL,
        sports character varying(50),
        [name] character varying(50),
@@ -87,21 +97,21 @@ ALTER CLASS event ADD ATTRIBUTE
        players integer;
 
 
-ALTER CLASS event ADD ATTRIBUTE
+ALTER CLASS public.[event] ADD ATTRIBUTE
        CONSTRAINT [pk_event_code] PRIMARY KEY(code);
 
-ALTER CLASS athlete ADD ATTRIBUTE
+ALTER CLASS public.athlete ADD ATTRIBUTE
        code integer AUTO_INCREMENT(16693, 1) NOT NULL,
        [name] character varying(40) NOT NULL,
        gender character(1),
        nation_code character(3),
-       event character varying(30);
-ALTER SERIAL athlete_ai_code START WITH 16693;
+       [event] character varying(30);
+ALTER SERIAL public.athlete_ai_code START WITH 16693;
 
-ALTER CLASS athlete ADD ATTRIBUTE
+ALTER CLASS public.athlete ADD ATTRIBUTE
        CONSTRAINT [pk_athlete_code] PRIMARY KEY(code);
 
-ALTER CLASS participant ADD ATTRIBUTE
+ALTER CLASS public.participant ADD ATTRIBUTE
        host_year integer NOT NULL,
        nation_code character(3) NOT NULL,
        gold integer DEFAULT 0,
@@ -109,10 +119,10 @@ ALTER CLASS participant ADD ATTRIBUTE
        bronze integer DEFAULT 0;
 
 
-ALTER CLASS participant ADD ATTRIBUTE
+ALTER CLASS public.participant ADD ATTRIBUTE
        CONSTRAINT [pk_participant_host_year_nation_code] PRIMARY KEY(host_year, nation_code);
 
-ALTER CLASS olympic ADD ATTRIBUTE
+ALTER CLASS public.olympic ADD ATTRIBUTE
        host_year integer NOT NULL,
        host_nation character varying(40) NOT NULL,
        host_city character varying(20) NOT NULL,
@@ -123,10 +133,10 @@ ALTER CLASS olympic ADD ATTRIBUTE
        introduction character varying(1500);
 
 
-ALTER CLASS olympic ADD ATTRIBUTE
+ALTER CLASS public.olympic ADD ATTRIBUTE
        CONSTRAINT [pk_olympic_host_year] PRIMARY KEY(host_year);
 
-ALTER CLASS game ADD ATTRIBUTE
+ALTER CLASS public.game ADD ATTRIBUTE
        host_year integer NOT NULL,
        event_code integer NOT NULL,
        athlete_code integer NOT NULL,
@@ -136,10 +146,10 @@ ALTER CLASS game ADD ATTRIBUTE
        game_date date;
 
 
-ALTER CLASS game ADD ATTRIBUTE
+ALTER CLASS public.game ADD ATTRIBUTE
        CONSTRAINT [pk_game_host_year_event_code_athlete_code] PRIMARY KEY(host_year, event_code, athlete_code);
 
-ALTER CLASS record ADD ATTRIBUTE
+ALTER CLASS public.record ADD ATTRIBUTE
        host_year integer NOT NULL,
        event_code integer NOT NULL,
        athlete_code integer NOT NULL,
@@ -148,10 +158,10 @@ ALTER CLASS record ADD ATTRIBUTE
        unit character varying(5);
 
 
-ALTER CLASS record ADD ATTRIBUTE
+ALTER CLASS public.record ADD ATTRIBUTE
        CONSTRAINT [pk_record_host_year_event_code_athlete_code_medal] PRIMARY KEY(host_year, event_code, athlete_code, medal);
 
-ALTER CLASS history ADD ATTRIBUTE
+ALTER CLASS public.history ADD ATTRIBUTE
        event_code integer NOT NULL,
        athlete character varying(40) NOT NULL,
        host_year integer,
@@ -159,18 +169,18 @@ ALTER CLASS history ADD ATTRIBUTE
        unit character varying(5);
 
 
-ALTER CLASS history ADD ATTRIBUTE
+ALTER CLASS public.history ADD ATTRIBUTE
        CONSTRAINT [pk_history_event_code_athlete] PRIMARY KEY(event_code, athlete);
 
 
 
-ALTER CLASS [participant] ADD CONSTRAINT [fk_participant_host_year] FOREIGN KEY(host_year) REFERENCES olympic ON DELETE RESTRICT ON UPDATE RESTRICT ;
+ALTER CLASS public.participant ADD CONSTRAINT [fk_participant_host_year] FOREIGN KEY(host_year) REFERENCES public.olympic ON DELETE RESTRICT ON UPDATE RESTRICT ;
 
-ALTER CLASS [participant] ADD CONSTRAINT [fk_participant_nation_code] FOREIGN KEY(nation_code) REFERENCES nation ON DELETE RESTRICT ON UPDATE RESTRICT ;
+ALTER CLASS public.participant ADD CONSTRAINT [fk_participant_nation_code] FOREIGN KEY(nation_code) REFERENCES public.nation ON DELETE RESTRICT ON UPDATE RESTRICT ;
 
-ALTER CLASS [game] ADD CONSTRAINT [fk_game_event_code] FOREIGN KEY(event_code) REFERENCES event ON DELETE RESTRICT ON UPDATE RESTRICT ;
+ALTER CLASS public.game ADD CONSTRAINT [fk_game_event_code] FOREIGN KEY(event_code) REFERENCES public.[event] ON DELETE RESTRICT ON UPDATE RESTRICT ;
 
-ALTER CLASS [game] ADD CONSTRAINT [fk_game_athlete_code] FOREIGN KEY(athlete_code) REFERENCES athlete ON DELETE RESTRICT ON UPDATE RESTRICT ;
+ALTER CLASS public.game ADD CONSTRAINT [fk_game_athlete_code] FOREIGN KEY(athlete_code) REFERENCES public.athlete ON DELETE RESTRICT ON UPDATE RESTRICT ;
 
 
 COMMIT WORK;

--- a/demo/make_cubrid_demo.bat
+++ b/demo/make_cubrid_demo.bat
@@ -36,7 +36,7 @@ cd %CUBRID_DATABASES%\demodb
 echo ********** Creating database %DBNAME% ...
 %CUBRID%\bin\cub_admin createdb --db-volume-size=100M --log-volume-size=100M --replace %DBNAME% en_US.utf8
 echo ********** Loading objects ...
-%CUBRID%\bin\cub_admin loaddb %DBNAME% --schema-file=%CUBRID%\demo\demodb_schema --data-file=%CUBRID%\demo\demodb_objects --no-user-specified-name -u dba
+%CUBRID%\bin\cub_admin loaddb %DBNAME% --schema-file=%CUBRID%\demo\demodb_schema --data-file=%CUBRID%\demo\demodb_objects -u dba
 echo ********** Makedemo complete.
 goto exit
 

--- a/demo/make_cubrid_demo.sh
+++ b/demo/make_cubrid_demo.sh
@@ -21,4 +21,4 @@ if [ -z "$CUBRID" ]; then
 fi
 
 cubrid createdb --db-volume-size=100M --log-volume-size=100M demodb en_US.utf8  > /dev/null 2>&1
-cubrid loaddb -u dba -s $CUBRID/demo/demodb_schema -d $CUBRID/demo/demodb_objects --no-user-specified-name demodb > /dev/null 2>&1
+cubrid loaddb -u dba -s $CUBRID/demo/demodb_schema -d $CUBRID/demo/demodb_objects demodb > /dev/null 2>&1


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24726

This is for test convenience purpose.
Avoid specifying the public schema every time the dba user runs a query that uses public user tables.