### PR TITLE
[CBRD-24747] Add a comment 'Obsolete' to unused error code macro, ER_CANNOT_GET_KEY_LOCK.

### DIFF
--- a/src/base/error_code.h
+++ b/src/base/error_code.h
@@ -1387,7 +1387,7 @@
 #define ER_BLOCK_DDL_STMT                           -1099
 #define ER_BLOCK_NOWHERE_STMT                       -1100
 
-#define ER_CANNOT_GET_KEY_LOCK                      -1101
+#define ER_CANNOT_GET_KEY_LOCK                      -1101	/* Obsolete */
 
 #define ER_PRM_BAD_VALUE_NO_DATA                    -1102
 #define ER_PRM_CANNOT_CHANGE_NO_DATA                -1103


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24747

Purpose
Add the comment to unused macro.

Implementation
N/A

Remarks
N/A