### PR TITLE
[LETS-681] The checkpoint without the quorum confirmation

### DIFF
--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -7656,7 +7656,7 @@ logpb_checkpoint_trantable (THREAD_ENTRY * const thread_p)
   /* NOTE. in development (TODO)
    * If the log records up to trantable_checkpoint_lsa is not stored on PS,
    * it will fail to do recovery with PS's which have lagged behind the snapshot LSA.
-   * In the near future, ATS will restore with the checkpoint info from the log in PS and it will wroks well.
+   * In the near future, ATS will restore with the checkpoint info from the log in PS and it will work well.
    */
   logpb_flush_pages_direct (thread_p);
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -7653,10 +7653,12 @@ logpb_checkpoint_trantable (THREAD_ENTRY * const thread_p)
 
   log_write_metalog_to_file (false);
 
-  // function explicitly needs to be called in critical section-free context
-  LOG_CS_EXIT (thread_p);
-  logpb_flush_pages (thread_p, &trantable_checkpoint_lsa);
-  LOG_CS_ENTER (thread_p);
+  /* NOTE. in development (TODO)
+   * If the log records up to trantable_checkpoint_lsa is not stored on PS,
+   * it will fail to do recovery with PS's which have lagged behind the snapshot LSA.
+   * In the near future, ATS will restore with the checkpoint info from the log in PS and it will wroks well.
+   */
+  logpb_flush_pages_direct (thread_p);
 
   // drop previous checkpoints and persist to disk
   if (detailed_logging)


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-681

The checkpoint on ATS requires quorum confirmation, which is needed to synchronize the checkpoint information on ATS (m eta file) and the log records on PS. This can cause a hang when an ATS stops with PSes less than quorum because the checkpoint daemon can't get its job done. This quorum requirement for the checkpoint is going to be removed when Recovery references the checkpoint information on PS. So, we're getting rid of this restriction in advance to avoid the hang.

- logpb_flush_pages () -> logpb_flush_pages_direct(), which just requests to flush log pages.
- It could cause a recovery failure when log records up to the checkpoint (snapshot) LSA are not stored in the PS used for the recovery of an ATS, but it even can happen with logpb_flush_pages() if the recovery starts with a PS that was not in the quorum for the checkpoint. It will be fixed [LETS-682](http://jira.cubrid.org/browse/LETS-682) and [LETS-633](http://jira.cubrid.org/browse/LETS-633).
