### PR TITLE
[CBRD-24770] Whenever one `QFILE_TUPLE_RECORD` of `(CONNECTBY_PROC_NODE *)->start_with_list_id` is completed, `(INDX_SCAN_ID *)->indx_cov.list_id` must be cleared

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -15329,6 +15329,23 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 	      break;
 	    }
 
+	  if (xasl->spec_list->s_id.type == S_INDX_SCAN && SCAN_IS_INDEX_COVERED (&xasl->spec_list->s_id.s.isid)
+	      && xasl->spec_list->s_id.s.isid.indx_cov.lsid->status == S_OPENED)
+	    {
+	      INDX_SCAN_ID *isidp = &xasl->spec_list->s_id.s.isid;
+
+	      /* close current list and start a new one */
+	      qfile_close_scan (thread_p, isidp->indx_cov.lsid);
+	      qfile_destroy_list (thread_p, isidp->indx_cov.list_id);
+	      isidp->indx_cov.list_id =
+		qfile_open_list (thread_p, isidp->indx_cov.type_list, NULL, isidp->indx_cov.query_id, 0,
+				 isidp->indx_cov.list_id);
+	      if (isidp->indx_cov.list_id == NULL)
+		{
+		  GOTO_EXIT_ON_ERROR;
+		}
+	    }
+
 	  parent_tuple_added = false;
 
 	  /* reset parent tuple position pseudocolumn value */
@@ -15671,22 +15688,6 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 	}
 
       qfile_close_scan (thread_p, &lfscan_id);
-
-      if (xasl->spec_list->s_id.type == S_INDX_SCAN && SCAN_IS_INDEX_COVERED (&xasl->spec_list->s_id.s.isid))
-	{
-	  INDX_SCAN_ID *isidp = &xasl->spec_list->s_id.s.isid;
-
-	  /* close current list and start a new one */
-	  qfile_close_scan (thread_p, isidp->indx_cov.lsid);
-	  qfile_destroy_list (thread_p, isidp->indx_cov.list_id);
-	  isidp->indx_cov.list_id =
-	    qfile_open_list (thread_p, isidp->indx_cov.type_list, NULL, isidp->indx_cov.query_id, 0,
-			     isidp->indx_cov.list_id);
-	  if (isidp->indx_cov.list_id == NULL)
-	    {
-	      GOTO_EXIT_ON_ERROR;
-	    }
-	}
 
       if (qp_lfscan != S_END)
 	{

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -15289,6 +15289,13 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 	}
     }
 
+  /* start the scanner on "input" */
+  if (qexec_open_scan (thread_p, xasl->spec_list, xasl->val_list, &xasl_state->vd, false, true, false,
+		       false, &xasl->spec_list->s_id, xasl_state->query_id, S_SELECT, false, NULL) != NO_ERROR)
+    {
+      GOTO_EXIT_ON_ERROR;
+    }
+
   /* we have all list files, let's begin */
 
   while (listfile1->tuple_cnt > 0)
@@ -15320,6 +15327,23 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 	  if (qp_lfscan != S_SUCCESS)
 	    {
 	      break;
+	    }
+
+	  if (xasl->spec_list->s_id.type == S_INDX_SCAN && SCAN_IS_INDEX_COVERED (&xasl->spec_list->s_id.s.isid)
+	      && xasl->spec_list->s_id.s.isid.indx_cov.lsid->status == S_OPENED)
+	    {
+	      INDX_SCAN_ID *isidp = &xasl->spec_list->s_id.s.isid;
+
+	      /* close current list and start a new one */
+	      qfile_close_scan (thread_p, isidp->indx_cov.lsid);
+	      qfile_destroy_list (thread_p, isidp->indx_cov.list_id);
+	      isidp->indx_cov.list_id =
+		qfile_open_list (thread_p, isidp->indx_cov.type_list, NULL, isidp->indx_cov.query_id, 0,
+				 isidp->indx_cov.list_id);
+	      if (isidp->indx_cov.list_id == NULL)
+		{
+		  GOTO_EXIT_ON_ERROR;
+		}
 	    }
 
 	  parent_tuple_added = false;
@@ -15366,13 +15390,6 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 		{
 		  GOTO_EXIT_ON_ERROR;
 		}
-	    }
-
-	  /* start the scanner on "input" */
-	  if (qexec_open_scan (thread_p, xasl->spec_list, xasl->val_list, &xasl_state->vd, false, true, false,
-			       false, &xasl->spec_list->s_id, xasl_state->query_id, S_SELECT, false, NULL) != NO_ERROR)
-	    {
-	      GOTO_EXIT_ON_ERROR;
 	    }
 
 	  xasl->next_scan_block_on = false;
@@ -15522,14 +15539,12 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 	    {
 	      GOTO_EXIT_ON_ERROR;
 	    }
+	  qexec_end_scan (thread_p, xasl->spec_list);
 
 	  if (has_order_siblings_by)
 	    {
 	      qfile_close_list (thread_p, listfile2_tmp);
 	    }
-
-	  qexec_end_scan (thread_p, xasl->spec_list);
-	  qexec_close_scan (thread_p, xasl->spec_list);
 
 	  if (!parent_tuple_added)
 	    {
@@ -15689,6 +15704,9 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 
       listfile2 = qfile_open_list (thread_p, &type_list, NULL, xasl_state->query_id, 0, NULL);
     }
+
+  qexec_end_scan (thread_p, xasl->spec_list);
+  qexec_close_scan (thread_p, xasl->spec_list);
 
   if (listfile1 != connect_by->start_with_list_id)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24770

A new covered index scan is performed whenever one `QFILE_TUPLE_RECORD` is processed in `(CONNECTBY_PROC_NODE *)->start_with_list_id`. So, `(INDX_SCAN_ID *)->indx_cov.list_id` must be cleared whenever one `QFILE_TUPLE_RECORD` is completed, not when `listfile1` is replaced with `listfile2`.