### PR TITLE
[CBRD-24773] Change the description of options in loaddb

### DIFF
--- a/msg/de_DE.utf8/utils.msg
+++ b/msg/de_DE.utf8/utils.msg
@@ -503,7 +503,7 @@ gültige Optionen:\n\
   -l, --load-only                  Dateiladung ohne vorherige Syntaxprüfung; nur im SA_MODE\n\
       --estimated-size=ANZAHL      abgeschätzte Anzahl von Instanzen; Standard: 5000\n\
   -v, --verbose                    ausführliche Statusmeldungen aktivieren; Standard: inaktiv\n\
-  -c, --periodic-commit=ANZAHL     Einfügungsanzahl für periodische Festschreibung; Standard: keine Festschreibung während der Ladung\n\
+  -c, --periodic-commit=ANZAHL     Einfügungsanzahl für periodische Festschreibung; Standard: 10240\n\
       --no-oid                     OID nicht anwenden\n\
       --no-statistics              Statistiken während Ladung nicht aktualisieren\n\
   -s, --schema-file=DATEI[:ZEILE]  Schema ab ZEILE mit DATEI erstellen\n\

--- a/msg/en_US.utf8/utils.msg
+++ b/msg/en_US.utf8/utils.msg
@@ -504,7 +504,7 @@ valid options:\n\
   -l, --load-only                load data file without prior syntax checking; SA_MODE only\n\
       --estimated-size=NUMBER    estimated NUMBER of instances; default: 5000\n\
   -v, --verbose                  enable verbose status messages; default: disabled\n\
-  -c, --periodic-commit=COUNT    insertion COUNT for periodic commit; default: no commit during loading\n\
+  -c, --periodic-commit=COUNT    insertion COUNT for periodic commit; default: 10240\n\
       --no-oid                   don't use OID\n\
       --no-statistics            do not update the statistics while loading\n\
   -s, --schema-file=FILE[:LINE]  create schema from LINE with FILE\n\

--- a/msg/en_US/utils.msg
+++ b/msg/en_US/utils.msg
@@ -504,7 +504,7 @@ valid options:\n\
   -l, --load-only                load data file without prior syntax checking; SA_MODE only\n\
       --estimated-size=NUMBER    estimated NUMBER of instances; default: 5000\n\
   -v, --verbose                  enable verbose status messages; default: disabled\n\
-  -c, --periodic-commit=COUNT    insertion COUNT for periodic commit; default: no commit during loading\n\
+  -c, --periodic-commit=COUNT    insertion COUNT for periodic commit; default: 10240\n\
       --no-oid                   don't use OID\n\
       --no-statistics            do not update the statistics while loading\n\
   -s, --schema-file=FILE[:LINE]  create schema from LINE with FILE\n\

--- a/msg/es_ES.utf8/utils.msg
+++ b/msg/es_ES.utf8/utils.msg
@@ -503,7 +503,7 @@ opciones validas:\n\
   -l, --load-only                load data file without prior syntax checking; SA_MODE only\n\
       --estimated-size=NUMBER    NUMERO estimado de instancias; estandar: 5000\n\
   -v, --verbose                  habilitar mensajes de estado verbose; estandar: inhabilitado\n\
-  -c, --periodic-commit=COUNT    insertar COUNT al cometer periodicamente; estandar: no cometer mientras cargando\n\
+  -c, --periodic-commit=COUNT    insertar COUNT al cometer periodicamente; estandar: 10240\n\
       --no-oid                   no utilizar OID\n\
       --no-statistics            no actualizar las estadisticas mientras cargando\n\
   -s, --schema-file=FILE[:LINE]  crear esquema de la LINEA con ARCHIVO\n\

--- a/msg/fr_FR.utf8/utils.msg
+++ b/msg/fr_FR.utf8/utils.msg
@@ -505,7 +505,7 @@ options valids:\n\
   -l, --load-only                    load data file without prior syntax checking; SA_MODE only\n\
       --estimated-size=NOMBRE        estimation du NOMBRE des instances; par défaut: 5000\n\
   -v, --verbose                      activer les messages verbeux d'état; par défaut: désactivé\n\
-  -c, --periodic-commit=COMPTE       COMPTE d'insertion pour la validation périodique; par défaut: aucune validation pendant le chargement\n\
+  -c, --periodic-commit=COMPTE       COMPTE d'insertion pour la validation périodique; 10240\n\
       --no-oid                       utilise pas l'OID\n\
       --no-statistics                ne met pas à jour les statistiques pendant le chargement\n\
   -s, --schema-file=FICHIER[:LIGNE]  crée le schéma de la LIGNE en utilisant le FICHIER\n\

--- a/msg/it_IT.utf8/utils.msg
+++ b/msg/it_IT.utf8/utils.msg
@@ -503,7 +503,7 @@ opzioni valide:\n\
   -l, --load-only                load data file without prior syntax checking; SA_MODE only\n\
       --estimated-size=NUMBERO   Stima del NUMERO di instanze; predefinito: 5000\n\
   -v, --verbose                  attivare i messaggi dettagliati di stato; predefinito: non attivo\n\
-  -c, --periodic-commit=COUNT    inserimento COUNT per periodico commit; predefinito: no commit durante il caricamento\n\
+  -c, --periodic-commit=COUNT    inserimento COUNT per periodico commit; predefinito: 10240\n\
       --no-oid                   non usare OID\n\
       --no-statistics            non aggiornare le statistiche durante il caricamento\n\
   -s, --schema-file=FILE[:LINE]  creare schema da LINE con FILE\n\

--- a/msg/ja_JP.utf8/utils.msg
+++ b/msg/ja_JP.utf8/utils.msg
@@ -503,7 +503,7 @@ loaddb: データベースにオブジェクトやスキーマロード\n\
   -l, --load-only                load data file without prior syntax checking; SA_MODE only\n\
       --estimated-size=NUMBER    インスタンスの予測数; デフォルト: 5000\n\
   -v, --verbose                  多様な進行情報を出力; デフォルト: 出力しない\n\
-  -c, --periodic-commit=COUNT    周期的なコミットに関するカウント; デフォルト: ロード中にコミットしない\n\
+  -c, --periodic-commit=COUNT    周期的なコミットに関するカウント; デフォルト: 10240\n\
       --no-oid                   OIDを未使用\n\
       --no-statistics            ロードの後、スタティスティックス情報を更新しない。\n\
   -s, --schema-file=FILE[:LINE]  ファイル[:ライン]情報でスキーマ生成\n\

--- a/msg/km_KH.utf8/utils.msg
+++ b/msg/km_KH.utf8/utils.msg
@@ -504,7 +504,7 @@ valid options:\n\
   -l, --load-only                load data file without prior syntax checking; SA_MODE only\n\
       --estimated-size=NUMBER    estimated NUMBER of instances; default: 5000\n\
   -v, --verbose                  enable verbose status messages; default: disabled\n\
-  -c, --periodic-commit=COUNT    insertion COUNT for periodic commit; default: no commit during loading\n\
+  -c, --periodic-commit=COUNT    insertion COUNT for periodic commit; default: 10240\n\
       --no-oid                   don't use OID\n\
       --no-statistics            do not update the statistics while loading\n\
   -s, --schema-file=FILE[:LINE]  create schema from LINE with FILE\n\

--- a/msg/ko_KR.euckr/utils.msg
+++ b/msg/ko_KR.euckr/utils.msg
@@ -503,7 +503,7 @@ loaddb: 데이터베이스에 객체 및 스키마 적재\n\
   -l, --load-only                신택스 체크없이 데이터 파일 로딩; SA_MODE만 지원\n\
       --estimated-size=NUMBER    인스턴스의 대략적인 개수; 기본값: 5000\n\
   -v, --verbose                  많은 상태 정보를 출력; 기본값: 출력하지 않음\n\
-  -c, --periodic-commit=COUNT    주기적인 커밋에 대한 카운트; 기본값: 적재 중 커밋하지 않음(SA_MODE)\n\
+  -c, --periodic-commit=COUNT    주기적인 커밋에 대한 카운트; 기본값: 10240\n\
       --no-oid                   OID 사용 안 함\n\
       --no-statistics            로딩 후에 통계 정보 갱신하지 않음\n\
   -s, --schema-file=FILE[:LINE]  파일[:라인] 정보로 스키마 생성\n\

--- a/msg/ko_KR.utf8/utils.msg
+++ b/msg/ko_KR.utf8/utils.msg
@@ -503,7 +503,7 @@ loaddb: 데이터베이스에 객체 및 스키마 적재\n\
   -l, --load-only                신택스 체크없이 데이터 파일 로딩; SA_MODE만 지원\n\
       --estimated-size=NUMBER    인스턴스의 대략적인 개수; 기본값: 5000\n\
   -v, --verbose                  많은 상태 정보를 출력; 기본값: 출력하지 않음\n\
-  -c, --periodic-commit=COUNT    주기적인 커밋에 대한 카운트; 기본값: 적재 중 커밋하지 않음(SA_MODE)\n\
+  -c, --periodic-commit=COUNT    주기적인 커밋에 대한 카운트; 기본값: 10240\n\
       --no-oid                   OID 사용 안 함\n\
       --no-statistics            로딩 후에 통계 정보 갱신하지 않음\n\
   -s, --schema-file=FILE[:LINE]  파일[:라인] 정보로 스키마 생성\n\

--- a/msg/ro_RO.utf8/utils.msg
+++ b/msg/ro_RO.utf8/utils.msg
@@ -517,7 +517,7 @@ opţiuni valide:\n\
       --estimated-size=NUMĂR        NUMĂR estimat de instanţe; implicit: 5000\n\
   -v, --verbose                     activează mesaje detaliate de stare; implicit: dezactivate\n\
   -c, --periodic-commit=CONTOR      CONTOR de inserare pentru salvare periodică;\n\
-                                    implicit: nu se face commit în timpul încărcării\n\
+                                    implicit: 10240\n\
       --no-oid                      nu se va folosi OID\n\
       --no-statistics               nu se vor actualiza statisticile în timpul încărcării\n\
   -s, --schema-file=FIŞIER[:LINIE]  creează schema de la linia, respectiv din fişierul specificat\n\

--- a/msg/tr_TR.utf8/utils.msg
+++ b/msg/tr_TR.utf8/utils.msg
@@ -503,7 +503,7 @@ geçerli seçenekler:\n\
   -l, --load-only                load data file without prior syntax checking; SA_MODE only\n\
       --estimated-size=NUMBER    örneklerini tahmin NUMBER; varsayılan: 5000\n\
   -v, --verbose                  Ayrıntılı durum mesajları sağlamak; varsayılan: devre dışı\n\
-  -c, --periodic-commit=COUNT    Periyodik tamamlama için ekleme COUNT; varsayılan: yükleme sırasında taahhüt yok\n\
+  -c, --periodic-commit=COUNT    Periyodik tamamlama için ekleme COUNT; varsayılan: 10240\n\
       --no-oid                   OID kullanmayın\n\
       --no-statistics            yüklerken istatistikleri güncelleştirmeyin\n\
   -s, --schema-file=FILE[:LINE]  FILE ile LINE şeması oluşturun\n\

--- a/msg/vi_VN.utf8/utils.msg
+++ b/msg/vi_VN.utf8/utils.msg
@@ -504,7 +504,7 @@ valid options:\n\
   -l, --load-only                load data file without prior syntax checking; SA_MODE only\n\
       --estimated-size=NUMBER    estimated NUMBER of instances; default: 5000\n\
   -v, --verbose                  enable verbose status messages; default: disabled\n\
-  -c, --periodic-commit=COUNT    insertion COUNT for periodic commit; default: no commit during loading\n\
+  -c, --periodic-commit=COUNT    insertion COUNT for periodic commit; default: 10240\n\
       --no-oid                   don't use OID\n\
       --no-statistics            do not update the statistics while loading\n\
   -s, --schema-file=FILE[:LINE]  create schema from LINE with FILE\n\

--- a/msg/zh_CN.utf8/utils.msg
+++ b/msg/zh_CN.utf8/utils.msg
@@ -503,7 +503,7 @@ loaddb: 将对象和结构导入到数据库.\n\
   -l, --load-only                加载数据不检查语法; 仅在SA_MODE模式下使用\n\
       --estimated-size=NUMBER    用NUMBER作为估计的实例数目; 默认: 5000\n\
   -v, --verbose                  开启详细状态信息; 默认: 关闭\n\
-  -c, --periodic-commit=COUNT    每插入COUNT个实例进行周期性的提交; 默认: 在读取时不提交\n\
+  -c, --periodic-commit=COUNT    每插入COUNT个实例进行周期性的提交; 默认: 10240\n\
       --no-oid                   不使用 OID\n\
       --no-statistics            在读取时不更新统计信息\n\
   -s, --schema-file=FILE[:LINE]  从文件 FILE 的第 LINE 行创建结构(schema)\n\


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24773

Purpose
The default value of the "-c, --periodic-commit=COUNT" option of loaddb is wrong. The default value for this option is 10240.

Implementation
valid options:
  -S, --SA-mode                  standalone mode execution
  ....
  -c, --periodic-commit=COUNT    insertion COUNT for periodic commit; default: 10240

Remarks
N/A