### PR TITLE
[CBRD-24759] Core dump occurs when recording log without error manager initialization in shard cas.

### DIFF
--- a/src/broker/cas.c
+++ b/src/broker/cas.c
@@ -724,6 +724,8 @@ conn_retry:
     tran_timeout = 0;
     query_timeout = 0;
 
+    er_init (NULL, ER_NEVER_EXIT);
+
     for (;;)
       {
 #if !defined(CAS_FOR_ORACLE) && !defined(CAS_FOR_MYSQL) && !defined(CAS_FOR_CGW)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24759

Purpose
In the debug version, if you record a log without initializing the error manager, a core dump occurs.

Implementation
Added error manager initialization function(er_init()) to main() function of shard cas.


Remarks
N/A
