### PR TITLE
[LETS-667] remove incorrect usage of reference_lsa

### DIFF
--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -445,7 +445,6 @@ namespace cublog
 	redo_context.m_reader.reinterpret_copy_and_add_align<T> ());
     if (log_rv_check_redo_is_needed (rcv.pgptr, record_info.m_start_lsa, redo_context.m_end_redo_lsa))
       {
-	rcv.reference_lsa = m_lsa;
 	log_rv_redo_record_sync_apply (thread_p, redo_context, record_info, m_vpid, rcv);
       }
   }


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-667

It is of no use setting `reference_lsa` in this context.
The usage of `reference_lsa` seems to have been overlooked by a previous review