### PR TITLE
[CBRD-24772] A segfault occurs when using the connect by REGEXP_SUBSTR statement (#4296)

### DIFF
--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -22071,10 +22071,10 @@ pt_get_var_regu_variable_p_list (const REGU_VARIABLE * regu, bool is_prior, int 
 
     case TYPE_FUNC:
       {
-	REGU_VARIABLE_LIST *r = &regu->value.funcp->operand;
-	while (*r)
+	REGU_VARIABLE_LIST r = regu->value.funcp->operand;
+	while (r)
 	  {
-	    list1 = pt_get_var_regu_variable_p_list (&(*r)->value, is_prior, err);
+	    list1 = pt_get_var_regu_variable_p_list (&r->value, is_prior, err);
 
 	    if (!list)
 	      {
@@ -22090,7 +22090,7 @@ pt_get_var_regu_variable_p_list (const REGU_VARIABLE * regu, bool is_prior, int 
 		list2->next = list1;
 	      }
 
-	    *r = (*r)->next;
+	    r = r->next;
 	  }
       }
       break;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24772

This is a backport for 10.2 #4296 
