### PR TITLE
[CBRD-24756] Revert "Fix coredump due to trying to find log record using wrong rcvindex"

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -11253,6 +11253,7 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
   LOG_PAGE *preserved_log_page_p = NULL;	// log_page for redo/undo lsa
 
   LOG_LSA process_lsa = LSA_INITIALIZER;
+  LOG_LSA current_logrec_lsa = LSA_INITIALIZER;
   LOG_LSA prev_lsa = LSA_INITIALIZER;
 
   LOG_RECTYPE log_type;
@@ -11301,6 +11302,7 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 	}
 
       LSA_COPY (&process_lsa, undo_lsa);
+      LSA_COPY (&current_logrec_lsa, undo_lsa);
 
       log_rec_hdr = LOG_GET_LOG_RECORD_HEADER (log_page_p, &process_lsa);
 
@@ -11316,7 +11318,7 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 	{
 	case LOG_SUPPLEMENTAL_INFO:
 	  {
-	    scan_code = cdc_get_undo_record (thread_p, log_page_p, *undo_lsa, undo_recdes);
+	    scan_code = cdc_get_undo_record (thread_p, log_page_p, current_logrec_lsa, undo_recdes);
 	    if (scan_code != S_SUCCESS)
 	      {
 		error_code = ER_FAILED;
@@ -11330,21 +11332,14 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 	  {
 	    LOG_REC_MVCC_UNDOREDO *mvcc_undoredo = NULL;
 
-	    if ((error_code =
-		 cdc_log_read_advance_and_preserve_if_needed (thread_p, sizeof (*mvcc_undoredo), &process_lsa,
-							      log_page_p, preserved_log_page_p)) != NO_ERROR)
-	      {
-		goto error;
-	      }
+	    LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (*mvcc_undoredo), &process_lsa, log_page_p);
 
 	    mvcc_undoredo = (LOG_REC_MVCC_UNDOREDO *) (log_page_p->area + process_lsa.offset);
 	    rcvindex = mvcc_undoredo->undoredo.data.rcvindex;
 
-	    log_page_p = process_lsa.pageid == undo_lsa->pageid ? log_page_p : preserved_log_page_p;
-
 	    if (rcvindex == RVHF_MVCC_DELETE_MODIFY_HOME || rcvindex == RVHF_UPDATE_NOTIFY_VACUUM)
 	      {
-		scan_code = cdc_get_undo_record (thread_p, log_page_p, *undo_lsa, undo_recdes);
+		scan_code = cdc_get_undo_record (thread_p, log_page_p, current_logrec_lsa, undo_recdes);
 		if (scan_code != S_SUCCESS)
 		  {
 		    error_code = ER_FAILED;
@@ -11370,12 +11365,9 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 	    undoredo = (LOG_REC_UNDOREDO *) (log_page_p->area + process_lsa.offset);
 	    rcvindex = undoredo->data.rcvindex;
 
-	    /* if the next log page is fetched into log_page_p, then use the preserved_log_page_p */
-	    log_page_p = process_lsa.pageid == undo_lsa->pageid ? log_page_p : preserved_log_page_p;
-
 	    if (rcvindex == RVHF_DELETE || rcvindex == RVHF_UPDATE)
 	      {
-		scan_code = cdc_get_undo_record (thread_p, log_page_p, *undo_lsa, undo_recdes);
+		scan_code = cdc_get_undo_record (thread_p, log_page_p, current_logrec_lsa, undo_recdes);
 		if (scan_code != S_SUCCESS)
 		  {
 		    error_code = ER_FAILED;
@@ -11384,6 +11376,9 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 	      }
 	    else if (rcvindex == RVOVF_CHANGE_LINK || rcvindex == RVOVF_NEWPAGE_LINK)
 	      {
+		/* if the next log page is fetched into log_page_p, then use the preserved_log_page_p */
+		log_page_p = process_lsa.pageid == undo_lsa->pageid ? log_page_p : preserved_log_page_p;
+
 		/* GET OVF UNDO IMAGE */
 		if ((error_code =
 		     cdc_get_overflow_recdes (thread_p, log_page_p, undo_recdes, *undo_lsa, rcvindex,
@@ -11410,11 +11405,11 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 	    undo = (LOG_REC_UNDO *) (log_page_p->area + process_lsa.offset);
 	    rcvindex = undo->data.rcvindex;
 
-	    /* if the next log page is fetched into log_page_p, then use the preserved_log_page_p */
-	    log_page_p = process_lsa.pageid == undo_lsa->pageid ? log_page_p : preserved_log_page_p;
-
 	    if (rcvindex == RVOVF_PAGE_UPDATE)
 	      {
+		/* if the next log page is fetched into log_page_p, then use the preserved_log_page_p */
+		log_page_p = process_lsa.pageid == undo_lsa->pageid ? log_page_p : preserved_log_page_p;
+
 		/* GET OVF UNDO IMAGE */
 		if ((error_code =
 		     cdc_get_overflow_recdes (thread_p, log_page_p, undo_recdes, *undo_lsa, rcvindex,
@@ -11426,7 +11421,7 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 	      }
 	    else if (rcvindex == RVHF_MVCC_UPDATE_OVERFLOW)
 	      {
-		scan_code = cdc_get_undo_record (thread_p, log_page_p, *undo_lsa, undo_recdes);
+		scan_code = cdc_get_undo_record (thread_p, log_page_p, current_logrec_lsa, undo_recdes);
 		if (scan_code != S_SUCCESS)
 		  {
 		    error_code = ER_FAILED;
@@ -11503,6 +11498,7 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 	}
 
       LSA_COPY (&process_lsa, redo_lsa);
+      LSA_COPY (&current_logrec_lsa, redo_lsa);
 
       log_rec_hdr = LOG_GET_LOG_RECORD_HEADER (log_page_p, &process_lsa);
 
@@ -11522,12 +11518,7 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 	    LOG_REC_MVCC_UNDOREDO *mvcc_undoredo = NULL;
 	    LOG_RCVINDEX rcvindex;
 
-	    if ((error_code =
-		 cdc_log_read_advance_and_preserve_if_needed (thread_p, sizeof (*mvcc_undoredo), &process_lsa,
-							      log_page_p, preserved_log_page_p)) != NO_ERROR)
-	      {
-		goto error;
-	      }
+	    LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (*mvcc_undoredo), &process_lsa, log_page_p);
 
 	    mvcc_undoredo = (LOG_REC_MVCC_UNDOREDO *) (log_page_p->area + process_lsa.offset);
 	    rcvindex = mvcc_undoredo->undoredo.data.rcvindex;
@@ -11635,10 +11626,7 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 		/*if LOG_MVCC_UNDOREDO_DATA_DIFF , get undo data first and get diff */
 		if (is_diff)
 		  {
-		    char temp_buf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT] = "\0";
-		    LOG_PAGE *temp_pgptr = (LOG_PAGE *) PTR_ALIGN (temp_buf, MAX_ALIGNMENT);
-
-		    scan_code = cdc_get_undo_record (thread_p, temp_pgptr, *redo_lsa, &tmp_undo_recdes);
+		    scan_code = cdc_get_undo_record (thread_p, log_page_p, current_logrec_lsa, &tmp_undo_recdes);
 		    if (scan_code != S_SUCCESS)
 		      {
 			error_code = ER_FAILED;
@@ -11854,10 +11842,7 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 		/*if LOG_MVCC_UNDOREDO_DATA_DIFF , get undo data first and get diff */
 		if (is_diff)
 		  {
-		    char temp_buf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT] = "\0";
-		    LOG_PAGE *temp_pgptr = (LOG_PAGE *) PTR_ALIGN (temp_buf, MAX_ALIGNMENT);
-
-		    scan_code = cdc_get_undo_record (thread_p, temp_pgptr, *redo_lsa, &tmp_undo_recdes);
+		    scan_code = cdc_get_undo_record (thread_p, log_page_p, current_logrec_lsa, &tmp_undo_recdes);
 		    if (scan_code != S_SUCCESS)
 		      {
 			error_code = ER_FAILED;
@@ -12256,12 +12241,6 @@ cdc_get_overflow_recdes (THREAD_ENTRY * thread_p, LOG_PAGE * log_page_p, RECDES 
 	      error_code = ER_FAILED;
 	      goto end;
 	    }
-	}
-
-      if (rcvindex == RVOVF_CHANGE_LINK || rcvindex == RVOVF_NEWPAGE_LINK)
-	{
-	  /* rcvindex of previous log record is RVOVF_PAGE_UPDATE */
-	  rcvindex = RVOVF_PAGE_UPDATE;
 	}
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24756

Purpose

Reverts CUBRID/cubrid#4314 due to wrong issue number in commit message