### PR TITLE
[CBRD-24780] An error occurs when casting an empty string to bigint.

### DIFF
--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -5044,7 +5044,9 @@ tp_atobi (const DB_VALUE * src, DB_BIGINT * num_value, DB_DATA_STATUS * data_sta
 	}
     }
 
-  if (!is_hex)
+  /* See CBRD-24780.
+   * For backwards compatibility, casting from empty string to bigint is allowed. */
+  if (!is_hex && *strp != '\0')
     {
       /* check whether is scientific format */
       p = strp;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24780

For backwards compatibility, casting from empty string to bigint is allowed.
```
select cast ('' as bigint);

/* AS-IS */
ERROR: Cannot coerce value of domain "character" to domain "bigint".

/* TO-BE */
<00001>  cast('' as bigint): 0
```