### PR TITLE
[CBRD-24775] Upgrade to CMake 3.x in CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,8 +13,7 @@ install:
 - ps: choco install ant --ignore-dependencies --no-progress
 - ps: choco install cmake --version=3.26.3 --no-progress
 - ps: $env:ANT="C:\ProgramData\chocolatey\bin\ant.exe"
-- ps: $env:CMAKE="C:\Program Files\CMake\bin\cmake.exe"
-- set PATH=%CMAKE%;%PATH%
+- set PATH=C:\Program Files\CMake\bin\;%PATH%
 
 clone_script:
 - ps: >-

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,6 +11,7 @@ matrix:
 
 install:
 - ps: choco install ant --ignore-dependencies --no-progress
+- ps: choco install cmake --no-progress
 - ps: $env:ANT="C:\ProgramData\chocolatey\bin\ant.exe"
 
 clone_script:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,8 +11,10 @@ matrix:
 
 install:
 - ps: choco install ant --ignore-dependencies --no-progress
-- ps: choco install cmake --no-progress
+- ps: choco install cmake --version=3.26.3 --no-progress
 - ps: $env:ANT="C:\ProgramData\chocolatey\bin\ant.exe"
+- ps: $env:CMAKE="C:\Program Files\CMake\bin\cmake.exe"
+- set PATH=%CMAKE%;%PATH%
 
 clone_script:
 - ps: >-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: /home
   docker:
-    - image: cubridci/cubridci:develop
+    - image: cubridci/cubridci:develop-buildng
     
 oraclelinux: &oraclelinux
   working_directory: /home

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,7 @@ jobs:
           command: |
             mkdir -p /tmp/build_logs
             scl enable devtoolset-8 -- /entrypoint.sh build
+            mv -f build.log /tmp/build_logs
       - run:
           name: Commits
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,6 @@ jobs:
           command: |
             mkdir -p /tmp/build_logs
             scl enable devtoolset-8 -- /entrypoint.sh build
-            mv -f build.log /tmp/build_logs
       - run:
           name: Commits
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: /home
   docker:
-    - image: cubridci/cubridci:develop-buildng
+    - image: cubridci/cubridci:develop_buildng
     
 oraclelinux: &oraclelinux
   working_directory: /home

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 #
 message(STATUS "======== CMakeLists.txt")
 
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.6.0)
 
 function(with_unit_tests res) # checks for -DUNIT_TESTS=ON or -DUNIT_TEST_???=ON
   get_cmake_property(vars VARIABLES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 #
 message(STATUS "======== CMakeLists.txt")
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.6)
 
 function(with_unit_tests res) # checks for -DUNIT_TESTS=ON or -DUNIT_TEST_???=ON
   get_cmake_property(vars VARIABLES)
@@ -112,9 +112,6 @@ endfunction(target_external_dependencies)
 
 macro(ADD_BY_PRODUCTS_VARIABLE prefix_dependee)
   if (CMAKE_GENERATOR MATCHES "Ninja")
-    if(CMAKE_VERSION VERSION_LESS "3.2")
-      message(FATAL_ERROR "The Ninja generator requires CMake 3.2+. Try the \"Unix Makefiles\" generator instead.")
-    endif()
     set(${prefix_dependee}_BYPRODUCTS BUILD_BYPRODUCTS "${ARGN}")
   endif()
 endmacro()
@@ -1451,14 +1448,9 @@ if(WIN32)
   else()
     message(WARNING "Cannot generate MSI installer with unsupported compiler version")
   endif()
-  if(CMAKE_VERSION VERSION_GREATER "3.1")
     set_property(INSTALL "${CUBRID_BINDIR}/$<TARGET_FILE_NAME:cubridtray>"
       PROPERTY CPACK_START_MENU_SHORTCUTS "CUBRID Service Tray")
     configure_file(cmake/CPackWixPatch.cmake.in wix_patch.xml @ONLY)
-  else(CMAKE_VERSION VERSION_GREATER "3.1")
-    # TODO: msi package will not working on CMAKE version 3.5 or less
-    set(CPACK_PACKAGE_EXECUTABLES cubridtray "CUBRID Service Tray")
-  endif(CMAKE_VERSION VERSION_GREATER "3.1")
 endif(WIN32)
 
 include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 #
 message(STATUS "======== CMakeLists.txt")
 
-cmake_minimum_required(VERSION 3.6.0)
+cmake_minimum_required(VERSION 2.8)
 
 function(with_unit_tests res) # checks for -DUNIT_TESTS=ON or -DUNIT_TEST_???=ON
   get_cmake_property(vars VARIABLES)

--- a/build.sh
+++ b/build.sh
@@ -29,7 +29,7 @@ script_dir=$(dirname $(readlink -f $0))
 # variables for options
 build_target="x86_64"
 build_mode="release"
-build_generator="make"
+build_generator="ninja"
 source_dir=`pwd`
 default_java_dir="/usr/lib/jvm/java"
 java_dir=""

--- a/cmake/CPackOptions.cmake.in
+++ b/cmake/CPackOptions.cmake.in
@@ -45,10 +45,10 @@ elseif(CPACK_GENERATOR STREQUAL "RPM")
   set(CPACK_RPM_USER_FILELIST
     "%config(noreplace) /opt/cubrid/conf"
     %dir "/opt/cubrid/databases"
-    "/etc/profile.d/cubrid.csh"
-    "/etc/profile.d/cubrid.sh"
-    "/etc/init.d/cubrid"
-    "/etc/init.d/cubrid-ha"
+    %attr(755,-,-) "/etc/profile.d/cubrid.csh"
+    %attr(755,-,-) "/etc/profile.d/cubrid.sh"
+    %attr(755,-,-) "/etc/init.d/cubrid"
+    %attr(755,-,-) "/etc/init.d/cubrid-ha"
     )
   set(CPACK_RPM_PACKAGE_AUTOREQ " no")
 endif()

--- a/cmake/CPackOptions.cmake.in
+++ b/cmake/CPackOptions.cmake.in
@@ -42,13 +42,10 @@ elseif(CPACK_GENERATOR STREQUAL "RPM")
   set(CPACK_RPM_PRE_INSTALL_SCRIPT_FILE "${CMAKE_SOURCE_DIR}/cmake/CPack_preinstall.sh.in")
   set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE "${CMAKE_SOURCE_DIR}/cmake/CPack_postinstall.sh.in")
   set(CPACK_RPM_PRE_UNINSTALL_SCRIPT_FILE "${CMAKE_SOURCE_DIR}/cmake/CPack_preuninstall.sh.in")
+  set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "/etc/profile.d/cubrid.csh /etc/profile.d/cubrid.sh /etc/init.d/cubrid /etc/init.d/cubrid-ha")
   set(CPACK_RPM_USER_FILELIST
     "%config(noreplace) /opt/cubrid/conf"
-    %dir "/opt/cubrid/databases"
-    %attr(755,-,-) "/etc/profile.d/cubrid.csh"
-    %attr(755,-,-) "/etc/profile.d/cubrid.sh"
-    %attr(755,-,-) "/etc/init.d/cubrid"
-    %attr(755,-,-) "/etc/init.d/cubrid-ha"
+    "%dir /opt/cubrid/databases"
     )
   set(CPACK_RPM_PACKAGE_AUTOREQ " no")
 endif()


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24775

**Purpose**
This PR will support CMake 3.x in CI
- CPACK_RPM_USER_FILELIST should be fixed to avoid the following error.
```
CPack: Create package
CMake Error at /usr/local/share/cmake-3.23/Modules/Internal/CPack/CPackRPM.cmake:1310 (string):
  string sub-command REGEX, mode MATCH regex "(%[A-Za-z]+(\([^()]*\))? )*"
  matched an empty string.
Call Stack (most recent call first):
  /usr/local/share/cmake-3.23/Modules/Internal/CPack/CPackRPM.cmake:1968 (cpack_rpm_generate_package)

 


CMake Error at /usr/local/share/cmake-3.23/Modules/Internal/CPack/CPackRPM.cmake:1310 (string):
  string sub-command REGEX, mode MATCH regex "(%[A-Za-z]+(\([^()]*\))? )*"
  matched an empty string.
Call Stack (most recent call first):
  /usr/local/share/cmake-3.23/Modules/Internal/CPack/CPackRPM.cmake:1968 (cpack_rpm_generate_package)
 ...
```
- .circleci/config.yml and .appveyor.yml will be revised to use CMake 3.x

**Implementation**
- Fix CPackOptions.cmake file
- ~Make CMake 3.6.0 as minimum in CMakeLists.txt~
  - ~remove redundant scripts~
- Use Ninja generator as a default

Note
Forward-porting for this PR to develop branch is required. 