### PR TITLE
[CBRD-24781] Added csql option for catalog rebuild

### DIFF
--- a/src/compat/db_client_type.hpp
+++ b/src/compat/db_client_type.hpp
@@ -46,6 +46,7 @@ enum db_client_type
   DB_CLIENT_TYPE_SKIP_VACUUM_ADMIN_CSQL = 16,
   DB_CLIENT_TYPE_ADMIN_COMPACTDB_WOS = 17, /* admin compactdb that can run on standby */
   DB_CLIENT_TYPE_ADMIN_LOADDB_COMPAT = 18, /* loaddb with --no-user-specified-name option */
+  DB_CLIENT_TYPE_ADMIN_CSQL_REBUILD_CATALOG = 19,
 
   DB_CLIENT_TYPE_MAX
 };

--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -1044,7 +1044,7 @@ csql_do_session_cmd (char *line_read, CSQL_ARGUMENT * csql_arg)
 	{
 	  if (csql_arg->sysadm && au_is_dba_group_member (Au_user))
 	    {
-	      au_sysadm_disable ();
+	      au_disable ();
 	    }
 	  csql_Database_connected = true;
 
@@ -2880,6 +2880,12 @@ csql (const char *argv0, CSQL_ARGUMENT * csql_arg)
       client_type = DB_CLIENT_TYPE_CSQL;
     }
 
+  if (csql_arg->sysadm_rebuild_catalog)
+    {
+      client_type = DB_CLIENT_TYPE_ADMIN_CSQL_REBUILD_CATALOG;
+      csql_arg->sysadm = true;
+    }
+
   if (db_restart_ex (argv0, csql_arg->db_name, csql_arg->user_name, csql_arg->passwd, NULL, client_type) != NO_ERROR)
     {
       if (!csql_Is_interactive || csql_arg->passwd != NULL || db_error_code () != ER_AU_INVALID_PASSWORD)
@@ -2934,7 +2940,7 @@ csql (const char *argv0, CSQL_ARGUMENT * csql_arg)
 
   if (csql_arg->sysadm && au_is_dba_group_member (Au_user))
     {
-      au_sysadm_disable ();
+      au_disable ();
     }
 
   /* allow environmental setting of the "-s" command line flag to enable automated testing */

--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -3484,7 +3484,7 @@ csql_connect (char *argument, CSQL_ARGUMENT * csql_arg)
 
   if (csql_arg->sysadm && au_is_dba_group_member (Au_user))
     {
-      au_sysadm_disable ();
+      au_disable ();
     }
   csql_Database_connected = true;
 

--- a/src/executables/csql.h
+++ b/src/executables/csql.h
@@ -277,6 +277,7 @@ extern "C"
     bool nopager;
     bool continue_on_error;
     bool sysadm;
+    bool sysadm_rebuild_catalog;
     bool write_on_standby;
     bool trigger_action_flag;
     bool plain_output;

--- a/src/executables/csql_launcher.c
+++ b/src/executables/csql_launcher.c
@@ -428,7 +428,8 @@ main (int argc, char *argv[])
 	}
     }
 
-  if ((csql_arg.sysadm || csql_arg.sysadm_rebuild_catalog) && (csql_arg.user_name == NULL || strcasecmp (csql_arg.user_name, "DBA")))
+  if ((csql_arg.sysadm || csql_arg.sysadm_rebuild_catalog)
+      && (csql_arg.user_name == NULL || strcasecmp (csql_arg.user_name, "DBA")))
     {
       /* sysadm is allowed only to DBA */
       goto print_usage;

--- a/src/executables/csql_launcher.c
+++ b/src/executables/csql_launcher.c
@@ -137,6 +137,7 @@ main (int argc, char *argv[])
     {CSQL_NO_PAGER_L, 0, 0, CSQL_NO_PAGER_S},
     {CSQL_NO_SINGLE_LINE_L, 0, 0, CSQL_NO_SINGLE_LINE_S},
     {CSQL_SYSADM_L, 0, 0, CSQL_SYSADM_S},
+    {CSQL_SYSADM_REBUILD_CATALOG_L, 0, 0, CSQL_SYSADM_REBUILD_CATALOG_S},
     {CSQL_WRITE_ON_STANDBY_L, 0, 0, CSQL_WRITE_ON_STANDBY_S},
     {CSQL_STRING_WIDTH_L, 1, 0, CSQL_STRING_WIDTH_S},
     {CSQL_NO_TRIGGER_ACTION_L, 0, 0, CSQL_NO_TRIGGER_ACTION_S},
@@ -255,6 +256,10 @@ main (int argc, char *argv[])
 
 	case CSQL_SYSADM_S:
 	  csql_arg.sysadm = true;
+	  break;
+
+	case CSQL_SYSADM_REBUILD_CATALOG_S:
+	  csql_arg.sysadm_rebuild_catalog = true;
 	  break;
 
 	case CSQL_WRITE_ON_STANDBY_S:
@@ -410,7 +415,20 @@ main (int argc, char *argv[])
       goto print_usage;
     }
 
-  if (csql_arg.sysadm && (csql_arg.user_name == NULL || strcasecmp (csql_arg.user_name, "DBA")))
+  if (csql_arg.sysadm_rebuild_catalog)
+    {
+      if (!csql_arg.sa_mode)
+	{
+	  goto print_usage;
+	}
+
+      if (csql_arg.in_file_name == NULL && csql_arg.command == NULL)
+	{
+	  goto print_usage;
+	}
+    }
+
+  if ((csql_arg.sysadm || csql_arg.sysadm_rebuild_catalog) && (csql_arg.user_name == NULL || strcasecmp (csql_arg.user_name, "DBA")))
     {
       /* sysadm is allowed only to DBA */
       goto print_usage;

--- a/src/executables/utility.h
+++ b/src/executables/utility.h
@@ -1437,6 +1437,8 @@ typedef struct _ha_config
 #define CSQL_QUERY_COLUMN_ENCLOSURE_L		"enclosure"
 #define CSQL_LOADDB_OUTPUT_S			'd'
 #define CSQL_LOADDB_OUTPUT_L			"loaddb-output"
+#define CSQL_SYSADM_REBUILD_CATALOG_S           12020
+#define CSQL_SYSADM_REBUILD_CATALOG_L           "sysadm-rebuild-catalog"
 
 #define COMMDB_SERVER_LIST_S                    'P'
 #define COMMDB_SERVER_LIST_L                    "server-list"

--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -6405,8 +6405,8 @@ check_authorization (MOP classobj, SM_CLASS * sm_class, DB_AUTH type)
   if (Au_disable)
     {
       int client_type = db_get_client_type ();
-      if ((client_type != DB_CLIENT_TYPE_ADMIN_CSQL && client_type != DB_CLIENT_TYPE_ADMIN_CSQL_WOS
-	   && client_type != DB_CLIENT_TYPE_SKIP_VACUUM_ADMIN_CSQL) || !(sm_class->flags & SM_CLASSFLAG_SYSTEM))
+      if (!(client_type == DB_CLIENT_TYPE_ADMIN_CSQL || client_type == DB_CLIENT_TYPE_ADMIN_CSQL_WOS
+	    || client_type == DB_CLIENT_TYPE_SKIP_VACUUM_ADMIN_CSQL) || !(sm_class->flags & SM_CLASSFLAG_SYSTEM))
 	{
 	  return NO_ERROR;
 	}

--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -6404,7 +6404,9 @@ check_authorization (MOP classobj, SM_CLASS * sm_class, DB_AUTH type)
    */
   if (Au_disable)
     {
-      if (db_get_client_type() != DB_CLIENT_TYPE_ADMIN_CSQL || !(sm_class->flags & SM_CLASSFLAG_SYSTEM))
+      int client_type = db_get_client_type ();
+      if ((client_type != DB_CLIENT_TYPE_ADMIN_CSQL && client_type != DB_CLIENT_TYPE_ADMIN_CSQL_WOS
+	   && client_type != DB_CLIENT_TYPE_SKIP_VACUUM_ADMIN_CSQL) || !(sm_class->flags & SM_CLASSFLAG_SYSTEM))
 	{
 	  return NO_ERROR;
 	}

--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -6405,8 +6405,7 @@ check_authorization (MOP classobj, SM_CLASS * sm_class, DB_AUTH type)
   if (Au_disable)
     {
       int client_type = db_get_client_type ();
-      if (!(client_type == DB_CLIENT_TYPE_ADMIN_CSQL || client_type == DB_CLIENT_TYPE_ADMIN_CSQL_WOS
-	    || client_type == DB_CLIENT_TYPE_SKIP_VACUUM_ADMIN_CSQL) || !(sm_class->flags & SM_CLASSFLAG_SYSTEM))
+      if (!BOOT_ADMIN_CSQL_CLIENT_TYPE (client_type) || !(sm_class->flags & SM_CLASSFLAG_SYSTEM))
 	{
 	  return NO_ERROR;
 	}

--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -311,7 +311,6 @@ MOP Au_root = NULL;
  * use the AU_DISABLE, AU_ENABLE macros instead.
  */
 int Au_disable = 1;
-bool Au_sysadm = false;
 
 /*
  * Au_ignore_passwords
@@ -6403,9 +6402,12 @@ check_authorization (MOP classobj, SM_CLASS * sm_class, DB_AUTH type)
    * Callers generally check Au_disable already to avoid the function call.
    * Check it again to be safe, at this point, it isn't going to add anything.
    */
-  if (Au_disable && (!Au_sysadm || !(sm_class->flags & SM_CLASSFLAG_SYSTEM)))
+  if (Au_disable)
     {
-      return NO_ERROR;
+      if (db_get_client_type() != DB_CLIENT_TYPE_ADMIN_CSQL || !(sm_class->flags & SM_CLASSFLAG_SYSTEM))
+	{
+	  return NO_ERROR;
+	}
     }
 
   /* try to catch attempts by even the DBA to update a protected class */
@@ -9411,19 +9413,6 @@ au_disable (void)
 }
 
 /*
- * au_sysadm_disable - set Au_disable for sysadm
- *   return: original Au_disable value
- */
-int
-au_sysadm_disable (void)
-{
-  int save = Au_disable;
-  Au_disable = 1;
-  Au_sysadm = true;
-  return save;
-}
-
-/*
  * au_enable - restore Au_disable
  *   return:
  *   save(in): original Au_disable value
@@ -9432,7 +9421,6 @@ void
 au_enable (int save)
 {
   Au_disable = save;
-  Au_sysadm = false;
 }
 
 /*

--- a/src/object/authenticate.h
+++ b/src/object/authenticate.h
@@ -100,7 +100,6 @@ extern const char *AU_DBA_USER_NAME;
 
 
 int au_disable (void);
-int au_sysadm_disable (void);
 void au_enable (int save);
 MOP au_get_public_user (void);
 MOP au_get_dba_user (void);

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -9017,6 +9017,14 @@ do_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
       break;
     }
 
+  if (db_get_client_type () == DB_CLIENT_TYPE_ADMIN_CSQL_REBUILD_CATALOG)
+    {
+      if (sm_check_system_class_by_name (class_name))
+	{
+	  sm_mark_system_class (class_obj, 1);
+	}
+    }
+
   if (do_flush_class_mop == true)
     {
       assert (error == NO_ERROR);

--- a/src/transaction/boot.h
+++ b/src/transaction/boot.h
@@ -49,10 +49,12 @@
 
 #define BOOT_ADMIN_CLIENT_TYPE(client_type) \
         ((client_type) == DB_CLIENT_TYPE_ADMIN_UTILITY \
-         || (client_type) == DB_CLIENT_TYPE_ADMIN_COMPACTDB_WOS \
          || (client_type) == DB_CLIENT_TYPE_ADMIN_CSQL \
+         || (client_type) == DB_CLIENT_TYPE_ADMIN_CSQL_REBUILD_CATALOG \
          || (client_type) == DB_CLIENT_TYPE_ADMIN_CSQL_WOS \
-         || (client_type) == DB_CLIENT_TYPE_SKIP_VACUUM_ADMIN_CSQL)
+         || (client_type) == DB_CLIENT_TYPE_SKIP_VACUUM_ADMIN_CSQL \
+         || (client_type) == DB_CLIENT_TYPE_ADMIN_COMPACTDB_WOS \
+	 || (client_type) == DB_CLIENT_TYPE_ADMIN_LOADDB_COMPAT)
 
 #define BOOT_LOG_REPLICATOR_TYPE(client_type) \
         ((client_type) == DB_CLIENT_TYPE_LOG_COPIER \
@@ -60,11 +62,12 @@
 
 #define BOOT_CSQL_CLIENT_TYPE(client_type) \
         ((client_type) == DB_CLIENT_TYPE_CSQL \
-        || (client_type) == DB_CLIENT_TYPE_READ_ONLY_CSQL \
-        || (client_type) == DB_CLIENT_TYPE_SKIP_VACUUM_CSQL \
-        || (client_type) == DB_CLIENT_TYPE_SKIP_VACUUM_ADMIN_CSQL \
-        || (client_type) == DB_CLIENT_TYPE_ADMIN_CSQL \
-        || (client_type) == DB_CLIENT_TYPE_ADMIN_CSQL_WOS)
+         || (client_type) == DB_CLIENT_TYPE_READ_ONLY_CSQL \
+         || (client_type) == DB_CLIENT_TYPE_ADMIN_CSQL \
+         || (client_type) == DB_CLIENT_TYPE_ADMIN_CSQL_REBUILD_CATALOG \
+         || (client_type) == DB_CLIENT_TYPE_ADMIN_CSQL_WOS \
+         || (client_type) == DB_CLIENT_TYPE_SKIP_VACUUM_CSQL \
+         || (client_type) == DB_CLIENT_TYPE_SKIP_VACUUM_ADMIN_CSQL)
 
 #define BOOT_BROKER_AND_DEFAULT_CLIENT_TYPE(client_type) \
         ((client_type) == DB_CLIENT_TYPE_DEFAULT \

--- a/src/transaction/boot.h
+++ b/src/transaction/boot.h
@@ -69,6 +69,16 @@
          || (client_type) == DB_CLIENT_TYPE_SKIP_VACUUM_CSQL \
          || (client_type) == DB_CLIENT_TYPE_SKIP_VACUUM_ADMIN_CSQL)
 
+/* DB_CLIENT_TYPE_ADMIN_CSQL_REBUILD_CATALOG is excluded
+ * for using the `--sysadm_rebuild_catalog` option of the csql utility.
+ *
+ * See CBRD-24781 for the details.
+ */
+#define BOOT_ADMIN_CSQL_CLIENT_TYPE(client_type) \
+        ((client_type) == DB_CLIENT_TYPE_ADMIN_CSQL \
+         || (client_type) == DB_CLIENT_TYPE_ADMIN_CSQL_WOS \
+         || (client_type) == DB_CLIENT_TYPE_SKIP_VACUUM_ADMIN_CSQL)
+
 #define BOOT_BROKER_AND_DEFAULT_CLIENT_TYPE(client_type) \
         ((client_type) == DB_CLIENT_TYPE_DEFAULT \
          || (client_type) == DB_CLIENT_TYPE_BROKER \

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -5957,6 +5957,8 @@ boot_client_type_to_string (BOOT_CLIENT_TYPE type)
       return "ADMIN_UTILITY";
     case DB_CLIENT_TYPE_ADMIN_CSQL:
       return "ADMIN_CSQL";
+    case DB_CLIENT_TYPE_ADMIN_CSQL_REBUILD_CATALOG:
+      return "ADMIN_CSQL_REBUILD_CATALOG";
     case DB_CLIENT_TYPE_LOG_COPIER:
       return "LOG_COPIER";
     case DB_CLIENT_TYPE_LOG_APPLIER:
@@ -5973,6 +5975,10 @@ boot_client_type_to_string (BOOT_CLIENT_TYPE type)
       return "SKIP_VACUUM_CSQL";
     case DB_CLIENT_TYPE_SKIP_VACUUM_ADMIN_CSQL:
       return "SKIP_VACUUM_ADMIN_CSQL";
+    case DB_CLIENT_TYPE_ADMIN_COMPACTDB_WOS:
+      return "ADMIN_COMPACTDB_WOS";
+    case DB_CLIENT_TYPE_ADMIN_LOADDB_COMPAT:
+      return "ADMIN_LOADDB_COMPAT";
     case DB_CLIENT_TYPE_UNKNOWN:
     default:
       return "UNKNOWN";


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24781

Add an option to change the catalog only when the csql utility is executed in standalone mode and the `command` or `input-file` option is used.