### PR TITLE
[CBRD-24633] Fixed typo in option name of unloaddb

### DIFF
--- a/src/executables/utility.h
+++ b/src/executables/utility.h
@@ -1364,7 +1364,7 @@ typedef struct _ha_config
 #define UNLOAD_SPLIT_SCHEMA_FILES_S             11920
 #define UNLOAD_SPLIT_SCHEMA_FILES_L             "split-schema-files"
 #define UNLOAD_AS_DBA_S                         11921
-#define UNLOAD_AS_DBA_L                         "same-as-dba"
+#define UNLOAD_AS_DBA_L                         "as-dba"
 
 /* compactdb option list */
 #define COMPACT_VERBOSE_S                       'v'


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24633

Purpose
There was a typo in the option name of unloaddb, so it was corrected.

Implementation
AS_IS
--same-as-dba

TO_BE
--as-dba

Remarks
N/A

