### PR TITLE
[CBRD-24743] dlopen with RTLD_GLOBAL flag (broker_monitor)

### DIFF
--- a/src/broker/broker_monitor.c
+++ b/src/broker/broker_monitor.c
@@ -2192,7 +2192,7 @@ initscr ()
   for (major_version = TINFO_HIGH_VERSION; major_version >= TINFO_LOW_VERSION; major_version--)
     {
       sprintf (tinfo_so, "libtinfo.so.%d", major_version);
-      if ((dl_handle = dlopen (tinfo_so, RTLD_LAZY)) != NULL)
+      if ((dl_handle = dlopen (tinfo_so, RTLD_LAZY | RTLD_GLOBAL)) != NULL)
 	{
 	  break;
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24743

**Description**
* fix memory corruption error described in comment of CBRD-24743

**Remarks**
* changed RTLD_LOCAL (default) to RTLD_GLOBAL when doing dlopen ()
* changed binaries are tested in CentOS, Ubuntu, debian
