### PR TITLE
[CBRD-24620] Replace db name copy method not to occur memory leak

### DIFF
--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -127,6 +127,7 @@ int (*csql_text_console_to_utf8) (const char *, const int, char **, int *) = NUL
 
 int csql_Row_count;
 int csql_Num_failures;
+char csql_Db_name[512];
 
 /* command editor lines */
 int csql_Line_lwm = -1;
@@ -3384,7 +3385,6 @@ csql_connect (char *argument, CSQL_ARGUMENT * csql_arg)
   char *p = NULL;
   const char *err_msg;
   CSQL_ARGUMENT csql_new_arg;
-  char csql_db_name[DB_NAME_LEN];
 
   if (argument == NULL)
     {
@@ -3475,8 +3475,8 @@ csql_connect (char *argument, CSQL_ARGUMENT * csql_arg)
 
 /*If login is success, copy csql_new_arg to csql_arg*/
   csql_new_arg.user_name = strdup (user_name_ptr);
-  strcpy (csql_db_name, db_name_ptr);
-  csql_new_arg.db_name = csql_db_name;
+  strcpy (csql_Db_name, db_name_ptr);
+  csql_new_arg.db_name = csql_Db_name;
 
   FREE_MEM ((char *) csql_arg->user_name);
   FREE_MEM ((char *) csql_arg->passwd);

--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -3384,6 +3384,7 @@ csql_connect (char *argument, CSQL_ARGUMENT * csql_arg)
   char *p = NULL;
   const char *err_msg;
   CSQL_ARGUMENT csql_new_arg;
+  char csql_db_name[DB_NAME_LEN];
 
   if (argument == NULL)
     {
@@ -3474,10 +3475,10 @@ csql_connect (char *argument, CSQL_ARGUMENT * csql_arg)
 
 /*If login is success, copy csql_new_arg to csql_arg*/
   csql_new_arg.user_name = strdup (user_name_ptr);
-  csql_new_arg.db_name = strdup (db_name_ptr);
+  strcpy (csql_db_name, db_name_ptr);
+  csql_new_arg.db_name = csql_db_name;
 
   FREE_MEM ((char *) csql_arg->user_name);
-  FREE_MEM ((char *) csql_arg->db_name);
   FREE_MEM ((char *) csql_arg->passwd);
 
   memcpy (csql_arg, &csql_new_arg, sizeof (CSQL_ARGUMENT));

--- a/src/executables/csql_launcher.c
+++ b/src/executables/csql_launcher.c
@@ -357,7 +357,7 @@ main (int argc, char *argv[])
 
   if (argc - optind == 1)
     {
-      csql_arg.db_name = strdup (argv[optind]);
+      csql_arg.db_name = argv[optind];
     }
   else if (argc > optind)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24620

**Description**

The user typing that the below command to connect other users is not intuitive, while the CSQL session is connected;

CALL login ('user_name', 'password') ON CLASS db_user;
So, we should add the session command user to use more intuitive while the CSQL session is connected.

;connect user_name db_name@host_name
This can helps user to connect more intuitive while the CSQL session is connected.

**Remarks**
* This PR is to avoid possible memory leak of #4134 pointed out by valgrind.
