### PR TITLE
[LETS-699] Materialize channel name id, not generate it when needed

### DIFF
--- a/src/communication/communication_channel.cpp
+++ b/src/communication/communication_channel.cpp
@@ -261,7 +261,7 @@ namespace cubcomm
 
   void channel::materialize_channel_id ()
   {
-    assert (m_channel_name.empty ());
+    assert (m_channel_id.empty ());
 
     std::stringstream ss;
 

--- a/src/communication/communication_channel.cpp
+++ b/src/communication/communication_channel.cpp
@@ -75,6 +75,8 @@ namespace cubcomm
 
     m_port = comm.m_port;
     comm.m_port = INVALID_PORT;
+
+    materialize_channel_id ();
   }
 
   channel::~channel ()
@@ -165,8 +167,6 @@ namespace cubcomm
 
     m_socket = css_tcp_client_open (hostname, port);
 
-    er_log_chn_debug ("[%s] Connect to %s:%d socket = %d.\n", get_channel_id ().c_str (), hostname, port, m_socket);
-
     if (IS_INVALID_SOCKET (m_socket))
       {
 	return REQUEST_REFUSED;
@@ -176,13 +176,16 @@ namespace cubcomm
     m_hostname = hostname;
     m_port = port;
 
+    materialize_channel_id ();
+
+    er_log_chn_debug ("[%s] Connect to %s:%d socket = %d.\n", get_channel_id ().c_str (), hostname, port, m_socket);
+
+
     return NO_ERRORS;
   }
 
   css_error_code channel::accept (SOCKET socket)
   {
-    er_log_chn_debug ("[%s] Accept connection to socket = %d.\n", get_channel_id ().c_str (), socket);
-
     if (is_connection_alive () || IS_INVALID_SOCKET (socket))
       {
 	return INTERNAL_CSS_ERROR;
@@ -190,6 +193,10 @@ namespace cubcomm
 
     m_type = CHANNEL_TYPE::LISTENER;
     m_socket = socket;
+
+    materialize_channel_id ();
+
+    er_log_chn_debug ("[%s] Accept connection to socket = %d.\n", get_channel_id ().c_str (), socket);
 
     return NO_ERRORS;
   }
@@ -252,4 +259,19 @@ namespace cubcomm
     return m_port;
   }
 
+  void channel::materialize_channel_id ()
+  {
+    std::stringstream ss;
+
+    ss << m_channel_name << "_" << m_hostname;
+
+    if (m_port != -1)
+      {
+	ss << "_" << m_port;
+      }
+
+    ss << "_" << m_socket;
+
+    m_channel_id = ss.str ();
+  }
 } /* namespace cubcomm */

--- a/src/communication/communication_channel.cpp
+++ b/src/communication/communication_channel.cpp
@@ -261,6 +261,8 @@ namespace cubcomm
 
   void channel::materialize_channel_id ()
   {
+    assert (m_channel_name.empty ());
+
     std::stringstream ss;
 
     ss << m_channel_name << "_" << m_hostname;

--- a/src/communication/communication_channel.hpp
+++ b/src/communication/communication_channel.hpp
@@ -105,18 +105,8 @@ namespace cubcomm
 
       std::string get_channel_id () const
       {
-	std::stringstream ss;
-
-	ss << m_channel_name << "_" << m_hostname;
-
-	if (m_port != -1)
-	  {
-	    ss << "_" << m_port;
-	  }
-
-	ss << "_" << m_socket;
-
-	return ss.str ();
+	assert (!m_channel_id.empty());
+	return m_channel_id;
       }
 
     protected:
@@ -126,6 +116,12 @@ namespace cubcomm
       std::string m_channel_name;
       std::string m_hostname;
       int m_port = INVALID_PORT;
+
+    private:
+      void materialize_channel_id ();
+
+    private:
+      std::string m_channel_id;
   };
 
 

--- a/src/communication/communication_server_channel.cpp
+++ b/src/communication/communication_server_channel.cpp
@@ -93,19 +93,17 @@ namespace cubcomm
 
   css_error_code server_channel::accept (SOCKET socket)
   {
-    er_log_chn_debug ("[%s] Accept connection to socket = %d.\n", get_channel_id ().c_str (), socket);
+    css_error_code rc = NO_ERRORS;
 
-    if (is_connection_alive () || IS_INVALID_SOCKET (socket))
+    rc = channel::accept (socket);
+    if (rc != NO_ERRORS)
       {
-	return INTERNAL_CSS_ERROR;
+	return rc;
       }
-
-    m_type = CHANNEL_TYPE::LISTENER;
-    m_socket = socket;
 
     char buffer[CUB_MAXHOSTNAMELEN];
     size_t max_size = CUB_MAXHOSTNAMELEN;
-    css_error_code rc = recv (buffer, max_size);
+    rc = recv (buffer, max_size);
     m_hostname = buffer;
     m_conn_type = static_cast<cubcomm::server_server> (css_get_master_request (socket));
     return rc;


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-699.

- Construct the channel id string when accepting and connecting since the socket number is assigned here.
- Return the pre-constructed channel id when get_channel_id() is called.
- Make server_channel::accept() go through channel::accept() since it has the exact same logic.
