### PR TITLE
[CBRD-24788] backport of #4336 to 11.2 - Add defense code to prevent core dump due to uninitialized pointer variable in csql

### DIFF
--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -1737,7 +1737,6 @@ csql_execute_statements (const CSQL_ARGUMENT * csql_arg, int type, const void *s
   DB_QUERY_TYPE *attr_spec = NULL;	/* result attribute spec. */
   int total;			/* number of statements to execute */
   bool do_abort_transaction = false;	/* flag for transaction abort */
-  PT_NODE *statement;
   char sql_text[DDL_LOG_BUFFER_SIZE] = { 0 };
 
   csql_Num_failures = 0;
@@ -1834,6 +1833,7 @@ csql_execute_statements (const CSQL_ARGUMENT * csql_arg, int type, const void *s
       DB_QUERY_RESULT *result = NULL;	/* result pointer */
       int db_error;
       char stmt_msg[LINE_BUFFER_SIZE];
+      PT_NODE *statement = NULL;
 
       /* Start the execution of stms */
       stmt_msg[0] = '\0';


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24788

Purpose
* backport of #4336 to release/11.2
* In csql, a pointer variable was declared but not initialized.
Since these uninitialized variables have garbage values, using these variables can cause a core dump.
Since this variable is used only in the for loop, it must be declared and initialized in the for loop.

Implementation
N/A

Remarks
N/A
