### PR TITLE
[LETS-699] Assign a unique number for the channel id

### DIFF
--- a/src/communication/communication_channel.cpp
+++ b/src/communication/communication_channel.cpp
@@ -43,26 +43,32 @@ namespace cubcomm
 #define er_log_chn_debug(...) \
   if (prm_get_bool_value (PRM_ID_ER_LOG_COMM_CHANNEL)) _er_log_debug (ARG_FILE_LINE, "[COMM_CHN]" __VA_ARGS__)
 
+  std::atomic<uint64_t> channel::unique_id_allocator = 0;
+
   channel::channel (int max_timeout_in_ms)
-    : m_max_timeout_in_ms (max_timeout_in_ms),
-      m_type (CHANNEL_TYPE::NO_TYPE),
-      m_socket (INVALID_SOCKET)
+    : m_max_timeout_in_ms (max_timeout_in_ms)
+    , m_type (CHANNEL_TYPE::NO_TYPE)
+    , m_socket (INVALID_SOCKET)
+    , m_unique_id (unique_id_allocator++)
   {
   }
 
   channel::channel (std::string &&channel_name)
     : m_channel_name { std::move (channel_name) }
+    , m_unique_id (unique_id_allocator++)
   {
   }
 
   channel::channel (int max_timeout_in_ms, std::string &&channel_name)
     : m_max_timeout_in_ms (max_timeout_in_ms)
     , m_channel_name { std::move (channel_name) }
+    , m_unique_id (unique_id_allocator++)
   {
   }
 
   channel::channel (channel &&comm)
     : m_max_timeout_in_ms (comm.m_max_timeout_in_ms)
+    , m_unique_id (comm.m_unique_id)
   {
     m_type = comm.m_type;
     comm.m_type = NO_TYPE;

--- a/src/communication/communication_channel.hpp
+++ b/src/communication/communication_channel.hpp
@@ -114,7 +114,7 @@ namespace cubcomm
 	    ss << "_" << m_port;
 	  }
 
-	ss << "_" << m_socket;
+	ss << "_" << m_unique_id;
 
 	return ss.str ();
       }
@@ -126,8 +126,11 @@ namespace cubcomm
       std::string m_channel_name;
       std::string m_hostname;
       int m_port = INVALID_PORT;
-  };
+      const uint64_t m_unique_id;
 
+    private:
+      static std::atomic<uint64_t> unique_id_allocator; // allocates ever-increasing value to m_uqniue_id
+  };
 
 } /* cubcomm namespace */
 

--- a/unit_tests/request_client_server/comm_channel_mock.cpp
+++ b/unit_tests/request_client_server/comm_channel_mock.cpp
@@ -145,26 +145,32 @@ namespace cubcomm
   // channel mockup
   //
 
+  std::atomic<uint64_t> channel::unique_id_allocator = 0;
+
   channel::channel (int max_timeout_in_ms)
-    : m_max_timeout_in_ms (max_timeout_in_ms),
-      m_type (CHANNEL_TYPE::NO_TYPE),
-      m_socket (INVALID_SOCKET)
+    : m_max_timeout_in_ms (max_timeout_in_ms)
+    , m_type (CHANNEL_TYPE::NO_TYPE)
+    , m_socket (INVALID_SOCKET)
+    , m_unique_id (unique_id_allocator++)
   {
   }
 
   channel::channel (std::string &&channel_name)
     : m_channel_name { std::move (channel_name) }
+    , m_unique_id (unique_id_allocator++)
   {
   }
 
   channel::channel (int max_timeout_in_ms, std::string &&channel_name)
     : m_max_timeout_in_ms (max_timeout_in_ms)
     , m_channel_name { std::move (channel_name) }
+    , m_unique_id (unique_id_allocator++)
   {
   }
 
   channel::channel (channel &&comm)
     : m_max_timeout_in_ms (comm.m_max_timeout_in_ms)
+    , m_unique_id (comm.m_unique_id)
   {
     m_type = comm.m_type;
     comm.m_type = NO_TYPE;
@@ -174,6 +180,9 @@ namespace cubcomm
 
     m_channel_name = std::move (comm.m_channel_name);
     m_hostname = std::move (comm.m_hostname);
+
+    m_port = comm.m_port;
+    comm.m_port = INVALID_PORT;
   }
 
   channel::~channel ()


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-699

- a static atomic member var to assign unique number for each channel.
- use m_unique_id instead of m_socket_id for the channel id.