### PR TITLE
[CBRD-24542] Prevent schema loading with loaddb in HA Mode.

### DIFF
--- a/msg/de_DE.utf8/utils.msg
+++ b/msg/de_DE.utf8/utils.msg
@@ -496,7 +496,7 @@ Anwendung: %1$s loaddb [OPTION] Datenbanknamen[@host]\n\
 gültige Optionen:\n\
   -S, --SA-mode                    Stand-Alone-Ausführung\n\
   -C, --CS-mode                    Client-Server-Ausführung\n\
-                                   WAARSCHUWING: In client-servermodus kan alleen databestand (-d, --data-file=FILE) worden geladen.\n\
+                                   WAARSCHUWING: In de HA-modus kunnen alleen gegevensbestanden (-d, --data-file=FILE) worden geladen in client-server-modus.\n\
   -u, --user=ID                    Benutzer ID für Datenbankzugang; Standard: "public"\n\
   -p, --password=PASSWORT          Benutzerpasswort; Standard: keinen\n\
       --data-file-check-only       Syntaxprüfung der Datei ohne Ladung; Standard: inaktiv\n\

--- a/msg/en_US.utf8/utils.msg
+++ b/msg/en_US.utf8/utils.msg
@@ -497,7 +497,7 @@ usage: %1$s loaddb [OPTION] database-name[@host]\n\
 valid options:\n\
   -S, --SA-mode                  standalone mode execution\n\
   -C, --CS-mode                  client-server mode execution\n\
-                                 WARNING: In client-server mode, only data file(-d, --data-file=FILE) can be loaded.\n\
+                                 WARNING: When in HA Mode, only data files (-d, --data-file=FILE) can be loaded in client-server mode.\n\
   -u, --user=ID                  user ID for database access; default: "public"\n\
   -p, --password=PASS            user password; default: none\n\
       --data-file-check-only     check syntax for data file without load; default: disabled\n\

--- a/msg/en_US/utils.msg
+++ b/msg/en_US/utils.msg
@@ -497,7 +497,7 @@ usage: %1$s loaddb [OPTION] database-name[@host]\n\
 valid options:\n\
   -S, --SA-mode                  standalone mode execution\n\
   -C, --CS-mode                  client-server mode execution\n\
-                                 WARNING: In client-server mode, only data file(-d, --data-file=FILE) can be loaded.\n\
+                                 WARNING: When in HA Mode, only data files (-d, --data-file=FILE) can be loaded in client-server mode.\n\
   -u, --user=ID                  user ID for database access; default: "public"\n\
   -p, --password=PASS            user password; default: none\n\
       --data-file-check-only     check syntax for data file without load; default: disabled\n\

--- a/msg/es_ES.utf8/utils.msg
+++ b/msg/es_ES.utf8/utils.msg
@@ -496,7 +496,7 @@ uso: %1$s loaddb [OPTION] database-name[@host]\n\
 opciones validas:\n\
   -S, --SA-mode                  modo de ejecucion independiente\n\
   -C, --CS-mode                  modo de ejecucion cliente-servidor\n\
-                                 ADVERTENCIA: En el modo cliente-servidor, solo se puede cargar el archivo de datos (-d, --data-file=FILE).\n\
+                                 ADVERTENCIA: En modo HA, solo los archivos de datos (-d, --data-file=FILE) se pueden cargar en modo cliente-servidor.\n\
   -u, --user=ID                  ID de utilizador para acceso a la base de datos; estandar: "public"\n\
   -p, --password=PASS            contrasena de utilizador; estandar: ninguna\n\
       --data-file-check-only     check syntax for data file without load; default: disabled\n\

--- a/msg/fr_FR.utf8/utils.msg
+++ b/msg/fr_FR.utf8/utils.msg
@@ -498,7 +498,7 @@ usage: %1$s loaddb [OPTION] database-name[@host]\n\
 options valids:\n\
   -S, --SA-mode                      exécution en mode autonome\n\
   -C, --CS-mode                      exécution en mode client-serveur\n\
-                                     ATTENTION : en mode client-serveur, seul le fichier de données (-d, --data-file=FILE) peut être chargé.\n\
+                                     ATTENTION : En mode HA, seuls les fichiers de données (-d, --data-file=FILE) peuvent être chargés en mode client-serveur.\n\
   -u, --user=ID                      ID d'utilisateur pour l'accès à la base de données, par défaut: "public"\n\
   -p, --password=MOT-DE-PASSE        MOT DE PASSE d'utilisateur; par défaut: aucun\n\
       --data-file-check-only         check syntax for data file without load; default: disabled\n\

--- a/msg/it_IT.utf8/utils.msg
+++ b/msg/it_IT.utf8/utils.msg
@@ -496,7 +496,7 @@ uso: %1$s loaddb [OPZIONE] nome-database[@host]\n\
 opzioni valide:\n\
   -S, --SA-mode                  modalità di esecuzione autonoma\n\
   -C, --CS-mode                  modalità di esecuzione client-server\n\
-                                 ATTENZIONE: In modalità client-server, è possibile caricare solo file di dati (-d, --data-file=FILE).\n\
+                                 ATTENZIONE: In modalità HA, solo i file di dati (-d, --data-file=FILE) possono essere caricati in modalità client-server.\n\
   -u, --user=ID                  user ID per l'accesso al database; predefinito: "public"\n\
   -p, --password=PASS            password utente; predefinito: nessuno\n\
       --data-file-check-only     check syntax for data file without load; default: disabled\n\

--- a/msg/ja_JP.utf8/utils.msg
+++ b/msg/ja_JP.utf8/utils.msg
@@ -496,7 +496,7 @@ loaddb: データベースにオブジェクトやスキーマロード\n\
 オプション:\n\
   -S, --SA-mode                  独立モードで実行\n\
   -C, --CS-mode                  クライアントーサーバモードで実行\n\
-                                 警告: クライアント サーバー モードでは、データ ファイル (-d、--data-file=FILE) のみをロードできます。\n\
+                                 警告: HA モードの場合、クライアント/サーバー モードではデータ ファイル (-d、--data-file=FILE) のみをロードできます。\n\
   -u, --user=ID                  データベースアクセスに関するユーザー名; デフォルト: 「public」\n\
   -p, --password=PASS            ユーザーパスワード; デフォルト: なし\n\
       --data-file-check-only     check syntax for data file without load; default: disabled\n\

--- a/msg/km_KH.utf8/utils.msg
+++ b/msg/km_KH.utf8/utils.msg
@@ -497,7 +497,7 @@ usage: %1$s loaddb [OPTION] database-name[@host]\n\
 valid options:\n\
   -S, --SA-mode                  stand-alone mode execution\n\
   -C, --CS-mode                  client-server mode execution\n\
-                                 WARNING: In client-server mode, only data file(-d, --data-file=FILE) can be loaded.\n\
+                                 WARNING: When in HA Mode, only data files (-d, --data-file=FILE) can be loaded in client-server mode.\n\
   -u, --user=ID                  user ID for database access; default: "public"\n\
   -p, --password=PASS            user password; default: none\n\
       --data-file-check-only     check syntax for data file without load; default: disabled\n\

--- a/msg/ko_KR.euckr/utils.msg
+++ b/msg/ko_KR.euckr/utils.msg
@@ -496,7 +496,7 @@ loaddb: 데이터베이스에 객체 및 스키마 적재\n\
 옵션:\n\
   -S, --SA-mode                  독립 모드 실행\n\
   -C, --CS-mode                  클라이언트 서버 모드 실행\n\
-                                 경고: 클라이언트 서버 모드에서는 데이터 파일(-d, --data-file=FILE)만 로드 할 수 있습니다.\n\
+                                 경고: HA Mode 일때, 클라이언트-서버 모드에서는 데이터 파일(-d, --data-file=FILE)만 로드할 수 있습니다.\n\
   -u, --user=ID                  데이터베이스 접근에 관한 사용자 이름; 기본값: "public"\n\
   -p, --password=PASS            사용자 패스워드; 기본값: 없음\n\
       --data-file-check-only     데이터 파일을 로딩하지 않고 신택스만 검사; 기본값: 아니오\n\

--- a/msg/ko_KR.utf8/utils.msg
+++ b/msg/ko_KR.utf8/utils.msg
@@ -496,7 +496,7 @@ loaddb: 데이터베이스에 객체 및 스키마 적재\n\
 옵션:\n\
   -S, --SA-mode                  독립 모드 실행\n\
   -C, --CS-mode                  클라이언트 서버 모드 실행\n\
-                                 경고: 클라이언트 서버 모드에서는 데이터 파일(-d, --data-file=FILE)만 로드 할 수 있습니다.\n\
+                                 경고: HA Mode 일때, 클라이언트-서버 모드에서는 데이터 파일(-d, --data-file=FILE)만 로드할 수 있습니다.\n\
   -u, --user=ID                  데이터베이스 접근에 관한 사용자 이름; 기본값: "public"\n\
   -p, --password=PASS            사용자 패스워드; 기본값: 없음\n\
       --data-file-check-only     데이터 파일을 로딩하지 않고 신택스만 검사; 기본값: 아니오\n\

--- a/msg/ro_RO.utf8/utils.msg
+++ b/msg/ro_RO.utf8/utils.msg
@@ -508,7 +508,7 @@ utilizare: %1$s loaddb [OPŢIUNI] nume-bază-de-date[@host]\n\
 opţiuni valide:\n\
   -S, --SA-mode                     mod de execuţie independent\n\
   -C, --CS-mode                     mod de execuţie client-server\n\
-                                    AVERTISMENT: În modul client-server, numai fișierul de date (-d, --data-file=FILE) poate fi încărcat.\n\
+                                    AVERTISMENT: În modul HA, numai fișierele de date (-d, --data-file=FILE) pot fi încărcate în modul client-server.\n\
   -u, --user=ID                     ID de utilizator pentru acces la baza de date; implicit: "public"\n\
   -p, --password=PAROLA             parola de utilizator; implicit: nulă\n\
       --data-file-check-only        verifică sintaxa fișierului fără a-l încărca; implicit: dezactivat\n\

--- a/msg/tr_TR.utf8/utils.msg
+++ b/msg/tr_TR.utf8/utils.msg
@@ -496,7 +496,7 @@ kullanım: %1$s loaddb [SEÇENEK] database-name[@host]\n\
 geçerli seçenekler:\n\
   -S, --SA-mode                  stand-alone modu yürütme\n\
   -C, --CS-mode                  istemci-sunucu modunda yürütme\n\
-                                 UYARI: İstemci-sunucu modunda, yalnızca veri dosyası(-d, --data-file=DOSYA) yüklenebilir.\n\
+                                 UYARI: HA Modundayken, istemci-sunucu modunda sadece veri dosyaları (-d, --data-file=FILE) yüklenebilir.\n\
   -u, --user=ID                  veritabanı erişimi için kullanıcı kimliği; varsayılan: "public"\n\
   -p, --password=PASS            kullanıcı şifresi; varsayılan: hiçbir\n\
       --data-file-check-only     check syntax for data file without load; default: disabled\n\

--- a/msg/vi_VN.utf8/utils.msg
+++ b/msg/vi_VN.utf8/utils.msg
@@ -497,7 +497,7 @@ usage: %1$s loaddb [OPTION] database-name[@host]\n\
 valid options:\n\
   -S, --SA-mode                  standalone mode execution\n\
   -C, --CS-mode                  client-server mode execution\n\
-                                 WARNING: In client-server mode, only data file(-d, --data-file=FILE) can be loaded.\n\
+                                 WARNING: When in HA Mode, only data files (-d, --data-file=FILE) can be loaded in client-server mode.\n\
   -u, --user=ID                  user ID for database access; default: "public"\n\
   -p, --password=PASS            user password; default: none\n\
       --data-file-check-only     check syntax for data file without load; default: disabled\n\

--- a/msg/zh_CN.utf8/utils.msg
+++ b/msg/zh_CN.utf8/utils.msg
@@ -496,7 +496,7 @@ loaddb: 将对象和结构导入到数据库.\n\
 可用选项:\n\
   -S, --SA-mode                  单机模式执行\n\
   -C, --CS-mode                  客户端-服务器模式执行\n\
-                                 警告：在客户端-服务器模式下，只能加载数据文件(-d, --data-file=FILE)。\n\
+                                 警告：在 HA 模式下，只能以客户端-服务器模式加载数据文件 (-d, --data-file=FILE)。\n\
   -u, --user=ID                  用于访问数据库的用户ID; 默认: "public"\n\
   -p, --password=PASS            用户密码; 默认: 空\n\
       --data-file-check-only     对数据文件只进行语法检查不加载数据; 默认: disabled\n\

--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -198,7 +198,7 @@ ldr_validate_object_file (const char *argv0, load_args * args)
 		   || args->schema_file_list.empty () == false || args->trigger_file.empty () == false))
 		{
 		  PRINT_AND_LOG_ERR_MSG
-		    ("loaddb: In case of using loaddb CS mode (-C, --CS-mode) in HA Mode, only OBJECT can be loaded.\n");
+		    ("In loaddb CS (-C, --CS-mode) in HA mode, only OBJECT loading is possible.\n");
 		  return ER_FAILED;
 		}
 	    }

--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -186,13 +186,28 @@ ldr_validate_object_file (const char *argv0, load_args * args)
       return ER_FAILED;
     }
 
-  if (args->cs_mode && (args->load_only == true
-			|| args->index_file.empty () == false
-			|| args->schema_file.empty () == false
-			|| args->schema_file_list.empty () == false || args->trigger_file.empty () == false))
+  if (args->cs_mode)
     {
-      fprintf (stderr, "In loaddb CS mode (-C, --CS-mode), only object loading is possible.\n");
-      return ER_FAILED;
+      if (sysprm_load_and_init (args->volume.c_str (), NULL, SYSPRM_IGNORE_INTL_PARAMS) == NO_ERROR)
+	{
+	  if (prm_get_integer_value (PRM_ID_HA_MODE))
+	    {
+	      if ((args->load_only == true
+		   || args->index_file.empty () == false
+		   || args->schema_file.empty () == false
+		   || args->schema_file_list.empty () == false || args->trigger_file.empty () == false))
+		{
+		  PRINT_AND_LOG_ERR_MSG
+		    ("loaddb: In case of using loaddb CS mode (-C, --CS-mode) in HA Mode, only OBJECT can be loaded.\n");
+		  return ER_FAILED;
+		}
+	    }
+	}
+      else
+	{
+	  PRINT_AND_LOG_ERR_MSG ("loaddb: Cannot load system parameters.\n");
+	  return ER_FAILED;
+	}
     }
 
   if (args->schema_file.empty () == false && args->schema_file_list.empty () == false)

--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -197,8 +197,7 @@ ldr_validate_object_file (const char *argv0, load_args * args)
 		   || args->schema_file.empty () == false
 		   || args->schema_file_list.empty () == false || args->trigger_file.empty () == false))
 		{
-		  PRINT_AND_LOG_ERR_MSG
-		    ("In loaddb CS (-C, --CS-mode) in HA mode, only OBJECT loading is possible.\n");
+		  PRINT_AND_LOG_ERR_MSG ("In loaddb CS (-C, --CS-mode) in HA mode, only OBJECT loading is possible.\n");
 		  return ER_FAILED;
 		}
 	    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24542

Purpose
* When running online mode loaddb (cubrid loaddb -C) in HA environment DDL replication does not occur to slave nodes.
* For this reason, the online mode loaddb is modified so that only object loading is possible.
* If schema loading is attempted, an error is output.
* In case of using loaddb -C option in HA Mode, the following options cannot be used.
--load-only
-i, --index-file
-s, --schema-file
--schema-file-list
--trigger-file=FILE

Implementation
N/A

Remarks
N/A
