### PR TITLE
[LETS-666] zero-out unused parts of a slotted page

### DIFF
--- a/src/storage/slotted_page.c
+++ b/src/storage/slotted_page.c
@@ -2432,8 +2432,8 @@ spage_update_record_in_place (PAGE_PTR page_p, SPAGE_HEADER * page_header_p, SPA
   // zero-out the remaining free space
   if (slot_p->record_length < old_record_length)
     {
-      memset ((void *) page_p + slot_p->offset_to_record + slot_p->record_length,
-              0, (old_record_length - slot_p->record_length));
+      memset ((void *) page_p + slot_p->offset_to_record + slot_p->record_length, 0,
+	      (old_record_length - slot_p->record_length));
     }
 
   page_header_p->total_free -= space;

--- a/src/storage/slotted_page.c
+++ b/src/storage/slotted_page.c
@@ -1267,7 +1267,7 @@ spage_compact (THREAD_ENTRY * thread_p, PAGE_PTR page_p)
   ASSERT_ALIGN ((char *) page_p + page_header_p->offset_to_free_area, page_header_p->alignment);
 
   // zero-out the remaining free space
-  memset ((void *) page_p + page_header_p->offset_to_free_area, 0, page_header_p->total_free);
+  memset ((void *) page_p + page_header_p->offset_to_free_area, 0, page_header_p->cont_free);
 
   spage_verify_header (page_p);
 

--- a/src/storage/slotted_page.c
+++ b/src/storage/slotted_page.c
@@ -1266,6 +1266,9 @@ spage_compact (THREAD_ENTRY * thread_p, PAGE_PTR page_p)
   page_header_p->offset_to_free_area = to_offset;
   ASSERT_ALIGN ((char *) page_p + page_header_p->offset_to_free_area, page_header_p->alignment);
 
+  // zero-out the remaining free space
+  memset ((void *) page_p + page_header_p->offset_to_free_area, 0, page_header_p->total_free);
+
   spage_verify_header (page_p);
 
   /* The page is set dirty somewhere else */
@@ -2416,6 +2419,7 @@ spage_update_record_in_place (PAGE_PTR page_p, SPAGE_HEADER * page_header_p, SPA
   /* Update the record in place. Same area */
   is_located_end = spage_is_record_located_at_end (page_header_p, slot_p);
 
+  const unsigned int old_record_length = slot_p->record_length;
   slot_p->record_length = record_descriptor_p->length;
   if (SPAGE_OVERFLOW (slot_p->offset_to_record + record_descriptor_p->length))
     {
@@ -2424,6 +2428,14 @@ spage_update_record_in_place (PAGE_PTR page_p, SPAGE_HEADER * page_header_p, SPA
       return SP_ERROR;
     }
   memcpy (((char *) page_p + slot_p->offset_to_record), record_descriptor_p->data, record_descriptor_p->length);
+
+  // zero-out the remaining free space
+  if (slot_p->record_length < old_record_length)
+    {
+      memset ((void *) page_p + slot_p->offset_to_record + slot_p->record_length,
+              0, (old_record_length - slot_p->record_length));
+    }
+
   page_header_p->total_free -= space;
 
   /* If the record was located at the end, we can execute a simple compaction */


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-666

This patch contains a small part that is considered correct out of the more extensive modification in #4261 .
The rest - meaning out-of-transactional-log compaction is most probably incorrect - this is still to be investigated by http://jira.cubrid.org/browse/LETS-703.

It only zeroes-out free slotted page space in only two situations:
- when a slot is in-place modified with shorted data
- after a complete page compation, the contiguous free space in page is zeroed-out

This zeroing-out of unused slotted page space will help in the event that page compaction is employed when a slotted page is served by a page servrer.

As a side note. There are probably many other situations where it makes sense to zero-out unused slotted page areas, but these are the low hanging ones.
