### PR TITLE
[CBRD-24796] Changed the position of the comment clause in the index creation statement

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -3494,11 +3494,6 @@ emit_index_def (extract_context & ctxt, print_output & output_ctx, DB_OBJECT * c
 	{
 	  output_ctx (")");
 	}
-      if (constraint->comment != NULL && constraint->comment[0] != '\0')
-	{
-	  output_ctx (" ");
-	  help_print_describe_comment (output_ctx, constraint->comment);
-	}
 
       /* Safeguard. */
       /* If it's unique then it must surely be with online flag. */
@@ -3508,6 +3503,13 @@ emit_index_def (extract_context & ctxt, print_output & output_ctx, DB_OBJECT * c
 	{
 	  output_ctx (" WITH ONLINE");
 	}
+
+      if (constraint->comment != NULL && constraint->comment[0] != '\0')
+	{
+	  output_ctx (" ");
+	  help_print_describe_comment (output_ctx, constraint->comment);
+	}
+
       output_ctx (";\n");
     }
 }

--- a/src/object/object_printer.cpp
+++ b/src/object/object_printer.cpp
@@ -836,6 +836,11 @@ void object_printer::describe_constraint (const sm_class &cls, const sm_class_co
       m_buf (" ON UPDATE %s", classobj_describe_foreign_key_action (constraint.fk_info->update_action));
     }
 
+  if (constraint.index_status == SM_INVISIBLE_INDEX)
+    {
+      m_buf (" INVISIBLE");
+    }
+
   if (constraint.comment != NULL && constraint.comment[0] != '\0')
     {
       m_buf (" ");
@@ -847,11 +852,6 @@ void object_printer::describe_constraint (const sm_class &cls, const sm_class_co
 	{
 	  describe_comment (constraint.comment);
 	}
-    }
-
-  if (constraint.index_status == SM_INVISIBLE_INDEX)
-    {
-      m_buf (" INVISIBLE");
     }
 
   if (prt_type == class_description::CSQL_SCHEMA_COMMAND)

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -2691,10 +2691,10 @@ create_stmt
 	  ON_						/* 9 */
 	  only_class_name				/* 10 */
 	  index_column_name_list			/* 11 */
-	  opt_where_clause				/* 12 */
-	  opt_comment_spec				/* 13 */
-	  opt_with_online				/* 14 */
-	  opt_invisible					/* 15 */
+	  opt_where_clause				/* 12 */	  
+	  opt_with_online				/* 13 */
+	  opt_invisible					/* 14 */
+          opt_comment_spec				/* 15 */
 		{{ DBG_TRACE_GRAMMAR(create_stmt,  CREATE ~ INDEX identifier ON_ ~);
 
 			PT_NODE *node = parser_pop_hint_node ();
@@ -2812,12 +2812,12 @@ create_stmt
 			      }
 			    node->info.index.where = $12;
 			    node->info.index.column_names = col;
-			    node->info.index.comment = $13;
+			    node->info.index.comment = $15;
 
-                            int with_online_ret = $14;  // 0 for normal, 1 for online no parallel,
+                            int with_online_ret = $13;  // 0 for normal, 1 for online no parallel,
                                                         // thread_count + 1 for parallel
                             bool is_online = with_online_ret > 0;
-                            bool is_invisible = $15;
+                            bool is_invisible = $14;
 
                             if (is_online && is_invisible)
                               {
@@ -10430,9 +10430,9 @@ attr_index_def
 	: index_or_key              /* 1 */
 	  identifier                /* 2 */
 	  index_column_name_list    /* 3 */
-	  opt_where_clause          /* 4 */
-	  opt_comment_spec          /* 5 */
-	  opt_invisible             /* 6 */
+	  opt_where_clause          /* 4 */	  
+	  opt_invisible             /* 5 */
+          opt_comment_spec          /* 6 */
 		{{ DBG_TRACE_GRAMMAR(attr_index_def, : index_or_key identifier index_column_name_list opt_where_clause opt_comment_spec opt_invisible);
 			int arg_count = 0, prefix_col_count = 0;
 			PT_NODE* node = parser_new_node(this_parser,
@@ -10447,7 +10447,7 @@ attr_index_def
 			  }
 			node->info.index.indexed_class = NULL;
 			node->info.index.where = $4;
-			node->info.index.comment = $5;
+			node->info.index.comment = $6;
 			node->info.index.index_status = SM_NORMAL_INDEX;
 
 			prefix_col_count =
@@ -10490,7 +10490,7 @@ attr_index_def
 			  }
 			node->info.index.column_names = col;
 			node->info.index.index_status = SM_NORMAL_INDEX;
-			if ($6)
+			if ($5)
 				{
 					node->info.index.index_status = SM_INVISIBLE_INDEX;
 				}

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -6346,14 +6346,6 @@ pt_print_alter_index (PARSER_CONTEXT * parser, PT_NODE * p)
     }
 #endif
 
-  if (p->info.index.comment != NULL)
-    {
-      comment = pt_print_bytes (parser, p->info.index.comment);
-      b = pt_append_nulstring (parser, b, " comment ");
-      b = pt_append_varchar (parser, b, comment);
-      b = pt_append_nulstring (parser, b, " ");
-    }
-
   if (p->info.index.index_status == SM_INVISIBLE_INDEX)
     {
       b = pt_append_nulstring (parser, b, " INVISIBLE ");
@@ -6361,6 +6353,14 @@ pt_print_alter_index (PARSER_CONTEXT * parser, PT_NODE * p)
   else if (p->info.index.index_status == SM_NORMAL_INDEX)
     {
       b = pt_append_nulstring (parser, b, " VISIBLE ");
+    }
+
+  if (p->info.index.comment != NULL)
+    {
+      comment = pt_print_bytes (parser, p->info.index.comment);
+      b = pt_append_nulstring (parser, b, " comment ");
+      b = pt_append_varchar (parser, b, comment);
+      b = pt_append_nulstring (parser, b, " ");
     }
 
   if (p->info.index.code == PT_REBUILD_INDEX)
@@ -7318,13 +7318,6 @@ pt_print_create_index (PARSER_CONTEXT * parser, PT_NODE * p)
       b = pt_append_varchar (parser, b, r4);
     }
 
-  if (p->info.index.comment != NULL)
-    {
-      comment = pt_print_bytes (parser, p->info.index.comment);
-      b = pt_append_nulstring (parser, b, " comment ");
-      b = pt_append_varchar (parser, b, comment);
-    }
-
   if (p->info.index.index_status == SM_INVISIBLE_INDEX)
     {
       b = pt_append_nulstring (parser, b, " INVISIBLE ");
@@ -7332,6 +7325,13 @@ pt_print_create_index (PARSER_CONTEXT * parser, PT_NODE * p)
   else if (p->info.index.index_status == SM_ONLINE_INDEX_BUILDING_IN_PROGRESS)
     {
       b = pt_append_nulstring (parser, b, " WITH ONLINE ");
+    }
+
+  if (p->info.index.comment != NULL)
+    {
+      comment = pt_print_bytes (parser, p->info.index.comment);
+      b = pt_append_nulstring (parser, b, " comment ");
+      b = pt_append_varchar (parser, b, comment);
     }
 
   parser->custom_print = saved_cp;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24796

* Change the comment clause to be placed at the end in the index creation statement.


```
drop table if exists tbl;
create table tbl(c1 int, c2 int, c3 int, index idx1 (c1) invisible comment 'invisible index');
create index idx2 on tbl(c2) with online  comment 'visible index';
create index idx3 on tbl(c3)  invisible  comment 'visible index';
;sc tbl
show create table tbl;
drop tbl;
```
