### PR TITLE
[CBRD-24797] 'databases.txt.sample' file does not exist In CUBRID package(zip, msi) for windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1326,11 +1326,9 @@ if(USE_CUBRID_ENV)
     ${CMAKE_SOURCE_DIR}/contrib/readme/README_TAR_INSTALL
     DESTINATION ${CUBRID_PREFIXDIR})
 # on Windows, databases.txt is create from 'make_cubrid_demo.bat' because databases.txt is deleted in MSI file for install.
-  if(UNIX)
   install(FILES
     ${CMAKE_SOURCE_DIR}/contrib/readme/databases.txt.sample
     DESTINATION ${CUBRID_DATABASES})
-  endif(UNIX)
   install(FILES
     ${CMAKE_SOURCE_DIR}/contrib/readme/README_SOCK.txt
     DESTINATION ${CUBRID_VARDIR}/${CUBRID_SOCK}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24797

Purpose
reported issue from QA

Implementation
- delete 'if (Unix)' for 'databases.txt.sample'  in CMake.

Remarks
N/A