### PR TITLE
[CBRD-24741] Provides a way to revive the cub_server process in case of abnormal shutdown

### DIFF
--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -324,7 +324,7 @@ css_setup_server_loop (void)
       (void) os_set_signal_handler (SIGFPE, SIG_IGN);
     }
 #else /* LINUX || x86_SOLARIS || HPUX */
-  (void) os_set_signal_handler (SIGFPE, SIG_IGN);
+  // (void) os_set_signal_handler (SIGFPE, SIG_IGN);
 #endif /* LINUX || x86_SOLARIS || HPUX */
 
   if (!IS_INVALID_SOCKET (css_Pipe_to_master))

--- a/src/executables/server.c
+++ b/src/executables/server.c
@@ -208,6 +208,8 @@ crash_handler (int signo, siginfo_t * siginfo, void *dummyp)
 {
   int pid;
 
+  _er_log_debug (ARG_FILE_LINE, "cub_server(pid=%d) received the signal(signo=%d).", getpid (), signo);
+
   if (os_set_signal_handler (signo, SIG_DFL) == SIG_ERR)
     {
       return;
@@ -217,6 +219,8 @@ crash_handler (int signo, siginfo_t * siginfo, void *dummyp)
     {
       return;
     }
+
+  _er_log_debug (ARG_FILE_LINE, "cub_server(pid=%d) will be restarted.", getpid ());
 
   signal (SIGCHLD, SIG_IGN);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24741

### Purpose
* support the functionality to revive the cub_server when it dies abnormally

### Implementation
* restart cub_server if the following signals are received and cub_server is abnormally terminated
  * SIGABRT
  * SIGILL
  * SIGFPE
  * SIGBUS
  * SIGSEGV
  * SIGSYS
* other signals were not considered in this PR
* please see the jira issue if you wonder about si_code

### Remarks
* about SIGFPE
  * signal handler of SIGFPE is set to SIG_IGN in the css_setup_server_loop(). However, I think that this signal should not be ignored when it occurs. Please share your thoughts on this.