### PR TITLE
[CBRD-24804] Bugfix in identifying keywords of PL/CSQL text

### DIFF
--- a/src/executables/csql_support.c
+++ b/src/executables/csql_support.c
@@ -1227,7 +1227,7 @@ csql_walk_statement (const char *str)
 		}
 	      else if (match_word_ci ("case", &p))
 		{
-                  // case can start an expression and can appear in a balance 0 area
+		  // case can start an expression and can appear in a balance 0 area
 		  if (plcsql_begin_end_balance == 0)
 		    {
 		      plcsql_nest_level++;

--- a/src/executables/csql_support.c
+++ b/src/executables/csql_support.c
@@ -1221,14 +1221,21 @@ csql_walk_statement (const char *str)
 		{
 		  if (plcsql_begin_end_balance == 0)
 		    {
-		      // plcsql_begin_end_balance == 0:
-		      //   the procedure or function is not in a block statement
 		      plcsql_nest_level++;
 		    }
 		  continue;
 		}
-	      else if (match_word_ci ("begin", &p) || match_word_ci ("if", &p) ||
-		       match_word_ci ("case", &p) || match_word_ci ("loop", &p))
+	      else if (match_word_ci ("case", &p))
+		{
+                  // case can start an expression and can appear in a balance 0 area
+		  if (plcsql_begin_end_balance == 0)
+		    {
+		      plcsql_nest_level++;
+		    }
+		  plcsql_begin_end_balance++;
+		  continue;
+		}
+	      else if (match_word_ci ("begin", &p) || match_word_ci ("if", &p) || match_word_ci ("loop", &p))
 		{
 		  plcsql_begin_end_balance++;
 		  continue;

--- a/src/jsp/antlr4/PcsLexer.g4
+++ b/src/jsp/antlr4/PcsLexer.g4
@@ -83,6 +83,7 @@ FUNCTION:                     F U N C T I O N ;
 IF:                           I F ;
 IMMEDIATE:                    I M M E D I A T E ;
 IN:                           I N ;
+INOUT:                        I N O U T;
 INTEGER:                      I N T E G E R ;
 INT:                          I N T ;
 INTO:                         I N T O ;

--- a/src/jsp/antlr4/PcsParser.g4
+++ b/src/jsp/antlr4/PcsParser.g4
@@ -48,8 +48,8 @@ parameter_list
     ;
 
 parameter
-    : parameter_name IN? type_spec          # parameter_in
-    | parameter_name IN? OUT type_spec      # parameter_out
+    : parameter_name IN? type_spec                      # parameter_in
+    | parameter_name ( IN? OUT | INOUT ) type_spec      # parameter_out
     ;
 
 default_value_part

--- a/src/parser/csql_lexer.l
+++ b/src/parser/csql_lexer.l
@@ -96,8 +96,8 @@ int expecting_pl_lang_spec = 0;
 %x PL_LANG_SPEC
 %x PLCSQL_TEXT
 
-
-
+ /* id letter */
+IDL       [a-zA-Z0-9_]
 
 %%
 
@@ -1589,18 +1589,28 @@ _[uU][tT][fF]8[']		{
                                                                 BEGIN(PLCSQL_TEXT);
                                                                 init_plcsql_lexing();
                                                                 return PLCSQL; }
+
 <PL_LANG_SPEC>[ \t\r]+					{ begin_token(yytext); }
 <PL_LANG_SPEC>\n					{ begin_token(yytext);
 								this_parser->line = yylineno;
 								this_parser->column = yycolumn = yycolumn_end = 0; }
+
 <PL_LANG_SPEC><<EOF>> 					{
                                                                 BEGIN(INITIAL);
                                                                 csql_yyerror("unterminated PL language spec");
                                                                 return UNTERMINATED_PL_LANG_SPEC; }
-<PL_LANG_SPEC>. 					{       BEGIN(PLCSQL_TEXT);
+
+<PL_LANG_SPEC>{IDL}+                                    {
+                                                                BEGIN(PLCSQL_TEXT);
                                                                 init_plcsql_lexing();
+                                                                yybuffer_pos -= csql_yyleng;
                                                                 yyless(0); }
 
+<PL_LANG_SPEC>.                                         {
+                                                                BEGIN(PLCSQL_TEXT);
+                                                                init_plcsql_lexing();
+                                                                yybuffer_pos -= csql_yyleng;
+                                                                yyless(0); }
 
  /* mode PLCSQL_TEXT */
 
@@ -1639,8 +1649,15 @@ _[uU][tT][fF]8[']		{
 
 <PLCSQL_TEXT>[bB][eE][gG][iI][nN]                       |
 <PLCSQL_TEXT>[iI][fF]                                   |
-<PLCSQL_TEXT>[cC][aA][sS][eE]                           |
 <PLCSQL_TEXT>[lL][oO][oO][pP]                           { begin_token(yytext);
+                                                                plcsql_begin_end_balance++;
+							        csql_yylval.cptr = pt_makename(yytext);
+                                                                return PLCSQL_TEXT_SOME; }
+<PLCSQL_TEXT>[cC][aA][sS][eE]                           { begin_token(yytext);
+                                                                // case can start an expression and can appear in a balance 0 area
+                                                                if (plcsql_begin_end_balance == 0) {
+                                                                        plcsql_nest_level++;
+                                                                }
                                                                 plcsql_begin_end_balance++;
 							        csql_yylval.cptr = pt_makename(yytext);
                                                                 return PLCSQL_TEXT_SOME; }
@@ -1675,6 +1692,10 @@ _[uU][tT][fF]8[']		{
                                                                         // increase the nest level only when it is not in a block statement
                                                                         plcsql_nest_level++;
                                                                 }
+							        csql_yylval.cptr = pt_makename(yytext);
+                                                                return PLCSQL_TEXT_SOME; }
+
+<PLCSQL_TEXT>{IDL}+                                     { begin_token(yytext);
 							        csql_yylval.cptr = pt_makename(yytext);
                                                                 return PLCSQL_TEXT_SOME; }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24804

. added a new token rule to lead to longest keyword match and to prevent substring match (e.g. gender rather than g end er)
. considered the case of CASE keyword appearing in declaration area of CREATE statements
. added INOUT keyword - not directly related to this issue but to ease tests.