### PR TITLE
[LETS-702] clarify move semantics for request handler signature

### DIFF
--- a/src/communication/request_client_server.hpp
+++ b/src/communication/request_client_server.hpp
@@ -377,7 +377,7 @@ namespace cubcomm
     if (req_handle_it == m_request_handlers.end ())
       {
 	// no such handler
-	assert (false);
+	assert_release (false);
 	return;
       }
     er_log_recv_request (m_channel, static_cast<int> (msgid), message_size);

--- a/src/communication/request_sync_client_server.hpp
+++ b/src/communication/request_sync_client_server.hpp
@@ -346,21 +346,6 @@ namespace cubcomm
     assert (other.m_user_payload.empty ());
   }
 
-//  template <typename T_OUTGOING_MSG_ID, typename T_INCOMING_MSG_ID, typename T_PAYLOAD>
-//  typename request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::sequenced_payload &
-//  request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::sequenced_payload::operator= (
-//	  sequenced_payload &&other)
-//  {
-//    if (this != &other)
-//      {
-//	m_rsn = std::move (other.m_rsn);
-//	m_user_payload = std::move (other.m_user_payload);
-
-//	other.m_rsn = NO_RESPONSE_SEQUENCE_NUMBER;
-//      }
-//    return *this;
-//  }
-
   template <typename T_OUTGOING_MSG_ID, typename T_INCOMING_MSG_ID, typename T_PAYLOAD>
   void
   request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::sequenced_payload::push_payload (

--- a/src/communication/request_sync_client_server.hpp
+++ b/src/communication/request_sync_client_server.hpp
@@ -52,7 +52,7 @@ namespace cubcomm
       // request_sync_client_server.
       class sequenced_payload;
 
-      using incoming_request_handler_t = std::function<void (sequenced_payload &)>;
+      using incoming_request_handler_t = std::function<void (sequenced_payload &&)>;
 
     public:
       request_sync_client_server (cubcomm::channel &&a_channel,
@@ -87,7 +87,7 @@ namespace cubcomm
       using request_queue_autosend_t = cubcomm::request_queue_autosend<request_sync_send_queue_t>;
 
       void unpack_and_handle (cubpacking::unpacker &deserializator, const incoming_request_handler_t &handler);
-      void handle_response (sequenced_payload &seq_payload);
+      void handle_response (sequenced_payload &&seq_payload);
       void register_handler (T_INCOMING_MSG_ID msgid, const incoming_request_handler_t &handler);
 
     private:
@@ -114,7 +114,7 @@ namespace cubcomm
       sequenced_payload (const sequenced_payload &other) = delete;
       ~sequenced_payload () = default;
 
-      sequenced_payload &operator= (sequenced_payload &&other);
+      sequenced_payload &operator= (sequenced_payload &&other) = delete;
       sequenced_payload &operator= (const sequenced_payload &) = delete;
 
       void push_payload (T_PAYLOAD &&a_payload);
@@ -298,7 +298,7 @@ namespace cubcomm
   template <typename T_OUTGOING_MSG_ID, typename T_INCOMING_MSG_ID, typename T_PAYLOAD>
   void
   request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::handle_response (
-	  sequenced_payload &seq_payload)
+	  sequenced_payload &&seq_payload)
   {
     m_response_broker.register_response (seq_payload.get_response_sequence_number (),
 					 std::move (seq_payload.pull_payload ()));
@@ -312,7 +312,7 @@ namespace cubcomm
     sequenced_payload ip;
 
     ip.unpack (deserializator);
-    handler (ip);
+    handler (std::move (ip));
   }
 
   template <typename T_OUTGOING_MSG_ID, typename T_INCOMING_MSG_ID, typename T_PAYLOAD>
@@ -343,22 +343,23 @@ namespace cubcomm
     , m_user_payload (std::move (other.m_user_payload))
   {
     other.m_rsn = NO_RESPONSE_SEQUENCE_NUMBER;
+    assert (other.m_user_payload.empty ());
   }
 
-  template <typename T_OUTGOING_MSG_ID, typename T_INCOMING_MSG_ID, typename T_PAYLOAD>
-  typename request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::sequenced_payload &
-  request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::sequenced_payload::operator= (
-	  sequenced_payload &&other)
-  {
-    if (this != &other)
-      {
-	m_rsn = std::move (other.m_rsn);
-	m_user_payload = std::move (other.m_user_payload);
+//  template <typename T_OUTGOING_MSG_ID, typename T_INCOMING_MSG_ID, typename T_PAYLOAD>
+//  typename request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::sequenced_payload &
+//  request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::sequenced_payload::operator= (
+//	  sequenced_payload &&other)
+//  {
+//    if (this != &other)
+//      {
+//	m_rsn = std::move (other.m_rsn);
+//	m_user_payload = std::move (other.m_user_payload);
 
-	other.m_rsn = NO_RESPONSE_SEQUENCE_NUMBER;
-      }
-    return *this;
-  }
+//	other.m_rsn = NO_RESPONSE_SEQUENCE_NUMBER;
+//      }
+//    return *this;
+//  }
 
   template <typename T_OUTGOING_MSG_ID, typename T_INCOMING_MSG_ID, typename T_PAYLOAD>
   void

--- a/src/communication/request_sync_send_queue.hpp
+++ b/src/communication/request_sync_send_queue.hpp
@@ -175,10 +175,10 @@ namespace cubcomm
     // synchronize push request into the queue and notify consumers
 
     std::unique_lock<std::mutex> ulock (m_queue_mutex);
-    m_request_queue.emplace ();
-    m_request_queue.back ().m_id = reqid;
-    m_request_queue.back ().m_payload = std::move (payload);
-    m_request_queue.back ().m_error_handler = std::move (error_handler);
+    m_request_queue.emplace (queue_item_type { reqid, std::move (payload), std::move (error_handler) });
+    //m_request_queue.back ().m_id = reqid;
+    //m_request_queue.back ().m_payload = std::move (payload);
+    //m_request_queue.back ().m_error_handler = std::move (error_handler);
 
     ulock.unlock ();
     m_queue_condvar.notify_all ();

--- a/src/communication/request_sync_send_queue.hpp
+++ b/src/communication/request_sync_send_queue.hpp
@@ -176,9 +176,6 @@ namespace cubcomm
 
     std::unique_lock<std::mutex> ulock (m_queue_mutex);
     m_request_queue.emplace (queue_item_type { reqid, std::move (payload), std::move (error_handler) });
-    //m_request_queue.back ().m_id = reqid;
-    //m_request_queue.back ().m_payload = std::move (payload);
-    //m_request_queue.back ().m_error_handler = std::move (error_handler);
 
     ulock.unlock ();
     m_queue_condvar.notify_all ();

--- a/src/server/active_tran_server.cpp
+++ b/src/server/active_tran_server.cpp
@@ -159,9 +159,9 @@ active_tran_server::connection_handler::get_request_handlers ()
 }
 
 void
-active_tran_server::connection_handler::receive_saved_lsa (page_server_conn_t::sequenced_payload &a_ip)
+active_tran_server::connection_handler::receive_saved_lsa (page_server_conn_t::sequenced_payload &&a_sp)
 {
-  std::string message = a_ip.pull_payload ();
+  std::string message = a_sp.pull_payload ();
   log_lsa saved_lsa;
 
   assert (sizeof (log_lsa) == message.size ());

--- a/src/server/active_tran_server.hpp
+++ b/src/server/active_tran_server.hpp
@@ -57,7 +57,7 @@ class active_tran_server : public tran_server
 	void remove_prior_sender_sink ();
 
 	// request handlers
-	void receive_saved_lsa (page_server_conn_t::sequenced_payload &a_ip);
+	void receive_saved_lsa (page_server_conn_t::sequenced_payload &&a_sp);
 
 	log_lsa get_saved_lsa () const override final;
 

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -144,35 +144,41 @@ page_server::connection_handler::push_request (page_to_tran_request id, std::str
 }
 
 void
-page_server::connection_handler::receive_log_prior_list (tran_server_conn_t::sequenced_payload &a_ip)
+page_server::connection_handler::receive_log_prior_list (tran_server_conn_t::sequenced_payload &&a_sp)
 {
-  log_Gl.get_log_prior_receiver ().push_message (std::move (a_ip.pull_payload ()));
+  log_Gl.get_log_prior_receiver ().push_message (std::move (a_sp.pull_payload ()));
 }
 
-template<class F, class ... Args>
-void
-page_server::connection_handler::push_async_response (F &&a_func, tran_server_conn_t::sequenced_payload &&a_sp,
-    Args &&... args)
-{
-  auto handler_func = std::bind (std::forward<F> (a_func), std::placeholders::_1, std::placeholders::_2,
-				 std::forward<Args> (args)...);
-  m_ps.get_responder ().async_execute (std::ref (*m_conn), std::move (a_sp), std::move (handler_func));
-}
+//template<class F, class ... Args>
+//void
+//page_server::connection_handler::push_async_response (F &&a_func, tran_server_conn_t::sequenced_payload &&a_sp,
+//    Args &&... args)
+//{
+//  auto handler_func = std::bind (std::forward<F> (a_func), std::placeholders::_1, std::placeholders::_2,
+//				 std::forward<Args> (args)...);
+//  m_ps.get_responder ().async_execute (std::ref (*m_conn), std::move (a_sp), std::move (handler_func));
+//}
 
 void
-page_server::connection_handler::receive_log_page_fetch (tran_server_conn_t::sequenced_payload &a_sp)
+page_server::connection_handler::receive_log_page_fetch (tran_server_conn_t::sequenced_payload &&a_sp)
 {
-  push_async_response (&logpb_respond_fetch_log_page_request, std::move (a_sp));
-}
-
-void
-page_server::connection_handler::receive_data_page_fetch (tran_server_conn_t::sequenced_payload &a_sp)
-{
-  push_async_response (&pgbuf_respond_data_fetch_page_request, std::move (a_sp));
+  //push_async_response (&logpb_respond_fetch_log_page_request, std::move (a_sp));
+  m_ps.get_responder ().async_execute (std::ref (*m_conn), std::move (a_sp),
+				       std::bind (logpb_respond_fetch_log_page_request, std::placeholders::_1,
+					   std::placeholders::_2));
 }
 
 void
-page_server::connection_handler::handle_oldest_active_mvccid_request (tran_server_conn_t::sequenced_payload &a_sp)
+page_server::connection_handler::receive_data_page_fetch (tran_server_conn_t::sequenced_payload &&a_sp)
+{
+  //push_async_response (&pgbuf_respond_data_fetch_page_request, std::move (a_sp));
+  m_ps.get_responder ().async_execute (std::ref (*m_conn), std::move (a_sp),
+				       std::bind (pgbuf_respond_data_fetch_page_request, std::placeholders::_1,
+					   std::placeholders::_2));
+}
+
+void
+page_server::connection_handler::handle_oldest_active_mvccid_request (tran_server_conn_t::sequenced_payload &&a_sp)
 {
   assert (m_server_type == transaction_server_type::ACTIVE);
   const MVCCID oldest_mvccid = m_ps.m_pts_mvcc_tracker.get_global_oldest_active_mvccid ();
@@ -185,15 +191,18 @@ page_server::connection_handler::handle_oldest_active_mvccid_request (tran_serve
 }
 
 void
-page_server::connection_handler::receive_log_boot_info_fetch (tran_server_conn_t::sequenced_payload &a_sp)
+page_server::connection_handler::receive_log_boot_info_fetch (tran_server_conn_t::sequenced_payload &&a_sp)
 {
   m_prior_sender_sink_hook_func =
 	  std::bind (&connection_handler::prior_sender_sink_hook, this, std::placeholders::_1);
-  push_async_response (&log_pack_log_boot_info, std::move (a_sp), std::ref (m_prior_sender_sink_hook_func));
+  //push_async_response (&log_pack_log_boot_info, std::move (a_sp), std::ref (m_prior_sender_sink_hook_func));
+  m_ps.get_responder ().async_execute (std::ref (*m_conn), std::move (a_sp),
+				       std::bind (log_pack_log_boot_info, std::placeholders::_1,
+					   std::placeholders::_2, std::ref (m_prior_sender_sink_hook_func)));
 }
 
 void
-page_server::connection_handler::receive_stop_log_prior_dispatch (tran_server_conn_t::sequenced_payload &a_sp)
+page_server::connection_handler::receive_stop_log_prior_dispatch (tran_server_conn_t::sequenced_payload &&a_sp)
 {
   // empty request message
 
@@ -207,7 +216,7 @@ page_server::connection_handler::receive_stop_log_prior_dispatch (tran_server_co
 }
 
 void
-page_server::connection_handler::receive_oldest_active_mvccid (tran_server_conn_t::sequenced_payload &a_sp)
+page_server::connection_handler::receive_oldest_active_mvccid (tran_server_conn_t::sequenced_payload &&a_sp)
 {
   assert (m_server_type == transaction_server_type::PASSIVE);
 
@@ -217,7 +226,7 @@ page_server::connection_handler::receive_oldest_active_mvccid (tran_server_conn_
 }
 
 void
-page_server::connection_handler::receive_disconnect_request (tran_server_conn_t::sequenced_payload &)
+page_server::connection_handler::receive_disconnect_request (tran_server_conn_t::sequenced_payload &&)
 {
   // if this instance acted as a prior sender sink - in other words, if this connection handler was for a
   // passive transaction server - it should have been disconnected beforehand
@@ -283,7 +292,7 @@ page_server::connection_handler::abnormal_tran_server_disconnect (css_error_code
  *        this message has no actual use currently. However, this mechanism will be reserved,
  *        because it can be used in the future when multiple PS's are supported. */
 void
-page_server::connection_handler::receive_boot_info_request (tran_server_conn_t::sequenced_payload &a_sp)
+page_server::connection_handler::receive_boot_info_request (tran_server_conn_t::sequenced_payload &&a_sp)
 {
   /* It is simply a dummy value to check whether the TS (get_boot_info_from_page_server) receives the message well */
   DKNVOLS nvols_perm = VOLID_MAX;
@@ -567,7 +576,7 @@ page_server::disconnect_all_tran_servers ()
   constexpr auto millis_20 = std::chrono::milliseconds { 20 };
   while (!m_conn_cv.wait_for (ulock, millis_20, [this]
   {
-    return m_active_tran_server_conn == nullptr && m_passive_tran_server_conn.empty();
+    return m_active_tran_server_conn == nullptr && m_passive_tran_server_conn.empty ();
     }));
 
   ulock.unlock ();

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -149,20 +149,9 @@ page_server::connection_handler::receive_log_prior_list (tran_server_conn_t::seq
   log_Gl.get_log_prior_receiver ().push_message (std::move (a_sp.pull_payload ()));
 }
 
-//template<class F, class ... Args>
-//void
-//page_server::connection_handler::push_async_response (F &&a_func, tran_server_conn_t::sequenced_payload &&a_sp,
-//    Args &&... args)
-//{
-//  auto handler_func = std::bind (std::forward<F> (a_func), std::placeholders::_1, std::placeholders::_2,
-//				 std::forward<Args> (args)...);
-//  m_ps.get_responder ().async_execute (std::ref (*m_conn), std::move (a_sp), std::move (handler_func));
-//}
-
 void
 page_server::connection_handler::receive_log_page_fetch (tran_server_conn_t::sequenced_payload &&a_sp)
 {
-  //push_async_response (&logpb_respond_fetch_log_page_request, std::move (a_sp));
   m_ps.get_responder ().async_execute (std::ref (*m_conn), std::move (a_sp),
 				       std::bind (logpb_respond_fetch_log_page_request, std::placeholders::_1,
 					   std::placeholders::_2));
@@ -171,7 +160,6 @@ page_server::connection_handler::receive_log_page_fetch (tran_server_conn_t::seq
 void
 page_server::connection_handler::receive_data_page_fetch (tran_server_conn_t::sequenced_payload &&a_sp)
 {
-  //push_async_response (&pgbuf_respond_data_fetch_page_request, std::move (a_sp));
   m_ps.get_responder ().async_execute (std::ref (*m_conn), std::move (a_sp),
 				       std::bind (pgbuf_respond_data_fetch_page_request, std::placeholders::_1,
 					   std::placeholders::_2));
@@ -195,7 +183,7 @@ page_server::connection_handler::receive_log_boot_info_fetch (tran_server_conn_t
 {
   m_prior_sender_sink_hook_func =
 	  std::bind (&connection_handler::prior_sender_sink_hook, this, std::placeholders::_1);
-  //push_async_response (&log_pack_log_boot_info, std::move (a_sp), std::ref (m_prior_sender_sink_hook_func));
+
   m_ps.get_responder ().async_execute (std::ref (*m_conn), std::move (a_sp),
 				       std::bind (log_pack_log_boot_info, std::placeholders::_1,
 					   std::placeholders::_2, std::ref (m_prior_sender_sink_hook_func)));

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -130,21 +130,21 @@ class page_server
 
       private:
 	// Request handlers for the request server:
-	void receive_boot_info_request (tran_server_conn_t::sequenced_payload &a_ip);
-	void receive_log_page_fetch (tran_server_conn_t::sequenced_payload &a_ip);
-	void receive_data_page_fetch (tran_server_conn_t::sequenced_payload &a_ip);
-	void receive_disconnect_request (tran_server_conn_t::sequenced_payload &a_ip);
-	void receive_log_prior_list (tran_server_conn_t::sequenced_payload &a_ip);
-	void handle_oldest_active_mvccid_request (tran_server_conn_t::sequenced_payload &a_sp);
-	void receive_log_boot_info_fetch (tran_server_conn_t::sequenced_payload &a_ip);
-	void receive_stop_log_prior_dispatch (tran_server_conn_t::sequenced_payload &a_sp);
-	void receive_oldest_active_mvccid (tran_server_conn_t::sequenced_payload &a_sp);
+	void receive_boot_info_request (tran_server_conn_t::sequenced_payload &&a_ip);
+	void receive_log_page_fetch (tran_server_conn_t::sequenced_payload &&a_ip);
+	void receive_data_page_fetch (tran_server_conn_t::sequenced_payload &&a_ip);
+	void receive_disconnect_request (tran_server_conn_t::sequenced_payload &&a_ip);
+	void receive_log_prior_list (tran_server_conn_t::sequenced_payload &&a_ip);
+	void handle_oldest_active_mvccid_request (tran_server_conn_t::sequenced_payload &&a_sp);
+	void receive_log_boot_info_fetch (tran_server_conn_t::sequenced_payload &&a_ip);
+	void receive_stop_log_prior_dispatch (tran_server_conn_t::sequenced_payload &&a_sp);
+	void receive_oldest_active_mvccid (tran_server_conn_t::sequenced_payload &&a_sp);
 
 	void abnormal_tran_server_disconnect (css_error_code error_code, bool &abort_further_processing);
 
 	// Helper function to convert above functions into responder specific tasks.
-	template<class F, class ... Args>
-	void push_async_response (F &&, tran_server_conn_t::sequenced_payload &&a_sp, Args &&...args);
+//	template<class F, class ... Args>
+//	void push_async_response (F &&, tran_server_conn_t::sequenced_payload &&a_sp, Args &&...args);
 
 	// Function used as sink for log transfer
 	void prior_sender_sink_hook (std::string &&message) const;

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -142,6 +142,10 @@ class page_server
 
 	void abnormal_tran_server_disconnect (css_error_code error_code, bool &abort_further_processing);
 
+	// Helper function to convert above functions into responder specific tasks.
+	template<class F, class ... Args>
+	void push_async_response (F &&, tran_server_conn_t::sequenced_payload &&a_sp, Args &&...args);
+
 	// Function used as sink for log transfer
 	void prior_sender_sink_hook (std::string &&message) const;
 

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -130,13 +130,13 @@ class page_server
 
       private:
 	// Request handlers for the request server:
-	void receive_boot_info_request (tran_server_conn_t::sequenced_payload &&a_ip);
-	void receive_log_page_fetch (tran_server_conn_t::sequenced_payload &&a_ip);
-	void receive_data_page_fetch (tran_server_conn_t::sequenced_payload &&a_ip);
-	void receive_disconnect_request (tran_server_conn_t::sequenced_payload &&a_ip);
-	void receive_log_prior_list (tran_server_conn_t::sequenced_payload &&a_ip);
+	void receive_boot_info_request (tran_server_conn_t::sequenced_payload &&a_sp);
+	void receive_log_page_fetch (tran_server_conn_t::sequenced_payload &&a_sp);
+	void receive_data_page_fetch (tran_server_conn_t::sequenced_payload &&a_sp);
+	void receive_disconnect_request (tran_server_conn_t::sequenced_payload &&a_sp);
+	void receive_log_prior_list (tran_server_conn_t::sequenced_payload &&a_sp);
 	void handle_oldest_active_mvccid_request (tran_server_conn_t::sequenced_payload &&a_sp);
-	void receive_log_boot_info_fetch (tran_server_conn_t::sequenced_payload &&a_ip);
+	void receive_log_boot_info_fetch (tran_server_conn_t::sequenced_payload &&a_sp);
 	void receive_stop_log_prior_dispatch (tran_server_conn_t::sequenced_payload &&a_sp);
 	void receive_oldest_active_mvccid (tran_server_conn_t::sequenced_payload &&a_sp);
 

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -142,10 +142,6 @@ class page_server
 
 	void abnormal_tran_server_disconnect (css_error_code error_code, bool &abort_further_processing);
 
-	// Helper function to convert above functions into responder specific tasks.
-//	template<class F, class ... Args>
-//	void push_async_response (F &&, tran_server_conn_t::sequenced_payload &&a_sp, Args &&...args);
-
 	// Function used as sink for log transfer
 	void prior_sender_sink_hook (std::string &&message) const;
 

--- a/src/server/passive_tran_server.cpp
+++ b/src/server/passive_tran_server.cpp
@@ -213,8 +213,8 @@ passive_tran_server::create_connection_handler (cubcomm::channel &&chn, tran_ser
 }
 
 void
-passive_tran_server::connection_handler::receive_log_prior_list (page_server_conn_t::sequenced_payload &a_ip)
+passive_tran_server::connection_handler::receive_log_prior_list (page_server_conn_t::sequenced_payload &&a_sp)
 {
-  std::string message = a_ip.pull_payload ();
+  std::string message = a_sp.pull_payload ();
   log_Gl.get_log_prior_receiver ().push_message (std::move (message));
 }

--- a/src/server/passive_tran_server.hpp
+++ b/src/server/passive_tran_server.hpp
@@ -52,7 +52,7 @@ class passive_tran_server : public tran_server
 	connection_handler () = delete;
 
 	connection_handler (cubcomm::channel &&chn, tran_server &ts)
-	  : tran_server::connection_handler (std::move (chn), ts, get_request_handlers())
+	  : tran_server::connection_handler (std::move (chn), ts, get_request_handlers ())
 	{}
 
 	connection_handler (const connection_handler &) = delete;
@@ -67,7 +67,7 @@ class passive_tran_server : public tran_server
 	request_handlers_map_t get_request_handlers () final override;
 
 	/* reuqest handlers */
-	void receive_log_prior_list (page_server_conn_t::sequenced_payload &a_ip);
+	void receive_log_prior_list (page_server_conn_t::sequenced_payload &&a_sp);
     };
 
   private:

--- a/src/server/server_request_responder.hpp
+++ b/src/server/server_request_responder.hpp
@@ -47,11 +47,6 @@ class server_request_responder
     //
 
   public:
-    enum request_type
-    {
-    };
-
-  public:
     using connection_t = T_CONN;
     using payload_t = typename connection_t::payload_t;
     using sequenced_payload_t = typename connection_t::sequenced_payload;

--- a/src/server/server_request_responder.hpp
+++ b/src/server/server_request_responder.hpp
@@ -47,6 +47,11 @@ class server_request_responder
     //
 
   public:
+    enum request_type
+    {
+    };
+
+  public:
     using connection_t = T_CONN;
     using payload_t = typename connection_t::payload_t;
     using sequenced_payload_t = typename connection_t::sequenced_payload;

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -169,7 +169,7 @@ tran_server::send_receive (tran_to_page_request reqid, std::string &&payload_in,
   // TODO: exits when a thread waiting on it (transaction or whatever) stops. It should wake up periodically and check it.
   m_main_conn_cv.wait_for (s_lock, timeout_1m, [&] ()
   {
-    if (m_page_server_conn_vec.empty())
+    if (m_page_server_conn_vec.empty ())
       {
 	err_code = ER_CONN_NO_PAGE_SERVER_AVAILABLE;
 	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CONN_NO_PAGE_SERVER_AVAILABLE, 0);
@@ -418,7 +418,7 @@ tran_server::disconnect_page_server_async (const connection_handler *conn)
       else
 	{
 	  er_log_debug (ARG_FILE_LINE, "The main connection is changed from %s to %s.\n",
-			prev_main_conn_id.c_str (), (*conn_vec.begin())->get_channel_id ().c_str ());
+			prev_main_conn_id.c_str (), (*conn_vec.begin ())->get_channel_id ().c_str ());
 	}
       ulock.unlock ();
       m_main_conn_cv.notify_all ();
@@ -485,7 +485,7 @@ tran_server::connection_handler::get_request_handlers ()
 }
 
 void
-tran_server::connection_handler::receive_disconnect_request (page_server_conn_t::sequenced_payload &a_ip)
+tran_server::connection_handler::receive_disconnect_request (page_server_conn_t::sequenced_payload &&)
 {
   m_is_disconnecting.store (true);
   m_conn->stop_response_broker (); // wake up threads waiting for a response and tell them it won't be served.

--- a/src/server/tran_server.hpp
+++ b/src/server/tran_server.hpp
@@ -121,7 +121,7 @@ class tran_server
 
       private:
 	// Request handlers for requests in common
-	void receive_disconnect_request (page_server_conn_t::sequenced_payload &a_ip);
+	void receive_disconnect_request (page_server_conn_t::sequenced_payload &&a_sp);
 
 	void send_disconnect_request ();
 

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -8471,7 +8471,6 @@ pgbuf_request_data_page_from_page_server (THREAD_ENTRY & thread_r, const VPID * 
 }
 
 // *INDENT-OFF*
-void
 /*
  * pgbuf_respond_data_fetch_page_request - Page Server responds to a request for a heap page
  *
@@ -8483,6 +8482,7 @@ void
  *    - a system parameter
  *    - if the compression algorighm was not able to compress the data, the page is sent uncompressed
  */
+void
 pgbuf_respond_data_fetch_page_request (THREAD_ENTRY &thread_r, std::string &payload_in_out)
 {
   assert (is_page_server ());

--- a/unit_tests/request_client_server/test_main.cpp
+++ b/unit_tests/request_client_server/test_main.cpp
@@ -176,7 +176,12 @@ struct payload_with_op_count : public cubpacking::packable_object
   {
   }
   payload_with_op_count (const payload_with_op_count &) = delete;
-  payload_with_op_count (payload_with_op_count &&) = default;
+  payload_with_op_count (payload_with_op_count &&that)
+    : val { that.val }, op_count { that.op_count }
+  {
+    that.val = 0;
+    that.op_count = 0;
+  }
 
   payload_with_op_count &operator = (const payload_with_op_count &) = delete;
   payload_with_op_count &operator = (payload_with_op_count &&) = default;
@@ -185,6 +190,11 @@ struct payload_with_op_count : public cubpacking::packable_object
   size_t get_packed_size (cubpacking::packer &serializator, std::size_t start_offset = 0) const final;
   void pack (cubpacking::packer &serializator) const final;
   void unpack (cubpacking::unpacker &deserializator) final;
+
+  bool empty () const
+  {
+    return (val == 0 && op_count == 0);
+  }
 };
 
 // Send both reqids and op_count into the request payload
@@ -1242,17 +1252,17 @@ test_two_request_sync_client_server_env::create_request_sync_client_server_one (
 
   // handle requests 2 to 1
   test_request_sync_client_server_one_t::incoming_request_handler_t req_handler_0 =
-	  [this] (test_request_sync_client_server_one_t::sequenced_payload &a_sp)
+	  [this] (test_request_sync_client_server_one_t::sequenced_payload &&a_sp)
   {
     handle_req_and_respond_on_scs_one<reqids_2_to_1::_0> (a_sp);
   };
   test_request_sync_client_server_one_t::incoming_request_handler_t req_handler_1 =
-	  [] (test_request_sync_client_server_one_t::sequenced_payload &a_sp)
+	  [] (test_request_sync_client_server_one_t::sequenced_payload &&a_sp)
   {
     mock_check_expected_id_sync<reqids_2_to_1, reqids_2_to_1::_1> (a_sp);
   };
   test_request_sync_client_server_one_t::incoming_request_handler_t req_handler_2 =
-	  [] (test_request_sync_client_server_one_t::sequenced_payload &a_sp)
+	  [] (test_request_sync_client_server_one_t::sequenced_payload &&a_sp)
   {
     mock_check_expected_id_sync<reqids_2_to_1, reqids_2_to_1::_2> (a_sp);
   };
@@ -1280,12 +1290,12 @@ test_two_request_sync_client_server_env::create_request_sync_client_server_two (
 
   // handle requests 1 to 2
   test_request_sync_client_server_two_t::incoming_request_handler_t req_handler_0 =
-	  [this] (test_request_sync_client_server_two_t::sequenced_payload &a_sp)
+	  [this] (test_request_sync_client_server_two_t::sequenced_payload &&a_sp)
   {
     handle_req_and_respond_on_scs_two<reqids_1_to_2::_0> (a_sp);
   };
   test_request_sync_client_server_two_t::incoming_request_handler_t req_handler_1 =
-	  [] (test_request_sync_client_server_two_t::sequenced_payload &a_sp)
+	  [] (test_request_sync_client_server_two_t::sequenced_payload &&a_sp)
   {
     mock_check_expected_id_sync<reqids_1_to_2, reqids_1_to_2::_1> (a_sp);
   };

--- a/unit_tests/request_client_server/test_main.cpp
+++ b/unit_tests/request_client_server/test_main.cpp
@@ -252,12 +252,12 @@ class test_two_request_sync_client_server_env
     template<typename T_SCS, typename T_MSGID>
     void send_recv_and_increment_msg_count (T_SCS &scs, T_MSGID msgid, int i, std::atomic<size_t> &msg_count_inout);
     template<typename T_MSGID, T_MSGID T_VAL, typename T_SCS, typename T_SEQUENCED_PAYLOAD>
-    void handle_req_and_respond (T_SCS &scs, T_SEQUENCED_PAYLOAD &payload, std::atomic<size_t> &msg_count_inout);
+    void handle_req_and_respond (T_SCS &scs, T_SEQUENCED_PAYLOAD &&payload, std::atomic<size_t> &msg_count_inout);
 
     template<reqids_2_to_1 T_VAL>
-    void handle_req_and_respond_on_scs_one (test_request_sync_client_server_one_t::sequenced_payload &sp);
+    void handle_req_and_respond_on_scs_one (test_request_sync_client_server_one_t::sequenced_payload &&sp);
     template<reqids_1_to_2 T_VAL>
-    void handle_req_and_respond_on_scs_two (test_request_sync_client_server_two_t::sequenced_payload &sp);
+    void handle_req_and_respond_on_scs_two (test_request_sync_client_server_two_t::sequenced_payload &&sp);
 
     uq_test_request_sync_client_server_one_t create_request_sync_client_server_one ();
     uq_test_request_sync_client_server_two_t create_request_sync_client_server_two ();
@@ -1190,7 +1190,7 @@ test_two_request_sync_client_server_env::send_recv_and_increment_msg_count (
 
 template<typename T_MSGID, T_MSGID T_VAL, typename T_SCS, typename T_SEQUENCED_PAYLOAD>
 void
-test_two_request_sync_client_server_env::handle_req_and_respond (T_SCS &scs, T_SEQUENCED_PAYLOAD &sp,
+test_two_request_sync_client_server_env::handle_req_and_respond (T_SCS &scs, T_SEQUENCED_PAYLOAD &&sp,
     std::atomic<size_t> &msg_count_inout)
 {
   payload_with_op_count payload = sp.pull_payload ();
@@ -1230,17 +1230,17 @@ test_two_request_sync_client_server_env::send_recv_request_on_scs_two (reqids_2_
 template<reqids_2_to_1 T_VAL>
 void
 test_two_request_sync_client_server_env::handle_req_and_respond_on_scs_one (
-	test_request_sync_client_server_one_t::sequenced_payload &sp)
+	test_request_sync_client_server_one_t::sequenced_payload &&sp)
 {
-  handle_req_and_respond<reqids_2_to_1, T_VAL> (get_scs_one (), sp, m_total_1_to_2_message_count);
+  handle_req_and_respond<reqids_2_to_1, T_VAL> (get_scs_one (), std::move (sp), m_total_1_to_2_message_count);
 }
 
 template<reqids_1_to_2 T_VAL>
 void
 test_two_request_sync_client_server_env::handle_req_and_respond_on_scs_two (
-	test_request_sync_client_server_two_t::sequenced_payload &sp)
+	test_request_sync_client_server_two_t::sequenced_payload &&sp)
 {
-  handle_req_and_respond<reqids_1_to_2, T_VAL> (get_scs_two (), sp, m_total_2_to_1_message_count);
+  handle_req_and_respond<reqids_1_to_2, T_VAL> (get_scs_two (), std::move (sp), m_total_2_to_1_message_count);
 }
 
 uq_test_request_sync_client_server_one_t
@@ -1254,7 +1254,7 @@ test_two_request_sync_client_server_env::create_request_sync_client_server_one (
   test_request_sync_client_server_one_t::incoming_request_handler_t req_handler_0 =
 	  [this] (test_request_sync_client_server_one_t::sequenced_payload &&a_sp)
   {
-    handle_req_and_respond_on_scs_one<reqids_2_to_1::_0> (a_sp);
+    handle_req_and_respond_on_scs_one<reqids_2_to_1::_0> (std::move (a_sp));
   };
   test_request_sync_client_server_one_t::incoming_request_handler_t req_handler_1 =
 	  [] (test_request_sync_client_server_one_t::sequenced_payload &&a_sp)
@@ -1292,7 +1292,7 @@ test_two_request_sync_client_server_env::create_request_sync_client_server_two (
   test_request_sync_client_server_two_t::incoming_request_handler_t req_handler_0 =
 	  [this] (test_request_sync_client_server_two_t::sequenced_payload &&a_sp)
   {
-    handle_req_and_respond_on_scs_two<reqids_1_to_2::_0> (a_sp);
+    handle_req_and_respond_on_scs_two<reqids_1_to_2::_0> (std::move (a_sp));
   };
   test_request_sync_client_server_two_t::incoming_request_handler_t req_handler_1 =
 	  [] (test_request_sync_client_server_two_t::sequenced_payload &&a_sp)


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-702

Change signature of `incoming_request_handler_t` functor definition to accept a rvalue reference for `sequenced_payload`.
Wherever appropriate, the `sequenced_payload` value is moved, instead of copied - most prominently in `request_sync_client_server::handle_response`.
As a result, `sequenced_payload &operator= (sequenced_payload &&other)` is explicitly declared deleted.

Adapted unit-tests accordingly.