### PR TITLE
[LETS-498] Remove the part that start/stop copylogdb/applylogdb when cubrid hb start/stop

### DIFF
--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -1783,7 +1783,7 @@ process_server (int command_type, int argc, char **argv, bool show_usage, bool c
 		      if (status == NO_ERROR)
 			{
 			  (void) process_javasp (command_type, 1, (const char **) &token, false, true,
-					     process_window_service, false);
+						 process_window_service, false);
 			}
 		    }
 		}

--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -4041,18 +4041,6 @@ us_hb_process_stop (HA_CONF * ha_conf, const char *db_name)
   /* stop javasp server */
   (void) process_javasp (STOP, 1, (const char **) &db_name, false, true, false, true);
 
-  status = us_hb_copylogdb_stop (ha_conf, db_name, NULL, NULL);
-  if (status != NO_ERROR)
-    {
-      goto ret;
-    }
-
-  status = us_hb_applylogdb_stop (ha_conf, db_name, NULL, NULL);
-  if (status != NO_ERROR)
-    {
-      goto ret;
-    }
-
   status = us_hb_server_stop (ha_conf, db_name);
 
 ret:

--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -3950,50 +3950,13 @@ us_hb_process_start (HA_CONF * ha_conf, const char *db_name, bool check_result)
 
   print_message (stdout, MSGCAT_UTIL_GENERIC_START_STOP_2S, PRINT_HA_PROCS_NAME, PRINT_CMD_START);
 
-  pids = da_create (100, sizeof (int));
-  if (pids == NULL)
-    {
-      status = ER_GENERIC_ERROR;
-      goto ret;
-    }
-
   status = us_hb_server_start (ha_conf, db_name);
   if (status != NO_ERROR)
     {
       goto ret;
     }
 
-  status = us_hb_copylogdb_start (pids, ha_conf, db_name, NULL, NULL);
-  if (status != NO_ERROR)
-    {
-      goto ret;
-    }
-
-  status = us_hb_applylogdb_start (pids, ha_conf, db_name, NULL, NULL);
-  if (status != NO_ERROR)
-    {
-      goto ret;
-    }
-
-  sleep (HB_START_WAITING_TIME_IN_SECS);
-  if (check_result == true)
-    {
-      for (i = 0; i < da_size (pids); i++)
-	{
-	  da_get (pids, i, &pid);
-	  if (is_terminated_process (pid))
-	    {
-	      status = ER_GENERIC_ERROR;
-	      break;
-	    }
-	}
-    }
-
 ret:
-  if (pids)
-    {
-      da_destroy (pids);
-    }
 
   print_result (PRINT_HA_PROCS_NAME, status, START);
   return status;

--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -3944,9 +3944,6 @@ static int
 us_hb_process_start (HA_CONF * ha_conf, const char *db_name, bool check_result)
 {
   int status = NO_ERROR;
-  int i;
-  int pid;
-  dynamic_array *pids = NULL;
 
   print_message (stdout, MSGCAT_UTIL_GENERIC_START_STOP_2S, PRINT_HA_PROCS_NAME, PRINT_CMD_START);
 

--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -334,7 +334,7 @@ static int us_hb_utils_stop (HA_CONF * ha_conf, const char *db_name, const char 
 static int us_hb_server_start (HA_CONF * ha_conf, const char *db_name);
 static int us_hb_server_stop (HA_CONF * ha_conf, const char *db_name);
 
-static int us_hb_process_start (HA_CONF * ha_conf, const char *db_name, bool check_result);
+static int us_hb_process_start (HA_CONF * ha_conf, const char *db_name);
 static int us_hb_process_stop (HA_CONF * ha_conf, const char *db_name);
 
 static int us_hb_process_copylogdb (int command_type, HA_CONF * ha_conf, const char *db_name, const char *node_name,
@@ -3941,7 +3941,7 @@ us_hb_server_stop (HA_CONF * ha_conf, const char *db_name)
 }
 
 static int
-us_hb_process_start (HA_CONF * ha_conf, const char *db_name, bool check_result)
+us_hb_process_start (HA_CONF * ha_conf, const char *db_name)
 {
   int status = NO_ERROR;
 
@@ -4632,7 +4632,7 @@ process_heartbeat_start (HA_CONF * ha_conf, int argc, const char **argv)
 	}
     }
 
-  status = us_hb_process_start (ha_conf, db_name, true);
+  status = us_hb_process_start (ha_conf, db_name);
   if (status != NO_ERROR)
     {
       if (db_name == NULL)


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-498

Purpose 

copylogdb and applylogdb is no longer needed in newHA architecture,
so copylogdb and applylogdb should not be started or stopped when 'cubrid hb start/stop' is executed.

Implementation
 - `us_hb_process_start ()` is the function called when 'cubrid hb start' is executed
   - remove the `us_hb_copylogdb_start ()` and `us_hb_applylogdb_start ()` 
 - `us_hb_process_stop ()` is the function called when 'cubrid hb stop' is executed or when `us_hb_process_start ()` is failed
   - remove the `us_hb_copylogdb_stop ()` and `us_hb_applylogdb_stop ()` 

Note 
- This issue consists of two PRs
   1. #4364
   2. #4366