### PR TITLE
[LETS-498] Block the commands that can start copylogdb/applylogdb

### DIFF
--- a/msg/de_DE.utf8/utils.msg
+++ b/msg/de_DE.utf8/utils.msg
@@ -117,8 +117,6 @@ Vorhandene Admin-Utilitynamen:\n\
     paramdump\n\
     statdump\n\
     changemode\n\
-    copylogdb\n\
-    applylogdb\n\
     applyinfo\n\
     acldb\n\
     genlocale\n\
@@ -241,9 +239,6 @@ Anwendung: %2$s heartbeat <Befehl> [args]\n\
 Vorhandene Befehle:\n\
     start          [database-name]\n\
     stop           [-h <host-name>] [-i] [database-name]\n\
-    copylogdb      <start|stop> [-h <host-name>] database-name node-name\n\
-    applylogdb     <start|stop> [-h <host-name>] database-name node-name\n\
-    replication    <start|stop> node-name\n\
     status         [-v] [-h <host-name>]\n\
     reload\n
 31 '%1$s' Argument ist nicht nötig.\n

--- a/msg/en_US.utf8/utils.msg
+++ b/msg/en_US.utf8/utils.msg
@@ -117,8 +117,6 @@ Available admin utility-name:\n\
     paramdump\n\
     statdump\n\
     changemode\n\
-    copylogdb\n\
-    applylogdb\n\
     applyinfo\n\
     acldb\n\
     genlocale\n\
@@ -241,9 +239,6 @@ usage: %2$s heartbeat <command> [args]\n\
 Available command:\n\
     start          [database-name]\n\
     stop           [-h <host-name>] [-i] [database-name]\n\
-    copylogdb      <start|stop> [-h <host-name>] database-name node-name\n\
-    applylogdb     <start|stop> [-h <host-name>] database-name node-name\n\
-    replication    <start|stop> node-name\n\
     status         [-v] [-h <host-name>]\n\
     reload\n
 31 '%1$s' argument is not needed.\n

--- a/msg/en_US/utils.msg
+++ b/msg/en_US/utils.msg
@@ -117,8 +117,6 @@ Available admin utility-name:\n\
     paramdump\n\
     statdump\n\
     changemode\n\
-    copylogdb\n\
-    applylogdb\n\
     applyinfo\n\
     acldb\n\
     genlocale\n\

--- a/msg/en_US/utils.msg
+++ b/msg/en_US/utils.msg
@@ -241,9 +241,6 @@ usage: %2$s heartbeat <command> [args]\n\
 Available command:\n\
     start          [database-name]\n\
     stop           [-h <host-name>] [-i] [database-name]\n\
-    copylogdb      <start|stop> [-h <host-name>] database-name node-name\n\
-    applylogdb     <start|stop> [-h <host-name>] database-name node-name\n\
-    replication    <start|stop> node-name\n\
     status         [-v] [-h <host-name>]\n\
     reload\n
 31 '%1$s' argument is not needed.\n

--- a/msg/es_ES.utf8/utils.msg
+++ b/msg/es_ES.utf8/utils.msg
@@ -117,8 +117,6 @@ Nombre de utilidad admin disponible:\n\
     paramdump\n\
     statdump\n\
     changemode\n\
-    copylogdb\n\
-    applylogdb\n\
     applyinfo\n\
     acldb\n\
     genlocale\n\
@@ -241,9 +239,6 @@ uso: %2$s heartbeat <command> [args]\n\
 Comando disponible: \n\
     start          [database-name]\n\
     stop           [-h <host-name>] [-i] [database-name]\n\
-    copylogdb      <start|stop> [-h <host-name>] database-name node-name\n\
-    applylogdb     <start|stop> [-h <host-name>] database-name node-name\n\
-    replication    <start|stop> node-name\n\
     status         [-v] [-h <host-name>]\n\
     reload\n
 31 Argumento '%1$s' no es necesario.\n

--- a/msg/fr_FR.utf8/utils.msg
+++ b/msg/fr_FR.utf8/utils.msg
@@ -117,8 +117,6 @@ Nom d'utilitaires d'administration disponible:\n\
     paramdump\n\
     statdump\n\
     changemode\n\
-    copylogdb\n\
-    applylogdb\n\
     applyinfo\n\
     acldb\n\
     genlocale\n\
@@ -241,9 +239,6 @@ usage: %2$s heartbeat <command> [args]\n\
 Commandes disponibles:\n\
     start          [database-name]\n\
     stop           [-h <host-name>] [-i] [database-name]\n\
-    copylogdb      <start|stop> [-h <host-name>] database-name node-name\n\
-    applylogdb     <start|stop> [-h <host-name>] database-name node-name\n\
-    replication    <start|stop> node-name\n\
     status         [-v] [-h <host-name>]\n\
     reload\n
 31 Argument '%1$s' n'est pas nécessaire.\n

--- a/msg/it_IT.utf8/utils.msg
+++ b/msg/it_IT.utf8/utils.msg
@@ -117,8 +117,6 @@ Utilità admin disponibile:\n\
     paramdump\n\
     statdump\n\
     changemode\n\
-    copylogdb\n\
-    applylogdb\n\
     applyinfo\n\
     acldb\n\
     genlocale\n\
@@ -241,9 +239,6 @@ uso: %2$s heartbeat <commando> [args]\n\
 Commandi disponibili:\n\
     start          [database-name]\n\
     stop           [-h <host-name>] [-i] [database-name]\n\
-    copylogdb      <start|stop> [-h <host-name>] database-name node-name\n\
-    applylogdb     <start|stop> [-h <host-name>] database-name node-name\n\
-    replication    <start|stop> node-name\n\
     status         [-v] [-h <host-name>]\n\
     reload\n
 31 argomento '%1$s' non è necessaria.\n

--- a/msg/ja_JP.utf8/utils.msg
+++ b/msg/ja_JP.utf8/utils.msg
@@ -117,8 +117,6 @@ cubrid 管理者ユーティリティー、バージョン　%1$s\n\
     paramdump\n\
     statdump\n\
     changemode\n\
-    copylogdb\n\
-    applylogdb\n\
     applyinfo\n\
     acldb\n\
     genlocale\n\
@@ -241,9 +239,6 @@ cubrid 管理者ユーティリティー、バージョン　%1$s\n\
 正しいコマンド:\n\
     start          [データベース名]\n\
     stop           [-h <host-name>] [-i] [データベース名]\n\
-    copylogdb      <start|stop> [-h <host-name>] [データベース名] [ノード名]\n\
-    applylogdb     <start|stop> [-h <host-name>] [データベース名] [ノード名]\n\
-    replication    <start|stop> node-name\n\
     status         [-v] [-h <host-name>]\n\
     reload\n
 31 '%1$s'パラメーターが必要です。\n

--- a/msg/km_KH.utf8/utils.msg
+++ b/msg/km_KH.utf8/utils.msg
@@ -117,8 +117,6 @@ Available admin utility-name:\n\
     paramdump\n\
     statdump\n\
     changemode\n\
-    copylogdb\n\
-    applylogdb\n\
     applyinfo\n\
     acldb\n\
     genlocale\n\
@@ -241,9 +239,6 @@ usage: %2$s heartbeat <command> [args]\n\
 Available command:\n\
     start          [database-name]\n\
     stop           [-h <host-name>] [-i] [database-name]\n\
-    copylogdb      <start|stop> [-h <host-name>] database-name node-name\n\
-    applylogdb     <start|stop> [-h <host-name>] database-name node-name\n\
-    replication    <start|stop> node-name\n\
     status         [-v] [-h <host-name>]\n\
     reload\n
 31 '%1$s' argument is not needed.\n

--- a/msg/ko_KR.euckr/utils.msg
+++ b/msg/ko_KR.euckr/utils.msg
@@ -117,8 +117,6 @@ cubrid 관리자 유틸리티, 버전 %1$s\n\
     paramdump\n\
     statdump\n\
     changemode\n\
-    copylogdb\n\
-    applylogdb\n\
     applyinfo\n\
     acldb\n\
     genlocale\n\
@@ -241,9 +239,6 @@ cubrid 관리자 유틸리티, 버전 %1$s\n\
 가용한 명령어:\n\
     start         [데이터베이스 이름]\n\
     stop          [-h <호스트 이름>] [-i] [데이터베이스 이름]\n\
-    copylogdb     <start|stop> [-h <호스트 이름>] <데이터베이스 이름> <노드 이름>\n\
-    applylogdb    <start|stop> [-h <호스트 이름>] <데이터베이스 이름> <노드 이름>\n\
-    replication   <start|stop> <노드 이름>\n\
     status         [-v] [-h <호스트 이름>]\n\
     reload\n
 31 '%1$s' 인자가 필요 없습니다.\n

--- a/msg/ko_KR.utf8/utils.msg
+++ b/msg/ko_KR.utf8/utils.msg
@@ -117,8 +117,6 @@ cubrid 관리자 유틸리티, 버전 %1$s\n\
     paramdump\n\
     statdump\n\
     changemode\n\
-    copylogdb\n\
-    applylogdb\n\
     applyinfo\n\
     acldb\n\
     genlocale\n\
@@ -241,9 +239,6 @@ cubrid 관리자 유틸리티, 버전 %1$s\n\
 가용한 명령어:\n\
     start         [데이터베이스 이름]\n\
     stop          [-h <호스트 이름>] [-i] [데이터베이스 이름]\n\
-    copylogdb     <start|stop> [-h <호스트 이름>] <데이터베이스 이름> <노드 이름>\n\
-    applylogdb    <start|stop> [-h <호스트 이름>] <데이터베이스 이름> <노드 이름>\n\
-    replication   <start|stop> <노드 이름>\n\
     status         [-v] [-h <호스트 이름>]\n\
     reload\n
 31 '%1$s' 인자가 필요 없습니다.\n

--- a/msg/ro_RO.utf8/utils.msg
+++ b/msg/ro_RO.utf8/utils.msg
@@ -117,8 +117,6 @@ Nume de utilitare de administrare disponibile:\n\
     paramdump\n\
     statdump\n\
     changemode\n\
-    copylogdb\n\
-    applylogdb\n\
     applyinfo\n\
     acldb\n\
     genlocale\n\
@@ -241,9 +239,6 @@ utilizare: %2$s heartbeat <command> [args]\n\
 Comenzi disponibile:\n\
     start          [database-name]\n\
     stop           [-h <host-name>] [-i] [database-name]\n\
-    copylogdb      <start|stop> [-h <host-name>] database-name node-name\n\
-    applylogdb     <start|stop> [-h <host-name>] database-name node-name\n\
-    replication    <start|stop> node-name\n\
     status         [-v] [-h <host-name>]\n\
     reload\n
 31 Argumentul '%1$s' nu este necesar.\n

--- a/msg/tr_TR.utf8/utils.msg
+++ b/msg/tr_TR.utf8/utils.msg
@@ -117,8 +117,6 @@ Mevcut yönetici yardımcı programı-adı:\n\
     paramdump\n\
     statdump\n\
     changemode\n\
-    copylogdb\n\
-    applylogdb\n\
     applyinfo\n\
     acldb\n\
     genlocale\n\
@@ -241,9 +239,6 @@ kullanım: %2$s heartbeat <komut> [args]\n\
 Mevcut komut:\n\
     start          [database-name]\n\
     stop           [-h <host-name>] [-i] [database-name]\n\
-    copylogdb      <start|stop> [-h <host-name>] database-name node-name\n\
-    applylogdb     <start|stop> [-h <host-name>] database-name node-name\n\
-    replication    <start|stop> node-name\n\
     status         [-v] [-h <host-name>]\n\
     reload\n
 31 '%1$s' argümanı gerekli değildir.\n

--- a/msg/vi_VN.utf8/utils.msg
+++ b/msg/vi_VN.utf8/utils.msg
@@ -117,8 +117,6 @@ Available admin utility-name:\n\
     paramdump\n\
     statdump\n\
     changemode\n\
-    copylogdb\n\
-    applylogdb\n\
     applyinfo\n\
     acldb\n\
     genlocale\n\
@@ -241,9 +239,6 @@ usage: %2$s heartbeat <command> [args]\n\
 Available command:\n\
     start          [database-name]\n\
     stop           [-h <host-name>] [-i] [database-name]\n\
-    copylogdb      <start|stop> [-h <host-name>] database-name node-name\n\
-    applylogdb     <start|stop> [-h <host-name>] database-name node-name\n\
-    replication    <start|stop> node-name\n\
     status         [-v] [-h <host-name>]\n\
     reload\n
 31 '%1$s' argument is not needed.\n

--- a/msg/zh_CN.utf8/utils.msg
+++ b/msg/zh_CN.utf8/utils.msg
@@ -117,8 +117,6 @@ cubrid 管理工具，版本 %1$s\n\
     paramdump\n\
     statdump\n\
     changemode\n\
-    copylogdb\n\
-    applylogdb\n\
     applyinfo\n\
     acldb\n\
     genlocale\n\
@@ -241,9 +239,6 @@ cubrid 管理工具，版本 %1$s\n\
 可用命令:\n\
     start          [数据库名]\n\
     stop           [-h <host-name>] [-i] [数据库名]\n\
-    copylogdb      <start|stop> [-h <host-name>] 数据库名 节点名\n\
-    applylogdb     <start|stop> [-h <host-name>] 数据库名 节点名\n\
-    replication    <start|stop> 节点名\n\
     status         [-v] [-h <host-name>]\n\
     reload\n
 31 不需要参数 '%1$s' .\n

--- a/src/executables/util_admin.c
+++ b/src/executables/util_admin.c
@@ -927,8 +927,10 @@ static UTIL_MAP ua_Utility_Map[] = {
   {PARAMDUMP, SA_CS, 1, UTIL_OPTION_PARAMDUMP, "paramdump", ua_Paramdump_Option, ua_Paramdump_Option_Map},
   {STATDUMP, CS_ONLY, 1, UTIL_OPTION_STATDUMP, "statdump", ua_Statdump_Option, ua_Statdump_Option_Map},
   {CHANGEMODE, CS_ONLY, 1, UTIL_OPTION_CHANGEMODE, "changemode", ua_Changemode_Option, ua_Changemode_Option_Map},
+#if defined (ENABLE_UNUSED_FUNCTION)
   {COPYLOGDB, CS_ONLY, 1, UTIL_OPTION_COPYLOGDB, "copylogdb", ua_Copylog_Option, ua_Copylog_Option_Map},
   {APPLYLOGDB, CS_ONLY, 1, UTIL_OPTION_APPLYLOGDB, "applylogdb", ua_Applylog_Option, ua_Applylog_Option_Map},
+#endif
   {APPLYINFO, CS_ONLY, 1, UTIL_OPTION_APPLYINFO, "applyinfo", ua_ApplyInfo_Option, ua_ApplyInfo_Option_Map},
   {ACLDB, CS_ONLY, 1, UTIL_OPTION_ACLDB, "acldb", ua_Acl_Option, ua_Acl_Option_Map},
   {GENLOCALE, SA_ONLY, 1, UTIL_OPTION_GENERATE_LOCALE, "genlocale", ua_GenLocale_Option, ua_GenLocale_Map},

--- a/src/executables/util_admin.c
+++ b/src/executables/util_admin.c
@@ -927,7 +927,12 @@ static UTIL_MAP ua_Utility_Map[] = {
   {PARAMDUMP, SA_CS, 1, UTIL_OPTION_PARAMDUMP, "paramdump", ua_Paramdump_Option, ua_Paramdump_Option_Map},
   {STATDUMP, CS_ONLY, 1, UTIL_OPTION_STATDUMP, "statdump", ua_Statdump_Option, ua_Statdump_Option_Map},
   {CHANGEMODE, CS_ONLY, 1, UTIL_OPTION_CHANGEMODE, "changemode", ua_Changemode_Option, ua_Changemode_Option_Map},
-#if defined (ENABLE_UNUSED_FUNCTION)
+#if 0
+  /*
+   * In the newHA architecture, the execution of "copylogdb" and "applylogdb" is not supported.
+   * TODO: Once the DR (Disaster Recovery) concept is finalized, the codes related to "copylogdb" and "applylogdb" should be either removed or re-used.
+   */
+
   {COPYLOGDB, CS_ONLY, 1, UTIL_OPTION_COPYLOGDB, "copylogdb", ua_Copylog_Option, ua_Copylog_Option_Map},
   {APPLYLOGDB, CS_ONLY, 1, UTIL_OPTION_APPLYLOGDB, "applylogdb", ua_Applylog_Option, ua_Applylog_Option_Map},
 #endif

--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -88,11 +88,13 @@ typedef enum
   ACCESS_CONTROL,
   RESET,
   INFO,
-  SC_COPYLOGDB,
-  SC_APPLYLOGDB,
   GET_SHARID,
   TEST,
+#if defined (ENABLE_UNUSED_FUNCTION)
+  SC_COPYLOGDB,
+  SC_APPLYLOGDB,
   REPLICATION
+#endif
 } UTIL_SERVICE_COMMAND_E;
 
 typedef enum
@@ -233,12 +235,14 @@ static UTIL_SERVICE_OPTION_MAP_T us_Command_map[] = {
   {ACCESS_CONTROL, COMMAND_TYPE_ACL, MASK_SERVER | MASK_BROKER | MASK_GATEWAY},
   {RESET, COMMAND_TYPE_RESET, MASK_BROKER | MASK_GATEWAY},
   {INFO, COMMAND_TYPE_INFO, MASK_BROKER | MASK_GATEWAY},
-  {SC_COPYLOGDB, COMMAND_TYPE_COPYLOGDB, MASK_HEARTBEAT},
-  {SC_APPLYLOGDB, COMMAND_TYPE_APPLYLOGDB, MASK_HEARTBEAT},
   {GET_SHARID, COMMAND_TYPE_GETID, MASK_BROKER},
   {TEST, COMMAND_TYPE_TEST, MASK_BROKER},
+#if defined (ENABLE_UNUSED_FUNCTION)
+  {SC_COPYLOGDB, COMMAND_TYPE_COPYLOGDB, MASK_HEARTBEAT},
+  {SC_APPLYLOGDB, COMMAND_TYPE_APPLYLOGDB, MASK_HEARTBEAT},
   {REPLICATION, COMMAND_TYPE_REPLICATION, MASK_HEARTBEAT},
   {REPLICATION, COMMAND_TYPE_REPLICATION_SHORT, MASK_HEARTBEAT},
+#endif
   {-1, "", MASK_ALL}
 };
 
@@ -281,8 +285,10 @@ static int process_heartbeat_stop (HA_CONF * ha_conf, int argc, const char **arg
 static int process_heartbeat_deregister (int argc, const char **argv);
 static int process_heartbeat_status (int argc, const char **argv);
 static int process_heartbeat_reload (int argc, const char **argv);
+#if defined (ENABLE_UNUSED_FUNCTION)
 static int process_heartbeat_util (HA_CONF * ha_conf, int command_type, int argc, const char **argv);
 static int process_heartbeat_replication (HA_CONF * ha_conf, int argc, const char **argv);
+#endif
 
 static int proc_execute_internal (const char *file, const char *args[], bool wait_child, bool close_output,
 				  bool close_err, bool hide_cmd_args, int *pid);
@@ -391,18 +397,20 @@ command_string (int command_type)
     case ACCESS_CONTROL:
       command = PRINT_CMD_ACL;
       break;
+    case TEST:
+      command = PRINT_CMD_TEST;
+      break;
+#if defined (ENABLE_UNUSED_FUNCTION)
     case SC_COPYLOGDB:
       command = PRINT_CMD_COPYLOGDB;
       break;
     case SC_APPLYLOGDB:
       command = PRINT_CMD_APPLYLOGDB;
       break;
-    case TEST:
-      command = PRINT_CMD_TEST;
-      break;
     case REPLICATION:
       command = PRINT_CMD_REPLICATION;
       break;
+#endif
     case STOP:
     default:
       command = PRINT_CMD_STOP;
@@ -1783,7 +1791,7 @@ process_server (int command_type, int argc, char **argv, bool show_usage, bool c
 		      if (status == NO_ERROR)
 			{
 			  (void) process_javasp (command_type, 1, (const char **) &token, false, true,
-					     process_window_service, false);
+						 process_window_service, false);
 			}
 		    }
 		}
@@ -4973,6 +4981,7 @@ process_heartbeat_reload (int argc, const char **argv)
 }
 
 #if !defined(WINDOWS)
+#if defined (ENABLE_UNUSED_FUNCTION)
 /*
  * process_heartbeat_util -
  *
@@ -5122,6 +5131,7 @@ ret:
   return status;
 }
 #endif
+#endif
 
 /*
  * process_heartbeat -
@@ -5176,6 +5186,7 @@ process_heartbeat (int command_type, int argc, const char **argv)
     case RELOAD:
       status = process_heartbeat_reload (argc, argv);
       break;
+#if defined (ENABLE_UNUSED_FUNCTION)
     case SC_COPYLOGDB:
     case SC_APPLYLOGDB:
       status = process_heartbeat_util (&ha_conf, command_type, argc, argv);
@@ -5183,6 +5194,7 @@ process_heartbeat (int command_type, int argc, const char **argv)
     case REPLICATION:
       status = process_heartbeat_replication (&ha_conf, argc, argv);
       break;
+#endif
     default:
       status = ER_GENERIC_ERROR;
       break;

--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -88,10 +88,10 @@ typedef enum
   ACCESS_CONTROL,
   RESET,
   INFO,
-  GET_SHARID,
-  TEST,
   SC_COPYLOGDB,
   SC_APPLYLOGDB,
+  GET_SHARID,
+  TEST,
   REPLICATION
 } UTIL_SERVICE_COMMAND_E;
 
@@ -393,14 +393,14 @@ command_string (int command_type)
     case ACCESS_CONTROL:
       command = PRINT_CMD_ACL;
       break;
-    case TEST:
-      command = PRINT_CMD_TEST;
-      break;
     case SC_COPYLOGDB:
       command = PRINT_CMD_COPYLOGDB;
       break;
     case SC_APPLYLOGDB:
       command = PRINT_CMD_APPLYLOGDB;
+      break;
+    case TEST:
+      command = PRINT_CMD_TEST;
       break;
     case REPLICATION:
       command = PRINT_CMD_REPLICATION;

--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -235,7 +235,12 @@ static UTIL_SERVICE_OPTION_MAP_T us_Command_map[] = {
   {INFO, COMMAND_TYPE_INFO, MASK_BROKER | MASK_GATEWAY},
   {GET_SHARID, COMMAND_TYPE_GETID, MASK_BROKER},
   {TEST, COMMAND_TYPE_TEST, MASK_BROKER},
-#if defined (ENABLE_UNUSED_FUNCTION)
+#if 0
+  /*
+   * In the newHA architecture, the execution of "copylogdb" and "applylogdb" is not supported.
+   * TODO: Once the DR (Disaster Recovery) concept is finalized, the codes related to "copylogdb" and "applylogdb" should be either removed or re-used.
+   */
+
   {SC_COPYLOGDB, COMMAND_TYPE_COPYLOGDB, MASK_HEARTBEAT},
   {SC_APPLYLOGDB, COMMAND_TYPE_APPLYLOGDB, MASK_HEARTBEAT},
   {REPLICATION, COMMAND_TYPE_REPLICATION, MASK_HEARTBEAT},

--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -90,11 +90,9 @@ typedef enum
   INFO,
   GET_SHARID,
   TEST,
-#if defined (ENABLE_UNUSED_FUNCTION)
   SC_COPYLOGDB,
   SC_APPLYLOGDB,
   REPLICATION
-#endif
 } UTIL_SERVICE_COMMAND_E;
 
 typedef enum
@@ -285,10 +283,8 @@ static int process_heartbeat_stop (HA_CONF * ha_conf, int argc, const char **arg
 static int process_heartbeat_deregister (int argc, const char **argv);
 static int process_heartbeat_status (int argc, const char **argv);
 static int process_heartbeat_reload (int argc, const char **argv);
-#if defined (ENABLE_UNUSED_FUNCTION)
 static int process_heartbeat_util (HA_CONF * ha_conf, int command_type, int argc, const char **argv);
 static int process_heartbeat_replication (HA_CONF * ha_conf, int argc, const char **argv);
-#endif
 
 static int proc_execute_internal (const char *file, const char *args[], bool wait_child, bool close_output,
 				  bool close_err, bool hide_cmd_args, int *pid);
@@ -400,7 +396,6 @@ command_string (int command_type)
     case TEST:
       command = PRINT_CMD_TEST;
       break;
-#if defined (ENABLE_UNUSED_FUNCTION)
     case SC_COPYLOGDB:
       command = PRINT_CMD_COPYLOGDB;
       break;
@@ -410,7 +405,6 @@ command_string (int command_type)
     case REPLICATION:
       command = PRINT_CMD_REPLICATION;
       break;
-#endif
     case STOP:
     default:
       command = PRINT_CMD_STOP;
@@ -4981,7 +4975,6 @@ process_heartbeat_reload (int argc, const char **argv)
 }
 
 #if !defined(WINDOWS)
-#if defined (ENABLE_UNUSED_FUNCTION)
 /*
  * process_heartbeat_util -
  *
@@ -5131,7 +5124,6 @@ ret:
   return status;
 }
 #endif
-#endif
 
 /*
  * process_heartbeat -
@@ -5186,7 +5178,6 @@ process_heartbeat (int command_type, int argc, const char **argv)
     case RELOAD:
       status = process_heartbeat_reload (argc, argv);
       break;
-#if defined (ENABLE_UNUSED_FUNCTION)
     case SC_COPYLOGDB:
     case SC_APPLYLOGDB:
       status = process_heartbeat_util (&ha_conf, command_type, argc, argv);
@@ -5194,7 +5185,6 @@ process_heartbeat (int command_type, int argc, const char **argv)
     case REPLICATION:
       status = process_heartbeat_replication (&ha_conf, argc, argv);
       break;
-#endif
     default:
       status = ER_GENERIC_ERROR;
       break;


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-498

Purpose

In the new HA architecture, copylogdb and applylogdb are no longer required. 
Instead of using the 'cubrid hb start' command, 
there are other commands available that can be used to execute copylogdb and applylogdb.
 - cubrid hb replication start
 - cubrid hb copylogdb/applylogdb start
 - cub_admin copylogdb/applylogdb

And these commands are required to be blocked.

Implementation

- In the us_Command_map, which represents a set of commands for heartbeat, comment out SC_COPYLOGDB, SC_APPLYLOGDB, and REPLICATION
- In the ua_Utility_Map, which represents a set of commands for cub_admin, comment out COPYLOGDB, APPLYLOGDB

NOTE 
* applylogdb and copylogdb can be re-used later in the future when DR concept is discussed. So I decided to preserve the codes (functions and enum)
* To minimize changes, all the code lines related to copylogdb/applylogdb will be retained. They will be removed or marked as unused in a later issue.