### PR TITLE
[CBRD-24516] rev: replace the information which is printed in "show trace" from aggregate function optimization

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -23880,13 +23880,15 @@ qexec_evaluate_aggregates_optimize (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * ag
 
 	    }
 
-	  /* agg_index_name is set to show it in the trace information */
-	  spec->s_id.scan_stats.agg_index_name = NULL;
-	  error = heap_get_indexinfo_of_btid (thread_p, &ACCESS_SPEC_CLS_OID (spec), &agg_ptr->btid,
-					      NULL, NULL, NULL, NULL, &spec->s_id.scan_stats.agg_index_name, NULL);
-	  if (error != NO_ERROR)
+	  if (thread_is_on_trace (thread_p))
 	    {
-	      return error;
+	      /* agg_index_name is set to show it in the trace information */
+	      error = heap_get_indexinfo_of_btid (thread_p, &ACCESS_SPEC_CLS_OID (spec), &agg_ptr->btid,
+						  NULL, NULL, NULL, NULL, &spec->s_id.scan_stats.agg_index_name, NULL);
+	      if (error != NO_ERROR)
+		{
+		  return error;
+		}
 	    }
 	}
     }

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -7860,7 +7860,6 @@ qexec_intprt_fnc (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_s
 
 	  if (!is_scan_needed)
 	    {
-	      xasl->spec_list->s_id.scan_stats.agg_optimized_scan = true;
 	      return S_SUCCESS;
 	    }
 
@@ -23871,6 +23870,14 @@ qexec_evaluate_aggregates_optimize (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * ag
 		{
 		  error = er_errid ();
 		  return (error == NO_ERROR ? ER_FAILED : error);
+		}
+
+	      spec->s_id.scan_stats.agg_index_name = NULL;
+	      error = heap_get_indexinfo_of_btid (thread_p, &ACCESS_SPEC_CLS_OID (spec), &agg_ptr->btid,
+						  NULL, NULL, NULL, NULL, &spec->s_id.scan_stats.agg_index_name, NULL);
+	      if (error != NO_ERROR)
+		{
+		  return error;
 		}
 	    }
 	}

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -23878,13 +23878,15 @@ qexec_evaluate_aggregates_optimize (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * ag
 		  return (error == NO_ERROR ? ER_FAILED : error);
 		}
 
-	      spec->s_id.scan_stats.agg_index_name = NULL;
-	      error = heap_get_indexinfo_of_btid (thread_p, &ACCESS_SPEC_CLS_OID (spec), &agg_ptr->btid,
-						  NULL, NULL, NULL, NULL, &spec->s_id.scan_stats.agg_index_name, NULL);
-	      if (error != NO_ERROR)
-		{
-		  return error;
-		}
+	    }
+
+	  /* agg_index_name is set to show it in the trace information */
+	  spec->s_id.scan_stats.agg_index_name = NULL;
+	  error = heap_get_indexinfo_of_btid (thread_p, &ACCESS_SPEC_CLS_OID (spec), &agg_ptr->btid,
+					      NULL, NULL, NULL, NULL, &spec->s_id.scan_stats.agg_index_name, NULL);
+	  if (error != NO_ERROR)
+	    {
+	      return error;
 	    }
 	}
     }

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -1802,6 +1802,12 @@ qexec_clear_access_spec_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl_p, ACCES
   pg_cnt = 0;
   for (p = list; p; p = p->next)
     {
+      /* aggregate optimize related should be free */
+      if (p->s_id.scan_stats.agg_index_name != NULL)
+	{
+	  free (p->s_id.scan_stats.agg_index_name);
+	}
+
       memset (&p->s_id.scan_stats, 0, sizeof (SCAN_STATS));
 
       if (p->parts != NULL)

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -7732,7 +7732,8 @@ scan_print_stats_json (SCAN_ID * scan_id, json_t * scan_stats)
 	{
 	  if (scan_id->scan_stats.agg_index_name)
 	    {
-	      json_object_set_new (scan_stats, "aggregate optimized,", scan);
+	      json_object_set_new (scan, "alg_index", json_string (scan_id->scan_stats.agg_index_name));
+	      json_object_set_new (scan_stats, "agl", scan);
 	    }
 	  else
 	    {

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -7822,7 +7822,14 @@ scan_print_stats_text (FILE * fp, SCAN_ID * scan_id)
   switch (scan_id->type)
     {
     case S_HEAP_SCAN:
-      fprintf (fp, "(heap");
+      if (scan_id->scan_stats.agg_index_name)
+	{
+	  fprintf (fp, "(");	/* aggregate optimization is not a scan */
+	}
+      else
+	{
+	  fprintf (fp, "(heap");
+	}
       break;
 
     case S_INDX_SCAN:
@@ -7873,7 +7880,13 @@ scan_print_stats_text (FILE * fp, SCAN_ID * scan_id)
       break;
     }
 
-  fprintf (fp, " time: %d, fetch: %llu, ioread: %llu", TO_MSEC (scan_id->scan_stats.elapsed_scan),
+  /* need space for the followed "time ... " except for aggregate optimization */
+  if (scan_id->scan_stats.agg_index_name == NULL)
+    {
+      fprintf (fp, " ");
+    }
+
+  fprintf (fp, "time: %d, fetch: %llu, ioread: %llu", TO_MSEC (scan_id->scan_stats.elapsed_scan),
 	   (unsigned long long int) scan_id->scan_stats.num_fetches,
 	   (unsigned long long int) scan_id->scan_stats.num_ioreads);
 

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -7730,7 +7730,7 @@ scan_print_stats_json (SCAN_ID * scan_id, json_t * scan_stats)
 
       if (scan_id->type == S_HEAP_SCAN)
 	{
-	  if (scan_id->scan_stats.agg_optimized_scan)
+	  if (scan_id->scan_stats.agg_index_name)
 	    {
 	      json_object_set_new (scan_stats, "aggregate optimized,", scan);
 	    }
@@ -7821,14 +7821,7 @@ scan_print_stats_text (FILE * fp, SCAN_ID * scan_id)
   switch (scan_id->type)
     {
     case S_HEAP_SCAN:
-      if (scan_id->scan_stats.agg_optimized_scan)
-	{
-	  fprintf (fp, "(aggregate optimized,");
-	}
-      else
-	{
-	  fprintf (fp, "(heap");
-	}
+      fprintf (fp, "(heap");
       break;
 
     case S_INDX_SCAN:
@@ -7887,8 +7880,13 @@ scan_print_stats_text (FILE * fp, SCAN_ID * scan_id)
     {
     case S_HEAP_SCAN:
     case S_LIST_SCAN:
-      fprintf (fp, ", readrows: %llu, rows: %llu)", (unsigned long long int) scan_id->scan_stats.read_rows,
+      fprintf (fp, ", readrows: %llu, rows: %llu", (unsigned long long int) scan_id->scan_stats.read_rows,
 	       (unsigned long long int) scan_id->scan_stats.qualified_rows);
+      if (scan_id->scan_stats.agg_index_name)
+	{
+	  fprintf (fp, ", agl=%s", scan_id->scan_stats.agg_index_name);
+	}
+      fprintf (fp, ")");
       break;
 
     case S_INDX_SCAN:

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -7732,8 +7732,8 @@ scan_print_stats_json (SCAN_ID * scan_id, json_t * scan_stats)
 	{
 	  if (scan_id->scan_stats.agg_index_name)
 	    {
-	      json_object_set_new (scan, "alg_index", json_string (scan_id->scan_stats.agg_index_name));
-	      json_object_set_new (scan_stats, "agl", scan);
+	      json_object_set_new (scan, "alg", json_string (scan_id->scan_stats.agg_index_name));
+	      json_object_set_new (scan_stats, "noscan", scan);
 	    }
 	  else
 	    {
@@ -7824,7 +7824,7 @@ scan_print_stats_text (FILE * fp, SCAN_ID * scan_id)
     case S_HEAP_SCAN:
       if (scan_id->scan_stats.agg_index_name)
 	{
-	  fprintf (fp, "(");	/* aggregate optimization is not a scan */
+	  fprintf (fp, "(noscan");	/* aggregate optimization is not a scan */
 	}
       else
 	{
@@ -7880,13 +7880,7 @@ scan_print_stats_text (FILE * fp, SCAN_ID * scan_id)
       break;
     }
 
-  /* need space for the followed "time ... " except for aggregate optimization */
-  if (scan_id->scan_stats.agg_index_name == NULL)
-    {
-      fprintf (fp, " ");
-    }
-
-  fprintf (fp, "time: %d, fetch: %llu, ioread: %llu", TO_MSEC (scan_id->scan_stats.elapsed_scan),
+  fprintf (fp, " time: %d, fetch: %llu, ioread: %llu", TO_MSEC (scan_id->scan_stats.elapsed_scan),
 	   (unsigned long long int) scan_id->scan_stats.num_fetches,
 	   (unsigned long long int) scan_id->scan_stats.num_ioreads);
 
@@ -7898,7 +7892,7 @@ scan_print_stats_text (FILE * fp, SCAN_ID * scan_id)
 	       (unsigned long long int) scan_id->scan_stats.qualified_rows);
       if (scan_id->scan_stats.agg_index_name)
 	{
-	  fprintf (fp, ", agl=%s", scan_id->scan_stats.agg_index_name);
+	  fprintf (fp, ", agl: %s", scan_id->scan_stats.agg_index_name);
 	}
       fprintf (fp, ")");
       break;

--- a/src/query/scan_manager.h
+++ b/src/query/scan_manager.h
@@ -323,7 +323,7 @@ struct scan_stats
   bool multi_range_opt;
   bool index_skip_scan;
   bool loose_index_scan;
-  bool agg_optimized_scan;
+  char *agg_index_name;
 
   /* hash list scan */
   struct timeval elapsed_hash_build;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24516

Trace Statistics:
SELECT (time: 0, fetch: 12, ioread: 0)
SCAN (table: dba.t1), (aggregate optimized, time: 0, fetch: 0, ioread: 0, readrows: 0, rows: 0)
-->
SCAN (table: dba.t1), (noscan time: 0, fetch: 0, ioread: 0, readrows: 0, rows: 0, agl:pk_t1_id)
