### PR TITLE
[CBRD-24809] bugfix in the (sub)state transition in csql_walk_statement

### DIFF
--- a/src/executables/csql_support.c
+++ b/src/executables/csql_support.c
@@ -1169,7 +1169,7 @@ csql_walk_statement (const char *str)
 	    case CSQL_SUBSTATE_EXPECTING_IS_OR_AS:
 	      if (match_word_ci ("is", &p) || match_word_ci ("as", &p))
 		{
-		  substate = CSQL_SUBSTATE_PLCSQL_TEXT;
+		  substate = CSQL_SUBSTATE_PL_LANG_SPEC;
 		  continue;
 		}
 	      else


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24809

. a single line of bug in state transition which tracks PL/CSQL text's beginning and end