### PR TITLE
[CBRD-24820] Mandate 'DBMS_OUTPUT.' before put_line() usages.

### DIFF
--- a/demo/plcsql/demo_hello.sql
+++ b/demo/plcsql/demo_hello.sql
@@ -1,4 +1,4 @@
 create or replace procedure demo_hello() as
 begin
-    put_line('Hello CUBRID PL/CSQL!');
+    DBMS_OUTPUT.put_line('Hello CUBRID PL/CSQL!');
 end;

--- a/demo/plcsql/test_ddl.sql
+++ b/demo/plcsql/test_ddl.sql
@@ -7,5 +7,5 @@ create or replace procedure test_ddl() as
 begin
     EXECUTE IMMEDIATE 'drop table if exists ' || new_table;
     EXECUTE IMMEDIATE 'CREATE TABLE ' || new_table || ' (id INT UNIQUE, name VARCHAR, phone VARCHAR DEFAULT ''000-0000'');';
-    put_line ('creating ' || new_table || ' table is succeed!');
+    DBMS_OUTPUT.put_line ('creating ' || new_table || ' table is succeed!');
 end;

--- a/demo/plcsql/test_dml_delete.sql
+++ b/demo/plcsql/test_dml_delete.sql
@@ -22,6 +22,6 @@ begin
 
     for r in (SELECT phone FROM a_tbl) loop
         p := r.phone;
-        PUT_LINE(p);
+        DBMS_OUTPUT.PUT_LINE(p);
     end loop;
 end;

--- a/demo/plcsql/test_dml_insert.sql
+++ b/demo/plcsql/test_dml_insert.sql
@@ -34,44 +34,44 @@ begin
     temp := temp || '/* ((';
     temp := temp || '(((( */';
 
-    put_line (temp);
+    DBMS_OUTPUT.put_line (temp);
 
     EXECUTE IMMEDIATE temp;
-    put_line(temp || ' is succeed');
+    DBMS_OUTPUT.put_line(temp || ' is succeed');
 
     INSERT INTO a_tbl1 SET id=7, phone='777-7777';
 
 -- 1)
-    PUT_LINE('[Test 1] =====================================================================');
+    DBMS_OUTPUT.PUT_LINE('[Test 1] =====================================================================');
     INSERT INTO a_tbl1 SET id=6, phone='000-0000' ON DUPLICATE KEY UPDATE phone='666-6666';
 
 -- 2)
-    PUT_LINE('Expected: ');
-    PUT_LINE(6 || ' ' || 'eee' || ' ' || '666-6666');
+    DBMS_OUTPUT.PUT_LINE('Expected: ');
+    DBMS_OUTPUT.PUT_LINE(6 || ' ' || 'eee' || ' ' || '666-6666');
 
-    PUT_LINE('Actual: ');
+    DBMS_OUTPUT.PUT_LINE('Actual: ');
     for r in (SELECT id, name, phone FROM a_tbl1 WHERE id=6) loop
         i := r.id;
         n := r.name;
         p := r.phone;
-        PUT_LINE(i || ' ' || n || ' ' || p);
+        DBMS_OUTPUT.PUT_LINE(i || ' ' || n || ' ' || p);
     end loop;
-    PUT_LINE('[Test 1] OK');
+    DBMS_OUTPUT.PUT_LINE('[Test 1] OK');
 
 -- 3)
-    PUT_LINE('[Test 2] =====================================================================');
-    PUT_LINE('Expected: ');
-    PUT_LINE(7 || ' ' || 'ggg' || ' ' || '777-7777');
+    DBMS_OUTPUT.PUT_LINE('[Test 2] =====================================================================');
+    DBMS_OUTPUT.PUT_LINE('Expected: ');
+    DBMS_OUTPUT.PUT_LINE(7 || ' ' || 'ggg' || ' ' || '777-7777');
 
     INSERT INTO a_tbl1 SELECT * FROM a_tbl1 WHERE id=7 ON DUPLICATE KEY UPDATE name='ggg';
 
-    PUT_LINE('Actual: ');
+    DBMS_OUTPUT.PUT_LINE('Actual: ');
     for r in (SELECT id, name, phone FROM a_tbl1 WHERE id=7) loop
         i := r.id;
         n := r.name;
         p := r.phone;
-        PUT_LINE(i || ' ' || n || ' ' || p);
+        DBMS_OUTPUT.PUT_LINE(i || ' ' || n || ' ' || p);
     end loop;
 
-    PUT_LINE('[Test 2] OK');
+    DBMS_OUTPUT.PUT_LINE('[Test 2] OK');
 end;

--- a/demo/plcsql/test_tcl_commit.sql
+++ b/demo/plcsql/test_tcl_commit.sql
@@ -24,7 +24,7 @@ begin
     for r in (SELECT code, name FROM test_tcl_tbl WHERE code > 2) loop
         i := r.code;
         n := r.name;
-        PUT_LINE(i);
-        PUT_LINE('code = ' || i || ' name = ' || n);
+        DBMS_OUTPUT.PUT_LINE(i);
+        DBMS_OUTPUT.PUT_LINE('code = ' || i || ' name = ' || n);
     end loop;
 end;

--- a/demo/plcsql/test_tcl_rollback.sql
+++ b/demo/plcsql/test_tcl_rollback.sql
@@ -40,6 +40,6 @@ begin
     for r in (SELECT code, name FROM test_tcl_tbl2 WHERE code > 2) loop
         i := r.code;
         n := r.name;
-        PUT_LINE('code = ' || i || ', name = ' || n);
+        DBMS_OUTPUT.PUT_LINE('code = ' || i || ', name = ' || n);
     end loop;
 end;

--- a/src/jsp/antlr4/PcsLexer.g4
+++ b/src/jsp/antlr4/PcsLexer.g4
@@ -62,6 +62,7 @@ DATE:                         D A T E ;
 DATETIME:                     D A T E T I M E ;
 DATETIMELTZ:                  D A T E T I M E L T Z ;
 DATETIMETZ:                   D A T E T I M E T Z ;
+DBMS_OUTPUT:                  D B M S '_' O U T P U T ;
 DEC:                          D E C ;
 DECIMAL:                      D E C I M A L ;
 DECLARE:                      D E C L A R E ;

--- a/src/jsp/antlr4/PcsParser.g4
+++ b/src/jsp/antlr4/PcsParser.g4
@@ -205,7 +205,7 @@ return_statement
     ;
 
 procedure_call
-    : routine_name function_argument?
+    : (DBMS_OUTPUT '.')? routine_name function_argument?
     ;
 
 body

--- a/src/jsp/com/cubrid/plcsql/compiler/Misc.java
+++ b/src/jsp/com/cubrid/plcsql/compiler/Misc.java
@@ -42,6 +42,11 @@ public class Misc {
         PROC,
     }
 
+    public static String detachPkgName(String routineName) {
+        int idx = routineName.indexOf('$');
+        return idx >= 0 ? routineName.substring(idx + 1) : routineName;
+    }
+
     public static int[] getLineColumnOf(ParserRuleContext ctx) {
         if (ctx == null) {
             return UNKNOWN_LINE_COLUMN;

--- a/src/jsp/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/src/jsp/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -44,6 +44,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -1816,15 +1817,17 @@ public class ParseTreeConverter extends PcsParserBaseVisitor<AstNode> {
         return new StmtRollback(ctx);
     }
 
+    private static final Set<String> dbmsOutputProc = new TreeSet<>(
+        Arrays.asList("DISABLE", "ENABLE", "GET_LINE", "NEW_LINE", "PUT_LINE", "PUT")
+    );
     @Override
     public AstNode visitProcedure_call(Procedure_callContext ctx) {
 
         String name = Misc.getNormalizedText(ctx.routine_name());
-        if (ctx.DBMS_OUTPUT() != null && "PUT_LINE".equals(name)) {
-            // special treatment of 'put_line' procedure to ease migration from Oracle
-            // DBMS_OUTPUT is not an actual package but just a syntactic "ornament".
-            // NOTE: users cannot define a procedure of this name because of the prepended '$'
-            name = "$PUT_LINE";
+        if (ctx.DBMS_OUTPUT() != null && dbmsOutputProc.contains(name)) {
+            // DBMS_OUTPUT is not an actual package but just a syntactic "ornament" to ease migration from Oracle.
+            // NOTE: users cannot define a procedure of this name because of '$'
+            name = "DBMS_OUTPUT$" + name;
         }
 
         NodeList<Expr> args = visitFunction_argument(ctx.function_argument());
@@ -1845,7 +1848,7 @@ public class ParseTreeConverter extends PcsParserBaseVisitor<AstNode> {
                 throw new SemanticError(
                         Misc.getLineColumnOf(ctx), // s044
                         "the number of arguments to procedure "
-                                + name
+                                + Misc.detachPkgName(name)
                                 + " does not match the number of its formal parameters");
             }
 
@@ -1862,7 +1865,7 @@ public class ParseTreeConverter extends PcsParserBaseVisitor<AstNode> {
                                 "argument "
                                         + (i + 1)
                                         + " to the procedure "
-                                        + name
+                                        + Misc.detachPkgName(name)
                                         + " must be assignable to because it is to an OUT parameter");
                     }
                 }

--- a/src/jsp/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/src/jsp/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -1820,6 +1820,13 @@ public class ParseTreeConverter extends PcsParserBaseVisitor<AstNode> {
     public AstNode visitProcedure_call(Procedure_callContext ctx) {
 
         String name = Misc.getNormalizedText(ctx.routine_name());
+        if (ctx.DBMS_OUTPUT() != null && "PUT_LINE".equals(name)) {
+            // special treatment of 'put_line' procedure to ease migration from Oracle
+            // DBMS_OUTPUT is not an actual package but just a syntactic "ornament".
+            // NOTE: users cannot define a procedure of this name because of the prepended '$'
+            name = "$PUT_LINE";
+        }
+
         NodeList<Expr> args = visitFunction_argument(ctx.function_argument());
 
         DeclProc decl = symbolStack.getDeclProc(name);

--- a/src/jsp/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/src/jsp/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -1817,15 +1817,17 @@ public class ParseTreeConverter extends PcsParserBaseVisitor<AstNode> {
         return new StmtRollback(ctx);
     }
 
-    private static final Set<String> dbmsOutputProc = new TreeSet<>(
-        Arrays.asList("DISABLE", "ENABLE", "GET_LINE", "NEW_LINE", "PUT_LINE", "PUT")
-    );
+    private static final Set<String> dbmsOutputProc =
+            new TreeSet<>(
+                    Arrays.asList("DISABLE", "ENABLE", "GET_LINE", "NEW_LINE", "PUT_LINE", "PUT"));
+
     @Override
     public AstNode visitProcedure_call(Procedure_callContext ctx) {
 
         String name = Misc.getNormalizedText(ctx.routine_name());
         if (ctx.DBMS_OUTPUT() != null && dbmsOutputProc.contains(name)) {
-            // DBMS_OUTPUT is not an actual package but just a syntactic "ornament" to ease migration from Oracle.
+            // DBMS_OUTPUT is not an actual package but just a syntactic "ornament" to ease
+            // migration from Oracle.
             // NOTE: users cannot define a procedure of this name because of '$'
             name = "DBMS_OUTPUT$" + name;
         }

--- a/src/jsp/com/cubrid/plcsql/compiler/SymbolStack.java
+++ b/src/jsp/com/cubrid/plcsql/compiler/SymbolStack.java
@@ -127,15 +127,49 @@ public class SymbolStack {
             }
 
             // add procedures
-            DeclProc dp =
-                    new DeclProc(
+            DeclProc dp;
+
+            dp = new DeclProc(
                             null,
-                            "$PUT_LINE",
+                            "DBMS_OUTPUT$DISABLE",
+                            new NodeList<DeclParam>());
+            putDeclTo(predefinedSymbols, "DBMS_OUTPUT$DISABLE", dp);
+
+            dp = new DeclProc(
+                            null,
+                            "DBMS_OUTPUT$ENABLE",
                             new NodeList<DeclParam>()
-                                    .addNode(new DeclParamIn(null, "s", TypeSpecSimple.STRING)),
+                                    .addNode(new DeclParamIn(null, "size", TypeSpecSimple.INT)));
+            putDeclTo(predefinedSymbols, "DBMS_OUTPUT$ENABLE", dp);
+
+            dp = new DeclProc(
                             null,
-                            null);
-            putDeclTo(predefinedSymbols, "$PUT_LINE", dp);
+                            "DBMS_OUTPUT$GET_LINE",
+                            new NodeList<DeclParam>()
+                                    .addNode(new DeclParamOut(null, "line", TypeSpecSimple.STRING))
+                                    .addNode(new DeclParamOut(null, "status", TypeSpecSimple.INT)));
+            putDeclTo(predefinedSymbols, "DBMS_OUTPUT$GET_LINE", dp);
+
+            dp = new DeclProc(
+                            null,
+                            "DBMS_OUTPUT$NEW_LINE",
+                            new NodeList<DeclParam>());
+            putDeclTo(predefinedSymbols, "DBMS_OUTPUT$NEW_LINE", dp);
+
+            dp = new DeclProc(
+                            null,
+                            "DBMS_OUTPUT$PUT_LINE",
+                            new NodeList<DeclParam>()
+                                    .addNode(new DeclParamIn(null, "s", TypeSpecSimple.STRING)));
+            putDeclTo(predefinedSymbols, "DBMS_OUTPUT$PUT_LINE", dp);
+
+            dp = new DeclProc(
+                            null,
+                            "DBMS_OUTPUT$PUT",
+                            new NodeList<DeclParam>()
+                                    .addNode(new DeclParamIn(null, "s", TypeSpecSimple.STRING)));
+            putDeclTo(predefinedSymbols, "DBMS_OUTPUT$PUT", dp);
+
 
             // add constants TODO implement SQLERRM and SQLCODE properly
             DeclConst dc =

--- a/src/jsp/com/cubrid/plcsql/compiler/SymbolStack.java
+++ b/src/jsp/com/cubrid/plcsql/compiler/SymbolStack.java
@@ -130,12 +130,12 @@ public class SymbolStack {
             DeclProc dp =
                     new DeclProc(
                             null,
-                            "PUT_LINE",
+                            "$PUT_LINE",
                             new NodeList<DeclParam>()
                                     .addNode(new DeclParamIn(null, "s", TypeSpecSimple.STRING)),
                             null,
                             null);
-            putDeclTo(predefinedSymbols, "PUT_LINE", dp);
+            putDeclTo(predefinedSymbols, "$PUT_LINE", dp);
 
             // add constants TODO implement SQLERRM and SQLCODE properly
             DeclConst dc =

--- a/src/jsp/com/cubrid/plcsql/compiler/SymbolStack.java
+++ b/src/jsp/com/cubrid/plcsql/compiler/SymbolStack.java
@@ -129,20 +129,19 @@ public class SymbolStack {
             // add procedures
             DeclProc dp;
 
-            dp = new DeclProc(
-                            null,
-                            "DBMS_OUTPUT$DISABLE",
-                            new NodeList<DeclParam>());
+            dp = new DeclProc(null, "DBMS_OUTPUT$DISABLE", new NodeList<DeclParam>());
             putDeclTo(predefinedSymbols, "DBMS_OUTPUT$DISABLE", dp);
 
-            dp = new DeclProc(
+            dp =
+                    new DeclProc(
                             null,
                             "DBMS_OUTPUT$ENABLE",
                             new NodeList<DeclParam>()
                                     .addNode(new DeclParamIn(null, "size", TypeSpecSimple.INT)));
             putDeclTo(predefinedSymbols, "DBMS_OUTPUT$ENABLE", dp);
 
-            dp = new DeclProc(
+            dp =
+                    new DeclProc(
                             null,
                             "DBMS_OUTPUT$GET_LINE",
                             new NodeList<DeclParam>()
@@ -150,26 +149,24 @@ public class SymbolStack {
                                     .addNode(new DeclParamOut(null, "status", TypeSpecSimple.INT)));
             putDeclTo(predefinedSymbols, "DBMS_OUTPUT$GET_LINE", dp);
 
-            dp = new DeclProc(
-                            null,
-                            "DBMS_OUTPUT$NEW_LINE",
-                            new NodeList<DeclParam>());
+            dp = new DeclProc(null, "DBMS_OUTPUT$NEW_LINE", new NodeList<DeclParam>());
             putDeclTo(predefinedSymbols, "DBMS_OUTPUT$NEW_LINE", dp);
 
-            dp = new DeclProc(
+            dp =
+                    new DeclProc(
                             null,
                             "DBMS_OUTPUT$PUT_LINE",
                             new NodeList<DeclParam>()
                                     .addNode(new DeclParamIn(null, "s", TypeSpecSimple.STRING)));
             putDeclTo(predefinedSymbols, "DBMS_OUTPUT$PUT_LINE", dp);
 
-            dp = new DeclProc(
+            dp =
+                    new DeclProc(
                             null,
                             "DBMS_OUTPUT$PUT",
                             new NodeList<DeclParam>()
                                     .addNode(new DeclParamIn(null, "s", TypeSpecSimple.STRING)));
             putDeclTo(predefinedSymbols, "DBMS_OUTPUT$PUT", dp);
-
 
             // add constants TODO implement SQLERRM and SQLCODE properly
             DeclConst dc =

--- a/src/jsp/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
+++ b/src/jsp/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
@@ -1078,7 +1078,7 @@ public class TypeChecker extends AstVisitor<TypeSpec> {
                         Misc.getLineColumnOf(arg.ctx), // s214
                         String.format(
                                 "argument %d to the call of %s has an incompatible type",
-                                i + 1, decl.name));
+                                i + 1, Misc.detachPkgName(decl.name)));
             } else {
                 arg.setCoercion(c);
             }

--- a/src/jsp/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/src/jsp/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -133,7 +133,7 @@ public class SpLib {
     public static Integer SQLCODE = null;
     public static Date SYSDATE = null;
 
-    public static void PUT_LINE(String s) {
+    public static void $PUT_LINE(String s) {
         DBMS_OUTPUT.putLine(s);
     }
 

--- a/src/jsp/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/src/jsp/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -133,9 +133,39 @@ public class SpLib {
     public static Integer SQLCODE = null;
     public static Date SYSDATE = null;
 
-    public static void $PUT_LINE(String s) {
+    // --------------------------------------------------------
+    // DBMS_OUTPUT procedures
+
+    public static void DBMS_OUTPUT$DISABLE() {
+        DBMS_OUTPUT.disable();
+    }
+
+    public static void DBMS_OUTPUT$ENABLE(Integer size) {
+        if (size == null) {
+            throw new VALUE_ERROR();
+        }
+        DBMS_OUTPUT.enable(size);
+    }
+
+    public static void DBMS_OUTPUT$GET_LINE(String[] line, Integer[] status) {
+        int[] iArr = new int[0];
+        DBMS_OUTPUT.getLine(line, iArr);
+        status[0] = iArr[0];
+    }
+
+    public static void DBMS_OUTPUT$NEW_LINE() {
+        DBMS_OUTPUT.newLine();
+    }
+
+    public static void DBMS_OUTPUT$PUT_LINE(String s) {
         DBMS_OUTPUT.putLine(s);
     }
+
+    public static void DBMS_OUTPUT$PUT(String s) {
+        DBMS_OUTPUT.put(s);
+    }
+
+    // --------------------------------------------------------
 
     public static class Query {
         public final String query;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24820

. updates PL/CSQL syntax so that it mandates 'DBMS_OUTPUT.' before usages of put_line() for Oracle compatibility.
. Currently, DBMS_OUTPUT is not an actual package. PL/CSQL does not have the concept of package at least for its first release version.
DBMS_OUTPUT is only allowed before put_line procedure call and is just a syntactic "ornament" only to ease migration from Oracle.

