### PR TITLE
[CBRD-24404] Fix error case of the host look-up.

### DIFF
--- a/src/connection/host_lookup.c
+++ b/src/connection/host_lookup.c
@@ -233,10 +233,7 @@ host_lookup_internal (const char *hostname, struct sockaddr *saddr, LOOKUP_TYPE 
 
 return_phase:
 
-  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_UHOST_ERROR, 0);
-  fprintf (stdout, "%s\n", er_msg ());
-  fflush (stdout);
-  exit (0);
+  return NULL;
 }
 
 /*


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24404

**Purpose**

When the session command ';database' is invoked, host look-up is failed like 'db@127.0.0.1' and then copy the db name.
But previous code never works when using 'db@127.0.0.1' command.
So, I fixed it.

**Remarks**

Overwritting PR.
