### PR TITLE
[LETS-721] Set system parameters for transaction server automatically when ha_mode is on

### DIFF
--- a/src/base/server_type.cpp
+++ b/src/base/server_type.cpp
@@ -212,7 +212,7 @@ void setup_tran_server_params_on_ha_mode ()
 {
   assert (!HA_DISABLED ());
 
-  char *page_hosts_new_value;
+  char *page_hosts_new_value = NULL;
   constexpr size_t MAX_BUFSIZE = 4096;
 
   char ha_node_list[MAX_BUFSIZE];
@@ -220,7 +220,12 @@ void setup_tran_server_params_on_ha_mode ()
 
   int port_id = prm_get_master_port_id ();
 
-  page_hosts_new_value = (char *) malloc (MAX_BUFSIZE); // free is called by sysprm_final()
+  page_hosts_new_value = (char *) calloc (MAX_BUFSIZE, sizeof (char)); // free is called by sysprm_final()
+  if (page_hosts_new_value == NULL)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, MAX_BUFSIZE);
+      return;
+    }
 
   strncpy_bufsize (ha_node_list, prm_get_string_value (PRM_ID_HA_NODE_LIST));
 

--- a/src/base/server_type.cpp
+++ b/src/base/server_type.cpp
@@ -214,8 +214,6 @@ void setup_tran_server_params_on_single_node_config ()
 
 int setup_tran_server_params_on_ha_mode ()
 {
-  assert (!HA_DISABLED ());
-
   char *page_server_host_list = NULL;
   constexpr size_t MAX_BUFSIZE = 4096;
   int list_size = 0;
@@ -242,7 +240,7 @@ int setup_tran_server_params_on_ha_mode ()
       char page_server_host[MAX_BUFSIZE] = {0};
       sprintf (page_server_host, "%s:%d,", str, port_id);
 
-      if (strlen (page_server_host) + strlen (page_server_host_list) > list_size)
+      if (strlen (page_server_host) + strlen (page_server_host_list) >= list_size)
 	{
 	  /* Block the overflow */
 	  char *tmp = (char *) realloc (page_server_host_list, list_size + MAX_BUFSIZE);
@@ -253,8 +251,6 @@ int setup_tran_server_params_on_ha_mode ()
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, list_size + MAX_BUFSIZE);
 	      return ER_OUT_OF_VIRTUAL_MEMORY;
 	    }
-
-	  memset (tmp + list_size, 0, MAX_BUFSIZE);
 
 	  page_server_host_list = tmp;
 	  list_size += MAX_BUFSIZE;


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-721

Purpose

Automatically setting the system parameters for LETS using legacy system parameters set in cubrid_ha.conf and cubrid.conf
page_server_hosts and remote_storage will be set in this issue, and transaction_server_type will be set later.
