### PR TITLE
[CBRD-24824] rpm - set file perm of /etc/profile.d/cubrid.csh to 644

### DIFF
--- a/cmake/CPack_preinstall.sh.in
+++ b/cmake/CPack_preinstall.sh.in
@@ -9,7 +9,7 @@ install -d "$RPM_BUILD_ROOT/../tmpBBroot"/opt/cubrid/databases
 echo "CUBRID=/opt/cubrid" > "$RPM_BUILD_ROOT/../tmpBBroot"/etc/profile.d/cubrid.sh
 cat "$RPM_BUILD_ROOT/../tmpBBroot"/opt/cubrid/share/scripts/cubrid.sh >> "$RPM_BUILD_ROOT/../tmpBBroot"/etc/profile.d/cubrid.sh
 #
-cp "$RPM_BUILD_ROOT/../tmpBBroot"/opt/cubrid/share/scripts/cubrid.csh "$RPM_BUILD_ROOT/../tmpBBroot"/etc/profile.d/cubrid.csh
+install -c -m 644 "$RPM_BUILD_ROOT/../tmpBBroot"/opt/cubrid/share/scripts/cubrid.csh "$RPM_BUILD_ROOT/../tmpBBroot"/etc/profile.d/cubrid.csh
 #
 install -c -m 755 "$RPM_BUILD_ROOT/../tmpBBroot"/opt/cubrid/share/init.d/cubrid "$RPM_BUILD_ROOT/../tmpBBroot"/etc/init.d/cubrid
 install -c -m 755 "$RPM_BUILD_ROOT/../tmpBBroot"/opt/cubrid/share/init.d/cubrid-ha "$RPM_BUILD_ROOT/../tmpBBroot"/etc/init.d/cubrid-ha


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24824

**Description**
* set file protection mode of **/etc/profile.d/cubrid.csh** to **644** (for RPM)
