### PR TITLE
[CBRD-24809] two more bugs in recognizing meaningful keywords

### DIFF
--- a/src/executables/csql_support.c
+++ b/src/executables/csql_support.c
@@ -1248,17 +1248,6 @@ csql_walk_statement (const char *str)
 		}
 	      else
 		{
-		  if (is_identifier_letter (*p))
-		    {
-		      // once an identifier letter is found, advance p while the next letter is also an identifir letter
-		      // in other words, consume the whole identifier
-		      while (p + 1 < str + str_length && is_identifier_letter (*(p + 1)))
-			{
-			  p++;
-			}
-		      continue;
-		    }
-
 		  // keep the substate CSQL_SUBSTATE_PLCSQL_TEXT
 		  // break and proceed to the second switch
 		}
@@ -1293,8 +1282,7 @@ csql_walk_statement (const char *str)
 		}
 	      else
 		{
-		  // keep the substate CSQL_SUBSTATE_PLCSQL_TEXT
-		  // break and proceed to the second switch
+                  goto substate_transition;	// use goto to repeat a substate transition without increasing p
 		}
 
 	      break;
@@ -1302,6 +1290,22 @@ csql_walk_statement (const char *str)
 	    default:
 	      assert (false);	// unreachable
 	    }
+
+          if (is_identifier_letter (*p))
+            {
+	      if (!is_last_stmt_valid)
+		{
+		  is_last_stmt_valid = true;
+		}
+
+              // once an identifier letter is found, advance p while the next letter is also an identifir letter
+              // in other words, consume the whole identifier
+              while (p + 1 < str + str_length && is_identifier_letter (*(p + 1)))
+                {
+                  p++;
+                }
+              continue;
+            }
 
 	  switch (*p)
 	    {

--- a/src/executables/csql_support.c
+++ b/src/executables/csql_support.c
@@ -1282,7 +1282,7 @@ csql_walk_statement (const char *str)
 		}
 	      else
 		{
-                  goto substate_transition;	// use goto to repeat a substate transition without increasing p
+		  goto substate_transition;	// use goto to repeat a substate transition without increasing p
 		}
 
 	      break;
@@ -1291,21 +1291,21 @@ csql_walk_statement (const char *str)
 	      assert (false);	// unreachable
 	    }
 
-          if (is_identifier_letter (*p))
-            {
+	  if (is_identifier_letter (*p))
+	    {
 	      if (!is_last_stmt_valid)
 		{
 		  is_last_stmt_valid = true;
 		}
 
-              // once an identifier letter is found, advance p while the next letter is also an identifir letter
-              // in other words, consume the whole identifier
-              while (p + 1 < str + str_length && is_identifier_letter (*(p + 1)))
-                {
-                  p++;
-                }
-              continue;
-            }
+	      // once an identifier letter is found, advance p while the next letter is also an identifir letter
+	      // in other words, consume the whole identifier
+	      while (p + 1 < str + str_length && is_identifier_letter (*(p + 1)))
+		{
+		  p++;
+		}
+	      continue;
+	    }
 
 	  switch (*p)
 	    {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24809

- csql_walk_statement() fails to recognize a meaningful keyword right after 'end'. For example, 
```
create procedure poo as 
   i int;
begin
  i = case 
        when true then
          case 
          when true then 1
          end
        end;    // fails to recognize this end
end;
```

. whole word matching of meaningful keywords has been done only within PL/CSQL text. 
However, it should also be done outside the PL/CSQL text because a meaningful keyword at a postfix of an identifier can cause wrong state transition. For example, 
`aaa_create bbb_or ccc_replace ddd_procedure poo ...`