### PR TITLE
[LETS-698] Fail to register request once response_broker terminated

### DIFF
--- a/src/communication/request_sync_client_server.hpp
+++ b/src/communication/request_sync_client_server.hpp
@@ -254,6 +254,7 @@ namespace cubcomm
   {
     // Get a unique sequence number of response and group with the payload
     const response_sequence_number rsn = m_rsn_generator.get_unique_number ();
+    css_error_code error_code { NO_ERRORS };
 
     send_queue_error_handler error_handler_ftor = [&rsn, this] (
 		css_error_code error_code, bool &abort_further_processing)
@@ -267,7 +268,11 @@ namespace cubcomm
     // a trace of a request in 'this';
     // otherwise, the only, at runtime, indication is that a thread waits for a condition variable
     // add an upfront entry in the broker such that all roundtrip requests are accounted for
-    m_response_broker.register_request (rsn);
+    error_code = m_response_broker.register_request (rsn);
+    if (error_code != NO_ERRORS)
+      {
+	return error_code;
+      }
 
     // Send the request
     m_queue->push (a_outgoing_message_id, { rsn, std::move (a_request_payload) }, std::move (error_handler_ftor));
@@ -275,7 +280,6 @@ namespace cubcomm
     // The following broker response getter is the blocking part.
 
     // check whether actual answer or error
-    css_error_code error_code { NO_ERRORS };
     std::tie (a_response_payload, error_code) = m_response_broker.get_response (rsn);
     if (error_code != NO_ERRORS)
       {

--- a/src/communication/response_broker.hpp
+++ b/src/communication/response_broker.hpp
@@ -57,7 +57,7 @@ namespace cubcomm
       response_broker &operator = (const response_broker &) = delete;
       response_broker &operator = (response_broker &&) = delete;
 
-      void register_request (response_sequence_number a_rsn);
+      T_ERROR register_request (response_sequence_number a_rsn);
       void register_response (response_sequence_number a_rsn, T_PAYLOAD &&a_payload);
       void register_error (response_sequence_number a_rsn, T_ERROR &&a_error);
 
@@ -77,7 +77,7 @@ namespace cubcomm
 	  bucket &operator = (const bucket &) = delete;
 	  bucket &operator = (bucket &&) = delete;
 
-	  void register_request (response_sequence_number a_rsn);
+	  T_ERROR register_request (response_sequence_number a_rsn);
 	  void register_response (response_sequence_number a_rsn, T_PAYLOAD &&a_payload);
 	  void register_error (response_sequence_number a_rsn, T_ERROR &&a_error);
 
@@ -137,10 +137,10 @@ namespace cubcomm
   }
 
   template <typename T_PAYLOAD, typename T_ERROR>
-  void
+  T_ERROR
   response_broker<T_PAYLOAD, T_ERROR>::register_request (response_sequence_number a_rsn)
   {
-    get_bucket (a_rsn).register_request (a_rsn);
+    return get_bucket (a_rsn).register_request (a_rsn);
   }
 
   template <typename T_PAYLOAD, typename T_ERROR>
@@ -194,17 +194,22 @@ namespace cubcomm
   }
 
   template <typename T_PAYLOAD, typename T_ERROR>
-  void
+  T_ERROR
   response_broker<T_PAYLOAD, T_ERROR>::bucket::register_request (response_sequence_number a_rsn)
   {
     {
       std::lock_guard<std::mutex> lk_guard (m_mutex);
 
-      assert (!m_terminate);
+      if (m_terminate)
+	{
+	  return m_error;
+	}
       assert (m_response_payloads.find (a_rsn) == m_response_payloads.cend ());
 
       payload_or_error_type &ent = m_response_payloads[a_rsn];
       ent.m_response_or_error_present = false;
+
+      return m_no_error;
     }
     // don't notify anything because there is no-one interested in this (the request has not even been flown out yet)
   }


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-698

- register_request () returns the error when the response broker has been terminated.
- It can be seen as what was missed in d7c5db015c.