### PR TITLE
[CBRD-24819] Support SQLERRM and SQLCODE in exception handler blocks

### DIFF
--- a/src/jsp/antlr4/PcsLexer.g4
+++ b/src/jsp/antlr4/PcsLexer.g4
@@ -125,6 +125,8 @@ SETNEQ:                       S E T N E Q;
 SHORT:                        S H O R T ;
 SMALLINT:                     S M A L L I N T ;
 SQL:                          S Q L ;
+SQLCODE:                      S Q L C O D E ;
+SQLERRM:                      S Q L E R R M ;
 STRING:                       S T R I N G ;
 SUBSET:                       S U B S E T ;
 SUBSETEQ:                     S U B S E T E Q;

--- a/src/jsp/antlr4/PcsParser.g4
+++ b/src/jsp/antlr4/PcsParser.g4
@@ -343,8 +343,10 @@ atom
     | case_expression                           # case_exp
     | SQL PERCENT_ROWCOUNT                      # sql_rowcount_exp  // this must go before the cursor_attr_exp line
     | cursor_exp ( PERCENT_ISOPEN | PERCENT_FOUND | PERCENT_NOTFOUND | PERCENT_ROWCOUNT )   # cursor_attr_exp
-    | LPAREN expression RPAREN                        # paren_exp
-    //| '{' expressions '}'                       # list_exp    TODO: restore later
+    | LPAREN expression RPAREN                  # paren_exp
+    | SQLCODE                                   # sqlcode_exp
+    | SQLERRM                                   # sqlerrm_exp
+    //| '{' expressions '}'                     # list_exp    TODO: restore later
     ;
 
 function_call

--- a/src/jsp/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/src/jsp/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -872,6 +872,16 @@ public class ParseTreeConverter extends PcsParserBaseVisitor<AstNode> {
         return visitExpression(ctx.expression());
     }
 
+    @Override
+    public Expr visitSqlcode_exp(Sqlcode_expContext ctx) {
+        return new ExprSqlCode(ctx, exHandlerDepth);
+    }
+
+    @Override
+    public Expr visitSqlerrm_exp(Sqlerrm_expContext ctx) {
+        return new ExprSqlErrm(ctx, exHandlerDepth);
+    }
+
     /* TODO: restore later
     @Override
     public Expr visitList_exp(List_expContext ctx) {

--- a/src/jsp/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/src/jsp/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -1999,9 +1999,11 @@ public class ParseTreeConverter extends PcsParserBaseVisitor<AstNode> {
                     "OTHERS may not be combined with another exception using OR");
         }
 
+        exHandlerDepth++;
         NodeList<Stmt> stmts = visitSeq_of_statements(ctx.seq_of_statements());
+        exHandlerDepth--;
 
-        return new ExHandler(ctx, exceptions, stmts);
+        return new ExHandler(ctx, exceptions, stmts, exHandlerDepth + 1);
     }
 
     public String getImportString() {
@@ -2113,6 +2115,8 @@ public class ParseTreeConverter extends PcsParserBaseVisitor<AstNode> {
 
     private final Map<ParserRuleContext, SqlSemantics> staticSqls;
     private final Set<String> imports = new TreeSet<>();
+
+    private int exHandlerDepth;
 
     private boolean autonomousTransaction = false;
     private boolean connectionRequired = false;

--- a/src/jsp/com/cubrid/plcsql/compiler/ast/ExHandler.java
+++ b/src/jsp/com/cubrid/plcsql/compiler/ast/ExHandler.java
@@ -44,12 +44,14 @@ public class ExHandler extends AstNode {
 
     public final List<ExName> exNames;
     public final NodeList<Stmt> stmts;
+    public final int depth;
 
-    public ExHandler(ParserRuleContext ctx, List<ExName> exNames, NodeList<Stmt> stmts) {
+    public ExHandler(ParserRuleContext ctx, List<ExName> exNames, NodeList<Stmt> stmts, int depth) {
         super(ctx);
 
         this.exNames = exNames;
         this.stmts = stmts;
+        this.depth = depth;
     }
 
     @Override
@@ -75,6 +77,7 @@ public class ExHandler extends AstNode {
         }
 
         return tmpl.replace("%'EXCEPTIONS'%", sbuf.toString())
+                .replace("%'DEPTH'%", Integer.toString(depth))
                 .replace("  %'STATEMENTS'%", Misc.indentLines(stmts.toJavaCode(), 1));
     }
 
@@ -83,5 +86,5 @@ public class ExHandler extends AstNode {
     // --------------------------------------------------
 
     private static final String tmpl =
-            Misc.combineLines(" catch (%'EXCEPTIONS'% e) {", "  %'STATEMENTS'%", "}");
+            Misc.combineLines(" catch (%'EXCEPTIONS'% e%'DEPTH'%) {", "  %'STATEMENTS'%", "}");
 }

--- a/src/jsp/com/cubrid/plcsql/compiler/ast/ExprSqlCode.java
+++ b/src/jsp/com/cubrid/plcsql/compiler/ast/ExprSqlCode.java
@@ -54,7 +54,8 @@ public class ExprSqlCode extends Expr {
             return String.format("e%d.code", exHandlerDepth);
         } else {
             assert exHandlerDepth == 0;
-            return "0";     // SQLCODEs that do not belong to an exception handler evaluates to zero (rf Oracle Spec.)
+            return "0"; // SQLCODEs that do not belong to an exception handler evaluates to zero (rf
+            // Oracle Spec.)
         }
     }
 }

--- a/src/jsp/com/cubrid/plcsql/compiler/ast/ExprSqlCode.java
+++ b/src/jsp/com/cubrid/plcsql/compiler/ast/ExprSqlCode.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+
+package com.cubrid.plcsql.compiler.ast;
+
+import com.cubrid.plcsql.compiler.visitor.AstVisitor;
+import org.antlr.v4.runtime.ParserRuleContext;
+
+public class ExprSqlCode extends Expr {
+
+    @Override
+    public <R> R accept(AstVisitor<R> visitor) {
+        return visitor.visitExprSqlCode(this);
+    }
+
+    public final int exHandlerDepth;
+
+    public ExprSqlCode(ParserRuleContext ctx, int exHandlerDepth) {
+        super(ctx);
+        this.exHandlerDepth = exHandlerDepth;
+    }
+
+    @Override
+    public String exprToJavaCode() {
+
+        if (exHandlerDepth > 0) {
+            return String.format("e%d.code", exHandlerDepth);
+        } else {
+            assert exHandlerDepth == 0;
+            return "0";     // SQLCODEs that do not belong to an exception handler evaluates to zero (rf Oracle Spec.)
+        }
+    }
+}

--- a/src/jsp/com/cubrid/plcsql/compiler/ast/ExprSqlErrm.java
+++ b/src/jsp/com/cubrid/plcsql/compiler/ast/ExprSqlErrm.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+
+package com.cubrid.plcsql.compiler.ast;
+
+import com.cubrid.plcsql.compiler.visitor.AstVisitor;
+import org.antlr.v4.runtime.ParserRuleContext;
+
+public class ExprSqlErrm extends Expr {
+
+    @Override
+    public <R> R accept(AstVisitor<R> visitor) {
+        return visitor.visitExprSqlErrm(this);
+    }
+
+    public final int exHandlerDepth;
+
+    public ExprSqlErrm(ParserRuleContext ctx, int exHandlerDepth) {
+        super(ctx);
+        this.exHandlerDepth = exHandlerDepth;
+    }
+
+    @Override
+    public String exprToJavaCode() {
+
+        if (exHandlerDepth > 0) {
+            return String.format("e%d.getMessage()", exHandlerDepth);
+        } else {
+            assert exHandlerDepth == 0;
+            return "\"no error\"";
+        }
+    }
+}

--- a/src/jsp/com/cubrid/plcsql/compiler/ast/Unit.java
+++ b/src/jsp/com/cubrid/plcsql/compiler/ast/Unit.java
@@ -127,9 +127,9 @@ public class Unit extends AstNode {
                         routine.retType == null ? "void" : routine.retType.toJavaCode())
                 .replace("%'METHOD-NAME'%", routine.name)
                 .replace("      %'PARAMETERS'%", Misc.indentLines(strParams, 3))
-                .replace("    %'GET-CONNECTION'%", Misc.indentLines(strGetConn, 2))
-                .replace("    %'DECL-CLASS'%", Misc.indentLines(strDecls, 2))
-                .replace("    %'BODY'%", Misc.indentLines(routine.body.toJavaCode(), 2));
+                .replace("      %'GET-CONNECTION'%", Misc.indentLines(strGetConn, 3))
+                .replace("      %'DECL-CLASS'%", Misc.indentLines(strDecls, 3))
+                .replace("      %'BODY'%", Misc.indentLines(routine.body.toJavaCode(), 3));
     }
 
     public String getClassName() {
@@ -158,12 +158,12 @@ public class Unit extends AstNode {
                     "    ) throws Exception {",
                     "",
                     "    try {",
-                    "    Long[] sql_rowcount = new Long[] { -1L };",
-                    "    %'GET-CONNECTION'%",
+                    "      Long[] sql_rowcount = new Long[] { -1L };",
+                    "      %'GET-CONNECTION'%",
                     "",
-                    "    %'DECL-CLASS'%",
+                    "      %'DECL-CLASS'%",
                     "",
-                    "    %'BODY'%",
+                    "      %'BODY'%",
                     "    } catch (OutOfMemoryError e) {",
                     "      Server.log(e);",
                     "      throw new STORAGE_ERROR();",

--- a/src/jsp/com/cubrid/plcsql/compiler/visitor/AstVisitor.java
+++ b/src/jsp/com/cubrid/plcsql/compiler/visitor/AstVisitor.java
@@ -112,6 +112,10 @@ public abstract class AstVisitor<R> {
 
     public abstract R visitExprAutoParam(ExprAutoParam node);
 
+    public abstract R visitExprSqlCode(ExprSqlCode node);
+
+    public abstract R visitExprSqlErrm(ExprSqlErrm node);
+
     public abstract R visitStmtAssign(StmtAssign node);
 
     public abstract R visitStmtBasicLoop(StmtBasicLoop node);

--- a/src/jsp/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
+++ b/src/jsp/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
@@ -647,7 +647,9 @@ public class TypeChecker extends AstVisitor<TypeSpec> {
 
     @Override
     public TypeSpec visitStmtBlock(StmtBlock node) {
-        visitNodeList(node.decls);
+        if (node.decls != null) {
+            visitNodeList(node.decls);
+        }
         visitBody(node.body);
         return null;
     }

--- a/src/jsp/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
+++ b/src/jsp/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
@@ -624,6 +624,16 @@ public class TypeChecker extends AstVisitor<TypeSpec> {
     }
 
     @Override
+    public TypeSpec visitExprSqlCode(ExprSqlCode node) {
+        return TypeSpecSimple.INT;
+    }
+
+    @Override
+    public TypeSpec visitExprSqlErrm(ExprSqlErrm node) {
+        return TypeSpecSimple.STRING;
+    }
+
+    @Override
     public TypeSpec visitStmtAssign(StmtAssign node) {
         TypeSpec valType = visit(node.val);
         TypeSpec varType = ((DeclIdTyped) node.var.decl).typeSpec();


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24819

- SQLCODE - if in exception handler then the code of the exception being handled. Otherwise 0
- SQLERRM - if in exception handler then the message of the exception being handled. Otherwise 'no error'

Simple testcase
```
create or replace procedure test_exception_nested as
    error0 exception;
begin
    dbms_output.put_line('sqlcode=' || sqlcode);
    dbms_output.put_line('sqlerrm=' || sqlerrm);
    raise error0;
exception
when error0 then
    declare
        i int;
    begin
        dbms_output.put_line('sqlcode=' || sqlcode);
        dbms_output.put_line('sqlerrm=' || sqlerrm);
        i := 3/0;
    exception
    when zero_divide then
        dbms_output.put_line('sqlcode=' || sqlcode);
        dbms_output.put_line('sqlerrm=' || sqlerrm);
    end;
end;

```