### PR TITLE
[CBRD-24828] Executor error when using udf() and bind variable in update query

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -1011,16 +1011,6 @@ pt_bind_type_of_host_var (PARSER_CONTEXT * parser, PT_NODE * hv)
   if (val)
     {
       hv = pt_bind_type_from_dbval (parser, hv, val);
-      /*
-         TODO:
-         the host variable's precision should be -1,
-         however, it looks not cleared from node allocation
-         for example, in case of reusing the node from JAVA SP session
-       */
-      if (hv->data_type)
-	{
-	  hv->data_type->info.data_type.precision = -1;
-	}
     }
   /* else : There isn't a host var yet.  This happens if someone does a db_compile_statement before doing
    * db_push_values, as might happen in a dynamic esql PREPARE statement where the host vars might not be supplied

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -12120,7 +12120,7 @@ pt_upd_domain_info (PARSER_CONTEXT * parser, PT_NODE * arg1, PT_NODE * arg2, PT_
 	{
 	case PT_TYPE_CHAR:
 	  dt->info.data_type.precision = ((dt->info.data_type.precision > DB_MAX_CHAR_PRECISION)
-					  ? DB_MAX_CHAR_PRECISION : dt->info.data_type.precision);
+					  ? DB_DEFAULT_PRECISION : dt->info.data_type.precision);
 	  break;
 
 	case PT_TYPE_VARCHAR:
@@ -12130,7 +12130,7 @@ pt_upd_domain_info (PARSER_CONTEXT * parser, PT_NODE * arg1, PT_NODE * arg2, PT_
 
 	case PT_TYPE_NCHAR:
 	  dt->info.data_type.precision = ((dt->info.data_type.precision > DB_MAX_NCHAR_PRECISION)
-					  ? DB_MAX_NCHAR_PRECISION : dt->info.data_type.precision);
+					  ? DB_DEFAULT_PRECISION : dt->info.data_type.precision);
 	  break;
 
 	case PT_TYPE_VARNCHAR:


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24828

An error occurred in execution after binding a value in a prepared query including a stored procedure.

```
create table t_user (
        u_no int primary key,
        email varchar(100),
        yn char(1)
);

insert into t_user set
        u_no=123,
        email='info@cubrid.com',
        yn='Y';

prepare st from 'update t_user set email=(select encryptFunc(?)), yn=? where u_no = ?';

execute st using 'info@cubrid.com', 'Y', 123;
```
expected successful execution.