### PR TITLE
[CBRD-24827] Core dumped, use invisible index for  SELECT_BTREE_NODE_INFO or SELECT_KEY_INFO

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -7743,10 +7743,10 @@ exit_on_error:
 
 
 static void
-pt_write_semantic_warning (PARSER_CONTEXT * parser, PT_NODE * name, int line_no, int er_set_no, int msg_no)
+pt_write_semantic_warning (PARSER_CONTEXT * parser, PT_NODE * name, int line_no, int msg_no)
 {
   char *buf = NULL;
-  char *fmt = msgcat_message (MSGCAT_CATALOG_CUBRID, er_set_no, msg_no);
+  char *fmt = msgcat_message (MSGCAT_CATALOG_CUBRID, MSGCAT_SET_PARSER_SEMANTIC, msg_no);
 
   if (name->info.name.meta_class != PT_INDEX_NAME)
     {
@@ -7783,10 +7783,11 @@ pt_resolve_using_index (PARSER_CONTEXT * parser, PT_NODE * index, PT_NODE * from
   SM_CLASS_CONSTRAINT *cons;
   int found = 0;
   int errid;
+  int err_msg_no, err_line_no;
 
   assert (index != NULL);
 
-  *is_ignore = true;
+  *is_ignore = false;
   if (index->info.name.original == NULL)
     {
       if (index->etc != (void *) PT_IDX_HINT_CLASS_NONE)
@@ -7815,7 +7816,6 @@ pt_resolve_using_index (PARSER_CONTEXT * parser, PT_NODE * index, PT_NODE * from
 	  if (spec->node_type != PT_SPEC)
 	    {
 	      PT_INTERNAL_ERROR (parser, "resolution");
-	      *is_ignore = false;
 	      return NULL;
 	    }
 
@@ -7838,7 +7838,6 @@ pt_resolve_using_index (PARSER_CONTEXT * parser, PT_NODE * index, PT_NODE * from
 		      PT_INTERNAL_ERROR (parser, "resolution");
 		    }
 
-		  *is_ignore = false;
 		  return NULL;
 		}
 	      if (index->info.name.original != NULL)
@@ -7847,9 +7846,9 @@ pt_resolve_using_index (PARSER_CONTEXT * parser, PT_NODE * index, PT_NODE * from
 		  if (cons == NULL || (cons->index_status != SM_NORMAL_INDEX))
 		    {
 		      /* error; the index is not for the specified class or unusable index */
-		      pt_write_semantic_warning (parser, index, __LINE__, MSGCAT_SET_PARSER_SEMANTIC,
-						 MSGCAT_SEMANTIC_USING_INDEX_ERR_1);
-		      return NULL;
+		      err_line_no = __LINE__;
+		      err_msg_no = MSGCAT_SEMANTIC_USING_INDEX_ERR_1;
+		      goto null_return;
 		    }
 		}
 
@@ -7861,9 +7860,9 @@ pt_resolve_using_index (PARSER_CONTEXT * parser, PT_NODE * index, PT_NODE * from
 	}
 
       /* the specified class in "class.index" does not exist in spec list */
-      pt_write_semantic_warning (parser, index, __LINE__, MSGCAT_SET_PARSER_SEMANTIC,
-				 MSGCAT_SEMANTIC_USING_INDEX_ERR_2);
-      return NULL;
+      err_line_no = __LINE__;
+      err_msg_no = MSGCAT_SEMANTIC_USING_INDEX_ERR_2;
+      goto null_return;
     }
 
   /* case (index->info.name.resolved == NULL) */
@@ -7875,7 +7874,6 @@ pt_resolve_using_index (PARSER_CONTEXT * parser, PT_NODE * index, PT_NODE * from
       if (spec->node_type != PT_SPEC)
 	{
 	  PT_INTERNAL_ERROR (parser, "resolution");
-	  *is_ignore = false;
 	  return NULL;
 	}
 
@@ -7901,7 +7899,6 @@ pt_resolve_using_index (PARSER_CONTEXT * parser, PT_NODE * index, PT_NODE * from
 		  PT_INTERNAL_ERROR (parser, "resolution");
 		}
 
-	      *is_ignore = false;
 	      return NULL;
 	    }
 	  cons = classobj_find_class_index (class_, index->info.name.original);
@@ -7917,23 +7914,36 @@ pt_resolve_using_index (PARSER_CONTEXT * parser, PT_NODE * index, PT_NODE * from
 	}
     }
 
+  if (found == 1)
+    {
+      return index;
+    }
+
   if (found == 0)
     {
       /* error; can not find the class of the index */
-      pt_write_semantic_warning (parser, index, __LINE__, MSGCAT_SET_PARSER_SEMANTIC,
-				 MSGCAT_SEMANTIC_USING_INDEX_ERR_1);
-      return NULL;
+      err_line_no = __LINE__;
+      err_msg_no = MSGCAT_SEMANTIC_USING_INDEX_ERR_1;
     }
-  else if (found > 1)
+  else				/* if(found > 1) */
     {
       index->info.name.resolved = NULL;
       /* we found more than one classes which have index of the same name */
-      pt_write_semantic_warning (parser, index, __LINE__, MSGCAT_SET_PARSER_SEMANTIC,
-				 MSGCAT_SEMANTIC_USING_INDEX_ERR_3);
-      return NULL;
+      err_line_no = __LINE__;
+      err_msg_no = MSGCAT_SEMANTIC_USING_INDEX_ERR_3;
     }
 
-  return index;
+null_return:
+  if (PT_SPEC_SPECIAL_INDEX_SCAN (from))
+    {
+      PT_ERRORmf (parser, index, MSGCAT_SET_PARSER_SEMANTIC, err_msg_no, pt_short_print (parser, index));
+    }
+  else
+    {
+      *is_ignore = true;
+      pt_write_semantic_warning (parser, index, err_line_no, err_msg_no);
+    }
+  return NULL;
 }
 
 /*


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24827

In [CBRD-24396], when an incorrect index name is specified as a hint, it has been modified so that it can be ignored and continued.

However, in the two hints SELECT_KEY_INFO and SELECT_BTREE_NODE_INFO, normal operation is impossible if the index information is removed, so error handling is required immediately.

