### PR TITLE
[LETS-731] reuse extensible block to avoid re-allocating memory at each call

### DIFF
--- a/src/communication/communication_channel.cpp
+++ b/src/communication/communication_channel.cpp
@@ -112,7 +112,7 @@ namespace cubcomm
     int templen = 0;
     constexpr int vector_length = 2;
     int total_len = 0, rc = NO_ERRORS;
-    struct iovec iov[2];
+    struct iovec iov[vector_length];
 
     assert (m_type != NO_TYPE);
 

--- a/src/communication/communication_channel.cpp
+++ b/src/communication/communication_channel.cpp
@@ -109,7 +109,8 @@ namespace cubcomm
 
   css_error_code channel::send (const char *buffer, std::size_t length)
   {
-    int templen, vector_length = 2;
+    int templen = 0;
+    constexpr int vector_length = 2;
     int total_len = 0, rc = NO_ERRORS;
     struct iovec iov[2];
 

--- a/src/communication/request_client_server.hpp
+++ b/src/communication/request_client_server.hpp
@@ -244,6 +244,7 @@ namespace cubcomm
   template <typename MsgId>
   request_client<MsgId>::request_client (channel &&chn)
     : m_channel (std::move (chn))
+    , m_send_extensible_block { cubmem::CSTYLE_BLOCK_ALLOCATOR }
   {
   }
 
@@ -405,6 +406,7 @@ namespace cubcomm
   template <typename ClientMsgId, typename ServerMsgId>
   request_client_server<ClientMsgId, ServerMsgId>::request_client_server (channel &&chn)
     : request_server<ServerMsgId>::request_server (std::move (chn))
+    , m_send_extensible_block { cubmem::CSTYLE_BLOCK_ALLOCATOR }
   {
   }
 

--- a/src/communication/request_client_server.hpp
+++ b/src/communication/request_client_server.hpp
@@ -150,10 +150,9 @@ namespace cubcomm
 
       inline const channel &get_channel () const;		// get underlying channel
 
-    protected:
-      cubmem::extensible_block m_send_extensible_block;
     private:
       channel m_channel;					// requests are sent on this channel
+      cubmem::extensible_block m_send_extensible_block;
   };
 
   // A server that handles request messages. All requests must be preregistered.
@@ -199,7 +198,6 @@ namespace cubcomm
       std::thread m_thread;				// thread that loops and handles requests
       bool m_shutdown = true;				// set to true when thread must stop
       request_handlers_container m_request_handlers;	// request handler map
-
       cubmem::extensible_block m_recv_extensible_block;
   };
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-731

Use `cubmem::extensible_block` for:
- the send buffer in `request_client`
- the receive buffer in `request_server` and `request_client_server`
- the send buffer in `request_client_server`

Will avoid alloc/de-alloc buffers for each message.

