### PR TITLE
[CBRD-24623] Fixed coredump that occurs when performing unloaddb on an empty DB.

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -4783,6 +4783,7 @@ extract_class (extract_context & ctxt)
 	    {
 	      fclose (output_file);
 	      output_file = NULL;
+	      return ER_FAILED;
 	    }
 	}
     }
@@ -4848,6 +4849,7 @@ extract_vclass (extract_context & ctxt)
 	    {
 	      fclose (output_file);
 	      output_file = NULL;
+	      return ER_FAILED;
 	    }
 	}
     }
@@ -4911,6 +4913,7 @@ extract_pk (extract_context & ctxt)
 	    {
 	      fclose (output_file);
 	      output_file = NULL;
+	      return ER_FAILED;
 	    }
 	}
     }
@@ -4974,6 +4977,7 @@ extract_fk (extract_context & ctxt)
 	    {
 	      fclose (output_file);
 	      output_file = NULL;
+	      return ER_FAILED;
 	    }
 	}
     }
@@ -5035,6 +5039,7 @@ extract_grant (extract_context & ctxt)
 	    {
 	      fclose (output_file);
 	      output_file = NULL;
+	      return ER_FAILED;
 	    }
 	}
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24623

Purpose
When there is no class in unloaddb, coredump occurs due to lack of exception handling.
Add exception handling when class does not exist.

Implementation
N/A

Remarks
N/A
