### PR TITLE
[LETS-741] Temporary fix for CI tests

### DIFF
--- a/src/executables/master_heartbeat.c
+++ b/src/executables/master_heartbeat.c
@@ -3695,9 +3695,9 @@ hb_resource_job_change_mode (HB_JOB_ARG * arg)
 	   * Transaction Server can not execute the write transaction.
 	   * The Transaction Server state need to be changed to HB_PSTATE_REGISTERED_AND_ACTIVE by this job in order to
 	   * execute the write transaction, which internally changes the db_Disable_modification to false
-           * in css_change_ha_server_state () -> logtb_enable_update ().
+	   * in css_change_ha_server_state () -> logtb_enable_update ().
 	   * When the TS state is defined and this job is re-defined for newHA,
-           * these modified parts will also be addressed.
+	   * these modified parts will also be addressed.
 	   */
 
 	  continue;

--- a/src/executables/master_heartbeat.c
+++ b/src/executables/master_heartbeat.c
@@ -3688,7 +3688,18 @@ hb_resource_job_change_mode (HB_JOB_ARG * arg)
     {
       if (proc->type != HB_PTYPE_TRAN_SERVER)
 	{
-	  // TODO: Temporary fix for CI test failure, this can be replaced when all the states for TS are defined.
+	  /* TODO :
+	   * This section needed to be modified at the point when the states of TS is defined
+	   * and the resource job is defined according to newHA - failover.
+	   * It has been temporarily modified only to resolve the CI test failure, which is because the
+	   * Transaction Server can not execute the write transaction.
+	   * The Transaction Server state need to be changed to HB_PSTATE_REGISTERED_AND_ACTIVE by this job in order to
+	   * execute the write transaction, which internally changes the db_Disable_modification to false
+           * in css_change_ha_server_state () -> logtb_enable_update ().
+	   * When the TS state is defined and this job is re-defined for newHA,
+           * these modified parts will also be addressed.
+	   */
+
 	  continue;
 	}
 

--- a/src/executables/master_heartbeat.c
+++ b/src/executables/master_heartbeat.c
@@ -3689,15 +3689,18 @@ hb_resource_job_change_mode (HB_JOB_ARG * arg)
       if (proc->type != HB_PTYPE_TRAN_SERVER)
 	{
 	  /* TODO :
-	   * This section needed to be modified at the point when the states of TS is defined
-	   * and the resource job is defined according to newHA - failover.
 	   * It has been temporarily modified only to resolve the CI test failure, which is because the
 	   * Transaction Server can not execute the write transaction.
-	   * The Transaction Server state need to be changed to HB_PSTATE_REGISTERED_AND_ACTIVE by this job in order to
-	   * execute the write transaction, which internally changes the db_Disable_modification to false
-	   * in css_change_ha_server_state () -> logtb_enable_update ().
-	   * When the TS state is defined and this job is re-defined for newHA,
-	   * these modified parts will also be addressed.
+	   * During failover, the Transaction Server state need to be changed to HB_PSTATE_REGISTERED_AND_ACTIVE
+	   * by this job in order to execute the write transaction, which internally changes the "db_Disable_modification" to false
+	   * (in css_change_ha_server_state () -> logtb_enable_update ()).
+	   *
+	   * This job will be re-defined when TS states are re-defined, and failover mechanism is re-designed.
+	   * 1. All the resource jobs check if process type is HB_PTYPE_TRAN_SERVER instead of HB_PTYPE_SERVER.
+	   * 2. hb_Resource is re-defined to have only two processes, HB_PTYPE_PAGE_SERVER and HB_PTYPE_TRAN_SERVER.
+	   * 3. This job check the state of HB_PTYPE_TRAN_SERVER to the one that defined for TS,
+	   *    or this job can be removed if TS state is not change by cub_master, but changed by the TS itself
+	   *    when it meets the condition then informs to cub_master.
 	   */
 
 	  continue;

--- a/src/executables/master_heartbeat.c
+++ b/src/executables/master_heartbeat.c
@@ -3698,7 +3698,7 @@ hb_resource_job_change_mode (HB_JOB_ARG * arg)
 	   * This job will be re-defined when TS states are re-defined, and failover mechanism is re-designed.
 	   * 1. All the resource jobs check if process type is HB_PTYPE_TRAN_SERVER instead of HB_PTYPE_SERVER.
 	   * 2. hb_Resource is re-defined to have only two processes, HB_PTYPE_PAGE_SERVER and HB_PTYPE_TRAN_SERVER.
-	   * 3. This job check the state of HB_PTYPE_TRAN_SERVER to the one that defined for TS,
+	   * 3. This job check the state of HB_PTYPE_TRAN_SERVER if it is the one that defined for TS such as (HB_PSTATE_IN_TRANSITION), 
 	   *    or this job can be removed if TS state is not change by cub_master, but changed by the TS itself
 	   *    when it meets the condition then informs to cub_master.
 	   */

--- a/src/executables/master_heartbeat.c
+++ b/src/executables/master_heartbeat.c
@@ -3686,8 +3686,9 @@ hb_resource_job_change_mode (HB_JOB_ARG * arg)
   rv = pthread_mutex_lock (&hb_Resource->lock);
   for (proc = hb_Resource->procs; proc; proc = proc->next)
     {
-      if (proc->type != HB_PTYPE_SERVER)
+      if (proc->type != HB_PTYPE_TRAN_SERVER)
 	{
+	  // TODO: Temporary fix for CI test failure, this can be replaced when all the states for TS are defined.
 	  continue;
 	}
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-741

Purpose

use oldHA mechanism to make TS writable
CI test will be run successfully after #4400 is merged

Implementation

Use  `hb_resource_job_change_mode ()` to change the Server state to writable.
