### PR TITLE
[CBRD-24844] Garbage value when querying bit varying(n) column using DBLINK.

### DIFF
--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -859,12 +859,12 @@ dblink_scan_next (DBLINK_SCAN_INFO * scan_info, val_list_node * val_list)
 	  if (utype == CCI_U_TYPE_BIT)
 	    {
 	      /* bit_val.size * 8 : bit length for the value */
-	      (void) db_make_bit (&cci_value, bit_val.size * 8, bit_val.buf, prec);
+	      (void) db_make_bit (&cci_value, prec, bit_val.buf, bit_val.size * 8);
 	    }
 	  else
 	    {
 	      /* bit_val.size * 8 : bit length for the value */
-	      (void) db_make_varbit (&cci_value, bit_val.size * 8, bit_val.buf, prec);
+	      (void) db_make_varbit (&cci_value, prec, bit_val.buf, bit_val.size * 8);
 	    }
 	  break;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24844

Garbage values are appended to the real data when the bit varying length is greater than it of its data. 

```
cubrid createdb t1 en_USl;
cubrid createdb t2 en_US;
-- in t2 database
create table ttbl (T_BITVARYING BIT VARYING(16));    -- Over 8bits
insert into ttbl values (0xcf);                              -- 8bits
-- in t1 database
CREATE VIEW test;
AS SELECT t2_ttbl.*;
FROM dblink('localhost:33000:t2:dba::','select T_BITVARYING from ttbl') AS t2_ttbl(T_BITVARYING BIT VARYING(16));   -- Over 8bits
select * from test;
```

result of the above query

```
expected result: 0xcf
actual result: 0xcf01
```
