### PR TITLE
[CBRD-24836] Deletion of a large number of skewed FK indexes following the deletion of the parents table in SA mode

### DIFF
--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -4302,13 +4302,6 @@ locator_check_primary_key_delete (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 	    {
 	      bool lob_exist = false;
 
-#if !defined (SERVER_MODE)
-	      /* In not SERVER mode, btree_physical_delete() is called. Access to the deallocated page must be prevented. 
-	       * In locator_add_or_remove_index_internal(), you can see that it operates differently according to the "use_mvcc" variable.
-	       * If not SERVER_MODE, "use_mvcc" is always false in that function. And in those conditions, problems arise.
-	       */
-	      bt_scan.is_key_partially_processed = false;
-#endif
 	      error_code =
 		btree_prepare_bts (thread_p, &bt_scan, &fkref->self_btid, &isid, &key_val_range, NULL, &fkref->self_oid,
 				   NULL, NULL, false, NULL);
@@ -4317,6 +4310,14 @@ locator_check_primary_key_delete (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 		  assert (er_errid () != NO_ERROR);
 		  goto error2;
 		}
+
+#if !defined (SERVER_MODE)
+	      /* In not SERVER mode, btree_physical_delete() is called. Access to the deallocated page must be prevented. 
+	       * In locator_add_or_remove_index_internal(), you can see that it operates differently according to the "use_mvcc" variable.
+	       * If not SERVER_MODE, "use_mvcc" is always false in that function. And in those conditions, problems arise.
+	       */
+	      bt_scan.is_key_partially_processed = false;
+#endif
 	      error_code = btree_range_scan (thread_p, &bt_scan, btree_range_scan_select_visible_oids);
 	      if (error_code != NO_ERROR)
 		{
@@ -4654,13 +4655,6 @@ locator_check_primary_key_update (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 
 	  do
 	    {
-#if !defined (SERVER_MODE)
-	      /* In not SERVER mode, btree_physical_delete() is called. Access to the deallocated page must be prevented. 
-	       * In locator_add_or_remove_index_internal(), you can see that it operates differently according to the "use_mvcc" variable.
-	       * If not SERVER_MODE, "use_mvcc" is always false in that function. And in those conditions, problems arise.
-	       */
-	      bt_scan.is_key_partially_processed = false;
-#endif
 	      error_code =
 		btree_prepare_bts (thread_p, &bt_scan, &fkref->self_btid, &isid, &key_val_range, NULL, &fkref->self_oid,
 				   NULL, NULL, false, NULL);
@@ -4669,6 +4663,14 @@ locator_check_primary_key_update (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 		  assert (er_errid () != NO_ERROR);
 		  goto error2;
 		}
+
+#if !defined (SERVER_MODE)
+	      /* In not SERVER mode, btree_physical_delete() is called. Access to the deallocated page must be prevented. 
+	       * In locator_add_or_remove_index_internal(), you can see that it operates differently according to the "use_mvcc" variable.
+	       * If not SERVER_MODE, "use_mvcc" is always false in that function. And in those conditions, problems arise.
+	       */
+	      bt_scan.is_key_partially_processed = false;
+#endif
 	      error_code = btree_range_scan (thread_p, &bt_scan, btree_range_scan_select_visible_oids);
 	      if (error_code != NO_ERROR)
 		{

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -4302,6 +4302,13 @@ locator_check_primary_key_delete (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 	    {
 	      bool lob_exist = false;
 
+#if !defined (SERVER_MODE)
+	      /* In not SERVER mode, btree_physical_delete() is called. Access to the deallocated page must be prevented. 
+	       * In locator_add_or_remove_index_internal(), you can see that it operates differently according to the "use_mvcc" variable.
+	       * If not SERVER_MODE, "use_mvcc" is always false in that function. And in those conditions, problems arise.
+	       */
+	      bt_scan.is_key_partially_processed = false;
+#endif
 	      error_code =
 		btree_prepare_bts (thread_p, &bt_scan, &fkref->self_btid, &isid, &key_val_range, NULL, &fkref->self_oid,
 				   NULL, NULL, false, NULL);
@@ -4647,6 +4654,13 @@ locator_check_primary_key_update (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 
 	  do
 	    {
+#if !defined (SERVER_MODE)
+	      /* In not SERVER mode, btree_physical_delete() is called. Access to the deallocated page must be prevented. 
+	       * In locator_add_or_remove_index_internal(), you can see that it operates differently according to the "use_mvcc" variable.
+	       * If not SERVER_MODE, "use_mvcc" is always false in that function. And in those conditions, problems arise.
+	       */
+	      bt_scan.is_key_partially_processed = false;
+#endif
 	      error_code =
 		btree_prepare_bts (thread_p, &bt_scan, &fkref->self_btid, &isid, &key_val_range, NULL, &fkref->self_oid,
 				   NULL, NULL, false, NULL);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24836

* In not SERVER mode, btree_physical_delete() is called. Access to the deallocated page must be prevented. 

When the FK index is skeweed, if BTS_IS_HARD_CAPACITY_ENOUGH() is not satisfied, the result is divided and processed.
At this time, in SA mode, btree_physical_delete() is called.
When trying to read the results continuously, the already deallocated page is accessed.

Test Case)
`--------------------------------------------------------------------------
SET @maxrec:=8193;
DROP TABLE IF EXISTS ts, tm;
CREATE TABLE tm(id int primary key);
CREATE TABLE ts(id int, fid int);

insert into tm values(1);
insert into ts select rownum, 1  from db_class a, db_class b, db_class c, db_class d where rownum <= @maxrec;
ALTER TABLE ts ADD FOREIGN KEY fk_ts_fid(fid) references tm ON DELETE CASCADE;
delete from tm;

alter table ts drop foreign key fk_ts_fid;
insert into tm values(1);
insert into ts select rownum, 1  from db_class a, db_class b, db_class c, db_class d where rownum <= @maxrec;
ALTER TABLE ts ADD FOREIGN KEY fk_ts_fid(fid) references tm ON DELETE SET NULL;
delete from tm;

alter table ts drop foreign key fk_ts_fid;
insert into tm values(1);
insert into ts select rownum, 1  from db_class a, db_class b, db_class c, db_class d where rownum <= @maxrec;
ALTER TABLE ts ADD FOREIGN KEY fk_ts_fid(fid) references tm ON UPDATE SET NULL;
update tm set id = 2;
---------------------------------------------------------------------------`

