### PR TITLE
[CBRD-24698] Change table names to lowercase in pt_resolve_showstmt_args_unnamed

### DIFF
--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -6748,6 +6748,7 @@ pt_resolve_showstmt_args_unnamed (PARSER_CONTEXT * parser, const SHOWSTMT_NAMED_
 				  PT_NODE * args)
 {
   int i;
+  char lower_table_name[DB_MAX_IDENTIFIER_LENGTH];
   PT_NODE *arg, *id_string;
   PT_NODE *prev = NULL, *head = NULL;
 
@@ -6776,8 +6777,10 @@ pt_resolve_showstmt_args_unnamed (PARSER_CONTEXT * parser, const SHOWSTMT_NAMED_
 	      goto error;
 	    }
 
+	  intl_identifier_lower (arg->info.name.original, lower_table_name);
+
 	  /* replace identifier node with string value node */
-	  id_string = pt_make_string_value (parser, arg->info.name.original);
+	  id_string = pt_make_string_value (parser, lower_table_name);
 	  if (id_string == NULL)
 	    {
 	      goto error;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24698

Change table names to lowercase in pt_resolve_showstmt_args_unnamed.
The problem of distinguishing uppercase and lowercase letters of table names in the following show statements has been resolved.
```
SHOW HEAP HEADER OF [schema_name.]table_name;
SHOW ALL HEAP HEADER OF [schema_name.]table_name;
SHOW HEAP CAPACITY OF [schema_name.]table_name;
SHOW ALL HEAP CAPACITY OF [schema_name.]table_name;
SHOW INDEX HEADER OF [schema_name.]table_name.index_name;
SHOW ALL INDEXES HEADER OF [schema_name.]table_name;
SHOW INDEX CAPACITY OF [schema_name.]table_name.index_name;
SHOW ALL INDEXES CAPACITY OF [schema_name.]table_name;
```