### PR TITLE
[CBRD-24516] multi-aggregate-optimize: replace the information which is printed in "show trace" from aggregate function optimization

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -1805,12 +1805,17 @@ qexec_clear_access_spec_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl_p, ACCES
       /* aggregate optimize related should be free */
       if (p->s_id.scan_stats.agl)
 	{
-	  SCAN_AGL *agl;
+	  SCAN_AGL *next, *agl = p->s_id.scan_stats.agl;;
 
-	  for (agl = p->s_id.scan_stats.agl; agl; agl = agl->next)
+	  while (agl)
 	    {
+	      /* save before free */
+	      next = agl->next;
+
 	      free (agl->agg_index_name);
 	      free (agl);
+
+	      agl = next;
 	    }
 	}
 

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -7730,9 +7730,41 @@ scan_print_stats_json (SCAN_ID * scan_id, json_t * scan_stats)
 
       if (scan_id->type == S_HEAP_SCAN)
 	{
-	  if (scan_id->scan_stats.agg_index_name)
+	  if (scan_id->scan_stats.agl)
 	    {
-	      json_object_set_new (scan, "alg", json_string (scan_id->scan_stats.agg_index_name));
+	      SCAN_AGL *agl;
+	      char *agl_index;
+	      int len;
+
+	      for (agl = scan_id->scan_stats.agl; agl; agl = agl->next)
+		{
+		  len += strlen (agl->agg_index_name + 2);	/* for ", " */
+		}
+
+	      agl_index = (char *) malloc (len);
+	      if (agl_index == NULL)
+		{
+		  return;
+		}
+
+	      *agl_index = '\0';
+	      for (agl = scan_id->scan_stats.agl; agl; agl = agl->next)
+		{
+		  if (*agl_index)
+		    {
+		      sprintf (agl_index, "%s, %s", agl_index, agl->agg_index_name);
+		    }
+		  else
+		    {
+		      sprintf (agl_index, "%s", agl->agg_index_name);
+		    }
+		}
+	      json_object_set_new (scan, "agl", json_string (agl_index));
+	      free (agl_index);
+	    }
+
+	  if (scan_id->scan_stats.noscan)
+	    {
 	      json_object_set_new (scan_stats, "noscan", scan);
 	    }
 	  else
@@ -7822,7 +7854,7 @@ scan_print_stats_text (FILE * fp, SCAN_ID * scan_id)
   switch (scan_id->type)
     {
     case S_HEAP_SCAN:
-      if (scan_id->scan_stats.agg_index_name)
+      if (scan_id->scan_stats.noscan)
 	{
 	  fprintf (fp, "(noscan");	/* aggregate optimization is not a scan */
 	}
@@ -7890,9 +7922,23 @@ scan_print_stats_text (FILE * fp, SCAN_ID * scan_id)
     case S_LIST_SCAN:
       fprintf (fp, ", readrows: %llu, rows: %llu", (unsigned long long int) scan_id->scan_stats.read_rows,
 	       (unsigned long long int) scan_id->scan_stats.qualified_rows);
-      if (scan_id->scan_stats.agg_index_name)
+      if (scan_id->scan_stats.agl)
 	{
-	  fprintf (fp, ", agl: %s", scan_id->scan_stats.agg_index_name);
+	  SCAN_AGL *agl;
+
+	  fprintf (fp, ", agl: [");
+	  for (agl = scan_id->scan_stats.agl; agl; agl = agl->next)
+	    {
+	      fprintf (fp, "%s", agl->agg_index_name);
+	      if (agl->next)
+		{
+		  fprintf (fp, ", ");
+		}
+	      else
+		{
+		  fprintf (fp, "]");
+		}
+	    }
 	}
       fprintf (fp, ")");
       break;

--- a/src/query/scan_manager.h
+++ b/src/query/scan_manager.h
@@ -302,6 +302,13 @@ struct scan_pos
   QFILE_TUPLE_POSITION ls_tplpos;	/* List file index scan position */
 };				/* Scan position structure */
 
+typedef struct scan_agl SCAN_AGL;
+struct scan_agl
+{
+  char *agg_index_name;
+  SCAN_AGL *next;
+};
+
 typedef struct scan_stats SCAN_STATS;
 struct scan_stats
 {
@@ -323,7 +330,8 @@ struct scan_stats
   bool multi_range_opt;
   bool index_skip_scan;
   bool loose_index_scan;
-  char *agg_index_name;
+  bool noscan;			/* aggregate optimize is not scan */
+  SCAN_AGL *agl;		/* for multiple aggregate optimize */
 
   /* hash list scan */
   struct timeval elapsed_hash_build;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24516

SHOW TRACE is will be shown as like below:
```
Trace Statistics:
 SELECT (time: 3736, fetch: 7664, ioread: 0)
   SCAN (table: dba.mx), (heap time: 3505, fetch: 7664, ioread: 0, readrows: 1000000, rows: 1000000, agl: [idx_mx, idx_min])

```