### PR TITLE
[CBRD-24850] Enhancing group_concat() Performance by Optimizing String Size and Length Calculation Methods

### DIFF
--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -165,6 +165,8 @@ db_value_domain_init (DB_VALUE * value, const DB_TYPE type, const int precision,
   value->domain.numeric_info.scale = scale;
   value->need_clear = false;
   value->domain.general_info.is_null = 1;
+  value->data.ch.medium.length=-1;
+  
 
   switch (type)
     {

--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -165,8 +165,8 @@ db_value_domain_init (DB_VALUE * value, const DB_TYPE type, const int precision,
   value->domain.numeric_info.scale = scale;
   value->need_clear = false;
   value->domain.general_info.is_null = 1;
-  value->data.ch.medium.length=-1;
-  
+  value->data.ch.medium.length = -1;
+
 
   switch (type)
     {

--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -165,7 +165,6 @@ db_value_domain_init (DB_VALUE * value, const DB_TYPE type, const int precision,
   value->domain.numeric_info.scale = scale;
   value->need_clear = false;
   value->domain.general_info.is_null = 1;
-  value->data.ch.medium.length = -1;
 
 
   switch (type)
@@ -528,6 +527,7 @@ db_value_domain_min (DB_VALUE * value, const DB_TYPE type,
       value->data.ch.info.is_max_string = false;
       value->data.ch.info.compressed_need_clear = false;
       value->data.ch.medium.size = 1;
+      value->data.ch.medium.length = -1;
       value->data.ch.medium.buf = (char *) "\0";	/* zero; 0 */
       value->data.ch.medium.compressed_buf = NULL;
       value->data.ch.medium.compressed_size = 0;
@@ -544,6 +544,7 @@ db_value_domain_min (DB_VALUE * value, const DB_TYPE type,
       value->data.ch.info.is_max_string = false;
       value->data.ch.info.compressed_need_clear = false;
       value->data.ch.medium.size = 1;
+      value->data.ch.medium.length = -1;
       value->data.ch.medium.buf = (char *) "\40";	/* space; 32 */
       value->data.ch.medium.compressed_buf = NULL;
       value->data.ch.medium.compressed_size = 0;
@@ -692,6 +693,7 @@ db_value_domain_max (DB_VALUE * value, const DB_TYPE type,
       value->data.ch.info.is_max_string = true;
       value->data.ch.info.compressed_need_clear = false;
       value->data.ch.medium.size = 0;
+      value->data.ch.medium.length = -1;
       value->data.ch.medium.buf = NULL;
       value->data.ch.medium.compressed_buf = NULL;
       value->data.ch.medium.compressed_size = 0;
@@ -708,6 +710,7 @@ db_value_domain_max (DB_VALUE * value, const DB_TYPE type,
       value->data.ch.info.is_max_string = true;
       value->data.ch.info.compressed_need_clear = false;
       value->data.ch.medium.size = 0;
+      value->data.ch.medium.length = -1;
       value->data.ch.medium.buf = NULL;
       value->data.ch.medium.compressed_buf = NULL;
       value->data.ch.medium.compressed_size = 0;
@@ -844,6 +847,7 @@ db_value_domain_default (DB_VALUE * value, const DB_TYPE type,
       value->data.ch.info.is_max_string = false;
       value->data.ch.info.compressed_need_clear = false;
       value->data.ch.medium.size = 0;
+      value->data.ch.medium.length = -1;
       value->data.ch.medium.buf = (char *) "";
       value->data.ch.medium.compressed_buf = NULL;
       value->data.ch.medium.compressed_size = 0;
@@ -857,6 +861,7 @@ db_value_domain_default (DB_VALUE * value, const DB_TYPE type,
       value->data.ch.info.compressed_need_clear = false;
       value->data.ch.info.is_max_string = false;
       value->data.ch.medium.size = 1;
+      value->data.ch.medium.length = -1;
       value->data.ch.medium.buf = (char *) "";
       value->data.ch.medium.compressed_buf = NULL;
       value->data.ch.medium.compressed_size = 0;

--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -166,7 +166,6 @@ db_value_domain_init (DB_VALUE * value, const DB_TYPE type, const int precision,
   value->need_clear = false;
   value->domain.general_info.is_null = 1;
 
-
   switch (type)
     {
     case DB_TYPE_NUMERIC:

--- a/src/compat/dbtype_def.h
+++ b/src/compat/dbtype_def.h
@@ -1010,6 +1010,7 @@ extern "C"
       const char *buf;
       int compressed_size;
       char *compressed_buf;
+      int length;
     } medium;
     struct
     {

--- a/src/compat/dbtype_def.h
+++ b/src/compat/dbtype_def.h
@@ -1010,7 +1010,7 @@ extern "C"
       const char *buf;
       int compressed_size;
       char *compressed_buf;
-      int length;		//Only Use for group_concat() now
+      int length;		/* Only Use for group_concat() now */
     } medium;
     struct
     {

--- a/src/compat/dbtype_def.h
+++ b/src/compat/dbtype_def.h
@@ -1010,7 +1010,7 @@ extern "C"
       const char *buf;
       int compressed_size;
       char *compressed_buf;
-      int length;
+      int length;		//Only Use for group_concat() now
     } medium;
     struct
     {

--- a/src/compat/dbtype_function.i
+++ b/src/compat/dbtype_function.i
@@ -621,7 +621,7 @@ db_get_char (const DB_VALUE * value, int *length)
 	str = value->data.ch.medium.buf;
 	intl_char_count ((unsigned char *) str, value->data.ch.medium.size,
 			 (INTL_CODESET) value->data.ch.info.codeset, length);
-	value->data.ch.medium.length = length;
+	((DB_VALUE*)value)->data.ch.medium.length = *length;
       }
       break;
     case LARGE_STRING:

--- a/src/compat/dbtype_function.i
+++ b/src/compat/dbtype_function.i
@@ -621,7 +621,6 @@ db_get_char (const DB_VALUE * value, int *length)
 	str = value->data.ch.medium.buf;
 	intl_char_count ((unsigned char *) str, value->data.ch.medium.size,
 			 (INTL_CODESET) value->data.ch.info.codeset, length);
-	((DB_VALUE *) value)->data.ch.medium.length = *length;
       }
       break;
     case LARGE_STRING:

--- a/src/compat/dbtype_function.i
+++ b/src/compat/dbtype_function.i
@@ -621,7 +621,7 @@ db_get_char (const DB_VALUE * value, int *length)
 	str = value->data.ch.medium.buf;
 	intl_char_count ((unsigned char *) str, value->data.ch.medium.size,
 			 (INTL_CODESET) value->data.ch.info.codeset, length);
-	((DB_VALUE*)value)->data.ch.medium.length = *length;
+	((DB_VALUE *) value)->data.ch.medium.length = *length;
       }
       break;
     case LARGE_STRING:

--- a/src/compat/dbtype_function.i
+++ b/src/compat/dbtype_function.i
@@ -1013,11 +1013,11 @@ db_make_db_char (DB_VALUE * value, const INTL_CODESET codeset, const int collati
   value->domain.char_info.collation_id = collation_id;
   value->need_clear = false;
   /*
-  * Implemented it in a way that fills in the length value
-  * during the operation of obtaining the length later, to avoid 
-  * the significant overhead of intl_char_length for each db_make_db_char, 
-  * if we directly calculate and insert the length value.
-  */
+   * Implemented it in a way that fills in the length value
+   * during the operation of obtaining the length later, to avoid 
+   * the significant overhead of intl_char_length for each db_make_db_char, 
+   * if we directly calculate and insert the length value.
+   */
   value->data.ch.medium.length = -1;
 
   return NO_ERROR;

--- a/src/compat/dbtype_function.i
+++ b/src/compat/dbtype_function.i
@@ -621,6 +621,7 @@ db_get_char (const DB_VALUE * value, int *length)
 	str = value->data.ch.medium.buf;
 	intl_char_count ((unsigned char *) str, value->data.ch.medium.size,
 			 (INTL_CODESET) value->data.ch.info.codeset, length);
+	value->data.ch.medium.length = length;
       }
       break;
     case LARGE_STRING:

--- a/src/compat/dbtype_function.i
+++ b/src/compat/dbtype_function.i
@@ -1658,7 +1658,7 @@ db_make_varchar (DB_VALUE * value, const int max_char_length, DB_CONST_C_CHAR st
     {
       error = db_make_db_char (value, (INTL_CODESET) codeset, collation_id, str, char_str_byte_size);
     }
-  value->data.ch.medium.length = -1;
+
   return error;
 }
 

--- a/src/compat/dbtype_function.i
+++ b/src/compat/dbtype_function.i
@@ -1012,6 +1012,13 @@ db_make_db_char (DB_VALUE * value, const INTL_CODESET codeset, const int collati
 					? 1 : DB_IS_NULL (value));
   value->domain.char_info.collation_id = collation_id;
   value->need_clear = false;
+  /*
+  * Implemented it in a way that fills in the length value
+  * during the operation of obtaining the length later, to avoid 
+  * the significant overhead of intl_char_length for each db_make_db_char, 
+  * if we directly calculate and insert the length value.
+  */
+  value->data.ch.medium.length = -1;
 
   return NO_ERROR;
 }
@@ -1651,7 +1658,7 @@ db_make_varchar (DB_VALUE * value, const int max_char_length, DB_CONST_C_CHAR st
     {
       error = db_make_db_char (value, (INTL_CODESET) codeset, collation_id, str, char_str_byte_size);
     }
-
+  value->data.ch.medium.length = -1;
   return error;
 }
 

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -2181,7 +2181,9 @@ pr_clone_value (const DB_VALUE * src, DB_VALUE * dest)
 		   * destination domain.  No need to do it twice.
 		   * Make sure the COPY flag is set in the setval call.
 		   */
+      int length = src->data.ch.medium.length;
 		  type->setval (dest, src, true);
+      dest->data.ch.medium.length = length;
 		}
 	      else
 		{

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -2181,9 +2181,7 @@ pr_clone_value (const DB_VALUE * src, DB_VALUE * dest)
 		   * destination domain.  No need to do it twice.
 		   * Make sure the COPY flag is set in the setval call.
 		   */
-		  int length = src->data.ch.medium.length;
 		  type->setval (dest, src, true);
-		  dest->data.ch.medium.length = length;
 		}
 	      else
 		{
@@ -11317,6 +11315,7 @@ static void
 mr_initval_char (DB_VALUE * value, int precision, int scale)
 {
   DB_DOMAIN_INIT_CHAR (value, precision);
+  value->data.ch.medium.length = -1;
 }
 
 static int
@@ -12177,6 +12176,7 @@ static void
 mr_initval_nchar (DB_VALUE * value, int precision, int scale)
 {
   db_value_domain_init (value, DB_TYPE_NCHAR, precision, scale);
+  value->data.ch.medium.length = -1;
 }
 
 static int
@@ -13076,6 +13076,7 @@ mr_initval_varnchar (DB_VALUE * value, int precision, int scale)
 {
   db_make_varnchar (value, precision, NULL, 0, LANG_SYS_CODESET, LANG_SYS_COLLATION);
   value->need_clear = false;
+  value->data.ch.medium.length = -1;
 }
 
 static int

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -11375,6 +11375,7 @@ mr_setval_char (DB_VALUE * dest, const DB_VALUE * src, bool copy)
 		  dest->need_clear = true;
 		}
 	    }
+	  dest->data.ch.medium.length = src->data.ch.medium.length;
 	}
     }
 
@@ -12232,6 +12233,7 @@ mr_setval_nchar (DB_VALUE * dest, const DB_VALUE * src, bool copy)
 		  dest->need_clear = true;
 		}
 	    }
+	  dest->data.ch.medium.length = src->data.ch.medium.length;
 	}
     }
   return error;
@@ -13152,6 +13154,7 @@ mr_setval_varnchar (DB_VALUE * dest, const DB_VALUE * src, bool copy)
 	    }
 
 	  dest->data.ch.medium.compressed_size = src->data.ch.medium.compressed_size;
+	  dest->data.ch.medium.length = src->data.ch.medium.length;
 	}
     }
 

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -2181,9 +2181,9 @@ pr_clone_value (const DB_VALUE * src, DB_VALUE * dest)
 		   * destination domain.  No need to do it twice.
 		   * Make sure the COPY flag is set in the setval call.
 		   */
-      int length = src->data.ch.medium.length;
+		  int length = src->data.ch.medium.length;
 		  type->setval (dest, src, true);
-      dest->data.ch.medium.length = length;
+		  dest->data.ch.medium.length = length;
 		}
 	      else
 		{

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -10271,6 +10271,7 @@ mr_setval_string (DB_VALUE * dest, const DB_VALUE * src, bool copy)
 	    }
 	}
 
+      dest->data.ch.medium.length = src->data.ch.medium.length;
       dest->data.ch.medium.compressed_size = src->data.ch.medium.compressed_size;
     }
 

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -11315,7 +11315,6 @@ static void
 mr_initval_char (DB_VALUE * value, int precision, int scale)
 {
   DB_DOMAIN_INIT_CHAR (value, precision);
-  value->data.ch.medium.length = -1;
 }
 
 static int
@@ -12176,7 +12175,6 @@ static void
 mr_initval_nchar (DB_VALUE * value, int precision, int scale)
 {
   db_value_domain_init (value, DB_TYPE_NCHAR, precision, scale);
-  value->data.ch.medium.length = -1;
 }
 
 static int
@@ -13076,7 +13074,6 @@ mr_initval_varnchar (DB_VALUE * value, int precision, int scale)
 {
   db_make_varnchar (value, precision, NULL, 0, LANG_SYS_CODESET, LANG_SYS_COLLATION);
   value->need_clear = false;
-  value->data.ch.medium.length = -1;
 }
 
 static int

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -9212,6 +9212,11 @@ qstr_concatenate (const unsigned char *s1, int s1_length, int s1_size_, int s1_p
   if (QSTR_IS_FIXED_LENGTH (s1_type) && QSTR_IS_FIXED_LENGTH (s2_type))
     {
       /*
+       * The only time we enter inside this if statement is 
+       * when we are using the iso88591 codeset and a data type like char(100). 
+       * This is because the size is not fixed in all other cases.
+       */
+      /*
        *  The result will be a chararacter string of length =
        *  string1_precision + string2_precision.  If the result
        *  length is greater than the maximum allowed for a fixed

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -196,9 +196,10 @@ static int qstr_append (unsigned char *s1, int s1_length, int s1_precision, DB_T
 			int s2_length, int s2_precision, DB_TYPE s2_type, INTL_CODESET codeset, int *result_length,
 			int *result_size, DB_DATA_STATUS * data_status);
 #endif
-static int qstr_concatenate (const unsigned char *s1, int s1_length, int s1_size, int s1_precision, DB_TYPE s1_type, const unsigned char *s2,
-		  int s2_length, int s2_size, int s2_precision, DB_TYPE s2_type, INTL_CODESET codeset, unsigned char **result,
-		  int *result_length, int *result_size, DB_TYPE * result_type, DB_DATA_STATUS * data_status);
+static int qstr_concatenate (const unsigned char *s1, int s1_length, int s1_size, int s1_precision, DB_TYPE s1_type,
+			     const unsigned char *s2, int s2_length, int s2_size, int s2_precision, DB_TYPE s2_type,
+			     INTL_CODESET codeset, unsigned char **result, int *result_length, int *result_size,
+			     DB_TYPE * result_type, DB_DATA_STATUS * data_status);
 static int qstr_bit_concatenate (const unsigned char *s1, int s1_length, int s1_precision, DB_TYPE s1_type,
 				 const unsigned char *s2, int s2_length, int s2_precision, DB_TYPE s2_type,
 				 unsigned char **result, int *result_length, int *result_size, DB_TYPE * result_type,
@@ -1210,12 +1211,12 @@ db_string_concatenate (const DB_VALUE * string1, const DB_VALUE * string2, DB_VA
 		  string2 = &temp;
 		}
 	    }
-    ///////////////////ilhan
-    error_status = qstr_concatenate(DB_GET_UCHAR (string1), (int) db_get_string_length ((DB_VALUE *)string1),
-             (int) db_get_string_size (string1),
+
+	  error_status = qstr_concatenate (DB_GET_UCHAR (string1), (int) db_get_string_length ((DB_VALUE *) string1),
+					   (int) db_get_string_size (string1),
 					   (int) QSTR_VALUE_PRECISION (string1), DB_VALUE_DOMAIN_TYPE (string1),
-					   DB_GET_UCHAR (string2), (int) db_get_string_length ((DB_VALUE *)string2),
-             (int) db_get_string_size(string2),
+					   DB_GET_UCHAR (string2), (int) db_get_string_length ((DB_VALUE *) string2),
+					   (int) db_get_string_size (string2),
 					   (int) QSTR_VALUE_PRECISION (string2), DB_VALUE_DOMAIN_TYPE (string2),
 					   codeset, &r, &r_length, &r_size, &r_type, data_status);
 
@@ -1242,7 +1243,7 @@ db_string_concatenate (const DB_VALUE * string1, const DB_VALUE * string2, DB_VA
 
 	      qstr_make_typed_string (r_type, result, result_domain_length, (char *) r, r_size, codeset, common_coll);
 	      r[r_size] = 0;
-        result->data.ch.medium.length = r_length;
+	      result->data.ch.medium.length = r_length;
 	      result->need_clear = true;
 	    }
 	}
@@ -8074,20 +8075,21 @@ db_get_string_length (const DB_VALUE * value)
       break;
     }
 #endif
-  
+
   str = value->data.ch.medium.buf;
   length = size = value->data.ch.medium.size;
   codeset = (INTL_CODESET) value->data.ch.medium.codeset;
-  DB_VALUE* p = (DB_VALUE*) value;
+  DB_VALUE *p = (DB_VALUE *) value;
 
-  if(p->data.ch.medium.length!=-1){
-    return p->data.ch.medium.length;
-  }
+  if (p->data.ch.medium.length != -1)
+    {
+      return p->data.ch.medium.length;
+    }
   if (value->domain.general_info.type != DB_TYPE_BIT && value->domain.general_info.type != DB_TYPE_VARBIT)
     {
       intl_char_count ((unsigned char *) str, size, codeset, &length);
     }
-  p->data.ch.medium.length=length;
+  p->data.ch.medium.length = length;
   return length;
 }
 
@@ -9131,15 +9133,17 @@ qstr_append (unsigned char *s1, int s1_length, int s1_precision, DB_TYPE s1_type
 }
 #endif
 /*
- * qstr_concatenate () - ilhan
+ * qstr_concatenate ()
  *
  * Arguments:
  *             s1: (IN)  First string pointer.
  *      s1_length: (IN)  Character length of <s1>.
+ *        s1_size: (IN)  Byte size of <s1>.
  *   s1_precision: (IN)  Max character length of <s1>.
  *        s1_type: (IN)  Domain type of <s1>.
  *             s2: (IN)  Second string pointer.
  *      s2_length: (IN)  Character length of <s2>.
+ *        s2_size: (IN)  Byte size of <s2>.
  *   s2_precision: (IN)  Max character length of <s2>.
  *        s2_type: (IN)  Domain type of <s2>.
  *        codeset: (IN)  international codeset.
@@ -9155,9 +9159,10 @@ qstr_append (unsigned char *s1, int s1_length, int s1_precision, DB_TYPE s1_type
  */
 
 static int
-qstr_concatenate (const unsigned char *s1, int s1_length, int s1_size_, int s1_precision, DB_TYPE s1_type, const unsigned char *s2,
-		  int s2_length, int s2_size_, int s2_precision, DB_TYPE s2_type, INTL_CODESET codeset, unsigned char **result,
-		  int *result_length, int *result_size, DB_TYPE * result_type, DB_DATA_STATUS * data_status)
+qstr_concatenate (const unsigned char *s1, int s1_length, int s1_size_, int s1_precision, DB_TYPE s1_type,
+		  const unsigned char *s2, int s2_length, int s2_size_, int s2_precision, DB_TYPE s2_type,
+		  INTL_CODESET codeset, unsigned char **result, int *result_length, int *result_size,
+		  DB_TYPE * result_type, DB_DATA_STATUS * data_status)
 {
   int copy_length, copy_size;
   int pad1_length, pad2_length;
@@ -9169,8 +9174,8 @@ qstr_concatenate (const unsigned char *s1, int s1_length, int s1_size_, int s1_p
 
   *data_status = DATA_STATUS_OK;
 
-  s1_size=s1_size_;
-  s2_size=s2_size_;
+  s1_size = s1_size_;
+  s2_size = s2_size_;
 
   /*
    *  Categorize the source string into fixed and variable
@@ -9344,10 +9349,12 @@ qstr_concatenate (const unsigned char *s1, int s1_length, int s1_size_, int s1_p
        *  copied contained anything but pad characters, then raise
        *  a truncation exception.
        */
-      copy_length = s1_length; copy_size = s1_size;
+      copy_length = s1_length;
+      copy_size = s1_size;
       if (copy_length > *result_length)
 	{
-	  copy_length = *result_length; copy_size = *result_size;
+	  copy_length = *result_length;
+	  copy_size = *result_size;
 
 	  if (varchar_truncated ((unsigned char *) s1, s1_type, s1_length, copy_length, codeset))
 	    {
@@ -9362,10 +9369,12 @@ qstr_concatenate (const unsigned char *s1, int s1_length, int s1_size_, int s1_p
       /*
        *  Processess string2 as we did for string1.
        */
-      cat_length = s2_length; cat_size = s2_size;
+      cat_length = s2_length;
+      cat_size = s2_size;
       if (cat_length > (*result_length - copy_length))
 	{
-	  cat_length = *result_length - copy_length; cat_size = *result_size - copy_size;
+	  cat_length = *result_length - copy_length;
+	  cat_size = *result_size - copy_size;
 
 	  if (varchar_truncated ((unsigned char *) s2, s2_type, s2_length, cat_length, codeset))
 	    {

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -8089,7 +8089,9 @@ db_get_string_length (const DB_VALUE * value)
     {
       intl_char_count ((unsigned char *) str, size, codeset, &length);
     }
+
   p->data.ch.medium.length = length;
+  
   return length;
 }
 

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -8027,7 +8027,7 @@ qstr_bit_to_hex_coerce (char *buffer, int buffer_size, const char *src, int src_
 }
 
 /*
- * db_get_string_length -
+ * db_get_string_length
  *
  * Arguments:
  *        value: Value  container

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -8091,7 +8091,7 @@ db_get_string_length (const DB_VALUE * value)
     }
 
   p->data.ch.medium.length = length;
-  
+
   return length;
 }
 

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -8027,7 +8027,7 @@ qstr_bit_to_hex_coerce (char *buffer, int buffer_size, const char *src, int src_
 }
 
 /*
- * db_get_string_length ilhan
+ * db_get_string_length -
  *
  * Arguments:
  *        value: Value  container
@@ -9133,7 +9133,7 @@ qstr_append (unsigned char *s1, int s1_length, int s1_precision, DB_TYPE s1_type
 }
 #endif
 /*
- * qstr_concatenate ()
+ * qstr_concatenate () -
  *
  * Arguments:
  *             s1: (IN)  First string pointer.
@@ -9224,9 +9224,6 @@ qstr_concatenate (const unsigned char *s1, int s1_length, int s1_size_, int s1_p
 	  *result_length = QSTR_MAX_PRECISION (s1_type);
 	  *data_status = DATA_STATUS_TRUNCATED;
 	}
-
-      //intl_char_size ((unsigned char *) s1, s1_logical_length, codeset, &s1_size);
-      //intl_char_size ((unsigned char *) s2, s2_logical_length, codeset, &s2_size);
 
       if (s1_size == 0)
 	{

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -8090,8 +8090,6 @@ db_get_string_length (const DB_VALUE * value)
       intl_char_count ((unsigned char *) str, size, codeset, &length);
     }
 
-  p->data.ch.medium.length = length;
-
   return length;
 }
 

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -9315,9 +9315,6 @@ qstr_concatenate (const unsigned char *s1, int s1_length, int s1_size_, int s1_p
 	  *result_type = DB_TYPE_VARCHAR;
 	}
 
-      //intl_char_size ((unsigned char *) s1, s1_logical_length, codeset, &s1_size);
-      //intl_char_size ((unsigned char *) s2, s2_logical_length, codeset, &s2_size);
-
       if (s1_size == 0)
 	{
 	  s1_size = s1_logical_length;
@@ -9361,7 +9358,6 @@ qstr_concatenate (const unsigned char *s1, int s1_length, int s1_size_, int s1_p
 	      *data_status = DATA_STATUS_TRUNCATED;
 	    }
 	}
-      //intl_char_size ((unsigned char *) s1, copy_length, codeset, &copy_size);
 
       pad1_length = MIN (s1_logical_length, *result_length) - copy_length;
       length_left = *result_length - copy_length - pad1_length;
@@ -9381,7 +9377,6 @@ qstr_concatenate (const unsigned char *s1, int s1_length, int s1_size_, int s1_p
 	      *data_status = DATA_STATUS_TRUNCATED;
 	    }
 	}
-      //intl_char_size ((unsigned char *) s2, cat_length, codeset, &cat_size);
 
       pad2_length = length_left - cat_length;
 
@@ -9395,7 +9390,6 @@ qstr_concatenate (const unsigned char *s1, int s1_length, int s1_size_, int s1_p
       (void) qstr_pad_string ((unsigned char *) &cat_ptr[cat_size], pad2_length, codeset);
     }
 
-  //intl_char_size (*result, *result_length, codeset, result_size);
 
   return error_status;
 

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -8079,11 +8079,10 @@ db_get_string_length (const DB_VALUE * value)
   str = value->data.ch.medium.buf;
   length = size = value->data.ch.medium.size;
   codeset = (INTL_CODESET) value->data.ch.medium.codeset;
-  DB_VALUE *p = (DB_VALUE *) value;
 
-  if (p->data.ch.medium.length != -1)
+  if (value->data.ch.medium.length != -1)
     {
-      return p->data.ch.medium.length;
+      return value->data.ch.medium.length;
     }
   if (value->domain.general_info.type != DB_TYPE_BIT && value->domain.general_info.type != DB_TYPE_VARBIT)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24850

This pull request introduces the following changes to enhance the performance of the group_concat() function:

1. A **_medium.length_** component has been added to DB_CHAR, which is one of the constituents of DB_VALUE (db_value->data.ch.medium.length). Code has been added to **initialize this component to -1** when executing db_value_domain_default() and db_make_db_char() functions. (src/compat/dbtype_def.h, src/compat/db_macro.c, src/compat/dbtype_function.i)
2. When copying DB_VALUE, the pr_clone_value() function is executed, which in turn carries out mr_setval_string() on the destination. The code has been modified to also copy the **_length_** value during this process. (src/object/object_primitive.c)
3. A code modification has been included that checks if a **_length_** value is valid when executing the db_get_string_length() function. If the **_length_** value is valid, it is used. If not, a value obtained through intl_char_count() is stored in **_length_**.  (src/query/string_opfunc.c)
4. The code within qstr_concatenate has been updated to minimize the execution of the intl_char_count() and intl_char_size() functions. Instead, these values are now pre-received as arguments. (src/query/string_opfunc.c)