### PR TITLE
[LETS-725] Register the cub_server process to cub_master when it is created

### DIFF
--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1290,9 +1290,10 @@ css_start_shutdown_server ()
 }
 
 int
-css_ha_register (const char *server_name)
+css_register_ha_server (const char *server_name)
 {
   assert (server_name != NULL);
+  assert (!HA_DISABLED ());
 
   CSS_CONN_ENTRY *conn;
   std::string message_to_master = css_pack_message_to_master (server_name);

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1297,10 +1297,6 @@ css_register_ha_server (const char *server_name)
 
   CSS_CONN_ENTRY *conn;
   std::string message_to_master = css_pack_message_to_master (server_name);
-  if (message_to_master.empty ())
-    {
-      return ER_FAILED;
-    }
 
   // connection is established before server recovery, only when ha_mode is turned on.
   conn =

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1289,6 +1289,12 @@ css_start_shutdown_server ()
   css_Server_shutdown_inited = true;
 }
 
+#if !defined (WINDOWS)
+/*
+ * css_register_ha_server() - register server to cub_master
+ *  return: error if failed to register
+ *  server_name(in): server name
+ */
 int
 css_register_ha_server (const char *server_name)
 {
@@ -1334,6 +1340,7 @@ css_register_ha_server (const char *server_name)
       return ERR_CSS_ERROR_DURING_SERVER_CONNECT;
     }
 }
+#endif /* !WINDOWS */
 
 /*
  * css_init() -

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -102,7 +102,7 @@ static bool css_Server_shutdown_inited = false;
 static struct timeval css_Shutdown_timeout = { 0, 0 };
 
 static char *css_Master_server_name = NULL;	/* database identifier */
-static int css_Master_port_id;
+static int css_Master_port_id = -1;
 static CSS_CONN_ENTRY *css_Master_conn = NULL;
 static IP_INFO *css_Server_accessible_ip_info;
 static char *ip_list_file_name = NULL;
@@ -1409,6 +1409,9 @@ css_init (THREAD_ENTRY * thread_p, const char *server_name, int port_id)
 
   if (!HA_DISABLED ())
     {
+      // These global variables are set in css_register_ha_server ()
+      assert (css_Master_port_id != -1);
+      assert (css_Pipe_to_master != INVALID_SOCKET);
       assert (css_Master_conn != NULL);
     }
   else

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1297,6 +1297,7 @@ css_ha_register (const char *server_name)
   CSS_CONN_ENTRY *conn;
   std::string message_to_master = css_pack_message_to_master (server_name);
 
+  // connection is established before server recovery, only when ha_mode is turned on.
   conn =
     css_connect_to_master_server (prm_get_integer_value (PRM_ID_TCP_PORT_ID), message_to_master.c_str (),
 				  message_to_master.size ());
@@ -1308,13 +1309,14 @@ css_ha_register (const char *server_name)
 
       if (status != NO_ERROR)
 	{
-	  fprintf (stderr, "failed_to_hearbeat register");
+	  fprintf (stderr, "failed to hearbeat register to master \n");
 	  css_close_connection_to_master ();
 
 	  return status;
 	}
       else
 	{
+	  // established connection will be re-used in css_init () after server recovery.
 	  css_Master_conn = conn;
 	  return NO_ERROR;
 	}

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1410,6 +1410,7 @@ css_init (THREAD_ENTRY * thread_p, const char *server_name, int port_id)
   if (!HA_DISABLED ())
     {
       // These global variables are set in css_register_ha_server ()
+      assert (css_Master_server_name != NULL);
       assert (css_Master_port_id != -1);
       assert (css_Pipe_to_master != INVALID_SOCKET);
       assert (css_Master_conn != NULL);

--- a/src/connection/server_support.h
+++ b/src/connection/server_support.h
@@ -65,7 +65,7 @@ extern void
 css_initialize_server_interfaces (int (*request_handler)
 				  (THREAD_ENTRY * thrd, unsigned int eid, int request, int size, char *buffer),
 				  CSS_THREAD_FN connection_error_handler);
-extern void css_ha_register (const char *server_name);
+extern int css_ha_register (const char *server_name);
 extern int css_init (THREAD_ENTRY * thread_p, const char *server_name, int connection_id);
 extern char *css_add_client_version_string (THREAD_ENTRY * thread_p, const char *version_string);
 #if defined (ENABLE_UNUSED_FUNCTION)

--- a/src/connection/server_support.h
+++ b/src/connection/server_support.h
@@ -65,6 +65,7 @@ extern void
 css_initialize_server_interfaces (int (*request_handler)
 				  (THREAD_ENTRY * thrd, unsigned int eid, int request, int size, char *buffer),
 				  CSS_THREAD_FN connection_error_handler);
+extern void css_ha_register (const char *server_name);
 extern int css_init (THREAD_ENTRY * thread_p, const char *server_name, int connection_id);
 extern char *css_add_client_version_string (THREAD_ENTRY * thread_p, const char *version_string);
 #if defined (ENABLE_UNUSED_FUNCTION)

--- a/src/connection/server_support.h
+++ b/src/connection/server_support.h
@@ -65,7 +65,7 @@ extern void
 css_initialize_server_interfaces (int (*request_handler)
 				  (THREAD_ENTRY * thrd, unsigned int eid, int request, int size, char *buffer),
 				  CSS_THREAD_FN connection_error_handler);
-extern int css_ha_register (const char *server_name);
+extern int css_register_ha_server (const char *server_name);
 extern int css_init (THREAD_ENTRY * thread_p, const char *server_name, int connection_id);
 extern char *css_add_client_version_string (THREAD_ENTRY * thread_p, const char *version_string);
 #if defined (ENABLE_UNUSED_FUNCTION)

--- a/src/connection/server_support.h
+++ b/src/connection/server_support.h
@@ -65,7 +65,9 @@ extern void
 css_initialize_server_interfaces (int (*request_handler)
 				  (THREAD_ENTRY * thrd, unsigned int eid, int request, int size, char *buffer),
 				  CSS_THREAD_FN connection_error_handler);
+#if !defined (WINDOWS)
 extern int css_register_ha_server (const char *server_name);
+#endif // !WINDOWS
 extern int css_init (THREAD_ENTRY * thread_p, const char *server_name, int connection_id);
 extern char *css_add_client_version_string (THREAD_ENTRY * thread_p, const char *version_string);
 #if defined (ENABLE_UNUSED_FUNCTION)

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2267,7 +2267,11 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
   if (!HA_DISABLED ())
     {
       // This must be called after init_server_type () because cub_master have to know which type of server it is.
-      css_ha_register (db_name);
+      error_code = css_ha_register (db_name);
+      if (error_code != NO_ERROR)
+	{
+	  goto error;
+	}
     }
 #endif /* SERVER_MODE */
 

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2266,7 +2266,19 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
 #if defined(SERVER_MODE)
   if (!HA_DISABLED ())
     {
-      // This must be called after init_server_type () because cub_master have to know which type of server it is.
+      /* This must be called before server recovery (log_initialize_passive_tran_server (), or log_initialize ())
+       * The Transaction Server (TS) can be recovered under the following conditions:
+       *   1. It connects to all the Page Servers (PSes).
+       *   2. It connects to the PS that has the latest image.
+       * If the above conditions are not met, then the TS waits.
+       * While the TS is waiting, the cluster can be shutdown, so that the cub_master should be able to
+       * manage the TS that has not been recovered.
+       * So that the cub_master can instruct the TS to either stop or perform recovery when needed.
+       *
+       * This must be called after
+       * 1) css_init_conn_list () because all the global variables related to connection are initialized there, and
+       * 2) init_server_type () because cub_master have to know which type of server it is.
+       */
       error_code = css_register_ha_server (db_name);
       if (error_code != NO_ERROR)
 	{

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2267,7 +2267,7 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
   if (!HA_DISABLED ())
     {
       // This must be called after init_server_type () because cub_master have to know which type of server it is.
-      error_code = css_ha_register (db_name);
+      error_code = css_register_ha_server (db_name);
       if (error_code != NO_ERROR)
 	{
 	  goto error;

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2263,6 +2263,14 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
       goto error;
     }
 
+#if defined(SERVER_MODE)
+  if (!HA_DISABLED ())
+    {
+      // This must be called after init_server_type () because cub_master have to know which type of server it is.
+      css_ha_register (db_name);
+    }
+#endif /* SERVER_MODE */
+
   /*
    * Compose the full name of the database and find location of logs
    */

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2263,7 +2263,7 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
       goto error;
     }
 
-#if defined(SERVER_MODE)
+#if defined (SERVER_MODE) && !defined (WINDOWS)
   if (!HA_DISABLED ())
     {
       /* This must be called before server recovery (log_initialize_passive_tran_server (), or log_initialize ())
@@ -2285,7 +2285,7 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
 	  goto error;
 	}
     }
-#endif /* SERVER_MODE */
+#endif /* SERVER_MODE && !WINDOWS */
 
   /*
    * Compose the full name of the database and find location of logs


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-725

Purpose

In newHA, it is necessary for cub_master to manage the cub_server processes before their recovery is completed.
Therefore, it is intended to establish a connection between cub_master and the server before the recovery starts, and register the TS and PS processes to cub_master.