### PR TITLE
[LETS-759] Temporarily speed up CI tests by using localhost rather than hostname

### DIFF
--- a/src/base/server_type.cpp
+++ b/src/base/server_type.cpp
@@ -26,7 +26,7 @@
 #include "log_impl.h"
 #include "page_server.hpp"
 #include "system_parameter.h"
-#include "tcp.h"
+#include "util_func.h"
 
 #include <string>
 
@@ -40,7 +40,6 @@ SERVER_TYPE get_server_type_from_config (server_type_config parameter_value);
 transaction_server_type get_transaction_server_type_from_config (transaction_server_type_config parameter_value);
 void setup_tran_server_params_on_single_node_config ();
 int setup_tran_server_params_on_ha_mode ();
-bool is_localhost (const char *hostname);
 
 static SERVER_TYPE g_server_type = SERVER_TYPE_UNKNOWN;
 static transaction_server_type g_transaction_server_type = transaction_server_type::ACTIVE;
@@ -218,14 +217,14 @@ int setup_tran_server_params_on_ha_mode ()
 {
   char *page_server_host_list = NULL;
   constexpr size_t MAX_BUFSIZE = 4096;
-  int list_size = 0;
+  size_t list_size = 0;
 
   char ha_node_list[MAX_BUFSIZE];
   char *str, *savep;
 
   int port_id = prm_get_master_port_id ();
 
-  const char *localhost_str = "localhost";
+  constexpr const char *localhost_str = "localhost";
 
   page_server_host_list = (char *) calloc (MAX_BUFSIZE, sizeof (char)); // free is called by sysprm_final()
   if (page_server_host_list == NULL)
@@ -243,7 +242,7 @@ int setup_tran_server_params_on_ha_mode ()
     {
       char page_server_host[MAX_BUFSIZE] = {0};
 
-      if (is_localhost (str))
+      if (util_is_localhost (str))
 	{
 	  sprintf (page_server_host, "%s:%d,", localhost_str, port_id);
 	}
@@ -287,26 +286,6 @@ int setup_tran_server_params_on_ha_mode ()
    */
 
   return NO_ERROR;
-}
-
-bool is_localhost (const char *hostname)
-{
-  assert (hostname != NULL);
-  char local_hostname[CUB_MAXHOSTNAMELEN];
-
-  if (GETHOSTNAME (local_hostname, CUB_MAXHOSTNAMELEN) != 0)
-    {
-      return false;
-    }
-
-  if (strcmp (hostname, local_hostname) == 0)
-    {
-      return true;
-    }
-  else
-    {
-      return false;
-    }
 }
 
 void finalize_server_type ()

--- a/src/base/util_func.c
+++ b/src/base/util_func.c
@@ -875,14 +875,12 @@ util_get_second_and_ms_since_epoch (time_t * secs, int *msec)
 // *INDENT-ON*
 
 /*
- * util_is_localhost -
+ * util_is_localhost - check if host is localhost
  *
- * return:
- *
- * NOTE:
+ * return: true if host is localhost, false otherwise
  */
 bool
-util_is_localhost (char *host)
+util_is_localhost (const char *host)
 {
   char localhost[CUB_MAXHOSTNAMELEN];
   GETHOSTNAME (localhost, CUB_MAXHOSTNAMELEN);

--- a/src/base/util_func.h
+++ b/src/base/util_func.h
@@ -79,7 +79,7 @@ extern void util_get_second_and_ms_since_epoch (time_t * secs, int *msec);
 extern int64_t util_get_time_as_ms_since_epoch ();
 extern time_t util_msec_to_sec (int64_t msec);
 
-extern bool util_is_localhost (char *host);
+extern bool util_is_localhost (const char *host);
 extern bool are_hostnames_equal (const char *hostname_a, const char *hostname_b);
 
 #endif /* _UTIL_FUNC_H_ */

--- a/src/base/util_func.h
+++ b/src/base/util_func.h
@@ -79,4 +79,7 @@ extern void util_get_second_and_ms_since_epoch (time_t * secs, int *msec);
 extern int64_t util_get_time_as_ms_since_epoch ();
 extern time_t util_msec_to_sec (int64_t msec);
 
+extern bool util_is_localhost (char *host);
+extern bool are_hostnames_equal (const char *hostname_a, const char *hostname_b);
+
 #endif /* _UTIL_FUNC_H_ */

--- a/src/executables/util_common.c
+++ b/src/executables/util_common.c
@@ -588,67 +588,6 @@ utility_localtime (const time_t * ts, struct tm *result)
 }
 
 /*
- * util_is_localhost -
- *
- * return:
- *
- * NOTE:
- */
-bool
-util_is_localhost (char *host)
-{
-  char localhost[CUB_MAXHOSTNAMELEN];
-  GETHOSTNAME (localhost, CUB_MAXHOSTNAMELEN);
-
-  return are_hostnames_equal (host, localhost);
-}
-
-/**
- * Compare two host names if are equal, if one of the host names is canonical name and the other is not, then
- * only host part (e.g. for canonical name "host-1.cubrid.org" host part is "host-1") is used for comparison
- *
- * for example following hosts are equal:
- *  "host-1"            "host-1"
- *  "host-1"            "host-1.cubrid.org"
- *  "host-1.cubrid.org" "host-1"
- *  "host-1.cubrid.org" "host-1.cubrid.org"
- *
- * for example following hosts are not equal:
- *  "host-1"            "host-2"
- *  "host-1.cubrid.org" "host-2"
- *  "host-1"            "host-2.cubrid.org"
- *  "host-1.cubrid.org" "host-2.cubrid.org"
- *  "host-1.cubrid.org" "host-1.cubrid.com"
- *
- * @param hostname_a first hostname
- * @param hostname_b second hostname
- *
- * @return true if hostname_a is same as hostname_b
- */
-bool
-are_hostnames_equal (const char *hostname_a, const char *hostname_b)
-{
-  const char *a;
-  const char *b;
-
-  for (a = hostname_a, b = hostname_b; *a && *b && (*a == *b); ++a, ++b)
-    ;
-
-  if (*a == '\0' && *b != '\0')
-    {
-      return *b == '.';
-    }
-  else if (*a != '\0' && *b == '\0')
-    {
-      return *a == '.';
-    }
-  else
-    {
-      return *a == *b;
-    }
-}
-
-/*
  * util_get_num_of_ha_nodes - counter the number of nodes
  *      in either ha_node_list or ha_replica_list
  *    return: the number of nodes in a node list

--- a/src/executables/utility.h
+++ b/src/executables/utility.h
@@ -1748,9 +1748,6 @@ extern "C"
 
   extern FILE *fopen_ex (const char *filename, const char *type);
 
-  extern bool util_is_localhost (char *host);
-  extern bool are_hostnames_equal (const char *hostname_a, const char *hostname_b);
-
   extern void util_free_ha_conf (HA_CONF * ha_conf);
   extern int util_make_ha_conf (HA_CONF * ha_conf);
   extern int util_get_ha_mode_for_sa_utils (void);


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-759

Purpose

There was a performance degradation when accessing the local Page Server through the network layer in newHA. 
As a temporary solution, if the hostname of the Page Server matches the local hostname, we intend to set the page_server_hosts to localhost:port_id.