### PR TITLE
[CBRD-24610] Remove un-used local variable in the btree_prepare_bts function

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -15111,7 +15111,6 @@ btree_prepare_bts (THREAD_ENTRY * thread_p, BTREE_SCAN * bts, BTID * btid, INDX_
 {
   key_val_range inf_key_val_range;
   PAGE_PTR root_page = NULL;
-  VPID root_vpid;
   int error_code = NO_ERROR;
   DB_MIDXKEY *midxkey = NULL;
   DB_VALUE *swap_key = NULL;
@@ -15145,8 +15144,6 @@ btree_prepare_bts (THREAD_ENTRY * thread_p, BTREE_SCAN * bts, BTID * btid, INDX_
 
   if (!bts->is_btid_int_valid)
     {
-      root_vpid.pageid = btid->root_pageid;
-      root_vpid.volid = btid->vfid.volid;
       root_page = btree_fix_root_with_info (thread_p, btid, PGBUF_LATCH_READ, NULL, NULL, &bts->btid_int);
       if (root_page == NULL)
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24610