### PR TITLE
[LETS-738] Add information about whether TS, PS exists to the node information

### DIFF
--- a/src/executables/master_heartbeat.c
+++ b/src/executables/master_heartbeat.c
@@ -2077,6 +2077,8 @@ hb_add_node_to_cluster (char *host_name, unsigned short priority)
       p->state = HB_NSTATE_UNKNOWN;
       p->score = 0;
       p->heartbeat_gap = 0;
+      p->has_transaction_server = false;
+      p->has_page_server = false;
       p->last_recv_hbtime.tv_sec = 0;
       p->last_recv_hbtime.tv_usec = 0;
 
@@ -5569,6 +5571,8 @@ hb_reload_config (void)
 	  new_node->state = old_node->state;
 	  new_node->score = old_node->score;
 	  new_node->heartbeat_gap = old_node->heartbeat_gap;
+	  new_node->has_transaction_server = old_node->has_transaction_server;
+	  new_node->has_page_server = old_node->has_page_server;
 	  new_node->last_recv_hbtime.tv_sec = old_node->last_recv_hbtime.tv_sec;
 	  new_node->last_recv_hbtime.tv_usec = old_node->last_recv_hbtime.tv_usec;
 

--- a/src/executables/master_heartbeat.c
+++ b/src/executables/master_heartbeat.c
@@ -2077,8 +2077,8 @@ hb_add_node_to_cluster (char *host_name, unsigned short priority)
       p->state = HB_NSTATE_UNKNOWN;
       p->score = 0;
       p->heartbeat_gap = 0;
-      p->has_transaction_server = false;
-      p->has_page_server = false;
+      p->is_tran_server_alive = false;
+      p->is_page_server_alive = false;
       p->last_recv_hbtime.tv_sec = 0;
       p->last_recv_hbtime.tv_usec = 0;
 
@@ -5571,8 +5571,8 @@ hb_reload_config (void)
 	  new_node->state = old_node->state;
 	  new_node->score = old_node->score;
 	  new_node->heartbeat_gap = old_node->heartbeat_gap;
-	  new_node->has_transaction_server = old_node->has_transaction_server;
-	  new_node->has_page_server = old_node->has_page_server;
+	  new_node->is_tran_server_alive = old_node->is_tran_server_alive;
+	  new_node->is_page_server_alive = old_node->is_page_server_alive;
 	  new_node->last_recv_hbtime.tv_sec = old_node->last_recv_hbtime.tv_sec;
 	  new_node->last_recv_hbtime.tv_usec = old_node->last_recv_hbtime.tv_usec;
 

--- a/src/executables/master_heartbeat.h
+++ b/src/executables/master_heartbeat.h
@@ -207,6 +207,8 @@ struct hb_node_entry
   HB_NODE_STATE_TYPE state;
   short score;
   short heartbeat_gap;
+  bool has_transaction_server;
+  bool has_page_server;
 
   struct timeval last_recv_hbtime;	/* last received heartbeat time */
 };

--- a/src/executables/master_heartbeat.h
+++ b/src/executables/master_heartbeat.h
@@ -207,8 +207,8 @@ struct hb_node_entry
   HB_NODE_STATE_TYPE state;
   short score;
   short heartbeat_gap;
-  bool has_transaction_server;
-  bool has_page_server;
+  bool is_tran_server_alive;
+  bool is_page_server_alive;
 
   struct timeval last_recv_hbtime;	/* last received heartbeat time */
 };


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-738

Describe here

Required to know whether TS and PS are currently running within one of the nodes in the cluster. 
This information will be used for failover (score calculation). 
In the process of defining the newHA node, the information within cub_master needs to be predefined.

Implementation
- Insert TS and PS variables into the data managed per node (HB_NODE_ENTRY)
- Initialize the variable values during initialization and re-initialization.

Note
- The part where these variables are updated will be done during the process of exchanging heartbeats