### PR TITLE
[CBRD-24862] Missing column name extraction of scalar subquery when using extended DBLINK

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -11447,19 +11447,16 @@ pt_get_column_name_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int 
   S_LINK_COLUMNS *plkcol = (S_LINK_COLUMNS *) arg;
   PT_NODE *name = NULL;
 
-  if (node->node_type == PT_SELECT)
+  switch (node->node_type)
     {
-      ;				//*continue_walk = PT_STOP_WALK;
-    }
-  else if (node->node_type == PT_DOT_)
-    {				// case: tbl.col      
+    case PT_DOT_:
       check_for_already_exists
 	(parser, plkcol, node->info.dot.arg1->info.name.original, node->info.dot.arg2->info.name.original);
 
       *continue_walk = PT_LIST_WALK;
-    }
-  else if (node->node_type == PT_NAME)
-    {
+      break;
+
+    case PT_NAME:
       if (node->type_enum == PT_TYPE_STAR)
 	{			// case:  tbl.*
 	  check_for_already_exists (parser, plkcol, node->info.name.original, NULL);
@@ -11468,30 +11465,27 @@ pt_get_column_name_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int 
 	{
 	  check_for_already_exists (parser, plkcol, NULL, node->info.name.original);
 	}
-    }
-  else if (node->node_type == PT_VALUE && node->type_enum == PT_TYPE_STAR)
-    {
-      {
-	name = parser_new_node (parser, PT_NAME);
-	name->type_enum = PT_TYPE_STAR;
-	if (plkcol->col_list)
-	  {
-	    parser_free_node (parser, plkcol->col_list);
-	  }
-	plkcol->col_list = name;
-      }
-    }
-  return node;
-}
+      break;
 
-#if 0
-static PT_NODE *
-pt_get_column_name_post (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk)
-{
-  *continue_walk = PT_CONTINUE_WALK;
+    case PT_VALUE:
+      if (node->type_enum == PT_TYPE_STAR)
+	{
+	  name = parser_new_node (parser, PT_NAME);
+	  name->type_enum = PT_TYPE_STAR;
+	  if (plkcol->col_list)
+	    {
+	      parser_free_node (parser, plkcol->col_list);
+	    }
+	  plkcol->col_list = name;
+	}
+      break;
+
+    default:
+      break;
+    }
+
   return node;
 }
-#endif
 
 static void
 pt_get_cols_for_dblink (PARSER_CONTEXT * parser, S_LINK_COLUMNS * plkcol, PT_QUERY_INFO * query, PT_NODE * on_cond)

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -11536,6 +11536,10 @@ pt_get_cols_for_dblink (PARSER_CONTEXT * parser, S_LINK_COLUMNS * plkcol, PT_QUE
     {
       (void) parser_walk_tree (parser, query->order_by, pt_get_column_name_pre, plkcol, NULL, NULL);
     }
+  if (query->orderby_for)
+    {
+      (void) parser_walk_tree (parser, query->orderby_for, pt_get_column_name_pre, plkcol, NULL, NULL);
+    }
 }
 
 static void

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -10852,7 +10852,6 @@ pt_get_server_name_list (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int
   SERVER_NAME_LIST *snl = (SERVER_NAME_LIST *) arg;
   PT_NODE *new_name, *new_owner;
 
-  //*continue_walk = PT_STOP_WALK;
   *continue_walk = PT_CONTINUE_WALK;
   assert (continue_walk != NULL);
 
@@ -11889,10 +11888,9 @@ pt_convert_dblink_select_query (PARSER_CONTEXT * parser, PT_NODE * query_stmt, S
 
   parser_walk_tree (parser, query_stmt, pt_convert_dblink_synonym, NULL, NULL, NULL);
 
+  parser_walk_tree (parser, from_tbl, pt_get_server_name_list, snl, NULL, NULL);
   while (from_tbl)
     {
-      parser_walk_tree (parser, from_tbl, pt_get_server_name_list, snl, NULL, NULL);
-
       if (from_tbl->info.spec.entity_name && from_tbl->info.spec.remote_server_name)
 	{
 	  assert (from_tbl->info.spec.entity_name->node_type == PT_NAME);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24862

* There was a problem of not getting the list of columns to be obtained from the remote table in the "inline view" and "connect by" statements.


`create table t1(id int, v1 int);
create table t2(id int, v2 int);
insert into t1 values(1, 1), (2,2), (3,10);
insert into t2 values (1, 10), (2, 100);
create server localsrv(host='localhost', port=33000, dbname=demodb, user=dba);

select (select id from t1@localsrv where v1=v2)   from t2@localsrv;
select (select id from t1@localsrv where v1=x.v2) from t2@localsrv x;`

`CREATE TABLE tree(ID INT, MgrID INT, Name VARCHAR(32), BirthYear INT);
INSERT INTO tree VALUES (1,NULL,'Kim', 1963);
INSERT INTO tree VALUES (2,NULL,'Moy', 1958);

SELECT name FROM tree@localsrv  CONNECT BY PRIOR id=mgrid ORDER BY id;`
