### PR TITLE
[CBRD-24858] Create structures to be used for network communication

### DIFF
--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -150,12 +150,12 @@ set (BASE_HEADERS
   ${BASE_DIR}/mem_block.hpp
   ${BASE_DIR}/memory_reference_store.hpp
   ${BASE_DIR}/memory_private_allocator.hpp
+  ${BASE_DIR}/memory_monitor_common.h
   ${BASE_DIR}/msgcat_set_log.hpp
   ${BASE_DIR}/packable_object.hpp
   ${BASE_DIR}/packer.hpp
   ${BASE_DIR}/perf.hpp
   ${BASE_DIR}/perf_def.hpp
-  ${BASE_DIR}/memory_monitor_common.h
   ${BASE_DIR}/pinning.hpp
   ${BASE_DIR}/pinnable_buffer.hpp
   ${BASE_DIR}/porting_inline.hpp

--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -155,6 +155,7 @@ set (BASE_HEADERS
   ${BASE_DIR}/packer.hpp
   ${BASE_DIR}/perf.hpp
   ${BASE_DIR}/perf_def.hpp
+	${BASE_DIR}/memory_monitor_common.hpp
   ${BASE_DIR}/pinning.hpp
   ${BASE_DIR}/pinnable_buffer.hpp
   ${BASE_DIR}/porting_inline.hpp

--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -155,7 +155,7 @@ set (BASE_HEADERS
   ${BASE_DIR}/packer.hpp
   ${BASE_DIR}/perf.hpp
   ${BASE_DIR}/perf_def.hpp
-  ${BASE_DIR}/memory_monitor_common.hpp
+  ${BASE_DIR}/memory_monitor_common.h
   ${BASE_DIR}/pinning.hpp
   ${BASE_DIR}/pinnable_buffer.hpp
   ${BASE_DIR}/porting_inline.hpp

--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -155,7 +155,7 @@ set (BASE_HEADERS
   ${BASE_DIR}/packer.hpp
   ${BASE_DIR}/perf.hpp
   ${BASE_DIR}/perf_def.hpp
-	${BASE_DIR}/memory_monitor_common.hpp
+  ${BASE_DIR}/memory_monitor_common.hpp
   ${BASE_DIR}/pinning.hpp
   ${BASE_DIR}/pinnable_buffer.hpp
   ${BASE_DIR}/porting_inline.hpp

--- a/src/base/memory_monitor_common.h
+++ b/src/base/memory_monitor_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008 Search Solution Corporation
+ *
  * Copyright 2016 CUBRID Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/base/memory_monitor_common.h
+++ b/src/base/memory_monitor_common.h
@@ -17,7 +17,7 @@
  */
 
 /*
- * memory_monitor_common.hpp - common structures for cubrid memory monitoring module
+ * memory_monitor_common.hpp - common structures for memory monitoring module
  */
 
 #ifndef _MEMORY_MONITOR_COMMON_H_

--- a/src/base/memory_monitor_common.h
+++ b/src/base/memory_monitor_common.h
@@ -24,7 +24,6 @@
 #define _MEMORY_MONITOR_COMMON_H_
 #include "dbtype_def.h"
 
-#include <string>
 #include <cstdint>
 
 typedef struct memmon_mem_stat

--- a/src/base/memory_monitor_common.h
+++ b/src/base/memory_monitor_common.h
@@ -17,7 +17,7 @@
  */
 
 /*
- * memory_monitor_common.hpp - common structures for memory monitoring module
+ * memory_monitor_common.h - common structures for memory monitoring module
  */
 
 #ifndef _MEMORY_MONITOR_COMMON_H_

--- a/src/base/memory_monitor_common.h
+++ b/src/base/memory_monitor_common.h
@@ -22,6 +22,7 @@
 
 #ifndef _MEMORY_MONITOR_COMMON_H_
 #define _MEMORY_MONITOR_COMMON_H_
+#include "dbtype_def.h"
 
 #include <string>
 #include <cstdint>
@@ -36,19 +37,19 @@ typedef struct memmon_mem_stat
 
 typedef struct memmon_server_info
 {
-  char *name;
+  char name[DB_MAX_IDENTIFIER_LENGTH];
   uint64_t total_mem_usage;
 } MEMMON_SERVER_INFO;
 
 typedef struct memmon_subcomp_info
 {
-  char *name;
+  char name[DB_MAX_IDENTIFIER_LENGTH];
   uint64_t cur_stat;
 } MEMMON_SUBCOMP_INFO;
 
 typedef struct memmon_comp_info
 {
-  char *name;
+  char name[DB_MAX_IDENTIFIER_LENGTH];
   MEMMON_MEM_STAT stat;
   uint32_t num_subcomp;
   MEMMON_SUBCOMP_INFO *subcomp_info;
@@ -57,7 +58,7 @@ typedef struct memmon_comp_info
 typedef struct memmon_module_info
 {
   MEMMON_SERVER_INFO server_info;
-  char *name;
+  char name[DB_MAX_IDENTIFIER_LENGTH];
   MEMMON_MEM_STAT stat;
   uint32_t num_comp;
   MEMMON_COMP_INFO *comp_info;

--- a/src/base/memory_monitor_common.h
+++ b/src/base/memory_monitor_common.h
@@ -60,7 +60,7 @@ typedef struct memmon_module_info
   char *name;
   MEMMON_MEM_STAT stat;
   uint32_t num_comp;
-  MEMMON_COMP_INFO **comp_info;
+  MEMMON_COMP_INFO *comp_info;
 } MEMMON_MODULE_INFO;
 
 typedef struct memmon_tran_stat

--- a/src/base/memory_monitor_common.h
+++ b/src/base/memory_monitor_common.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2008 Search Solution Corporation
- * Copyright 2016 CUBRID Corporation
+ * Copyright 2023 CUBRID Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -17,21 +17,14 @@
  */
 
 /*
- * memory_monitor.hpp - cubrid memory monitoring module
+ * memory_monitor_common.hpp - common structures for cubrid memory monitoring module
  */
 
 #ifndef _MEMORY_MONITOR_COMMON_H_
 #define _MEMORY_MONITOR_COMMON_H_
 
-
-#include "perf_def.hpp"
-#include "thread_compat.hpp"
-
 #include <string>
-#include <type_traits>
 #include <cstdint>
-
-#include <cassert>
 
 typedef struct memmon_mem_stat
 {

--- a/src/base/memory_monitor_common.h
+++ b/src/base/memory_monitor_common.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+/*
+ * memory_monitor.hpp - cubrid memory monitoring module
+ */
+
+#ifndef _MEMORY_MONITOR_COMMON_H_
+#define _MEMORY_MONITOR_COMMON_H_
+
+
+#include "perf_def.hpp"
+#include "thread_compat.hpp"
+
+#include <string>
+#include <type_traits>
+#include <cstdint>
+
+#include <cassert>
+
+typedef struct memmon_mem_stat
+{
+  uint64_t init_stat;
+  uint64_t cur_stat;
+  uint64_t peak_stat;
+  uint32_t expand_count;
+} MEMMON_MEM_STAT;
+
+typedef struct memmon_server_info
+{
+  char *name;
+  uint64_t total_mem_usage;
+} MEMMON_SERVER_INFO;
+
+typedef struct memmon_subcomp_info
+{
+  char *name;
+  uint64_t cur_stat;
+} MEMMON_SUBCOMP_INFO;
+
+typedef struct memmon_comp_info
+{
+  char *name;
+  MEMMON_MEM_STAT stat;
+  uint32_t num_subcomp;
+  MEMMON_SUBCOMP_INFO *subcomp_info;
+} MEMMON_COMP_INFO;
+
+typedef struct memmon_module_info
+{
+  MEMMON_SERVER_INFO server_info;
+  char *name;
+  MEMMON_MEM_STAT stat;
+  uint32_t num_comp;
+  MEMMON_COMP_INFO **comp_info;
+} MEMMON_MODULE_INFO;
+
+typedef struct memmon_tran_stat
+{
+  int tranid;
+  uint64_t cur_stat;
+} MEMMON_TRAN_STAT;
+
+typedef struct memmon_tran_info
+{
+  MEMMON_SERVER_INFO server_info;
+  uint32_t num_tran;
+  MEMMON_TRAN_STAT *tran_stat;
+} MEMMON_TRAN_INFO;
+
+#endif // _MEMORY_MONITOR_COMMON_H_

--- a/src/base/memory_monitor_common.h
+++ b/src/base/memory_monitor_common.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2008 Search Solution Corporation
- * Copyright 2023 CUBRID Corporation
+ * Copyright 2016 CUBRID Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24858

Add structures to be used for memmon utility / Memory Monitoring Manager in new header memory_monitoring_common.h

The added structures are used to store the memory usage information tracked by the server.