### PR TITLE
[LETS-758] Disable replication logs generated for applylogdb

### DIFF
--- a/src/transaction/log_comm.c
+++ b/src/transaction/log_comm.c
@@ -269,6 +269,13 @@ log_dump_log_info (const char *logname_info, bool also_stdout, const char *fmt, 
 bool
 log_does_allow_replication (void)
 {
+  return false;
+
+#if 0
+/* TODO - newHA
+ * if copylogdb and applylogdb is re-used for HA, then this commented out code should be enabled.
+ */
+
 #if defined(WINDOWS) || defined(SA_MODE)
   return false;
 
@@ -309,5 +316,6 @@ log_does_allow_replication (void)
 #else /* SERVER_MODE */
 
   return false;
+#endif
 #endif
 }

--- a/src/transaction/replication.c
+++ b/src/transaction/replication.c
@@ -299,6 +299,8 @@ repl_log_insert (THREAD_ENTRY * thread_p, const OID * class_oid, const OID * ins
   char *ptr;
   int error = NO_ERROR, strlen;
 
+  assert (log_does_allow_replication () == true);
+
   tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
   tdes = LOG_FIND_TDES (tran_index);
   if (tdes == NULL)
@@ -514,6 +516,8 @@ repl_log_insert_statement (THREAD_ENTRY * thread_p, REPL_INFO_SBR * repl_info)
   LOG_REPL_RECORD *repl_rec;
   char *ptr;
   int error = NO_ERROR, strlen1, strlen2, strlen3, strlen4;
+
+  assert (log_does_allow_replication () == true);
 
   tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
   tdes = LOG_FIND_TDES (tran_index);


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-758

Purpose

In newHA implementation, there is no applylogdb to apply replication log records so that replication logs are no longer required.

Implementation

- comment out the `log_does_allow_replication ()`
- `log_does_allow_replication()` is used in the context of generating replication logs when performing DML and DDL statements.