### PR TITLE
[LETS-756] Try to connect to disconnected page servers periodically

### DIFF
--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -324,7 +324,7 @@ tran_server::get_boot_info_from_page_server ()
 int
 tran_server::connection_handler::connect (const cubcomm::node &node)
 {
-  auto ps_conn_error_lambda = [&node, this] ()
+  auto ps_conn_error_lambda = [&node, this] (const std::lock_guard<std::shared_mutex> &)
   {
     m_state = state::IDLE;
 
@@ -349,22 +349,22 @@ tran_server::connection_handler::connect (const cubcomm::node &node)
 				   CMD_SERVER_SERVER_CONNECT);
   if (comm_error_code != css_error_code::NO_ERRORS)
     {
-      return ps_conn_error_lambda ();
+      return ps_conn_error_lambda (lockg_state);
     }
 
   if (srv_chn.send_int (static_cast<int> (m_ts.m_conn_type)) != NO_ERRORS)
     {
-      return ps_conn_error_lambda ();
+      return ps_conn_error_lambda (lockg_state);
     }
 
   int returned_code;
   if (srv_chn.recv_int (returned_code) != css_error_code::NO_ERRORS)
     {
-      return ps_conn_error_lambda ();
+      return ps_conn_error_lambda (lockg_state);
     }
   if (returned_code != static_cast<int> (m_ts.m_conn_type))
     {
-      return ps_conn_error_lambda ();
+      return ps_conn_error_lambda (lockg_state);
     }
 
   // NOTE: only the base class part (cubcomm::channel) of a cubcomm::server_channel instance is

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -453,7 +453,6 @@ tran_server::uses_remote_storage () const
 void
 tran_server::connection_handler::set_connection (cubcomm::channel &&chn)
 {
-  auto lockg_conn = std::lock_guard<std::shared_mutex> { m_conn_mtx };
   constexpr size_t RESPONSE_PARTITIONING_SIZE = 24;   // Arbitrarily chosen
   // TODO: to reduce contention as much as possible, should be equal to the maximum number
   // of active transactions that the system allows (PRM_ID_CSS_MAX_CLIENTS) + 1
@@ -461,6 +460,8 @@ tran_server::connection_handler::set_connection (cubcomm::channel &&chn)
   cubcomm::send_queue_error_handler no_transaction_handler { nullptr };
   // Transaction server will use message specific error handlers.
   // Implementation will assert that an error handler is present if needed.
+
+  auto lockg_conn = std::lock_guard<std::shared_mutex> { m_conn_mtx };
 
   assert (m_conn == nullptr);
   m_conn.reset (new page_server_conn_t (std::move (chn), get_request_handlers (), tran_to_page_request::RESPOND,

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -665,7 +665,7 @@ tran_server::ps_connector::connect_if_idle (cubthread::entry &)
   /* Assume that they stores PS information in the same order */
   assert (m_ts.m_connection_list.size () == m_ts.m_page_server_conn_vec.size());
 
-  for (int i=0; i < m_ts.m_page_server_conn_vec.size (); i++)
+  for (size_t i = 0; i < m_ts.m_page_server_conn_vec.size (); i++)
     {
       if (m_ts.m_page_server_conn_vec[i]->is_idle ())
 	{

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -538,6 +538,33 @@ tran_server::connection_handler::is_disconnecting () const
   return m_is_disconnecting.load ();
 }
 
+tran_server::ps_connector::ps_connector (tran_server &ts)
+  : m_ts { ts }
+{
+  m_thread = std::thread (&tran_server::ps_connector::connect_loop, std::ref (*this));
+}
+
+tran_server::ps_connector::~ps_connector ()
+{
+}
+
+void
+tran_server::ps_connector::start ()
+{
+}
+
+void
+tran_server::ps_connector::terminate ()
+{
+}
+
+void
+tran_server::ps_connector::connect_loop ()
+{
+}
+
+
+
 void
 assert_is_tran_server ()
 {

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -611,59 +611,30 @@ tran_server::connection_handler::is_connected ()
 
 tran_server::ps_connector::ps_connector (tran_server &ts)
   : m_ts { ts }
-  , m_terminate { false }
 {
+  m_thread = std::thread (&tran_server::ps_connector::connect_loop, std::ref (*this));
 }
 
 tran_server::ps_connector::~ps_connector ()
 {
-  assert (m_terminate.load () == true);
 }
 
 void
 tran_server::ps_connector::start ()
 {
-  m_thread = std::thread (&tran_server::ps_connector::connect_loop, std::ref (*this));
 }
 
 void
 tran_server::ps_connector::terminate ()
 {
-  m_terminate.store (true);
-
-  if (m_thread.joinable ())
-    {
-      m_thread.join ();
-    }
-  else
-    {
-      assert (false);
-    }
 }
 
 void
 tran_server::ps_connector::connect_loop ()
 {
-  constexpr std::chrono::seconds one_sec { 1 };
-
-  /* Assume that they stores PS information in the same order */
-  assert (m_ts.m_connection_list.size () == m_ts.m_page_server_conn_vec.size());
-
-  while (true)
-    {
-      for (int i=0; i < m_ts.m_page_server_conn_vec.size (); i++)
-	{
-	  // 흠 state 상태를 체크하고, connect를 수행하기까지의 lock을 잡아야 하지 않나..? 밖에서 어케 잡지
-	  // connect 요청하고 내부에서 에러처리하는 방식으로 해야하나
-	  if (m_ts.m_page_server_conn_vec[i].get_state () ==
-	      tran_server::connection_handler::state::OPEN))
-	    {
-	    }
-
-	}
-      this_thread::sleep_for (one_sec);
-    }
 }
+
+
 
 void
 assert_is_tran_server ()

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -661,7 +661,7 @@ tran_server::ps_connector::terminate ()
 void
 tran_server::ps_connector::try_connect_to_all_ps (cubthread::entry &)
 {
-  /* Assume that they stores PS information in the same order.
+  /* Assume that they store PS information in the same order.
    * TODO: combine two vectors */
   assert (m_ts.m_connection_list.size () == m_ts.m_page_server_conn_vec.size());
 
@@ -671,7 +671,7 @@ tran_server::ps_connector::try_connect_to_all_ps (cubthread::entry &)
 	{
 	  /*
 	   * TODO It can be too verbose now since it always complain to fail to connect when a PS has been stopped.
-	   * Later on, this job is going to be tirggered by a cluster manager or cub_mster when a PS is ready to connect.
+	   * Later on, this job is going to be triggered by a cluster manager or cub_master when a PS is ready to connect.
 	   */
 	  m_ts.m_page_server_conn_vec[i]->connect (m_ts.m_connection_list[i]);
 	}

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -324,8 +324,10 @@ tran_server::get_boot_info_from_page_server ()
 int
 tran_server::connection_handler::connect (const cubcomm::node &node)
 {
-  auto ps_conn_error_lambda = [&node] ()
+  auto ps_conn_error_lambda = [&node, this] ()
   {
+    m_state = state::IDLE;
+
     er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_NET_PAGESERVER_CONNECTION, 1, node.get_host ().c_str ());
     return ER_NET_PAGESERVER_CONNECTION;
   };

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -631,12 +631,7 @@ tran_server::ps_connector::ps_connector (tran_server &ts)
 
 tran_server::ps_connector::~ps_connector ()
 {
-  if (m_terminate.load () == false)
-    {
-      terminate ();
-    }
-
-  assert (m_terminate.load() == true);
+  terminate ();
 }
 
 void
@@ -657,8 +652,10 @@ tran_server::ps_connector::start ()
 void
 tran_server::ps_connector::terminate ()
 {
-  m_terminate.store (true);
-  cubthread::get_manager ()->destroy_daemon (m_daemon);
+  if (m_terminate.exchange (true) == false)
+    {
+      cubthread::get_manager ()->destroy_daemon (m_daemon);
+    }
 }
 
 void

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -643,6 +643,8 @@ void
 tran_server::ps_connector::start ()
 {
   assert (m_terminate.load () == false);
+  /* After init_page_server_hosts() */
+  assert (m_ts.m_page_server_conn_vec.empty () == false);
 
   auto func_exec = std::bind (&tran_server::ps_connector::try_connect_to_all_ps, std::ref (*this), std::placeholders::_1);
   auto entry = new cubthread::entry_callable_task (std::move (func_exec));

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -466,7 +466,6 @@ tran_server::connection_handler::set_connection (cubcomm::channel &&chn)
   assert (m_conn == nullptr);
   m_conn.reset (new page_server_conn_t (std::move (chn), get_request_handlers (), tran_to_page_request::RESPOND,
 					page_to_tran_request::RESPOND, RESPONSE_PARTITIONING_SIZE, std::move (no_transaction_handler)));
-  assert (m_conn != nullptr);
 
   m_conn->start ();
 }

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -644,7 +644,7 @@ tran_server::ps_connector::start ()
 {
   assert (m_terminate.load () == false);
 
-  auto func_exec = std::bind (&tran_server::ps_connector::connect_if_idle, std::ref (*this), std::placeholders::_1);
+  auto func_exec = std::bind (&tran_server::ps_connector::try_connect_to_all_ps, std::ref (*this), std::placeholders::_1);
   auto entry = new cubthread::entry_callable_task (std::move (func_exec));
 
   constexpr std::chrono::seconds five_sec { 5 };
@@ -660,7 +660,7 @@ tran_server::ps_connector::terminate ()
 }
 
 void
-tran_server::ps_connector::connect_if_idle (cubthread::entry &)
+tran_server::ps_connector::try_connect_to_all_ps (cubthread::entry &)
 {
   /* Assume that they stores PS information in the same order.
    * TODO: combine two vectors */

--- a/src/server/tran_server.hpp
+++ b/src/server/tran_server.hpp
@@ -115,6 +115,7 @@ class tran_server
 
 	const std::string get_channel_id () const;
 	bool is_connected ();
+	bool is_idle ();
 
 	virtual log_lsa get_saved_lsa () const = 0; // used in active_tran_server
 
@@ -214,7 +215,7 @@ class tran_server
 
       private:
 	tran_server &m_ts;
-	bool m_terminate;
+	std::atomic<bool> m_terminate;
 	std::mutex m_mtx;
 	std::thread m_thread;
     };

--- a/src/server/tran_server.hpp
+++ b/src/server/tran_server.hpp
@@ -148,6 +148,33 @@ class tran_server
     std::condition_variable_any m_main_conn_cv;
 
   private:
+    class ps_connector
+    {
+      public:
+	ps_connector (tran_server &ts);
+
+	ps_connector (const ps_connector &) = delete;
+	ps_connector (ps_connector &&) = delete;
+
+	~ps_connector ();
+
+	ps_connector &operator = (const ps_connector &) = delete;
+	ps_connector &operator = (ps_connector &&) = delete;
+
+	void start ();
+	void terminate ();
+
+      private:
+	void connect_loop ();
+
+      private:
+	tran_server &m_ts;
+	bool m_terminate;
+	std::mutex m_mtx;
+	std::thread m_thread;
+    };
+
+  private:
     int init_page_server_hosts (const char *db_name);
     int get_boot_info_from_page_server ();
     int connect_to_page_server (const cubcomm::node &node, const char *db_name);

--- a/src/server/tran_server.hpp
+++ b/src/server/tran_server.hpp
@@ -169,7 +169,7 @@ class tran_server
 
       private:
 	tran_server &m_ts;
-	bool m_terminate;
+	atomic<bool> m_terminate;
 	std::mutex m_mtx;
 	std::thread m_thread;
     };

--- a/src/server/tran_server.hpp
+++ b/src/server/tran_server.hpp
@@ -217,7 +217,7 @@ class tran_server
 	void terminate ();
 
       private:
-	void connect_if_idle (cubthread::entry &);
+	void try_connect_to_all_ps (cubthread::entry &);
 
       private:
 	tran_server &m_ts;

--- a/src/server/tran_server.hpp
+++ b/src/server/tran_server.hpp
@@ -219,9 +219,9 @@ class tran_server
     };
 
   private:
-    int init_page_server_hosts (const char *db_name);
+    int init_page_server_hosts ();
     int get_boot_info_from_page_server ();
-    int connect_to_page_server (connection_handler &conn_handler, const cubcomm::node &node, const char *db_name);
+    int connect_to_page_server (connection_handler &conn_handler, const cubcomm::node &node);
     int reset_main_connection ();
 
     int parse_server_host (const std::string &host);
@@ -229,6 +229,7 @@ class tran_server
 
   private:
     cubcomm::server_server m_conn_type;
+    std::string m_server_name;
 };
 
 #endif // !_tran_server_HPP_

--- a/src/server/tran_server.hpp
+++ b/src/server/tran_server.hpp
@@ -196,6 +196,10 @@ class tran_server
     std::shared_mutex m_main_conn_mtx;
 
   private:
+    /*
+     * Try to [re]connect to disconected page servers.
+     * TODO This is a temporary feature, which is going to be done by the cluster manager or cub_master. It tries to connect to all page servers periodically, but later on, it is going to connect to PSes that are ready to connect.
+    */
     class ps_connector
     {
       public:

--- a/src/server/tran_server.hpp
+++ b/src/server/tran_server.hpp
@@ -213,7 +213,7 @@ class tran_server
 
       private:
 	tran_server &m_ts;
-	atomic<bool> m_terminate;
+	bool m_terminate;
 	std::mutex m_mtx;
 	std::thread m_thread;
     };

--- a/src/server/tran_server.hpp
+++ b/src/server/tran_server.hpp
@@ -106,7 +106,7 @@ class tran_server
 
 	virtual ~connection_handler ();
 
-	void set_connection (cubcomm::channel &&chn);
+	int connect (const cubcomm::node &node);
 	void disconnect_async (bool with_disc_msg);
 	void wait_async_disconnection ();
 
@@ -160,6 +160,7 @@ class tran_server
 	};
 
       private:
+	void set_connection (cubcomm::channel &&chn);
 	// Request handlers for requests in common
 	void receive_disconnect_request (page_server_conn_t::sequenced_payload &&a_sp);
 
@@ -221,7 +222,6 @@ class tran_server
   private:
     int init_page_server_hosts ();
     int get_boot_info_from_page_server ();
-    int connect_to_page_server (connection_handler &conn_handler, const cubcomm::node &node);
     int reset_main_connection ();
 
     int parse_server_host (const std::string &host);

--- a/src/server/tran_server.hpp
+++ b/src/server/tran_server.hpp
@@ -24,7 +24,8 @@
 #include "log_lsa.hpp"
 #include "request_sync_client_server.hpp"
 #include "tran_page_requests.hpp"
-#include "async_disconnect_handler.hpp"
+#include "thread_manager.hpp"
+#include "thread_looper.hpp"
 
 #include <string>
 #include <vector>
@@ -65,6 +66,7 @@ class tran_server
     tran_server (cubcomm::server_server conn_type)
       : m_main_conn { nullptr }
       , m_conn_type { conn_type }
+      , m_ps_connector { *this }
     {
     }
     tran_server (const tran_server &) = delete;
@@ -211,13 +213,15 @@ class tran_server
 	void terminate ();
 
       private:
-	void connect_loop ();
+	void connect_if_idle (cubthread::entry &);
 
       private:
 	tran_server &m_ts;
+
+	cubthread::daemon *m_daemon;
+
 	std::atomic<bool> m_terminate;
 	std::mutex m_mtx;
-	std::thread m_thread;
     };
 
   private:
@@ -231,6 +235,8 @@ class tran_server
   private:
     cubcomm::server_server m_conn_type;
     std::string m_server_name;
+
+    ps_connector m_ps_connector;
 };
 
 #endif // !_tran_server_HPP_


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-756

Add a ps_connector in tran_server, which tries to reconnect to all disconnected page servers. 
- It tries to all `connection_handler` that are in `IDLE` state. As described in a comment, later on, it is going to connect to only PSes that are ready to connect by an upper layer.
- The internal thread is implemented with cubrid daemon since it uses `er_set` internally.
- It's started on `tran_server::boot()` and terminated in `tran_server::disconnect_all_page_servers ()`.

Put `connect_to_page_server` into connection_handler as `connect`
- Mainly, because the creating channel has to be done inside the `m_state` lock scope.
- And it seems more make sense with the current codebase after several refactoring.
