### PR TITLE
[CBRD-24684] revised: divide operation result into NUMERIC type

### DIFF
--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -4456,7 +4456,9 @@ pt_limit_to_numbering_expr (PARSER_CONTEXT * parser, PT_NODE * limit, PT_OP_TYPE
 
       sum->data_type->type_enum = PT_TYPE_NUMERIC;
       sum->data_type->info.data_type.precision = DB_MAX_NUMERIC_PRECISION;
-      sum->data_type->info.data_type.dec_precision = 0;
+
+      /* It is necessary to prepare for the division operation in advance.*/
+      sum->data_type->info.data_type.dec_precision = DB_DEFAULT_NUMERIC_DIVISION_SCALE; /* 9 */
 
       sum->info.expr.arg1 = parser_copy_tree (parser, limit);
       sum->info.expr.arg2 = parser_copy_tree (parser, limit->next);

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -4345,6 +4345,8 @@ pt_limit_to_numbering_expr (PARSER_CONTEXT * parser, PT_NODE * limit, PT_OP_TYPE
   PT_NODE *lhs, *sum, *part1, *part2, *node;
   DB_VALUE sum_val;
 
+  static bool oracle_style_divide = prm_get_bool_value (PRM_ID_ORACLE_STYLE_DIVIDE);
+
   db_make_null (&sum_val);
 
   if (limit == NULL)
@@ -4456,9 +4458,13 @@ pt_limit_to_numbering_expr (PARSER_CONTEXT * parser, PT_NODE * limit, PT_OP_TYPE
 
       sum->data_type->type_enum = PT_TYPE_NUMERIC;
       sum->data_type->info.data_type.precision = DB_MAX_NUMERIC_PRECISION;
+      sum->data_type->info.data_type.dec_precision = 0;
 
-      /* It is necessary to prepare for the division operation in advance. */
-      sum->data_type->info.data_type.dec_precision = DB_DEFAULT_NUMERIC_DIVISION_SCALE;	/* 9 */
+      if (oracle_style_divide)
+	{
+	  /* It is necessary to prepare for the division operation in advance. */
+	  sum->data_type->info.data_type.dec_precision = DB_DEFAULT_NUMERIC_DIVISION_SCALE;	/* 9 */
+	}
 
       sum->info.expr.arg1 = parser_copy_tree (parser, limit);
       sum->info.expr.arg2 = parser_copy_tree (parser, limit->next);

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -4457,8 +4457,8 @@ pt_limit_to_numbering_expr (PARSER_CONTEXT * parser, PT_NODE * limit, PT_OP_TYPE
       sum->data_type->type_enum = PT_TYPE_NUMERIC;
       sum->data_type->info.data_type.precision = DB_MAX_NUMERIC_PRECISION;
 
-      /* It is necessary to prepare for the division operation in advance.*/
-      sum->data_type->info.data_type.dec_precision = DB_DEFAULT_NUMERIC_DIVISION_SCALE; /* 9 */
+      /* It is necessary to prepare for the division operation in advance. */
+      sum->data_type->info.data_type.dec_precision = DB_DEFAULT_NUMERIC_DIVISION_SCALE;	/* 9 */
 
       sum->info.expr.arg1 = parser_copy_tree (parser, limit);
       sum->info.expr.arg2 = parser_copy_tree (parser, limit->next);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24684

Under the parameter ORACLE_DIVIDE_STYLE on

```
csql> select rownum from db_class limit 5/4 offset 0;
=== <Result of SELECT Command in Line 1> ===
                rownum
======================
                     1

csql> select rownum from db_class limit 5/4 offset 1/2;
=== <Result of SELECT Command in Line 1> ===
                rownum
======================
                     1
                     2
```

limit with offset represents "\<limit\> from \<offset\> to \<offset\> + \<limit\>" and the query is rewritten as below:

select rownum from db_class limit 5/4 offset 1/2;
==> rewritten
select rownum from db_class where inst_num() > offset and inst_num() <= offset + limit;

The above two query results should be the same as in Oracle.