### PR TITLE
[LETS-697] Handle the abnormal disconnection of a page server.

### DIFF
--- a/src/communication/request_sync_client_server.hpp
+++ b/src/communication/request_sync_client_server.hpp
@@ -286,6 +286,14 @@ namespace cubcomm
     std::tie (a_response_payload, error_code) = m_response_broker.get_response (rsn);
     if (error_code != NO_ERRORS)
       {
+	/*
+	 * Set CONNECTION_CLOSED as the error code if the internal socket is closed.
+	 * It lets the outside know that it's disconnected abnormally for some reason.
+	 */
+	if (!m_conn->get_channel ().is_connection_alive ())
+	  {
+	    error_code = CONNECTION_CLOSED;
+	  }
 	// clear payload
 	a_response_payload = T_PAYLOAD ();
       }

--- a/src/communication/request_sync_client_server.hpp
+++ b/src/communication/request_sync_client_server.hpp
@@ -73,9 +73,8 @@ namespace cubcomm
       void stop_incoming_communication_thread ();
       void stop_outgoing_communication_thread ();
 
-      /* only used by unit tests
-       */
       std::string get_underlying_channel_id () const;
+      bool is_underlying_channel_alive () const;
 
       void push (T_OUTGOING_MSG_ID a_outgoing_message_id, T_PAYLOAD &&a_payload);
       css_error_code send_recv (T_OUTGOING_MSG_ID a_outgoing_message_id, T_PAYLOAD &&a_request_payload,
@@ -235,6 +234,13 @@ namespace cubcomm
   request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::get_underlying_channel_id () const
   {
     return m_conn->get_channel ().get_channel_id ();
+  }
+
+  template <typename T_OUTGOING_MSG_ID, typename T_INCOMING_MSG_ID, typename T_PAYLOAD>
+  bool
+  request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::is_underlying_channel_alive () const
+  {
+    return m_conn->get_channel ().is_connection_alive ();
   }
 
   template <typename T_OUTGOING_MSG_ID, typename T_INCOMING_MSG_ID, typename T_PAYLOAD>

--- a/src/communication/request_sync_client_server.hpp
+++ b/src/communication/request_sync_client_server.hpp
@@ -286,14 +286,6 @@ namespace cubcomm
     std::tie (a_response_payload, error_code) = m_response_broker.get_response (rsn);
     if (error_code != NO_ERRORS)
       {
-	/*
-	 * Set CONNECTION_CLOSED as the error code if the internal socket is closed.
-	 * It lets the outside know that it's disconnected abnormally for some reason.
-	 */
-	if (!m_conn->get_channel ().is_connection_alive ())
-	  {
-	    error_code = CONNECTION_CLOSED;
-	  }
 	// clear payload
 	a_response_payload = T_PAYLOAD ();
       }

--- a/src/communication/request_sync_client_server.hpp
+++ b/src/communication/request_sync_client_server.hpp
@@ -73,8 +73,9 @@ namespace cubcomm
       void stop_incoming_communication_thread ();
       void stop_outgoing_communication_thread ();
 
+      /* only used by unit tests
+       */
       std::string get_underlying_channel_id () const;
-      bool is_underlying_channel_alive () const;
 
       void push (T_OUTGOING_MSG_ID a_outgoing_message_id, T_PAYLOAD &&a_payload);
       css_error_code send_recv (T_OUTGOING_MSG_ID a_outgoing_message_id, T_PAYLOAD &&a_request_payload,
@@ -234,13 +235,6 @@ namespace cubcomm
   request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::get_underlying_channel_id () const
   {
     return m_conn->get_channel ().get_channel_id ();
-  }
-
-  template <typename T_OUTGOING_MSG_ID, typename T_INCOMING_MSG_ID, typename T_PAYLOAD>
-  bool
-  request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::is_underlying_channel_alive () const
-  {
-    return m_conn->get_channel ().is_connection_alive ();
   }
 
   template <typename T_OUTGOING_MSG_ID, typename T_INCOMING_MSG_ID, typename T_PAYLOAD>

--- a/src/communication/request_sync_send_queue.hpp
+++ b/src/communication/request_sync_send_queue.hpp
@@ -197,6 +197,15 @@ namespace cubcomm
 	}
 	if (err_code != NO_ERRORS)
 	  {
+	    /*
+	     * Set CONNECTION_CLOSED as the error code if the internal socket is closed.
+	     * It lets the outside know that it's disconnected abnormally for some reason.
+	     */
+	    if (!m_client.get_channel ().is_connection_alive ())
+	      {
+		err_code = CONNECTION_CLOSED;
+	      }
+
 	    /* The send over socket is not - in and by itself - capable of detecting when the peer has
 	     * actully dropped the connection. It errors-out as an after effect (eg: when, maybe, the buffer
 	     * is full and there's no more space left to write new data).

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -457,35 +457,38 @@ tran_server::connection_handler::set_connection (cubcomm::channel &&chn)
   // TODO: to reduce contention as much as possible, should be equal to the maximum number
   // of active transactions that the system allows (PRM_ID_CSS_MAX_CLIENTS) + 1
 
-  cubcomm::send_queue_error_handler default_error_handler = [this]
-      (css_error_code error_code, bool &abort_further_processing)
-  {
-    abort_further_processing = false;
-
-    // Remove the connection_handler if the internal socket is closed. It's been disconnected abnormally.
-    if (error_code == CONNECTION_CLOSED)
-      {
-	abort_further_processing = true;
-	er_log_debug (ARG_FILE_LINE,
-		      "default_error_handler: an abnormal disconnection has been detected. channel id: %s.\n", get_channel_id ().c_str ());
-
-	constexpr auto with_disc_msg = false;
-	disconnect_async (with_disc_msg);
-      }
-    else
-      {
-	er_log_debug (ARG_FILE_LINE, "default_error_handler: error code: %d, channel id: %s.\n", error_code,
-		      get_channel_id ().c_str ());
-      }
-  };
+  auto error_handler = std::bind (&tran_server::connection_handler::default_error_handler, this,
+				  std::placeholders::_1, std::placeholders::_2);
 
   auto lockg_conn = std::lock_guard<std::shared_mutex> { m_conn_mtx };
 
   assert (m_conn == nullptr);
   m_conn.reset (new page_server_conn_t (std::move (chn), get_request_handlers (), tran_to_page_request::RESPOND,
-					page_to_tran_request::RESPOND, RESPONSE_PARTITIONING_SIZE, std::move (default_error_handler)));
+					page_to_tran_request::RESPOND, RESPONSE_PARTITIONING_SIZE, std::move (error_handler)));
 
   m_conn->start ();
+}
+
+void
+tran_server::connection_handler::default_error_handler (css_error_code error_code, bool &abort_further_processing)
+{
+  abort_further_processing = false;
+
+  // Remove the connection_handler if the internal socket is closed. It's been disconnected abnormally.
+  if (error_code == CONNECTION_CLOSED)
+    {
+      abort_further_processing = true;
+      er_log_debug (ARG_FILE_LINE,
+		    "default_error_handler: an abnormal disconnection has been detected. channel id: %s.\n", get_channel_id ().c_str ());
+
+      constexpr auto with_disc_msg = false;
+      disconnect_async (with_disc_msg);
+    }
+  else
+    {
+      er_log_debug (ARG_FILE_LINE, "default_error_handler: error code: %d, channel id: %s.\n", error_code,
+		    get_channel_id ().c_str ());
+    }
 }
 
 tran_server::connection_handler::~connection_handler ()

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -606,7 +606,8 @@ bool
 tran_server::connection_handler::is_connected ()
 {
   auto slock = std::shared_lock<std::shared_mutex> { m_state_mtx };
-  return m_state == state::CONNECTED;
+  /* state::CONNECTED guarantees that m_conn != nullptr */
+  return m_state == state::CONNECTED && m_conn->is_underlying_channel_alive ();
 }
 
 void

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -460,6 +460,8 @@ tran_server::connection_handler::set_connection (cubcomm::channel &&chn)
   cubcomm::send_queue_error_handler default_error_handler = [this]
       (css_error_code error_code, bool &abort_further_processing)
   {
+    abort_further_processing = false;
+
     // Remove the connection_handler if the internal socket is closed. It's been disconnected abnormally.
     if (error_code == CONNECTION_CLOSED)
       {

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -443,13 +443,11 @@ tran_server::connection_handler::set_connection (cubcomm::channel &&chn)
       (css_error_code error_code, bool &abort_further_processing)
   {
     // Remove the connection_handler if the internal socket is closed. It's been disconnected abnormally.
-    // m_conn can't be nullptr here because all request and error handler are digested befroe reset m_conn
     if (error_code == CONNECTION_CLOSED)
       {
 	abort_further_processing = true;
 	er_log_debug (ARG_FILE_LINE,
-		      "default_error_handler: an abnormal disconnection has been detected. error code: %d, channel id: %s.\n", error_code,
-		      get_channel_id ().c_str ());
+		      "default_error_handler: an abnormal disconnection has been detected. channel id: %s.\n", get_channel_id ().c_str ());
 
 	constexpr auto with_disc_msg = false;
 	disconnect_async (with_disc_msg);

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -444,7 +444,7 @@ tran_server::connection_handler::set_connection (cubcomm::channel &&chn)
   {
     // Remove the connection_handler if the internal socket is closed. It's been disconnected abnormally.
     // m_conn can't be nullptr here because all request and error handler are digested befroe reset m_conn
-    if (!m_conn->is_underlying_channel_alive ())
+    if (error_code == CONNECTION_CLOSED)
       {
 	abort_further_processing = true;
 	er_log_debug (ARG_FILE_LINE,
@@ -606,7 +606,7 @@ tran_server::connection_handler::send_receive (tran_to_page_request reqid, std::
   const css_error_code error_code = m_conn->send_recv (reqid, std::move (payload_in), payload_out);
   if (error_code != NO_ERRORS)
     {
-      if (!m_conn->is_underlying_channel_alive ())
+      if (error_code == CONNECTION_CLOSED)
 	{
 	  er_log_debug (ARG_FILE_LINE,
 			"sned_receive: an abnormal disconnection has been detected. error code: %d, channel id: %s.\n", error_code,

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -609,7 +609,7 @@ tran_server::connection_handler::send_receive (tran_to_page_request reqid, std::
       if (error_code == CONNECTION_CLOSED)
 	{
 	  er_log_debug (ARG_FILE_LINE,
-			"sned_receive: an abnormal disconnection has been detected. error code: %d, channel id: %s.\n", error_code,
+			"send_receive: an abnormal disconnection has been detected. error code: %d, channel id: %s.\n", error_code,
 			get_channel_id ().c_str ());
 
 	  slock_conn.unlock (); /* disconnect_async requires that m_conn_mtx and m_state_mtx are unlocked */

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -636,8 +636,7 @@ bool
 tran_server::connection_handler::is_connected ()
 {
   auto slock = std::shared_lock<std::shared_mutex> { m_state_mtx };
-  /* state::CONNECTED guarantees that m_conn != nullptr */
-  return m_state == state::CONNECTED && m_conn->is_underlying_channel_alive ();
+  return m_state == state::CONNECTED;
 }
 
 void

--- a/src/server/tran_server.hpp
+++ b/src/server/tran_server.hpp
@@ -164,6 +164,8 @@ class tran_server
 
       private:
 	void set_connection (cubcomm::channel &&chn);
+	// The default error handler for sending reqeust
+	void default_error_handler (css_error_code error_code, bool &abort_further_processing);
 	// Request handlers for requests in common
 	void receive_disconnect_request (page_server_conn_t::sequenced_payload &&a_sp);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-697

An error during communication is not spotted immediately. It's noticed when a request is pushed to the connection. The disconnection can be found when
- (A) push_request() : it's reported through the error handler given when setting the connection (`connection_handler::set_connection`).  
- send_receive()      : 
  - (B) while pushing a request: it's reported through the error handler given in the `request_sync_client_server::send_recv`
  - (C) while getting its response: it's never reported now.
 
When the connection is disconnected, the push() fails, its internal socket gets invalid (`channel:send`), and throws the error. The error code, in this case, is `ERROR_ON_WRITE`, but I set it to `CONNECTION_CLOSED` when the connection gets invalid to let the outside know that it's not just a write error, but the socket has been closed. And in each case:
- (A): If the error code is `CONNECTION_CLOSED`, clean up the connection_handler.
- (B): The current error handler set the error code and make it's returned to `get_response()`. So, I leave it as it is and deal with the case it's returned in `connection_handler::send_receive`. It's because `request_sync_client_server::send_recv` doesn't know connection_handler.
- (C): If push() succeeded and the connection fails while waiting for its response, there is no way for the waiter to know it. The subsequent request will fail, clean the connection_handler, and, in turn, let the waiter know the connection_handler got wrong so it's closed. (http://jira.cubrid.org/browse/LETS-762). In this case, the default error code, `ERROR_ON_WRITE` is returned. This is a walkaround and this should be addressed with a timeout for send_receive or something in a separate issue.
