### PR TITLE
[LETS-727][LETS-728] Define state of TS and PS

### DIFF
--- a/src/executables/master_heartbeat.c
+++ b/src/executables/master_heartbeat.c
@@ -3843,6 +3843,7 @@ hb_alloc_new_proc (void)
     {
       memset ((void *) p, 0, sizeof (HB_PROC_ENTRY));
       p->state = HB_PSTATE_UNKNOWN;
+      p->server_state = HB_SERVER_STATE_INIT;
       p->next = NULL;
       p->prev = NULL;
       p->being_shutdown = false;
@@ -5447,6 +5448,24 @@ hb_process_state_string (unsigned char ptype, int pstate)
       return HB_PSTATE_REGISTERED_AND_ACTIVE_STR;
     case HB_PSTATE_REGISTERED_AND_TO_BE_ACTIVE:
       return HB_PSTATE_REGISTERED_AND_TO_BE_ACTIVE_STR;
+    }
+
+  return "invalid";
+}
+
+const char *
+hb_server_state_string (int state)
+{
+  switch (state)
+    {
+    case HB_SERVER_STATE_INIT:
+      return HB_SERVER_STATE_INIT_STR;
+    case HB_SERVER_STATE_RECOVERY:
+      return HB_SERVER_STATE_RECOVERY_STR;
+    case HB_SERVER_STATE_RECOVERED:
+      return HB_SERVER_STATE_RECOVERED_STR;
+    case HB_SERVER_STATE_CATCH_UP:
+      return HB_SERVER_STATE_CATCH_UP_STR;
     }
 
   return "invalid";

--- a/src/executables/master_heartbeat.h
+++ b/src/executables/master_heartbeat.h
@@ -120,7 +120,8 @@ enum HB_PROC_STATE
 
 /* Heartbeat resource process detail state.
  * These states are to provide detailed information about server process
- * from start to the provision of the service.
+ * from start (HB_PSTATE_STARTED) to the provision of the service (HB_PSTATE_REGISTERED_*).
+ * When the server is ready to provide a service, then it does not need to show a detail state.
  */
 enum HB_SERVER_STATE
 {
@@ -128,13 +129,15 @@ enum HB_SERVER_STATE
   HB_SERVER_STATE_RECOVERY = 1,
   HB_SERVER_STATE_RECOVERED = 2,	/* only for PS */
   HB_SERVER_STATE_CATCH_UP = 3,	/* only for PS */
-  HB_SERVER_STATE_MAX
+  HB_SERVER_STATE_READY = 4	/* When the server is ready, then no detail state to be shown to user */
 };
 
-#define HB_SERVER_STATE_INIT_STR                "initial"
-#define HB_SERVER_STATE_RECOVERY_STR            "recovery"
-#define HB_SERVER_STATE_RECOVERED_STR           "recovered"
-#define HB_SERVER_STATE_CATCH_UP_STR            "catch_up"
+#define HB_SERVER_STATE_INIT_STR                "(initial)"	/* ex) state registered(initial) */
+#define HB_SERVER_STATE_RECOVERY_STR            "(recovery)"
+#define HB_SERVER_STATE_RECOVERED_STR           "(recovered)"
+#define HB_SERVER_STATE_CATCH_UP_STR            "(catch_up)"
+#define HB_SERVER_STATE_READY_STR                ""	/* Nothing to be shown */
+#define HB_SERVER_STATE_STR_SZ                   (16)
 
 /* heartbeat node score bitmask */
 #define HB_NODE_SCORE_MASTER                    0x8000

--- a/src/executables/master_heartbeat.h
+++ b/src/executables/master_heartbeat.h
@@ -118,6 +118,21 @@ enum HB_PROC_STATE
 
 #define HB_REPLICA_PRIORITY                     0x7FFF
 
+/* heartbeat resource process detail state */
+enum HB_SERVER_STATE
+{
+  HB_SERVER_STATE_INIT = 0,
+  HB_SERVER_STATE_RECOVERY = 1,
+  HB_SERVER_STATE_RECOVERED = 2,	/* only for PS */
+  HB_SERVER_STATE_CATCH_UP = 3,	/* only for PS */
+  HB_SERVER_STATE_MAX
+};
+
+#define HB_SERVER_STATE_INIT_STR                "initial"
+#define HB_SERVER_STATE_RECOVERY_STR            "recovery"
+#define HB_SERVER_STATE_RECOVERED_STR           "recovered"
+#define HB_SERVER_STATE_CATCH_UP_STR            "catch_up"
+
 /* heartbeat node score bitmask */
 #define HB_NODE_SCORE_MASTER                    0x8000
 #define HB_NODE_SCORE_TO_BE_MASTER              0xF000
@@ -278,6 +293,7 @@ struct HB_PROC_ENTRY
 
   unsigned char state;		/* process state */
   unsigned char type;		/* single/master-slave */
+  unsigned char server_state;	/* server state */
 
   int sfd;
 

--- a/src/executables/master_heartbeat.h
+++ b/src/executables/master_heartbeat.h
@@ -132,7 +132,7 @@ enum HB_SERVER_STATE
   HB_SERVER_STATE_READY = 4	/* When the server is ready, then no detail state to be shown to user */
 };
 
-#define HB_SERVER_STATE_INIT_STR                "(initial)"	/* ex) state registered(initial) */
+#define HB_SERVER_STATE_INIT_STR                "(initial)"	/* ex) state started(initial) */
 #define HB_SERVER_STATE_RECOVERY_STR            "(recovery)"
 #define HB_SERVER_STATE_RECOVERED_STR           "(recovered)"
 #define HB_SERVER_STATE_CATCH_UP_STR            "(catch_up)"

--- a/src/executables/master_heartbeat.h
+++ b/src/executables/master_heartbeat.h
@@ -118,7 +118,10 @@ enum HB_PROC_STATE
 
 #define HB_REPLICA_PRIORITY                     0x7FFF
 
-/* heartbeat resource process detail state */
+/* Heartbeat resource process detail state.
+ * These states are to provide detailed information about server process
+ * from start to the provision of the service.
+ */
 enum HB_SERVER_STATE
 {
   HB_SERVER_STATE_INIT = 0,
@@ -291,9 +294,9 @@ struct HB_PROC_ENTRY
   HB_PROC_ENTRY *next;
   HB_PROC_ENTRY **prev;
 
-  unsigned char state;		/* process state */
+  unsigned char state;		/* process state (HB_PROC_STATE) */
+  unsigned char server_state;	/* detailed server state (HB_SERVER_STATE) */
   unsigned char type;		/* single/master-slave */
-  unsigned char server_state;	/* server state */
 
   int sfd;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-727
http://jira.cubrid.org/browse/LETS-728

Purpose

Further refine the state representation when TS and PS are still unable to provide the service.
The refined states include 'initial', 'recovery', 'recovered', and 'catch-up'.

Please review the name of the state.
- 'initial' is the state that process is just started (forked)