### PR TITLE
[LETS-763] [Refactoring] Putting cubcomm::node into connection_handler in tran_server

### DIFF
--- a/src/communication/communication_node.hpp
+++ b/src/communication/communication_node.hpp
@@ -28,11 +28,11 @@ namespace cubcomm
   {
     public:
       node () = default;
-      node (const node &nd) = default;
+      node (const node &nd) = delete;
       node (node &&nd) = default;
       node (long port, std::string host);
 
-      node &operator= (const node &nd) = default;
+      node &operator= (const node &nd) = delete;
       node &operator= (node &&nd) = default;
 
       long get_port () const;

--- a/src/server/active_tran_server.cpp
+++ b/src/server/active_tran_server.cpp
@@ -131,8 +131,8 @@ active_tran_server::stop_outgoing_page_server_messages ()
 {
 }
 
-active_tran_server::connection_handler::connection_handler (tran_server &ts)
-  : tran_server::connection_handler (ts)
+active_tran_server::connection_handler::connection_handler (tran_server &ts, cubcomm::node &&node)
+  : tran_server::connection_handler (ts, std::move (node))
   ,m_saved_lsa { NULL_LSA }
 {
   m_prior_sender_sink_hook_func = std::bind (&tran_server::connection_handler::push_request, this,
@@ -200,8 +200,8 @@ active_tran_server::connection_handler::remove_prior_sender_sink ()
 }
 
 active_tran_server::connection_handler *
-active_tran_server::create_connection_handler (tran_server &ts) const
+active_tran_server::create_connection_handler (tran_server &ts, cubcomm::node &&node) const
 {
   // active_tran_server::connection_handler
-  return new connection_handler (ts);
+  return new connection_handler (ts, std::move (node));
 }

--- a/src/server/active_tran_server.hpp
+++ b/src/server/active_tran_server.hpp
@@ -42,7 +42,7 @@ class active_tran_server : public tran_server
     {
       public:
 	connection_handler () = delete;
-	connection_handler (tran_server &ts);
+	connection_handler (tran_server &ts, cubcomm::node &&node);
 
 	connection_handler (const connection_handler &) = delete;
 	connection_handler (connection_handler &&) = delete;
@@ -70,7 +70,7 @@ class active_tran_server : public tran_server
     bool get_remote_storage_config () final override;
 
     void stop_outgoing_page_server_messages () final override;
-    connection_handler *create_connection_handler (tran_server &ts) const final override;
+    connection_handler *create_connection_handler (tran_server &ts, cubcomm::node &&node) const final override;
 
   private:
     bool m_uses_remote_storage = false;

--- a/src/server/passive_tran_server.cpp
+++ b/src/server/passive_tran_server.cpp
@@ -206,10 +206,10 @@ void passive_tran_server::wait_replication_past_target_lsa (LOG_LSA lsa)
 }
 
 passive_tran_server::connection_handler *
-passive_tran_server::create_connection_handler (tran_server &ts) const
+passive_tran_server::create_connection_handler (tran_server &ts, cubcomm::node &&node) const
 {
   // passive_tran_server::connection_handler
-  return new connection_handler (ts);
+  return new connection_handler (ts, std::move (node));
 }
 
 void

--- a/src/server/passive_tran_server.hpp
+++ b/src/server/passive_tran_server.hpp
@@ -50,8 +50,8 @@ class passive_tran_server : public tran_server
     {
       public:
 	connection_handler () = delete;
-	connection_handler (tran_server &ts)
-	  : tran_server::connection_handler (ts)
+	connection_handler (tran_server &ts, cubcomm::node &&node)
+	  : tran_server::connection_handler (ts, std::move (node))
 	{ }
 
 	connection_handler (const connection_handler &) = delete;
@@ -76,7 +76,7 @@ class passive_tran_server : public tran_server
     bool get_remote_storage_config () final override;
 
     void stop_outgoing_page_server_messages () final override;
-    connection_handler *create_connection_handler (tran_server &ts) const final override;
+    connection_handler *create_connection_handler (tran_server &ts, cubcomm::node &&node) const final override;
 
   private:
     std::unique_ptr<cublog::atomic_replicator> m_replicator;

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -74,8 +74,7 @@ tran_server::create_connection_with_server_host (const std::string &host)
   m_ps_hostname = host.substr (0, col_pos);
   er_log_debug (ARG_FILE_LINE, "Page server hosts: %s port: %d\n", m_ps_hostname.c_str (), port);
 
-  cubcomm::node conn{port, m_ps_hostname};
-  m_connection_list.push_back (conn);
+  m_page_server_conn_vec.emplace_back (create_connection_handler (*this, {port, m_ps_hostname}));
 
   return NO_ERROR;
 }
@@ -236,7 +235,7 @@ tran_server::init_page_server_hosts ()
     }
 
   int exit_code = create_connections_with_server_hosts_config (hosts);
-  if (m_connection_list.empty ())
+  if (m_page_server_conn_vec.empty ())
     {
       // no valid hosts
       int exit_code = ER_HOST_PORT_PARAMETER;
@@ -254,11 +253,9 @@ tran_server::init_page_server_hosts ()
   //
   int valid_connection_count = 0;
   bool failed_conn = false;
-  for (const cubcomm::node &node : m_connection_list)
+  for (const auto &conn : m_page_server_conn_vec)
     {
-      /* create a empty connection_handler specialized for each tran serve type */
-      m_page_server_conn_vec.emplace_back (create_connection_handler (*this));
-      exit_code = m_page_server_conn_vec.back ()->connect (node);
+      exit_code = conn->connect ();
       if (exit_code == NO_ERROR)
 	{
 	  ++valid_connection_count;
@@ -266,7 +263,6 @@ tran_server::init_page_server_hosts ()
       else
 	{
 	  failed_conn = true;
-	  er_log_debug (ARG_FILE_LINE, "Failed to connect to host: %s port: %d\n", node.get_host ().c_str (), node.get_port ());
 	}
     }
   reset_main_connection ();
@@ -322,13 +318,13 @@ tran_server::get_boot_info_from_page_server ()
 }
 
 int
-tran_server::connection_handler::connect (const cubcomm::node &node)
+tran_server::connection_handler::connect ()
 {
-  auto ps_conn_error_lambda = [&node, this] (const std::lock_guard<std::shared_mutex> &)
+  auto ps_conn_error_lambda = [this] (const std::lock_guard<std::shared_mutex> &)
   {
     m_state = state::IDLE;
 
-    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_NET_PAGESERVER_CONNECTION, 1, node.get_host ().c_str ());
+    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_NET_PAGESERVER_CONNECTION, 1, m_node.get_host ().c_str ());
     return ER_NET_PAGESERVER_CONNECTION;
   };
 
@@ -345,7 +341,7 @@ tran_server::connection_handler::connect (const cubcomm::node &node)
 
   srv_chn.set_channel_name ("TS_PS_comm");
 
-  css_error_code comm_error_code = srv_chn.connect (node.get_host ().c_str (), node.get_port (),
+  css_error_code comm_error_code = srv_chn.connect (m_node.get_host ().c_str (), m_node.get_port (),
 				   CMD_SERVER_SERVER_CONNECT);
   if (comm_error_code != css_error_code::NO_ERRORS)
     {
@@ -661,19 +657,15 @@ tran_server::ps_connector::terminate ()
 void
 tran_server::ps_connector::try_connect_to_all_ps (cubthread::entry &)
 {
-  /* Assume that they store PS information in the same order.
-   * TODO: combine two vectors */
-  assert (m_ts.m_connection_list.size () == m_ts.m_page_server_conn_vec.size());
-
-  for (size_t i = 0; i < m_ts.m_page_server_conn_vec.size (); i++)
+  for (const auto &conn : m_ts.m_page_server_conn_vec)
     {
-      if (m_ts.m_page_server_conn_vec[i]->is_idle ())
+      if (conn->is_idle ())
 	{
 	  /*
 	   * TODO It can be too verbose now since it always complain to fail to connect when a PS has been stopped.
 	   * Later on, this job is going to be triggered by a cluster manager or cub_master when a PS is ready to connect.
 	   */
-	  m_ts.m_page_server_conn_vec[i]->connect (m_ts.m_connection_list[i]);
+	  conn->connect ();
 	}
 
       if (m_terminate.load ())

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -43,7 +43,7 @@ tran_server::~tran_server ()
 }
 
 int
-tran_server::add_connection_handler (const std::string &host)
+tran_server::register_connection_handler (const std::string &host)
 {
   std::string m_ps_hostname;
   auto col_pos = host.find (":");
@@ -80,7 +80,7 @@ tran_server::add_connection_handler (const std::string &host)
 }
 
 int
-tran_server::create_connection_handlers (std::string &hosts)
+tran_server::register_connection_handlers (std::string &hosts)
 {
   auto col_pos = hosts.find (":");
 
@@ -100,12 +100,12 @@ tran_server::create_connection_handlers (std::string &hosts)
       std::string token = hosts.substr (0, pos);
       hosts.erase (0, pos + delimiter.length ());
 
-      if (add_connection_handler (token) != NO_ERROR)
+      if (register_connection_handler (token) != NO_ERROR)
 	{
 	  exit_code = ER_HOST_PORT_PARAMETER;
 	}
     }
-  if (add_connection_handler (hosts) != NO_ERROR)
+  if (register_connection_handler (hosts) != NO_ERROR)
     {
       exit_code = ER_HOST_PORT_PARAMETER;
     }
@@ -234,7 +234,7 @@ tran_server::init_page_server_hosts ()
 	}
     }
 
-  int exit_code = create_connection_handlers (hosts);
+  int exit_code = register_connection_handlers (hosts);
   if (m_page_server_conn_vec.empty ())
     {
       // no valid hosts

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -43,7 +43,7 @@ tran_server::~tran_server ()
 }
 
 int
-tran_server::parse_server_host (const std::string &host)
+tran_server::create_connection_with_server_host (const std::string &host)
 {
   std::string m_ps_hostname;
   auto col_pos = host.find (":");
@@ -81,7 +81,7 @@ tran_server::parse_server_host (const std::string &host)
 }
 
 int
-tran_server::parse_page_server_hosts_config (std::string &hosts)
+tran_server::create_connections_with_server_hosts_config (std::string &hosts)
 {
   auto col_pos = hosts.find (":");
 
@@ -101,12 +101,12 @@ tran_server::parse_page_server_hosts_config (std::string &hosts)
       std::string token = hosts.substr (0, pos);
       hosts.erase (0, pos + delimiter.length ());
 
-      if (parse_server_host (token) != NO_ERROR)
+      if (create_connection_with_server_host (token) != NO_ERROR)
 	{
 	  exit_code = ER_HOST_PORT_PARAMETER;
 	}
     }
-  if (parse_server_host (hosts) != NO_ERROR)
+  if (create_connection_with_server_host (hosts) != NO_ERROR)
     {
       exit_code = ER_HOST_PORT_PARAMETER;
     }
@@ -235,7 +235,7 @@ tran_server::init_page_server_hosts ()
 	}
     }
 
-  int exit_code = parse_page_server_hosts_config (hosts);
+  int exit_code = create_connections_with_server_hosts_config (hosts);
   if (m_connection_list.empty ())
     {
       // no valid hosts

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -43,7 +43,7 @@ tran_server::~tran_server ()
 }
 
 int
-tran_server::create_connection_with_server_host (const std::string &host)
+tran_server::add_connection_handler (const std::string &host)
 {
   std::string m_ps_hostname;
   auto col_pos = host.find (":");
@@ -80,7 +80,7 @@ tran_server::create_connection_with_server_host (const std::string &host)
 }
 
 int
-tran_server::create_connections_with_server_hosts_config (std::string &hosts)
+tran_server::create_connection_handlers (std::string &hosts)
 {
   auto col_pos = hosts.find (":");
 
@@ -100,12 +100,12 @@ tran_server::create_connections_with_server_hosts_config (std::string &hosts)
       std::string token = hosts.substr (0, pos);
       hosts.erase (0, pos + delimiter.length ());
 
-      if (create_connection_with_server_host (token) != NO_ERROR)
+      if (add_connection_handler (token) != NO_ERROR)
 	{
 	  exit_code = ER_HOST_PORT_PARAMETER;
 	}
     }
-  if (create_connection_with_server_host (hosts) != NO_ERROR)
+  if (add_connection_handler (hosts) != NO_ERROR)
     {
       exit_code = ER_HOST_PORT_PARAMETER;
     }
@@ -234,7 +234,7 @@ tran_server::init_page_server_hosts ()
 	}
     }
 
-  int exit_code = create_connections_with_server_hosts_config (hosts);
+  int exit_code = create_connection_handlers (hosts);
   if (m_page_server_conn_vec.empty ())
     {
       // no valid hosts

--- a/src/server/tran_server.hpp
+++ b/src/server/tran_server.hpp
@@ -169,7 +169,7 @@ class tran_server
 	void receive_disconnect_request (page_server_conn_t::sequenced_payload &&a_sp);
 
       private:
-	cubcomm::node m_node;
+	const cubcomm::node m_node;
 
 	std::unique_ptr<page_server_conn_t> m_conn;
 	std::shared_mutex m_conn_mtx;

--- a/src/server/tran_server.hpp
+++ b/src/server/tran_server.hpp
@@ -235,8 +235,8 @@ class tran_server
     int get_boot_info_from_page_server ();
     int reset_main_connection ();
 
-    int create_connection_handlers (std::string &hosts);
-    int add_connection_handler (const std::string &host);
+    int register_connection_handlers (std::string &hosts);
+    int register_connection_handler (const std::string &host);
 
   private:
     cubcomm::server_server m_conn_type;

--- a/src/server/tran_server.hpp
+++ b/src/server/tran_server.hpp
@@ -233,8 +233,8 @@ class tran_server
     int get_boot_info_from_page_server ();
     int reset_main_connection ();
 
-    int parse_server_host (const std::string &host);
-    int parse_page_server_hosts_config (std::string &hosts);
+    int create_connection_with_server_host (const std::string &host);
+    int create_connections_with_server_hosts_config (std::string &hosts);
 
   private:
     cubcomm::server_server m_conn_type;

--- a/src/server/tran_server.hpp
+++ b/src/server/tran_server.hpp
@@ -235,8 +235,8 @@ class tran_server
     int get_boot_info_from_page_server ();
     int reset_main_connection ();
 
-    int create_connection_with_server_host (const std::string &host);
-    int create_connections_with_server_hosts_config (std::string &hosts);
+    int create_connection_handlers (std::string &hosts);
+    int add_connection_handler (const std::string &host);
 
   private:
     cubcomm::server_server m_conn_type;


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-763

- connection_handler contains cubcomm::node.
- connection_handlers are created when parsing host_node.
