### PR TITLE
[CBRD-24684] fix mis-modified: divide operation result into numeric type

### DIFF
--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -3845,7 +3845,7 @@ pt_copypush_terms (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * query, PT_
 
       /* alias name: cublink */
       rewritten = pt_append_bytes (parser, rewritten, ") cublink", 9);
-#if 0
+
       if (query->info.dblink_table.cols != NULL)
 	{
 	  /* aliased column list */
@@ -3854,7 +3854,7 @@ pt_copypush_terms (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * query, PT_
 	  rewritten = pt_append_varchar (parser, rewritten, col_list);
 	  rewritten = pt_append_bytes (parser, rewritten, ")", 1);
 	}
-#endif
+
       if (pushed_pred != NULL)
 	{
 	  /* where predicate */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24684

dblink-related codes that are not related to this issue are reflected and need to be modified.