### PR TITLE
[CBRD-24875] min, max functions results have a strange

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -16394,7 +16394,15 @@ btree_find_min_or_max_key (THREAD_ENTRY * thread_p, BTID * btid, DB_VALUE * key,
    * in case of desc domain index,
    * we have to find the min/max key in opposite order.
    */
-  if (BTS->btid_int.key_type->is_desc)
+
+  if (TP_DOMAIN_TYPE (BTS->btid_int.key_type) == DB_TYPE_MIDXKEY)
+    {
+      if (BTS->btid_int.key_type->setdomain->is_desc)
+	{
+	  find_min_key = !find_min_key;
+	}
+    }
+  else if (BTS->btid_int.key_type->is_desc)
     {
       find_min_key = !find_min_key;
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24875

*  Modify to consider the case of DB_TYPE_MIDXKEY when determining BTS->use_desc_index in btree_find_min_or_max_key().
