### PR TITLE
[LETS-766] Add/Remove sink_hook on connecting/disconnecting

### DIFF
--- a/src/server/active_tran_server.cpp
+++ b/src/server/active_tran_server.cpp
@@ -186,6 +186,20 @@ active_tran_server::connection_handler::get_saved_lsa () const
 }
 
 void
+active_tran_server::connection_handler::on_connecting ()
+{
+  m_prior_sender_sink_hook_func = std::bind (&tran_server::connection_handler::push_request, this,
+				  tran_to_page_request::SEND_LOG_PRIOR_LIST, std::placeholders::_1);
+  log_Gl.m_prior_sender.add_sink (m_prior_sender_sink_hook_func);
+}
+
+void
+active_tran_server::connection_handler::on_disconnecting ()
+{
+  remove_prior_sender_sink ();
+}
+
+void
 active_tran_server::connection_handler::remove_prior_sender_sink ()
 {
   /*

--- a/src/server/active_tran_server.cpp
+++ b/src/server/active_tran_server.cpp
@@ -135,14 +135,11 @@ active_tran_server::connection_handler::connection_handler (tran_server &ts, cub
   : tran_server::connection_handler (ts, std::move (node))
   ,m_saved_lsa { NULL_LSA }
 {
-  m_prior_sender_sink_hook_func = std::bind (&tran_server::connection_handler::push_request, this,
-				  tran_to_page_request::SEND_LOG_PRIOR_LIST, std::placeholders::_1);
-  log_Gl.m_prior_sender.add_sink (m_prior_sender_sink_hook_func);
 }
 
 active_tran_server::connection_handler::~connection_handler ()
 {
-  remove_prior_sender_sink ();
+  assert (m_prior_sender_sink_hook_func == nullptr);
 }
 
 active_tran_server::connection_handler::request_handlers_map_t
@@ -197,12 +194,6 @@ active_tran_server::connection_handler::on_connecting ()
 
 void
 active_tran_server::connection_handler::on_disconnecting ()
-{
-  remove_prior_sender_sink ();
-}
-
-void
-active_tran_server::connection_handler::remove_prior_sender_sink ()
 {
   if (m_prior_sender_sink_hook_func != nullptr)
     {

--- a/src/server/active_tran_server.cpp
+++ b/src/server/active_tran_server.cpp
@@ -188,6 +188,8 @@ active_tran_server::connection_handler::get_saved_lsa () const
 void
 active_tran_server::connection_handler::on_connecting ()
 {
+  assert (m_prior_sender_sink_hook_func == nullptr);
+
   m_prior_sender_sink_hook_func = std::bind (&tran_server::connection_handler::push_request, this,
 				  tran_to_page_request::SEND_LOG_PRIOR_LIST, std::placeholders::_1);
   log_Gl.m_prior_sender.add_sink (m_prior_sender_sink_hook_func);
@@ -202,11 +204,7 @@ active_tran_server::connection_handler::on_disconnecting ()
 void
 active_tran_server::connection_handler::remove_prior_sender_sink ()
 {
-  /*
-   * Now, it's removed only when disconencting all page servers during shutdown.
-   * TODO: used when abnormal or normal disonnection of PS. It may need a latch.
-   */
-  if (static_cast<bool> (m_prior_sender_sink_hook_func))
+  if (m_prior_sender_sink_hook_func != nullptr)
     {
       log_Gl.m_prior_sender.remove_sink (m_prior_sender_sink_hook_func);
       m_prior_sender_sink_hook_func = nullptr;

--- a/src/server/active_tran_server.hpp
+++ b/src/server/active_tran_server.hpp
@@ -54,7 +54,6 @@ class active_tran_server : public tran_server
 
       private:
 	request_handlers_map_t get_request_handlers () final override;
-	void remove_prior_sender_sink ();
 
 	// request handlers
 	void receive_saved_lsa (page_server_conn_t::sequenced_payload &&a_sp);

--- a/src/server/active_tran_server.hpp
+++ b/src/server/active_tran_server.hpp
@@ -61,6 +61,9 @@ class active_tran_server : public tran_server
 
 	log_lsa get_saved_lsa () const override final;
 
+	void on_connecting () override final;
+	void on_disconnecting () override final;
+
       private:
 	cublog::prior_sender::sink_hook_t m_prior_sender_sink_hook_func;
 	std::atomic<log_lsa> m_saved_lsa;

--- a/src/server/passive_tran_server.cpp
+++ b/src/server/passive_tran_server.cpp
@@ -64,6 +64,16 @@ passive_tran_server::connection_handler::get_saved_lsa () const
 }
 
 void
+passive_tran_server::connection_handler::on_connecting ()
+{
+}
+
+void
+passive_tran_server::connection_handler::on_disconnecting ()
+{
+}
+
+void
 passive_tran_server::stop_outgoing_page_server_messages ()
 {
   cubthread::get_manager ()->destroy_daemon (m_oldest_active_mvccid_sender);

--- a/src/server/passive_tran_server.hpp
+++ b/src/server/passive_tran_server.hpp
@@ -65,6 +65,9 @@ class passive_tran_server : public tran_server
       private:
 	request_handlers_map_t get_request_handlers () final override;
 
+	void on_connecting () override final;
+	void on_disconnecting () override final;
+
 	/* reuqest handlers */
 	void receive_log_prior_list (page_server_conn_t::sequenced_payload &&a_sp);
     };

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -478,7 +478,7 @@ tran_server::connection_handler::~connection_handler ()
 void
 tran_server::connection_handler::disconnect_async (bool with_disc_msg)
 {
-  auto lockg = std::lock_guard <std::shared_mutex> { m_state_mtx };
+  auto ulock = std::unique_lock <std::shared_mutex> { m_state_mtx };
 
   if (m_state == state::IDLE || m_state == state::DISCONNECTING)
     {
@@ -487,6 +487,8 @@ tran_server::connection_handler::disconnect_async (bool with_disc_msg)
 
   assert (m_state == state::CONNECTING || m_state == state::CONNECTED);
   m_state = state::DISCONNECTING;
+
+  ulock.unlock();
 
   on_disconnecting (); // server-type specific jobs before disconnect
 

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -363,11 +363,10 @@ tran_server::connection_handler::connect ()
       return ps_conn_error_lambda (lockg_state);
     }
 
-  // NOTE: only the base class part (cubcomm::channel) of a cubcomm::server_channel instance is
-  // moved as argument below
   set_connection (std::move (srv_chn));
 
-  // TODO initailizing jobs will be triggered such as the catch-up process. state::CONNECTED will be set asynchronously when it's done.
+  // Do the preliminary jobs depending on the server type before opening the conneciton to the outisde.
+  on_connecting ();
 
   m_state = state::CONNECTED;
 
@@ -483,6 +482,8 @@ tran_server::connection_handler::disconnect_async (bool with_disc_msg)
 
   assert (m_state == state::CONNECTING || m_state == state::CONNECTED);
   m_state = state::DISCONNECTING;
+
+  on_disconnecting (); // server-type specific jobs before disconnect
 
   m_disconn_future = std::async (std::launch::async, [this, with_disc_msg]
   {

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -330,48 +330,53 @@ tran_server::connection_handler::connect ()
 
   assert_is_tran_server ();
 
-  auto lockg_state = std::lock_guard<std::shared_mutex> { m_state_mtx };
-  assert (m_state == state::IDLE);
+  {
+    auto lockg_state = std::lock_guard<std::shared_mutex> { m_state_mtx };
+    assert (m_state == state::IDLE);
 
-  m_state = state::CONNECTING;
+    m_state = state::CONNECTING;
 
-  // connect to page server
-  constexpr int CHANNEL_POLL_TIMEOUT = 1000;    // 1000 milliseconds = 1 second
-  cubcomm::server_channel srv_chn (m_ts.m_server_name.c_str (), SERVER_TYPE_PAGE, CHANNEL_POLL_TIMEOUT);
+    // connect to page server
+    constexpr int CHANNEL_POLL_TIMEOUT = 1000;    // 1000 milliseconds = 1 second
+    cubcomm::server_channel srv_chn (m_ts.m_server_name.c_str (), SERVER_TYPE_PAGE, CHANNEL_POLL_TIMEOUT);
 
-  srv_chn.set_channel_name ("TS_PS_comm");
+    srv_chn.set_channel_name ("TS_PS_comm");
 
-  css_error_code comm_error_code = srv_chn.connect (m_node.get_host ().c_str (), m_node.get_port (),
-				   CMD_SERVER_SERVER_CONNECT);
-  if (comm_error_code != css_error_code::NO_ERRORS)
-    {
-      return ps_conn_error_lambda (lockg_state);
-    }
+    css_error_code comm_error_code = srv_chn.connect (m_node.get_host ().c_str (), m_node.get_port (),
+				     CMD_SERVER_SERVER_CONNECT);
+    if (comm_error_code != css_error_code::NO_ERRORS)
+      {
+	return ps_conn_error_lambda (lockg_state);
+      }
 
-  if (srv_chn.send_int (static_cast<int> (m_ts.m_conn_type)) != NO_ERRORS)
-    {
-      return ps_conn_error_lambda (lockg_state);
-    }
+    if (srv_chn.send_int (static_cast<int> (m_ts.m_conn_type)) != NO_ERRORS)
+      {
+	return ps_conn_error_lambda (lockg_state);
+      }
 
-  int returned_code;
-  if (srv_chn.recv_int (returned_code) != css_error_code::NO_ERRORS)
-    {
-      return ps_conn_error_lambda (lockg_state);
-    }
-  if (returned_code != static_cast<int> (m_ts.m_conn_type))
-    {
-      return ps_conn_error_lambda (lockg_state);
-    }
+    int returned_code;
+    if (srv_chn.recv_int (returned_code) != css_error_code::NO_ERRORS)
+      {
+	return ps_conn_error_lambda (lockg_state);
+      }
+    if (returned_code != static_cast<int> (m_ts.m_conn_type))
+      {
+	return ps_conn_error_lambda (lockg_state);
+      }
 
-  set_connection (std::move (srv_chn));
+    set_connection (std::move (srv_chn));
+
+    er_log_debug (ARG_FILE_LINE, "Transaction server successfully connected to the page server. Channel id: %s.\n",
+		  srv_chn.get_channel_id ().c_str ());
+  }
 
   // Do the preliminary jobs depending on the server type before opening the conneciton to the outisde.
   on_connecting ();
 
-  m_state = state::CONNECTED;
+  auto lockg_state = std::lock_guard<std::shared_mutex> { m_state_mtx };
+  assert (m_state == state::CONNECTING);
 
-  er_log_debug (ARG_FILE_LINE, "Transaction server successfully connected to the page server. Channel id: %s.\n",
-		srv_chn.get_channel_id ().c_str ());
+  m_state = state::CONNECTED;
 
   return NO_ERROR;
 }

--- a/src/server/tran_server.hpp
+++ b/src/server/tran_server.hpp
@@ -130,6 +130,15 @@ class tran_server
 
 	virtual request_handlers_map_t get_request_handlers ();
 
+	/*
+	 * Do the server-type-specific jobs before state transtition.
+	 *
+	 * on_connecting:     CONNECTING -> (*) -> CONNECTED
+	 * on_disconnecting:  DISCONNECTING -> (*) -> IDLE
+	 */
+	virtual void on_connecting () = 0;
+	virtual void on_disconnecting () = 0;
+
       protected:
 	tran_server &m_ts;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-766

The sink_hook for sending prior lists to PS was added on the ctor and removed on the dtor of the connection_handler. But now the connection_handler is destroyed with the server. It must be added and removed on connect and disconnect.

- Add pure virtual function: on_connecting() and on_disconnecting(). It's called between the state transition:
  -  on_connecting:     CONNECTING -> (*) -> CONNECTED
  -  on_disconnecting:  DISCONNECTING -> (*) -> IDLE
- Each server type defines its own preliminary jobs for connecting and disconnecting those functions. The add/remove are there.