### PR TITLE
[CBRD-24684] bug-fix: divide operation result into NUMERIC type

### DIFF
--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -4479,7 +4479,7 @@ pt_limit_to_numbering_expr (PARSER_CONTEXT * parser, PT_NODE * limit, PT_OP_TYPE
       else
 	{
 	  sum->data_type->info.data_type.dec_precision = 0;
-	  sum->info.expr.arg2 = parser_copy_tree (parser, limit);
+	  sum->info.expr.arg1 = parser_copy_tree (parser, limit);
 	}
 
       sum->info.expr.arg2 = parser_copy_tree (parser, limit->next);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24684

If limit and offset include a division operation, the between logic is created for inst_num() as shown below.

`limit 7/4 offset 1/2 --> inst_num() > 1/2 and inst_num() <= 1/2 + 7/4`
But in this calculation logic, 1/2 + 7/4 = 2.25 returns wrong result.
The query result below should have 1 row, but a wrong result occurs that brings 2 rows.

`select rownum from db_class limit 7/4 offset 1/2; `
To correct this, we need to treat 1/2 as floor(1/2).

`select rownum from db_class limit 7/4 offset 1/2`
What this query means is to get 7/4 results from offset 1/2.
That is, since we need to get 1.25 results from offset 0.5, we will get 1 result. Because 1.75 is less than 2.
When processing this in a query, it is processed as getting a result between 0.5 and (0.5 + 1.75) of the results. Here, 1/2 or 0.5 offset is not a problem, but the latter part becomes 0.5 + 1.75 = 2.25, so the number of results is 2. That is, 0.5 + 1.75 should be calculated as 0 + 1.75.