### PR TITLE
[CBRD-24860] Implement functions related to memory tracking for Memory Monitoring Manager Module

### DIFF
--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -465,11 +465,8 @@ namespace cubperf
 
     if (thread_p)
       {
-	tdes = LOG_FIND_TDES (thread_p->tran_index);
-	if (tdes != NULL)
-	  {
-	    tdes->cur_mem_usage += size;
-	  }
+	tdes = LOG_FIND_CURRENT_TDES (thread_p);
+	tdes->cur_mem_usage += size;
       }
   }
 
@@ -492,11 +489,8 @@ namespace cubperf
 
     if (thread_p)
       {
-	tdes = LOG_FIND_TDES (thread_p->tran_index);
-	if (tdes != NULL)
-	  {
-	    tdes->cur_mem_usage -= size;
-	  }
+	tdes = LOG_FIND_CURRENT_TDES (thread_p);
+	tdes->cur_mem_usage -= size;
       }
   }
 

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -317,7 +317,7 @@ namespace cubperf
 	      {
 		comp_idx = add_component (info[idx].comp_name);
 	      }
-	    /* XXX: add error if comp_idx > MAX_COMP_IDX */
+	    assert (comp_idx < MAX_COMP_IDX);
 
 	    if (info[idx].subcomp_name)
 	      {
@@ -331,7 +331,7 @@ namespace cubperf
 		  {
 		    subcomp_idx = m_component[comp_idx]->add_subcomponent (info[idx].subcomp_name);
 		  }
-		/* XXX: add error if subcomp_idx > MAX_SUBCOMP_IDX */
+		assert (subcomp_idx < MAX_COMP_IDX);
 	      }
 	    else
 	      {

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -439,12 +439,7 @@ namespace cubperf
     m_module[module_idx]->add_stat (size, comp_idx, subcomp_idx, allocation_at_init);
 
     tdes = LOG_FIND_CURRENT_TDES (thread_p);
-    if (tdes == NULL)
-      {
-	er_set (ER_FATAL_ERROR_SEVERITY, ARG_FILE_LINE, ER_LOG_UNKNOWN_TRANINDEX, 1, LOG_FIND_THREAD_TRAN_INDEX (thread_p));
-	/* for code protection */
-	assert (tdes != NULL);
-      }
+    assert (tdes != NULL);
     tdes->cur_mem_usage += size;
   }
 
@@ -466,12 +461,7 @@ namespace cubperf
     m_module[module_idx]->sub_stat (size, comp_idx, subcomp_idx, deallocation_at_init);
 
     tdes = LOG_FIND_CURRENT_TDES (thread_p);
-    if (tdes == NULL)
-      {
-	er_set (ER_FATAL_ERROR_SEVERITY, ARG_FILE_LINE, ER_LOG_UNKNOWN_TRANINDEX, 1, LOG_FIND_THREAD_TRAN_INDEX (thread_p));
-	/* for code protection */
-	assert (tdes != NULL);
-      }
+    assert (tdes != NULL);
     tdes->cur_mem_usage -= size;
   }
 

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -121,13 +121,13 @@ namespace cubperf
       void add_expand_count (MMON_STAT_ID stat_id);
       void end_init_phase ();
       int add_component (const char *name);
-      inline int make_comp_idx_map_val (int comp_idx, int subcomp_idx);
 
     private:
-      void get_comp_and_subcomp_idx (MMON_STAT_ID stat_id, int &comp_idx, int &subcomp_idx);
-      inline int get_comp_map_idx (MMON_STAT_ID stat_id);
-      inline int get_comp_idx (int comp_idx_map_val);
-      inline int get_subcomp_idx (int comp_idx_map_val);
+      void get_comp_and_subcomp_idx (MMON_STAT_ID stat_id, int &comp_idx, int &subcomp_idx) const;
+      inline int make_comp_idx_map_val (int comp_idx, int subcomp_idx) const;
+      inline int get_comp_map_idx (MMON_STAT_ID stat_id) const;
+      inline int get_comp_idx (int comp_idx_map_val) const;
+      inline int get_subcomp_idx (int comp_idx_map_val) const;
 
     private:
       std::string m_module_name;
@@ -190,28 +190,29 @@ namespace cubperf
       std::unique_ptr<mmon_module> m_module[MMON_MODULE_LAST];
   };
 
-  inline int mmon_module::make_comp_idx_map_val (int comp_idx, int subcomp_idx)
+  inline int mmon_module::make_comp_idx_map_val (int comp_idx, int subcomp_idx) const
   {
     return (comp_idx << 16 | subcomp_idx);
   }
 
-  inline int mmon_module::get_comp_map_idx (MMON_STAT_ID stat_id)
+  inline int mmon_module::get_comp_map_idx (MMON_STAT_ID stat_id) const
   {
     return (((int) stat_id) & MMON_PARSE_MASK);
   }
-  inline int memory_monitor::get_module_idx (MMON_STAT_ID stat_id) const
-  {
-    return (((int) stat_id) >> 16);
-  }
 
-  inline int mmon_module::get_comp_idx (int comp_idx_map_val)
+  inline int mmon_module::get_comp_idx (int comp_idx_map_val) const
   {
     return (comp_idx_map_val >> 16);
   }
 
-  inline int mmon_module::get_subcomp_idx (int comp_idx_map_val)
+  inline int mmon_module::get_subcomp_idx (int comp_idx_map_val) const
   {
     return (comp_idx_map_val & MMON_PARSE_MASK);
+  }
+
+  inline int memory_monitor::get_module_idx (MMON_STAT_ID stat_id) const
+  {
+    return (((int) stat_id) >> 16);
   }
 
   const char *mmon_subcomponent::get_name ()
@@ -339,7 +340,7 @@ namespace cubperf
     return error;
   }
 
-  void mmon_module::get_comp_and_subcomp_idx (MMON_STAT_ID stat_id, int &comp_idx, int &subcomp_idx)
+  void mmon_module::get_comp_and_subcomp_idx (MMON_STAT_ID stat_id, int &comp_idx, int &subcomp_idx) const
   {
     int comp_map_idx = get_comp_map_idx (stat_id);
     int idx_map_val;

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -333,14 +333,10 @@ namespace cubperf
 		  }
 		assert (subcomp_idx < MAX_COMP_IDX);
 	      }
-	    else
-	      {
-		assert (info[idx].subcomp_name == NULL);
-	      }
 	  }
 	else
 	  {
-	    assert (info[idx].comp_name == NULL);
+	    assert (info[idx].subcomp_name == NULL);
 	  }
 
 	m_comp_idx_map.push_back (make_comp_idx_map_val (comp_idx, subcomp_idx));
@@ -446,12 +442,7 @@ namespace cubperf
     int module_idx = MMON_GET_MODULE_IDX_FROM_STAT_ID (stat_id);
     int comp_map_idx = MMON_GET_COMP_MAP_IDX_FROM_STAT_ID (stat_id);
     int idx_map_val, comp_idx, subcomp_idx;
-    bool allocation_at_init = false;
-
-    if (!LOG_ISRESTARTED ())
-      {
-	allocation_at_init = true;
-      }
+    bool allocation_at_init = !LOG_ISRESTARTED ();
 
     idx_map_val = m_module[module_idx]->get_comp_idx_map_val (comp_map_idx);
     comp_idx = get_comp_idx_from_comp_idx_map (idx_map_val);
@@ -478,12 +469,7 @@ namespace cubperf
     int module_idx = MMON_GET_MODULE_IDX_FROM_STAT_ID (stat_id);
     int comp_map_idx = MMON_GET_COMP_MAP_IDX_FROM_STAT_ID (stat_id);
     int idx_map_val, comp_idx, subcomp_idx;
-    bool deallocation_at_init = false;
-
-    if (!LOG_ISRESTARTED ())
-      {
-	deallocation_at_init = true;
-      }
+    bool deallocation_at_init = !LOG_ISRESTARTED ();
 
     idx_map_val = m_module[module_idx]->get_comp_idx_map_val (comp_map_idx);
     comp_idx = get_comp_idx_from_comp_idx_map (idx_map_val);

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -363,7 +363,7 @@ namespace cubperf
      * 3) compare with peak_stat
      * 4) if cur_stat(new) > peak_stat, update peak_stat
      * 5) if is_expanded == true, expand_count++
-     * 6) call component->add_stat(size, subcomp_idx, allocation_at_init, is_resized) */
+     * 6) call component->add_stat(size, subcomp_idx, allocation_at_init, is_expanded) */
 
     if (allocation_at_init)
       {
@@ -384,7 +384,7 @@ namespace cubperf
 
     if (comp_idx != mmon_module::MAX_COMP_IDX)
       {
-	m_component[comp_idx]->add_stat (size, subcomp_idx, allocation_at_init, is_resized);
+	m_component[comp_idx]->add_stat (size, subcomp_idx, allocation_at_init, is_expanded);
       }
   }
 
@@ -445,7 +445,7 @@ namespace cubperf
     TRANID trid = NULL_TRANID;
     int module_idx = MMON_GET_MODULE_IDX_FROM_STAT_ID (stat_id);
     int comp_map_idx = MMON_GET_COMP_MAP_IDX_FROM_STAT_ID (stat_id);
-    int compound, comp_idx, subcomp_idx;
+    int idx_map_val, comp_idx, subcomp_idx;
     bool allocation_at_init = false;
 
     if (!LOG_ISRESTARTED ())
@@ -453,9 +453,9 @@ namespace cubperf
 	allocation_at_init = true;
       }
 
-    compound = m_module[module_idx]->get_comp_idx_map_val (comp_map_idx);
-    comp_idx = get_comp_idx_from_comp_idx_map (compound);
-    subcomp_idx = get_subcomp_idx_from_comp_idx_map (compound);
+    idx_map_val = m_module[module_idx]->get_comp_idx_map_val (comp_map_idx);
+    comp_idx = get_comp_idx_from_comp_idx_map (idx_map_val);
+    subcomp_idx = get_subcomp_idx_from_comp_idx_map (idx_map_val);
 
     m_total_mem_usage += size;
 
@@ -477,7 +477,7 @@ namespace cubperf
     TRANID trid = NULL_TRANID;
     int module_idx = MMON_GET_MODULE_IDX_FROM_STAT_ID (stat_id);
     int comp_map_idx = MMON_GET_COMP_MAP_IDX_FROM_STAT_ID (stat_id);
-    int compound, comp_idx, subcomp_idx;
+    int idx_map_val, comp_idx, subcomp_idx;
     bool deallocation_at_init = false;
 
     if (!LOG_ISRESTARTED ())
@@ -485,9 +485,9 @@ namespace cubperf
 	deallocation_at_init = true;
       }
 
-    compound = m_module[module_idx]->get_comp_idx_map_val (comp_map_idx);
-    comp_idx = get_comp_idx_from_comp_idx_map (compound);
-    subcomp_idx = get_subcomp_idx_from_comp_idx_map (compound);
+    idx_map_val = m_module[module_idx]->get_comp_idx_map_val (comp_map_idx);
+    comp_idx = get_comp_idx_from_comp_idx_map (idx_map_val);
+    subcomp_idx = get_subcomp_idx_from_comp_idx_map (idx_map_val);
 
     m_total_mem_usage -= size;
 

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -528,8 +528,8 @@ int mmon_initialize (const char *server_name)
 
   if (cubperf::mmon_Gl == nullptr)
     {
-      /* error case */
-      return -1;
+      error = ER_OUT_OF_VIRTUAL_MEMORY;
+      return error;
     }
 
   /* normal return */

--- a/src/base/memory_monitor_sr.hpp
+++ b/src/base/memory_monitor_sr.hpp
@@ -34,15 +34,12 @@
 #include "thread_compat.hpp"
 #include "memory_monitor_common.h"
 
-/* 32-bit MMON_STAT_ID: [module_idx: 16 | comp_idx_map_idx: 16]
- * 32-bit mmon_module::m_comp_idx_map[comp_idx_map_idx] value: [comp_idx: 16 | subcomp_idx: 16]
- */
 #define MMON_PARSE_MASK 0x0000FFFF
-#define MMON_MAKE_INIT_STAT_ID(module_idx) ((module_idx) << 16)
+#define MMON_MAKE_STAT_ID(module_idx) ((module_idx) << 16)
 
 typedef enum
 {
-  MMON_STAT_LAST = MMON_MAKE_INIT_STAT_ID (MMON_MODULE_LAST)
+  MMON_STAT_LAST = MMON_MAKE_STAT_ID (MMON_MODULE_LAST)
 } MMON_STAT_ID;
 
 /* APIs */

--- a/src/base/memory_monitor_sr.hpp
+++ b/src/base/memory_monitor_sr.hpp
@@ -35,7 +35,7 @@
 #include "memory_monitor_common.h"
 
 /* 32-bit MMON_STAT_ID: [module_idx: 16 | comp_idx_map_idx: 16]
- * 32-bit m_comp_idx_map[comp_idx_map_idx] value: [comp_idx: 16 | subcomp_idx: 16]
+ * 32-bit mmon_module::m_comp_idx_map[comp_idx_map_idx] value: [comp_idx: 16 | subcomp_idx: 16]
  */
 #define MMON_PARSE_MASK 0x0000FFFF
 #define MMON_MAKE_INIT_STAT_ID_FOR_MODULE(module_idx) ((module_idx) << 16)

--- a/src/base/memory_monitor_sr.hpp
+++ b/src/base/memory_monitor_sr.hpp
@@ -37,7 +37,7 @@
 #define MMON_PARSE_MASK 0x0000FFFF
 #define MMON_MAKE_INIT_STAT_ID_FOR_MODULE(module_idx) ((module_idx) << 16)
 #define MMON_GET_MODULE_IDX_FROM_STAT_ID(stat) ((stat) >> 16)
-#define MMON_GET_COMP_INFO_IDX_FROM_STAT_ID(stat) ((stat) & MMON_PARSE_MASK)
+#define MMON_GET_COMP_MAP_IDX_FROM_STAT_ID(stat) ((stat) & MMON_PARSE_MASK)
 
 typedef enum
 {
@@ -47,10 +47,10 @@ typedef enum
 /* APIs */
 int mmon_initialize (const char *server_name);
 void mmon_finalize ();
-int mmon_add_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID stat_id, uint64_t size);
-int mmon_sub_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID stat_id, uint64_t size);
-int mmon_move_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID src, MMON_STAT_ID dest, uint64_t size);
-int mmon_resize_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID stat_id, uint64_t old_size, uint64_t new_size);
+void mmon_add_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID stat_id, uint64_t size);
+void mmon_sub_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID stat_id, uint64_t size);
+void mmon_move_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID src, MMON_STAT_ID dest, uint64_t size);
+void mmon_resize_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID stat_id, uint64_t old_size, uint64_t new_size);
 int mmon_aggregate_module_info (MMON_MODULE_INFO *info, int module_index);
 int mmon_aggregate_tran_info (MMON_TRAN_INFO *info, int tran_count);
 

--- a/src/base/memory_monitor_sr.hpp
+++ b/src/base/memory_monitor_sr.hpp
@@ -38,22 +38,21 @@
  * 32-bit m_comp_idx_map[comp_idx_map_idx] value: [comp_idx: 16 | subcomp_idx: 16]
  */
 #define MMON_PARSE_MASK 0x0000FFFF
-#define MMON_MAKE_INIT_STAT_ID_FOR_MODULE(module_idx) ((module_idx) << 16)
-#define MMON_GET_MODULE_IDX_FROM_STAT_ID(stat) ((stat) >> 16)
-#define MMON_GET_COMP_MAP_IDX_FROM_STAT_ID(stat) ((stat) & MMON_PARSE_MASK)
+#define MMON_MAKE_INIT_STAT_ID(module_idx) ((module_idx) << 16)
 
 typedef enum
 {
-  MMON_STAT_LAST = MMON_MAKE_INIT_STAT_ID_FOR_MODULE (MMON_MODULE_LAST)
+  MMON_STAT_LAST = MMON_MAKE_INIT_STAT_ID (MMON_MODULE_LAST)
 } MMON_STAT_ID;
 
 /* APIs */
 int mmon_initialize (const char *server_name);
+void mmon_notify_server_start ();
 void mmon_finalize ();
-void mmon_add_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID stat_id, uint64_t size);
-void mmon_sub_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID stat_id, uint64_t size);
-void mmon_move_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID src, MMON_STAT_ID dest, uint64_t size);
-void mmon_resize_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID stat_id, uint64_t old_size, uint64_t new_size);
+void mmon_add_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID stat_id, int64_t size);
+void mmon_sub_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID stat_id, int64_t size);
+void mmon_move_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID src, MMON_STAT_ID dest, int64_t size);
+void mmon_resize_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID stat_id, int64_t old_size, int64_t new_size);
 int mmon_aggregate_module_info (MMON_MODULE_INFO *info, int module_index);
 int mmon_aggregate_tran_info (MMON_TRAN_INFO *info, int tran_count);
 

--- a/src/base/memory_monitor_sr.hpp
+++ b/src/base/memory_monitor_sr.hpp
@@ -34,6 +34,9 @@
 #include "thread_compat.hpp"
 #include "memory_monitor_common.h"
 
+/* 32-bit MMON_STAT_ID: [module_idx: 16 | comp_idx_map_idx: 16]
+ * 32-bit m_comp_idx_map[comp_idx_map_idx] value: [comp_idx: 16 | subcomp_idx: 16]
+ */
 #define MMON_PARSE_MASK 0x0000FFFF
 #define MMON_MAKE_INIT_STAT_ID_FOR_MODULE(module_idx) ((module_idx) << 16)
 #define MMON_GET_MODULE_IDX_FROM_STAT_ID(stat) ((stat) >> 16)

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2815,6 +2815,7 @@ error:
   vacuum_stop_master (thread_p);
 
 #if defined(SERVER_MODE)
+  mmon_finalize ();
   cdc_daemons_destroy ();
 
   pgbuf_daemons_destroy ();
@@ -3130,6 +3131,7 @@ xboot_shutdown_server (REFPTR (THREAD_ENTRY, thread_p), ER_FINAL_CODE is_er_fina
   vacuum_stop_master (thread_p);
 
 #if defined(SERVER_MODE)
+  mmon_finalize ();
   pgbuf_daemons_destroy ();
   cdc_daemons_destroy ();
 #endif

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2778,6 +2778,9 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
     {
       /* server is up! */
       boot_server_status (BOOT_SERVER_UP);
+#if defined(SERVER_MODE)
+      mmon_notify_server_start ();
+#endif /* SERVER_MODE */
     }
 #if !defined(SA_MODE)
   json_set_alloc_funcs (malloc, free);

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -87,6 +87,7 @@
 #if defined(SERVER_MODE)
 #include "connection_sr.h"
 #include "server_support.h"
+#include "memory_monitor_sr.hpp"
 #endif /* SERVER_MODE */
 
 #if defined(WINDOWS)
@@ -2359,6 +2360,14 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
 	  goto error;
 	}
     }
+
+#if defined(SERVER_MODE)
+  error_code = mmon_initialize (db_name);
+  if (error_code != NO_ERROR)
+    {
+      goto error;
+    }
+#endif
 
   spage_boot (thread_p);
   error_code = heap_manager_initialize ();

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -603,7 +603,9 @@ struct log_tdes
   log_postpone_cache m_log_postpone_cache;
 
   bool has_supplemental_log;	/* Checks if supplemental log has been appended within the transaction */
-    std::atomic < uint64_t > cur_mem_usage;
+  // *INDENT-OFF*
+  std::atomic < uint64_t > cur_mem_usage;
+  // *INDENT-ON*
 
   // *INDENT-OFF*
 #if defined (SERVER_MODE) || (defined (SA_MODE) && defined (__cplusplus))

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -60,6 +60,7 @@
 #include "tde.h"
 #include "lockfree_circular_queue.hpp"
 
+#include <atomic>
 #include <unordered_set>
 #include <queue>
 #include <assert.h>
@@ -602,6 +603,7 @@ struct log_tdes
   log_postpone_cache m_log_postpone_cache;
 
   bool has_supplemental_log;	/* Checks if supplemental log has been appended within the transaction */
+    std::atomic < uint64_t > cur_mem_usage;
 
   // *INDENT-OFF*
 #if defined (SERVER_MODE) || (defined (SA_MODE) && defined (__cplusplus))

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -604,7 +604,7 @@ struct log_tdes
 
   bool has_supplemental_log;	/* Checks if supplemental log has been appended within the transaction */
   // *INDENT-OFF*
-  std::atomic < uint64_t > cur_mem_usage;
+  std::atomic<uint64_t> cur_mem_usage;
   // *INDENT-ON*
 
   // *INDENT-OFF*

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -1582,6 +1582,7 @@ logtb_clear_tdes (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
   tdes->has_deadlock_priority = false;
 
   tdes->num_log_records_written = 0;
+  tdes->cur_mem_usage = 0;
 
   LSA_SET_NULL (&tdes->rcv.tran_start_postpone_lsa);
   LSA_SET_NULL (&tdes->rcv.sysop_start_postpone_lsa);
@@ -1681,6 +1682,7 @@ logtb_initialize_tdes (LOG_TDES * tdes, int tran_index)
   tdes->is_user_active = false;
 
   tdes->has_supplemental_log = false;
+  tdes->cur_mem_usage = 0;
 
   LSA_SET_NULL (&tdes->rcv.tran_start_postpone_lsa);
   LSA_SET_NULL (&tdes->rcv.sysop_start_postpone_lsa);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24860

Implementation of memory tracking in memory monitoring manager module

description of memory_monitor::add/sub_stat

1. get module_idx, comp_map_idx through stat_id
2. if LOG_ISRESTARTED() == 0, allocation_at_init = true
3. get component index(comp_idx) and subcomponent index(subcomp_idx) using comp_idx_map in module
4. update m_total_mem_usage
5. call m_module[module_idx]->add_stat (..)
    add/sub_stat (..) in mmon_module and mmon_component
        1. update init_stat(if allocation/deallocation_at_init == true), cur_stat, peak_stat(if cur_stat > peak_stat) of module
        2. (only add_stat) update expand_count if is_expanded == true
        3. if comp_idx or subcomp_idx != mmon_module::MAX_COMP_IDX, call mmon_component::add/sub_stat (..) or mmon_subcomponent::add/sub_cur_stat (..)
6. if transaction exists, update tdes->cur_mem_usage

resize_stat and move_stat just use memory_monitor::add_stat/sub_stat (..)