### PR TITLE
[CBRD-24880] semantic check for remote table column names and aliases

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -255,6 +255,8 @@ static PT_NODE *pt_count_with_clauses (PARSER_CONTEXT * parser, PT_NODE * node, 
 static int pt_resolve_dblink_server_name (PARSER_CONTEXT * parser, PT_NODE * node, char **server_owner_name);
 static int pt_resolve_dblink_check_owner_name (PARSER_CONTEXT * parser, PT_NODE * node, char **server_owner_name);
 
+static T_CCI_COL_INFO *pt_dblink_get_column_info (char *url, char *user, char *password, char *sql_text);
+
 static void pt_gather_dblink_colums (PARSER_CONTEXT * parser, PT_NODE * query_stmt);
 typedef struct
 {
@@ -1200,6 +1202,10 @@ pt_bind_scope (PARSER_CONTEXT * parser, PT_BIND_NAMES_ARG * bind_arg)
 	    }
 	  else if (table->node_type == PT_DBLINK_TABLE)
 	    {
+	      PT_NODE *cols;
+	      T_CCI_COL_INFO *col_info;
+	      int i = 0;
+
 	      assert (spec->info.spec.derived_table_type == PT_DERIVED_DBLINK_TABLE);
 	      if (table->info.dblink_table.is_name && table->info.dblink_table.url == NULL)
 		{
@@ -5103,26 +5109,85 @@ pt_remake_dblink_select_list (PARSER_CONTEXT * parser, PT_SPEC_INFO * class_spec
 
 #define MAX_LEN_CONNECTION_URL	512
 
+static T_CCI_COL_INFO *
+pt_dblink_get_column_info (char *url, char *user_name, char *password, char *sql_text)
+{
+  T_CCI_ERROR err_buf;
+  T_CCI_COL_INFO *col_info;
+  char conn_url[MAX_LEN_CONNECTION_URL] = { 0, };
+  int conn_handle, stmt_handle;
+  char *find = strstr (url, ":?");
+  int stmt_type, col_cnt;
+
+  if (find)
+    {
+      snprintf (conn_url, MAX_LEN_CONNECTION_URL, "%s%s", url, "&__gateway=true");
+    }
+  else
+    {
+      snprintf (conn_url, MAX_LEN_CONNECTION_URL, "%s%s", url, "?__gateway=true");
+    }
+
+  conn_handle = cci_connect_with_url_ex (conn_url, user_name, password, &err_buf);
+  if (conn_handle < 0)
+    {
+      stmt_handle = -1;
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, err_buf.err_msg);
+      goto error_exit;
+    }
+  else
+    {
+      T_CCI_CUBRID_STMT stmt_type;
+
+      stmt_handle = cci_prepare (conn_handle, sql_text, 0, &err_buf);
+      if (stmt_handle < 0)
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, err_buf.err_msg);
+	  goto error_exit;
+	}
+      col_info = (T_CCI_COL_INFO *) cci_get_result_info (stmt_handle, &stmt_type, &col_cnt);
+      if (col_info == NULL)
+	{
+	  /* this can not be reached, something wrong */
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, "unknown error");
+	  goto error_exit;
+	}
+    }
+
+  return col_info;
+
+error_exit:
+  return NULL;
+}
+
 static int
 pt_dblink_table_get_column_defs (PARSER_CONTEXT * parser, PT_NODE * dblink, S_REMOTE_TBL_COLS * rmt_tbl_cols)
 {
-  PT_NODE *attr_def;
-  int req, conn, col_count, res;
+  int req, conn, col_cnt, res, i;
   T_CCI_ERROR cci_error;
   T_CCI_COL_INFO *col_info;
-  T_CCI_CUBRID_STMT cmd_type;
+  T_CCI_CUBRID_STMT stmt_type;
+
   PT_DBLINK_INFO *dblink_table = &dblink->info.dblink_table;
   char *table_name = dblink_table->remote_table_name;
-
   char *find;
   char conn_url[MAX_LEN_CONNECTION_URL] = { 0, };
 
   char *url = (char *) dblink_table->url->info.value.data_value.str->bytes;
   char *user = (char *) dblink_table->user->info.value.data_value.str->bytes;
   char *passwd = (char *) dblink_table->pwd->info.value.data_value.str->bytes;
-  bool need_get_err_msg = false;
+  char sql_text[300], *sql = sql_text;
 
-  assert (dblink_table->cols == NULL);
+  S_REMOTE_COL_ATTR *rmt_attr;
+
+  if (table_name)
+    {
+      sprintf (sql_text, "SELECT * FROM %s", table_name);
+    }
+  else
+    {
+      sql = (char *) dblink_table->qstr->info.value.data_value.str->bytes;
+    }
 
   find = strstr (url, ":?");
 
@@ -5135,7 +5200,6 @@ pt_dblink_table_get_column_defs (PARSER_CONTEXT * parser, PT_NODE * dblink, S_RE
       snprintf (conn_url, MAX_LEN_CONNECTION_URL, "%s%s", url, "?__gateway=true");
     }
 
-  req = -1;
   conn = cci_connect_with_url_ex (conn_url, user, passwd, &cci_error);
   if (conn < 0)
     {
@@ -5144,7 +5208,7 @@ pt_dblink_table_get_column_defs (PARSER_CONTEXT * parser, PT_NODE * dblink, S_RE
       goto set_parser_error;
     }
 
-  req = cci_schema_info (conn, CCI_SCH_ATTRIBUTE, table_name, NULL, CCI_ATTR_NAME_PATTERN_MATCH, &cci_error);
+  req = cci_prepare (conn, sql, 0, &cci_error);
   if (req < 0)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, cci_error.err_msg);
@@ -5152,97 +5216,37 @@ pt_dblink_table_get_column_defs (PARSER_CONTEXT * parser, PT_NODE * dblink, S_RE
       goto set_parser_error;
     }
 
-  /* 
-   * TTR_NAME, DOMAIN, SCALE, PRECISION, INDEXED, NON_NULL, SHARED, UNIQUE, DEFAULT, ATTR_ORDER, 
-   * CLASS_NAME, SOURCE_CLASS, IS_KEY, REMARKS 
-   */
-  col_info = cci_get_result_info (req, &cmd_type, &col_count);
-  if (!col_info && col_count == 0)
+  col_info = (T_CCI_COL_INFO *) cci_get_result_info (req, &stmt_type, &col_cnt);
+  if (col_info == NULL || col_cnt <= 0)
     {
+      /* this can not be reached, something wrong */
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, "unknown error");
       res = ER_FAILED;
       goto set_parser_error;
     }
 
-  res = cci_cursor (req, 1, CCI_CURSOR_FIRST, &cci_error);
-  if (res < 0)
+  for (i = 0; i < col_cnt; i++)
     {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, cci_error.err_msg);
-      goto set_parser_error;
+      rmt_attr = rmt_tbl_cols->get_col_attr (col_info[i].col_name);
+      rmt_attr->type_idx = col_info[i].ext_type;
+      rmt_attr->dec_precision = col_info[i].scale;
+      rmt_attr->precision = col_info[i].precision;
     }
 
-  S_REMOTE_COL_ATTR *rmt_attr;
-  do
-    {
-      int ind, dec_precision, precision;
-      PT_TYPE_ENUM type_idx;
-      char *buf = 0x00;
-
-      res = cci_fetch (req, &cci_error);
-      if (res < 0)
-	{
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, cci_error.err_msg);
-	  goto set_parser_error;
-	}
-
-      if ((res = cci_get_data (req, DBLINK_ATTR_NAME, CCI_A_TYPE_STR, &buf, &ind)) < 0)
-	{
-	  need_get_err_msg = true;
-	  goto set_parser_error;
-	}
-
-      rmt_attr = rmt_tbl_cols->get_col_attr (buf);
-
-      /* type */
-      if ((res = cci_get_data (req, DBLINK_ATTR_TYPE, CCI_A_TYPE_INT, &rmt_attr->type_idx, &ind)) < 0)
-	{
-	  need_get_err_msg = true;
-	  goto set_parser_error;
-	}
-      /* scale */
-      if ((res = cci_get_data (req, DBLINK_ATTR_SCALE, CCI_A_TYPE_INT, &rmt_attr->dec_precision, &ind)) < 0)
-	{
-	  need_get_err_msg = true;
-	  goto set_parser_error;
-	}
-      /* precision */
-      if ((res = cci_get_data (req, DBLINK_ATTR_PRECISION, CCI_A_TYPE_INT, &rmt_attr->precision, &ind)) < 0)
-	{
-	  need_get_err_msg = true;
-	  goto set_parser_error;
-	}
-
-      res = cci_cursor (req, 1, CCI_CURSOR_CURRENT, &cci_error);
-    }
-  while (res == CCI_ER_NO_ERROR);
-
-  if (res != CCI_ER_NO_MORE_DATA)
-    {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, cci_error.err_msg);
-    }
-  else
-    {
-      res = NO_ERROR;
-    }
+  res = NO_ERROR;
 
 set_parser_error:
-  if (need_get_err_msg)
-    {
-      cci_error.err_msg[0] = 0x00;
-      if (cci_get_err_msg (res, cci_error.err_msg, sizeof (cci_error.err_msg)) == 0)
-	{
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, cci_error.err_msg);
-	}
-    }
-
   if (req >= 0)
     {
       int err;
+
       if ((err = cci_close_req_handle (req)) < 0)
 	{
 	  cci_get_err_msg (err, cci_error.err_msg, sizeof (cci_error.err_msg));
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, cci_error.err_msg);
 	}
     }
+
   if (conn >= 0)
     {
       if (cci_disconnect (conn, &cci_error) < 0)
@@ -11586,4 +11590,36 @@ pt_check_dblink_query (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *
     }
 
   return node;
+}
+
+int
+pt_check_dblink_column_alias (PARSER_CONTEXT * parser, PT_NODE * dblink)
+{
+  int i = 0, err;
+  S_REMOTE_TBL_COLS rmt_tbl_cols;
+  PT_NODE *cols;
+
+  err = pt_dblink_table_get_column_defs (parser, dblink, &rmt_tbl_cols);
+
+  if (err != NO_ERROR)
+    {
+      return err;
+    }
+
+  cols = dblink->info.dblink_table.cols;
+  while (cols)
+    {
+      if (strcmp (rmt_tbl_cols.get_name (i), cols->info.attr_def.attr_name->info.name.original) != 0)
+	{
+	  PT_ERRORf3 (parser, dblink, "\"%s\" not matched column or alias \"%s\"",
+		      rmt_tbl_cols.get_name (i), cols->info.attr_def.attr_name->info.name.original, ER_DBLINK);
+	  return ER_FAILED;
+	}
+
+      i++;
+      cols = cols->next;
+    }
+
+  return NO_ERROR;
+
 }

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -1200,10 +1200,6 @@ pt_bind_scope (PARSER_CONTEXT * parser, PT_BIND_NAMES_ARG * bind_arg)
 	    }
 	  else if (table->node_type == PT_DBLINK_TABLE)
 	    {
-	      PT_NODE *cols;
-	      T_CCI_COL_INFO *col_info;
-	      int i = 0;
-
 	      assert (spec->info.spec.derived_table_type == PT_DERIVED_DBLINK_TABLE);
 	      if (table->info.dblink_table.is_name && table->info.dblink_table.url == NULL)
 		{

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -3772,6 +3772,7 @@ pt_remove_cast_wrap_for_dblink (PARSER_CONTEXT * parser, PT_NODE * old_node, voi
   return new_node;
 }
 
+extern int pt_check_dblink_column_alias (PARSER_CONTEXT * parser, PT_NODE * dblink);
 /*
  * pt_copypush_terms() - push sargable term into the derived subquery
  *   return:
@@ -3828,6 +3829,12 @@ pt_copypush_terms (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * query, PT_
 	}
       break;
     case PT_DBLINK_TABLE:
+
+      if (pt_check_dblink_column_alias (parser, query) != NO_ERROR)
+	{
+	  return;
+	}
+
       /* copy terms */
       query->info.dblink_table.pushed_pred = parser_copy_tree_list (parser, term_list);
       /* remove the cast wrap from pushed predicate */
@@ -3845,7 +3852,7 @@ pt_copypush_terms (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * query, PT_
 
       /* alias name: cublink */
       rewritten = pt_append_bytes (parser, rewritten, ") cublink", 9);
-
+#if 0
       if (query->info.dblink_table.cols != NULL)
 	{
 	  /* aliased column list */
@@ -3854,7 +3861,7 @@ pt_copypush_terms (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * query, PT_
 	  rewritten = pt_append_varchar (parser, rewritten, col_list);
 	  rewritten = pt_append_bytes (parser, rewritten, ")", 1);
 	}
-
+#endif
       if (pushed_pred != NULL)
 	{
 	  /* where predicate */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24880

It needs to check semantic for rewriting correctly the query with predicate pushing.

The dblink query can be rewritten by pushing predicates to enhance the performance. The query is rewritten by wrapping the user's query with "SELECT * FROM". While the rewriting processing it needs check the column names and aliases wether they are the same as DBLINK column definition's one.

For example, the following query is rewritten and the rewritten query returns error from the ORACLE server.

`SELECT t.a, t.c FROM DBLINK(srv1, 'SELECT a, b AS p FROM t1 WHERE a > 10') t(a, c) JOIN tbl ON t.a = tbl.a WHERE c > 'a';
`
==> rewritten query to be executed at remote server (ORACLE or otheer DBMS)
`SELECT * FROM (SELECT a, b AS p FROM t1 WHERE a > 10) cublink (a, c) WHERE c > 'a'`
The query should be rewritten as below:

`SELECT * FROM (SELECT a, b AS p FROM t1 WHERE a > 10) cublink WHERE p > 10`