### PR TITLE
[LETS-772] Send prior lists regardless of connection_handler’s state

### DIFF
--- a/src/server/active_tran_server.cpp
+++ b/src/server/active_tran_server.cpp
@@ -187,8 +187,8 @@ active_tran_server::connection_handler::on_connecting ()
 {
   assert (m_prior_sender_sink_hook_func == nullptr);
 
-  m_prior_sender_sink_hook_func = std::bind (&tran_server::connection_handler::push_request, this,
-				  tran_to_page_request::SEND_LOG_PRIOR_LIST, std::placeholders::_1);
+  m_prior_sender_sink_hook_func = std::bind (&active_tran_server::connection_handler::prior_sender_sink_hook, this,
+				  std::placeholders::_1);
   log_Gl.m_prior_sender.add_sink (m_prior_sender_sink_hook_func);
 }
 
@@ -200,6 +200,16 @@ active_tran_server::connection_handler::on_disconnecting ()
       log_Gl.m_prior_sender.remove_sink (m_prior_sender_sink_hook_func);
       m_prior_sender_sink_hook_func = nullptr;
     }
+}
+
+void
+active_tran_server::connection_handler::prior_sender_sink_hook (std::string &&message)
+{
+  assert (message.size () > 0);
+
+  auto slock_conn = std::shared_lock<std::shared_mutex> { m_conn_mtx };
+  m_conn->push (tran_to_page_request::SEND_LOG_PRIOR_LIST, std::move (message));
+
 }
 
 active_tran_server::connection_handler *

--- a/src/server/active_tran_server.cpp
+++ b/src/server/active_tran_server.cpp
@@ -208,8 +208,7 @@ active_tran_server::connection_handler::prior_sender_sink_hook (std::string &&me
   assert (message.size () > 0);
 
   auto slock_conn = std::shared_lock<std::shared_mutex> { m_conn_mtx };
-  m_conn->push (tran_to_page_request::SEND_LOG_PRIOR_LIST, std::move (message));
-
+  push_request_regardless_of_state (tran_to_page_request::SEND_LOG_PRIOR_LIST, std::move (message));
 }
 
 active_tran_server::connection_handler *

--- a/src/server/active_tran_server.cpp
+++ b/src/server/active_tran_server.cpp
@@ -207,7 +207,6 @@ active_tran_server::connection_handler::prior_sender_sink_hook (std::string &&me
 {
   assert (message.size () > 0);
 
-  auto slock_conn = std::shared_lock<std::shared_mutex> { m_conn_mtx };
   push_request_regardless_of_state (tran_to_page_request::SEND_LOG_PRIOR_LIST, std::move (message));
 }
 

--- a/src/server/active_tran_server.hpp
+++ b/src/server/active_tran_server.hpp
@@ -63,6 +63,9 @@ class active_tran_server : public tran_server
 	void on_connecting () override final;
 	void on_disconnecting () override final;
 
+	// Function used as sink for log transfer
+	void prior_sender_sink_hook (std::string &&message);
+
       private:
 	cublog::prior_sender::sink_hook_t m_prior_sender_sink_hook_func;
 	std::atomic<log_lsa> m_saved_lsa;

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -597,6 +597,13 @@ tran_server::connection_handler::push_request (tran_to_page_request reqid, std::
   return NO_ERROR;
 }
 
+void
+tran_server::connection_handler::push_request_regardless_of_state (tran_to_page_request reqid, std::string &&payload)
+{
+  auto slock_conn = std::shared_lock<std::shared_mutex> { m_conn_mtx };
+  m_conn->push (reqid, std::move (payload));
+}
+
 int
 tran_server::connection_handler::send_receive (tran_to_page_request reqid, std::string &&payload_in,
     std::string &payload_out)

--- a/src/server/tran_server.hpp
+++ b/src/server/tran_server.hpp
@@ -129,6 +129,7 @@ class tran_server
 	{ }
 
 	virtual request_handlers_map_t get_request_handlers ();
+	void push_request_regardless_of_state (tran_to_page_request reqid, std::string &&payload);
 
 	/*
 	 * Do the server-type-specific jobs before state transtition.

--- a/src/server/tran_server.hpp
+++ b/src/server/tran_server.hpp
@@ -142,6 +142,9 @@ class tran_server
       protected:
 	tran_server &m_ts;
 
+	std::unique_ptr<page_server_conn_t> m_conn;
+	std::shared_mutex m_conn_mtx;
+
       private:
 	/*
 	 * The internal state of connection_handler. A connection_handler must be in one of those states.
@@ -181,9 +184,6 @@ class tran_server
 
       private:
 	const cubcomm::node m_node;
-
-	std::unique_ptr<page_server_conn_t> m_conn;
-	std::shared_mutex m_conn_mtx;
 
 	state m_state;
 	std::shared_mutex m_state_mtx;

--- a/src/server/tran_server.hpp
+++ b/src/server/tran_server.hpp
@@ -143,9 +143,6 @@ class tran_server
       protected:
 	tran_server &m_ts;
 
-	std::unique_ptr<page_server_conn_t> m_conn;
-	std::shared_mutex m_conn_mtx;
-
       private:
 	/*
 	 * The internal state of connection_handler. A connection_handler must be in one of those states.
@@ -185,6 +182,9 @@ class tran_server
 
       private:
 	const cubcomm::node m_node;
+
+	std::unique_ptr<page_server_conn_t> m_conn;
+	std::shared_mutex m_conn_mtx;
 
 	state m_state;
 	std::shared_mutex m_state_mtx;


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-772

- Add a sink_hook function using m_conn directly.
- Make m_conn protected.
