### PR TITLE
[CBRD-24878] Implement aggregate functions for Memory Monitoring Manager Module

### DIFF
--- a/src/base/memory_monitor_cl.hpp
+++ b/src/base/memory_monitor_cl.hpp
@@ -28,9 +28,9 @@
 
 typedef enum mmon_module_option
 {
-  MMON_MODULE_DETAIL,
-  MMON_MODULE_BRIEF,
-  MMON_MODULE_DEFAULT
+  MMON_MODULE_DETAIL,   /* -m <module_index> or <module_name> */
+  MMON_MODULE_BRIEF,    /* -m brief */
+  MMON_MODULE_DEFAULT   /* default case (with no command option) */
 } MMON_MODULE_OPTION;
 
 constexpr char *module_names[] =

--- a/src/base/memory_monitor_cl.hpp
+++ b/src/base/memory_monitor_cl.hpp
@@ -26,6 +26,13 @@
 
 #include "memory_monitor_common.h"
 
+typedef enum mmon_module_option
+{
+  MMON_MODULE_DETAIL,
+  MMON_MODULE_BRIEF,
+  MMON_MODULE_DEFAULT
+} MMON_MODULE_OPTION;
+
 constexpr char *module_names[] =
 {
   ""				/* It will be changed to "heap" */

--- a/src/base/memory_monitor_cl.hpp
+++ b/src/base/memory_monitor_cl.hpp
@@ -26,13 +26,6 @@
 
 #include "memory_monitor_common.h"
 
-typedef enum mmon_module_option
-{
-  MMON_MODULE_DETAIL,   /* -m <module_index> or <module_name> */
-  MMON_MODULE_BRIEF,    /* -m brief */
-  MMON_MODULE_DEFAULT   /* default case (with no command option) */
-} MMON_MODULE_OPTION;
-
 constexpr char *module_names[] =
 {
   ""				/* It will be changed to "heap" */

--- a/src/base/memory_monitor_common.h
+++ b/src/base/memory_monitor_common.h
@@ -26,12 +26,6 @@
 
 #include <cstdint>
 
-typedef enum mmon_module_option
-{
-  MMON_MODULE_BRIEF_OPTION,
-  MMON_MODULE_DEFAULT_OPTION
-} MMON_MODULE_OPTION;
-
 typedef enum mmon_module_id
 {
   //MMON_MODULE_HEAP = 1,
@@ -68,7 +62,6 @@ typedef struct mmon_comp_info
 
 typedef struct mmon_module_info
 {
-  MMON_SERVER_INFO server_info;
   char name[DB_MAX_IDENTIFIER_LENGTH];
   MMON_OUTPUT_MEM_STAT stat;
   uint32_t num_comp;
@@ -83,7 +76,6 @@ typedef struct mmon_tran_stat
 
 typedef struct mmon_tran_info
 {
-  MMON_SERVER_INFO server_info;
   uint32_t num_tran;
   MMON_TRAN_STAT *tran_stat;
 } MMON_TRAN_INFO;

--- a/src/base/memory_monitor_common.h
+++ b/src/base/memory_monitor_common.h
@@ -25,6 +25,7 @@
 #include "dbtype_def.h"
 
 #include <cstdint>
+#include <vector>
 
 typedef enum mmon_module_id
 {
@@ -57,7 +58,7 @@ typedef struct mmon_comp_info
   char name[DB_MAX_IDENTIFIER_LENGTH];
   MMON_OUTPUT_MEM_STAT stat;
   uint32_t num_subcomp;
-  MMON_SUBCOMP_INFO *subcomp_info;
+    std::vector < MMON_SUBCOMP_INFO > subcomp_info;
 } MMON_COMP_INFO;
 
 typedef struct mmon_module_info
@@ -65,7 +66,7 @@ typedef struct mmon_module_info
   char name[DB_MAX_IDENTIFIER_LENGTH];
   MMON_OUTPUT_MEM_STAT stat;
   uint32_t num_comp;
-  MMON_COMP_INFO *comp_info;
+    std::vector < MMON_COMP_INFO > comp_info;
 } MMON_MODULE_INFO;
 
 typedef struct mmon_tran_stat
@@ -77,7 +78,7 @@ typedef struct mmon_tran_stat
 typedef struct mmon_tran_info
 {
   uint32_t num_tran;
-  MMON_TRAN_STAT *tran_stat;
+    std::vector < MMON_TRAN_STAT > tran_stat;
 } MMON_TRAN_INFO;
 
 #endif // _MEMORY_MONITOR_COMMON_H_

--- a/src/base/memory_monitor_common.h
+++ b/src/base/memory_monitor_common.h
@@ -58,7 +58,9 @@ typedef struct mmon_comp_info
   char name[DB_MAX_IDENTIFIER_LENGTH];
   MMON_OUTPUT_MEM_STAT stat;
   uint32_t num_subcomp;
-    std::vector < MMON_SUBCOMP_INFO > subcomp_info;
+  // *INDENT-OFF*
+  std::vector < MMON_SUBCOMP_INFO > subcomp_info;
+  // *INDENT-ON*
 } MMON_COMP_INFO;
 
 typedef struct mmon_module_info
@@ -66,7 +68,9 @@ typedef struct mmon_module_info
   char name[DB_MAX_IDENTIFIER_LENGTH];
   MMON_OUTPUT_MEM_STAT stat;
   uint32_t num_comp;
-    std::vector < MMON_COMP_INFO > comp_info;
+  // *INDENT-OFF*
+  std::vector < MMON_COMP_INFO > comp_info;
+  // *INDENT-ON*
 } MMON_MODULE_INFO;
 
 typedef struct mmon_tran_stat
@@ -78,7 +82,9 @@ typedef struct mmon_tran_stat
 typedef struct mmon_tran_info
 {
   uint32_t num_tran;
-    std::vector < MMON_TRAN_STAT > tran_stat;
+  // *INDENT-OFF*
+  std::vector < MMON_TRAN_STAT > tran_stat;
+  // *INDENT-ON*
 } MMON_TRAN_INFO;
 
 #endif // _MEMORY_MONITOR_COMMON_H_

--- a/src/base/memory_monitor_common.h
+++ b/src/base/memory_monitor_common.h
@@ -26,8 +26,11 @@
 
 #include <cstdint>
 
-#define MMON_MODULE_BRIEF_OPTION 1
-#define MMON_MODULE_DEFAULT_OPTION 2
+typedef enum mmon_module_option
+{
+  MMON_MODULE_BRIEF_OPTION,
+  MMON_MODULE_DEFAULT_OPTION
+} MMON_MODULE_OPTION;
 
 typedef enum mmon_module_id
 {

--- a/src/base/memory_monitor_common.h
+++ b/src/base/memory_monitor_common.h
@@ -58,7 +58,9 @@ typedef struct mmon_comp_info
   char name[DB_MAX_IDENTIFIER_LENGTH];
   MMON_OUTPUT_MEM_STAT stat;
   uint32_t num_subcomp;
-    std::vector < MMON_SUBCOMP_INFO > subcomp_info;
+  // *INDENT-OFF*
+  std::vector<MMON_SUBCOMP_INFO> subcomp_info;
+  // *INDENT-ON*
 } MMON_COMP_INFO;
 
 typedef struct mmon_module_info
@@ -66,7 +68,9 @@ typedef struct mmon_module_info
   char name[DB_MAX_IDENTIFIER_LENGTH];
   MMON_OUTPUT_MEM_STAT stat;
   uint32_t num_comp;
-    std::vector < MMON_COMP_INFO > comp_info;
+  // *INDENT-OFF*
+  std::vector<MMON_COMP_INFO> comp_info;
+  // *INDENT-ON*
 } MMON_MODULE_INFO;
 
 typedef struct mmon_tran_stat
@@ -78,7 +82,9 @@ typedef struct mmon_tran_stat
 typedef struct mmon_tran_info
 {
   uint32_t num_tran;
-    std::vector < MMON_TRAN_STAT > tran_stat;
+  // *INDENT-OFF*
+  std::vector<MMON_TRAN_STAT> tran_stat;
+  // *INDENT-ON*
 } MMON_TRAN_INFO;
 
 #endif // _MEMORY_MONITOR_COMMON_H_

--- a/src/base/memory_monitor_common.h
+++ b/src/base/memory_monitor_common.h
@@ -26,6 +26,9 @@
 
 #include <cstdint>
 
+#define MMON_MODULE_BRIEF_OPTION 1
+#define MMON_MODULE_DEFAULT_OPTION 2
+
 typedef enum mmon_module_id
 {
   //MMON_MODULE_HEAP = 1,

--- a/src/base/memory_monitor_common.h
+++ b/src/base/memory_monitor_common.h
@@ -37,7 +37,7 @@ typedef struct mmon_output_mem_stat
   uint64_t init_stat;
   uint64_t cur_stat;
   uint64_t peak_stat;
-  uint32_t expand_count;
+  uint32_t expand_resize_count;
 } MMON_OUTPUT_MEM_STAT;
 
 typedef struct mmon_server_info

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -391,11 +391,6 @@ namespace cubperf
 
 		    if (error != NO_ERROR)
 		      {
-			for (uint32_t j = 0; j < i; j++)
-			  {
-			    free_and_init (info.comp_info[j].subcomp_info);
-			  }
-			free_and_init (info.comp_info);
 			break;
 		      }
 		  }

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -498,13 +498,12 @@ namespace cubperf
 
   int memory_monitor::aggregater::get_module_info (MMON_MODULE_INFO *&info, int module_index) const
   {
-    int idx = 0;
     int error = NO_ERROR;
 
     if (module_index == -1)
       {
 	// aggregate all detail memory information of modules
-	for (idx; idx < MMON_MODULE_LAST; idx++)
+	for (int idx = 0; idx < MMON_MODULE_LAST; idx++)
 	  {
 	    error = m_mmon->m_module[idx]->aggregate_stats (info[idx], false);
 	    if (error != NO_ERROR)
@@ -515,7 +514,7 @@ namespace cubperf
       }
     else
       {
-	error =  m_mmon->m_module[module_index]->aggregate_stats (info[idx], false);
+	error =  m_mmon->m_module[module_index]->aggregate_stats (info[0], false);
       }
 
     return error;

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -564,7 +564,7 @@ namespace cubperf
       {
 	info.num_tran = std::min (tran_count, (int) tran_info.size ());
 
-	// sort memory usage in descending order
+	// sort by memory usage in descending order
 	const auto &comp = [] (const auto& tran_pair1, const auto& tran_pair2)
 	{
 	  return tran_pair1.second > tran_pair2.second;

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -391,9 +391,9 @@ namespace cubperf
 
 		    if (error != NO_ERROR)
 		      {
-			for (uint32_t i = 0; i < info.num_comp; i++)
+			for (uint32_t j = 0; j < i; j++)
 			  {
-			    free_and_init (info.comp_info[i].subcomp_info);
+			    free_and_init (info.comp_info[j].subcomp_info);
 			  }
 			free_and_init (info.comp_info);
 			break;

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -284,6 +284,7 @@ namespace cubperf
     info.num_subcomp = m_subcomponent.size ();
     if (info.num_subcomp != 0)
       {
+	// deallocation of this allocation will occur at smmon_get_module_info()
 	info.subcomp_info = (MMON_SUBCOMP_INFO *)malloc (sizeof (MMON_SUBCOMP_INFO) * info.num_subcomp);
 
 	if (info.subcomp_info == NULL)
@@ -376,6 +377,7 @@ namespace cubperf
 	info.num_comp = m_component.size ();
 	if (info.num_comp != 0)
 	  {
+	    // deallocation of this allocation will occur at smmon_get_module_info()
 	    info.comp_info = (MMON_COMP_INFO *)malloc (sizeof (MMON_COMP_INFO) * info.num_comp);
 
 	    if (info.comp_info == NULL)
@@ -566,6 +568,7 @@ namespace cubperf
 	std::sort (tran_info.begin (), tran_info.end (), comp);
       }
 
+    // deallocation of this allocation will occur at smmon_get_tran_info()
     info.tran_stat = (MMON_TRAN_STAT *)malloc (sizeof (MMON_TRAN_STAT) * info.num_tran);
     if (info.tran_stat == NULL)
       {

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -157,7 +157,7 @@ namespace cubperf
       void move_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID src, MMON_STAT_ID dest, int64_t size);
       void end_init_phase ();
       int aggregate_module_info (MMON_MODULE_INFO &info, int module_index) const;
-      int aggregate_module_brief_info (MMON_MODULE_INFO *&info, int option) const;
+      int aggregate_module_brief_info (MMON_MODULE_INFO *&info, MMON_MODULE_OPTION option) const;
       int aggregate_tran_info (MMON_TRAN_INFO &info, int tran_count) const;
 
     private:
@@ -178,7 +178,7 @@ namespace cubperf
 
 	  void get_server_info (MMON_SERVER_INFO &info) const;
 	  int get_module_info (MMON_MODULE_INFO &info, int module_index) const;
-	  int get_module_brief_info (MMON_MODULE_INFO *&info, int option) const;
+	  int get_module_brief_info (MMON_MODULE_INFO *&info, MMON_MODULE_OPTION option) const;
 	  int get_transaction_info (MMON_TRAN_INFO &info, int tran_count) const;
 
 	private:
@@ -480,13 +480,10 @@ namespace cubperf
 
   int memory_monitor::aggregater::get_module_info (MMON_MODULE_INFO &info, int module_index) const
   {
-    int error = NO_ERROR;
-
-    error = m_mmon->m_module[module_index]->aggregate_stats (info, false);
-    return error;
+    return m_mmon->m_module[module_index]->aggregate_stats (info, false);
   }
 
-  int memory_monitor::aggregater::get_module_brief_info (MMON_MODULE_INFO *&info, int option) const
+  int memory_monitor::aggregater::get_module_brief_info (MMON_MODULE_INFO *&info, MMON_MODULE_OPTION option) const
   {
     int error = NO_ERROR;
 
@@ -629,7 +626,7 @@ namespace cubperf
     return error;
   }
 
-  int memory_monitor::aggregate_module_brief_info (MMON_MODULE_INFO *&info, int option) const
+  int memory_monitor::aggregate_module_brief_info (MMON_MODULE_INFO *&info, MMON_MODULE_OPTION option) const
   {
     int error = NO_ERROR;
 
@@ -726,42 +723,22 @@ void mmon_resize_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID stat_id, int64_t old
 
 int mmon_aggregate_module_info (MMON_MODULE_INFO &info, int module_index)
 {
-  int error = NO_ERROR;
-
   assert (mmon_Gl != nullptr);
   assert (module_index < (int)MMON_MODULE_LAST && module_index > 0);
 
-  error = mmon_Gl->aggregate_module_info (info, module_index);
-
-  return error;
+  return mmon_Gl->aggregate_module_info (info, module_index);
 }
 
-int mmon_aggregate_module_brief_info (MMON_MODULE_INFO *&info, int option)
+int mmon_aggregate_module_brief_info (MMON_MODULE_INFO *&info, MMON_MODULE_OPTION option)
 {
-  int error = NO_ERROR;
-
   assert (mmon_Gl != nullptr);
 
-  if (option == MMON_MODULE_BRIEF_OPTION || option == MMON_MODULE_DEFAULT_OPTION)
-    {
-      error = mmon_Gl->aggregate_module_brief_info (info, option);
-    }
-  else
-    {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
-      return ER_GENERIC_ERROR;
-    }
-
-  return error;
+  return mmon_Gl->aggregate_module_brief_info (info, option);
 }
 
 int mmon_aggregate_tran_info (MMON_TRAN_INFO &info, int tran_count)
 {
-  int error = NO_ERROR;
-
   assert (mmon_Gl != nullptr);
 
-  error = mmon_Gl->aggregate_tran_info (info, tran_count);
-
-  return error;
+  return mmon_Gl->aggregate_tran_info (info, tran_count);
 }

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -116,7 +116,7 @@ namespace cubperf
       mmon_module &operator = (const mmon_module &) = delete;
       mmon_module &operator = (mmon_module &&) = delete;
 
-      virtual void aggregate_stats (bool get_summary, MMON_MODULE_INFO &info) const;
+      virtual void aggregate_stats (bool is_summary, MMON_MODULE_INFO &info) const;
       void add_stat (MMON_STAT_ID stat_id, int64_t size);
       void add_expand_resize_count (MMON_STAT_ID stat_id);
       void end_init_phase ();
@@ -340,13 +340,13 @@ namespace cubperf
       }
   }
 
-  void mmon_module::aggregate_stats (bool get_summary, MMON_MODULE_INFO &info) const
+  void mmon_module::aggregate_stats (bool is_summary, MMON_MODULE_INFO &info) const
   {
     int error = NO_ERROR;
 
     strncpy (info.name, m_module_name.c_str (), m_module_name.size ());
 
-    if (get_summary)
+    if (is_summary)
       {
 	info.stat.cur_stat = m_stat.cur_stat.load ();
       }
@@ -496,7 +496,7 @@ namespace cubperf
 
   void memory_monitor::aggregater::get_transaction_info (int tran_count, MMON_TRAN_INFO &info) const
   {
-    std::vector <std::pair <int, uint64_t>> tran_info;
+    LOG_TRAN_MEM_INFO tran_info;
 
     logtb_get_tran_memory_info_nolatch (tran_info);
 

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -517,7 +517,14 @@ namespace cubperf
       }
     else
       {
-	info.num_tran = tran_count;
+	if (tran_count > tran_info.size ())
+	  {
+	    info.num_tran = tran_info.size ();
+	  }
+	else
+	  {
+	    info.num_tran = tran_count;
+	  }
 	qsort (&tran_info.front (), tran_info.size (), sizeof (tran_info[0]), comp);
       }
 

--- a/src/base/memory_monitor_sr.hpp
+++ b/src/base/memory_monitor_sr.hpp
@@ -51,7 +51,7 @@ void mmon_sub_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID stat_id, int64_t size);
 void mmon_move_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID src, MMON_STAT_ID dest, int64_t size);
 void mmon_resize_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID stat_id, int64_t old_size, int64_t new_size);
 int mmon_aggregate_module_info (MMON_MODULE_INFO &info, int module_index);
-int mmon_aggregate_module_brief_info (MMON_MODULE_INFO *&info, int option);
+int mmon_aggregate_module_brief_info (MMON_MODULE_INFO *&info, MMON_MODULE_OPTION option);
 int mmon_aggregate_tran_info (MMON_TRAN_INFO &info, int tran_count);
 
 #endif /* _MEMORY_MONITOR_SR_HPP_ */

--- a/src/base/memory_monitor_sr.hpp
+++ b/src/base/memory_monitor_sr.hpp
@@ -50,7 +50,7 @@ void mmon_add_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID stat_id, int64_t size);
 void mmon_sub_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID stat_id, int64_t size);
 void mmon_move_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID src, MMON_STAT_ID dest, int64_t size);
 void mmon_resize_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID stat_id, int64_t old_size, int64_t new_size);
-int mmon_aggregate_module_info (MMON_MODULE_INFO *info, int module_index);
-int mmon_aggregate_tran_info (MMON_TRAN_INFO *info, int tran_count);
+int mmon_aggregate_module_info (MMON_MODULE_INFO &info, int module_index);
+int mmon_aggregate_tran_info (MMON_TRAN_INFO &info, int tran_count);
 
 #endif /* _MEMORY_MONITOR_SR_HPP_ */

--- a/src/base/memory_monitor_sr.hpp
+++ b/src/base/memory_monitor_sr.hpp
@@ -50,8 +50,8 @@ void mmon_sub_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID stat_id, int64_t size);
 void mmon_move_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID src, MMON_STAT_ID dest, int64_t size);
 void mmon_resize_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID stat_id, int64_t old_size, int64_t new_size);
 void mmon_aggregate_server_info (MMON_SERVER_INFO &info);
-void mmon_aggregate_module_info (MMON_MODULE_INFO *&info, int module_index);
-void mmon_aggregate_module_info_summary (MMON_MODULE_INFO *&info);
-void mmon_aggregate_tran_info (MMON_TRAN_INFO &info, int tran_count);
+void mmon_aggregate_module_info (int module_index, MMON_MODULE_INFO *info);
+void mmon_aggregate_module_info_summary (MMON_MODULE_INFO *info);
+void mmon_aggregate_tran_info (int tran_count, MMON_TRAN_INFO &info);
 
 #endif /* _MEMORY_MONITOR_SR_HPP_ */

--- a/src/base/memory_monitor_sr.hpp
+++ b/src/base/memory_monitor_sr.hpp
@@ -27,7 +27,6 @@
 #error SERVER_MODE macro should be pre-defined to compile
 #endif /* SERVER_MODE */
 
-#include <cstdint>
 #include <type_traits>
 
 #include "perf_def.hpp"
@@ -51,8 +50,8 @@ void mmon_sub_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID stat_id, int64_t size);
 void mmon_move_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID src, MMON_STAT_ID dest, int64_t size);
 void mmon_resize_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID stat_id, int64_t old_size, int64_t new_size);
 void mmon_aggregate_server_info (MMON_SERVER_INFO &info);
-int mmon_aggregate_module_info (MMON_MODULE_INFO *&info, int module_index);
-int mmon_aggregate_module_info_summary (MMON_MODULE_INFO *&info, bool sorted_by_mem_usage);
-int mmon_aggregate_tran_info (MMON_TRAN_INFO &info, int tran_count);
+void mmon_aggregate_module_info (MMON_MODULE_INFO *&info, int module_index);
+void mmon_aggregate_module_info_summary (MMON_MODULE_INFO *&info, bool sorted_by_mem_usage);
+void mmon_aggregate_tran_info (MMON_TRAN_INFO &info, int tran_count);
 
 #endif /* _MEMORY_MONITOR_SR_HPP_ */

--- a/src/base/memory_monitor_sr.hpp
+++ b/src/base/memory_monitor_sr.hpp
@@ -52,7 +52,7 @@ void mmon_move_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID src, MMON_STAT_ID dest
 void mmon_resize_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID stat_id, int64_t old_size, int64_t new_size);
 void mmon_aggregate_server_info (MMON_SERVER_INFO &info);
 int mmon_aggregate_module_info (MMON_MODULE_INFO *&info, int module_index);
-int mmon_aggregate_module_info_summary (MMON_MODULE_INFO *&info, bool sorted_result);
+int mmon_aggregate_module_info_summary (MMON_MODULE_INFO *&info, bool sorted_by_mem_usage);
 int mmon_aggregate_tran_info (MMON_TRAN_INFO &info, int tran_count);
 
 #endif /* _MEMORY_MONITOR_SR_HPP_ */

--- a/src/base/memory_monitor_sr.hpp
+++ b/src/base/memory_monitor_sr.hpp
@@ -51,7 +51,7 @@ void mmon_move_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID src, MMON_STAT_ID dest
 void mmon_resize_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID stat_id, int64_t old_size, int64_t new_size);
 void mmon_aggregate_server_info (MMON_SERVER_INFO &info);
 void mmon_aggregate_module_info (MMON_MODULE_INFO *&info, int module_index);
-void mmon_aggregate_module_info_summary (MMON_MODULE_INFO *&info, bool sorted_by_mem_usage);
+void mmon_aggregate_module_info_summary (MMON_MODULE_INFO *&info);
 void mmon_aggregate_tran_info (MMON_TRAN_INFO &info, int tran_count);
 
 #endif /* _MEMORY_MONITOR_SR_HPP_ */

--- a/src/base/memory_monitor_sr.hpp
+++ b/src/base/memory_monitor_sr.hpp
@@ -51,6 +51,7 @@ void mmon_sub_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID stat_id, int64_t size);
 void mmon_move_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID src, MMON_STAT_ID dest, int64_t size);
 void mmon_resize_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID stat_id, int64_t old_size, int64_t new_size);
 int mmon_aggregate_module_info (MMON_MODULE_INFO &info, int module_index);
+int mmon_aggregate_module_brief_info (MMON_MODULE_INFO *&info, int option);
 int mmon_aggregate_tran_info (MMON_TRAN_INFO &info, int tran_count);
 
 #endif /* _MEMORY_MONITOR_SR_HPP_ */

--- a/src/base/memory_monitor_sr.hpp
+++ b/src/base/memory_monitor_sr.hpp
@@ -50,8 +50,9 @@ void mmon_add_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID stat_id, int64_t size);
 void mmon_sub_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID stat_id, int64_t size);
 void mmon_move_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID src, MMON_STAT_ID dest, int64_t size);
 void mmon_resize_stat (THREAD_ENTRY *thread_p, MMON_STAT_ID stat_id, int64_t old_size, int64_t new_size);
-int mmon_aggregate_module_info (MMON_MODULE_INFO &info, int module_index);
-int mmon_aggregate_module_brief_info (MMON_MODULE_INFO *&info, MMON_MODULE_OPTION option);
+void mmon_aggregate_server_info (MMON_SERVER_INFO &info);
+int mmon_aggregate_module_info (MMON_MODULE_INFO *&info, int module_index);
+int mmon_aggregate_module_info_summary (MMON_MODULE_INFO *&info, bool sorted_result);
 int mmon_aggregate_tran_info (MMON_TRAN_INFO &info, int tran_count);
 
 #endif /* _MEMORY_MONITOR_SR_HPP_ */

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -1202,7 +1202,7 @@ extern bool logtb_has_deadlock_priority (int tran_index);
 extern void xlogtb_dump_trantable (THREAD_ENTRY * thread_p, FILE * out_fp);
 
 /* For memory monitoring */
-extern LOG_TDES **logtb_get_trantable_nolatch (int *total_tran_indices);
+extern void logtb_get_tran_memory_info_nolatch (std::vector < std::pair < int, uint64_t >> &tran_info);
 
 extern bool logpb_need_wal (const LOG_LSA * lsa);
 extern char *logpb_backup_level_info_to_string (char *buf, int buf_size, const LOG_HDR_BKUP_LEVEL_INFO * info);

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -1203,7 +1203,8 @@ extern void xlogtb_dump_trantable (THREAD_ENTRY * thread_p, FILE * out_fp);
 
 /* For memory monitoring */
 // *INDENT-OFF*
-extern void logtb_get_tran_memory_info_nolatch (std::vector<std::pair<int, uint64_t>> &tran_info);
+typedef std::vector<std::pair <int, uint64_t>> LOG_TRAN_MEM_INFO;
+extern void logtb_get_tran_memory_info_nolatch (LOG_TRAN_MEM_INFO &tran_info);
 // *INDENT-ON*
 
 extern bool logpb_need_wal (const LOG_LSA * lsa);

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -1201,6 +1201,9 @@ extern bool logtb_has_deadlock_priority (int tran_index);
 /* For Debugging */
 extern void xlogtb_dump_trantable (THREAD_ENTRY * thread_p, FILE * out_fp);
 
+/* For memory monitoring */
+extern LOG_TDES **logtb_get_trantable_nolatch (int *total_tran_indices);
+
 extern bool logpb_need_wal (const LOG_LSA * lsa);
 extern char *logpb_backup_level_info_to_string (char *buf, int buf_size, const LOG_HDR_BKUP_LEVEL_INFO * info);
 extern const char *tran_abort_reason_to_string (TRAN_ABORT_REASON val);

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -1202,7 +1202,9 @@ extern bool logtb_has_deadlock_priority (int tran_index);
 extern void xlogtb_dump_trantable (THREAD_ENTRY * thread_p, FILE * out_fp);
 
 /* For memory monitoring */
-extern void logtb_get_tran_memory_info_nolatch (std::vector < std::pair < int, uint64_t >> &tran_info);
+// *INDENT-OFF*
+extern void logtb_get_tran_memory_info_nolatch (std::vector<std::pair<int, uint64_t>> &tran_info);
+// *INDENT-ON*
 
 extern bool logpb_need_wal (const LOG_LSA * lsa);
 extern char *logpb_backup_level_info_to_string (char *buf, int buf_size, const LOG_HDR_BKUP_LEVEL_INFO * info);

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -1466,7 +1466,7 @@ xlogtb_dump_trantable (THREAD_ENTRY * thread_p, FILE * out_fp)
  *
  */
 void
-logtb_get_tran_memory_info_nolatch (LOG_TRAN_MEM_INFO &tran_info)
+logtb_get_tran_memory_info_nolatch (LOG_TRAN_MEM_INFO & tran_info)
 {
   LOG_TDES *tdes;
 

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -1465,12 +1465,14 @@ xlogtb_dump_trantable (THREAD_ENTRY * thread_p, FILE * out_fp)
  * return: nothing
  *
  */
+// *INDENT-OFF*
 void
-logtb_get_tran_memory_info_nolatch (std::vector < std::pair < int, uint64_t >> &tran_info)
+logtb_get_tran_memory_info_nolatch (std::vector<std::pair<int, uint64_t>> &tran_info)
+// *INDENT-ON*
 {
   LOG_TDES *tdes;
 
-  for (int i = 0; i < NUM_TOTAL_TRAN_INDICES; i++)
+  for (int i = LOG_SYSTEM_TRAN_INDEX + 1; i < NUM_TOTAL_TRAN_INDICES; i++)
     {
       tdes = log_Gl.trantable.all_tdes[i];
       if (tdes != NULL && tdes->trid != NULL_TRANID && tdes->state == TRAN_ACTIVE)

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -1467,7 +1467,7 @@ xlogtb_dump_trantable (THREAD_ENTRY * thread_p, FILE * out_fp)
  */
 // *INDENT-OFF*
 void
-logtb_get_tran_memory_info_nolatch (std::vector<std::pair<int, uint64_t>> &tran_info)
+logtb_get_tran_memory_info_nolatch (LOG_TRAN_MEM_INFO &tran_info)
 // *INDENT-ON*
 {
   LOG_TDES *tdes;

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -1465,7 +1465,6 @@ xlogtb_dump_trantable (THREAD_ENTRY * thread_p, FILE * out_fp)
  * return: nothing
  *
  */
-// *INDENT-OFF*
 void
 logtb_get_tran_memory_info_nolatch (LOG_TRAN_MEM_INFO &tran_info)
 // *INDENT-ON*

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -68,6 +68,7 @@
 #include "dbtype.h"
 #if defined (SERVER_MODE)
 #include "server_support.h"
+#include "memory_monitor_sr.hpp"
 #endif // SERVER_MODE
 #include "string_buffer.hpp"
 #if defined (SA_MODE)
@@ -1458,17 +1459,25 @@ xlogtb_dump_trantable (THREAD_ENTRY * thread_p, FILE * out_fp)
 }
 
 /*
- * logtb_get_trantable_nolatch - get the transaction table with nolatch
+ * logtb_get_tran_memory_info_nolatch - get the transaction memory information
+ *                                      with nolatch
  *
- * return: trantable list
+ * return: nothing
  *
  */
-LOG_TDES **
-logtb_get_trantable_nolatch (int *total_tran_indices)
+void
+logtb_get_tran_memory_info_nolatch (std::vector < std::pair < int, uint64_t >> &tran_info)
 {
-  *total_tran_indices = NUM_TOTAL_TRAN_INDICES;
+  LOG_TDES *tdes;
 
-  return log_Gl.trantable.all_tdes;
+  for (int i = 0; i < NUM_TOTAL_TRAN_INDICES; i++)
+    {
+      tdes = log_Gl.trantable.all_tdes[i];
+      if (tdes != NULL && tdes->trid != NULL_TRANID && tdes->state == TRAN_ACTIVE)
+	{
+	  tran_info.push_back (std::make_pair (tdes->trid, tdes->cur_mem_usage.load ()));
+	}
+    }
 }
 
 /*

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -1467,7 +1467,6 @@ xlogtb_dump_trantable (THREAD_ENTRY * thread_p, FILE * out_fp)
  */
 void
 logtb_get_tran_memory_info_nolatch (LOG_TRAN_MEM_INFO &tran_info)
-// *INDENT-ON*
 {
   LOG_TDES *tdes;
 

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -1458,6 +1458,20 @@ xlogtb_dump_trantable (THREAD_ENTRY * thread_p, FILE * out_fp)
 }
 
 /*
+ * logtb_get_trantable_nolatch - get the transaction table with nolatch
+ *
+ * return: trantable list
+ *
+ */
+LOG_TDES **
+logtb_get_trantable_nolatch (int *total_tran_indices)
+{
+  *total_tran_indices = NUM_TOTAL_TRAN_INDICES;
+
+  return log_Gl.trantable.all_tdes;
+}
+
+/*
  * logtb_free_tran_mvcc_info - free transaction MVCC info
  *
  * return: nothing..


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24878

Implement aggregating functions

**Purpose:**
- The aggregating functions are implemented with the purpose of collecting and delivering memory usage information of registered modules that the Memory Monitoring Manager module has been monitoring, to the user upon their request.

**Additional Info:**
- Add mmon_aggregate_module_info_summary(..) and sub-functions for "brief" and "default" case of -m option