### PR TITLE
[CBRD-24516] separate agl-index-list: replace the information which is printed in "show trace" from aggregate function optimization

### DIFF
--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -7926,17 +7926,13 @@ scan_print_stats_text (FILE * fp, SCAN_ID * scan_id)
 	{
 	  SCAN_AGL *agl;
 
-	  fprintf (fp, ", agl: [");
+	  fprintf (fp, ", agl: ");
 	  for (agl = scan_id->scan_stats.agl; agl; agl = agl->next)
 	    {
 	      fprintf (fp, "%s", agl->agg_index_name);
 	      if (agl->next)
 		{
 		  fprintf (fp, ", ");
-		}
-	      else
-		{
-		  fprintf (fp, "]");
 		}
 	    }
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24516

change the trace message for agl-index list not to print out "[ ]".
