### PR TITLE
[LETS-754] Reset main connection after connecting PSes

### DIFF
--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -413,17 +413,16 @@ tran_server::disconnect_all_page_servers ()
 int
 tran_server::reset_main_connection ()
 {
-  auto &conn_vec = m_page_server_conn_vec;
   auto ulock = std::unique_lock<std::shared_mutex> { m_main_conn_mtx };
 
   /* the priority to select the main connection is the order in the container */
-  const auto main_conn_cand_it = std::find_if (conn_vec.cbegin (), conn_vec.cend (),
+  const auto main_conn_cand_it = std::find_if (m_page_server_conn_vec.cbegin (), m_page_server_conn_vec.cend (),
 				 [] (const auto &conn)
   {
     return conn->is_connected ();
   });
 
-  if (main_conn_cand_it == conn_vec.cend())
+  if (main_conn_cand_it == m_page_server_conn_vec.cend ())
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CONN_NO_PAGE_SERVER_AVAILABLE, 0);
       return ER_CONN_NO_PAGE_SERVER_AVAILABLE;

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -726,7 +726,7 @@ tran_server::ps_connector::try_connect_to_all_ps (cubthread::entry &)
 
       if (m_terminate.load ())
 	{
-	  break;
+	  return;
 	}
     }
 

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -735,8 +735,11 @@ tran_server::ps_connector::try_connect_to_all_ps (cubthread::entry &)
   if (newly_connected)
     {
       // It should be done when the connection_handler's state gets CONNECTED.
-      // TODO Someday, it will be CONNECTING right after connect() and become CONNECTED asynchronously, then it should be chnaged along.
-      (void) m_ts.reset_main_connection ();
+      // TODO in near future, it will be CONNECTING right after connect() and become CONNECTED asynchronously, then it should be changed along.
+      if (m_ts.reset_main_connection () != NO_ERROR)
+	{
+	  assert (false);
+	}
     }
 }
 

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -417,21 +417,21 @@ tran_server::reset_main_connection ()
   auto ulock = std::unique_lock<std::shared_mutex> { m_main_conn_mtx };
 
   /* the priority to select the main connection is the order in the container */
-  const auto main_conn_cand = std::find_if (conn_vec.cbegin (), conn_vec.cend (),
-			      [] (const auto &conn)
+  const auto main_conn_cand_it = std::find_if (conn_vec.cbegin (), conn_vec.cend (),
+				 [] (const auto &conn)
   {
     return conn->is_connected ();
   });
 
-  if (main_conn_cand == conn_vec.cend())
+  if (main_conn_cand_it == conn_vec.cend())
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CONN_NO_PAGE_SERVER_AVAILABLE, 0);
       return ER_CONN_NO_PAGE_SERVER_AVAILABLE;
     }
 
-  if (m_main_conn != main_conn_cand->get ())
+  if (m_main_conn != main_conn_cand_it->get ())
     {
-      m_main_conn = main_conn_cand->get ();
+      m_main_conn = main_conn_cand_it->get ();
       er_log_debug (ARG_FILE_LINE, "The main connection is set to %s.\n",
 		    m_main_conn->get_channel_id ().c_str ());
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-754

I thought that "resetting the main connection at the end of `connect()`" would allow the catchup during ATS boot, but it turns out its' not the case because the catch-up process also requires prior_lsa which hasn't initialized when making connection_handler.
So, It'd be better to reset the main connection after connecting all PSes.

- Reset the main connection after establishing all connections on `boot()`
- Reset the main connection after checking and reconnecting all PSes by `ps_connector`.
- Fix `reset_main_connection` not to mix up the main connection by widening the lock scope. It was that a main connection elected first can be set later.


Sidenote:
When the catch-up process is implemented, the resetting should be also revised. We will not be able to set a new connection as the main connection until the asynchronous catch-up process is done. My plan for now is to extend `ps_connector` to also check and reset the main connection periodically.
 
