### PR TITLE
backport for CBRD-24541 to 10.2

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -6749,6 +6749,11 @@ qexec_close_scan (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * curr_spec)
 	  curr_spec->parts = NULL;
 	  curr_spec->curent = NULL;
 	  curr_spec->pruned = false;
+	  /* init btid */
+	  if (curr_spec->indexptr)
+	    {
+	      BTID_COPY (&curr_spec->indexptr->btid, &curr_spec->btid);
+	    }
 	}
       break;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24541

backport for CBRD-24541 to 10.2
