### PR TITLE
[CBRD-24897] Query rewriter can lose parent paths of a name in qo_collect_name_spec()

### DIFF
--- a/src/optimizer/query_rewrite.c
+++ b/src/optimizer/query_rewrite.c
@@ -1152,6 +1152,9 @@ static PT_NODE *
 qo_collect_name_spec (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk)
 {
   PT_NAME_SPEC_INFO *info = (PT_NAME_SPEC_INFO *) arg;
+
+  /* To fall through from PT_DOT to PT_NAME, the `node` is changed in PT_DOT.
+   * The original `node` needs to be backed up in order to return it later. */
   PT_NODE *backup_node = node;
 
   *continue_walk = PT_CONTINUE_WALK;

--- a/src/optimizer/query_rewrite.c
+++ b/src/optimizer/query_rewrite.c
@@ -1152,6 +1152,7 @@ static PT_NODE *
 qo_collect_name_spec (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk)
 {
   PT_NAME_SPEC_INFO *info = (PT_NAME_SPEC_INFO *) arg;
+  PT_NODE *backup_node = node;
 
   *continue_walk = PT_CONTINUE_WALK;
 
@@ -1261,7 +1262,7 @@ qo_collect_name_spec (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *c
       *continue_walk = PT_STOP_WALK;
     }
 
-  return node;
+  return backup_node;
 }
 
 /*


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24897

In the qo_collect_name_spec function, to fall through from PT_DOT to PT_NAME, the `node` is changed in PT_DOT. The original `node` needs to be backed up in order to return it later.