### PR TITLE
[LETS-777] small refactoring of log prior sender

### DIFF
--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -1855,7 +1855,7 @@ prior_list_serialize (const log_prior_node *head)
     }
 
   // calculate size
-  size_t size = prior_list_serialized_size (head);
+  const size_t size = prior_list_serialized_size (head);
 
   std::string serialized;
   serialized.reserve (size);

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3438,6 +3438,10 @@ logpb_append_prior_lsa_list (THREAD_ENTRY * thread_p, LOG_PRIOR_NODE * list)
   assert (log_Gl.prior_info.prior_flush_list_header == NULL);
   log_Gl.prior_info.prior_flush_list_header = list;
 
+  // TODO
+  //  - only send this in case of active transaction server
+  //  - from page server to passive transaction servers, the log prior messages are
+  //    relayed without going through the unpackage-repackage loop
   log_Gl.m_prior_sender.send_list (list);
 
   /* append log buffer */

--- a/src/transaction/log_prior_send.hpp
+++ b/src/transaction/log_prior_send.hpp
@@ -52,6 +52,9 @@ namespace cublog
       void remove_sink (const sink_hook_t &fun);                  // add a hook for a new sink
 
     private:
+      void send_serialized_message (std::string &&message);
+
+    private:
       // non-owning pointers
       std::vector<const sink_hook_t *> m_sink_hooks;              // hooks for sinks
       std::mutex m_sink_hooks_mutex;                              // protect access on sink hooks


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-777

Extract the code that actually sends the packaged message in a function - which will be reused afterwards from the outside.

Small optimization to:
- copy messages to all but the last sink hook
- move the message into the last sink hook as it is of no use afterwards
