### PR TITLE
[CBRD-24906] The problem of performing a cross join by changing to the '0 <> 0' condition when the WHERE clause is always false

### DIFF
--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -357,7 +357,6 @@ extern "C"
   extern void pt_resolve_object (PARSER_CONTEXT * parser, PT_NODE * node);
   extern int pt_resolved (const PT_NODE * expr);
   extern bool pt_false_where (PARSER_CONTEXT * parser, PT_NODE * statement);
-  extern PT_NODE *pt_do_where_type (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);
   extern PT_NODE *pt_where_type (PARSER_CONTEXT * parser, PT_NODE * where);
   extern PT_NODE *pt_where_type_keep_true (PARSER_CONTEXT * parser, PT_NODE * where);
   extern bool pt_false_search_condition (PARSER_CONTEXT * parser, const PT_NODE * statement);

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -20385,20 +20385,6 @@ pt_semantic_type (PARSER_CONTEXT * parser, PT_NODE * tree, SEMANTIC_CHK_INFO * s
       tree = NULL;
     }
 
-  /* When qo_reduce_equality_terms is executed in mq_optimize, a removable predicate like '1=1' is generated.
-   * This predicate is removed by executing pt_where_type after pt_fold_const_expr has executed.
-   * 
-   * If this predicate remains without being removed, it becomes a data filter and MRO (Multiple Key Ranges
-   * Optimization) cannot be performed.
-   *
-   * See CBRD-24735 and CBRD-24906 for details. CBRD-24906 is a regression of CBRD-24735.
-   */
-  tree = parser_walk_tree (parser, tree, pt_eval_type_pre, sc_info_ptr, pt_eval_type, sc_info_ptr);
-  if (pt_has_error (parser))
-    {
-      tree = NULL;
-    }
-
   return tree;
 }
 

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -6810,45 +6810,6 @@ pt_product_sets (PARSER_CONTEXT * parser, TP_DOMAIN * domain, DB_VALUE * set1, D
 }
 
 /*
- * pt_do_where_type () -
- *   return:
- *   parser(in):
- *   node(in):
- *   arg(in):
- *   continue_walk(in):
- */
-PT_NODE *
-pt_do_where_type (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk)
-{
-  PT_NODE *spec = NULL;
-
-  if (node == NULL)
-    {
-      return NULL;
-    }
-
-  switch (node->node_type)
-    {
-    case PT_SELECT:
-      for (spec = node->info.query.q.select.from; spec; spec = spec->next)
-	{
-	  if (spec->node_type == PT_SPEC && spec->info.spec.on_cond)
-	    {
-	      spec->info.spec.on_cond = pt_where_type (parser, spec->info.spec.on_cond);
-	    }
-	}
-
-      node->info.query.q.select.where = pt_where_type (parser, node->info.query.q.select.where);
-      break;
-
-    default:
-      break;
-    }
-
-  return node;
-}
-
-/*
  * pt_where_type () - Test for constant folded where clause,
  * 		      and fold as necessary
  *   return:
@@ -20430,9 +20391,9 @@ pt_semantic_type (PARSER_CONTEXT * parser, PT_NODE * tree, SEMANTIC_CHK_INFO * s
    * If this predicate remains without being removed, it becomes a data filter and MRO (Multiple Key Ranges
    * Optimization) cannot be performed.
    *
-   * See CBRD-24735 for the details.
+   * See CBRD-24735 and CBRD-24906 for details. CBRD-24906 is a regression of CBRD-24735.
    */
-  tree = parser_walk_tree (parser, tree, NULL, NULL, pt_do_where_type, NULL);
+  tree = parser_walk_tree (parser, tree, pt_eval_type_pre, sc_info_ptr, pt_eval_type, sc_info_ptr);
   if (pt_has_error (parser))
     {
       tree = NULL;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24906

Revert the changes in CBRD-24735 (#4240).

An error occurs when the following query is executed.
   ```
   drop table if exists t1, t2;
   create table t1 (c1 int primary key, c2 int, c3 int);
   create table t2 (c1 int primary key, c2 int, c3 int);
   
   select /*+ recompile */ count (*)
   from t1 as a
   where a.c1 in (select b.c2 from t2 as b where a.c1 = b.c1 and b.c3 = 1 and b.c3 = 2);
   
   /*
   Query plan:
   
   iscan
       class: a node[0]
       index: pk_t1_c1 term[0] (covers)
       cost:  1 card 0
   
   Query stmt:
   
   select count(*) from t1 a where a.c1 in null
   
   ERROR: System error (index plan generation - invalid key value) in src/parser/xasl_generation.c (line: 12174)
   */
   ```

And other side-effects are expected.
So, we will revert CBRD-24735 and then change the approach to resolve the issue.