### PR TITLE
[CBRD-24872] [win] broker start ctrl-service wait for cas invocation

### DIFF
--- a/src/win_tools/ctrlservice/ctrlservice.cpp
+++ b/src/win_tools/ctrlservice/ctrlservice.cpp
@@ -83,6 +83,7 @@ int
 _tmain (int argc, char *argv[])
 {
   bool rc;
+  int broker_start_loop_cnt_max = 40;
 
   // Install a Service if -i switch used
   if (argc == 2)
@@ -257,6 +258,28 @@ _tmain (int argc, char *argv[])
 
 	  // send control code
 	  rc = ControlService (scHandle, service_control_code, &ss);
+
+	  /*
+	   * When starting a broker having large number of CASes,
+	   * it will waits for some time for CAS invocation.
+	   */
+
+	  if (service_control_code == SERVICE_CONTROL_BROKER_START)
+	    {
+	      for (int i = 0; i < broker_start_loop_cnt_max; i++ )
+	        {
+	          if (!rc && ss.dwCurrentState == SERVICE_RUNNING && GetLastError () == ERROR_SERVICE_REQUEST_TIMEOUT)
+	            {
+	              Sleep (200);
+	              rc = ControlService (scHandle, SERVICE_CONTROL_INTERROGATE, &ss);
+	            }
+	          else
+	            {
+	              break;
+	            }
+	        }
+	    }
+
 	  if (!rc && ss.dwCurrentState == SERVICE_RUNNING && GetLastError () == ERROR_SERVICE_REQUEST_TIMEOUT)
 	    {
 	      if (!ControlService (scHandle, SERVICE_CONTROL_INTERROGATE, &ss))

--- a/src/win_tools/ctrlservice/ctrlservice.cpp
+++ b/src/win_tools/ctrlservice/ctrlservice.cpp
@@ -267,17 +267,17 @@ _tmain (int argc, char *argv[])
 	  if (service_control_code == SERVICE_CONTROL_BROKER_START)
 	    {
 	      for (int i = 0; i < broker_start_loop_cnt_max; i++ )
-	        {
-	          if (!rc && ss.dwCurrentState == SERVICE_RUNNING && GetLastError () == ERROR_SERVICE_REQUEST_TIMEOUT)
-	            {
-	              Sleep (200);
-	              rc = ControlService (scHandle, SERVICE_CONTROL_INTERROGATE, &ss);
-	            }
-	          else
-	            {
-	              break;
-	            }
-	        }
+		{
+		  if (!rc && ss.dwCurrentState == SERVICE_RUNNING && GetLastError () == ERROR_SERVICE_REQUEST_TIMEOUT)
+		    {
+		      Sleep (200);
+		      rc = ControlService (scHandle, SERVICE_CONTROL_INTERROGATE, &ss);
+		    }
+		  else
+		    {
+		      break;
+		    }
+		}
 	    }
 
 	  if (!rc && ss.dwCurrentState == SERVICE_RUNNING && GetLastError () == ERROR_SERVICE_REQUEST_TIMEOUT)

--- a/src/win_tools/ctrlservice/ctrlservice.cpp
+++ b/src/win_tools/ctrlservice/ctrlservice.cpp
@@ -83,7 +83,7 @@ int
 _tmain (int argc, char *argv[])
 {
   bool rc;
-  int broker_start_loop_cnt_max = 40;
+  int broker_start_loop_cnt_max = 50;
 
   // Install a Service if -i switch used
   if (argc == 2)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24872

**Description**
* in Windows, **broker_start** is executed by a windows service.
* Windows Service Control Manager (SCM) spawns the service process for the broker_startup
* The broker_start service request may end with a timeout event in the middle of creating a CAS process.
  (Even in this case, the creation of the cas process proceeds normally)

**Implementation**
* monitor TIMEOUT event and wait 200ms for normal termination of **broker_startup**
  (repeat it until the timeout event is not caught or retry count reached to 50)
* 40 is for slow Windows machine