### PR TITLE
[CBRD-24908] [win] use SOMAXCONN_HINT to obtain actual backlog value

### DIFF
--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1408,7 +1408,11 @@ init_env (void)
       return (-1);
     }
 
+#if defined (WINDOWS)
+  if (listen (sock_fd, SOMAXCONN_HINT (shm_appl->job_queue_size)) < 0)
+#else
   if (listen (sock_fd, shm_appl->job_queue_size) < 0)
+#endif
     {
       UW_SET_ERROR_CODE (UW_ER_CANT_BIND, 0);
       return (-1);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24908

**Description**
* To accept a large number of client connection requests, the **CUBRID broker**'s connection wait queue must be set to a meaningful size.
* Unlike **Linux**, **Windows** scales backlog size requests from 200 to 65535 to around 200 unless otherwise specified.
* To control actual backlog size by ourselves, we need to indicate the Windows do not resize backlog size by itself as follow:

` ret =  listen (socket_descriptor, SOMAXCONN_HINT (backlog));`

