### PR TITLE
[LETS-778] Set the main conn even when uses_remote_storage () is false

### DIFF
--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -125,8 +125,12 @@ tran_server::boot (const char *db_name)
       return error_code;
     }
 
-  if (uses_remote_storage ())
+  if (m_page_server_conn_vec.empty () == false)
     {
+      /*
+       * At least one PS is given by the configuration.
+       * Even if uses_remote_storage () == false, the remote storage can exist.
+       */
       error_code = reset_main_connection ();
       if (error_code != NO_ERROR)
 	{
@@ -134,14 +138,17 @@ tran_server::boot (const char *db_name)
 	  return error_code;
 	}
 
+      m_ps_connector.start ();
+    }
+
+  if (uses_remote_storage ())
+    {
       error_code = get_boot_info_from_page_server ();
       if (error_code != NO_ERROR)
 	{
 	  ASSERT_ERROR ();
 	  return error_code;
 	}
-
-      m_ps_connector.start ();
     }
 
   return NO_ERROR;


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-778

It occurs because the main connection is not set. Even when `uses_remote_storage ()` is false, there can be remote storages, aka PS. Therefore, we have to set the main connection.

PS. `uses_remote_storage()` and the `remote_storage` parameter seems confusing to me. It seems to mean whether there is remote storage or not, but what it really mean is we are using the local storage. I think it'd better to change it to "uses_local_storage_only()` and adapt all the code using it since it's opposite meaning.