### PR TITLE
[CBRD-24910] Fix the core dump caused by accessing a corrupted log record header

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -14474,6 +14474,7 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
   LOG_LSA cur_log_lsa = LSA_INITIALIZER;
 
   LOG_RECORD_HEADER *log_rec_header;
+  LOG_RECTYPE log_type;
   LOG_REC_DONETIME *donetime;
   LOG_REC_HA_SERVER_STATE *dummy;
 
@@ -14572,10 +14573,11 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
 
       log_rec_header = LOG_GET_LOG_RECORD_HEADER (log_pgptr, &process_lsa);
       LSA_COPY (&forw_lsa, &log_rec_header->forw_lsa);
+      log_type = log_rec_header->type;
 
       LOG_READ_ADD_ALIGN (thread_p, sizeof (*log_rec_header), &process_lsa, log_pgptr);
 
-      if (log_rec_header->type == LOG_COMMIT || log_rec_header->type == LOG_ABORT)
+      if (log_type == LOG_COMMIT || log_type == LOG_ABORT)
 	{
 	  LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (*donetime), &process_lsa, log_pgptr);
 	  donetime = (LOG_REC_DONETIME *) (log_pgptr->area + process_lsa.offset);
@@ -14586,7 +14588,7 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
 	  return NO_ERROR;
 	}
 
-      if (log_rec_header->type == LOG_DUMMY_HA_SERVER_STATE)
+      if (log_type == LOG_DUMMY_HA_SERVER_STATE)
 	{
 	  LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (*dummy), &process_lsa, log_pgptr);
 	  dummy = (LOG_REC_HA_SERVER_STATE *) (log_pgptr->area + process_lsa.offset);
@@ -14633,10 +14635,11 @@ cdc_get_lsa_with_start_point (THREAD_ENTRY * thread_p, time_t * time, LOG_LSA * 
   LOG_LSA process_lsa;
   LOG_LSA current_lsa;
 
-  LOG_RECORD_HEADER *log_rec_header;
   LOG_PAGE *log_page_p = NULL;
   char *log_pgbuf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
 
+  LOG_RECORD_HEADER *log_rec_header;
+  LOG_RECTYPE log_type;
   LOG_REC_DONETIME *donetime;
   LOG_REC_HA_SERVER_STATE *dummy;
   time_t at_time;
@@ -14670,10 +14673,11 @@ cdc_get_lsa_with_start_point (THREAD_ENTRY * thread_p, time_t * time, LOG_LSA * 
 
       LSA_COPY (&current_lsa, &process_lsa);
       LSA_COPY (&forw_lsa, &log_rec_header->forw_lsa);
+      log_type = log_rec_header->type;
 
       LOG_READ_ADD_ALIGN (thread_p, sizeof (*log_rec_header), &process_lsa, log_page_p);
 
-      if (log_rec_header->type == LOG_COMMIT || log_rec_header->type == LOG_ABORT)
+      if (log_type == LOG_COMMIT || log_type == LOG_ABORT)
 	{
 	  LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (*donetime), &process_lsa, log_page_p);
 	  donetime = (LOG_REC_DONETIME *) (log_page_p->area + process_lsa.offset);
@@ -14687,7 +14691,7 @@ cdc_get_lsa_with_start_point (THREAD_ENTRY * thread_p, time_t * time, LOG_LSA * 
 	    }
 	}
 
-      if (log_rec_header->type == LOG_DUMMY_HA_SERVER_STATE)
+      if (log_type == LOG_DUMMY_HA_SERVER_STATE)
 	{
 	  LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (*dummy), &process_lsa, log_page_p);
 	  dummy = (LOG_REC_HA_SERVER_STATE *) (log_page_p->area + process_lsa.offset);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -14649,15 +14649,12 @@ cdc_get_lsa_with_start_point (THREAD_ENTRY * thread_p, time_t * time, LOG_LSA * 
   log_page_p = (LOG_PAGE *) PTR_ALIGN (log_pgbuf, MAX_ALIGNMENT);
   log_page_p->hdr.logical_pageid = NULL_PAGEID;
   log_page_p->hdr.offset = NULL_OFFSET;
-  bool is_active = false;
 
   char ctime_buf[CTIME_MAX];
   int error = NO_ERROR;
 
-  if (LSA_ISNULL (start_lsa))
-    {
-      is_active = true;
-    }
+  assert (!LSA_ISNULL (start_lsa));
+  cdc_log ("%s : start point LSA = %3lld|%3d", __func__, LSA_AS_ARGS (start_lsa));
 
   LSA_COPY (&process_lsa, start_lsa);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24910

Purpose

`cdc_get_start_point_from_file ()` should return the LSA of log record which contains time value. 
But It was not returning the accurate address of the log. It was returning the end position of the log record instead. 

NOTE : 
When the end position of a log record coincides with the starting position of the next log record, it is possible to find the log record header of the next log record using the end position of the current log record. However, if the end position of the log record differs from the starting position of the next log record, it can lead to accessing a corrupted log record header

Crashed in `cdc_get_lsa_with_start_point`, `cdc_get_lsa_with_start_point ()` uses LSA returned from `cdc_get_start_point_from_file ()` and assumes that LSA is pointing to the log record header. 