### PR TITLE
[LETS-406] initialize log prior sender only when needed

### DIFF
--- a/src/server/active_tran_server.cpp
+++ b/src/server/active_tran_server.cpp
@@ -189,7 +189,7 @@ active_tran_server::connection_handler::on_connecting ()
 
   m_prior_sender_sink_hook_func = std::bind (&active_tran_server::connection_handler::prior_sender_sink_hook, this,
 				  std::placeholders::_1);
-  log_Gl.m_prior_sender.add_sink (m_prior_sender_sink_hook_func);
+  log_Gl.get_log_prior_sender ().add_sink (m_prior_sender_sink_hook_func);
 }
 
 void
@@ -197,7 +197,7 @@ active_tran_server::connection_handler::on_disconnecting ()
 {
   if (m_prior_sender_sink_hook_func != nullptr)
     {
-      log_Gl.m_prior_sender.remove_sink (m_prior_sender_sink_hook_func);
+      log_Gl.get_log_prior_sender ().remove_sink (m_prior_sender_sink_hook_func);
       m_prior_sender_sink_hook_func = nullptr;
     }
 }

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -325,7 +325,7 @@ page_server::connection_handler::remove_prior_sender_sink ()
 
   if (static_cast<bool> (m_prior_sender_sink_hook_func))
     {
-      log_Gl.m_prior_sender.remove_sink (m_prior_sender_sink_hook_func);
+      log_Gl.get_log_prior_sender ().remove_sink (m_prior_sender_sink_hook_func);
       m_prior_sender_sink_hook_func = nullptr;
     }
 }

--- a/src/transaction/log_global.c
+++ b/src/transaction/log_global.c
@@ -151,7 +151,6 @@ void
 log_global::finalize_log_prior_sender ()
 {
   assert (m_prior_sender != nullptr);
-  assert (m_prior_sender->is_empty ());
   m_prior_sender.reset (nullptr);
 }
 

--- a/src/transaction/log_global.c
+++ b/src/transaction/log_global.c
@@ -77,7 +77,6 @@ log_global::log_global ()
   , bg_archive_info ()
   , mvcc_table ()
   , unique_stats_table GLOBAL_UNIQUE_STATS_TABLE_INITIALIZER
-  , m_prior_sender ()
   , m_ps_lsa_up_to_date (false)
   , m_ps_consensus_flushed_lsa (NULL_LSA)
 {
@@ -142,14 +141,38 @@ log_global::wait_for_ps_flushed_lsa (const log_lsa &flush_lsa)
 }
 
 void
+log_global::initialize_log_prior_sender ()
+{
+  assert (m_prior_sender == nullptr);
+  m_prior_sender = std::make_unique<cublog::prior_sender> ();
+}
+
+void
+log_global::finalize_log_prior_sender ()
+{
+  assert (m_prior_sender != nullptr);
+  assert (m_prior_sender->is_empty ());
+  m_prior_sender.reset (nullptr);
+}
+
+cublog::prior_sender &
+log_global::get_log_prior_sender()
+{
+  assert (m_prior_sender != nullptr);
+  return *m_prior_sender;
+}
+
+void
 log_global::initialize_log_prior_receiver ()
 {
+  assert (m_prior_recver == nullptr);
   m_prior_recver = std::make_unique<cublog::prior_recver> (prior_info);
 }
 
 void
 log_global::finalize_log_prior_receiver ()
 {
+  assert (m_prior_recver != nullptr);
   m_prior_recver.reset (nullptr);
 }
 

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -714,29 +714,40 @@ struct log_global
 
   // *INDENT-OFF*
   cublog::meta m_metainfo;
-  cublog::prior_sender m_prior_sender;
+private:
 #if defined (SERVER_MODE)
+  std::unique_ptr<cublog::prior_sender> m_prior_sender = nullptr;
   std::unique_ptr<cublog::prior_recver> m_prior_recver = nullptr;
-#endif // SERVER_MODE = !SA_MODE
+#endif /* SERVER_MODE = !SA_MODE */
+  // *INDENT-ON*
 
-  private:
-    std::mutex m_ps_lsa_mutex;
-    std::condition_variable m_ps_lsa_cv;
-    std::atomic<bool> m_ps_lsa_up_to_date;
-    LOG_LSA m_ps_consensus_flushed_lsa; // The quorum (number of the majority) of PS have done flushing log recrods until this.
+private:
+  // *INDENT-OFF*
+  std::mutex m_ps_lsa_mutex;
+  std::condition_variable m_ps_lsa_cv;
+  std::atomic<bool> m_ps_lsa_up_to_date;
+  LOG_LSA m_ps_consensus_flushed_lsa;	// The quorum (number of the majority) of PS have done flushing log recrods until this.
+  // *INDENT-ON*
 
-  public:
-  log_global ();
-  ~log_global ();
+public:
+    log_global ();
+   ~log_global ();
 
 #if defined (SERVER_MODE)
+  void initialize_log_prior_sender ();
+  void finalize_log_prior_sender ();
+  // *INDENT-OFF*
+  cublog::prior_sender &get_log_prior_sender ();
+  // *INDENT-ON*
   void initialize_log_prior_receiver ();
   void finalize_log_prior_receiver ();
+  // *INDENT-OFF*
   cublog::prior_recver &get_log_prior_receiver ();
+  // *INDENT-ON*
+
   void wait_for_ps_flushed_lsa (const log_lsa & flush_lsa);
   void wakeup_ps_flush_waiters ();
-#endif // SERVER_MODE
-  // *INDENT-ON*
+#endif				/* SERVER_MODE */
 };
 
 /* logging statistics */

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -727,11 +727,11 @@ private:
   std::condition_variable m_ps_lsa_cv;
   std::atomic<bool> m_ps_lsa_up_to_date;
   LOG_LSA m_ps_consensus_flushed_lsa;	// The quorum (number of the majority) of PS have done flushing log recrods until this.
-  // *INDENT-ON*
 
 public:
-    log_global ();
-   ~log_global ();
+  log_global ();
+  ~log_global ();
+  // *INDENT-ON*
 
 #if defined (SERVER_MODE)
   void initialize_log_prior_sender ();

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -3492,7 +3492,7 @@ log_pack_log_boot_info (THREAD_ENTRY &thread_r, std::string &payload_in_out,
 			  sizeof (log_lsa));
 
     // within the same locks, initialize log prior dispatch to the newly connected passive transaction server
-    log_Gl.m_prior_sender.add_sink (log_prior_sender_sink);
+    log_Gl.get_log_prior_sender ().add_sink (log_prior_sender_sink);
     // TODO: in the future, this needs to be made explicit:
     //  - as passive transaction servers (PTS) go on/off-line at a random pace
     //  - and, as each PTS has the list of available page servers (PS) it can connect to

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3438,11 +3438,15 @@ logpb_append_prior_lsa_list (THREAD_ENTRY * thread_p, LOG_PRIOR_NODE * list)
   assert (log_Gl.prior_info.prior_flush_list_header == NULL);
   log_Gl.prior_info.prior_flush_list_header = list;
 
-  // TODO
-  //  - only send this in case of active transaction server
-  //  - from page server to passive transaction servers, the log prior messages are
-  //    relayed without going through the unpackage-repackage loop
-  log_Gl.m_prior_sender.send_list (list);
+#if defined(SERVER_MODE)
+  if (is_active_transaction_server ())
+    {
+      // only send this in case of active transaction server
+      // from page server to passive transaction servers, the log prior messages are
+      // relayed without going through the unpackage-repackage loop
+      log_Gl.get_log_prior_sender ().send_list (list);
+    }
+#endif /* SERVER_MODE */
 
   /* append log buffer */
   while (log_Gl.prior_info.prior_flush_list_header != NULL)

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3439,11 +3439,9 @@ logpb_append_prior_lsa_list (THREAD_ENTRY * thread_p, LOG_PRIOR_NODE * list)
   log_Gl.prior_info.prior_flush_list_header = list;
 
 #if defined(SERVER_MODE)
-  if (is_active_transaction_server ())
+  if (is_active_transaction_server () || is_page_server ())
     {
-      // only send this in case of active transaction server
-      // from page server to passive transaction servers, the log prior messages are
-      // relayed without going through the unpackage-repackage loop
+      // the log prior sender is not initialized on a passive transaction server
       log_Gl.get_log_prior_sender ().send_list (list);
     }
 #endif /* SERVER_MODE */

--- a/src/transaction/log_prior_send.cpp
+++ b/src/transaction/log_prior_send.cpp
@@ -25,6 +25,14 @@
 
 namespace cublog
 {
+  prior_sender::~prior_sender ()
+  {
+    // this assert works because an instance of this class is kept inside a unique pointer;
+    // the way the unique pointer implements the reset functions is:
+    // first un-assigns the held pointer and the deletes it
+    assert (is_empty ());
+  }
+
   void
   prior_sender::send_list (const log_prior_node *head)
   {

--- a/src/transaction/log_prior_send.cpp
+++ b/src/transaction/log_prior_send.cpp
@@ -84,4 +84,11 @@ namespace cublog
     assert (find_it != m_sink_hooks.end ());
     m_sink_hooks.erase (find_it);
   }
+
+  bool
+  prior_sender::is_empty ()
+  {
+    std::unique_lock<std::mutex> ulock (m_sink_hooks_mutex);
+    return m_sink_hooks.empty ();
+  }
 }

--- a/src/transaction/log_prior_send.hpp
+++ b/src/transaction/log_prior_send.hpp
@@ -39,6 +39,8 @@ namespace cublog
 
     public:
       prior_sender () = default;
+      ~prior_sender ();
+
       prior_sender (const prior_sender &) = delete;
       prior_sender (prior_sender &&) = delete;
 

--- a/src/transaction/log_prior_send.hpp
+++ b/src/transaction/log_prior_send.hpp
@@ -53,10 +53,9 @@ namespace cublog
       void add_sink (const sink_hook_t &fun);                     // add a hook for a new sink
       void remove_sink (const sink_hook_t &fun);                  // add a hook for a new sink
 
-      bool is_empty ();
-
     private:
       void send_serialized_message (std::string &&message);
+      bool is_empty ();
 
     private:
       // non-owning pointers

--- a/src/transaction/log_prior_send.hpp
+++ b/src/transaction/log_prior_send.hpp
@@ -40,7 +40,7 @@ namespace cublog
     public:
       prior_sender () = default;
       prior_sender (const prior_sender &) = delete;
-      prior_sender (prior_sender &&) = default;
+      prior_sender (prior_sender &&) = delete;
 
       prior_sender &operator = (const prior_sender &) = delete;
       prior_sender &operator = (prior_sender &&) = delete;
@@ -50,6 +50,8 @@ namespace cublog
 
       void add_sink (const sink_hook_t &fun);                     // add a hook for a new sink
       void remove_sink (const sink_hook_t &fun);                  // add a hook for a new sink
+
+      bool is_empty ();
 
     private:
       void send_serialized_message (std::string &&message);

--- a/unit_tests/log/test_main_chkpt_info.cpp
+++ b/unit_tests/log/test_main_chkpt_info.cpp
@@ -827,7 +827,16 @@ namespace cublog
     : m_prior_lsa_info (prior_lsa_info)
   {
   }
-  prior_recver::~prior_recver () = default;
+
+  prior_recver::~prior_recver ()
+  {
+    assert_release (!m_thread.joinable ());
+  }
+
+  prior_sender::~prior_sender ()
+  {
+    assert_release (false);
+  }
 }
 
 mvcc_active_tran::mvcc_active_tran () = default;

--- a/unit_tests/log/test_main_prior_list_serialize.cpp
+++ b/unit_tests/log/test_main_prior_list_serialize.cpp
@@ -300,9 +300,11 @@ test_env::require_mem_equal (const char *memleft, const char *memrite, size_t me
     }
 }
 
-//
-// Definitions of CUBRID stuff that is not used, but is needed by the linker
-//
+// ****************************************************************
+// CUBRID stuff; required by linker:
+//  - whatever is not (should not be) touched at all is asserted
+//  - some of it actually called with benign/no effect
+// ****************************************************************
 
 #include "error_manager.h"
 #include "log_compress.h"
@@ -457,7 +459,16 @@ namespace cublog
     : m_prior_lsa_info (prior_lsa_info)
   {
   }
-  prior_recver::~prior_recver () = default;
+
+  prior_recver::~prior_recver ()
+  {
+    assert_release (!m_thread.joinable ());
+  }
+
+  prior_sender::~prior_sender ()
+  {
+    assert_release (false);
+  }
 }
 
 log_global::log_global ()

--- a/unit_tests/log/test_main_prior_sendrecv.cpp
+++ b/unit_tests/log/test_main_prior_sendrecv.cpp
@@ -141,7 +141,13 @@ test_env::~test_env ()
   free_list (m_source_nodes_head);
   free_list (m_source_prior_info.prior_list_header);
 
+  for (const auto &sink : m_prior_sender_sinks)
+    {
+      // hooks sinks on the sender
+      m_sender.remove_sink (sink);
+    }
   m_prior_sender_sinks.clear ();
+
   for (size_t i = 0; i < m_recvers.size (); ++i)
     {
       delete m_recvers[i];

--- a/unit_tests/log_repl/test_main_log_repl_atomic_helper.cpp
+++ b/unit_tests/log_repl/test_main_log_repl_atomic_helper.cpp
@@ -942,7 +942,9 @@ er_set (int severity, const char */*file_name*/, const int /*line_no*/, int err_
 }
 
 // ****************************************************************
-// CUBRID stuff; not used but required by linker
+// CUBRID stuff; required by linker:
+//  - whatever is not (should not be) touched at all is asserted
+//  - some of it actually called with benign/no effect
 // ****************************************************************
 
 const char *
@@ -1073,17 +1075,19 @@ namespace cublog
   {
     assert_release (!m_thread.joinable ());
   }
+
+  prior_sender::~prior_sender ()
+  {
+    assert_release (false);
+  }
 }
 
 log_global::log_global ()
-//: m_prior_recver (std::make_unique<cublog::prior_recver> (prior_info))
 {
-  //assert (false);
 }
 
 log_global::~log_global ()
 {
-  //assert (false);
 }
 
 int


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-406

Log prior sender is only initialized when needed - on ATS (which originates the log) and PS (which only relays the log from ATS to PTSs).

Implementation:
- the class usage is changed from a value member of `struct log_global` to a unique pointer
- both `log_global::m_prior_sender` and `log_global::m_prior_recver` have been made private and accessed via getters - `get_log_prior_sender` and `get_log_prior_receiver` (which existed before)
- `init_server_type`: initialize `log_global::m_prior_sender` for ATS and PS; will remain null for PTS as PTS does not dispatch log prior nodes any further
  - previously, on PTS, the function `log_Gl.get_log_prior_sender ().send_list` would be called
  - the log prior lists would be serialized and then thrown away as no log prior sinks are ever registered on a PTS
- `logpb_append_prior_lsa_list`: the dispatch of log prior linked lists is only done for Active Transaction Servers and Page Servers
- `xboot_shutdown_server`: it is needed to tear down connection infrastructure on ATS after the call to `log_final` (which flushes the log and, thus, needs to have the log prior sender alive); moved tearing down of connection infrastructure to peer servers on ATS after the call to `log_final` (1)
- adapted calls to use the getters
- adapted tests  following addition of an explicit destructor

With regard to (1), scalability tests have been run and execute successfully.

