### PR TITLE
[CBRD-24892] The restoredb with level 1 fails when some of the permanent volume header is not included

### DIFF
--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -10419,10 +10419,18 @@ fileio_restore_volume (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session_
 	    {
 	      if (volid != LOG_DBFIRST_VOLID && is_prev_vol_header_restored == false)
 		{
+#if !defined(NDEBUG)
+		  printf ("[FOUND UNLINK] [lv%d] volid=%d, vol=%s, prev_vol=%s\n", session_p->dbfile.level, volid,
+			  to_vol_label_p, prev_vol_label_p);
+#endif
 		  auto it_found = find_if (unlinked_vol_info.cbegin (), unlinked_vol_info.cend (), find_unlinked_vol);
 
 		  if (it_found == unlinked_vol_info.cend ())
 		    {
+#if !defined(NDEBUG)
+		      printf ("[SAVE UNLINK] [lv%d] volid=%d, vol=%s, prev_vol=%s\n", session_p->dbfile.level, volid,
+			      to_vol_label_p, prev_vol_label_p);
+#endif
 		      unlinked_vol_info.push_back (make_tuple
 						   (volid, string (to_vol_label_p), string (prev_vol_label_p)));
 		    }
@@ -10434,9 +10442,13 @@ fileio_restore_volume (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session_
 
 	      if (it_found != unlinked_vol_info.cend ())
 		{
+#if !defined(NDEBUG)
+		  printf ("[UNSAVE UNLINK] [lv%d] volid=%d, vol=%s, prev_vol=%s\n", session_p->dbfile.level, volid,
+			  to_vol_label_p, prev_vol_label_p);
+#endif
 		  // The volume headers of both previous and current volumes are in the full level backup volume.
-                  // Therefore, the link between the two volumes is naturally established during the restoration process.
-                  // So, there is no need to explicitly set it.
+		  // Therefore, the link between the two volumes is naturally established during the restoration process.
+		  // So, there is no need to explicitly set it.
 		  unlinked_vol_info.erase (it_found);
 		}
 	    }

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -10455,6 +10455,10 @@ fileio_restore_volume (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session_
 
 	  is_prev_vol_header_restored = true;
 	}
+      else
+	{
+	  is_prev_vol_header_restored = false;
+	}
 
       /* save current volname */
       strncpy (prev_vol_label_p, to_vol_label_p, PATH_MAX);

--- a/src/storage/file_io.h
+++ b/src/storage/file_io.h
@@ -577,7 +577,8 @@ extern int fileio_get_next_restore_file (THREAD_ENTRY * thread_p, FILEIO_BACKUP_
 					 VOLID * volid);
 extern int fileio_restore_volume (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session, char *to_vlabel,
 				  char *verbose_to_vlabel, char *prev_vlabel, FILEIO_RESTORE_PAGE_BITMAP * page_bitmap,
-				  bool remember_pages);
+				  bool remember_pages, bool & is_prev_vheader_restored, std::vector < std::tuple < int,
+				  std::string, std::string >> &unlinked_vol_info);
 extern int fileio_skip_restore_volume (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session);
 extern const char *fileio_get_zip_method_string (FILEIO_ZIP_METHOD zip_method);
 extern const char *fileio_get_zip_level_string (FILEIO_ZIP_LEVEL zip_level);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24892