### PR TITLE
[CBRD-24897] Query rewriter can lose parent paths of a name in qo_collect_name_spec() (#4501)

### DIFF
--- a/src/optimizer/query_rewrite.c
+++ b/src/optimizer/query_rewrite.c
@@ -1105,6 +1105,10 @@ qo_collect_name_spec (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *c
 {
   PT_NAME_SPEC_INFO *info = (PT_NAME_SPEC_INFO *) arg;
 
+  /* To fall through from PT_DOT to PT_NAME, the `node` is changed in PT_DOT.
+   * The original `node` needs to be backed up in order to return it later. */
+  PT_NODE *backup_node = node;
+
   *continue_walk = PT_CONTINUE_WALK;
 
   switch (node->node_type)
@@ -1213,7 +1217,7 @@ qo_collect_name_spec (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *c
       *continue_walk = PT_STOP_WALK;
     }
 
-  return node;
+  return backup_node;
 }
 
 /*


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24897

backport #4501