### PR TITLE
[CBRD-24478] fixed missing INVISIBLE keyword in unloaddb

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -3564,7 +3564,7 @@ emit_index_def (extract_context & ctxt, print_output & output_ctx, DB_OBJECT * c
 	  output_ctx (" WITH ONLINE");
 	}
 #endif
-      else if (constraint->index_status == SM_INVISIBLE_INDEX)
+      if (constraint->index_status == SM_INVISIBLE_INDEX)
 	{
 	  output_ctx (" INVISIBLE ");
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24478

* In the process of unloaddb, there was a problem of missing the invisible keyword.
  It was an error when writing the dbname_indexes file, which is the result of unloaddb.

* case
   1) create table tbl(c1 int, c2 int, c3 int, index idx1 (c1) invisible);
   2) unload
   3) in dbname_indexes file
     CREATE INDEX [idx1] ON [dba].[tbl] ([c1]) WITH DEDUPLICATE=0;    --- fail 
     CREATE INDEX [idx1] ON [dba].[tbl] ([c1]) WITH DEDUPLICATE=0 INVISIBLE ;  -- after fix
