### PR TITLE
[LETS-780] Add details in "Quorum unsatisfied:.." msg for tests

### DIFF
--- a/src/server/active_tran_server.cpp
+++ b/src/server/active_tran_server.cpp
@@ -87,14 +87,20 @@ active_tran_server::compute_consensus_lsa ()
    */
   std::sort (collected_saved_lsa.begin (), collected_saved_lsa.end ());
 
-  LOG_LSA consensus_lsa;
-
-  if (cur_node_cnt < quorum)
+    LOG_LSA consensus_lsa;
+    if (cur_node_cnt < quorum)
     {
+      if (prm_get_bool_value (PRM_ID_ER_LOG_QUORUM_CONSENSUS))
+        {
+          // if the quorum is not met, only sort if we're about to log the details (see below); otherwise the sorting is useless   
+          std::sort (collected_saved_lsa.begin (), collected_saved_lsa.end ());
+        }
       consensus_lsa = NULL_LSA; // the quorum is not met.
     }
   else
     {
+      // always do the sort if the quorum is met:
+      std::sort (collected_saved_lsa.begin (), collected_saved_lsa.end ());
       consensus_lsa = collected_saved_lsa[cur_node_cnt - quorum];
     }
 
@@ -106,10 +112,7 @@ active_tran_server::compute_consensus_lsa ()
 
       n = snprintf (msg_buf, BUF_SIZE, "compute_consensus_lsa - ");
 
-      if (cur_node_cnt < quorum)
-	{
-	  n += snprintf (msg_buf + n, BUF_SIZE - n, "Quorum unsatisfied: ");
-	}
+      n += snprintf (msg_buf + n, BUF_SIZE - n, "Quorum %ssatisfied: ", ((cur_node_cnt < quorum) ? "un" : ""));
 
       // cppcheck-suppress [wrongPrintfScanfArgNum]
       n += snprintf (msg_buf + n, BUF_SIZE - n,

--- a/src/server/active_tran_server.cpp
+++ b/src/server/active_tran_server.cpp
@@ -85,16 +85,17 @@ active_tran_server::compute_consensus_lsa ()
    * total: 5, cur: 4 - [5, 6, 9, 10] -> "6"
    * total: 3, cur: 2 - [9, 10] -> "9"
    */
-  std::sort (collected_saved_lsa.begin (), collected_saved_lsa.end ());
 
-    LOG_LSA consensus_lsa;
-    if (cur_node_cnt < quorum)
+  const bool quorum_not_met = cur_node_cnt < quorum;
+
+  LOG_LSA consensus_lsa;
+  if (quorum_not_met)
     {
       if (prm_get_bool_value (PRM_ID_ER_LOG_QUORUM_CONSENSUS))
-        {
-          // if the quorum is not met, only sort if we're about to log the details (see below); otherwise the sorting is useless   
-          std::sort (collected_saved_lsa.begin (), collected_saved_lsa.end ());
-        }
+	{
+	  // if the quorum is not met, only sort if we're about to log the details (see below); otherwise the sorting is useless
+	  std::sort (collected_saved_lsa.begin (), collected_saved_lsa.end ());
+	}
       consensus_lsa = NULL_LSA; // the quorum is not met.
     }
   else
@@ -112,7 +113,7 @@ active_tran_server::compute_consensus_lsa ()
 
       n = snprintf (msg_buf, BUF_SIZE, "compute_consensus_lsa - ");
 
-      n += snprintf (msg_buf + n, BUF_SIZE - n, "Quorum %ssatisfied: ", ((cur_node_cnt < quorum) ? "un" : ""));
+      n += snprintf (msg_buf + n, BUF_SIZE - n, "Quorum %ssatisfied: ", (quorum_not_met ? "un" : ""));
 
       // cppcheck-suppress [wrongPrintfScanfArgNum]
       n += snprintf (msg_buf + n, BUF_SIZE - n,


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-780

Add details in the log msg printe when the quorum is not met.
- In this case, the consensus_lsa is printed as NULL_LSA (-1|-1).