### PR TITLE
[CBRD-24842] Print the error message when the hostname lookup fails before the broker is initialized

### DIFF
--- a/src/broker/broker_admin_pub.c
+++ b/src/broker/broker_admin_pub.c
@@ -74,6 +74,8 @@
 #include "chartype.h"
 #include "cubrid_getopt.h"
 #include "dbtype_def.h"
+#include "host_lookup.h"
+#include "system_parameter.h"
 
 #if defined(CAS_FOR_ORACLE) || defined(CAS_FOR_MYSQL)
 #define DB_EMPTY_SESSION        (0)
@@ -324,9 +326,17 @@ admin_start_cmd (T_BROKER_INFO * br_info, int br_num, int master_shm_id, bool ac
     }
   chdir (envvar_bindir_file (path, BROKER_PATH_MAX, ""));
 
+  if (gethostname (hostname, sizeof (hostname)) < 0)
+    {
+      fprintf (stderr, "gethostname error\n");
+      return -1;
+    }
   /* cannot execute broker initialize unless success host look-up */
   if (GETHOSTNAME (hostname, CUB_MAXHOSTNAMELEN) != 0)
     {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_TCP_HOST_NAME_ERROR, 2, hostname, HOSTS_FILE);
+      fprintf (stderr, er_msg ());
+      fflush (stderr);
       return -1;
     }
 

--- a/src/broker/broker_admin_pub.c
+++ b/src/broker/broker_admin_pub.c
@@ -328,7 +328,7 @@ admin_start_cmd (T_BROKER_INFO * br_info, int br_num, int master_shm_id, bool ac
 
   if (gethostname (hostname, sizeof (hostname)) < 0)
     {
-      fprintf (stderr, "gethostname error\n");
+      fprintf (stderr, "gethostname error: cannot get local hostname\n");
       return -1;
     }
   /* cannot execute broker initialize unless success host look-up */

--- a/src/broker/broker_shm.c
+++ b/src/broker/broker_shm.c
@@ -757,7 +757,7 @@ get_host_ip (unsigned char *ip_addr)
 
   if (gethostname (hostname, sizeof (hostname)) < 0)
     {
-      fprintf (stderr, "gethostname error\n");
+      fprintf (stderr, "gethostname error: cannot get local hostname\n");
       return -1;
     }
   if ((hp = gethostbyname_uhost (hostname)) == NULL)

--- a/src/broker/broker_shm.c
+++ b/src/broker/broker_shm.c
@@ -757,7 +757,7 @@ get_host_ip (unsigned char *ip_addr)
 
   if (gethostname (hostname, sizeof (hostname)) < 0)
     {
-      fprintf (stderr, "gethostname error: cannot get local hostname\n");
+      fprintf (stderr, "gethostname error\n");
       return -1;
     }
   if ((hp = gethostbyname_uhost (hostname)) == NULL)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24842

**Description**

- in addition to #4497 ,
- fix below:

Print the error message when the hostname lookup fails before the broker is initialized.

**Remarks**

N/A
