### PR TITLE
[CBRD-24924] [Regression] Core dumped in pt_bind_names

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -1266,6 +1266,10 @@ pt_bind_scope (PARSER_CONTEXT * parser, PT_BIND_NAMES_ARG * bind_arg)
 		    {
 		      if (pt_remake_dblink_select_list (parser, &spec->info.spec, rmt_tbl_cols) != NO_ERROR)
 			{
+			  if (!pt_has_error (parser))
+			    {
+			      PT_ERROR (parser, table, "Failed to make select-list for dblink");
+			    }
 			  goto error_exit;
 			}
 		    }
@@ -11507,7 +11511,6 @@ pt_get_column_name_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int 
 	{
 	  check_for_already_exists (parser, plkcol, NULL, node->info.name.original);
 	}
-      plkcol->col_list->info.name.flag = node->info.name.flag;
       break;
 
     case PT_VALUE:


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24924

The dblink arais error when the connection of the remote server is not valid. In this case, if an error is set by er_set, pt_has_error cannot check if an error has occurred. So, we should set an error by PT_ERRORf3.