### PR TITLE
[LETS-746] Initialize unsent_lsa conditionally to fix cores on PTS

### DIFF
--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -185,7 +185,10 @@ LOG_RESET_APPEND_LSA (const LOG_LSA *lsa)
   log_Gl.hdr.append_lsa = *lsa;
   log_Gl.prior_info.prior_lsa = *lsa;
 #if defined (SERVER_MODE)
-  log_Gl.get_log_prior_sender ().reset_unsent_lsa (*lsa);
+  if (is_active_transaction_server () || is_page_server ())
+    {
+      log_Gl.get_log_prior_sender ().reset_unsent_lsa (*lsa);
+    }
 #endif /* SERVER_MODE */
   log_Gl.append.set_nxio_lsa (*lsa);
 }

--- a/src/transaction/log_prior_send.cpp
+++ b/src/transaction/log_prior_send.cpp
@@ -22,6 +22,7 @@
 #include "log_append.hpp"
 #include "log_lsa.hpp"
 #include "system_parameter.h"
+#include "server_type.hpp"
 
 namespace cublog
 {
@@ -103,6 +104,7 @@ namespace cublog
   void
   prior_sender::reset_unsent_lsa (const LOG_LSA &lsa)
   {
+    assert (is_active_transaction_server () || is_page_server ());
     m_unsent_lsa = lsa;
   }
 

--- a/unit_tests/log/test_main_prior_list_serialize.cpp
+++ b/unit_tests/log/test_main_prior_list_serialize.cpp
@@ -341,6 +341,12 @@ is_active_transaction_server ()
   return true;
 }
 
+bool
+is_page_server ()
+{
+  return false;
+}
+
 PGLENGTH
 db_log_page_size ()
 {

--- a/unit_tests/log/test_main_prior_sendrecv.cpp
+++ b/unit_tests/log/test_main_prior_sendrecv.cpp
@@ -360,3 +360,15 @@ void
 _er_log_debug (const char *file_name, const int line_no, const char *fmt, ...)
 {
 }
+
+bool
+is_active_transaction_server ()
+{
+  return true;
+}
+
+bool
+is_page_server ()
+{
+  return false;
+}


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-746

The cores occur because the prior sender is initialized only on ATS and PS.
- \+ Adapt a unit test