### PR TITLE
[CBRD-24893] change buffer size of datatype

### DIFF
--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -1093,7 +1093,7 @@ cgw_col_bindings (SQLHSTMT hstmt, SQLSMALLINT num_cols, T_COL_BINDER ** col_bind
 
       if (col_unsigned_type)
 	{
-	  bind_col_size = col_size + 1;
+	  bind_col_size = col_size + 10;
 	}
       else
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24893

Purpose
In the case of mariadb, the unsigned Bigint type buffer size value was small, resulting in memory overflow.
So, I modified the buffer size of datatype.

Implementation
N/A

Remarks
N/A