### PR TITLE
[CBRD-24893] Free statement handle

### DIFF
--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -1123,7 +1123,7 @@ cgw_col_bindings (SQLHSTMT hstmt, SQLSMALLINT num_cols, T_COL_BINDER ** col_bind
 	  this_col_binding_buff->next = NULL;
 	  this_col_binding_buff->is_exist_col_data = false;
 
-	  this_col_binding->data_buffer = MALLOC (bind_col_size);
+	  this_col_binding->data_buffer = (wchar_t *) MALLOC (bind_col_size);
 	  if (!(this_col_binding->data_buffer))
 	    {
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_INTERFACE_NO_MORE_MEMORY, 0);

--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -151,6 +151,16 @@ cgw_cleanup ()
   cgw_cleanup_handle (local_odbc_handle);
 }
 
+void
+cgw_free_stmt (T_SRV_HANDLE * srv_handle)
+{
+  if (srv_handle->cgw_handle->hstmt)
+    {
+      SQLFreeHandle (SQL_HANDLE_STMT, local_odbc_handle->hstmt);
+      local_odbc_handle->hstmt = NULL;
+    }
+}
+
 int
 cgw_get_handle (T_CGW_HANDLE ** cgw_handle)
 {

--- a/src/broker/cas_cgw.h
+++ b/src/broker/cas_cgw.h
@@ -149,6 +149,7 @@ union odbc_bind_info
 
 extern int cgw_init ();
 extern void cgw_cleanup ();
+extern void cgw_free_stmt (T_SRV_HANDLE * srv_handle);
 extern int cgw_col_bindings (SQLHSTMT hstmt, SQLSMALLINT num_cols, T_COL_BINDER ** col_binding,
 			     T_COL_BINDER ** col_binding_buff);
 extern void cgw_cleanup_binder (T_COL_BINDER * first_col_binding);

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -11746,3 +11746,11 @@ recompile_statement (T_SRV_HANDLE * srv_handle)
 
   return err_code;
 }
+
+#if defined(CAS_FOR_CGW)
+void
+ux_cgw_free_stmt (T_SRV_HANDLE * srv_handle)
+{
+  cgw_free_stmt (srv_handle);
+}
+#endif

--- a/src/broker/cas_execute.h
+++ b/src/broker/cas_execute.h
@@ -235,4 +235,8 @@ extern int ux_lob_read (DB_VALUE * lob_dbval, int64_t offset, int size, T_NET_BU
 #endif /* !CAS_FOR_ORACLE && !CAS_FOR_MYSQL */
 
 extern int get_tuple_count (T_SRV_HANDLE * srv_handle);
+#if defined(CAS_FOR_CGW)
+extern void ux_cgw_free_stmt (T_SRV_HANDLE * srv_handle);
+#endif
+
 #endif /* _CAS_EXECUTE_H_ */

--- a/src/broker/cas_function.c
+++ b/src/broker/cas_function.c
@@ -1082,10 +1082,6 @@ fn_close_req_handle (SOCKET sock_fd, int argc, void **argv, T_NET_BUF * net_buf,
 
   cas_log_write (SRV_HANDLE_QUERY_SEQ_NUM (srv_handle), false, "close_req_handle srv_h_id %d", srv_h_id);
 
-#if defined(CAS_FOR_CGW)
-  cgw_free_stmt (srv_handle);
-#endif
-
   hm_srv_handle_free (srv_h_id);
 
   net_buf_cp_int (net_buf, 0, NULL);	/* res code */

--- a/src/broker/cas_function.c
+++ b/src/broker/cas_function.c
@@ -1082,6 +1082,10 @@ fn_close_req_handle (SOCKET sock_fd, int argc, void **argv, T_NET_BUF * net_buf,
 
   cas_log_write (SRV_HANDLE_QUERY_SEQ_NUM (srv_handle), false, "close_req_handle srv_h_id %d", srv_h_id);
 
+#if defined(CAS_FOR_CGW)
+  cgw_free_stmt (srv_handle);
+#endif
+
   hm_srv_handle_free (srv_h_id);
 
   net_buf_cp_int (net_buf, 0, NULL);	/* res code */

--- a/src/broker/cas_handle.c
+++ b/src/broker/cas_handle.c
@@ -181,7 +181,7 @@ hm_srv_handle_free (int h_id)
 #endif /* !CAS_FOR_ORACLE && !CAS_FOR_MYSQL */
 
 #if defined (CAS_FOR_CGW)
-  srv_handle->cgw_handle = NULL;
+  ux_cgw_free_stmt (srv_handle);
 #endif
 
   FREE_MEM (srv_handle);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24893

Purpose
In the case of MySQL, if the handle is reused without initializing the statement handle, the number of columns is incorrectly obtained.

Implementation
add initialize statement handle function

Remarks
N/A