### PR TITLE
[CBRD-24404] Fix the hostname to be stored instead of alias

### DIFF
--- a/src/connection/host_lookup.c
+++ b/src/connection/host_lookup.c
@@ -304,6 +304,11 @@ load_hosts_file ()
 	    }
 	  else
 	    {
+	      if (hostname[0] != '\0')
+		{
+		  break;
+		}
+
 	      str_len = strlen (temp_token);
 	      if (str_len > HOSTNAME_LEN - 1)
 		{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24404

**Description**

in addition to #4380 and #3740 ,
$CUBRID/conf/cubrid_hosts.conf stores alias instead hostname, so we store hostname instead of alias.

**Remarks**

Overwritting PR.