### PR TITLE
[CBRD-24882] change min/max of vacuum_ovfp_check_duration

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -2401,10 +2401,10 @@ bool PRM_STATDUMP_FORCE_ADD_INT_MAX = false;
 static bool prm_statdump_force_add_int_max_default = false;
 static unsigned int prm_statdump_force_add_int_max_flag = 0;
 
-int PRM_VACUUM_OVFP_CHECK_DURATION = 2678400;
-static int prm_vacuum_ovfp_check_duration_default = 2678400;	/* 31 days * 24 hours * 60 min * 60 secs  */
-static int prm_vacuum_ovfp_check_duration_upper = INT_MAX;
-static int prm_vacuum_ovfp_check_duration_lower = 60;	// 1 min
+int PRM_VACUUM_OVFP_CHECK_DURATION = 45000;
+static int prm_vacuum_ovfp_check_duration_default = 45000;
+static int prm_vacuum_ovfp_check_duration_upper = 600000;
+static int prm_vacuum_ovfp_check_duration_lower = 1;	// 1 min
 static unsigned int prm_vacuum_ovfp_check_duration_flag = 0;
 
 int PRM_VACUUM_OVFP_CHECK_THRESHOLD = 1000;
@@ -6289,7 +6289,7 @@ SYSPRM_PARAM prm_Def[] = {
    (DUP_PRM_FUNC) NULL},
   {PRM_ID_VACUUM_OVFP_CHECK_DURATION,
    PRM_NAME_VACUUM_OVFP_CHECK_DURATION,
-   (PRM_FOR_SERVER | PRM_USER_CHANGE | PRM_TIME_UNIT | PRM_DIFFER_UNIT),
+   (PRM_FOR_SERVER),
    PRM_INTEGER,
    &prm_vacuum_ovfp_check_duration_flag,
    (void *) &prm_vacuum_ovfp_check_duration_default,

--- a/src/monitor/monitor_vacuum_ovfp_threshold.cpp
+++ b/src/monitor/monitor_vacuum_ovfp_threshold.cpp
@@ -560,7 +560,7 @@ ovfp_threshold_mgr::ovfp_threshold_mgr()
       m_ovfp_threshold[worker_idx].set_worker_idx (worker_idx, &m_ovfp_lock);
     }
 
-  m_over_secs = 2678400; // 31 day
+  m_over_secs = 45000 /* min */ * 60; // sec
   m_threshold_pages = 1000;
   m_since_time[0] = '\0';
 }
@@ -571,6 +571,7 @@ ovfp_threshold_mgr::init()
   time_to_string (time (NULL), m_since_time, sizeof (m_since_time));
 
   m_over_secs = prm_get_integer_value (PRM_ID_VACUUM_OVFP_CHECK_DURATION);
+  m_over_secs *= 60; // to second
   m_threshold_pages = prm_get_integer_value (PRM_ID_VACUUM_OVFP_CHECK_THRESHOLD);
 }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24882

* Change max/min/default value of vacuum_ovfp_check_duration
> * min=1, max=600000, default=45000
> * Change the input unit to minutes
  
