### PR TITLE
[CBRD-24934] [Regression] extending dblink to DML: double quoted identifier

### DIFF
--- a/src/base/intl_support.c
+++ b/src/base/intl_support.c
@@ -2730,19 +2730,21 @@ intl_strcasecmp_utf8_one_cp (const ALPHABET_DATA * alphabet, unsigned char *str1
  * intl_identifier_casecmp_for_dblinke() - compares two identifiers strings
  *			       case insensitive excluding double quote for dblink
  *
- *   return: 0 if strings are equal, -1 if str1 < str2 , 1 if str1 > str2
- *   str1(in):
- *   str2(in):
+ *   return: 0 if dblink_col_name equals to remote_col_name
+ *   dblink_col_name(in):
+ *   remote_col_name(in):
  *
  * NOTE: this routine is the same as intl_identifier_casecmp
- *       the first argument str1 may start with double quote but the second one never
+ *       the first argument dblink_col_name may start with double quote
+ *       but the remote_col_name never
  */
 int
-intl_identifier_casecmp_for_dblink (const char *str1, const char *str2)
+intl_identifier_casecmp_for_dblink (const char *dblink_col_name, const char *remote_col_name)
 {
   int str1_size;
   int str2_size;
-  int offset;
+  char *str1 = (char *) dblink_col_name;
+  char *str2 = (char *) remote_col_name;
 
   assert (str1 != NULL);
   assert (str2 != NULL);
@@ -2750,9 +2752,12 @@ intl_identifier_casecmp_for_dblink (const char *str1, const char *str2)
   str1_size = (*str1 == '\"') ? strlen (str1) - 2 : strlen (str1);
   str2_size = strlen (str2);
 
-  offset = (*str1 == '\"') ? 1 : 0;
+  if (*str1 == '\"')
+    {
+      str1 = str1 + 1;
+    }
 
-  return intl_identifier_casecmp_w_size (lang_id (), (unsigned char *) str1 + offset, (unsigned char *) str2, str1_size,
+  return intl_identifier_casecmp_w_size (lang_id (), (unsigned char *) str1, (unsigned char *) str2, str1_size,
 					 str2_size);
 }
 

--- a/src/base/intl_support.c
+++ b/src/base/intl_support.c
@@ -2749,11 +2749,12 @@ intl_identifier_casecmp_for_dblink (const char *dblink_col_name, const char *rem
   assert (str1 != NULL);
   assert (str2 != NULL);
 
-  str1_size = (*str1 == '\"') ? strlen (str1) - 2 : strlen (str1);
+  str1_size = strlen (str1);
   str2_size = strlen (str2);
 
   if (*str1 == '\"')
     {
+      str1_size = str1_size - 2;
       str1 = str1 + 1;
     }
 

--- a/src/base/intl_support.c
+++ b/src/base/intl_support.c
@@ -2727,34 +2727,33 @@ intl_strcasecmp_utf8_one_cp (const ALPHABET_DATA * alphabet, unsigned char *str1
 }
 
 /*
- * intl_identifier_casecmp_with_quote() - compares two identifiers strings
- *			       case insensitive excluding double-quote
+ * intl_identifier_casecmp_for_dblinke() - compares two identifiers strings
+ *			       case insensitive excluding double quote for dblink
+ *
  *   return: 0 if strings are equal, -1 if str1 < str2 , 1 if str1 > str2
  *   str1(in):
  *   str2(in):
  *
- * NOTE: this routine is the same as intl_identifier_casecmp_with
- *       but the identifier starting with double quote(")
+ * NOTE: this routine is the same as intl_identifier_casecmp
+ *       the first argument str1 may start with double quote but the second one never
  */
 int
-intl_identifier_casecmp_with_quote (const char *str1, const char *str2)
+intl_identifier_casecmp_for_dblink (const char *str1, const char *str2)
 {
   int str1_size;
   int str2_size;
-  int str1_offset;
-  int str2_offset;
+  int offset;
 
   assert (str1 != NULL);
   assert (str2 != NULL);
 
   str1_size = (*str1 == '\"') ? strlen (str1) - 2 : strlen (str1);
-  str2_size = (*str2 == '\"') ? strlen (str2) - 2 : strlen (str2);
+  str2_size = strlen (str2);
 
-  str1_offset = (*str1 == '\"') ? 1 : 0;
-  str2_offset = (*str2 == '\"') ? 1 : 0;
+  offset = (*str1 == '\"') ? 1 : 0;
 
-  return intl_identifier_casecmp_w_size (lang_id (), (unsigned char *) str1 + str1_offset,
-					 (unsigned char *) str2 + str2_offset, str1_size, str2_size);
+  return intl_identifier_casecmp_w_size (lang_id (), (unsigned char *) str1 + offset, (unsigned char *) str2, str1_size,
+					 str2_size);
 }
 
 /*

--- a/src/base/intl_support.c
+++ b/src/base/intl_support.c
@@ -2727,6 +2727,37 @@ intl_strcasecmp_utf8_one_cp (const ALPHABET_DATA * alphabet, unsigned char *str1
 }
 
 /*
+ * intl_identifier_casecmp_with_quote() - compares two identifiers strings
+ *			       case insensitive excluding double-quote
+ *   return: 0 if strings are equal, -1 if str1 < str2 , 1 if str1 > str2
+ *   str1(in):
+ *   str2(in):
+ *
+ * NOTE: this routine is the same as intl_identifier_casecmp_with
+ *       but the identifier starting with double quote(")
+ */
+int
+intl_identifier_casecmp_with_quote (const char *str1, const char *str2)
+{
+  int str1_size;
+  int str2_size;
+  int str1_offset;
+  int str2_offset;
+
+  assert (str1 != NULL);
+  assert (str2 != NULL);
+
+  str1_size = (*str1 == '\"') ? strlen (str1) - 2 : strlen (str1);
+  str2_size = (*str2 == '\"') ? strlen (str2) - 2 : strlen (str2);
+
+  str1_offset = (*str1 == '\"') ? 1 : 0;
+  str2_offset = (*str2 == '\"') ? 1 : 0;
+
+  return intl_identifier_casecmp_w_size (lang_id (), (unsigned char *) str1 + str1_offset,
+					 (unsigned char *) str2 + str2_offset, str1_size, str2_size);
+}
+
+/*
  * intl_identifier_casecmp() - compares two identifiers strings
  *			       case insensitive
  *   return: 0 if strings are equal, -1 if str1 < str2 , 1 if str1 > str2

--- a/src/base/intl_support.h
+++ b/src/base/intl_support.h
@@ -254,7 +254,7 @@ extern "C"
   extern int intl_case_match_tok (const INTL_LANG lang_id, const INTL_CODESET codeset, unsigned char *tok,
 				  unsigned char *src, const int size_tok, const int size_src, int *matched_size_src);
   extern int intl_identifier_casecmp (const char *str1, const char *str2);
-  extern int intl_identifier_casecmp_with_quote (const char *str1, const char *str2);
+  extern int intl_identifier_casecmp_for_dblink (const char *str1, const char *str2);
   extern int intl_identifier_ncasecmp (const char *str1, const char *str2, const int len);
   extern int intl_identifier_cmp (const char *str1, const char *str2);
 #if defined(ENABLE_UNUSED_FUNCTION)

--- a/src/base/intl_support.h
+++ b/src/base/intl_support.h
@@ -254,7 +254,7 @@ extern "C"
   extern int intl_case_match_tok (const INTL_LANG lang_id, const INTL_CODESET codeset, unsigned char *tok,
 				  unsigned char *src, const int size_tok, const int size_src, int *matched_size_src);
   extern int intl_identifier_casecmp (const char *str1, const char *str2);
-  extern int intl_identifier_casecmp_for_dblink (const char *str1, const char *str2);
+  extern int intl_identifier_casecmp_for_dblink (const char *dblink_col_name, const char *remote_col_name);
   extern int intl_identifier_ncasecmp (const char *str1, const char *str2, const int len);
   extern int intl_identifier_cmp (const char *str1, const char *str2);
 #if defined(ENABLE_UNUSED_FUNCTION)

--- a/src/base/intl_support.h
+++ b/src/base/intl_support.h
@@ -254,6 +254,7 @@ extern "C"
   extern int intl_case_match_tok (const INTL_LANG lang_id, const INTL_CODESET codeset, unsigned char *tok,
 				  unsigned char *src, const int size_tok, const int size_src, int *matched_size_src);
   extern int intl_identifier_casecmp (const char *str1, const char *str2);
+  extern int intl_identifier_casecmp_with_quote (const char *str1, const char *str2);
   extern int intl_identifier_ncasecmp (const char *str1, const char *str2, const int len);
   extern int intl_identifier_cmp (const char *str1, const char *str2);
 #if defined(ENABLE_UNUSED_FUNCTION)

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -4930,7 +4930,7 @@ pt_mk_attr_def_node (PARSER_CONTEXT * parser, PT_NODE * name_node, S_REMOTE_TBL_
   const char *col_name = name_node->info.name.original;
   for (int i = 0; i < rmt_cols->get_attr_size (); i++)
     {
-      if (intl_identifier_casecmp (col_name, rmt_cols->get_name (i)) == 0)
+      if (intl_identifier_casecmp_with_quote (col_name, rmt_cols->get_name (i)) == 0)
 	{
 	  if (pt_dblink_table_fill_attr_def (parser, def_node, rmt_cols->get_attr (i)))
 	    {
@@ -5010,13 +5010,13 @@ pt_check_column_list (PARSER_CONTEXT * parser, const char *tbl_alias_nm, PT_DBLI
       col_name = col->info.name.original;
       for (i = 0; i < rmt_cols->get_attr_size (); i++)
 	{
-	  if (intl_identifier_casecmp (col_name, rmt_cols->get_name (i)) == 0)
+	  if (intl_identifier_casecmp_with_quote (col_name, rmt_cols->get_name (i)) == 0)
 	    {
 	      if (col->info.name.resolved == NULL)
 		{
 		  break;
 		}
-	      else if (intl_identifier_casecmp (tbl_alias_nm, col->info.name.resolved) == 0)
+	      else if (intl_identifier_casecmp_with_quote (tbl_alias_nm, col->info.name.resolved) == 0)
 		{
 		  break;
 		}
@@ -11643,7 +11643,7 @@ pt_check_dblink_column_alias (PARSER_CONTEXT * parser, PT_NODE * dblink)
     {
       assert (cols_idx < rmt_tbl_cols->get_attr_size ());
       col_name = (char *) cols->info.attr_def.attr_name->info.name.original;
-      if (intl_identifier_casecmp (rmt_tbl_cols->get_name (cols_idx), col_name) != 0)
+      if (intl_identifier_casecmp_with_quote (rmt_tbl_cols->get_name (cols_idx), col_name) != 0)
 	{
 	  PT_ERRORf3 (parser, dblink, "\"%s\" not matched column or alias \"%s\"",
 		      cols->info.attr_def.attr_name->info.name.original, rmt_tbl_cols->get_name (cols_idx), ER_DBLINK);

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -4930,7 +4930,7 @@ pt_mk_attr_def_node (PARSER_CONTEXT * parser, PT_NODE * name_node, S_REMOTE_TBL_
   const char *col_name = name_node->info.name.original;
   for (int i = 0; i < rmt_cols->get_attr_size (); i++)
     {
-      if (intl_identifier_casecmp_with_quote (col_name, rmt_cols->get_name (i)) == 0)
+      if (intl_identifier_casecmp_for_dblink (col_name, rmt_cols->get_name (i)) == 0)
 	{
 	  if (pt_dblink_table_fill_attr_def (parser, def_node, rmt_cols->get_attr (i)))
 	    {
@@ -5010,13 +5010,13 @@ pt_check_column_list (PARSER_CONTEXT * parser, const char *tbl_alias_nm, PT_DBLI
       col_name = col->info.name.original;
       for (i = 0; i < rmt_cols->get_attr_size (); i++)
 	{
-	  if (intl_identifier_casecmp_with_quote (col_name, rmt_cols->get_name (i)) == 0)
+	  if (intl_identifier_casecmp_for_dblink (col_name, rmt_cols->get_name (i)) == 0)
 	    {
 	      if (col->info.name.resolved == NULL)
 		{
 		  break;
 		}
-	      else if (intl_identifier_casecmp_with_quote (tbl_alias_nm, col->info.name.resolved) == 0)
+	      else if (intl_identifier_casecmp_for_dblink (tbl_alias_nm, col->info.name.resolved) == 0)
 		{
 		  break;
 		}
@@ -11643,7 +11643,7 @@ pt_check_dblink_column_alias (PARSER_CONTEXT * parser, PT_NODE * dblink)
     {
       assert (cols_idx < rmt_tbl_cols->get_attr_size ());
       col_name = (char *) cols->info.attr_def.attr_name->info.name.original;
-      if (intl_identifier_casecmp_with_quote (rmt_tbl_cols->get_name (cols_idx), col_name) != 0)
+      if (intl_identifier_casecmp (rmt_tbl_cols->get_name (cols_idx), col_name) != 0)
 	{
 	  PT_ERRORf3 (parser, dblink, "\"%s\" not matched column or alias \"%s\"",
 		      cols->info.attr_def.attr_name->info.name.original, rmt_tbl_cols->get_name (cols_idx), ER_DBLINK);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24934

To use reserved words as table or column names in other DBMS such as Oracle using extended table names in CUBRID, double quotes should be wrapped inside the braket like ["FROM"]. However, in the remote server, this identifier is being returned without double quotes. It can receive column information by sending a SELECT ["ALTER"], ["COUNT"], ["ADD"] FROM ["From"] query through cci_prepare. At this time, the column information becomes ALTER, COUNT, ADD without double quotes.