### PR TITLE
[CBRD-24935] extending dblink to DML: function is pushed

### DIFF
--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -15940,9 +15940,9 @@ pt_print_value (PARSER_CONTEXT * parser, PT_NODE * p)
     case PT_TYPE_INTEGER:
     case PT_TYPE_BIGINT:
     case PT_TYPE_SMALLINT:
-      if (!(parser->custom_print & (PT_PRINT_SUPPRESS_FOR_DBLINK | PT_SUPPRESS_BIGINT_CAST)))
+      if (p->info.value.text != NULL)
 	{
-	  if ((p->info.value.text != NULL))
+	  if (!(parser->custom_print & (PT_PRINT_SUPPRESS_FOR_DBLINK | PT_SUPPRESS_BIGINT_CAST)))
 	    {
 	      r = p->info.value.text;
 	    }

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -15940,9 +15940,12 @@ pt_print_value (PARSER_CONTEXT * parser, PT_NODE * p)
     case PT_TYPE_INTEGER:
     case PT_TYPE_BIGINT:
     case PT_TYPE_SMALLINT:
-      if ((p->info.value.text != NULL) && !(parser->custom_print & PT_SUPPRESS_BIGINT_CAST))
+      if (!(parser->custom_print & PT_PRINT_SUPPRESS_FOR_DBLINK))
 	{
-	  r = p->info.value.text;
+	  if ((p->info.value.text != NULL) && !(parser->custom_print & PT_SUPPRESS_BIGINT_CAST))
+	    {
+	      r = p->info.value.text;
+	    }
 	}
       else
 	{
@@ -15993,10 +15996,13 @@ pt_print_value (PARSER_CONTEXT * parser, PT_NODE * p)
     case PT_TYPE_DATETIME:
     case PT_TYPE_DATETIMETZ:
     case PT_TYPE_DATETIMELTZ:
-      if (p->info.value.text)
+      if (!(parser->custom_print & PT_PRINT_SUPPRESS_FOR_DBLINK))
 	{
-	  q = pt_append_nulstring (parser, q, p->info.value.text);
-	  break;
+	  if (p->info.value.text)
+	    {
+	      q = pt_append_nulstring (parser, q, p->info.value.text);
+	      break;
+	    }
 	}
       r = (char *) p->info.value.data_value.str->bytes;
 
@@ -16037,17 +16043,20 @@ pt_print_value (PARSER_CONTEXT * parser, PT_NODE * p)
     case PT_TYPE_CHAR:
     case PT_TYPE_NCHAR:
     case PT_TYPE_BIT:
-      if (p->info.value.text && prt_cs == INTL_CODESET_NONE && prt_coll_id == -1)
+      if (!(parser->custom_print & PT_PRINT_SUPPRESS_FOR_DBLINK))
 	{
-	  if (parser->flag.dont_prt_long_string && (strlen (p->info.value.text) >= DONT_PRT_LONG_STRING_LENGTH))
+	  if (p->info.value.text && prt_cs == INTL_CODESET_NONE && prt_coll_id == -1)
 	    {
-	      parser->flag.long_string_skipped = 1;
+	      if (parser->flag.dont_prt_long_string && (strlen (p->info.value.text) >= DONT_PRT_LONG_STRING_LENGTH))
+		{
+		  parser->flag.long_string_skipped = 1;
+		  break;
+		}
+
+	      q = pt_append_nulstring (parser, q, p->info.value.text);
+
 	      break;
 	    }
-
-	  q = pt_append_nulstring (parser, q, p->info.value.text);
-
-	  break;
 	}
       r1 = p->info.value.data_value.str;
       if (parser->flag.dont_prt_long_string)
@@ -16111,17 +16120,20 @@ pt_print_value (PARSER_CONTEXT * parser, PT_NODE * p)
     case PT_TYPE_VARCHAR:	/* have to check for embedded quotes */
     case PT_TYPE_VARNCHAR:
     case PT_TYPE_VARBIT:
-      if (p->info.value.text && prt_cs == INTL_CODESET_NONE && prt_coll_id == -1)
+      if (!(parser->custom_print & PT_PRINT_SUPPRESS_FOR_DBLINK))
 	{
-	  if (parser->flag.dont_prt_long_string && (strlen (p->info.value.text) >= DONT_PRT_LONG_STRING_LENGTH))
+	  if (p->info.value.text && prt_cs == INTL_CODESET_NONE && prt_coll_id == -1)
 	    {
-	      parser->flag.long_string_skipped = 1;
+	      if (parser->flag.dont_prt_long_string && (strlen (p->info.value.text) >= DONT_PRT_LONG_STRING_LENGTH))
+		{
+		  parser->flag.long_string_skipped = 1;
+		  break;
+		}
+
+	      q = pt_append_nulstring (parser, q, p->info.value.text);
+
 	      break;
 	    }
-
-	  q = pt_append_nulstring (parser, q, p->info.value.text);
-
-	  break;
 	}
       r1 = p->info.value.data_value.str;
       if (parser->flag.dont_prt_long_string)

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -15940,12 +15940,10 @@ pt_print_value (PARSER_CONTEXT * parser, PT_NODE * p)
     case PT_TYPE_INTEGER:
     case PT_TYPE_BIGINT:
     case PT_TYPE_SMALLINT:
-      if (p->info.value.text != NULL)
+      if (p->info.value.text != NULL
+	  && !(parser->custom_print & (PT_PRINT_SUPPRESS_FOR_DBLINK | PT_SUPPRESS_BIGINT_CAST)))
 	{
-	  if (!(parser->custom_print & (PT_PRINT_SUPPRESS_FOR_DBLINK | PT_SUPPRESS_BIGINT_CAST)))
-	    {
-	      r = p->info.value.text;
-	    }
+	  r = p->info.value.text;
 	}
       else
 	{

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -15940,9 +15940,9 @@ pt_print_value (PARSER_CONTEXT * parser, PT_NODE * p)
     case PT_TYPE_INTEGER:
     case PT_TYPE_BIGINT:
     case PT_TYPE_SMALLINT:
-      if (!(parser->custom_print & PT_PRINT_SUPPRESS_FOR_DBLINK))
+      if (!(parser->custom_print & (PT_PRINT_SUPPRESS_FOR_DBLINK | PT_SUPPRESS_BIGINT_CAST)))
 	{
-	  if ((p->info.value.text != NULL) && !(parser->custom_print & PT_SUPPRESS_BIGINT_CAST))
+	  if ((p->info.value.text != NULL))
 	    {
 	      r = p->info.value.text;
 	    }

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -301,7 +301,7 @@ static PT_NODE *pt_check_function_collation (PARSER_CONTEXT * parser, PT_NODE * 
 static void pt_hv_consistent_data_type_with_domain (PARSER_CONTEXT * parser, PT_NODE * node);
 static void pt_update_host_var_data_type (PARSER_CONTEXT * parser, PT_NODE * hv_node);
 static bool pt_cast_needs_wrap_for_collation (PT_NODE * node, const INTL_CODESET codeset);
-static PT_NODE *pt_do_not_fold_dblink_related_cast (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg,
+static PT_NODE *pt_do_not_fold_dblink_related_function (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg,
 						    int *continue_walk);
 static bool pt_is_dblink_related (PT_NODE * p);
 
@@ -7823,7 +7823,7 @@ pt_fold_constants_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *
 	      if (!node->flag.do_not_fold && pt_is_dblink_related (node))
 		{
 		  // do not fold for dblink-related expr
-		  parser_walk_tree (parser, node, pt_do_not_fold_dblink_related_cast, NULL, NULL, NULL);
+		  parser_walk_tree (parser, node, pt_do_not_fold_dblink_related_function, NULL, NULL, NULL);
 		}
 	    }
 	}
@@ -18941,7 +18941,7 @@ error_zerodate:
  * set flag of the node not to do constant folding for dblink-related cast
  */
 static PT_NODE *
-pt_do_not_fold_dblink_related_cast (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg, int *continue_walk)
+pt_do_not_fold_dblink_related_function (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg, int *continue_walk)
 {
   if (expr->node_type == PT_EXPR)
     {

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -302,7 +302,7 @@ static void pt_hv_consistent_data_type_with_domain (PARSER_CONTEXT * parser, PT_
 static void pt_update_host_var_data_type (PARSER_CONTEXT * parser, PT_NODE * hv_node);
 static bool pt_cast_needs_wrap_for_collation (PT_NODE * node, const INTL_CODESET codeset);
 static PT_NODE *pt_do_not_fold_dblink_related_function (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg,
-						    int *continue_walk);
+							int *continue_walk);
 static bool pt_is_dblink_related (PT_NODE * p);
 
 /*

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -301,8 +301,6 @@ static PT_NODE *pt_check_function_collation (PARSER_CONTEXT * parser, PT_NODE * 
 static void pt_hv_consistent_data_type_with_domain (PARSER_CONTEXT * parser, PT_NODE * node);
 static void pt_update_host_var_data_type (PARSER_CONTEXT * parser, PT_NODE * hv_node);
 static bool pt_cast_needs_wrap_for_collation (PT_NODE * node, const INTL_CODESET codeset);
-static PT_NODE *pt_do_not_fold_dblink_related_expr (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg,
-							int *continue_walk);
 static bool pt_is_dblink_related (PT_NODE * p);
 
 /*
@@ -7807,25 +7805,6 @@ pt_fold_constants_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *
 	{
 	  // we want to test full execution of sub-tree; don't fold it!
 	  *continue_walk = PT_LIST_WALK;
-	}
-      break;
-    case PT_EXPR:
-      if (parser->dblink_remote)
-	{
-	  switch (node->info.expr.op)
-	    {
-	    case PT_AND:
-	    case PT_OR:
-	    case PT_XOR:
-	    case PT_NOT:
-	      break;
-	    default:
-	      if (!node->flag.do_not_fold && pt_is_dblink_related (node))
-		{
-		  // do not fold for dblink-related expr
-		  parser_walk_tree (parser, node, pt_do_not_fold_dblink_related_expr, NULL, NULL, NULL);
-		}
-	    }
 	}
     default:
       // nope
@@ -18935,20 +18914,6 @@ overflow:
 error_zerodate:
   PT_ERRORc (parser, o1, er_msg ());
   return 0;
-}
-
-/*
- * set flag of the node not to do constant folding for dblink-related cast
- */
-static PT_NODE *
-pt_do_not_fold_dblink_related_expr (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg, int *continue_walk)
-{
-  if (expr->node_type == PT_EXPR)
-    {
-      expr->flag.do_not_fold = true;
-    }
-
-  return expr;
 }
 
 /*

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -301,7 +301,7 @@ static PT_NODE *pt_check_function_collation (PARSER_CONTEXT * parser, PT_NODE * 
 static void pt_hv_consistent_data_type_with_domain (PARSER_CONTEXT * parser, PT_NODE * node);
 static void pt_update_host_var_data_type (PARSER_CONTEXT * parser, PT_NODE * hv_node);
 static bool pt_cast_needs_wrap_for_collation (PT_NODE * node, const INTL_CODESET codeset);
-static PT_NODE *pt_do_not_fold_dblink_related_function (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg,
+static PT_NODE *pt_do_not_fold_dblink_related_expr (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg,
 							int *continue_walk);
 static bool pt_is_dblink_related (PT_NODE * p);
 
@@ -7823,7 +7823,7 @@ pt_fold_constants_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *
 	      if (!node->flag.do_not_fold && pt_is_dblink_related (node))
 		{
 		  // do not fold for dblink-related expr
-		  parser_walk_tree (parser, node, pt_do_not_fold_dblink_related_function, NULL, NULL, NULL);
+		  parser_walk_tree (parser, node, pt_do_not_fold_dblink_related_expr, NULL, NULL, NULL);
 		}
 	    }
 	}
@@ -18941,7 +18941,7 @@ error_zerodate:
  * set flag of the node not to do constant folding for dblink-related cast
  */
 static PT_NODE *
-pt_do_not_fold_dblink_related_function (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg, int *continue_walk)
+pt_do_not_fold_dblink_related_expr (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg, int *continue_walk)
 {
   if (expr->node_type == PT_EXPR)
     {

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -7810,10 +7810,22 @@ pt_fold_constants_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *
 	}
       break;
     case PT_EXPR:
-      if (parser->dblink_remote && pt_is_dblink_related (node))
+      if (parser->dblink_remote)
 	{
-	  // do not fold for dblink-related expr
-	  parser_walk_tree (parser, node, pt_do_not_fold_dblink_related_cast, NULL, NULL, NULL);
+	  switch (node->info.expr.op)
+	    {
+	    case PT_AND:
+	    case PT_OR:
+	    case PT_XOR:
+	    case PT_NOT:
+	      break;
+	    default:
+	      if (!node->flag.do_not_fold && pt_is_dblink_related (node))
+		{
+		  // do not fold for dblink-related expr
+		  parser_walk_tree (parser, node, pt_do_not_fold_dblink_related_cast, NULL, NULL, NULL);
+		}
+	    }
 	}
     default:
       // nope
@@ -18931,12 +18943,9 @@ error_zerodate:
 static PT_NODE *
 pt_do_not_fold_dblink_related_cast (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg, int *continue_walk)
 {
-  if (expr->node_type == PT_EXPR && expr->info.expr.op == PT_CAST)
+  if (expr->node_type == PT_EXPR)
     {
-      if (PT_EXPR_INFO_IS_FLAGED (expr, PT_EXPR_INFO_CAST_WRAP))
-	{
-	  expr->flag.do_not_fold = true;
-	}
+      expr->flag.do_not_fold = true;
     }
 
   return expr;

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -3762,10 +3762,13 @@ pt_remove_cast_wrap_for_dblink (PARSER_CONTEXT * parser, PT_NODE * old_node, voi
 
   if (old_node->node_type == PT_EXPR)
     {
-      if (old_node->info.expr.op == PT_CAST && PT_EXPR_INFO_IS_FLAGED (old_node, PT_EXPR_INFO_CAST_WRAP))
+      if (old_node->info.expr.op == PT_CAST)
 	{
-	  new_node = old_node->info.expr.arg1;
-	  parser_free_node (parser, old_node);
+	  if (PT_EXPR_INFO_IS_FLAGED (old_node, PT_EXPR_INFO_CAST_WRAP | PT_EXPR_INFO_CAST_SHOULD_FOLD))
+	    {
+	      new_node = old_node->info.expr.arg1;
+	      parser_free_node (parser, old_node);
+	    }
 	}
     }
 
@@ -4133,7 +4136,8 @@ mq_is_dblink_pushable_term (PARSER_CONTEXT * parser, PT_NODE * term)
       else
 	{
 	  /* wrapped cast should be pushed and it will be removed while rewriting the dblink query */
-	  if (term->info.expr.op == PT_CAST && PT_EXPR_INFO_IS_FLAGED (term, PT_EXPR_INFO_CAST_WRAP))
+	  if (term->info.expr.op == PT_CAST
+	      && PT_EXPR_INFO_IS_FLAGED (term, PT_EXPR_INFO_CAST_WRAP | PT_EXPR_INFO_CAST_SHOULD_FOLD))
 	    {
 	      return true;
 	    }

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -220,8 +220,6 @@ static PUSHABLE_TYPE mq_is_pushable_subquery (PARSER_CONTEXT * parser, PT_NODE *
 					      PT_NODE * class_spec, bool is_vclass, PT_NODE * order_by,
 					      PT_NODE * class_);
 static PUSHABLE_TYPE mq_is_removable_select_list (PARSER_CONTEXT * parser, PT_NODE * subquery, PT_NODE * mainquery);
-static PT_NODE *pt_remove_cast_wrap_for_dblink (PARSER_CONTEXT * parser, PT_NODE * old_node, void *arg,
-						int *continue_walk);
 static void pt_copypush_terms (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * query, PT_NODE * term_list,
 			       FIND_ID_TYPE type);
 static int mq_copypush_sargable_terms_dblink (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * spec,
@@ -3747,35 +3745,6 @@ pt_check_pushable_term (PARSER_CONTEXT * parser, PT_NODE * term, FIND_ID_INFO * 
 }
 
 /*
- * pt_remove_cast_wrap_for_dblink () - copies exactly a term node excluding cast node for dblink,
-      and returns a pointer to the copy. It is eligible for a walk "pre" function
- *   return:
- *   parser(in):
- *   old_node(in):
- *   arg(in):
- *   continue_walk(in):
- */
-static PT_NODE *
-pt_remove_cast_wrap_for_dblink (PARSER_CONTEXT * parser, PT_NODE * old_node, void *arg, int *continue_walk)
-{
-  PT_NODE *new_node = old_node;
-
-  if (old_node->node_type == PT_EXPR)
-    {
-      if (old_node->info.expr.op == PT_CAST)
-	{
-	  if (PT_EXPR_INFO_IS_FLAGED (old_node, PT_EXPR_INFO_CAST_WRAP | PT_EXPR_INFO_CAST_SHOULD_FOLD))
-	    {
-	      new_node = old_node->info.expr.arg1;
-	      parser_free_node (parser, old_node);
-	    }
-	}
-    }
-
-  return new_node;
-}
-
-/*
  * pt_copypush_terms() - push sargable term into the derived subquery
  *   return:
  *   parser(in):
@@ -3839,10 +3808,8 @@ pt_copypush_terms (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * query, PT_
 
       /* copy terms */
       query->info.dblink_table.pushed_pred = parser_copy_tree_list (parser, term_list);
-      /* remove the cast wrap from pushed predicate */
-      query->info.dblink_table.pushed_pred =
-	parser_walk_tree (parser, query->info.dblink_table.pushed_pred, pt_remove_cast_wrap_for_dblink, NULL, NULL,
-			  NULL);
+
+      /* print the pushed predicates */
       save_custom = parser->custom_print;
       parser->custom_print |=
 	PT_CONVERT_RANGE | PT_SUPPRESS_RESOLVED | PT_PRINT_NO_HOST_VAR_INDEX | PT_PRINT_SUPPRESS_FOR_DBLINK;
@@ -4135,13 +4102,6 @@ mq_is_dblink_pushable_term (PARSER_CONTEXT * parser, PT_NODE * term)
 	}
       else
 	{
-	  /* wrapped cast should be pushed and it will be removed while rewriting the dblink query */
-	  if (term->info.expr.op == PT_CAST
-	      && PT_EXPR_INFO_IS_FLAGED (term, PT_EXPR_INFO_CAST_WRAP | PT_EXPR_INFO_CAST_SHOULD_FOLD))
-	    {
-	      return true;
-	    }
-
 	  /* other expression like built-in and stored function and etc. */
 	  return false;
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24935

In dblink, predicate push should exclude functions. In the case of built-in functions such as "cast" and "str_to_date", if the argument consists only of constants, the function disappears by constant folding, and the function expression is replaced with a text field in the PT_VALUE node instead. do. While processing this in the predicate push logic, the corresponding function expression is being pushed when the PT_VALUE node is pushed.
