### PR TITLE
[CBRD-24926] The problem of performing predicate pushing when the value of the column changes every time

### DIFF
--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -479,6 +479,14 @@ struct json_t;
            (n)->info.expr.op == PT_LT_INF || \
            (n)->info.expr.op == PT_RANGE ))
 
+#define PT_IS_EXPR_NODE_WITH_NON_PUSHABLE(n) \
+        ( (PT_IS_EXPR_NODE (n)) && \
+          ((n)->info.expr.op == PT_DRANDOM || \
+           (n)->info.expr.op == PT_DRAND || \
+           (n)->info.expr.op == PT_RANDOM || \
+           (n)->info.expr.op == PT_RAND || \
+           (n)->info.expr.op == PT_SYS_GUID ))
+
 #define PT_IS_EXPR_WITH_PRIOR_ARG(x) (PT_IS_EXPR_NODE (x) && \
 		PT_IS_EXPR_NODE_WITH_OPERATOR ((x)->info.expr.arg1, PT_PRIOR))
 

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -3510,11 +3510,11 @@ pt_check_pushable_subquery_select_list (PARSER_CONTEXT * parser, PT_NODE * query
 		cinfo.method_found = true;	/* not pushable */
 		break;
 
-              case PT_EXPR:
+	      case PT_EXPR:
 		if (PT_IS_EXPR_NODE_WITH_NON_PUSHABLE (list))
 		  {
 		    cinfo.method_found = true;
-                    break;
+		    break;
 		  }
 
 	      default:		/* do traverse */

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -3383,6 +3383,14 @@ pt_check_pushable (PARSER_CONTEXT * parser, PT_NODE * tree, void *arg, int *cont
 	  cinfop->method_found = true;	/* not pushable */
 	}
       break;
+
+    case PT_EXPR:
+      if (PT_IS_EXPR_NODE_WITH_NON_PUSHABLE (tree))
+	{
+	  cinfop->method_found = true;
+	}
+      break;
+
     default:
       break;
     }				/* switch (tree->node_type) */
@@ -3500,6 +3508,17 @@ pt_check_pushable_subquery_select_list (PARSER_CONTEXT * parser, PT_NODE * query
 
 	      case PT_METHOD_CALL:
 		cinfo.method_found = true;	/* not pushable */
+		break;
+
+              case PT_EXPR:
+		if (PT_IS_EXPR_NODE_WITH_NON_PUSHABLE (list))
+		  {
+		    cinfo.method_found = true;
+		  }
+		else
+		  {
+		    parser_walk_leaves (parser, list, pt_check_pushable, &cinfo, NULL, NULL);
+		  }
 		break;
 
 	      default:		/* do traverse */

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -3514,12 +3514,8 @@ pt_check_pushable_subquery_select_list (PARSER_CONTEXT * parser, PT_NODE * query
 		if (PT_IS_EXPR_NODE_WITH_NON_PUSHABLE (list))
 		  {
 		    cinfo.method_found = true;
+                    break;
 		  }
-		else
-		  {
-		    parser_walk_leaves (parser, list, pt_check_pushable, &cinfo, NULL, NULL);
-		  }
-		break;
 
 	      default:		/* do traverse */
 		parser_walk_leaves (parser, list, pt_check_pushable, &cinfo, NULL, NULL);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24926

This pull request is intended to resolve issues where unintended predicate_push occurs when calling random functions such as drandom, random, sys_guid.

1. Changes in the **pt_check_pushable_subquery_select_list** function: This function iterates over the select list of a subquery. Within this function, content has been added to make predicate_push impossible when encountering functions like random or sys_guid.

2. Changes in the **pt_check_pushable** function: To handle cases where functions like random() are included as child nodes such as expr in the elements of the subquery's select list, content has been added to the pt_check_pushable function, which iterates over leaf nodes, to inspect them, even if they don't fall under all the cases examined by the **pt_check_pushable_subquery_select_list** function.