### PR TITLE
[CBRD-24938] add comment to dblink query for statement type checking in gateway

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -5193,14 +5193,14 @@ pt_dblink_table_get_column_defs (PARSER_CONTEXT * parser, PT_NODE * dblink, S_RE
       rmt_tbl_cols->set_select_star ();
 
       /* preparing the query to get the column info */
-      var_buf = pt_append_nulstring (parser, var_buf, "SELECT * FROM ");
-      var_buf = pt_append_nulstring (parser, var_buf, table_name);
-      sql = (char *) var_buf->bytes;
+      sql = pt_append_string (parser, "/* DBLINK SELECT */ SELECT * FROM ", table_name);
     }
   else
     {
       /* for collecting column info from "SELECT sel-list form dblink(server, 'SELECT ...') */
-      sql = (char *) dblink_table->qstr->info.value.data_value.str->bytes;
+      sql =
+	pt_append_string (parser, "/* DBLINK SELECT */ ",
+			  (char *) dblink_table->qstr->info.value.data_value.str->bytes);
     }
 
   find = strstr (url, ":?");

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -12983,11 +12983,11 @@ pt_to_dblink_table_spec_list (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE *
 
   if (pdblink->rewritten)
     {
-      sql = (char *) pdblink->rewritten->bytes;
+      sql = pt_append_string (parser, "/* DBLINK SELECT */ ", (char *) pdblink->rewritten->bytes);
     }
   else
     {
-      sql = (char *) pdblink->qstr->info.value.data_value.str->bytes;
+      sql = pt_append_string (parser, "/* DBLINK SELECT */ ", (char *) pdblink->qstr->info.value.data_value.str->bytes);
     }
 
   if (pdblink->pushed_pred)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24938

When the gateway checks whether the current query format is SELECT or DML, an error may occur because string parsing is being performed.
So, when sending a query to the gateway, if it puts a comment such as /* DBLINK SELECT */ in front of the query and send it, the gateway can easily determine whether the query is a SELECT statement or a DML statement.
