### PR TITLE
[CBRD-24934] rev: [Regression] extending dblink to DML: double quoted…

### DIFF
--- a/src/base/intl_support.c
+++ b/src/base/intl_support.c
@@ -2752,7 +2752,7 @@ intl_identifier_casecmp_for_dblink (const char *dblink_col_name, const char *rem
   str1_size = strlen (str1);
   str2_size = strlen (str2);
 
-  if (*str1 == '\"')
+  if (*str1 == '\"' || *str1 == '`')
     {
       str1_size = str1_size - 2;
       str1 = str1 + 1;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24934

Add back quote (`) in addition to double quote (") as a special character to wrap reserved words or case-sensitive table names or column names.
MySQL and MariaDB use back quotes for this purpose.
