### PR TITLE
[CBRD-24939] dblink query could return zero column count in column info.

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -5255,7 +5255,7 @@ set_parser_error:
 
   if (conn >= 0)
     {
-      if ((cci_disconnect (conn, &cci_error)) < 0 && cci_error.err_msg[0] == '\0')
+      if ((cci_disconnect (conn, &cci_error)) < 0)
 	{
 	  cci_get_err_msg (err, cci_error.err_msg, sizeof (cci_error.err_msg));
 	}

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -5231,6 +5231,7 @@ pt_dblink_table_get_column_defs (PARSER_CONTEXT * parser, PT_NODE * dblink, S_RE
     {
       /* this can not be reached, something wrong */
       sprintf (cci_error.err_msg, "unknown error: cannot fetch the column info from remote server");
+      err = ER_FAILED;
       goto set_parser_error;
     }
 

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -5167,7 +5167,7 @@ static int
 pt_dblink_table_get_column_defs (PARSER_CONTEXT * parser, PT_NODE * dblink, S_REMOTE_TBL_COLS * rmt_tbl_cols)
 {
   int req = -1, conn = -1, col_cnt, err = ER_DBLINK, i;
-  T_CCI_ERROR cci_error;
+  T_CCI_ERROR cci_error = { 0, };
   T_CCI_COL_INFO *col_info;
   T_CCI_CUBRID_STMT stmt_type;
 
@@ -5231,7 +5231,6 @@ pt_dblink_table_get_column_defs (PARSER_CONTEXT * parser, PT_NODE * dblink, S_RE
     {
       /* this can not be reached, something wrong */
       sprintf (cci_error.err_msg, "unknown error: cannot fetch the column info from remote server");
-      err = ER_FAILED;
       goto set_parser_error;
     }
 
@@ -5248,15 +5247,15 @@ pt_dblink_table_get_column_defs (PARSER_CONTEXT * parser, PT_NODE * dblink, S_RE
 set_parser_error:
   if (req >= 0)
     {
-      if ((err = cci_close_req_handle (req)) < 0)
+      if ((cci_close_req_handle (req)) < 0 && cci_error.err_msg[0] == '\0')
 	{
 	  cci_get_err_msg (err, cci_error.err_msg, sizeof (cci_error.err_msg));
 	}
     }
 
-  if (err >= 0 && conn >= 0)
+  if (conn >= 0)
     {
-      if ((err = cci_disconnect (conn, &cci_error)) < 0)
+      if ((cci_disconnect (conn, &cci_error)) < 0 && cci_error.err_msg[0] == '\0')
 	{
 	  cci_get_err_msg (err, cci_error.err_msg, sizeof (cci_error.err_msg));
 	}

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -5167,7 +5167,7 @@ static int
 pt_dblink_table_get_column_defs (PARSER_CONTEXT * parser, PT_NODE * dblink, S_REMOTE_TBL_COLS * rmt_tbl_cols)
 {
   int req = -1, conn = -1, col_cnt, err = ER_DBLINK, i;
-  T_CCI_ERROR cci_error = { 0, };
+  T_CCI_ERROR cci_error;
   T_CCI_COL_INFO *col_info;
   T_CCI_CUBRID_STMT stmt_type;
 
@@ -5245,22 +5245,6 @@ pt_dblink_table_get_column_defs (PARSER_CONTEXT * parser, PT_NODE * dblink, S_RE
   err = NO_ERROR;
 
 set_parser_error:
-  if (req >= 0)
-    {
-      if ((cci_close_req_handle (req)) < 0 && cci_error.err_msg[0] == '\0')
-	{
-	  cci_get_err_msg (err, cci_error.err_msg, sizeof (cci_error.err_msg));
-	}
-    }
-
-  if (conn >= 0)
-    {
-      if ((cci_disconnect (conn, &cci_error)) < 0)
-	{
-	  cci_get_err_msg (err, cci_error.err_msg, sizeof (cci_error.err_msg));
-	}
-    }
-
   if (err < 0)
     {
       if (cci_error.err_msg[0] == '\0')
@@ -5280,6 +5264,16 @@ set_parser_error:
 		      "Failed to get column information for query [%s] on remote [%s]\n%s",
 		      sql, server_name, cci_error.err_msg);
 	}
+    }
+
+  if (req >= 0)
+    {
+      cci_close_req_handle (req);
+    }
+
+  if (conn >= 0)
+    {
+      cci_disconnect (conn, &cci_error);
     }
 
   return err;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24939

To get column information from dblink, cci_get_result_info (req, &stmt_type, &col_cnt) is used. At this time, col_cnt can be 0, which should be treated as an error, but there is a bug that has not been handled.