### PR TITLE
[CBRD-24849] Remove unnecessary synonym files

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -1029,7 +1029,6 @@ export_synonym (extract_context & ctxt, print_output & output_ctx)
 
   if (db_query_first_tuple (query_result) == DB_CURSOR_SUCCESS)
     {
-      output_ctx ("\n");
       do
 	{
 	  for (i = 0; i < SYNONYM_VALUE_INDEX_MAX; i++)
@@ -1126,6 +1125,8 @@ export_synonym (extract_context & ctxt, print_output & output_ctx)
 		  continue;
 		}
 	    }
+
+	  output_ctx ("\n");
 
 	  if (is_public == 1)
 	    {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24849

Purpose
When synonyms are extracted using the -i and --input-class-only options, only synonyms related to the class to be extracted should be extracted.
In the process of synonym extraction, even if there is no related synonym, an empty line is added to create a synonym file.
Modified to not create unnecessary files.

Implementation
N/A

Remarks
N/A