### PR TITLE
[LETS-783] Have waiters on send_receive notice the abnormal disconnection

### DIFF
--- a/src/communication/request_sync_client_server.hpp
+++ b/src/communication/request_sync_client_server.hpp
@@ -74,6 +74,7 @@ namespace cubcomm
       void stop_response_broker ();
       void stop_incoming_communication_thread ();
       void stop_outgoing_communication_thread ();
+      void wait_until_all_requests_sent ();
 
       /* only used by unit tests
        */
@@ -233,6 +234,13 @@ namespace cubcomm
 
     // terminate receiving messages
     m_conn.reset (nullptr);
+  }
+
+  template <typename T_OUTGOING_MSG_ID, typename T_INCOMING_MSG_ID, typename T_PAYLOAD>
+  void
+  request_sync_client_server<T_OUTGOING_MSG_ID, T_INCOMING_MSG_ID, T_PAYLOAD>::wait_until_all_requests_sent ()
+  {
+    m_queue->wait_until_empty ();
   }
 
   template <typename T_OUTGOING_MSG_ID, typename T_INCOMING_MSG_ID, typename T_PAYLOAD>

--- a/src/communication/request_sync_client_server.hpp
+++ b/src/communication/request_sync_client_server.hpp
@@ -60,7 +60,7 @@ namespace cubcomm
 				  T_OUTGOING_MSG_ID a_outgoing_response_msgid,
 				  T_INCOMING_MSG_ID a_incoming_response_msgid,
 				  size_t response_partition_count,
-				  send_queue_error_handler &&error_handler);
+				  send_queue_error_handler &&req_error_handler);
       ~request_sync_client_server ();
       request_sync_client_server (const request_sync_client_server &) = delete;
       request_sync_client_server (request_sync_client_server &&) = delete;
@@ -149,9 +149,9 @@ namespace cubcomm
 	  std::map<T_INCOMING_MSG_ID, incoming_request_handler_t> &&a_incoming_request_handlers,
 	  T_OUTGOING_MSG_ID a_outgoing_response_msgid, T_INCOMING_MSG_ID a_incoming_response_msgid,
 	  size_t response_partition_count,
-	  send_queue_error_handler &&error_handler)
+	  send_queue_error_handler &&req_error_handler)
     : m_conn { new request_client_server_t (std::move (a_channel)) }
-  , m_queue { new request_sync_send_queue_t (*m_conn, std::move (error_handler)) }
+  , m_queue { new request_sync_send_queue_t (*m_conn, std::move (req_error_handler)) }
   , m_queue_autosend { new request_queue_autosend_t (*m_queue) }
   , m_outgoing_response_msgid { a_outgoing_response_msgid }
   , m_incoming_response_msgid { a_incoming_response_msgid }
@@ -167,6 +167,13 @@ namespace cubcomm
     incoming_request_handler_t bound_response_handler =
 	    std::bind (&request_sync_client_server::handle_response, this, std::placeholders::_1);
     register_handler (m_incoming_response_msgid, bound_response_handler);
+
+    auto recv_error_handler = [this] (css_error_code error)
+    {
+      return;
+    };
+
+    m_conn->register_error_handler (recv_error_handler);
   }
 
   template <typename T_OUTGOING_MSG_ID, typename T_INCOMING_MSG_ID, typename T_PAYLOAD>

--- a/src/communication/request_sync_send_queue.hpp
+++ b/src/communication/request_sync_send_queue.hpp
@@ -96,6 +96,8 @@ namespace cubcomm
       template <typename Duration>
       void wait_not_empty_and_send_all (queue_type &backbuffer, const Duration &timeout);
 
+      void wait_until_empty ();
+
     private:
       void send_queue (queue_type &q); // Send queued requests to the server
 
@@ -294,6 +296,18 @@ namespace cubcomm
 
     send_queue (backbuffer);
     assert (backbuffer.empty ());
+  }
+
+  template <typename ReqClient, typename ReqPayload>
+  void
+  request_sync_send_queue<ReqClient, ReqPayload>::wait_until_empty ()
+  {
+    constexpr auto ten_millis = std::chrono::milliseconds (10);
+    std::unique_lock<std::mutex> ulock (m_queue_mutex);
+    while (!m_queue_condvar.wait_for (ulock, ten_millis, [this]
+    {
+      return m_request_queue.empty ();
+      }));
   }
 
   //

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -113,7 +113,7 @@ page_server::connection_handler::connection_handler (cubcomm::channel &chn, tran
   tran_to_page_request::RESPOND,
   RESPONSE_PARTITIONING_SIZE,
   std::bind (&page_server::connection_handler::abnormal_tran_server_disconnect,
-	     std::ref (*this), std::placeholders::_1, std::placeholders::_2)));
+	     std::ref (*this), std::placeholders::_1, std::placeholders::_2), nullptr));
   m_ps.get_responder ().register_connection (m_conn.get ());
 
   assert (m_conn != nullptr);

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -487,12 +487,16 @@ tran_server::connection_handler::set_connection (cubcomm::channel &&chn)
 
   auto error_handler = std::bind (&tran_server::connection_handler::default_error_handler, this,
 				  std::placeholders::_1, std::placeholders::_2);
+  auto recv_error_handler = [this] (css_error_code err)
+  {
+    disconnect_async (false);
+  };
 
   auto lockg_conn = std::lock_guard<std::shared_mutex> { m_conn_mtx };
 
   assert (m_conn == nullptr);
   m_conn.reset (new page_server_conn_t (std::move (chn), get_request_handlers (), tran_to_page_request::RESPOND,
-					page_to_tran_request::RESPOND, RESPONSE_PARTITIONING_SIZE, std::move (error_handler), nullptr));
+					page_to_tran_request::RESPOND, RESPONSE_PARTITIONING_SIZE, std::move (error_handler), recv_error_handler));
 
   m_conn->start ();
 }

--- a/src/server/tran_server.cpp
+++ b/src/server/tran_server.cpp
@@ -492,7 +492,7 @@ tran_server::connection_handler::set_connection (cubcomm::channel &&chn)
 
   assert (m_conn == nullptr);
   m_conn.reset (new page_server_conn_t (std::move (chn), get_request_handlers (), tran_to_page_request::RESPOND,
-					page_to_tran_request::RESPOND, RESPONSE_PARTITIONING_SIZE, std::move (error_handler)));
+					page_to_tran_request::RESPOND, RESPONSE_PARTITIONING_SIZE, std::move (error_handler), nullptr));
 
   m_conn->start ();
 }

--- a/src/server/tran_server.hpp
+++ b/src/server/tran_server.hpp
@@ -178,7 +178,8 @@ class tran_server
       private:
 	void set_connection (cubcomm::channel &&chn);
 	// The default error handler for sending reqeust
-	void default_error_handler (css_error_code error_code, bool &abort_further_processing);
+	void send_error_handler (css_error_code error_code, bool &abort_further_processing);
+	void recv_error_handler (css_error_code error_code);
 	// Request handlers for requests in common
 	void receive_disconnect_request (page_server_conn_t::sequenced_payload &&a_sp);
 

--- a/unit_tests/request_client_server/comm_channel_mock.cpp
+++ b/unit_tests/request_client_server/comm_channel_mock.cpp
@@ -155,6 +155,27 @@ add_socket_direction (const std::string &sender_id, const std::string &receiver_
 }
 
 void
+disconnect_sender_socket_direction (const std::string &sender_id)
+{
+  const auto it = global_sender_sockdirs.find (sender_id);
+  if (it != global_sender_sockdirs.cend())
+    {
+      it->second->disconnect ();
+    }
+}
+
+void
+disconnect_receiver_socket_direction (const std::string &receiver_id)
+{
+  const auto it = global_receiver_sockdirs.find (receiver_id);
+
+  if (it != global_receiver_sockdirs.cend())
+    {
+      it->second->disconnect ();
+    }
+}
+
+void
 clear_socket_directions ()
 {
   global_sender_sockdirs.clear ();
@@ -328,20 +349,8 @@ namespace cubcomm
 
   void channel::close_connection ()
   {
-    for (auto &it : global_sender_sockdirs)
-      {
-	if (it.first == get_channel_id ())
-	  {
-	    it.second->disconnect ();
-	  }
-      }
-    for (auto &it : global_receiver_sockdirs)
-      {
-	if (it.first == get_channel_id ())
-	  {
-	    it.second->disconnect ();
-	  }
-      }
+    disconnect_sender_socket_direction (get_channel_id ());
+    disconnect_receiver_socket_direction (get_channel_id ());
   }
 
   int channel::get_max_timeout_in_ms () const

--- a/unit_tests/request_client_server/comm_channel_mock.cpp
+++ b/unit_tests/request_client_server/comm_channel_mock.cpp
@@ -407,7 +407,6 @@ namespace cubcomm
   int channel::wait_for (unsigned short int, unsigned short int &revents) const
   {
     std::string chnid = get_channel_id ();
-
     if (global_sockdirs_initialized.load () == false)
       {
 	revents = 0;

--- a/unit_tests/request_client_server/comm_channel_mock.hpp
+++ b/unit_tests/request_client_server/comm_channel_mock.hpp
@@ -66,18 +66,25 @@ class mock_socket_direction
     void wait_for_all_messages ();              // wait until all messages are pulled and the message queue is empty
     void wait_until_message_count (size_t count);
 
+    void freeze ();                             // Block to read a meessage to simulate a communication delay
+    void unfreeze ();                           // Unblock to read a message to simulate a coomunication delay
+
   private:
     std::queue<std::string> m_messages;
     std::mutex m_mutex;
     std::condition_variable m_condvar;
     bool m_disconnect = false;
     size_t m_message_count = 0;
+    bool m_frozen = false;
 };
 
 void add_socket_direction (const std::string &sender_id, const std::string &receiver_id,
 			   mock_socket_direction &sockdir, bool last_one_to_be_initialized);
 void disconnect_sender_socket_direction (const std::string &sender_id);
 void disconnect_receiver_socket_direction (const std::string &receiver_id);
+void freeze_receiver_socket_direction (const std::string &receiver_id);
+void unfreeze_receiver_socket_direction (const std::string &receiver_id);
+bool does_receiver_socket_direction_have_message (const std::string &receiver_id);
 void clear_socket_directions ();
 
 #endif // _COMM_CHANNEL_MOCK_HPP_

--- a/unit_tests/request_client_server/comm_channel_mock.hpp
+++ b/unit_tests/request_client_server/comm_channel_mock.hpp
@@ -76,6 +76,8 @@ class mock_socket_direction
 
 void add_socket_direction (const std::string &sender_id, const std::string &receiver_id,
 			   mock_socket_direction &sockdir, bool last_one_to_be_initialized);
+void disconnect_sender_socket_direction (const std::string &sender_id);
+void disconnect_receiver_socket_direction (const std::string &receiver_id);
 void clear_socket_directions ();
 
 #endif // _COMM_CHANNEL_MOCK_HPP_

--- a/unit_tests/request_client_server/comm_channel_mock.hpp
+++ b/unit_tests/request_client_server/comm_channel_mock.hpp
@@ -67,7 +67,7 @@ class mock_socket_direction
     void wait_until_message_count (size_t count);
 
     void freeze ();                             // Block to read a message to simulate a communication delay
-    void unfreeze ();                           // Unblock to read a message to simulate a coomunication delay
+    void unfreeze ();                           // Unblock to read a message to simulate a communication delay
 
   private:
     std::queue<std::string> m_messages;

--- a/unit_tests/request_client_server/comm_channel_mock.hpp
+++ b/unit_tests/request_client_server/comm_channel_mock.hpp
@@ -66,7 +66,7 @@ class mock_socket_direction
     void wait_for_all_messages ();              // wait until all messages are pulled and the message queue is empty
     void wait_until_message_count (size_t count);
 
-    void freeze ();                             // Block to read a meessage to simulate a communication delay
+    void freeze ();                             // Block to read a message to simulate a communication delay
     void unfreeze ();                           // Unblock to read a message to simulate a coomunication delay
 
   private:

--- a/unit_tests/request_client_server/test_main.cpp
+++ b/unit_tests/request_client_server/test_main.cpp
@@ -635,42 +635,42 @@ TEST_CASE ("Two request_sync_client_server communicate with each other", "")
 
   constexpr int MESSAGE_COUNT = 4200;
 
-#define BIND_ENV_FUNC(foo) \
-  std::bind (&(test_two_request_sync_client_server_env::foo), std::ref (env), std::placeholders::_1, std::placeholders::_2)
-
 #define REPEAT_REQUEST_WITH_MSGID(req_foo, msgid) \
   for (int i = 0; i < MESSAGE_COUNT; ++i) req_foo (msgid, i)
 
-  std::vector<std::thread> threads;
-  threads.emplace_back ([&] ()
+  SECTION ("Push and send requests and confirm they are handled")
   {
-    REPEAT_REQUEST_WITH_MSGID (env.send_recv_request_on_scs_one, reqids_1_to_2::_0);
-  });
-  threads.emplace_back ([&] ()
-  {
-    REPEAT_REQUEST_WITH_MSGID (env.push_request_on_scs_one, reqids_1_to_2::_1);
-  });
-  threads.emplace_back ([&] ()
-  {
-    REPEAT_REQUEST_WITH_MSGID (env.send_recv_request_on_scs_two, reqids_2_to_1::_0);
-  });
-  threads.emplace_back ([&] ()
-  {
-    REPEAT_REQUEST_WITH_MSGID (env.push_request_on_scs_two, reqids_2_to_1::_1);
-  });
-  threads.emplace_back ([&] ()
-  {
-    REPEAT_REQUEST_WITH_MSGID (env.push_request_on_scs_two, reqids_2_to_1::_1);
-  });
-
-  for (auto &th : threads)
+    std::vector<std::thread> threads;
+    threads.emplace_back ([&] ()
     {
-      th.join ();
-    }
+      REPEAT_REQUEST_WITH_MSGID (env.send_recv_request_on_scs_one, reqids_1_to_2::_0);
+    });
+    threads.emplace_back ([&] ()
+    {
+      REPEAT_REQUEST_WITH_MSGID (env.push_request_on_scs_one, reqids_1_to_2::_1);
+    });
+    threads.emplace_back ([&] ()
+    {
+      REPEAT_REQUEST_WITH_MSGID (env.send_recv_request_on_scs_two, reqids_2_to_1::_0);
+    });
+    threads.emplace_back ([&] ()
+    {
+      REPEAT_REQUEST_WITH_MSGID (env.push_request_on_scs_two, reqids_2_to_1::_1);
+    });
+    threads.emplace_back ([&] ()
+    {
+      REPEAT_REQUEST_WITH_MSGID (env.push_request_on_scs_two, reqids_2_to_1::_1);
+    });
 
-  env.wait_for_all_messages ();
+    for (auto &th : threads)
+      {
+	th.join ();
+      }
 
-  require_all_sent_requests_are_handled ();
+    env.wait_for_all_messages ();
+
+    require_all_sent_requests_are_handled ();
+  }
 }
 
 TEST_CASE ("Test response sequence number generator", "")

--- a/unit_tests/request_client_server/test_main.cpp
+++ b/unit_tests/request_client_server/test_main.cpp
@@ -647,7 +647,7 @@ TEST_CASE ("Two request_sync_client_server communicate with each other", "")
 
   test_two_request_sync_client_server_env env;
 
-  SECTION ("Push and send requests and confirm they are handled")
+  SECTION ("Send and handle requests")
   {
     constexpr int MESSAGE_COUNT = 4200;
 
@@ -686,7 +686,7 @@ TEST_CASE ("Two request_sync_client_server communicate with each other", "")
     require_all_sent_requests_are_handled ();
   }
 
-  SECTION ("Detect a failure while push request")
+  SECTION ("Detect errors on push_request")
   {
     {
       // Ensure no failure is detected.
@@ -709,7 +709,7 @@ TEST_CASE ("Two request_sync_client_server communicate with each other", "")
     }
   }
 
-  SECTION ("Detect a failure while send_recv request")
+  SECTION ("Detect errors on send_recv_request")
   {
     {
       // Ensure no failure is detected.

--- a/unit_tests/request_client_server/test_main.cpp
+++ b/unit_tests/request_client_server/test_main.cpp
@@ -264,6 +264,9 @@ class test_two_request_sync_client_server_env
     template<reqids_1_to_2 T_VAL>
     void handle_req_and_respond_on_scs_two (test_request_sync_client_server_two_t::sequenced_payload &&sp);
 
+    void send_error_handler (css_error_code error_code, bool &abort_further_processing);
+    void recv_error_handler (css_error_code error_code);
+
     uq_test_request_sync_client_server_one_t create_request_sync_client_server_one ();
     uq_test_request_sync_client_server_two_t create_request_sync_client_server_two ();
 
@@ -1324,6 +1327,18 @@ test_two_request_sync_client_server_env::handle_req_and_respond_on_scs_two (
   handle_req_and_respond<reqids_1_to_2, T_VAL> (get_scs_two (), std::move (sp), m_total_2_to_1_message_count);
 }
 
+void
+test_two_request_sync_client_server_env::send_error_handler (css_error_code error_code, bool &abort_further_processing)
+{
+  assert (false);
+}
+
+void
+test_two_request_sync_client_server_env::recv_error_handler (css_error_code error_code)
+{
+  assert (false);
+}
+
 uq_test_request_sync_client_server_one_t
 test_two_request_sync_client_server_env::create_request_sync_client_server_one ()
 {
@@ -1352,6 +1367,11 @@ test_two_request_sync_client_server_env::create_request_sync_client_server_one (
     mock_check_expected_id_sync<reqids_2_to_1, reqids_2_to_1::_2, actual_payload_t> (a_sp.pull_payload ());
   };
 
+  auto send_error_handler = std::bind (&test_two_request_sync_client_server_env::send_error_handler, this,
+				       std::placeholders::_1, std::placeholders::_2);
+  auto recv_error_handler = std::bind (&test_two_request_sync_client_server_env::recv_error_handler, this,
+				       std::placeholders::_1);
+
   uq_test_request_sync_client_server_one_t scs_one
   {
     new test_request_sync_client_server_one_t (std::move (chn),
@@ -1359,7 +1379,8 @@ test_two_request_sync_client_server_env::create_request_sync_client_server_one (
       { reqids_2_to_1::_0, req_handler_0 },
       { reqids_2_to_1::_1, req_handler_1 },
       { reqids_2_to_1::_2, req_handler_2 }
-    }, reqids_1_to_2::RESPOND, reqids_2_to_1::RESPOND, 10, nullptr, nullptr)
+    }, reqids_1_to_2::RESPOND, reqids_2_to_1::RESPOND, 10
+    , std::move (send_error_handler), std::move (recv_error_handler))
   };
   scs_one->start ();
 

--- a/unit_tests/request_client_server/test_main.cpp
+++ b/unit_tests/request_client_server/test_main.cpp
@@ -1359,7 +1359,7 @@ test_two_request_sync_client_server_env::create_request_sync_client_server_one (
       { reqids_2_to_1::_0, req_handler_0 },
       { reqids_2_to_1::_1, req_handler_1 },
       { reqids_2_to_1::_2, req_handler_2 }
-    }, reqids_1_to_2::RESPOND, reqids_2_to_1::RESPOND, 10, nullptr)
+    }, reqids_1_to_2::RESPOND, reqids_2_to_1::RESPOND, 10, nullptr, nullptr)
   };
   scs_one->start ();
 
@@ -1393,7 +1393,7 @@ test_two_request_sync_client_server_env::create_request_sync_client_server_two (
     {
       { reqids_1_to_2::_0, req_handler_0 },
       { reqids_1_to_2::_1, req_handler_1 }
-    }, reqids_2_to_1::RESPOND, reqids_1_to_2::RESPOND, 10, nullptr)
+    }, reqids_2_to_1::RESPOND, reqids_1_to_2::RESPOND, 10, nullptr, nullptr)
   };
   scs_two->start ();
 

--- a/unit_tests/request_client_server/test_main.cpp
+++ b/unit_tests/request_client_server/test_main.cpp
@@ -721,13 +721,13 @@ TEST_CASE ("Two request_sync_client_server communicate with each other", "")
     }
     {
       // Send a send_recv request from the scs1 to the scs2 while the internal socket is frozen.
-      // Then, disconnect the ineternal socket and confirm this disconnection is dectected on scs1.
+      // Then, disconnect the internal socket and confirm this disconnection is detected on scs1.
       const auto receiver_id = env.get_scs_one ().get_underlying_channel_id ();
       freeze_receiver_socket_direction (receiver_id);
 
       auto disconnecter = std::thread ([&] ()
       {
-	// Wait until a request is pushed and disconnect the socket.
+	// Wait until a request is pushed and the socket is disconnected.
 	// This has to be done by another thread since the send_recv() is a blocking call.
 	while (!does_receiver_socket_direction_have_message (receiver_id))
 	  {


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-783

**Implementation**
- Push recv error handler from connection_handler into `request_server` and call it when an error occurs while receiving a message.
- The recv error handler the tran server uses is just to disconnect the page server.
- The `send_receive` no longer does disconnection.

**Unit tests**
- Most of the changes are about adding unit tests.
    - Detect errors on push_request
    - Detect errors on send_recv_request
- To do that, split the `request_sync_client_server` test case into three sections: the existing on and newly added tests.
- To do that, some functions for the `socket_direction`, the mock for an internal socket,  are added.
    - `disconnect_sender/receiver_socket_direction`: disconnect the socket direction.
    - `[un]freeze_receiver_socket_direction`: block to read a message to simulate a communication delay. Without this, we can't simulate the failure two internal actions, sending, and receiving, in the send_recv.
    - `does_receiver_socket_direction_have_message`: a helper to confirm a message is added.
- Add functions to see if there are requests left. It's only used in unit tests, but could be helpful for the future.