### PR TITLE
[CBRD-24876] Improves MIN/MAX performance when the first part of the function index is not a function

### DIFF
--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -5777,8 +5777,8 @@ sm_find_index (MOP classop, char **att_names, int num_atts, bool unique_index_on
 	      continue;
 	    }
 
-	  /* exclude filter or function index */
-	  if (con->filter_predicate || con->func_index_info)
+	  /* exclude filter or function index(If the first key part of index is a function) */
+	  if (con->filter_predicate || (con->func_index_info && con->func_index_info->col_id == 0))
 	    {
 	      continue;
 	    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24876

* If the first key part in the function index is not a function, change the index to be used when obtaining the minimum/maximum value.
