### PR TITLE
[CBRD-24920] [regression] to not output decimal point 0 of double type in csql

### DIFF
--- a/src/executables/csql_result_format.c
+++ b/src/executables/csql_result_format.c
@@ -1352,16 +1352,31 @@ conv_double_to_string (char *double_str, int *length)
 
   if (exp_num > 0)
     {
-      memcpy (sp, double_str, offset = (int) (dot - double_str));
-      memcpy (sp + offset, dot + 1, p = (int) (exp - dot) - 1);
-      memset (sp + offset + p, '0', exp_num - (int) (exp - dot) + 1);
+      if (dot)
+	{
+          memcpy (sp, double_str, offset = (int) (dot - double_str));
+          memcpy (sp + offset, dot + 1, p = (int) (exp - dot) - 1);
+          memset (sp + offset + p, '0', exp_num - (int) (exp - dot) + 1);
+	}
+      else
+	{
+          memcpy (sp, double_str, p = (int) (exp - double_str));
+          memset (sp + p, '0', exp_num);
+	}
     }
   else
     {
       exp_num = -exp_num;
       memset (sp + 2, '0', offset = exp_num - 1);
-      memcpy (sp + 2 + offset, double_str, p = (int) (dot - double_str));
-      memcpy (sp + 2 + offset + p, dot + 1, (int) (exp - dot) - 1);
+      if (dot)
+	{
+          memcpy (sp + 2 + offset, double_str, p = (int) (dot - double_str));
+          memcpy (sp + 2 + offset + p, dot + 1, (int) (exp - dot) - 1);
+	}
+      else
+	{
+	  memcpy (sp + 2 + offset, double_str, (int) (exp - double_str));
+	}
     }
 
   *length = (sign < 0) ? strlen (return_str) : strlen (return_str + 1);

--- a/src/executables/csql_result_format.c
+++ b/src/executables/csql_result_format.c
@@ -1354,14 +1354,14 @@ conv_double_to_string (char *double_str, int *length)
     {
       if (dot)
 	{
-          memcpy (sp, double_str, offset = (int) (dot - double_str));
-          memcpy (sp + offset, dot + 1, p = (int) (exp - dot) - 1);
-          memset (sp + offset + p, '0', exp_num - (int) (exp - dot) + 1);
+	  memcpy (sp, double_str, offset = (int) (dot - double_str));
+	  memcpy (sp + offset, dot + 1, p = (int) (exp - dot) - 1);
+	  memset (sp + offset + p, '0', exp_num - (int) (exp - dot) + 1);
 	}
       else
 	{
-          memcpy (sp, double_str, p = (int) (exp - double_str));
-          memset (sp + p, '0', exp_num);
+	  memcpy (sp, double_str, p = (int) (exp - double_str));
+	  memset (sp + p, '0', exp_num);
 	}
     }
   else
@@ -1370,8 +1370,8 @@ conv_double_to_string (char *double_str, int *length)
       memset (sp + 2, '0', offset = exp_num - 1);
       if (dot)
 	{
-          memcpy (sp + 2 + offset, double_str, p = (int) (dot - double_str));
-          memcpy (sp + 2 + offset + p, dot + 1, (int) (exp - dot) - 1);
+	  memcpy (sp + 2 + offset, double_str, p = (int) (dot - double_str));
+	  memcpy (sp + 2 + offset + p, dot + 1, (int) (exp - dot) - 1);
 	}
       else
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24920

If the oracle_compat_number_behavior parameter is set, do not output decimal point 0 when outputting double type in csql.

```
create table ttbl ( a double);
insert into ttbl values (-1.0e+308);
select * from ttbl;
```

fatal error occurred