### PR TITLE
[CBRD-24876] Improves MIN/MAX performance when a function index but the first key is not a function.

### DIFF
--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -5933,8 +5933,8 @@ sm_find_index (MOP classop, char **att_names, int num_atts, bool unique_index_on
 	      continue;
 	    }
 
-	  /* exclude filter or function index */
-	  if (con->filter_predicate || con->func_index_info)
+	  /* exclude filter or function index(If the first key part of index is a function) */
+	  if (con->filter_predicate || (con->func_index_info && con->func_index_info->col_id < num_atts))
 	    {
 	      continue;
 	    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24876

* If the first key part in the function index is not a function, change the index to be used when obtaining the minimum/maximum value.

```
drop table if exists t1, t2;
create table t1(col1 int, col2 int );
create table t2  like t1;
insert into t1 select rownum, random() from table({0,1,2,3,4,5,6,7,8,9}) a, table({0,1,2,3,4,5,6,7,8,9}) b, table({0,1,2,3,4,5,6,7,8,9}) c, table({0,1,2,3,4,5,6,7,8,9}) d;
insert into t2 select * from t1;

create index idx on t1(col1, abs(col2));
create index idx on t2(col1 desc, abs(col2) desc);

-- In the execution result below, you can see that the number of fetches is reduced.
set trace on;
select /*+ recompile */ min(col1), max(col1) from t1;  
show trace;
select /*+ recompile */ min(col1), max(col1) from t2;  
show trace;

```