### PR TITLE
[CBRD-24940] When using the --split-schema-files option, index, trigger, and object files cannot be extracted.

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -5062,7 +5062,7 @@ extract_vclass (extract_context & ctxt)
     }
 
   emit_schema (ctxt, output_ctx, EXTRACT_VCLASS);
-  err = (er_errid () == NO_ERROR) ? ER_FAILED : NO_ERROR;
+  err = (er_errid () == NO_ERROR) ? NO_ERROR : ER_FAILED;
 
   fflush (output_file);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24940

Purpose
Using the --split-schema-files option, 11 Schema files, Schema info files, and Object, Index, and Trigger files must be created as shown below.

demodb_schema_user
demodb_schema_class
demodb_schema_vclass
demodb_schema_synonym
demodb_schema_vclass_query_spec
demodb_schema_serial
demodb_schema_procedure
demodb_schema_server
demodb_schema_pk
demodb_schema_fk
demodb_schema_grant
demodb_objects
demodb_indexes
demodb_trigger

demodb_schema_info
 

Implementation
N/A

Remarks
N/A