### PR TITLE
[CBRD-24889] Implement print function of memmon utility

### DIFF
--- a/cs/CMakeLists.txt
+++ b/cs/CMakeLists.txt
@@ -104,6 +104,7 @@ set(BASE_SOURCES
   ${BASE_DIR}/mem_block.cpp
   ${BASE_DIR}/memory_alloc.c
   ${BASE_DIR}/memory_hash.c
+  ${BASE_DIR}/memory_monitor_cl.cpp
   ${BASE_DIR}/memory_private_allocator.cpp
   ${BASE_DIR}/message_catalog.c
   ${BASE_DIR}/misc_string.c

--- a/src/base/memory_monitor_cl.cpp
+++ b/src/base/memory_monitor_cl.cpp
@@ -1,0 +1,161 @@
+/*
+ *
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+/*
+ * memory_monitor_cl.hpp - client structures and functions
+ *                         for memory monitoring module
+ */
+
+#include <cstring>
+#include <string>
+#include <stdio.h>
+
+#include "memory_monitor_cl.hpp"
+
+/*
+ * mmon_convert_module_name_to_index -
+ *
+ * return: module index
+ *
+ *   module_name(in):
+ */
+int
+mmon_convert_module_name_to_index (const char *module_name)
+{
+  for (int i = 0; i < MMON_MODULE_LAST; i++)
+    {
+      if (!strcmp (module_name, module_names[i]))
+	{
+	  return i;
+	}
+    }
+
+  /* for code protection. unreachable */
+  return -1;
+}
+
+/*
+ * mmon_print_server_info -
+ *
+ * return:
+ *
+ *   server_info(in/out):
+ */
+void
+mmon_print_server_info (MMON_SERVER_INFO &server_info)
+{
+  fprintf (stdout, "====================Cubrid Memmon====================\n");
+  fprintf (stdout, "Server Name: %s\n", server_info.name);
+  fprintf (stdout, "Total Memory Usage(KB): %lu\n\n", CONVERT_TO_KB_SIZE (server_info.total_mem_usage));
+  fprintf (stdout, "-----------------------------------------------------\n");
+}
+
+/*
+ * mmon_print_module_info -
+ *
+ * return:
+ *
+ *   module_info(in):
+ */
+void
+mmon_print_module_info (std::vector<MMON_MODULE_INFO> &module_info)
+{
+  const std::string init_size_str ("Init Size(KB)");
+  const std::string cur_size_str ("Cur Size(KB)");
+  const std::string peak_size_str ("Peak Size(KB)");
+  const std::string resize_expand_str ("Resize Expand");
+
+  for (const auto &m_info : module_info)
+    {
+      fprintf (stdout, "Module Name: %s\n\n", m_info.name);
+      fprintf (stdout, "%-13s\t: %17lu\n", init_size_str.c_str (), CONVERT_TO_KB_SIZE (m_info.stat.init_stat));
+      fprintf (stdout, "%-13s\t: %17lu\n", cur_size_str.c_str (), CONVERT_TO_KB_SIZE (m_info.stat.cur_stat));
+      fprintf (stdout, "%-13s\t: %17lu\n", peak_size_str.c_str (), CONVERT_TO_KB_SIZE (m_info.stat.peak_stat));
+      fprintf (stdout, "%-13s\t: %17u\n\n", resize_expand_str.c_str (), m_info.stat.expand_resize_count);
+
+      for (const auto &comp_info : m_info.comp_info)
+	{
+	  fprintf (stdout, "%s\n", comp_info.name);
+	  fprintf (stdout, "\t%-17s\t: %17lu\n", init_size_str.c_str (), CONVERT_TO_KB_SIZE (comp_info.stat.init_stat));
+	  fprintf (stdout, "\t%-17s\t: %17lu\n", cur_size_str.c_str (), CONVERT_TO_KB_SIZE (comp_info.stat.cur_stat));
+
+	  for (const auto &subcomp_info : comp_info.subcomp_info)
+	    {
+	      std::string out_name (subcomp_info.name);
+	      out_name += "(KB)";
+	      fprintf (stdout, "\t  %-15s\t: %17lu\n", out_name.c_str (), CONVERT_TO_KB_SIZE (subcomp_info.cur_stat));
+	    }
+	  fprintf (stdout, "\t%-17s\t: %17lu\n", peak_size_str.c_str (), CONVERT_TO_KB_SIZE (comp_info.stat.peak_stat));
+	  fprintf (stdout, "\t%-17s\t: %17u\n\n", resize_expand_str.c_str (), comp_info.stat.expand_resize_count);
+	}
+      fprintf (stdout, "\n-----------------------------------------------------\n\n");
+    }
+}
+
+/*
+ * mmon_print_module_info_summary -
+ *
+ * return:
+ *
+ *   module_info(in):
+ */
+void
+mmon_print_module_info_summary (uint64_t server_mem_usage, std::vector<MMON_MODULE_INFO> &module_info)
+{
+  double percent = 0.0;
+
+  fprintf (stdout, "Per Module Memory Usage (KB)\n");
+  fprintf (stdout, "\tModule\t\tModule\t\t\tModule\n");
+  fprintf (stdout, "\tIndex\t\tName\t\t\tUsage(%%)\n");
+
+  for (const auto &m_info : module_info)
+    {
+      if (m_info.stat.cur_stat != 0)
+	{
+	  percent = (double) m_info.stat.cur_stat / (double) server_mem_usage;
+	}
+
+      fprintf (stdout, "\t%5d\t%-20s\t: %17lu(%3d%%)\n", mmon_convert_module_name_to_index (m_info.name),
+	       m_info.name, CONVERT_TO_KB_SIZE (m_info.stat.cur_stat), (int)percent);
+    }
+  fprintf (stdout, "\n-----------------------------------------------------\n\n");
+}
+
+/*
+ * mmon_print_tran_info -
+ *
+ * return:
+ *
+ *   tran_info(in):
+ */
+void
+mmon_print_tran_info (MMON_TRAN_INFO &tran_info)
+{
+  const std::string tran_id_str ("Transaction ID");
+  const std::string mem_usage_str ("Memory Usage");
+
+  fprintf (stdout, "Transaction Memory Usage Info (KB)\n");
+  fprintf (stdout, "\t%14s | %12s\n", tran_id_str.c_str (), mem_usage_str.c_str ());
+
+  for (const auto &t_stat : tran_info.tran_stat)
+    {
+      fprintf (stdout, "\t%14d | %17lu\n", t_stat.tranid, t_stat.cur_stat);
+    }
+  fprintf (stdout, "\n-----------------------------------------------------\n\n");
+}
+

--- a/src/base/memory_monitor_cl.cpp
+++ b/src/base/memory_monitor_cl.cpp
@@ -47,8 +47,7 @@ mmon_convert_module_name_to_index (const char *module_name)
     }
 
   /* for code protection. unreachable */
-  assert (false);
-  return -1;
+  assert (false && "module index matching failed");
 }
 
 /*

--- a/src/base/memory_monitor_cl.cpp
+++ b/src/base/memory_monitor_cl.cpp
@@ -17,7 +17,7 @@
  */
 
 /*
- * memory_monitor_cl.hpp - client structures and functions
+ * memory_monitor_cl.cpp - definitions of client functions
  *                         for memory monitoring module
  */
 
@@ -158,4 +158,3 @@ mmon_print_tran_info (MMON_TRAN_INFO &tran_info)
     }
   fprintf (stdout, "\n-----------------------------------------------------\n\n");
 }
-

--- a/src/base/memory_monitor_cl.cpp
+++ b/src/base/memory_monitor_cl.cpp
@@ -60,7 +60,7 @@ mmon_convert_module_name_to_index (const char *module_name)
 void
 mmon_print_server_info (MMON_SERVER_INFO &server_info)
 {
-  fprintf (stdout, "====================Cubrid Memmon====================\n");
+  fprintf (stdout, "====================cubrid memmon====================\n");
   fprintf (stdout, "Server Name: %s\n", server_info.name);
   fprintf (stdout, "Total Memory Usage(KB): %lu\n\n", MMON_CONVERT_TO_KB_SIZE (server_info.total_mem_usage));
   fprintf (stdout, "-----------------------------------------------------\n");
@@ -76,33 +76,33 @@ mmon_print_server_info (MMON_SERVER_INFO &server_info)
 void
 mmon_print_module_info (std::vector<MMON_MODULE_INFO> &module_info)
 {
-  const auto init_size_str = std::string {"Init Size(KB)"};
-  const auto cur_size_str = std::string {"Cur Size(KB)"};
+  const auto init_size_str = std::string {"Initial Size(KB)"};
+  const auto cur_size_str = std::string {"Current Size(KB)"};
   const auto peak_size_str = std::string {"Peak Size(KB)"};
-  const auto resize_expand_str = std::string {"Resize Expand"};
+  const auto resize_expand_str = std::string {"Resize Expand Count"};
 
   for (const auto &m_info : module_info)
     {
       fprintf (stdout, "Module Name: %s\n\n", m_info.name);
-      fprintf (stdout, "%-13s\t: %17lu\n", init_size_str.c_str (), MMON_CONVERT_TO_KB_SIZE (m_info.stat.init_stat));
-      fprintf (stdout, "%-13s\t: %17lu\n", cur_size_str.c_str (), MMON_CONVERT_TO_KB_SIZE (m_info.stat.cur_stat));
-      fprintf (stdout, "%-13s\t: %17lu\n", peak_size_str.c_str (), MMON_CONVERT_TO_KB_SIZE (m_info.stat.peak_stat));
-      fprintf (stdout, "%-13s\t: %17u\n\n", resize_expand_str.c_str (), m_info.stat.expand_resize_count);
+      fprintf (stdout, "%-19s\t: %17lu\n", init_size_str.c_str (), MMON_CONVERT_TO_KB_SIZE (m_info.stat.init_stat));
+      fprintf (stdout, "%-19s\t: %17lu\n", cur_size_str.c_str (), MMON_CONVERT_TO_KB_SIZE (m_info.stat.cur_stat));
+      fprintf (stdout, "%-19s\t: %17lu\n", peak_size_str.c_str (), MMON_CONVERT_TO_KB_SIZE (m_info.stat.peak_stat));
+      fprintf (stdout, "%-19s\t: %17u\n\n", resize_expand_str.c_str (), m_info.stat.expand_resize_count);
 
       for (const auto &comp_info : m_info.comp_info)
 	{
 	  fprintf (stdout, "%s\n", comp_info.name);
-	  fprintf (stdout, "\t%-17s\t: %17lu\n", init_size_str.c_str (), MMON_CONVERT_TO_KB_SIZE (comp_info.stat.init_stat));
-	  fprintf (stdout, "\t%-17s\t: %17lu\n", cur_size_str.c_str (), MMON_CONVERT_TO_KB_SIZE (comp_info.stat.cur_stat));
+	  fprintf (stdout, "\t%-23s\t: %17lu\n", init_size_str.c_str (), MMON_CONVERT_TO_KB_SIZE (comp_info.stat.init_stat));
+	  fprintf (stdout, "\t%-23s\t: %17lu\n", cur_size_str.c_str (), MMON_CONVERT_TO_KB_SIZE (comp_info.stat.cur_stat));
 
 	  for (const auto &subcomp_info : comp_info.subcomp_info)
 	    {
 	      auto out_name = std::string {subcomp_info.name};
 	      out_name += "(KB)";
-	      fprintf (stdout, "\t  %-15s\t: %17lu\n", out_name.c_str (), MMON_CONVERT_TO_KB_SIZE (subcomp_info.cur_stat));
+	      fprintf (stdout, "\t  %-20s\t: %17lu\n", out_name.c_str (), MMON_CONVERT_TO_KB_SIZE (subcomp_info.cur_stat));
 	    }
-	  fprintf (stdout, "\t%-17s\t: %17lu\n", peak_size_str.c_str (), MMON_CONVERT_TO_KB_SIZE (comp_info.stat.peak_stat));
-	  fprintf (stdout, "\t%-17s\t: %17u\n\n", resize_expand_str.c_str (), comp_info.stat.expand_resize_count);
+	  fprintf (stdout, "\t%-23s\t: %17lu\n", peak_size_str.c_str (), MMON_CONVERT_TO_KB_SIZE (comp_info.stat.peak_stat));
+	  fprintf (stdout, "\t%-23s\t: %17u\n\n", resize_expand_str.c_str (), comp_info.stat.expand_resize_count);
 	}
       fprintf (stdout, "\n-----------------------------------------------------\n\n");
     }
@@ -147,11 +147,8 @@ mmon_print_module_info_summary (uint64_t server_mem_usage, std::vector<MMON_MODU
 void
 mmon_print_tran_info (MMON_TRAN_INFO &tran_info)
 {
-  const auto tran_id_str = std::string {"Transaction ID"};
-  const auto mem_usage_str = std::string {"Memory Usage"};
-
   fprintf (stdout, "Transaction Memory Usage Info (KB)\n");
-  fprintf (stdout, "\t%14s | %12s\n", tran_id_str.c_str (), mem_usage_str.c_str ());
+  fprintf (stdout, "\t%14s | %12s\n", "Transaction ID", "Memory Usage");
 
   for (const auto &t_stat : tran_info.tran_stat)
     {

--- a/src/base/memory_monitor_cl.hpp
+++ b/src/base/memory_monitor_cl.hpp
@@ -30,13 +30,6 @@
 
 #define MMON_CONVERT_TO_KB_SIZE(size) ((size) / 1024)
 
-constexpr char module_names[MMON_MODULE_LAST][DB_MAX_IDENTIFIER_LENGTH] =
-{
-  /* TODO: this dummy modules will be changed when heap module is registered */
-  "dummy",
-  "long dummy"
-};
-
 void mmon_print_server_info (MMON_SERVER_INFO &server_info);
 void mmon_print_module_info (std::vector<MMON_MODULE_INFO> &module_info);
 void mmon_print_module_info_summary (uint64_t server_mem_usage, std::vector<MMON_MODULE_INFO> &module_info);

--- a/src/base/memory_monitor_cl.hpp
+++ b/src/base/memory_monitor_cl.hpp
@@ -28,6 +28,17 @@
 
 #include "memory_monitor_common.h"
 
-// XXX: will be added print function
+#define CONVERT_TO_KB_SIZE(size) ((size) / 1024)
 
+constexpr char module_names[MMON_MODULE_LAST][DB_MAX_IDENTIFIER_LENGTH] =
+{
+  /* XXX: this dummy modules will be changed when heap module is registered */
+  "dummy",
+  "long dummy"
+};
+
+void mmon_print_server_info (MMON_SERVER_INFO &server_info);
+void mmon_print_module_info (std::vector<MMON_MODULE_INFO> &module_info);
+void mmon_print_module_info_summary (uint64_t server_mem_usage, std::vector<MMON_MODULE_INFO> &module_info);
+void mmon_print_tran_info (MMON_TRAN_INFO &tran_info);
 #endif // _MEMORY_MONITOR_CL_HPP_

--- a/src/base/memory_monitor_cl.hpp
+++ b/src/base/memory_monitor_cl.hpp
@@ -28,11 +28,11 @@
 
 #include "memory_monitor_common.h"
 
-#define CONVERT_TO_KB_SIZE(size) ((size) / 1024)
+#define MMON_CONVERT_TO_KB_SIZE(size) ((size) / 1024)
 
 constexpr char module_names[MMON_MODULE_LAST][DB_MAX_IDENTIFIER_LENGTH] =
 {
-  /* XXX: this dummy modules will be changed when heap module is registered */
+  /* TODO: this dummy modules will be changed when heap module is registered */
   "dummy",
   "long dummy"
 };

--- a/src/base/memory_monitor_common.h
+++ b/src/base/memory_monitor_common.h
@@ -27,6 +27,12 @@
 #include <cstdint>
 #include <vector>
 
+constexpr char module_names[MMON_MODULE_LAST][DB_MAX_IDENTIFIER_LENGTH] = {
+  /* TODO: this dummy modules will be changed when heap module is registered */
+  "dummy",
+  "long dummy"
+};
+
 typedef enum mmon_module_id
 {
   /* TODO: this dummy modules will be changed when heap module is registered */

--- a/src/base/memory_monitor_common.h
+++ b/src/base/memory_monitor_common.h
@@ -27,12 +27,6 @@
 #include <cstdint>
 #include <vector>
 
-constexpr char module_names[MMON_MODULE_LAST][DB_MAX_IDENTIFIER_LENGTH] = {
-  /* TODO: this dummy modules will be changed when heap module is registered */
-  "dummy",
-  "long dummy"
-};
-
 typedef enum mmon_module_id
 {
   /* TODO: this dummy modules will be changed when heap module is registered */
@@ -41,6 +35,14 @@ typedef enum mmon_module_id
   MMON_MODULE_LONG_DUMMY,
   MMON_MODULE_LAST
 } MMON_MODULE_ID;
+
+// The order of module name MUST be the same with MMON_MODULE_ID
+// starting from MMON_MODULE_ALL + 1
+constexpr char module_names[MMON_MODULE_LAST][DB_MAX_IDENTIFIER_LENGTH] = {
+  /* TODO: this dummy modules will be changed when heap module is registered */
+  "dummy",
+  "long dummy"
+};
 
 typedef struct mmon_output_mem_stat
 {

--- a/src/base/memory_monitor_common.h
+++ b/src/base/memory_monitor_common.h
@@ -29,7 +29,10 @@
 
 typedef enum mmon_module_id
 {
+  /* XXX: this dummy modules will be changed when heap module is registered */
   MMON_MODULE_ALL = -1,
+  MMON_MODULE_DUMMY,
+  MMON_MODULE_LONG_DUMMY,
   MMON_MODULE_LAST
 } MMON_MODULE_ID;
 

--- a/src/base/memory_monitor_common.h
+++ b/src/base/memory_monitor_common.h
@@ -29,7 +29,7 @@
 
 typedef enum mmon_module_id
 {
-  /* XXX: this dummy modules will be changed when heap module is registered */
+  /* TODO: this dummy modules will be changed when heap module is registered */
   MMON_MODULE_ALL = -1,
   MMON_MODULE_DUMMY,
   MMON_MODULE_LONG_DUMMY,

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -69,7 +69,9 @@ namespace cubperf
   {
     public:
       mmon_subcomponent (const char *subcomp_name)
-	: m_subcomp_name {subcomp_name}, m_cur_stat {0} {}
+	: m_subcomp_name {subcomp_name}
+	, m_cur_stat {0}
+      {}
       mmon_subcomponent (const mmon_subcomponent &) = delete;
       mmon_subcomponent (mmon_subcomponent &&) = delete;
 
@@ -91,7 +93,9 @@ namespace cubperf
   {
     public:
       mmon_component (const char *comp_name)
-	: m_comp_name {comp_name}, m_stat {0, 0, 0, 0} {}
+	: m_comp_name {comp_name}
+	, m_stat {0, 0, 0, 0}
+      {}
       mmon_component (const mmon_component &) = delete;
       mmon_component (mmon_component &&) = delete;
 
@@ -320,7 +324,8 @@ namespace cubperf
   }
 
   mmon_module::mmon_module (const char *module_name, const MMON_STAT_INFO *info)
-    : m_module_name {module_name}, m_stat {0, 0, 0, 0}
+    : m_module_name {module_name}
+    , m_stat {0, 0, 0, 0}
   {
     /* register component and subcomponent information
      * add component and subcomponent */
@@ -533,11 +538,15 @@ namespace cubperf
   }
 
   memory_monitor::memory_monitor (const char *server_name)
-    : m_server_name {server_name}, m_total_mem_usage {0}, m_aggregater {this}
+    : m_server_name {server_name}
+    , m_total_mem_usage {0}
+    , m_aggregater {this}
   {
     /* TODO: this dummy modules will be changed when heap module is registered */
-    m_module[0] = std::make_unique<mmon_module> ("dummy", dummy_stat_info);
-    m_module[1] = std::make_unique<mmon_module> ("long dummy", long_dummy_stat_info);
+    m_module[MMON_MODULE_DUMMY] = std::make_unique<mmon_module>
+				  (module_names[MMON_MODULE_DUMMY], dummy_stat_info);
+    m_module[MMON_MODULE_LONG_DUMMY] = std::make_unique<mmon_module>
+				       (module_names[MMON_MODULE_LONG_DUMMY], long_dummy_stat_info);
   }
 
   void memory_monitor::add_stat (MMON_STAT_ID stat_id, int64_t size)

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -50,7 +50,7 @@ namespace cubperf
     std::atomic<uint32_t> expand_resize_count;
   } MMON_MEM_STAT;
 
-  /* XXX: this dummy modules will be changed when heap module is registered */
+  /* TODO: this dummy modules will be changed when heap module is registered */
   MMON_STAT_INFO dummy_stat_info[] =
   {
     {MMON_STAT_DUMMY_1, NULL, NULL},
@@ -69,7 +69,7 @@ namespace cubperf
   {
     public:
       mmon_subcomponent (const char *subcomp_name)
-	: m_subcomp_name (subcomp_name), m_cur_stat (0) {}
+	: m_subcomp_name {subcomp_name}, m_cur_stat {0} {}
       mmon_subcomponent (const mmon_subcomponent &) = delete;
       mmon_subcomponent (mmon_subcomponent &&) = delete;
 
@@ -91,7 +91,7 @@ namespace cubperf
   {
     public:
       mmon_component (const char *comp_name)
-	: m_comp_name (comp_name), m_stat {0, 0, 0, 0} {}
+	: m_comp_name {comp_name}, m_stat {0, 0, 0, 0} {}
       mmon_component (const mmon_component &) = delete;
       mmon_component (mmon_component &&) = delete;
 
@@ -320,7 +320,7 @@ namespace cubperf
   }
 
   mmon_module::mmon_module (const char *module_name, const MMON_STAT_INFO *info)
-    : m_module_name (module_name), m_stat {0, 0, 0, 0}
+    : m_module_name {module_name}, m_stat {0, 0, 0, 0}
   {
     /* register component and subcomponent information
      * add component and subcomponent */
@@ -533,9 +533,9 @@ namespace cubperf
   }
 
   memory_monitor::memory_monitor (const char *server_name)
-    : m_server_name (server_name), m_total_mem_usage (0), m_aggregater (this)
+    : m_server_name {server_name}, m_total_mem_usage {0}, m_aggregater {this}
   {
-    /* XXX: this dummy modules will be changed when heap module is registered */
+    /* TODO: this dummy modules will be changed when heap module is registered */
     m_module[0] = std::make_unique<mmon_module> ("dummy", dummy_stat_info);
     m_module[1] = std::make_unique<mmon_module> ("long dummy", long_dummy_stat_info);
   }

--- a/src/base/memory_monitor_sr.hpp
+++ b/src/base/memory_monitor_sr.hpp
@@ -38,7 +38,7 @@
 
 typedef enum
 {
-  /* XXX: this dummy modules will be changed when heap module is registered */
+  /* TODO: this dummy modules will be changed when heap module is registered */
   MMON_STAT_DUMMY_1 = MMON_MAKE_STAT_ID (MMON_MODULE_DUMMY),
   MMON_STAT_DUMMY_2,
   MMON_STAT_LONG_DUMMY_1 = MMON_MAKE_STAT_ID (MMON_MODULE_LONG_DUMMY),

--- a/src/base/memory_monitor_sr.hpp
+++ b/src/base/memory_monitor_sr.hpp
@@ -38,6 +38,11 @@
 
 typedef enum
 {
+  /* XXX: this dummy modules will be changed when heap module is registered */
+  MMON_STAT_DUMMY_1 = MMON_MAKE_STAT_ID (MMON_MODULE_DUMMY),
+  MMON_STAT_DUMMY_2,
+  MMON_STAT_LONG_DUMMY_1 = MMON_MAKE_STAT_ID (MMON_MODULE_LONG_DUMMY),
+  MMON_STAT_LONG_DUMMY_2,
   MMON_STAT_LAST = MMON_MAKE_STAT_ID (MMON_MODULE_LAST)
 } MMON_STAT_ID;
 

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -7313,10 +7313,11 @@ smmon_get_server_info (THREAD_ENTRY * thread_p, unsigned int rid, char *request,
   else
     {
       buffer = PTR_ALIGN (buffer_a, MAX_ALIGNMENT);
-      size -= buffer - buffer_a;
 
       ptr = or_pack_string (buffer, server_info.name);
       ptr = or_pack_int64 (ptr, server_info.total_mem_usage);
+
+      assert (size == (ptr - buffer));
     }
 
   if (error != NO_ERROR)
@@ -7419,7 +7420,6 @@ smmon_get_module_info (THREAD_ENTRY * thread_p, unsigned int rid, char *request,
        *    - packing information with sequence of
        *      module info -> component info w/ subcomponent info */
       buffer = PTR_ALIGN (buffer_a, MAX_ALIGNMENT);
-      size -= buffer - buffer_a;
 
       ptr = buffer;
 
@@ -7452,6 +7452,7 @@ smmon_get_module_info (THREAD_ENTRY * thread_p, unsigned int rid, char *request,
             }
         }
       // *INDENT-ON*
+      assert (size == (ptr - buffer));
     }
 
   if (error != NO_ERROR)
@@ -7527,7 +7528,6 @@ smmon_get_module_info_summary (THREAD_ENTRY * thread_p, unsigned int rid, char *
       /* 3) packing information
        *    - packing information with sequence of module info */
       buffer = PTR_ALIGN (buffer_a, MAX_ALIGNMENT);
-      size -= buffer - buffer_a;
 
       ptr = buffer;
 
@@ -7538,6 +7538,7 @@ smmon_get_module_info_summary (THREAD_ENTRY * thread_p, unsigned int rid, char *
           ptr = or_pack_int64 (ptr, m_info.stat.cur_stat);
         }
       // *INDENT-ON*
+      assert (size == (ptr - buffer));
     }
 
   if (error != NO_ERROR)
@@ -7613,7 +7614,6 @@ smmon_get_tran_info (THREAD_ENTRY * thread_p, unsigned int rid, char *request, i
        *    - packing information with sequence of
        *      server info -> transaction info */
       buffer = PTR_ALIGN (buffer_a, MAX_ALIGNMENT);
-      size -= buffer - buffer_a;
 
       ptr = or_pack_int (buffer, info.num_tran);
 
@@ -7624,6 +7624,7 @@ smmon_get_tran_info (THREAD_ENTRY * thread_p, unsigned int rid, char *request, i
           ptr = or_pack_int64 (ptr, t_stat.cur_stat);
         }
       // *INDENT-ON*
+      assert (size == (ptr - buffer));
     }
 
   if (error != NO_ERROR)

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -7292,15 +7292,10 @@ smmon_get_server_info (THREAD_ENTRY * thread_p, unsigned int rid, char *request,
   mmon_aggregate_server_info (server_info);
 
   string_len = or_packed_string_length (server_info.name, NULL);
-  if (string_len % MAX_ALIGNMENT)
-    {
-      size += string_len + OR_INT_SIZE;
-    }
-  else
-    {
-      size += string_len;
-    }
-  //size += or_packed_string_length (server_info.name, NULL);
+  /* (CBRD-24943) Alignment size check is needed because or_pack_int64() use different alignment unit(8 byte)
+   * to other packing function(4 byte). And it occurs to use more 4 bytes for alignment. */
+  size = size % MAX_ALIGNMENT ? size + INT_ALIGNMENT : size;
+
   // Size of total_mem_usage
   size += OR_INT64_SIZE;
 

--- a/src/executables/util_admin.c
+++ b/src/executables/util_admin.c
@@ -895,6 +895,8 @@ static GETOPT_LONG ua_Flashback_Option[] = {
 
 static UTIL_ARG_MAP ua_Memmon_Option_Map[] = {
   {OPTION_STRING_TABLE, {0}, {0}},
+  /* Getting integer option value can't differentiate about user input value or default value.
+   * It can make some error use case. So set it to default value with magic number to pass this case. */
   {MEMMON_MODULE_S, {ARG_INTEGER}, {(void *) -2097573308}},
   {MEMMON_TRANSACTION_S, {ARG_BOOLEAN}, {0}},
   {MEMMON_TRAN_COUNT_S, {ARG_STRING}, {0}},

--- a/src/executables/util_admin.c
+++ b/src/executables/util_admin.c
@@ -895,7 +895,7 @@ static GETOPT_LONG ua_Flashback_Option[] = {
 
 static UTIL_ARG_MAP ua_Memmon_Option_Map[] = {
   {OPTION_STRING_TABLE, {0}, {0}},
-  {MEMMON_MODULE_S, {ARG_INTEGER}, {(void *) -2}},
+  {MEMMON_MODULE_S, {ARG_INTEGER}, {(void *) -2097573308}},
   {MEMMON_TRANSACTION_S, {ARG_BOOLEAN}, {0}},
   {MEMMON_TRAN_COUNT_S, {ARG_STRING}, {0}},
   {MEMMON_SHOW_ALL_S, {ARG_BOOLEAN}, {0}},

--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -4548,6 +4548,8 @@ memmon (UTIL_FUNCTION_ARG * arg)
 {
 #if defined(CS_MODE)
   constexpr int DEFAULT_OPTION_PRINT_CNT = 5;
+  /* Getting integer option value can't differentiate about user input value or default value.
+   * It can make some error use case. So set it to default value with magic number to pass this case. */
   constexpr int MODULE_INDEX_MAGIC_NUMBER = -2097573308;	/* INT_MIN + 49910340 */
   UTIL_ARG_MAP *arg_map = arg->arg_map;
   char er_msg_file[PATH_MAX];

--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -4671,36 +4671,38 @@ memmon (UTIL_FUNCTION_ARG * arg)
 
       mmon_print_module_info (module_info);
     }
-
-  if (print_show_all)
+  else
     {
-      module_count = MMON_MODULE_LAST;
-      error_code = mmon_get_module_info_summary (module_count, module_info);
-      if (error_code != NO_ERROR)
+      if (print_show_all)
 	{
-	  goto error_exit;
+	  module_count = MMON_MODULE_LAST;
+	  error_code = mmon_get_module_info_summary (module_count, module_info);
+	  if (error_code != NO_ERROR)
+	    {
+	      goto error_exit;
+	    }
+
+	  mmon_print_module_info_summary (server_info.total_mem_usage, module_info);
+
+	  print_transaction = true;
 	}
-
-      mmon_print_module_info_summary (server_info.total_mem_usage, module_info);
-
-      print_transaction = true;
-    }
-  else if (print_default)
-    {
-      /* default case */
-      // *INDENT-OFF*
-      module_count = std::min ((int) MMON_MODULE_LAST, DEFAULT_OPTION_PRINT_CNT);
-      // *INDENT-ON*
-      error_code = mmon_get_module_info_summary (module_count, module_info);
-      if (error_code != NO_ERROR)
+      else if (print_default)
 	{
-	  goto error_exit;
+	  /* default case */
+          // *INDENT-OFF*
+          module_count = std::min ((int) MMON_MODULE_LAST, DEFAULT_OPTION_PRINT_CNT);
+          // *INDENT-ON*
+	  error_code = mmon_get_module_info_summary (module_count, module_info);
+	  if (error_code != NO_ERROR)
+	    {
+	      goto error_exit;
+	    }
+
+	  mmon_print_module_info_summary (server_info.total_mem_usage, module_info);
+
+	  print_transaction = true;
+	  tran_count = DEFAULT_OPTION_PRINT_CNT;
 	}
-
-      mmon_print_module_info_summary (server_info.total_mem_usage, module_info);
-
-      print_transaction = true;
-      tran_count = DEFAULT_OPTION_PRINT_CNT;
     }
 
   if (print_transaction)

--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -4548,6 +4548,7 @@ memmon (UTIL_FUNCTION_ARG * arg)
 {
 #if defined(CS_MODE)
   constexpr int DEFAULT_OPTION_PRINT_CNT = 5;
+  constexpr int MODULE_INDEX_MAGIC_NUMBER = -2097573308;	/* INT_MIN + 49910340 */
   UTIL_ARG_MAP *arg_map = arg->arg_map;
   char er_msg_file[PATH_MAX];
   const char *database_name;
@@ -4587,10 +4588,13 @@ memmon (UTIL_FUNCTION_ARG * arg)
     }
   else
     {
-      PRINT_AND_LOG_ERR_MSG (msgcat_message
-			     (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_MEMMON, MEMMON_MSG_NO_MATCHING_MODULE),
-			     module_index);
-      goto error_exit;
+      if (module_index != MODULE_INDEX_MAGIC_NUMBER)
+	{
+	  PRINT_AND_LOG_ERR_MSG (msgcat_message
+				 (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_MEMMON, MEMMON_MSG_NO_MATCHING_MODULE),
+				 module_index);
+	  goto error_exit;
+	}
     }
 
   if (!print_transaction && !print_module && !print_show_all)
@@ -4653,54 +4657,48 @@ memmon (UTIL_FUNCTION_ARG * arg)
       goto error_exit;
     }
 
-  // TODO: mmon_print_server_info (server_info);
+  mmon_print_server_info (server_info);
 
   if (print_module)
     {
-      /* XXX: This condition can be removed when a module is registered */
-      if (MMON_MODULE_LAST != 0)
+      error_code = mmon_get_module_info (module_index, module_info);
+      if (error_code != NO_ERROR)
 	{
-	  error_code = mmon_get_module_info (module_index, module_info);
-	  if (error_code != NO_ERROR)
-	    {
-	      goto error_exit;
-	    }
-
-	  // TODO: mmon_print_module_info (module_info);
+	  goto error_exit;
 	}
+
+      mmon_print_module_info (module_info);
     }
-  else
-    {
-      if (print_show_all)
-	{
-	  module_count = MMON_MODULE_LAST;
-	}
-      else if (print_default)
-	{
-	  /* default case */
-          // *INDENT-OFF*
-          module_count = std::min ((int) MMON_MODULE_LAST, DEFAULT_OPTION_PRINT_CNT);
-          // *INDENT-ON*
-	  tran_count = DEFAULT_OPTION_PRINT_CNT;
-	}
-      else
-	{
-	  /* code protection. unreachable. */
-	  assert (false);
-	}
-      /* XXX: This condition can be removed when a module is registered */
-      if (MMON_MODULE_LAST != 0)
-	{
-	  error_code = mmon_get_module_info_summary (module_count, module_info);
-	  if (error_code != NO_ERROR)
-	    {
-	      goto error_exit;
-	    }
 
-	  // TODO: mmon_print_module_info_summary (module_info);
+  if (print_show_all)
+    {
+      module_count = MMON_MODULE_LAST;
+      error_code = mmon_get_module_info_summary (module_count, module_info);
+      if (error_code != NO_ERROR)
+	{
+	  goto error_exit;
 	}
+
+      mmon_print_module_info_summary (server_info.total_mem_usage, module_info);
 
       print_transaction = true;
+    }
+  else if (print_default)
+    {
+      /* default case */
+      // *INDENT-OFF*
+      module_count = std::min ((int) MMON_MODULE_LAST, DEFAULT_OPTION_PRINT_CNT);
+      // *INDENT-ON*
+      error_code = mmon_get_module_info_summary (module_count, module_info);
+      if (error_code != NO_ERROR)
+	{
+	  goto error_exit;
+	}
+
+      mmon_print_module_info_summary (server_info.total_mem_usage, module_info);
+
+      print_transaction = true;
+      tran_count = DEFAULT_OPTION_PRINT_CNT;
     }
 
   if (print_transaction)
@@ -4711,7 +4709,7 @@ memmon (UTIL_FUNCTION_ARG * arg)
 	  goto error_exit;
 	}
 
-      // TODO: mmon_print_tran_info (tran_info);
+      mmon_print_tran_info (tran_info);
     }
 
   // XXX: for test, it will removed at main implementation


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24889

Implementation of print functions of memmon utility:
 - mmon_print_server/module/tran_info() and mmon_print_module_info_summary()

Additional works in this issue in code:
 - Register dummy modules in memory_monitoring_manager class for test
 - Add magic number in utility for default value of module_index
 - Decouple print_all and print_default from print_module because it can make malfunction
 - Add alignment workaround code for packing/unpacking alignment issue