### PR TITLE
[CBRD-24942] System parameter oracle_compat_number_behavior not reflected in CAS

### DIFF
--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -11272,7 +11272,8 @@ pt_common_type_op (PT_TYPE_ENUM t1, PT_OP_TYPE op, PT_TYPE_ENUM t2)
 {
   PT_TYPE_ENUM result_type;
 
-  static bool oracle_compat_number = prm_get_bool_value (PRM_ID_ORACLE_COMPAT_NUMBER_BEHAVIOR);
+  /* it should not be static because the parameter could be changed without broker restart */
+  bool oracle_compat_number = prm_get_bool_value (PRM_ID_ORACLE_COMPAT_NUMBER_BEHAVIOR);
 
   if (pt_is_op_hv_late_bind (op) && (t1 == PT_TYPE_MAYBE || t2 == PT_TYPE_MAYBE))
     {

--- a/src/query/numeric_opfunc.c
+++ b/src/query/numeric_opfunc.c
@@ -3852,7 +3852,8 @@ numeric_db_value_print (const DB_VALUE * val, char *buf)
   bool found_first_non_zero = false;
   int scale = db_value_scale (val);
 
-  static bool oracle_compat_number = prm_get_bool_value (PRM_ID_ORACLE_COMPAT_NUMBER_BEHAVIOR);
+  /* it should not be static because the parameter could be changed without broker restart */
+  bool oracle_compat_number = prm_get_bool_value (PRM_ID_ORACLE_COMPAT_NUMBER_BEHAVIOR);
 
   assert (val != NULL && buf != NULL);
 

--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -5763,7 +5763,8 @@ qdata_divide_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, DB_VALUE * result_
   TP_DOMAIN *cast_dom2 = NULL;
   TP_DOMAIN_STATUS dom_status;
 
-  static bool oracle_compat_number = prm_get_bool_value (PRM_ID_ORACLE_COMPAT_NUMBER_BEHAVIOR);
+  /* it should not be static because the parameter could be changed without broker restart */
+  bool oracle_compat_number = prm_get_bool_value (PRM_ID_ORACLE_COMPAT_NUMBER_BEHAVIOR);
 
   if ((domain_p != NULL && TP_DOMAIN_TYPE (domain_p) == DB_TYPE_NULL) || DB_IS_NULL (dbval1_p) || DB_IS_NULL (dbval2_p))
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24942

In numeric_db_value_print of CAS oracle_compat_number variable is declared as "static bool". It's because of performance to get a system parameter rapidly. This static variable mislead the parameter setting "oracle_compat_number_behavior". Since the system parameter "oracle_compat_number_behavior" is changed and server restarted, the variable oracle_compat_number is not reflect it. Consequently, the static variable oracle_compat_number should not be static variable.
