### PR TITLE
[LETS-782] Create connection handlers to catch up between PSes

### DIFF
--- a/src/communication/request_sync_client_server.hpp
+++ b/src/communication/request_sync_client_server.hpp
@@ -157,7 +157,6 @@ namespace cubcomm
   , m_incoming_response_msgid { a_incoming_response_msgid }
   , m_response_broker { response_partition_count, NO_ERRORS, ERROR_ON_WRITE }
   {
-    assert (a_incoming_request_handlers.size () > 0);
     for (const auto &pair: a_incoming_request_handlers)
       {
 	assert (static_cast<bool> (pair.second));

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -376,13 +376,9 @@ page_server::follower_connection_handler::follower_connection_handler (cubcomm::
   m_conn.reset (new follower_server_conn_t (std::move (chn),
   {
     {
-      follower_to_followee_request::SEND_DISCONNECT,
-      std::bind (&page_server::follower_connection_handler::receive_disconnect_request, std::ref (*this), std::placeholders::_1)
+      follower_to_followee_request::SEND_DUMMY,
+      std::bind (&page_server::follower_connection_handler::receive_dummy_request, std::ref (*this), std::placeholders::_1)
     },
-    {
-      follower_to_followee_request::SEND_LOG_PAGES_FETCH,
-      std::bind (&page_server::follower_connection_handler::receive_log_pages_fetch, std::ref (*this), std::placeholders::_1)
-    }
   },
   followee_to_follower_request::RESPOND,
   follower_to_followee_request::RESPOND,
@@ -392,24 +388,12 @@ page_server::follower_connection_handler::follower_connection_handler (cubcomm::
   m_conn->start ();
 }
 
-void page_server::follower_connection_handler::receive_disconnect_request (follower_server_conn_t::sequenced_payload
+void page_server::follower_connection_handler::receive_dummy_request (follower_server_conn_t::sequenced_payload
     &&a_sp)
 {
   // TODO release the resouce of this connection_handler
-  er_log_debug (ARG_FILE_LINE, "A follower has requested to disconnect.");
+  er_log_debug (ARG_FILE_LINE, "A follower has requested a duumy request");
 }
-
-void page_server::follower_connection_handler::receive_log_pages_fetch (follower_server_conn_t::sequenced_payload
-    &&a_sp)
-{
-  follower_server_conn_t::sequenced_payload payload;
-  // TODO serve requeste log pages
-  er_log_debug (ARG_FILE_LINE, "A follower have requested some log pages.");
-
-  payload.push_payload ("Dummy reseponse");
-  m_conn->respond (std::move (payload));
-}
-
 
 page_server::followee_connection_handler::followee_connection_handler (cubcomm::channel &&chn, page_server &ps)
   : m_ps { ps }

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -391,7 +391,6 @@ page_server::follower_connection_handler::follower_connection_handler (cubcomm::
 void page_server::follower_connection_handler::receive_dummy_request (follower_server_conn_t::sequenced_payload
     &&a_sp)
 {
-  // TODO release the resouce of this connection_handler
   er_log_debug (ARG_FILE_LINE, "A follower has requested a duumy request");
 }
 
@@ -615,7 +614,6 @@ page_server::connect_to_followee_page_server (std::string &&hostname, int32_t po
   er_log_debug (ARG_FILE_LINE,
 		"This page server successfully connected to the followee page server to catch up. Channel id: %s.\n",
 		srv_chn.get_channel_id ().c_str ());
-
 
   // TODO remove it. Just a test to make sure the connection works.
   m_followee_conn->push_request (follower_to_followee_request::SEND_DUMMY, std::string (""));

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -616,6 +616,10 @@ page_server::connect_to_followee_page_server (std::string &&hostname, int32_t po
 		"This page server successfully connected to the followee page server to catch up. Channel id: %s.\n",
 		srv_chn.get_channel_id ().c_str ());
 
+
+  // TODO remove it. Just a test to make sure the connection works.
+  m_followee_conn->push_request (follower_to_followee_request::SEND_DUMMY, std::string (""));
+
   return NO_ERROR;
 }
 

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -176,6 +176,48 @@ class page_server
     using connection_handler_uptr_t = std::unique_ptr<connection_handler>;
 
     /*
+     * TODO
+     * 1. catchup diagram and explaination.
+     * 2. take it out of page_server? then I think we should take all connection_handlers out of servers and put them together.
+     *
+     */
+    class follower_connection_handler
+    {
+      public:
+	using followee_server_conn_t =
+		cubcomm::request_sync_client_server<followee_to_follower_request, follower_to_followee_request, std::string>;
+
+	follower_connection_handler () = delete;
+	follower_connection_handler (cubcomm::channel &chn);
+
+	follower_connection_handler (const connection_handler &) = delete;
+	follower_connection_handler (connection_handler &&) = delete;
+
+	~follower_connection_handler ();
+
+	follower_connection_handler &operator= (const connection_handler &) = delete;
+	follower_connection_handler &operator= (connection_handler &&) = delete;
+    };
+
+    class followee_connection_handler
+    {
+      public:
+	using follower_server_conn_t =
+		cubcomm::request_sync_client_server<follower_to_followee_request, followee_to_follower_request, std::string>;
+
+	followee_connection_handler () = delete;
+	followee_connection_handler (cubcomm::channel &chn);
+
+	followee_connection_handler (const connection_handler &) = delete;
+	followee_connection_handler (connection_handler &&) = delete;
+
+	~followee_connection_handler ();
+
+	followee_connection_handler &operator= (const connection_handler &) = delete;
+	followee_connection_handler &operator= (connection_handler &&) = delete;
+    };
+
+    /*
      * helper class to track the active oldest mvccids of each Page Transaction Server.
      * This provides the globally oldest active mvcc id to the vacuum on ATS.
      * The vacuum has to take mvcc status of all PTSes into considerations,

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -202,8 +202,7 @@ class page_server
 	follower_connection_handler &operator= (connection_handler &&) = delete;
 
       private:
-	void receive_disconnect_request (follower_server_conn_t::sequenced_payload &&a_sp);
-	void receive_log_pages_fetch (follower_server_conn_t::sequenced_payload &&a_sp);
+	void receive_dummy_request (follower_server_conn_t::sequenced_payload &&a_sp);  // TODO remove it
 
 	page_server &m_ps;
 	std::unique_ptr<follower_server_conn_t> m_conn;

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -181,10 +181,7 @@ class page_server
     };
 
     /*
-     * TODO
-     * 1. catchup diagram and explaination.
-     * 2. take it out of page_server? then I think we should take all connection_handlers out of servers and put them together.
-     *
+     *  TODO add some explanation and diagrams for this.
      */
     class follower_connection_handler
     {

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -126,7 +126,7 @@ class page_server
 	connection_handler &operator= (const connection_handler &) = delete;
 	connection_handler &operator= (connection_handler &&) = delete;
 
-	void push_request (page_to_tran_request id, std::string msg);
+	void push_request (page_to_tran_request id, std::string &&msg);
 	const std::string &get_connection_id () const;
 
 	void remove_prior_sender_sink ();
@@ -202,6 +202,9 @@ class page_server
 	follower_connection_handler &operator= (connection_handler &&) = delete;
 
       private:
+	void receive_disconnect_request (follower_server_conn_t::sequenced_payload &&a_sp);
+	void receive_log_pages_fetch (follower_server_conn_t::sequenced_payload &&a_sp);
+
 	page_server &m_ps;
 	std::unique_ptr<follower_server_conn_t> m_conn;
     };
@@ -221,10 +224,10 @@ class page_server
 	followee_connection_handler &operator= (const connection_handler &) = delete;
 	followee_connection_handler &operator= (connection_handler &&) = delete;
 
-	void push_request (page_to_tran_request id, std::string msg);
-	int send_receive (tran_to_page_request reqid, std::string &&payload_in, std::string &payload_out);
-
       private:
+	void push_request (follower_to_followee_request reqid, std::string &&msg);
+	int send_receive (follower_to_followee_request reqid, std::string &&payload_in, std::string &payload_out);
+
 	page_server &m_ps;
 	std::unique_ptr<followee_server_conn_t> m_conn;
     };

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -110,7 +110,7 @@ class page_server
 		cubcomm::request_sync_client_server<page_to_tran_request, tran_to_page_request, std::string>;
 
 	connection_handler () = delete;
-	connection_handler (cubcomm::channel &chn, transaction_server_type server_type, page_server &ps);
+	connection_handler (cubcomm::channel &&chn, transaction_server_type server_type, page_server &ps);
 
 	connection_handler (const connection_handler &) = delete;
 	connection_handler (connection_handler &&) = delete;
@@ -188,15 +188,19 @@ class page_server
 		cubcomm::request_sync_client_server<followee_to_follower_request, follower_to_followee_request, std::string>;
 
 	follower_connection_handler () = delete;
-	follower_connection_handler (cubcomm::channel &chn);
+	follower_connection_handler (cubcomm::channel &&chn, page_server &ps);
 
 	follower_connection_handler (const connection_handler &) = delete;
 	follower_connection_handler (connection_handler &&) = delete;
 
-	~follower_connection_handler ();
-
 	follower_connection_handler &operator= (const connection_handler &) = delete;
 	follower_connection_handler &operator= (connection_handler &&) = delete;
+
+	void push_request (page_to_tran_request id, std::string msg);
+	int send_receive (tran_to_page_request reqid, std::string &&payload_in, std::string &payload_out);
+
+      private:
+	page_server &m_ps;
     };
 
     class followee_connection_handler
@@ -206,15 +210,16 @@ class page_server
 		cubcomm::request_sync_client_server<follower_to_followee_request, followee_to_follower_request, std::string>;
 
 	followee_connection_handler () = delete;
-	followee_connection_handler (cubcomm::channel &chn);
+	followee_connection_handler (cubcomm::channel &&chn, page_server &ps);
 
 	followee_connection_handler (const connection_handler &) = delete;
 	followee_connection_handler (connection_handler &&) = delete;
 
-	~followee_connection_handler ();
-
 	followee_connection_handler &operator= (const connection_handler &) = delete;
 	followee_connection_handler &operator= (connection_handler &&) = delete;
+
+      private:
+	page_server &m_ps;
     };
 
     /*

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -223,10 +223,10 @@ class page_server
 	followee_connection_handler &operator= (const connection_handler &) = delete;
 	followee_connection_handler &operator= (connection_handler &&) = delete;
 
-      private:
 	void push_request (follower_to_followee_request reqid, std::string &&msg);
 	int send_receive (follower_to_followee_request reqid, std::string &&payload_in, std::string &payload_out);
 
+      private:
 	page_server &m_ps;
 	std::unique_ptr<followee_server_conn_t> m_conn;
     };

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -189,7 +189,7 @@ class page_server
     class follower_connection_handler
     {
       public:
-	using followee_server_conn_t =
+	using follower_server_conn_t =
 		cubcomm::request_sync_client_server<followee_to_follower_request, follower_to_followee_request, std::string>;
 
 	follower_connection_handler () = delete;
@@ -201,17 +201,15 @@ class page_server
 	follower_connection_handler &operator= (const connection_handler &) = delete;
 	follower_connection_handler &operator= (connection_handler &&) = delete;
 
-	void push_request (page_to_tran_request id, std::string msg);
-	int send_receive (tran_to_page_request reqid, std::string &&payload_in, std::string &payload_out);
-
       private:
 	page_server &m_ps;
+	std::unique_ptr<follower_server_conn_t> m_conn;
     };
 
     class followee_connection_handler
     {
       public:
-	using follower_server_conn_t =
+	using followee_server_conn_t =
 		cubcomm::request_sync_client_server<follower_to_followee_request, followee_to_follower_request, std::string>;
 
 	followee_connection_handler () = delete;
@@ -223,8 +221,12 @@ class page_server
 	followee_connection_handler &operator= (const connection_handler &) = delete;
 	followee_connection_handler &operator= (connection_handler &&) = delete;
 
+	void push_request (page_to_tran_request id, std::string msg);
+	int send_receive (tran_to_page_request reqid, std::string &&payload_in, std::string &payload_out);
+
       private:
 	page_server &m_ps;
+	std::unique_ptr<followee_server_conn_t> m_conn;
     };
 
     /*
@@ -283,8 +285,8 @@ class page_server
     async_disconnect_handler<connection_handler> m_async_disconnect_handler;
     pts_mvcc_tracker m_pts_mvcc_tracker;
 
-    follower_connection_handler_uptr_t m_follower_conn;
-    std::vector<followee_connection_handler_uptr_t> m_followee_conn_vec;
+    followee_connection_handler_uptr_t m_followee_conn;
+    std::vector<follower_connection_handler_uptr_t> m_follower_conn_vec;
 };
 
 #endif // !_PAGE_SERVER_HPP_

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -173,7 +173,6 @@ class page_server
 	std::mutex m_abnormal_tran_server_disconnect_mtx;
 	bool m_abnormal_tran_server_disconnect;
     };
-    using connection_handler_uptr_t = std::unique_ptr<connection_handler>;
 
     /*
      * TODO
@@ -250,6 +249,10 @@ class page_server
 	std::unordered_map<std::string, MVCCID> m_pts_oldest_active_mvccids;
 	std::mutex m_pts_oldest_active_mvccids_mtx;
     };
+  private:
+    using connection_handler_uptr_t = std::unique_ptr<connection_handler>;
+    using follower_connection_handler_uptr_t = std::unique_ptr<follower_connection_handler>;
+    using followee_connection_handler_uptr_t = std::unique_ptr<followee_connection_handler>;
 
     using responder_t = server_request_responder<connection_handler::tran_server_conn_t>;
 
@@ -271,6 +274,9 @@ class page_server
 
     async_disconnect_handler<connection_handler> m_async_disconnect_handler;
     pts_mvcc_tracker m_pts_mvcc_tracker;
+
+    follower_connection_handler_uptr_t m_follower_conn;
+    std::vector<followee_connection_handler_uptr_t> m_followee_conn_vec;
 };
 
 #endif // !_PAGE_SERVER_HPP_

--- a/src/server/tran_page_requests.hpp
+++ b/src/server/tran_page_requests.hpp
@@ -62,8 +62,10 @@ enum class follower_to_followee_request
   // Reserve for responses
   RESPOND,
 
-  SEND_DISCONNECT, /* response-less */
-  SEND_LOG_PAGES_FETCH, /* synchronously waiting for response */
+  SEND_DUMMY, // TODO for test. remove it.
+
+  // TODO SEND_DISCONNECT, /* response-less */
+  // TODO SEND_LOG_PAGES_FETCH, /* synchronously waiting for response */
 };
 
 // to catch up from PS to PS

--- a/src/server/tran_page_requests.hpp
+++ b/src/server/tran_page_requests.hpp
@@ -56,16 +56,26 @@ enum class page_to_tran_request
   SEND_TO_PTS_LOG_PRIOR_LIST, /* response-less */
 };
 
-enum class page_to_page_catchup_request
+// to catch up from PS to PS
+enum class follower_to_followee_request
 {
   // Reserve for responses
   RESPOND,
 
-  SEND_DUMMY_REQUEST,
+  SEND_DUMMY_PUSH_REQUEST,
+  SEND_DUMMY_SEND_RECV_REQUEST,
 
-  // followee only
   // TODO SEND_DISCONNECT, /* response-less */
   // TODO SEND_LOG_PAGES_FETCH, /* synchronously waiting for response */
+};
+
+// to catch up from PS to PS
+enum class followee_to_follower_request
+{
+  // Reserve for responses
+  RESPOND,
+
+  // followee doesn't request
 };
 
 #endif // !_TRAN_PAGE_REQUESTS_HPP_

--- a/src/server/tran_page_requests.hpp
+++ b/src/server/tran_page_requests.hpp
@@ -56,5 +56,17 @@ enum class page_to_tran_request
   SEND_TO_PTS_LOG_PRIOR_LIST, /* response-less */
 };
 
+enum class page_to_page_catchup_request
+{
+  // Reserve for responses
+  RESPOND,
+
+  SEND_DUMMY_REQUEST,
+
+  // followee only
+  // TODO SEND_DISCONNECT, /* response-less */
+  // TODO SEND_LOG_PAGES_FETCH, /* synchronously waiting for response */
+};
+
 #endif // !_TRAN_PAGE_REQUESTS_HPP_
 

--- a/src/server/tran_page_requests.hpp
+++ b/src/server/tran_page_requests.hpp
@@ -56,7 +56,7 @@ enum class page_to_tran_request
   SEND_TO_PTS_LOG_PRIOR_LIST, /* response-less */
 };
 
-// to catch up from PS to PS
+// requets from page server to page server to catchup
 enum class follower_to_followee_request
 {
   // Reserve for responses
@@ -68,7 +68,7 @@ enum class follower_to_followee_request
   // TODO SEND_LOG_PAGES_FETCH, /* synchronously waiting for response */
 };
 
-// to catch up from PS to PS
+// requets from page server to page server to catchup
 enum class followee_to_follower_request
 {
   // Reserve for responses

--- a/src/server/tran_page_requests.hpp
+++ b/src/server/tran_page_requests.hpp
@@ -62,11 +62,8 @@ enum class follower_to_followee_request
   // Reserve for responses
   RESPOND,
 
-  SEND_DUMMY_PUSH_REQUEST,
-  SEND_DUMMY_SEND_RECV_REQUEST,
-
-  // TODO SEND_DISCONNECT, /* response-less */
-  // TODO SEND_LOG_PAGES_FETCH, /* synchronously waiting for response */
+  SEND_DISCONNECT, /* response-less */
+  SEND_LOG_PAGES_FETCH, /* synchronously waiting for response */
 };
 
 // to catch up from PS to PS


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-782

There are arguable implementation design choices. Please look into the Jira issue for these.:
- Extending the existing connection_handler to handle catchup requests vs. Creating a new separate dedicated connection_handler
- Bundling up follower and followee connection_handler or split them.

Some unrelated fixes:
- Use rvalue reference for page_server::connection_handler() and page_server::connection_handler::push_request().

Note:
- Disconnection will be addressed in the following issue.
- Defining requests will be addressed in the issues for them.
- Some descriptions and diagrams will be added when all issues related to these connection_handlers are reviewed and merged.
- `page_server::connection_handler` will be changed to `page_server::tran_server_connection_handler` after this PR is merged.
