### PR TITLE
[CBRD-24966] Core dump while processing DML with subquery in dblink

### DIFF
--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -11763,6 +11763,12 @@ pt_convert_dblink_dml_query (PARSER_CONTEXT * parser, PT_NODE * node,
       server = upd_spec->info.spec.remote_server_name;
     }
 
+  if (server == NULL)
+    {
+      PT_ERRORm (parser, node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_UPDATE_DERIVED_TABLE);
+      return;
+    }
+
   assert (server->node_type == PT_NAME);
 
   ct->info.dblink_table.is_name = true;

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -11765,6 +11765,7 @@ pt_convert_dblink_dml_query (PARSER_CONTEXT * parser, PT_NODE * node,
 
   if (server == NULL)
     {
+      /* the subquery target in update query is not allowed */
       PT_ERRORm (parser, node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_UPDATE_DERIVED_TABLE);
       return;
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24966

If a subquery is included in the DML query target of dblink, error handling is not performed and a core dump occurs.