### PR TITLE
[CBRD-24905] The problem is that a core dump occurs when a value of an invalid index type (such as Collection Type) is bound to host variables

### DIFF
--- a/src/object/object_primitive.h
+++ b/src/object/object_primitive.h
@@ -142,6 +142,8 @@ typedef struct pr_type
     inline bool is_always_variable () const;
     inline bool is_size_computed () const;
 
+    inline bool is_indexable () const;
+
     // size functions
     inline int get_mem_size_of_mem (const void *mem, const tp_domain * domain = NULL) const;
     inline int get_disk_size_of_mem (const void *mem, const tp_domain * domain = NULL) const;
@@ -443,6 +445,13 @@ pr_type::is_size_computed () const
 {
   assert ((f_data_lengthmem == NULL) == (f_data_lengthval == NULL));
   return f_data_lengthmem != NULL && f_data_lengthval != NULL;
+}
+
+bool
+pr_type::is_indexable () const
+{
+  assert ((f_index_writeval == NULL) == (f_index_readval == NULL) == (f_index_cmpdisk == NULL));
+  return f_index_cmpdisk != NULL;
 }
 
 int

--- a/src/object/object_primitive.h
+++ b/src/object/object_primitive.h
@@ -142,8 +142,6 @@ typedef struct pr_type
     inline bool is_always_variable () const;
     inline bool is_size_computed () const;
 
-    inline bool is_indexable () const;
-
     // size functions
     inline int get_mem_size_of_mem (const void *mem, const tp_domain * domain = NULL) const;
     inline int get_disk_size_of_mem (const void *mem, const tp_domain * domain = NULL) const;
@@ -445,13 +443,6 @@ pr_type::is_size_computed () const
 {
   assert ((f_data_lengthmem == NULL) == (f_data_lengthval == NULL));
   return f_data_lengthmem != NULL && f_data_lengthval != NULL;
-}
-
-bool
-pr_type::is_indexable () const
-{
-  assert ((f_index_writeval == NULL) == (f_index_readval == NULL) == (f_index_cmpdisk == NULL));
-  return f_index_cmpdisk != NULL;
 }
 
 int

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -1588,17 +1588,12 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
       idx_type_id = TP_DOMAIN_TYPE (idx_dom);
       val_type_id = DB_VALUE_DOMAIN_TYPE (val);
 
-#if 0
-      /* 1st solution: use tp_valid_indextype (). tp_valid_indextype () should always be up to date. */
       if (!tp_valid_indextype (val_type_id))
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_TP_CANT_COERCE, 2, pr_type_name (idx_type_id),
 		  pr_type_name (val_type_id));
 	  goto err_exit;
 	}
-#endif
-
-
 
       if (TP_IS_STRING_TYPE (val_type_id))
 	{
@@ -1742,18 +1737,8 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
 	    }
 	}
 
-#if 1
-      /* 2st solution: Check whether the index type is valid by pr_type.However, tp_domain_resolve_value () must be called first. */
-      if (!dom->type->is_indexable ())
-	{
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_TP_CANT_COERCE, 2, pr_type_name (TP_DOMAIN_TYPE (idx_dom)),
-		  pr_type_name (TP_DOMAIN_TYPE (val_dom)));
-	  goto err_exit;
-	}
-
       buf_size += dom->type->get_index_size_of_value (val);
     }
-#endif
 
   /* add more domain to setdomain for partial key */
   if (need_new_setdomain == true)

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -1967,30 +1967,18 @@ scan_regu_key_to_index_key (THREAD_ENTRY * thread_p, KEY_RANGE * key_ranges, KEY
       else
 	{
 	  ret = fetch_copy_dbval (thread_p, key_ranges->key1, vd, NULL, NULL, NULL, &key_val_range->key1);
-	  if (ret == NO_ERROR)
+	  db_type = DB_VALUE_DOMAIN_TYPE (&key_val_range->key1);
+
+	  if (ret == NO_ERROR && curr_key_prefix_length > 0)
 	    {
-	      if (!DB_IS_NULL (&key_val_range->key1))
+	      if (TP_IS_CHAR_TYPE (db_type) || TP_IS_BIT_TYPE (db_type))
 		{
-		  db_type = DB_VALUE_DOMAIN_TYPE (&key_val_range->key1);
+		  key_len = db_get_string_length (&key_val_range->key1);
 
-		  if (!tp_valid_indextype (db_type))
+		  if (key_len > curr_key_prefix_length)
 		    {
-		      ret = ER_FAILED;
-		      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_TP_CANT_COERCE, 2,
-			      pr_type_name (TP_DOMAIN_TYPE (btree_domainp)), pr_type_name (db_type));
-		    }
-
-		  if (curr_key_prefix_length > 0)
-		    {
-		      if (TP_IS_CHAR_TYPE (db_type) || TP_IS_BIT_TYPE (db_type))
-			{
-			  key_len = db_get_string_length (&key_val_range->key1);
-			  if (key_len > curr_key_prefix_length)
-			    {
-			      ret = db_string_truncate (&key_val_range->key1, curr_key_prefix_length);
-			      key_val_range->is_truncated = true;
-			    }
-			}
+		      ret = db_string_truncate (&key_val_range->key1, curr_key_prefix_length);
+		      key_val_range->is_truncated = true;
 		    }
 		}
 	    }
@@ -2026,30 +2014,19 @@ scan_regu_key_to_index_key (THREAD_ENTRY * thread_p, KEY_RANGE * key_ranges, KEY
       else
 	{
 	  ret = fetch_copy_dbval (thread_p, key_ranges->key2, vd, NULL, NULL, NULL, &key_val_range->key2);
-	  if (ret == NO_ERROR)
+
+	  db_type = DB_VALUE_DOMAIN_TYPE (&key_val_range->key2);
+
+	  if (ret == NO_ERROR && curr_key_prefix_length > 0)
 	    {
-	      if (!DB_IS_NULL (&key_val_range->key1))
+	      if (TP_IS_CHAR_TYPE (db_type) || TP_IS_BIT_TYPE (db_type))
 		{
-		  db_type = DB_VALUE_DOMAIN_TYPE (&key_val_range->key2);
+		  key_len = db_get_string_length (&key_val_range->key2);
 
-		  if (!DB_IS_NULL (&key_val_range->key1) && !tp_valid_indextype (db_type))
+		  if (key_len > curr_key_prefix_length)
 		    {
-		      ret = ER_FAILED;
-		      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_TP_CANT_COERCE, 2,
-			      pr_type_name (TP_DOMAIN_TYPE (btree_domainp)), pr_type_name (db_type));
-		    }
-
-		  if (curr_key_prefix_length > 0)
-		    {
-		      if (TP_IS_CHAR_TYPE (db_type) || TP_IS_BIT_TYPE (db_type))
-			{
-			  key_len = db_get_string_length (&key_val_range->key2);
-			  if (key_len > curr_key_prefix_length)
-			    {
-			      ret = db_string_truncate (&key_val_range->key2, curr_key_prefix_length);
-			      key_val_range->is_truncated = true;
-			    }
-			}
+		      ret = db_string_truncate (&key_val_range->key2, curr_key_prefix_length);
+		      key_val_range->is_truncated = true;
 		    }
 		}
 	    }

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -1967,18 +1967,27 @@ scan_regu_key_to_index_key (THREAD_ENTRY * thread_p, KEY_RANGE * key_ranges, KEY
       else
 	{
 	  ret = fetch_copy_dbval (thread_p, key_ranges->key1, vd, NULL, NULL, NULL, &key_val_range->key1);
-	  db_type = DB_VALUE_DOMAIN_TYPE (&key_val_range->key1);
-
-	  if (ret == NO_ERROR && curr_key_prefix_length > 0)
+	  if (ret == NO_ERROR)
 	    {
-	      if (TP_IS_CHAR_TYPE (db_type) || TP_IS_BIT_TYPE (db_type))
-		{
-		  key_len = db_get_string_length (&key_val_range->key1);
+	      db_type = DB_VALUE_DOMAIN_TYPE (&key_val_range->key1);
 
-		  if (key_len > curr_key_prefix_length)
+	      if (!tp_valid_indextype (db_type))
+		{
+		  ret = ER_FAILED;
+		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_TP_CANT_COERCE, 2,
+			  pr_type_name (TP_DOMAIN_TYPE (btree_domainp)), pr_type_name (db_type));
+		}
+
+	      if (curr_key_prefix_length > 0)
+		{
+		  if (TP_IS_CHAR_TYPE (db_type) || TP_IS_BIT_TYPE (db_type))
 		    {
-		      ret = db_string_truncate (&key_val_range->key1, curr_key_prefix_length);
-		      key_val_range->is_truncated = true;
+		      key_len = db_get_string_length (&key_val_range->key1);
+		      if (key_len > curr_key_prefix_length)
+			{
+			  ret = db_string_truncate (&key_val_range->key1, curr_key_prefix_length);
+			  key_val_range->is_truncated = true;
+			}
 		    }
 		}
 	    }
@@ -2014,19 +2023,27 @@ scan_regu_key_to_index_key (THREAD_ENTRY * thread_p, KEY_RANGE * key_ranges, KEY
       else
 	{
 	  ret = fetch_copy_dbval (thread_p, key_ranges->key2, vd, NULL, NULL, NULL, &key_val_range->key2);
-
-	  db_type = DB_VALUE_DOMAIN_TYPE (&key_val_range->key2);
-
-	  if (ret == NO_ERROR && curr_key_prefix_length > 0)
+	  if (ret == NO_ERROR)
 	    {
-	      if (TP_IS_CHAR_TYPE (db_type) || TP_IS_BIT_TYPE (db_type))
-		{
-		  key_len = db_get_string_length (&key_val_range->key2);
+	      db_type = DB_VALUE_DOMAIN_TYPE (&key_val_range->key2);
 
-		  if (key_len > curr_key_prefix_length)
+	      if (!tp_valid_indextype (db_type))
+		{
+		  ret = ER_FAILED;
+		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_TP_CANT_COERCE, 2,
+			  pr_type_name (TP_DOMAIN_TYPE (btree_domainp)), pr_type_name (db_type));
+		}
+
+	      if (curr_key_prefix_length > 0)
+		{
+		  if (TP_IS_CHAR_TYPE (db_type) || TP_IS_BIT_TYPE (db_type))
 		    {
-		      ret = db_string_truncate (&key_val_range->key2, curr_key_prefix_length);
-		      key_val_range->is_truncated = true;
+		      key_len = db_get_string_length (&key_val_range->key2);
+		      if (key_len > curr_key_prefix_length)
+			{
+			  ret = db_string_truncate (&key_val_range->key2, curr_key_prefix_length);
+			  key_val_range->is_truncated = true;
+			}
 		    }
 		}
 	    }

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -1969,26 +1969,27 @@ scan_regu_key_to_index_key (THREAD_ENTRY * thread_p, KEY_RANGE * key_ranges, KEY
 	  ret = fetch_copy_dbval (thread_p, key_ranges->key1, vd, NULL, NULL, NULL, &key_val_range->key1);
 	  if (ret == NO_ERROR)
 	    {
-	      db_type = DB_VALUE_DOMAIN_TYPE (&key_val_range->key1);
-
-#if 1
-	      if (!DB_IS_NULL (&key_val_range->key1) && !tp_valid_indextype (db_type))
+	      if (!DB_IS_NULL (&key_val_range->key1))
 		{
-		  ret = ER_FAILED;
-		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_TP_CANT_COERCE, 2,
-			  pr_type_name (TP_DOMAIN_TYPE (btree_domainp)), pr_type_name (db_type));
-		}
-#endif
+		  db_type = DB_VALUE_DOMAIN_TYPE (&key_val_range->key1);
 
-	      if (curr_key_prefix_length > 0)
-		{
-		  if (TP_IS_CHAR_TYPE (db_type) || TP_IS_BIT_TYPE (db_type))
+		  if (!tp_valid_indextype (db_type))
 		    {
-		      key_len = db_get_string_length (&key_val_range->key1);
-		      if (key_len > curr_key_prefix_length)
+		      ret = ER_FAILED;
+		      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_TP_CANT_COERCE, 2,
+			      pr_type_name (TP_DOMAIN_TYPE (btree_domainp)), pr_type_name (db_type));
+		    }
+
+		  if (curr_key_prefix_length > 0)
+		    {
+		      if (TP_IS_CHAR_TYPE (db_type) || TP_IS_BIT_TYPE (db_type))
 			{
-			  ret = db_string_truncate (&key_val_range->key1, curr_key_prefix_length);
-			  key_val_range->is_truncated = true;
+			  key_len = db_get_string_length (&key_val_range->key1);
+			  if (key_len > curr_key_prefix_length)
+			    {
+			      ret = db_string_truncate (&key_val_range->key1, curr_key_prefix_length);
+			      key_val_range->is_truncated = true;
+			    }
 			}
 		    }
 		}
@@ -2027,26 +2028,27 @@ scan_regu_key_to_index_key (THREAD_ENTRY * thread_p, KEY_RANGE * key_ranges, KEY
 	  ret = fetch_copy_dbval (thread_p, key_ranges->key2, vd, NULL, NULL, NULL, &key_val_range->key2);
 	  if (ret == NO_ERROR)
 	    {
-	      db_type = DB_VALUE_DOMAIN_TYPE (&key_val_range->key2);
-
-#if 0
-	      if (!DB_IS_NULL (&key_val_range->key1) && !tp_valid_indextype (db_type))
+	      if (!DB_IS_NULL (&key_val_range->key1))
 		{
-		  ret = ER_FAILED;
-		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_TP_CANT_COERCE, 2,
-			  pr_type_name (TP_DOMAIN_TYPE (btree_domainp)), pr_type_name (db_type));
-		}
-#endif
+		  db_type = DB_VALUE_DOMAIN_TYPE (&key_val_range->key2);
 
-	      if (curr_key_prefix_length > 0)
-		{
-		  if (TP_IS_CHAR_TYPE (db_type) || TP_IS_BIT_TYPE (db_type))
+		  if (!DB_IS_NULL (&key_val_range->key1) && !tp_valid_indextype (db_type))
 		    {
-		      key_len = db_get_string_length (&key_val_range->key2);
-		      if (key_len > curr_key_prefix_length)
+		      ret = ER_FAILED;
+		      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_TP_CANT_COERCE, 2,
+			      pr_type_name (TP_DOMAIN_TYPE (btree_domainp)), pr_type_name (db_type));
+		    }
+
+		  if (curr_key_prefix_length > 0)
+		    {
+		      if (TP_IS_CHAR_TYPE (db_type) || TP_IS_BIT_TYPE (db_type))
 			{
-			  ret = db_string_truncate (&key_val_range->key2, curr_key_prefix_length);
-			  key_val_range->is_truncated = true;
+			  key_len = db_get_string_length (&key_val_range->key2);
+			  if (key_len > curr_key_prefix_length)
+			    {
+			      ret = db_string_truncate (&key_val_range->key2, curr_key_prefix_length);
+			      key_val_range->is_truncated = true;
+			    }
 			}
 		    }
 		}

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -1502,6 +1502,7 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
   bool need_new_setdomain = false;
   TP_DOMAIN *idx_setdomain = NULL, *vals_setdomain = NULL;
   TP_DOMAIN *idx_dom = NULL, *val_dom = NULL, *dom = NULL, *next = NULL;
+  DB_TYPE idx_type_id;
   TP_DOMAIN dom_buf;
   DB_VALUE *coerced_values = NULL;
   bool *has_coerced_values = NULL;
@@ -1584,7 +1585,16 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
 	    }
 	}
 
+      idx_type_id = TP_DOMAIN_TYPE (idx_dom);
       val_type_id = DB_VALUE_DOMAIN_TYPE (val);
+
+      if (!tp_valid_indextype (val_type_id))
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_TP_CANT_COERCE, 2, pr_type_name (idx_type_id),
+		  pr_type_name (val_type_id));
+	  goto err_exit;
+	}
+
       if (TP_IS_STRING_TYPE (val_type_id))
 	{
 	  /* we need to check for maxes */
@@ -1599,7 +1609,7 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
 	    }
 	}
 
-      if (TP_DOMAIN_TYPE (idx_dom) != val_type_id)
+      if (idx_type_id != val_type_id)
 	{
 	  /* allocate DB_VALUE array to store coerced values. */
 	  if (has_coerced_values == NULL)
@@ -1634,8 +1644,8 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
 	      has_coerced_values[i] = true;
 	    }
 	}
-      else if (TP_DOMAIN_TYPE (idx_dom) == DB_TYPE_NUMERIC || TP_DOMAIN_TYPE (idx_dom) == DB_TYPE_CHAR
-	       || TP_DOMAIN_TYPE (idx_dom) == DB_TYPE_BIT || TP_DOMAIN_TYPE (idx_dom) == DB_TYPE_NCHAR)
+      else if (idx_type_id == DB_TYPE_NUMERIC || idx_type_id == DB_TYPE_CHAR || idx_type_id == DB_TYPE_BIT
+	       || idx_type_id == DB_TYPE_NCHAR)
 	{
 	  /* skip variable string domain : DB_TYPE_VARCHAR, DB_TYPE_VARNCHAR, DB_TYPE_VARBIT */
 

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -1588,12 +1588,17 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
       idx_type_id = TP_DOMAIN_TYPE (idx_dom);
       val_type_id = DB_VALUE_DOMAIN_TYPE (val);
 
+#if 0
+      /* 1st solution: use tp_valid_indextype (). tp_valid_indextype () should always be up to date. */
       if (!tp_valid_indextype (val_type_id))
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_TP_CANT_COERCE, 2, pr_type_name (idx_type_id),
 		  pr_type_name (val_type_id));
 	  goto err_exit;
 	}
+#endif
+
+
 
       if (TP_IS_STRING_TYPE (val_type_id))
 	{
@@ -1737,8 +1742,18 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
 	    }
 	}
 
+#if 1
+      /* 2st solution: Check whether the index type is valid by pr_type.However, tp_domain_resolve_value () must be called first. */
+      if (!dom->type->is_indexable ())
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_TP_CANT_COERCE, 2, pr_type_name (TP_DOMAIN_TYPE (idx_dom)),
+		  pr_type_name (TP_DOMAIN_TYPE (val_dom)));
+	  goto err_exit;
+	}
+
       buf_size += dom->type->get_index_size_of_value (val);
     }
+#endif
 
   /* add more domain to setdomain for partial key */
   if (need_new_setdomain == true)

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -1971,12 +1971,14 @@ scan_regu_key_to_index_key (THREAD_ENTRY * thread_p, KEY_RANGE * key_ranges, KEY
 	    {
 	      db_type = DB_VALUE_DOMAIN_TYPE (&key_val_range->key1);
 
-	      if (!tp_valid_indextype (db_type))
+#if 1
+	      if (!DB_IS_NULL (&key_val_range->key1) && !tp_valid_indextype (db_type))
 		{
 		  ret = ER_FAILED;
 		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_TP_CANT_COERCE, 2,
 			  pr_type_name (TP_DOMAIN_TYPE (btree_domainp)), pr_type_name (db_type));
 		}
+#endif
 
 	      if (curr_key_prefix_length > 0)
 		{
@@ -2027,12 +2029,14 @@ scan_regu_key_to_index_key (THREAD_ENTRY * thread_p, KEY_RANGE * key_ranges, KEY
 	    {
 	      db_type = DB_VALUE_DOMAIN_TYPE (&key_val_range->key2);
 
-	      if (!tp_valid_indextype (db_type))
+#if 0
+	      if (!DB_IS_NULL (&key_val_range->key1) && !tp_valid_indextype (db_type))
 		{
 		  ret = ER_FAILED;
 		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_TP_CANT_COERCE, 2,
 			  pr_type_name (TP_DOMAIN_TYPE (btree_domainp)), pr_type_name (db_type));
 		}
+#endif
 
 	      if (curr_key_prefix_length > 0)
 		{

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -19145,9 +19145,6 @@ btree_compare_key (DB_VALUE * key1, DB_VALUE * key2, TP_DOMAIN * key_domain, int
       assert (key1_type != DB_TYPE_MIDXKEY);
       assert (key2_type != DB_TYPE_MIDXKEY);
 
-      assert (tp_valid_indextype (key1_type));
-      assert (tp_valid_indextype (key2_type));
-
       /* safe code */
       if (key1_type == DB_TYPE_MIDXKEY)
 	{
@@ -19191,6 +19188,9 @@ btree_compare_key (DB_VALUE * key1, DB_VALUE * key2, TP_DOMAIN * key_domain, int
 	      return DB_UNK;
 	    }
 	}
+
+      assert (tp_valid_indextype (key1_type));
+      assert (tp_valid_indextype (key2_type));
 
       assert_release (c == DB_UNK || (DB_LT <= c && c <= DB_GT));
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24905

Raise an error if the value is of an invalid index type (such as Collection Type) before generating the DB_VALUE for index scanning.