### PR TITLE
[CBRD-24920] [regression-rev] to not output decimal point 0 of double type in csql

### DIFF
--- a/src/executables/csql_result_format.c
+++ b/src/executables/csql_result_format.c
@@ -1422,7 +1422,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, bool plain_string, CSQL_
 
 	  if (DB_VALUE_TYPE (value) == DB_TYPE_FLOAT)
 	    {
-	      sprintf (double_str, "%g", db_get_float (value));
+	      sprintf (double_str, "%.7g", db_get_float (value));
 	    }
 	  else
 	    {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24920

If the oracle_compat_number_behavior parameter is set, do not output decimal point 0 when outputting double type in csql.

In float type, we should %.7g instead of %g for proper mantissa fraction.
