### PR TITLE
[CBRD-24953] Gateway passed wrong precision value of column to DBLink Server

### DIFF
--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -680,8 +680,9 @@ cgw_get_col_info (SQLHSTMT hstmt, int col_num, T_ODBC_COL_INFO * col_info)
   SQLRETURN err_code;
   SQLSMALLINT col_name_length = 0;
   SQLSMALLINT class_name_length = 0;
-  SQLLEN col_data_type = 0;
+  SQLSMALLINT col_data_type = 0;
   SQLLEN col_unsigned_type = 0;
+  SQLSMALLINT col_decimal_digits = 0;
 
   memset (col_info, 0x0, sizeof (T_ODBC_COL_INFO));
 
@@ -693,21 +694,16 @@ cgw_get_col_info (SQLHSTMT hstmt, int col_num, T_ODBC_COL_INFO * col_info)
 
   SQL_CHK_ERR (hstmt,
 	       SQL_HANDLE_STMT,
-	       err_code = SQLColAttribute (hstmt,
-					   col_num,
-					   SQL_DESC_NAME,
-					   col_info->col_name, sizeof (col_info->col_name), &col_name_length, NULL));
-  SQL_CHK_ERR (hstmt,
-	       SQL_HANDLE_STMT,
-	       err_code = SQLColAttribute (hstmt, col_num, SQL_DESC_CONCISE_TYPE, NULL, 0, NULL, &col_data_type));
+	       err_code = SQLDescribeCol (hstmt,
+					  (SQLSMALLINT) col_num,
+					  (SQLCHAR *) col_info->col_name,
+					  sizeof (col_info->col_name),
+					  &col_name_length, &col_data_type, &col_info->precision, &col_decimal_digits,
+					  &col_info->is_not_null));
 
   SQL_CHK_ERR (hstmt,
 	       SQL_HANDLE_STMT,
 	       err_code = SQLColAttribute (hstmt, col_num, SQL_DESC_SCALE, NULL, 0, NULL, &col_info->scale));
-
-  SQL_CHK_ERR (hstmt,
-	       SQL_HANDLE_STMT,
-	       err_code = SQLColAttribute (hstmt, col_num, SQL_DESC_PRECISION, NULL, 0, NULL, &col_info->precision));
 
   SQL_CHK_ERR (hstmt,
 	       SQL_HANDLE_STMT,
@@ -723,12 +719,6 @@ cgw_get_col_info (SQLHSTMT hstmt, int col_num, T_ODBC_COL_INFO * col_info)
 	}
       col_info->precision = num;
     }
-  SQL_CHK_ERR (hstmt,
-	       SQL_HANDLE_STMT,
-	       err_code = SQLColAttribute (hstmt,
-					   col_num,
-					   SQL_DESC_NAME,
-					   col_info->col_name, sizeof (col_info->col_name), &col_name_length, NULL));
 
   SQL_CHK_ERR (hstmt,
 	       SQL_HANDLE_STMT,
@@ -737,9 +727,6 @@ cgw_get_col_info (SQLHSTMT hstmt, int col_num, T_ODBC_COL_INFO * col_info)
 					   SQL_DESC_TABLE_NAME,
 					   col_info->class_name, sizeof (col_info->class_name), &class_name_length,
 					   NULL));
-
-  SQL_CHK_ERR (hstmt, SQL_HANDLE_STMT, err_code = SQLColAttribute (hstmt, col_num, SQL_DESC_NULLABLE, NULL, 0,	// Note count of bytes!
-								   NULL, &col_info->is_not_null));
 
   SQL_CHK_ERR (hstmt,
 	       SQL_HANDLE_STMT,

--- a/src/broker/cas_cgw.h
+++ b/src/broker/cas_cgw.h
@@ -111,7 +111,7 @@ struct t_odbc_col_info
 {
   char data_type;
   SQLLEN scale;
-  SQLLEN precision;
+  SQLULEN precision;
   char charset;
   char col_name[COL_NAME_LEN + 1];
   char default_value[DEFAULT_VALUE_LEN + 1];
@@ -125,7 +125,7 @@ struct t_odbc_col_info
   char is_shared;
   char attr_name[ATTR_NAME_LEN + 1];
   char class_name[CLASS_NAME_LEN + 1];
-  SQLLEN is_not_null;
+  SQLSMALLINT is_not_null;
 };
 
 typedef union odbc_bind_info ODBC_BIND_INFO;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24953

Purpose
When a Prepare Statmemt occurs, the gateway sends column information to the DBLink Server.
An error was found in passing the precision value as 0 among the column information.
Due to incorrect precision, cubrid creates a column with char(0).
Changed the way to obtain the precision of char and varchar types.

Implementation
N/A

Remarks
N/A