### PR TITLE
[CBRD-24949] CAS Protocol V12, send oracle_compat_number_behavior system parameter to the clients

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -6233,7 +6233,7 @@ SYSPRM_PARAM prm_Def[] = {
    (DUP_PRM_FUNC) NULL},
   {PRM_ID_ORACLE_COMPAT_NUMBER_BEHAVIOR,
    PRM_NAME_ORACLE_COMPAT_NUMBER_BEHAVIOR,
-   (PRM_FOR_SERVER | PRM_FORCE_SERVER),
+   (PRM_FOR_CLIENT | PRM_FOR_SERVER | PRM_FORCE_SERVER),
    PRM_BOOLEAN,
    &prm_oracle_compat_number_behavior_flag,
    (void *) &prm_oracle_compat_number_behavior_default,

--- a/src/broker/cas.c
+++ b/src/broker/cas.c
@@ -1417,6 +1417,11 @@ cas_main (void)
 	      }
 	    cas_bi_set_cci_pconnect (shm_appl->cci_pconnect);
 
+	    if (DOES_CLIENT_UNDERSTAND_THE_PROTOCOL (req_info.client_version, PROTOCOL_V12))
+	      {
+		cas_bi_set_oracle_compat_number_behavior (prm_get_bool_value (PRM_ID_ORACLE_COMPAT_NUMBER_BEHAVIOR));
+	      }
+
 	    cas_info[CAS_INFO_STATUS] = CAS_INFO_STATUS_ACTIVE;
 	    /* todo: casting T_BROKER_VERSION to T_CAS_PROTOCOL */
 	    cas_send_connect_reply_to_driver ((T_CAS_PROTOCOL) req_info.client_version, client_sock_fd, cas_info);

--- a/src/broker/cas_meta.c
+++ b/src/broker/cas_meta.c
@@ -242,6 +242,6 @@ cas_bi_make_broker_info (char *broker_info, char dbms_type, char statement_pooli
 
   broker_info[BROKER_INFO_PROTO_VERSION] = CAS_PROTO_PACK_CURRENT_NET_VER;
   broker_info[BROKER_INFO_FUNCTION_FLAG] = (char) (BROKER_RENEWED_ERROR_CODE | BROKER_SUPPORT_HOLDABLE_RESULT);
-  broker_info[BROKER_INFO_RESERVED2] = 0;
+  broker_info[BROKER_INFO_SYSTEM_PARAM] = 0;
   broker_info[BROKER_INFO_RESERVED3] = 0;
 }

--- a/src/broker/cas_meta.c
+++ b/src/broker/cas_meta.c
@@ -226,7 +226,8 @@ cas_di_understand_renewed_error_code (const char *driver_info)
 }
 
 void
-cas_bi_make_broker_info (char *broker_info, char dbms_type, char statement_pooling, char cci_pconnect)
+cas_bi_make_broker_info (char *broker_info, char dbms_type, char statement_pooling, char cci_pconnect,
+			 char oracle_compat_number_behavior)
 {
   broker_info[BROKER_INFO_DBMS_TYPE] = dbms_type;
   broker_info[BROKER_INFO_KEEP_CONNECTION] = CAS_KEEP_CONNECTION_ON;
@@ -242,6 +243,15 @@ cas_bi_make_broker_info (char *broker_info, char dbms_type, char statement_pooli
 
   broker_info[BROKER_INFO_PROTO_VERSION] = CAS_PROTO_PACK_CURRENT_NET_VER;
   broker_info[BROKER_INFO_FUNCTION_FLAG] = (char) (BROKER_RENEWED_ERROR_CODE | BROKER_SUPPORT_HOLDABLE_RESULT);
-  broker_info[BROKER_INFO_SYSTEM_PARAM] = 0;
+
+  if (oracle_compat_number_behavior)
+    {
+      SET_BIT (broker_info[BROKER_INFO_SYSTEM_PARAM], MASK_ORACLE_COMPAT_NUMBER_BEHAVIOR);
+    }
+  else
+    {
+      CLEAR_BIT (broker_info[BROKER_INFO_SYSTEM_PARAM], MASK_ORACLE_COMPAT_NUMBER_BEHAVIOR);
+    }
+
   broker_info[BROKER_INFO_RESERVED3] = 0;
 }

--- a/src/broker/cas_meta.c
+++ b/src/broker/cas_meta.c
@@ -121,6 +121,21 @@ cas_bi_get_cci_pconnect (void)
 }
 
 void
+cas_bi_set_oracle_compat_number_behavior (char oracle_compat_number_behavior)
+{
+  assert (oracle_compat_number_behavior == 0 || oracle_compat_number_behavior == 1);
+
+  if (oracle_compat_number_behavior)
+    {
+      SET_BIT (broker_info[BROKER_INFO_SYSTEM_PARAM], MASK_ORACLE_COMPAT_NUMBER_BEHAVIOR);
+    }
+  else
+    {
+      CLEAR_BIT (broker_info[BROKER_INFO_SYSTEM_PARAM], MASK_ORACLE_COMPAT_NUMBER_BEHAVIOR);
+    }
+}
+
+void
 cas_bi_set_protocol_version (const char protocol_version)
 {
   broker_info[BROKER_INFO_PROTO_VERSION] = protocol_version;

--- a/src/broker/cas_protocol.h
+++ b/src/broker/cas_protocol.h
@@ -129,7 +129,7 @@ extern "C"
 /* For backward compatibility */
 #define BROKER_INFO_MAJOR_VERSION               (BROKER_INFO_PROTO_VERSION)
 #define BROKER_INFO_MINOR_VERSION               (BROKER_INFO_FUNCTION_FLAG)
-#define BROKER_INFO_PATCH_VERSION               (BROKER_INFO_RESERVED2)
+#define BROKER_INFO_PATCH_VERSION               (BROKER_INFO_SYSTEM_PARAM)
 #define BROKER_INFO_RESERVED                    (BROKER_INFO_RESERVED3)
 
 #define CAS_PID_SIZE                            4
@@ -150,11 +150,8 @@ extern "C"
 #define CCI_PCONNECT_OFF                        0
 #define CCI_PCONNECT_ON                         1
 
-#define ORACLE_COMPAT_NUMBER_BEHAVIOR_NO        0
-#define ORACLE_COMPAT_NUMBER_BEHAVIOR_YES       1
-
 /* BITMASK for System Parameter */
-#define MASK_ORACLE_COMPAT_NUMBER_BEHAVIOR      0x01    // oracle_compat_number_behavior
+#define MASK_ORACLE_COMPAT_NUMBER_BEHAVIOR      0x01	// oracle_compat_number_behavior
 
 #define CAS_REQ_HEADER_JDBC	"JDBC"
 #define CAS_REQ_HEADER_ODBC	"ODBC"
@@ -365,7 +362,7 @@ extern "C"
   extern char cas_bi_get_statement_pooling (void);
   extern void cas_bi_set_cci_pconnect (const char cci_pconnect);
   extern char cas_bi_get_cci_pconnect (void);
-  extern void cas_bi_set_oracle_compat_number_behavior ( char oracle_compat_number_behavior);
+  extern void cas_bi_set_oracle_compat_number_behavior (char oracle_compat_number_behavior);
   extern void cas_bi_set_protocol_version (const char protocol_version);
   extern char cas_bi_get_protocol_version (void);
   extern void cas_bi_set_renewed_error_code (const bool renewed_error_code);

--- a/src/broker/cas_protocol.h
+++ b/src/broker/cas_protocol.h
@@ -150,6 +150,12 @@ extern "C"
 #define CCI_PCONNECT_OFF                        0
 #define CCI_PCONNECT_ON                         1
 
+#define ORACLE_COMPAT_NUMBER_BEHAVIOR_NO        0
+#define ORACLE_COMPAT_NUMBER_BEHAVIOR_YES       1
+
+/* BITMASK for System Parameter */
+#define MASK_ORACLE_COMPAT_NUMBER_BEHAVIOR      0x01    // oracle_compat_number_behavior
+
 #define CAS_REQ_HEADER_JDBC	"JDBC"
 #define CAS_REQ_HEADER_ODBC	"ODBC"
 #define CAS_REQ_HEADER_PHP	"PHP"
@@ -233,7 +239,8 @@ extern "C"
     PROTOCOL_V9 = 9,		/* cas health check: get function status */
     PROTOCOL_V10 = 10,		/* Secure Broker/CAS using SSL */
     PROTOCOL_V11 = 11,		/* make out resultset */
-    CURRENT_PROTOCOL = PROTOCOL_V11
+    PROTOCOL_V12 = 12,		/* Remove trailing zeros from double and float types */
+    CURRENT_PROTOCOL = PROTOCOL_V12
   };
   typedef enum t_cas_protocol T_CAS_PROTOCOL;
 
@@ -245,7 +252,7 @@ extern "C"
     BROKER_INFO_CCI_PCONNECT,
     BROKER_INFO_PROTO_VERSION,
     BROKER_INFO_FUNCTION_FLAG,
-    BROKER_INFO_RESERVED2,
+    BROKER_INFO_SYSTEM_PARAM,
     BROKER_INFO_RESERVED3
   };
   typedef enum t_broker_info_pos T_BROKER_INFO_POS;
@@ -358,6 +365,7 @@ extern "C"
   extern char cas_bi_get_statement_pooling (void);
   extern void cas_bi_set_cci_pconnect (const char cci_pconnect);
   extern char cas_bi_get_cci_pconnect (void);
+  extern void cas_bi_set_oracle_compat_number_behavior ( char oracle_compat_number_behavior);
   extern void cas_bi_set_protocol_version (const char protocol_version);
   extern char cas_bi_get_protocol_version (void);
   extern void cas_bi_set_renewed_error_code (const bool renewed_error_code);

--- a/src/broker/cas_protocol.h
+++ b/src/broker/cas_protocol.h
@@ -368,7 +368,8 @@ extern "C"
   extern void cas_bi_set_renewed_error_code (const bool renewed_error_code);
   extern bool cas_bi_get_renewed_error_code (void);
   extern bool cas_di_understand_renewed_error_code (const char *driver_info);
-  extern void cas_bi_make_broker_info (char *broker_info, char dbms_type, char statement_pooling, char cci_pconnect);
+  extern void cas_bi_make_broker_info (char *broker_info, char dbms_type, char statement_pooling, char cci_pconnect,
+				       char oracle_compat_number_behavior);
 #ifdef __cplusplus
 }
 #endif

--- a/src/broker/shard_proxy.c
+++ b/src/broker/shard_proxy.c
@@ -32,6 +32,7 @@
 #include "shard_proxy.h"
 #include "shard_proxy_handler.h"
 #include "shard_key_func.h"
+#include "system_parameter.h"
 
 #if defined(WINDOWS)
 #include "broker_wsa_init.h"
@@ -210,6 +211,12 @@ main (int argc, char *argv[])
   if (error)
     {
       PROXY_LOG (PROXY_LOG_MODE_ERROR, "Failed to initialize proxy context handler.");
+      return error;
+    }
+
+  if (sysprm_load_and_init (NULL, NULL, SYSPRM_IGNORE_INTL_PARAMS) != NO_ERROR)
+    {
+      PROXY_LOG (PROXY_LOG_MODE_ERROR, "System Parameter load failed.");
       return error;
     }
 

--- a/src/broker/shard_proxy_io.c
+++ b/src/broker/shard_proxy_io.c
@@ -42,6 +42,7 @@
 #include "cas_error.h"
 #include "shard_shm.h"
 #include "broker_acl.h"
+#include "system_parameter.h"
 
 #ifndef min
 #define min(a,b)    ((a) < (b) ? (a) : (b))
@@ -928,6 +929,7 @@ proxy_io_make_client_dbinfo_ok (char *driver_info, char **buffer)
   int proxy_pid;
   char broker_info[BROKER_INFO_SIZE];
   T_BROKER_VERSION client_version;
+  char oracle_compat_number_behavior = 0;
 
   assert (buffer);
 
@@ -955,7 +957,13 @@ proxy_io_make_client_dbinfo_ok (char *driver_info, char **buffer)
       dbms_type = CAS_DBMS_CUBRID;
     }
 
-  cas_bi_make_broker_info (broker_info, dbms_type, shm_as_p->statement_pooling, shm_as_p->cci_pconnect);
+  if (DOES_CLIENT_UNDERSTAND_THE_PROTOCOL (client_version, PROTOCOL_V12))
+    {
+      oracle_compat_number_behavior = prm_get_bool_value (PRM_ID_ORACLE_COMPAT_NUMBER_BEHAVIOR);
+    }
+
+  cas_bi_make_broker_info (broker_info, dbms_type, shm_as_p->statement_pooling, shm_as_p->cci_pconnect,
+			   oracle_compat_number_behavior);
 
   if (DOES_CLIENT_UNDERSTAND_THE_PROTOCOL (client_version, PROTOCOL_V4))
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24949

Purpose
* to eliminate user confusion, 2-way expression is unified with the oracle_compat_number_behavior system parameter.
* in order for the broker to deliver the value of the system parameters including oracle_compat_number_behavior to the client, the broker extends the broker info that the client receives using the RESERVED field.
* Change the CAS Protocol version from PROTOCOL_V11 to PROTOCOL_V12 to express the extension of the above protocol

Implementation
N/A

Remarks
N/A