### PR TITLE
[CBRD-24968] An error occurs when a table alias name is used and a column name is used within a function.

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -11508,7 +11508,6 @@ pt_get_column_name_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int 
     case PT_DOT_:
       check_for_already_exists (parser, plkcol, node->info.dot.arg1->info.name.original,
 				node->info.dot.arg2->info.name.original);
-      *continue_walk = PT_LIST_WALK;
       break;
 
     case PT_NAME:


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24968

```
-- at remote side
drop table if exists remote_t2;
drop table remote_t2;
create table remote_t2 (col1 int, col2 int);
insert into remote_t2 values (1,2);
insert into remote_t2 values (2,null);
insert into remote_t2 values (3,4);

-- at local side 
select b.col1, 
       nvl(b.col2,9999)
from  remote_t2@remote_server b;
```

ERROR: Class of b does not have attribute col2.
