### PR TITLE
[CBRD-24972] Change the order of the list of files in the database_schema_info file

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -5620,10 +5620,9 @@ create_schema_info (extract_context & ctxt)
   int err = NO_ERROR;
   char output_filename[PATH_MAX * 2] = { '\0' };
   char order_str[PATH_MAX * 2] = { '\0' };
-  const char *loading_order[] =
-    { "_schema_user", "_schema_class", "_schema_vclass", "_schema_synonym", "_schema_vclass_query_spec",
+  const char *loading_order[] = { "_schema_user", "_schema_class", "_schema_vclass", "_schema_synonym",
     "_schema_serial", "_schema_procedure", "_schema_server",
-    "_schema_pk", "_schema_fk", "_schema_grant",
+    "_schema_pk", "_schema_fk", "_schema_grant", "_schema_vclass_query_spec"
   };
 
   const size_t len = sizeof (loading_order) / sizeof (loading_order[0]);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24972

Purpose
loaddb --schema-flie-list fails when load of dblink select query within create view.
because 'database_schema_vclass_query_spec' is load before 'database_schema_server' in 'database_schema_info'.
So I changed database_schema_vclass_query_spec location to the bottom.

Implementation
N/A

Remarks
N/A