### PR TITLE
[CBRD-24975] Remove date and time related modifier from dblink query

### DIFF
--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -16004,38 +16004,34 @@ pt_print_value (PARSER_CONTEXT * parser, PT_NODE * p)
 	}
       r = (char *) p->info.value.data_value.str->bytes;
 
-
-      if (!(parser->custom_print & PT_PRINT_SUPPRESS_FOR_DBLINK))
+      switch (p->type_enum)
 	{
-	  switch (p->type_enum)
-	    {
-	    case PT_TYPE_DATE:
-	      q = pt_append_nulstring (parser, q, "date ");
-	      break;
-	    case PT_TYPE_TIME:
-	      q = pt_append_nulstring (parser, q, "time ");
-	      break;
-	    case PT_TYPE_TIMESTAMP:
-	      q = pt_append_nulstring (parser, q, "timestamp ");
-	      break;
-	    case PT_TYPE_TIMESTAMPTZ:
-	      q = pt_append_nulstring (parser, q, "timestamptz ");
-	      break;
-	    case PT_TYPE_TIMESTAMPLTZ:
-	      q = pt_append_nulstring (parser, q, "timestampltz ");
-	      break;
-	    case PT_TYPE_DATETIME:
-	      q = pt_append_nulstring (parser, q, "datetime ");
-	      break;
-	    case PT_TYPE_DATETIMETZ:
-	      q = pt_append_nulstring (parser, q, "datetimetz ");
-	      break;
-	    case PT_TYPE_DATETIMELTZ:
-	      q = pt_append_nulstring (parser, q, "datetimeltz ");
-	      break;
-	    default:
-	      break;
-	    }
+	case PT_TYPE_DATE:
+	  q = pt_append_nulstring (parser, q, "date ");
+	  break;
+	case PT_TYPE_TIME:
+	  q = pt_append_nulstring (parser, q, "time ");
+	  break;
+	case PT_TYPE_TIMESTAMP:
+	  q = pt_append_nulstring (parser, q, "timestamp ");
+	  break;
+	case PT_TYPE_TIMESTAMPTZ:
+	  q = pt_append_nulstring (parser, q, "timestamptz ");
+	  break;
+	case PT_TYPE_TIMESTAMPLTZ:
+	  q = pt_append_nulstring (parser, q, "timestampltz ");
+	  break;
+	case PT_TYPE_DATETIME:
+	  q = pt_append_nulstring (parser, q, "datetime ");
+	  break;
+	case PT_TYPE_DATETIMETZ:
+	  q = pt_append_nulstring (parser, q, "datetimetz ");
+	  break;
+	case PT_TYPE_DATETIMELTZ:
+	  q = pt_append_nulstring (parser, q, "datetimeltz ");
+	  break;
+	default:
+	  break;
 	}
 
       q = pt_append_string_prefix (parser, q, p);

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -16004,34 +16004,38 @@ pt_print_value (PARSER_CONTEXT * parser, PT_NODE * p)
 	}
       r = (char *) p->info.value.data_value.str->bytes;
 
-      switch (p->type_enum)
+
+      if (!(parser->custom_print & PT_PRINT_SUPPRESS_FOR_DBLINK))
 	{
-	case PT_TYPE_DATE:
-	  q = pt_append_nulstring (parser, q, "date ");
-	  break;
-	case PT_TYPE_TIME:
-	  q = pt_append_nulstring (parser, q, "time ");
-	  break;
-	case PT_TYPE_TIMESTAMP:
-	  q = pt_append_nulstring (parser, q, "timestamp ");
-	  break;
-	case PT_TYPE_TIMESTAMPTZ:
-	  q = pt_append_nulstring (parser, q, "timestamptz ");
-	  break;
-	case PT_TYPE_TIMESTAMPLTZ:
-	  q = pt_append_nulstring (parser, q, "timestampltz ");
-	  break;
-	case PT_TYPE_DATETIME:
-	  q = pt_append_nulstring (parser, q, "datetime ");
-	  break;
-	case PT_TYPE_DATETIMETZ:
-	  q = pt_append_nulstring (parser, q, "datetimetz ");
-	  break;
-	case PT_TYPE_DATETIMELTZ:
-	  q = pt_append_nulstring (parser, q, "datetimeltz ");
-	  break;
-	default:
-	  break;
+	  switch (p->type_enum)
+	    {
+	    case PT_TYPE_DATE:
+	      q = pt_append_nulstring (parser, q, "date ");
+	      break;
+	    case PT_TYPE_TIME:
+	      q = pt_append_nulstring (parser, q, "time ");
+	      break;
+	    case PT_TYPE_TIMESTAMP:
+	      q = pt_append_nulstring (parser, q, "timestamp ");
+	      break;
+	    case PT_TYPE_TIMESTAMPTZ:
+	      q = pt_append_nulstring (parser, q, "timestamptz ");
+	      break;
+	    case PT_TYPE_TIMESTAMPLTZ:
+	      q = pt_append_nulstring (parser, q, "timestampltz ");
+	      break;
+	    case PT_TYPE_DATETIME:
+	      q = pt_append_nulstring (parser, q, "datetime ");
+	      break;
+	    case PT_TYPE_DATETIMETZ:
+	      q = pt_append_nulstring (parser, q, "datetimetz ");
+	      break;
+	    case PT_TYPE_DATETIMELTZ:
+	      q = pt_append_nulstring (parser, q, "datetimeltz ");
+	      break;
+	    default:
+	      break;
+	    }
 	}
 
       q = pt_append_string_prefix (parser, q, p);

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -7806,6 +7806,12 @@ pt_fold_constants_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *
 	  // we want to test full execution of sub-tree; don't fold it!
 	  *continue_walk = PT_LIST_WALK;
 	}
+    case PT_EXPR:
+      if (!node->flag.do_not_fold && pt_is_dblink_related (node))
+	{
+	  node->flag.do_not_fold = 1;
+	  *continue_walk = PT_STOP_WALK;
+	}
     default:
       // nope
       break;
@@ -18923,8 +18929,18 @@ error_zerodate:
 static bool
 pt_is_dblink_related (PT_NODE * p)
 {
+  PT_OP_TYPE op;
+
   if (p->node_type == PT_EXPR)
     {
+      op = p->info.expr.op;
+
+      /* for and, or, xor operator do not check */
+      if (op == PT_AND || op == PT_OR || op == PT_XOR)
+	{
+	  return false;
+	}
+
       if (p->info.expr.arg1 && pt_is_dblink_related (p->info.expr.arg1))
 	{
 	  return true;

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -7789,6 +7789,22 @@ pt_eval_type_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *conti
   return node;
 }
 
+/*
+ * pt_set_flag_do_not_fold_for_dblink - setting "do_not_fold" flag recursively
+ *   return	: the expr node after setting the flag
+ *
+ *   parser(in)	: the parser context
+ *   node(in)	: the node not to be folded
+ *   arg(in)	:
+ *   continue_walk(in):
+ */
+static PT_NODE *
+pt_set_flag_do_not_fold_for_dblink (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg, int *continue_walk)
+{
+  expr->flag.do_not_fold = 1;
+  return expr;
+}
+
 static PT_NODE *
 pt_fold_constants_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk)
 {
@@ -7807,10 +7823,9 @@ pt_fold_constants_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *
 	  *continue_walk = PT_LIST_WALK;
 	}
     case PT_EXPR:
-      if (!node->flag.do_not_fold && pt_is_dblink_related (node))
+      if (pt_is_dblink_related (node))
 	{
-	  node->flag.do_not_fold = 1;
-	  *continue_walk = PT_STOP_WALK;
+	  parser_walk_tree (parser, node, pt_set_flag_do_not_fold_for_dblink, NULL, NULL, NULL);
 	}
     default:
       // nope


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24975

In the process of rewriting a dblink query, a modifier may be added like as the format of datetime 'YYYY-MM-DD hh:mm:ss' while performing constant folding of functions related to time and date, such as to_datetime. However, since these modifiers may not work in other DBMS other than CUBRID, it must avoid adding modifiers when rewriting queries.
