### PR TITLE
[CBRD-24974] The problem is that error occurs when loading unloaded schema file if both DBA and user have tables and views with same name

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -167,7 +167,6 @@ static int order_classes (DB_OBJLIST ** class_list, DB_OBJLIST ** order_list, in
 static void emit_cycle_warning (print_output & output_ctx);
 static void force_one_class (print_output & output_ctx, DB_OBJLIST ** class_list, DB_OBJLIST ** order_list);
 static DB_OBJLIST *get_ordered_classes (print_output & output_ctx, MOP * class_table);
-static void emit_class_owner (extract_context & ctxt, print_output & output_ctx, MOP class_);
 static int export_serial (extract_context & ctxt, print_output & output_ctx);
 static int emit_indexes (extract_context & ctxt, print_output & output_ctx, DB_OBJLIST * classes, int has_indexes,
 			 DB_OBJLIST * vclass_list_has_using_index);
@@ -641,43 +640,6 @@ get_ordered_classes (print_output & output_ctx, MOP * class_table)
 	}
     }
   return (ordered);
-}
-
-
-/*
- * emit_class_owner - Emits a change_owner statement for a class that has been
- * created.
- *    return:  void
- *    fp(in/out):  FILE pointer
- *    class(in): class MOP
- */
-static void
-emit_class_owner (extract_context & ctxt, print_output & output_ctx, MOP class_)
-{
-  const char *classname;
-  MOP owner;
-  DB_VALUE value;
-
-  classname = db_get_class_name (class_);
-  if (classname != NULL)
-    {
-      owner = au_get_class_owner (class_);
-      if (owner != NULL)
-	{
-	  if (db_get (owner, "name", &value) == NO_ERROR)
-	    {
-	      if (DB_VALUE_TYPE (&value) == DB_TYPE_STRING && db_get_string (&value) != NULL)
-		{
-		  if (ctxt.is_dba_user || ctxt.is_dba_group_member)
-		    {
-		      output_ctx ("call [change_owner]('%s', '%s') on class [db_root];\n",
-				  sm_remove_qualifier_name (classname), db_get_string (&value));
-		    }
-		}
-	      db_value_clear (&value);
-	    }
-	}
-    }
 }
 
 /*
@@ -1592,36 +1554,6 @@ emit_schema (extract_context & ctxt, print_output & output_ctx, EXTRACT_CLASS_TY
 	{
 	  emit_class_meta (output_ctx, cl->op);
 	}
-
-      /*
-       * Before version 11.2, if an auto_increment column was added after changing the class owner,
-       * owner mismatch occurred.
-       * 
-       * e.g. create user u1;
-       *      create table t1;
-       *      call change_owner ('t1', 'u1') on class db_root;
-       *      alter table t1 add attribute c1 int auto_increment;
-       *      select c.clasS_name, c.owner.name, s.name, s.owner.name
-       *      from _db_class c, db_serial s
-       *      where c.class_name = s.class_name;
-       *
-       *        class_name            owner.name            name                  owner.name
-       *      ========================================================================================
-       *        't1'                  'U1'                  't1_ai_c1'            'DBA'
-       *
-       * After version 11.2, when adding an auto_increment column, there is no problem
-       * because it sets the owner in unique_name.
-       * 
-       * There is a problem if the DBA does not change the owner immediately when creating multiple classes
-       * with the same name. This is because a DBA cannot own multiple classes with the same name at the same time.
-       * Therefore, the owner must be changed immediately after class creation.
-       */
-#if 0
-      if (ctxt.do_auth)
-	{
-	  emit_class_owner (ctxt, output_ctx, cl->op);
-	}
-#endif
     }
 }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24974

In the unloaded schema file, tables and views owned by dba are created and the owner is changed. If the dba and the user own a table or view with the same name, an error occurs when loading. To prevent errors from occurring, the dba should not temporarily own tables and views.

**AS-IS**
```
CREATE CLASS [t1] REUSE_OID, COLLATE utf8_bin;
call [change_owner]('t1', 'U1') on class [db_root];

CREATE CLASS [v1] REUSE_OID, COLLATE utf8_bin;
call [change_owner]('v1', 'U1') on class [db_root];
```

**TO-BE**
```
CREATE CLASS [u1].[t1] REUSE_OID, COLLATE utf8_bin;

CREATE CLASS [u1].[v1] REUSE_OID, COLLATE utf8_bin;
```