### PR TITLE
[LETS-748] Add the request to get log pages to catch up with

### DIFF
--- a/src/communication/request_sync_client_server.hpp
+++ b/src/communication/request_sync_client_server.hpp
@@ -157,7 +157,6 @@ namespace cubcomm
   , m_incoming_response_msgid { a_incoming_response_msgid }
   , m_response_broker { response_partition_count, NO_ERRORS, ERROR_ON_WRITE }
   {
-    assert (a_incoming_request_handlers.size () > 0);
     for (const auto &pair: a_incoming_request_handlers)
       {
 	assert (static_cast<bool> (pair.second));

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -404,10 +404,6 @@ page_server::follower_connection_handler::follower_connection_handler (cubcomm::
   m_conn.reset (new follower_server_conn_t (std::move (chn),
   {
     {
-      follower_to_followee_request::SEND_DUMMY,
-      std::bind (&page_server::follower_connection_handler::receive_dummy_request, std::ref (*this), std::placeholders::_1)
-    },
-    {
       follower_to_followee_request::SEND_LOG_PAGES_FETCH,
       std::bind (&page_server::follower_connection_handler::receive_log_pages_fetch, std::ref (*this), std::placeholders::_1)
     },
@@ -801,9 +797,6 @@ page_server::connect_to_followee_page_server (std::string &&hostname, int32_t po
   er_log_debug (ARG_FILE_LINE,
 		"This page server successfully connected to the followee page server to catch up. Channel id: %s.\n",
 		srv_chn.get_channel_id ().c_str ());
-
-  // TODO remove it. Just a test to make sure the connection works.
-  m_followee_conn->push_request (follower_to_followee_request::SEND_DUMMY, std::string (""));
 
   return NO_ERROR;
 }

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -218,6 +218,7 @@ page_server::connection_handler::receive_start_catch_up (tran_server_conn_t::seq
 
     assert (!log_Gl.hdr.append_lsa.is_null ());
     assert (!catchup_lsa.is_null ());
+    assert (catchup_lsa >= log_Gl.hdr.append_lsa);
 
     if (log_Gl.hdr.append_lsa == catchup_lsa)
       {
@@ -227,7 +228,7 @@ page_server::connection_handler::receive_start_catch_up (tran_server_conn_t::seq
 
     constexpr int MAX_PAGE_REQUEST_CNT_AT_ONCE = 10; // Arbitrarily chosen
     const LOG_PAGEID start_pageid = log_Gl.hdr.append_lsa.pageid;
-    const LOG_PAGEID end_pageid = catchup_lsa.pageid;
+    const LOG_PAGEID end_pageid = catchup_lsa.offset == 0 ? catchup_lsa.pageid - 1 : catchup_lsa.pageid;
     const size_t total_page_count = end_pageid - start_pageid + 1;
 
     _er_log_debug (ARG_FILE_LINE, "[CATCH-UP] The catch-up pages range from %lld to %lld, count = %lld.\n",

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -376,13 +376,9 @@ page_server::follower_connection_handler::follower_connection_handler (cubcomm::
   m_conn.reset (new follower_server_conn_t (std::move (chn),
   {
     {
-      follower_to_followee_request::SEND_DISCONNECT,
-      std::bind (&page_server::follower_connection_handler::receive_disconnect_request, std::ref (*this), std::placeholders::_1)
+      follower_to_followee_request::SEND_DUMMY,
+      std::bind (&page_server::follower_connection_handler::receive_dummy_request, std::ref (*this), std::placeholders::_1)
     },
-    {
-      follower_to_followee_request::SEND_LOG_PAGES_FETCH,
-      std::bind (&page_server::follower_connection_handler::receive_log_pages_fetch, std::ref (*this), std::placeholders::_1)
-    }
   },
   followee_to_follower_request::RESPOND,
   follower_to_followee_request::RESPOND,
@@ -392,24 +388,12 @@ page_server::follower_connection_handler::follower_connection_handler (cubcomm::
   m_conn->start ();
 }
 
-void page_server::follower_connection_handler::receive_disconnect_request (follower_server_conn_t::sequenced_payload
+void page_server::follower_connection_handler::receive_dummy_request (follower_server_conn_t::sequenced_payload
     &&a_sp)
 {
   // TODO release the resouce of this connection_handler
-  er_log_debug (ARG_FILE_LINE, "A follower has requested to disconnect.");
+  er_log_debug (ARG_FILE_LINE, "A follower has requested a duumy request");
 }
-
-void page_server::follower_connection_handler::receive_log_pages_fetch (follower_server_conn_t::sequenced_payload
-    &&a_sp)
-{
-  follower_server_conn_t::sequenced_payload payload;
-  // TODO serve requeste log pages
-  er_log_debug (ARG_FILE_LINE, "A follower have requested some log pages.");
-
-  payload.push_payload ("Dummy reseponse");
-  m_conn->respond (std::move (payload));
-}
-
 
 page_server::followee_connection_handler::followee_connection_handler (cubcomm::channel &&chn, page_server &ps)
   : m_ps { ps }

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -222,7 +222,6 @@ page_server::connection_handler::receive_start_catch_up (tran_server_conn_t::seq
   m_ps.m_followee_conn->request_log_pages (catchup_lsa.pageid, 1, log_pgptrs);
 }
 
-
 void
 page_server::connection_handler::receive_log_boot_info_fetch (tran_server_conn_t::sequenced_payload &&a_sp)
 {
@@ -448,6 +447,17 @@ page_server::follower_connection_handler::receive_log_pages_fetch (follower_serv
 	}
     }
   sp_out.push_payload (std::move (payload_out));
+}
+
+template<class F, class ... Args>
+void
+page_server::follower_connection_handler::push_async_response (F &&a_func,
+    follower_server_conn_t::sequenced_payload &&a_sp,
+    Args &&... args)
+{
+  auto handler_func = std::bind (std::forward<F> (a_func), std::placeholders::_1, std::placeholders::_2,
+				 std::forward<Args> (args)...);
+  m_ps.get_responder ().async_execute (std::ref (*m_conn), std::move (a_sp), std::move (handler_func));
 }
 
 page_server::followee_connection_handler::followee_connection_handler (cubcomm::channel &&chn, page_server &ps)

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -225,7 +225,7 @@ page_server::connection_handler::receive_start_catch_up (tran_server_conn_t::seq
 	return; // TODO the cold-start case. No need to catch up.
       }
 
-    constexpr size_t MAX_PAGE_REQUEST_CNT_AT_ONCE = 10; // Arbitrarily chosen
+    constexpr int MAX_PAGE_REQUEST_CNT_AT_ONCE = 10; // Arbitrarily chosen
     const LOG_PAGEID start_pageid = log_Gl.hdr.append_lsa.pageid;
     const LOG_PAGEID end_pageid = catchup_lsa.pageid;
     const size_t total_page_count = end_pageid - start_pageid + 1;
@@ -233,7 +233,7 @@ page_server::connection_handler::receive_start_catch_up (tran_server_conn_t::seq
     _er_log_debug (ARG_FILE_LINE, "[CATCH-UP] The catch-up pages range from %lld to %lld, count = %lld.\n",
 		   start_pageid, end_pageid, total_page_count);
 
-    const size_t page_cnt_in_buffer = std::min (total_page_count, MAX_PAGE_REQUEST_CNT_AT_ONCE);
+    const int page_cnt_in_buffer = (int) std::min (total_page_count, (size_t) MAX_PAGE_REQUEST_CNT_AT_ONCE);
     const size_t buffer_size_in_total = page_cnt_in_buffer * LOG_PAGESIZE + MAX_ALIGNMENT;
 
     auto log_pgbuf_buffer = std::unique_ptr<char []> { new char[buffer_size_in_total] };
@@ -241,7 +241,7 @@ page_server::connection_handler::receive_start_catch_up (tran_server_conn_t::seq
     std::vector<LOG_PAGE *> log_pgptr_vec;
     char *log_pgptr = aligned_log_pgbuf;
 
-    for (size_t i = 0; i < page_cnt_in_buffer; i++)
+    for (int i = 0; i < page_cnt_in_buffer; i++)
       {
 	log_pgptr_vec.emplace_back (reinterpret_cast<LOG_PAGE *> (aligned_log_pgbuf + i * LOG_PAGESIZE));
       }
@@ -250,7 +250,7 @@ page_server::connection_handler::receive_start_catch_up (tran_server_conn_t::seq
     size_t remaining_page_cnt = total_page_count;
     while (remaining_page_cnt > 0)
       {
-	const size_t request_page_cnt = std::min (page_cnt_in_buffer, remaining_page_cnt);
+	const int request_page_cnt = (int) std::min ((size_t) page_cnt_in_buffer, remaining_page_cnt);
 	// TODO request next log pages asynchronously with std::async
 	const int error_code = m_ps.m_followee_conn->request_log_pages (request_start_pageid, request_page_cnt, log_pgptr_vec);
 	if (error_code != NO_ERROR)

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -482,10 +482,9 @@ page_server::follower_connection_handler::serve_log_pages (THREAD_ENTRY &, std::
 
   for (int i = 0; i < cnt; i++)
     {
-      const LOG_PAGEID log_pageid = start_pageid + i;
-      const log_lsa fetch_lsa { log_pageid, 0 };
+      const log_lsa fetch_lsa { start_pageid + i, 0 };
 
-      assert (log_pageid != LOGPB_HEADER_PAGE_ID);
+      assert (fetch_lsa.pageid != LOGPB_HEADER_PAGE_ID);
 
       error = lr.set_lsa_and_fetch_page (fetch_lsa);
 

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -391,7 +391,6 @@ page_server::follower_connection_handler::follower_connection_handler (cubcomm::
 void page_server::follower_connection_handler::receive_dummy_request (follower_server_conn_t::sequenced_payload
     &&a_sp)
 {
-  // TODO release the resouce of this connection_handler
   er_log_debug (ARG_FILE_LINE, "A follower has requested a duumy request");
 }
 
@@ -615,7 +614,6 @@ page_server::connect_to_followee_page_server (std::string &&hostname, int32_t po
   er_log_debug (ARG_FILE_LINE,
 		"This page server successfully connected to the followee page server to catch up. Channel id: %s.\n",
 		srv_chn.get_channel_id ().c_str ());
-
 
   // TODO remove it. Just a test to make sure the connection works.
   m_followee_conn->push_request (follower_to_followee_request::SEND_DUMMY, std::string (""));

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -616,6 +616,10 @@ page_server::connect_to_followee_page_server (std::string &&hostname, int32_t po
 		"This page server successfully connected to the followee page server to catch up. Channel id: %s.\n",
 		srv_chn.get_channel_id ().c_str ());
 
+
+  // TODO remove it. Just a test to make sure the connection works.
+  m_followee_conn->push_request (follower_to_followee_request::SEND_DUMMY, std::string (""));
+
   return NO_ERROR;
 }
 

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -242,6 +242,7 @@ page_server::connection_handler::receive_start_catch_up (tran_server_conn_t::seq
       assert_release (false);
     }
 
+  // TODO append received log pages to the log buffer
 }
 
 void
@@ -442,7 +443,7 @@ page_server::follower_connection_handler::serve_log_pages (THREAD_ENTRY &, std::
 
   // Pack the requested log pages
   int error = NO_ERROR;
-  payload_in_out = { reinterpret_cast<const char *> (&error), sizeof (error) };
+  payload_in_out = { reinterpret_cast<const char *> (&error), sizeof (error) }; // Pack NO_ERROR assuming it'll succeed.
   log_reader lr { LOG_CS_SAFE_READER };
 
   for (int i = 0; i < cnt; i++)
@@ -456,6 +457,7 @@ page_server::follower_connection_handler::serve_log_pages (THREAD_ENTRY &, std::
 
       if (error != NO_ERROR)
 	{
+	  // All or Nothing. Abandon all appended pages and just set the error.
 	  payload_in_out = { reinterpret_cast<const char *> (&error), sizeof (error) };
 	  break;
 	}

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -837,6 +837,13 @@ page_server::get_responder ()
   return *m_responder;
 }
 
+page_server::follower_responder_t &
+page_server::get_follower_responder ()
+{
+  assert (m_follower_responder);
+  return *m_follower_responder;
+}
+
 void
 page_server::push_request_to_active_tran_server (page_to_tran_request reqid, std::string &&payload)
 {
@@ -885,10 +892,12 @@ void
 page_server::init_request_responder ()
 {
   m_responder = std::make_unique<responder_t> ();
+  m_follower_responder = std::make_unique<follower_responder_t> ();
 }
 
 void
 page_server::finalize_request_responder ()
 {
   m_responder.reset (nullptr);
+  m_follower_responder.reset (nullptr);
 }

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -205,6 +205,8 @@ class page_server
 	void receive_dummy_request (follower_server_conn_t::sequenced_payload &&a_sp);  // TODO remove it
 	void receive_log_pages_fetch (follower_server_conn_t::sequenced_payload &&a_sp);
 
+	void serve_log_pages (THREAD_ENTRY &, std::string &payload_in_out);
+
 	// Helper function to convert above functions into responder specific tasks.
 	template<class F, class ... Args>
 	void push_async_response (F &&, follower_server_conn_t::sequenced_payload &&a_sp, Args &&...args);

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -207,10 +207,6 @@ class page_server
 
 	void serve_log_pages (THREAD_ENTRY &, std::string &payload_in_out);
 
-	// Helper function to convert above functions into responder specific tasks.
-	template<class F, class ... Args>
-	void push_async_response (F &&, follower_server_conn_t::sequenced_payload &&a_sp, Args &&...args);
-
 	page_server &m_ps;
 	std::unique_ptr<follower_server_conn_t> m_conn;
     };

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -176,6 +176,48 @@ class page_server
     using connection_handler_uptr_t = std::unique_ptr<connection_handler>;
 
     /*
+     * TODO
+     * 1. catchup diagram and explaination.
+     * 2. take it out of page_server? then I think we should take all connection_handlers out of servers and put them together.
+     *
+     */
+    class follower_connection_handler
+    {
+      public:
+	using followee_server_conn_t =
+		cubcomm::request_sync_client_server<followee_to_follower_request, follower_to_followee_request, std::string>;
+
+	follower_connection_handler () = delete;
+	follower_connection_handler (cubcomm::channel &chn);
+
+	follower_connection_handler (const connection_handler &) = delete;
+	follower_connection_handler (connection_handler &&) = delete;
+
+	~follower_connection_handler ();
+
+	follower_connection_handler &operator= (const connection_handler &) = delete;
+	follower_connection_handler &operator= (connection_handler &&) = delete;
+    };
+
+    class followee_connection_handler
+    {
+      public:
+	using follower_server_conn_t =
+		cubcomm::request_sync_client_server<follower_to_followee_request, followee_to_follower_request, std::string>;
+
+	followee_connection_handler () = delete;
+	followee_connection_handler (cubcomm::channel &chn);
+
+	followee_connection_handler (const connection_handler &) = delete;
+	followee_connection_handler (connection_handler &&) = delete;
+
+	~followee_connection_handler ();
+
+	followee_connection_handler &operator= (const connection_handler &) = delete;
+	followee_connection_handler &operator= (connection_handler &&) = delete;
+    };
+
+    /*
      * helper class to track the active oldest mvccids of each Page Transaction Server.
      * This provides the globally oldest active mvcc id to the vacuum on ATS.
      * The vacuum has to take mvcc status of all PTSes into considerations,

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -202,8 +202,7 @@ class page_server
 	follower_connection_handler &operator= (connection_handler &&) = delete;
 
       private:
-	void receive_disconnect_request (follower_server_conn_t::sequenced_payload &&a_sp);
-	void receive_log_pages_fetch (follower_server_conn_t::sequenced_payload &&a_sp);
+	void receive_dummy_request (follower_server_conn_t::sequenced_payload &&a_sp);  // TODO remove it
 
 	page_server &m_ps;
 	std::unique_ptr<follower_server_conn_t> m_conn;

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -199,6 +199,8 @@ class page_server
 	follower_connection_handler &operator= (const connection_handler &) = delete;
 	follower_connection_handler &operator= (connection_handler &&) = delete;
 
+	~follower_connection_handler ();
+
       private:
 	void receive_dummy_request (follower_server_conn_t::sequenced_payload &&a_sp);  // TODO remove it
 	void receive_log_pages_fetch (follower_server_conn_t::sequenced_payload &&a_sp);

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -181,10 +181,7 @@ class page_server
     };
 
     /*
-     * TODO
-     * 1. catchup diagram and explaination.
-     * 2. take it out of page_server? then I think we should take all connection_handlers out of servers and put them together.
-     *
+     *  TODO add some explanation and diagrams for this.
      */
     class follower_connection_handler
     {

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -203,6 +203,10 @@ class page_server
 	void receive_dummy_request (follower_server_conn_t::sequenced_payload &&a_sp);  // TODO remove it
 	void receive_log_pages_fetch (follower_server_conn_t::sequenced_payload &&a_sp);
 
+	// Helper function to convert above functions into responder specific tasks.
+	template<class F, class ... Args>
+	void push_async_response (F &&, follower_server_conn_t::sequenced_payload &&a_sp, Args &&...args);
+
 	page_server &m_ps;
 	std::unique_ptr<follower_server_conn_t> m_conn;
     };

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -126,7 +126,7 @@ class page_server
 	connection_handler &operator= (const connection_handler &) = delete;
 	connection_handler &operator= (connection_handler &&) = delete;
 
-	void push_request (page_to_tran_request id, std::string msg);
+	void push_request (page_to_tran_request id, std::string &&msg);
 	const std::string &get_connection_id () const;
 
 	void remove_prior_sender_sink ();
@@ -202,6 +202,9 @@ class page_server
 	follower_connection_handler &operator= (connection_handler &&) = delete;
 
       private:
+	void receive_disconnect_request (follower_server_conn_t::sequenced_payload &&a_sp);
+	void receive_log_pages_fetch (follower_server_conn_t::sequenced_payload &&a_sp);
+
 	page_server &m_ps;
 	std::unique_ptr<follower_server_conn_t> m_conn;
     };
@@ -221,10 +224,10 @@ class page_server
 	followee_connection_handler &operator= (const connection_handler &) = delete;
 	followee_connection_handler &operator= (connection_handler &&) = delete;
 
-	void push_request (page_to_tran_request id, std::string msg);
-	int send_receive (tran_to_page_request reqid, std::string &&payload_in, std::string &payload_out);
-
       private:
+	void push_request (follower_to_followee_request reqid, std::string &&msg);
+	int send_receive (follower_to_followee_request reqid, std::string &&payload_in, std::string &payload_out);
+
 	page_server &m_ps;
 	std::unique_ptr<followee_server_conn_t> m_conn;
     };

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -101,7 +101,6 @@ class page_server
     int connect_to_followee_page_server (std::string &&hostname, int32_t port);
 
     void push_request_to_active_tran_server (page_to_tran_request reqid, std::string &&payload);
-
     cublog::replicator &get_replicator ();
     void start_log_replicator (const log_lsa &start_lsa);
     void finish_replication_during_shutdown (cubthread::entry &thread_entry);

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -202,7 +202,6 @@ class page_server
 	~follower_connection_handler ();
 
       private:
-	void receive_dummy_request (follower_server_conn_t::sequenced_payload &&a_sp);  // TODO remove it
 	void receive_log_pages_fetch (follower_server_conn_t::sequenced_payload &&a_sp);
 
 	void serve_log_pages (THREAD_ENTRY &, std::string &payload_in_out);

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -110,7 +110,7 @@ class page_server
 		cubcomm::request_sync_client_server<page_to_tran_request, tran_to_page_request, std::string>;
 
 	connection_handler () = delete;
-	connection_handler (cubcomm::channel &chn, transaction_server_type server_type, page_server &ps);
+	connection_handler (cubcomm::channel &&chn, transaction_server_type server_type, page_server &ps);
 
 	connection_handler (const connection_handler &) = delete;
 	connection_handler (connection_handler &&) = delete;
@@ -188,15 +188,19 @@ class page_server
 		cubcomm::request_sync_client_server<followee_to_follower_request, follower_to_followee_request, std::string>;
 
 	follower_connection_handler () = delete;
-	follower_connection_handler (cubcomm::channel &chn);
+	follower_connection_handler (cubcomm::channel &&chn, page_server &ps);
 
 	follower_connection_handler (const connection_handler &) = delete;
 	follower_connection_handler (connection_handler &&) = delete;
 
-	~follower_connection_handler ();
-
 	follower_connection_handler &operator= (const connection_handler &) = delete;
 	follower_connection_handler &operator= (connection_handler &&) = delete;
+
+	void push_request (page_to_tran_request id, std::string msg);
+	int send_receive (tran_to_page_request reqid, std::string &&payload_in, std::string &payload_out);
+
+      private:
+	page_server &m_ps;
     };
 
     class followee_connection_handler
@@ -206,15 +210,16 @@ class page_server
 		cubcomm::request_sync_client_server<follower_to_followee_request, followee_to_follower_request, std::string>;
 
 	followee_connection_handler () = delete;
-	followee_connection_handler (cubcomm::channel &chn);
+	followee_connection_handler (cubcomm::channel &&chn, page_server &ps);
 
 	followee_connection_handler (const connection_handler &) = delete;
 	followee_connection_handler (connection_handler &&) = delete;
 
-	~followee_connection_handler ();
-
 	followee_connection_handler &operator= (const connection_handler &) = delete;
 	followee_connection_handler &operator= (connection_handler &&) = delete;
+
+      private:
+	page_server &m_ps;
     };
 
     /*

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -223,10 +223,10 @@ class page_server
 	followee_connection_handler &operator= (const connection_handler &) = delete;
 	followee_connection_handler &operator= (connection_handler &&) = delete;
 
-      private:
 	void push_request (follower_to_followee_request reqid, std::string &&msg);
 	int send_receive (follower_to_followee_request reqid, std::string &&payload_in, std::string &payload_out);
 
+      private:
 	page_server &m_ps;
 	std::unique_ptr<followee_server_conn_t> m_conn;
     };

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -101,6 +101,7 @@ class page_server
     int connect_to_followee_page_server (std::string &&hostname, int32_t port);
 
     void push_request_to_active_tran_server (page_to_tran_request reqid, std::string &&payload);
+
     cublog::replicator &get_replicator ();
     void start_log_replicator (const log_lsa &start_lsa);
     void finish_replication_during_shutdown (cubthread::entry &thread_entry);
@@ -201,6 +202,8 @@ class page_server
       private:
 	void receive_dummy_request (follower_server_conn_t::sequenced_payload &&a_sp);  // TODO remove it
 
+	void receive_log_pages_fetch (follower_server_conn_t::sequenced_payload &&a_sp);
+
 	page_server &m_ps;
 	std::unique_ptr<follower_server_conn_t> m_conn;
     };
@@ -222,6 +225,8 @@ class page_server
 
 	void push_request (follower_to_followee_request reqid, std::string &&msg);
 	int send_receive (follower_to_followee_request reqid, std::string &&payload_in, std::string &payload_out);
+
+	int request_log_pages (LOG_PAGEID start_pageid, int count, std::vector<LOG_PAGE *> log_pages_out);
 
       private:
 	page_server &m_ps;

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -189,7 +189,7 @@ class page_server
     class follower_connection_handler
     {
       public:
-	using followee_server_conn_t =
+	using follower_server_conn_t =
 		cubcomm::request_sync_client_server<followee_to_follower_request, follower_to_followee_request, std::string>;
 
 	follower_connection_handler () = delete;
@@ -201,17 +201,15 @@ class page_server
 	follower_connection_handler &operator= (const connection_handler &) = delete;
 	follower_connection_handler &operator= (connection_handler &&) = delete;
 
-	void push_request (page_to_tran_request id, std::string msg);
-	int send_receive (tran_to_page_request reqid, std::string &&payload_in, std::string &payload_out);
-
       private:
 	page_server &m_ps;
+	std::unique_ptr<follower_server_conn_t> m_conn;
     };
 
     class followee_connection_handler
     {
       public:
-	using follower_server_conn_t =
+	using followee_server_conn_t =
 		cubcomm::request_sync_client_server<follower_to_followee_request, followee_to_follower_request, std::string>;
 
 	followee_connection_handler () = delete;
@@ -223,8 +221,12 @@ class page_server
 	followee_connection_handler &operator= (const connection_handler &) = delete;
 	followee_connection_handler &operator= (connection_handler &&) = delete;
 
+	void push_request (page_to_tran_request id, std::string msg);
+	int send_receive (tran_to_page_request reqid, std::string &&payload_in, std::string &payload_out);
+
       private:
 	page_server &m_ps;
+	std::unique_ptr<followee_server_conn_t> m_conn;
     };
 
     /*
@@ -283,8 +285,8 @@ class page_server
     async_disconnect_handler<connection_handler> m_async_disconnect_handler;
     pts_mvcc_tracker m_pts_mvcc_tracker;
 
-    follower_connection_handler_uptr_t m_follower_conn;
-    std::vector<followee_connection_handler_uptr_t> m_followee_conn_vec;
+    followee_connection_handler_uptr_t m_followee_conn;
+    std::vector<follower_connection_handler_uptr_t> m_follower_conn_vec;
 };
 
 #endif // !_PAGE_SERVER_HPP_

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -229,7 +229,7 @@ class page_server
 	void push_request (follower_to_followee_request reqid, std::string &&msg);
 	int send_receive (follower_to_followee_request reqid, std::string &&payload_in, std::string &payload_out);
 
-	int request_log_pages (LOG_PAGEID start_pageid, int count, std::vector<LOG_PAGE *> log_pages_out);
+	int request_log_pages (LOG_PAGEID start_pageid, int count, std::vector<LOG_PAGE *> &log_pages_out);
 
       private:
 	page_server &m_ps;

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -266,12 +266,14 @@ class page_server
     using followee_connection_handler_uptr_t = std::unique_ptr<followee_connection_handler>;
 
     using responder_t = server_request_responder<connection_handler::tran_server_conn_t>;
+    using follower_responder_t = server_request_responder<follower_connection_handler::follower_server_conn_t>;
 
   private: // functions that depend on private types
     void disconnect_active_tran_server ();
     void disconnect_tran_server_async (const connection_handler *conn);
     bool is_active_tran_server_connected () const;
     responder_t &get_responder ();
+    follower_responder_t &get_follower_responder ();
 
   private: // members
     const std::string m_server_name;
@@ -284,6 +286,7 @@ class page_server
     std::unique_ptr<cublog::replicator> m_replicator;
 
     std::unique_ptr<responder_t> m_responder;
+    std::unique_ptr<follower_responder_t> m_follower_responder;
 
     async_disconnect_handler<connection_handler> m_async_disconnect_handler;
     pts_mvcc_tracker m_pts_mvcc_tracker;

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -173,7 +173,6 @@ class page_server
 	std::mutex m_abnormal_tran_server_disconnect_mtx;
 	bool m_abnormal_tran_server_disconnect;
     };
-    using connection_handler_uptr_t = std::unique_ptr<connection_handler>;
 
     /*
      * TODO
@@ -250,6 +249,10 @@ class page_server
 	std::unordered_map<std::string, MVCCID> m_pts_oldest_active_mvccids;
 	std::mutex m_pts_oldest_active_mvccids_mtx;
     };
+  private:
+    using connection_handler_uptr_t = std::unique_ptr<connection_handler>;
+    using follower_connection_handler_uptr_t = std::unique_ptr<follower_connection_handler>;
+    using followee_connection_handler_uptr_t = std::unique_ptr<followee_connection_handler>;
 
     using responder_t = server_request_responder<connection_handler::tran_server_conn_t>;
 
@@ -271,6 +274,9 @@ class page_server
 
     async_disconnect_handler<connection_handler> m_async_disconnect_handler;
     pts_mvcc_tracker m_pts_mvcc_tracker;
+
+    follower_connection_handler_uptr_t m_follower_conn;
+    std::vector<followee_connection_handler_uptr_t> m_followee_conn_vec;
 };
 
 #endif // !_PAGE_SERVER_HPP_

--- a/src/server/server_request_responder.hpp
+++ b/src/server/server_request_responder.hpp
@@ -163,7 +163,7 @@ template<typename T_CONN>
 server_request_responder<T_CONN>::server_request_responder ()
   : m_threads_context_manager (std::make_unique<cubthread::system_worker_entry_manager> (TT_SYSTEM_WORKER))
 {
-  const auto THREAD_COUNT = std::thread::hardware_concurrency ();
+  const auto THREAD_COUNT = 4;// std::thread::hardware_concurrency ();
   const auto TASK_MAX_COUNT = THREAD_COUNT * 4;
 
   m_threads = cubthread::get_manager ()->create_worker_pool (THREAD_COUNT, TASK_MAX_COUNT, "server_request_responder",

--- a/src/server/server_request_responder.hpp
+++ b/src/server/server_request_responder.hpp
@@ -163,7 +163,8 @@ template<typename T_CONN>
 server_request_responder<T_CONN>::server_request_responder ()
   : m_threads_context_manager (std::make_unique<cubthread::system_worker_entry_manager> (TT_SYSTEM_WORKER))
 {
-  const auto THREAD_COUNT = 4;// std::thread::hardware_concurrency ();
+  const auto THREAD_COUNT = 4; // std::thread::hardware_concurrency ();
+  // TODO configurable and register it to cubthread::manager (set_max_thread_count_from_config)
   const auto TASK_MAX_COUNT = THREAD_COUNT * 4;
 
   m_threads = cubthread::get_manager ()->create_worker_pool (THREAD_COUNT, TASK_MAX_COUNT, "server_request_responder",

--- a/src/server/tran_page_requests.hpp
+++ b/src/server/tran_page_requests.hpp
@@ -65,7 +65,7 @@ enum class follower_to_followee_request
   SEND_DUMMY, // TODO for test. remove it.
 
   // TODO SEND_DISCONNECT, /* response-less */
-  // TODO SEND_LOG_PAGES_FETCH, /* synchronously waiting for response */
+  SEND_LOG_PAGES_FETCH, /* synchronously waiting for response */
 };
 
 // requets from page server to page server to catchup

--- a/src/server/tran_page_requests.hpp
+++ b/src/server/tran_page_requests.hpp
@@ -62,8 +62,6 @@ enum class follower_to_followee_request
   // Reserve for responses
   RESPOND,
 
-  SEND_DUMMY, // TODO for test. remove it.
-
   // TODO SEND_DISCONNECT, /* response-less */
   SEND_LOG_PAGES_FETCH, /* synchronously waiting for response */
 };

--- a/src/server/tran_page_requests.hpp
+++ b/src/server/tran_page_requests.hpp
@@ -62,8 +62,10 @@ enum class follower_to_followee_request
   // Reserve for responses
   RESPOND,
 
-  SEND_DISCONNECT, /* response-less */
-  SEND_LOG_PAGES_FETCH, /* synchronously waiting for response */
+  SEND_DUMMY, // TODO for test. remove it.
+
+  // TODO SEND_DISCONNECT, /* response-less */
+  // TODO SEND_LOG_PAGES_FETCH, /* synchronously waiting for response */
 };
 
 // to catch up from PS to PS

--- a/src/server/tran_page_requests.hpp
+++ b/src/server/tran_page_requests.hpp
@@ -56,16 +56,26 @@ enum class page_to_tran_request
   SEND_TO_PTS_LOG_PRIOR_LIST, /* response-less */
 };
 
-enum class page_to_page_catchup_request
+// to catch up from PS to PS
+enum class follower_to_followee_request
 {
   // Reserve for responses
   RESPOND,
 
-  SEND_DUMMY_REQUEST,
+  SEND_DUMMY_PUSH_REQUEST,
+  SEND_DUMMY_SEND_RECV_REQUEST,
 
-  // followee only
   // TODO SEND_DISCONNECT, /* response-less */
   // TODO SEND_LOG_PAGES_FETCH, /* synchronously waiting for response */
+};
+
+// to catch up from PS to PS
+enum class followee_to_follower_request
+{
+  // Reserve for responses
+  RESPOND,
+
+  // followee doesn't request
 };
 
 #endif // !_TRAN_PAGE_REQUESTS_HPP_

--- a/src/server/tran_page_requests.hpp
+++ b/src/server/tran_page_requests.hpp
@@ -56,5 +56,17 @@ enum class page_to_tran_request
   SEND_TO_PTS_LOG_PRIOR_LIST, /* response-less */
 };
 
+enum class page_to_page_catchup_request
+{
+  // Reserve for responses
+  RESPOND,
+
+  SEND_DUMMY_REQUEST,
+
+  // followee only
+  // TODO SEND_DISCONNECT, /* response-less */
+  // TODO SEND_LOG_PAGES_FETCH, /* synchronously waiting for response */
+};
+
 #endif // !_TRAN_PAGE_REQUESTS_HPP_
 

--- a/src/server/tran_page_requests.hpp
+++ b/src/server/tran_page_requests.hpp
@@ -56,7 +56,7 @@ enum class page_to_tran_request
   SEND_TO_PTS_LOG_PRIOR_LIST, /* response-less */
 };
 
-// to catch up from PS to PS
+// requets from page server to page server to catchup
 enum class follower_to_followee_request
 {
   // Reserve for responses
@@ -68,7 +68,7 @@ enum class follower_to_followee_request
   // TODO SEND_LOG_PAGES_FETCH, /* synchronously waiting for response */
 };
 
-// to catch up from PS to PS
+// requets from page server to page server to catchup
 enum class followee_to_follower_request
 {
   // Reserve for responses

--- a/src/server/tran_page_requests.hpp
+++ b/src/server/tran_page_requests.hpp
@@ -62,11 +62,8 @@ enum class follower_to_followee_request
   // Reserve for responses
   RESPOND,
 
-  SEND_DUMMY_PUSH_REQUEST,
-  SEND_DUMMY_SEND_RECV_REQUEST,
-
-  // TODO SEND_DISCONNECT, /* response-less */
-  // TODO SEND_LOG_PAGES_FETCH, /* synchronously waiting for response */
+  SEND_DISCONNECT, /* response-less */
+  SEND_LOG_PAGES_FETCH, /* synchronously waiting for response */
 };
 
 // to catch up from PS to PS

--- a/src/server/tran_page_requests.hpp
+++ b/src/server/tran_page_requests.hpp
@@ -56,7 +56,7 @@ enum class page_to_tran_request
   SEND_TO_PTS_LOG_PRIOR_LIST, /* response-less */
 };
 
-// requets from page server to page server to catchup
+// requests from page server to page server to catchup
 enum class follower_to_followee_request
 {
   // Reserve for responses
@@ -66,7 +66,7 @@ enum class follower_to_followee_request
   SEND_LOG_PAGES_FETCH, /* synchronously waiting for response */
 };
 
-// requets from page server to page server to catchup
+// requests from page server to page server to catchup
 enum class followee_to_follower_request
 {
   // Reserve for responses


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-748

- `follower_responder_t`: is used to respond to the requests for the catch-up. I was not going to use this and make the catch-up communication sequential, but I've decided to use it. It is useful in that 
  - The follower can disconnect instantly while the catch-up is in progress.
  - The `thread::entry` is required to fetch log pages in followee, and workers in the `server_request_responder` has its entry.
  - I tried to integrate two `server_request_responder`s (for TS-PS and PS-PS), but I failed. Now, we have several connection_handlers and responders so we may need to refactor them. Welcome to any opinion on it. 
- Requests are sent in one direction (follower -> followee)
  - `request_log_pages()`: a follower requests multiple log pages for the catch up. 
  - DISCONNECT: TODO in the following PR.
  - `receive_log_pages_fetch()`: a follwee serves multiple log pages. It uses `serve_log_pages` internally.
- Now the log pages are requested in `receive_start_catch_up()`.
  - It will be moved in another dedicated thread in near future. We can implement some details then, but I've implemented it to test various cases to confirm the request works well. It's going to be revised more in the future. 
  - It allocates a huge buffer containing several pages (now 10 at most).
  - It requests pages in units of the buffer, ends up getting all the pages from `log_Gl.hdr.append_lsa.pageid` to `catchup_lsa.pageid`.
- I have confirmed that it can fetch multiple pages including ones in archives.   
