### PR TITLE
[CBRD-24905] The problem is that a core dump occurs when a value of an invalid index type (such as Collection Type) is bound to host variables (#4614)

### DIFF
--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -1496,6 +1496,7 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
   bool need_new_setdomain = false;
   TP_DOMAIN *idx_setdomain = NULL, *vals_setdomain = NULL;
   TP_DOMAIN *idx_dom = NULL, *val_dom = NULL, *dom = NULL, *next = NULL;
+  DB_TYPE idx_type_id;
   TP_DOMAIN dom_buf;
   DB_VALUE *coerced_values = NULL;
   bool *has_coerced_values = NULL;
@@ -1573,7 +1574,16 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
 	    }
 	}
 
+      idx_type_id = TP_DOMAIN_TYPE (idx_dom);
       val_type_id = DB_VALUE_DOMAIN_TYPE (val);
+
+      if (!tp_valid_indextype (val_type_id))
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_TP_CANT_COERCE, 2, pr_type_name (idx_type_id),
+		  pr_type_name (val_type_id));
+	  goto err_exit;
+	}
+
       if (TP_IS_STRING_TYPE (val_type_id))
 	{
 	  /* we need to check for maxes */
@@ -1588,7 +1598,7 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
 	    }
 	}
 
-      if (TP_DOMAIN_TYPE (idx_dom) != val_type_id)
+      if (idx_type_id != val_type_id)
 	{
 	  /* allocate DB_VALUE array to store coerced values. */
 	  if (has_coerced_values == NULL)
@@ -1623,8 +1633,8 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
 	      has_coerced_values[i] = true;
 	    }
 	}
-      else if (TP_DOMAIN_TYPE (idx_dom) == DB_TYPE_NUMERIC || TP_DOMAIN_TYPE (idx_dom) == DB_TYPE_CHAR
-	       || TP_DOMAIN_TYPE (idx_dom) == DB_TYPE_BIT || TP_DOMAIN_TYPE (idx_dom) == DB_TYPE_NCHAR)
+      else if (idx_type_id == DB_TYPE_NUMERIC || idx_type_id == DB_TYPE_CHAR || idx_type_id == DB_TYPE_BIT
+	       || idx_type_id == DB_TYPE_NCHAR)
 	{
 	  /* skip variable string domain : DB_TYPE_VARCHAR, DB_TYPE_VARNCHAR, DB_TYPE_VARBIT */
 

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -18685,9 +18685,6 @@ btree_compare_key (DB_VALUE * key1, DB_VALUE * key2, TP_DOMAIN * key_domain, int
       assert (key1_type != DB_TYPE_MIDXKEY);
       assert (key2_type != DB_TYPE_MIDXKEY);
 
-      assert (tp_valid_indextype (key1_type));
-      assert (tp_valid_indextype (key2_type));
-
       /* safe code */
       if (key1_type == DB_TYPE_MIDXKEY)
 	{
@@ -18731,6 +18728,9 @@ btree_compare_key (DB_VALUE * key1, DB_VALUE * key2, TP_DOMAIN * key_domain, int
 	      return DB_UNK;
 	    }
 	}
+
+      assert (tp_valid_indextype (key1_type));
+      assert (tp_valid_indextype (key2_type));
 
       assert_release (c == DB_UNK || (DB_LT <= c && c <= DB_GT));
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24905

backport #4614