### PR TITLE
[CBRD-24946] field lookup failure when column name is of <table>.<column> form in the select list

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/jdbc/CUBRIDServerSideResultSet.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/jdbc/CUBRIDServerSideResultSet.java
@@ -453,7 +453,7 @@ public class CUBRIDServerSideResultSet implements ResultSet {
     public int findColumn(String columnName) throws SQLException {
         Integer index = statementHandler.getColNameIndex().get(columnName.toLowerCase());
         if (index == null) {
-            CUBRIDServerSideJDBCErrorManager.createCUBRIDException(
+            throw CUBRIDServerSideJDBCErrorManager.createCUBRIDException(
                     CUBRIDServerSideJDBCErrorCode.ER_INVALID_COLUMN_NAME, null);
         }
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -2417,8 +2417,11 @@ public class ParseTreeConverter extends PcsParserBaseVisitor<AstNode> {
         assert colName != null;
 
         int dotIdx = colName.lastIndexOf(".");
-        if (dotIdx > 0 && dotIdx < colName.length() - 1 && ci.className != null && ci.className.length() > 0 &&
-            ci.attrName != null) {
+        if (dotIdx > 0
+                && dotIdx < colName.length() - 1
+                && ci.className != null
+                && ci.className.length() > 0
+                && ci.attrName != null) {
 
             String afterDot = colName.substring(dotIdx + 1).toLowerCase();
             String attrName = ci.attrName.toLowerCase();
@@ -2482,7 +2485,9 @@ public class ParseTreeConverter extends PcsParserBaseVisitor<AstNode> {
                 if (old != null) {
                     throw new SemanticError(
                             Misc.getLineColumnOf(ctx), // s427
-                            String.format("more than one columns have the same name '%s' in the SELECT list", col));
+                            String.format(
+                                    "more than one columns have the same name '%s' in the SELECT list",
+                                    col));
                 }
             }
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -2412,6 +2412,25 @@ public class ParseTreeConverter extends PcsParserBaseVisitor<AstNode> {
         return ret;
     }
 
+    private String getColumnNameInSelectList(ColumnInfo ci) {
+        String colName = ci.colName;
+        assert colName != null;
+
+        int dotIdx = colName.lastIndexOf(".");
+        if (dotIdx > 0 && dotIdx < colName.length() - 1 && ci.className != null && ci.className.length() > 0 &&
+            ci.attrName != null) {
+
+            String afterDot = colName.substring(dotIdx + 1).toLowerCase();
+            String attrName = ci.attrName.toLowerCase();
+            if (afterDot.equals(attrName)) {
+                // In this case, colName must be of the form <table name alias>.<attr name>
+                return ci.attrName;
+            }
+        }
+
+        return colName;
+    }
+
     private StaticSql checkAndConvertStaticSql(SqlSemantics sws, ParserRuleContext ctx) {
 
         LinkedHashMap<Expr, TypeSpec> hostExprs = new LinkedHashMap<>();
@@ -2456,10 +2475,15 @@ public class ParseTreeConverter extends PcsParserBaseVisitor<AstNode> {
             for (ColumnInfo ci : sws.selectList) {
                 String sqlType = getSqlTypeNameFromCode(ci.type);
 
-                String col = Misc.getNormalizedText(ci.colName);
+                String col = Misc.getNormalizedText(getColumnNameInSelectList(ci));
                 TypeSpec typeSpec = typeSpecs.get(sqlType);
                 assert typeSpec != null;
-                selectList.put(col, typeSpec);
+                TypeSpec old = selectList.put(col, typeSpec);
+                if (old != null) {
+                    throw new SemanticError(
+                            Misc.getLineColumnOf(ctx), // s427
+                            String.format("more than one columns have the same name '%s' in the SELECT list", col));
+                }
             }
 
             // check (name-binding) and convert into-variables used in the SQL

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -2423,9 +2423,8 @@ public class ParseTreeConverter extends PcsParserBaseVisitor<AstNode> {
                 && ci.className.length() > 0
                 && ci.attrName != null) {
 
-            String afterDot = colName.substring(dotIdx + 1).toLowerCase();
-            String attrName = ci.attrName.toLowerCase();
-            if (afterDot.equals(attrName)) {
+            String afterDot = colName.substring(dotIdx + 1);
+            if (afterDot.equalsIgnoreCase(ci.attrName)) {
                 // In this case, colName must be of the form <table name alias>.<attr name>
                 return ci.attrName;
             }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
@@ -437,15 +437,17 @@ public class TypeChecker extends AstVisitor<TypeSpec> {
 
                 node.setType(ret);
 
-                int i = 1;
+                int i = 1, found = -1;
                 for (String c : declForRecord.fieldTypes.keySet()) {
                     if (c.equals(node.fieldName)) {
-                        break;
+                        assert found < 0;
+                        found = i;
                     }
                     i++;
                 }
-                assert i <= declForRecord.fieldTypes.size();
-                node.setColIndex(i);
+                assert found > 0;
+
+                node.setColIndex(found);
             }
         } else {
             // this record is for a dynamic SQL


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24946

* In such cases, we need to detach <table name alias>. from the beginning of the column name given by the server.
