### PR TITLE
[CBRD-24970] Sends the type of heterogeneous DBMS connected to the cu…

### DIFF
--- a/src/broker/cas.c
+++ b/src/broker/cas.c
@@ -870,7 +870,7 @@ cas_main (void)
   char tmp_name[SRV_CON_DBNAME_SIZE] = { 0, };
   char tmp_user[SRV_CON_DBUSER_SIZE] = { 0, };
   char tmp_passwd[SRV_CON_DBPASSWD_SIZE] = { 0, };
-  SUPPORTED_DBMS_TYPE dbms_type = NOT_SUPPORTED_DBMS;
+  T_DBMS_TYPE dbms_type = CAS_DBMS_NONE;
   char *find_gateway = NULL;
   char errplog_path[BROKER_PATH_MAX] = { 0, };
   char errlog_file[BROKER_PATH_MAX] = { 0, };
@@ -1273,7 +1273,7 @@ cas_main (void)
 	    strncpy (tmp_user, db_user, SRV_CON_DBUSER_SIZE);
 	    strncpy (tmp_passwd, db_passwd, SRV_CON_DBUSER_SIZE);
 
-	    if (dbms_type == SUPPORTED_DBMS_ORACLE)
+	    if (dbms_type == CAS_CGW_DBMS_ORACLE)
 	      {
 		snprintf (odbc_connect_url, CGW_LINK_URL_MAX_LEN, ORACLE_CONNECT_URL_FORMAT,
 			  shm_appl->cgw_link_odbc_driver_name,
@@ -1287,7 +1287,7 @@ cas_main (void)
 			  shm_appl->cgw_link_server_port,
 			  tmp_name, tmp_user, "********", shm_appl->cgw_link_connect_url_property);
 	      }
-	    else if (dbms_type == SUPPORTED_DBMS_MYSQL || dbms_type == SUPPORTED_DBMS_MARIADB)
+	    else if (dbms_type == CAS_CGW_DBMS_MYSQL || dbms_type == CAS_CGW_DBMS_MARIADB)
 	      {
 		snprintf (odbc_connect_url, CGW_LINK_URL_MAX_LEN, MYSQL_CONNECT_URL_FORMAT,
 			  shm_appl->cgw_link_odbc_driver_name,
@@ -1406,6 +1406,10 @@ cas_main (void)
 				   cas_default_isolation_level, cas_default_lock_timeout);
 
 	    as_info->cur_keep_con = shm_appl->keep_connection;
+#if defined(CAS_FOR_CGW)
+	    cas_bi_set_dbms_type (dbms_type);
+#endif /* CAS_FOR_MYSQL */
+
 	    cas_bi_set_statement_pooling (shm_appl->statement_pooling);
 	    if (shm_appl->statement_pooling)
 	      {

--- a/src/broker/cas_cgw.h
+++ b/src/broker/cas_cgw.h
@@ -98,14 +98,6 @@ typedef enum
   PLUS
 } SIGN;
 
-typedef enum
-{
-  SUPPORTED_DBMS_ORACLE = 0,
-  SUPPORTED_DBMS_MYSQL,
-  SUPPORTED_DBMS_MARIADB,
-  NOT_SUPPORTED_DBMS
-} SUPPORTED_DBMS_TYPE;
-
 typedef struct t_odbc_col_info T_ODBC_COL_INFO;
 struct t_odbc_col_info
 {
@@ -160,7 +152,7 @@ extern int cgw_get_stmt_handle (SQLHDBC hdbc, SQLHSTMT * stmt);
 extern int cgw_get_driver_info (SQLHDBC hdbc, SQLUSMALLINT info_type, void *driver_info, SQLSMALLINT size);
 
 // db connection functions
-extern int cgw_database_connect (SUPPORTED_DBMS_TYPE dbms_type, const char *connect_url, char *db_name, char *db_user,
+extern int cgw_database_connect (T_DBMS_TYPE dbms_type, const char *connect_url, char *db_name, char *db_user,
 				 char *db_passwd);
 extern void cgw_database_disconnect (void);
 extern int cgw_is_database_connected (void);
@@ -184,8 +176,8 @@ extern int cgw_cur_tuple (T_NET_BUF * net_buf, T_COL_BINDER * first_col_binding,
 extern int cgw_copy_tuple (T_COL_BINDER * src_col_binding, T_COL_BINDER * dst_col_binding);
 
 extern int cgw_endtran (SQLHDBC hdbc, int tran_type);
-extern SUPPORTED_DBMS_TYPE cgw_is_supported_dbms (char *dbms);
-extern void cgw_set_dbms_type (SUPPORTED_DBMS_TYPE dbms_type);
-extern SUPPORTED_DBMS_TYPE cgw_get_dbms_type ();
+extern T_DBMS_TYPE cgw_is_supported_dbms (char *dbms);
+extern void cgw_set_dbms_type (T_DBMS_TYPE dbms_type);
+extern T_DBMS_TYPE cgw_get_dbms_type ();
 
 #endif /* _CAS_CGW_H_ */

--- a/src/broker/cas_protocol.h
+++ b/src/broker/cas_protocol.h
@@ -270,12 +270,16 @@ extern "C"
 
   enum t_dbms_type
   {
+    CAS_DBMS_NONE = 0,
     CAS_DBMS_CUBRID = 1,
     CAS_DBMS_MYSQL = 2,
     CAS_DBMS_ORACLE = 3,
     CAS_PROXY_DBMS_CUBRID = 4,
     CAS_PROXY_DBMS_MYSQL = 5,
-    CAS_PROXY_DBMS_ORACLE = 6
+    CAS_PROXY_DBMS_ORACLE = 6,
+    CAS_CGW_DBMS_ORACLE = 7,
+    CAS_CGW_DBMS_MYSQL = 8,
+    CAS_CGW_DBMS_MARIADB = 9
   };
   typedef enum t_dbms_type T_DBMS_TYPE;
 #define IS_CONNECTED_TO_PROXY(type) \


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24970

Purpose
Add the DBMS type connected to dblink to the 1st byte of broker_info.
- CAS_CGW_DBMS_ORACLE
- CAS_CGW_DBMS_MYSQL
- CAS_CGW_DBMS_MARIADB

*DBMS Type will also be added to CCI's broker_cas_protocol.h.

Implementation
N/A

Remarks
N/A