### PR TITLE
[CBRD-24623] Changed so that the file can be found when specifying the file path of schema_info file in the --schema-file-list option.

### DIFF
--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -1406,7 +1406,7 @@ ldr_check_file_list (std::string & file_name, int &num_files, int &error_code)
   char buffer[PATH_MAX] = { 0, };
   std::string read_file_name = "";
   std::string schema_info_fullpath = "";
-  size_t last_backslash = 0;
+  size_t seperator_pos = 0;
 #if defined(WINDOWS)
   size_t last_slash = 0;
 #endif
@@ -1470,11 +1470,11 @@ ldr_check_file_list (std::string & file_name, int &num_files, int &error_code)
 
       strcpy (schema_object_file->schema_file_name, buffer);
 
-      last_backslash = schema_info_fullpath.find_last_of (PATH_SEPARATOR);
+      seperator_pos = schema_info_fullpath.find_last_of (PATH_SEPARATOR);
 
-      if (last_backslash == std::string::npos)
+      if (seperator_pos == std::string::npos)
 	{
-	  last_backslash = 0;
+	  seperator_pos = 0;
 	}
 
 #if defined(WINDOWS)
@@ -1485,31 +1485,21 @@ ldr_check_file_list (std::string & file_name, int &num_files, int &error_code)
 	  last_slash = 0;
 	}
 
-      if (last_slash > last_backslash)
+      if (last_slash > seperator_pos)
 	{
-	  schema_info_fullpath = schema_info_fullpath.substr (0, last_slash + 1);
-	  read_file_name = schema_info_fullpath + buffer;
-	}
-      else if (last_slash < last_backslash)
-	{
-	  schema_info_fullpath = schema_info_fullpath.substr (0, last_backslash + 1);
-	  read_file_name = schema_info_fullpath + buffer;
-	}
-      else
-	{
-	  read_file_name = buffer;
-	}
-#else
-      if (last_backslash > 0)
-	{
-	  schema_info_fullpath = schema_info_fullpath.substr (0, last_backslash + 1);
-	  read_file_name = schema_info_fullpath + buffer;
-	}
-      else
-	{
-	  read_file_name = buffer;
+	  seperator_pos = last_slash;
 	}
 #endif
+
+      if (seperator_pos > 0)
+	{
+	  schema_info_fullpath = schema_info_fullpath.substr (0, seperator_pos + 1);
+	  read_file_name = schema_info_fullpath + buffer;
+	}
+      else
+	{
+	  read_file_name = buffer;
+	}
 
       schema_object_file->schema_fp = ldr_check_file (read_file_name, error_code);
       if (error_code != NO_ERROR && schema_object_file->schema_fp == NULL)

--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -1405,6 +1405,8 @@ ldr_check_file_list (std::string & file_name, int &num_files, int &error_code)
   T_SCHEMA_FILE_LIST_INFO **new_schema_info = NULL;
   char buffer[PATH_MAX] = { 0, };
   std::string read_file_name = "";
+  std::string schema_info_fullpath = "";
+  size_t last_slash = 0;
 
   error_code = NO_ERROR;
 
@@ -1420,6 +1422,7 @@ ldr_check_file_list (std::string & file_name, int &num_files, int &error_code)
 
   while (fgets ((char *) buffer, LINE_MAX, schema_fp) != NULL)
     {
+      schema_info_fullpath = file_name;
       trim (buffer);
 
       if (buffer[0] == '\0')
@@ -1463,7 +1466,18 @@ ldr_check_file_list (std::string & file_name, int &num_files, int &error_code)
       num_files++;
 
       strcpy (schema_object_file->schema_file_name, buffer);
-      read_file_name = buffer;
+
+      last_slash = schema_info_fullpath.find_last_of (PATH_SEPARATOR);
+      if (last_slash != std::string::npos)
+	{
+	  schema_info_fullpath = schema_info_fullpath.substr (0, last_slash + 1);
+	  read_file_name = schema_info_fullpath + buffer;
+	}
+      else
+	{
+	  read_file_name = buffer;
+	}
+
       schema_object_file->schema_fp = ldr_check_file (read_file_name, error_code);
       if (error_code != NO_ERROR && schema_object_file->schema_fp == NULL)
 	{

--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -1406,7 +1406,10 @@ ldr_check_file_list (std::string & file_name, int &num_files, int &error_code)
   char buffer[PATH_MAX] = { 0, };
   std::string read_file_name = "";
   std::string schema_info_fullpath = "";
+  size_t last_backslash = 0;
+#if defined(WINDOWS)
   size_t last_slash = 0;
+#endif
 
   error_code = NO_ERROR;
 
@@ -1467,16 +1470,46 @@ ldr_check_file_list (std::string & file_name, int &num_files, int &error_code)
 
       strcpy (schema_object_file->schema_file_name, buffer);
 
-      last_slash = schema_info_fullpath.find_last_of (PATH_SEPARATOR);
-      if (last_slash != std::string::npos)
+      last_backslash = schema_info_fullpath.find_last_of (PATH_SEPARATOR);
+
+      if (last_backslash == std::string::npos)
+	{
+	  last_backslash = 0;
+	}
+
+#if defined(WINDOWS)
+      last_slash = schema_info_fullpath.find_last_of ('/');
+
+      if (last_slash == std::string::npos)
+	{
+	  last_slash = 0;
+	}
+
+      if (last_slash > last_backslash)
 	{
 	  schema_info_fullpath = schema_info_fullpath.substr (0, last_slash + 1);
+	  read_file_name = schema_info_fullpath + buffer;
+	}
+      else if (last_slash < last_backslash)
+	{
+	  schema_info_fullpath = schema_info_fullpath.substr (0, last_backslash + 1);
 	  read_file_name = schema_info_fullpath + buffer;
 	}
       else
 	{
 	  read_file_name = buffer;
 	}
+#else
+      if (last_backslash > 0)
+	{
+	  schema_info_fullpath = schema_info_fullpath.substr (0, last_backslash + 1);
+	  read_file_name = schema_info_fullpath + buffer;
+	}
+      else
+	{
+	  read_file_name = buffer;
+	}
+#endif
 
       schema_object_file->schema_fp = ldr_check_file (read_file_name, error_code);
       if (error_code != NO_ERROR && schema_object_file->schema_fp == NULL)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24623

Purpose
If you specify the path to demodb_schema_info in loaddb as shown below, the list of files in the demodb_schema_info file cannot be found. Modified so that it can be found in ./testdb/unload/ when looking for the file list.
--schema-file-list=./testdb/unload/demodb_schema_info

Implementation
N/A

Remarks
N/A