### PR TITLE
[CBRD-24950] Check runtime values assigned to a NOT NULL variable

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/DeclConst.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/DeclConst.java
@@ -69,9 +69,12 @@ public class DeclConst extends DeclIdTyped {
     @Override
     public String toJavaCode() {
         if (notNull) {
-            return String.format("final %s %s = checkNotNull(%s);", typeSpec.toJavaCode(), name, val.toJavaCode());
+            return String.format(
+                    "final %s %s = checkNotNull(%s);",
+                    typeSpec.toJavaCode(), name, val.toJavaCode());
         } else {
-            return String.format("final %s %s = %s;", typeSpec.toJavaCode(), name, val.toJavaCode());
+            return String.format(
+                    "final %s %s = %s;", typeSpec.toJavaCode(), name, val.toJavaCode());
         }
     }
 }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/DeclConst.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/DeclConst.java
@@ -68,10 +68,10 @@ public class DeclConst extends DeclIdTyped {
 
     @Override
     public String toJavaCode() {
-        return String.format("final %s %s = %s;", typeSpec.toJavaCode(), name, val.toJavaCode());
+        if (notNull) {
+            return String.format("final %s %s = checkNotNull(%s);", typeSpec.toJavaCode(), name, val.toJavaCode());
+        } else {
+            return String.format("final %s %s = %s;", typeSpec.toJavaCode(), name, val.toJavaCode());
+        }
     }
-
-    // --------------------------------------------------
-    // Private
-    // --------------------------------------------------
 }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/DeclVar.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/DeclVar.java
@@ -70,7 +70,11 @@ public class DeclVar extends DeclIdTyped {
         if (val == null) {
             return String.format("%s[] %s = new %s[] { null };", ty, name, ty);
         } else {
-            return String.format("%s[] %s = new %s[] { %s };", ty, name, ty, val.toJavaCode());
+            if (notNull) {
+                return String.format("%s[] %s = new %s[] { checkNotNull(%s) };", ty, name, ty, val.toJavaCode());
+            } else {
+                return String.format("%s[] %s = new %s[] { %s };", ty, name, ty, val.toJavaCode());
+            }
         }
     }
 }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/DeclVar.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/DeclVar.java
@@ -71,7 +71,8 @@ public class DeclVar extends DeclIdTyped {
             return String.format("%s[] %s = new %s[] { null };", ty, name, ty);
         } else {
             if (notNull) {
-                return String.format("%s[] %s = new %s[] { checkNotNull(%s) };", ty, name, ty, val.toJavaCode());
+                return String.format(
+                        "%s[] %s = new %s[] { checkNotNull(%s) };", ty, name, ty, val.toJavaCode());
             } else {
                 return String.format("%s[] %s = new %s[] { %s };", ty, name, ty, val.toJavaCode());
             }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprField.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprField.java
@@ -66,7 +66,8 @@ public class ExprField extends Expr {
             // record is for a Static SQL
             //
             assert type != null;
-            return String.format("(%s) %s.getObject(%d)", type.toJavaCode(), record.toJavaCode(), colIndex);
+            return String.format(
+                    "(%s) %s.getObject(%d)", type.toJavaCode(), record.toJavaCode(), colIndex);
         } else {
 
             // record is for a Dynamic SQL

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprField.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprField.java
@@ -66,7 +66,7 @@ public class ExprField extends Expr {
             // record is for a Static SQL
             //
             assert type != null;
-            return String.format("%s.%s(%d)", record.toJavaCode(), type.nameOfGetMethod, colIndex);
+            return String.format("(%s) %s.getObject(%d)", type.toJavaCode(), record.toJavaCode(), colIndex);
         } else {
 
             // record is for a Dynamic SQL

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/StmtAssign.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/StmtAssign.java
@@ -53,7 +53,7 @@ public class StmtAssign extends Stmt {
     @Override
     public String toJavaCode() {
 
-        boolean checkNotNull = (var.decl instanceof DeclVar) && ((DeclVar) var.decl).notNull; 
+        boolean checkNotNull = (var.decl instanceof DeclVar) && ((DeclVar) var.decl).notNull;
         if (checkNotNull) {
             return String.format("%s = checkNotNull(%s);", var.toJavaCode(), val.toJavaCode());
         } else {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/StmtAssign.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/StmtAssign.java
@@ -52,7 +52,13 @@ public class StmtAssign extends Stmt {
 
     @Override
     public String toJavaCode() {
-        return String.format("%s = %s;", var.toJavaCode(), val.toJavaCode());
+
+        boolean checkNotNull = (var.decl instanceof DeclVar) && ((DeclVar) var.decl).notNull; 
+        if (checkNotNull) {
+            return String.format("%s = checkNotNull(%s);", var.toJavaCode(), val.toJavaCode());
+        } else {
+            return String.format("%s = %s;", var.toJavaCode(), val.toJavaCode());
+        }
     }
 
     // --------------------------------------------------

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/StmtCursorFetch.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/StmtCursorFetch.java
@@ -102,7 +102,9 @@ public class StmtCursorFetch extends Stmt {
             if (columnTypeList == null) {
                 resultStr = String.format("rs.getObject(%d)", i + 1);
             } else {
-                resultStr = String.format("(%s) rs.getObject(%d)", columnTypeList.get(i).toJavaCode(), i + 1);
+                resultStr =
+                        String.format(
+                                "(%s) rs.getObject(%d)", columnTypeList.get(i).toJavaCode(), i + 1);
             }
 
             if (i > 0) {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/StmtCursorFetch.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/StmtCursorFetch.java
@@ -98,11 +98,12 @@ public class StmtCursorFetch extends Stmt {
         StringBuffer sbuf = new StringBuffer();
         for (ExprId id : intoVarList) {
 
-            String nameOfGetMethod =
-                    (columnTypeList == null)
-                            ? "getObject"
-                            : columnTypeList.get(i).getNameOfGetMethod();
-            String resultStr = String.format("rs.%s(%d)", nameOfGetMethod, i + 1);
+            String resultStr;
+            if (columnTypeList == null) {
+                resultStr = String.format("rs.getObject(%d)", i + 1);
+            } else {
+                resultStr = String.format("(%s) rs.getObject(%d)", columnTypeList.get(i).toJavaCode(), i + 1);
+            }
 
             if (i > 0) {
                 sbuf.append("\n");

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/StmtSql.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/StmtSql.java
@@ -161,7 +161,10 @@ public abstract class StmtSql extends Stmt {
             if (dynamic) {
                 resultStr = String.format("r%%'LEVEL'%%.getObject(%d)", i + 1);
             } else {
-                resultStr = String.format("(%s) r%%'LEVEL'%%.getObject(%d)", columnTypeList.get(i).toJavaCode(), i + 1);
+                resultStr =
+                        String.format(
+                                "(%s) r%%'LEVEL'%%.getObject(%d)",
+                                columnTypeList.get(i).toJavaCode(), i + 1);
             }
 
             if (i > 0) {
@@ -171,7 +174,10 @@ public abstract class StmtSql extends Stmt {
             Coercion c = coercions.get(i);
             boolean checkNotNull = (id.decl instanceof DeclVar) && ((DeclVar) id.decl).notNull;
             if (checkNotNull) {
-                sbuf.append(String.format("%s = checkNotNull(%s);", id.toJavaCode(), c.toJavaCode(resultStr)));
+                sbuf.append(
+                        String.format(
+                                "%s = checkNotNull(%s);",
+                                id.toJavaCode(), c.toJavaCode(resultStr)));
             } else {
                 sbuf.append(String.format("%s = %s;", id.toJavaCode(), c.toJavaCode(resultStr)));
             }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/TypeSpec.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/TypeSpec.java
@@ -34,14 +34,12 @@ public abstract class TypeSpec extends AstNode {
 
     public final String pcsName;
     public final String javaCode;
-    public final String nameOfGetMethod;
     public final int simpleTypeIdx;
 
-    public TypeSpec(String pcsName, String javaCode, String nameOfGetMethod, int simpleTypeIdx) {
+    public TypeSpec(String pcsName, String javaCode, int simpleTypeIdx) {
         super(null);
         this.pcsName = pcsName;
         this.javaCode = javaCode;
-        this.nameOfGetMethod = nameOfGetMethod;
         this.simpleTypeIdx = simpleTypeIdx;
     }
 
@@ -77,10 +75,6 @@ public abstract class TypeSpec extends AstNode {
     }
 
     public abstract String toJavaSignature();
-
-    public String getNameOfGetMethod() {
-        return nameOfGetMethod;
-    }
 
     // overriden by TypeSpecSimple
     public boolean isNumber() {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/TypeSpecPercent.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/TypeSpecPercent.java
@@ -45,7 +45,7 @@ public class TypeSpecPercent extends TypeSpec {
     public final String column;
 
     public TypeSpecPercent(String table, String column) {
-        super(null, null, null, -1);
+        super(null, null, -1);
         this.table = table;
         this.column = column;
     }
@@ -76,16 +76,6 @@ public class TypeSpecPercent extends TypeSpec {
             return "%UNRESOLVED";
         } else {
             return resolvedType.toString();
-        }
-    }
-
-    @Override
-    public String getNameOfGetMethod() {
-        if (resolvedType == null) {
-            assert false;
-            throw new RuntimeException("unreachable");
-        } else {
-            return resolvedType.getNameOfGetMethod();
         }
     }
 }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/TypeSpecSimple.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/TypeSpecSimple.java
@@ -73,43 +73,42 @@ public class TypeSpecSimple extends TypeSpec {
     }
 
     // the following two are not actual Java types but only for internal type checking
-    public static TypeSpecSimple NULL = new TypeSpecSimple("Null", "Null", null, IDX_NULL);
-    public static TypeSpecSimple CURSOR = new TypeSpecSimple("Cursor", "Cursor", null, IDX_CURSOR);
+    public static TypeSpecSimple NULL = new TypeSpecSimple("Null", "Null", IDX_NULL);
+    public static TypeSpecSimple CURSOR = new TypeSpecSimple("Cursor", "Cursor", IDX_CURSOR);
 
     // (1) used as an argument type of some operators in SpLib
     // (2) used as an expression type when a specific Java type cannot be given
     public static TypeSpecSimple OBJECT =
-            new TypeSpecSimple("Object", "java.lang.Object", "getObject", IDX_OBJECT);
+            new TypeSpecSimple("Object", "java.lang.Object", IDX_OBJECT);
 
     public static TypeSpecSimple BOOLEAN =
-            new TypeSpecSimple("Boolean", "java.lang.Boolean", "getBoolean", IDX_BOOLEAN);
+            new TypeSpecSimple("Boolean", "java.lang.Boolean", IDX_BOOLEAN);
     public static TypeSpecSimple STRING =
-            new TypeSpecSimple("String", "java.lang.String", "getString", IDX_STRING);
+            new TypeSpecSimple("String", "java.lang.String", IDX_STRING);
     public static TypeSpecSimple NUMERIC =
-            new TypeSpecSimple("Numeric", "java.math.BigDecimal", "getBigDecimal", IDX_NUMERIC);
+            new TypeSpecSimple("Numeric", "java.math.BigDecimal", IDX_NUMERIC);
     public static TypeSpecSimple SHORT =
-            new TypeSpecSimple("Short", "java.lang.Short", "getShort", IDX_SHORT);
+            new TypeSpecSimple("Short", "java.lang.Short", IDX_SHORT);
     public static TypeSpecSimple INT =
-            new TypeSpecSimple("Int", "java.lang.Integer", "getInt", IDX_INT);
+            new TypeSpecSimple("Int", "java.lang.Integer", IDX_INT);
     public static TypeSpecSimple BIGINT =
-            new TypeSpecSimple("Bigint", "java.lang.Long", "getLong", IDX_BIGINT);
+            new TypeSpecSimple("Bigint", "java.lang.Long", IDX_BIGINT);
     public static TypeSpecSimple FLOAT =
-            new TypeSpecSimple("Float", "java.lang.Float", "getFloat", IDX_FLOAT);
+            new TypeSpecSimple("Float", "java.lang.Float", IDX_FLOAT);
     public static TypeSpecSimple DOUBLE =
-            new TypeSpecSimple("Double", "java.lang.Double", "getDouble", IDX_DOUBLE);
+            new TypeSpecSimple("Double", "java.lang.Double", IDX_DOUBLE);
     public static TypeSpecSimple DATE =
-            new TypeSpecSimple("Date", "java.sql.Date", "getDate", IDX_DATE);
+            new TypeSpecSimple("Date", "java.sql.Date", IDX_DATE);
     public static TypeSpecSimple TIME =
-            new TypeSpecSimple("Time", "java.sql.Time", "getTime", IDX_TIME);
+            new TypeSpecSimple("Time", "java.sql.Time", IDX_TIME);
     public static TypeSpecSimple TIMESTAMP =
-            new TypeSpecSimple("Timestamp", "java.sql.Timestamp", "getTimestamp", IDX_TIMESTAMP);
+            new TypeSpecSimple("Timestamp", "java.sql.Timestamp", IDX_TIMESTAMP);
     public static TypeSpecSimple DATETIME =
-            new TypeSpecSimple("Datetime", "java.sql.Timestamp", "getTimestamp", IDX_DATETIME);
+            new TypeSpecSimple("Datetime", "java.sql.Timestamp", IDX_DATETIME);
     public static TypeSpecSimple SYS_REFCURSOR =
             new TypeSpecSimple(
                     "Sys_refcursor",
                     "com.cubrid.plcsql.predefined.sp.SpLib.Query",
-                    null,
                     IDX_SYS_REFCURSOR);
 
     /* TODO: restore later
@@ -142,9 +141,8 @@ public class TypeSpecSimple extends TypeSpec {
     // Private
     // ------------------------------------------------------------------
 
-    private TypeSpecSimple(
-            String pcsName, String fullJavaType, String nameOfGetMethod, int simpleTypeIdx) {
-        super(pcsName, getJavaCode(fullJavaType), nameOfGetMethod, simpleTypeIdx);
+    private TypeSpecSimple(String pcsName, String fullJavaType, int simpleTypeIdx) {
+        super(pcsName, getJavaCode(fullJavaType), simpleTypeIdx);
         this.fullJavaType = fullJavaType;
     }
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/TypeSpecSimple.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/TypeSpecSimple.java
@@ -87,20 +87,15 @@ public class TypeSpecSimple extends TypeSpec {
             new TypeSpecSimple("String", "java.lang.String", IDX_STRING);
     public static TypeSpecSimple NUMERIC =
             new TypeSpecSimple("Numeric", "java.math.BigDecimal", IDX_NUMERIC);
-    public static TypeSpecSimple SHORT =
-            new TypeSpecSimple("Short", "java.lang.Short", IDX_SHORT);
-    public static TypeSpecSimple INT =
-            new TypeSpecSimple("Int", "java.lang.Integer", IDX_INT);
+    public static TypeSpecSimple SHORT = new TypeSpecSimple("Short", "java.lang.Short", IDX_SHORT);
+    public static TypeSpecSimple INT = new TypeSpecSimple("Int", "java.lang.Integer", IDX_INT);
     public static TypeSpecSimple BIGINT =
             new TypeSpecSimple("Bigint", "java.lang.Long", IDX_BIGINT);
-    public static TypeSpecSimple FLOAT =
-            new TypeSpecSimple("Float", "java.lang.Float", IDX_FLOAT);
+    public static TypeSpecSimple FLOAT = new TypeSpecSimple("Float", "java.lang.Float", IDX_FLOAT);
     public static TypeSpecSimple DOUBLE =
             new TypeSpecSimple("Double", "java.lang.Double", IDX_DOUBLE);
-    public static TypeSpecSimple DATE =
-            new TypeSpecSimple("Date", "java.sql.Date", IDX_DATE);
-    public static TypeSpecSimple TIME =
-            new TypeSpecSimple("Time", "java.sql.Time", IDX_TIME);
+    public static TypeSpecSimple DATE = new TypeSpecSimple("Date", "java.sql.Date", IDX_DATE);
+    public static TypeSpecSimple TIME = new TypeSpecSimple("Time", "java.sql.Time", IDX_TIME);
     public static TypeSpecSimple TIMESTAMP =
             new TypeSpecSimple("Timestamp", "java.sql.Timestamp", IDX_TIMESTAMP);
     public static TypeSpecSimple DATETIME =

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/TypeSpecVariadic.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/TypeSpecVariadic.java
@@ -69,7 +69,7 @@ public class TypeSpecVariadic extends TypeSpec {
     }
 
     public TypeSpecVariadic(TypeSpecSimple elem) {
-        super(null, null, null, -1);
+        super(null, null, -1);
         this.elem = elem;
     }
 }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
@@ -640,7 +640,8 @@ public class TypeChecker extends AstVisitor<TypeSpec> {
         TypeSpec valType = visit(node.val);
         TypeSpec varType = ((DeclIdTyped) node.var.decl).typeSpec();
 
-        boolean checkNotNull = (node.var.decl instanceof DeclVar) && ((DeclVar) node.var.decl).notNull;
+        boolean checkNotNull =
+                (node.var.decl instanceof DeclVar) && ((DeclVar) node.var.decl).notNull;
         if (checkNotNull && valType.equals(TypeSpecSimple.NULL)) {
             throw new SemanticError(
                     Misc.getLineColumnOf(node.val.ctx), // s231

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
@@ -639,6 +639,14 @@ public class TypeChecker extends AstVisitor<TypeSpec> {
     public TypeSpec visitStmtAssign(StmtAssign node) {
         TypeSpec valType = visit(node.val);
         TypeSpec varType = ((DeclIdTyped) node.var.decl).typeSpec();
+
+        boolean checkNotNull = (node.var.decl instanceof DeclVar) && ((DeclVar) node.var.decl).notNull;
+        if (checkNotNull && valType.equals(TypeSpecSimple.NULL)) {
+            throw new SemanticError(
+                    Misc.getLineColumnOf(node.val.ctx), // s231
+                    "NOT NULL constraint violation");
+        }
+
         Coercion c = Coercion.getCoercion(valType, varType);
         if (c == null) {
             throw new SemanticError(

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -55,7 +55,7 @@ public class SpLib {
 
     public static <T> T checkNotNull(T val) {
         if (val == null) {
-            throw new VALUE_ERROR("NOT NULL constraint violation");    
+            throw new VALUE_ERROR("NOT NULL constraint violation");
         }
 
         return val;

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -53,6 +53,14 @@ import java.util.regex.PatternSyntaxException;
 
 public class SpLib {
 
+    public static <T> T checkNotNull(T val) {
+        if (val == null) {
+            throw new VALUE_ERROR("NOT NULL constraint violation");    
+        }
+
+        return val;
+    }
+
     public static Integer checkForLoopIterStep(Integer step) {
         if (step <= 0) {
             throw new VALUE_ERROR("FOR loop iteration steps must be positive integers");


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24950

- run-time check of assigned values to NOT NULL variables or constants - using checkNotNull method of SpLib
  - NOT NULL constant/variable declarations
  - assignment to NOT NULL variables
  - INTO clauses of Static/Dynamic SQL SELECT statements
- compile-time check of assigned values to NOT NULL variables
- droping 'nameOfGetMethod' field of TypeSpec and using getObject and type casting instead
  - to avoid wasNull check of ResultSet