### PR TITLE
[CBRD-24951] INVALID_CURSOR must be raised when FETCH or CLOSE is done on an unopened cursor

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/StmtCursorClose.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/StmtCursorClose.java
@@ -31,6 +31,7 @@
 package com.cubrid.plcsql.compiler.ast;
 
 import com.cubrid.plcsql.compiler.visitor.AstVisitor;
+import com.cubrid.plcsql.compiler.Misc;
 import org.antlr.v4.runtime.ParserRuleContext;
 
 public class StmtCursorClose extends Stmt {
@@ -50,10 +51,19 @@ public class StmtCursorClose extends Stmt {
 
     @Override
     public String toJavaCode() {
-        return id.toJavaCode() + ".close();";
+        return tmplStmt.replace("%'CURSOR'%", id.toJavaCode());
     }
 
     // --------------------------------------------------
     // Private
     // --------------------------------------------------
+
+    private static final String tmplStmt =
+            Misc.combineLines(
+                    "// cursor close",
+                    "if (%'CURSOR'%.isOpen()) {",
+                    "  %'CURSOR'%.close();",
+                    "} else {",
+                    "  throw new INVALID_CURSOR(\"tried to close an unopened cursor\");",
+                    "}");
 }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/StmtCursorClose.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/StmtCursorClose.java
@@ -30,8 +30,8 @@
 
 package com.cubrid.plcsql.compiler.ast;
 
-import com.cubrid.plcsql.compiler.visitor.AstVisitor;
 import com.cubrid.plcsql.compiler.Misc;
+import com.cubrid.plcsql.compiler.visitor.AstVisitor;
 import org.antlr.v4.runtime.ParserRuleContext;
 
 public class StmtCursorClose extends Stmt {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/StmtCursorFetch.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/StmtCursorFetch.java
@@ -79,6 +79,9 @@ public class StmtCursorFetch extends Stmt {
     private static final String tmplStmt =
             Misc.combineLines(
                     "{ // cursor fetch",
+                    "  if (!%'CURSOR'%.isOpen()) {",
+                    "    throw new INVALID_CURSOR(\"tried to fetch with an unopened cursor\");",
+                    "  }",
                     "  ResultSet rs = %'CURSOR'%.rs;",
                     "  if (rs == null) {",
                     "    throw new PROGRAM_ERROR();",

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -69,10 +69,15 @@ public class SpLib {
         return step;
     }
 
+    // ---------------------------------------------------------------------------------------
     // builtin exceptions
+    //
     public static class CASE_NOT_FOUND extends PlcsqlRuntimeError {
         public CASE_NOT_FOUND() {
             super(CODE_CASE_NOT_FOUND, MSG_CASE_NOT_FOUND);
+        }
+        public CASE_NOT_FOUND(String subMsg) {
+            super(CODE_CASE_NOT_FOUND, isEmptyStr(subMsg) ? MSG_CASE_NOT_FOUND : (MSG_CASE_NOT_FOUND + ": " + subMsg));
         }
     }
 
@@ -80,15 +85,17 @@ public class SpLib {
         public CURSOR_ALREADY_OPEN() {
             super(CODE_CURSOR_ALREADY_OPEN, MSG_CURSOR_ALREADY_OPEN);
         }
+        public CURSOR_ALREADY_OPEN(String subMsg) {
+            super(CODE_CURSOR_ALREADY_OPEN, isEmptyStr(subMsg) ? MSG_CURSOR_ALREADY_OPEN : (MSG_CURSOR_ALREADY_OPEN + ": " + subMsg));
+        }
     }
 
     public static class INVALID_CURSOR extends PlcsqlRuntimeError {
         public INVALID_CURSOR() {
             super(CODE_INVALID_CURSOR, MSG_INVALID_CURSOR);
         }
-
-        public INVALID_CURSOR(String s) {
-            super(CODE_STORAGE_ERROR, (s == null || s.length() == 0) ? MSG_INVALID_CURSOR : s);
+        public INVALID_CURSOR(String subMsg) {
+            super(CODE_INVALID_CURSOR, isEmptyStr(subMsg) ? MSG_INVALID_CURSOR: (MSG_INVALID_CURSOR+ ": " + subMsg));
         }
     }
 
@@ -96,11 +103,17 @@ public class SpLib {
         public NO_DATA_FOUND() {
             super(CODE_NO_DATA_FOUND, MSG_NO_DATA_FOUND);
         }
+        public NO_DATA_FOUND(String subMsg) {
+            super(CODE_NO_DATA_FOUND, isEmptyStr(subMsg) ? MSG_NO_DATA_FOUND : (MSG_NO_DATA_FOUND + ": " + subMsg));
+        }
     }
 
     public static class PROGRAM_ERROR extends PlcsqlRuntimeError {
         public PROGRAM_ERROR() {
             super(CODE_PROGRAM_ERROR, MSG_PROGRAM_ERROR);
+        }
+        public PROGRAM_ERROR(String subMsg) {
+            super(CODE_PROGRAM_ERROR, isEmptyStr(subMsg) ? MSG_PROGRAM_ERROR : (MSG_PROGRAM_ERROR + ": " + subMsg));
         }
     }
 
@@ -108,15 +121,17 @@ public class SpLib {
         public STORAGE_ERROR() {
             super(CODE_STORAGE_ERROR, MSG_STORAGE_ERROR);
         }
+        public STORAGE_ERROR(String subMsg) {
+            super(CODE_STORAGE_ERROR, isEmptyStr(subMsg) ? MSG_STORAGE_ERROR : (MSG_STORAGE_ERROR + ": " + subMsg));
+        }
     }
 
     public static class SQL_ERROR extends PlcsqlRuntimeError {
         public SQL_ERROR() {
             super(CODE_STORAGE_ERROR, MSG_SQL_ERROR);
         }
-
-        public SQL_ERROR(String s) {
-            super(CODE_STORAGE_ERROR, (s == null || s.length() == 0) ? MSG_SQL_ERROR : s);
+        public SQL_ERROR(String subMsg) {
+            super(CODE_STORAGE_ERROR, isEmptyStr(subMsg) ? MSG_SQL_ERROR : (MSG_SQL_ERROR + ": " + subMsg));
         }
     }
 
@@ -124,15 +139,17 @@ public class SpLib {
         public TOO_MANY_ROWS() {
             super(CODE_TOO_MANY_ROWS, MSG_TOO_MANY_ROWS);
         }
+        public TOO_MANY_ROWS(String subMsg) {
+            super(CODE_TOO_MANY_ROWS, isEmptyStr(subMsg) ? MSG_TOO_MANY_ROWS : (MSG_TOO_MANY_ROWS + ": " + subMsg));
+        }
     }
 
     public static class VALUE_ERROR extends PlcsqlRuntimeError {
         public VALUE_ERROR() {
             super(CODE_VALUE_ERROR, MSG_VALUE_ERROR);
         }
-
         public VALUE_ERROR(String subMsg) {
-            super(CODE_VALUE_ERROR, MSG_VALUE_ERROR + ": " + subMsg);
+            super(CODE_VALUE_ERROR, isEmptyStr(subMsg) ? MSG_VALUE_ERROR : (MSG_VALUE_ERROR + ": " + subMsg));
         }
     }
 
@@ -140,26 +157,27 @@ public class SpLib {
         public ZERO_DIVIDE() {
             super(CODE_ZERO_DIVIDE, MSG_ZERO_DIVIDE);
         }
+        public ZERO_DIVIDE(String subMsg) {
+            super(CODE_ZERO_DIVIDE, isEmptyStr(subMsg) ? MSG_ZERO_DIVIDE : (MSG_ZERO_DIVIDE + ": " + subMsg));
+        }
     }
+
+    //
+    // builtin exceptions
+    // ---------------------------------------------------------------------------------------
 
     // user defined exception
     public static class $APP_ERROR extends PlcsqlRuntimeError {
-        public $APP_ERROR(int code, String msg) {
-            super(code, msg);
+        public $APP_ERROR(int code, String subMsg) {
+            super(code, isEmptyStr(subMsg) ? MSG_APP_ERROR : (MSG_APP_ERROR + ": " + subMsg));
         }
-
-        public $APP_ERROR(String msg) {
-            super(CODE_APP_ERROR, msg);
+        public $APP_ERROR(String subMsg) {
+            super(CODE_APP_ERROR, isEmptyStr(subMsg) ? MSG_APP_ERROR : (MSG_APP_ERROR + ": " + subMsg));
         }
-
         public $APP_ERROR() {
-            super(CODE_APP_ERROR, "a user defined exception");
+            super(CODE_APP_ERROR, MSG_APP_ERROR);
         }
     }
-
-    public static String SQLERRM = null;
-    public static Integer SQLCODE = null;
-    public static Date SYSDATE = null;
 
     // --------------------------------------------------------
     // DBMS_OUTPUT procedures
@@ -2647,7 +2665,6 @@ public class SpLib {
     private static final int CODE_TOO_MANY_ROWS = 7;
     private static final int CODE_VALUE_ERROR = 8;
     private static final int CODE_ZERO_DIVIDE = 9;
-
     private static final int CODE_APP_ERROR = 99;
 
     private static final String MSG_CASE_NOT_FOUND = "case not found";
@@ -2660,6 +2677,7 @@ public class SpLib {
     private static final String MSG_TOO_MANY_ROWS = "too many rows";
     private static final String MSG_VALUE_ERROR = "value error";
     private static final String MSG_ZERO_DIVIDE = "division by zero";
+    private static final String MSG_APP_ERROR = "user defined exception";
 
     private static final Short SHORT_ZERO = Short.valueOf((short) 0);
     private static final Integer INT_ZERO = Integer.valueOf(0);
@@ -3298,5 +3316,9 @@ public class SpLib {
             assert rConv != null;
             return lConv.compareTo(rConv);
         }
+    }
+
+    private static boolean isEmptyStr(String s) {
+        return s == null || s.length() == 0;
     }
 }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -86,6 +86,10 @@ public class SpLib {
         public INVALID_CURSOR() {
             super(CODE_INVALID_CURSOR, MSG_INVALID_CURSOR);
         }
+
+        public INVALID_CURSOR(String s) {
+            super(CODE_STORAGE_ERROR, (s == null || s.length() == 0) ? MSG_INVALID_CURSOR : s);
+        }
     }
 
     public static class NO_DATA_FOUND extends PlcsqlRuntimeError {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -76,8 +76,11 @@ public class SpLib {
         public CASE_NOT_FOUND() {
             super(CODE_CASE_NOT_FOUND, MSG_CASE_NOT_FOUND);
         }
+
         public CASE_NOT_FOUND(String subMsg) {
-            super(CODE_CASE_NOT_FOUND, isEmptyStr(subMsg) ? MSG_CASE_NOT_FOUND : (MSG_CASE_NOT_FOUND + ": " + subMsg));
+            super(
+                    CODE_CASE_NOT_FOUND,
+                    isEmptyStr(subMsg) ? MSG_CASE_NOT_FOUND : (MSG_CASE_NOT_FOUND + ": " + subMsg));
         }
     }
 
@@ -85,8 +88,13 @@ public class SpLib {
         public CURSOR_ALREADY_OPEN() {
             super(CODE_CURSOR_ALREADY_OPEN, MSG_CURSOR_ALREADY_OPEN);
         }
+
         public CURSOR_ALREADY_OPEN(String subMsg) {
-            super(CODE_CURSOR_ALREADY_OPEN, isEmptyStr(subMsg) ? MSG_CURSOR_ALREADY_OPEN : (MSG_CURSOR_ALREADY_OPEN + ": " + subMsg));
+            super(
+                    CODE_CURSOR_ALREADY_OPEN,
+                    isEmptyStr(subMsg)
+                            ? MSG_CURSOR_ALREADY_OPEN
+                            : (MSG_CURSOR_ALREADY_OPEN + ": " + subMsg));
         }
     }
 
@@ -94,8 +102,11 @@ public class SpLib {
         public INVALID_CURSOR() {
             super(CODE_INVALID_CURSOR, MSG_INVALID_CURSOR);
         }
+
         public INVALID_CURSOR(String subMsg) {
-            super(CODE_INVALID_CURSOR, isEmptyStr(subMsg) ? MSG_INVALID_CURSOR: (MSG_INVALID_CURSOR+ ": " + subMsg));
+            super(
+                    CODE_INVALID_CURSOR,
+                    isEmptyStr(subMsg) ? MSG_INVALID_CURSOR : (MSG_INVALID_CURSOR + ": " + subMsg));
         }
     }
 
@@ -103,8 +114,11 @@ public class SpLib {
         public NO_DATA_FOUND() {
             super(CODE_NO_DATA_FOUND, MSG_NO_DATA_FOUND);
         }
+
         public NO_DATA_FOUND(String subMsg) {
-            super(CODE_NO_DATA_FOUND, isEmptyStr(subMsg) ? MSG_NO_DATA_FOUND : (MSG_NO_DATA_FOUND + ": " + subMsg));
+            super(
+                    CODE_NO_DATA_FOUND,
+                    isEmptyStr(subMsg) ? MSG_NO_DATA_FOUND : (MSG_NO_DATA_FOUND + ": " + subMsg));
         }
     }
 
@@ -112,8 +126,11 @@ public class SpLib {
         public PROGRAM_ERROR() {
             super(CODE_PROGRAM_ERROR, MSG_PROGRAM_ERROR);
         }
+
         public PROGRAM_ERROR(String subMsg) {
-            super(CODE_PROGRAM_ERROR, isEmptyStr(subMsg) ? MSG_PROGRAM_ERROR : (MSG_PROGRAM_ERROR + ": " + subMsg));
+            super(
+                    CODE_PROGRAM_ERROR,
+                    isEmptyStr(subMsg) ? MSG_PROGRAM_ERROR : (MSG_PROGRAM_ERROR + ": " + subMsg));
         }
     }
 
@@ -121,8 +138,11 @@ public class SpLib {
         public STORAGE_ERROR() {
             super(CODE_STORAGE_ERROR, MSG_STORAGE_ERROR);
         }
+
         public STORAGE_ERROR(String subMsg) {
-            super(CODE_STORAGE_ERROR, isEmptyStr(subMsg) ? MSG_STORAGE_ERROR : (MSG_STORAGE_ERROR + ": " + subMsg));
+            super(
+                    CODE_STORAGE_ERROR,
+                    isEmptyStr(subMsg) ? MSG_STORAGE_ERROR : (MSG_STORAGE_ERROR + ": " + subMsg));
         }
     }
 
@@ -130,8 +150,11 @@ public class SpLib {
         public SQL_ERROR() {
             super(CODE_STORAGE_ERROR, MSG_SQL_ERROR);
         }
+
         public SQL_ERROR(String subMsg) {
-            super(CODE_STORAGE_ERROR, isEmptyStr(subMsg) ? MSG_SQL_ERROR : (MSG_SQL_ERROR + ": " + subMsg));
+            super(
+                    CODE_STORAGE_ERROR,
+                    isEmptyStr(subMsg) ? MSG_SQL_ERROR : (MSG_SQL_ERROR + ": " + subMsg));
         }
     }
 
@@ -139,8 +162,11 @@ public class SpLib {
         public TOO_MANY_ROWS() {
             super(CODE_TOO_MANY_ROWS, MSG_TOO_MANY_ROWS);
         }
+
         public TOO_MANY_ROWS(String subMsg) {
-            super(CODE_TOO_MANY_ROWS, isEmptyStr(subMsg) ? MSG_TOO_MANY_ROWS : (MSG_TOO_MANY_ROWS + ": " + subMsg));
+            super(
+                    CODE_TOO_MANY_ROWS,
+                    isEmptyStr(subMsg) ? MSG_TOO_MANY_ROWS : (MSG_TOO_MANY_ROWS + ": " + subMsg));
         }
     }
 
@@ -148,8 +174,11 @@ public class SpLib {
         public VALUE_ERROR() {
             super(CODE_VALUE_ERROR, MSG_VALUE_ERROR);
         }
+
         public VALUE_ERROR(String subMsg) {
-            super(CODE_VALUE_ERROR, isEmptyStr(subMsg) ? MSG_VALUE_ERROR : (MSG_VALUE_ERROR + ": " + subMsg));
+            super(
+                    CODE_VALUE_ERROR,
+                    isEmptyStr(subMsg) ? MSG_VALUE_ERROR : (MSG_VALUE_ERROR + ": " + subMsg));
         }
     }
 
@@ -157,8 +186,11 @@ public class SpLib {
         public ZERO_DIVIDE() {
             super(CODE_ZERO_DIVIDE, MSG_ZERO_DIVIDE);
         }
+
         public ZERO_DIVIDE(String subMsg) {
-            super(CODE_ZERO_DIVIDE, isEmptyStr(subMsg) ? MSG_ZERO_DIVIDE : (MSG_ZERO_DIVIDE + ": " + subMsg));
+            super(
+                    CODE_ZERO_DIVIDE,
+                    isEmptyStr(subMsg) ? MSG_ZERO_DIVIDE : (MSG_ZERO_DIVIDE + ": " + subMsg));
         }
     }
 
@@ -171,9 +203,13 @@ public class SpLib {
         public $APP_ERROR(int code, String subMsg) {
             super(code, isEmptyStr(subMsg) ? MSG_APP_ERROR : (MSG_APP_ERROR + ": " + subMsg));
         }
+
         public $APP_ERROR(String subMsg) {
-            super(CODE_APP_ERROR, isEmptyStr(subMsg) ? MSG_APP_ERROR : (MSG_APP_ERROR + ": " + subMsg));
+            super(
+                    CODE_APP_ERROR,
+                    isEmptyStr(subMsg) ? MSG_APP_ERROR : (MSG_APP_ERROR + ": " + subMsg));
         }
+
         public $APP_ERROR() {
             super(CODE_APP_ERROR, MSG_APP_ERROR);
         }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24951

* besides the main subject of this issue, another version of built-in exception constructors were added so that they take an additional informative sub-message.
