### PR TITLE
[CBRD-24842] When replacing the hostname with 'localhost' after a GETHOSTNAME error, error will be cleared

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -10857,6 +10857,7 @@ prm_tune_parameters (void)
       if (GETHOSTNAME (host_name, sizeof (host_name)))
 	{
 	  strncpy (host_name, "localhost", sizeof (host_name) - 1);
+	  er_clear ();
 	}
 
       snprintf (newval, sizeof (newval) - 1, "%s@%s", host_name, host_name);
@@ -11009,6 +11010,7 @@ prm_tune_parameters (void)
       if (GETHOSTNAME (host_name, sizeof (host_name)))
 	{
 	  strncpy (host_name, "localhost", sizeof (host_name) - 1);
+	  er_clear ();
 	}
 
       snprintf (newval, sizeof (newval) - 1, "%s@%s", host_name, host_name);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24842

**Description**

in addition to https://github.com/CUBRID/cubrid/pull/4497 ,
* If hostname is set to '**localhost**' again after _GETHOSTNAME_() fails, 
  * we decide not to consider this situation as an error 
  * and initialize the error accordingly (by **er_clear**()).

**Remarks**

Overwritting PR.
