### PR TITLE
[CBRD-24981] accepts Ctrl-C as the character to exit the broker monitor

### DIFF
--- a/src/broker/broker_monitor.c
+++ b/src/broker/broker_monitor.c
@@ -680,7 +680,7 @@ main (int argc, char **argv)
 	      shm_br = NULL;
 	    }
 #endif
-	  if (in_ch == 'q')
+	  if (in_ch == 'q' || in_ch == 'Q' || in_ch == 0x03)
 	    {
 	      break;
 	    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24981

**Description**
* in addition to #4266, #4330
  * Entering the CTRL-C key will terminate the broker monitor.

**Remarks**
* ASCII code value for CTRL-C is 0x03