### PR TITLE
[CBRD-24969] Remove semicolon after shard key

### DIFF
--- a/src/broker/shard_parser.c
+++ b/src/broker/shard_parser.c
@@ -316,15 +316,14 @@ sp_make_int_sp_value_from_string (SP_VALUE * value_p, char *pos, int length)
 {
   int result = 0;
   char tmp = pos[length];
+  char *p;
 
-  if (length > 1 && pos[length - 1] == ';')
+  p = strchr (pos, ';');
+  if (p)
     {
-      pos[length - 1] = '\0';
+      *p = '\0';
     }
-  else
-    {
-      pos[length] = '\0';
-    }
+  pos[length] = '\0';
 
   result = parse_bigint (&value_p->integer, pos, 10);
   if (result != 0)

--- a/src/broker/shard_parser.c
+++ b/src/broker/shard_parser.c
@@ -316,7 +316,7 @@ sp_make_int_sp_value_from_string (SP_VALUE * value_p, char *pos, int length)
 {
   int result = 0;
   const int KEY_LENGTH = 128;
-  char shard_key [KEY_LENGTH];
+  char shard_key[KEY_LENGTH];
   char *p;
 
   snprintf (shard_key, KEY_LENGTH, "%s", pos);

--- a/src/broker/shard_parser.c
+++ b/src/broker/shard_parser.c
@@ -58,7 +58,6 @@ static int sp_get_int_bind_value (SP_PARSER_CTX * parser_p, SP_PARSER_HINT * hin
 static int sp_is_valid_hint (SP_PARSER_CTX * parser_p, SP_PARSER_HINT * hint_p);
 static bool sp_is_start_token (SP_TOKEN token);
 
-
 SP_PARSER_CTX *
 sp_create_parser (const char *sql_stmt)
 {
@@ -318,7 +317,15 @@ sp_make_int_sp_value_from_string (SP_VALUE * value_p, char *pos, int length)
   int result = 0;
   char tmp = pos[length];
 
-  pos[length] = '\0';
+  if (length > 1 && pos[length - 1] == ';')
+    {
+      pos[length - 1] = '\0';
+    }
+  else
+    {
+      pos[length] = '\0';
+    }
+
   result = parse_bigint (&value_p->integer, pos, 10);
   if (result != 0)
     {

--- a/src/broker/shard_parser.c
+++ b/src/broker/shard_parser.c
@@ -315,22 +315,24 @@ static int
 sp_make_int_sp_value_from_string (SP_VALUE * value_p, char *pos, int length)
 {
   int result = 0;
-  char tmp = pos[length];
+  const int KEY_LENGTH = 128;
+  char shard_key [KEY_LENGTH];
   char *p;
 
-  p = strchr (pos, ';');
+  snprintf (shard_key, KEY_LENGTH, "%s", pos);
+  p = strchr (shard_key, ';');
   if (p)
     {
       *p = '\0';
     }
-  pos[length] = '\0';
+  shard_key[length] = '\0';
 
-  result = parse_bigint (&value_p->integer, pos, 10);
+  result = parse_bigint (&value_p->integer, shard_key, 10);
   if (result != 0)
     {
       return ER_SP_INVALID_HINT;
     }
-  pos[length] = tmp;
+
   value_p->type = VT_INTEGER;
   return NO_ERROR;
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24969

**Description**
* remove additional semicolon after shard key.

**Remarks**
* **sp_make_int_sp_value_from_string** () expect integer number style shard key and it convert the string type key to bigint.
* In the case of a token with a shard key and followed by semicolon without space, the shard parser recognizes it as a shard key, including the semicolon. For example,

  [SHARD KEY USED IN Query] => [SHARD KEY TO CONVERT TO INTEGER]
  * /*+ shard_key */ 1 => '1' ==> parse_bigint (&new_val, "1", 10);
  * /*+ shard_key */ 1 ; => '1'
  * /*+ shard_key */ 1   ; => '1'
  * /*+ shard_key */ 1abc   ; => '1abc' ==> parse_bigint (&new_val, "1abc", 10); =====> raise error
  * /*+ shard_key */ **1;** => '**1;**' **==>** '1' ===>  parse_bigint (&new_val, "1", 10);
* Since the shard parser is a simple code based on string analysis, **if a semicolon is followed by the shard key, exclude the semicolon** and convert it to an integer.
