### PR TITLE
[CBRD-24986] Error when creating a view containing dblink in loaddb

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -4879,8 +4879,18 @@ pt_dblink_table_fill_attr_def (PARSER_CONTEXT * parser, PT_NODE * attr_def_node,
   bool need_precision = true;
 
   attr_def_node->data_type = NULL;
-  /* it needs to convert ext type to CCI_U_TYPE */
-  attr_def_node->type_enum = pt_type[pt_dblink_get_basic_utype (attr->type_idx)];
+
+  if (attr->type_idx > PT_TYPE_NONE)
+    {
+      /* this is the case of loaddb */
+      attr_def_node->type_enum = (PT_TYPE_ENUM) attr->type_idx;
+    }
+  else
+    {
+      /* it needs to convert ext type to CCI_U_TYPE */
+      attr_def_node->type_enum = pt_type[pt_dblink_get_basic_utype (attr->type_idx)];
+    }
+
   switch (attr_def_node->type_enum)
     {
     case PT_TYPE_JSON:
@@ -5227,6 +5237,24 @@ pt_dblink_table_get_column_defs (PARSER_CONTEXT * parser, PT_NODE * dblink, S_RE
     }
   else
     {
+      int client_type = db_get_client_type ();
+
+      /* in the case of loaddb, it can just check the column from the attr_def node. */
+      if (client_type == DB_CLIENT_TYPE_LOADDB_UTILITY)
+	{
+	  PT_NODE *cols;
+
+	  for (cols = dblink_table->cols; cols; cols = cols->next)
+	    {
+	      rmt_attr = rmt_tbl_cols->get_col_attr ((char *) cols->info.attr_def.attr_name->info.name.original);
+	      rmt_attr->type_idx = cols->type_enum;
+	      rmt_attr->dec_precision = (cols->data_type) ? cols->info.data_type.dec_precision : 0;
+	      rmt_attr->precision = (cols->data_type) ? cols->info.data_type.precision : 0;
+	      rmt_attr->charset = (cols->data_type) ? cols->info.data_type.units : 0;
+	    }
+	  return NO_ERROR;
+	}
+
       /* for collecting column info from "SELECT sel-list form dblink(server, 'SELECT ...') */
       sql =
 	pt_append_string (parser, "/* DBLINK SELECT */ ",

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -5240,7 +5240,7 @@ pt_dblink_table_get_column_defs (PARSER_CONTEXT * parser, PT_NODE * dblink, S_RE
       int client_type = db_get_client_type ();
 
       /* in the case of loaddb, it can just check the column from the attr_def node. */
-      if (client_type == DB_CLIENT_TYPE_LOADDB_UTILITY)
+      if (client_type == DB_CLIENT_TYPE_LOADDB_UTILITY || client_type == DB_CLIENT_TYPE_ADMIN_LOADDB_COMPAT)
 	{
 	  PT_NODE *cols;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24986

When creating a view that includes dblink in loaddb, column information is checked by connecting to a remote server during the semantic check process. However, during this process, loaddb may fail if connection to the remote server is not possible. So, in the case of loaddb, when creating a view that includes dblink, it must perform a semantic check based on the column information defined in the query spec without connecting to a remote server.
