### PR TITLE
[CBRD-24972] Change the order of the database_schema_info file list

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -5583,8 +5583,9 @@ create_schema_info (extract_context & ctxt)
   char output_filename[PATH_MAX * 2] = { '\0' };
   char filename_fullpath[PATH_MAX * 2] = { '\0' };
   char order_str[PATH_MAX * 2] = { '\0' };
-  const char *loading_order[] = { "_schema_user", "_schema_class", "_schema_vclass", "_schema_synonym",
-    "_schema_serial", "_schema_procedure", "_schema_server",
+  const char *loading_order[] =
+    { "_schema_user", "_schema_class", "_schema_vclass", "_schema_server", "_schema_synonym",
+    "_schema_serial", "_schema_procedure",
     "_schema_pk", "_schema_fk", "_schema_grant", "_schema_vclass_query_spec"
   };
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24972

Purpose
Change the order of the database_schema_info file list

* Changed to the location under testdb_schema_server.
testdb_schema_user
testdb_schema_class
testdb_schema_vclass
**testdb_schema_server**
testdb_schema_synonym
testdb_schema_serial
testdb_schema_procedure
testdb_schema_pk
testdb_schema_fk
testdb_schema_grant
testdb_schema_vclass_query_spec

Implementation
N/A

Remarks
N/A