### PR TITLE
[CBRD-24985] A phenomenon in which the executed query is not executed properly due to Query rewrite.

### DIFF
--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -693,7 +693,7 @@ pt_lambda_node (PARSER_CONTEXT * parser, PT_NODE * tree_or_name, void *void_arg,
 	  if (temp->node_type == PT_NAME)
 	    {
 	      PT_NAME_INFO_SET_FLAG (temp, PT_NAME_INFO_CONSTANT);
-	      temp->info.name.constant_value = lambda_arg->tree;
+	      temp->info.name.constant_value = parser_copy_tree (parser, lambda_arg->tree);
 	    }
 
 	  return tree_or_name;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24985

There was a problem referencing a freed node. I solved it by copying that node.
