### PR TITLE
[CBRD-24992] set EP_BASE to '3rdparty' for 'cubridmanager' external project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -835,6 +835,7 @@ endif(WIN32)
 # for cmserver
 if(WITH_CCI AND WITH_CMSERVER AND EXISTS ${CMAKE_SOURCE_DIR}/cubridmanager/server)
   include(ExternalProject)
+  set_property(DIRECTORY PROPERTY EP_BASE "${CMAKE_BINARY_DIR}/3rdparty")
   get_target_property(CCI_PUBLIC_HEADERS cascci PUBLIC_HEADER)
   get_target_property(CMDEP_PUBLIC_HEADERS cmdep PUBLIC_HEADER)
   get_target_property(CMSTAT_PUBLIC_HEADERS cmstat PUBLIC_HEADER)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24992

**Description**
* set **EP_BASE** to ${**CMAKE_BINARY_DIR**}/**3rdparty**" for 'cubridmanager' external project.

**Remarks**
* if not set, build time temporary files are created in ${CMAKE_BINARY_DIR}/tmp, and they are included in CUBRID distribution (during cubridmanager build process)
