### PR TITLE
[CBRD-24855] Memory Monitoring - Register heap file module

### DIFF
--- a/msg/en_US.utf8/utils.msg
+++ b/msg/en_US.utf8/utils.msg
@@ -1331,5 +1331,5 @@ valid options:\n\
     -m, --module=TYPE             display detailed memory usage information of the specified TYPE.\n\
                                   TYPE of modules\n\
                                   -1      all modules\n\
-                                   0      heap module\n\
-                                   1      common module\n
+                                   0      common module\n\
+                                   1      heap module\n

--- a/msg/en_US.utf8/utils.msg
+++ b/msg/en_US.utf8/utils.msg
@@ -1330,4 +1330,6 @@ valid options:\n\
                                   WARNING: This option has to be used with '-t(--transaction)' option.\n\
     -m, --module=TYPE             display detailed memory usage information of the specified TYPE.\n\
                                   TYPE of modules\n\
-                                  -1      all modules\n
+                                  -1      all modules\n\
+                                   0      heap module\n\
+                                   1      common module\n

--- a/msg/en_US/utils.msg
+++ b/msg/en_US/utils.msg
@@ -1331,5 +1331,5 @@ valid options:\n\
     -m, --module=TYPE             display detailed memory usage information of the specified TYPE.\n\
                                   TYPE of modules\n\
                                   -1      all modules\n\
-                                   0      heap module\n\
-                                   1      common module\n
+                                   0      common module\n\
+                                   1      heap module\n

--- a/msg/en_US/utils.msg
+++ b/msg/en_US/utils.msg
@@ -1330,4 +1330,6 @@ valid options:\n\
                                   WARNING: This option has to be used with '-t(--transaction)' option.\n\
     -m, --module=TYPE             display detailed memory usage information of the specified TYPE.\n\
                                   TYPE of modules\n\
-                                  -1      all modules\n
+                                  -1      all modules\n\
+                                   0      heap module\n\
+                                   1      common module\n

--- a/src/base/area_alloc.c
+++ b/src/base/area_alloc.c
@@ -442,12 +442,12 @@ area_alloc (AREA * area)
   if (block == NULL)
     {
       pthread_mutex_unlock (&area->area_mutex);
+#ifdef SERVER_MODE
+      (void) mmon_set_tracking_tag (prev_tag);
+#endif
       /* error has been set */
       return NULL;
     }
-#ifdef SERVER_MODE
-  (void) mmon_set_tracking_tag (prev_tag);
-#endif
 
   /* alloc free entry from this new block */
   entry_idx = block->bitmap.get_entry ();
@@ -459,6 +459,9 @@ area_alloc (AREA * area)
       free_and_init (block);
 
       pthread_mutex_unlock (&area->area_mutex);
+#ifdef SERVER_MODE
+      (void) mmon_set_tracking_tag (prev_tag);
+#endif
       /* error has been set */
       return NULL;
     }
@@ -485,6 +488,10 @@ found:
 
   entry_ptr += AREA_PREFIX_SIZE;
 #endif /* !NDEBUG */
+
+#ifdef SERVER_MODE
+  (void) mmon_set_tracking_tag (prev_tag);
+#endif
 
   assert (entry_ptr < (block->data + area->block_size));
 
@@ -626,7 +633,7 @@ area_flush (AREA * area)
       next_blockset = blockset->next;
 
 #ifdef SERVER_MODE
-      mmon_sub_stat_with_tracking_tag (sizeof (AREA_BLOCK) * blockset->used_count + sizeof (AREA_BLOCKSET_LIST));
+      mmon_sub_stat_with_tracking_tag (sizeof (AREA_BLOCK) * blockset->used_count);
 #endif
       for (i = 0; i < blockset->used_count; i++)
 	{

--- a/src/base/memory_hash.c
+++ b/src/base/memory_hash.c
@@ -916,6 +916,9 @@ mht_create (const char *name, int est_size, unsigned int (*hash_func) (const voi
 
       return NULL;
     }
+#ifdef SERVER_MODE
+  mmon_add_stat_with_tracking_tag (DB_SIZEOF (MHT_TABLE));
+#endif
 
   /* Initialize the chunky memory manager */
   ht->heap_id = db_create_fixed_heap (DB_SIZEOF (HENTRY), MAX (2, ht_estsize / 2 + 1));

--- a/src/base/memory_hash.c
+++ b/src/base/memory_hash.c
@@ -929,6 +929,9 @@ mht_create (const char *name, int est_size, unsigned int (*hash_func) (const voi
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, DB_SIZEOF (HENTRY));
 
+#ifdef SERVER_MODE
+      mmon_sub_stat_with_tracking_tag (DB_SIZEOF (MHT_TABLE));
+#endif
       free_and_init (ht);
       return NULL;
     }
@@ -941,6 +944,9 @@ mht_create (const char *name, int est_size, unsigned int (*hash_func) (const voi
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, size);
 
       db_destroy_fixed_heap (ht->heap_id);
+#ifdef SERVER_MODE
+      mmon_sub_stat_with_tracking_tag (DB_SIZEOF (MHT_TABLE));
+#endif
       free_and_init (ht);
       return NULL;
     }
@@ -1154,6 +1160,9 @@ mht_destroy (MHT_TABLE * ht)
   /* release hash table entry storage */
   db_destroy_fixed_heap (ht->heap_id);
 
+#ifdef SERVER_MODE
+  mmon_sub_stat_with_tracking_tag (DB_SIZEOF (MHT_TABLE));
+#endif
   free_and_init (ht);
 }
 

--- a/src/base/memory_hash.h
+++ b/src/base/memory_hash.h
@@ -29,6 +29,9 @@
 #include "dbtype_def.h"
 #include "memory_alloc.h"
 #include "thread_compat.hpp"
+#if defined(SERVER_MODE)
+#include "memory_monitor_sr.hpp"
+#endif
 
 #include <stdio.h>
 

--- a/src/base/memory_monitor_cl.cpp
+++ b/src/base/memory_monitor_cl.cpp
@@ -83,6 +83,11 @@ mmon_print_module_info (std::vector<MMON_MODULE_INFO> &module_info)
 
   for (const auto &m_info : module_info)
     {
+      // It's a temporary measure for hiding MMON_OTHERS
+      if (!strcmp (m_info.name, "OTHERS"))
+	{
+	  continue;
+	}
       fprintf (stdout, "Module Name: %s\n\n", m_info.name);
       fprintf (stdout, "%-19s\t: %17lu\n", init_size_str.c_str (), MMON_CONVERT_TO_KB_SIZE (m_info.stat.init_stat));
       fprintf (stdout, "%-19s\t: %17lu\n", cur_size_str.c_str (), MMON_CONVERT_TO_KB_SIZE (m_info.stat.cur_stat));
@@ -126,6 +131,11 @@ mmon_print_module_info_summary (uint64_t server_mem_usage, std::vector<MMON_MODU
 
   for (const auto &m_info : module_info)
     {
+      // It's a temporary measure for hiding MMON_OTHERS
+      if (!strcmp (m_info.name, "OTHERS"))
+	{
+	  continue;
+	}
       if (server_mem_usage != 0)
 	{
 	  cur_stat_ratio = m_info.stat.cur_stat / (double) server_mem_usage;

--- a/src/base/memory_monitor_cl.cpp
+++ b/src/base/memory_monitor_cl.cpp
@@ -152,7 +152,14 @@ mmon_print_tran_info (MMON_TRAN_INFO &tran_info)
 
   for (const auto &t_stat : tran_info.tran_stat)
     {
-      fprintf (stdout, "\t%14d | %17lu\n", t_stat.tranid, t_stat.cur_stat);
+      if (t_stat.cur_stat >= 0)
+	{
+	  fprintf (stdout, "\t%14d | %17lu\n", t_stat.tranid, t_stat.cur_stat);
+	}
+      else
+	{
+	  fprintf (stdout, "\t%14d | %17lu\n", t_stat.tranid, 0);
+	}
     }
   fprintf (stdout, "\n-----------------------------------------------------\n\n");
 }

--- a/src/base/memory_monitor_cl.cpp
+++ b/src/base/memory_monitor_cl.cpp
@@ -129,6 +129,7 @@ mmon_print_module_info_summary (uint64_t server_mem_usage, std::vector<MMON_MODU
       if (server_mem_usage != 0)
 	{
 	  cur_stat_ratio = m_info.stat.cur_stat / (double) server_mem_usage;
+	  cur_stat_ratio *= 100;
 	}
 
       fprintf (stdout, "\t%5d\t%-20s\t: %17lu(%3d%%)\n", mmon_convert_module_name_to_index (m_info.name),

--- a/src/base/memory_monitor_cl.cpp
+++ b/src/base/memory_monitor_cl.cpp
@@ -166,8 +166,13 @@ mmon_print_tran_info (MMON_TRAN_INFO &tran_info)
   for (const auto &t_stat : tran_info.tran_stat)
     {
       // There can be some cases that some transactions' cur_stat can have minus value
-      // because they can only free memory (e.g. finalize cache).
-      // So in that case, we just show 0 value to user.
+      // because they can not allocate memory but free memory.
+      // e.g.
+      // 1. A thread get object from pool but the pool is full because other threads return object to pool
+      //    when the thread return its object to pool. In this case the thread have to free the object.
+      // 2. A thread initialize cache(just alloc) and another therad finalize cache(just free).
+      // ...
+      // So in this case, we just show 0 value to user.
       if (t_stat.cur_stat >= 0)
 	{
 	  fprintf (stdout, "\t%14d | %17lu\n", t_stat.tranid, t_stat.cur_stat);

--- a/src/base/memory_monitor_cl.cpp
+++ b/src/base/memory_monitor_cl.cpp
@@ -84,6 +84,7 @@ mmon_print_module_info (std::vector<MMON_MODULE_INFO> &module_info)
   for (const auto &m_info : module_info)
     {
       // TODO: It's a temporary measure for hiding MMON_OTHERS
+      //       It will be deleted when all other modules in CUBRID are registered in memory_monitor.
       if (!strcmp (m_info.name, "OTHERS"))
 	{
 	  continue;
@@ -132,6 +133,7 @@ mmon_print_module_info_summary (uint64_t server_mem_usage, std::vector<MMON_MODU
   for (const auto &m_info : module_info)
     {
       // TODO: It's a temporary measure for hiding MMON_OTHERS
+      //       It will be deleted when all other modules in CUBRID are registered in memory_monitor.
       if (!strcmp (m_info.name, "OTHERS"))
 	{
 	  continue;
@@ -163,6 +165,9 @@ mmon_print_tran_info (MMON_TRAN_INFO &tran_info)
 
   for (const auto &t_stat : tran_info.tran_stat)
     {
+      // There can be some cases that some transactions' cur_stat can have minus value
+      // because they can only free memory (e.g. finalize cache).
+      // So in that case, we just show 0 value to user.
       if (t_stat.cur_stat >= 0)
 	{
 	  fprintf (stdout, "\t%14d | %17lu\n", t_stat.tranid, t_stat.cur_stat);

--- a/src/base/memory_monitor_cl.cpp
+++ b/src/base/memory_monitor_cl.cpp
@@ -83,7 +83,7 @@ mmon_print_module_info (std::vector<MMON_MODULE_INFO> &module_info)
 
   for (const auto &m_info : module_info)
     {
-      // It's a temporary measure for hiding MMON_OTHERS
+      // TODO: It's a temporary measure for hiding MMON_OTHERS
       if (!strcmp (m_info.name, "OTHERS"))
 	{
 	  continue;
@@ -131,7 +131,7 @@ mmon_print_module_info_summary (uint64_t server_mem_usage, std::vector<MMON_MODU
 
   for (const auto &m_info : module_info)
     {
-      // It's a temporary measure for hiding MMON_OTHERS
+      // TODO: It's a temporary measure for hiding MMON_OTHERS
       if (!strcmp (m_info.name, "OTHERS"))
 	{
 	  continue;

--- a/src/base/memory_monitor_cl.hpp
+++ b/src/base/memory_monitor_cl.hpp
@@ -34,4 +34,5 @@ void mmon_print_server_info (MMON_SERVER_INFO &server_info);
 void mmon_print_module_info (std::vector<MMON_MODULE_INFO> &module_info);
 void mmon_print_module_info_summary (uint64_t server_mem_usage, std::vector<MMON_MODULE_INFO> &module_info);
 void mmon_print_tran_info (MMON_TRAN_INFO &tran_info);
+
 #endif // _MEMORY_MONITOR_CL_HPP_

--- a/src/base/memory_monitor_common.h
+++ b/src/base/memory_monitor_common.h
@@ -39,9 +39,9 @@ typedef enum mmon_module_id
 // The order of module name MUST be the same with MMON_MODULE_ID
 // starting from MMON_MODULE_ALL + 1
 constexpr char module_names[MMON_MODULE_LAST][DB_MAX_IDENTIFIER_LENGTH] = {
-  "heap",
-  "common",
-  "others"
+  "HEAP",
+  "COMMON",
+  "OTHERS"
 };
 
 typedef struct mmon_output_mem_stat

--- a/src/base/memory_monitor_common.h
+++ b/src/base/memory_monitor_common.h
@@ -29,19 +29,19 @@
 
 typedef enum mmon_module_id
 {
-  /* TODO: this dummy modules will be changed when heap module is registered */
   MMON_MODULE_ALL = -1,
-  MMON_MODULE_DUMMY,
-  MMON_MODULE_LONG_DUMMY,
+  MMON_MODULE_HEAP,
+  MMON_MODULE_COMMON,
+  MMON_MODULE_OTHERS,
   MMON_MODULE_LAST
 } MMON_MODULE_ID;
 
 // The order of module name MUST be the same with MMON_MODULE_ID
 // starting from MMON_MODULE_ALL + 1
 constexpr char module_names[MMON_MODULE_LAST][DB_MAX_IDENTIFIER_LENGTH] = {
-  /* TODO: this dummy modules will be changed when heap module is registered */
-  "dummy",
-  "long dummy"
+  "heap",
+  "common",
+  "others"
 };
 
 typedef struct mmon_output_mem_stat

--- a/src/base/memory_monitor_common.h
+++ b/src/base/memory_monitor_common.h
@@ -30,8 +30,9 @@
 typedef enum mmon_module_id
 {
   MMON_MODULE_ALL = -1,
-  MMON_MODULE_HEAP,
   MMON_MODULE_COMMON,
+  MMON_MODULE_HEAP,
+  /* Add new modules before this */
   MMON_MODULE_OTHERS,
   MMON_MODULE_LAST
 } MMON_MODULE_ID;
@@ -39,8 +40,8 @@ typedef enum mmon_module_id
 // The order of module name MUST be the same with MMON_MODULE_ID
 // starting from MMON_MODULE_ALL + 1
 constexpr char module_names[MMON_MODULE_LAST][DB_MAX_IDENTIFIER_LENGTH] = {
-  "HEAP",
   "COMMON",
+  "HEAP",
   "OTHERS"
 };
 

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -744,10 +744,11 @@ void mmon_aggregate_tran_info (int tran_count, MMON_TRAN_INFO &info)
 MMON_STAT_ID mmon_set_tracking_tag (MMON_STAT_ID new_tag)
 {
   MMON_STAT_ID prev_tag;
+  THREAD_ENTRY *cur_thread_p;
 
-  mmon_tracking_thread_p = thread_get_thread_entry_info ();
-  prev_tag = mmon_tracking_thread_p->mmon_tracking_tag;
-  mmon_tracking_thread_p->mmon_tracking_tag = new_tag;
+  cur_thread_p = thread_get_thread_entry_info ();
+  prev_tag = cur_thread_p->mmon_tracking_tag;
+  cur_thread_p->mmon_tracking_tag = new_tag;
 
   return prev_tag;
 }

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -30,6 +30,11 @@
 #include "memory_monitor_sr.hpp"
 #include "log_impl.h"
 
+#if !defined (NDEBUG)
+thread_local char mmon_err_msg[DB_MAX_IDENTIFIER_LENGTH];
+thread_local int mmon_err_msg_size = 0;
+#endif
+
 namespace cubperf
 {
   class memory_monitor;
@@ -189,6 +194,7 @@ namespace cubperf
       void aggregate_module_info (int module_index, std::vector<MMON_MODULE_INFO> &info) const;
       void aggregate_module_info_summary (std::vector<MMON_MODULE_INFO> &info) const;
       void aggregate_tran_info (int tran_count, MMON_TRAN_INFO &info) const;
+      void stat_dump_debug ();
 
     private:
       inline int get_module_idx (MMON_STAT_ID stat_id) const;
@@ -258,6 +264,11 @@ namespace cubperf
     assert ((size >= 0) || ((uint64_t) (-size) <= m_cur_stat));
 
     m_cur_stat += size;
+
+#if !defined (NDEBUG)
+    mmon_err_msg_size += sprintf (mmon_err_msg + mmon_err_msg_size,
+				  "_%s", m_subcomp_name.c_str ());
+#endif
   }
 
   void mmon_subcomponent::get_stat (MMON_SUBCOMP_INFO &info) const
@@ -276,6 +287,11 @@ namespace cubperf
     assert ((size >= 0) || ((uint64_t) (-size) <= m_stat.cur_stat));
 
     m_stat.cur_stat += size;
+
+#if !defined (NDEBUG)
+    mmon_err_msg_size += sprintf (mmon_err_msg + mmon_err_msg_size,
+				  "_%s", m_comp_name.c_str ());
+#endif
 
     if (m_stat.cur_stat > m_stat.peak_stat)
       {
@@ -422,6 +438,10 @@ namespace cubperf
 
     m_stat.cur_stat += size;
 
+#if !defined (NDEBUG)
+    mmon_err_msg_size = sprintf (mmon_err_msg, "[MMON-ADD] %s", m_module_name.c_str ());
+#endif
+
     if (m_stat.cur_stat > m_stat.peak_stat)
       {
 	m_stat.peak_stat = m_stat.cur_stat.load ();
@@ -433,6 +453,11 @@ namespace cubperf
 	assert ((size_t)comp_idx < m_component.size ());
 	m_component[comp_idx]->add_stat (subcomp_idx, size);
       }
+#if !defined (NDEBUG)
+    mmon_err_msg_size += sprintf (mmon_err_msg + mmon_err_msg_size, ": %ld\n", size);
+    er_log_debug (ARG_FILE_LINE, mmon_err_msg);
+    memset (mmon_err_msg, 0, DB_MAX_IDENTIFIER_LENGTH);
+#endif
   }
 
   void mmon_module::add_expand_resize_count (MMON_STAT_ID stat_id)
@@ -637,6 +662,61 @@ namespace cubperf
   {
     m_aggregater.get_transaction_info (tran_count, info);
   }
+
+  void memory_monitor::stat_dump_debug ()
+  {
+    MMON_SERVER_INFO server_info;
+    std::vector<MMON_MODULE_INFO> module_info;
+    MMON_TRAN_INFO tran_info;
+    const auto init_size_str = std::string {"Initial Size(KB)"};
+    const auto cur_size_str = std::string {"Current Size(KB)"};
+    const auto peak_size_str = std::string {"Peak Size(KB)"};
+    const auto resize_expand_str = std::string {"Resize Expand Count"};
+    FILE *fp = fopen ("memory_monitor_dump.txt", "w+");
+
+    auto MMON_CONVERT_TO_KB_SIZE = [] (uint64_t size)
+    {
+      return ((size) / 1024);
+    };
+
+    module_info.resize (MMON_MODULE_LAST);
+
+    m_aggregater.get_server_info (server_info);
+    m_aggregater.get_module_info ((int) MMON_MODULE_ALL, module_info);
+
+    fprintf (fp, "====================cubrid memmon====================\n");
+    fprintf (fp, "Server Name: %s\n", server_info.name);
+    fprintf (fp, "Total Memory Usage(KB): %lu\n\n", server_info.total_mem_usage);
+    fprintf (fp, "-----------------------------------------------------\n");
+
+    for (const auto &m_info : module_info)
+      {
+	fprintf (fp, "Module Name: %s\n\n", m_info.name);
+	fprintf (fp, "%-19s\t: %17lu\n", init_size_str.c_str (), m_info.stat.init_stat);
+	fprintf (fp, "%-19s\t: %17lu\n", cur_size_str.c_str (), m_info.stat.cur_stat);
+	fprintf (fp, "%-19s\t: %17lu\n", peak_size_str.c_str (), m_info.stat.peak_stat);
+	fprintf (fp, "%-19s\t: %17u\n\n", resize_expand_str.c_str (), m_info.stat.expand_resize_count);
+
+	for (const auto &comp_info : m_info.comp_info)
+	  {
+	    fprintf (fp, "%s\n", comp_info.name);
+	    fprintf (fp, "\t%-23s\t: %17lu\n", init_size_str.c_str (), comp_info.stat.init_stat);
+	    fprintf (fp, "\t%-23s\t: %17lu\n", cur_size_str.c_str (), comp_info.stat.cur_stat);
+
+	    for (const auto &subcomp_info : comp_info.subcomp_info)
+	      {
+		auto out_name = std::string {subcomp_info.name};
+		out_name += "(KB)";
+		fprintf (fp, "\t  %-20s\t: %17lu\n", out_name.c_str (), subcomp_info.cur_stat);
+	      }
+	    fprintf (fp, "\t%-23s\t: %17lu\n", peak_size_str.c_str (), comp_info.stat.peak_stat);
+	    fprintf (fp, "\t%-23s\t: %17u\n\n", resize_expand_str.c_str (), comp_info.stat.expand_resize_count);
+	  }
+	fprintf (fp, "\n-----------------------------------------------------\n\n");
+      }
+
+    fclose (fp);
+  }
 } // namespace cubperf
 
 /* APIs */
@@ -658,6 +738,9 @@ int mmon_initialize (const char *server_name)
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (memory_monitor));
 	  error = ER_OUT_OF_VIRTUAL_MEMORY;
 	}
+#if !defined (NDEBUG)
+      memset (mmon_err_msg, 0, DB_MAX_IDENTIFIER_LENGTH);
+#endif
     }
   return error;
 }
@@ -674,6 +757,9 @@ void mmon_finalize ()
 {
   if (mmon_Gl != nullptr)
     {
+#if !defined (NDEBUG)
+      mmon_Gl->stat_dump_debug ();
+#endif
       delete mmon_Gl;
       mmon_Gl = nullptr;
     }

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -816,9 +816,9 @@ void mmon_move_stat_with_tracking_tag (int64_t size, MMON_STAT_ID stat_id, bool 
 
   if (mmon_Gl != nullptr)
     {
+      cur_thread_p = thread_get_thread_entry_info ();
       if (cur_thread_p != NULL)
 	{
-	  cur_thread_p = thread_get_thread_entry_info ();
 	  assert (cur_thread_p->mmon_tracking_tag != MMON_STAT_LAST);
 
 	  if (tag_is_src)

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -740,3 +740,20 @@ void mmon_aggregate_tran_info (int tran_count, MMON_TRAN_INFO &info)
 
   mmon_Gl->aggregate_tran_info (tran_count, info);
 }
+
+MMON_STAT_ID mmon_set_tracking_tag (MMON_STAT_ID new_tag)
+{
+  MMON_STAT_ID prev_tag;
+
+  mmon_tracking_thread_p = thread_get_thread_entry_info ();
+  prev_tag = mmon_tracking_thread_p->mmon_tracking_tag;
+  mmon_tracking_thread_p->mmon_tracking_tag = new_tag;
+
+  return prev_tag;
+}
+
+void mmon_add_stat_with_tracking_tag (int64_t size)
+{
+  THREAD_ENTRY *cur_thread_p = thread_get_thread_entry_info ();
+  mmon_add_stat (cur_thread_p, cur_thread_p->mmon_tracking_tag, size);
+}

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -797,7 +797,7 @@ void mmon_sub_stat_with_tracking_tag (int64_t size)
   if (mmon_Gl != nullptr)
     {
       cur_thread_p = thread_get_thread_entry_info ();
-      if (cur_thred_p != NULL)
+      if (cur_thread_p != NULL)
 	{
 	  assert (cur_thread_p->mmon_tracking_tag != MMON_STAT_LAST);
 	  mmon_sub_stat (cur_thread_p, cur_thread_p->mmon_tracking_tag, size);

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -512,6 +512,11 @@ namespace cubperf
   {
     strncpy (info.name, m_mmon->m_server_name.c_str (), m_mmon->m_server_name.size ());
     info.total_mem_usage = m_mmon->m_total_mem_usage.load ();
+
+    // TODO: It's a temporary measure for hiding MMON_OTHERS
+    MMON_MODULE_INFO module_info;
+    m_mmon->m_module[MMON_MODULE_OTHERS]->aggregate_stats (true, module_info);
+    info.total_mem_usage -= module_info.stat.cur_stat;
   }
 
   void memory_monitor::aggregater::get_module_info (int module_index, std::vector<MMON_MODULE_INFO> &info) const

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -755,8 +755,16 @@ MMON_STAT_ID mmon_set_tracking_tag (MMON_STAT_ID new_tag)
   if (mmon_Gl != nullptr)
     {
       cur_thread_p = thread_get_thread_entry_info ();
-      prev_tag = cur_thread_p->mmon_tracking_tag;
-      cur_thread_p->mmon_tracking_tag = new_tag;
+      if (cur_thread_p != NULL)
+	{
+	  prev_tag = cur_thread_p->mmon_tracking_tag;
+	  cur_thread_p->mmon_tracking_tag = new_tag;
+	}
+      else
+	{
+	  // for checking dump
+	  assert (false);
+	}
     }
 
   return prev_tag;
@@ -769,8 +777,16 @@ void mmon_add_stat_with_tracking_tag (int64_t size)
   if (mmon_Gl != nullptr)
     {
       cur_thread_p = thread_get_thread_entry_info ();
-      assert (cur_thread_p->mmon_tracking_tag != MMON_STAT_LAST);
-      mmon_add_stat (cur_thread_p, cur_thread_p->mmon_tracking_tag, size);
+      if (cur_thread_p != NULL)
+	{
+	  assert (cur_thread_p->mmon_tracking_tag != MMON_STAT_LAST);
+	  mmon_add_stat (cur_thread_p, cur_thread_p->mmon_tracking_tag, size);
+	}
+      else
+	{
+	  // for checking dump
+	  assert (false);
+	}
     }
 }
 
@@ -781,8 +797,16 @@ void mmon_sub_stat_with_tracking_tag (int64_t size)
   if (mmon_Gl != nullptr)
     {
       cur_thread_p = thread_get_thread_entry_info ();
-      assert (cur_thread_p->mmon_tracking_tag != MMON_STAT_LAST);
-      mmon_sub_stat (cur_thread_p, cur_thread_p->mmon_tracking_tag, size);
+      if (cur_thred_p != NULL)
+	{
+	  assert (cur_thread_p->mmon_tracking_tag != MMON_STAT_LAST);
+	  mmon_sub_stat (cur_thread_p, cur_thread_p->mmon_tracking_tag, size);
+	}
+      else
+	{
+	  // for checking dump
+	  assert (false);
+	}
     }
 }
 
@@ -792,16 +816,24 @@ void mmon_move_stat_with_tracking_tag (int64_t size, MMON_STAT_ID stat_id, bool 
 
   if (mmon_Gl != nullptr)
     {
-      cur_thread_p = thread_get_thread_entry_info ();
-      assert (cur_thread_p->mmon_tracking_tag != MMON_STAT_LAST);
-
-      if (tag_is_src)
+      if (cur_thread_p != NULL)
 	{
-	  mmon_move_stat (cur_thread_p, cur_thread_p->mmon_tracking_tag, stat_id, size);
+	  cur_thread_p = thread_get_thread_entry_info ();
+	  assert (cur_thread_p->mmon_tracking_tag != MMON_STAT_LAST);
+
+	  if (tag_is_src)
+	    {
+	      mmon_move_stat (cur_thread_p, cur_thread_p->mmon_tracking_tag, stat_id, size);
+	    }
+	  else
+	    {
+	      mmon_move_stat (cur_thread_p, stat_id, cur_thread_p->mmon_tracking_tag, size);
+	    }
 	}
       else
 	{
-	  mmon_move_stat (cur_thread_p, stat_id, cur_thread_p->mmon_tracking_tag, size);
+	  // for checking dump
+	  assert (false);
 	}
     }
 }
@@ -813,7 +845,15 @@ void mmon_resize_stat_with_tracking_tag (int64_t old_size, int64_t new_size)
   if (mmon_Gl != nullptr)
     {
       cur_thread_p = thread_get_thread_entry_info ();
-      assert (cur_thread_p->mmon_tracking_tag != MMON_STAT_LAST);
-      mmon_resize_stat (cur_thread_p, cur_thread_p->mmon_tracking_tag, old_size, new_size);
+      if (cur_thread_p != NULL)
+	{
+	  assert (cur_thread_p->mmon_tracking_tag != MMON_STAT_LAST);
+	  mmon_resize_stat (cur_thread_p, cur_thread_p->mmon_tracking_tag, old_size, new_size);
+	}
+      else
+	{
+	  // for checking dump
+	  assert (false);
+	}
     }
 }

--- a/src/base/memory_monitor_sr.hpp
+++ b/src/base/memory_monitor_sr.hpp
@@ -30,19 +30,26 @@
 #include <type_traits>
 
 #include "perf_def.hpp"
-#include "thread_compat.hpp"
+#include "thread_entry.hpp"
 #include "memory_monitor_common.h"
 
 #define MMON_PARSE_MASK 0x0000FFFF
 #define MMON_MAKE_STAT_ID(module_idx) ((module_idx) << 16)
 
-typedef enum
+typedef enum mmon_stat_id:int
 {
-  /* TODO: this dummy modules will be changed when heap module is registered */
-  MMON_STAT_DUMMY_1 = MMON_MAKE_STAT_ID (MMON_MODULE_DUMMY),
-  MMON_STAT_DUMMY_2,
-  MMON_STAT_LONG_DUMMY_1 = MMON_MAKE_STAT_ID (MMON_MODULE_LONG_DUMMY),
-  MMON_STAT_LONG_DUMMY_2,
+  MMON_HEAP_SCAN = MMON_MAKE_STAT_ID (MMON_MODULE_HEAP),
+  MMON_HEAP_BESTSPACE,
+  MMON_HEAP_CLASSREPR,
+  MMON_HEAP_CLASSREPR_HASH,
+  MMON_HEAP_ATTRINFO,
+  MMON_HEAP_HFIDTABLE,
+  MMON_HEAP_HFIDTABLE_HASH,
+  MMON_HEAP_CHNGUESS,
+  MMON_HEAP_CHNGUESS_HASH,
+  MMON_HEAP_OTHERS,
+  MMON_COMMON = MMON_MAKE_STAT_ID (MMON_MODULE_COMMON),
+  MMON_OTHERS = MMON_MAKE_STAT_ID (MMON_MODULE_OTHERS),
   MMON_STAT_LAST = MMON_MAKE_STAT_ID (MMON_MODULE_LAST)
 } MMON_STAT_ID;
 

--- a/src/base/memory_monitor_sr.hpp
+++ b/src/base/memory_monitor_sr.hpp
@@ -30,8 +30,8 @@
 #include <type_traits>
 
 #include "perf_def.hpp"
-#include "thread_entry.hpp"
 #include "memory_monitor_common.h"
+#include "thread_manager.hpp""
 
 #define MMON_PARSE_MASK 0x0000FFFF
 #define MMON_MAKE_STAT_ID(module_idx) ((module_idx) << 16)
@@ -66,4 +66,6 @@ void mmon_aggregate_module_info (int module_index, std::vector<MMON_MODULE_INFO>
 void mmon_aggregate_module_info_summary (std::vector<MMON_MODULE_INFO> &info);
 void mmon_aggregate_tran_info (int tran_count, MMON_TRAN_INFO &info);
 
+MMON_STAT_ID mmon_set_tracking_tag (MMON_STAT_ID new_tag);
+void mmon_add_stat_with_tracking_tag (int64_t size);
 #endif /* _MEMORY_MONITOR_SR_HPP_ */

--- a/src/base/memory_monitor_sr.hpp
+++ b/src/base/memory_monitor_sr.hpp
@@ -68,4 +68,7 @@ void mmon_aggregate_tran_info (int tran_count, MMON_TRAN_INFO &info);
 
 MMON_STAT_ID mmon_set_tracking_tag (MMON_STAT_ID new_tag);
 void mmon_add_stat_with_tracking_tag (int64_t size);
+void mmon_sub_stat_with_tracking_tag (int64_t size);
+void mmon_move_stat_with_tracking_tag (int64_t size, bool tag_is_src);
+void mmon_resize_stat_with_tracking_tag (int64_t old_size, int64_t new_size);
 #endif /* _MEMORY_MONITOR_SR_HPP_ */

--- a/src/base/memory_monitor_sr.hpp
+++ b/src/base/memory_monitor_sr.hpp
@@ -31,7 +31,7 @@
 
 #include "perf_def.hpp"
 #include "memory_monitor_common.h"
-#include "thread_manager.hpp""
+#include "thread_manager.hpp"
 
 #define MMON_PARSE_MASK 0x0000FFFF
 #define MMON_MAKE_STAT_ID(module_idx) ((module_idx) << 16)

--- a/src/base/memory_monitor_sr.hpp
+++ b/src/base/memory_monitor_sr.hpp
@@ -38,6 +38,7 @@
 
 typedef enum mmon_stat_id:int
 {
+  MMON_COMMON = MMON_MAKE_STAT_ID (MMON_MODULE_COMMON),
   MMON_HEAP_SCAN = MMON_MAKE_STAT_ID (MMON_MODULE_HEAP),
   MMON_HEAP_BESTSPACE,
   MMON_HEAP_CLASSREPR,
@@ -48,7 +49,6 @@ typedef enum mmon_stat_id:int
   MMON_HEAP_CHNGUESS,
   MMON_HEAP_CHNGUESS_HASH,
   MMON_HEAP_OTHERS,
-  MMON_COMMON = MMON_MAKE_STAT_ID (MMON_MODULE_COMMON),
   MMON_OTHERS = MMON_MAKE_STAT_ID (MMON_MODULE_OTHERS),
   MMON_STAT_LAST = MMON_MAKE_STAT_ID (MMON_MODULE_LAST)
 } MMON_STAT_ID;
@@ -69,6 +69,6 @@ void mmon_aggregate_tran_info (int tran_count, MMON_TRAN_INFO &info);
 MMON_STAT_ID mmon_set_tracking_tag (MMON_STAT_ID new_tag);
 void mmon_add_stat_with_tracking_tag (int64_t size);
 void mmon_sub_stat_with_tracking_tag (int64_t size);
-void mmon_move_stat_with_tracking_tag (int64_t size, bool tag_is_src);
+void mmon_move_stat_with_tracking_tag (int64_t size, MMON_STAT_ID stat_id, bool tag_is_src);
 void mmon_resize_stat_with_tracking_tag (int64_t old_size, int64_t new_size);
 #endif /* _MEMORY_MONITOR_SR_HPP_ */

--- a/src/base/object_representation_sr.c
+++ b/src/base/object_representation_sr.c
@@ -1646,6 +1646,9 @@ or_install_btids_foreign_key_ref (DB_SEQ * fk_container, OR_INDEX * index)
 
       if (set_get_element_nocopy (fk_seq, 0, &val) != NO_ERROR)
 	{
+#ifdef SERVER_MODE
+	  mmon_sub_stat_with_tracking_tag (sizeof (OR_FOREIGN_KEY));
+#endif
 	  free_and_init (fk);
 	  return;
 	}
@@ -1654,6 +1657,9 @@ or_install_btids_foreign_key_ref (DB_SEQ * fk_container, OR_INDEX * index)
 
       if (args != 3)
 	{
+#ifdef SERVER_MODE
+	  mmon_sub_stat_with_tracking_tag (sizeof (OR_FOREIGN_KEY));
+#endif
 	  free_and_init (fk);
 	  return;
 	}

--- a/src/base/object_representation_sr.c
+++ b/src/base/object_representation_sr.c
@@ -2620,9 +2620,6 @@ or_get_current_representation (RECDES * record, int do_indexes)
       // *INDENT-OFF*
       new (&att->auto_increment.serial_obj) std::atomic<or_aligned_oid> (oid_Null_oid);
       // *INDENT-ON*
-#ifdef SERVER_MODE
-      mmon_add_stat_with_tracking_tag (sizeof (std::atomic < or_aligned_oid >));
-#endif
       /* get the btree index id if an index has been assigned */
       or_get_att_index (ptr + ORC_ATT_INDEX_OFFSET, &att->index);
 
@@ -3835,9 +3832,6 @@ or_free_classrep (OR_CLASSREP * rep)
 #endif
 	      free_and_init (att->btids);
 	    }
-#ifdef SERVER_MODE
-	  mmon_sub_stat_with_tracking_tag (sizeof (std::atomic < or_aligned_oid >));
-#endif
 	}
 #ifdef SERVER_MODE
       mmon_sub_stat_with_tracking_tag (sizeof (OR_ATTRIBUTE) * rep->n_attributes);

--- a/src/base/object_representation_sr.c
+++ b/src/base/object_representation_sr.c
@@ -589,10 +589,22 @@ orc_subclasses_from_record (RECDES * record, int *array_size, OID ** array_ptr)
 	  if (array == NULL)
 	    {
 	      array = (OID *) malloc (newsize * sizeof (OID));
+#ifdef SERVER_MODE
+	      if (array != NULL)
+		{
+		  mmon_add_stat_with_tracking_tag (newsize * sizeof (OID));
+		}
+#endif
 	    }
 	  else
 	    {
 	      array = (OID *) realloc (array, newsize * sizeof (OID));
+#ifdef SERVER_MODE
+	      if (array != NULL)
+		{
+		  mmon_resize_stat_with_tracking_tag (max * sizeof (OID), newsize * sizeof (OID));
+		}
+#endif
 	    }
 
 	  if (array == NULL)

--- a/src/base/object_representation_sr.c
+++ b/src/base/object_representation_sr.c
@@ -3835,6 +3835,9 @@ or_free_classrep (OR_CLASSREP * rep)
 #endif
 	      free_and_init (att->btids);
 	    }
+#ifdef SERVER_MODE
+	  mmon_sub_stat_with_tracking_tag (sizeof (std::atomic < or_aligned_oid >));
+#endif
 	}
 #ifdef SERVER_MODE
       mmon_sub_stat_with_tracking_tag (sizeof (OR_ATTRIBUTE) * rep->n_attributes);

--- a/src/base/object_representation_sr.h
+++ b/src/base/object_representation_sr.h
@@ -171,6 +171,9 @@ struct or_index
 {
   OR_INDEX *next;		/* obsolete : use array for accessing elements */
   OR_ATTRIBUTE **atts;		/* Array of associated attributes */
+#ifdef SERVER_MODE
+  int att_cnt;			/* size of atts for memory monitoring */
+#endif
   int *asc_desc;		/* array of ascending / descending */
   int *attrs_prefix_length;	/* prefix length */
   char *btname;			/* index( or constraint) name */

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -7287,11 +7287,10 @@ smmon_get_server_info (THREAD_ENTRY * thread_p, unsigned int rid, char *request,
   char *reply = OR_ALIGNED_BUF_START (a_reply);
   int error = NO_ERROR;
   MMON_SERVER_INFO server_info;
-  int string_len;
 
   mmon_aggregate_server_info (server_info);
 
-  string_len = or_packed_string_length (server_info.name, NULL);
+  size += or_packed_string_length (server_info.name, NULL);
   /* (CBRD-24943) Alignment size check is needed because or_pack_int64() use different alignment unit(8 byte)
    * to other packing function(4 byte). And it occurs to use more 4 bytes for alignment. */
   size = size % MAX_ALIGNMENT ? size + INT_ALIGNMENT : size;

--- a/src/compat/db_elo.c
+++ b/src/compat/db_elo.c
@@ -32,6 +32,9 @@
 #include "elo.h"
 #include "db_elo.h"
 #include "dbtype.h"
+#if defined(SERVER_MODE)
+#include "memory_monitor_sr.hpp"
+#endif /* SERVER_MODE */
 
 /*
  * db_elo.c - DB_API for ELO layer

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -1383,12 +1383,22 @@ db_json_get_raw_json_body_from_document (const JSON_DOC *doc)
 {
   JSON_STRING_BUFFER buffer;
   rapidjson::Writer<JSON_STRING_BUFFER> json_default_writer (buffer);
+  char *ret = NULL;
 
   buffer.Clear ();
 
   doc->Accept (json_default_writer);
 
-  return db_private_strdup (NULL, buffer.GetString ());
+  ret = db_private_strdup (NULL, buffer.GetString ());
+
+#ifdef SERVER_MODE
+  if (ret != NULL)
+    {
+      mmon_add_stat_with_tracking_tag (strlen (ret) + 1);
+    }
+#endif
+
+  return ret;
 }
 
 char *

--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -2053,6 +2053,13 @@ db_get_deep_copy_of_json (const DB_JSON * src, DB_JSON * dst)
 
   raw_schema_body = db_private_strdup (NULL, src->schema_raw);
 
+#ifdef SERVER_MODE
+  if (raw_schema_body != NULL)
+    {
+      mmon_add_stat_with_tracking_tag (strlen (raw_schema_body) + 1);
+    }
+#endif
+
   doc_copy = db_json_get_copy_of_doc (src->document);
 
   dst->schema_raw = raw_schema_body;

--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -42,6 +42,8 @@
 #include "tz_support.h"
 #if !defined(SERVER_MODE)
 #include "object_accessor.h"
+#else
+#include "memory_monitor_sr.hpp"
 #endif
 #include "elo.h"
 #include "db_elo.h"
@@ -981,6 +983,9 @@ db_string_truncate (DB_VALUE * value, const int precision)
 	      error = ER_OUT_OF_VIRTUAL_MEMORY;
 	      break;
 	    }
+#ifdef SERVER_MODE
+	  mmon_add_stat_with_tracking_tag (byte_size + 1);
+#endif
 
 	  assert (byte_size < db_get_string_size (value));
 	  strncpy (string, val_str, byte_size);
@@ -1006,6 +1011,9 @@ db_string_truncate (DB_VALUE * value, const int precision)
 	      error = ER_OUT_OF_VIRTUAL_MEMORY;
 	      break;
 	    }
+#ifdef SERVER_MODE
+	  mmon_add_stat_with_tracking_tag (byte_size + 1);
+#endif
 
 	  assert (byte_size < db_get_string_size (value));
 	  strncpy (string, val_str, byte_size);
@@ -1032,6 +1040,9 @@ db_string_truncate (DB_VALUE * value, const int precision)
 	      error = ER_OUT_OF_VIRTUAL_MEMORY;
 	      break;
 	    }
+#ifdef SERVER_MODE
+	  mmon_add_stat_with_tracking_tag (byte_size + 1);
+#endif
 
 	  assert (byte_size < db_get_string_size (value));
 	  strncpy (string, val_str, byte_size);
@@ -1057,6 +1068,9 @@ db_string_truncate (DB_VALUE * value, const int precision)
 	      error = ER_OUT_OF_VIRTUAL_MEMORY;
 	      break;
 	    }
+#ifdef SERVER_MODE
+	  mmon_add_stat_with_tracking_tag (byte_size + 1);
+#endif
 
 	  assert (byte_size < db_get_string_size (value));
 	  strncpy (string, val_str, byte_size);
@@ -1083,6 +1097,9 @@ db_string_truncate (DB_VALUE * value, const int precision)
 	      error = ER_OUT_OF_VIRTUAL_MEMORY;
 	      break;
 	    }
+#ifdef SERVER_MODE
+	  mmon_add_stat_with_tracking_tag (precision);
+#endif
 
 	  memcpy (string, val_str, precision);
 	  db_make_bit (&src_value, precision << 3, string, precision << 3);
@@ -1105,6 +1122,9 @@ db_string_truncate (DB_VALUE * value, const int precision)
 	      error = ER_OUT_OF_VIRTUAL_MEMORY;
 	      break;
 	    }
+#ifdef SERVER_MODE
+	  mmon_add_stat_with_tracking_tag (precision);
+#endif
 
 	  memcpy (string, val_str, precision);
 	  db_make_varbit (&src_value, precision << 3, string, precision << 3);
@@ -1129,6 +1149,9 @@ db_string_truncate (DB_VALUE * value, const int precision)
 
   if (string != NULL)
     {
+#ifdef SERVER_MODE
+      mmon_sub_stat_with_tracking_tag (strlen (string) + 1);
+#endif
       db_private_free (NULL, string);
     }
 

--- a/src/executables/unittests_lf.c
+++ b/src/executables/unittests_lf.c
@@ -166,7 +166,7 @@ mmon_sub_stat_with_tracking_tag (int64_t size)
 }
 
 void
-mmon_move_stat_with_tracking_tag (int64_t size, bool tag_is_src)
+mmon_move_stat_with_tracking_tag (int64_t size, MMON_STAT_ID stat_id, bool tag_is_src)
 {
   return;
 }

--- a/src/executables/unittests_lf.c
+++ b/src/executables/unittests_lf.c
@@ -22,6 +22,9 @@
 
 #include "porting.h"
 #include "lock_free.h"
+#if defined(SERVER_MODE)
+#include "memory_monitor_sr.hpp"
+#endif
 #include <stdio.h>
 #include <pthread.h>
 #include <time.h>
@@ -76,6 +79,103 @@ struct xentry
 using my_hashmap = lf_hash_table_cpp<int, xentry>;
 using my_hashmap_iterator = my_hashmap::iterator;
 // *INDENT-ON*
+
+/* fake functions */
+int
+mmon_initialize (const char *server_name)
+{
+  return 0;
+}
+
+void
+mmon_notify_server_start ()
+{
+  return;
+}
+
+void
+mmon_finalize ()
+{
+  return;
+}
+
+void
+mmon_add_stat (THREAD_ENTRY * thread_p, MMON_STAT_ID stat_id, int64_t size)
+{
+  return;
+}
+
+void
+mmon_sub_stat (THREAD_ENTRY * thread_p, MMON_STAT_ID stat_id, int64_t size)
+{
+  return;
+}
+
+void
+mmon_move_stat (THREAD_ENTRY * thread_p, MMON_STAT_ID src, MMON_STAT_ID dest, int64_t size)
+{
+  return;
+}
+
+void
+mmon_resize_stat (THREAD_ENTRY * thread_p, MMON_STAT_ID stat_id, int64_t old_size, int64_t new_size)
+{
+  return;
+}
+
+void
+mmon_aggregate_server_info (MMON_SERVER_INFO & info)
+{
+  return;
+}
+
+void
+mmon_aggregate_module_info (int module_index, std::vector < MMON_MODULE_INFO > &info)
+{
+  return;
+}
+
+void
+mmon_aggregate_module_info_summary (std::vector < MMON_MODULE_INFO > &info)
+{
+  return;
+}
+
+void
+mmon_aggregate_tran_info (int tran_count, MMON_TRAN_INFO & info)
+{
+  return;
+}
+
+MMON_STAT_ID
+mmon_set_tracking_tag (MMON_STAT_ID new_tag)
+{
+  return MMON_STAT_LAST;
+}
+
+void
+mmon_add_stat_with_tracking_tag (int64_t size)
+{
+  return;
+}
+
+void
+mmon_sub_stat_with_tracking_tag (int64_t size)
+{
+  return;
+}
+
+void
+mmon_move_stat_with_tracking_tag (int64_t size, bool tag_is_src)
+{
+  return;
+}
+
+void
+mmon_resize_stat_with_tracking_tag (int64_t old_size, int64_t new_size)
+{
+  return;
+}
 
 /* entry manipulation functions */
 static void *

--- a/src/object/elo.c
+++ b/src/object/elo.c
@@ -160,6 +160,9 @@ elo_copy_structure (const DB_ELO * elo, DB_ELO * dest)
 	{
 	  return ER_OUT_OF_VIRTUAL_MEMORY;
 	}
+#ifdef SERVER_MODE
+      mmon_add_stat_with_tracking_tag (strlen (locator) + 1);
+#endif
     }
 
   if (elo->meta_data != NULL)
@@ -169,10 +172,16 @@ elo_copy_structure (const DB_ELO * elo, DB_ELO * dest)
 	{
 	  if (locator != NULL)
 	    {
+#ifdef SERVER_MODE
+	      mmon_sub_stat_with_tracking_tag (strlen (locator) + 1);
+#endif
 	      db_private_free_and_init (NULL, locator);
 	    }
 	  return ER_OUT_OF_VIRTUAL_MEMORY;
 	}
+#ifdef SERVER_MODE
+      mmon_add_stat_with_tracking_tag (strlen (meta_data) + 1);
+#endif
     }
 
   *dest = *elo;

--- a/src/object/elo.c
+++ b/src/object/elo.c
@@ -63,6 +63,9 @@
 #include "object_primitive.h"
 #include "object_representation.h"
 #include "storage_common.h"
+#if defined (SERVER_MODE)
+#include "memory_monitor_sr.hpp"
+#endif /* defined (SERVER_MODE) */
 
 static const DB_ELO elo_Initializer = { -1LL, NULL, NULL, ELO_NULL, ES_NONE };
 
@@ -102,6 +105,9 @@ elo_create (DB_ELO * elo)
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, strlen (out_uri));
       return ER_OUT_OF_VIRTUAL_MEMORY;
     }
+#ifdef SERVER_MODE
+  mmon_add_stat_with_tracking_tag (strlen (out_uri) + 1);
+#endif
 
   elo_init_structure (elo);
   elo->size = 0;
@@ -189,11 +195,17 @@ elo_free_structure (DB_ELO * elo)
     {
       if (elo->locator != NULL)
 	{
+#ifdef SERVER_MODE
+	  mmon_sub_stat_with_tracking_tag (strlen (elo->locator) + 1);
+#endif
 	  db_private_free_and_init (NULL, elo->locator);
 	}
 
       if (elo->meta_data != NULL)
 	{
+#ifdef SERVER_MODE
+	  mmon_sub_stat_with_tracking_tag (strlen (elo->meta_data) + 1);
+#endif
 	  db_private_free_and_init (NULL, elo->meta_data);
 	}
 
@@ -229,6 +241,9 @@ elo_copy (DB_ELO * elo, DB_ELO * dest)
 	  assert (er_errid () != NO_ERROR);
 	  return er_errid ();
 	}
+#ifdef SERVER_MODE
+      mmon_add_stat_with_tracking_tag (strlen (elo->meta_data) + 1);
+#endif
     }
 
   /* if it uses external storage, do transaction work */
@@ -247,6 +262,9 @@ elo_copy (DB_ELO * elo, DB_ELO * dest)
 	  es_delete_file (out_uri);
 	  goto error_return;
 	}
+#ifdef SERVER_MODE
+      mmon_add_stat_with_tracking_tag (strlen (out_uri) + 1);
+#endif
     }
   else
     {
@@ -271,6 +289,9 @@ elo_copy (DB_ELO * elo, DB_ELO * dest)
 		ret = er_errid ();
 		goto error_return;
 	      }
+#ifdef SERVER_MODE
+	    mmon_add_stat_with_tracking_tag (strlen (out_uri) + 1);
+#endif
 	    ret = lob_locator_change_state (elo->locator, locator, LOB_PERMANENT_CREATED);
 	    if (ret != NO_ERROR)
 	      {
@@ -288,6 +309,11 @@ elo_copy (DB_ELO * elo, DB_ELO * dest)
 		ret = er_errid ();
 		goto error_return;
 	      }
+#ifdef SERVER_MODE
+	    mmon_add_stat_with_tracking_tag (strlen (elo->locator) + 1);
+	    strcpy (out_uri, elo->locator);
+	    //out_uri = (char *) &(elo->locator[0]); 
+#endif
 	    ret = lob_locator_drop (elo->locator);
 	    if (ret != NO_ERROR)
 	      {
@@ -310,6 +336,9 @@ elo_copy (DB_ELO * elo, DB_ELO * dest)
 		es_delete_file (out_uri);
 		goto error_return;
 	      }
+#ifdef SERVER_MODE
+	    mmon_add_stat_with_tracking_tag (strlen (out_uri) + 1);
+#endif
 	    ret = lob_locator_add (locator, LOB_PERMANENT_CREATED);
 	    if (ret != NO_ERROR)
 	      {
@@ -338,11 +367,17 @@ elo_copy (DB_ELO * elo, DB_ELO * dest)
 error_return:
   if (locator != NULL)
     {
+#ifdef SERVER_MODE
+      mmon_add_stat_with_tracking_tag (strlen (out_uri) + 1);
+#endif
       db_private_free_and_init (NULL, locator);
     }
 
   if (meta_data != NULL)
     {
+#ifdef SERVER_MODE
+      mmon_sub_stat_with_tracking_tag (strlen (elo->meta_data) + 1);
+#endif
       db_private_free_and_init (NULL, meta_data);
     }
   return ret;

--- a/src/object/elo.c
+++ b/src/object/elo.c
@@ -272,7 +272,7 @@ elo_copy (DB_ELO * elo, DB_ELO * dest)
 	  goto error_return;
 	}
 #ifdef SERVER_MODE
-      mmon_add_stat_with_tracking_tag (strlen (out_uri) + 1);
+      mmon_add_stat_with_tracking_tag (strlen (locator) + 1);
 #endif
     }
   else
@@ -299,7 +299,7 @@ elo_copy (DB_ELO * elo, DB_ELO * dest)
 		goto error_return;
 	      }
 #ifdef SERVER_MODE
-	    mmon_add_stat_with_tracking_tag (strlen (out_uri) + 1);
+	    mmon_add_stat_with_tracking_tag (strlen (locator) + 1);
 #endif
 	    ret = lob_locator_change_state (elo->locator, locator, LOB_PERMANENT_CREATED);
 	    if (ret != NO_ERROR)
@@ -319,9 +319,7 @@ elo_copy (DB_ELO * elo, DB_ELO * dest)
 		goto error_return;
 	      }
 #ifdef SERVER_MODE
-	    mmon_add_stat_with_tracking_tag (strlen (elo->locator) + 1);
-	    strcpy (out_uri, elo->locator);
-	    //out_uri = (char *) &(elo->locator[0]); 
+	    mmon_add_stat_with_tracking_tag (strlen (locator) + 1);
 #endif
 	    ret = lob_locator_drop (elo->locator);
 	    if (ret != NO_ERROR)
@@ -346,7 +344,7 @@ elo_copy (DB_ELO * elo, DB_ELO * dest)
 		goto error_return;
 	      }
 #ifdef SERVER_MODE
-	    mmon_add_stat_with_tracking_tag (strlen (out_uri) + 1);
+	    mmon_add_stat_with_tracking_tag (strlen (locator) + 1);
 #endif
 	    ret = lob_locator_add (locator, LOB_PERMANENT_CREATED);
 	    if (ret != NO_ERROR)
@@ -377,7 +375,7 @@ error_return:
   if (locator != NULL)
     {
 #ifdef SERVER_MODE
-      mmon_add_stat_with_tracking_tag (strlen (out_uri) + 1);
+      mmon_sub_stat_with_tracking_tag (strlen (locator) + 1);
 #endif
       db_private_free_and_init (NULL, locator);
     }

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -54,6 +54,8 @@
 #include "virtual_object.h"
 #include "transform_cl.h"
 #include "dbi.h"
+#else /* defined (SERVER_MODE) */
+#include "memory_monitor_sr.hpp"
 #endif /* !defined (SERVER_MODE) */
 
 #include "dbtype.h"
@@ -1957,6 +1959,11 @@ pr_clear_value (DB_VALUE * value)
 	    }
 	  if (value->data.json.schema_raw != NULL)
 	    {
+#ifdef SERVER_MODE
+              // *INDENT-OFF*
+              mmon_sub_stat_with_tracking_tag (strlen (const_cast<char *>(value->data.json.schema_raw)) + 1);
+              // *INDENT-ON*
+#endif
 	      db_private_free (NULL, const_cast < char *>(value->data.json.schema_raw));
 	      value->data.json.schema_raw = NULL;
 	    }
@@ -1988,6 +1995,9 @@ pr_clear_value (DB_VALUE * value)
 	{
 	  if (value->need_clear)
 	    {
+#ifdef SERVER_MODE
+	      mmon_sub_stat_with_tracking_tag (value->data.midxkey.size);
+#endif
 	      db_private_free_and_init (NULL, midxkey_buf);
 	    }
 	  /*
@@ -2009,6 +2019,9 @@ pr_clear_value (DB_VALUE * value)
 	{
 	  if (value->need_clear)
 	    {
+#ifdef SERVER_MODE
+	      mmon_sub_stat_with_tracking_tag (value->data.ch.medium.size);
+#endif
 	      // here is safe to const_cast since the ownership was handed over by setting need_clear flag to true
 	      char *temp = CONST_CAST (char *, char_medium_buf);
 	      db_private_free_and_init (NULL, temp);
@@ -2028,6 +2041,9 @@ pr_clear_value (DB_VALUE * value)
 	    {
 	      if (value->data.ch.info.compressed_need_clear != 0)
 		{
+#ifdef SERVER_MODE
+		  mmon_sub_stat_with_tracking_tag (value->data.ch.medium.compressed_size);
+#endif
 		  // here is safe to const_cast since the ownership was handed over by setting need_clear flag to true
 		  db_private_free_and_init (NULL, compressed_str);
 		}
@@ -2042,6 +2058,9 @@ pr_clear_value (DB_VALUE * value)
 	    {
 	      if (value->data.ch.info.compressed_need_clear != 0)
 		{
+#ifdef SERVER_MODE
+		  mmon_sub_stat_with_tracking_tag (value->data.ch.medium.compressed_size);
+#endif
 		  db_private_free_and_init (NULL, compressed_str);
 		}
 	    }
@@ -2064,6 +2083,9 @@ pr_clear_value (DB_VALUE * value)
 	  char *temp = CONST_CAST (char *, db_get_enum_string (value));
 	  if (temp != NULL)
 	    {
+#ifdef SERVER_MODE
+	      mmon_sub_stat_with_tracking_tag (value->data.enumeration.str_val.medium.size);
+#endif
 	      db_private_free_and_init (NULL, temp);
 	    }
 	}
@@ -6925,6 +6947,9 @@ mr_setval_set_internal (DB_VALUE * dest, const DB_VALUE * src, bool copy, DB_TYP
 		    }
 		  else
 		    {
+#ifdef SERVER_MODE
+		      mmon_add_stat_with_tracking_tag (src_ref->disk_size);
+#endif
 		      ref->need_clear = true;
 		      ref->disk_size = src_ref->disk_size;
 		      ref->disk_domain = src_ref->disk_domain;

--- a/src/object/object_representation.c
+++ b/src/object/object_representation.c
@@ -45,6 +45,9 @@
 #include "query_list.h"
 #include "set_object.h"
 #include "access_spec.hpp"
+#if defined(SERVER_MODE)
+#include "memory_monitor_sr.hpp"
+#endif /* SERVER_MODE */
 
 #if defined (SUPPRESS_STRLEN_WARNING)
 #define strlen(s1)  ((int) strlen(s1))
@@ -6032,6 +6035,9 @@ or_get_enumeration (OR_BUF * buf, DB_ENUMERATION * enumeration)
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (DB_ENUM_ELEMENT) * count);
       return ER_OUT_OF_VIRTUAL_MEMORY;
     }
+#ifdef SERVER_MODE
+  mmon_add_stat_with_tracking_tag (sizeof (DB_ENUM_ELEMENT) * count);
+#endif
 
   for (idx = 0; idx < count; idx++)
     {
@@ -6062,6 +6068,9 @@ or_get_enumeration (OR_BUF * buf, DB_ENUMERATION * enumeration)
 	  error = ER_OUT_OF_VIRTUAL_MEMORY;
 	  goto error_return;
 	}
+#ifdef SERVER_MODE
+      mmon_add_stat_with_tracking_tag (str_size + 1);
+#endif
       value_str = db_get_string (&value);
       if (value_str)
 	{
@@ -6093,8 +6102,14 @@ error_return:
     {
       for (--idx; idx >= 0; idx--)
 	{
+#ifdef SERVER_MODE
+	  mmon_sub_stat_with_tracking_tag (strlen (DB_GET_ENUM_ELEM_STRING (&enum_vals[idx])) + 1);
+#endif
 	  free_and_init (DB_GET_ENUM_ELEM_STRING (&enum_vals[idx]));
 	}
+#ifdef SERVER_MODE
+      mmon_sub_stat_with_tracking_tag (sizeof (DB_ENUM_ELEMENT) * count);
+#endif
       free_and_init (enum_vals);
     }
   pr_clear_value (&value);
@@ -6703,6 +6718,12 @@ or_get_json_schema (OR_BUF * buf, REFPTR (char, schema))
   else
     {
       schema = db_private_strdup (NULL, db_get_string (&schema_value));
+#ifdef SERVER_MODE
+      if (schema != NULL)
+	{
+	  mmon_add_stat_with_tracking_tag (db_get_string_size (&schema_value) + 1);
+	}
+#endif
     }
 
   pr_clear_value (&schema_value);

--- a/src/object/object_representation.c
+++ b/src/object/object_representation.c
@@ -1009,6 +1009,9 @@ or_put_varchar_internal (OR_BUF * buf, char *string, int charlen, int align)
 	  rc = ER_OUT_OF_VIRTUAL_MEMORY;
 	  goto cleanup;
 	}
+#ifdef SERVER_MODE
+      mmon_add_stat_with_tracking_tag (compress_buffer_size);
+#endif
 
       /* Compress the string */
       compressed_length = LZ4_compress_default (string, compressed_string, charlen, compress_buffer_size);
@@ -1095,6 +1098,9 @@ cleanup:
 
   if (compressed_string != NULL)
     {
+#ifdef SERVER_MODE
+      mmon_sub_stat_with_tracking_tag (compress_buffer_size);
+#endif
       free_and_init (compressed_string);
     }
 

--- a/src/query/numeric_opfunc.c
+++ b/src/query/numeric_opfunc.c
@@ -41,6 +41,9 @@
 #include "byte_order.h"
 #include "object_primitive.h"
 #include "object_representation.h"
+#if defined (SERVER_MODE)
+#include "memory_monitor_sr.hpp"
+#endif /* SERVER_MODE */
 
 #if defined (__cplusplus)
 #include <cmath>
@@ -3623,6 +3626,9 @@ numeric_db_value_coerce_from_num (DB_VALUE * src, DB_VALUE * dest, DB_DATA_STATU
 	    assert (er_errid () != NO_ERROR);
 	    return er_errid ();
 	  }
+#ifdef SERVER_MODE
+	mmon_add_stat_with_tracking_tag (size + 1);
+#endif
 
 	strcpy (return_string, str_buf);
 	type = DB_VALUE_DOMAIN_TYPE (dest);

--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -1445,6 +1445,10 @@ file_header_dump_descriptor (THREAD_ENTRY * thread_p, const FILE_HEADER * fhead,
 	    file_print_name_of_class (thread_p, fp, &fhead->descriptor.btree.class_oid);
 	    fprintf (fp, ", %s, ATTRID: %5d \n", index_name != NULL ? index_name : "*UNKNOWN-INDEX*",
 		     fhead->descriptor.btree.attr_id);
+	    if (index_name != NULL)
+	      {
+		free_and_init (index_name);
+	      }
 	  }
       }
       break;

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -12385,7 +12385,7 @@ heap_attrinfo_start_with_index (THREAD_ENTRY * thread_p, OID * class_oid, RECDES
   if (set_attrids != guess_attrids)
     {
 #ifdef SERVER_MODE
-      if (ser_attrids != NULL)
+      if (set_attrids != NULL)
 	{
 	  mmon_sub_stat (thread_p, MMON_HEAP_ATTRINFO, classrepr->n_attributes * sizeof (ATTR_ID));
 	}
@@ -12408,7 +12408,7 @@ error:
   if (set_attrids != guess_attrids)
     {
 #ifdef SERVER_MODE
-      if (ser_attrids != NULL)
+      if (set_attrids != NULL)
 	{
 	  mmon_sub_stat (thread_p, MMON_HEAP_ATTRINFO, classrepr->n_attributes * sizeof (ATTR_ID));
 	}
@@ -12554,7 +12554,7 @@ heap_attrinfo_start_with_btid (THREAD_ENTRY * thread_p, OID * class_oid, BTID * 
   if (set_attrids != guess_attrids)
     {
 #ifdef SERVER_MODE
-      if (ser_attrids != NULL)
+      if (set_attrids != NULL)
 	{
 	  mmon_sub_stat (thread_p, MMON_HEAP_ATTRINFO, num_found_attrs * sizeof (ATTR_ID));
 	}
@@ -12575,7 +12575,7 @@ error:
   if (set_attrids != guess_attrids)
     {
 #ifdef SERVER_MODE
-      if (ser_attrids != NULL)
+      if (set_attrids != NULL)
 	{
 	  mmon_sub_stat (thread_p, MMON_HEAP_ATTRINFO, num_found_attrs * sizeof (ATTR_ID));
 	}

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -981,6 +981,9 @@ heap_stats_entry_free (THREAD_ENTRY * thread_p, void *data, void *args)
       else
 	{
 	  free_and_init (ent);
+#ifdef SERVER_MODE
+	  mmon_sub_stat (thread_p, MMON_HEAP_BESTSPACE, sizeof (HEAP_STATS_ENTRY));
+#endif
 
 	  heap_Bestspace->num_free++;
 	}
@@ -16929,6 +16932,9 @@ heap_classrepr_dump_all (THREAD_ENTRY * thread_p, FILE * fp, OID * class_oid)
 	}
 
       fprintf (fp, "\n*** End of dump.\n");
+#ifdef SERVER_MODE
+      mmon_sub_stat (thread_p, MMON_HEAP_OTHERS, sizeof (OR_CLASSREP *) * count);
+#endif
       free_and_init (rep_all);
     }
 
@@ -17861,6 +17867,9 @@ heap_header_next_scan (THREAD_ENTRY * thread_p, int cursor, DB_VALUE ** out_valu
     {
       goto cleanup;
     }
+#ifdef SERVER_MODE
+  mmon_add_stat (thread_p, MMON_HEAP_OTHERS, strlen (class_name) + 1);
+#endif
 
   /* Class_oid */
   oid_to_string (buf, sizeof (buf), &heap_hdr->class_oid);
@@ -17870,6 +17879,9 @@ heap_header_next_scan (THREAD_ENTRY * thread_p, int cursor, DB_VALUE ** out_valu
     {
       goto cleanup;
     }
+#ifdef SERVER_MODE
+  mmon_add_stat (thread_p, MMON_HEAP_OTHERS, strlen (buf) + 1);
+#endif
 
   /* HFID */
   db_make_int (out_values[idx], hfid_p->vfid.volid);
@@ -17889,6 +17901,9 @@ heap_header_next_scan (THREAD_ENTRY * thread_p, int cursor, DB_VALUE ** out_valu
     {
       goto cleanup;
     }
+#ifdef SERVER_MODE
+  mmon_add_stat (thread_p, MMON_HEAP_OTHERS, strlen (buf) + 1);
+#endif
 
   /* Next_vpid */
   vpid_to_string (buf, sizeof (buf), &heap_hdr->next_vpid);
@@ -17898,6 +17913,9 @@ heap_header_next_scan (THREAD_ENTRY * thread_p, int cursor, DB_VALUE ** out_valu
     {
       goto cleanup;
     }
+#ifdef SERVER_MODE
+  mmon_add_stat (thread_p, MMON_HEAP_OTHERS, strlen (buf) + 1);
+#endif
 
   /* Unfill space */
   db_make_int (out_values[idx], heap_hdr->unfill_space);
@@ -17950,6 +17968,9 @@ heap_header_next_scan (THREAD_ENTRY * thread_p, int cursor, DB_VALUE ** out_valu
     {
       goto cleanup;
     }
+#ifdef SERVER_MODE
+  mmon_add_stat (thread_p, MMON_HEAP_OTHERS, strlen (buf) + 1);
+#endif
 
   db_make_int (out_values[idx], heap_hdr->estimates.num_second_best);
   idx++;
@@ -17989,6 +18010,9 @@ heap_header_next_scan (THREAD_ENTRY * thread_p, int cursor, DB_VALUE ** out_valu
     {
       goto cleanup;
     }
+#ifdef SERVER_MODE
+  mmon_add_stat (thread_p, MMON_HEAP_OTHERS, strlen (buf) + 1);
+#endif
 
   vpid_to_string (buf, sizeof (buf), &heap_hdr->estimates.last_vpid);
   error = db_make_string_copy (out_values[idx], buf);
@@ -17997,6 +18021,9 @@ heap_header_next_scan (THREAD_ENTRY * thread_p, int cursor, DB_VALUE ** out_valu
     {
       goto cleanup;
     }
+#ifdef SERVER_MODE
+  mmon_add_stat (thread_p, MMON_HEAP_OTHERS, strlen (buf) + 1);
+#endif
 
   vpid_to_string (buf, sizeof (buf), &heap_hdr->estimates.full_search_vpid);
   error = db_make_string_copy (out_values[idx], buf);
@@ -18005,6 +18032,9 @@ heap_header_next_scan (THREAD_ENTRY * thread_p, int cursor, DB_VALUE ** out_valu
     {
       goto cleanup;
     }
+#ifdef SERVER_MODE
+  mmon_add_stat (thread_p, MMON_HEAP_OTHERS, strlen (buf) + 1);
+#endif
 
   assert (idx == out_cnt);
 
@@ -18017,6 +18047,9 @@ cleanup:
 
   if (class_name != NULL)
     {
+#ifdef SERVER_MODE
+      mmon_sub_stat (thread_p, MMON_HEAP_OTHERS, strlen (class_name) + 1);
+#endif
       free_and_init (class_name);
     }
 
@@ -18112,6 +18145,9 @@ heap_capacity_next_scan (THREAD_ENTRY * thread_p, int cursor, DB_VALUE ** out_va
     {
       goto cleanup;
     }
+#ifdef SERVER_MODE
+  mmon_add_stat (thread_p, MMON_HEAP_OTHERS, strlen (classname) + 1);
+#endif
 
   oid_to_string (class_oid_str, sizeof (class_oid_str), &fdes.heap.class_oid);
   error = db_make_string_copy (out_values[idx], class_oid_str);
@@ -18120,6 +18156,9 @@ heap_capacity_next_scan (THREAD_ENTRY * thread_p, int cursor, DB_VALUE ** out_va
     {
       goto cleanup;
     }
+#ifdef SERVER_MODE
+  mmon_add_stat (thread_p, MMON_HEAP_OTHERS, strlen (class_oid_str) + 1);
+#endif
 
   db_make_int (out_values[idx], hfid_p->vfid.volid);
   idx++;
@@ -18182,6 +18221,9 @@ cleanup:
 
   if (classname != NULL)
     {
+#ifdef SERVER_MODE
+      mmon_sub_stat (thread_p, MMON_HEAP_OTHERS, strlen (classname) + 1);
+#endif
       free_and_init (classname);
     }
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -1550,6 +1550,9 @@ heap_classrepr_finalize_cache (void)
 
   if (heap_Classrepr == NULL)
     {
+#ifdef SERVER_MODE
+      (void) mmon_set_tracking_tag (prev_tag);
+#endif
       return NO_ERROR;		/* nop */
     }
 
@@ -14867,6 +14870,10 @@ heap_chkreloc_end (HEAP_CHKALL_RELOCOIDS * chk)
 #endif
   free_and_init (chk->unfound_reloc_oids);
 
+#ifdef SERVER_MODE
+  (void) mmon_set_tracking_tag (prev_tag);
+#endif
+
   return valid_reloc;
 }
 
@@ -15497,6 +15504,10 @@ heap_chnguess_finalize (void)
   heap_Guesschn->nbytes = 0;
 
   heap_Guesschn = NULL;
+
+#ifdef SERVER_MODE
+  (void) mmon_set_tracking_tag (prev_tag);
+#endif
 
   return ret;
 }
@@ -17645,6 +17656,9 @@ heap_object_upgrade_domain (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * upd_scanca
   ATTR_ID atts_id[1] = { 0 };
   DB_VALUE orig_value;
   TP_DOMAIN_STATUS status;
+#ifdef SERVER_MODE
+  MMON_STAT_ID prev_tag = mmon_set_tracking_tag (MMON_HEAP_OTHERS);
+#endif
 
   db_make_null (&orig_value);
 
@@ -17957,6 +17971,9 @@ heap_object_upgrade_domain (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * upd_scanca
 
 exit:
   pr_clear_value (&orig_value);
+#ifdef SERVER_MODE
+  (void) mmon_set_tracking_tag (prev_tag);
+#endif
   return error;
 }
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -71,6 +71,9 @@
 #include "log_append.hpp"
 #include "string_buffer.hpp"
 #include "tde.h"
+#if defined(SERVER_MODE)
+#include "memory_monitor_sr.hpp"
+#endif /* SERVER_MODE */
 
 #include <set>
 
@@ -14306,6 +14309,9 @@ heap_dump_capacity (THREAD_ENTRY * thread_p, FILE * fp, const HFID * hfid)
 static DISK_ISVALID
 heap_chkreloc_start (HEAP_CHKALL_RELOCOIDS * chk)
 {
+#ifdef SERVER_MODE
+  MMON_STAT_ID prev_tracking_tag = mmon_set_tracking_tag (MMON_HEAP_OTHERS);
+#endif
   chk->ht = mht_create ("Validate Relocation entries hash table", HEAP_CHK_ADD_UNFOUND_RELOCOIDS, oid_hash,
 			oid_compare_equals);
   if (chk->ht == NULL)
@@ -14340,6 +14346,10 @@ heap_chkreloc_start (HEAP_CHKALL_RELOCOIDS * chk)
   chk->verify = true;
   chk->verify_not_vacuumed = false;
   chk->not_vacuumed_res = DISK_VALID;
+
+#ifdef SERVER_MODE
+  (void) mmon_set_tracking_tag (prev_tracking_tag);
+#endif
 
   return DISK_VALID;
 }

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -24110,7 +24110,7 @@ heap_hfid_table_entry_alloc (void)
     }
 
 #ifdef SERVER_MODE
-  mmon_add_stat (thread_get_thread_entry_info (), MMON_HEAP_HFIDTABLE, sizeof (HEAP_HFID_TABLE_ENTRY));
+  mmon_add_stat (thread_get_thread_entry_info (), MMON_HEAP_HFIDTABLE_HASH, sizeof (HEAP_HFID_TABLE_ENTRY));
 #endif
 
   new_entry->classname = NULL;
@@ -24141,7 +24141,7 @@ heap_hfid_table_entry_free (void *entry)
 	}
 
 #ifdef SERVER_MODE
-      mmon_sub_stat (thread_get_thread_entry_info (), MMON_HEAP_HFIDTABLE, sizeof (HEAP_HFID_TABLE_ENTRY));
+      mmon_sub_stat (thread_get_thread_entry_info (), MMON_HEAP_HFIDTABLE_HASH, sizeof (HEAP_HFID_TABLE_ENTRY));
 #endif
       free (entry);
       return NO_ERROR;

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -35,6 +35,9 @@
 #include "memory_alloc.h"
 #include "page_buffer.h"
 #include "resource_tracker.hpp"
+#if defined(SERVER_MODE)
+#include "memory_monitor_sr.hpp"
+#endif
 
 #include <cstring>
 #include <sstream>
@@ -127,6 +130,9 @@ namespace cubthread
     , no_supplemental_log (false)
     , trigger_involved (false)
     , is_cdc_daemon (false)
+#ifdef SERVER_MODE
+    , mmon_tracking_tag (MMON_OTHERS)
+#endif
 #if !defined (NDEBUG)
     , fi_test_array (NULL)
     , count_private_allocators (0)

--- a/src/thread/thread_entry.hpp
+++ b/src/thread/thread_entry.hpp
@@ -52,6 +52,8 @@ struct log_zip;
 struct vacuum_worker;
 // from xasl_unpack_info.hpp
 struct xasl_unpack_info;
+// from memory_monitor_sr.hpp
+enum mmon_stat_id:int;
 
 // forward resource trackers
 namespace cubbase
@@ -278,6 +280,11 @@ namespace cubthread
       bool no_supplemental_log;
       bool trigger_involved;
       bool is_cdc_daemon;
+
+#ifdef SERVER_MODE
+      /* for memory monitoring */
+      enum mmon_stat_id mmon_tracking_tag;
+#endif
 
 #if !defined(NDEBUG)
       fi_test_item *fi_test_array;

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2265,6 +2265,14 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
 
   event_log_init (db_name);
 
+#if defined(SERVER_MODE)
+  error_code = mmon_initialize (db_name);
+  if (error_code != NO_ERROR)
+    {
+      goto error;
+    }
+#endif
+
   /* initialize allocations areas for things we need, on the client, most of this is done inside ws_init(). */
   area_init ();
   error_code = set_area_init ();
@@ -2317,14 +2325,6 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
       goto error;
     }
   /* *INDENT-ON* */
-
-#if defined(SERVER_MODE)
-  error_code = mmon_initialize (db_name);
-  if (error_code != NO_ERROR)
-    {
-      goto error;
-    }
-#endif
 
   pr_Enable_string_compression = prm_get_bool_value (PRM_ID_ENABLE_STRING_COMPRESSION);
 

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -604,7 +604,7 @@ struct log_tdes
 
   bool has_supplemental_log;	/* Checks if supplemental log has been appended within the transaction */
   // *INDENT-OFF*
-  std::atomic<uint64_t> cur_mem_usage;
+  std::atomic<int64_t> cur_mem_usage;
   // *INDENT-ON*
 
   // *INDENT-OFF*

--- a/src/transaction/mvcc.c
+++ b/src/transaction/mvcc.c
@@ -30,6 +30,9 @@
 #include "perf_monitor.h"
 #include "porting_inline.hpp"
 #include "vacuum.h"
+#if defined(SERVER_MODE)
+#include "memory_monitor_sr.hpp"
+#endif /* SERVER_MODE */
 
 #define MVCC_IS_REC_INSERTER_ACTIVE(thread_p, rec_header_p) \
   (mvcc_is_active_id (thread_p, (rec_header_p)->mvcc_ins_id))
@@ -664,6 +667,9 @@ mvcc_snapshot::reset ()
 void
 mvcc_snapshot::copy_to (mvcc_snapshot & dest) const
 {
+#ifdef SERVER_MODE
+  MMON_STAT_ID prev_tag = mmon_set_tracking_tag (MMON_OTHERS);
+#endif
   dest.m_active_mvccs.initialize ();
   m_active_mvccs.copy_to (dest.m_active_mvccs, mvcc_active_tran::copy_safety::THREAD_SAFE);
 
@@ -671,6 +677,9 @@ mvcc_snapshot::copy_to (mvcc_snapshot & dest) const
   dest.highest_completed_mvccid = highest_completed_mvccid;
   dest.snapshot_fnc = snapshot_fnc;
   dest.valid = valid;
+#ifdef SERVER_MODE
+  (void) mmon_set_tracking_tag (prev_tag);
+#endif
 }
 
 mvcc_info::mvcc_info ()

--- a/src/transaction/mvcc_active_tran.cpp
+++ b/src/transaction/mvcc_active_tran.cpp
@@ -41,6 +41,16 @@ mvcc_active_tran::mvcc_active_tran ()
 
 mvcc_active_tran::~mvcc_active_tran ()
 {
+#ifdef SERVER_MODE
+  if (m_bit_area)
+    {
+      mmon_sub_stat_with_tracking_tag (sizeof (unit_type) * BITAREA_MAX_SIZE);
+    }
+  if (m_long_tran_mvccids)
+    {
+      mmon_sub_stat_with_tracking_tag (sizeof (UINT64) * long_tran_max_size ());
+    }
+#endif
   delete [] m_bit_area;
   delete [] m_long_tran_mvccids;
 }
@@ -68,8 +78,14 @@ void
 mvcc_active_tran::finalize ()
 {
 #ifdef SERVER_MODE
-  mmon_sub_stat_with_tracking_tag (sizeof (unit_type) * BITAREA_MAX_SIZE +
-				   sizeof (UINT64) * long_tran_max_size ());
+  if (m_bit_area)
+    {
+      mmon_sub_stat_with_tracking_tag (sizeof (unit_type) * BITAREA_MAX_SIZE);
+    }
+  if (m_long_tran_mvccids)
+    {
+      mmon_sub_stat_with_tracking_tag (sizeof (UINT64) * long_tran_max_size ());
+    }
 #endif
   delete [] m_bit_area;
   m_bit_area = NULL;

--- a/src/transaction/mvcc_active_tran.cpp
+++ b/src/transaction/mvcc_active_tran.cpp
@@ -23,6 +23,9 @@
 #include "mvcc_active_tran.hpp"
 
 #include "log_impl.h"
+#if defined(SERVER_MODE)
+#include "memory_monitor_sr.hpp"
+#endif /* SERVER_MODE */
 
 #include <cstring>
 
@@ -55,11 +58,19 @@ mvcc_active_tran::initialize ()
   m_long_tran_mvccids = new MVCCID[long_tran_max_size ()] ();
   m_long_tran_mvccids_length = 0;
   m_initialized = true;
+#ifdef SERVER_MODE
+  mmon_add_stat_with_tracking_tag (sizeof (unit_type) * BITAREA_MAX_SIZE +
+				   sizeof (UINT64) * long_tran_max_size ());
+#endif
 }
 
 void
 mvcc_active_tran::finalize ()
 {
+#ifdef SERVER_MODE
+  mmon_sub_stat_with_tracking_tag (sizeof (unit_type) * BITAREA_MAX_SIZE +
+				   sizeof (UINT64) * long_tran_max_size ());
+#endif
   delete [] m_bit_area;
   m_bit_area = NULL;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24855

Register heap module
 - When base data structure is returned to its free-list, free-area, etc.,  subtract transaction memory usage.
 - Add mmon_tracking_tag in THREAD_ENTRY
 - Add memory tracking functions at base data structures
 - Add memory tracking functions at heap file module
   - will be upload per component