### PR TITLE
[CBRD-24996] er_clear() is slipped even if synonym is found succesfully

### DIFF
--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -5495,6 +5495,10 @@ sm_find_class_with_purpose (const char *name, bool for_update)
 	  char target_name[SM_MAX_IDENTIFIER_LENGTH] = { '\0' };
 	  sm_get_synonym_target_name (synonym_mop, target_name, SM_MAX_IDENTIFIER_LENGTH);
 	  class_mop = locator_find_class_with_purpose (target_name, for_update);
+	  if (class_mop)
+	    {
+	      er_clear ();
+	    }
 	}
       else
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24996

If the table is not found but the synonym is found, the error is cleared.