### PR TITLE
[CBRD-25004] function pushed incorrectly in dblink

### DIFF
--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -4151,7 +4151,11 @@ mq_is_dblink_pushable_term (PARSER_CONTEXT * parser, PT_NODE * term)
 	  /* wrapped cast should be pushed and it will be removed while rewriting the dblink query */
 	  if (term->info.expr.op == PT_CAST && PT_EXPR_INFO_IS_FLAGED (term, PT_EXPR_INFO_CAST_WRAP))
 	    {
-	      return true;
+	      /* it needs to check if the argument is pushable */
+	      if (mq_is_dblink_pushable_term (parser, term->info.expr.arg1))
+		{
+		  return true;
+		}
 	    }
 
 	  /* other expression like built-in and stored function and etc. */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25004

In dblink queries, functions should not be pushed, but there were cases where they were pushed incorrectly. For example, when a cast is wrapped with a function and a push is checked, only the cast is removed.
