### PR TITLE
[CBRD-25018] In case of unsigned tinyint in mysql and mariadb, error …

### DIFF
--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -474,8 +474,16 @@ cgw_cur_tuple (T_NET_BUF * net_buf, T_COL_BINDER * first_col_binding, int cursor
 		}
 	      break;
 	    case SQL_TINYINT:
-	      net_buf_cp_int (net_buf, NET_SIZE_SHORT, NULL);
-	      net_buf_cp_short (net_buf, *((char *) this_col_binding->data_buffer));
+	      if (this_col_binding->col_unsigned_type)
+		{
+		  net_buf_cp_int (net_buf, NET_SIZE_SHORT, NULL);
+		  net_buf_cp_short (net_buf, *((unsigned char *) this_col_binding->data_buffer));
+		}
+	      else
+		{
+		  net_buf_cp_int (net_buf, NET_SIZE_SHORT, NULL);
+		  net_buf_cp_short (net_buf, *((char *) this_col_binding->data_buffer));
+		}
 	      break;
 	    case SQL_FLOAT:
 	    case SQL_REAL:
@@ -1055,11 +1063,7 @@ cgw_col_bindings (SQLHSTMT hstmt, SQLSMALLINT num_cols, T_COL_BINDER ** col_bind
 
 	  if (col_unsigned_type)
 	    {
-	      if (col_data_type == SQL_TINYINT)
-		{
-		  col_data_type = SQL_SMALLINT;
-		}
-	      else if (col_data_type == SQL_SMALLINT)
+	      if (col_data_type == SQL_SMALLINT)
 		{
 		  col_data_type = SQL_INTEGER;
 		}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25018

Purpose
In the case of unsigned tinyint in mysql and mariadb, an error occurred when retrieving the value as smallint type.
When the Gateway requested a value from ODBC, it requested a smallint. At this time, if the value was 127 or higher, 0xFF was added in front of the value and an incorrect value was delivered.
For example, if you input 225 into unsigned tinyint and read the value, it should return 225 (0xE1), but in reality, it returns 65505 (0xFFE1).
For reference, values 1 to 127 are returned as 1(0x01) to 127(0xF7).

 In the case of unsigned tinyint, when requesting a value from ODBC, it needs to be changed to request tinyint.

Implementation
N/A

Remarks
N/A