### PR TITLE
[CBRD-25021] Change buffer size to prevent Gateway CAS coredump in Windows

### DIFF
--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -1716,7 +1716,7 @@ cgw_sql_prepare (SQLCHAR * sql_stmt)
 		   err_code = SQLAllocHandle (SQL_HANDLE_STMT, local_odbc_handle->hdbc, &local_odbc_handle->hstmt));
     }
 
-  out_length = strlen (in_string) * sizeof (wchar_t);
+  out_length = strlen (in_string) * sizeof (wchar_t) + 1;
   out_string = (wchar_t *) malloc (out_length);
   if (out_string == NULL)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25021

Purpose
In the process of changing Multibyte to Unicode in Windows, data overflow occurred because the size of the buffer containing Unicode data was small.
When data overflow occurred, coredump occurred irregularly in Gateway CAS.
Data overflow was prevented by changing the buffer size.

Implementation
N/A

Remarks
N/A