### PR TITLE
[CBRD-25007] string literals with a length larger than 65535 results in an invalid Java string literal

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprStr.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprStr.java
@@ -84,4 +84,3 @@ public class ExprStr extends Expr {
 
     private static final int MAX_STR_LITERAL_LEN = 65535;
 }
-

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprStr.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprStr.java
@@ -49,6 +49,39 @@ public class ExprStr extends Expr {
     }
 
     public String javaCode() {
-        return '"' + val + '"';
+
+        int len = val.length();
+        if (len <= MAX_STR_LITERAL_LEN) {
+            return "(\"" + val + "\")";
+        } else {
+            StringBuilder sbuilder = new StringBuilder();
+            boolean first = true;
+            sbuilder.append("String.join(\"\", new String[] { ");
+
+            int b;
+            for (b = 0; b + MAX_STR_LITERAL_LEN < len; b += MAX_STR_LITERAL_LEN) {
+                if (first) {
+                    first = false;
+                } else {
+                    sbuilder.append(", ");
+                }
+                sbuilder.append('"' + val.substring(b, b + MAX_STR_LITERAL_LEN) + '"');
+            }
+            if (!first) {
+                sbuilder.append(", ");
+            }
+            sbuilder.append('"' + val.substring(b, len) + '"');
+
+            sbuilder.append(" })");
+
+            return sbuilder.toString();
+        }
     }
+
+    // -------------------------------------------------------------------
+    // Private
+    // -------------------------------------------------------------------
+
+    private static final int MAX_STR_LITERAL_LEN = 65535;
 }
+


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25007

