### PR TITLE
[CBRD-25008] A host variable in a SELECT list causes a semantic error

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/data/DBType.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/data/DBType.java
@@ -56,6 +56,7 @@ public class DBType {
     public static final int DB_TIMESTAMP = 11;
     public static final int DB_DATE = 12;
     public static final int DB_MONETARY = 13;
+    public static final int DB_VARIABLE = 14;
     public static final int DB_SHORT = 18;
     public static final int DB_NUMERIC = 22;
     public static final int DB_OID = 20;

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -33,6 +33,7 @@ package com.cubrid.plcsql.compiler;
 import static com.cubrid.plcsql.compiler.antlrgen.PcsParser.*;
 
 import com.cubrid.jsp.data.ColumnInfo;
+import com.cubrid.jsp.data.DBType;
 import com.cubrid.plcsql.compiler.antlrgen.PcsParserBaseVisitor;
 import com.cubrid.plcsql.compiler.ast.*;
 import com.cubrid.plcsql.compiler.serverapi.*;
@@ -2191,6 +2192,10 @@ public class ParseTreeConverter extends PcsParserBaseVisitor<AstNode> {
     }
 
     private ExprId visitNonFuncIdentifier(String name, ParserRuleContext ctx) {
+        return visitNonFuncIdentifier(name, ctx, true);
+    }
+
+    private ExprId visitNonFuncIdentifier(String name, ParserRuleContext ctx, boolean throwIfNotFound) {
         ExprId ret;
         Decl decl = symbolStack.getDeclForIdExpr(name);
         if (decl == null) {
@@ -2201,11 +2206,10 @@ public class ParseTreeConverter extends PcsParserBaseVisitor<AstNode> {
         } else if (decl instanceof DeclFunc) {
             ret = null; // the name represents a function in its scope
         } else {
-            assert false : "unreachable";
             throw new RuntimeException("unreachable");
         }
 
-        if (ret == null) {
+        if (ret == null && throwIfNotFound) {
             throw new SemanticError(Misc.getLineColumnOf(ctx), "undeclared id " + name);
         } else {
             return ret;
@@ -2380,7 +2384,38 @@ public class ParseTreeConverter extends PcsParserBaseVisitor<AstNode> {
             for (ColumnInfo ci : sws.selectList) {
                 String col = Misc.getNormalizedText(getColumnNameInSelectList(ci));
 
-                if (!DBTypeAdapter.isSupported(ci.type)) {
+                // get type of the column
+                TypeSpec typeSpec;
+                if (ci.type == DBType.DB_VARIABLE) {
+                    // Maybe, the column contains a host variable
+
+                    ExprId id = visitNonFuncIdentifier(col, ctx, false);
+                    if (id == null) {
+                        // col is not a host variable, but an expression which has a host variable as a subexpression
+                        typeSpec = TypeSpecSimple.OBJECT;   // unknown some type. best offort to give a type
+                    } else {
+                        // col is a single identifier, which is almost of no use and stupid
+                        DeclId decl = id.decl;
+                        if (decl instanceof DeclIdTyped) {
+                            typeSpec = ((DeclIdTyped) decl).typeSpec();
+                        } else if (decl instanceof DeclForIter) {
+                            typeSpec = TypeSpecSimple.INT;
+                        } else if (decl instanceof DeclForRecord) {
+                            throw new SemanticError(
+                                    Misc.getLineColumnOf(ctx), // s423
+                                    "for-loop iterator record " + id.name + " cannot be in a select list");
+                        } else if (decl instanceof DeclCursor) {
+                            throw new SemanticError(
+                                    Misc.getLineColumnOf(ctx), // s424
+                                    "cursor " + id.name + " cannot be in a select list");
+                        } else {
+                            throw new RuntimeException("unreachable");
+                        }
+                    }
+
+                } else if (DBTypeAdapter.isSupported(ci.type)) {
+                    typeSpec = DBTypeAdapter.getTypeSpec(ci.type);
+                } else {
                     throw new SemanticError(
                             Misc.getLineColumnOf(ctx), // s426
                             "the SELECT statement contains a column "
@@ -2388,7 +2423,6 @@ public class ParseTreeConverter extends PcsParserBaseVisitor<AstNode> {
                                     + " of an unsupported type "
                                     + DBTypeAdapter.getSqlTypeName(ci.type));
                 }
-                TypeSpec typeSpec = DBTypeAdapter.getTypeSpec(ci.type);
                 assert typeSpec != null;
 
                 TypeSpec old = selectList.put(col, typeSpec);

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -2195,7 +2195,8 @@ public class ParseTreeConverter extends PcsParserBaseVisitor<AstNode> {
         return visitNonFuncIdentifier(name, ctx, true);
     }
 
-    private ExprId visitNonFuncIdentifier(String name, ParserRuleContext ctx, boolean throwIfNotFound) {
+    private ExprId visitNonFuncIdentifier(
+            String name, ParserRuleContext ctx, boolean throwIfNotFound) {
         ExprId ret;
         Decl decl = symbolStack.getDeclForIdExpr(name);
         if (decl == null) {
@@ -2391,8 +2392,11 @@ public class ParseTreeConverter extends PcsParserBaseVisitor<AstNode> {
 
                     ExprId id = visitNonFuncIdentifier(col, ctx, false);
                     if (id == null) {
-                        // col is not a host variable, but an expression which has a host variable as a subexpression
-                        typeSpec = TypeSpecSimple.OBJECT;   // unknown some type. best offort to give a type
+                        // col is not a host variable, but an expression which has a host variable
+                        // as a subexpression
+                        typeSpec =
+                                TypeSpecSimple
+                                        .OBJECT; // unknown some type. best offort to give a type
                     } else {
                         // col is a single identifier, which is almost of no use and stupid
                         DeclId decl = id.decl;
@@ -2403,7 +2407,9 @@ public class ParseTreeConverter extends PcsParserBaseVisitor<AstNode> {
                         } else if (decl instanceof DeclForRecord) {
                             throw new SemanticError(
                                     Misc.getLineColumnOf(ctx), // s423
-                                    "for-loop iterator record " + id.name + " cannot be in a select list");
+                                    "for-loop iterator record "
+                                            + id.name
+                                            + " cannot be in a select list");
                         } else if (decl instanceof DeclCursor) {
                             throw new SemanticError(
                                     Misc.getLineColumnOf(ctx), // s424


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25008

- If a column of a select list has DB_VARIABLE (14) type, then give it OBJECT type except for the case when it is a single host variable, in which case give it the type of the host variable.
