### PR TITLE
[CBRD-25022] Error representing empty string as NULL character in windows

### DIFF
--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -2628,7 +2628,7 @@ cgw_unicode_to_utf8 (wchar_t * in_src, int in_size, char **out_target, int *out_
       return (-1);
     }
 
-  if (in_size <= 0)
+  if (in_size < 0)
     {
       return (-1);
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25022

Purpose
When reading an empty string in Windows ODBC, it should be expressed as '', but it is expressed as NULL.

Implementation
N/A

Remarks
N/A