### PR TITLE
[CBRD-25006] addition and subtraction on TIMESTAMP values produce a wrong value

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/CoercionScheme.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/CoercionScheme.java
@@ -82,12 +82,10 @@ public enum CoercionScheme {
             int len = argTypes.size();
 
             TypeSpec headTy = argTypes.get(0);
-            boolean hasDatetime = headTy.equals(TypeSpecSimple.DATETIME);
 
             TypeSpec wholeCommonTy = null;
             for (int i = 1; i < len; i++) {
                 TypeSpec argType = argTypes.get(i);
-                hasDatetime = hasDatetime || argType.equals(TypeSpecSimple.DATETIME);
 
                 TypeSpec commonTy = getCommonTypeInner(headTy, argType, compOpCommonType);
                 if (commonTy == null) {
@@ -112,17 +110,7 @@ public enum CoercionScheme {
             } else if (wholeCommonTy.equals(TypeSpecSimple.OBJECT)) {
                 // In this case, pairwise common types are not equal to a single type, and
                 // pairwise coomparison in opBetween and opIn in SpLib uses runtime type check and
-                // conversion.
-                if (hasDatetime) {
-                    // This case is not supported because the Java types of DATETIME and TIMESTAMP
-                    // are the same Timestamp,
-                    // which causes ambiguity in runtime type check in compareWithRuntimeConv in
-                    // SpLib.
-                    // TODO: This can be improved by a different code generation of operator between
-                    // and in,
-                    //       or by using a different Java class for DATETIME type.
-                    return null;
-                }
+                // conversion, that is, compareWithRuntimeTypeConv().
             }
 
             List<TypeSpec> ret = new ArrayList<>();

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/SymbolStack.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/SymbolStack.java
@@ -75,33 +75,34 @@ public class SymbolStack {
                     // System.out.println("temp: " + m.getName());
 
                     Operator opAnnot = m.getAnnotation(Operator.class);
-                    assert opAnnot != null;
+                    if (opAnnot != null) {
 
-                    // parameter types
-                    Class[] paramTypes = m.getParameterTypes();
-                    NodeList<DeclParam> params = new NodeList<>();
+                        // parameter types
+                        Class[] paramTypes = m.getParameterTypes();
+                        NodeList<DeclParam> params = new NodeList<>();
 
-                    int i = 0;
-                    for (Class pt : paramTypes) {
-                        String typeName = pt.getTypeName();
-                        // System.out.println("  " + typeName);
-                        TypeSpec paramType = TypeSpec.ofJavaName(typeName);
-                        assert paramType != null;
+                        int i = 0;
+                        for (Class pt : paramTypes) {
+                            String typeName = pt.getTypeName();
+                            // System.out.println("  " + typeName);
+                            TypeSpec paramType = TypeSpec.ofJavaName(typeName);
+                            assert paramType != null;
 
-                        DeclParamIn p = new DeclParamIn(null, "p" + i, paramType);
-                        params.addNode(p);
-                        i++;
+                            DeclParamIn p = new DeclParamIn(null, "p" + i, paramType);
+                            params.addNode(p);
+                            i++;
+                        }
+
+                        // return type
+                        String typeName = m.getReturnType().getTypeName();
+                        // System.out.println("  =>" + typeName);
+                        TypeSpec retType = TypeSpec.ofJavaName(typeName);
+                        assert retType != null;
+
+                        // add op
+                        DeclFunc op = new DeclFunc(null, name, params, retType);
+                        putOperator(name, op, opAnnot.coercionScheme());
                     }
-
-                    // return type
-                    String typeName = m.getReturnType().getTypeName();
-                    // System.out.println("  =>" + typeName);
-                    TypeSpec retType = TypeSpec.ofJavaName(typeName);
-                    assert retType != null;
-
-                    // add op
-                    DeclFunc op = new DeclFunc(null, name, params, retType);
-                    putOperator(name, op, opAnnot.coercionScheme());
                 }
             }
         }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/DeclRoutine.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/DeclRoutine.java
@@ -56,6 +56,19 @@ public abstract class DeclRoutine extends Decl {
         this.body = body;
     }
 
+    public boolean hasTimestampParam() {
+
+        if (paramList != null) {
+            for (DeclParam dp: paramList.nodes) {
+                if (dp.typeSpec.equals(TypeSpecSimple.TIMESTAMP)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     public String getDeclBlockName() {
         return name.toLowerCase() + '_' + (scope.level + 1);
     }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/DeclRoutine.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/DeclRoutine.java
@@ -59,7 +59,7 @@ public abstract class DeclRoutine extends Decl {
     public boolean hasTimestampParam() {
 
         if (paramList != null) {
-            for (DeclParam dp: paramList.nodes) {
+            for (DeclParam dp : paramList.nodes) {
                 if (dp.typeSpec.equals(TypeSpecSimple.TIMESTAMP)) {
                     return true;
                 }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprBetween.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprBetween.java
@@ -44,6 +44,12 @@ public class ExprBetween extends Expr {
     public final Expr lowerBound;
     public final Expr upperBound;
 
+    public boolean forTimestampParam;
+
+    public void setForTimestampParam() {
+        forTimestampParam = true;
+    }
+
     public ExprBetween(ParserRuleContext ctx, Expr target, Expr lowerBound, Expr upperBound) {
         super(ctx);
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprBinaryOp.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprBinaryOp.java
@@ -44,6 +44,12 @@ public class ExprBinaryOp extends Expr {
     public final Expr left;
     public final Expr right;
 
+    public boolean forTimestampParam;
+
+    public void setForTimestampParam() {
+        forTimestampParam = true;
+    }
+
     public ExprBinaryOp(ParserRuleContext ctx, String opStr, Expr left, Expr right) {
         super(ctx);
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprIn.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprIn.java
@@ -43,6 +43,12 @@ public class ExprIn extends Expr {
     public final Expr target;
     public final NodeList<Expr> inElements;
 
+    public boolean forTimestampParam;
+
+    public void setForTimestampParam() {
+        forTimestampParam = true;
+    }
+
     public ExprIn(ParserRuleContext ctx, Expr target, NodeList<Expr> inElements) {
         super(ctx);
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -405,7 +405,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
         CodeTemplate tmpl;
 
         if (node.resultType.equals(TypeSpecSimple.NULL)) {
-            // in this case, every branch including else has null as its expression.
+            // in this case, every branch including else-part has null as its expression.
             tmpl = new CodeTemplate("ExprCase", Misc.getLineColumnOf(node.ctx), "null");
         } else {
             tmpl =

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -337,7 +337,11 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
 
     private static String[] tmplExprBetween =
             new String[] {
-                "opBetween%'TIMESTAMP'%(", "  %'+TARGET'%,", "  %'+LOWER-BOUND'%,", "  %'+UPPER-BOUND'%", ")"
+                "opBetween%'TIMESTAMP'%(",
+                "  %'+TARGET'%,",
+                "  %'+LOWER-BOUND'%,",
+                "  %'+UPPER-BOUND'%",
+                ")"
             };
 
     @Override
@@ -364,7 +368,9 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
     //
 
     private static String[] tmplExprBinaryOp =
-            new String[] {"op%'OPERATION'%%'TIMESTAMP'%(", "  %'+LEFT-OPERAND'%,", "  %'+RIGHT-OPERAND'%", ")"};
+            new String[] {
+                "op%'OPERATION'%%'TIMESTAMP'%(", "  %'+LEFT-OPERAND'%,", "  %'+RIGHT-OPERAND'%", ")"
+            };
 
     @Override
     public CodeToResolve visitExprBinaryOp(ExprBinaryOp node) {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -337,7 +337,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
 
     private static String[] tmplExprBetween =
             new String[] {
-                "opBetween(", "  %'+TARGET'%,", "  %'+LOWER-BOUND'%,", "  %'+UPPER-BOUND'%", ")"
+                "opBetween%'TIMESTAMP'%(", "  %'+TARGET'%,", "  %'+LOWER-BOUND'%,", "  %'+UPPER-BOUND'%", ")"
             };
 
     @Override
@@ -347,6 +347,8 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                         "ExprBetween",
                         Misc.getLineColumnOf(node.ctx),
                         tmplExprBetween,
+                        "%'TIMESTAMP'%",
+                        node.forTimestampParam ? "Timestamp" : "",
                         "%'+TARGET'%",
                         visit(node.target),
                         "%'+LOWER-BOUND'%",
@@ -362,7 +364,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
     //
 
     private static String[] tmplExprBinaryOp =
-            new String[] {"op%'OPERATION'%(", "  %'+LEFT-OPERAND'%,", "  %'+RIGHT-OPERAND'%", ")"};
+            new String[] {"op%'OPERATION'%%'TIMESTAMP'%(", "  %'+LEFT-OPERAND'%,", "  %'+RIGHT-OPERAND'%", ")"};
 
     @Override
     public CodeToResolve visitExprBinaryOp(ExprBinaryOp node) {
@@ -373,6 +375,8 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                         tmplExprBinaryOp,
                         "%'OPERATION'%",
                         node.opStr,
+                        "%'TIMESTAMP'%",
+                        node.forTimestampParam ? "Timestamp" : "",
                         "%'+LEFT-OPERAND'%",
                         visit(node.left),
                         "%'+RIGHT-OPERAND'%",
@@ -622,7 +626,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
     //
 
     private static String[] tmplExprIn =
-            new String[] {"opIn(", "  %'+TARGET'%,", "  %'+IN-ELEMENTS'%", ")"};
+            new String[] {"opIn%'TIMESTAMP'%(", "  %'+TARGET'%,", "  %'+IN-ELEMENTS'%", ")"};
 
     @Override
     public CodeToResolve visitExprIn(ExprIn node) {
@@ -632,6 +636,8 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                         "ExprIn",
                         Misc.getLineColumnOf(node.ctx),
                         tmplExprIn,
+                        "%'TIMESTAMP'%",
+                        node.forTimestampParam ? "Timestamp" : "",
                         "%'+TARGET'%",
                         visit(node.target),
                         "%'+IN-ELEMENTS'%",

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
@@ -230,6 +230,10 @@ public class TypeChecker extends AstVisitor<TypeSpec> {
         }
         assert outCoercions.size() == 3;
 
+        if (op.hasTimestampParam()) {
+            node.setForTimestampParam();
+        }
+
         node.target.setCoercion(outCoercions.get(0));
         node.lowerBound.setCoercion(outCoercions.get(1));
         node.upperBound.setCoercion(outCoercions.get(2));
@@ -252,6 +256,10 @@ public class TypeChecker extends AstVisitor<TypeSpec> {
                     "operands do not have compatible types");
         }
         assert outCoercions.size() == 2;
+
+        if (binOp.hasTimestampParam()) {
+            node.setForTimestampParam();
+        }
 
         node.left.setCoercion(outCoercions.get(0));
         node.right.setCoercion(outCoercions.get(1));
@@ -497,6 +505,10 @@ public class TypeChecker extends AstVisitor<TypeSpec> {
         }
         assert outCoercions.size() == len;
 
+        if (op.hasTimestampParam()) {
+            node.setForTimestampParam();
+        }
+
         for (int i = 0; i < len; i++) {
             Expr arg = args.get(i);
             Coercion c = outCoercions.get(i);
@@ -631,6 +643,7 @@ public class TypeChecker extends AstVisitor<TypeSpec> {
                     Misc.getLineColumnOf(node.ctx), // s215
                     "argument does not have a compatible type");
         }
+        assert !unaryOp.hasTimestampParam();
 
         node.operand.setCoercion(outCoercions.get(0));
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -746,13 +746,23 @@ public class SpLib {
         throw new PROGRAM_ERROR(); // unreachable
     }
     public static Boolean opNullSafeEqTimestamp(Timestamp l, Timestamp r) {
-        if (l == null || r == null) {
-            return null;
-        }
-        assert l.getNanos() == 0;
-        assert r.getNanos() == 0;
+        if (l == null) {
+            if (r == null) {
+                return true;
+            } else {
+                assert r.getNanos() == 0;
+                return false;
+            }
+        } else {
+            assert l.getNanos() == 0;
 
-        return commonOpNullSafeEq(l, r);
+            if (r == null) {
+                return false;
+            } else {
+                assert r.getNanos() == 0;
+                return l.equals(r);
+            }
+        }
     }
 
     @Operator(coercionScheme = CoercionScheme.CompOp)
@@ -1742,7 +1752,7 @@ public class SpLib {
         throw new PROGRAM_ERROR(); // unreachable
     }
     public static Timestamp opAddTimestamp(Long l, Timestamp r) {
-        return opAdd(r, l);
+        return opAddTimestamp(r, l);
     }
 
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -663,6 +663,15 @@ public class SpLib {
         // TIMESTAMP
         throw new PROGRAM_ERROR(); // unreachable
     }
+    public static Boolean opEqTimestamp(Timestamp l, Timestamp r) {
+        if (l == null || r == null) {
+            return null;
+        }
+        assert l.getNanos() == 0;
+        assert r.getNanos() == 0;
+
+        return commonOpEq(l, r);
+    }
 
     @Operator(coercionScheme = CoercionScheme.CompOp)
     public static Boolean opEq(Object l, Object r) {
@@ -735,6 +744,15 @@ public class SpLib {
         // cannot be called actually, but only to register this operator with a parameter type
         // TIMESTAMP
         throw new PROGRAM_ERROR(); // unreachable
+    }
+    public static Boolean opNullSafeEqTimestamp(Timestamp l, Timestamp r) {
+        if (l == null || r == null) {
+            return null;
+        }
+        assert l.getNanos() == 0;
+        assert r.getNanos() == 0;
+
+        return commonOpNullSafeEq(l, r);
     }
 
     @Operator(coercionScheme = CoercionScheme.CompOp)
@@ -812,6 +830,15 @@ public class SpLib {
         // TIMESTAMP
         throw new PROGRAM_ERROR(); // unreachable
     }
+    public static Boolean opNeqTimestamp(Timestamp l, Timestamp r) {
+        if (l == null || r == null) {
+            return null;
+        }
+        assert l.getNanos() == 0;
+        assert r.getNanos() == 0;
+
+        return commonOpNeq(l, r);
+    }
 
     @Operator(coercionScheme = CoercionScheme.CompOp)
     public static Boolean opNeq(Object l, Object r) {
@@ -886,6 +913,15 @@ public class SpLib {
         // TIMESTAMP
         throw new PROGRAM_ERROR(); // unreachable
     }
+    public static Boolean opLeTimestamp(Timestamp l, Timestamp r) {
+        if (l == null || r == null) {
+            return null;
+        }
+        assert l.getNanos() == 0;
+        assert r.getNanos() == 0;
+
+        return commonOpLe(l, r);
+    }
 
     @Operator(coercionScheme = CoercionScheme.CompOp)
     public static Boolean opLe(Object l, Object r) {
@@ -957,6 +993,15 @@ public class SpLib {
         // cannot be called actually, but only to register this operator with a parameter type
         // TIMESTAMP
         throw new PROGRAM_ERROR(); // unreachable
+    }
+    public static Boolean opGeTimestamp(Timestamp l, Timestamp r) {
+        if (l == null || r == null) {
+            return null;
+        }
+        assert l.getNanos() == 0;
+        assert r.getNanos() == 0;
+
+        return commonOpGe(l, r);
     }
 
     @Operator(coercionScheme = CoercionScheme.CompOp)
@@ -1030,6 +1075,15 @@ public class SpLib {
         // TIMESTAMP
         throw new PROGRAM_ERROR(); // unreachable
     }
+    public static Boolean opLtTimestamp(Timestamp l, Timestamp r) {
+        if (l == null || r == null) {
+            return null;
+        }
+        assert l.getNanos() == 0;
+        assert r.getNanos() == 0;
+
+        return commonOpLt(l, r);
+    }
 
     @Operator(coercionScheme = CoercionScheme.CompOp)
     public static Boolean opLt(Object l, Object r) {
@@ -1102,6 +1156,15 @@ public class SpLib {
         // cannot be called actually, but only to register this operator with a parameter type
         // TIMESTAMP
         throw new PROGRAM_ERROR(); // unreachable
+    }
+    public static Boolean opGtTimestamp(Timestamp l, Timestamp r) {
+        if (l == null || r == null) {
+            return null;
+        }
+        assert l.getNanos() == 0;
+        assert r.getNanos() == 0;
+
+        return commonOpGt(l, r);
     }
 
     @Operator(coercionScheme = CoercionScheme.CompOp)
@@ -1209,6 +1272,16 @@ public class SpLib {
         // TIMESTAMP
         throw new PROGRAM_ERROR(); // unreachable
     }
+    public static Boolean opBetweenTimestamp(Timestamp o, Timestamp lower, Timestamp upper) {
+        if (o == null || lower == null || upper == null) {
+            return null;
+        }
+        assert o.getNanos() == 0;
+        assert lower.getNanos() == 0;
+        assert upper.getNanos() == 0;
+
+        return o.compareTo(lower) >= 0 && o.compareTo(upper) <= 0;
+    }
 
     @Operator(coercionScheme = CoercionScheme.NAryCompOp)
     public static Boolean opBetween(Object o, Object lower, Object upper) {
@@ -1282,6 +1355,26 @@ public class SpLib {
         // cannot be called actually, but only to register this operator with a parameter type
         // TIMESTAMP
         throw new PROGRAM_ERROR(); // unreachable
+    }
+    public static Boolean opInTimestamp(Timestamp o, Timestamp... arr) {
+        assert arr != null; // guaranteed by the syntax
+        if (o == null) {
+            return null;
+        }
+        assert o.getNanos() == 0;
+
+        boolean nullFound = false;
+        for (Timestamp p : arr) {
+            if (p == null) {
+                nullFound = true;
+            } else {
+                assert p.getNanos() == 0;
+                if (o.equals(p)) {
+                    return true;
+                }
+            }
+        }
+        return nullFound ? null : false;
     }
 
     @Operator(coercionScheme = CoercionScheme.NAryCompOp)
@@ -1618,15 +1711,28 @@ public class SpLib {
     }
 
     @Operator(coercionScheme = CoercionScheme.ArithOp)
-    public static Timestamp opAdd(Long l, Timestamp r) {
-        return opAdd(r, l);
-    }
-
-    @Operator(coercionScheme = CoercionScheme.ArithOp)
     public static ZonedDateTime opAdd(ZonedDateTime l, Long r) {
         // cannot be called actually, but only to register this operator with a parameter type
         // TIMESTAMP
         throw new PROGRAM_ERROR(); // unreachable
+    }
+    public static Timestamp opAddTimestamp(Timestamp l, Long r) {
+        if (l == null || r == null) {
+            return null;
+        }
+        if (l.equals(NULL_DATETIME)) {
+            throw new VALUE_ERROR("attempt to use 'zero date'");
+        }
+        assert l.getNanos() == 0;
+
+        LocalDateTime lldt = l.toLocalDateTime();
+        return Timestamp.valueOf(lldt.plus(r.longValue(), ChronoUnit.SECONDS));
+    }
+
+
+    @Operator(coercionScheme = CoercionScheme.ArithOp)
+    public static Timestamp opAdd(Long l, Timestamp r) {
+        return opAdd(r, l);
     }
 
     @Operator(coercionScheme = CoercionScheme.ArithOp)
@@ -1635,6 +1741,10 @@ public class SpLib {
         // TIMESTAMP
         throw new PROGRAM_ERROR(); // unreachable
     }
+    public static Timestamp opAddTimestamp(Long l, Timestamp r) {
+        return opAdd(r, l);
+    }
+
 
     @Operator(coercionScheme = CoercionScheme.ArithOp)
     public static Object opAdd(Object l, Object r) {
@@ -1738,6 +1848,21 @@ public class SpLib {
         // TIMESTAMP
         throw new PROGRAM_ERROR(); // unreachable
     }
+    public static Long opSubtractTimestamp(Timestamp l, Timestamp r) {
+        if (l == null || r == null) {
+            return null;
+        }
+        if (l.equals(NULL_DATETIME) || r.equals(NULL_DATETIME)) {
+            throw new VALUE_ERROR("attempt to use 'zero date'");
+        }
+        assert l.getNanos() == 0;
+        assert r.getNanos() == 0;
+
+        LocalDateTime lldt = l.toLocalDateTime();
+        LocalDateTime rldt = r.toLocalDateTime();
+        return rldt.until(lldt, ChronoUnit.SECONDS);
+    }
+
 
     @Operator(coercionScheme = CoercionScheme.ArithOp)
     public static Time opSubtract(Time l, Long r) {
@@ -1780,6 +1905,19 @@ public class SpLib {
         // TIMESTAMP
         throw new PROGRAM_ERROR(); // unreachable
     }
+    public static Timestamp opSubtractTimestamp(Timestamp l, Long r) {
+        if (l == null || r == null) {
+            return null;
+        }
+        if (l.equals(NULL_DATETIME)) {
+            throw new VALUE_ERROR("attempt to use 'zero date'");
+        }
+        assert l.getNanos() == 0;
+
+        LocalDateTime lldt = l.toLocalDateTime();
+        return Timestamp.valueOf(lldt.minus(r.longValue(), ChronoUnit.SECONDS));
+    }
+
 
     @Operator(coercionScheme = CoercionScheme.ArithOp)
     public static Object opSubtract(Object l, Object r) {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -2739,11 +2739,10 @@ public class SpLib {
             return convDateToString((Date) e);
         } else if (e instanceof Time) {
             return convTimeToString((Time) e);
-            /*
-            } else if (e instanceof Timestamp) {
-                // e is DATETIME or TIMESTAMP. impossible to figure out for now
-                // TODO: match different Java types to DATETIME and TIMESTAMP, respectively
-            */
+        } else if (e instanceof Timestamp) {
+            // e is DATETIME or TIMESTAMP. impossible to figure out for now
+            // TODO: match different Java types to DATETIME and TIMESTAMP, respectively
+            throw new PROGRAM_ERROR("ambiguous run-time type: TIMESTAMP or DATETIME");
         }
 
         throw new VALUE_ERROR("not compatible with STRING");
@@ -3167,6 +3166,7 @@ public class SpLib {
                 lConv = convStringToTime((String) l);
                 rConv = (Time) r;
             } else if (r instanceof Timestamp) {
+                // compare as DATETIMEs
                 lConv = convStringToDatetime((String) l);
                 rConv = (Timestamp) r;
             } else {
@@ -3204,7 +3204,7 @@ public class SpLib {
                 lConv = convShortToTime((Short) l);
                 rConv = (Time) r;
             } else if (r instanceof Timestamp) {
-                // NOTE: r must be a TIMESTAMP
+                // compare as TIMESTAMPs
                 lConv = convShortToTimestamp((Short) l);
                 rConv = convDatetimeToTimestamp((Timestamp) r);
             } else {
@@ -3242,7 +3242,7 @@ public class SpLib {
                 lConv = convIntToTime((Integer) l);
                 rConv = (Time) r;
             } else if (r instanceof Timestamp) {
-                // NOTE: r must be a TIMESTAMP
+                // compare as TIMESTAMPs
                 lConv = convIntToTimestamp((Integer) l);
                 rConv = convDatetimeToTimestamp((Timestamp) r);
             } else {
@@ -3280,7 +3280,7 @@ public class SpLib {
                 lConv = convBigintToTime((Long) l);
                 rConv = (Time) r;
             } else if (r instanceof Timestamp) {
-                // NOTE: r must be a TIMESTAMP
+                // compare as TIMESTAMPs
                 lConv = convBigintToTimestamp((Long) l);
                 rConv = convDatetimeToTimestamp((Timestamp) r);
             } else {
@@ -3417,6 +3417,7 @@ public class SpLib {
             } else if (r instanceof Time) {
                 // not applicable
             } else if (r instanceof Timestamp) {
+                // compare as DATETIMEs
                 lConv = convDateToDatetime((Date) l);
                 rConv = (Timestamp) r;
             } else {
@@ -3487,6 +3488,7 @@ public class SpLib {
             } else if (r instanceof Time) {
                 // not applicable
             } else if (r instanceof Timestamp) {
+                // compare as DATETIMEs
                 lConv = (Timestamp) l;
                 rConv = (Timestamp) r;
             } else {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -663,6 +663,7 @@ public class SpLib {
         // TIMESTAMP
         throw new PROGRAM_ERROR(); // unreachable
     }
+
     public static Boolean opEqTimestamp(Timestamp l, Timestamp r) {
         if (l == null || r == null) {
             return null;
@@ -745,6 +746,7 @@ public class SpLib {
         // TIMESTAMP
         throw new PROGRAM_ERROR(); // unreachable
     }
+
     public static Boolean opNullSafeEqTimestamp(Timestamp l, Timestamp r) {
         if (l == null) {
             if (r == null) {
@@ -840,6 +842,7 @@ public class SpLib {
         // TIMESTAMP
         throw new PROGRAM_ERROR(); // unreachable
     }
+
     public static Boolean opNeqTimestamp(Timestamp l, Timestamp r) {
         if (l == null || r == null) {
             return null;
@@ -923,6 +926,7 @@ public class SpLib {
         // TIMESTAMP
         throw new PROGRAM_ERROR(); // unreachable
     }
+
     public static Boolean opLeTimestamp(Timestamp l, Timestamp r) {
         if (l == null || r == null) {
             return null;
@@ -1004,6 +1008,7 @@ public class SpLib {
         // TIMESTAMP
         throw new PROGRAM_ERROR(); // unreachable
     }
+
     public static Boolean opGeTimestamp(Timestamp l, Timestamp r) {
         if (l == null || r == null) {
             return null;
@@ -1085,6 +1090,7 @@ public class SpLib {
         // TIMESTAMP
         throw new PROGRAM_ERROR(); // unreachable
     }
+
     public static Boolean opLtTimestamp(Timestamp l, Timestamp r) {
         if (l == null || r == null) {
             return null;
@@ -1167,6 +1173,7 @@ public class SpLib {
         // TIMESTAMP
         throw new PROGRAM_ERROR(); // unreachable
     }
+
     public static Boolean opGtTimestamp(Timestamp l, Timestamp r) {
         if (l == null || r == null) {
             return null;
@@ -1282,6 +1289,7 @@ public class SpLib {
         // TIMESTAMP
         throw new PROGRAM_ERROR(); // unreachable
     }
+
     public static Boolean opBetweenTimestamp(Timestamp o, Timestamp lower, Timestamp upper) {
         if (o == null || lower == null || upper == null) {
             return null;
@@ -1366,6 +1374,7 @@ public class SpLib {
         // TIMESTAMP
         throw new PROGRAM_ERROR(); // unreachable
     }
+
     public static Boolean opInTimestamp(Timestamp o, Timestamp... arr) {
         assert arr != null; // guaranteed by the syntax
         if (o == null) {
@@ -1726,6 +1735,7 @@ public class SpLib {
         // TIMESTAMP
         throw new PROGRAM_ERROR(); // unreachable
     }
+
     public static Timestamp opAddTimestamp(Timestamp l, Long r) {
         if (l == null || r == null) {
             return null;
@@ -1739,7 +1749,6 @@ public class SpLib {
         return Timestamp.valueOf(lldt.plus(r.longValue(), ChronoUnit.SECONDS));
     }
 
-
     @Operator(coercionScheme = CoercionScheme.ArithOp)
     public static Timestamp opAdd(Long l, Timestamp r) {
         return opAdd(r, l);
@@ -1751,10 +1760,10 @@ public class SpLib {
         // TIMESTAMP
         throw new PROGRAM_ERROR(); // unreachable
     }
+
     public static Timestamp opAddTimestamp(Long l, Timestamp r) {
         return opAddTimestamp(r, l);
     }
-
 
     @Operator(coercionScheme = CoercionScheme.ArithOp)
     public static Object opAdd(Object l, Object r) {
@@ -1858,6 +1867,7 @@ public class SpLib {
         // TIMESTAMP
         throw new PROGRAM_ERROR(); // unreachable
     }
+
     public static Long opSubtractTimestamp(Timestamp l, Timestamp r) {
         if (l == null || r == null) {
             return null;
@@ -1872,7 +1882,6 @@ public class SpLib {
         LocalDateTime rldt = r.toLocalDateTime();
         return rldt.until(lldt, ChronoUnit.SECONDS);
     }
-
 
     @Operator(coercionScheme = CoercionScheme.ArithOp)
     public static Time opSubtract(Time l, Long r) {
@@ -1915,6 +1924,7 @@ public class SpLib {
         // TIMESTAMP
         throw new PROGRAM_ERROR(); // unreachable
     }
+
     public static Timestamp opSubtractTimestamp(Timestamp l, Long r) {
         if (l == null || r == null) {
             return null;
@@ -1927,7 +1937,6 @@ public class SpLib {
         LocalDateTime lldt = l.toLocalDateTime();
         return Timestamp.valueOf(lldt.minus(r.longValue(), ChronoUnit.SECONDS));
     }
-
 
     @Operator(coercionScheme = CoercionScheme.ArithOp)
     public static Object opSubtract(Object l, Object r) {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -671,7 +671,7 @@ public class SpLib {
         assert l.getNanos() == 0;
         assert r.getNanos() == 0;
 
-        return commonOpEq(l, r);
+        return l.equals(r);
     }
 
     @Operator(coercionScheme = CoercionScheme.CompOp)
@@ -850,7 +850,7 @@ public class SpLib {
         assert l.getNanos() == 0;
         assert r.getNanos() == 0;
 
-        return commonOpNeq(l, r);
+        return !l.equals(r);
     }
 
     @Operator(coercionScheme = CoercionScheme.CompOp)
@@ -934,7 +934,7 @@ public class SpLib {
         assert l.getNanos() == 0;
         assert r.getNanos() == 0;
 
-        return commonOpLe(l, r);
+        return l.compareTo(r) <= 0;
     }
 
     @Operator(coercionScheme = CoercionScheme.CompOp)
@@ -1016,7 +1016,7 @@ public class SpLib {
         assert l.getNanos() == 0;
         assert r.getNanos() == 0;
 
-        return commonOpGe(l, r);
+        return l.compareTo(r) >= 0;
     }
 
     @Operator(coercionScheme = CoercionScheme.CompOp)
@@ -1098,7 +1098,7 @@ public class SpLib {
         assert l.getNanos() == 0;
         assert r.getNanos() == 0;
 
-        return commonOpLt(l, r);
+        return l.compareTo(r) < 0;
     }
 
     @Operator(coercionScheme = CoercionScheme.CompOp)
@@ -1181,7 +1181,7 @@ public class SpLib {
         assert l.getNanos() == 0;
         assert r.getNanos() == 0;
 
-        return commonOpGt(l, r);
+        return l.compareTo(r) > 0;
     }
 
     @Operator(coercionScheme = CoercionScheme.CompOp)

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -1971,9 +1971,11 @@ public class SpLib {
         if (e == null) {
             return null;
         }
+
         if (e.equals(NULL_TIMESTAMP)) {
             return NULL_DATETIME;
         }
+        assert e.getNanos() == 0;
 
         return new Timestamp(
                 e.getYear(),
@@ -1989,9 +1991,11 @@ public class SpLib {
         if (e == null) {
             return null;
         }
+
         if (e.equals(NULL_TIMESTAMP)) {
             return NULL_DATE;
         }
+        assert e.getNanos() == 0;
 
         return new Date(e.getYear(), e.getMonth(), e.getDate());
     }
@@ -2000,6 +2004,7 @@ public class SpLib {
         if (e == null) {
             return null;
         }
+        assert e.getNanos() == 0;
 
         return new Time(e.getHours(), e.getMinutes(), e.getSeconds());
     }
@@ -2008,11 +2013,13 @@ public class SpLib {
         if (e == null) {
             return null;
         }
+
         if (e.equals(NULL_TIMESTAMP)) {
             // must be calculated everytime because the AM/PM indicator can change according to the
             // locale change
             return String.format("00:00:00 %s 00/00/0000", AM_PM.format(ZERO_DATE));
         }
+        assert e.getNanos() == 0;
 
         return TIMESTAMP_FORMAT.format(e);
     }
@@ -2417,7 +2424,7 @@ public class SpLib {
         }
 
         if (dt.equals(DateTimeParser.nullDatetime)) {
-            return new Timestamp(-1900, -1, 0, 0, 0, 0, 0);
+            return NULL_DATETIME;
         } else {
             return new Timestamp(
                     dt.getYear() - 1900,
@@ -2474,7 +2481,7 @@ public class SpLib {
         }
 
         if (zdt.equals(DateTimeParser.nullDatetimeUTC)) {
-            return new Timestamp(-1900, -1, 0, 0, 0, 0, 0);
+            return NULL_TIMESTAMP;
         } else {
             assert zdt.getNano() == 0;
             return new Timestamp(
@@ -2599,7 +2606,7 @@ public class SpLib {
             return (Date) e;
         } else if (e instanceof Timestamp) {
             // e is DATETIME or TIMESTAMP
-            return convTimestampToDate((Timestamp) e);
+            return convDatetimeToDate((Timestamp) e);
         }
 
         throw new VALUE_ERROR("not compatible with DATE");
@@ -2626,7 +2633,7 @@ public class SpLib {
             return (Time) e;
         } else if (e instanceof Timestamp) {
             // e is DATETIME or TIMESTAMP
-            return convTimestampToTime((Timestamp) e);
+            return convDatetimeToTime((Timestamp) e);
         }
 
         throw new VALUE_ERROR("not compatible with TIME");
@@ -3123,6 +3130,7 @@ public class SpLib {
             } else if (r instanceof Time) {
                 // not applicable
             } else if (r instanceof Timestamp) {
+                // not applicable
             } else {
                 throw new PROGRAM_ERROR(); // unreachable
             }
@@ -3159,7 +3167,7 @@ public class SpLib {
                 lConv = convStringToTime((String) l);
                 rConv = (Time) r;
             } else if (r instanceof Timestamp) {
-                lConv = convStringToTimestamp((String) l);
+                lConv = convStringToDatetime((String) l);
                 rConv = (Timestamp) r;
             } else {
                 throw new PROGRAM_ERROR(); // unreachable
@@ -3195,11 +3203,10 @@ public class SpLib {
             } else if (r instanceof Time) {
                 lConv = convShortToTime((Short) l);
                 rConv = (Time) r;
-            } else if (r
-                    instanceof Timestamp) { // NOTE: r cannot be a DATETIME by compile time check in
-                // CoercionScheme
+            } else if (r instanceof Timestamp) {
+                // NOTE: r must be a TIMESTAMP
                 lConv = convShortToTimestamp((Short) l);
-                rConv = (Timestamp) r;
+                rConv = convDatetimeToTimestamp((Timestamp) r);
             } else {
                 throw new PROGRAM_ERROR(); // unreachable
             }
@@ -3234,11 +3241,10 @@ public class SpLib {
             } else if (r instanceof Time) {
                 lConv = convIntToTime((Integer) l);
                 rConv = (Time) r;
-            } else if (r
-                    instanceof Timestamp) { // NOTE: r cannot be a DATETIME by compile time check in
-                // CoercionScheme
+            } else if (r instanceof Timestamp) {
+                // NOTE: r must be a TIMESTAMP
                 lConv = convIntToTimestamp((Integer) l);
-                rConv = (Timestamp) r;
+                rConv = convDatetimeToTimestamp((Timestamp) r);
             } else {
                 throw new PROGRAM_ERROR(); // unreachable
             }
@@ -3273,11 +3279,10 @@ public class SpLib {
             } else if (r instanceof Time) {
                 lConv = convBigintToTime((Long) l);
                 rConv = (Time) r;
-            } else if (r
-                    instanceof Timestamp) { // NOTE: r cannot be a DATETIME by compile time check in
-                // CoercionScheme
+            } else if (r instanceof Timestamp) {
+                // NOTE: r must be a TIMESTAMP
                 lConv = convBigintToTimestamp((Long) l);
-                rConv = (Timestamp) r;
+                rConv = convDatetimeToTimestamp((Timestamp) r);
             } else {
                 throw new PROGRAM_ERROR(); // unreachable
             }
@@ -3412,7 +3417,8 @@ public class SpLib {
             } else if (r instanceof Time) {
                 // not applicable
             } else if (r instanceof Timestamp) {
-                // not applicable
+                lConv = convDateToDatetime((Date) l);
+                rConv = (Timestamp) r;
             } else {
                 throw new PROGRAM_ERROR(); // unreachable
             }
@@ -3456,15 +3462,18 @@ public class SpLib {
                 // not applicable
             } else if (r instanceof String) {
                 lConv = (Timestamp) l;
-                rConv = convStringToTimestamp((String) r);
+                rConv = convStringToDatetime((String) r);
             } else if (r instanceof Short) {
-                lConv = (Timestamp) l;
+                // l must be a TIMESTAMP
+                lConv = convDatetimeToTimestamp((Timestamp) l);
                 rConv = convShortToTimestamp((Short) r);
             } else if (r instanceof Integer) {
-                lConv = (Timestamp) l;
+                // l must be a TIMESTAMP
+                lConv = convDatetimeToTimestamp((Timestamp) l);
                 rConv = convIntToTimestamp((Integer) r);
             } else if (r instanceof Long) {
-                lConv = (Timestamp) l;
+                // l must be a TIMESTAMP
+                lConv = convDatetimeToTimestamp((Timestamp) l);
                 rConv = convBigintToTimestamp((Long) r);
             } else if (r instanceof BigDecimal) {
                 // not applicable
@@ -3474,7 +3483,7 @@ public class SpLib {
                 // not applicable
             } else if (r instanceof Date) {
                 lConv = (Timestamp) l;
-                rConv = convDateToTimestamp((Date) r);
+                rConv = convDateToDatetime((Date) r);
             } else if (r instanceof Time) {
                 // not applicable
             } else if (r instanceof Timestamp) {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25006

- The initial plan to solve this problem was to use another Java type for Cubrid TIMESTAMP type and still use Java method overloading.
- However, the actual implementation is to give different names to methods implementing addition and subtraction of TIMESTAMP values, and still use java.sql.Timestamp type for Cubrid TIMESTAMP type.
