### PR TITLE
[LETS-750] [LETS-781] Append received pages during catch-up

### DIFF
--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -1025,7 +1025,7 @@ page_server::execute_catchup (cubthread::entry &entry, const LOG_LSA catchup_lsa
       // TODO append pages in log_pgptr_vec to the log buffer while pulling next pages.
       for (size_t i = 0; i < receive_page_cnt; i++)
 	{
-	  logpb_append_catchup_page (&entry, log_pgptr_vec[i]);
+	  logpb_catchup_append_page (&entry, log_pgptr_vec[i]);
 	}
     }
 
@@ -1033,7 +1033,7 @@ page_server::execute_catchup (cubthread::entry &entry, const LOG_LSA catchup_lsa
     {
       assert (remaining_page_cnt == 0);
 
-      logpb_finish_catchup (&entry, catchup_lsa);
+      logpb_catchup_finish (&entry, catchup_lsa);
 
       _er_log_debug (ARG_FILE_LINE, "[CATCH_UP] The catch-up is completed, ranging from %lld to %lld, count = %lld.\n",
 		     start_pageid, end_pageid, total_page_count);

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -1176,7 +1176,7 @@ page_server::execute_catchup (cubthread::entry &entry, const LOG_LSA catchup_lsa
 	}
     }
 
-  bool with_disc_msg;
+  bool with_disc_msg = true;
   if (error == NO_ERROR)
     {
       assert (remaining_page_cnt == 0);
@@ -1195,8 +1195,7 @@ page_server::execute_catchup (cubthread::entry &entry, const LOG_LSA catchup_lsa
 
       push_request_to_active_tran_server (page_to_tran_request::SEND_CATCHUP_COMPLETE, std::string());
 
-      constexpr bool with_disc_msg = true;
-      disconnect_followee_page_server (with_disc_msg);
+      with_disc_msg = true;
     }
   else
     {

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -998,6 +998,10 @@ page_server::execute_catchup (cubthread::entry &entry, const LOG_LSA catchup_lsa
   int error = NO_ERROR;
 
   LOG_CS_ENTER (&entry);
+  auto unlock_log_cs_on_exit = scope_exit {[&entry] ()
+  {
+    LOG_CS_EXIT (&entry);
+  }};
 
   while (remaining_page_cnt > 0)
     {
@@ -1052,8 +1056,6 @@ page_server::execute_catchup (cubthread::entry &entry, const LOG_LSA catchup_lsa
     }
 
   disconnect_followee_page_server (with_disc_msg);
-
-  LOG_CS_EXIT (&entry);
 }
 
 bool

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -1034,7 +1034,7 @@ page_server::execute_catchup (cubthread::entry &entry, const LOG_LSA catchup_lsa
       error = logpb_catchup_finish (&entry, catchup_lsa);
       if (error != NO_ERROR)
 	{
-	  // not reachable.
+	  // unacceptable.
 	  assert_release (false);
 	}
 

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -1022,7 +1022,7 @@ page_server::execute_catchup (cubthread::entry &entry, const LOG_LSA catchup_lsa
 	  request_page_cnt = std::min (log_pgptr_recv_vec.size (), remaining_page_cnt);
 	  req_future = std::async (std::launch::async, request_pages_to_buffer, request_start_pageid, request_page_cnt);
 	}
-      // TODO append pages in log_pgptr_vec to the log buffer while pulling next pages.
+
       for (size_t i = 0; i < receive_page_cnt; i++)
 	{
 	  logpb_catchup_append_page (&entry, log_pgptr_vec[i]);

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -998,7 +998,6 @@ page_server::execute_catchup (cubthread::entry &entry, const LOG_LSA catchup_lsa
   int error = NO_ERROR;
 
   LOG_CS_ENTER (&entry);
-  logpb_flush_pages_direct (&entry);
 
   while (remaining_page_cnt > 0)
     {

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -1049,6 +1049,13 @@ page_server::execute_catchup (cubthread::entry &entry, const LOG_LSA catchup_lsa
     }
   else
     {
+      /*
+       * TODO
+       * In this case, we are going to re-initiate the catch-up with another PS.
+       * Now, we asuume it doesn't happen.
+       */
+      assert (false);
+
       assert (remaining_page_cnt > 0);
       _er_log_debug (ARG_FILE_LINE, "[CATCH_UP] The catch-up stops with the error: %d. remainder: %lld total = %lld.\n",
 		     error, remaining_page_cnt, total_page_count);

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -1033,7 +1033,7 @@ page_server::execute_catchup (cubthread::entry &entry, const LOG_LSA catchup_lsa
     {
       assert (remaining_page_cnt == 0);
 
-      logpb_end_catchup (&entry, catchup_lsa);
+      logpb_finish_catchup (&entry, catchup_lsa);
 
       _er_log_debug (ARG_FILE_LINE, "[CATCH_UP] The catch-up is completed, ranging from %lld to %lld, count = %lld.\n",
 		     start_pageid, end_pageid, total_page_count);

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -1263,6 +1263,9 @@ extern void log_set_db_restore_time (THREAD_ENTRY * thread_p, INT64 db_restore_t
 
 extern int logpb_prior_lsa_append_all_list (THREAD_ENTRY * thread_p);
 
+extern int logpb_append_catchup_page (THREAD_ENTRY * thread_p, const LOG_PAGE * const pgptr);
+extern int logpb_end_catchup (THREAD_ENTRY * thread_p, const LOG_LSA catchup_lsa);
+
 extern bool logtb_check_class_for_rr_isolation_err (const OID * class_oid);
 
 extern void logpb_vacuum_reset_log_header_cache (THREAD_ENTRY * thread_p, LOG_HEADER * loghdr);

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -1264,8 +1264,8 @@ extern void log_set_db_restore_time (THREAD_ENTRY * thread_p, INT64 db_restore_t
 extern int logpb_prior_lsa_append_all_list (THREAD_ENTRY * thread_p);
 
 #if defined(SERVER_MODE)
-extern int logpb_append_catchup_page (THREAD_ENTRY * thread_p, const LOG_PAGE * const pgptr);
-extern int logpb_finish_catchup (THREAD_ENTRY * thread_p, const LOG_LSA catchup_lsa);
+extern void logpb_catchup_append_page (THREAD_ENTRY * thread_p, const LOG_PAGE * const pgptr);
+extern int logpb_catchup_finish (THREAD_ENTRY * thread_p, const LOG_LSA catchup_lsa);
 #endif // SERVER_MODE
 
 extern bool logtb_check_class_for_rr_isolation_err (const OID * class_oid);

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -1263,8 +1263,10 @@ extern void log_set_db_restore_time (THREAD_ENTRY * thread_p, INT64 db_restore_t
 
 extern int logpb_prior_lsa_append_all_list (THREAD_ENTRY * thread_p);
 
+#if defined(SERVER_MODE)
 extern int logpb_append_catchup_page (THREAD_ENTRY * thread_p, const LOG_PAGE * const pgptr);
 extern int logpb_end_catchup (THREAD_ENTRY * thread_p, const LOG_LSA catchup_lsa);
+#endif // SERVER_MODE
 
 extern bool logtb_check_class_for_rr_isolation_err (const OID * class_oid);
 

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -1265,7 +1265,7 @@ extern int logpb_prior_lsa_append_all_list (THREAD_ENTRY * thread_p);
 
 #if defined(SERVER_MODE)
 extern int logpb_append_catchup_page (THREAD_ENTRY * thread_p, const LOG_PAGE * const pgptr);
-extern int logpb_end_catchup (THREAD_ENTRY * thread_p, const LOG_LSA catchup_lsa);
+extern int logpb_finish_catchup (THREAD_ENTRY * thread_p, const LOG_LSA catchup_lsa);
 #endif // SERVER_MODE
 
 extern bool logtb_check_class_for_rr_isolation_err (const OID * class_oid);

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3416,12 +3416,12 @@ logpb_catchup_append_page (THREAD_ENTRY * thread_p, const LOG_PAGE * const log_p
  *   
  *       ┌──► ┌─►_SUCCESS
  *       │    │      │
- *       │    │ (*)  │ start appending a page
+ *       │    │ (*)  │ Start appending a page
  *       │    │      ▼
  *       │    └──_IN_PROGRESS
  *       │           │
  *       │           │ It happens to flush log pages during the catch-up.
- *       │           │ so EOF is appended at the prev_lsa.
+ *       │           │ So, EOF is appended at the prev_lsa.
  *       │           ▼
  *       │       _PARTIAL_FLUSHED_END_OF_LOG
  *       │           │
@@ -3430,7 +3430,7 @@ logpb_catchup_append_page (THREAD_ENTRY * thread_p, const LOG_PAGE * const log_p
  *       │           ▼
  *       │       _PARTIAL_ENDED
  *       │           │
- *       │           │ flush log pages to remove the EOF.
+ *       │           │ Flush log pages to remove the EOF.
  *       │           │ It appends the EOF at the append_lsa instead.
  *       │           ▼
  *       │       _PARTIAL_FLUSHED_ORIGINAL

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3583,7 +3583,7 @@ logpb_catchup_finish (THREAD_ENTRY * thread_p, const LOG_LSA catchup_lsa)
 
       nav_lsa = log_rec->forw_lsa;
 
-      if (nav_lsa.is_null () && logpb_is_page_in_archive (nav_lsa.pageid))
+      if (nav_lsa.is_null () && logpb_is_page_in_archive (prev_lsa.pageid))
 	{
 	  nav_lsa.pageid = prev_lsa.pageid + 1;
 	  nav_lsa.offset = NULL_OFFSET;

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3380,6 +3380,7 @@ logpb_catchup_append_page (THREAD_ENTRY * thread_p, const LOG_PAGE * const log_p
 
   if (log_Gl.append.log_pgptr->hdr.logical_pageid + 1 == log_pgptr->hdr.logical_pageid)
     {
+      assert (log_Pb.partial_append.status == LOGPB_APPENDREC_IN_PROGRESS);
       // The normal case. Only exception is the first page. 
       log_Gl.append.prev_lsa = log_Gl.hdr.append_lsa;
       logpb_next_append_page (thread_p, LOG_SET_DIRTY);

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3378,16 +3378,16 @@ logpb_catchup_append_page (THREAD_ENTRY * thread_p, const LOG_PAGE * const pgptr
 
   logpb_catchup_start_append (thread_p);
 
-  if (log_Gl.append.log_pgptr->hdr.logical_pageid == pgptr->hdr.logical_pageid)
+  if (log_Gl.append.log_pgptr->hdr.logical_pageid + 1 == pgptr->hdr.logical_pageid)
     {
-      memcpy (log_Gl.append.log_pgptr, pgptr, LOG_PAGESIZE);
+      log_Gl.append.prev_lsa = log_Gl.hdr.append_lsa;
+      logpb_next_append_page (thread_p, LOG_SET_DIRTY);
     }
   else
     {
-      assert (log_Gl.append.log_pgptr->hdr.logical_pageid + 1 == pgptr->hdr.logical_pageid);
-
-      log_Gl.append.prev_lsa = log_Gl.hdr.append_lsa;
-      logpb_next_append_page (thread_p, LOG_SET_DIRTY);
+      // Only for the first page. Just overwrite the page, 
+      // and DON'T change meta data like log_Gl.append.prev_lsa. They don't go backward.
+      assert_release (log_Gl.append.log_pgptr->hdr.logical_pageid == pgptr->hdr.logical_pageid);
     }
 
   memcpy (log_Gl.append.log_pgptr, pgptr, LOG_PAGESIZE);

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3396,6 +3396,8 @@ logpb_append_catchup_page (THREAD_ENTRY * thread_p, const LOG_PAGE * const pgptr
 	}
     }
 
+  logpb_set_dirty (thread_p, log_Gl.append.log_pgptr);
+
   return NO_ERROR;
 }
 
@@ -3409,7 +3411,6 @@ logpb_append_catchup_page (THREAD_ENTRY * thread_p, const LOG_PAGE * const pgptr
 int
 logpb_end_catchup (THREAD_ENTRY * thread_p, const LOG_LSA catchup_lsa)
 {
-  // set prev_lsa and append_lsa to the correct value
   assert (LOG_CS_OWN_WRITE_MODE (thread_p));
 
   char log_pgbuf[LOG_PAGESIZE + MAX_ALIGNMENT], *aligned_log_pgbuf;
@@ -3470,6 +3471,8 @@ logpb_end_catchup (THREAD_ENTRY * thread_p, const LOG_LSA catchup_lsa)
   log_Gl.hdr.append_lsa = catchup_lsa;
   log_Gl.prior_info.prior_lsa = catchup_lsa;
   log_Gl.get_log_prior_sender ().reset_unsent_lsa (catchup_lsa);
+
+  logpb_flush_all_append_pages (thread_p);
 
   return NO_ERROR;
 }

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3380,13 +3380,13 @@ logpb_catchup_append_page (THREAD_ENTRY * thread_p, const LOG_PAGE * const log_p
 
   if (log_Gl.append.log_pgptr->hdr.logical_pageid + 1 == log_pgptr->hdr.logical_pageid)
     {
-      assert (log_Pb.partial_append.status == LOGPB_APPENDREC_IN_PROGRESS);
       // The normal case. Only exception is the first page. 
       log_Gl.append.prev_lsa = log_Gl.hdr.append_lsa;
       logpb_next_append_page (thread_p, LOG_SET_DIRTY);
     }
   else if (log_Gl.append.log_pgptr->hdr.logical_pageid == log_pgptr->hdr.logical_pageid)
     {
+      assert (log_Pb.partial_append.status == LOGPB_APPENDREC_IN_PROGRESS);
       // For the first page, just overwrite the page.
       // DON'T change meta data like log_Gl.append.prev_lsa. They don't go backward
     }

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3492,7 +3492,7 @@ logpb_catchup_end_append (THREAD_ENTRY * thread_p, const LOG_PAGE * const log_pg
   assert (log_Gl.hdr.append_lsa.pageid == log_pgptr->hdr.logical_pageid);
   log_Gl.hdr.append_lsa.offset = log_pgptr->hdr.offset;
 
-  LOG_RECORD_HEADER *log_rec = LOG_GET_LOG_RECORD_HEADER (log_pgptr, &log_Gl.hdr.append_lsa);
+  const LOG_RECORD_HEADER *const log_rec = LOG_GET_LOG_RECORD_HEADER (log_pgptr, &log_Gl.hdr.append_lsa);
   log_Gl.append.prev_lsa = log_rec->back_lsa;
 
   switch (log_Pb.partial_append.status)
@@ -3502,7 +3502,7 @@ logpb_catchup_end_append (THREAD_ENTRY * thread_p, const LOG_PAGE * const log_pg
       break;
     case LOGPB_APPENDREC_PARTIAL_FLUSHED_END_OF_LOG:
       {
-	LOG_RECORD_HEADER *origin_append_log_record = LOG_GET_LOG_RECORD_HEADER (log_pgptr, &log_Gl.hdr.append_lsa);
+	const LOG_RECORD_HEADER *const origin_append_log_record = log_rec;
 
 	// The temporary EOF log record at the prev_lsa has to be removed.
 	log_Pb.partial_append.status = LOGPB_APPENDREC_PARTIAL_ENDED;
@@ -3510,7 +3510,8 @@ logpb_catchup_end_append (THREAD_ENTRY * thread_p, const LOG_PAGE * const log_pg
 	assert (log_Pb.partial_append.status == LOGPB_APPENDREC_PARTIAL_FLUSHED_ORIGINAL);
 
 	// A new EOF has been appended at the append_lsa in logpb_flush_all_append_pages. Remove it as well.
-	LOG_RECORD_HEADER *append_log_rec = LOG_GET_LOG_RECORD_HEADER (log_Gl.append.log_pgptr, &log_Gl.hdr.append_lsa);
+	LOG_RECORD_HEADER *const append_log_rec =
+	  LOG_GET_LOG_RECORD_HEADER (log_Gl.append.log_pgptr, &log_Gl.hdr.append_lsa);
 	assert (append_log_rec->type == LOG_END_OF_LOG);
 	assert (log_Gl.append.log_pgptr->hdr.logical_pageid == log_pgptr->hdr.logical_pageid);
 	memcpy (append_log_rec, origin_append_log_record, sizeof (LOG_RECORD_HEADER));

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3405,7 +3405,7 @@ logpb_append_catchup_page (THREAD_ENTRY * thread_p, const LOG_PAGE * const pgptr
 	  log_Gl.append.prev_lsa = log_rec->back_lsa;
 
 	  // We don't need to set log_Gl.hdr.append_lsa correctly here.
-	  // It will be set at the end of the catch-up in logpb_end_catchup ().
+	  // It will be set at the end of the catch-up in logpb_finish_catchup ().
 	}
       else
 	{
@@ -3443,14 +3443,14 @@ logpb_append_catchup_page (THREAD_ENTRY * thread_p, const LOG_PAGE * const pgptr
 }
 
 /*
- * logpb_end_catchup -
+ * logpb_finish_catchup -
  *
  * return: NO_ERROR
  *
  *   node(in):
  */
 int
-logpb_end_catchup (THREAD_ENTRY * thread_p, const LOG_LSA catchup_lsa)
+logpb_finish_catchup (THREAD_ENTRY * thread_p, const LOG_LSA catchup_lsa)
 {
   assert (LOG_CS_OWN_WRITE_MODE (thread_p));
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3531,12 +3531,14 @@ logpb_catchup_finish (THREAD_ENTRY * thread_p, const LOG_LSA catchup_lsa)
 
   assert (nav_lsa == catchup_lsa);
 
-  // prior_info 변경할때 race condition이 있을 수 있나?
   log_Gl.append.prev_lsa = prev_lsa;
-  log_Gl.prior_info.prev_lsa = prev_lsa;
   log_Gl.hdr.append_lsa = catchup_lsa;
-  log_Gl.prior_info.prior_lsa = catchup_lsa;
   log_Gl.get_log_prior_sender ().reset_unsent_lsa (catchup_lsa);
+  {
+    auto lockg = std::lock_guard { log_Gl.prior_info.prior_lsa_mutex };
+    log_Gl.prior_info.prev_lsa = prev_lsa;
+    log_Gl.prior_info.prior_lsa = catchup_lsa;
+  }
 
   logpb_flush_all_append_pages (thread_p);
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3483,7 +3483,6 @@ logpb_catchup_end_append (THREAD_ENTRY * thread_p, const LOG_PAGE * const log_pg
   assert (LOG_CS_OWN_WRITE_MODE (thread_p));
 
   const bool have_only_partial_record_in_page = log_pgptr->hdr.offset == NULL_LOG_OFFSET;
-
   if (have_only_partial_record_in_page)
     {
       // Do nothing. It will be finished up at a following call.

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3485,7 +3485,7 @@ logpb_catchup_end_append (THREAD_ENTRY * thread_p, const LOG_PAGE * const log_pg
   const bool have_only_partial_record_in_page = log_pgptr->hdr.offset == NULL_LOG_OFFSET;
   if (have_only_partial_record_in_page)
     {
-      // Do nothing. It will be finished up at a following call.
+      // Do nothing. It will be finished up in one of following logpb_catchup_end_append ().
       return;
     }
 
@@ -3498,7 +3498,7 @@ logpb_catchup_end_append (THREAD_ENTRY * thread_p, const LOG_PAGE * const log_pg
   switch (log_Pb.partial_append.status)
     {
     case LOGPB_APPENDREC_IN_PROGRESS:
-      /* success, fall through */
+      /* success */
       break;
     case LOGPB_APPENDREC_PARTIAL_FLUSHED_END_OF_LOG:
       {

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3361,6 +3361,7 @@ logpb_write_toflush_pages_to_archive (THREAD_ENTRY * thread_p)
     }
 }
 
+#if defined(SERVER_MODE)
 /*
  * logpb_append_catchup_page -
  *
@@ -3463,12 +3464,17 @@ logpb_end_catchup (THREAD_ENTRY * thread_p, const LOG_LSA catchup_lsa)
 
   assert (nav_lsa == catchup_lsa);
 
+  // prior_info 변경할때 race condition이 있을 수 있나?
   log_Gl.append.prev_lsa = prev_lsa;
+  log_Gl.prior_info.prev_lsa = prev_lsa;
   log_Gl.hdr.append_lsa = catchup_lsa;
   log_Gl.prior_info.prior_lsa = catchup_lsa;
+  log_Gl.get_log_prior_sender ().reset_unsent_lsa (catchup_lsa);
 
   return NO_ERROR;
 }
+
+#endif /* SERVER_MODE */
 
 /*
  * logpb_append_next_record -

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3392,6 +3392,7 @@ logpb_catchup_append_page (THREAD_ENTRY * thread_p, const LOG_PAGE * const log_p
     }
   else
     {
+      // Not reachable. The appedning page must be either the cuurent append.log_pgptr or the next one.
       logpb_fatal_error (thread_p, true, ARG_FILE_LINE, "logpb_catchup_append_page");
     }
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3405,12 +3405,12 @@ logpb_catchup_append_page (THREAD_ENTRY * thread_p, const LOG_PAGE * const log_p
  *      LOGPB_APPENDREC_SUCCESS: 
  *        A normal case. The previous appending has been successfully.
  *      LOGPB_APPENDREC_IN_PROGRESS:
- *        The previous appended page doesn't have a start of a record. It only constains a middle part 
- *        or the last part of a record. In this case, the prev_lsa has not been advanced, 
+ *        The previous appended page doesn't have a start of a log record. It only constains a middle part 
+ *        or the last part of a log record. In this case, the prev_lsa has not been advanced, 
  *        and the EOF will be appended when flushing log pages halfway through appending a page.
  *      LOGPB_APPENDREC_PARTIAL_FLUSHED_END_OF_LOG:
- *        Log pages are flushed during appending a page including only a partial record, and the temporary EOF 
- *        has been appended at the prev_lsa. We will remove this at logpb_catchup_end_append() when the partial record completes.
+ *        Log pages are flushed during appending a page including only a partial log record, and the temporary EOF 
+ *        has been appended at the prev_lsa. We will remove this at logpb_catchup_end_append() when the partial log record completes.
  *      
  *      The status transition:
  *   
@@ -3571,7 +3571,7 @@ logpb_catchup_finish (THREAD_ENTRY * thread_p, const LOG_LSA catchup_lsa)
 	  nav_lsa.offset = log_pgptr->hdr.offset;
 	  if (nav_lsa.offset == NULL_OFFSET)
 	    {
-	      // There is nothing in thie page. Here is a part of incomplete log record.
+	      // There is nothing in this page. Here is a part of incomplete log record.
 	      nav_lsa.pageid++;
 	      continue;
 	    }

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3394,8 +3394,6 @@ logpb_catchup_append_page (THREAD_ENTRY * thread_p, const LOG_PAGE * const pgptr
   logpb_set_dirty (thread_p, log_Gl.append.log_pgptr);
 
   logpb_catchup_end_append (thread_p, pgptr);
-
-  return NO_ERROR;
 }
 
 static void

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3418,11 +3418,17 @@ logpb_append_catchup_page (THREAD_ENTRY * thread_p, const LOG_PAGE * const pgptr
 	}
       else if (log_Pb.partial_append.status == LOGPB_APPENDREC_PARTIAL_FLUSHED_END_OF_LOG)
 	{
+	  LOG_RECORD_HEADER *origin_append_log_record = LOG_GET_LOG_RECORD_HEADER (pgptr, &log_Gl.hdr.append_lsa);
 	  /* we need to flush the correct version now */
 	  log_Pb.partial_append.status = LOGPB_APPENDREC_PARTIAL_ENDED;
 	  logpb_flush_all_append_pages (thread_p);
 	  assert (log_Pb.partial_append.status == LOGPB_APPENDREC_PARTIAL_FLUSHED_ORIGINAL);
 
+	  LOG_RECORD_HEADER *append_log_rec =
+	    LOG_GET_LOG_RECORD_HEADER (log_Gl.append.log_pgptr, &log_Gl.hdr.append_lsa);
+	  assert (append_log_rec->type == LOG_END_OF_LOG);
+	  assert (log_Gl.append.log_pgptr->hdr.logical_pageid == pgptr->hdr.logical_pageid);
+	  memcpy (append_log_rec, origin_append_log_record, sizeof (LOG_RECORD_HEADER));
 	  logpb_set_dirty (thread_p, log_Gl.append.log_pgptr);
 	}
       else


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-750

http://jira.cubrid.org/browse/LETS-781

- Call `logpb_catchup_append_page()` for each received page and call `logpb_catchup_finish()` at the end.
  - `logpb_catchup_append_page()`: appends a page. This creates a new page except for the first page. This sets `prev_lsa` and `append_lsa` to valid ones. They don't need to be precise. It's enough to set them to existing LSA and advance them constantly when flushing or archiving happens. It is just that log records after them are ignored.
  - `logpb_catchup_finish()`: searches log pages and sets the `prev_lsa` and `append_lsa` to proper ones to accept new log records.
- `logpb_catchup_start_append()`, `logpb_catchup_end_append()`: set the partial appending status properly before and after appending a page.
  - The thing is that it can happen to flush log pages and archive while appending log pages. We must set `prev_lsa`, `append_lsa`, and `log_Pb.partial_append.status` properly for them to work well. It's described in the comment for the functions about the status.
  - Basically, the `log_Pb.partial_append.status` during the catch-up has the same meaning as the partial appending of a big log record since it happens in the catchup also when a big log record ranges several pages. The `log_Pb.partial_append.status` transition in the catch-up.:
```
┌──► ┌─►_SUCCESS
│    │      │
│    │ (*)  │ start appending a page
│    │      ▼
│    └──_IN_PROGRESS
│           │
│           │ It happens to flush log pages during the catch-up.
│           │ so EOF is appended at the prev_lsa.
│           ▼
│       _PARTIAL_FLUSHED_END_OF_LOG
│           │
│           │ It's done to append log pages containing an incomplete log record.
│           │ If there is no incomplete log record, just a page has been appended.
│           ▼
│       _PARTIAL_ENDED
│           │
│           │ flush log pages to remove the EOF.
│           │ It appends the EOF at the append_lsa instead.
│           ▼
│       _PARTIAL_FLUSHED_ORIGINAL
│           │
│           │ Remove the EOF at the append_lsa on the memory buffer.
└───────────┘ This will be flushed in the next time.

(*): It's done to append log pages containing an incomplete log record without flushing in the middle.

```

Note:
- Two issues are done together. I was going to split them, but it turns out that most of what's for LETS-781 is also needed for LETS-750. Mainly, the change of the partial appending status is needed for LETS-750 as well because of flushing while adding a page.
- It's beyond the scope to describe all behavior of the partial append. We can have a call to share how they behave and more detailed design discussion.