### PR TITLE
[LETS-749] Set aside prior nodes from ATS during the catch-up

### DIFF
--- a/src/base/server_type.cpp
+++ b/src/base/server_type.cpp
@@ -149,6 +149,7 @@ int init_server_type (const char *db_name)
 	  // passive tran server also needs (a) prior receiver(s) to receive log from page server(s)
 	  // the mechanism is that of a pub sub; a PTS subscribes to receive log from one page server (for now)
 	  log_Gl.initialize_log_prior_receiver ();
+	  log_Gl.get_log_prior_receiver ().start_thread ();
 
 	  pts_Gl = new passive_tran_server ();
 	  ts_Gl.reset (pts_Gl);
@@ -167,6 +168,8 @@ int init_server_type (const char *db_name)
       // sender ready, if needed (very unlikely scenario, but principially so)
       log_Gl.initialize_log_prior_sender ();
       log_Gl.initialize_log_prior_receiver ();
+      // The thread in the log_prior_receiver who appends log prior nodes will start once the catch-up is completed.
+      // Until then, it just receives and keeps prior nodes form ATS. See receive_start_catch_up() and execute_catchup.
     }
   else
     {

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -1027,7 +1027,6 @@ page_server::execute_catchup (cubthread::entry &entry, const LOG_LSA catchup_lsa
       _er_log_debug (ARG_FILE_LINE, "[CATCH_UP] The catch-up is completed, ranging from %lld to %lld, count = %lld.\n",
 		     start_pageid, end_pageid, total_page_count);
       // TODO: send CATCHUP_DONE_MSG to the ATS
-      // TODO: start appneding log prior nodes from the ATS.
 
       log_Gl.get_log_prior_receiver ().start_thread ();
 

--- a/src/transaction/log_global.c
+++ b/src/transaction/log_global.c
@@ -159,6 +159,19 @@ log_global::initialize_log_prior_receiver ()
 {
   assert (m_prior_recver == nullptr);
   m_prior_recver = std::make_unique<cublog::prior_recver> (prior_info);
+  
+  if (is_passive_transaction_server ())
+  {
+    m_prior_recver->start_thread ();
+  }
+  else if (is_page_server ())
+  {
+    // It will be started once the catch-up is completed. See receive_start_catch_up() and execute_catchup().
+  }
+  else 
+  {
+    assert (false);
+  }
 }
 
 void

--- a/src/transaction/log_global.c
+++ b/src/transaction/log_global.c
@@ -159,19 +159,6 @@ log_global::initialize_log_prior_receiver ()
 {
   assert (m_prior_recver == nullptr);
   m_prior_recver = std::make_unique<cublog::prior_recver> (prior_info);
-  
-  if (is_passive_transaction_server ())
-  {
-    m_prior_recver->start_thread ();
-  }
-  else if (is_page_server ())
-  {
-    // It will be started once the catch-up is completed. See receive_start_catch_up() and execute_catchup().
-  }
-  else 
-  {
-    assert (false);
-  }
 }
 
 void

--- a/src/transaction/log_prior_recv.cpp
+++ b/src/transaction/log_prior_recv.cpp
@@ -32,7 +32,10 @@ namespace cublog
 
   prior_recver::~prior_recver ()
   {
-    stop_thread ();
+    if (m_thread.get_id () != std::thread::id ())
+      {
+	stop_thread ();
+      }
   }
 
   void

--- a/src/transaction/log_prior_recv.cpp
+++ b/src/transaction/log_prior_recv.cpp
@@ -28,7 +28,6 @@ namespace cublog
   prior_recver::prior_recver (log_prior_lsa_info &prior_lsa_info)
     : m_prior_lsa_info (prior_lsa_info)
   {
-    // start_thread ();
   }
 
   prior_recver::~prior_recver ()
@@ -48,7 +47,7 @@ namespace cublog
   void
   prior_recver::start_thread ()
   {
-    assert (m_thread.get_id() == std::thread::id()); // make sure that it's not been started.
+    assert (m_thread.get_id () == std::thread::id ()); // make sure that it's not been started.
     m_shutdown = false;
     m_thread = std::thread (&prior_recver::loop_message_to_prior_info, std::ref (*this));
   }

--- a/src/transaction/log_prior_recv.cpp
+++ b/src/transaction/log_prior_recv.cpp
@@ -28,7 +28,7 @@ namespace cublog
   prior_recver::prior_recver (log_prior_lsa_info &prior_lsa_info)
     : m_prior_lsa_info (prior_lsa_info)
   {
-    start_thread ();
+    // start_thread ();
   }
 
   prior_recver::~prior_recver ()
@@ -48,6 +48,7 @@ namespace cublog
   void
   prior_recver::start_thread ()
   {
+    assert (m_thread.get_id() == std::thread::id()); // make sure that it's not been started.
     m_shutdown = false;
     m_thread = std::thread (&prior_recver::loop_message_to_prior_info, std::ref (*this));
   }

--- a/src/transaction/log_prior_recv.hpp
+++ b/src/transaction/log_prior_recv.hpp
@@ -53,13 +53,13 @@ namespace cublog
       prior_recver &operator = (prior_recver &&) = delete;
 
       void push_message (std::string &&str);                  // push message from prior_sender into message queue
+      void start_thread ();                                   // run loop_message_to_prior_info in a thread
 
     private:
       using message_container = std::queue<std::string>;      // internal message container type
 
       void loop_message_to_prior_info ();                     // convert messages into prior node lists and append them
       // to prior info
-      void start_thread ();                                   // run loop_message_to_prior_info in a thread
       void stop_thread ();                                    // stop thread running loop_message_to_prior_info()
 
       log_prior_lsa_info &m_prior_lsa_info;                   // prior list destination

--- a/unit_tests/log/test_main_prior_sendrecv.cpp
+++ b/unit_tests/log/test_main_prior_sendrecv.cpp
@@ -125,6 +125,7 @@ test_env::test_env (size_t receivers_count)
 
       // add new prior receiver that reconstructs destination prior info
       m_recvers.push_back (new cublog::prior_recver (*m_dest_prior_infos.back ()));
+      m_recvers.back ()->start_thread ();
 
       // add new sink for prior receiver
       m_prior_sender_sinks.emplace_back (


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-749

Start the prior_recv thread when the catch-up is done. Until it's started, the prior nodes from ATS are kept in its internal queue, just not being consumed.

Tested on #4720.
