### PR TITLE
[CBRD-25012] arguments to OUT parameters of a Stored Procedure/Function are not updated

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -34,10 +34,10 @@ import com.cubrid.plcsql.compiler.Coercion;
 import com.cubrid.plcsql.compiler.Misc;
 import com.cubrid.plcsql.compiler.ast.*;
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
@@ -114,7 +114,9 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
 
         // get connection, if necessary
         String strGetConn =
-                node.connectionRequired ? String.format(tmplGetConn, node.autonomousTransaction) : "";
+                node.connectionRequired
+                        ? String.format(tmplGetConn, node.autonomousTransaction)
+                        : "";
 
         // declarations
         Object codeDeclClass =
@@ -138,7 +140,9 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
 
         // parameters
         Object strParamArr =
-                Misc.isEmpty(node.routine.paramList) ? "" : visitNodeList(node.routine.paramList).setDelimiter(",");
+                Misc.isEmpty(node.routine.paramList)
+                        ? ""
+                        : visitNodeList(node.routine.paramList).setDelimiter(",");
 
         // nullify OUT parameters
         String[] strNullifyOutParam = getNullifyOutParamCode(node.routine.paramList);
@@ -607,7 +611,9 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
             DeclParam param = paramList.nodes.get(i);
 
             if (param instanceof DeclParamOut) {
-                ret.add(String.format("stmt.registerOutParameter(%d, java.sql.Types.OTHER);", i + 2));
+                ret.add(
+                        String.format(
+                                "stmt.registerOutParameter(%d, java.sql.Types.OTHER);", i + 2));
             }
 
             if (param instanceof DeclParamIn) {
@@ -615,13 +621,13 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
             } else if (((DeclParamOut) param).alsoIn) {
                 ret.add(String.format("stmt.setObject(%d, o%d[0]);", i + 2, i));
             }
-
         }
 
         return ret.toArray(DUMMY_STRING_ARRAY);
     }
 
-    private static String[] getUpdateGlobalFuncOutArgsCode(int size, NodeList<DeclParam> paramList) {
+    private static String[] getUpdateGlobalFuncOutArgsCode(
+            int size, NodeList<DeclParam> paramList) {
 
         List<String> ret = new LinkedList<>();
 
@@ -630,7 +636,10 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
             DeclParam param = paramList.nodes.get(i);
 
             if (param instanceof DeclParamOut) {
-                ret.add(String.format("o%d[0] = (%s) stmt.getObject(%d);", i, param.typeSpec.javaCode, i + 2));
+                ret.add(
+                        String.format(
+                                "o%d[0] = (%s) stmt.getObject(%d);",
+                                i, param.typeSpec.javaCode, i + 2));
             }
         }
 
@@ -646,7 +655,8 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
         String dynSql = String.format("?= call %s(%s)", node.name, getQuestionMarks(argSize));
         String paramStr = getGlobalFuncParamStr(argSize, node.decl.paramList);
         String[] setGlobalFuncArgs = getGlobalFuncArgsSetCode(argSize, node.decl.paramList);
-        String[] updateGlobalFuncOutArgs = getUpdateGlobalFuncOutArgsCode(argSize, node.decl.paramList);
+        String[] updateGlobalFuncOutArgs =
+                getUpdateGlobalFuncOutArgsCode(argSize, node.decl.paramList);
 
         CodeTemplate tmpl =
                 new CodeTemplate(
@@ -1211,8 +1221,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 "%'CURSOR'%",
                 node.id.javaCode(),
                 "%'+SET-INTO-VARIABLES'%",
-                setIntoVars
-                );
+                setIntoVars);
     }
 
     // -------------------------------------------------------------------------
@@ -1220,9 +1229,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
     //
 
     private static String[] tmplStmtCursorOpenWithoutHostExprs =
-            new String[] {
-                "{ // cursor open", "  %'CURSOR'%.open(conn);", "}"
-            };
+            new String[] {"{ // cursor open", "  %'CURSOR'%.open(conn);", "}"};
 
     private static String[] tmplStmtCursorOpenWithHostExprs =
             new String[] {
@@ -1661,7 +1668,8 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 "}"
             };
 
-    private Object getSetGlobalProcArgsCode(int size, List<? extends Expr> args, NodeList<DeclParam> paramList) {
+    private Object getSetGlobalProcArgsCode(
+            int size, List<? extends Expr> args, NodeList<DeclParam> paramList) {
 
         if (size == 0) {
             return "";
@@ -1673,13 +1681,15 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
 
             DeclParam param = paramList.nodes.get(i);
 
-            if (param instanceof DeclParamOut){
+            if (param instanceof DeclParamOut) {
 
                 ret.addElement(
-                    new CodeTemplate(
-                        "global procedure out argument",
-                        Misc.UNKNOWN_LINE_COLUMN,
-                        String.format("stmt_%%'LEVEL'%%.registerOutParameter(%d, java.sql.Types.OTHER);", i + 1)));
+                        new CodeTemplate(
+                                "global procedure out argument",
+                                Misc.UNKNOWN_LINE_COLUMN,
+                                String.format(
+                                        "stmt_%%'LEVEL'%%.registerOutParameter(%d, java.sql.Types.OTHER);",
+                                        i + 1)));
             }
 
             if (param instanceof DeclParamIn || ((DeclParamOut) param).alsoIn) {
@@ -1712,8 +1722,10 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
             if (param instanceof DeclParamOut) {
                 Expr arg = args.get(i);
                 assert arg instanceof ExprId;
-                ret.add(String.format("\n%s = (%s) stmt_%%'LEVEL'%%.getObject(%d);",
-                    ((ExprId) arg).javaCode(), param.typeSpec.javaCode, i + 1));
+                ret.add(
+                        String.format(
+                                "\n%s = (%s) stmt_%%'LEVEL'%%.getObject(%d);",
+                                ((ExprId) arg).javaCode(), param.typeSpec.javaCode, i + 1));
             }
         }
 
@@ -1727,8 +1739,10 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
 
         int argSize = node.args.nodes.size();
         String dynSql = String.format("call %s(%s)", node.name, getQuestionMarks(argSize));
-        Object setGlobalProcArgs = getSetGlobalProcArgsCode(argSize, node.args.nodes, node.decl.paramList);
-        String[] updGlobalProcOutArgs = getUpdateGlobalProcOutArgsCode(argSize, node.args.nodes, node.decl.paramList);
+        Object setGlobalProcArgs =
+                getSetGlobalProcArgsCode(argSize, node.args.nodes, node.decl.paramList);
+        String[] updGlobalProcOutArgs =
+                getUpdateGlobalProcOutArgsCode(argSize, node.args.nodes, node.decl.paramList);
 
         return new CodeTemplate(
                 "StmtGlobalProcCall",
@@ -2579,7 +2593,8 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                             codeLines.add(indent + l);
                         }
                     } else {
-                        resolveTemplateLine(l, indentLevel + indentLevelDelta, codeLines, codeRangeMarkers);
+                        resolveTemplateLine(
+                                l, indentLevel + indentLevelDelta, codeLines, codeRangeMarkers);
                     }
                 } else if (substitute instanceof String[]) {
                     for (String l : (String[]) substitute) {
@@ -2588,7 +2603,8 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                                 codeLines.add(indent + l);
                             }
                         } else {
-                            resolveTemplateLine(l, indentLevel + indentLevelDelta, codeLines, codeRangeMarkers);
+                            resolveTemplateLine(
+                                    l, indentLevel + indentLevelDelta, codeLines, codeRangeMarkers);
                         }
                     }
                 } else if (substitute instanceof CodeToResolve) {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -84,15 +84,11 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 "  public static %'RETURN-TYPE'% %'METHOD-NAME'%(",
                 "      %'+PARAMETERS'%",
                 "    ) throws Exception {",
-                "",
                 "    %'+NULLIFY-OUT-PARAMETERS'%",
-                "",
                 "    try {",
                 "      Long[] sql_rowcount = new Long[] { null };",
                 "      %'GET-CONNECTION'%",
-                "",
                 "      %'+DECL-CLASS'%",
-                "",
                 "      %'+BODY'%",
                 "    } catch (OutOfMemoryError e) {",
                 "      Server.log(e);",
@@ -180,11 +176,8 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 "%'RETURN-TYPE'% %'METHOD-NAME'%(",
                 "    %'+PARAMETERS'%",
                 "  ) throws Exception {",
-                "",
                 "  %'+NULLIFY-OUT-PARAMETERS'%",
-                "",
                 "  %'+DECL-CLASS'%",
-                "",
                 "  %'+BODY'%",
                 "}"
             };
@@ -1724,7 +1717,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 assert arg instanceof ExprId;
                 ret.add(
                         String.format(
-                                "\n%s = (%s) stmt_%%'LEVEL'%%.getObject(%d);",
+                                "%s = (%s) stmt_%%'LEVEL'%%.getObject(%d);",
                                 ((ExprId) arg).javaCode(), param.typeSpec.javaCode, i + 1));
             }
         }
@@ -2572,8 +2565,10 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 if (smallHoles.size() > 0) {
                     line = substituteSmallHolesInLine(line);
                 }
-                String indent = Misc.getIndent(indentLevel);
-                codeLines.add(line.length() == 0 ? "" : indent + line);
+                if (line.trim().length() > 0) {
+                    String indent = Misc.getIndent(indentLevel);
+                    codeLines.add(indent + line);
+                }
             } else {
                 assert smallHoles.size() == 0;
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -2202,10 +2202,6 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
             new String[] {"stmt_%'LEVEL'%.setObject(%'INDEX'%,", "  %'+VALUE'%", ");"};
 
     private Object getSetUsedExpr(List<? extends Expr> exprList) {
-        return getSetUsedExpr(exprList, 1);
-    }
-
-    private Object getSetUsedExpr(List<? extends Expr> exprList, int startIndex) {
 
         if (exprList == null || exprList.size() == 0) {
             return "// no used values";
@@ -2223,7 +2219,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                             Misc.getLineColumnOf(expr.ctx),
                             tmplSetObject,
                             "%'INDEX'%",
-                            "" + (i + startIndex),
+                            "" + (i + 1),
                             "%'+VALUE'%",
                             visit(expr));
             ret.addElement(tmpl);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25012

- call CallableStatement.registerOutParameter() appropriately before execution and update OUT parameters after execution
- In addition, minor code refinements
  - remove unnecessary comments in the generated Java code
  - avoid String.split() for performance
