### PR TITLE
[CBRD-25017] check redefinition of a name used earlier in the same declaration part

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -45,12 +45,12 @@ import java.time.LocalTime;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.HashMap;
 import java.util.TreeSet;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.apache.commons.text.StringEscapeUtils;
@@ -2218,7 +2218,9 @@ public class ParseTreeConverter extends PcsParserBaseVisitor<AstNode> {
             int[] pos = Misc.getLineColumnOf(saved);
             throw new SemanticError(
                     Misc.getLineColumnOf(declCtx), // s068
-                    String.format("name %s has already been used at line %d and column %d", name, pos[0], pos[1]));
+                    String.format(
+                            "name %s has already been used at line %d and column %d",
+                            name, pos[0], pos[1]));
         }
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25017

- Record the used identifier name in a declaration part, and check every declared name if it is contained in the set of already used identifiers
