### PR TITLE
[CBRD-25046] typo error in jsp_sr.c

### DIFF
--- a/src/jsp/jsp_sr.c
+++ b/src/jsp/jsp_sr.c
@@ -256,7 +256,7 @@ delay_load_hook (unsigned dliNotify, PDelayLoadInfo pdli)
 
 	if (jvm_path)
 	  {
-	    err_msgs.append ("\n\tFailed to load libjvm from 'JVM_PATH' envirnment variable: ");
+	    err_msgs.append ("\n\tFailed to load libjvm from 'JVM_PATH' environment variable: ");
 	    err_msgs.append ("\n\t\t");
 	    err_msgs.append (jvm_path);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25046

There is a typo error in jsp_src.c as "envirnment".
