### PR TITLE
[LETS-812] Decache the DDL related caches in PTS

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -20433,16 +20433,20 @@ heap_get_insert_location_with_lock (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONT
       lk_result = lock_object (thread_p, &context->res_oid, &context->class_oid, lock, LK_COND_LOCK);
       if (lk_result == LK_GRANTED)
 	{
-	  /* if lock == SCH_M_LOCK, then it is the class creation */
 	  /* successfully locked! */
+#if defined (SERVER_MODE)
 	  if (lock == SCH_M_LOCK && OID_IS_ROOTOID (&context->class_oid))
 	    {
+	      /* if lock == SCH_M_LOCK, then it is the class creation */
 	      /* Schema modification lock is acquired to create Class or VClass */
+	      assert (!OID_ISNULL (&context->res_oid));
+
 	      if (is_active_transaction_server ())
 		{
 		  log_append_schema_modification_lock (thread_p, &context->res_oid);
 		}
 	    }
+#endif
 
 	  return NO_ERROR;
 	}

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -20437,8 +20437,6 @@ heap_get_insert_location_with_lock (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONT
 #if defined (SERVER_MODE)
 	  if (lock == SCH_M_LOCK && OID_IS_ROOTOID (&context->class_oid))
 	    {
-	      /* if lock == SCH_M_LOCK, then it is the class creation */
-	      /* Schema modification lock is acquired to create Class or VClass */
 	      assert (!OID_ISNULL (&context->res_oid));
 
 	      if (is_active_transaction_server ())

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -20433,7 +20433,17 @@ heap_get_insert_location_with_lock (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONT
       lk_result = lock_object (thread_p, &context->res_oid, &context->class_oid, lock, LK_COND_LOCK);
       if (lk_result == LK_GRANTED)
 	{
+	  /* if lock == SCH_M_LOCK, then it is the class creation */
 	  /* successfully locked! */
+	  if (lock == SCH_M_LOCK && OID_IS_ROOTOID (&context->class_oid))
+	    {
+	      /* Schema modification lock is acquired to create Class or VClass */
+	      if (is_active_transaction_server ())
+		{
+		  log_append_schema_modification_lock (thread_p, &context->res_oid);
+		}
+	    }
+
 	  return NO_ERROR;
 	}
       else if (lk_result != LK_NOTGRANTED_DUE_TIMEOUT)

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -20438,11 +20438,9 @@ heap_get_insert_location_with_lock (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONT
 	  if (lock == SCH_M_LOCK && OID_IS_ROOTOID (&context->class_oid))
 	    {
 	      assert (!OID_ISNULL (&context->res_oid));
+	      assert (is_active_transaction_server ());
 
-	      if (is_active_transaction_server ())
-		{
-		  log_append_schema_modification_lock (thread_p, &context->res_oid);
-		}
+	      log_append_schema_modification_lock (thread_p, &context->res_oid);
 	    }
 #endif
 

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -12885,6 +12885,15 @@ locator_lock_and_get_object_internal (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT 
   else
     {
       lock_acquired = true;
+
+      if (OID_IS_ROOTOID (context->class_oid_p) && lock_mode == SCH_M_LOCK)
+	{
+	  /* Lock is acquired to modify the class record (DDL is executed) */
+	  if (is_active_transaction_server ())
+	    {
+	      log_append_schema_modification_lock (thread_p, context->oid_p);
+	    }
+	}
     }
 
   assert (OID_IS_ROOTOID (context->class_oid_p) || lock_mode == S_LOCK || lock_mode == X_LOCK);

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -2542,6 +2542,19 @@ xlocator_fetch (THREAD_ENTRY * thread_p, OID * oid, int chn, LOCK lock,
 		   * rules. This object must be also locked. */
 		  object_locked = true;
 		}
+
+#if defined (SERVER_MODE)
+	      if (lock == SCH_M_LOCK)
+		{
+		  assert (OID_IS_ROOTOID (class_oid));
+		  assert (!OID_ISNULL (p_oid));
+
+		  if (is_active_transaction_server ())
+		    {
+		      log_append_schema_modification_lock (thread_p, p_oid);
+		    }
+		}
+#endif
 	    }
 	  break;
 	}
@@ -12886,15 +12899,6 @@ locator_lock_and_get_object_internal (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT 
   else
     {
       lock_acquired = true;
-
-      if (OID_IS_ROOTOID (context->class_oid_p) && lock_mode == SCH_M_LOCK)
-	{
-	  /* Lock is acquired to modify the class record (DDL is executed) */
-	  if (is_active_transaction_server ())
-	    {
-	      log_append_schema_modification_lock (thread_p, context->oid_p);
-	    }
-	}
     }
 
   assert (OID_IS_ROOTOID (context->class_oid_p) || lock_mode == S_LOCK || lock_mode == X_LOCK);

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -59,6 +59,7 @@
 #endif /* ENABLE_SYSTEMTAP */
 #include "record_descriptor.hpp"
 #include "slotted_page.h"
+#include "server_type.hpp"
 #include "xasl_cache.h"
 #include "xasl_predicate.hpp"
 #include "thread_manager.hpp"	// for thread_get_thread_entry_info

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -2544,15 +2544,12 @@ xlocator_fetch (THREAD_ENTRY * thread_p, OID * oid, int chn, LOCK lock,
 		}
 
 #if defined (SERVER_MODE)
-	      if (lock == SCH_M_LOCK)
+	      if (lock == SCH_M_LOCK && is_active_transaction_server ())
 		{
 		  assert (OID_IS_ROOTOID (class_oid));
 		  assert (!OID_ISNULL (p_oid));
 
-		  if (is_active_transaction_server ())
-		    {
-		      log_append_schema_modification_lock (thread_p, p_oid);
-		    }
+		  log_append_schema_modification_lock (thread_p, p_oid);
 		}
 #endif
 	    }

--- a/src/transaction/log_2pc.c
+++ b/src/transaction/log_2pc.c
@@ -2012,6 +2012,7 @@ log_2pc_recovery_analysis_record (THREAD_ENTRY * thread_p, LOG_RECTYPE record_ty
     case LOG_END_ATOMIC_REPL:
     case LOG_TRANTABLE_SNAPSHOT:
     case LOG_ASSIGNED_MVCCID:
+    case LOG_SCHEMA_MODIFICATION_LOCK:
     case LOG_END_OF_LOG:
       /*
        * Either the prepare to commit or start 2PC record should

--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -416,6 +416,7 @@ prior_lsa_alloc_and_copy_data (THREAD_ENTRY *thread_p, LOG_RECTYPE rec_type, LOG
     case LOG_END_ATOMIC_REPL:
     case LOG_TRANTABLE_SNAPSHOT:
     case LOG_ASSIGNED_MVCCID:
+    case LOG_SCHEMA_MODIFICATION_LOCK:
       assert (rlength == 0 && rdata == NULL);
 
       error_code = prior_lsa_gen_record (thread_p, node, rec_type, ulength, udata);
@@ -1317,6 +1318,9 @@ prior_lsa_gen_record (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LOG_RECTYPE 
       break;
     case LOG_SUPPLEMENTAL_INFO:
       node->data_header_length = sizeof (LOG_REC_SUPPLEMENT);
+      break;
+    case LOG_SCHEMA_MODIFICATION_LOCK:
+      node->data_header_length = sizeof (LOG_REC_SCHEMA_MODIFICATION_LOCK);
       break;
     default:
       break;

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -3739,12 +3739,23 @@ log_append_schema_modification_lock (THREAD_ENTRY * thread_p, const OID * classo
 {
   assert (!OID_ISNULL (classoid));
 
-  LOG_TDES *tdes = LOG_FIND_CURRENT_TDES (thread_p);
-  assert (tdes != nullptr);
+  int tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
+  LOG_TDES *tdes = LOG_FIND_TDES (tran_index);
+  if (tdes == nullptr)
+    {
+      assert (false);
+      er_set (ER_FATAL_ERROR_SEVERITY, ARG_FILE_LINE, ER_LOG_UNKNOWN_TRANINDEX, 1, tran_index);
+      return;
+    }
+
 
   LOG_PRIOR_NODE *node =
     prior_lsa_alloc_and_copy_data (thread_p, LOG_SCHEMA_MODIFICATION_LOCK, RV_NOT_DEFINED, NULL, 0, NULL, 0, NULL);
-  assert (node != nullptr);
+  if (node == nullptr)
+    {
+      assert (false);
+      return;
+    }
 
   auto record = (LOG_REC_SCHEMA_MODIFICATION_LOCK *) node->data_header;
   COPY_OID (&record->classoid, classoid);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -7291,7 +7291,7 @@ log_dump_record_schema_modification_lock (THREAD_ENTRY * thread_p, FILE * out_fp
   /* Get the DATA HEADER */
   LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (*log_rec), log_lsa, log_page_p);
   log_rec = ((LOG_REC_SCHEMA_MODIFICATION_LOCK *) ((char *) log_page_p->area + log_lsa->offset));
-  fprintf (out_fp, "OID = %d|%d|%d \n", OID_AS_ARGS (&log_rec->classoid));
+  fprintf (out_fp, ", CLASSOID = %d|%d|%d\n", OID_AS_ARGS (&log_rec->classoid));
 
   return log_page_p;
 }

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -7291,7 +7291,7 @@ log_dump_record_schema_modification_lock (THREAD_ENTRY * thread_p, FILE * out_fp
   /* Get the DATA HEADER */
   LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (*log_rec), log_lsa, log_page_p);
   log_rec = ((LOG_REC_SCHEMA_MODIFICATION_LOCK *) ((char *) log_page_p->area + log_lsa->offset));
-  fprintf (out_fp, ", CLASSOID = %d|%d|%d\n", OID_AS_ARGS (&log_rec->classoid));
+  fprintf (out_fp, ", classoid = %d|%d|%d\n", OID_AS_ARGS (&log_rec->classoid));
 
   return log_page_p;
 }

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -3748,7 +3748,6 @@ log_append_schema_modification_lock (THREAD_ENTRY * thread_p, const OID * classo
       return;
     }
 
-
   LOG_PRIOR_NODE *node =
     prior_lsa_alloc_and_copy_data (thread_p, LOG_SCHEMA_MODIFICATION_LOCK, RV_NOT_DEFINED, NULL, 0, NULL, 0, NULL);
   if (node == nullptr)

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -3735,9 +3735,9 @@ log_append_assigned_mvccid (THREAD_ENTRY * thread_p, MVCCID mvccid)
 }
 
 void
-log_append_schema_modification_lock (THREAD_ENTRY * thread_p, const OID classoid)
+log_append_schema_modification_lock (THREAD_ENTRY * thread_p, const OID * classoid)
 {
-  assert (!OID_ISNULL (&classoid));
+  assert (!OID_ISNULL (classoid));
 
   LOG_TDES *tdes = LOG_FIND_CURRENT_TDES (thread_p);
   assert (tdes != nullptr);
@@ -3747,7 +3747,7 @@ log_append_schema_modification_lock (THREAD_ENTRY * thread_p, const OID classoid
   assert (node != nullptr);
 
   auto record = (LOG_REC_SCHEMA_MODIFICATION_LOCK *) node->data_header;
-  COPY_OID (&record->classoid, &classoid);
+  COPY_OID (&record->classoid, classoid);
 
   (void) prior_lsa_next_record (thread_p, node, tdes);
 }

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -294,6 +294,8 @@ static LOG_PAGE *log_dump_record_assigned_mvccid (THREAD_ENTRY * thread_p, FILE 
 						  LOG_PAGE * log_page_p);
 static LOG_PAGE *log_dump_record_supplemental_info (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_LSA * log_lsa,
 						    LOG_PAGE * log_page_p);
+static LOG_PAGE *log_dump_record_schema_modification_lock (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_LSA * log_lsa,
+							   LOG_PAGE * log_page_p);
 static LOG_PAGE *log_dump_record (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_RECTYPE record_type, LOG_LSA * lsa_p,
 				  LOG_PAGE * log_page_p, LOG_ZIP * log_zip_p);
 static void log_rollback_record (THREAD_ENTRY * thread_p, LOG_LSA * log_lsa, LOG_PAGE * log_page_p,
@@ -509,6 +511,8 @@ log_to_string (LOG_RECTYPE type)
       return "LOG_DUMMY_GENERIC";
     case LOG_SUPPLEMENTAL_INFO:
       return "LOG_SUPPLEMENTAL_INFO";
+    case LOG_SCHEMA_MODIFICATION_LOCK:
+      return "LOG_SCHEMA_MODIFICATION_LOCK";
     case LOG_SMALLER_LOGREC_TYPE:
     case LOG_LARGER_LOGREC_TYPE:
       break;
@@ -3726,6 +3730,24 @@ log_append_assigned_mvccid (THREAD_ENTRY * thread_p, MVCCID mvccid)
 
   auto recp = (LOG_REC_ASSIGNED_MVCCID *) node->data_header;
   recp->mvccid = mvccid;
+
+  (void) prior_lsa_next_record (thread_p, node, tdes);
+}
+
+void
+log_append_schema_modification_lock (THREAD_ENTRY * thread_p, const OID classoid)
+{
+  assert (!OID_ISNULL (&classoid));
+
+  LOG_TDES *tdes = LOG_FIND_CURRENT_TDES (thread_p);
+  assert (tdes != nullptr);
+
+  LOG_PRIOR_NODE *node =
+    prior_lsa_alloc_and_copy_data (thread_p, LOG_SCHEMA_MODIFICATION_LOCK, RV_NOT_DEFINED, NULL, 0, NULL, 0, NULL);
+  assert (node != nullptr);
+
+  auto record = (LOG_REC_SCHEMA_MODIFICATION_LOCK *) node->data_header;
+  COPY_OID (&record->classoid, &classoid);
 
   (void) prior_lsa_next_record (thread_p, node, tdes);
 }
@@ -7261,6 +7283,20 @@ log_dump_record_supplemental_info (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_L
 }
 
 static LOG_PAGE *
+log_dump_record_schema_modification_lock (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_LSA * log_lsa,
+					  LOG_PAGE * log_page_p)
+{
+  LOG_REC_SCHEMA_MODIFICATION_LOCK *log_rec;
+
+  /* Get the DATA HEADER */
+  LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (*log_rec), log_lsa, log_page_p);
+  log_rec = ((LOG_REC_SCHEMA_MODIFICATION_LOCK *) ((char *) log_page_p->area + log_lsa->offset));
+  fprintf (out_fp, "OID = %d|%d|%d \n", OID_AS_ARGS (&log_rec->classoid));
+
+  return log_page_p;
+}
+
+static LOG_PAGE *
 log_dump_record (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_RECTYPE record_type, LOG_LSA * log_lsa,
 		 LOG_PAGE * log_page_p, LOG_ZIP * log_zip_p)
 {
@@ -7361,6 +7397,10 @@ log_dump_record (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_RECTYPE record_type
 
     case LOG_SUPPLEMENTAL_INFO:
       log_page_p = log_dump_record_supplemental_info (thread_p, out_fp, log_lsa, log_page_p);
+      break;
+
+    case LOG_SCHEMA_MODIFICATION_LOCK:
+      log_page_p = log_dump_record_schema_modification_lock (thread_p, out_fp, log_lsa, log_page_p);
       break;
 
     case LOG_2PC_COMMIT_DECISION:
@@ -8290,6 +8330,7 @@ log_rollback (THREAD_ENTRY * thread_p, LOG_TDES * tdes, const LOG_LSA * upto_lsa
 	    case LOG_END_ATOMIC_REPL:
 	    case LOG_ASSIGNED_MVCCID:
 	    case LOG_SUPPLEMENTAL_INFO:
+	    case LOG_SCHEMA_MODIFICATION_LOCK:
 	      break;
 
 	    case LOG_RUN_POSTPONE:
@@ -8725,6 +8766,7 @@ log_do_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * start_postp
 		    case LOG_SUPPLEMENTAL_INFO:
 		    case LOG_START_ATOMIC_REPL:
 		    case LOG_ASSIGNED_MVCCID:
+		    case LOG_SCHEMA_MODIFICATION_LOCK:
 		    case LOG_END_ATOMIC_REPL:
 		      break;
 

--- a/src/transaction/log_manager.h
+++ b/src/transaction/log_manager.h
@@ -130,6 +130,7 @@ extern void log_append_compensate_with_undo_nxlsa (THREAD_ENTRY * thread_p, LOG_
 extern void log_append_ha_server_state (THREAD_ENTRY * thread_p, int state);
 extern void log_append_empty_record (THREAD_ENTRY * thread_p, LOG_RECTYPE logrec_type, LOG_DATA_ADDR * addr);
 extern void log_append_assigned_mvccid (THREAD_ENTRY * thread_p, MVCCID mvccid);
+extern void log_append_schema_modification_lock (THREAD_ENTRY * thread_p, const OID * classoid);
 
 // *INDENT-OFF*
 extern void log_append_trantable_snapshot (THREAD_ENTRY *thread_p, const cublog::checkpoint_info &chkpt_info);

--- a/src/transaction/log_record.hpp
+++ b/src/transaction/log_record.hpp
@@ -152,6 +152,13 @@ enum log_rectype
                                  * it contains transaction user info, DDL statement, undo lsa, redo lsa for DML,
                                  * or undo images that never retrieved from the log. */
 
+  LOG_SCHEMA_MODIFICATION_LOCK, /* Log when SCH_M_LOCK is acquired, and this is for PTS replication to know
+                                 * when to acquire a SCH_M_LOCK for replicating DDL modification, and
+                                 * which table to be locked.
+                                 * PTS needs to block the read transactions which try to access the same class
+                                 * being modified by the replicator.
+                                 */
+
   /* NOTE: add actual (persistent) new values before this */
   LOG_DUMMY_UNIT_TESTING,	/* exclusively for unit testing; not to be persisted;
                                  * constant value does not need be preserved */
@@ -452,6 +459,12 @@ struct log_rec_supplement
 {
   SUPPLEMENT_REC_TYPE rec_type;
   int length;
+};
+
+typedef struct log_rec_schema_modification_lock LOG_REC_SCHEMA_MODIFICATION_LOCK;
+struct log_rec_schema_modification_lock
+{
+  OID classoid;
 };
 
 #define LOG_GET_LOG_RECORD_HEADER(log_page_p, lsa) \

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -2563,6 +2563,7 @@ log_rv_analysis_record_on_tran_server (THREAD_ENTRY * thread_p, LOG_RECTYPE log_
     case LOG_START_ATOMIC_REPL:
     case LOG_END_ATOMIC_REPL:
     case LOG_TRANTABLE_SNAPSHOT:
+    case LOG_SCHEMA_MODIFICATION_LOCK:
       break;
 
     case LOG_SMALLER_LOGREC_TYPE:
@@ -4028,6 +4029,7 @@ log_recovery_redo (THREAD_ENTRY * thread_p, log_recovery_context & context)
 	    case LOG_END_ATOMIC_REPL:
 	    case LOG_TRANTABLE_SNAPSHOT:
 	    case LOG_ASSIGNED_MVCCID:
+	    case LOG_SCHEMA_MODIFICATION_LOCK:
 	      break;
 
 	    case LOG_SYSOP_END:
@@ -4977,6 +4979,7 @@ log_recovery_undo (THREAD_ENTRY * thread_p)
 		case LOG_END_ATOMIC_REPL:
 		case LOG_TRANTABLE_SNAPSHOT:
 		case LOG_ASSIGNED_MVCCID:
+		case LOG_SCHEMA_MODIFICATION_LOCK:
 		  /* Not for UNDO ... */
 		  /* Break switch to go to previous record */
 		  break;
@@ -5940,7 +5943,10 @@ log_startof_nxrec (THREAD_ENTRY * thread_p, LOG_LSA * lsa, bool canuse_forwaddr)
       LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (LOG_REC_HA_SERVER_STATE), &log_lsa, log_pgptr);
       LOG_READ_ADD_ALIGN (thread_p, sizeof (LOG_REC_HA_SERVER_STATE), &log_lsa, log_pgptr);
       break;
-
+    case LOG_SCHEMA_MODIFICATION_LOCK:
+      LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (LOG_REC_SCHEMA_MODIFICATION_LOCK), &log_lsa, log_pgptr);
+      LOG_READ_ADD_ALIGN (thread_p, sizeof (LOG_REC_SCHEMA_MODIFICATION_LOCK), &log_lsa, log_pgptr);
+      break;
     case LOG_SMALLER_LOGREC_TYPE:
     case LOG_LARGER_LOGREC_TYPE:
     default:

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -231,7 +231,7 @@ namespace cublog
 	     */
 	    int error = heap_get_class_name (&thread_entry, &log_rec.classoid, &classname);
 	    _er_log_debug (ARG_FILE_LINE,"[REPL LOCK] Schema modification lock is aquired on %s (OID = %d|%d|%d)\n",
-			   OID_AS_ARGS (&log_rec.classoid), error != NO_ERROR ? "null" : classname);
+			   error != NO_ERROR ? "null" : classname, OID_AS_ARGS (&log_rec.classoid));
 
 	    if (classname != NULL)
 	      {

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -219,16 +219,24 @@ namespace cublog
 	  }
 	  case LOG_SCHEMA_MODIFICATION_LOCK:
 	  {
-	    char *classname;
+	    char *classname = NULL;
 
 	    m_redo_context.m_reader.advance_when_does_not_fit (sizeof (LOG_REC_SCHEMA_MODIFICATION_LOCK));
 	    const LOG_REC_SCHEMA_MODIFICATION_LOCK log_rec =
 		    m_redo_context.m_reader.reinterpret_copy_and_add_align<LOG_REC_SCHEMA_MODIFICATION_LOCK> ();
 
+	    /* TODO:
+	     * All these debug logging part will be removed.
+	     * Lock will be acquired for the class that log_rec.classoid indicates
+	     */
 	    int error = heap_get_class_name (&thread_entry, &log_rec.classoid, &classname);
-	    _er_log_debug (ARG_FILE_LINE,"[REPL LOCK] OID = %d|%d|%d, classname = %s\n", OID_AS_ARGS (&log_rec.classoid),
-			   classname);
-	    free_and_init (classname);
+	    _er_log_debug (ARG_FILE_LINE,"[REPL LOCK] Schema modification lock is aquired on %s (OID = %d|%d|%d)\n",
+			   OID_AS_ARGS (&log_rec.classoid), error != NO_ERROR ? "null" : classname);
+
+	    if (classname != NULL)
+	      {
+		free_and_init (classname);
+	      }
 	    break;
 	  }
 	  default:

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -230,7 +230,7 @@ namespace cublog
 	     * Lock will be acquired for the class that log_rec.classoid indicates
 	     */
 	    int error = heap_get_class_name (&thread_entry, &log_rec.classoid, &classname);
-	    _er_log_debug (ARG_FILE_LINE,"[REPL LOCK] Schema modification lock is aquired on %s (OID = %d|%d|%d)\n",
+	    _er_log_debug (ARG_FILE_LINE,"[REPL_LOCK] Schema modification lock is aquired on %s (OID = %d|%d|%d)\n",
 			   error != NO_ERROR ? "null" : classname, OID_AS_ARGS (&log_rec.classoid));
 
 	    if (classname != NULL)

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -98,6 +98,11 @@ namespace cublog
 
       log_lsa m_lowest_unapplied_lsa;
       mutable std::mutex m_lowest_unapplied_lsa_mutex;
+
+      /* Store the locked objects for DDL replication.
+       * Since multiple DDL operation can be executed within single trnasaction,
+       * more than one objects can be mapped to one transaction */
+      std::multimap <TRANID, OID> m_locked_objects;
   };
 }
 

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -90,7 +90,7 @@ namespace cublog
       void set_lowest_unapplied_lsa ();
       void replicate_sysop_start_postpone (cubthread::entry &thread_entry, const LOG_RECORD_HEADER &rec_header);
 
-      void release_locks_by_tranid (cubthread::entry &thread_entry, const TRANID trid);
+      void unlock_and_discard_caches (cubthread::entry &thread_entry, const TRANID trid);
       void acquire_lock (cubthread::entry &thread_entry, const TRANID trid, const OID *classoid);
 
     private:

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -91,6 +91,7 @@ namespace cublog
       void replicate_sysop_start_postpone (cubthread::entry &thread_entry, const LOG_RECORD_HEADER &rec_header);
 
       void release_locks_by_tranid (cubthread::entry &thread_entry, const TRANID trid);
+      void acquire_lock (cubthread::entry &thread_entry, const TRANID trid, const OID *classoid);
 
     private:
       atomic_replication_helper m_atomic_helper;

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -90,6 +90,8 @@ namespace cublog
       void set_lowest_unapplied_lsa ();
       void replicate_sysop_start_postpone (cubthread::entry &thread_entry, const LOG_RECORD_HEADER &rec_header);
 
+      void release_locks_by_tranid (cubthread::entry &thread_entry, const TRANID trid);
+
     private:
       atomic_replication_helper m_atomic_helper;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-812

Purpose 

Caches that have been modified during DDL operation should be discarded, since the caches can be used by read transactions in PTS.

based on 
#4736 
#4745 
