### PR TITLE
[LETS-749] Revert "Set aside prior nodes from ATS during the catch-up"

### DIFF
--- a/src/base/server_type.cpp
+++ b/src/base/server_type.cpp
@@ -149,7 +149,6 @@ int init_server_type (const char *db_name)
 	  // passive tran server also needs (a) prior receiver(s) to receive log from page server(s)
 	  // the mechanism is that of a pub sub; a PTS subscribes to receive log from one page server (for now)
 	  log_Gl.initialize_log_prior_receiver ();
-	  log_Gl.get_log_prior_receiver ().start_thread ();
 
 	  pts_Gl = new passive_tran_server ();
 	  ts_Gl.reset (pts_Gl);
@@ -168,8 +167,6 @@ int init_server_type (const char *db_name)
       // sender ready, if needed (very unlikely scenario, but principially so)
       log_Gl.initialize_log_prior_sender ();
       log_Gl.initialize_log_prior_receiver ();
-      // The thread in the log_prior_receiver who appends log prior nodes will start once the catch-up is completed.
-      // Until then, it just receives and keeps prior nodes form ATS. See receive_start_catch_up() and execute_catchup.
     }
   else
     {

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -246,8 +246,8 @@ page_server::tran_server_connection_handler::receive_start_catch_up (tran_server
       return;
     }
 
-  // Establish a connection with the PS to catch up with, and start the cathup asynchronously.
-  // The connection will be destoryed at the end of the catch-up.
+  // Establish a connection with the PS to catch up with, and start the catch-up asynchronously.
+  // The connection will be destroyed at the end of the catch-up.
   m_ps.connect_to_followee_page_server (std::move (host), port);
   m_ps.start_catchup (catchup_lsa);
 }

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -226,14 +226,10 @@ page_server::tran_server_connection_handler::receive_start_catch_up (tran_server
   _er_log_debug (ARG_FILE_LINE,
 		 "[CATCH_UP] It's been requested to start catch-up with the follower (%s:%d), until LSA = (%lld|%d)\n",
 		 host.c_str (), port,LSA_AS_ARGS (&catchup_lsa));
-
   if (port == -1)
     {
       // TODO: It means that the ATS is booting up.
       // it will be set properly after ATS recovery is implemented.
-
-      log_Gl.get_log_prior_receiver ().start_thread ();
-
       m_ps.push_request_to_active_tran_server (page_to_tran_request::SEND_CATCHUP_COMPLETE, std::string());
       return;
     }
@@ -250,8 +246,8 @@ page_server::tran_server_connection_handler::receive_start_catch_up (tran_server
       return;
     }
 
-  // Establish a connection with the PS to catch up with, and start the catch-up asynchronously.
-  // The connection will be destroyed at the end of the catch-up.
+  // Establish a connection with the PS to catch up with, and start the cathup asynchronously.
+  // The connection will be destoryed at the end of the catch-up.
   m_ps.connect_to_followee_page_server (std::move (host), port);
   m_ps.start_catchup (catchup_lsa);
 }
@@ -1190,8 +1186,7 @@ page_server::execute_catchup (cubthread::entry &entry, const LOG_LSA catchup_lsa
 
       _er_log_debug (ARG_FILE_LINE, "[CATCH_UP] The catch-up is completed, ranging from %lld to %lld, count = %lld.\n",
 		     start_pageid, end_pageid, total_page_count);
-
-      log_Gl.get_log_prior_receiver ().start_thread ();
+      // TODO: start appneding log prior nodes from the ATS.
 
       push_request_to_active_tran_server (page_to_tran_request::SEND_CATCHUP_COMPLETE, std::string());
 

--- a/src/transaction/log_prior_recv.cpp
+++ b/src/transaction/log_prior_recv.cpp
@@ -28,14 +28,12 @@ namespace cublog
   prior_recver::prior_recver (log_prior_lsa_info &prior_lsa_info)
     : m_prior_lsa_info (prior_lsa_info)
   {
+    start_thread ();
   }
 
   prior_recver::~prior_recver ()
   {
-    if (m_thread.get_id () != std::thread::id ())
-      {
-	stop_thread ();
-      }
+    stop_thread ();
   }
 
   void
@@ -50,7 +48,6 @@ namespace cublog
   void
   prior_recver::start_thread ()
   {
-    assert (m_thread.get_id () == std::thread::id ()); // make sure that it's not been started.
     m_shutdown = false;
     m_thread = std::thread (&prior_recver::loop_message_to_prior_info, std::ref (*this));
   }

--- a/src/transaction/log_prior_recv.hpp
+++ b/src/transaction/log_prior_recv.hpp
@@ -53,13 +53,13 @@ namespace cublog
       prior_recver &operator = (prior_recver &&) = delete;
 
       void push_message (std::string &&str);                  // push message from prior_sender into message queue
-      void start_thread ();                                   // run loop_message_to_prior_info in a thread
 
     private:
       using message_container = std::queue<std::string>;      // internal message container type
 
       void loop_message_to_prior_info ();                     // convert messages into prior node lists and append them
       // to prior info
+      void start_thread ();                                   // run loop_message_to_prior_info in a thread
       void stop_thread ();                                    // stop thread running loop_message_to_prior_info()
 
       log_prior_lsa_info &m_prior_lsa_info;                   // prior list destination

--- a/unit_tests/log/test_main_prior_sendrecv.cpp
+++ b/unit_tests/log/test_main_prior_sendrecv.cpp
@@ -125,7 +125,6 @@ test_env::test_env (size_t receivers_count)
 
       // add new prior receiver that reconstructs destination prior info
       m_recvers.push_back (new cublog::prior_recver (*m_dest_prior_infos.back ()));
-      m_recvers.back ()->start_thread ();
 
       // add new sink for prior receiver
       m_prior_sender_sinks.emplace_back (


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-749

Revert it before fixing to get the tests stable.
