### PR TITLE
[LETS-749] Pause the prior log receiver when a new ATS connects

### DIFF
--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -779,6 +779,9 @@ page_server::set_active_tran_server_connection (cubcomm::channel &&chn)
       disconnect_active_tran_server ();
     }
 
+  // Pause the log prior receiver to process log records from the enw ATS. It just keeps them until the catch-up is compeleted.
+  log_Gl.get_log_prior_receiver ().wait_until_empty_and_pause ();
+
   m_active_tran_server_conn.reset (new tran_server_connection_handler (std::move (chn), transaction_server_type::ACTIVE,
 				   *this));
 }

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -1215,6 +1215,7 @@ page_server::execute_catchup (cubthread::entry &entry, const LOG_LSA catchup_lsa
 void
 page_server::complete_catchup ()
 {
+  log_Gl.get_log_prior_receiver ().resume ();
   push_request_to_active_tran_server (page_to_tran_request::SEND_CATCHUP_COMPLETE, std::string());
 }
 

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -230,7 +230,7 @@ page_server::tran_server_connection_handler::receive_start_catch_up (tran_server
     {
       // TODO: It means that the ATS is booting up.
       // it will be set properly after ATS recovery is implemented.
-      m_ps.push_request_to_active_tran_server (page_to_tran_request::SEND_CATCHUP_COMPLETE, std::string());
+      m_ps.complete_catchup ();
       return;
     }
 
@@ -242,7 +242,7 @@ page_server::tran_server_connection_handler::receive_start_catch_up (tran_server
     {
       _er_log_debug (ARG_FILE_LINE, "[CATCH_UP] There is nothing to catch up.\n");
 
-      m_ps.push_request_to_active_tran_server (page_to_tran_request::SEND_CATCHUP_COMPLETE, std::string());
+      m_ps.complete_catchup ();
       return;
     }
 
@@ -1189,9 +1189,8 @@ page_server::execute_catchup (cubthread::entry &entry, const LOG_LSA catchup_lsa
 
       _er_log_debug (ARG_FILE_LINE, "[CATCH_UP] The catch-up is completed, ranging from %lld to %lld, count = %lld.\n",
 		     start_pageid, end_pageid, total_page_count);
-      // TODO: start appneding log prior nodes from the ATS.
 
-      push_request_to_active_tran_server (page_to_tran_request::SEND_CATCHUP_COMPLETE, std::string());
+      complete_catchup ();
 
       with_disc_msg = true;
     }
@@ -1211,6 +1210,12 @@ page_server::execute_catchup (cubthread::entry &entry, const LOG_LSA catchup_lsa
     }
 
   disconnect_followee_page_server (with_disc_msg);
+}
+
+void
+page_server::complete_catchup ()
+{
+  push_request_to_active_tran_server (page_to_tran_request::SEND_CATCHUP_COMPLETE, std::string());
 }
 
 bool

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -779,7 +779,7 @@ page_server::set_active_tran_server_connection (cubcomm::channel &&chn)
       disconnect_active_tran_server ();
     }
 
-  // Pause the log prior receiver to process log records from the enw ATS. It just keeps them until the catch-up is compeleted.
+  // Pause the log prior receiver to process log records from the new ATS. It just keeps them until the catch-up is completed.
   log_Gl.get_log_prior_receiver ().wait_until_empty_and_pause ();
 
   m_active_tran_server_conn.reset (new tran_server_connection_handler (std::move (chn), transaction_server_type::ACTIVE,

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -293,6 +293,7 @@ class page_server
 
     void start_catchup (const LOG_LSA catchup_lsa);
     void execute_catchup (cubthread::entry &entry, const LOG_LSA catchup_lsa);
+    void complete_catchup ();
 
     tran_server_responder_t &get_tran_server_responder ();
     follower_responder_t &get_follower_responder ();

--- a/src/transaction/log_prior_recv.cpp
+++ b/src/transaction/log_prior_recv.cpp
@@ -157,9 +157,9 @@ namespace cublog
 	    backbuffer.pop ();
 	  }
 
-	ulock.lock ();
-
 	m_messages_consume_cv.notify_one ();
+
+	ulock.lock ();
       }
   }
 }

--- a/src/transaction/log_prior_recv.cpp
+++ b/src/transaction/log_prior_recv.cpp
@@ -44,7 +44,7 @@ namespace cublog
     std::unique_lock<std::mutex> ulock (m_messages_mutex);
     m_messages.push (std::move (str));
     ulock.unlock ();
-    m_messages_condvar.notify_one ();
+    m_messages_push_cv.notify_one ();
   }
 
   void
@@ -61,7 +61,7 @@ namespace cublog
     std::unique_lock<std::mutex> ulock (m_messages_mutex);
     m_shutdown = true;
     ulock.unlock ();
-    m_messages_condvar.notify_one ();
+    m_messages_push_cv.notify_one ();
 
     m_thread.join ();
   }
@@ -74,7 +74,7 @@ namespace cublog
     std::unique_lock<std::mutex> ulock (m_messages_mutex);
     while (true)
       {
-	m_messages_condvar.wait (ulock, [this]
+	m_messages_push_cv.wait (ulock, [this]
 	{
 	  return m_shutdown || !m_messages.empty ();
 	});

--- a/src/transaction/log_prior_recv.cpp
+++ b/src/transaction/log_prior_recv.cpp
@@ -67,6 +67,18 @@ namespace cublog
   }
 
   void
+  prior_recver::wait_until_empty_and_pause ()
+  {
+    std::unique_lock<std::mutex> ulock (m_messages_mutex);
+
+    constexpr auto sleep_30ms = std::chrono::milliseconds (30);
+    while (!m_messages_consume_cv.wait_for (ulock, sleep_30ms, [this]
+    {
+      return !m_messages.empty();
+      }));
+  }
+
+  void
   prior_recver::loop_message_to_prior_info ()
   {
     message_container backbuffer;
@@ -107,6 +119,8 @@ namespace cublog
 	  }
 
 	ulock.lock ();
+
+	m_messages_consume_cv.notify_one ();
       }
   }
 }

--- a/src/transaction/log_prior_recv.cpp
+++ b/src/transaction/log_prior_recv.cpp
@@ -40,7 +40,7 @@ namespace cublog
   void
   prior_recver::push_message (std::string &&str)
   {
-    std::unique_lock<std::mutex> ulock (m_messages_mutex);
+    std::unique_lock<std::mutex> ulock (m_mutex);
 
     assert (m_state == state::RUN || m_state == state::PAUSED);
 
@@ -60,7 +60,7 @@ namespace cublog
   void
   prior_recver::stop_thread ()
   {
-    std::unique_lock<std::mutex> ulock (m_messages_mutex);
+    std::unique_lock<std::mutex> ulock (m_mutex);
 
     assert (m_state != state::SHUTDOWN);
     m_state = state::SHUTDOWN;
@@ -74,7 +74,7 @@ namespace cublog
   void
   prior_recver::wait_until_empty_and_pause ()
   {
-    std::unique_lock<std::mutex> ulock (m_messages_mutex);
+    std::unique_lock<std::mutex> ulock (m_mutex);
 
     if (m_state == state::SHUTDOWN)
       {
@@ -99,7 +99,7 @@ namespace cublog
   void
   prior_recver::resume ()
   {
-    std::unique_lock<std::mutex> ulock (m_messages_mutex);
+    std::unique_lock<std::mutex> ulock (m_mutex);
 
     assert (m_state == state::PAUSED);
 
@@ -122,7 +122,7 @@ namespace cublog
   {
     message_container backbuffer;
 
-    std::unique_lock<std::mutex> ulock (m_messages_mutex);
+    std::unique_lock<std::mutex> ulock (m_mutex);
     while (true)
       {
 	m_messages_push_cv.wait (ulock, [this]

--- a/src/transaction/log_prior_recv.cpp
+++ b/src/transaction/log_prior_recv.cpp
@@ -95,6 +95,12 @@ namespace cublog
       {
 	m_messages_push_cv.notify_one ();
       }
+
+    if (prm_get_bool_value (PRM_ID_ER_LOG_PRIOR_TRANSFER))
+      {
+	_er_log_debug (ARG_FILE_LINE,
+		       "[LOG_PRIOR_TRANSFER] Resume prior_recver: the number of kept messages while paused = %lu.\n", m_messages.size ());
+      }
   }
 
   void

--- a/src/transaction/log_prior_recv.cpp
+++ b/src/transaction/log_prior_recv.cpp
@@ -84,6 +84,15 @@ namespace cublog
       return m_messages.empty () || m_state == state::SHUTDOWN;
       }));
 
+    /*
+     * TODO
+     *  Even if the m_messages is empty, some log reocrds can be appended to the log buffer.
+     *    - It moves the messages to the backbuffer internally.
+     *      This could be appended after it assumes all messages are consumed.
+     *    - The pushed prior nodes from the message queue are appended asynchronously by `log_Flush_daemon`.
+     *      This could be appended afterwards.
+     */
+
     if (m_state != state::SHUTDOWN)
       {
 	m_state = state::PAUSED;

--- a/src/transaction/log_prior_recv.cpp
+++ b/src/transaction/log_prior_recv.cpp
@@ -93,7 +93,6 @@ namespace cublog
   void
   prior_recver::resume ()
   {
-    auto notify_one = false;
     {
       auto lockg = std::lock_guard { m_mutex };
       assert (m_state == state::PAUSED);

--- a/src/transaction/log_prior_recv.cpp
+++ b/src/transaction/log_prior_recv.cpp
@@ -78,7 +78,7 @@ namespace cublog
     constexpr auto sleep_30ms = std::chrono::milliseconds (30);
     while (!m_messages_consume_cv.wait_for (ulock, sleep_30ms, [this]
     {
-      return !m_messages.empty();
+      return m_messages.empty();
       }));
 
     m_paused = true;

--- a/src/transaction/log_prior_recv.cpp
+++ b/src/transaction/log_prior_recv.cpp
@@ -105,19 +105,15 @@ namespace cublog
       assert (m_state == state::PAUSED);
       m_state = state::RUN;
 
-      notify_one = !m_messages.empty ();
+      if (prm_get_bool_value (PRM_ID_ER_LOG_PRIOR_TRANSFER))
+	{
+	  _er_log_debug (ARG_FILE_LINE,
+			 "[LOG_PRIOR_TRANSFER] Resume prior_recver: the number of kept messages while paused = %lu.\n", m_messages.size ());
+	}
     }
 
-    if (notify_one)
-      {
-	m_messages_push_cv.notify_one ();
-      }
-
-    if (prm_get_bool_value (PRM_ID_ER_LOG_PRIOR_TRANSFER))
-      {
-	_er_log_debug (ARG_FILE_LINE,
-		       "[LOG_PRIOR_TRANSFER] Resume prior_recver: the number of kept messages while paused = %lu.\n", m_messages.size ());
-      }
+    // There may be some pushed msg while pausing.
+    m_messages_push_cv.notify_one ();
   }
 
   void

--- a/src/transaction/log_prior_recv.cpp
+++ b/src/transaction/log_prior_recv.cpp
@@ -29,7 +29,7 @@ namespace cublog
     : m_prior_lsa_info (prior_lsa_info)
   {
     m_state = state::RUN;
-    start_thread ();
+    m_thread = std::thread (&prior_recver::loop_message_to_prior_info, std::ref (*this));
   }
 
   prior_recver::~prior_recver ()
@@ -48,12 +48,6 @@ namespace cublog
     }
 
     m_messages_push_cv.notify_one ();
-  }
-
-  void
-  prior_recver::start_thread ()
-  {
-    m_thread = std::thread (&prior_recver::loop_message_to_prior_info, std::ref (*this));
   }
 
   void

--- a/src/transaction/log_prior_recv.hpp
+++ b/src/transaction/log_prior_recv.hpp
@@ -66,7 +66,7 @@ namespace cublog
 
       message_container m_messages;                           // internal queue of messages
       std::mutex m_messages_mutex;                            // protect access on message queue
-      std::condition_variable m_messages_condvar;             // notify internal thread of new messages
+      std::condition_variable m_messages_push_cv;             // notify internal thread of new messages
 
       std::thread m_thread;                                   // internal thread
       bool m_shutdown = false;                                // true to stop internal thread

--- a/src/transaction/log_prior_recv.hpp
+++ b/src/transaction/log_prior_recv.hpp
@@ -83,7 +83,6 @@ namespace cublog
 
       void loop_message_to_prior_info ();                     // convert messages into prior node lists and append them
       // to prior info
-      void start_thread ();                                   // run loop_message_to_prior_info in a thread
       void stop_thread ();                                    // stop thread running loop_message_to_prior_info()
 
       log_prior_lsa_info &m_prior_lsa_info;                   // prior list destination

--- a/src/transaction/log_prior_recv.hpp
+++ b/src/transaction/log_prior_recv.hpp
@@ -74,7 +74,7 @@ namespace cublog
 
       std::thread m_thread;                                   // internal thread
       bool m_shutdown = false;                                // true to stop internal thread
-      bool m_paused = false;                                // true to stop internal thread
+      bool m_paused = false;                                  // true to pause consuming messages
   };
 }
 

--- a/src/transaction/log_prior_recv.hpp
+++ b/src/transaction/log_prior_recv.hpp
@@ -60,6 +60,27 @@ namespace cublog
     private:
       using message_container = std::queue<std::string>;      // internal message container type
 
+      /*
+       * The state transition
+       *
+       * RUN -> PAUSING -> PAUSED -> RUN
+       * (*) -> SHUTDOWN
+       *
+       * - RUN:      It starts with this state. It accepts messages and appends nodes if possible.
+       * - PAUSING:  It's being paused. It's consuming existing prior nodes
+       *             that have been not appended. It's assumed that no msg is pushed.
+       * - PAUSED:   It's been paused. It accepts messages, but doesn't append them.
+       *             It's transitioned to RUN when resume () is called.
+       * - SHUTDOWN: It's shutting down. It will be destroyed soon.
+       */
+      enum class state
+      {
+	RUN,
+	PAUSING,
+	PAUSED,
+	SHUTDOWN,
+      };
+
       void loop_message_to_prior_info ();                     // convert messages into prior node lists and append them
       // to prior info
       void start_thread ();                                   // run loop_message_to_prior_info in a thread
@@ -73,8 +94,8 @@ namespace cublog
       std::condition_variable m_messages_consume_cv;          // notify a set of message has been consumed
 
       std::thread m_thread;                                   // internal thread
-      bool m_shutdown = false;                                // true to stop internal thread
-      bool m_paused = false;                                  // true to pause consuming messages
+
+      state m_state;                                          // see the comment on enum class state
   };
 }
 

--- a/src/transaction/log_prior_recv.hpp
+++ b/src/transaction/log_prior_recv.hpp
@@ -54,8 +54,8 @@ namespace cublog
 
       void push_message (std::string &&str);                  // push message from prior_sender into message queue
 
-      void wait_until_empty_and_pause ();
-      void resume ();
+      void wait_until_empty_and_pause ();                     // digest all existing prior nodes and pause consuming coming ones
+      void resume ();                                         // resume the paused thread
 
     private:
       using message_container = std::queue<std::string>;      // internal message container type

--- a/src/transaction/log_prior_recv.hpp
+++ b/src/transaction/log_prior_recv.hpp
@@ -89,7 +89,7 @@ namespace cublog
       log_prior_lsa_info &m_prior_lsa_info;                   // prior list destination
 
       message_container m_messages;                           // internal queue of messages
-      std::mutex m_messages_mutex;                            // protect access on message queue
+      std::mutex m_mutex;                                     // protect access on message queue and m_state
       std::condition_variable m_messages_push_cv;             // notify internal thread of new messages
       std::condition_variable m_messages_consume_cv;          // notify a set of message has been consumed
 

--- a/src/transaction/log_prior_recv.hpp
+++ b/src/transaction/log_prior_recv.hpp
@@ -55,6 +55,8 @@ namespace cublog
       void push_message (std::string &&str);                  // push message from prior_sender into message queue
       void start_thread ();                                   // run loop_message_to_prior_info in a thread
 
+      void wait_until_empty_and_pause ();
+
     private:
       using message_container = std::queue<std::string>;      // internal message container type
 
@@ -67,6 +69,7 @@ namespace cublog
       message_container m_messages;                           // internal queue of messages
       std::mutex m_messages_mutex;                            // protect access on message queue
       std::condition_variable m_messages_push_cv;             // notify internal thread of new messages
+      std::condition_variable m_messages_consume_cv;          // notify a set of message has been consumed
 
       std::thread m_thread;                                   // internal thread
       bool m_shutdown = false;                                // true to stop internal thread

--- a/src/transaction/log_prior_recv.hpp
+++ b/src/transaction/log_prior_recv.hpp
@@ -56,6 +56,7 @@ namespace cublog
       void start_thread ();                                   // run loop_message_to_prior_info in a thread
 
       void wait_until_empty_and_pause ();
+      void resume ();
 
     private:
       using message_container = std::queue<std::string>;      // internal message container type
@@ -73,6 +74,7 @@ namespace cublog
 
       std::thread m_thread;                                   // internal thread
       bool m_shutdown = false;                                // true to stop internal thread
+      bool m_paused = false;                                // true to stop internal thread
   };
 }
 

--- a/unit_tests/log/test_main_prior_sendrecv.cpp
+++ b/unit_tests/log/test_main_prior_sendrecv.cpp
@@ -57,9 +57,11 @@ class test_env
     void flush_and_transfer_log ();	  // simulate log flush. log is transferred to the receivers in the process
     // and at the end prior lists are compared
 
+    void wait_until_flushed ();          // make sure that all messages have been processed
+    void require_prior_list_match () const; // check prior list in source matches the lists
+
   private:
     static void free_list (log_prior_node *headp);
-    void require_prior_list_match () const;
 
     // Sender & source data
     cublog::prior_sender m_sender;			  // the log sender
@@ -207,13 +209,17 @@ test_env::flush_and_transfer_log ()
       m_source_prior_info.prior_list_header = nullptr;
       m_source_prior_info.prior_list_tail = nullptr;
 
-      // now make sure that all messages have been processed
-      // note: if m_source_prior_info.prior_list_header == nullptr, no message is sent.
-      test_Flush_track.wait_until_count_and_reset (m_dest_prior_infos.size ());
+      wait_until_flushed ();
     }
 
-  // check prior list in source matches the lists
   require_prior_list_match ();
+}
+
+void
+test_env::wait_until_flushed ()
+{
+  // note: if m_source_prior_info.prior_list_header == nullptr, no message is sent.
+  test_Flush_track.wait_until_count_and_reset (m_dest_prior_infos.size ());
 }
 
 void

--- a/unit_tests/log/test_main_prior_sendrecv.cpp
+++ b/unit_tests/log/test_main_prior_sendrecv.cpp
@@ -270,21 +270,31 @@ test_env::require_prior_list_match () const
     {
       return;
     }
-  for (auto &dest_prior_info : m_dest_prior_infos)
+
+  for (size_t i = 0; i< m_dest_prior_infos.size (); i++)
     {
+      const auto &dest_prior_info = m_dest_prior_infos[i];
       const log_prior_node *dest_node = dest_prior_info->prior_list_header;
       const log_prior_node *source_node = m_source_nodes_head;
-      while (source_node != nullptr)
+      while (dest_node != nullptr)
 	{
-	  REQUIRE (dest_node != nullptr);
+	  REQUIRE (source_node != nullptr);
 	  REQUIRE (dest_node->start_lsa == source_node->start_lsa);
 
 	  source_node = source_node->next;
 	  dest_node = dest_node->next;
 	}
-      REQUIRE (dest_node == nullptr);
+
       REQUIRE (m_source_prior_info.prev_lsa == dest_prior_info->prev_lsa);
-      REQUIRE (m_source_nodes_tail->start_lsa == dest_prior_info->prior_list_tail->start_lsa);
+      if (source_node != nullptr)
+	{
+	  // it has beend paused;
+	  REQUIRE (m_paused_lsa[i] == source_node->start_lsa);
+	}
+      else
+	{
+	  REQUIRE (m_source_nodes_tail->start_lsa == dest_prior_info->prior_list_tail->start_lsa);
+	}
     }
 }
 

--- a/unit_tests/log/test_main_prior_sendrecv.cpp
+++ b/unit_tests/log/test_main_prior_sendrecv.cpp
@@ -87,13 +87,21 @@ do_test (test_env &env)
   env.append_log ();
   env.flush_and_transfer_log ();
 
+  env.wait_until_flushed ();
+  env.require_prior_list_match ();
+
   env.flush_and_transfer_log ();
+
+  env.require_prior_list_match ();
 
   for (size_t i = 0; i < 3; ++i)
     {
       env.append_log ();
     }
   env.flush_and_transfer_log ();
+
+  env.wait_until_flushed ();
+  env.require_prior_list_match ();
 }
 
 TEST_CASE ("Test prior list transfers with a single receiver", "")
@@ -208,11 +216,7 @@ test_env::flush_and_transfer_log ()
 
       m_source_prior_info.prior_list_header = nullptr;
       m_source_prior_info.prior_list_tail = nullptr;
-
-      wait_until_flushed ();
     }
-
-  require_prior_list_match ();
 }
 
 void

--- a/unit_tests/log/test_main_prior_sendrecv.cpp
+++ b/unit_tests/log/test_main_prior_sendrecv.cpp
@@ -325,7 +325,7 @@ test_env::require_prior_list_match () const
 
       if (source_node != nullptr)
 	{
-	  // some from source_node haven't been arrrived.
+	  // some from source_node haven't been arrived.
 	  // it must've been paused.
 	  REQUIRE (source_node->start_lsa == m_paused_lsa[i]);
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-749

**The previous approach**: Start the prior receiver thread when the catch-up is done.  
**The previous issue**: It leads to duplicated thread initializations over ats re-connecting.

**The current approach**: 
- When ATS connects, it digests all existing prior nodes and pauses the internal thread.
  - We have some choices here. We can abandon the remainder and we can pause the thread when the previous ATS disconnects. 
  - Abandon the remainder? : It would be safer and reduce how much to catch up with to digest existing ones.
  - Pause when the previous disconnects? : I'd like to do it as lazily as possible.
- When a PS has done catching up, it resumes the thread, which starts appending log prior nodes that have been kept.

Add a unit test for pause/resume
- Refactor existing tests to make use of internal functions.
  - Take out `wait_until_count_and_reset` and `require_prior_list_match`.
  - Adapt `require_prior_list_match` to accept paused prior receiver scenarios. If any node has not arrived at the dest_prior_node after flushing, it means a receiver must've been paused. 

I'll make modifications to the Jira issue after this review.