### PR TITLE
[CBRD-25048] Core dumped in pgbuf_replace_watcher_debug at src/storage/page_buffer.c:12574

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -8043,7 +8043,6 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
       /* A record was found */
       if (get_rec_info)
 	{
-
 	  PGBUF_INIT_WATCHER (&rec_info_page_watcher, PGBUF_ORDERED_HEAP_NORMAL, hfid);
 	  pgbuf_replace_watcher (thread_p, &scan_cache->page_watcher, &rec_info_page_watcher);
 	  scan =

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -7831,6 +7831,7 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
   int get_rec_info = cache_recordinfo != NULL;
   bool is_null_recdata;
   PGBUF_WATCHER old_page_watcher;
+  PGBUF_WATCHER rec_info_page_watcher;
 
   assert (scan_cache != NULL);
 
@@ -8042,8 +8043,11 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
       /* A record was found */
       if (get_rec_info)
 	{
+
+                 PGBUF_INIT_WATCHER (&rec_info_page_watcher, PGBUF_ORDERED_HEAP_NORMAL, hfid);
+                 pgbuf_replace_watcher (thread_p, &scan_cache->page_watcher, &rec_info_page_watcher);
 	  scan =
-	    heap_get_record_info (thread_p, oid, recdes, forward_recdes, &scan_cache->page_watcher, scan_cache,
+	    heap_get_record_info (thread_p, oid, recdes, forward_recdes, &rec_info_page_watcher, scan_cache,
 				  ispeeking, cache_recordinfo);
 	}
       else

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -8044,8 +8044,8 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
       if (get_rec_info)
 	{
 
-                 PGBUF_INIT_WATCHER (&rec_info_page_watcher, PGBUF_ORDERED_HEAP_NORMAL, hfid);
-                 pgbuf_replace_watcher (thread_p, &scan_cache->page_watcher, &rec_info_page_watcher);
+	  PGBUF_INIT_WATCHER (&rec_info_page_watcher, PGBUF_ORDERED_HEAP_NORMAL, hfid);
+	  pgbuf_replace_watcher (thread_p, &scan_cache->page_watcher, &rec_info_page_watcher);
 	  scan =
 	    heap_get_record_info (thread_p, oid, recdes, forward_recdes, &rec_info_page_watcher, scan_cache,
 				  ispeeking, cache_recordinfo);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25048

This issue arises due to the modifications induced by the CBRD-25037 issue. The reason for the error is that the processing within the `heap_next_internal ()` differs between when the `select_record_info` hint is used and when it is not used. Therefore, when the `select_record_info` hint is used, modifications have been made to transfer the value to the local page_watcher variable as before the change, and then execute `heap_get_record_info ()`.