### PR TITLE
[CBRD-25049] Core dumped in mvcc_is_mvcc_disabled_class at src/transaction/mvcc.c:618

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -24883,9 +24883,10 @@ heap_scan_get_visible_version (THREAD_ENTRY * thread_p, const OID * oid, OID * c
 	}
 
       const bool need_check_visibility = scan_cache->mvcc_snapshot != NULL
-	&& scan_cache->mvcc_snapshot->snapshot_fnc != NULL && !mvcc_is_mvcc_disabled_class (class_oid)
-	&& scan_cache->mvcc_snapshot->snapshot_fnc (thread_p, &mvcc_header,
-						    scan_cache->mvcc_snapshot) != SNAPSHOT_SATISFIED;
+	&& scan_cache->mvcc_snapshot->snapshot_fnc != NULL && class_oid != NULL
+	&& !mvcc_is_mvcc_disabled_class (class_oid)
+	&& scan_cache->mvcc_snapshot->snapshot_fnc (thread_p, &mvcc_header, scan_cache->mvcc_snapshot) !=
+	SNAPSHOT_SATISFIED;
 
       if (!need_check_visibility)
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25049

This issue is due to the changes made by the CBRD-25037 issue. The error occurred because the handling of the case where `class_oid`, used as an argument in `mvcc_is_mvcc_disabled_class()`, is NULL before executing `mvcc_is_mvcc_disabled_class()` was not handled. Therefore, modifications have been made to handle this case.