### PR TITLE
[LETS-842] Use the sysprm, checkpoint_interval, for checkpoint_tran as well

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -10885,8 +10885,7 @@ log_checkpoint_trantable_daemon_init ()
 
   if (is_tran_server_with_remote_storage ())
     {
-      constexpr auto loop_time = std::chrono::seconds (60);
-      cubthread::looper looper (loop_time);
+      cubthread::looper looper (log_get_checkpoint_interval);
       cubthread::entry_callable_task * daemon_task =
           new cubthread::entry_callable_task (log_checkpoint_trantable_execute);
       log_Checkpoint_trantable_daemon =


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-842

I don't think we need a new system parameter to set the interval of `log_checkpoint_trantable_daemon`. We can make use of the existing one for `log_checkpoint_daemon`. Each of two daemons are for its own checkpoint mechanism of each server types, ATS and PS.

With this, the system parameter, `checkpoint_interval` means
- on ATS: the interval of `log_checkpoint_trantable_daemon`
- on PS:   the interval of `log_checkpoint_daemon`.
