### PR TITLE
[LETS-844] log debug message 'Received saved LSA' before notifying waiting thread

### DIFF
--- a/src/server/active_tran_server.cpp
+++ b/src/server/active_tran_server.cpp
@@ -185,14 +185,15 @@ active_tran_server::connection_handler::receive_saved_lsa (page_server_conn_t::s
   std::memcpy (&saved_lsa, message.c_str (), sizeof (log_lsa));
 
   assert (saved_lsa >= get_saved_lsa ()); // PS can send the same saved_lsa as before in some cases
+
+  quorum_consenesus_er_log ("Received saved LSA = %lld|%d from %s.\n", LSA_AS_ARGS (&saved_lsa),
+			    get_channel_id ().c_str ());
+
   if (saved_lsa > get_saved_lsa ())
     {
       m_saved_lsa.store (saved_lsa);
       log_Gl.wakeup_ps_flush_waiters ();
     }
-
-  quorum_consenesus_er_log ("Received saved LSA = %lld|%d from %s.\n", LSA_AS_ARGS (&saved_lsa),
-			    get_channel_id ().c_str ());
 }
 
 void

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3541,7 +3541,7 @@ logpb_catchup_finish (THREAD_ENTRY * thread_p, const LOG_LSA catchup_lsa)
   assert (LOG_CS_OWN_WRITE_MODE (thread_p));
   assert (log_Pb.partial_append.status = LOGPB_APPENDREC_SUCCESS);
 
-  char log_pgbuf[LOG_PAGESIZE + MAX_ALIGNMENT], *aligned_log_pgbuf;
+  char log_pgbuf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT], *aligned_log_pgbuf;
   LOG_LSA prev_lsa = log_Gl.append.prev_lsa;
   LOG_LSA nav_lsa = log_Gl.append.prev_lsa;
   LOG_PAGE *log_pgptr = NULL;


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-844

The modification fixes a "race condition" in the way debug logging is written to the log file and the way it is read to allow the testing code to be able to snapshot and investigate a consistent state of the debugging log.
I will exemplify with the following snippet:
```
[QUORUM_CONSENSUS] compute_consensus_lsa - Quorum unsatisfied: total node count = 5, current node count = 2, quorum = 3, consensus LSA = -1|-1
Collected saved lsa list = [ 7407|11832 7407|11832 ] ((1))

[QUORUM_CONSENSUS] compute_consensus_lsa - Quorum unsatisfied: total node count = 5, current node count = 2, quorum = 3, consensus LSA = -1|-1
Collected saved lsa list = [ 7407|11832 7407|13792 ] ((2))

[QUORUM_CONSENSUS] Received saved LSA = 7407|13792 from TS_PS_comm_172.21.0.11_1523_1. ((3))

[QUORUM_CONSENSUS] compute_consensus_lsa - Quorum unsatisfied: total node count = 5, current node count = 2, quorum = 3, consensus LSA = -1|-1
Collected saved lsa list = [ 7407|13792 7407|13792 ]

```
- logged line `((1))` is consistent and a consequence of previous `Received saved LSA` messages from PSs
- logged line `((2))` is not consistent because the `Received saved LSA` message that should produce it is logged afterwards - presumably it is line `((3))`

The cause for this is the way the code is executed by concurrent threads:
- the `connection_handler::receive_saved_lsa` -> `log_global::wakeup_ps_flush_waiters` logic on the connection thread
- and the `log_global::wait_for_ps_flushed_lsa` -> `compute_consensus_lsa ()` logic on a user or system transaction thread which triggers the calculation of consensus LSA and, consequently, the logging of the `Collected saved lsa list` line

Other
- fix Windows build