### PR TITLE
[CBRD-25053] [Regression] Core dumped in tp_is_domain_cached at src/object/object_domain.c:2276

### DIFF
--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -2245,6 +2245,7 @@ tp_is_domain_cached (TP_DOMAIN * dlist, TP_DOMAIN * transient, TP_MATCH exact, T
 
 	      match = ((domain->precision == transient->precision) && (domain->collation_id == transient->collation_id)
 		       && (domain->is_desc == transient->is_desc)
+		       && (domain->codeset == transient->codeset)
 		       && (domain->collation_flag == transient->collation_flag));
 	    }
 	  else if (exact == TP_STR_MATCH)
@@ -2255,6 +2256,7 @@ tp_is_domain_cached (TP_DOMAIN * dlist, TP_DOMAIN * transient, TP_MATCH exact, T
 	       */
 	      match = ((domain->precision >= transient->precision) && (domain->collation_id == transient->collation_id)
 		       && (domain->is_desc == transient->is_desc)
+		       && (domain->codeset == transient->codeset)
 		       && (domain->collation_flag == transient->collation_flag));
 	    }
 	  else
@@ -2268,6 +2270,7 @@ tp_is_domain_cached (TP_DOMAIN * dlist, TP_DOMAIN * transient, TP_MATCH exact, T
 	       * destination domain tolerance.
 	       */
 	      match = ((domain->collation_id == transient->collation_id) && (domain->is_desc == transient->is_desc)
+		       && (domain->codeset == transient->codeset)
 		       && (domain->collation_flag == transient->collation_flag));
 	    }
 
@@ -2683,7 +2686,8 @@ tp_domain_find_charbit (DB_TYPE type, int codeset, int collation_id, unsigned ch
 		{
 		  break;	/* found */
 		}
-	      else if (dom->collation_id == collation_id && dom->collation_flag == collation_flag)
+	      else if (dom->collation_id == collation_id && dom->collation_flag == collation_flag
+		       && dom->codeset == codeset)
 		{
 		  /* codeset should be the same if collations are equal */
 		  assert (dom->codeset == codeset);

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -2244,8 +2244,8 @@ tp_is_domain_cached (TP_DOMAIN * dlist, TP_DOMAIN * transient, TP_MATCH exact, T
 		}
 
 	      match = ((domain->precision == transient->precision) && (domain->collation_id == transient->collation_id)
-		       && (domain->is_desc == transient->is_desc)
 		       && (domain->codeset == transient->codeset)
+		       && (domain->is_desc == transient->is_desc)
 		       && (domain->collation_flag == transient->collation_flag));
 	    }
 	  else if (exact == TP_STR_MATCH)
@@ -2255,8 +2255,8 @@ tp_is_domain_cached (TP_DOMAIN * dlist, TP_DOMAIN * transient, TP_MATCH exact, T
 	       * string without modification.
 	       */
 	      match = ((domain->precision >= transient->precision) && (domain->collation_id == transient->collation_id)
-		       && (domain->is_desc == transient->is_desc)
 		       && (domain->codeset == transient->codeset)
+		       && (domain->is_desc == transient->is_desc)
 		       && (domain->collation_flag == transient->collation_flag));
 	    }
 	  else
@@ -2384,6 +2384,7 @@ tp_is_domain_cached (TP_DOMAIN * dlist, TP_DOMAIN * transient, TP_MATCH exact, T
 		}
 
 	      match = ((domain->precision == transient->precision) && (domain->collation_id == transient->collation_id)
+		       && (domain->codeset == transient->codeset)
 		       && (domain->is_desc == transient->is_desc)
 		       && (domain->collation_flag == transient->collation_flag));
 	    }
@@ -2394,6 +2395,7 @@ tp_is_domain_cached (TP_DOMAIN * dlist, TP_DOMAIN * transient, TP_MATCH exact, T
 	       * in the DB_TYPE_CHAR case above.
 	       */
 	      match = ((domain->collation_id == transient->collation_id)
+		       && (domain->codeset == transient->codeset)
 		       && (transient->precision == 0 || (transient->precision == TP_FLOATING_PRECISION_VALUE)
 			   || domain->precision >= transient->precision)
 		       && (domain->is_desc == transient->is_desc)
@@ -2424,6 +2426,7 @@ tp_is_domain_cached (TP_DOMAIN * dlist, TP_DOMAIN * transient, TP_MATCH exact, T
 		}
 
 	      match = ((domain->precision == transient->precision) && (domain->collation_id == transient->collation_id)
+		       && (domain->codeset == transient->codeset)
 		       && (domain->is_desc == transient->is_desc)
 		       && (domain->collation_flag == transient->collation_flag));
 	    }
@@ -2431,6 +2434,7 @@ tp_is_domain_cached (TP_DOMAIN * dlist, TP_DOMAIN * transient, TP_MATCH exact, T
 	    {
 	      /* see notes above under the DB_TYPE_VARCHAR clause */
 	      match = ((domain->collation_id == transient->collation_id) && (domain->is_desc == transient->is_desc)
+		       && (domain->codeset == transient->codeset)
 		       && (domain->collation_flag == transient->collation_flag));
 	    }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25053

The charset could be different for dblink. The charset should be checked together with collation.