### PR TITLE
[LETS-812] Discard the ddl related caches

### DIFF
--- a/src/query/partition.c
+++ b/src/query/partition.c
@@ -2339,6 +2339,9 @@ reload_from_cache:
       /* Cache the loaded info. If the call below is successful, pinfo will be returned holding the cached information */
       partition_cache_pruning_context (pinfo, &already_exists);
 
+      /* cache is not modified during replication in PTS */
+      assert (thread_p->type != TT_REPLICATION_PTS);
+
       /* Multiple thread can reach here synchronously. In this case redo the action of load from cache. */
       if (already_exists)
 	{

--- a/src/query/xasl_cache.c
+++ b/src/query/xasl_cache.c
@@ -1369,6 +1369,9 @@ xcache_insert (THREAD_ENTRY * thread_p, const compile_context * context, XASL_ST
   assert (stream != NULL);
   assert (stream->buffer != NULL || !context->recompile_xasl);
 
+  /* cache can not be modified during replication in PTS */
+  assert (thread_p->type != TT_REPLICATION_PTS);
+
   if (!xcache_Enabled)
     {
       return NO_ERROR;

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -2532,6 +2532,9 @@ search_begin:
 	  goto exit;
 	}
 
+      /* cache is not modified during replication in PTS */
+      assert (thread_p->type != TT_REPLICATION_PTS);
+
       cache_entry->repr[reprid] = repr_from_record;
       repr = cache_entry->repr[reprid];
       repr_from_record = NULL;
@@ -2607,6 +2610,9 @@ search_begin:
 	    }
 	  else
 	    {
+	      /* cache can not be modified during replication in PTS */
+	      assert (thread_p->type != TT_REPLICATION_PTS);
+
 	      /* use load representation from record */
 	      cache_entry->repr[reprid] = repr_from_record;
 	      repr = repr_from_record;
@@ -24285,6 +24291,9 @@ heap_cache_class_info (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hf
   assert (hfid != NULL && !HFID_IS_NULL (hfid));
   assert (ftype == FILE_HEAP || ftype == FILE_HEAP_REUSE_SLOTS);
 
+  /* cache is not modified during replication in PTS */
+  assert (thread_p->type != TT_REPLICATION_PTS);
+
   if (class_oid == NULL || OID_ISNULL (class_oid))
     {
       /* We can't cache it. */
@@ -24383,6 +24392,12 @@ heap_hfid_cache_get (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid
       return error_code;
     }
   assert (entry != NULL);
+
+  if (inserted == 1 && thread_p->type == TT_REPLICATION_PTS)
+    {
+      /* cache is not modified during replication in PTS */
+      assert (false);
+    }
 
   /*  Here we check only the classname because this is the last field to be populated by other possible concurrent
    *  inserters. This means that if this field is already set by someone else, then the entry data is already

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -161,7 +161,6 @@ namespace cublog
 
 	    if (m_locked_classes.count (header.trid) > 0)
 	      {
-		discard_caches_for_ddl (thread_entry, header.trid);
 		release_all_locks_for_ddl (thread_entry, header.trid);
 	      }
 

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -434,7 +434,7 @@ namespace cublog
       {
 	const OID classoid = it->second;
 
-	heap_classrepr_decache (&thread_entry, &classoid);
+	(void) heap_classrepr_decache (&thread_entry, &classoid);
 	xcache_remove_by_oid (&thread_entry, &classoid);
 	partition_decache_class (&thread_entry, &classoid);
       }

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -21,8 +21,10 @@
 #include "log_replication_jobs.hpp"
 
 #include "heap_file.h"
+#include "locator_sr.h"
 #include "log_recovery_redo_parallel.hpp"
 #include "oid.h"
+#include "xasl_cache.h"
 
 namespace cublog
 {
@@ -123,6 +125,7 @@ namespace cublog
 
 	    if (m_locked_classes.count (header.trid) > 0)
 	      {
+		discard_caches_for_ddl (thread_entry, header.trid);
 		release_all_locks_for_ddl (thread_entry, header.trid);
 	      }
 
@@ -158,6 +161,7 @@ namespace cublog
 
 	    if (m_locked_classes.count (header.trid) > 0)
 	      {
+		discard_caches_for_ddl (thread_entry, header.trid);
 		release_all_locks_for_ddl (thread_entry, header.trid);
 	      }
 
@@ -412,5 +416,27 @@ namespace cublog
 #endif
 
     m_locked_classes.emplace (trid, *classoid);
+  }
+
+  void
+  atomic_replicator::discard_caches_for_ddl (cubthread::entry &thread_entry, const TRANID trid)
+  {
+    assert (m_locked_classes.count (trid) > 0);
+
+    /* TODO:
+     * This is to update locator_Mht_classnames which contains class names,
+     * and it will be replaced with a function to update specific class name only if needed.
+     */
+    locator_initialize (&thread_entry);
+
+    auto [begin, end] = m_locked_classes.equal_range (trid);
+    for (auto it = begin; it != end; it++)
+      {
+	const OID classoid = it->second;
+
+	heap_classrepr_decache (&thread_entry, &classoid);
+	xcache_remove_by_oid (&thread_entry, &classoid);
+	partition_decache_class (&thread_entry, &classoid);
+      }
   }
 }

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -431,9 +431,10 @@ namespace cublog
     auto [begin, end] = m_locked_classes.equal_range (trid);
     for (auto it = begin; it != end; it++)
       {
-	const OID classoid = it->second;
+	auto classoid = it->second;
 
 	(void) heap_classrepr_decache (&thread_entry, &classoid);
+	(void) heap_delete_hfid_from_cache (&thread_entry, &classoid);
 	xcache_remove_by_oid (&thread_entry, &classoid);
 	partition_decache_class (&thread_entry, &classoid);
       }

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -92,6 +92,7 @@ namespace cublog
 
       void release_all_locks_for_ddl (cubthread::entry &thread_entry, const TRANID trid);
       void acquire_lock_for_ddl (cubthread::entry &thread_entry, const TRANID trid, const OID *classoid);
+      void discard_caches_for_ddl (cubthread::entry &thread_entry, const TRANID trid);
 
     private:
       atomic_replication_helper m_atomic_helper;


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-812

Purpose

Caches that have been modified during DDL operation should be discarded, since the caches can be used by read transactions in PTS.