### PR TITLE
[LETS-855] adapt .github/CODEOWNERS for LETS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,23 +23,5 @@
 # accidental assign as reviewer for PR for people not [yet] involved with the project;
 
 # required default reviewer
-/src/base/ @wrlawodms @joohok @hornetmj @cristiarg
-/src/base/memory_monitor_* @wrlawodms @joohok @hornetmj @cristiarg
-/src/broker/ @hornetmj
-/src/cm_common/ @wrlawodms @joohok @hornetmj @cristiarg
-/src/compat/ @wrlawodms @joohok @hornetmj @cristiarg
-/src/jsp/ @wrlawodms @joohok @hornetmj @cristiarg
-/src/method/ @wrlawodms @joohok @hornetmj @cristiarg
-/src/optimizer/ @wrlawodms @joohok @hornetmj @cristiarg
-/src/parser/ @wrlawodms @joohok @hornetmj @cristiarg
-/src/parser/view_transform.* @wrlawodms @joohok @hornetmj @cristiarg
-/src/query/ @wrlawodms @joohok @hornetmj @cristiarg
-/src/query/query_executor.* @wrlawodms @joohok @hornetmj @cristiarg
-/src/query/query_hash_scan.* @wrlawodms @joohok @hornetmj @cristiarg
-/src/query/scan_manager.* @wrlawodms @joohok @hornetmj @cristiarg
-/src/query/vacuum.* @wrlawodms @joohok @hornetmj @cristiarg
-/src/storage/ @wrlawodms @joohok @hornetmj @cristiarg
-/src/storage/statistics* @wrlawodms @joohok @hornetmj @cristiarg
-/src/transaction/ @wrlawodms @joohok @hornetmj @cristiarg
-/src/win_tools/ @wrlawodms @joohok @hornetmj @cristiarg
-/src/xasl/ @wrlawodms @joohok @hornetmj @cristiarg
+/src @wrlawodms @joohok @hornetmj @cristiarg
+/unit_tests @wrlawodms @joohok @hornetmj @cristiarg

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,24 +17,29 @@
 
 # assign reviewers about all files
 
+# NOTE:
+# this is the contents of the file for the LETS `scalability_dev` feature branch;
+# it is much different from the `develop` branch and it is only added as such to prevent
+# accidental assign as reviewer for PR for people not [yet] involved with the project;
+
 # required default reviewer
-/src/base/ @beyondykk9
-/src/base/memory_monitor_* @hornetmj
-/src/broker/ @kisoo-han
-/src/cm_common/ @kisoo-han
-/src/compat/ @beyondykk9
-/src/jsp/ @beyondykk9
-/src/method/ @beyondykk9
-/src/optimizer/ @shparkcubrid
-/src/parser/ @beyondykk9
-/src/parser/view_transform.* @shparkcubrid
-/src/query/ @beyondykk9
-/src/query/query_executor.* @shparkcubrid
-/src/query/query_hash_scan.* @shparkcubrid
-/src/query/scan_manager.* @shparkcubrid
-/src/query/vacuum.* @hornetmj
-/src/storage/ @hornetmj
-/src/storage/statistics* @shparkcubrid
-/src/transaction/ @hornetmj
-/src/win_tools/ @kisoo-han
-/src/xasl/ @beyondykk9
+/src/base/ @wrlawodms @joohok @hornetmj @cristiarg
+/src/base/memory_monitor_* @wrlawodms @joohok @hornetmj @cristiarg
+/src/broker/ @hornetmj
+/src/cm_common/ @wrlawodms @joohok @hornetmj @cristiarg
+/src/compat/ @wrlawodms @joohok @hornetmj @cristiarg
+/src/jsp/ @wrlawodms @joohok @hornetmj @cristiarg
+/src/method/ @wrlawodms @joohok @hornetmj @cristiarg
+/src/optimizer/ @wrlawodms @joohok @hornetmj @cristiarg
+/src/parser/ @wrlawodms @joohok @hornetmj @cristiarg
+/src/parser/view_transform.* @wrlawodms @joohok @hornetmj @cristiarg
+/src/query/ @wrlawodms @joohok @hornetmj @cristiarg
+/src/query/query_executor.* @wrlawodms @joohok @hornetmj @cristiarg
+/src/query/query_hash_scan.* @wrlawodms @joohok @hornetmj @cristiarg
+/src/query/scan_manager.* @wrlawodms @joohok @hornetmj @cristiarg
+/src/query/vacuum.* @wrlawodms @joohok @hornetmj @cristiarg
+/src/storage/ @wrlawodms @joohok @hornetmj @cristiarg
+/src/storage/statistics* @wrlawodms @joohok @hornetmj @cristiarg
+/src/transaction/ @wrlawodms @joohok @hornetmj @cristiarg
+/src/win_tools/ @wrlawodms @joohok @hornetmj @cristiarg
+/src/xasl/ @wrlawodms @joohok @hornetmj @cristiarg


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-855

developers involved with the project are assigned for all code areas regardless of competence; this is to avoid interference - even accidental - with assigning to PR's developers not involved in the project
