### PR TITLE
[LETS-813] Update the classname cache only if needed

### DIFF
--- a/src/storage/oid.h
+++ b/src/storage/oid.h
@@ -144,6 +144,25 @@ inline bool operator!=(const OID& oid1, const OID& oid2)
 {
   return !OID_EQ (&oid1, &oid2);
 }
+
+inline bool operator>(const OID& oid1, const OID& oid2)
+{
+  return OID_GT (&oid1, &oid2);
+}
+inline bool operator>=(const OID& oid1, const OID& oid2)
+{
+  return OID_GTE (&oid1, &oid2);
+}
+
+inline bool operator<(const OID& oid1, const OID& oid2)
+{
+  return OID_LT (&oid1, &oid2);
+}
+
+inline bool operator<=(const OID& oid1, const OID& oid2)
+{
+  return OID_LTE (&oid1, &oid2);
+}
 // *INDENT-ON*
 #endif
 

--- a/src/storage/oid.h
+++ b/src/storage/oid.h
@@ -144,25 +144,6 @@ inline bool operator!=(const OID& oid1, const OID& oid2)
 {
   return !OID_EQ (&oid1, &oid2);
 }
-
-inline bool operator>(const OID& oid1, const OID& oid2)
-{
-  return OID_GT (&oid1, &oid2);
-}
-inline bool operator>=(const OID& oid1, const OID& oid2)
-{
-  return OID_GTE (&oid1, &oid2);
-}
-
-inline bool operator<(const OID& oid1, const OID& oid2)
-{
-  return OID_LT (&oid1, &oid2);
-}
-
-inline bool operator<=(const OID& oid1, const OID& oid2)
-{
-  return OID_LTE (&oid1, &oid2);
-}
 // *INDENT-ON*
 #endif
 

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -14034,7 +14034,6 @@ locator_remove_classname_entry (THREAD_ENTRY * thread_p, const char *classname)
   if (csect_enter (thread_p, CSECT_CT_OID_TABLE, INF_WAIT) != NO_ERROR)
     {
       assert (false);
-      csect_exit (thread_p, CSECT_LOCATOR_SR_CLASSNAME_TABLE);
       return ER_FAILED;
     }
 

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -13934,15 +13934,7 @@ locator_put_classname_entry (THREAD_ENTRY * thread_p, const char *classname, con
 
   if (csect_enter (thread_p, CSECT_LOCATOR_SR_CLASSNAME_TABLE, INF_WAIT) != NO_ERROR)
     {
-      /* Some kind of failure. We must notify the error to the caller. */
       assert (false);
-      return;
-    }
-
-  if (csect_enter (thread_p, CSECT_CT_OID_TABLE, INF_WAIT) != NO_ERROR)
-    {
-      assert (false);
-      csect_exit (thread_p, CSECT_LOCATOR_SR_CLASSNAME_TABLE);
       return;
     }
 
@@ -13971,7 +13963,6 @@ locator_put_classname_entry (THREAD_ENTRY * thread_p, const char *classname, con
   (void) mht_put (locator_Mht_classnames, entry->e_name, entry);
 
   csect_exit (thread_p, CSECT_LOCATOR_SR_CLASSNAME_TABLE);
-  csect_exit (thread_p, CSECT_CT_OID_TABLE);
 }
 
 void
@@ -13981,7 +13972,6 @@ locator_remove_classname_entry (THREAD_ENTRY * thread_p, const char *classname)
 
   if (csect_enter (thread_p, CSECT_LOCATOR_SR_CLASSNAME_TABLE, INF_WAIT) != NO_ERROR)
     {
-      /* Some kind of failure. We must notify the error to the caller. */
       assert (false);
       return;
     }
@@ -13999,6 +13989,32 @@ locator_remove_classname_entry (THREAD_ENTRY * thread_p, const char *classname)
 
   csect_exit (thread_p, CSECT_LOCATOR_SR_CLASSNAME_TABLE);
   csect_exit (thread_p, CSECT_CT_OID_TABLE);
+}
+
+void
+locator_update_classname_entry (THREAD_ENTRY * thread_p, const char *classname)
+{
+  LOCATOR_CLASSNAME_ENTRY *entry = NULL;
+
+  if (csect_enter (thread_p, CSECT_LOCATOR_SR_CLASSNAME_TABLE, INF_WAIT) != NO_ERROR)
+    {
+      assert (false);
+      return;
+    }
+
+  entry = (LOCATOR_CLASSNAME_ENTRY *) mht_get (locator_Mht_classnames, classname);
+ 
+  assert (entry != NULL);
+  assert (entry->e_name != NULL);
+  free_and_init (entry->e_name);
+
+  entry->e_tran_index = NULL_TRAN_INDEX;
+  entry->e_name = strdup ((char *) classname);
+  entry->e_tran_index = NULL_TRAN_INDEX;
+  entry->e_current.action = LC_CLASSNAME_EXIST;
+  LSA_SET_NULL (&entry->e_current.savep_lsa);
+
+  csect_exit (thread_p, CSECT_LOCATOR_SR_CLASSNAME_TABLE);
 }
 
 bool

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -13949,7 +13949,7 @@ locator_initialize_classname_entry (LOCATOR_CLASSNAME_ENTRY * entry, const char 
   if (entry->e_name == nullptr)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (classname));
-      return ER_FAILED;
+      return ER_OUT_OF_VIRTUAL_MEMORY;
     }
   entry->e_tran_index = NULL_TRAN_INDEX;
   entry->e_current.action = LC_CLASSNAME_EXIST;

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -13938,7 +13938,6 @@ locator_initialize_classname_entry (LOCATOR_CLASSNAME_ENTRY * entry, const char 
 {
   assert (classname != nullptr);
 
-  /* Memory for classname is allocated in atomic_replicator::update_classname_cache_for_ddl () */
   entry->e_name = strdup (classname);
   if (entry->e_name == nullptr)
     {

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -13924,6 +13924,83 @@ locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oi
   return error_code;
 }
 
+void
+locator_put_classname_entry (THREAD_ENTRY * thread_p, const char *classname, const OID *classoid)
+{
+  assert (classname != NULL);
+  assert (strlen (classname) < DB_MAX_IDENTIFIER_LENGTH);
+
+  LOCATOR_CLASSNAME_ENTRY *entry;
+
+  if (csect_enter (thread_p, CSECT_LOCATOR_SR_CLASSNAME_TABLE, INF_WAIT) != NO_ERROR)
+    {
+      /* Some kind of failure. We must notify the error to the caller. */
+      assert (false);
+      return;
+    }
+
+  if (csect_enter (thread_p, CSECT_CT_OID_TABLE, INF_WAIT) != NO_ERROR)
+    {
+      assert (false);
+      csect_exit (thread_p, CSECT_LOCATOR_SR_CLASSNAME_TABLE);
+      return;
+    }
+
+  entry = ((LOCATOR_CLASSNAME_ENTRY *) malloc (sizeof (*entry)));
+  if (entry == NULL)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (*entry));
+      return;
+    }
+
+  entry->e_name = strdup ((char *) classname);
+  if (entry->e_name == NULL)
+    {
+      free_and_init (entry);
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, (size_t) (strlen (classname) + 1));
+      return;
+    }
+
+  entry->e_tran_index = NULL_TRAN_INDEX;
+
+  entry->e_current.action = LC_CLASSNAME_EXIST;
+  COPY_OID (&entry->e_current.oid, classoid);
+  LSA_SET_NULL (&entry->e_current.savep_lsa);
+  entry->e_current.prev = NULL;
+
+  (void) mht_put (locator_Mht_classnames, entry->e_name, entry);
+
+  csect_exit (thread_p, CSECT_LOCATOR_SR_CLASSNAME_TABLE);
+  csect_exit (thread_p, CSECT_CT_OID_TABLE);
+}
+
+void
+locator_remove_classname_entry (THREAD_ENTRY * thread_p, const char *classname)
+{
+  LOCATOR_CLASSNAME_ENTRY *entry = NULL;
+
+  if (csect_enter (thread_p, CSECT_LOCATOR_SR_CLASSNAME_TABLE, INF_WAIT) != NO_ERROR)
+    {
+      /* Some kind of failure. We must notify the error to the caller. */
+      assert (false);
+      return;
+    }
+
+  if (csect_enter (thread_p, CSECT_CT_OID_TABLE, INF_WAIT) != NO_ERROR)
+    {
+      assert (false);
+      csect_exit (thread_p, CSECT_LOCATOR_SR_CLASSNAME_TABLE);
+      return;
+    }
+
+  entry = (LOCATOR_CLASSNAME_ENTRY *) mht_get (locator_Mht_classnames, classname);
+
+  (void) locator_force_drop_class_name_entry (entry->e_name, entry, NULL);
+
+  csect_exit (thread_p, CSECT_LOCATOR_SR_CLASSNAME_TABLE);
+  csect_exit (thread_p, CSECT_CT_OID_TABLE);
+}
+
 bool
 has_errors_filtered_for_insert (std::vector<int> error_filter_array)
 {

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -13962,7 +13962,7 @@ locator_put_classname_entry (THREAD_ENTRY * thread_p, const char *classname, con
   scope_exit <std::function <void ()>> classname_csect_exit ([&thread_p] () {csect_exit (thread_p, CSECT_LOCATOR_SR_CLASSNAME_TABLE); });
   // *INDENT-ON*
 
-  entry = ((LOCATOR_CLASSNAME_ENTRY *) malloc (sizeof (*entry)));
+  entry = (LOCATOR_CLASSNAME_ENTRY *) malloc (sizeof (*entry));
   if (entry == NULL)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (*entry));
@@ -14014,6 +14014,13 @@ locator_remove_classname_entry (THREAD_ENTRY * thread_p, const char *classname)
     }
 
   entry = (LOCATOR_CLASSNAME_ENTRY *) mht_get (locator_Mht_classnames, classname);
+  if (entry == NULL)
+    {
+      assert (false);
+      csect_exit (thread_p, CSECT_CT_OID_TABLE);
+      csect_exit (thread_p, CSECT_LOCATOR_SR_CLASSNAME_TABLE);
+      return;
+    }
 
   (void) locator_force_drop_class_name_entry (entry->e_name, entry, NULL);
 
@@ -14052,7 +14059,7 @@ locator_update_classname_entry (THREAD_ENTRY * thread_p, const char *old_classna
   assert (old_entry != NULL);
 
   /* create new entry with new key (new_classname) */
-  new_entry = ((LOCATOR_CLASSNAME_ENTRY *) malloc (sizeof (*new_entry)));
+  new_entry = (LOCATOR_CLASSNAME_ENTRY *) malloc (sizeof (*new_entry));
   if (new_entry == NULL)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (*new_entry));

--- a/src/transaction/locator_sr.h
+++ b/src/transaction/locator_sr.h
@@ -139,6 +139,9 @@ extern int locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID
 				       HEAP_SCANCACHE * scan_cache, int *force_count, int pruning_type,
 				       PRUNING_CONTEXT * pcontext, FUNC_PRED_UNPACK_INFO * func_preds,
 				       UPDATE_INPLACE_STYLE force_in_place, bool dont_check_fk);
+extern void locator_put_classname_entry (THREAD_ENTRY * thread_p, const char *classname, const OID * class_oid);
+extern void locator_remove_classname_entry (THREAD_ENTRY * thread_p, const char *classname);
+
 extern bool has_errors_filtered_for_insert (std::vector<int> error_filter_array);
 // *INDENT-ON*
 

--- a/src/transaction/locator_sr.h
+++ b/src/transaction/locator_sr.h
@@ -142,7 +142,8 @@ extern int locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID
 // *INDENT-ON*
 extern void locator_put_classname_entry (THREAD_ENTRY * thread_p, const char *classname, const OID * class_oid);
 extern void locator_remove_classname_entry (THREAD_ENTRY * thread_p, const char *classname);
-extern void locator_update_classname_entry (THREAD_ENTRY * thread_p, const char *classname);
+extern void locator_update_classname_entry (THREAD_ENTRY * thread_p, const char *old_classname,
+					    const char *new_classname);
 
 // *INDENT-OFF*
 extern bool has_errors_filtered_for_insert (std::vector<int> error_filter_array);

--- a/src/transaction/locator_sr.h
+++ b/src/transaction/locator_sr.h
@@ -139,9 +139,12 @@ extern int locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID
 				       HEAP_SCANCACHE * scan_cache, int *force_count, int pruning_type,
 				       PRUNING_CONTEXT * pcontext, FUNC_PRED_UNPACK_INFO * func_preds,
 				       UPDATE_INPLACE_STYLE force_in_place, bool dont_check_fk);
+// *INDENT-ON*
 extern void locator_put_classname_entry (THREAD_ENTRY * thread_p, const char *classname, const OID * class_oid);
 extern void locator_remove_classname_entry (THREAD_ENTRY * thread_p, const char *classname);
+extern void locator_update_classname_entry (THREAD_ENTRY * thread_p, const char *classname);
 
+// *INDENT-OFF*
 extern bool has_errors_filtered_for_insert (std::vector<int> error_filter_array);
 // *INDENT-ON*
 

--- a/src/transaction/locator_sr.h
+++ b/src/transaction/locator_sr.h
@@ -140,10 +140,10 @@ extern int locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID
 				       PRUNING_CONTEXT * pcontext, FUNC_PRED_UNPACK_INFO * func_preds,
 				       UPDATE_INPLACE_STYLE force_in_place, bool dont_check_fk);
 // *INDENT-ON*
-extern void locator_put_classname_entry (THREAD_ENTRY * thread_p, const char *classname, const OID * class_oid);
-extern void locator_remove_classname_entry (THREAD_ENTRY * thread_p, const char *classname);
-extern void locator_update_classname_entry (THREAD_ENTRY * thread_p, const char *old_classname,
-					    const char *new_classname);
+extern int locator_put_classname_entry (THREAD_ENTRY * thread_p, const char *classname, const OID * class_oid);
+extern int locator_remove_classname_entry (THREAD_ENTRY * thread_p, const char *classname);
+extern int locator_update_classname_entry (THREAD_ENTRY * thread_p, const char *old_classname,
+					   const char *new_classname);
 
 // *INDENT-OFF*
 extern bool has_errors_filtered_for_insert (std::vector<int> error_filter_array);

--- a/src/transaction/locator_sr.h
+++ b/src/transaction/locator_sr.h
@@ -139,15 +139,13 @@ extern int locator_multi_insert_force (THREAD_ENTRY * thread_p, HFID * hfid, OID
 				       HEAP_SCANCACHE * scan_cache, int *force_count, int pruning_type,
 				       PRUNING_CONTEXT * pcontext, FUNC_PRED_UNPACK_INFO * func_preds,
 				       UPDATE_INPLACE_STYLE force_in_place, bool dont_check_fk);
+
+extern bool has_errors_filtered_for_insert (std::vector<int> error_filter_array);
 // *INDENT-ON*
+
 extern int locator_put_classname_entry (THREAD_ENTRY * thread_p, const char *classname, const OID * class_oid);
 extern int locator_remove_classname_entry (THREAD_ENTRY * thread_p, const char *classname);
 extern int locator_update_classname_entry (THREAD_ENTRY * thread_p, const char *old_classname,
 					   const char *new_classname);
-
-// *INDENT-OFF*
-extern bool has_errors_filtered_for_insert (std::vector<int> error_filter_array);
-// *INDENT-ON*
-
 
 #endif /* _LOCATOR_SR_H_ */

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -408,8 +408,9 @@ namespace cublog
   void
   atomic_replicator::bookkeep_classname (cubthread::entry &thread_entry, const OID *classoid)
   {
-    assert (!OID_ISNULL (classoid) && !OID_ISTEMP (classoid));
     char *classname = NULL;
+
+    assert (!OID_ISNULL (classoid) && !OID_ISTEMP (classoid));
 
     (void) heap_get_class_name (&thread_entry, classoid, &classname);
     if (classname != NULL)
@@ -449,10 +450,9 @@ namespace cublog
       }
     else
       {
-	/* classname == NULL */
+	/* If the classname is removed after DDL, then it is DROP TABLE/VIEW case */
 	if (m_classname_map.find (*classoid) != m_classname_map.end ())
 	  {
-	    /* If the classname is removed after DDL, then it is DROP TABLE/VIEW case */
 	    locator_remove_classname_entry (&thread_entry, m_classname_map[*classoid].c_str ());
 	  }
       }

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -239,7 +239,6 @@ namespace cublog
 	    const LOG_REC_SCHEMA_MODIFICATION_LOCK log_rec =
 		    m_redo_context.m_reader.reinterpret_copy_and_add_align<LOG_REC_SCHEMA_MODIFICATION_LOCK> ();
 
-	    // check if m_locked_classes[header.trid] has log_rec.classoid
 	    if (is_already_locked_for_ddl (header.trid, &log_rec.classoid))
 	      {
 		break;
@@ -516,14 +515,6 @@ namespace cublog
   bool
   atomic_replicator::is_already_locked_for_ddl (const TRANID trid, const OID *classoid)
   {
-    if (m_locked_classes.count (trid) > 0)
-      {
-	if (m_locked_classes[trid].count (*classoid) > 0)
-	  {
-	    return true;
-	  }
-      }
-
-    return false;
+    return m_locked_classes.count (trid) > 0 && m_locked_classes[trid].count (*classoid) > 0;
   }
 }

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -239,14 +239,14 @@ namespace cublog
 	    const LOG_REC_SCHEMA_MODIFICATION_LOCK log_rec =
 		    m_redo_context.m_reader.reinterpret_copy_and_add_align<LOG_REC_SCHEMA_MODIFICATION_LOCK> ();
 
-	    if (is_already_locked_for_ddl (header.trid, &log_rec.classoid))
+	    if (is_locked_for_ddl (header.trid, &log_rec.classoid))
 	      {
 		break;
 	      }
 
 	    acquire_lock_for_ddl (thread_entry, header.trid, &log_rec.classoid);
 
-	    bookkeep_classname (thread_entry, &log_rec.classoid);
+	    bookkeep_classname_for_ddl (thread_entry, &log_rec.classoid);
 	    break;
 	  }
 	  default:
@@ -411,7 +411,7 @@ namespace cublog
   }
 
   void
-  atomic_replicator::bookkeep_classname (cubthread::entry &thread_entry, const OID *classoid)
+  atomic_replicator::bookkeep_classname_for_ddl (cubthread::entry &thread_entry, const OID *classoid)
   {
     assert (!OID_ISNULL (classoid) && !OID_ISTEMP (classoid));
 
@@ -520,7 +520,7 @@ namespace cublog
   }
 
   bool
-  atomic_replicator::is_already_locked_for_ddl (const TRANID trid, const OID *classoid)
+  atomic_replicator::is_locked_for_ddl (const TRANID trid, const OID *classoid)
   {
     return m_locked_classes.count (trid) > 0 && m_locked_classes[trid].count (*classoid) > 0;
   }

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -451,7 +451,7 @@ namespace cublog
 	    if (m_classname_map[*classoid] != classname)
 	      {
 		/* If the classname is modified after DDL, then it is RENAME TABLE/VIEW case */
-		locator_update_classname_entry (&thread_entry, classname);
+		locator_update_classname_entry (&thread_entry, m_classname_map[*classoid].c_str(), classname);
 	      }
 	  }
 
@@ -475,17 +475,12 @@ namespace cublog
   {
     assert (m_locked_classes.count (trid) > 0);
 
-    /* TODO:
-     * This is to update locator_Mht_classnames which contains class names,
-     * and it will be replaced with a function to update specific class name only if needed.
-     */
-    locator_initialize (&thread_entry);
-
     auto [begin, end] = m_locked_classes.equal_range (trid);
     for (auto it = begin; it != end; it++)
       {
 	auto classoid = it->second;
 
+	update_classname_cache_for_ddl (thread_entry, &classoid);
 	(void) heap_classrepr_decache (&thread_entry, &classoid);
 	(void) heap_delete_hfid_from_cache (&thread_entry, &classoid);
 	xcache_remove_by_oid (&thread_entry, &classoid);

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -109,7 +109,7 @@ namespace cublog
       /* Keep track of the locked classes for DDL replication.
        * Since multiple DDL operations can be executed within single transaction,
        * more than one classes can be mapped to one transaction */
-      std::multimap <TRANID, OID> m_locked_classes;
+      std::unordered_map <TRANID, std::set<OID>> m_locked_classes;
       std::unordered_map <OID, std::string> m_classname_map;
   };
 }

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -90,6 +90,9 @@ namespace cublog
       void set_lowest_unapplied_lsa ();
       void replicate_sysop_start_postpone (cubthread::entry &thread_entry, const LOG_RECORD_HEADER &rec_header);
 
+      void bookkeep_classname (cubthread::entry &thread_entry, const OID *classoid);
+      void update_classname_cache_for_ddl (cubthread::entry &thread_entry, const OID *classoid);
+
       void release_all_locks_for_ddl (cubthread::entry &thread_entry, const TRANID trid);
       void acquire_lock_for_ddl (cubthread::entry &thread_entry, const TRANID trid, const OID *classoid);
       void discard_caches_for_ddl (cubthread::entry &thread_entry, const TRANID trid);
@@ -107,6 +110,7 @@ namespace cublog
        * Since multiple DDL operations can be executed within single transaction,
        * more than one classes can be mapped to one transaction */
       std::multimap <TRANID, OID> m_locked_classes;
+      std::unordered_map <OID, std::string> m_classname_map;
   };
 }
 

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -92,13 +92,13 @@ namespace cublog
 
       /* TODO:
        * Make seperate class for ddl_replication_helper */
-      void bookkeep_classname (cubthread::entry &thread_entry, const OID *classoid);
+      void bookkeep_classname_for_ddl (cubthread::entry &thread_entry, const OID *classoid);
       void update_classname_cache_for_ddl (cubthread::entry &thread_entry, const OID *classoid);
 
       void release_all_locks_for_ddl (cubthread::entry &thread_entry, const TRANID trid);
       void acquire_lock_for_ddl (cubthread::entry &thread_entry, const TRANID trid, const OID *classoid);
       void discard_caches_for_ddl (cubthread::entry &thread_entry, const TRANID trid);
-      bool is_already_locked_for_ddl (const TRANID trid, const OID *classoid);
+      bool is_locked_for_ddl (const TRANID trid, const OID *classoid);
 
     private:
       atomic_replication_helper m_atomic_helper;

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -109,7 +109,7 @@ namespace cublog
       /* Keep track of the locked classes for DDL replication.
        * Since multiple DDL operations can be executed within single transaction,
        * more than one classes can be mapped to one transaction */
-      std::unordered_map <TRANID, std::set<OID>> m_locked_classes;
+      std::unordered_map <TRANID, std::unordered_set<OID>> m_locked_classes;
       std::unordered_map <OID, std::string> m_classname_map;
   };
 }

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -90,12 +90,15 @@ namespace cublog
       void set_lowest_unapplied_lsa ();
       void replicate_sysop_start_postpone (cubthread::entry &thread_entry, const LOG_RECORD_HEADER &rec_header);
 
+      /* TODO:
+       * Make seperate class for ddl_replication_helper */
       void bookkeep_classname (cubthread::entry &thread_entry, const OID *classoid);
       void update_classname_cache_for_ddl (cubthread::entry &thread_entry, const OID *classoid);
 
       void release_all_locks_for_ddl (cubthread::entry &thread_entry, const TRANID trid);
       void acquire_lock_for_ddl (cubthread::entry &thread_entry, const TRANID trid, const OID *classoid);
       void discard_caches_for_ddl (cubthread::entry &thread_entry, const TRANID trid);
+      bool is_already_locked_for_ddl (const TRANID trid, const OID *classoid);
 
     private:
       atomic_replication_helper m_atomic_helper;


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-813

Purpose
When starting DDL:
1. Check if there is a classname associated with the classOID.
2. If there is a classname, temporarily keep it (`m_classname_map`)
3. Upon DDL commit, check if the classname has changed.
   - If the classname was not present but is now, it's a CREATE statement.
   - If the classname was present but is now missing, it's a DROP statement.
   - If the classname has changed, it's a RENAME statement.
4. Update locator_Mht_classnames accordingly for each case.

NOTE: 
Modified the data structure of `m_locked_classes` from `std::multimap <TRANID, OID>` to `std::unordered_map <TRANID, std::unordered_set <OID>>`.
because : 
- Previous assumption
   - Even if multiple DDLs are performed for the same class within a single transaction, 
   only one LOG_SCHEMA_MODIFICATION_LOCK log should be generated. 
   - Because the <classname, oid, lock mode> is cached in CAS (workspace), and client would use the cached information. 
- Actual test result
   - Cached lock in CAS (workspace) is de-cached when semantic check error occur
      - example
      Rename table tbl to tbl2;  -- lock info is cached in workspace
      Rename table tbl to tbl2;  -- lock info is decached from workspace
      Rename table tbl2 to tbl;  -- To cache the lock information, it request lock info from server, and leave a LOG_SCHEMA_MODIFICATION_LOCK again.
- A cleaner solution will be implemented in the following issue
