### PR TITLE
[LETS-794]  Integrate work pools into one in page_server

### DIFF
--- a/src/base/server_type.cpp
+++ b/src/base/server_type.cpp
@@ -290,11 +290,9 @@ int get_maxim_extra_thread_count_by_server_type ()
   if (local_server_type == SERVER_TYPE_PAGE)
     {
       // thread pool used by page server to perform parallel replication
-      //
       const int replication_parallel_thread_count = prm_get_integer_value (PRM_ID_REPLICATION_PARALLEL_COUNT);
 
-      // thread pool used by page server to asynchronously service requests from transaction servers
-      //
+      // thread pool used by page server to asynchronously service requests from transaction servers and follower page servers
       const int server_request_responder_thread_count
 	= prm_get_integer_value (PRM_ID_SCAL_PERF_PS_REQ_RESPONDER_THREAD_COUNT);
 

--- a/src/base/server_type.cpp
+++ b/src/base/server_type.cpp
@@ -266,7 +266,7 @@ bool is_tran_server_with_remote_storage ()
 }
 
 /*
- * get_page_server_maxim_extra_thread_count - returns the number of extra thread count per
+ * get_maxim_extra_thread_count_by_server_type - returns the number of extra thread count per
  *        scalability server type
  *
  */
@@ -289,22 +289,7 @@ int get_maxim_extra_thread_count_by_server_type ()
 
   if (local_server_type == SERVER_TYPE_PAGE)
     {
-      // thread pool used by page server to perform parallel replication
-      //
-      const int replication_parallel_thread_count = prm_get_integer_value (PRM_ID_REPLICATION_PARALLEL_COUNT);
-
-      // thread pool used by page server to asynchronously service requests from transaction servers
-      //
-      int server_request_responder_thread_count
-	= prm_get_integer_value (PRM_ID_SCAL_PERF_PS_REQ_RESPONDER_THREAD_COUNT);
-      // TODO: there are now two such thread pools on the page server; a future refactoring will remove one
-      server_request_responder_thread_count *= 2;
-
-      // TODO: there is a worker pool to deal with background tasks that need cubthread::entry: page_server::m_worker_pool
-      // a future refactoring will make it shared with request responders above.
-      const int shared_worker_pool_thread_count = 4;
-
-      return replication_parallel_thread_count + server_request_responder_thread_count + shared_worker_pool_thread_count;
+      return ps_Gl->get_internal_thread_count ();
     }
   // NOTE: the same parallel replication mechanism is also used for active transaction server recovery mechanism;
   // but, because that one is transient and only occuring before any other thread infrastructure is instantiated in

--- a/src/base/server_type.cpp
+++ b/src/base/server_type.cpp
@@ -266,7 +266,7 @@ bool is_tran_server_with_remote_storage ()
 }
 
 /*
- * get_maxim_extra_thread_count_by_server_type - returns the number of extra thread count per
+ * get_page_server_maxim_extra_thread_count - returns the number of extra thread count per
  *        scalability server type
  *
  */
@@ -289,7 +289,22 @@ int get_maxim_extra_thread_count_by_server_type ()
 
   if (local_server_type == SERVER_TYPE_PAGE)
     {
-      return ps_Gl->get_internal_thread_count ();
+      // thread pool used by page server to perform parallel replication
+      //
+      const int replication_parallel_thread_count = prm_get_integer_value (PRM_ID_REPLICATION_PARALLEL_COUNT);
+
+      // thread pool used by page server to asynchronously service requests from transaction servers
+      //
+      int server_request_responder_thread_count
+	= prm_get_integer_value (PRM_ID_SCAL_PERF_PS_REQ_RESPONDER_THREAD_COUNT);
+      // TODO: there are now two such thread pools on the page server; a future refactoring will remove one
+      server_request_responder_thread_count *= 2;
+
+      // TODO: there is a worker pool to deal with background tasks that need cubthread::entry: page_server::m_worker_pool
+      // a future refactoring will make it shared with request responders above.
+      const int shared_worker_pool_thread_count = 4;
+
+      return replication_parallel_thread_count + server_request_responder_thread_count + shared_worker_pool_thread_count;
     }
   // NOTE: the same parallel replication mechanism is also used for active transaction server recovery mechanism;
   // but, because that one is transient and only occuring before any other thread infrastructure is instantiated in

--- a/src/base/server_type.cpp
+++ b/src/base/server_type.cpp
@@ -266,7 +266,7 @@ bool is_tran_server_with_remote_storage ()
 }
 
 /*
- * get_page_server_maxim_extra_thread_count - returns the number of extra thread count per
+ * get_maxim_extra_thread_count_by_server_type - returns the number of extra thread count per
  *        scalability server type
  *
  */
@@ -295,13 +295,10 @@ int get_maxim_extra_thread_count_by_server_type ()
 
       // thread pool used by page server to asynchronously service requests from transaction servers
       //
-      int server_request_responder_thread_count
+      const int server_request_responder_thread_count
 	= prm_get_integer_value (PRM_ID_SCAL_PERF_PS_REQ_RESPONDER_THREAD_COUNT);
-      // TODO: there are now two such thread pools on the page server; a future refactoring will remove one
-      server_request_responder_thread_count *= 2;
 
-      // TODO: there is a worker pool to deal with background tasks that need cubthread::entry: page_server::m_worker_pool
-      // a future refactoring will make it shared with request responders above.
+      // extra threads for asynchronous jobs in page_server
       const int shared_worker_pool_thread_count = 4;
 
       return replication_parallel_thread_count + server_request_responder_thread_count + shared_worker_pool_thread_count;

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -1304,3 +1304,15 @@ page_server::finalize_request_responder ()
   m_tran_server_responder.reset (nullptr);
   m_follower_responder.reset (nullptr);
 }
+
+const size_t
+page_server::get_internal_thread_count ()
+{
+  // thread pool used by page server to perform parallel replication
+  const int replication_parallel_thread_count = prm_get_integer_value (PRM_ID_REPLICATION_PARALLEL_COUNT);
+
+  // Refer to page_server::page_server () to see threads
+  const size_t worker_count = m_worker_pool->get_max_count ();
+
+  return replication_parallel_thread_count + worker_count;
+}

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -45,7 +45,7 @@ page_server::page_server (const char *db_name)
   size_t thread_count = 4; // Arbitrary chosen
   size_t task_max_count = thread_count * 4;
 
-  // two async responder: m_tran_server_responder, m_follower_responder
+  // For two async responders: m_tran_server_responder, m_follower_responder
   const size_t responder_thread_cnt = (size_t) prm_get_integer_value (PRM_ID_SCAL_PERF_PS_REQ_RESPONDER_THREAD_COUNT);
   const size_t responder_max_task_cnt = (size_t) prm_get_integer_value (PRM_ID_SCAL_PERF_PS_REQ_RESPONDER_TASK_COUNT);
 
@@ -67,6 +67,9 @@ page_server::~page_server ()
   assert (m_passive_tran_server_conn.size () == 0);
 
   m_async_disconnect_handler.terminate ();
+
+  assert (m_tran_server_responder == nullptr);
+  assert (m_follower_responder == nullptr);
 
   cubthread::get_manager ()->destroy_worker_pool (m_worker_pool);
   assert (m_worker_pool == nullptr);

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -1304,15 +1304,3 @@ page_server::finalize_request_responder ()
   m_tran_server_responder.reset (nullptr);
   m_follower_responder.reset (nullptr);
 }
-
-const size_t
-page_server::get_internal_thread_count ()
-{
-  // thread pool used by page server to perform parallel replication
-  const int replication_parallel_thread_count = prm_get_integer_value (PRM_ID_REPLICATION_PARALLEL_COUNT);
-
-  // Refer to page_server::page_server () to see threads
-  const size_t worker_count = m_worker_pool->get_max_count ();
-
-  return replication_parallel_thread_count + worker_count;
-}

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -40,12 +40,20 @@
 
 page_server::page_server (const char *db_name)
   : m_server_name { db_name }
+  , m_worker_context_manager { TT_SYSTEM_WORKER }
 {
-  const auto thread_count = 4; // Arbitrary chosen
-  const auto task_max_count = thread_count * 4;
+  size_t thread_count = 4; // Arbitrary chosen
+  size_t task_max_count = thread_count * 4;
+
+  // two async responder: m_tran_server_responder, m_follower_responder
+  const size_t responder_thread_cnt = 2 * (size_t) prm_get_integer_value (PRM_ID_SCAL_PERF_PS_REQ_RESPONDER_THREAD_COUNT);
+  const size_t responder_max_task_cnt = 2 * (size_t) prm_get_integer_value (PRM_ID_SCAL_PERF_PS_REQ_RESPONDER_TASK_COUNT);
+
+  thread_count += responder_thread_cnt;
+  task_max_count +=  responder_max_task_cnt;
 
   m_worker_pool = cubthread::get_manager ()->create_worker_pool (thread_count, task_max_count, "page_server_workers",
-		  nullptr, 1, false);
+		  &m_worker_context_manager, 1, false);
 }
 
 page_server::~page_server ()
@@ -1286,8 +1294,8 @@ page_server::finish_replication_during_shutdown (cubthread::entry &thread_entry)
 void
 page_server::init_request_responder ()
 {
-  m_tran_server_responder = std::make_unique<tran_server_responder_t> ();
-  m_follower_responder = std::make_unique<follower_responder_t> ();
+  m_tran_server_responder = std::make_unique<tran_server_responder_t> (*m_worker_pool);
+  m_follower_responder = std::make_unique<follower_responder_t> (*m_worker_pool);
 }
 
 void

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -46,8 +46,8 @@ page_server::page_server (const char *db_name)
   size_t task_max_count = thread_count * 4;
 
   // two async responder: m_tran_server_responder, m_follower_responder
-  const size_t responder_thread_cnt = 2 * (size_t) prm_get_integer_value (PRM_ID_SCAL_PERF_PS_REQ_RESPONDER_THREAD_COUNT);
-  const size_t responder_max_task_cnt = 2 * (size_t) prm_get_integer_value (PRM_ID_SCAL_PERF_PS_REQ_RESPONDER_TASK_COUNT);
+  const size_t responder_thread_cnt = (size_t) prm_get_integer_value (PRM_ID_SCAL_PERF_PS_REQ_RESPONDER_THREAD_COUNT);
+  const size_t responder_max_task_cnt = (size_t) prm_get_integer_value (PRM_ID_SCAL_PERF_PS_REQ_RESPONDER_TASK_COUNT);
 
   thread_count += responder_thread_cnt;
   task_max_count +=  responder_max_task_cnt;

--- a/src/server/page_server.cpp
+++ b/src/server/page_server.cpp
@@ -1297,8 +1297,9 @@ page_server::finish_replication_during_shutdown (cubthread::entry &thread_entry)
 void
 page_server::init_request_responder ()
 {
-  m_tran_server_responder = std::make_unique<tran_server_responder_t> (*m_worker_pool);
-  m_follower_responder = std::make_unique<follower_responder_t> (*m_worker_pool);
+  assert (m_worker_pool != nullptr);
+  m_tran_server_responder = std::make_unique<tran_server_responder_t> (m_worker_pool);
+  m_follower_responder = std::make_unique<follower_responder_t> (m_worker_pool);
 }
 
 void

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -380,8 +380,8 @@ class page_server
      * It's used by two server_request_responders for tran servers and follower servers,
      * and some extra jobs like the catch-up.
      *
-     * Note that both tran_server_responder and follower_responder hold references to the worker pool.
-     * Thus, they must be destroyed prior to the worker pool - to avoid dangling references.
+     * Note that both tran_server_responder and follower_responder hold pointers to the worker pool.
+     * Thus, they must be destroyed prior to the worker pool - to avoid dangling pointers.
      * The responders ensure that all jobs are waited for completion in their dtors.
      */
     cubthread::system_worker_entry_manager m_worker_context_manager;

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -323,6 +323,7 @@ class page_server
     std::future<void> m_follower_disc_future;
     std::mutex m_follower_disc_mutex;
 
+    cubthread::system_worker_entry_manager m_worker_context_manager;
     cubthread::entry_workpool *m_worker_pool; // a worker_pool to take some asynchronous jobs that needs a thread entry
 };
 

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -109,6 +109,7 @@ class page_server
     void init_request_responder ();
     void finalize_request_responder ();
 
+    // get the count of internal threads which use cubthread::entry
     const size_t get_internal_thread_count ();
 
   private: // types

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -109,6 +109,8 @@ class page_server
     void init_request_responder ();
     void finalize_request_responder ();
 
+    const size_t get_internal_thread_count ();
+
   private: // types
     class tran_server_connection_handler
     {
@@ -297,6 +299,8 @@ class page_server
 
     tran_server_responder_t &get_tran_server_responder ();
     follower_responder_t &get_follower_responder ();
+
+    const size_t get_workerpool_thread_count ();
 
   private: // members
     const std::string m_server_name;

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -109,9 +109,6 @@ class page_server
     void init_request_responder ();
     void finalize_request_responder ();
 
-    // get the count of internal threads which use cubthread::entry
-    const size_t get_internal_thread_count ();
-
   private: // types
     class tran_server_connection_handler
     {
@@ -300,8 +297,6 @@ class page_server
 
     tran_server_responder_t &get_tran_server_responder ();
     follower_responder_t &get_follower_responder ();
-
-    const size_t get_workerpool_thread_count ();
 
   private: // members
     const std::string m_server_name;

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -323,7 +323,7 @@ class page_server
     std::future<void> m_follower_disc_future;
     std::mutex m_follower_disc_mutex;
 
-    cubthread::entry_workpool *m_worker_pool; // a worker_pool to take some background jobs that needs a thread entry
+    cubthread::entry_workpool *m_worker_pool; // a worker_pool to take some asynchronous jobs that needs a thread entry
 };
 
 #endif // !_PAGE_SERVER_HPP_

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -328,7 +328,9 @@ class page_server
      * It's used by two server_request_responders for tran servers and follower servers,
      * and some extra jobs like the catch-up.
      *
-     * Note that server_request_responders have to be destroyed earlier since they ensure all jobs are done in their dtors.
+     * Note that both tran_server_responder and follower_responder hold references to the worker pool.
+     * Thus, they must be destroyed prior to the worker pool - to avoid dangling references.
+     * The responders ensure that all jobs are waited for completion in their dtors.
      */
     cubthread::system_worker_entry_manager m_worker_context_manager;
     cubthread::entry_workpool *m_worker_pool;

--- a/src/server/page_server.hpp
+++ b/src/server/page_server.hpp
@@ -323,8 +323,15 @@ class page_server
     std::future<void> m_follower_disc_future;
     std::mutex m_follower_disc_mutex;
 
+    /*
+     * A worker_pool to take some asynchronous jobs that need a thread entry.
+     * It's used by two server_request_responders for tran servers and follower servers,
+     * and some extra jobs like the catch-up.
+     *
+     * Note that server_request_responders have to be destroyed earlier since they ensure all jobs are done in their dtors.
+     */
     cubthread::system_worker_entry_manager m_worker_context_manager;
-    cubthread::entry_workpool *m_worker_pool; // a worker_pool to take some asynchronous jobs that needs a thread entry
+    cubthread::entry_workpool *m_worker_pool;
 };
 
 #endif // !_PAGE_SERVER_HPP_

--- a/src/server/server_request_responder.hpp
+++ b/src/server/server_request_responder.hpp
@@ -55,7 +55,7 @@ class server_request_responder
 
     class task;
 
-    server_request_responder (cubthread::entry_workpool &shared_workerpool);
+    server_request_responder (cubthread::entry_workpool *shared_workerpool);
 
     server_request_responder (const server_request_responder &) = delete;
     server_request_responder (server_request_responder &&) = delete;
@@ -80,7 +80,7 @@ class server_request_responder
     inline void retire_task (const connection_t *connection_ptr);
 
   private:
-    cubthread::entry_workpool &m_workerpool;
+    cubthread::entry_workpool *m_workerpool;
 
     /* monitor executing tasks on a per-connection basis
      * because the behavior of the thread pool - when it itself is requested to terminate - like, upon
@@ -160,7 +160,7 @@ class server_request_responder<T_CONN>::task : public cubthread::entry_task
 //
 
 template<typename T_CONN>
-server_request_responder<T_CONN>::server_request_responder (cubthread::entry_workpool &shared_workerpool)
+server_request_responder<T_CONN>::server_request_responder (cubthread::entry_workpool *shared_workerpool)
   : m_workerpool { shared_workerpool }
 {
 }
@@ -193,7 +193,7 @@ template<typename T_CONN>
 void
 server_request_responder<T_CONN>::async_execute (task *a_task)
 {
-  m_workerpool.execute (a_task);
+  m_workerpool->execute (a_task);
 }
 
 template<typename T_CONN>

--- a/src/server/server_request_responder.hpp
+++ b/src/server/server_request_responder.hpp
@@ -55,7 +55,7 @@ class server_request_responder
 
     class task;
 
-    server_request_responder (cubthread::entry_workpool *shared_workerpool);
+    server_request_responder (cubthread::entry_workpool *const shared_workerpool);
 
     server_request_responder (const server_request_responder &) = delete;
     server_request_responder (server_request_responder &&) = delete;
@@ -160,7 +160,7 @@ class server_request_responder<T_CONN>::task : public cubthread::entry_task
 //
 
 template<typename T_CONN>
-server_request_responder<T_CONN>::server_request_responder (cubthread::entry_workpool *shared_workerpool)
+server_request_responder<T_CONN>::server_request_responder (cubthread::entry_workpool *const shared_workerpool)
   : m_workerpool { shared_workerpool }
 {
 }

--- a/src/server/server_request_responder.hpp
+++ b/src/server/server_request_responder.hpp
@@ -80,7 +80,7 @@ class server_request_responder
     inline void retire_task (const connection_t *connection_ptr);
 
   private:
-    cubthread::entry_workpool *m_workerpool;
+    cubthread::entry_workpool *const m_workerpool;
 
     /* monitor executing tasks on a per-connection basis
      * because the behavior of the thread pool - when it itself is requested to terminate - like, upon

--- a/unit_tests/server/test_server_request_responder_main.cpp
+++ b/unit_tests/server/test_server_request_responder_main.cpp
@@ -126,7 +126,7 @@ struct test_env
     m_worker_pool = cubthread::get_manager ()->create_worker_pool (responder_thread_cnt, responder_max_task_cnt,
 		    "test_async_responder_workers", NULL, 1, false);
 
-    m_rrh = std::make_unique <server_request_responder<test_conn>> (*m_worker_pool);
+    m_rrh = std::make_unique <server_request_responder<test_conn>> (m_worker_pool);
 
     for (const auto &conn : m_conns)
       {

--- a/unit_tests/server/test_server_request_responder_main.cpp
+++ b/unit_tests/server/test_server_request_responder_main.cpp
@@ -115,13 +115,22 @@ struct test_env
   test_thread_init_final m_thread_init_final;   // only to initialize/finalize cubthread
   std::array<test_conn, T_CONN_COUNT> m_conns;
   // responder must be destroyed before connections because responder handles connections in its dtor
-  server_request_responder<test_conn> m_rrh;
+  cubthread::entry_workpool *m_worker_pool;
+  std::unique_ptr<server_request_responder<test_conn>> m_rrh;
 
   test_env ()
   {
+    const size_t responder_thread_cnt = (size_t) prm_get_integer_value (PRM_ID_SCAL_PERF_PS_REQ_RESPONDER_THREAD_COUNT);
+    const size_t responder_max_task_cnt = (size_t) prm_get_integer_value (PRM_ID_SCAL_PERF_PS_REQ_RESPONDER_TASK_COUNT);
+
+    m_worker_pool = cubthread::get_manager ()->create_worker_pool (responder_thread_cnt, responder_max_task_cnt,
+		    "test_async_responder_workers", NULL, 1, false);
+
+    m_rrh = std::make_unique <server_request_responder<test_conn>> (*m_worker_pool);
+
     for (const auto &conn : m_conns)
       {
-	m_rrh.register_connection (&conn);
+	m_rrh->register_connection (&conn);
       }
   }
 
@@ -129,8 +138,10 @@ struct test_env
   {
     for (const auto &conn : m_conns)
       {
-	m_rrh.wait_connection_to_become_idle (&conn);
+	m_rrh->wait_connection_to_become_idle (&conn);
       }
+
+    cubthread::get_manager ()->destroy_worker_pool (m_worker_pool);
   }
 
   void simulate_request (size_t conn_index)
@@ -149,7 +160,7 @@ struct test_env
       std::this_thread::sleep_for (std::chrono::microseconds (1));
     };
 
-    m_rrh.async_execute (conn_ref, std::move (sp), std::move (handler));
+    m_rrh->async_execute (conn_ref, std::move (sp), std::move (handler));
   }
 };
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-794

- Share the `m_worker_pool` with server request responders in the `page_server`.
- There are two server request responders in the `page_server` and the number of threads by `PRM_ID_SCAL_PERF_PS_REQ_RESPONDER_THREAD_COUNT` is for both of them. 
  - It can get separate later if needed. Probably, the maximum of tran_server for the one for tran servers and the maximum of followers for another for followers.
- It's out of scope to define a `entry_task` for extra async jobs in page_server like the catch-up.
- Adapt a unit test.
