### PR TITLE
[CBRD-24761] More readable code for the heap_Bestspace->num_stats_entries -= 1

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -1154,7 +1154,7 @@ heap_stats_del_bestspace_by_vpid (THREAD_ENTRY * thread_p, VPID * vpid)
   (void) heap_stats_entry_free (thread_p, ent, NULL);
   ent = NULL;
 
-  heap_Bestspace->num_stats_entries -= 1;
+  heap_Bestspace->num_stats_entries--;
 
 end:
   assert (mht_count (heap_Bestspace->vpid_ht) == mht_count (heap_Bestspace->hfid_ht));


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24761

Purpose
In other parts, heap_Bestspace->num_stats_entries is decreased using the form 'heap_Bestspace->num_stats_entries--'.
but, in the function heap_stats_del_bestspace_by_vpid, heap_Bestspace->num_stats_entries is decreased using the form 'heap_Bestspace->num_stats_entries -= 1'.
so, I unified them into one format 'val--'.

Implementation
N/A

Remarks
N/A