### PR TITLE
[CBRD-24438] fixed an issue where a space was added to the end of the query string in the log file

### DIFF
--- a/src/base/hide_password.cpp
+++ b/src/base/hide_password.cpp
@@ -696,7 +696,7 @@ hide_password::fprintf_replace_newline (FILE *fp, char *query, int (*cas_fprintf
 	{
 	  chbk = query[offset];
 	  query[offset] = '\0';
-	  cas_fprintf (fp, "%s ", query);
+	  cas_fprintf (fp, "%s", query);
 	  query[offset] = chbk;
 	  query += offset;
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24438

* fixed an issue where a space was added to the end of the query string in the log file
