### PR TITLE
[CBRD-25071] SYS_DATETIME in PL/CSQL function call returns NULL

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/BooleanValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/BooleanValue.java
@@ -70,6 +70,10 @@ public class BooleanValue extends Value {
         return new Double(value);
     }
 
+    public Object toObject() {
+        return Boolean.valueOf(value == 1 ? true : false);
+    }
+
     public String toString() {
         return "" + value;
     }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/DatetimeValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/DatetimeValue.java
@@ -121,4 +121,8 @@ public class DatetimeValue extends Value {
     public String[] toStringArray() throws TypeMismatchException {
         return new String[] {toString()};
     }
+
+    public Object toObject() throws TypeMismatchException {
+        return toTimestamp();
+    }
 }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/TimestampValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/TimestampValue.java
@@ -81,6 +81,10 @@ public class TimestampValue extends Value {
         return timestamp;
     }
 
+    public Object toObject() throws TypeMismatchException {
+        return timestamp;
+    }
+
     public Object toDefault() throws TypeMismatchException {
         return toTimestamp();
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25071

Since toObject () was not implemented, SYS_DATETIME returns NULL. Similarly to the issue, toObject() is added in the BooleanValue and DateTimeValue classes.