### PR TITLE
[CBRD-25073] fix core dump that occurs when user information is omitted in create server statement

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -3172,8 +3172,7 @@ create_stmt
                                                       : si->port ? si->port->buffer_pos
                                                       : si->host ? si->host->buffer_pos : -1;
 
-                                     if(t_buf_pos == -1)  
-                                        pt_add_password_offset(t_buf_pos, t_buf_pos, true, en_server_password);
+                                     pt_add_password_offset(t_buf_pos, t_buf_pos, true, en_server_password);
                                 }
 
                                 if( !si->host || !si->port || !si->dbname || !si->user || !si->pwd)

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -3167,7 +3167,13 @@ create_stmt
                                      }
                                      si->pwd = val;
                                       
-                                    pt_add_password_offset(si->user->buffer_pos, si->user->buffer_pos, true, en_server_password);
+                                     int t_buf_pos = si->user ? si->user->buffer_pos 
+                                                      : si->dbname ? si->dbname->buffer_pos
+                                                      : si->port ? si->port->buffer_pos
+                                                      : si->host ? si->host->buffer_pos : -1;
+
+                                     if(t_buf_pos == -1)  
+                                        pt_add_password_offset(t_buf_pos, t_buf_pos, true, en_server_password);
                                 }
 
                                 if( !si->host || !si->port || !si->dbname || !si->user || !si->pwd)

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -3167,12 +3167,10 @@ create_stmt
                                      }
                                      si->pwd = val;
                                       
-                                     int t_buf_pos = si->user ? si->user->buffer_pos 
-                                                      : si->dbname ? si->dbname->buffer_pos
-                                                      : si->port ? si->port->buffer_pos
-                                                      : si->host ? si->host->buffer_pos : -1;
-
-                                     pt_add_password_offset(t_buf_pos, t_buf_pos, true, en_server_password);
+                                     if(si->user)
+                                     {
+                                        pt_add_password_offset(si->user->buffer_pos, si->user->buffer_pos, true, en_server_password);
+                                     }
                                 }
 
                                 if( !si->host || !si->port || !si->dbname || !si->user || !si->pwd)

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -3167,7 +3167,7 @@ create_stmt
                                      }
                                      si->pwd = val;
                                       
-                                     if(si->user)
+                                     if (si->user)
                                      {
                                         pt_add_password_offset(si->user->buffer_pos, si->user->buffer_pos, true, en_server_password);
                                      }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25073

* fix core dump that occurs when user information is omitted in create server statement