### PR TITLE
[LETS-806] Fix the core when the RVPGBUF_DEALLOC log record is replicated to PTS

### DIFF
--- a/src/transaction/log_recovery_redo.hpp
+++ b/src/transaction/log_recovery_redo.hpp
@@ -16,8 +16,8 @@
  *
  */
 
-#ifndef _LOC_RECOVERY_REDO_HPP_
-#define _LOC_RECOVERY_REDO_HPP_
+#ifndef _LOG_RECOVERY_REDO_HPP_
+#define _LOG_RECOVERY_REDO_HPP_
 
 #include "log_compress.h"
 #include "log_lsa.hpp"
@@ -703,4 +703,4 @@ log_rv_redo_rec_info<T>::log_rv_redo_rec_info (const log_lsa lsa, LOG_RECTYPE ty
 
 }
 
-#endif // _LOC_RECOVERY_REDO_HPP_
+#endif // _LOG_RECOVERY_REDO_HPP_

--- a/src/transaction/log_recovery_redo.hpp
+++ b/src/transaction/log_recovery_redo.hpp
@@ -645,14 +645,14 @@ void log_rv_redo_record_sync_apply (THREAD_ENTRY *thread_p, log_rv_redo_context 
 			 VPID_AS_ARGS (&rcv_vpid), (int) rcv.offset, (int) rcv.length);
     }
 
-  if (is_passive_transaction_server() && log_data.rcvindex == RVPGBUF_DEALLOC)
+  if (log_data.rcvindex == RVPGBUF_DEALLOC && is_passive_transaction_server())
     {
       /* TODO:
        * redofunc for RVPGBUF_DEALLOC (pgbuf_rv_dealloc_redo ()) invalidates the page buffer in PTS,
        * but it does not set page lsa (pgbuf_set_lsa ()) before invalidation.
        * We need to set page lsa when redoing RVPGBUF_DEALLOC log, as what ATS does (see the caller of LOG_NEED_TO_SET_LSA ()).
        */
-      assert (rcv.pgptr != nullptr && pgbuf_get_fix_count (rcv.pgptr) <= 0);
+      assert (rcv.pgptr != nullptr && pgbuf_get_fix_count (rcv.pgptr) == 0);
       rcv.pgptr = nullptr;
     }
 

--- a/src/transaction/log_recovery_redo.hpp
+++ b/src/transaction/log_recovery_redo.hpp
@@ -647,7 +647,11 @@ void log_rv_redo_record_sync_apply (THREAD_ENTRY *thread_p, log_rv_redo_context 
 
   if (is_passive_transaction_server() && log_data.rcvindex == RVPGBUF_DEALLOC)
     {
-      // rcv pgptr is already unfixed and invalidated by the deallocation (pgbuf_rv_dealloc_redo ())
+      /* TODO:
+       * redofunc for RVPGBUF_DEALLOC (pgbuf_rv_dealloc_redo ()) invalidates the page buffer in PTS,
+       * but it does not set page lsa (pgbuf_set_lsa ()) before invalidation.
+       * We need to set page lsa when redoing RVPGBUF_DEALLOC log, as what ATS does (see the caller of LOG_NEED_TO_SET_LSA ()).
+       */
       assert (rcv.pgptr != nullptr && pgbuf_get_fix_count (rcv.pgptr) <= 0);
       rcv.pgptr = nullptr;
     }

--- a/src/transaction/log_recovery_redo.hpp
+++ b/src/transaction/log_recovery_redo.hpp
@@ -647,7 +647,7 @@ void log_rv_redo_record_sync_apply (THREAD_ENTRY *thread_p, log_rv_redo_context 
 
   if (is_passive_transaction_server() && log_data.rcvindex == RVPGBUF_DEALLOC)
     {
-      // rcv.pgptr is invalidated and unfixed by pgbuf_rv_dealloc_redo ()
+      // rcv pgptr is already unfixed and invalidated by the deallocation (pgbuf_rv_dealloc_redo ())
       rcv.pgptr = nullptr;
     }
 

--- a/src/transaction/log_recovery_redo.hpp
+++ b/src/transaction/log_recovery_redo.hpp
@@ -26,6 +26,7 @@
 #include "log_recovery.h"
 #include "page_buffer.h"
 #include "perf_monitor_trackers.hpp"
+#include "server_type.hpp"
 #include "scope_exit.hpp"
 #include "system_parameter.h"
 #include "type_helper.hpp"
@@ -642,6 +643,12 @@ void log_rv_redo_record_sync_apply (THREAD_ENTRY *thread_p, log_rv_redo_context 
 			 "rcv = {mvccid=%llu, vpid=(%d, %d), offset = %d, data_length = %d}",
 			 LSA_AS_ARGS (&record_info.m_start_lsa), (long long int) rcv.mvcc_id,
 			 VPID_AS_ARGS (&rcv_vpid), (int) rcv.offset, (int) rcv.length);
+    }
+
+  if (is_passive_transaction_server() && log_data.rcvindex == RVPGBUF_DEALLOC)
+    {
+      // rcv.pgptr is invalidated and unfixed by pgbuf_rv_dealloc_redo ()
+      rcv.pgptr = nullptr;
     }
 
   if (rcv.pgptr != nullptr)

--- a/src/transaction/log_recovery_redo.hpp
+++ b/src/transaction/log_recovery_redo.hpp
@@ -648,6 +648,7 @@ void log_rv_redo_record_sync_apply (THREAD_ENTRY *thread_p, log_rv_redo_context 
   if (is_passive_transaction_server() && log_data.rcvindex == RVPGBUF_DEALLOC)
     {
       // rcv pgptr is already unfixed and invalidated by the deallocation (pgbuf_rv_dealloc_redo ())
+      assert (rcv.pgptr != nullptr && pgbuf_get_fix_count (rcv.pgptr) <= 0);
       rcv.pgptr = nullptr;
     }
 

--- a/unit_tests/log_repl/test_main_log_repl_atomic_helper.cpp
+++ b/unit_tests/log_repl/test_main_log_repl_atomic_helper.cpp
@@ -1118,11 +1118,13 @@ log_rv_check_redo_is_needed (const PAGE_PTR & /*pgptr*/, const LOG_LSA & /*rcv_l
 bool
 is_passive_transaction_server()
 {
+  assert_release (false);
   return false;
 }
 
 int
 pgbuf_get_fix_count (PAGE_PTR /*pgptr*/)
 {
+  assert_release (false);
   return 0;
 }

--- a/unit_tests/log_repl/test_main_log_repl_atomic_helper.cpp
+++ b/unit_tests/log_repl/test_main_log_repl_atomic_helper.cpp
@@ -1114,3 +1114,9 @@ log_rv_check_redo_is_needed (const PAGE_PTR & /*pgptr*/, const LOG_LSA & /*rcv_l
   assert_release (false);
   return false;
 }
+
+bool
+is_passive_transaction_server()
+{
+  return false;
+}

--- a/unit_tests/log_repl/test_main_log_repl_atomic_helper.cpp
+++ b/unit_tests/log_repl/test_main_log_repl_atomic_helper.cpp
@@ -1120,3 +1120,9 @@ is_passive_transaction_server()
 {
   return false;
 }
+
+int
+pgbuf_get_fix_count (PAGE_PTR /*pgptr*/)
+{
+  return 0;
+}


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-806

Purpose

When applying RVPGBUF_DEALLOC in the PTS replicator, the redo function already invalidates and unfixes the corresponding page. 
 However, because the replicator is unaware of whether the page has been unfixed, it attempts to unfix it again. The goal is to resolve the crash occurring during this process.
If the page has already been unfixed, it is necessary to invalidate `rcv.pgptr` used by the replicator.