### PR TITLE
[CBRD-24988] If a key containing null is inserted after the fence key is created, the decompressed key may have an incorrect nullmap

### DIFF
--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -9063,7 +9063,7 @@ pr_midxkey_add_prefix (DB_VALUE * result, DB_VALUE * prefix, DB_VALUE * postfix,
 	    }
 	  else
 	    {
-	      assert (or_multi_is_null (midx_result.buf, i));
+	      or_multi_set_null (midx_result.buf, i);
 	    }
 
 	  /* update offset */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24988

When decompressing a key in the pr_midxkey_add_prefix function, even if it is null, nullmap is explicitly set as in AS-IS.