### PR TITLE
[CBRD-25059] adddate() built-in function call returns a string value, not a datetime value

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/StringValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/StringValue.java
@@ -36,8 +36,18 @@ import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 
 public class StringValue extends Value {
+    // TODO: consider string value's locale (new SimpleDateFormat("...", Locale.KOREA));
+    private static final String dateTimePattern = "hh:mm:ss.SSS a dd/MM/yyyy";
+    private static final SimpleDateFormat dateFormat =
+            new SimpleDateFormat("hh:mm:ss.SSS a dd/MM/yyyy");
+
     private String value;
 
     public StringValue(String value) {
@@ -149,7 +159,11 @@ public class StringValue extends Value {
 
     public Date toDate() throws TypeMismatchException {
         try {
-            return Date.valueOf(value);
+            LocalDate lDate =
+                    LocalDate.from(
+                            LocalDateTime.parse(
+                                    value, DateTimeFormatter.ofPattern(dateTimePattern)));
+            return Date.valueOf(lDate);
         } catch (IllegalArgumentException e) {
             throw new TypeMismatchException(e.getMessage());
         }
@@ -157,7 +171,11 @@ public class StringValue extends Value {
 
     public Time toTime() throws TypeMismatchException {
         try {
-            return Time.valueOf(value);
+            LocalTime lTime =
+                    LocalTime.from(
+                            LocalDateTime.parse(
+                                    value, DateTimeFormatter.ofPattern(dateTimePattern)));
+            return Time.valueOf(lTime);
         } catch (IllegalArgumentException e) {
             throw new TypeMismatchException(e.getMessage());
         }
@@ -165,7 +183,9 @@ public class StringValue extends Value {
 
     public Timestamp toTimestamp() throws TypeMismatchException {
         try {
-            return Timestamp.valueOf(value);
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern(dateTimePattern);
+            LocalDateTime localDateTime = LocalDateTime.from(formatter.parse(value));
+            return Timestamp.valueOf(localDateTime);
         } catch (IllegalArgumentException e) {
             throw new TypeMismatchException(e.getMessage());
         }
@@ -173,7 +193,9 @@ public class StringValue extends Value {
 
     public Timestamp toDatetime() throws TypeMismatchException {
         try {
-            return Timestamp.valueOf(value);
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern(dateTimePattern);
+            LocalDateTime localDateTime = LocalDateTime.from(formatter.parse(value));
+            return Timestamp.valueOf(localDateTime);
         } catch (IllegalArgumentException e) {
             throw new TypeMismatchException(e.getMessage());
         }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/StringValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/StringValue.java
@@ -41,12 +41,12 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 public class StringValue extends Value {
-    // TODO: consider string value's locale (new SimpleDateFormat("...", Locale.KOREA));
     private static final String dateTimePattern = "hh:mm:ss.SSS a dd/MM/yyyy";
-    private static final SimpleDateFormat dateFormat =
-            new SimpleDateFormat("hh:mm:ss.SSS a dd/MM/yyyy");
+    // Locale.US: hardcoding. TODO: set it to CUBRID server's locale
+    private static final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(dateTimePattern, Locale.US);
 
     private String value;
 
@@ -159,10 +159,7 @@ public class StringValue extends Value {
 
     public Date toDate() throws TypeMismatchException {
         try {
-            LocalDate lDate =
-                    LocalDate.from(
-                            LocalDateTime.parse(
-                                    value, DateTimeFormatter.ofPattern(dateTimePattern)));
+            LocalDate lDate = LocalDate.from(LocalDateTime.parse(value, dateTimeFormatter));
             return Date.valueOf(lDate);
         } catch (IllegalArgumentException e) {
             throw new TypeMismatchException(e.getMessage());
@@ -171,10 +168,7 @@ public class StringValue extends Value {
 
     public Time toTime() throws TypeMismatchException {
         try {
-            LocalTime lTime =
-                    LocalTime.from(
-                            LocalDateTime.parse(
-                                    value, DateTimeFormatter.ofPattern(dateTimePattern)));
+            LocalTime lTime = LocalTime.from(LocalDateTime.parse(value, dateTimeFormatter));
             return Time.valueOf(lTime);
         } catch (IllegalArgumentException e) {
             throw new TypeMismatchException(e.getMessage());
@@ -183,8 +177,7 @@ public class StringValue extends Value {
 
     public Timestamp toTimestamp() throws TypeMismatchException {
         try {
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern(dateTimePattern);
-            LocalDateTime localDateTime = LocalDateTime.from(formatter.parse(value));
+            LocalDateTime localDateTime = LocalDateTime.from(dateTimeFormatter.parse(value));
             return Timestamp.valueOf(localDateTime);
         } catch (IllegalArgumentException e) {
             throw new TypeMismatchException(e.getMessage());
@@ -193,8 +186,7 @@ public class StringValue extends Value {
 
     public Timestamp toDatetime() throws TypeMismatchException {
         try {
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern(dateTimePattern);
-            LocalDateTime localDateTime = LocalDateTime.from(formatter.parse(value));
+            LocalDateTime localDateTime = LocalDateTime.from(dateTimeFormatter.parse(value));
             return Timestamp.valueOf(localDateTime);
         } catch (IllegalArgumentException e) {
             throw new TypeMismatchException(e.getMessage());

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/StringValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/StringValue.java
@@ -36,7 +36,6 @@ import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
-import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -46,7 +45,8 @@ import java.util.Locale;
 public class StringValue extends Value {
     private static final String dateTimePattern = "hh:mm:ss.SSS a dd/MM/yyyy";
     // Locale.US: hardcoding. TODO: set it to CUBRID server's locale
-    private static final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(dateTimePattern, Locale.US);
+    private static final DateTimeFormatter dateTimeFormatter =
+            DateTimeFormatter.ofPattern(dateTimePattern, Locale.US);
 
     private String value;
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -671,7 +671,9 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
 
     private static String[] tmplExprBuiltinFuncCall =
             new String[] {
-                "(%'RESULT-TYPE'%) invokeBuiltinFunc(conn, \"%'NAME'%\", %'RESULT-TYPE-CODE'%,", "  %'+ARGS'%", ")"
+                "(%'RESULT-TYPE'%) invokeBuiltinFunc(conn, \"%'NAME'%\", %'RESULT-TYPE-CODE'%,",
+                "  %'+ARGS'%",
+                ")"
             };
 
     @Override
@@ -688,8 +690,9 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                     new CodeTemplate(
                             "ExprBuiltinFuncCall",
                             Misc.getLineColumnOf(node.ctx),
-                            String.format("(%s) invokeBuiltinFunc(conn, \"%s\", %d)",
-                                ty, node.name, node.resultType.simpleTypeIdx));
+                            String.format(
+                                    "(%s) invokeBuiltinFunc(conn, \"%s\", %d)",
+                                    ty, node.name, node.resultType.simpleTypeIdx));
         } else {
             tmpl =
                     new CodeTemplate(

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -671,7 +671,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
 
     private static String[] tmplExprBuiltinFuncCall =
             new String[] {
-                "(%'RESULT-TYPE'%) invokeBuiltinFunc(conn, \"%'NAME'%\",", "  %'+ARGS'%", ")"
+                "(%'RESULT-TYPE'%) invokeBuiltinFunc(conn, \"%'NAME'%\", %'RESULT-TYPE-CODE'%,", "  %'+ARGS'%", ")"
             };
 
     @Override
@@ -688,7 +688,8 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                     new CodeTemplate(
                             "ExprBuiltinFuncCall",
                             Misc.getLineColumnOf(node.ctx),
-                            String.format("(%s) invokeBuiltinFunc(conn, \"%s\")", ty, node.name));
+                            String.format("(%s) invokeBuiltinFunc(conn, \"%s\", %d)",
+                                ty, node.name, node.resultType.simpleTypeIdx));
         } else {
             tmpl =
                     new CodeTemplate(
@@ -699,6 +700,8 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                             ty,
                             "%'NAME'%",
                             node.name,
+                            "%'RESULT-TYPE-CODE'%",
+                            Integer.toString(node.resultType.simpleTypeIdx),
                             // assumption: built-in functions do not have OUT parameters
                             "%'+ARGS'%",
                             visitNodeList(node.args).setDelimiter(","));
@@ -1054,7 +1057,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 "%'+ELSE-PART'%",
                 node.elsePart == null ? "throw new CASE_NOT_FOUND();" : visit(node.elsePart),
                 "%'LEVEL'%",
-                "" + node.level // level replacement must go last
+                Integer.toString(node.level) // level replacement must go last
                 );
     }
 
@@ -1215,7 +1218,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                     "%'+HOST-EXPRS'%",
                     hostExprs,
                     "%'LEVEL'%",
-                    "" + node.cursor.scope.level);
+                    Integer.toString(node.cursor.scope.level));
         }
     }
 
@@ -1362,7 +1365,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 "%'+HANDLE-INTO-CLAUSE'%",
                 handleIntoClause,
                 "%'LEVEL'%",
-                "" + node.level);
+                Integer.toString(node.level));
     }
 
     @Override
@@ -1430,7 +1433,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                     "%'LABEL'%",
                     node.label == null ? "" : node.label + "_%'LEVEL'%:",
                     "%'LEVEL'%",
-                    "" + node.cursor.scope.level,
+                    Integer.toString(node.cursor.scope.level),
                     "%'+STATEMENTS'%",
                     visitNodeList(node.stmts));
         } else {
@@ -1454,7 +1457,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                     "%'LABEL'%",
                     node.label == null ? "" : node.label + "_%'LEVEL'%:",
                     "%'LEVEL'%",
-                    "" + node.cursor.scope.level,
+                    Integer.toString(node.cursor.scope.level),
                     "%'+STATEMENTS'%",
                     visitNodeList(node.stmts));
         }
@@ -1508,7 +1511,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 Misc.getLineColumnOf(node.ctx),
                 node.reverse ? tmplStmtForIterLoopReverse : tmplStmtForIterLoop,
                 "%'LVL'%",
-                "" + node.iter.scope.level,
+                Integer.toString(node.iter.scope.level),
                 "%'OPT-LABEL'%",
                 labelStr,
                 "%'I'%",
@@ -1582,7 +1585,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 "%'LABEL'%",
                 node.label == null ? "" : node.label + "_%'LEVEL'%:",
                 "%'LEVEL'%",
-                "" + node.record.scope.level,
+                Integer.toString(node.record.scope.level),
                 "%'+STATEMENTS'%",
                 visitNodeList(node.stmts));
     }
@@ -2118,7 +2121,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                                 Misc.getLineColumnOf(arg.ctx),
                                 tmplDupCursorArg,
                                 "%'INDEX'%",
-                                "" + i,
+                                Integer.toString(i),
                                 "%'+ARG'%",
                                 visit(arg)));
             }
@@ -2254,7 +2257,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                             Misc.getLineColumnOf(expr.ctx),
                             tmplSetObject,
                             "%'INDEX'%",
-                            "" + (i + 1),
+                            Integer.toString(i + 1),
                             "%'+VALUE'%",
                             visit(expr));
             ret.addElement(tmpl);
@@ -2314,9 +2317,9 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                     Misc.UNKNOWN_LINE_COLUMN,
                     tmplCoerceAndCheckPrec,
                     "%'PREC'%",
-                    "" + checkPrec.prec,
+                    Integer.toString(checkPrec.prec),
                     "%'SCALE'%",
-                    "" + checkPrec.scale,
+                    Short.toString(checkPrec.scale),
                     "%'+EXPR'%",
                     applyCoercion(checkPrec.c, exprCode));
         } else {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
@@ -551,7 +551,6 @@ public class TypeChecker extends AstVisitor<TypeSpec> {
             TypeSpecSimple ret;
             if (DBTypeAdapter.isSupported(ci.type)) {
                 ret = DBTypeAdapter.getValueType(ci.type);
-                assert !ret.equals(TypeSpecSimple.NULL);
             } else {
                 // Allow the other types too, which can lead to run-time type errors,
                 // but accepts some more working programs. For example,

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -33,9 +33,9 @@ package com.cubrid.plcsql.predefined.sp;
 import com.cubrid.jsp.Server;
 import com.cubrid.plcsql.builtin.DBMS_OUTPUT;
 import com.cubrid.plcsql.compiler.CoercionScheme;
-import com.cubrid.plcsql.compiler.ast.TypeSpecSimple;
 import com.cubrid.plcsql.compiler.DateTimeParser;
 import com.cubrid.plcsql.compiler.annotation.Operator;
+import com.cubrid.plcsql.compiler.ast.TypeSpecSimple;
 import com.cubrid.plcsql.predefined.PlcsqlRuntimeError;
 import java.math.BigDecimal;
 import java.math.MathContext;
@@ -175,7 +175,8 @@ public class SpLib {
     // To provide line and column numbers for run-time exceptions
     // -------------------------------------------------------------------------------
 
-    public static Object invokeBuiltinFunc(Connection conn, String name, int resultTypeCode, Object... args) {
+    public static Object invokeBuiltinFunc(
+            Connection conn, String name, int resultTypeCode, Object... args) {
 
         int argsLen = args.length;
         String hostVars = getHostVarsStr(argsLen);

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -33,6 +33,7 @@ package com.cubrid.plcsql.predefined.sp;
 import com.cubrid.jsp.Server;
 import com.cubrid.plcsql.builtin.DBMS_OUTPUT;
 import com.cubrid.plcsql.compiler.CoercionScheme;
+import com.cubrid.plcsql.compiler.ast.TypeSpecSimple;
 import com.cubrid.plcsql.compiler.DateTimeParser;
 import com.cubrid.plcsql.compiler.annotation.Operator;
 import com.cubrid.plcsql.predefined.PlcsqlRuntimeError;
@@ -174,7 +175,7 @@ public class SpLib {
     // To provide line and column numbers for run-time exceptions
     // -------------------------------------------------------------------------------
 
-    public static Object invokeBuiltinFunc(Connection conn, String name, Object... args) {
+    public static Object invokeBuiltinFunc(Connection conn, String name, int resultTypeCode, Object... args) {
 
         int argsLen = args.length;
         String hostVars = getHostVarsStr(argsLen);
@@ -186,7 +187,46 @@ public class SpLib {
             }
             ResultSet rs = pstmt.executeQuery();
             if (rs.next()) {
-                Object ret = rs.getObject(1);
+                Object ret;
+                switch (resultTypeCode) {
+                    case TypeSpecSimple.IDX_NULL:
+                    case TypeSpecSimple.IDX_OBJECT:
+                        ret = rs.getObject(1);
+                        break;
+                    case TypeSpecSimple.IDX_STRING:
+                        ret = rs.getString(1);
+                        break;
+                    case TypeSpecSimple.IDX_SHORT:
+                        ret = rs.getShort(1);
+                        break;
+                    case TypeSpecSimple.IDX_INT:
+                        ret = rs.getInt(1);
+                        break;
+                    case TypeSpecSimple.IDX_BIGINT:
+                        ret = rs.getLong(1);
+                        break;
+                    case TypeSpecSimple.IDX_NUMERIC:
+                        ret = rs.getBigDecimal(1);
+                        break;
+                    case TypeSpecSimple.IDX_FLOAT:
+                        ret = rs.getFloat(1);
+                        break;
+                    case TypeSpecSimple.IDX_DOUBLE:
+                        ret = rs.getDouble(1);
+                        break;
+                    case TypeSpecSimple.IDX_DATE:
+                        ret = rs.getDate(1);
+                        break;
+                    case TypeSpecSimple.IDX_TIME:
+                        ret = rs.getTime(1);
+                        break;
+                    case TypeSpecSimple.IDX_DATETIME:
+                    case TypeSpecSimple.IDX_TIMESTAMP:
+                        ret = rs.getTimestamp(1);
+                        break;
+                    default:
+                        throw new PROGRAM_ERROR(); // unreachable
+                }
                 assert !rs.next(); // it must have only one record
 
                 Statement stmt = rs.getStatement();

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -2861,7 +2861,6 @@ public class SpLib {
         }
 
         BigDecimal bd = strToBigDecimal(e);
-        ;
         return Long.valueOf(bigDecimalToLong(bd));
     }
 
@@ -3384,7 +3383,7 @@ public class SpLib {
         try {
             return new BigDecimal(s);
         } catch (NumberFormatException e) {
-            throw new VALUE_ERROR("not in a NUMERIC format");
+            throw new VALUE_ERROR("not in a number form");
         }
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25059

- use different get methods of ResultSet in SpLib.invokeBuiltinFunc() according to the return type of the function being called.
