### PR TITLE
[CBRD-25092] Fix wrong index calculation of the JVM option args

### DIFF
--- a/src/jsp/jsp_sr.c
+++ b/src/jsp/jsp_sr.c
@@ -511,7 +511,8 @@ jsp_start_server (const char *db_name, const char *path, int port)
   jobjectArray args;
   JavaVMInitArgs vm_arguments;
   JavaVMOption *options;
-  int vm_n_options = 2;
+  int vm_n_default_options = 2;
+  int vm_n_ext_options = 0;
   char classpath[PATH_MAX + 32] = { 0 };
   char logging_prop[PATH_MAX + 32] = { 0 };
   char option_debug[70];
@@ -551,27 +552,26 @@ jsp_start_server (const char *db_name, const char *path, int port)
     debug_port = prm_get_integer_value (PRM_ID_JAVA_STORED_PROCEDURE_DEBUG);
     if (debug_port != -1)
       {
-	vm_n_options += 2;	/* set debug flag and debugging port */
+	vm_n_default_options += 2;	/* set debug flag and debugging port */
       }
 
     jvm_opt_sysprm = (char *) prm_get_string_value (PRM_ID_JAVA_STORED_PROCEDURE_JVM_OPTIONS);
   // *INDENT-OFF*
   std::vector <std::string> opts = jsp_tokenize_jvm_options (jvm_opt_sysprm);
   // *INDENT-ON*
-    vm_n_options += (int) opts.size ();
-    options = new JavaVMOption[vm_n_options];
+    vm_n_ext_options += (int) opts.size ();
+    options = new JavaVMOption[vm_n_default_options + vm_n_ext_options];
     if (options == NULL)
       {
 	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 0);
 	goto error;
       }
 
-    int idx = 3;
+    int ext_idx = vm_n_default_options;
     options[0].optionString = classpath;
     options[1].optionString = logging_prop;
     if (debug_port != -1)
       {
-	idx += 2;
 	snprintf (option_debug, sizeof (option_debug) - 1, debug_jdwp, debug_port);
 	options[2].optionString = debug_flag;
 	options[3].optionString = option_debug;
@@ -580,12 +580,12 @@ jsp_start_server (const char *db_name, const char *path, int port)
     for (auto it = opts.begin (); it != opts.end (); ++it)
       {
       // *INDENT-OFF*
-      options[idx++].optionString = const_cast <char*> (it->c_str ());
+      options[ext_idx++].optionString = const_cast <char*> (it->c_str ());
       // *INDENT-ON*
       }
 
     vm_arguments.version = JNI_VERSION_1_6;
-    vm_arguments.nOptions = vm_n_options;
+    vm_arguments.nOptions = vm_n_default_options + vm_n_ext_options;
     vm_arguments.options = options;
     vm_arguments.ignoreUnrecognized = JNI_TRUE;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25092

regression of [CBRD-25087](http://jira.cubrid.org/browse/CBRD-25087).
Because a default option , '-Xrs' is removed and the index calculation is not updated.