### PR TITLE
[CBRD-24988] When recalculating the offset in the pr_midxkey_remove_prefix function, the pr_midxkey_element_disk_size function is called only if it is not null

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -13280,6 +13280,15 @@ btree_split_node (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR P, PAGE_PTR
 	  ret = ER_FAILED;
 	  goto exit_on_error;
 	}
+
+#if !defined(NDEBUG)
+      if (prm_get_integer_value (PRM_ID_ER_BTREE_DEBUG) & BTREE_DEBUG_DUMP_SIMPLE)
+	{
+	  fprintf (stdout, "btree_split_node - lower fence key for R(%d:%d:%d):", R_vpid->volid, R_vpid->pageid, j);
+	  db_value_print (sep_key);
+	  fprintf (stdout, "\n");
+	}
+#endif
     }
 
   /* move the second half of page Q to page R */
@@ -13324,6 +13333,16 @@ btree_split_node (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR P, PAGE_PTR
 	  goto exit_on_error;
 	}
       leftsize++;
+
+#if !defined(NDEBUG)
+      if (prm_get_integer_value (PRM_ID_ER_BTREE_DEBUG) & BTREE_DEBUG_DUMP_SIMPLE)
+	{
+	  fprintf (stdout, "btree_split_node - upper fence key for Q(%d:%d:%d):", Q_vpid->volid, Q_vpid->pageid,
+		   leftcnt + 1);
+	  db_value_print (sep_key);
+	  fprintf (stdout, "\n");
+	}
+#endif
     }
 
   FI_TEST (thread_p, FI_TEST_BTREE_MANAGER_RANDOM_EXIT, 0);
@@ -13397,6 +13416,15 @@ btree_split_node (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR P, PAGE_PTR
       ret = ER_FAILED;
       goto exit_on_error;
     }
+
+#if !defined(NDEBUG)
+  if (prm_get_integer_value (PRM_ID_ER_BTREE_DEBUG) & BTREE_DEBUG_DUMP_SIMPLE)
+    {
+      fprintf (stdout, "btree_split_node - insert sep_key to P(%d:%d:%d):", P_vpid->volid, P_vpid->pageid, p_slot_id);
+      db_value_print (sep_key);
+      fprintf (stdout, "\n");
+    }
+#endif
 
   p_redo_data = PTR_ALIGN (p_redo_data_buf, BTREE_MAX_ALIGN);
 
@@ -14130,6 +14158,15 @@ btree_split_root (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR P, PAGE_PTR
 	{
 	  goto exit_on_error;
 	}
+
+#if !defined(NDEBUG)
+      if (prm_get_integer_value (PRM_ID_ER_BTREE_DEBUG) & BTREE_DEBUG_DUMP_SIMPLE)
+	{
+	  fprintf (stdout, "btree_split_root - lower fence key for R(%d:%d:%d):", R_vpid->volid, R_vpid->pageid, j);
+	  db_value_print (sep_key);
+	  fprintf (stdout, "\n");
+	}
+#endif
     }
 
   for (i = 1; i <= rightcnt; i++, j++)
@@ -14204,6 +14241,15 @@ btree_split_root (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR P, PAGE_PTR
 	  goto exit_on_error;
 	}
       leftsize = i;
+
+#if !defined(NDEBUG)
+      if (prm_get_integer_value (PRM_ID_ER_BTREE_DEBUG) & BTREE_DEBUG_DUMP_SIMPLE)
+	{
+	  fprintf (stdout, "btree_split_root - upper fence key for Q(%d:%d:%d):", Q_vpid->volid, Q_vpid->pageid, i);
+	  db_value_print (sep_key);
+	  fprintf (stdout, "\n");
+	}
+#endif
     }
   else
     {
@@ -14256,6 +14302,15 @@ btree_split_root (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR P, PAGE_PTR
     {
       goto exit_on_error;
     }
+
+#if !defined(NDEBUG)
+  if (prm_get_integer_value (PRM_ID_ER_BTREE_DEBUG) & BTREE_DEBUG_DUMP_SIMPLE)
+    {
+      fprintf (stdout, "btree_split_root - insert sep_key to P(%d:%d:%d):", P_vpid->volid, P_vpid->pageid, 1);
+      db_value_print (sep_key);
+      fprintf (stdout, "\n");
+    }
+#endif
 
   /* log the inserted record for undo/redo purposes, */
   btree_rv_write_log_record (recset_data, &recset_length, &rec, BTREE_NON_LEAF_NODE);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24988

1. When recalculating the offset in the pr_midxkey_remove_prefix function, the pr_midxkey_element_disk_size function is called only if it is not null.
2. Add a check for `(DB_MIDXKEY *)->size == or_multi_get_size_offset (...) || (DB_MIDXKEY *)->size >= OR_MULTI_MAX_OFFSET`
   - mr_index_lengthmem_midxkey
   - pr_midxkey_add_prefix
   - pr_midxkey_remove_prefix
3. When BTREE_DEBUG_DUMP_SIMPLE is set, adds output for seperate key, lower fence key, and upper fence key.
   - btree_split_root 
   - btree_split_node

Please see the [comment](http://jira.cubrid.org/browse/CBRD-24988?focusedCommentId=4765626&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-4765626) for details.