### PR TITLE
[LETS-810] Acquire a lock for serial operation in PTS

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -20668,7 +20668,7 @@ heap_get_insert_location_with_lock (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONT
 	      assert (!OID_ISNULL (&context->res_oid));
 	      assert (is_active_transaction_server ());
 
-	      log_append_locked_object (thread_p, &context->class_oid, &context->res_oid, lock);
+	      log_append_repl_ddl_lock_info (thread_p, &context->class_oid, &context->res_oid, lock);
 	    }
 #endif
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -20657,8 +20657,9 @@ heap_get_insert_location_with_lock (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONT
 	{
 	  /* successfully locked! */
 #if defined (SERVER_MODE)
-	  if ((lock == SCH_M_LOCK && OID_IS_ROOTOID (&context->class_oid))
-	      || (lock == X_LOCK && OID_EQ (&context->class_oid, oid_Serial_class_oid)))
+	  const bool is_lock_for_class = OID_IS_ROOTOID (&context->class_oid) && lock == SCH_M_LOCK;
+	  const bool is_lock_for_serial = OID_EQ (&context->class_oid, oid_Serial_class_oid) && lock == X_LOCK;
+	  if (is_lock_for_class || is_lock_for_serial)
 	    {
 	      assert (!OID_ISNULL (&context->res_oid));
 	      assert (is_active_transaction_server ());

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -20662,7 +20662,7 @@ heap_get_insert_location_with_lock (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONT
 	   * when a serial is created (class_oid == oid_Serial_class_oid).
 	   * The creation of a serial implies the insertion of a record into db_serial*/
 	  const bool is_lock_for_class = OID_IS_ROOTOID (&context->class_oid) && lock == SCH_M_LOCK;
-	  const bool is_lock_for_serial = OID_EQ (&context->class_oid, oid_Serial_class_oid) && lock == X_LOCK;
+	  const bool is_lock_for_serial = oid_is_serial (&context->class_oid) && lock == X_LOCK;
 	  if (is_lock_for_class || is_lock_for_serial)
 	    {
 	      assert (!OID_ISNULL (&context->res_oid));

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -20657,12 +20657,13 @@ heap_get_insert_location_with_lock (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONT
 	{
 	  /* successfully locked! */
 #if defined (SERVER_MODE)
-	  if (lock == SCH_M_LOCK && OID_IS_ROOTOID (&context->class_oid))
+	  if ((lock == SCH_M_LOCK && OID_IS_ROOTOID (&context->class_oid))
+	      || (lock == X_LOCK && OID_EQ (&context->class_oid, oid_Serial_class_oid)))
 	    {
 	      assert (!OID_ISNULL (&context->res_oid));
 	      assert (is_active_transaction_server ());
 
-	      log_append_schema_modification_lock (thread_p, &context->res_oid);
+	      log_append_locked_object (thread_p, &context->class_oid, &context->res_oid, lock);
 	    }
 #endif
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -20657,6 +20657,10 @@ heap_get_insert_location_with_lock (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONT
 	{
 	  /* successfully locked! */
 #if defined (SERVER_MODE)
+	  /* lock information is logged to replicate DDL operations on PTS.
+	   * Logging here occurs when a class is created (class_oid == oid_Root_class_oid) or
+	   * when a serial is created (class_oid == oid_Serial_class_oid).
+	   * The creation of a serial implies the insertion of a record into db_serial*/
 	  const bool is_lock_for_class = OID_IS_ROOTOID (&context->class_oid) && lock == SCH_M_LOCK;
 	  const bool is_lock_for_serial = OID_EQ (&context->class_oid, oid_Serial_class_oid) && lock == X_LOCK;
 	  if (is_lock_for_class || is_lock_for_serial)

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -2549,7 +2549,7 @@ xlocator_fetch (THREAD_ENTRY * thread_p, OID * oid, int chn, LOCK lock,
 		   * ALTER/DROP SERIAL statement will fetch the record in db_serial and update or delete it */
 
 		  const bool is_lock_for_class = OID_IS_ROOTOID (class_oid) && lock == SCH_M_LOCK;
-		  const bool is_lock_for_serial = OID_EQ (class_oid, oid_Serial_class_oid) && lock == X_LOCK;
+		  const bool is_lock_for_serial = oid_is_serial (class_oid) && lock == X_LOCK;
 		  if (is_lock_for_class || is_lock_for_serial)
 		    {
 		      assert (!OID_ISNULL (p_oid));

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -2554,7 +2554,7 @@ xlocator_fetch (THREAD_ENTRY * thread_p, OID * oid, int chn, LOCK lock,
 		    {
 		      assert (!OID_ISNULL (p_oid));
 
-		      log_append_locked_object (thread_p, class_oid, p_oid, lock);
+		      log_append_repl_ddl_lock_info (thread_p, class_oid, p_oid, lock);
 		    }
 		}
 #endif

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -2541,12 +2541,16 @@ xlocator_fetch (THREAD_ENTRY * thread_p, OID * oid, int chn, LOCK lock,
 		}
 
 #if defined (SERVER_MODE)
-	      if (is_active_transaction_server () &&
-		  lock == SCH_M_LOCK || (lock == X_LOCK && OID_EQ (class_oid, oid_Serial_class_oid)))
+	      if (is_active_transaction_server ())
 		{
-		  assert (!OID_ISNULL (p_oid));
+		  const bool is_lock_for_class = OID_IS_ROOTOID (class_oid) && lock == SCH_M_LOCK;
+		  const bool is_lock_for_serial = OID_EQ (class_oid, oid_Serial_class_oid) && lock == X_LOCK;
+		  if (is_lock_for_class || is_lock_for_serial)
+		    {
+		      assert (!OID_ISNULL (p_oid));
 
-		  log_append_locked_object (thread_p, class_oid, p_oid, lock);
+		      log_append_locked_object (thread_p, class_oid, p_oid, lock);
+		    }
 		}
 #endif
 	    }

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -2544,7 +2544,6 @@ xlocator_fetch (THREAD_ENTRY * thread_p, OID * oid, int chn, LOCK lock,
 	      if (is_active_transaction_server () &&
 		  lock == SCH_M_LOCK || (lock == X_LOCK && OID_EQ (class_oid, oid_Serial_class_oid)))
 		{
-		  assert (OID_IS_ROOTOID (class_oid));
 		  assert (!OID_ISNULL (p_oid));
 
 		  log_append_locked_object (thread_p, class_oid, p_oid, lock);

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -2541,12 +2541,13 @@ xlocator_fetch (THREAD_ENTRY * thread_p, OID * oid, int chn, LOCK lock,
 		}
 
 #if defined (SERVER_MODE)
-	      if (lock == SCH_M_LOCK && is_active_transaction_server ())
+	      if (is_active_transaction_server () &&
+		  lock == SCH_M_LOCK || (lock == X_LOCK && OID_EQ (class_oid, oid_Serial_class_oid)))
 		{
 		  assert (OID_IS_ROOTOID (class_oid));
 		  assert (!OID_ISNULL (p_oid));
 
-		  log_append_schema_modification_lock (thread_p, p_oid);
+		  log_append_locked_object (thread_p, class_oid, p_oid, lock);
 		}
 #endif
 	    }

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -2543,6 +2543,11 @@ xlocator_fetch (THREAD_ENTRY * thread_p, OID * oid, int chn, LOCK lock,
 #if defined (SERVER_MODE)
 	      if (is_active_transaction_server ())
 		{
+		  /* lock information is logged to replicate DDL operations on PTS.
+		   * Logging here occurs when a class is fetched for DDL (class_oid == oid_Root_class_oid) or
+		   * when a serial record is fetched for DDL (class_oid == oid_Serial_class_oid).
+		   * ALTER/DROP SERIAL statement will fetch the record in db_serial and update or delete it */
+
 		  const bool is_lock_for_class = OID_IS_ROOTOID (class_oid) && lock == SCH_M_LOCK;
 		  const bool is_lock_for_serial = OID_EQ (class_oid, oid_Serial_class_oid) && lock == X_LOCK;
 		  if (is_lock_for_class || is_lock_for_serial)

--- a/src/transaction/log_2pc.c
+++ b/src/transaction/log_2pc.c
@@ -2012,7 +2012,7 @@ log_2pc_recovery_analysis_record (THREAD_ENTRY * thread_p, LOG_RECTYPE record_ty
     case LOG_END_ATOMIC_REPL:
     case LOG_TRANTABLE_SNAPSHOT:
     case LOG_ASSIGNED_MVCCID:
-    case LOG_LOCKED_OBJECT:
+    case LOG_REPL_DDL_LOCK_INFO:
     case LOG_END_OF_LOG:
       /*
        * Either the prepare to commit or start 2PC record should

--- a/src/transaction/log_2pc.c
+++ b/src/transaction/log_2pc.c
@@ -2012,7 +2012,7 @@ log_2pc_recovery_analysis_record (THREAD_ENTRY * thread_p, LOG_RECTYPE record_ty
     case LOG_END_ATOMIC_REPL:
     case LOG_TRANTABLE_SNAPSHOT:
     case LOG_ASSIGNED_MVCCID:
-    case LOG_SCHEMA_MODIFICATION_LOCK:
+    case LOG_LOCKED_OBJECT:
     case LOG_END_OF_LOG:
       /*
        * Either the prepare to commit or start 2PC record should

--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -416,7 +416,7 @@ prior_lsa_alloc_and_copy_data (THREAD_ENTRY *thread_p, LOG_RECTYPE rec_type, LOG
     case LOG_END_ATOMIC_REPL:
     case LOG_TRANTABLE_SNAPSHOT:
     case LOG_ASSIGNED_MVCCID:
-    case LOG_SCHEMA_MODIFICATION_LOCK:
+    case LOG_LOCKED_OBJECT:
       assert (rlength == 0 && rdata == NULL);
 
       error_code = prior_lsa_gen_record (thread_p, node, rec_type, ulength, udata);
@@ -1319,8 +1319,8 @@ prior_lsa_gen_record (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LOG_RECTYPE 
     case LOG_SUPPLEMENTAL_INFO:
       node->data_header_length = sizeof (LOG_REC_SUPPLEMENT);
       break;
-    case LOG_SCHEMA_MODIFICATION_LOCK:
-      node->data_header_length = sizeof (LOG_REC_SCHEMA_MODIFICATION_LOCK);
+    case LOG_LOCKED_OBJECT:
+      node->data_header_length = sizeof (LOG_REC_LOCKED_OBJECT);
       break;
     default:
       break;

--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -416,7 +416,7 @@ prior_lsa_alloc_and_copy_data (THREAD_ENTRY *thread_p, LOG_RECTYPE rec_type, LOG
     case LOG_END_ATOMIC_REPL:
     case LOG_TRANTABLE_SNAPSHOT:
     case LOG_ASSIGNED_MVCCID:
-    case LOG_LOCKED_OBJECT:
+    case LOG_REPL_DDL_LOCK_INFO:
       assert (rlength == 0 && rdata == NULL);
 
       error_code = prior_lsa_gen_record (thread_p, node, rec_type, ulength, udata);
@@ -1319,8 +1319,8 @@ prior_lsa_gen_record (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LOG_RECTYPE 
     case LOG_SUPPLEMENTAL_INFO:
       node->data_header_length = sizeof (LOG_REC_SUPPLEMENT);
       break;
-    case LOG_LOCKED_OBJECT:
-      node->data_header_length = sizeof (LOG_REC_LOCKED_OBJECT);
+    case LOG_REPL_DDL_LOCK_INFO:
+      node->data_header_length = sizeof (LOG_REC_REPL_DDL_LOCK_INFO);
       break;
     default:
       break;

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -3738,6 +3738,8 @@ void
 log_append_locked_object (THREAD_ENTRY * thread_p, const OID * classoid, const OID * oid, const LOCK lock)
 {
   assert (!OID_ISNULL (classoid));
+  assert (!OID_IS_ROOTOID (classoid) || lock == SCH_M_LOCK);	// if classoid is rootoid, lock must be SCH_M_LOCK
+  assert (!OID_EQ (classoid, oid_Serial_class_oid) || lock == X_LOCK);	// if classoid is serial class oid, lock must be X_LOCK
 
   int tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
   LOG_TDES *tdes = LOG_FIND_TDES (tran_index);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -3758,7 +3758,7 @@ log_append_locked_object (THREAD_ENTRY * thread_p, const OID * classoid, const O
       return;
     }
 
-  auto record = (LOG_REC_LOCKED_OBJECT *) node->data_header;
+  auto *const record = (LOG_REC_LOCKED_OBJECT *) node->data_header;
   COPY_OID (&record->oid, oid);
   COPY_OID (&record->classoid, classoid);
   record->lock_mode = lock;

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -294,8 +294,8 @@ static LOG_PAGE *log_dump_record_assigned_mvccid (THREAD_ENTRY * thread_p, FILE 
 						  LOG_PAGE * log_page_p);
 static LOG_PAGE *log_dump_record_supplemental_info (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_LSA * log_lsa,
 						    LOG_PAGE * log_page_p);
-static LOG_PAGE *log_dump_record_locked_object (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_LSA * log_lsa,
-						LOG_PAGE * log_page_p);
+static LOG_PAGE *log_dump_record_repl_ddl_lock_info (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_LSA * log_lsa,
+						     LOG_PAGE * log_page_p);
 static LOG_PAGE *log_dump_record (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_RECTYPE record_type, LOG_LSA * lsa_p,
 				  LOG_PAGE * log_page_p, LOG_ZIP * log_zip_p);
 static void log_rollback_record (THREAD_ENTRY * thread_p, LOG_LSA * log_lsa, LOG_PAGE * log_page_p,
@@ -511,8 +511,8 @@ log_to_string (LOG_RECTYPE type)
       return "LOG_DUMMY_GENERIC";
     case LOG_SUPPLEMENTAL_INFO:
       return "LOG_SUPPLEMENTAL_INFO";
-    case LOG_LOCKED_OBJECT:
-      return "LOG_LOCKED_OBJECT";
+    case LOG_REPL_DDL_LOCK_INFO:
+      return "LOG_REPL_DDL_LOCK_INFO";
     case LOG_SMALLER_LOGREC_TYPE:
     case LOG_LARGER_LOGREC_TYPE:
       break;
@@ -3735,11 +3735,12 @@ log_append_assigned_mvccid (THREAD_ENTRY * thread_p, MVCCID mvccid)
 }
 
 void
-log_append_locked_object (THREAD_ENTRY * thread_p, const OID * classoid, const OID * oid, const LOCK lock)
+log_append_repl_ddl_lock_info (THREAD_ENTRY * thread_p, const OID * classoid, const OID * oid, const LOCK lock)
 {
-  assert (!OID_ISNULL (classoid));
+  assert (!OID_ISNULL (classoid) && !OID_ISNULL (oid));
   assert (!OID_IS_ROOTOID (classoid) || lock == SCH_M_LOCK);	// if classoid is rootoid, lock must be SCH_M_LOCK
-  assert (!OID_EQ (classoid, oid_Serial_class_oid) || lock == X_LOCK);	// if classoid is serial class oid, lock must be X_LOCK
+  assert (!oid_is_serial (classoid) || lock == X_LOCK);	// if classoid is serial class oid, lock must be X_LOCK
+  assert ((OID_IS_ROOTOID (classoid) && lock == SCH_M_LOCK) || (oid_is_serial (classoid) && lock == X_LOCK));
 
   int tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
   LOG_TDES *tdes = LOG_FIND_TDES (tran_index);
@@ -3751,14 +3752,14 @@ log_append_locked_object (THREAD_ENTRY * thread_p, const OID * classoid, const O
     }
 
   LOG_PRIOR_NODE *node =
-    prior_lsa_alloc_and_copy_data (thread_p, LOG_LOCKED_OBJECT, RV_NOT_DEFINED, NULL, 0, NULL, 0, NULL);
+    prior_lsa_alloc_and_copy_data (thread_p, LOG_REPL_DDL_LOCK_INFO, RV_NOT_DEFINED, NULL, 0, NULL, 0, NULL);
   if (node == nullptr)
     {
       assert (false);
       return;
     }
 
-  auto *const record = (LOG_REC_LOCKED_OBJECT *) node->data_header;
+  auto *const record = (LOG_REC_REPL_DDL_LOCK_INFO *) node->data_header;
   COPY_OID (&record->oid, oid);
   COPY_OID (&record->classoid, classoid);
   record->lock_mode = lock;
@@ -7297,13 +7298,13 @@ log_dump_record_supplemental_info (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_L
 }
 
 static LOG_PAGE *
-log_dump_record_locked_object (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_LSA * log_lsa, LOG_PAGE * log_page_p)
+log_dump_record_repl_ddl_lock_info (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_LSA * log_lsa, LOG_PAGE * log_page_p)
 {
-  LOG_REC_LOCKED_OBJECT *log_rec;
+  LOG_REC_REPL_DDL_LOCK_INFO *log_rec;
 
   /* Get the DATA HEADER */
   LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (*log_rec), log_lsa, log_page_p);
-  log_rec = ((LOG_REC_LOCKED_OBJECT *) ((char *) log_page_p->area + log_lsa->offset));
+  log_rec = ((LOG_REC_REPL_DDL_LOCK_INFO *) ((char *) log_page_p->area + log_lsa->offset));
   fprintf (out_fp, ", classoid = %d|%d|%d", OID_AS_ARGS (&log_rec->classoid));
   fprintf (out_fp, ", oid = %d|%d|%d", OID_AS_ARGS (&log_rec->oid));
   fprintf (out_fp, ", lock = %s\n", LOCK_TO_LOCKMODE_STRING (log_rec->lock_mode));
@@ -7414,8 +7415,8 @@ log_dump_record (THREAD_ENTRY * thread_p, FILE * out_fp, LOG_RECTYPE record_type
       log_page_p = log_dump_record_supplemental_info (thread_p, out_fp, log_lsa, log_page_p);
       break;
 
-    case LOG_LOCKED_OBJECT:
-      log_page_p = log_dump_record_locked_object (thread_p, out_fp, log_lsa, log_page_p);
+    case LOG_REPL_DDL_LOCK_INFO:
+      log_page_p = log_dump_record_repl_ddl_lock_info (thread_p, out_fp, log_lsa, log_page_p);
       break;
 
     case LOG_2PC_COMMIT_DECISION:
@@ -8345,7 +8346,7 @@ log_rollback (THREAD_ENTRY * thread_p, LOG_TDES * tdes, const LOG_LSA * upto_lsa
 	    case LOG_END_ATOMIC_REPL:
 	    case LOG_ASSIGNED_MVCCID:
 	    case LOG_SUPPLEMENTAL_INFO:
-	    case LOG_LOCKED_OBJECT:
+	    case LOG_REPL_DDL_LOCK_INFO:
 	      break;
 
 	    case LOG_RUN_POSTPONE:
@@ -8781,7 +8782,7 @@ log_do_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG_LSA * start_postp
 		    case LOG_SUPPLEMENTAL_INFO:
 		    case LOG_START_ATOMIC_REPL:
 		    case LOG_ASSIGNED_MVCCID:
-		    case LOG_LOCKED_OBJECT:
+		    case LOG_REPL_DDL_LOCK_INFO:
 		    case LOG_END_ATOMIC_REPL:
 		      break;
 

--- a/src/transaction/log_manager.h
+++ b/src/transaction/log_manager.h
@@ -130,7 +130,8 @@ extern void log_append_compensate_with_undo_nxlsa (THREAD_ENTRY * thread_p, LOG_
 extern void log_append_ha_server_state (THREAD_ENTRY * thread_p, int state);
 extern void log_append_empty_record (THREAD_ENTRY * thread_p, LOG_RECTYPE logrec_type, LOG_DATA_ADDR * addr);
 extern void log_append_assigned_mvccid (THREAD_ENTRY * thread_p, MVCCID mvccid);
-extern void log_append_locked_object (THREAD_ENTRY * thread_p, const OID * classoid, const OID * oid, const LOCK lock);
+extern void log_append_repl_ddl_lock_info (THREAD_ENTRY * thread_p, const OID * classoid, const OID * oid,
+					   const LOCK lock);
 
 // *INDENT-OFF*
 extern void log_append_trantable_snapshot (THREAD_ENTRY *thread_p, const cublog::checkpoint_info &chkpt_info);

--- a/src/transaction/log_manager.h
+++ b/src/transaction/log_manager.h
@@ -130,7 +130,7 @@ extern void log_append_compensate_with_undo_nxlsa (THREAD_ENTRY * thread_p, LOG_
 extern void log_append_ha_server_state (THREAD_ENTRY * thread_p, int state);
 extern void log_append_empty_record (THREAD_ENTRY * thread_p, LOG_RECTYPE logrec_type, LOG_DATA_ADDR * addr);
 extern void log_append_assigned_mvccid (THREAD_ENTRY * thread_p, MVCCID mvccid);
-extern void log_append_schema_modification_lock (THREAD_ENTRY * thread_p, const OID * classoid);
+extern void log_append_locked_object (THREAD_ENTRY * thread_p, const OID * classoid, const OID * oid, const LOCK lock);
 
 // *INDENT-OFF*
 extern void log_append_trantable_snapshot (THREAD_ENTRY *thread_p, const cublog::checkpoint_info &chkpt_info);

--- a/src/transaction/log_record.hpp
+++ b/src/transaction/log_record.hpp
@@ -152,11 +152,11 @@ enum log_rectype
                                  * it contains transaction user info, DDL statement, undo lsa, redo lsa for DML,
                                  * or undo images that never retrieved from the log. */
 
-  LOG_LOCKED_OBJECT, /* Log when SCH_M_LOCK is acquired, and this is for PTS replication to know
-                                 * when to acquire a SCH_M_LOCK for replicating DDL modification, and
-                                 * which table to be locked.
-                                 * PTS needs to block the read transactions which try to access the same class
+  LOG_LOCKED_OBJECT,            /* Log when the lock is acquired for DDL operations, and this is for PTS replicator
+                                 * to know when to acquire a lock, and which objects to be locked.
+                                 * PTS needs to block the read transactions which try to access the same objects
                                  * being modified by the replicator.
+                                 * (lock is required for the record in root class and db_serial, which is not mvcc class)
                                  */
 
   /* NOTE: add actual (persistent) new values before this */

--- a/src/transaction/log_record.hpp
+++ b/src/transaction/log_record.hpp
@@ -152,7 +152,7 @@ enum log_rectype
                                  * it contains transaction user info, DDL statement, undo lsa, redo lsa for DML,
                                  * or undo images that never retrieved from the log. */
 
-  LOG_SCHEMA_MODIFICATION_LOCK, /* Log when SCH_M_LOCK is acquired, and this is for PTS replication to know
+  LOG_LOCKED_OBJECT, /* Log when SCH_M_LOCK is acquired, and this is for PTS replication to know
                                  * when to acquire a SCH_M_LOCK for replicating DDL modification, and
                                  * which table to be locked.
                                  * PTS needs to block the read transactions which try to access the same class
@@ -461,10 +461,12 @@ struct log_rec_supplement
   int length;
 };
 
-typedef struct log_rec_schema_modification_lock LOG_REC_SCHEMA_MODIFICATION_LOCK;
-struct log_rec_schema_modification_lock
+typedef struct log_rec_locked_object LOG_REC_LOCKED_OBJECT;
+struct log_rec_locked_object
 {
+  OID oid;
   OID classoid;
+  LOCK lock_mode;
 };
 
 #define LOG_GET_LOG_RECORD_HEADER(log_page_p, lsa) \

--- a/src/transaction/log_record.hpp
+++ b/src/transaction/log_record.hpp
@@ -152,7 +152,7 @@ enum log_rectype
                                  * it contains transaction user info, DDL statement, undo lsa, redo lsa for DML,
                                  * or undo images that never retrieved from the log. */
 
-  LOG_LOCKED_OBJECT,            /* Log when the lock is acquired for DDL operation, and this is for PTS replicator
+  LOG_REPL_DDL_LOCK_INFO,       /* Log when the lock is acquired for DDL operation, and this is for PTS replicator
                                  * to know when to acquire the lock, and which object to be locked.
                                  * PTS needs to block the read transactions which try to access the same object
                                  * being modified by the replicator.
@@ -461,8 +461,8 @@ struct log_rec_supplement
   int length;
 };
 
-typedef struct log_rec_locked_object LOG_REC_LOCKED_OBJECT;
-struct log_rec_locked_object
+typedef struct log_rec_repl_ddl_lock_info LOG_REC_REPL_DDL_LOCK_INFO;
+struct log_rec_repl_ddl_lock_info
 {
   OID oid;
   OID classoid;

--- a/src/transaction/log_record.hpp
+++ b/src/transaction/log_record.hpp
@@ -152,11 +152,11 @@ enum log_rectype
                                  * it contains transaction user info, DDL statement, undo lsa, redo lsa for DML,
                                  * or undo images that never retrieved from the log. */
 
-  LOG_LOCKED_OBJECT,            /* Log when the lock is acquired for DDL operations, and this is for PTS replicator
-                                 * to know when to acquire a lock, and which objects to be locked.
-                                 * PTS needs to block the read transactions which try to access the same objects
+  LOG_LOCKED_OBJECT,            /* Log when the lock is acquired for DDL operation, and this is for PTS replicator
+                                 * to know when to acquire the lock, and which object to be locked.
+                                 * PTS needs to block the read transactions which try to access the same object
                                  * being modified by the replicator.
-                                 * (lock is required for the record in root class and db_serial, which is not mvcc class)
+                                 * (lock is required for the record in root class and db_serial, which are not mvcc classes)
                                  */
 
   /* NOTE: add actual (persistent) new values before this */

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -2563,7 +2563,7 @@ log_rv_analysis_record_on_tran_server (THREAD_ENTRY * thread_p, LOG_RECTYPE log_
     case LOG_START_ATOMIC_REPL:
     case LOG_END_ATOMIC_REPL:
     case LOG_TRANTABLE_SNAPSHOT:
-    case LOG_LOCKED_OBJECT:
+    case LOG_REPL_DDL_LOCK_INFO:
       break;
 
     case LOG_SMALLER_LOGREC_TYPE:
@@ -4029,7 +4029,7 @@ log_recovery_redo (THREAD_ENTRY * thread_p, log_recovery_context & context)
 	    case LOG_END_ATOMIC_REPL:
 	    case LOG_TRANTABLE_SNAPSHOT:
 	    case LOG_ASSIGNED_MVCCID:
-	    case LOG_LOCKED_OBJECT:
+	    case LOG_REPL_DDL_LOCK_INFO:
 	      break;
 
 	    case LOG_SYSOP_END:
@@ -4979,7 +4979,7 @@ log_recovery_undo (THREAD_ENTRY * thread_p)
 		case LOG_END_ATOMIC_REPL:
 		case LOG_TRANTABLE_SNAPSHOT:
 		case LOG_ASSIGNED_MVCCID:
-		case LOG_LOCKED_OBJECT:
+		case LOG_REPL_DDL_LOCK_INFO:
 		  /* Not for UNDO ... */
 		  /* Break switch to go to previous record */
 		  break;
@@ -5943,9 +5943,9 @@ log_startof_nxrec (THREAD_ENTRY * thread_p, LOG_LSA * lsa, bool canuse_forwaddr)
       LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (LOG_REC_HA_SERVER_STATE), &log_lsa, log_pgptr);
       LOG_READ_ADD_ALIGN (thread_p, sizeof (LOG_REC_HA_SERVER_STATE), &log_lsa, log_pgptr);
       break;
-    case LOG_LOCKED_OBJECT:
-      LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (LOG_REC_LOCKED_OBJECT), &log_lsa, log_pgptr);
-      LOG_READ_ADD_ALIGN (thread_p, sizeof (LOG_REC_LOCKED_OBJECT), &log_lsa, log_pgptr);
+    case LOG_REPL_DDL_LOCK_INFO:
+      LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (LOG_REC_REPL_DDL_LOCK_INFO), &log_lsa, log_pgptr);
+      LOG_READ_ADD_ALIGN (thread_p, sizeof (LOG_REC_REPL_DDL_LOCK_INFO), &log_lsa, log_pgptr);
       break;
     case LOG_SMALLER_LOGREC_TYPE:
     case LOG_LARGER_LOGREC_TYPE:

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -2563,7 +2563,7 @@ log_rv_analysis_record_on_tran_server (THREAD_ENTRY * thread_p, LOG_RECTYPE log_
     case LOG_START_ATOMIC_REPL:
     case LOG_END_ATOMIC_REPL:
     case LOG_TRANTABLE_SNAPSHOT:
-    case LOG_SCHEMA_MODIFICATION_LOCK:
+    case LOG_LOCKED_OBJECT:
       break;
 
     case LOG_SMALLER_LOGREC_TYPE:
@@ -4029,7 +4029,7 @@ log_recovery_redo (THREAD_ENTRY * thread_p, log_recovery_context & context)
 	    case LOG_END_ATOMIC_REPL:
 	    case LOG_TRANTABLE_SNAPSHOT:
 	    case LOG_ASSIGNED_MVCCID:
-	    case LOG_SCHEMA_MODIFICATION_LOCK:
+	    case LOG_LOCKED_OBJECT:
 	      break;
 
 	    case LOG_SYSOP_END:
@@ -4979,7 +4979,7 @@ log_recovery_undo (THREAD_ENTRY * thread_p)
 		case LOG_END_ATOMIC_REPL:
 		case LOG_TRANTABLE_SNAPSHOT:
 		case LOG_ASSIGNED_MVCCID:
-		case LOG_SCHEMA_MODIFICATION_LOCK:
+		case LOG_LOCKED_OBJECT:
 		  /* Not for UNDO ... */
 		  /* Break switch to go to previous record */
 		  break;
@@ -5943,9 +5943,9 @@ log_startof_nxrec (THREAD_ENTRY * thread_p, LOG_LSA * lsa, bool canuse_forwaddr)
       LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (LOG_REC_HA_SERVER_STATE), &log_lsa, log_pgptr);
       LOG_READ_ADD_ALIGN (thread_p, sizeof (LOG_REC_HA_SERVER_STATE), &log_lsa, log_pgptr);
       break;
-    case LOG_SCHEMA_MODIFICATION_LOCK:
-      LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (LOG_REC_SCHEMA_MODIFICATION_LOCK), &log_lsa, log_pgptr);
-      LOG_READ_ADD_ALIGN (thread_p, sizeof (LOG_REC_SCHEMA_MODIFICATION_LOCK), &log_lsa, log_pgptr);
+    case LOG_LOCKED_OBJECT:
+      LOG_READ_ADVANCE_WHEN_DOESNT_FIT (thread_p, sizeof (LOG_REC_LOCKED_OBJECT), &log_lsa, log_pgptr);
+      LOG_READ_ADD_ALIGN (thread_p, sizeof (LOG_REC_LOCKED_OBJECT), &log_lsa, log_pgptr);
       break;
     case LOG_SMALLER_LOGREC_TYPE:
     case LOG_LARGER_LOGREC_TYPE:

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -240,7 +240,7 @@ namespace cublog
 	    const LOG_REC_LOCKED_OBJECT log_rec =
 		    m_redo_context.m_reader.reinterpret_copy_and_add_align<LOG_REC_LOCKED_OBJECT> ();
 
-	    if (is_locked_for_ddl (header.trid, &log_rec.classoid))
+	    if (is_locked_for_ddl (header.trid, &log_rec.oid))
 	      {
 		break;
 	      }

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -414,8 +414,8 @@ namespace cublog
     assert (!OID_ISNULL (&log_rec.oid) && !OID_ISTEMP (&log_rec.oid));
 
     /* TODO:
-     * If a PTS read transaction holds a lock for an extended period without releasing it for the same class,
-     * the replicator could wait too long to acquire the lock.
+     * If a PTS read transaction holds a lock for an extended period without releasing it for the same class or
+     * the same object in db_serial, the replicator could wait too long to acquire the lock.
      * In such cases, there might be an introduction of a mechanism to abort read transaction that holds lock.
      */
 

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -233,11 +233,11 @@ namespace cublog
 	      }
 	    break;
 	  }
-	  case LOG_SCHEMA_MODIFICATION_LOCK:
+	  case LOG_LOCKED_OBJECT:
 	  {
-	    m_redo_context.m_reader.advance_when_does_not_fit (sizeof (LOG_REC_SCHEMA_MODIFICATION_LOCK));
-	    const LOG_REC_SCHEMA_MODIFICATION_LOCK log_rec =
-		    m_redo_context.m_reader.reinterpret_copy_and_add_align<LOG_REC_SCHEMA_MODIFICATION_LOCK> ();
+	    m_redo_context.m_reader.advance_when_does_not_fit (sizeof (LOG_REC_LOCKED_OBJECT));
+	    const LOG_REC_LOCKED_OBJECT log_rec =
+		    m_redo_context.m_reader.reinterpret_copy_and_add_align<LOG_REC_LOCKED_OBJECT> ();
 
 	    if (is_locked_for_ddl (header.trid, &log_rec.classoid))
 	      {

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -238,11 +238,11 @@ namespace cublog
 	      }
 	    break;
 	  }
-	  case LOG_LOCKED_OBJECT:
+	  case LOG_REPL_DDL_LOCK_INFO:
 	  {
-	    m_redo_context.m_reader.advance_when_does_not_fit (sizeof (LOG_REC_LOCKED_OBJECT));
-	    const LOG_REC_LOCKED_OBJECT log_rec =
-		    m_redo_context.m_reader.reinterpret_copy_and_add_align<LOG_REC_LOCKED_OBJECT> ();
+	    m_redo_context.m_reader.advance_when_does_not_fit (sizeof (LOG_REC_REPL_DDL_LOCK_INFO));
+	    const LOG_REC_REPL_DDL_LOCK_INFO log_rec =
+		    m_redo_context.m_reader.reinterpret_copy_and_add_align<LOG_REC_REPL_DDL_LOCK_INFO> ();
 
 	    const bool is_class = OID_IS_ROOTOID (&log_rec.classoid);
 
@@ -409,7 +409,7 @@ namespace cublog
 
   void
   atomic_replicator::acquire_lock_for_ddl (cubthread::entry &thread_entry, const TRANID trid,
-      const LOG_REC_LOCKED_OBJECT &log_rec, const bool is_class)
+      const LOG_REC_REPL_DDL_LOCK_INFO &log_rec, const bool is_class)
   {
     assert (!OID_ISNULL (&log_rec.classoid) && !OID_ISTEMP (&log_rec.classoid));
     assert (!OID_ISNULL (&log_rec.oid) && !OID_ISTEMP (&log_rec.oid));

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -100,7 +100,7 @@ namespace cublog
       void acquire_lock_for_ddl (cubthread::entry &thread_entry, const TRANID trid, const LOG_REC_LOCKED_OBJECT &log_rec,
 				 const bool is_class);
       void discard_caches_for_ddl (cubthread::entry &thread_entry, const TRANID trid);
-      bool is_locked_for_ddl (const TRANID trid, const OID *oid, const bool is_class);
+      bool is_locked_for_ddl (const TRANID trid, const OID *oid, const bool is_class) const;
 
     private:
       atomic_replication_helper m_atomic_helper;

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -20,6 +20,7 @@
 #define _ATOMIC_REPLICATOR_HPP_
 
 #include "atomic_replication_helper.hpp"
+#include "log_record.hpp"
 #include "log_replication.hpp"
 
 namespace cublog
@@ -92,11 +93,11 @@ namespace cublog
 
       /* TODO:
        * Make seperate class for ddl_replication_helper */
-      void bookkeep_classname_for_ddl (cubthread::entry &thread_entry, const OID *classoid);
+      void bookkeep_classname_for_ddl (cubthread::entry &thread_entry, const LOG_REC_LOCKED_OBJECT &log_rec);
       void update_classname_cache_for_ddl (cubthread::entry &thread_entry, const OID *classoid);
 
       void release_all_locks_for_ddl (cubthread::entry &thread_entry, const TRANID trid);
-      void acquire_lock_for_ddl (cubthread::entry &thread_entry, const TRANID trid, const OID *classoid);
+      void acquire_lock_for_ddl (cubthread::entry &thread_entry, const TRANID trid, const LOG_REC_LOCKED_OBJECT &log_rec);
       void discard_caches_for_ddl (cubthread::entry &thread_entry, const TRANID trid);
       bool is_locked_for_ddl (const TRANID trid, const OID *classoid);
 
@@ -111,8 +112,8 @@ namespace cublog
 
       /* Keep track of the locked classes for DDL replication.
        * Since multiple DDL operations can be executed within single transaction,
-       * more than one classes can be mapped to one transaction */
-      std::unordered_map <TRANID, std::unordered_set<OID>> m_locked_classes;
+       * more than one classes or objects(SERIAL) can be mapped to one transaction */
+      std::multimap <TRANID, LOG_REC_LOCKED_OBJECT> m_locked_objects;
       std::unordered_map <OID, std::string> m_classname_map;
   };
 }

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -97,7 +97,7 @@ namespace cublog
       void update_classname_cache_for_ddl (cubthread::entry &thread_entry, const OID *classoid);
 
       void release_all_locks_for_ddl (cubthread::entry &thread_entry, const TRANID trid);
-      void acquire_lock_for_ddl (cubthread::entry &thread_entry, const TRANID trid, const LOG_REC_LOCKED_OBJECT &log_rec,
+      void acquire_lock_for_ddl (cubthread::entry &thread_entry, const TRANID trid, const LOG_REC_REPL_DDL_LOCK_INFO &log_rec,
 				 const bool is_class);
       void discard_caches_for_ddl (cubthread::entry &thread_entry, const TRANID trid);
       bool is_locked_for_ddl (const TRANID trid, const OID *oid, const bool is_class) const;
@@ -114,8 +114,8 @@ namespace cublog
       /* Keep track of the locked objects for DDL replication.
        * Since multiple DDL operations can be executed within single transaction,
        * more than one classes or objects(records in db_serial) can be mapped to one transaction */
-      std::multimap <TRANID, LOG_REC_LOCKED_OBJECT> m_locked_classes;
-      std::multimap <TRANID, LOG_REC_LOCKED_OBJECT> m_locked_serials;
+      std::multimap <TRANID, LOG_REC_REPL_DDL_LOCK_INFO> m_locked_classes;
+      std::multimap <TRANID, LOG_REC_REPL_DDL_LOCK_INFO> m_locked_serials;
       std::unordered_map <OID, std::string> m_classname_map;
   };
 }

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -110,9 +110,9 @@ namespace cublog
       log_lsa m_lowest_unapplied_lsa;
       mutable std::mutex m_lowest_unapplied_lsa_mutex;
 
-      /* Keep track of the locked classes for DDL replication.
+      /* Keep track of the locked objects for DDL replication.
        * Since multiple DDL operations can be executed within single transaction,
-       * more than one classes or objects(SERIAL) can be mapped to one transaction */
+       * more than one classes or objects(records in db_serial) can be mapped to one transaction */
       std::multimap <TRANID, LOG_REC_LOCKED_OBJECT> m_locked_objects;
       std::unordered_map <OID, std::string> m_classname_map;
   };

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -93,13 +93,14 @@ namespace cublog
 
       /* TODO:
        * Make seperate class for ddl_replication_helper */
-      void bookkeep_classname_for_ddl (cubthread::entry &thread_entry, const LOG_REC_LOCKED_OBJECT &log_rec);
+      void bookkeep_classname_for_ddl (cubthread::entry &thread_entry, const OID *classoid);
       void update_classname_cache_for_ddl (cubthread::entry &thread_entry, const OID *classoid);
 
       void release_all_locks_for_ddl (cubthread::entry &thread_entry, const TRANID trid);
-      void acquire_lock_for_ddl (cubthread::entry &thread_entry, const TRANID trid, const LOG_REC_LOCKED_OBJECT &log_rec);
+      void acquire_lock_for_ddl (cubthread::entry &thread_entry, const TRANID trid, const LOG_REC_LOCKED_OBJECT &log_rec,
+				 const bool is_class);
       void discard_caches_for_ddl (cubthread::entry &thread_entry, const TRANID trid);
-      bool is_locked_for_ddl (const TRANID trid, const OID *classoid);
+      bool is_locked_for_ddl (const TRANID trid, const OID *oid, const bool is_class);
 
     private:
       atomic_replication_helper m_atomic_helper;
@@ -113,7 +114,8 @@ namespace cublog
       /* Keep track of the locked objects for DDL replication.
        * Since multiple DDL operations can be executed within single transaction,
        * more than one classes or objects(records in db_serial) can be mapped to one transaction */
-      std::multimap <TRANID, LOG_REC_LOCKED_OBJECT> m_locked_objects;
+      std::multimap <TRANID, LOG_REC_LOCKED_OBJECT> m_locked_classes;
+      std::multimap <TRANID, LOG_REC_LOCKED_OBJECT> m_locked_serials;
       std::unordered_map <OID, std::string> m_classname_map;
   };
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-810

Purpose
Made the log record type and log data, as well as the locking functions on the PTS side, more generic, as it requires handling locks for the SERIAL

- Changed LOG_SCHEMA_MODIFICATION_LOCK to LOG_REPL_DDL_LOCK_INFO.
  - Previously, only the OID (classoid) of the locked object was recorded in the log, but this issue, it record the oid, classoid, and lock modes all together
- Leave the LOG_REPL_DDL_LOCK_INFO when the record in DB_SERIAL is fetched or inserted
  - `xlocator_fectch ()`, `heap_get_insert_location_with_lock ()`
- X_LOCK will be acquired on the record in DB_SERIAL