### PR TITLE
[CBRD-25102] [Regression] createdb is hang when set 'sort_buffer_size=3G' on cubrid.conf

### DIFF
--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -3743,7 +3743,7 @@ qfile_get_estimated_pages_for_sorting (QFILE_LIST_ID * list_id_p, SORTKEY_INFO *
 {
   int prorated_pages, sort_key_size, sort_key_overhead;
 
-  prorated_pages = (int) list_id_p->page_cnt;
+  prorated_pages = (int) MAX (list_id_p->page_cnt, 1);
   if (key_info_p->use_original == 1)
     {
       /* P_sort_key */

--- a/src/storage/external_sort.c
+++ b/src/storage/external_sort.c
@@ -2197,6 +2197,7 @@ sort_inphase_sort (THREAD_ENTRY * thread_p, SORT_PARAM * sort_param, SORT_GET_FU
   out_curfile = sort_param->in_half;
 
   output_buffer = sort_param->internal_memory + ((long)(sort_param->tot_buffers - 1) * DB_PAGESIZE);
+  assert (output_buffer > sort_param->internal_memory);
 
   numrecs = 0;
   sort_numrecs = 0;
@@ -2252,12 +2253,7 @@ sort_inphase_sort (THREAD_ENTRY * thread_p, SORT_PARAM * sort_param, SORT_GET_FU
 	  goto exit_on_error;
 
 	case SORT_REC_DOESNT_FIT:
-	  if (numrecs <= 0)
-	    {
-	      error = ER_FAILED;
-	      goto exit_on_error;
-	    }
-	  else
+	  if (numrecs > 0)
 	    {
 	      /* Perform internal sorting and flush the run */
 

--- a/src/storage/external_sort.c
+++ b/src/storage/external_sort.c
@@ -2196,7 +2196,7 @@ sort_inphase_sort (THREAD_ENTRY * thread_p, SORT_PARAM * sort_param, SORT_GET_FU
   sort_param->tot_runs = 0;
   out_curfile = sort_param->in_half;
 
-  output_buffer = sort_param->internal_memory + ((long)(sort_param->tot_buffers - 1) * DB_PAGESIZE);
+  output_buffer = sort_param->internal_memory + ((long) (sort_param->tot_buffers - 1) * DB_PAGESIZE);
   assert (output_buffer > sort_param->internal_memory);
 
   numrecs = 0;

--- a/src/storage/external_sort.c
+++ b/src/storage/external_sort.c
@@ -2196,7 +2196,7 @@ sort_inphase_sort (THREAD_ENTRY * thread_p, SORT_PARAM * sort_param, SORT_GET_FU
   sort_param->tot_runs = 0;
   out_curfile = sort_param->in_half;
 
-  output_buffer = sort_param->internal_memory + (sort_param->tot_buffers - 1) * DB_PAGESIZE;
+  output_buffer = sort_param->internal_memory + ((long)(sort_param->tot_buffers - 1) * DB_PAGESIZE);
 
   numrecs = 0;
   sort_numrecs = 0;
@@ -2252,7 +2252,12 @@ sort_inphase_sort (THREAD_ENTRY * thread_p, SORT_PARAM * sort_param, SORT_GET_FU
 	  goto exit_on_error;
 
 	case SORT_REC_DOESNT_FIT:
-	  if (numrecs > 0)
+	  if (numrecs <= 0)
+	    {
+	      error = ER_FAILED;
+	      goto exit_on_error;
+	    }
+	  else
 	    {
 	      /* Perform internal sorting and flush the run */
 

--- a/src/storage/statistics_cl.c
+++ b/src/storage/statistics_cl.c
@@ -507,7 +507,7 @@ stats_get_ndv_by_query (const MOP class_mop, CLASS_ATTR_NDV * class_attr_ndv, FI
 	{
 	  goto end;
 	}
-      class_attr_ndv->attr_ndv[i].ndv = DB_GET_BIGINT (&value);
+      class_attr_ndv->attr_ndv[i].ndv = MAX (DB_GET_BIGINT (&value), 1);
     }
 
   /* get count(*) */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25102

There is a problem with page size estimation being incorrect when sorting for values that are all null.

Modify as follows
```
1. Add defense code to prevent infinite loop and Cast to LONG to prevent overflow when calculating buffer.
2. If the page of the list file is 0, set the minimum value to 1. This eliminates the problem of needlessly allocating large amounts of memory.
3. Set the NDV value to 1 for all null values. 1 is the worst NDV.
```