### PR TITLE
[CBRD-25107] [Regression] Core dumped in stats_get_ndv_by_query at src/storage/statistics_cl.c:474

### DIFF
--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -5786,7 +5786,7 @@ stats_update_statistics (MOP classop, int with_fullscan)
   char *reply;
   char *ptr;
   int request_size;
-  CLASS_ATTR_NDV class_attr_ndv;
+  CLASS_ATTR_NDV class_attr_ndv = CLASS_ATTR_NDV_INITIALIZER;
 
   /* get NDV by query */
   if (stats_get_ndv_by_query (classop, &class_attr_ndv, NULL, with_fullscan) != NO_ERROR)
@@ -5837,7 +5837,7 @@ end:
   return error;
 #else /* CS_MODE */
   int success;
-  CLASS_ATTR_NDV class_attr_ndv;
+  CLASS_ATTR_NDV class_attr_ndv = CLASS_ATTR_NDV_INITIALIZER;
 
   /* get NDV by query */
   if (stats_get_ndv_by_query (classop, &class_attr_ndv, NULL, with_fullscan) != NO_ERROR)
@@ -5885,7 +5885,7 @@ stats_update_all_statistics (int with_fullscan)
   OR_ALIGNED_BUF (OR_INT_SIZE) a_reply;
   char *reply;
   char *ptr;
-  CLASS_ATTR_NDV class_attr_ndv;
+  CLASS_ATTR_NDV class_attr_ndv = CLASS_ATTR_NDV_INITIALIZER;
   const char *query = "select c.unique_name from _db_class as c where c.class_type = 0 and [partition] is null "
     "union "
     "select c.unique_name from _db_class as c, TABLE(c.partition) as g(x) where c.class_type = 0 and x.pname is null;";
@@ -5996,7 +5996,7 @@ end:
 
 #else /* CS_MODE */
   int error = NO_ERROR;
-  CLASS_ATTR_NDV class_attr_ndv;
+  CLASS_ATTR_NDV class_attr_ndv = CLASS_ATTR_NDV_INITIALIZER;
   const char *query = "select c.unique_name from _db_class as c where c.class_type = 0 and [partition] is null "
     "union "
     "select c.unique_name from _db_class as c, TABLE(c.partition) as g(x) where c.class_type = 0 and x.pname is null;";

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -10389,7 +10389,7 @@ sloaddb_update_stats (THREAD_ENTRY * thread_p, unsigned int rid, char *request, 
 
   session->get_class_registry ().get_all_class_entries (class_entries);
 
-  for (const cubload::class_entry * class_entry:class_entries)
+for (const cubload::class_entry * class_entry:class_entries)
     {
       if (!class_entry->is_ignored ())
 	{

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -3999,7 +3999,7 @@ sqst_update_statistics (THREAD_ENTRY * thread_p, unsigned int rid, char *request
   char *ptr;
   OR_ALIGNED_BUF (OR_INT_SIZE) a_reply;
   char *reply = OR_ALIGNED_BUF_START (a_reply);
-  CLASS_ATTR_NDV class_attr_ndv;
+  CLASS_ATTR_NDV class_attr_ndv = CLASS_ATTR_NDV_INITIALIZER;
 
   ptr = or_unpack_int (request, &class_attr_ndv.attr_cnt);
 
@@ -10389,7 +10389,13 @@ sloaddb_update_stats (THREAD_ENTRY * thread_p, unsigned int rid, char *request, 
 
   session->get_class_registry ().get_all_class_entries (class_entries);
 
-  oid_cnt = class_entries.size ();
+  for (const cubload::class_entry * class_entry:class_entries)
+    {
+      if (!class_entry->is_ignored ())
+	{
+	  oid_cnt++;
+	}
+    }
 
   /* start packing result */
   if (oid_cnt > 0)

--- a/src/storage/statistics.h
+++ b/src/storage/statistics.h
@@ -113,6 +113,7 @@ struct class_attr_ndv
   int attr_cnt;			/* column id */
   ATTR_NDV *attr_ndv;		/* Number of Distinct Values of column */
 };
+#define CLASS_ATTR_NDV_INITIALIZER	{0, NULL}
 
 #if !defined(SERVER_MODE)
 extern int stats_get_statistics (OID * classoid, unsigned int timestamp, CLASS_STATS ** stats_p);

--- a/src/storage/statistics_cl.c
+++ b/src/storage/statistics_cl.c
@@ -380,7 +380,7 @@ void
 stats_ndv_dump (const char *class_name_p, FILE * file_p)
 {
   MOP class_mop;
-  CLASS_ATTR_NDV class_attr_ndv;
+  CLASS_ATTR_NDV class_attr_ndv = CLASS_ATTR_NDV_INITIALIZER;
   int i;
 
   class_mop = sm_find_class (class_name_p);
@@ -507,7 +507,7 @@ stats_get_ndv_by_query (const MOP class_mop, CLASS_ATTR_NDV * class_attr_ndv, FI
 	{
 	  goto end;
 	}
-      class_attr_ndv->attr_ndv[i].ndv = DB_GET_BIGINT (&value);
+      class_attr_ndv->attr_ndv[i].ndv = MAX (DB_GET_BIGINT (&value), 1);
     }
 
   /* get count(*) */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25107

The problem occurs because the number of oids is greater than the actual oids. so I fix oid_cnt to check ignore_class when performing update_statistics in loaddb and add routine to Init class_attr_ndv.