### PR TITLE
[LETS-852] Fix the core dump in PTS when rollback the CREATE table statement 

### DIFF
--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -763,7 +763,7 @@ namespace cublog
 	    const atomic_log_entry &last_but_one_entry = *last_but_one_entry_it;
 
 	    if (!LSA_ISNULL (&last_entry.m_sysop_end_last_parent_lsa) &&
-		(last_but_one_entry.m_lsa > last_entry.m_sysop_end_last_parent_lsa))
+		(last_but_one_entry.m_lsa >= last_entry.m_sysop_end_last_parent_lsa))
 	      {
 		assert (last_but_one_entry.m_rectype == LOG_SYSOP_ATOMIC_START);
 

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -713,9 +713,10 @@ namespace cublog
 	      }
 	  }
 	// part of scenario (3)
-	// atomic replication sequence within a postpone sequence
+	// atomic replication sequence within a postpone sequence or logical compensation sequence
 	else if (LOG_SYSOP_END == last_entry.m_rectype
-		 && LOG_SYSOP_END_LOGICAL_RUN_POSTPONE == last_entry.m_sysop_end_type)
+		 && (LOG_SYSOP_END_LOGICAL_RUN_POSTPONE == last_entry.m_sysop_end_type
+		     || LOG_SYSOP_END_LOGICAL_COMPENSATE == last_entry.m_sysop_end_type))
 	  {
 	    const atomic_log_entry_vector_type::const_iterator last_but_one_entry_it = (last_entry_it - 1);
 	    const atomic_log_entry &last_but_one_entry = *last_but_one_entry_it;

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -756,6 +756,26 @@ namespace cublog
 		  }
 	      }
 	  }
+	// scenario (6)
+	else if (LOG_SYSOP_END == last_entry.m_rectype
+		 && LOG_SYSOP_END_LOGICAL_COMPENSATE == last_entry.m_sysop_end_type)
+	  {
+	    const atomic_log_entry_vector_type::const_iterator last_but_one_entry_it = (last_entry_it - 1);
+	    const atomic_log_entry &last_but_one_entry = *last_but_one_entry_it;
+
+	    if (!LSA_ISNULL (&last_entry.m_sysop_end_last_parent_lsa) &&
+		(last_but_one_entry.m_lsa > last_entry.m_sysop_end_last_parent_lsa))
+	      {
+		assert (last_but_one_entry.m_rectype == LOG_SYSOP_ATOMIC_START);
+
+		m_log_vec.erase (last_but_one_entry_it, m_log_vec.cend ());
+
+		if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
+		  {
+		    dump ("sequence::can_purge(10) after erase");
+		  }
+	      }
+	  }
 	// scenario (1)
 	else if (LOG_END_ATOMIC_REPL == last_entry.m_rectype)
 	  {
@@ -781,7 +801,7 @@ namespace cublog
 
 		    if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
 		      {
-			dump ("sequence::can_purge(10) after erase");
+			dump ("sequence::can_purge(11) after erase");
 		      }
 
 		    break;
@@ -791,7 +811,7 @@ namespace cublog
 		  {
 		    if (prm_get_bool_value (PRM_ID_ER_LOG_PTS_ATOMIC_REPL_DEBUG))
 		      {
-			dump ("sequence::can_purge(11) error");
+			dump ("sequence::can_purge(12) error");
 		      }
 
 		    assert_release ("inconsistent atomic log sequence found" == nullptr);

--- a/src/transaction/atomic_replication_helper.cpp
+++ b/src/transaction/atomic_replication_helper.cpp
@@ -713,10 +713,9 @@ namespace cublog
 	      }
 	  }
 	// part of scenario (3)
-	// atomic replication sequence within a postpone sequence or logical compensation sequence
+	// atomic replication sequence within a postpone sequence
 	else if (LOG_SYSOP_END == last_entry.m_rectype
-		 && (LOG_SYSOP_END_LOGICAL_RUN_POSTPONE == last_entry.m_sysop_end_type
-		     || LOG_SYSOP_END_LOGICAL_COMPENSATE == last_entry.m_sysop_end_type))
+		 && LOG_SYSOP_END_LOGICAL_RUN_POSTPONE == last_entry.m_sysop_end_type)
 	  {
 	    const atomic_log_entry_vector_type::const_iterator last_but_one_entry_it = (last_entry_it - 1);
 	    const atomic_log_entry &last_but_one_entry = *last_but_one_entry_it;

--- a/src/transaction/atomic_replication_helper.hpp
+++ b/src/transaction/atomic_replication_helper.hpp
@@ -143,6 +143,16 @@ namespace cublog
    *     |                          RVHF_SET_PREV_VERSION_LSA)
    *     |
    *     \--LOG_END_ATOMIC_REPL
+   *
+   *  (6)
+   *    standalone sysop atomic sequences with sysop end type LOG_SYSOP_END_LOGICAL_COMPENSATE
+   *    occurs when CREATE TABLE statement is aborted
+   *
+   *    LOG_SYSOP_ATOMIC_START
+   *     |
+   *     |  .. redo records .. (eg: RVFL_PARTSECT_DEALLOC, RVFL_FHEAD_DEALLOC, RVPGBUF_DEALLOC)
+   *     |
+   *     \--LOG_SYSOP_END with LOG_SYSOP_END_LOGICAL_COMPENSATE
    */
   class atomic_replication_helper
   {


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-852

After executing CREATE TABLE in ATS and then rollback, a core dump occurred in PTS. 

PTS replicator keeps track of logs that need to be applied atomically, such as sysops. (atomic_replication_helper)
When replicating logs like LOG_SYSOP_END, it checks if it can apply the logs within the sysop scope (sysop start ~ sysop end) and then purge the  bookkept logs.

However, the issue arose because the handling for `LOG_SYSOP_END_LOGICAL_COMPENSATE` type was missing, leading to the failure to purge the bookkept logs.

To address this problem, I added a case within the atomic_log_sequence to accommodate the `LOG_SYSOP_END_LOGICAL_COMPENSATE` log type.

Log sequence found when `CREATE TABLE` is rollbacked :  
```
LOG_SYSOP_ATOMIC_START
RVFL_PARTSECT_DEALLOC
RVFL_FHEAD_DEALLOC
RVPGBUF_DEALLOC
LOG_SYSOP_END_LOGICAL_COMPENSATE
```

The condition for LOG_SYSOP_END_LOGICAL_COMPENSATE is different from LOG_SYSOP_END_LOGICAL_UNDO because the last parent LSA for LOG_SYSOP_END_LOGICAL_COMPENSATE could not be NULL.