### PR TITLE
[CBRD-25104] [Regression] query cost is changed in query plan

### DIFF
--- a/src/storage/statistics_cl.c
+++ b/src/storage/statistics_cl.c
@@ -507,7 +507,8 @@ stats_get_ndv_by_query (const MOP class_mop, CLASS_ATTR_NDV * class_attr_ndv, FI
 	{
 	  goto end;
 	}
-      class_attr_ndv->attr_ndv[i].ndv = MAX (DB_GET_BIGINT (&value), 1);
+      /* if NDV is 0, it is all null values. */
+      class_attr_ndv->attr_ndv[i].ndv = DB_GET_BIGINT (&value) == 0 ? 1 : DB_GET_BIGINT (&value);
     }
 
   /* get count(*) */

--- a/src/storage/statistics_sr.c
+++ b/src/storage/statistics_sr.c
@@ -1227,7 +1227,7 @@ stats_update_partitioned_statistics (THREAD_ENTRY * thread_p, OID * class_id_p, 
 	  goto cleanup;
 	}
       cls_info_p->ci_tot_pages += subcls_info->ci_tot_pages;
-      cls_info_p->ci_tot_objects += subcls_info->ci_tot_objects;
+      cls_info_p->ci_tot_objects = class_attr_ndv->attr_ndv[class_attr_ndv->attr_cnt].ndv;;
 
       /* get disk repr for subclass */
       error = catalog_get_last_representation_id (thread_p, &partitions[i], &subcls_repr_id);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25104

There is an issue where the total number of rows in the partition table are added per partition. the total number of rows is used without adding.
There is an issue where the selectivity is set to 1 when the varchar is over 4000. it is fixed to be set to 1 only when NDV is 0.
