### PR TITLE
[LETS-883] Cleanup lock resources used by PTS replicator

### DIFF
--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -3241,7 +3241,7 @@ xboot_shutdown_server (REFPTR (THREAD_ENTRY, thread_p), ER_FINAL_CODE is_er_fina
       // and, thus, does not need to reach a consistent state at shutdown (because it
       // will pick a consistent state at boot from the page server(s) it connects to), replication
       // needs to be explicitly terminated gracefully before log infrastructure is finalized.
-      // In addition, replication needs to be terminated before lock manager module is finailized
+      // In addition, replication needs to be terminated before lock manager module is finalized
       // (which is done in log_final ()), since locks are acquired during replication for ddl statements.
       pts_ptr->finish_replication_during_shutdown (*thread_p);
 

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -3240,7 +3240,9 @@ xboot_shutdown_server (REFPTR (THREAD_ENTRY, thread_p), ER_FINAL_CODE is_er_fina
       // passive transaction server is completely transient - and read-only -
       // and, thus, does not need to reach a consistent state at shutdown (because it
       // will pick a consistent state at boot from the page server(s) it connects to), replication
-      // needs to be explicitly terminated gracefully before log infrastructure is finalized
+      // needs to be explicitly terminated gracefully before log infrastructure is finalized.
+      // In addition, replication needs to be terminated before lock manager module is finailized
+      // (which is done in log_final ()), since locks are acquired during replication for ddl statements.
       pts_ptr->finish_replication_during_shutdown (*thread_p);
 
       ts_Gl->stop_outgoing_page_server_messages ();

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -47,7 +47,7 @@ namespace cublog
      * termination state for atomic replication is needed
      */
 
-    cleanup_lock_resources ();
+    cleanup_lock_resources_for_ddl ();
   }
 
   void
@@ -575,7 +575,7 @@ namespace cublog
   }
 
   void
-  atomic_replicator::cleanup_lock_resources ()
+  atomic_replicator::cleanup_lock_resources_for_ddl ()
   {
     cubthread::entry &thread_entry = cubthread::get_entry ();
     lock_unlock_all (&thread_entry);

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -46,7 +46,7 @@ namespace cublog
      * termination state for atomic replication is needed
      */
 
-    cleanup_lock_resources ();
+    cleanup_lock_resources_for_ddl ();
   }
 
   void
@@ -385,17 +385,9 @@ namespace cublog
   {
     assert (m_locked_classes.count (trid) > 0);
 
-    if (m_locked_classes.size() == 1)
+    for (auto classoid : m_locked_classes[trid])
       {
-	// If there are no more DDL statements to replicate, the intention locks should also be removed.
-	lock_unlock_all (&thread_entry);
-      }
-    else
-      {
-	for (auto classoid : m_locked_classes[trid])
-	  {
-	    lock_unlock_object_and_cleanup (&thread_entry, &classoid, oid_Root_class_oid, SCH_M_LOCK);
-	  }
+	lock_unlock_object_and_cleanup (&thread_entry, &classoid, oid_Root_class_oid, SCH_M_LOCK);
       }
 
     m_locked_classes.erase (trid);
@@ -536,7 +528,7 @@ namespace cublog
   }
 
   void
-  atomic_replicator::cleanup_lock_resources ()
+  atomic_replicator::cleanup_lock_resources_for_ddl ()
   {
     cubthread::entry &thread_entry = cubthread::get_entry ();
     lock_unlock_all (&thread_entry);

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -46,6 +46,8 @@ namespace cublog
      * and, thus, does not need to be left in consistent state; thus, no check as to the consistent
      * termination state for atomic replication is needed
      */
+
+    cleanup_lock_resources ();
   }
 
   void
@@ -570,5 +572,12 @@ namespace cublog
       }
 
     return false;
+  }
+
+  void
+  atomic_replicator::cleanup_lock_resources ()
+  {
+    cubthread::entry &thread_entry = cubthread::get_entry ();
+    lock_unlock_all (&thread_entry);
   }
 }

--- a/src/transaction/log_replication_atomic.cpp
+++ b/src/transaction/log_replication_atomic.cpp
@@ -580,11 +580,4 @@ namespace cublog
     cubthread::entry &thread_entry = cubthread::get_entry ();
     lock_unlock_all (&thread_entry);
   }
-
-  void
-  atomic_replicator::cleanup_lock_resources_for_ddl ()
-  {
-    cubthread::entry &thread_entry = cubthread::get_entry ();
-    lock_unlock_all (&thread_entry);
-  }
 }

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -99,7 +99,7 @@ namespace cublog
       void acquire_lock_for_ddl (cubthread::entry &thread_entry, const TRANID trid, const OID *classoid);
       void discard_caches_for_ddl (cubthread::entry &thread_entry, const TRANID trid);
       bool is_locked_for_ddl (const TRANID trid, const OID *classoid);
-      void cleanup_lock_resources ();
+      void cleanup_lock_resources_for_ddl ();
 
     private:
       atomic_replication_helper m_atomic_helper;

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -101,7 +101,7 @@ namespace cublog
 				 const bool is_class);
       void discard_caches_for_ddl (cubthread::entry &thread_entry, const TRANID trid);
       bool is_locked_for_ddl (const TRANID trid, const OID *oid, const bool is_class) const;
-      void cleanup_lock_resources ();
+      void cleanup_lock_resources_for_ddl ();
 
     private:
       atomic_replication_helper m_atomic_helper;

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -99,6 +99,7 @@ namespace cublog
       void acquire_lock_for_ddl (cubthread::entry &thread_entry, const TRANID trid, const OID *classoid);
       void discard_caches_for_ddl (cubthread::entry &thread_entry, const TRANID trid);
       bool is_locked_for_ddl (const TRANID trid, const OID *classoid);
+      void cleanup_lock_resources ();
 
     private:
       atomic_replication_helper m_atomic_helper;

--- a/src/transaction/log_replication_atomic.hpp
+++ b/src/transaction/log_replication_atomic.hpp
@@ -101,6 +101,7 @@ namespace cublog
 				 const bool is_class);
       void discard_caches_for_ddl (cubthread::entry &thread_entry, const TRANID trid);
       bool is_locked_for_ddl (const TRANID trid, const OID *oid, const bool is_class) const;
+      void cleanup_lock_resources ();
 
     private:
       atomic_replication_helper m_atomic_helper;


### PR DESCRIPTION
http://jira.cubrid.org/browse/LETS-883

purpose
Since the current PTS replicator also uses a lock manager, it is necessary to clean up any remaining locks upon replicator termination or when all the locks have been released

Use `lock_unlock_all ()` to clean-up resources  
- Release of IX_LOCK for the Root class.
   - When performing SCH_M_LOCK on the class record, an intention lock is acquired for the root class.
   - This is currently not being cleaned up.
   - When there is no more ddl statements to replicate, then replicator call `lock_unlock_all ()`
- Release of locks during PTS shutdown when DDL is in progress.
  - Lock resources obtained for DDL execution need to be cleaned up.
  - call `lock_unlock_all ()` in dtor of atomic_replicator