### PR TITLE
[CBRD-25116] Fixed incorrect checking of the return value of the pt_check_path_eq function

### DIFF
--- a/src/optimizer/query_rewrite.c
+++ b/src/optimizer/query_rewrite.c
@@ -2409,7 +2409,7 @@ qo_converse_sarg_terms (PARSER_CONTEXT * parser, PT_NODE * where)
 		{
 		  for (attr = attr_list; attr; attr = attr->next)
 		    {
-		      if (pt_check_path_eq (parser, attr, arg1))
+		      if (pt_check_path_eq (parser, attr, arg1) == 0)
 			{
 			  attr->line_number++;	/* increase attribute count */
 			  break;
@@ -2433,7 +2433,7 @@ qo_converse_sarg_terms (PARSER_CONTEXT * parser, PT_NODE * where)
 		{
 		  for (attr = attr_list; attr; attr = attr->next)
 		    {
-		      if (pt_check_path_eq (parser, attr, arg2))
+		      if (pt_check_path_eq (parser, attr, arg2) == 0)
 			{
 			  attr->line_number++;	/* increase attribute count */
 			  break;
@@ -2627,11 +2627,11 @@ qo_converse_sarg_terms (PARSER_CONTEXT * parser, PT_NODE * where)
 		  arg1_cnt = arg2_cnt = 0;	/* init */
 		  for (attr = attr_list; attr; attr = attr->next)
 		    {
-		      if (pt_check_path_eq (parser, attr, arg1))
+		      if (pt_check_path_eq (parser, attr, arg1) == 0)
 			{
 			  arg1_cnt = attr->line_number;
 			}
-		      else if (pt_check_path_eq (parser, attr, arg2))
+		      else if (pt_check_path_eq (parser, attr, arg2) == 0)
 			{
 			  arg2_cnt = attr->line_number;
 			}

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -13917,6 +13917,9 @@ pt_check_path_eq (PARSER_CONTEXT * parser, const PT_NODE * p, const PT_NODE * q)
       return 1;
     }
 
+  CAST_POINTER_TO_NODE (p);
+  CAST_POINTER_TO_NODE (q);
+
   /* check node types are same */
   if (p->node_type != q->node_type)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24795
http://jira.cubrid.org/browse/CBRD-25116

### Fixed incorrect checking of the return value of the pt_check_path_eq function
In CBRD-24795, checking by calling the pt_name_equal function was changed to checking by calling the pt_check_path_eq  function. If the two are equal, the pt_name_equal function returns true (!= 0), but the pt_check_path_eq function returns 0. After changing the calling function, incorrect checking of the return value was occurring. And it was fixed.
```
drop table if exists t1;
create table t1 (a int, b int, c int, d int, e int);
create index idx_t1_abs_b_a on t1 (abs (b), a);

set optimization level 513;

select /*+ recompile ordered */ ta.*
from t1 ta, t1 tb
where (ta.b = abs (tb.b) or ta.c = abs (tb.b))
and ta.a = tb.a;
```

**AS-IS**
- The following predicate must be indexable.
```
term[0]: (ta.b range ( abs(tb.b) = ) or ta.c range ( abs(tb.b) = )) (sel 0.001999) (rank 2) (join term) (inner-join) (loc 0)
```

**TO-BE**
```
term[0]:  abs(tb.b) range (ta.b =  or ta.c = ) (sel 0.001999) (rank 3) (join term) (inner-join) (indexable  abs([dba.t1].[b])[1]) (loc 0)
```