### PR TITLE
[CBRD-25070] Fix segfault when SP is called on SA mode

### DIFF
--- a/src/method/method_invoke_group.cpp
+++ b/src/method/method_invoke_group.cpp
@@ -53,8 +53,8 @@ namespace cubmethod
 
     // init runtime context
     session_get_method_runtime_context (thread_p, m_rctx);
+    session_get_session_id (thread_p, &m_sid);
 
-    m_sid = thread_p->conn_entry->session_id;
     m_tid = logtb_find_current_tranid (thread_p);
 
     method_sig_node *sig = sig_list.method_sig;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25070

To get session_id, session_get_session_id () should be used.