### PR TITLE
[CBRD-25120] Abnormal termination when executing 'loaddb --no-statistics'

### DIFF
--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -1256,7 +1256,8 @@ ldr_server_load (load_args * args, int *exit_status, bool * interrupted)
 		     last_stat.rows_committed, last_stat.rows_failed);
     }
 
-  if (!load_interrupted && !status.is_load_failed () && !args->syntax_check && error_code == NO_ERROR && !args->disable_statistics)
+  if (!load_interrupted && !status.is_load_failed () && !args->syntax_check && error_code == NO_ERROR
+      && !args->disable_statistics)
     {
       // Update class statistics
       if (args->verbose)

--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -1256,7 +1256,7 @@ ldr_server_load (load_args * args, int *exit_status, bool * interrupted)
 		     last_stat.rows_committed, last_stat.rows_failed);
     }
 
-  if (!load_interrupted && !status.is_load_failed () && !args->syntax_check && error_code == NO_ERROR)
+  if (!load_interrupted && !status.is_load_failed () && !args->syntax_check && error_code == NO_ERROR && !args->disable_statistics)
     {
       // Update class statistics
       if (args->verbose)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25120

fix to operate normally when using the '--no-statistics' option.
