### PR TITLE
[CBRD-25128] In STRING_CAT '||' operation, incorrect handling of null when setting oracle_style_empty_string

### DIFF
--- a/src/executables/csql_result.c
+++ b/src/executables/csql_result.c
@@ -485,8 +485,6 @@ display_empty_result (int stmt_type, int line_no)
   return;
 }
 
-#define IS_STRING_TYPE(type)     (type == DB_TYPE_STRING || \
-                                  type == DB_TYPE_CHAR)
 /*
  * get_current_result() - get the attribute values of the current result
  *   return: pointer newly allocated value array. On error, NULL.
@@ -562,7 +560,7 @@ get_current_result (int **lengths, const CUR_RESULT_INFO * result_info, const CS
 	      /* UNKNOWN, maybe host variable */
 	      || result_info->attr_types[i] == DB_TYPE_NULL || result_info->attr_types[i] == DB_TYPE_VARIABLE
 	      || value_type == result_info->attr_types[i]
-	      || (IS_STRING_TYPE (value_type) && IS_STRING_TYPE (result_info->attr_types[i])));
+	      || (TP_IS_CHAR_TYPE (value_type) && TP_IS_CHAR_TYPE (result_info->attr_types[i])));
 
       switch (value_type)
 	{

--- a/src/executables/csql_result.c
+++ b/src/executables/csql_result.c
@@ -485,6 +485,8 @@ display_empty_result (int stmt_type, int line_no)
   return;
 }
 
+#define IS_STRING_TYPE(type)     (type == DB_TYPE_STRING || \
+                                  type == DB_TYPE_CHAR)
 /*
  * get_current_result() - get the attribute values of the current result
  *   return: pointer newly allocated value array. On error, NULL.
@@ -559,7 +561,8 @@ get_current_result (int **lengths, const CUR_RESULT_INFO * result_info, const CS
       assert (value_type == DB_TYPE_NULL
 	      /* UNKNOWN, maybe host variable */
 	      || result_info->attr_types[i] == DB_TYPE_NULL || result_info->attr_types[i] == DB_TYPE_VARIABLE
-	      || value_type == result_info->attr_types[i]);
+	      || value_type == result_info->attr_types[i]
+	      || (IS_STRING_TYPE (value_type) && IS_STRING_TYPE (result_info->attr_types[i])));
 
       switch (value_type)
 	{

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -6066,6 +6066,7 @@ does_op_specially_treat_null_arg (PT_OP_TYPE op)
     case PT_TO_CHAR:
       return true;
     case PT_REPLACE:
+    case PT_STRCAT:
       return prm_get_bool_value (PRM_ID_ORACLE_STYLE_EMPTY_STRING);
     default:
       return false;
@@ -18243,9 +18244,10 @@ pt_fold_const_expr (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg)
       /* use the caching variant of this function ! */
       domain = pt_xasl_node_to_domain (parser, expr);
 
-      if (domain && QSTR_IS_ANY_CHAR_OR_BIT (TP_DOMAIN_TYPE (domain)))
+      if (domain
+	  && (QSTR_IS_ANY_CHAR_OR_BIT (TP_DOMAIN_TYPE (domain)) || type1 == PT_TYPE_NULL || type2 == PT_TYPE_NULL))
 	{
-	  if (opd1 && opd1->node_type == PT_VALUE && type1 == PT_TYPE_NULL && PT_IS_STRING_TYPE (type2))
+	  if (opd1 && opd1->node_type == PT_VALUE && type1 == PT_TYPE_NULL)
 	    {
 	      /* fold 'null || char_opnd' expr to 'char_opnd' */
 	      result = parser_copy_tree (parser, opd2);
@@ -18255,7 +18257,7 @@ pt_fold_const_expr (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg)
 		  goto end;
 		}
 	    }
-	  else if (opd2 && opd2->node_type == PT_VALUE && type2 == PT_TYPE_NULL && PT_IS_STRING_TYPE (type1))
+	  else if (opd2 && opd2->node_type == PT_VALUE && type2 == PT_TYPE_NULL)
 	    {
 	      /* fold 'char_opnd || null' expr to 'char_opnd' */
 	      result = parser_copy_tree (parser, opd1);

--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -6046,12 +6046,9 @@ qdata_strcat_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, DB_VALUE * result_
   TP_DOMAIN *cast_dom2 = NULL;
   TP_DOMAIN_STATUS dom_status;
 
-  if (!prm_get_bool_value (PRM_ID_ORACLE_STYLE_EMPTY_STRING))
+  if (domain_p != NULL && TP_DOMAIN_TYPE (domain_p) == DB_TYPE_NULL)
     {
-      if (domain_p != NULL && TP_DOMAIN_TYPE (domain_p) == DB_TYPE_NULL)
-	{
-	  return NO_ERROR;
-	}
+      return NO_ERROR;
     }
 
   type1 = dbval1_p ? DB_VALUE_DOMAIN_TYPE (dbval1_p) : DB_TYPE_NULL;

--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -6046,9 +6046,12 @@ qdata_strcat_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, DB_VALUE * result_
   TP_DOMAIN *cast_dom2 = NULL;
   TP_DOMAIN_STATUS dom_status;
 
-  if (domain_p != NULL && TP_DOMAIN_TYPE (domain_p) == DB_TYPE_NULL)
+  if (!prm_get_bool_value (PRM_ID_ORACLE_STYLE_EMPTY_STRING))
     {
-      return NO_ERROR;
+      if (domain_p != NULL && TP_DOMAIN_TYPE (domain_p) == DB_TYPE_NULL)
+	{
+	  return NO_ERROR;
+	}
     }
 
   type1 = dbval1_p ? DB_VALUE_DOMAIN_TYPE (dbval1_p) : DB_TYPE_NULL;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25128

When oracle_style_empty_string is set, empty string '' is treated as null. And NULL is treated as NULL, but STRING_CAT operations such as '||' must be treated as empty string ''. Because ORACLE has NULL and || This is because the operation result is not NULL but an empty string.
