### PR TITLE
[CBRD-25129] Change CSQL environment variable name

### DIFF
--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -2929,19 +2929,22 @@ csql (const char *argv0, CSQL_ARGUMENT * csql_arg)
   csql_Pager_cmd[PATH_MAX - 1] = '\0';
   csql_Formatter_cmd[PATH_MAX - 1] = '\0';
 
-  env = getenv ("EDITOR");
+  env = getenv ("CUBRID_CSQL_EDITOR");
+  env = env != NULL ? env : getenv ("EDITOR");
   if (env)
     {
       strncpy (csql_Editor_cmd, env, PATH_MAX - 1);
     }
 
-  env = getenv ("SHELL");
+  env = getenv ("CUBRID_CSQL_SHELL");
+  env = env != NULL ? env : getenv ("SHELL");
   if (env)
     {
       strncpy (csql_Shell_cmd, env, PATH_MAX - 1);
     }
 
-  env = getenv ("FORMATTER");
+  env = getenv ("CUBRID_CSQL_FORMATTER");
+  env = env != NULL ? env : getenv ("FORMATTER");
   if (env)
     {
       strncpy (csql_Formatter_cmd, env, PATH_MAX - 1);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25129

**Purpose**
The environment variables EDITOR, SHELL and FORMATTER used in CSQL pose an issue where users cannot directly discern their association with CUBRID.
Address this, the variable names will be changed as follows:
- EDITOR -> CUBRID_CSQL_EDITOR
- SHELL -> CUBRID_CSQL_SHELL
- FORMATTER -> CUBRID_CSQL_FORMATTER

To maintain compatibility, the previously used names(EDITOR, SHELL, FORMATTER) will still be supported.

**Implementation**
N/A

**Remark**
N/A