### PR TITLE
[CBRD-25115] fixed inaccuracy in length limit of where clause when creating filter index

### DIFF
--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -4132,11 +4132,9 @@ build_filter_pred_string_for_compare (PARSER_CONTEXT * parser, char *pred_string
   PT_NODE *where_predicate;
   PARSER_VARCHAR *filter_expr = NULL;
   int save_custom;
-
-  char *class_name = "tbl";
   char query_buf[1024];
 
-  snprintf (query_buf, sizeof (query_buf), "SELECT * FROM [%s] WHERE %s", class_name, pred_string);
+  snprintf (query_buf, sizeof (query_buf), "SELECT * FROM [x] WHERE %s", pred_string);
   stmt = parser_parse_string_use_sys_charset (parser, query_buf);
   if (stmt == NULL || *stmt == NULL || pt_has_error (parser))
     {
@@ -4349,7 +4347,7 @@ classobj_find_constraint_by_attrs (SM_CLASS_CONSTRAINT * cons_list, DB_CONSTRAIN
 	      cons_pred = build_filter_pred_string_for_compare (t_parser, cons->filter_predicate->pred_string);
 
 	      if ((flt_pred->length != cons_pred->length)
-		  || strcmp ((char *) flt_pred->bytes, (char *) cons_pred->bytes))
+		  || strcasecmp ((char *) flt_pred->bytes, (char *) cons_pred->bytes))
 		{
 		  continue;
 		}

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -28055,8 +28055,8 @@ pt_get_offset_length_of_where_clause(PT_NODE* pnode, int buffer_pos)
      {
        int t_size = buffer_pos - pnode->info.index.offset_where_clause;
        int t_fd = fileno(this_parser->file);      
-       lseek64(t_fd, pnode->info.index.offset_where_clause, SEEK_SET);
-       read(t_fd, buf, t_size);
+       lseek (t_fd, pnode->info.index.offset_where_clause, SEEK_SET);
+       read (t_fd, buf, t_size);
        buf[t_size] = '\0';
 
        buf_ptr = buf;

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -2126,6 +2126,8 @@ struct pt_index_info
   SM_INDEX_STATUS index_status;	/* Index status : NORMAL / ONLINE / INVISIBLE */
   int ib_threads;
   short deduplicate_level;	/* -1: Not set yet, 0 : Not Use, others : mod by pow(2,deduplicate_level), refer to DEDUPLICATE_KEY_LEVEL_??? */
+  int offset_where_clause;	/* Starting position of the where clause contents (excluding the string "WHERE") in parser->original_buffer */
+  int length_where_clause;
 };
 
 /* CREATE USER INFO */

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -15019,12 +15019,17 @@ do_recreate_filter_index_constr (PARSER_CONTEXT * parser, SM_PREDICATE_INFO * fi
       flt_pos.alter = alter;
       flt_pos.new_user_specified_name = NULL;
       flt_pos.old_user_specified_name = NULL;
+      flt_pos.new_name = NULL;
+      flt_pos.old_name = NULL;
 
       if (alter->info.alter.alter_clause.attr_mthd.attr_def_list)
 	{
 	  flt_pos.new_name = get_attr_name (alter->info.alter.alter_clause.attr_mthd.attr_def_list);
 	}
-      flt_pos.old_name = alter->info.alter.alter_clause.attr_mthd.attr_old_name->info.name.original;
+      if (alter->info.alter.alter_clause.attr_mthd.attr_old_name)
+	{
+	  flt_pos.old_name = alter->info.alter.alter_clause.attr_mthd.attr_old_name->info.name.original;
+	}
 
       (void) parser_walk_tree (parser, where_predicate, replace_names_alter_chg_attr_for_where_of_filter,
 			       (void *) &flt_pos, NULL, NULL);

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -15539,7 +15539,8 @@ pt_get_table_names_index_expr_for_where_of_filter (PARSER_CONTEXT * parser, PT_N
   SFLT_IDX_WHERE_POSITIONS *flt_pos = (SFLT_IDX_WHERE_POSITIONS *) void_arg;
 
   assert (flt_pos->alter == NULL);
-  assert (flt_pos->new_name == NULL && flt_pos->new_user_specified_name == NULL);
+  assert (flt_pos->new_name && flt_pos->new_name[0] == '\0');
+  assert (flt_pos->new_user_specified_name && flt_pos->new_user_specified_name[0] == '\0');
 
   *continue_walk = PT_CONTINUE_WALK;
   if (node->node_type == PT_DOT_)

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -2941,9 +2941,19 @@ create_or_drop_index_helper (PARSER_CONTEXT * parser, const char *const constrai
 		  goto end;
 		}
 
-	      memcpy (pred_index_info.pred_string, parser->original_buffer + idx_info->offset_where_clause,
-		      idx_info->length_where_clause);
-	      pred_index_info.pred_string[idx_info->length_where_clause] = '\0';
+	      if (parser->original_buffer)
+		{
+		  memcpy (pred_index_info.pred_string, parser->original_buffer + idx_info->offset_where_clause,
+			  idx_info->length_where_clause);
+		  pred_index_info.pred_string[idx_info->length_where_clause] = '\0';
+		}
+	      else
+		{
+		  int t_fd = fileno (parser->file);
+		  lseek64 (t_fd, idx_info->offset_where_clause, SEEK_SET);
+		  read (t_fd, pred_index_info.pred_string, idx_info->length_where_clause);
+		  pred_index_info.pred_string[idx_info->length_where_clause] = '\0';
+		}
 	    }
 
 	  pt_enter_packing_buf ();

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -42,7 +42,7 @@
 #include "system_parameter.h"
 #if defined(WINDOWS)
 #include "misc_string.h"
-#include "porting.h"
+#include <io.h>
 #endif /* WINDOWS */
 #include "semantic_check.h"
 #include "xasl_generation.h"

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -27,6 +27,9 @@
 #include <stdarg.h>
 #include <ctype.h>
 #include <assert.h>
+#if defined(WINDOWS)
+#include "io.h"
+#endif /* WINDOWS */
 
 #include "authenticate.h"
 #include "error_manager.h"
@@ -42,7 +45,6 @@
 #include "system_parameter.h"
 #if defined(WINDOWS)
 #include "misc_string.h"
-#include <io.h>
 #endif /* WINDOWS */
 #include "semantic_check.h"
 #include "xasl_generation.h"

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -42,6 +42,7 @@
 #include "system_parameter.h"
 #if defined(WINDOWS)
 #include "misc_string.h"
+#include "porting.h"
 #endif /* WINDOWS */
 #include "semantic_check.h"
 #include "xasl_generation.h"

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -2950,7 +2950,7 @@ create_or_drop_index_helper (PARSER_CONTEXT * parser, const char *const constrai
 	      else
 		{
 		  int t_fd = fileno (parser->file);
-		  lseek64 (t_fd, idx_info->offset_where_clause, SEEK_SET);
+		  lseek (t_fd, idx_info->offset_where_clause, SEEK_SET);
 		  read (t_fd, pred_index_info.pred_string, idx_info->length_where_clause);
 		  pred_index_info.pred_string[idx_info->length_where_clause] = '\0';
 		}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25115

* When saving the contents of the where clause of the filter index, be sure to save the user's original string.
* In the loaddb process, a process of reading directly from FILE was added because the query is not in the buffer.
