### PR TITLE
[CBRD-25139] When using oracle style empty string, the result of replace is null.

### DIFF
--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -18253,19 +18253,22 @@ pt_fold_const_expr (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg)
       if (domain
 	  && (QSTR_IS_ANY_CHAR_OR_BIT (TP_DOMAIN_TYPE (domain)) || type1 == PT_TYPE_NULL || type2 == PT_TYPE_NULL))
 	{
-	  if (opd3 && opd3->node_type == PT_VALUE && type3 == PT_TYPE_NULL)	/* REPLACE */
+	  if (opd3)		/* REPLACE */
 	    {
-	      /* need to replace the NULL with empty string */
-	      int err =
-		db_string_make_empty_typed_string (&opd3->info.value.db_value, DB_TYPE_STRING, DB_DEFAULT_PRECISION,
-						   TP_DOMAIN_CODESET (domain), TP_DOMAIN_COLLATION (domain));
-	      if (err != NO_ERROR)
+	      if (opd3->node_type == PT_VALUE && type3 == PT_TYPE_NULL)
 		{
-		  has_error = true;
-		}
-	      else
-		{
-		  result = expr;
+		  /* need to replace the NULL with empty string */
+		  int err =
+		    db_string_make_empty_typed_string (&opd3->info.value.db_value, DB_TYPE_STRING, DB_DEFAULT_PRECISION,
+						       TP_DOMAIN_CODESET (domain), TP_DOMAIN_COLLATION (domain));
+		  if (err != NO_ERROR)
+		    {
+		      has_error = true;
+		    }
+		  else
+		    {
+		      result = expr;
+		    }
 		}
 	    }
 	  else if (opd1 && opd1->node_type == PT_VALUE && type1 == PT_TYPE_NULL)

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -18255,10 +18255,17 @@ pt_fold_const_expr (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg)
 	{
 	  if (opd3 && opd3->node_type == PT_VALUE && type3 == PT_TYPE_NULL)	/* REPLACE */
 	    {
-	      result = parser_copy_tree (parser, opd1);
-	      if (result == NULL)
+	      /* need to replace the NULL with empty string */
+	      int err =
+		db_string_make_empty_typed_string (&opd3->info.value.db_value, DB_TYPE_STRING, DB_DEFAULT_PRECISION,
+						   TP_DOMAIN_CODESET (domain), TP_DOMAIN_COLLATION (domain));
+	      if (err != NO_ERROR)
 		{
 		  has_error = true;
+		}
+	      else
+		{
+		  result = expr;
 		}
 	    }
 	  else if (opd1 && opd1->node_type == PT_VALUE && type1 == PT_TYPE_NULL)

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -18237,9 +18237,15 @@ pt_fold_const_expr (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg)
     }
 
   if (prm_get_bool_value (PRM_ID_ORACLE_STYLE_EMPTY_STRING)
-      && (op == PT_STRCAT || op == PT_PLUS || op == PT_CONCAT || op == PT_CONCAT_WS))
+      && (op == PT_STRCAT || op == PT_PLUS || op == PT_CONCAT || op == PT_CONCAT_WS || op == PT_REPLACE))
     {
       TP_DOMAIN *domain;
+
+      if (op == PT_REPLACE)
+	{
+	  opd3 = expr->info.expr.arg3;
+	  type3 = (opd3) ? opd3->type_enum : PT_TYPE_NULL;
+	}
 
       /* use the caching variant of this function ! */
       domain = pt_xasl_node_to_domain (parser, expr);
@@ -18247,7 +18253,15 @@ pt_fold_const_expr (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg)
       if (domain
 	  && (QSTR_IS_ANY_CHAR_OR_BIT (TP_DOMAIN_TYPE (domain)) || type1 == PT_TYPE_NULL || type2 == PT_TYPE_NULL))
 	{
-	  if (opd1 && opd1->node_type == PT_VALUE && type1 == PT_TYPE_NULL)
+	  if (opd3 && opd3->node_type == PT_VALUE && type3 == PT_TYPE_NULL)	/* REPLACE */
+	    {
+	      result = parser_copy_tree (parser, opd1);
+	      if (result == NULL)
+		{
+		  has_error = true;
+		}
+	    }
+	  else if (opd1 && opd1->node_type == PT_VALUE && type1 == PT_TYPE_NULL)
 	    {
 	      /* fold 'null || char_opnd' expr to 'char_opnd' */
 	      result = parser_copy_tree (parser, opd2);

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -18268,7 +18268,6 @@ pt_fold_const_expr (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg)
 	      if (result == NULL)
 		{
 		  has_error = true;
-		  goto end;
 		}
 	    }
 	  else if (opd2 && opd2->node_type == PT_VALUE && type2 == PT_TYPE_NULL)
@@ -18278,7 +18277,6 @@ pt_fold_const_expr (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg)
 	      if (result == NULL)
 		{
 		  has_error = true;
-		  goto end;
 		}
 	    }
 

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -1552,7 +1552,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, val_descr *
 	    }
 	}
       if (!prm_get_bool_value (PRM_ID_ORACLE_STYLE_EMPTY_STRING)
-	  && (DB_IS_NULL (peek_left) || (peek_third && DB_IS_NULL (peek_third))))
+	  && (DB_IS_NULL (peek_left) || DB_IS_NULL (peek_right) || (peek_third && DB_IS_NULL (peek_third))))
 	{
 	  PRIM_SET_NULL (arithptr->value);
 	}

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -1551,7 +1551,8 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, val_descr *
 	      goto error;
 	    }
 	}
-      if (DB_IS_NULL (peek_left) || (peek_third && DB_IS_NULL (peek_third)))
+      if (!prm_get_bool_value (PRM_ID_ORACLE_STYLE_EMPTY_STRING)
+	  && (DB_IS_NULL (peek_left) || (peek_third && DB_IS_NULL (peek_third))))
 	{
 	  PRIM_SET_NULL (arithptr->value);
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25139

When setting oracle style empty string=y, the result is null when using syntax such as replace(?,'-','').

CREATE TABLE tbl(i VARCHAR(100));
INSERT INTO tbl SELECT '2013-01-01' FROM dual;
SELECT  REPLACE(i,'-','') FROM tbl;

Expected Result
```
  replace(i, '-', '')
======================
  '20130101' 
```

Actual Result:
```
  replace(i, '-', '')
======================
  NULL
```
