### PR TITLE
[CBRD-25130] Fixing operator precedence of '||' (string concatenation)

### DIFF
--- a/pl_engine/pl_server/src/main/antlr/PlcParser.g4
+++ b/pl_engine/pl_server/src/main/antlr/PlcParser.g4
@@ -321,7 +321,8 @@ is_null_expression
 concatenation
     : unary_expression                                          # concatenation_prime
     | concatenation ('*' | '/' | DIV | MOD) concatenation       # mult_exp
-    | concatenation ('+' | '-' | '||') concatenation            # add_exp
+    | concatenation ('+' | '-' ) concatenation                  # add_exp
+    | concatenation '||' concatenation                          # str_concat_exp
     | concatenation ('<<' | '>>') concatenation                 # bit_shift_exp
     | concatenation ('&') concatenation                         # bit_and_exp
     | concatenation ('^') concatenation                         # bit_xor_exp

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -549,23 +549,21 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
 
     @Override
     public Expr visitAdd_exp(Add_expContext ctx) {
-        String opStr =
-                ctx.PLUS_SIGN() != null
-                        ? "Add"
-                        : ctx.MINUS_SIGN() != null
-                                ? "Subtract"
-                                : ctx.CONCAT_OP() != null ? "Concat" : null;
-        if (opStr == null) {
-            assert false : "unreachable"; // by syntax
-            throw new RuntimeException("unreachable");
-        }
-
-        String castTy = opStr.equals("Concat") ? "Object" : "Integer";
 
         Expr l = visitExpression(ctx.concatenation(0));
         Expr r = visitExpression(ctx.concatenation(1));
 
+        String opStr = ctx.PLUS_SIGN() != null ? "Add" : "Subtract";
         return new ExprBinaryOp(ctx, opStr, l, r);
+    }
+
+    @Override
+    public Expr visitStr_concat_exp(Str_concat_expContext ctx) {
+
+        Expr l = visitExpression(ctx.concatenation(0));
+        Expr r = visitExpression(ctx.concatenation(1));
+
+        return new ExprBinaryOp(ctx, "Concat", l, r);
     }
 
     @Override


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25130

