### PR TITLE
[CBRD-25090] A core dump occurs when NA is specified in the select list in the create view statement

### DIFF
--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -10127,9 +10127,6 @@ fixup_self_domain (TP_DOMAIN * domain, MOP self)
   for (d = domain; d != NULL; d = d->next)
     {
       /* PR_TYPE is changeable only for transient domain. */
-      // assert (d->type != tp_Type_null || !d->is_cached); assert ( !(d->type == tp_Type_null && d->is_cached));
-      //assert (d->type != tp_Type_null || (d->type == tp_Type_null && d->is_cached));
-      assert ((d->type != tp_Type_null && !d->is_cached) || (d->type == tp_Type_null && d->is_cached));
       if (d->type == tp_Type_null && !d->is_cached)
 	{
 	  d->type = tp_Type_object;

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -10127,7 +10127,9 @@ fixup_self_domain (TP_DOMAIN * domain, MOP self)
   for (d = domain; d != NULL; d = d->next)
     {
       /* PR_TYPE is changeable only for transient domain. */
-      assert (d->type != tp_Type_null || !d->is_cached);
+      // assert (d->type != tp_Type_null || !d->is_cached); assert ( !(d->type == tp_Type_null && d->is_cached));
+      //assert (d->type != tp_Type_null || (d->type == tp_Type_null && d->is_cached));
+      assert ((d->type != tp_Type_null && !d->is_cached) || (d->type == tp_Type_null && d->is_cached));
       if (d->type == tp_Type_null && !d->is_cached)
 	{
 	  d->type = tp_Type_object;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25090

* fixed an issue where a core dump occurs when NA is included in the select list when creating a view.
* Occurs in assert() statement, so only occurs in debug mode

`drop table if exists tbl;
 create table tbl(id int, v int);
 create view v1 as select NA x from tbl;`