### PR TITLE
[CBRD-24941] fix two small bugs

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -2445,7 +2445,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
             for (PlParamInfo pi : sws.hostExprs) {
                 if (pi.name.equals("?")) {
                     // auto parameter
-                    assert pi.value != null;
                     if (!DBTypeAdapter.isSupported(pi.type)) {
                         throw new SemanticError(
                                 Misc.getLineColumnOf(ctx), // s419

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -2777,7 +2777,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
             return hole.startsWith("%'+");
         }
 
-        // collect small holes into 'holes' and return null. 
+        // collect small holes into 'holes' and return null.
         // Or return a big hole immediately if one found
         private static String getHoles(Set<String> holes, String line) {
 
@@ -2787,17 +2787,17 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
             while (i < len) {
                 int begin = line.indexOf("%'", i);
                 if (begin == -1) {
-                    return null;    // no more holes
+                    return null; // no more holes
                 }
                 int end = line.indexOf("'%", begin + 2);
                 if (end == -1) {
-                    return null;    // no more holes
+                    return null; // no more holes
                 }
 
                 if (end == begin + 2) {
                     // %''%
                     i += 3;
-                    continue;   // not a hole
+                    continue; // not a hole
                 }
 
                 int j = begin + 2;
@@ -2806,7 +2806,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                     j++;
                 }
                 // Hole names can consist of dashes and capital letters
-                for ( ; j < end; j++) {
+                for (; j < end; j++) {
                     char c = line.charAt(j);
                     if (c == '-' || (c >= 'A' && c <= 'Z')) {
                     } else {
@@ -2815,7 +2815,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 }
                 if (j < end) {
                     i += 2;
-                    continue;   // not a hole
+                    continue; // not a hole
                 }
 
                 i = end + 2;

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -2796,7 +2796,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
 
                 if (end == begin + 2) {
                     // %''%
-                    i += 3;
+                    i = begin + 3;
                     continue; // not a hole
                 }
 
@@ -2809,12 +2809,13 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 for (; j < end; j++) {
                     char c = line.charAt(j);
                     if (c == '-' || (c >= 'A' && c <= 'Z')) {
+                        // OK
                     } else {
                         break;
                     }
                 }
                 if (j < end) {
-                    i += 2;
+                    i = j;
                     continue; // not a hole
                 }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24941

1. It wrongly asserted that auto parameter values cannot be null. This commit removed the assertion.
2. It wrongly asserted that text "%'" starts a hole of code template. Actually, it can appear in a legal code. For example, "STR LIKE   'abc%'". This commit removed the assertion 
3. This commit reinforced the criteria of deciding code template holes. In addition to the old condition of being enclosed by %' and '%, a code template hole name must consist only of dashes and capital letters.
