### PR TITLE
[CBRD-25117] Clarify the assert in function heap_stats_get_second_best.

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -3181,11 +3181,11 @@ heap_stats_get_second_best (HEAP_HDR_STATS * heap_hdr, VPID * vpid)
   heap_hdr->estimates.head_second_best = HEAP_STATS_NEXT_BEST_INDEX (head);
 
   /* If both head and tail refer to the same index, the number of second best hints is 0. */
-  assert (heap_hdr->estimates.num_second_best != HEAP_NUM_BEST_SPACESTATS);
+  assert (heap_hdr->estimates.num_second_best < HEAP_NUM_BEST_SPACESTATS);
   assert ((heap_hdr->estimates.tail_second_best >= heap_hdr->estimates.head_second_best)
 	  ? ((heap_hdr->estimates.tail_second_best - heap_hdr->estimates.head_second_best)
 	     == heap_hdr->estimates.num_second_best)
-	  : ((10 + heap_hdr->estimates.tail_second_best - heap_hdr->estimates.head_second_best)
+	  : ((HEAP_NUM_BEST_SPACESTATS + heap_hdr->estimates.tail_second_best - heap_hdr->estimates.head_second_best)
 	     == heap_hdr->estimates.num_second_best));
 
   *vpid = heap_hdr->estimates.second_best[head];


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25117

Purpose
Changes the hard coded constant to macro and clarify the condition in assert.

Implementation
N/A

Remarks
N/A