### PR TITLE
[CBRD-25145] Problem of removing expr from sort spec of analytic function when statement pooling

### DIFF
--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -3017,6 +3017,7 @@ struct pt_killstmt_info
 struct pt_sort_spec_info
 {
   PT_NODE *expr;		/* PT_EXPR, PT_VALUE, PT_NAME */
+  PT_NODE *prev_expr;		/* PT_EXPR, PT_VALUE, PT_NAME */
   QFILE_TUPLE_VALUE_POSITION pos_descr;	/* Value position descriptor */
   PT_MISC_TYPE asc_or_desc;	/* enum value will be PT_ASC or PT_DESC */
   PT_MISC_TYPE nulls_first_or_last;	/* enum value will be PT_NULLS_DEFAULT, PT_NULLS_FIRST or PT_NULLS_LAST */

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -14954,6 +14954,7 @@ static PT_NODE *
 pt_apply_sort_spec (PARSER_CONTEXT * parser, PT_NODE * p, void *arg)
 {
   PT_APPLY_WALK (parser, p->info.sort_spec.expr, arg);
+  PT_APPLY_WALK (parser, p->info.sort_spec.prev_expr, arg);
   return p;
 }
 

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -16596,9 +16596,6 @@ pt_to_buildlist_proc (PARSER_CONTEXT * parser, PT_NODE * select_node, QO_PLAN * 
 
 	  select_node->info.query.q.select.list = node;
 
-	  /* we can dispose of the sort columns now as they no longer serve a purpose */
-	  parser_free_tree (parser, select_list_ex);
-	  select_list_ex = NULL;
 	  /* register initial outlist */
 	  xasl->outptr_list = buildlist->a_outptr_list_ex;
 

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -16588,7 +16588,6 @@ pt_to_buildlist_proc (PARSER_CONTEXT * parser, PT_NODE * select_node, QO_PLAN * 
 	  /* whatever we're left with in select_list_ex are sort columns of analytic functions; there might be
 	   * subqueries, generate aptr and dptr lists for them */
 	  node = select_node->info.query.q.select.list;
-
 	  select_node->info.query.q.select.list = select_list_ex;
 
 	  pt_set_aptr (parser, select_node, xasl);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25145

When creating xasl with a rewrite query, the expression pointed to by sort_spec changed to PT_VALUE cannot be found.
In to-be, the previous expression is backed up in prev_expr of sort_spec.