### PR TITLE
[CBRD-24479] The maximum number of objects in lockdb is meaningless

### DIFF
--- a/msg/de_DE.utf8/utils.msg
+++ b/msg/de_DE.utf8/utils.msg
@@ -845,6 +845,7 @@ Anwendung: %1$s lockdb [OPTION] Datenbanknamen\n\
 \n\
 gültige Optionen:\n\
   -o, --output-file=DATEI       Umleiten der Ausgabemeldungen in DATEI; Standard: keine\n
+  -c, --contention             display only lock information which has contention\n
 
 
 $set 26 MSGCAT_UTIL_SET_KILLTRAN

--- a/msg/de_DE.utf8/utils.msg
+++ b/msg/de_DE.utf8/utils.msg
@@ -844,7 +844,7 @@ lockdb: Lockstatus der Datenbank anzeigen.\n\
 Anwendung: %1$s lockdb [OPTION] Datenbanknamen\n\
 \n\
 gültige Optionen:\n\
-  -o, --output-file=DATEI       Umleiten der Ausgabemeldungen in DATEI; Standard: keine\n
+  -o, --output-file=DATEI       Umleiten der Ausgabemeldungen in DATEI; Standard: keine\n\
   -c, --contention             display only lock information which has contention\n
 
 

--- a/msg/en_US.utf8/utils.msg
+++ b/msg/en_US.utf8/utils.msg
@@ -846,6 +846,7 @@ usage: %1$s lockdb [OPTION] database-name\n\
 \n\
 valid options:\n\
   -o, --output-file=FILE       redirect output messages to FILE; default: none\n
+  -c, --contention             display only lock information which has contention\n
 
 
 $set 26 MSGCAT_UTIL_SET_KILLTRAN

--- a/msg/en_US.utf8/utils.msg
+++ b/msg/en_US.utf8/utils.msg
@@ -845,7 +845,7 @@ lockdb: Display lock-status of the database.\n\
 usage: %1$s lockdb [OPTION] database-name\n\
 \n\
 valid options:\n\
-  -o, --output-file=FILE       redirect output messages to FILE; default: none\n
+  -o, --output-file=FILE       redirect output messages to FILE; default: none\n\
   -c, --contention             display only lock information which has contention\n
 
 

--- a/msg/en_US/utils.msg
+++ b/msg/en_US/utils.msg
@@ -846,6 +846,7 @@ usage: %1$s lockdb [OPTION] database-name\n\
 \n\
 valid options:\n\
   -o, --output-file=FILE       redirect output messages to FILE; default: none\n
+  -c, --contention             display only lock information which has contention\n
 
 
 $set 26 MSGCAT_UTIL_SET_KILLTRAN

--- a/msg/en_US/utils.msg
+++ b/msg/en_US/utils.msg
@@ -845,7 +845,7 @@ lockdb: Display lock-status of the database.\n\
 usage: %1$s lockdb [OPTION] database-name\n\
 \n\
 valid options:\n\
-  -o, --output-file=FILE       redirect output messages to FILE; default: none\n
+  -o, --output-file=FILE       redirect output messages to FILE; default: none\n\
   -c, --contention             display only lock information which has contention\n
 
 

--- a/msg/es_ES.utf8/utils.msg
+++ b/msg/es_ES.utf8/utils.msg
@@ -845,6 +845,7 @@ uso : %1$s lockdb [OPTION] database-name\n\
 \n\
 opciones validas:\n\
   -o, --output-file=FILE       redireccionar mensajes de salida al ARCHIVO; estandar: ninguno\n
+  -c, --contention             display only lock information which has contention\n
 
 
 $set 26 MSGCAT_UTIL_SET_KILLTRAN

--- a/msg/es_ES.utf8/utils.msg
+++ b/msg/es_ES.utf8/utils.msg
@@ -844,7 +844,7 @@ lockdb: Mostrar estado de bloqueo de la base de datos.\n\
 uso : %1$s lockdb [OPTION] database-name\n\
 \n\
 opciones validas:\n\
-  -o, --output-file=FILE       redireccionar mensajes de salida al ARCHIVO; estandar: ninguno\n
+  -o, --output-file=FILE       redireccionar mensajes de salida al ARCHIVO; estandar: ninguno\n\
   -c, --contention             display only lock information which has contention\n
 
 

--- a/msg/fr_FR.utf8/utils.msg
+++ b/msg/fr_FR.utf8/utils.msg
@@ -848,6 +848,7 @@ usage: %1$s lockdb [OPTION] database-name\n\
 \n\
 options valids:\n\
   -o, --output-file=FICHIER   redirige les messages de sortie à FICHIER; par défaut: aucun\n
+  -c, --contention             display only lock information which has contention\n
 
 
 $set 26 MSGCAT_UTIL_SET_KILLTRAN

--- a/msg/fr_FR.utf8/utils.msg
+++ b/msg/fr_FR.utf8/utils.msg
@@ -847,7 +847,7 @@ lockdb: Affiche l'état du verrouillage de la base de données.\n\
 usage: %1$s lockdb [OPTION] database-name\n\
 \n\
 options valids:\n\
-  -o, --output-file=FICHIER   redirige les messages de sortie à FICHIER; par défaut: aucun\n
+  -o, --output-file=FICHIER   redirige les messages de sortie à FICHIER; par défaut: aucun\n\
   -c, --contention             display only lock information which has contention\n
 
 

--- a/msg/it_IT.utf8/utils.msg
+++ b/msg/it_IT.utf8/utils.msg
@@ -845,6 +845,7 @@ uso: %1$s lockdb [OPZIONE] nome-database\n\
 \n\
 opzioni valide:\n\
   -o, --output-file=FILE       reindirizzare i messaggi di output a FILE; predefinito: nessuno\n
+  -c, --contention             display only lock information which has contention\n
 
 
 $set 26 MSGCAT_UTIL_SET_KILLTRAN

--- a/msg/it_IT.utf8/utils.msg
+++ b/msg/it_IT.utf8/utils.msg
@@ -844,7 +844,7 @@ lockdb: Visualizzare lock-status del database.\n\
 uso: %1$s lockdb [OPZIONE] nome-database\n\
 \n\
 opzioni valide:\n\
-  -o, --output-file=FILE       reindirizzare i messaggi di output a FILE; predefinito: nessuno\n
+  -o, --output-file=FILE       reindirizzare i messaggi di output a FILE; predefinito: nessuno\n\
   -c, --contention             display only lock information which has contention\n
 
 

--- a/msg/ja_JP.utf8/utils.msg
+++ b/msg/ja_JP.utf8/utils.msg
@@ -845,6 +845,7 @@ lockdb: データベースのロック情報を出力\n\
 \n\
 オプション:\n\
   -o, --output-file=FILE       出力メッセージをセーブするファイル; デフォルト: なし\n
+  -c, --contention             display only lock information which has contention\n
 
 
 $set 26 MSGCAT_UTIL_SET_KILLTRAN

--- a/msg/ja_JP.utf8/utils.msg
+++ b/msg/ja_JP.utf8/utils.msg
@@ -844,7 +844,7 @@ lockdb: データベースのロック情報を出力\n\
 使い方: %1$s lockdb [オプション] <データベース名>\n\
 \n\
 オプション:\n\
-  -o, --output-file=FILE       出力メッセージをセーブするファイル; デフォルト: なし\n
+  -o, --output-file=FILE       出力メッセージをセーブするファイル; デフォルト: なし\n\
   -c, --contention             display only lock information which has contention\n
 
 

--- a/msg/km_KH.utf8/utils.msg
+++ b/msg/km_KH.utf8/utils.msg
@@ -846,7 +846,7 @@ lockdb: Display lock-status of the database.\n\
 usage: %1$s lockdb [OPTION] database-name\n\
 \n\
 valid options:\n\
-  -o, --output-file=FILE       redirect output messages to FILE; default: none\n
+  -o, --output-file=FILE       redirect output messages to FILE; default: none\n\
   -c, --contention             display only lock information which has contention\n
 
 

--- a/msg/km_KH.utf8/utils.msg
+++ b/msg/km_KH.utf8/utils.msg
@@ -847,6 +847,7 @@ usage: %1$s lockdb [OPTION] database-name\n\
 \n\
 valid options:\n\
   -o, --output-file=FILE       redirect output messages to FILE; default: none\n
+  -c, --contention             display only lock information which has contention\n
 
 
 $set 26 MSGCAT_UTIL_SET_KILLTRAN

--- a/msg/ko_KR.euckr/utils.msg
+++ b/msg/ko_KR.euckr/utils.msg
@@ -845,6 +845,7 @@ lockdb: 데이터베이스의 lock 정보 출력\n\
 \n\
 옵션:\n\
   -o, --output-file=FILE       출력 메시지를 재지정할 파일; 기본값: 없음\n
+  -c, --contention             display only lock information which has contention\n
 
 
 $set 26 MSGCAT_UTIL_SET_KILLTRAN

--- a/msg/ko_KR.euckr/utils.msg
+++ b/msg/ko_KR.euckr/utils.msg
@@ -844,7 +844,7 @@ lockdb: 데이터베이스의 lock 정보 출력\n\
 사용법: %1$s lockdb [옵션] <데이터베이스 이름>\n\
 \n\
 옵션:\n\
-  -o, --output-file=FILE       출력 메시지를 재지정할 파일; 기본값: 없음\n
+  -o, --output-file=FILE       출력 메시지를 재지정할 파일; 기본값: 없음\n\
   -c, --contention             display only lock information which has contention\n
 
 

--- a/msg/ko_KR.utf8/utils.msg
+++ b/msg/ko_KR.utf8/utils.msg
@@ -843,6 +843,7 @@ lockdb: 데이터베이스의 lock 정보 출력\n\
 \n\
 옵션:\n\
   -o, --output-file=FILE       출력 메시지를 재지정할 파일; 기본값: 없음\n
+  -c, --contention             display only lock information which has contention\n
 
 
 $set 26 MSGCAT_UTIL_SET_KILLTRAN

--- a/msg/ko_KR.utf8/utils.msg
+++ b/msg/ko_KR.utf8/utils.msg
@@ -842,7 +842,7 @@ lockdb: 데이터베이스의 lock 정보 출력\n\
 사용법: %1$s lockdb [옵션] <데이터베이스 이름>\n\
 \n\
 옵션:\n\
-  -o, --output-file=FILE       출력 메시지를 재지정할 파일; 기본값: 없음\n
+  -o, --output-file=FILE       출력 메시지를 재지정할 파일; 기본값: 없음\n\
   -c, --contention             display only lock information which has contention\n
 
 

--- a/msg/ro_RO.utf8/utils.msg
+++ b/msg/ro_RO.utf8/utils.msg
@@ -862,6 +862,7 @@ utilizare: %1$s lockdb [OPŢIUNI] nume-bază-de-date\n\
 \n\
 opţiuni valide:\n\
   -o, --output-file=FIŞIER    redirecţionează mesajele de ieşire către un FIŞIER; implicit: nul\n
+  -c, --contention             display only lock information which has contention\n
 
 
 $set 26 MSGCAT_UTIL_SET_KILLTRAN

--- a/msg/ro_RO.utf8/utils.msg
+++ b/msg/ro_RO.utf8/utils.msg
@@ -861,7 +861,7 @@ lockdb: Afişează situaţia lock-urilor bazei de date.\n\
 utilizare: %1$s lockdb [OPŢIUNI] nume-bază-de-date\n\
 \n\
 opţiuni valide:\n\
-  -o, --output-file=FIŞIER    redirecţionează mesajele de ieşire către un FIŞIER; implicit: nul\n
+  -o, --output-file=FIŞIER    redirecţionează mesajele de ieşire către un FIŞIER; implicit: nul\n\
   -c, --contention             display only lock information which has contention\n
 
 

--- a/msg/tr_TR.utf8/utils.msg
+++ b/msg/tr_TR.utf8/utils.msg
@@ -845,6 +845,7 @@ kullanım: %1$s lockdb [SEÇENEK] database-name\n\
 \n\
 geçerli seçenekler:\n\
   -o, --output-file=FILE      FILE çıktı mesajları yönlendirme; varsayılan: hiçbir\n
+  -c, --contention             display only lock information which has contention\n
 
 
 $set 26 MSGCAT_UTIL_SET_KILLTRAN

--- a/msg/tr_TR.utf8/utils.msg
+++ b/msg/tr_TR.utf8/utils.msg
@@ -844,7 +844,7 @@ lockdb: veritabanının kilit durumunu görüntüler.\n\
 kullanım: %1$s lockdb [SEÇENEK] database-name\n\
 \n\
 geçerli seçenekler:\n\
-  -o, --output-file=FILE      FILE çıktı mesajları yönlendirme; varsayılan: hiçbir\n
+  -o, --output-file=FILE      FILE çıktı mesajları yönlendirme; varsayılan: hiçbir\n\
   -c, --contention             display only lock information which has contention\n
 
 

--- a/msg/vi_VN.utf8/utils.msg
+++ b/msg/vi_VN.utf8/utils.msg
@@ -846,7 +846,7 @@ lockdb: Display lock-status of the database.\n\
 usage: %1$s lockdb [OPTION] database-name\n\
 \n\
 valid options:\n\
-  -o, --output-file=FILE       redirect output messages to FILE; default: none\n
+  -o, --output-file=FILE       redirect output messages to FILE; default: none\n\
   -c, --contention             display only lock information which has contention\n
 
 

--- a/msg/vi_VN.utf8/utils.msg
+++ b/msg/vi_VN.utf8/utils.msg
@@ -847,6 +847,7 @@ usage: %1$s lockdb [OPTION] database-name\n\
 \n\
 valid options:\n\
   -o, --output-file=FILE       redirect output messages to FILE; default: none\n
+  -c, --contention             display only lock information which has contention\n
 
 
 $set 26 MSGCAT_UTIL_SET_KILLTRAN

--- a/msg/zh_CN.utf8/utils.msg
+++ b/msg/zh_CN.utf8/utils.msg
@@ -843,7 +843,7 @@ lockdb: 显示数据库的锁状态.\n\
 用法: %1$s lockdb [选项] 数据库名\n\
 \n\
 可用选项:\n\
-  -o, --output-file=FILE       重定向输出信息到文件 FILE ; 默认: 空\n
+  -o, --output-file=FILE       重定向输出信息到文件 FILE ; 默认: 空\n\
   -c, --contention             display only lock information which has contention\n
 
 

--- a/msg/zh_CN.utf8/utils.msg
+++ b/msg/zh_CN.utf8/utils.msg
@@ -844,6 +844,7 @@ lockdb: 显示数据库的锁状态.\n\
 \n\
 可用选项:\n\
   -o, --output-file=FILE       重定向输出信息到文件 FILE ; 默认: 空\n
+  -c, --contention             display only lock information which has contention\n
 
 
 $set 26 MSGCAT_UTIL_SET_KILLTRAN

--- a/src/base/lock_free.h
+++ b/src/base/lock_free.h
@@ -390,6 +390,7 @@ class lf_hash_table_cpp
 
     size_t get_size () const;
     size_t get_element_count () const;
+    size_t get_alloc_element_count () const;
 
     lf_hash_table &get_hash_table ();
     lf_freelist &get_freelist ();
@@ -615,6 +616,13 @@ lf_hash_table_cpp<Key, T>::get_element_count () const
     {
       return 0;
     }
+}
+
+template <class Key, class T>
+size_t
+lf_hash_table_cpp<Key, T>::get_alloc_element_count () const
+{
+  return m_freelist.alloc_cnt;
 }
 
 template <class Key, class T>

--- a/src/base/lockfree_hashmap.hpp
+++ b/src/base/lockfree_hashmap.hpp
@@ -75,6 +75,7 @@ namespace lockfree
 
       size_t get_size () const;
       size_t get_element_count () const;
+      size_t get_alloc_element_count () const;
 
     private:
       using address_type = address_marker<T>;
@@ -455,6 +456,13 @@ namespace lockfree
   hashmap<Key, T>::get_element_count () const
   {
     return m_freelist->get_claimed_count ();
+  }
+
+  template <class Key, class T>
+  size_t
+  hashmap<Key, T>::get_alloc_element_count () const
+  {
+    return m_freelist->get_alloc_count ();
   }
 
   template <class Key, class T>

--- a/src/base/xserver_interface.h
+++ b/src/base/xserver_interface.h
@@ -242,7 +242,7 @@ extern int xcatalog_check_rep_dir (THREAD_ENTRY * thread_p, OID * class_id, OID 
 
 extern int xacl_reload (THREAD_ENTRY * thread_p);
 extern void xacl_dump (THREAD_ENTRY * thread_p, FILE * outfp);
-extern void xlock_dump (THREAD_ENTRY * thread_p, FILE * outfp);
+extern void xlock_dump (THREAD_ENTRY * thread_p, FILE * outfp, int is_contention);
 
 extern int xlogtb_get_pack_tran_table (THREAD_ENTRY * thread_p, char **buffer_p, int *size_p,
 				       int include_query_exec_info);

--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -3898,7 +3898,9 @@ lock_dump (FILE * outfp, int is_contention)
   ptr = request;
   ptr = or_pack_int (ptr, is_contention);
 
-  req_error = net_client_request_recv_stream (NET_SERVER_LK_DUMP, request, OR_ALIGNED_BUF_SIZE (a_request), NULL, 0, NULL, 0, outfp);
+  req_error =
+    net_client_request_recv_stream (NET_SERVER_LK_DUMP, request, OR_ALIGNED_BUF_SIZE (a_request), NULL, 0, NULL, 0,
+				    outfp);
 #else /* CS_MODE */
 
   THREAD_ENTRY *thread_p = enter_server ();

--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -3895,8 +3895,7 @@ lock_dump (FILE * outfp, int is_contention)
 
   request = OR_ALIGNED_BUF_START (a_request);
 
-  ptr = request;
-  ptr = or_pack_int (ptr, is_contention);
+  (void) or_pack_int (request, is_contention);
 
   req_error =
     net_client_request_recv_stream (NET_SERVER_LK_DUMP, request, OR_ALIGNED_BUF_SIZE (a_request), NULL, 0, NULL, 0,

--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -3881,22 +3881,29 @@ acl_dump (FILE * outfp)
  *   outfp(in):
  */
 void
-lock_dump (FILE * outfp)
+lock_dump (FILE * outfp, int is_contention)
 {
 #if defined(CS_MODE)
   int req_error;
+  OR_ALIGNED_BUF (OR_INT_SIZE) a_request;
+  char *request, *ptr;
 
   if (outfp == NULL)
     {
       outfp = stdout;
     }
 
-  req_error = net_client_request_recv_stream (NET_SERVER_LK_DUMP, NULL, 0, NULL, 0, NULL, 0, outfp);
+  request = OR_ALIGNED_BUF_START (a_request);
+
+  ptr = request;
+  ptr = or_pack_int (ptr, is_contention);
+
+  req_error = net_client_request_recv_stream (NET_SERVER_LK_DUMP, request, OR_ALIGNED_BUF_SIZE (a_request), NULL, 0, NULL, 0, outfp);
 #else /* CS_MODE */
 
   THREAD_ENTRY *thread_p = enter_server ();
 
-  xlock_dump (thread_p, outfp);
+  xlock_dump (thread_p, outfp, is_contention);
 
   exit_server (*thread_p);
 #endif /* !CS_MODE */

--- a/src/communication/network_interface_cl.h
+++ b/src/communication/network_interface_cl.h
@@ -190,7 +190,7 @@ extern const char *tran_get_tranlist_state_name (TRAN_STATE state);
 extern "C"
 {
 #endif
-  extern void lock_dump (FILE * outfp);
+  extern void lock_dump (FILE * outfp, int is_contention);
   extern void vacuum_dump (FILE * outfp);
 #ifdef __cplusplus
 }

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -2373,11 +2373,14 @@ slock_dump (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen
   int file_size;
   char *buffer;
   int buffer_size;
+  int is_contention;
   int send_size;
+  char *ptr;
   OR_ALIGNED_BUF (OR_INT_SIZE) a_reply;
   char *reply = OR_ALIGNED_BUF_START (a_reply);
 
-  (void) or_unpack_int (request, &buffer_size);
+  ptr = or_unpack_int (request, &buffer_size);
+  ptr = or_unpack_int (ptr, &is_contention);
 
   buffer = (char *) db_private_alloc (thread_p, buffer_size);
   if (buffer == NULL)
@@ -2395,7 +2398,7 @@ slock_dump (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen
       return;
     }
 
-  xlock_dump (thread_p, outfp);
+  xlock_dump (thread_p, outfp, is_contention);
   file_size = ftell (outfp);
 
   /*

--- a/src/executables/util_admin.c
+++ b/src/executables/util_admin.c
@@ -266,11 +266,13 @@ static GETOPT_LONG ua_Space_Option[] = {
 static UTIL_ARG_MAP ua_Lock_Option_Map[] = {
   {OPTION_STRING_TABLE, {0}, {0}},
   {LOCK_OUTPUT_FILE_S, {ARG_STRING}, {0}},
+  {LOCK_DISPLAY_CONTENTION_S, {ARG_BOOLEAN}, {0}},
   {0, {0}, {0}}
 };
 
 static GETOPT_LONG ua_Lock_Option[] = {
   {LOCK_OUTPUT_FILE_L, 1, 0, LOCK_OUTPUT_FILE_S},
+  {LOCK_DISPLAY_CONTENTION_L, 0, 0, LOCK_DISPLAY_CONTENTION_S},
   {0, 0, 0, 0}
 };
 

--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -1237,6 +1237,7 @@ lockdb (UTIL_FUNCTION_ARG * arg)
   const char *database_name;
   const char *output_file = NULL;
   FILE *outfp = NULL;
+  int is_contention;
 
   if (utility_get_option_string_table_size (arg_map) != 1)
     {
@@ -1249,6 +1250,7 @@ lockdb (UTIL_FUNCTION_ARG * arg)
       goto print_lock_usage;
     }
 
+  is_contention = utility_get_option_bool_value (arg_map, LOCK_DISPLAY_CONTENTION_S);
   output_file = utility_get_option_string_value (arg_map, LOCK_OUTPUT_FILE_S, 0);
   if (output_file == NULL)
     {
@@ -1287,7 +1289,7 @@ lockdb (UTIL_FUNCTION_ARG * arg)
 
   (void) db_set_isolation (TRAN_READ_COMMITTED);
 
-  lock_dump (outfp);
+  lock_dump (outfp, is_contention);
   db_shutdown ();
 
   if (outfp != stdout)

--- a/src/executables/util_front.c
+++ b/src/executables/util_front.c
@@ -137,6 +137,7 @@ static ARG_MAP_TABLE ua_Space_map[] = {
 
 static ARG_MAP_TABLE ua_Lock_map[] = {
   {"-o", "--" LOCK_OUTPUT_FILE_L},
+  {"-a", "--" LOCK_DISPLAY_CONTENTION_L},
   {0, 0}
 };
 

--- a/src/executables/util_front.c
+++ b/src/executables/util_front.c
@@ -137,7 +137,7 @@ static ARG_MAP_TABLE ua_Space_map[] = {
 
 static ARG_MAP_TABLE ua_Lock_map[] = {
   {"-o", "--" LOCK_OUTPUT_FILE_L},
-  {"-a", "--" LOCK_DISPLAY_CONTENTION_L},
+  {"-c", "--" LOCK_DISPLAY_CONTENTION_L},
   {0, 0}
 };
 

--- a/src/executables/utility.h
+++ b/src/executables/utility.h
@@ -1172,6 +1172,8 @@ typedef struct _ha_config
 /* lockdb option list */
 #define LOCK_OUTPUT_FILE_S                      'o'
 #define LOCK_OUTPUT_FILE_L                      "output-file"
+#define LOCK_DISPLAY_CONTENTION_S               'c'
+#define LOCK_DISPLAY_CONTENTION_L               "contention"
 
 /* optimizedb option list */
 #define OPTIMIZE_CLASS_NAME_S                   'n'

--- a/src/object/object_print.c
+++ b/src/object/object_print.c
@@ -666,7 +666,7 @@ help_print_info (const char *command, FILE * fpp)
     }
   else if (MATCH_TOKEN (buffer, "lock"))
     {
-      lock_dump (fpp);
+      lock_dump (fpp, 0);
     }
   else if (MATCH_TOKEN (buffer, "stats"))
     {

--- a/src/thread/thread_lockfree_hash_map.hpp
+++ b/src/thread/thread_lockfree_hash_map.hpp
@@ -67,6 +67,7 @@ namespace cubthread
 
       size_t get_size () const;
       size_t get_element_count () const;
+      size_t get_alloc_element_count () const;
 
     private:
       bool is_old_type () const;
@@ -282,6 +283,13 @@ namespace cubthread
   lockfree_hashmap<Key, T>::get_element_count () const
   {
     return is_old_type () ? m_old_hash.get_element_count () : m_new_hash.get_element_count ();
+  }
+
+  template <class Key, class T>
+  size_t
+  lockfree_hashmap<Key, T>::get_alloc_element_count () const
+  {
+    return is_old_type () ? m_old_hash.get_alloc_element_count () : m_new_hash.get_alloc_element_count ();
   }
 
 #undef lockfree_hashmap_forward_func

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -5250,7 +5250,7 @@ lock_dump_deadlock_victims (THREAD_ENTRY * thread_p, FILE * outfile)
 	}
     }
 
-  xlock_dump (thread_p, outfile);
+  xlock_dump (thread_p, outfile, 0/* is_contention */);
 }
 #endif /* SERVER_MODE */
 
@@ -8441,7 +8441,7 @@ lock_dump_acquired (FILE * fp, LK_ACQUIRED_LOCKS * acqlocks)
  *              level or modify the design of the application.
  */
 void
-xlock_dump (THREAD_ENTRY * thread_p, FILE * outfp)
+xlock_dump (THREAD_ENTRY * thread_p, FILE * outfp, int is_contention)
 {
 #if !defined (SERVER_MODE)
   return;
@@ -8456,7 +8456,7 @@ xlock_dump (THREAD_ENTRY * thread_p, FILE * outfp)
   int old_wait_msecs = 0;	/* Old transaction lock wait */
   int tran_index;
   LK_RES *res_ptr;
-  int num_locked;
+  int num_locked, num_alloc, size_alloc;
   float lock_timeout_sec;
   char lock_timeout_string[64];
 
@@ -8518,18 +8518,35 @@ xlock_dump (THREAD_ENTRY * thread_p, FILE * outfp)
 
   /* compute number of lock res entries */
   num_locked = (int) lk_Gl.m_obj_hash_table.get_element_count ();
+  num_alloc = (int) lk_Gl.obj_free_entry_list.alloc_cnt;
+  size_alloc = num_alloc * sizeof (LK_ENTRY);
 
   /* dump object lock table */
   fprintf (outfp, "Object Lock Table:\n");
   fprintf (outfp, "\tCurrent number of objects which are locked    = %d\n", num_locked);
-  fprintf (outfp, "\tMaximum number of objects which can be locked = %d\n\n", lk_Gl.max_obj_locks);
+  fprintf (outfp, "\tCurrent number of objects which are allocated = %d\n", num_alloc);
+  if (size_alloc < 1024)
+    {
+      fprintf (outfp, "\tCurrent size of objects which are allocated = %d\n\n", size_alloc);
+    }
+  else if (size_alloc >= 1024 && size_alloc < 1048576)
+    {
+      fprintf (outfp, "\tCurrent size of objects which are allocated = %dK\n\n", size_alloc/1024);
+    }
+  else
+    {
+      fprintf (outfp, "\tCurrent size of objects which are allocated = %dM\n\n", size_alloc/1024/1024);
+    }
 
   // *INDENT-OFF*
   lk_hashmap_iterator iterator { thread_p, lk_Gl.m_obj_hash_table };
   // *INDENT-ON*
   for (res_ptr = iterator.iterate (); res_ptr != NULL; res_ptr = iterator.iterate ())
     {
-      lock_dump_resource (thread_p, outfp, res_ptr);
+      if (!is_contention || (res_ptr->holder != NULL && res_ptr->holder->blocked_mode != NULL_LOCK) || res_ptr->waiter != NULL)
+	{
+	  lock_dump_resource (thread_p, outfp, res_ptr);
+	}
     }
 
   /* Reset the wait back to the way it was */

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -8526,17 +8526,17 @@ xlock_dump (THREAD_ENTRY * thread_p, FILE * outfp, int is_contention)
   fprintf (outfp, "Object Lock Table:\n");
   fprintf (outfp, "\tCurrent number of objects which are locked    = %d\n", num_locked);
   fprintf (outfp, "\tCurrent number of objects which are allocated = %d\n", num_resource_alloc);
-  if (size_alloc < 1024)
+  if (size_alloc < ONE_K)
     {
       fprintf (outfp, "\tCurrent size of objects which are allocated = %d\n\n", size_alloc);
     }
-  else if (size_alloc >= 1024 && size_alloc < 1048576)
+  else if (size_alloc >= ONE_K && size_alloc < ONE_M)
     {
-      fprintf (outfp, "\tCurrent size of objects which are allocated = %dK\n\n", size_alloc / 1024);
+      fprintf (outfp, "\tCurrent size of objects which are allocated = %dK\n\n", size_alloc / ONE_K);
     }
   else
     {
-      fprintf (outfp, "\tCurrent size of objects which are allocated = %dM\n\n", size_alloc / 1024 / 1024);
+      fprintf (outfp, "\tCurrent size of objects which are allocated = %dM\n\n", size_alloc / ONE_M);
     }
 
   // *INDENT-OFF*

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -5250,7 +5250,7 @@ lock_dump_deadlock_victims (THREAD_ENTRY * thread_p, FILE * outfile)
 	}
     }
 
-  xlock_dump (thread_p, outfile, 0/* is_contention */);
+  xlock_dump (thread_p, outfile, 0 /* is_contention */ );
 }
 #endif /* SERVER_MODE */
 
@@ -8532,11 +8532,11 @@ xlock_dump (THREAD_ENTRY * thread_p, FILE * outfp, int is_contention)
     }
   else if (size_alloc >= 1024 && size_alloc < 1048576)
     {
-      fprintf (outfp, "\tCurrent size of objects which are allocated = %dK\n\n", size_alloc/1024);
+      fprintf (outfp, "\tCurrent size of objects which are allocated = %dK\n\n", size_alloc / 1024);
     }
   else
     {
-      fprintf (outfp, "\tCurrent size of objects which are allocated = %dM\n\n", size_alloc/1024/1024);
+      fprintf (outfp, "\tCurrent size of objects which are allocated = %dM\n\n", size_alloc / 1024 / 1024);
     }
 
   // *INDENT-OFF*
@@ -8544,7 +8544,8 @@ xlock_dump (THREAD_ENTRY * thread_p, FILE * outfp, int is_contention)
   // *INDENT-ON*
   for (res_ptr = iterator.iterate (); res_ptr != NULL; res_ptr = iterator.iterate ())
     {
-      if (!is_contention || (res_ptr->holder != NULL && res_ptr->holder->blocked_mode != NULL_LOCK) || res_ptr->waiter != NULL)
+      if (!is_contention || (res_ptr->holder != NULL && res_ptr->holder->blocked_mode != NULL_LOCK)
+	  || res_ptr->waiter != NULL)
 	{
 	  lock_dump_resource (thread_p, outfp, res_ptr);
 	}

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -5250,7 +5250,7 @@ lock_dump_deadlock_victims (THREAD_ENTRY * thread_p, FILE * outfile)
 	}
     }
 
-  xlock_dump (thread_p, outfile, 0/* is_contention */);
+  xlock_dump (thread_p, outfile, 0 /* is_contention */ );
 }
 #endif /* SERVER_MODE */
 
@@ -8531,11 +8531,11 @@ xlock_dump (THREAD_ENTRY * thread_p, FILE * outfp, int is_contention)
     }
   else if (size_alloc >= 1024 && size_alloc < 1048576)
     {
-      fprintf (outfp, "\tCurrent size of objects which are allocated = %dK\n\n", size_alloc/1024);
+      fprintf (outfp, "\tCurrent size of objects which are allocated = %dK\n\n", size_alloc / 1024);
     }
   else
     {
-      fprintf (outfp, "\tCurrent size of objects which are allocated = %dM\n\n", size_alloc/1024/1024);
+      fprintf (outfp, "\tCurrent size of objects which are allocated = %dM\n\n", size_alloc / 1024 / 1024);
     }
 
   // *INDENT-OFF*
@@ -8543,7 +8543,8 @@ xlock_dump (THREAD_ENTRY * thread_p, FILE * outfp, int is_contention)
   // *INDENT-ON*
   for (res_ptr = iterator.iterate (); res_ptr != NULL; res_ptr = iterator.iterate ())
     {
-      if (!is_contention || (res_ptr->holder != NULL && res_ptr->holder->blocked_mode != NULL_LOCK) || res_ptr->waiter != NULL)
+      if (!is_contention || (res_ptr->holder != NULL && res_ptr->holder->blocked_mode != NULL_LOCK)
+	  || res_ptr->waiter != NULL)
 	{
 	  lock_dump_resource (thread_p, outfp, res_ptr);
 	}

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -8456,7 +8456,8 @@ xlock_dump (THREAD_ENTRY * thread_p, FILE * outfp, int is_contention)
   int old_wait_msecs = 0;	/* Old transaction lock wait */
   int tran_index;
   LK_RES *res_ptr;
-  int num_locked, num_entry_alloc, num_resource_alloc, size_alloc;
+  int num_locked, num_entry_alloc, num_resource_alloc;
+  UINT64 size_alloc;
   float lock_timeout_sec;
   char lock_timeout_string[64];
 
@@ -8520,7 +8521,7 @@ xlock_dump (THREAD_ENTRY * thread_p, FILE * outfp, int is_contention)
   num_locked = (int) lk_Gl.m_obj_hash_table.get_element_count ();
   num_resource_alloc = (int) lk_Gl.m_obj_hash_table.get_alloc_element_count ();
   num_entry_alloc = (int) lk_Gl.obj_free_entry_list.alloc_cnt;
-  size_alloc = (num_entry_alloc * sizeof (LK_ENTRY)) + (num_resource_alloc * sizeof (LK_RES));
+  size_alloc = ((UINT64) num_entry_alloc * sizeof (LK_ENTRY)) + ((UINT64) num_resource_alloc * sizeof (LK_RES));
 
   /* dump object lock table */
   fprintf (outfp, "Object Lock Table:\n");

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -8529,15 +8529,15 @@ xlock_dump (THREAD_ENTRY * thread_p, FILE * outfp, int is_contention)
   fprintf (outfp, "\tCurrent number of objects which are allocated = %d\n", num_resource_alloc);
   if (size_alloc < ONE_K)
     {
-      fprintf (outfp, "\tCurrent size of objects which are allocated = %d\n\n", size_alloc);
+      fprintf (outfp, "\tCurrent size of objects which are allocated = %llu\n\n", size_alloc);
     }
   else if (size_alloc >= ONE_K && size_alloc < ONE_M)
     {
-      fprintf (outfp, "\tCurrent size of objects which are allocated = %dK\n\n", size_alloc / ONE_K);
+      fprintf (outfp, "\tCurrent size of objects which are allocated = %lluK\n\n", size_alloc / ONE_K);
     }
   else
     {
-      fprintf (outfp, "\tCurrent size of objects which are allocated = %dM\n\n", size_alloc / ONE_M);
+      fprintf (outfp, "\tCurrent size of objects which are allocated = %lluM\n\n", size_alloc / ONE_M);
     }
 
   // *INDENT-OFF*


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24479

add 'Current number of objects which are allocated'
add 'Current size of objects which are allocated '
add -c (contention only) mode
