### PR TITLE
[CBRD-25152] Fix two bugs in the syntax

### DIFF
--- a/pl_engine/pl_server/src/main/antlr/PlcLexer.g4
+++ b/pl_engine/pl_server/src/main/antlr/PlcLexer.g4
@@ -158,7 +158,7 @@ PERIOD:   '.';
 FLOATING_POINT_NUM: FPNUM_W_POINT | FPNUM_WO_POINT;
 UNSIGNED_INTEGER:   BASIC_UINT;
 
-DELIMITED_ID: ('"' | '[' | '`') REGULAR_ID ('"' | ']' | '`') ;
+DELIMITED_ID: ('"' REGULAR_ID '"') | ('[' REGULAR_ID ']') | ('`' REGULAR_ID '`') ;
 CHAR_STRING: '\''  (~('\'' | '\r' | '\n') | '\'' '\'' | NEWLINE)* '\'';
 
 NULL_SAFE_EQUALS_OP:          '<=>';
@@ -215,6 +215,10 @@ SPACES: [ \t\r\n]+ -> channel(HIDDEN);
 // ************************
 mode STATIC_SQL;
 // ************************
+
+SS_SINGLE_LINE_COMMENT:    '--' ~('\r' | '\n')* NEWLINE_EOF                 -> channel(HIDDEN);
+SS_SINGLE_LINE_COMMENT2:   '//' ~('\r' | '\n')* NEWLINE_EOF                 -> channel(HIDDEN);
+SS_MULTI_LINE_COMMENT:     '/*' .*? '*/'                                    -> channel(HIDDEN);
 
 SS_SEMICOLON :  ';' {
         setType(PlcParser.SEMICOLON);

--- a/pl_engine/pl_server/src/main/antlr/PlcParser.g4
+++ b/pl_engine/pl_server/src/main/antlr/PlcParser.g4
@@ -155,12 +155,12 @@ else_part
     ;
 
 loop_statement
-    : label_declaration? LOOP seq_of_statements END LOOP                        # stmt_basic_loop
-    | label_declaration? WHILE expression LOOP seq_of_statements END LOOP       # stmt_while_loop
-    | label_declaration? FOR iterator LOOP seq_of_statements END LOOP           # stmt_for_iter_loop
-    | label_declaration? FOR for_cursor LOOP seq_of_statements END LOOP         # stmt_for_cursor_loop
-    | label_declaration? FOR for_static_sql LOOP seq_of_statements END LOOP     # stmt_for_static_sql_loop
-    | label_declaration? FOR for_dynamic_sql LOOP seq_of_statements END LOOP    # stmt_for_dynamic_sql_loop
+    : label_declaration? LOOP seq_of_statements END LOOP label_name?                       # stmt_basic_loop
+    | label_declaration? WHILE expression LOOP seq_of_statements END LOOP label_name?      # stmt_while_loop
+    | label_declaration? FOR iterator LOOP seq_of_statements END LOOP label_name?          # stmt_for_iter_loop
+    | label_declaration? FOR for_cursor LOOP seq_of_statements END LOOP label_name?        # stmt_for_cursor_loop
+    | label_declaration? FOR for_static_sql LOOP seq_of_statements END LOOP label_name?    # stmt_for_static_sql_loop
+    | label_declaration? FOR for_dynamic_sql LOOP seq_of_statements END LOOP label_name?   # stmt_for_dynamic_sql_loop
     ;
 
  // actually far more complicated according to the Spec.
@@ -413,7 +413,7 @@ err_msg
     ;
 
 simple_case_statement
-    : CASE expression simple_case_statement_when_part+  case_statement_else_part? END CASE
+    : CASE expression simple_case_statement_when_part+  case_statement_else_part? END CASE label_name?
     ;
 
 simple_case_statement_when_part
@@ -421,7 +421,7 @@ simple_case_statement_when_part
     ;
 
 searched_case_statement
-    : CASE searched_case_statement_when_part+ case_statement_else_part? END CASE
+    : CASE searched_case_statement_when_part+ case_statement_else_part? END CASE label_name?
     ;
 
 searched_case_statement_when_part


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25152

-  fix two bugs in the lexer rules
    - fix DELIMITED_ID rule
    - add lexer rules for comment in Static SQL
- add optional label_name after END LOOP and END CASE in the parser syntax for Oracle compatibility

