### PR TITLE
[CBRD-25162] Change the BTREE_RV_GET_DATA_LENGTH() function to a macro

### DIFF
--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -5300,7 +5300,7 @@ scan_next_heap_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 	}
 
       if (is_peeking == PEEK && hsidp->scan_cache.page_watcher.pgptr != NULL
-	  && PGBUF_PAGE_HAS_CHANGED (hsidp->scan_cache.page_watcher.pgptr, &ref_lsa))
+	  && PGBUF_IS_PAGE_CHANGED (hsidp->scan_cache.page_watcher.pgptr, &ref_lsa))
 	{
 	  is_peeking = COPY;
 	  COPY_OID (&hsidp->curr_oid, &retry_oid);
@@ -5476,7 +5476,7 @@ scan_next_heap_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 
 	      if (object_get_status == OBJ_REPEAT_GET_WITH_LOCK
 		  || (hsidp->scan_cache.page_watcher.pgptr != NULL
-		      && PGBUF_PAGE_HAS_CHANGED (hsidp->scan_cache.page_watcher.pgptr, &ref_lsa)))
+		      && PGBUF_IS_PAGE_CHANGED (hsidp->scan_cache.page_watcher.pgptr, &ref_lsa)))
 		{
 		  is_peeking = COPY;
 		  COPY_OID (&hsidp->curr_oid, &retry_oid);
@@ -5497,7 +5497,7 @@ scan_next_heap_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 	    }
 
 	  if (is_peeking == PEEK && hsidp->scan_cache.page_watcher.pgptr != NULL
-	      && PGBUF_PAGE_HAS_CHANGED (hsidp->scan_cache.page_watcher.pgptr, &ref_lsa))
+	      && PGBUF_IS_PAGE_CHANGED (hsidp->scan_cache.page_watcher.pgptr, &ref_lsa))
 	    {
 	      is_peeking = COPY;
 	      COPY_OID (&hsidp->curr_oid, &retry_oid);
@@ -5514,7 +5514,7 @@ scan_next_heap_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 		}
 
 	      if (is_peeking != 0 && hsidp->scan_cache.page_watcher.pgptr != NULL
-		  && PGBUF_PAGE_HAS_CHANGED (hsidp->scan_cache.page_watcher.pgptr, &ref_lsa))
+		  && PGBUF_IS_PAGE_CHANGED (hsidp->scan_cache.page_watcher.pgptr, &ref_lsa))
 		{
 		  is_peeking = COPY;
 		  COPY_OID (&hsidp->curr_oid, &retry_oid);
@@ -5535,7 +5535,7 @@ scan_next_heap_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 		}
 
 	      if (is_peeking == PEEK && hsidp->scan_cache.page_watcher.pgptr != NULL
-		  && PGBUF_PAGE_HAS_CHANGED (hsidp->scan_cache.page_watcher.pgptr, &ref_lsa))
+		  && PGBUF_IS_PAGE_CHANGED (hsidp->scan_cache.page_watcher.pgptr, &ref_lsa))
 		{
 		  is_peeking = COPY;
 		  COPY_OID (&hsidp->curr_oid, &retry_oid);

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -5300,7 +5300,7 @@ scan_next_heap_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 	}
 
       if (is_peeking == PEEK && hsidp->scan_cache.page_watcher.pgptr != NULL
-	  && pgbuf_page_has_changed (hsidp->scan_cache.page_watcher.pgptr, &ref_lsa))
+	  && PGBUF_PAGE_HAS_CHANGED (hsidp->scan_cache.page_watcher.pgptr, &ref_lsa))
 	{
 	  is_peeking = COPY;
 	  COPY_OID (&hsidp->curr_oid, &retry_oid);
@@ -5476,7 +5476,7 @@ scan_next_heap_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 
 	      if (object_get_status == OBJ_REPEAT_GET_WITH_LOCK
 		  || (hsidp->scan_cache.page_watcher.pgptr != NULL
-		      && pgbuf_page_has_changed (hsidp->scan_cache.page_watcher.pgptr, &ref_lsa)))
+		      && PGBUF_PAGE_HAS_CHANGED (hsidp->scan_cache.page_watcher.pgptr, &ref_lsa)))
 		{
 		  is_peeking = COPY;
 		  COPY_OID (&hsidp->curr_oid, &retry_oid);
@@ -5497,7 +5497,7 @@ scan_next_heap_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 	    }
 
 	  if (is_peeking == PEEK && hsidp->scan_cache.page_watcher.pgptr != NULL
-	      && pgbuf_page_has_changed (hsidp->scan_cache.page_watcher.pgptr, &ref_lsa))
+	      && PGBUF_PAGE_HAS_CHANGED (hsidp->scan_cache.page_watcher.pgptr, &ref_lsa))
 	    {
 	      is_peeking = COPY;
 	      COPY_OID (&hsidp->curr_oid, &retry_oid);
@@ -5514,7 +5514,7 @@ scan_next_heap_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 		}
 
 	      if (is_peeking != 0 && hsidp->scan_cache.page_watcher.pgptr != NULL
-		  && pgbuf_page_has_changed (hsidp->scan_cache.page_watcher.pgptr, &ref_lsa))
+		  && PGBUF_PAGE_HAS_CHANGED (hsidp->scan_cache.page_watcher.pgptr, &ref_lsa))
 		{
 		  is_peeking = COPY;
 		  COPY_OID (&hsidp->curr_oid, &retry_oid);
@@ -5535,7 +5535,7 @@ scan_next_heap_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 		}
 
 	      if (is_peeking == PEEK && hsidp->scan_cache.page_watcher.pgptr != NULL
-		  && pgbuf_page_has_changed (hsidp->scan_cache.page_watcher.pgptr, &ref_lsa))
+		  && PGBUF_PAGE_HAS_CHANGED (hsidp->scan_cache.page_watcher.pgptr, &ref_lsa))
 		{
 		  is_peeking = COPY;
 		  COPY_OID (&hsidp->curr_oid, &retry_oid);

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -1043,7 +1043,7 @@ const size_t BTREE_RV_BUFFER_SIZE =
 #endif /* !NDEBUG */
 
 #if defined (NDEBUG)
-#define BTREE_RV_GET_DATA_LENGTH (rv_ptr, rv_start, rv_length)  (rv_length) = CAST_BUFLEN ((rv_ptr) - (rv_start))
+#define BTREE_RV_GET_DATA_LENGTH(rv_ptr, rv_start, rv_length)  (rv_length) = CAST_BUFLEN ((rv_ptr) - (rv_start))
 #else
 static void
 BTREE_RV_GET_DATA_LENGTH (const char *rv_ptr, const char *rv_start, int &rv_length)

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -1042,6 +1042,9 @@ const size_t BTREE_RV_BUFFER_SIZE =
   (4 * LOG_RV_RECORD_UPDPARTIAL_ALIGNED_SIZE (BTREE_OBJECT_MAX_SIZE) + BTREE_RV_DEBUG_INFO_MAX_SIZE);
 #endif /* !NDEBUG */
 
+#if defined (NDEBUG)
+#define BTREE_RV_GET_DATA_LENGTH (rv_ptr, rv_start, rv_length)  (rv_length) = CAST_BUFLEN ((rv_ptr) - (rv_start))
+#else
 static void
 BTREE_RV_GET_DATA_LENGTH (const char *rv_ptr, const char *rv_start, int &rv_length)
 {
@@ -1050,6 +1053,7 @@ BTREE_RV_GET_DATA_LENGTH (const char *rv_ptr, const char *rv_start, int &rv_leng
   rv_length = CAST_BUFLEN (rv_ptr - rv_start);
   assert (0 <= rv_length && (size_t) rv_length <= BTREE_RV_BUFFER_SIZE);
 }
+#endif
 
 /* Debug identifiers to help with detecting recovery issues. */
 enum btree_rv_debug_id

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -4346,25 +4346,6 @@ pgbuf_get_lsa (PAGE_PTR pgptr)
 }
 
 /*
- * pgbuf_page_has_changed () - check if page has change based on current LSA and a previous reference LSA
- *   return: page lsa
- *   pgptr(in): Pointer to page
- */
-int
-pgbuf_page_has_changed (PAGE_PTR pgptr, LOG_LSA * ref_lsa)
-{
-  LOG_LSA curr_lsa;
-
-  LSA_COPY (&curr_lsa, pgbuf_get_lsa (pgptr));
-
-  if (!LSA_EQ (ref_lsa, &curr_lsa))
-    {
-      return 1;
-    }
-  return 0;
-}
-
-/*
  * pgbuf_set_lsa () - Set the log sequence address of the page to the given lsa
  *   return: page lsa or NULL
  *   pgptr(in): Pointer to page

--- a/src/storage/page_buffer.h
+++ b/src/storage/page_buffer.h
@@ -167,7 +167,7 @@ extern const VPID vpid_Null_vpid;
   ((ptype) == PAGE_HEAP || (ptype) == PAGE_OVERFLOW)
 
 // check if page has change based on current LSA and a previous reference LSA 
-#define PGBUF_PAGE_HAS_CHANGED(pgptr, ref_lsa)    (!LSA_EQ ((ref_lsa), pgbuf_get_lsa ((pgptr))))
+#define PGBUF_IS_PAGE_CHANGED(pgptr, ref_lsa)    (!LSA_EQ ((ref_lsa), pgbuf_get_lsa ((pgptr))))
 
 typedef enum
 {

--- a/src/storage/page_buffer.h
+++ b/src/storage/page_buffer.h
@@ -166,6 +166,8 @@ extern const VPID vpid_Null_vpid;
 #define PGBUF_IS_ORDERED_PAGETYPE(ptype) \
   ((ptype) == PAGE_HEAP || (ptype) == PAGE_OVERFLOW)
 
+// check if page has change based on current LSA and a previous reference LSA 
+#define PGBUF_PAGE_HAS_CHANGED(pgptr, ref_lsa)    (!LSA_EQ ((ref_lsa), pgbuf_get_lsa ((pgptr))))
 
 typedef enum
 {
@@ -367,7 +369,6 @@ extern void pgbuf_set_dirty (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, bool free_
 #define pgbuf_set_dirty_and_free(thread_p, pgptr) pgbuf_set_dirty (thread_p, pgptr, FREE); pgptr = NULL
 
 extern LOG_LSA *pgbuf_get_lsa (PAGE_PTR pgptr);
-extern int pgbuf_page_has_changed (PAGE_PTR pgptr, LOG_LSA * ref_lsa);
 
 #if !defined(NDEBUG)
 #define pgbuf_set_lsa(...)   pgbuf_set_lsa_debug(__VA_ARGS__, ARG_FILE_LINE_FUNC)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25162

* In Release mode, change BTREE_RV_GET_DATA_LENGTH(), which has no meaning as a function, to a macro.
* change pgbuf_page_has_changed() to macro PGBUF_PAGE_HAS_CHANGED()
