### PR TITLE
[CBRD-25152] preserve comments for hints

### DIFF
--- a/pl_engine/pl_server/src/main/antlr/PlcLexer.g4
+++ b/pl_engine/pl_server/src/main/antlr/PlcLexer.g4
@@ -216,9 +216,10 @@ SPACES: [ \t\r\n]+ -> channel(HIDDEN);
 mode STATIC_SQL;
 // ************************
 
-SS_SINGLE_LINE_COMMENT:    '--' ~('\r' | '\n')* NEWLINE_EOF                 -> channel(HIDDEN);
-SS_SINGLE_LINE_COMMENT2:   '//' ~('\r' | '\n')* NEWLINE_EOF                 -> channel(HIDDEN);
-SS_MULTI_LINE_COMMENT:     '/*' .*? '*/'                                    -> channel(HIDDEN);
+// Do not drop comments because they can have a hint.
+SS_SINGLE_LINE_COMMENT:    '--' ~('\r' | '\n')* NEWLINE_EOF     { setType(PlcParser.SS_NON_STR); } ;
+SS_SINGLE_LINE_COMMENT2:   '//' ~('\r' | '\n')* NEWLINE_EOF     { setType(PlcParser.SS_NON_STR); } ;
+SS_MULTI_LINE_COMMENT:     '/*' .*? '*/'                        { setType(PlcParser.SS_NON_STR); } ;
 
 SS_SEMICOLON :  ';' {
         setType(PlcParser.SEMICOLON);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25152

In the last commit, the comments in Static SQLs are dropped, which may cause a problem in case the comment contains hints.
This commit makes a change so that the comments are not dropped and handed over to the parser.

For example
```
create or replace procedure poo as
     cursor c is
         SELECT /*+ USE_NL ORDERED  */ a.name, b.host_year, b.medal
         FROM athlete a, game b
         WHERE a.name = 'Sim Kwon Ho' AND a.code = b.athlete_code;
 begin
     null;
 end;
```
are now translated to 
```
public class Proc_POO {
  public static void POO(
    ) throws Exception {
    try {
      Long[] sql_rowcount = new Long[] { null };
      Connection conn = DriverManager.getConnection("jdbc:default:connection::?autonomous_transaction=false");
      class Decl_of_poo_2 {
        Decl_of_poo_2() throws Exception {};
        final Query C = new Query("select /*+ ORDERED USE_NL */ a.[name], b.host_year, b.medal from [dba.athlete] a, [dba.game] b where a.code=b.athlete_code and a.[name]= ?:0 "); // param-ref-counts: [], param-marks: [0]
      }
      Decl_of_poo_2 poo_2 = new Decl_of_poo_2();
      ;
    } catch (PlcsqlRuntimeError e) {
      Throwable c = e.getCause();
      int[] pos = getPlcLineColumn(codeRangeMarkerList, c == null ? e : c, "Proc_POO.java");
      throw e.setPlcLineColumn(pos);
    } catch (OutOfMemoryError e) {
      Server.log(e);
      int[] pos = getPlcLineColumn(codeRangeMarkerList, e, "Proc_POO.java");
      throw new STORAGE_ERROR().setPlcLineColumn(pos);
    } catch (Throwable e) {
      Server.log(e);
      int[] pos = getPlcLineColumn(codeRangeMarkerList, e, "Proc_POO.java");
      throw new PROGRAM_ERROR().setPlcLineColumn(pos);
    }
  }
  private static List<CodeRangeMarker> codeRangeMarkerList = buildCodeRangeMarkerList(" (1,1,1 (14,2,5 )15 (17,7,5 )18 )32");
}

```
