### PR TITLE
[CBRD-25148] 11.3, fix ux_execute_arrary mem leak

### DIFF
--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -2584,7 +2584,7 @@ ux_execute_array (T_SRV_HANDLE * srv_handle, int argc, void **argv, T_NET_BUF * 
 {
   DB_VALUE *value_list = NULL;
   int err_code;
-  int i, num_bind = 0;
+  int i, num_bind_params, num_bind = 0;
   int num_markers;
   int stmt_id = -1;
   int first_value;
@@ -2645,7 +2645,7 @@ ux_execute_array (T_SRV_HANDLE * srv_handle, int argc, void **argv, T_NET_BUF * 
     {
       goto return_success;
     }
-  num_bind = argc / 2;
+  num_bind_params = num_bind = argc / 2;
 
   err_code = make_bind_value (num_bind, argc, argv, &value_list, net_buf, DB_TYPE_NULL);
   if (err_code < 0)
@@ -2830,7 +2830,7 @@ ux_execute_array (T_SRV_HANDLE * srv_handle, int argc, void **argv, T_NET_BUF * 
 
   if (value_list)
     {
-      for (i = 0; i < num_bind; i++)
+      for (i = 0; i < num_bind_params; i++)
 	{
 	  db_value_clear (&(value_list[i]));
 	}
@@ -2863,7 +2863,7 @@ execute_array_error:
 
   if (value_list)
     {
-      for (i = 0; i < num_bind; i++)
+      for (i = 0; i < num_bind_params; i++)
 	{
 	  db_value_clear (&(value_list[i]));
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25148

**Description**
* This is backport of #4863 to release/11.3
  * Avoid definite/possible memory leak at ux_execute_array () for temporary positional parameter values of type DB_VALUE array.