### PR TITLE
[CBRD-25164] Fix error in covered index query results using function indexes

### DIFF
--- a/src/query/query_evaluator.c
+++ b/src/query/query_evaluator.c
@@ -2824,6 +2824,8 @@ eval_key_filter (THREAD_ENTRY * thread_p, DB_VALUE * value, FILTER_INFO * filter
     {
       if (DB_VALUE_TYPE (value) == DB_TYPE_MIDXKEY)
 	{
+	  int func_idx_col_id = filterp->func_idx_col_id;
+
 	  midxkey = db_get_midxkey (value);
 
 	  if (filterp->btree_num_attrs <= 0 || !filterp->btree_attr_ids || !midxkey)
@@ -2833,6 +2835,11 @@ eval_key_filter (THREAD_ENTRY * thread_p, DB_VALUE * value, FILTER_INFO * filter
 
 	  prev_j_index = 0;
 	  prev_j_ptr = NULL;
+
+	  if (func_idx_col_id == -1)
+	    {
+	      func_idx_col_id = filterp->btree_num_attrs + 1;
+	    }
 
 	  /* for all attributes specified in the filter */
 	  for (i = 0; i < scan_attrsp->num_attrs; i++)
@@ -2859,13 +2866,9 @@ eval_key_filter (THREAD_ENTRY * thread_p, DB_VALUE * value, FILTER_INFO * filter
 		      return V_ERROR;
 		    }
 
-		  if (filterp->func_idx_col_id != -1 && j > filterp->func_idx_col_id)
-		    {
-		      j = j + 1;
-		    }
-
 		  /* get j-th element value from the midxkey */
-		  if (pr_midxkey_get_element_nocopy (midxkey, j, valp, &prev_j_index, &prev_j_ptr) != NO_ERROR)
+		  if (pr_midxkey_get_element_nocopy (midxkey, ((j < func_idx_col_id) ? j : j + 1),
+						     valp, &prev_j_index, &prev_j_ptr) != NO_ERROR)
 		    {
 		      return V_ERROR;
 		    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25164

* Fix error in covered index query results using function indexes
 - This problem occurs because the value is not properly obtained during the key filtering process.
 
 * test query
```
drop table if exists tx;
create table tx (id int, v1 int, v2 int, v3 int);
insert into tx values(1,1,10,100), (2,2,20,200);

create index idx on tx(v1,  ln(v2), v3);
select v3 from tx where v1 = 1 and v3 = 100;

drop index idx on tx;
create index idx on tx(v1,  ln(v1), v3);
select v3 from tx where v1 = 1 and v3 = 100;

drop index idx on tx;
create index idx on tx(v1,  ln(v1), v3, v2);
select v2 from tx where v1 = 1 and v3 = 100;

drop index idx on tx;
create index idx on tx(ln(v1), v2, v3);
select v2 from tx where ln(v1) > 0 and v3 = 100;
```
