### PR TITLE
[CBRD-25151] Compiler fails to give line and column numbers for a semantic error

### DIFF
--- a/pl_engine/pl_server/src/main/antlr/PlcLexer.g4
+++ b/pl_engine/pl_server/src/main/antlr/PlcLexer.g4
@@ -208,7 +208,7 @@ SINGLE_LINE_COMMENT:    '--' ~('\r' | '\n')* NEWLINE_EOF                 -> chan
 SINGLE_LINE_COMMENT2:   '//' ~('\r' | '\n')* NEWLINE_EOF                 -> channel(HIDDEN);
 MULTI_LINE_COMMENT:     '/*' .*? '*/'                                    -> channel(HIDDEN);
 
-REGULAR_ID: SIMPLE_LETTER (SIMPLE_LETTER | '_' | [0-9])*;
+REGULAR_ID: (SIMPLE_LETTER | '_') (SIMPLE_LETTER | '_' | [0-9])*;
 
 SPACES: [ \t\r\n]+ -> channel(HIDDEN);
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -158,10 +158,7 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
                                     + " must be assignable to because it is to an OUT parameter");
                 }
 
-                TypeSpecSimple retType =
-                        DBTypeAdapter.getDeclTypeSpec(
-                                fs.retType.type, fs.retType.prec, fs.retType.scale);
-                if (retType == null) {
+                if (!DBTypeAdapter.isSupported(fs.retType.type)) {
                     String sqlType = DBTypeAdapter.getSqlTypeName(fs.retType.type);
                     throw new SemanticError( // s418
                             Misc.getLineColumnOf(node.ctx),
@@ -169,6 +166,10 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
                                     + sqlType
                                     + " as its return type");
                 }
+
+                TypeSpecSimple retType =
+                        DBTypeAdapter.getDeclTypeSpec(
+                                fs.retType.type, fs.retType.prec, fs.retType.scale);
                 addToImports(retType.fullJavaType);
 
                 gfc.decl = new DeclFunc(null, fs.name, paramList, retType);
@@ -180,10 +181,7 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
             } else if (q instanceof ServerAPI.ColumnType) {
                 ServerAPI.ColumnType ct = (ServerAPI.ColumnType) q;
 
-                TypeSpecSimple ty =
-                        DBTypeAdapter.getDeclTypeSpec(
-                                ct.colType.type, ct.colType.prec, ct.colType.scale);
-                if (ty == null) {
+                if (!DBTypeAdapter.isSupported(ct.colType.type)) {
                     String sqlType = DBTypeAdapter.getSqlTypeName(ct.colType.type);
                     throw new SemanticError( // s410
                             Misc.getLineColumnOf(node.ctx),
@@ -194,6 +192,10 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
                                     + " has an unsupported type "
                                     + sqlType);
                 }
+
+                TypeSpecSimple ty =
+                        DBTypeAdapter.getDeclTypeSpec(
+                                ct.colType.type, ct.colType.prec, ct.colType.scale);
                 addToImports(ty.fullJavaType);
 
                 assert node instanceof TypeSpecPercent;
@@ -306,7 +308,7 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
             }
             String column = Misc.getNormalizedText(ctx.identifier());
 
-            TypeSpec ret = new TypeSpecPercent(table, column);
+            TypeSpec ret = new TypeSpecPercent(ctx, table, column);
             semanticQuestions.put(ret, new ServerAPI.ColumnType(table, column));
             return ret;
         }
@@ -2578,12 +2580,13 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
         int len = params.length;
         for (int i = 0; i < len; i++) {
 
-            TypeSpecSimple paramType =
-                    DBTypeAdapter.getDeclTypeSpec(params[i].type, params[i].prec, params[i].scale);
-            if (paramType == null) {
+            if (!DBTypeAdapter.isSupported(params[i].type)) {
                 String sqlType = DBTypeAdapter.getSqlTypeName(params[i].type);
                 return name + " uses unsupported type " + sqlType + " for parameter " + (i + 1);
             }
+
+            TypeSpecSimple paramType =
+                    DBTypeAdapter.getDeclTypeSpec(params[i].type, params[i].prec, params[i].scale);
             addToImports(paramType.fullJavaType);
 
             if ((params[i].mode & ServerConstants.PARAM_MODE_OUT) != 0) {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprFalse.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprFalse.java
@@ -41,7 +41,7 @@ public class ExprFalse extends Expr {
     }
 
     public ExprFalse(ParserRuleContext ctx) {
-        super(null);
+        super(ctx);
     }
 
     public String javaCode() {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/TypeSpec.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/TypeSpec.java
@@ -30,6 +30,8 @@
 
 package com.cubrid.plcsql.compiler.ast;
 
+import org.antlr.v4.runtime.ParserRuleContext;
+
 public abstract class TypeSpec extends AstNode {
 
     public final String plcName;
@@ -37,9 +39,10 @@ public abstract class TypeSpec extends AstNode {
     public final int simpleTypeIdx;
     public final String typicalValueStr; // used to type builtin function calls
 
-    public TypeSpec(String plcName, String javaCode, int simpleTypeIdx, String typicalValueStr) {
+    public TypeSpec(ParserRuleContext ctx,
+            String plcName, String javaCode, int simpleTypeIdx, String typicalValueStr) {
 
-        super(null);
+        super(ctx);
         this.plcName = plcName;
         this.javaCode = javaCode;
         this.simpleTypeIdx = simpleTypeIdx;

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/TypeSpec.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/TypeSpec.java
@@ -39,8 +39,12 @@ public abstract class TypeSpec extends AstNode {
     public final int simpleTypeIdx;
     public final String typicalValueStr; // used to type builtin function calls
 
-    public TypeSpec(ParserRuleContext ctx,
-            String plcName, String javaCode, int simpleTypeIdx, String typicalValueStr) {
+    public TypeSpec(
+            ParserRuleContext ctx,
+            String plcName,
+            String javaCode,
+            int simpleTypeIdx,
+            String typicalValueStr) {
 
         super(ctx);
         this.plcName = plcName;

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/TypeSpecPercent.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/TypeSpecPercent.java
@@ -31,6 +31,7 @@
 package com.cubrid.plcsql.compiler.ast;
 
 import com.cubrid.plcsql.compiler.visitor.AstVisitor;
+import org.antlr.v4.runtime.ParserRuleContext;
 
 public class TypeSpecPercent extends TypeSpec {
 
@@ -44,8 +45,8 @@ public class TypeSpecPercent extends TypeSpec {
     public final String table;
     public final String column;
 
-    public TypeSpecPercent(String table, String column) {
-        super(null, null, -1, null);
+    public TypeSpecPercent(ParserRuleContext ctx, String table, String column) {
+        super(ctx, null, null, -1, null);
         this.table = table;
         this.column = column;
     }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/TypeSpecSimple.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/TypeSpecSimple.java
@@ -149,7 +149,7 @@ public class TypeSpecSimple extends TypeSpec {
 
     protected TypeSpecSimple(
             String plcName, String fullJavaType, int simpleTypeIdx, String typicalValueStr) {
-        super(plcName, getJavaCode(fullJavaType), simpleTypeIdx, typicalValueStr);
+        super(null, plcName, getJavaCode(fullJavaType), simpleTypeIdx, typicalValueStr);
         this.fullJavaType = fullJavaType;
     }
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/TypeSpecVariadic.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/TypeSpecVariadic.java
@@ -74,7 +74,7 @@ public class TypeSpecVariadic extends TypeSpec {
     }
 
     public TypeSpecVariadic(TypeSpecSimple elem) {
-        super(null, null, -1, null);
+        super(null, null, null, -1, null);
         this.elem = elem;
     }
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25151

(1) set corresponding parse tree nodes to AST nodes of types TypeSpecPercent and ExprFalse
        . in order to get the line and column numbers for semantic errors related to the nodes.
        . NOTE: parse tree nodes has been omitted for those two types of AST nodes because they were considered singleton classes
(2) minor refinements
        . check if a type informed by the server is supported or not before getting their internal representation.
        . fix identifier lexer rule; allow underscore for the first letter of identifiers as CUBRID parser does.