### PR TITLE
[CBRD-25170] Mistaking NULL return of a built-in function as the default value of the return type

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprField.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprField.java
@@ -66,13 +66,13 @@ public class ExprField extends Expr {
             //
             assert type != null;
             return String.format(
-                    "(%s) %s.getObject(%d)", type.javaCode, record.javaCode(), colIndex);
+                    "(%s) getFieldWithIndex(%s, %d)", type.javaCode, record.javaCode(), colIndex);
         } else {
 
             // record is for a Dynamic SQL
             //
             assert type == null;
-            return String.format("%s.getObject(\"%s\")", record.javaCode(), fieldName);
+            return String.format("getFieldWithName(%s, \"%s\")", record.javaCode(), fieldName);
         }
     }
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -1162,9 +1162,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
             Coercion c = node.coercions.get(i);
             String idCode = id.javaCode();
             ret.add(String.format("%s = %s;", idCode, c.javaCode(resultStr)));
-            ret.add(
-                    String.format(
-                            "if (%s != null && rs.wasNull()) { %s = null; }", idCode, idCode));
+            ret.add(String.format("if (%1$s != null && rs.wasNull()) { %1$s = null; }", idCode));
 
             i++;
         }
@@ -1330,8 +1328,8 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
             ret.add(String.format("%s = %s;", idCode, c.javaCode(resultStr)));
             ret.add(
                     String.format(
-                            "if (%s != null && r%%'LEVEL'%%.wasNull()) { %s = null; }",
-                            idCode, idCode));
+                            "if (%1$s != null && r%%'LEVEL'%%.wasNull()) { %1$s = null; }",
+                            idCode));
 
             if ((id.decl instanceof DeclVar) && ((DeclVar) id.decl).notNull) {
                 ret.add(

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -810,6 +810,9 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 "      ResultSet r = stmt.executeQuery();",
                 "      if (r.next()) {",
                 "        ret = r.getBigDecimal(1);",
+                "        if (ret != null && r.wasNull()) {",
+                "          ret = null;",
+                "        }",
                 "      } else {",
                 "        ret = null;",
                 "      }",
@@ -1157,7 +1160,9 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
             }
 
             Coercion c = node.coercions.get(i);
-            ret.add(String.format("%s = %s;", id.javaCode(), c.javaCode(resultStr)));
+            String idCode = id.javaCode();
+            ret.add(String.format("%s = %s;", idCode, c.javaCode(resultStr)));
+            ret.add(String.format("if (%s != null && rs.wasNull()) { %s = null; }", idCode, idCode));
 
             i++;
         }
@@ -1319,14 +1324,12 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
             }
 
             Coercion c = node.coercions.get(i);
-            boolean checkNotNull = (id.decl instanceof DeclVar) && ((DeclVar) id.decl).notNull;
-            if (checkNotNull) {
-                ret.add(
-                        String.format(
-                                "%s = checkNotNull(%s, \"NOT NULL constraint violated\");",
-                                id.javaCode(), c.javaCode(resultStr)));
-            } else {
-                ret.add(String.format("%s = %s;", id.javaCode(), c.javaCode(resultStr)));
+            String idCode = id.javaCode();
+            ret.add(String.format("%s = %s;", idCode, c.javaCode(resultStr)));
+            ret.add(String.format("if (%s != null && r%%'LEVEL'%%.wasNull()) { %s = null; }", idCode, idCode));
+
+            if ((id.decl instanceof DeclVar) && ((DeclVar) id.decl).notNull) {
+                ret.add(String.format( "checkNotNull(%s, \"NOT NULL constraint violated\");", idCode));
             }
 
             i++;

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -1162,7 +1162,9 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
             Coercion c = node.coercions.get(i);
             String idCode = id.javaCode();
             ret.add(String.format("%s = %s;", idCode, c.javaCode(resultStr)));
-            ret.add(String.format("if (%s != null && rs.wasNull()) { %s = null; }", idCode, idCode));
+            ret.add(
+                    String.format(
+                            "if (%s != null && rs.wasNull()) { %s = null; }", idCode, idCode));
 
             i++;
         }
@@ -1326,10 +1328,15 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
             Coercion c = node.coercions.get(i);
             String idCode = id.javaCode();
             ret.add(String.format("%s = %s;", idCode, c.javaCode(resultStr)));
-            ret.add(String.format("if (%s != null && r%%'LEVEL'%%.wasNull()) { %s = null; }", idCode, idCode));
+            ret.add(
+                    String.format(
+                            "if (%s != null && r%%'LEVEL'%%.wasNull()) { %s = null; }",
+                            idCode, idCode));
 
             if ((id.decl instanceof DeclVar) && ((DeclVar) id.decl).notNull) {
-                ret.add(String.format( "checkNotNull(%s, \"NOT NULL constraint violated\");", idCode));
+                ret.add(
+                        String.format(
+                                "checkNotNull(%s, \"NOT NULL constraint violated\");", idCode));
             }
 
             i++;

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -41,9 +41,6 @@ import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
 import java.sql.*;
-import java.sql.Date;
-import java.sql.Time;
-import java.sql.Timestamp;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
@@ -59,6 +56,24 @@ import java.util.Stack;
 import java.util.regex.PatternSyntaxException;
 
 public class SpLib {
+
+    public static Object getFieldWithIndex(ResultSet rs, int idx) throws SQLException {
+        Object o = rs.getObject(idx);
+        if (o != null && rs.wasNull()) {
+            return null;
+        } else {
+            return o;
+        }
+    }
+
+    public static Object getFieldWithName(ResultSet rs, String name) throws SQLException {
+        Object o = rs.getObject(name);
+        if (o != null && rs.wasNull()) {
+            return null;
+        } else {
+            return o;
+        }
+    }
 
     public static String checkStrLength(boolean isChar, int length, String val) {
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -261,6 +261,9 @@ public class SpLib {
                         throw new PROGRAM_ERROR(); // unreachable
                 }
                 assert !rs.next(); // it must have only one record
+                if (ret != null && rs.wasNull()) {
+                    ret = null;
+                }
 
                 Statement stmt = rs.getStatement();
                 if (stmt != null) {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25170

- added wasNull check after every ResultSet.getXXX() call
    - built-in function call
    - field lookup
    - serial value lookup
    - into clause of cursor fetch
    - into clause of Static/Dynamic SQL SELECT
