### PR TITLE
[CBRD-25178] core dump occurs when a false query is created due to constant folding.

### DIFF
--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -17277,9 +17277,13 @@ pt_plan_cte (PARSER_CONTEXT * parser, PT_NODE * node, PROC_TYPE proc_type)
       return NULL;
     }
   non_recursive_part_xasl = (XASL_NODE *) non_recursive_part->info.query.xasl;
-  non_recursive_part_xasl->cte_xasl_id = non_recursive_part->xasl_id;
-  non_recursive_part_xasl->cte_host_var_count = non_recursive_part->cte_host_var_count;
-  non_recursive_part_xasl->cte_host_var_index = non_recursive_part->cte_host_var_index;
+  /* checking false query */
+  if (non_recursive_part_xasl)
+    {
+      non_recursive_part_xasl->cte_xasl_id = non_recursive_part->xasl_id;
+      non_recursive_part_xasl->cte_host_var_count = non_recursive_part->cte_host_var_count;
+      non_recursive_part_xasl->cte_host_var_index = non_recursive_part->cte_host_var_index;
+    }
 
   if (recursive_part)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25178

If a false query (null query) is created in a CTE query due to constant folding, the xasl of the non-recursive part may become null, causing a problem of referring to a null point.