### PR TITLE
[CBRD-25179] A core dump occurs when the CTE query is a false query (null query)

### DIFF
--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -13569,12 +13569,7 @@ pt_uncorr_post (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continu
 	  assert (PT_IS_QUERY (non_recursive_part) || PT_IS_VALUE_NODE (non_recursive_part));
 
 	  /* checking false-query by constant folding */
-	  if (non_recursive_part->type_enum == PT_TYPE_NULL)
-	    {
-	      break;
-	    }
-
-	  if (PT_IS_VALUE_NODE (non_recursive_part))
+	  if (PT_IS_VALUE_NODE (non_recursive_part) && non_recursive_part->type_enum != PT_TYPE_NULL)
 	    {
 	      info->xasl = pt_append_xasl (xasl, info->xasl);
 	      break;

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -13568,10 +13568,19 @@ pt_uncorr_post (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continu
 	  // non_recursive_part can become PT_VALUE during constant folding
 	  assert (PT_IS_QUERY (non_recursive_part) || PT_IS_VALUE_NODE (non_recursive_part));
 
-	  /* checking false-query by constant folding */
-	  if (PT_IS_VALUE_NODE (non_recursive_part) && non_recursive_part->type_enum != PT_TYPE_NULL)
+	  /*
+	     We need to check a false-query and a select-null query by constant folding.
+	     A false-query and a select-null query are distinguished as follows.
+	     false-query's node_type is PT_VALUE and type_enum is PT_TYPE_NULL.
+	     In select-null query, node_type is PT_SELECT and type_enum is PT_TYPE_NULL.
+	     false-query is not necessary to append xasl because it's not a query.
+	   */
+	  if (PT_IS_VALUE_NODE (non_recursive_part))
 	    {
-	      info->xasl = pt_append_xasl (xasl, info->xasl);
+	      if (non_recursive_part->type_enum != PT_TYPE_NULL)
+		{
+		  info->xasl = pt_append_xasl (xasl, info->xasl);
+		}
 	      break;
 	    }
 

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -13567,6 +13567,13 @@ pt_uncorr_post (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continu
 	  PT_NODE *non_recursive_part = node->info.cte.non_recursive_part;
 	  // non_recursive_part can become PT_VALUE during constant folding
 	  assert (PT_IS_QUERY (non_recursive_part) || PT_IS_VALUE_NODE (non_recursive_part));
+
+	  /* checking false-query by constant folding */
+	  if (non_recursive_part->type_enum == PT_TYPE_NULL)
+	    {
+	      break;
+	    }
+
 	  if (PT_IS_VALUE_NODE (non_recursive_part))
 	    {
 	      info->xasl = pt_append_xasl (xasl, info->xasl);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25179

When a CTE query is rewritten as a false query due to constant folding, a core dump referring to a null point occurs in cub_server.
