### PR TITLE
[CBRD-25195] A core dump occurs when multiple tables and serial functions are used simultaneously in one query.

### DIFF
--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -18017,6 +18017,11 @@ error:
       free_and_init (*oid_listp);
     }
 
+  if (*lock_listp)
+    {
+      free_and_init (*lock_listp);
+    }
+
   if (*tcard_listp)
     {
       free_and_init (*tcard_listp);

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -18160,6 +18160,7 @@ pt_serial_to_xasl_class_oid_list (PARSER_CONTEXT * parser, const PT_NODE * seria
   *nump = o_num;
   *sizep = o_size;
   *oid_listp = o_list;
+  *lock_listp = lck_list;
   *tcard_listp = t_list;
 
   return o_num;
@@ -18168,6 +18169,11 @@ error:
   if (*oid_listp)
     {
       free_and_init (*oid_listp);
+    }
+
+  if (*lock_listp)
+    {
+      free_and_init (*lock_listp);
     }
 
   if (*tcard_listp)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25195

A core dump occurs when more than 10 tables and more than 1 serial function are used simultaneously in one query.

This is related to the memory allocation and reallocation routines commonly used by pt_spec_to_xasl_class_oid_list and pt_serial_to_xasl_class_oid_list, which handle table specs and serial specs in the parser.