### PR TITLE
[CBRD-25184] Temporary regression testing environment for PL/CSQL phase-1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
     parallelism: 8
     <<: *test_defaults
 
-  test_plsql:
+  test_plcsql:
     <<: *defaults
     environment:
       TEST_SUITE: plcsql

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ test_defaults: &test_defaults
         shell: /bin/bash
         environment:
           _JAVA_OPTIONS: -Xmx1g
+          BRANCH_TESTCASES: feature/plcsql
         command: |
           ulimit -c 1
           /entrypoint.sh checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,8 @@ test_defaults: &test_defaults
           glob_path="cubrid-testcases/$TEST_SUITE/_*"
           if [ $TEST_SUITE = "plcsql" ] 
           then
+            # Hack way to run plcsql test without modifying CUBRID CI docker
+            TEST_SUITE="sql"
             glob_path=cubrid-testcases/sql/_05_plcsql
           elif [ $TEST_SUITE = "sql" ] 
           then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,12 +17,14 @@ test_defaults: &test_defaults
           ulimit -c 1
           /entrypoint.sh checkout
           glob_path="cubrid-testcases/$TEST_SUITE/_*"
-          if [ $TEST_SUITE = "plcsql" ]; then
+          if [ $TEST_SUITE = "plcsql" ] 
+          then
             glob_path=cubrid-testcases/$TEST_SUITE/_05_plcsql
-          elif [ $TEST_SUITE = "sql" ]; then
+          elif [ $TEST_SUITE = "sql" ] 
+          then
             rm -rf cubrid-testcases/$TEST_SUITE/_05_plcsql
           else
-            ;
+            
           fi
           circleci tests glob $glob_path | circleci tests split | tee tc.list
           find $glob_path -maxdepth 0 -type d -print0 | grep -vzZ -f tc.list | xargs -0 rm -rf

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,6 @@ workflows:
           requires:
             - build
 
-      - build-windows
+      - build-windows:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ test_defaults: &test_defaults
             rm -rf cubrid-testcases/$TEST_SUITE/_05_plcsql
           fi
           circleci tests glob $glob_path | circleci tests split | tee tc.list
-          find $glob_path -maxdepth 0 -type d -print0 | grep -vzZ -f tc.list | xargs -0 rm -rf
+          find cubrid-testcases/$TEST_SUITE/_* -maxdepth 0 -type d -print0 | grep -vzZ -f tc.list | xargs -0 rm -rf
           /entrypoint.sh test
     - run:
         name: Collect Logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ test_defaults: &test_defaults
           glob_path="cubrid-testcases/$TEST_SUITE/_*"
           if [ $TEST_SUITE = "plcsql" ] 
           then
-            glob_path=cubrid-testcases/$TEST_SUITE/_05_plcsql
+            glob_path=cubrid-testcases/sql/_05_plcsql
           elif [ $TEST_SUITE = "sql" ] 
           then
             rm -rf cubrid-testcases/$TEST_SUITE/_05_plcsql

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,11 +2,6 @@ defaults: &defaults
   working_directory: /home
   docker:
     - image: cubridci/cubridci:develop
-    
-oraclelinux: &oraclelinux
-  working_directory: /home
-  docker:
-    - image: cubridci/cubridci:ol7.8 
 
 test_defaults: &test_defaults
   steps:
@@ -20,8 +15,16 @@ test_defaults: &test_defaults
         command: |
           ulimit -c 1
           /entrypoint.sh checkout
-          circleci tests glob cubrid-testcases/$TEST_SUITE/_* | circleci tests split | tee tc.list
-          find cubrid-testcases/$TEST_SUITE/_* -maxdepth 0 -type d -print0 | grep -vzZ -f tc.list | xargs -0 rm -rf
+          glob_path="cubrid-testcases/$TEST_SUITE/_*"
+          if [ $TEST_SUITE = "plcsql" ]; then
+            glob_path=cubrid-testcases/$TEST_SUITE/_05_plcsql
+          elif [ $TEST_SUITE = "sql" ]; then
+            rm -rf cubrid-testcases/$TEST_SUITE/_05_plcsql
+          else
+            ;
+          fi
+          circleci tests glob $glob_path | circleci tests split | tee tc.list
+          find $glob_path -maxdepth 0 -type d -print0 | grep -vzZ -f tc.list | xargs -0 rm -rf
           /entrypoint.sh test
     - run:
         name: Collect Logs
@@ -84,10 +87,17 @@ jobs:
     parallelism: 8
     <<: *test_defaults
 
+  test_plsql:
+    <<: *defaults
+    environment:
+      TEST_SUITE: plcsql
+    resource_class: medium
+    <<: *test_defaults
+
   build-windows:
     machine:
       image: 'windows-server-2019-vs2019:2022.08.1'
-      resource_class: windows.large
+      resource_class: windows.medium
       shell: powershell.exe -ExecutionPolicy Bypass
     environment:
       - CMAKE_GENERATOR: "Visual Studio 16 2019"
@@ -126,6 +136,9 @@ workflows:
           requires:
             - build
       - test_sql:
+          requires:
+            - build
+      - test_plsql:
           requires:
             - build
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,8 +141,10 @@ workflows:
       - test_sql:
           requires:
             - build
-      - test_plsql:
+      - test_plcsql:
           requires:
             - build
 
       - build-windows
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,21 +84,6 @@ jobs:
     parallelism: 8
     <<: *test_defaults
 
-  test_medium_ol:
-    <<: *oraclelinux
-    environment:
-      TEST_SUITE: medium
-    resource_class: medium
-    <<: *test_defaults
-
-  test_sql_ol:
-    <<: *oraclelinux
-    environment:
-      TEST_SUITE: sql
-    resource_class: medium
-    parallelism: 8
-    <<: *test_defaults
-
   build-windows:
     machine:
       image: 'windows-server-2019-vs2019:2022.08.1'
@@ -144,10 +129,4 @@ workflows:
           requires:
             - build
 
-      - test_medium_ol:
-          requires:
-            - build
-      - test_sql_ol:
-          requires:
-            - build
       - build-windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,6 @@ test_defaults: &test_defaults
           elif [ $TEST_SUITE = "sql" ] 
           then
             rm -rf cubrid-testcases/$TEST_SUITE/_05_plcsql
-          else
-            
           fi
           circleci tests glob $glob_path | circleci tests split | tee tc.list
           find $glob_path -maxdepth 0 -type d -print0 | grep -vzZ -f tc.list | xargs -0 rm -rf


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25814

- Add a new job for PL/CSQL testing
  - please see `test_plcsql` in checks
- Remove redundant tests to save credits
  - oracle linux
  - downgrade build-windows's resource class to medium

NOTE: this change will be reverted when plcsql-p1 is merged