### PR TITLE
[CBRD-25207] count(*) value is incorrect after no-logging option loaddb

### DIFF
--- a/src/base/xserver_interface.h
+++ b/src/base/xserver_interface.h
@@ -169,6 +169,7 @@ extern int xlogtb_reset_isolation (THREAD_ENTRY * thread_p, TRAN_ISOLATION isola
 extern LOG_LSA *log_get_final_restored_lsa (void);
 extern float log_get_db_compatibility (void);
 extern int log_set_no_logging (void);
+extern bool log_is_no_logging (void);
 extern bool logtb_has_updated (THREAD_ENTRY * thread_p);
 
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -3825,7 +3825,7 @@ log_sysop_commit_internal (THREAD_ENTRY * thread_p, LOG_REC_SYSOP_END * log_reco
     }
 
   if ((LSA_ISNULL (&tdes->tail_lsa) || LSA_LE (&tdes->tail_lsa, LOG_TDES_LAST_SYSOP_PARENT_LSA (tdes)))
-      && log_record->type == LOG_SYSOP_END_COMMIT)
+      && (log_record->type == LOG_SYSOP_END_COMMIT || log_No_logging))
     {
       /* No change. */
       assert (LSA_ISNULL (&LOG_TDES_LAST_SYSOP (tdes)->posp_lsa));

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1018,6 +1018,18 @@ log_set_no_logging (void)
 }
 
 /*
+ * This function is for an external interface
+ * to process statistical information of the B-tree index header.
+ * In a no logging environment, the statistical information of the B-tree index header
+ * should not depend on the updated log. This is a function to check this.
+ */
+bool
+log_is_no_logging (void)
+{
+  return log_No_logging;
+}
+
+/*
  * log_initialize - Initialize the log manager
  *
  * return: nothing
@@ -3824,7 +3836,8 @@ log_sysop_commit_internal (THREAD_ENTRY * thread_p, LOG_REC_SYSOP_END * log_reco
        * we don't actually allow empty logical system operation because it might hide a logic flaw. however, there are
        * unusual cases when a logical operation does not really require logging (see RVPGBUF_FLUSH_PAGE). if you create
        * such a case, you should add a dummy log record to trick this assert. */
-      assert (!LSA_ISNULL (&tdes->tail_lsa) && LSA_GT (&tdes->tail_lsa, LOG_TDES_LAST_SYSOP_PARENT_LSA (tdes)));
+      assert (log_No_logging || (!LSA_ISNULL (&tdes->tail_lsa)
+				 && LSA_GT (&tdes->tail_lsa, LOG_TDES_LAST_SYSOP_PARENT_LSA (tdes))));
 
       /* now that we have access to tdes, we can do some updates on log record and sanity checks */
       if (log_record->type == LOG_SYSOP_END_LOGICAL_RUN_POSTPONE)

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -3836,8 +3836,7 @@ log_sysop_commit_internal (THREAD_ENTRY * thread_p, LOG_REC_SYSOP_END * log_reco
        * we don't actually allow empty logical system operation because it might hide a logic flaw. however, there are
        * unusual cases when a logical operation does not really require logging (see RVPGBUF_FLUSH_PAGE). if you create
        * such a case, you should add a dummy log record to trick this assert. */
-      assert (log_No_logging || (!LSA_ISNULL (&tdes->tail_lsa)
-				 && LSA_GT (&tdes->tail_lsa, LOG_TDES_LAST_SYSOP_PARENT_LSA (tdes))));
+      assert (!LSA_ISNULL (&tdes->tail_lsa) && LSA_GT (&tdes->tail_lsa, LOG_TDES_LAST_SYSOP_PARENT_LSA (tdes)));
 
       /* now that we have access to tdes, we can do some updates on log record and sanity checks */
       if (log_record->type == LOG_SYSOP_END_LOGICAL_RUN_POSTPONE)

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -5042,7 +5042,7 @@ logtb_reflect_global_unique_stats_to_btree (THREAD_ENTRY * thread_p)
        stats = (GLOBAL_UNIQUE_STATS *) lf_hash_iterate (&it))
     {
       /* reflect only if some changes were logged */
-      if (!LSA_ISNULL (&stats->last_log_lsa))
+      if (log_is_no_logging () || !LSA_ISNULL (&stats->last_log_lsa))
 	{
 	  error = btree_reflect_global_unique_statistics (thread_p, stats, false);
 	  if (error != NO_ERROR)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25207

After loaddb with no-logging option, the result of "SELECT count(*)" query always comes out as 0.