### PR TITLE
[CBRD-25206] Change the statistical information of the B-tree index root header to 64 bits.

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -5602,16 +5602,10 @@ xbtree_add_index (THREAD_ENTRY * thread_p, BTID * btid, TP_DOMAIN * key_type, OI
 
   if (unique_pk)
     {
-      root_header->num_oids = num_oids & 0xffffffff;
-      root_header->num_nulls = num_nulls & 0xffffffff;
-      root_header->num_keys = num_keys & 0xffffffff;
+      root_header->num_oids = num_oids;
+      root_header->num_nulls = num_nulls;
+      root_header->num_keys = num_keys;
       root_header->unique_pk = unique_pk;
-
-      over += root_header->_64.num_oids = num_oids >> 32;
-      over += root_header->_64.num_nulls = num_nulls >> 32;
-      over += root_header->_64.num_keys = num_keys >> 32;
-
-      root_header->_64.over = (over > 0);
 
       assert (BTREE_IS_UNIQUE (root_header->unique_pk));
       assert (BTREE_IS_PRIMARY_KEY (root_header->unique_pk) || !BTREE_IS_PRIMARY_KEY (root_header->unique_pk));
@@ -6375,16 +6369,9 @@ btree_get_unique_statistics (THREAD_ENTRY * thread_p, BTID * btid, long long *oi
 
   assert ((root_header->unique_pk & (BTREE_CONSTRAINT_UNIQUE | BTREE_CONSTRAINT_PRIMARY_KEY)) != 0);
 
-  *oid_cnt = (unsigned int) root_header->num_oids;
-  *null_cnt = (unsigned int) root_header->num_nulls;
-  *key_cnt = (unsigned int) root_header->num_keys;
-
-  if (root_header->_64.over)
-    {
-      *oid_cnt |= (((long long) root_header->_64.num_oids) << 32);
-      *null_cnt |= (((long long) root_header->_64.num_nulls) << 32);
-      *key_cnt |= (((long long) root_header->_64.num_keys) << 32);
-    }
+  *oid_cnt = root_header->num_oids;
+  *null_cnt = root_header->num_nulls;
+  *key_cnt = root_header->num_keys;
 
   pgbuf_unfix_and_init (thread_p, root);
 
@@ -14556,15 +14543,9 @@ btree_reflect_global_unique_statistics (THREAD_ENTRY * thread_p, GLOBAL_UNIQUE_S
 	  int over = 0;
 
 	  /* update header information */
-	  root_header->num_nulls = unique_stat_info->unique_stats.num_nulls & 0xffffffff;
-	  root_header->num_oids = unique_stat_info->unique_stats.num_oids & 0xffffffff;
-	  root_header->num_keys = unique_stat_info->unique_stats.num_keys & 0xffffffff;
-
-	  over += root_header->_64.num_nulls = unique_stat_info->unique_stats.num_nulls >> 32;
-	  over += root_header->_64.num_oids = unique_stat_info->unique_stats.num_oids >> 32;
-	  over += root_header->_64.num_keys = unique_stat_info->unique_stats.num_keys >> 32;
-
-	  root_header->_64.over = (over > 0);
+	  root_header->num_nulls = unique_stat_info->unique_stats.num_nulls;
+	  root_header->num_oids = unique_stat_info->unique_stats.num_oids;
+	  root_header->num_keys = unique_stat_info->unique_stats.num_keys;
 
 	  page_lsa = pgbuf_get_lsa (root);
 	  /* update the page's LSA to the last global unique statistics change that was made at commit, only if it is
@@ -17469,13 +17450,6 @@ btree_rv_roothdr_undo_update (THREAD_ENTRY * thread_p, LOG_RCV * recv)
       num_oids = (unsigned int) root_header->num_oids;
       num_keys = (unsigned int) root_header->num_keys;
 
-      if (root_header->_64.over)
-	{
-	  num_nulls |= (long long) root_header->_64.num_nulls << 32;
-	  num_oids |= (long long) root_header->_64.num_oids << 32;
-	  num_keys |= (long long) root_header->_64.num_keys << 32;
-	}
-
       /* unpack the root statistics */
       datap = (char *) recv->data;
       OR_GET_BIGINT (datap, &delta);
@@ -17487,15 +17461,9 @@ btree_rv_roothdr_undo_update (THREAD_ENTRY * thread_p, LOG_RCV * recv)
       OR_GET_BIGINT (datap, &delta);
       num_keys += delta;
 
-      root_header->num_nulls = num_nulls & 0xffffffff;
-      root_header->num_oids = num_oids & 0xffffffff;
-      root_header->num_keys = num_keys & 0xffffffff;
-
-      over += root_header->_64.num_nulls = num_nulls >> 32;
-      over += root_header->_64.num_oids = num_oids >> 32;
-      over += root_header->_64.num_keys = num_keys >> 32;
-
-      root_header->_64.over = (over > 0);
+      root_header->num_nulls = num_nulls;
+      root_header->num_oids = num_oids;
+      root_header->num_keys = num_keys;
     }
 
   pgbuf_set_dirty (thread_p, recv->pgptr, DONT_FREE);

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -1895,11 +1895,6 @@ btree_build_nleafs (THREAD_ENTRY * thread_p, LOAD_ARGS * load_args, int n_nulls,
   root_header->node.split_info.pivot = 0.0f;
   root_header->node.split_info.index = 0;
 
-  /* the 64 bit extending should be initialized to 0 
-   * because only the 32bit count is used at this point */
-  root_header->_64.over = 0;
-  root_header->_64.num_nulls = root_header->_64.num_oids = root_header->num_keys = 0;
-
   if (load_args->btid->unique_pk)
     {
       root_header->num_nulls = n_nulls;

--- a/src/storage/btree_load.h
+++ b/src/storage/btree_load.h
@@ -207,9 +207,9 @@ typedef struct btree_root_header BTREE_ROOT_HEADER;
 struct btree_root_header
 {
   BTREE_NODE_HEADER node;
-  long long num_oids;		/* Number of OIDs stored in the Btree */
-  long long num_nulls;		/* Number of NULLs (they aren't stored) */
-  long long num_keys;		/* Number of unique keys in the Btree */
+  INT64 num_oids;		/* Number of OIDs stored in the Btree */
+  INT64 num_nulls;		/* Number of NULLs (they aren't stored) */
+  INT64 num_keys;		/* Number of unique keys in the Btree */
   OID topclass_oid;		/* topclass oid or NULL OID(non unique index) */
   int unique_pk;		/* unique or non-unique, is primary key */
 

--- a/src/storage/btree_load.h
+++ b/src/storage/btree_load.h
@@ -207,21 +207,13 @@ typedef struct btree_root_header BTREE_ROOT_HEADER;
 struct btree_root_header
 {
   BTREE_NODE_HEADER node;
-  int num_oids;			/* Number of OIDs stored in the Btree */
-  int num_nulls;		/* Number of NULLs (they aren't stored) */
-  int num_keys;			/* Number of unique keys in the Btree */
+  long long num_oids;		/* Number of OIDs stored in the Btree */
+  long long num_nulls;		/* Number of NULLs (they aren't stored) */
+  long long num_keys;		/* Number of unique keys in the Btree */
   OID topclass_oid;		/* topclass oid or NULL OID(non unique index) */
   int unique_pk;		/* unique or non-unique, is primary key */
-  struct
-  {
-    int over:2;			/* for checking to over 32 bit */
-    int num_oids:10;		/* extend 10 bit for num_oids */
-    int num_nulls:10;		/* extend 10 bit for num_nulls */
-    int num_keys:10;		/* extend 10 bit for num_keys */
-  } _64;
 
-/* support for SUPPORT_DEDUPLICATE_KEY_MODE */
-  // int rev_level;             /* Btree revision level */
+  /* support for SUPPORT_DEDUPLICATE_KEY_MODE */
   struct
   {
     int rev_level:16;		/* Btree revision level */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25206

Regarding the count(*) optimization using the statistical information of the B-tree index header introduced from version 11.2, it is necessary to unify num_nulls, num_oids, and num_keys, which were treated as 32 bits + 10 bits, to 64 bits in consideration of backward compatibility.
Since the disk image of version 11.4 (fig-cake) is not compatible with previous versions, it is necessary to process it in 64-bit from this version to simplify the logic and improve performance.
