### PR TITLE
[CBRD-25180] Occur temp volume growth, when performing prepare() -> multiple execute().

### DIFF
--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -7222,6 +7222,7 @@ qmgr_execute_query (const XASL_ID * xasl_id, QUERY_ID * query_idp, int dbval_cnt
       if (IS_QUERY_EXECUTE_WITH_COMMIT (flag))
 	{
 	  ptr = or_unpack_int (ptr, &end_query_result);
+	  /* If all net_Deferred_end_queries are closed on the server, the value of end_query_result is NO_ERROR. */
 	  if (end_query_result == NO_ERROR)
 	    {
 	      net_Deferred_end_queries_count = 0;

--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -7159,7 +7159,6 @@ qmgr_execute_query (const XASL_ID * xasl_id, QUERY_ID * query_idp, int dbval_cnt
 	}
 
       request_len += OR_INT_SIZE + OR_PTR_SIZE * net_Deferred_end_queries_count;
-      net_Deferred_end_queries_count = 0;
     }
 
   /* Add message in log in case of autocommit transactions. It helps to trace query execution. */
@@ -7223,6 +7222,10 @@ qmgr_execute_query (const XASL_ID * xasl_id, QUERY_ID * query_idp, int dbval_cnt
       if (IS_QUERY_EXECUTE_WITH_COMMIT (flag))
 	{
 	  ptr = or_unpack_int (ptr, &end_query_result);
+	  if (end_query_result == NO_ERROR)
+	    {
+	      net_Deferred_end_queries_count = 0;
+	    }
 	  ptr = or_unpack_int (ptr, &tran_state);
 	  ptr = or_unpack_int (ptr, &should_conn_reset);
 

--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -7223,6 +7223,7 @@ qmgr_execute_query (const XASL_ID * xasl_id, QUERY_ID * query_idp, int dbval_cnt
 	{
 	  ptr = or_unpack_int (ptr, &end_query_result);
 	  /* If all net_Deferred_end_queries are closed on the server, the value of end_query_result is NO_ERROR. */
+          /* If end_query_result is not NO_ERROR, net_Deferred_end_queries_count will not reset to attempt a close on commit or abort. */
 	  if (end_query_result == NO_ERROR)
 	    {
 	      net_Deferred_end_queries_count = 0;

--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -7223,7 +7223,7 @@ qmgr_execute_query (const XASL_ID * xasl_id, QUERY_ID * query_idp, int dbval_cnt
 	{
 	  ptr = or_unpack_int (ptr, &end_query_result);
 	  /* If all net_Deferred_end_queries are closed on the server, the value of end_query_result is NO_ERROR. */
-          /* If end_query_result is not NO_ERROR, net_Deferred_end_queries_count will not reset to attempt a close on commit or abort. */
+	  /* If end_query_result is not NO_ERROR, net_Deferred_end_queries_count will not reset to attempt a close on commit or abort. */
 	  if (end_query_result == NO_ERROR)
 	    {
 	      net_Deferred_end_queries_count = 0;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25180

**Description**
The results (temporary volume) is dangled, when preforming execute() multiple time after preparing a sql. This problem does not always occur, but it occurs if all of the following conditions are met.
 - transaction mode is auto commit mode.
 - the resultset is forward and it is not read until the end.
 - the resultset explicitly doesn't close the results after execute() and fetch().
 - the result's page of execute() are more than two pages.

**Resolution**
-  modify the code to be net_Deferred_end_queries count = 0 only if end_query_result returned from server is NO_ERROR, instead of unconditionally changing net_Deferred_end_queries count = 0.