### PR TITLE
[CBRD-23768] Unnecessary row X-LOCK is set depending on the plan

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -8300,7 +8300,7 @@ qexec_intprt_fnc (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_s
 	      else if (scan_id->type == S_INDX_SCAN)
 		{
 		  lock_unlock_object_donot_move_to_non2pl (thread_p, scan_id->s.isid.curr_oidp,
-							   &scan_id->s.hsid.cls_oid, lock_mode);
+							   &scan_id->s.isid.cls_oid, lock_mode);
 		}
 	    }
 	  qexec_clear_all_lists (thread_p, xasl);

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -7473,11 +7473,7 @@ qexec_execute_scan (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl
 
       if (xasl->curr_spec->s_id.mvcc_select_lock_needed && !qualified)
 	{
-	  /*
-	   * FIXME : it is temporary solution that logic to release the lock is added on here to simplify implementation.
-	   * need to change the location where the lock is generated from scan_next_index_lookup_heap(), scan_next_heap_scan() to here.
-	   */
-	  /* did not pass the evaluation - unlock object */
+	  /* did not pass the evaluation - unlock object from scan_next_index_lookup_heap(), scan_next_heap_scan() */
 	  QEXEC_UNLOCK_UNQUALIFIED_OID (thread_p, xasl);
 	}
 
@@ -8288,11 +8284,7 @@ qexec_intprt_fnc (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_s
 
 	  if (xasl->curr_spec->s_id.mvcc_select_lock_needed && !qualified)
 	    {
-	      /*
-	       * FIXME : it is temporary solution that logic to release the lock is added on here to simplify implementation.
-	       * need to change the location where the lock is generated from scan_next_index_lookup_heap(), scan_next_heap_scan() to here.
-	       */
-	      /* did not pass the evaluation - unlock object */
+	      /* did not pass the evaluation - unlock object from scan_next_index_lookup_heap(), scan_next_heap_scan() */
 	      QEXEC_UNLOCK_UNQUALIFIED_OID (thread_p, xasl);
 	    }
 	  qexec_clear_all_lists (thread_p, xasl);

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -7454,6 +7454,21 @@ qexec_execute_scan (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl
 	    }
 	}			/* if (qualified) */
 
+      if (xasl->curr_spec->s_id.mvcc_select_lock_needed && !qualified)
+	    {
+	      /* did not pass the evaluation - unlock object (join pred X) */
+	      LOCK lock_mode = X_LOCK;
+	      SCAN_ID *scan_id = &xasl->curr_spec->s_id;
+	      if (scan_id->type == S_HEAP_SCAN)
+		{
+		  lock_unlock_object_donot_move_to_non2pl (thread_p, &scan_id->s.hsid.curr_oid, &scan_id->s.hsid.cls_oid, lock_mode);
+		}
+	      else if (scan_id->type == S_INDX_SCAN)
+		{
+		  lock_unlock_object_donot_move_to_non2pl (thread_p, scan_id->s.isid.curr_oidp, &scan_id->s.hsid.cls_oid, lock_mode);
+		}
+	    }
+
     }
   while (1);
 
@@ -8249,6 +8264,20 @@ qexec_intprt_fnc (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_s
 		}
 	    }
 
+	  if (xasl->curr_spec->s_id.mvcc_select_lock_needed && !qualified)
+	    {
+	      /* did not pass the evaluation - unlock object */
+	      LOCK lock_mode = X_LOCK;
+	      SCAN_ID *scan_id = &xasl->curr_spec->s_id;
+	      if (scan_id->type == S_HEAP_SCAN)
+		{
+		  lock_unlock_object_donot_move_to_non2pl (thread_p, &scan_id->s.hsid.curr_oid, &scan_id->s.hsid.cls_oid, lock_mode);
+		}
+	      else if (scan_id->type == S_INDX_SCAN)
+		{
+		  lock_unlock_object_donot_move_to_non2pl (thread_p, scan_id->s.isid.curr_oidp, &scan_id->s.hsid.cls_oid, lock_mode);
+		}
+	    }
 	  qexec_clear_all_lists (thread_p, xasl);
 	}
 

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -7457,6 +7457,11 @@ qexec_execute_scan (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl
 
       if (xasl->curr_spec->s_id.mvcc_select_lock_needed && !qualified)
 	{
+	  /*
+	   * FIXME : it is temporary solution that logic to release the lock is added on here to simplify implementation.
+	   * need to change the location where the lock is generated from scan_next_index_lookup_heap(), scan_next_heap_scan() to here.
+	   */
+
 	  /* did not pass the evaluation - unlock object */
 	  LOCK lock_mode = X_LOCK;
 	  SCAN_ID *scan_id = &xasl->curr_spec->s_id;
@@ -8279,6 +8284,11 @@ qexec_intprt_fnc (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_s
 
 	  if (xasl->curr_spec->s_id.mvcc_select_lock_needed && !qualified)
 	    {
+	      /*
+	       * FIXME : it is temporary solution that logic to release the lock is added on here to simplify implementation.
+	       * need to change the location where the lock is generated from scan_next_index_lookup_heap(), scan_next_heap_scan() to here.
+	       */
+
 	      /* did not pass the evaluation - unlock object */
 	      LOCK lock_mode = X_LOCK;
 	      SCAN_ID *scan_id = &xasl->curr_spec->s_id;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23768

Since the lock is generated in scan_next_scan(), the predicates below are not evaluated. so unnecessary lock is created.
- dptr (corelated subquery)
- after join predicate for outer join
- scan_ptr (join predicate)
- if predicate (predicate including subquery)

**Implementation**
 It is correct to change the location where the lock is created. However, to simplify implementation, add logic to release the lock after evaluation of the all predicates.
