### PR TITLE
[CBRD-25209] If a transaction is terminated without commit/rollback, write the ABORT log to the ddl_audit log

### DIFF
--- a/src/base/ddl_log.c
+++ b/src/base/ddl_log.c
@@ -131,7 +131,6 @@ static void logddl_set_sql_text (char *sql_text, int sql_len, HIDE_PWD_INFO_PTR 
 static bool logddl_set_stmt_type (int stmt_type, PT_NODE * statement);
 
 static bool is_executed_ddl_for_trans = false;
-static bool is_executed_ddl_for_csql = false;
 static bool has_password_type = false;
 
 void
@@ -200,7 +199,6 @@ logddl_free (bool all_free)
   if (all_free)
     {
       is_executed_ddl_for_trans = false;
-      is_executed_ddl_for_csql = false;
 
       ddl_audit_handle.auto_commit_mode = false;
       ddl_audit_handle.csql_input_type = CSQL_INPUT_TYPE_NONE;
@@ -384,8 +382,6 @@ logddl_set_stmt_type (int stmt_type, PT_NODE * statement)
   if (logddl_is_ddl_type (stmt_type, statement) == true)
     {
       is_executed_ddl_for_trans = true;
-      is_executed_ddl_for_csql = true;
-
       ddl_audit_handle.ddl_stmt_cnt++;
       return true;
     }
@@ -907,8 +903,7 @@ write_error:
       fp = NULL;
     }
 
-  is_executed_ddl_for_trans = false;
-  logddl_free (false);
+  logddl_free (true);
 }
 
 void
@@ -927,7 +922,7 @@ logddl_write_end_for_csql_fileinput (const char *fmt, ...)
       return;
     }
 
-  if (is_executed_ddl_for_csql == false)
+  if (is_executed_ddl_for_trans == false)
     {
       return;
     }

--- a/src/base/ddl_log.h
+++ b/src/base/ddl_log.h
@@ -36,6 +36,7 @@
 
 #define LOGDDL_TRAN_TYPE_COMMIT             "COMMIT"
 #define LOGDDL_TRAN_TYPE_ROLLBACK           "ROLLBACK"
+#define LOGDDL_TRAN_TYPE_ABORT              "ABORT"
 
 #define DDL_LOG_BUFFER_SIZE                 (8192)
 

--- a/src/broker/cas.c
+++ b/src/broker/cas.c
@@ -767,7 +767,7 @@ conn_retry:
 
 	if (!is_xa_prepared ())
 	  {
-	    ux_end_tran (CCI_TRAN_ROLLBACK, false);
+	    ux_end_tran (CCI_TRAN_ROLLBACK, false, true);
 	  }
 
 #if !defined(CAS_FOR_ORACLE) && !defined(CAS_FOR_MYSQL) && !defined(CAS_FOR_CGW)
@@ -1476,7 +1476,7 @@ cas_main (void)
 
 	    if (!is_xa_prepared ())
 	      {
-		if (ux_end_tran (CCI_TRAN_ROLLBACK, false) < 0)
+		if (ux_end_tran (CCI_TRAN_ROLLBACK, false, true) < 0)
 		  {
 		    as_info->reset_flag = TRUE;
 		  }

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -1170,7 +1170,7 @@ prepare_error:
 #endif /* CAS_FOR_CGW */
 
 int
-ux_end_tran (int tran_type, bool reset_con_status)
+ux_end_tran (int tran_type, bool reset_con_status, bool ddl_audit_log)
 {
   int err_code = 0;
 
@@ -1262,6 +1262,11 @@ ux_end_tran (int tran_type, bool reset_con_status)
     }
   err_code = 0;
 #endif
+
+  if (ddl_audit_log && tran_type != CCI_TRAN_COMMIT)
+    {
+      logddl_write_tran_str (LOGDDL_TRAN_TYPE_ABORT);
+    }
 
   return err_code;
 }
@@ -10957,14 +10962,14 @@ ux_auto_commit (T_NET_BUF * net_buf, T_REQ_INFO * req_info)
   if (req_info->need_auto_commit == TRAN_AUTOCOMMIT)
     {
       cas_log_write (0, false, "auto_commit %s", tran_was_latest_query_committed ()? "(server)" : "(local)");
-      err_code = ux_end_tran (CCI_TRAN_COMMIT, true);
+      err_code = ux_end_tran (CCI_TRAN_COMMIT, true, true);
       cas_log_write (0, false, "auto_commit %d", err_code);
       logddl_set_msg ("auto_commit %d", err_code);
     }
   else if (req_info->need_auto_commit == TRAN_AUTOROLLBACK)
     {
       cas_log_write (0, false, "auto_commit %s", tran_was_latest_query_aborted ()? "(local)" : "(server)");
-      err_code = ux_end_tran (CCI_TRAN_ROLLBACK, true);
+      err_code = ux_end_tran (CCI_TRAN_ROLLBACK, true, true);
       cas_log_write (0, false, "auto_rollback %d", err_code);
       logddl_set_msg ("auto_rollback %d", err_code);
     }

--- a/src/broker/cas_execute.h
+++ b/src/broker/cas_execute.h
@@ -89,7 +89,7 @@ extern int ux_cgw_prepare (char *sql_stmt, int flag, char auto_commit_mode, T_NE
 extern int ux_prepare (char *sql_stmt, int flag, char auto_commit_mode, T_NET_BUF * ne_buf, T_REQ_INFO * req_info,
 		       unsigned int query_seq_num);
 #endif /* CAS_FOR_CGW */
-extern int ux_end_tran (int tran_type, bool reset_con_status);
+extern int ux_end_tran (int tran_type, bool reset_con_status, bool ddl_audit_log);
 extern int ux_end_session (void);
 extern int ux_get_row_count (T_NET_BUF * net_buf);
 extern int ux_get_last_insert_id (T_NET_BUF * net_buf);

--- a/src/broker/cas_function.c
+++ b/src/broker/cas_function.c
@@ -188,7 +188,7 @@ fn_end_tran (SOCKET sock_fd, int argc, void **argv, T_NET_BUF * net_buf, T_REQ_I
 
   gettimeofday (&end_tran_begin, NULL);
 
-  err_code = ux_end_tran ((char) tran_type, false);
+  err_code = ux_end_tran ((char) tran_type, false, false);
 
   if ((tran_type == CCI_TRAN_ROLLBACK) && (req_info->client_version < CAS_MAKE_VER (8, 2, 0)))
     {
@@ -2119,10 +2119,6 @@ fn_con_close (SOCKET sock_fd, int argc, void **argv, T_NET_BUF * net_buf, T_REQ_
   cas_log_write (0, true, "con_close");
   net_buf_cp_int (net_buf, 0, NULL);
 
-  if (req_info->driver_info[DRIVER_INFO_CLIENT_TYPE] != CAS_CLIENT_SERVER_SIDE_JDBC)
-    {
-      logddl_free (true);
-    }
   return FN_CLOSE_CONN;
 }
 

--- a/src/broker/cas_xa.c
+++ b/src/broker/cas_xa.c
@@ -200,7 +200,7 @@ fn_xa_end_tran (SOCKET sock_fd, int argc, void **argv, T_NET_BUF * net_buf, T_RE
 	  return FN_KEEP_CONN;
 	}
 
-      ux_end_tran (tran_type, true);
+      ux_end_tran (tran_type, true, true);
       set_xa_prepare_flag ();
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25209

* If a transaction is terminated without commit/rollback, write the ABORT log to the ddl_audit log
  - When the following two conditions are met:
        - autocommit = false
        - Exit without performing commit/rollback     