### PR TITLE
[CBRD-25180] Occur temp volume growth, when performing prepare() -> multiple execute().

### DIFF
--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -6409,7 +6409,6 @@ qmgr_execute_query (const XASL_ID * xasl_id, QUERY_ID * query_idp, int dbval_cnt
 	}
 
       request_len += OR_INT_SIZE + OR_PTR_SIZE * net_Deferred_end_queries_count;
-      net_Deferred_end_queries_count = 0;
     }
 
   /* Add message in log in case of autocommit transactions. It helps to trace query execution. */
@@ -6473,6 +6472,12 @@ qmgr_execute_query (const XASL_ID * xasl_id, QUERY_ID * query_idp, int dbval_cnt
       if (IS_QUERY_EXECUTE_WITH_COMMIT (flag))
 	{
 	  ptr = or_unpack_int (ptr, &end_query_result);
+	  /* If all net_Deferred_end_queries are closed on the server, the value of end_query_result is NO_ERROR. */
+	  /* If end_query_result is not NO_ERROR, net_Deferred_end_queries_count will not reset to attempt a close on commit or abort. */
+	  if (end_query_result == NO_ERROR)
+	    {
+	      net_Deferred_end_queries_count = 0;
+	    }
 	  ptr = or_unpack_int (ptr, &tran_state);
 	  ptr = or_unpack_int (ptr, &should_conn_reset);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25180

- backport of #4915