### PR TITLE
[CBRD-25176] Failure when creating fk of deduplicate attribute

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -5951,7 +5951,7 @@ btree_remake_foreign_key_with_PK (THREAD_ENTRY * thread_p, BTID * btid, DB_VALUE
   DB_MIDXKEY midxkey;
   TP_DOMAIN *tp_dom = NULL;
   TP_DOMAIN *setdomain_ptr = NULL;
-  DB_VALUE new_key_dbvals_ary[8];
+  DB_VALUE new_key_dbvals_array[8];
   DB_VALUE *new_key_dbvals = NULL;
   DB_VALUE *dbvals_ptr = NULL;
   ATTR_ID last_attrid;
@@ -5975,9 +5975,9 @@ btree_remake_foreign_key_with_PK (THREAD_ENTRY * thread_p, BTID * btid, DB_VALUE
 	}
 
       assert ((num_attrs - 1) == key->data.midxkey.ncolumns);
-      if (key->data.midxkey.ncolumns <= (sizeof (new_key_dbvals_ary) / sizeof (DB_VALUE)))
+      if (key->data.midxkey.ncolumns <= (sizeof (new_key_dbvals_array) / sizeof (DB_VALUE)))
 	{
-	  new_key_dbvals = new_key_dbvals_ary;
+	  new_key_dbvals = new_key_dbvals_array;
 	}
       else
 	{
@@ -6057,7 +6057,7 @@ clear_pos:
 	{
 	  pr_clear_value (&new_key_dbvals[i]);	/* it might be alloced/copied */
 	}
-      if (new_key_dbvals_ary != new_key_dbvals)
+      if (new_key_dbvals_array != new_key_dbvals)
 	{
 	  db_private_free (thread_p, new_key_dbvals);
 	}

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -5992,14 +5992,10 @@ btree_remake_foreign_key_with_PK (THREAD_ENTRY * thread_p, BTID * btid, DB_VALUE
 	    }
 	}
 
-      for (i = 0; i < key->data.midxkey.ncolumns; i++)
-	{
-	  db_make_null (&(new_key_dbvals[i]));
-	}
-
       /* copy prefix of current key into target key */
       for (i = 0; i < key->data.midxkey.ncolumns; i++)
 	{
+	  db_make_null (&(new_key_dbvals[i]));
 	  pr_midxkey_get_element_nocopy (&key->data.midxkey, i, &new_key_dbvals[i], NULL, NULL);
 	}
 
@@ -6113,13 +6109,10 @@ btree_remake_reference_key_with_FK (THREAD_ENTRY * thread_p, TP_DOMAIN * pk_doma
 	  return ER_FAILED;
 	}
     }
-  for (i = 0; i < pk_column_cnt; i++)
-    {
-      db_make_null (&(dbvals_ptr[i]));
-    }
 
   for (i = 0; i < pk_column_cnt; i++)
     {
+      db_make_null (&(dbvals_ptr[i]));
       pr_midxkey_get_element_nocopy (&(fk_key->data.midxkey), i, &dbvals_ptr[i], NULL, NULL);
     }
 

--- a/src/storage/btree.h
+++ b/src/storage/btree.h
@@ -665,6 +665,8 @@ extern int btree_find_foreign_key (THREAD_ENTRY * thread_p, BTID * btid, DB_VALU
 /* support for SUPPORT_DEDUPLICATE_KEY_MODE */
 extern int btree_remake_foreign_key_with_PK (THREAD_ENTRY * thread_p, BTID * btid, DB_VALUE * key, OID * class_oid,
 					     key_val_range * kv_range, bool * is_newly);
+extern int btree_remake_reference_key_with_FK (TP_DOMAIN * pk_domain, DB_VALUE * dbvals, DB_VALUE * fk_key,
+					       DB_VALUE * new_key);
 
 extern void btree_scan_clear_key (BTREE_SCAN * btree_scan);
 

--- a/src/storage/btree.h
+++ b/src/storage/btree.h
@@ -665,7 +665,7 @@ extern int btree_find_foreign_key (THREAD_ENTRY * thread_p, BTID * btid, DB_VALU
 /* support for SUPPORT_DEDUPLICATE_KEY_MODE */
 extern int btree_remake_foreign_key_with_PK (THREAD_ENTRY * thread_p, BTID * btid, DB_VALUE * key, OID * class_oid,
 					     key_val_range * kv_range, bool * is_newly);
-extern int btree_remake_reference_key_with_FK (TP_DOMAIN * pk_domain, DB_VALUE * dbvals, DB_VALUE * fk_key,
+extern int btree_remake_reference_key_with_FK (THREAD_ENTRY * thread_p, TP_DOMAIN * pk_domain, DB_VALUE * fk_key,
 					       DB_VALUE * new_key);
 
 extern void btree_scan_clear_key (BTREE_SCAN * btree_scan);

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -3936,6 +3936,9 @@ btree_load_check_fk (THREAD_ENTRY * thread_p, const LOAD_ARGS * load_args, const
   bool has_nulls = false;
 
   bool has_deduplicate_key_col = false;
+  int pk_column_cnt = 0;
+  DB_VALUE fk_dbvals_ary[8];
+  DB_VALUE *fk_dbvals_ptr = NULL;
   DB_VALUE new_fk_key[2];
   DB_VALUE *fk_key_ptr = &fk_key;
 
@@ -4109,27 +4112,28 @@ btree_load_check_fk (THREAD_ENTRY * thread_p, const LOAD_ARGS * load_args, const
 	  assert (!DB_IS_NULL (&fk_key));
 	  assert (DB_VALUE_DOMAIN_TYPE (&fk_key) == DB_TYPE_MIDXKEY);
 
-	  /* { v1, OID }      ==> v1
-	   * { v1, v2 , OID } ==> { v1, v2 }
-	   */
-
 	  DB_VALUE *new_ptr = (fk_key_ptr == &(new_fk_key[0])) ? &(new_fk_key[1]) : &(new_fk_key[0]);
 
+	  if (fk_dbvals_ptr == NULL)
+	    {
+	      pk_column_cnt = fk_key.data.midxkey.ncolumns - 1;
+	      if (pk_column_cnt <= (sizeof (fk_dbvals_ary) / sizeof (DB_VALUE)))
+		{
+		  fk_dbvals_ptr = fk_dbvals_ary;
+		}
+	      else
+		{
+		  fk_dbvals_ptr = (DB_VALUE *) db_private_alloc (thread_p, pk_column_cnt * sizeof (DB_VALUE));
+		  if (fk_dbvals_ptr == NULL)
+		    {
+		      ASSERT_ERROR_AND_SET (ret);
+		      goto end;
+		    }
+		}
+	    }
+
 	  pr_clear_value (new_ptr);
-	  if (fk_key.data.midxkey.ncolumns > 2)
-	    {
-	      pr_clone_value (&fk_key, new_ptr);
-	      /* Fakes the last column(deduplicate_key_attr) as if it doesn't exist. 
-	       * To do this, reduce the number of columns.
-	       * Modify bitmap information for btree_multicol_key_is_null() function. */
-	      new_ptr->data.midxkey.ncolumns--;
-	      or_multi_set_null (new_ptr->data.midxkey.buf, new_ptr->data.midxkey.ncolumns);
-	      new_ptr->data.midxkey.domain = pk_bt_scan.btid_int.key_type;
-	    }
-	  else
-	    {
-	      pr_midxkey_get_element_nocopy (&fk_key.data.midxkey, 0, new_ptr, NULL, NULL);
-	    }
+	  btree_remake_reference_key_with_FK (pk_bt_scan.btid_int.key_type, fk_dbvals_ptr, &fk_key, new_ptr);
 
 	  if (btree_compare_key (fk_key_ptr, new_ptr, pk_bt_scan.btid_int.key_type, 1, 1, NULL) == DB_EQ)
 	    {			/* Remove the added deduplicate_key_attr and it can be the same key. */
@@ -4321,6 +4325,18 @@ end:
 
   pr_clear_value (&(new_fk_key[0]));
   pr_clear_value (&(new_fk_key[1]));
+
+  if (fk_dbvals_ptr)
+    {
+      for (i = 0; i < pk_column_cnt; i++)
+	{
+	  pr_clear_value (&fk_dbvals_ptr[i]);	/* it might be alloced/copied */
+	}
+      if (fk_dbvals_ptr != fk_dbvals_ary)
+	{
+	  db_private_free (thread_p, fk_dbvals_ptr);
+	}
+    }
 
   if (clear_pcontext == true)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25176

* Failed to create fk index with deduplicate attribute after changing the structure of MIDXKEY

This is to fix a malfunction issue that was affected by changes in the MIDXKEY structure in CBRD-24988.
AS-IS:
     After cloning MIDXKEY, use a trick to compare by reducing the number of columns by only one.
TO-BE:
     Create and use a new key normally.