### PR TITLE
[CBRD-25212] remove warning messages from compilation

### DIFF
--- a/src/base/ddl_log.c
+++ b/src/base/ddl_log.c
@@ -622,7 +622,7 @@ logddl_make_copy_filename (T_APP_NAME app_name, const char *file_full_path, char
   const char *name_tmp = NULL;
   int retval = 0;
 
-  if (file_full_path == NULL || copy_filename == NULL || buf_size < 0)
+  if (file_full_path == NULL || copy_filename == NULL)
     {
       return -1;
     }
@@ -658,7 +658,7 @@ logddl_make_copy_dir (T_APP_NAME app_name, char *copy_filename, char *copy_fullp
   const char *env_root = NULL;
   int retval = 0;
 
-  if (copy_filename == NULL || copy_fullpath == NULL || buf_size < 0)
+  if (copy_filename == NULL || copy_fullpath == NULL)
     {
       return -1;
     }
@@ -883,7 +883,7 @@ logddl_write_tran_str (const char *fmt, ...)
 	  len = DDL_LOG_BUFFER_SIZE;
 	}
 
-      if (len < 0 || fwrite (msg, sizeof (char), len, fp) != len)
+      if (len < 0 || fwrite (msg, sizeof (char), len, fp) != (size_t) len)
 	{
 	  goto write_error;
 	}

--- a/src/base/event_log.c
+++ b/src/base/event_log.c
@@ -187,7 +187,7 @@ event_file_open (const char *path)
 static FILE *
 event_file_backup (FILE * fp, const char *path)
 {
-  char backup_file[PATH_MAX];
+  char backup_file[PATH_MAX + 10];
 
   assert (fp != NULL);
   assert (path != NULL);

--- a/src/base/ini_parser.c
+++ b/src/base/ini_parser.c
@@ -488,7 +488,7 @@ static INI_LINE_STATUS
 ini_parse_line (char *input_line, char *section, char *key, char *value)
 {
   INI_LINE_STATUS status;
-  char line[INI_BUFSIZ + 1];
+  char line[INI_BUFSIZ + 4];
   int len;
 
   strcpy (line, ini_str_trim (input_line));
@@ -515,7 +515,7 @@ ini_parse_line (char *input_line, char *section, char *key, char *value)
       leading_char = section[0];
       if (leading_char == '@' || leading_char == '%')
 	{
-	  sprintf (section, "%c%s", leading_char, ini_str_trim (section + 1));
+	  snprintf (section, INI_BUFSIZ + 2, "%c%s", leading_char, ini_str_trim (section + 1));
 	}
 
       if (leading_char != '@')

--- a/src/base/object_representation.h
+++ b/src/base/object_representation.h
@@ -2684,6 +2684,8 @@ or_get_oid (OR_BUF * buf, OID * oid)
 {
   ASSERT_ALIGN (buf->ptr, INT_ALIGNMENT);
 
+  OID_SET_NULL (oid);
+
   if ((buf->ptr + OR_OID_SIZE) > buf->endptr)
     {
       return or_underflow (buf);

--- a/src/base/object_representation_sr.c
+++ b/src/base/object_representation_sr.c
@@ -2442,7 +2442,7 @@ or_get_current_representation (RECDES * record, int do_indexes)
 		  sizeof (OR_ATTRIBUTE) * rep->n_attributes);
 	  goto error_cleanup;
 	}
-      memset (rep->attributes, 0, sizeof (OR_ATTRIBUTE) * rep->n_attributes);
+      memset ((void *) rep->attributes, 0, sizeof (OR_ATTRIBUTE) * rep->n_attributes);
     }
 
   if (rep->n_shared_attrs > 0)
@@ -2454,7 +2454,7 @@ or_get_current_representation (RECDES * record, int do_indexes)
 		  sizeof (OR_ATTRIBUTE) * rep->n_shared_attrs);
 	  goto error_cleanup;
 	}
-      memset (rep->shared_attrs, 0, sizeof (OR_ATTRIBUTE) * rep->n_shared_attrs);
+      memset ((void *) rep->shared_attrs, 0, sizeof (OR_ATTRIBUTE) * rep->n_shared_attrs);
     }
 
   if (rep->n_class_attrs > 0)
@@ -2466,7 +2466,7 @@ or_get_current_representation (RECDES * record, int do_indexes)
 		  sizeof (OR_ATTRIBUTE) * rep->n_class_attrs);
 	  goto error_cleanup;
 	}
-      memset (rep->class_attrs, 0, sizeof (OR_ATTRIBUTE) * rep->n_class_attrs);
+      memset ((void *) rep->class_attrs, 0, sizeof (OR_ATTRIBUTE) * rep->n_class_attrs);
     }
 
 
@@ -3015,7 +3015,7 @@ or_get_old_representation (RECDES * record, int repid, int do_indexes)
       free_and_init (rep);
       return NULL;
     }
-  memset (rep->attributes, 0, sizeof (OR_ATTRIBUTE) * rep->n_attributes);
+  memset ((void *) rep->attributes, 0, sizeof (OR_ATTRIBUTE) * rep->n_attributes);
 
   /* Calculate the beginning of the set_of(rep_attribute) in the representation object. Assume that the start of the
    * disk_rep points directly at the the substructure's variable offset table (which it does) and use
@@ -3214,7 +3214,7 @@ or_get_all_representation (RECDES * record, bool do_indexes, int *count)
 		  (sizeof (OR_ATTRIBUTE) * rep->n_attributes));
 	  goto error;
 	}
-      memset (rep->attributes, 0, sizeof (OR_ATTRIBUTE) * rep->n_attributes);
+      memset ((void *) rep->attributes, 0, sizeof (OR_ATTRIBUTE) * rep->n_attributes);
 
       /* Calculate the beginning of the set_of(rep_attribute) in the representation object. Assume that the start of
        * the disk_rep points directly at the the substructure's variable offset table (which it does) and use

--- a/src/base/xserver_interface.h
+++ b/src/base/xserver_interface.h
@@ -174,8 +174,7 @@ extern bool logtb_has_updated (THREAD_ENTRY * thread_p);
 
 
 extern BTID *xbtree_add_index (THREAD_ENTRY * thread_p, BTID * btid, TP_DOMAIN * key_type, OID * class_oid, int attr_id,
-			       int unique_pk, long long num_oids, long long num_nulls, long long num_keys,
-			       int deduplicate_key_pos);
+			       int unique_pk, INT64 num_oids, INT64 num_nulls, INT64 num_keys, int deduplicate_key_pos);
 extern BTID *xbtree_load_index (THREAD_ENTRY * thread_p, BTID * btid, const char *bt_name, TP_DOMAIN * key_type,
 				OID * class_oids, int n_classes, int n_attrs, int *attr_ids, int *attrs_prefix_length,
 				HFID * hfids, int unique_pk, int not_null_flag, OID * fk_refcls_oid,

--- a/src/compat/dbtype_function.i
+++ b/src/compat/dbtype_function.i
@@ -557,6 +557,7 @@ db_get_bit (const DB_VALUE * value, int *length)
 
   if (value->domain.general_info.is_null)
     {
+      *length = 0;
       return NULL;
     }
 

--- a/src/connection/host_lookup.c
+++ b/src/connection/host_lookup.c
@@ -407,7 +407,8 @@ is_valid_ip (char *ip_addr)
 	  dot++;
 	}
     }
-  while (token = strtok_r (NULL, delim, &save_ptr_strtok));
+  while ((token = strtok_r (NULL, delim, &save_ptr_strtok)) != NULL);
+
   if (dot != NUM_IPADDR_DOT)
     {
       goto err_phase;

--- a/src/executables/compactdb_common.c
+++ b/src/executables/compactdb_common.c
@@ -255,7 +255,7 @@ get_class_mops_from_file (const char *input_filename, MOP ** class_list, int *nu
 	  goto end;
 	}
 
-      strncpy (class_names[i], buffer, len);
+      strncpy (class_names[i], buffer, len + 1);
       class_names[i][len] = 0;
     }
 

--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -162,7 +162,7 @@ char csql_Scratch_text[SCRATCH_TEXT_LEN];
 int csql_Error_code = NO_ERROR;
 
 static char csql_Prompt[100];
-static char csql_Prompt_offline[100];
+static char csql_Prompt_offline[101];
 static char csql_Name[100];
 
 /*

--- a/src/executables/unittests_snapshot.c
+++ b/src/executables/unittests_snapshot.c
@@ -120,7 +120,7 @@ logtb_tran_btid_hash_cmp_func (const void *key1, const void *key2)
 static void
 logtb_initialize_tdes_for_mvcc_testing (LOG_TDES * tdes, int tran_index)
 {
-  memset (tdes, 0, sizeof (LOG_TDES));
+  memset ((void *) tdes, 0, sizeof (LOG_TDES));
   tdes->tran_index = tran_index;
   tdes->trid = NULL_TRANID;
 
@@ -157,7 +157,7 @@ logtb_initialize_mvcc_testing (int num_threads, THREAD_ENTRY ** thread_array)
       error_code = ER_OUT_OF_VIRTUAL_MEMORY;
       goto error;
     }
-  memset (*thread_array, 0, size);
+  memset ((void *) *thread_array, 0, size);
   for (i = 0; i < num_threads; i++)
     {
       thread_p = *thread_array + i;

--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -1802,7 +1802,7 @@ emit_query_specs (extract_context & ctxt, print_output & output_ctx, DB_OBJLIST 
 		  null_spec = pt_print_query_spec_no_list (parser, *query_ptr);
 		  SPLIT_USER_SPECIFIED_NAME (name, owner_name, class_name);
 
-		  PRINT_OWNER_NAME (output_owner, (ctxt.is_dba_user || ctxt.is_dba_group_member), output_owner,
+		  PRINT_OWNER_NAME (owner_name, (ctxt.is_dba_user || ctxt.is_dba_group_member), output_owner,
 				    sizeof (output_owner));
 
 		  output_ctx ("ALTER VCLASS %s%s%s%s ADD QUERY %s ; \n", output_owner,
@@ -3503,7 +3503,7 @@ emit_index_def (extract_context & ctxt, print_output & output_ctx, DB_OBJECT * c
       assert ((constraint->index_status == SM_ONLINE_INDEX_BUILDING_IN_PROGRESS)
 	      || (ctype != DB_CONSTRAINT_UNIQUE && ctype != DB_CONSTRAINT_REVERSE_UNIQUE));
 
-      if ((reserved_col_buf[0] == '\0') && !SM_IS_CONSTRAINT_UNIQUE_FAMILY (ctype))
+      if ((reserved_col_buf[0] == '\0') && !DB_IS_CONSTRAINT_UNIQUE_FAMILY (ctype))
 	{
 	  dk_print_deduplicate_key_info (reserved_col_buf, sizeof (reserved_col_buf), DEDUPLICATE_KEY_LEVEL_OFF);
 	}

--- a/src/executables/unloaddb.h
+++ b/src/executables/unloaddb.h
@@ -61,15 +61,15 @@ extern int lo_count;
 #define PRINT_IDENTIFIER_WITH_QUOTE(s) "\"", (s), "\""
 #define PRINT_FUNCTION_INDEX_NAME(s) "\"", (s), "\""
 
-#define PRINT_OWNER_NAME(owner, print, out_owner, out_len) \
+#define PRINT_OWNER_NAME(owner, print, output_owner, out_len) \
 do \
   { \
   size_t total_len = strlen (owner) + 4; \
   assert (strlen ((owner)) < STATIC_CAST (int, out_len)); \
   if (print) \
-      snprintf (out_owner, total_len, "%s%s%s%s", PRINT_IDENTIFIER (owner), "."); \
+      snprintf (output_owner, total_len, "%s%s%s%s", PRINT_IDENTIFIER (owner), "."); \
   else \
-    strcpy(out_owner, ""); \
+    strcpy(output_owner, ""); \
   } \
 while (0)
 

--- a/src/executables/unloaddb.h
+++ b/src/executables/unloaddb.h
@@ -61,11 +61,11 @@ extern int lo_count;
 #define PRINT_IDENTIFIER_WITH_QUOTE(s) "\"", (s), "\""
 #define PRINT_FUNCTION_INDEX_NAME(s) "\"", (s), "\""
 
-#define PRINT_OWNER_NAME(owner, print, output_owner, out_len) \
+#define PRINT_OWNER_NAME(owner, print, output_owner, output_len) \
 do \
   { \
   size_t total_len = strlen (owner) + 4; \
-  assert (strlen ((owner)) < STATIC_CAST (int, out_len)); \
+  assert (strlen ((owner)) < STATIC_CAST (int, output_len)); \
   if (print) \
       snprintf (output_owner, total_len, "%s%s%s%s", PRINT_IDENTIFIER (owner), "."); \
   else \

--- a/src/executables/unloaddb.h
+++ b/src/executables/unloaddb.h
@@ -61,15 +61,15 @@ extern int lo_count;
 #define PRINT_IDENTIFIER_WITH_QUOTE(s) "\"", (s), "\""
 #define PRINT_FUNCTION_INDEX_NAME(s) "\"", (s), "\""
 
-#define PRINT_OWNER_NAME(owner, print, output_owner, output_len) \
+#define PRINT_OWNER_NAME(owner, print, out_owner, out_len) \
 do \
   { \
   size_t total_len = strlen (owner) + 4; \
-  assert (strlen ((owner)) < STATIC_CAST (int, output_len)); \
+  assert (strlen ((owner)) < STATIC_CAST (int, out_len)); \
   if (print) \
-      snprintf (output_owner, total_len, "%s%s%s%s", PRINT_IDENTIFIER (owner), "."); \
+      snprintf (out_owner, total_len, "%s%s%s%s", PRINT_IDENTIFIER (owner), "."); \
   else \
-    strcpy(output_owner, ""); \
+    strcpy(out_owner, ""); \
   } \
 while (0)
 

--- a/src/method/method_struct_query.cpp
+++ b/src/method/method_struct_query.cpp
@@ -493,7 +493,7 @@ namespace cubmethod
     fprintf (stdout, "tuple_count: %d\n", tuple_count);
     fprintf (stdout, "ins_oid (%d, %d, %d)\n", ins_oid.pageid, ins_oid.slotid, ins_oid.volid);
     fprintf (stdout, "include_oid: %d\n", include_oid);
-    fprintf (stdout, "query_id: %lld\n", query_id);
+    fprintf (stdout, "query_id: %lu\n", query_id);
   }
 
   void

--- a/src/method/method_struct_query.cpp
+++ b/src/method/method_struct_query.cpp
@@ -493,7 +493,7 @@ namespace cubmethod
     fprintf (stdout, "tuple_count: %d\n", tuple_count);
     fprintf (stdout, "ins_oid (%d, %d, %d)\n", ins_oid.pageid, ins_oid.slotid, ins_oid.volid);
     fprintf (stdout, "include_oid: %d\n", include_oid);
-    fprintf (stdout, "query_id: %lu\n", query_id);
+    fprintf (stdout, "query_id: %ud\n", (unsigned int)query_id);
   }
 
   void

--- a/src/method/query_method.cpp
+++ b/src/method/query_method.cpp
@@ -224,7 +224,7 @@ method_dispatch_internal (packing_unpacker &unpacker)
 	  uint64_t id;
 	  std::vector <int> handlers;
 	  unpacker.unpack_all (id, handlers);
-	  for (int i = 0; i < handlers.size (); i++)
+	  for (int i = 0; i < (int)handlers.size (); i++)
 	    {
 	      cubmethod::get_callback_handler()->free_query_handle (handlers[i], false);
 	    }

--- a/src/monitor/monitor_vacuum_ovfp_threshold.cpp
+++ b/src/monitor/monitor_vacuum_ovfp_threshold.cpp
@@ -519,12 +519,12 @@ ovfp_threshold_mgr::print (THREAD_ENTRY *thread_p, FILE *outfp, const INDEX_OVFP
       assert (class_name != NULL && index_name != NULL);
       if (class_name)
 	{
-	  fprintf (outfp, "  %-*s", MAX (attr_lengths[0], strlen (class_name)), class_name);
+	  fprintf (outfp, "  %-*s", MAX (attr_lengths[0], (int)strlen (class_name)), class_name);
 	  free_and_init (class_name);
 	}
       if (index_name)
 	{
-	  fprintf (outfp, "  %-*s", MAX (attr_lengths[1], strlen (index_name)), index_name);
+	  fprintf (outfp, "  %-*s", MAX (attr_lengths[1], (int)strlen (index_name)), index_name);
 	  free_and_init (index_name);
 	}
 
@@ -532,11 +532,11 @@ ovfp_threshold_mgr::print (THREAD_ENTRY *thread_p, FILE *outfp, const INDEX_OVFP
 
       sprintf (line_buf, "  %d (%s)", pt->read_pages[RECENT_POS], time_to_string (pt->event_time[RECENT_POS], time_buf,
 	       sizeof (time_buf)));
-      fprintf (outfp, "  %-*s", MAX (attr_lengths[3], strlen (line_buf)), line_buf);
+      fprintf (outfp, "  %-*s", MAX (attr_lengths[3], (int)strlen (line_buf)), line_buf);
 
       sprintf (line_buf, "  %d (%s)", pt->read_pages[MAX_POS], time_to_string (pt->event_time[MAX_POS], time_buf,
 	       sizeof (time_buf)));
-      fprintf (outfp, "  %-*s\n", MAX (attr_lengths[4], strlen (line_buf)), line_buf);
+      fprintf (outfp, "  %-*s\n", MAX (attr_lengths[4], (int)strlen (line_buf)), line_buf);
 
       pt = pt->next;
     }

--- a/src/monitor/monitor_vacuum_ovfp_threshold.cpp
+++ b/src/monitor/monitor_vacuum_ovfp_threshold.cpp
@@ -528,7 +528,7 @@ ovfp_threshold_mgr::print (THREAD_ENTRY *thread_p, FILE *outfp, const INDEX_OVFP
 	  free_and_init (index_name);
 	}
 
-      fprintf (outfp, "  %*lld", attr_lengths[2], (long long) pt->hit_cnt);
+      fprintf (outfp, "  %*ld", attr_lengths[2], pt->hit_cnt);
 
       sprintf (line_buf, "  %d (%s)", pt->read_pages[RECENT_POS], time_to_string (pt->event_time[RECENT_POS], time_buf,
 	       sizeof (time_buf)));

--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -4184,7 +4184,7 @@ classobj_find_constraint_by_attrs (SM_CLASS_CONSTRAINT * cons_list, DB_CONSTRAIN
 	}
     }
 
-  is_uk_new = SM_IS_CONSTRAINT_UNIQUE_FAMILY (new_cons);
+  is_uk_new = DB_IS_CONSTRAINT_UNIQUE_FAMILY (new_cons);
 
   for (cons = cons_list; cons; cons = cons->next)
     {
@@ -8171,7 +8171,7 @@ classobj_check_index_compatibility (SM_CLASS_CONSTRAINT * constraints, const DB_
 	{
 	  return SM_CREATE_NEW_INDEX;
 	}
-      else if (existing_con->type == SM_CONSTRAINT_INDEX || existing_con->type == DB_CONSTRAINT_REVERSE_INDEX)
+      else if (existing_con->type == SM_CONSTRAINT_INDEX || existing_con->type == SM_CONSTRAINT_REVERSE_INDEX)
 	{
 	  return SM_SHARE_INDEX;
 	}

--- a/src/object/deduplicate_key.c
+++ b/src/object/deduplicate_key.c
@@ -151,7 +151,7 @@ dk_get_deduplicate_key_value (OID * rec_oid, int att_id, DB_VALUE * value)
   bool is_test_for_developer = false;
   if (is_test_for_developer)
     {
-#define OID_2_BIGINT(oidptr) (((oidptr)->volid << 48) | ((oidptr)->pageid << 16) | (oidptr)->slotid)
+#define OID_2_BIGINT(oidptr) (((int64_t)((oidptr)->volid) << 48) | ((oidptr)->pageid << 16) | (oidptr)->slotid)
       assert (CALC_MOD_VALUE_FROM_LEVEL (level) <= SHRT_MAX);
       db_make_short (value, (short) (OID_2_BIGINT (rec_oid) % CALC_MOD_VALUE_FROM_LEVEL (level)));
 

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -11518,7 +11518,7 @@ tp_value_auto_cast_with_precision_check (const DB_VALUE * src, DB_VALUE * dest, 
       /* if the numeric's precision is 19 or more, then it can get the bigint enough */
       if (desired_domain->type->id == DB_TYPE_NUMERIC && desired_domain->precision < 19)
 	{
-	  INT64 bigint;
+	  INT64 bigint = 0;
 
 	  assert (desired_domain->precision >= 0);
 

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -3568,7 +3568,7 @@ static int
 mr_data_readval_utime (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain, int size, bool copy, char *copy_buf,
 		       int copy_buf_len)
 {
-  DB_UTIME utm;
+  DB_UTIME utm = 0;
   int rc = NO_ERROR;
 
   if (value == NULL)
@@ -3591,7 +3591,7 @@ static int
 mr_data_readval_timestampltz (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain, int size, bool copy, char *copy_buf,
 			      int copy_buf_len)
 {
-  DB_UTIME utm;
+  DB_UTIME utm = 0;
   int rc = NO_ERROR;
 
   if (value == NULL)

--- a/src/parser/keyword.c
+++ b/src/parser/keyword.c
@@ -821,7 +821,7 @@ verify_test (bool is_keywords, KEYWORDS_TABLE_SRCH_INFO & info)
 	  assert (strcasecmp (pk->keyword, keywords[i].keyword) == 0);
 	}
 
-      for (i = 0; i < sizeof (functions) / sizeof (functions[0]); i++)
+      for (i = 0; i < (int) (sizeof (functions) / sizeof (functions[0])); i++)
 	{
 	  pk = pt_find_keyword (functions[i].keyword);
 	  if (pk)
@@ -840,7 +840,7 @@ verify_test (bool is_keywords, KEYWORDS_TABLE_SRCH_INFO & info)
 	  assert (strcasecmp (pf->keyword, functions[i].keyword) == 0);
 	}
 
-      for (i = 0; i < sizeof (keywords) / sizeof (keywords[0]); i++)
+      for (i = 0; i < (int) (sizeof (keywords) / sizeof (keywords[0])); i++)
 	{
 	  pf = pt_find_function_name (keywords[i].keyword);
 	  if (pf)

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -11607,7 +11607,7 @@ pt_convert_dblink_dml_query (PARSER_CONTEXT * parser, PT_NODE * node,
   PT_NODE *list = NULL;		/* for insert select list */
   PT_NODE *spec, *into_spec = NULL, *upd_spec = NULL, *server;
 
-  PARSER_VARCHAR *comment, *dml;
+  PARSER_VARCHAR *comment = NULL, *dml;
 
   switch (node->node_type)
     {

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -17209,7 +17209,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	      cmp = 1;
 	      break;
 	    }
-	  [[fallthrought]];
+	  [[fallthrough]];
 	case PT_NE_ALL:
 	  cmp = set_issome (arg1, db_get_set (arg2), PT_EQ_SOME, 1);
 	  if (cmp == 1)
@@ -17740,7 +17740,7 @@ pt_is_dblink_related (PT_NODE * p)
 static PT_NODE *
 pt_fold_const_expr (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg)
 {
-  PT_TYPE_ENUM type1, type2 = PT_TYPE_NONE, type3, result_type;
+  PT_TYPE_ENUM type1, type2 = PT_TYPE_NONE, type3 = PT_TYPE_NONE, result_type;
   PT_NODE *opd1 = NULL, *opd2 = NULL, *opd3 = NULL, *result = NULL;
   DB_VALUE dummy, dbval_res, *arg1, *arg2, *arg3;
   PT_OP_TYPE op;

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -7809,15 +7809,13 @@ pt_fold_constants_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *
   switch (node->node_type)
     {
     case PT_FUNCTION:
-    case PT_EXPR:
-      if (node->node_type == PT_FUNCTION)
+      if (node->info.function.function_type == F_BENCHMARK)
 	{
-	  if (node->info.function.function_type == F_BENCHMARK)
-	    {
-	      // we want to test full execution of sub-tree; don't fold it!
-	      *continue_walk = PT_LIST_WALK;
-	    }
+	  // we want to test full execution of sub-tree; don't fold it!
+	  *continue_walk = PT_LIST_WALK;
 	}
+      [[fallthrough]];
+    case PT_EXPR:
       if (pt_is_dblink_related (node))
 	{
 	  parser_walk_tree (parser, node, pt_set_flag_do_not_fold_for_dblink, NULL, NULL, NULL);
@@ -17206,15 +17204,13 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	  break;
 
 	case PT_IS_NOT_IN:
-	case PT_NE_ALL:
-	  if (op == PT_IS_NOT_IN)
+	  if (o2->node_type == PT_VALUE && o2->info.value.is_false_where)
 	    {
-	      if (o2->node_type == PT_VALUE && o2->info.value.is_false_where)
-		{
-		  cmp = 1;
-		  break;
-		}
+	      cmp = 1;
+	      break;
 	    }
+	  [[fallthrought]];
+	case PT_NE_ALL:
 	  cmp = set_issome (arg1, db_get_set (arg2), PT_EQ_SOME, 1);
 	  if (cmp == 1)
 	    cmp = 0;

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -7809,12 +7809,15 @@ pt_fold_constants_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *
   switch (node->node_type)
     {
     case PT_FUNCTION:
-      if (node->info.function.function_type == F_BENCHMARK)
-	{
-	  // we want to test full execution of sub-tree; don't fold it!
-	  *continue_walk = PT_LIST_WALK;
-	}
     case PT_EXPR:
+      if (node->node_type == PT_FUNCTION)
+	{
+	  if (node->info.function.function_type == F_BENCHMARK)
+	    {
+	      // we want to test full execution of sub-tree; don't fold it!
+	      *continue_walk = PT_LIST_WALK;
+	    }
+	}
       if (pt_is_dblink_related (node))
 	{
 	  parser_walk_tree (parser, node, pt_set_flag_do_not_fold_for_dblink, NULL, NULL, NULL);
@@ -17203,12 +17206,15 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	  break;
 
 	case PT_IS_NOT_IN:
-	  if (o2->node_type == PT_VALUE && o2->info.value.is_false_where)
-	    {
-	      cmp = 1;
-	      break;
-	    }
 	case PT_NE_ALL:
+	  if (op == PT_IS_NOT_IN)
+	    {
+	      if (o2->node_type == PT_VALUE && o2->info.value.is_false_where)
+		{
+		  cmp = 1;
+		  break;
+		}
+	    }
 	  cmp = set_issome (arg1, db_get_set (arg2), PT_EQ_SOME, 1);
 	  if (cmp == 1)
 	    cmp = 0;

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -3514,8 +3514,7 @@ pt_check_pushable_subquery_select_list (PARSER_CONTEXT * parser, PT_NODE * query
 		    cinfo.method_found = true;
 		    break;
 		  }
-		parser_walk_leaves (parser, list, pt_check_pushable, &cinfo, NULL, NULL);
-		break;
+		[[fallthrough]];
 
 	      default:		/* do traverse */
 		parser_walk_leaves (parser, list, pt_check_pushable, &cinfo, NULL, NULL);

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -3514,6 +3514,8 @@ pt_check_pushable_subquery_select_list (PARSER_CONTEXT * parser, PT_NODE * query
 		    cinfo.method_found = true;
 		    break;
 		  }
+		parser_walk_leaves (parser, list, pt_check_pushable, &cinfo, NULL, NULL);
+		break;
 
 	      default:		/* do traverse */
 		parser_walk_leaves (parser, list, pt_check_pushable, &cinfo, NULL, NULL);

--- a/src/query/crypt_opfunc.c
+++ b/src/query/crypt_opfunc.c
@@ -337,7 +337,7 @@ crypt_default_decrypt (THREAD_ENTRY * thread_p, const char *src, int src_len, co
 		       char **dest_p, int *dest_len_p, CIPHER_ENCRYPTION_TYPE enc_type)
 {
   char *dest = NULL;
-  int dest_len;
+  int dest_len = 0;
   int error_status = NO_ERROR;
   int pad, pad_len;
   int i;

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -183,7 +183,7 @@ print_utype_to_string (int type)
 static int
 dblink_make_cci_value (DB_VALUE * cci_value, T_CCI_U_TYPE utype, void *val, int prec, int len, int codeset)
 {
-  int error;
+  int error = NO_ERROR;
 
   switch (utype)
     {
@@ -393,7 +393,7 @@ dblink_bind_param (int stmt_handle, VAL_DESCR * vd, DBLINK_HOST_VARS * host_vars
   DB_TIME time;
   T_CCI_DATE cci_date;
   T_CCI_BIT cci_bit;
-  int num_size;
+  int num_size = 0;
   char num_str[40];
 
   unsigned char type;
@@ -523,6 +523,7 @@ dblink_bind_param (int stmt_handle, VAL_DESCR * vd, DBLINK_HOST_VARS * host_vars
 	  break;
 	case DB_TYPE_NULL:
 	  value = NULL;
+	  a_type = CCI_A_TYPE_STR;
 	  u_type = CCI_U_TYPE_NULL;
 	  break;
 	default:

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -10636,7 +10636,9 @@ do_change_att_schema_only (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NOD
 	    {
 	      break;
 	    }
-	[[fallthrough]] default:
+	  [[fallthrough]];
+
+	default:
 	  att = attribute->info.attr_def.attr_name;
 	  att_name = att->info.name.original;
 
@@ -11206,10 +11208,7 @@ build_attr_change_map (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NODE * 
 	  break;
 	case PT_CONSTRAIN_NULL:
 	  attr_chg_properties->p[P_NOT_NULL] = ATT_CHG_PROPERTY_LOST;
-	  constr_att_list = cnstr->info.constraint.un.not_null.attr;
-	  chg_prop_idx = P_NOT_NULL;
-	  save_pt_costraint = true;
-	  break;
+	  [[fallthrough]];
 	case PT_CONSTRAIN_NOT_NULL:
 	  constr_att_list = cnstr->info.constraint.un.not_null.attr;
 	  chg_prop_idx = P_NOT_NULL;

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -2895,7 +2895,7 @@ create_or_drop_index_helper (PARSER_CONTEXT * parser, const char *const constrai
 	      || !classobj_check_attr_in_unique_constraint (class_->constraints, attnames, func_index_info))
 	    {
 	      dk_create_index_level_adjust (idx_info, attnames, asc_desc, attrs_prefix_length, func_index_info,
-					    nnames, SM_IS_CONSTRAINT_REVERSE_INDEX_FAMILY (ctype));
+					    nnames, DB_IS_CONSTRAINT_REVERSE_INDEX_FAMILY (ctype));
 	    }
 	}
     }
@@ -10631,13 +10631,12 @@ do_change_att_schema_only (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NOD
 	case PT_TYPE_SMALLINT:
 	  break;
 
-	case PT_TYPE_NUMERIC:
-	  if (attribute->data_type->info.data_type.dec_precision == 0)
+	default:
+	  if (attribute->type_enum == PT_TYPE_NUMERIC && attribute->data_type->info.data_type.dec_precision == 0)
 	    {
 	      break;
 	    }
 
-	default:
 	  att = attribute->info.attr_def.attr_name;
 	  att_name = att->info.name.original;
 
@@ -11207,6 +11206,10 @@ build_attr_change_map (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NODE * 
 	  break;
 	case PT_CONSTRAIN_NULL:
 	  attr_chg_properties->p[P_NOT_NULL] = ATT_CHG_PROPERTY_LOST;
+	  constr_att_list = cnstr->info.constraint.un.not_null.attr;
+	  chg_prop_idx = P_NOT_NULL;
+	  save_pt_costraint = true;
+	  break;
 	case PT_CONSTRAIN_NOT_NULL:
 	  constr_att_list = cnstr->info.constraint.un.not_null.attr;
 	  chg_prop_idx = P_NOT_NULL;

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -10631,12 +10631,12 @@ do_change_att_schema_only (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NOD
 	case PT_TYPE_SMALLINT:
 	  break;
 
-	default:
-	  if (attribute->type_enum == PT_TYPE_NUMERIC && attribute->data_type->info.data_type.dec_precision == 0)
+	case PT_TYPE_NUMERIC:
+	  if (attribute->data_type->info.data_type.dec_precision == 0)
 	    {
 	      break;
 	    }
-
+	[[fallthrough]] default:
 	  att = attribute->info.attr_def.attr_name;
 	  att_name = att->info.name.original;
 

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -4643,7 +4643,7 @@ do_rename_partition (MOP old_class, const char *newname)
   int newlen;
   int error;
   char new_subname[PARTITION_VARCHAR_LEN + 1], *ptr;
-  char expr[DB_MAX_PARTITION_EXPR_LENGTH] = { '\0' };
+  char expr[DB_MAX_PARTITION_EXPR_LENGTH + 1] = { '\0' };
   char *expr_ptr = NULL;
 
   if (!old_class || !newname)

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -15348,12 +15348,12 @@ do_supplemental_statement (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVE
 
 	    if (cls_info[i]->objtype == CDC_TABLE)
 	      {
-		strncpy (drop_stmt, drop_prefix, strlen (drop_prefix));
+		strncpy (drop_stmt, drop_prefix, strlen (drop_prefix) + 1);
 		drop_copied_length = strlen (drop_prefix);
 	      }
 	    else if (cls_info[i]->objtype == CDC_VIEW)
 	      {
-		strncpy (drop_stmt, drop_view_prefix, strlen (drop_view_prefix));
+		strncpy (drop_stmt, drop_view_prefix, strlen (drop_view_prefix) + 1);
 		drop_copied_length = strlen (drop_view_prefix);
 	      }
 	    else
@@ -15363,16 +15363,16 @@ do_supplemental_statement (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVE
 
 	    if (statement->info.drop.if_exists)
 	      {
-		strncpy (drop_stmt + drop_copied_length, if_exist_statement, strlen (if_exist_statement));
+		strncpy (drop_stmt + drop_copied_length, if_exist_statement, strlen (if_exist_statement) + 1);
 		drop_copied_length += strlen (if_exist_statement);
 	      }
 
-	    strncpy (drop_stmt + drop_copied_length, cls_info[i]->name, strlen (cls_info[i]->name));
+	    strncpy (drop_stmt + drop_copied_length, cls_info[i]->name, strlen (cls_info[i]->name) + 1);
 	    drop_copied_length += strlen (cls_info[i]->name);
 
 	    if (statement->info.drop.is_cascade_constraints)
 	      {
-		strncpy (drop_stmt + drop_copied_length, cascade_statement, strlen (cascade_statement));
+		strncpy (drop_stmt + drop_copied_length, cascade_statement, strlen (cascade_statement) + 1);
 		drop_copied_length += strlen (cascade_statement);
 	      }
 
@@ -15618,6 +15618,10 @@ do_supplemental_statement (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVE
 	break;
       }
     case PT_REMOVE_TRIGGER:
+      {
+	ddl_type = CDC_ALTER;
+	objtype = CDC_TRIGGER;
+      }
       break;
 
     case PT_ALTER_TRIGGER:
@@ -17056,7 +17060,7 @@ int
 do_prepare_merge (PARSER_CONTEXT * parser, PT_NODE * statement)
 {
   int err = NO_ERROR;
-  PT_NODE *non_nulls_upd = NULL, *non_nulls_ins = NULL, *lhs, *flat, *spec;
+  PT_NODE *non_nulls_upd = NULL, *non_nulls_ins = NULL, *lhs, *flat = NULL, *spec;
   int has_unique = 0, has_trigger = 0, has_virt = 0, au_save;
   bool server_insert, server_update, server_op, insert_only = false;
 
@@ -17491,7 +17495,7 @@ do_execute_merge (PARSER_CONTEXT * parser, PT_NODE * statement)
   int err = NO_ERROR;
   INT64 result = 0;
   int error = NO_ERROR;
-  PT_NODE *flat, *spec = NULL, *values_list = NULL;
+  PT_NODE *flat = NULL, *spec = NULL, *values_list = NULL;
   const char *savepoint_name;
   DB_OBJECT *class_obj;
   QFILE_LIST_ID *list_id = NULL;
@@ -21017,7 +21021,7 @@ get_dblink_owner_name_from_dbserver (PARSER_CONTEXT * parser, PT_NODE * server_n
 {
   DB_OBJECT *server_object = NULL;
   MOP user_obj = NULL;
-  int au_save, error;
+  int au_save, error = NO_ERROR;
   DB_VALUE user_val;
 
   db_make_null (&user_val);
@@ -21210,7 +21214,7 @@ get_dblink_password_encrypt (const char *passwd, DB_VALUE * encrypt_val, bool is
   int err, length, buf_size;
   char cipher[DBLINK_PASSWORD_CIPHER_LENGTH + 1], newpwd[DBLINK_PASSWORD_MAX_BUFSIZE + 1];
   char confused[DBLINK_PASSWORD_CIPHER_LENGTH + 1] = { 0, };
-  unsigned char private_key[DBLINK_CRYPT_KEY_LENGTH];
+  unsigned char private_key[DBLINK_CRYPT_KEY_LENGTH * 3];
   struct timeval check_time = { 0, 0 };
   struct tm *lt;
   char empty_str[4] = { 0x00, };

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -5583,7 +5583,7 @@ QFILE_LIST_CACHE_ENTRY *
 qfile_lookup_list_cache_entry (THREAD_ENTRY * thread_p, XASL_CACHE_ENTRY * xasl, const DB_VALUE_ARRAY * params,
 			       bool * result_cached)
 {
-  QFILE_LIST_CACHE_ENTRY *lent;
+  QFILE_LIST_CACHE_ENTRY *lent = NULL;
   int tran_index;
 #if defined(SERVER_MODE)
   TRAN_ISOLATION tran_isolation;

--- a/src/query/query_aggregate.cpp
+++ b/src/query/query_aggregate.cpp
@@ -963,7 +963,7 @@ int
 qdata_evaluate_aggregate_optimize (cubthread::entry *thread_p, cubxasl::aggregate_list_node *agg_p, HFID *hfid_p,
 				   OID *super_oid)
 {
-  long long oid_count = 0, null_count = 0, key_count = 0;
+  INT64 oid_count = 0, null_count = 0, key_count = 0;
   int flag_btree_stat_needed = true;
 
   if (!agg_p->flag_agg_optimize)

--- a/src/query/stream_to_xasl.c
+++ b/src/query/stream_to_xasl.c
@@ -4482,7 +4482,7 @@ stx_build_access_spec_type (THREAD_ENTRY * thread_p, char *ptr, ACCESS_SPEC_TYPE
     }
 
   /* access_spec_type->s_id not sent to server */
-  memset (&access_spec->s_id, '\0', sizeof (SCAN_ID));
+  memset ((void *) &access_spec->s_id, '\0', sizeof (SCAN_ID));
   access_spec->s_id.status = S_CLOSED;
 
   if (access_spec->type == TARGET_JSON_TABLE)

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -12083,7 +12083,7 @@ db_time_format (const DB_VALUE * src_value, const DB_VALUE * format, const DB_VA
   INTL_CODESET codeset;
   int res_collation;
   char tzr[TZR_SIZE + 1], tzd[TZ_DS_STRING_SIZE + 1];
-  char hours_or_minutes[4];
+  char hours_or_minutes[32];
   int tzh = 0, tzm = 0;
   bool is_valid_tz = false;
   DB_VALUE new_time_value;
@@ -22451,7 +22451,7 @@ db_date_format (const DB_VALUE * date_value, const DB_VALUE * format, const DB_V
   INTL_CODESET codeset;
   int res_collation;
   char tzr[TZR_SIZE + 1], tzd[TZ_DS_STRING_SIZE + 1];
-  char hours_or_minutes[4];
+  char hours_or_minutes[32];
   int tzh = 0, tzm = 0;
   bool is_valid_tz = false;
   bool has_tzh = false;

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -20,6 +20,7 @@
  * vacuum.c - Vacuuming system implementation.
  *
  */
+#include "inttypes.h"
 #include "system.h"
 #include "vacuum.h"
 

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1128,7 +1128,7 @@ xvacuum_dump (THREAD_ENTRY * thread_p, FILE * outfp)
 
   fprintf (outfp, "\n");
   fprintf (outfp, "*** Vacuum Dump ***\n");
-  fprintf (outfp, "First log page ID referenced = %lld ", min_log_pageid);
+  fprintf (outfp, "First log page ID referenced = %ld ", min_log_pageid);
 
   if (logpb_is_page_in_archive (min_log_pageid))
     {

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -20,7 +20,10 @@
  * vacuum.c - Vacuuming system implementation.
  *
  */
-#include "inttypes.h"
+#if !defined(WINDOWS)
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
+#endif
 #include "system.h"
 #include "vacuum.h"
 

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1128,7 +1128,7 @@ xvacuum_dump (THREAD_ENTRY * thread_p, FILE * outfp)
 
   fprintf (outfp, "\n");
   fprintf (outfp, "*** Vacuum Dump ***\n");
-  fprintf (outfp, "First log page ID referenced = %ld ", min_log_pageid);
+  fprintf (outfp, "First log page ID referenced = %" PRId64 " ", min_log_pageid);
 
   if (logpb_is_page_in_archive (min_log_pageid))
     {

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -22,6 +22,11 @@
 
 #ident "$Id$"
 
+#if !defined(WINDOWS)
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
+#endif
+
 #include "btree.h"
 
 #include "btree_load.h"

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -4566,8 +4566,8 @@ btree_dump_root_header (THREAD_ENTRY * thread_p, FILE * fp, PAGE_PTR page_ptr)
 
   fprintf (fp, "==============    R O O T    P A G E   ================\n\n");
   fprintf (fp, " Key_Type: %s\n", pr_type_name (TP_DOMAIN_TYPE (key_type)));
-  fprintf (fp, " Num OIDs: %ld, Num NULLs: %ld, Num keys: %ld\n", root_header->num_oids, root_header->num_nulls,
-	   root_header->num_keys);
+  fprintf (fp, " Num OIDs: %" PRId64 ", Num NULLs: %" PRId64 ", Num keys: %" PRId64 "\n", root_header->num_oids,
+	   root_header->num_nulls, root_header->num_keys);
   fprintf (fp, " Topclass_oid: (%d %d %d)\n", root_header->topclass_oid.volid, root_header->topclass_oid.pageid,
 	   root_header->topclass_oid.slotid);
   fprintf (fp, " Unique: ");
@@ -5558,7 +5558,7 @@ btree_search_leaf_page (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR page_
  */
 BTID *
 xbtree_add_index (THREAD_ENTRY * thread_p, BTID * btid, TP_DOMAIN * key_type, OID * class_oid, int attr_id,
-		  int unique_pk, long long num_oids, long long num_nulls, long long num_keys, int deduplicate_key_pos)
+		  int unique_pk, INT64 num_oids, INT64 num_nulls, INT64 num_keys, int deduplicate_key_pos)
 {
   BTREE_ROOT_HEADER root_header_info, *root_header = NULL;
   VPID root_vpid;
@@ -6239,7 +6239,7 @@ xbtree_class_test_unique (THREAD_ENTRY * thread_p, char *buf, int buf_size)
 static int
 xbtree_test_unique (THREAD_ENTRY * thread_p, BTID * btid)
 {
-  long long num_oids, num_nulls, num_keys;
+  INT64 num_oids, num_nulls, num_keys;
 
   if (logtb_get_global_unique_stats (thread_p, btid, &num_oids, &num_nulls, &num_keys) != NO_ERROR)
     {
@@ -6311,8 +6311,8 @@ xbtree_get_unique_pk (THREAD_ENTRY * thread_p, BTID * btid)
  * Note: In MVCC the statistics are taken from memory structures. In non-mvcc from B-tree header
  */
 int
-btree_get_unique_statistics_for_count (THREAD_ENTRY * thread_p, BTID * btid, long long *oid_cnt, long long *null_cnt,
-				       long long *key_cnt)
+btree_get_unique_statistics_for_count (THREAD_ENTRY * thread_p, BTID * btid, INT64 * oid_cnt, INT64 * null_cnt,
+				       INT64 * key_cnt)
 {
   LOG_TRAN_BTID_UNIQUE_STATS *unique_stats = NULL;
 
@@ -6340,8 +6340,7 @@ btree_get_unique_statistics_for_count (THREAD_ENTRY * thread_p, BTID * btid, lon
  * the btree is not a unique btree, all the stats will be -1.
  */
 int
-btree_get_unique_statistics (THREAD_ENTRY * thread_p, BTID * btid, long long *oid_cnt, long long *null_cnt,
-			     long long *key_cnt)
+btree_get_unique_statistics (THREAD_ENTRY * thread_p, BTID * btid, INT64 * oid_cnt, INT64 * null_cnt, INT64 * key_cnt)
 {
   VPID root_vpid;
   PAGE_PTR root = NULL;
@@ -8999,7 +8998,7 @@ btree_dump_capacity (THREAD_ENTRY * thread_p, FILE * fp, BTID * btid)
 
   /* dump the capacity information */
   fprintf (fp, "\nDistinct Key Count: %d\n", cpc.dis_key_cnt);
-  fprintf (fp, "Total Value Count: %ld\n", cpc.tot_val_cnt);
+  fprintf (fp, "Total Value Count: %" PRId64 "\n", cpc.tot_val_cnt);
   fprintf (fp, "Deduplicate Distinct Key Count: %d\n", cpc.deduplicate_dis_key_cnt);
   fprintf (fp, "Average Value Count Per Key: %d\n", cpc.avg_val_per_key);
   fprintf (fp, "Average Value Count Per Deduplicate Key: %d\n", cpc.avg_val_per_dedup_key);
@@ -17385,7 +17384,7 @@ int
 btree_rv_update_tran_stats (THREAD_ENTRY * thread_p, LOG_RCV * recv)
 {
   char *datap;
-  long long num_nulls, num_oids, num_keys;
+  INT64 num_nulls, num_oids, num_keys;
   BTID btid;
 
   assert (recv->length >= (3 * OR_BIGINT_SIZE) + OR_BTID_ALIGNED_SIZE);
@@ -17430,7 +17429,7 @@ btree_rv_roothdr_undo_update (THREAD_ENTRY * thread_p, LOG_RCV * recv)
 {
   char *datap;
   BTREE_ROOT_HEADER *root_header = NULL;
-  long long num_nulls, num_oids, num_keys;
+  INT64 num_nulls, num_oids, num_keys;
 
   if (recv->length < 3 * OR_BIGINT_SIZE)
     {
@@ -17444,7 +17443,7 @@ btree_rv_roothdr_undo_update (THREAD_ENTRY * thread_p, LOG_RCV * recv)
   if (root_header != NULL)
     {
       int over = 0;
-      long long delta;
+      INT64 delta;
 
       num_nulls = (unsigned int) root_header->num_nulls;
       num_oids = (unsigned int) root_header->num_oids;
@@ -21043,7 +21042,7 @@ btree_scan_for_show_index_header (THREAD_ENTRY * thread_p, DB_VALUE ** out_value
   char buf[256] = { 0 };
   OR_BUF or_buf;
   TP_DOMAIN *key_type;
-  long long num_oids = 0, num_nulls = 0, num_keys = 0;
+  INT64 num_oids = 0, num_nulls = 0, num_keys = 0;
   bool fetch_unique_stats = false;
   int unique_stats_idx = -1;
   RECDES recdes = RECDES_INITIALIZER;
@@ -22632,7 +22631,7 @@ int
 btree_rv_undo_global_unique_stats_commit (THREAD_ENTRY * thread_p, LOG_RCV * recv)
 {
   char *datap;
-  long long num_nulls, num_oids, num_keys;
+  INT64 num_nulls, num_oids, num_keys;
   BTID btid;
 
   assert (recv->length >= (3 * OR_BIGINT_SIZE) + OR_BTID_ALIGNED_SIZE);
@@ -22702,7 +22701,7 @@ int
 btree_rv_redo_global_unique_stats_commit (THREAD_ENTRY * thread_p, LOG_RCV * recv)
 {
   char *datap;
-  long long num_nulls, num_oids, num_keys;
+  INT64 num_nulls, num_oids, num_keys;
   BTID btid;
 
   assert (recv->length >= (3 * OR_BIGINT_SIZE) + OR_BTID_ALIGNED_SIZE);
@@ -35581,7 +35580,7 @@ btree_online_index_check_unique_constraint (THREAD_ENTRY * thread_p, BTID * btid
 					    OID * class_oid)
 {
   int ret = NO_ERROR;
-  long long g_num_oids = 0, g_num_nulls = 0, g_num_keys = 0;
+  INT64 g_num_oids = 0, g_num_nulls = 0, g_num_keys = 0;
   LOG_TRAN_BTID_UNIQUE_STATS *unique_stats = logtb_tran_find_btid_stats (thread_p, btid, true);
 
   if (unique_stats == NULL)

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -4566,7 +4566,7 @@ btree_dump_root_header (THREAD_ENTRY * thread_p, FILE * fp, PAGE_PTR page_ptr)
 
   fprintf (fp, "==============    R O O T    P A G E   ================\n\n");
   fprintf (fp, " Key_Type: %s\n", pr_type_name (TP_DOMAIN_TYPE (key_type)));
-  fprintf (fp, " Num OIDs: %lld, Num NULLs: %lld, Num keys: %lld\n", root_header->num_oids, root_header->num_nulls,
+  fprintf (fp, " Num OIDs: %ld, Num NULLs: %ld, Num keys: %ld\n", root_header->num_oids, root_header->num_nulls,
 	   root_header->num_keys);
   fprintf (fp, " Topclass_oid: (%d %d %d)\n", root_header->topclass_oid.volid, root_header->topclass_oid.pageid,
 	   root_header->topclass_oid.slotid);
@@ -8999,7 +8999,7 @@ btree_dump_capacity (THREAD_ENTRY * thread_p, FILE * fp, BTID * btid)
 
   /* dump the capacity information */
   fprintf (fp, "\nDistinct Key Count: %d\n", cpc.dis_key_cnt);
-  fprintf (fp, "Total Value Count: %lld\n", cpc.tot_val_cnt);
+  fprintf (fp, "Total Value Count: %ld\n", cpc.tot_val_cnt);
   fprintf (fp, "Deduplicate Distinct Key Count: %d\n", cpc.deduplicate_dis_key_cnt);
   fprintf (fp, "Average Value Count Per Key: %d\n", cpc.avg_val_per_key);
   fprintf (fp, "Average Value Count Per Deduplicate Key: %d\n", cpc.avg_val_per_dedup_key);
@@ -12374,8 +12374,8 @@ btree_find_split_point (THREAD_ENTRY * thread_p, BTID_INT * btid, PAGE_PTR page_
   assert (left_size <= left_max_size);
   assert (left_size >= left_min_size);
   assert (tot_rec - left_size <= right_max_size);
-  assert (left_size + new_fence_size <= BTREE_NODE_MAX_SPLIT_SIZE (thread_p, page_ptr));
-  assert (tot_rec - left_size + new_fence_size <= BTREE_NODE_MAX_SPLIT_SIZE (thread_p, page_ptr));
+  assert (left_size + new_fence_size <= (int) BTREE_NODE_MAX_SPLIT_SIZE (thread_p, page_ptr));
+  assert (tot_rec - left_size + new_fence_size <= (int) BTREE_NODE_MAX_SPLIT_SIZE (thread_p, page_ptr));
 
   /* Safe guard: Rules #3. */
   /* Left node will have at least one non-fence record. */

--- a/src/storage/btree.h
+++ b/src/storage/btree.h
@@ -670,10 +670,10 @@ extern void btree_scan_clear_key (BTREE_SCAN * btree_scan);
 
 extern bool btree_is_unique_type (BTREE_TYPE type);
 extern int xbtree_get_unique_pk (THREAD_ENTRY * thread_p, BTID * btid);
-extern int btree_get_unique_statistics (THREAD_ENTRY * thread_p, BTID * btid, long long *oid_cnt, long long *null_cnt,
-					long long *key_cnt);
-extern int btree_get_unique_statistics_for_count (THREAD_ENTRY * thread_p, BTID * btid, long long *oid_cnt,
-						  long long *null_cnt, long long *key_cnt);
+extern int btree_get_unique_statistics (THREAD_ENTRY * thread_p, BTID * btid, INT64 * oid_cnt, INT64 * null_cnt,
+					INT64 * key_cnt);
+extern int btree_get_unique_statistics_for_count (THREAD_ENTRY * thread_p, BTID * btid, INT64 * oid_cnt,
+						  INT64 * null_cnt, INT64 * key_cnt);
 extern int btree_get_stats (THREAD_ENTRY * thread_p, BTREE_STATS * stat_info_p, bool with_fullscan);
 extern int btree_get_pkey_btid (THREAD_ENTRY * thread_p, OID * cls_oid, BTID * pkey_btid);
 extern DISK_ISVALID btree_check_by_class_oid (THREAD_ENTRY * thread_p, OID * cls_oid, BTID * idx_btid);

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -247,7 +247,7 @@ static int list_length (const BTREE_NODE * this_list);
 static void list_print (const BTREE_NODE * this_list);
 #endif /* defined(CUBRID_DEBUG) */
 static int btree_pack_root_header (RECDES * Rec, BTREE_ROOT_HEADER * header, TP_DOMAIN * key_type);
-static void btree_rv_save_root_head (long long null_delta, long long oid_delta, long long key_delta, RECDES * recdes);
+static void btree_rv_save_root_head (INT64 null_delta, INT64 oid_delta, INT64 key_delta, RECDES * recdes);
 static int btree_advance_to_next_slot_and_fix_page (THREAD_ENTRY * thread_p, BTID_INT * btid, VPID * vpid,
 						    PAGE_PTR * pg_ptr, INT16 * slot_id, DB_VALUE * key,
 						    bool * clear_key, bool is_desc, int *key_cnt,
@@ -495,8 +495,8 @@ btree_node_header_redo_log (THREAD_ENTRY * thread_p, VFID * vfid, PAGE_PTR page_
  *
  */
 int
-btree_change_root_header_delta (THREAD_ENTRY * thread_p, VFID * vfid, PAGE_PTR page_ptr, long long null_delta,
-				long long oid_delta, long long key_delta)
+btree_change_root_header_delta (THREAD_ENTRY * thread_p, VFID * vfid, PAGE_PTR page_ptr, INT64 null_delta,
+				INT64 oid_delta, INT64 key_delta)
 {
   RECDES rec, delta_rec;
   char delta_rec_buf[(3 * OR_BIGINT_SIZE) + BTREE_MAX_ALIGN];
@@ -647,7 +647,7 @@ btree_init_overflow_header (THREAD_ENTRY * thread_p, PAGE_PTR page_ptr, BTREE_OV
  * Note: This is a UTILITY routine, but not an actual recovery routine.
  */
 static void
-btree_rv_save_root_head (long long null_delta, long long oid_delta, long long key_delta, RECDES * recdes)
+btree_rv_save_root_head (INT64 null_delta, INT64 oid_delta, INT64 key_delta, RECDES * recdes)
 {
   char *datap;
 
@@ -680,8 +680,7 @@ btree_rv_save_root_head (long long null_delta, long long oid_delta, long long ke
  * Note: This is a UTILITY routine, but not an actual recovery routine.
  */
 void
-btree_rv_mvcc_save_increments (const BTID * btid, long long key_delta, long long oid_delta, long long null_delta,
-			       RECDES * recdes)
+btree_rv_mvcc_save_increments (const BTID * btid, INT64 key_delta, INT64 oid_delta, INT64 null_delta, RECDES * recdes)
 {
   char *datap;
 
@@ -1149,8 +1148,9 @@ xbtree_load_index (THREAD_ENTRY * thread_p, BTID * btid, const char *bt_name, TP
       pr_clear_value (&load_args->current_key);
 
       BTID_SET_NULL (btid);
-      if (xbtree_add_index (thread_p, btid, key_type, &class_oids[0], attr_ids[0], unique_pk, sort_args->n_oids,
-			    sort_args->n_nulls, load_args->n_keys, btid_int.deduplicate_key_idx) == NULL)
+      if (xbtree_add_index (thread_p, btid, key_type, &class_oids[0], attr_ids[0], unique_pk, (INT64) sort_args->n_oids,
+			    (INT64) sort_args->n_nulls, (INT64) load_args->n_keys,
+			    btid_int.deduplicate_key_idx) == NULL)
 	{
 	  goto error;
 	}

--- a/src/storage/btree_load.h
+++ b/src/storage/btree_load.h
@@ -262,8 +262,8 @@ struct btree_node
 
 /* Recovery routines */
 extern void btree_rv_nodehdr_dump (FILE * fp, int length, void *data);
-extern void btree_rv_mvcc_save_increments (const BTID * btid, long long key_delta, long long oid_delta,
-					   long long null_delta, RECDES * recdes);
+extern void btree_rv_mvcc_save_increments (const BTID * btid, INT64 key_delta, INT64 oid_delta,
+					   INT64 null_delta, RECDES * recdes);
 
 STATIC_INLINE bool btree_clear_key_value (bool * clear_flag, DB_VALUE * key_value) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE void btree_init_temp_key_value (bool * clear_flag, DB_VALUE * key_value) __attribute__ ((ALWAYS_INLINE));
@@ -279,7 +279,7 @@ extern BTREE_OVERFLOW_HEADER *btree_get_overflow_header (THREAD_ENTRY * thread_p
 extern int btree_node_header_undo_log (THREAD_ENTRY * thread_p, VFID * vfid, PAGE_PTR page_ptr);
 extern int btree_node_header_redo_log (THREAD_ENTRY * thread_p, VFID * vfid, PAGE_PTR page_ptr);
 extern int btree_change_root_header_delta (THREAD_ENTRY * thread_p, VFID * vfid, PAGE_PTR page_ptr,
-					   long long null_delta, long long oid_delta, long long key_delta);
+					   INT64 null_delta, INT64 oid_delta, INT64 key_delta);
 
 extern int btree_get_disk_size_of_key (DB_VALUE *);
 extern TP_DOMAIN *btree_generate_prefix_domain (BTID_INT * btid);

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -9794,7 +9794,7 @@ locator_check_unique_btree_entries (THREAD_ENTRY * thread_p, BTID * btid, OID * 
 #if defined(SERVER_MODE)
   int tran_index;
 #else
-  long long btree_oid_cnt, btree_null_cnt, btree_key_cnt;
+  INT64 btree_oid_cnt, btree_null_cnt, btree_key_cnt;
 #endif /* SERVER_MODE */
   bool bt_checkscan_inited = false;
 

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -419,9 +419,9 @@ typedef enum tran_abort_reason TRAN_ABORT_REASON;
 typedef struct log_unique_stats LOG_UNIQUE_STATS;
 struct log_unique_stats
 {
-  long long num_nulls;		/* number of nulls */
-  long long num_keys;		/* number of keys */
-  long long num_oids;		/* number of oids */
+  INT64 num_nulls;		/* number of nulls */
+  INT64 num_keys;		/* number of keys */
+  INT64 num_oids;		/* number of oids */
 };
 
 typedef struct log_tran_btid_unique_stats LOG_TRAN_BTID_UNIQUE_STATS;
@@ -1220,8 +1220,8 @@ extern void logtb_complete_mvcc (THREAD_ENTRY * thread_p, LOG_TDES * tdes, bool 
 extern void logtb_complete_sub_mvcc (THREAD_ENTRY * thread_p, LOG_TDES * tdes);
 
 extern LOG_TRAN_CLASS_COS *logtb_tran_find_class_cos (THREAD_ENTRY * thread_p, const OID * class_oid, bool create);
-extern int logtb_tran_update_unique_stats (THREAD_ENTRY * thread_p, const BTID * btid, long long n_keys,
-					   long long n_oids, long long n_nulls, bool write_to_log);
+extern int logtb_tran_update_unique_stats (THREAD_ENTRY * thread_p, const BTID * btid, INT64 n_keys,
+					   INT64 n_oids, INT64 n_nulls, bool write_to_log);
 
 // *INDENT-OFF*
 extern int logtb_tran_update_unique_stats (THREAD_ENTRY * thread_p, const BTID &btid, const btree_unique_stats &ustats,
@@ -1230,8 +1230,8 @@ extern int logtb_tran_update_unique_stats (THREAD_ENTRY * thread_p, const multi_
                                            bool write_to_log);
 // *INDENT-ON*
 
-extern int logtb_tran_update_btid_unique_stats (THREAD_ENTRY * thread_p, const BTID * btid, long long n_keys,
-						long long n_oids, long long n_nulls);
+extern int logtb_tran_update_btid_unique_stats (THREAD_ENTRY * thread_p, const BTID * btid, INT64 n_keys,
+						INT64 n_oids, INT64 n_nulls);
 extern LOG_TRAN_BTID_UNIQUE_STATS *logtb_tran_find_btid_stats (THREAD_ENTRY * thread_p, const BTID * btid, bool create);
 extern int logtb_tran_prepare_count_optim_classes (THREAD_ENTRY * thread_p, const char **classes,
 						   LC_PREFETCH_FLAGS * flags, int n_classes);
@@ -1240,12 +1240,12 @@ extern int logtb_find_log_records_count (int tran_index);
 
 extern int logtb_initialize_global_unique_stats_table (THREAD_ENTRY * thread_p);
 extern void logtb_finalize_global_unique_stats_table (THREAD_ENTRY * thread_p);
-extern int logtb_get_global_unique_stats (THREAD_ENTRY * thread_p, BTID * btid, long long *num_oids,
-					  long long *num_nulls, long long *num_keys);
-extern int logtb_rv_update_global_unique_stats_by_abs (THREAD_ENTRY * thread_p, BTID * btid, long long num_oids,
-						       long long num_nulls, long long num_keys);
-extern int logtb_update_global_unique_stats_by_delta (THREAD_ENTRY * thread_p, BTID * btid, long long oid_delta,
-						      long long null_delta, long long key_delta, bool log);
+extern int logtb_get_global_unique_stats (THREAD_ENTRY * thread_p, BTID * btid, INT64 * num_oids,
+					  INT64 * num_nulls, INT64 * num_keys);
+extern int logtb_rv_update_global_unique_stats_by_abs (THREAD_ENTRY * thread_p, BTID * btid, INT64 num_oids,
+						       INT64 num_nulls, INT64 num_keys);
+extern int logtb_update_global_unique_stats_by_delta (THREAD_ENTRY * thread_p, BTID * btid, INT64 oid_delta,
+						      INT64 null_delta, INT64 key_delta, bool log);
 extern int logtb_delete_global_unique_stats (THREAD_ENTRY * thread_p, BTID * btid);
 extern int logtb_reflect_global_unique_stats_to_btree (THREAD_ENTRY * thread_p);
 extern int logtb_tran_update_all_global_unique_stats (THREAD_ENTRY * thread_p);

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -1312,7 +1312,7 @@ logpb_initialize_header (THREAD_ENTRY * thread_p, LOG_HEADER * loghdr, const cha
   assert (loghdr != NULL);
 
   /* to also initialize padding bytes */
-  memset (loghdr, 0, sizeof (LOG_HEADER));
+  memset ((void *) loghdr, 0, sizeof (LOG_HEADER));
 
   strncpy (loghdr->magic, CUBRID_MAGIC_LOG_ACTIVE, CUBRID_MAGIC_MAX_LENGTH);
 

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -3504,8 +3504,8 @@ logtb_tran_find_btid_stats (THREAD_ENTRY * thread_p, const BTID * btid, bool cre
  * Note: the statistics are searched and created if they not exist.
  */
 int
-logtb_tran_update_btid_unique_stats (THREAD_ENTRY * thread_p, const BTID * btid, long long n_keys, long long n_oids,
-				     long long n_nulls)
+logtb_tran_update_btid_unique_stats (THREAD_ENTRY * thread_p, const BTID * btid, INT64 n_keys, INT64 n_oids,
+				     INT64 n_nulls)
 {
   /* search and create if not found */
   LOG_TRAN_BTID_UNIQUE_STATS *unique_stats = logtb_tran_find_btid_stats (thread_p, btid, true);
@@ -3538,8 +3538,8 @@ logtb_tran_update_btid_unique_stats (THREAD_ENTRY * thread_p, const BTID * btid,
  * Note: the statistics are searched and created if they not exist.
  */
 int
-logtb_tran_update_unique_stats (THREAD_ENTRY * thread_p, const BTID * btid, long long n_keys, long long n_oids,
-				long long n_nulls, bool write_to_log)
+logtb_tran_update_unique_stats (THREAD_ENTRY * thread_p, const BTID * btid, INT64 n_keys, INT64 n_oids, INT64 n_nulls,
+				bool write_to_log)
 {
   int error = NO_ERROR;
 
@@ -4744,7 +4744,7 @@ logtb_get_global_unique_stats_entry (THREAD_ENTRY * thread_p, BTID * btid, bool 
   int error_code = NO_ERROR;
   LF_TRAN_ENTRY *t_entry = thread_get_tran_entry (thread_p, THREAD_TS_GLOBAL_UNIQUE_STATS);
   GLOBAL_UNIQUE_STATS *stats = NULL;
-  long long num_oids, num_nulls, num_keys;
+  INT64 num_oids, num_nulls, num_keys;
 
   assert (btid != NULL);
 
@@ -4803,8 +4803,8 @@ logtb_get_global_unique_stats_entry (THREAD_ENTRY * thread_p, BTID * btid, bool 
  *		     of keys for the given btid
  */
 int
-logtb_get_global_unique_stats (THREAD_ENTRY * thread_p, BTID * btid, long long *num_oids, long long *num_nulls,
-			       long long *num_keys)
+logtb_get_global_unique_stats (THREAD_ENTRY * thread_p, BTID * btid, INT64 * num_oids, INT64 * num_nulls,
+			       INT64 * num_keys)
 {
   int error_code = NO_ERROR;
   GLOBAL_UNIQUE_STATS *stats = NULL;
@@ -4839,8 +4839,8 @@ logtb_get_global_unique_stats (THREAD_ENTRY * thread_p, BTID * btid, long long *
  *   num_keys (in) : the new number of keys
  */
 int
-logtb_rv_update_global_unique_stats_by_abs (THREAD_ENTRY * thread_p, BTID * btid, long long num_oids,
-					    long long num_nulls, long long num_keys)
+logtb_rv_update_global_unique_stats_by_abs (THREAD_ENTRY * thread_p, BTID * btid, INT64 num_oids,
+					    INT64 num_nulls, INT64 num_keys)
 {
   int error_code = NO_ERROR;
   GLOBAL_UNIQUE_STATS *stats = NULL;
@@ -4889,13 +4889,13 @@ logtb_rv_update_global_unique_stats_by_abs (THREAD_ENTRY * thread_p, BTID * btid
  *   log (in) : true if we need to log the changes
  */
 int
-logtb_update_global_unique_stats_by_delta (THREAD_ENTRY * thread_p, BTID * btid, long long oid_delta,
-					   long long null_delta, long long key_delta, bool log)
+logtb_update_global_unique_stats_by_delta (THREAD_ENTRY * thread_p, BTID * btid, INT64 oid_delta,
+					   INT64 null_delta, INT64 key_delta, bool log)
 {
   int error_code = NO_ERROR;
   GLOBAL_UNIQUE_STATS *stats = NULL;
   LOG_TDES *tdes = LOG_FIND_CURRENT_TDES (thread_p);
-  long long num_oids, num_nulls, num_keys;
+  INT64 num_oids, num_nulls, num_keys;
 
   if (oid_delta == 0 && key_delta == 0 && null_delta == 0)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25212

We need remove the warning messages from compilation (CUBRID engine build). By doing this, we can prevent potential problems in advance.

The target source code is as follows.

src/base/
src/compat/
src/connection/
src/communication/
src/heaplayers/
src/thread/
src/object/
src/session/
src/jsp/
src/method/
src/parser/
src/query/
src/xasl/
