### PR TITLE
[CUBRID-24687] query result is strange, when there is hidden columns in the select list.

### DIFF
--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -4914,7 +4914,7 @@ cur_tuple (T_QUERY_RESULT * q_result, int max_col_size, char sensitive_flag, DB_
   char *null_type_column = q_result->null_type_column;
   int err_code;
 
-  ncols = q_result->num_column;
+  ncols = db_query_column_count (result);
   for (i = 0; i < ncols; i++)
     {
       if (sensitive_flag == TRUE && col_update_info[i].updatable == TRUE)

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -4914,7 +4914,7 @@ cur_tuple (T_QUERY_RESULT * q_result, int max_col_size, char sensitive_flag, DB_
   char *null_type_column = q_result->null_type_column;
   int err_code;
 
-  ncols = db_query_column_count (result);
+  ncols = q_result->num_column;
   for (i = 0; i < ncols; i++)
     {
       if (sensitive_flag == TRUE && col_update_info[i].updatable == TRUE)

--- a/src/compat/db_query.c
+++ b/src/compat/db_query.c
@@ -3150,6 +3150,9 @@ db_query_tuple_count (DB_QUERY_RESULT * result)
 int
 db_query_column_count (DB_QUERY_RESULT * result)
 {
+  DB_QUERY_TYPE *t;
+  int num_attrs = 0;
+
   CHECK_1ARG_MINUSONE (result);
 
   if (result->status == T_CLOSED)
@@ -3164,7 +3167,12 @@ db_query_column_count (DB_QUERY_RESULT * result)
       return -1;
     }
 
-  return (DB_OID_INCLUDED (result)) ? (result->col_cnt - 1) : result->col_cnt;
+  for (t = result->query_type; t != NULL; t = db_query_format_next (t), num_attrs++)
+    {
+      ;
+    }
+
+  return (num_attrs);
 }
 
 #if defined(WINDOWS) || defined (ENABLE_UNUSED_FUNCTION)

--- a/src/compat/db_query.c
+++ b/src/compat/db_query.c
@@ -3172,7 +3172,7 @@ db_query_column_count (DB_QUERY_RESULT * result)
       num_cols++;
     }
 
-  return (num_cols);
+  return num_cols;
 }
 
 #if defined(WINDOWS) || defined (ENABLE_UNUSED_FUNCTION)

--- a/src/compat/db_query.c
+++ b/src/compat/db_query.c
@@ -3151,7 +3151,7 @@ int
 db_query_column_count (DB_QUERY_RESULT * result)
 {
   DB_QUERY_TYPE *t;
-  int num_attrs = 0;
+  int num_cols = 0;
 
   CHECK_1ARG_MINUSONE (result);
 
@@ -3167,12 +3167,12 @@ db_query_column_count (DB_QUERY_RESULT * result)
       return -1;
     }
 
-  for (t = result->query_type; t != NULL; t = db_query_format_next (t), num_attrs++)
+  for (t = result->query_type; t != NULL; t = db_query_format_next (t))
     {
-      ;
+      num_cols++;
     }
 
-  return (num_attrs);
+  return (num_cols);
 }
 
 #if defined(WINDOWS) || defined (ENABLE_UNUSED_FUNCTION)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24687

**Description**
The query result is strange, when there is hidden columns in ther select list. This is the case when sp is used in the order by clause, as in the following query. (ex : SELECT col1, col2) FROM tbl1 ORDER BY intTest(col1))

**Resolution**
- fix to use query_type instead of col_cnt at db_query_column_count().