### PR TITLE
[CBRD-25044] Supports Windows build in Debug mode

### DIFF
--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -1755,28 +1755,6 @@ pgbuf_fix_with_retry (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_MOD
 }
 
 /*
- * below two functions are dummies for Windows build
- * (which defined at cubridsa.def)
- */
-#if defined(WINDOWS)
-#if !defined(NDEBUG)
-PAGE_PTR
-pgbuf_fix_release (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_MODE fetch_mode,
-		   PGBUF_LATCH_MODE request_mode, PGBUF_LATCH_CONDITION condition)
-{
-  return NULL;
-}
-#else
-PAGE_PTR
-pgbuf_fix_debug (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_MODE fetch_mode, PGBUF_LATCH_MODE request_mode,
-		 PGBUF_LATCH_CONDITION condition, const char *caller_file, int caller_line)
-{
-  return NULL;
-}
-#endif
-#endif
-
-/*
  * pgbuf_fix () -
  *   return: Pointer to the page or NULL
  *   vpid(in): Complete Page identifier

--- a/win/cubridsa/cubridsa.def
+++ b/win/cubridsa/cubridsa.def
@@ -81,10 +81,6 @@ EXPORTS
     htonl
     htoni64
     numeric_coerce_int_to_num
-    pgbuf_fix_release
-    pgbuf_fix_debug
-    pgbuf_get_vpid_ptr
-    pgbuf_set_dirty
     prm_get_master_port_id
     prm_get_bool_value
     prm_get_float_value


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25044

* Supports Windows build in Debug mode
 - The following functions are not called outside the dll, so they are removed from cubridsa.def.
     - pgbuf_fix_release
     - pgbuf_fix_debug
     - pgbuf_get_vpid_ptr
     - pgbuf_set_dirty