### PR TITLE
[CBRD-25208] Set java.io.tmpdir according to the CUBRID_TMP in Java SP server (#4917)

### DIFF
--- a/src/jsp/com/cubrid/jsp/Server.java
+++ b/src/jsp/com/cubrid/jsp/Server.java
@@ -52,6 +52,7 @@ public class Server {
     private static String spPath;
     private static String rootPath;
     private static String udsPath;
+    private static String tmpPath;
 
     private static List<String> jvmArguments = null;
 
@@ -85,6 +86,12 @@ public class Server {
                             + "_java.log";
             loggingThread = new LoggingThread(logFilePath);
             loggingThread.start();
+
+            tmpPath = System.getProperty("CUBRID_TMP");
+            if (tmpPath == null) {
+                tmpPath = rootPath + File.separator + "tmp";
+            }
+            System.setProperty("java.io.tmpdir", tmpPath);
 
             if (OSValidator.IS_UNIX && port_number == -1) {
                 final File socketFile = new File(udsPath);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25208

Set java.io.tmpdir according to the CUBRID_TMP. If CUBRID_TMP is set, it is utilized as java.io.tmpdir, otherwise $CUBRID/tmp is used.

backport of #4917