### PR TITLE
[CBRD-25203] Implement 'memory_monitor::add/sub_stat()' with API

### DIFF
--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -131,16 +131,13 @@ namespace cubmem
 
   void memory_monitor::sub_stat (char *ptr)
   {
+#if defined(WINDOWS)
     size_t allocated_size = 0;
-
-    if (ptr == NULL)
-      {
-	return;
-      }
-
-#if !defined(WINDOWS)
-    allocated_size = malloc_usable_size ((void *)ptr);
+#else
+    size_t allocated_size = malloc_usable_size ((void *)ptr);
 #endif // !WINDOWS
+
+    assert (ptr != NULL);
 
     if (allocated_size >= MMON_ALLOC_META_SIZE)
       {

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -47,7 +47,7 @@ namespace cubmem
   size_t memory_monitor::get_allocated_size (const char *ptr)
   {
 #if defined(WINDOWS)
-    size_t allocated_size = _msize ((void *)ptr);
+    size_t allocated_size = 0;
 #else
     size_t allocated_size = malloc_usable_size ((void *)ptr);
 #endif // WINDOWS
@@ -73,7 +73,7 @@ namespace cubmem
   {
     std::string filecopy (file);
 #if defined(WINDOWS)
-    std::string target ("\\src\\");
+    std::string target (""); // not supported
 #else
     std::string target ("/src/");
 #endif // WINDOWS
@@ -83,7 +83,7 @@ namespace cubmem
 #if !defined (NDEBUG)
     size_t lpos = filecopy.find (target);
     assert (pos == lpos);
-#endif // NDEBUG
+#endif // !NDEBUG
 
     if (pos != std::string::npos)
       {
@@ -117,9 +117,8 @@ namespace cubmem
       {
 	metainfo.tag_id = m_tag_map.size ();
 	// tag_id is start with 0
-	std::pair <std::string, int> tag_map_entry (tag_name, metainfo.tag_id);
-	m_tag_map.insert (tag_map_entry);
-	m_stat_map.insert (std::make_pair (metainfo.tag_id, metainfo.allocated_size));
+	m_tag_map.emplace (tag_name, metainfo.tag_id);
+	m_stat_map.emplace (metainfo.tag_id, metainfo.allocated_size);
       }
     tag_map_lock.unlock ();
 
@@ -132,18 +131,16 @@ namespace cubmem
 
   void memory_monitor::sub_stat (char *ptr)
   {
-    size_t allocated_size;
+    size_t allocated_size = 0;
 
     if (ptr == NULL)
       {
 	return;
       }
 
-#if defined(WINDOWS)
-    allocated_size = _msize ((void *)ptr);
-#else
+#if !defined(WINDOWS)
     allocated_size = malloc_usable_size ((void *)ptr);
-#endif // WINDOWS
+#endif // !WINDOWS
 
     if (allocated_size >= MMON_ALLOC_META_SIZE)
       {

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -92,6 +92,77 @@ namespace cubmem
 
     return filecopy + ':' + std::to_string (line);
   }
+
+  void memory_monitor::add_stat (char *ptr, const size_t size, const char *file, const int line)
+  {
+    std::string tag_name;
+    MMON_METAINFO metainfo;
+
+    // size should not be 0 because of MMON_ALLOC_META_SIZE
+    assert (size > 0);
+
+    metainfo.allocated_size = (uint64_t) size;
+    m_total_mem_usage += metainfo.allocated_size;
+
+    tag_name = make_tag_name (file, line);
+
+    std::unique_lock <std::mutex> tag_map_lock (m_tag_map_mutex);
+    auto search = m_tag_map.find (tag_name);
+    if (search != m_tag_map.end ())
+      {
+	metainfo.tag_id = search->second;
+	m_stat_map[metainfo.tag_id] += metainfo.allocated_size;
+      }
+    else
+      {
+	metainfo.tag_id = m_tag_map.size ();
+	// tag_id is start with 0
+	std::pair <std::string, int> tag_map_entry (tag_name, metainfo.tag_id);
+	m_tag_map.insert (tag_map_entry);
+	m_stat_map.insert (std::make_pair (metainfo.tag_id, metainfo.allocated_size));
+      }
+    tag_map_lock.unlock ();
+
+    // put meta info into the allocated chunk
+    char *meta_ptr = ptr + metainfo.allocated_size - MMON_ALLOC_META_SIZE;
+    metainfo.magic_number = m_magic_number;
+    memcpy (meta_ptr, &metainfo, MMON_ALLOC_META_SIZE);
+    m_meta_alloc_count++;
+  }
+
+  void memory_monitor::sub_stat (char *ptr)
+  {
+    size_t allocated_size;
+
+    if (ptr == NULL)
+      {
+	return;
+      }
+
+#if defined(WINDOWS)
+    allocated_size = _msize ((void *)ptr);
+#else
+    allocated_size = malloc_usable_size ((void *)ptr);
+#endif // WINDOWS
+
+    if (allocated_size >= MMON_ALLOC_META_SIZE)
+      {
+	char *meta_ptr = ptr + allocated_size - MMON_ALLOC_META_SIZE;
+	const MMON_METAINFO *metainfo = (const MMON_METAINFO *) meta_ptr;
+
+	if (metainfo->magic_number == m_magic_number)
+	  {
+	    assert ((metainfo->tag_id >= 0 && metainfo->tag_id <= m_stat_map.size()));
+	    assert (m_stat_map[metainfo->tag_id] >= metainfo->allocated_size);
+
+	    m_total_mem_usage -= metainfo->allocated_size;
+	    m_stat_map[metainfo->tag_id] -= metainfo->allocated_size;
+
+	    memset (meta_ptr, 0, MMON_ALLOC_META_SIZE);
+	    m_meta_alloc_count--;
+	  }
+      }
+  }
 }
 
 using namespace cubmem;
@@ -110,4 +181,20 @@ size_t mmon_get_allocated_size (char *ptr)
   // unreachable
   assert (false);
   return 0;
+}
+
+void mmon_add_stat (char *ptr, const size_t size, const char *file, const int line)
+{
+  if (mmon_is_memory_monitor_enabled ())
+    {
+      mmon_Gl->add_stat (ptr, size, file, line);
+    }
+}
+
+void mmon_sub_stat (char *ptr)
+{
+  if (mmon_is_memory_monitor_enabled ())
+    {
+      mmon_Gl->sub_stat (ptr);
+    }
 }

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -42,7 +42,10 @@ namespace cubmem
   memory_monitor::memory_monitor (const char *server_name)
     : m_server_name {server_name},
       m_magic_number {*reinterpret_cast <const int *> ("MMON")}
-  {}
+  {
+    m_total_mem_usage = 0;
+    m_meta_alloc_count = 0;
+  }
 
   size_t memory_monitor::get_allocated_size (const char *ptr)
   {
@@ -74,6 +77,7 @@ namespace cubmem
     std::string filecopy (file);
 #if defined(WINDOWS)
     std::string target (""); // not supported
+    assert (false);
 #else
     std::string target ("/src/");
 #endif // WINDOWS
@@ -154,6 +158,7 @@ namespace cubmem
 
 	    memset (meta_ptr, 0, MMON_ALLOC_META_SIZE);
 	    m_meta_alloc_count--;
+	    assert (m_meta_alloc_count >= 0);
 	  }
       }
   }

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -115,7 +115,7 @@ namespace cubmem
 
     tag_name = make_tag_name (file, line);
 
-    std::unique_lock <std::mutex> tag_map_lock (m_tag_map_mutex);
+    std::unique_lock <std::mutex> map_lock (m_map_mutex);
     auto search = m_tag_map.find (tag_name);
     if (search != m_tag_map.end ())
       {
@@ -129,7 +129,7 @@ namespace cubmem
 	m_tag_map.emplace (tag_name, metainfo.tag_id);
 	m_stat_map.emplace (metainfo.tag_id, metainfo.allocated_size);
       }
-    tag_map_lock.unlock ();
+    map_lock.unlock ();
 
     // put meta info into the allocated chunk
     char *meta_ptr = get_metainfo_pos (ptr, metainfo.allocated_size);

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -51,9 +51,10 @@ namespace cubmem
   {
 #if defined(WINDOWS)
     size_t allocated_size = 0;
+    assert (false);
 #else
     size_t allocated_size = malloc_usable_size ((void *)ptr);
-#endif // WINDOWS
+#endif // !WINDOWS
 
     if (allocated_size <= MMON_ALLOC_META_SIZE)
       {
@@ -80,7 +81,7 @@ namespace cubmem
     assert (false);
 #else
     std::string target ("/src/");
-#endif // WINDOWS
+#endif // !WINDOWS
 
     // Find the last occurrence of "src" in the path
     size_t pos = filecopy.rfind (target);
@@ -137,6 +138,7 @@ namespace cubmem
   {
 #if defined(WINDOWS)
     size_t allocated_size = 0;
+    assert (false);
 #else
     size_t allocated_size = malloc_usable_size ((void *)ptr);
 #endif // !WINDOWS

--- a/src/base/memory_monitor_sr.hpp
+++ b/src/base/memory_monitor_sr.hpp
@@ -61,8 +61,8 @@ namespace cubmem
     private:
       std::string m_server_name;
       mutable std::mutex m_tag_map_mutex;
-      std::unordered_map <std::string, int> m_tag_map;              // tag name <-> tag id
-      std::unordered_map <int, std::atomic <uint64_t>> m_stat_map;  // tag id <-> memory usage
+      std::unordered_map <std::string, int> m_tag_map;              // key: tag name, value: tag id
+      std::unordered_map <int, std::atomic <uint64_t>> m_stat_map;  // key: tag id, value: memory usage
       std::atomic <uint64_t> m_total_mem_usage;
       int m_meta_alloc_count;                                       // for checking occupancy of memory used by metainfo space
       const int m_magic_number;

--- a/src/base/memory_monitor_sr.hpp
+++ b/src/base/memory_monitor_sr.hpp
@@ -36,7 +36,7 @@ namespace cubmem
   // This meta size is related with allocation byte align
   // Don't adjust it freely
   // 8 byte size + 4 byte tag + 4 byte magicnumber
-  static constexpr int MMON_ALLOC_META_SIZE = 16;
+  static constexpr int MMON_METAINFO_SIZE = 16;
 
   class memory_monitor
   {
@@ -56,7 +56,7 @@ namespace cubmem
       void sub_stat (char *ptr);
 
     private:
-      static char *get_meta_ptr (char *ptr, size_t size);
+      static char *get_metainfo_pos (char *ptr, size_t size);
       static std::string make_tag_name (const char *file, const int line);
 
     private:

--- a/src/base/memory_monitor_sr.hpp
+++ b/src/base/memory_monitor_sr.hpp
@@ -67,6 +67,12 @@ namespace cubmem
       std::unordered_map <int, std::atomic <uint64_t>> m_stat_map;  // key: tag id, value: memory usage
       std::atomic <uint64_t> m_total_mem_usage;
       std::atomic <int> m_meta_alloc_count;                         // for checking occupancy of memory used by metainfo space
+      // Magic number is for checking an allocated memory which is out-of-scope of memory_monitor.
+      // It's because memory_monitor starts to manage information about heap memory allocation
+      // not "right after cubrid server starts" but "after some allocations are occurred because of
+      // memory_monitor has some dependencies to start (e.g. system parameter, error file initialize, etc..).
+      // And memory_monitor also can't manage some allocations after it is started like allocations at C++ containers(STL),
+      // and some C++ allocations occurred at header files.
       const int m_magic_number;
   };
 } //namespace cubmem

--- a/src/base/memory_monitor_sr.hpp
+++ b/src/base/memory_monitor_sr.hpp
@@ -61,7 +61,7 @@ namespace cubmem
 
     private:
       std::string m_server_name;
-      mutable std::mutex m_tag_map_mutex;
+      mutable std::mutex m_map_mutex;
       // Entries of m_tag_map and m_stat_map will not be deleted
       std::unordered_map <std::string, int> m_tag_map;              // key: tag name, value: tag id
       std::unordered_map <int, std::atomic <uint64_t>> m_stat_map;  // key: tag id, value: memory usage

--- a/src/base/memory_monitor_sr.hpp
+++ b/src/base/memory_monitor_sr.hpp
@@ -51,20 +51,22 @@ namespace cubmem
       memory_monitor &operator = (memory_monitor &&) = delete;
 
     public:
-      size_t get_allocated_size (const char *ptr);
+      size_t get_allocated_size (char *ptr);
       void add_stat (char *ptr, const size_t size, const char *file, const int line);
       void sub_stat (char *ptr);
 
     private:
+      static char *get_meta_ptr (char *ptr, size_t size);
       static std::string make_tag_name (const char *file, const int line);
 
     private:
       std::string m_server_name;
       mutable std::mutex m_tag_map_mutex;
+      // Entries of m_tag_map and m_stat_map will not be deleted
       std::unordered_map <std::string, int> m_tag_map;              // key: tag name, value: tag id
       std::unordered_map <int, std::atomic <uint64_t>> m_stat_map;  // key: tag id, value: memory usage
       std::atomic <uint64_t> m_total_mem_usage;
-      int m_meta_alloc_count;                                       // for checking occupancy of memory used by metainfo space
+      std::atomic <int> m_meta_alloc_count;                         // for checking occupancy of memory used by metainfo space
       const int m_magic_number;
   };
 } //namespace cubmem


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25203

This PR implements `add/sub_stat()` with API and adds member variables into `memory_monitor` class for the functions
 - add member variables at memory_monitor class
 - implement `add_stat()` and `sub_stat()` functions
