### PR TITLE
[CBRD-25218] Create a JAR file for compiled Java classes of PL/CSQL

### DIFF
--- a/pl_engine/pl_server/build.gradle.kts
+++ b/pl_engine/pl_server/build.gradle.kts
@@ -52,6 +52,9 @@ dependencies {
     implementation("org.apache.commons:commons-text:1.10.0")
     implementation("org.apache.commons:commons-collections4:4.4")
     implementation("org.apache.commons:commons-lang3:3.13.0")
+    implementation("commons-io:commons-io:2.15.1")
+    implementation("org.apache.commons:commons-compress:1.25.0")
+
     implementation("org.antlr:antlr4-runtime:4.9.3")
 
     // CUBRID JDBC

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/ExecuteThread.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/ExecuteThread.java
@@ -321,14 +321,13 @@ public class ExecuteThread extends Thread {
         sendResult(result, procedure);
     }
 
-    private void writeJar(List<CompiledCode> compiledCodeList, Path jarPath) {
+    private void writeJar(List<CompiledCode> compiledCodeList, Path jarPath) throws IOException {
         JarArchiveOutputStream jaos = null;
         try {
             OutputStream jarStream = Files.newOutputStream(jarPath);
             jaos = new JarArchiveOutputStream(new BufferedOutputStream(jarStream));
 
-            List<CompiledCode> codeList = compiler.getFileManager().getCodeList();
-            for (CompiledCode c : codeList) {
+            for (CompiledCode c : compiledCodeList) {
                 JarArchiveEntry jae = new JarArchiveEntry(c.getClassName() + ".class");
                 jaos.putArchiveEntry(jae);
                 ByteArrayInputStream bis = new ByteArrayInputStream(c.getByteCode());

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/ExecuteThread.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/ExecuteThread.java
@@ -32,6 +32,9 @@
 package com.cubrid.jsp;
 
 import com.cubrid.jsp.classloader.ClassLoaderManager;
+import com.cubrid.jsp.compiler.CompiledCode;
+import com.cubrid.jsp.compiler.MemoryJavaCompiler;
+import com.cubrid.jsp.compiler.SourceCode;
 import com.cubrid.jsp.context.Context;
 import com.cubrid.jsp.context.ContextManager;
 import com.cubrid.jsp.data.CUBRIDPacker;
@@ -49,19 +52,23 @@ import com.cubrid.plcsql.compiler.PlcsqlCompilerMain;
 import com.cubrid.plcsql.predefined.PlcsqlRuntimeError;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.net.Socket;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.SQLException;
 import java.util.List;
-import javax.tools.JavaCompiler;
-import javax.tools.ToolProvider;
+import org.apache.commons.compress.archivers.jar.JarArchiveEntry;
+import org.apache.commons.compress.archivers.jar.JarArchiveOutputStream;
+import org.apache.commons.io.IOUtils;
 
 public class ExecuteThread extends Thread {
 
@@ -314,6 +321,32 @@ public class ExecuteThread extends Thread {
         sendResult(result, procedure);
     }
 
+    private void writeJar(List<CompiledCode> compiledCodeList, Path jarPath) {
+        JarArchiveOutputStream jaos = null;
+        try {
+            OutputStream jarStream = Files.newOutputStream(jarPath);
+            jaos = new JarArchiveOutputStream(new BufferedOutputStream(jarStream));
+
+            List<CompiledCode> codeList = compiler.getFileManager().getCodeList();
+            for (CompiledCode c : codeList) {
+                JarArchiveEntry jae = new JarArchiveEntry(c.getClassName() + ".class");
+                jaos.putArchiveEntry(jae);
+                ByteArrayInputStream bis = new ByteArrayInputStream(c.getByteCode());
+                IOUtils.copy(bis, jaos);
+                bis.close();
+                jaos.closeArchiveEntry();
+            }
+        } catch (IOException e) {
+            throw e;
+        } finally {
+            if (jaos != null) {
+                jaos.flush();
+                jaos.finish();
+                jaos.close();
+            }
+        }
+    }
+
     private void processCompile() throws Exception {
         unpacker.setBuffer(ctx.getInboundQueue().take());
         boolean verbose = unpacker.unpackBool();
@@ -323,6 +356,8 @@ public class ExecuteThread extends Thread {
         try {
             info = PlcsqlCompilerMain.compilePLCSQL(inSource, verbose);
             if (info.errCode == 0) {
+
+                // The following writes .java file into /dynamic directory
                 Path javaFilePath =
                         ClassLoaderManager.getDynamicPath().resolve(info.className + ".java");
                 File file = javaFilePath.toFile();
@@ -330,27 +365,15 @@ public class ExecuteThread extends Thread {
                     file.delete();
                 }
                 new FileWriter(file).append(info.translated).close();
+                //
 
-                JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
-                if (compiler == null) {
-                    throw new IllegalStateException(
-                            "Cannot find the system Java compiler. Check that your class path includes tools.jar");
-                }
+                MemoryJavaCompiler compiler = new MemoryJavaCompiler();
+                SourceCode sCode = new SourceCode(info.className, info.translated);
+                compiler.compile(sCode);
 
-                Path cubrid_env_root = Server.getServer().getRootPath();
-                String javacOpts[] = {
-                    "-classpath", cubrid_env_root + "/java/pl_server.jar", file.getPath()
-                };
-
-                if (compiler.run(null, null, null, javacOpts) != 0) {
-                    String command =
-                            "javac "
-                                    + javaFilePath
-                                    + " -cp "
-                                    + cubrid_env_root
-                                    + "/java/pl_server.jar";
-                    throw new RuntimeException(command);
-                }
+                Path jarPath = ClassLoaderManager.getDynamicPath().resolve(info.className + ".jar");
+                List<CompiledCode> codeList = compiler.getFileManager().getCodeList();
+                writeJar(codeList, jarPath);
             }
         } catch (Exception e) {
             info =

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/compiler/CompiledCode.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/compiler/CompiledCode.java
@@ -30,6 +30,7 @@
  */
 
 package com.cubrid.jsp.compiler;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -37,25 +38,25 @@ import java.net.URI;
 import javax.tools.SimpleJavaFileObject;
 
 public class CompiledCode extends SimpleJavaFileObject {
-        private String className = null;
-        private ByteArrayOutputStream baos = null;
+    private String className = null;
+    private ByteArrayOutputStream baos = null;
 
-        public CompiledCode(String className) throws java.net.URISyntaxException {
-                super(new URI(className), Kind.CLASS);
-                this.className = className;
-                this.baos = new ByteArrayOutputStream();
-        }
+    public CompiledCode(String className) throws java.net.URISyntaxException {
+        super(new URI(className), Kind.CLASS);
+        this.className = className;
+        this.baos = new ByteArrayOutputStream();
+    }
 
-        public String getClassName() {
-		return className;
-	}
+    public String getClassName() {
+        return className;
+    }
 
-        public byte[] getByteCode () {
-                return baos.toByteArray();
-        }
+    public byte[] getByteCode() {
+        return baos.toByteArray();
+    }
 
-        @Override
-        public OutputStream openOutputStream() throws IOException {
-            return baos;
-        }
+    @Override
+    public OutputStream openOutputStream() throws IOException {
+        return baos;
+    }
 }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/compiler/CompiledCode.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/compiler/CompiledCode.java
@@ -1,0 +1,61 @@
+/*
+ *
+ * Copyright (c) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+
+package com.cubrid.jsp.compiler;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import javax.tools.SimpleJavaFileObject;
+
+public class CompiledCode extends SimpleJavaFileObject {
+        private String className = null;
+        private ByteArrayOutputStream baos = null;
+
+        public CompiledCode(String className) throws java.net.URISyntaxException {
+                super(new URI(className), Kind.CLASS);
+                this.className = className;
+                this.baos = new ByteArrayOutputStream();
+        }
+
+        public String getClassName() {
+		return className;
+	}
+
+        public byte[] getByteCode () {
+                return baos.toByteArray();
+        }
+
+        @Override
+        public OutputStream openOutputStream() throws IOException {
+            return baos;
+        }
+}

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/compiler/MemoryFileManager.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/compiler/MemoryFileManager.java
@@ -1,0 +1,76 @@
+/*
+ *
+ * Copyright (c) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+
+package com.cubrid.jsp.compiler;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.tools.FileObject;
+import javax.tools.ForwardingJavaFileManager;
+import javax.tools.JavaFileManager;
+import javax.tools.JavaFileObject;
+
+public class MemoryFileManager extends ForwardingJavaFileManager<JavaFileManager> {
+
+        private List<CompiledCode> codeList = new ArrayList<CompiledCode>();
+
+        public MemoryFileManager(JavaFileManager fileManager) {
+                super (fileManager);
+        }
+
+        @Override
+        public JavaFileObject getJavaFileForOutput(
+                JavaFileManager.Location location, String className,
+                JavaFileObject.Kind kind, FileObject sibling) throws IOException {
+                try {
+                        CompiledCode c = new CompiledCode(className);
+
+                        // register CompiledCode in GlobalClassStore
+                        codeList.add(c);
+                        
+                        return c;
+                } catch (Exception e) {
+                        throw new RuntimeException(
+                                        "Error occurs while creating output class file in memory for "
+                                                        + className, e);
+                }
+        }
+
+        @Override
+	public ClassLoader getClassLoader(JavaFileManager.Location location) {
+		return null;
+	}
+
+        public List<CompiledCode> getCodeList () {
+                return codeList;
+        }
+}

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/compiler/MemoryFileManager.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/compiler/MemoryFileManager.java
@@ -41,36 +41,38 @@ import javax.tools.JavaFileObject;
 
 public class MemoryFileManager extends ForwardingJavaFileManager<JavaFileManager> {
 
-        private List<CompiledCode> codeList = new ArrayList<CompiledCode>();
+    private List<CompiledCode> codeList = new ArrayList<CompiledCode>();
 
-        public MemoryFileManager(JavaFileManager fileManager) {
-                super (fileManager);
+    public MemoryFileManager(JavaFileManager fileManager) {
+        super(fileManager);
+    }
+
+    @Override
+    public JavaFileObject getJavaFileForOutput(
+            JavaFileManager.Location location,
+            String className,
+            JavaFileObject.Kind kind,
+            FileObject sibling)
+            throws IOException {
+        try {
+            CompiledCode c = new CompiledCode(className);
+
+            // register CompiledCode in GlobalClassStore
+            codeList.add(c);
+
+            return c;
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    "Error occurs while creating output class file in memory for " + className, e);
         }
+    }
 
-        @Override
-        public JavaFileObject getJavaFileForOutput(
-                JavaFileManager.Location location, String className,
-                JavaFileObject.Kind kind, FileObject sibling) throws IOException {
-                try {
-                        CompiledCode c = new CompiledCode(className);
+    @Override
+    public ClassLoader getClassLoader(JavaFileManager.Location location) {
+        return null;
+    }
 
-                        // register CompiledCode in GlobalClassStore
-                        codeList.add(c);
-                        
-                        return c;
-                } catch (Exception e) {
-                        throw new RuntimeException(
-                                        "Error occurs while creating output class file in memory for "
-                                                        + className, e);
-                }
-        }
-
-        @Override
-	public ClassLoader getClassLoader(JavaFileManager.Location location) {
-		return null;
-	}
-
-        public List<CompiledCode> getCodeList () {
-                return codeList;
-        }
+    public List<CompiledCode> getCodeList() {
+        return codeList;
+    }
 }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/compiler/MemoryJavaCompiler.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/compiler/MemoryJavaCompiler.java
@@ -1,0 +1,99 @@
+/*
+ *
+ * Copyright (c) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+
+package com.cubrid.jsp.compiler;
+
+import com.cubrid.jsp.Server;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.ToolProvider;
+
+public class MemoryJavaCompiler {
+
+        private JavaCompiler compiler;
+        private Iterable<String> options = null;
+        private MemoryFileManager fileManager = null;
+
+        public MemoryJavaCompiler () {
+                compiler = ToolProvider.getSystemJavaCompiler();
+                if (compiler == null) {
+                        throw new IllegalStateException(
+                                "Cannot find the system Java compiler. Check that your class path includes tools.jar");
+                }
+
+                Path cubrid_env_root = Server.getServer().getRootPath();
+                useOptions ("-classpath", cubrid_env_root + "/java/pl_server.jar");
+
+                fileManager = new MemoryFileManager(compiler.getStandardFileManager(null, null, null));
+        }
+
+        public void useOptions(String... options) {
+                this.options = Arrays.asList(options);
+        }
+        
+        public void compile (SourceCode code) {
+                DiagnosticCollector<JavaFileObject> collector = new DiagnosticCollector<>();
+
+                JavaCompiler.CompilationTask task = compiler.getTask(null, fileManager, collector, options, null, Arrays.asList(code));
+
+                boolean result = task.call();
+                if (!result || collector.getDiagnostics().size() > 0) {
+                        String exceptionMsg = new String("Unable to compile the source");
+			boolean hasErrors = false;
+                        
+			for (Diagnostic<? extends JavaFileObject> d : collector.getDiagnostics()) {
+				switch (d.getKind()) {
+				case NOTE:
+				case MANDATORY_WARNING:
+				case WARNING:
+					break;
+				case OTHER:
+				case ERROR:
+				default:
+					hasErrors = true;
+					break;
+				}
+			}
+			if (hasErrors) {
+				throw new RuntimeException(exceptionMsg.toString());
+			}
+                }
+        }
+
+        public MemoryFileManager getFileManager () {
+                return fileManager;
+        }
+}

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/compiler/SourceCode.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/compiler/SourceCode.java
@@ -30,31 +30,32 @@
  */
 
 package com.cubrid.jsp.compiler;
-import java.net.URI;
 
+import java.net.URI;
 import javax.tools.SimpleJavaFileObject;
 
 public class SourceCode extends SimpleJavaFileObject {
-        private String className;
-        private String code;
+    private String className;
+    private String code;
 
-	public SourceCode(String className, String code) {
-		super(URI.create("string:///" + className.replace('.', '/')
-				+ Kind.SOURCE.extension), Kind.SOURCE);
-		this.code = code;
-		this.className = className;
-	}
+    public SourceCode(String className, String code) {
+        super(
+                URI.create("string:///" + className.replace('.', '/') + Kind.SOURCE.extension),
+                Kind.SOURCE);
+        this.code = code;
+        this.className = className;
+    }
 
-	public String getClassName() {
-		return className;
-	}
+    public String getClassName() {
+        return className;
+    }
 
-	public String getCode() {
-		return code;
-	}
+    public String getCode() {
+        return code;
+    }
 
-        @Override
-        public CharSequence getCharContent(boolean ignoreEncodingErrors) {
-                return code;
-        }
+    @Override
+    public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+        return code;
+    }
 }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/compiler/SourceCode.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/compiler/SourceCode.java
@@ -1,0 +1,60 @@
+/*
+ *
+ * Copyright (c) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+
+package com.cubrid.jsp.compiler;
+import java.net.URI;
+
+import javax.tools.SimpleJavaFileObject;
+
+public class SourceCode extends SimpleJavaFileObject {
+        private String className;
+        private String code;
+
+	public SourceCode(String className, String code) {
+		super(URI.create("string:///" + className.replace('.', '/')
+				+ Kind.SOURCE.extension), Kind.SOURCE);
+		this.code = code;
+		this.className = className;
+	}
+
+	public String getClassName() {
+		return className;
+	}
+
+	public String getCode() {
+		return code;
+	}
+
+        @Override
+        public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+                return code;
+        }
+}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25218

- Introduce a Javac compiler class named `MemoryJavaCompiler`, which utilizes `MemoryFileManager` to manage compiled bytecode in memory effectively.
- Within the writeJar() function, the list of bytecode (List<CompiledCode>) is packaged into a jar file.
- Utilize the commons-io and commons-compress libraries for this implementation.
Implement a routine to create a jar from Java classes created by compiled PL/CSQL program.