### PR TITLE
[CBRD-25216] Check if there is enough buffer to store the user-specified name

### DIFF
--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -5678,7 +5678,7 @@ au_change_serial_owner (MOP serial_mop, MOP owner_mop, bool by_class_owner_chang
   sm_downcase_name (owner_name, downcase_owner_name, DB_MAX_USER_LENGTH);
   db_ws_free_and_init (owner_name);
 
-  snprintf (serial_new_name, SM_MAX_IDENTIFIER_LENGTH, "%s.%s", downcase_owner_name, serial_name);
+  sprintf (serial_new_name, "%s.%s", downcase_owner_name, serial_name);
 
   serial_class_mop = sm_find_class (CT_SERIAL_NAME);
   if (serial_class_mop == NULL)
@@ -5782,7 +5782,7 @@ au_change_serial_owner_method (MOP obj, DB_VALUE * return_val, DB_VALUE * serial
 
   serial_class_mop = sm_find_class (CT_SERIAL_NAME);
 
-  sm_user_specified_name (serial_name, user_specified_serial_name, DB_MAX_SERIAL_NAME_LENGTH);
+  sm_user_specified_name_for_serial (serial_name, user_specified_serial_name, DB_MAX_SERIAL_NAME_LENGTH);
   serial_mop = do_get_serial_obj_id (&serial_obj_id, serial_class_mop, user_specified_serial_name);
   if (serial_mop == NULL)
     {

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -2225,7 +2225,18 @@ sm_user_specified_name (const char *name, char *buf, int buf_size)
       return sm_downcase_name (name, buf, buf_size);
     }
 
-  assert (strlen (name) < SM_MAX_IDENTIFIER_LENGTH - SM_MAX_USER_LENGTH);
+  /* If the length of the object name was not previously checked, it may exceed 222 bytes.
+   * In this case, return only the object name without raising an error. And expect that the object is not found */
+  if (strlen (name) >= SM_MAX_IDENTIFIER_LENGTH - SM_MAX_USER_LENGTH)
+    {
+      assert (strlen (name) < SM_MAX_IDENTIFIER_LENGTH);
+
+      /*
+       * e.g.   name: object_name (exceeds)
+       *      return: object_name (exceeds)
+       */
+      return sm_downcase_name (name, buf, buf_size);
+    }
 
   if (sm_check_system_class_by_name (name))
     {
@@ -2305,7 +2316,18 @@ sm_user_specified_name_for_serial (const char *name, char *buf, int buf_size)
       return sm_downcase_name (name, buf, buf_size);
     }
 
-  assert (strlen (name) < DB_MAX_SERIAL_NAME_LENGTH - SM_MAX_USER_LENGTH);
+  /* If the length of the object name was not previously checked, it may exceed 482 bytes.
+   * In this case, return only the object name without raising an error. And expect that the object is not found */
+  if (strlen (name) >= DB_MAX_SERIAL_NAME_LENGTH - SM_MAX_USER_LENGTH)
+    {
+      assert (strlen (name) < DB_MAX_SERIAL_NAME_LENGTH);
+
+      /*
+       * e.g.   name: object_name (exceeds)
+       *      return: object_name (exceeds)
+       */
+      return sm_downcase_name (name, buf, buf_size);
+    }
 
   current_schema_name = sc_current_schema_name ();
 

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -2378,6 +2378,7 @@ sm_qualifier_name (const char *name, char *buf, int buf_size)
   /* If it exceeds SM_MAX_USER_LENGTH, it is not a user-specified name. */
   if (qualifier_name_len >= SM_MAX_USER_LENGTH)
     {
+      assert (false);
       buf[0] = '\0';
       return NULL;
     }

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -2379,6 +2379,7 @@ sm_qualifier_name (const char *name, char *buf, int buf_size)
   if (qualifier_name_len >= SM_MAX_USER_LENGTH)
     {
       assert (false);
+      ERROR_SET_WARNING (error, ER_SM_INVALID_ARGUMENTS);
       buf[0] = '\0';
       return NULL;
     }

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -2189,13 +2189,14 @@ sm_downcase_name (const char *name, char *buf, int buf_size)
 char *
 sm_user_specified_name (const char *name, char *buf, int buf_size)
 {
-  char user_specified_name[SM_MAX_IDENTIFIER_LENGTH] = { '\0' };
-  const char *current_schema_name = NULL;
   const char *dot = NULL;
+  char user_specified_name[SM_MAX_IDENTIFIER_LENGTH];
+  int user_specified_name_len;
+  const char *current_schema_name = NULL;
   int error = NO_ERROR;
 
   assert (buf != NULL);
-  assert (buf_size > 0);
+  assert (buf_size >= SM_MAX_IDENTIFIER_LENGTH);
 
   if (name == NULL || name[0] == '\0')
     {
@@ -2204,10 +2205,16 @@ sm_user_specified_name (const char *name, char *buf, int buf_size)
       return NULL;
     }
 
-  /* If the name is already a user-specified name or a system class name, do not recreate it. */
+  /* Find the ending position of the user-specified name. */
   dot = strchr (name, '.');
+
+  /* If the name is already a user-specified name or a system class name, do not recreate it. */
   if (dot != NULL)
     {
+      /* There must be only one dot(.) because dot(.) cannot be used in identifier names
+       * even if the exception rule is used. */
+      assert (strchr (dot + 1, '.') == NULL);
+
       assert (STATIC_CAST (int, dot - name) < SM_MAX_USER_LENGTH);
       assert (strlen (dot + 1) < SM_MAX_IDENTIFIER_LENGTH - SM_MAX_USER_LENGTH);
 
@@ -2217,7 +2224,9 @@ sm_user_specified_name (const char *name, char *buf, int buf_size)
        */
       return sm_downcase_name (name, buf, buf_size);
     }
+
   assert (strlen (name) < SM_MAX_IDENTIFIER_LENGTH - SM_MAX_USER_LENGTH);
+
   if (sm_check_system_class_by_name (name))
     {
       /*
@@ -2229,14 +2238,95 @@ sm_user_specified_name (const char *name, char *buf, int buf_size)
 
   current_schema_name = sc_current_schema_name ();
 
-  assert (snprintf (NULL, 0, "%s.%s", current_schema_name, name) < buf_size);
-  assert (snprintf (NULL, 0, "%s.%s", current_schema_name, name) < SM_MAX_IDENTIFIER_LENGTH);
+  /* Calculate the length of the user-specified name in advance. */
+  user_specified_name_len = snprintf (NULL, 0, "%s.%s", current_schema_name, name);
+
+  if (user_specified_name_len >= buf_size || user_specified_name_len >= SM_MAX_IDENTIFIER_LENGTH)
+    {
+      assert (false);
+      ERROR_SET_WARNING (error, ER_SM_INVALID_ARGUMENTS);
+      buf[0] = '\0';
+      return NULL;
+    }
 
   /*
    * e.g.   name: object_name
    *      return: current_user_name.object_name
    */
-  snprintf (user_specified_name, SM_MAX_IDENTIFIER_LENGTH, "%s.%s", current_schema_name, name);
+  sprintf (user_specified_name, "%s.%s", current_schema_name, name);
+  user_specified_name[user_specified_name_len] = '\0';
+
+  return sm_downcase_name (user_specified_name, buf, buf_size);
+}
+
+/*
+ * sm_user_specified_name_for_serial() - Make the name a user-specified name.
+ *   return: output buffer pointer or NULL on error
+ *   name(in): user-specified name or object name
+ *   buf(out): output buffer
+ *   buf_size(in): output buffer length
+ */
+char *
+sm_user_specified_name_for_serial (const char *name, char *buf, int buf_size)
+{
+  const char *dot = NULL;
+  char user_specified_name[DB_MAX_SERIAL_NAME_LENGTH];
+  int user_specified_name_len;
+  const char *current_schema_name = NULL;
+  int error = NO_ERROR;
+
+  assert (buf != NULL);
+  assert (buf_size >= DB_MAX_SERIAL_NAME_LENGTH);
+
+  if (name == NULL || name[0] == '\0')
+    {
+      ERROR_SET_WARNING (error, ER_SM_INVALID_ARGUMENTS);
+      buf[0] = '\0';
+      return NULL;
+    }
+
+  /* Find the ending position of the user-specified name. */
+  dot = strchr (name, '.');
+
+  /* If the name is already a user-specified name or a system class name, do not recreate it. */
+  if (dot != NULL)
+    {
+      /* There must be only one dot(.) because dot(.) cannot be used in identifier names
+       * even if the exception rule is used. */
+      assert (strchr (dot + 1, '.') == NULL);
+
+      assert (STATIC_CAST (int, dot - name) < SM_MAX_USER_LENGTH);
+      assert (strlen (dot + 1) < DB_MAX_SERIAL_NAME_LENGTH - SM_MAX_USER_LENGTH);
+
+      /*
+       * e.g.   name: user_name.object_name
+       *      return: user_name.object_name
+       */
+      return sm_downcase_name (name, buf, buf_size);
+    }
+
+  assert (strlen (name) < DB_MAX_SERIAL_NAME_LENGTH - SM_MAX_USER_LENGTH);
+
+  current_schema_name = sc_current_schema_name ();
+
+  /* Calculate the length of the user-specified name in advance. */
+  user_specified_name_len = snprintf (NULL, 0, "%s.%s", current_schema_name, name);
+
+  if (user_specified_name_len >= buf_size || user_specified_name_len >= SM_MAX_IDENTIFIER_LENGTH)
+    {
+      assert (false);
+      ERROR_SET_WARNING (error, ER_SM_INVALID_ARGUMENTS);
+      buf[0] = '\0';
+      return NULL;
+    }
+
+  /*
+   * e.g.   name: object_name
+   *      return: current_user_name.object_name
+   */
+  sprintf (user_specified_name, "%s.%s", current_schema_name, name);
+  user_specified_name[user_specified_name_len] = '\0';
+
   return sm_downcase_name (user_specified_name, buf, buf_size);
 }
 
@@ -2251,32 +2341,49 @@ char *
 sm_qualifier_name (const char *name, char *buf, int buf_size)
 {
   const char *dot = NULL;
-  int len = 0;
+  int qualifier_name_len;
   int error = NO_ERROR;
+
+  assert (buf != NULL);
+  assert (buf_size >= SM_MAX_USER_LENGTH);
 
   if (name == NULL || name[0] == '\0')
     {
       ERROR_SET_WARNING (error, ER_SM_INVALID_ARGUMENTS);
+      buf[0] = '\0';
       return NULL;
     }
 
-  assert (buf != NULL);
-  assert (buf_size > 0);
+
+  /* Find the ending position of the user-specified name. */
+  dot = strchr (name, '.');
 
   /* If the name is not a user-specified name, NULL is returned. */
-  dot = strchr (name, '.');
   if (dot == NULL)
     {
+      /*
+       * e.g.           name: object_name
+       *      qualifier_name: NULL
+       */
+      buf[0] = '\0';
       return NULL;
     }
 
-  len = STATIC_CAST (int, dot - name);
+  /* There must be only one dot(.) because dot(.) cannot be used in identifier names
+   * even if the exception rule is used. */
+  assert (strchr (dot + 1, '.') == NULL);
 
-  assert (len < buf_size);
-  assert (len < SM_MAX_USER_LENGTH);
+  qualifier_name_len = STATIC_CAST (int, dot - name);
 
-  memcpy (buf, name, len);
-  buf[len] = '\0';
+  /* If it exceeds SM_MAX_USER_LENGTH, it is not a user-specified name. */
+  if (qualifier_name_len >= SM_MAX_USER_LENGTH)
+    {
+      buf[0] = '\0';
+      return NULL;
+    }
+
+  memcpy (buf, name, qualifier_name_len);
+  buf[qualifier_name_len] = '\0';
 
   return buf;
 }

--- a/src/object/schema_manager.h
+++ b/src/object/schema_manager.h
@@ -218,6 +218,7 @@ extern bool sm_has_indexes (MOBJ class_);
 /* Interpreter support functions */
 extern char *sm_downcase_name (const char *name, char *buf, int buf_size);
 extern char *sm_user_specified_name (const char *name, char *buf, int buf_size);
+extern char *sm_user_specified_name_for_serial (const char *name, char *buf, int buf_size);
 extern char *sm_qualifier_name (const char *name, char *buf, int buf_size);
 extern const char *sm_remove_qualifier_name (const char *name);
 extern MOP sm_find_class (const char *name);

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -10791,6 +10791,7 @@ pt_get_name_without_current_user_name (const char *name)
   /* If it exceeds DB_MAX_USER_LENGTH, it is not a user-specified name. */
   if (qualifier_name_len >= DB_MAX_USER_LENGTH)
     {
+      assert (false);
       return name;
     }
 

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -10781,10 +10781,6 @@ pt_get_name_without_current_user_name (const char *name)
       return name;
     }
 
-  /* There must be only one dot(.) because dot(.) cannot be used in identifier names
-   * even if the exception rule is used. */
-  assert (strchr (dot + 1, '.') == NULL);
-
   /* Length of user-specified name. */
   qualifier_name_len = STATIC_CAST (int, dot - name);
 

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -10787,7 +10787,6 @@ pt_get_name_without_current_user_name (const char *name)
   /* If it exceeds DB_MAX_USER_LENGTH, it is not a user-specified name. */
   if (qualifier_name_len >= DB_MAX_USER_LENGTH)
     {
-      assert (false);
       return name;
     }
 

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -10756,8 +10756,9 @@ pt_get_name_with_qualifier_removed (const char *name)
 const char *
 pt_get_name_without_current_user_name (const char *name)
 {
-  char *dot = NULL;
-  char name_copy[DB_MAX_IDENTIFIER_LENGTH] = { '\0' };
+  const char *dot = NULL;
+  char qualifier_name[DB_MAX_USER_LENGTH];
+  int qualifier_name_len;
   const char *current_schema_name = NULL;
   const char *object_name = NULL;
   int error = NO_ERROR;
@@ -10767,10 +10768,8 @@ pt_get_name_without_current_user_name (const char *name)
       return name;
     }
 
-  assert (strlen (name) < DB_MAX_IDENTIFIER_LENGTH);
-  strcpy (name_copy, name);
-
-  dot = strchr (name_copy, '.');
+  /* Find the ending position of the user-specified name. */
+  dot = strchr (name, '.');
 
   /* If the name is not a user-specified name, it is returned as is. */
   if (dot == NULL)
@@ -10782,17 +10781,32 @@ pt_get_name_without_current_user_name (const char *name)
       return name;
     }
 
+  /* There must be only one dot(.) because dot(.) cannot be used in identifier names
+   * even if the exception rule is used. */
+  assert (strchr (dot + 1, '.') == NULL);
+
+  /* Length of user-specified name. */
+  qualifier_name_len = STATIC_CAST (int, dot - name);
+
+  /* If it exceeds DB_MAX_USER_LENGTH, it is not a user-specified name. */
+  if (qualifier_name_len >= DB_MAX_USER_LENGTH)
+    {
+      return name;
+    }
+
+  /* Copy the user-specified name to the buffer for comparison with the current schema name. */
+  memcpy (qualifier_name, name, qualifier_name_len);
+  qualifier_name[qualifier_name_len] = '\0';
+
   current_schema_name = sc_current_schema_name ();
 
-  dot[0] = '\0';
-
-  if (intl_identifier_casecmp (name_copy, current_schema_name) == 0)
+  if (intl_identifier_casecmp (qualifier_name, current_schema_name) == 0)
     {
       /*
        * e.g.        name: current_schema_name.object_name
        *      object_name: object_name
        */
-      object_name = strchr (name, '.') + 1;
+      object_name = dot + 1;
     }
   else
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25216

We found that the buffer of the pt_get_name_without_current_user_name function may be insufficient to copy the user-specified name. Also, we found that if the name of the auto-increment serial exceeds 254 bytes, it is truncated to 254 bytes when the owner of the table changes. In debug mode, if the table name exceeds 222 bytes, an assertion occurs in sm_user_specified_name. To prevent this, there are the following changes:

1. Copy only the qualifier name from the user-specified name in the pt_get_name_without_current_user_name function.
2. Add sm_user_specified_name_for_serial function.
3. Check if there is enough buffer in sm_user_specified_name and sm_qualifier_name functions.
4. Do not truncate the length of the new serial name to 254 bytes in the au_change_serial_owner function.
5. Add a safe guard to sm_user_specified_name and sm_user_specified_name_for_serial.