### PR TITLE
[CBRD-25194] Calls to built-in functions with no argument emit run-time errors

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -3996,7 +3996,7 @@ public class SpLib {
 
     private static String getHostVarsStr(int len) {
         if (len == 0) {
-            return "";
+            return "()";
         } else {
             String[] arr = new String[len];
             Arrays.fill(arr, "?");


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25194

. minor bug: I omitted empty arguments parentheses for built-in function calls.
