### PR TITLE
[CBRD-25009] added 'Ctrl+d' to the ;EXit line of the CSQL help messages

### DIFF
--- a/msg/de_DE.utf8/csql.msg
+++ b/msg/de_DE.utf8/csql.msg
@@ -153,7 +153,7 @@ $ csql help messages
    ;PRINT                       - Befehlspuffer drucken.\n\
    ;SHELL                       - Shell rufen.\n\
    ;CD                          - aktuelles Verzeichnis ändern.\n\
-   ;EXit                        - Programm beenden.\n\
+   ;EXit (or Ctrl+d)            - Programm beenden.\n\
 \n\
    ;CLear                       - Befehlspuffer leeren.\n\
    ;EDIT   [format/fmt]         - System-Editor [nach dem Formatierer] mit dem Befehlspuffer.\n\

--- a/msg/en_US.utf8/csql.msg
+++ b/msg/en_US.utf8/csql.msg
@@ -152,7 +152,7 @@ $ csql help messages
    ;PRINT                       - print command buffer.\n\
    ;SHELL                       - invoke shell.\n\
    ;CD                          - change current working directory.\n\
-   ;EXit                        - exit program.\n\
+   ;EXit (or Ctrl+d)            - exit program.\n\
 \n\
    ;CLear                       - clear command buffer.\n\
    ;EDIT   [format/fmt]         - invoke system editor [after formatter] with command buffer.\n\

--- a/msg/en_US/csql.msg
+++ b/msg/en_US/csql.msg
@@ -152,7 +152,7 @@ $ csql help messages
    ;PRINT                       - print command buffer.\n\
    ;SHELL                       - invoke shell.\n\
    ;CD                          - change current working directory.\n\
-   ;EXit                        - exit program.\n\
+   ;EXit (or Ctrl+d)            - exit program.\n\
 \n\
    ;CLear                       - clear command buffer.\n\
    ;EDIT   [format/fmt]         - invoke system editor [after formatter] with command buffer.\n\

--- a/msg/es_ES.utf8/csql.msg
+++ b/msg/es_ES.utf8/csql.msg
@@ -152,7 +152,7 @@ $ csql help messages
    ;PRINT                       - imprimir bufer de comando.\n\
    ;SHELL                       - invocar shell.\n\
    ;CD                          - cambiar directorio de trabajo actual.\n\
-   ;EXit                        - salir del programa.\n\
+   ;EXit (or Ctrl+d)            - salir del programa.\n\
 \n\
    ;CLear                       - limpia bufer de comando.\n\
    ;EDIT   [format/fmt]         - invoque el editor del sistema [después del formateador] con el búfer de comandos.\n\

--- a/msg/fr_FR.utf8/csql.msg
+++ b/msg/fr_FR.utf8/csql.msg
@@ -152,7 +152,7 @@ $ csql help messages
    ;PRINT                       - affiche tampon de commande.\n\
    ;SHELL                       - invoque l'interpréteur de commandes.\n\
    ;CD                          - change le répertoire courant.\n\
-   ;EXit                        - quitte le programme.\n\
+   ;EXit (or Ctrl+d)            - quitte le programme.\n\
 \n\
    ;CLear                       - efface le tampon de commande.\n\
    ;EDIT   [format/fmt]         - invoque éditeur système [après le formateur] avec le tampon de commande.\n\

--- a/msg/it_IT.utf8/csql.msg
+++ b/msg/it_IT.utf8/csql.msg
@@ -152,7 +152,7 @@ $ messaggi di aiuto csql
    ;PRINT                       - stampa buffer dei comandi.\n\
    ;SHELL                       - richiamare shell.\n\
    ;CD                          - cambiare directory di lavoro corrente.\n\
-   ;EXit                        - uscire dal programma.\n\
+   ;EXit (or Ctrl+d)            - uscire dal programma.\n\
 \n\
    ;CLear                       - pulire il buffer di comando.\n\
    ;EDIT   [format/fmt]         - invocare editor di sistema [dopo il formattatore] con il buffer dei comandi.\n\

--- a/msg/ja_JP.utf8/csql.msg
+++ b/msg/ja_JP.utf8/csql.msg
@@ -152,7 +152,7 @@ $ csql help messages
    ;PRINT                       - コマンドバッファーの内容を出力。\n\
    ;SHELL                       - シェル実行。\n\
    ;CD                          - 現在作業ディレクトリー変更。\n\
-   ;EXit                        - 終了。\n\
+   ;EXit (or Ctrl+d)            - 終了。\n\
 \n\
    ;CLear                       - コマンドバッファーの内容を消す。\n\
    ;EDIT   [format/fmt]         - コマンドバッファを使用して[フォーマッタの後に]システムエディタを呼び出します。\n\

--- a/msg/km_KH.utf8/csql.msg
+++ b/msg/km_KH.utf8/csql.msg
@@ -152,7 +152,7 @@ $ csql help messages
    ;PRINT                       - print command buffer.\n\
    ;SHELL                       - invoke shell.\n\
    ;CD                          - change current working directory.\n\
-   ;EXit                        - exit program.\n\
+   ;EXit (or Ctrl+d)            - exit program.\n\
 \n\
    ;CLear                       - clear command buffer.\n\
    ;EDIT   [format/fmt]         - invoke system editor [after formatter] with command buffer.\n\

--- a/msg/ko_KR.euckr/csql.msg
+++ b/msg/ko_KR.euckr/csql.msg
@@ -151,7 +151,7 @@ $ csql help messages
    ;PRINT                       - 명령어 버퍼 내용을 프린트.\n\
    ;SHELL                       - 쉘 수행.\n\
    ;CD                          - 현재 작업 디렉터리 변경.\n\
-   ;EXit                        - 종료.\n\
+   ;EXit (or Ctrl+d)            - 종료.\n\
 \n\
    ;CLear                       - 명령어 버퍼 내용을 지움.\n\
    ;EDIT   [format/fmt]         - 명령어 버퍼 [포맷 후] 편집.\n\

--- a/msg/ko_KR.utf8/csql.msg
+++ b/msg/ko_KR.utf8/csql.msg
@@ -151,7 +151,7 @@ $ csql help messages
    ;PRINT                       - 명령어 버퍼 내용을 프린트.\n\
    ;SHELL                       - 쉘 수행.\n\
    ;CD                          - 현재 작업 디렉터리 변경.\n\
-   ;EXit                        - 종료.\n\
+   ;EXit (or Ctrl+d)            - 종료.\n\
 \n\
    ;CLear                       - 명령어 버퍼 내용을 지움.\n\
    ;EDIT   [format/fmt]         - 명령어 버퍼 [포맷 후] 편집.\n\

--- a/msg/ro_RO.utf8/csql.msg
+++ b/msg/ro_RO.utf8/csql.msg
@@ -152,7 +152,7 @@ $ csql help messages
    ;PRINT                       - afişează buffer-ul de comenzi.\n\
    ;SHELL                       - invocă shell-ul.\n\
    ;CD                          - schimbă directorul curent de lucru.\n\
-   ;EXit                        - închide aplicaţia.\n\
+   ;EXit (or Ctrl+d)            - închide aplicaţia.\n\
 \n\
    ;CLear                       - goleşte buffer-ul de comenzi.\n\
    ;EDIT   [format/fmt]         - invocă editorul de sistem [după formatator] cu bufferul de comandă.\n\

--- a/msg/tr_TR.utf8/csql.msg
+++ b/msg/tr_TR.utf8/csql.msg
@@ -152,7 +152,7 @@ $ csql help messages
    ;PRINT                       - komut buffer yazdır.\n\
    ;SHELL                       - dış kabuk çağırma.\n\
    ;CD                          - Geçerli çalışma dizini değiştirin.\n\
-   ;EXit                        - programdan çık.\n\
+   ;EXit (or Ctrl+d)            - programdan çık.\n\
 \n\
    ;CLear                       - komut buffer temizle.\n\
    ;EDIT   [format/fmt]         - komut arabelleği ile [biçimlendiriciden sonra] sistem düzenleyicisini çağırın.\n\

--- a/msg/vi_VN.utf8/csql.msg
+++ b/msg/vi_VN.utf8/csql.msg
@@ -152,7 +152,7 @@ $ csql help messages
    ;PRINT                       - print command buffer.\n\
    ;SHELL                       - invoke shell.\n\
    ;CD                          - change current working directory.\n\
-   ;EXit                        - exit program.\n\
+   ;EXit (or Ctrl+d)            - exit program.\n\
 \n\
    ;CLear                       - clear command buffer.\n\
    ;EDIT   [format/fmt]         - invoke system editor [after formatter] with command buffer.\n\

--- a/msg/zh_CN.utf8/csql.msg
+++ b/msg/zh_CN.utf8/csql.msg
@@ -152,7 +152,7 @@ $ csql help messages
    ;PRINT                       - 打印命令缓冲区.\n\
    ;SHELL                       - 调用shell.\n\
    ;CD                          - 改变当前工作目录.\n\
-   ;EXit                        - 退出程序.\n\
+   ;EXit (or Ctrl+d)            - 退出程序.\n\
 \n\
    ;CLear                       - 清理命令缓冲区.\n\
    ;EDIT   [format/fmt]         - 使用命令缓冲区调用系统编辑器 [在格式化程序之后].\n\


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25009

. Inform that Ctrl+d can be used to quit the CSQL when it falls into an irresponsive status.
