### PR TITLE
[CBRD-25204] Implement aggregate function of memory monitor

### DIFF
--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -151,6 +151,7 @@ set (BASE_HEADERS
   ${BASE_DIR}/lockfree_transaction_table.hpp
   ${BASE_DIR}/lockfree_transaction_system.hpp
   ${BASE_DIR}/mem_block.hpp
+  ${BASE_DIR}/memory_monitor_common.hpp
   ${BASE_DIR}/memory_monitor_sr.hpp
   ${BASE_DIR}/memory_reference_store.hpp
   ${BASE_DIR}/memory_private_allocator.hpp

--- a/src/base/memory_monitor_common.hpp
+++ b/src/base/memory_monitor_common.hpp
@@ -1,0 +1,43 @@
+/*
+ *
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+/*
+ * memory_monitor_common.hpp - Declaration of structures which is using
+ *                             both server and client
+ */
+
+#ifndef _MEMORY_MONITOR_COMMON_HPP_
+#define _MEMORY_MONITOR_COMMON_HPP_
+
+#include <stdint.h>
+#include <string>
+#include <vector>
+#include <algorithm>
+
+#define MMON_MAX_SERVER_NAME_LENGTH 255
+
+typedef struct mmon_server_info MMON_SERVER_INFO;
+struct mmon_server_info
+{
+  char server_name[MMON_MAX_SERVER_NAME_LENGTH];
+  uint64_t total_mem_usage;
+  uint64_t mmon_metainfo_mem_usage;
+  int num_stat;
+  std::vector<std::pair<std::string, uint64_t>> stat_info;
+};
+#endif // _MEMORY_MONITOR_COMMON_HPP_

--- a/src/base/memory_monitor_common.hpp
+++ b/src/base/memory_monitor_common.hpp
@@ -29,15 +29,15 @@
 #include <vector>
 #include <algorithm>
 
-#define MMON_MAX_SERVER_NAME_LENGTH 255
+#define MMON_MAX_SERVER_NAME_LENGTH 32
 
 typedef struct mmon_server_info MMON_SERVER_INFO;
 struct mmon_server_info
 {
   char server_name[MMON_MAX_SERVER_NAME_LENGTH];
   uint64_t total_mem_usage;
-  uint64_t mmon_metainfo_mem_usage;
+  uint64_t total_metainfo_mem_usage;
   int num_stat;
-  std::vector<std::pair<std::string, uint64_t>> stat_info;
+  std::vector<std::pair<std::string, uint64_t>> stat_info; // <stat name, memory usage>
 };
 #endif // _MEMORY_MONITOR_COMMON_HPP_

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -169,6 +169,25 @@ namespace cubmem
 	  }
       }
   }
+
+  void memory_monitor::aggregate_server_info (MMON_SERVER_INFO &server_info)
+  {
+    strncpy (server_info.server_name, m_server_name.c_str (), m_server_name.size () + 1);
+    server_info.total_mem_usage = m_total_mem_usage.load ();
+    server_info.mmon_metainfo_mem_usage = m_meta_alloc_count * MMON_METAINFO_SIZE;
+    server_info.num_stat = m_tag_map.size ();
+
+    for (auto it = m_tag_map.begin (); it != m_tag_map.end (); ++it)
+      {
+	server_info.stat_info.emplace_back (it->first, m_stat_map[it->second].load ());
+      }
+
+    const auto &comp = [] (const auto &stat_pair1, const auto &stat_pair2)
+    {
+      return stat_pair1.second > stat_pair2.second;
+    };
+    std::sort (server_info.stat_info.begin (), server_info.stat_info.end (), comp);
+  }
 }
 
 using namespace cubmem;
@@ -191,4 +210,9 @@ void mmon_add_stat (char *ptr, const size_t size, const char *file, const int li
 void mmon_sub_stat (char *ptr)
 {
   mmon_Gl->sub_stat (ptr);
+}
+
+void mmon_aggregate_server_info (MMON_SERVER_INFO &server_info)
+{
+  mmon_Gl->aggregate_server_info (server_info);
 }

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -116,7 +116,7 @@ namespace cubmem
     stat_name = make_stat_name (file, line);
 
     std::unique_lock <std::shared_mutex> stat_map_write_lock (m_stat_map_mutex);
-    auto search = m_stat_name_map.find (stat_name);
+    const auto search = m_stat_name_map.find (stat_name);
     if (search != m_stat_name_map.end ())
       {
 	metainfo.stat_id = search->second;

--- a/src/base/memory_monitor_sr.hpp
+++ b/src/base/memory_monitor_sr.hpp
@@ -24,11 +24,11 @@
 #ifndef _MEMORY_MONITOR_SR_HPP_
 #define _MEMORY_MONITOR_SR_HPP_
 
-#include <stdint.h>
-#include <string>
 #include <atomic>
 #include <unordered_map>
 #include <mutex>
+
+#include "memory_monitor_common.hpp"
 
 namespace cubmem
 {
@@ -54,6 +54,7 @@ namespace cubmem
       size_t get_allocated_size (char *ptr);
       void add_stat (char *ptr, const size_t size, const char *file, const int line);
       void sub_stat (char *ptr);
+      void aggregate_server_info (MMON_SERVER_INFO &server_info);
 
     private:
       static char *get_metainfo_pos (char *ptr, size_t size);
@@ -81,4 +82,5 @@ bool mmon_is_memory_monitor_enabled ();
 size_t mmon_get_allocated_size (char *ptr);
 void mmon_add_stat (char *ptr, const size_t size, const char *file, const int line);
 void mmon_sub_stat (char *ptr);
+void mmon_aggregate_server_info (MMON_SERVER_INFO &server_info);
 #endif // _MEMORY_MONITOR_SR_HPP_

--- a/src/base/memory_monitor_sr.hpp
+++ b/src/base/memory_monitor_sr.hpp
@@ -26,7 +26,7 @@
 
 #include <atomic>
 #include <unordered_map>
-#include <mutex>
+#include <shared_mutex>
 
 #include "memory_monitor_common.hpp"
 
@@ -35,7 +35,7 @@ namespace cubmem
   // IMPORTANT!!
   // This meta size is related with allocation byte align
   // Don't adjust it freely
-  // 8 byte size + 4 byte tag + 4 byte magicnumber
+  // 8 byte size + 4 byte stat + 4 byte magicnumber
   static constexpr int MMON_METAINFO_SIZE = 16;
 
   class memory_monitor
@@ -59,14 +59,14 @@ namespace cubmem
 
     private:
       static char *get_metainfo_pos (char *ptr, size_t size);
-      static std::string make_tag_name (const char *file, const int line);
+      static std::string make_stat_name (const char *file, const int line);
 
     private:
       std::string m_server_name;
-      mutable std::mutex m_map_mutex;
-      // Entries of m_tag_map and m_stat_map will not be deleted
-      std::unordered_map <std::string, int> m_tag_map;              // key: tag name, value: tag id
-      std::unordered_map <int, std::atomic <uint64_t>> m_stat_map;  // key: tag id, value: memory usage
+      mutable std::shared_mutex m_stat_map_mutex;
+      // Entries of m_stat_name_map and m_stat_map will not be deleted
+      std::unordered_map <std::string, int> m_stat_name_map;        // key: stat name, value: stat id
+      std::unordered_map <int, std::atomic <uint64_t>> m_stat_map;  // key: stat id, value: memory usage
       std::atomic <uint64_t> m_total_mem_usage;
       std::atomic <int> m_meta_alloc_count;                         // for checking occupancy of memory used by metainfo space
       // Magic number is for checking an allocated memory which is out-of-scope of memory_monitor.

--- a/src/base/memory_monitor_sr.hpp
+++ b/src/base/memory_monitor_sr.hpp
@@ -55,6 +55,7 @@ namespace cubmem
       void add_stat (char *ptr, const size_t size, const char *file, const int line);
       void sub_stat (char *ptr);
       void aggregate_server_info (MMON_SERVER_INFO &server_info);
+      void finalize_dump ();
 
     private:
       static char *get_metainfo_pos (char *ptr, size_t size);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25204

 - Add structure MMON_SERVER_INFO at the new file `memory_monitor_common.hpp` for using both saving the information of `memory_monitor` class and receiving the information at the client-side
 - Implement aggregation method `aggregate_server_info()` in memory_monitor class
 - Implement aggregation API `mmon_aggregate_server_info()`
 - Implement debug API `finalize_dump()` for checking all memory allocations freed