### PR TITLE
[CBRD-25209] Fixed an issue where ddl statement was missing from audit_log when an error occurred in autocommit mode.

### DIFF
--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -10961,14 +10961,14 @@ ux_auto_commit (T_NET_BUF * net_buf, T_REQ_INFO * req_info)
   if (req_info->need_auto_commit == TRAN_AUTOCOMMIT)
     {
       cas_log_write (0, false, "auto_commit %s", tran_was_latest_query_committed ()? "(server)" : "(local)");
-      err_code = ux_end_tran (CCI_TRAN_COMMIT, true, true);
+      err_code = ux_end_tran (CCI_TRAN_COMMIT, true, false);
       cas_log_write (0, false, "auto_commit %d", err_code);
       logddl_set_msg ("auto_commit %d", err_code);
     }
   else if (req_info->need_auto_commit == TRAN_AUTOROLLBACK)
     {
       cas_log_write (0, false, "auto_commit %s", tran_was_latest_query_aborted ()? "(local)" : "(server)");
-      err_code = ux_end_tran (CCI_TRAN_ROLLBACK, true, true);
+      err_code = ux_end_tran (CCI_TRAN_ROLLBACK, true, false);
       cas_log_write (0, false, "auto_rollback %d", err_code);
       logddl_set_msg ("auto_rollback %d", err_code);
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25209

* Fixed an issue where DDL statement was missing from audit_log when an error occurred in autocommit mode.
* http://jira.cubrid.org/browse/CBRD-25209?focusedCommentId=4766021&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-4766021
* 
