### PR TITLE
[CBRD-25205] Start/end 'memory_monitor' when server booting/shutdown

### DIFF
--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -246,6 +246,7 @@ int mmon_initialize (const char *server_name)
   int error = NO_ERROR;
 
   assert (mmon_Gl == nullptr);
+  assert (server_name != nullptr);
 
   if (prm_get_bool_value (PRM_ID_ENABLE_MEMORY_MONITORING))
     {

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -246,7 +246,6 @@ int mmon_initialize (const char *server_name)
   int error = NO_ERROR;
 
   assert (mmon_Gl == nullptr);
-  assert_release (server_name != NULL);
 
   if (prm_get_bool_value (PRM_ID_ENABLE_MEMORY_MONITORING))
     {

--- a/src/base/memory_monitor_sr.hpp
+++ b/src/base/memory_monitor_sr.hpp
@@ -80,6 +80,8 @@ namespace cubmem
 } //namespace cubmem
 
 bool mmon_is_memory_monitor_enabled ();
+int mmon_initialize (const char *server_name);
+void mmon_finalize ();
 size_t mmon_get_allocated_size (char *ptr);
 void mmon_add_stat (char *ptr, const size_t size, const char *file, const int line);
 void mmon_sub_stat (char *ptr);

--- a/src/communication/network_sr.c
+++ b/src/communication/network_sr.c
@@ -60,6 +60,7 @@
 #include "thread_manager.hpp"
 #include "session.h"
 #include "network_request_def.hpp"
+#include "memory_monitor_sr.hpp"
 
 static void net_server_init (void);
 static int net_server_request (THREAD_ENTRY * thread_p, unsigned int rid, int request, int size, char *buffer);
@@ -1178,6 +1179,7 @@ net_server_start (const char *server_name)
 
   cubthread::finalize ();
   cubthread::internal_tasks_worker_pool::finalize ();
+  mmon_finalize ();
   er_final (ER_ALL_FINAL);
   csect_finalize_static_critical_sections ();
   (void) sync_finalize_sync_stats ();

--- a/src/communication/network_sr.c
+++ b/src/communication/network_sr.c
@@ -1132,7 +1132,12 @@ net_server_start (const char *server_name)
       status = -1;
       goto end;
     }
-
+#if defined(SERVER_MODE)
+  if (mmon_initialize (server_name) != NO_ERROR)
+    {
+      goto end;
+    }
+#endif
   net_server_init ();
   css_initialize_server_interfaces (net_server_request, net_server_conn_down);
 

--- a/src/communication/network_sr.c
+++ b/src/communication/network_sr.c
@@ -1132,12 +1132,14 @@ net_server_start (const char *server_name)
       status = -1;
       goto end;
     }
-#if defined(SERVER_MODE)
+
   if (mmon_initialize (server_name) != NO_ERROR)
     {
+      PRINT_AND_LOG_ERR_MSG ("Failed to initialize memory_monitor\n");
+      status = -1;
       goto end;
     }
-#endif
+
   net_server_init ();
   css_initialize_server_interfaces (net_server_request, net_server_conn_down);
 

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2265,13 +2265,6 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
 
   event_log_init (db_name);
 
-#if defined(SERVER_MODE)
-  if (mmon_initialize (db_name) != NO_ERROR)
-    {
-      goto error;
-    }
-#endif
-
   /* initialize allocations areas for things we need, on the client, most of this is done inside ws_init(). */
   area_init ();
   error_code = set_area_init ();

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -98,6 +98,7 @@
 #if defined(ENABLE_SYSTEMTAP)
 #include "probes.h"
 #endif /* ENABLE_SYSTEMTAP */
+#include "memory_monitor_sr.hpp"
 
 #define BOOT_LEAVE_SAFE_OSDISK_PARTITION_FREE_SPACE  \
   (1250 * (IO_DEFAULT_PAGE_SIZE / IO_PAGESIZE))	/* 5 Mbytes */
@@ -2263,6 +2264,13 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
   er_clear ();
 
   event_log_init (db_name);
+
+#if defined(SERVER_MODE)
+  if (mmon_initialize (db_name) != NO_ERROR)
+    {
+      goto error;
+    }
+#endif
 
   /* initialize allocations areas for things we need, on the client, most of this is done inside ws_init(). */
   area_init ();


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25205

In this PR,
 - add mmon_initialize() and mmon_finalize()
   - mmon_initialize() creates global memory_monitor class `mmon_Gl` with nothrow. If it fails to create, return `ER_OUT_OF_VIRTUAL_MEMORY`
   - mmon_finalize() deletes `mmon_Gl` if it exists.
   - call `mmon_Gl->finalize_dump()` for checking all memories are freed when we build debug mode.
 - call mmon_initialize() at boot_restart_server() and mmon_finalize() at net_server_start()
