### PR TITLE
[CBRD-24794] Set the system parameter 'PRM_ID_ENABLE_NEW_LFHASH' to true so that lockfree_hashmap uses a new version hash table.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ pipeline {
                 } else {
                   echo 'Skip junit for feature branch'
                 }
-              
+              }
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
   environment {
     OUTPUT_DIR = 'packages'
     TEST_REPORT = 'reports'
-    JUNIT_REQUIRED = true
+    JUNIT_REQUIRED = 'true'
   }
 
   stages {
@@ -39,7 +39,7 @@ pipeline {
             script {
               if (env.BRANCH_NAME ==~ /^feature\/.*/) {
                 echo 'Skip testing for feature branch'
-                JUNIT_REQUIRED = false
+                JUNIT_REQUIRED = 'false'
               } else {
             	echo 'Testing...'
             	sh '/entrypoint.sh test || echo "$? failed"'
@@ -48,10 +48,14 @@ pipeline {
           }
           post {
             always {
-              archiveArtifacts "${OUTPUT_DIR}/*"
-              if (env.JUNIT_REQUIRED) {
-                junit "${TEST_REPORT}/*.xml"
-              }
+              script {
+                archiveArtifacts "${OUTPUT_DIR}/*"
+                if (env.JUNIT_REQUIRED == 'true' && fileExists("${TEST_REPORT}/summary.xml")) {
+                  junit "${TEST_REPORT}/*.xml"
+                } else {
+                  echo 'Skip junit for feature branch'
+                }
+              
             }
           }
         }
@@ -77,7 +81,7 @@ pipeline {
             script {
               if (env.BRANCH_NAME ==~ /^feature\/.*/) {
                 echo 'Skip testing for feature branch'
-                JUNIT_REQUIRED = false
+                JUNIT_REQUIRED = 'false'
               } else {
             	echo 'Testing...'
             	sh '/entrypoint.sh test || echo "$? failed"'
@@ -86,9 +90,13 @@ pipeline {
           }
           post {
             always {
-              archiveArtifacts "${OUTPUT_DIR}/*"
-              if (env.JUNIT_REQUIRED) {
-                junit "${TEST_REPORT}/*.xml"
+              script {
+                archiveArtifacts "${OUTPUT_DIR}/*"
+                if (env.JUNIT_REQUIRED == 'true' && fileExists("${TEST_REPORT}/summary.xml")) {
+                  junit "${TEST_REPORT}/*.xml"
+                } else {
+                  echo 'Skip junit for feature branch'
+                }
               }
             }
           }
@@ -96,9 +104,9 @@ pipeline {
 
         stage('Windows Release') {
           when {
-            expression {
+            not {
               // Skip Windows Release stage for feature branches
-              return !(env.BRANCH_NAME ==~ /^feature\/.*/)
+              branch 'feature/*'
             }
           }
           agent {

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -2257,8 +2257,8 @@ bool PRM_REPR_CACHE_LOG = false;
 static bool prm_repr_cache_log_default = false;
 static unsigned int prm_repr_cache_log_flag = 0;
 
-bool PRM_NEW_LFHASH = false;
-static bool prm_new_lfhash_default = false;
+bool PRM_NEW_LFHASH = true;
+static bool prm_new_lfhash_default = true;
 static unsigned int prm_new_lfhash_flag = 0;
 
 bool PRM_HEAP_INFO_CACHE_LOGGING = false;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24794