### PR TITLE
[CBRD-25064] loaddb terminates with exit code 0 even though an error occurred

### DIFF
--- a/src/loaddb/load_sa_loader.cpp
+++ b/src/loaddb/load_sa_loader.cpp
@@ -6288,7 +6288,6 @@ ldr_sa_load (load_args *args, int *status, bool *interrupted)
 						 LOADDB_MSG_LAST_COMMITTED_LINE), lastcommit);
 		}
 	      *interrupted = true;
-	      *status = 3;
 	    }
 	  else
 	    {
@@ -6365,6 +6364,11 @@ ldr_sa_load (load_args *args, int *status, bool *interrupted)
 		}
 	    }
 	}
+    }
+
+  if (errors > 0 || *interrupted == true)
+    {
+      *status = 3;
     }
 
   ldr_final ();


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25064

- backport of (#4958)
