### PR TITLE
[CBRD-25087] Move printing backtrace in parent code (#4968)

### DIFF
--- a/src/executables/javasp.cpp
+++ b/src/executables/javasp.cpp
@@ -342,36 +342,7 @@ static void javasp_signal_handler (int sig)
 	  return;
 	}
 
-      int pid = getpid ();
-      std::string err_msg;
-
-      void *addresses[64];
-      int nn_addresses = backtrace (addresses, sizeof (addresses) / sizeof (void *));
-      char **symbols = backtrace_symbols (addresses, nn_addresses);
-
-
-      err_msg += "pid (";
-      err_msg += std::to_string (pid);
-      err_msg += ")\n";
-
-      for (int i = 0; i < nn_addresses; i++)
-	{
-	  err_msg += symbols[i];
-	  if (i < nn_addresses - 1)
-	    {
-	      err_msg += "\n";
-	    }
-	}
-      free (symbols);
-
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_SERVER_CRASHED, 1, err_msg.c_str ());
-
-      pid = fork ();
-      if (pid < 0)
-	{
-	  perror ("fork");
-	}
-
+      int pid = fork ();
       if (pid == 0) // child
 	{
 	  execl (executable_path, UTIL_JAVASP_NAME, "start", db_name.c_str (), NULL);
@@ -379,6 +350,29 @@ static void javasp_signal_handler (int sig)
 	}
       else
 	{
+	  // error handling in parent
+	  std::string err_msg;
+
+	  void *addresses[64];
+	  int nn_addresses = backtrace (addresses, sizeof (addresses) / sizeof (void *));
+	  char **symbols = backtrace_symbols (addresses, nn_addresses);
+
+	  err_msg += "pid (";
+	  err_msg += std::to_string (pid);
+	  err_msg += ")\n";
+
+	  for (int i = 0; i < nn_addresses; i++)
+	    {
+	      err_msg += symbols[i];
+	      if (i < nn_addresses - 1)
+		{
+		  err_msg += "\n";
+		}
+	    }
+	  free (symbols);
+
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_SERVER_CRASHED, 1, err_msg.c_str ());
+
 	  exit (1);
 	}
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25087

In case of memory overflow, segfault occurs in backtrace() and cub_javasp can not be restarted.

backport of #4968 