### PR TITLE
[CBRD-25224] Implement wrapping functions of allocation functions

### DIFF
--- a/src/base/memory_cppwrapper.hpp
+++ b/src/base/memory_cppwrapper.hpp
@@ -28,14 +28,12 @@
 #ifdef SERVER_MODE
 inline void *operator new (size_t size, const char *file, const int line)
 {
-  void *p = cub_alloc (size, file, line);
-  return p;
+  return cub_alloc (size, file, line);
 }
 
 inline void *operator new[] (size_t size, const char *file, const int line)
 {
-  void *p = cub_alloc (size, file, line);
-  return p;
+  return cub_alloc (size, file, line);
 }
 
 inline void operator delete (void *ptr) noexcept

--- a/src/base/memory_cppwrapper.hpp
+++ b/src/base/memory_cppwrapper.hpp
@@ -26,6 +26,10 @@
 #include "memory_cwrapper.h"
 
 #ifdef SERVER_MODE
+// TODO: The usage of operator new encompasses various additional methods beyond basic usage.
+// However, as CUBRID does not currently utilize such additional methods, they are not overloaded.
+// It has been decided that overloading will be undertaken should any issues arise from
+// the discovery of the utilization of these additional methods.
 inline void *operator new (size_t size, const char *file, const int line)
 {
   return cub_alloc (size, file, line);

--- a/src/base/memory_cppwrapper.hpp
+++ b/src/base/memory_cppwrapper.hpp
@@ -1,0 +1,54 @@
+/*
+ *
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+/*
+ * memory_cppwrapper.hpp - Overloading operator new, delete
+ */
+
+#ifndef _MEMORY_CPPWRAPPER_HPP_
+#define _MEMORY_CPPWRAPPER_HPP_
+
+#include "memory_cwrapper.h"
+
+#ifdef SERVER_MODE
+inline void *operator new (size_t size, const char *file, const int line)
+{
+  void *p = cub_alloc (size, file, line);
+  return p;
+}
+
+inline void *operator new[] (size_t size, const char *file, const int line)
+{
+  void *p = cub_alloc (size, file, line);
+  return p;
+}
+
+inline void operator delete (void *ptr) noexcept
+{
+  cub_free (ptr);
+}
+
+inline void operator delete (void *ptr, size_t sz) noexcept
+{
+  cub_free (ptr);
+}
+
+#define new new(__FILE__, __LINE__)
+#endif // SERVER_MODE
+
+#endif // _MEMORY_CPPWRAPPER_HPP_

--- a/src/base/memory_cwrapper.h
+++ b/src/base/memory_cwrapper.h
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+/*
+ * memory_cwrapper.h - managing memory with allocating wrapper functions
+ *                     and memory monitor
+ */
+
+#ifndef _MEMORY_CWRAPPER_H_
+#define _MEMORY_CWRAPPER_H_
+
+#ifdef SERVER_MODE
+#include <string.h>
+#include <stdlib.h>
+#include <malloc.h>
+#include <assert.h>
+
+#include "memory_monitor_sr.hpp"
+
+/*#ifndef HAVE_USR_INCLUDE_MALLOC_H
+#define HAVE_USR_INCLUDE_MALLOC_H
+#endif*/
+
+inline size_t
+get_alloc_size (void *ptr)
+{
+  if (ptr == NULL)
+    {
+      return 0;
+    }
+  else
+    {
+      return mmon_get_allocated_size ((char *) ptr);
+    }
+}
+
+inline void
+cub_free (void *ptr)
+{
+  if (mmon_is_memory_monitor_enabled () && ptr != NULL)
+    {
+      mmon_sub_stat ((char *) ptr);
+      assert (malloc_usable_size (ptr) != 0);
+    }
+  free (ptr);
+}
+
+inline void *
+cub_alloc (size_t size, const char *file, const int line)
+{
+  void *p = NULL;
+
+  if (mmon_is_memory_monitor_enabled ())
+    {
+      p = malloc (size + cubmem::MMON_METAINFO_SIZE);
+      if (p != NULL)
+	{
+	  mmon_add_stat ((char *) p, malloc_usable_size (p), file, line);
+	}
+    }
+  else
+    {
+      p = malloc (size);
+    }
+
+  return p;
+}
+
+inline void *
+cub_calloc (size_t num, size_t size, const char *file, const int line)
+{
+  void *p = NULL;
+
+  if (mmon_is_memory_monitor_enabled ())
+    {
+      p = malloc (num * size + cubmem::MMON_METAINFO_SIZE);
+      if (p != NULL)
+	{
+	  memset (p, 0, num * size + cubmem::MMON_METAINFO_SIZE);
+	  mmon_add_stat ((char *) p, malloc_usable_size (p), file, line);
+	}
+    }
+  else
+    {
+      p = calloc (num, size);
+    }
+
+  return p;
+}
+
+inline void *
+cub_realloc (void *ptr, size_t size, const char *file, const int line)
+{
+  void *p = NULL;
+
+  if (mmon_is_memory_monitor_enabled ())
+    {
+      p = malloc (size + cubmem::MMON_METAINFO_SIZE);
+      if (p != NULL)
+	{
+	  mmon_add_stat ((char *) p, malloc_usable_size (p), file, line);
+
+	  if (ptr != NULL)
+	    {
+	      memcpy (p, ptr, get_alloc_size (ptr));
+	      cub_free (ptr);
+	    }
+	}
+    }
+  else
+    {
+      p = realloc (ptr, size);
+    }
+
+  return p;
+}
+
+inline char *
+cub_strdup (const char *str, const char *file, const int line)
+{
+  void *p = NULL;
+  char *ret = NULL;
+
+  p = cub_alloc (strlen (str) + 1, file, line);
+  if (p != NULL)
+    {
+      ret = (char *) p;
+      memcpy (ret, str, strlen (str) + 1);
+    }
+
+  return ret;
+}
+
+#define malloc(sz) cub_alloc(sz, __FILE__, __LINE__)
+#define calloc(num, sz) cub_calloc(num, sz, __FILE__, __LINE__)
+#define realloc(ptr, sz) cub_realloc(ptr, sz, __FILE__, __LINE__)
+#define strdup(str) cub_strdup(str, __FILE__, __LINE__)
+#define free(ptr) cub_free(ptr)
+#endif // SERVER_MODE
+
+#endif // _MEMORY_CWRAPPER_H_

--- a/src/base/memory_cwrapper.h
+++ b/src/base/memory_cwrapper.h
@@ -1,4 +1,5 @@
 /*
+ *
  * Copyright 2016 CUBRID Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,7 +33,7 @@
 #include "memory_monitor_sr.hpp"
 
 inline size_t
-get_alloc_size (void *ptr)
+get_allocated_size (void *ptr)
 {
   if (ptr == NULL)
     {
@@ -112,7 +113,7 @@ cub_realloc (void *ptr, size_t size, const char *file, const int line)
 
 	  if (ptr != NULL)
 	    {
-	      memcpy (p, ptr, get_alloc_size (ptr));
+	      memcpy (p, ptr, get_allocated_size (ptr));
 	      cub_free (ptr);
 	    }
 	}

--- a/src/base/memory_cwrapper.h
+++ b/src/base/memory_cwrapper.h
@@ -31,10 +31,6 @@
 
 #include "memory_monitor_sr.hpp"
 
-/*#ifndef HAVE_USR_INCLUDE_MALLOC_H
-#define HAVE_USR_INCLUDE_MALLOC_H
-#endif*/
-
 inline size_t
 get_alloc_size (void *ptr)
 {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25224

Implement wrappings functions of allocation functions and overload C++ new/delete for tracking memory:
 - add `cub_alloc()` / `cub_calloc()` / `cub_realloc()` / `cub_strcpy()` / `cub_free()` for wrapping allocation functions
 - add `get_allocated_size()` for copying data of old memory chunk in `cub_realloc()`
 - add definitions of malloc/calloc/realloc/strdup/free for changing the functions to wrapping functions
 - add overloaded `new` / `delete` to track memory
 - add a definition of `new` for changing original new to overloaded new