### PR TITLE
[CBRD-25171] Use PEEK_KEY_VALUE instead of COPY_KEY_VALUE in btree_range_scan_read_record()

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -4424,7 +4424,6 @@ peek_key_to_copy_key (BTREE_SCAN * bts)
       if (DB_IS_NULL (&bts->cur_key) == false)
 	{
 	  DB_VALUE t_key;
-	  /*db_make_null (&t_key); */
 	  pr_clone_value (&(bts->cur_key), &t_key);
 	  btree_clear_key_value (&bts->clear_cur_key, &bts->cur_key);
 	  bts->cur_key = t_key;
@@ -4491,7 +4490,7 @@ btree_check_decompress_key (BTREE_SCAN * bts)
 	}
       else
 	{
-	  assert (0);
+	  assert (false);
 	}
     }
 

--- a/src/storage/btree.h
+++ b/src/storage/btree.h
@@ -217,6 +217,10 @@ struct btree_scan
   bool clear_common_prefix_key;	// 
   bool is_cur_key_compressed;	/* If false, cur_key is a complete key.
 				 * Otherwise it must be combined with common_prefix_key. */
+#define USE_PEEK_IN_RANGE_SCAN_READ
+#if defined(USE_PEEK_IN_RANGE_SCAN_READ)
+  bool is_cur_key_copied;
+#endif
   //---------------------------------------------------------------------------------------------
 
   BTREE_KEYRANGE key_range;	/* key range information */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25171

* Use PEEK_KEY_VALUE instead of COPY_KEY_VALUE in btree_range_scan_read_record()
    - If you need to use cur_key after pgbuf_unfix(), clone it.
