### PR TITLE
[CBRD-24731] Combine AUTHID property syntax and Execution rights functionality

### DIFF
--- a/msg/de_DE.utf8/cubrid.msg
+++ b/msg/de_DE.utf8/cubrid.msg
@@ -1446,8 +1446,9 @@ $ LOADDB
 1359 Java VM crashed: %1$s
 1360 In line %1$d, column %2$d\nStored procedure compile error: %3$s
 1361 Dropping system generated stored procedure is not allowed.
+1362 PL/CSQL Stored procedure/function does not support Invoker's rights
 
-1362 Letzter Fehler
+1363 Letzter Fehler
 
 $set 6 MSGCAT_SET_INTERNAL
 1 Fehler in Fehler-Subsystem (Zeile %1$d):
@@ -1935,7 +1936,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 317 Identifiers cannot be in a LIMIT clause.
 318 Stored procedure/function "$1$s" does not exist.
 
-$set 9 MSGCAT_SET_PARSER_RUNTIME
+\$set 9 MSGCAT_SET_PARSER_RUNTIME
 1 Außer virtuellem Speicher: %1$d Bytes können nicht zugewiesen werden.
 2 Transaktion Isolationslevel muss 1, 2, 3, 4, 5 oder 6 sein.
 3 Timeout Wert muss -1, 0, oder >0 sein.

--- a/msg/de_DE.utf8/cubrid.msg
+++ b/msg/de_DE.utf8/cubrid.msg
@@ -1936,7 +1936,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 317 Identifiers cannot be in a LIMIT clause.
 318 Stored procedure/function "$1$s" does not exist.
 
-\$set 9 MSGCAT_SET_PARSER_RUNTIME
+$set 9 MSGCAT_SET_PARSER_RUNTIME
 1 Außer virtuellem Speicher: %1$d Bytes können nicht zugewiesen werden.
 2 Transaktion Isolationslevel muss 1, 2, 3, 4, 5 oder 6 sein.
 3 Timeout Wert muss -1, 0, oder >0 sein.

--- a/msg/en_US.utf8/cubrid.msg
+++ b/msg/en_US.utf8/cubrid.msg
@@ -1446,8 +1446,9 @@ Check the path of the key file (_keys) and make sure that it includes proper key
 1359 Java VM crashed: %1$s
 1360 In line %1$d, column %2$d\nStored procedure compile error: %3$s
 1361 Dropping system generated stored procedure is not allowed.
+1362 PL/CSQL Stored procedure/function does not support Invoker's rights
 
-1362 Last Error
+1363 Last Error
 
 $set 6 MSGCAT_SET_INTERNAL
 1 Error in error subsystem (line %1$d):
@@ -1935,7 +1936,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 317 Identifiers cannot be in a LIMIT clause.
 318 Stored procedure/function "$1$s" does not exist.
 
-$set 9 MSGCAT_SET_PARSER_RUNTIME
+\$set 9 MSGCAT_SET_PARSER_RUNTIME
 1 Out of virtual memory: unable to allocate %1$d bytes.
 2 Transaction isolation level must be 4, 5 or 6.
 3 Timeout value must be -1, 0, or >0.

--- a/msg/en_US.utf8/cubrid.msg
+++ b/msg/en_US.utf8/cubrid.msg
@@ -1936,7 +1936,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 317 Identifiers cannot be in a LIMIT clause.
 318 Stored procedure/function "$1$s" does not exist.
 
-\$set 9 MSGCAT_SET_PARSER_RUNTIME
+$set 9 MSGCAT_SET_PARSER_RUNTIME
 1 Out of virtual memory: unable to allocate %1$d bytes.
 2 Transaction isolation level must be 4, 5 or 6.
 3 Timeout value must be -1, 0, or >0.

--- a/msg/es_ES.utf8/cubrid.msg
+++ b/msg/es_ES.utf8/cubrid.msg
@@ -1446,8 +1446,9 @@ Verifique la ruta del archivo de claves (_keys) y asegúrese de que incluya la c
 1359 Java VM crashed: %1$s
 1360 In line %1$d, column %2$d\nStored procedure compile error: %3$s
 1361 Dropping system generated stored procedure is not allowed.
+1362 PL/CSQL Stored procedure/function does not support Invoker's rights
 
-1362 Ultimo error
+1363 Ultimo error
 
 $set 6 MSGCAT_SET_INTERNAL
 1 Error en subsistema de error (linea %1$d):
@@ -1935,7 +1936,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 317 Identifiers cannot be in a LIMIT clause.
 318 Stored procedure/function "$1$s" does not exist.
 
-$set 9 MSGCAT_SET_PARSER_RUNTIME
+\$set 9 MSGCAT_SET_PARSER_RUNTIME
 1 Sin memoria virtual: incapaz de asignar %1$d bytes.
 2 Nivel de aislacion de transaccion debe ser 1, 2, 3, 4, 5 o 6.
 3 Valor del tiempo de expiracion debe ser -1, 0, o >0.

--- a/msg/es_ES.utf8/cubrid.msg
+++ b/msg/es_ES.utf8/cubrid.msg
@@ -1936,7 +1936,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 317 Identifiers cannot be in a LIMIT clause.
 318 Stored procedure/function "$1$s" does not exist.
 
-\$set 9 MSGCAT_SET_PARSER_RUNTIME
+$set 9 MSGCAT_SET_PARSER_RUNTIME
 1 Sin memoria virtual: incapaz de asignar %1$d bytes.
 2 Nivel de aislacion de transaccion debe ser 1, 2, 3, 4, 5 o 6.
 3 Valor del tiempo de expiracion debe ser -1, 0, o >0.

--- a/msg/fr_FR.utf8/cubrid.msg
+++ b/msg/fr_FR.utf8/cubrid.msg
@@ -1936,7 +1936,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 317 Identifiers cannot be in a LIMIT clause.
 318 Stored procedure/function "$1$s" does not exist.
 
-\$set 9 MSGCAT_SET_PARSER_RUNTIME
+$set 9 MSGCAT_SET_PARSER_RUNTIME
 1 Mémoire virtuelle épuisée: impossible d'allouer %1$d octets.
 2 Niveau d'isolement de la transaction doit être de 1, 2, 3, 4, 5 ou 6.
 3 Valeur du délai d'expiration doit être -1, 0 ou >0.

--- a/msg/fr_FR.utf8/cubrid.msg
+++ b/msg/fr_FR.utf8/cubrid.msg
@@ -1446,8 +1446,9 @@ Vérifiez le chemin du fichier de clé (_keys) et assurez-vous qu'il inclut la c
 1359 Java VM crashed: %1$s
 1360 In line %1$d, column %2$d\nStored procedure compile error: %3$s
 1361 Dropping system generated stored procedure is not allowed.
+1362 PL/CSQL Stored procedure/function does not support Invoker's rights
 
-1362 Dernière erreur
+1363 Dernière erreur
 
 $set 6 MSGCAT_SET_INTERNAL
 1 Erreur dans le sous-système d'erreur (ligne %1$d):
@@ -1935,7 +1936,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 317 Identifiers cannot be in a LIMIT clause.
 318 Stored procedure/function "$1$s" does not exist.
 
-$set 9 MSGCAT_SET_PARSER_RUNTIME
+\$set 9 MSGCAT_SET_PARSER_RUNTIME
 1 Mémoire virtuelle épuisée: impossible d'allouer %1$d octets.
 2 Niveau d'isolement de la transaction doit être de 1, 2, 3, 4, 5 ou 6.
 3 Valeur du délai d'expiration doit être -1, 0 ou >0.

--- a/msg/it_IT.utf8/cubrid.msg
+++ b/msg/it_IT.utf8/cubrid.msg
@@ -1936,7 +1936,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 317 Identifiers cannot be in a LIMIT clause.
 318 Stored procedure/function "$1$s" does not exist.
 
-\$set 9 MSGCAT_SET_PARSER_RUNTIME
+$set 9 MSGCAT_SET_PARSER_RUNTIME
 1 Fuori di memoria virtuale: Impossibile allocare %1$d byte.
 2 Livello di isolamento di transazione deve essere 1, 2, 3, 4, 5 o 6.
 3 Il valore di timeout deve essere -1, 0 o >0.

--- a/msg/it_IT.utf8/cubrid.msg
+++ b/msg/it_IT.utf8/cubrid.msg
@@ -1446,8 +1446,9 @@ Controllare il percorso del file della chiave (_keys) e assicurarsi che includa 
 1359 Java VM crashed: %1$s
 1360 In line %1$d, column %2$d\nStored procedure compile error: %3$s
 1361 Dropping system generated stored procedure is not allowed.
+1362 PL/CSQL Stored procedure/function does not support Invoker's rights
 
-1362 Ultimo errore
+1363 Ultimo errore
 
 $set 6 MSGCAT_SET_INTERNAL
 1 Errore nel sottosistema di errore (linea %1$d):
@@ -1935,7 +1936,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 317 Identifiers cannot be in a LIMIT clause.
 318 Stored procedure/function "$1$s" does not exist.
 
-$set 9 MSGCAT_SET_PARSER_RUNTIME
+\$set 9 MSGCAT_SET_PARSER_RUNTIME
 1 Fuori di memoria virtuale: Impossibile allocare %1$d byte.
 2 Livello di isolamento di transazione deve essere 1, 2, 3, 4, 5 o 6.
 3 Il valore di timeout deve essere -1, 0 o >0.

--- a/msg/ja_JP.utf8/cubrid.msg
+++ b/msg/ja_JP.utf8/cubrid.msg
@@ -1936,7 +1936,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 317 Identifiers cannot be in a LIMIT clause.
 318 Stored procedure/function "$1$s" does not exist.
 
-\$set 9 MSGCAT_SET_PARSER_RUNTIME
+$set 9 MSGCAT_SET_PARSER_RUNTIME
 1 バチャールメモリーが足りません。: %1$dバイトがアロケーションできません。
 2 トランザクションアイソレーションレベルは1、2、3、4、5、6の中で指定されます。
 3 タイムアウトバリューは-1、0、または0より大きいバリューの中で指定されます。

--- a/msg/ja_JP.utf8/cubrid.msg
+++ b/msg/ja_JP.utf8/cubrid.msg
@@ -1446,8 +1446,9 @@ $ LOADDB
 1359 Java VM crashed: %1$s
 1360 In line %1$d, column %2$d\nStored procedure compile error: %3$s
 1361 Dropping system generated stored procedure is not allowed.
+1362 PL/CSQL Stored procedure/function does not support Invoker's rights
 
-1362 ラストエラー
+1363 ラストエラー
 
 $set 6 MSGCAT_SET_INTERNAL
 1 エラーサブシステムにエラー発生(ライン %1$d):
@@ -1935,7 +1936,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 317 Identifiers cannot be in a LIMIT clause.
 318 Stored procedure/function "$1$s" does not exist.
 
-$set 9 MSGCAT_SET_PARSER_RUNTIME
+\$set 9 MSGCAT_SET_PARSER_RUNTIME
 1 バチャールメモリーが足りません。: %1$dバイトがアロケーションできません。
 2 トランザクションアイソレーションレベルは1、2、3、4、5、6の中で指定されます。
 3 タイムアウトバリューは-1、0、または0より大きいバリューの中で指定されます。

--- a/msg/km_KH.utf8/cubrid.msg
+++ b/msg/km_KH.utf8/cubrid.msg
@@ -1446,8 +1446,9 @@ Check the path of the key file (_keys) and make sure that it includes proper key
 1359 Java VM crashed: %1$s
 1360 In line %1$d, column %2$d\nStored procedure compile error: %3$s
 1361 Dropping system generated stored procedure is not allowed.
+1362 PL/CSQL Stored procedure/function does not support Invoker's rights
 
-1362 Last Error
+1363 Last Error
 
 $set 6 MSGCAT_SET_INTERNAL
 1 Error in error subsystem (line %1$d):
@@ -1935,7 +1936,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 317 Identifiers cannot be in a LIMIT clause.
 318 Stored procedure/function "$1$s" does not exist.
 
-$set 9 MSGCAT_SET_PARSER_RUNTIME
+\$set 9 MSGCAT_SET_PARSER_RUNTIME
 1 Out of virtual memory: unable to allocate %1$d bytes.
 2 Transaction isolation level must be 4, 5 or 6.
 3 Timeout value must be -1, 0, or >0.

--- a/msg/km_KH.utf8/cubrid.msg
+++ b/msg/km_KH.utf8/cubrid.msg
@@ -1936,7 +1936,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 317 Identifiers cannot be in a LIMIT clause.
 318 Stored procedure/function "$1$s" does not exist.
 
-\$set 9 MSGCAT_SET_PARSER_RUNTIME
+$set 9 MSGCAT_SET_PARSER_RUNTIME
 1 Out of virtual memory: unable to allocate %1$d bytes.
 2 Transaction isolation level must be 4, 5 or 6.
 3 Timeout value must be -1, 0, or >0.

--- a/msg/ko_KR.euckr/cubrid.msg
+++ b/msg/ko_KR.euckr/cubrid.msg
@@ -1446,8 +1446,9 @@ $ LOADDB
 1359 Java VM 에 장애가 발생함. : %1$s
 1360 In line %1$d, column %2$d\nStored procedure compile error: %3$s
 1361 시스템 생성 stored procedure를 삭제(drop)할 수 없습니다.
+1362 PL/CSQL 저장 프로시저/함수는 호출자 권한을 지원하지 않습니다
 
-1362 마지막 에러
+1363 마지막 에러
 
 $set 6 MSGCAT_SET_INTERNAL
 1 에러 서브 시스템에 에러 발생(라인 %1$d):

--- a/msg/ko_KR.utf8/cubrid.msg
+++ b/msg/ko_KR.utf8/cubrid.msg
@@ -1936,7 +1936,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 317 식별자는 LIMIT 절 안에 있을 수 없습니다.
 318 저장 프로시저/함수 "$1$s"이(가) 존재하지 않습니다.
 
-\$set 9 MSGCAT_SET_PARSER_RUNTIME
+$set 9 MSGCAT_SET_PARSER_RUNTIME
 1 가상 메모리 없음: %1$d 바이트를 할당할 수 없습니다.
 2 트랜잭션 isolation 레벨은 1, 2, 3, 4, 5, 6 중에서 지정되어야 합니다.
 3 타임아웃 값은 -1, 0 또는 >0 이어야 합니다.

--- a/msg/ko_KR.utf8/cubrid.msg
+++ b/msg/ko_KR.utf8/cubrid.msg
@@ -1446,8 +1446,9 @@ $ LOADDB
 1359 Java VM 에 장애가 발생함. : %1$s
 1360 In line %1$d, column %2$d\nStored procedure compile error: %3$s
 1361 시스템 생성 stored procedure를 삭제(drop)할 수 없습니다.
+1362 PL/CSQL 저장 프로시저/함수는 호출자 권한을 지원하지 않습니다
 
-1362 마지막 에러
+1363 마지막 에러
 
 $set 6 MSGCAT_SET_INTERNAL
 1 에러 서브 시스템에 에러 발생(라인 %1$d):
@@ -1935,7 +1936,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 317 식별자는 LIMIT 절 안에 있을 수 없습니다.
 318 저장 프로시저/함수 "$1$s"이(가) 존재하지 않습니다.
 
-$set 9 MSGCAT_SET_PARSER_RUNTIME
+\$set 9 MSGCAT_SET_PARSER_RUNTIME
 1 가상 메모리 없음: %1$d 바이트를 할당할 수 없습니다.
 2 트랜잭션 isolation 레벨은 1, 2, 3, 4, 5, 6 중에서 지정되어야 합니다.
 3 타임아웃 값은 -1, 0 또는 >0 이어야 합니다.

--- a/msg/ro_RO.utf8/cubrid.msg
+++ b/msg/ro_RO.utf8/cubrid.msg
@@ -1446,8 +1446,9 @@ Verificați calea fișierului cheie (_keys) și asigurați-vă că acesta includ
 1359 Java VM crashed: %1$s
 1360 In line %1$d, column %2$d\nStored procedure compile error: %3$s
 1361 Dropping system generated stored procedure is not allowed.
+1362 PL/CSQL Stored procedure/function does not support Invoker's rights
 
-1362 Ultima eroare
+1363 Ultima eroare
 
 $set 6 MSGCAT_SET_INTERNAL
 1 Eroare în subsistemul de erori (linia %1$d):
@@ -1935,7 +1936,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 317 Identifiers cannot be in a LIMIT clause.
 318 Stored procedure/function "$1$s" does not exist.
 
-$set 9 MSGCAT_SET_PARSER_RUNTIME
+\$set 9 MSGCAT_SET_PARSER_RUNTIME
 1 Memorie virtuală epuizată: nu s-au putut aloca %1$d bytes.
 2 Nivelul de izolare al tranzacţiilor trebuie să fie 1, 2, 3, 4, 5 or 6.
 3 Valoarea pentru durata de expirare trebuie să fie -1, 0, or >0.

--- a/msg/ro_RO.utf8/cubrid.msg
+++ b/msg/ro_RO.utf8/cubrid.msg
@@ -1936,7 +1936,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 317 Identifiers cannot be in a LIMIT clause.
 318 Stored procedure/function "$1$s" does not exist.
 
-\$set 9 MSGCAT_SET_PARSER_RUNTIME
+$set 9 MSGCAT_SET_PARSER_RUNTIME
 1 Memorie virtuală epuizată: nu s-au putut aloca %1$d bytes.
 2 Nivelul de izolare al tranzacţiilor trebuie să fie 1, 2, 3, 4, 5 or 6.
 3 Valoarea pentru durata de expirare trebuie să fie -1, 0, or >0.

--- a/msg/tr_TR.utf8/cubrid.msg
+++ b/msg/tr_TR.utf8/cubrid.msg
@@ -1936,7 +1936,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 317 Identifiers cannot be in a LIMIT clause.
 318 Stored procedure/function "$1$s" does not exist.
 
-\$set 9 MSGCAT_SET_PARSER_RUNTIME
+$set 9 MSGCAT_SET_PARSER_RUNTIME
 1 Sanal bellek yetersiz: %1$d bayt bölüm ayıramadı.
 2 İşlemin yalıtım düzeyi 1, 2, 3, 4, 5 veya 6 olması gerekir.
 3 Zaman aşımı değeri -1, 0, veya >0 olması gerekir .

--- a/msg/tr_TR.utf8/cubrid.msg
+++ b/msg/tr_TR.utf8/cubrid.msg
@@ -1446,8 +1446,9 @@ Anahtar dosyasının (_keys) yolunu kontrol edin ve uygun anahtarı içerdiğind
 1359 Java VM crashed: %1$s
 1360 In line %1$d, column %2$d\nStored procedure compile error: %3$s
 1361 Dropping system generated stored procedure is not allowed.
+1362 PL/CSQL Stored procedure/function does not support Invoker's rights
 
-1362 Son Hata
+1363 Son Hata
 
 $set 6 MSGCAT_SET_INTERNAL
 1 Alt Hata içinde hata (satır %1$d):
@@ -1935,7 +1936,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 317 Identifiers cannot be in a LIMIT clause.
 318 Stored procedure/function "$1$s" does not exist.
 
-$set 9 MSGCAT_SET_PARSER_RUNTIME
+\$set 9 MSGCAT_SET_PARSER_RUNTIME
 1 Sanal bellek yetersiz: %1$d bayt bölüm ayıramadı.
 2 İşlemin yalıtım düzeyi 1, 2, 3, 4, 5 veya 6 olması gerekir.
 3 Zaman aşımı değeri -1, 0, veya >0 olması gerekir .

--- a/msg/vi_VN.utf8/cubrid.msg
+++ b/msg/vi_VN.utf8/cubrid.msg
@@ -1943,7 +1943,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 317 Identifiers cannot be in a LIMIT clause.
 318 Stored procedure/function "$1$s" does not exist.
 
-\$set 9 MSGCAT_SET_PARSER_RUNTIME
+$set 9 MSGCAT_SET_PARSER_RUNTIME
 1 Out of virtual memory: unable to allocate %1$d bytes.
 2 Transaction isolation level must be 4, 5 or 6.
 3 Timeout value must be -1, 0, or >0.

--- a/msg/vi_VN.utf8/cubrid.msg
+++ b/msg/vi_VN.utf8/cubrid.msg
@@ -1453,8 +1453,9 @@ Check the path of the key file (_keys) and make sure that it includes proper key
 1359 Java VM crashed: %1$s
 1360 In line %1$d, column %2$d\nStored procedure compile error: %3$s
 1361 Dropping system generated stored procedure is not allowed.
+1362 PL/CSQL Stored procedure/function does not support Invoker's rights
 
-1362 Last Error
+1363 Last Error
 
 $set 6 MSGCAT_SET_INTERNAL
 1 Error in error subsystem (line %1$d):
@@ -1942,7 +1943,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 317 Identifiers cannot be in a LIMIT clause.
 318 Stored procedure/function "$1$s" does not exist.
 
-$set 9 MSGCAT_SET_PARSER_RUNTIME
+\$set 9 MSGCAT_SET_PARSER_RUNTIME
 1 Out of virtual memory: unable to allocate %1$d bytes.
 2 Transaction isolation level must be 4, 5 or 6.
 3 Timeout value must be -1, 0, or >0.

--- a/msg/zh_CN.utf8/cubrid.msg
+++ b/msg/zh_CN.utf8/cubrid.msg
@@ -1937,7 +1937,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 317 Identifiers cannot be in a LIMIT clause.
 318 Stored procedure/function "$1$s" does not exist.
 
-\$set 9 MSGCAT_SET_PARSER_RUNTIME
+$set 9 MSGCAT_SET_PARSER_RUNTIME
 1 虚拟内存耗尽: 无法申请 %1$d 字节.
 2 事务的隔离等级必须为 1, 2, 3, 4, 5 或 6.
 3 超时值必须为 -1, 0, 或 >0.

--- a/msg/zh_CN.utf8/cubrid.msg
+++ b/msg/zh_CN.utf8/cubrid.msg
@@ -1447,8 +1447,9 @@ $ LOADDB
 1359 Java VM crashed: %1$s
 1360 In line %1$d, column %2$d\nStored procedure compile error: %3$s
 1361 Dropping system generated stored procedure is not allowed.
+1362 PL/CSQL Stored procedure/function does not support Invoker's rights
 
-1362 最后一个错误.
+1363 最后一个错误.
 
 $set 6 MSGCAT_SET_INTERNAL
 1 在错误子系统中错误 (line %1$d):
@@ -1936,7 +1937,7 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 317 Identifiers cannot be in a LIMIT clause.
 318 Stored procedure/function "$1$s" does not exist.
 
-$set 9 MSGCAT_SET_PARSER_RUNTIME
+\$set 9 MSGCAT_SET_PARSER_RUNTIME
 1 虚拟内存耗尽: 无法申请 %1$d 字节.
 2 事务的隔离等级必须为 1, 2, 3, 4, 5 或 6.
 3 超时值必须为 -1, 0, 或 >0.

--- a/src/base/error_code.h
+++ b/src/base/error_code.h
@@ -1739,8 +1739,9 @@
 #define ER_SP_SERVER_CRASHED                        -1359
 #define ER_SP_COMPILE_ERROR                         -1360
 #define ER_SP_DROP_NOT_ALLOWED_SYSTEM_GENERATED     -1361
+#define ER_SP_INVOKERS_RIGHTS_NOT_SUPPORTED         -1362
 
-#define ER_LAST_ERROR                               -1362
+#define ER_LAST_ERROR                               -1363
 
 /*
  * CAUTION!

--- a/src/jsp/jsp_cl.h
+++ b/src/jsp/jsp_cl.h
@@ -89,7 +89,7 @@ extern int jsp_check_param_type_supported (PT_NODE * node);
 extern int jsp_check_return_type_supported (DB_TYPE type);
 
 extern int jsp_is_exist_stored_procedure (const char *name);
-extern char *jsp_get_owner_name (const char *name);
+extern const char *jsp_get_owner_name (const char *name);
 extern int jsp_get_return_type (const char *name);
 extern int jsp_get_sp_type (const char *name);
 extern MOP jsp_find_stored_procedure (const char *name);

--- a/src/jsp/sp_catalog.cpp
+++ b/src/jsp/sp_catalog.cpp
@@ -60,7 +60,7 @@ static int sp_builtin_init ()
   v.lang = SP_LANG_PLCSQL;
   v.owner = Au_public_user;
   v.comment = "";
-  v.directive = 0;
+  v.directive = SP_DIRECTIVE_RIGHTS_OWNER;
 
   a.is_system_generated = true;
 

--- a/src/jsp/sp_catalog.hpp
+++ b/src/jsp/sp_catalog.hpp
@@ -45,8 +45,30 @@ struct sp_arg_info
   DB_TYPE data_type;
   SP_MODE_ENUM mode;
   std::string comment;
+
+  sp_arg_info (const std::string& s_name, const std::string& p_name) 
+  : sp_name {s_name}
+  , pkg_name {p_name}
+  , index_of {SP_TYPE_ENUM::SP_TYPE_PROCEDURE}
+  , is_system_generated {false}
+  , arg_name {}
+  , data_type {DB_TYPE::DB_TYPE_NULL}
+  , mode {SP_MODE_ENUM::SP_MODE_IN}
+  , comment {}
+  {}
+
+  sp_arg_info ()
+  : sp_arg_info ("", "")
+  {}
 };
 typedef sp_arg_info SP_ARG_INFO;
+
+enum sp_directive : int
+{
+  SP_DIRECTIVE_RIGHTS_OWNER = 0x00,
+  SP_DIRECTIVE_RIGHTS_CALLER = (0x01 << 0),
+};
+typedef sp_directive SP_DIRECTIVE_ENUM;
 
 struct sp_info
 {
@@ -58,9 +80,23 @@ struct sp_info
   std::vector <sp_arg_info> args;
   SP_LANG_ENUM lang;
   std::string target;
-  int directive;
+  SP_DIRECTIVE_ENUM directive;
   MOP owner;
   std::string comment;
+
+  sp_info () 
+  : sp_name {}
+  , pkg_name {}
+  , sp_type {SP_TYPE_ENUM::SP_TYPE_PROCEDURE}
+  , return_type {DB_TYPE::DB_TYPE_NULL}
+  , is_system_generated {false}
+  , args {}
+  , lang {SP_LANG_ENUM::SP_LANG_PLCSQL}
+  , target {}
+  , directive {SP_DIRECTIVE_ENUM::SP_DIRECTIVE_RIGHTS_OWNER}
+  , owner {nullptr}
+  , comment {}
+  {}
 };
 typedef sp_info SP_INFO;
 // *INDENT-ON*


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24731

This PR combines the implementation of CBRD-24871, CBRD-25072, and CBRD-25075 into a single feature, and in this process. Also it restricted the creating PL/CSQL as Invoker's rights.

- By the AUTHID property, the value of _db_stored_procedure's directive column is set
- According to the directive value, a stored routine performs as definer's or invoker's rights respectivly.
- A new error message is added when a user try to create PL/CSQL routine with invoker's rights