### PR TITLE
[CBRD-25098] Problem where inst_num() is inappropriately changed to order_by_num() when a subquery containing an ORDER BY is view merged.

### DIFF
--- a/src/optimizer/query_rewrite.c
+++ b/src/optimizer/query_rewrite.c
@@ -1891,14 +1891,14 @@ qo_reduce_order_by_for (PARSER_CONTEXT * parser, PT_NODE * node)
       /* replace orderby_num() to groupby_num() */
       node->info.query.orderby_for = pt_lambda_with_arg (parser, node->info.query.orderby_for, ord_num, grp_num,
 							 false /* loc_check: DEFAULT */ ,
-							 0 /* type: DEFAULT */ ,
+							 2 /* type: don't walk into subquery */ ,
 							 false /* dont_replace: DEFAULT */ );
 
       /* Even though node->info.q.query.q.select has no orderby_num so far, it is a safe guard to prevent potential
        * rewrite problem. */
       node->info.query.q.select.list = pt_lambda_with_arg (parser, node->info.query.q.select.list, ord_num, grp_num,
 							   false /* loc_check: DEFAULT */ ,
-							   0 /* type: DEFAULT */ ,
+							   2 /* type: don't walk into subquery */ ,
 							   false /* dont_replace: DEFAULT */ );
 
       node->info.query.q.select.having =
@@ -2180,13 +2180,13 @@ qo_reduce_order_by (PARSER_CONTEXT * parser, PT_NODE * node)
 		  node->info.query.orderby_for =
 		    pt_lambda_with_arg (parser, node->info.query.orderby_for, ord_num, ins_num,
 					false /* loc_check: DEFAULT */ ,
-					0 /* type: DEFAULT */ ,
+					2 /* type: don't walk into subquery */ ,
 					false /* dont_replace: DEFAULT */ );
 
 		  node->info.query.q.select.list =
 		    pt_lambda_with_arg (parser, node->info.query.q.select.list, ord_num, ins_num,
 					false /* loc_check: DEFAULT */ ,
-					0 /* type: DEFAULT */ ,
+					2 /* type: don't walk into subquery */ ,
 					false /* dont_replace: DEFAULT */ );
 
 		  node->info.query.q.select.where =
@@ -2228,7 +2228,7 @@ qo_reduce_order_by (PARSER_CONTEXT * parser, PT_NODE * node)
 		  /* replace orderby_num() to groupby_num() */
 		  node->info.query.q.select.list = pt_lambda_with_arg (parser, node->info.query.q.select.list, ord_num,
 								       grp_num, false /* loc_check: DEFAULT */ ,
-								       0 /* type: DEFAULT */ ,
+								       2 /* type: don't walk into subquery */ ,
 								       false /* dont_replace: DEFAULT */ );
 
 		  parser_free_tree (parser, ord_num);

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -138,6 +138,8 @@ static void strcat_with_realloc (PT_STRING_BLOCK * sb, const char *tail);
 static PT_NODE *pt_lambda_check_reduce_eq (PARSER_CONTEXT * parser, PT_NODE * tree_or_name, void *void_arg,
 					   int *continue_walk);
 static PT_NODE *pt_lambda_node (PARSER_CONTEXT * parser, PT_NODE * tree_or_name, void *void_arg, int *continue_walk);
+static PT_NODE *pt_lambda_node_pre (PARSER_CONTEXT * parser, PT_NODE * tree_or_name, void *void_arg,
+				    int *continue_walk);
 static PT_NODE *pt_find_id_node (PARSER_CONTEXT * parser, PT_NODE * tree, void *void_arg, int *continue_walk);
 static PT_NODE *copy_node_in_tree_pre (PARSER_CONTEXT * parser, PT_NODE * old_node, void *arg, int *continue_walk);
 static PT_NODE *copy_node_in_tree_post (PARSER_CONTEXT * parser, PT_NODE * new_node, void *arg, int *continue_walk);
@@ -565,6 +567,34 @@ pt_lambda_check_reduce_eq (PARSER_CONTEXT * parser, PT_NODE * tree_or_name, void
       break;
     default:
       break;
+    }
+
+  return tree_or_name;
+}
+
+/*
+ * pt_lambda_node_pre () - check query node type
+ *   return:
+ *   parser(in):
+ *   tree_or_name(in/out):
+ *   void_arg(in/out):
+ *   continue_walk(in/out):
+ */
+static PT_NODE *
+pt_lambda_node_pre (PARSER_CONTEXT * parser, PT_NODE * tree_or_name, void *void_arg, int *continue_walk)
+{
+  if (!tree_or_name)
+    {
+      return tree_or_name;
+    }
+
+  if (PT_IS_QUERY_NODE_TYPE (tree_or_name->node_type))
+    {
+      *continue_walk = PT_LIST_WALK;
+    }
+  else
+    {
+      *continue_walk = PT_CONTINUE_WALK;
     }
 
   return tree_or_name;
@@ -1044,6 +1074,7 @@ pt_continue_walk (PARSER_CONTEXT * parser, PT_NODE * tree, void *arg, int *conti
 /*
  * pt_lambda_with_arg () - walks a tree and modifies it in place to replace
  * 	                   name nodes with copies of a corresponding tree
+ *			   type 1 : for reduce_eq_term, type 2 : don't walk into subquery
  *   return:
  *   parser(in):
  *   tree_with_names(in):
@@ -1115,8 +1146,9 @@ pt_lambda_with_arg (PARSER_CONTEXT * parser, PT_NODE * tree_with_names, PT_NODE 
     }
 
   tree =
-    parser_walk_tree (parser, tree_with_names, ((type) ? pt_lambda_check_reduce_eq : NULL), &lambda_arg, pt_lambda_node,
-		      &lambda_arg);
+    parser_walk_tree (parser, tree_with_names,
+		      ((type == 1) ? pt_lambda_check_reduce_eq : (type == 2) ? pt_lambda_node_pre : NULL), &lambda_arg,
+		      pt_lambda_node, &lambda_arg);
 
   if (corresponding_tree && corresponding_tree->node_type == PT_EXPR)
     {

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -2174,7 +2174,7 @@ mq_update_order_by (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * quer
 
   /* replace rownum of select-list to orderby_num */
   statement->info.query.q.select.list =
-    pt_lambda_with_arg (parser, statement->info.query.q.select.list, ins_num, ord_num, false, 0, false);
+    pt_lambda_with_arg (parser, statement->info.query.q.select.list, ins_num, ord_num, false, 2, false);
 
   if (free_node != NULL)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25098

fix the case below so that it does not walk into the subquery. This prevents unnecessary exchanges.

inst_num() -> order_by_num()
order_by_num() -> inst_num()
order_by_num() -> group_by_num()

