### PR TITLE
[CBRD-25064] change to return success when performing execute standalone's loaddb  with zero-sized object files.

### DIFF
--- a/src/loaddb/load_driver.cpp
+++ b/src/loaddb/load_driver.cpp
@@ -82,13 +82,6 @@ namespace cubload
   int
   driver::parse (std::istream &iss, int line_offset)
   {
-    // If the file size is 0, no load is performed.
-    iss.seekg (0, std::ios::end);
-    if (iss.tellg() <= 0)
-      {
-	return 0;
-      }
-
     m_scanner->switch_streams (&iss);
     m_scanner->set_lineno (line_offset + 1);
     m_semantic_helper.reset_after_batch ();

--- a/src/loaddb/load_driver.cpp
+++ b/src/loaddb/load_driver.cpp
@@ -83,10 +83,10 @@ namespace cubload
   driver::parse (std::istream &iss, int line_offset)
   {
     // If the file size is 0, no load is performed.
-    iss.seekg(0, std::ios::end);
+    iss.seekg (0, std::ios::end);
     if (iss.tellg() <= 0)
       {
-         return 0; 
+	return 0;
       }
 
     m_scanner->switch_streams (&iss);

--- a/src/loaddb/load_driver.cpp
+++ b/src/loaddb/load_driver.cpp
@@ -82,6 +82,13 @@ namespace cubload
   int
   driver::parse (std::istream &iss, int line_offset)
   {
+    // If the file size is 0, no load is performed.
+    iss.seekg(0, std::ios::end);
+    if (iss.tellg() <= 0)
+      {
+         return 0; 
+      }
+
     m_scanner->switch_streams (&iss);
     m_scanner->set_lineno (line_offset + 1);
     m_semantic_helper.reset_after_batch ();

--- a/src/loaddb/load_sa_loader.cpp
+++ b/src/loaddb/load_sa_loader.cpp
@@ -6359,6 +6359,7 @@ ldr_sa_load (load_args *args, int *status, bool *interrupted)
   int defaults = 0;
   int fails = 0;
   int64_t lastcommit = 0;
+  bool is_emptyfile = false;
   int ldr_init_ret = NO_ERROR;
 
   std::ifstream object_file (args->object_file);
@@ -6386,6 +6387,14 @@ ldr_sa_load (load_args *args, int *status, bool *interrupted)
       ldr_register_post_commit_handler ();
     }
 
+  /* get the size of object file */
+  object_file.seekg (0, std::ios::end);
+  if (object_file.tellg() <= 0)
+    {
+      is_emptyfile = true;
+    }
+  object_file.seekg (0, std::ios::beg);
+
   /* Check if we need to perform syntax checking. */
   if (!args->load_only)
     {
@@ -6395,7 +6404,10 @@ ldr_sa_load (load_args *args, int *status, bool *interrupted)
 	{
 	  ldr_init_ret = ldr_Driver->get_class_installer ().install_class (args->table_name.c_str ());
 	}
-      ldr_Driver->parse (object_file);
+      if (!is_emptyfile)
+	{
+	  ldr_Driver->parse (object_file);
+	}
       ldr_stats (&errors, &objects, &defaults, &lastcommit, &fails);
     }
   else
@@ -6452,7 +6464,10 @@ ldr_sa_load (load_args *args, int *status, bool *interrupted)
 		  ldr_Driver->get_class_installer ().install_class (args->table_name.c_str ());
 		}
 
-	      ldr_Driver->parse (object_file);
+	      if (!is_emptyfile)
+		{
+		  ldr_Driver->parse (object_file);
+		}
 	      ldr_stats (&errors, &objects, &defaults, &lastcommit, &fails);
 
 	      if (errors)

--- a/src/loaddb/load_sa_loader.cpp
+++ b/src/loaddb/load_sa_loader.cpp
@@ -6476,12 +6476,9 @@ ldr_sa_load (load_args *args, int *status, bool *interrupted)
 		}
 	      else
 		{
-		  if (objects || fails)
-		    {
-		      print_log_msg (1,
-				     msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_LOADDB,
-						     LOADDB_MSG_INSERT_AND_FAIL_COUNT), objects, fails);
-		    }
+		  print_log_msg (1,
+			         msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_LOADDB,
+						 LOADDB_MSG_INSERT_AND_FAIL_COUNT), objects, fails);
 
 		  if (defaults)
 		    {

--- a/src/loaddb/load_sa_loader.cpp
+++ b/src/loaddb/load_sa_loader.cpp
@@ -6477,7 +6477,7 @@ ldr_sa_load (load_args *args, int *status, bool *interrupted)
 	      else
 		{
 		  print_log_msg (1,
-			         msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_LOADDB,
+				 msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_LOADDB,
 						 LOADDB_MSG_INSERT_AND_FAIL_COUNT), objects, fails);
 
 		  if (defaults)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25064

The loaddb utility behaves differently on zero-sized object files between standalone mode and client-server mode. 
So, when loaddb of standalone exeute with zero-sized object files, it is changed to return success, the same as the client-server mode.
