### PR TITLE
[CBRD-25208] Slip CUBRID_TMP should be retrieved by using getenv() (#5003)

### DIFF
--- a/src/jsp/com/cubrid/jsp/Server.java
+++ b/src/jsp/com/cubrid/jsp/Server.java
@@ -75,7 +75,7 @@ public class Server {
         ServerSocket serverSocket = null;
         int port_number = Integer.parseInt(port);
         try {
-            tmpPath = System.getProperty("CUBRID_TMP");
+            tmpPath = System.getenv("CUBRID_TMP");
             if (tmpPath == null) {
                 tmpPath = rootPath + File.separator + "tmp";
             }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25208

backport of #5003 
