### PR TITLE
[CBRD-25243] case-insensitive hostname for CUBRID userhosts

### DIFF
--- a/src/connection/host_lookup.c
+++ b/src/connection/host_lookup.c
@@ -104,6 +104,7 @@ static bool is_valid_ip (char *ip_addr);
 static bool is_valid_hostname (char *hostname, int str_len);
 static int load_hosts_file ();
 static struct hostent *host_lookup_internal (const char *hostname, struct sockaddr *saddr, LOOKUP_TYPE lookup_type);
+static void strcpy_ucase (char *dst, const char *src);
 
 /*
  * hostent_alloc () - Allocate memory hostent structure.
@@ -176,6 +177,7 @@ host_lookup_internal (const char *hostname, struct sockaddr *saddr, LOOKUP_TYPE 
 
   char addr_trans_ch_buf[IPADDR_LEN];
   struct sockaddr_in *addr_trans = NULL;
+  char hostname_u[HOSTNAME_LEN];
 
   if (hosts_conf_file_Load == LOAD_INIT)
     {
@@ -205,11 +207,13 @@ host_lookup_internal (const char *hostname, struct sockaddr *saddr, LOOKUP_TYPE 
 
     }
 
+  strcpy_ucase (hostname_u, hostname);
+
   /* Look up in the user_host_Map */
   /* The case which is looking up the IP addr and checking the hostname or IP addr in the hash map */
-  if ((lookup_type == HOSTNAME_TO_IPADDR) && (user_host_Map.find (hostname) != user_host_Map.end ()))
+  if ((lookup_type == HOSTNAME_TO_IPADDR) && (user_host_Map.find (hostname_u) != user_host_Map.end ()))
     {
-      hp = hostent_Cache[user_host_Map.find (hostname)->second];
+      hp = hostent_Cache[user_host_Map.find (hostname_u)->second];
     }
   else if ((lookup_type == IPADDR_TO_HOSTNAME) && (user_host_Map.find (addr_trans_ch_buf) != user_host_Map.end ()))
     {
@@ -324,7 +328,7 @@ load_hosts_file ()
 		}
 	      else
 		{
-		  strcpy (hostname, token);
+		  strcpy_ucase (hostname, token);
 		}
 	    }
 	}
@@ -679,4 +683,26 @@ getaddrinfo_uhost (char *node, char *service, struct addrinfo *hints, struct add
 return_phase:
 
   return ret;
+}
+
+static void
+strcpy_ucase (char *dst, const char *src)
+{
+  int len, i;
+
+  if (dst == NULL || src == NULL)
+    {
+      return;
+    }
+
+  len = strlen (src) > (HOSTNAME_LEN - 1) ? (HOSTNAME_LEN - 1) : strlen (src);
+
+  for (i = 0; i < len; i++)
+    {
+      dst[i] = toupper (src[i]);
+    }
+
+  dst[i] = '\0';
+
+  return;
 }

--- a/src/executables/util_common.c
+++ b/src/executables/util_common.c
@@ -545,7 +545,7 @@ are_hostnames_equal (const char *hostname_a, const char *hostname_b)
   const char *a;
   const char *b;
 
-  for (a = hostname_a, b = hostname_b; *a && *b && (toupper (*a) == toupper (*b)); ++a, ++b)
+  for (a = hostname_a, b = hostname_b; *a && *b && (*a == *b); ++a, ++b)
     ;
 
   if (*a == '\0' && *b != '\0')
@@ -558,7 +558,7 @@ are_hostnames_equal (const char *hostname_a, const char *hostname_b)
     }
   else
     {
-      return toupper (*a) == toupper (*b);
+      return *a == *b;
     }
 }
 

--- a/src/executables/util_common.c
+++ b/src/executables/util_common.c
@@ -538,13 +538,14 @@ util_is_localhost (char *host)
  *
  * @return true if hostname_a is same as hostname_b
  */
+
 bool
 are_hostnames_equal (const char *hostname_a, const char *hostname_b)
 {
   const char *a;
   const char *b;
 
-  for (a = hostname_a, b = hostname_b; *a && *b && (*a == *b); ++a, ++b)
+  for (a = hostname_a, b = hostname_b; *a && *b && (toupper (*a) == toupper (*b)); ++a, ++b)
     ;
 
   if (*a == '\0' && *b != '\0')
@@ -557,7 +558,7 @@ are_hostnames_equal (const char *hostname_a, const char *hostname_b)
     }
   else
     {
-      return *a == *b;
+      return toupper (*a) == toupper (*b);
     }
 }
 

--- a/src/executables/util_common.c
+++ b/src/executables/util_common.c
@@ -538,7 +538,6 @@ util_is_localhost (char *host)
  *
  * @return true if hostname_a is same as hostname_b
  */
-
 bool
 are_hostnames_equal (const char *hostname_a, const char *hostname_b)
 {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25243

**Description**
* case-insensitive hostname service for CUBRID userhosts, like that of GNU
* '**Cent7**' and '**cent7**' will be recognized as same host names.

**Implementation**
* to simplify modifications
  * we will store **{host name converted to uppercase, ipAddress}** in unordered_map
  * hostname will be converted to uppercase, and the search will proceed in unordered_Map.

**Remarks**
* We also neeed to make the function **are_hostnames_equal** () to case-insensitive
* check HA startup for the following configuration (with GNU host lookup, **use_user_hosts=no** in cubrid.conf)
  * hostname: '**dev1**' in lowercase, /etc/hosts entry, uppercase '**DEV1**'
```
   $ cat /etc/hosts
   192.168.2.34 DEV1
   192.168.2.38 DEV2
   $ hostname
    dev1

```
* this issue will be handled in [[CBRD-25245](http://jira.cubrid.org/browse/CBRD-25245)] first, and then will progress this issue