### PR TITLE
[CBRD-25245] 11.2, case insensitive are_hostnames_equal ()

### DIFF
--- a/src/executables/util_common.c
+++ b/src/executables/util_common.c
@@ -631,7 +631,7 @@ are_hostnames_equal (const char *hostname_a, const char *hostname_b)
   const char *a;
   const char *b;
 
-  for (a = hostname_a, b = hostname_b; *a && *b && (*a == *b); ++a, ++b)
+  for (a = hostname_a, b = hostname_b; *a && *b && (toupper (*a) == toupper(*b)); ++a, ++b)
     ;
 
   if (*a == '\0' && *b != '\0')
@@ -644,7 +644,7 @@ are_hostnames_equal (const char *hostname_a, const char *hostname_b)
     }
   else
     {
-      return *a == *b;
+      return toupper (*a) == toupper (*b);
     }
 }
 

--- a/src/executables/util_common.c
+++ b/src/executables/util_common.c
@@ -631,7 +631,7 @@ are_hostnames_equal (const char *hostname_a, const char *hostname_b)
   const char *a;
   const char *b;
 
-  for (a = hostname_a, b = hostname_b; *a && *b && (toupper (*a) == toupper(*b)); ++a, ++b)
+  for (a = hostname_a, b = hostname_b; *a && *b && (toupper (*a) == toupper (*b)); ++a, ++b)
     ;
 
   if (*a == '\0' && *b != '\0')


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25245

**Description**
* this is backport of #5009 to release/11.2
