### PR TITLE
[CBRD-25248] Server crash for Java SPs running a SELECT statement with 'WHERE 0 <> 0' clause

### DIFF
--- a/src/method/method_invoke_group.cpp
+++ b/src/method/method_invoke_group.cpp
@@ -343,6 +343,12 @@ namespace cubmethod
   query_cursor *
   method_invoke_group::create_cursor (QUERY_ID query_id, bool oid_included)
   {
+    if (query_id == NULL_QUERY_ID || query_id >= SHRT_MAX)
+      {
+	// false query e.g) SELECT * FROM db_class WHERE 0 <> 0
+	return nullptr;
+      }
+
     m_cursor_set.insert (query_id);
     return m_rctx->create_cursor (m_thread_p, query_id, oid_included);
   }

--- a/src/method/method_invoke_java.cpp
+++ b/src/method/method_invoke_java.cpp
@@ -520,7 +520,6 @@ namespace cubmethod
 	  }
 	i++;
       }
-
     error = mcon_send_data_to_java (m_group->get_socket (), METHOD_RESPONSE_SUCCESS, info);
     return error;
   }

--- a/src/method/method_invoke_java.cpp
+++ b/src/method/method_invoke_java.cpp
@@ -475,7 +475,6 @@ namespace cubmethod
     int pos;
     int fetch_count;
     int fetch_flag;
-    fetch_info info;
 
     unpacker.unpack_all (qid, pos, fetch_count, fetch_flag);
 
@@ -494,6 +493,7 @@ namespace cubmethod
 	cursor->open ();
       }
 
+    fetch_info info;
     int i = 0;
     SCAN_CODE s_code = S_SUCCESS;
     while (s_code == S_SUCCESS)

--- a/src/method/method_invoke_java.cpp
+++ b/src/method/method_invoke_java.cpp
@@ -475,20 +475,13 @@ namespace cubmethod
     int pos;
     int fetch_count;
     int fetch_flag;
+    fetch_info info;
 
     unpacker.unpack_all (qid, pos, fetch_count, fetch_flag);
 
     /* find query cursor */
-    fetch_info info;
     query_cursor *cursor = m_group->get_cursor (qid);
-    if (cursor == nullptr)
-      {
-	assert (false);
-	error = mcon_send_data_to_java (m_group->get_socket (), METHOD_RESPONSE_ERROR, ER_FAILED, "unknown error",
-					ARG_FILE_LINE);
-	return error;
-      }
-    else
+    if (cursor != nullptr)
       {
 	if (cursor->get_is_opened () == false)
 	  {

--- a/src/method/method_query_handler.cpp
+++ b/src/method/method_query_handler.cpp
@@ -523,7 +523,14 @@ namespace cubmethod
 
     if (qres && qres->type == T_SELECT)
       {
-	result_info.query_id = qres->res.s.query_id;
+	if (qresult.tuple_count > 0)
+	  {
+	    result_info.query_id = qres->res.s.query_id;
+	  }
+	else
+	  {
+	    result_info.query_id = NULL_QUERY_ID; // initialized value
+	  }
       }
     return error;
   }

--- a/src/method/method_runtime_context.cpp
+++ b/src/method/method_runtime_context.cpp
@@ -259,8 +259,7 @@ namespace cubmethod
   {
     if (query_id == NULL_QUERY_ID || query_id >= SHRT_MAX)
       {
-	// something wrong!
-	assert (false);
+	// false query e.g) SELECT * FROM db_class WHERE 0 <> 0
 	return nullptr;
       }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25248

For false query such as "SELECT * FROM db_class WHERE 0 <> 0", dummy query id is set.
I've changed to set the query_id as NULL_QUERY_ID if a query is not executed (`tuple_count <= 0`).