### PR TITLE
[CBRD-25249] Fix not to resolve names of static SQL without considering user variables in compiling PL/CSQL

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -941,9 +941,6 @@ pt_bind_name_or_path_in_scope (PARSER_CONTEXT * parser, PT_BIND_NAMES_ARG * bind
       /* If pt_name in group by/ having, maybe it's alias. We will try to resolve it later. */
       if (!is_pt_name_in_group_having (in_node))
 	{
-	  /* it may be a naked parameter or a path expression anchored by a naked parameter. Try and resolve it as
-	   * such. */
-	  node = pt_bind_parameter_path (parser, in_node);
 
 	  if (node == NULL && parser->flag.is_parsing_static_sql == 1)
 	    {
@@ -951,6 +948,12 @@ pt_bind_name_or_path_in_scope (PARSER_CONTEXT * parser, PT_BIND_NAMES_ARG * bind
 	      pt_reset_error (parser);
 
 	      node = pt_parameterize_for_static_sql (parser, in_node);
+	    }
+	  else			// in case of compiling static SQL, do not resolve with variable defined in runtime
+	    {
+	      /* it may be a naked parameter or a path expression anchored by a naked parameter. Try and resolve it as
+	       * such. */
+	      node = pt_bind_parameter_path (parser, in_node);
 	    }
 
 	  if (node == NULL && !pt_has_error (parser))

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -942,7 +942,7 @@ pt_bind_name_or_path_in_scope (PARSER_CONTEXT * parser, PT_BIND_NAMES_ARG * bind
       if (!is_pt_name_in_group_having (in_node))
 	{
 
-	  if (node == NULL && parser->flag.is_parsing_static_sql == 1)
+	  if (parser->flag.is_parsing_static_sql == 1)
 	    {
 	      // clear unknown attribute error, the unknown symbol will be converted (paramterized) to host variable
 	      pt_reset_error (parser);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25249

When compiling Static SQL, the query parser interprets PL's variable as a SQL's user variable. In PL/CSQL compilation, only static information should be considered, without regarding to runtime values.