### PR TITLE
[CBRD-25190] Subtracting two date/time function calls results in a type error

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
@@ -601,17 +601,11 @@ public class TypeChecker extends AstVisitor<TypeSpec> {
             if (DBTypeAdapter.isSupported(ci.type)) {
                 ret = DBTypeAdapter.getValueType(ci.type);
             } else {
-                // Allow the other types too, which can lead to run-time type errors,
-                // but accepts some more working programs. For example,
-                //
-                // create or replace procedure poo(i int) as
-                // begin
-                //     for r in (execute immediate 'select * from db_collation') loop
-                //         dbms_output.put_line(nvl2(i, r.coll_id, 2.7));
-                //     end loop;
-                // end;
-
-                ret = TypeSpecSimple.OBJECT;
+                throw new SemanticError(
+                        Misc.getLineColumnOf(node.ctx), // s233
+                        String.format(
+                                "unsupported return type (code %d) of the built-in function %s",
+                                ci.type, node.name));
             }
 
             node.setResultType(ret);
@@ -1211,7 +1205,7 @@ public class TypeChecker extends AstVisitor<TypeSpec> {
 
     private String checkArgsAndConvertToTypicalValuesStr(List<Expr> args, String funcName) {
         if (args.size() == 0) {
-            return "";
+            return "()";
         }
 
         StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25190

two updates

1. return '()' rather than an empty string for empty arguments for built-in functions.
2. raise error for unsupported return types of built-in functions.