### PR TITLE
[CBRD-25253] [bugfix] SELECT statement is shown in semantic error messages of built-in function calls

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
@@ -628,7 +628,9 @@ public class TypeChecker extends AstVisitor<TypeSpec> {
         } else {
             throw new SemanticError(
                     Misc.getLineColumnOf(node.ctx), // s230
-                    "typing function " + node.name + " call failed: " + ss.errMsg);
+                    "function "
+                            + node.name
+                            + " is undefined or given wrong number or types of arguments");
         }
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25253


