### PR TITLE
[CBRD-25193] [bugfix] TO_NUMBER('1234567', '9999999') call results in a compile time error

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -26636,21 +26636,6 @@ parser_keyword_func (const char *name, PT_NODE * args)
 	  return NULL;
 	}
 
-      if (c == 2)
-	{
-	  PT_NODE *node = args->next;
-	  if (node->node_type != PT_VALUE ||
-	      (node->type_enum != PT_TYPE_CHAR &&
-	       node->type_enum != PT_TYPE_VARCHAR &&
-	       node->type_enum != PT_TYPE_NCHAR &&
-	       node->type_enum != PT_TYPE_VARNCHAR))
-	    {
-	      push_msg (MSGCAT_SYNTAX_INVALID_TO_NUMBER);
-	      csql_yyerror_explicit (10, 10);
-	      return NULL;
-	    }
-	}
-
       a1 = args;
       if (a1)
 	a2 = a1->next;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25193

the arg2's type is checked in query parser. This information should be checked in type checking.