### PR TITLE
[CBRD-25199] Make Unit-test of memory monitor module

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
+            choco upgrade chocolatey
             choco install openjdk8redhatbuild --no-progress -y
             choco install cmake --version=3.26.3 --installargs 'ADD_CMAKE_TO_PATH=System' --no-progress -y
             choco install winflexbison wixtoolset --no-progress -y

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,7 @@ jobs:
           command: |
             choco upgrade chocolatey
             choco install openjdk8redhatbuild --no-progress -y
+            choco install cmake.install --version=3.26.3 --no-progress -y
             choco install cmake --version=3.26.3 --installargs 'ADD_CMAKE_TO_PATH=System' --no-progress -y
             choco install winflexbison wixtoolset --no-progress -y
             choco install ant --ignore-dependencies --no-progress -y

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
           command: |
             choco upgrade chocolatey
             choco install openjdk8redhatbuild --no-progress -y
-            choco install cmake.install --version=3.26.3 --no-progress -y
+            choco install cmake.install --version=3.26.3 --installargs 'ADD_CMAKE_TO_PATH=System' --no-progress -y
             choco install cmake --version=3.26.3 --installargs 'ADD_CMAKE_TO_PATH=System' --no-progress -y
             choco install winflexbison wixtoolset --no-progress -y
             choco install ant --ignore-dependencies --no-progress -y

--- a/build.sh
+++ b/build.sh
@@ -33,7 +33,7 @@ build_generator="make"
 source_dir=`pwd`
 default_java_dir="/usr/lib/jvm/java"
 java_dir=""
-configure_options=""
+configure_options="-DUNIT_TEST_MEMORY_MONITOR=ON"
 # default build_dir = "$source_dir/build_${build_target}_${build_mode}"
 build_dir=""
 prefix_dir=""

--- a/build.sh
+++ b/build.sh
@@ -33,7 +33,9 @@ build_generator="make"
 source_dir=`pwd`
 default_java_dir="/usr/lib/jvm/java"
 java_dir=""
-configure_options="-DUNIT_TEST_MEMORY_MONITOR=ON"
+configure_options=""
+# if you turn on the unit test of memory monitor
+# configure_options="-DUNIT_TEST_MEMORY_MONITOR=ON" or "-DUNIT_TESTS=ON"
 # default build_dir = "$source_dir/build_${build_target}_${build_mode}"
 build_dir=""
 prefix_dir=""

--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -105,6 +105,7 @@ set(BASE_SOURCES
   ${BASE_DIR}/mem_block.cpp
   ${BASE_DIR}/memory_alloc.c
   ${BASE_DIR}/memory_hash.c
+  ${BASE_DIR}/memory_monitor_api.cpp
   ${BASE_DIR}/memory_monitor_sr.cpp
   ${BASE_DIR}/memory_private_allocator.cpp
   ${BASE_DIR}/message_catalog.c

--- a/src/base/memory_monitor_api.cpp
+++ b/src/base/memory_monitor_api.cpp
@@ -1,0 +1,93 @@
+/*
+ *
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+/*
+ * memory_monitor_api.cpp - Implementation of memory monitor APIs
+ */
+
+#include <cassert>
+
+#include "error_manager.h"
+#include "system_parameter.h"
+#include "memory_monitor_sr.hpp"
+
+namespace cubmem
+{
+  memory_monitor *mmon_Gl = nullptr;
+}
+
+using namespace cubmem;
+
+bool mmon_is_memory_monitor_enabled ()
+{
+  return (mmon_Gl != nullptr);
+}
+
+int mmon_initialize (const char *server_name)
+{
+  int error = NO_ERROR;
+
+  assert (mmon_Gl == nullptr);
+  assert (server_name != nullptr);
+
+  if (prm_get_bool_value (PRM_ID_ENABLE_MEMORY_MONITORING))
+    {
+#if !defined(WINDOWS)
+      mmon_Gl = new (std::nothrow) memory_monitor (server_name);
+      if (mmon_Gl == nullptr)
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (memory_monitor));
+	  error = ER_OUT_OF_VIRTUAL_MEMORY;
+	  return error;
+	}
+#endif // !WINDOWS
+    }
+  return error;
+}
+
+void mmon_finalize ()
+{
+  if (mmon_is_memory_monitor_enabled ())
+    {
+#if !defined (NDEBUG)
+      mmon_Gl->finalize_dump ();
+#endif
+      delete mmon_Gl;
+      mmon_Gl = nullptr;
+    }
+}
+
+size_t mmon_get_allocated_size (char *ptr)
+{
+  return mmon_Gl->get_allocated_size (ptr);
+}
+
+void mmon_add_stat (char *ptr, const size_t size, const char *file, const int line)
+{
+  mmon_Gl->add_stat (ptr, size, file, line);
+}
+
+void mmon_sub_stat (char *ptr)
+{
+  mmon_Gl->sub_stat (ptr);
+}
+
+void mmon_aggregate_server_info (MMON_SERVER_INFO &server_info)
+{
+  mmon_Gl->aggregate_server_info (server_info);
+}

--- a/src/base/memory_monitor_sr.cpp
+++ b/src/base/memory_monitor_sr.cpp
@@ -69,6 +69,18 @@ namespace cubmem
     std::string target ("/src/");
 #endif // !WINDOWS
 
+    // TODO: To minimize the search cost and prevent unnecessary paths
+    //       from being included in the tag_name, we are cutting the string based on
+    //       the rightmost "/src/" found. However, in this case, when the allocation
+    //       occurs on the same 'line', "/src/test.c" and "/src/thirdparty/src/test.c"
+    //       get the same tag_name, making it impossible to distinguish memory alloc-
+    //       ations from two different files. However, such exceptional situations
+    //       are very rare, as memory allocations must occur on the same line number.
+    //       Handling these exceptions would increase the overall cost of this function.
+    //       Moreover, currently, although these exceptional situations theoretically exist,
+    //       they have not been encountered in developer tests.
+    //       Therefore, it has been decided to address them if discovered in the future.
+
     // Find the last occurrence of "src" in the path
     size_t pos = filecopy.rfind (target);
 #if !defined (NDEBUG)

--- a/src/base/memory_monitor_sr.hpp
+++ b/src/base/memory_monitor_sr.hpp
@@ -79,11 +79,11 @@ namespace cubmem
   };
 } //namespace cubmem
 
-bool mmon_is_memory_monitor_enabled ();
-int mmon_initialize (const char *server_name);
-void mmon_finalize ();
-size_t mmon_get_allocated_size (char *ptr);
-void mmon_add_stat (char *ptr, const size_t size, const char *file, const int line);
-void mmon_sub_stat (char *ptr);
-void mmon_aggregate_server_info (MMON_SERVER_INFO &server_info);
+extern bool mmon_is_memory_monitor_enabled ();
+extern int mmon_initialize (const char *server_name);
+extern void mmon_finalize ();
+extern size_t mmon_get_allocated_size (char *ptr);
+extern void mmon_add_stat (char *ptr, const size_t size, const char *file, const int line);
+extern void mmon_sub_stat (char *ptr);
+extern void mmon_aggregate_server_info (MMON_SERVER_INFO &server_info);
 #endif // _MEMORY_MONITOR_SR_HPP_

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -99,6 +99,7 @@ if (UNIT_TESTS OR UNIT_TEST_MONITOR)
   message("    monitor")
   add_subdirectory(monitor)
 endif(UNIT_TESTS OR UNIT_TEST_MONITOR)
+
 if (UNIT_TESTS OR UNIT_TEST_MEMORY_MONITOR)
   message("    memory_monitor")
   add_subdirectory(memory_monitor)

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -22,9 +22,11 @@
 
 project(Test)
 
+set(TEST_COMMON_DIR ${CMAKE_CURRENT_SOURCE_DIR}/common)
+
 set (TEST_INCLUDES
   ${EP_INCLUDES}
-  ${CMAKE_CURRENT_SOURCE_DIR}/common  # todo: find a better solution
+  ${TEST_COMMON_DIR}
   )
 
 option (UNIT_TEST_MEMORY_ALLOC  "Unit testing: memory allocation")
@@ -35,13 +37,28 @@ option (UNIT_TEST_PACKING "Unit testing: packing")
 option (UNIT_TEST_RESOURCE_TRACKER "Unit testing: resource tracker")
 option (UNIT_TEST_MONITOR "Unit testing: monitor")
 option (UNIT_TEST_LOADDB "Unit testing: loaddb module")
+option (UNIT_TEST_MEMORY_MONITOR "Unit testing: memory monitor")
 
 message("  unit_tests/...")
 
-if (AT_LEAST_ONE_UNIT_TEST)
-  message("    common")
-  add_subdirectory(common)
-endif()
+# Catch2
+include(ExternalProject)
+set(CATCH2_TARGET catch2)
+externalproject_add(${CATCH2_TARGET}
+  GIT_REPOSITORY      https://github.com/catchorg/Catch2
+  GIT_TAG             255aa5f   # https://github.com/catchorg/Catch2/releases/tag/v2.11.3
+  INSTALL_COMMAND     ""
+  CMAKE_CACHE_ARGS    -DCATCH_BUILD_TESTING:STRING=off
+                      -DCATCH_INSTALL_DOCS:STRING=off
+                      -DCATCH_INSTALL_HELPERS:STRING=off
+                      -DBUILD_TESTING:STRING=off
+)
+set (CATCH2_DIR ${CMAKE_BINARY_DIR}/unit_tests/catch2-prefix/src/catch2)
+include_directories(${CATCH2_DIR}/single_include)
+list(APPEND TESTS_EXTERNAL_TARGETS ${CATCH2_TARGET})
+
+message("   common")
+add_subdirectory(common)
 
 if (UNIT_TESTS OR UNIT_TEST_MEMORY_ALLOC)
   message("    memory_alloc")
@@ -82,3 +99,7 @@ if (UNIT_TESTS OR UNIT_TEST_MONITOR)
   message("    monitor")
   add_subdirectory(monitor)
 endif(UNIT_TESTS OR UNIT_TEST_MONITOR)
+if (UNIT_TESTS OR UNIT_TEST_MEMORY_MONITOR)
+  message("    memory_monitor")
+  add_subdirectory(memory_monitor)
+endif(UNIT_TESTS OR UNIT_TEST_MEMORY_MONITOR)

--- a/unit_tests/memory_monitor/CMakeLists.txt
+++ b/unit_tests/memory_monitor/CMakeLists.txt
@@ -1,0 +1,49 @@
+#
+#  Copyright 2016 CUBRID Corporation
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#
+
+project(test_memory_monitor)
+
+#
+# test_memory_monitor
+#
+
+set(TEST_MEMORY_MONITOR_SOURCES
+  ${BASE_DIR}/memory_monitor_sr.cpp
+  test_memory_monitor_main.cpp
+  )
+SET_SOURCE_FILES_PROPERTIES(
+  ${TEST_MEMORY_MONITOR_SOURCES}
+  PROPERTIES LANGUAGE CXX
+  )
+
+add_executable(test_memory_monitor
+  ${TEST_MEMORY_MONITOR_SOURCES}
+  )
+
+target_compile_options(test_memory_monitor PRIVATE ${compile_warning_flags})
+target_compile_definitions(test_memory_monitor PRIVATE
+  ${COMMON_DEFS} SERVER_MODE
+  )
+target_include_directories(test_memory_monitor PRIVATE
+  ${TEST_INCLUDES}
+  )
+add_dependencies(test_memory_monitor
+  ${CATCH2_TARGET}
+  )
+if(WIN32)
+  target_link_libraries(test_memory_monitor PRIVATE ws2_32)
+endif(WIN32)

--- a/unit_tests/memory_monitor/test_memory_monitor_main.cpp
+++ b/unit_tests/memory_monitor/test_memory_monitor_main.cpp
@@ -1,5 +1,4 @@
 /*
- * Copyright 2008 Search Solution Corporation
  * Copyright 2016 CUBRID Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");

--- a/unit_tests/memory_monitor/test_memory_monitor_main.cpp
+++ b/unit_tests/memory_monitor/test_memory_monitor_main.cpp
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#define CATCH_CONFIG_MAIN
+#include "catch2/catch.hpp"
+
+#include <cstdlib>
+#include <malloc.h>
+
+// hack to access the private parts of log_checkpoint_info, to verify that the members remain the same after pack/unpack
+#define private public
+#include "memory_monitor_sr.hpp"
+#undef private
+
+char *test_mem_in_the_scope = NULL;
+int test_mem_in_the_scope_idx = -1;
+
+using namespace cubmem;
+
+memory_monitor *test_mmon_Gl = nullptr;
+
+bool mmon_is_memory_monitor_enabled ()
+{
+  return (test_mmon_Gl != nullptr);
+}
+
+int mmon_initialize (const char *server_name)
+{
+  test_mmon_Gl = new (std::nothrow) memory_monitor ("unittest");
+  if (test_mmon_Gl == nullptr)
+    {
+      fprintf (stdout, "memory_monitor allocation failed\n");
+    }
+  return 0;
+}
+
+void mmon_finalize ()
+{
+  if (mmon_is_memory_monitor_enabled ())
+    {
+      delete test_mmon_Gl;
+      test_mmon_Gl = nullptr;
+    }
+}
+
+size_t mmon_get_allocated_size (char *ptr)
+{
+  return test_mmon_Gl->get_allocated_size (ptr);
+}
+
+void mmon_add_stat (char *ptr, const size_t size, const char *file, const int line)
+{
+  test_mmon_Gl->add_stat (ptr, size, file, line);
+}
+
+void mmon_sub_stat (char *ptr)
+{
+  test_mmon_Gl->sub_stat (ptr);
+}
+
+void mmon_aggregate_server_info (MMON_SERVER_INFO &server_info)
+{
+  test_mmon_Gl->aggregate_server_info (server_info);
+}
+
+int find_test_stat (MMON_SERVER_INFO &server_info, std::string target)
+{
+  int cnt = 0;
+  for (const auto &[stat_name, mem_usage] : server_info.stat_info)
+    {
+      if (stat_name.compare (target) == 0)
+	{
+	  return cnt;
+	}
+      cnt++;
+    }
+
+  // there is no matching target
+  return -1;
+}
+
+TEST_CASE ("Test mmon_add_stat", "")
+{
+  MMON_SERVER_INFO test_server_info;
+  size_t allocated_size;
+  int ret;
+  mmon_initialize ("unittest");
+
+  mmon_aggregate_server_info (test_server_info);
+  ret = find_test_stat (test_server_info, "add_test.c:100");
+  REQUIRE (ret == -1);
+  test_server_info.stat_info.clear();
+  test_mem_in_the_scope = (char *) malloc (32);
+  allocated_size = malloc_usable_size (test_mem_in_the_scope);
+  mmon_add_stat (test_mem_in_the_scope, allocated_size, "add_test.c", 100);
+  mmon_aggregate_server_info (test_server_info);
+  ret = find_test_stat (test_server_info, "add_test.c:100");
+  REQUIRE (ret != -1);
+  test_mem_in_the_scope_idx = ret;
+  REQUIRE (test_server_info.total_mem_usage == allocated_size);
+  REQUIRE (test_server_info.total_metainfo_mem_usage == MMON_METAINFO_SIZE);
+  REQUIRE (test_server_info.num_stat == 1);
+  REQUIRE (test_server_info.stat_info[ret].second == allocated_size);
+}
+
+TEST_CASE ("Test mmon_sub_stat", "")
+{
+  MMON_SERVER_INFO test_server_info;
+  char *test_mem_small = (char *) malloc (10);
+  char *test_mem_out_of_scope = (char *) malloc (50);
+  int ret;
+
+  mmon_aggregate_server_info (test_server_info);
+  ret = find_test_stat (test_server_info, "add_test.c:100");
+  REQUIRE (ret == test_mem_in_the_scope_idx);
+  test_server_info.stat_info.clear();
+  mmon_sub_stat (test_mem_small);
+  mmon_sub_stat (test_mem_out_of_scope);
+  mmon_sub_stat (test_mem_in_the_scope);
+  mmon_aggregate_server_info (test_server_info);
+  ret = find_test_stat (test_server_info, "add_test.c:100");
+  REQUIRE (ret != -1);
+  REQUIRE (test_server_info.stat_info[ret].second == 0);
+  mmon_finalize();
+}

--- a/unit_tests/memory_monitor/test_memory_monitor_main.cpp
+++ b/unit_tests/memory_monitor/test_memory_monitor_main.cpp
@@ -159,7 +159,7 @@ TEST_CASE ("Test mmon_add_stat", "")
 //
 // Test add_stat() with single thread when different file paths
 // that will be made same stat name are given (abnormal case)
-// There is a potential issue scenario that can't distinguish different allocation. (TODO)
+// There is a potential issue scenario that can't distinguish different allocation. (TODO in memory_monitor::make_stat_name ())
 // However, since such behavior is currently allowed,
 // it is necessary to test whether such behavior also returns the expected results.
 //

--- a/unit_tests/memory_monitor/test_memory_monitor_main.cpp
+++ b/unit_tests/memory_monitor/test_memory_monitor_main.cpp
@@ -25,7 +25,7 @@
 #include "memory_monitor_sr.hpp"
 
 // For multithread test
-static const int num_threads = 100;
+constexpr int num_threads = 100;
 
 // Global variable for whole unit-test
 char *test_mem_in_the_scope = NULL;

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -294,6 +294,7 @@ if(UNIX)
   set(UNITTESTS_LF_SOURCES
     ${BASE_DIR}/porting.c
     ${BASE_DIR}/lock_free.c
+    ${BASE_DIR}/memory_monitor_api.cpp
     ${BASE_DIR}/memory_monitor_sr.cpp
     ${EXECUTABLES_DIR}/unittests_lf.c
     )
@@ -308,6 +309,7 @@ if(UNIX)
 
 
   set(UNITTESTS_AREA_SOURCES
+    ${BASE_DIR}/memory_monitor_api.cpp
     ${BASE_DIR}/memory_monitor_sr.cpp
     ${EXECUTABLES_DIR}/unittests_area.c
     )
@@ -321,6 +323,7 @@ if(UNIX)
   target_link_libraries(unittests_area LINK_PRIVATE cubrid)
 
   set(UNITTESTS_SNAPSHOT_SOURCES
+      ${BASE_DIR}/memory_monitor_api.cpp
       ${BASE_DIR}/memory_monitor_sr.cpp
       ${EXECUTABLES_DIR}/unittests_snapshot.c
       )
@@ -336,6 +339,7 @@ if(UNIX)
     target_link_libraries(unittests_snapshot LINK_PRIVATE cubrid)
     
   set(UNITTESTS_BIT_SOURCES
+    ${BASE_DIR}/memory_monitor_api.cpp
     ${BASE_DIR}/memory_monitor_sr.cpp
     ${EXECUTABLES_DIR}/unittests_bit.c
     )


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25199

Unit tests for memory_monitor class:
 - Devide `memory_monitor_sr.cpp` into two files with class methods of memory_monitor(`memory_monitor_sr.cpp`) and APIs(`memory_monitor_api.cpp`) because of minimize dependency of unit-test
   - ex) mmon_initialize() need system_parameter.c, error_manager.c and error_manager.c needs something.c and so on... But the test don't need mmon_initialize() that sever uses.
   - modify `cubrid/CMakelists.txt`
   - modify `util/CMakelists.txt` for `unittest_lf`
 - Modify `CMakelists.txt` of unit_tests directory to add unit-test directory for memory_monitor and add `CATCH2` external project
 - Add a new unit test with main source file(`test_memory_monitor_main.cpp`) and its `CMakelists.txt`
 - Modify `build.sh` for  make a executable file of the unit test of memory_monitor class
