### PR TITLE
[CBRD-25242] Improved speed of parse_digits()

### DIFF
--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -23072,7 +23072,7 @@ parse_digits (char *s, int *nr, int cnt)
     }
 
   /* do not support negative numbers because... they are not supported :) */
-  while (*t != 0 && char_isdigit (*t))
+  while (*t != 0 && (cnt-- > 0) && char_isdigit (*t))
     {
       val = (val * 10) + (*t - '0');
       t++;

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -23063,42 +23063,23 @@ error:
 int
 parse_digits (char *s, int *nr, int cnt)
 {
-  int count = 0, len;
-  char *ch;
-  /* res[64] is safe because res has a max length of cnt, which is max 4 */
-  char res[64];
-  const int res_count = sizeof (res) / sizeof (char);
+  char *t = s;
+  int val = 0;
 
-  ch = s;
-  *nr = 0;
-
-  memset (res, 0, sizeof (res));
-
-  while (WHITESPACE (*ch))
+  while (WHITESPACE (*t))
     {
-      ch++;
-      count++;
+      t++;
     }
 
   /* do not support negative numbers because... they are not supported :) */
-  while (*ch != 0 && (*ch >= '0' && *ch <= '9'))
+  while (*t != 0 && char_isdigit (*t))
     {
-      STRCHCAT (res, *ch);
-
-      ch++;
-      count++;
-
-      /* trim at cnt characters */
-      len = strlen (res);
-      if (len == cnt || len == res_count - 1)
-	{
-	  break;
-	}
+      val = (val * 10) + (*t - '0');
+      t++;
     }
 
-  *nr = atol (res);
-
-  return count;
+  *nr = val;
+  return (int) (t - s);
 }
 
 /*


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25242

* Improved speed of parse_digits()
    -  Functions that improve performance by improving the speed of parse_digits()
        - to_date()
       - to_time()
       - to_timestamp()
       - to_datetime()
       - str_to_date()
