### PR TITLE
[CBRD-25254] initialize the lexer lineno on JDBC connection too

### DIFF
--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -916,6 +916,7 @@ ux_prepare (char *sql_stmt, int flag, char auto_commit_mode, T_NET_BUF * net_buf
       goto prepare_result_set;
     }
 
+  db_init_lexer_lineno();
   session = db_open_buffer (sql_stmt);
   if (!session)
     {

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -880,6 +880,7 @@ ux_prepare (char *sql_stmt, int flag, char auto_commit_mode, T_NET_BUF * net_buf
 	  goto prepare_error;
 	}
 
+      db_init_lexer_lineno ();
       session = db_open_buffer (tmp);
       if (!session)
 	{
@@ -1527,6 +1528,7 @@ ux_execute (T_SRV_HANDLE * srv_handle, char flag, int max_col_size, int max_row,
     {
       hm_session_free (srv_handle);
 
+      db_init_lexer_lineno ();
       session = db_open_buffer (srv_handle->sql_stmt);
       if (!session)
 	{
@@ -1850,6 +1852,7 @@ ux_execute_all (T_SRV_HANDLE * srv_handle, char flag, int max_col_size, int max_
     {
       hm_session_free (srv_handle);
 
+      db_init_lexer_lineno ();
       session = db_open_buffer (srv_handle->sql_stmt);
       if (!session)
 	{
@@ -2433,6 +2436,7 @@ ux_execute_batch (int argc, void **argv, T_NET_BUF * net_buf, T_REQ_INFO * req_i
       net_arg_get_str (&sql_stmt, &sql_size, argv[query_index]);
       cas_log_write_nonl (0, false, "batch %d : ", query_index + 1);
 
+      db_init_lexer_lineno ();
       session = db_open_buffer (sql_stmt);
       if (!session)
 	{
@@ -2686,6 +2690,7 @@ ux_execute_array (T_SRV_HANDLE * srv_handle, int argc, void **argv, T_NET_BUF * 
 
       if (is_prepared == FALSE)
 	{
+	  db_init_lexer_lineno ();
 	  session = db_open_buffer (srv_handle->sql_stmt);
 	  if (!session)
 	    {
@@ -11773,6 +11778,7 @@ recompile_statement (T_SRV_HANDLE * srv_handle)
   int stmt_id = 0;
   DB_SESSION *session = NULL;
 
+  db_init_lexer_lineno ();
   session = db_open_buffer (srv_handle->sql_stmt);
   if (!session)
     {

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -916,7 +916,7 @@ ux_prepare (char *sql_stmt, int flag, char auto_commit_mode, T_NET_BUF * net_buf
       goto prepare_result_set;
     }
 
-  db_init_lexer_lineno();
+  db_init_lexer_lineno ();
   session = db_open_buffer (sql_stmt);
   if (!session)
     {

--- a/src/broker/cas_function.c
+++ b/src/broker/cas_function.c
@@ -1992,6 +1992,7 @@ fn_get_query_info (SOCKET sock_fd, int argc, void **argv, T_NET_BUF * net_buf, T
       cas_log_query_info_init (srv_h_id, TRUE);
       srv_handle->query_info_flag = TRUE;
 
+      db_init_lexer_lineno ();
       session = db_open_buffer (sql_stmt);
       if (!session)
 	{

--- a/src/compat/db_vdb.c
+++ b/src/compat/db_vdb.c
@@ -275,10 +275,11 @@ db_open_file (FILE * file)
 }
 
 void
-db_init_lexer_lineno()
+db_init_lexer_lineno ()
 {
-  csql_yyset_lineno(1);
+  csql_yyset_lineno (1);
 }
+
 /*
  * db_make_session_for_one_statement_execution() -
  * return:

--- a/src/compat/db_vdb.c
+++ b/src/compat/db_vdb.c
@@ -274,6 +274,11 @@ db_open_file (FILE * file)
   return session;
 }
 
+void
+db_init_lexer_lineno()
+{
+  csql_yyset_lineno(1);
+}
 /*
  * db_make_session_for_one_statement_execution() -
  * return:

--- a/src/compat/dbi.h
+++ b/src/compat/dbi.h
@@ -579,6 +579,7 @@ extern "C"
   extern DB_SESSION *db_open_buffer (const char *buffer);
   extern DB_SESSION *db_open_file (FILE * file);
   extern DB_SESSION *db_open_file_name (const char *name);
+  extern void db_init_lexer_lineno();
 
   extern int db_statement_count (DB_SESSION * session);
 

--- a/src/compat/dbi.h
+++ b/src/compat/dbi.h
@@ -579,7 +579,7 @@ extern "C"
   extern DB_SESSION *db_open_buffer (const char *buffer);
   extern DB_SESSION *db_open_file (FILE * file);
   extern DB_SESSION *db_open_file_name (const char *name);
-  extern void db_init_lexer_lineno();
+  extern void db_init_lexer_lineno ();
 
   extern int db_statement_count (DB_SESSION * session);
 

--- a/src/compat/dbi_compat.h
+++ b/src/compat/dbi_compat.h
@@ -622,6 +622,7 @@ extern "C"
   extern DB_SESSION *db_open_buffer (const char *buffer);
   extern DB_SESSION *db_open_file (FILE * file);
   extern DB_SESSION *db_open_file_name (const char *name);
+  extern void db_init_lexer_lineno();
 
   extern int db_statement_count (DB_SESSION * session);
 

--- a/src/compat/dbi_compat.h
+++ b/src/compat/dbi_compat.h
@@ -622,7 +622,7 @@ extern "C"
   extern DB_SESSION *db_open_buffer (const char *buffer);
   extern DB_SESSION *db_open_file (FILE * file);
   extern DB_SESSION *db_open_file_name (const char *name);
-  extern void db_init_lexer_lineno();
+  extern void db_init_lexer_lineno ();
 
   extern int db_statement_count (DB_SESSION * session);
 

--- a/src/method/method_query_handler.cpp
+++ b/src/method/method_query_handler.cpp
@@ -764,6 +764,7 @@ namespace cubmethod
       {
 	g_open_buffer_control_flags |= PARSER_FOR_PLCSQL_STATIC_SQL;
       }
+    db_init_lexer_lineno();
     m_session = db_open_buffer (m_sql_stmt.c_str());
     g_open_buffer_control_flags = 0;
 
@@ -841,6 +842,7 @@ namespace cubmethod
 	return ER_FAILED;
       }
 
+    db_init_lexer_lineno ();
     m_session = db_open_buffer (sql_stmt_copy.c_str());
     if (!m_session)
       {

--- a/src/method/method_schema_info.cpp
+++ b/src/method/method_schema_info.cpp
@@ -136,6 +136,7 @@ namespace cubmethod
   {
     lang_set_parser_use_client_charset (false);
 
+    db_init_lexer_lineno ();
     m_session = db_open_buffer (sql_stmt.c_str());
     if (!m_session)
       {

--- a/win/cubridcs/cubridcs.def
+++ b/win/cubridcs/cubridcs.def
@@ -258,6 +258,7 @@ EXPORTS
     db_need_reconnect
     db_object
     db_objlist_free
+    db_init_lexer_lineno
     db_open_buffer
     db_ping_server
     db_push_values

--- a/win/cubridsa/cubridsa.def
+++ b/win/cubridsa/cubridsa.def
@@ -586,6 +586,7 @@ EXPORTS
     db_objlist_next
     db_objlist_object
     db_objlist_print
+    db_init_lexer_lineno
     db_open_buffer
     db_open_file
     db_open_file_name


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25254

Lerxer lineno initialization code is added in ux_prepare() so that the line number is correct on JDBC connection too.
