### PR TITLE
[CBRD-25260] Change the the behavior of finding server when omitting user schema

### DIFF
--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -18751,15 +18751,6 @@ pt_print_dblink_table (PARSER_CONTEXT * parser, PT_NODE * p)
 	  q = pt_append_varchar (parser, q, r);
 	  q = pt_append_nulstring (parser, q, ".");
 	}
-      else
-	{			//ctshim
-	  char *owner_name = (char *) au_user_name ();
-	  assert (owner_name != NULL);
-	  q = pt_append_nulstring (parser, q, "[");
-	  q = pt_append_nulstring (parser, q, owner_name);
-	  q = pt_append_nulstring (parser, q, "]");
-	  q = pt_append_nulstring (parser, q, ".");
-	}
       r = pt_print_bytes (parser, p->info.dblink_table.conn);
       q = pt_append_varchar (parser, q, r);
 

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -18751,6 +18751,15 @@ pt_print_dblink_table (PARSER_CONTEXT * parser, PT_NODE * p)
 	  q = pt_append_varchar (parser, q, r);
 	  q = pt_append_nulstring (parser, q, ".");
 	}
+      else
+	{			//ctshim
+	  char *owner_name = (char *) au_user_name ();
+	  assert (owner_name != NULL);
+	  q = pt_append_nulstring (parser, q, "[");
+	  q = pt_append_nulstring (parser, q, owner_name);
+	  q = pt_append_nulstring (parser, q, "]");
+	  q = pt_append_nulstring (parser, q, ".");
+	}
       r = pt_print_bytes (parser, p->info.dblink_table.conn);
       q = pt_append_varchar (parser, q, r);
 

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -206,7 +206,7 @@ static int do_select_internal (PARSER_CONTEXT * parser, PT_NODE * statement, boo
 
 static int get_dblink_password_encrypt (const char *passwd, DB_VALUE * encrypt_val, bool is_external);
 static int get_dblink_password_decrypt (const char *passwd_cipher, DB_VALUE * decrypt_val);
-static MOP server_find (PT_NODE * node_server, PT_NODE * node_owner, bool force_owner_name);
+static MOP server_find (PT_NODE * node_server, PT_NODE * node_owner);
 
 static int do_supplemental_statement (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLASS_INFO ** cls_info,
 				      OID * reserved_oid);
@@ -20270,7 +20270,7 @@ do_drop_server (PARSER_CONTEXT * parser, PT_NODE * statement)
   CHECK_MODIFICATION_ERROR ();
 
   drop_server = &(statement->info.drop_server);
-  server_object = server_find (drop_server->server_name, drop_server->owner_name, false);
+  server_object = server_find (drop_server->server_name, drop_server->owner_name);
   if (server_object == NULL)
     {
       error = er_errid ();
@@ -20430,7 +20430,7 @@ do_create_server (PARSER_CONTEXT * parser, PT_NODE * statement)
 
   sm_downcase_name ((char *) create_server->server_name->info.name.original, name_buf, SERVER_ATTR_LINK_NAME_BUF_SIZE);
   attr_val[0] = name_buf;
-  server_object = server_find (create_server->server_name, create_server->owner_name, true);
+  server_object = server_find (create_server->server_name, create_server->owner_name);
   if (server_object != NULL)
     {
       error = ER_DBLINK_SERVER_ALREADY_EXISTS;
@@ -20581,7 +20581,7 @@ do_rename_server (PARSER_CONTEXT * parser, PT_NODE * statement)
 
   CHECK_MODIFICATION_ERROR ();
 
-  server_object = server_find (rename_server->old_name, rename_server->owner_name, false);
+  server_object = server_find (rename_server->old_name, rename_server->owner_name);
   if (server_object == NULL)
     {
       return er_errid ();
@@ -20623,7 +20623,7 @@ do_rename_server (PARSER_CONTEXT * parser, PT_NODE * statement)
       pr_clear_value (&name_val);
     }
 
-  if (server_find (rename_server->new_name, owner_node, false))
+  if (server_find (rename_server->new_name, owner_node))
     {
       error = ER_DBLINK_SERVER_ALREADY_EXISTS;
     }
@@ -20690,7 +20690,7 @@ do_alter_server (PARSER_CONTEXT * parser, PT_NODE * statement)
   alter = &(statement->info.alter_server);
   server_name = alter->server_name->info.name.original;
 
-  server_object = server_find (alter->server_name, alter->current_owner_name, false);
+  server_object = server_find (alter->server_name, alter->current_owner_name);
   if (server_object == NULL)
     {
       return er_errid ();
@@ -20893,7 +20893,7 @@ do_alter_server (PARSER_CONTEXT * parser, PT_NODE * statement)
 	  goto end;
 	}
 
-      if (server_find (alter->server_name, alter->owner_name, false))
+      if (server_find (alter->server_name, alter->owner_name))
 	{
 	  char buf[2048];
 	  sprintf (buf, "[%s].[%s]",
@@ -20941,7 +20941,7 @@ get_dblink_info_from_dbserver (PARSER_CONTEXT * parser, PT_NODE * server_name, P
   db_make_null (&user_val);
 
   cnt = 0;
-  server_object = server_find (server_name, owner_name, false);
+  server_object = server_find (server_name, owner_name);
   if (server_object == NULL)
     {
       return er_errid ();
@@ -21049,7 +21049,7 @@ get_dblink_owner_name_from_dbserver (PARSER_CONTEXT * parser, PT_NODE * server_n
 
   db_make_null (&user_val);
 
-  server_object = server_find (server_nm, owner_nm, false);
+  server_object = server_find (server_nm, owner_nm);
   if (server_object == NULL)
     {
       return er_errid ();
@@ -21354,14 +21354,13 @@ get_dblink_password_decrypt (const char *passwd_cipher, DB_VALUE * decrypt_val)
  *
  * return		  : Record object or NULL
  * node_server(in)	  : PT_NODE* for server name.
- * node_owner(in)         : PT_NODE* for owner name.
- * force_owner_name(in)   : Set whether to designate as the current user when node_owner is NULL
+ * node_owner(in)         : PT_NODE* for owner name. 
  * 
  * Remark: 
  *      
  */
 static MOP
-server_find (PT_NODE * node_server, PT_NODE * node_owner, bool force_owner_name)
+server_find (PT_NODE * node_server, PT_NODE * node_owner)
 {
   int error = NO_ERROR;
   MOP server_obj = NULL;
@@ -21386,7 +21385,7 @@ server_find (PT_NODE * node_server, PT_NODE * node_owner, bool force_owner_name)
       intl_identifier_upper (owner_name, upper_case_name);
       owner_name = upper_case_name;
     }
-  else if (force_owner_name)
+  else
     {
       owner_name = (char *) au_user_name ();
       if (!owner_name)
@@ -21395,16 +21394,10 @@ server_find (PT_NODE * node_server, PT_NODE * node_owner, bool force_owner_name)
 	}
     }
 
-  if (owner_name)
-    {
-      sprintf (query,
-	       "SELECT [_db_server], [owner] FROM [_db_server] WHERE [link_name] = '%s' AND [owner].[name] = '%s'",
-	       name_buf, owner_name);
-    }
-  else
-    {
-      sprintf (query, "SELECT [_db_server], [owner] FROM [_db_server] WHERE [link_name] = '%s'", name_buf);
-    }
+  assert (owner_name);
+  sprintf (query,
+	   "SELECT [_db_server], [owner] FROM [_db_server] WHERE [link_name] = '%s' AND [owner].[name] = '%s'",
+	   name_buf, owner_name);
 
   if (owner_name == upper_case_name)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25260

* If the Owner name is not specified in the SERVER name, it is considered that the current_user name has been specified.


```
cubrid createdb testdb en_us.utf8

csql -S -udba testdb -c "create table t1 (col1 int); create table t2 (col1 int, col2 int);"
csql -S -udba testdb -c "create user test_user;"
csql -S -udba testdb -c "grant ALL PRIVILEGES on t1 to test_user;"
csql -S -udba testdb -c "grant ALL PRIVILEGES on t1 to public;"
csql -S -udba testdb -c "grant ALL PRIVILEGES on t2 to public;"
csql -S -udba testdb -c "insert into t1 values (1), (2);"
csql -S -udba testdb -c "insert into t2 values (1, 10), (2, 20);"

cubrid server start testdb; cubrid broker start

csql -u public testdb -c "create server srv1 (HOST='127.0.0.1', PORT=33000, DBNAME=testdb, USER=dba, PASSWORD='');"
csql -u public testdb -c "create view v1 as select * from dblink (srv1, 'select col1 from t1') as t(col1 int);"

csql -u test_user testdb -c "create server srv1 (HOST='127.0.0.1', PORT=33000, DBNAME=testdb, USER=dba, PASSWORD='');"
--csql -u test_user testdb -c "create view v1 as select * from dblink (srv1, 'select col1 from t1') as t(col1 int);"
csql -u test_user testdb -c "create view v1 as select * from dblink (srv1, 'select col1, col2 from t2') as t(col1 int, col2 int);"
csql -u test_user testdb -c "create view v2 as select * from dblink (test_user.srv1, 'select col1 from t1') as t(col1 int);"
csql -u test_user testdb -c "create view v3 as select * from dblink (public.srv1, 'select col1 from t1') as t(col1 int);"

csql -u test_user testdb -c "select * from v1;"
csql -u test_user testdb -c "select * from v2;"
csql -u test_user testdb -c "select * from v3;"

```