### PR TITLE
[CBRD-25262] Problem with some show statements not filtering the owner correctly

### DIFF
--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -7375,14 +7375,15 @@ pt_make_query_show_create_table (PARSER_CONTEXT * parser, PT_NODE * table_name)
  *    SELECT * FROM
  *      (SELECT IF( VC.vclass_name = '',
  *                  (SELECT COUNT(*) FROM <view_name> LIMIT 1),
- *                  VC.vclass_name )
- *                AS View_,
+ *                  LOWER(VC.owner_name) + VC.vclass_name )
+ *                AS VIEW,
  *              IF( VC.comment IS NULL or VC.comment = '',
  *                  VC.vclass_def,
  *                  VC.vclass_def + ' COMMENT=''' + VC.comment + '''' )
- *                AS Create_View
+ *                AS [CREATE VIEW]
  *              FROM db_vclass VC
- *              WHERE VC.vclass_name=<view_name>)
+ *              WHERE VC.vclass_name=<lower_view_name> AND
+ *                    VC.owner_name=<upper_owner_name>)
  *     show_create_view;
  *
  *  Note : The first column in query (name of view = VC.vclass_name) is wrapped
@@ -7405,6 +7406,8 @@ pt_make_query_show_create_view (PARSER_CONTEXT * parser, PT_NODE * view_identifi
   PT_NODE *node = NULL;
   PT_NODE *from_item = NULL;
   char lower_view_name[DB_MAX_IDENTIFIER_LENGTH];
+  char owner_name[DB_MAX_USER_LENGTH];
+  char upper_owner_name[DB_MAX_USER_LENGTH];
 
   assert (view_identifier != NULL);
   assert (view_identifier->node_type == PT_NAME);
@@ -7424,19 +7427,33 @@ pt_make_query_show_create_view (PARSER_CONTEXT * parser, PT_NODE * view_identifi
 
   intl_identifier_lower (view_identifier->info.name.original, lower_view_name);
 
+  sm_qualifier_name (lower_view_name, owner_name, DB_MAX_USER_LENGTH);
+  intl_identifier_upper (owner_name, upper_owner_name);
+
   /* ------ SELECT list ------- */
   {
-    /* View name : IF( VC.vclass_name = '', (SELECT COUNT(*) FROM <view_name> LIMIT 1), VC.vclass_name ) AS View */
+    /* View name : IF( VC.vclass_name = '',
+     *                 (SELECT COUNT(*) FROM <view_name> LIMIT 1),
+     *                 LOWER(VC.owner_name) + VC.vclass_name )
+     *               AS View
+     */
     PT_NODE *if_true_node = NULL;
     PT_NODE *if_false_node = NULL;
     PT_NODE *pred = NULL;
     PT_NODE *view_field = NULL;
+    PT_NODE *lhs = NULL, *rhs = NULL;
+    PT_NODE *concat_sep = NULL;
 
     if_true_node = pt_make_dummy_query_check_table (parser, lower_view_name);
-    if_false_node = pt_make_dotted_identifier (parser, "VC.vclass_name");
+    lhs = pt_make_dotted_identifier (parser, "VC.owner_name");
+    lhs = parser_make_expression (parser, PT_LOWER, lhs, NULL, NULL);
+    concat_sep = pt_make_string_value (parser, ".");
+    rhs = pt_make_dotted_identifier (parser, "VC.vclass_name");
+    if_false_node = parser_make_expression (parser, PT_CONCAT, lhs, concat_sep, NULL);
+    if_false_node = parser_make_expression (parser, PT_CONCAT, if_false_node, rhs, NULL);
     pred = pt_make_pred_name_string_val (parser, PT_EQ, "VC.vclass_name", "");
 
-    view_field = pt_make_if_with_expressions (parser, pred, if_true_node, if_false_node, "View");
+    view_field = pt_make_if_with_expressions (parser, pred, if_true_node, if_false_node, "VIEW");
     node->info.query.q.select.list = parser_append_node (view_field, node->info.query.q.select.list);
   }
 
@@ -7461,7 +7478,7 @@ pt_make_query_show_create_view (PARSER_CONTEXT * parser, PT_NODE * view_identifi
     rhs = pt_make_pred_name_string_val (parser, PT_EQ, "VC.comment", "");
     pred = parser_make_expression (parser, PT_OR, lhs, rhs, NULL);
 
-    create_view_field = pt_make_if_with_expressions (parser, pred, if_true_node, if_false_node, "Create View");
+    create_view_field = pt_make_if_with_expressions (parser, pred, if_true_node, if_false_node, "CREATE VIEW");
 
     node->info.query.q.select.list = parser_append_node (create_view_field, node->info.query.q.select.list);
   }
@@ -7471,13 +7488,21 @@ pt_make_query_show_create_view (PARSER_CONTEXT * parser, PT_NODE * view_identifi
 
   /* ------ SELECT ... WHERE ------- */
   {
-    PT_NODE *where_item = NULL;
-    where_item =
+    PT_NODE *where_item1 = NULL, *where_item2 = NULL;
+
+    /* VC.vclass_name = <lower_view_name> */
+    where_item1 =
       pt_make_pred_name_string_val (parser, PT_EQ, "VC.vclass_name", sm_remove_qualifier_name (lower_view_name));
+
+    /* VC.owner_name = <upper_owner_name> */
+    where_item2 = pt_make_pred_name_string_val (parser, PT_EQ, "VC.owner_name", upper_owner_name);
+
+    /* where_item1: where_item1 AND where_item2 */
+    where_item1 = parser_make_expression (parser, PT_AND, where_item1, where_item2, NULL);
 
     /* WHERE list should be empty */
     assert (node->info.query.q.select.where == NULL);
-    node->info.query.q.select.where = parser_append_node (where_item, node->info.query.q.select.where);
+    node->info.query.q.select.where = parser_append_node (where_item1, node->info.query.q.select.where);
   }
 
   return node;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25262

Changes are as follows:
1. Add owner filtering to the pt_make_query_show_create_view function.
2. Uppercase the column names in the 'SHOW CREATE VIEW' statement.
3. Append the schema names to the view names.

For example:
```
csql> call login ('u1') on class db_user;
csql> show create view v1;

-- AS-IS
  View                  Create View
============================================
  'v1'                  'select _utf8'public' collate utf8_bin'
  'v1'                  'select _utf8'u1' collate utf8_bin'

-- TO-BE
  VIEW                  CREATE VIEW
============================================
  'u1.v1'               'select _utf8'u1' collate utf8_bin'
```