### PR TITLE
[CBRD-25211] Occur EXECUTE authorization failure when SP's owner is not current user

### DIFF
--- a/src/jsp/jsp_cl.cpp
+++ b/src/jsp/jsp_cl.cpp
@@ -350,46 +350,6 @@ jsp_get_return_type (const char *name)
 }
 
 /*
- * jsp_get_owner - Return Java Stored Procedure Owner
- *   return: if fail return error code
- *           else return Java Stored Procedure Owner's MOP
- *   name(in): java stored procedure name
- *
- * Note:
- */
-
-MOP
-jsp_get_owner (const char *name)
-{
-  DB_OBJECT *mop_p;
-  DB_VALUE owner;
-
-  int err;
-  int save;
-
-  AU_DISABLE (save);
-
-  mop_p = jsp_find_stored_procedure (name);
-  if (mop_p == NULL)
-    {
-      AU_ENABLE (save);
-
-      assert (er_errid () != NO_ERROR);
-      return NULL;
-    }
-
-  err = db_get (mop_p, SP_ATTR_OWNER, &owner);
-  if (err != NO_ERROR)
-    {
-      AU_ENABLE (save);
-      return NULL;
-    }
-
-  AU_ENABLE (save);
-  return db_get_object (&owner);
-}
-
-/*
  * jsp_get_sp_type - Return Java Stored Procedure Type
  *   return: if fail return error code
  *           else return Java Stored Procedure Type
@@ -1038,11 +998,11 @@ drop_stored_procedure (const char *name, SP_TYPE_ENUM expected_type)
     }
 
   if (1 == db_get_int (&generated_val))
-    {
+  {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_DROP_NOT_ALLOWED_SYSTEM_GENERATED, 0);
       err = er_errid ();
       goto error;
-    }
+  }
 
   err = db_get (sp_mop, SP_ATTR_SP_TYPE, &sp_type_val);
   if (err != NO_ERROR)

--- a/src/jsp/jsp_cl.cpp
+++ b/src/jsp/jsp_cl.cpp
@@ -309,6 +309,45 @@ jsp_get_return_type (const char *name)
 }
 
 /*
+ * jsp_get_owner - Return Java Stored Procedure Owner
+ *   return: if fail return error code
+ *           else return Java Stored Procedure Owner's MOP
+ *   name(in): java stored procedure name
+ *
+ * Note:
+ */
+
+MOP
+jsp_get_owner (const char *name)
+{
+  DB_OBJECT *mop_p;
+  DB_VALUE owner;
+  int err;
+  int save;
+
+  AU_DISABLE (save);
+
+  mop_p = jsp_find_stored_procedure (name);
+  if (mop_p == NULL)
+    {
+      AU_ENABLE (save);
+
+      assert (er_errid () != NO_ERROR);
+      return NULL;
+    }
+
+  err = db_get (mop_p, SP_ATTR_OWNER, &owner);
+  if (err != NO_ERROR)
+    {
+      AU_ENABLE (save);
+      return NULL;
+    }
+
+  AU_ENABLE (save);
+  return db_get_object (&owner);
+}
+
+/*
  * jsp_get_sp_type - Return Java Stored Procedure Type
  *   return: if fail return error code
  *           else return Java Stored Procedure Type
@@ -957,11 +996,11 @@ drop_stored_procedure (const char *name, SP_TYPE_ENUM expected_type)
     }
 
   if (1 == db_get_int (&generated_val))
-  {
+    {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_DROP_NOT_ALLOWED_SYSTEM_GENERATED, 0);
       err = er_errid ();
       goto error;
-  }
+    }
 
   err = db_get (sp_mop, SP_ATTR_SP_TYPE, &sp_type_val);
   if (err != NO_ERROR)

--- a/src/jsp/jsp_cl.cpp
+++ b/src/jsp/jsp_cl.cpp
@@ -119,7 +119,7 @@ static int *jsp_make_method_arglist (PARSER_CONTEXT *parser, PT_NODE *node_list)
 extern bool ssl_client;
 
 static int
-check_execute_authorization (MOP sp_obj, AU_TYPE au_type)
+check_execute_authorization (const MOP sp_obj, const DB_AUTH au_type)
 {
   int error = ER_FAILED;
   MOP owner_mop = NULL;
@@ -138,8 +138,9 @@ check_execute_authorization (MOP sp_obj, AU_TYPE au_type)
 	  owner_mop = db_get_object (&owner);
 	  if (!ws_is_same_object (owner_mop, Au_user))
 	    {
-	      error = (au_type == AU_EXECUTE) ? ER_AU_EXECUTE_FAILURE : ER_AU_SELECT_FAILURE;
+	      error = (au_type == DB_AUTH_EXECUTE) ? ER_AU_EXECUTE_FAILURE : ER_AU_SELECT_FAILURE;
 	      er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, error, 0);
+	      return error;
 	    }
 
 	  error = NO_ERROR;
@@ -181,12 +182,13 @@ jsp_find_stored_procedure (const char *name, DB_AUTH purpose)
   if (er_errid () == ER_OBJ_OBJECT_NOT_FOUND)
     {
       er_clear ();
-      er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, ER_SP_NOT_EXIST, 1, name);
+      err = ER_SP_NOT_EXIST;
+      er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, err, 1, name);
     }
 
-  if (purpose != DB_AUTH_NONE && check_execute_authorization (mop, purpose) != NO_ERROR)
+  if (purpose != DB_AUTH_NONE)
     {
-      goto end;
+      err = check_execute_authorization (mop, purpose);
     }
 
 end:

--- a/src/jsp/jsp_cl.h
+++ b/src/jsp/jsp_cl.h
@@ -90,7 +90,6 @@ extern int jsp_check_return_type_supported (DB_TYPE type);
 extern int jsp_is_exist_stored_procedure (const char *name);
 extern int jsp_get_return_type (const char *name);
 extern int jsp_get_sp_type (const char *name);
-extern MOP jsp_get_owner (const char *name);
 extern MOP jsp_find_stored_procedure (const char *name);
 
 extern void jsp_set_prepare_call (void);

--- a/src/jsp/jsp_cl.h
+++ b/src/jsp/jsp_cl.h
@@ -90,7 +90,7 @@ extern int jsp_check_return_type_supported (DB_TYPE type);
 extern int jsp_is_exist_stored_procedure (const char *name);
 extern int jsp_get_return_type (const char *name);
 extern int jsp_get_sp_type (const char *name);
-extern MOP jsp_find_stored_procedure (const char *name);
+extern MOP jsp_find_stored_procedure (const char *name, DB_AUTH purpose);
 
 extern void jsp_set_prepare_call (void);
 extern void jsp_unset_prepare_call (void);

--- a/src/jsp/jsp_cl.h
+++ b/src/jsp/jsp_cl.h
@@ -90,6 +90,7 @@ extern int jsp_check_return_type_supported (DB_TYPE type);
 extern int jsp_is_exist_stored_procedure (const char *name);
 extern int jsp_get_return_type (const char *name);
 extern int jsp_get_sp_type (const char *name);
+extern MOP jsp_get_owner (const char *name);
 extern MOP jsp_find_stored_procedure (const char *name);
 
 extern void jsp_set_prepare_call (void);

--- a/src/method/method_callback.cpp
+++ b/src/method/method_callback.cpp
@@ -599,7 +599,7 @@ namespace cubmethod
 
     AU_DISABLE (save);
     {
-      mop_p = jsp_find_stored_procedure (name);
+      mop_p = jsp_find_stored_procedure (name, DB_AUTH_SELECT);
       if (mop_p == NULL)
 	{
 	  assert (er_errid () != NO_ERROR);

--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -6210,7 +6210,7 @@ au_change_sp_owner_method (MOP obj, DB_VALUE * returnval, DB_VALUE * sp, DB_VALU
     {
       if (owner != NULL && IS_STRING (owner) && !DB_IS_NULL (owner) && db_get_string (owner) != NULL)
 	{
-	  sp_mop = jsp_find_stored_procedure (db_get_string (sp));
+	  sp_mop = jsp_find_stored_procedure (db_get_string (sp), DB_AUTH_SELECT);
 	  if (sp_mop != NULL)
 	    {
 	      user = au_find_user (db_get_string (owner));

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -3854,7 +3854,7 @@ pt_to_method_sig_list (PARSER_CONTEXT * parser, PT_NODE * node_list, PT_NODE * s
 	      (*tail)->arg_info.arg_mode = regu_int_array_alloc (num_args);
 	      (*tail)->arg_info.arg_type = regu_int_array_alloc (num_args);
 
-	      DB_OBJECT *mop_p = jsp_find_stored_procedure ((*tail)->method_name);
+	      DB_OBJECT *mop_p = jsp_find_stored_procedure ((*tail)->method_name, DB_AUTH_EXECUTE);
 	      if (mop_p)
 		{
 		  /* java stored procedure signature */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25211

As a preliminary task of CBRD-24912, a checking routine that the stored procedure's owner is same with the current user.
