### PR TITLE
[CBRD-25271] Core occurs when applying nvl function index to char type column

### DIFF
--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -520,19 +520,11 @@ db_string_unique_prefix (const DB_VALUE * db_string1, const DB_VALUE * db_string
   precision = DB_VALUE_PRECISION (db_string1);
   /* Determine the result type */
   result_type = DB_VALUE_DOMAIN_TYPE (db_string1);
-  if (QSTR_IS_CHAR (result_type))
-    {
-      result_type = DB_TYPE_VARCHAR;
-    }
-  else if (QSTR_IS_NATIONAL_CHAR (result_type))
-    {
-      result_type = DB_TYPE_VARNCHAR;
-    }
-  else if (QSTR_IS_BIT (result_type))
+  if (QSTR_IS_BIT (result_type))
     {
       result_type = DB_TYPE_VARBIT;
     }
-  else
+  else if (!QSTR_IS_CHAR (result_type) && !QSTR_IS_NATIONAL_CHAR (result_type))
     {
       db_make_null (db_result);
 #if defined(CUBRID_DEBUG)

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -5740,22 +5740,9 @@ btree_generate_prefix_domain (BTID_INT * btid)
   dbtype = TP_DOMAIN_TYPE (domain);
 
   /* varying domains did not come into use until btree revision level 1 */
-  if (dbtype == DB_TYPE_CHAR || dbtype == DB_TYPE_NCHAR || dbtype == DB_TYPE_BIT)
+  if (dbtype == DB_TYPE_BIT)
     {
-      switch (dbtype)
-	{
-	case DB_TYPE_CHAR:
-	  vartype = DB_TYPE_VARCHAR;
-	  break;
-	case DB_TYPE_NCHAR:
-	  vartype = DB_TYPE_VARNCHAR;
-	  break;
-	case DB_TYPE_BIT:
-	  vartype = DB_TYPE_VARBIT;
-	  break;
-	default:
-	  return NULL;
-	}
+      vartype = DB_TYPE_VARBIT;
 
       var_domain =
 	tp_domain_resolve (vartype, domain->class_mop, domain->precision, domain->scale, domain->setdomain,


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25271

When splitting a B-tree node, even if the key is char-type, it is changed to varchar-type during the process of creating a prefix.
The precision of the changed varchar-type is set to 1GB, which is MAX_DB_VARCHAR_PRECISION, and in the case of utf8, x4 is applied during the length calculation process, so the length of the integer type overflows and becomes a minus value, resulting in a fatal segmentation violation error.
The code below is part of the mr_data_lengthval_char code called from db_string_unique_prefix. The reason mr_data_lengthval_char is called rather than mr_data_lengthval_string is because the key is char-type.

The ignore_trailing_space parameter was introduced in version 11.0, and with the introduction of this part, the B-tree node split part was modified. When splitting a node, the CHAR type is not changed to VARCHAR type after 11.0 version.