### PR TITLE
[CBRD-25277] 'Outer join query optimization failed.' error occurs in Eliminate INNER JOIN

### DIFF
--- a/src/optimizer/query_rewrite.c
+++ b/src/optimizer/query_rewrite.c
@@ -3386,7 +3386,7 @@ qo_reset_spec_location (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * query
       curr_loc = spec->info.spec.location;
       after_loc = curr_loc - 1;
 
-      if (curr_loc <= 0 || after_loc <= 0)
+      if (curr_loc <= 0 || after_loc < 0)
 	{
 	  spec = spec->next;
 	  continue;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25277

Correctly set the PT_SPEC location when performing Eliminate INNER JOIN optimization.