### PR TITLE
[CBRD-24521] consider backslash escapes in PL/CSQL text too

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/data/DBType.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/data/DBType.java
@@ -42,7 +42,7 @@ import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
 
-public class DBType {
+public class DBType {   // see src/compat/dbtype_def.h
     public static final int DB_NULL = 0;
     public static final int DB_INT = 1;
     public static final int DB_FLOAT = 2;

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/data/DBType.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/data/DBType.java
@@ -42,7 +42,7 @@ import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
 
-public class DBType {   // see src/compat/dbtype_def.h
+public class DBType { // see src/compat/dbtype_def.h
     public static final int DB_NULL = 0;
     public static final int DB_INT = 1;
     public static final int DB_FLOAT = 2;

--- a/src/parser/csql_lexer.l
+++ b/src/parser/csql_lexer.l
@@ -1467,17 +1467,17 @@ _[uU][tT][fF]8[']		{
 
 "\\n"				{
 					csql_yylval.cptr = pt_append_string(this_parser, csql_yylval.cptr,
-									    (from_plcsql_text || prm_get_bool_value (PRM_ID_NO_BACKSLASH_ESCAPES) || this_parser->flag.strings_have_no_escapes) ? "\\n" : "\n");
+									    (prm_get_bool_value (PRM_ID_NO_BACKSLASH_ESCAPES) || this_parser->flag.strings_have_no_escapes) ? "\\n" : "\n");
 				}
 
 "\\r"				{
 					csql_yylval.cptr = pt_append_string(this_parser, csql_yylval.cptr,
-									    (from_plcsql_text || prm_get_bool_value (PRM_ID_NO_BACKSLASH_ESCAPES) || this_parser->flag.strings_have_no_escapes) ? "\\r" : "\r");
+									    (prm_get_bool_value (PRM_ID_NO_BACKSLASH_ESCAPES) || this_parser->flag.strings_have_no_escapes) ? "\\r" : "\r");
 				}
 
 "\\t"				{
 					csql_yylval.cptr = pt_append_string(this_parser, csql_yylval.cptr,
-									    (from_plcsql_text || prm_get_bool_value (PRM_ID_NO_BACKSLASH_ESCAPES) || this_parser->flag.strings_have_no_escapes) ? "\\t" : "\t");
+									    (prm_get_bool_value (PRM_ID_NO_BACKSLASH_ESCAPES) || this_parser->flag.strings_have_no_escapes) ? "\\t" : "\t");
 				}
 
 "\\%"				{
@@ -1489,7 +1489,7 @@ _[uU][tT][fF]8[']		{
 				}
 
 [\\]['"]			{
-					if (from_plcsql_text || prm_get_bool_value (PRM_ID_NO_BACKSLASH_ESCAPES) || this_parser->flag.strings_have_no_escapes)
+					if (prm_get_bool_value (PRM_ID_NO_BACKSLASH_ESCAPES) || this_parser->flag.strings_have_no_escapes)
 					  {
 					    csql_yylval.cptr = pt_append_string(this_parser, csql_yylval.cptr, "\\");
 					    unput(*(yytext + 1));
@@ -1503,14 +1503,14 @@ _[uU][tT][fF]8[']		{
 
 [\\].				{
 					csql_yylval.cptr = pt_append_string(this_parser, csql_yylval.cptr,
-							   (from_plcsql_text || prm_get_bool_value (PRM_ID_NO_BACKSLASH_ESCAPES) || this_parser->flag.strings_have_no_escapes) ? yytext : yytext + 1);
+							   (prm_get_bool_value (PRM_ID_NO_BACKSLASH_ESCAPES) || this_parser->flag.strings_have_no_escapes) ? yytext : yytext + 1);
 				}
 
 [\\]\n				{
 					this_parser->line = yylineno;
 					this_parser->column = yycolumn = yycolumn_end = 0;
 
-					if (from_plcsql_text || prm_get_bool_value (PRM_ID_NO_BACKSLASH_ESCAPES) || this_parser->flag.strings_have_no_escapes)
+					if (prm_get_bool_value (PRM_ID_NO_BACKSLASH_ESCAPES) || this_parser->flag.strings_have_no_escapes)
 					  {
 					    csql_yylval.cptr = pt_append_string(this_parser, csql_yylval.cptr, "\\\n");
 					  }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24521

. minor: comment
. remove erroneous disabling of backslash escapes in PL/CSQL code
