### PR TITLE
[CBRD-25284] The constant_value in the name node is missing from tree traversal.

### DIFF
--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -13211,6 +13211,7 @@ pt_apply_name (PARSER_CONTEXT * parser, PT_NODE * p, void *arg)
 {
   PT_APPLY_WALK (parser, p->info.name.path_correlation, arg);
   PT_APPLY_WALK (parser, p->info.name.default_value, arg);
+  PT_APPLY_WALK (parser, p->info.name.constant_value, arg);
   PT_APPLY_WALK (parser, p->info.name.indx_key_limit, arg);
   return p;
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25284

The constant_value in the name node is missing from tree traversal.
It is not a problem currently, but it could be a potential problem, such as copying the tree.
