### PR TITLE
[CBRD-25128] In STRING_CAT '||' operation, incorrect handling of null when setting oracle_style_empty_string (#4842)

### DIFF
--- a/src/executables/csql_result.c
+++ b/src/executables/csql_result.c
@@ -549,7 +549,8 @@ get_current_result (int **lengths, const CUR_RESULT_INFO * result_info, bool pla
       assert (value_type == DB_TYPE_NULL
 	      /* UNKNOWN, maybe host variable */
 	      || result_info->attr_types[i] == DB_TYPE_NULL || result_info->attr_types[i] == DB_TYPE_VARIABLE
-	      || value_type == result_info->attr_types[i]);
+	      || value_type == result_info->attr_types[i]
+	      || (TP_IS_CHAR_TYPE (value_type) && TP_IS_CHAR_TYPE (result_info->attr_types[i])));
 
       switch (value_type)
 	{

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -5949,6 +5949,7 @@ does_op_specially_treat_null_arg (PT_OP_TYPE op)
     case PT_TO_CHAR:
       return true;
     case PT_REPLACE:
+    case PT_STRCAT:
       return prm_get_bool_value (PRM_ID_ORACLE_STYLE_EMPTY_STRING);
     default:
       return false;
@@ -19236,9 +19237,10 @@ pt_fold_const_expr (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg)
       /* use the caching variant of this function ! */
       domain = pt_xasl_node_to_domain (parser, expr);
 
-      if (domain && QSTR_IS_ANY_CHAR_OR_BIT (TP_DOMAIN_TYPE (domain)))
+      if (domain
+	  && (QSTR_IS_ANY_CHAR_OR_BIT (TP_DOMAIN_TYPE (domain)) || type1 == PT_TYPE_NULL || type2 == PT_TYPE_NULL))
 	{
-	  if (opd1 && opd1->node_type == PT_VALUE && type1 == PT_TYPE_NULL && PT_IS_STRING_TYPE (type2))
+	  if (opd1 && opd1->node_type == PT_VALUE && type1 == PT_TYPE_NULL)
 	    {
 	      /* fold 'null || char_opnd' expr to 'char_opnd' */
 	      result = parser_copy_tree (parser, opd2);
@@ -19248,7 +19250,7 @@ pt_fold_const_expr (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg)
 		  goto end;
 		}
 	    }
-	  else if (opd2 && opd2->node_type == PT_VALUE && type2 == PT_TYPE_NULL && PT_IS_STRING_TYPE (type1))
+	  else if (opd2 && opd2->node_type == PT_VALUE && type2 == PT_TYPE_NULL)
 	    {
 	      /* fold 'char_opnd || null' expr to 'char_opnd' */
 	      result = parser_copy_tree (parser, opd1);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25128

This is a back port for 10.2 patch
