### PR TITLE
[CBRD-25285] Add a new ClassLoader to avoid reloading classes that load JNI in a Java SP Server

### DIFF
--- a/msg/de_DE.utf8/utils.msg
+++ b/msg/de_DE.utf8/utils.msg
@@ -914,7 +914,8 @@ $set 34 MSGCAT_UTIL_SET_LOADJAVA
 Usage: loadjava [OPTION] database-name java-class-file\n\
 \n\
 valid options:\n\
-  -y, --overwrite              Klassendatei, wenn vorhanden, überschreiben, Standard nein\n
+  -y, --overwrite              Klassendatei, wenn vorhanden, überschreiben, Standard nein\n\
+  -j, --jni                    add a Class or Jar to static loading for JNI\n
 
 $set 37 MSGCAT_UTIL_SET_PLANDUMP
 15 Ausgangdatei '%1$s' kann nicht geöffnet werden\n

--- a/msg/en_US.utf8/utils.msg
+++ b/msg/en_US.utf8/utils.msg
@@ -915,7 +915,8 @@ $set 34 MSGCAT_UTIL_SET_LOADJAVA
 Usage: loadjava [OPTION] database-name java-class-file\n\
 \n\
 valid options:\n\
-  -y, --overwrite              overwrite class file if exist, default no\n
+  -y, --overwrite              overwrite class file if exist, default no\n\
+  -j, --jni                    add a Class or Jar to static loading for JNI\n
 
 $set 37 MSGCAT_UTIL_SET_PLANDUMP
 15 Cannot open output file '%1$s'\n

--- a/msg/en_US/utils.msg
+++ b/msg/en_US/utils.msg
@@ -915,7 +915,8 @@ $set 34 MSGCAT_UTIL_SET_LOADJAVA
 Usage: loadjava [OPTION] database-name java-class-file\n\
 \n\
 valid options:\n\
-  -y, --overwrite              overwrite class file if exist, default no\n
+  -y, --overwrite              overwrite class file if exist, default no\n\
+  -j, --jni                    add a Class or Jar to static loading for JNI\n
 
 $set 37 MSGCAT_UTIL_SET_PLANDUMP
 15 Cannot open output file '%1$s'\n

--- a/msg/es_ES.utf8/utils.msg
+++ b/msg/es_ES.utf8/utils.msg
@@ -914,7 +914,8 @@ $set 34 MSGCAT_UTIL_SET_LOADJAVA
 Usage: loadjava [OPTION] database-name java-class-file\n\
 \n\
 valid options:\n\
-  -y, --overwrite              sobrescribir archivo de clase si existe, estandar no\n
+  -y, --overwrite              sobrescribir archivo de clase si existe, estandar no\n\
+  -j, --jni                    add a Class or Jar to static loading for JNI\n
 
 $set 37 MSGCAT_UTIL_SET_PLANDUMP
 15 No se puede abrir archivo de salida '%1$s'\n

--- a/msg/fr_FR.utf8/utils.msg
+++ b/msg/fr_FR.utf8/utils.msg
@@ -917,7 +917,8 @@ $set 34 MSGCAT_UTIL_SET_LOADJAVA
 Usage: loadjava [OPTION] database-name java-class-file\n\
 \n\
 valid options:\n\
-  -y, --overwrite              remplace le fichier de classe si lui existe, par défaut non\n
+  -y, --overwrite              remplace le fichier de classe si lui existe, par défaut non\n\
+  -j, --jni                    add a Class or Jar to static loading for JNI\n
 
 $set 37 MSGCAT_UTIL_SET_PLANDUMP
 15 Impossible d'ouvrir le fichier de sortie '%1$s'\n

--- a/msg/it_IT.utf8/utils.msg
+++ b/msg/it_IT.utf8/utils.msg
@@ -914,7 +914,8 @@ $set 34 MSGCAT_UTIL_SET_LOADJAVA
 Usage: loadjava [OPTION] database-name java-class-file\n\
 \n\
 valid options:\n\
-  -y, --overwrite              sovrascrivere class file, se esiste, niente predefinito\n
+  -y, --overwrite              sovrascrivere class file, se esiste, niente predefinito\n\
+  -j, --jni                    add a Class or Jar to static loading for JNI\n
 
 $set 37 MSGCAT_UTIL_SET_PLANDUMP
 15 Impossibile aprire il file di output '%1$s'\n

--- a/msg/ja_JP.utf8/utils.msg
+++ b/msg/ja_JP.utf8/utils.msg
@@ -914,7 +914,8 @@ $set 34 MSGCAT_UTIL_SET_LOADJAVA
 Usage: loadjava [OPTION] database-name java-class-file\n\
 \n\
 valid options:\n\
-  -y, --overwrite              クラスファイルがもう存在したらオーバーライトする。; デフォルト: オーバーライトしない\n
+  -y, --overwrite              クラスファイルがもう存在したらオーバーライトする。; デフォルト: オーバーライトしない\n\
+  -j, --jni                    add a Class or Jar to static loading for JNI\n
 
 $set 37 MSGCAT_UTIL_SET_PLANDUMP
 15 出力ファイル「%1$s」が開けません。\n

--- a/msg/km_KH.utf8/utils.msg
+++ b/msg/km_KH.utf8/utils.msg
@@ -916,7 +916,8 @@ $set 34 MSGCAT_UTIL_SET_LOADJAVA
 Usage: loadjava [OPTION] database-name java-class-file\n\
 \n\
 valid options:\n\
-  -y, --overwrite              overwrite class file if exist, default no\n
+  -y, --overwrite              overwrite class file if exist, default no\n\
+  -j, --jni                    add a Class or Jar to static loading for JNI\n
 
 $set 37 MSGCAT_UTIL_SET_PLANDUMP
 15 Cannot open output file '%1$s'\n

--- a/msg/ko_KR.euckr/utils.msg
+++ b/msg/ko_KR.euckr/utils.msg
@@ -914,7 +914,8 @@ $set 34 MSGCAT_UTIL_SET_LOADJAVA
 Usage: loadjava [OPTION] database-name java-class-file\n\
 \n\
 valid options:\n\
-  -y, --overwrite              클래스 파일이 이미 존재하면 덮어씀; 기본값: 덮어쓰지 않음\n
+  -y, --overwrite              클래스 파일이 이미 존재하면 덮어씀; 기본값: 덮어쓰지 않음\n\
+  -j, --jni                    JNI 사용을 위해 정적 로딩 영역에 클래스 또는 Jar를 추가함\n
 
 $set 37 MSGCAT_UTIL_SET_PLANDUMP
 15 출력 파일 '%1$s'을 열 수 없습니다\n

--- a/msg/ko_KR.utf8/utils.msg
+++ b/msg/ko_KR.utf8/utils.msg
@@ -912,7 +912,8 @@ $set 34 MSGCAT_UTIL_SET_LOADJAVA
 Usage: loadjava [OPTION] database-name java-class-file\n\
 \n\
 valid options:\n\
-  -y, --overwrite              클래스 파일이 이미 존재하면 덮어씀; 기본값: 덮어쓰지 않음\n
+  -y, --overwrite              클래스 파일이 이미 존재하면 덮어씀; 기본값: 덮어쓰지 않음\n\
+  -j, --jni                    JNI 사용을 위해 정적 로딩 영역에 클래스 또는 Jar를 추가함\n
 
 $set 37 MSGCAT_UTIL_SET_PLANDUMP
 15 출력 파일 '%1$s'을 열 수 없습니다\n

--- a/msg/ro_RO.utf8/utils.msg
+++ b/msg/ro_RO.utf8/utils.msg
@@ -931,7 +931,8 @@ $set 34 MSGCAT_UTIL_SET_LOADJAVA
 Usage: loadjava [OPTION] database-name java-class-file\n\
 \n\
 valid options:\n\
-  -y, --overwrite              suprascrie fişierul de clasă dacă exista, implicit nu\n
+  -y, --overwrite              suprascrie fişierul de clasă dacă exista, implicit nu\n\
+  -j, --jni                    add a Class or Jar to static loading for JNI\n
 
 $set 37 MSGCAT_UTIL_SET_PLANDUMP
 15 Fişierul de ieşire '%1$s' nu a putut fi deschis\n

--- a/msg/tr_TR.utf8/utils.msg
+++ b/msg/tr_TR.utf8/utils.msg
@@ -914,7 +914,8 @@ $set 34 MSGCAT_UTIL_SET_LOADJAVA
 Usage: loadjava [OPTION] database-name java-class-file\n\
 \n\
 valid options:\n\
-  -y, --overwrite              varsa sınıf dosyanın üzerine yazmak, varsayılan yok\n
+  -y, --overwrite              varsa sınıf dosyanın üzerine yazmak, varsayılan yok\n\
+  -j, --jni                    add a Class or Jar to static loading for JNI\n
 
 $set 37 MSGCAT_UTIL_SET_PLANDUMP
 15 Çıktı dosyası '%1$s' açılamıyor \n

--- a/msg/vi_VN.utf8/utils.msg
+++ b/msg/vi_VN.utf8/utils.msg
@@ -916,7 +916,8 @@ $set 34 MSGCAT_UTIL_SET_LOADJAVA
 Usage: loadjava [OPTION] database-name java-class-file\n\
 \n\
 valid options:\n\
-  -y, --overwrite              overwrite class file if exist, default no\n
+  -y, --overwrite              overwrite class file if exist, default no\n\
+  -j, --jni                    add a Class or Jar to static loading for JNI\n
 
 $set 37 MSGCAT_UTIL_SET_PLANDUMP
 15 Cannot open output file '%1$s'\n

--- a/msg/zh_CN.utf8/utils.msg
+++ b/msg/zh_CN.utf8/utils.msg
@@ -913,7 +913,8 @@ $set 34 MSGCAT_UTIL_SET_LOADJAVA
 Usage: loadjava [OPTION] database-name java-class-file\n\
 \n\
 valid options:\n\
-  -y, --overwrite              如果类存在则进行重写, 默认 不\n
+  -y, --overwrite              如果类存在则进行重写, 默认 不\n\
+  -j, --jni                    add a Class or Jar to static loading for JNI\n
 
 $set 37 MSGCAT_UTIL_SET_PLANDUMP
 15 无法打开输出文件 '%1$s'\n

--- a/src/executables/loadjava.cpp
+++ b/src/executables/loadjava.cpp
@@ -90,6 +90,7 @@ parse_argument (int argc, char *argv[])
 	  break;
 	case 'j':
 	  Path = STATIC_PATH;
+	  break;
 	case 'h':
 	/* fall through */
 	default:

--- a/src/executables/loadjava.cpp
+++ b/src/executables/loadjava.cpp
@@ -40,12 +40,18 @@
 namespace fs = std::filesystem;
 
 #define JAVA_DIR                "java"
+#define JAVA_STATIC_DIR         "java_static"
+
 #if defined(WINDOWS)
 #define SEPERATOR               "\\"
 #else /* ! WINDOWS */
 #define SEPERATOR               "/"
 #endif /* !WINDOWS */
 
+static const std::string DYNAMIC_PATH = JAVA_DIR;
+static const std::string STATIC_PATH = JAVA_STATIC_DIR;
+
+static std::string Path;
 static char *Program_name = NULL;
 static char *Dbname = NULL;
 std::string Src_class;
@@ -64,13 +70,14 @@ parse_argument (int argc, char *argv[])
   struct option loadjava_option[] =
   {
     {"overwrite", 0, 0, 'y'},
+    {"jni", 0, 0, 'j'},
     {0, 0, 0, 0}
   };
 
   while (1)
     {
       int option_index = 0;
-      int option_key = getopt_long (argc, argv, "yh", loadjava_option, &option_index);
+      int option_key = getopt_long (argc, argv, "y:jh", loadjava_option, &option_index);
       if (option_key == -1)
 	{
 	  break;
@@ -81,6 +88,8 @@ parse_argument (int argc, char *argv[])
 	case 'y':
 	  Force_overwrite = true;
 	  break;
+	case 'j':
+	  Path = STATIC_PATH;
 	case 'h':
 	/* fall through */
 	default:
@@ -202,7 +211,11 @@ main (int argc, char *argv[])
   java_dir_path.assign (std::string (db->pathname));
 
   // e.g. $CUBRID/demodb/java
-  java_dir_path.append (JAVA_DIR);
+  if (Path.empty())
+    {
+      Path = DYNAMIC_PATH;
+    }
+  java_dir_path.append (Path);
 
   if (create_java_directories (java_dir_path) != NO_ERROR)
     {

--- a/src/executables/loadjava.cpp
+++ b/src/executables/loadjava.cpp
@@ -77,7 +77,7 @@ parse_argument (int argc, char *argv[])
   while (1)
     {
       int option_index = 0;
-      int option_key = getopt_long (argc, argv, "y:jh", loadjava_option, &option_index);
+      int option_key = getopt_long (argc, argv, "yjh", loadjava_option, &option_index);
       if (option_key == -1)
 	{
 	  break;

--- a/src/jsp/com/cubrid/jsp/StoredProcedureClassLoader.java
+++ b/src/jsp/com/cubrid/jsp/StoredProcedureClassLoader.java
@@ -93,7 +93,7 @@ public class StoredProcedureClassLoader extends URLClassLoader {
         }
     }
 
-    public Class<?> loadClass(String name) throws ClassNotFoundException {
+    public Class<?> loadClass(String name) {
         Class<?> found = null;
         try {
             if (isModified()) {
@@ -102,12 +102,13 @@ public class StoredProcedureClassLoader extends URLClassLoader {
             } else {
                 found = super.loadClass(name);
             }
-
-            if (found == null) {
-                found = parentInstance.loadClass(name);
-            }
-        } catch (IOException e) {
+        } catch (Exception e) {
         }
+
+        if (found == null) {
+            found = parentInstance.loadClass(name);
+        }
+
         return found;
     }
 

--- a/src/jsp/com/cubrid/jsp/StoredProcedureClassLoader.java
+++ b/src/jsp/com/cubrid/jsp/StoredProcedureClassLoader.java
@@ -93,7 +93,7 @@ public class StoredProcedureClassLoader extends URLClassLoader {
         }
     }
 
-    public Class<?> loadClass(String name) {
+    public Class<?> loadClass(String name) throws ClassNotFoundException {
         Class<?> found = null;
         try {
             if (isModified()) {

--- a/src/jsp/com/cubrid/jsp/StoredProcedureStaticClassLoader.java
+++ b/src/jsp/com/cubrid/jsp/StoredProcedureStaticClassLoader.java
@@ -70,6 +70,10 @@ public class StoredProcedureStaticClassLoader extends URLClassLoader {
         }
     }
 
+    public Class<?> loadClass(String name) throws ClassNotFoundException {
+        return super.loadClass(name);
+    }
+
     private void initJar() throws IOException {
         try (Stream<Path> files = Files.list(root)) {
             files.filter((file) -> !Files.isDirectory(file) && (file.toString().endsWith(".jar")))

--- a/src/jsp/com/cubrid/jsp/StoredProcedureStaticClassLoader.java
+++ b/src/jsp/com/cubrid/jsp/StoredProcedureStaticClassLoader.java
@@ -39,30 +39,24 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.nio.file.attribute.FileTime;
 import java.util.stream.Stream;
 
-public class StoredProcedureClassLoader extends URLClassLoader {
-    private static volatile StoredProcedureClassLoader instance = null;
-    private static volatile StoredProcedureStaticClassLoader parentInstance = null;
+public class StoredProcedureStaticClassLoader extends URLClassLoader {
+    private static volatile StoredProcedureStaticClassLoader instance = null;
 
-    private static final String ROOT_PATH = Server.getSpPath() + "/java/";
+    private static final String ROOT_PATH = Server.getSpPath() + "/java_static/";
     private static final Path root = Paths.get(ROOT_PATH);
 
-    private FileTime lastModified = null;
-
     /* For singleton */
-    public static synchronized StoredProcedureClassLoader getInstance() {
+    public static synchronized StoredProcedureStaticClassLoader getInstance() {
         if (instance == null) {
-            instance = new StoredProcedureClassLoader();
+            instance = new StoredProcedureStaticClassLoader();
         }
-        parentInstance = StoredProcedureStaticClassLoader.getInstance();
 
         return instance;
     }
 
-    private StoredProcedureClassLoader() {
+    private StoredProcedureStaticClassLoader() {
         super(new URL[0]);
         init();
     }
@@ -71,7 +65,6 @@ public class StoredProcedureClassLoader extends URLClassLoader {
         try {
             addURL(root.toUri().toURL());
             initJar();
-            lastModified = getLastModifiedTime(root);
         } catch (Exception e) {
             Server.log(e);
         }
@@ -91,33 +84,5 @@ public class StoredProcedureClassLoader extends URLClassLoader {
         } catch (NoSuchFileException e) {
             // ignore
         }
-    }
-
-    public Class<?> loadClass(String name) throws ClassNotFoundException {
-        Class<?> found = null;
-        try {
-            if (isModified()) {
-                instance = new StoredProcedureClassLoader();
-                found = instance.loadClass(name);
-            } else {
-                found = super.loadClass(name);
-            }
-
-            if (found == null) {
-                found = parentInstance.loadClass(name);
-            }
-        } catch (IOException e) {
-        }
-        return found;
-    }
-
-    private boolean isModified() throws IOException {
-        return lastModified.compareTo(getLastModifiedTime(root)) != 0;
-    }
-
-    private FileTime getLastModifiedTime(Path path) throws IOException {
-        BasicFileAttributes attr = Files.readAttributes(path, BasicFileAttributes.class);
-        FileTime lastModifiedTime = attr.lastModifiedTime();
-        return lastModifiedTime;
     }
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25285

A new classloader (`StoredProcedureStaticClassLoader`) will be added to avoid reloading classes that load JNI. By `loadjava`'s `-j` option, classes are copied to `/java_static` directory and the classloader will try to find classes in the path.
The classloader does not check whether any file is modified in the path, Also is not be re-initialized like `StoredProcedureClassLoader`. To update overwritten classes in `/java_static`, restarting Java SP server(`cub_javasp`) is required.