### PR TITLE
[CBRD-25195] A core dump occurs when multiple tables and serial functions are used simultaneously in one query. (#4897)

### DIFF
--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -17206,6 +17206,11 @@ error:
       free_and_init (*oid_listp);
     }
 
+  if (*lock_listp)
+    {
+      free_and_init (*lock_listp);
+    }
+
   if (*tcard_listp)
     {
       free_and_init (*tcard_listp);
@@ -17349,6 +17354,7 @@ pt_serial_to_xasl_class_oid_list (PARSER_CONTEXT * parser, const PT_NODE * seria
   *nump = o_num;
   *sizep = o_size;
   *oid_listp = o_list;
+  *lock_listp = lck_list;
   *tcard_listp = t_list;
 
   return o_num;
@@ -17357,6 +17363,11 @@ error:
   if (*oid_listp)
     {
       free_and_init (*oid_listp);
+    }
+
+  if (*lock_listp)
+    {
+      free_and_init (*lock_listp);
     }
 
   if (*tcard_listp)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25195

This is a backport for 10.2 patch
