### PR TITLE
[CBRD-25296] Assertion fail on a DATETIMELTZ value to a SP's parameter of DATETIME type

### DIFF
--- a/src/compat/db_value_printer.cpp
+++ b/src/compat/db_value_printer.cpp
@@ -126,6 +126,145 @@ void db_value_printer::describe_comment_value (const db_value *value)
 }
 
 //--------------------------------------------------------------------------------
+void db_value_printer::describe_type (const db_value *value)
+{
+  if (DB_IS_NULL (value))
+    {
+      m_buf ("NULL");
+    }
+  else
+    {
+      DB_TYPE type = DB_VALUE_TYPE (value);
+      switch (type)
+	{
+	case DB_TYPE_NULL:
+	  m_buf ("NULL");
+	  break;
+	case DB_TYPE_INTEGER:
+	  m_buf ("INTEGER");
+	  break;
+	case DB_TYPE_BIGINT:
+	  m_buf ("BIGINT");
+	  break;
+	case DB_TYPE_FLOAT:
+	  m_buf ("FLOAT");
+	  break;
+	case DB_TYPE_DOUBLE:
+	  m_buf ("DOUBLE");
+	  break;
+	case DB_TYPE_VARCHAR:
+	  m_buf ("VARCHAR");
+	  break;
+	case DB_TYPE_OBJECT:
+	  m_buf ("OBJECT");
+	  break;
+	case DB_TYPE_SET:
+	  m_buf ("SET");
+	  break;
+	case DB_TYPE_MULTISET:
+	  m_buf ("MULTISET");
+	  break;
+	case DB_TYPE_SEQUENCE:
+	  m_buf ("SEQUENCE");
+	  break;
+	case DB_TYPE_BLOB:
+	  m_buf ("BLOB");
+	  break;
+	case DB_TYPE_CLOB:
+	  m_buf ("CLOB");
+	  break;
+	case DB_TYPE_TIME:
+	  m_buf ("TIME");
+	  break;
+	case DB_TYPE_TIMESTAMP:
+	  m_buf ("TIMESTAMP");
+	  break;
+	case DB_TYPE_TIMESTAMPTZ:
+	  m_buf ("TIMESTAMPTZ");
+	  break;
+	case DB_TYPE_TIMESTAMPLTZ:
+	  m_buf ("TIMESTAMPLTZ");
+	  break;
+	case DB_TYPE_DATETIME:
+	  m_buf ("DATETIME");
+	  break;
+	case DB_TYPE_DATETIMETZ:
+	  m_buf ("DATETIMETZ");
+	  break;
+	case DB_TYPE_DATETIMELTZ:
+	  m_buf ("DATETIMELTZ");
+	  break;
+	case DB_TYPE_DATE:
+	  m_buf ("DATE");
+	  break;
+	case DB_TYPE_MONETARY:
+	  m_buf ("MONETARY");
+	  break;
+	case DB_TYPE_VARIABLE:
+	  m_buf ("VARIABLE");
+	  break;
+	case DB_TYPE_SUB:
+	  m_buf ("SUB");
+	  break;
+	case DB_TYPE_POINTER:
+	  m_buf ("POINTER");
+	  break;
+	case DB_TYPE_ERROR:
+	  m_buf ("ERROR");
+	  break;
+	case DB_TYPE_SMALLINT:
+	  m_buf ("SMALLINT");
+	  break;
+	case DB_TYPE_VOBJ:
+	  m_buf ("VOBJ");
+	  break;
+	case DB_TYPE_OID:
+	  m_buf ("OID");
+	  break;
+	case DB_TYPE_NUMERIC:
+	  m_buf ("NUMERIC");
+	  break;
+	case DB_TYPE_BIT:
+	  m_buf ("BIT");
+	  break;
+	case DB_TYPE_VARBIT:
+	  m_buf ("VARBIT");
+	  break;
+	case DB_TYPE_CHAR:
+	  m_buf ("CHAR");
+	  break;
+	case DB_TYPE_NCHAR:
+	  m_buf ("NCHAR");
+	  break;
+	case DB_TYPE_VARNCHAR:
+	  m_buf ("VARNCHAR");
+	  break;
+	case DB_TYPE_DB_VALUE:
+	  m_buf ("DB_VALUE");
+	  break;
+	case DB_TYPE_RESULTSET:
+	  m_buf ("DB_RESULTSET");
+	  break;
+	case DB_TYPE_MIDXKEY:
+	  m_buf ("DB_MIDXKEY");
+	  break;
+	case DB_TYPE_TABLE:
+	  m_buf ("DB_TABLE");
+	  break;
+	case DB_TYPE_ENUMERATION:
+	  m_buf ("ENUM");
+	  break;
+	case DB_TYPE_JSON:
+	  m_buf ("JSON");
+	  break;
+	default:
+	  m_buf ("UNKNOWN");
+	  break;
+	}
+    }
+}
+
+//--------------------------------------------------------------------------------
 void db_value_printer::describe_value (const db_value *value)
 {
   INTL_CODESET codeset = INTL_CODESET_NONE;

--- a/src/compat/db_value_printer.hpp
+++ b/src/compat/db_value_printer.hpp
@@ -48,6 +48,7 @@ class db_value_printer
       , m_padding (padding)
     {}
 
+    void describe_type  (const db_value *value);
     void describe_money (const db_monetary *value); //former describe_money(parser...)
     void describe_value (const db_value *value);    //former describe_value(parser...)
     void describe_data (const db_value *value);     //former describe_data(parser...)

--- a/src/method/method_invoke_group.cpp
+++ b/src/method/method_invoke_group.cpp
@@ -20,6 +20,7 @@
 
 #include "boot_sr.h"
 #include "dbtype.h"		/* db_value_* */
+#include "db_value_printer.hpp"
 #include "jsp_comm.h"		/* common communcation functions for javasp */
 #include "mem_block.hpp" /* cubmem::extensible_block */
 #include "method_invoke.hpp"
@@ -30,6 +31,7 @@
 #include "method_connection_sr.hpp"
 #include "method_connection_pool.hpp"
 #include "session.h"
+#include "string_buffer.hpp"
 
 #if defined (SA_MODE)
 #include "query_method.hpp"
@@ -173,6 +175,72 @@ namespace cubmethod
     m_parameter_info = param_info;
   }
 
+  bool
+  method_invoke_group::is_supported_dbtype (const DB_VALUE &value)
+  {
+    bool res = false;
+    switch (DB_VALUE_TYPE (&value))
+      {
+      case DB_TYPE_INTEGER:
+      case DB_TYPE_SHORT:
+      case DB_TYPE_BIGINT:
+      case DB_TYPE_FLOAT:
+      case DB_TYPE_DOUBLE:
+      case DB_TYPE_MONETARY:
+      case DB_TYPE_NUMERIC:
+      case DB_TYPE_CHAR:
+      case DB_TYPE_NCHAR:
+      case DB_TYPE_VARNCHAR:
+      case DB_TYPE_STRING:
+
+      case DB_TYPE_DATE:
+      case DB_TYPE_TIME:
+      case DB_TYPE_TIMESTAMP:
+      case DB_TYPE_DATETIME:
+
+      case DB_TYPE_SET:
+      case DB_TYPE_MULTISET:
+      case DB_TYPE_SEQUENCE:
+      case DB_TYPE_OID:
+      case DB_TYPE_OBJECT:
+
+      case DB_TYPE_RESULTSET:
+      case DB_TYPE_NULL:
+	res = true;
+	break;
+
+      // unsupported types
+      case DB_TYPE_BIT:
+      case DB_TYPE_VARBIT:
+      case DB_TYPE_TABLE:
+      case DB_TYPE_BLOB:
+      case DB_TYPE_CLOB:
+      case DB_TYPE_TIMESTAMPTZ:
+      case DB_TYPE_TIMESTAMPLTZ:
+      case DB_TYPE_DATETIMETZ:
+      case DB_TYPE_DATETIMELTZ:
+      case DB_TYPE_JSON:
+	res = false;
+	break;
+
+      // obsolete, internal, unused type
+      case DB_TYPE_ELO:
+      case DB_TYPE_VARIABLE:
+      case DB_TYPE_SUB:
+      case DB_TYPE_POINTER:
+      case DB_TYPE_ERROR:
+      case DB_TYPE_VOBJ:
+      case DB_TYPE_DB_VALUE:
+      case DB_TYPE_MIDXKEY:
+      case DB_TYPE_ENUMERATION:
+      default:
+	assert (false);
+	break;
+      }
+
+    return res;
+  }
+
   int
   method_invoke_group::prepare (std::vector<std::reference_wrapper<DB_VALUE>> &arg_base,
 				const std::vector<bool> &arg_use_vec)
@@ -194,6 +262,24 @@ namespace cubmethod
 	  }
 	  case METHOD_TYPE_JAVA_SP:
 	  {
+	    /* check arg_base's type is supported */
+	    for (const DB_VALUE &value : arg_base)
+	      {
+		if (is_supported_dbtype (value) == false)
+		  {
+		    error = ER_SP_EXECUTE_ERROR;
+		    std::string err_msg = "unsupported argument type - ";
+
+		    string_buffer sb;
+		    db_value_printer printer (sb);
+		    printer.describe_type (&value);
+
+		    err_msg += std::string (sb.get_buffer(), sb.len ());
+		    set_error_msg (err_msg);
+		    return error;
+		  }
+	      }
+
 	    /* optimize arguments only for java sp not to send redundant values */
 	    DB_VALUE null_val;
 	    db_make_null (&null_val);

--- a/src/method/method_invoke_group.hpp
+++ b/src/method/method_invoke_group.hpp
@@ -111,6 +111,8 @@ namespace cubmethod
     private:
       void destory_all_cursors ();
 
+      bool is_supported_dbtype (const DB_VALUE &value);
+
       runtime_context *m_rctx;
       bool m_is_running;
       bool m_is_for_scan;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25296

When calling a function or procedure, it's necessary to verify that the types of the provided arguments are supported. 
These arguments are passed as an array of DB_VALUE, and a newly introduced function named is_supported_dbtype() is responsible for checking their DB_TYPE. 
In situations where the argument type is not supported, an error message should be generated in the following format: 'unsupported argument type - <DB_TYPE>', where the <DB_TYPE> placeholder is replaced with the actual string representation of the DB_TYPE.

To print DB_TYPE to a string representation, a new function called `describe_type()` has been added to the `db_value_printer` module. This addition was necessary because the existing `compat` layer does not offer such functionality, although a similar function, qdump_data_type_string(), exists within query_dump.c.