### PR TITLE
[CBRD-25298] trim class and method names of the target method

### DIFF
--- a/src/jsp/com/cubrid/jsp/TargetMethod.java
+++ b/src/jsp/com/cubrid/jsp/TargetMethod.java
@@ -65,12 +65,12 @@ public class TargetMethod {
         int nameStart = signature.substring(0, argStart).lastIndexOf('.') + 1;
 
         if (signature.charAt(0) == '\'') {
-            className = signature.substring(1, nameStart - 1);
+            className = signature.substring(1, nameStart - 1).trim();
         } else {
-            className = signature.substring(0, nameStart - 1);
+            className = signature.substring(0, nameStart - 1).trim();
         }
 
-        methodName = signature.substring(nameStart, argStart - 1);
+        methodName = signature.substring(nameStart, argStart - 1).trim();
         String args = signature.substring(argStart, argEnd);
         argsTypes = classesFor(args);
     }
@@ -201,14 +201,32 @@ public class TargetMethod {
         descriptorMap.put("double", "D");
     }
 
+    private static final String[] DUMMY_STRING_ARRAY = new String[0];
+
     public Method getMethod()
             throws SecurityException, NoSuchMethodException, ClassNotFoundException {
         Class<?> c = getClass(className);
         if (c == null) {
-            throw new ClassNotFoundException (className);
+            throw new ClassNotFoundException(className);
         }
-        Method m = c.getMethod(methodName, argsTypes);
-        return m;
+        try {
+            return c.getMethod(methodName, argsTypes);
+        } catch (NoSuchMethodException e) {
+            String argsTypeNames;
+            int len = argsTypes.length;
+            if (len > 0) {
+                String[] arr = new String[len];
+                for (int i = 0; i < len; i++) {
+                    arr[i] = argsTypes[i].getTypeName();
+                }
+                argsTypeNames = String.join(", ", arr);
+            } else {
+                argsTypeNames = "";
+            }
+
+            throw new NoSuchMethodException(
+                    String.format("%s.%s(%s)", className, methodName, argsTypeNames));
+        }
     }
 
     public Class<?>[] getArgsTypes() {

--- a/src/jsp/com/cubrid/jsp/TargetMethod.java
+++ b/src/jsp/com/cubrid/jsp/TargetMethod.java
@@ -201,8 +201,6 @@ public class TargetMethod {
         descriptorMap.put("double", "D");
     }
 
-    private static final String[] DUMMY_STRING_ARRAY = new String[0];
-
     public Method getMethod()
             throws SecurityException, NoSuchMethodException, ClassNotFoundException {
         Class<?> c = getClass(className);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25298

. trim the class name and the method name before search for the method by reflection
. use familiar type names of parameter types in the error messages of NoSuchMethod

