### PR TITLE
[CBRD-25300] When unloaddb, the comment of reverse unique index is mi…

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -3295,9 +3295,17 @@ emit_reverse_unique_def (extract_context & ctxt, print_output & output_ctx, DB_O
 
 	      // reverse unique does not care for direction of the column.
 	    }
-	  output_ctx (");\n");
+
+	  output_ctx (")");
+
+	  if (constraint->comment != NULL && constraint->comment[0] != '\0')
+	    {
+	      output_ctx (" ");
+	      help_print_describe_comment (output_ctx, constraint->comment);
+	    }
 	}
     }
+  output_ctx (";\n");
 }
 
 
@@ -5572,6 +5580,7 @@ emit_unique_key (extract_context & ctxt, print_output & output_ctx, DB_OBJLIST *
 
       if (reverse_unique_flag)
 	{
+	  output_ctx ("\n");
 	  emit_reverse_unique_def (ctxt, output_ctx, cl->op);
 	}
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25300

Purpose
When unloaddb, the comment of reverse unique index is missing

Implementation
Added comment to reverse unique

Remarks
N/A
