### PR TITLE
[CBRD-25300] When unloaddb, the comment of reverse unique index is missing

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -2613,7 +2613,15 @@ emit_reverse_unique_def (print_output & output_ctx, DB_OBJECT * class_)
 
 	      // reverse unique does not care for direction of the column.
 	    }
-	  output_ctx (");\n");
+	  output_ctx (")");
+
+	  if (constraint->comment != NULL && constraint->comment[0] != '\0')
+	    {
+	      output_ctx (" ");
+	      help_print_describe_comment (output_ctx, constraint->comment);
+	    }
+
+	  output_ctx (";\n");
 	}
     }
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25300

* this is backport of #5121 to release/11.0
* Added comment to reverse unique
