### PR TITLE
[CBRD-25297] building Java type import list at code generation stage

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -1052,8 +1052,7 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
         }
 
         throw new SemanticError(
-                Misc.getLineColumnOf(ctx),
-                "AUTONOMOUS_TRANSACTION is not supported yet");
+                Misc.getLineColumnOf(ctx), "AUTONOMOUS_TRANSACTION is not supported yet");
 
         /*
         // just turn on the flag and return nothing

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -66,22 +66,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
         this.staticSqls = staticSqls;
     }
 
-    public void addToImports(String i) {
-
-        assert i != null;
-
-        if ("com.cubrid.plcsql.predefined.sp.SpLib.Query".equals(i)) {
-            // no need to import Cursor now
-        } else if (i.startsWith("java.lang.")
-                && i.lastIndexOf('.') == 9) { // 9:the index of the second '.'
-            // no need to import java.lang.*
-        } else if (i.startsWith("Null")) {
-            // NULL type is not a java type but an internal type for convenience in typechecking.
-        } else {
-            imports.add(i);
-        }
-    }
-
     public void askServerSemanticQuestions() {
         if (semanticQuestions.size() == 0) {
             return; // nothing to do
@@ -187,7 +171,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
                 Type retType =
                         DBTypeAdapter.getDeclType(
                                 fs.retType.type, fs.retType.prec, fs.retType.scale);
-                addToImports(retType.fullJavaType);
 
                 gfc.decl = new DeclFunc(null, fs.name, paramList, TypeSpec.getBogus(retType));
 
@@ -213,7 +196,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
                 Type ty =
                         DBTypeAdapter.getDeclType(
                                 ct.colType.type, ct.colType.prec, ct.colType.scale);
-                addToImports(ty.fullJavaType);
 
                 assert node instanceof TypeSpecPercent;
                 ((TypeSpecPercent) node).type = ty;
@@ -225,10 +207,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
 
     @Override
     public AstNode visitSql_script(Sql_scriptContext ctx) {
-
-        addToImports("com.cubrid.jsp.Server");
-        addToImports("com.cubrid.plcsql.predefined.PlcsqlRuntimeError");
-        addToImports("java.util.List");
 
         AstNode ret = visitCreate_routine(ctx.create_routine());
 
@@ -358,7 +336,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
             throw new RuntimeException("unreachable");
         }
 
-        addToImports("java.math.BigDecimal");
         return new TypeSpec(ctx, TypeNumeric.getInstance(precision, scale));
     }
 
@@ -409,7 +386,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
         String plcType = Misc.getNormalizedText(ctx);
         Type ty = nameToType.get(plcType);
         assert ty != null;
-        addToImports(ty.fullJavaType);
         return new TypeSpec(ctx, ty);
     }
 
@@ -637,7 +613,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
 
     @Override
     public ExprDate visitDate_exp(Date_expContext ctx) {
-        addToImports("java.sql.Date");
 
         String s = ctx.quoted_string().getText();
         s = unquoteStr(s);
@@ -653,7 +628,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
 
     @Override
     public ExprTime visitTime_exp(Time_expContext ctx) {
-        addToImports("java.sql.Time");
 
         String s = ctx.quoted_string().getText();
         s = unquoteStr(s);
@@ -669,7 +643,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
 
     @Override
     public ExprTimestamp visitTimestamp_exp(Timestamp_expContext ctx) {
-        addToImports("java.sql.Timestamp");
 
         String s = ctx.quoted_string().getText();
         return parseZonedDateTime(ctx, s, false, "TIMESTAMP");
@@ -677,7 +650,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
 
     @Override
     public ExprDatetime visitDatetime_exp(Datetime_expContext ctx) {
-        addToImports("java.sql.Timestamp");
 
         String s = ctx.quoted_string().getText();
         s = unquoteStr(s);
@@ -733,7 +705,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
                             Misc.getLineColumnOf(ctx), // s006
                             "number of digits of an integer literal may not exceed 38");
                 }
-                addToImports("java.math.BigDecimal");
                 ty = Type.NUMERIC_ANY;
             } else if (bi.compareTo(INT_MAX) > 0 || bi.compareTo(INT_MIN) < 0) {
                 ty = Type.BIGINT;
@@ -751,7 +722,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     @Override
     public ExprFloat visitFp_num_exp(Fp_num_expContext ctx) {
         try {
-            addToImports("java.math.BigDecimal");
 
             String text = ctx.FLOATING_POINT_NUM().getText().toLowerCase();
 
@@ -830,8 +800,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
                         || fieldName.equals("NEXTVAL")) {
 
                     connectionRequired = true;
-                    addToImports("java.sql.*");
-                    addToImports("java.math.BigDecimal");
 
                     String recordText = Misc.getNormalizedText(ctx.record);
                     // do not push a symbol table: no nested structure
@@ -864,7 +832,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
         if (decl == null) {
 
             connectionRequired = true;
-            addToImports("java.sql.*");
 
             ExprGlobalFuncCall ret = new ExprGlobalFuncCall(ctx, name, args);
             semanticQuestions.put(ret, new ServerAPI.FunctionSignature(name));
@@ -879,7 +846,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
                 }
 
                 connectionRequired = true;
-                addToImports("java.sql.*");
                 return new ExprBuiltinFuncCall(ctx, name, args);
             } else {
                 if (decl.paramList.nodes.size() != args.nodes.size()) {
@@ -1015,7 +981,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     @Override
     public Expr visitList_exp(List_expContext ctx) {
         NodeList<Expr> elems = visitExpressions(ctx.expressions());
-        addToImports("java.util.Arrays");
         return new ExprList(ctx, elems);
     }
      */
@@ -1140,7 +1105,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     public AstNode visitCursor_definition(Cursor_definitionContext ctx) {
 
         connectionRequired = true;
-        addToImports("java.sql.*");
 
         String name = Misc.getNormalizedText(ctx.identifier());
 
@@ -1320,7 +1284,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
             // this is possibly a global function call
 
             connectionRequired = true;
-            addToImports("java.sql.*");
 
             Expr ret = new ExprGlobalFuncCall(ctx, name, EMPTY_ARGS);
             semanticQuestions.put(ret, new ServerAPI.FunctionSignature(name));
@@ -1336,7 +1299,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
             } else if (decl instanceof DeclFunc) {
                 if (decl.scope().level == SymbolStack.LEVEL_PREDEFINED) {
                     connectionRequired = true;
-                    addToImports("java.sql.*");
                     return new ExprBuiltinFuncCall(ctx, name, EMPTY_ARGS);
                 } else {
                     return new ExprLocalFuncCall(ctx, name, EMPTY_ARGS, scope, (DeclFunc) decl);
@@ -1553,7 +1515,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     public AstNode visitStmt_for_cursor_loop(Stmt_for_cursor_loopContext ctx) {
 
         connectionRequired = true;
-        addToImports("java.sql.*");
 
         symbolStack.pushSymbolTable("for_cursor_loop", null);
 
@@ -1605,7 +1566,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     public StmtForSqlLoop visitStmt_for_static_sql_loop(Stmt_for_static_sql_loopContext ctx) {
 
         connectionRequired = true;
-        addToImports("java.sql.*");
 
         symbolStack.pushSymbolTable("for_s_sql_loop", null);
 
@@ -1653,7 +1613,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     public StmtForSqlLoop visitStmt_for_dynamic_sql_loop(Stmt_for_dynamic_sql_loopContext ctx) {
 
         connectionRequired = true;
-        addToImports("java.sql.*");
 
         symbolStack.pushSymbolTable("for_d_sql_loop", null);
 
@@ -1794,10 +1753,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
 
         symbolStack.popSymbolTable();
 
-        if (whenParts.nodes.size() > 0) {
-            addToImports("java.util.Objects");
-        }
-
         controlFlowBlocked = allFlowsBlocked; // s017-6
         return new StmtCase(ctx, level, selector, whenParts, elsePart);
     }
@@ -1843,7 +1798,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     public StmtStaticSql visitStatic_sql(Static_sqlContext ctx) {
 
         connectionRequired = true;
-        addToImports("java.sql.*");
         SqlSemantics sws = staticSqls.get(ctx);
         assert sws != null;
         StaticSql staticSql = checkAndConvertStaticSql(sws, ctx);
@@ -1870,7 +1824,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     public AstNode visitClose_statement(Close_statementContext ctx) {
 
         connectionRequired = true;
-        addToImports("java.sql.*");
 
         IdentifierContext idCtx = ctx.cursor_exp().identifier();
 
@@ -1889,7 +1842,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     public AstNode visitOpen_statement(Open_statementContext ctx) {
 
         connectionRequired = true;
-        addToImports("java.sql.*");
 
         IdentifierContext idCtx = ctx.cursor_exp().identifier();
 
@@ -1933,7 +1885,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     public AstNode visitFetch_statement(Fetch_statementContext ctx) {
 
         connectionRequired = true;
-        addToImports("java.sql.*");
 
         IdentifierContext idCtx = ctx.cursor_exp().identifier();
         ExprId cursor = visitNonFuncIdentifier(idCtx); // s037: undeclared id ...
@@ -1979,7 +1930,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     public AstNode visitOpen_for_statement(Open_for_statementContext ctx) {
 
         connectionRequired = true;
-        addToImports("java.sql.*");
 
         ExprId refCursor = visitNonFuncIdentifier(ctx.identifier()); // s040: undeclared id ...
         if (!isAssignableTo(refCursor)) {
@@ -2009,14 +1959,12 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     @Override
     public StmtCommit visitCommit_statement(Commit_statementContext ctx) {
         connectionRequired = true;
-        addToImports("java.sql.*");
         return new StmtCommit(ctx);
     }
 
     @Override
     public StmtRollback visitRollback_statement(Rollback_statementContext ctx) {
         connectionRequired = true;
-        addToImports("java.sql.*");
         return new StmtRollback(ctx);
     }
 
@@ -2041,7 +1989,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
         if (decl == null) {
 
             connectionRequired = true;
-            addToImports("java.sql.*");
 
             StmtGlobalProcCall ret = new StmtGlobalProcCall(ctx, name, args);
             semanticQuestions.put(ret, new ServerAPI.ProcedureSignature(name));
@@ -2085,7 +2032,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     public StmtSql visitExecute_immediate(Execute_immediateContext ctx) {
 
         connectionRequired = true;
-        addToImports("java.sql.*");
 
         Expr dynSql = visitExpression(ctx.dyn_sql().expression());
 
@@ -2447,7 +2393,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
                     }
 
                     ExprAutoParam autoParam = new ExprAutoParam(ctx, pi.value, pi.type);
-                    addToImports(DBTypeAdapter.getValueType(pi.type).fullJavaType);
                     hostExprs.put(
                             autoParam,
                             null); // null: type check is not necessary for auto parameters
@@ -2577,7 +2522,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
 
             Type paramType =
                     DBTypeAdapter.getDeclType(params[i].type, params[i].prec, params[i].scale);
-            addToImports(paramType.fullJavaType);
 
             TypeSpec tySpec = TypeSpec.getBogus(paramType);
             if ((params[i].mode & ServerConstants.PARAM_MODE_OUT) != 0) {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -1051,9 +1051,15 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
                     "AUTONOMOUS_TRANSACTION can only be declared at the top level");
         }
 
+        throw new SemanticError(
+                Misc.getLineColumnOf(ctx),
+                "AUTONOMOUS_TRANSACTION is not supported yet");
+
+        /*
         // just turn on the flag and return nothing
         autonomousTransaction = true;
         return null;
+         */
     }
 
     @Override

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprAutoParam.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprAutoParam.java
@@ -41,6 +41,7 @@ import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.util.Set;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.apache.commons.text.StringEscapeUtils;
 
@@ -65,7 +66,7 @@ public class ExprAutoParam extends Expr {
         return DBTypeAdapter.getValueType(ty);
     }
 
-    public String javaCode() {
+    public String javaCode(Set<String> javaTypesUsed) {
 
         if (ty == DBType.DB_NULL) {
             return "null";
@@ -97,6 +98,7 @@ public class ExprAutoParam extends Expr {
                 return String.format("new Long(%sL)", javaObj);
             case DBType.DB_NUMERIC:
                 assert javaObj instanceof BigDecimal;
+                javaTypesUsed.add("java.math.BigDecimal");
                 return String.format("new BigDecimal(\"%s\")", javaObj);
             case DBType.DB_FLOAT:
                 assert javaObj instanceof Float;
@@ -106,13 +108,16 @@ public class ExprAutoParam extends Expr {
                 return String.format("new Double(%s)", javaObj);
             case DBType.DB_DATE:
                 assert javaObj instanceof Date;
+                javaTypesUsed.add("java.sql.Date");
                 return String.format("Date.valueOf(\"%s\")", javaObj);
             case DBType.DB_TIME:
                 assert javaObj instanceof Time;
+                javaTypesUsed.add("java.sql.Time");
                 return String.format("Time.valueOf(\"%s\")", javaObj);
             case DBType.DB_DATETIME:
             case DBType.DB_TIMESTAMP:
                 assert javaObj instanceof Timestamp;
+                javaTypesUsed.add("java.sql.Timestamp");
                 return String.format("Timestamp.valueOf(\"%s\")", javaObj);
             default:
                 assert false : "unreachable";

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprDate.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprDate.java
@@ -33,6 +33,7 @@ package com.cubrid.plcsql.compiler.ast;
 import com.cubrid.jsp.value.DateTimeParser;
 import com.cubrid.plcsql.compiler.visitor.AstVisitor;
 import java.time.LocalDate;
+import java.util.Set;
 import org.antlr.v4.runtime.ParserRuleContext;
 
 public class ExprDate extends Expr {
@@ -50,7 +51,10 @@ public class ExprDate extends Expr {
         this.date = date;
     }
 
-    public String javaCode() {
+    public String javaCode(Set<String> javaTypesUsed) {
+
+        javaTypesUsed.add("java.sql.Date");
+
         if (date.equals(DateTimeParser.nullDate)) {
             return "new Date(0 - 1900, 0 - 1, 0)";
         } else {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprDatetime.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprDatetime.java
@@ -33,6 +33,7 @@ package com.cubrid.plcsql.compiler.ast;
 import com.cubrid.jsp.value.DateTimeParser;
 import com.cubrid.plcsql.compiler.visitor.AstVisitor;
 import java.time.LocalDateTime;
+import java.util.Set;
 import org.antlr.v4.runtime.ParserRuleContext;
 
 public class ExprDatetime extends Expr {
@@ -50,7 +51,10 @@ public class ExprDatetime extends Expr {
         this.time = time;
     }
 
-    public String javaCode() {
+    public String javaCode(Set<String> javaTypesUsed) {
+
+        javaTypesUsed.add("java.sql.Timestamp");
+
         if (time.equals(DateTimeParser.nullDatetime)) {
             return "new Timestamp(0 - 1900, 0 - 1, 0, 0, 0, 0, 0)";
             // server

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprField.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprField.java
@@ -33,6 +33,7 @@ package com.cubrid.plcsql.compiler.ast;
 import com.cubrid.plcsql.compiler.type.Type;
 import com.cubrid.plcsql.compiler.visitor.AstVisitor;
 import org.antlr.v4.runtime.ParserRuleContext;
+import java.util.Set;
 
 public class ExprField extends Expr {
 
@@ -59,13 +60,14 @@ public class ExprField extends Expr {
         this.fieldName = fieldName;
     }
 
-    public String javaCode() {
+    public String javaCode(Set<String> javaTypesUsed) {
 
         if (colIndex > 0) {
 
             // record is for a Static SQL
             //
             assert type != null;
+            javaTypesUsed.add(type.fullJavaType);
             return String.format(
                     "(%s) getFieldWithIndex(%s, %d)", type.javaCode, record.javaCode(), colIndex);
         } else {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprField.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprField.java
@@ -32,8 +32,8 @@ package com.cubrid.plcsql.compiler.ast;
 
 import com.cubrid.plcsql.compiler.type.Type;
 import com.cubrid.plcsql.compiler.visitor.AstVisitor;
-import org.antlr.v4.runtime.ParserRuleContext;
 import java.util.Set;
+import org.antlr.v4.runtime.ParserRuleContext;
 
 public class ExprField extends Expr {
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprFloat.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprFloat.java
@@ -32,8 +32,8 @@ package com.cubrid.plcsql.compiler.ast;
 
 import com.cubrid.plcsql.compiler.type.Type;
 import com.cubrid.plcsql.compiler.visitor.AstVisitor;
-import org.antlr.v4.runtime.ParserRuleContext;
 import java.util.Set;
+import org.antlr.v4.runtime.ParserRuleContext;
 
 public class ExprFloat extends Expr {
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprFloat.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprFloat.java
@@ -33,6 +33,7 @@ package com.cubrid.plcsql.compiler.ast;
 import com.cubrid.plcsql.compiler.type.Type;
 import com.cubrid.plcsql.compiler.visitor.AstVisitor;
 import org.antlr.v4.runtime.ParserRuleContext;
+import java.util.Set;
 
 public class ExprFloat extends Expr {
 
@@ -51,13 +52,14 @@ public class ExprFloat extends Expr {
         this.ty = ty;
     }
 
-    public String javaCode() {
+    public String javaCode(Set<String> javaTypesUsed) {
         switch (ty.idx) {
             case Type.IDX_DOUBLE:
                 return "new Double(\"" + val + "\")";
             case Type.IDX_FLOAT:
                 return "new Float(\"" + val + "\")";
             case Type.IDX_NUMERIC:
+                javaTypesUsed.add("java.math.BigDecimal");
                 return "new BigDecimal(\"" + val + "\")";
             default:
                 throw new RuntimeException("unreachable");

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprTime.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprTime.java
@@ -32,6 +32,7 @@ package com.cubrid.plcsql.compiler.ast;
 
 import com.cubrid.plcsql.compiler.visitor.AstVisitor;
 import java.time.LocalTime;
+import java.util.Set;
 import org.antlr.v4.runtime.ParserRuleContext;
 
 public class ExprTime extends Expr {
@@ -49,7 +50,8 @@ public class ExprTime extends Expr {
         this.time = time;
     }
 
-    public String javaCode() {
+    public String javaCode(Set<String> javaTypesUsed) {
+        javaTypesUsed.add("java.sql.Time");
         return String.format(
                 "new Time(%d, %d, %d)", time.getHour(), time.getMinute(), time.getSecond());
     }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprTimestamp.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprTimestamp.java
@@ -33,6 +33,7 @@ package com.cubrid.plcsql.compiler.ast;
 import com.cubrid.jsp.value.DateTimeParser;
 import com.cubrid.plcsql.compiler.visitor.AstVisitor;
 import java.time.ZonedDateTime;
+import java.util.Set;
 import org.antlr.v4.runtime.ParserRuleContext;
 
 public class ExprTimestamp extends Expr {
@@ -52,7 +53,9 @@ public class ExprTimestamp extends Expr {
         this.originType = originType;
     }
 
-    public String javaCode() {
+    public String javaCode(Set<String> javaTypesUsed) {
+
+        javaTypesUsed.add("java.sql.Timestamp");
 
         if (time.equals(DateTimeParser.nullDatetimeUTC)) {
             return "new Timestamp(0 - 1900, 0 - 1, 0, 0, 0, 0, 0)";

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprUint.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprUint.java
@@ -32,8 +32,8 @@ package com.cubrid.plcsql.compiler.ast;
 
 import com.cubrid.plcsql.compiler.type.Type;
 import com.cubrid.plcsql.compiler.visitor.AstVisitor;
-import org.antlr.v4.runtime.ParserRuleContext;
 import java.util.Set;
+import org.antlr.v4.runtime.ParserRuleContext;
 
 public class ExprUint extends Expr {
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprUint.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprUint.java
@@ -33,6 +33,7 @@ package com.cubrid.plcsql.compiler.ast;
 import com.cubrid.plcsql.compiler.type.Type;
 import com.cubrid.plcsql.compiler.visitor.AstVisitor;
 import org.antlr.v4.runtime.ParserRuleContext;
+import java.util.Set;
 
 public class ExprUint extends Expr {
 
@@ -51,9 +52,10 @@ public class ExprUint extends Expr {
         this.ty = ty;
     }
 
-    public String javaCode() {
+    public String javaCode(Set<String> javaTypesUsed) {
         switch (ty.idx) {
             case Type.IDX_NUMERIC:
+                javaTypesUsed.add("java.math.BigDecimal");
                 return "new BigDecimal(\"" + val + "\")";
             case Type.IDX_BIGINT:
                 return "new Long(" + val + "L)";

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -46,12 +46,12 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
 
     private Set<String> javaTypesUsed = new HashSet<>();
 
-    private void addToImports(String fullJavaType) {
+    private void addToImports(String fullJavaType) {}
 
-    }
     private String getJavaCodeOfType(TypeSpec tySpec) {
         return getJavaCodeOfType(tySpec.type);
     }
+
     private String getJavaCodeOfType(Type type) {
         javaTypesUsed.add(type.fullJavaType);
         return type.javaCode;
@@ -155,7 +155,10 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                                 visitNodeList(node.routine.decls));
 
         // return type
-        String strRetType = node.routine.retTypeSpec == null ? "void" : getJavaCodeOfType(node.routine.retTypeSpec);
+        String strRetType =
+                node.routine.retTypeSpec == null
+                        ? "void"
+                        : getJavaCodeOfType(node.routine.retTypeSpec);
 
         // parameters
         Object strParamArr =
@@ -170,17 +173,20 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
         CodeToResolve bodyCode = visit(node.routine.body);
 
         // imports
-        // CAUTION: importsArray must be made after visiting all the subnodes of this Unit node because javaTypesUsed,
-        //  which is the set of Java types to appear in the generated Java code, is built while visiting the submodes
+        // CAUTION: importsArray must be made after visiting all the subnodes of this Unit node
+        // because javaTypesUsed,
+        //  which is the set of Java types to appear in the generated Java code, is built while
+        // visiting the submodes
         int i = 0;
         String[] importsArray = new String[javaTypesUsed.size()];
-        for (String javaType: javaTypesUsed) {
+        for (String javaType : javaTypesUsed) {
             if ("com.cubrid.plcsql.predefined.sp.SpLib.Query".equals(javaType)) {
                 // no need to import Cursor now
             } else if (javaType.startsWith("java.lang.") && javaType.lastIndexOf('.') == 9) {
                 // no need to import java.lang.*;
             } else if (javaType.startsWith("Null")) {
-                // NULL type is not a java type but an internal type for convenience in typechecking.
+                // NULL type is not a java type but an internal type for convenience in
+                // typechecking.
             } else {
                 importsArray[i] = "import " + javaType + ";";
                 i++;
@@ -559,7 +565,9 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
     @Override
     public CodeToResolve visitExprDate(ExprDate node) {
 
-        CodeTemplate tmpl = new CodeTemplate("ExprDate", Misc.UNKNOWN_LINE_COLUMN, node.javaCode(javaTypesUsed));
+        CodeTemplate tmpl =
+                new CodeTemplate(
+                        "ExprDate", Misc.UNKNOWN_LINE_COLUMN, node.javaCode(javaTypesUsed));
         return applyCoercion(node.coercion, tmpl);
     }
 
@@ -567,7 +575,8 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
     public CodeToResolve visitExprDatetime(ExprDatetime node) {
 
         CodeTemplate tmpl =
-                new CodeTemplate("ExprDatetime", Misc.UNKNOWN_LINE_COLUMN, node.javaCode(javaTypesUsed));
+                new CodeTemplate(
+                        "ExprDatetime", Misc.UNKNOWN_LINE_COLUMN, node.javaCode(javaTypesUsed));
         return applyCoercion(node.coercion, tmpl);
     }
 
@@ -582,7 +591,9 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
     @Override
     public CodeToResolve visitExprField(ExprField node) {
 
-        CodeTemplate tmpl = new CodeTemplate("ExprField", Misc.getLineColumnOf(node.ctx), node.javaCode(javaTypesUsed));
+        CodeTemplate tmpl =
+                new CodeTemplate(
+                        "ExprField", Misc.getLineColumnOf(node.ctx), node.javaCode(javaTypesUsed));
         return applyCoercion(node.coercion, tmpl);
     }
 
@@ -825,14 +836,17 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
 
     @Override
     public CodeToResolve visitExprUint(ExprUint node) {
-        CodeTemplate tmpl = new CodeTemplate("ExprUnit", Misc.UNKNOWN_LINE_COLUMN, node.javaCode(javaTypesUsed));
+        CodeTemplate tmpl =
+                new CodeTemplate(
+                        "ExprUnit", Misc.UNKNOWN_LINE_COLUMN, node.javaCode(javaTypesUsed));
         return applyCoercion(node.coercion, tmpl);
     }
 
     @Override
     public CodeToResolve visitExprFloat(ExprFloat node) {
         CodeTemplate tmpl =
-                new CodeTemplate("ExprFloat", Misc.UNKNOWN_LINE_COLUMN, node.javaCode(javaTypesUsed));
+                new CodeTemplate(
+                        "ExprFloat", Misc.UNKNOWN_LINE_COLUMN, node.javaCode(javaTypesUsed));
         return applyCoercion(node.coercion, tmpl);
     }
 
@@ -902,7 +916,9 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
     @Override
     public CodeToResolve visitExprTime(ExprTime node) {
 
-        CodeTemplate tmpl = new CodeTemplate("ExprTime", Misc.UNKNOWN_LINE_COLUMN, node.javaCode(javaTypesUsed));
+        CodeTemplate tmpl =
+                new CodeTemplate(
+                        "ExprTime", Misc.UNKNOWN_LINE_COLUMN, node.javaCode(javaTypesUsed));
         return applyCoercion(node.coercion, tmpl);
     }
 
@@ -940,7 +956,8 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
     public CodeToResolve visitExprTimestamp(ExprTimestamp node) {
 
         CodeTemplate tmpl =
-                new CodeTemplate("ExprTimestamp", Misc.UNKNOWN_LINE_COLUMN, node.javaCode(javaTypesUsed));
+                new CodeTemplate(
+                        "ExprTimestamp", Misc.UNKNOWN_LINE_COLUMN, node.javaCode(javaTypesUsed));
         return applyCoercion(node.coercion, tmpl);
     }
 
@@ -948,7 +965,8 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
     public CodeToResolve visitExprAutoParam(ExprAutoParam node) {
 
         CodeTemplate tmpl =
-                new CodeTemplate("ExprAutoParam", Misc.UNKNOWN_LINE_COLUMN, node.javaCode(javaTypesUsed));
+                new CodeTemplate(
+                        "ExprAutoParam", Misc.UNKNOWN_LINE_COLUMN, node.javaCode(javaTypesUsed));
         return applyCoercion(node.coercion, tmpl);
     }
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -44,10 +44,27 @@ import java.util.Set;
 
 public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
 
+    private Set<String> javaTypesUsed = new HashSet<>();
+
+    private void addToImports(String fullJavaType) {
+
+    }
+    private String getJavaCodeOfType(TypeSpec tySpec) {
+        return getJavaCodeOfType(tySpec.type);
+    }
+    private String getJavaCodeOfType(Type type) {
+        javaTypesUsed.add(type.fullJavaType);
+        return type.javaCode;
+    }
+
     public List<String> codeLines = new ArrayList<>(); // no LinkedList : frequent access by indexes
     public StringBuilder codeRangeMarkers = new StringBuilder();
 
     public String buildCodeLines(Unit unit) {
+
+        javaTypesUsed.add("com.cubrid.jsp.Server");
+        javaTypesUsed.add("com.cubrid.plcsql.predefined.PlcsqlRuntimeError");
+        javaTypesUsed.add("java.util.List");
 
         CodeToResolve ctr = visitUnit(unit);
         ctr.resolve(0, codeLines, codeRangeMarkers);
@@ -60,6 +77,8 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
 
         return String.join("\n", codeLines.toArray(DUMMY_STRING_ARRAY));
     }
+
+    // -----------------------------------------------------------------
 
     @Override
     public <E extends AstNode> CodeTemplateList visitNodeList(NodeList<E> nodeList) {
@@ -112,6 +131,10 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
     @Override
     public CodeToResolve visitUnit(Unit node) {
 
+        if (node.connectionRequired) {
+            javaTypesUsed.add("java.sql.*");
+        }
+
         // get connection, if necessary
         String strGetConn =
                 node.connectionRequired
@@ -131,12 +154,8 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                                 "%'+DECLARATIONS'%",
                                 visitNodeList(node.routine.decls));
 
-        // imports
-        String[] importsArray = node.getImportsArray();
-        int len = importsArray.length;
-        for (int i = 0; i < len; i++) {
-            importsArray[i] = "import " + importsArray[i] + ";";
-        }
+        // return type
+        String strRetType = node.routine.retTypeSpec == null ? "void" : getJavaCodeOfType(node.routine.retTypeSpec);
 
         // parameters
         Object strParamArr =
@@ -147,6 +166,28 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
         // nullify OUT parameters
         String[] strNullifyOutParam = getNullifyOutParamCode(node.routine.paramList);
 
+        // body
+        CodeToResolve bodyCode = visit(node.routine.body);
+
+        // imports
+        // CAUTION: importsArray must be made after visiting all the subnodes of this Unit node because javaTypesUsed,
+        //  which is the set of Java types to appear in the generated Java code, is built while visiting the submodes
+        int i = 0;
+        String[] importsArray = new String[javaTypesUsed.size()];
+        for (String javaType: javaTypesUsed) {
+            if ("com.cubrid.plcsql.predefined.sp.SpLib.Query".equals(javaType)) {
+                // no need to import Cursor now
+            } else if (javaType.startsWith("java.lang.") && javaType.lastIndexOf('.') == 9) {
+                // no need to import java.lang.*;
+            } else if (javaType.startsWith("Null")) {
+                // NULL type is not a java type but an internal type for convenience in typechecking.
+            } else {
+                importsArray[i] = "import " + javaType + ";";
+                i++;
+            }
+        }
+        importsArray = Arrays.copyOf(importsArray, i);
+
         return new CodeTemplate(
                 "Unit",
                 new int[] {1, 1},
@@ -156,7 +197,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 "%'CLASS-NAME'%",
                 node.getClassName(),
                 "%'RETURN-TYPE'%",
-                node.routine.retTypeSpec == null ? "void" : node.routine.retTypeSpec.type.javaCode,
+                strRetType,
                 "%'METHOD-NAME'%",
                 node.routine.name,
                 "%'+PARAMETERS'%",
@@ -168,7 +209,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 "%'+DECL-CLASS'%",
                 codeDeclClass,
                 "%'+BODY'%",
-                visit(node.routine.body));
+                bodyCode);
     }
 
     // -----------------------------------------------------------------
@@ -210,7 +251,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 Misc.UNKNOWN_LINE_COLUMN,
                 tmplDeclRoutine,
                 "%'RETURN-TYPE'%",
-                node.retTypeSpec == null ? "void" : node.retTypeSpec.type.javaCode,
+                node.retTypeSpec == null ? "void" : getJavaCodeOfType(node.retTypeSpec),
                 "%'+PARAMETERS'%",
                 visitNodeList(node.paramList).setDelimiter(","),
                 "%'+NULLIFY-OUT-PARAMETERS'%",
@@ -235,13 +276,13 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
 
     @Override
     public CodeToResolve visitDeclParamIn(DeclParamIn node) {
-        String code = String.format("%s %s", node.typeSpec.type.javaCode, node.name);
+        String code = String.format("%s %s", getJavaCodeOfType(node.typeSpec), node.name);
         return new CodeTemplate("DeclParamIn", Misc.UNKNOWN_LINE_COLUMN, code);
     }
 
     @Override
     public CodeToResolve visitDeclParamOut(DeclParamOut node) {
-        String code = String.format("%s[] %s", node.typeSpec.type.javaCode, node.name);
+        String code = String.format("%s[] %s", getJavaCodeOfType(node.typeSpec), node.name);
         return new CodeTemplate("DeclParamOut", Misc.UNKNOWN_LINE_COLUMN, code);
     }
 
@@ -260,7 +301,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
     @Override
     public CodeToResolve visitDeclVar(DeclVar node) {
 
-        String ty = node.typeSpec.type.javaCode;
+        String ty = getJavaCodeOfType(node.typeSpec);
         if (node.val == null) {
             String code = String.format("%s[] %s = new %s[] { null };", ty, node.name, ty);
             return new CodeTemplate("DeclVar", Misc.UNKNOWN_LINE_COLUMN, code);
@@ -298,7 +339,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 node.notNull ? Misc.getLineColumnOf(node.ctx) : Misc.UNKNOWN_LINE_COLUMN,
                 node.notNull ? tmplNotNullConst : tmplNullableConst,
                 "%'TYPE'%",
-                node.typeSpec.type.javaCode,
+                getJavaCodeOfType(node.typeSpec),
                 "%'NAME'%",
                 node.name,
                 "%'+VAL'%",
@@ -425,7 +466,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                             Misc.UNKNOWN_LINE_COLUMN,
                             tmplExprCase,
                             "%'SELECTOR-TYPE'%",
-                            node.selectorType.javaCode,
+                            getJavaCodeOfType(node.selectorType),
                             "%'+SELECTOR-VALUE'%",
                             visit(node.selector),
                             "%'+WHEN-PARTS'%",
@@ -433,7 +474,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                             "%'+ELSE-PART'%",
                             node.elsePart == null ? "null" : visit(node.elsePart),
                             "%'RESULT-TYPE'%",
-                            node.resultType.javaCode);
+                            getJavaCodeOfType(node.resultType));
         }
 
         return applyCoercion(node.coercion, tmpl);
@@ -505,7 +546,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                             "%'CURSOR'%",
                             node.id.javaCode(),
                             "%'JAVA-TYPE'%",
-                            node.attr.ty.javaCode,
+                            getJavaCodeOfType(node.attr.ty),
                             "%'SUBMSG'%",
                             "tried to retrieve an attribute from an unopened SYS_REFCURSOR",
                             "%'METHOD'%",
@@ -518,7 +559,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
     @Override
     public CodeToResolve visitExprDate(ExprDate node) {
 
-        CodeTemplate tmpl = new CodeTemplate("ExprDate", Misc.UNKNOWN_LINE_COLUMN, node.javaCode());
+        CodeTemplate tmpl = new CodeTemplate("ExprDate", Misc.UNKNOWN_LINE_COLUMN, node.javaCode(javaTypesUsed));
         return applyCoercion(node.coercion, tmpl);
     }
 
@@ -526,7 +567,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
     public CodeToResolve visitExprDatetime(ExprDatetime node) {
 
         CodeTemplate tmpl =
-                new CodeTemplate("ExprDatetime", Misc.UNKNOWN_LINE_COLUMN, node.javaCode());
+                new CodeTemplate("ExprDatetime", Misc.UNKNOWN_LINE_COLUMN, node.javaCode(javaTypesUsed));
         return applyCoercion(node.coercion, tmpl);
     }
 
@@ -541,8 +582,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
     @Override
     public CodeToResolve visitExprField(ExprField node) {
 
-        CodeTemplate tmpl =
-                new CodeTemplate("ExprField", Misc.getLineColumnOf(node.ctx), node.javaCode());
+        CodeTemplate tmpl = new CodeTemplate("ExprField", Misc.getLineColumnOf(node.ctx), node.javaCode(javaTypesUsed));
         return applyCoercion(node.coercion, tmpl);
     }
 
@@ -595,7 +635,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                         "%'DYNAMIC-SQL'%",
                         dynSql,
                         "%'RETURN-TYPE'%",
-                        node.decl.retTypeSpec.type.javaCode,
+                        getJavaCodeOfType(node.decl.retTypeSpec),
                         "%'PARAMETERS'%",
                         wrapperParam,
                         "%'+SET-GLOBAL-FUNC-ARGS'%",
@@ -685,7 +725,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
 
         assert node.args != null;
         assert node.resultType != null;
-        String ty = node.resultType.javaCode;
+        String ty = getJavaCodeOfType(node.resultType);
 
         CodeTemplate tmpl;
 
@@ -756,7 +796,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                         "%'FUNC-NAME'%",
                         node.name,
                         "%'RETURN-TYPE'%",
-                        node.decl.retTypeSpec.type.javaCode,
+                        getJavaCodeOfType(node.decl.retTypeSpec),
                         "%'PARAMETERS'%",
                         wrapperParam,
                         "%'+ALLOC-COERCED-OUT-ARGS'%",
@@ -785,14 +825,14 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
 
     @Override
     public CodeToResolve visitExprUint(ExprUint node) {
-        CodeTemplate tmpl = new CodeTemplate("ExprUnit", Misc.UNKNOWN_LINE_COLUMN, node.javaCode());
+        CodeTemplate tmpl = new CodeTemplate("ExprUnit", Misc.UNKNOWN_LINE_COLUMN, node.javaCode(javaTypesUsed));
         return applyCoercion(node.coercion, tmpl);
     }
 
     @Override
     public CodeToResolve visitExprFloat(ExprFloat node) {
         CodeTemplate tmpl =
-                new CodeTemplate("ExprFloat", Misc.UNKNOWN_LINE_COLUMN, node.javaCode());
+                new CodeTemplate("ExprFloat", Misc.UNKNOWN_LINE_COLUMN, node.javaCode(javaTypesUsed));
         return applyCoercion(node.coercion, tmpl);
     }
 
@@ -862,7 +902,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
     @Override
     public CodeToResolve visitExprTime(ExprTime node) {
 
-        CodeTemplate tmpl = new CodeTemplate("ExprTime", Misc.UNKNOWN_LINE_COLUMN, node.javaCode());
+        CodeTemplate tmpl = new CodeTemplate("ExprTime", Misc.UNKNOWN_LINE_COLUMN, node.javaCode(javaTypesUsed));
         return applyCoercion(node.coercion, tmpl);
     }
 
@@ -900,7 +940,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
     public CodeToResolve visitExprTimestamp(ExprTimestamp node) {
 
         CodeTemplate tmpl =
-                new CodeTemplate("ExprTimestamp", Misc.UNKNOWN_LINE_COLUMN, node.javaCode());
+                new CodeTemplate("ExprTimestamp", Misc.UNKNOWN_LINE_COLUMN, node.javaCode(javaTypesUsed));
         return applyCoercion(node.coercion, tmpl);
     }
 
@@ -908,7 +948,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
     public CodeToResolve visitExprAutoParam(ExprAutoParam node) {
 
         CodeTemplate tmpl =
-                new CodeTemplate("ExprAutoParam", Misc.UNKNOWN_LINE_COLUMN, node.javaCode());
+                new CodeTemplate("ExprAutoParam", Misc.UNKNOWN_LINE_COLUMN, node.javaCode(javaTypesUsed));
         return applyCoercion(node.coercion, tmpl);
     }
 
@@ -1059,7 +1099,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 Misc.getLineColumnOf(node.ctx),
                 tmplStmtCase,
                 "%'SELECTOR-TYPE'%",
-                node.selectorType.javaCode,
+                getJavaCodeOfType(node.selectorType),
                 "%'+SELECTOR-VALUE'%",
                 visit(node.selector),
                 "%'+WHEN-PARTS'%",
@@ -1140,7 +1180,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 "}"
             };
 
-    private static String[] getSetIntoVarsCode(StmtCursorFetch node) {
+    private String[] getSetIntoVarsCode(StmtCursorFetch node) {
 
         List<String> ret = new LinkedList<>();
 
@@ -1157,7 +1197,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 resultStr =
                         String.format(
                                 "(%s) rs.getObject(%d)",
-                                node.columnTypeList.get(i).javaCode, i + 1);
+                                getJavaCodeOfType(node.columnTypeList.get(i)), i + 1);
             }
 
             Coercion c = node.coercions.get(i);
@@ -1321,7 +1361,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 resultStr =
                         String.format(
                                 "(%s) r%%'LEVEL'%%.getObject(%d)",
-                                node.columnTypeList.get(i).javaCode, i + 1);
+                                getJavaCodeOfType(node.columnTypeList.get(i)), i + 1);
             }
 
             Coercion c = node.coercions.get(i);
@@ -2321,7 +2361,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                         exprPlcsqlPos,
                         tmplCastCoercion,
                         "%'TYPE'%",
-                        cast.dst.javaCode,
+                        getJavaCodeOfType(cast.dst),
                         "%'+EXPR'%",
                         exprCode);
             } else if (c instanceof Coercion.Conversion) {
@@ -2413,7 +2453,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
         }
     }
 
-    private static String getCallWrapperParam(
+    private String getCallWrapperParam(
             int size, NodeList<Expr> args, NodeList<DeclParam> paramList) {
 
         if (size == 0) {
@@ -2435,9 +2475,9 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
             if (param instanceof DeclParamOut) {
                 ExprId id = (ExprId) args.nodes.get(i);
                 DeclIdTyped declId = (DeclIdTyped) id.decl;
-                sbuf.append(String.format("%s[] o%d", declId.typeSpec().type.javaCode, i));
+                sbuf.append(String.format("%s[] o%d", getJavaCodeOfType(declId.typeSpec()), i));
             } else {
-                sbuf.append(String.format("%s o%d", param.typeSpec.type.javaCode, i));
+                sbuf.append(String.format("%s o%d", getJavaCodeOfType(param.typeSpec), i));
             }
         }
 
@@ -2449,7 +2489,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
         String[] updateOutArgs;
     }
 
-    private static GlobalCallCodeSnippets getGlobalCallCodeSnippets(
+    private GlobalCallCodeSnippets getGlobalCallCodeSnippets(
             int size, int argOffset, NodeList<Expr> args, NodeList<DeclParam> paramList) {
 
         List<String> setArgs = new LinkedList<>();
@@ -2485,7 +2525,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 String outVal =
                         String.format(
                                 "(%s) stmt.getObject(%d)",
-                                param.typeSpec.type.javaCode, i + argOffset);
+                                getJavaCodeOfType(param.typeSpec), i + argOffset);
                 updateOutArgs.add(String.format("o%d[0] = %s;", i, cRev.javaCode(outVal)));
 
                 DeclId declId = id.decl;
@@ -2512,7 +2552,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
         String[] updateOutArgs;
     }
 
-    private static LocalCallCodeSnippets getLocalCallCodeSnippets(
+    private LocalCallCodeSnippets getLocalCallCodeSnippets(
             int size, NodeList<Expr> args, NodeList<DeclParam> paramList) {
 
         List<String> allocCoercedOutArgs = new LinkedList<>();
@@ -2539,7 +2579,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 if (c instanceof Coercion.Identity) {
                     argsToLocal.append("o" + i);
                 } else {
-                    String paramType = param.typeSpec.type.javaCode;
+                    String paramType = getJavaCodeOfType(param.typeSpec);
                     allocCoercedOutArgs.add(
                             String.format(
                                     "%s[] p%d = new %s[] { %s };",

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -46,8 +46,6 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
 
     private Set<String> javaTypesUsed = new HashSet<>();
 
-    private void addToImports(String fullJavaType) {}
-
     private String getJavaCodeOfType(TypeSpec tySpec) {
         return getJavaCodeOfType(tySpec.type);
     }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
@@ -483,7 +483,6 @@ public class TypeChecker extends AstVisitor<Type> {
                 assert found > 0;
                 node.setType(ret);
                 node.setColIndex(found);
-                ptConv.addToImports(ret.fullJavaType);
             }
         } else {
             // this record is for a dynamic SQL
@@ -605,7 +604,6 @@ public class TypeChecker extends AstVisitor<Type> {
             Type ret;
             if (DBTypeAdapter.isSupported(ci.type)) {
                 ret = DBTypeAdapter.getValueType(ci.type);
-                ptConv.addToImports(ret.fullJavaType);
             } else {
                 throw new SemanticError(
                         Misc.getLineColumnOf(node.ctx), // s233


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25297

. building Java type import list in earlier stages of compilation has been the cause of omitting required Java type imports by mistake. It should be near the Java code generated.
. a small update irrelevant to this issue is applied: semantic error "not supported yet" on autonomous transaction pragma.

