### PR TITLE
[CBRD-25304] Remove redundant condition in pgbuf_latch_bcb_upon_fix

### DIFF
--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -5720,15 +5720,9 @@ pgbuf_latch_bcb_upon_fix (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr, PGBUF_LAT
 	    {
 	      /* the caller is the holder of the buffer page */
 	      holder->fix_count++;
+
 	      /* holder->dirty_before_holder not changed */
-	      if (request_mode == PGBUF_LATCH_WRITE)
-		{
-		  holder->perf_stat.hold_has_write_latch = 1;
-		}
-	      else
-		{
-		  holder->perf_stat.hold_has_read_latch = 1;
-		}
+	      holder->perf_stat.hold_has_read_latch = 1;
 	    }
 #if defined(SERVER_MODE)
 	  else
@@ -5745,16 +5739,9 @@ pgbuf_latch_bcb_upon_fix (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr, PGBUF_LAT
 
 	      holder->fix_count = 1;
 	      holder->bufptr = bufptr;
-	      if (request_mode == PGBUF_LATCH_WRITE)
-		{
-		  holder->perf_stat.hold_has_write_latch = 1;
-		  holder->perf_stat.hold_has_read_latch = 0;
-		}
-	      else
-		{
-		  holder->perf_stat.hold_has_read_latch = 1;
-		  holder->perf_stat.hold_has_write_latch = 0;
-		}
+
+	      holder->perf_stat.hold_has_read_latch = 1;
+	      holder->perf_stat.hold_has_write_latch = 0;
 	      holder->perf_stat.dirtied_by_holder = 0;
 	      holder->perf_stat.dirty_before_hold = buf_is_dirty;
 	    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25304

Purpose

`request_mode` is checked redundantly when perf stat is updated