### PR TITLE
[CBRD-25305] Exclude the unused function heap_get_if_diff_chn from compilation.

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -7330,6 +7330,7 @@ heap_scancache_end_modify (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache)
     }
 }
 
+#if defined (ENABLE_UNUSED_FUNCTION)
 /*
  * heap_get_if_diff_chn () - Get specified object of the given slotted page when
  *                       its cache coherency number is different
@@ -7444,6 +7445,7 @@ heap_get_if_diff_chn (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, INT16 slotid, REC
 
   return scan;
 }
+#endif
 
 /*
  * heap_prepare_get_context () - Prepare for obtaining/processing heap object.

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -668,7 +668,7 @@ static int heap_scancache_end_internal (THREAD_ENTRY * thread_p, HEAP_SCANCACHE 
 #if defined (ENABLE_UNUSED_FUNCTION)
 static SCAN_CODE heap_get_if_diff_chn (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, INT16 slotid, RECDES * recdes,
 				       bool ispeeking, int chn, MVCC_SNAPSHOT * mvcc_snapshot);
-#endif /* #if defined (ENABLE_UNUSED_FUNCTION) */
+#endif /* ENABLE_UNUSED_FUNCTION */
 static int heap_estimate_avg_length (THREAD_ENTRY * thread_p, const HFID * hfid, int &avg_reclen);
 static int heap_get_capacity (THREAD_ENTRY * thread_p, const HFID * hfid, INT64 * num_recs, INT64 * num_recs_relocated,
 			      INT64 * num_recs_inovf, INT64 * num_pages, int *avg_freespace, int *avg_freespace_nolast,
@@ -7447,7 +7447,7 @@ heap_get_if_diff_chn (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, INT16 slotid, REC
 
   return scan;
 }
-#endif /* #if defined (ENABLE_UNUSED_FUNCTION) */
+#endif /* ENABLE_UNUSED_FUNCTION */
 
 /*
  * heap_prepare_get_context () - Prepare for obtaining/processing heap object.

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -665,8 +665,10 @@ static int heap_scancache_reset_modify (THREAD_ENTRY * thread_p, HEAP_SCANCACHE 
 static int heap_scancache_quick_start_internal (HEAP_SCANCACHE * scan_cache, const HFID * hfid);
 static int heap_scancache_quick_end (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache);
 static int heap_scancache_end_internal (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache, bool scan_state);
+#if defined (ENABLE_UNUSED_FUNCTION)
 static SCAN_CODE heap_get_if_diff_chn (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, INT16 slotid, RECDES * recdes,
 				       bool ispeeking, int chn, MVCC_SNAPSHOT * mvcc_snapshot);
+#endif /* #if defined (ENABLE_UNUSED_FUNCTION) */
 static int heap_estimate_avg_length (THREAD_ENTRY * thread_p, const HFID * hfid, int &avg_reclen);
 static int heap_get_capacity (THREAD_ENTRY * thread_p, const HFID * hfid, INT64 * num_recs, INT64 * num_recs_relocated,
 			      INT64 * num_recs_inovf, INT64 * num_pages, int *avg_freespace, int *avg_freespace_nolast,
@@ -7445,7 +7447,7 @@ heap_get_if_diff_chn (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, INT16 slotid, REC
 
   return scan;
 }
-#endif
+#endif /* #if defined (ENABLE_UNUSED_FUNCTION) */
 
 /*
  * heap_prepare_get_context () - Prepare for obtaining/processing heap object.


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25305

Purpose
Mark and exclude the unused function heap_get_if_diff_chn ( ... ) from compilation.

Implementation
N/A

Remarks
N/A