### PR TITLE
[CBRD-25306] Remove the unused parameter is_indexscan.

### DIFF
--- a/src/connection/connection_support.c
+++ b/src/connection/connection_support.c
@@ -2763,7 +2763,7 @@ css_make_access_status_exist_user (THREAD_ENTRY * thread_p, OID * class_oid, LAS
       goto end;
     }
 
-  error = heap_scancache_start (thread_p, &scan_cache, &hfid, NULL, true, false, mvcc_snapshot);
+  error = heap_scancache_start (thread_p, &scan_cache, &hfid, NULL, true, mvcc_snapshot);
   if (error != NO_ERROR)
     {
       goto end;

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -195,7 +195,7 @@ namespace cubload
 	return LC_CLASSNAME_ERROR;
       }
 
-    error = heap_scancache_start (&thread_ref, &scan_cache, &hfid, NULL, true, false, NULL);
+    error = heap_scancache_start (&thread_ref, &scan_cache, &hfid, NULL, true, NULL);
     if (error != NO_ERROR)
       {
 	ASSERT_ERROR ();

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -12031,7 +12031,7 @@ qexec_execute_obj_fetch (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE *
 	  GOTO_EXIT_ON_ERROR;
 	}
 
-      if (heap_scancache_start (thread_p, &scan_cache, NULL, NULL, true, false, mvcc_snapshot) != NO_ERROR)
+      if (heap_scancache_start (thread_p, &scan_cache, NULL, NULL, true, mvcc_snapshot) != NO_ERROR)
 	{
 	  GOTO_EXIT_ON_ERROR;
 	}
@@ -12732,7 +12732,7 @@ qexec_execute_selupd_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE
 	      if (scan_cache_inited == false)
 		{
 		  if (heap_scancache_start (thread_p, &scan_cache, &crt_incr_info.m_class_hfid,
-					    &crt_incr_info.m_class_oid, false, false, mvcc_snapshot) != NO_ERROR)
+					    &crt_incr_info.m_class_oid, false, mvcc_snapshot) != NO_ERROR)
 		    {
 		      goto exit_on_error;
 		    }

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -4101,7 +4101,7 @@ scan_start_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 	{
 	  /* A new argument(is_indexscan = false) is appended */
 	  ret =
-	    heap_scancache_start (thread_p, &hsidp->scan_cache, &hsidp->hfid, &hsidp->cls_oid, scan_id->fixed, false,
+	    heap_scancache_start (thread_p, &hsidp->scan_cache, &hsidp->hfid, &hsidp->cls_oid, scan_id->fixed,
 				  mvcc_snapshot);
 	  if (ret != NO_ERROR)
 	    {
@@ -4181,7 +4181,7 @@ scan_start_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 
       /* A new argument(is_indexscan = true) is appended */
       ret =
-	heap_scancache_start (thread_p, &isidp->scan_cache, &isidp->hfid, &isidp->cls_oid, scan_id->fixed, true,
+	heap_scancache_start (thread_p, &isidp->scan_cache, &isidp->hfid, &isidp->cls_oid, scan_id->fixed,
 			      mvcc_snapshot);
       if (ret != NO_ERROR)
 	{

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -745,7 +745,7 @@ bt_load_heap_scancache_start_for_attrinfo (THREAD_ENTRY * thread_p, SORT_ARGS * 
 
   /* Start scancache */
   if (heap_scancache_start (thread_p, scan_cache, &args->hfids[args->cur_class],
-			    &args->class_ids[args->cur_class], save_cache_last_fix_page, false, NULL) != NO_ERROR)
+			    &args->class_ids[args->cur_class], save_cache_last_fix_page, NULL) != NO_ERROR)
     {
       return ER_FAILED;
     }

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -4619,7 +4619,7 @@ catcls_get_server_compat_info (THREAD_ENTRY * thread_p, INTL_CODESET * charset_i
       goto exit;
     }
 
-  error = heap_scancache_start (thread_p, &scan_cache, &hfid, NULL, true, false, NULL);
+  error = heap_scancache_start (thread_p, &scan_cache, &hfid, NULL, true, NULL);
   if (error != NO_ERROR)
     {
       goto exit;
@@ -5061,7 +5061,7 @@ catcls_get_db_collation (THREAD_ENTRY * thread_p, LANG_COLL_COMPAT ** db_collati
       goto exit;
     }
 
-  error = heap_scancache_start (thread_p, &scan_cache, &hfid, NULL, true, false, NULL);
+  error = heap_scancache_start (thread_p, &scan_cache, &hfid, NULL, true, NULL);
   if (error != NO_ERROR)
     {
       goto exit;
@@ -5282,7 +5282,7 @@ catcls_get_apply_info_log_record_time (THREAD_ENTRY * thread_p, time_t * log_rec
       goto exit;
     }
 
-  error = heap_scancache_start (thread_p, &scan_cache, &hfid, NULL, true, false, NULL);
+  error = heap_scancache_start (thread_p, &scan_cache, &hfid, NULL, true, NULL);
   if (error != NO_ERROR)
     {
       goto exit;

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -658,7 +658,7 @@ static int heap_scancache_check_with_hfid (THREAD_ENTRY * thread_p, HFID * hfid,
 					   HEAP_SCANCACHE ** scan_cache);
 static int heap_scancache_start_internal (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache, const HFID * hfid,
 					  const OID * class_oid, int cache_last_fix_page, bool is_queryscan,
-					  int is_indexscan, MVCC_SNAPSHOT * mvcc_snapshot);
+					  MVCC_SNAPSHOT * mvcc_snapshot);
 static int heap_scancache_force_modify (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache);
 static int heap_scancache_reset_modify (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache, const HFID * hfid,
 					const OID * class_oid);
@@ -6806,12 +6806,11 @@ heap_scancache_check_with_hfid (THREAD_ENTRY * thread_p, HFID * hfid, OID * clas
  *   cache_last_fix_page(in): Wheater or not to cache the last fetched page
  *                            between scan objects ?
  *   is_queryscan(in):
- *   is_indexscan(in):
  *
  */
 static int
 heap_scancache_start_internal (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache, const HFID * hfid,
-			       const OID * class_oid, int cache_last_fix_page, bool is_queryscan, int is_indexscan,
+			       const OID * class_oid, int cache_last_fix_page, bool is_queryscan,
 			       MVCC_SNAPSHOT * mvcc_snapshot)
 {
   int ret = NO_ERROR;
@@ -6920,14 +6919,13 @@ exit_on_error:
  *                  For any class, NULL or NULL_OID can be given
  *   cache_last_fix_page(in): Wheater or not to cache the last fetched page
  *                            between scan objects ?
- *   is_indexscan(in):
  *
  */
 int
 heap_scancache_start (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache, const HFID * hfid, const OID * class_oid,
-		      int cache_last_fix_page, int is_indexscan, MVCC_SNAPSHOT * mvcc_snapshot)
+		      int cache_last_fix_page, MVCC_SNAPSHOT * mvcc_snapshot)
 {
-  return heap_scancache_start_internal (thread_p, scan_cache, hfid, class_oid, cache_last_fix_page, true, is_indexscan,
+  return heap_scancache_start_internal (thread_p, scan_cache, hfid, class_oid, cache_last_fix_page, true,
 					mvcc_snapshot);
 }
 
@@ -6966,7 +6964,7 @@ heap_scancache_start_modify (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cach
   int i;
   int ret = NO_ERROR;
 
-  if (heap_scancache_start_internal (thread_p, scan_cache, hfid, NULL, false, false, false, mvcc_snapshot) != NO_ERROR)
+  if (heap_scancache_start_internal (thread_p, scan_cache, hfid, NULL, false, false, mvcc_snapshot) != NO_ERROR)
     {
       goto exit_on_error;
     }
@@ -8300,7 +8298,7 @@ heap_scanrange_start (THREAD_ENTRY * thread_p, HEAP_SCANRANGE * scan_range, cons
   int ret = NO_ERROR;
 
   /* Start the scan cache */
-  ret = heap_scancache_start (thread_p, &scan_range->scan_cache, hfid, class_oid, true, false, mvcc_snapshot);
+  ret = heap_scancache_start (thread_p, &scan_range->scan_cache, hfid, class_oid, true, mvcc_snapshot);
   if (ret != NO_ERROR)
     {
       goto exit_on_error;
@@ -14473,7 +14471,7 @@ heap_dump (THREAD_ENTRY * thread_p, FILE * fp, HFID * hfid, bool dump_records)
       /* Dump individual Objects */
       if (dump_records == true)
 	{
-	  if (heap_scancache_start (thread_p, &scan_cache, hfid, NULL, true, false, NULL) != NO_ERROR)
+	  if (heap_scancache_start (thread_p, &scan_cache, hfid, NULL, true, NULL) != NO_ERROR)
 	    {
 	      /* something went wrong, return */
 	      heap_attrinfo_end (thread_p, &attr_info);
@@ -16714,7 +16712,7 @@ xheap_has_instance (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
 	  return ER_FAILED;
 	}
     }
-  if (heap_scancache_start (thread_p, &scan_cache, hfid, class_oid, true, false, mvcc_snapshot) != NO_ERROR)
+  if (heap_scancache_start (thread_p, &scan_cache, hfid, class_oid, true, mvcc_snapshot) != NO_ERROR)
     {
       return ER_FAILED;
     }

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -407,8 +407,7 @@ extern VFID *heap_ovf_find_vfid (THREAD_ENTRY * thread_p, const HFID * hfid, VFI
 extern void heap_flush (THREAD_ENTRY * thread_p, const OID * oid);
 extern int xheap_reclaim_addresses (THREAD_ENTRY * thread_p, const HFID * hfid);
 extern int heap_scancache_start (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache, const HFID * hfid,
-				 const OID * class_oid, int cache_last_fix_page, int is_indexscan,
-				 MVCC_SNAPSHOT * mvcc_snapshot);
+				 const OID * class_oid, int cache_last_fix_page, MVCC_SNAPSHOT * mvcc_snapshot);
 extern int heap_scancache_start_modify (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache, const HFID * hfid,
 					const OID * class_oid, int op_type, MVCC_SNAPSHOT * mvcc_snapshot);
 extern int heap_scancache_quick_start (HEAP_SCANCACHE * scan_cache);

--- a/src/storage/system_catalog.c
+++ b/src/storage/system_catalog.c
@@ -4702,8 +4702,7 @@ catalog_check_consistency (THREAD_ENTRY * thread_p)
       goto exit_on_error;
     }
 
-  if (heap_scancache_start (thread_p, &scan_cache, &root_hfid, oid_Root_class_oid, true, false, mvcc_snapshot) !=
-      NO_ERROR)
+  if (heap_scancache_start (thread_p, &scan_cache, &root_hfid, oid_Root_class_oid, true, mvcc_snapshot) != NO_ERROR)
     {
       goto exit_on_error;
     }
@@ -5016,8 +5015,7 @@ catalog_dump (THREAD_ENTRY * thread_p, FILE * fp, int dump_flag)
       return;
     }
 
-  if (heap_scancache_start (thread_p, &scan_cache, &root_hfid, oid_Root_class_oid, true, false, mvcc_snapshot) !=
-      NO_ERROR)
+  if (heap_scancache_start (thread_p, &scan_cache, &root_hfid, oid_Root_class_oid, true, mvcc_snapshot) != NO_ERROR)
     {
       return;
     }

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -291,7 +291,7 @@ locator_initialize (THREAD_ENTRY * thread_p)
       goto error;
     }
 
-  if (heap_scancache_start (thread_p, &scan_cache, &root_hfid, NULL, true, false, NULL) != NO_ERROR)
+  if (heap_scancache_start (thread_p, &scan_cache, &root_hfid, NULL, true, NULL) != NO_ERROR)
     {
       goto error;
     }
@@ -1960,8 +1960,7 @@ locator_check_class_names (THREAD_ENTRY * thread_p)
       goto error;
     }
 
-  if (heap_scancache_start (thread_p, &scan_cache, &root_hfid, oid_Root_class_oid, true, false, mvcc_snapshot) !=
-      NO_ERROR)
+  if (heap_scancache_start (thread_p, &scan_cache, &root_hfid, oid_Root_class_oid, true, mvcc_snapshot) != NO_ERROR)
     {
       goto error;
     }
@@ -2489,7 +2488,7 @@ xlocator_fetch (THREAD_ENTRY * thread_p, OID * oid, int chn, LOCK lock,
   /* Assume that the needed object can fit in one page */
   copyarea_length = DB_PAGESIZE;
 
-  error_code = heap_scancache_start (thread_p, &nxobj.area_scancache, NULL, NULL, false, false, mvcc_snapshot);
+  error_code = heap_scancache_start (thread_p, &nxobj.area_scancache, NULL, NULL, false, mvcc_snapshot);
   if (error_code != NO_ERROR)
     {
       nxobj.mobjs = NULL;
@@ -2861,7 +2860,7 @@ xlocator_fetch_all (THREAD_ENTRY * thread_p, const HFID * hfid, LOCK * lock, LC_
   COPY_OID (&oid, last_oid);
 
   /* Start a scan cursor for getting several classes */
-  error_code = heap_scancache_start (thread_p, &scan_cache, hfid, class_oid, true, false, mvcc_snapshot);
+  error_code = heap_scancache_start (thread_p, &scan_cache, hfid, class_oid, true, mvcc_snapshot);
   if (error_code != NO_ERROR)
     {
       if (*lock != NULL_LOCK)
@@ -3088,7 +3087,7 @@ xlocator_fetch_lockset (THREAD_ENTRY * thread_p, LC_LOCKSET * lockset, LC_COPYAR
     }
 
   /* Start a scan cursor for getting several classes */
-  error_code = heap_scancache_start (thread_p, &nxobj.area_scancache, NULL, NULL, true, false, NULL);
+  error_code = heap_scancache_start (thread_p, &nxobj.area_scancache, NULL, NULL, true, NULL);
   if (error_code != NO_ERROR)
     {
       lock_unlock_objects_lock_set (thread_p, lockset);
@@ -3471,7 +3470,7 @@ locator_all_reference_lockset (THREAD_ENTRY * thread_p, OID * oid, int prune_lev
    */
 
   /* Start a scan cursor for getting several classes */
-  if (heap_scancache_start (thread_p, &scan_cache, NULL, NULL, true, false, mvcc_snapshot) != NO_ERROR)
+  if (heap_scancache_start (thread_p, &scan_cache, NULL, NULL, true, mvcc_snapshot) != NO_ERROR)
     {
       goto error;
     }
@@ -4320,7 +4319,7 @@ locator_check_primary_key_delete (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 	      oid_list.next_list = NULL;
 	    }
 
-	  error_code = heap_scancache_start (thread_p, &isid.scan_cache, &hfid, &fkref->self_oid, true, true, NULL);
+	  error_code = heap_scancache_start (thread_p, &isid.scan_cache, &hfid, &fkref->self_oid, true, NULL);
 	  if (error_code != NO_ERROR)
 	    {
 	      ASSERT_ERROR ();
@@ -4698,7 +4697,7 @@ locator_check_primary_key_update (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 	      oid_list.next_list = NULL;
 	    }
 
-	  error_code = heap_scancache_start (thread_p, &isid.scan_cache, &hfid, &fkref->self_oid, true, true, NULL);
+	  error_code = heap_scancache_start (thread_p, &isid.scan_cache, &hfid, &fkref->self_oid, true, NULL);
 	  if (error_code != NO_ERROR)
 	    {
 	      ASSERT_ERROR ();
@@ -8947,7 +8946,7 @@ xlocator_remove_class_from_index (THREAD_ENTRY * thread_p, OID * class_oid, BTID
     }
 
   /* Start a scan cursor */
-  error_code = heap_scancache_start (thread_p, &scan_cache, hfid, class_oid, false, false, mvcc_snapshot);
+  error_code = heap_scancache_start (thread_p, &scan_cache, hfid, class_oid, false, mvcc_snapshot);
   if (error_code != NO_ERROR)
     {
       free_and_init (copy_rec.data);
@@ -9390,7 +9389,7 @@ locator_check_btree_entries (THREAD_ENTRY * thread_p, BTID * btid, HFID * hfid, 
   scan_init_index_scan (&isid, NULL, mvcc_snapshot);
 
   /* Start a scan cursor and a class attribute information */
-  if (heap_scancache_start (thread_p, &scan_cache, hfid, class_oid, false, false, mvcc_snapshot) != NO_ERROR)
+  if (heap_scancache_start (thread_p, &scan_cache, hfid, class_oid, false, mvcc_snapshot) != NO_ERROR)
     {
       return DISK_ERROR;
     }
@@ -9588,7 +9587,7 @@ locator_check_btree_entries (THREAD_ENTRY * thread_p, BTID * btid, HFID * hfid, 
 
   scan_init_iss (&isid);
 
-  if (heap_scancache_start (thread_p, &isid.scan_cache, hfid, class_oid, true, true, mvcc_snapshot) != NO_ERROR)
+  if (heap_scancache_start (thread_p, &isid.scan_cache, hfid, class_oid, true, mvcc_snapshot) != NO_ERROR)
     {
       isallvalid = DISK_ERROR;
       goto error;
@@ -9863,7 +9862,7 @@ locator_check_unique_btree_entries (THREAD_ENTRY * thread_p, BTID * btid, OID * 
       class_oid = &class_oids[j];
 
       /* Start a scan cursor and a class attribute information */
-      if (heap_scancache_start (thread_p, &scan_cache[j], hfid, class_oid, true, false, mvcc_snapshot) != NO_ERROR)
+      if (heap_scancache_start (thread_p, &scan_cache[j], hfid, class_oid, true, mvcc_snapshot) != NO_ERROR)
 	{
 	  goto error;
 	}
@@ -10028,7 +10027,7 @@ locator_check_unique_btree_entries (THREAD_ENTRY * thread_p, BTID * btid, OID * 
     }
   isid.copy_buf_len = DBVAL_BUFSIZE;
 
-  if (heap_scancache_start (thread_p, &isid.scan_cache, hfid, class_oid, true, true, mvcc_snapshot) != NO_ERROR)
+  if (heap_scancache_start (thread_p, &isid.scan_cache, hfid, class_oid, true, mvcc_snapshot) != NO_ERROR)
     {
       goto error;
     }
@@ -10501,7 +10500,7 @@ locator_check_by_class_oid (THREAD_ENTRY * thread_p, OID * cls_oid, HFID * hfid,
       return DISK_ERROR;
     }
 
-  if (heap_scancache_start (thread_p, &scan, &root_hfid, oid_Root_class_oid, true, false, mvcc_snapshot) != NO_ERROR)
+  if (heap_scancache_start (thread_p, &scan, &root_hfid, oid_Root_class_oid, true, mvcc_snapshot) != NO_ERROR)
     {
       return DISK_ERROR;
     }
@@ -10591,7 +10590,7 @@ locator_check_all_entries_of_all_btrees (THREAD_ENTRY * thread_p, bool repair)
       return DISK_ERROR;
     }
 
-  if (heap_scancache_start (thread_p, &scan, &root_hfid, oid_Root_class_oid, true, false, mvcc_snapshot) != NO_ERROR)
+  if (heap_scancache_start (thread_p, &scan, &root_hfid, oid_Root_class_oid, true, mvcc_snapshot) != NO_ERROR)
     {
       return DISK_ERROR;
     }
@@ -10714,7 +10713,7 @@ locator_guess_sub_classes (THREAD_ENTRY * thread_p, LC_LOCKHINT ** lockhint_subc
    * Start a scan cursor for fetching the desired classes.
    */
 
-  error_code = heap_scancache_start (thread_p, &scan_cache, NULL, NULL, true, false, NULL);
+  error_code = heap_scancache_start (thread_p, &scan_cache, NULL, NULL, true, NULL);
   if (error_code != NO_ERROR)
     {
       return error_code;
@@ -11417,7 +11416,7 @@ xlocator_fetch_lockhint_classes (THREAD_ENTRY * thread_p, LC_LOCKHINT * lockhint
    * Start a scan cursor for getting the classes
    */
 
-  error_code = heap_scancache_start (thread_p, &nxobj.area_scancache, NULL, NULL, true, false, NULL);
+  error_code = heap_scancache_start (thread_p, &nxobj.area_scancache, NULL, NULL, true, NULL);
   if (error_code != NO_ERROR)
     {
       lock_unlock_classes_lock_hint (thread_p, lockhint);
@@ -11773,7 +11772,7 @@ xlocator_check_fk_validity (THREAD_ENTRY * thread_p, OID * cls_oid, HFID * hfid,
 
   aligned_midxkey_buf = PTR_ALIGN (midxkey_buf, MAX_ALIGNMENT);
 
-  error_code = heap_scancache_start (thread_p, &scan_cache, hfid, cls_oid, false, false, mvcc_snapshot);
+  error_code = heap_scancache_start (thread_p, &scan_cache, hfid, cls_oid, false, mvcc_snapshot);
   if (error_code != NO_ERROR)
     {
       return error_code;
@@ -11908,7 +11907,7 @@ xlocator_lock_and_fetch_all (THREAD_ENTRY * thread_p, const HFID * hfid, LOCK * 
   COPY_OID (&oid, last_oid);
 
   /* Start a scan cursor for getting several classes */
-  error_code = heap_scancache_start (thread_p, &scan_cache, hfid, class_oid, true, false, mvcc_snapshot);
+  error_code = heap_scancache_start (thread_p, &scan_cache, hfid, class_oid, true, mvcc_snapshot);
   if (error_code != NO_ERROR)
     {
       goto error;
@@ -12760,7 +12759,7 @@ redistribute_partition_data (THREAD_ENTRY * thread_p, OID * class_oid, int no_oi
 
       PGBUF_INIT_WATCHER (&old_page_watcher, PGBUF_ORDERED_HEAP_NORMAL, &hfid);
 
-      error = heap_scancache_start (thread_p, &scan_cache, &hfid, &oid_list[i], false, false, NULL);
+      error = heap_scancache_start (thread_p, &scan_cache, &hfid, &oid_list[i], false, NULL);
       if (error != NO_ERROR)
 	{
 	  goto exit;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25306

Purpose
Remove the unused parameter is_indexscan.
'int is_indexscan' is a parameter of functions 'heap_scancache_start' and 'heap_scancache_start_internal'.

Implementation
N/A

Remarks
N/A