### PR TITLE
[CBRD-25319] fix FQDN stytle hostname error in use_user_hosts

### DIFF
--- a/src/connection/host_lookup.c
+++ b/src/connection/host_lookup.c
@@ -245,7 +245,7 @@ load_hosts_file ()
   char host_conf_file_full_path[PATH_MAX];
   char *hosts_conf_dir;
 
-  char *token, temp_token[LINE_BUF_SIZE + 1];
+  char *token;
   char *save_ptr_strtok;
   /*delimiter */
   const char *delim = " \t\n";
@@ -292,10 +292,9 @@ load_hosts_file ()
 	    {
 	      break;
 	    }
-	  strcpy (temp_token, token);
 	  if (hostent_flag == INSERT_IPADDR)
 	    {
-	      if (is_valid_ip (temp_token) == false)
+	      if (is_valid_ip (token) == false)
 		{
 		  continue;
 		}
@@ -313,16 +312,16 @@ load_hosts_file ()
 		  break;
 		}
 
-	      str_len = strlen (temp_token);
+	      str_len = strlen (token);
 	      if (str_len > HOSTNAME_LEN - 1)
 		{
 		  continue;
 		}
-	      else if (is_valid_ip (temp_token) == true)
+	      else if (is_valid_ip (token) == true)
 		{
 		  continue;
 		}
-	      else if (is_valid_hostname (temp_token, str_len) == false)
+	      else if (is_valid_hostname (token, str_len) == false)
 		{
 		  continue;
 		}
@@ -385,8 +384,10 @@ is_valid_ip (char *ip_addr)
   char *token;
   char *save_ptr_strtok;
   const char *delim = " .\n";
+  char temp_str[LINE_BUF_SIZE + 1];
 
-  if ((token = strtok_r (ip_addr, delim, &save_ptr_strtok)) == NULL)
+  snprintf (temp_str, LINE_BUF_SIZE + 1, "%s", ip_addr);
+  if ((token = strtok_r (temp_str, delim, &save_ptr_strtok)) == NULL)
     {
       goto err_phase;
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25319

**Description**
* Fix usage of FQDN (like cubrid.co.kr) with '**use_user_hosts**' service

**Remarks**
* To verify the valid hostname, following codes were used:
```
321  else if (is_valid_ip (temp_token) == true)
322    {
323      continue;
324    }
325  else if (is_valid_hostname (temp_token, str_len) == false)
326   {
327     continue;
328   }
```
* When line # 321 is called, the **temp_token** value can be changed to NULL or another value by **strtok_r** (), which is what we didn't expect.
* In this case, **is_valid_hostname** () could fails at line#325, with subject hostname to NULL
  * maybe it have been called in **is_valid_hostname (NULL, 7)** style, not **is_valid_hostname ("dev2.com", 7)**
