### PR TITLE
[CBRD-25313] Get HFID from class-name using caches and dump with HFID

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -14534,10 +14534,11 @@ heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, cons
   error_code = heap_hfid_cache_get (thread_p, &class_oid, &hfid, NULL, NULL);
   if (error_code != NO_ERROR)
     {
+      ASSERT_ERROR ();
       return;
     }
-  heap_dump (thread_p, fp, &hfid, dump_records);
 
+  heap_dump (thread_p, fp, &hfid, dump_records);
 }
 #endif
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -14524,18 +14524,19 @@ heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, cons
   OID class_oid;
   LC_FIND_CLASSNAME status;
   HFID hfid;
-  
-  status = xlocator_find_class_oid(thread_p, class_name, &class_oid, S_LOCK);
-  if (status != LC_CLASSNAME_EXIST){
-    return;
-  }
 
-  error_code = heap_hfid_cache_get(thread_p, &class_oid, &hfid, NULL, NULL);
+  status = xlocator_find_class_oid (thread_p, class_name, &class_oid, S_LOCK);
+  if (status != LC_CLASSNAME_EXIST)
+    {
+      return;
+    }
+
+  error_code = heap_hfid_cache_get (thread_p, &class_oid, &hfid, NULL, NULL);
   if (error_code != NO_ERROR)
-  {
-    return;
-  }
-  heap_dump(thread_p, fp, &hfid, dump_records);
+    {
+      return;
+    }
+  heap_dump (thread_p, fp, &hfid, dump_records);
 
 }
 #endif

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -14520,7 +14520,23 @@ heap_dump (THREAD_ENTRY * thread_p, FILE * fp, HFID * hfid, bool dump_records)
 void
 heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, const char *class_name)
 {
-  /* TODO: Fetch HFID of class which corresponds to class_name, and dump heap file by HFID. Will be handled at CBRD-25313 and CBRD-25314. */
+  int error_code = NO_ERROR;
+  OID class_oid;
+  LC_FIND_CLASSNAME status;
+  HFID hfid;
+  
+  status = xlocator_find_class_oid(thread_p, class_name, &class_oid, S_LOCK);
+  if (status != LC_CLASSNAME_EXIST){
+    return;
+  }
+
+  error_code = heap_hfid_cache_get(thread_p, &class_oid, &hfid, NULL, NULL);
+  if (error_code != NO_ERROR)
+  {
+    return;
+  }
+  heap_dump(thread_p, fp, &hfid, dump_records);
+
 }
 #endif
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25313

Retrieve the HFID of a class from class-name and dump the class heap file

- Convert `class-name` to `class oid` with `locator_Mht_classnames`cache  using `xlocator_find_class_oid` function.
- Convert `class oid` to `HFID` with `heap_Hfid_table` cache using `heap_hfid_cache_get` function.
- Dump corresponding heap file by retrieved `HFID` using `heap_dump` function.
