### PR TITLE
[CBRD-25072] result_type member variable of method_sig_node is defined incorrectly

### DIFF
--- a/src/jsp/jsp_cl.cpp
+++ b/src/jsp/jsp_cl.cpp
@@ -703,6 +703,7 @@ jsp_create_stored_procedure (PARSER_CONTEXT *parser, PT_NODE *statement)
 		  compile_info.err_column, err_msg.c_str ());
 	  pt_record_error (parser, parser->statement_number, compile_info.err_line, compile_info.err_column, er_msg (),
 			   NULL);
+	  goto error_exit;
 	}
     }
   else				/* SP_LANG_JAVA */

--- a/src/jsp/jsp_cl.cpp
+++ b/src/jsp/jsp_cl.cpp
@@ -1262,6 +1262,7 @@ jsp_make_method_sig_list (PARSER_CONTEXT *parser, PT_NODE *node, method_sig_list
 	sig->next = nullptr;
 	sig->num_method_args = sig_num_args;
 	sig->method_type = METHOD_TYPE_JAVA_SP;
+	sig->result_type = sig_result_type;
 
 	// method_name
 	const char *method_name = db_get_string (&method);
@@ -1351,8 +1352,6 @@ jsp_make_method_sig_list (PARSER_CONTEXT *parser, PT_NODE *node, method_sig_list
 	    sig->arg_info->arg_mode = nullptr;
 	    sig->arg_info->arg_type = nullptr;
 	  }
-
-	sig->arg_info->result_type = sig_result_type;
 
 	sig_list.num_methods = 1;
       }

--- a/src/method/method_def.cpp
+++ b/src/method/method_def.cpp
@@ -46,6 +46,7 @@ method_sig_node::method_sig_node (method_sig_node &&obj)
   method_type = obj.method_type;
   method_arg_pos = obj.method_arg_pos;
   num_method_args = obj.num_method_args;
+  result_type = obj.result_type;
 
   obj.method_name = nullptr;
   obj.auth_name = nullptr;
@@ -61,7 +62,6 @@ method_sig_node::method_sig_node (method_sig_node &&obj)
     {
       arg_info->arg_mode = obj.arg_info->arg_mode;
       arg_info->arg_type = obj.arg_info->arg_type;
-      arg_info->result_type = obj.arg_info->result_type;
 
       obj.arg_info->arg_mode = nullptr;
       obj.arg_info->arg_type = nullptr;
@@ -118,6 +118,8 @@ method_sig_node::method_sig_node (const method_sig_node &obj)
       class_name = nullptr;
     }
 
+  result_type = obj.result_type;
+
   if (obj.arg_info != nullptr)
     {
       if (num_method_args > 0)
@@ -135,7 +137,6 @@ method_sig_node::method_sig_node (const method_sig_node &obj)
 	  arg_info->arg_mode = nullptr;
 	  arg_info->arg_type = nullptr;
 	}
-      arg_info->result_type = obj.arg_info->result_type;
     }
 }
 
@@ -156,6 +157,7 @@ method_sig_node::pack (cubpacking::packer &serializator) const
 
   serializator.pack_int (method_type);
   serializator.pack_int (num_method_args);
+  serializator.pack_int (result_type);
 
   for (int i = 0; i < num_method_args + 1; i++)
     {
@@ -183,7 +185,6 @@ method_sig_node::pack (cubpacking::packer &serializator) const
 	{
 	  serializator.pack_int (arg_info->arg_type[i]);
 	}
-      serializator.pack_int (arg_info->result_type);
     }
   else
     {
@@ -204,9 +205,9 @@ method_sig_node::get_packed_size (cubpacking::packer &serializator, std::size_t 
       size += serializator.get_packed_c_string_size (auth_name, strlen (auth_name), size);
     }
 
-  /* method type and num_method_args */
-  size += serializator.get_packed_int_size (size);
-  size += serializator.get_packed_int_size (size);
+  size += serializator.get_packed_int_size (size); /* method type */
+  size += serializator.get_packed_int_size (size); /* num_method_args */
+  size += serializator.get_packed_int_size (size); /* result_type */
 
   for (int i = 0; i < num_method_args + 1; i++)
     {
@@ -227,7 +228,6 @@ method_sig_node::get_packed_size (cubpacking::packer &serializator, std::size_t 
 	  size += serializator.get_packed_int_size (size); /* method_sig->arg_info->arg_mode[i] */
 	  size += serializator.get_packed_int_size (size); /* method_sig->arg_info->arg_type[i] */
 	}
-      size += serializator.get_packed_int_size (size); /* method_sig->arg_info->result_type */
     }
 
   return size;
@@ -281,6 +281,8 @@ method_sig_node::operator= (const method_sig_node &obj)
 	  method_arg_pos = nullptr;
 	}
 
+      result_type = obj.result_type;
+
       if (obj.class_name != nullptr)
 	{
 	  int class_name_len = strlen (obj.class_name);
@@ -304,7 +306,6 @@ method_sig_node::operator= (const method_sig_node &obj)
 		  arg_info->arg_type[n] = obj.arg_info->arg_type[n];
 		}
 	    }
-	  arg_info->result_type = obj.arg_info->result_type;
 	}
       else
 	{
@@ -341,6 +342,7 @@ method_sig_node::unpack (cubpacking::unpacker &deserializator)
   deserializator.unpack_int (type);
   method_type = static_cast<METHOD_TYPE> (type);
   deserializator.unpack_int (num_method_args);
+  deserializator.unpack_int (result_type);
 
   method_arg_pos = (int *) db_private_alloc (NULL, sizeof (int) * (num_method_args + 1));
   for (int n = 0; n < num_method_args + 1; n++)
@@ -387,7 +389,6 @@ method_sig_node::unpack (cubpacking::unpacker &deserializator)
 	  arg_info->arg_type = nullptr;
 	}
 
-      deserializator.unpack_int (arg_info->result_type);
     }
   else
     {

--- a/src/method/method_def.hpp
+++ b/src/method/method_def.hpp
@@ -126,7 +126,6 @@ struct method_arg_info
 {
   int *arg_mode; /* IN, OUT, INOUT */
   int *arg_type; /* DB_TYPE */
-  int result_type; /* DB_TYPE */
 
   method_arg_info () = default;
 };
@@ -141,6 +140,7 @@ struct method_sig_node
   METHOD_TYPE method_type;	/* instance or class method */
   int num_method_args;		/* number of arguments */
   int *method_arg_pos;		/* arg position in list file */
+  int result_type;              /* DB_TYPE */
 
   char *class_name;		/* class name for the class method */
   METHOD_ARG_INFO *arg_info;    /* argument info */

--- a/src/method/method_struct_invoke.cpp
+++ b/src/method/method_struct_invoke.cpp
@@ -202,6 +202,7 @@ namespace cubmethod
     signature.assign (sig->method_name);
     auth.assign (sig->auth_name);
     num_args = sig->num_method_args;
+    result_type = sig->result_type;
     if (num_args > 0)
       {
 	arg_pos.resize (num_args);
@@ -214,8 +215,6 @@ namespace cubmethod
 	    arg_mode[i] = sig->arg_info->arg_mode[i];
 	    arg_type[i] = sig->arg_info->arg_type[i];
 	  }
-
-	result_type = sig->arg_info->result_type;
       }
 
     transaction_control = tc;

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -3923,7 +3923,7 @@ pt_to_method_sig_list (PARSER_CONTEXT * parser, PT_NODE * node_list, PT_NODE * s
 		  DB_VALUE result_type;
 		  if (db_get (mop_p, SP_ATTR_RETURN_TYPE, &result_type) == NO_ERROR)
 		    {
-		      (*tail)->arg_info->result_type = db_get_int (&result_type);
+		      (*tail)->result_type = db_get_int (&result_type);
 		      pr_clear_value (&result_type);
 		    }
 		  else

--- a/src/query/stream_to_xasl.c
+++ b/src/query/stream_to_xasl.c
@@ -2553,6 +2553,8 @@ stx_build_method_sig (THREAD_ENTRY * thread_p, char *ptr, METHOD_SIG * method_si
 
   num_args = method_sig->num_method_args;
 
+  ptr = or_unpack_int (ptr, &method_sig->result_type);
+
   method_sig->method_arg_pos = (int *) stx_alloc_struct (thread_p, sizeof (int) * (num_args + 1));
   if (method_sig->method_arg_pos == NULL)
     {
@@ -2627,8 +2629,6 @@ stx_build_method_arg_info (THREAD_ENTRY * thread_p, char *ptr, METHOD_ARG_INFO *
     {
       ptr = or_unpack_int (ptr, &method_arg_info->arg_type[n]);
     }
-
-  ptr = or_unpack_int (ptr, &method_arg_info->result_type);
 
   return ptr;
 

--- a/src/query/xasl_to_stream.c
+++ b/src/query/xasl_to_stream.c
@@ -5813,6 +5813,7 @@ xts_process_method_sig (char *ptr, const METHOD_SIG * method_sig, int count)
 
   ptr = or_pack_int (ptr, method_sig->method_type);
   ptr = or_pack_int (ptr, method_sig->num_method_args);
+  ptr = or_pack_int (ptr, method_sig->result_type);
 
   for (n = 0; n < method_sig->num_method_args + 1; n++)
     {
@@ -5855,8 +5856,6 @@ xts_process_method_arg_info (char *ptr, const METHOD_ARG_INFO * method_arg_info,
     {
       ptr = or_pack_int (ptr, method_arg_info->arg_type[n]);
     }
-
-  ptr = or_pack_int (ptr, method_arg_info->result_type);
 
   return ptr;
 }
@@ -7582,6 +7581,7 @@ xts_sizeof_method_sig (const METHOD_SIG * method_sig)
 	   + PTR_SIZE		/* auth_name */
 	   + OR_INT_SIZE	/* method_type */
 	   + OR_INT_SIZE	/* num_method_args */
+	   + (OR_INT_SIZE)	/* result type */
 	   + (OR_INT_SIZE * (method_sig->num_method_args + 1))	/* method_arg_pos */
 	   + PTR_SIZE);		/* next */
 
@@ -7598,7 +7598,7 @@ xts_sizeof_method_arg_info (const METHOD_ARG_INFO * method_arg_info, int num_arg
 
   size += ((num_args * OR_INT_SIZE)	/* arg_mode */
 	   + (num_args * OR_INT_SIZE)	/* arg_type */
-	   + (OR_INT_SIZE));	/* result type */
+    );
 
   return size;
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25072

This PR is a regression from #4782, where result_type is defined in the wrong struct.