### PR TITLE
[CBRD-25310] Rollback make_stat_name() to return std::string

### DIFF
--- a/src/base/memory_monitor_sr.hpp
+++ b/src/base/memory_monitor_sr.hpp
@@ -93,7 +93,7 @@ namespace cubmem
 
     private:
       inline char *get_metainfo_pos (char *ptr, size_t size);
-      inline void make_stat_name (char *buf, const char *file, const int line);
+      inline std::string make_stat_name (const char *file, const int line);
 
     private:
       std::string m_server_name;
@@ -118,10 +118,10 @@ namespace cubmem
     return m_target_pos;
   }
 
-  inline void memory_monitor::make_stat_name (char *buf, const char *file, const int line)
+  inline std::string memory_monitor::make_stat_name (const char *file, const int line)
   {
-    assert (strlen (file + m_target_pos) + std::to_string (line).length() + 1 <= MMON_MAX_NAME_LENGTH);
-    snprintf (buf, MMON_MAX_NAME_LENGTH, "%s:%d", file + m_target_pos, line);
+    std::string filecopy (file + m_target_pos);
+    return filecopy + ":" + std::to_string (line);
   }
 
   inline char *memory_monitor::get_metainfo_pos (char *ptr, size_t size)
@@ -131,7 +131,7 @@ namespace cubmem
 
   inline void memory_monitor::add_stat (char *ptr, const size_t size, const char *file, const int line)
   {
-    char stat_name[MMON_MAX_NAME_LENGTH];
+    std::string stat_name;
 
     // size should not be 0 because of MMON_METAINFO_SIZE
     assert (size > 0);
@@ -141,7 +141,7 @@ namespace cubmem
     metainfo->allocated_size = (uint64_t) size;
     m_total_mem_usage += metainfo->allocated_size;
 
-    make_stat_name (stat_name, file, line);
+    stat_name = make_stat_name (file, line);
 
 retry:
     const auto search = m_stat_name_map.find (stat_name);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25068

Fix regression test error:
 - rollback `make_stat_name()` to return std::string, not using `char *` buffer.