### PR TITLE
[CBRD-25314] Get partition information of class to get HFID of subclasses

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -14552,6 +14552,11 @@ heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, cons
     {
       heap_dump (thread_p, fp, &parts[i].class_hfid, dump_records);
     }
+
+  if (parts != NULL)
+    {
+      heap_clear_partition_info (thread_p, parts, parts_count);
+    }
 }
 #endif
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -14524,6 +14524,8 @@ heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, cons
   OID class_oid;
   LC_FIND_CLASSNAME status;
   HFID hfid;
+  OR_PARTITION *parts = NULL;
+  int parts_count = 0;
 
   status = xlocator_find_class_oid (thread_p, class_name, &class_oid, S_LOCK);
   if (status != LC_CLASSNAME_EXIST)
@@ -14539,6 +14541,17 @@ heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, cons
     }
 
   heap_dump (thread_p, fp, &hfid, dump_records);
+
+  error_code = heap_get_class_partitions (thread_p, &class_oid, &parts, &parts_count);
+  if (error_code != NO_ERROR)
+    {
+      return;
+    }
+
+  for (int i = 1; i < parts_count; i++)
+    {
+      heap_dump (thread_p, fp, &parts[i].class_hfid, dump_records);
+    }
 }
 #endif
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -14536,7 +14536,7 @@ heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, cons
   error_code = heap_hfid_cache_get (thread_p, &class_oid, &hfid, NULL, NULL);
   if (error_code != NO_ERROR)
     {
-      ASSERT_ERROR ();
+      assert (false);
       return;
     }
 
@@ -14545,6 +14545,7 @@ heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, cons
   error_code = heap_get_class_partitions (thread_p, &class_oid, &parts, &parts_count);
   if (error_code != NO_ERROR)
     {
+      assert (false);
       return;
     }
 
@@ -14553,10 +14554,7 @@ heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, cons
       heap_dump (thread_p, fp, &parts[i].class_hfid, dump_records);
     }
 
-  if (parts != NULL)
-    {
-      heap_clear_partition_info (thread_p, parts, parts_count);
-    }
+  heap_clear_partition_info (thread_p, parts, parts_count);
 }
 #endif
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25314

For a given `class-oid`, determine whether the class is a partitioned table. If it is, dump its subclasses with their `HFID`.
  

- Retrieve the partition information of the class using the `heap_get_class_partitions` function.
- If the number of partitions is 0, the given class is not partitioned. If the number of partitions is greater than 0, `parts` will contain the `class-oid` of subclasses.
- Since the first element of `parts` is the information of root class (itself), information of subclass contains from second element.
- Dump the subclass using their respective `HFID` with the `heap_dump` function.