### PR TITLE
[CBRD-25307] Remove meaningless comments from heap_create_internal ( ... ) header.

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -5235,7 +5235,6 @@ heap_manager_finalize (void)
  *   hfid(in/out): Object heap file identifier.
  *                 All fields in the identifier are set, except the volume
  *                 identifier which should have already been set by the caller.
- *   exp_npgs(in): Expected number of pages
  *   class_oid(in): OID of the class for which the heap will be created.
  *   reuse_oid(in): if true, the OIDs of deleted instances will be reused
  *


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25307

Purpose
the parameter `exp_npgs` was removed from old commit, so the comments of parameter `exp_npgs` is meaningless now.

Implementation
N/A

Remarks
N/A