### PR TITLE
[CBRD-25325] change assert policy by m_qlist_count of thread

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -15087,16 +15087,16 @@ end:
   if (prm_get_bool_value (PRM_ID_LOG_QUERY_LISTS))
     {
       er_print_callstack (ARG_FILE_LINE, "ending query execution with qlist_count = %d\n", thread_p->m_qlist_count);
-    }
-  if (list_id && list_id->type_list.type_cnt != 0)
-    {
-      // one new list file
-      assert (thread_p->m_qlist_count == qlist_enter_count + 1);
-    }
-  else
-    {
-      // no new list files
-      assert (thread_p->m_qlist_count == qlist_enter_count);
+      if (list_id && list_id->type_list.type_cnt != 0)
+	{
+	  // one new list file
+	  assert (thread_p->m_qlist_count == qlist_enter_count + 1);
+	}
+      else
+	{
+	  // no new list files
+	  assert (thread_p->m_qlist_count == qlist_enter_count);
+	}
     }
 #endif // SERVER_MODE
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25325

When a query is executed and a temporary list file or result list file is used, the thread counts it using a member variable called m_qlist_count. It appears that this count value was originally created for use in debugging, but the only time this count value is actually written to the log is when the PRM_ID_LOG_QUERY_LISTS system parameter is "on".
However, with the introduction of the subquery result-cache, there are cases where this count value does not match the logic. In other words, an assert occurs when the list file in result-cache is used in UNION. It is difficult to modify the logic to avoid this assert, and other side effects must also be considered.
The conclusion is that the assert needs to be generated for debugging only when the PRM_ID_LOG_QUERY_LISTS system parameter is in the "on" state.
