### PR TITLE
[CBRD-25327] Delete the contents related to DEDUPLICATE from the cubrid.conf file

### DIFF
--- a/conf/cubrid.conf
+++ b/conf/cubrid.conf
@@ -72,8 +72,3 @@ log_volume_size=512M
 #
 # log_max_archives=2147483647
 log_max_archives=0 
-
-# for deduplicate (-1 ~ 14, -1 forces explicit statements to also be ignored.)
-deduplicate_key_level=-1
-print_index_detail=no
-


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25327

* Delete the contents related to DEDUPLICATE from the cubrid.conf file
* For now, it only applies to 11.3.1
