### PR TITLE
[CBRD-25328] 11.3, change host name in cubrid_hosts.conf to use hyphen

### DIFF
--- a/conf/cubrid_hosts.conf
+++ b/conf/cubrid_hosts.conf
@@ -15,4 +15,4 @@
 #
 #
 127.0.0.1	localhost
-0.0.0.0         your_hostname
+0.0.0.0         your-hostname


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25328

Description
* this is backport of #5157 to release/11.3
