### PR TITLE
[CBRD-25312] Print usage message when class-name is given for non heap_dump mode

### DIFF
--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1574,7 +1574,7 @@ diagdb (UTIL_FUNCTION_ARG * arg)
       goto print_diag_usage;
     }
 
-  if (diag == DIAGDUMP_ALL && class_name != NULL)
+  if (diag != DIAGDUMP_HEAP && class_name != NULL)
     {
       goto print_diag_usage;
     }

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -14552,6 +14552,11 @@ heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, cons
     {
       heap_dump (thread_p, fp, &parts[i].class_hfid, dump_records);
     }
+
+  if (parts != NULL)
+    {
+      heap_clear_partition_info (thread_p, parts, parts_count);
+    }
 }
 #endif
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -14524,6 +14524,8 @@ heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, cons
   OID class_oid;
   LC_FIND_CLASSNAME status;
   HFID hfid;
+  OR_PARTITION *parts = NULL;
+  int parts_count = 0;
 
   status = xlocator_find_class_oid (thread_p, class_name, &class_oid, S_LOCK);
   if (status != LC_CLASSNAME_EXIST)
@@ -14539,6 +14541,17 @@ heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, cons
     }
 
   heap_dump (thread_p, fp, &hfid, dump_records);
+
+  error_code = heap_get_class_partitions (thread_p, &class_oid, &parts, &parts_count);
+  if (error_code != NO_ERROR)
+    {
+      return;
+    }
+
+  for (int i = 1; i < parts_count; i++)
+    {
+      heap_dump (thread_p, fp, &parts[i].class_hfid, dump_records);
+    }
 }
 #endif
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -14536,7 +14536,7 @@ heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, cons
   error_code = heap_hfid_cache_get (thread_p, &class_oid, &hfid, NULL, NULL);
   if (error_code != NO_ERROR)
     {
-      ASSERT_ERROR ();
+      assert (false);
       return;
     }
 
@@ -14545,6 +14545,7 @@ heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, cons
   error_code = heap_get_class_partitions (thread_p, &class_oid, &parts, &parts_count);
   if (error_code != NO_ERROR)
     {
+      assert (false);
       return;
     }
 
@@ -14553,10 +14554,7 @@ heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, cons
       heap_dump (thread_p, fp, &parts[i].class_hfid, dump_records);
     }
 
-  if (parts != NULL)
-    {
-      heap_clear_partition_info (thread_p, parts, parts_count);
-    }
+  heap_clear_partition_info (thread_p, parts, parts_count);
 }
 #endif
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25312

Originally, when class-name is given, `diagdb` prints usage if dump mode is `DIAGDUMP_ALL`.
For correct behavior, modify to print usage if dump mode is not `DIAGDUMP_HEAP`.
