### PR TITLE
[CBRD-25312] Print usage message when class-name is given for non heap_dump mode

### DIFF
--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1574,7 +1574,7 @@ diagdb (UTIL_FUNCTION_ARG * arg)
       goto print_diag_usage;
     }
 
-  if (diag == DIAGDUMP_ALL && class_name != NULL)
+  if (diag != DIAGDUMP_HEAP && class_name != NULL)
     {
       goto print_diag_usage;
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25312

Originally, when class-name is given, `diagdb` prints usage if dump mode is `DIAGDUMP_ALL`.
For correct behavior, modify to print usage if dump mode is not `DIAGDUMP_HEAP`.
