### PR TITLE
[CBRD-25336] modify ha_make_slave.sh script to use $CUBRID_TMP and $TMPDIR

### DIFF
--- a/contrib/scripts/ha/ha_make_slavedb.sh
+++ b/contrib/scripts/ha/ha_make_slavedb.sh
@@ -149,7 +149,7 @@ function ssh_cubrid()
 	if $verbose; then
 		echo "[$cubrid_user@$host]$ $command"
 	fi
-	ssh -p $ssh_port -t $cubrid_user@$host "export PATH=$PATH; export LD_LIBRARY_PATH=$LD_LIBRARY_PATH; export CUBRID=$CUBRID; export CUBRID_DATABASES=$CUBRID_DATABASES; $command"
+	ssh -p $ssh_port -t $cubrid_user@$host "export PATH=$PATH; export LD_LIBRARY_PATH=$LD_LIBRARY_PATH; export CUBRID=$CUBRID; export CUBRID_DATABASES=$CUBRID_DATABASES; export CUBRID_TMP=$CUBRID_TMP; export TMPDIR=$TMPDIR; $command"
 }
 
 function ssh_expect()


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25336

When rebuilding replication using ha_make_slave.sh if it set $CUBRID_TMP and $TMPDIR environment, an error occurs where localhost cannot be found.So, we will modify ha_make_slave.sh to use two environment variables.
