### PR TITLE
[CBRD-25337] After switching users from csql to session command, DDL Log must be recorded in the changed DB log file.

### DIFF
--- a/src/base/ddl_log.c
+++ b/src/base/ddl_log.c
@@ -783,6 +783,8 @@ void
 logddl_write ()
 {
   FILE *fp = NULL;
+  char *dbname = NULL;
+  char *user_name = NULL;
 
   if (ddl_logging_enabled == false)
     {
@@ -794,8 +796,11 @@ logddl_write ()
       return;
     }
 
-  logddl_set_db_name (db_get_database_name ());
-  logddl_set_user_name (db_get_user_name ());
+  dbname = db_get_database_name ();
+  logddl_set_db_name (dbname);
+
+  user_name = db_get_user_name ();
+  logddl_set_user_name (user_name);
 
   fp = logddl_open (ddl_audit_handle.app_name);
 
@@ -830,6 +835,16 @@ write_error:
       fclose (fp);
       fp = NULL;
     }
+
+  if (dbname != NULL)
+    {
+      db_string_free (dbname);
+    }
+
+  if (user_name != NULL)
+    {
+      db_string_free (user_name);
+    }
 }
 
 void
@@ -840,6 +855,8 @@ logddl_write_tran_str (const char *fmt, ...)
   int len = 0;
   struct timeval time_val;
   va_list args;
+  char *dbname = NULL;
+  char *user_name = NULL;
 
   if (ddl_logging_enabled == false)
     {
@@ -851,8 +868,11 @@ logddl_write_tran_str (const char *fmt, ...)
       goto write_error;
     }
 
-  logddl_set_db_name (db_get_database_name ());
-  logddl_set_user_name (db_get_user_name ());
+  dbname = db_get_database_name ();
+  logddl_set_db_name (dbname);
+
+  user_name = db_get_user_name ();
+  logddl_set_user_name (user_name);
 
   fp = logddl_open (ddl_audit_handle.app_name);
 
@@ -927,6 +947,16 @@ write_error:
       fp = NULL;
     }
 
+  if (dbname != NULL)
+    {
+      db_string_free (dbname);
+    }
+
+  if (user_name != NULL)
+    {
+      db_string_free (user_name);
+    }
+
   logddl_free (true);
 }
 
@@ -936,6 +966,9 @@ logddl_write_end_for_csql_fileinput (const char *fmt, ...)
   FILE *fp = NULL;
   struct timeval time_val;
   va_list args;
+  char *dbname = NULL;
+  char *user_name = NULL;
+
   if (ddl_logging_enabled == false)
     {
       return;
@@ -951,8 +984,11 @@ logddl_write_end_for_csql_fileinput (const char *fmt, ...)
       return;
     }
 
-  logddl_set_db_name (db_get_database_name ());
-  logddl_set_user_name (db_get_user_name ());
+  dbname = db_get_database_name ();
+  logddl_set_db_name (dbname);
+
+  user_name = db_get_user_name ();
+  logddl_set_user_name (user_name);
 
   fp = logddl_open (ddl_audit_handle.app_name);
 
@@ -992,6 +1028,16 @@ write_error:
     {
       fclose (fp);
       fp = NULL;
+    }
+
+  if (dbname != NULL)
+    {
+      db_string_free (dbname);
+    }
+
+  if (user_name != NULL)
+    {
+      db_string_free (user_name);
     }
 
   logddl_free (true);

--- a/src/base/ddl_log.c
+++ b/src/base/ddl_log.c
@@ -50,6 +50,7 @@
 #include "broker_config.h"
 #include "util_func.h"
 #include "hide_password.h"
+#include "db.h"
 
 #define DDL_LOG_MSG 	            (256)
 #define DDL_LOG_PATH    	    "log/ddl_audit"
@@ -793,6 +794,9 @@ logddl_write ()
       return;
     }
 
+  logddl_set_db_name (db_get_database_name ());
+  logddl_set_user_name (db_get_user_name ());
+
   fp = logddl_open (ddl_audit_handle.app_name);
 
   if (fp != NULL)
@@ -846,6 +850,9 @@ logddl_write_tran_str (const char *fmt, ...)
     {
       goto write_error;
     }
+
+  logddl_set_db_name (db_get_database_name ());
+  logddl_set_user_name (db_get_user_name ());
 
   fp = logddl_open (ddl_audit_handle.app_name);
 
@@ -943,6 +950,9 @@ logddl_write_end_for_csql_fileinput (const char *fmt, ...)
     {
       return;
     }
+
+  logddl_set_db_name (db_get_database_name ());
+  logddl_set_user_name (db_get_user_name ());
 
   fp = logddl_open (ddl_audit_handle.app_name);
 

--- a/src/broker/cas.c
+++ b/src/broker/cas.c
@@ -1370,8 +1370,6 @@ cas_main (void)
 
 	    logddl_check_ddl_audit_param ();
 	    logddl_set_broker_info (shm_as_index, shm_appl->broker_name);
-	    logddl_set_db_name (db_name);
-	    logddl_set_user_name (db_user);
 	    logddl_set_ip (client_ip_str);
 
 	    db_set_client_ip_addr (client_ip_str);

--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -3603,6 +3603,15 @@ csql_connect (char *argument, CSQL_ARGUMENT * csql_arg)
       db_disable_trigger ();
     }
 
+  if (csql_arg->db_name != NULL)
+    {
+      logddl_set_db_name (csql_arg->db_name);
+    }
+  if (csql_arg->user_name != NULL)
+    {
+      logddl_set_user_name (csql_arg->user_name);
+    }
+
   fprintf (csql_Output_fp, "Connected.\n");
 
 

--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -2978,14 +2978,7 @@ csql (const char *argv0, CSQL_ARGUMENT * csql_arg)
 
   logddl_init (APP_NAME_CSQL);
   logddl_check_ddl_audit_param ();
-  if (csql_arg->db_name != NULL)
-    {
-      logddl_set_db_name (csql_arg->db_name);
-    }
-  if (csql_arg->user_name != NULL)
-    {
-      logddl_set_user_name (csql_arg->user_name);
-    }
+
   if (get_host_ip (ip_addr) == 0)
     {
       logddl_set_ip ((char *) ip_addr);
@@ -3601,15 +3594,6 @@ csql_connect (char *argument, CSQL_ARGUMENT * csql_arg)
   if (csql_arg->trigger_action_flag == false)
     {
       db_disable_trigger ();
-    }
-
-  if (csql_arg->db_name != NULL)
-    {
-      logddl_set_db_name (csql_arg->db_name);
-    }
-  if (csql_arg->user_name != NULL)
-    {
-      logddl_set_user_name (csql_arg->user_name);
     }
 
   fprintf (csql_Output_fp, "Connected.\n");

--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -640,8 +640,6 @@ loaddb_internal (UTIL_FUNCTION_ARG * arg, int dba_mode)
 
   logddl_init (APP_NAME_LOADDB);
   logddl_check_ddl_audit_param ();
-  logddl_set_db_name (args.volume.c_str ());
-  logddl_set_user_name (args.user_name.c_str ());
 
   /* disable trigger actions to be fired */
   db_disable_trigger ();


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25337

Purpose
In csql, DDL Log records must be recorded for each connected DB.
In csql, when changing a user using the login method, the changed user name must be recorded in the DDL Log.

Implementation
N/A

Remarks
N/A
