### PR TITLE
[CBRD-25307] heap_Guesschn_area should be accessed through the pointer, heap_Guesschn.

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -15237,8 +15237,7 @@ heap_chnguess_realloc (void)
   if (heap_Guesschn->bitindex == NULL)
     {
       ret = ER_OUT_OF_VIRTUAL_MEMORY;
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ret, 1,
-	      (size_t) (heap_Guesschn->nbytes * heap_Guesschn->num_entries));
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ret, 1, (size_t) (heap_Guesschn->nbytes * heap_Guesschn->num_entries));
       heap_Guesschn->bitindex = save_bitindex;
       heap_Guesschn->nbytes = save_nbytes;
       heap_Guesschn->num_clients = HEAP_NBYTES_TO_NBITS (save_nbytes);

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -15212,8 +15212,8 @@ heap_chnguess_realloc (void)
   /*
    * Save current information, so we can copy them at a alater point
    */
-  save_bitindex = heap_Guesschn_area.bitindex;
-  save_nbytes = heap_Guesschn_area.nbytes;
+  save_bitindex = heap_Guesschn->bitindex;
+  save_nbytes = heap_Guesschn->nbytes;
 
   /*
    * Find the number of clients that need to be supported. Avoid small
@@ -15230,18 +15230,18 @@ heap_chnguess_realloc (void)
     }
 
   /* Make sure every single bit is used */
-  heap_Guesschn_area.nbytes = HEAP_NBITS_TO_NBYTES (heap_Guesschn_area.num_clients);
-  heap_Guesschn_area.num_clients = HEAP_NBYTES_TO_NBITS (heap_Guesschn_area.nbytes);
+  heap_Guesschn->nbytes = HEAP_NBITS_TO_NBYTES (heap_Guesschn->num_clients);
+  heap_Guesschn->num_clients = HEAP_NBYTES_TO_NBITS (heap_Guesschn->nbytes);
 
-  heap_Guesschn_area.bitindex = (unsigned char *) malloc (heap_Guesschn_area.nbytes * heap_Guesschn_area.num_entries);
-  if (heap_Guesschn_area.bitindex == NULL)
+  heap_Guesschn->bitindex = (unsigned char *) malloc (heap_Guesschn->nbytes * heap_Guesschn->num_entries);
+  if (heap_Guesschn->bitindex == NULL)
     {
       ret = ER_OUT_OF_VIRTUAL_MEMORY;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ret, 1,
-	      (size_t) (heap_Guesschn_area.nbytes * heap_Guesschn_area.num_entries));
-      heap_Guesschn_area.bitindex = save_bitindex;
-      heap_Guesschn_area.nbytes = save_nbytes;
-      heap_Guesschn_area.num_clients = HEAP_NBYTES_TO_NBITS (save_nbytes);
+	      (size_t) (heap_Guesschn->nbytes * heap_Guesschn->num_entries));
+      heap_Guesschn->bitindex = save_bitindex;
+      heap_Guesschn->nbytes = save_nbytes;
+      heap_Guesschn->num_clients = HEAP_NBYTES_TO_NBITS (save_nbytes);
       goto exit_on_error;
     }
 
@@ -15249,15 +15249,15 @@ heap_chnguess_realloc (void)
    * Now reset the bits for each entry
    */
 
-  for (i = 0; i < heap_Guesschn_area.num_entries; i++)
+  for (i = 0; i < heap_Guesschn->num_entries; i++)
     {
-      entry = &heap_Guesschn_area.entries[i];
-      entry->bits = &heap_Guesschn_area.bitindex[i * heap_Guesschn_area.nbytes];
+      entry = &heap_Guesschn->entries[i];
+      entry->bits = &heap_Guesschn->bitindex[i * heap_Guesschn->nbytes];
       /*
        * Copy the bits
        */
       memcpy (entry->bits, &save_bitindex[i * save_nbytes], save_nbytes);
-      HEAP_NBYTES_CLEARED (&entry->bits[save_nbytes], heap_Guesschn_area.nbytes - save_nbytes);
+      HEAP_NBYTES_CLEARED (&entry->bits[save_nbytes], heap_Guesschn->nbytes - save_nbytes);
     }
   /*
    * Now throw previous storage
@@ -15468,7 +15468,7 @@ heap_chnguess_remove_entry (const void *oid_key, void *ent, void *xignore)
   OID_SET_NULL (&entry->oid);
   entry->chn = NULL_CHN;
   entry->recently_accessed = false;
-  heap_Guesschn_area.clock_hand = entry->idx;
+  heap_Guesschn->clock_hand = entry->idx;
 
   return NO_ERROR;
 }
@@ -15499,7 +15499,7 @@ heap_chnguess_dump (FILE * fp)
       max_tranindex = logtb_get_number_of_total_tran_indices ();
       for (i = 0; i < heap_Guesschn->num_entries; i++)
 	{
-	  entry = &heap_Guesschn_area.entries[i];
+	  entry = &heap_Guesschn->entries[i];
 
 	  if (!OID_ISNULL (&entry->oid))
 	    {
@@ -15624,7 +15624,7 @@ heap_chnguess_put (THREAD_ENTRY * thread_p, const OID * oid, int tran_index, int
        */
       if (entry->chn != chn)
 	{
-	  HEAP_NBYTES_CLEARED (entry->bits, heap_Guesschn_area.nbytes);
+	  HEAP_NBYTES_CLEARED (entry->bits, heap_Guesschn->nbytes);
 	  entry->chn = chn;
 	}
     }
@@ -15664,7 +15664,7 @@ heap_chnguess_put (THREAD_ENTRY * thread_p, const OID * oid, int tran_index, int
 		{
 		  entry->oid = *oid;
 		  entry->chn = chn;
-		  HEAP_NBYTES_CLEARED (entry->bits, heap_Guesschn_area.nbytes);
+		  HEAP_NBYTES_CLEARED (entry->bits, heap_Guesschn->nbytes);
 		  break;
 		}
 	    }
@@ -15712,7 +15712,7 @@ heap_chnguess_clear (THREAD_ENTRY * thread_p, int tran_index)
     {
       for (i = 0; i < heap_Guesschn->num_entries; i++)
 	{
-	  entry = &heap_Guesschn_area.entries[i];
+	  entry = &heap_Guesschn->entries[i];
 	  if (!OID_ISNULL (&entry->oid))
 	    {
 	      HEAP_BIT_CLEAR (entry->bits, (unsigned int) tran_index);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25307

Purpose
The gloabl structure heap_Guesschn_area in heap module should be accessed through a pointer, heap_Guesschn, except in an initailization.

Implementation
N/A

Remarks
N/A