### PR TITLE
[CBRD-25307] heap_Classrepr_cache should be accessed through the pointer, heap_Classrepr.

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -1527,8 +1527,8 @@ heap_classrepr_finalize_cache (void)
 #endif /* DEBUG_CLASSREPR_CACHE */
 
   /* finalize hash entries table */
-  cache_entry = heap_Classrepr_cache.area;
-  for (i = 0; cache_entry != NULL && i < heap_Classrepr_cache.num_entries; i++)
+  cache_entry = heap_Classrepr->area;
+  for (i = 0; cache_entry != NULL && i < heap_Classrepr->num_entries; i++)
     {
       pthread_mutex_destroy (&cache_entry[i].mutex);
 
@@ -1548,36 +1548,36 @@ heap_classrepr_finalize_cache (void)
 	}
       free_and_init (cache_entry[i].repr);
     }
-  if (heap_Classrepr_cache.area != NULL)
+  if (heap_Classrepr->area != NULL)
     {
-      free_and_init (heap_Classrepr_cache.area);
+      free_and_init (heap_Classrepr->area);
     }
-  heap_Classrepr_cache.num_entries = -1;
+  heap_Classrepr->num_entries = -1;
 
   /* finalize hash bucket table */
-  hash_entry = heap_Classrepr_cache.hash_table;
-  for (i = 0; hash_entry != NULL && i < heap_Classrepr_cache.num_hash; i++)
+  hash_entry = heap_Classrepr->hash_table;
+  for (i = 0; hash_entry != NULL && i < heap_Classrepr->num_hash; i++)
     {
       pthread_mutex_destroy (&hash_entry[i].hash_mutex);
     }
-  heap_Classrepr_cache.num_hash = -1;
-  if (heap_Classrepr_cache.hash_table != NULL)
+  heap_Classrepr->num_hash = -1;
+  if (heap_Classrepr->hash_table != NULL)
     {
-      free_and_init (heap_Classrepr_cache.hash_table);
+      free_and_init (heap_Classrepr->hash_table);
     }
 
   /* finalize hash lock table */
-  if (heap_Classrepr_cache.lock_table != NULL)
+  if (heap_Classrepr->lock_table != NULL)
     {
-      free_and_init (heap_Classrepr_cache.lock_table);
+      free_and_init (heap_Classrepr->lock_table);
     }
 
   /* finalize LRU list */
 
-  pthread_mutex_destroy (&heap_Classrepr_cache.LRU_list.LRU_mutex);
+  pthread_mutex_destroy (&heap_Classrepr->LRU_list.LRU_mutex);
 
   /* initialize free list */
-  pthread_mutex_destroy (&heap_Classrepr_cache.free_list.free_mutex);
+  pthread_mutex_destroy (&heap_Classrepr->free_list.free_mutex);
 
   heap_Classrepr = NULL;
 
@@ -1649,18 +1649,18 @@ heap_classrepr_entry_remove_from_LRU (HEAP_CLASSREPR_ENTRY * cache_entry)
 {
   if (cache_entry)
     {
-      if (cache_entry == heap_Classrepr_cache.LRU_list.LRU_top)
+      if (cache_entry == heap_Classrepr->LRU_list.LRU_top)
 	{
-	  heap_Classrepr_cache.LRU_list.LRU_top = cache_entry->next;
+	  heap_Classrepr->LRU_list.LRU_top = cache_entry->next;
 	}
       else
 	{
 	  cache_entry->prev->next = cache_entry->next;
 	}
 
-      if (cache_entry == heap_Classrepr_cache.LRU_list.LRU_bottom)
+      if (cache_entry == heap_Classrepr->LRU_list.LRU_bottom)
 	{
-	  heap_Classrepr_cache.LRU_list.LRU_bottom = cache_entry->prev;
+	  heap_Classrepr->LRU_list.LRU_bottom = cache_entry->prev;
 	}
       else
 	{
@@ -1783,9 +1783,9 @@ heap_classrepr_decache_guessed_last (const OID * class_oid)
       /* Remove from LRU list */
       if (cache_entry->zone == ZONE_LRU)
 	{
-	  rv = pthread_mutex_lock (&heap_Classrepr_cache.LRU_list.LRU_mutex);
+	  rv = pthread_mutex_lock (&heap_Classrepr->LRU_list.LRU_mutex);
 	  (void) heap_classrepr_entry_remove_from_LRU (cache_entry);
-	  pthread_mutex_unlock (&heap_Classrepr_cache.LRU_list.LRU_mutex);
+	  pthread_mutex_unlock (&heap_Classrepr->LRU_list.LRU_mutex);
 	  cache_entry->zone = ZONE_VOID;
 	}
       cache_entry->prev = NULL;
@@ -1913,7 +1913,7 @@ heap_classrepr_free (OR_CLASSREP * classrep, int *idx_incache)
       return NO_ERROR;
     }
 
-  cache_entry = &heap_Classrepr_cache.area[*idx_incache];
+  cache_entry = &heap_Classrepr->area[*idx_incache];
 
   rv = pthread_mutex_lock (&cache_entry->mutex);
   cache_entry->fcnt--;
@@ -1923,9 +1923,9 @@ heap_classrepr_free (OR_CLASSREP * classrep, int *idx_incache)
        * Is this entry declared to be decached
        */
 #ifdef DEBUG_CLASSREPR_CACHE
-      rv = pthread_mutex_lock (&heap_Classrepr_cache.num_fix_entries_mutex);
-      heap_Classrepr_cache.num_fix_entries--;
-      pthread_mutex_unlock (&heap_Classrepr_cache.num_fix_entries_mutex);
+      rv = pthread_mutex_lock (&heap_Classrepr->num_fix_entries_mutex);
+      heap_Classrepr->num_fix_entries--;
+      pthread_mutex_unlock (&heap_Classrepr->num_fix_entries_mutex);
 #endif /* DEBUG_CLASSREPR_CACHE */
       if (cache_entry->force_decache)
 	{
@@ -1941,9 +1941,9 @@ heap_classrepr_free (OR_CLASSREP * classrep, int *idx_incache)
       else
 	{
 	  /* relocate entry to the top of LRU list */
-	  if (cache_entry != heap_Classrepr_cache.LRU_list.LRU_top)
+	  if (cache_entry != heap_Classrepr->LRU_list.LRU_top)
 	    {
-	      rv = pthread_mutex_lock (&heap_Classrepr_cache.LRU_list.LRU_mutex);
+	      rv = pthread_mutex_lock (&heap_Classrepr->LRU_list.LRU_mutex);
 	      if (cache_entry->zone == ZONE_LRU)
 		{
 		  /* remove from LRU list */
@@ -1952,19 +1952,19 @@ heap_classrepr_free (OR_CLASSREP * classrep, int *idx_incache)
 
 	      /* insert into LRU top */
 	      cache_entry->prev = NULL;
-	      cache_entry->next = heap_Classrepr_cache.LRU_list.LRU_top;
-	      if (heap_Classrepr_cache.LRU_list.LRU_top == NULL)
+	      cache_entry->next = heap_Classrepr->LRU_list.LRU_top;
+	      if (heap_Classrepr->LRU_list.LRU_top == NULL)
 		{
-		  heap_Classrepr_cache.LRU_list.LRU_bottom = cache_entry;
+		  heap_Classrepr->LRU_list.LRU_bottom = cache_entry;
 		}
 	      else
 		{
-		  heap_Classrepr_cache.LRU_list.LRU_top->prev = cache_entry;
+		  heap_Classrepr->LRU_list.LRU_top->prev = cache_entry;
 		}
-	      heap_Classrepr_cache.LRU_list.LRU_top = cache_entry;
+	      heap_Classrepr->LRU_list.LRU_top = cache_entry;
 	      cache_entry->zone = ZONE_LRU;
 
-	      pthread_mutex_unlock (&heap_Classrepr_cache.LRU_list.LRU_mutex);
+	      pthread_mutex_unlock (&heap_Classrepr->LRU_list.LRU_mutex);
 	    }
 	}
     }
@@ -2026,7 +2026,7 @@ heap_classrepr_lock_class (THREAD_ENTRY * thread_p, HEAP_CLASSREPR_HASH * hash_a
 	}
     }
 
-  cur_lock_entry = &heap_Classrepr_cache.lock_table[cur_thrd_entry->index];
+  cur_lock_entry = &heap_Classrepr->lock_table[cur_thrd_entry->index];
   cur_lock_entry->class_oid = *class_oid;
   cur_lock_entry->next_wait_thrd = NULL;
   cur_lock_entry->lock_next = hash_anchor->lock_next;
@@ -2116,23 +2116,23 @@ heap_classrepr_entry_alloc (void)
 /* check_free_list: */
 
   /* 1. Get entry from free list */
-  if (heap_Classrepr_cache.free_list.free_top == NULL)
+  if (heap_Classrepr->free_list.free_top == NULL)
     {
       goto check_LRU_list;
     }
 
-  rv = pthread_mutex_lock (&heap_Classrepr_cache.free_list.free_mutex);
-  if (heap_Classrepr_cache.free_list.free_top == NULL)
+  rv = pthread_mutex_lock (&heap_Classrepr->free_list.free_mutex);
+  if (heap_Classrepr->free_list.free_top == NULL)
     {
-      pthread_mutex_unlock (&heap_Classrepr_cache.free_list.free_mutex);
+      pthread_mutex_unlock (&heap_Classrepr->free_list.free_mutex);
       cache_entry = NULL;
     }
   else
     {
-      cache_entry = heap_Classrepr_cache.free_list.free_top;
-      heap_Classrepr_cache.free_list.free_top = cache_entry->next;
-      heap_Classrepr_cache.free_list.free_cnt--;
-      pthread_mutex_unlock (&heap_Classrepr_cache.free_list.free_mutex);
+      cache_entry = heap_Classrepr->free_list.free_top;
+      heap_Classrepr->free_list.free_top = cache_entry->next;
+      heap_Classrepr->free_list.free_cnt--;
+      pthread_mutex_unlock (&heap_Classrepr->free_list.free_mutex);
 
       rv = pthread_mutex_lock (&cache_entry->mutex);
       cache_entry->next = NULL;
@@ -2143,13 +2143,13 @@ heap_classrepr_entry_alloc (void)
 
 check_LRU_list:
   /* 2. Get entry from LRU list */
-  if (heap_Classrepr_cache.LRU_list.LRU_bottom == NULL)
+  if (heap_Classrepr->LRU_list.LRU_bottom == NULL)
     {
       goto expand_list;
     }
 
-  rv = pthread_mutex_lock (&heap_Classrepr_cache.LRU_list.LRU_mutex);
-  for (cache_entry = heap_Classrepr_cache.LRU_list.LRU_bottom; cache_entry != NULL; cache_entry = cache_entry->prev)
+  rv = pthread_mutex_lock (&heap_Classrepr->LRU_list.LRU_mutex);
+  for (cache_entry = heap_Classrepr->LRU_list.LRU_bottom; cache_entry != NULL; cache_entry = cache_entry->prev)
     {
       if (cache_entry->fcnt == 0)
 	{
@@ -2160,7 +2160,7 @@ check_LRU_list:
 	  break;
 	}
     }
-  pthread_mutex_unlock (&heap_Classrepr_cache.LRU_list.LRU_mutex);
+  pthread_mutex_unlock (&heap_Classrepr->LRU_list.LRU_mutex);
 
   if (cache_entry == NULL)
     {
@@ -2232,14 +2232,14 @@ static int
 heap_classrepr_entry_free (HEAP_CLASSREPR_ENTRY * cache_entry)
 {
   int rv;
-  rv = pthread_mutex_lock (&heap_Classrepr_cache.free_list.free_mutex);
+  rv = pthread_mutex_lock (&heap_Classrepr->free_list.free_mutex);
 
-  cache_entry->next = heap_Classrepr_cache.free_list.free_top;
-  heap_Classrepr_cache.free_list.free_top = cache_entry;
+  cache_entry->next = heap_Classrepr->free_list.free_top;
+  heap_Classrepr->free_list.free_top = cache_entry;
   cache_entry->zone = ZONE_FREE;
-  heap_Classrepr_cache.free_list.free_cnt++;
+  heap_Classrepr->free_list.free_cnt++;
 
-  pthread_mutex_unlock (&heap_Classrepr_cache.free_list.free_mutex);
+  pthread_mutex_unlock (&heap_Classrepr->free_list.free_mutex);
 
   return NO_ERROR;
 }
@@ -2521,9 +2521,9 @@ search_begin:
       cache_entry->fcnt = 1;
       cache_entry->class_oid = *class_oid;
 #ifdef DEBUG_CLASSREPR_CACHE
-      r = pthread_mutex_lock (&heap_Classrepr_cache.num_fix_entries_mutex);
-      heap_Classrepr_cache.num_fix_entries++;
-      pthread_mutex_unlock (&heap_Classrepr_cache.num_fix_entries_mutex);
+      r = pthread_mutex_lock (&heap_Classrepr->num_fix_entries_mutex);
+      heap_Classrepr->num_fix_entries++;
+      pthread_mutex_unlock (&heap_Classrepr->num_fix_entries_mutex);
 
 #endif /* DEBUG_CLASSREPR_CACHE */
       *idx_incache = cache_entry->idx;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25307

Purpose
The gloabl structure heap_Classrepr_cache in heap module should be accessed through a pointer, heap_Classrepr, except in an initailization.

Implementation
N/A

Remarks
N/A