### PR TITLE
[CBRD-25342] Update Outdated Default Generator in build.sh Help Message

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -469,7 +469,7 @@ function show_usage ()
   echo "  -m      Set build mode(release, debug or coverage); [default: release]"
   echo "  -i      Increase build number; [default: no]"
   echo "  -a      Run autogen.sh before build; [default: yes]"
-  echo "  -g      Specifies the generator for a build (make, ninja); [default: make]"
+  echo "  -g      Specifies the generator for a build (make, ninja); [default: ninja]"
   echo "  -c opts Set configure options; [default: NONE]"
   echo "  -s path Set source path; [default: current directory]"
   echo "  -b path Set build path; [default: <source path>/build_<mode>_<target>]"


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25342

Purpose

The current help message output by build.sh -h incorrectly states that the default generator for builds is make. However, as of the recent updates (refer to [CBRD-24775](http://jira.cubrid.org/browse/CBRD-24775)), the default generator has been changed to ninja. This discrepancy could lead to confusion and incorrect usage of the script by new developers or automated systems not aware of the change.

Current Result:
```
  -g      Specifies the generator for a build (make, ninja); [default: make]
```

Expected Result:
```
  -g      Specifies the generator for a build (make, ninja); [default: ninja]
```