### PR TITLE
[CBRD-25338] fix typo 'requiements' -> 'requirements'

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Follow tutorials at:
   - To use ninja build system, CMake 3.16.3 or later is required
 - For more information about 3rdparty libraries, see [3rdparty/README.md](3rdparty/README.md)
 
-### How to Install the Build Requiements
+### How to Install the Build Requirements
 
   Please refer to the following link:
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25338

There is a typo error that is similar to CUBRID-25315.
filepath: https://github.com/CUBRID/cubrid/blob/develop/README.md

Expected:

    # How to Install the Build Requirements

Actual:

    # How to Install the Build Requiements 

 