### PR TITLE
[CBRD-24902] Store PL/CSQL source code in _db_stored_procedure_code catalog

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/data/CompileInfo.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/data/CompileInfo.java
@@ -43,7 +43,6 @@ public class CompileInfo implements PackableObject {
     public String createStmt = null;
     public String className = null;
     public String signature = null;
-    public byte[] compiled = null;
 
     public CompileInfo(int code, int line, int column, String msg) {
         assert code < 0;
@@ -76,11 +75,6 @@ public class CompileInfo implements PackableObject {
             packer.packString(createStmt);
             packer.packString(className);
             packer.packString(signature);
-            if (compiled != null) {
-                packer.packCString(compiled);
-            } else {
-                packer.packCString(dummy);
-            }
         }
     }
 }

--- a/src/jsp/jsp_cl.cpp
+++ b/src/jsp/jsp_cl.cpp
@@ -828,7 +828,7 @@ jsp_create_stored_procedure (PARSER_CONTEXT *parser, PT_NODE *statement)
       code_info.stype = 0;
       code_info.scode = pl_code;
       code_info.otype = 0;
-      code_info.ocode = "dummy"; // TODO
+      code_info.ocode = "dummy"; // TODO: CBRD-24552
       code_info.owner = Au_user; // current user
 
       err = sp_add_stored_procedure_code (code_info);

--- a/src/jsp/jsp_cl.cpp
+++ b/src/jsp/jsp_cl.cpp
@@ -1148,7 +1148,7 @@ drop_stored_procedure (const char *name, SP_TYPE_ENUM expected_type)
 	}
 
       target = db_get_string (&target_val);
-      class_name = get_class_name (target);
+      class_name = get_class_name (std::string (target));
 
       err = drop_stored_procedure_code (class_name.c_str ());
       if (err != NO_ERROR)

--- a/src/jsp/jsp_cl.cpp
+++ b/src/jsp/jsp_cl.cpp
@@ -36,7 +36,6 @@
 #include <chrono>
 #include <ctime>
 #include <iomanip>
-#include <chrono>
 #include <sstream>
 
 #include "authenticate.h"

--- a/src/jsp/jsp_cl.cpp
+++ b/src/jsp/jsp_cl.cpp
@@ -1066,12 +1066,12 @@ static int
 drop_stored_procedure (const char *name, SP_TYPE_ENUM expected_type)
 {
   MOP sp_mop, arg_mop, owner;
-  DB_VALUE sp_type_val, arg_cnt_val, args_val, owner_val, generated_val, target_val, temp;
+  DB_VALUE sp_type_val, arg_cnt_val, args_val, owner_val, generated_val, target_val, lang_val, temp;
   SP_TYPE_ENUM real_type;
   std::string class_name;
   const char *target;
   DB_SET *arg_set_p;
-  int save, i, arg_cnt;
+  int save, i, arg_cnt, lang;
   int err;
 
   AU_DISABLE (save);
@@ -1131,19 +1131,30 @@ drop_stored_procedure (const char *name, SP_TYPE_ENUM expected_type)
     }
 
   // delete _db_stored_procedure_code
-  err = db_get (sp_mop, SP_ATTR_TARGET, &target_val);
+
+  err = db_get (sp_mop, SP_ATTR_LANG, &lang_val);
   if (err != NO_ERROR)
     {
       goto error;
     }
 
-  target = db_get_string (&target_val);
-  class_name = get_class_name (target);
-
-  err = drop_stored_procedure_code (class_name.c_str ());
-  if (err != NO_ERROR)
+  lang = db_get_int (&lang_val);
+  if (lang == SP_LANG_PLCSQL)
     {
-      goto error;
+      err = db_get (sp_mop, SP_ATTR_TARGET, &target_val);
+      if (err != NO_ERROR)
+	{
+	  goto error;
+	}
+
+      target = db_get_string (&target_val);
+      class_name = get_class_name (target);
+
+      err = drop_stored_procedure_code (class_name.c_str ());
+      if (err != NO_ERROR)
+	{
+	  goto error;
+	}
     }
 
   err = db_get (sp_mop, SP_ATTR_ARG_COUNT, &arg_cnt_val);

--- a/src/object/schema_system_catalog_install.cpp
+++ b/src/object/schema_system_catalog_install.cpp
@@ -913,8 +913,10 @@ namespace cubschema
     },
 // constraints
     {
-      {DB_CONSTRAINT_UNIQUE, "", {"name", "created_time", nullptr}, false},
-      {DB_CONSTRAINT_NOT_NULL, "", {"name", nullptr}, false},
+      // TODO: before created_time is managed in cub_javasp in the next issue, comment out the follwoing line. 
+      // {DB_CONSTRAINT_UNIQUE, "", {"name", "created_time", nullptr}, false},
+      {DB_CONSTRAINT_UNIQUE, "", {"name", nullptr}, false},
+      {DB_CONSTRAINT_NOT_NULL, "", {"created_time", nullptr}, false}
     },
 // authorization
     {

--- a/src/object/schema_system_catalog_install.cpp
+++ b/src/object/schema_system_catalog_install.cpp
@@ -913,7 +913,7 @@ namespace cubschema
     },
 // constraints
     {
-      // TODO: before created_time is managed in cub_javasp in the next issue, comment out the follwoing line. 
+      // TODO: before created_time is managed in cub_javasp in the next issue, comment out the follwoing line.
       // {DB_CONSTRAINT_UNIQUE, "", {"name", "created_time", nullptr}, false},
       {DB_CONSTRAINT_UNIQUE, "", {"name", nullptr}, false},
       {DB_CONSTRAINT_NOT_NULL, "", {"created_time", nullptr}, false}

--- a/src/object/schema_system_catalog_install.cpp
+++ b/src/object/schema_system_catalog_install.cpp
@@ -913,8 +913,8 @@ namespace cubschema
     },
 // constraints
     {
-      {DB_CONSTRAINT_UNIQUE, "", {"name", nullptr}, false},
       {DB_CONSTRAINT_UNIQUE, "", {"name", "created_time", nullptr}, false},
+      {DB_CONSTRAINT_NOT_NULL, "", {"name", nullptr}, false},
     },
 // authorization
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24902

- call sp_add_stored_procedure_code() if registering stored routine is PL/CSQL.
  - `create_time` is generated in sp_add_stored_procedure().
  - `stype`, `otype` and `ocode` have dummy value now. their value will be set properly in the next PR.
- In drop_stored_procedure (), To delete a row of PL/CSQL's code, drop_stored_procedure_code () is called.
- To fix assertion in btree_unique(), {"name"}'s constraints is changed from DB_CONSTRAINT_UNIQUE to DB_CONSTRAINT_NOT_NULL.