### PR TITLE
[CBRD-25347] Fix tracking holes of memory monitoring

### DIFF
--- a/src/base/memory_cwrapper.h
+++ b/src/base/memory_cwrapper.h
@@ -77,12 +77,15 @@ get_allocated_size (void *ptr)
 inline void
 cub_free (void *ptr)
 {
-  if (mmon_is_memory_monitor_enabled () && ptr != NULL)
+  if (ptr != NULL)
     {
-      assert (malloc_usable_size (ptr) != 0);
-      mmon_sub_stat ((char *) ptr);
+      if (mmon_is_memory_monitor_enabled ())
+	{
+	  assert (malloc_usable_size (ptr) != 0);
+	  mmon_sub_stat ((char *) ptr);
+	}
+      free (ptr);
     }
-  free (ptr);
 }
 
 inline void *


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25347

Change conditions in cub_free()
