### PR TITLE
[CBRD-25345] check invalid ACL entry

### DIFF
--- a/src/broker/broker_acl.c
+++ b/src/broker/broker_acl.c
@@ -149,6 +149,12 @@ access_control_read_config_file (T_SHM_APPL_SERVER * shm_appl, char *filename, c
 	  continue;
 	}
 
+      if (!char_isalpha (buf[0]) && !(buf[0] == '[' || buf[0] == '*'))
+	{
+	  sprintf (admin_err_msg, "invalid acl list entry: (%s)", buf);
+	  goto error;
+	}
+
       if (is_current_broker_section == false && strncmp (buf, "[%", 2) == 0 && buf[strlen (buf) - 1] == ']')
 	{
 	  buf[strlen (buf) - 1] = '\0';
@@ -246,13 +252,6 @@ access_control_read_config_file (T_SHM_APPL_SERVER * shm_appl, char *filename, c
     }
 
   fclose (fd_access_list);
-
-  if (is_current_broker_section == false)
-    {
-      sprintf (admin_err_msg, "error: broker section is NOT found (%s)", filename);
-      return -1;
-    }
-
 
 #if defined (WINDOWS)
   MAKE_ACL_SEM_NAME (acl_sem_name, shm_appl->broker_name);

--- a/src/broker/broker_acl.c
+++ b/src/broker/broker_acl.c
@@ -116,7 +116,7 @@ access_control_read_config_file (T_SHM_APPL_SERVER * shm_appl, char *filename, c
   int num_access_list = 0, line = 0;
   ACCESS_INFO new_access_info[ACL_MAX_ITEM_COUNT];
   ACCESS_INFO *access_info;
-  bool is_current_broker_section;
+  bool is_current_broker_section = false;
 #if defined(WINDOWS)
   char acl_sem_name[BROKER_NAME_LEN];
 #endif
@@ -128,8 +128,6 @@ access_control_read_config_file (T_SHM_APPL_SERVER * shm_appl, char *filename, c
       sprintf (admin_err_msg, "%s: error while loading access control file(%s)", shm_appl->broker_name, filename);
       return -1;
     }
-
-  is_current_broker_section = false;
 
   memset (new_access_info, '\0', sizeof (new_access_info));
 
@@ -248,6 +246,13 @@ access_control_read_config_file (T_SHM_APPL_SERVER * shm_appl, char *filename, c
     }
 
   fclose (fd_access_list);
+
+  if (is_current_broker_section == false)
+    {
+      sprintf (admin_err_msg, "error: broker section is NOT found (%s)", filename);
+      return -1;
+    }
+
 
 #if defined (WINDOWS)
   MAKE_ACL_SEM_NAME (acl_sem_name, shm_appl->broker_name);

--- a/src/broker/broker_acl.c
+++ b/src/broker/broker_acl.c
@@ -204,7 +204,7 @@ access_control_read_config_file (T_SHM_APPL_SERVER * shm_appl, char *filename, c
 	}
 
       ip_file = p;
-      if (ip_file == NULL)
+      if (ip_file == NULL || strlen (ip_file) == 0)
 	{
 	  sprintf (admin_err_msg,
 		   "%s: error while loading access control file(%s:%d)" " - IP list file paths are empty.",

--- a/src/broker/broker_acl.c
+++ b/src/broker/broker_acl.c
@@ -151,7 +151,7 @@ access_control_read_config_file (T_SHM_APPL_SERVER * shm_appl, char *filename, c
 
       if (!char_isalpha (buf[0]) && !(buf[0] == '[' || buf[0] == '*'))
 	{
-	  sprintf (admin_err_msg, "invalid acl list entry: (%s)", buf);
+	  sprintf (admin_err_msg, "%s: invalid acl list entry: (%s:%d)", shm_appl->broker_name, filename, line);
 	  goto error;
 	}
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25345

**Description**
* broker ACL list example
  ```
  dbname1:dbuser1:READIP.txt
  *:dba:READIP.txt
  ```
**Remarks**: just add check invalid ACL entry whether it start with the following characters:
  1. '[' (for section name)
  2. '*' (for database name wild card)
  3. alphabet (for valid database name)
* **anything else could be invalid**
* please comment, if you have any other opinion 