### PR TITLE
[CBRD-25257] Include headers of wrapping functions into "all" cubrid files

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -243,6 +243,12 @@ jobs:
               fi
             fi
 
+            filename=$(basename $f)
+            check_server_file=$(grep $filename cubrid/CMakeLists.txt)
+            if [ "$check_server_file" == "" ]; then
+              result_for_f="PASS"
+            fi
+
             echo "$f: $result_for_f"
             if [ "$result_for_f" = "FAIL" ]; then
               result="FAIL"

--- a/src/storage/btree_unique.cpp
+++ b/src/storage/btree_unique.cpp
@@ -25,6 +25,18 @@
 #include "string_buffer.hpp"
 
 #include <utility>
+#if 0
+// This file contains `placement new` being used within it, and there are
+// no explicit cases of calling `new`. Since heap memory monitoring does not
+// encounter any holes even without tracking this file, it is considered an
+// exception from the tracked files.
+//
+// To bring this file into the scope of memory monitoring, the usage of
+// `placement new` needs to be removed.
+
+// XXX: SHOULD BE THE LAST INCLUDE HEADER
+#include "memory_wrapper.hpp"
+#endif
 
 btree_unique_stats::btree_unique_stats (stat_type keys, stat_type nulls /* = 0 */)
   : m_rows (keys + nulls)

--- a/src/transaction/mvcc.c
+++ b/src/transaction/mvcc.c
@@ -30,6 +30,18 @@
 #include "perf_monitor.h"
 #include "porting_inline.hpp"
 #include "vacuum.h"
+#if 0
+// This file contains `placement new` being used within it, and there are
+// no explicit cases of calling `new`. Since heap memory monitoring does not
+// encounter any holes even without tracking this file, it is considered an
+// exception from the tracked files.
+//
+// To bring this file into the scope of memory monitoring, the usage of
+// `placement new` needs to be removed.
+
+// XXX: SHOULD BE THE LAST INCLUDE HEADER
+#include "memory_wrapper.hpp"
+#endif
 
 #define MVCC_IS_REC_INSERTER_ACTIVE(thread_p, rec_header_p) \
   (mvcc_is_active_id (thread_p, (rec_header_p)->mvcc_ins_id))


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25257

Fix new workflow with adding false include memory_wrapper.hpp in the files not using it.
