### PR TITLE
[CBRD-25354] The format specifier for the argument is incorrect and the error_code argument is missing in vacuum_er_log_error().

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1523,7 +1523,7 @@ vacuum_heap (THREAD_ENTRY * thread_p, VACUUM_WORKER * worker, MVCCID threshold_m
 	  vacuum_check_shutdown_interruption (thread_p, error_code);
 
 	  vacuum_er_log_error (VACUUM_ER_LOG_HEAP, "Vacuum heap page %d|%d, error_code=%d.",
-			       page_ptr->oid.volid, page_ptr->oid.pageid);
+			       page_ptr->oid.volid, page_ptr->oid.pageid, error_code);
 
 #if defined (NDEBUG)
 	  if (!thread_p->shutdown)
@@ -2008,7 +2008,7 @@ retry_prepare:
 	    {
 	      ASSERT_ERROR_AND_SET (error_code);
 	      vacuum_check_shutdown_interruption (thread_p, error_code);
-	      vacuum_er_log_error (VACUUM_ER_LOG_HEAP, "Failed to fix page %d|d.", VPID_AS_ARGS (&forward_vpid));
+	      vacuum_er_log_error (VACUUM_ER_LOG_HEAP, "Failed to fix page %d|%d.", VPID_AS_ARGS (&forward_vpid));
 	      return error_code;
 	    }
 	  /* Both pages fixed. */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25354

Purpose

1. The vacuum_er_log_error() function is called without passing the error_code argument in the vacuum_heap(). This results in garbage values being output for the error code.
2. In vacuum_er_log_error() function, The format specifier for the argument is incorrect.

Implementation

- N/A

Remarks

- N/A