### PR TITLE
[CBRD-25360] Backport from develop to 11.3 - An issue where the serial value is not unloaded when auto_increment exists in the table.

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -169,6 +169,7 @@ static void emit_cycle_warning (print_output & output_ctx);
 static void force_one_class (print_output & output_ctx, DB_OBJLIST ** class_list, DB_OBJLIST ** order_list);
 static DB_OBJLIST *get_ordered_classes (print_output & output_ctx, MOP * class_table);
 static int export_serial (extract_context & ctxt, print_output & output_ctx);
+static int emit_class_alter_serial (extract_context & ctxt, print_output & output_ctx);
 static int emit_indexes (extract_context & ctxt, print_output & output_ctx, DB_OBJLIST * classes, int has_indexes,
 			 DB_OBJLIST * vclass_list_has_using_index);
 
@@ -900,6 +901,241 @@ err:
   return error;
 }
 
+static int
+emit_class_alter_serial (extract_context & ctxt, print_output & output_ctx)
+{
+  int error = NO_ERROR;
+  int i;
+  DB_QUERY_RESULT *query_result;
+  DB_QUERY_ERROR query_error;
+  DB_VALUE values[SERIAL_VALUE_INDEX_MAX], diff_value, answer_value;
+  DB_DOMAIN *domain;
+  char str_buf[NUMERIC_MAX_STRING_SIZE] = { '\0' };
+  char *uppercase_user = NULL;
+  size_t uppercase_user_size = 0;
+  size_t query_size = 0;
+  char *query = NULL;
+
+  /*
+   * You must check SERIAL_VALUE_INDEX enum defined on the top of this file
+   * when changing the following query. Notice the order of the result.
+   */
+  const char *query_all =
+    "select [unique_name], [name], [owner].[name], " "[current_val], " "[increment_val], " "[max_val], " "[min_val], "
+    "[cyclic], " "[started], " "[cached_num], " "[comment] "
+    "from [db_serial] where [class_name] is not null and [att_name] is not null";
+
+  const char *query_user =
+    "select [unique_name], [name], [owner].[name], " "[current_val], " "[increment_val], " "[max_val], " "[min_val], "
+    "[cyclic], " "[started], " "[cached_num], " "[comment] "
+    "from [db_serial] where [class_name] is not null and [att_name] is not null and owner.name='%s'";
+
+  if (ctxt.is_dba_user == false && ctxt.is_dba_group_member == false)
+    {
+      uppercase_user_size = intl_identifier_upper_string_size (ctxt.login_user);
+      uppercase_user = (char *) malloc (uppercase_user_size + 1);
+      if (uppercase_user == NULL)
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, uppercase_user_size);
+	  return ER_OUT_OF_VIRTUAL_MEMORY;
+	}
+
+      intl_identifier_upper (ctxt.login_user, uppercase_user);
+
+      query_size = strlen (query_user) + strlen (uppercase_user) + 1;
+      query = (char *) malloc (query_size);
+      if (query_user == NULL)
+	{
+	  if (uppercase_user != NULL)
+	    {
+	      free_and_init (uppercase_user);
+	    }
+
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, query_size);
+	  return ER_OUT_OF_VIRTUAL_MEMORY;
+	}
+
+      sprintf (query, query_user, uppercase_user);
+    }
+
+  db_make_null (&diff_value);
+  db_make_null (&answer_value);
+
+  error = db_compile_and_execute_local (((query == NULL) ? query_all : query), &query_result, &query_error);
+  if (error < 0)
+    {
+      goto err;
+    }
+
+
+
+  if (db_query_first_tuple (query_result) == DB_CURSOR_SUCCESS)
+    {
+      do
+	{
+	  for (i = 0; i < SERIAL_VALUE_INDEX_MAX; i++)
+	    {
+	      error = db_query_get_tuple_value (query_result, i, &values[i]);
+	      if (error != NO_ERROR)
+		{
+		  goto err;
+		}
+
+	      /* Validation of the result value */
+	      switch (i)
+		{
+		case SERIAL_OWNER_NAME:
+		  {
+		    if (DB_IS_NULL (&values[i]) || DB_VALUE_TYPE (&values[i]) != DB_TYPE_STRING)
+		      {
+			db_make_string (&values[i], "PUBLIC");
+		      }
+		  }
+		  break;
+
+		case SERIAL_UNIQUE_NAME:
+		case SERIAL_NAME:
+		  {
+		    if (DB_IS_NULL (&values[i]) || DB_VALUE_TYPE (&values[i]) != DB_TYPE_STRING)
+		      {
+			er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_INVALID_SERIAL_VALUE, 0);
+			error = ER_INVALID_SERIAL_VALUE;
+			goto err;
+		      }
+		  }
+		  break;
+
+		case SERIAL_CURRENT_VAL:
+		case SERIAL_INCREMENT_VAL:
+		case SERIAL_MAX_VAL:
+		case SERIAL_MIN_VAL:
+		  {
+		    if (DB_IS_NULL (&values[i]) || DB_VALUE_TYPE (&values[i]) != DB_TYPE_NUMERIC)
+		      {
+			er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_INVALID_SERIAL_VALUE, 0);
+			error = ER_INVALID_SERIAL_VALUE;
+			goto err;
+		      }
+		  }
+		  break;
+
+		case SERIAL_CYCLIC:
+		case SERIAL_STARTED:
+		case SERIAL_CACHED_NUM:
+		  {
+		    if (DB_IS_NULL (&values[i]) || DB_VALUE_TYPE (&values[i]) != DB_TYPE_INTEGER)
+		      {
+			er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_INVALID_SERIAL_VALUE, 0);
+			error = ER_INVALID_SERIAL_VALUE;
+			goto err;
+		      }
+		  }
+		  break;
+
+		case SERIAL_COMMENT:
+		  {
+		    if (DB_IS_NULL (&values[i]) == false && DB_VALUE_TYPE (&values[i]) != DB_TYPE_STRING)
+		      {
+			er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_INVALID_SERIAL_VALUE, 0);
+			error = ER_INVALID_SERIAL_VALUE;
+			goto err;
+		      }
+		  }
+		  break;
+
+		default:
+		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_INVALID_SERIAL_VALUE, 0);
+		  error = ER_INVALID_SERIAL_VALUE;
+		  goto err;
+		}
+	    }
+
+	  if (db_get_int (&values[SERIAL_STARTED]) == 1)
+	    {
+	      /* Calculate next value of serial */
+	      db_make_null (&diff_value);
+	      error = numeric_db_value_sub (&values[SERIAL_MAX_VAL], &values[SERIAL_CURRENT_VAL], &diff_value);
+	      if (error == ER_IT_DATA_OVERFLOW)
+		{
+		  // max - curr might be flooded.
+		  diff_value = values[SERIAL_MAX_VAL];
+		  er_clear ();
+		}
+	      else if (error != NO_ERROR)
+		{
+		  goto err;
+		}
+
+	      error = numeric_db_value_compare (&values[SERIAL_INCREMENT_VAL], &diff_value, &answer_value);
+	      if (error != NO_ERROR)
+		{
+		  goto err;
+		}
+	      /* increment > diff */
+	      if (db_get_int (&answer_value) > 0)
+		{
+		  /* no cyclic case */
+		  if (db_get_int (&values[SERIAL_CYCLIC]) == 0)
+		    {
+		      domain = tp_domain_resolve_default (DB_TYPE_NUMERIC);
+		      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_IT_DATA_OVERFLOW, 1,
+			      pr_type_name (TP_DOMAIN_TYPE (domain)));
+		      error = ER_IT_DATA_OVERFLOW;
+		      goto err;
+		    }
+
+		  db_value_clear (&values[SERIAL_CURRENT_VAL]);
+		  values[SERIAL_CURRENT_VAL] = values[SERIAL_MIN_VAL];
+		}
+	      /* increment <= diff */
+	      else
+		{
+		  error =
+		    numeric_db_value_add (&values[SERIAL_CURRENT_VAL], &values[SERIAL_INCREMENT_VAL], &answer_value);
+		  if (error != NO_ERROR)
+		    {
+		      goto err;
+		    }
+
+		  db_value_clear (&values[SERIAL_CURRENT_VAL]);
+		  values[SERIAL_CURRENT_VAL] = answer_value;
+		}
+	    }
+
+	  if (ctxt.is_dba_user == false && ctxt.is_dba_group_member == false)
+	    {
+	      output_ctx ("\nALTER SERIAL %s%s%s START WITH %s;\n",
+			  PRINT_IDENTIFIER (db_get_string (&values[SERIAL_NAME])),
+			  numeric_db_value_print (&values[SERIAL_CURRENT_VAL], str_buf));
+	    }
+	  else
+	    {
+	      output_ctx ("\nALTER SERIAL %s%s%s START WITH %s;\n",
+			  PRINT_IDENTIFIER (db_get_string (&values[SERIAL_UNIQUE_NAME])),
+			  numeric_db_value_print (&values[SERIAL_CURRENT_VAL], str_buf));
+	    }
+
+	  db_value_clear (&diff_value);
+	  db_value_clear (&answer_value);
+	  for (i = 0; i < SERIAL_VALUE_INDEX_MAX; i++)
+	    {
+	      db_value_clear (&values[i]);
+	    }
+	}
+      while (db_query_next_tuple (query_result) == DB_CURSOR_SUCCESS);
+    }
+
+err:
+  db_query_end (query_result);
+
+  if (uppercase_user != NULL)
+    {
+      free_and_init (uppercase_user);
+    }
+  return error;
+}
+
+
 /*
  * export_synonym - export _db_synonym
  *    return: NO_ERROR if successful, error code otherwise
@@ -1237,6 +1473,16 @@ extract_schema (extract_context & ctxt, print_output & schema_output_ctx)
   emit_class_query_spec (ctxt, schema_output_ctx, EXTRACT_CLASS);
   if (er_errid () != NO_ERROR)
     {
+      err_count++;
+    }
+
+  if (emit_class_alter_serial (ctxt, schema_output_ctx) < NO_ERROR)
+    {
+      fprintf (stderr, "%s", db_error_string (3));
+      if (db_error_code () == ER_INVALID_SERIAL_VALUE)
+	{
+	  fprintf (stderr, " Check the value of db_serial object.\n");
+	}
       err_count++;
     }
 
@@ -4938,6 +5184,17 @@ extract_class (extract_context & ctxt)
   emit_class_query_spec (ctxt, output_ctx, EXTRACT_CLASS);
   if (er_errid () == ER_FAILED)
     {
+      err = ER_FAILED;
+      goto end_class;
+    }
+
+  if (emit_class_alter_serial (ctxt, output_ctx) < NO_ERROR)
+    {
+      fprintf (stderr, "%s", db_error_string (3));
+      if (db_error_code () == ER_INVALID_SERIAL_VALUE)
+	{
+	  fprintf (stderr, " Check the value of db_serial object.\n");
+	}
       err = ER_FAILED;
       goto end_class;
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25360

Purpose
If auto_increment exists in the table, the corresponding serial value is not unloaded when unloading, and an error occurs when using the DB after reconstructing the DB using loaddb for data without a serial value.

Implementation
* Add the code below to the schema file
* ALTER SERIAL <table_name>_ai_<column_name> START WITH <current_value>;

Remarks
