### PR TITLE
[CBRD-25360] Backport from develop to 11.3 - Modify the method of obtaining schema information for tables with auto_increment using unloadd

### DIFF
--- a/src/compat/db_vdb.c
+++ b/src/compat/db_vdb.c
@@ -303,6 +303,7 @@ db_parse_one_statement (DB_SESSION * session)
       if (session->type_list)
 	{
 	  db_free_query_format (session->type_list[0]);
+	  session->type_list[0] = NULL;
 	}
       if (session->statements[0])
 	{

--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -1050,69 +1050,29 @@ emit_class_alter_serial (extract_context & ctxt, print_output & output_ctx)
 		}
 	    }
 
-	  if (db_get_int (&values[SERIAL_STARTED]) == 1)
-	    {
-	      /* Calculate next value of serial */
-	      db_make_null (&diff_value);
-	      error = numeric_db_value_sub (&values[SERIAL_MAX_VAL], &values[SERIAL_CURRENT_VAL], &diff_value);
-	      if (error == ER_IT_DATA_OVERFLOW)
-		{
-		  // max - curr might be flooded.
-		  diff_value = values[SERIAL_MAX_VAL];
-		  er_clear ();
-		}
-	      else if (error != NO_ERROR)
-		{
-		  goto err;
-		}
-
-	      error = numeric_db_value_compare (&values[SERIAL_INCREMENT_VAL], &diff_value, &answer_value);
-	      if (error != NO_ERROR)
-		{
-		  goto err;
-		}
-	      /* increment > diff */
-	      if (db_get_int (&answer_value) > 0)
-		{
-		  /* no cyclic case */
-		  if (db_get_int (&values[SERIAL_CYCLIC]) == 0)
-		    {
-		      domain = tp_domain_resolve_default (DB_TYPE_NUMERIC);
-		      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_IT_DATA_OVERFLOW, 1,
-			      pr_type_name (TP_DOMAIN_TYPE (domain)));
-		      error = ER_IT_DATA_OVERFLOW;
-		      goto err;
-		    }
-
-		  db_value_clear (&values[SERIAL_CURRENT_VAL]);
-		  values[SERIAL_CURRENT_VAL] = values[SERIAL_MIN_VAL];
-		}
-	      /* increment <= diff */
-	      else
-		{
-		  error =
-		    numeric_db_value_add (&values[SERIAL_CURRENT_VAL], &values[SERIAL_INCREMENT_VAL], &answer_value);
-		  if (error != NO_ERROR)
-		    {
-		      goto err;
-		    }
-
-		  db_value_clear (&values[SERIAL_CURRENT_VAL]);
-		  values[SERIAL_CURRENT_VAL] = answer_value;
-		}
-	    }
-
 	  if (ctxt.is_dba_user == false && ctxt.is_dba_group_member == false)
 	    {
 	      output_ctx ("\nALTER SERIAL %s%s%s START WITH %s;\n",
 			  PRINT_IDENTIFIER (db_get_string (&values[SERIAL_NAME])),
 			  numeric_db_value_print (&values[SERIAL_CURRENT_VAL], str_buf));
+
+	      if (db_get_int (&values[SERIAL_STARTED]) == 1)
+		{
+
+		  output_ctx ("SELECT %s%s%s.NEXT_VALUE;\n ", PRINT_IDENTIFIER (db_get_string (&values[SERIAL_NAME])));
+		}
 	    }
 	  else
 	    {
 	      output_ctx ("\nALTER SERIAL %s%s%s START WITH %s;\n",
 			  PRINT_IDENTIFIER (db_get_string (&values[SERIAL_UNIQUE_NAME])),
 			  numeric_db_value_print (&values[SERIAL_CURRENT_VAL], str_buf));
+
+	      if (db_get_int (&values[SERIAL_STARTED]) == 1)
+		{
+		  output_ctx ("SELECT %s%s%s.NEXT_VALUE;\n ",
+			      PRINT_IDENTIFIER (db_get_string (&values[SERIAL_UNIQUE_NAME])));
+		}
 	    }
 
 	  db_value_clear (&diff_value);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25360

Purpose
Modify the method of obtaining schema information for tables with auto_increment using unloaddb

Implementation

Add the following content to the schema file
ALTER SERIAL [tbl_ai_id] START WITH 32766;
SELECT [tbl_ai_id].NEXT_VALUE;
