### PR TITLE
[CBRD-25363] Backport from develop to 11.3 - Issue of creating an unnecessarily empty db_name_schema_uk file when performing unloaddb

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -3102,7 +3102,7 @@ emit_unique_def (extract_context & ctxt, print_output & output_ctx, DB_OBJECT * 
 
   PRINT_OWNER_NAME (owner_name, (ctxt.is_dba_user || ctxt.is_dba_group_member), output_owner, sizeof (output_owner));
 
-  output_ctx ("ALTER %s %s%s%s%s ADD ATTRIBUTE\n", class_type, output_owner, PRINT_IDENTIFIER (class_name_p));
+  output_ctx ("\nALTER %s %s%s%s%s ADD ATTRIBUTE\n", class_type, output_owner, PRINT_IDENTIFIER (class_name_p));
 
   for (constraint = constraint_list; constraint != NULL; constraint = db_constraint_next (constraint))
     {
@@ -3480,7 +3480,7 @@ emit_reverse_unique_def (extract_context & ctxt, print_output & output_ctx, DB_O
 	  PRINT_OWNER_NAME (owner_name, (ctxt.is_dba_user || ctxt.is_dba_group_member), output_owner,
 			    sizeof (output_owner));
 
-	  output_ctx ("CREATE REVERSE UNIQUE INDEX %s%s%s on %s%s%s%s (", PRINT_IDENTIFIER (constraint->name),
+	  output_ctx ("\nCREATE REVERSE UNIQUE INDEX %s%s%s on %s%s%s%s (", PRINT_IDENTIFIER (constraint->name),
 		      output_owner, PRINT_IDENTIFIER (class_name));
 
 	  for (att = atts; *att != NULL; att++)
@@ -5741,13 +5741,11 @@ emit_unique_key (extract_context & ctxt, print_output & output_ctx, DB_OBJLIST *
 
       if (unique_flag)
 	{
-	  output_ctx ("\n");
 	  emit_unique_def (ctxt, output_ctx, cl->op, class_type);
 	}
 
       if (reverse_unique_flag)
 	{
-	  output_ctx ("\n");
 	  emit_reverse_unique_def (ctxt, output_ctx, cl->op);
 	}
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25363

Purpose
If the table has a unique index, the db_name_schema_uk file is created when the --split-schema-files option is used in unloaddb.
However, if there is no unique index in the table, but there is a primary key, db_name_schema_uk is created.
