### PR TITLE
[CBRD-25007] bugfix in Java code generation of long string literals

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -505,7 +505,7 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
         ExprStr escape = ctx.escape == null ? null : visitQuoted_string(ctx.escape);
 
         if (escape != null) {
-            String escapeStr = StringEscapeUtils.unescapeJava(escape.val);
+            String escapeStr = escape.val;
             if (escapeStr.length() != 1) {
                 throw new SemanticError(
                         Misc.getLineColumnOf(ctx.escape), // s002
@@ -2200,7 +2200,7 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     }
 
     private static String quotedStrToJavaStr(String val) {
-        return StringEscapeUtils.escapeJava(unquoteStr(val));
+        return unquoteStr(val);
     }
 
     // --------------------------------------------------------

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -756,7 +756,7 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     @Override
     public ExprStr visitQuoted_string(Quoted_stringContext ctx) {
         String val = ctx.getText();
-        return new ExprStr(ctx, quotedStrToJavaStr(val));
+        return new ExprStr(ctx, unquoteStr(val));
     }
 
     @Override
@@ -2197,10 +2197,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     private static String unquoteStr(String val) {
         val = val.substring(1, val.length() - 1); // strip enclosing '
         return val.replace("''", "'");
-    }
-
-    private static String quotedStrToJavaStr(String val) {
-        return unquoteStr(val);
     }
 
     // --------------------------------------------------------

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprStr.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprStr.java
@@ -81,5 +81,4 @@ public class ExprStr extends Expr {
     //   65534: maximum byte length of a Java string literal,
     //   4: maximum byte length of a character in UTF-8
     private static final int STR_LITERAL_CUT_LEN = 16383;
-
 }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprStr.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/ExprStr.java
@@ -32,6 +32,7 @@ package com.cubrid.plcsql.compiler.ast;
 
 import com.cubrid.plcsql.compiler.visitor.AstVisitor;
 import org.antlr.v4.runtime.ParserRuleContext;
+import org.apache.commons.text.StringEscapeUtils;
 
 public class ExprStr extends Expr {
 
@@ -51,29 +52,23 @@ public class ExprStr extends Expr {
     public String javaCode() {
 
         int len = val.length();
-        if (len <= MAX_STR_LITERAL_LEN) {
-            return "(\"" + val + "\")";
+        if (len <= STR_LITERAL_CUT_LEN) {
+            return "(\"" + StringEscapeUtils.escapeJava(val) + "\")";
         } else {
             StringBuilder sbuilder = new StringBuilder();
             boolean first = true;
-            sbuilder.append("String.join(\"\", new String[] { ");
+            sbuilder.append("String.join(\"\", new String[] {");
 
-            int b;
-            for (b = 0; b + MAX_STR_LITERAL_LEN < len; b += MAX_STR_LITERAL_LEN) {
+            for (int b = 0; b < len; b += STR_LITERAL_CUT_LEN) {
                 if (first) {
                     first = false;
                 } else {
                     sbuilder.append(", ");
                 }
-                sbuilder.append('"' + val.substring(b, b + MAX_STR_LITERAL_LEN) + '"');
+                int e = Math.min(len, b + STR_LITERAL_CUT_LEN);
+                sbuilder.append('"' + StringEscapeUtils.escapeJava(val.substring(b, e)) + '"');
             }
-            if (!first) {
-                sbuilder.append(", ");
-            }
-            sbuilder.append('"' + val.substring(b, len) + '"');
-
-            sbuilder.append(" })");
-
+            sbuilder.append("})");
             return sbuilder.toString();
         }
     }
@@ -82,5 +77,9 @@ public class ExprStr extends Expr {
     // Private
     // -------------------------------------------------------------------
 
-    private static final int MAX_STR_LITERAL_LEN = 65535;
+    // 16383 * 4 = 65532 <= 65534 where
+    //   65534: maximum byte length of a Java string literal,
+    //   4: maximum byte length of a character in UTF-8
+    private static final int STR_LITERAL_CUT_LEN = 16383;
+
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25007

(1) change the string literal cut length from 65535 to 16383
(2) keep the original (unescaped) version of the string literal until Java code generation
