### PR TITLE
[CBRD-25372] Create views without type checking

### DIFF
--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -7552,11 +7552,14 @@ pt_check_vclass_query_spec (PARSER_CONTEXT * parser, PT_NODE * qry, PT_NODE * at
 			   attribute_name (parser, attr), pt_short_print (parser, col));
 	    }
 	}
+#if 0
+      /* spec change: no type check for creating view */
       else if (pt_check_vclass_attr_qspec_compatible (parser, attr, col) != PT_UNION_COMP)
 	{
 	  PT_ERRORmf2 (parser, col, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_ATT_INCOMPATIBLE_COL,
 		       attribute_name (parser, attr), pt_short_print (parser, col));
 	}
+#endif
 
       /* any shared attribute must correspond to NA in the query_spec */
       if (is_shared_attribute (parser, attr) && col->type_enum != PT_TYPE_NA && col->type_enum != PT_TYPE_NULL)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25372
When CUBRID creates a view using the "CREATE VIEW ... AS SELECT ..." statement, it checks whether type conversion is possible for each column of the view. However, in the case of Oracle, the view is created without performing this type check.
Type conversion is checked when the created view is executed, and if type conversion is not possible, an error is processed.
