### PR TITLE
[CBRD-25374] sort-limit-optimization does not work when there is an expression containing a bind variable in the limit clause.

### DIFF
--- a/src/parser/parse_evaluate.c
+++ b/src/parser/parse_evaluate.c
@@ -1254,7 +1254,8 @@ pt_evaluate_tree_internal (PARSER_CONTEXT * parser, PT_NODE * tree, DB_VALUE * d
 	  domain = pt_node_to_db_domain (parser, tree, NULL);
 
 	  /* recheck type of expr for host_var */
-	  if (domain->type->id == DB_TYPE_NULL && (pt_is_hostvar (arg1) || pt_is_hostvar (arg2) || pt_is_hostvar (arg3)))
+	  if (domain && domain->type && domain->type->id == DB_TYPE_NULL
+	      && (pt_is_hostvar (arg1) || pt_is_hostvar (arg2) || pt_is_hostvar (arg3)))
 	    {
 	      common_type = pt_common_type (type1, type2);
 	      if (type3 != PT_TYPE_NONE)

--- a/src/parser/parse_evaluate.c
+++ b/src/parser/parse_evaluate.c
@@ -1252,6 +1252,7 @@ pt_evaluate_tree_internal (PARSER_CONTEXT * parser, PT_NODE * tree, DB_VALUE * d
 	      qualifier = tree->info.expr.qualifier;
 	    }
 	  domain = pt_node_to_db_domain (parser, tree, NULL);
+	  domain = tp_domain_cache (domain);
 
 	  /* recheck type of expr for host_var */
 	  if (domain && domain->type && domain->type->id == DB_TYPE_NULL
@@ -1263,8 +1264,8 @@ pt_evaluate_tree_internal (PARSER_CONTEXT * parser, PT_NODE * tree, DB_VALUE * d
 		  common_type = pt_common_type (common_type, type3);
 		}
 	      domain = pt_type_enum_to_db_domain (common_type);
+	      domain = tp_domain_cache (domain);
 	    }
-	  domain = tp_domain_cache (domain);
 
 	  /* PT_BETWEEN_xxxx, PT_ASSIGN, PT_LIKE_ESCAPE do not need to be evaluated and will return 0 from
 	   * 'pt_evaluate_db_value_expr()' */

--- a/src/parser/parse_evaluate.c
+++ b/src/parser/parse_evaluate.c
@@ -923,7 +923,7 @@ pt_evaluate_tree_internal (PARSER_CONTEXT * parser, PT_NODE * tree, DB_VALUE * d
   PT_NODE *or_next;
   DB_VALUE *val, opd1, opd2, opd3;
   PT_OP_TYPE op;
-  PT_TYPE_ENUM type1, type2, type3;
+  PT_TYPE_ENUM type1 = PT_TYPE_NONE, type2 = PT_TYPE_NONE, type3 = PT_TYPE_NONE, common_type = PT_TYPE_NONE;
   TP_DOMAIN *domain;
   PT_MISC_TYPE qualifier = (PT_MISC_TYPE) 0;
   QUERY_ID query_id_self = parser->query_id;
@@ -1252,6 +1252,17 @@ pt_evaluate_tree_internal (PARSER_CONTEXT * parser, PT_NODE * tree, DB_VALUE * d
 	      qualifier = tree->info.expr.qualifier;
 	    }
 	  domain = pt_node_to_db_domain (parser, tree, NULL);
+
+	  /* recheck type of expr for host_var */
+	  if (domain->type->id == DB_TYPE_NULL && (pt_is_hostvar (arg1) || pt_is_hostvar (arg2) || pt_is_hostvar (arg3)))
+	    {
+	      common_type = pt_common_type (type1, type2);
+	      if (type3 != PT_TYPE_NONE)
+		{
+		  common_type = pt_common_type (common_type, type3);
+		}
+	      domain = pt_type_enum_to_db_domain (common_type);
+	    }
 	  domain = tp_domain_cache (domain);
 
 	  /* PT_BETWEEN_xxxx, PT_ASSIGN, PT_LIKE_ESCAPE do not need to be evaluated and will return 0 from


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25374

In semantic check, the type of expr node containing host var is not evaluated. Because of this, an error occurs in the const folding. In pt_evaluate_tree_internal(), host_var is changed to a value, so the type of the expr node containing host_var should be rechecked.
