### PR TITLE
[CBRD-25362] bug fix in SP argument type conversion in PL engine

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/DateTimeParser.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/DateTimeParser.java
@@ -47,26 +47,26 @@ import java.util.Locale;
 
 public class DateTimeParser {
 
+    // zoneless part of min timestamp: 1970-01-01 00:00:01
+    public static final LocalDateTime minTimestampLocal = LocalDateTime.of(1970, 1, 1, 0, 0, 1);
+    // zoneless part of max timestamp local part: 2038-01-19 03:14:07
+    public static final LocalDateTime maxTimestampLocal = LocalDateTime.of(2038, 1, 19, 3, 14, 7);
+
+    // min datetime: 0001-01-01 00:00:00.000
+    public static final LocalDateTime minDatetimeLocal = LocalDateTime.of(1, 1, 1, 0, 0, 0, 0);
+    // max datetime: 9999-12-31 23:59:59.999
+    public static final LocalDateTime maxDatetimeLocal = LocalDateTime.of(9999, 12, 31, 23, 59, 59, 999);
+
     private static final ZoneOffset TIMEZONE_0 = ZoneOffset.of("Z");
     // TODO: update the following value along with the server
     private static final ZoneOffset TIMEZONE_SESSION = ZoneOffset.of("+09:00");
-
-    // zoneless part of min timestamp: 1970-01-01 00:00:01
-    private static final LocalDateTime minTimestampLocal = LocalDateTime.of(1970, 1, 1, 0, 0, 1);
-    // zoneless part of max timestamp local part: 2038-01-19 03:14:07
-    private static final LocalDateTime maxTimestampLocal = LocalDateTime.of(2038, 1, 19, 3, 14, 7);
-    // min datetime: 0001-01-01 00:00:00.000
-    private static final LocalDateTime minDatetime = LocalDateTime.of(1, 1, 1, 0, 0, 0, 0);
-    // max datetime: 9999-12-31 23:59:59.999
-    private static final LocalDateTime maxDatetime =
-            LocalDateTime.of(9999, 12, 31, 23, 59, 59, 999);
 
     private static final ZonedDateTime minTimestamp =
             ZonedDateTime.of(minTimestampLocal, TIMEZONE_0);
     private static final ZonedDateTime maxTimestamp =
             ZonedDateTime.of(maxTimestampLocal, TIMEZONE_0);
-    private static final ZonedDateTime minDatetimeUTC = ZonedDateTime.of(minDatetime, TIMEZONE_0);
-    private static final ZonedDateTime maxDatetimeUTC = ZonedDateTime.of(maxDatetime, TIMEZONE_0);
+    private static final ZonedDateTime minDatetimeUTC = ZonedDateTime.of(minDatetimeLocal, TIMEZONE_0);
+    private static final ZonedDateTime maxDatetimeUTC = ZonedDateTime.of(maxDatetimeLocal, TIMEZONE_0);
 
     public static final LocalDate nullDate = LocalDate.MAX;
     public static final LocalDateTime nullDatetime = LocalDateTime.MAX;
@@ -116,7 +116,7 @@ public class DateTimeParser {
             LocalDateTime ret = parseDateAndTime(s, true);
             if (ret != null
                     && ret != nullDatetime
-                    && (ret.compareTo(minDatetime) < 0 || ret.compareTo(maxDatetime) > 0)) {
+                    && (ret.compareTo(minDatetimeLocal) < 0 || ret.compareTo(maxDatetimeLocal) > 0)) {
                 return null;
             }
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/DateTimeParser.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/DateTimeParser.java
@@ -55,7 +55,8 @@ public class DateTimeParser {
     // min datetime: 0001-01-01 00:00:00.000
     public static final LocalDateTime minDatetimeLocal = LocalDateTime.of(1, 1, 1, 0, 0, 0, 0);
     // max datetime: 9999-12-31 23:59:59.999
-    public static final LocalDateTime maxDatetimeLocal = LocalDateTime.of(9999, 12, 31, 23, 59, 59, 999);
+    public static final LocalDateTime maxDatetimeLocal =
+            LocalDateTime.of(9999, 12, 31, 23, 59, 59, 999);
 
     private static final ZoneOffset TIMEZONE_0 = ZoneOffset.of("Z");
     // TODO: update the following value along with the server
@@ -65,8 +66,10 @@ public class DateTimeParser {
             ZonedDateTime.of(minTimestampLocal, TIMEZONE_0);
     private static final ZonedDateTime maxTimestamp =
             ZonedDateTime.of(maxTimestampLocal, TIMEZONE_0);
-    private static final ZonedDateTime minDatetimeUTC = ZonedDateTime.of(minDatetimeLocal, TIMEZONE_0);
-    private static final ZonedDateTime maxDatetimeUTC = ZonedDateTime.of(maxDatetimeLocal, TIMEZONE_0);
+    private static final ZonedDateTime minDatetimeUTC =
+            ZonedDateTime.of(minDatetimeLocal, TIMEZONE_0);
+    private static final ZonedDateTime maxDatetimeUTC =
+            ZonedDateTime.of(maxDatetimeLocal, TIMEZONE_0);
 
     public static final LocalDate nullDate = LocalDate.MAX;
     public static final LocalDateTime nullDatetime = LocalDateTime.MAX;
@@ -116,7 +119,8 @@ public class DateTimeParser {
             LocalDateTime ret = parseDateAndTime(s, true);
             if (ret != null
                     && ret != nullDatetime
-                    && (ret.compareTo(minDatetimeLocal) < 0 || ret.compareTo(maxDatetimeLocal) > 0)) {
+                    && (ret.compareTo(minDatetimeLocal) < 0
+                            || ret.compareTo(maxDatetimeLocal) > 0)) {
                 return null;
             }
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/DateValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/DateValue.java
@@ -33,7 +33,6 @@ package com.cubrid.jsp.value;
 
 import com.cubrid.jsp.exception.TypeMismatchException;
 import java.sql.Date;
-import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Calendar;
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/DateValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/DateValue.java
@@ -68,10 +68,6 @@ public class DateValue extends Value {
         return date;
     }
 
-    public Time toTime() throws TypeMismatchException {
-        return new Time(date.getTime());
-    }
-
     public Timestamp toTimestamp() throws TypeMismatchException {
         return new Timestamp(date.getTime());
     }
@@ -90,10 +86,6 @@ public class DateValue extends Value {
 
     public Date[] toDateArray() throws TypeMismatchException {
         return new Date[] {date};
-    }
-
-    public Time[] toTimeArray() throws TypeMismatchException {
-        return new Time[] {toTime()};
     }
 
     public Timestamp[] toTimestampArray() throws TypeMismatchException {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/DatetimeValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/DatetimeValue.java
@@ -84,7 +84,11 @@ public class DatetimeValue extends Value {
 
     public Timestamp toTimestamp() throws TypeMismatchException {
         long sec = timestamp.getTime() / 1000L; // truncate milli-seconds
-        return new Timestamp(sec * 1000L);
+        Timestamp ret = new Timestamp(sec * 1000L);
+        if (!ValueUtilities.checkValidTimestamp(ret)) {
+            throw new TypeMismatchException("out of valid range of a Timestamp: " + timestamp);
+        }
+        return ret;
     }
 
     public Timestamp toDatetime() throws TypeMismatchException {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/DoubleValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/DoubleValue.java
@@ -113,7 +113,7 @@ public class DoubleValue extends Value {
     }
 
     public Time[] toTimeArray() throws TypeMismatchException {
-        return new Time[] { toTime() };
+        return new Time[] {toTime()};
     }
 
     public Timestamp toTimestamp() throws TypeMismatchException {
@@ -123,7 +123,7 @@ public class DoubleValue extends Value {
     }
 
     public Timestamp[] toTimestampArray() throws TypeMismatchException {
-        return new Timestamp[] { toTimestamp() };
+        return new Timestamp[] {toTimestamp()};
     }
 
     public String toString() {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/DoubleValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/DoubleValue.java
@@ -33,6 +33,8 @@ package com.cubrid.jsp.value;
 
 import com.cubrid.jsp.exception.TypeMismatchException;
 import java.math.BigDecimal;
+import java.sql.Time;
+import java.sql.Timestamp;
 
 public class DoubleValue extends Value {
     private double value;
@@ -102,6 +104,26 @@ public class DoubleValue extends Value {
 
     public Object toObject() throws TypeMismatchException {
         return toDoubleObject();
+    }
+
+    public Time toTime() throws TypeMismatchException {
+        BigDecimal bd = BigDecimal.valueOf(value);
+        long l = ValueUtilities.bigDecimalToLong(bd);
+        return ValueUtilities.longToTime(l);
+    }
+
+    public Time[] toTimeArray() throws TypeMismatchException {
+        return new Time[] { toTime() };
+    }
+
+    public Timestamp toTimestamp() throws TypeMismatchException {
+        BigDecimal bd = BigDecimal.valueOf(value);
+        long l = ValueUtilities.bigDecimalToLong(bd);
+        return ValueUtilities.longToTimestamp(l);
+    }
+
+    public Timestamp[] toTimestampArray() throws TypeMismatchException {
+        return new Timestamp[] { toTimestamp() };
     }
 
     public String toString() {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/FloatValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/FloatValue.java
@@ -113,7 +113,7 @@ public class FloatValue extends Value {
     }
 
     public Time[] toTimeArray() throws TypeMismatchException {
-        return new Time[] { toTime() };
+        return new Time[] {toTime()};
     }
 
     public Timestamp toTimestamp() throws TypeMismatchException {
@@ -123,7 +123,7 @@ public class FloatValue extends Value {
     }
 
     public Timestamp[] toTimestampArray() throws TypeMismatchException {
-        return new Timestamp[] { toTimestamp() };
+        return new Timestamp[] {toTimestamp()};
     }
 
     public String toString() {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/FloatValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/FloatValue.java
@@ -33,6 +33,8 @@ package com.cubrid.jsp.value;
 
 import com.cubrid.jsp.exception.TypeMismatchException;
 import java.math.BigDecimal;
+import java.sql.Time;
+import java.sql.Timestamp;
 
 public class FloatValue extends Value {
     private float value;
@@ -102,6 +104,26 @@ public class FloatValue extends Value {
 
     public Object toObject() throws TypeMismatchException {
         return toFloatObject();
+    }
+
+    public Time toTime() throws TypeMismatchException {
+        BigDecimal bd = BigDecimal.valueOf(new Float(value).doubleValue());
+        long l = ValueUtilities.bigDecimalToLong(bd);
+        return ValueUtilities.longToTime(l);
+    }
+
+    public Time[] toTimeArray() throws TypeMismatchException {
+        return new Time[] { toTime() };
+    }
+
+    public Timestamp toTimestamp() throws TypeMismatchException {
+        BigDecimal bd = BigDecimal.valueOf(new Float(value).doubleValue());
+        long l = ValueUtilities.bigDecimalToLong(bd);
+        return ValueUtilities.longToTimestamp(l);
+    }
+
+    public Timestamp[] toTimestampArray() throws TypeMismatchException {
+        return new Timestamp[] { toTimestamp() };
     }
 
     public String toString() {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/IntValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/IntValue.java
@@ -143,7 +143,7 @@ public class IntValue extends Value {
     }
 
     public Time[] toTimeArray() throws TypeMismatchException {
-        return new Time[] { toTime() };
+        return new Time[] {toTime()};
     }
 
     public Timestamp toTimestamp() throws TypeMismatchException {
@@ -151,7 +151,7 @@ public class IntValue extends Value {
     }
 
     public Timestamp[] toTimestampArray() throws TypeMismatchException {
-        return new Timestamp[] { toTimestamp() };
+        return new Timestamp[] {toTimestamp()};
     }
 
     public String toString() {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/IntValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/IntValue.java
@@ -33,6 +33,8 @@ package com.cubrid.jsp.value;
 
 import com.cubrid.jsp.exception.TypeMismatchException;
 import java.math.BigDecimal;
+import java.sql.Time;
+import java.sql.Timestamp;
 
 public class IntValue extends Value {
     private int value;
@@ -134,6 +136,22 @@ public class IntValue extends Value {
 
     public Object[] toObjectArray() throws TypeMismatchException {
         return new Object[] {toObject()};
+    }
+
+    public Time toTime() throws TypeMismatchException {
+        return ValueUtilities.longToTime(new Integer(value).longValue());
+    }
+
+    public Time[] toTimeArray() throws TypeMismatchException {
+        return new Time[] { toTime() };
+    }
+
+    public Timestamp toTimestamp() throws TypeMismatchException {
+        return ValueUtilities.longToTimestamp(new Integer(value).longValue());
+    }
+
+    public Timestamp[] toTimestampArray() throws TypeMismatchException {
+        return new Timestamp[] { toTimestamp() };
     }
 
     public String toString() {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/LongValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/LongValue.java
@@ -111,7 +111,7 @@ public class LongValue extends Value {
     }
 
     public Time[] toTimeArray() throws TypeMismatchException {
-        return new Time[] { toTime() };
+        return new Time[] {toTime()};
     }
 
     public Timestamp toTimestamp() throws TypeMismatchException {
@@ -119,7 +119,7 @@ public class LongValue extends Value {
     }
 
     public Timestamp[] toTimestampArray() throws TypeMismatchException {
-        return new Timestamp[] { toTimestamp() };
+        return new Timestamp[] {toTimestamp()};
     }
 
     public String toString() {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/LongValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/LongValue.java
@@ -33,6 +33,8 @@ package com.cubrid.jsp.value;
 
 import com.cubrid.jsp.exception.TypeMismatchException;
 import java.math.BigDecimal;
+import java.sql.Time;
+import java.sql.Timestamp;
 
 public class LongValue extends Value {
     private long value;
@@ -102,6 +104,22 @@ public class LongValue extends Value {
 
     public Object toObject() throws TypeMismatchException {
         return toLongObject();
+    }
+
+    public Time toTime() throws TypeMismatchException {
+        return ValueUtilities.longToTime(value);
+    }
+
+    public Time[] toTimeArray() throws TypeMismatchException {
+        return new Time[] { toTime() };
+    }
+
+    public Timestamp toTimestamp() throws TypeMismatchException {
+        return ValueUtilities.longToTimestamp(value);
+    }
+
+    public Timestamp[] toTimestampArray() throws TypeMismatchException {
+        return new Timestamp[] { toTimestamp() };
     }
 
     public String toString() {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/NumericValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/NumericValue.java
@@ -33,7 +33,6 @@ package com.cubrid.jsp.value;
 
 import com.cubrid.jsp.exception.TypeMismatchException;
 import java.math.BigDecimal;
-import java.sql.Time;
 import java.sql.Timestamp;
 
 public class NumericValue extends Value {
@@ -120,7 +119,7 @@ public class NumericValue extends Value {
     }
 
     public Timestamp[] toTimestampArray() throws TypeMismatchException {
-        return new Timestamp[] { toTimestamp() };
+        return new Timestamp[] {toTimestamp()};
     }
 
     public String toString() {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/NumericValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/NumericValue.java
@@ -33,6 +33,8 @@ package com.cubrid.jsp.value;
 
 import com.cubrid.jsp.exception.TypeMismatchException;
 import java.math.BigDecimal;
+import java.sql.Time;
+import java.sql.Timestamp;
 
 public class NumericValue extends Value {
     private BigDecimal value;
@@ -107,6 +109,18 @@ public class NumericValue extends Value {
 
     public Object toObject() throws TypeMismatchException {
         return toBigDecimal();
+    }
+
+    public Timestamp toTimestamp() throws TypeMismatchException {
+        if (value == null) {
+            return null;
+        }
+        long l = ValueUtilities.bigDecimalToLong(value);
+        return ValueUtilities.longToTimestamp(l);
+    }
+
+    public Timestamp[] toTimestampArray() throws TypeMismatchException {
+        return new Timestamp[] { toTimestamp() };
     }
 
     public String toString() {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/ShortValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/ShortValue.java
@@ -33,6 +33,8 @@ package com.cubrid.jsp.value;
 
 import com.cubrid.jsp.exception.TypeMismatchException;
 import java.math.BigDecimal;
+import java.sql.Time;
+import java.sql.Timestamp;
 
 public class ShortValue extends Value {
     private short value;
@@ -134,6 +136,22 @@ public class ShortValue extends Value {
 
     public Object[] toObjectArray() throws TypeMismatchException {
         return new Object[] {toObject()};
+    }
+
+    public Time toTime() throws TypeMismatchException {
+        return ValueUtilities.longToTime(new Short(value).longValue());
+    }
+
+    public Time[] toTimeArray() throws TypeMismatchException {
+        return new Time[] { toTime() };
+    }
+
+    public Timestamp toTimestamp() throws TypeMismatchException {
+        return ValueUtilities.longToTimestamp(new Short(value).longValue());
+    }
+
+    public Timestamp[] toTimestampArray() throws TypeMismatchException {
+        return new Timestamp[] { toTimestamp() };
     }
 
     public String toString() {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/ShortValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/ShortValue.java
@@ -143,7 +143,7 @@ public class ShortValue extends Value {
     }
 
     public Time[] toTimeArray() throws TypeMismatchException {
-        return new Time[] { toTime() };
+        return new Time[] {toTime()};
     }
 
     public Timestamp toTimestamp() throws TypeMismatchException {
@@ -151,7 +151,7 @@ public class ShortValue extends Value {
     }
 
     public Timestamp[] toTimestampArray() throws TypeMismatchException {
-        return new Timestamp[] { toTimestamp() };
+        return new Timestamp[] {toTimestamp()};
     }
 
     public String toString() {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/TimeValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/TimeValue.java
@@ -64,20 +64,8 @@ public class TimeValue extends Value {
         assert time.getTime() % 1000L == 0;
     }
 
-    public Date toDate() throws TypeMismatchException {
-        return new Date(time.getTime());
-    }
-
     public Time toTime() throws TypeMismatchException {
         return time;
-    }
-
-    public Timestamp toTimestamp() throws TypeMismatchException {
-        return new Timestamp(time.getTime());
-    }
-
-    public Timestamp toDatetime() throws TypeMismatchException {
-        return new Timestamp(time.getTime());
     }
 
     public Object toObject() throws TypeMismatchException {
@@ -88,20 +76,8 @@ public class TimeValue extends Value {
         return time.toString();
     }
 
-    public Date[] toDateArray() throws TypeMismatchException {
-        return new Date[] {toDate()};
-    }
-
     public Time[] toTimeArray() throws TypeMismatchException {
         return new Time[] {toTime()};
-    }
-
-    public Timestamp[] toTimestampArray() throws TypeMismatchException {
-        return new Timestamp[] {toTimestamp()};
-    }
-
-    public Timestamp[] toDatetimeArray() throws TypeMismatchException {
-        return new Timestamp[] {toDatetime()};
     }
 
     public Object[] toObjectArray() throws TypeMismatchException {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/TimeValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/TimeValue.java
@@ -32,9 +32,7 @@
 package com.cubrid.jsp.value;
 
 import com.cubrid.jsp.exception.TypeMismatchException;
-import java.sql.Date;
 import java.sql.Time;
-import java.sql.Timestamp;
 import java.util.Calendar;
 
 public class TimeValue extends Value {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/ValueUtilities.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/ValueUtilities.java
@@ -33,6 +33,11 @@ package com.cubrid.jsp.value;
 
 import com.cubrid.jsp.data.DBType;
 import com.cubrid.jsp.exception.TypeMismatchException;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 public class ValueUtilities {
     public static Object resolveValue(int dbType, Value value) throws TypeMismatchException {
@@ -92,4 +97,103 @@ public class ValueUtilities {
         }
         return resolvedResult;
     }
+
+    public static Time longToTime(long l) throws TypeMismatchException {
+        if (l < 0L) {
+            // negative values seem to result in a invalid time value
+            // e.g.
+            // select cast(cast(-1 as bigint) as time);
+            // === <Result of SELECT Command in Line 1> ===
+            //
+            // <00001>  cast( cast(-1 as bigint) as time): 12:00:0/ AM
+            //
+            // 1 row selected. (0.004910 sec) Committed. (0.000020 sec)
+            throw new TypeMismatchException("negative values not allowed");
+        }
+
+        int totalSec = (int) (l % 86400L);
+        int hour = totalSec / 3600;
+        int minuteSec = totalSec % 3600;
+        int min = minuteSec / 60;
+        int sec = minuteSec % 60;
+        return new Time(hour, min, sec);
+    }
+
+    public static Timestamp longToTimestamp(long l) throws TypeMismatchException {
+        if (l < 0L) {
+            //   select cast(cast(-100 as bigint) as timestamp);
+            //   ERROR: Cannot coerce value of domain "bigint" to domain "timestamp"
+            throw new TypeMismatchException("negative values not allowed");
+        } else if (l > 2147483647L) {
+            // 2147483647L : see section 'implicit type conversion' in the user manual
+            throw new TypeMismatchException("values over 2,147,483,647 not allowed");
+        } else {
+            return new Timestamp(l * 1000L); // * 1000 : converts it to milli-seconds
+        }
+    }
+
+    public static long bigDecimalToLong(BigDecimal bd) throws TypeMismatchException {
+        // 1.5 -->2, and -1.5 --> -2 NOTE; different from // Math.round
+        BigDecimal bdp = bd.setScale(0, RoundingMode.HALF_UP);
+        try {
+            return bdp.longValueExact();
+        } catch (ArithmeticException e) {
+            throw new TypeMismatchException("not fit in a BIGINT: " + bd);
+        }
+    }
+
+    public static int bigDecimalToInt(BigDecimal bd) throws TypeMismatchException {
+        // 1.5 -->2, and -1.5 --> -2 NOTE; different from // Math.round
+        BigDecimal bdp = bd.setScale(0, RoundingMode.HALF_UP);
+        try {
+            return bdp.intValueExact();
+        } catch (ArithmeticException e) {
+            throw new TypeMismatchException("not fit in an INTEGER: " + bd);
+        }
+    }
+
+    public static short bigDecimalToShort(BigDecimal bd) throws TypeMismatchException {
+        // 1.5 -->2, and -1.5 --> -2 NOTE; different from // Math.round
+        BigDecimal bdp = bd.setScale(0, RoundingMode.HALF_UP);
+        try {
+            return bdp.shortValueExact();
+        } catch (ArithmeticException e) {
+            throw new TypeMismatchException("not fit in a SHORT: " + bd);
+        }
+    }
+
+    public static boolean checkValidTimestamp(Timestamp ts) {
+        if (ts == null) {
+            return false;
+        }
+
+        if (ts.equals(NULL_TIMESTAMP)) {
+            return true;
+        }
+
+        return ts.compareTo(MIN_TIMESTAMP) >= 0 && ts.compareTo(MAX_TIMESTAMP) <= 0;
+    }
+
+    public static boolean checkValidDatetime(Timestamp dt) {
+        if (dt == null) {
+            return false;
+        }
+
+        if (dt.equals(NULL_DATETIME)) {
+            return true;
+        }
+
+        return dt.compareTo(MIN_DATETIME) >= 0 && dt.compareTo(MAX_DATETIME) <= 0;
+    }
+
+    public static final Timestamp MIN_TIMESTAMP = Timestamp.valueOf(DateTimeParser.minTimestampLocal);
+    public static final Timestamp MAX_TIMESTAMP = Timestamp.valueOf(DateTimeParser.maxTimestampLocal);
+    public static final Timestamp MIN_DATETIME = Timestamp.valueOf(DateTimeParser.minDatetimeLocal);
+    public static final Timestamp MAX_DATETIME = Timestamp.valueOf(DateTimeParser.maxDatetimeLocal);
+
+    public static final Date NULL_DATE = new Date(0 - 1900, 0 - 1, 0);
+    public static final Timestamp NULL_TIMESTAMP = new Timestamp(0 - 1900, 0 - 1, 0, 0, 0, 0, 0);
+    public static final Timestamp NULL_DATETIME = new Timestamp(0 - 1900, 0 - 1, 0, 0, 0, 0, 0);
+
+
 }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/ValueUtilities.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/ValueUtilities.java
@@ -33,11 +33,11 @@ package com.cubrid.jsp.value;
 
 import com.cubrid.jsp.data.DBType;
 import com.cubrid.jsp.exception.TypeMismatchException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 
 public class ValueUtilities {
     public static Object resolveValue(int dbType, Value value) throws TypeMismatchException {
@@ -186,14 +186,14 @@ public class ValueUtilities {
         return dt.compareTo(MIN_DATETIME) >= 0 && dt.compareTo(MAX_DATETIME) <= 0;
     }
 
-    public static final Timestamp MIN_TIMESTAMP = Timestamp.valueOf(DateTimeParser.minTimestampLocal);
-    public static final Timestamp MAX_TIMESTAMP = Timestamp.valueOf(DateTimeParser.maxTimestampLocal);
+    public static final Timestamp MIN_TIMESTAMP =
+            Timestamp.valueOf(DateTimeParser.minTimestampLocal);
+    public static final Timestamp MAX_TIMESTAMP =
+            Timestamp.valueOf(DateTimeParser.maxTimestampLocal);
     public static final Timestamp MIN_DATETIME = Timestamp.valueOf(DateTimeParser.minDatetimeLocal);
     public static final Timestamp MAX_DATETIME = Timestamp.valueOf(DateTimeParser.maxDatetimeLocal);
 
     public static final Date NULL_DATE = new Date(0 - 1900, 0 - 1, 0);
     public static final Timestamp NULL_TIMESTAMP = new Timestamp(0 - 1900, 0 - 1, 0, 0, 0, 0, 0);
     public static final Timestamp NULL_DATETIME = new Timestamp(0 - 1900, 0 - 1, 0, 0, 0, 0, 0);
-
-
 }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -893,6 +893,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                         (node.mode == ExprSerialVal.SerialVal.CURR_VAL)
                                 ? "CURRENT_VALUE"
                                 : "NEXT_VALUE");
+        javaTypesUsed.add("java.math.BigDecimal");
         return applyCoercion(node.coercion, tmpl);
     }
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -31,9 +31,9 @@
 package com.cubrid.plcsql.predefined.sp;
 
 import com.cubrid.jsp.Server;
+import com.cubrid.jsp.exception.TypeMismatchException;
 import com.cubrid.jsp.value.DateTimeParser;
 import com.cubrid.jsp.value.ValueUtilities;
-import com.cubrid.jsp.exception.TypeMismatchException;
 import com.cubrid.plcsql.builtin.DBMS_OUTPUT;
 import com.cubrid.plcsql.compiler.CoercionScheme;
 import com.cubrid.plcsql.compiler.SymbolStack;

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -32,6 +32,8 @@ package com.cubrid.plcsql.predefined.sp;
 
 import com.cubrid.jsp.Server;
 import com.cubrid.jsp.value.DateTimeParser;
+import com.cubrid.jsp.value.ValueUtilities;
+import com.cubrid.jsp.exception.TypeMismatchException;
 import com.cubrid.plcsql.builtin.DBMS_OUTPUT;
 import com.cubrid.plcsql.compiler.CoercionScheme;
 import com.cubrid.plcsql.compiler.SymbolStack;
@@ -2004,7 +2006,7 @@ public class SpLib {
         if (l == null || r == null) {
             return null;
         }
-        if (l.equals(NULL_DATE)) {
+        if (l.equals(ValueUtilities.NULL_DATE)) {
             throw new VALUE_ERROR("attempt to use 'zero date'");
         }
 
@@ -2022,7 +2024,7 @@ public class SpLib {
         if (l == null || r == null) {
             return null;
         }
-        if (l.equals(NULL_DATETIME)) {
+        if (l.equals(ValueUtilities.NULL_DATETIME)) {
             throw new VALUE_ERROR("attempt to use 'zero date'");
         }
 
@@ -2041,7 +2043,7 @@ public class SpLib {
         if (l == null || r == null) {
             return null;
         }
-        if (l.equals(NULL_DATETIME)) {
+        if (l.equals(ValueUtilities.NULL_DATETIME)) {
             throw new VALUE_ERROR("attempt to use 'zero date'");
         }
         assert l.getNanos() == 0;
@@ -2158,7 +2160,7 @@ public class SpLib {
         if (l == null || r == null) {
             return null;
         }
-        if (l.equals(NULL_DATE) || r.equals(NULL_DATE)) {
+        if (l.equals(ValueUtilities.NULL_DATE) || r.equals(ValueUtilities.NULL_DATE)) {
             throw new VALUE_ERROR("attempt to use 'zero date'");
         }
 
@@ -2172,7 +2174,7 @@ public class SpLib {
         if (l == null || r == null) {
             return null;
         }
-        if (l.equals(NULL_DATETIME) || r.equals(NULL_DATETIME)) {
+        if (l.equals(ValueUtilities.NULL_DATETIME) || r.equals(ValueUtilities.NULL_DATETIME)) {
             throw new VALUE_ERROR("attempt to use 'zero date'");
         }
 
@@ -2192,7 +2194,7 @@ public class SpLib {
         if (l == null || r == null) {
             return null;
         }
-        if (l.equals(NULL_DATETIME) || r.equals(NULL_DATETIME)) {
+        if (l.equals(ValueUtilities.NULL_DATETIME) || r.equals(ValueUtilities.NULL_DATETIME)) {
             throw new VALUE_ERROR("attempt to use 'zero date'");
         }
         assert l.getNanos() == 0;
@@ -2217,7 +2219,7 @@ public class SpLib {
         if (l == null || r == null) {
             return null;
         }
-        if (l.equals(NULL_DATE)) {
+        if (l.equals(ValueUtilities.NULL_DATE)) {
             throw new VALUE_ERROR("attempt to use 'zero date'");
         }
 
@@ -2230,7 +2232,7 @@ public class SpLib {
         if (l == null || r == null) {
             return null;
         }
-        if (l.equals(NULL_DATETIME)) {
+        if (l.equals(ValueUtilities.NULL_DATETIME)) {
             throw new VALUE_ERROR("attempt to use 'zero date'");
         }
 
@@ -2249,7 +2251,7 @@ public class SpLib {
         if (l == null || r == null) {
             return null;
         }
-        if (l.equals(NULL_DATETIME)) {
+        if (l.equals(ValueUtilities.NULL_DATETIME)) {
             throw new VALUE_ERROR("attempt to use 'zero date'");
         }
         assert l.getNanos() == 0;
@@ -2354,8 +2356,8 @@ public class SpLib {
         if (e == null) {
             return null;
         }
-        if (e.equals(NULL_DATETIME)) {
-            return NULL_DATE;
+        if (e.equals(ValueUtilities.NULL_DATETIME)) {
+            return ValueUtilities.NULL_DATE;
         }
 
         return new Date(e.getYear(), e.getMonth(), e.getDate());
@@ -2373,8 +2375,8 @@ public class SpLib {
         if (e == null) {
             return null;
         }
-        if (e.equals(NULL_DATETIME)) {
-            return NULL_TIMESTAMP;
+        if (e.equals(ValueUtilities.NULL_DATETIME)) {
+            return ValueUtilities.NULL_TIMESTAMP;
         }
 
         return new Timestamp(
@@ -2391,7 +2393,7 @@ public class SpLib {
         if (e == null) {
             return null;
         }
-        if (e.equals(NULL_DATETIME)) {
+        if (e.equals(ValueUtilities.NULL_DATETIME)) {
             // must be calculated everytime because the AM/PM indicator can change according to the
             // locale change
             return String.format("00:00:00.000 %s 00/00/0000", AM_PM.format(ZERO_DATE));
@@ -2405,8 +2407,8 @@ public class SpLib {
         if (e == null) {
             return null;
         }
-        if (e.equals(NULL_DATE)) {
-            return NULL_DATETIME;
+        if (e.equals(ValueUtilities.NULL_DATE)) {
+            return ValueUtilities.NULL_DATETIME;
         }
 
         return new Timestamp(e.getYear(), e.getMonth(), e.getDate(), 0, 0, 0, 0);
@@ -2416,8 +2418,8 @@ public class SpLib {
         if (e == null) {
             return null;
         }
-        if (e.equals(NULL_DATE)) {
-            return NULL_TIMESTAMP;
+        if (e.equals(ValueUtilities.NULL_DATE)) {
+            return ValueUtilities.NULL_TIMESTAMP;
         }
 
         return new Timestamp(e.getYear(), e.getMonth(), e.getDate(), 0, 0, 0, 0);
@@ -2427,7 +2429,7 @@ public class SpLib {
         if (e == null) {
             return null;
         }
-        if (e.equals(NULL_DATE)) {
+        if (e.equals(ValueUtilities.NULL_DATE)) {
             return "00/00/0000";
         }
 
@@ -2449,8 +2451,8 @@ public class SpLib {
             return null;
         }
 
-        if (e.equals(NULL_TIMESTAMP)) {
-            return NULL_DATETIME;
+        if (e.equals(ValueUtilities.NULL_TIMESTAMP)) {
+            return ValueUtilities.NULL_DATETIME;
         }
         assert e.getNanos() == 0;
 
@@ -2469,8 +2471,8 @@ public class SpLib {
             return null;
         }
 
-        if (e.equals(NULL_TIMESTAMP)) {
-            return NULL_DATE;
+        if (e.equals(ValueUtilities.NULL_TIMESTAMP)) {
+            return ValueUtilities.NULL_DATE;
         }
         assert e.getNanos() == 0;
 
@@ -2491,7 +2493,7 @@ public class SpLib {
             return null;
         }
 
-        if (e.equals(NULL_TIMESTAMP)) {
+        if (e.equals(ValueUtilities.NULL_TIMESTAMP)) {
             // must be calculated everytime because the AM/PM indicator can change according to the
             // locale change
             return String.format("00:00:00 %s 00/00/0000", AM_PM.format(ZERO_DATE));
@@ -2901,7 +2903,7 @@ public class SpLib {
         }
 
         if (dt.equals(DateTimeParser.nullDatetime)) {
-            return NULL_DATETIME;
+            return ValueUtilities.NULL_DATETIME;
         } else {
             return new Timestamp(
                     dt.getYear() - 1900,
@@ -2958,7 +2960,7 @@ public class SpLib {
         }
 
         if (zdt.equals(DateTimeParser.nullDatetimeUTC)) {
-            return NULL_TIMESTAMP;
+            return ValueUtilities.NULL_TIMESTAMP;
         } else {
             assert zdt.getNano() == 0;
             return new Timestamp(
@@ -3511,67 +3513,42 @@ public class SpLib {
     }
 
     private static long bigDecimalToLong(BigDecimal bd) {
-        bd = bd.setScale(0, RoundingMode.HALF_UP); // 1.5 -->2, and -1.5 --> -2 NOTE: different from
-        // Math.round
         try {
-            return bd.longValueExact();
-        } catch (ArithmeticException e) {
-            throw new VALUE_ERROR("not fit in a BIGINT: " + bd);
+            return ValueUtilities.bigDecimalToLong(bd);
+        } catch (TypeMismatchException e) {
+            throw new VALUE_ERROR(e.getMessage());
         }
     }
 
     private static int bigDecimalToInt(BigDecimal bd) {
-        bd = bd.setScale(0, RoundingMode.HALF_UP); // 1.5 -->2, and -1.5 --> -2 NOTE: different from
-        // Math.round
         try {
-            return bd.intValueExact();
-        } catch (ArithmeticException e) {
-            throw new VALUE_ERROR("not fit in an INTEGER: " + bd);
+            return ValueUtilities.bigDecimalToInt(bd);
+        } catch (TypeMismatchException e) {
+            throw new VALUE_ERROR(e.getMessage());
         }
     }
 
     private static short bigDecimalToShort(BigDecimal bd) {
-        bd = bd.setScale(0, RoundingMode.HALF_UP); // 1.5 -->2, and -1.5 --> -2 NOTE: different from
-        // Math.round
         try {
-            return bd.shortValueExact();
-        } catch (ArithmeticException e) {
-            throw new VALUE_ERROR("not fit in a SHORT: " + bd);
+            return ValueUtilities.bigDecimalToShort(bd);
+        } catch (TypeMismatchException e) {
+            throw new VALUE_ERROR(e.getMessage());
         }
     }
 
     private static Time longToTime(long l) {
-        if (l < 0L) {
-            // negative values seem to result in a invalid time value
-            // e.g.
-            // select cast(cast(-1 as bigint) as time);
-            // === <Result of SELECT Command in Line 1> ===
-            //
-            // <00001>  cast( cast(-1 as bigint) as time): 12:00:0/ AM
-            //
-            // 1 row selected. (0.004910 sec) Committed. (0.000020 sec)
-            throw new VALUE_ERROR("negative values not allowed");
+        try {
+            return ValueUtilities.longToTime(l);
+        } catch (TypeMismatchException e) {
+            throw new VALUE_ERROR(e.getMessage());
         }
-
-        int totalSec = (int) (l % 86400L);
-        int hour = totalSec / 3600;
-        int minuteSec = totalSec % 3600;
-        int min = minuteSec / 60;
-        int sec = minuteSec % 60;
-        return new Time(hour, min, sec);
     }
 
     private static Timestamp longToTimestamp(long l) {
-        if (l < 0L) {
-            //   select cast(cast(-100 as bigint) as timestamp);
-            //   ERROR: Cannot coerce value of domain "bigint" to domain "timestamp"
-            throw new VALUE_ERROR("negative values not allowed");
-        } else if (l
-                > 2147483647L) { // 2147483647L : see section 'implicit type conversion' in the user
-            // manual
-            throw new VALUE_ERROR("values over 2,147,483,647 not allowed");
-        } else {
-            return new Timestamp(l * 1000L); // * 1000 : converts it to milli-seconds
+        try {
+            return ValueUtilities.longToTimestamp(l);
+        } catch (TypeMismatchException e) {
+            throw new VALUE_ERROR(e.getMessage());
         }
     }
 
@@ -4010,10 +3987,6 @@ public class SpLib {
             return "(" + String.join(", ", arr) + ")";
         }
     }
-
-    private static final Date NULL_DATE = new Date(0 - 1900, 0 - 1, 0);
-    private static final Timestamp NULL_DATETIME = new Timestamp(0 - 1900, 0 - 1, 0, 0, 0, 0, 0);
-    private static final Timestamp NULL_TIMESTAMP = new Timestamp(0 - 1900, 0 - 1, 0, 0, 0, 0, 0);
 
     private static boolean isEmptyStr(String s) {
         return s == null || s.length() == 0;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25362

(1) ban illegal type conversions
    . time --> datetime, date, timestamp
    . date --> time
(2) support legal type conversions
    . short --> time, timestamp
    . int --> time, timestamp
    . bigint --> time, timestamp
    . numeric --> timestamp
    . float --> time, timestamp
    . double --> time, timestamp
(3) check value range when converting a datetime to a timestamp
