### PR TITLE
[CBRD-25377] Enable the 'monitor_waiting_thread' feature regardless of whether the EnableThreadMonitoring macro is defined

### DIFF
--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -521,7 +521,7 @@ if(WIN32)
   set_target_properties(cubrid PROPERTIES OUTPUT_NAME libcubrid)
 endif(WIN32)
 
-target_compile_definitions(cubrid PRIVATE SERVER_MODE CUBRID_EXPORTING ${COMMON_DEFS})
+target_compile_definitions(cubrid PRIVATE SERVER_MODE EnableThreadMonitoring CUBRID_EXPORTING ${COMMON_DEFS})
 if(NOT USE_CUBRID_ENV)
   target_compile_definitions(cubrid PRIVATE ${DIR_DEFS})
 endif(NOT USE_CUBRID_ENV)
@@ -560,6 +560,7 @@ if(AT_LEAST_ONE_UNIT_TEST)
 
   target_compile_definitions(cubrid-win-lib PRIVATE
     SERVER_MODE
+    EnableThreadMonitoring
     ${COMMON_DEFS}
     )
 

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -2735,7 +2735,7 @@ fileio_unformat_and_rename (THREAD_ENTRY * thread_p, const char *vol_label_p, co
     {
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, "file remove",
 	      prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
-      er_log_debug (ARG_FILE_LINE, "fileio_unformat: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
+      _er_log_debug (ARG_FILE_LINE, "fileio_unformat: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
     }
 #endif
 
@@ -3954,7 +3954,7 @@ fileio_read (THREAD_ENTRY * thread_p, int vol_fd, void *io_page_p, PAGEID page_i
     {
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, "file read",
 	      prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
-      er_log_debug (ARG_FILE_LINE, "fileio_read: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
+      _er_log_debug (ARG_FILE_LINE, "fileio_read: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
     }
 #endif
 
@@ -4157,7 +4157,7 @@ fileio_write (THREAD_ENTRY * thread_p, int vol_fd, void *io_page_p, PAGEID page_
     {
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, "file write",
 	      prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
-      er_log_debug (ARG_FILE_LINE, "fileio_write: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
+      _er_log_debug (ARG_FILE_LINE, "fileio_write: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
     }
 #endif
 
@@ -4242,7 +4242,7 @@ fileio_read_pages (THREAD_ENTRY * thread_p, int vol_fd, char *io_pages_p, PAGEID
     {
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, "file read",
 	      prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
-      er_log_debug (ARG_FILE_LINE, "fileio_read_pages: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
+      _er_log_debug (ARG_FILE_LINE, "fileio_read_pages: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
     }
 #endif
 
@@ -4329,7 +4329,7 @@ fileio_write_pages (THREAD_ENTRY * thread_p, int vol_fd, char *io_pages_p, PAGEI
     {
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, "file write",
 	      prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
-      er_log_debug (ARG_FILE_LINE, "fileio_write_pages: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
+      _er_log_debug (ARG_FILE_LINE, "fileio_write_pages: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
     }
 #endif
 
@@ -4465,7 +4465,7 @@ fileio_synchronize (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel, FIL
 	{
 	  er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, "file sync",
 		  prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
-	  er_log_debug (ARG_FILE_LINE, "fileio_synchronize: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
+	  _er_log_debug (ARG_FILE_LINE, "fileio_synchronize: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
 	}
 #endif
 

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -2735,7 +2735,8 @@ fileio_unformat_and_rename (THREAD_ENTRY * thread_p, const char *vol_label_p, co
     {
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, "file remove",
 	      prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
-      _er_log_debug (ARG_FILE_LINE, "[MONITOR_WAITING_THREAD] fileio_unformat: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
+      _er_log_debug (ARG_FILE_LINE, "[MONITOR_WAITING_THREAD] fileio_unformat: %6d.%06d\n", elapsed_time.tv_sec,
+		     elapsed_time.tv_usec);
     }
 #endif
 
@@ -3954,7 +3955,8 @@ fileio_read (THREAD_ENTRY * thread_p, int vol_fd, void *io_page_p, PAGEID page_i
     {
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, "file read",
 	      prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
-      _er_log_debug (ARG_FILE_LINE, "[MONITOR_WAITING_THREAD] fileio_read: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
+      _er_log_debug (ARG_FILE_LINE, "[MONITOR_WAITING_THREAD] fileio_read: %6d.%06d\n", elapsed_time.tv_sec,
+		     elapsed_time.tv_usec);
     }
 #endif
 
@@ -4157,7 +4159,8 @@ fileio_write (THREAD_ENTRY * thread_p, int vol_fd, void *io_page_p, PAGEID page_
     {
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, "file write",
 	      prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
-      _er_log_debug (ARG_FILE_LINE, "[MONITOR_WAITING_THREAD] fileio_write: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
+      _er_log_debug (ARG_FILE_LINE, "[MONITOR_WAITING_THREAD] fileio_write: %6d.%06d\n", elapsed_time.tv_sec,
+		     elapsed_time.tv_usec);
     }
 #endif
 
@@ -4242,7 +4245,8 @@ fileio_read_pages (THREAD_ENTRY * thread_p, int vol_fd, char *io_pages_p, PAGEID
     {
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, "file read",
 	      prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
-      _er_log_debug (ARG_FILE_LINE, "[MONITOR_WAITING_THREAD] fileio_read_pages: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
+      _er_log_debug (ARG_FILE_LINE, "[MONITOR_WAITING_THREAD] fileio_read_pages: %6d.%06d\n", elapsed_time.tv_sec,
+		     elapsed_time.tv_usec);
     }
 #endif
 
@@ -4329,7 +4333,8 @@ fileio_write_pages (THREAD_ENTRY * thread_p, int vol_fd, char *io_pages_p, PAGEI
     {
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, "file write",
 	      prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
-      _er_log_debug (ARG_FILE_LINE, "[MONITOR_WAITING_THREAD] fileio_write_pages: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
+      _er_log_debug (ARG_FILE_LINE, "[MONITOR_WAITING_THREAD] fileio_write_pages: %6d.%06d\n", elapsed_time.tv_sec,
+		     elapsed_time.tv_usec);
     }
 #endif
 
@@ -4465,7 +4470,8 @@ fileio_synchronize (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel, FIL
 	{
 	  er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, "file sync",
 		  prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
-	  _er_log_debug (ARG_FILE_LINE, "[MONITOR_WAITING_THREAD] fileio_synchronize: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
+	  _er_log_debug (ARG_FILE_LINE, "[MONITOR_WAITING_THREAD] fileio_synchronize: %6d.%06d\n", elapsed_time.tv_sec,
+			 elapsed_time.tv_usec);
 	}
 #endif
 

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -2735,7 +2735,7 @@ fileio_unformat_and_rename (THREAD_ENTRY * thread_p, const char *vol_label_p, co
     {
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, "file remove",
 	      prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
-      _er_log_debug (ARG_FILE_LINE, "fileio_unformat: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
+      _er_log_debug (ARG_FILE_LINE, "[MONITOR_WAITING_THREAD] fileio_unformat: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
     }
 #endif
 
@@ -3954,7 +3954,7 @@ fileio_read (THREAD_ENTRY * thread_p, int vol_fd, void *io_page_p, PAGEID page_i
     {
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, "file read",
 	      prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
-      _er_log_debug (ARG_FILE_LINE, "fileio_read: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
+      _er_log_debug (ARG_FILE_LINE, "[MONITOR_WAITING_THREAD] fileio_read: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
     }
 #endif
 
@@ -4157,7 +4157,7 @@ fileio_write (THREAD_ENTRY * thread_p, int vol_fd, void *io_page_p, PAGEID page_
     {
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, "file write",
 	      prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
-      _er_log_debug (ARG_FILE_LINE, "fileio_write: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
+      _er_log_debug (ARG_FILE_LINE, "[MONITOR_WAITING_THREAD] fileio_write: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
     }
 #endif
 
@@ -4242,7 +4242,7 @@ fileio_read_pages (THREAD_ENTRY * thread_p, int vol_fd, char *io_pages_p, PAGEID
     {
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, "file read",
 	      prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
-      _er_log_debug (ARG_FILE_LINE, "fileio_read_pages: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
+      _er_log_debug (ARG_FILE_LINE, "[MONITOR_WAITING_THREAD] fileio_read_pages: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
     }
 #endif
 
@@ -4329,7 +4329,7 @@ fileio_write_pages (THREAD_ENTRY * thread_p, int vol_fd, char *io_pages_p, PAGEI
     {
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, "file write",
 	      prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
-      _er_log_debug (ARG_FILE_LINE, "fileio_write_pages: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
+      _er_log_debug (ARG_FILE_LINE, "[MONITOR_WAITING_THREAD] fileio_write_pages: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
     }
 #endif
 
@@ -4465,7 +4465,7 @@ fileio_synchronize (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel, FIL
 	{
 	  er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, "file sync",
 		  prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
-	  _er_log_debug (ARG_FILE_LINE, "fileio_synchronize: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
+	  _er_log_debug (ARG_FILE_LINE, "[MONITOR_WAITING_THREAD] fileio_synchronize: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
 	}
 #endif
 

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -6125,7 +6125,7 @@ end:
     {
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, "lock object (lock_object)",
 	      prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
-      _er_log_debug (ARG_FILE_LINE, "lock_object: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
+      _er_log_debug (ARG_FILE_LINE, "[MONITOR_WAITING_THREAD] lock_object: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
     }
 #endif
 
@@ -6245,7 +6245,7 @@ end:
     {
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, "lock object (lock_object)",
 	      prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
-      _er_log_debug (ARG_FILE_LINE, "lock_object: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
+      _er_log_debug (ARG_FILE_LINE, "[MONITOR_WAITING_THREAD] lock_object: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
     }
 #endif
 
@@ -6358,7 +6358,7 @@ lock_scan (THREAD_ENTRY * thread_p, const OID * class_oid, int cond_flag, LOCK c
     {
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, "lock object (lock_scan)",
 	      prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
-      _er_log_debug (ARG_FILE_LINE, "lock_scan: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
+      _er_log_debug (ARG_FILE_LINE, "[MONITOR_WAITING_THREAD] lock_scan: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
     }
 #endif
 
@@ -6567,7 +6567,7 @@ lock_classes_lock_hint (THREAD_ENTRY * thread_p, LC_LOCKHINT * lockhint)
     {
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, "lock object (lock_classes_lock_hint)",
 	      prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
-      _er_log_debug (ARG_FILE_LINE, "lock_classes_lock_hint: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
+      _er_log_debug (ARG_FILE_LINE, "[MONITOR_WAITING_THREAD] lock_classes_lock_hint: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
     }
 #endif
 

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -6125,7 +6125,8 @@ end:
     {
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, "lock object (lock_object)",
 	      prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
-      _er_log_debug (ARG_FILE_LINE, "[MONITOR_WAITING_THREAD] lock_object: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
+      _er_log_debug (ARG_FILE_LINE, "[MONITOR_WAITING_THREAD] lock_object: %6d.%06d\n", elapsed_time.tv_sec,
+		     elapsed_time.tv_usec);
     }
 #endif
 
@@ -6245,7 +6246,8 @@ end:
     {
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, "lock object (lock_object)",
 	      prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
-      _er_log_debug (ARG_FILE_LINE, "[MONITOR_WAITING_THREAD] lock_object: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
+      _er_log_debug (ARG_FILE_LINE, "[MONITOR_WAITING_THREAD] lock_object: %6d.%06d\n", elapsed_time.tv_sec,
+		     elapsed_time.tv_usec);
     }
 #endif
 
@@ -6358,7 +6360,8 @@ lock_scan (THREAD_ENTRY * thread_p, const OID * class_oid, int cond_flag, LOCK c
     {
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, "lock object (lock_scan)",
 	      prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
-      _er_log_debug (ARG_FILE_LINE, "[MONITOR_WAITING_THREAD] lock_scan: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
+      _er_log_debug (ARG_FILE_LINE, "[MONITOR_WAITING_THREAD] lock_scan: %6d.%06d\n", elapsed_time.tv_sec,
+		     elapsed_time.tv_usec);
     }
 #endif
 
@@ -6567,7 +6570,8 @@ lock_classes_lock_hint (THREAD_ENTRY * thread_p, LC_LOCKHINT * lockhint)
     {
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, "lock object (lock_classes_lock_hint)",
 	      prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
-      _er_log_debug (ARG_FILE_LINE, "[MONITOR_WAITING_THREAD] lock_classes_lock_hint: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
+      _er_log_debug (ARG_FILE_LINE, "[MONITOR_WAITING_THREAD] lock_classes_lock_hint: %6d.%06d\n", elapsed_time.tv_sec,
+		     elapsed_time.tv_usec);
     }
 #endif
 

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -6125,7 +6125,7 @@ end:
     {
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, "lock object (lock_object)",
 	      prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
-      er_log_debug (ARG_FILE_LINE, "lock_object: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
+      _er_log_debug (ARG_FILE_LINE, "lock_object: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
     }
 #endif
 
@@ -6245,7 +6245,7 @@ end:
     {
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, "lock object (lock_object)",
 	      prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
-      er_log_debug (ARG_FILE_LINE, "lock_object: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
+      _er_log_debug (ARG_FILE_LINE, "lock_object: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
     }
 #endif
 
@@ -6358,7 +6358,7 @@ lock_scan (THREAD_ENTRY * thread_p, const OID * class_oid, int cond_flag, LOCK c
     {
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, "lock object (lock_scan)",
 	      prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
-      er_log_debug (ARG_FILE_LINE, "lock_scan: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
+      _er_log_debug (ARG_FILE_LINE, "lock_scan: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
     }
 #endif
 
@@ -6567,7 +6567,7 @@ lock_classes_lock_hint (THREAD_ENTRY * thread_p, LC_LOCKHINT * lockhint)
     {
       er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 2, "lock object (lock_classes_lock_hint)",
 	      prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD));
-      er_log_debug (ARG_FILE_LINE, "lock_classes_lock_hint: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
+      _er_log_debug (ARG_FILE_LINE, "lock_classes_lock_hint: %6d.%06d\n", elapsed_time.tv_sec, elapsed_time.tv_usec);
     }
 #endif
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25377

Purpose
- During SERVER_MODE builds, define the EnableThreadMonitoring macro to enable the 'monitor_waiting_thread' functionality
- Through error logs, we can determine how much time a thread spent on tasks such as file I/O or acquiring locks.

Implementation
- Add EnableThreadMonitoring definition in cubrid/CMakefiles.txt
  - Removing #ifdef EnableThreadMonitoring ~ #endif from the code is possible, but this approach was chosen to clearly distinguish the related code segments.

Remarks
- @mhoh3963
  - Could we also support SA_MODE?
  - The er_log_debug() function is used for logging. However, I suggest using _er_log_debug() with a prefix such as '[FILEIO]' or introducing a new error function, like monitor_waiting_thread_log(), for this purpose in this area. I prefer simply using _er_log_debug().