### PR TITLE
[CBRD-25312] Add error message for class_name which does not exists

### DIFF
--- a/msg/en_US/utils.msg
+++ b/msg/en_US/utils.msg
@@ -817,6 +817,7 @@ $set 23 MSGCAT_UTIL_SET_MIGDB
 
 $set 24 MSGCAT_UTIL_SET_DIAGDB
 15 Couldn't open output file '%1$s'\n
+16 Unknown class "%1$s"\n
 60 \
 diagdb: Dump a database.\n\
 usage: %1$s diagdb [OPTION] database-name\n\

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1574,7 +1574,7 @@ diagdb (UTIL_FUNCTION_ARG * arg)
       goto print_diag_usage;
     }
 
-  if (diag == DIAGDUMP_ALL && class_name != NULL)
+  if (diag != DIAGDUMP_HEAP && class_name != NULL)
     {
       goto print_diag_usage;
     }

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1738,7 +1738,7 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 		{
 		  goto error_exit;
 		}
-      }
+	    }
 	  heap_dump_heap_file (thread_p, outfp, dump_records, class_name);
 	}
     }

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1738,8 +1738,7 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 		{
 		  goto error_exit;
 		}
-	    }
-	  fprintf (outfp, "\n*** DUMP HEAP OF %s ***\n", class_name);
+      }
 	  heap_dump_heap_file (thread_p, outfp, dump_records, class_name);
 	}
     }

--- a/src/executables/utility.h
+++ b/src/executables/utility.h
@@ -1197,7 +1197,7 @@ typedef struct _ha_config
 #define DIAG_OUTPUT_FILE_L                      "output-file"
 #define DIAG_EMERGENCY_S                        11202
 #define DIAG_EMERGENCY_L                        "emergency"
-#define DIAG_CLASS_NAME_S                       'c'
+#define DIAG_CLASS_NAME_S                       'n'
 #define DIAG_CLASS_NAME_L                       "class-name"
 
 /* patch option list */

--- a/src/executables/utility.h
+++ b/src/executables/utility.h
@@ -304,6 +304,7 @@ typedef enum
 typedef enum
 {
   DIAGDB_MSG_BAD_OUTPUT = 15,
+  DIAGDB_MSG_UNKNOWN_CLASS = 16,
   DIAGDB_MSG_USAGE = 60
 } MSGCAT_DIAGDB_MSG;
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -14531,7 +14531,8 @@ heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, cons
   status = xlocator_find_class_oid (thread_p, class_name, &class_oid, S_LOCK);
   if (status != LC_CLASSNAME_EXIST)
     {
-      fprintf (stderr, msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_DIAGDB, DIAGDB_MSG_UNKNOWN_CLASS), class_name);
+      fprintf (stderr, msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_DIAGDB, DIAGDB_MSG_UNKNOWN_CLASS),
+	       class_name);
       return;
     }
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -46,6 +46,7 @@
 #include "btree.h"
 #include "btree_unique.hpp"
 #include "schema_system_catalog_constants.h"	/* for CT_SERIAL_NAME */
+#include "utility.h"
 #include "transform.h"
 #include "serial.h"
 #include "object_primitive.h"
@@ -14530,8 +14531,11 @@ heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, cons
   status = xlocator_find_class_oid (thread_p, class_name, &class_oid, S_LOCK);
   if (status != LC_CLASSNAME_EXIST)
     {
+      fprintf (stderr, msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_DIAGDB, DIAGDB_MSG_UNKNOWN_CLASS), class_name);
       return;
     }
+
+  fprintf (fp, "\n*** DUMP HEAP OF %s ***\n", class_name);
 
   error_code = heap_hfid_cache_get (thread_p, &class_oid, &hfid, NULL, NULL);
   if (error_code != NO_ERROR)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25312

- Change short option of `class_name` from -c to -n
- Add error message for `class_name` which does not exists in database.

Both modification is for coherence with optimizedb utility. Optimizedb utility uses -n flag for `class_name`, and if the class_name does not exists, It prints `Unknown class "class_name"`