### PR TITLE
[CBRD-25312] Add error message for class_name which does not exists

### DIFF
--- a/msg/en_US/utils.msg
+++ b/msg/en_US/utils.msg
@@ -817,6 +817,7 @@ $set 23 MSGCAT_UTIL_SET_MIGDB
 
 $set 24 MSGCAT_UTIL_SET_DIAGDB
 15 Couldn't open output file '%1$s'\n
+16 Unknown class "%1$s"\n
 60 \
 diagdb: Dump a database.\n\
 usage: %1$s diagdb [OPTION] database-name\n\

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1574,7 +1574,7 @@ diagdb (UTIL_FUNCTION_ARG * arg)
       goto print_diag_usage;
     }
 
-  if (diag == DIAGDUMP_ALL && class_name != NULL)
+  if (diag != DIAGDUMP_HEAP && class_name != NULL)
     {
       goto print_diag_usage;
     }

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1737,7 +1737,7 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 	    {
 	      if (utility_check_class_name (class_name) != NO_ERROR)
 		{
-      db_shutdown ();
+		  db_shutdown ();
 		  goto error_exit;
 		}
 	    }
@@ -1750,7 +1750,7 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 					 (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_DIAGDB, DIAGDB_MSG_UNKNOWN_CLASS),
 					 class_name);
 		}
-        db_shutdown ();
+	      db_shutdown ();
 	      goto error_exit;
 	    }
 	}

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1738,7 +1738,7 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 		{
 		  goto error_exit;
 		}
-      }
+	    }
 	  heap_dump_heap_file (thread_p, outfp, dump_records, class_name);
 	}
     }

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1536,6 +1536,7 @@ diagdb (UTIL_FUNCTION_ARG * arg)
   bool is_emergency = false;
   DIAGDUMP_TYPE diag;
   THREAD_ENTRY *thread_p;
+  int error_code = NO_ERROR;
 
   db_name = utility_get_option_string_value (arg_map, OPTION_STRING_TABLE, 0);
   if (db_name == NULL)
@@ -1739,11 +1740,16 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 		  goto error_exit;
 		}
 	    }
-	  if (heap_dump_heap_file (thread_p, outfp, dump_records, class_name) == ER_LC_UNKNOWN_CLASSNAME)
+	  error_code = heap_dump_heap_file (thread_p, outfp, dump_records, class_name);
+	  if (error_code != NO_ERROR)
 	    {
-	      PRINT_AND_LOG_ERR_MSG (msgcat_message
-				     (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_DIAGDB, DIAGDB_MSG_UNKNOWN_CLASS),
-				     class_name);
+	      if (error_code == ER_LC_UNKNOWN_CLASSNAME)
+		{
+		  PRINT_AND_LOG_ERR_MSG (msgcat_message
+					 (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_DIAGDB, DIAGDB_MSG_UNKNOWN_CLASS),
+					 class_name);
+		}
+	      goto error_exit;
 	    }
 	}
     }

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1740,9 +1740,11 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 		}
 	    }
 	  if (heap_dump_heap_file (thread_p, outfp, dump_records, class_name) == ER_LC_UNKNOWN_CLASSNAME)
-    {
-      PRINT_AND_LOG_ERR_MSG (msgcat_message(MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_DIAGDB, DIAGDB_MSG_UNKNOWN_CLASS), class_name);
-    }
+	    {
+	      PRINT_AND_LOG_ERR_MSG (msgcat_message
+				     (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_DIAGDB, DIAGDB_MSG_UNKNOWN_CLASS),
+				     class_name);
+	    }
 	}
     }
 

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1738,8 +1738,7 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 		{
 		  goto error_exit;
 		}
-	    }
-	  fprintf (outfp, "\n*** DUMP HEAP OF %s ***\n", class_name);
+      }
 	  heap_dump_heap_file (thread_p, outfp, dump_records, class_name);
 	}
     }

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1739,7 +1739,10 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 		  goto error_exit;
 		}
 	    }
-	  heap_dump_heap_file (thread_p, outfp, dump_records, class_name);
+	  if (heap_dump_heap_file (thread_p, outfp, dump_records, class_name) == ER_LC_UNKNOWN_CLASSNAME)
+    {
+      PRINT_AND_LOG_ERR_MSG (msgcat_message(MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_DIAGDB, DIAGDB_MSG_UNKNOWN_CLASS), class_name);
+    }
 	}
     }
 

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1737,6 +1737,7 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 	    {
 	      if (utility_check_class_name (class_name) != NO_ERROR)
 		{
+      db_shutdown ();
 		  goto error_exit;
 		}
 	    }
@@ -1749,6 +1750,7 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 					 (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_DIAGDB, DIAGDB_MSG_UNKNOWN_CLASS),
 					 class_name);
 		}
+        db_shutdown ();
 	      goto error_exit;
 	    }
 	}

--- a/src/executables/utility.h
+++ b/src/executables/utility.h
@@ -1197,7 +1197,7 @@ typedef struct _ha_config
 #define DIAG_OUTPUT_FILE_L                      "output-file"
 #define DIAG_EMERGENCY_S                        11202
 #define DIAG_EMERGENCY_L                        "emergency"
-#define DIAG_CLASS_NAME_S                       'c'
+#define DIAG_CLASS_NAME_S                       'n'
 #define DIAG_CLASS_NAME_L                       "class-name"
 
 /* patch option list */

--- a/src/executables/utility.h
+++ b/src/executables/utility.h
@@ -304,6 +304,7 @@ typedef enum
 typedef enum
 {
   DIAGDB_MSG_BAD_OUTPUT = 15,
+  DIAGDB_MSG_UNKNOWN_CLASS = 16,
   DIAGDB_MSG_USAGE = 60
 } MSGCAT_DIAGDB_MSG;
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -46,7 +46,6 @@
 #include "btree.h"
 #include "btree_unique.hpp"
 #include "schema_system_catalog_constants.h"	/* for CT_SERIAL_NAME */
-#include "utility.h"
 #include "transform.h"
 #include "serial.h"
 #include "object_primitive.h"

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -14531,7 +14531,8 @@ heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, cons
   status = xlocator_find_class_oid (thread_p, class_name, &class_oid, S_LOCK);
   if (status != LC_CLASSNAME_EXIST)
     {
-      fprintf (stderr, msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_DIAGDB, DIAGDB_MSG_UNKNOWN_CLASS), class_name);
+      fprintf (stderr, msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_DIAGDB, DIAGDB_MSG_UNKNOWN_CLASS),
+	       class_name);
       return;
     }
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -14512,7 +14512,7 @@ heap_dump (THREAD_ENTRY * thread_p, FILE * fp, HFID * hfid, bool dump_records)
 /*
  * heap_dump_heap_file () - dump a specific heap file with class name
  *
- * return            :
+ * return            : error code
  * thread_p (in)     : thread entry
  * fp (in)           : output file
  * dump_records (in) : true to dump records
@@ -14531,7 +14531,6 @@ heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, cons
   status = xlocator_find_class_oid (thread_p, class_name, &class_oid, S_LOCK);
   if (status != LC_CLASSNAME_EXIST)
     {
-      er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, ER_LC_UNKNOWN_CLASSNAME, 1, class_name);
       return ER_LC_UNKNOWN_CLASSNAME;
     }
 
@@ -14540,6 +14539,7 @@ heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, cons
   error_code = heap_hfid_cache_get (thread_p, &class_oid, &hfid, NULL, NULL);
   if (error_code != NO_ERROR)
     {
+      assert (false);
       return error_code;
     }
 
@@ -14548,6 +14548,7 @@ heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, cons
   error_code = heap_get_class_partitions (thread_p, &class_oid, &parts, &parts_count);
   if (error_code != NO_ERROR)
     {
+      assert (false);
       return error_code;
     }
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -14518,7 +14518,7 @@ heap_dump (THREAD_ENTRY * thread_p, FILE * fp, HFID * hfid, bool dump_records)
  * dump_records (in) : true to dump records
  * class_name (in)   : name of class to dump
  */
-void
+int
 heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, const char *class_name)
 {
   int error_code = NO_ERROR;
@@ -14531,9 +14531,8 @@ heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, cons
   status = xlocator_find_class_oid (thread_p, class_name, &class_oid, S_LOCK);
   if (status != LC_CLASSNAME_EXIST)
     {
-      fprintf (stderr, msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_DIAGDB, DIAGDB_MSG_UNKNOWN_CLASS),
-	       class_name);
-      return;
+      er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, ER_LC_UNKNOWN_CLASSNAME, 1, class_name);
+      return ER_LC_UNKNOWN_CLASSNAME;
     }
 
   fprintf (fp, "\n*** DUMP HEAP OF %s ***\n", class_name);
@@ -14541,8 +14540,7 @@ heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, cons
   error_code = heap_hfid_cache_get (thread_p, &class_oid, &hfid, NULL, NULL);
   if (error_code != NO_ERROR)
     {
-      assert (false);
-      return;
+      return error_code;
     }
 
   heap_dump (thread_p, fp, &hfid, dump_records);
@@ -14550,8 +14548,7 @@ heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, cons
   error_code = heap_get_class_partitions (thread_p, &class_oid, &parts, &parts_count);
   if (error_code != NO_ERROR)
     {
-      assert (false);
-      return;
+      return error_code;
     }
 
   for (int i = 1; i < parts_count; i++)
@@ -14560,6 +14557,7 @@ heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, cons
     }
 
   heap_clear_partition_info (thread_p, parts, parts_count);
+  return NO_ERROR;
 }
 #endif
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -14530,7 +14530,8 @@ heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, cons
   status = xlocator_find_class_oid (thread_p, class_name, &class_oid, S_LOCK);
   if (status != LC_CLASSNAME_EXIST)
     {
-      return ER_LC_UNKNOWN_CLASSNAME;
+      error_code = ER_LC_UNKNOWN_CLASSNAME;
+      goto exit;
     }
 
   fprintf (fp, "\n*** DUMP HEAP OF %s ***\n", class_name);
@@ -14539,7 +14540,7 @@ heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, cons
   if (error_code != NO_ERROR)
     {
       assert (false);
-      return error_code;
+      goto exit;
     }
 
   heap_dump (thread_p, fp, &hfid, dump_records);
@@ -14548,7 +14549,7 @@ heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, cons
   if (error_code != NO_ERROR)
     {
       assert (false);
-      return error_code;
+      goto exit;
     }
 
   for (int i = 1; i < parts_count; i++)
@@ -14557,7 +14558,9 @@ heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, cons
     }
 
   heap_clear_partition_info (thread_p, parts, parts_count);
-  return NO_ERROR;
+
+exit:
+  return error_code;
 }
 #endif
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -46,6 +46,7 @@
 #include "btree.h"
 #include "btree_unique.hpp"
 #include "schema_system_catalog_constants.h"	/* for CT_SERIAL_NAME */
+#include "utility.h"
 #include "transform.h"
 #include "serial.h"
 #include "object_primitive.h"
@@ -14530,8 +14531,11 @@ heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, cons
   status = xlocator_find_class_oid (thread_p, class_name, &class_oid, S_LOCK);
   if (status != LC_CLASSNAME_EXIST)
     {
+      fprintf (stderr, msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_DIAGDB, DIAGDB_MSG_UNKNOWN_CLASS), class_name);
       return;
     }
+
+  fprintf (fp, "\n*** DUMP HEAP OF %s ***\n", class_name);
 
   error_code = heap_hfid_cache_get (thread_p, &class_oid, &hfid, NULL, NULL);
   if (error_code != NO_ERROR)

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -555,7 +555,7 @@ extern int heap_set_autoincrement_value (THREAD_ENTRY * thread_p, HEAP_CACHE_ATT
 
 extern void heap_dump (THREAD_ENTRY * thread_p, FILE * fp, HFID * hfid, bool dump_records);
 #if defined (SA_MODE)
-extern void heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, const char *class_name);
+extern int heap_dump_heap_file (THREAD_ENTRY * thread_p, FILE * fp, bool dump_records, const char *class_name);
 #endif
 extern void heap_attrinfo_dump (THREAD_ENTRY * thread_p, FILE * fp, HEAP_CACHE_ATTRINFO * attr_info, bool dump_schema);
 #if defined (CUBRID_DEBUG)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25312

- Change short option of `class_name` from -c to -n
- Add error message for `class_name` which does not exists in database.

Both modification is for coherence with optimizedb utility. Optimizedb utility uses -n flag for `class_name`, and if the class_name does not exists, It prints `Unknown class "class_name".`