### PR TITLE
[CBRD-24605] Fix core dump caused by NULL optarg in loadjava package option

### DIFF
--- a/src/executables/loadjava.cpp
+++ b/src/executables/loadjava.cpp
@@ -100,7 +100,7 @@ parse_argument (int argc, char *argv[])
 	case 'p':
 	{
 	  // check valid package name
-	  if (optarg == null)
+	  if (optarg == NULL)
 	    {
 	      error = ER_FAILED;
 	      goto exit;

--- a/src/executables/loadjava.cpp
+++ b/src/executables/loadjava.cpp
@@ -74,10 +74,11 @@ usage (void)
 static int
 parse_argument (int argc, char *argv[])
 {
+  int error = NO_ERROR;
   struct option loadjava_option[] =
   {
     {"overwrite", 0, 0, 'y'},
-    {"package", 0, 0, 'p'},
+    {"package", 1, 0, 'p'},
     {"jni", 0, 0, 'j'},
     {0, 0, 0, 0}
   };
@@ -99,6 +100,12 @@ parse_argument (int argc, char *argv[])
 	case 'p':
 	{
 	  // check valid package name
+	  if (optarg == null)
+	    {
+	      error = ER_FAILED;
+	      goto exit;
+	    }
+
 	  std::string package_name (optarg);
 	  if (!package_name.empty())
 	    {
@@ -120,8 +127,8 @@ parse_argument (int argc, char *argv[])
 	case 'h':
 	/* fall through */
 	default:
-	  usage ();
-	  return ER_FAILED;
+	  error = ER_FAILED;
+	  goto exit;
 	}
     }
 
@@ -132,13 +139,19 @@ parse_argument (int argc, char *argv[])
     }
   else
     {
-      usage ();
-      return ER_FAILED;
+      error = ER_FAILED;
+      goto exit;
     }
 
   Program_name = argv[0];
 
-  return NO_ERROR;
+exit:
+  if (error != NO_ERROR)
+    {
+      usage ();
+    }
+
+  return error;
 }
 
 static int


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24605

Because `loadjava_option` package's has_arg member is not specified correctly, It couldn't get `optarg` and it is set as `NULL`.
- Set 1 to package option's has_arg member
- If optarg is NULL, I've change the logic to print the `usage ()`.