### PR TITLE
[CBRD-25394] Add missing #include directives to support building with GCC 11

### DIFF
--- a/src/base/string_buffer.hpp
+++ b/src/base/string_buffer.hpp
@@ -42,6 +42,7 @@
 #include <stddef.h>
 #include <stdio.h>
 #include <functional>
+#include <string>
 
 class string_buffer
 {

--- a/src/connection/host_lookup.h
+++ b/src/connection/host_lookup.h
@@ -23,6 +23,8 @@
 #ifndef _HOST_LOOKUP_H_
 #define _HOST_LOOKUP_H_
 
+#include <string>
+
 #ident "$Id$"
 extern struct hostent *gethostbyname_uhost (const char *name);
 extern int getnameinfo_uhost (struct sockaddr *addr, socklen_t addrlen, char *host, size_t hostlen,

--- a/src/executables/esql_grammar.y
+++ b/src/executables/esql_grammar.y
@@ -3446,7 +3446,7 @@ of_select_lp
 char exec_echo[10] = "";
 static char *outfile_name = NULL;
 bool need_line_directive;
-FILE *esql_yyin, *esql_yyout;
+extern FILE *esql_yyin, *esql_yyout;
 char *esql_yyfilename;
 int esql_yyendcol = 0;
 int errors = 0;

--- a/src/object/schema_system_catalog_definition.hpp
+++ b/src/object/schema_system_catalog_definition.hpp
@@ -24,6 +24,7 @@
 #ifndef _SCHEMA_SYSTEM_CATALOG_DEFINITION_HPP_
 #define _SCHEMA_SYSTEM_CATALOG_DEFINITION_HPP_
 
+#include <string>
 #include <string_view>
 #include <vector>
 #include <optional>

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -61,6 +61,7 @@
 #include "lockfree_circular_queue.hpp"
 
 #include <unordered_set>
+#include <unordered_map>
 #include <queue>
 #include <assert.h>
 #if defined(SOLARIS)

--- a/src/transaction/transaction_transient.hpp
+++ b/src/transaction/transaction_transient.hpp
@@ -26,6 +26,7 @@
 
 #include <forward_list>
 #include <functional>
+#include <string>
 
 // todo - namespace cubtx
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25394

### Description:
This pull request addresses an issue with building the CUBRID project on development environments other than CentOS 7 with Devtoolset 8. Specifically, it **resolves build failures** on Ubuntu 22.04 with GCC 11 by adding a few missing #include directives.

### Background
The current CUBRID build process is officially supported only on CentOS 7 with Devtoolset 8. Attempts to build the project on newer environments, such as Ubuntu 22.04 with GCC 11, often fail due to missing header inclusions. This issue appears to stem from omissions that prevent successful compilation under the C++17 standard used by GCC 11.

### Changes Made
By **simply adding the necessary #include directives** in approximately six locations within the codebase, **the build process completes successfully on Ubuntu 22.04 with GCC 11**. The modifications adhere to the C++17 standards, ensuring compatibility with modern development environments.

> [!CAUTION]
> esql_grammar.y also modified. It causes build to fail without `extern` keyword.


### Benefits
- Enhanced Compatibility: Developers can now build CUBRID on a variety of operating systems, provided they have the necessary dependencies (systemtab and sys/sdt.h).
- Ease of Setup: Simplifies the process of setting up personal development environments using cutting-edge technologies.
- Modern Tooling: Facilitates the use of advanced debugging tools like Mozilla's rr debugger, which requires newer kernels available in modern distributions.

### Weakness
- esql_grammar.y is modified without analyzing the exact reason of build failure. 