### PR TITLE
[CBRD-25399] Fix DELETE statement's rewritten query is changed by the PT_SUPPRESS_RESOLVED flag.

### DIFF
--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -8720,11 +8720,8 @@ pt_print_delete (PARSER_CONTEXT * parser, PT_NODE * p)
 {
   PARSER_VARCHAR *q = 0, *r1, *r2;
 
-  unsigned int save_custom = parser->custom_print;
-  parser->custom_print |= PT_SUPPRESS_RESOLVED;
   r1 = pt_print_bytes_l (parser, p->info.delete_.target_classes);
   r2 = pt_print_bytes_spec_list (parser, p->info.delete_.spec);
-  parser->custom_print = save_custom;
 
   if (p->info.delete_.with != NULL)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25399

**Purpose**
PT_SUPPRESS_RESOLVED is applied to DELETE statement's node in plcsql phase-0 commit. It causes a regression that DELETE statement's rewritten query is changed and also can not be compiled.

**Implementation**
It reverts code applying PT_SUPPRESS_RESOLVED to `custom_print` flags.