### PR TITLE
[CBRD-25417] Activate daemons flushing data pages and double write buffer before recovery

### DIFF
--- a/src/storage/double_write_buffer.c
+++ b/src/storage/double_write_buffer.c
@@ -3933,12 +3933,6 @@ class dwb_flush_block_daemon_task: public cubthread::entry_task
 
     void execute (cubthread::entry &thread_ref) override
     {
-      if (!BO_IS_SERVER_RESTARTED ())
-        {
-	  // wait for boot to finish
-	  return;
-        }
-
       /* performance tracking */
       PERF_UTIME_TRACKER_TIME (NULL, &m_perf_track, PSTAT_DWB_FLUSH_BLOCK_COND_WAIT);
 
@@ -3963,12 +3957,6 @@ class dwb_flush_block_daemon_task: public cubthread::entry_task
 void
 dwb_file_sync_helper_execute (cubthread::entry &thread_ref)
 {
-  if (!BO_IS_SERVER_RESTARTED ())
-    {
-      // wait for boot to finish
-      return;
-    }
-
   /* flush pages as long as necessary */
   if (prm_get_bool_value (PRM_ID_ENABLE_DWB_FLUSH_THREAD) == true)
     {

--- a/src/storage/double_write_buffer.c
+++ b/src/storage/double_write_buffer.c
@@ -3933,6 +3933,11 @@ class dwb_flush_block_daemon_task: public cubthread::entry_task
 
     void execute (cubthread::entry &thread_ref) override
     {
+      if (!BO_IS_FLUSH_DAEMON_AVAILABLE ())
+      {
+        return;
+      }
+
       /* performance tracking */
       PERF_UTIME_TRACKER_TIME (NULL, &m_perf_track, PSTAT_DWB_FLUSH_BLOCK_COND_WAIT);
 
@@ -3957,6 +3962,11 @@ class dwb_flush_block_daemon_task: public cubthread::entry_task
 void
 dwb_file_sync_helper_execute (cubthread::entry &thread_ref)
 {
+  if (!BO_IS_FLUSH_DAEMON_AVAILABLE ())
+      {
+        return;
+      }
+
   /* flush pages as long as necessary */
   if (prm_get_bool_value (PRM_ID_ENABLE_DWB_FLUSH_THREAD) == true)
     {

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -10969,7 +10969,6 @@ pgbuf_flush_page_and_neighbors_fb (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr, 
   forward = true;
   search_nondirty = false;
   abort_reason = 0;
-
   for (i = 1; i < PGBUF_NEIGHBOR_PAGES;)
     {
       if (forward == true)

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2477,6 +2477,9 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
       ASSERT_ERROR ();
       goto error;
     }
+#if defined(SERVER_MODE)
+  dwb_daemons_init ();
+#endif /* SERVER_MODE */
 
   /*
    * Now restart the recovery manager and execute any recovery actions
@@ -2492,8 +2495,6 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
     }
 
 #if defined(SERVER_MODE)
-  pgbuf_daemons_init ();
-  dwb_daemons_init ();
   cdc_daemons_init ();
 #endif /* SERVER_MODE */
 
@@ -2807,8 +2808,6 @@ error:
 
 #if defined(SERVER_MODE)
   cdc_daemons_destroy ();
-
-  pgbuf_daemons_destroy ();
   dwb_daemons_destroy ();
 #endif
 

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -146,6 +146,8 @@ extern void boot_client_all_finalize (bool is_er_final);
 
 BOOT_SERVER_STATUS boot_Server_status = BOOT_SERVER_DOWN;
 
+bool boot_Enabled_flush_daemons = false;
+
 #if defined(SERVER_MODE)
 /* boot_cl.c:boot_Host_name[] if CS_MODE and SA_MODE */
 char boot_Host_name[CUB_MAXHOSTNAMELEN] = "";
@@ -2477,8 +2479,10 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
       ASSERT_ERROR ();
       goto error;
     }
+
 #if defined(SERVER_MODE)
   dwb_daemons_init ();
+  pgbuf_daemons_init ();
 #endif /* SERVER_MODE */
 
   /*
@@ -2495,6 +2499,7 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
     }
 
 #if defined(SERVER_MODE)
+  BO_ENABLE_FLUSH_DAEMONS ();
   cdc_daemons_init ();
 #endif /* SERVER_MODE */
 
@@ -2808,7 +2813,10 @@ error:
 
 #if defined(SERVER_MODE)
   cdc_daemons_destroy ();
+
+  assert (BO_IS_FLUSH_DAEMON_AVAILABLE ());
   dwb_daemons_destroy ();
+  pgbuf_daemons_destroy ();
 #endif
 
   log_final (thread_p);

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -146,7 +146,9 @@ extern void boot_client_all_finalize (bool is_er_final);
 
 BOOT_SERVER_STATUS boot_Server_status = BOOT_SERVER_DOWN;
 
+#if defined(SERVER_MODE)
 bool boot_Enabled_flush_daemons = false;
+#endif /* SERVER_MODE */
 
 #if defined(SERVER_MODE)
 /* boot_cl.c:boot_Host_name[] if CS_MODE and SA_MODE */
@@ -2481,8 +2483,8 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
     }
 
 #if defined(SERVER_MODE)
-  dwb_daemons_init ();
   pgbuf_daemons_init ();
+  dwb_daemons_init ();
 #endif /* SERVER_MODE */
 
   /*
@@ -2500,6 +2502,7 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
 
 #if defined(SERVER_MODE)
   BO_ENABLE_FLUSH_DAEMONS ();
+
   cdc_daemons_init ();
 #endif /* SERVER_MODE */
 
@@ -2814,9 +2817,9 @@ error:
 #if defined(SERVER_MODE)
   cdc_daemons_destroy ();
 
-  assert (BO_IS_FLUSH_DAEMON_AVAILABLE ());
-  dwb_daemons_destroy ();
+  BO_DISABLE_FLUSH_DAEMONS ();
   pgbuf_daemons_destroy ();
+  dwb_daemons_destroy ();
 #endif
 
   log_final (thread_p);

--- a/src/transaction/boot_sr.h
+++ b/src/transaction/boot_sr.h
@@ -85,16 +85,28 @@ struct check_args
         (boot_Server_status == BOOT_SERVER_UP \
          || boot_Server_status == BOOT_SERVER_MAINTENANCE)
 
+#if defined(SERVER_MODE)
 extern bool boot_Enabled_flush_daemons;
+
 #define BO_IS_FLUSH_DAEMON_AVAILABLE() \
         (boot_Enabled_flush_daemons == true)
 #define BO_ENABLE_FLUSH_DAEMONS() \
         do \
           { \
-            assert (!BO_IS_FLUSH_DAEMON_AVAILABLE ());\
-            boot_Enabled_flush_daemons = true;\
+            if (!BO_IS_FLUSH_DAEMON_AVAILABLE ()) \
+              { \
+                boot_Enabled_flush_daemons = true; \
+              } \
           } \
-        while (0);
+        while (0)
+#define BO_DISABLE_FLUSH_DAEMONS() \
+        do \
+          { \
+            assert (BO_IS_FLUSH_DAEMON_AVAILABLE ()); \
+            boot_Enabled_flush_daemons = false; \
+          } \
+        while (0)
+#endif /* SERVER_MODE */
 
 extern void boot_server_status (BOOT_SERVER_STATUS status);
 

--- a/src/transaction/boot_sr.h
+++ b/src/transaction/boot_sr.h
@@ -85,6 +85,17 @@ struct check_args
         (boot_Server_status == BOOT_SERVER_UP \
          || boot_Server_status == BOOT_SERVER_MAINTENANCE)
 
+extern bool boot_Enabled_flush_daemons;
+#define BO_IS_FLUSH_DAEMON_AVAILABLE() \
+        (boot_Enabled_flush_daemons == true)
+#define BO_ENABLE_FLUSH_DAEMONS() \
+        do \
+          { \
+            assert (!BO_IS_FLUSH_DAEMON_AVAILABLE ());\
+            boot_Enabled_flush_daemons = true;\
+          } \
+        while (0);
+
 extern void boot_server_status (BOOT_SERVER_STATUS status);
 
 /* structure for passing arguments into boot_restart_server et. al. */

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1368,6 +1368,13 @@ log_initialize_internal (THREAD_ENTRY * thread_p, const char *db_fullname, const
        * System was involved in a crash.
        * Execute the recovery process
        */
+
+      /* The actions of flushing the page buffer and double write buffer are currently designed to operate in a single thread.
+       * As we parallelize the log recovery redo process, this flush operation can also run in multiple threads.
+       * To prevent this, daemons performing the flush should be activated to flush the pages in single thread.
+       * If recovery is not being performed, these daemons will run after completing the log_initialize () */
+      BO_ENABLE_FLUSH_DAEMONS ();
+
       log_recovery (thread_p, ismedia_crash, stopat);
     }
   else

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1369,12 +1369,13 @@ log_initialize_internal (THREAD_ENTRY * thread_p, const char *db_fullname, const
        * Execute the recovery process
        */
 
+#if defined(SERVER_MODE)
       /* The actions of flushing the page buffer and double write buffer are currently designed to operate in a single thread.
        * As we parallelize the log recovery redo process, this flush operation can also run in multiple threads.
        * To prevent this, daemons performing the flush should be activated to flush the pages in single thread.
        * If recovery is not being performed, these daemons will run after completing the log_initialize () */
       BO_ENABLE_FLUSH_DAEMONS ();
-
+#endif /* SERVER_MODE */
       log_recovery (thread_p, ismedia_crash, stopat);
     }
   else


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25417

Data page/ DWB flushing process should run in single-thread during recovery. 
Flushing mechanism is not designed for parallelism, so it should run as single threaded mode even in parallelized recovery redo process.

Flush daemon will be woken up whenever flush operation is required.
