### PR TITLE
[CBRD-25304] Removed unnecessary parameters from the pgbuf_is_valid_page function.

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -22141,8 +22141,7 @@ btree_check_valid_record (THREAD_ENTRY * thread_p, BTID_INT * btid, RECDES * rec
 
       vpid_ptr = recp->data + recp->length - vpid_size;
       OR_GET_VPID (vpid_ptr, &first_overflow_vpid);
-      if (!log_is_in_crash_recovery ()
-	  && pgbuf_is_valid_page (thread_p, &first_overflow_vpid, true, NULL, NULL) == DISK_INVALID)
+      if (!log_is_in_crash_recovery () && pgbuf_is_valid_page (thread_p, &first_overflow_vpid, true) == DISK_INVALID)
 	{
 	  assert (false);
 	  return ER_FAILED;

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -25887,7 +25887,7 @@ heap_rv_postpone_append_pages_to_heap (THREAD_ENTRY * thread_p, LOG_RCV * recv)
   // Check every page is allocated
   for (size_t i = 0; i < array_size; i++)
     {
-      if (pgbuf_is_valid_page (thread_p, &heap_pages_array[i], false, NULL, NULL) != DISK_VALID)
+      if (pgbuf_is_valid_page (thread_p, &heap_pages_array[i], false) != DISK_VALID)
 	{
 	  assert (false);
 	  return ER_FAILED;

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -1812,7 +1812,7 @@ pgbuf_fix_release (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_MODE f
     {
       /* Make sure that the page has been allocated (i.e., is a valid page) */
       /* Suppress errors if fetch mode is OLD_PAGE_IF_IN_BUFFER. */
-      if (pgbuf_is_valid_page (thread_p, vpid, fetch_mode == OLD_PAGE_IF_IN_BUFFER, NULL, NULL) != DISK_VALID)
+      if (pgbuf_is_valid_page (thread_p, vpid, fetch_mode == OLD_PAGE_IF_IN_BUFFER) != DISK_VALID)
 	{
 	  return NULL;
 	}
@@ -4111,7 +4111,7 @@ pgbuf_copy_to_area (THREAD_ENTRY * thread_p, const VPID * vpid, int start_offset
 	   */
 	  if (pgbuf_get_check_page_validation_level (PGBUF_DEBUG_PAGE_VALIDATION_ALL))
 	    {
-	      if (pgbuf_is_valid_page (thread_p, vpid, false NULL, NULL) != DISK_VALID)
+	      if (pgbuf_is_valid_page (thread_p, vpid, false) != DISK_VALID)
 		{
 		  return NULL;
 		}
@@ -4209,7 +4209,7 @@ pgbuf_copy_from_area (THREAD_ENTRY * thread_p, const VPID * vpid, int start_offs
 	  /* Do not cache the page in the page buffer pool. Write the desired portion of the page directly to disk */
 	  if (pgbuf_get_check_page_validation_level (PGBUF_DEBUG_PAGE_VALIDATION_ALL))
 	    {
-	      if (pgbuf_is_valid_page (thread_p, vpid, false NULL, NULL) != DISK_VALID)
+	      if (pgbuf_is_valid_page (thread_p, vpid, false) != DISK_VALID)
 		{
 		  return NULL;
 		}
@@ -10178,12 +10178,9 @@ pgbuf_get_check_page_validation_level (int page_validation_level)
  *       capabilities.
  */
 DISK_ISVALID
-pgbuf_is_valid_page (THREAD_ENTRY * thread_p, const VPID * vpid, bool no_error,
-		     DISK_ISVALID (*fun) (const VPID * vpid, void *args), void *args)
+pgbuf_is_valid_page (THREAD_ENTRY * thread_p, const VPID * vpid, bool no_error)
 {
   DISK_ISVALID valid;
-
-  /* TODO: fix me */
 
   if (fileio_get_volume_label (vpid->volid, PEEK) == NULL || VPID_ISNULL (vpid))
     {
@@ -10194,15 +10191,12 @@ pgbuf_is_valid_page (THREAD_ENTRY * thread_p, const VPID * vpid, bool no_error,
 
   /*valid = disk_isvalid_page (thread_p, vpid->volid, vpid->pageid); */
   valid = disk_is_page_sector_reserved_with_debug_crash (thread_p, vpid->volid, vpid->pageid, !no_error);
-  if (valid != DISK_VALID || (fun != NULL && (valid = (*fun) (vpid, args)) != DISK_VALID))
+  if ((valid != DISK_VALID) && (valid != DISK_ERROR && !no_error))
     {
-      if (valid != DISK_ERROR && !no_error)
-	{
-	  er_set (ER_FATAL_ERROR_SEVERITY, ARG_FILE_LINE, ER_PB_BAD_PAGEID, 2, vpid->pageid,
-		  fileio_get_volume_label (vpid->volid, PEEK));
+      er_set (ER_FATAL_ERROR_SEVERITY, ARG_FILE_LINE, ER_PB_BAD_PAGEID, 2, vpid->pageid,
+	      fileio_get_volume_label (vpid->volid, PEEK));
 
-	  assert (false);
-	}
+      assert (false);
     }
 
   return valid;
@@ -11583,7 +11577,7 @@ pgbuf_ordered_fix_release (THREAD_ENTRY * thread_p, const VPID * req_vpid, PAGE_
       else if (VPID_EQ (req_vpid, &(holder->bufptr->vpid)))
 	{
 	  /* already have a fix on this page, should not be here */
-	  if (pgbuf_is_valid_page (thread_p, req_vpid, false, NULL, NULL) != DISK_VALID)
+	  if (pgbuf_is_valid_page (thread_p, req_vpid, false) != DISK_VALID)
 	    {
 #if defined(PGBUF_ORDERED_DEBUG)
 	      _er_log_debug (__FILE__, __LINE__,

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -10167,9 +10167,6 @@ pgbuf_get_check_page_validation_level (int page_validation_level)
  * pgbuf_is_valid_page () - Verify if given page is a valid one
  *   return: either: DISK_INVALID, DISK_VALID, DISK_ERROR
  *   vpid(in): Complete Page identifier
- *   fun(in): A second function to call to verify if the above page is valid
- *            The function is called on vpid, and arguments
- *   args(in): Additional argument for fun
  *
  * Note: Verify that the given page is valid according to functions:
  *         1) disk_isvalid_page
@@ -10191,7 +10188,7 @@ pgbuf_is_valid_page (THREAD_ENTRY * thread_p, const VPID * vpid, bool no_error)
 
   /*valid = disk_isvalid_page (thread_p, vpid->volid, vpid->pageid); */
   valid = disk_is_page_sector_reserved_with_debug_crash (thread_p, vpid->volid, vpid->pageid, !no_error);
-  if ((valid != DISK_VALID) && (valid != DISK_ERROR && !no_error))
+  if (valid == DISK_INVALID && !no_error)
     {
       er_set (ER_FATAL_ERROR_SEVERITY, ARG_FILE_LINE, ER_PB_BAD_PAGEID, 2, vpid->pageid,
 	      fileio_get_volume_label (vpid->volid, PEEK));

--- a/src/storage/page_buffer.h
+++ b/src/storage/page_buffer.h
@@ -397,8 +397,7 @@ extern void pgbuf_set_page_ptype (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, PAGE_
 extern bool pgbuf_is_lsa_temporary (PAGE_PTR pgptr);
 extern bool pgbuf_check_page_ptype (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, PAGE_TYPE ptype);
 extern bool pgbuf_check_page_type_no_error (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, PAGE_TYPE ptype);
-extern DISK_ISVALID pgbuf_is_valid_page (THREAD_ENTRY * thread_p, const VPID * vpid, bool no_error,
-					 DISK_ISVALID (*fun) (const VPID * vpid, void *args), void *args);
+extern DISK_ISVALID pgbuf_is_valid_page (THREAD_ENTRY * thread_p, const VPID * vpid, bool no_error);
 
 #if defined(CUBRID_DEBUG)
 extern void pgbuf_dump_if_any_fixed (void);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25304

Purpose

The fun and arg parameters of the pgbuf_is_valid_page function are always passed as NULL in all calling instances. Therefore, these parameters were deemed unnecessary and removed from the pgbuf_is_valid_page function.

Implementation

N/A

Remarks

N/A