### PR TITLE
[CBRD-25419] If you use the -i and --input-class-only options together in unloaddb, unrelated alter serial statements will be output.

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -1001,7 +1001,7 @@ emit_class_alter_serial (extract_context & ctxt, print_output & output_ctx)
     {
       do
 	{
-	  for (i = 0; i < SERIAL_VALUE_INDEX_MAX; i++)
+	  for (i = 0; i < ALTER_SERIAL_VALUE_INDEX_MAX; i++)
 	    {
 	      error = db_query_get_tuple_value (query_result, i, &values[i]);
 	      if (error != NO_ERROR)

--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -930,7 +930,7 @@ emit_class_alter_serial (extract_context & ctxt, print_output & output_ctx)
   int i;
   DB_QUERY_RESULT *query_result;
   DB_QUERY_ERROR query_error;
-  DB_VALUE values[SERIAL_VALUE_INDEX_MAX], diff_value, answer_value;
+  DB_VALUE values[ALTER_SERIAL_VALUE_INDEX_MAX], diff_value, answer_value;
   DB_DOMAIN *domain;
   char str_buf[NUMERIC_MAX_STRING_SIZE] = { '\0' };
   char *uppercase_user = NULL;

--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -140,6 +140,24 @@ typedef enum
 
 typedef enum
 {
+  ALTER_SERIAL_UNIQUE_NAME,
+  ALTER_SERIAL_NAME,
+  ALTER_SERIAL_OWNER_NAME,
+  ALTER_SERIAL_CURRENT_VAL,
+  ALTER_SERIAL_INCREMENT_VAL,
+  ALTER_SERIAL_MAX_VAL,
+  ALTER_SERIAL_MIN_VAL,
+  ALTER_SERIAL_CYCLIC,
+  ALTER_SERIAL_STARTED,
+  ALTER_SERIAL_CACHED_NUM,
+  ALTER_SERIAL_CLASS_NAME,
+  ALTER_SERIAL_COMMENT,
+
+  ALTER_SERIAL_VALUE_INDEX_MAX
+} ALTER_SERIAL_VALUE_INDEX;
+
+typedef enum
+{
   SYNONYM_NAME,
   SYNONYM_OWNER,
   SYNONYM_OWNER_NAME,
@@ -920,18 +938,24 @@ emit_class_alter_serial (extract_context & ctxt, print_output & output_ctx)
   size_t query_size = 0;
   char *query = NULL;
 
+  DB_OBJLIST *cl = NULL;
+  const char *schema_name = NULL;
+  char temp_schema[DB_MAX_CLASS_LENGTH] = { '\0' };
+  const char *serial_owner_name = NULL;
+  const char *serial_class_name = NULL;
+
   /*
    * You must check SERIAL_VALUE_INDEX enum defined on the top of this file
    * when changing the following query. Notice the order of the result.
    */
   const char *query_all =
-    "select [unique_name], [name], [owner].[name], " "[current_val], " "[increment_val], " "[max_val], " "[min_val], "
-    "[cyclic], " "[started], " "[cached_num], " "[comment] "
+    "select [unique_name], [name], [owner].[name], [current_val], [increment_val], [max_val], [min_val], "
+    "[cyclic], [started], [cached_num], [class_name], [comment] "
     "from [db_serial] where [class_name] is not null and [att_name] is not null";
 
   const char *query_user =
-    "select [unique_name], [name], [owner].[name], " "[current_val], " "[increment_val], " "[max_val], " "[min_val], "
-    "[cyclic], " "[started], " "[cached_num], " "[comment] "
+    "select [unique_name], [name], [owner].[name], [class_name], [current_val], [increment_val], [max_val], [min_val], "
+    "[cyclic], [started], [cached_num], [class_name], [comment] "
     "from [db_serial] where [class_name] is not null and [att_name] is not null and owner.name='%s'";
 
   if (ctxt.is_dba_user == false && ctxt.is_dba_group_member == false)
@@ -988,7 +1012,7 @@ emit_class_alter_serial (extract_context & ctxt, print_output & output_ctx)
 	      /* Validation of the result value */
 	      switch (i)
 		{
-		case SERIAL_OWNER_NAME:
+		case ALTER_SERIAL_OWNER_NAME:
 		  {
 		    if (DB_IS_NULL (&values[i]) || DB_VALUE_TYPE (&values[i]) != DB_TYPE_STRING)
 		      {
@@ -997,8 +1021,8 @@ emit_class_alter_serial (extract_context & ctxt, print_output & output_ctx)
 		  }
 		  break;
 
-		case SERIAL_UNIQUE_NAME:
-		case SERIAL_NAME:
+		case ALTER_SERIAL_UNIQUE_NAME:
+		case ALTER_SERIAL_NAME:
 		  {
 		    if (DB_IS_NULL (&values[i]) || DB_VALUE_TYPE (&values[i]) != DB_TYPE_STRING)
 		      {
@@ -1009,10 +1033,10 @@ emit_class_alter_serial (extract_context & ctxt, print_output & output_ctx)
 		  }
 		  break;
 
-		case SERIAL_CURRENT_VAL:
-		case SERIAL_INCREMENT_VAL:
-		case SERIAL_MAX_VAL:
-		case SERIAL_MIN_VAL:
+		case ALTER_SERIAL_CURRENT_VAL:
+		case ALTER_SERIAL_INCREMENT_VAL:
+		case ALTER_SERIAL_MAX_VAL:
+		case ALTER_SERIAL_MIN_VAL:
 		  {
 		    if (DB_IS_NULL (&values[i]) || DB_VALUE_TYPE (&values[i]) != DB_TYPE_NUMERIC)
 		      {
@@ -1023,9 +1047,9 @@ emit_class_alter_serial (extract_context & ctxt, print_output & output_ctx)
 		  }
 		  break;
 
-		case SERIAL_CYCLIC:
-		case SERIAL_STARTED:
-		case SERIAL_CACHED_NUM:
+		case ALTER_SERIAL_CYCLIC:
+		case ALTER_SERIAL_STARTED:
+		case ALTER_SERIAL_CACHED_NUM:
 		  {
 		    if (DB_IS_NULL (&values[i]) || DB_VALUE_TYPE (&values[i]) != DB_TYPE_INTEGER)
 		      {
@@ -1036,7 +1060,18 @@ emit_class_alter_serial (extract_context & ctxt, print_output & output_ctx)
 		  }
 		  break;
 
-		case SERIAL_COMMENT:
+		case ALTER_SERIAL_CLASS_NAME:
+		  {
+		    if (DB_IS_NULL (&values[i]) || DB_VALUE_TYPE (&values[i]) != DB_TYPE_STRING)
+		      {
+			er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_INVALID_SERIAL_VALUE, 0);
+			error = ER_INVALID_SERIAL_VALUE;
+			goto err;
+		      }
+		  }
+		  break;
+
+		case ALTER_SERIAL_COMMENT:
 		  {
 		    if (DB_IS_NULL (&values[i]) == false && DB_VALUE_TYPE (&values[i]) != DB_TYPE_STRING)
 		      {
@@ -1054,34 +1089,60 @@ emit_class_alter_serial (extract_context & ctxt, print_output & output_ctx)
 		}
 	    }
 
+	  if (required_class_only == true)
+	    {
+	      int same_schema = 0;
+	      for (cl = ctxt.classes; cl != NULL; cl = cl->next)
+		{
+		  schema_name = db_get_class_name (cl->op);
+
+		  serial_owner_name = db_get_string (&values[ALTER_SERIAL_OWNER_NAME]);
+		  serial_class_name = db_get_string (&values[ALTER_SERIAL_CLASS_NAME]);
+
+		  str_tolower ((char *) serial_owner_name);
+		  snprintf (temp_schema, DB_MAX_CLASS_LENGTH, "%s%s%s", (serial_owner_name), ".", serial_class_name);
+
+		  if (strcmp (temp_schema, schema_name) == 0)
+		    {
+		      same_schema++;
+		    }
+		}
+
+	      if (same_schema == 0)
+		{
+		  continue;
+		}
+	    }
+
 	  if (ctxt.is_dba_user == false && ctxt.is_dba_group_member == false)
 	    {
 	      output_ctx ("\nALTER SERIAL %s%s%s START WITH %s;\n",
-			  PRINT_IDENTIFIER (db_get_string (&values[SERIAL_NAME])),
-			  numeric_db_value_print (&values[SERIAL_CURRENT_VAL], str_buf));
+			  PRINT_IDENTIFIER (db_get_string (&values[ALTER_SERIAL_NAME])),
+			  numeric_db_value_print (&values[ALTER_SERIAL_CURRENT_VAL], str_buf));
 
-	      if (db_get_int (&values[SERIAL_STARTED]) == 1)
+	      if (db_get_int (&values[ALTER_SERIAL_STARTED]) == 1)
 		{
 
-		  output_ctx ("SELECT %s%s%s.NEXT_VALUE;\n ", PRINT_IDENTIFIER (db_get_string (&values[SERIAL_NAME])));
+		  output_ctx ("SELECT %s%s%s.NEXT_VALUE;\n ",
+			      PRINT_IDENTIFIER (db_get_string (&values[ALTER_SERIAL_NAME])));
 		}
 	    }
 	  else
 	    {
 	      output_ctx ("\nALTER SERIAL %s%s%s START WITH %s;\n",
-			  PRINT_IDENTIFIER (db_get_string (&values[SERIAL_UNIQUE_NAME])),
-			  numeric_db_value_print (&values[SERIAL_CURRENT_VAL], str_buf));
+			  PRINT_IDENTIFIER (db_get_string (&values[ALTER_SERIAL_UNIQUE_NAME])),
+			  numeric_db_value_print (&values[ALTER_SERIAL_CURRENT_VAL], str_buf));
 
-	      if (db_get_int (&values[SERIAL_STARTED]) == 1)
+	      if (db_get_int (&values[ALTER_SERIAL_STARTED]) == 1)
 		{
 		  output_ctx ("SELECT %s%s%s.NEXT_VALUE;\n ",
-			      PRINT_IDENTIFIER (db_get_string (&values[SERIAL_UNIQUE_NAME])));
+			      PRINT_IDENTIFIER (db_get_string (&values[ALTER_SERIAL_UNIQUE_NAME])));
 		}
 	    }
 
 	  db_value_clear (&diff_value);
 	  db_value_clear (&answer_value);
-	  for (i = 0; i < SERIAL_VALUE_INDEX_MAX; i++)
+	  for (i = 0; i < ALTER_SERIAL_VALUE_INDEX_MAX; i++)
 	    {
 	      db_value_clear (&values[i]);
 	    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25419

Purpose
When extracting schema information using the -i and --input-class-only options together in unloaddb, the schema of the table specified in the input file and the related ALTER SERIAL statement are included and extracted.

Implementation
N/A

Remarks
N/A