### PR TITLE
[CBRD-25428] When execution of the recursive part in the recursive CTE ends, clear VAL_LIST

### DIFF
--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -4590,7 +4590,10 @@ fetch_val_list (THREAD_ENTRY * thread_p, regu_variable_list_node * regu_list, va
 	    }
 	  else
 	    {
-	      pr_clear_value (regup->value.vfetch_to);
+	      if (pr_is_set_type (DB_VALUE_DOMAIN_TYPE (regup->value.vfetch_to)))
+		{
+		  pr_clear_value (regup->value.vfetch_to);
+		}
 	      rc = fetch_peek_dbval (thread_p, &regup->value, vd, class_oid, obj_oid, tpl, &tmp);
 	    }
 
@@ -4611,7 +4614,10 @@ fetch_val_list (THREAD_ENTRY * thread_p, regu_variable_list_node * regu_list, va
        */
       for (regup = regu_list; regup != NULL; regup = regup->next)
 	{
-	  pr_clear_value (regup->value.vfetch_to);
+	  if (pr_is_set_type (DB_VALUE_DOMAIN_TYPE (regup->value.vfetch_to)))
+	    {
+	      pr_clear_value (regup->value.vfetch_to);
+	    }
 	  if (fetch_copy_dbval (thread_p, &regup->value, vd, class_oid, obj_oid, tpl, regup->value.vfetch_to) !=
 	      NO_ERROR)
 	    {

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -4612,7 +4612,6 @@ fetch_val_list (THREAD_ENTRY * thread_p, regu_variable_list_node * regu_list, va
       for (regup = regu_list; regup != NULL; regup = regup->next)
 	{
 	  pr_clear_value (regup->value.vfetch_to);
-
 	  if (fetch_copy_dbval (thread_p, &regup->value, vd, class_oid, obj_oid, tpl, regup->value.vfetch_to) !=
 	      NO_ERROR)
 	    {

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -4590,10 +4590,7 @@ fetch_val_list (THREAD_ENTRY * thread_p, regu_variable_list_node * regu_list, va
 	    }
 	  else
 	    {
-	      if (pr_is_set_type (DB_VALUE_DOMAIN_TYPE (regup->value.vfetch_to)))
-		{
-		  pr_clear_value (regup->value.vfetch_to);
-		}
+	      pr_clear_value (regup->value.vfetch_to);
 	      rc = fetch_peek_dbval (thread_p, &regup->value, vd, class_oid, obj_oid, tpl, &tmp);
 	    }
 
@@ -4614,10 +4611,8 @@ fetch_val_list (THREAD_ENTRY * thread_p, regu_variable_list_node * regu_list, va
        */
       for (regup = regu_list; regup != NULL; regup = regup->next)
 	{
-	  if (pr_is_set_type (DB_VALUE_DOMAIN_TYPE (regup->value.vfetch_to)))
-	    {
-	      pr_clear_value (regup->value.vfetch_to);
-	    }
+	  pr_clear_value (regup->value.vfetch_to);
+
 	  if (fetch_copy_dbval (thread_p, &regup->value, vd, class_oid, obj_oid, tpl, regup->value.vfetch_to) !=
 	      NO_ERROR)
 	    {

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -16142,6 +16142,14 @@ qexec_execute_cte (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_
 	      GOTO_EXIT_ON_ERROR;
 	    }
 
+	  /* Before executing the next recursive part, clearing VAL_LIST is necessary.
+	   * See CBRD-25428 for the details.
+	   */
+	  if (recursive_part->val_list)
+	    {
+	      qexec_clear_db_val_list (recursive_part->val_list->valp);
+	    }
+
 	  if (first_iteration)
 	    {
 	      /* unify list_id types after the first execution of the recursive part */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25428

In the recursive CTE, clear VAL_LIST when the execution of the recursive part is completed.