### PR TITLE
[CBRD-25426] Remove empty space in schema file

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -847,7 +847,7 @@ export_serial (extract_context & ctxt, print_output & output_ctx)
 
 	  if (db_get_int (&values[SERIAL_STARTED]) == 1)
 	    {
-	      output_ctx ("SELECT %s%s%s.NEXT_VALUE;\n ", PRINT_IDENTIFIER (db_get_string (&values[SERIAL_NAME])));
+	      output_ctx ("SELECT %s%s%s.NEXT_VALUE;\n", PRINT_IDENTIFIER (db_get_string (&values[SERIAL_NAME])));
 	    }
 
 	  if (ctxt.is_dba_user || ctxt.is_dba_group_member)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25426

Purpose
Remove empty space in schema file from which serial is extracted

Implementation
AS-IS
`SELECT [seq2].NEXT_VALUE;`
` call [change_serial_owner] ('seq2', 'DBA') on class [db_serial];`

TO-BE
`SELECT [seq2].NEXT_VALUE;`
`call [change_serial_owner] ('seq2', 'DBA') on class [db_serial];`


