### PR TITLE
[CBRD-25426] Backport to 10.2 - If the current_val of serial is the same as max_val, an error occurs during unloaddb/loaddb.

### DIFF
--- a/src/compat/db_vdb.c
+++ b/src/compat/db_vdb.c
@@ -303,6 +303,7 @@ db_parse_one_statement (DB_SESSION * session)
       if (session->type_list)
 	{
 	  db_free_query_format (session->type_list[0]);
+	  session->type_list[0] = NULL;
 	}
       if (session->statements[0])
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25426

Purpose
If you create SERIAL in ascending/descending order and increase current_val to max_val and then perform unload/load, two errors occur.
* In the case of ascending Serial, an error occurs when performing unloaddb.
* In the case of descending Serial, no error occurs in unladdb. However, an error occurs when performing loaddb.

Implementation
N/A

Remarks
N/A