### PR TITLE
[CBRD-25219] SP 리턴 타입과 SP 인자 타입에 precision, scale 정보 저장

### DIFF
--- a/cs/CMakeLists.txt
+++ b/cs/CMakeLists.txt
@@ -59,6 +59,7 @@ set(COMPAT_SOURCES
   ${COMPAT_DIR}/db_value_printer.cpp
   ${COMPAT_DIR}/db_vdb.c
   ${COMPAT_DIR}/db_virt.c
+  ${COMPAT_DIR}/dbtype_def.c
   ${COMPAT_DIR}/dbtype_function.c
   )
 

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -60,6 +60,7 @@ set(COMPAT_SOURCES
   ${COMPAT_DIR}/db_value_printer.cpp
   ${COMPAT_DIR}/db_vdb.c
   ${COMPAT_DIR}/db_virt.c
+  ${COMPAT_DIR}/dbtype_def.c
   ${COMPAT_DIR}/dbtype_function.c
   )
 set(COMPAT_SOURCES_C

--- a/src/compat/dbtype_def.c
+++ b/src/compat/dbtype_def.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#include <cstddef>
+#include <cstring>
+#include <cassert>
+#include <dbtype_def.h>
+
+/* CAUTION: the following list must match DB_TYPE defined in dbtype_def.h */
+const char *db_type_names[DB_TYPE_LAST + 1] =
+{
+    NULL /* NULL */,
+    "INTEGER",
+    "FLOAT",
+    "DOUBLE",
+    "STRING",
+    "OBJECT",
+    "SET",
+    "MULTISET",
+    "SEQUENCE",
+    "ELO",
+    "TIME",
+    "TIMESTAMP",
+    "DATE",
+    "MONETARY",
+    NULL /* VARIABLE */,
+    NULL /* SUB */,
+    NULL /* POINTER */,
+    NULL /* ERROR */,
+    "SHORT",
+    NULL /* VOBJ */,
+    NULL /* OID */,
+    NULL /* DB_VALUE */,
+    "NUMERIC",
+    "BIT",
+    "VARBIT",
+    "CHAR",
+    "NCHAR",
+    "VARNCHAR",
+    NULL /* RESULTSET */,
+    NULL /* MIDXKEY */,
+    NULL /* TABLE */,
+    "BIGINT",
+    "DATETIME",
+    "BLOB",
+    "CLOB",
+    "ENUM",
+    "TIMESTAMPTZ",
+    "TIMESTAMPLTZ",
+    "DATETIMETZ",
+    "DATETIMELTZ",
+    "JSON"
+};
+
+int
+db_get_db_type_of_name(const char *name)
+{
+    assert (name);
+
+    int i;
+    for (i = 0; i <= DB_TYPE_LAST; i++) {
+        const char *name_i = db_type_names[i];
+        if (name_i && strcmp(name, name_i) == 0) {
+            return i;
+        }
+    }
+
+    return -1;  // no such DB_TYPE
+}
+
+const char*
+db_get_name_of_db_type(const int db_type)
+{
+    if (db_type >= 0 && db_type <= DB_TYPE_LAST) {
+        return db_type_names[db_type];
+    } else {
+        return NULL;
+    }
+}

--- a/src/compat/dbtype_def.c
+++ b/src/compat/dbtype_def.c
@@ -22,73 +22,77 @@
 #include <dbtype_def.h>
 
 /* CAUTION: the following list must match DB_TYPE defined in dbtype_def.h */
-static const char *db_type_names[DB_TYPE_LAST + 1] =
-{
-    NULL /* NULL */,
-    "INTEGER",
-    "FLOAT",
-    "DOUBLE",
-    "VARCHAR",
-    "OBJECT",
-    "SET",
-    "MULTISET",
-    "SEQUENCE",
-    "ELO",
-    "TIME",
-    "TIMESTAMP",
-    "DATE",
-    "MONETARY",
-    NULL /* VARIABLE */,
-    NULL /* SUB */,
-    NULL /* POINTER */,
-    NULL /* ERROR */,
-    "SHORT",
-    NULL /* VOBJ */,
-    NULL /* OID */,
-    NULL /* DB_VALUE */,
-    "NUMERIC",
-    "BIT",
-    "VARBIT",
-    "CHAR",
-    "NCHAR",
-    "VARNCHAR",
-    NULL /* RESULTSET */,
-    NULL /* MIDXKEY */,
-    NULL /* TABLE */,
-    "BIGINT",
-    "DATETIME",
-    "BLOB",
-    "CLOB",
-    "ENUM",
-    "TIMESTAMPTZ",
-    "TIMESTAMPLTZ",
-    "DATETIMETZ",
-    "DATETIMELTZ",
-    "JSON"
+static const char *db_type_names[DB_TYPE_LAST + 1] = {
+  NULL /* NULL */ ,
+  "INTEGER",
+  "FLOAT",
+  "DOUBLE",
+  "VARCHAR",
+  "OBJECT",
+  "SET",
+  "MULTISET",
+  "SEQUENCE",
+  "ELO",
+  "TIME",
+  "TIMESTAMP",
+  "DATE",
+  "MONETARY",
+  NULL /* VARIABLE */ ,
+  NULL /* SUB */ ,
+  NULL /* POINTER */ ,
+  NULL /* ERROR */ ,
+  "SHORT",
+  NULL /* VOBJ */ ,
+  NULL /* OID */ ,
+  NULL /* DB_VALUE */ ,
+  "NUMERIC",
+  "BIT",
+  "VARBIT",
+  "CHAR",
+  "NCHAR",
+  "VARNCHAR",
+  NULL /* RESULTSET */ ,
+  NULL /* MIDXKEY */ ,
+  NULL /* TABLE */ ,
+  "BIGINT",
+  "DATETIME",
+  "BLOB",
+  "CLOB",
+  "ENUM",
+  "TIMESTAMPTZ",
+  "TIMESTAMPLTZ",
+  "DATETIMETZ",
+  "DATETIMELTZ",
+  "JSON"
 };
 
 int
-db_get_db_type_of_name(const char *name)
+db_get_db_type_of_name (const char *name)
 {
-    assert (name);
+  assert (name);
 
-    int i;
-    for (i = 0; i <= DB_TYPE_LAST; i++) {
-        const char *name_i = db_type_names[i];
-        if (name_i && strcmp(name, name_i) == 0) {
-            return i;
-        }
+  int i;
+  for (i = 0; i <= DB_TYPE_LAST; i++)
+    {
+      const char *name_i = db_type_names[i];
+      if (name_i && strcmp (name, name_i) == 0)
+	{
+	  return i;
+	}
     }
 
-    return -1;  // no such DB_TYPE
+  return -1;			// no such DB_TYPE
 }
 
-const char*
-db_get_name_of_db_type(const int db_type)
+const char *
+db_get_name_of_db_type (const int db_type)
 {
-    if (db_type >= 0 && db_type <= DB_TYPE_LAST) {
-        return db_type_names[db_type];
-    } else {
-        return NULL;
+  if (db_type >= 0 && db_type <= DB_TYPE_LAST)
+    {
+      return db_type_names[db_type];
+    }
+  else
+    {
+      return NULL;
     }
 }

--- a/src/compat/dbtype_def.c
+++ b/src/compat/dbtype_def.c
@@ -22,13 +22,13 @@
 #include <dbtype_def.h>
 
 /* CAUTION: the following list must match DB_TYPE defined in dbtype_def.h */
-const char *db_type_names[DB_TYPE_LAST + 1] =
+static const char *db_type_names[DB_TYPE_LAST + 1] =
 {
     NULL /* NULL */,
     "INTEGER",
     "FLOAT",
     "DOUBLE",
-    "STRING",
+    "VARCHAR",
     "OBJECT",
     "SET",
     "MULTISET",

--- a/src/compat/dbtype_def.h
+++ b/src/compat/dbtype_def.h
@@ -676,6 +676,7 @@ extern "C"
 
   /* This defines the basic type identifier constants. These are used in the domain specifications of attributes and method
    * arguments and as value type tags in the DB_VALUE structures.
+   * CAUTION: the following list must match db_type_names defined in dbtype_def.c
    */
   typedef enum
   {
@@ -731,6 +732,11 @@ extern "C"
 
     DB_TYPE_LAST = DB_TYPE_JSON
   } DB_TYPE;
+
+  extern const char *db_type_names[DB_TYPE_LAST + 1];
+  extern int db_get_db_type_of_name(const char *name);
+  extern const char* db_get_name_of_db_type(const int db_type);
+
 
   /* Domain information stored in DB_VALUE structures. */
   typedef union db_domain_info DB_DOMAIN_INFO;

--- a/src/compat/dbtype_def.h
+++ b/src/compat/dbtype_def.h
@@ -733,7 +733,6 @@ extern "C"
     DB_TYPE_LAST = DB_TYPE_JSON
   } DB_TYPE;
 
-  extern const char *db_type_names[DB_TYPE_LAST + 1];
   extern int db_get_db_type_of_name(const char *name);
   extern const char* db_get_name_of_db_type(const int db_type);
 

--- a/src/compat/dbtype_def.h
+++ b/src/compat/dbtype_def.h
@@ -733,8 +733,8 @@ extern "C"
     DB_TYPE_LAST = DB_TYPE_JSON
   } DB_TYPE;
 
-  extern int db_get_db_type_of_name(const char *name);
-  extern const char* db_get_name_of_db_type(const int db_type);
+  extern int db_get_db_type_of_name (const char *name);
+  extern const char *db_get_name_of_db_type (const int db_type);
 
 
   /* Domain information stored in DB_VALUE structures. */

--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -4314,9 +4314,9 @@ emit_stored_procedure_args (print_output & output_ctx, int arg_cnt, DB_SET * arg
       output_ctx ("%s ", arg_mode == SP_MODE_IN ? "IN" : arg_mode == SP_MODE_OUT ? "OUT" : "INOUT");
 
       {
-          const char *arg_type_str = db_get_string(&arg_type_val);
-          const int arg_type_str_len = db_get_string_size(&arg_type_val);
-          jsp_parse_data_type_str(&arg_type, NULL, NULL, arg_type_str, arg_type_str_len);
+	const char *arg_type_str = db_get_string (&arg_type_val);
+	const int arg_type_str_len = db_get_string_size (&arg_type_val);
+	jsp_parse_data_type_str (&arg_type, NULL, NULL, arg_type_str, arg_type_str_len);
       }
 
       if (arg_type == DB_TYPE_RESULTSET)
@@ -4429,9 +4429,9 @@ emit_stored_procedure (extract_context & ctxt, print_output & output_ctx)
 
       if (sp_type == SP_TYPE_FUNCTION)
 	{
-          const char *rtn_type_str = db_get_string(&rtn_type_val);
-          const int rtn_type_str_len = db_get_string_size(&rtn_type_val);
-          jsp_parse_data_type_str(&rtn_type, NULL, NULL, rtn_type_str, rtn_type_str_len);
+	  const char *rtn_type_str = db_get_string (&rtn_type_val);
+	  const int rtn_type_str_len = db_get_string_size (&rtn_type_val);
+	  jsp_parse_data_type_str (&rtn_type, NULL, NULL, rtn_type_str, rtn_type_str_len);
 
 	  if (rtn_type == DB_TYPE_RESULTSET)
 	    {

--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -4359,7 +4359,11 @@ emit_stored_procedure_args (print_output & output_ctx, int arg_cnt, DB_SET * arg
       arg_mode = db_get_int (&arg_mode_val);
       output_ctx ("%s ", arg_mode == SP_MODE_IN ? "IN" : arg_mode == SP_MODE_OUT ? "OUT" : "INOUT");
 
-      arg_type = db_get_int (&arg_type_val);
+      {
+          const char *arg_type_str = db_get_string(&arg_type_val);
+          const int arg_type_str_len = db_get_string_size(&arg_type_val);
+          jsp_parse_data_type_str(&arg_type, NULL, NULL, arg_type_str, arg_type_str_len);
+      }
 
       if (arg_type == DB_TYPE_RESULTSET)
 	{
@@ -4471,7 +4475,9 @@ emit_stored_procedure (extract_context & ctxt, print_output & output_ctx)
 
       if (sp_type == SP_TYPE_FUNCTION)
 	{
-	  rtn_type = db_get_int (&rtn_type_val);
+          const char *rtn_type_str = db_get_string(&rtn_type_val);
+          const int rtn_type_str_len = db_get_string_size(&rtn_type_val);
+          jsp_parse_data_type_str(&rtn_type, NULL, NULL, rtn_type_str, rtn_type_str_len);
 
 	  if (rtn_type == DB_TYPE_RESULTSET)
 	    {

--- a/src/jsp/jsp_cl.c
+++ b/src/jsp/jsp_cl.c
@@ -99,7 +99,7 @@ static int server_port = -1;
 static int call_cnt = 0;
 static bool is_prepare_call[MAX_CALL_COUNT] = { false, };
 
-static void jsp_stringify_data_type(char *buf, PT_TYPE_ENUM type_enum, PT_NODE *data_type);
+static void jsp_stringify_data_type (char *buf, PT_TYPE_ENUM type_enum, PT_NODE * data_type);
 
 static SP_TYPE_ENUM jsp_map_pt_misc_to_sp_type (PT_MISC_TYPE pt_enum);
 static int jsp_map_pt_misc_to_sp_mode (PT_MISC_TYPE pt_enum);
@@ -307,9 +307,9 @@ jsp_get_return_type (const char *name)
   AU_ENABLE (save);
 
   int ret_type;
-  const char *ret_type_str = db_get_string(&return_type);
-  const int ret_type_str_len = db_get_string_size(&return_type);
-  jsp_parse_data_type_str(&ret_type, NULL, NULL, ret_type_str, ret_type_str_len);
+  const char *ret_type_str = db_get_string (&return_type);
+  const int ret_type_str_len = db_get_string_size (&return_type);
+  jsp_parse_data_type_str (&ret_type, NULL, NULL, ret_type_str, ret_type_str_len);
   return ret_type;
 }
 
@@ -675,7 +675,7 @@ jsp_create_stored_procedure (PARSER_CONTEXT * parser, PT_NODE * statement)
 
   comment = (char *) PT_NODE_SP_COMMENT (statement);
 
-  jsp_stringify_data_type(ret_type_str, statement->info.sp.ret_type, statement->info.sp.ret_data_type);
+  jsp_stringify_data_type (ret_type_str, statement->info.sp.ret_type, statement->info.sp.ret_data_type);
   err = jsp_add_stored_procedure (name, type, ret_type_str, param_list, decl, comment);
   if (err != NO_ERROR)
     {
@@ -1120,9 +1120,9 @@ jsp_add_stored_procedure (const char *name, const PT_MISC_TYPE type, const char 
 
       arg_comment = (char *) PT_NODE_SP_ARG_COMMENT (node_p);
 
-      jsp_stringify_data_type(data_type_buf, node_p->type_enum, node_p->data_type);
+      jsp_stringify_data_type (data_type_buf, node_p->type_enum, node_p->data_type);
       err = jsp_add_stored_procedure_argument (&mop, checked_name, name_info.original, i, data_type_buf,
-					   node_p->info.sp_param.mode, arg_comment);
+					       node_p->info.sp_param.mode, arg_comment);
       if (err != NO_ERROR)
 	{
 	  goto error;
@@ -1455,11 +1455,11 @@ jsp_make_method_sig_list (PARSER_CONTEXT * parser, PT_NODE * node, method_sig_li
 		error = db_get (arg_mop_p, SP_ATTR_DATA_TYPE, &arg_type);
 		if (error == NO_ERROR)
 		  {
-                    int type_val;
+		    int type_val;
 
-                    const char *arg_type_str = db_get_string(&arg_type);
-                    const int arg_type_str_len = db_get_string_size(&arg_type);
-                    jsp_parse_data_type_str(&type_val, NULL, NULL, arg_type_str, arg_type_str_len);
+		    const char *arg_type_str = db_get_string (&arg_type);
+		    const int arg_type_str_len = db_get_string_size (&arg_type);
+		    jsp_parse_data_type_str (&type_val, NULL, NULL, arg_type_str, arg_type_str_len);
 
 		    if (type_val == DB_TYPE_RESULTSET && !jsp_is_prepare_call ())
 		      {
@@ -1488,11 +1488,11 @@ jsp_make_method_sig_list (PARSER_CONTEXT * parser, PT_NODE * node, method_sig_li
 	    goto end;
 	  }
 
-        {
-            const char *res_type_str = db_get_string(&result_type);
-            const int res_type_str_len = db_get_string_size(&result_type);
-            jsp_parse_data_type_str(&sig_result_type, NULL, NULL, res_type_str, res_type_str_len);
-        }
+	{
+	  const char *res_type_str = db_get_string (&result_type);
+	  const int res_type_str_len = db_get_string_size (&result_type);
+	  jsp_parse_data_type_str (&sig_result_type, NULL, NULL, res_type_str, res_type_str_len);
+	}
 
 	if (sig_result_type == DB_TYPE_RESULTSET && !jsp_is_prepare_call ())
 	  {
@@ -1632,125 +1632,152 @@ jsp_make_method_arglist (PARSER_CONTEXT * parser, PT_NODE * node_list)
 }
 
 static void
-jsp_get_prec_scale_from_data_type(int *prec, int *scale, PT_NODE *data_type)
+jsp_get_prec_scale_from_data_type (int *prec, int *scale, PT_NODE * data_type)
 {
-    assert (prec);
-    assert (data_type);
+  assert (prec);
+  assert (data_type);
 
-    if (data_type->type_enum == PT_TYPE_TABLE_COLUMN) {
-        data_type = data_type->data_type;
+  if (data_type->type_enum == PT_TYPE_TABLE_COLUMN)
+    {
+      data_type = data_type->data_type;
     }
 
-    if (scale) {
-        assert (data_type->type_enum == PT_TYPE_NUMERIC);
-        *scale = data_type->info.data_type.dec_precision;
-    } else {
-        assert (data_type->type_enum == PT_TYPE_CHAR || data_type->type_enum == PT_TYPE_VARCHAR);
+  if (scale)
+    {
+      assert (data_type->type_enum == PT_TYPE_NUMERIC);
+      *scale = data_type->info.data_type.dec_precision;
+    }
+  else
+    {
+      assert (data_type->type_enum == PT_TYPE_CHAR || data_type->type_enum == PT_TYPE_VARCHAR);
     }
 
-    *prec = data_type->info.data_type.precision;
+  *prec = data_type->info.data_type.precision;
 }
 
 static void
-jsp_stringify_data_type(char *buf, PT_TYPE_ENUM type_enum, PT_NODE *data_type)
+jsp_stringify_data_type (char *buf, PT_TYPE_ENUM type_enum, PT_NODE * data_type)
 {
-    switch (type_enum) {
+  switch (type_enum)
+    {
     case PT_TYPE_NONE:
-        strcpy(buf, "void");
-        return;
+      strcpy (buf, "void");
+      return;
     case PT_TYPE_RESULTSET:
-        strcpy(buf, "CURSOR");
-        return;
+      strcpy (buf, "CURSOR");
+      return;
     default:
-        ;   // do nothing
+      ;				// do nothing
     }
 
-    int db_type = pt_type_enum_to_db(type_enum);
-    strcpy(buf, db_get_name_of_db_type(db_type));
+  int db_type = pt_type_enum_to_db (type_enum);
+  strcpy (buf, db_get_name_of_db_type (db_type));
 
-    switch (db_type) {
+  switch (db_type)
+    {
     case DB_TYPE_NUMERIC:
     case DB_TYPE_CHAR:
     case DB_TYPE_VARCHAR:
-    {
-        char *prec_pos = buf + strlen(buf);
-        if (db_type == DB_TYPE_NUMERIC) {
-            int prec, scale;
-            jsp_get_prec_scale_from_data_type(&prec, &scale, data_type);
-            sprintf(prec_pos, "(%d, %d)", prec, scale);
-        } else {
-            // char or varchar
-            int prec;
-            jsp_get_prec_scale_from_data_type(&prec, NULL, data_type);
-            sprintf(prec_pos, "(%d)", prec);
-        }
-        break;
-    }
+      {
+	char *prec_pos = buf + strlen (buf);
+	if (db_type == DB_TYPE_NUMERIC)
+	  {
+	    int prec, scale;
+	    jsp_get_prec_scale_from_data_type (&prec, &scale, data_type);
+	    sprintf (prec_pos, "(%d, %d)", prec, scale);
+	  }
+	else
+	  {
+	    // char or varchar
+	    int prec;
+	    jsp_get_prec_scale_from_data_type (&prec, NULL, data_type);
+	    sprintf (prec_pos, "(%d)", prec);
+	  }
+	break;
+      }
     default:
-        ;   // do nothing
+      ;				// do nothing
     }
 }
 
 void
-jsp_parse_data_type_str(int *db_type, int *precision, int *scale, const char *data_type_str, const int data_type_str_len)
+jsp_parse_data_type_str (int *db_type, int *precision, int *scale, const char *data_type_str,
+			 const int data_type_str_len)
 {
 
-    // The way this function parses the data type string depends on
-    // the way the string was built in jsp_stringify_data_type()
+  // The way this function parses the data type string depends on
+  // the way the string was built in jsp_stringify_data_type()
 
-    bool has_precision, need_precision;
-    assert(db_type);
+  bool has_precision, need_precision;
+  assert (db_type);
 
-    char buf[SP_DATA_TYPE_STR_LEN_MAX + 1];
-    memcpy(buf, data_type_str, data_type_str_len);
-    buf[data_type_str_len] = '\0';
+  char buf[SP_DATA_TYPE_STR_LEN_MAX + 1];
+  memcpy (buf, data_type_str, data_type_str_len);
+  buf[data_type_str_len] = '\0';
 
-    char *lparen_pos = strchr(buf, '(');
-    if (lparen_pos) {
-        has_precision = true;
-        *lparen_pos = '\0';
-    } else {
-        has_precision = false;
+  char *lparen_pos = strchr (buf, '(');
+  if (lparen_pos)
+    {
+      has_precision = true;
+      *lparen_pos = '\0';
+    }
+  else
+    {
+      has_precision = false;
     }
 
-    int ty;
-    if (strcmp(buf, "void") == 0) {
-        ty = DB_TYPE_NULL;
-    } else if (strcmp(buf, "CURSOR") == 0) {
-        ty = DB_TYPE_RESULTSET;
-    } else {
-        ty = db_get_db_type_of_name(buf); // it returns -1 when no match
+  int ty;
+  if (strcmp (buf, "void") == 0)
+    {
+      ty = DB_TYPE_NULL;
     }
-    assert (ty >= 0);
-    *db_type = ty;
-    need_precision = (ty == DB_TYPE_NUMERIC) || (ty == DB_TYPE_CHAR) || (ty == DB_TYPE_VARCHAR);
+  else if (strcmp (buf, "CURSOR") == 0)
+    {
+      ty = DB_TYPE_RESULTSET;
+    }
+  else
+    {
+      ty = db_get_db_type_of_name (buf);	// it returns -1 when no match
+    }
+  assert (ty >= 0);
+  *db_type = ty;
+  need_precision = (ty == DB_TYPE_NUMERIC) || (ty == DB_TYPE_CHAR) || (ty == DB_TYPE_VARCHAR);
 
-    assert (has_precision == need_precision);
+  assert (has_precision == need_precision);
 
-    if (precision && scale) {
-        if (need_precision) {
-            char *token= lparen_pos + 1, *delim;
-            if (ty == DB_TYPE_NUMERIC) {
-                delim = strchr(token, ',');
-                *delim = '\0';
-                *precision = atoi(token);
+  if (precision && scale)
+    {
+      if (need_precision)
+	{
+	  char *token = lparen_pos + 1, *delim;
+	  if (ty == DB_TYPE_NUMERIC)
+	    {
+	      delim = strchr (token, ',');
+	      *delim = '\0';
+	      *precision = atoi (token);
 
-                token = delim + 2;      // 2: a space after the comma
-                delim = strchr(token, ')');
-                *delim = '\0';
-                *scale = atoi(token);
-            } else {
-                // char or varchar
-                delim = strchr(token, ')');
-                *delim = '\0';
-                *precision = atoi(token);
-            }
-        } else {
-            *precision = *scale = 0;    // neither precioson nor scale can be given for this type
-        }
-    } else {
-        // in this case, both must be null: restriction of using this function
-        assert(!precision);
-        assert(!scale);
+	      token = delim + 2;	// 2: a space after the comma
+	      delim = strchr (token, ')');
+	      *delim = '\0';
+	      *scale = atoi (token);
+	    }
+	  else
+	    {
+	      // char or varchar
+	      delim = strchr (token, ')');
+	      *delim = '\0';
+	      *precision = atoi (token);
+	    }
+	}
+      else
+	{
+	  *precision = *scale = 0;	// neither precioson nor scale can be given for this type
+	}
+    }
+  else
+    {
+      // in this case, both must be null: restriction of using this function
+      assert (!precision);
+      assert (!scale);
     }
 }

--- a/src/jsp/jsp_cl.h
+++ b/src/jsp/jsp_cl.h
@@ -53,6 +53,8 @@
 #define SP_ATTR_MODE            "mode"
 #define SP_ATTR_ARG_COMMENT     "comment"
 
+#define SP_DATA_TYPE_STR_LEN_MAX    (31)
+
 typedef enum
 {
   SP_TYPE_PROCEDURE = 1,
@@ -71,6 +73,11 @@ typedef enum
   SP_LANG_PLCSQL = 0,
   SP_LANG_JAVA = 1
 } SP_LANG_ENUM;
+
+
+extern void jsp_stringify_data_type(char *buf, PT_TYPE_ENUM type_enum, PT_NODE *data_type);
+extern void jsp_parse_data_type_str(int *db_type, int *precision, int *scale,
+    const char *data_type_str, const int data_type_str_len);
 
 extern int jsp_create_stored_procedure (PARSER_CONTEXT * parser, PT_NODE * statement);
 extern int jsp_alter_stored_procedure (PARSER_CONTEXT * parser, PT_NODE * statement);

--- a/src/jsp/jsp_cl.h
+++ b/src/jsp/jsp_cl.h
@@ -75,7 +75,6 @@ typedef enum
 } SP_LANG_ENUM;
 
 
-extern void jsp_stringify_data_type(char *buf, PT_TYPE_ENUM type_enum, PT_NODE *data_type);
 extern void jsp_parse_data_type_str(int *db_type, int *precision, int *scale,
     const char *data_type_str, const int data_type_str_len);
 

--- a/src/jsp/jsp_cl.h
+++ b/src/jsp/jsp_cl.h
@@ -75,8 +75,8 @@ typedef enum
 } SP_LANG_ENUM;
 
 
-extern void jsp_parse_data_type_str(int *db_type, int *precision, int *scale,
-    const char *data_type_str, const int data_type_str_len);
+extern void jsp_parse_data_type_str (int *db_type, int *precision, int *scale,
+				     const char *data_type_str, const int data_type_str_len);
 
 extern int jsp_create_stored_procedure (PARSER_CONTEXT * parser, PT_NODE * statement);
 extern int jsp_alter_stored_procedure (PARSER_CONTEXT * parser, PT_NODE * statement);

--- a/src/method/method_callback.cpp
+++ b/src/method/method_callback.cpp
@@ -645,9 +645,9 @@ namespace cubmethod
 
 		  if (db_get (arg_mop_p, SP_ATTR_DATA_TYPE, &arg_type) == NO_ERROR)
 		    {
-                      const char *arg_type_str = db_get_string(&arg_type);
-                      const int arg_type_str_len = db_get_string_size(&arg_type);
-                      jsp_parse_data_type_str(&param_info.type, NULL, NULL, arg_type_str, arg_type_str_len);
+		      const char *arg_type_str = db_get_string (&arg_type);
+		      const int arg_type_str_len = db_get_string_size (&arg_type);
+		      jsp_parse_data_type_str (&param_info.type, NULL, NULL, arg_type_str, arg_type_str_len);
 		    }
 
 		  pr_clear_value (&mode);
@@ -665,9 +665,9 @@ namespace cubmethod
 
       if (db_get (mop_p, SP_ATTR_RETURN_TYPE, &return_type) == NO_ERROR)
 	{
-          const char *rtn_type_str = db_get_string(&return_type);
-          const int rtn_type_str_len = db_get_string_size(&return_type);
-          jsp_parse_data_type_str(&res.ret.type, NULL, NULL, rtn_type_str, rtn_type_str_len);
+	  const char *rtn_type_str = db_get_string (&return_type);
+	  const int rtn_type_str_len = db_get_string_size (&return_type);
+	  jsp_parse_data_type_str (&res.ret.type, NULL, NULL, rtn_type_str, rtn_type_str_len);
 	  pr_clear_value (&return_type);
 	}
     }

--- a/src/method/method_callback.cpp
+++ b/src/method/method_callback.cpp
@@ -645,7 +645,9 @@ namespace cubmethod
 
 		  if (db_get (arg_mop_p, SP_ATTR_DATA_TYPE, &arg_type) == NO_ERROR)
 		    {
-		      param_info.type = db_get_int (&arg_type);
+                      const char *arg_type_str = db_get_string(&arg_type);
+                      const int arg_type_str_len = db_get_string_size(&arg_type);
+                      jsp_parse_data_type_str(&param_info.type, NULL, NULL, arg_type_str, arg_type_str_len);
 		    }
 
 		  pr_clear_value (&mode);
@@ -663,7 +665,9 @@ namespace cubmethod
 
       if (db_get (mop_p, SP_ATTR_RETURN_TYPE, &return_type) == NO_ERROR)
 	{
-	  res.ret.type = db_get_int (&return_type);
+          const char *rtn_type_str = db_get_string(&return_type);
+          const int rtn_type_str_len = db_get_string_size(&return_type);
+          jsp_parse_data_type_str(&res.ret.type, NULL, NULL, rtn_type_str, rtn_type_str_len);
 	  pr_clear_value (&return_type);
 	}
     }

--- a/src/method/method_callback.cpp
+++ b/src/method/method_callback.cpp
@@ -647,7 +647,8 @@ namespace cubmethod
 		    {
 		      const char *arg_type_str = db_get_string (&arg_type);
 		      const int arg_type_str_len = db_get_string_size (&arg_type);
-		      jsp_parse_data_type_str (&param_info.type, NULL, NULL, arg_type_str, arg_type_str_len);
+		      jsp_parse_data_type_str (&param_info.type, &param_info.precision, &param_info.scale,
+					       arg_type_str, arg_type_str_len);
 		    }
 
 		  pr_clear_value (&mode);
@@ -667,7 +668,7 @@ namespace cubmethod
 	{
 	  const char *rtn_type_str = db_get_string (&return_type);
 	  const int rtn_type_str_len = db_get_string_size (&return_type);
-	  jsp_parse_data_type_str (&res.ret.type, NULL, NULL, rtn_type_str, rtn_type_str_len);
+	  jsp_parse_data_type_str (&res.ret.type, &res.ret.precision, &res.ret.scale, rtn_type_str, rtn_type_str_len);
 	  pr_clear_value (&return_type);
 	}
     }

--- a/src/object/schema_system_catalog_install.cpp
+++ b/src/object/schema_system_catalog_install.cpp
@@ -49,7 +49,7 @@ catcls_add_data_type (struct db_object *class_mop)
 
   for (i = 0; i <= DB_TYPE_LAST; i++)
     {
-      const char* type_name = db_get_name_of_db_type(i);
+      const char *type_name = db_get_name_of_db_type (i);
       if (type_name != NULL)
 	{
 	  obj = db_create_internal (class_mop);

--- a/src/object/schema_system_catalog_install.cpp
+++ b/src/object/schema_system_catalog_install.cpp
@@ -47,25 +47,10 @@ catcls_add_data_type (struct db_object *class_mop)
   DB_VALUE val;
   int i;
 
-  const char *names[DB_TYPE_LAST] =
-  {
-    "INTEGER", "FLOAT", "DOUBLE", "STRING", "OBJECT",
-    "SET", "MULTISET", "SEQUENCE", "ELO", "TIME",
-    "TIMESTAMP", "DATE", "MONETARY", NULL /* VARIABLE */, NULL /* SUB */,
-    NULL /* POINTER */, NULL /* ERROR */, "SHORT", NULL /* VOBJ */,
-    NULL /* OID */,
-    NULL /* VALUE */, "NUMERIC", "BIT", "VARBIT", "CHAR",
-    "NCHAR", "VARNCHAR", NULL /* RESULTSET */, NULL /* MIDXKEY */,
-    NULL /* TABLE */,
-    "BIGINT", "DATETIME",
-    "BLOB", "CLOB", "ENUM",
-    "TIMESTAMPTZ", "TIMESTAMPLTZ", "DATETIMETZ", "DATETIMELTZ",
-    "JSON"
-  };
-
-  for (i = 0; i < DB_TYPE_LAST; i++)
+  for (i = 0; i <= DB_TYPE_LAST; i++)
     {
-      if (names[i] != NULL)
+      const char* type_name = db_get_name_of_db_type(i);
+      if (type_name != NULL)
 	{
 	  obj = db_create_internal (class_mop);
 	  if (obj == NULL)
@@ -74,10 +59,10 @@ catcls_add_data_type (struct db_object *class_mop)
 	      return er_errid ();
 	    }
 
-	  db_make_int (&val, i + 1);
+	  db_make_int (&val, i);
 	  db_put_internal (obj, "type_id", &val);
 
-	  db_make_varchar (&val, 16, names[i], strlen (names[i]), LANG_SYS_CODESET, LANG_SYS_COLLATION);
+	  db_make_varchar (&val, 16, type_name, strlen (type_name), LANG_SYS_CODESET, LANG_SYS_COLLATION);
 	  db_put_internal (obj, "type_name", &val);
 	}
     }
@@ -831,7 +816,7 @@ namespace cubschema
     {
       {"sp_name", format_varchar (255)},
       {"sp_type", "integer"},
-      {"return_type", "integer"},
+      {"return_type", format_varchar (31)},
       {"arg_count", "integer"},
       {"args", format_sequence (CT_STORED_PROC_ARGS_NAME)},
       {"lang", "integer"},
@@ -867,7 +852,7 @@ namespace cubschema
       {"sp_name", format_varchar (255)},
       {"index_of", "integer"},
       {"arg_name", format_varchar (255)},
-      {"data_type", "integer"},
+      {"data_type", format_varchar (31)},
       {"mode", "integer"},
       {"comment", format_varchar (1024)},
     },

--- a/src/object/schema_system_catalog_install_query_spec.cpp
+++ b/src/object/schema_system_catalog_install_query_spec.cpp
@@ -1163,12 +1163,7 @@ sm_define_view_stored_procedure_spec (void)
 	"SELECT "
 	  "[sp].[sp_name] AS [sp_name], "
 	  "CASE [sp].[sp_type] WHEN 1 THEN 'PROCEDURE' ELSE 'FUNCTION' END AS [sp_type], "
-	  "CASE [sp].[return_type] "
-	    "WHEN 0 THEN 'void' "
-	    "WHEN 28 THEN 'CURSOR' "
-	    /* CT_DATATYPE_NAME */
-	    "ELSE (SELECT [t].[type_name] FROM [%s] AS [t] WHERE [sp].[return_type] = [t].[type_id]) "
-	    "END AS [return_type], "
+	  "[sp].[return_type] AS [return_type], "
 	  "[sp].[arg_count] AS [arg_count], "
 	  "CASE [sp].[lang] WHEN 1 THEN 'JAVA' ELSE '' END AS [lang], "
 	  "[sp].[target] AS [target], "
@@ -1177,7 +1172,6 @@ sm_define_view_stored_procedure_spec (void)
 	"FROM "
 	  /* CT_STORED_PROC_NAME */
 	  "[%s] AS [sp]",
-	CT_DATATYPE_NAME,
 	CT_STORED_PROC_NAME);
   // *INDENT-ON*
 
@@ -1195,11 +1189,7 @@ sm_define_view_stored_procedure_arguments_spec (void)
 	  "[sp].[sp_name] AS [sp_name], "
 	  "[sp].[index_of] AS [index_of], "
 	  "[sp].[arg_name] AS [arg_name], "
-	  "CASE [sp].[data_type] "
-	    "WHEN 28 THEN 'CURSOR' "
-	    /* CT_DATATYPE_NAME */
-	    "ELSE (SELECT [t].[type_name] FROM [%s] AS [t] WHERE [sp].[data_type] = [t].[type_id]) "
-	    "END AS [data_type], "
+	  "[sp].[data_type] AS [data_type], "
 	  "CASE [sp].[mode] WHEN 1 THEN 'IN' WHEN 2 THEN 'OUT' ELSE 'INOUT' END AS [mode], "
 	  "[sp].[comment] AS [comment] "
 	"FROM "
@@ -1208,7 +1198,6 @@ sm_define_view_stored_procedure_arguments_spec (void)
 	"ORDER BY " /* Is it possible to remove ORDER BY? */
 	  "[sp].[sp_name], "
 	  "[sp].[index_of]",
-	CT_DATATYPE_NAME,
 	CT_STORED_PROC_ARGS_NAME);
   // *INDENT-ON*
 

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -9363,7 +9363,7 @@ pt_is_defined_class (PARSER_CONTEXT * parser, PT_NODE * data_type)
 static PT_TYPE_ENUM
 pt_resolve_table_column_type (PARSER_CONTEXT * parser, PT_NODE * data_type)
 {
-  assert(!data_type->data_type);
+  assert (!data_type->data_type);
 
   PT_NODE *table_column = data_type->info.data_type.table_column;
   assert (PT_IS_DOT_NODE (table_column));
@@ -9387,15 +9387,18 @@ pt_resolve_table_column_type (PARSER_CONTEXT * parser, PT_NODE * data_type)
   int db_type = TP_DOMAIN_TYPE (domain);
   PT_TYPE_ENUM type_enum = pt_db_to_type_enum ((DB_TYPE) db_type);
 
-  PT_NODE *dt = parser_new_node(parser, PT_DATA_TYPE);
+  PT_NODE *dt = parser_new_node (parser, PT_DATA_TYPE);
   dt->type_enum = type_enum;
 
-  if (type_enum == PT_TYPE_NUMERIC) {
-    dt->info.data_type.precision = db_domain_precision(domain);
-    dt->info.data_type.dec_precision = db_domain_scale(domain);
-  } else if (type_enum == PT_TYPE_CHAR || type_enum == PT_TYPE_VARCHAR) {
-    dt->info.data_type.precision = db_domain_precision(domain);
-  }
+  if (type_enum == PT_TYPE_NUMERIC)
+    {
+      dt->info.data_type.precision = db_domain_precision (domain);
+      dt->info.data_type.dec_precision = db_domain_scale (domain);
+    }
+  else if (type_enum == PT_TYPE_CHAR || type_enum == PT_TYPE_VARCHAR)
+    {
+      dt->info.data_type.precision = db_domain_precision (domain);
+    }
 
   data_type->data_type = dt;
 
@@ -9504,7 +9507,7 @@ pt_check_create_stored_procedure (PARSER_CONTEXT * parser, PT_NODE * node)
 
       if (pt_is_type_supported_by_sp (parser, param->type_enum, param->data_type))
 	{
-	  assert (param->type_enum != PT_TYPE_NONE); // even if it was, it is updated in pt_is_type_supported_by_sp()
+	  assert (param->type_enum != PT_TYPE_NONE);	// even if it was, it is updated in pt_is_type_supported_by_sp()
 	}
       else
 	{
@@ -9534,7 +9537,7 @@ pt_check_create_stored_procedure (PARSER_CONTEXT * parser, PT_NODE * node)
 
       if (pt_is_type_supported_by_sp (parser, node->info.sp.ret_type, node->info.sp.ret_data_type))
 	{
-	  assert (node->info.sp.ret_type != PT_TYPE_NONE); // even if it was, it is updated in pt_is_type_supported_by_sp()
+	  assert (node->info.sp.ret_type != PT_TYPE_NONE);	// even if it was, it is updated in pt_is_type_supported_by_sp()
 	}
       else
 	{

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -3893,7 +3893,12 @@ pt_to_method_sig_list (PARSER_CONTEXT * parser, PT_NODE * node_list, PT_NODE * s
 
 			      if (db_get (arg_mop_p, SP_ATTR_DATA_TYPE, &arg_type) == NO_ERROR)
 				{
-				  (*tail)->arg_info.arg_type[i] = db_get_int (&arg_type);
+                                  int db_type;
+                                  const char *arg_type_str = db_get_string(&arg_type);
+                                  const int arg_type_str_len = db_get_string_size(&arg_type);
+                                  jsp_parse_data_type_str(&db_type, NULL, NULL, arg_type_str, arg_type_str_len);
+
+				  (*tail)->arg_info.arg_type[i] = db_type;
 				}
 
 			      pr_clear_value (&mode);
@@ -3916,7 +3921,12 @@ pt_to_method_sig_list (PARSER_CONTEXT * parser, PT_NODE * node_list, PT_NODE * s
 		  DB_VALUE result_type;
 		  if (db_get (mop_p, SP_ATTR_RETURN_TYPE, &result_type) == NO_ERROR)
 		    {
-		      (*tail)->arg_info.result_type = db_get_int (&result_type);
+                      int db_type;
+                      const char *res_type_str = db_get_string(&result_type);
+                      const int res_type_str_len = db_get_string_size(&result_type);
+                      jsp_parse_data_type_str(&db_type, NULL, NULL, res_type_str, res_type_str_len);
+
+		      (*tail)->arg_info.result_type = db_type;
 		      pr_clear_value (&result_type);
 		    }
 		  else

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -3893,10 +3893,10 @@ pt_to_method_sig_list (PARSER_CONTEXT * parser, PT_NODE * node_list, PT_NODE * s
 
 			      if (db_get (arg_mop_p, SP_ATTR_DATA_TYPE, &arg_type) == NO_ERROR)
 				{
-                                  int db_type;
-                                  const char *arg_type_str = db_get_string(&arg_type);
-                                  const int arg_type_str_len = db_get_string_size(&arg_type);
-                                  jsp_parse_data_type_str(&db_type, NULL, NULL, arg_type_str, arg_type_str_len);
+				  int db_type;
+				  const char *arg_type_str = db_get_string (&arg_type);
+				  const int arg_type_str_len = db_get_string_size (&arg_type);
+				  jsp_parse_data_type_str (&db_type, NULL, NULL, arg_type_str, arg_type_str_len);
 
 				  (*tail)->arg_info.arg_type[i] = db_type;
 				}
@@ -3921,10 +3921,10 @@ pt_to_method_sig_list (PARSER_CONTEXT * parser, PT_NODE * node_list, PT_NODE * s
 		  DB_VALUE result_type;
 		  if (db_get (mop_p, SP_ATTR_RETURN_TYPE, &result_type) == NO_ERROR)
 		    {
-                      int db_type;
-                      const char *res_type_str = db_get_string(&result_type);
-                      const int res_type_str_len = db_get_string_size(&result_type);
-                      jsp_parse_data_type_str(&db_type, NULL, NULL, res_type_str, res_type_str_len);
+		      int db_type;
+		      const char *res_type_str = db_get_string (&result_type);
+		      const int res_type_str_len = db_get_string_size (&result_type);
+		      jsp_parse_data_type_str (&db_type, NULL, NULL, res_type_str, res_type_str_len);
 
 		      (*tail)->arg_info.result_type = db_type;
 		      pr_clear_value (&result_type);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25219

- SP의 리턴 타입과 SP 인자 타입에 필요한 경우 precision, scale 정보를 저장하기 위한 변경 
  - 타입이 numeric 일 때, precision과 scale 저장
  - 타입이 char 또는 varchar 일 때 precision (문자열길이) 저장
  - 나머지 경우에는 변화 없음

- 구현
  - 시스템 테이블 컬럼 두 개 _db_stored_procedure.return_type 과 _db_stored_procedure_args.data_type 의 타입 변경 
    - INTEGER  --> VARCHAR(31)
    - 이 컬럼에 값을 읽고 쓰는 코드를 타입 변경에 맞게 수정 
  - 시맨틱 체크 과정 중 table.column%TYPE 모양의 타입 지정 검사 루틴에 precision과 scale 저장 과정 추가
  - _db_data_type 에 저장되는 타입 이름 중 STRING 을 VARCHAR 로 변경 - 
    - CTP SQL 테스트에서 80개 TC결과에 영향.
    - STRING 은 VARCHAR(1073741823) 를 의미하는 것으로 기존 표시 부적절
