### PR TITLE
[CBRD-25358] error handling when using for update clause for system tables such as db_root, dual, etc.

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -9180,7 +9180,6 @@ pt_resolve_names (PARSER_CONTEXT * parser, PT_NODE * statement, SEMANTIC_CHK_INF
       PT_NODE *node = statement->info.query.q.select.for_update;
       PT_NODE *spec = NULL;
       PT_NODE *entity;
-      DB_OBJECT *db;
 
       if (statement->info.query.q.select.for_update != NULL)
 	{
@@ -9197,8 +9196,8 @@ pt_resolve_names (PARSER_CONTEXT * parser, PT_NODE * statement, SEMANTIC_CHK_INF
 
 	      for (entity = spec->info.spec.flat_entity_list; entity; entity = entity->next)
 		{
-		  db = entity->info.name.db_object;
-		  if (db_is_system_class (db) && (db_check_authorization (db, DB_AUTH_UPDATE) != NO_ERROR))
+		  if (sm_check_system_class_by_name (entity->info.name.original)
+		      && (db_get_client_type () != DB_CLIENT_TYPE_ADMIN_CSQL))
 		    {
 		      PT_ERRORmf2 (parser, entity, MSGCAT_SET_PARSER_RUNTIME, MSGCAT_RUNTIME_IS_NOT_AUTHORIZED_ON,
 				   "UPDATE", entity->info.name.original);
@@ -9218,8 +9217,8 @@ pt_resolve_names (PARSER_CONTEXT * parser, PT_NODE * statement, SEMANTIC_CHK_INF
 	      spec->info.spec.flag = (PT_SPEC_FLAG) (spec->info.spec.flag | PT_SPEC_FLAG_FOR_UPDATE_CLAUSE);
 	      for (entity = spec->info.spec.flat_entity_list; entity; entity = entity->next)
 		{
-		  db = entity->info.name.db_object;
-		  if (db_is_system_class (db) && (db_check_authorization (db, DB_AUTH_UPDATE) != NO_ERROR))
+		  if (sm_check_system_class_by_name (entity->info.name.original)
+		      && (db_get_client_type () != DB_CLIENT_TYPE_ADMIN_CSQL))
 		    {
 		      PT_ERRORmf2 (parser, entity, MSGCAT_SET_PARSER_RUNTIME, MSGCAT_RUNTIME_IS_NOT_AUTHORIZED_ON,
 				   "UPDATE", entity->info.name.original);

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -9196,8 +9196,7 @@ pt_resolve_names (PARSER_CONTEXT * parser, PT_NODE * statement, SEMANTIC_CHK_INF
 
 	      for (entity = spec->info.spec.flat_entity_list; entity; entity = entity->next)
 		{
-		  if (sm_check_system_class_by_name (entity->info.name.original)
-		      && (db_get_client_type () != DB_CLIENT_TYPE_ADMIN_CSQL))
+		  if (sm_check_system_class_by_name (entity->info.name.original))
 		    {
 		      PT_ERRORmf2 (parser, entity, MSGCAT_SET_PARSER_RUNTIME, MSGCAT_RUNTIME_IS_NOT_AUTHORIZED_ON,
 				   "UPDATE", entity->info.name.original);
@@ -9217,8 +9216,7 @@ pt_resolve_names (PARSER_CONTEXT * parser, PT_NODE * statement, SEMANTIC_CHK_INF
 	      spec->info.spec.flag = (PT_SPEC_FLAG) (spec->info.spec.flag | PT_SPEC_FLAG_FOR_UPDATE_CLAUSE);
 	      for (entity = spec->info.spec.flat_entity_list; entity; entity = entity->next)
 		{
-		  if (sm_check_system_class_by_name (entity->info.name.original)
-		      && (db_get_client_type () != DB_CLIENT_TYPE_ADMIN_CSQL))
+		  if (sm_check_system_class_by_name (entity->info.name.original))
 		    {
 		      PT_ERRORmf2 (parser, entity, MSGCAT_SET_PARSER_RUNTIME, MSGCAT_RUNTIME_IS_NOT_AUTHORIZED_ON,
 				   "UPDATE", entity->info.name.original);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25358

db_root 및 db_attribute 처럼 시스템 테이블 / 뷰에 대해 "FOR UPDATE" 절을 사용할 때 오류가 발생하지 않습니다.  이에 대한 오류 처리가 필요합니다.

sysadm뿐만 아니라 dba포함 모든 사용자는 FOR UPDATE 구문에 시스템 테이블 / 뷰를 사용할 수 없도록 했습니다.

