### PR TITLE
[CBRD-25433] enable profile mode in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -534,7 +534,7 @@ function get_options ()
   esac
 
   case $build_mode in
-    release|debug|coverage);;
+    release|debug|coverage|profile);;
     *) show_usage; print_fatal "Mode [$build_mode] is not a valid mode" ;;
   esac
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25433

The current implementation of build.sh supports the -m option with the following modes: release, debug, and coverage. However, both build.sh and CMakeLists.txt are already prepared for profile mode. This oversight prevents developers from utilizing the profile mode, which is beneficial for performance profiling using tools like gperf.

To address this, we need to fix a single line in build.sh to enable the profile mode. This improvement will provide developers with the additional capability to use profile mode, enhancing their ability to perform detailed performance analysis.

### Changes
Update one line of build.sh to support the profile mode in the -m option.