### PR TITLE
[CBRD-25344] write SQL LOG ahead and then execute prepare

### DIFF
--- a/src/broker/cas.c
+++ b/src/broker/cas.c
@@ -505,6 +505,12 @@ main (int argc, char *argv[])
 #if !defined(WINDOWS)
   signal (SIGTERM, cas_sig_handler);
   signal (SIGINT, cas_sig_handler);
+  signal (SIGSEGV, cas_sig_handler);
+  signal (SIGABRT, cas_sig_handler);
+  signal (SIGFPE, cas_sig_handler);
+  signal (SIGILL, cas_sig_handler);
+  signal (SIGBUS, cas_sig_handler);
+  signal (SIGSYS, cas_sig_handler);
   signal (SIGUSR1, SIG_IGN);
   signal (SIGPIPE, SIG_IGN);
   signal (SIGXFSZ, SIG_IGN);

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -2441,7 +2441,6 @@ ux_execute_batch (int argc, void **argv, T_NET_BUF * net_buf, T_REQ_INFO * req_i
       session = db_open_buffer (sql_stmt);
       if (!session)
 	{
-	  cas_log_compile_end_write_query_string_nonl (sql_stmt, strlen (sql_stmt), NULL);
 	  cas_log_write2 ("");
 	  goto batch_error;
 	}

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -2435,19 +2435,20 @@ ux_execute_batch (int argc, void **argv, T_NET_BUF * net_buf, T_REQ_INFO * req_i
 
       net_arg_get_str (&sql_stmt, &sql_size, argv[query_index]);
       cas_log_write_nonl (0, false, "batch %d : ", query_index + 1);
+      cas_log_compile_begin_write_query_string_nonl (sql_stmt, strlen (sql_stmt), NULL);
 
       db_init_lexer_lineno ();
       session = db_open_buffer (sql_stmt);
       if (!session)
 	{
-	  cas_log_write_query_string_nonl (sql_stmt, strlen (sql_stmt), NULL);
+	  cas_log_compile_end_write_query_string_nonl (sql_stmt, strlen (sql_stmt), NULL);
 	  cas_log_write2 ("");
 	  goto batch_error;
 	}
       else
 	{
 	  assert (session->parser);
-	  cas_log_write_query_string_nonl (sql_stmt, strlen (sql_stmt), &session->parser->hide_pwd_info);
+	  cas_log_compile_end_write_query_string_nonl (sql_stmt, strlen (sql_stmt), &session->parser->hide_pwd_info);
 	}
 
       SQL_LOG2_COMPILE_BEGIN (as_info->cur_sql_log2, sql_stmt);

--- a/src/broker/cas_function.c
+++ b/src/broker/cas_function.c
@@ -416,10 +416,6 @@ fn_prepare_internal (SOCKET sock_fd, int argc, void **argv, T_NET_BUF * net_buf,
       PARSER_CONTEXT *psr = ((DB_SESSION *) srv_handle->session)->parser;
       cas_log_compile_end_write_query_string (sql_stmt, sql_size - 1, &psr->hide_pwd_info);
     }
-  else
-    {
-      cas_log_compile_end_write_query_string (sql_stmt, sql_size - 1, NULL);
-    }
 
   cas_log_write (query_seq_num_current_value (), false, "prepare srv_h_id %s%d%s%s", (srv_h_id < 0) ? "error:" : "",
 		 (srv_h_id < 0) ? err_info.err_number : srv_h_id, (srv_handle != NULL

--- a/src/broker/cas_function.c
+++ b/src/broker/cas_function.c
@@ -373,6 +373,8 @@ fn_prepare_internal (SOCKET sock_fd, int argc, void **argv, T_NET_BUF * net_buf,
 
 
   cas_log_write_nonl (query_seq_num_next_value (), false, "prepare %d ", flag);
+  cas_log_compile_begin_write_query_string (sql_stmt, sql_size - 1, NULL);
+
   SQL_LOG2_COMPILE_BEGIN (as_info->cur_sql_log2, ((const char *) sql_stmt));
 
   /* append query string to as_info->log_msg */
@@ -412,11 +414,11 @@ fn_prepare_internal (SOCKET sock_fd, int argc, void **argv, T_NET_BUF * net_buf,
     {
       assert (((DB_SESSION *) srv_handle->session)->parser);
       PARSER_CONTEXT *psr = ((DB_SESSION *) srv_handle->session)->parser;
-      cas_log_write_query_string (sql_stmt, sql_size - 1, &psr->hide_pwd_info);
+      cas_log_compile_end_write_query_string (sql_stmt, sql_size - 1, &psr->hide_pwd_info);
     }
   else
     {
-      cas_log_write_query_string (sql_stmt, sql_size - 1, NULL);
+      cas_log_compile_end_write_query_string (sql_stmt, sql_size - 1, NULL);
     }
 
   cas_log_write (query_seq_num_current_value (), false, "prepare srv_h_id %s%d%s%s", (srv_h_id < 0) ? "error:" : "",

--- a/src/broker/cas_log.c
+++ b/src/broker/cas_log.c
@@ -66,7 +66,7 @@ typedef int mode_t;
 #define SQL_LOG_BUFFER_SIZE 163840
 #define ACCESS_LOG_IS_DENIED_TYPE(T)  ((T)==ACL_REJECTED)
 
-#define CAS_LOG_NOT_HIDE_PW    0
+#define CAS_LOG_VISIBLE_PW     0
 #define CAS_LOG_HIDE_PW        1
 
 static const char *get_access_log_type_string (ACCESS_LOG_TYPE type);
@@ -710,7 +710,7 @@ cas_log_compile_begin_write_query_string (char *query, int size, HIDE_PWD_INFO_P
       saved_temp_stmt_fpos = cas_ftell (log_fp);
     }
 
-  cas_log_write_query_string_internal (query, size, true, hide_pwd_info_ptr, CAS_LOG_NOT_HIDE_PW);
+  cas_log_write_query_string_internal (query, size, true, hide_pwd_info_ptr, CAS_LOG_VISIBLE_PW);
 }
 
 void
@@ -744,7 +744,7 @@ cas_log_compile_begin_write_query_string_nonl (char *query, int size, HIDE_PWD_I
       saved_temp_stmt_fpos = cas_ftell (log_fp);
     }
 
-  cas_log_write_query_string_internal (query, size, false, hide_pwd_info_ptr, CAS_LOG_NOT_HIDE_PW);
+  cas_log_write_query_string_internal (query, size, false, hide_pwd_info_ptr, CAS_LOG_VISIBLE_PW);
 }
 
 void

--- a/src/broker/cas_log.c
+++ b/src/broker/cas_log.c
@@ -708,9 +708,8 @@ cas_log_compile_begin_write_query_string (char *query, int size, HIDE_PWD_INFO_P
   if (log_fp != NULL && query != NULL)
     {
       saved_temp_stmt_fpos = cas_ftell (log_fp);
+      cas_log_write_query_string_internal (query, size, true, hide_pwd_info_ptr, CAS_LOG_VISIBLE_PW);
     }
-
-  cas_log_write_query_string_internal (query, size, true, hide_pwd_info_ptr, CAS_LOG_VISIBLE_PW);
 }
 
 void
@@ -723,10 +722,13 @@ cas_log_compile_end_write_query_string (char *query, int size, HIDE_PWD_INFO_PTR
 
   if (log_fp != NULL && query != NULL)
     {
-      saved_temp_stmt_fpos = cas_fseek (log_fp, saved_temp_stmt_fpos, SEEK_SET);
+      /* If password exists in query */
+      if (hide_pwd_info_ptr != NULL && hide_pwd_info_ptr->used > 0)
+	{
+	  cas_fseek (log_fp, saved_temp_stmt_fpos, SEEK_SET);
+	  cas_log_write_query_string_internal (query, size, true, hide_pwd_info_ptr, CAS_LOG_HIDE_PW);
+	}
     }
-
-  cas_log_write_query_string_internal (query, size, true, hide_pwd_info_ptr, CAS_LOG_HIDE_PW);
 
   saved_temp_stmt_fpos = 0;
 }
@@ -742,9 +744,8 @@ cas_log_compile_begin_write_query_string_nonl (char *query, int size, HIDE_PWD_I
   if (log_fp != NULL && query != NULL)
     {
       saved_temp_stmt_fpos = cas_ftell (log_fp);
+      cas_log_write_query_string_internal (query, size, false, hide_pwd_info_ptr, CAS_LOG_VISIBLE_PW);
     }
-
-  cas_log_write_query_string_internal (query, size, false, hide_pwd_info_ptr, CAS_LOG_VISIBLE_PW);
 }
 
 void
@@ -757,10 +758,13 @@ cas_log_compile_end_write_query_string_nonl (char *query, int size, HIDE_PWD_INF
 
   if (log_fp != NULL && query != NULL)
     {
-      saved_temp_stmt_fpos = cas_fseek (log_fp, saved_temp_stmt_fpos, SEEK_SET);
+      /* If password exists in query */
+      if (hide_pwd_info_ptr != NULL && hide_pwd_info_ptr->used > 0)
+	{
+	  cas_fseek (log_fp, saved_temp_stmt_fpos, SEEK_SET);
+	  cas_log_write_query_string_internal (query, size, false, hide_pwd_info_ptr, CAS_LOG_HIDE_PW);
+	}
     }
-
-  cas_log_write_query_string_internal (query, size, false, hide_pwd_info_ptr, CAS_LOG_HIDE_PW);
 
   saved_temp_stmt_fpos = 0;
 }
@@ -787,7 +791,6 @@ static void
 cas_log_write_query_string_internal (char *query, int size, bool newline, HIDE_PWD_INFO_PTR hide_pwd_info_ptr,
 				     bool ishidepw)
 {
-
   if (log_fp == NULL && as_info->cur_sql_log_mode != SQL_LOG_MODE_NONE)
     {
       cas_log_open (shm_appl->broker_name);

--- a/src/broker/cas_log.c
+++ b/src/broker/cas_log.c
@@ -66,6 +66,9 @@ typedef int mode_t;
 #define SQL_LOG_BUFFER_SIZE 163840
 #define ACCESS_LOG_IS_DENIED_TYPE(T)  ((T)==ACL_REJECTED)
 
+#define CAS_LOG_NOT_HIDE_PW    0
+#define CAS_LOG_HIDE_PW        1
+
 static const char *get_access_log_type_string (ACCESS_LOG_TYPE type);
 static char cas_log_buffer[CAS_LOG_BUFFER_SIZE];	/* 8K buffer */
 static char sql_log_buffer[SQL_LOG_BUFFER_SIZE];
@@ -86,7 +89,7 @@ static FILE *access_log_open (char *log_file_name);
 static bool cas_log_begin_hang_check_time (void);
 static void cas_log_end_hang_check_time (bool is_prev_time_set);
 static void cas_log_write_query_string_internal (char *query, int size, bool newline,
-						 HIDE_PWD_INFO_PTR hide_pwd_info_ptr);
+						 HIDE_PWD_INFO_PTR hide_pwd_info_ptr, bool ishidepw);
 
 #ifdef CAS_ERROR_LOG
 static int error_file_offset;
@@ -114,6 +117,8 @@ static int cas_unlink (const char *pathname);
 static int cas_rename (const char *oldpath, const char *newpath);
 static int cas_mkdir (const char *pathname, mode_t mode);
 static void access_log_backup (char *access_log_file, struct tm *ct);
+
+static INT64 saved_temp_stmt_fpos = 0;
 
 static char *
 make_sql_log_filename (T_CUBRID_FILE_ID fid, char *filename_buf, size_t buf_size, const char *br_name)
@@ -693,15 +698,83 @@ cas_log_write_value_string (char *value, int size)
 }
 
 void
+cas_log_compile_begin_write_query_string (char *query, int size, HIDE_PWD_INFO_PTR hide_pwd_info_ptr)
+{
+  if (log_fp == NULL && as_info->cur_sql_log_mode != SQL_LOG_MODE_NONE)
+    {
+      cas_log_open (shm_appl->broker_name);
+    }
+
+  if (log_fp != NULL && query != NULL)
+    {
+      saved_temp_stmt_fpos = cas_ftell (log_fp);
+    }
+
+  cas_log_write_query_string_internal (query, size, true, hide_pwd_info_ptr, CAS_LOG_NOT_HIDE_PW);
+}
+
+void
+cas_log_compile_end_write_query_string (char *query, int size, HIDE_PWD_INFO_PTR hide_pwd_info_ptr)
+{
+  if (log_fp == NULL && as_info->cur_sql_log_mode != SQL_LOG_MODE_NONE)
+    {
+      cas_log_open (shm_appl->broker_name);
+    }
+
+  if (log_fp != NULL && query != NULL)
+    {
+      saved_temp_stmt_fpos = cas_fseek (log_fp, saved_temp_stmt_fpos, SEEK_SET);
+    }
+
+  cas_log_write_query_string_internal (query, size, true, hide_pwd_info_ptr, CAS_LOG_HIDE_PW);
+
+  saved_temp_stmt_fpos = 0;
+}
+
+void
+cas_log_compile_begin_write_query_string_nonl (char *query, int size, HIDE_PWD_INFO_PTR hide_pwd_info_ptr)
+{
+  if (log_fp == NULL && as_info->cur_sql_log_mode != SQL_LOG_MODE_NONE)
+    {
+      cas_log_open (shm_appl->broker_name);
+    }
+
+  if (log_fp != NULL && query != NULL)
+    {
+      saved_temp_stmt_fpos = cas_ftell (log_fp);
+    }
+
+  cas_log_write_query_string_internal (query, size, false, hide_pwd_info_ptr, CAS_LOG_NOT_HIDE_PW);
+}
+
+void
+cas_log_compile_end_write_query_string_nonl (char *query, int size, HIDE_PWD_INFO_PTR hide_pwd_info_ptr)
+{
+  if (log_fp == NULL && as_info->cur_sql_log_mode != SQL_LOG_MODE_NONE)
+    {
+      cas_log_open (shm_appl->broker_name);
+    }
+
+  if (log_fp != NULL && query != NULL)
+    {
+      saved_temp_stmt_fpos = cas_fseek (log_fp, saved_temp_stmt_fpos, SEEK_SET);
+    }
+
+  cas_log_write_query_string_internal (query, size, false, hide_pwd_info_ptr, CAS_LOG_HIDE_PW);
+
+  saved_temp_stmt_fpos = 0;
+}
+
+void
 cas_log_write_query_string_nonl (char *query, int size, HIDE_PWD_INFO_PTR hide_pwd_info_ptr)
 {
-  cas_log_write_query_string_internal (query, size, false, hide_pwd_info_ptr);
+  cas_log_write_query_string_internal (query, size, false, hide_pwd_info_ptr, CAS_LOG_HIDE_PW);
 }
 
 void
 cas_log_write_query_string (char *query, int size, HIDE_PWD_INFO_PTR hide_pwd_info_ptr)
 {
-  cas_log_write_query_string_internal (query, size, true, hide_pwd_info_ptr);
+  cas_log_write_query_string_internal (query, size, true, hide_pwd_info_ptr, CAS_LOG_HIDE_PW);
 }
 
 static void
@@ -711,7 +784,8 @@ cas_fprintf_password (FILE * fp, char *query, HIDE_PWD_INFO_PTR hide_pwd_info_pt
 }
 
 static void
-cas_log_write_query_string_internal (char *query, int size, bool newline, HIDE_PWD_INFO_PTR hide_pwd_info_ptr)
+cas_log_write_query_string_internal (char *query, int size, bool newline, HIDE_PWD_INFO_PTR hide_pwd_info_ptr,
+				     bool ishidepw)
 {
 
   if (log_fp == NULL && as_info->cur_sql_log_mode != SQL_LOG_MODE_NONE)
@@ -721,7 +795,27 @@ cas_log_write_query_string_internal (char *query, int size, bool newline, HIDE_P
 
   if (log_fp != NULL && query != NULL)
     {
-      cas_fprintf_password (log_fp, query, hide_pwd_info_ptr);
+      if (ishidepw == CAS_LOG_HIDE_PW)
+	{
+	  cas_fprintf_password (log_fp, query, hide_pwd_info_ptr);
+	}
+      else
+	{
+	  char *s;
+
+	  for (s = query; *s; s++)
+	    {
+	      if (*s == '\n' || *s == '\r')
+		{
+		  cas_fputc (' ', log_fp);
+		}
+	      else
+		{
+		  cas_fputc (*s, log_fp);
+		}
+	    }
+	}
+
       if (newline)
 	{
 	  fputc ('\n', log_fp);

--- a/src/broker/cas_log.h
+++ b/src/broker/cas_log.h
@@ -64,7 +64,10 @@ extern void cas_log_write_client_ip (const unsigned char *ip_addr);
 extern void cas_log_write_query_string_nonl (char *query, int size, HIDE_PWD_INFO_PTR hide_pwd_info_ptr);
 extern void cas_log_open_and_write (char *br_name, unsigned int seq_num, bool unit_start, const char *fmt, ...);
 extern CAS_LOG_FD_STATUS cas_log_get_fd_status (void);
-
+extern void cas_log_compile_begin_write_query_string (char *query, int size, HIDE_PWD_INFO_PTR hide_pwd_info_ptr);
+extern void cas_log_compile_end_write_query_string (char *query, int size, HIDE_PWD_INFO_PTR hide_pwd_info_ptr);
+extern void cas_log_compile_begin_write_query_string_nonl (char *query, int size, HIDE_PWD_INFO_PTR hide_pwd_info_ptr);
+extern void cas_log_compile_end_write_query_string_nonl (char *query, int size, HIDE_PWD_INFO_PTR hide_pwd_info_ptr);
 
 #define ARG_FILE_LINE   __FILE__, __LINE__
 #if defined (NDEBUG)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25344

Purpose
Currently, the query is recorded in the log after executing the query. However, there is a problem that the query is not recorded in the log when a core dump occurs while executing the query.
we decided to record the query in the log before executing (prepare) the query.

Implementation
N/A

Remarks
N/A