### PR TITLE
[CBRD-25337] Fixed an issue where dbname could not be read when an error occurred in loaddb.

### DIFF
--- a/src/base/ddl_log.c
+++ b/src/base/ddl_log.c
@@ -807,7 +807,14 @@ logddl_write ()
     }
 
   user_name = db_get_user_name ();
-  logddl_set_user_name (user_name);
+  if (user_name)
+    {
+      logddl_set_user_name (user_name);
+    }
+  else
+    {
+      logddl_set_user_name ("unknown");
+    }
 
   fp = logddl_open (ddl_audit_handle.app_name);
 
@@ -886,7 +893,14 @@ logddl_write_tran_str (const char *fmt, ...)
     }
 
   user_name = db_get_user_name ();
-  logddl_set_user_name (user_name);
+  if (user_name)
+    {
+      logddl_set_user_name (user_name);
+    }
+  else
+    {
+      logddl_set_user_name ("unknown");
+    }
 
   fp = logddl_open (ddl_audit_handle.app_name);
 
@@ -1009,7 +1023,14 @@ logddl_write_end_for_csql_fileinput (const char *fmt, ...)
     }
 
   user_name = db_get_user_name ();
-  logddl_set_user_name (user_name);
+  if (user_name)
+    {
+      logddl_set_user_name (user_name);
+    }
+  else
+    {
+      logddl_set_user_name ("unknown");
+    }
 
   fp = logddl_open (ddl_audit_handle.app_name);
 

--- a/src/base/ddl_log.c
+++ b/src/base/ddl_log.c
@@ -803,7 +803,7 @@ logddl_write ()
     }
   else
     {
-      logddl_set_db_name ("");
+      logddl_set_db_name ("unknown");
     }
 
   user_name = db_get_user_name ();
@@ -882,7 +882,7 @@ logddl_write_tran_str (const char *fmt, ...)
     }
   else
     {
-      logddl_set_db_name ("");
+      logddl_set_db_name ("unknown");
     }
 
   user_name = db_get_user_name ();
@@ -1005,7 +1005,7 @@ logddl_write_end_for_csql_fileinput (const char *fmt, ...)
     }
   else
     {
-      logddl_set_db_name ("");
+      logddl_set_db_name ("unknown");
     }
 
   user_name = db_get_user_name ();

--- a/src/base/ddl_log.c
+++ b/src/base/ddl_log.c
@@ -797,7 +797,14 @@ logddl_write ()
     }
 
   dbname = db_get_database_name ();
-  logddl_set_db_name (dbname);
+  if (dbname)
+    {
+      logddl_set_db_name (dbname);
+    }
+  else
+    {
+      logddl_set_db_name ("");
+    }
 
   user_name = db_get_user_name ();
   logddl_set_user_name (user_name);
@@ -869,7 +876,14 @@ logddl_write_tran_str (const char *fmt, ...)
     }
 
   dbname = db_get_database_name ();
-  logddl_set_db_name (dbname);
+  if (dbname)
+    {
+      logddl_set_db_name (dbname);
+    }
+  else
+    {
+      logddl_set_db_name ("");
+    }
 
   user_name = db_get_user_name ();
   logddl_set_user_name (user_name);
@@ -985,7 +999,14 @@ logddl_write_end_for_csql_fileinput (const char *fmt, ...)
     }
 
   dbname = db_get_database_name ();
-  logddl_set_db_name (dbname);
+  if (dbname)
+    {
+      logddl_set_db_name (dbname);
+    }
+  else
+    {
+      logddl_set_db_name ("");
+    }
 
   user_name = db_get_user_name ();
   logddl_set_user_name (user_name);

--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -742,7 +742,6 @@ loaddb_internal (UTIL_FUNCTION_ARG * arg, int dba_mode)
       util_log_write_errstr ("%s\n", db_error_string (3));
       status = 3;
       db_end_session ();
-      db_shutdown ();
       goto error_return;
     }
 
@@ -815,7 +814,6 @@ loaddb_internal (UTIL_FUNCTION_ARG * arg, int dba_mode)
 	{
 	  // failed
 	  db_end_session ();
-	  db_shutdown ();
 	  goto error_return;
 	}
     }
@@ -833,7 +831,6 @@ loaddb_internal (UTIL_FUNCTION_ARG * arg, int dba_mode)
 	  util_log_write_errstr (msg_format);
 	  status = 3;
 	  db_end_session ();
-	  db_shutdown ();
 	  print_log_msg (1, " done.\n\nRestart loaddb with '-%c %s:%d' option\n", LOAD_INDEX_FILE_S,
 			 args.index_file.c_str (), index_file_start_line);
 	  logddl_write_end ();
@@ -868,7 +865,6 @@ loaddb_internal (UTIL_FUNCTION_ARG * arg, int dba_mode)
 	  util_log_write_errstr (msg_format);
 	  status = 3;
 	  db_end_session ();
-	  db_shutdown ();
 	  print_log_msg (1, " done.\n\nRestart loaddb with '--%s %s:%d' option\n", LOAD_TRIGGER_FILE_L,
 			 args.trigger_file.c_str (), trigger_file_start_line);
 	  logddl_write_end ();
@@ -922,6 +918,7 @@ error_return:
     }
 
   logddl_destroy ();
+  db_shutdown ();
   return status;
 }
 
@@ -1604,7 +1601,6 @@ ldr_load_schema_file (FILE * schema_fp, int schema_file_start_line, load_args ar
       util_log_write_errstr (msg_format);
       status = 3;
       db_end_session ();
-      db_shutdown ();
       print_log_msg (1, " done.\n\nRestart loaddb with '-%c %s:%d' option\n", LOAD_SCHEMA_FILE_S,
 		     args.schema_file.c_str (), schema_file_start_line);
       logddl_write_end ();
@@ -1631,7 +1627,6 @@ ldr_load_schema_file (FILE * schema_fp, int schema_file_start_line, load_args ar
 	{
 	  status = 3;
 	  db_end_session ();
-	  db_shutdown ();
 	  print_log_msg (1, "\nAborting current transaction...\n");
 	  return status;
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25337

Purpose
ddl logger sets db name and various information before recording logs.
An issue occurred where loaddb crashes if the db name is NULL when an error occurs in loaddb.
Modified to shutdown db when loaddb is terminated.

Implementation
N/A

Remarks
N/A