### PR TITLE
[CBRD-24871] Slip: error message of ER_SP_INVOKERS_RIGHTS_NOT_SUPPORTED is omitted

### DIFF
--- a/msg/en_US/cubrid.msg
+++ b/msg/en_US/cubrid.msg
@@ -1447,8 +1447,9 @@ Check the path of the key file (_keys) and make sure that it includes proper key
 1359 Java VM crashed: %1$s
 1360 In line %1$d, column %2$d\nStored procedure compile error: %3$s
 1361 Dropping system generated stored procedure is not allowed.
+1362 PL/CSQL Stored procedure/function does not support Invoker's rights
 
-1362 Last Error
+1363 Last Error
 
 $set 6 MSGCAT_SET_INTERNAL
 1 Error in error subsystem (line %1$d):

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -3097,8 +3097,8 @@ create_stmt
                         expecting_pl_lang_spec = 1;
 		}
 	  identifier opt_sp_param_list	                /* 5, 6 */
-          opt_authid                                    /* 7 */
-	  RETURN sp_return_type		                /* 8, 9 */
+	  RETURN sp_return_type		                /* 7, 8 */
+          opt_authid                                    /* 9 */
 	  is_or_as pl_language_spec		        /* 10, 11 */
 	  opt_comment_spec				/* 12 */
 		{ pop_msg(); }
@@ -3109,10 +3109,10 @@ create_stmt
 			    node->info.sp.or_replace = $2;
 			    node->info.sp.name = $5;
 			    node->info.sp.type = PT_SP_FUNCTION;
-                            node->info.sp.auth_id = $7;
+                            node->info.sp.auth_id = $9;
 			    node->info.sp.param_list = $6;
-			    node->info.sp.ret_type = (int) TO_NUMBER(CONTAINER_AT_0($9));
-			    node->info.sp.ret_data_type = CONTAINER_AT_1($9);
+			    node->info.sp.ret_type = (int) TO_NUMBER(CONTAINER_AT_0($8));
+			    node->info.sp.ret_data_type = CONTAINER_AT_1($8);
 			    node->info.sp.body = $11;
 			    node->info.sp.comment = $12;
 			  }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24871

In en_US/cubrid.msg, error message of ER_SP_INVOKERS_RIGHTS_NOT_SUPPORTED is omitted.