### PR TITLE
[CBRD-25395] whether the result-cache is referenced must be indicated…

### DIFF
--- a/src/query/query_dump.c
+++ b/src/query/query_dump.c
@@ -3296,7 +3296,7 @@ qdump_print_stats_text (FILE * fp, xasl_node * xasl_p, int indent)
 
   if (xasl_p->sub_xasl_id && xasl_p->sub_cache_ref_count > 0)
     {
-      fprintf (fp, "%*cRESULT CACHE (reference count : %d)\n", indent, ' ', xasl_p->sub_cache_ref_count);
+      fprintf (fp, "%*cRESULT CACHE (reference count: %d)\n", indent, ' ', xasl_p->sub_cache_ref_count);
     }
   else
     {

--- a/src/query/query_dump.c
+++ b/src/query/query_dump.c
@@ -3294,8 +3294,15 @@ qdump_print_stats_text (FILE * fp, xasl_node * xasl_p, int indent)
       break;
     }
 
-  qdump_print_access_spec_stats_text (fp, xasl_p->spec_list, indent);
-  qdump_print_access_spec_stats_text (fp, xasl_p->merge_spec, indent);
+  if (xasl_p->sub_xasl_id && xasl_p->sub_cache_ref_count > 0)
+    {
+      fprintf (fp, "%*cRESULT CACHE (reference count : %d)\n", indent, ' ', xasl_p->sub_cache_ref_count);
+    }
+  else
+    {
+      qdump_print_access_spec_stats_text (fp, xasl_p->spec_list, indent);
+      qdump_print_access_spec_stats_text (fp, xasl_p->merge_spec, indent);
+    }
 
   qdump_print_stats_text (fp, xasl_p->scan_ptr, indent);
   qdump_print_stats_text (fp, xasl_p->connect_by_ptr, indent);

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -25484,6 +25484,7 @@ qexec_execute_subquery_for_result_cache (THREAD_ENTRY * thread_p, XASL_NODE * xa
       if (cached_result && list_cache_entry_p)
 	{
 	  list_id = &list_cache_entry_p->list_id;
+	  xasl->sub_cache_ref_count = list_cache_entry_p->ref_count;
 	}
 
       if (host_var_count > 0)

--- a/src/query/xasl.h
+++ b/src/query/xasl.h
@@ -1060,6 +1060,7 @@ struct xasl_node
   XASL_ID *sub_xasl_id;		/* for cached subquery */
   int sub_host_var_count;	/* for subquery's host variable count */
   int *sub_host_var_index;	/* for subquery's host variable index */
+  int sub_cache_ref_count;	/* for subquery's result-cache ref. count */
 
 #if defined (ENABLE_COMPOSITE_LOCK)
   /* note: upon reactivation, you may face header cross reference issues */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25395
Displays the reference count in trace information for queries (including subqueries) that refer to the result-cache.

Result Cache가 적용된 경우 아래와 같이 SCAN 대신 RESULT CACHE 형식으로  TRACE 출력을 합니다.

```
Trace Statistics:
  SELECT (time: 23, fetch: 156, fetch_time: 0, ioread: 32)
    SCAN (table: public.game), (heap time: 17, fetch: 124, ioread: 31, readrows: 8653, rows: 5676)
      SCAN (hash temp(m), build time: 0, time: 2, fetch: 0, ioread: 0, readrows: 359, rows: 340)
      UNION (time: 0, fetch: 8, fetch_time: 0, ioread: 0)
        SELECT (time: 0, fetch: 0, fetch_time: 0, ioread: 0)
          RESULT CACHE (reference count : 1)
        SELECT (time: 0, fetch: 0, fetch_time: 0, ioread: 0)
          RESULT CACHE (reference count : 1)

```