### PR TITLE
[CBRD-25420] fix regression: PL 루틴에서 설정된 에러를 메인 질의에서 잘못 처리

### DIFF
--- a/src/sp/jsp_cl.c
+++ b/src/sp/jsp_cl.c
@@ -471,8 +471,6 @@ jsp_call_stored_procedure (PARSER_CONTEXT * parser, PT_NODE * statement)
 	  error = method_invoke_fold_constants (sig_list, args, ret_value);
 	}
       sig_list.freemem ();
-
-      error = er_errid ();
     }
 
   if (error == NO_ERROR)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25420

PL에서 메인 질의와 PL에서 수행하는 질의는 동일한 CAS를 공유하며, PL에서 수행하는 질의에 의해 에러 메시지가 설정될 수 있습니다. 그러나 PL에서 수행하는 질의에 의해 설정된 CAS 에러 코드는 무시되어야 하며 PL의 에러 처리에 의해 전달 받은 에러 코드와 에러 메시지를 덮어 (overwrite) 하여 사용되어야 합니다.

정리하면 CAS에서 PL을 위해 별도의 에러 매니저를 사용하기 보다, PL을 호출한 후 서버에서 전달받은 에러 코드만을 처리하여 다시 에러 매니저의 에러가 제대로 설정되므로, 잘못 들어간 `error = er_errid()`를 제거해야합니다.
쉬운 이해를 위해 다음의 구조를 참고합니다.
```
메인 질의 ->
          PL이 호출한 질의 1
          PL이 호출한 질의 2
           ....
```