### PR TITLE
[CBRD-24531] Fix regression: revert removed code in merging

### DIFF
--- a/src/method/method_def.cpp
+++ b/src/method/method_def.cpp
@@ -49,10 +49,13 @@ method_sig_node::method_sig_node (method_sig_node &&obj)
   method_arg_pos = obj.method_arg_pos;
   num_method_args = obj.num_method_args;
   result_type = obj.result_type;
+  oid = obj.oid;
 
   obj.method_name = nullptr;
   obj.auth_name = nullptr;
   obj.method_arg_pos = nullptr;
+  obj.oid = OID_INITIALIZER;
+
 
   if (obj.class_name != nullptr)
     {
@@ -103,6 +106,7 @@ method_sig_node::method_sig_node (const method_sig_node &obj)
 
   method_type = obj.method_type;
   num_method_args = obj.num_method_args;
+  oid = obj.oid;
 
   if (obj.num_method_args > 0)
     {
@@ -271,7 +275,7 @@ method_sig_node::get_packed_size (cubpacking::packer &serializator, std::size_t 
 	}
     }
 
-  size += serializator.get_packed_oid_size (size); /* method_sig->arg_info->arg_type[i] */
+  size += serializator.get_packed_oid_size (size); /* OID */
 
   return size;
 }

--- a/src/method/method_invoke_java.cpp
+++ b/src/method/method_invoke_java.cpp
@@ -772,7 +772,7 @@ namespace cubmethod
     db_make_null (&res);
     unpacker.unpack_all (attr_name);
 
-    if (OID_ISNULL (&m_method_sig->oid) || m_method_sig->oid.pageid == -1)
+    if (OID_ISNULL (&m_method_sig->oid))
       {
 	error = ER_FAILED;
       }

--- a/src/method/method_invoke_java.cpp
+++ b/src/method/method_invoke_java.cpp
@@ -772,7 +772,7 @@ namespace cubmethod
     db_make_null (&res);
     unpacker.unpack_all (attr_name);
 
-    if (OID_ISNULL (&m_method_sig->oid))
+    if (OID_ISNULL (&m_method_sig->oid) || m_method_sig->oid.pageid == -1)
       {
 	error = ER_FAILED;
       }

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -3998,7 +3998,33 @@ pt_to_method_sig_list (PARSER_CONTEXT * parser, PT_NODE * node_list, PT_NODE * s
 		      break;
 		    }
 
-		  (*tail)->oid = *WS_OID (mop_p);
+		  /* OID */
+		  DB_VALUE target_val;
+		  if (db_get (mop_p, SP_ATTR_TARGET, &target_val) == NO_ERROR)
+		    {
+		      const char *target_c = db_get_string (&target_val);
+		      MOP code_mop = NULL;
+		      if (target_c != NULL)
+			{
+			  std::string target (target_c);
+			  std::string cls_name = jsp_get_class_name_of_target (target);
+			  code_mop = jsp_find_stored_procedure_code (cls_name.c_str ());
+			}
+		      pr_clear_value (&target_val);
+
+		      if (code_mop)
+			{
+			  (*tail)->oid = *WS_OID (code_mop);
+			}
+		      else
+			{
+			  (*tail)->oid = OID_INITIALIZER;
+			}
+		    }
+		  else
+		    {
+		      break;
+		    }
 		}
 	      else
 		{

--- a/src/query/stream_to_xasl.c
+++ b/src/query/stream_to_xasl.c
@@ -2612,6 +2612,8 @@ stx_build_method_sig (THREAD_ENTRY * thread_p, char *ptr, METHOD_SIG * method_si
 /* is can be null */
   method_sig->class_name = stx_restore_string (thread_p, ptr);
 
+  ptr = or_unpack_oid (ptr, &method_sig->oid);
+
   ptr = or_unpack_int (ptr, &offset);
   if (offset == 0)
     {

--- a/src/query/xasl_to_stream.c
+++ b/src/query/xasl_to_stream.c
@@ -5863,6 +5863,8 @@ xts_process_method_sig (char *ptr, const METHOD_SIG * method_sig, int count)
     }
   ptr = or_pack_int (ptr, offset);
 
+  ptr = or_pack_oid (ptr, &method_sig->oid);
+
   offset = xts_save_method_arg_info (method_sig->arg_info, method_sig->num_method_args);
   if (offset == ER_FAILED)
     {

--- a/src/sp/jsp_cl.h
+++ b/src/sp/jsp_cl.h
@@ -59,4 +59,10 @@ extern void jsp_set_prepare_call (void);
 extern void jsp_unset_prepare_call (void);
 extern bool jsp_is_prepare_call (void);
 
+#ifdef  __cplusplus
+extern
+  std::string
+jsp_get_class_name_of_target (const std::string & target);
+#endif
+
 #endif /* _JSP_CL_H_ */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24531

At https://github.com/CUBRID/cubrid/pull/5274, serveral code setting OID corresponding to a row of _db_stored_procedure_code is removed while merging with upstream branch.