### PR TITLE
[CBRD-25450] 서버측에서 AUTHID 변경 동작에 대한 버그 수정

### DIFF
--- a/src/method/method_invoke.hpp
+++ b/src/method/method_invoke.hpp
@@ -123,6 +123,26 @@ namespace cubmethod
 
       void erase_query_cursor (const std::uint64_t query_id);
 
+      // TODO: refactoring
+      // When removing method transformation in the other issue (CBRD-25416), the following function will be moved to proper place
+      template <typename ... Args>
+      int send_data_to_client (cubthread::entry *thread_p, Args &&... args)
+      {
+	int error_code = NO_ERROR;
+	auto dummy = [&] (const cubmem::block & b)
+	{
+	  return NO_ERROR;
+	};
+
+	error_code = method_send_data_to_client (thread_p, m_client_header, std::forward<Args> (args)...);
+	if (error_code != NO_ERROR)
+	  {
+	    return error_code;
+	  }
+
+	return xs_receive (thread_p, dummy);
+      }
+
       const cubmethod::header &get_next_java_header (cubmethod::header &header);
 
       cubmethod::header m_client_header; // header sending to cubridcs

--- a/src/method/method_invoke_java.cpp
+++ b/src/method/method_invoke_java.cpp
@@ -78,14 +78,7 @@ namespace cubmethod
       return NO_ERROR;
     };
 
-    error = method_send_data_to_client (thread_p, m_client_header, METHOD_CALLBACK_CHANGE_RIGHTS, 0,
-					m_method_sig->auth_name);
-    if (error != NO_ERROR)
-      {
-	return error;
-      }
-
-    error = xs_receive (thread_p, dummy);
+    error = send_data_to_client (thread_p, METHOD_CALLBACK_CHANGE_RIGHTS, 0, std::string (m_method_sig->auth_name));
     if (error != NO_ERROR)
       {
 	return error;
@@ -95,19 +88,6 @@ namespace cubmethod
     cubmethod::invoke_java arg (m_group->get_id (), m_group->get_tran_id (), m_method_sig, m_transaction_control);
 
     error = mcon_send_data_to_java (m_group->get_socket (), header, arg);
-
-    error = method_send_data_to_client (thread_p, m_client_header, METHOD_CALLBACK_CHANGE_RIGHTS, 1, std::string (""));
-    if (error != NO_ERROR)
-      {
-	return error;
-      }
-
-    error = xs_receive (thread_p, dummy);
-    if (error != NO_ERROR)
-      {
-	return error;
-      }
-
     return error;
   }
 
@@ -186,6 +166,8 @@ namespace cubmethod
 	  }
       }
     while (error_code == NO_ERROR && start_code == SP_CODE_INTERNAL_JDBC);
+
+    error_code = send_data_to_client (thread_p, METHOD_CALLBACK_CHANGE_RIGHTS, 1, std::string (""));
 
     return error_code;
   }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25450

METHOD_CALLBACK_CHANGE_RIGHTS 프로토콜은 invoke 함수 전, 그리고 get_return 함수 이후에 호출되어야 정상적으로 유저 권한 스택이 관리가 됩니다.

AS-IS: invoke 함수 전후로 호출
TO-BE: invoke 함수 전, get_return 함수 이후에 호출