### PR TITLE
[CBRD-25344] Fixed an issue where passwords were showing up in the log

### DIFF
--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -2441,6 +2441,7 @@ ux_execute_batch (int argc, void **argv, T_NET_BUF * net_buf, T_REQ_INFO * req_i
       session = db_open_buffer (sql_stmt);
       if (!session)
 	{
+	  cas_log_compile_end_write_query_string_nonl (sql_stmt, strlen (sql_stmt), NULL);
 	  cas_log_write2 ("");
 	  goto batch_error;
 	}

--- a/src/broker/cas_function.c
+++ b/src/broker/cas_function.c
@@ -416,6 +416,10 @@ fn_prepare_internal (SOCKET sock_fd, int argc, void **argv, T_NET_BUF * net_buf,
       PARSER_CONTEXT *psr = ((DB_SESSION *) srv_handle->session)->parser;
       cas_log_compile_end_write_query_string (sql_stmt, sql_size - 1, &psr->hide_pwd_info);
     }
+  else
+    {
+      cas_log_compile_end_write_query_string (sql_stmt, sql_size - 1, NULL);
+    }
 
   cas_log_write (query_seq_num_current_value (), false, "prepare srv_h_id %s%d%s%s", (srv_h_id < 0) ? "error:" : "",
 		 (srv_h_id < 0) ? err_info.err_number : srv_h_id, (srv_handle != NULL

--- a/src/broker/cas_log.c
+++ b/src/broker/cas_log.c
@@ -722,8 +722,8 @@ cas_log_compile_end_write_query_string (char *query, int size, HIDE_PWD_INFO_PTR
 
   if (log_fp != NULL && query != NULL)
     {
-      /* If password exists in query */
-      if (hide_pwd_info_ptr != NULL && hide_pwd_info_ptr->used > 0)
+      /* If the password information does not exist or the password exists in the query */
+      if (hide_pwd_info_ptr == NULL || (hide_pwd_info_ptr != NULL && hide_pwd_info_ptr->used > 0))
 	{
 	  cas_fseek (log_fp, saved_temp_stmt_fpos, SEEK_SET);
 	  cas_log_write_query_string_internal (query, size, true, hide_pwd_info_ptr, CAS_LOG_HIDE_PW);
@@ -758,8 +758,8 @@ cas_log_compile_end_write_query_string_nonl (char *query, int size, HIDE_PWD_INF
 
   if (log_fp != NULL && query != NULL)
     {
-      /* If password exists in query */
-      if (hide_pwd_info_ptr != NULL && hide_pwd_info_ptr->used > 0)
+      /* If the password information does not exist or the password exists in the query */
+      if (hide_pwd_info_ptr == NULL || (hide_pwd_info_ptr != NULL && hide_pwd_info_ptr->used > 0))
 	{
 	  cas_fseek (log_fp, saved_temp_stmt_fpos, SEEK_SET);
 	  cas_log_write_query_string_internal (query, size, false, hide_pwd_info_ptr, CAS_LOG_HIDE_PW);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25344

Purpose
There is an issue where the password is written to the Log file when prepare or parser generation fails.

Implementation
N/A

Remarks
N/A
