### PR TITLE
[CBRD-25452] Creating temporary files using CUBRID_TMP Env

### DIFF
--- a/broker/CMakeLists.txt
+++ b/broker/CMakeLists.txt
@@ -524,6 +524,7 @@ if(WITH_CCI)
     ${BROKER_DIR}/broker_log_replay.c
     ${BROKER_DIR}/broker_log_util.c
     ${BROKER_DIR}/log_top_string.c
+    ${BASE_DIR}/filesys_temp.cpp
     )
   SET_SOURCE_FILES_PROPERTIES(
       ${CUBRID_REPLAY_SOURCES}

--- a/contrib/windows_scripts/cubrid_env.bat
+++ b/contrib/windows_scripts/cubrid_env.bat
@@ -25,6 +25,7 @@ echo Setting CUBRID Environments
 
 set CUBRID=C:\CUBRID
 set CUBRID_DATABASES=%CUBRID%\databases
+set CUBRID_TMP=%CUBRID%\tmp
 
 reg add "HKEY_LOCAL_MACHINE\SOFTWARE\CUBRID\cmserver" /v "ROOT_PATH" /t REG_SZ /d "%CUBRID%\\" /f
 reg add "HKEY_LOCAL_MACHINE\SOFTWARE\CUBRID\cmserver" /v "Version" /t REG_SZ /d "11.0" /f
@@ -34,6 +35,7 @@ reg add "HKEY_LOCAL_MACHINE\SOFTWARE\CUBRID\CUBRID" /v "Patch" /t REG_SZ /d "0" 
 
 reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /v "CUBRID" /t REG_SZ /d "%CUBRID%\\" /f
 reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /v "CUBRID_DATABASES" /t REG_SZ /d "%CUBRID_DATABASES%" /f
+reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /v "CUBRID_TMP" /t REG_SZ /d "%CUBRID_TMP%" /f
 reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /v "Path" /t REG_SZ /d "%CUBRID%\cci\bin;%CUBRID%\bin;%PATH%" /f
 
 echo %CUBRID%

--- a/src/base/filesys_temp.cpp
+++ b/src/base/filesys_temp.cpp
@@ -34,7 +34,7 @@
 
 #include "environment_variable.h"
 
-#define	CUBRID_TMP_ENV	"CUBRID_TMP"
+#define	CUBRID_TMP_ENV	"TMP"
 #define PREFIX_LEN      3
 
 namespace

--- a/src/base/filesys_temp.cpp
+++ b/src/base/filesys_temp.cpp
@@ -31,12 +31,16 @@
 #include <io.h>
 #endif
 
+#define	CUBRID_TMP_ENV	"CUBRID_TMP"
+
 namespace
 {
   std::string unique_tmp_filename (const char *prefix="cub_") //generates an unique filename in tmp folder
   {
 #ifdef LINUX
-    std::string filename = std::filesystem::temp_directory_path ();
+    const char *cubrid_tmp = std::getenv (CUBRID_TMP_ENV);
+    std::string filename = cubrid_tmp != nullptr ? cubrid_tmp : std::filesystem::temp_directory_path ();
+
     filename += "/";
     filename += prefix;
     filename += "XXXXXX"; //used with mkstemp()
@@ -47,6 +51,7 @@ namespace
     auto pos = filename.rfind ('\\');
     filename.insert (pos+1, prefix);
 #endif
+
     return filename;
   }
 }

--- a/src/base/filesys_temp.cpp
+++ b/src/base/filesys_temp.cpp
@@ -32,6 +32,8 @@
 #include <io.h>
 #endif
 
+#include "environment_variable.h"
+
 #define	CUBRID_TMP_ENV	"CUBRID_TMP"
 #define PREFIX_LEN      3
 
@@ -39,7 +41,7 @@ namespace
 {
   std::string unique_tmp_filename (const char *prefix="cub_") //generates an unique filename in tmp folder
   {
-    const char *cubrid_tmp = std::getenv (CUBRID_TMP_ENV);
+    const char *cubrid_tmp = envvar_get (CUBRID_TMP_ENV);
 #ifdef LINUX
     std::string filename = cubrid_tmp != nullptr ? cubrid_tmp : std::filesystem::temp_directory_path ().u8string ();
 
@@ -107,7 +109,7 @@ std::pair<std::string, FILE *> filesys::open_temp_file (const char *prefix, cons
 
 std::string filesys::temp_directory_path (void)
 {
-  const char *cubrid_tmp = std::getenv (CUBRID_TMP_ENV);
+  const char *cubrid_tmp = envvar_get (CUBRID_TMP_ENV);
   std::string pathname = cubrid_tmp != nullptr ? cubrid_tmp : std::filesystem::temp_directory_path ().u8string ();
 
   return pathname;

--- a/src/base/filesys_temp.cpp
+++ b/src/base/filesys_temp.cpp
@@ -62,13 +62,13 @@ namespace
 
     if (ret > 0)
       {
-        filename = buf;
+	filename = buf;
       }
     else
       {
-        filename = std::tmpnam (buf);
-        auto pos = filename.rfind ('\\');
-        filename.insert (pos+1, prefix);
+	filename = std::tmpnam (buf);
+	auto pos = filename.rfind ('\\');
+	filename.insert (pos+1, prefix);
       }
 #endif
 

--- a/src/base/filesys_temp.cpp
+++ b/src/base/filesys_temp.cpp
@@ -88,7 +88,7 @@ std::pair<std::string, FILE *> filesys::open_temp_file (const char *prefix, cons
 std::string filesys::temp_directory_path (void)
 {
   const char *cubrid_tmp = std::getenv (CUBRID_TMP_ENV);
-  std::string pathname = cubrid_tmp != nullptr ? cubrid_tmp : std::filesystem::temp_directory_path ();
+  std::string pathname = cubrid_tmp != nullptr ? cubrid_tmp : std::filesystem::temp_directory_path ().u8string ();
 
   return pathname;
 }

--- a/src/base/filesys_temp.cpp
+++ b/src/base/filesys_temp.cpp
@@ -54,10 +54,10 @@ namespace
 
     if (cubrid_tmp != nullptr)
       {
-        char pf[PREFIX_LEN];
+	char pf[PREFIX_LEN];
 
-        snprintf (pf, PREFIX_LEN, "%s", prefix != nullptr ? prefix : "CT");
-        ret = GetTempFileName (cubrid_tmp, pf, 0, buf);
+	snprintf (pf, PREFIX_LEN, "%s", prefix != nullptr ? prefix : "CT");
+	ret = GetTempFileName (cubrid_tmp, pf, 0, buf);
       }
 
     if (ret > 0)

--- a/src/base/filesys_temp.cpp
+++ b/src/base/filesys_temp.cpp
@@ -84,3 +84,11 @@ std::pair<std::string, FILE *> filesys::open_temp_file (const char *prefix, cons
 #endif
   return {filename, fileptr};
 }
+
+std::string filesys::temp_directory_path (void)
+{
+  const char *cubrid_tmp = std::getenv (CUBRID_TMP_ENV);
+  std::string pathname = cubrid_tmp != nullptr ? cubrid_tmp : std::filesystem::temp_directory_path ();
+
+  return pathname;
+}

--- a/src/base/filesys_temp.cpp
+++ b/src/base/filesys_temp.cpp
@@ -39,7 +39,7 @@ namespace
   {
 #ifdef LINUX
     const char *cubrid_tmp = std::getenv (CUBRID_TMP_ENV);
-    std::string filename = cubrid_tmp != nullptr ? cubrid_tmp : std::filesystem::temp_directory_path ();
+    std::string filename = cubrid_tmp != nullptr ? cubrid_tmp : std::filesystem::temp_directory_path ().u8string ();
 
     filename += "/";
     filename += prefix;

--- a/src/base/filesys_temp.hpp
+++ b/src/base/filesys_temp.hpp
@@ -33,6 +33,8 @@ namespace filesys //File System
 
   //opens a new file in OS's tmp folder; return file name & FILE*
   std::pair<std::string, FILE *> open_temp_file (const char *prefix, const char *mode="w", int flags=0);
+
+  std::string temp_directory_path (void);
 }
 
 #endif //_FILESYS_TEMP_H_

--- a/src/broker/broker_log_replay.c
+++ b/src/broker/broker_log_replay.c
@@ -40,6 +40,9 @@
 #include "porting.h"
 #include "error_code.h"
 
+#include "filesys.hpp"
+#include "filesys_temp.hpp"
+
 #define STAT_MAX_DIFF_TIME              (60000)	/* 60 * 1000 : 10 min */
 #define SORT_BUF_MAX                    (4096)
 #define BIND_STR_BUF_SIZE               (4096)
@@ -146,6 +149,7 @@ static int break_time = 0;
 static double print_result_diff_time_lower = 0;
 
 static FILE *br_tmpfp = NULL;
+static char br_tmp_filename[PATH_MAX];
 
 static unsigned int num_slower_queries[STAT_MAX_DIFF_TIME] = { 0 };
 static unsigned int num_faster_queries[STAT_MAX_DIFF_TIME] = { 0 };
@@ -1198,10 +1202,9 @@ print_result_without_sort (FILE * outfp, int print_diff_time_lower, int read_buf
   int res = 0;
   char *endp;
   char *read_buf;
-  FILE *next_tmp_fp;
   T_SQL_RESULT result;
 
-  next_tmp_fp = tmpfile ();
+  auto [filename, next_tmp_fp] = filesys::open_temp_file ("br_", "w+b");
   if (next_tmp_fp == NULL)
     {
       fprintf (stderr, "cannot open temp file\n");
@@ -1213,6 +1216,7 @@ print_result_without_sort (FILE * outfp, int print_diff_time_lower, int read_buf
     {
       fprintf (stderr, "memory allocation failed\n");
       fclose (next_tmp_fp);
+      unlink (filename.c_str ());
       return ER_FAILED;
     }
 
@@ -1240,6 +1244,7 @@ print_result_without_sort (FILE * outfp, int print_diff_time_lower, int read_buf
 	{
 	  fprintf (stderr, "memory allocation failed\n");
 	  fclose (next_tmp_fp);
+          unlink (filename.c_str ());
 	  free_and_init (read_buf);
 	  return ER_FAILED;
 	}
@@ -1251,11 +1256,13 @@ print_result_without_sort (FILE * outfp, int print_diff_time_lower, int read_buf
     }
 
   fclose (br_tmpfp);
+  unlink (br_tmp_filename);
 
   fflush (next_tmp_fp);
 
   /* save next temp file pointer in global variable */
   br_tmpfp = next_tmp_fp;
+  strcpy (br_tmp_filename, filename.c_str());
 
   free_and_init (read_buf);
   return NO_ERROR;
@@ -1277,7 +1284,6 @@ print_result_with_sort (FILE * outfp, int print_diff_time_lower, int num_query, 
   int res = 0;
   char *endp;
   char *read_buf = NULL;
-  FILE *next_tmp_fp;
   T_SQL_RESULT *result;
 
   if (num_query <= 0)
@@ -1285,7 +1291,7 @@ print_result_with_sort (FILE * outfp, int print_diff_time_lower, int num_query, 
       return NO_ERROR;
     }
 
-  next_tmp_fp = tmpfile ();
+  auto [filename, next_tmp_fp] = filesys::open_temp_file ("br_", "w+b");
   if (next_tmp_fp == NULL)
     {
       fprintf (stderr, "cannot open temp file\n");
@@ -1297,6 +1303,7 @@ print_result_with_sort (FILE * outfp, int print_diff_time_lower, int num_query, 
     {
       fprintf (stderr, "memory allocation failed\n");
       fclose (next_tmp_fp);
+      unlink (filename.c_str ());
       return ER_FAILED;
     }
   memset (result, '\0', sizeof (T_SQL_RESULT) * num_query);
@@ -1359,6 +1366,7 @@ print_result_with_sort (FILE * outfp, int print_diff_time_lower, int num_query, 
   free_and_init (result);
 
   fclose (br_tmpfp);
+  unlink (br_tmp_filename);
 
   fflush (outfp);
   fflush (next_tmp_fp);
@@ -1379,6 +1387,7 @@ error:
       free_and_init (result[i].sql_info);
     }
   fclose (next_tmp_fp);
+  unlink (filename.c_str ());
 
   return ER_FAILED;
 }
@@ -1562,6 +1571,12 @@ date_format_err:
  *   cci_errfp(out):
  *   skip_sqlfp(out):
  */
+
+#define PROC_ERR(code){ \
+        close_file (*infp, *outfp, *cci_errfp, *skip_sqlfp); \
+        return code; \
+}
+
 static int
 open_file (char *infilename, char *outfilename, FILE ** infp, FILE ** outfp, FILE ** cci_errfp, FILE ** skip_sqlfp)
 {
@@ -1576,35 +1591,36 @@ open_file (char *infilename, char *outfilename, FILE ** infp, FILE ** outfp, FIL
   if (*outfp == NULL)
     {
       fprintf (stderr, "cannot open output file '%s'\n", outfilename);
-      goto error;
+      PROC_ERR (ER_FAILED);
     }
 
-  br_tmpfp = tmpfile ();
+  auto [filename, fileptr] = filesys::open_temp_file ("br_", "w+b");
+
+  br_tmpfp = fileptr;
+
   if (br_tmpfp == NULL)
     {
       fprintf (stderr, "cannot open temp file\n");
-      goto error;
+      PROC_ERR (ER_FAILED);
     }
+  strcpy (br_tmp_filename, filename.c_str());
 
   *cci_errfp = fopen (CCI_ERR_FILE_NAME, "w");
   if (*cci_errfp == NULL)
     {
       fprintf (stderr, "cannot open output file '%s'\n", CCI_ERR_FILE_NAME);
-      goto error;
+      PROC_ERR (ER_FAILED);
     }
 
   *skip_sqlfp = fopen (PASS_SQL_FILE_NAME, "w");
   if (*skip_sqlfp == NULL)
     {
       fprintf (stderr, "cannot open output file '%s'\n", PASS_SQL_FILE_NAME);
-      goto error;
+      PROC_ERR (ER_FAILED);
     }
 
   return NO_ERROR;
 
-error:
-  close_file (*infp, *outfp, *cci_errfp, *skip_sqlfp);
-  return ER_FAILED;
 }
 
 /*

--- a/src/broker/broker_log_replay.c
+++ b/src/broker/broker_log_replay.c
@@ -1204,7 +1204,7 @@ print_result_without_sort (FILE * outfp, int print_diff_time_lower, int read_buf
   char *read_buf;
   T_SQL_RESULT result;
 
-  auto [filename, next_tmp_fp] = filesys::open_temp_file ("br_", "w+b");
+  auto[filename, next_tmp_fp] = filesys::open_temp_file ("br_", "w+b");
   if (next_tmp_fp == NULL)
     {
       fprintf (stderr, "cannot open temp file\n");
@@ -1244,7 +1244,7 @@ print_result_without_sort (FILE * outfp, int print_diff_time_lower, int read_buf
 	{
 	  fprintf (stderr, "memory allocation failed\n");
 	  fclose (next_tmp_fp);
-          unlink (filename.c_str ());
+	  unlink (filename.c_str ());
 	  free_and_init (read_buf);
 	  return ER_FAILED;
 	}
@@ -1262,7 +1262,7 @@ print_result_without_sort (FILE * outfp, int print_diff_time_lower, int read_buf
 
   /* save next temp file pointer in global variable */
   br_tmpfp = next_tmp_fp;
-  strcpy (br_tmp_filename, filename.c_str());
+  strcpy (br_tmp_filename, filename.c_str ());
 
   free_and_init (read_buf);
   return NO_ERROR;
@@ -1291,7 +1291,7 @@ print_result_with_sort (FILE * outfp, int print_diff_time_lower, int num_query, 
       return NO_ERROR;
     }
 
-  auto [filename, next_tmp_fp] = filesys::open_temp_file ("br_", "w+b");
+  auto[filename, next_tmp_fp] = filesys::open_temp_file ("br_", "w+b");
   if (next_tmp_fp == NULL)
     {
       fprintf (stderr, "cannot open temp file\n");
@@ -1594,7 +1594,7 @@ open_file (char *infilename, char *outfilename, FILE ** infp, FILE ** outfp, FIL
       PROC_ERR (ER_FAILED);
     }
 
-  auto [filename, fileptr] = filesys::open_temp_file ("br_", "w+b");
+  auto[filename, fileptr] = filesys::open_temp_file ("br_", "w+b");
 
   br_tmpfp = fileptr;
 
@@ -1603,7 +1603,7 @@ open_file (char *infilename, char *outfilename, FILE ** infp, FILE ** outfp, FIL
       fprintf (stderr, "cannot open temp file\n");
       PROC_ERR (ER_FAILED);
     }
-  strcpy (br_tmp_filename, filename.c_str());
+  strcpy (br_tmp_filename, filename.c_str ());
 
   *cci_errfp = fopen (CCI_ERR_FILE_NAME, "w");
   if (*cci_errfp == NULL)

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -89,6 +89,8 @@
 #include "crypt_opfunc.h"
 #include "flashback.h"
 #include "method_compile.hpp"
+#include "filesys.hpp"
+#include "filesys_temp.hpp"
 
 #if defined (SUPPRESS_STRLEN_WARNING)
 #define strlen(s1)  ((int) strlen(s1))
@@ -1988,7 +1990,6 @@ slogtb_reset_isolation (THREAD_ENTRY * thread_p, unsigned int rid, char *request
 void
 slogpb_dump_stat (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen)
 {
-  FILE *outfp;
   int file_size;
   char *buffer;
   int buffer_size;
@@ -2005,7 +2006,7 @@ slogpb_dump_stat (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int 
       return;
     }
 
-  outfp = tmpfile ();
+  auto[filename, outfp] = filesys::open_temp_file ("dump_logpb_stat_", "w+b");
   if (outfp == NULL)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
@@ -2013,6 +2014,8 @@ slogpb_dump_stat (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int 
       db_private_free_and_init (NULL, buffer);
       return;
     }
+
+  filesys::auto_delete_file file_del (filename.c_str ());
 
   xlogpb_dump_stat (outfp);
   file_size = ftell (outfp);
@@ -2301,7 +2304,6 @@ sacl_reload (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqle
 void
 sacl_dump (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen)
 {
-  FILE *outfp;
   int file_size;
   char *buffer;
   int buffer_size;
@@ -2318,7 +2320,7 @@ sacl_dump (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen)
       return;
     }
 
-  outfp = tmpfile ();
+  auto[filename, outfp] = filesys::open_temp_file ("dump_acl_", "w+b");
   if (outfp == NULL)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
@@ -2327,6 +2329,7 @@ sacl_dump (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen)
       return;
     }
 
+  filesys::auto_delete_file file_del (filename.c_str ());
   xacl_dump (thread_p, outfp);
   file_size = ftell (outfp);
 
@@ -2379,7 +2382,6 @@ sacl_dump (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen)
 void
 slock_dump (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen)
 {
-  FILE *outfp;
   int file_size;
   char *buffer;
   int buffer_size;
@@ -2399,7 +2401,7 @@ slock_dump (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen
       return;
     }
 
-  outfp = tmpfile ();
+  auto[filename, outfp] = filesys::open_temp_file ("dump_lock_", "w+b");
   if (outfp == NULL)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
@@ -2407,6 +2409,8 @@ slock_dump (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen
       db_private_free_and_init (thread_p, buffer);
       return;
     }
+
+  filesys::auto_delete_file file_del (filename.c_str ());
 
   xlock_dump (thread_p, outfp, is_contention);
   file_size = ftell (outfp);
@@ -6077,7 +6081,6 @@ sqmgr_drop_query_plans_by_sha1 (THREAD_ENTRY * thread_p, unsigned int rid, char 
 void
 sqmgr_dump_query_plans (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen)
 {
-  FILE *outfp;
   int file_size;
   char *buffer;
   int buffer_size;
@@ -6094,7 +6097,7 @@ sqmgr_dump_query_plans (THREAD_ENTRY * thread_p, unsigned int rid, char *request
       return;
     }
 
-  outfp = tmpfile ();
+  auto[filename, outfp] = filesys::open_temp_file ("dump_qplan_", "w+b");
   if (outfp == NULL)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
@@ -6102,6 +6105,8 @@ sqmgr_dump_query_plans (THREAD_ENTRY * thread_p, unsigned int rid, char *request
       db_private_free_and_init (thread_p, buffer);
       return;
     }
+
+  filesys::auto_delete_file file_del (filename.c_str ());
 
   xqmgr_dump_query_plans (thread_p, outfp);
   file_size = ftell (outfp);
@@ -6156,7 +6161,6 @@ sqmgr_dump_query_plans (THREAD_ENTRY * thread_p, unsigned int rid, char *request
 void
 sqmgr_dump_query_cache (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen)
 {
-  FILE *outfp;
   int file_size;
   char *buffer;
   int buffer_size;
@@ -6173,7 +6177,7 @@ sqmgr_dump_query_cache (THREAD_ENTRY * thread_p, unsigned int rid, char *request
       return;
     }
 
-  outfp = tmpfile ();
+  auto[filename, outfp] = filesys::open_temp_file ("dump_qcache_", "w+b");
   if (outfp == NULL)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
@@ -6181,6 +6185,8 @@ sqmgr_dump_query_cache (THREAD_ENTRY * thread_p, unsigned int rid, char *request
       db_private_free_and_init (thread_p, buffer);
       return;
     }
+
+  filesys::auto_delete_file file_del (filename.c_str ());
 
   xqmgr_dump_query_cache (thread_p, outfp);
   file_size = ftell (outfp);
@@ -7154,7 +7160,6 @@ sthread_kill_or_interrupt_tran (THREAD_ENTRY * thread_p, unsigned int rid, char 
 void
 sthread_dump_cs_stat (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen)
 {
-  FILE *outfp;
   int file_size;
   char *buffer;
   int buffer_size;
@@ -7171,7 +7176,7 @@ sthread_dump_cs_stat (THREAD_ENTRY * thread_p, unsigned int rid, char *request, 
       return;
     }
 
-  outfp = tmpfile ();
+  auto[filename, outfp] = filesys::open_temp_file ("dump_thread_cs_", "w+b");
   if (outfp == NULL)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
@@ -7270,7 +7275,6 @@ slogtb_get_pack_tran_table (THREAD_ENTRY * thread_p, unsigned int rid, char *req
 void
 slogtb_dump_trantable (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen)
 {
-  FILE *outfp;
   int file_size;
   char *buffer;
   int buffer_size;
@@ -7287,7 +7291,7 @@ slogtb_dump_trantable (THREAD_ENTRY * thread_p, unsigned int rid, char *request,
       return;
     }
 
-  outfp = tmpfile ();
+  auto[filename, outfp] = filesys::open_temp_file ("dump_logtb_", "w+b");
   if (outfp == NULL)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
@@ -7295,6 +7299,8 @@ slogtb_dump_trantable (THREAD_ENTRY * thread_p, unsigned int rid, char *request,
       db_private_free_and_init (thread_p, buffer);
       return;
     }
+
+  filesys::auto_delete_file file_del (filename.c_str ());
 
   xlogtb_dump_trantable (thread_p, outfp);
   file_size = ftell (outfp);
@@ -7903,7 +7909,6 @@ sprm_server_obtain_parameters (THREAD_ENTRY * thread_p, unsigned int rid, char *
 void
 sprm_server_dump_parameters (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen)
 {
-  FILE *outfp;
   int file_size;
   char *buffer;
   int buffer_size;
@@ -7920,7 +7925,7 @@ sprm_server_dump_parameters (THREAD_ENTRY * thread_p, unsigned int rid, char *re
       return;
     }
 
-  outfp = tmpfile ();
+  auto[filename, outfp] = filesys::open_temp_file ("dump_prm_", "w+b");
   if (outfp == NULL)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
@@ -7928,6 +7933,8 @@ sprm_server_dump_parameters (THREAD_ENTRY * thread_p, unsigned int rid, char *re
       db_private_free_and_init (thread_p, buffer);
       return;
     }
+
+  filesys::auto_delete_file file_del (filename.c_str ());
 
   xsysprm_dump_server_parameters (outfp);
   file_size = ftell (outfp);
@@ -9590,7 +9597,6 @@ svacuum (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen)
 void
 svacuum_dump (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen)
 {
-  FILE *outfp;
   int file_size;
   char *buffer;
   int buffer_size;
@@ -9607,7 +9613,7 @@ svacuum_dump (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reql
       return;
     }
 
-  outfp = tmpfile ();
+  auto[filename, outfp] = filesys::open_temp_file ("dump_vacuum_", "w+b");
   if (outfp == NULL)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
@@ -9615,6 +9621,8 @@ svacuum_dump (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reql
       db_private_free_and_init (thread_p, buffer);
       return;
     }
+
+  filesys::auto_delete_file file_del (filename.c_str ());
 
   xvacuum_dump (thread_p, outfp);
   file_size = ftell (outfp);

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -29,6 +29,8 @@
 #include <string.h>
 #include <assert.h>
 
+#include "filesys.hpp"
+#include "filesys_temp.hpp"
 #include "porting.h"
 #include "porting_inline.hpp"
 #include "perf_monitor.h"
@@ -89,8 +91,6 @@
 #include "crypt_opfunc.h"
 #include "flashback.h"
 #include "method_compile.hpp"
-#include "filesys.hpp"
-#include "filesys_temp.hpp"
 
 #if defined (SUPPRESS_STRLEN_WARNING)
 #define strlen(s1)  ((int) strlen(s1))

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -2006,7 +2006,7 @@ slogpb_dump_stat (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int 
       return;
     }
 
-  auto[filename, outfp] = filesys::open_temp_file ("dump_logpb_stat_", "w+b");
+  auto[filename, outfp] = filesys::open_temp_file ("logpb_dump_stat_", "w+b");
   if (outfp == NULL)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
@@ -2320,7 +2320,7 @@ sacl_dump (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen)
       return;
     }
 
-  auto[filename, outfp] = filesys::open_temp_file ("dump_acl_", "w+b");
+  auto[filename, outfp] = filesys::open_temp_file ("acl_dump_", "w+b");
   if (outfp == NULL)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
@@ -2401,7 +2401,7 @@ slock_dump (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen
       return;
     }
 
-  auto[filename, outfp] = filesys::open_temp_file ("dump_lock_", "w+b");
+  auto[filename, outfp] = filesys::open_temp_file ("lock_dump_", "w+b");
   if (outfp == NULL)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
@@ -6097,7 +6097,7 @@ sqmgr_dump_query_plans (THREAD_ENTRY * thread_p, unsigned int rid, char *request
       return;
     }
 
-  auto[filename, outfp] = filesys::open_temp_file ("dump_qplan_", "w+b");
+  auto[filename, outfp] = filesys::open_temp_file ("qplan_dump_", "w+b");
   if (outfp == NULL)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
@@ -6177,7 +6177,7 @@ sqmgr_dump_query_cache (THREAD_ENTRY * thread_p, unsigned int rid, char *request
       return;
     }
 
-  auto[filename, outfp] = filesys::open_temp_file ("dump_qcache_", "w+b");
+  auto[filename, outfp] = filesys::open_temp_file ("qcache_dump_", "w+b");
   if (outfp == NULL)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
@@ -7176,7 +7176,7 @@ sthread_dump_cs_stat (THREAD_ENTRY * thread_p, unsigned int rid, char *request, 
       return;
     }
 
-  auto[filename, outfp] = filesys::open_temp_file ("dump_thread_cs_", "w+b");
+  auto[filename, outfp] = filesys::open_temp_file ("thread_cs_dump_", "w+b");
   if (outfp == NULL)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
@@ -7291,7 +7291,7 @@ slogtb_dump_trantable (THREAD_ENTRY * thread_p, unsigned int rid, char *request,
       return;
     }
 
-  auto[filename, outfp] = filesys::open_temp_file ("dump_logtb_", "w+b");
+  auto[filename, outfp] = filesys::open_temp_file ("logtb_dump_", "w+b");
   if (outfp == NULL)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
@@ -7925,7 +7925,7 @@ sprm_server_dump_parameters (THREAD_ENTRY * thread_p, unsigned int rid, char *re
       return;
     }
 
-  auto[filename, outfp] = filesys::open_temp_file ("dump_prm_", "w+b");
+  auto[filename, outfp] = filesys::open_temp_file ("prm_dump_", "w+b");
   if (outfp == NULL)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
@@ -9613,7 +9613,7 @@ svacuum_dump (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reql
       return;
     }
 
-  auto[filename, outfp] = filesys::open_temp_file ("dump_vacuum_", "w+b");
+  auto[filename, outfp] = filesys::open_temp_file ("vacuum_dump_", "w+b");
   if (outfp == NULL)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -7185,6 +7185,8 @@ sthread_dump_cs_stat (THREAD_ENTRY * thread_p, unsigned int rid, char *request, 
       return;
     }
 
+  filesys::auto_delete_file file_del (filename.c_str ());
+
   sync_dump_statistics (outfp, SYNC_TYPE_ALL);
 
   file_size = ftell (outfp);

--- a/src/compat/db_admin.c
+++ b/src/compat/db_admin.c
@@ -68,6 +68,7 @@
 #include "connection_cl.h"
 #include "dbtype.h"
 #include "method_callback.hpp"
+#include "filesys_temp.hpp"
 
 #if !defined(WINDOWS)
 void (*prev_sigfpe_handler) (int) = SIG_DFL;
@@ -173,7 +174,8 @@ db_init (const char *program, int print_version, const char *dbname, const char 
 #if defined (CUBRID_DEBUG)
   int value;
   const char *env_value;
-  char more_vol_info_temp_file[L_tmpnam];
+  char more_vol_info_temp_file[PATH_MAX];
+  std::string filename = "";
 #endif
   const char *more_vol_info_file = NULL;
   int error = NO_ERROR;
@@ -203,8 +205,10 @@ db_init (const char *program, int print_version, const char *dbname, const char 
 
 	  db_npages = npages / 4;
 
-	  if (tmpnam (more_vol_info_temp_file) != NULL && (more_vols_fp = fopen (more_vol_info_temp_file, "w")) != NULL)
+	  std::tie (filename, more_vols_fp) = filesys::open_temp_file ("db");;
+	  if (more_vols_fp != NULL)
 	    {
+	      snprintf (more_vol_info_temp_file, PATH_MAX, "%s", filename.c_str ());
 	      fprintf (more_vols_fp, "%s %s %s %d", "PURPOSE", "DATA", "NPAGES", db_npages);
 	      fprintf (more_vols_fp, "%s %s %s %d", "PURPOSE", "INDEX", "NPAGES", db_npages);
 	      fprintf (more_vols_fp, "%s %s %s %d", "PURPOSE", "TEMP", "NPAGES", db_npages);

--- a/src/connection/connection_cl.c
+++ b/src/connection/connection_cl.c
@@ -969,7 +969,7 @@ css_connect_to_master_server (int master_port_id, const char *server_name, int n
 #else /* WINDOWS */
       /* send the "pathname" for the datagram */
       /* be sure to open the datagram first.  */
-      pname = std::filesystem::temp_directory_path ();
+      pname = filesys::temp_directory_path ();
       pname += "/csql_tcp_setup_server" + std::to_string (getpid ());
       (void) unlink (pname.c_str ());	// make sure file is deleted
 

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -1166,7 +1166,7 @@ css_connect_to_master_server (int master_port_id, const char *server_name, int n
 #else /* WINDOWS */
       /* send the "pathname" for the datagram */
       /* be sure to open the datagram first.  */
-      pname = std::filesystem::temp_directory_path ();
+      pname = filesys::temp_directory_path ();
       pname += "/cubrid_tcp_setup_server" + std::to_string (getpid ());
       (void) unlink (pname.c_str ());	// make sure file is deleted
 

--- a/src/win_tools/cubridservice/cubridservice.cpp
+++ b/src/win_tools/cubridservice/cubridservice.cpp
@@ -481,6 +481,7 @@ SetCUBRIDEnvVar ()
   DWORD dwBufLength = BUF_LENGTH;
   TCHAR sEnvCUBRID[BUF_LENGTH];
   TCHAR sEnvCUBRID_DATABASES[BUF_LENGTH];
+  TCHAR sEnvCUBRID_TMP[BUF_LENGTH];
   TCHAR sEnvCUBRID_MODE[BUF_LENGTH];
   TCHAR sEnvPath[BUF_LENGTH];
 
@@ -529,6 +530,22 @@ SetCUBRIDEnvVar ()
 	{
 	  fprintf (debugfd, "$CUBRID_DATABASES = %s\n", getenv ("CUBRID_DATABASES"));
 	}
+#endif
+    }
+
+  dwBufLength = BUF_LENGTH;
+  nResult = RegQueryValueEx (hKey, TEXT ("CUBRID_TMP"), NULL, NULL, (LPBYTE) sEnvCUBRID_TMP, &dwBufLength);
+  if (nResult == ERROR_SUCCESS)
+    {
+      // set CUBRID_TMP Environment variable.
+      strcpy (EnvString, "CUBRID_TMP=");
+      strcat (EnvString, sEnvCUBRID_TMP);
+      _putenv (EnvString);
+#ifdef _DEBUG
+      if (debugfd)
+        {
+          fprintf (debugfd, "$CUBRID_TMP = %s\n", getenv ("CUBRID_TMP"));
+        }
 #endif
     }
 

--- a/src/win_tools/cubridservice/cubridservice.cpp
+++ b/src/win_tools/cubridservice/cubridservice.cpp
@@ -543,9 +543,9 @@ SetCUBRIDEnvVar ()
       _putenv (EnvString);
 #ifdef _DEBUG
       if (debugfd)
-        {
-          fprintf (debugfd, "$CUBRID_TMP = %s\n", getenv ("CUBRID_TMP"));
-        }
+	{
+	  fprintf (debugfd, "$CUBRID_TMP = %s\n", getenv ("CUBRID_TMP"));
+	}
 #endif
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25452

**Description**
* subjects of modification (tmpfile()): esql_grammar.y will be excluded
  * communication/network_interface_sr.c (8 lines)
  * broker/broker_log_replay.c (3 lines)
  * executables/esql_grammar.y (1 line)

**Implementation**
1. modify filesys::open_temp_file method to reflect  CUBRID_TMP Env
2. replace tmpfile () to filesys::open_temp_file
3. replace tmpnam () to filesys::open_temp_file (compat/db_admin.c)

**Remarks**
* For the testing/QA. please refer jira issue CBRD-25452
* affected commands for tmpfile () modification
  * cubrid vacuumdb --dump demodb -C
  * cubrid plandump demodb
  * cubrid lockdb demodb
  * cubrid server acl status demodb

  * csql -u dba demodb
    * ;info qcache
    * ;info logstat
    * ;info trantable
    * ;info csstat
