### PR TITLE
[CBRD-25434] Change the recovery range in analysis phase when executing restoredb (#5278)

### DIFF
--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -2915,6 +2915,11 @@ log_recovery_analysis (THREAD_ENTRY * thread_p, LOG_LSA * start_lsa, LOG_LSA * s
 				  &may_use_checkpoint, &may_need_synch_checkpoint_2pc);
 	  if (*did_incom_recovery == true)
 	    {
+	      /* The end_redo_lsa needs to be reverted to the prev_lsa value.
+	       * The log record pointed to by end_redo_lsa is not a target for redo
+	       */
+	      LSA_COPY (end_redo_lsa, &prev_lsa);
+
 	      LSA_SET_NULL (&lsa);
 	      break;
 	    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25434

The log record pointed to by end_redo_lsa should not be included in the range of recovery through restoredb. Therefore, end_redo_lsa needs to be reverted to the prev_lsa.

backport #5278
