### PR TITLE
[CBRD-24407] change to reflect its, when changing lock_timeout or isolation_level via "set system parameters".

### DIFF
--- a/src/compat/db_admin.c
+++ b/src/compat/db_admin.c
@@ -2754,7 +2754,7 @@ db_set_system_parameters (const char *data)
       rc = sysprm_change_server_parameters (assignments);
     }
 
-  if (rc == PRM_ERR_NO_ERROR || rc == PRM_ERR_NOT_FOR_CLIENT || rc == PRM_ERR_NOT_FOR_CLIENT_NO_AUTH)
+  if (rc == PRM_ERR_NO_ERROR)
     {
       /* values were successfully set on server, set them on client too */
       sysprm_change_parameter_values (assignments, true, true);

--- a/src/compat/db_admin.c
+++ b/src/compat/db_admin.c
@@ -2767,7 +2767,7 @@ db_set_system_parameters (const char *data)
 	  SYSPRM_ASSIGN_VALUE *tmp;
 
 	  rc = sysprm_obtain_parameters ((char *) prm_get_name (PRM_ID_LK_TIMEOUT), &tmp);
-	  if (tmp->value.i >= 0)
+	  if (tmp->value.i > 0)
 	    {
 	      tran_reset_wait_times (tmp->value.i * 1000);
 	    }

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -4964,6 +4964,7 @@ do_set_xaction (PARSER_CONTEXT * parser, PT_NODE * statement)
 
 	  if (error == NO_ERROR)
 	    {
+	      prm_set_integer_value (PRM_ID_LOG_ISOLATION_LEVEL, (int) tran_isolation);
 	      error = tran_reset_isolation (tran_isolation, async_ws);
 	    }
 	  break;
@@ -4981,6 +4982,7 @@ do_set_xaction (PARSER_CONTEXT * parser, PT_NODE * statement)
 	  else
 	    {
 	      wait_secs = db_get_float (&val);
+	      prm_set_integer_value (PRM_ID_LK_TIMEOUT, wait_secs);
 	      if (wait_secs > 0)
 		{
 		  wait_secs *= 1000;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24407

I modify it to do the same behavior like "set transaction" statement when changing it via the "set system parameters" statement, as can changing isolation_level and lock_timeout using the "set transaction" statement.

- set system parameters 'lock_timeout=10s' <-- set transaction lock timeout 10;
- set system parameters 'isolation_level=5' <-- set transaction isolation level repeatable read;

