### PR TITLE
[CBRD-25428] When execution of the recursive part in the recursive CTE ends, clear VAL_LIST (#5264)

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -16010,6 +16010,14 @@ qexec_execute_cte (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_
 	      GOTO_EXIT_ON_ERROR;
 	    }
 
+	  /* Before executing the next recursive part, clearing VAL_LIST is necessary.
+	   * See CBRD-25428 for the details.
+	   */
+	  if (recursive_part->val_list)
+	    {
+	      qexec_clear_db_val_list (recursive_part->val_list->valp);
+	    }
+
 	  if (first_iteration)
 	    {
 	      /* unify list_id types after the first execution of the recursive part */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25428

backport #5264