### PR TITLE
[CBRD-25437] cub_server의 등록/해제 과정 구현

### DIFF
--- a/src/connection/connection_globals.h
+++ b/src/connection/connection_globals.h
@@ -57,20 +57,59 @@ typedef struct css_conn_rule_info
   int num_curr_conn;
 } CSS_CONN_RULE_INFO;
 
-extern int css_Service_id;
-extern const char *css_Service_name;
+/*
+ * server register resource message body
+ */
 
-extern int css_Server_use_new_connection_protocol;
-extern int css_Server_inhibit_connection_socket;
-extern SOCKET css_Server_connection_socket;
-extern CSS_CONN_RULE_INFO css_Conn_rules[];
-extern const int css_Conn_rules_size;
+/* process register */
+typedef struct css_server_proc_register CSS_SERVER_PROC_REGISTER;
+struct css_server_proc_register
+{
+  static constexpr int CSS_SERVER_MAX_SZ_SERVER_NAME = 256;
+  static constexpr int CSS_SERVER_MAX_SZ_PROC_EXEC_PATH = 128;
+  static constexpr int CSS_SERVER_MAX_SZ_PROC_ARGS = 1024;
 
-extern SOCKET css_Pipe_to_master;
+  char server_name[CSS_SERVER_MAX_SZ_SERVER_NAME];
+  int server_name_length;
+  int pid;
+  char exec_path[CSS_SERVER_MAX_SZ_PROC_EXEC_PATH];
+  char args[CSS_SERVER_MAX_SZ_PROC_ARGS];
+
+  inline css_server_proc_register ();
+};
+
+css_server_proc_register::css_server_proc_register ():server_name_length (0), pid (0)
+{
+  memset (server_name, 0, CSS_SERVER_MAX_SZ_SERVER_NAME);
+  memset (exec_path, 0, CSS_SERVER_MAX_SZ_PROC_EXEC_PATH);
+  memset (args, 0, CSS_SERVER_MAX_SZ_PROC_ARGS);
+}
+
+extern int
+  css_Service_id;
+extern const char *
+  css_Service_name;
+
+extern int
+  css_Server_use_new_connection_protocol;
+extern int
+  css_Server_inhibit_connection_socket;
+extern SOCKET
+  css_Server_connection_socket;
+extern CSS_CONN_RULE_INFO
+  css_Conn_rules[];
+extern const int
+  css_Conn_rules_size;
+
+extern SOCKET
+  css_Pipe_to_master;
 
 #define CSS_NET_MAGIC_SIZE		8
-extern char css_Net_magic[CSS_NET_MAGIC_SIZE];
-extern void css_init_conn_rules (void);
-extern int css_get_max_conn (void);
+extern char
+  css_Net_magic[CSS_NET_MAGIC_SIZE];
+extern void
+css_init_conn_rules (void);
+extern int
+css_get_max_conn (void);
 
 #endif /* _CONNECTION_GLOBALS_H_ */

--- a/src/connection/connection_globals.h
+++ b/src/connection/connection_globals.h
@@ -35,6 +35,8 @@
 typedef bool (*CSS_CHECK_CLIENT_TYPE) (BOOT_CLIENT_TYPE client_type);
 typedef int (*CSS_GET_MAX_CONN_NUM) (void);
 
+#define CSS_SERVER_PROC_REGISTER_INITIALIZER    {-1, "", 0, "", ""}
+
 /*
  * a rule defining how a client consumes connections.
  * ex) a client using CR_NORMAL_FIRST_RESERVED_LAST

--- a/src/connection/connection_globals.h
+++ b/src/connection/connection_globals.h
@@ -79,7 +79,9 @@ struct css_server_proc_register
 };
 
 // *INDENT-OFF*
-css_server_proc_register::css_server_proc_register ():server_name_length (0), pid (0)
+css_server_proc_register::css_server_proc_register ()
+  : server_name_length (0)
+  , pid (0)
 {
   memset (server_name, 0, CSS_SERVER_MAX_SZ_SERVER_NAME);
   memset (exec_path, 0, CSS_SERVER_MAX_SZ_PROC_EXEC_PATH);

--- a/src/connection/connection_globals.h
+++ b/src/connection/connection_globals.h
@@ -32,6 +32,8 @@
 
 #define CSS_MAX_CLIENT_COUNT   4000
 
+#define CSS_SERVER_PROC_REGISTER_INITIALIZER    {-1, "", 0, "", ""}
+
 typedef bool (*CSS_CHECK_CLIENT_TYPE) (BOOT_CLIENT_TYPE client_type);
 typedef int (*CSS_GET_MAX_CONN_NUM) (void);
 

--- a/src/connection/connection_globals.h
+++ b/src/connection/connection_globals.h
@@ -75,20 +75,7 @@ struct css_server_proc_register
 
   char exec_path[CSS_SERVER_MAX_SZ_PROC_EXEC_PATH];
   char args[CSS_SERVER_MAX_SZ_PROC_ARGS];
-
-  inline css_server_proc_register ();
 };
-
-// *INDENT-OFF*
-css_server_proc_register::css_server_proc_register ()
-  : server_name_length (0)
-  , pid (0)
-{
-  memset (server_name, 0, CSS_SERVER_MAX_SZ_SERVER_NAME);
-  memset (exec_path, 0, CSS_SERVER_MAX_SZ_PROC_EXEC_PATH);
-  memset (args, 0, CSS_SERVER_MAX_SZ_PROC_ARGS);
-}
-// *INDENT-ON*
 
 extern int css_Service_id;
 extern const char *css_Service_name;

--- a/src/connection/connection_globals.h
+++ b/src/connection/connection_globals.h
@@ -69,9 +69,10 @@ struct css_server_proc_register
   static constexpr int CSS_SERVER_MAX_SZ_PROC_EXEC_PATH = 128;
   static constexpr int CSS_SERVER_MAX_SZ_PROC_ARGS = 1024;
 
+  int pid;
   char server_name[CSS_SERVER_MAX_SZ_SERVER_NAME];
   int server_name_length;
-  int pid;
+
   char exec_path[CSS_SERVER_MAX_SZ_PROC_EXEC_PATH];
   char args[CSS_SERVER_MAX_SZ_PROC_ARGS];
 

--- a/src/connection/connection_globals.h
+++ b/src/connection/connection_globals.h
@@ -35,8 +35,6 @@
 typedef bool (*CSS_CHECK_CLIENT_TYPE) (BOOT_CLIENT_TYPE client_type);
 typedef int (*CSS_GET_MAX_CONN_NUM) (void);
 
-#define CSS_SERVER_PROC_REGISTER_INITIALIZER    {-1, "", 0, "", ""}
-
 /*
  * a rule defining how a client consumes connections.
  * ex) a client using CR_NORMAL_FIRST_RESERVED_LAST

--- a/src/connection/connection_globals.h
+++ b/src/connection/connection_globals.h
@@ -78,38 +78,29 @@ struct css_server_proc_register
   inline css_server_proc_register ();
 };
 
+// *INDENT-OFF*
 css_server_proc_register::css_server_proc_register ():server_name_length (0), pid (0)
 {
   memset (server_name, 0, CSS_SERVER_MAX_SZ_SERVER_NAME);
   memset (exec_path, 0, CSS_SERVER_MAX_SZ_PROC_EXEC_PATH);
   memset (args, 0, CSS_SERVER_MAX_SZ_PROC_ARGS);
 }
+// *INDENT-ON*
 
-extern int
-  css_Service_id;
-extern const char *
-  css_Service_name;
+extern int css_Service_id;
+extern const char *css_Service_name;
 
-extern int
-  css_Server_use_new_connection_protocol;
-extern int
-  css_Server_inhibit_connection_socket;
-extern SOCKET
-  css_Server_connection_socket;
-extern CSS_CONN_RULE_INFO
-  css_Conn_rules[];
-extern const int
-  css_Conn_rules_size;
+extern int css_Server_use_new_connection_protocol;
+extern int css_Server_inhibit_connection_socket;
+extern SOCKET css_Server_connection_socket;
+extern CSS_CONN_RULE_INFO css_Conn_rules[];
+extern const int css_Conn_rules_size;
 
-extern SOCKET
-  css_Pipe_to_master;
+extern SOCKET css_Pipe_to_master;
 
 #define CSS_NET_MAGIC_SIZE		8
-extern char
-  css_Net_magic[CSS_NET_MAGIC_SIZE];
-extern void
-css_init_conn_rules (void);
-extern int
-css_get_max_conn (void);
+extern char css_Net_magic[CSS_NET_MAGIC_SIZE];
+extern void css_init_conn_rules (void);
+extern int css_get_max_conn (void);
 
 #endif /* _CONNECTION_GLOBALS_H_ */

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -1077,25 +1077,16 @@ css_common_connect (CSS_CONN_ENTRY * conn, unsigned short *rid,
 
 /*
  * css_make_set_proc_register() - make a server proc register.
- *   return: server proc register
+ *   return:
  *   server_name(in):
  *   server_name_lenth(in):
+ *   proc_register(out):
  */
-static SERVER_PROC_REGISTER *
-css_make_set_proc_register (const char *server_name, int server_name_length)
+static void
+css_make_set_proc_register (const char *server_name, int server_name_length, SERVER_PROC_REGISTER * proc_register)
 {
-  SERVER_PROC_REGISTER *proc_register;
   char *p, *last;
   char **argv;
-
-  proc_register = (SERVER_PROC_REGISTER *) malloc (sizeof (SERVER_PROC_REGISTER));
-  if (proc_register == NULL)
-    {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (SERVER_PROC_REGISTER));
-      return (NULL);
-    }
-
-  memset ((void *) proc_register, 0, sizeof (SERVER_PROC_REGISTER));
 
   strncpy_bufsize (proc_register->server_name, server_name);
   proc_register->server_name_length = htonl (server_name_length);
@@ -1108,8 +1099,6 @@ css_make_set_proc_register (const char *server_name, int server_name_length)
     {
       p += snprintf (p, MAX ((last - p), 0), "%s ", *argv);
     }
-
-  return (proc_register);
 }
 
 /*
@@ -1132,7 +1121,9 @@ css_connect_to_master_server (int master_port_id, const char *server_name, int n
   std::string pname;
   int datagram_fd, socket_fd;
 #endif
-  SERVER_PROC_REGISTER *proc_register = NULL;
+  const char *data;
+  int data_length;
+  SERVER_PROC_REGISTER proc_register;
 
   css_Service_id = master_port_id;
   if (GETHOSTNAME (hname, CUB_MAXHOSTNAMELEN) != 0)
@@ -1149,37 +1140,27 @@ css_connect_to_master_server (int master_port_id, const char *server_name, int n
 
   /* select the connection protocol */
 
-  //  The following code is changed to register the server in the master_Server_monitor for monitoring
-  //  abnormally terminated servers (Check CBRD-24741 for details). This issue will be handled for
-  //  Linux/Unix first, and then for Windows. Therefore, the data sent to the master is different
-  //  between Windows and Linux/Unix. When Windows is supported, both of them will send proc_register
-  //  as register data.
+  //  When supporting the Windows environment, It will be modified to send the same data
+  //  (proc_register) for the Windows protocol (SERVER_REQUEST_NEW) as well.
 
   if (css_Server_use_new_connection_protocol)
     {
       // Windows
       connection_protocol = SERVER_REQUEST_NEW;
-      if (css_common_connect (conn, &rid, hname, connection_protocol, server_name, name_length, master_port_id) == NULL)
-	{
-	  goto fail_end;
-	}
+      data = server_name;
+      data_length = name_length;
     }
   else
     {
       // Linux and Unix
       connection_protocol = SERVER_REQUEST;
-      proc_register = css_make_set_proc_register (server_name, name_length);
-      if (proc_register == NULL)
-	{
-	  er_log_debug (ARG_FILE_LINE, "failed to make server proc register.\n");
-	  goto fail_end;
-	}
-      if (css_common_connect
-	  (conn, &rid, hname, connection_protocol, (const char *) proc_register, sizeof (*proc_register),
-	   master_port_id) == NULL)
-	{
-	  goto fail_end;
-	}
+      css_make_set_proc_register (server_name, name_length, &proc_register);
+      data = (const char *) &proc_register;
+      data_length = sizeof (proc_register);
+    }
+  if (css_common_connect (conn, &rid, hname, connection_protocol, data, data_length, master_port_id) == NULL)
+    {
+      goto fail_end;
     }
   if (css_readn (conn->fd, (char *) &response_buff, sizeof (int), -1) != sizeof (int))
     {

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -1143,7 +1143,7 @@ css_connect_to_master_server (int master_port_id, const char *server_name, int n
 
   /* select the connection protocol */
 
-  // TODO : Following code is changed to register server to master_Server_monitor for monitoring abnormally 
+  // Note : Following code is changed to register server in master_Server_monitor for monitoring abnormally 
   //        terminated server. (Check CBRD-24741 for details.) This issue will be handle for Linux/Unix first
   //        and then for Windows. Therefore, data which sends to the master is different between Windows and Linux/Unix.
   //        When Windows is supported, both of them will send proc_register as register data.

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -1088,12 +1088,12 @@ css_set_proc_register (const char *server_name, int server_name_length, CSS_SERV
   char **argv;
 
   memcpy (proc_register->server_name, server_name, server_name_length);
-  proc_register->server_name_length = htonl (server_name_length);
-  proc_register->pid = htonl (getpid ());
+  proc_register->server_name_length = server_name_length;
+  proc_register->pid = getpid ();
   strncpy_bufsize (proc_register->exec_path, css_Server_exec_path);
 
-  p = (char *) &proc_register->args[0];
-  last = (char *) (p + sizeof (proc_register->args));
+  p = (char *) proc_register->args;
+  last = p + proc_register->CSS_SERVER_MAX_SZ_PROC_ARGS;
   for (argv = css_Server_argv; *argv; argv++)
     {
       p += snprintf (p, MAX ((last - p), 0), "%s ", *argv);

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -1075,19 +1075,19 @@ css_common_connect (CSS_CONN_ENTRY * conn, unsigned short *rid,
 }
 
 /*
- * css_make_set_proc_register() - make a server proc register.
+ * css_set_proc_register() - make a server proc register.
  *   return:
  *   server_name(in):
  *   server_name_lenth(in):
  *   proc_register(out):
  */
 static void
-css_make_set_proc_register (const char *server_name, int server_name_length, CSS_SERVER_PROC_REGISTER * proc_register)
+css_set_proc_register (const char *server_name, int server_name_length, CSS_SERVER_PROC_REGISTER * proc_register)
 {
   char *p, *last;
   char **argv;
 
-  strncpy_bufsize (proc_register->server_name, server_name);
+  memcpy (proc_register->server_name, server_name, server_name_length);
   proc_register->server_name_length = htonl (server_name_length);
   proc_register->pid = htonl (getpid ());
   strncpy_bufsize (proc_register->exec_path, css_Exec_path);
@@ -1153,7 +1153,7 @@ css_connect_to_master_server (int master_port_id, const char *server_name, int n
     {
       // Linux and Unix
       connection_protocol = SERVER_REQUEST;
-      css_make_set_proc_register (server_name, name_length, &proc_register);
+      css_set_proc_register (server_name, name_length, &proc_register);
       data = (const char *) &proc_register;
       data_length = sizeof (proc_register);
     }
@@ -3171,6 +3171,7 @@ css_free_user_access_status (void)
 void
 css_set_exec_path (char *exec_path)
 {
+  assert (exec_path != NULL);
   strncpy (css_Exec_path, exec_path, sizeof (css_Exec_path) - 1);
 }
 
@@ -3183,5 +3184,6 @@ css_set_exec_path (char *exec_path)
 void
 css_set_argv (char **argv)
 {
+  assert (argv != NULL);
   css_Argv = argv;
 }

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -1122,6 +1122,7 @@ css_connect_to_master_server (int master_port_id, const char *server_name, int n
 #endif
   const char *data;
   int data_length;
+  CSS_SERVER_PROC_REGISTER proc_register = CSS_SERVER_PROC_REGISTER_INITIALIZER;
 
   css_Service_id = master_port_id;
   if (GETHOSTNAME (hname, CUB_MAXHOSTNAMELEN) != 0)

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -1122,7 +1122,7 @@ css_connect_to_master_server (int master_port_id, const char *server_name, int n
 #endif
   const char *data;
   int data_length;
-  CSS_SERVER_PROC_REGISTER proc_register;
+  CSS_SERVER_PROC_REGISTER proc_register = CSS_SERVER_PROC_REGISTER_INITIALIZER;
 
   css_Service_id = master_port_id;
   if (GETHOSTNAME (hname, CUB_MAXHOSTNAMELEN) != 0)

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -81,7 +81,6 @@
 #include "connection_sr.h"
 #include "server_support.h"
 #include "thread_manager.hpp"	// for thread_get_thread_entry_info
-#include "master_server_monitor.hpp"
 
 #ifdef PACKET_TRACE
 #define TRACE(string, arg)					\
@@ -1083,7 +1082,7 @@ css_common_connect (CSS_CONN_ENTRY * conn, unsigned short *rid,
  *   proc_register(out):
  */
 static void
-css_make_set_proc_register (const char *server_name, int server_name_length, SERVER_PROC_REGISTER * proc_register)
+css_make_set_proc_register (const char *server_name, int server_name_length, CSS_SERVER_PROC_REGISTER * proc_register)
 {
   char *p, *last;
   char **argv;
@@ -1123,7 +1122,7 @@ css_connect_to_master_server (int master_port_id, const char *server_name, int n
 #endif
   const char *data;
   int data_length;
-  SERVER_PROC_REGISTER proc_register;
+  CSS_SERVER_PROC_REGISTER proc_register;
 
   css_Service_id = master_port_id;
   if (GETHOSTNAME (hname, CUB_MAXHOSTNAMELEN) != 0)
@@ -1158,10 +1157,12 @@ css_connect_to_master_server (int master_port_id, const char *server_name, int n
       data = (const char *) &proc_register;
       data_length = sizeof (proc_register);
     }
+
   if (css_common_connect (conn, &rid, hname, connection_protocol, data, data_length, master_port_id) == NULL)
     {
       goto fail_end;
     }
+
   if (css_readn (conn->fd, (char *) &response_buff, sizeof (int), -1) != sizeof (int))
     {
       goto fail_end;

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -1122,7 +1122,6 @@ css_connect_to_master_server (int master_port_id, const char *server_name, int n
 #endif
   const char *data;
   int data_length;
-  CSS_SERVER_PROC_REGISTER proc_register = CSS_SERVER_PROC_REGISTER_INITIALIZER;
 
   css_Service_id = master_port_id;
   if (GETHOSTNAME (hname, CUB_MAXHOSTNAMELEN) != 0)

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -1140,7 +1140,7 @@ css_connect_to_master_server (int master_port_id, const char *server_name, int n
 
   /* select the connection protocol */
 
-  //  When supporting the Windows environment, It will be modified to send the same data
+  //  TODO : When supporting the Windows environment, It will be modified to send the same data
   //  (proc_register) for the Windows protocol (SERVER_REQUEST_NEW) as well.
 
   if (css_Server_use_new_connection_protocol)

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -149,8 +149,8 @@ CSS_THREAD_FN css_Request_handler = NULL;
 /* This will handle closed connection errors */
 CSS_THREAD_FN css_Connection_error_handler = NULL;
 
-static char css_Exec_path[PATH_MAX];
-static char **css_Argv;
+static char css_Server_exec_path[PATH_MAX];
+static char **css_Server_argv;
 
 #define CSS_CONN_IDX(conn_arg) ((conn_arg) - css_Conn_array)
 
@@ -1090,11 +1090,11 @@ css_set_proc_register (const char *server_name, int server_name_length, CSS_SERV
   memcpy (proc_register->server_name, server_name, server_name_length);
   proc_register->server_name_length = htonl (server_name_length);
   proc_register->pid = htonl (getpid ());
-  strncpy_bufsize (proc_register->exec_path, css_Exec_path);
+  strncpy_bufsize (proc_register->exec_path, css_Server_exec_path);
 
   p = (char *) &proc_register->args[0];
   last = (char *) (p + sizeof (proc_register->args));
-  for (argv = css_Argv; *argv; argv++)
+  for (argv = css_Server_argv; *argv; argv++)
     {
       p += snprintf (p, MAX ((last - p), 0), "%s ", *argv);
     }
@@ -3172,7 +3172,7 @@ void
 css_set_exec_path (char *exec_path)
 {
   assert (exec_path != NULL);
-  strncpy (css_Exec_path, exec_path, sizeof (css_Exec_path) - 1);
+  strncpy (css_Server_exec_path, exec_path, sizeof (css_Server_exec_path) - 1);
 }
 
 /*
@@ -3185,5 +3185,5 @@ void
 css_set_argv (char **argv)
 {
   assert (argv != NULL);
-  css_Argv = argv;
+  css_Server_argv = argv;
 }

--- a/src/connection/connection_sr.h
+++ b/src/connection/connection_sr.h
@@ -192,4 +192,7 @@ extern void css_set_user_access_status (const char *db_user, const char *host, c
 extern void css_get_user_access_status (int num_user, LAST_ACCESS_STATUS ** access_status_array);
 extern void css_free_user_access_status (void);
 
+extern void css_set_exec_path (char *exec_path);
+extern void css_set_argv (char **argv);
+
 #endif /* _CONNECTION_SR_H_ */

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -319,8 +319,8 @@ css_accept_server_request (CSS_CONN_ENTRY * conn, int reason)
  *   return: none
  *   conn(in)
  *   rid(in)
- *   proc_register(in)
- *   server_name_length(in)
+ *   buffer(in)
+ * 
  */
 static void
 css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
@@ -337,10 +337,10 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
   datagram_length = 0;
 
   css_accept_server_request (conn, SERVER_REQUEST_ACCEPTED);
-  fprintf (stdout, "css_accept_new_request\n");
+
   if (css_receive_data (conn, rid, &datagram, &datagram_length, -1) == NO_ERRORS)
     {
-      fprintf (stdout, "datagram: %s\n", datagram);
+
       if (datagram != NULL && css_tcp_master_datagram (datagram, &server_fd))
 	{
 	  datagram_conn = css_make_conn (server_fd);
@@ -454,7 +454,13 @@ css_register_new_server (CSS_CONN_ENTRY * conn, unsigned short rid)
   char *data = NULL;
   SOCKET_QUEUE_ENTRY *entry;
 
-  /* read server name */
+  // Note : css_register_new_server () is used at two situations.
+  //        1. When client request for connect a cub_server to cub_master which already registered.
+  //        2. When a new cub_server requests to register itself to cub_master.
+  //        For first situation, css_register_new_server receives server name as data,
+  //        For second situation, css_register_new_server receives SERVER_PROC_REGISTER as data.
+  //        css_register_new_server judge which case is by checking entry is NULL or not.
+
   if (css_receive_data (conn, rid, &data, &data_length, -1) == NO_ERRORS)
     {
       entry = css_return_entry_of_server (data, css_Master_socket_anchor);

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -59,6 +59,7 @@
 #include "error_manager.h"
 #include "connection_globals.h"
 #include "connection_cl.h"
+#include "connection_defs.h"
 #if defined(WINDOWS)
 #include "wintcp.h"
 #else /* ! WINDOWS */
@@ -485,7 +486,7 @@ css_register_new_server (CSS_CONN_ENTRY * conn, unsigned short rid)
 #if defined(DEBUG)
 	  css_Active_server_count++;
 #endif
-	  css_add_request_to_socket_queue (conn, false, server_name, conn->fd, READ_WRITE, 0,
+	  css_add_request_to_socket_queue (conn, false, data, conn->fd, READ_WRITE, 0,
 					   &css_Master_socket_anchor);
 
 #else /* ! WINDOWS */

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -337,6 +337,7 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
   int datagram_length;
   SOCKET server_fd = INVALID_SOCKET;
   int length;
+  int server_name_length;
   CSS_CONN_ENTRY *datagram_conn;
   SOCKET_QUEUE_ENTRY *entry;
   CSS_SERVER_PROC_REGISTER *proc_register = (CSS_SERVER_PROC_REGISTER *) buffer;
@@ -357,8 +358,11 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 #endif
 	  css_add_request_to_socket_queue (datagram_conn, false, proc_register->server_name, server_fd, READ_WRITE, 0,
 					   &css_Master_socket_anchor);
+
 	  length = (int) strlen (proc_register->server_name) + 1;
-	  if (length < proc_register->server_name_length)
+	  server_name_length = (int) ntohl (proc_register->server_name_length);
+
+	  if (length < server_name_length)
 	    {
 	      entry = css_return_entry_of_server (proc_register->server_name, css_Master_socket_anchor);
 	      if (entry != NULL)
@@ -389,7 +393,7 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 	  if (!entry->ha_mode)
 	    {
               /* *INDENT-OFF* */
-              master_Server_monitor->make_and_insert_server_entry (proc_register->pid, proc_register->exec_path, proc_register->args, datagram_conn);
+              master_Server_monitor->make_and_insert_server_entry (ntohl(proc_register->pid), proc_register->exec_path, proc_register->args, datagram_conn);
               /* *INDENT-ON* */
 	    }
 	}

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -66,7 +66,6 @@
 #endif /* ! WINDOWS */
 #include "master_util.h"
 #include "master_request.h"
-#include "system_parameter.h"
 #if !defined(WINDOWS)
 #include "master_heartbeat.h"
 #endif
@@ -130,12 +129,6 @@ pthread_mutex_t css_Master_socket_anchor_lock;
 pthread_mutex_t css_Master_er_log_lock = PTHREAD_MUTEX_INITIALIZER;
 pthread_mutex_t css_Master_er_log_enable_lock = PTHREAD_MUTEX_INITIALIZER;
 bool css_Master_er_log_enabled = true;
-
-#if !defined(WINDOWS)
-/* *INDENT-OFF* */
-std::unique_ptr<server_monitor> master_Server_monitor = nullptr;
-/* *INDENT-ON* */
-#endif
 
 /*
  * css_master_error() - print error message to syslog or console
@@ -363,7 +356,7 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 	  //  packed from css_pack_server_name(). Since there are some cases that returns server_name and server_name_length
 	  //  as NULL, we need to check if server_name is packed information or not.
 	  length = (int) strlen (proc_register->server_name) + 1;
-	  server_name_length = (int) ntohl (proc_register->server_name_length);
+	  server_name_length = proc_register->server_name_length;
 
 	  if (length < server_name_length)
 	    {
@@ -393,10 +386,11 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 		    }
 		}
 	    }
+
 	  if (!entry->ha_mode)
 	    {
               /* *INDENT-OFF* */
-              master_Server_monitor->make_and_insert_server_entry (ntohl(proc_register->pid), proc_register->exec_path, proc_register->args, datagram_conn);
+              master_Server_monitor->make_and_insert_server_entry (proc_register->pid, proc_register->exec_path, proc_register->args, datagram_conn);
               /* *INDENT-ON* */
 	    }
 	}

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -59,7 +59,6 @@
 #include "error_manager.h"
 #include "connection_globals.h"
 #include "connection_cl.h"
-#include "connection_defs.h"
 #if defined(WINDOWS)
 #include "wintcp.h"
 #else /* ! WINDOWS */
@@ -67,6 +66,7 @@
 #endif /* ! WINDOWS */
 #include "master_util.h"
 #include "master_request.h"
+#include "system_parameter.h"
 #if !defined(WINDOWS)
 #include "master_heartbeat.h"
 #endif

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -131,6 +131,9 @@ pthread_mutex_t css_Master_er_log_lock = PTHREAD_MUTEX_INITIALIZER;
 pthread_mutex_t css_Master_er_log_enable_lock = PTHREAD_MUTEX_INITIALIZER;
 bool css_Master_er_log_enabled = true;
 
+/* *INDENT-OFF* */
+std::unique_ptr<server_monitor> master_Server_monitor = nullptr;
+/* *INDENT-ON* */
 /*
  * css_master_error() - print error message to syslog or console
  *   return: none

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -486,8 +486,7 @@ css_register_new_server (CSS_CONN_ENTRY * conn, unsigned short rid)
 #if defined(DEBUG)
 	  css_Active_server_count++;
 #endif
-	  css_add_request_to_socket_queue (conn, false, data, conn->fd, READ_WRITE, 0,
-					   &css_Master_socket_anchor);
+	  css_add_request_to_socket_queue (conn, false, data, conn->fd, READ_WRITE, 0, &css_Master_socket_anchor);
 
 #else /* ! WINDOWS */
 	  /* accept a request from a new server */

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -326,6 +326,7 @@ static void
 css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 {
   char *datagram;
+  char *server_name;
   int datagram_length;
   SOCKET server_fd = INVALID_SOCKET;
   int length;
@@ -355,7 +356,7 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 	      entry = css_return_entry_of_server (proc_register->server_name, css_Master_socket_anchor);
 	      if (entry != NULL)
 		{
-		  char *server_name = proc_register->server_name + length;
+		  server_name = proc_register->server_name + length;
 		  entry->version_string = (char *) malloc (strlen (server_name) + 1);
 		  if (entry->version_string != NULL)
 		    {
@@ -389,6 +390,10 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
   if (datagram)
     {
       free_and_init (datagram);
+    }
+  if (proc_register)
+    {
+      free_and_init (proc_register);
     }
 }
 
@@ -454,12 +459,12 @@ css_register_new_server (CSS_CONN_ENTRY * conn, unsigned short rid)
   char *data = NULL;
   SOCKET_QUEUE_ENTRY *entry;
 
-  // Note : css_register_new_server () is used at two situations.
-  //        1. When client request for connect a cub_server to cub_master which already registered.
-  //        2. When a new cub_server requests to register itself to cub_master.
-  //        For first situation, css_register_new_server receives server name as data,
-  //        For second situation, css_register_new_server receives SERVER_PROC_REGISTER as data.
-  //        css_register_new_server judge which case is by checking entry is NULL or not.
+  //  Note: css_register_new_server() is used in two situations:
+  //  1. When a client requests to connect a cub_server to cub_master, which is already registered.
+  //  2. When a new cub_server requests to register itself to cub_master.
+  //  For the first situation, css_register_new_server() receives the server name as data.
+  //  For the second situation, css_register_new_server() receives SERVER_PROC_REGISTER as data.
+  //  css_register_new_server determines which case it is by checking if the entry is NULL or not.
 
   if (css_receive_data (conn, rid, &data, &data_length, -1) == NO_ERRORS)
     {

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -359,6 +359,9 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 	  css_add_request_to_socket_queue (datagram_conn, false, proc_register->server_name, server_fd, READ_WRITE, 0,
 					   &css_Master_socket_anchor);
 
+	  //  Note : server_name is usually packed(appended) information of server_name, version_string, env_var, pid,
+	  //  packed from css_pack_server_name(). Since there are some cases that returns server_name and server_name_length
+	  //  as NULL, we need to check if server_name is packed information or not.
 	  length = (int) strlen (proc_register->server_name) + 1;
 	  server_name_length = (int) ntohl (proc_register->server_name_length);
 

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -391,10 +391,6 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
     {
       free_and_init (datagram);
     }
-  if (proc_register)
-    {
-      free_and_init (proc_register);
-    }
 }
 
 /*

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -339,7 +339,7 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
   int length;
   CSS_CONN_ENTRY *datagram_conn;
   SOCKET_QUEUE_ENTRY *entry;
-  SERVER_PROC_REGISTER *proc_register = (SERVER_PROC_REGISTER *) buffer;
+  CSS_SERVER_PROC_REGISTER *proc_register = (CSS_SERVER_PROC_REGISTER *) buffer;
 
   datagram = NULL;
   datagram_length = 0;
@@ -466,7 +466,7 @@ css_register_new_server (CSS_CONN_ENTRY * conn, unsigned short rid)
   //  1. When a client requests to connect a cub_server to cub_master, which is already registered.
   //  2. When a new cub_server requests to register itself to cub_master.
   //  For the first situation, css_register_new_server() receives the server name as data.
-  //  For the second situation, css_register_new_server() receives SERVER_PROC_REGISTER as data.
+  //  For the second situation, css_register_new_server() receives CSS_SERVER_PROC_REGISTER as data.
   //  css_register_new_server determines which case it is by checking if the entry is NULL or not.
 
   if (css_receive_data (conn, rid, &data, &data_length, -1) == NO_ERRORS)

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -131,9 +131,12 @@ pthread_mutex_t css_Master_er_log_lock = PTHREAD_MUTEX_INITIALIZER;
 pthread_mutex_t css_Master_er_log_enable_lock = PTHREAD_MUTEX_INITIALIZER;
 bool css_Master_er_log_enabled = true;
 
+#if !defined(WINDOWS)
 /* *INDENT-OFF* */
 std::unique_ptr<server_monitor> master_Server_monitor = nullptr;
 /* *INDENT-ON* */
+#endif
+
 /*
  * css_master_error() - print error message to syslog or console
  *   return: none
@@ -1241,7 +1244,6 @@ main (int argc, char **argv)
 	  goto cleanup;
 	}
     }
-#endif
 
   // TODO : When no non-HA server exists in HA environment, server_monitor should not be initialized.
   //        In this issue, server_monitor is initialized only when HA is disabled. Once all sub-tasks of
@@ -1254,6 +1256,7 @@ main (int argc, char **argv)
       master_Server_monitor.reset (new server_monitor ());
       // *INDENT-ON*
     }
+#endif
 
   conn = css_make_conn (css_Master_socket_fd[0]);
   css_add_request_to_socket_queue (conn, false, NULL, css_Master_socket_fd[0], READ_WRITE, 0,

--- a/src/executables/master_request.c
+++ b/src/executables/master_request.c
@@ -725,6 +725,7 @@ css_process_shutdown (char *time_buffer)
 	  master_Server_monitor->remove_server_entry_by_conn (temp->conn_ptr);
 #endif
 	  css_process_start_shutdown (temp, timeout * 60, buffer);
+
 	  /* wait process terminated */
 	  master_util_wait_proc_terminate (temp->pid);
 	}

--- a/src/executables/master_request.c
+++ b/src/executables/master_request.c
@@ -56,6 +56,7 @@
 #include "master_util.h"
 #include "master_request.h"
 #include "master_heartbeat.h"
+#include "master_server_monitor.hpp"
 
 #if defined (SUPPRESS_STRLEN_WARNING)
 #define strlen(s1)  ((int) strlen(s1))
@@ -531,6 +532,7 @@ css_process_kill_slave (CSS_CONN_ENTRY * conn, unsigned short request_id, char *
 			    msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_MASTER, MASTER_MSG_SERVER_STATUS),
 			    server_name, timeout);
 		  css_process_start_shutdown (temp, timeout * 60, buffer);
+		  master_Server_monitor->remove_server_entry_by_conn (temp->conn_ptr);
 		}
 	      snprintf (buffer, MASTER_TO_SRV_MSG_SIZE,
 			msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_MASTER, MASTER_MSG_SERVER_NOTIFIED),
@@ -718,7 +720,7 @@ css_process_shutdown (char *time_buffer)
 	  && !IS_MASTER_CONN_NAME_HA_COPYLOG (temp->name) && !IS_MASTER_CONN_NAME_HA_APPLYLOG (temp->name))
 	{
 	  css_process_start_shutdown (temp, timeout * 60, buffer);
-
+	  master_Server_monitor->remove_server_entry_by_conn (temp->conn_ptr);
 	  /* wait process terminated */
 	  master_util_wait_proc_terminate (temp->pid);
 	}

--- a/src/executables/master_request.c
+++ b/src/executables/master_request.c
@@ -531,10 +531,10 @@ css_process_kill_slave (CSS_CONN_ENTRY * conn, unsigned short request_id, char *
 		  snprintf (buffer, MASTER_TO_SRV_MSG_SIZE,
 			    msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_MASTER, MASTER_MSG_SERVER_STATUS),
 			    server_name, timeout);
-		  css_process_start_shutdown (temp, timeout * 60, buffer);
 #if !defined(WINDOWS)
 		  master_Server_monitor->remove_server_entry_by_conn (temp->conn_ptr);
 #endif
+		  css_process_start_shutdown (temp, timeout * 60, buffer);
 		}
 	      snprintf (buffer, MASTER_TO_SRV_MSG_SIZE,
 			msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_MASTER, MASTER_MSG_SERVER_NOTIFIED),
@@ -721,10 +721,10 @@ css_process_shutdown (char *time_buffer)
 	  && !IS_MASTER_CONN_NAME_DRIVER (temp->name) && !IS_MASTER_CONN_NAME_HA_SERVER (temp->name)
 	  && !IS_MASTER_CONN_NAME_HA_COPYLOG (temp->name) && !IS_MASTER_CONN_NAME_HA_APPLYLOG (temp->name))
 	{
-	  css_process_start_shutdown (temp, timeout * 60, buffer);
 #if !defined(WINDOWS)
 	  master_Server_monitor->remove_server_entry_by_conn (temp->conn_ptr);
 #endif
+	  css_process_start_shutdown (temp, timeout * 60, buffer);
 	  /* wait process terminated */
 	  master_util_wait_proc_terminate (temp->pid);
 	}

--- a/src/executables/master_request.c
+++ b/src/executables/master_request.c
@@ -532,7 +532,9 @@ css_process_kill_slave (CSS_CONN_ENTRY * conn, unsigned short request_id, char *
 			    msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_MASTER, MASTER_MSG_SERVER_STATUS),
 			    server_name, timeout);
 		  css_process_start_shutdown (temp, timeout * 60, buffer);
+#if !defined(WINDOWS)
 		  master_Server_monitor->remove_server_entry_by_conn (temp->conn_ptr);
+#endif
 		}
 	      snprintf (buffer, MASTER_TO_SRV_MSG_SIZE,
 			msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_MASTER, MASTER_MSG_SERVER_NOTIFIED),
@@ -720,7 +722,9 @@ css_process_shutdown (char *time_buffer)
 	  && !IS_MASTER_CONN_NAME_HA_COPYLOG (temp->name) && !IS_MASTER_CONN_NAME_HA_APPLYLOG (temp->name))
 	{
 	  css_process_start_shutdown (temp, timeout * 60, buffer);
+#if !defined(WINDOWS)
 	  master_Server_monitor->remove_server_entry_by_conn (temp->conn_ptr);
+#endif
 	  /* wait process terminated */
 	  master_util_wait_proc_terminate (temp->pid);
 	}

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -25,6 +25,8 @@
 
 #include "master_server_monitor.hpp"
 
+std::unique_ptr<server_monitor> master_Server_monitor = nullptr;
+
 server_monitor::server_monitor ()
 {
   m_server_entry_list = std::make_unique<std::list<server_entry>> ();

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -21,6 +21,7 @@
 //
 
 #include <sstream>
+#include <algorithm>
 
 #include "master_server_monitor.hpp"
 
@@ -68,6 +69,16 @@ server_monitor::make_and_insert_server_entry (int pid, const char *exec_path, ch
   m_server_entry_list->push_back (temp);
   fprintf (stdout, "server_entry is registerd in server_entry_list : pid : %d, exec_path : %s, args : %s\n", pid,
 	   exec_path, args);
+}
+
+void
+server_monitor::remove_server_entry_by_conn (CSS_CONN_ENTRY *conn)
+{
+  m_server_entry_list->erase (remove_if (m_server_entry_list->begin(),
+					 m_server_entry_list->end(), [conn] (auto e) -> bool {return e.m_conn == conn;}));
+
+  fprintf (stdout, "server_entry is removed from server_entry_list, Current monitoring server in list: %d\n",
+	   m_server_entry_list->size ());
 }
 
 server_monitor::server_entry::

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -77,7 +77,7 @@ server_monitor::remove_server_entry_by_conn (CSS_CONN_ENTRY *conn)
   m_server_entry_list->erase (remove_if (m_server_entry_list->begin(),
 					 m_server_entry_list->end(), [conn] (auto e) -> bool {return e.m_conn == conn;}));
 
-  fprintf (stdout, "server has been removed from master_Server_monitor. Number of monitoring server in monitor: %d\n",
+  fprintf (stdout, "server has been removed from master_Server_monitor. Number of server in master_Server_monitor: %d\n",
 	   m_server_entry_list->size ());
 }
 

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -100,7 +100,7 @@ server_entry (int pid, const char *exec_path, char *args, CSS_CONN_ENTRY *conn)
 }
 
 CSS_CONN_ENTRY *
-server_monitor::server_entry::get_conn ()
+server_monitor::server_entry::get_conn () const
 {
   return m_conn;
 }

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -67,7 +67,7 @@ server_monitor::make_and_insert_server_entry (int pid, const char *exec_path, ch
 {
   server_entry temp (pid, exec_path, args, conn);
   m_server_entry_list->push_back (temp);
-  fprintf (stdout, "server_entry is registerd in server_entry_list : pid : %d, exec_path : %s, args : %s\n", pid,
+  fprintf (stdout, "server has been registered into master_Server_monitor : pid : %d, exec_path : %s, args : %s\n", pid,
 	   exec_path, args);
 }
 
@@ -77,7 +77,7 @@ server_monitor::remove_server_entry_by_conn (CSS_CONN_ENTRY *conn)
   m_server_entry_list->erase (remove_if (m_server_entry_list->begin(),
 					 m_server_entry_list->end(), [conn] (auto e) -> bool {return e.m_conn == conn;}));
 
-  fprintf (stdout, "server_entry is removed from server_entry_list, Current monitoring server in list: %d\n",
+  fprintf (stdout, "server has been removed from master_Server_monitor. Number of monitoring server in monitor: %d\n",
 	   m_server_entry_list->size ());
 }
 

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -97,6 +97,12 @@ server_entry (int pid, const char *exec_path, char *args, CSS_CONN_ENTRY *conn)
     }
 }
 
+CSS_CONN_ENTRY *
+server_monitor::server_entry::get_conn ()
+{
+  return m_conn;
+}
+
 void
 server_monitor::server_entry::proc_make_arg (char *args)
 {

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -28,7 +28,7 @@
 server_monitor::server_monitor ()
 {
   m_server_entry_list = std::make_unique<std::vector<server_entry>> ();
-  fprintf (stdout, "server_entry_list is created. \n");
+  fprintf (stdout, "[SERVER_REVIVE_DEBUG] : server_entry_list is created. \n");
 
   m_thread_shutdown = false;
   m_monitoring_thread = std::make_unique<std::thread> ([this]()
@@ -39,7 +39,7 @@ server_monitor::server_monitor ()
       }
   });
 
-  fprintf (stdout, "server_monitor_thread is created. \n");
+  fprintf (stdout, "[SERVER_REVIVE_DEBUG] : server_monitor_thread is created. \n");
   fflush (stdout);
 }
 
@@ -51,11 +51,11 @@ server_monitor::~server_monitor ()
   if (m_monitoring_thread->joinable())
     {
       m_monitoring_thread->join();
-      fprintf (stdout, "server_monitor_thread is terminated. \n");
+      fprintf (stdout, "[SERVER_REVIVE_DEBUG] : server_monitor_thread is terminated. \n");
     }
 
   assert (m_server_entry_list->size () == 0);
-  fprintf (stdout, "server_entry_list is deleted. \n");
+  fprintf (stdout, "[SERVER_REVIVE_DEBUG] : server_entry_list is deleted. \n");
   fflush (stdout);
 }
 
@@ -64,17 +64,26 @@ server_monitor::make_and_insert_server_entry (int pid, const char *exec_path, ch
     CSS_CONN_ENTRY *conn)
 {
   m_server_entry_list->emplace_back (pid, exec_path, args, conn);
-  fprintf (stdout, "server has been registered into master_Server_monitor : pid : %d, exec_path : %s, args : %s\n", pid,
+  fprintf (stdout,
+	   "[SERVER_REVIVE_DEBUG] : server has been registered into master_Server_monitor : pid : %d, exec_path : %s, args : %s\n",
+	   pid,
 	   exec_path, args);
 }
 
 void
 server_monitor::remove_server_entry_by_conn (CSS_CONN_ENTRY *conn)
 {
+#if defined(DEBUG)
+  size_t org_size = m_server_entry_list->size ();
+#endif
   m_server_entry_list->erase (std::remove_if (m_server_entry_list->begin(),
 			      m_server_entry_list->end(), [conn] (auto e) -> bool {return e.m_conn == conn;}));
 
-  fprintf (stdout, "server has been removed from master_Server_monitor. Number of server in master_Server_monitor: %d\n",
+#if defined(DEBUG)
+  assert (org_size > m_server_entry_list->size ());
+#endif
+  fprintf (stdout,
+	   "[SERVER_REVIVE_DEBUG] : server has been removed from master_Server_monitor. Number of server in master_Server_monitor: %d\n",
 	   m_server_entry_list->size ());
 }
 

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -25,7 +25,7 @@
 
 #include "master_server_monitor.hpp"
 
-std::unique_ptr<server_monitor> master_Server_monitor = nullptr;
+
 
 server_monitor::server_monitor ()
 {

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -60,10 +60,19 @@ server_monitor::~server_monitor ()
   fflush (stdout);
 }
 
+void
+server_monitor::make_and_insert_server_entry (int pid, const char *exec_path, char *args,
+    CSS_CONN_ENTRY *conn)
+{
+  server_entry temp (pid, exec_path, args, conn);
+  m_server_entry_list->push_back (temp);
+  fprintf (stdout, "server_entry is registerd in server_entry_list : pid : %d, exec_path : %s, args : %s\n", pid,
+	   exec_path, args);
+}
+
 server_monitor::server_entry::
-server_entry (int pid, const char *server_name, const char *exec_path, char *args, CSS_CONN_ENTRY *conn)
+server_entry (int pid, const char *exec_path, char *args, CSS_CONN_ENTRY *conn)
   : m_pid {pid}
-  , m_server_name {server_name}
   , m_exec_path {exec_path}
   , m_conn {conn}
   , m_last_revive_time {0, 0}

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -27,7 +27,7 @@
 
 server_monitor::server_monitor ()
 {
-  m_server_entry_list = std::make_unique<std::vector<server_entry>> ();
+  m_server_entry_list = std::make_unique<std::list<server_entry>> ();
   fprintf (stdout, "[SERVER_REVIVE_DEBUG] : server_entry_list is created. \n");
 
   m_thread_shutdown = false;
@@ -73,15 +73,12 @@ server_monitor::make_and_insert_server_entry (int pid, const char *exec_path, ch
 void
 server_monitor::remove_server_entry_by_conn (CSS_CONN_ENTRY *conn)
 {
+  const auto result = std::remove_if (m_server_entry_list->begin(), m_server_entry_list->end(),
+				      [conn] (auto e) -> bool {return e.m_conn == conn;});
 #if defined(DEBUG)
-  size_t org_size = m_server_entry_list->size ();
+  assert (result != m_server_entry_list->end ());
 #endif
-  m_server_entry_list->erase (std::remove_if (m_server_entry_list->begin(),
-			      m_server_entry_list->end(), [conn] (auto e) -> bool {return e.m_conn == conn;}));
-
-#if defined(DEBUG)
-  assert (org_size > m_server_entry_list->size ());
-#endif
+  m_server_entry_list->erase (result, m_server_entry_list->end());
   fprintf (stdout,
 	   "[SERVER_REVIVE_DEBUG] : server has been removed from master_Server_monitor. Number of server in master_Server_monitor: %d\n",
 	   m_server_entry_list->size ());

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -76,7 +76,7 @@ void
 server_monitor::remove_server_entry_by_conn (CSS_CONN_ENTRY *conn)
 {
   const auto result = std::remove_if (m_server_entry_list->begin(), m_server_entry_list->end(),
-				      [conn] (auto e) -> bool {return e.get_conn() == conn;});
+				      [conn] (auto& e) -> bool {return e.get_conn() == conn;});
   assert (result != m_server_entry_list->end ());
 
   m_server_entry_list->erase (result, m_server_entry_list->end());

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -74,10 +74,9 @@ void
 server_monitor::remove_server_entry_by_conn (CSS_CONN_ENTRY *conn)
 {
   const auto result = std::remove_if (m_server_entry_list->begin(), m_server_entry_list->end(),
-				      [conn] (auto e) -> bool {return e.m_conn == conn;});
-#if defined(DEBUG)
+				      [conn] (auto e) -> bool {return e.get_conn() == conn;});
   assert (result != m_server_entry_list->end ());
-#endif
+
   m_server_entry_list->erase (result, m_server_entry_list->end());
   fprintf (stdout,
 	   "[SERVER_REVIVE_DEBUG] : server has been removed from master_Server_monitor. Number of server in master_Server_monitor: %d\n",

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -63,8 +63,7 @@ void
 server_monitor::make_and_insert_server_entry (int pid, const char *exec_path, char *args,
     CSS_CONN_ENTRY *conn)
 {
-  server_entry temp (pid, exec_path, args, conn);
-  m_server_entry_list->push_back (temp);
+  m_server_entry_list->emplace_back (pid, exec_path, args, conn);
   fprintf (stdout, "server has been registered into master_Server_monitor : pid : %d, exec_path : %s, args : %s\n", pid,
 	   exec_path, args);
 }
@@ -72,8 +71,8 @@ server_monitor::make_and_insert_server_entry (int pid, const char *exec_path, ch
 void
 server_monitor::remove_server_entry_by_conn (CSS_CONN_ENTRY *conn)
 {
-  m_server_entry_list->erase (remove_if (m_server_entry_list->begin(),
-					 m_server_entry_list->end(), [conn] (auto e) -> bool {return e.m_conn == conn;}));
+  m_server_entry_list->erase (std::remove_if (m_server_entry_list->begin(),
+			      m_server_entry_list->end(), [conn] (auto e) -> bool {return e.m_conn == conn;}));
 
   fprintf (stdout, "server has been removed from master_Server_monitor. Number of server in master_Server_monitor: %d\n",
 	   m_server_entry_list->size ());

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -25,8 +25,6 @@
 
 #include "master_server_monitor.hpp"
 
-
-
 server_monitor::server_monitor ()
 {
   m_server_entry_list = std::make_unique<std::vector<server_entry>> ();

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -30,12 +30,6 @@
 #include <time.h>
 #include "connection_defs.h"
 
-#define SERVER_MAX_SZ_SERVER_NAME           (256)
-#define SERVER_MAX_SZ_PROC_EXEC_PATH        (128)
-#define SERVER_MAX_SZ_PROC_ARGV             (64)
-#define SERVER_MAX_NUM_PROC_ARGV            (16)
-#define SERVER_MAX_SZ_PROC_ARGS             (SERVER_MAX_NUM_PROC_ARGV*SERVER_MAX_SZ_PROC_ARGV)
-
 class server_monitor
 {
   public:
@@ -44,18 +38,12 @@ class server_monitor
       public:
 	server_entry (int pid, const char *exec_path, char *args, CSS_CONN_ENTRY *conn);
 	~server_entry () {};
-	server_entry &operator= (const server_entry &other)
-	{
-	  if (this != &other)
-	    {
-	      m_exec_path = other.m_exec_path;
-	      m_argv = other.m_argv;
-	      m_conn = other.m_conn;
-	      m_last_revive_time = other.m_last_revive_time;
-	      m_need_revive = other.m_need_revive;
-	    }
-	  return *this;
-	}
+
+	server_entry &operator= (const server_entry &) = default;
+	server_entry &operator= (server_entry &&) = default;
+
+	server_entry (const server_entry &) = default;
+	server_entry (server_entry &&) = delete;
 
 	CSS_CONN_ENTRY *m_conn;                       // connection entry of server process
 
@@ -96,12 +84,28 @@ class server_monitor
 typedef struct server_proc_register SERVER_PROC_REGISTER;
 struct server_proc_register
 {
+  static constexpr int SERVER_MAX_SZ_SERVER_NAME = 256;
+  static constexpr int SERVER_MAX_SZ_PROC_EXEC_PATH = 128;
+  static constexpr int SERVER_MAX_SZ_PROC_ARGS = 1024;
+
   char server_name[SERVER_MAX_SZ_SERVER_NAME];
   int server_name_length;
   int pid;
   char exec_path[SERVER_MAX_SZ_PROC_EXEC_PATH];
   char args[SERVER_MAX_SZ_PROC_ARGS];
+
+  inline server_proc_register ();
 };
 
 extern std::unique_ptr<server_monitor> master_Server_monitor;
+
+server_proc_register::server_proc_register ()
+  : server_name_length (0)
+  , pid (0)
+{
+  memset (server_name, 0, SERVER_MAX_SZ_SERVER_NAME);
+  memset (exec_path, 0, SERVER_MAX_SZ_PROC_EXEC_PATH);
+  memset (args, 0, SERVER_MAX_SZ_PROC_ARGS);
+}
+
 #endif

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -47,7 +47,10 @@ class server_monitor
 	server_entry &operator= (const server_entry &) = delete;
 	server_entry &operator= (server_entry &&) = default;
 
-	CSS_CONN_ENTRY *m_conn;                       // connection entry of server process
+	CSS_CONN_ENTRY *get_conn ()
+	{
+	  return m_conn;
+	}
 
       private:
 	void proc_make_arg (char *args);
@@ -55,6 +58,7 @@ class server_monitor
 	int m_pid;                                    // process ID of server process
 	std::string m_exec_path;                      // executable path of server process
 	std::vector<std::string> m_argv;              // arguments of server process
+	CSS_CONN_ENTRY *m_conn;                       // connection entry of server process
 	timeval m_last_revive_time;                   // latest revive time
 	bool m_need_revive;                           // need to revive (true if the server is abnormally terminated)
     };

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -45,14 +45,33 @@ class server_monitor
 	server_entry (int pid, const char *exec_path, char *args, CSS_CONN_ENTRY *conn);
 	~server_entry () {};
 
+	server_entry (const server_entry &) = delete;
+	server_entry (server_entry &&) = delete;
+
+	server_entry &operator= (const server_entry &other)
+	{
+	  if (this != &other)
+	    {
+	      m_server_name = other.m_server_name;
+	      m_exec_path = other.m_exec_path;
+	      m_argv = other.m_argv;
+	      m_conn = other.m_conn;
+	      m_last_revive_time = other.m_last_revive_time;
+	      m_need_revive = other.m_need_revive;
+	    }
+	  return *this;
+	}
+	server_entry &operator= (server_entry &&other) = delete;
+
+	CSS_CONN_ENTRY *m_conn;                       // connection entry of server process
+
       private:
 	void proc_make_arg (char *args);
 
-	const int m_pid;                              // process ID
-	const std::string m_server_name;              // server name
-	const std::string m_exec_path;                // executable path of server process
+	int m_pid;                              // process ID
+	std::string m_server_name;              // server name
+	std::string m_exec_path;                // executable path of server process
 	std::vector<std::string> m_argv;              // arguments of server process
-	CSS_CONN_ENTRY *m_conn;                       // connection entry of server process
 	timeval m_last_revive_time;                   // latest revive time
 	bool m_need_revive;                           // need to revive (true if the server is abnormally terminated)
     };
@@ -68,6 +87,7 @@ class server_monitor
 
     void make_and_insert_server_entry (int pid, const char *exec_path, char *args,
 				       CSS_CONN_ENTRY *conn);
+    void remove_server_entry_by_conn (CSS_CONN_ENTRY *conn);
 
   private:
     std::unique_ptr<std::vector <server_entry>> m_server_entry_list;    // list of server entries

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -41,7 +41,7 @@ class server_monitor
 	server_entry (int pid, const char *exec_path, char *args, CSS_CONN_ENTRY *conn);
 	~server_entry () {};
 
-	server_entry (const server_entry &) = default;
+	server_entry (const server_entry &) = delete;
 	server_entry (server_entry &&) = delete;
 
 	server_entry &operator= (const server_entry &) = delete;

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -43,7 +43,7 @@ class server_monitor
 	server_entry &operator= (server_entry &&) = default;
 
 	server_entry (const server_entry &) = default;
-	server_entry (server_entry &&) = delete;
+	server_entry (server_entry &&) = default;
 
 	CSS_CONN_ENTRY *m_conn;                       // connection entry of server process
 

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -29,6 +29,7 @@
 #include <memory>
 #include <time.h>
 #include "connection_defs.h"
+#include "connection_globals.h"
 
 class server_monitor
 {
@@ -76,36 +77,5 @@ class server_monitor
     volatile bool m_thread_shutdown;                                    // flag to shutdown monitoring thread
 };
 
-/*
- * server register resource message body
- */
-
-/* process register */
-typedef struct server_proc_register SERVER_PROC_REGISTER;
-struct server_proc_register
-{
-  static constexpr int SERVER_MAX_SZ_SERVER_NAME = 256;
-  static constexpr int SERVER_MAX_SZ_PROC_EXEC_PATH = 128;
-  static constexpr int SERVER_MAX_SZ_PROC_ARGS = 1024;
-
-  char server_name[SERVER_MAX_SZ_SERVER_NAME];
-  int server_name_length;
-  int pid;
-  char exec_path[SERVER_MAX_SZ_PROC_EXEC_PATH];
-  char args[SERVER_MAX_SZ_PROC_ARGS];
-
-  inline server_proc_register ();
-};
-
 extern std::unique_ptr<server_monitor> master_Server_monitor;
-
-server_proc_register::server_proc_register ()
-  : server_name_length (0)
-  , pid (0)
-{
-  memset (server_name, 0, SERVER_MAX_SZ_SERVER_NAME);
-  memset (exec_path, 0, SERVER_MAX_SZ_PROC_EXEC_PATH);
-  memset (args, 0, SERVER_MAX_SZ_PROC_ARGS);
-}
-
 #endif

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -52,7 +52,6 @@ class server_monitor
 	{
 	  if (this != &other)
 	    {
-	      m_server_name = other.m_server_name;
 	      m_exec_path = other.m_exec_path;
 	      m_argv = other.m_argv;
 	      m_conn = other.m_conn;
@@ -68,9 +67,8 @@ class server_monitor
       private:
 	void proc_make_arg (char *args);
 
-	int m_pid;                              // process ID
-	std::string m_server_name;              // server name
-	std::string m_exec_path;                // executable path of server process
+	int m_pid;                                    // process ID of server process
+	std::string m_exec_path;                      // executable path of server process
 	std::vector<std::string> m_argv;              // arguments of server process
 	timeval m_last_revive_time;                   // latest revive time
 	bool m_need_revive;                           // need to revive (true if the server is abnormally terminated)
@@ -95,11 +93,6 @@ class server_monitor
     volatile bool m_thread_shutdown;                                    // flag to shutdown monitoring thread
 };
 
-/*
- * server register resource message body
- */
-
-/* process register */
 typedef struct server_proc_register SERVER_PROC_REGISTER;
 struct server_proc_register
 {

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -40,11 +40,11 @@ class server_monitor
 	server_entry (int pid, const char *exec_path, char *args, CSS_CONN_ENTRY *conn);
 	~server_entry () {};
 
-	server_entry &operator= (const server_entry &) = default;
-	server_entry &operator= (server_entry &&) = default;
-
 	server_entry (const server_entry &) = default;
 	server_entry (server_entry &&) = default;
+
+	server_entry &operator= (const server_entry &) = default;
+	server_entry &operator= (server_entry &&) = default;
 
 	CSS_CONN_ENTRY *m_conn;                       // connection entry of server process
 

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -26,6 +26,7 @@
 #include <cstring>
 #include <thread>
 #include <vector>
+#include <list>
 #include <memory>
 #include <time.h>
 #include "connection_defs.h"
@@ -41,9 +42,9 @@ class server_monitor
 	~server_entry () {};
 
 	server_entry (const server_entry &) = default;
-	server_entry (server_entry &&) = default;
+	server_entry (server_entry &&) = delete;
 
-	server_entry &operator= (const server_entry &) = default;
+	server_entry &operator= (const server_entry &) = delete;
 	server_entry &operator= (server_entry &&) = default;
 
 	CSS_CONN_ENTRY *m_conn;                       // connection entry of server process
@@ -72,7 +73,7 @@ class server_monitor
     void remove_server_entry_by_conn (CSS_CONN_ENTRY *conn);
 
   private:
-    std::unique_ptr<std::vector <server_entry>> m_server_entry_list;    // list of server entries
+    std::unique_ptr<std::list <server_entry>> m_server_entry_list;      // list of server entries
     std::unique_ptr<std::thread> m_monitoring_thread;                   // monitoring thread
     volatile bool m_thread_shutdown;                                    // flag to shutdown monitoring thread
 };

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -44,10 +44,6 @@ class server_monitor
       public:
 	server_entry (int pid, const char *exec_path, char *args, CSS_CONN_ENTRY *conn);
 	~server_entry () {};
-
-	server_entry (const server_entry &) = delete;
-	server_entry (server_entry &&) = delete;
-
 	server_entry &operator= (const server_entry &other)
 	{
 	  if (this != &other)
@@ -60,7 +56,6 @@ class server_monitor
 	    }
 	  return *this;
 	}
-	server_entry &operator= (server_entry &&other) = delete;
 
 	CSS_CONN_ENTRY *m_conn;                       // connection entry of server process
 
@@ -93,6 +88,11 @@ class server_monitor
     volatile bool m_thread_shutdown;                                    // flag to shutdown monitoring thread
 };
 
+/*
+ * server register resource message body
+ */
+
+/* process register */
 typedef struct server_proc_register SERVER_PROC_REGISTER;
 struct server_proc_register
 {

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -47,10 +47,7 @@ class server_monitor
 	server_entry &operator= (const server_entry &) = delete;
 	server_entry &operator= (server_entry &&) = default;
 
-	CSS_CONN_ENTRY *get_conn ()
-	{
-	  return m_conn;
-	}
+	CSS_CONN_ENTRY *get_conn ();
 
       private:
 	void proc_make_arg (char *args);

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -30,20 +30,20 @@
 #include <time.h>
 #include "connection_defs.h"
 
+#define SERVER_MAX_SZ_SERVER_NAME           (256)
+#define SERVER_MAX_SZ_PROC_EXEC_PATH        (128)
+#define SERVER_MAX_SZ_PROC_ARGV             (64)
+#define SERVER_MAX_NUM_PROC_ARGV            (16)
+#define SERVER_MAX_SZ_PROC_ARGS             (SERVER_MAX_NUM_PROC_ARGV*SERVER_MAX_SZ_PROC_ARGV)
+
 class server_monitor
 {
   public:
     class server_entry
     {
       public:
-	server_entry (int pid, const char *server_name, const char *exec_path, char *args, CSS_CONN_ENTRY *conn);
+	server_entry (int pid, const char *exec_path, char *args, CSS_CONN_ENTRY *conn);
 	~server_entry () {};
-
-	server_entry (const server_entry &) = delete;
-	server_entry (server_entry &&) = delete;
-
-	server_entry &operator = (const server_entry &) = delete;
-	server_entry &operator = (server_entry &&) = delete;
 
       private:
 	void proc_make_arg (char *args);
@@ -66,10 +66,28 @@ class server_monitor
     server_monitor &operator = (const server_monitor &) = delete;
     server_monitor &operator = (server_monitor &&) = delete;
 
+    void make_and_insert_server_entry (int pid, const char *exec_path, char *args,
+				       CSS_CONN_ENTRY *conn);
+
   private:
     std::unique_ptr<std::vector <server_entry>> m_server_entry_list;    // list of server entries
     std::unique_ptr<std::thread> m_monitoring_thread;                   // monitoring thread
     volatile bool m_thread_shutdown;                                    // flag to shutdown monitoring thread
+};
+
+/*
+ * server register resource message body
+ */
+
+/* process register */
+typedef struct server_proc_register SERVER_PROC_REGISTER;
+struct server_proc_register
+{
+  char server_name[SERVER_MAX_SZ_SERVER_NAME];
+  int server_name_length;
+  int pid;
+  char exec_path[SERVER_MAX_SZ_PROC_EXEC_PATH];
+  char args[SERVER_MAX_SZ_PROC_ARGS];
 };
 
 extern std::unique_ptr<server_monitor> master_Server_monitor;

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -47,7 +47,7 @@ class server_monitor
 	server_entry &operator= (const server_entry &) = delete;
 	server_entry &operator= (server_entry &&) = default;
 
-	CSS_CONN_ENTRY *get_conn ();
+	CSS_CONN_ENTRY *get_conn () const;
 
       private:
 	void proc_make_arg (char *args);

--- a/src/executables/server.c
+++ b/src/executables/server.c
@@ -352,8 +352,9 @@ main (int argc, char **argv)
 
 #if !defined(WINDOWS)
     hb_set_exec_path (executable_path);
-    css_set_exec_path (executable_path);
     hb_set_argv (argv);
+
+    css_set_exec_path (executable_path);
     css_set_argv (argv);
 
     /* create a new session */

--- a/src/executables/server.c
+++ b/src/executables/server.c
@@ -50,6 +50,7 @@
 #include "system_parameter.h"
 #include "perf_monitor.h"
 #include "util_func.h"
+#include "connection_sr.h"
 #if defined(WINDOWS)
 #include "wintcp.h"
 #else /* !defined (WINDOWS) */
@@ -351,7 +352,9 @@ main (int argc, char **argv)
 
 #if !defined(WINDOWS)
     hb_set_exec_path (executable_path);
+    css_set_exec_path (executable_path);
     hb_set_argv (argv);
+    css_set_argv (argv);
 
     /* create a new session */
     setsid ();

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -92,10 +92,10 @@ set(CUB_MASTER_SOURCES
   ${EXECUTABLES_DIR}/master.c
   ${EXECUTABLES_DIR}/master_request.c
   ${EXECUTABLES_DIR}/master_util.c
-  ${EXECUTABLES_DIR}/master_server_monitor.cpp
   )
 if(UNIX)
   list(APPEND CUB_MASTER_SOURCES ${EXECUTABLES_DIR}/master_heartbeat.c)
+  list(APPEND CUB_MASTER_SOURCES ${EXECUTABLES_DIR}/master_server_monitor.cpp)
   SET_SOURCE_FILES_PROPERTIES(
 	${CUB_MASTER_SOURCES}
 	PROPERTIES LANGUAGE CXX

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -92,6 +92,7 @@ set(CUB_MASTER_SOURCES
   ${EXECUTABLES_DIR}/master.c
   ${EXECUTABLES_DIR}/master_request.c
   ${EXECUTABLES_DIR}/master_util.c
+  ${EXECUTABLES_DIR}/master_server_monitor.cpp
   )
 if(UNIX)
   list(APPEND CUB_MASTER_SOURCES ${EXECUTABLES_DIR}/master_heartbeat.c)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25437

`cub_server` 구동 / 종료 시, master_Server_monitor에 등록 / 해제 되는 루틴 구현

- server 구동 시
  - server가 구동 된 후, cub_master와 연결할 때, 기존의 `server_name` 을 보내던 방식을 `SERVER_PROC_REGISTER`를 보내어서 server 등록에 필요한 정보들을 전송 
  - master는 필요한 정보들을 수신하여, `server_entry`를 생성하고, `server_entry_list`로 삽입
- server 종료 시
  - server가 정상적으로 종료 되는 루틴에서, `server_entry_list` 내의 socket 값이 같은 `server_entry`를 탐색하여 제거.