### PR TITLE
[CBRD-25356] rename att_name in db_serial to attr_name

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -678,12 +678,12 @@ export_serial (extract_context & ctxt, print_output & output_ctx)
   const char *query_all =
     "select [unique_name], [name], [owner].[name], " "[current_val], " "[increment_val], " "[max_val], " "[min_val], "
     "[cyclic], " "[started], " "[cached_num], " "[comment] "
-    "from [db_serial] where [class_name] is null and [att_name] is null";
+    "from [db_serial] where [class_name] is null and [attr_name] is null";
 
   const char *query_user =
     "select [unique_name], [name], [owner].[name], " "[current_val], " "[increment_val], " "[max_val], " "[min_val], "
     "[cyclic], " "[started], " "[cached_num], " "[comment] "
-    "from [db_serial] where [class_name] is null and [att_name] is null and owner.name='%s'";
+    "from [db_serial] where [class_name] is null and [attr_name] is null and owner.name='%s'";
 
   if (ctxt.is_dba_user == false && ctxt.is_dba_group_member == false)
     {

--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -2313,8 +2313,8 @@ classobj_constraint_size (SM_CONSTRAINT * constraint)
  *   constraint_seq(in): Constraint entry.  This is a sequence of the form:
  *      {
  *	    "B-tree ID",
- *	    [ "att_name", "asc_dsc", ]
- *	    [ "att_name", "asc_dsc", ]
+ *	    [ "attr_name", "asc_dsc", ]
+ *	    [ "attr_name", "asc_dsc", ]
  *	    {fk_info | pk_info | prefix_length}
  *          "filter_predicate",
  *          "comment"

--- a/src/object/schema_system_catalog_install.cpp
+++ b/src/object/schema_system_catalog_install.cpp
@@ -925,7 +925,7 @@ namespace cubschema
 	}
       },
       {"class_name", "string"},
-      {"att_name", "string"},
+      {"attr_name", "string"},
       {attribute_kind::CLASS_METHOD, "change_serial_owner", "au_change_serial_owner_method"},
       {
 	"cached_num", "integer", [] (DB_VALUE* val)

--- a/src/storage/storage_common.h
+++ b/src/storage/storage_common.h
@@ -1100,7 +1100,7 @@ typedef enum
 #define SERIAL_ATTR_CYCLIC          "cyclic"
 #define SERIAL_ATTR_STARTED         "started"
 #define SERIAL_ATTR_CLASS_NAME      "class_name"
-#define SERIAL_ATTR_ATT_NAME        "att_name"
+#define SERIAL_ATTR_ATT_NAME        "attr_name"
 #define SERIAL_ATTR_CACHED_NUM      "cached_num"
 #define SERIAL_ATTR_COMMENT         "comment"
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25356

### 문제점

```
;sc db_serial
att_name CHARACTER VARYING(...)
```

```
;sc db_attribute
attr_name CHARACTER VARYING(255)
```

att_name과 attr_name으로 서로 다르게 출력됩니다.

### 해결책

 attr_name으로 통일했습니다.

;sc db_serial을 입력하면

```
att_name -> attr_name
```

위와 같이 결과가 바뀌게 됩니다.
