### PR TITLE
[CBRD-25451] fix(CMakePreset): allow users to customize install prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,10 @@ x86
 *.*.orig
 tags
 cscope.out
+/.cache/
+/.env
+/.env.*.local
+/.envrc
 
 ## popular build directories
 Debug/

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -13,7 +13,7 @@
       "binaryDir": "${sourceDir}/build_preset_${presetName}",
       "cacheVariables": {
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
-        "CMAKE_INSTALL_PREFIX": "$env{HOME}/CUBRID",
+        "CMAKE_INSTALL_PREFIX": "$env{CUBRID}",
         "WITH_CCI": "true"
       }
     },


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25451

Install location is changed from $HOME/CUBRID to $CUBRID so that users can customize the location.