### PR TITLE
[CBRD-25432] Support Worktree and fix QA unittest error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,8 +115,6 @@ if(EXISTS "${CMAKE_SOURCE_DIR}/.git") # Regular Git project
     else() # Git Worktree
         set_git_dir_from_worktree(GIT_DIR HEAD_FILE)
     endif()
-else()
-    message(FATAL_ERROR "Not a git repository")
 endif()
 
 if(VERSION_MATCHES_LENGTH GREATER 3)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25432

아래 PR에서
https://github.com/CUBRID/cubrid/pull/5275

해당 레포가 git 레포가 아니면 에러 메세지를 내뱉도록 했는데, 
QA 시스템에서 유닛 테스팅을 할 시 git 레포가 아닌 상태로 빌드를 돌려도 통과해야 합니다.

따라서 git 레포인지 아닌지 검사하는 부분을 삭제합니다.