### PR TITLE
[CBRD-24639] Fix DBMS_OUTPUT.get_line's internal error caused by empty array is allocated in SpLib

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -488,7 +488,7 @@ public class SpLib {
     }
 
     public static void DBMS_OUTPUT$GET_LINE(String[] line, Integer[] status) {
-        int[] iArr = new int[0];
+        int[] iArr = new int[1];
         DBMS_OUTPUT.getLine(line, iArr);
         status[0] = iArr[0];
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24639
