### PR TITLE
[CBRD-25474] 서브쿼리 캐시가 불필요한 구문의 처리

### DIFF
--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -3512,14 +3512,61 @@ end:
 }
 
 static PT_NODE *
+do_check_cte_spec (PARSER_CONTEXT * parser, PT_NODE * stmt, void *arg, int *continue_walk)
+{
+  bool *has_cte_spec = (bool *) arg;
+
+  *continue_walk = PT_CONTINUE_WALK;
+
+  if (stmt->node_type != PT_SPEC)
+    {
+      return stmt;
+    }
+
+  if (stmt->info.spec.cte_pointer)
+    {
+      *has_cte_spec = true;
+      *continue_walk = PT_STOP_WALK;
+    }
+
+  return stmt;
+}
+
+static PT_NODE *
 do_prepare_subquery_pre (PARSER_CONTEXT * parser, PT_NODE * stmt, void *arg, int *continue_walk)
 {
   int *err = (int *) arg;
 
   *continue_walk = PT_CONTINUE_WALK;
 
-  if (!PT_IS_QUERY_NODE_TYPE (stmt->node_type))
+  switch (stmt->node_type)
     {
+    case PT_UNION:
+    case PT_INTERSECTION:
+    case PT_DIFFERENCE:
+      (void *) parser_walk_tree (parser, stmt->info.query.q.union_.arg1, do_prepare_subquery_pre, err, NULL, NULL);
+      if (*err != NO_ERROR)
+	{
+	  goto stop_walk;
+	}
+      (void *) parser_walk_tree (parser, stmt->info.query.q.union_.arg2, do_prepare_subquery_pre, err, NULL, NULL);
+      goto stop_walk;
+
+    case PT_CREATE_TRIGGER:
+    case PT_ALTER:
+      goto stop_walk;
+
+    case PT_CREATE_ENTITY:
+      if (stmt->info.create_entity.entity_type != PT_CLASS)
+	{
+	  goto stop_walk;
+	}
+      return stmt;
+
+    case PT_SELECT:
+      break;
+
+    default:
       return stmt;
     }
 
@@ -3527,13 +3574,33 @@ do_prepare_subquery_pre (PARSER_CONTEXT * parser, PT_NODE * stmt, void *arg, int
        || stmt->info.query.is_subquery == PT_IS_CTE_NON_REC_SUBQUERY) && stmt->info.query.correlation_level == 0
       && (stmt->info.query.hint & PT_HINT_QUERY_CACHE))
     {
+      bool has_cte_spec = false;
+
+      /* exclude cache from CTE referencing */
+      parser_walk_tree (parser, stmt, do_check_cte_spec, &has_cte_spec, NULL, NULL);
+
+      if (has_cte_spec)
+	{
+	  goto stop_walk;
+	}
+
       *err = do_prepare_subquery (parser, stmt);
+
       if (*err != NO_ERROR)
 	{
-	  *continue_walk = PT_STOP_WALK;
+	  goto stop_walk;
+	}
+      else
+	{
+	  /* no more deep walking tree for excluding nested caching */
+	  *continue_walk = PT_LIST_WALK;
 	}
     }
 
+  return stmt;
+
+stop_walk:
+  *continue_walk = PT_STOP_WALK;
   return stmt;
 }
 
@@ -3541,6 +3608,16 @@ static int
 do_check_subquery_cache (PARSER_CONTEXT * parser, PT_NODE * statement)
 {
   int err = NO_ERROR;
+
+  if (statement->node_type == PT_SELECT)
+    {
+      if (PT_SELECT_INFO_IS_FLAGED (statement, PT_SELECT_INFO_COLS_SCHEMA)
+	  || PT_SELECT_INFO_IS_FLAGED (statement, PT_SELECT_FULL_INFO_COLS_SCHEMA)
+	  || PT_SELECT_INFO_IS_FLAGED (statement, PT_SELECT_INFO_IDX_SCHEMA))
+	{
+	  return NO_ERROR;
+	}
+    }
 
   /* All CTE and sub-queries included in the query must be prepared first. */
   if (pt_is_allowed_result_cache ())

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -3609,16 +3609,6 @@ do_check_subquery_cache (PARSER_CONTEXT * parser, PT_NODE * statement)
 {
   int err = NO_ERROR;
 
-  if (statement->node_type == PT_SELECT)
-    {
-      if (PT_SELECT_INFO_IS_FLAGED (statement, PT_SELECT_INFO_COLS_SCHEMA)
-	  || PT_SELECT_INFO_IS_FLAGED (statement, PT_SELECT_FULL_INFO_COLS_SCHEMA)
-	  || PT_SELECT_INFO_IS_FLAGED (statement, PT_SELECT_INFO_IDX_SCHEMA))
-	{
-	  return NO_ERROR;
-	}
-    }
-
   /* All CTE and sub-queries included in the query must be prepared first. */
   if (pt_is_allowed_result_cache ())
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25474

서브쿼리 캐시는 일반적으로 아래와 같은 형태의 쿼리에서 uncorrelated 성격의 서브쿼리에 대해서만 적용된다.

SELECT
UNION (INTERSECTION, DIFFERENCE 포함)
INSERT ... SELECT
UPDATE ... SELECT
DEELTE ... SELECT
CREATE TABLE ... AS SELECT
다만 위 구문에서 CREATE 구문의 경우, 좀더 세분해서 처리할 필요가 있다. 아래 쿼리의 경우 내부적으로는 SELECT 구문이 포함되고 있어서, 체크해서 캐시하지 않도록 해야한다.

- CREATE TRIGGER 구문
- CREATE VIEW 구문

그리고 서브 쿼리에서 CTE 쿼리를 참조하는 경우도 제외해야 한다. 예를 들면 아래와 같은 쿼리이다.

```
WITH cte AS (SELECT ... FROM ... WHERE)
SELECT * FROM (SELECT /*+ QUERY_CACHE */ ... FROM cte WHERE ...)
```
즉, FROM 절 내에 cte 테이블이 포함된 경우 캐시에서 제외시켜야 한다.
