### PR TITLE
[CBRD-25479] support a user name before sp name in definitions and calls

### DIFF
--- a/pl_engine/pl_server/src/main/antlr/PlcParser.g4
+++ b/pl_engine/pl_server/src/main/antlr/PlcParser.g4
@@ -39,8 +39,12 @@ create_routine
     ;
 
 routine_definition
-    : (PROCEDURE | FUNCTION) identifier ( (LPAREN parameter_list RPAREN)? | LPAREN RPAREN ) (RETURN type_spec)?
+    : (PROCEDURE | FUNCTION) routine_uniq_name ( (LPAREN parameter_list RPAREN)? | LPAREN RPAREN ) (RETURN type_spec)?
       (authid_spec)? (IS | AS) (LANGUAGE PLCSQL)? seq_of_declare_specs? body (SEMICOLON)?
+    ;
+
+routine_uniq_name
+    : (owner=identifier '.')? name=identifier
     ;
 
 parameter_list
@@ -210,7 +214,11 @@ return_statement
     ;
 
 procedure_call
-    : (DBMS_OUTPUT '.')? routine_name function_argument?
+    : proc_call_name function_argument?
+    ;
+
+proc_call_name
+    : (owner=identifier '.')? (DBMS_OUTPUT '.')? name=identifier
     ;
 
 body
@@ -354,7 +362,25 @@ atom
     ;
 
 function_call
-    : function_name function_argument
+    : func_call_name function_argument
+    ;
+
+func_call_name
+    : (owner=identifier '.')? name=func_name
+    ;
+
+func_name
+    : identifier
+    | DATE
+    | DEFAULT
+    | IF
+    | INSERT
+    | MOD
+    | REPLACE
+    | REVERSE
+    | TIME
+    | TIMESTAMP
+    | TRUNCATE
     ;
 
 relational_operator
@@ -443,10 +469,6 @@ restricted_using_clause
 
 restricted_using_element
     : (IN)? expression
-    ;
-
-routine_name
-    : identifier
     ;
 
 parameter_name
@@ -557,20 +579,6 @@ quoted_string
 identifier
     : REGULAR_ID
     | DELIMITED_ID
-    ;
-
-function_name
-    : identifier
-    | DATE
-    | DEFAULT
-    | IF
-    | INSERT
-    | MOD
-    | REPLACE
-    | REVERSE
-    | TIME
-    | TIMESTAMP
-    | TRUNCATE
     ;
 
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/Misc.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/Misc.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.TerminalNode;
 
 public class Misc {
 
@@ -66,6 +67,17 @@ public class Misc {
     public static String detachPkgName(String routineName) {
         int idx = routineName.indexOf('$');
         return idx >= 0 ? routineName.substring(idx + 1) : routineName;
+    }
+
+    public static int[] getLineColumnOf(TerminalNode node) {
+        if (node == null) {
+            return UNKNOWN_LINE_COLUMN;
+        }
+
+        Token start = node.getSymbol();
+        assert start != null;
+
+        return new int[] {start.getLine(), start.getCharPositionInLine() + 1};
     }
 
     public static int[] getLineColumnOf(ParserRuleContext ctx) {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -63,9 +63,7 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     public final SymbolStack symbolStack = new SymbolStack();
 
     public ParseTreeConverter(
-            Map<ParserRuleContext, SqlSemantics> staticSqls,
-            String spOwner,
-            String spRevision) {
+            Map<ParserRuleContext, SqlSemantics> staticSqls, String spOwner, String spRevision) {
         this.staticSqls = staticSqls;
         this.spOwner = Misc.getNormalizedText(spOwner);
         this.spRevision = spRevision;

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -62,8 +62,10 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
 
     public final SymbolStack symbolStack = new SymbolStack();
 
-    public ParseTreeConverter(Map<ParserRuleContext, SqlSemantics> staticSqls) {
+    public ParseTreeConverter(Map<ParserRuleContext, SqlSemantics> staticSqls, String spOwner, String routineRevision) {
         this.staticSqls = staticSqls;
+        this.spOwner = Misc.getNormalizedText(spOwner);
+        this.routineRevision = routineRevision;
     }
 
     public void askServerSemanticQuestions() {
@@ -222,6 +224,7 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     public Unit visitCreate_routine(Create_routineContext ctx) {
 
         previsitRoutine_definition(ctx.routine_definition());
+        assert spName != null;
         DeclRoutine decl = visitRoutine_definition(ctx.routine_definition());
         return new Unit(ctx, autonomousTransaction, connectionRequired, imports, decl);
     }
@@ -233,7 +236,7 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
             return EMPTY_PARAMS;
         }
 
-        boolean ofTopLevel = symbolStack.getCurrentScope().level == 2;
+        boolean ofTopLevel = symbolStack.getCurrentScope().level == (SymbolStack.LEVEL_MAIN + 1);
         NodeList<DeclParam> ret = new NodeList<>();
         if (ofTopLevel) {
             for (ParameterContext pc : ctx.parameter()) {
@@ -834,8 +837,30 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     @Override
     public Expr visitFunction_call(Function_callContext ctx) {
 
-        String name = Misc.getNormalizedText(ctx.function_name());
+        String name = Misc.getNormalizedText(ctx.func_call_name().name);
         NodeList<Expr> args = visitFunction_argument(ctx.function_argument());
+
+        if (ctx.func_call_name().owner != null) {
+            // This has an owner name
+
+            String owner = Misc.getNormalizedText(ctx.func_call_name().owner);
+            if (owner.equals(spOwner) && name.equals(spName) && isSpFunc) {
+
+                // OK: recursive call of the stored procedure being defined
+                // Note that owner name is unused afterwards.
+            } else {
+
+                // This has an owner name and the target function is not the SP being defined
+                // Take this as a global function call.
+                connectionRequired = true;
+
+                String uniqName = owner + '.' + name;
+                ExprGlobalFuncCall ret = new ExprGlobalFuncCall(ctx, uniqName, args);
+                semanticQuestions.put(ret, new ServerAPI.FunctionSignature(uniqName));
+
+                return ret; // done
+            }
+        }
 
         DeclFunc decl = symbolStack.getDeclFunc(name);
         if (decl == null) {
@@ -1156,27 +1181,9 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     @Override
     public DeclRoutine visitRoutine_definition(Routine_definitionContext ctx) {
 
-        if (ctx.LANGUAGE() != null && symbolStack.getCurrentScope().level > 1) {
-            int[] lineColumn = Misc.getLineColumnOf(ctx);
-            throw new SyntaxError(
-                    lineColumn[0],
-                    lineColumn[1],
-                    "illegal keywords LANGUAGE PLCSQL for a local procedure/function");
-        }
-
-        if (ctx.authid_spec() != null && symbolStack.getCurrentScope().level > 1) {
-            int[] lineColumn = Misc.getLineColumnOf(ctx);
-            throw new SyntaxError(
-                    lineColumn[0],
-                    lineColumn[1],
-                    "illegal keyword AUTHID for a local procedure/function");
-        }
-
-        String name = Misc.getNormalizedText(ctx.identifier());
+        String name = Misc.getNormalizedText(ctx.routine_uniq_name().name);
         boolean isFunction = (ctx.PROCEDURE() == null);
-
-        symbolStack.pushSymbolTable(
-                name, isFunction ? Misc.RoutineType.FUNC : Misc.RoutineType.PROC);
+        symbolStack.pushSymbolTable(name, isFunction ? Misc.RoutineType.FUNC : Misc.RoutineType.PROC);
 
         visitParameter_list(ctx.parameter_list()); // just to put symbols to the symbol table
 
@@ -1208,7 +1215,7 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
         ret.decls = decls;
         ret.body = body;
 
-        if (symbolStack.getCurrentScope().level > 1) {
+        if (symbolStack.getCurrentScope().level > SymbolStack.LEVEL_MAIN) {
             // check it only for local routines
             checkRedefinitionOfUsedName(name, ctx);
         }
@@ -1300,7 +1307,7 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
 
             if (idUsedInCurrentDeclPart != null) {
                 idUsedInCurrentDeclPart.put(
-                        name, new UseAndDeclLevel(ctx, symbolStack.LEVEL_PREDEFINED));
+                        name, new UseAndDeclLevel(ctx, SymbolStack.LEVEL_PREDEFINED));
             }
 
             // this is possibly a global function call
@@ -1997,15 +2004,37 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     @Override
     public AstNode visitProcedure_call(Procedure_callContext ctx) {
 
-        String name = Misc.getNormalizedText(ctx.routine_name());
-        if (ctx.DBMS_OUTPUT() != null && dbmsOutputProc.contains(name)) {
+        String name = Misc.getNormalizedText(ctx.proc_call_name().name);
+        NodeList<Expr> args = visitFunction_argument(ctx.function_argument());
+
+        if (ctx.proc_call_name().owner != null) {
+            // This has an owner name
+
+            String owner = Misc.getNormalizedText(ctx.proc_call_name().owner);
+            if (owner.equals(spOwner) && ctx.proc_call_name().DBMS_OUTPUT() == null && name.equals(spName) && !isSpFunc) {
+
+                // OK: recursive call of the stored procedure being defined
+                // Note that owner name is unused afterwards.
+            } else {
+
+                // This has an owner name and the target procedure is not the SP being defined
+                // Take this as a global procedure call.
+                connectionRequired = true;
+
+                String uniqName = owner + '.' + name;
+                StmtGlobalProcCall ret = new StmtGlobalProcCall(ctx, uniqName, args);
+                semanticQuestions.put(ret, new ServerAPI.ProcedureSignature(uniqName));
+
+                return ret; // done
+            }
+        }
+
+        if (ctx.proc_call_name().DBMS_OUTPUT() != null && dbmsOutputProc.contains(name)) {
             // DBMS_OUTPUT is not an actual package but just a syntactic "ornament" to ease
             // migration from Oracle.
             // NOTE: users cannot define a procedure of this name because of '$'
             name = "DBMS_OUTPUT$" + name;
         }
-
-        NodeList<Expr> args = visitFunction_argument(ctx.function_argument());
 
         DeclProc decl = symbolStack.getDeclProc(name);
         if (decl == null) {
@@ -2238,6 +2267,12 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
             new LinkedHashMap<>();
 
     private final Map<ParserRuleContext, SqlSemantics> staticSqls;
+    private final String spOwner;
+    private final String routineRevision;
+
+    private String spName;
+    private boolean isSpFunc;
+
     private final Set<String> imports = new TreeSet<>();
 
     private int exHandlerDepth;
@@ -2298,13 +2333,44 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
 
     private void previsitRoutine_definition(Routine_definitionContext ctx) {
 
-        String name = Misc.getNormalizedText(ctx.identifier());
+        String name = Misc.getNormalizedText(ctx.routine_uniq_name().name);
+
+        if (symbolStack.getCurrentScope().level > SymbolStack.LEVEL_MAIN) {
+
+            // local procedure/function
+
+            if (ctx.LANGUAGE() != null) {
+                throw new SemanticError(
+                        Misc.getLineColumnOf(ctx.LANGUAGE()),   // s083
+                        "illegal keywords LANGUAGE PLCSQL for a local procedure/function");
+            }
+            if (ctx.authid_spec() != null) {
+                throw new SemanticError(
+                        Misc.getLineColumnOf(ctx.LANGUAGE()),   // s084
+                        "illegal keyword AUTHID for a local procedure/function");
+            }
+            if (ctx.routine_uniq_name().owner != null) {
+                throw new SemanticError(
+                        Misc.getLineColumnOf(ctx.routine_uniq_name().owner), // s085
+                        "owner specification is not allowed for local procedures/functions");
+            }
+        } else {
+
+            // SP being defined
+
+            assert symbolStack.getCurrentScope().level == SymbolStack.LEVEL_MAIN;
+            spName = name;
+            isSpFunc = (ctx.PROCEDURE() == null);
+        }
+
+        if (ctx.routine_uniq_name().owner != null) {
+            String owner = Misc.getNormalizedText(ctx.routine_uniq_name().owner);
+            assert owner.equals(spOwner);
+        }
 
         // in order not to corrupt the current symbol table with the parameters
         symbolStack.pushSymbolTable("temp", null);
-
         NodeList<DeclParam> paramList = visitParameter_list(ctx.parameter_list());
-
         symbolStack.popSymbolTable();
 
         if (ctx.PROCEDURE() == null) {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -65,10 +65,10 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     public ParseTreeConverter(
             Map<ParserRuleContext, SqlSemantics> staticSqls,
             String spOwner,
-            String routineRevision) {
+            String spRevision) {
         this.staticSqls = staticSqls;
         this.spOwner = Misc.getNormalizedText(spOwner);
-        this.routineRevision = routineRevision;
+        this.spRevision = spRevision;
     }
 
     public void askServerSemanticQuestions() {
@@ -849,7 +849,7 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
             String owner = Misc.getNormalizedText(ctx.func_call_name().owner);
             if (owner.equals(spOwner) && name.equals(spName) && isSpFunc) {
 
-                // OK: recursive call of the stored procedure being defined
+                // OK: recursive call of the stored function being defined
                 // Note that owner name is unused afterwards.
             } else {
 
@@ -2275,7 +2275,7 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
 
     private final Map<ParserRuleContext, SqlSemantics> staticSqls;
     private final String spOwner;
-    private final String routineRevision;
+    private final String spRevision;
 
     private String spName;
     private boolean isSpFunc;

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -62,7 +62,10 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
 
     public final SymbolStack symbolStack = new SymbolStack();
 
-    public ParseTreeConverter(Map<ParserRuleContext, SqlSemantics> staticSqls, String spOwner, String routineRevision) {
+    public ParseTreeConverter(
+            Map<ParserRuleContext, SqlSemantics> staticSqls,
+            String spOwner,
+            String routineRevision) {
         this.staticSqls = staticSqls;
         this.spOwner = Misc.getNormalizedText(spOwner);
         this.routineRevision = routineRevision;
@@ -1183,7 +1186,8 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
 
         String name = Misc.getNormalizedText(ctx.routine_uniq_name().name);
         boolean isFunction = (ctx.PROCEDURE() == null);
-        symbolStack.pushSymbolTable(name, isFunction ? Misc.RoutineType.FUNC : Misc.RoutineType.PROC);
+        symbolStack.pushSymbolTable(
+                name, isFunction ? Misc.RoutineType.FUNC : Misc.RoutineType.PROC);
 
         visitParameter_list(ctx.parameter_list()); // just to put symbols to the symbol table
 
@@ -2011,7 +2015,10 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
             // This has an owner name
 
             String owner = Misc.getNormalizedText(ctx.proc_call_name().owner);
-            if (owner.equals(spOwner) && ctx.proc_call_name().DBMS_OUTPUT() == null && name.equals(spName) && !isSpFunc) {
+            if (owner.equals(spOwner)
+                    && ctx.proc_call_name().DBMS_OUTPUT() == null
+                    && name.equals(spName)
+                    && !isSpFunc) {
 
                 // OK: recursive call of the stored procedure being defined
                 // Note that owner name is unused afterwards.
@@ -2341,12 +2348,12 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
 
             if (ctx.LANGUAGE() != null) {
                 throw new SemanticError(
-                        Misc.getLineColumnOf(ctx.LANGUAGE()),   // s083
+                        Misc.getLineColumnOf(ctx.LANGUAGE()), // s083
                         "illegal keywords LANGUAGE PLCSQL for a local procedure/function");
             }
             if (ctx.authid_spec() != null) {
                 throw new SemanticError(
-                        Misc.getLineColumnOf(ctx.LANGUAGE()),   // s084
+                        Misc.getLineColumnOf(ctx.LANGUAGE()), // s084
                         "illegal keyword AUTHID for a local procedure/function");
             }
             if (ctx.routine_uniq_name().owner != null) {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/PlcsqlCompilerMain.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/PlcsqlCompilerMain.java
@@ -51,7 +51,14 @@ import org.antlr.v4.runtime.tree.*;
 
 public class PlcsqlCompilerMain {
 
+    // temporary code - the owner and revision strings will come from the server
+    private static int revision = 1;
     public static CompileInfo compilePLCSQL(String in, boolean verbose) {
+        return compilePLCSQL(in, verbose, "dba", Integer.toString(revision++));
+    }
+    // end of temporary code
+
+    public static CompileInfo compilePLCSQL(String in, boolean verbose, String owner, String revision) {
 
         // System.out.println("[TEMP] text to the compiler");
         // System.out.println(in);
@@ -59,7 +66,7 @@ public class PlcsqlCompilerMain {
         int optionFlags = verbose ? OPT_VERBOSE : 0;
         CharStream input = CharStreams.fromString(in);
         try {
-            return compileInner(input, optionFlags);
+            return compileInner(input, optionFlags, owner, revision);
         } catch (SyntaxError e) {
             CompileInfo err = new CompileInfo(-1, e.line, e.column, e.getMessage());
             return err;
@@ -137,7 +144,7 @@ public class PlcsqlCompilerMain {
         return t;
     }
 
-    private static CompileInfo compileInner(CharStream input, int optionFlags) {
+    private static CompileInfo compileInner(CharStream input, int optionFlags, String owner, String revision) {
 
         boolean verbose = (optionFlags & OPT_VERBOSE) > 0;
 
@@ -227,7 +234,7 @@ public class PlcsqlCompilerMain {
         // ------------------------------------------
         // converting parse tree to AST
 
-        ParseTreeConverter converter = new ParseTreeConverter(staticSqls);
+        ParseTreeConverter converter = new ParseTreeConverter(staticSqls, owner, revision);
         Unit unit = (Unit) converter.visit(tree);
 
         if (verbose) {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/PlcsqlCompilerMain.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/PlcsqlCompilerMain.java
@@ -53,12 +53,14 @@ public class PlcsqlCompilerMain {
 
     // temporary code - the owner and revision strings will come from the server
     private static int revision = 1;
+
     public static CompileInfo compilePLCSQL(String in, boolean verbose) {
         return compilePLCSQL(in, verbose, "dba", Integer.toString(revision++));
     }
     // end of temporary code
 
-    public static CompileInfo compilePLCSQL(String in, boolean verbose, String owner, String revision) {
+    public static CompileInfo compilePLCSQL(
+            String in, boolean verbose, String owner, String revision) {
 
         // System.out.println("[TEMP] text to the compiler");
         // System.out.println(in);
@@ -144,7 +146,8 @@ public class PlcsqlCompilerMain {
         return t;
     }
 
-    private static CompileInfo compileInner(CharStream input, int optionFlags, String owner, String revision) {
+    private static CompileInfo compileInner(
+            CharStream input, int optionFlags, String owner, String revision) {
 
         boolean verbose = (optionFlags & OPT_VERBOSE) > 0;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25479

PlcsqlCompilerMain.java 의 상단에 서버로부터 받는 SP owner, revision 을 하드코딩하는 임시 코드가 있습니다. 
일단, 이 PR 을 merge 한 후 그 임시 코드 대신 실제 서버로부터의 owner, revision을 사용하도록 수정할 수 있습니다. 
