### PR TITLE
[CBRD-25482] When a general user unloads a view, remove the owner's schema from query_spec.

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -2110,6 +2110,10 @@ emit_query_specs (extract_context & ctxt, print_output & output_ctx, DB_OBJLIST 
 			      PRINT_IDENTIFIER (class_name), query_ptr_result);
 		}
 	    }
+	  else
+	    {
+	      output_ctx ("/* ERROR : ALTER VCLASS %s%s%s ADD QUERY ... */\n", PRINT_IDENTIFIER (name));
+	    }
 
 	  parser_free_parser (parser);
 	}
@@ -2245,6 +2249,10 @@ emit_query_specs_has_using_index (extract_context & ctxt, print_output & output_
 		  output_ctx ("ALTER VCLASS %s%s%s%s ADD QUERY %s ;\n", output_owner,
 			      PRINT_IDENTIFIER (class_name), query_ptr_result);
 		}
+	    }
+	  else
+	    {
+	      output_ctx ("/* ERROR : ALTER VCLASS %s%s%s ADD QUERY ... */\n", PRINT_IDENTIFIER (name));
 	    }
 
 	  parser_free_parser (parser);

--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -1960,13 +1960,15 @@ emit_query_specs (extract_context & ctxt, print_output & output_ctx, DB_OBJLIST 
   PARSER_CONTEXT *parser;
   PT_NODE **query_ptr;
   const char *name;
-  char owner_name[DB_MAX_IDENTIFIER_LENGTH] = { '\0' };
+  char owner_name[DB_MAX_IDENTIFIER_LENGTH];
+  owner_name[0] = '\0';
   char *class_name = NULL;
   const char *null_spec;
   bool has_using_index;
   bool change_vclass_spec;
   int i;
-  char output_owner[DB_MAX_USER_LENGTH + 4] = { '\0' };
+  char output_owner[DB_MAX_USER_LENGTH + 4];
+  output_owner[0] = '\0';
   char *query_ptr_result;
 
   /*
@@ -2081,6 +2083,7 @@ emit_query_specs (extract_context & ctxt, print_output & output_ctx, DB_OBJLIST 
 	  parser = parser_create_parser ();
 	  if (parser == NULL)
 	    {
+	      output_ctx ("/* ERROR : ALTER VCLASS %s%s%s ADD QUERY ... */\n", PRINT_IDENTIFIER (name));
 	      continue;
 	    }
 
@@ -2215,6 +2218,7 @@ emit_query_specs_has_using_index (extract_context & ctxt, print_output & output_
 	  parser = parser_create_parser ();
 	  if (parser == NULL)
 	    {
+	      output_ctx ("/* ERROR : ALTER VCLASS %s%s%s ADD QUERY ... */\n", PRINT_IDENTIFIER (name));
 	      continue;
 	    }
 
@@ -2231,7 +2235,7 @@ emit_query_specs_has_using_index (extract_context & ctxt, print_output & output_
 				    sizeof (output_owner));
 
 		  output_ctx ("ALTER VCLASS %s%s%s%s CHANGE QUERY %d %s ;\n", output_owner,
-			      PRINT_IDENTIFIER (class_name), i, db_query_spec_string (s));
+			      PRINT_IDENTIFIER (class_name), i, query_ptr_result);
 		}
 	      else
 		{		/* emit the usual statements */
@@ -2239,7 +2243,7 @@ emit_query_specs_has_using_index (extract_context & ctxt, print_output & output_
 				    sizeof (output_owner));
 
 		  output_ctx ("ALTER VCLASS %s%s%s%s ADD QUERY %s ;\n", output_owner,
-			      PRINT_IDENTIFIER (class_name), db_query_spec_string (s));
+			      PRINT_IDENTIFIER (class_name), query_ptr_result);
 		}
 	    }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25482

Purpose

- 일반 사용자가 View를 unload하면 view_name의 소유자 schema만 제거되고 query_spec은 제거되지 않습니다.
- 따라서 query_spec(view 생성 시 사용자가 입력한 쿼리)도 수정하여 소유자의 schema를 제거하겠습니다.

AS-IS
`ALTER VCLASS [v1] ADD QUERY select [u1.t1].[col1], [u1.t1].[col2] from [u1.t1] [u1.t1] ;`

TO-BE
`ALTER VCLASS [v1] ADD QUERY select [t1].[col1], [t1].[col2] from [t1] [t1] ;`

Implementation
N/A

Remarks
N/A