### PR TITLE
[CBRD-25457] Executing the “AUTO_INCREMENT” and “DEFAULT” attributes separately using the “ALTER TABLE MODIFY” syntax on the same column resulted in an error of two attributes co-existing in that column

### DIFF
--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -11110,16 +11110,20 @@ build_attr_change_map (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NODE * 
    * DEFAULT value and AUTO INCREMENT cannot be defined for the same column.
    * Therefore, it will change to the property on which the last MODIFY statement was executed. 
    */
-  if (attr_def->info.attr_def.data_default != NULL && att->flags & SM_ATTFLAG_AUTO_INCREMENT)
+  if (attr_def->info.attr_def.data_default != NULL)
     {
-      attr_chg_properties->p[P_AUTO_INCR] |= ATT_CHG_PROPERTY_LOST;
+      if (att->flags & SM_ATTFLAG_AUTO_INCREMENT)
+	{
+	  attr_chg_properties->p[P_AUTO_INCR] |= ATT_CHG_PROPERTY_LOST;
+	}
     }
-
-  if (attr_def->info.attr_def.auto_increment != NULL
-      && (!DB_IS_NULL (&(att->default_value.original_value)) || !DB_IS_NULL (&(att->default_value.value))
-	  || att->default_value.default_expr.default_expr_type != DB_DEFAULT_NONE))
+  else if (attr_def->info.attr_def.auto_increment != NULL)
     {
-      attr_chg_properties->p[P_DEFAULT_VALUE] |= ATT_CHG_PROPERTY_LOST;
+      if ((!DB_IS_NULL (&(att->default_value.original_value)) || !DB_IS_NULL (&(att->default_value.value))
+	   || att->default_value.default_expr.default_expr_type != DB_DEFAULT_NONE))
+	{
+	  attr_chg_properties->p[P_DEFAULT_VALUE] |= ATT_CHG_PROPERTY_LOST;
+	}
     }
 
   /* existing FOREIGN KEY (referencing) */

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -11106,6 +11106,22 @@ build_attr_change_map (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NODE * 
       attr_chg_properties->p[P_AUTO_INCR] |= ATT_CHG_PROPERTY_PRESENT_OLD;
     }
 
+  /* 
+   * DEFAULT value and AUTO INCREMENT cannot be defined for the same column.
+   * Therefore, it will change to the property on which the last MODIFY statement was executed. 
+   */
+  if (attr_def->info.attr_def.data_default != NULL && att->flags & SM_ATTFLAG_AUTO_INCREMENT)
+    {
+      attr_chg_properties->p[P_AUTO_INCR] |= ATT_CHG_PROPERTY_LOST;
+    }
+
+  if (attr_def->info.attr_def.auto_increment != NULL
+      && (!DB_IS_NULL (&(att->default_value.original_value)) || !DB_IS_NULL (&(att->default_value.value))
+	  || att->default_value.default_expr.default_expr_type != DB_DEFAULT_NONE))
+    {
+      attr_chg_properties->p[P_DEFAULT_VALUE] |= ATT_CHG_PROPERTY_LOST;
+    }
+
   /* existing FOREIGN KEY (referencing) */
   attr_chg_properties->p[P_CONSTR_FK] = 0;
   if (att->flags & SM_ATTFLAG_FOREIGN_KEY)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25457

Purpose
- "CREATE TABLE" 및 "ALTER COLUMN" 문 수행 시 "AUTO_INCREMENT" 및 "DEFAULT" 속성을 동시에 사용할 경우 아래와 같은 에러가 발생 합니다.
`ERROR: SHARED, DEFAULT and AUTO_INCREMENT cannot be defined with each other.`

- 하지만, "ALTER TABLE .. MODIFY" 문을 사용하여 "AUTO_INCREMENT" 및 "DEFAULT" 속성을 개별적으로 실행하면 해당 column에 두 속성이 공존하게 됩니다.

- 이 문제로 인해 "AUTO_INCREMENT" 및 "DEFAULT" 속성이 있는 테이블을 unload 한 다음 load 하면 테이블이 생성되지 않습니다.

Implementation
N/A

Remarks
**ALTER TABLE .. MODIFY 사양 변경**
1. 다음 속성 중 하나만 같은 column에 사용할 수 있습니다. : AUTO_INCREMENT, SHARED 또는 DEFAULT
2. AUTO_INCREMENT와 DEFAULT 속성은 마지막으로 MODIFY한 것만 적용 됩니다.
3. Column의 속성을 제거하고 싶을 경우 아래와 같이 제거할 수 있습니다.

- SHARED 속성 제거 방법
  - SHARED 속성은 DROP COLUMN 문을 수행하여 제거할 수 있습니다.
- DEFAULT 속성 제거 방법
  - DEFAULT 속성은 DEFAULT NULL로 수정하여 제거할 수 있습니다.
  - DEFAULT NULL은 스키마 정보에 표시되지 않습니다. (모든 TABLE의 DEFAULT 값은 DEFAULT NULL입니다.)
- AUTO_INCREMENT 속성 제거 방법
  - AUTO_INCREMENT 속성은 DEFAULT NULL로 수정하여 제거할 수 있습니다.
  - ex) AUTO_INCREMENT를 DEFAULT로 수정하면 AUTO_INCREMENT 속성이 제거되고, DEFAULT는 NULL로 수정됩니다.
        DEFAULT NULL은 스키마 정보에 표시되지 않으므로 해당 컬럼에는 속성이 없습니다.