### PR TITLE
[CBRD-25484] Inner join과 non-ANSI outer join을 함께 사용할 경우 조인 조건의 순서에 따라 오류가 발생

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -2671,46 +2671,45 @@ pt_bind_names (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue
 			      /* converse join type */
 			      join_type = (join_type == PT_JOIN_LEFT_OUTER) ? PT_JOIN_RIGHT_OUTER : PT_JOIN_LEFT_OUTER;
 
-			      /* need to move unnecessary spec list located between the two swapped specs to the end of the entire spec list */
+			      /* move unnecessary spec list located between the two swapped specs to the end of the entire spec list */
 			      s_start = NULL;
-			      p_end = p_spec;
-			      s_end = p_spec;
 
-			      for (tmp = p_spec; tmp != spec; tmp = tmp->next)
+			      for (tmp = p_spec; tmp; tmp = tmp->next)
 				{
-				  /* find the head node of the spec list to be moved
-				   * find the previous node to detach the head node */
-				  if (!s_start && tmp->next->info.spec.join_type == PT_JOIN_NONE && tmp->next != spec)
+				  if (!s_start)
 				    {
-				      p_end = tmp;
-				      s_start = tmp->next;
+				      /* cannot find the spec to move */
+				      if (tmp->next == spec)
+					{
+					  break;
+					}
+
+				      /* find the head node of the spec list to be moved
+				       * find the previous node to detach the head node */
+				      if (tmp->next->info.spec.join_type == PT_JOIN_NONE)
+					{
+					  p_end = tmp;
+					  s_start = tmp->next;
+					}
 				    }
 
-				  else if (!s_start)
+				  else
 				    {
-				      p_end = tmp;
-				      s_end = tmp;
-				    }
-
-				  /* if the head node of the spec list to be moved is found, also find the tail node of the spec list to be moved */
-				  if (s_start)
-				    {
+				      /* find the tail node of the spec list to be moved */
 				      if (tmp->next == spec)
 					{
 					  s_end = tmp;
 					}
+
+				      if (!tmp->next)
+					{
+					  s_end->next = NULL;
+					  p_end->next = spec;
+					  tmp->next = s_start;
+					  break;
+					}
 				    }
 				}
-
-			      for (tmp = spec; tmp->next; tmp = tmp->next)
-				{
-				  ;
-				}
-			      /* found end of spec list */
-
-			      s_end->next = NULL;
-			      p_end->next = spec;
-			      tmp->next = s_start;
 			    }
 			  else
 			    {

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -2672,9 +2672,11 @@ pt_bind_names (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue
 			      join_type = (join_type == PT_JOIN_LEFT_OUTER) ? PT_JOIN_RIGHT_OUTER : PT_JOIN_LEFT_OUTER;
 
 			      /* move unnecessary spec list located between the two swapped specs to the end of the entire spec list */
+			      p_end = NULL;
 			      s_start = NULL;
+			      s_end = NULL;
 
-			      for (tmp = p_spec; tmp; tmp = tmp->next)
+			      for (tmp = p_spec; tmp->next; tmp = tmp->next)
 				{
 				  if (!s_start)
 				    {
@@ -2700,15 +2702,14 @@ pt_bind_names (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue
 					{
 					  s_end = tmp;
 					}
-
-				      if (!tmp->next)
-					{
-					  s_end->next = NULL;
-					  p_end->next = spec;
-					  tmp->next = s_start;
-					  break;
-					}
 				    }
+				}
+
+			      if (s_start && s_end && p_end)
+				{
+				  s_end->next = NULL;
+				  p_end->next = spec;
+				  tmp->next = s_start;
 				}
 			    }
 			  else

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -2671,12 +2671,15 @@ pt_bind_names (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue
 			      /* converse join type */
 			      join_type = (join_type == PT_JOIN_LEFT_OUTER) ? PT_JOIN_RIGHT_OUTER : PT_JOIN_LEFT_OUTER;
 
+			      /* need to move unnecessary spec list located between the two swapped specs to the end of the entire spec list */
 			      s_start = NULL;
 			      p_end = p_spec;
 			      s_end = p_spec;
 
 			      for (tmp = p_spec; tmp != spec; tmp = tmp->next)
 				{
+				  /* find the head node of the spec list to be moved
+				   * find the previous node to detach the head node */
 				  if (!s_start && tmp->next->info.spec.join_type == PT_JOIN_NONE && tmp->next != spec)
 				    {
 				      p_end = tmp;
@@ -2689,6 +2692,7 @@ pt_bind_names (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue
 				      s_end = tmp;
 				    }
 
+				  /* if the head node of the spec list to be moved is found, also find the tail node of the spec list to be moved */
 				  if (s_start)
 				    {
 				      if (tmp->next == spec)
@@ -2702,6 +2706,7 @@ pt_bind_names (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue
 				{
 				  ;
 				}
+			      /* found end of spec list */
 
 			      s_end->next = NULL;
 			      p_end->next = spec;

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -2676,7 +2676,7 @@ pt_bind_names (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue
 			      s_start = NULL;
 			      s_end = NULL;
 
-			      for (tmp = p_spec; tmp->next; tmp = tmp->next)
+			      for (tmp = p_spec; tmp && tmp->next; tmp = tmp->next)
 				{
 				  if (!s_start)
 				    {

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -2670,6 +2670,29 @@ pt_bind_names (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue
 
 			      /* converse join type */
 			      join_type = (join_type == PT_JOIN_LEFT_OUTER) ? PT_JOIN_RIGHT_OUTER : PT_JOIN_LEFT_OUTER;
+
+			      for (tmp = p_spec; tmp->next != spec; tmp = tmp->next)
+				{
+				  if (tmp->next->info.spec.join_type == PT_JOIN_NONE)
+				    {
+				      s_start = tmp->next;
+				      tmp->next = spec;
+				      break;
+				    }
+				}
+
+			      for (tmp = s_start; tmp->next != spec; tmp = tmp->next)
+				{
+				  ;
+				}
+			      tmp->next = NULL;
+
+			      for (tmp = spec; tmp->next; tmp = tmp->next)
+				{
+				  ;
+				}
+
+			      tmp->next = s_start;
 			    }
 			  else
 			    {

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -2671,27 +2671,40 @@ pt_bind_names (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue
 			      /* converse join type */
 			      join_type = (join_type == PT_JOIN_LEFT_OUTER) ? PT_JOIN_RIGHT_OUTER : PT_JOIN_LEFT_OUTER;
 
-			      for (tmp = p_spec; tmp->next != spec; tmp = tmp->next)
+			      s_start = NULL;
+			      p_end = p_spec;
+			      s_end = p_spec;
+
+			      for (tmp = p_spec; tmp != spec; tmp = tmp->next)
 				{
-				  if (tmp->next->info.spec.join_type == PT_JOIN_NONE)
+				  if (!s_start && tmp->next->info.spec.join_type == PT_JOIN_NONE && tmp->next != spec)
 				    {
+				      p_end = tmp;
 				      s_start = tmp->next;
-				      tmp->next = spec;
-				      break;
+				    }
+
+				  else if (!s_start)
+				    {
+				      p_end = tmp;
+				      s_end = tmp;
+				    }
+
+				  if (s_start)
+				    {
+				      if (tmp->next == spec)
+					{
+					  s_end = tmp;
+					}
 				    }
 				}
-
-			      for (tmp = s_start; tmp->next != spec; tmp = tmp->next)
-				{
-				  ;
-				}
-			      tmp->next = NULL;
 
 			      for (tmp = spec; tmp->next; tmp = tmp->next)
 				{
 				  ;
 				}
 
+			      s_end->next = NULL;
+			      p_end->next = spec;
 			      tmp->next = s_start;
 			    }
 			  else


### PR DESCRIPTION
[http://jira.cubrid.org/browse/CBRD-25484](http://jira.cubrid.org/browse/CBRD-25484)

네 개 이상의 테이블을 조인하면서, inner join과 non-ANSI outer join을 포함하는 쿼리를 수행할 때, 조인 조건으로 사용된 컬럼을 찾지 못해 오류가 발생합니다.

해당 오류는 Semantic check 단계에서, PT_SPEC의 조인 조건에 사용된 PT_NAME 노드를 바인딩할 때 발생하는 것으로,
아우터 조인해야 할 두 spec 사이에 다른 spec이 위치할 때 발생합니다.

아우터 조인해야 할 spec 사이에 다른 spec이 위치하는 이유는 non-ANSI outer join을 ANSI outer join으로 변환할 때 조인 조건의 나열 순서와 테이블의 나열 순서에 따라 spec의 순서와 조인 방향이 변경되기 때문입니다.