### PR TITLE
[CBRD-25372] remove pt_check_class_attr_qspec_compatible

### DIFF
--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -7571,11 +7571,6 @@ pt_check_vclass_query_spec (PARSER_CONTEXT * parser, PT_NODE * qry, PT_NODE * at
 			   attribute_name (parser, attr), pt_short_print (parser, col));
 	    }
 	}
-      else if (pt_check_vclass_attr_qspec_compatible (parser, attr, col) != PT_UNION_COMP)
-	{
-	  PT_ERRORmf2 (parser, col, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_ATT_INCOMPATIBLE_COL,
-		       attribute_name (parser, attr), pt_short_print (parser, col));
-	}
 
       /* any shared attribute must correspond to NA in the query_spec */
       if (is_shared_attribute (parser, attr) && col->type_enum != PT_TYPE_NA && col->type_enum != PT_TYPE_NULL)

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -7255,27 +7255,6 @@ pt_is_compatible_type (const PT_TYPE_ENUM arg1_type, const PT_TYPE_ENUM arg2_typ
 }
 
 /*
- * pt_check_vclass_attr_qspec_compatible () -
- *   return:
- *   parser(in):
- *   attr(in):
- *   col(in):
- */
-static PT_UNION_COMPATIBLE
-pt_check_vclass_attr_qspec_compatible (PARSER_CONTEXT * parser, PT_NODE * attr, PT_NODE * col)
-{
-  bool is_object_type;
-  PT_UNION_COMPATIBLE c = pt_union_compatible (parser, attr, col, true, &is_object_type);
-
-  if (c == PT_UNION_INCOMP && pt_is_compatible_type (attr->type_enum, col->type_enum))
-    {
-      c = PT_UNION_COMP;
-    }
-
-  return c;
-}
-
-/*
  * pt_check_vclass_union_spec () -
  *   return:
  *   parser(in):


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25372

This PR continues the analysis done by https://github.com/CUBRID/cubrid/pull/5224

## Create View 수행 시, column에 대한 타입 변환 가능 여부 삭제

큐브리드는 현재 각 뷰의 컬럼에 대해 타입 변환이 가능한지 확인하는데, Oracle의 경우에는 이러한 타입 검사를 수행하지 않고 뷰가 생성됩니다. 대신 뷰가 실행될 때 타입 변환이 가능한지 여부를 확인하며, 만약 타입 변환이 불가능하다면 오류가 처리됩니다.

따라서 이 PR은 create view를 할 시 class attribute의 타입 비교 검사를 없애고, 타입이 맞지 않더라도 뷰를 정상 생성시킵니다.

### As Is

```sql
create table tbl (flag char(1));

insert into tbl values('1');

// works fine
create view v1 ( sum1 numeric(22) ) as select 0+nvl(flag, '0')  from tbl;
// error!
create view v1 ( sum1 numeric(22) ) as select nvl(flag, '0')  from tbl;

```

### To Be
```sql
// works fine too
create view v1 ( sum1 numeric(22) ) as select nvl(flag, '0')  from tbl;
```

### cubrid-testcases

fail된 medium와 sql 테스트는 아래 테스트 케이스를 머지하면 통과하게 됩니다.
https://github.com/CUBRID/cubrid-testcases/pull/1834

