### PR TITLE
[CBRD-25156] integer division considering ORACLE_COMPAT_NUMBER_BEHAVIOR system parameter

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/CoercionScheme.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/CoercionScheme.java
@@ -360,33 +360,33 @@ public enum CoercionScheme {
         compOpCommonType[Type.IDX_OBJECT][Type.IDX_OBJECT] = Type.OBJECT;
 
         compOpCommonType[Type.IDX_BOOLEAN][Type.IDX_NULL] = Type.BOOLEAN;
-        compOpCommonType[Type.IDX_BOOLEAN][Type.IDX_OBJECT] = Type.BOOLEAN;
+        compOpCommonType[Type.IDX_BOOLEAN][Type.IDX_OBJECT] = Type.OBJECT;
         compOpCommonType[Type.IDX_BOOLEAN][Type.IDX_BOOLEAN] = Type.BOOLEAN;
 
         compOpCommonType[Type.IDX_STRING][Type.IDX_NULL] = Type.STRING_ANY;
-        compOpCommonType[Type.IDX_STRING][Type.IDX_OBJECT] = Type.STRING_ANY;
+        compOpCommonType[Type.IDX_STRING][Type.IDX_OBJECT] = Type.OBJECT;
         compOpCommonType[Type.IDX_STRING][Type.IDX_STRING] = Type.STRING_ANY;
 
         compOpCommonType[Type.IDX_SHORT][Type.IDX_NULL] = Type.SHORT;
-        compOpCommonType[Type.IDX_SHORT][Type.IDX_OBJECT] = Type.SHORT;
+        compOpCommonType[Type.IDX_SHORT][Type.IDX_OBJECT] = Type.OBJECT;
         compOpCommonType[Type.IDX_SHORT][Type.IDX_STRING] = Type.DOUBLE;
         compOpCommonType[Type.IDX_SHORT][Type.IDX_SHORT] = Type.SHORT;
 
         compOpCommonType[Type.IDX_INT][Type.IDX_NULL] = Type.INT;
-        compOpCommonType[Type.IDX_INT][Type.IDX_OBJECT] = Type.INT;
+        compOpCommonType[Type.IDX_INT][Type.IDX_OBJECT] = Type.OBJECT;
         compOpCommonType[Type.IDX_INT][Type.IDX_STRING] = Type.DOUBLE;
         compOpCommonType[Type.IDX_INT][Type.IDX_SHORT] = Type.INT;
         compOpCommonType[Type.IDX_INT][Type.IDX_INT] = Type.INT;
 
         compOpCommonType[Type.IDX_BIGINT][Type.IDX_NULL] = Type.BIGINT;
-        compOpCommonType[Type.IDX_BIGINT][Type.IDX_OBJECT] = Type.BIGINT;
+        compOpCommonType[Type.IDX_BIGINT][Type.IDX_OBJECT] = Type.OBJECT;
         compOpCommonType[Type.IDX_BIGINT][Type.IDX_STRING] = Type.DOUBLE;
         compOpCommonType[Type.IDX_BIGINT][Type.IDX_SHORT] = Type.BIGINT;
         compOpCommonType[Type.IDX_BIGINT][Type.IDX_INT] = Type.BIGINT;
         compOpCommonType[Type.IDX_BIGINT][Type.IDX_BIGINT] = Type.BIGINT;
 
         compOpCommonType[Type.IDX_NUMERIC][Type.IDX_NULL] = Type.NUMERIC_ANY;
-        compOpCommonType[Type.IDX_NUMERIC][Type.IDX_OBJECT] = Type.NUMERIC_ANY;
+        compOpCommonType[Type.IDX_NUMERIC][Type.IDX_OBJECT] = Type.OBJECT;
         compOpCommonType[Type.IDX_NUMERIC][Type.IDX_STRING] = Type.DOUBLE;
         compOpCommonType[Type.IDX_NUMERIC][Type.IDX_SHORT] = Type.NUMERIC_ANY;
         compOpCommonType[Type.IDX_NUMERIC][Type.IDX_INT] = Type.NUMERIC_ANY;
@@ -394,7 +394,7 @@ public enum CoercionScheme {
         compOpCommonType[Type.IDX_NUMERIC][Type.IDX_NUMERIC] = Type.NUMERIC_ANY;
 
         compOpCommonType[Type.IDX_FLOAT][Type.IDX_NULL] = Type.FLOAT;
-        compOpCommonType[Type.IDX_FLOAT][Type.IDX_OBJECT] = Type.FLOAT;
+        compOpCommonType[Type.IDX_FLOAT][Type.IDX_OBJECT] = Type.OBJECT;
         compOpCommonType[Type.IDX_FLOAT][Type.IDX_STRING] = Type.DOUBLE;
         compOpCommonType[Type.IDX_FLOAT][Type.IDX_SHORT] = Type.FLOAT;
         compOpCommonType[Type.IDX_FLOAT][Type.IDX_INT] = Type.FLOAT;
@@ -403,7 +403,7 @@ public enum CoercionScheme {
         compOpCommonType[Type.IDX_FLOAT][Type.IDX_FLOAT] = Type.FLOAT;
 
         compOpCommonType[Type.IDX_DOUBLE][Type.IDX_NULL] = Type.DOUBLE;
-        compOpCommonType[Type.IDX_DOUBLE][Type.IDX_OBJECT] = Type.DOUBLE;
+        compOpCommonType[Type.IDX_DOUBLE][Type.IDX_OBJECT] = Type.OBJECT;
         compOpCommonType[Type.IDX_DOUBLE][Type.IDX_STRING] = Type.DOUBLE;
         compOpCommonType[Type.IDX_DOUBLE][Type.IDX_SHORT] = Type.DOUBLE;
         compOpCommonType[Type.IDX_DOUBLE][Type.IDX_INT] = Type.DOUBLE;
@@ -413,12 +413,12 @@ public enum CoercionScheme {
         compOpCommonType[Type.IDX_DOUBLE][Type.IDX_DOUBLE] = Type.DOUBLE;
 
         compOpCommonType[Type.IDX_DATE][Type.IDX_NULL] = Type.DATE;
-        compOpCommonType[Type.IDX_DATE][Type.IDX_OBJECT] = Type.DATE;
+        compOpCommonType[Type.IDX_DATE][Type.IDX_OBJECT] = Type.OBJECT;
         compOpCommonType[Type.IDX_DATE][Type.IDX_STRING] = Type.DATE;
         compOpCommonType[Type.IDX_DATE][Type.IDX_DATE] = Type.DATE;
 
         compOpCommonType[Type.IDX_TIME][Type.IDX_NULL] = Type.TIME;
-        compOpCommonType[Type.IDX_TIME][Type.IDX_OBJECT] = Type.TIME;
+        compOpCommonType[Type.IDX_TIME][Type.IDX_OBJECT] = Type.OBJECT;
         compOpCommonType[Type.IDX_TIME][Type.IDX_STRING] = Type.TIME;
         compOpCommonType[Type.IDX_TIME][Type.IDX_SHORT] = Type.TIME;
         compOpCommonType[Type.IDX_TIME][Type.IDX_INT] = Type.TIME;
@@ -426,13 +426,13 @@ public enum CoercionScheme {
         compOpCommonType[Type.IDX_TIME][Type.IDX_TIME] = Type.TIME;
 
         compOpCommonType[Type.IDX_DATETIME][Type.IDX_NULL] = Type.DATETIME;
-        compOpCommonType[Type.IDX_DATETIME][Type.IDX_OBJECT] = Type.DATETIME;
+        compOpCommonType[Type.IDX_DATETIME][Type.IDX_OBJECT] = Type.OBJECT;
         compOpCommonType[Type.IDX_DATETIME][Type.IDX_STRING] = Type.DATETIME;
         compOpCommonType[Type.IDX_DATETIME][Type.IDX_DATE] = Type.DATETIME;
         compOpCommonType[Type.IDX_DATETIME][Type.IDX_DATETIME] = Type.DATETIME;
 
         compOpCommonType[Type.IDX_TIMESTAMP][Type.IDX_NULL] = Type.TIMESTAMP;
-        compOpCommonType[Type.IDX_TIMESTAMP][Type.IDX_OBJECT] = Type.TIMESTAMP;
+        compOpCommonType[Type.IDX_TIMESTAMP][Type.IDX_OBJECT] = Type.OBJECT;
         compOpCommonType[Type.IDX_TIMESTAMP][Type.IDX_STRING] = Type.TIMESTAMP;
         compOpCommonType[Type.IDX_TIMESTAMP][Type.IDX_SHORT] = Type.TIMESTAMP;
         compOpCommonType[Type.IDX_TIMESTAMP][Type.IDX_INT] = Type.TIMESTAMP;

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/CoercionScheme.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/CoercionScheme.java
@@ -133,7 +133,10 @@ public enum CoercionScheme {
                 Type rType = argTypes.get(1);
 
                 Type commonTy;
-                if (opName.equals("opSubtract")) {
+                if (opName.equals("opAdd")) {
+                    commonTy =
+                            getCommonTypeInner(lType, rType, arithOpCommonType, addCommonTypeExt);
+                } else if (opName.equals("opSubtract")) {
                     commonTy =
                             getCommonTypeInner(
                                     lType, rType, arithOpCommonType, subtractCommonTypeExt);
@@ -443,6 +446,7 @@ public enum CoercionScheme {
     // Setting for arithmetic operators (unary -, *, /, +, binary -)
 
     static final Type[][] arithOpCommonType = new Type[Type.BOUND_OF_IDX][Type.BOUND_OF_IDX];
+    static final Type[][] addCommonTypeExt = new Type[Type.BOUND_OF_IDX][Type.BOUND_OF_IDX];
     static final Type[][] subtractCommonTypeExt = new Type[Type.BOUND_OF_IDX][Type.BOUND_OF_IDX];
 
     static {
@@ -451,28 +455,30 @@ public enum CoercionScheme {
         arithOpCommonType[Type.IDX_OBJECT][Type.IDX_NULL] = Type.OBJECT;
         arithOpCommonType[Type.IDX_OBJECT][Type.IDX_OBJECT] = Type.OBJECT;
 
+        arithOpCommonType[Type.IDX_STRING][Type.IDX_NULL] = Type.STRING_ANY;
+        arithOpCommonType[Type.IDX_STRING][Type.IDX_OBJECT] = Type.OBJECT;
         arithOpCommonType[Type.IDX_STRING][Type.IDX_STRING] = Type.DOUBLE;
 
         arithOpCommonType[Type.IDX_SHORT][Type.IDX_NULL] = Type.SHORT;
-        arithOpCommonType[Type.IDX_SHORT][Type.IDX_OBJECT] = Type.SHORT;
+        arithOpCommonType[Type.IDX_SHORT][Type.IDX_OBJECT] = Type.OBJECT;
         arithOpCommonType[Type.IDX_SHORT][Type.IDX_STRING] = Type.DOUBLE;
         arithOpCommonType[Type.IDX_SHORT][Type.IDX_SHORT] = Type.SHORT;
 
         arithOpCommonType[Type.IDX_INT][Type.IDX_NULL] = Type.INT;
-        arithOpCommonType[Type.IDX_INT][Type.IDX_OBJECT] = Type.INT;
+        arithOpCommonType[Type.IDX_INT][Type.IDX_OBJECT] = Type.OBJECT;
         arithOpCommonType[Type.IDX_INT][Type.IDX_STRING] = Type.DOUBLE;
         arithOpCommonType[Type.IDX_INT][Type.IDX_SHORT] = Type.INT;
         arithOpCommonType[Type.IDX_INT][Type.IDX_INT] = Type.INT;
 
         arithOpCommonType[Type.IDX_BIGINT][Type.IDX_NULL] = Type.BIGINT;
-        arithOpCommonType[Type.IDX_BIGINT][Type.IDX_OBJECT] = Type.BIGINT;
+        arithOpCommonType[Type.IDX_BIGINT][Type.IDX_OBJECT] = Type.OBJECT;
         arithOpCommonType[Type.IDX_BIGINT][Type.IDX_STRING] = Type.DOUBLE;
         arithOpCommonType[Type.IDX_BIGINT][Type.IDX_SHORT] = Type.BIGINT;
         arithOpCommonType[Type.IDX_BIGINT][Type.IDX_INT] = Type.BIGINT;
         arithOpCommonType[Type.IDX_BIGINT][Type.IDX_BIGINT] = Type.BIGINT;
 
         arithOpCommonType[Type.IDX_NUMERIC][Type.IDX_NULL] = Type.NUMERIC_ANY;
-        arithOpCommonType[Type.IDX_NUMERIC][Type.IDX_OBJECT] = Type.NUMERIC_ANY;
+        arithOpCommonType[Type.IDX_NUMERIC][Type.IDX_OBJECT] = Type.OBJECT;
         arithOpCommonType[Type.IDX_NUMERIC][Type.IDX_STRING] = Type.DOUBLE;
         arithOpCommonType[Type.IDX_NUMERIC][Type.IDX_SHORT] = Type.NUMERIC_ANY;
         arithOpCommonType[Type.IDX_NUMERIC][Type.IDX_INT] = Type.NUMERIC_ANY;
@@ -480,7 +486,7 @@ public enum CoercionScheme {
         arithOpCommonType[Type.IDX_NUMERIC][Type.IDX_NUMERIC] = Type.NUMERIC_ANY;
 
         arithOpCommonType[Type.IDX_FLOAT][Type.IDX_NULL] = Type.FLOAT;
-        arithOpCommonType[Type.IDX_FLOAT][Type.IDX_OBJECT] = Type.FLOAT;
+        arithOpCommonType[Type.IDX_FLOAT][Type.IDX_OBJECT] = Type.OBJECT;
         arithOpCommonType[Type.IDX_FLOAT][Type.IDX_STRING] = Type.DOUBLE;
         arithOpCommonType[Type.IDX_FLOAT][Type.IDX_SHORT] = Type.FLOAT;
         arithOpCommonType[Type.IDX_FLOAT][Type.IDX_INT] = Type.FLOAT;
@@ -489,7 +495,7 @@ public enum CoercionScheme {
         arithOpCommonType[Type.IDX_FLOAT][Type.IDX_FLOAT] = Type.FLOAT;
 
         arithOpCommonType[Type.IDX_DOUBLE][Type.IDX_NULL] = Type.DOUBLE;
-        arithOpCommonType[Type.IDX_DOUBLE][Type.IDX_OBJECT] = Type.DOUBLE;
+        arithOpCommonType[Type.IDX_DOUBLE][Type.IDX_OBJECT] = Type.OBJECT;
         arithOpCommonType[Type.IDX_DOUBLE][Type.IDX_STRING] = Type.DOUBLE;
         arithOpCommonType[Type.IDX_DOUBLE][Type.IDX_SHORT] = Type.DOUBLE;
         arithOpCommonType[Type.IDX_DOUBLE][Type.IDX_INT] = Type.DOUBLE;
@@ -498,16 +504,26 @@ public enum CoercionScheme {
         arithOpCommonType[Type.IDX_DOUBLE][Type.IDX_FLOAT] = Type.DOUBLE;
         arithOpCommonType[Type.IDX_DOUBLE][Type.IDX_DOUBLE] = Type.DOUBLE;
 
+        addCommonTypeExt[Type.IDX_STRING][Type.IDX_STRING] = Type.STRING_ANY;
+        addCommonTypeExt[Type.IDX_DATE][Type.IDX_OBJECT] = Type.OBJECT;
+        addCommonTypeExt[Type.IDX_TIME][Type.IDX_OBJECT] = Type.OBJECT;
+        addCommonTypeExt[Type.IDX_DATETIME][Type.IDX_OBJECT] = Type.OBJECT;
+        addCommonTypeExt[Type.IDX_TIMESTAMP][Type.IDX_OBJECT] = Type.OBJECT;
+
+        subtractCommonTypeExt[Type.IDX_DATE][Type.IDX_OBJECT] = Type.OBJECT;
         subtractCommonTypeExt[Type.IDX_DATE][Type.IDX_STRING] = Type.DATETIME;
         subtractCommonTypeExt[Type.IDX_DATE][Type.IDX_DATE] = Type.DATE;
 
+        subtractCommonTypeExt[Type.IDX_TIME][Type.IDX_OBJECT] = Type.OBJECT;
         subtractCommonTypeExt[Type.IDX_TIME][Type.IDX_STRING] = Type.TIME;
         subtractCommonTypeExt[Type.IDX_TIME][Type.IDX_TIME] = Type.TIME;
 
+        subtractCommonTypeExt[Type.IDX_DATETIME][Type.IDX_OBJECT] = Type.OBJECT;
         subtractCommonTypeExt[Type.IDX_DATETIME][Type.IDX_STRING] = Type.DATETIME;
         subtractCommonTypeExt[Type.IDX_DATETIME][Type.IDX_DATE] = Type.DATETIME;
         subtractCommonTypeExt[Type.IDX_DATETIME][Type.IDX_DATETIME] = Type.DATETIME;
 
+        subtractCommonTypeExt[Type.IDX_TIMESTAMP][Type.IDX_OBJECT] = Type.OBJECT;
         subtractCommonTypeExt[Type.IDX_TIMESTAMP][Type.IDX_STRING] = Type.DATETIME;
         subtractCommonTypeExt[Type.IDX_TIMESTAMP][Type.IDX_DATE] = Type.TIMESTAMP;
         subtractCommonTypeExt[Type.IDX_TIMESTAMP][Type.IDX_DATETIME] = Type.DATETIME;
@@ -525,28 +541,30 @@ public enum CoercionScheme {
         intArithOpCommonType[Type.IDX_OBJECT][Type.IDX_NULL] = Type.OBJECT;
         intArithOpCommonType[Type.IDX_OBJECT][Type.IDX_OBJECT] = Type.OBJECT;
 
+        intArithOpCommonType[Type.IDX_STRING][Type.IDX_NULL] = Type.BIGINT;
+        intArithOpCommonType[Type.IDX_STRING][Type.IDX_OBJECT] = Type.OBJECT;
         intArithOpCommonType[Type.IDX_STRING][Type.IDX_STRING] = Type.BIGINT;
 
         intArithOpCommonType[Type.IDX_SHORT][Type.IDX_NULL] = Type.SHORT;
-        intArithOpCommonType[Type.IDX_SHORT][Type.IDX_OBJECT] = Type.SHORT;
+        intArithOpCommonType[Type.IDX_SHORT][Type.IDX_OBJECT] = Type.OBJECT;
         intArithOpCommonType[Type.IDX_SHORT][Type.IDX_STRING] = Type.BIGINT;
         intArithOpCommonType[Type.IDX_SHORT][Type.IDX_SHORT] = Type.SHORT;
 
         intArithOpCommonType[Type.IDX_INT][Type.IDX_NULL] = Type.INT;
-        intArithOpCommonType[Type.IDX_INT][Type.IDX_OBJECT] = Type.INT;
+        intArithOpCommonType[Type.IDX_INT][Type.IDX_OBJECT] = Type.OBJECT;
         intArithOpCommonType[Type.IDX_INT][Type.IDX_STRING] = Type.BIGINT;
         intArithOpCommonType[Type.IDX_INT][Type.IDX_SHORT] = Type.INT;
         intArithOpCommonType[Type.IDX_INT][Type.IDX_INT] = Type.INT;
 
         intArithOpCommonType[Type.IDX_BIGINT][Type.IDX_NULL] = Type.BIGINT;
-        intArithOpCommonType[Type.IDX_BIGINT][Type.IDX_OBJECT] = Type.BIGINT;
+        intArithOpCommonType[Type.IDX_BIGINT][Type.IDX_OBJECT] = Type.OBJECT;
         intArithOpCommonType[Type.IDX_BIGINT][Type.IDX_STRING] = Type.BIGINT;
         intArithOpCommonType[Type.IDX_BIGINT][Type.IDX_SHORT] = Type.BIGINT;
         intArithOpCommonType[Type.IDX_BIGINT][Type.IDX_INT] = Type.BIGINT;
         intArithOpCommonType[Type.IDX_BIGINT][Type.IDX_BIGINT] = Type.BIGINT;
 
         intArithOpCommonType[Type.IDX_NUMERIC][Type.IDX_NULL] = Type.BIGINT;
-        intArithOpCommonType[Type.IDX_NUMERIC][Type.IDX_OBJECT] = Type.BIGINT;
+        intArithOpCommonType[Type.IDX_NUMERIC][Type.IDX_OBJECT] = Type.OBJECT;
         intArithOpCommonType[Type.IDX_NUMERIC][Type.IDX_STRING] = Type.BIGINT;
         intArithOpCommonType[Type.IDX_NUMERIC][Type.IDX_SHORT] = Type.BIGINT;
         intArithOpCommonType[Type.IDX_NUMERIC][Type.IDX_INT] = Type.BIGINT;
@@ -554,7 +572,7 @@ public enum CoercionScheme {
         intArithOpCommonType[Type.IDX_NUMERIC][Type.IDX_NUMERIC] = Type.BIGINT;
 
         intArithOpCommonType[Type.IDX_FLOAT][Type.IDX_NULL] = Type.BIGINT;
-        intArithOpCommonType[Type.IDX_FLOAT][Type.IDX_OBJECT] = Type.BIGINT;
+        intArithOpCommonType[Type.IDX_FLOAT][Type.IDX_OBJECT] = Type.OBJECT;
         intArithOpCommonType[Type.IDX_FLOAT][Type.IDX_STRING] = Type.BIGINT;
         intArithOpCommonType[Type.IDX_FLOAT][Type.IDX_SHORT] = Type.BIGINT;
         intArithOpCommonType[Type.IDX_FLOAT][Type.IDX_INT] = Type.BIGINT;
@@ -563,7 +581,7 @@ public enum CoercionScheme {
         intArithOpCommonType[Type.IDX_FLOAT][Type.IDX_FLOAT] = Type.BIGINT;
 
         intArithOpCommonType[Type.IDX_DOUBLE][Type.IDX_NULL] = Type.BIGINT;
-        intArithOpCommonType[Type.IDX_DOUBLE][Type.IDX_OBJECT] = Type.BIGINT;
+        intArithOpCommonType[Type.IDX_DOUBLE][Type.IDX_OBJECT] = Type.OBJECT;
         intArithOpCommonType[Type.IDX_DOUBLE][Type.IDX_STRING] = Type.BIGINT;
         intArithOpCommonType[Type.IDX_DOUBLE][Type.IDX_SHORT] = Type.BIGINT;
         intArithOpCommonType[Type.IDX_DOUBLE][Type.IDX_INT] = Type.BIGINT;
@@ -607,7 +625,7 @@ public enum CoercionScheme {
         }
 
         int tables = table.length;
-        for (int i = 0; i < tables; i++) {
+        for (int i = tables - 1; i >= 0; i--) { // check extensions first
             Type commonTy = table[i][row][col];
             if (commonTy != null) {
                 return commonTy;

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -780,13 +780,13 @@ public class SpLib {
             // bigint
             return opBitCompli((Long) l);
         } else if (l instanceof BigDecimal) {
-            // not applicable
+            // bigint
             return opBitCompli(convNumericToBigint((BigDecimal) l));
         } else if (l instanceof Float) {
-            // not applicable
+            // bigint
             return opBitCompli(convFloatToBigint((Float) l));
         } else if (l instanceof Double) {
-            // not applicable
+            // bigint
             return opBitCompli(convDoubleToBigint((Double) l));
         } else if (l instanceof Date) {
             // not applicable

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -2030,36 +2030,49 @@ public class SpLib {
     // ====================================
     // /
     @Operator(coercionScheme = CoercionScheme.ArithOp)
-    public static Short opDiv(Short l, Short r) {
+    public static Object opDiv(Short l, Short r) {
         if (l == null || r == null) {
             return null;
         }
         if (r.equals((short) 0)) {
             throw new ZERO_DIVIDE();
         }
-        return (short) (l / r);
+        if (Server.getSystemParameterBool(Server.SYS_PARAM_ORACLE_COMPAT_NUMBER_BEHAVIOR)) {
+            return opDiv(BigDecimal.valueOf(l.longValue()), BigDecimal.valueOf(r.longValue()));
+        } else {
+            return (short) (l / r);
+        }
     }
 
     @Operator(coercionScheme = CoercionScheme.ArithOp)
-    public static Integer opDiv(Integer l, Integer r) {
+    public static Object opDiv(Integer l, Integer r) {
         if (l == null || r == null) {
             return null;
         }
         if (r.equals(0)) {
             throw new ZERO_DIVIDE();
         }
-        return l / r;
+        if (Server.getSystemParameterBool(Server.SYS_PARAM_ORACLE_COMPAT_NUMBER_BEHAVIOR)) {
+            return opDiv(BigDecimal.valueOf(l.longValue()), BigDecimal.valueOf(r.longValue()));
+        } else {
+            return l / r;
+        }
     }
 
     @Operator(coercionScheme = CoercionScheme.ArithOp)
-    public static Long opDiv(Long l, Long r) {
+    public static Object opDiv(Long l, Long r) {
         if (l == null || r == null) {
             return null;
         }
         if (r.equals(0)) {
             throw new ZERO_DIVIDE();
         }
-        return l / r;
+
+        if (Server.getSystemParameterBool(Server.SYS_PARAM_ORACLE_COMPAT_NUMBER_BEHAVIOR)) {
+            return opDiv(BigDecimal.valueOf(l), BigDecimal.valueOf(r));
+        } else {
+            return l / r;
+        }
     }
 
     @Operator(coercionScheme = CoercionScheme.ArithOp)

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -689,7 +689,42 @@ public class SpLib {
         if (l == null) {
             return null;
         }
-        throw new PROGRAM_ERROR(); // unreachable
+
+        if (l instanceof Boolean) {
+            // not applicable
+        } else if (l instanceof String) {
+            // double
+            return opNeg(convStringToDouble((String) l));
+        } else if (l instanceof Short) {
+            // short
+            return opNeg((Short) l);
+        } else if (l instanceof Integer) {
+            // int
+            return opNeg((Integer) l);
+        } else if (l instanceof Long) {
+            // bigint
+            return opNeg((Long) l);
+        } else if (l instanceof BigDecimal) {
+            // numeric
+            return opNeg((BigDecimal) l);
+        } else if (l instanceof Float) {
+            // float
+            return opNeg((Float) l);
+        } else if (l instanceof Double) {
+            // double
+            return opNeg((Double) l);
+        } else if (l instanceof Date) {
+            // not applicable
+        } else if (l instanceof Time) {
+            // not applicable
+        } else if (l instanceof Timestamp) {
+            throw new PROGRAM_ERROR("operand's type is ambiguous: TIMESTAMP or DATETIME");
+        }
+
+        throw new VALUE_ERROR(
+                String.format(
+                        "cannot negate the argument due to its incompatible run-time type %s",
+                        plcsqlTypeOfJavaObject(l)));
     }
 
     // ====================================
@@ -729,7 +764,42 @@ public class SpLib {
         if (l == null) {
             return null;
         }
-        throw new PROGRAM_ERROR(); // unreachable
+
+        if (l instanceof Boolean) {
+            // not applicable
+        } else if (l instanceof String) {
+            // bigint
+            return opBitCompli(convStringToBigint((String) l));
+        } else if (l instanceof Short) {
+            // short
+            return opBitCompli((Short) l);
+        } else if (l instanceof Integer) {
+            // int
+            return opBitCompli((Integer) l);
+        } else if (l instanceof Long) {
+            // bigint
+            return opBitCompli((Long) l);
+        } else if (l instanceof BigDecimal) {
+            // not applicable
+            return opBitCompli(convNumericToBigint((BigDecimal) l));
+        } else if (l instanceof Float) {
+            // not applicable
+            return opBitCompli(convFloatToBigint((Float) l));
+        } else if (l instanceof Double) {
+            // not applicable
+            return opBitCompli(convDoubleToBigint((Double) l));
+        } else if (l instanceof Date) {
+            // not applicable
+        } else if (l instanceof Time) {
+            // not applicable
+        } else if (l instanceof Timestamp) {
+            throw new PROGRAM_ERROR("operand's type is ambiguous: TIMESTAMP or DATETIME");
+        }
+
+        throw new VALUE_ERROR(
+                String.format(
+                        "cannot take bit-compliment of the argument due to its incompatible run-time type %s",
+                        plcsqlTypeOfJavaObject(l)));
     }
 
     // ====================================
@@ -2024,7 +2094,8 @@ public class SpLib {
         if (l == null || r == null) {
             return null;
         }
-        throw new PROGRAM_ERROR(); // unreachable
+
+        return opMultWithRuntimeTypeConv(l, r);
     }
 
     // ====================================
@@ -2143,7 +2214,8 @@ public class SpLib {
         if (l == null || r == null) {
             return null;
         }
-        throw new PROGRAM_ERROR(); // unreachable
+
+        return opDivWithRuntimeTypeConv(l, r);
     }
 
     // ====================================
@@ -2195,7 +2267,8 @@ public class SpLib {
         if (l == null || r == null) {
             return null;
         }
-        throw new PROGRAM_ERROR(); // unreachable
+
+        return opDivIntWithRuntimeTypeConv(l, r);
     }
 
     // ====================================
@@ -2247,11 +2320,20 @@ public class SpLib {
         if (l == null || r == null) {
             return null;
         }
-        throw new PROGRAM_ERROR(); // unreachable
+
+        return opModWithRuntimeTypeConv(l, r);
     }
 
     // ====================================
     // +
+    @Operator(coercionScheme = CoercionScheme.ArithOp)
+    public static String opAdd(String l, String r) {
+        if (l == null || r == null) {
+            return null;
+        }
+        return (l + r);
+    }
+
     @Operator(coercionScheme = CoercionScheme.ArithOp)
     public static Short opAdd(Short l, Short r) {
         if (l == null || r == null) {
@@ -2411,7 +2493,8 @@ public class SpLib {
         if (l == null || r == null) {
             return null;
         }
-        throw new PROGRAM_ERROR(); // unreachable
+
+        return opAddWithRuntimeTypeConv(l, r);
     }
 
     // ====================================
@@ -2612,7 +2695,8 @@ public class SpLib {
         if (l == null || r == null) {
             return null;
         }
-        throw new PROGRAM_ERROR(); // unreachable
+
+        return opSubtractWithRuntimeTypeConv(l, r);
     }
 
     // ====================================
@@ -3951,6 +4035,1671 @@ public class SpLib {
         }
     }
 
+    private static Object opAddWithRuntimeTypeConv(Object l, Object r) {
+        assert l != null;
+        assert r != null;
+
+        if (l instanceof Boolean) {
+            // not applicable
+        } else if (l instanceof String) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // string
+                return opAdd((String) l, (String) r);
+            } else if (r instanceof Short) {
+                // double
+                return opAdd(convStringToDouble((String) l), convShortToDouble((Short) r));
+            } else if (r instanceof Integer) {
+                // double
+                return opAdd(convStringToDouble((String) l), convIntToDouble((Integer) r));
+            } else if (r instanceof Long) {
+                // double
+                return opAdd(convStringToDouble((String) l), convBigintToDouble((Long) r));
+            } else if (r instanceof BigDecimal) {
+                // double
+                return opAdd(convStringToDouble((String) l), convNumericToDouble((BigDecimal) r));
+            } else if (r instanceof Float) {
+                // double
+                return opAdd(convStringToDouble((String) l), convFloatToDouble((Float) r));
+            } else if (r instanceof Double) {
+                // double
+                return opAdd(convStringToDouble((String) l), (Double) r);
+            } else if (r instanceof Date) {
+                // (bigint, date)
+                return opAdd(convStringToBigint((String) l), (Date) r);
+            } else if (r instanceof Time) {
+                // (bigint, time)
+                return opAdd(convStringToBigint((String) l), (Time) r);
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Short) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // double
+                return opAdd(convShortToDouble((Short) l), convStringToDouble((String) r));
+            } else if (r instanceof Short) {
+                // short
+                return opAdd((Short) l, (Short) r);
+            } else if (r instanceof Integer) {
+                // int
+                return opAdd(convShortToInt((Short) l), (Integer) r);
+            } else if (r instanceof Long) {
+                // bigint
+                return opAdd(convShortToBigint((Short) l), (Long) r);
+            } else if (r instanceof BigDecimal) {
+                // numeric
+                return opAdd(convShortToNumeric((Short) l), (BigDecimal) r);
+            } else if (r instanceof Float) {
+                // float
+                return opAdd(convShortToFloat((Short) l), (Float) r);
+            } else if (r instanceof Double) {
+                // double
+                return opAdd(convShortToDouble((Short) l), (Double) r);
+            } else if (r instanceof Date) {
+                // (bigint, date)
+                return opAdd(convShortToBigint((Short) l), (Date) r);
+            } else if (r instanceof Time) {
+                // (bigint, time)
+                return opAdd(convShortToBigint((Short) l), (Time) r);
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Integer) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // double
+                return opAdd(convIntToDouble((Integer) l), convStringToDouble((String) r));
+            } else if (r instanceof Short) {
+                // int
+                return opAdd((Integer) l, convShortToInt((Short) r));
+            } else if (r instanceof Integer) {
+                // int
+                return opAdd((Integer) l, (Integer) r);
+            } else if (r instanceof Long) {
+                // bigint
+                return opAdd(convIntToBigint((Integer) l), (Long) r);
+            } else if (r instanceof BigDecimal) {
+                // numeric
+                return opAdd(convIntToNumeric((Integer) l), (BigDecimal) r);
+            } else if (r instanceof Float) {
+                // float
+                return opAdd(convIntToFloat((Integer) l), (Float) r);
+            } else if (r instanceof Double) {
+                // double
+                return opAdd(convIntToDouble((Integer) l), (Double) r);
+            } else if (r instanceof Date) {
+                // (bigint, date)
+                return opAdd(convIntToBigint((Integer) l), (Date) r);
+            } else if (r instanceof Time) {
+                // (bigint, time)
+                return opAdd(convIntToBigint((Integer) l), (Time) r);
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Long) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // double
+                return opAdd(convBigintToDouble((Long) l), convStringToDouble((String) r));
+            } else if (r instanceof Short) {
+                // bigint
+                return opAdd((Long) l, convShortToBigint((Short) r));
+            } else if (r instanceof Integer) {
+                // bigint
+                return opAdd((Long) l, convIntToBigint((Integer) r));
+            } else if (r instanceof Long) {
+                // bigint
+                return opAdd((Long) l, (Long) r);
+            } else if (r instanceof BigDecimal) {
+                // numeric
+                return opAdd(convBigintToNumeric((Long) l), (BigDecimal) r);
+            } else if (r instanceof Float) {
+                // float
+                return opAdd(convBigintToFloat((Long) l), (Float) r);
+            } else if (r instanceof Double) {
+                // double
+                return opAdd(convBigintToDouble((Long) l), (Double) r);
+            } else if (r instanceof Date) {
+                // (bigint, date)
+                return opAdd((Long) l, (Date) r);
+            } else if (r instanceof Time) {
+                // (bigint, time)
+                return opAdd((Long) l, (Time) r);
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof BigDecimal) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // double
+                return opAdd(convNumericToDouble((BigDecimal) l), convStringToDouble((String) r));
+            } else if (r instanceof Short) {
+                // numeric
+                return opAdd((BigDecimal) l, convShortToNumeric((Short) r));
+            } else if (r instanceof Integer) {
+                // numeric
+                return opAdd((BigDecimal) l, convIntToNumeric((Integer) r));
+            } else if (r instanceof Long) {
+                // numeric
+                return opAdd((BigDecimal) l, convBigintToNumeric((Long) r));
+            } else if (r instanceof BigDecimal) {
+                // numeric
+                return opAdd((BigDecimal) l, (BigDecimal) r);
+            } else if (r instanceof Float) {
+                // double
+                return opAdd(convNumericToDouble((BigDecimal) l), convFloatToDouble((Float) r));
+            } else if (r instanceof Double) {
+                // double
+                return opAdd(convNumericToDouble((BigDecimal) l), (Double) r);
+            } else if (r instanceof Date) {
+                // (bigint, date)
+                return opAdd(convNumericToBigint((BigDecimal) l), (Date) r);
+            } else if (r instanceof Time) {
+                // (bigint, time)
+                return opAdd(convNumericToBigint((BigDecimal) l), (Time) r);
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Float) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // double
+                return opAdd(convFloatToDouble((Float) l), convStringToDouble((String) r));
+            } else if (r instanceof Short) {
+                // float
+                return opAdd((Float) l, convShortToFloat((Short) r));
+            } else if (r instanceof Integer) {
+                // float
+                return opAdd((Float) l, convIntToFloat((Integer) r));
+            } else if (r instanceof Long) {
+                // float
+                return opAdd((Float) l, convBigintToFloat((Long) r));
+            } else if (r instanceof BigDecimal) {
+                // double
+                return opAdd(convFloatToDouble((Float) l), convNumericToDouble((BigDecimal) r));
+            } else if (r instanceof Float) {
+                // float
+                return opAdd((Float) l, (Float) r);
+            } else if (r instanceof Double) {
+                // double
+                return opAdd(convFloatToDouble((Float) l), (Double) r);
+            } else if (r instanceof Date) {
+                // (bigint, date)
+                return opAdd(convFloatToBigint((Float) l), (Date) r);
+            } else if (r instanceof Time) {
+                // (bigint, time)
+                return opAdd(convFloatToBigint((Float) l), (Time) r);
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Double) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // double
+                return opAdd((Double) l, convStringToDouble((String) r));
+            } else if (r instanceof Short) {
+                // double
+                return opAdd((Double) l, convShortToDouble((Short) r));
+            } else if (r instanceof Integer) {
+                // double
+                return opAdd((Double) l, convIntToDouble((Integer) r));
+            } else if (r instanceof Long) {
+                // double
+                return opAdd((Double) l, convBigintToDouble((Long) r));
+            } else if (r instanceof BigDecimal) {
+                // double
+                return opAdd((Double) l, convNumericToDouble((BigDecimal) r));
+            } else if (r instanceof Float) {
+                // double
+                return opAdd((Double) l, convFloatToDouble((Float) r));
+            } else if (r instanceof Double) {
+                // double
+                return opAdd((Double) l, (Double) r);
+            } else if (r instanceof Date) {
+                // (bigint, date)
+                return opAdd(convDoubleToBigint((Double) l), (Date) r);
+            } else if (r instanceof Time) {
+                // (bigint, time)
+                return opAdd(convDoubleToBigint((Double) l), (Time) r);
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Date) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // (date, bigint)
+                return opAdd((Date) l, convStringToBigint((String) r));
+            } else if (r instanceof Short) {
+                // (date, bigint)
+                return opAdd((Date) l, convShortToBigint((Short) r));
+            } else if (r instanceof Integer) {
+                // (date, bigint)
+                return opAdd((Date) l, convIntToBigint((Integer) r));
+            } else if (r instanceof Long) {
+                // (date, bigint)
+                return opAdd((Date) l, (Long) r);
+            } else if (r instanceof BigDecimal) {
+                // (date, bigint)
+                return opAdd((Date) l, convNumericToBigint((BigDecimal) r));
+            } else if (r instanceof Float) {
+                // (date, bigint)
+                return opAdd((Date) l, convFloatToBigint((Float) r));
+            } else if (r instanceof Double) {
+                // (date, bigint)
+                return opAdd((Date) l, convDoubleToBigint((Double) r));
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Time) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // (time, bigint)
+                return opAdd((Time) l, convStringToBigint((String) r));
+            } else if (r instanceof Short) {
+                // (time, bigint)
+                return opAdd((Time) l, convShortToBigint((Short) r));
+            } else if (r instanceof Integer) {
+                // (time, bigint)
+                return opAdd((Time) l, convIntToBigint((Integer) r));
+            } else if (r instanceof Long) {
+                // (time, bigint)
+                return opAdd((Time) l, (Long) r);
+            } else if (r instanceof BigDecimal) {
+                // (time, bigint)
+                return opAdd((Time) l, convNumericToBigint((BigDecimal) r));
+            } else if (r instanceof Float) {
+                // (time, bigint)
+                return opAdd((Time) l, convFloatToBigint((Float) r));
+            } else if (r instanceof Double) {
+                // (time, bigint)
+                return opAdd((Time) l, convDoubleToBigint((Double) r));
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Timestamp) {
+            throw new PROGRAM_ERROR("left operand's type is ambiguous: TIMESTAMP or DATETIME");
+        }
+
+        throw new VALUE_ERROR(
+                String.format(
+                        "cannot add two arguments due to their incompatible run-time types (%s, %s)",
+                        plcsqlTypeOfJavaObject(l), plcsqlTypeOfJavaObject(r)));
+    }
+
+    private static Object opSubtractWithRuntimeTypeConv(Object l, Object r) {
+        assert l != null;
+        assert r != null;
+
+        if (l instanceof Boolean) {
+            // not applicable
+        } else if (l instanceof String) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // double
+                return opSubtract(convStringToDouble((String) l), convStringToDouble((String) r));
+            } else if (r instanceof Short) {
+                // double
+                return opSubtract(convStringToDouble((String) l), convShortToDouble((Short) r));
+            } else if (r instanceof Integer) {
+                // double
+                return opSubtract(convStringToDouble((String) l), convIntToDouble((Integer) r));
+            } else if (r instanceof Long) {
+                // double
+                return opSubtract(convStringToDouble((String) l), convBigintToDouble((Long) r));
+            } else if (r instanceof BigDecimal) {
+                // double
+                return opSubtract(
+                        convStringToDouble((String) l), convNumericToDouble((BigDecimal) r));
+            } else if (r instanceof Float) {
+                // double
+                return opSubtract(convStringToDouble((String) l), convFloatToDouble((Float) r));
+            } else if (r instanceof Double) {
+                // double
+                return opSubtract(convStringToDouble((String) l), (Double) r);
+            } else if (r instanceof Date) {
+                // datetime
+                return opSubtract(convStringToDatetime((String) l), convDateToDatetime((Date) r));
+            } else if (r instanceof Time) {
+                // time
+                return opSubtract(convStringToTime((String) l), (Time) r);
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Short) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // double
+                return opSubtract(convShortToDouble((Short) l), convStringToDouble((String) r));
+            } else if (r instanceof Short) {
+                // short
+                return opSubtract((Short) l, (Short) r);
+            } else if (r instanceof Integer) {
+                // int
+                return opSubtract(convShortToInt((Short) l), (Integer) r);
+            } else if (r instanceof Long) {
+                // bigint
+                return opSubtract(convShortToBigint((Short) l), (Long) r);
+            } else if (r instanceof BigDecimal) {
+                // numeric
+                return opSubtract(convShortToNumeric((Short) l), (BigDecimal) r);
+            } else if (r instanceof Float) {
+                // float
+                return opSubtract(convShortToFloat((Short) l), (Float) r);
+            } else if (r instanceof Double) {
+                // double
+                return opSubtract(convShortToDouble((Short) l), (Double) r);
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Integer) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // double
+                return opSubtract(convIntToDouble((Integer) l), convStringToDouble((String) r));
+            } else if (r instanceof Short) {
+                // int
+                return opSubtract((Integer) l, convShortToInt((Short) r));
+            } else if (r instanceof Integer) {
+                // int
+                return opSubtract((Integer) l, (Integer) r);
+            } else if (r instanceof Long) {
+                // bigint
+                return opSubtract(convIntToBigint((Integer) l), (Long) r);
+            } else if (r instanceof BigDecimal) {
+                // numeric
+                return opSubtract(convIntToNumeric((Integer) l), (BigDecimal) r);
+            } else if (r instanceof Float) {
+                // float
+                return opSubtract(convIntToFloat((Integer) l), (Float) r);
+            } else if (r instanceof Double) {
+                // double
+                return opSubtract(convIntToDouble((Integer) l), (Double) r);
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Long) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // double
+                return opSubtract(convBigintToDouble((Long) l), convStringToDouble((String) r));
+            } else if (r instanceof Short) {
+                // bigint
+                return opSubtract((Long) l, convShortToBigint((Short) r));
+            } else if (r instanceof Integer) {
+                // bigint
+                return opSubtract((Long) l, convIntToBigint((Integer) r));
+            } else if (r instanceof Long) {
+                // bigint
+                return opSubtract((Long) l, (Long) r);
+            } else if (r instanceof BigDecimal) {
+                // numeric
+                return opSubtract(convBigintToNumeric((Long) l), (BigDecimal) r);
+            } else if (r instanceof Float) {
+                // float
+                return opSubtract(convBigintToFloat((Long) l), (Float) r);
+            } else if (r instanceof Double) {
+                // double
+                return opSubtract(convBigintToDouble((Long) l), (Double) r);
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof BigDecimal) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // double
+                return opSubtract(
+                        convNumericToDouble((BigDecimal) l), convStringToDouble((String) r));
+            } else if (r instanceof Short) {
+                // numeric
+                return opSubtract((BigDecimal) l, convShortToNumeric((Short) r));
+            } else if (r instanceof Integer) {
+                // numeric
+                return opSubtract((BigDecimal) l, convIntToNumeric((Integer) r));
+            } else if (r instanceof Long) {
+                // numeric
+                return opSubtract((BigDecimal) l, convBigintToNumeric((Long) r));
+            } else if (r instanceof BigDecimal) {
+                // numeric
+                return opSubtract((BigDecimal) l, (BigDecimal) r);
+            } else if (r instanceof Float) {
+                // double
+                return opSubtract(
+                        convNumericToDouble((BigDecimal) l), convFloatToDouble((Float) r));
+            } else if (r instanceof Double) {
+                // double
+                return opSubtract(convNumericToDouble((BigDecimal) l), (Double) r);
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Float) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // double
+                return opSubtract(convFloatToDouble((Float) l), convStringToDouble((String) r));
+            } else if (r instanceof Short) {
+                // float
+                return opSubtract((Float) l, convShortToFloat((Short) r));
+            } else if (r instanceof Integer) {
+                // float
+                return opSubtract((Float) l, convIntToFloat((Integer) r));
+            } else if (r instanceof Long) {
+                // float
+                return opSubtract((Float) l, convBigintToFloat((Long) r));
+            } else if (r instanceof BigDecimal) {
+                // double
+                return opSubtract(
+                        convFloatToDouble((Float) l), convNumericToDouble((BigDecimal) r));
+            } else if (r instanceof Float) {
+                // float
+                return opSubtract((Float) l, (Float) r);
+            } else if (r instanceof Double) {
+                // double
+                return opSubtract(convFloatToDouble((Float) l), (Double) r);
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Double) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // double
+                return opSubtract((Double) l, convStringToDouble((String) r));
+            } else if (r instanceof Short) {
+                // double
+                return opSubtract((Double) l, convShortToDouble((Short) r));
+            } else if (r instanceof Integer) {
+                // double
+                return opSubtract((Double) l, convIntToDouble((Integer) r));
+            } else if (r instanceof Long) {
+                // double
+                return opSubtract((Double) l, convBigintToDouble((Long) r));
+            } else if (r instanceof BigDecimal) {
+                // double
+                return opSubtract((Double) l, convNumericToDouble((BigDecimal) r));
+            } else if (r instanceof Float) {
+                // double
+                return opSubtract((Double) l, convFloatToDouble((Float) r));
+            } else if (r instanceof Double) {
+                // double
+                return opSubtract((Double) l, (Double) r);
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Date) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // datetime
+                return opSubtract(convDateToDatetime((Date) l), convStringToDatetime((String) r));
+            } else if (r instanceof Short) {
+                // (date, bigint)
+                return opSubtract((Date) l, convShortToBigint((Short) r));
+            } else if (r instanceof Integer) {
+                // (date, bigint)
+                return opSubtract((Date) l, convIntToBigint((Integer) r));
+            } else if (r instanceof Long) {
+                // (date, bigint)
+                return opSubtract((Date) l, (Long) r);
+            } else if (r instanceof BigDecimal) {
+                // (date, bigint)
+                return opSubtract((Date) l, convNumericToBigint((BigDecimal) r));
+            } else if (r instanceof Float) {
+                // (date, bigint)
+                return opSubtract((Date) l, convFloatToBigint((Float) r));
+            } else if (r instanceof Double) {
+                // (date, bigint)
+                return opSubtract((Date) l, convDoubleToBigint((Double) r));
+            } else if (r instanceof Date) {
+                return opSubtract((Date) l, (Date) r);
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Time) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // time
+                return opSubtract((Time) l, convStringToTime((String) r));
+            } else if (r instanceof Short) {
+                // (time, bigint)
+                return opSubtract((Time) l, convShortToBigint((Short) r));
+            } else if (r instanceof Integer) {
+                // (time, bigint)
+                return opSubtract((Time) l, convIntToBigint((Integer) r));
+            } else if (r instanceof Long) {
+                // (time, bigint)
+                return opSubtract((Time) l, (Long) r);
+            } else if (r instanceof BigDecimal) {
+                // (time, bigint)
+                return opSubtract((Time) l, convNumericToBigint((BigDecimal) r));
+            } else if (r instanceof Float) {
+                // (time, bigint)
+                return opSubtract((Time) l, convFloatToBigint((Float) r));
+            } else if (r instanceof Double) {
+                // (time, bigint)
+                return opSubtract((Time) l, convDoubleToBigint((Double) r));
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // time
+                return opSubtract((Time) l, (Time) r);
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Timestamp) {
+            throw new PROGRAM_ERROR("left operand's type is ambiguous: TIMESTAMP or DATETIME");
+        }
+
+        throw new VALUE_ERROR(
+                String.format(
+                        "cannot subtract two arguments due to their incompatible run-time types (%s, %s)",
+                        plcsqlTypeOfJavaObject(l), plcsqlTypeOfJavaObject(r)));
+    }
+
+    private static Object opMultWithRuntimeTypeConv(Object l, Object r) {
+        assert l != null;
+        assert r != null;
+
+        if (l instanceof Boolean) {
+            // not applicable
+        } else if (l instanceof String) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // double
+                return opMult(convStringToDouble((String) l), convStringToDouble((String) r));
+            } else if (r instanceof Short) {
+                // double
+                return opMult(convStringToDouble((String) l), convShortToDouble((Short) r));
+            } else if (r instanceof Integer) {
+                // double
+                return opMult(convStringToDouble((String) l), convIntToDouble((Integer) r));
+            } else if (r instanceof Long) {
+                // double
+                return opMult(convStringToDouble((String) l), convBigintToDouble((Long) r));
+            } else if (r instanceof BigDecimal) {
+                // double
+                return opMult(convStringToDouble((String) l), convNumericToDouble((BigDecimal) r));
+            } else if (r instanceof Float) {
+                // double
+                return opMult(convStringToDouble((String) l), convFloatToDouble((Float) r));
+            } else if (r instanceof Double) {
+                // double
+                return opMult(convStringToDouble((String) l), (Double) r);
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Short) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // double
+                return opMult(convShortToDouble((Short) l), convStringToDouble((String) r));
+            } else if (r instanceof Short) {
+                // short
+                return opMult((Short) l, (Short) r);
+            } else if (r instanceof Integer) {
+                // int
+                return opMult(convShortToInt((Short) l), (Integer) r);
+            } else if (r instanceof Long) {
+                // bigint
+                return opMult(convShortToBigint((Short) l), (Long) r);
+            } else if (r instanceof BigDecimal) {
+                // numeric
+                return opMult(convShortToNumeric((Short) l), (BigDecimal) r);
+            } else if (r instanceof Float) {
+                // float
+                return opMult(convShortToFloat((Short) l), (Float) r);
+            } else if (r instanceof Double) {
+                // double
+                return opMult(convShortToDouble((Short) l), (Double) r);
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Integer) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // double
+                return opMult(convIntToDouble((Integer) l), convStringToDouble((String) r));
+            } else if (r instanceof Short) {
+                // int
+                return opMult((Integer) l, convShortToInt((Short) r));
+            } else if (r instanceof Integer) {
+                // int
+                return opMult((Integer) l, (Integer) r);
+            } else if (r instanceof Long) {
+                // bigint
+                return opMult(convIntToBigint((Integer) l), (Long) r);
+            } else if (r instanceof BigDecimal) {
+                // numeric
+                return opMult(convIntToNumeric((Integer) l), (BigDecimal) r);
+            } else if (r instanceof Float) {
+                // float
+                return opMult(convIntToFloat((Integer) l), (Float) r);
+            } else if (r instanceof Double) {
+                // double
+                return opMult(convIntToDouble((Integer) l), (Double) r);
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Long) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // double
+                return opMult(convBigintToDouble((Long) l), convStringToDouble((String) r));
+            } else if (r instanceof Short) {
+                // bigint
+                return opMult((Long) l, convShortToBigint((Short) r));
+            } else if (r instanceof Integer) {
+                // bigint
+                return opMult((Long) l, convIntToBigint((Integer) r));
+            } else if (r instanceof Long) {
+                // bigint
+                return opMult((Long) l, (Long) r);
+            } else if (r instanceof BigDecimal) {
+                // numeric
+                return opMult(convBigintToNumeric((Long) l), (BigDecimal) r);
+            } else if (r instanceof Float) {
+                // float
+                return opMult(convBigintToFloat((Long) l), (Float) r);
+            } else if (r instanceof Double) {
+                // double
+                return opMult(convBigintToDouble((Long) l), (Double) r);
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof BigDecimal) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // double
+                return opMult(convNumericToDouble((BigDecimal) l), convStringToDouble((String) r));
+            } else if (r instanceof Short) {
+                // numeric
+                return opMult((BigDecimal) l, convShortToNumeric((Short) r));
+            } else if (r instanceof Integer) {
+                // numeric
+                return opMult((BigDecimal) l, convIntToNumeric((Integer) r));
+            } else if (r instanceof Long) {
+                // numeric
+                return opMult((BigDecimal) l, convBigintToNumeric((Long) r));
+            } else if (r instanceof BigDecimal) {
+                // numeric
+                return opMult((BigDecimal) l, (BigDecimal) r);
+            } else if (r instanceof Float) {
+                // double
+                return opMult(convNumericToDouble((BigDecimal) l), convFloatToDouble((Float) r));
+            } else if (r instanceof Double) {
+                // double
+                return opMult(convNumericToDouble((BigDecimal) l), (Double) r);
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Float) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // double
+                return opMult(convFloatToDouble((Float) l), convStringToDouble((String) r));
+            } else if (r instanceof Short) {
+                // float
+                return opMult((Float) l, convShortToFloat((Short) r));
+            } else if (r instanceof Integer) {
+                // float
+                return opMult((Float) l, convIntToFloat((Integer) r));
+            } else if (r instanceof Long) {
+                // float
+                return opMult((Float) l, convBigintToFloat((Long) r));
+            } else if (r instanceof BigDecimal) {
+                // double
+                return opMult(convFloatToDouble((Float) l), convNumericToDouble((BigDecimal) r));
+            } else if (r instanceof Float) {
+                // float
+                return opMult((Float) l, (Float) r);
+            } else if (r instanceof Double) {
+                // double
+                return opMult(convFloatToDouble((Float) l), (Double) r);
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Double) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // double
+                return opMult((Double) l, convStringToDouble((String) r));
+            } else if (r instanceof Short) {
+                // double
+                return opMult((Double) l, convShortToDouble((Short) r));
+            } else if (r instanceof Integer) {
+                // double
+                return opMult((Double) l, convIntToDouble((Integer) r));
+            } else if (r instanceof Long) {
+                // double
+                return opMult((Double) l, convBigintToDouble((Long) r));
+            } else if (r instanceof BigDecimal) {
+                // double
+                return opMult((Double) l, convNumericToDouble((BigDecimal) r));
+            } else if (r instanceof Float) {
+                // double
+                return opMult((Double) l, convFloatToDouble((Float) r));
+            } else if (r instanceof Double) {
+                // double
+                return opMult((Double) l, (Double) r);
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Date) {
+            // not applicable
+
+        } else if (l instanceof Time) {
+            // not applicable
+
+        } else if (l instanceof Timestamp) {
+            throw new PROGRAM_ERROR("left operand's type is ambiguous: TIMESTAMP or DATETIME");
+        }
+
+        throw new VALUE_ERROR(
+                String.format(
+                        "cannot multiply two arguments due to their incompatible run-time types (%s, %s)",
+                        plcsqlTypeOfJavaObject(l), plcsqlTypeOfJavaObject(r)));
+    }
+
+    private static Object opDivWithRuntimeTypeConv(Object l, Object r) {
+        assert l != null;
+        assert r != null;
+
+        if (l instanceof Boolean) {
+            // not applicable
+        } else if (l instanceof String) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // double
+                return opDiv(convStringToDouble((String) l), convStringToDouble((String) r));
+            } else if (r instanceof Short) {
+                // double
+                return opDiv(convStringToDouble((String) l), convShortToDouble((Short) r));
+            } else if (r instanceof Integer) {
+                // double
+                return opDiv(convStringToDouble((String) l), convIntToDouble((Integer) r));
+            } else if (r instanceof Long) {
+                // double
+                return opDiv(convStringToDouble((String) l), convBigintToDouble((Long) r));
+            } else if (r instanceof BigDecimal) {
+                // double
+                return opDiv(convStringToDouble((String) l), convNumericToDouble((BigDecimal) r));
+            } else if (r instanceof Float) {
+                // double
+                return opDiv(convStringToDouble((String) l), convFloatToDouble((Float) r));
+            } else if (r instanceof Double) {
+                // double
+                return opDiv(convStringToDouble((String) l), (Double) r);
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Short) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // double
+                return opDiv(convShortToDouble((Short) l), convStringToDouble((String) r));
+            } else if (r instanceof Short) {
+                // short
+                return opDiv((Short) l, (Short) r);
+            } else if (r instanceof Integer) {
+                // int
+                return opDiv(convShortToInt((Short) l), (Integer) r);
+            } else if (r instanceof Long) {
+                // bigint
+                return opDiv(convShortToBigint((Short) l), (Long) r);
+            } else if (r instanceof BigDecimal) {
+                // numeric
+                return opDiv(convShortToNumeric((Short) l), (BigDecimal) r);
+            } else if (r instanceof Float) {
+                // float
+                return opDiv(convShortToFloat((Short) l), (Float) r);
+            } else if (r instanceof Double) {
+                // double
+                return opDiv(convShortToDouble((Short) l), (Double) r);
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Integer) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // double
+                return opDiv(convIntToDouble((Integer) l), convStringToDouble((String) r));
+            } else if (r instanceof Short) {
+                // int
+                return opDiv((Integer) l, convShortToInt((Short) r));
+            } else if (r instanceof Integer) {
+                // int
+                return opDiv((Integer) l, (Integer) r);
+            } else if (r instanceof Long) {
+                // bigint
+                return opDiv(convIntToBigint((Integer) l), (Long) r);
+            } else if (r instanceof BigDecimal) {
+                // numeric
+                return opDiv(convIntToNumeric((Integer) l), (BigDecimal) r);
+            } else if (r instanceof Float) {
+                // float
+                return opDiv(convIntToFloat((Integer) l), (Float) r);
+            } else if (r instanceof Double) {
+                // double
+                return opDiv(convIntToDouble((Integer) l), (Double) r);
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Long) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // double
+                return opDiv(convBigintToDouble((Long) l), convStringToDouble((String) r));
+            } else if (r instanceof Short) {
+                // bigint
+                return opDiv((Long) l, convShortToBigint((Short) r));
+            } else if (r instanceof Integer) {
+                // bigint
+                return opDiv((Long) l, convIntToBigint((Integer) r));
+            } else if (r instanceof Long) {
+                // bigint
+                return opDiv((Long) l, (Long) r);
+            } else if (r instanceof BigDecimal) {
+                // numeric
+                return opDiv(convBigintToNumeric((Long) l), (BigDecimal) r);
+            } else if (r instanceof Float) {
+                // float
+                return opDiv(convBigintToFloat((Long) l), (Float) r);
+            } else if (r instanceof Double) {
+                // double
+                return opDiv(convBigintToDouble((Long) l), (Double) r);
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof BigDecimal) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // double
+                return opDiv(convNumericToDouble((BigDecimal) l), convStringToDouble((String) r));
+            } else if (r instanceof Short) {
+                // numeric
+                return opDiv((BigDecimal) l, convShortToNumeric((Short) r));
+            } else if (r instanceof Integer) {
+                // numeric
+                return opDiv((BigDecimal) l, convIntToNumeric((Integer) r));
+            } else if (r instanceof Long) {
+                // numeric
+                return opDiv((BigDecimal) l, convBigintToNumeric((Long) r));
+            } else if (r instanceof BigDecimal) {
+                // numeric
+                return opDiv((BigDecimal) l, (BigDecimal) r);
+            } else if (r instanceof Float) {
+                // double
+                return opDiv(convNumericToDouble((BigDecimal) l), convFloatToDouble((Float) r));
+            } else if (r instanceof Double) {
+                // double
+                return opDiv(convNumericToDouble((BigDecimal) l), (Double) r);
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Float) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // double
+                return opDiv(convFloatToDouble((Float) l), convStringToDouble((String) r));
+            } else if (r instanceof Short) {
+                // float
+                return opDiv((Float) l, convShortToFloat((Short) r));
+            } else if (r instanceof Integer) {
+                // float
+                return opDiv((Float) l, convIntToFloat((Integer) r));
+            } else if (r instanceof Long) {
+                // float
+                return opDiv((Float) l, convBigintToFloat((Long) r));
+            } else if (r instanceof BigDecimal) {
+                // double
+                return opDiv(convFloatToDouble((Float) l), convNumericToDouble((BigDecimal) r));
+            } else if (r instanceof Float) {
+                // float
+                return opDiv((Float) l, (Float) r);
+            } else if (r instanceof Double) {
+                // double
+                return opDiv(convFloatToDouble((Float) l), (Double) r);
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Double) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // double
+                return opDiv((Double) l, convStringToDouble((String) r));
+            } else if (r instanceof Short) {
+                // double
+                return opDiv((Double) l, convShortToDouble((Short) r));
+            } else if (r instanceof Integer) {
+                // double
+                return opDiv((Double) l, convIntToDouble((Integer) r));
+            } else if (r instanceof Long) {
+                // double
+                return opDiv((Double) l, convBigintToDouble((Long) r));
+            } else if (r instanceof BigDecimal) {
+                // double
+                return opDiv((Double) l, convNumericToDouble((BigDecimal) r));
+            } else if (r instanceof Float) {
+                // double
+                return opDiv((Double) l, convFloatToDouble((Float) r));
+            } else if (r instanceof Double) {
+                // double
+                return opDiv((Double) l, (Double) r);
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Date) {
+            // not applicable
+
+        } else if (l instanceof Time) {
+            // not applicable
+
+        } else if (l instanceof Timestamp) {
+            throw new PROGRAM_ERROR("left operand's type is ambiguous: TIMESTAMP or DATETIME");
+        }
+
+        throw new VALUE_ERROR(
+                String.format(
+                        "cannot divide two arguments due to their incompatible run-time types (%s, %s)",
+                        plcsqlTypeOfJavaObject(l), plcsqlTypeOfJavaObject(r)));
+    }
+
+    private static Object opModWithRuntimeTypeConv(Object l, Object r) {
+        assert l != null;
+        assert r != null;
+
+        if (l instanceof Boolean) {
+            // not applicable
+        } else if (l instanceof String) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // bigint
+                return opMod(convStringToBigint((String) l), convStringToBigint((String) r));
+            } else if (r instanceof Short) {
+                // bigint
+                return opMod(convStringToBigint((String) l), convShortToBigint((Short) r));
+            } else if (r instanceof Integer) {
+                // bigint
+                return opMod(convStringToBigint((String) l), convIntToBigint((Integer) r));
+            } else if (r instanceof Long) {
+                // bigint
+                return opMod(convStringToBigint((String) l), (Long) r);
+            } else if (r instanceof BigDecimal) {
+                // bigint
+                return opMod(convStringToBigint((String) l), convNumericToBigint((BigDecimal) r));
+            } else if (r instanceof Float) {
+                // bigint
+                return opMod(convStringToBigint((String) l), convFloatToBigint((Float) r));
+            } else if (r instanceof Double) {
+                // bigint
+                return opMod(convStringToBigint((String) l), convDoubleToBigint((Double) r));
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Short) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // bigint
+                return opMod(convShortToBigint((Short) l), convStringToBigint((String) r));
+            } else if (r instanceof Short) {
+                // short
+                return opMod((Short) l, (Short) r);
+            } else if (r instanceof Integer) {
+                // bigint
+                return opMod(convShortToBigint((Short) l), convIntToBigint((Integer) r));
+            } else if (r instanceof Long) {
+                // bigint
+                return opMod(convShortToBigint((Short) l), (Long) r);
+            } else if (r instanceof BigDecimal) {
+                // bigint
+                return opMod(convShortToBigint((Short) l), convNumericToBigint((BigDecimal) r));
+            } else if (r instanceof Float) {
+                // bigint
+                return opMod(convShortToBigint((Short) l), convFloatToBigint((Float) r));
+            } else if (r instanceof Double) {
+                // bigint
+                return opMod(convShortToBigint((Short) l), convDoubleToBigint((Double) r));
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Integer) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // bigint
+                return opMod(convIntToBigint((Integer) l), convStringToBigint((String) r));
+            } else if (r instanceof Short) {
+                // bigint
+                return opMod(convIntToBigint((Integer) l), convShortToBigint((Short) r));
+            } else if (r instanceof Integer) {
+                // int
+                return opMod((Integer) l, (Integer) r);
+            } else if (r instanceof Long) {
+                // bigint
+                return opMod(convIntToBigint((Integer) l), (Long) r);
+            } else if (r instanceof BigDecimal) {
+                // bigint
+                return opMod(convIntToBigint((Integer) l), convNumericToBigint((BigDecimal) r));
+            } else if (r instanceof Float) {
+                // bigint
+                return opMod(convIntToBigint((Integer) l), convFloatToBigint((Float) r));
+            } else if (r instanceof Double) {
+                // bigint
+                return opMod(convIntToBigint((Integer) l), convDoubleToBigint((Double) r));
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Long) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // bigint
+                return opMod((Long) l, convStringToBigint((String) r));
+            } else if (r instanceof Short) {
+                // bigint
+                return opMod((Long) l, convShortToBigint((Short) r));
+            } else if (r instanceof Integer) {
+                // bigint
+                return opMod((Long) l, convIntToBigint((Integer) r));
+            } else if (r instanceof Long) {
+                // bigint
+                return opMod((Long) l, (Long) r);
+            } else if (r instanceof BigDecimal) {
+                // bigint
+                return opMod((Long) l, convNumericToBigint((BigDecimal) r));
+            } else if (r instanceof Float) {
+                // bigint
+                return opMod((Long) l, convFloatToBigint((Float) r));
+            } else if (r instanceof Double) {
+                // bigint
+                return opMod((Long) l, convDoubleToBigint((Double) r));
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof BigDecimal) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // bigint
+                return opMod(convNumericToBigint((BigDecimal) l), convStringToBigint((String) r));
+            } else if (r instanceof Short) {
+                // bigint
+                return opMod(convNumericToBigint((BigDecimal) l), convShortToBigint((Short) r));
+            } else if (r instanceof Integer) {
+                // bigint
+                return opMod(convNumericToBigint((BigDecimal) l), convIntToBigint((Integer) r));
+            } else if (r instanceof Long) {
+                // bigint
+                return opMod(convNumericToBigint((BigDecimal) l), (Long) r);
+            } else if (r instanceof BigDecimal) {
+                // bigint
+                return opMod(
+                        convNumericToBigint((BigDecimal) l), convNumericToBigint((BigDecimal) r));
+            } else if (r instanceof Float) {
+                // bigint
+                return opMod(convNumericToBigint((BigDecimal) l), convFloatToBigint((Float) r));
+            } else if (r instanceof Double) {
+                // bigint
+                return opMod(convNumericToBigint((BigDecimal) l), convDoubleToBigint((Double) r));
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Float) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // bigint
+                return opMod(convFloatToBigint((Float) l), convStringToBigint((String) r));
+            } else if (r instanceof Short) {
+                // bigint
+                return opMod(convFloatToBigint((Float) l), convShortToBigint((Short) r));
+            } else if (r instanceof Integer) {
+                // bigint
+                return opMod(convFloatToBigint((Float) l), convIntToBigint((Integer) r));
+            } else if (r instanceof Long) {
+                // bigint
+                return opMod(convFloatToBigint((Float) l), (Long) r);
+            } else if (r instanceof BigDecimal) {
+                // bigint
+                return opMod(convFloatToBigint((Float) l), convNumericToBigint((BigDecimal) r));
+            } else if (r instanceof Float) {
+                // bigint
+                return opMod(convFloatToBigint((Float) l), convFloatToBigint((Float) r));
+            } else if (r instanceof Double) {
+                // bigint
+                return opMod(convFloatToBigint((Float) l), convDoubleToBigint((Double) r));
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Double) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // bigint
+                return opMod(convDoubleToBigint((Double) l), convStringToBigint((String) r));
+            } else if (r instanceof Short) {
+                // bigint
+                return opMod(convDoubleToBigint((Double) l), convShortToBigint((Short) r));
+            } else if (r instanceof Integer) {
+                // bigint
+                return opMod(convDoubleToBigint((Double) l), convIntToBigint((Integer) r));
+            } else if (r instanceof Long) {
+                // bigint
+                return opMod(convDoubleToBigint((Double) l), (Long) r);
+            } else if (r instanceof BigDecimal) {
+                // bigint
+                return opMod(convDoubleToBigint((Double) l), convNumericToBigint((BigDecimal) r));
+            } else if (r instanceof Float) {
+                // bigint
+                return opMod(convDoubleToBigint((Double) l), convFloatToBigint((Float) r));
+            } else if (r instanceof Double) {
+                // bigint
+                return opMod(convDoubleToBigint((Double) l), convDoubleToBigint((Double) r));
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Date) {
+            // not applicable
+
+        } else if (l instanceof Time) {
+            // not applicable
+
+        } else if (l instanceof Timestamp) {
+            throw new PROGRAM_ERROR("left operand's type is ambiguous: TIMESTAMP or DATETIME");
+        }
+
+        throw new VALUE_ERROR(
+                String.format(
+                        "cannot take remainder of two arguments due to their incompatible run-time types (%s, %s)",
+                        plcsqlTypeOfJavaObject(l), plcsqlTypeOfJavaObject(r)));
+    }
+
+    private static Object opDivIntWithRuntimeTypeConv(Object l, Object r) {
+        assert l != null;
+        assert r != null;
+
+        if (l instanceof Boolean) {
+            // not applicable
+        } else if (l instanceof String) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // bigint
+                return opDivInt(convStringToBigint((String) l), convStringToBigint((String) r));
+            } else if (r instanceof Short) {
+                // bigint
+                return opDivInt(convStringToBigint((String) l), convShortToBigint((Short) r));
+            } else if (r instanceof Integer) {
+                // bigint
+                return opDivInt(convStringToBigint((String) l), convIntToBigint((Integer) r));
+            } else if (r instanceof Long) {
+                // bigint
+                return opDivInt(convStringToBigint((String) l), (Long) r);
+            } else if (r instanceof BigDecimal) {
+                // bigint
+                return opDivInt(
+                        convStringToBigint((String) l), convNumericToBigint((BigDecimal) r));
+            } else if (r instanceof Float) {
+                // bigint
+                return opDivInt(convStringToBigint((String) l), convFloatToBigint((Float) r));
+            } else if (r instanceof Double) {
+                // bigint
+                return opDivInt(convStringToBigint((String) l), convDoubleToBigint((Double) r));
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Short) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // bigint
+                return opDivInt(convShortToBigint((Short) l), convStringToBigint((String) r));
+            } else if (r instanceof Short) {
+                // short
+                return opDivInt((Short) l, (Short) r);
+            } else if (r instanceof Integer) {
+                // bigint
+                return opDivInt(convShortToBigint((Short) l), convIntToBigint((Integer) r));
+            } else if (r instanceof Long) {
+                // bigint
+                return opDivInt(convShortToBigint((Short) l), (Long) r);
+            } else if (r instanceof BigDecimal) {
+                // bigint
+                return opDivInt(convShortToBigint((Short) l), convNumericToBigint((BigDecimal) r));
+            } else if (r instanceof Float) {
+                // bigint
+                return opDivInt(convShortToBigint((Short) l), convFloatToBigint((Float) r));
+            } else if (r instanceof Double) {
+                // bigint
+                return opDivInt(convShortToBigint((Short) l), convDoubleToBigint((Double) r));
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Integer) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // bigint
+                return opDivInt(convIntToBigint((Integer) l), convStringToBigint((String) r));
+            } else if (r instanceof Short) {
+                // bigint
+                return opDivInt(convIntToBigint((Integer) l), convShortToBigint((Short) r));
+            } else if (r instanceof Integer) {
+                // int
+                return opDivInt((Integer) l, (Integer) r);
+            } else if (r instanceof Long) {
+                // bigint
+                return opDivInt(convIntToBigint((Integer) l), (Long) r);
+            } else if (r instanceof BigDecimal) {
+                // bigint
+                return opDivInt(convIntToBigint((Integer) l), convNumericToBigint((BigDecimal) r));
+            } else if (r instanceof Float) {
+                // bigint
+                return opDivInt(convIntToBigint((Integer) l), convFloatToBigint((Float) r));
+            } else if (r instanceof Double) {
+                // bigint
+                return opDivInt(convIntToBigint((Integer) l), convDoubleToBigint((Double) r));
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Long) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // bigint
+                return opDivInt((Long) l, convStringToBigint((String) r));
+            } else if (r instanceof Short) {
+                // bigint
+                return opDivInt((Long) l, convShortToBigint((Short) r));
+            } else if (r instanceof Integer) {
+                // bigint
+                return opDivInt((Long) l, convIntToBigint((Integer) r));
+            } else if (r instanceof Long) {
+                // bigint
+                return opDivInt((Long) l, (Long) r);
+            } else if (r instanceof BigDecimal) {
+                // bigint
+                return opDivInt((Long) l, convNumericToBigint((BigDecimal) r));
+            } else if (r instanceof Float) {
+                // bigint
+                return opDivInt((Long) l, convFloatToBigint((Float) r));
+            } else if (r instanceof Double) {
+                // bigint
+                return opDivInt((Long) l, convDoubleToBigint((Double) r));
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof BigDecimal) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // bigint
+                return opDivInt(
+                        convNumericToBigint((BigDecimal) l), convStringToBigint((String) r));
+            } else if (r instanceof Short) {
+                // bigint
+                return opDivInt(convNumericToBigint((BigDecimal) l), convShortToBigint((Short) r));
+            } else if (r instanceof Integer) {
+                // bigint
+                return opDivInt(convNumericToBigint((BigDecimal) l), convIntToBigint((Integer) r));
+            } else if (r instanceof Long) {
+                // bigint
+                return opDivInt(convNumericToBigint((BigDecimal) l), (Long) r);
+            } else if (r instanceof BigDecimal) {
+                // bigint
+                return opDivInt(
+                        convNumericToBigint((BigDecimal) l), convNumericToBigint((BigDecimal) r));
+            } else if (r instanceof Float) {
+                // bigint
+                return opDivInt(convNumericToBigint((BigDecimal) l), convFloatToBigint((Float) r));
+            } else if (r instanceof Double) {
+                // bigint
+                return opDivInt(
+                        convNumericToBigint((BigDecimal) l), convDoubleToBigint((Double) r));
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Float) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // bigint
+                return opDivInt(convFloatToBigint((Float) l), convStringToBigint((String) r));
+            } else if (r instanceof Short) {
+                // bigint
+                return opDivInt(convFloatToBigint((Float) l), convShortToBigint((Short) r));
+            } else if (r instanceof Integer) {
+                // bigint
+                return opDivInt(convFloatToBigint((Float) l), convIntToBigint((Integer) r));
+            } else if (r instanceof Long) {
+                // bigint
+                return opDivInt(convFloatToBigint((Float) l), (Long) r);
+            } else if (r instanceof BigDecimal) {
+                // bigint
+                return opDivInt(convFloatToBigint((Float) l), convNumericToBigint((BigDecimal) r));
+            } else if (r instanceof Float) {
+                // bigint
+                return opDivInt(convFloatToBigint((Float) l), convFloatToBigint((Float) r));
+            } else if (r instanceof Double) {
+                // bigint
+                return opDivInt(convFloatToBigint((Float) l), convDoubleToBigint((Double) r));
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Double) {
+
+            if (r instanceof Boolean) {
+                // not applicable
+            } else if (r instanceof String) {
+                // bigint
+                return opDivInt(convDoubleToBigint((Double) l), convStringToBigint((String) r));
+            } else if (r instanceof Short) {
+                // bigint
+                return opDivInt(convDoubleToBigint((Double) l), convShortToBigint((Short) r));
+            } else if (r instanceof Integer) {
+                // bigint
+                return opDivInt(convDoubleToBigint((Double) l), convIntToBigint((Integer) r));
+            } else if (r instanceof Long) {
+                // bigint
+                return opDivInt(convDoubleToBigint((Double) l), (Long) r);
+            } else if (r instanceof BigDecimal) {
+                // bigint
+                return opDivInt(
+                        convDoubleToBigint((Double) l), convNumericToBigint((BigDecimal) r));
+            } else if (r instanceof Float) {
+                // bigint
+                return opDivInt(convDoubleToBigint((Double) l), convFloatToBigint((Float) r));
+            } else if (r instanceof Double) {
+                // bigint
+                return opDivInt(convDoubleToBigint((Double) l), convDoubleToBigint((Double) r));
+            } else if (r instanceof Date) {
+                // not applicable
+            } else if (r instanceof Time) {
+                // not applicable
+            } else if (r instanceof Timestamp) {
+                throw new PROGRAM_ERROR("right operand's type is ambiguous: TIMESTAMP or DATETIME");
+            }
+
+        } else if (l instanceof Date) {
+            // not applicable
+
+        } else if (l instanceof Time) {
+            // not applicable
+
+        } else if (l instanceof Timestamp) {
+            throw new PROGRAM_ERROR("left operand's type is ambiguous: TIMESTAMP or DATETIME");
+        }
+
+        throw new VALUE_ERROR(
+                String.format(
+                        "cannot divide two arguments as integers due to their incompatible run-time types (%s, %s)",
+                        plcsqlTypeOfJavaObject(l), plcsqlTypeOfJavaObject(r)));
+    }
+
     private static int compareWithRuntimeTypeConv(Object l, Object r) {
         assert l != null;
         assert r != null;
@@ -4396,5 +6145,35 @@ public class SpLib {
 
         assert false; // unreachable
         return null;
+    }
+
+    private static String plcsqlTypeOfJavaObject(Object o) {
+        assert o != null;
+        Class<?> c = o.getClass();
+        if (c == Boolean.class) {
+            return "boolean";
+        } else if (c == String.class) {
+            return "string";
+        } else if (c == Short.class) {
+            return "short";
+        } else if (c == Integer.class) {
+            return "int";
+        } else if (c == Long.class) {
+            return "bigint";
+        } else if (c == BigDecimal.class) {
+            return "numeric";
+        } else if (c == Float.class) {
+            return "float";
+        } else if (c == Double.class) {
+            return "double";
+        } else if (c == Date.class) {
+            return "date";
+        } else if (c == Time.class) {
+            return "time";
+        } else if (c == Timestamp.class) {
+            return "timestamp or datetime (ambiguous)";
+        } else {
+            return "<unknown>";
+        }
     }
 }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -6160,27 +6160,27 @@ public class SpLib {
         assert o != null;
         Class<?> c = o.getClass();
         if (c == Boolean.class) {
-            return "boolean";
+            return "BOOLEAN";
         } else if (c == String.class) {
-            return "string";
+            return "STRING";
         } else if (c == Short.class) {
-            return "short";
+            return "SHORT";
         } else if (c == Integer.class) {
-            return "int";
+            return "INT";
         } else if (c == Long.class) {
-            return "bigint";
+            return "BIGINT";
         } else if (c == BigDecimal.class) {
-            return "numeric";
+            return "NUMERIC";
         } else if (c == Float.class) {
-            return "float";
+            return "FLOAT";
         } else if (c == Double.class) {
-            return "double";
+            return "DOUBLE";
         } else if (c == Date.class) {
-            return "date";
+            return "DATE";
         } else if (c == Time.class) {
-            return "time";
+            return "TIME";
         } else if (c == Timestamp.class) {
-            return "timestamp or datetime (ambiguous)";
+            return "TIMESTAMP or DATETIME (ambiguous)";
         } else {
             return "<unknown>";
         }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -3443,6 +3443,7 @@ public class SpLib {
             return null;
         }
 
+        e = e.trim();
         if (e.length() == 0) {
             return INT_ZERO;
         }
@@ -3457,6 +3458,7 @@ public class SpLib {
             return null;
         }
 
+        e = e.trim();
         if (e.length() == 0) {
             return SHORT_ZERO;
         }
@@ -3471,6 +3473,7 @@ public class SpLib {
             return null;
         }
 
+        e = e.trim();
         if (e.length() == 0) {
             return DOUBLE_ZERO;
         }
@@ -3487,6 +3490,7 @@ public class SpLib {
             return null;
         }
 
+        e = e.trim();
         if (e.length() == 0) {
             return FLOAT_ZERO;
         }
@@ -3511,6 +3515,7 @@ public class SpLib {
             return null;
         }
 
+        e = e.trim();
         if (e.length() == 0) {
             return LONG_ZERO;
         }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -2328,6 +2328,15 @@ public class SpLib {
     // +
     @Operator(coercionScheme = CoercionScheme.ArithOp)
     public static String opAdd(String l, String r) {
+        if (Server.getSystemParameterBool(Server.SYS_PARAM_ORACLE_STYLE_EMPTY_STRING)) {
+            if (l == null) {
+                l = EMPTY_STRING;
+            }
+            if (r == null) {
+                r = EMPTY_STRING;
+            }
+        }
+
         if (l == null || r == null) {
             return null;
         }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25156

ORACLE_COMPAT_NUMBER_BEHAVIOR 시스템 파라메터가 yes 로 설정되어 있을 때
정수 나눗셈 연산에서 operand 들을 우선 numeric 으로 변환한 후 나눗셈의 결과도 numeric 으로 되도록 구현한 것입니다. 
(no 로 설정되어 있을 때는 정수 나눗셈의 결과는 정수)
예를 들면, 1/2 의 결과는 시스템 파라메터 설정에 따라 0.5 (numeric) 또는 0 (integer) 가 됩니다. 

정수 나눗셈 결과가 시스템 설정에 따라 numeric 또는 정수 타입 (short, int, bigint) 가 될 수 있으므로 
정수 나눗셈 연산 표현식의 타입은 이 두 경우를 아우르는 Object 로 타이핑을 할 수 있습니다. 

이번 PR 에서는 연산의 operand 중 하나가 Object 로 타이핑되어 있을 때 실행시간에 타입 검사를 하여 
타입별로 올바른 연산으로 분기하도록 구현하는 부분도 새롭게 추가하였습니다. 

두 개의 commit 중 2606dd2 이 COMPAT_NUMBER_BEHAVIOR 시스템 파라메터를 적용하는 부분이고 (비교적 단순)
6066fac 가 컴파일 시간에 Object 로 타이핑된 operand 들을 실행시간에 타입 검사를 하여 
타입별 연산으로 분기하는 부분을 구현한 것입니다. 

그리고, 기존에 + 연산자가 문자열에 적용되었을 때 double 로 캐스팅한 후 숫자 연산을 하던 것을 
큐브리드 엔진과 마찬가지로 문자열 concat 으로 동작하도록 수정하는 내용도 함께 포함되어 있습니다. 
