### PR TITLE
[CBRD-25459] Implement an interface on the PL server to send requests to the DB server

### DIFF
--- a/src/executables/javasp.cpp
+++ b/src/executables/javasp.cpp
@@ -116,6 +116,8 @@ static void javasp_signal_handler (int sig);
 static bool is_signal_handling = false;
 static char executable_path[PATH_MAX];
 
+static bool is_server_conncted = false;
+
 static std::string command;
 static std::string db_name;
 static JAVASP_SERVER_INFO running_info = JAVASP_SERVER_INFO_INITIALIZER;
@@ -123,6 +125,7 @@ static JAVASP_SERVER_INFO running_info = JAVASP_SERVER_INFO_INITIALIZER;
 /*
  * main() - javasp main function
  */
+
 
 int
 main (int argc, char *argv[])
@@ -272,6 +275,7 @@ main (int argc, char *argv[])
 	    PRINT_AND_LOG_ERR_MSG ("%s\n", db_error_string (3));
 	    goto exit;
 	  }
+	is_server_conncted = true;
 
 	int cnt = 0;
 	status = javasp_start_server (jsp_info, db_name, pathname);
@@ -282,7 +286,6 @@ main (int argc, char *argv[])
 
 	    do
 	      {
-		SLEEP_MILISEC (0, 100);
 		int error = db_ping_server (0, NULL);
 		if (error != NO_ERROR)
 		  {
@@ -292,16 +295,15 @@ main (int argc, char *argv[])
 		  {
 		    cnt = 0;
 		  }
+		SLEEP_MILISEC (0, 500);
 
 		if (cnt > 10)
 		  {
-		    status = ER_GENERIC_ERROR;
+		    // can not connect with cub_server
 		    break;
 		  }
 	      }
 	    while (true);
-
-	    db_shutdown ();
 	  }
       }
     else if (command.compare ("stop") == 0)
@@ -348,6 +350,11 @@ exit:
 	{
 	  JAVASP_PRINT_ERR_MSG ("%s\n", er_msg ());
 	}
+    }
+
+  if (is_server_conncted)
+    {
+      (void) db_shutdown ();
     }
 
   return status;

--- a/src/executables/javasp.cpp
+++ b/src/executables/javasp.cpp
@@ -143,7 +143,7 @@ static int
 get_server_state_from_master (CSS_CONN_ENTRY *conn, const char *db_name)
 {
   unsigned short request_id;
-  int error = NO_ERROR;
+  int error = NO_ERRORS;
   int server_state;
   int buffer_size;
   int *buffer = NULL;

--- a/src/executables/javasp.cpp
+++ b/src/executables/javasp.cpp
@@ -342,7 +342,7 @@ main (int argc, char *argv[])
 	    command = "running";
 	    javasp_read_info (db_name.c_str(), running_info);
 
-            // check DB server's state through master request
+	    // check DB server's state through master request
 	    int port_id = prm_get_master_port_id ();
 	    if (port_id <= 0)
 	      {
@@ -357,6 +357,7 @@ main (int argc, char *argv[])
 		state = get_server_state_from_master (master_conn, db_name.c_str ());
 		if (state < DB_SERVER_STATE_REGISTERED && state != DB_SERVER_STATE_UNKNOWN)
 		  {
+		    JAVASP_PRINT_ERR_MSG ("Stopped due to the shutdown of the database server\n");
 		    break;
 		  }
 		SLEEP_MILISEC (1, 0);
@@ -388,8 +389,8 @@ exit:
     }
 
 #if defined(WINDOWS)
-    // socket shutdown for windows
-    windows_socket_shutdown (jsp_old_hook);
+  // socket shutdown for windows
+  windows_socket_shutdown (jsp_old_hook);
 #endif /* WINDOWS */
 
   if (command.compare ("ping") == 0)

--- a/src/executables/javasp.cpp
+++ b/src/executables/javasp.cpp
@@ -119,7 +119,7 @@ static void javasp_signal_handler (int sig);
 static bool is_signal_handling = false;
 static char executable_path[PATH_MAX];
 
-static bool is_server_conncted = false;
+static bool is_server_connected = false;
 
 static std::string command;
 static std::string db_name;
@@ -334,7 +334,7 @@ main (int argc, char *argv[])
 	    PRINT_AND_LOG_ERR_MSG ("%s\n", db_error_string (3));
 	    goto exit;
 	  }
-	is_server_conncted = true;
+	is_server_connected = true;
 
 	status = javasp_start_server (jsp_info, db_name, pathname);
 	if (status == NO_ERROR)
@@ -417,7 +417,7 @@ exit:
 	}
     }
 
-  if (is_server_conncted)
+  if (is_server_connected)
     {
       (void) db_shutdown ();
     }

--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -1791,12 +1791,6 @@ process_server (int command_type, int argc, char **argv, bool show_usage, bool c
 	      break;
 	    }
 
-	  /* try to stop javasp server first */
-	  if (is_javasp_running (token) == JAVASP_SERVER_RUNNING)
-	    {
-	      (void) process_pl (command_type, 1, (const char **) &token, false, true, process_window_service, false);
-	    }
-
 	  print_message (stdout, MSGCAT_UTIL_GENERIC_START_STOP_3S, PRINT_SERVER_NAME, PRINT_CMD_STOP, token);
 
 	  if (is_server_running (CHECK_SERVER, token, 0))

--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -1360,8 +1360,6 @@ process_service (int command_type, bool process_window_service)
 	{
 	  if (!are_all_services_stopped (0, process_window_service))
 	    {
-	      (void) process_pl (command_type, 0, NULL, false, false, process_window_service, false);
-
 	      if (strcmp (get_property (SERVICE_START_SERVER), PROPERTY_ON) == 0
 		  && us_Property_map[SERVER_START_LIST].property_value != NULL
 		  && us_Property_map[SERVER_START_LIST].property_value[0] != '\0')
@@ -1385,6 +1383,8 @@ process_service (int command_type, bool process_window_service)
 		{
 		  (void) process_heartbeat (command_type, 0, NULL);
 		}
+
+	      (void) process_pl (command_type, 0, NULL, false, false, process_window_service, false);
 
 	      (void) process_master (command_type);
 

--- a/src/sp/jsp_sr.c
+++ b/src/sp/jsp_sr.c
@@ -732,12 +732,12 @@ jsp_start_server (const char *db_name, const char *path, int port)
   }
 
 exit:
-#if defined (SA_MODE)
+//#if defined (SA_MODE)
   if (jvm != NULL)
     {
       JVM_DetachCurrentThread (jvm);
     }
-#endif
+//#endif
 
   return er_errid ();
 }

--- a/src/sp/jsp_sr.c
+++ b/src/sp/jsp_sr.c
@@ -732,12 +732,10 @@ jsp_start_server (const char *db_name, const char *path, int port)
   }
 
 exit:
-//#if defined (SA_MODE)
   if (jvm != NULL)
     {
       JVM_DetachCurrentThread (jvm);
     }
-//#endif
 
   return er_errid ();
 }

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -1387,7 +1387,10 @@ boot_shutdown_client (bool is_er_final)
 #endif /* !CS_MODE */
 	}
 
-      boot_client_all_finalize (is_er_final);
+      if (!boot_Is_client_all_final)
+	{
+	  boot_client_all_finalize (is_er_final);
+	}
     }
 
   return NO_ERROR;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25459

Purpose
- PL 서버에서 DB 서버 (cub_server) 에 요청을 보낼 수 있도록 클라이언트로 연결
- PL 서버가 DB 서버가 종료되는 경우를 감지하여 스스로 종료할 수 있도록 수정

Implementation
- PL 서버에서 DB 서버 (cub_server) 에 요청을 보낼 수 있도록 db_restart() API로 cub_server에 연결
- DB 서버가 다운된 경우를 알기 위해 마스터에 연결하여 서버의 State를 체크
  - HA 모드가 아닌 경우에는 DB_SERVER_STATE_UNKNOWN와 DB_SERVER_STATE_DEAD 가 반환, DEAD 인 경우 서버에 문제가 있는 것으로 판단
  - HA 모드인 경우에는 broker.c의 서버 모니터 기능과 같은 로직으로 서버 기능 여부 판단

Repro
```
cubrid server start demodb
cubrid server status
kill -9 <pid>
```

Additional Information
- db_restart () 를 통한 클라이언트 로써의 연결에서 ping을 통해서도 감지 가능하지만, 이 경우 server task로 처리되어 ping 메시지마다 디버깅 로그가 수집되므로, 마스터를 통한 연결 감지로 디자인 방향을 변경
