### PR TITLE
[CBRD-25438] Implementation of server revive routine for master monitoring thread

### DIFF
--- a/cs/CMakeLists.txt
+++ b/cs/CMakeLists.txt
@@ -30,7 +30,6 @@ set(EXECUTABLE_SOURCES
   ${EXECUTABLES_DIR}/unloaddb.c
   ${EXECUTABLES_DIR}/util_common.c
   ${EXECUTABLES_DIR}/util_cs.c
-  ${EXECUTABLES_DIR}/master_server_monitor.cpp
   )
 
 set(EXECUTABLE_HEADERS
@@ -392,6 +391,7 @@ set(API_HEADERS
 list(APPEND CONNECTION_SOURCES ${CONNECTION_DIR}/heartbeat.c)
 if(UNIX)
   list(APPEND EXECUTABLE_SOURCES ${EXECUTABLES_DIR}/checksumdb.c)
+  list(APPEND EXECUTABLE_SOURCES ${EXECUTABLES_DIR}/master_server_monitor.cpp)
   list(APPEND CONNECTION_SOURCES ${CONNECTION_DIR}/tcp.c)
   list(APPEND BASE_SOURCES ${BASE_DIR}/dynamic_load.c)
   list(APPEND TRANSACTION_SOURCES ${TRANSACTION_DIR}/log_applier_sql_log.c)

--- a/cs/CMakeLists.txt
+++ b/cs/CMakeLists.txt
@@ -30,7 +30,6 @@ set(EXECUTABLE_SOURCES
   ${EXECUTABLES_DIR}/unloaddb.c
   ${EXECUTABLES_DIR}/util_common.c
   ${EXECUTABLES_DIR}/util_cs.c
-  ${EXECUTABLES_DIR}/master_server_monitor.cpp
   )
 
 set(EXECUTABLE_HEADERS

--- a/cs/CMakeLists.txt
+++ b/cs/CMakeLists.txt
@@ -30,6 +30,7 @@ set(EXECUTABLE_SOURCES
   ${EXECUTABLES_DIR}/unloaddb.c
   ${EXECUTABLES_DIR}/util_common.c
   ${EXECUTABLES_DIR}/util_cs.c
+  ${EXECUTABLES_DIR}/master_server_monitor.cpp
   )
 
 set(EXECUTABLE_HEADERS
@@ -433,7 +434,6 @@ SET_SOURCE_FILES_PROPERTIES(
   ${EXECUTABLES_DIR}/unloaddb.c
   ${EXECUTABLES_DIR}/util_common.c
   ${EXECUTABLES_DIR}/util_cs.c
-  ${EXECUTABLES_DIR}/master_server_monitor.cpp
   ${COMPAT_SOURCES}
   ${BASE_SOURCES}
   ${HEAPLAYER_SOURCES}

--- a/cs/CMakeLists.txt
+++ b/cs/CMakeLists.txt
@@ -433,6 +433,7 @@ SET_SOURCE_FILES_PROPERTIES(
   ${EXECUTABLES_DIR}/unloaddb.c
   ${EXECUTABLES_DIR}/util_common.c
   ${EXECUTABLES_DIR}/util_cs.c
+  ${EXECUTABLES_DIR}/master_server_monitor.cpp
   ${COMPAT_SOURCES}
   ${BASE_SOURCES}
   ${HEAPLAYER_SOURCES}

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -1007,9 +1007,9 @@ css_check_master_socket_input (int *count, fd_set * fd_var)
 
 #if !defined(WINDOWS)
 		      /* Abnormal termination of non-HA server process is detected. */
-                       /* *INDENT-OFF* */
-                       master_Server_monitor->find_set_entry_to_revive (temp->conn_ptr);
-                       /* *INDENT-ON* */
+                      /* *INDENT-OFF* */
+                      master_Server_monitor->find_set_entry_to_revive (temp->conn_ptr);
+                      /* *INDENT-ON* */
 #endif
 		      css_remove_entry_by_conn (temp->conn_ptr, &css_Master_socket_anchor);
 		    }

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -1009,10 +1009,13 @@ css_check_master_socket_input (int *count, fd_set * fd_var)
 
 #if !defined(WINDOWS)
 		      /* Abnormal termination of non-HA server process is detected. */
-                      /* *INDENT-OFF* */
-                      master_Server_monitor->produce_job (server_monitor::job_type::REVIVE_SERVER, -1, "", "", temp->name);
-                      /* *INDENT-ON* */
+		      if (css_return_entry_of_server (temp->name, css_Master_socket_anchor) != NULL)
+			{
+                        /* *INDENT-OFF* */
+                        master_Server_monitor->produce_job (server_monitor::job_type::REVIVE_SERVER, -1, "", "", temp->name);
+                        /* *INDENT-ON* */
 #endif
+			}
 		      css_remove_entry_by_conn (temp->conn_ptr, &css_Master_socket_anchor);
 		    }
 		}

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -1005,9 +1005,12 @@ css_check_master_socket_input (int *count, fd_set * fd_var)
 			  css_Active_server_count--;
 			}
 #endif
+
+#if !defined(WINDOWS)
                       /* *INDENT-OFF* */
                       master_Server_monitor->find_set_entry_to_revive (temp->conn_ptr);
                       /* *INDENT-ON* */
+#endif
 		      css_remove_entry_by_conn (temp->conn_ptr, &css_Master_socket_anchor);
 		    }
 		}

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -1004,6 +1004,7 @@ css_check_master_socket_input (int *count, fd_set * fd_var)
 			  css_Active_server_count--;
 			}
 #endif
+                      master_Server_monitor->find_set_entry_to_revive (temp->conn_ptr);
 		      css_remove_entry_by_conn (temp->conn_ptr, &css_Master_socket_anchor);
 		    }
 		}

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -358,8 +358,7 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 	  length = (int) strlen (proc_register->server_name) + 1;
 	  server_name_length = proc_register->server_name_length;
 
-	  char server_name_str[256];
-	  memset (server_name_str, 0, sizeof (server_name_str));
+	  char server_name_str[DB_MAX_IDENTIFIER_LENGTH] = { 0 };
 	  strncpy (server_name_str, proc_register->server_name, length);
 
 	  if (length < server_name_length)

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -1008,9 +1008,9 @@ css_check_master_socket_input (int *count, fd_set * fd_var)
 #endif
 
 #if !defined(WINDOWS)
-                        /* *INDENT-OFF* */
-                        master_Server_monitor->produce_job (server_monitor::job_type::REVIVE_SERVER, -1, "", "", temp->name);
-                        /* *INDENT-ON* */
+		      /* *INDENT-OFF* */
+		      master_Server_monitor->produce_job (server_monitor::job_type::REVIVE_SERVER, -1, "", "", temp->name);
+		      /* *INDENT-ON* */
 #endif
 		      css_remove_entry_by_conn (temp->conn_ptr, &css_Master_socket_anchor);
 		    }

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -1004,7 +1004,9 @@ css_check_master_socket_input (int *count, fd_set * fd_var)
 			  css_Active_server_count--;
 			}
 #endif
+                      /* *INDENT-OFF* */
                       master_Server_monitor->find_set_entry_to_revive (temp->conn_ptr);
+                      /* *INDENT-ON* */
 		      css_remove_entry_by_conn (temp->conn_ptr, &css_Master_socket_anchor);
 		    }
 		}

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -82,12 +82,12 @@ static void css_reject_client_request (CSS_CONN_ENTRY * conn, unsigned short rid
 static void css_reject_server_request (CSS_CONN_ENTRY * conn, int reason);
 static void css_accept_server_request (CSS_CONN_ENTRY * conn, int reason);
 static void css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer);
-static void css_accept_old_request (CSS_CONN_ENTRY * conn, unsigned short rid, SOCKET_QUEUE_ENTRY * entry,
-				    char *server_name, int server_name_length);
+static void css_accept_old_request (CSS_CONN_ENTRY * conn, unsigned short rid,
+				    SOCKET_QUEUE_ENTRY * entry, char *server_name, int server_name_length);
 static void css_register_new_server (CSS_CONN_ENTRY * conn, unsigned short rid);
 static void css_register_new_server2 (CSS_CONN_ENTRY * conn, unsigned short rid);
-static bool css_send_new_request_to_server (SOCKET server_fd, SOCKET client_fd, unsigned short rid,
-					    CSS_SERVER_REQUEST request);
+static bool css_send_new_request_to_server (SOCKET server_fd,
+					    SOCKET client_fd, unsigned short rid, CSS_SERVER_REQUEST request);
 static void css_send_to_existing_server (CSS_CONN_ENTRY * conn, unsigned short rid, CSS_SERVER_REQUEST request);
 static void css_process_new_connection (SOCKET fd);
 static int css_enroll_read_sockets (SOCKET_QUEUE_ENTRY * anchor_p, fd_set * fd_var);
@@ -169,8 +169,8 @@ css_master_timeout (void)
   struct timeval timeout;
 
   /* check for timeout */
-  if (css_Master_timeout && time ((time_t *) (&timeout.tv_sec)) != (time_t) (-1)
-      && css_Master_timeout->tv_sec < timeout.tv_sec)
+  if (css_Master_timeout
+      && time ((time_t *) (&timeout.tv_sec)) != (time_t) (-1) && css_Master_timeout->tv_sec < timeout.tv_sec)
     {
       return (0);
     }
@@ -349,8 +349,9 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 #if defined(DEBUG)
 	  css_Active_server_count++;
 #endif
-	  css_add_request_to_socket_queue (datagram_conn, false, proc_register->server_name, server_fd, READ_WRITE, 0,
-					   &css_Master_socket_anchor);
+	  css_add_request_to_socket_queue (datagram_conn, false,
+					   proc_register->server_name,
+					   server_fd, READ_WRITE, 0, &css_Master_socket_anchor);
 
 	  //  Note : server_name is usually packed(appended) information of server_name, version_string, env_var, pid,
 	  //  packed from css_pack_server_name(). Since there are some cases that returns server_name and server_name_length
@@ -411,8 +412,8 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
  *   server_name_length(in)
  */
 static void
-css_accept_old_request (CSS_CONN_ENTRY * conn, unsigned short rid, SOCKET_QUEUE_ENTRY * entry, char *server_name,
-			int server_name_length)
+css_accept_old_request (CSS_CONN_ENTRY * conn, unsigned short rid,
+			SOCKET_QUEUE_ENTRY * entry, char *server_name, int server_name_length)
 {
   char *datagram;
   int datagram_length;
@@ -563,8 +564,8 @@ css_register_new_server2 (CSS_CONN_ENTRY * conn, unsigned short rid)
 	      css_Active_server_count++;
 #endif
 	      entry =
-		css_add_request_to_socket_queue (conn, false, server_name, conn->fd, READ_WRITE, 0,
-						 &css_Master_socket_anchor);
+		css_add_request_to_socket_queue (conn, false, server_name,
+						 conn->fd, READ_WRITE, 0, &css_Master_socket_anchor);
 	      /* store this for later */
 	      if (entry != NULL)
 		{
@@ -1005,11 +1006,10 @@ css_check_master_socket_input (int *count, fd_set * fd_var)
 			}
 #endif
                       /* *INDENT-OFF* */
+                      fprintf(stdout, "css_check_master_socket_input: removing server entry by conn\n");
                       master_Server_monitor->find_set_entry_to_revive (temp->conn_ptr);
                       /* *INDENT-ON* */
-
-		      //master_Server_monitor->remove_server_entry_by_conn (temp->conn_ptr);
-		      //css_remove_entry_by_conn (temp->conn_ptr, &css_Master_socket_anchor);
+		      css_remove_entry_by_conn (temp->conn_ptr, &css_Master_socket_anchor);
 		    }
 		}
 	      /* stop loop in case an error caused temp to be deleted */
@@ -1058,8 +1058,8 @@ again:
 #if !defined(WINDOWS)
 					     (fcntl (temp->fd, F_GETFL, 0) < 0) ||
 #endif /* !WINDOWS */
-					     (temp->error_p != 0) || (temp->conn_ptr == NULL)
-					     || (temp->conn_ptr->status == CONN_CLOSED))))
+					     (temp->error_p != 0)
+					     || (temp->conn_ptr == NULL) || (temp->conn_ptr->status == CONN_CLOSED))))
 	{
 #if defined(DEBUG)
 	  if (css_Active_server_count > 0)
@@ -1265,11 +1265,11 @@ main (int argc, char **argv)
 #endif
 
   conn = css_make_conn (css_Master_socket_fd[0]);
-  css_add_request_to_socket_queue (conn, false, NULL, css_Master_socket_fd[0], READ_WRITE, 0,
-				   &css_Master_socket_anchor);
+  css_add_request_to_socket_queue (conn, false, NULL, css_Master_socket_fd[0],
+				   READ_WRITE, 0, &css_Master_socket_anchor);
   conn = css_make_conn (css_Master_socket_fd[1]);
-  css_add_request_to_socket_queue (conn, false, NULL, css_Master_socket_fd[1], READ_WRITE, 0,
-				   &css_Master_socket_anchor);
+  css_add_request_to_socket_queue (conn, false, NULL, css_Master_socket_fd[1],
+				   READ_WRITE, 0, &css_Master_socket_anchor);
   css_master_loop ();
   css_master_cleanup (SIGINT);
   css_master_error (msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_MASTER, MASTER_MSG_EXITING));
@@ -1370,8 +1370,8 @@ css_remove_entry_by_conn (CSS_CONN_ENTRY * conn_p, SOCKET_QUEUE_ENTRY ** anchor_
  *   anchor_p(out):
  */
 SOCKET_QUEUE_ENTRY *
-css_add_request_to_socket_queue (CSS_CONN_ENTRY * conn_p, int info_p, char *name_p, SOCKET fd, int fd_type, int pid,
-				 SOCKET_QUEUE_ENTRY ** anchor_p)
+css_add_request_to_socket_queue (CSS_CONN_ENTRY * conn_p, int info_p,
+				 char *name_p, SOCKET fd, int fd_type, int pid, SOCKET_QUEUE_ENTRY ** anchor_p)
 {
   SOCKET_QUEUE_ENTRY *p;
 
@@ -1392,8 +1392,8 @@ css_add_request_to_socket_queue (CSS_CONN_ENTRY * conn_p, int info_p, char *name
 	{
 	  strcpy (p->name, name_p);
 #if !defined(WINDOWS)
-	  if (IS_MASTER_CONN_NAME_HA_SERVER (p->name) || IS_MASTER_CONN_NAME_HA_COPYLOG (p->name)
-	      || IS_MASTER_CONN_NAME_HA_APPLYLOG (p->name))
+	  if (IS_MASTER_CONN_NAME_HA_SERVER (p->name)
+	      || IS_MASTER_CONN_NAME_HA_COPYLOG (p->name) || IS_MASTER_CONN_NAME_HA_APPLYLOG (p->name))
 	    {
 	      p->ha_mode = TRUE;
 	    }

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -1007,6 +1007,7 @@ css_check_master_socket_input (int *count, fd_set * fd_var)
 #endif
 
 #if !defined(WINDOWS)
+		      /* Abnormal termination of non-HA server process is detected. */
                       /* *INDENT-OFF* */
                       master_Server_monitor->find_set_entry_to_revive (temp->conn_ptr);
                       /* *INDENT-ON* */

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -358,6 +358,12 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 	  length = (int) strlen (proc_register->server_name) + 1;
 	  server_name_length = proc_register->server_name_length;
 
+	  char *server_name_str = (char *) malloc (length);
+	  if (server_name_str != NULL)
+	    {
+	      strcpy (server_name_str, proc_register->server_name);
+	    }
+
 	  if (length < server_name_length)
 	    {
 	      entry = css_return_entry_of_server (proc_register->server_name, css_Master_socket_anchor);
@@ -391,8 +397,12 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 	    {
               /* *INDENT-OFF* */
 
-              master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_REGISTER_ENTRY, proc_register->pid, proc_register->exec_path, proc_register->args);
+              master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_REGISTER_ENTRY, proc_register->pid, proc_register->exec_path, proc_register->args, server_name_str);
               /* *INDENT-ON* */
+	    }
+	  if (server_name_str != NULL)
+	    {
+	      free_and_init (server_name_str);
 	    }
 	}
     }
@@ -1009,7 +1019,7 @@ css_check_master_socket_input (int *count, fd_set * fd_var)
 #if !defined(WINDOWS)
 		      /* Abnormal termination of non-HA server process is detected. */
                       /* *INDENT-OFF* */
-                      master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_REVIVE_ENTRY, temp->pid, "", "");
+                      master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_REVIVE_ENTRY, -1, "", "", temp->name);
                       /* *INDENT-ON* */
 #endif
 		      css_remove_entry_by_conn (temp->conn_ptr, &css_Master_socket_anchor);

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -394,7 +394,7 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 	    {
               /* *INDENT-OFF* */
 
-              master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_REGISTER_ENTRY, proc_register->pid, proc_register->exec_path, proc_register->args, server_name_str);
+              master_Server_monitor->produce_job (server_monitor::job_type::REGISTER_ENTRY, proc_register->pid, proc_register->exec_path, proc_register->args, server_name_str);
               /* *INDENT-ON* */
 	    }
 	}
@@ -1012,7 +1012,7 @@ css_check_master_socket_input (int *count, fd_set * fd_var)
 #if !defined(WINDOWS)
 		      /* Abnormal termination of non-HA server process is detected. */
                       /* *INDENT-OFF* */
-                      master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_REVIVE_ENTRY, -1, "", "", temp->name);
+                      master_Server_monitor->produce_job (server_monitor::job_type::REVIVE_ENTRY, -1, "", "", temp->name);
                       /* *INDENT-ON* */
 #endif
 		      css_remove_entry_by_conn (temp->conn_ptr, &css_Master_socket_anchor);

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -334,6 +334,7 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
   CSS_CONN_ENTRY *datagram_conn;
   SOCKET_QUEUE_ENTRY *entry;
   CSS_SERVER_PROC_REGISTER *proc_register = (CSS_SERVER_PROC_REGISTER *) buffer;
+  char server_name_str[DB_MAX_IDENTIFIER_LENGTH] = { 0 };
 
   datagram = NULL;
   datagram_length = 0;
@@ -359,7 +360,6 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 	  server_name_length = proc_register->server_name_length;
 
 	  assert (length <= DB_MAX_IDENTIFIER_LENGTH);
-	  char server_name_str[DB_MAX_IDENTIFIER_LENGTH] = { 0 };
 	  strncpy (server_name_str, proc_register->server_name, length);
 
 	  if (length < server_name_length)
@@ -395,7 +395,7 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 	    {
               /* *INDENT-OFF* */
 
-              master_Server_monitor->produce_job (server_monitor::job_type::REGISTER_ENTRY, proc_register->pid, proc_register->exec_path, proc_register->args, server_name_str);
+              master_Server_monitor->produce_job (server_monitor::job_type::REGISTER_SERVER, proc_register->pid, proc_register->exec_path, proc_register->args, server_name_str);
               /* *INDENT-ON* */
 	    }
 	}
@@ -1013,7 +1013,7 @@ css_check_master_socket_input (int *count, fd_set * fd_var)
 #if !defined(WINDOWS)
 		      /* Abnormal termination of non-HA server process is detected. */
                       /* *INDENT-OFF* */
-                      master_Server_monitor->produce_job (server_monitor::job_type::REVIVE_ENTRY, -1, "", "", temp->name);
+                      master_Server_monitor->produce_job (server_monitor::job_type::REVIVE_SERVER, -1, "", "", temp->name);
                       /* *INDENT-ON* */
 #endif
 		      css_remove_entry_by_conn (temp->conn_ptr, &css_Master_socket_anchor);

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -82,12 +82,12 @@ static void css_reject_client_request (CSS_CONN_ENTRY * conn, unsigned short rid
 static void css_reject_server_request (CSS_CONN_ENTRY * conn, int reason);
 static void css_accept_server_request (CSS_CONN_ENTRY * conn, int reason);
 static void css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer);
-static void css_accept_old_request (CSS_CONN_ENTRY * conn, unsigned short rid, SOCKET_QUEUE_ENTRY * entry,
-				    char *server_name, int server_name_length);
+static void css_accept_old_request (CSS_CONN_ENTRY * conn, unsigned short rid,
+				    SOCKET_QUEUE_ENTRY * entry, char *server_name, int server_name_length);
 static void css_register_new_server (CSS_CONN_ENTRY * conn, unsigned short rid);
 static void css_register_new_server2 (CSS_CONN_ENTRY * conn, unsigned short rid);
-static bool css_send_new_request_to_server (SOCKET server_fd, SOCKET client_fd, unsigned short rid,
-					    CSS_SERVER_REQUEST request);
+static bool css_send_new_request_to_server (SOCKET server_fd,
+					    SOCKET client_fd, unsigned short rid, CSS_SERVER_REQUEST request);
 static void css_send_to_existing_server (CSS_CONN_ENTRY * conn, unsigned short rid, CSS_SERVER_REQUEST request);
 static void css_process_new_connection (SOCKET fd);
 static int css_enroll_read_sockets (SOCKET_QUEUE_ENTRY * anchor_p, fd_set * fd_var);
@@ -169,8 +169,8 @@ css_master_timeout (void)
   struct timeval timeout;
 
   /* check for timeout */
-  if (css_Master_timeout && time ((time_t *) (&timeout.tv_sec)) != (time_t) (-1)
-      && css_Master_timeout->tv_sec < timeout.tv_sec)
+  if (css_Master_timeout
+      && time ((time_t *) (&timeout.tv_sec)) != (time_t) (-1) && css_Master_timeout->tv_sec < timeout.tv_sec)
     {
       return (0);
     }
@@ -349,8 +349,9 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 #if defined(DEBUG)
 	  css_Active_server_count++;
 #endif
-	  css_add_request_to_socket_queue (datagram_conn, false, proc_register->server_name, server_fd, READ_WRITE, 0,
-					   &css_Master_socket_anchor);
+	  css_add_request_to_socket_queue (datagram_conn, false,
+					   proc_register->server_name,
+					   server_fd, READ_WRITE, 0, &css_Master_socket_anchor);
 
 	  //  Note : server_name is usually packed(appended) information of server_name, version_string, env_var, pid,
 	  //  packed from css_pack_server_name(). Since there are some cases that returns server_name and server_name_length
@@ -390,7 +391,7 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 	  if (!entry->ha_mode)
 	    {
               /* *INDENT-OFF* */
-              master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_REGISTER_ENTRY, proc_register->pid, proc_register->exec_path, proc_register->args, datagram_conn);
+              master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_REGISTER_ENTRY, proc_register->pid, proc_register->exec_path, proc_register->args);
               /* *INDENT-ON* */
 	    }
 	}
@@ -411,8 +412,8 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
  *   server_name_length(in)
  */
 static void
-css_accept_old_request (CSS_CONN_ENTRY * conn, unsigned short rid, SOCKET_QUEUE_ENTRY * entry, char *server_name,
-			int server_name_length)
+css_accept_old_request (CSS_CONN_ENTRY * conn, unsigned short rid,
+			SOCKET_QUEUE_ENTRY * entry, char *server_name, int server_name_length)
 {
   char *datagram;
   int datagram_length;
@@ -563,8 +564,8 @@ css_register_new_server2 (CSS_CONN_ENTRY * conn, unsigned short rid)
 	      css_Active_server_count++;
 #endif
 	      entry =
-		css_add_request_to_socket_queue (conn, false, server_name, conn->fd, READ_WRITE, 0,
-						 &css_Master_socket_anchor);
+		css_add_request_to_socket_queue (conn, false, server_name,
+						 conn->fd, READ_WRITE, 0, &css_Master_socket_anchor);
 	      /* store this for later */
 	      if (entry != NULL)
 		{
@@ -1008,7 +1009,7 @@ css_check_master_socket_input (int *count, fd_set * fd_var)
 #if !defined(WINDOWS)
 		      /* Abnormal termination of non-HA server process is detected. */
                       /* *INDENT-OFF* */
-                      master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_REVIVE_ENTRY, temp->pid, "", "", nullptr);
+                      master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_REVIVE_ENTRY, temp->pid, "", "");
                       /* *INDENT-ON* */
 #endif
 		      css_remove_entry_by_conn (temp->conn_ptr, &css_Master_socket_anchor);
@@ -1060,8 +1061,8 @@ again:
 #if !defined(WINDOWS)
 					     (fcntl (temp->fd, F_GETFL, 0) < 0) ||
 #endif /* !WINDOWS */
-					     (temp->error_p != 0) || (temp->conn_ptr == NULL)
-					     || (temp->conn_ptr->status == CONN_CLOSED))))
+					     (temp->error_p != 0)
+					     || (temp->conn_ptr == NULL) || (temp->conn_ptr->status == CONN_CLOSED))))
 	{
 #if defined(DEBUG)
 	  if (css_Active_server_count > 0)
@@ -1267,11 +1268,11 @@ main (int argc, char **argv)
 #endif
 
   conn = css_make_conn (css_Master_socket_fd[0]);
-  css_add_request_to_socket_queue (conn, false, NULL, css_Master_socket_fd[0], READ_WRITE, 0,
-				   &css_Master_socket_anchor);
+  css_add_request_to_socket_queue (conn, false, NULL, css_Master_socket_fd[0],
+				   READ_WRITE, 0, &css_Master_socket_anchor);
   conn = css_make_conn (css_Master_socket_fd[1]);
-  css_add_request_to_socket_queue (conn, false, NULL, css_Master_socket_fd[1], READ_WRITE, 0,
-				   &css_Master_socket_anchor);
+  css_add_request_to_socket_queue (conn, false, NULL, css_Master_socket_fd[1],
+				   READ_WRITE, 0, &css_Master_socket_anchor);
   css_master_loop ();
   css_master_cleanup (SIGINT);
   css_master_error (msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_MASTER, MASTER_MSG_EXITING));
@@ -1372,8 +1373,8 @@ css_remove_entry_by_conn (CSS_CONN_ENTRY * conn_p, SOCKET_QUEUE_ENTRY ** anchor_
  *   anchor_p(out):
  */
 SOCKET_QUEUE_ENTRY *
-css_add_request_to_socket_queue (CSS_CONN_ENTRY * conn_p, int info_p, char *name_p, SOCKET fd, int fd_type, int pid,
-				 SOCKET_QUEUE_ENTRY ** anchor_p)
+css_add_request_to_socket_queue (CSS_CONN_ENTRY * conn_p, int info_p,
+				 char *name_p, SOCKET fd, int fd_type, int pid, SOCKET_QUEUE_ENTRY ** anchor_p)
 {
   SOCKET_QUEUE_ENTRY *p;
 
@@ -1394,8 +1395,8 @@ css_add_request_to_socket_queue (CSS_CONN_ENTRY * conn_p, int info_p, char *name
 	{
 	  strcpy (p->name, name_p);
 #if !defined(WINDOWS)
-	  if (IS_MASTER_CONN_NAME_HA_SERVER (p->name) || IS_MASTER_CONN_NAME_HA_COPYLOG (p->name)
-	      || IS_MASTER_CONN_NAME_HA_APPLYLOG (p->name))
+	  if (IS_MASTER_CONN_NAME_HA_SERVER (p->name)
+	      || IS_MASTER_CONN_NAME_HA_COPYLOG (p->name) || IS_MASTER_CONN_NAME_HA_APPLYLOG (p->name))
 	    {
 	      p->ha_mode = TRUE;
 	    }

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -334,7 +334,6 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
   CSS_CONN_ENTRY *datagram_conn;
   SOCKET_QUEUE_ENTRY *entry;
   CSS_SERVER_PROC_REGISTER *proc_register = (CSS_SERVER_PROC_REGISTER *) buffer;
-  char server_name_str[DB_MAX_IDENTIFIER_LENGTH] = { 0 };
 
   datagram = NULL;
   datagram_length = 0;
@@ -360,7 +359,6 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 	  server_name_length = proc_register->server_name_length;
 
 	  assert (length <= DB_MAX_IDENTIFIER_LENGTH);
-	  strncpy (server_name_str, proc_register->server_name, length);
 
 	  if (length < server_name_length)
 	    {
@@ -394,7 +392,7 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 	  if (!entry->ha_mode)
 	    {
               /* *INDENT-OFF* */
-              master_Server_monitor->produce_job (server_monitor::job_type::REGISTER_SERVER, proc_register->pid, proc_register->exec_path, proc_register->args, server_name_str);
+              master_Server_monitor->produce_job (server_monitor::job_type::REGISTER_SERVER, proc_register->pid, proc_register->exec_path, proc_register->args, proc_register->server_name);
               /* *INDENT-ON* */
 	    }
 	}

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -1007,7 +1007,9 @@ css_check_master_socket_input (int *count, fd_set * fd_var)
                       /* *INDENT-OFF* */
                       master_Server_monitor->find_set_entry_to_revive (temp->conn_ptr);
                       /* *INDENT-ON* */
-		      css_remove_entry_by_conn (temp->conn_ptr, &css_Master_socket_anchor);
+
+		      //master_Server_monitor->remove_server_entry_by_conn (temp->conn_ptr);
+		      //css_remove_entry_by_conn (temp->conn_ptr, &css_Master_socket_anchor);
 		    }
 		}
 	      /* stop loop in case an error caused temp to be deleted */

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -394,7 +394,6 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 	  if (!entry->ha_mode)
 	    {
               /* *INDENT-OFF* */
-
               master_Server_monitor->produce_job (server_monitor::job_type::REGISTER_SERVER, proc_register->pid, proc_register->exec_path, proc_register->args, server_name_str);
               /* *INDENT-ON* */
 	    }

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -390,7 +390,7 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 	  if (!entry->ha_mode)
 	    {
               /* *INDENT-OFF* */
-              master_Server_monitor->make_and_insert_server_entry (proc_register->pid, proc_register->exec_path, proc_register->args, datagram_conn);
+              master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_REGISTER_ENTRY, proc_register->pid, proc_register->exec_path, proc_register->args, datagram_conn);
               /* *INDENT-ON* */
 	    }
 	}
@@ -1008,7 +1008,7 @@ css_check_master_socket_input (int *count, fd_set * fd_var)
 #if !defined(WINDOWS)
 		      /* Abnormal termination of non-HA server process is detected. */
                       /* *INDENT-OFF* */
-                      master_Server_monitor->find_set_entry_to_revive (temp->conn_ptr);
+                      master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_REVIVE_ENTRY, temp->pid, "", "", nullptr);
                       /* *INDENT-ON* */
 #endif
 		      css_remove_entry_by_conn (temp->conn_ptr, &css_Master_socket_anchor);

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -1008,14 +1008,10 @@ css_check_master_socket_input (int *count, fd_set * fd_var)
 #endif
 
 #if !defined(WINDOWS)
-		      /* Abnormal termination of non-HA server process is detected. */
-		      if (css_return_entry_of_server (temp->name, css_Master_socket_anchor) != NULL)
-			{
                         /* *INDENT-OFF* */
                         master_Server_monitor->produce_job (server_monitor::job_type::REVIVE_SERVER, -1, "", "", temp->name);
                         /* *INDENT-ON* */
 #endif
-			}
 		      css_remove_entry_by_conn (temp->conn_ptr, &css_Master_socket_anchor);
 		    }
 		}

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -82,12 +82,12 @@ static void css_reject_client_request (CSS_CONN_ENTRY * conn, unsigned short rid
 static void css_reject_server_request (CSS_CONN_ENTRY * conn, int reason);
 static void css_accept_server_request (CSS_CONN_ENTRY * conn, int reason);
 static void css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer);
-static void css_accept_old_request (CSS_CONN_ENTRY * conn, unsigned short rid,
-				    SOCKET_QUEUE_ENTRY * entry, char *server_name, int server_name_length);
+static void css_accept_old_request (CSS_CONN_ENTRY * conn, unsigned short rid, SOCKET_QUEUE_ENTRY * entry,
+				    char *server_name, int server_name_length);
 static void css_register_new_server (CSS_CONN_ENTRY * conn, unsigned short rid);
 static void css_register_new_server2 (CSS_CONN_ENTRY * conn, unsigned short rid);
-static bool css_send_new_request_to_server (SOCKET server_fd,
-					    SOCKET client_fd, unsigned short rid, CSS_SERVER_REQUEST request);
+static bool css_send_new_request_to_server (SOCKET server_fd, SOCKET client_fd, unsigned short rid,
+					    CSS_SERVER_REQUEST request);
 static void css_send_to_existing_server (CSS_CONN_ENTRY * conn, unsigned short rid, CSS_SERVER_REQUEST request);
 static void css_process_new_connection (SOCKET fd);
 static int css_enroll_read_sockets (SOCKET_QUEUE_ENTRY * anchor_p, fd_set * fd_var);
@@ -169,8 +169,8 @@ css_master_timeout (void)
   struct timeval timeout;
 
   /* check for timeout */
-  if (css_Master_timeout
-      && time ((time_t *) (&timeout.tv_sec)) != (time_t) (-1) && css_Master_timeout->tv_sec < timeout.tv_sec)
+  if (css_Master_timeout && time ((time_t *) (&timeout.tv_sec)) != (time_t) (-1)
+      && css_Master_timeout->tv_sec < timeout.tv_sec)
     {
       return (0);
     }
@@ -349,9 +349,8 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 #if defined(DEBUG)
 	  css_Active_server_count++;
 #endif
-	  css_add_request_to_socket_queue (datagram_conn, false,
-					   proc_register->server_name,
-					   server_fd, READ_WRITE, 0, &css_Master_socket_anchor);
+	  css_add_request_to_socket_queue (datagram_conn, false, proc_register->server_name, server_fd, READ_WRITE, 0,
+					   &css_Master_socket_anchor);
 
 	  //  Note : server_name is usually packed(appended) information of server_name, version_string, env_var, pid,
 	  //  packed from css_pack_server_name(). Since there are some cases that returns server_name and server_name_length
@@ -391,6 +390,7 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 	  if (!entry->ha_mode)
 	    {
               /* *INDENT-OFF* */
+
               master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_REGISTER_ENTRY, proc_register->pid, proc_register->exec_path, proc_register->args);
               /* *INDENT-ON* */
 	    }
@@ -412,8 +412,8 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
  *   server_name_length(in)
  */
 static void
-css_accept_old_request (CSS_CONN_ENTRY * conn, unsigned short rid,
-			SOCKET_QUEUE_ENTRY * entry, char *server_name, int server_name_length)
+css_accept_old_request (CSS_CONN_ENTRY * conn, unsigned short rid, SOCKET_QUEUE_ENTRY * entry, char *server_name,
+			int server_name_length)
 {
   char *datagram;
   int datagram_length;
@@ -564,8 +564,8 @@ css_register_new_server2 (CSS_CONN_ENTRY * conn, unsigned short rid)
 	      css_Active_server_count++;
 #endif
 	      entry =
-		css_add_request_to_socket_queue (conn, false, server_name,
-						 conn->fd, READ_WRITE, 0, &css_Master_socket_anchor);
+		css_add_request_to_socket_queue (conn, false, server_name, conn->fd, READ_WRITE, 0,
+						 &css_Master_socket_anchor);
 	      /* store this for later */
 	      if (entry != NULL)
 		{
@@ -1061,8 +1061,8 @@ again:
 #if !defined(WINDOWS)
 					     (fcntl (temp->fd, F_GETFL, 0) < 0) ||
 #endif /* !WINDOWS */
-					     (temp->error_p != 0)
-					     || (temp->conn_ptr == NULL) || (temp->conn_ptr->status == CONN_CLOSED))))
+					     (temp->error_p != 0) || (temp->conn_ptr == NULL)
+					     || (temp->conn_ptr->status == CONN_CLOSED))))
 	{
 #if defined(DEBUG)
 	  if (css_Active_server_count > 0)
@@ -1268,11 +1268,11 @@ main (int argc, char **argv)
 #endif
 
   conn = css_make_conn (css_Master_socket_fd[0]);
-  css_add_request_to_socket_queue (conn, false, NULL, css_Master_socket_fd[0],
-				   READ_WRITE, 0, &css_Master_socket_anchor);
+  css_add_request_to_socket_queue (conn, false, NULL, css_Master_socket_fd[0], READ_WRITE, 0,
+				   &css_Master_socket_anchor);
   conn = css_make_conn (css_Master_socket_fd[1]);
-  css_add_request_to_socket_queue (conn, false, NULL, css_Master_socket_fd[1],
-				   READ_WRITE, 0, &css_Master_socket_anchor);
+  css_add_request_to_socket_queue (conn, false, NULL, css_Master_socket_fd[1], READ_WRITE, 0,
+				   &css_Master_socket_anchor);
   css_master_loop ();
   css_master_cleanup (SIGINT);
   css_master_error (msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_MASTER, MASTER_MSG_EXITING));
@@ -1373,8 +1373,8 @@ css_remove_entry_by_conn (CSS_CONN_ENTRY * conn_p, SOCKET_QUEUE_ENTRY ** anchor_
  *   anchor_p(out):
  */
 SOCKET_QUEUE_ENTRY *
-css_add_request_to_socket_queue (CSS_CONN_ENTRY * conn_p, int info_p,
-				 char *name_p, SOCKET fd, int fd_type, int pid, SOCKET_QUEUE_ENTRY ** anchor_p)
+css_add_request_to_socket_queue (CSS_CONN_ENTRY * conn_p, int info_p, char *name_p, SOCKET fd, int fd_type, int pid,
+				 SOCKET_QUEUE_ENTRY ** anchor_p)
 {
   SOCKET_QUEUE_ENTRY *p;
 
@@ -1395,8 +1395,8 @@ css_add_request_to_socket_queue (CSS_CONN_ENTRY * conn_p, int info_p,
 	{
 	  strcpy (p->name, name_p);
 #if !defined(WINDOWS)
-	  if (IS_MASTER_CONN_NAME_HA_SERVER (p->name)
-	      || IS_MASTER_CONN_NAME_HA_COPYLOG (p->name) || IS_MASTER_CONN_NAME_HA_APPLYLOG (p->name))
+	  if (IS_MASTER_CONN_NAME_HA_SERVER (p->name) || IS_MASTER_CONN_NAME_HA_COPYLOG (p->name)
+	      || IS_MASTER_CONN_NAME_HA_APPLYLOG (p->name))
 	    {
 	      p->ha_mode = TRUE;
 	    }

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -82,12 +82,12 @@ static void css_reject_client_request (CSS_CONN_ENTRY * conn, unsigned short rid
 static void css_reject_server_request (CSS_CONN_ENTRY * conn, int reason);
 static void css_accept_server_request (CSS_CONN_ENTRY * conn, int reason);
 static void css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer);
-static void css_accept_old_request (CSS_CONN_ENTRY * conn, unsigned short rid,
-				    SOCKET_QUEUE_ENTRY * entry, char *server_name, int server_name_length);
+static void css_accept_old_request (CSS_CONN_ENTRY * conn, unsigned short rid, SOCKET_QUEUE_ENTRY * entry,
+				    char *server_name, int server_name_length);
 static void css_register_new_server (CSS_CONN_ENTRY * conn, unsigned short rid);
 static void css_register_new_server2 (CSS_CONN_ENTRY * conn, unsigned short rid);
-static bool css_send_new_request_to_server (SOCKET server_fd,
-					    SOCKET client_fd, unsigned short rid, CSS_SERVER_REQUEST request);
+static bool css_send_new_request_to_server (SOCKET server_fd, SOCKET client_fd, unsigned short rid,
+					    CSS_SERVER_REQUEST request);
 static void css_send_to_existing_server (CSS_CONN_ENTRY * conn, unsigned short rid, CSS_SERVER_REQUEST request);
 static void css_process_new_connection (SOCKET fd);
 static int css_enroll_read_sockets (SOCKET_QUEUE_ENTRY * anchor_p, fd_set * fd_var);
@@ -169,8 +169,8 @@ css_master_timeout (void)
   struct timeval timeout;
 
   /* check for timeout */
-  if (css_Master_timeout
-      && time ((time_t *) (&timeout.tv_sec)) != (time_t) (-1) && css_Master_timeout->tv_sec < timeout.tv_sec)
+  if (css_Master_timeout && time ((time_t *) (&timeout.tv_sec)) != (time_t) (-1)
+      && css_Master_timeout->tv_sec < timeout.tv_sec)
     {
       return (0);
     }
@@ -349,9 +349,8 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 #if defined(DEBUG)
 	  css_Active_server_count++;
 #endif
-	  css_add_request_to_socket_queue (datagram_conn, false,
-					   proc_register->server_name,
-					   server_fd, READ_WRITE, 0, &css_Master_socket_anchor);
+	  css_add_request_to_socket_queue (datagram_conn, false, proc_register->server_name, server_fd, READ_WRITE, 0,
+					   &css_Master_socket_anchor);
 
 	  //  Note : server_name is usually packed(appended) information of server_name, version_string, env_var, pid,
 	  //  packed from css_pack_server_name(). Since there are some cases that returns server_name and server_name_length
@@ -412,8 +411,8 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
  *   server_name_length(in)
  */
 static void
-css_accept_old_request (CSS_CONN_ENTRY * conn, unsigned short rid,
-			SOCKET_QUEUE_ENTRY * entry, char *server_name, int server_name_length)
+css_accept_old_request (CSS_CONN_ENTRY * conn, unsigned short rid, SOCKET_QUEUE_ENTRY * entry, char *server_name,
+			int server_name_length)
 {
   char *datagram;
   int datagram_length;
@@ -564,8 +563,8 @@ css_register_new_server2 (CSS_CONN_ENTRY * conn, unsigned short rid)
 	      css_Active_server_count++;
 #endif
 	      entry =
-		css_add_request_to_socket_queue (conn, false, server_name,
-						 conn->fd, READ_WRITE, 0, &css_Master_socket_anchor);
+		css_add_request_to_socket_queue (conn, false, server_name, conn->fd, READ_WRITE, 0,
+						 &css_Master_socket_anchor);
 	      /* store this for later */
 	      if (entry != NULL)
 		{
@@ -1008,9 +1007,9 @@ css_check_master_socket_input (int *count, fd_set * fd_var)
 
 #if !defined(WINDOWS)
 		      /* Abnormal termination of non-HA server process is detected. */
-                      /* *INDENT-OFF* */
-                      master_Server_monitor->find_set_entry_to_revive (temp->conn_ptr);
-                      /* *INDENT-ON* */
+                       /* *INDENT-OFF* */
+                       master_Server_monitor->find_set_entry_to_revive (temp->conn_ptr);
+                       /* *INDENT-ON* */
 #endif
 		      css_remove_entry_by_conn (temp->conn_ptr, &css_Master_socket_anchor);
 		    }
@@ -1061,8 +1060,8 @@ again:
 #if !defined(WINDOWS)
 					     (fcntl (temp->fd, F_GETFL, 0) < 0) ||
 #endif /* !WINDOWS */
-					     (temp->error_p != 0)
-					     || (temp->conn_ptr == NULL) || (temp->conn_ptr->status == CONN_CLOSED))))
+					     (temp->error_p != 0) || (temp->conn_ptr == NULL)
+					     || (temp->conn_ptr->status == CONN_CLOSED))))
 	{
 #if defined(DEBUG)
 	  if (css_Active_server_count > 0)
@@ -1268,11 +1267,11 @@ main (int argc, char **argv)
 #endif
 
   conn = css_make_conn (css_Master_socket_fd[0]);
-  css_add_request_to_socket_queue (conn, false, NULL, css_Master_socket_fd[0],
-				   READ_WRITE, 0, &css_Master_socket_anchor);
+  css_add_request_to_socket_queue (conn, false, NULL, css_Master_socket_fd[0], READ_WRITE, 0,
+				   &css_Master_socket_anchor);
   conn = css_make_conn (css_Master_socket_fd[1]);
-  css_add_request_to_socket_queue (conn, false, NULL, css_Master_socket_fd[1],
-				   READ_WRITE, 0, &css_Master_socket_anchor);
+  css_add_request_to_socket_queue (conn, false, NULL, css_Master_socket_fd[1], READ_WRITE, 0,
+				   &css_Master_socket_anchor);
   css_master_loop ();
   css_master_cleanup (SIGINT);
   css_master_error (msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_MASTER, MASTER_MSG_EXITING));
@@ -1373,8 +1372,8 @@ css_remove_entry_by_conn (CSS_CONN_ENTRY * conn_p, SOCKET_QUEUE_ENTRY ** anchor_
  *   anchor_p(out):
  */
 SOCKET_QUEUE_ENTRY *
-css_add_request_to_socket_queue (CSS_CONN_ENTRY * conn_p, int info_p,
-				 char *name_p, SOCKET fd, int fd_type, int pid, SOCKET_QUEUE_ENTRY ** anchor_p)
+css_add_request_to_socket_queue (CSS_CONN_ENTRY * conn_p, int info_p, char *name_p, SOCKET fd, int fd_type, int pid,
+				 SOCKET_QUEUE_ENTRY ** anchor_p)
 {
   SOCKET_QUEUE_ENTRY *p;
 
@@ -1395,8 +1394,8 @@ css_add_request_to_socket_queue (CSS_CONN_ENTRY * conn_p, int info_p,
 	{
 	  strcpy (p->name, name_p);
 #if !defined(WINDOWS)
-	  if (IS_MASTER_CONN_NAME_HA_SERVER (p->name)
-	      || IS_MASTER_CONN_NAME_HA_COPYLOG (p->name) || IS_MASTER_CONN_NAME_HA_APPLYLOG (p->name))
+	  if (IS_MASTER_CONN_NAME_HA_SERVER (p->name) || IS_MASTER_CONN_NAME_HA_COPYLOG (p->name)
+	      || IS_MASTER_CONN_NAME_HA_APPLYLOG (p->name))
 	    {
 	      p->ha_mode = TRUE;
 	    }

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -358,6 +358,7 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 	  length = (int) strlen (proc_register->server_name) + 1;
 	  server_name_length = proc_register->server_name_length;
 
+	  assert (length <= DB_MAX_IDENTIFIER_LENGTH);
 	  char server_name_str[DB_MAX_IDENTIFIER_LENGTH] = { 0 };
 	  strncpy (server_name_str, proc_register->server_name, length);
 

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -1006,7 +1006,6 @@ css_check_master_socket_input (int *count, fd_set * fd_var)
 			}
 #endif
                       /* *INDENT-OFF* */
-                      fprintf(stdout, "css_check_master_socket_input: removing server entry by conn\n");
                       master_Server_monitor->find_set_entry_to_revive (temp->conn_ptr);
                       /* *INDENT-ON* */
 		      css_remove_entry_by_conn (temp->conn_ptr, &css_Master_socket_anchor);

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -358,11 +358,9 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 	  length = (int) strlen (proc_register->server_name) + 1;
 	  server_name_length = proc_register->server_name_length;
 
-	  char *server_name_str = (char *) malloc (length);
-	  if (server_name_str != NULL)
-	    {
-	      strcpy (server_name_str, proc_register->server_name);
-	    }
+	  char server_name_str[256];
+	  memset (server_name_str, 0, sizeof (server_name_str));
+	  strncpy (server_name_str, proc_register->server_name, length);
 
 	  if (length < server_name_length)
 	    {
@@ -399,10 +397,6 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 
               master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_REGISTER_ENTRY, proc_register->pid, proc_register->exec_path, proc_register->args, server_name_str);
               /* *INDENT-ON* */
-	    }
-	  if (server_name_str != NULL)
-	    {
-	      free_and_init (server_name_str);
 	    }
 	}
     }

--- a/src/executables/master_request.c
+++ b/src/executables/master_request.c
@@ -533,7 +533,7 @@ css_process_kill_slave (CSS_CONN_ENTRY * conn, unsigned short request_id, char *
 			    server_name, timeout);
 #if !defined(WINDOWS)
                   /* *INDENT-OFF* */
-		  master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_REMOVE_ENTRY, temp->pid, "", "", nullptr);
+		  master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_REMOVE_ENTRY, temp->pid, "", "");
                   /* *INDENT-ON* */
 #endif
 		  css_process_start_shutdown (temp, timeout * 60, buffer);
@@ -725,7 +725,7 @@ css_process_shutdown (char *time_buffer)
 	{
 #if !defined(WINDOWS)
           /* *INDENT-OFF* */
-	  master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_REMOVE_ENTRY, temp->pid, "", "", nullptr);
+	  master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_REMOVE_ENTRY, temp->pid, "", "");
           /* *INDENT-ON* */
 #endif
 	  css_process_start_shutdown (temp, timeout * 60, buffer);

--- a/src/executables/master_request.c
+++ b/src/executables/master_request.c
@@ -533,7 +533,7 @@ css_process_kill_slave (CSS_CONN_ENTRY * conn, unsigned short request_id, char *
 			    server_name, timeout);
 #if !defined(WINDOWS)
                   /* *INDENT-OFF* */
-		  master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_REMOVE_ENTRY, -1, "", "", server_name);
+		  master_Server_monitor->produce_job (server_monitor::job_type::REMOVE_ENTRY, -1, "", "", server_name);
                   /* *INDENT-ON* */
 #endif
 		  css_process_start_shutdown (temp, timeout * 60, buffer);
@@ -725,7 +725,7 @@ css_process_shutdown (char *time_buffer)
 	{
 #if !defined(WINDOWS)
           /* *INDENT-OFF* */
-	  master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_REMOVE_ENTRY, -1, "", "", temp->name);
+	  master_Server_monitor->produce_job (server_monitor::job_type::REMOVE_ENTRY, -1, "", "", temp->name);
           /* *INDENT-ON* */
 #endif
 	  css_process_start_shutdown (temp, timeout * 60, buffer);

--- a/src/executables/master_request.c
+++ b/src/executables/master_request.c
@@ -532,7 +532,9 @@ css_process_kill_slave (CSS_CONN_ENTRY * conn, unsigned short request_id, char *
 			    msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_MASTER, MASTER_MSG_SERVER_STATUS),
 			    server_name, timeout);
 #if !defined(WINDOWS)
-		  master_Server_monitor->remove_server_entry_by_conn (temp->conn_ptr);
+                  /* *INDENT-OFF* */
+		  master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_REMOVE_ENTRY, temp->pid, "", "", nullptr);
+                  /* *INDENT-ON* */
 #endif
 		  css_process_start_shutdown (temp, timeout * 60, buffer);
 		}
@@ -722,7 +724,9 @@ css_process_shutdown (char *time_buffer)
 	  && !IS_MASTER_CONN_NAME_HA_COPYLOG (temp->name) && !IS_MASTER_CONN_NAME_HA_APPLYLOG (temp->name))
 	{
 #if !defined(WINDOWS)
-	  master_Server_monitor->remove_server_entry_by_conn (temp->conn_ptr);
+          /* *INDENT-OFF* */
+	  master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_REMOVE_ENTRY, temp->pid, "", "", nullptr);
+          /* *INDENT-ON* */
 #endif
 	  css_process_start_shutdown (temp, timeout * 60, buffer);
 

--- a/src/executables/master_request.c
+++ b/src/executables/master_request.c
@@ -533,7 +533,7 @@ css_process_kill_slave (CSS_CONN_ENTRY * conn, unsigned short request_id, char *
 			    server_name, timeout);
 #if !defined(WINDOWS)
                   /* *INDENT-OFF* */
-		  master_Server_monitor->produce_job (server_monitor::job_type::REMOVE_ENTRY, -1, "", "", server_name);
+		  master_Server_monitor->produce_job (server_monitor::job_type::UNREGISTER_SERVER, -1, "", "", server_name);
                   /* *INDENT-ON* */
 #endif
 		  css_process_start_shutdown (temp, timeout * 60, buffer);
@@ -725,7 +725,7 @@ css_process_shutdown (char *time_buffer)
 	{
 #if !defined(WINDOWS)
           /* *INDENT-OFF* */
-	  master_Server_monitor->produce_job (server_monitor::job_type::REMOVE_ENTRY, -1, "", "", temp->name);
+	  master_Server_monitor->produce_job (server_monitor::job_type::UNREGISTER_SERVER, -1, "", "", temp->name);
           /* *INDENT-ON* */
 #endif
 	  css_process_start_shutdown (temp, timeout * 60, buffer);

--- a/src/executables/master_request.c
+++ b/src/executables/master_request.c
@@ -533,7 +533,7 @@ css_process_kill_slave (CSS_CONN_ENTRY * conn, unsigned short request_id, char *
 			    server_name, timeout);
 #if !defined(WINDOWS)
                   /* *INDENT-OFF* */
-		  master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_REMOVE_ENTRY, temp->pid, "", "");
+		  master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_REMOVE_ENTRY, -1, "", "", server_name);
                   /* *INDENT-ON* */
 #endif
 		  css_process_start_shutdown (temp, timeout * 60, buffer);
@@ -725,7 +725,7 @@ css_process_shutdown (char *time_buffer)
 	{
 #if !defined(WINDOWS)
           /* *INDENT-OFF* */
-	  master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_REMOVE_ENTRY, temp->pid, "", "");
+	  master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_REMOVE_ENTRY, -1, "", "", temp->name);
           /* *INDENT-ON* */
 #endif
 	  css_process_start_shutdown (temp, timeout * 60, buffer);

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -27,8 +27,6 @@
 
 #include "master_server_monitor.hpp"
 
-#include "system_parameter.h"
-
 std::unique_ptr<server_monitor> master_Server_monitor = nullptr;
 
 

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -275,22 +275,13 @@ server_monitor::consume_job ()
     {
       return !m_job_queue.empty () || m_thread_shutdown;
     });
-
-    if (m_thread_shutdown)
-      {
-	while (!m_job_queue.empty ())
-	  {
-	    m_job_queue.pop ();
-	  }
-	return;
-      }
   }
 
   while (true)
     {
       {
 	std::unique_lock<std::mutex> lock (m_server_monitor_mutex);
-	if (m_job_queue.empty ())
+	if (m_thread_shutdown || m_job_queue.empty ())
 	  {
 	    break;
 	  }

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -112,7 +112,6 @@ void
 server_monitor::make_and_insert_server_entry (int pid, const char *exec_path, char *args,
     CSS_CONN_ENTRY *conn)
 {
-  //std::lock_guard<std::mutex> lock(m_server_entry_list_lock);
   m_server_entry_list->emplace_back (pid, exec_path, args, conn);
   fprintf (stdout,
 	   "[SERVER_REVIVE_DEBUG] : server has been registered into master_Server_monitor : pid : %d, exec_path : %s, args : %s\n",
@@ -154,7 +153,6 @@ server_monitor::remove_server_entry_by_pid (int pid)
 void
 server_monitor::find_set_entry_to_revive (CSS_CONN_ENTRY *conn)
 {
-  std::lock_guard<std::mutex> lock (m_server_entry_list_lock);
   for (auto &entry : *m_server_entry_list)
     {
       std::unique_lock<std::mutex> lock (entry.m_server_entry_lock);

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -147,7 +147,6 @@ server_monitor::find_set_entry_to_revive (CSS_CONN_ENTRY *conn)
       if (entry.get_conn() == conn)
 	{
 	  entry.set_need_revive (true);
-	  fprintf (stdout, "[SERVER_REVIVE_DEBUG] : set_need_revive\n");
 	  return;
 	}
     }

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -214,8 +214,8 @@ server_monitor::check_server_revived (const std::string &server_name)
       else
 	{
 	  fprintf (stdout, "[SERVER_REVIVE_DEBUG] : Server revive failed. pid : %d\n", entry->second.get_pid());
-	  m_server_entry_map.erase (entry);
 	  kill (entry->second.get_pid (), SIGKILL);
+	  m_server_entry_map.erase (entry);
 	}
     }
   else if (entry->second.get_need_revive ())

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -34,8 +34,9 @@ server_monitor::server_monitor ()
   constexpr int SERVER_MONITOR_JOB_QUEUE_SIZE = 1024;
   m_job_queue = new lockfree::circular_queue<server_monitor_job> (SERVER_MONITOR_JOB_QUEUE_SIZE);
   fprintf (stdout, "[SERVER_REVIVE_DEBUG] : job_queue is created. \n");
-  m_server_entry_list = std::make_unique<std::list<server_entry>> ();
-  fprintf (stdout, "[SERVER_REVIVE_DEBUG] : server_entry_list is created. \n");
+
+  m_server_entry_map = std::make_unique<std::unordered_map<std::string, server_entry>> ();
+  fprintf (stdout, "[SERVER_REVIVE_DEBUG] : server_entry_map is created. \n");
 
   start_monitoring_thread ();
   m_monitoring_thread = std::make_unique<std::thread> (&server_monitor::server_monitor_thread_worker, this);
@@ -57,13 +58,13 @@ server_monitor::~server_monitor ()
   stop_monitoring_thread ();
   if (m_monitoring_thread->joinable())
     {
-      m_monitor_cv.notify_all();
+      m_monitor_cv_empty.notify_all();
       m_monitoring_thread->join();
       fprintf (stdout, "[SERVER_REVIVE_DEBUG] : server_monitor_thread is terminated. \n");
     }
 
-  assert (m_server_entry_list->size () == 0);
-  fprintf (stdout, "[SERVER_REVIVE_DEBUG] : server_entry_list is deleted. \n");
+  assert (m_server_entry_map->size () == 0);
+  fprintf (stdout, "[SERVER_REVIVE_DEBUG] : server_entry_map is deleted. \n");
 
   fflush (stdout);
 }
@@ -85,10 +86,10 @@ server_monitor::server_monitor_thread_worker ()
 {
   while (!m_thread_shutdown)
     {
-      std::unique_lock<std::mutex> lock (m_monitor_mutex);
+      std::unique_lock<std::mutex> lock (m_monitor_mutex_empty);
 
       constexpr int period_in_secs = 1;
-      while (!m_monitor_cv.wait_for (lock, std::chrono::seconds (period_in_secs), [this] ()
+      while (!m_monitor_cv_empty.wait_for (lock, std::chrono::seconds (period_in_secs), [this] ()
       {
 	return !m_job_queue->is_empty () || m_thread_shutdown;
 	}));
@@ -97,7 +98,11 @@ server_monitor::server_monitor_thread_worker ()
 	{
 	  server_monitor_job consume_job;
 	  m_job_queue->consume (consume_job);
-
+	  m_monitor_cv_full.notify_all();
+	  fprintf (stdout,
+		   "[SERVER_REVIVE_DEBUG] : job_queue consume : job_type : %d, pid : %d, exec_path : %s, args : %s, server_name : %s\n",
+		   consume_job.m_job_type, consume_job.m_pid, consume_job.m_exec_path.c_str(), consume_job.m_args.c_str(),
+		   consume_job.m_server_name.c_str());
 	  switch (consume_job.m_job_type)
 	    {
 	    case SERVER_MONITOR_NO_JOB:
@@ -127,25 +132,23 @@ server_monitor::make_and_insert_server_entry (int pid, std::string exec_path, st
     std::chrono::steady_clock::time_point revive_time)
 {
   bool success = false;
-  for (auto &entry : *m_server_entry_list)
+  auto entry = m_server_entry_map->find (server_name);
+  if (entry != m_server_entry_map->end ())
     {
-      if (entry.get_server_name() == server_name)
-	{
-	  entry.set_pid (pid);
-	  entry.set_exec_path (exec_path);
-	  entry.proc_make_arg (args);
-	  entry.set_need_revive (false);
-	  success = true;
-	  fprintf (stdout,
-		   "[SERVER_REVIVE_DEBUG] : server entry has been updated in master_Server_monitor : pid : %d, exec_path : %s, args : %s\n",
-		   pid,
-		   exec_path.c_str(), args.c_str());
-	  break;
-	}
+      entry->second.set_pid (pid);
+      entry->second.set_exec_path (exec_path);
+      entry->second.proc_make_arg (args);
+      entry->second.set_need_revive (false);
+      success = true;
+      fprintf (stdout,
+	       "[SERVER_REVIVE_DEBUG] : server entry has been updated in master_Server_monitor : pid : %d, exec_path : %s, args : %s\n",
+	       pid,
+	       exec_path.c_str(), args.c_str());
     }
   if (!success)
     {
-      m_server_entry_list->emplace_back (pid, exec_path, args, server_name, revive_time);
+      m_server_entry_map->emplace (std::move (server_name), server_entry (pid, exec_path, args, revive_time));
+
       fprintf (stdout,
 	       "[SERVER_REVIVE_DEBUG] : server entry has been registered into master_Server_monitor : pid : %d, exec_path : %s, args : %s\n",
 	       pid,
@@ -156,16 +159,14 @@ server_monitor::make_and_insert_server_entry (int pid, std::string exec_path, st
 void
 server_monitor::remove_server_entry_by_name (std::string server_name)
 {
-  const auto result = std::remove_if (m_server_entry_list->begin(), m_server_entry_list->end(),
-				      [server_name] (auto& e) -> bool
-  {
-    return e.get_server_name() == server_name;
-  });
-  assert (result != m_server_entry_list->end ());
-  m_server_entry_list->erase (result, m_server_entry_list->end());
+
+  auto entry = m_server_entry_map->find (server_name);
+  assert (entry != m_server_entry_map->end ());
+  m_server_entry_map->erase (entry);
   fprintf (stdout,
-	   "[SERVER_REVIVE_DEBUG] : server has been removed from master_Server_monitor. Number of server in master_Server_monitor: %d\n",
-	   m_server_entry_list->size ());
+	   "[SERVER_REVIVE_DEBUG] : server entry has been removed from master_Server_monitor. Number of server in master_Server_monitor: %d\n",
+	   m_server_entry_map->size ());
+
 }
 
 void
@@ -176,30 +177,30 @@ server_monitor::revive_server_with_name (std::string server_name)
 	      PRM_ID_HA_UNACCEPTABLE_PROC_RESTART_TIMEDIFF_IN_MSECS);
   std::chrono::steady_clock::time_point tv;
   int out_pid = 0;
-  for (auto it = m_server_entry_list->begin(); it != m_server_entry_list->end(); it++)
+
+  auto entry = m_server_entry_map->find (server_name);
+  if (entry != m_server_entry_map->end ())
     {
-      if (it->get_server_name () == server_name)
+      entry->second.set_need_revive (true);
+      tv = std::chrono::steady_clock::now ();
+      auto timediff = std::chrono::duration_cast<std::chrono::milliseconds> (tv -
+		      entry->second.get_last_revive_time()).count();
+      if (timediff > SERVER_MONITOR_UNACCEPTABLE_REVIVE_TIMEDIFF_IN_MSECS)
 	{
-	  it->set_need_revive (true);
-	  tv = std::chrono::steady_clock::now ();
-	  auto timediff = std::chrono::duration_cast<std::chrono::milliseconds> (tv - it->get_last_revive_time()).count();
-	  if (timediff > SERVER_MONITOR_UNACCEPTABLE_REVIVE_TIMEDIFF_IN_MSECS)
-	    {
-	      it->set_last_revive_time (std::chrono::steady_clock::now ());
-	      server_monitor_try_revive_server (it->get_exec_path(), it->get_argv(), &out_pid);
-	      assert (out_pid > 0);
-	      it->set_pid (out_pid);
-	      master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_CONFIRM_REVIVE_ENTRY, -1, "", "",
-		  it->get_server_name ());
-	      return;
-	    }
-	  else
-	    {
-	      fprintf (stdout, "[SERVER_REVIVE_DEBUG] : Process failure repeated within a short period of time. pid : %d\n",
-		       it->get_pid());
-	      it = m_server_entry_list->erase (it);
-	      return;
-	    }
+	  entry->second.set_last_revive_time (std::chrono::steady_clock::now ());
+	  server_monitor_try_revive_server (entry->second.get_exec_path(), entry->second.get_argv(), &out_pid);
+	  assert (out_pid > 0);
+	  entry->second.set_pid (out_pid);
+	  master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_CONFIRM_REVIVE_ENTRY, -1, "", "",
+	      entry->first);
+	  return;
+	}
+      else
+	{
+	  fprintf (stdout, "[SERVER_REVIVE_DEBUG] : Process failure repeated within a short period of time. pid : %d\n",
+		   entry->second.get_pid());
+	  m_server_entry_map->erase (entry);
+	  return;
 	}
     }
 }
@@ -208,25 +209,23 @@ void
 server_monitor::server_monitor_check_server_revived (std::string server_name)
 {
   int error_code;
-  for (auto it = m_server_entry_list->begin(); it != m_server_entry_list->end(); it++)
+  auto entry = m_server_entry_map->find (server_name);
+  if (entry != m_server_entry_map->end ())
     {
-      if (it->get_server_name () == server_name)
+      error_code = kill (entry->second.get_pid (), 0);
+      if (error_code == ESRCH)
 	{
-	  error_code = kill (it->get_pid (), 0);
-	  if (error_code == ESRCH)
-	    {
-	      master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_REVIVE_ENTRY, -1, "", "", it->get_server_name ());
-	    }
-	  else if (it->get_need_revive ())
-	    {
-	      std::this_thread::sleep_for (std::chrono::milliseconds (1000));
-	      master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_CONFIRM_REVIVE_ENTRY, -1, "", "",
-		  it->get_server_name ());
-	    }
-	  else
-	    {
-	      fprintf (stdout, "[SERVER_REVIVE_DEBUG] : Server revive success. pid : %d\n", it->get_pid ());
-	    }
+	  master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_REVIVE_ENTRY, -1, "", "", entry->first);
+	}
+      else if (entry->second.get_need_revive ())
+	{
+	  std::this_thread::sleep_for (std::chrono::milliseconds (1000));
+	  master_Server_monitor->server_monitor_produce_job (SERVER_MONITOR_CONFIRM_REVIVE_ENTRY, -1, "", "",
+	      entry->first);
+	}
+      else
+	{
+	  fprintf (stdout, "[SERVER_REVIVE_DEBUG] : Server revive success. pid : %d\n", entry->second.get_pid());
 	}
       return;
     }
@@ -238,8 +237,15 @@ server_monitor::server_monitor_produce_job (server_monitor_job_type job_type, in
     std::string args, std::string server_name)
 {
   server_monitor::server_monitor_job job (job_type, pid, exec_path, args, server_name);
+  std::unique_lock<std::mutex> lock (m_monitor_mutex_full);
+
+  constexpr int period_in_secs = 1;
+  while (!m_monitor_cv_full.wait_for (lock, std::chrono::seconds (period_in_secs), [this] ()
+  {
+    return !m_job_queue->is_full ();
+    }));
   m_job_queue->produce (job);
-  m_monitor_cv.notify_all();
+  m_monitor_cv_full.notify_all();
 }
 
 void
@@ -287,11 +293,10 @@ server_monitor_job (server_monitor_job_type job_type, int pid, std::string exec_
 }
 
 server_monitor::server_entry::
-server_entry (int pid, std::string exec_path, std::string args, std::string server_name,
+server_entry (int pid, std::string exec_path, std::string args,
 	      std::chrono::steady_clock::time_point revive_time)
   : m_pid {pid}
   , m_exec_path {exec_path}
-  , m_server_name {server_name}
   , m_need_revive {false}
   , m_last_revive_time {revive_time}
 {
@@ -317,12 +322,6 @@ std::vector<std::string>
 server_monitor::server_entry::get_argv () const
 {
   return m_argv;
-}
-
-std::string
-server_monitor::server_entry::get_server_name () const
-{
-  return m_server_name;
 }
 
 bool

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -78,7 +78,6 @@ server_monitor::stop_monitoring_thread ()
 
   m_monitoring_thread->join();
   fprintf (stdout, "[SERVER_REVIVE_DEBUG] : server_monitor_thread is terminated. \n");
-
 }
 
 void
@@ -136,7 +135,6 @@ server_monitor::remove_server_entry (const std::string &server_name)
   fprintf (stdout,
 	   "[SERVER_REVIVE_DEBUG] : server entry has been removed from master_Server_monitor. Number of server in master_Server_monitor: %d\n",
 	   m_server_entry_map.size ());
-
 }
 
 void
@@ -152,12 +150,13 @@ server_monitor::revive_server (const std::string &server_name)
   if (entry != m_server_entry_map.end ())
     {
       entry->second.set_need_revive (true);
+
       tv = std::chrono::steady_clock::now ();
       auto timediff = std::chrono::duration_cast<std::chrono::seconds> (tv -
 		      entry->second.get_last_revive_time()).count();
+
       if (timediff > SERVER_MONITOR_UNACCEPTABLE_REVIVE_TIMEDIFF_IN_SECS)
 	{
-
 	  out_pid = try_revive_server (entry->second.get_exec_path(), entry->second.get_argv());
 	  if (out_pid == -1)
 	    {
@@ -311,8 +310,6 @@ server_monitor::consume_job ()
 	  break;
 	}
     }
-
-
 }
 
 server_monitor::job::

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -22,7 +22,6 @@
 
 #include <sstream>
 #include <algorithm>
-#include <sys/time.h>
 #include <unistd.h>
 #include <signal.h>
 #include <system_parameter.h>

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -270,7 +270,7 @@ server_monitor::produce_job_internal (job_type job_type, int pid, const std::str
 				      const std::string &args, const std::string &server_name)
 {
   std::lock_guard<std::mutex> lock (m_server_monitor_mutex);
-  m_job_queue.emplace (job (job_type, pid, exec_path, args, server_name));
+  m_job_queue.emplace (job_type, pid, exec_path, args, server_name);
 }
 
 void

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -61,16 +61,12 @@ server_monitor::server_monitor ()
 	      {
 		if (it->get_need_revive ())
 		  {
-		    //it->set_need_revive (false);
-
 		    tv = std::chrono::steady_clock::now ();
 		    auto timediff = std::chrono::duration_cast<std::chrono::milliseconds> (tv - it->get_last_revive_time()).count();
 		    if (timediff > SERVER_MONITOR_UNACCEPTABLE_REVIVE_TIMEDIFF_IN_MSECS)
 		      {
 			while (++ (it->m_revive_count) < SERVER_MONITOR_REVIVE_CONFIRM_MAX_RETRIES)
 			  {
-			    //it->set_need_revive (true);
-
 			    server_monitor_try_revive_server (it->get_exec_path(), it->get_argv(), &pid);
 			    assert (pid > 0);
 			    error_code = kill (pid, 0);

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -110,9 +110,6 @@ server_monitor::server_monitor_thread_worker ()
 		   consume_job.m_server_name.c_str());
 	  switch (consume_job.m_job_type)
 	    {
-	    case job_type::NO_JOB:
-	      assert (false);
-	      break;
 	    case job_type::REGISTER_ENTRY:
 	      make_and_insert_server_entry (consume_job.m_pid, consume_job.m_exec_path, consume_job.m_args, consume_job.m_server_name,
 					    consume_job.m_produce_time);
@@ -126,6 +123,7 @@ server_monitor::server_monitor_thread_worker ()
 	    case job_type::CONFIRM_REVIVE_ENTRY:
 	      check_server_revived (consume_job.m_server_name);
 	      break;
+	    case job_type::JOB_MAX:
 	    default:
 	      assert (false);
 	      break;

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -24,8 +24,10 @@
 #include <algorithm>
 #include <unistd.h>
 #include <signal.h>
-#include "system_parameter.h"
+
 #include "master_server_monitor.hpp"
+
+#include "system_parameter.h"
 
 std::unique_ptr<server_monitor> master_Server_monitor = nullptr;
 

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -70,7 +70,8 @@ server_monitor::server_monitor ()
 		timeval last_revive_time = it->get_last_revive_time ();
 		gettimeofday (&tv, nullptr);
 		it = m_server_entry_list->erase (it);
-		if (GET_ELAPSED_TIME (tv, last_revive_time) > 10000)
+		if (GET_ELAPSED_TIME (tv, last_revive_time) > prm_get_integer_value (
+			    PRM_ID_HA_UNACCEPTABLE_PROC_RESTART_TIMEDIFF_IN_MSECS))
 		  {
 		    while (++revive_count < max_retries)
 		      {

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -71,13 +71,15 @@ class server_monitor
 	std::vector<std::string> m_argv;              // arguments of server process
 	std::mutex m_server_entry_lock;                // lock for server entry
 
-      private:
+
 	void proc_make_arg (char *args);
 
 	int m_pid;                                    // process ID of server process
 	volatile bool m_need_revive;                  // need to revive (true if the server is abnormally terminated)
 	CSS_CONN_ENTRY *m_conn;                       // connection entry of server process
 	timeval m_last_revive_time;                   // latest revive time
+
+      private:
     };
 
     server_monitor ();
@@ -93,7 +95,10 @@ class server_monitor
 				       CSS_CONN_ENTRY *conn);
     void remove_server_entry_by_conn (CSS_CONN_ENTRY *conn);
     void find_set_entry_to_revive (CSS_CONN_ENTRY *conn);
+    int server_monitor_check_server_revived (server_monitor::server_entry &sentry);
+
     int get_server_entry_count () const;
+
 
   private:
     std::unique_ptr<std::list <server_entry>> m_server_entry_list;      // list of server entries

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -30,8 +30,6 @@
 #include <memory>
 #include <time.h>
 #include <mutex>
-#include <master_util.h>
-#include <master_request.h>
 #include "connection_defs.h"
 #include "connection_globals.h"
 
@@ -95,7 +93,6 @@ class server_monitor
     void make_and_insert_server_entry (int pid, const char *exec_path, char *args,
 				       CSS_CONN_ENTRY *conn);
     void remove_server_entry_by_conn (CSS_CONN_ENTRY *conn);
-    void remove_server_entry_by_pid (int pid);
     void find_set_entry_to_revive (CSS_CONN_ENTRY *conn);
     int get_server_entry_count () const;
 

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -97,7 +97,7 @@ class server_monitor
 				const std::string &server_name);
     void remove_server_entry (const std::string &server_name);
     void revive_server (const std::string &server_name);
-    int try_revive_server (const std::string &exec_path, std::vector<std::string> argv);
+    int try_revive_server (const std::string &exec_path, char *const *argv);
     void check_server_revived (const std::string &server_name);
 
     void produce_job_internal (job_type job_type, int pid, const std::string &exec_path, const std::string &args,
@@ -127,32 +127,32 @@ class server_monitor
 	    {
 	      m_pid = other.m_pid;
 	      m_need_revive = other.m_need_revive;
-	      m_last_revive_time = other.m_last_revive_time;
+	      m_registered_time = other.m_registered_time;
 	      m_exec_path = other.m_exec_path;
-	      m_argv = other.m_argv;
+	      m_argv = std::move (other.m_argv);
 	    }
 	  return *this;
 	}
 
 	int get_pid () const;
 	std::string get_exec_path () const;
-	std::vector<std::string> get_argv () const;
+	char *const *get_argv () const;
 	bool get_need_revive () const;
-	std::chrono::steady_clock::time_point get_last_revive_time () const;
+	std::chrono::steady_clock::time_point get_registered_time () const;
 
 	void set_pid (int pid);
 	void set_exec_path (const std::string &exec_path);
 	void set_need_revive (bool need_revive);
-	void set_last_revive_time (std::chrono::steady_clock::time_point revive_time);
+	void set_registered_time (std::chrono::steady_clock::time_point revive_time);
 
 	void proc_make_arg (const std::string &args);
 
       private:
 	int m_pid;                                                 // process ID of server process
 	std::string m_exec_path;                                   // executable path of server process
-	std::vector<std::string> m_argv;                           // arguments of server process
+	std::unique_ptr<char *[]> m_argv;                 // arguments of server process
 	volatile bool m_need_revive;                               // need to be revived by monitoring thread
-	std::chrono::steady_clock::time_point m_last_revive_time;  // last revive time
+	std::chrono::steady_clock::time_point m_registered_time;  // last revive time
     };
 
     std::unordered_map <std::string, server_entry> m_server_entry_map;  // map of server entries

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -107,7 +107,7 @@ class server_monitor
 
 	server_monitor_job (job_type job_type, int pid, std::string exec_path, std::string args,
 			    std::string server_name);
-	server_monitor_job () : m_job_type (server_monitor::job_type::NO_JOB), m_pid (0), m_exec_path (""), m_args (""),
+	server_monitor_job () : m_job_type (job_type::NO_JOB), m_pid (0), m_exec_path (""), m_args (""),
 	  m_server_name ("") {};
 	~server_monitor_job () {};
 

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -99,9 +99,6 @@ class server_monitor
     server_monitor &operator = (const server_monitor &) = delete;
     server_monitor &operator = (server_monitor &&) = delete;
 
-    void start_monitoring_thread ();
-    void stop_monitoring_thread ();
-    void server_monitor_thread_worker ();
     void make_and_insert_server_entry (int pid, const char *exec_path, char *args,
 				       CSS_CONN_ENTRY *conn);
     void remove_server_entry_by_conn (CSS_CONN_ENTRY *conn);
@@ -116,6 +113,10 @@ class server_monitor
     std::mutex m_server_entry_list_mutex;                               // lock for server entry list
     std::condition_variable m_monitor_cv;                               // condition variable for server entry list
     std::atomic_int m_revive_entry_count;                               // count of server entries for revive
+
+    void start_monitoring_thread ();
+    void stop_monitoring_thread ();
+    void server_monitor_thread_worker ();
 };
 
 extern std::unique_ptr<server_monitor> master_Server_monitor;

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -48,6 +48,13 @@ class server_monitor
 	server_entry &operator= (server_entry &&) = default;
 
 	CSS_CONN_ENTRY *get_conn () const;
+        bool get_need_revive () const;
+        void set_need_revive (bool need_revive);
+        char *const * get_argv () const;
+        const char* get_exec_path () const;
+        struct timeval get_last_revive_time () const;
+
+        bool m_need_revive;                           // need to revive (true if the server is abnormally terminated)
 
       private:
 	void proc_make_arg (char *args);
@@ -57,7 +64,7 @@ class server_monitor
 	std::vector<std::string> m_argv;              // arguments of server process
 	CSS_CONN_ENTRY *m_conn;                       // connection entry of server process
 	timeval m_last_revive_time;                   // latest revive time
-	bool m_need_revive;                           // need to revive (true if the server is abnormally terminated)
+	
     };
 
     server_monitor ();
@@ -72,6 +79,7 @@ class server_monitor
     void make_and_insert_server_entry (int pid, const char *exec_path, char *args,
 				       CSS_CONN_ENTRY *conn);
     void remove_server_entry_by_conn (CSS_CONN_ENTRY *conn);
+    void find_set_entry_to_revive (CSS_CONN_ENTRY *conn);
 
   private:
     std::unique_ptr<std::list <server_entry>> m_server_entry_list;      // list of server entries

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -75,19 +75,20 @@ class server_monitor
 	void set_need_revive (bool need_revive);
 	void set_last_revive_time ();
 
-	int m_revive_count;                                           // revive count of server process
-
 	void proc_make_arg (char *args);
 	bool server_entry_compare_args_and_argv (const char *args);
 
+	int m_revive_count;                                           // revive count of server process
+
       private:
-	int m_pid;                                                    // process ID of server process
-	std::string m_exec_path;                                      // executable path of server process
-	std::vector<std::string> m_argv;                              // arguments of server process
-	CSS_CONN_ENTRY *m_conn;                                       // connection entry of server process
-	volatile bool m_need_revive;                                  // need to revive (true if the server is abnormally terminated)
-	std::chrono::steady_clock::time_point m_last_revive_time;     // last revive time
-	std::mutex m_entry_mutex;                                     // lock for server entry
+	int m_pid;                                                 // process ID of server process
+	std::string m_exec_path;                                   // executable path of server process
+	std::vector<std::string> m_argv;                           // arguments of server process
+	CSS_CONN_ENTRY *m_conn;                                    // connection entry of server process
+	volatile bool m_need_revive;                               // need to be revived by monitoring thread
+	std::chrono::steady_clock::time_point m_last_revive_time;  // last revive time
+	std::mutex m_entry_mutex;                                  // lock for server entry
+
     };
 
     server_monitor ();

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -87,7 +87,6 @@ class server_monitor
 	CSS_CONN_ENTRY *m_conn;                                    // connection entry of server process
 	volatile bool m_need_revive;                               // need to be revived by monitoring thread
 	std::chrono::steady_clock::time_point m_last_revive_time;  // last revive time
-	std::mutex m_entry_mutex;                                  // lock for server entry
 
     };
 
@@ -100,6 +99,9 @@ class server_monitor
     server_monitor &operator = (const server_monitor &) = delete;
     server_monitor &operator = (server_monitor &&) = delete;
 
+    void start_monitoring_thread ();
+    void stop_monitoring_thread ();
+    void server_monitor_thread_worker ();
     void make_and_insert_server_entry (int pid, const char *exec_path, char *args,
 				       CSS_CONN_ENTRY *conn);
     void remove_server_entry_by_conn (CSS_CONN_ENTRY *conn);
@@ -111,7 +113,7 @@ class server_monitor
     std::unique_ptr<std::list <server_entry>> m_server_entry_list;      // list of server entries
     std::unique_ptr<std::thread> m_monitoring_thread;                   // monitoring thread
     volatile bool m_thread_shutdown;                                    // flag to shutdown monitoring thread
-    std::mutex m_monitor_mutex;                                         // lock for server entry list
+    std::mutex m_server_entry_list_mutex;                               // lock for server entry list
     std::condition_variable m_monitor_cv;                               // condition variable for server entry list
     std::atomic_int m_revive_entry_count;                               // count of server entries for revive
 };

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -75,11 +75,11 @@ class server_monitor
 
       private:
 
-	job_type m_job_type;                                     // job type
-	int m_pid;                                               // process ID of server process
-	std::string m_exec_path;                                 // executable path of server process
-	std::string m_args;                                      // arguments of server process
-	std::string m_server_name;                               // server name
+	job_type m_job_type;            // job type
+	int m_pid;                      // process ID of server process
+	std::string m_exec_path;        // executable path of server process
+	std::string m_args;             // arguments of server process
+	std::string m_server_name;      // server name
     };
 
   public:

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -42,11 +42,11 @@ class server_monitor
 
     enum class job_type
     {
-      NO_JOB,
-      REGISTER_ENTRY,
-      REMOVE_ENTRY,
-      REVIVE_ENTRY,
-      CONFIRM_REVIVE_ENTRY
+      REGISTER_ENTRY = 0,
+      REMOVE_ENTRY = 1,
+      REVIVE_ENTRY = 2,
+      CONFIRM_REVIVE_ENTRY =  3,
+      JOB_MAX
     };
 
     class server_entry
@@ -107,7 +107,7 @@ class server_monitor
 
 	server_monitor_job (job_type job_type, int pid, std::string exec_path, std::string args,
 			    std::string server_name);
-	server_monitor_job () : m_job_type (job_type::NO_JOB), m_pid (0), m_exec_path (""), m_args (""),
+	server_monitor_job () : m_job_type (job_type::JOB_MAX), m_pid (0), m_exec_path (""), m_args (""),
 	  m_server_name ("") {};
 	~server_monitor_job () {};
 

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -140,7 +140,7 @@ class server_monitor
   private:
     std::unordered_map <std::string, server_entry> m_server_entry_map;  // map of server entries
 
-    std::unique_ptr<std::thread> m_monitor_thread;                      // monitoring thread
+    std::unique_ptr<std::thread> m_monitoring_thread;                   // monitoring thread
     lockfree::circular_queue <server_monitor_job> *m_job_queue;         // job queue for monitoring thread
     volatile bool m_thread_shutdown;                                    // flag to shutdown monitoring thread
     std::mutex m_monitor_mutex_consumer;                                // lock for m_job_queue empty check

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -155,7 +155,8 @@ class server_monitor
     std::unique_ptr<std::thread> m_monitoring_thread;                   // monitoring thread
     std::queue<job> m_job_queue;                                        // job queue for monitoring thread
     volatile bool m_thread_shutdown;                                    // flag to shutdown monitoring thread
-    std::mutex m_monitor_mutex_consumer;                                // lock for m_job_queue empty check
+    std::mutex
+    m_server_monitor_mutex;                                  // lock for synchronizing m_job_queue and m_thread_shutdown
     std::condition_variable m_monitor_cv_consumer;                      // condition variable for m_job_queue empty check
 
     void start_monitoring_thread ();

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -78,6 +78,7 @@ class server_monitor
 	int m_revive_count;                                           // revive count of server process
 
 	void proc_make_arg (char *args);
+	bool server_entry_compare_args_and_argv (const char *args);
 
       private:
 	int m_pid;                                                    // process ID of server process
@@ -88,7 +89,6 @@ class server_monitor
 	m_need_revive;                                  // need to revive (true if the server is abnormally terminated)
 	std::chrono::steady_clock::time_point m_last_revive_time;     // last revive time
 	std::mutex m_entry_mutex;                                     // lock for server entry
-	std::condition_variable m_entry_cv;                           // condition variable for server entry
     };
 
     server_monitor ();
@@ -104,10 +104,8 @@ class server_monitor
 				       CSS_CONN_ENTRY *conn);
     void remove_server_entry_by_conn (CSS_CONN_ENTRY *conn);
     void find_set_entry_to_revive (CSS_CONN_ENTRY *conn);
+    void server_monitor_try_revive_server (std::string exec_path, std::vector<std::string> argv, int *out_pid);
     int server_monitor_check_server_revived (server_monitor::server_entry &sentry);
-
-    int get_server_entry_count () const;
-
 
   private:
     std::unique_ptr<std::list <server_entry>> m_server_entry_list;      // list of server entries

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -59,8 +59,8 @@ class server_monitor
     server_monitor &operator = (server_monitor &&) = delete;
 
     void register_server_entry (int pid, const std::string &exec_path, const std::string &args,
-				const std::string &server_name,
-				std::chrono::steady_clock::time_point revive_time);
+				const std::string &server_name
+			       );
     void remove_server_entry (const std::string &server_name);
     void revive_server (const std::string &server_name);
     int try_revive_server (const std::string &exec_path, std::vector<std::string> argv);
@@ -93,7 +93,6 @@ class server_monitor
 	std::string get_exec_path () const;
 	std::string get_args () const;
 	std::string get_server_name () const;
-	std::chrono::steady_clock::time_point get_produce_time () const;
 
       private:
 
@@ -102,7 +101,6 @@ class server_monitor
 	std::string m_exec_path;                                 // executable path of server process
 	std::string m_args;                                      // arguments of server process
 	std::string m_server_name;                               // server name
-	std::chrono::steady_clock::time_point m_produce_time;    // produced time of job
     };
 
     class server_entry
@@ -155,8 +153,7 @@ class server_monitor
     std::unique_ptr<std::thread> m_monitoring_thread;                   // monitoring thread
     std::queue<job> m_job_queue;                                        // job queue for monitoring thread
     volatile bool m_thread_shutdown;                                    // flag to shutdown monitoring thread
-    std::mutex
-    m_server_monitor_mutex;                                  // lock for synchronizing m_job_queue and m_thread_shutdown
+    std::mutex m_server_monitor_mutex;                                  // lock for syncing job_queue and thread_shutdown
     std::condition_variable m_monitor_cv_consumer;                      // condition variable for m_job_queue empty check
 
     void start_monitoring_thread ();

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -85,8 +85,7 @@ class server_monitor
 	std::string m_exec_path;                                      // executable path of server process
 	std::vector<std::string> m_argv;                              // arguments of server process
 	CSS_CONN_ENTRY *m_conn;                                       // connection entry of server process
-	volatile bool
-	m_need_revive;                                  // need to revive (true if the server is abnormally terminated)
+	volatile bool m_need_revive;                                  // need to revive (true if the server is abnormally terminated)
 	std::chrono::steady_clock::time_point m_last_revive_time;     // last revive time
 	std::mutex m_entry_mutex;                                     // lock for server entry
     };

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -48,23 +48,23 @@ class server_monitor
 	server_entry &operator= (server_entry &&) = default;
 
 	CSS_CONN_ENTRY *get_conn () const;
-        bool get_need_revive () const;
-        void set_need_revive (bool need_revive);
-        char *const * get_argv () const;
-        const char* get_exec_path () const;
-        struct timeval get_last_revive_time () const;
+	bool get_need_revive () const;
+	void set_need_revive (bool need_revive);
+	const char **get_argv () const;
+	const char *get_exec_path () const;
+	struct timeval get_last_revive_time () const;
 
-        bool m_need_revive;                           // need to revive (true if the server is abnormally terminated)
+	int m_revive_count;                           // revive count of server process
 
       private:
 	void proc_make_arg (char *args);
 
 	int m_pid;                                    // process ID of server process
+	bool m_need_revive;                           // need to revive (true if the server is abnormally terminated)
 	std::string m_exec_path;                      // executable path of server process
 	std::vector<std::string> m_argv;              // arguments of server process
 	CSS_CONN_ENTRY *m_conn;                       // connection entry of server process
 	timeval m_last_revive_time;                   // latest revive time
-	
     };
 
     server_monitor ();
@@ -80,6 +80,7 @@ class server_monitor
 				       CSS_CONN_ENTRY *conn);
     void remove_server_entry_by_conn (CSS_CONN_ENTRY *conn);
     void find_set_entry_to_revive (CSS_CONN_ENTRY *conn);
+    int get_server_entry_count () const;
 
   private:
     std::unique_ptr<std::list <server_entry>> m_server_entry_list;      // list of server entries
@@ -88,4 +89,5 @@ class server_monitor
 };
 
 extern std::unique_ptr<server_monitor> master_Server_monitor;
+//extern void css_remove_entry_by_conn (CSS_CONN_ENTRY * conn_p, SOCKET_QUEUE_ENTRY ** anchor_p);
 #endif

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -128,8 +128,8 @@ class server_monitor
 
     void make_and_insert_server_entry (int pid, std::string exec_path, std::string args, std::string server_name,
 				       std::chrono::steady_clock::time_point revive_time);
-    void remove_server_entry_by_name (std::string server_name);
-    void revive_server_with_name (std::string server_name);
+    void remove_server_entry (std::string server_name);
+    void revive_server (std::string server_name);
     void server_monitor_try_revive_server (std::string exec_path, std::vector<std::string> argv, int *out_pid);
     void server_monitor_check_server_revived (std::string server_name);
 
@@ -137,14 +137,14 @@ class server_monitor
 				     std::string server_name);
 
   private:
-    std::unique_ptr<std::unordered_map <std::string, server_entry>> m_server_entry_map;  // map of server entries
+    std::unordered_map <std::string, server_entry> m_server_entry_map;  // map of server entries
     std::unique_ptr<std::thread> m_monitoring_thread;                   // monitoring thread
     lockfree::circular_queue <server_monitor_job> *m_job_queue;         // job queue for monitoring thread
     volatile bool m_thread_shutdown;                                    // flag to shutdown monitoring thread
-    std::mutex m_monitor_mutex_empty;                                   // lock for for m_job_queue empty check
-    std::mutex m_monitor_mutex_full;                                    // lock for for m_job_queue full check
-    std::condition_variable m_monitor_cv_empty;                         // condition variable for m_job_queue empty check
-    std::condition_variable m_monitor_cv_full;                          // condition variable for m_job_queue full check
+    std::mutex m_monitor_mutex_consumer;                                // lock for m_job_queue empty check
+    std::mutex m_monitor_mutex_producer;                                  // lock for m_job_queue full check
+    std::condition_variable m_monitor_cv_consumer;                      // condition variable for m_job_queue empty check
+    std::condition_variable m_monitor_cv_producer;                      // condition variable for m_job_queue full check
 
     void start_monitoring_thread ();
     void stop_monitoring_thread ();

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -59,8 +59,7 @@ class server_monitor
     server_monitor &operator = (server_monitor &&) = delete;
 
     void register_server_entry (int pid, const std::string &exec_path, const std::string &args,
-				const std::string &server_name
-			       );
+				const std::string &server_name);
     void remove_server_entry (const std::string &server_name);
     void revive_server (const std::string &server_name);
     int try_revive_server (const std::string &exec_path, std::vector<std::string> argv);
@@ -153,14 +152,12 @@ class server_monitor
     std::unique_ptr<std::thread> m_monitoring_thread;                   // monitoring thread
     std::queue<job> m_job_queue;                                        // job queue for monitoring thread
     volatile bool m_thread_shutdown;                                    // flag to shutdown monitoring thread
-    std::mutex m_server_monitor_mutex;                                  // lock for syncing job_queue and thread_shutdown
+    std::mutex m_server_monitor_mutex;                                  // lock that syncs m_job_queue and m_thread_shutdown
     std::condition_variable m_monitor_cv_consumer;                      // condition variable for m_job_queue empty check
 
     void start_monitoring_thread ();
     void stop_monitoring_thread ();
     void server_monitor_thread_worker ();
-
-
 };
 
 extern std::unique_ptr<server_monitor> master_Server_monitor;

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -55,7 +55,7 @@ class server_monitor
 	      m_need_revive = other.m_need_revive;
 	      m_conn = other.m_conn;
 	      m_last_revive_time = other.m_last_revive_time;
-	      m_revive_count = other.m_revive_count;
+	      m_retries = other.m_retries;
 	      m_exec_path = other.m_exec_path;
 	      m_argv = other.m_argv;
 	    }
@@ -78,7 +78,7 @@ class server_monitor
 	void proc_make_arg (char *args);
 	bool server_entry_compare_args_and_argv (const char *args);
 
-	int m_revive_count;                                           // revive count of server process
+	int m_retries;                                             // retry count of server process
 
       private:
 	int m_pid;                                                 // process ID of server process

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -62,7 +62,6 @@ class server_monitor
 	}
 
 	CSS_CONN_ENTRY *get_conn () const;
-	int get_pid () const;
 	bool get_need_revive () const;
 	void set_need_revive (bool need_revive);
 	struct timeval get_last_revive_time () const;
@@ -76,7 +75,7 @@ class server_monitor
 	void proc_make_arg (char *args);
 
 	int m_pid;                                    // process ID of server process
-	bool m_need_revive;                           // need to revive (true if the server is abnormally terminated)
+	volatile bool m_need_revive;                  // need to revive (true if the server is abnormally terminated)
 	CSS_CONN_ENTRY *m_conn;                       // connection entry of server process
 	timeval m_last_revive_time;                   // latest revive time
     };

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -50,19 +50,18 @@ class server_monitor
 	CSS_CONN_ENTRY *get_conn () const;
 	bool get_need_revive () const;
 	void set_need_revive (bool need_revive);
-	const char **get_argv () const;
-	const char *get_exec_path () const;
 	struct timeval get_last_revive_time () const;
 
 	int m_revive_count;                           // revive count of server process
+	std::string m_exec_path;                      // executable path of server process
+	std::vector<std::string> m_argv;              // arguments of server process
 
       private:
 	void proc_make_arg (char *args);
 
 	int m_pid;                                    // process ID of server process
 	bool m_need_revive;                           // need to revive (true if the server is abnormally terminated)
-	std::string m_exec_path;                      // executable path of server process
-	std::vector<std::string> m_argv;              // arguments of server process
+
 	CSS_CONN_ENTRY *m_conn;                       // connection entry of server process
 	timeval m_last_revive_time;                   // latest revive time
     };

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -64,7 +64,7 @@ class server_monitor
 	job (const job &) = default;
 	job (job &&) = default;
 
-	job &operator= (const job &) = default;
+	job &operator= (const job &) = delete;
 	job &operator= (job &&) = default;
 
 	job_type get_job_type () const;
@@ -105,8 +105,8 @@ class server_monitor
     void produce_job (job_type job_type, int pid, const std::string &exec_path, const std::string &args,
 		      const std::string &server_name);
 
-    job consume_job ();
-    void process_job (job consume_job);
+    void consume_job (job &consune_job);
+    void process_job (job &consume_job);
 
   private:
 
@@ -148,11 +148,11 @@ class server_monitor
 	void proc_make_arg (const std::string &args);
 
       private:
-	int m_pid;                                                 // process ID of server process
-	std::string m_exec_path;                                   // executable path of server process
-	std::unique_ptr<char *[]> m_argv;                 // arguments of server process
-	volatile bool m_need_revive;                               // need to be revived by monitoring thread
-	std::chrono::steady_clock::time_point m_registered_time;  // last revive time
+	int m_pid;                                                  // process ID of server process
+	std::string m_exec_path;                                    // executable path of server process
+	std::unique_ptr<char *[]> m_argv;                           // arguments of server process
+	volatile bool m_need_revive;                                // need to be revived by monitoring thread
+	std::chrono::steady_clock::time_point m_registered_time;    // last revive time
     };
 
     std::unordered_map <std::string, server_entry> m_server_entry_map;  // map of server entries


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25438

- cub_server 비정상 종료시 master_monitoring_thread로 전달
- master_monitoring_thread는 server_entry 내의 정보를 통해 server 재구동
  - 재구동은 이전 재구동 시간과 현재 시간의 차이가 HA parameter (HA_UNACCEPTABLE_PROC_RESTART_TIMEDIFF_IN_MSECS) 보다 클 때만 시행
  - 재구동 실패 시 총 retries 횟수는 heartbeat의 retries 횟수와 동일하며, (HA_MAX_PROCESS_START_CONFIRM) 이는 fork-exec의 재시도 횟수와, confirm job의 재시도 횟수의 총 합임. (heartbeat와 동일한 방식)