### PR TITLE
[CBRD-25496] Incorrect size calculation of the disk_volume_header structure caused the related log size to increase unnecessarily by 3 bytes.

### DIFF
--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -5327,7 +5327,7 @@ disk_vhdr_get_vol_header_size (const DISK_VOLUME_HEADER * vhdr)
 
   assert (volume_header_size >= 0 && volume_header_size <= DB_PAGESIZE);
 
-  return (size_t) volume_header_size;
+  return volume_header_size;
 }
 
 /*

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -350,7 +350,8 @@ static bool disk_Logging = false;
 STATIC_INLINE char *disk_vhdr_get_vol_fullname (const DISK_VOLUME_HEADER * vhdr) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE char *disk_vhdr_get_next_vol_fullname (const DISK_VOLUME_HEADER * vhdr) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE char *disk_vhdr_get_vol_remarks (const DISK_VOLUME_HEADER * vhdr) __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE int disk_vhdr_length_of_varfields (const DISK_VOLUME_HEADER * vhdr) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE size_t disk_vhdr_get_vol_remarks_size (const DISK_VOLUME_HEADER * vhdr) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE size_t disk_vhdr_get_vol_header_size (const DISK_VOLUME_HEADER * vhdr) __attribute__ ((ALWAYS_INLINE));
 static int disk_vhdr_set_vol_fullname (DISK_VOLUME_HEADER * vhdr, const char *vol_fullname);
 static int disk_vhdr_set_next_vol_fullname (DISK_VOLUME_HEADER * vhdr, const char *next_vol_fullname);
 static int disk_vhdr_set_vol_remarks (DISK_VOLUME_HEADER * vhdr, const char *vol_remarks);
@@ -658,7 +659,7 @@ disk_format (THREAD_ENTRY * thread_p, const char *dbname, VOLID volid, DBDEF_VOL
 
   if (ext_info->voltype == DB_PERMANENT_VOLTYPE)
     {
-      log_append_dboutside_redo (thread_p, RVDK_NEWVOL, sizeof (*vhdr) + disk_vhdr_length_of_varfields (vhdr), vhdr);
+      log_append_dboutside_redo (thread_p, RVDK_NEWVOL, disk_vhdr_get_vol_header_size (vhdr), vhdr);
 
       fault_inject_random_crash ();
 
@@ -673,7 +674,7 @@ disk_format (THREAD_ENTRY * thread_p, const char *dbname, VOLID volid, DBDEF_VOL
        *       RVDK_FORMAT calls recovery detectable.
        */
       addr.offset = -1;		/* First call is marked with offset -1. */
-      log_append_redo_data (thread_p, RVDK_FORMAT, &addr, sizeof (*vhdr) + disk_vhdr_length_of_varfields (vhdr), vhdr);
+      log_append_redo_data (thread_p, RVDK_FORMAT, &addr, disk_vhdr_get_vol_header_size (vhdr), vhdr);
 
       fault_inject_random_crash ();
     }
@@ -704,7 +705,7 @@ disk_format (THREAD_ENTRY * thread_p, const char *dbname, VOLID volid, DBDEF_VOL
   if (ext_info->voltype == DB_PERMANENT_VOLTYPE)
     {
       addr.offset = 0;		/* Header is located at position zero */
-      log_append_redo_data (thread_p, RVDK_FORMAT, &addr, sizeof (*vhdr) + disk_vhdr_length_of_varfields (vhdr), vhdr);
+      log_append_redo_data (thread_p, RVDK_FORMAT, &addr, disk_vhdr_get_vol_header_size (vhdr), vhdr);
 
       fault_inject_random_crash ();
     }
@@ -5312,15 +5313,36 @@ disk_vhdr_get_vol_remarks (const DISK_VOLUME_HEADER * vhdr)
 }
 
 /*
- * disk_vhdr_length_of_varfields () - get length of volume header including variable fields
+ * disk_vhdr_get_vol_remarks_size () - get the size of 'remarks' from volume header
  *
- * return    : total length
+ * return    : the size of remarks
  * vhdr (in) : volume header
  */
-STATIC_INLINE int
-disk_vhdr_length_of_varfields (const DISK_VOLUME_HEADER * vhdr)
+STATIC_INLINE size_t
+disk_vhdr_get_vol_remarks_size (const DISK_VOLUME_HEADER * vhdr)
 {
-  return (vhdr->offset_to_vol_remarks + (int) strlen (disk_vhdr_get_vol_remarks (vhdr)));
+  assert (vhdr != NULL);
+
+  return strlen (disk_vhdr_get_vol_remarks (vhdr)) + 1;
+}
+
+/*
+ * disk_vhdr_get_vol_header_size () - get the size of volume header including variable fields
+ *
+ * return    : total size
+ * vhdr (in) : volume header
+ */
+STATIC_INLINE size_t
+disk_vhdr_get_vol_header_size (const DISK_VOLUME_HEADER * vhdr)
+{
+  assert (vhdr != NULL);
+
+  const char *remarks = disk_vhdr_get_vol_remarks (vhdr);
+  const int volume_header_size = remarks + disk_vhdr_get_vol_remarks_size (vhdr) - (char *) vhdr;
+
+  assert (volume_header_size >= 0 && volume_header_size <= DB_PAGESIZE);
+
+  return (size_t) volume_header_size;
 }
 
 /*

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -350,8 +350,7 @@ static bool disk_Logging = false;
 STATIC_INLINE char *disk_vhdr_get_vol_fullname (const DISK_VOLUME_HEADER * vhdr) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE char *disk_vhdr_get_next_vol_fullname (const DISK_VOLUME_HEADER * vhdr) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE char *disk_vhdr_get_vol_remarks (const DISK_VOLUME_HEADER * vhdr) __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE size_t disk_vhdr_get_vol_remarks_size (const DISK_VOLUME_HEADER * vhdr) __attribute__ ((ALWAYS_INLINE));
-STATIC_INLINE size_t disk_vhdr_get_vol_header_size (const DISK_VOLUME_HEADER * vhdr) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE int disk_vhdr_get_vol_header_size (const DISK_VOLUME_HEADER * vhdr) __attribute__ ((ALWAYS_INLINE));
 static int disk_vhdr_set_vol_fullname (DISK_VOLUME_HEADER * vhdr, const char *vol_fullname);
 static int disk_vhdr_set_next_vol_fullname (DISK_VOLUME_HEADER * vhdr, const char *next_vol_fullname);
 static int disk_vhdr_set_vol_remarks (DISK_VOLUME_HEADER * vhdr, const char *vol_remarks);
@@ -5313,32 +5312,18 @@ disk_vhdr_get_vol_remarks (const DISK_VOLUME_HEADER * vhdr)
 }
 
 /*
- * disk_vhdr_get_vol_remarks_size () - get the size of 'remarks' from volume header
- *
- * return    : the size of remarks
- * vhdr (in) : volume header
- */
-STATIC_INLINE size_t
-disk_vhdr_get_vol_remarks_size (const DISK_VOLUME_HEADER * vhdr)
-{
-  assert (vhdr != NULL);
-
-  return strlen (disk_vhdr_get_vol_remarks (vhdr)) + 1;
-}
-
-/*
  * disk_vhdr_get_vol_header_size () - get the size of volume header including variable fields
  *
  * return    : total size
  * vhdr (in) : volume header
  */
-STATIC_INLINE size_t
+STATIC_INLINE int
 disk_vhdr_get_vol_header_size (const DISK_VOLUME_HEADER * vhdr)
 {
   assert (vhdr != NULL);
 
   const char *remarks = disk_vhdr_get_vol_remarks (vhdr);
-  const int volume_header_size = remarks + disk_vhdr_get_vol_remarks_size (vhdr) - (char *) vhdr;
+  const int volume_header_size = (remarks + strlen (remarks) + 1) - (char *) (vhdr);
 
   assert (volume_header_size >= 0 && volume_header_size <= DB_PAGESIZE);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25496

**Purpose**

 디스크 볼륨 헤더는 '고정 길이' + '가변 길이' 정보로 구성되어 있으며, DISK_VOLUME_HEADER 구조체를 통해 표현됩니다.
 - DISK_VOLUME_HEADER 구조체

```
typedef struct disk_volume_header DISK_VOLUME_HEADER;
struct disk_volume_header
{
  /* 고정 길이 정보 */
  char magic[CUBRID_MAGIC_MAX_LENGTH];
...
  INT16 offset_to_vol_fullname;
  INT16 offset_to_next_vol_fullname;
  INT16 offset_to_vol_remarks;

  /* 가변 길이 정보 */
  char var_fields[1];
};
```


DISK_VOLUME_HEADER 구조체는 var_fields를 시작점으로 가변 길이 정보인 '볼륨 경로 + 다음 볼륨 경로 + 볼륨에 대한 주석'을 저장하며,

이 구조체를 저장하는 데이터 페이지의 나머지 공간을 사용하게 됩니다.

DISK_VOLUME_HEADER의 정확한 크기는 다음과 같이 '고정 길이 정보의 크기'와 '가변 길이 정보의 크기'의 합산으로 계산되는데,
 - 고정 길이 정보의 크기 - var_fields 멤버 변수 이전까지의 크기
 - 가변 길이 정보의 크기 - var_fields부터 각 가변 길이 정보인 '볼륨 경로 + 다음 볼륨 경로 + 볼륨에 대한 주석' 길이 정보의 합산

문제는 디스크 볼륨 헤더의 고정 길이 정보의 크기를 구하기 위해 sizeof(DISK_VOLUME_HEADER) 연산을 사용함에 따라

고정 길이 정보의 크기에 var_fields[1]의 크기가 불필요하게 포함되면서 발생하게 됩니다.

이로 인해 디스크 볼륨 헤더와 관련된 로그 레코드 생성 시 사용할 필요가 없는 3bytes 공간이 추가되어 낭비되게 됩니다.

참고로, var_fields[1]의 크기인 1byte가 아닌 3bytes 공간이 낭비되는 이유는

1. 구조체 메모리 정렬로 인해 var_fields[1] 뒤에 실제론 var_fields[1] 뒤에 3bytes만큼 공간이 추가로 존재해서 
총 4bytes만큼 추가로 더 해집니다.

2. 가변길이필드의 길이를 구하는 함수 disk_vhdr_length_of_varfields (vhdr) 에서 가변길이필드 길이를 구할 때 
마지막 문자열의 NULL문자를 더해주지 않아 실제 길이보다 1byte 짧은 길이로 계산되어지고 있습니다.

위와 같은 이유로 총 3bytes (4bytes - 1byte) 만큼의 공간이 낭비되는 것입니다.

**Implementation**

기존 디스크볼륨헤더 길이 계산식
- sizeof (*vhdr) + disk_vhdr_length_of_varfields (vhdr)
- disk_volume_header 구조체 크기 + 가변길이필드 길이

변경된 디스크볼륨헤더 길이 계산식
- 디스크볼륨헤더 끝주소 - 시작주소
- 끝주소는 remarks의 시작위치를 가져오는 함수에다 remarks의 사이즈를 더해 구한다.



**Remarks**

N/A
