### PR TITLE
[CBRD-25497] When the SQL log ID exceeds INT_MAX, it results in a negative value

### DIFF
--- a/src/transaction/log_applier_sql_log.c
+++ b/src/transaction/log_applier_sql_log.c
@@ -49,14 +49,14 @@
 
 #define SL_LOG_FILE_MAX_SIZE   \
   (prm_get_integer_value (PRM_ID_HA_SQL_LOG_MAX_SIZE_IN_MB) * 1024 * 1024)
-#define FILE_ID_FORMAT  "%d"
+#define FILE_ID_FORMAT  "%u"
 #define SQL_ID_FORMAT   "%010u"
 #define CATALOG_FORMAT  FILE_ID_FORMAT " | " SQL_ID_FORMAT
 
 typedef struct sl_info SL_INFO;
 struct sl_info
 {
-  int curr_file_id;
+  unsigned int curr_file_id;
   unsigned int last_inserted_sql_id;
 };
 
@@ -571,7 +571,7 @@ sl_log_open (void)
   FILE *fp;
 
   assert (sl_Info.curr_file_id >= 0);
-  if (snprintf (cur_sql_log_path, PATH_MAX - 1, "%s.%d", sql_log_base_path, sl_Info.curr_file_id) < 0)
+  if (snprintf (cur_sql_log_path, PATH_MAX - 1, "%s.%u", sql_log_base_path, sl_Info.curr_file_id) < 0)
     {
       assert (false);
       return NULL;
@@ -606,16 +606,9 @@ sl_open_next_file (FILE * old_fp)
   char new_file_path[PATH_MAX];
 
   sl_Info.last_inserted_sql_id = 0;
-  if (sl_Info.curr_file_id < INT_MAX)
-    {
-      sl_Info.curr_file_id++;
-    }
-  else
-    {
-      sl_Info.curr_file_id = 0;
-    }
+  sl_Info.curr_file_id++;
 
-  if (snprintf (new_file_path, PATH_MAX - 1, "%s.%d", sql_log_base_path, sl_Info.curr_file_id) < 0)
+  if (snprintf (new_file_path, PATH_MAX - 1, "%s.%u", sql_log_base_path, sl_Info.curr_file_id) < 0)
     {
       assert (false);
       return NULL;

--- a/src/transaction/log_applier_sql_log.c
+++ b/src/transaction/log_applier_sql_log.c
@@ -570,6 +570,7 @@ sl_log_open (void)
   char cur_sql_log_path[PATH_MAX];
   FILE *fp;
 
+  assert (sl_Info.curr_file_id >= 0);
   if (snprintf (cur_sql_log_path, PATH_MAX - 1, "%s.%d", sql_log_base_path, sl_Info.curr_file_id) < 0)
     {
       assert (false);
@@ -604,8 +605,15 @@ sl_open_next_file (FILE * old_fp)
   FILE *new_fp;
   char new_file_path[PATH_MAX];
 
-  sl_Info.curr_file_id++;
   sl_Info.last_inserted_sql_id = 0;
+  if (sl_Info.curr_file_id < INT_MAX)
+    {
+      sl_Info.curr_file_id++;
+    }
+  else
+    {
+      sl_Info.curr_file_id = 0;
+    }
 
   if (snprintf (new_file_path, PATH_MAX - 1, "%s.%d", sql_log_base_path, sl_Info.curr_file_id) < 0)
     {

--- a/src/transaction/log_applier_sql_log.c
+++ b/src/transaction/log_applier_sql_log.c
@@ -570,7 +570,6 @@ sl_log_open (void)
   char cur_sql_log_path[PATH_MAX];
   FILE *fp;
 
-  assert (sl_Info.curr_file_id >= 0);
   if (snprintf (cur_sql_log_path, PATH_MAX - 1, "%s.%u", sql_log_base_path, sl_Info.curr_file_id) < 0)
     {
       assert (false);
@@ -605,8 +604,8 @@ sl_open_next_file (FILE * old_fp)
   FILE *new_fp;
   char new_file_path[PATH_MAX];
 
-  sl_Info.last_inserted_sql_id = 0;
   sl_Info.curr_file_id++;
+  sl_Info.last_inserted_sql_id = 0;
 
   if (snprintf (new_file_path, PATH_MAX - 1, "%s.%u", sql_log_base_path, sl_Info.curr_file_id) < 0)
     {

--- a/src/transaction/log_applier_sql_log.c
+++ b/src/transaction/log_applier_sql_log.c
@@ -636,12 +636,12 @@ sl_open_next_file (FILE * old_fp)
 static int
 sl_remove_oldest_file (void)
 {
-  int oldest_file_id;
+  unsigned int oldest_file_id;
   char oldest_file_path[PATH_MAX];
 
   oldest_file_id = sl_Info.curr_file_id - sql_log_max_cnt;
 
-  snprintf (oldest_file_path, PATH_MAX - 1, "%s.%d", sql_log_base_path, oldest_file_id);
+  snprintf (oldest_file_path, PATH_MAX - 1, "%s.%u", sql_log_base_path, oldest_file_id);
 
   unlink (oldest_file_path);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25497

### **_Purpose_**

HA mode에서 ha_enable_sql_logging 파라미터를 yes로 설정하게 되면

applylogdb 프로세스가 DB에 반영하는 SQL에 대한 log 파일을 생성합니다. ( 기본값 = no )

생성되는 log 파일은 아래와 같은 규칙으로 이름이 정해져 생성됩니다.

db name_master hostname.sql.log.id

이 때, <id> 값이 INT_MAX (2147483647)를 초과하게 되면 음수로 바뀌는 문제가 발생하게 됩니다.

---
### **_Implementation_**

- file id의 선언 타입을 int형에서 unsigned int형으로 변경
- 타입 변경에 맞춰 %d로 출력하던 부분들도 전부 %u 로 변경하였음
---
### **_Remarks_**

- N/A