### PR TITLE
[CBRD-25361] Fixed the issue where trace information for CTEs and subqueries not provided. (#5200)

### DIFF
--- a/src/query/query_dump.c
+++ b/src/query/query_dump.c
@@ -3056,7 +3056,6 @@ qdump_print_stats_json (xasl_node * xasl_p, json_t * parent)
       subquery = json_array ();
       for (xptr = xasl_p->aptr_list; xptr; xptr = xptr->next)
 	{
-	  qdump_print_stats_json (xasl_p->aptr_list, proc);
 	  temp = json_object ();
 	  qdump_print_stats_json (xptr, temp);
 	  json_array_append_new (subquery, temp);

--- a/src/query/query_dump.c
+++ b/src/query/query_dump.c
@@ -2882,8 +2882,10 @@ qdump_print_stats_json (xasl_node * xasl_p, json_t * parent)
   GROUPBY_STATS *gstats;
   json_t *proc, *scan = NULL;
   json_t *subquery, *groupby, *orderby;
-  json_t *left, *right, *outer, *inner;
+  json_t *outer, *inner;
   json_t *cte_non_recursive_part, *cte_recursive_part;
+  json_t *temp;
+  xasl_node *xptr;
 
   if (xasl_p == NULL || parent == NULL)
     {
@@ -2917,14 +2919,14 @@ qdump_print_stats_json (xasl_node * xasl_p, json_t * parent)
     case UNION_PROC:
     case DIFFERENCE_PROC:
     case INTERSECTION_PROC:
-      left = json_object ();
-      right = json_object ();
-
-      qdump_print_stats_json (xasl_p->proc.union_.left, left);
-      qdump_print_stats_json (xasl_p->proc.union_.right, right);
-
-      json_object_set_new (proc, "left", left);
-      json_object_set_new (proc, "right", right);
+      subquery = json_array ();
+      for (xptr = xasl_p->aptr_list; xptr; xptr = xptr->next)
+	{
+	  temp = json_object ();
+	  qdump_print_stats_json (xptr, temp);
+	  json_array_append_new (subquery, temp);
+	}
+      json_object_set_new (proc, "SUBQUERY (uncorrelated)", subquery);
       break;
 
     case MERGELIST_PROC:
@@ -3051,22 +3053,26 @@ qdump_print_stats_json (xasl_node * xasl_p, json_t * parent)
 
   if (HAVE_SUBQUERY_PROC (xasl_p) && xasl_p->aptr_list != NULL)
     {
-      if (HAVE_SUBQUERY_PROC (xasl_p->aptr_list))
-	{
-	  subquery = json_object ();
-	  qdump_print_stats_json (xasl_p->aptr_list, subquery);
-	  json_object_set_new (proc, "SUBQUERY (uncorrelated)", subquery);
-	}
-      else
+      subquery = json_array ();
+      for (xptr = xasl_p->aptr_list; xptr; xptr = xptr->next)
 	{
 	  qdump_print_stats_json (xasl_p->aptr_list, proc);
+	  temp = json_object ();
+	  qdump_print_stats_json (xptr, temp);
+	  json_array_append_new (subquery, temp);
 	}
+      json_object_set_new (proc, "SUBQUERY (uncorrelated)", subquery);
     }
 
   if (xasl_p->dptr_list != NULL)
     {
-      subquery = json_object ();
-      qdump_print_stats_json (xasl_p->dptr_list, subquery);
+      subquery = json_array ();
+      for (xptr = xasl_p->dptr_list; xptr; xptr = xptr->next)
+	{
+	  temp = json_object ();
+	  qdump_print_stats_json (xptr, temp);
+	  json_array_append_new (subquery, temp);
+	}
       json_object_set_new (proc, "SUBQUERY (correlated)", subquery);
     }
 }
@@ -3174,6 +3180,7 @@ qdump_print_stats_text (FILE * fp, xasl_node * xasl_p, int indent)
 {
   ORDERBY_STATS *ostats;
   GROUPBY_STATS *gstats;
+  xasl_node *xptr;
 
   if (xasl_p == NULL)
     {
@@ -3206,19 +3213,15 @@ qdump_print_stats_text (FILE * fp, xasl_node * xasl_p, int indent)
       break;
 
     case UNION_PROC:
-      fprintf (fp, "UNION\n");
-      qdump_print_stats_text (fp, xasl_p->proc.union_.left, indent);
-      qdump_print_stats_text (fp, xasl_p->proc.union_.right, indent);
-      break;
     case DIFFERENCE_PROC:
-      fprintf (fp, "DIFFERENCE\n");
-      qdump_print_stats_text (fp, xasl_p->proc.union_.left, indent);
-      qdump_print_stats_text (fp, xasl_p->proc.union_.right, indent);
-      break;
     case INTERSECTION_PROC:
-      fprintf (fp, "INTERSECTION\n");
-      qdump_print_stats_text (fp, xasl_p->proc.union_.left, indent);
-      qdump_print_stats_text (fp, xasl_p->proc.union_.right, indent);
+      fprintf (fp, "%s (time: %d, fetch: %lld, ioread: %lld)\n", qdump_xasl_type_string (xasl_p),
+	       TO_MSEC (xasl_p->xasl_stats.elapsed_time), (long long int) xasl_p->xasl_stats.fetches,
+	       (long long int) xasl_p->xasl_stats.ioreads);
+      for (xptr = xasl_p->aptr_list; xptr; xptr = xptr->next)
+	{
+	  qdump_print_stats_text (fp, xptr, indent);
+	}
       break;
 
     case MERGELIST_PROC:
@@ -3318,13 +3321,19 @@ qdump_print_stats_text (FILE * fp, xasl_node * xasl_p, int indent)
 	  fprintf (fp, "%*cSUBQUERY (uncorrelated)\n", indent, ' ');
 	}
 
-      qdump_print_stats_text (fp, xasl_p->aptr_list, indent);
+      for (xptr = xasl_p->aptr_list; xptr; xptr = xptr->next)
+	{
+	  qdump_print_stats_text (fp, xptr, indent);
+	}
     }
 
   if (xasl_p->dptr_list != NULL)
     {
       fprintf (fp, "%*cSUBQUERY (correlated)\n", indent, ' ');
-      qdump_print_stats_text (fp, xasl_p->dptr_list, indent);
+      for (xptr = xasl_p->dptr_list; xptr; xptr = xptr->next)
+	{
+	  qdump_print_stats_text (fp, xptr, indent);
+	}
     }
 }
 #endif /* SERVER_MODE */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25361

There are currently issues with trace statistics. When tracing queries that use UNION, DIFFERENCE, INTERSECTION, and CTE together, the statistical information for the CTE is not output. Additionally, when using UNION-like SQL statements, the trace for the total cost is also not output. In this issue, we have made changes to enable the output of trace for the total cost of UNION-like SQL statements and to ensure that the statistical information for all subqueries bundled under the UNION statement is output.

backport #5200 