### PR TITLE
[CBRD-25503] Added parameter to set ACL per broker

### DIFF
--- a/src/broker/broker_acl.c
+++ b/src/broker/broker_acl.c
@@ -431,15 +431,15 @@ access_control_check_right_internal (T_SHM_APPL_SERVER * shm_as_p, char *dbname,
   int ret_val = -1;
   bool local_ip_flag = false;
 
-  if (address[0] == 127 && address[1] == 0 && address[2] == 0 && address[3] == 1)
-    {
-      local_ip_flag = true;
-    }
-
   // If there is no broker section in the ACL file and acl_broker_allow is ALLOW, access is allowed for all IPs.
   if (num_access_info == 0 && shm_as_p->acl_broker_allow == ALLOW)
     {
       return 0;
+    }
+
+  if (address[0] == 127 && address[1] == 0 && address[2] == 0 && address[3] == 1)
+    {
+      local_ip_flag = true;
     }
 
   address_ptr = strchr (dbname, '@');

--- a/src/broker/broker_acl.c
+++ b/src/broker/broker_acl.c
@@ -436,6 +436,12 @@ access_control_check_right_internal (T_SHM_APPL_SERVER * shm_as_p, char *dbname,
       local_ip_flag = true;
     }
 
+  // If there is no broker section in the ACL file and acl_broker_allow is ALLOW, access is allowed for all IPs.
+  if (num_access_info == 0 && shm_as_p->acl_broker_allow == ALLOW)
+    {
+      return 0;
+    }
+
   address_ptr = strchr (dbname, '@');
   if (address_ptr != NULL)
     {

--- a/src/broker/broker_admin_pub.c
+++ b/src/broker/broker_admin_pub.c
@@ -2740,6 +2740,7 @@ admin_acl_status_cmd (int master_shm_id, const char *broker_name)
 	    }
 
 	  fprintf (stdout, "[%%%s]\n", shm_appl->broker_name);
+	  fprintf (stdout, "ACCESS_CONTROL_BROKER_ALLOW=%s\n", (shm_appl->acl_broker_allow) ? "YES" : "NO");
 
 	  for (j = 0; j < shm_appl->num_access_info; j++)
 	    {

--- a/src/broker/broker_admin_pub.c
+++ b/src/broker/broker_admin_pub.c
@@ -2740,7 +2740,8 @@ admin_acl_status_cmd (int master_shm_id, const char *broker_name)
 	    }
 
 	  fprintf (stdout, "[%%%s]\n", shm_appl->broker_name);
-	  fprintf (stdout, "ACCESS_CONTROL_BROKER_ALLOW=%s\n", (shm_appl->acl_broker_allow) ? "YES" : "NO");
+	  fprintf (stdout, "ACCESS_CONTROL_BEHAVIOR_FOR_EMPTYBROKER=%s\n",
+		   (shm_appl->acl_broker_allow) ? "ALLOW" : "DENY");
 
 	  for (j = 0; j < shm_appl->num_access_info; j++)
 	    {

--- a/src/broker/broker_config.c
+++ b/src/broker/broker_config.c
@@ -140,6 +140,12 @@ static T_CONF_TABLE tbl_on_off[] = {
   {NULL, 0}
 };
 
+static T_CONF_TABLE tbl_yes_no[] = {
+  {"YES", YES},
+  {"NO", NO},
+  {NULL, 0}
+};
+
 static T_CONF_TABLE tbl_sql_log_mode[] = {
   {"ALL", SQL_LOG_MODE_ALL},
   {"ON", SQL_LOG_MODE_ALL},
@@ -231,6 +237,7 @@ const char *broker_keywords[] = {
   "MAX_NUM_APPL_SERVER",
   "MIN_NUM_APPL_SERVER",
   "TIME_TO_KILL",
+  "ACCESS_CONTROL_BROKER_ALLOW",
   "CCI_DEFAULT_AUTOCOMMIT",
   "LONG_QUERY_TIME",
   "LONG_TRANSACTION_TIME",
@@ -842,6 +849,14 @@ broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int
       strncpy_bufsize (time_str, s);
       br_info[num_brs].time_to_kill = (int) ut_time_string_to_sec (time_str, "sec");
       if (br_info[num_brs].time_to_kill < 0)
+	{
+	  errcode = PARAM_BAD_VALUE;
+	  goto conf_error;
+	}
+
+      INI_GETSTR_CHK (s, ini, sec_name, "ACCESS_CONTROL_BROKER_ALLOW", "NO", &lineno);
+      br_info[num_brs].acl_broker_allow = conf_get_value_table_yes_no (s);
+      if (br_info[num_brs].acl_broker_allow < 0)
 	{
 	  errcode = PARAM_BAD_VALUE;
 	  goto conf_error;
@@ -1611,6 +1626,7 @@ broker_config_dump (FILE * fp, const T_BROKER_INFO * br_info, int num_broker, in
 	}
       fprintf (fp, "JOB_QUEUE_SIZE\t\t=%d\n", br_info[i].job_queue_size);
       fprintf (fp, "TIME_TO_KILL\t\t=%d\n", br_info[i].time_to_kill);
+      fprintf (fp, "ACCESS_CONTROL_BROKER_ALLOW\t=%s\n", br_info[i].acl_broker_allow ? "YES" : "NO");
       tmp_str = get_conf_string (br_info[i].access_log, tbl_on_off);
       if (tmp_str)
 	{
@@ -1791,6 +1807,17 @@ int
 conf_get_value_table_on_off (const char *value)
 {
   return (get_conf_value (value, tbl_on_off));
+}
+
+/*
+* conf_get_value_table_yes_no - get value from no/yes table
+*   return: 0, 1 or -1 if fail
+*   value(in):
+*/
+int
+conf_get_value_table_yes_no (const char *value)
+{
+  return (get_conf_value (value, tbl_yes_no));
 }
 
 /*

--- a/src/broker/broker_config.c
+++ b/src/broker/broker_config.c
@@ -140,9 +140,9 @@ static T_CONF_TABLE tbl_on_off[] = {
   {NULL, 0}
 };
 
-static T_CONF_TABLE tbl_yes_no[] = {
-  {"YES", YES},
-  {"NO", NO},
+static T_CONF_TABLE tbl_allow_deny[] = {
+  {"ALLOW", ALLOW},
+  {"DENY", DENY},
   {NULL, 0}
 };
 
@@ -217,6 +217,7 @@ static char *conf_file_loaded[MAX_NUM_OF_CONF_FILE_LOADED];
 const char *broker_keywords[] = {
   "ACCESS_CONTROL",
   "ACCESS_CONTROL_FILE",
+  "ACCESS_CONTROL_BEHAVIOR_FOR_EMPTYBROKER",
   "ADMIN_LOG_FILE",
   "MASTER_SHM_ID",
   "ACCESS_LIST",
@@ -237,7 +238,6 @@ const char *broker_keywords[] = {
   "MAX_NUM_APPL_SERVER",
   "MIN_NUM_APPL_SERVER",
   "TIME_TO_KILL",
-  "ACCESS_CONTROL_BROKER_ALLOW",
   "CCI_DEFAULT_AUTOCOMMIT",
   "LONG_QUERY_TIME",
   "LONG_TRANSACTION_TIME",
@@ -854,8 +854,8 @@ broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int
 	  goto conf_error;
 	}
 
-      INI_GETSTR_CHK (s, ini, sec_name, "ACCESS_CONTROL_BROKER_ALLOW", "NO", &lineno);
-      br_info[num_brs].acl_broker_allow = conf_get_value_table_yes_no (s);
+      INI_GETSTR_CHK (s, ini, sec_name, "ACCESS_CONTROL_BEHAVIOR_FOR_EMPTYBROKER", "DENY", &lineno);
+      br_info[num_brs].acl_broker_allow = conf_get_value_table_allow_deny (s);
       if (br_info[num_brs].acl_broker_allow < 0)
 	{
 	  errcode = PARAM_BAD_VALUE;
@@ -1626,7 +1626,7 @@ broker_config_dump (FILE * fp, const T_BROKER_INFO * br_info, int num_broker, in
 	}
       fprintf (fp, "JOB_QUEUE_SIZE\t\t=%d\n", br_info[i].job_queue_size);
       fprintf (fp, "TIME_TO_KILL\t\t=%d\n", br_info[i].time_to_kill);
-      fprintf (fp, "ACCESS_CONTROL_BROKER_ALLOW\t=%s\n", br_info[i].acl_broker_allow ? "YES" : "NO");
+      fprintf (fp, "ACCESS_CONTROL_BEHAVIOR_FOR_EMPTYBROKER\t=%s\n", br_info[i].acl_broker_allow ? "ALLOW" : "DENY");
       tmp_str = get_conf_string (br_info[i].access_log, tbl_on_off);
       if (tmp_str)
 	{
@@ -1810,14 +1810,14 @@ conf_get_value_table_on_off (const char *value)
 }
 
 /*
-* conf_get_value_table_yes_no - get value from no/yes table
+* conf_get_value_table_allow_deny - get value from allow/deny table
 *   return: 0, 1 or -1 if fail
 *   value(in):
 */
 int
-conf_get_value_table_yes_no (const char *value)
+conf_get_value_table_allow_deny (const char *value)
 {
-  return (get_conf_value (value, tbl_yes_no));
+  return (get_conf_value (value, tbl_allow_deny));
 }
 
 /*

--- a/src/broker/broker_config.h
+++ b/src/broker/broker_config.h
@@ -319,7 +319,7 @@ extern int broker_config_read (const char *conf_file, T_BROKER_INFO * br_info, i
 extern void broker_config_dump (FILE * fp, const T_BROKER_INFO * br_info, int num_broker, int br_shm_id);
 
 extern int conf_get_value_table_on_off (const char *value);
-extern int conf_get_value_table_yes_no (const char *value);
+extern int conf_get_value_table_allow_deny (const char *value);
 extern int conf_get_value_sql_log_mode (const char *value);
 extern int conf_get_value_keep_con (const char *value);
 extern int conf_get_value_access_mode (const char *value);

--- a/src/broker/broker_config.h
+++ b/src/broker/broker_config.h
@@ -309,6 +309,8 @@ struct t_broker_info
   char cgw_link_server_port[CGW_LINK_SERVER_PORT_LEN];
   char cgw_link_odbc_driver_name[CGW_LINK_ODBC_DRIVER_NAME_LEN];
   char cgw_link_connect_url_property[CGW_LINK_CONNECT_URL_PROPERTY_LEN];
+
+  char acl_broker_allow;
 };
 
 extern int broker_config_read (const char *conf_file, T_BROKER_INFO * br_info, int *num_broker, int *br_shm_id,
@@ -317,6 +319,7 @@ extern int broker_config_read (const char *conf_file, T_BROKER_INFO * br_info, i
 extern void broker_config_dump (FILE * fp, const T_BROKER_INFO * br_info, int num_broker, int br_shm_id);
 
 extern int conf_get_value_table_on_off (const char *value);
+extern int conf_get_value_table_yes_no (const char *value);
 extern int conf_get_value_sql_log_mode (const char *value);
 extern int conf_get_value_keep_con (const char *value);
 extern int conf_get_value_access_mode (const char *value);

--- a/src/broker/broker_shm.c
+++ b/src/broker/broker_shm.c
@@ -567,6 +567,8 @@ broker_shm_initialize_shm_as (T_BROKER_INFO * br_info_p, T_SHM_PROXY * shm_proxy
   strcpy (shm_as_p->cgw_link_connect_url_property, br_info_p->cgw_link_connect_url_property);
 #endif
 
+  shm_as_p->acl_broker_allow = br_info_p->acl_broker_allow;
+
   if (shm_as_p->shard_flag == OFF)
     {
       assert (shm_proxy_p == NULL);

--- a/src/broker/broker_shm.h
+++ b/src/broker/broker_shm.h
@@ -639,6 +639,8 @@ struct t_shm_appl_server
   char cgw_link_odbc_driver_name[CGW_LINK_ODBC_DRIVER_NAME_LEN];
   char cgw_link_connect_url_property[CGW_LINK_CONNECT_URL_PROPERTY_LEN];
 
+  char acl_broker_allow;
+
   ACCESS_INFO access_info[ACL_MAX_ITEM_COUNT];
 
   T_MAX_HEAP_NODE job_queue[JOB_QUEUE_MAX_SIZE + 1];

--- a/src/broker/cas.c
+++ b/src/broker/cas.c
@@ -1229,7 +1229,7 @@ cas_main (void)
 
 	    ip_addr = (unsigned char *) (&client_ip_addr);
 
-	    if (shm_appl->access_control && shm_appl->acl_broker_allow == NO)
+	    if (shm_appl->access_control && shm_appl->acl_broker_allow == DENY)
 	      {
 		if (access_control_check_right (shm_appl, db_name, db_user, ip_addr) < 0)
 		  {

--- a/src/broker/cas.c
+++ b/src/broker/cas.c
@@ -1229,7 +1229,7 @@ cas_main (void)
 
 	    ip_addr = (unsigned char *) (&client_ip_addr);
 
-	    if (shm_appl->access_control && shm_appl->acl_broker_allow == DENY)
+	    if (shm_appl->access_control)
 	      {
 		if (access_control_check_right (shm_appl, db_name, db_user, ip_addr) < 0)
 		  {

--- a/src/broker/cas.c
+++ b/src/broker/cas.c
@@ -1229,7 +1229,7 @@ cas_main (void)
 
 	    ip_addr = (unsigned char *) (&client_ip_addr);
 
-	    if (shm_appl->access_control)
+	    if (shm_appl->access_control && shm_appl->acl_broker_allow == NO)
 	      {
 		if (access_control_check_right (shm_appl, db_name, db_user, ip_addr) < 0)
 		  {

--- a/src/broker/cas_common.h
+++ b/src/broker/cas_common.h
@@ -46,6 +46,9 @@
 #define ON	1
 #define OFF	0
 
+#define YES	1
+#define NO	0
+
 #define TRUE	1
 #define FALSE	0
 

--- a/src/broker/cas_common.h
+++ b/src/broker/cas_common.h
@@ -46,8 +46,8 @@
 #define ON	1
 #define OFF	0
 
-#define YES	1
-#define NO	0
+#define ALLOW	1
+#define DENY	0
 
 #define TRUE	1
 #define FALSE	0


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25503

Purpose
Broker 마다 ACL 설정값을 추가하여 ACCESS_CONTROL이 ON 인 경우에도 Broker에 접속하는 Client를 모두 허용하는 방법을 제공할 수있는 Broker parameter를 추가 하였다.

Implementation
* 파라메터 : ACCESS_CONTROL_BROKER_ALLOW
* cubrid broker info 로 파라메터 확인 가능
* cubrid broker acl status로 파라메터 확인 가능
* ACCESS_CONTROL= ON 이고, ACCESS_CONTROL_BEHAVIOR_FOR_EMPTYBROKER=DENY 이면 기존 동작과 동일
* ACCESS_CONTROL= ON 이고, ACCESS_CONTROL_BEHAVIOR_FOR_EMPTYBROKER=ALLOW 이면 ACL File에 Broker section이 없는 경에만 모든 IP 접속 허용

Remarks
