### PR TITLE
[CBRD-25495] change output destination from stdout to fp (file pointer) in heap_classrepr_dump.

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -2825,7 +2825,7 @@ heap_classrepr_dump (THREAD_ENTRY * thread_p, FILE * fp, const OID * class_oid, 
 		{
 		  pr_type->data_readval (&buf, &def_dbvalue, attrepr->domain, disk_length, copy, NULL, 0);
 
-		  db_fprint_value (stdout, &def_dbvalue);
+		  db_fprint_value (fp, &def_dbvalue);
 		  (void) pr_clear_value (&def_dbvalue);
 		}
 	      else


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25495

Purpose
the values are printed to stdout regardless of the use of option '-o'.

Implementation
N/A

Remarks
N/A