### PR TITLE
[CBRD-24046] Result cache for correlated scalar subquery

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -6377,7 +6377,7 @@ SYSPRM_PARAM prm_Def[] = {
    (DUP_PRM_FUNC) NULL},
   {PRM_ID_MAX_SUBQUERY_CACHE_SIZE,
    PRM_NAME_MAX_SUBQUERY_CACHE_SIZE,
-   (PRM_FOR_SERVER | PRM_USER_CHANGE | PRM_SIZE_UNIT | PRM_HIDDEN),
+   (PRM_FOR_SERVER | PRM_USER_CHANGE | PRM_SIZE_UNIT),
    PRM_BIGINT,
    &prm_max_subquery_cache_size_flag,
    (void *) &prm_max_subquery_cache_size_default,


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24046

매뉴얼 수정 과정에서 max_subquery_cache_size 파라미터를 PRM_HIDDEN으로 설정하지 않기로 결정하고, 이 파라미터에 대한 설명을 매뉴얼에 추가하기로 했습니다.