### PR TITLE
[CBRD-25502] page fixed in the function must be unfixed before heap_page_prev ends.

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -18758,6 +18758,7 @@ heap_page_prev (THREAD_ENTRY * thread_p, const OID * class_oid, const HFID * hfi
       if (OID_ISNULL (prev_vpid))
 	{
 	  /* no more pages to scan */
+	  pgbuf_ordered_unfix (thread_p, &pg_watcher);
 	  return S_END;
 	}
       /* get next page */
@@ -18772,7 +18773,6 @@ heap_page_prev (THREAD_ENTRY * thread_p, const OID * class_oid, const HFID * hfi
     }
   if (pg_watcher.pgptr == NULL)
     {
-      pgbuf_ordered_unfix (thread_p, &pg_watcher);
       return S_ERROR;
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25502

Purpose
heap_page_prev 함수 내에서 fix된 페이지는 함수 종료 전에 unfix되어야 한다.
추가적으로 페이지를 fix 했을 때 NULL을 반환 받았다면 unfix를 수행할 필요가 없으므로 코드에서 제거한다.

Implementation
N/A

Remarks
N/A