### PR TITLE
[CBRD-25466] remove backported CBRD-25316 in the 11.2 Patch 9

### DIFF
--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -4377,15 +4377,13 @@ pt_find_aggregate_analytic_post (PARSER_CONTEXT * parser, PT_NODE * tree, void *
  * [Note]
  * This function will search whether an aggregate or analytic function exists
  * in WHERE clause of below statements:
- *     INSERT, UPDATE, DO, SET, DELETE, SELECT, UNION, DIFFERENCE, INTERSECTION, and
+ *     INSERT, DO, SET, DELETE, SELECT, UNION, DIFFERENCE, INTERSECTION, and
  *     MERGE.
  * It stops searching when meets the first aggregate or analytic function.
  *
  * 1) For below node types, searching is limited to child node who containing
- *    SET clause:
- *     PT_UPDATE
  *    WHERE clause:
- *     PT_DO, PT_DELETE, PT_SET_SESSION_VARIABLES, PT_SELECT, PT_UPDATE
+ *     PT_DO, PT_DELETE, PT_SET_SESSION_VARIABLES, PT_SELECT
  *
  * 2) For below node types, searching is executed on its args:
  *     PT_UNION, PT_DIFFERENCE, PT_INTERSECTION
@@ -4449,24 +4447,6 @@ pt_find_aggregate_analytic_in_where (PARSER_CONTEXT * parser, PT_NODE * node)
       /* walk tree to search */
       (void) parser_walk_tree (parser, node, pt_find_aggregate_analytic_pre, &find, pt_find_aggregate_analytic_post,
 			       &find);
-      break;
-
-    case PT_UPDATE:
-      /* For UPDATE JOIN statements, aggregate functions or analytic functions cannot be used
-       * in the SET and WHERE clauses.  Aggregate functions cannot be used in the UPDATE statement,
-       * even if it is not an UPDATE JOIN statement.  Whether aggregate functions are used is checked
-       * in the pt_semantic_check_local function.
-       */
-      if (node->info.update.spec->next != NULL)
-	{
-	  find = pt_find_aggregate_analytic_in_where (parser, node->info.update.assignment);
-	  if (find != NULL)
-	    {
-	      break;
-	    }
-
-	  find = pt_find_aggregate_analytic_in_where (parser, node->info.update.search_cond);
-	}
       break;
 
     default:


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25466

- remove CBRD-25316, which was incorrectly backported in 11.2 Patch 9.
