### PR TITLE
[CBRD-25505] insert ... select .. on duplicate key update query result error with view

### DIFF
--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -2778,7 +2778,7 @@ struct pt_name_info
 #define PT_NAME_INFO_SERVER_SPECIFIED 16384	/* server name is specified for dblink */
 #define PT_NAME_INFO_REFERENCED_AT_ODKU 32768	/* a vclass referenced at "on duplicate key update clause" */
 
-  short flag;
+  int flag;
 #define PT_NAME_INFO_IS_FLAGED(e, f)    ((e)->info.name.flag & (short) (f))
 #define PT_NAME_INFO_SET_FLAG(e, f)     (e)->info.name.flag |= (short) (f)
 #define PT_NAME_INFO_CLEAR_FLAG(e, f)   (e)->info.name.flag &= (short) ~(f)

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -2778,7 +2778,7 @@ struct pt_name_info
 #define PT_NAME_INFO_USER_SPECIFIED 8192	/* resolved_name is added to original_name to make user_specified_name. */
 #define PT_NAME_INFO_SERVER_SPECIFIED 16384	/* server name is specified for dblink */
 
-  int flag;
+  short flag;
 #define PT_NAME_INFO_IS_FLAGED(e, f)    ((e)->info.name.flag & (short) (f))
 #define PT_NAME_INFO_SET_FLAG(e, f)     (e)->info.name.flag |= (short) (f)
 #define PT_NAME_INFO_CLEAR_FLAG(e, f)   (e)->info.name.flag &= (short) ~(f)

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -2776,6 +2776,7 @@ struct pt_name_info
 #define PT_NAME_DEFAULTF_ACCEPTS   4096	/* name of table/column that default function accepts: real table's, cte's */
 #define PT_NAME_INFO_USER_SPECIFIED 8192	/* resolved_name is added to original_name to make user_specified_name. */
 #define PT_NAME_INFO_SERVER_SPECIFIED 16384	/* server name is specified for dblink */
+#define PT_NAME_INFO_REFERENCED_AT_ODKU 32768	/* a vclass referenced at "on duplicate key update clause" */
 
   short flag;
 #define PT_NAME_INFO_IS_FLAGED(e, f)    ((e)->info.name.flag & (short) (f))

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -2779,9 +2779,9 @@ struct pt_name_info
 #define PT_NAME_INFO_REFERENCED_AT_ODKU 32768	/* a vclass referenced at "on duplicate key update clause" */
 
   int flag;
-#define PT_NAME_INFO_IS_FLAGED(e, f)    ((e)->info.name.flag & (short) (f))
-#define PT_NAME_INFO_SET_FLAG(e, f)     (e)->info.name.flag |= (short) (f)
-#define PT_NAME_INFO_CLEAR_FLAG(e, f)   (e)->info.name.flag &= (short) ~(f)
+#define PT_NAME_INFO_IS_FLAGED(e, f)    ((e)->info.name.flag & (int) (f))
+#define PT_NAME_INFO_SET_FLAG(e, f)     (e)->info.name.flag |= (int) (f)
+#define PT_NAME_INFO_CLEAR_FLAG(e, f)   (e)->info.name.flag &= (int) ~(f)
   short location;		/* 0: WHERE; n: join condition of n-th FROM */
   short tag_click_counter;	/* 0: normal name, 1: click counter name */
   PT_NODE *indx_key_limit;	/* key limits for index name */

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -1716,7 +1716,8 @@ typedef enum
   PT_SPEC_FLAG_MVCC_COND_REEV = 0x400,	/* the spec is used in mvcc condition reevaluation */
   PT_SPEC_FLAG_MVCC_ASSIGN_REEV = 0x800,	/* the spec is used in UPDATE assignment reevaluation */
   PT_SPEC_FLAG_DOESNT_HAVE_UNIQUE = 0x1000,	/* the spec was checked and does not have any uniques */
-  PT_SPEC_FLAG_SAMPLING_SCAN = 0x2000	/* spec for sampling scan */
+  PT_SPEC_FLAG_SAMPLING_SCAN = 0x2000,	/* spec for sampling scan */
+  PT_SPEC_FLAG_REFERENCED_AT_ODKU = 0x4000	/* spec for odku assignment */
 } PT_SPEC_FLAG;
 
 typedef enum
@@ -2776,12 +2777,11 @@ struct pt_name_info
 #define PT_NAME_DEFAULTF_ACCEPTS   4096	/* name of table/column that default function accepts: real table's, cte's */
 #define PT_NAME_INFO_USER_SPECIFIED 8192	/* resolved_name is added to original_name to make user_specified_name. */
 #define PT_NAME_INFO_SERVER_SPECIFIED 16384	/* server name is specified for dblink */
-#define PT_NAME_INFO_REFERENCED_AT_ODKU 32768	/* a vclass referenced at "on duplicate key update clause" */
 
   int flag;
-#define PT_NAME_INFO_IS_FLAGED(e, f)    ((e)->info.name.flag & (int) (f))
-#define PT_NAME_INFO_SET_FLAG(e, f)     (e)->info.name.flag |= (int) (f)
-#define PT_NAME_INFO_CLEAR_FLAG(e, f)   (e)->info.name.flag &= (int) ~(f)
+#define PT_NAME_INFO_IS_FLAGED(e, f)    ((e)->info.name.flag & (short) (f))
+#define PT_NAME_INFO_SET_FLAG(e, f)     (e)->info.name.flag |= (short) (f)
+#define PT_NAME_INFO_CLEAR_FLAG(e, f)   (e)->info.name.flag &= (short) ~(f)
   short location;		/* 0: WHERE; n: join condition of n-th FROM */
   short tag_click_counter;	/* 0: normal name, 1: click counter name */
   PT_NODE *indx_key_limit;	/* key limits for index name */

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -186,13 +186,6 @@ enum pushable_type
 };
 typedef enum pushable_type PUSHABLE_TYPE;
 
-typedef struct odku_info ODKU_INFO;
-struct odku_info
-{
-  PT_NODE *sel_spec;
-  bool has_vclass;
-};
-
 static PT_NODE *mq_bump_corr_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *void_arg, int *continue_walk);
 static PT_NODE *mq_bump_corr_post (PARSER_CONTEXT * parser, PT_NODE * node, void *void_arg, int *continue_walk);
 static PT_NODE *mq_union_bump_correlation (PARSER_CONTEXT * parser, PT_NODE * left, PT_NODE * right);

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -1674,7 +1674,7 @@ pt_check_odku_has_vclass (PARSER_CONTEXT * parser, PT_NODE * odku, void *arg, in
 
       if (class_ && mq_translatable_class (parser, class_))
 	{
-	  class_->info.name.flag |= PT_NAME_INFO_REFERENCED_AT_ODKU;
+	  PT_NAME_INFO_SET_FLAG (class_, PT_NAME_INFO_REFERENCED_AT_ODKU);
 	}
     }
 

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -1763,6 +1763,7 @@ mq_is_pushable_subquery (PARSER_CONTEXT * parser, PT_NODE * subquery, PT_NODE * 
       break;
 
     case PT_INSERT:
+      /* since INSERT can not have a spec list or statement conditions, there is nothing to check */
       statement_spec = mainquery->info.insert.spec;
       pred = NULL;
       select_list = NULL;

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -7347,7 +7347,7 @@ static PT_NODE *
 mq_odku_resolve_view_spec (PARSER_CONTEXT * parser, PT_NODE * odku, void *arg, int *continue_walk)
 {
   PT_NODE *sel_spec = (PT_NODE *) arg;
-  PT_NODE *entity, *sel_list = NULL, *subquery;
+  PT_NODE *entity, *subquery, *sel_list = NULL, *class_ = NULL;
 
   *continue_walk = PT_CONTINUE_WALK;
 
@@ -7357,8 +7357,12 @@ mq_odku_resolve_view_spec (PARSER_CONTEXT * parser, PT_NODE * odku, void *arg, i
     }
 
   entity = pt_find_spec (parser, sel_spec, odku);
+  if (entity)
+    {
+      class_ = entity->info.spec.flat_entity_list;
+    }
 
-  if (entity && mq_translatable_class (parser, entity->info.spec.flat_entity_list))
+  if (class_ && mq_translatable_class (parser, class_))
     {
       subquery = mq_fetch_subqueries (parser, entity->info.spec.flat_entity_list);
       if (subquery)

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -394,7 +394,7 @@ static void mq_auto_param_merge_clauses (PARSER_CONTEXT * parser, PT_NODE * stmt
 
 static PT_NODE *pt_check_for_update_subquery (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);
 static PT_NODE *pt_check_odku_refs_pre (PARSER_CONTEXT * parser, PT_NODE * odku, void *arg, int *continue_walk);
-static PT_NODE *pt_check_odku_refs_view (PARSER_CONTEXT * parser, PT_NODE * statement);
+static void pt_check_odku_refs_view (PARSER_CONTEXT * parser, PT_NODE * statement);
 static int pt_check_for_update_clause (PARSER_CONTEXT * parser, PT_NODE * query, bool root);
 
 static int pt_for_update_prepare_query_internal (PARSER_CONTEXT * parser, PT_NODE * query);
@@ -1668,7 +1668,7 @@ pt_check_odku_refs_pre (PARSER_CONTEXT * parser, PT_NODE * odku, void *arg, int 
       return odku;
     }
 
-  for (spec = sel_spec; spec; spec = sel_spec->next)
+  for (spec = sel_spec; spec; spec = spec->next)
     {
       if (spec->info.spec.id == odku->info.name.spec_id)
 	{
@@ -1685,10 +1685,11 @@ pt_check_odku_refs_pre (PARSER_CONTEXT * parser, PT_NODE * odku, void *arg, int 
  * for the view to indicate that it is referenced in odku.
  * This flag will be used when determining "pushable" in mq_is_pushable_subquery.
  */
-static PT_NODE *
+static void
 pt_check_odku_refs_view (PARSER_CONTEXT * parser, PT_NODE * statement)
 {
   PT_NODE *odku = statement->info.insert.odku_assignments;
+
   if (odku)
     {
       PT_NODE *sel_spec, *values;
@@ -1701,10 +1702,11 @@ pt_check_odku_refs_view (PARSER_CONTEXT * parser, PT_NODE * statement)
 	      sel_spec = values->info.query.q.select.from;
 	      while (odku)
 		{
-		  parser_walk_tree (parser, odku->info.expr.arg2, pt_check_odku_refs_pre, sel_spec, NULL, NULL);
+		  (void) parser_walk_tree (parser, odku->info.expr.arg2, pt_check_odku_refs_pre, sel_spec, NULL, NULL);
 		  odku = odku->next;
 		}
 	    }
+
 	  values = values->next;
 	}
     }

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -10198,7 +10198,15 @@ mq_class_lambda (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * class_,
 		}
 	      else
 		{
-		  newspec->info.spec.range_var->info.name.original = spec->info.spec.range_var->info.name.original;
+		  if (newspec->info.spec.entity_name)
+		    {
+		      newspec->info.spec.range_var->info.name.original =
+			newspec->info.spec.entity_name->info.name.original;
+		    }
+		  else
+		    {
+		      newspec->info.spec.range_var->info.name.original = spec->info.spec.range_var->info.name.original;
+		    }
 		}
 
 	      newspec->info.spec.location = spec->info.spec.location;

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -7364,7 +7364,7 @@ mq_odku_resolve_view_spec (PARSER_CONTEXT * parser, PT_NODE * odku, void *arg, i
 
   if (class_ && mq_translatable_class (parser, class_))
     {
-      subquery = mq_fetch_subqueries (parser, entity->info.spec.flat_entity_list);
+      subquery = mq_fetch_subqueries (parser, class_);
       if (subquery)
 	{
 	  sel_list = subquery->info.query.q.select.list;

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -1652,7 +1652,7 @@ mq_substitute_spec_in_method_and_hints (PARSER_CONTEXT * parser, PT_NODE * node,
 }
 
 /*
- * check the name nodes from view spec in "on duplicate key update" cluase
+ * check the name nodes from view spec in "on duplicate key update" clause
  */
 static PT_NODE *
 pt_check_odku_has_vclass (PARSER_CONTEXT * parser, PT_NODE * odku, void *arg, int *continue_walk)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25505

```
create table t(i int, j int, k int);
create unique index u_t_i on t(i);
create unique index u_t_j_k on t(j, k);

create table a(i int, s int);
create table b(i int, s int);

create view v as select a.i, b.s from a left join b on a.i = b.i;

insert into t (j, k) select i, s from v on duplicate key update i = v.s, k = k+1;
```

View를 translate하는 과정에서 아래와 같이 view merging이 되는데, view merging 쿼리에서 on duplicate key update 구문이 잘못 생성되고 있습니다.

`insert into t (j, k) select v.i, b.s from a v left outer join b b on v.i=b.i on duplicate key update t.i=v.s, t.k=t.k+1; `

이 구문은 아래와 같이 머지되지 않도록 생성되어야 합니다.

`insert into t (j, k) select v.i, v.s from (select v.i, b.s from a v left outer join b b on v.i=b.i) v (i, s) on duplicate key update t.i=v.s, t.k=t.k+1;`
