### PR TITLE
[CBRD-25491] Support revive of non-HA cub_server by using auto_restart_server parameter

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -3596,7 +3596,7 @@ SYSPRM_PARAM prm_Def[] = {
    (DUP_PRM_FUNC) NULL},
   {PRM_ID_AUTO_RESTART_SERVER,
    PRM_NAME_AUTO_RESTART_SERVER,
-   (PRM_FOR_SERVER | PRM_USER_CHANGE),
+   (PRM_FOR_CLIENT | PRM_USER_CHANGE),
    PRM_BOOLEAN,
    &prm_auto_restart_server_flag,
    (void *) &prm_auto_restart_server_default,

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -393,7 +393,7 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 	  if (!entry->ha_mode)
 	    {
 #if !defined(WINDOWS)
-	      if (prm_get_bool_value (PRM_ID_AUTO_RESTART_SERVER))
+	      if (auto_Restart_server)
 		{
 		      /* *INDENT-OFF* */
 		      master_Server_monitor->produce_job (server_monitor::job_type::REGISTER_SERVER, proc_register->pid, proc_register->exec_path, proc_register->args, proc_register->server_name);
@@ -1014,7 +1014,7 @@ css_check_master_socket_input (int *count, fd_set * fd_var)
 #endif
 
 #if !defined(WINDOWS)
-		      if (prm_get_bool_value (PRM_ID_AUTO_RESTART_SERVER))
+		      if (auto_Restart_server)
 			{
 			      /* *INDENT-OFF* */
 			      master_Server_monitor->produce_job (server_monitor::job_type::REVIVE_SERVER, -1, "", "", temp->name);
@@ -1222,6 +1222,8 @@ main (int argc, char **argv)
       goto cleanup;
     }
 
+  auto_Restart_server = prm_get_bool_value (PRM_ID_AUTO_RESTART_SERVER);
+
   TPRINTF (msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_MASTER, MASTER_MSG_STARTING), 0);
 
   /* close the message catalog and let the master daemon reopen. */
@@ -1266,7 +1268,7 @@ main (int argc, char **argv)
   // Since master_Server_monitor is module for restarting abnormally terminated cub_server,
   // it is only initialized only when auto_restart_server parameter is set to true.
 
-  if (prm_get_bool_value (PRM_ID_AUTO_RESTART_SERVER))
+  if (auto_Restart_server)
     {
       // *INDENT-OFF*
       master_Server_monitor.reset (new server_monitor ());

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -390,6 +390,11 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 	  if (!entry->ha_mode)
 	    {
               /* *INDENT-OFF* */
+              if (master_Server_monitor == nullptr)
+              {
+                master_Server_monitor.reset (new server_monitor ());
+              }
+              
               master_Server_monitor->make_and_insert_server_entry (proc_register->pid, proc_register->exec_path, proc_register->args, datagram_conn);
               /* *INDENT-ON* */
 	    }
@@ -1244,18 +1249,6 @@ main (int argc, char **argv)
 	  status = EXIT_FAILURE;
 	  goto cleanup;
 	}
-    }
-
-  // TODO : When no non-HA server exists in HA environment, server_monitor should not be initialized.
-  //        In this issue, server_monitor is initialized only when HA is disabled. Once all sub-tasks of
-  //        CBRD-24741 are done, this condition will be removed. And server_monitor will be initialized wh
-  //        en first non-HA server is started in HA environment. (server_monitor will be finalized when last
-  //        non-HA server is stopped in HA environment.)
-  if (HA_DISABLED ())
-    {
-      // *INDENT-OFF*
-      master_Server_monitor.reset (new server_monitor ());
-      // *INDENT-ON*
     }
 #endif
 

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -1264,9 +1264,7 @@ main (int argc, char **argv)
 	}
     }
 
-#if !defined(WINDOWS)
   auto_Restart_server = prm_get_bool_value (PRM_ID_AUTO_RESTART_SERVER);
-#endif
 
   // Since master_Server_monitor is module for restarting abnormally terminated cub_server,
   // it is initialized only when auto_restart_server parameter is set to true.

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -59,6 +59,7 @@
 #include "error_manager.h"
 #include "connection_globals.h"
 #include "connection_cl.h"
+#include "system_parameter.h"
 #if defined(WINDOWS)
 #include "wintcp.h"
 #else /* ! WINDOWS */
@@ -391,9 +392,9 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 	    {
 	      if (prm_get_bool_value (PRM_ID_AUTO_RESTART_SERVER))
 		{
-              /* *INDENT-OFF* */
-              master_Server_monitor->make_and_insert_server_entry (proc_register->pid, proc_register->exec_path, proc_register->args, datagram_conn);
-              /* *INDENT-ON* */
+                /* *INDENT-OFF* */
+                master_Server_monitor->make_and_insert_server_entry (proc_register->pid, proc_register->exec_path, proc_register->args, datagram_conn);
+                /* *INDENT-ON* */
 		}
 	    }
 	}

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -321,7 +321,7 @@ css_accept_server_request (CSS_CONN_ENTRY * conn, int reason)
  *   conn(in)
  *   rid(in)
  *   buffer(in)
- * 
+ *
  */
 static void
 css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
@@ -395,9 +395,10 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 #if !defined(WINDOWS)
 	      if (auto_Restart_server)
 		{
-		      /* *INDENT-OFF* */
-		      master_Server_monitor->produce_job (server_monitor::job_type::REGISTER_SERVER, proc_register->pid, proc_register->exec_path, proc_register->args, proc_register->server_name);
-		      /* *INDENT-ON* */
+		  /* *INDENT-OFF* */
+		  master_Server_monitor->produce_job (server_monitor::job_type::REGISTER_SERVER, proc_register->pid,
+						      proc_register->exec_path, proc_register->args, proc_register->server_name);
+		  /* *INDENT-ON* */
 		}
 #endif
 	    }
@@ -1016,9 +1017,9 @@ css_check_master_socket_input (int *count, fd_set * fd_var)
 #if !defined(WINDOWS)
 		      if (auto_Restart_server)
 			{
-			      /* *INDENT-OFF* */
-			      master_Server_monitor->produce_job (server_monitor::job_type::REVIVE_SERVER, -1, "", "", temp->name);
-			      /* *INDENT-ON* */
+			  /* *INDENT-OFF* */
+			  master_Server_monitor->produce_job (server_monitor::job_type::REVIVE_SERVER, -1, "", "", temp->name);
+			  /* *INDENT-ON* */
 			}
 #endif
 		      css_remove_entry_by_conn (temp->conn_ptr, &css_Master_socket_anchor);
@@ -1222,10 +1223,6 @@ main (int argc, char **argv)
       goto cleanup;
     }
 
-#if !defined(WINDOWS)
-  auto_Restart_server = prm_get_bool_value (PRM_ID_AUTO_RESTART_SERVER);
-#endif
-
   TPRINTF (msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_MASTER, MASTER_MSG_STARTING), 0);
 
   /* close the message catalog and let the master daemon reopen. */
@@ -1267,8 +1264,12 @@ main (int argc, char **argv)
 	}
     }
 
+#if !defined(WINDOWS)
+  auto_Restart_server = prm_get_bool_value (PRM_ID_AUTO_RESTART_SERVER);
+#endif
+
   // Since master_Server_monitor is module for restarting abnormally terminated cub_server,
-  // it is only initialized only when auto_restart_server parameter is set to true.
+  // it is initialized only when auto_restart_server parameter is set to true.
 
   if (auto_Restart_server)
     {

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -392,12 +392,14 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 
 	  if (!entry->ha_mode)
 	    {
+#if !defined(WINDOWS)
 	      if (prm_get_bool_value (PRM_ID_AUTO_RESTART_SERVER))
 		{
-                /* *INDENT-OFF* */
-                master_Server_monitor->produce_job (server_monitor::job_type::REGISTER_SERVER, proc_register->pid, proc_register->exec_path, proc_register->args, proc_register->server_name);
-                /* *INDENT-ON* */
+		      /* *INDENT-OFF* */
+		      master_Server_monitor->produce_job (server_monitor::job_type::REGISTER_SERVER, proc_register->pid, proc_register->exec_path, proc_register->args, proc_register->server_name);
+		      /* *INDENT-ON* */
 		}
+#endif
 	    }
 	}
     }
@@ -1014,9 +1016,9 @@ css_check_master_socket_input (int *count, fd_set * fd_var)
 #if !defined(WINDOWS)
 		      if (prm_get_bool_value (PRM_ID_AUTO_RESTART_SERVER))
 			{
-                        /* *INDENT-OFF* */
-                        master_Server_monitor->produce_job (server_monitor::job_type::REVIVE_SERVER, -1, "", "", temp->name);
-                        /* *INDENT-ON* */
+			      /* *INDENT-OFF* */
+			      master_Server_monitor->produce_job (server_monitor::job_type::REVIVE_SERVER, -1, "", "", temp->name);
+			      /* *INDENT-ON* */
 			}
 #endif
 		      css_remove_entry_by_conn (temp->conn_ptr, &css_Master_socket_anchor);

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -1222,7 +1222,9 @@ main (int argc, char **argv)
       goto cleanup;
     }
 
+#if !defined(WINDOWS)
   auto_Restart_server = prm_get_bool_value (PRM_ID_AUTO_RESTART_SERVER);
+#endif
 
   TPRINTF (msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_MASTER, MASTER_MSG_STARTING), 0);
 

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -1266,8 +1266,8 @@ main (int argc, char **argv)
 
   auto_Restart_server = prm_get_bool_value (PRM_ID_AUTO_RESTART_SERVER);
 
-  // Since master_Server_monitor is module for restarting abnormally terminated cub_server,
-  // it is initialized only when auto_restart_server parameter is set to true.
+  // Since master_Server_monitor is a module for restarting abnormally terminated cub_server,
+  // it is initialized only when the 'auto_restart_server' parameter is set to true.
 
   if (auto_Restart_server)
     {

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -1254,9 +1254,9 @@ main (int argc, char **argv)
 
   if (prm_get_bool_value (PRM_ID_AUTO_RESTART_SERVER))
     {
-       // *INDENT-OFF*
-       master_Server_monitor.reset (new server_monitor ());
-       // *INDENT-ON*
+      // *INDENT-OFF*
+      master_Server_monitor.reset (new server_monitor ());
+      // *INDENT-ON*
     }
 #endif
 

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -389,14 +389,12 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer)
 
 	  if (!entry->ha_mode)
 	    {
+	      if (prm_get_bool_value (PRM_ID_AUTO_RESTART_SERVER))
+		{
               /* *INDENT-OFF* */
-              if (master_Server_monitor == nullptr)
-              {
-                master_Server_monitor.reset (new server_monitor ());
-              }
-              
               master_Server_monitor->make_and_insert_server_entry (proc_register->pid, proc_register->exec_path, proc_register->args, datagram_conn);
               /* *INDENT-ON* */
+		}
 	    }
 	}
     }
@@ -1249,6 +1247,16 @@ main (int argc, char **argv)
 	  status = EXIT_FAILURE;
 	  goto cleanup;
 	}
+    }
+
+  // Since master_Server_monitor is module for restarting abnormally terminated cub_server,
+  // it is only initialized only when auto_restart_server parameter is set to true.
+
+  if (prm_get_bool_value (PRM_ID_AUTO_RESTART_SERVER))
+    {
+       // *INDENT-OFF*
+       master_Server_monitor.reset (new server_monitor ());
+       // *INDENT-ON*
     }
 #endif
 

--- a/src/executables/master_request.c
+++ b/src/executables/master_request.c
@@ -534,9 +534,9 @@ css_process_kill_slave (CSS_CONN_ENTRY * conn, unsigned short request_id, char *
 #if !defined(WINDOWS)
 		  if (auto_Restart_server)
 		    {
-		    /* *INDENT-OFF* */
-		    master_Server_monitor->produce_job (server_monitor::job_type::UNREGISTER_SERVER, -1, "", "", server_name);
-		    /* *INDENT-ON* */
+		      /* *INDENT-OFF* */
+		      master_Server_monitor->produce_job (server_monitor::job_type::UNREGISTER_SERVER, -1, "", "", server_name);
+		      /* *INDENT-ON* */
 		    }
 #endif
 		  css_process_start_shutdown (temp, timeout * 60, buffer);
@@ -726,6 +726,7 @@ css_process_shutdown (char *time_buffer)
       /* INDENT-ON */
     }
 #endif
+
   for (temp = css_Master_socket_anchor; temp; temp = temp->next)
     {
       /* do not send shutdown command to master and connector, only to servers: cause connector crash */

--- a/src/executables/master_request.c
+++ b/src/executables/master_request.c
@@ -532,7 +532,10 @@ css_process_kill_slave (CSS_CONN_ENTRY * conn, unsigned short request_id, char *
 			    msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_MASTER, MASTER_MSG_SERVER_STATUS),
 			    server_name, timeout);
 #if !defined(WINDOWS)
-		  master_Server_monitor->remove_server_entry_by_conn (temp->conn_ptr);
+		  if (prm_get_bool_value (PRM_ID_AUTO_RESTART_SERVER))
+		    {
+		      master_Server_monitor->remove_server_entry_by_conn (temp->conn_ptr);
+		    }
 #endif
 		  css_process_start_shutdown (temp, timeout * 60, buffer);
 		}
@@ -713,7 +716,12 @@ css_process_shutdown (char *time_buffer)
   memset (buffer, 0, sizeof (buffer));
   snprintf (buffer, MASTER_TO_SRV_MSG_SIZE,
 	    msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_MASTER, MASTER_MSG_GOING_DOWN), timeout);
-
+  if (prm_get_bool_value (PRM_ID_AUTO_RESTART_SERVER))
+    {
+      /* INDENT-OFF */
+      master_Server_monitor.reset ();
+      /* INDENT-ON */
+    }
   for (temp = css_Master_socket_anchor; temp; temp = temp->next)
     {
       /* do not send shutdown command to master and connector, only to servers: cause connector crash */
@@ -722,7 +730,10 @@ css_process_shutdown (char *time_buffer)
 	  && !IS_MASTER_CONN_NAME_HA_COPYLOG (temp->name) && !IS_MASTER_CONN_NAME_HA_APPLYLOG (temp->name))
 	{
 #if !defined(WINDOWS)
-	  master_Server_monitor->remove_server_entry_by_conn (temp->conn_ptr);
+	  if (prm_get_bool_value (PRM_ID_AUTO_RESTART_SERVER))
+	    {
+	      //master_Server_monitor->remove_server_entry_by_conn (temp->conn_ptr);
+	    }
 #endif
 	  css_process_start_shutdown (temp, timeout * 60, buffer);
 

--- a/src/executables/master_request.c
+++ b/src/executables/master_request.c
@@ -534,9 +534,9 @@ css_process_kill_slave (CSS_CONN_ENTRY * conn, unsigned short request_id, char *
 #if !defined(WINDOWS)
 		  if (prm_get_bool_value (PRM_ID_AUTO_RESTART_SERVER))
 		    {
-                    /* *INDENT-OFF* */
-                    master_Server_monitor->produce_job (server_monitor::job_type::UNREGISTER_SERVER, -1, "", "", server_name);
-                    /* *INDENT-ON* */
+		    /* *INDENT-OFF* */
+		    master_Server_monitor->produce_job (server_monitor::job_type::UNREGISTER_SERVER, -1, "", "", server_name);
+		    /* *INDENT-ON* */
 		    }
 #endif
 		  css_process_start_shutdown (temp, timeout * 60, buffer);
@@ -718,12 +718,14 @@ css_process_shutdown (char *time_buffer)
   memset (buffer, 0, sizeof (buffer));
   snprintf (buffer, MASTER_TO_SRV_MSG_SIZE,
 	    msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_MASTER, MASTER_MSG_GOING_DOWN), timeout);
+#if !defined(WINDOWS)
   if (prm_get_bool_value (PRM_ID_AUTO_RESTART_SERVER))
     {
       /* INDENT-OFF */
       master_Server_monitor.reset ();
       /* INDENT-ON */
     }
+#endif
   for (temp = css_Master_socket_anchor; temp; temp = temp->next)
     {
       /* do not send shutdown command to master and connector, only to servers: cause connector crash */
@@ -731,15 +733,6 @@ css_process_shutdown (char *time_buffer)
 	  && !IS_MASTER_CONN_NAME_DRIVER (temp->name) && !IS_MASTER_CONN_NAME_HA_SERVER (temp->name)
 	  && !IS_MASTER_CONN_NAME_HA_COPYLOG (temp->name) && !IS_MASTER_CONN_NAME_HA_APPLYLOG (temp->name))
 	{
-#if !defined(WINDOWS)
-	  if (prm_get_bool_value (PRM_ID_AUTO_RESTART_SERVER))
-	    {
-              /* *INDENT-OFF* */
-	      master_Server_monitor->produce_job (server_monitor::job_type::UNREGISTER_SERVER, -1, "", "", temp->name);
-              /* *INDENT-ON* */
-	    }
-
-#endif
 	  css_process_start_shutdown (temp, timeout * 60, buffer);
 
 	  /* wait process terminated */

--- a/src/executables/master_request.c
+++ b/src/executables/master_request.c
@@ -532,7 +532,7 @@ css_process_kill_slave (CSS_CONN_ENTRY * conn, unsigned short request_id, char *
 			    msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_MASTER, MASTER_MSG_SERVER_STATUS),
 			    server_name, timeout);
 #if !defined(WINDOWS)
-		  if (prm_get_bool_value (PRM_ID_AUTO_RESTART_SERVER))
+		  if (auto_Restart_server)
 		    {
 		    /* *INDENT-OFF* */
 		    master_Server_monitor->produce_job (server_monitor::job_type::UNREGISTER_SERVER, -1, "", "", server_name);
@@ -719,7 +719,7 @@ css_process_shutdown (char *time_buffer)
   snprintf (buffer, MASTER_TO_SRV_MSG_SIZE,
 	    msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_MASTER, MASTER_MSG_GOING_DOWN), timeout);
 #if !defined(WINDOWS)
-  if (prm_get_bool_value (PRM_ID_AUTO_RESTART_SERVER))
+  if (auto_Restart_server)
     {
       /* INDENT-OFF */
       master_Server_monitor.reset ();

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -52,7 +52,6 @@ server_monitor::~server_monitor ()
 {
   stop_monitoring_thread ();
 
-  assert (m_server_entry_map.size () == 0);
   fprintf (stdout, "[SERVER_REVIVE_DEBUG] : server_entry_map is deleted. \n");
 
   fflush (stdout);

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -28,7 +28,7 @@
 #include "master_server_monitor.hpp"
 
 std::unique_ptr<server_monitor> master_Server_monitor = nullptr;
-
+bool auto_Restart_server = true;
 
 server_monitor::server_monitor ()
 {

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -28,7 +28,7 @@
 #include "master_server_monitor.hpp"
 
 std::unique_ptr<server_monitor> master_Server_monitor = nullptr;
-bool auto_Restart_server = true;
+bool auto_Restart_server = false;
 
 server_monitor::server_monitor ()
 {

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -168,5 +168,6 @@ class server_monitor
 };
 
 extern std::unique_ptr<server_monitor> master_Server_monitor;
+extern bool auto_Restart_server;
 
 #endif

--- a/src/executables/server.c
+++ b/src/executables/server.c
@@ -219,47 +219,6 @@ crash_handler (int signo, siginfo_t * siginfo, void *dummyp)
     {
       return;
     }
-
-  if (!BO_IS_SERVER_RESTARTED ())
-    {
-      return;
-    }
-
-  pid = fork ();
-  if (pid == 0)
-    {
-      char err_log[PATH_MAX];
-      int ppid;
-      int fd, fd_max;
-
-      fd_max = css_get_max_socket_fds ();
-
-      for (fd = 3; fd < fd_max; fd++)
-	{
-	  close (fd);
-	}
-
-      ppid = getppid ();
-      while (1)
-	{
-	  if (kill (ppid, 0) < 0)
-	    {
-	      break;
-	    }
-	  sleep (1);
-	}
-
-      unmask_signal (signo);
-
-      if (prm_get_string_value (PRM_ID_ER_LOG_FILE) != NULL)
-	{
-	  snprintf (err_log, PATH_MAX, "%s.%d", prm_get_string_value (PRM_ID_ER_LOG_FILE), ppid);
-	  rename (prm_get_string_value (PRM_ID_ER_LOG_FILE), err_log);
-	}
-
-      execl (executable_path, executable_path, database_name, NULL);
-      exit (0);
-    }
 }
 
 #if !defined (NDEBUG)

--- a/src/executables/server.c
+++ b/src/executables/server.c
@@ -220,7 +220,7 @@ crash_handler (int signo, siginfo_t * siginfo, void *dummyp)
       return;
     }
 
-  if (!BO_IS_SERVER_RESTARTED () || !prm_get_bool_value (PRM_ID_AUTO_RESTART_SERVER))
+  if (!BO_IS_SERVER_RESTARTED ())
     {
       return;
     }

--- a/src/executables/server.c
+++ b/src/executables/server.c
@@ -207,8 +207,6 @@ CreateMiniDump (struct _EXCEPTION_POINTERS *pException, char *db_name)
 static void
 crash_handler (int signo, siginfo_t * siginfo, void *dummyp)
 {
-  int pid;
-
   if (signo != SIGABRT && siginfo != NULL && siginfo->si_code <= 0)
     {
       register_fatal_signal_handler (signo);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25491

- Purpose
  - 비정상 종료된 non-HA cub_server는 cub_master의 HA mode 설정과 관계없이 재구동되어야 한다. 현재까지는 HA mode가 disable 된 경우에만 non-HA server를 재구동 시켰다. 또한, 현재는 cub_master가 구동되는 시점에 항상 모듈을 초기화 시키고 있다.
  - 필요에 따라 parameter를 통해 재구동 옵션을 켜고 끌수 있게 하여서 재구동 모듈의 생성을 제어하고자 한다.
- Implementation
  - 기존 `auto_restart_server` parameter 사용 관련 함수 변경
  -  cub_server 재구동에 `auto_restart_server` paratmeter 사용
     -  서버용 파라미터에서 cub_master가 사용하는 파라미터로 변경 (`PRM_FOR_SERVER` -> `PRM_FOR_CLIENT`)
     -  `auto_restart_server` 가 true인 경우에만 모듈 생성/해제 및 job 생성
  - 쓰레드 생성 시점은 기존과 같이 cub_master 구동 시 생성
  - 쓰레드 소멸 시점
     - cub_master shutdown 함수에서 각 cub_server 종료 request 전에 모듈을 해제하여 불필요한 job 생성 방지

