### PR TITLE
[CBRD-25323] Remove unnecessary code

### DIFF
--- a/src/optimizer/query_rewrite.c
+++ b/src/optimizer/query_rewrite.c
@@ -3723,7 +3723,6 @@ qo_reduce_joined_tables_referenced_by_foreign_key (PARSER_CONTEXT * parser, PT_N
 		  || next_pk_spec->info.spec.join_type == PT_JOIN_RIGHT_OUTER
 		  || next_pk_spec->info.spec.join_type == PT_JOIN_FULL_OUTER))
 	    {
-	      assert (false);
 	      continue;		/* give up */
 	    }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25323

이 `assert(false);`는 non-ANSI OUTER JOIN과 ANSI OUTER JOIN 문법에서의 동작 차이를 나중에 다시 확인하기 위해 추가되었습니다. 커밋 전에 제거되었어야 했으나, 이 과정이 누락되었습니다. 두 조인 문법의 차이를 받아들이기로 하여, 이제 해당 코드를 제거합니다.