### PR TITLE
[CBRD-24046] Result cache for correlated scalar subquery

### DIFF
--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -27244,7 +27244,7 @@ pt_prepare_corr_subquery_hash_result_cache (PARSER_CONTEXT * parser, PT_NODE * n
   if (XASL_IS_FLAGED (xasl, XASL_USES_SQ_CACHE))
     {
       /* No need to check twice. */
-      return false;
+      return true;
     }
 
   if (node->info.query.q.select.hint & PT_HINT_NO_SUBQUERY_CACHE)

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -7029,6 +7029,7 @@ pt_make_regu_subquery (PARSER_CONTEXT * parser, XASL_NODE * xasl, const UNBOX un
 	      PT_ERRORm (parser, node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OUT_OF_MEMORY);
 	      regu = NULL;
 	    }
+
 	  if (pt_prepare_corr_subquery_hash_result_cache (parser, (PT_NODE *) node, xasl))
 	    {
 	      XASL_SET_FLAG (xasl, XASL_USES_SQ_CACHE);

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -27590,6 +27590,8 @@ pt_check_corr_subquery_not_cachable_expr (PARSER_CONTEXT * parser, PT_NODE * nod
 	case PT_DRAND:
 	case PT_RANDOM:
 	case PT_DRANDOM:
+	case PT_CURRENT_VALUE:
+	case PT_NEXT_VALUE:
 	  *cachable = false;
 	  *continue_walk = PT_STOP_WALK;
 	  break;

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -7029,6 +7029,10 @@ pt_make_regu_subquery (PARSER_CONTEXT * parser, XASL_NODE * xasl, const UNBOX un
 	      PT_ERRORm (parser, node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OUT_OF_MEMORY);
 	      regu = NULL;
 	    }
+	  if (pt_prepare_corr_subquery_hash_result_cache (parser, (PT_NODE *) node, xasl))
+	    {
+	      XASL_SET_FLAG (xasl, XASL_USES_SQ_CACHE);
+	    }
 	}
       else
 	{
@@ -27236,6 +27240,12 @@ pt_prepare_corr_subquery_hash_result_cache (PARSER_CONTEXT * parser, PT_NODE * n
   SQ_KEY *sq_key_struct;
   QPROC_DB_VALUE_LIST dbv_list;
   bool cachable = true;
+
+  if (XASL_IS_FLAGED (xasl, XASL_USES_SQ_CACHE))
+    {
+      /* No need to check twice. */
+      return false;
+    }
 
   if (node->info.query.q.select.hint & PT_HINT_NO_SUBQUERY_CACHE)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24046

서브 쿼리 내에 Serial 관련 구문이 포함되어 있어도 캐싱을 통해 질의 결과가 잘못 나오지 않도록 수정하였습니다.

아래는 예시입니다.

``` sql
with cte_1 AS 
(select
    distinct (select serial_next_value(serial_no) from tbl_b b where b.cola = a.cola and b.colb = 1) v
    from tbl_a a
    where a.colb = 1
) select /*+ recompile */ count(*) from cte_1;

=== <Result of SELECT Command in Line 1> ===

              count(*)
======================
                     1
-- 결과가 100이여야함.
```

또한 쿼리 재작성으로 인해 서브쿼리가 cast()와 같은 함수에 의해 감싸지더라도 정상적으로 작동하게 수정하였습니다.

아래는 예시입니다.

``` sql
update tbl_i set cola= cola +1 
where colb in (
             select  /*+ recompile */ 
                   distinct (select c.code from tbl_b c where c.cola = b.cola and c.colb = 1) code
             from tbl_a b
             where b.colb = 2
             );

show trace;

rewritten query: 
select [dba.tbl_i],
    class [dba.tbl_i],[dba.tbl_i].cola+1 as [tbl_i.cola] 
from [dba.tbl_i] [dba.tbl_i], 
    (select 
    distinct  cast((select c.code from [dba.tbl_b] c where c.cola=b.cola and c.colb= ?:1 ) as double) 
    from [dba.tbl_a] b 
    where b.colb= ?:0 ) av1861 (av_1) 
where [dba.tbl_i].colb=av1861.av_1
```
