### PR TITLE
[CBRD-24871] add CURRENT_USER keyword into the list of built-in function names

### DIFF
--- a/pl_engine/pl_server/src/main/antlr/PlcParser.g4
+++ b/pl_engine/pl_server/src/main/antlr/PlcParser.g4
@@ -367,6 +367,7 @@ atom
     | record_field                              # field_exp
     | function_call                             # call_exp
     | identifier                                # id_exp
+    | keyword_builtin_func                      # builtin_func
     | case_expression                           # case_exp
     | SQL PERCENT_ROWCOUNT                      # sql_rowcount_exp  // this must go before the cursor_attr_exp line
     | cursor_exp ( PERCENT_ISOPEN | PERCENT_FOUND | PERCENT_NOTFOUND | PERCENT_ROWCOUNT )   # cursor_attr_exp
@@ -389,13 +390,17 @@ func_call_name
 
 func_name
     : identifier
+    | keyword_builtin_func
+    ;
+
+keyword_builtin_func
+    : CURRENT_USER
     | DATE
     | DEFAULT
     | IF
     | INSERT
     | MOD
     | REPLACE
-    | REVERSE
     | TIME
     | TIMESTAMP
     | TRUNCATE
@@ -610,6 +615,7 @@ quoted_string
 identifier
     : REGULAR_ID
     | DELIMITED_ID
+    | REVERSE
     ;
 
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -38,7 +38,6 @@ import com.cubrid.jsp.value.DateTimeParser;
 import com.cubrid.plcsql.compiler.antlrgen.PlcParserBaseVisitor;
 import com.cubrid.plcsql.compiler.ast.*;
 import com.cubrid.plcsql.compiler.error.SemanticError;
-import com.cubrid.plcsql.compiler.error.SyntaxError;
 import com.cubrid.plcsql.compiler.error.UndeclaredId;
 import com.cubrid.plcsql.compiler.serverapi.*;
 import com.cubrid.plcsql.compiler.type.*;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24871

- authid 지정 기능 추가 과정에서 CURRENT_USER keyword 가 추가되면서 built-in 함수 CURRENT_USER 에 대한 호출문에서 문법 에러가 발생하게 되어 수정
  - 수정내용: CURRENT_USER 를 함수 이름으로 인식할 수 있도록 keyword_builtin_func에 추가  
    - keyword_builtin_func : keyword 이면서 built-in 함수 이름이기도 한 이름들 목록 
  - 다음 예제에서 에러가 났었습니다.
     ```
     create or replace procedure t () as
     begin
         dbms_output.put_line(CASE WHEN CURRENT_USER() = CURRENT_USER() THEN 'ok' ELSE 'no' END);
     end;

     ```
- keyword 이면서 built-in 함수 이름이기도 한 id 가 단독으로 사용되었을 때 built-in 함수 호출로 인식해야 하는데 하지 못하던 문제를 수정
  - 수정내용:  keyword_builtin_func 를 atom 아래에 추가
  - 아래와 같은 예제에서 문제가 있었습니다. 
    ```
    create or replace procedure t () as
    begin
        dbms_output.put_line(case isnull(DATE) when 0 then 'ok' when 1 then 'nok' end);
    end;

    ```
