### PR TITLE
[CBRD-25523] PL/CSQL 컴파일러가 SA 모드에서 동작하도록 수정

### DIFF
--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -69,6 +69,7 @@
 #include "compile_context.h"
 #if defined (SA_MODE)
 #include "thread_manager.hpp"
+#include "method_compile.hpp"
 #endif // SA_MODE
 #include "xasl.h"
 #include "lob_locator.hpp"
@@ -11333,6 +11334,17 @@ error:
 
   return rc;
 #else /* CS_MODE */
-  return NO_ERROR;
+  int success = ER_FAILED;
+
+  THREAD_ENTRY *thread_p = enter_server ();
+
+  cubmem::extensible_block ext_blk;
+  success = cubmethod::invoke_compile (*thread_p, compile_request, ext_blk);
+  packing_unpacker unpacker (ext_blk.get_ptr (), ext_blk.get_size ());
+  unpacker.unpack_all (compile_response);
+
+  exit_server (*thread_p);
+
+  return success;
 #endif /* !CS_MODE */
 }

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -11202,21 +11202,14 @@ css_send_error:
 void
 splcsql_transfer_file (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen)
 {
-  packing_unpacker unpacker (request, (size_t) reqlen);
-
+  int error = ER_FAILED;
   PLCSQL_COMPILE_REQUEST compile_request;
 
+  packing_unpacker unpacker (request, (size_t) reqlen);
   unpacker.unpack_all (compile_request);
 
-  cubmethod::runtime_context * ctx = NULL;
-  session_get_method_runtime_context (thread_p, ctx);
-
-  int error = ER_FAILED;
   cubmem::extensible_block ext_blk;
-  if (ctx)
-    {
-      error = cubmethod::invoke_compile (*thread_p, *ctx, compile_request, ext_blk);
-    }
+  error = cubmethod::invoke_compile (*thread_p, compile_request, ext_blk);
 
   // Error code and is_ignored.
   OR_ALIGNED_BUF (3 * OR_INT_SIZE) a_reply;

--- a/src/method/method_compile.hpp
+++ b/src/method/method_compile.hpp
@@ -37,7 +37,7 @@
 namespace cubmethod
 {
 #if defined (SERVER_MODE) || defined (SA_MODE)
-  int invoke_compile (cubthread::entry &thread_ref, runtime_context &ctx, const PLCSQL_COMPILE_REQUEST &compile_request,
+  int invoke_compile (cubthread::entry &thread_ref, const PLCSQL_COMPILE_REQUEST &compile_request,
 		      cubmem::extensible_block &out_blk);
 #endif
 }

--- a/src/sp/jsp_cl.cpp
+++ b/src/sp/jsp_cl.cpp
@@ -601,13 +601,13 @@ jsp_call_stored_procedure (PARSER_CONTEXT *parser, PT_NODE *statement)
 	    }
 	}
 
-      args.push_back (std::ref (*db_value));
-      vc = vc->next;
-
       if (to_break)
 	{
 	  break;
 	}
+
+      args.push_back (std::ref (*db_value));
+      vc = vc->next;
     }
 
   if (pt_has_error (parser))


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25523

- network_interface_cl의 plcsql_transfer_file ()에 SA 모드에 해당하는 로직 추가
- SA 모드에서는 thread_ref.conn_entry에서 session ID를 얻을 수 없으므로, cubemethod::invoke_compile () 함수의 session ID를 얻어오는 부분에 대해서 session_get_session_id () 함수를 통해 SERVER, SA 모드에 대해서 모두 제대로 session ID를 가져올 수 있게 수정