### PR TITLE
[CBRD-25525] Modify cub_vsnprintf() to support vsnprintf() in Windows build

### DIFF
--- a/src/base/porting.c
+++ b/src/base/porting.c
@@ -1476,6 +1476,11 @@ cub_vsnprintf (char *buffer, size_t count, const char *format, va_list argptr)
 {
   int len = _vscprintf_p (format, argptr) + 1;
 
+  if (count == 0)
+    {
+      return (len - 1);
+    }
+
   if (len > (int) count)
     {
       char *cp = (char *) malloc (len);
@@ -1495,7 +1500,7 @@ cub_vsnprintf (char *buffer, size_t count, const char *format, va_list argptr)
       buffer[count - 1] = 0;
 
       free (cp);
-      return (int) count;
+      return (int) len;
     }
 
   return _vsprintf_p (buffer, count, format, argptr);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25525

* vsnprintf() 함수와 윈도우 버전의 cub_vsnprint()의  리턴값이 동일하도록 맞춥니다.
* 윈도우에서도 vsnprintf()가 지원되지만 다른 함수들도 매핑된 함수들을 호출하고 있어 기존 방식을 유지 합니다.