### PR TITLE
[CBRD-25507] PLCSQL Explicit Cursor 쿼리 처리 시 ArrayIndexOutOfBoundsException 발생

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/impl/SUStatement.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/impl/SUStatement.java
@@ -40,7 +40,7 @@ public class SUStatement {
             GET_SCHEMA_INFO = 2,
             GET_AUTOINCREMENT_KEYS = 3;
 
-    private static final int DEFAULT_FETCH_SIZE = 100;
+    private static final int DEFAULT_FETCH_SIZE = 1000;
 
     private int handlerId = -1;
     private int type = NORMAL;

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/impl/SUStatement.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/impl/SUStatement.java
@@ -333,7 +333,7 @@ public class SUStatement {
         /* need not to send fetch request */
         if (fetchedStartCursorPosition >= 0
                 && fetchedStartCursorPosition <= cursorPosition
-                && cursorPosition <= fetchedStartCursorPosition + fetchedTupleNumber) {
+                && cursorPosition < fetchedStartCursorPosition + fetchedTupleNumber) {
             return;
         }
 
@@ -350,6 +350,8 @@ public class SUStatement {
 
         fetchedTupleNumber = fetchInfo.numFetched;
         fetchedStartCursorPosition = fetchInfo.tuples[0].tupleNumber() - 1;
+        cursorPosition =
+                fetchedStartCursorPosition; // update cursorPosition to the fetched start position.
     }
 
     public void moveCursor(int offset, int origin) {
@@ -431,11 +433,17 @@ public class SUStatement {
         SUResultTuple tuple = null;
         Object obj = null;
 
-        if ((tuples == null) || (tuples[cursorPosition - fetchedStartCursorPosition] == null)) {
+        int idx = cursorPosition - fetchedStartCursorPosition;
+        if (idx < 0) {
+            throw CUBRIDServerSideJDBCErrorManager.createCUBRIDException(
+                    CUBRIDServerSideJDBCErrorCode.ER_INVALID_INDEX, null);
+        }
+
+        if ((tuples == null) || (tuples[idx] == null)) {
             return null;
         }
 
-        tuple = tuples[cursorPosition - fetchedStartCursorPosition];
+        tuple = tuples[idx];
         if (tuple.getAttribute(index) == null) {
             // it is error case... but for safe guard
             wasNull = true;

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/impl/SUStatement.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/impl/SUStatement.java
@@ -79,6 +79,7 @@ public class SUStatement {
 
     int fetchedTupleNumber = 0;
     int fetchedStartCursorPosition = -1; /* start pos of fetched buffer */
+    int fetchedEndCursorPosition = 0;
 
     boolean isFetched = false;
 
@@ -333,7 +334,7 @@ public class SUStatement {
         /* need not to send fetch request */
         if (fetchedStartCursorPosition >= 0
                 && fetchedStartCursorPosition <= cursorPosition
-                && cursorPosition < fetchedStartCursorPosition + fetchedTupleNumber) {
+                && cursorPosition < fetchedEndCursorPosition) {
             return;
         }
 
@@ -350,8 +351,10 @@ public class SUStatement {
 
         fetchedTupleNumber = fetchInfo.numFetched;
         fetchedStartCursorPosition = fetchInfo.tuples[0].tupleNumber() - 1;
-        cursorPosition =
-                fetchedStartCursorPosition; // update cursorPosition to the fetched start position.
+        fetchedEndCursorPosition = fetchedStartCursorPosition + fetchedTupleNumber;
+
+        // update cursorPosition to the fetched start position
+        cursorPosition = fetchedStartCursorPosition;
     }
 
     public void moveCursor(int offset, int origin) {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/impl/SUStatement.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/impl/SUStatement.java
@@ -107,7 +107,9 @@ public class SUStatement {
 
         /* init fetch infos */
         fetchSize = DEFAULT_FETCH_SIZE;
-        fetchedStartCursorPosition = cursorPosition = totalTupleNumber = fetchedTupleNumber = fetchedEndCursorPosition = 0;
+        fetchedStartCursorPosition =
+                cursorPosition =
+                        totalTupleNumber = fetchedTupleNumber = fetchedEndCursorPosition = 0;
         fetchDirection = ResultSet.FETCH_FORWARD; // TODO: temporary init to FORWARD
 
         maxFetchSize = 0;
@@ -165,7 +167,9 @@ public class SUStatement {
         setColumnInfo(info.columnInfos);
 
         /* init fetch infos */
-        fetchedStartCursorPosition = cursorPosition = totalTupleNumber = fetchedTupleNumber = fetchedEndCursorPosition = 0;
+        fetchedStartCursorPosition =
+                cursorPosition =
+                        totalTupleNumber = fetchedTupleNumber = fetchedEndCursorPosition = 0;
         fetchDirection = ResultSet.FETCH_FORWARD; // TODO: temporary init to FORWARD
 
         commandType = (byte) info.getResultInfo().stmtType;

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/impl/SUStatement.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/impl/SUStatement.java
@@ -107,7 +107,7 @@ public class SUStatement {
 
         /* init fetch infos */
         fetchSize = DEFAULT_FETCH_SIZE;
-        fetchedStartCursorPosition = cursorPosition = totalTupleNumber = fetchedTupleNumber = 0;
+        fetchedStartCursorPosition = cursorPosition = totalTupleNumber = fetchedTupleNumber = fetchedEndCursorPosition = 0;
         fetchDirection = ResultSet.FETCH_FORWARD; // TODO: temporary init to FORWARD
 
         maxFetchSize = 0;
@@ -165,7 +165,7 @@ public class SUStatement {
         setColumnInfo(info.columnInfos);
 
         /* init fetch infos */
-        fetchedStartCursorPosition = cursorPosition = totalTupleNumber = fetchedTupleNumber = 0;
+        fetchedStartCursorPosition = cursorPosition = totalTupleNumber = fetchedTupleNumber = fetchedEndCursorPosition = 0;
         fetchDirection = ResultSet.FETCH_FORWARD; // TODO: temporary init to FORWARD
 
         commandType = (byte) info.getResultInfo().stmtType;
@@ -253,7 +253,7 @@ public class SUStatement {
         if (firstStmtType == CUBRIDCommandType.CUBRID_STMT_CALL_SP) {
             cursorPosition = 0; // already fetched
             fetchedStartCursorPosition = 0;
-            fetchedTupleNumber = 1;
+            fetchedTupleNumber = fetchedEndCursorPosition = 1;
 
             CallInfo callInfo = executeInfo.callInfo;
             tuples = new SUResultTuple[fetchedTupleNumber];

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -6031,7 +6031,7 @@ SYSPRM_PARAM prm_Def[] = {
    (DUP_PRM_FUNC) NULL},
   {PRM_ID_JAVA_STORED_PROCEDURE_DEBUG,
    PRM_NAME_JAVA_STORED_PROCEDURE_DEBUG,
-   (PRM_FOR_SERVER | PRM_HIDDEN),
+   (PRM_FOR_CLIENT | PRM_FOR_SERVER | PRM_HIDDEN),
    PRM_INTEGER,
    &prm_java_stored_procedure_debug_flag,
    (void *) &prm_java_stored_procedure_debug_default,

--- a/src/method/method_invoke_java.cpp
+++ b/src/method/method_invoke_java.cpp
@@ -463,7 +463,13 @@ namespace cubmethod
     fetch_info info;
 
     SCAN_CODE s_code = S_SUCCESS;
-    int fetch_count = cursor->get_fetch_count ();
+
+    /* Most cases, fetch_count will be the same value
+     * To handle an invalid value of fetch_count is set at `cursor->set_fetch_count (fetch_count);`
+     * Here, I'm going to get the fetch_count from the getter again.
+    */
+    fetch_count = cursor->get_fetch_count ();
+
     int start_index = cursor->get_current_index ();
     while (s_code == S_SUCCESS)
       {

--- a/src/method/method_invoke_java.cpp
+++ b/src/method/method_invoke_java.cpp
@@ -458,18 +458,21 @@ namespace cubmethod
 	cursor->open ();
       }
 
+    cursor->set_fetch_count (fetch_count);
+
     fetch_info info;
-    int i = 0;
+
     SCAN_CODE s_code = S_SUCCESS;
+    int start_index = cursor->get_current_index ();
     while (s_code == S_SUCCESS)
       {
 	s_code = cursor->next_row ();
-	if (s_code == S_END || i > cursor->get_fetch_count ())
+	int tuple_index = cursor->get_current_index ();
+	if (s_code == S_END || tuple_index - start_index >= cursor->get_fetch_count ())
 	  {
 	    break;
 	  }
 
-	int tuple_index = cursor->get_current_index ();
 	std::vector<DB_VALUE> tuple_values = cursor->get_current_tuple ();
 
 	if (cursor->get_is_oid_included())
@@ -483,7 +486,6 @@ namespace cubmethod
 	  {
 	    info.tuples.emplace_back (tuple_index, tuple_values);
 	  }
-	i++;
       }
 
     cubmem::block blk = std::move (mcon_pack_data_block (METHOD_RESPONSE_SUCCESS, info));

--- a/src/method/method_invoke_java.cpp
+++ b/src/method/method_invoke_java.cpp
@@ -463,12 +463,13 @@ namespace cubmethod
     fetch_info info;
 
     SCAN_CODE s_code = S_SUCCESS;
+    int fetch_count = cursor->get_fetch_count ();
     int start_index = cursor->get_current_index ();
     while (s_code == S_SUCCESS)
       {
 	s_code = cursor->next_row ();
 	int tuple_index = cursor->get_current_index ();
-	if (s_code == S_END || tuple_index - start_index >= cursor->get_fetch_count ())
+	if (s_code == S_END || tuple_index - start_index >= fetch_count)
 	  {
 	    break;
 	  }

--- a/src/method/method_query_cursor.cpp
+++ b/src/method/method_query_cursor.cpp
@@ -246,4 +246,10 @@ namespace cubmethod
   {
     return m_fetch_count;
   }
+
+  void
+  query_cursor::set_fetch_count (int cnt)
+  {
+    m_fetch_count = cnt;
+  }
 }

--- a/src/method/method_query_cursor.cpp
+++ b/src/method/method_query_cursor.cpp
@@ -250,6 +250,9 @@ namespace cubmethod
   void
   query_cursor::set_fetch_count (int cnt)
   {
-    m_fetch_count = cnt;
+    if (cnt > 0 && cnt < INT32_MAX) // check invalid value
+      {
+	m_fetch_count = cnt;
+      }
   }
 }

--- a/src/method/method_query_cursor.hpp
+++ b/src/method/method_query_cursor.hpp
@@ -68,7 +68,9 @@ namespace cubmethod
       int get_tuple_value (int index, DB_VALUE &result);
       bool get_is_oid_included ();
       bool get_is_opened ();
+
       int get_fetch_count ();
+      void set_fetch_count (int cnt);
 
     private:
       cubthread::entry *m_thread; /* which thread owns this cursor */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25507

- `fetch_count` 를 변경 가능하도록 수정 (디버깅 용도)
- 무의미하게 정의되어 있던 DEFAULT_FETCH_SIZE를 기존 동작과 같이 1000으로 변경한 후, 이 값으로 동작하도록 변경
- 서버측 JDBC의 fetch () 함수 문제 수정
    - 현재 읽고 있는 커서의 인덱스에서 첫번째 인덱스의 차이가 음수인 경우 시스템 에러를 발생하도록 수정
    - 서버측 JDBC의 fetch () 에서 서버 통신으로 row들을 가져온 경우 첫번째 인덱스 (`fetchedStartCursorPosition`)와 읽어야할 인덱스 (`cursorPosition`)가 동일한 값을 가지도록 수정
    - 잘못된 fetch request 조건 수정 (`cursorPosition < fetchedStartCursorPosition + fetchedTupleNumber`)