### PR TITLE
[CBRD-25461] Modify diagdb utility to additionally display volume creation

### DIFF
--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -3034,15 +3034,11 @@ disk_volume_header_end_scan (THREAD_ENTRY * thread_p, void **ptr)
 static void
 disk_vhdr_dump (FILE * fp, const DISK_VOLUME_HEADER * vhdr)
 {
-  time_t db_creation_time;
-  time_t vol_creation_time;
   char db_creation_time_val[CTIME_MAX];
   char vol_creation_time_val[CTIME_MAX];
 
-  db_creation_time = (time_t) vhdr->db_creation;
-  vol_creation_time = (time_t) vhdr->vol_creation;
-  (void) ctime_r (&db_creation_time, db_creation_time_val);
-  (void) ctime_r (&vol_creation_time, vol_creation_time_val);
+  (void) ctime_r ((time_t *) & vhdr->db_creation, db_creation_time_val);
+  (void) ctime_r ((time_t *) & vhdr->vol_creation, vol_creation_time_val);
 
   (void) fprintf (fp, " MAGIC SYMBOL = %s at disk location = %lld\n", vhdr->magic,
 		  offsetof (FILEIO_PAGE, page) + (long long) offsetof (DISK_VOLUME_HEADER, magic));

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -3034,8 +3034,15 @@ disk_volume_header_end_scan (THREAD_ENTRY * thread_p, void **ptr)
 static void
 disk_vhdr_dump (FILE * fp, const DISK_VOLUME_HEADER * vhdr)
 {
-  char time_val[CTIME_MAX];
-  time_t tmp_time;
+  time_t db_creation_time;
+  time_t vol_creation_time;
+  char db_creation_time_val[CTIME_MAX];
+  char vol_creation_time_val[CTIME_MAX];
+
+  db_creation_time = (time_t) vhdr->db_creation;
+  vol_creation_time = (time_t) vhdr->vol_creation;
+  (void) ctime_r (&db_creation_time, db_creation_time_val);
+  (void) ctime_r (&vol_creation_time, vol_creation_time_val);
 
   (void) fprintf (fp, " MAGIC SYMBOL = %s at disk location = %lld\n", vhdr->magic,
 		  offsetof (FILEIO_PAGE, page) + (long long) offsetof (DISK_VOLUME_HEADER, magic));
@@ -3052,9 +3059,9 @@ disk_vhdr_dump (FILE * fp, const DISK_VOLUME_HEADER * vhdr)
   (void) fprintf (fp, " SECTOR TABLE:    SIZE IN PAGES = %10d, FIRST_PAGE = %5d\n", vhdr->stab_npages,
 		  vhdr->stab_first_page);
 
-  tmp_time = (time_t) vhdr->db_creation;
-  (void) ctime_r (&tmp_time, time_val);
-  (void) fprintf (fp, " Database creation time = %s\n Lowest Checkpoint for recovery = %lld|%lld\n", time_val,
+  (void) fprintf (fp, " Database creation time = %s", db_creation_time_val);
+  (void) fprintf (fp, " Volume creation time = %s", vol_creation_time_val);
+  (void) fprintf (fp, " Lowest Checkpoint for recovery = %lld|%lld\n",
 		  (long long) vhdr->chkpt_lsa.pageid, (long long) vhdr->chkpt_lsa.offset);
   (void) fprintf (fp, "Boot_hfid: volid %d, fileid %d header_pageid %d\n", vhdr->boot_hfid.vfid.volid,
 		  vhdr->boot_hfid.vfid.fileid, vhdr->boot_hfid.hpgid);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -6216,24 +6216,30 @@ log_dump_data (THREAD_ENTRY * thread_p, FILE * out_fp, int length, LOG_LSA * log
 static void
 log_dump_header (FILE * out_fp, LOG_HEADER * log_header_p)
 {
-  time_t tmp_time;
-  char time_val[CTIME_MAX];
+  time_t db_creation_time;
+  time_t vol_creation_time;
+  char db_creation_time_val[CTIME_MAX];
+  char vol_creation_time_val[CTIME_MAX];
 
   fprintf (out_fp, "\n ** DUMP LOG HEADER **\n");
 
-  tmp_time = (time_t) log_header_p->db_creation;
-  (void) ctime_r (&tmp_time, time_val);
+  db_creation_time = (time_t) log_header_p->db_creation;
+  (void) ctime_r (&db_creation_time, db_creation_time_val);
+
+  vol_creation_time = (time_t) log_header_p->vol_creation;
+  (void) ctime_r (&vol_creation_time, vol_creation_time_val);
   fprintf (out_fp,
-	   "HDR: Magic Symbol = %s at disk location = %lld\n     Creation_time = %s"
+	   "HDR: Magic Symbol = %s at disk location = %lld\n"
+	   "     Db_creation_time = %s     Vol_creation_time = %s"
 	   "     Release = %s, Compatibility_disk_version = %g,\n"
 	   "     Db_pagesize = %d, log_pagesize= %d, Shutdown = %d,\n"
 	   "     Next_trid = %d, Next_mvcc_id = %llu, Num_avg_trans = %d, Num_avg_locks = %d,\n"
 	   "     Num_active_log_pages = %d, First_active_log_page = %lld,\n"
 	   "     Current_append = %lld|%d, Checkpoint = %lld|%d,\n", log_header_p->magic,
-	   (long long) offsetof (LOG_PAGE, area), time_val, log_header_p->db_release, log_header_p->db_compatibility,
-	   log_header_p->db_iopagesize, log_header_p->db_logpagesize, log_header_p->is_shutdown,
-	   log_header_p->next_trid, (long long int) log_header_p->mvcc_next_id, log_header_p->avg_ntrans,
-	   log_header_p->avg_nlocks, log_header_p->npages, (long long) log_header_p->fpageid,
+	   (long long) offsetof (LOG_PAGE, area), db_creation_time_val, vol_creation_time_val, log_header_p->db_release,
+	   log_header_p->db_compatibility, log_header_p->db_iopagesize, log_header_p->db_logpagesize,
+	   log_header_p->is_shutdown, log_header_p->next_trid, (long long int) log_header_p->mvcc_next_id,
+	   log_header_p->avg_ntrans, log_header_p->avg_nlocks, log_header_p->npages, (long long) log_header_p->fpageid,
 	   LSA_AS_ARGS (&log_header_p->append_lsa), LSA_AS_ARGS (&log_header_p->chkpt_lsa));
 
   fprintf (out_fp,

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -6216,21 +6216,18 @@ log_dump_data (THREAD_ENTRY * thread_p, FILE * out_fp, int length, LOG_LSA * log
 static void
 log_dump_header (FILE * out_fp, LOG_HEADER * log_header_p)
 {
-  time_t db_creation_time;
-  time_t vol_creation_time;
   char db_creation_time_val[CTIME_MAX];
   char vol_creation_time_val[CTIME_MAX];
 
+  (void) ctime_r ((time_t *) & log_header_p->db_creation, db_creation_time_val);
+  (void) ctime_r ((time_t *) & log_header_p->vol_creation, vol_creation_time_val);
+
   fprintf (out_fp, "\n ** DUMP LOG HEADER **\n");
 
-  db_creation_time = (time_t) log_header_p->db_creation;
-  (void) ctime_r (&db_creation_time, db_creation_time_val);
-
-  vol_creation_time = (time_t) log_header_p->vol_creation;
-  (void) ctime_r (&vol_creation_time, vol_creation_time_val);
   fprintf (out_fp,
 	   "HDR: Magic Symbol = %s at disk location = %lld\n"
-	   "     Db_creation_time = %s     Vol_creation_time = %s"
+	   "     Db_creation_time = %s"
+	   "     Vol_creation_time = %s"
 	   "     Release = %s, Compatibility_disk_version = %g,\n"
 	   "     Db_pagesize = %d, log_pagesize= %d, Shutdown = %d,\n"
 	   "     Next_trid = %d, Next_mvcc_id = %llu, Num_avg_trans = %d, Num_avg_locks = %d,\n"


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25461

### **_Purpose_**
디스크 볼륨 헤더, 활성로그볼륨, 보관로그볼륨에 각 볼륨들의 생성시간을 의미하는 vol_creation 정보가 추가됨에따라

데이터베이스 내부 정보를 확인할 수 있는 diagdb 유틸리티에서 vol_creation 정보를 추가로 출력하도록 수정해야합니다.

vol_creation 추가와 관련된 이슈
http://jira.cubrid.org/browse/CBRD-25365
 

현재 diagdb 유틸리티 사용 시 데이터볼륨 헤더 정보를 확인할 수 있는데 
데이터베이스의 생성시간을 아래와 같이 Database creation time으로 출력하고 있습니다.

```
$cubrid diagdb -d -1 -o diag.txt testdb

$cat diag.txt | grep "Database creation time"
 Database creation time = Mon Aug 12 20:46:32 2024
 Database creation time = Mon Aug 12 20:46:32 2024
 Database creation time = Mon Aug 12 20:46:32 2024
 Database creation time = Mon Aug 12 20:46:32 2024
```

또한 diagdb 유틸리티 사용 시 로그 헤더 정보도 확인 할 수 있는데 이 때 데이터베이스 생성시간인 Creation_time을 아래와 같이 출력하고 있습니다.

```
$cat diag.txt | grep "Creation_time" 
     Creation_time = Mon Aug 12 20:46:32 2024
```
 

새롭게 추가된 정보인 볼륨 생성시간을 출력에 포함시키고, 데이터베이스 생성시간과 볼륨 생성시간을 구분짓기 위해 다음 작업을 진행합니다.

---
### **_Implementation_**

- diagdb 유틸리티에서 데이터볼륨의 생성시간을 추가로 출력하도록 수정 (disk_vhdr_dump)
  - time 값을 담는 변수를 추가로 생성하여 볼륨생성시간을 저장 후 출력하도록 구현
    - time_t db_creation_time;
    - time_t vol_creation_time;
    - char db_creation_time_val[CTIME_MAX];
    - char vol_creation_time_val[CTIME_MAX];
- diagdb 유틸리티에서 활성로그볼륨의 생성시간을 추가로 출력하도록 수정 (log_dump_header)
  - time 값을 담는 변수를 추가로 생성하여 볼륨생성시간을 저장 후 출력하도록 구현
    - time_t db_creation_time;
    - time_t vol_creation_time;
    - char db_creation_time_val[CTIME_MAX];
    - char vol_creation_time_val[CTIME_MAX];
---
### **_Remarks_**

- N/A