### PR TITLE
[CBRD-25462] Modify the applyinfo utility to print the volume creation time.

### DIFF
--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -7129,19 +7129,27 @@ void
 la_print_log_header (const char *database_name, LOG_HEADER * hdr, bool verbose)
 {
   time_t tloc;
+  time_t db_creation_time;
+  time_t vol_creation_time;
   DB_DATETIME datetime;
   char timebuf[1024];
+  char db_creation_time_buf[1024];
+  char vol_creation_time_buf[1024];
 
-  tloc = hdr->db_creation;
-  db_localdatetime (&tloc, &datetime);
-  db_datetime_to_string ((char *) timebuf, 1024, &datetime);
+  db_creation_time = hdr->db_creation;
+  db_localdatetime (&db_creation_time, &datetime);
+  db_datetime_to_string ((char *) db_creation_time_buf, 1024, &datetime);
 
+  vol_creation_time = hdr->vol_creation;
+  db_localdatetime (&vol_creation_time, &datetime);
+  db_datetime_to_string ((char *) vol_creation_time_buf, 1024, &datetime);
   if (verbose)
     {
       printf ("%-30s : %s\n", "Magic", hdr->magic);
     }
   printf ("%-30s : %s\n", "DB name", database_name);
-  printf ("%-30s : %s (%ld)\n", "DB creation time", timebuf, tloc);
+  printf ("%-30s : %s (%ld)\n", "DB creation time", db_creation_time_buf, db_creation_time);
+  printf ("%-30s : %s (%ld)\n", "Vol creation time", vol_creation_time_buf, vol_creation_time);
   printf ("%-30s : %lld | %d\n", "EOF LSA", (long long int) hdr->eof_lsa.pageid, (int) hdr->eof_lsa.offset);
   printf ("%-30s : %lld | %d\n", "Append LSA", (long long int) hdr->append_lsa.pageid, (int) hdr->append_lsa.offset);
   printf ("%-30s : %s\n", "HA server state", css_ha_server_state_string ((HA_SERVER_STATE) hdr->ha_server_state));
@@ -7186,16 +7194,23 @@ la_print_log_header (const char *database_name, LOG_HEADER * hdr, bool verbose)
 void
 la_print_log_arv_header (const char *database_name, LOG_ARV_HEADER * hdr, bool verbose)
 {
-  time_t tloc;
+  time_t db_creation_time;
+  time_t vol_creation_time;
   DB_DATETIME datetime;
-  char timebuf[1024];
+  char db_creation_time_buf[1024];
+  char vol_creation_time_buf[1024];
 
-  tloc = hdr->db_creation;
-  db_localdatetime (&tloc, &datetime);
-  db_datetime_to_string ((char *) timebuf, 1024, &datetime);
+  db_creation_time = hdr->db_creation;
+  db_localdatetime (&db_creation_time, &datetime);
+  db_datetime_to_string ((char *) db_creation_time_buf, 1024, &datetime);
+
+  vol_creation_time = hdr->vol_creation;
+  db_localdatetime (&vol_creation_time, &datetime);
+  db_datetime_to_string ((char *) vol_creation_time_buf, 1024, &datetime);
 
   printf ("%-30s : %s\n", "DB name ", database_name);
-  printf ("%-30s : %s (%ld)\n", "DB creation time ", timebuf, tloc);
+  printf ("%-30s : %s (%ld)\n", "DB creation time", db_creation_time_buf, db_creation_time);
+  printf ("%-30s : %s (%ld)\n", "Vol creation time", vol_creation_time_buf, vol_creation_time);
   if (verbose)
     {
       printf ("%-30s : %d\n", "Next transaction identifier", hdr->next_trid);

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -7129,12 +7129,10 @@ void
 la_print_log_header (const char *database_name, LOG_HEADER * hdr, bool verbose)
 {
   time_t tloc;
-  time_t db_creation_time;
-  time_t vol_creation_time;
+  time_t db_creation_time, vol_creation_time;
   DB_DATETIME datetime;
   char timebuf[1024];
-  char db_creation_time_buf[1024];
-  char vol_creation_time_buf[1024];
+  char db_creation_time_buf[1024], vol_creation_time_buf[1024];
 
   db_creation_time = hdr->db_creation;
   db_localdatetime (&db_creation_time, &datetime);
@@ -7143,6 +7141,7 @@ la_print_log_header (const char *database_name, LOG_HEADER * hdr, bool verbose)
   vol_creation_time = hdr->vol_creation;
   db_localdatetime (&vol_creation_time, &datetime);
   db_datetime_to_string ((char *) vol_creation_time_buf, 1024, &datetime);
+
   if (verbose)
     {
       printf ("%-30s : %s\n", "Magic", hdr->magic);
@@ -7194,11 +7193,9 @@ la_print_log_header (const char *database_name, LOG_HEADER * hdr, bool verbose)
 void
 la_print_log_arv_header (const char *database_name, LOG_ARV_HEADER * hdr, bool verbose)
 {
-  time_t db_creation_time;
-  time_t vol_creation_time;
+  time_t db_creation_time, vol_creation_time;
   DB_DATETIME datetime;
-  char db_creation_time_buf[1024];
-  char vol_creation_time_buf[1024];
+  char db_creation_time_buf[1024], vol_creation_time_buf[1024];
 
   db_creation_time = hdr->db_creation;
   db_localdatetime (&db_creation_time, &datetime);
@@ -7211,6 +7208,7 @@ la_print_log_arv_header (const char *database_name, LOG_ARV_HEADER * hdr, bool v
   printf ("%-30s : %s\n", "DB name ", database_name);
   printf ("%-30s : %s (%ld)\n", "DB creation time", db_creation_time_buf, db_creation_time);
   printf ("%-30s : %s (%ld)\n", "Vol creation time", vol_creation_time_buf, vol_creation_time);
+
   if (verbose)
     {
       printf ("%-30s : %d\n", "Next transaction identifier", hdr->next_trid);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25462

### **_Purpose_**
로그 볼륨 헤더에 볼륨 생성시간(Vol creation time) 정보가 추가됨에 따라

HA환경에서 활성로그볼륨과 보관로그볼륨 정보를 출력하는

applyinfo 유틸리티 또한 볼륨 생성시간(Vol creation time) 정보를 추가로 출력하도록 수정해야합니다.

vol_creation 추가와 관련된 이슈
http://jira.cubrid.org/browse/CBRD-25365
 
---
### **_Implementation_**

- applyinfo 유틸리티에서 활성로그볼륨의 생성시간을 추가로 출력하도록 수정 (la_print_log_header)
  - time 값을 담는 변수를 추가로 생성하여 볼륨생성시간을 저장 후 출력하도록 구현
    - time_t db_creation_time;
    - time_t vol_creation_time;
    - char db_creation_time_buf[1024];
    - char vol_creation_time_buf[1024];
- applyinfo 유틸리티에서 보관로그볼륨의 생성시간을 추가로 출력하도록 수정 (la_print_log_arv_header)
  - time 값을 담는 변수를 추가로 생성하여 볼륨생성시간을 저장 후 출력하도록 구현
    - time_t db_creation_time;
    - time_t vol_creation_time;
    - char db_creation_time_buf[1024];
    - char vol_creation_time_buf[1024];
---
### **_Remarks_**

- N/A