### PR TITLE
[CBRD-25473] slip: processing host variable for subquery

### DIFF
--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -3613,6 +3613,8 @@ do_prepare_subquery_pre (PARSER_CONTEXT * parser, PT_NODE * stmt, void *arg, int
 	}
     }
 
+  return stmt;
+
 stop_walk:
   *continue_walk = PT_STOP_WALK;
   return stmt;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25473

develop 브랜치와 머지 중, 실수로 1개의 라인이 삭제가 되었습니다.