### PR TITLE
[CBRD-25296] take enum type as an unsupported type rather than an unused type

### DIFF
--- a/src/method/method_invoke_group.cpp
+++ b/src/method/method_invoke_group.cpp
@@ -236,6 +236,7 @@ namespace cubmethod
       case DB_TYPE_DATETIMETZ:
       case DB_TYPE_DATETIMELTZ:
       case DB_TYPE_JSON:
+      case DB_TYPE_ENUMERATION:
 	res = false;
 	break;
 
@@ -248,7 +249,6 @@ namespace cubmethod
       case DB_TYPE_VOBJ:
       case DB_TYPE_DB_VALUE:
       case DB_TYPE_MIDXKEY:
-      case DB_TYPE_ENUMERATION:
       default:
 	assert (false);
 	break;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25296

다음 예제는 현재 develop 브랜치 (8ca9ac33ed9) 에서 서버쪽 assertion fail 을 일으킨다. 
```
create or replace function poo(c char) return char as
begin
    return null;
end;

drop table if exists enum_tbl;
CREATE TABLE enum_tbl (
    color ENUM ('red', 'yellow', 'blue', 'green')
);
INSERT INTO enum_tbl (color) VALUES ('yellow');

select poo(color) from enum_tbl;
```
cub_server: /home/cubrid/cubrid/src/method/method_invoke_group.cpp:253: bool cubmethod::method_invoke_group::is_supported_dbtype(const DB_VALUE&): Assertion `false' failed.

assertion 위치를 살펴보면 ENUM 타입이 서버가 sp 인자 타입에서 볼 수 없는 타입으로 분류되어 있는 것을 알 수 있는데, 
위 예제에서 알 수 있듯이 사실이 아니다. 
ENUM 타입을 지원하지 않는 타입 쪽으로 옮겨 놓을 필요가 있다. 

옮긴 후 위 예제를 다시 실행해보면 정상 동작함(ENUM 타입에 대한 에러 메시지)을 확인할 수 있다. 
