### PR TITLE
[CBRD-25473] rev: subquery cache is incorrect in prepare statement

### DIFF
--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -3560,13 +3560,7 @@ do_prepare_subquery_pre (PARSER_CONTEXT * parser, PT_NODE * stmt, void *arg, int
     case PT_UNION:
     case PT_INTERSECTION:
     case PT_DIFFERENCE:
-      (void *) parser_walk_tree (parser, stmt->info.query.q.union_.arg1, do_prepare_subquery_pre, err, NULL, NULL);
-      if (*err != NO_ERROR)
-	{
-	  goto stop_walk;
-	}
-      (void *) parser_walk_tree (parser, stmt->info.query.q.union_.arg2, do_prepare_subquery_pre, err, NULL, NULL);
-      goto stop_walk;
+      return stmt;
 
     case PT_CREATE_TRIGGER:
     case PT_ALTER:
@@ -3586,7 +3580,8 @@ do_prepare_subquery_pre (PARSER_CONTEXT * parser, PT_NODE * stmt, void *arg, int
       return stmt;
     }
 
-  if ((stmt->info.query.is_subquery == PT_IS_SUBQUERY || stmt->info.query.is_subquery == PT_IS_UNION_SUBQUERY
+  if ((stmt->info.query.is_subquery == PT_IS_SUBQUERY || stmt->info.query.is_subquery == PT_IS_UNION_QUERY
+       || stmt->info.query.is_subquery == PT_IS_UNION_SUBQUERY
        || stmt->info.query.is_subquery == PT_IS_CTE_NON_REC_SUBQUERY) && stmt->info.query.correlation_level == 0
       && (stmt->info.query.hint & PT_HINT_QUERY_CACHE))
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25473

1) CTE 쿼리에 UNION 형태의 쿼리가 포함되어 있을 경우, 모든 UNION 서브쿼리가 캐시로 처리되어야 하는데, 일부만 처리되고 나머지는 캐시가 되지 않습니다.

2) CTE쿼리가 아닌 일반 UNION형태의 쿼리에서 서브쿼리가 캐시로 처리되어야 하는데, 처리가 되지 않습니다.

==> 수정 포인트

1) UNION / INTERSECTION / DEIFFERENCE에 대해 parser_walk_tree에서 STOP WALK하는 부분을 return stmt로 수정해야 합니다.

2) PT_IS_UNION_SUBQUERY 뿐만 아니라 PT_IS_UNION_QUERY도 포함해야 합니다.

```
create table tbl_a (cola int, colb int, colc int, cold int);
insert into tbl_a select ROWNUM, ROWNUM % 10, ROWNUM % 100, ROWNUM % 1000 
		from db_class a, db_class b, db_class c limit 10000;
create table tbl_b(cola int, colb int);
insert into tbl_b values(10,20),(11, 21),(12,22),(13,22),(14,23),(15,24),(16,6),(17,7),(18,8),(19,9);
```
위 스키마 환경에서 아래의 쿼리가 정상적으로 캐시가 되어야 합니다.
```
select /*+ query_cache */ * 
from (
        select /*+ query_cache */ cola, colb from tbl_a where cola > 10
    ) limit 2 
union 
select /*+ query_cache */ cola, colb from tbl_b where cola > 100;
```
캐시된 쿼리는 아래와 같이 2개입니다.

```
select /*+ query_cache */ * 
from (
        select /*+ query_cache */ cola, colb from tbl_a where cola > 10
    ) limit 2 
```

```
select /*+ query_cache */ cola, colb from tbl_b where cola > 100;
```

또한 아래의 CTE union 쿼리도 2개의 서브 쿼리가 캐시 되어야 합니다.

```
with ctea as (
select /*+ query_cache */ count(*) from tbl_a where colb = 8 
union
select /*+ query_cache */ count(*) from tbl_a where colb = 3),
cteb as (
select /*+ query_cache */ count(*) from tbl_a where colb = 8
union all
select /*+ query_cache */ count(*) from tbl_a where colb = 3),
ctec as (
select /*+ query_cache */ count(*) from tbl_a where colb = 8
intersect
select /*+ query_cache */ count(*) from tbl_a where colb = 3),
cted as (
select /*+ query_cache */ count(*) from tbl_a where colb = 8
difference
select /*+ query_cache */ count(*) from tbl_a where colb = 3)
select * from ctea union all select * from cteb union all select * from ctec union all select * from cted;
```
```
select /*+ query_cache */ count(*) from tbl_a where colb = 8
```
```
select /*+ query_cache */ count(*) from tbl_a where colb = 3
```