### PR TITLE
[CBRD-25534] [Regression] prepare 쿼리에서 서브쿼리 캐시 안됨

### DIFF
--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -1368,6 +1368,10 @@ xqmgr_execute_query (THREAD_ENTRY * thread_p, const XASL_ID * xasl_id_p, QUERY_I
       thread_p->trigger_involved = true;
     }
 
+  /* for result-cache only */
+  params.size = dbval_count;
+  params.vals = NULL;
+
 #if defined (SERVER_MODE)
   if (dbval_count)
     {
@@ -1404,12 +1408,15 @@ xqmgr_execute_query (THREAD_ENTRY * thread_p, const XASL_ID * xasl_id_p, QUERY_I
 
   if (qmgr_is_allowed_result_cache (*flag_p))
     {
-      params.size = dbval_count;
-      params.vals = NULL;
-
-      if (dbval_count)
+      if (dbval_count > 0)
 	{
 	  params.vals = (DB_VALUE *) malloc (sizeof (DB_VALUE) * dbval_count);
+
+	  if (params.vals == NULL)
+	    {
+	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (DB_VALUE) * dbval_count);
+	      goto exit_on_error;
+	    }
 
 	  for (i = 0; i < dbval_count; i++)
 	    {

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -1268,8 +1268,8 @@ xqmgr_execute_query (THREAD_ENTRY * thread_p, const XASL_ID * xasl_id_p, QUERY_I
   DB_VALUE *dbval;
   HL_HEAPID old_pri_heap_id;
   char *data;
-  int i;
 #endif
+  int i;
   DB_VALUE_ARRAY params;
   QMGR_QUERY_ENTRY *query_p;
   int tran_index = -1;
@@ -1397,9 +1397,6 @@ xqmgr_execute_query (THREAD_ENTRY * thread_p, const XASL_ID * xasl_id_p, QUERY_I
    * the XASL cache entry of the target query that is obtained from the XASL_ID, because all results of the query with
    * different parameters (host variables - DB_VALUES) are linked at the XASL cache entry.
    */
-  params.size = dbval_count;
-  params.vals = dbvals_p;
-
   if (copy_bind_value_to_tdes (thread_p, dbval_count, dbvals_p) != NO_ERROR)
     {
       goto exit_on_error;
@@ -1407,6 +1404,19 @@ xqmgr_execute_query (THREAD_ENTRY * thread_p, const XASL_ID * xasl_id_p, QUERY_I
 
   if (qmgr_is_allowed_result_cache (*flag_p))
     {
+      params.size = dbval_count;
+      params.vals = NULL;
+
+      if (dbval_count)
+	{
+	  params.vals = (DB_VALUE *) malloc (sizeof (DB_VALUE) * dbval_count);
+
+	  for (i = 0; i < dbval_count; i++)
+	    {
+	      pr_clone_value (&dbvals_p[i], &params.vals[i]);
+	    }
+	}
+
       if (qmgr_is_related_class_modified (thread_p, xasl_cache_entry_p, tran_index))
 	{
 	  do_not_cache = true;
@@ -1647,6 +1657,15 @@ end:
 #if defined (SERVER_MODE)
   qmgr_reset_query_exec_info (tran_index);
 #endif
+
+  if (params.vals)
+    {
+      for (i = 0; i < dbval_count; i++)
+	{
+	  pr_clear_value (&params.vals[i]);
+	}
+      free (params.vals);
+    }
 
   return list_id_p;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25534

쿼리 캐시 처리 시 쿼리의 param 값들(dbvals_p)을 복사하지 않고, 처리할 경우 쿼리 실행 과정에서 변경될 수 있으므로 캐시 처리를 위해 쿼리 실행 전에 미리 복사해 두어야 합니다.
쿼리 실행 시 param에 저장된 DB_VALUE가 연산 과정에서 타입 coercion이 발생할 수 있으며, 변경된 param에 의해 사용자가 지정한 param 값과 다른 형태의 캐시가 생성될 수 있습니다.

