### PR TITLE
[CBRD-25513] Fix a node with PT_DOT_ type is incorrectly parameterized to a host variable in PL/CSQL mode

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -941,8 +941,7 @@ pt_bind_name_or_path_in_scope (PARSER_CONTEXT * parser, PT_BIND_NAMES_ARG * bind
       /* If pt_name in group by/ having, maybe it's alias. We will try to resolve it later. */
       if (!is_pt_name_in_group_having (in_node))
 	{
-
-	  if (parser->flag.is_parsing_static_sql == 1)
+	  if (parser->flag.is_parsing_static_sql == 1 && in_node->node_type == PT_NAME)
 	    {
 	      // clear unknown attribute error, the unknown symbol will be converted (paramterized) to host variable
 	      pt_reset_error (parser);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25513
