### PR TITLE
[CBRD-24941] slip : one word is missing from the plcsql body text

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -12700,8 +12700,8 @@ plcsql_text
 		{{ DBG_TRACE_GRAMMAR(plcsql_text, | plcsql_text_part);
 
                         assert(g_plcsql_text == NULL);
-                        g_plcsql_text = g_query_string + @$.buffer_pos;
                         $$ = strlen($1);
+                        g_plcsql_text = g_query_string + @$.buffer_pos - $$;
 
 		DBG_PRINT}}
         ;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24941
