### PR TITLE
[CBRD-25478] When using the 'SHOW ARCHIVE LOG HEADER' command, there is an issue where the archive log volumes cannot be retrieved

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -9559,7 +9559,7 @@ log_archive_log_header_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VA
 				   void **ptr)
 {
   int error = NO_ERROR;
-  const char *path;
+  char path[PATH_MAX];
   int fd;
   char buf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
   LOG_PAGE *page_hdr;
@@ -9568,6 +9568,7 @@ log_archive_log_header_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VA
   *ptr = NULL;
 
   assert (DB_VALUE_TYPE (arg_values[0]) == DB_TYPE_CHAR);
+  assert (log_Archive_path != NULL);
 
   ctx = (ARCHIVE_LOG_HEADER_SCAN_CTX *) db_private_alloc (thread_p, sizeof (ARCHIVE_LOG_HEADER_SCAN_CTX));
   if (ctx == NULL)
@@ -9577,7 +9578,7 @@ log_archive_log_header_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VA
       goto exit_on_error;
     }
 
-  path = db_get_string (arg_values[0]);
+  snprintf (path, PATH_MAX, "%s/%s", log_Archive_path, db_get_string (arg_values[0]));
 
   page_hdr = (LOG_PAGE *) PTR_ALIGN (buf, MAX_ALIGNMENT);
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -9201,7 +9201,7 @@ log_active_log_header_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VAL
 				  void **ptr)
 {
   int error = NO_ERROR;
-  const char *path;
+  char path[PATH_MAX];
   int fd = -1;
   ACTIVE_LOG_HEADER_SCAN_CTX *ctx = NULL;
 
@@ -9231,7 +9231,9 @@ log_active_log_header_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VAL
       LOG_PAGE *page_hdr = (LOG_PAGE *) PTR_ALIGN (buf, MAX_ALIGNMENT);
 
       assert (DB_VALUE_TYPE (arg_values[0]) == DB_TYPE_CHAR);
-      path = db_get_string (arg_values[0]);
+      assert (log_Path != NULL);
+
+      snprintf (path, PATH_MAX, "%s%s%s", log_Path, FILEIO_PATH_SEPARATOR (log_Path), db_get_string (arg_values[0]));
 
       fd = fileio_open (path, O_RDONLY, 0);
       if (fd == -1)
@@ -9578,7 +9580,8 @@ log_archive_log_header_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VA
       goto exit_on_error;
     }
 
-  snprintf (path, PATH_MAX, "%s/%s", log_Archive_path, db_get_string (arg_values[0]));
+  snprintf (path, PATH_MAX, "%s%s%s", log_Archive_path, FILEIO_PATH_SEPARATOR (log_Archive_path),
+	    db_get_string (arg_values[0]));
 
   page_hdr = (LOG_PAGE *) PTR_ALIGN (buf, MAX_ALIGNMENT);
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -9231,7 +9231,6 @@ log_active_log_header_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VAL
       LOG_PAGE *page_hdr = (LOG_PAGE *) PTR_ALIGN (buf, MAX_ALIGNMENT);
 
       assert (DB_VALUE_TYPE (arg_values[0]) == DB_TYPE_CHAR);
-      assert (log_Path != NULL);
 
       snprintf (path, PATH_MAX, "%s%s%s", log_Path, FILEIO_PATH_SEPARATOR (log_Path), db_get_string (arg_values[0]));
 
@@ -9570,7 +9569,6 @@ log_archive_log_header_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VA
   *ptr = NULL;
 
   assert (DB_VALUE_TYPE (arg_values[0]) == DB_TYPE_CHAR);
-  assert (log_Archive_path != NULL);
 
   ctx = (ARCHIVE_LOG_HEADER_SCAN_CTX *) db_private_alloc (thread_p, sizeof (ARCHIVE_LOG_HEADER_SCAN_CTX));
   if (ctx == NULL)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25478

### **_Purpose_**
보관로그볼륨이 존재하지 않는 폴더에서 SHOW ARCHIVE LOG HEADER 구문을 사용하여 
보관로그볼륨 정보를 조회하지 못 하는 에러가 발생합니다.

원인은 보관로그볼륨 파일명으로 파일을 열 때 상대경로로 파일 열기를 시도하는데
이 때, 작업 폴더가 보관로그볼륨이 존재하는 위치가 아닌 다른 위치로 설정되어있어 
파일을 찾을 수 없어 에러가 발생합니다.

---
### **_Implementation_**
- fileio_open 함수 호출 시 경로 값을 상대경로가 아닌 절대경로로 전달
  - log_Archive_path : 보관로그볼륨이 존재하는 경로를 가지고 있는 전역변수