### PR TITLE
[CBRD-25545] Invalid serial value occurs in unloaddb

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -907,7 +907,7 @@ emit_class_alter_serial (extract_context & ctxt, print_output & output_ctx)
     "from [db_serial] where [class_name] is not null and [att_name] is not null";
 
   const char *query_user =
-    "select [unique_name], [name], [owner].[name], [class_name], [current_val], [increment_val], [max_val], [min_val], "
+    "select [unique_name], [name], [owner].[name], [current_val], [increment_val], [max_val], [min_val], "
     "[cyclic], [started], [cached_num], [class_name], [comment] "
     "from [db_serial] where [class_name] is not null and [att_name] is not null and owner.name='%s'";
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25545

Purpose
일반 계정으로 unloaddb를 수행할때 alert serial 정보를 얻기 위한 쿼리문에 잘 못된 컬럼이 있어 에러가 발생됨

Implementation
serial를 얻어 오는 쿼리에서 class_name을 삭제함

Remarks
