### PR TITLE
[CBRD-25559] [regression] CREATE ... AS SELECT 쿼리에 서브쿼리 캐시 적용 시 core dump

### DIFF
--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -8262,6 +8262,25 @@ pt_check_create_user (PARSER_CONTEXT * parser, PT_NODE * node)
     }
 }
 
+static PT_NODE *
+pt_check_query_cache_in_create_entity (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk)
+{
+  bool *has_cache_hint = (bool *) arg;
+
+  *continue_walk = PT_CONTINUE_WALK;
+
+  if (node->node_type == PT_SELECT)
+    {
+      if (node->info.query.hint & PT_HINT_QUERY_CACHE)
+	{
+	  *has_cache_hint = true;
+	  *continue_walk = PT_STOP_WALK;
+	}
+    }
+
+  return node;
+}
+
 /*
  * pt_check_create_entity () - semantic check a create class/vclass
  *   return:  none
@@ -8672,7 +8691,18 @@ pt_check_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
 	    }
 
 	  /* INSERT ... SELECT needs to do a semantic check to handle the subquery cache. */
-	  select = pt_semantic_check (parser, select);
+	  if (select)
+	    {
+	      bool has_cache_hint = false;
+
+	      (void *) parser_walk_tree (parser, select, pt_check_query_cache_in_create_entity, &has_cache_hint, NULL,
+					 NULL);
+
+	      if (has_cache_hint)
+		{
+		  select = pt_semantic_check (parser, select);
+		}
+	    }
 
 	  if (pt_has_parameters (parser, select))
 	    {

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -8669,9 +8669,10 @@ pt_check_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
 			      pt_short_print (parser, crt_attr));
 		  return;
 		}
-
-	      select = pt_semantic_check (parser, select);
 	    }
+
+	  /* INSERT ... SELECT needs to do a semantic check to handle the subquery cache. */
+	  select = pt_semantic_check (parser, select);
 
 	  if (pt_has_parameters (parser, select))
 	    {

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -8688,10 +8688,11 @@ pt_check_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
 			      pt_short_print (parser, crt_attr));
 		  return;
 		}
-	    }
 
+	      select = pt_semantic_check (parser, select);
+	    }
 	  /* INSERT ... SELECT needs to do a semantic check to handle the subquery cache. */
-	  if (select)
+	  else
 	    {
 	      bool has_cache_hint = false;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25559

CREATE ... AS SELECT 구문은 쿼리 컴파일 / 실행 과정에서 AS SELECT 구문이 INSERT ... SELECT 구문으로 확장되어 실행되는 구조입니다.

[CBRD-25230](http://jira.cubrid.org/browse/CBRD-25230) 이슈에서 INSERT ... SELECT 구문에 대해 서브 쿼리 캐시를 처리하고 있기 때문에, CREATE 구문에서 INSERT ... SELECT 구문에 대한 시멘틱 체크가 필요합니다.

pt_check_create_entity 에서 WITH쿼리에 대해서만 pt_semantic_check를 하고 있었는데, 이제 SELECT 쿼리에 대해서도 체크할 필요가 있습니다.
