### PR TITLE
[CBRD-25560] build(cmake): detect ccache and use it as launcher if exists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,16 +21,20 @@ cmake_minimum_required(VERSION 3.21)
 
 
 # Check if ccache is installed
-find_program(CCACHE_PROGRAM ccache)
+option(USE_CCACHE "Use ccache as compiler launcher" ON)
 
-# If ccache is found, use it as a compiler launcher
-if(CCACHE_PROGRAM)
+if(USE_CCACHE)
+  find_program(CCACHE_PROGRAM ccache)
+  if(CCACHE_PROGRAM)
     message(STATUS "Using ccache: ${CCACHE_PROGRAM}")
     # Set the compiler launcher globally
     set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}" CACHE STRING "C compiler launcher" FORCE)
     set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}" CACHE STRING "C++ compiler launcher" FORCE)
-else()
+  else()
     message(STATUS "ccache not found. Building without ccache.")
+  endif()
+else()
+  message(STATUS "ccache usage is disabled.")
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,21 @@ message(STATUS "======== CMakeLists.txt")
 
 cmake_minimum_required(VERSION 3.21)
 
+
+# Check if ccache is installed
+find_program(CCACHE_PROGRAM ccache)
+
+# If ccache is found, use it as a compiler launcher
+if(CCACHE_PROGRAM)
+    message(STATUS "Using ccache: ${CCACHE_PROGRAM}")
+    # Set the compiler launcher globally
+    set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}" CACHE STRING "C compiler launcher" FORCE)
+    set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}" CACHE STRING "C++ compiler launcher" FORCE)
+else()
+    message(STATUS "ccache not found. Building without ccache.")
+endif()
+
+
 function(with_unit_tests res) # checks for -DUNIT_TESTS=ON or -DUNIT_TEST_???=ON
   get_cmake_property(vars VARIABLES)
   foreach(var ${vars})

--- a/docs/install_build_requirements.md
+++ b/docs/install_build_requirements.md
@@ -50,6 +50,13 @@ curl -L https://ftp.gnu.org/gnu/bison/bison-$BISON_VERSION.tar.gz | tar xzvf - \
 
 ```
 
+It is advised to install ccache to speed up the build process. Once ccache is installed, cmake will automatically detect it. Use your favorite package manager to install ccache. For example:
+
+```sh
+# CentOS 7
+sudo yum install -y ccache
+```
+
 ## Windows
 
 Please refer to the following script. Note that you have to run Powershell as Administrator 

--- a/docs/install_build_requirements.md
+++ b/docs/install_build_requirements.md
@@ -54,7 +54,7 @@ It is advised to install ccache to speed up the build process. Once ccache is in
 
 ```sh
 # CentOS 7
-sudo yum install -y ccache
+yum install -y ccache
 ```
 
 ## Windows


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25560

# ccache 를 통한 빌드 속도 향상
 

CMake 설정 파일에 ccache를 사용하는 코드를 추가하여 빌드 속도를 크게 향상시킬 수 있습니다.

해당 코드를 프로젝트의 CMake 설정에 추가하여, ccache가 설치된 경우 이를 컴파일러 실행기로 설정하도록 했습니다. 이로 인해 반복적인 빌드 시간 단축이 가능해졌습니다.

build 파일을 지우고 처음부터 다시 빌드할 경우, 개발 서버 기준 2분 내외의 빌드 시간이 소모됩니다. 그러나 ccache를 사용할 경우, build 파일을 지우고 처음부터 다시 빌드하더라도 40초 내외로 빌드 시간을 줄일 수 있습니다.

CMakeLists.txt에서 자동으로 ccache 설치 여부를 감지하여 자동으로 사용하게 하는 방식입니다.

ccache가 설치되어있지 않은 개발자는 이 패치에 영향을 받지 않습니다.

테스트 환경:

개발 서버 Centos7 g++-8
개인 장비 WSL Ubuntu 22.04 g++-11
개인 장비 Arch Linux g++-13
 