### PR TITLE
[CBRD-24941] Slip: omitted long type indicating postfix L to a long zero literal

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -2300,7 +2300,7 @@ public class SpLib {
         if (l == null || r == null) {
             return null;
         }
-        if (r.equals(0)) {
+        if (r.equals(0L)) {
             throw new ZERO_DIVIDE();
         }
         return l % r;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24941

The omission of 'L' results in 'always-false' because they compare long and integer values. 
Due to this problem, he following example emits an 'internal server error' instead of 'division by zero'.
```
create or replace procedure poo as
begin
    dbms_output.put_line('123' mod 0);
end;
```
