### PR TITLE
[CBRD-25567] Problem with Range Predicates Using Pipe Operators Not Being Reducible to Common Range Terms

### DIFF
--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -17772,6 +17772,7 @@ pt_is_const_expr_node (PT_NODE * node)
 		  && pt_is_const_expr_node (node->info.expr.arg2)) ? true : false;
 	case PT_ISNULL:
 	  return pt_is_const_expr_node (node->info.expr.arg1);
+	case PT_STRCAT:
 	case PT_CONCAT:
 	  return (pt_is_const_expr_node (node->info.expr.arg1)
 		  && (node->info.expr.arg2 ? pt_is_const_expr_node (node->info.expr.arg2) : true)) ? true : false;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25567

In the pt_is_const_expr_node function, evaluate whether an expression using PT_STRCAT can be considered constant.