### PR TITLE
[CBRD-25561] Resolve the issue of applying duplicate changes after restoreslave

### DIFF
--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -111,7 +111,7 @@ static int synccoll_check_function_indexes (const LANG_COLL_COMPAT * db_coll, FI
 
 static int delete_all_ha_apply_info (void);
 static int insert_ha_apply_info (char *database_name, char *master_host_name, INT64 database_creation, INT64 pageid,
-				 int offset);
+				 int offset, INT64 committed_pageid, int committed_offset);
 static int delete_all_slave_ha_apply_info (char *database_name, char *master_host_name);
 
 static bool check_ha_db_and_node_list (char *database_name, char *source_host_name);
@@ -4380,7 +4380,8 @@ delete_all_ha_apply_info (void)
  *   return:
  */
 static int
-insert_ha_apply_info (char *database_name, char *master_host_name, INT64 database_creation, INT64 pageid, int offset)
+insert_ha_apply_info (char *database_name, char *master_host_name, INT64 database_creation, INT64 pageid, int offset,
+		      INT64 committed_pageid, int committed_offset)
 {
 #define APPLY_INFO_VALUES	15
 #define QUERY_BUF_SIZE		2048
@@ -4477,8 +4478,12 @@ insert_ha_apply_info (char *database_name, char *master_host_name, INT64 databas
   /* 3. copied_log_path */
   db_make_varchar (&in_value[in_value_idx++], 4096, log_path, strlen (log_path), LANG_SYS_CODESET, LANG_SYS_COLLATION);
 
-  /* 4 ~ 15. lsa */
-  for (i = 0; i < 6; i++)
+  /* 4 ~ 5. committed lsa */
+  db_make_bigint (&in_value[in_value_idx++], committed_pageid);
+  db_make_int (&in_value[in_value_idx++], committed_offset);
+
+  /* 6 ~ 15. lsa */
+  for (i = 0; i < 5; i++)
     {
       db_make_bigint (&in_value[in_value_idx++], pageid);
       db_make_int (&in_value[in_value_idx++], offset);
@@ -4775,7 +4780,8 @@ restoreslave (UTIL_FUNCTION_ARG * arg)
 
       error_code =
 	insert_ha_apply_info (database_name, master_host_name, restart_arg.db_creation,
-			      restart_arg.restart_repl_lsa.pageid, (int) restart_arg.restart_repl_lsa.offset);
+			      restart_arg.restart_repl_lsa.pageid, (int) restart_arg.restart_repl_lsa.offset,
+			      restart_arg.restart_committed_lsa.pageid, (int) restart_arg.restart_committed_lsa.offset);
       if (error_code < 0)
 	{
 	  PRINT_AND_LOG_ERR_MSG ("%s\n", db_error_string (3));

--- a/src/transaction/boot_sr.h
+++ b/src/transaction/boot_sr.h
@@ -126,8 +126,9 @@ struct bo_restart_arg
   bool is_restore_from_backup;
   INT64 db_creation;		/* database creation time */
   LOG_LSA restart_repl_lsa;	/* restart replication lsa after restoreslave */
-  LOG_LSA restart_committed_lsa;	/* After restoreslave, replicated logs before the committed LSA should not be applied by applylogdb.
-					 * Because logs before committed lsa are already applied by recovery process */
+  LOG_LSA restart_committed_lsa;	/* committed_lsa which will be used by applylogdb after restoreslave.
+					 * Replicated logs before the committed_lsa should not be applied by applylogdb,
+					 * because logs before committed_lsa are already applied by recovery process */
   char keys_file_path[PATH_MAX];	/* Master Key File (_keys) path for TDE. If it is not NULL, it is used, not the keys spcified system parameter or from default path */
 };
 

--- a/src/transaction/boot_sr.h
+++ b/src/transaction/boot_sr.h
@@ -126,6 +126,8 @@ struct bo_restart_arg
   bool is_restore_from_backup;
   INT64 db_creation;		/* database creation time */
   LOG_LSA restart_repl_lsa;	/* restart replication lsa after restoreslave */
+  LOG_LSA restart_committed_lsa;	/* After restoreslave, replicated logs before the committed LSA should not be applied by applylogdb.
+					 * Because logs before committed lsa are already applied by recovery process */
   char keys_file_path[PATH_MAX];	/* Master Key File (_keys) path for TDE. If it is not NULL, it is used, not the keys spcified system parameter or from default path */
 };
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1194,6 +1194,7 @@ log_initialize_internal (THREAD_ENTRY * thread_p, const char *db_fullname, const
     {
       r_args->db_creation = log_Gl.hdr.db_creation;
       LSA_COPY (&r_args->restart_repl_lsa, &log_Gl.hdr.smallest_lsa_at_last_chkpt);
+      LSA_COPY (&r_args->restart_committed_lsa, &log_Gl.hdr.append_lsa);
     }
 
   LSA_COPY (&log_Gl.chkpt_redo_lsa, &log_Gl.hdr.chkpt_lsa);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25561

Purpose

마스터 노드의 백업본을 이용해 Slave 노드에서 restoreslave를 수행한 경우,
Slave 노드는 이미 반영된 변경사항에 대한 로그를 Master 노드로부터 복제해오는 문제가 있다.

현재 applylogdb는 committed_lsa 이전에 commit된 트랜잭션에 대해서는 disk에 반영하고있지 않다. 
해당 메커니즘을 이용하여, restoreslave 시 committed_lsa값을 넘겨줄 수 있도록 수정했다.