### PR TITLE
[CBRD-25050] Add check for log record header corruption

### DIFF
--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -2680,8 +2680,9 @@ log_recovery_analysis (THREAD_ENTRY * thread_p, LOG_LSA * start_lsa, LOG_LSA * s
 		    {
 		      LSA_COPY (&last_log_tdes->tail_lsa, &log_rec->prev_tranlsa);
 		      LSA_COPY (&last_log_tdes->undo_nxlsa, &log_rec->prev_tranlsa);
-		      er_log_debug (ARG_FILE_LINE, "logpb_recovery_analysis: trid = %d, tail_lsa=%lld|%d\n",
-				    log_rec->trid, last_log_tdes->tail_lsa.pageid, last_log_tdes->tail_lsa.offset);
+		      er_log_debug (ARG_FILE_LINE, "%s: trid = %d, tail_lsa=%lld|%d\n",
+				    __func__, log_rec->trid, last_log_tdes->tail_lsa.pageid,
+				    last_log_tdes->tail_lsa.offset);
 		    }
 		}
 	      assert (!prev_lsa.is_null ());
@@ -2743,8 +2744,8 @@ log_recovery_analysis (THREAD_ENTRY * thread_p, LOG_LSA * start_lsa, LOG_LSA * s
 	  if (last_checked_page_id != log_lsa.pageid)
 	    {
 #if !defined(NDEBUG)
-	      er_log_debug (ARG_FILE_LINE, "logpb_recovery_analysis: log page %lld, checksum %d\n",
-			    log_page_p->hdr.logical_pageid, log_page_p->hdr.checksum);
+	      er_log_debug (ARG_FILE_LINE, "%s: log page %lld, checksum %d\n",
+			    __func__, log_page_p->hdr.logical_pageid, log_page_p->hdr.checksum);
 	      if (prm_get_bool_value (PRM_ID_LOGPB_LOGGING_DEBUG))
 		{
 		  fileio_page_hexa_dump ((const char *) log_page_p, LOG_PAGESIZE);
@@ -2773,9 +2774,8 @@ log_recovery_analysis (THREAD_ENTRY * thread_p, LOG_LSA * start_lsa, LOG_LSA * s
 		  /* Found corrupted log page. */
 		  if (prm_get_bool_value (PRM_ID_LOGPB_LOGGING_DEBUG))
 		    {
-		      _er_log_debug (ARG_FILE_LINE,
-				     "logpb_recovery_analysis: log page %lld is corrupted due to partial flush.\n",
-				     (long long int) log_lsa.pageid);
+		      _er_log_debug (ARG_FILE_LINE, "%s: log page %lld is corrupted due to partial flush.\n",
+				     __func__, (long long int) log_lsa.pageid);
 		    }
 		}
 
@@ -2797,8 +2797,8 @@ log_recovery_analysis (THREAD_ENTRY * thread_p, LOG_LSA * start_lsa, LOG_LSA * s
 		  LSA_COPY (end_redo_lsa, &lsa);
 		  LSA_COPY (&prev_lsa, end_redo_lsa);
 		  prev_prev_lsa = prev_lsa;
-		  er_log_debug (ARG_FILE_LINE, "log_recovery_analysis: broken record at LSA=%lld|%d ",
-				log_lsa.pageid, log_lsa.offset);
+		  er_log_debug (ARG_FILE_LINE, "%s: broken record at LSA=%lld|%d ",
+				__func__, log_lsa.pageid, log_lsa.offset);
 		  break;
 		}
 	    }
@@ -2895,8 +2895,8 @@ log_recovery_analysis (THREAD_ENTRY * thread_p, LOG_LSA * start_lsa, LOG_LSA * s
 		      if (prm_get_bool_value (PRM_ID_LOGPB_LOGGING_DEBUG))
 			{
 			  _er_log_debug (ARG_FILE_LINE,
-					 "logpb_recovery_analysis: Partial page flush - first corrupted log record LSA = (%lld, %d)\n",
-					 (long long int) log_lsa.pageid, log_lsa.offset);
+					 "%s: Partial page flush - first corrupted log record LSA = (%lld, %d)\n",
+					 __func__, (long long int) log_lsa.pageid, log_lsa.offset);
 			}
 		      LOG_RESET_APPEND_LSA (&log_lsa);
 		      LSA_SET_NULL (&lsa);

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -2529,6 +2529,7 @@ log_is_page_of_record_broken (THREAD_ENTRY * thread_p, const LOG_LSA * log_lsa,
 
   LSA_COPY (&fwd_log_lsa, &log_rec_header->forw_lsa);
 
+  /* TODO - Do we need to handle NULL fwd_log_lsa? */
   if (!LSA_ISNULL (&fwd_log_lsa))
     {
       if (LSA_GE (log_lsa, &fwd_log_lsa) || LSA_GE (&fwd_log_lsa, &log_Gl.hdr.eof_lsa))
@@ -2550,11 +2551,6 @@ log_is_page_of_record_broken (THREAD_ENTRY * thread_p, const LOG_LSA * log_lsa,
 		}
 	    }
 	}
-    }
-  else
-    {
-      // fwd_log_lsa is null
-      is_log_page_broken = true;
     }
 
   return is_log_page_broken;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25050

Purpose

log record를 flush하는 중에 비정상종료되면, 온전한 log record가 disk에 있을 것이라고 보장할 수 없다.
현재 recovery 범위를 지정하는 과정 중에, log record를 순차적으로 순회하면서 corruption이 있는지 파악한다. 
하지만, 로그레코드에 저장된 forw_lsa에 쓰레기 값이 저장되었는지 여부를 파악하고 있진 않다. 
따라서, 유효하지 않은 forw_lsa 값에 대하여 log page에 접근하거나, 잘못된 로그 레코드를 읽을 경우 문제가 발생한다.

따라서, forw_lsa 값에 대한 체크를 추가하여 이 문제를 해결한다.
