### PR TITLE
[CBRD-25502] Add assert to check that heap_page_prev is actually used.

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -18749,6 +18749,10 @@ heap_page_prev (THREAD_ENTRY * thread_p, const OID * class_oid, const HFID * hfi
   PGBUF_WATCHER old_pg_watcher;
   SCAN_CODE scan = S_SUCCESS;
 
+  /* we couldn't find any testcase for this function. */
+  /* but if this assert is called, it indicates that this function is being used. */
+  assert (false);
+
   PGBUF_INIT_WATCHER (&pg_watcher, PGBUF_ORDERED_HEAP_NORMAL, hfid);
   PGBUF_INIT_WATCHER (&old_pg_watcher, PGBUF_ORDERED_HEAP_NORMAL, hfid);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25502

Purpose
#5390 과 이슈를 공유합니다.

heap_page_prev가 사용되는 케이스를 찾을 수 없어 heap_page_prev가 실제로 호출되는 지 확인하기 위한 변경입니다.

Implementation
N/A

Remarks
N/A