### PR TITLE
[CBRD-25056] allow records of the same number of fields as the number of table columns in Static SQL UPDATE, INSERT, and REPLACE

### DIFF
--- a/pl_engine/pl_server/src/main/antlr/StaticSqlWithRecords.g4
+++ b/pl_engine/pl_server/src/main/antlr/StaticSqlWithRecords.g4
@@ -94,9 +94,14 @@ stmt_w_record_values
     ;
 
 stmt_w_record_set
-    : UPDATE any+ SET row_set any+ EOF
-    | INSERT any+ SET row_set (ON DUPLICATE KEY UPDATE any+)? EOF
-    | REPLACE any+ SET row_set EOF
+    : UPDATE any* table_spec SET row_set any+ EOF
+    | INSERT any* table_spec SET row_set (ON DUPLICATE KEY UPDATE any+)? EOF
+    | REPLACE any* table_spec SET row_set EOF
+    ;
+
+table_spec
+    : REGULAR_ID
+    | OPAQUE
     ;
 
 row_set

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -2746,7 +2746,10 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     }
 
     private String rewriteUpdateWithFieldsExpansion(
-            String sqlText, Row_setContext rowSet, Table_specContext tableSpec, Static_sqlContext ctx) {
+            String sqlText,
+            Row_setContext rowSet,
+            Table_specContext tableSpec,
+            Static_sqlContext ctx) {
 
         int start = rowSet.getStart().getStartIndex();
         int end = rowSet.getStop().getStopIndex() + 1;
@@ -2769,12 +2772,16 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
         if (sws.selectList.size() != recTy.selectList.size()) {
             throw new SemanticError(
                     Misc.getLineColumnOf(ctx), // s089
-                    "the number of fields of the record " + record +
-                        " is not equal to the number of columns of the table " + tableSpecText);
+                    "the number of fields of the record "
+                            + record
+                            + " is not equal to the number of columns of the table "
+                            + tableSpecText);
         }
 
-        // Type compatibility of each pair of table column and record field is not checked here because
-        // table columns can have a type that is not supported in PL/CSQL (for example, TIMESTAMPLTZ), but
+        // Type compatibility of each pair of table column and record field is not checked here
+        // because
+        // table columns can have a type that is not supported in PL/CSQL (for example,
+        // TIMESTAMPLTZ), but
         // the SQL can run successfully.
         // If the types are not compatible for a pair, then a run-time error will occur for it.
 
@@ -2801,7 +2808,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
 
             if (lowercased.indexOf("insert") == 0 || lowercased.indexOf("replace") == 0) {
 
-
                 parser = getParser(sqlText);
                 sei = replaceErrorListeners(parser);
 
@@ -2819,7 +2825,8 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
             Stmt_w_record_setContext tree = (Stmt_w_record_setContext) parser.stmt_w_record_set();
             if (!sei.hasError) {
                 // (UPDATE|INSERT|REPLACE) ... table SET ROW = r ...
-                return rewriteUpdateWithFieldsExpansion(sqlText, tree.row_set(), tree.table_spec(), ctx);
+                return rewriteUpdateWithFieldsExpansion(
+                        sqlText, tree.row_set(), tree.table_spec(), ctx);
             }
         }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25056

이전 구현까지는 (UPDATE | INSERT | REPLACE) table SET ROW = record ... 형태에서 
record 의 필드 이름들이 테이블 컬럼 이름들과 동일해야만 정상 동작했습니다. 
이번 변경은 필드 갯수와 컬럼 갯수만 일치하면 정상 동작하도록 수정했습니다. 

필드타입로부터 컬럼타입으로의 형변환 가능성은 컴파일 과정에서 체크하지 않으려고 합니다. 
왜냐하면 테이블 컬럼 타입이 PL/CSQL 에서 현재 지원하지 않더라도 SQL 실행은 성공하는 경우가 있기 때문입니다. 
(예를 들어, 컬럼 타입이 TIMESTAMPLTZ)
