### PR TITLE
[CBRD-25579] [regression] SYSDATE, SERIAL 함수 등을 사용할 때, 서브쿼리 캐시가 설정됨

### DIFF
--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -3574,6 +3574,14 @@ do_prepare_subquery_pre (PARSER_CONTEXT * parser, PT_NODE * stmt, void *arg, int
       return stmt;
 
     case PT_SELECT:
+      /* 
+       * SYSDATE, SERIAL related functions and other queries that should not be cached
+       * The parser sets the do_not_cache flag for these queries.
+       */
+      if (stmt->info.query.flag.do_not_cache)
+	{
+	  return stmt;
+	}
       break;
 
     default:


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25579

일반적으로 result-cache를 적용할 때, SYSDATE나 SERIAL 관련 함수처럼 캐쉬를 사용하는데 적절하지 않은 쿼리의 경우, do_not_cache라는 query flag를 통해 캐시를 적용하지 않도록 체크가 되고 있습니다.

하지만, 서브쿼리의 경우, 이 부분에 대해 체크하는 로직이 누락되어 있어서 서브쿼리 캐시에서는 정상 동작하지 않았습니다.

do_prepare_subquery_pre 함수에서 PT_SELECT의 경우, 이 flag를 체크하도록 수정하면  정상 동작합니다.

```
case PT_SELECT:
      /*
       * SYSDATE, SERIAL related functions and other queries that should not be cached
       * The parser sets the do_not_cache flag for these queries.
       */
      if (stmt->info.query.flag.do_not_cache)
        {
          return stmt;
        } 
```