### PR TITLE
[CBRD-25567] Problem with Range Predicates Using Pipe Operators Not Being Reducible to Common Range Terms (#5467)

### DIFF
--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -17250,6 +17250,7 @@ pt_is_const_expr_node (PT_NODE * node)
 	  }
 	  break;
 	case PT_PLUS:
+	case PT_STRCAT:
 	case PT_MINUS:
 	case PT_TIMES:
 	case PT_DIVIDE:
@@ -17473,7 +17474,6 @@ pt_is_const_expr_node (PT_NODE * node)
 		  && pt_is_const_expr_node (node->info.expr.arg2)) ? true : false;
 	case PT_ISNULL:
 	  return pt_is_const_expr_node (node->info.expr.arg1);
-	case PT_STRCAT:
 	case PT_CONCAT:
 	  return (pt_is_const_expr_node (node->info.expr.arg1)
 		  && (node->info.expr.arg2 ? pt_is_const_expr_node (node->info.expr.arg2) : true)) ? true : false;

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -17473,6 +17473,7 @@ pt_is_const_expr_node (PT_NODE * node)
 		  && pt_is_const_expr_node (node->info.expr.arg2)) ? true : false;
 	case PT_ISNULL:
 	  return pt_is_const_expr_node (node->info.expr.arg1);
+	case PT_STRCAT:
 	case PT_CONCAT:
 	  return (pt_is_const_expr_node (node->info.expr.arg1)
 		  && (node->info.expr.arg2 ? pt_is_const_expr_node (node->info.expr.arg2) : true)) ? true : false;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25567

backport #5467