### PR TITLE
[CBRD-25546] Using the SHOW command allows querying the active log volume and archive log volume paths of a different database when they are provided.

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -322,14 +322,13 @@ static void log_sysop_do_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG
 				   int data_size, const char *data);
 
 static int logtb_tran_update_stats_online_index_rb (THREAD_ENTRY * thread_p, void *data, void *args);
-static bool log_is_absolute_path (const char *path);
 static void log_build_full_path (const char *input_path, char *full_path);
 /*for CDC */
 static int cdc_log_extract (THREAD_ENTRY * thread_p, LOG_LSA * process_lsa, CDC_LOGINFO_ENTRY * log_info_entry);
 static int cdc_get_overflow_recdes (THREAD_ENTRY * thread_p, LOG_PAGE * log_page_p, RECDES * recdes,
 				    LOG_LSA lsa, LOG_RCVINDEX rcvindex, bool is_redo);
-static int cdc_get_ovfdata_from_log (THREAD_ENTRY * thread_p, LOG_PAGE * log_page_p, LOG_LSA * process_lsa,
-				     int *length, char **data, LOG_RCVINDEX rcvindex, bool is_redo);
+static int cdc_get_ovfdata_from_log (THREAD_ENTRY * thread_p, LOG_PAGE * log_page_p, LOG_LSA * process_lsa, int *length,
+				     char **data, LOG_RCVINDEX rcvindex, bool is_redo);
 static int cdc_find_primary_key (THREAD_ENTRY * thread_p, OID classoid, int repr_id, int *num_attr, int **pk_attr_id);
 static int cdc_make_ddl_loginfo (char *supplement_data, int trid, const char *user, CDC_LOGINFO_ENTRY * ddl_entry);
 static int cdc_make_dcl_loginfo (time_t at_time, int trid, char *user, int log_type, CDC_LOGINFO_ENTRY * dcl_entry);
@@ -10620,32 +10619,6 @@ logtb_tran_update_stats_online_index_rb (THREAD_ENTRY * thread_p, void *data, vo
 					       false);
 
   return error_code;
-}
-
-
-/*
- * log_is_absolute_path () - Checks if the given path argument is an absolute path.
- *
- * return    : boolean
- * path (in) : path
- */
-static bool
-log_is_absolute_path (const char *path)
-{
-  assert (path != NULL);
-
-#if defined(WINDOWS)
-  if ((path[1] == ':' && (path[2] == '\\' || path[2] == '/')) || (path[0] == '\\' && path[1] == '\\'))
-    {
-      return true;
-    }
-  else
-    {
-      return false;
-    }
-#endif
-
-  return path[0] == '/';
 }
 
 /*

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -9563,7 +9563,7 @@ log_archive_log_header_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VA
 {
   int error = NO_ERROR;
   char path[PATH_MAX];
-  int fd;
+  int fd = -1;
   char buf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
   LOG_PAGE *page_hdr;
   ARCHIVE_LOG_HEADER_SCAN_CTX *ctx = NULL;

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -323,7 +323,6 @@ static void log_sysop_do_postpone (THREAD_ENTRY * thread_p, LOG_TDES * tdes, LOG
 
 static int logtb_tran_update_stats_online_index_rb (THREAD_ENTRY * thread_p, void *data, void *args);
 static bool log_is_absolute_path (const char *path);
-static bool log_is_file_name_only (const char *path);
 
 /*for CDC */
 static int cdc_log_extract (THREAD_ENTRY * thread_p, LOG_LSA * process_lsa, CDC_LOGINFO_ENTRY * log_info_entry);
@@ -9239,21 +9238,10 @@ log_active_log_header_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VAL
 	{
 	  snprintf (path, PATH_MAX, "%s", db_get_string (arg_values[0]));
 	}
-      else			//relative path
+      else
 	{
-	  if (log_is_file_name_only (db_get_string (arg_values[0])))
-	    {
-	      snprintf (path, PATH_MAX, "%s%s%s", log_Path, FILEIO_PATH_SEPARATOR (log_Path),
-			db_get_string (arg_values[0]));
-	    }
-	  else
-	    {
-	      char dir_path[PATH_MAX];
-
-	      fileio_get_directory_path (dir_path, boot_db_full_name ());
-	      snprintf (path, PATH_MAX, "%s%s%s", dir_path, FILEIO_PATH_SEPARATOR (dir_path),
-			db_get_string (arg_values[0]));
-	    }
+	  snprintf (path, PATH_MAX, "%s%s%s", log_Path, FILEIO_PATH_SEPARATOR (log_Path),
+		    db_get_string (arg_values[0]));
 	}
 
       fd = fileio_open (path, O_RDONLY, 0);
@@ -9607,19 +9595,8 @@ log_archive_log_header_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VA
     }
   else
     {
-      if (log_is_file_name_only (db_get_string (arg_values[0])))
-	{
-	  snprintf (path, PATH_MAX, "%s%s%s", log_Archive_path, FILEIO_PATH_SEPARATOR (log_Archive_path),
-		    db_get_string (arg_values[0]));
-	}
-      else
-	{
-	  char dir_path[PATH_MAX];
-
-	  fileio_get_directory_path (dir_path, boot_db_full_name ());
-	  snprintf (path, PATH_MAX, "%s%s%s", dir_path, FILEIO_PATH_SEPARATOR (dir_path),
-		    db_get_string (arg_values[0]));
-	}
+      snprintf (path, PATH_MAX, "%s%s%s", log_Archive_path, FILEIO_PATH_SEPARATOR (log_Archive_path),
+		db_get_string (arg_values[0]));
     }
 
   page_hdr = (LOG_PAGE *) PTR_ALIGN (buf, MAX_ALIGNMENT);
@@ -10685,21 +10662,6 @@ log_is_absolute_path (const char *path)
 #endif
 
   return path[0] == '/';
-}
-
-/*
- * log_is_file_name_only () - Check if path contains any directory separator.
- *
- * return    : boolean
- * path (in) : path
- */
-static bool
-log_is_file_name_only (const char *path)
-{
-#if defined(WINDOWS)
-  return strchr (path, '\\') == NULL && strchr (path, '/') == NULL;
-#endif
-  return strchr (path, '/') == NULL;
 }
 
 static int


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25546

### **_Purpose_**
- SHOW 명령 사용 시 다른 DB의 활성로그볼륨과 보관로그볼륨 경로를 전달하면 조회가 되는 문제
  - 조회하려는 파일의 db_creation 값과 현재 데이터베이스의 db_creation 값을 비교하여 validate하는 과정 추가

- 기존 큐브리드의 스펙에서는 절대경로와 상대경로 둘 다 조회가 가능했지만 해당 이슈 전 수행된 선행이슈로 인해 
   절대경로 조회가 동작하지 않게 되었습니다.
- 이에 따라 사용자가 입력한 경로를 아래 두가지로 구분하는 로직을 추가합니다.
  1. 절대경로
     - 파일의 경로를 입력한 경우 ( ex : /home/user/CUBRID/databases/testdb/testdb_lgat )
  2. 상대경로
     - 파일의 경로를 입력하지 않고 파일명 또는 폴더명/파일명으로 입력한 경우 ( ex : log/testdb_lgat )

---
### **_Implementation_**
- 로그볼륨이 저장되어있는 경로를 담은 변수
  - log_Path
- 받은 문자열을 절대경로로 만들어주는 함수
  - log_build_full_path
-  사용자가 입력한 경로(파일명)가 저장된 변수
   - db_get_string (arg_values[0])


- 사용자가 입력한 문자열을 분석하여 절대경로인지, 상대경로인지 구분하여 동작하도록 구현
- 타 DB의 로그볼륨 경로를 입력한 것은 아닌지 활성로그볼륨 헤더의 db_creation과 정보를 출력하려는 볼륨의 db_creation을 비교하는 로직 추가

