### PR TITLE
[CBRD-25582] Cascade behavior not executing correctly when revoking permissions

### DIFF
--- a/src/object/authenticate_grant.cpp
+++ b/src/object/authenticate_grant.cpp
@@ -857,13 +857,13 @@ get_grants (MOP auth, DB_SET **grant_ptr, int filter)
       goto end;
     }
 
+  grants = db_get_set (&value);
+  gsize = set_size (grants);
+
   if (!filter)
     {
       goto end;
     }
-
-  grants = db_get_set (&value);
-  gsize = set_size (grants);
 
   /* there might be errors */
   error = er_errid ();


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25582

Purpose

Revoke 매뉴얼에 명시된 대로 Cascade 동작이 정상적으로 실행되지 않는 문제를 수정합니다.
```
권한을 부여한 사용자에게서 권한(WITH GRANT OPTION)을 해지하면, 권한을 해지당한 사용자로부터 권한을 받은 사용자도 권한을 해지당한다.
``` 

Implementation

get_grants() 함수에서 filter 인자 값이 false일 때, 변수 초기화를 위해 사용된 NULL 값만 반환되어 Revoke 시 Cascade가 정상적으로 동작하지 않았습니다.
이를 수정하여, filter 값이 false인 경우에도 db_authorization 카탈로그의 grants 값이 반환되도록 변경했습니다.

Remarks

N/A