### PR TITLE
[CBRD-25579] rev: [regression] system class, SYSDATE, SERIAL 함수 등을 사용할 때, 서브쿼리 캐시가 설정됨

### DIFF
--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -3528,9 +3528,9 @@ do_clear_subquery_cache_flag (PARSER_CONTEXT * parser, PT_NODE * stmt, void *arg
 }
 
 static PT_NODE *
-do_check_cte_spec (PARSER_CONTEXT * parser, PT_NODE * stmt, void *arg, int *continue_walk)
+do_check_cte_or_system_class_spec (PARSER_CONTEXT * parser, PT_NODE * stmt, void *arg, int *continue_walk)
 {
-  bool *has_cte_spec = (bool *) arg;
+  bool *has_cte_or_system_class = (bool *) arg;
 
   *continue_walk = PT_CONTINUE_WALK;
 
@@ -3541,8 +3541,22 @@ do_check_cte_spec (PARSER_CONTEXT * parser, PT_NODE * stmt, void *arg, int *cont
 
   if (stmt->info.spec.cte_pointer)
     {
-      *has_cte_spec = true;
+      *has_cte_or_system_class = true;
       *continue_walk = PT_STOP_WALK;
+    }
+
+  if (stmt->info.spec.entity_name)
+    {
+      const char *class_name = stmt->info.spec.entity_name->info.name.original;
+
+      if (class_name)
+	{
+	  if (sm_check_system_class_by_name (class_name))
+	    {
+	      *has_cte_or_system_class = true;
+	      *continue_walk = PT_STOP_WALK;
+	    }
+	}
     }
 
   return stmt;
@@ -3593,12 +3607,12 @@ do_prepare_subquery_pre (PARSER_CONTEXT * parser, PT_NODE * stmt, void *arg, int
        || stmt->info.query.is_subquery == PT_IS_CTE_NON_REC_SUBQUERY) && stmt->info.query.correlation_level == 0
       && (stmt->info.query.hint & PT_HINT_QUERY_CACHE))
     {
-      bool has_cte_spec = false;
+      bool has_cte_or_system_class = false;
 
-      /* exclude cache from CTE referencing */
-      parser_walk_tree (parser, stmt, do_check_cte_spec, &has_cte_spec, NULL, NULL);
+      /* exclude cache from CTE or system class referencing */
+      parser_walk_tree (parser, stmt, do_check_cte_or_system_class_spec, &has_cte_or_system_class, NULL, NULL);
 
-      if (has_cte_spec)
+      if (has_cte_or_system_class)
 	{
 	  goto stop_walk;
 	}

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -3608,9 +3608,12 @@ do_prepare_subquery_pre (PARSER_CONTEXT * parser, PT_NODE * stmt, void *arg, int
       && (stmt->info.query.hint & PT_HINT_QUERY_CACHE))
     {
       bool has_cte_or_system_class = false;
+      PT_NODE *saved = stmt->next;
 
       /* exclude cache from CTE or system class referencing */
+      stmt->next = NULL;
       parser_walk_tree (parser, stmt, do_check_cte_or_system_class_spec, &has_cte_or_system_class, NULL, NULL);
+      stmt->next = saved;
 
       if (has_cte_or_system_class)
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25579

system class가 포함된 서브 쿼리에 대해 캐시하지 않도록 로직을 추가했습니다.