### PR TITLE
[CBRD-25586] Fix the problem that query entries with no result sets are not freed (#5489)

### DIFF
--- a/src/method/method_invoke_group.cpp
+++ b/src/method/method_invoke_group.cpp
@@ -426,6 +426,7 @@ namespace cubmethod
     if (query_id == NULL_QUERY_ID || query_id >= SHRT_MAX)
       {
 	// false query e.g) SELECT * FROM db_class WHERE 0 <> 0
+	assert (query_id == NULL_QUERY_ID);
 	return nullptr;
       }
 

--- a/src/method/method_query_handler.cpp
+++ b/src/method/method_query_handler.cpp
@@ -523,11 +523,8 @@ namespace cubmethod
 
     if (qres && qres->type == T_SELECT)
       {
-	if (qresult.tuple_count > 0)
-	  {
-	    result_info.query_id = qres->res.s.query_id;
-	  }
-	else
+	result_info.query_id = qres->res.s.query_id;
+	if (result_info.query_id == NULL_QUERY_ID || result_info.query_id >= SHRT_MAX)
 	  {
 	    result_info.query_id = NULL_QUERY_ID; // initialized value
 	  }

--- a/src/method/method_query_handler.cpp
+++ b/src/method/method_query_handler.cpp
@@ -524,7 +524,7 @@ namespace cubmethod
     if (qres && qres->type == T_SELECT)
       {
 	result_info.query_id = qres->res.s.query_id;
-	if (result_info.query_id == NULL_QUERY_ID || result_info.query_id >= SHRT_MAX)
+	if (result_info.query_id >= SHRT_MAX) // handle invalid value
 	  {
 	    result_info.query_id = NULL_QUERY_ID; // initialized value
 	  }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25586

backport of #5489 
