### PR TITLE
[CBRD-24941] slip: missing the Long type indicator 'L' to zeroes

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -2135,7 +2135,7 @@ public class SpLib {
         if (l == null || r == null) {
             return null;
         }
-        if (r.equals(0)) {
+        if (r.equals(0L)) {
             throw new ZERO_DIVIDE();
         }
 
@@ -2247,7 +2247,7 @@ public class SpLib {
         if (l == null || r == null) {
             return null;
         }
-        if (r.equals(0)) {
+        if (r.equals(0L)) {
             throw new ZERO_DIVIDE();
         }
         return l / r;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24941

예전에 비슷한 수정이 있었는데, 두 군데 더 해주어야 했습니다. 
