### PR TITLE
[CBRD-25589] PREPARE 구문을 사용할 때 쿼리 캐시

### DIFF
--- a/src/compat/db_query.c
+++ b/src/compat/db_query.c
@@ -472,6 +472,8 @@ db_pack_prepare_info (const DB_PREPARE_INFO * info, char **buffer)
   packed_size += OR_INT_SIZE;
   /* recompile */
   packed_size += OR_INT_SIZE;
+  /* do_cache */
+  packed_size += OR_INT_SIZE;
   /* oids included */
   packed_size += OR_INT_SIZE;
   /* into list length */
@@ -516,6 +518,8 @@ db_pack_prepare_info (const DB_PREPARE_INFO * info, char **buffer)
   ptr = or_pack_int (ptr, info->auto_param_count);
   /* recompile */
   ptr = or_pack_int (ptr, info->recompile);
+  /* do_cache */
+  ptr = or_pack_int (ptr, info->do_cache);
   /* oids included */
   ptr = or_pack_int (ptr, info->oids_included);
   /* into list length */
@@ -585,6 +589,8 @@ db_unpack_prepare_info (DB_PREPARE_INFO * info, char *buffer)
   ptr = or_unpack_int (ptr, &info->auto_param_count);
   /* unpack recompile */
   ptr = or_unpack_int (ptr, &info->recompile);
+  /* unpack do_cache */
+  ptr = or_unpack_int (ptr, &info->do_cache);
   /* oids included */
   ptr = or_unpack_int (ptr, &info->oids_included);
   /* unpack into list length */

--- a/src/compat/db_query.h
+++ b/src/compat/db_query.h
@@ -158,6 +158,7 @@ extern "C"
     TP_DOMAIN **host_var_expected_domains;
     int auto_param_count;	/* number of auto parametrized values */
     int recompile;		/* statement should be recompiled */
+    int do_cache;		/* statement uses result cache */
     int oids_included;
     char **into_list;		/* names of the "into" variables */
     int into_count;		/* count of elements from the into array */

--- a/src/compat/db_vdb.c
+++ b/src/compat/db_vdb.c
@@ -2563,10 +2563,14 @@ do_process_prepare_statement (DB_SESSION * session, PT_NODE * statement)
   prepare_info.auto_param_count = prepared_session->parser->auto_param_count;
   /* set recompile */
   prepare_info.recompile = prepared_stmt->flag.recompile;
-  /* set OIDs included */
+
   if (prepare_info.stmt_type == CUBRID_STMT_SELECT)
     {
+      /* set OIDs included */
       prepare_info.oids_included = prepared_stmt->info.query.oids_included;
+
+      /* set result cache */
+      prepare_info.do_cache = prepared_stmt->info.query.flag.do_cache;
     }
 
   err = set_prepare_info_into_list (&prepare_info, prepared_stmt);
@@ -2690,6 +2694,7 @@ do_get_prepared_statement_info (DB_SESSION * session, int stmt_idx, int *subquer
       PT_INTERNAL_ERROR (parser, "allocate new node");
     }
   statement->info.execute.recompile = prepare_info.recompile;
+  statement->info.execute.do_cache = prepare_info.do_cache;
   statement->info.execute.oids_included = prepare_info.oids_included;
 
   XASL_ID_COPY (&statement->info.execute.xasl_id, &xasl_id);

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -3399,6 +3399,7 @@ struct pt_execute_info
   XASL_ID xasl_id;		/* XASL id */
   CUBRID_STMT_TYPE stmt_type;	/* statement type */
   int recompile;		/* not 0 if this statement should be recompiled */
+  int do_cache;			/* query uses result cache */
   int column_count;		/* select list column count */
   int oids_included;		/* OIDs included in select list */
 };

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -14996,6 +14996,11 @@ do_execute_session_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
       query_flag |= TRAN_AUTO_COMMIT;
     }
 
+  if (statement->info.execute.do_cache)
+    {
+      query_flag |= RESULT_CACHE_REQUIRED;
+    }
+
   if (query_trace == true)
     {
       do_set_trace_to_query_flag (&query_flag);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25589

PREPARE 문에서 서브쿼리 캐시는 적용되었으나, 기존의 쿼리 캐시에서 PREPARE 구문에 포함된 쿼리 캐시는 스펙에서 누락되었다. 예를 들면, 아래와 같은 PREPARE 구문은 캐시가 되지 않고 있다.

`PREPARE st from 'select /*+ query_cache */ a from xoo where a = to_number(?) and a = ?';`

PREPARE 구문에 대해서도 캐시가 되도록 로직을 추가한다.