### PR TITLE
[CBRD-24414] Align output of restoredb --list

### DIFF
--- a/msg/en_US.utf8/cubrid.msg
+++ b/msg/en_US.utf8/cubrid.msg
@@ -2142,7 +2142,7 @@ $set 15 MSGCAT_SET_IO
    Volume Name: %2$s\n\
    Unit Num: %3$d\n\
    Backup Level: %4$d (%5$s)\n\
-   Enter one of the following options:\n
+Enter one of the following options:\n
 11 Type\n \
   -  %1$d to quit.\n \
   -  %2$d to continue after the volume is mounted/loaded. (retry) \n \

--- a/msg/en_US.utf8/cubrid.msg
+++ b/msg/en_US.utf8/cubrid.msg
@@ -2126,19 +2126,19 @@ $set 15 MSGCAT_SET_IO
 2 Backup = %1$s is needed. \n It must be mounted/loaded to continue.\n Type 1 to continue after the backup is mounted/loaded.\n Type 0 to quit.\n
 3 \n\n*** BACKUP HEADER INFORMATION ***\n\n
 4 Backup magic file identification %1$s,\n
-5          Release: %1$s\n\
+5 Release: %1$s\n\
    Disk Version: %2$g\n
-6    Database Name: %1$s\n\
+6 Database Name: %1$s\n\
    DB Creation Time: %2$s\
    Pagesize: %3$d\n
-7     Backup Level: %1$d (%2$s)\n\
+7 Backup Level: %1$d (%2$s)\n\
    Start_lsa: %3$lld|%4$d\n\
    Last_lsa: %5$lld|%6$d\n
-8      Backup Time: %1$s\
+8 Backup Time: %1$s\
    Backup Unit Num: %2$d\n
-9  Database Volume Name: %1$s\n\
+9 Database Volume Name: %1$s\n\
    Volume Identifier: %2$d, Size: %3$lld bytes (%4$d pages)\n
-10   Database Name: %1$s\n\
+10 Database Name: %1$s\n\
    Volume Name: %2$s\n\
    Unit Num: %3$d\n\
    Backup Level: %4$d (%5$s)\n\
@@ -2157,15 +2157,15 @@ $set 15 MSGCAT_SET_IO
 19 Backup volume %1$s timestamp mismatch\n  (Timestamp: %2$s, expecting %3$s).\n\n
 20 Backup volume information file error, line %1$d.\n
 21 Backup Volume Label: Level: %1$d, Unit: %2$d, Database %3$s, Backup Time: %4$s\n
-22     Previous Backup Level: %1$d\n\
+22 Previous Backup Level: %1$d\n\
    Time: %2$s\
    (start_lsa was %3$lld|%4$d)\n
 23 The following database backup volume is needed to continue restoring:\n\n
 24 Backup destination is full, a new destination is required to continue:\n\n
 25 Preceding Backup Volume Name: %1$s\n
-26     Next Backup Volume Name: %1$s\n
-27  Backup Pagesize: %1$d\n
-28       Zip Method: %1$d (%2$s)\n\
+26 Next Backup Volume Name: %1$s\n
+27 Backup Pagesize: %1$d\n
+28 Zip Method: %1$d (%2$s)\n\
    Zip Level: %3$d (%4$s)\n
 29 Include Active Log: %1$s\n
 

--- a/msg/en_US.utf8/cubrid.msg
+++ b/msg/en_US.utf8/cubrid.msg
@@ -2127,21 +2127,21 @@ $set 15 MSGCAT_SET_IO
 3 \n\n*** BACKUP HEADER INFORMATION ***\n\n
 4 Backup magic file identification %1$s,\n
 5          Release: %1$s\n\
-     Disk Version: %2$g\n
+Disk Version: %2$g\n
 6    Database Name: %1$s\n\
- DB Creation Time: %2$s\
-         Pagesize: %3$d\n
+DB Creation Time: %2$s\
+Pagesize: %3$d\n
 7     Backup Level: %1$d (%2$s)\n\
-        Start_lsa: %3$lld|%4$d\n\
-         Last_lsa: %5$lld|%6$d\n
+Start_lsa: %3$lld|%4$d\n\
+Last_lsa: %5$lld|%6$d\n
 8      Backup Time: %1$s\
-  Backup Unit Num: %2$d\n
+Backup Unit Num: %2$d\n
 9  Database Volume name: %1$s\n\
-   Volume Identifier: %2$d, Size: %3$lld bytes (%4$d pages)\n
+Volume Identifier: %2$d, Size: %3$lld bytes (%4$d pages)\n
 10   Database Name: %1$s\n\
-     Volume Name: %2$s\n\
-        Unit Num: %3$d\n\
-    Backup Level: %4$d (%5$s)\n\
+Volume Name: %2$s\n\
+Unit Num: %3$d\n\
+Backup Level: %4$d (%5$s)\n\
 Enter one of the following options:\n
 11 Type\n \
   -  %1$d to quit.\n \
@@ -2164,7 +2164,7 @@ Enter one of the following options:\n
 26     Next Backup Volume Name: %1$s\n
 27  Backup Pagesize: %1$d\n
 28       Zip Method: %1$d (%2$s)\n\
-        Zip Level: %3$d (%4$s)\n
+Zip Level: %3$d (%4$s)\n
 29 Include Active Log: %1$s\n
 
 $set 16 MSGCAT_SET_LOG

--- a/msg/en_US.utf8/cubrid.msg
+++ b/msg/en_US.utf8/cubrid.msg
@@ -2127,22 +2127,22 @@ $set 15 MSGCAT_SET_IO
 3 \n\n*** BACKUP HEADER INFORMATION ***\n\n
 4 Backup magic file identification %1$s,\n
 5          Release: %1$s\n\
-Disk Version: %2$g\n
+   Disk Version: %2$g\n
 6    Database Name: %1$s\n\
-DB Creation Time: %2$s\
-Pagesize: %3$d\n
+   DB Creation Time: %2$s\
+   Pagesize: %3$d\n
 7     Backup Level: %1$d (%2$s)\n\
-Start_lsa: %3$lld|%4$d\n\
-Last_lsa: %5$lld|%6$d\n
+   Start_lsa: %3$lld|%4$d\n\
+   Last_lsa: %5$lld|%6$d\n
 8      Backup Time: %1$s\
-Backup Unit Num: %2$d\n
-9  Database Volume name: %1$s\n\
-Volume Identifier: %2$d, Size: %3$lld bytes (%4$d pages)\n
+   Backup Unit Num: %2$d\n
+9  Database Volume Name: %1$s\n\
+   Volume Identifier: %2$d, Size: %3$lld bytes (%4$d pages)\n
 10   Database Name: %1$s\n\
-Volume Name: %2$s\n\
-Unit Num: %3$d\n\
-Backup Level: %4$d (%5$s)\n\
-Enter one of the following options:\n
+   Volume Name: %2$s\n\
+   Unit Num: %3$d\n\
+   Backup Level: %4$d (%5$s)\n\
+   Enter one of the following options:\n
 11 Type\n \
   -  %1$d to quit.\n \
   -  %2$d to continue after the volume is mounted/loaded. (retry) \n \
@@ -2157,14 +2157,16 @@ Enter one of the following options:\n
 19 Backup volume %1$s timestamp mismatch\n  (Timestamp: %2$s, expecting %3$s).\n\n
 20 Backup volume information file error, line %1$d.\n
 21 Backup Volume Label: Level: %1$d, Unit: %2$d, Database %3$s, Backup Time: %4$s\n
-22     Previous Backup level: %1$d Time: %2$s (start_lsa was %3$lld|%4$d)\n
+22     Previous Backup Level: %1$d\n\
+   Time: %2$s\
+   (start_lsa was %3$lld|%4$d)\n
 23 The following database backup volume is needed to continue restoring:\n\n
 24 Backup destination is full, a new destination is required to continue:\n\n
 25 Preceding Backup Volume Name: %1$s\n
 26     Next Backup Volume Name: %1$s\n
 27  Backup Pagesize: %1$d\n
 28       Zip Method: %1$d (%2$s)\n\
-Zip Level: %3$d (%4$s)\n
+   Zip Level: %3$d (%4$s)\n
 29 Include Active Log: %1$s\n
 
 $set 16 MSGCAT_SET_LOG

--- a/msg/ko_KR.utf8/cubrid.msg
+++ b/msg/ko_KR.utf8/cubrid.msg
@@ -2126,22 +2126,22 @@ $set 15 MSGCAT_SET_IO
 2 백업 = %1$s 이(가) 필요합니다. \n 계속하려면 마운트/로드되어야 합니다.\n 마운트/로드 이후 계속하려면 1을 입력하세요.\n 종료하려면 0을 입력하세요.\n
 3 \n\n*** BACKUP HEADER INFORMATION ***\n\n
 4 Backup magic file identification %1$s,\n
-5           Release: %1$s\n\
-     Disk Version: %2$g\n
-6     Database Name: %1$s\n\
- DB Creation Time: %2$s\
-         Pagesize: %3$d\n
-7      Backup Level: %1$d (%2$s)\n\
-        Start_lsa: %3$lld|%4$d\n\
-         Last_lsa: %5$lld|%6$d\n
-8       Backup Time: %1$s\
-  Backup Unit Num: %2$d\n
+5          Release: %1$s\n\
+Disk Version: %2$g\n
+6    Database Name: %1$s\n\
+DB Creation Time: %2$s\
+Pagesize: %3$d\n
+7     Backup Level: %1$d (%2$s)\n\
+Start_lsa: %3$lld|%4$d\n\
+Last_lsa: %5$lld|%6$d\n
+8      Backup Time: %1$s\
+Backup Unit Num: %2$d\n
 9  Database Volume name: %1$s\n\
-   Volume Identifier: %2$d, Size: %3$lld bytes (%4$d pages)\n
-10    Database Name: %1$s\n\
-     Volume Name: %2$s\n\
-        Unit Num: %3$d\n\
-    Backup Level: %4$d (%5$s)\n\
+Volume Identifier: %2$d, Size: %3$lld bytes (%4$d pages)\n
+10   Database Name: %1$s\n\
+Volume Name: %2$s\n\
+Unit Num: %3$d\n\
+Backup Level: %4$d (%5$s)\n\
 다음 옵션 중 하나를 선택하시오:\n
 11 입력\n \
   -  %1$d: 종료\n \
@@ -2163,8 +2163,8 @@ $set 15 MSGCAT_SET_IO
 25 이전 백업 볼륨 이름: %1$s\n
 26      다음 백업 볼륨 이름: %1$s\n
 27   Backup Pagesize: %1$d\n
-28        Zip Method: %1$d (%2$s)\n\
-        Zip Level: %3$d (%4$s)\n
+28       Zip Method: %1$d (%2$s)\n\
+Zip Level: %3$d (%4$s)\n
 29 Include Active Log: %1$s\n
 
 $set 16 MSGCAT_SET_LOG

--- a/msg/ko_KR.utf8/cubrid.msg
+++ b/msg/ko_KR.utf8/cubrid.msg
@@ -2127,21 +2127,21 @@ $set 15 MSGCAT_SET_IO
 3 \n\n*** BACKUP HEADER INFORMATION ***\n\n
 4 Backup magic file identification %1$s,\n
 5          Release: %1$s\n\
-Disk Version: %2$g\n
+   Disk Version: %2$g\n
 6    Database Name: %1$s\n\
-DB Creation Time: %2$s\
-Pagesize: %3$d\n
+   DB Creation Time: %2$s\
+   Pagesize: %3$d\n
 7     Backup Level: %1$d (%2$s)\n\
-Start_lsa: %3$lld|%4$d\n\
-Last_lsa: %5$lld|%6$d\n
+   Start_lsa: %3$lld|%4$d\n\
+   Last_lsa: %5$lld|%6$d\n
 8      Backup Time: %1$s\
-Backup Unit Num: %2$d\n
-9  Database Volume name: %1$s\n\
-Volume Identifier: %2$d, Size: %3$lld bytes (%4$d pages)\n
+   Backup Unit Num: %2$d\n
+9  Database Volume Name: %1$s\n\
+   Volume Identifier: %2$d, Size: %3$lld bytes (%4$d pages)\n
 10   Database Name: %1$s\n\
-Volume Name: %2$s\n\
-Unit Num: %3$d\n\
-Backup Level: %4$d (%5$s)\n\
+   Volume Name: %2$s\n\
+   Unit Num: %3$d\n\
+   Backup Level: %4$d (%5$s)\n\
 다음 옵션 중 하나를 선택하시오:\n
 11 입력\n \
   -  %1$d: 종료\n \
@@ -2157,14 +2157,16 @@ Backup Level: %4$d (%5$s)\n\
 19 백업 볼륨 %1$s의 timestamp가 올바르지 않습니다.\n   (Timestamp: %2$s, 예상: %3$s).\n\n
 20 백업 볼륨 정보 파일 에러, 라인 %1$d.\n
 21 백업 볼륨 라벨: Level: %1$d, Unit: %2$d, Database %3$s, Backup Time: %4$s\n
-22      이전 백업 Level: %1$d Time: %2$s (start_lsa was %3$lld|%4$d)\n
+22      이전 백업 Level: %1$d\n\
+   Time: %2$s\
+   (start_lsa was %3$lld|%4$d)\n
 23 데이터베이스 복구를 위해서 다음의 백업 볼륨이 필요합니다:\n\n
 24 백업 장치의 여유 공간이 없습니다. 계속 진행하기 위해서 새로운 백업 장치가 필요합니다:\n\n
 25 이전 백업 볼륨 이름: %1$s\n
 26      다음 백업 볼륨 이름: %1$s\n
 27   Backup Pagesize: %1$d\n
 28       Zip Method: %1$d (%2$s)\n\
-Zip Level: %3$d (%4$s)\n
+   Zip Level: %3$d (%4$s)\n
 29 Include Active Log: %1$s\n
 
 $set 16 MSGCAT_SET_LOG

--- a/msg/ko_KR.utf8/cubrid.msg
+++ b/msg/ko_KR.utf8/cubrid.msg
@@ -2126,19 +2126,19 @@ $set 15 MSGCAT_SET_IO
 2 백업 = %1$s 이(가) 필요합니다. \n 계속하려면 마운트/로드되어야 합니다.\n 마운트/로드 이후 계속하려면 1을 입력하세요.\n 종료하려면 0을 입력하세요.\n
 3 \n\n*** BACKUP HEADER INFORMATION ***\n\n
 4 Backup magic file identification %1$s,\n
-5           Release: %1$s\n\
+5 Release: %1$s\n\
    Disk Version: %2$g\n
-6    Database Name: %1$s\n\
+6 Database Name: %1$s\n\
    DB Creation Time: %2$s\
    Pagesize: %3$d\n
-7     Backup Level: %1$d (%2$s)\n\
+7 Backup Level: %1$d (%2$s)\n\
    Start_lsa: %3$lld|%4$d\n\
    Last_lsa: %5$lld|%6$d\n
-8      Backup Time: %1$s\
+8 Backup Time: %1$s\
    Backup Unit Num: %2$d\n
-9  Database Volume Name: %1$s\n\
+9 Database Volume Name: %1$s\n\
    Volume Identifier: %2$d, Size: %3$lld bytes (%4$d pages)\n
-10    Database Name: %1$s\n\
+10 Database Name: %1$s\n\
    Volume Name: %2$s\n\
    Unit Num: %3$d\n\
    Backup Level: %4$d (%5$s)\n\
@@ -2157,15 +2157,15 @@ $set 15 MSGCAT_SET_IO
 19 백업 볼륨 %1$s의 timestamp가 올바르지 않습니다.\n   (Timestamp: %2$s, 예상: %3$s).\n\n
 20 백업 볼륨 정보 파일 에러, 라인 %1$d.\n
 21 백업 볼륨 라벨: Level: %1$d, Unit: %2$d, Database %3$s, Backup Time: %4$s\n
-22      이전 백업 Level: %1$d\n\
+22 이전 백업 Level: %1$d\n\
    Time: %2$s\
    (start_lsa was %3$lld|%4$d)\n
 23 데이터베이스 복구를 위해서 다음의 백업 볼륨이 필요합니다:\n\n
 24 백업 장치의 여유 공간이 없습니다. 계속 진행하기 위해서 새로운 백업 장치가 필요합니다:\n\n
 25 이전 백업 볼륨 이름: %1$s\n
-26      다음 백업 볼륨 이름: %1$s\n
-27   Backup Pagesize: %1$d\n
-28        Zip Method: %1$d (%2$s)\n\
+26 다음 백업 볼륨 이름: %1$s\n
+27 Backup Pagesize: %1$d\n
+28 Zip Method: %1$d (%2$s)\n\
    Zip Level: %3$d (%4$s)\n
 29 Include Active Log: %1$s\n
 

--- a/msg/ko_KR.utf8/cubrid.msg
+++ b/msg/ko_KR.utf8/cubrid.msg
@@ -2126,7 +2126,7 @@ $set 15 MSGCAT_SET_IO
 2 백업 = %1$s 이(가) 필요합니다. \n 계속하려면 마운트/로드되어야 합니다.\n 마운트/로드 이후 계속하려면 1을 입력하세요.\n 종료하려면 0을 입력하세요.\n
 3 \n\n*** BACKUP HEADER INFORMATION ***\n\n
 4 Backup magic file identification %1$s,\n
-5          Release: %1$s\n\
+5           Release: %1$s\n\
    Disk Version: %2$g\n
 6    Database Name: %1$s\n\
    DB Creation Time: %2$s\
@@ -2138,7 +2138,7 @@ $set 15 MSGCAT_SET_IO
    Backup Unit Num: %2$d\n
 9  Database Volume Name: %1$s\n\
    Volume Identifier: %2$d, Size: %3$lld bytes (%4$d pages)\n
-10   Database Name: %1$s\n\
+10    Database Name: %1$s\n\
    Volume Name: %2$s\n\
    Unit Num: %3$d\n\
    Backup Level: %4$d (%5$s)\n\
@@ -2165,7 +2165,7 @@ $set 15 MSGCAT_SET_IO
 25 이전 백업 볼륨 이름: %1$s\n
 26      다음 백업 볼륨 이름: %1$s\n
 27   Backup Pagesize: %1$d\n
-28       Zip Method: %1$d (%2$s)\n\
+28        Zip Method: %1$d (%2$s)\n\
    Zip Level: %3$d (%4$s)\n
 29 Include Active Log: %1$s\n
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24414

- Purpose
  - restoredb --list의 output message의 indentation이 맞지 않던 문제
- Implementation
  - `cubrid.msg` message 수정
