### PR TITLE
[CBRD-25521] Make cppcheck skip checking the src/heaplayers/malloc_2_8_3.c file if it hasn't been modified

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -176,7 +176,14 @@ jobs:
             *) continue ;; # skip others
             esac
 
-            ${{ env.CPPCHECK_PATH }}/cppcheck --force -j4 --inline-suppr --suppressions-list=.github/workflows/cppcheck-spr-list --quiet --enable=warning -iheaplayers $f 2>>$result_file
+            # cppcheck can use the -i option to ignore files in a specified directory like -iheaplayers.
+            # However, this option may not work correctly for files like malloc_2_8_3.c that are included in lea_heap.c.
+            # So, make sure cppcheck does not check any files under the src/heaplayers directory.
+            if [[ $f =~ ^src/heaplayers/.* ]]; then
+              continue
+            fi
+
+            ${{ env.CPPCHECK_PATH }}/cppcheck --force -j4 --inline-suppr --suppressions-list=.github/workflows/cppcheck-spr-list --quiet --enable=warning $f 2>>$result_file
           done
 
           echo "errors: `cat $result_file | grep " error: " | wc -l`" > $summary_file

--- a/src/heaplayers/lea_heap.c
+++ b/src/heaplayers/lea_heap.c
@@ -51,6 +51,9 @@
 #define system_malloc my_malloc
 #define system_free my_free
 
+#define CUBRIDCUBRIDCUBRID
+#undef CUBRIDCUBRIDCUBRID
+
 static void *my_malloc (size_t sz);
 static int my_free (void *p);
 

--- a/src/heaplayers/lea_heap.c
+++ b/src/heaplayers/lea_heap.c
@@ -51,9 +51,6 @@
 #define system_malloc my_malloc
 #define system_free my_free
 
-#define CUBRIDCUBRIDCUBRID
-#undef CUBRIDCUBRIDCUBRID
-
 static void *my_malloc (size_t sz);
 static int my_free (void *p);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25521

**Purpose**
- #5240에서 수정되지 않은 malloc_2_8_3.c 파일에 대한 cppcheck가 수행 됨
- 분석 시 malloc_2_8_3.c는 lea_heap.c 파일에 #include 되어 있으며, 이에 따라 cppcheck ... lea_heap.c 수행 시 malloc_2_8_3.c 역시 cppcheck로 검사 됨
- cppcheck 수행 시 이미 -iheaplayers 옵션으로 두 파일이 속한 경로를 무시하도록 설정되어 있으나 malloc_2_8_3.c 처럼 include 되어 검사 대상이 되는 경우에는 이 옵션이 적용되지 않음 

**Implementation**
- 쉘에서 if [[ $f =~ ^src/heaplayers/.* ]]; 조건으로 src/heaplayers/ 경로 상의 파일은 cppcheck가 수행되지 않도록 처리
- cppcheck 수행 시 불필요해진 -iheaplayers 옵션 제거

**Remarks**
- 수정이 정상적으로 동작하는지 확인하기 위해 src/heaplayers/lea_heap.c 파일을 임의로 수정
  - 기대 결과는 lea_heap.c 파일이 수정되었지만 cppcheck에서 에러가 발생하지 않아야 함
- 리뷰 완료 후 lea_heap.c 수정은 원복 후 병합 예정