### PR TITLE
[CBRD-25493] update docs to specify CMake version 3.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ Follow tutorials at:
   - GCC 8.3 or newer (devtoolset-8 is recommended)
   - Visual Studio 2017 version 15.0 or newer
 - A Java Developer Kit (JDK) 1.8 or newer required
-- CMake 2.8 or newer
-  - To use ninja build system, CMake 3.16.3 or later is required
+- CMake 3.21 or newer
 - For more information about 3rdparty libraries, see [3rdparty/README.md](3rdparty/README.md)
 
 ### How to Install the Build Requirements

--- a/docs/install_build_requirements.md
+++ b/docs/install_build_requirements.md
@@ -6,8 +6,7 @@
   - GCC 8.3 or newer (devtoolset-8 is recommended)
   - Visual Studio 2017 version 15.0 or newer
 - A Java Developer Kit (JDK) 1.8 or newer required
-- CMake 2.8 or newer
-  - To use ninja build system, CMake 3.16.3 or later is required
+- CMake 3.21 or newer
 - 3rdparty libraries that you need to install on your development environments.
 
 ## Linux (Fedora/RHEL/CentOS)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25493

영어, 한국어 이외의 언어로 된 메세지를 제거하는 과정에서
cmake 의 최소 버전이 3.21로 업데이트 된 사실을 문서에 반영합니다.
