### PR TITLE
[CBRD-25594] zero date from JSP

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/data/CUBRIDPacker.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/data/CUBRIDPacker.java
@@ -31,6 +31,7 @@
 
 package com.cubrid.jsp.data;
 
+import com.cubrid.jsp.value.ValueUtilities;
 import com.cubrid.jsp.jdbc.CUBRIDServerSideResultSet;
 import com.cubrid.jsp.protocol.PackableObject;
 import cubrid.sql.CUBRIDOID;
@@ -176,17 +177,29 @@ public class CUBRIDPacker {
             packString((String) result, charset);
         } else if (result instanceof java.sql.Date) {
             packInt(DBType.DB_DATE);
-            packString(result.toString(), charset);
+            if (result.equals(ValueUtilities.NULL_DATE)) {
+                packString("0000-00-00", charset);
+            } else {
+                packString(result.toString(), charset);
+            }
         } else if (result instanceof java.sql.Time) {
             packInt(DBType.DB_TIME);
             packString(result.toString(), charset);
         } else if (result instanceof java.sql.Timestamp) {
             packInt(ret_type);
             if (ret_type == DBType.DB_DATETIME) {
-                packString(result.toString());
+                if (result.equals(ValueUtilities.NULL_DATETIME)) {
+                    packString("0000-00-00 00:00:00.000");
+                } else {
+                    packString(result.toString());
+                }
             } else {
-                SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-                packString(formatter.format(result));
+                if (result.equals(ValueUtilities.NULL_TIMESTAMP)) {
+                    packString("0000-00-00 00:00:00");
+                } else {
+                    SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+                    packString(formatter.format(result));
+                }
             }
         } else if (result instanceof CUBRIDOID) {
             packInt(DBType.DB_OBJECT);

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/data/CUBRIDPacker.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/data/CUBRIDPacker.java
@@ -31,9 +31,9 @@
 
 package com.cubrid.jsp.data;
 
-import com.cubrid.jsp.value.ValueUtilities;
 import com.cubrid.jsp.jdbc.CUBRIDServerSideResultSet;
 import com.cubrid.jsp.protocol.PackableObject;
+import com.cubrid.jsp.value.ValueUtilities;
 import cubrid.sql.CUBRIDOID;
 import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/ValueUtilities.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/ValueUtilities.java
@@ -208,6 +208,6 @@ public class ValueUtilities {
     public static final Timestamp MAX_DATETIME = Timestamp.valueOf(DateTimeParser.maxDatetimeLocal);
 
     public static final Date NULL_DATE = new Date(0 - 1900, 0 - 1, 0);
-    public static final Timestamp NULL_TIMESTAMP = new Timestamp(0 - 1900, 0 - 1, 0, 0, 0, 0, 0);
+    public static final Timestamp NULL_TIMESTAMP = new Timestamp(0 - 1900, 0 - 1, 0, 0, 0, 0, 0); // TODO: CBRD-25595
     public static final Timestamp NULL_DATETIME = new Timestamp(0 - 1900, 0 - 1, 0, 0, 0, 0, 0);
 }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/ValueUtilities.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/ValueUtilities.java
@@ -208,6 +208,7 @@ public class ValueUtilities {
     public static final Timestamp MAX_DATETIME = Timestamp.valueOf(DateTimeParser.maxDatetimeLocal);
 
     public static final Date NULL_DATE = new Date(0 - 1900, 0 - 1, 0);
-    public static final Timestamp NULL_TIMESTAMP = new Timestamp(0 - 1900, 0 - 1, 0, 0, 0, 0, 0); // TODO: CBRD-25595
+    public static final Timestamp NULL_TIMESTAMP =
+            new Timestamp(0 - 1900, 0 - 1, 0, 0, 0, 0, 0); // TODO: CBRD-25595
     public static final Timestamp NULL_DATETIME = new Timestamp(0 - 1900, 0 - 1, 0, 0, 0, 0, 0);
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25594

SP 서버로부터 CUBRID 서버로 DATE, DATETIME, TIMESTAMP 값을 보낼 때 값을 문자열로 바꾸어 보냅니다. 
각 타입의 zero 값의 연월일이 0002-11-30 로 잘못 인식되는 문제가 있어 서버 코어 등 문제를 일으키고 있었습니다. 
pack 하기 전에 zero 값인지를 검사하여 알맞은 문자열을 사용하도록 했습니다. 
