### PR TITLE
[CBRD-25564] epoch is a valid (zero) Timestamp value

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/DatetimeValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/DatetimeValue.java
@@ -85,7 +85,8 @@ public class DatetimeValue extends Value {
     public Timestamp toTimestamp() throws TypeMismatchException {
         long sec = timestamp.getTime() / 1000L; // truncate milli-seconds
         Timestamp ret = new Timestamp(sec * 1000L);
-        if (!ValueUtilities.checkValidTimestamp(ret)) {
+        ret = ValueUtilities.checkValidTimestamp(ret);
+        if (ret == null) {
             throw new TypeMismatchException("out of valid range of a Timestamp: " + timestamp);
         }
         return ret;

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/ValueUtilities.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/ValueUtilities.java
@@ -174,16 +174,21 @@ public class ValueUtilities {
         return d.compareTo(MIN_DATE) >= 0 && d.compareTo(MAX_DATE) <= 0;
     }
 
-    public static boolean checkValidTimestamp(Timestamp ts) {
+    public static Timestamp checkValidTimestamp(Timestamp ts) {
         if (ts == null) {
-            return false;
+            return null;
         }
 
-        if (ts.equals(NULL_TIMESTAMP)) {
-            return true;
+        // '1970-01-01 00:00:00' (GMT) amounts to the Null Timestamp '0000-00-00 00:00:00' in CUBRID
+        if (ts.equals(NULL_TIMESTAMP) || ts.getTime() == 0L) {
+            return NULL_TIMESTAMP;
         }
 
-        return ts.compareTo(MIN_TIMESTAMP) >= 0 && ts.compareTo(MAX_TIMESTAMP) <= 0;
+        if (ts.compareTo(MIN_TIMESTAMP) >= 0 && ts.compareTo(MAX_TIMESTAMP) <= 0) {
+            return ts;
+        } else {
+            return null;
+        }
     }
 
     public static boolean checkValidDatetime(Timestamp dt) {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -2480,7 +2480,8 @@ public class SpLib {
 
         LocalDateTime lldt = l.toLocalDateTime();
         Timestamp ret = Timestamp.valueOf(lldt.plus(r.longValue(), ChronoUnit.SECONDS));
-        if (ValueUtilities.checkValidTimestamp(ret)) {
+        ret = ValueUtilities.checkValidTimestamp(ret);
+        if (ret != null) {
             return ret;
         } else {
             throw new VALUE_ERROR("not in the valid range of TIMESTAMP type");
@@ -2713,7 +2714,8 @@ public class SpLib {
 
         LocalDateTime lldt = l.toLocalDateTime();
         Timestamp ret = Timestamp.valueOf(lldt.minus(r.longValue(), ChronoUnit.SECONDS));
-        if (ValueUtilities.checkValidTimestamp(ret)) {
+        ret = ValueUtilities.checkValidTimestamp(ret);
+        if (ret != null) {
             return ret;
         } else {
             throw new VALUE_ERROR("not in the valid range of TIMESTAMP type");
@@ -2867,7 +2869,8 @@ public class SpLib {
                         e.getMinutes(),
                         e.getSeconds(),
                         0);
-        if (ValueUtilities.checkValidTimestamp(ret)) {
+        ret = ValueUtilities.checkValidTimestamp(ret);
+        if (ret != null) {
             return ret;
         } else {
             throw new VALUE_ERROR("not in the valid range of TIMESTAMP type");
@@ -2881,7 +2884,7 @@ public class SpLib {
         if (e.equals(ValueUtilities.NULL_DATETIME)) {
             // must be calculated everytime because the AM/PM indicator can change according to the
             // locale change
-            return String.format("00:00:00.000 %s 00/00/0000", AM_PM.format(ZERO_DATE));
+            return String.format("12:00:00.000 %s 00/00/0000", AM_PM.format(ZERO_DATE));
         }
 
         return DATETIME_FORMAT.format(e);
@@ -2908,7 +2911,8 @@ public class SpLib {
         }
 
         Timestamp ret = new Timestamp(e.getYear(), e.getMonth(), e.getDate(), 0, 0, 0, 0);
-        if (ValueUtilities.checkValidTimestamp(ret)) {
+        ret = ValueUtilities.checkValidTimestamp(ret);
+        if (ret != null) {
             return ret;
         } else {
             throw new VALUE_ERROR("not in the valid range of TIMESTAMP type");
@@ -2987,7 +2991,7 @@ public class SpLib {
         if (e.equals(ValueUtilities.NULL_TIMESTAMP)) {
             // must be calculated everytime because the AM/PM indicator can change according to the
             // locale change
-            return String.format("00:00:00 %s 00/00/0000", AM_PM.format(ZERO_DATE));
+            return String.format("12:00:00 %s 00/00/0000", AM_PM.format(ZERO_DATE));
         }
 
         Instant instant = Instant.ofEpochMilli(e.getTime());
@@ -4069,7 +4073,8 @@ public class SpLib {
     private static Timestamp longToTimestamp(long l) {
         try {
             Timestamp ret = ValueUtilities.longToTimestamp(l);
-            if (ValueUtilities.checkValidTimestamp(ret)) {
+            ret = ValueUtilities.checkValidTimestamp(ret);
+            if (ret != null) {
                 return ret;
             } else {
                 throw new VALUE_ERROR("not in the valid range of TIMESTAMP type");


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25564

Timestamp 의 값 범위 검사에서 한 가지 빠뜨린 부분의 구현입니다. 
1970-01-01 00:00:01 GMT 이 Timestamp 타입의 최소값이라고 사용자 메뉴얼에 명시되어 있지만, 
1970-01-01 00:00:00 GMT 도 valid 한 Timestamp 값이며 이는 Zero Timestamp 값으로 취급됩니다. 

추가로 사소한 변경이지만, 
Zero Timestamp와 Zero Datetime의 문자열 표현에서 "00:00:00 AM ..." 으로 되어 있던 것을 
큐브리드 엔진과 동일하게 "12:00:00 AM ..." 으로 출력되도록 수정하였습니다. 

아래 예제를 참고하세요.
```
csql> select timestamp'1970-01-01 09:00:00';    -- Zero Timestamp at +09:00

=== <Result of SELECT Command in Line 1> ===

  timestamp '1970-01-01 09:00:00'
=================================
  12:00:00 AM 00/00/0000         

1 row selected. (0.008814 sec) Committed. (0.000000 sec) 
```
