### PR TITLE
[CBRD-25596] An issue where the grant_option mask value is not properly revoked when the WITH GRANT OPTION is revoked.

### DIFF
--- a/src/object/authenticate_grant.cpp
+++ b/src/object/authenticate_grant.cpp
@@ -79,7 +79,7 @@ au_grant (MOP user, MOP class_mop, DB_AUTH type, bool grant_option)
   MOP auth;
   DB_SET *grants;
   DB_VALUE value;
-  int current, save = 0, gindex;
+  int current, save = 0, gindex, mask;
   SM_CLASS *classobj;
   int is_partition = DB_NOT_PARTITIONED_CLASS, i, savepoint_grant = 0;
   MOP *sub_partitions = NULL;
@@ -203,6 +203,15 @@ au_grant (MOP user, MOP class_mop, DB_AUTH type, bool grant_option)
 	      if (grant_option)
 		{
 		  current |= ((int) type << AU_GRANT_SHIFT);
+		}
+	      else
+		{
+		  mask = (int) ~ (type << AU_GRANT_SHIFT);
+		  current &= mask;
+		  if (current)
+		    {
+		      current |= (int) type;
+		    }
 		}
 
 	      db_make_int (&value, current);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25596

Purpose

WITH GRANT OPTION을 부여한 후 해지했을 때, 
db_auth 카탈로그에서 grantable 값은 'NO'로 변경되지만, db_authorization 카탈로그의 mask 값이 업데이트되지 않아 권한을 해지한 사용자가 여전히 다른 사용자에게 권한을 부여할 수 있는 문제가 있습니다

Implementation

N/A

Remarks

N/A