### PR TITLE
[CBRD-25548] get <cursor>%rowcount from a member variable of a Java object of the cursor

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -1295,6 +1295,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 "  }",
                 "  ResultSet rs = %'CURSOR'%.rs;",
                 "  if (rs.next()) {",
+                "    %'CURSOR'%.updateRowCount();",
                 "    %'+SET-INTO-VARIABLES'%",
                 "  } else {",
                 "    ;", // TODO: setting nulls to into-variables?
@@ -1577,6 +1578,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 "  ResultSet %'RECORD'%_r%'LEVEL'% = %'CURSOR'%.rs;",
                 "  %'LABEL'%",
                 "  while (%'RECORD'%_r%'LEVEL'%.next()) {",
+                "    %'CURSOR'%.updateRowCount();",
                 "    %'RECORD'%[0].set(",
                 "      %'+RECORD-FIELD-VALUES'%",
                 "    );",
@@ -1599,6 +1601,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 "  ResultSet %'RECORD'%_r%'LEVEL'% = %'CURSOR'%.rs;",
                 "  %'LABEL'%",
                 "  while (%'RECORD'%_r%'LEVEL'%.next()) {",
+                "    %'CURSOR'%.updateRowCount();",
                 "    %'RECORD'%[0].set(",
                 "      %'+RECORD-FIELD-VALUES'%",
                 "    );",

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -510,6 +510,7 @@ public class SpLib {
     public static class Query {
         public final String query;
         public ResultSet rs;
+        public int rowCount;
 
         public Query(String query) {
             this.query = query;
@@ -588,12 +589,15 @@ public class SpLib {
         }
 
         public long rowCount() {
+            if (!isOpen()) {
+                throw new INVALID_CURSOR("attempted to read an attribute of an unopened cursor");
+            }
+            return (long) rowCount;
+        }
+
+        public void updateRowCount() {
             try {
-                if (!isOpen()) {
-                    throw new INVALID_CURSOR(
-                            "attempted to read an attribute of an unopened cursor");
-                }
-                return (long) rs.getRow();
+                rowCount = rs.getRow();
             } catch (SQLException e) {
                 Server.log(e);
                 throw new SQL_ERROR(e.getMessage());


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25548

현재 구현에서 커서에 해당하는 자바 객체는 SpLib 에 정의된 Query 클래스입니다. 
기존에 커서의 %rowcount 속성은 Query 객체의 ResultSet의 getRow() 메소드를 호출하여 구해왔으나
ResultSet이 끝에 다다르면 getRow()가 0을 리턴하여 해당 이슈의 문제가 발생했습니다. 

Query 의 ResultSet의 next() 호출마다 Query 에 새로 도입된 rowCount 를 업데이트 해 두고 
%rowcount 속성을 이 rowCount 필드로부터 얻으면 해당 문제를 해결할 수 있습니다. 
