### PR TITLE
[CBRD-25549] print server output message in CSQL also on error results

### DIFF
--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -2310,6 +2310,10 @@ csql_execute_statements (const CSQL_ARGUMENT * csql_arg, int type, const void *s
 
 error:
   display_error (session, stmt_start_line_no);
+  if (csql_arg->pl_server_output)
+    {
+      csql_print_server_output (csql_arg);
+    }
   logddl_set_err_code (db_error_code ());
   if (do_abort_transaction)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25549

CSQL 에서 statement 실행 결과가 에러일 때도 server output message 를 (있으면) 출력하도록 수정했습니다. 
