### PR TITLE
[CBRD-25475] prevent BaseClassLoader's loadClass from returning null

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/TargetMethod.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/TargetMethod.java
@@ -83,20 +83,19 @@ public class TargetMethod {
         Class<?> c = null;
         try {
             c = cl.loadClass(name);
+            assert c != null;
             return c;
         } catch (ClassNotFoundException e) {
-            //
+            // ignore
         }
 
-        // TODO: CBRD-24514
         try {
             c = Server.class.getClassLoader().loadClass(name);
+            assert c != null;
             return c;
         } catch (ClassNotFoundException e) {
-            //
+            throw e;
         }
-
-        return c;
     }
 
     private Class<?>[] classesFor(String args) throws ClassNotFoundException, ExecuteException {
@@ -104,23 +103,23 @@ public class TargetMethod {
         if (args.length() == 0) {
             return new Class[0];
         }
-        // Count semicolons occurences.
-        int semiColons = 0;
+        // Count commas occurences.
+        int commas = 0;
         for (int i = 0; i < args.length(); i++) {
             if (args.charAt(i) == ',') {
-                semiColons++;
+                commas++;
             }
         }
-        Class<?>[] classes = new Class[semiColons + 1];
+        Class<?>[] classes = new Class[commas + 1];
 
         int index = 0;
-        for (int i = 0; i < semiColons; i++) {
+        for (int i = 0; i < commas; i++) {
             int sep = args.indexOf(',', index);
             classes[i] = classFor(args.substring(index, sep).trim());
             index = sep + 1;
         }
 
-        classes[semiColons] = classFor(args.substring(index).trim());
+        classes[commas] = classFor(args.substring(index).trim());
         return classes;
     }
 
@@ -130,7 +129,7 @@ public class TargetMethod {
             String arrTag;
             if (className.indexOf("[][]") >= 0) {
                 if (className.indexOf("[][][]") >= 0) {
-                    throw new ExecuteException("Unsupport data type: " + className);
+                    throw new ExecuteException("Unsupported data type: " + className);
                 }
                 arrTag = "[[";
             } else {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/classloader/BaseClassLoader.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/classloader/BaseClassLoader.java
@@ -73,7 +73,8 @@ public abstract class BaseClassLoader extends URLClassLoader {
         }
     }
 
-    public Class<?> loadClass(String name) {
+    @Override
+    public Class<?> loadClass(String name) throws ClassNotFoundException {
         Class c = findLoadedClass(name);
         if (c == null) {
             // find child first
@@ -96,7 +97,7 @@ public abstract class BaseClassLoader extends URLClassLoader {
             try {
                 c = getSystemClassLoader().loadClass(name);
             } catch (ClassNotFoundException e) {
-                // ignore
+                throw e;
             }
         }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25475

문제의 원인은 BaseClassLoader 의 loadClass 메소드가 ClassNotFoundException 을 throw 하는 대신 null 을 리턴하는 것인 듯 합니다. 
