### PR TITLE
[CBRD-25373] data overflow checks in numeric operations of SHORT, INT, and BIGINT values

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -635,7 +635,7 @@ public class SpLib {
         if (l == null) {
             return null;
         }
-        return ((short) -l);
+        return negateShortExact(l);
     }
 
     @Operator(coercionScheme = CoercionScheme.ArithOp)
@@ -643,7 +643,11 @@ public class SpLib {
         if (l == null) {
             return null;
         }
-        return -l;
+        try {
+            return Math.negateExact(l);
+        } catch (ArithmeticException e) {
+            throw new VALUE_ERROR("data overflow in negation of an INTEGER value");
+        }
     }
 
     @Operator(coercionScheme = CoercionScheme.ArithOp)
@@ -651,7 +655,11 @@ public class SpLib {
         if (l == null) {
             return null;
         }
-        return -l;
+        try {
+            return Math.negateExact(l);
+        } catch (ArithmeticException e) {
+            throw new VALUE_ERROR("data overflow in negation of a BIGINT value");
+        }
     }
 
     @Operator(coercionScheme = CoercionScheme.ArithOp)
@@ -2021,7 +2029,7 @@ public class SpLib {
         if (l == null || r == null) {
             return null;
         }
-        return (short) (l * r);
+        return multiplyShortExact(l, r);
     }
 
     @Operator(coercionScheme = CoercionScheme.ArithOp)
@@ -2029,7 +2037,11 @@ public class SpLib {
         if (l == null || r == null) {
             return null;
         }
-        return l * r;
+        try {
+            return Math.multiplyExact(l, r);
+        } catch (ArithmeticException e) {
+            throw new VALUE_ERROR("data overflow in multiplication of INTEGER values");
+        }
     }
 
     @Operator(coercionScheme = CoercionScheme.ArithOp)
@@ -2037,7 +2049,11 @@ public class SpLib {
         if (l == null || r == null) {
             return null;
         }
-        return l * r;
+        try {
+            return Math.multiplyExact(l, r);
+        } catch (ArithmeticException e) {
+            throw new VALUE_ERROR("data overflow in multiplication of BIGINT values");
+        }
     }
 
     @Operator(coercionScheme = CoercionScheme.ArithOp)
@@ -2348,7 +2364,7 @@ public class SpLib {
         if (l == null || r == null) {
             return null;
         }
-        return (short) (l + r);
+        return addShortExact(l, r);
     }
 
     @Operator(coercionScheme = CoercionScheme.ArithOp)
@@ -2356,7 +2372,11 @@ public class SpLib {
         if (l == null || r == null) {
             return null;
         }
-        return l + r;
+        try {
+            return Math.addExact(l, r);
+        } catch (ArithmeticException e) {
+            throw new VALUE_ERROR("data overflow in addition of INTEGER values");
+        }
     }
 
     @Operator(coercionScheme = CoercionScheme.ArithOp)
@@ -2364,7 +2384,11 @@ public class SpLib {
         if (l == null || r == null) {
             return null;
         }
-        return l + r;
+        try {
+            return Math.addExact(l, r);
+        } catch (ArithmeticException e) {
+            throw new VALUE_ERROR("data overflow in addition of BIGINT values");
+        }
     }
 
     @Operator(coercionScheme = CoercionScheme.ArithOp)
@@ -2528,7 +2552,7 @@ public class SpLib {
         if (l == null || r == null) {
             return null;
         }
-        return (short) (l - r);
+        return subtractShortExact(l, r);
     }
 
     @Operator(coercionScheme = CoercionScheme.ArithOp)
@@ -2536,7 +2560,11 @@ public class SpLib {
         if (l == null || r == null) {
             return null;
         }
-        return l - r;
+        try {
+            return Math.subtractExact(l, r);
+        } catch (ArithmeticException e) {
+            throw new VALUE_ERROR("data overflow in subtraction of INTEGER values");
+        }
     }
 
     @Operator(coercionScheme = CoercionScheme.ArithOp)
@@ -2544,7 +2572,11 @@ public class SpLib {
         if (l == null || r == null) {
             return null;
         }
-        return l - r;
+        try {
+            return Math.subtractExact(l, r);
+        } catch (ArithmeticException e) {
+            throw new VALUE_ERROR("data overflow in subtraction of BIGINT values");
+        }
     }
 
     @Operator(coercionScheme = CoercionScheme.ArithOp)
@@ -3876,6 +3908,50 @@ public class SpLib {
 
     private static final DateFormat AM_PM = new SimpleDateFormat("a", Locale.US);
     private static final Date ZERO_DATE = new Date(0L);
+
+    private static Short shortOfInt(int i) {
+        if (i <= Short.MAX_VALUE && i >= Short.MIN_VALUE) {
+            return (short) i;
+        } else {
+            return null;
+        }
+    }
+
+    private static Short addShortExact(Short l, Short r) {
+        int v = l.intValue() + r.intValue(); // never overflows
+        Short ret = shortOfInt(v);
+        if (ret == null) {
+            throw new VALUE_ERROR("data overflow in addition of SHORT values");
+        }
+        return ret;
+    }
+
+    private static Short subtractShortExact(Short l, Short r) {
+        int v = l.intValue() - r.intValue(); // never overflows
+        Short ret = shortOfInt(v);
+        if (ret == null) {
+            throw new VALUE_ERROR("data overflow in subtraction of SHORT values");
+        }
+        return ret;
+    }
+
+    private static Short negateShortExact(Short l) {
+        int v = -l.intValue(); // never overflows
+        Short ret = shortOfInt(v);
+        if (ret == null) {
+            throw new VALUE_ERROR("data overflow in negation of a SHORT value");
+        }
+        return ret;
+    }
+
+    private static Short multiplyShortExact(Short l, Short r) {
+        int v = l.intValue() * r.intValue(); // never overflows
+        Short ret = shortOfInt(v);
+        if (ret == null) {
+            throw new VALUE_ERROR("data overflow in multiplication of SHORT values");
+        }
+        return ret;
+    }
 
     private static String rtrim(String s) {
         assert s != null;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25373

SHORT, INT, BIGINT 타입에 대해서 오버플로우를 일으킬 수 있는 연산들 (+, -, *) 해당 SpLib 라이브러리 함수에 
오버플로우 여부를 검사하는 과정을 추가했습니다. 

INT와 BIGINT (자바의 Int와 Long) 에 대해서는 Java Math 클래스에 정의된 ...Exact 함수를 사용하였고, 
SHORT (자바의 Short) 에 대해서는 직접 구현한 함수를 사용하였습니다. 
