### PR TITLE
[CBRD-25464] bugfix: add EOF case in the POST_PLCSQL_TEXT mode of the lexer

### DIFF
--- a/src/parser/csql_lexer.l
+++ b/src/parser/csql_lexer.l
@@ -1684,9 +1684,9 @@ _[uU][tT][fF]8[']		{
                                                                 plcsql_begin_end_balance++;
 							        csql_yylval.cptr = pt_makename(yytext);
                                                                 return PLCSQL_TEXT_SOME; }
-<PLCSQL_TEXT>[eE][nN][dD][ \t\r\n]+[iI][fF]             |
-<PLCSQL_TEXT>[eE][nN][dD][ \t\r\n]+[cC][aA][sS][eE]     |
-<PLCSQL_TEXT>[eE][nN][dD][ \t\r\n]+[lL][oO][oO][pP]     |
+<PLCSQL_TEXT>[eE][nN][dD][ \t\r\n]+[iI][fF][ \t\r\n]*             |
+<PLCSQL_TEXT>[eE][nN][dD][ \t\r\n]+[cC][aA][sS][eE][ \t\r\n]*     |
+<PLCSQL_TEXT>[eE][nN][dD][ \t\r\n]+[lL][oO][oO][pP][ \t\r\n]*     |
 <PLCSQL_TEXT>[eE][nN][dD][ \t\r\n]*                     { begin_token(yytext);
                                                                 plcsql_begin_end_balance--;
                                                                 if (plcsql_begin_end_balance < 0) {
@@ -1728,19 +1728,21 @@ _[uU][tT][fF]8[']		{
 
  /* mode POST_PLCSQL_TEXT */
 
-<POST_PLCSQL_TEXT>[cC][oO][mM][mM][eE][nN][tT]          { BEGIN(INITIAL);
+<POST_PLCSQL_TEXT>[cC][oO][mM][mM][eE][nN][tT]        { BEGIN(INITIAL);
                                                                 yybuffer_pos -= csql_yyleng;
                                                                 yyless(0); }
 
-<POST_PLCSQL_TEXT>{IDL}+                                { BEGIN(INITIAL);
+<POST_PLCSQL_TEXT>{IDL}+                              { BEGIN(INITIAL);
                                                                 begin_token(yytext);
                                                                 csql_yylval.cptr = pt_makename(yytext);
                                                                 return PLCSQL_TEXT_SOME; }
 
-<POST_PLCSQL_TEXT>(\n|.)                                { BEGIN(INITIAL);
+<POST_PLCSQL_TEXT>(.)                                 { BEGIN(INITIAL);
                                                                 yybuffer_pos -= csql_yyleng;
                                                                 yyless(0); }
 
+<POST_PLCSQL_TEXT><<EOF>>                             { BEGIN(INITIAL);
+                                                                return 0; }
 
 %%
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25464

PL/CSQL 의 loaddb 지원 이슈를 처리하면서 lexer 에 POST_PLCSQL_TEXT 라는 모드가 생겼는데, 
여기서 EOF 로 끝나는 경우를 고려해 주지 않는 문제가 발견되었습니다. 
EOF을 고려해 주도록 수정했습니다. 
