### PR TITLE
[CBRD-25282] Prevents exit code from being set to 0 when parameters are not appropriate

### DIFF
--- a/src/executables/unloaddb.c
+++ b/src/executables/unloaddb.c
@@ -174,6 +174,7 @@ unloaddb (UTIL_FUNCTION_ARG * arg)
     {
       fprintf (stderr, "\nThe number of '--%s' ranges from 0 to %d.\n", UNLOAD_STRING_BUFFER_SIZE_L,
 	       MAX_PRE_ALLOC_VARCHAR_SIZE);
+      status = 1;		// set exit code
       goto end;
     }
 
@@ -182,6 +183,7 @@ unloaddb (UTIL_FUNCTION_ARG * arg)
     {
       fprintf (stderr, "\nThe number of '--%s' option ranges from 0 to %d.\n", UNLOAD_REQUEST_PAGES_L,
 	       MAX_REQ_DATA_PAGES);
+      status = 1;		// set exit code         
       goto end;
     }
 
@@ -196,6 +198,7 @@ unloaddb (UTIL_FUNCTION_ARG * arg)
       if (sampling_records < -1)
 	{
 	  fprintf (stderr, "\nThe number of '--%s' option ranges from 0 to %d.\n", UNLOAD_SAMPLING_TEST_L, INT_MAX);
+	  status = 1;		// set exit code
 	  goto end;
 	}
 
@@ -204,6 +207,7 @@ unloaddb (UTIL_FUNCTION_ARG * arg)
 	{
 	  fprintf (stderr, "\nThe number of '--%s' option ranges from 0 to %d.\n", UNLOAD_THREAD_COUNT_L,
 		   MAX_THREAD_COUNT);
+	  status = 1;		// set exit code         
 	  goto end;
 	}
 
@@ -215,6 +219,7 @@ unloaddb (UTIL_FUNCTION_ARG * arg)
 	    {
 	      fprintf (stderr, "warning: '--%s' option is ignored.\n", UNLOAD_MT_PROCESS_L);
 	      fflush (stderr);
+	      status = 1;	// set exit code
 	      goto end;
 	    }
 	  else if ((g_parallel_process_cnt > MAX_PROCESS_COUNT)
@@ -223,6 +228,7 @@ unloaddb (UTIL_FUNCTION_ARG * arg)
 	    {
 	      fprintf (stderr, "warning: '--%s' option is ignored.\n", UNLOAD_MT_PROCESS_L);
 	      fflush (stderr);
+	      status = 1;	// set exit code
 	      goto end;
 	    }
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25282

* Prevents exit code from being set to 0 when parameters are not appropriate

- `cubrid unloaddb -C -udba  -t 3000 demodb` 과 같이 적절하지 못한 파라메터값이 입력 되었을 때
  프로그램이 종료되면서 종료 코드를 0으로 지정하게 되어 있던 것을 1로 변경 함
  이를 통해 쉘 스크립트 등에서 프로그램의 오류 여부를 파악하는데 사용 함.
