### PR TITLE
[CBRD-25599] Modify the assert condition to exclude system transactions from the check in recovery redo phase

### DIFF
--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -3769,7 +3769,14 @@ log_recovery_redo (THREAD_ENTRY * thread_p, const LOG_LSA * start_redolsa, const
 	    case LOG_ABORT:
 	      {
 		rcv_redo_perf_stat.time_and_increment (cublog::PERF_STAT_ID_READ_LOG);
-		assert (logtb_find_tran_index (thread_p, tran_id) == NULL_TRAN_INDEX);
+
+		/* This is a check to verify whether completed transactions exist in the transaction table.
+		 * In the analysis phase, completed transactions are cleared from the transaction table.
+		 * However, system transactions are not cleared, so they are excluded from the assert condition
+		 */
+		assert (tran_id == LOG_SYSTEM_TRANID ||
+			(tran_id > LOG_SYSTEM_TRANID && logtb_find_tran_index (thread_p, tran_id) == NULL_TRAN_INDEX));
+
 		rcv_redo_perf_stat.time_and_increment (cublog::PERF_STAT_ID_COMMIT_ABORT);
 	      }
 	      break;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25599

Purpose

- analysis phase에서는 완료된 트랜잭션은 트랜잭션 테이블에서 제거한다.
- redo phase에서 LOG_COMMIT/LOG_ABORT 로그를 만나면, 
해당 로그를 기록한 트랜잭션 정보가 트랜잭션 테이블에 존재하는지 확인한다.
- 트랜잭션 테이블에 존재한다면, analysis 단계에서 문제가 발생한 것이기 때문이다.

하지만 현재 assertion에서는 시스템 트랜잭션은 고려하지 않고 있다.  
시스템 트랜잭션은 analysis 단계에서 정리되지 않기 때문에, 시스템 트랜잭션에 대해서는 체크하지 않도록  assertion을 수정해야한다.