### PR TITLE
[CBRD-25551] %TYPE of near variables and constants

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -2401,7 +2401,8 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
 
         String name = Misc.getNormalizedText(ctx.identifier());
 
-        // push a temporary symbol table, in order not to corrupt the current symbol table with the parameters
+        // push a temporary symbol table, in order not to corrupt the current symbol table with the
+        // parameters
         symbolStack.pushSymbolTable("temp", null);
         NodeList<DeclParam> paramList = visitParameter_list(ctx.parameter_list());
         symbolStack.popSymbolTable();

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/SymbolStack.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/SymbolStack.java
@@ -608,7 +608,7 @@ public class SymbolStack {
                     Misc.getLineColumnOf(decl.ctx), // s062
                     name + " has already been declared in the same scope");
         }
-        if (symbolTable.scope.level == 1 && map.size() == 0) {
+        if (symbolTable.scope.level == LEVEL_MAIN && map.size() == 0) {
             // the first symbol added to the level 1 is the top-level procedure/function being
             // created or replaced
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/DeclConst.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/DeclConst.java
@@ -49,8 +49,6 @@ public class DeclConst extends DeclIdTypeSpeced {
             ParserRuleContext ctx, String name, TypeSpec typeSpec, boolean notNull, Expr val) {
         super(ctx);
 
-        assert val != null;
-
         this.name = name;
         this.typeSpec = typeSpec;
         this.notNull = notNull;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25551

Jira 이슈에 설명한 문제가 발생하여 예전 구현을 revert 한 후 새로 구현하였습니다. 

previsit 과정에서 variable과 constant 도 감안하여 임시 심볼테이블에 추가해가며 프로시저/함수의 인자타입과 리턴타입에
그 variable과 constant 이름으로 %TYPE 을 사용하는 것을 허용합니다. 

첫번째 commit 은 revert 하는 commit 이므로 두 번째 commit 만 살펴보시는 것이 좀 더 보기 편하실 겁니다. 


