### PR TITLE
[CBRD-24941] slip: make argument to the variadic parameter of Query.open non-null

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -387,7 +387,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
 
         String code =
                 String.format(
-                        "final Query %s = new Query(\"%s\"); // param-ref-counts: %s, param-marks: %s",
+                        "final Query %s = new Query(\"%s\"); // param-ref-counts: %s, param-num-of-host-expr: %s",
                         node.name,
                         node.staticSql.rewritten,
                         Arrays.toString(node.paramRefCounts),
@@ -1361,8 +1361,8 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
             new String[] {
                 "{ // cursor open",
                 "  %'+DUPLICATE-CURSOR-ARG'%",
-                "  %'CURSOR'%.open(conn,",
-                "    %'+HOST-EXPRS'%);",
+                "  %'CURSOR'%.open(conn, new Object[] {",
+                "    %'+HOST-EXPRS'%});",
                 "}"
             };
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24941

CBRD-25606에서 보고된 문제에 의해 select 문의 호스트 변수에 bind 될 표현식에 null 이 단 하나가 될 수가 있는데, 
이 경우 Query.open 메소드의 variadic parameter 로 가는 인자가 single NULL 이 된다. 
이 NULL 이 인자가 없다는 것인지 NULL 하나를 인자로 갖는다는 것인지 모호하다. (Java variadic의 고질적 문제)
그리고, Query.open 메소드 코드 안에 variadic argument 가 null 이면 안된다는 assert 문이 있어서 internal server error가 발생한다. 
모호함을 없애주고 assertion fail 을 막기 위해서는 원래 의도와 일치하도록 Object 배열로 넘겨주면 해결된다. 
