### PR TITLE
[CBRD-25596] Prevent is_grantable from changing to 'NO' in db_auth when executing GRANT without WITH GRANT OPTION for grantable users

### DIFF
--- a/src/object/authenticate_grant.cpp
+++ b/src/object/authenticate_grant.cpp
@@ -226,6 +226,13 @@ au_grant_class (MOP user, MOP class_mop, DB_AUTH type, bool grant_option)
 		  upd_bits = (DB_AUTH) (~ins_bits & (int) type);
 		  if ((error == NO_ERROR) && upd_bits)
 		    {
+		      if (grant_option == 0)
+			{
+			  if (current - (int) type)
+			    {
+			      grant_option = 1;
+			    }
+			}
 		      error =
 			      accessor.update_auth (DB_OBJECT_CLASS, Au_user, user, class_mop, upd_bits,
 						    (grant_option) ? upd_bits : DB_AUTH_NONE);

--- a/src/object/authenticate_grant.cpp
+++ b/src/object/authenticate_grant.cpp
@@ -226,13 +226,9 @@ au_grant_class (MOP user, MOP class_mop, DB_AUTH type, bool grant_option)
 		  upd_bits = (DB_AUTH) (~ins_bits & (int) type);
 		  if ((error == NO_ERROR) && upd_bits)
 		    {
-		      if (grant_option == 0 && (current - (int) type))
-			{
-			  grant_option = 1;
-			}
 		      error =
 			      accessor.update_auth (DB_OBJECT_CLASS, Au_user, user, class_mop, upd_bits,
-						    (grant_option) ? upd_bits : DB_AUTH_NONE);
+						    (grant_option || (current & (type << AU_GRANT_SHIFT))) ? upd_bits : DB_AUTH_NONE);
 		    }
 		}
 

--- a/src/object/authenticate_grant.cpp
+++ b/src/object/authenticate_grant.cpp
@@ -226,12 +226,9 @@ au_grant_class (MOP user, MOP class_mop, DB_AUTH type, bool grant_option)
 		  upd_bits = (DB_AUTH) (~ins_bits & (int) type);
 		  if ((error == NO_ERROR) && upd_bits)
 		    {
-		      if (grant_option == 0)
+		      if (grant_option == 0 && (current - (int) type))
 			{
-			  if (current - (int) type)
-			    {
-			      grant_option = 1;
-			    }
+			  grant_option = 1;
 			}
 		      error =
 			      accessor.update_auth (DB_OBJECT_CLASS, Au_user, user, class_mop, upd_bits,


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25596

Purpose

- WITH GRANT OPTION 권한을 부여한 경우, 해당 권한을 GRANT 명령어로 직접 회수할 수 없습니다.
- 따라서, db_auth 카탈로그의 is_grantable 값이 'NO'로 변경되지 않게 수정 해야 합니다.

AS-IS
```sql
select grantor_name, grantee_name, is_grantable, (select grants from db_authorization where owner.name = 'U1') as grantee_grants from db_auth where grantee_name != 'PUBLIC';
/*
  grantor_name          grantee_name          is_grantable          grantee_grants      
========================================================================================
  'DBA'                 'U1'                  'YES'                  {0, dba.tbl, db_user, 257}
*/

GRANT SELECT ON dba.tbl TO u1;

select grantor_name, grantee_name, is_grantable, (select grants from db_authorization where owner.name = 'U1') as grantee_grants from db_auth where grantee_name != 'PUBLIC';
/*
  grantor_name          grantee_name          is_grantable          grantee_grants      
========================================================================================
  'DBA'                 'U1'                  'NO'                  {0, dba.tbl, db_user, 257}
*/
```

TO-BE
```sql
select grantor_name, grantee_name, is_grantable, (select grants from db_authorization where owner.name = 'U1') as grantee_grants from db_auth where grantee_name != 'PUBLIC';
/*
  grantor_name          grantee_name          is_grantable          grantee_grants      
========================================================================================
  'DBA'                 'U1'                  'YES'                  {0, dba.tbl, db_user, 257}
*/

GRANT SELECT ON dba.tbl TO u1;

select grantor_name, grantee_name, is_grantable, (select grants from db_authorization where owner.name = 'U1') as grantee_grants from db_auth where grantee_name != 'PUBLIC';
/*
  grantor_name          grantee_name          is_grantable          grantee_grants      
========================================================================================
  'DBA'                 'U1'                  'YES'                  {0, dba.tbl, db_user, 257}
*/
```

Implementation

N/A

Remarks

N/A