### PR TITLE
[CBRD-24911] Issue where trim() cannot be called in cub_manager for Windows (#5167)

### DIFF
--- a/cm_common/CMakeLists.txt
+++ b/cm_common/CMakeLists.txt
@@ -23,6 +23,9 @@ set(CMSTAT_SOURCES
   ${CM_COMMON_DIR}/cm_utils.c
   ${CM_COMMON_DIR}/cm_broker_jni.c
   )
+if(WIN32)
+  list(APPEND CMSTAT_SOURCES ${BASE_DIR}/chartype.c)
+endif(WIN32)
 SET_SOURCE_FILES_PROPERTIES(
     ${CMSTAT_SOURCES}
     PROPERTIES LANGUAGE CXX
@@ -56,6 +59,9 @@ set(CMDEP_SOURCES
   ${CM_COMMON_DIR}/cm_nameval.c
   ${CM_COMMON_DIR}/cm_utils.c
   )
+if(WIN32)
+  list(APPEND CMDEP_SOURCES ${BASE_DIR}/chartype.c)
+endif(WIN32)
 SET_SOURCE_FILES_PROPERTIES(
     ${CMDEP_SOURCES}
     PROPERTIES LANGUAGE CXX

--- a/src/cm_common/cm_utils.c
+++ b/src/cm_common/cm_utils.c
@@ -540,37 +540,6 @@ read_server_status_output (T_SERVER_STATUS_RESULT * res, char *out_file)
   res->result = info;
 }
 
-
-char *
-ut_trim (char *str)
-{
-  char *p;
-  char *s;
-
-  if (str == NULL)
-    return (str);
-
-  for (s = str; *s != '\0' && char_isspace2 (*s); s++)
-    ;
-  if (*s == '\0')
-    {
-      *str = '\0';
-      return (str);
-    }
-
-  /* *s must be a non-white char */
-  for (p = s; *p != '\0'; p++)
-    ;
-  for (p--; char_isspace2 (*p); p--)
-    ;
-  *++p = '\0';
-
-  if (s != str)
-    memmove (str, s, strlen (s) + 1);
-
-  return (str);
-}
-
 int
 string_tokenize (char *str, char *tok[], int num_tok)
 {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24911

* After applying [CBRD-25043], an operation error occurred in cub_manager for Windows.
* Change to include chartype.c when building libraries for Windows.
* backport #5167 