### PR TITLE
[CBRD-25507] Slip: Handling a cursor reaches to the end of result set

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/impl/SUStatement.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/impl/SUStatement.java
@@ -355,7 +355,7 @@ public class SUStatement {
 
         fetchedTupleNumber = fetchInfo.numFetched;
         if (fetchInfo.numFetched > 0) {
-            // fetch until reaching the end of the result set (S_END). 
+            // fetch until reaching the end of the result set (S_END).
             // If fetchInfo.numFetched == 0, it means there are no remaining rows.
             fetchedStartCursorPosition = fetchInfo.tuples[0].tupleNumber() - 1;
             fetchedEndCursorPosition = fetchedStartCursorPosition + fetchedTupleNumber;

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/impl/SUStatement.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/impl/SUStatement.java
@@ -354,9 +354,11 @@ public class SUStatement {
         }
 
         fetchedTupleNumber = fetchInfo.numFetched;
-        fetchedStartCursorPosition = fetchInfo.tuples[0].tupleNumber() - 1;
-        fetchedEndCursorPosition = fetchedStartCursorPosition + fetchedTupleNumber;
-
+        if (fetchInfo.numFetched > 0) {
+            // fetch request reach to the end of the result set (S_END)
+            fetchedStartCursorPosition = fetchInfo.tuples[0].tupleNumber() - 1;
+            fetchedEndCursorPosition = fetchedStartCursorPosition + fetchedTupleNumber;
+        }
         // update cursorPosition to the fetched start position
         cursorPosition = fetchedStartCursorPosition;
     }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/impl/SUStatement.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/impl/SUStatement.java
@@ -355,7 +355,8 @@ public class SUStatement {
 
         fetchedTupleNumber = fetchInfo.numFetched;
         if (fetchInfo.numFetched > 0) {
-            // fetch request reach to the end of the result set (S_END)
+            // fetch until reaching the end of the result set (S_END). 
+            // If fetchInfo.numFetched == 0, it means there are no remaining rows.
             fetchedStartCursorPosition = fetchInfo.tuples[0].tupleNumber() - 1;
             fetchedEndCursorPosition = fetchedStartCursorPosition + fetchedTupleNumber;
         }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25507

이 변경은 서버측 JDBC의 fetch() 프로토콜에서 서버측 커서가 끝에 도달하여 (S_END) 어떤 튜플도 반환되지 않은 경우에 대한 처리를 추가합니다.

이 경우 fetchInfo에서 반환된 튜플 갯수 (numFetched) 는 0으로 설정되며, tuples는 어떠한 레코드도 반환되지 않았기 때문에 null로 설정됩니다. 이슈의 comment에서 발생한 regression은 이 경우 tuples에 접근하여 NullPointerException가 원인입니다.