### PR TITLE
[CBRD-25035] [regression] extend query cache to CTE

### DIFF
--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -3539,10 +3539,10 @@ do_check_cte_or_system_class_spec (PARSER_CONTEXT * parser, PT_NODE * stmt, void
       return stmt;
     }
 
-  if (q->info.query.is_subquery == PT_IS_SUBQUERY || q->info.query.is_subquery == PT_IS_UNION_QUERY
-      || q->info.query.is_subquery == PT_IS_UNION_SUBQUERY)
+  if (stmt->info.spec.cte_pointer)
     {
-      if (stmt->info.spec.cte_pointer)
+      if (q->info.query.is_subquery == PT_IS_SUBQUERY || q->info.query.is_subquery == PT_IS_UNION_QUERY
+	  || q->info.query.is_subquery == PT_IS_UNION_SUBQUERY)
 	{
 	  goto stop_walk;
 	}

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -3528,9 +3528,9 @@ do_clear_subquery_cache_flag (PARSER_CONTEXT * parser, PT_NODE * stmt, void *arg
 }
 
 static PT_NODE *
-do_check_cte_or_system_class_spec (PARSER_CONTEXT * parser, PT_NODE * stmt, void *arg, int *continue_walk)
+do_check_subquery_refer_cte_spec (PARSER_CONTEXT * parser, PT_NODE * stmt, void *arg, int *continue_walk)
 {
-  bool *has_cte_or_system_class_or_dblink = (bool *) arg;
+  bool *has_cte_spec = (bool *) arg;
 
   *continue_walk = PT_CONTINUE_WALK;
 
@@ -3541,8 +3541,23 @@ do_check_cte_or_system_class_spec (PARSER_CONTEXT * parser, PT_NODE * stmt, void
 
   if (stmt->info.spec.cte_pointer)
     {
-      *has_cte_or_system_class_or_dblink = true;
+      *has_cte_spec = true;
       *continue_walk = PT_STOP_WALK;
+    }
+
+  return stmt;
+}
+
+static PT_NODE *
+do_check_system_class_or_dblink (PARSER_CONTEXT * parser, PT_NODE * stmt, void *arg, int *continue_walk)
+{
+  bool *has_system_class_or_dblink = (bool *) arg;
+
+  *continue_walk = PT_CONTINUE_WALK;
+
+  if (stmt->node_type != PT_SPEC)
+    {
+      return stmt;
     }
 
   if (stmt->info.spec.entity_name)
@@ -3553,14 +3568,14 @@ do_check_cte_or_system_class_spec (PARSER_CONTEXT * parser, PT_NODE * stmt, void
 	{
 	  if (sm_check_system_class_by_name (class_name))
 	    {
-	      *has_cte_or_system_class_or_dblink = true;
+	      *has_system_class_or_dblink = true;
 	      *continue_walk = PT_STOP_WALK;
 	    }
 	}
     }
   else if (stmt->info.spec.derived_table_type == PT_DERIVED_DBLINK_TABLE)
     {
-      *has_cte_or_system_class_or_dblink = true;
+      *has_system_class_or_dblink = true;
       *continue_walk = PT_STOP_WALK;
     }
 
@@ -3571,7 +3586,7 @@ static PT_NODE *
 do_prepare_subquery_pre (PARSER_CONTEXT * parser, PT_NODE * stmt, void *arg, int *continue_walk)
 {
   int *err = (int *) arg;
-  bool has_cte_or_system_class_or_dblink = false;
+  bool has_system_class_or_dblink = false;
   PT_NODE *saved;
 
   *continue_walk = PT_CONTINUE_WALK;
@@ -3606,14 +3621,13 @@ do_prepare_subquery_pre (PARSER_CONTEXT * parser, PT_NODE * stmt, void *arg, int
 
       if (stmt->info.query.hint & PT_HINT_QUERY_CACHE)
 	{
-	  /* exclude cache from CTE, system class, or dblink referencing */
+	  /* exclude cache from system class, or dblink referencing */
 	  saved = stmt->next;
 	  stmt->next = NULL;
-	  parser_walk_tree (parser, stmt, do_check_cte_or_system_class_spec,
-			    &has_cte_or_system_class_or_dblink, NULL, NULL);
+	  parser_walk_tree (parser, stmt, do_check_system_class_or_dblink, &has_system_class_or_dblink, NULL, NULL);
 	  stmt->next = saved;
 
-	  if (has_cte_or_system_class_or_dblink)
+	  if (has_system_class_or_dblink)
 	    {
 	      stmt->info.query.flag.do_cache = 0;
 	      stmt->info.query.flag.do_not_cache = 1;
@@ -3631,6 +3645,21 @@ do_prepare_subquery_pre (PARSER_CONTEXT * parser, PT_NODE * stmt, void *arg, int
        || stmt->info.query.is_subquery == PT_IS_CTE_NON_REC_SUBQUERY) && stmt->info.query.correlation_level == 0
       && (stmt->info.query.hint & PT_HINT_QUERY_CACHE))
     {
+      bool has_cte_spec = false;
+
+      /* exclude cache from CTE */
+      saved = stmt->next;
+      stmt->next = NULL;
+      parser_walk_tree (parser, stmt, do_check_subquery_refer_cte_spec, &has_cte_spec, NULL, NULL);
+      stmt->next = saved;
+
+      if (has_cte_spec)
+	{
+	  stmt->info.query.flag.do_cache = 0;
+	  stmt->info.query.flag.do_not_cache = 1;
+	  goto stop_walk;
+	}
+
       *err = do_prepare_subquery (parser, stmt);
 
       if (*err != NO_ERROR)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25035

[regression 이슈]

서브 쿼리 캐시 스펙:

서브 쿼리가 CTE를 참조하는 경우, 캐시에서 제외해야 한다.
메인 쿼리 혹은 서브 쿼리가 SYSTEM CLASS나 SYSTEM 함수 (SYSDATE등), DBLINK를 포함하는 경우, 캐시에서 제외해야 한다.
앞서 언급한 스펙에서 첫 번째와 두 번째의 전제 조건은 동일하지 않다. 즉, 첫 번째는 서브 쿼리에만 적용해야 하고, 두 번째는 메인 쿼리와 서브 쿼리 모두에 적용해야 한다.

이 두 전제 조건을 분리해서 구현해야 하는데, 로직이 분리되지 못하여 메인 쿼리에서 CTE를 참조하는 경우 캐시가 되지 못하는 문제가 발생하였다.

따라서 두 개의 로직을 분리하여 해결해야 한다.

아래의 쿼리는 캐시가 적용되어야 한다.
```
select /*+ query_cache */ count(*) from tbl_a
where colc in (with ctea as (select cola from tbl_b where colb = 7) select * from ctea)
and cola = 17;
```

아래의 서브 쿼리는 캐시가 적용될 수 없다.
```
with ctea as (select cola from tbl_b where colb = 7) 
select * 
from (select /*+ query_cache */ cola from ctea where cola > 0)  cte_ref
where cola = 17;
```