### PR TITLE
[CBRD-25414] The phenomenon of heap memory usage increasing each time utilities are executed

### DIFF
--- a/src/communication/network_sr.c
+++ b/src/communication/network_sr.c
@@ -1060,7 +1060,6 @@ loop:
       (void) xboot_unregister_client (thread_p, tran_index);
       session_remove_query_entry_all (thread_p);
     }
-
   css_free_conn (conn_p);
 
   css_set_thread_info (thread_p, -1, 0, local_tran_index, -1);

--- a/src/communication/network_sr.c
+++ b/src/communication/network_sr.c
@@ -1060,6 +1060,7 @@ loop:
       (void) xboot_unregister_client (thread_p, tran_index);
       session_remove_query_entry_all (thread_p);
     }
+
   css_free_conn (conn_p);
 
   css_set_thread_info (thread_p, -1, 0, local_tran_index, -1);

--- a/src/compat/db_admin.c
+++ b/src/compat/db_admin.c
@@ -993,6 +993,8 @@ db_shutdown (void)
 {
   int error = NO_ERROR;
 
+  db_end_session ();
+
   error = boot_shutdown_client (true);
   db_Database_name[0] = '\0';
   db_Connect_status = DB_CONNECTION_STATUS_NOT_CONNECTED;

--- a/src/compat/db_admin.c
+++ b/src/compat/db_admin.c
@@ -993,7 +993,7 @@ db_shutdown (void)
 {
   int error = NO_ERROR;
 
-  db_end_session ();
+  (void) db_end_session ();
 
   error = boot_shutdown_client (true);
   db_Database_name[0] = '\0';

--- a/src/compat/dbi_compat.h
+++ b/src/compat/dbi_compat.h
@@ -150,7 +150,6 @@ extern "C"
 			    const char *preferred_hosts, int client_type);
   extern SESSION_ID db_get_session_id (void);
   extern void db_set_session_id (const SESSION_ID session_id);
-  extern int db_end_session (void);
   extern int db_find_or_create_session (const char *db_user, const char *program_name);
   extern int db_get_row_count_cache (void);
   extern void db_update_row_count_cache (const int row_count);

--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -786,7 +786,6 @@ fatal_error:
 	}
     }
 
-  db_end_session ();
   db_shutdown ();
   csql_Database_connected = false;
   nonscr_display_error (csql_Scratch_text, SCRATCH_TEXT_LEN);
@@ -1034,7 +1033,6 @@ csql_do_session_cmd (char *line_read, CSQL_ARGUMENT * csql_arg)
       if (csql_Database_connected)
 	{
 	  csql_Database_connected = false;
-	  db_end_session ();
 	  db_shutdown ();
 	}
       er_init ("./csql.err", ER_NEVER_EXIT);
@@ -2731,7 +2729,6 @@ csql_exit_session (int error)
 	  histo_stop ();
 	}
     }
-  db_end_session ();
 
   if (db_shutdown () < 0)
     {
@@ -2814,7 +2811,6 @@ csql_exit_cleanup ()
 	}
 
       csql_Database_connected = false;
-      db_end_session ();
       db_shutdown ();
     }
 
@@ -3558,7 +3554,6 @@ csql_connect (char *argument, CSQL_ARGUMENT * csql_arg)
   if (csql_Database_connected)
     {
       csql_Database_connected = false;
-      db_end_session ();
       db_shutdown ();
 
     }

--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -742,7 +742,6 @@ loaddb_internal (UTIL_FUNCTION_ARG * arg, int dba_mode)
       print_log_msg (1, "%s\n", db_error_string (3));
       util_log_write_errstr ("%s\n", db_error_string (3));
       status = 3;
-      db_end_session ();
       goto error_return;
     }
 
@@ -814,7 +813,6 @@ loaddb_internal (UTIL_FUNCTION_ARG * arg, int dba_mode)
       if (interrupted || status != 0)
 	{
 	  // failed
-	  db_end_session ();
 	  goto error_return;
 	}
     }
@@ -831,7 +829,6 @@ loaddb_internal (UTIL_FUNCTION_ARG * arg, int dba_mode)
 	  msg_format = "Error occurred during index loading." "Aborting current transaction...\n";
 	  util_log_write_errstr (msg_format);
 	  status = 3;
-	  db_end_session ();
 	  print_log_msg (1, " done.\n\nRestart loaddb with '-%c %s:%d' option\n", LOAD_INDEX_FILE_S,
 			 args.index_file.c_str (), index_file_start_line);
 	  logddl_write_end ();
@@ -865,7 +862,6 @@ loaddb_internal (UTIL_FUNCTION_ARG * arg, int dba_mode)
 	  msg_format = "Error occurred during trigger loading." "Aborting current transaction...\n";
 	  util_log_write_errstr (msg_format);
 	  status = 3;
-	  db_end_session ();
 	  print_log_msg (1, " done.\n\nRestart loaddb with '--%s %s:%d' option\n", LOAD_TRIGGER_FILE_L,
 			 args.trigger_file.c_str (), trigger_file_start_line);
 	  logddl_write_end ();
@@ -887,7 +883,7 @@ loaddb_internal (UTIL_FUNCTION_ARG * arg, int dba_mode)
     }
 
   print_log_msg ((int) args.verbose, msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_LOADDB, LOADDB_MSG_CLOSING));
-  (void) db_end_session ();
+
   (void) db_shutdown ();
 
   fclose_and_init (loaddb_log_file);
@@ -1608,7 +1604,6 @@ ldr_load_schema_file (FILE * schema_fp, int schema_file_start_line, load_args ar
       msg_format = "Error occurred during schema loading." "Aborting current transaction...\n";
       util_log_write_errstr (msg_format);
       status = 3;
-      db_end_session ();
       print_log_msg (1, " done.\n\nRestart loaddb with '-%c %s:%d' option\n", LOAD_SCHEMA_FILE_S,
 		     args.schema_file.c_str (), schema_file_start_line);
       logddl_write_end ();
@@ -1634,7 +1629,6 @@ ldr_load_schema_file (FILE * schema_fp, int schema_file_start_line, load_args ar
       if (ldr_compare_storage_order (schema_fp) != NO_ERROR)
 	{
 	  status = 3;
-	  db_end_session ();
 	  print_log_msg (1, "\nAborting current transaction...\n");
 	  return status;
 	}

--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -883,7 +883,6 @@ loaddb_internal (UTIL_FUNCTION_ARG * arg, int dba_mode)
     }
 
   print_log_msg ((int) args.verbose, msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_LOADDB, LOADDB_MSG_CLOSING));
-
   (void) db_shutdown ();
 
   fclose_and_init (loaddb_log_file);

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -929,10 +929,10 @@ session_remove_expired_sessions (THREAD_ENTRY * thread_p)
 
 	  if (is_expired)
 	    {
-	      expired_sid_buffer[n_expired_sids++] = state->id;
-
 	      /* Now we can destroy this session */
 	      assert (state->ref_count == 0);
+
+	      expired_sid_buffer[n_expired_sids++] = state->id;
 
 	      /* Destroy the session related resources like session parameters */
 	      (void) session_state_uninit (state);

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -930,6 +930,13 @@ session_remove_expired_sessions (THREAD_ENTRY * thread_p)
 	  if (is_expired)
 	    {
 	      expired_sid_buffer[n_expired_sids++] = state->id;
+
+	      /* Now we can destroy this session */
+	      assert (state->ref_count == 0);
+
+	      /* Destroy the session related resources like session parameters */
+	      (void) session_state_uninit (state);
+
 	      if (n_expired_sids == EXPIRED_SESSION_BUFFER_SIZE)
 		{
 		  /* No more room in buffer */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25414

### **_Purpose_**

- 문제 상황
  1. memmon 유틸리티를 반복적으로 실행 시 힙메모리가 1160bytes씩 증가하는 문제
  2. 세션 생성 후 정상적인 종료가 아닌 kill 명령어를 통한 강제 종료 시 힙메모리가 1160bytes 증가된채로 정리되지 않는 문제

- 1번 문제 원인
  - 유틸리티 실행 시 세션을 생성하게 되는데, 이 때 세션 파라미터값을 저장하기 위한 힙메모리 1160bytes를 할당받습니다.
  - 하지만 세션 종료 시, 위에서 할당받았던 힙메모리 영역을 반환시켜주지 않고 종료하고 있기 때문에 발생하는 문제입니다.
  - 따라서 memmon 유틸리티 뿐만 아니라 세션을 생성하는 모든 유틸리티에서 발생하는 문제임을 확인하였고,
    세션을 할당받는 모든 유틸리티 대상으로 세션을 반환하도록 수정하였습니다.

- 2번 문제 원인
  - 유틸리티가 세션을 생성한 후 강제로 종료하여 세션이 만료되면
    만료된 세션을 처리하는 daemon에서 세션을 free 시켜줘야하는데 hashmap에서만 삭제처리를 진행하고
    세션을 free시켜주지 않아 발생하는 문제입니다.
  - 따라서, 해당 함수 내부에 세션이 할당받은 힙메모리 영역을 반환하도록 수정하였습니다.
 
---
### **_주요 함수 및 변수_**
- states_hashmap<SESSION_ID, session_state>
   - session state를 저장하는 해시맵
   - lockfree hashmap
- db_find_or_create_session()
  - 세션을 생성하는 함수, 해당 함수를 호출하게 되면 세션파라미터 저장을 위한 힙메모리 영역을 생성하게 됩니다.
  - 따라서 db_end_session()을 사용하여 해당 영역을 정리해주는 작업이 필요합니다.
- db_end_session()
  - 클라이언트가 서버에게 세션 종료를 요청하는 함수
  - 해당 함수를 호출하면 서버에게 net_request를 사용하여 서버 종료를 요청하게 됩니다.
- session_Control_daemon
  - 만료된 세션이 있는지 확인하고 제거하는 daemon
  - 60초 간격으로 session_remove_expired_sessions() 함수 호출
- session_remove_expired_sessions()
  - hashmap에서 session 정보를 불러와 session_check_timeout() 함수를 통해
    현재 시간과 session에 저장되어있는 active_time을 비교하여
    그 둘의 차이가 timeout 값 이상이면 만료된 세션이라고 판단하여
    session_states_hashmap에서 erase 하는 함수
  - 세션을 free 시켜주진 않고 있어 해당 함수 내부에 세션을 free시켜주도록 코드를 추가
- css_connection_handler_thread
  - client와 server 간의 connection을 handling하는 thread
  - error가 발생하면 net_server_conn_down 함수를 호출
- net_server_conn_down()
  - 클라이언트와의 연결이 끊어졌을 때 사용되는 함수
  - 연결이 끊어진 session과 관련된 transaction과 thread가 다 끝날 때 까지 기다린 후
     connection 정보 초기화와 session에 남아있는 query entry를 제거한다.

---
### **_Implementation_**
- db_shutdown 함수 내부에 db_end_session 함수를 추가하여 
   shutdown 이전 세션이 할당받은 힙메모리 영역을 반환하도록 수정하였습니다.
- 만료된 세션을 hashmap에서 제거하는 데몬에서 만료된 세션을 free해주도록 수정하였습니다.
- db_shutdown 함수 내부에 db_end_session이 추가됨에 따라
   db_shutdown 함수 호출 전 db_end_session을 호출하는 코드를 제거하였습니다.