### PR TITLE
[CBRD-25616] [Regression] Core dumped in fprint_special_strings at src/executables/unload_object_file.c:710

### DIFF
--- a/src/executables/unload_object_file.c
+++ b/src/executables/unload_object_file.c
@@ -707,6 +707,13 @@ fprint_special_strings (TEXT_OUTPUT * tout, DB_VALUE * value)
     case DB_TYPE_DOUBLE:
       {
 	char *pos;
+
+	if (tout->tail_ptr == NULL)
+	  {
+	    assert (tout->head_ptr == NULL);
+	    CHECK_PRINT_ERROR (get_text_output_mem (tout, -1));
+	  }
+
 	pos = tout->tail_ptr->ptr;
 	CHECK_PRINT_ERROR (text_print
 			   (tout, NULL, 0, "%.*g", (type == DB_TYPE_FLOAT) ? 10 : 17,


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25616
*  fix Core dumped in fprint_special_strings for float and double

* double, float 타입이 첫번째 컬럼으로 존재 할 때 unloaddb 에서 core dump 발생하는 문제 해소

```
csql -S -udba testdb -c "create table txx (float f); insert into txx values(3.14);"
cubrid unloaddb -S -udba testdb

```

