### PR TITLE
[CBRD-25618] Change constexpr to const due to MSVC 2017 bug

### DIFF
--- a/src/transaction/log_recovery_redo_perf.hpp
+++ b/src/transaction/log_recovery_redo_perf.hpp
@@ -49,7 +49,7 @@ namespace cublog
     PERF_STAT_ID_FINALIZE,
   };
 
-  static constexpr cubperf::statset_definition::init_list_t perf_stats_main_definition_init_list
+  static const cubperf::statset_definition::init_list_t perf_stats_main_definition_init_list
   {
     cubperf::stat_definition (PERF_STAT_ID_FETCH_PAGE, cubperf::stat_definition::COUNTER_AND_TIMER,
 			      "Counter fetch_page", "Timer fetch_page (ms)"),
@@ -83,7 +83,7 @@ namespace cublog
     PERF_STAT_ID_PARALLEL_RETIRE,
   };
 
-  static constexpr cubperf::statset_definition::init_list_t perf_stats_async_definition_init_list
+  static const cubperf::statset_definition::init_list_t perf_stats_async_definition_init_list
   {
     cubperf::stat_definition (PERF_STAT_ID_PARALLEL_POP, cubperf::stat_definition::COUNTER_AND_TIMER,
 			      "Counter pop", "Timer pop (ms)"),


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25618

Purpose

MSVC 2017에서 constexpr 키워드를 컴파일하는 과정에서 버그가 있는 것으로 보인다. 
따라서, constexpr 키워드를 const 키워드로 대체한다.
