### PR TITLE
[CBRD-25603] Revive cub_server that is started by cubrid server start command

### DIFF
--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -110,7 +110,7 @@ server_monitor::register_server_entry (int pid, const std::string &exec_path, co
     {
       entry->second.set_pid (pid);
       entry->second.set_need_revive (false);
-      entry->second.set_registered_time (std::chrono::steady_clock::now ());
+      entry->second.set_last_revived_time (std::chrono::steady_clock::now ());
       _er_log_debug (ARG_FILE_LINE,
 		     "[Server Monitor] [%s] Server entry has been registered. (pid : %d)",
 		     server_name.c_str(), pid);
@@ -158,7 +158,8 @@ server_monitor::revive_server (const std::string &server_name)
 
       tv = std::chrono::steady_clock::now ();
       auto timediff = std::chrono::duration_cast<std::chrono::seconds> (tv -
-		      entry->second.get_registered_time()).count();
+		      entry->second.get_last_revived_time()).count();
+      bool revived_before = entry->second.get_last_revived_time () != std::chrono::steady_clock::time_point ();
 
       // If the server is abnormally terminated and revived within a short period of time, it is considered as a repeated failure.
       // For HA server, heartbeat handle this case as demoting the server from master to slave and keep trying to revive the server.
@@ -169,10 +170,9 @@ server_monitor::revive_server (const std::string &server_name)
       // TODO: Consider retry count for repeated failure case, and give up reviving the server after several retries.
       // TODO: The timediff value continues to increase if REVIVE_SERVER handling is repeated. Thus, the if condition will always be
       // true after the first evaluation. Therefore, evaluating the timediff only once when producing the REVIVE_SERVER job is needed.
-      // (Currently, it is impossible since registered_time is stored in server_entry, which is not synchronized structure between monitor and main thread.)
+      // (Currently, it is impossible since last_revived_time is stored in server_entry, which is not synchronized structure between monitor and main thread.)
 
-      if (entry->second.get_registered_time() == std::chrono::steady_clock::time_point ()
-	  || timediff > SERVER_MONITOR_UNACCEPTABLE_REVIVE_TIMEDIFF_IN_SECS)
+      if (!revived_before || timediff > SERVER_MONITOR_UNACCEPTABLE_REVIVE_TIMEDIFF_IN_SECS)
 	{
 	  out_pid = try_revive_server (entry->second.get_exec_path(), entry->second.get_argv());
 	  if (out_pid == -1)
@@ -366,7 +366,7 @@ server_entry (int pid, const std::string &exec_path, const std::string &args,
   : m_pid {pid}
   , m_exec_path {exec_path}
   , m_need_revive {false}
-  , m_registered_time {revive_time}
+  , m_last_revived_time {revive_time}
 {
   if (args.size() > 0)
     {
@@ -399,9 +399,9 @@ server_monitor::server_entry::get_need_revive () const
 }
 
 std::chrono::steady_clock::time_point
-server_monitor::server_entry::get_registered_time () const
+server_monitor::server_entry::get_last_revived_time () const
 {
-  return m_registered_time;
+  return m_last_revived_time;
 }
 
 void
@@ -423,9 +423,9 @@ server_monitor::server_entry::set_need_revive (bool need_revive)
 }
 
 void
-server_monitor::server_entry::set_registered_time (std::chrono::steady_clock::time_point revive_time)
+server_monitor::server_entry::set_last_revived_time (std::chrono::steady_clock::time_point revive_time)
 {
-  m_registered_time = revive_time;
+  m_last_revived_time = revive_time;
 }
 
 void

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -118,7 +118,7 @@ server_monitor::register_server_entry (int pid, const std::string &exec_path, co
   else
     {
       m_server_entry_map.emplace (std::move (server_name), server_entry (pid, exec_path, args,
-				  std::chrono::steady_clock::now ()));
+				  std::chrono::steady_clock::time_point ()));
 
       _er_log_debug (ARG_FILE_LINE,
 		     "[Server Monitor] [%s] Server entry has been registered newly. (pid : %d)",
@@ -171,7 +171,8 @@ server_monitor::revive_server (const std::string &server_name)
       // true after the first evaluation. Therefore, evaluating the timediff only once when producing the REVIVE_SERVER job is needed.
       // (Currently, it is impossible since registered_time is stored in server_entry, which is not synchronized structure between monitor and main thread.)
 
-      if (timediff > SERVER_MONITOR_UNACCEPTABLE_REVIVE_TIMEDIFF_IN_SECS)
+      if (entry->second.get_registered_time() == std::chrono::steady_clock::time_point ()
+	  || timediff > SERVER_MONITOR_UNACCEPTABLE_REVIVE_TIMEDIFF_IN_SECS)
 	{
 	  out_pid = try_revive_server (entry->second.get_exec_path(), entry->second.get_argv());
 	  if (out_pid == -1)

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -126,7 +126,7 @@ class server_monitor
 	    {
 	      m_pid = other.m_pid;
 	      m_need_revive = other.m_need_revive;
-	      m_registered_time = other.m_registered_time;
+	      m_last_revived_time = other.m_last_revived_time;
 	      m_exec_path = other.m_exec_path;
 	      m_argv = std::move (other.m_argv);
 	    }
@@ -137,21 +137,21 @@ class server_monitor
 	std::string get_exec_path () const;
 	char *const *get_argv () const;
 	bool get_need_revive () const;
-	std::chrono::steady_clock::time_point get_registered_time () const;
+	std::chrono::steady_clock::time_point get_last_revived_time () const;
 
 	void set_pid (int pid);
 	void set_exec_path (const std::string &exec_path);
 	void set_need_revive (bool need_revive);
-	void set_registered_time (std::chrono::steady_clock::time_point revive_time);
+	void set_last_revived_time (std::chrono::steady_clock::time_point revive_time);
 
 	void proc_make_arg (const std::string &args);
 
       private:
-	int m_pid;                                                  // process ID of server process
-	std::string m_exec_path;                                    // executable path of server process
-	std::unique_ptr<char *[]> m_argv;                           // arguments of server process
-	volatile bool m_need_revive;                                // need to be revived by monitoring thread
-	std::chrono::steady_clock::time_point m_registered_time;    // last revive time
+	int m_pid;                                                    // process ID of server process
+	std::string m_exec_path;                                      // executable path of server process
+	std::unique_ptr<char *[]> m_argv;                             // arguments of server process
+	volatile bool m_need_revive;                                  // need to be revived by monitoring thread
+	std::chrono::steady_clock::time_point m_last_revived_time;    // last revived time
     };
 
     std::unordered_map <std::string, server_entry> m_server_entry_map;  // map of server entries


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25603

- Purpose
  - `cubrid server start`를 통해 구동된 cub_server의 경우, 120초 이내에 kill 되더라도, 재구동 되어야 한다.
 
- Implementation
  - 비정상 종료된 cub_server의 경우 `server_entry`를 제거하지 않고, 정상적으로 종료된 cub_server의 경우에만 `server_entry`를 제거하기 때문에, `cubrid server start`를 통해 cub_server 가 구동되는 경우에만 새로운 `server_entry`가 생성된다.
  - 새로운 `server_entry`를 생성하는 경우에는 `std::chrono::steady_clock::time_point()`를 통해 null time을 삽입하고, revive job에서 이를 확인하는 과정을 통해 timediff가 120초를 넘지 않아도 재구동을 시키도록 조건문을 변경한다.