### PR TITLE
[CBRD-25613] Fix uninitialized current_oid when scan_id->mvcc_select_lock_needed is set

### DIFF
--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -5218,6 +5218,7 @@ scan_next_heap_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
   hsidp = &scan_id->s.hsid;
   if (scan_id->mvcc_select_lock_needed)
     {
+      COPY_OID (&current_oid, &hsidp->curr_oid);
       p_current_oid = &current_oid;
     }
   else


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25613

scan_id->mvcc_select_lock_needed이 설정된 경우 초기화되지 않은 current_oid를 p_current_oid에 설정하고 있습니다. 초기화 되지 않은 current_oid를 &hsidp->curr_oid로 우선 초기화 하도록 변경했습니다.