### PR TITLE
[CBRD-24462] Improve the logic that determines the number of threads to be used when running the backupdb utility, and additionally print the number of threads specified by administrator

### DIFF
--- a/src/storage/external_sort.c
+++ b/src/storage/external_sort.c
@@ -1492,8 +1492,8 @@ sort_listfile (THREAD_ENTRY * thread_p, INT16 volid, int est_inp_pg_cnt, SORT_GE
     {
       num_cpus = cubthread::system_core_count ();
 
-      sort_param->px_height_max = (int) sqrt ((double) num_cpus);	/* n */
-      sort_param->px_array_size = num_cpus;	/* 2^^n */
+      sort_param->px_height_max = (int) sqrt ((double) num_cpus);
+      sort_param->px_array_size = num_cpus;
 
       assert_release (sort_param->px_array_size == pow ((double) 2, (double) sort_param->px_height_max));
     }

--- a/src/storage/external_sort.c
+++ b/src/storage/external_sort.c
@@ -50,6 +50,7 @@
 #include "server_support.h"
 #include "thread_entry_task.hpp"
 #include "thread_manager.hpp"	// for thread_get_thread_entry_info and thread_sleep
+#include "thread_worker_pool.hpp"
 
 #include <functional>
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
@@ -1489,9 +1490,7 @@ sort_listfile (THREAD_ENTRY * thread_p, INT16 volid, int est_inp_pg_cnt, SORT_GE
 #if defined(SERVER_MODE)
   if (prm_enable_sort_parallel == true)
     {
-      /* TODO - calc n, 2^^n get the number of CPUs TODO - fileio_os_sysconf really get #cores instead of #CPUs -
-       * NEED MORE CONSIDERATION */
-      num_cpus = fileio_os_sysconf ();
+      num_cpus = cubthread::system_core_count ();
 
       sort_param->px_height_max = (int) sqrt ((double) num_cpus);	/* n */
       sort_param->px_array_size = num_cpus;	/* 2^^n */

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -85,6 +85,8 @@
 #include "log_common_impl.h"
 #include "log_volids.hpp"
 #include "fault_injection.h"
+#include "thread_worker_pool.hpp"
+
 #if defined (SERVER_MODE)
 #include "vacuum.h"
 #endif /* SERVER_MODE */

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -11525,6 +11525,7 @@ fileio_lock_region (int fd, int cmd, int type, off_t offset, int whence, off_t l
 }
 #endif /* !WINDOWS */
 
+#if defined(ENABLE_UNUSED_FUNCTION)
 #if defined(SERVER_MODE)
 /*
  * fileio_os_sysconf () -
@@ -11554,6 +11555,7 @@ fileio_os_sysconf (void)
   return (nprocs > 1) ? (int) nprocs : 1;
 }
 #endif /* SERVER_MODE */
+#endif
 
 /*
  * fileio_initialize_res () -

--- a/src/storage/file_io.h
+++ b/src/storage/file_io.h
@@ -610,9 +610,11 @@ extern int fileio_symlink (const char *src, const char *dest, int overwrite);
 extern int fileio_set_permission (const char *vlabel);
 #endif /* !WINDOWS */
 
+#if defined(ENABLE_UNUSED_FUNCTION)
 #if defined(SERVER_MODE)
 int fileio_os_sysconf (void);
 #endif /* SERVER_MODE */
+#endif
 
 /* flush control related */
 extern int fileio_flush_control_initialize (void);

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -7635,7 +7635,6 @@ logpb_backup (THREAD_ENTRY * thread_p, int num_perm_vols, const char *allbackup_
   size_t read_thread_count = 0;
   int specified_thread_count = num_threads;
 
-
 #if defined (SERVER_MODE)
   // check whether there is ongoing backup.
   LOG_CS_ENTER (thread_p);
@@ -7912,8 +7911,8 @@ loop:
 	}
       fprintf (session.verbose_fp, "[ Database(%s) %s Backup start ]\n\n", boot_db_name (), str_tmp);
 
-      fprintf (session.verbose_fp, "- used threads count: %d\n\n", session.read_thread_info.num_threads);
-      fprintf (session.verbose_fp, "- admin-specified thread count: %d\n\n", specified_thread_count);
+      fprintf (session.verbose_fp, "- num-threads: %d (user-requested: %d)\n\n", session.read_thread_info.num_threads,
+	       num_threads);
 
       if (zip_method == FILEIO_ZIP_NONE_METHOD)
 	{

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -7633,6 +7633,8 @@ logpb_backup (THREAD_ENTRY * thread_p, int num_perm_vols, const char *allbackup_
 
   LOG_PAGEID vacuum_first_pageid = NULL_PAGEID;
   size_t read_thread_count = 0;
+  int specified_thread_count = num_threads;
+
 
 #if defined (SERVER_MODE)
   // check whether there is ongoing backup.
@@ -7910,7 +7912,8 @@ loop:
 	}
       fprintf (session.verbose_fp, "[ Database(%s) %s Backup start ]\n\n", boot_db_name (), str_tmp);
 
-      fprintf (session.verbose_fp, "- num-threads: %d\n\n", session.read_thread_info.num_threads);
+      fprintf (session.verbose_fp, "- used threads count: %d\n\n", session.read_thread_info.num_threads);
+      fprintf (session.verbose_fp, "- admin-specified thread count: %d\n\n", specified_thread_count);
 
       if (zip_method == FILEIO_ZIP_NONE_METHOD)
 	{

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -43,8 +43,6 @@
 #include "slotted_page.h"
 #include "system_parameter.h"
 #include "thread_manager.hpp"
-#include "thread_worker_pool.hpp"
-
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
 #include "memory_wrapper.hpp"
 

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -43,6 +43,8 @@
 #include "slotted_page.h"
 #include "system_parameter.h"
 #include "thread_manager.hpp"
+#include "thread_worker_pool.hpp"
+
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
 #include "memory_wrapper.hpp"
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24462


### **_Purpose_**

- 문제 상황
  - backup 유틸리티 사용 시 -t 옵션을 사용해 백업에 사용할 쓰레드 개수를 설정할 수 있는데
     -o 옵션을 사용해 자세한 백업 정보를 출력할 때, 사용자가 입력한 쓰레드 개수가 출력되지 않음
  - CPU 코어 수를 구하는 함수(fileio_os_sysconf)는 플랫폼 별 구현이 따로 되어있어 유지보수 측면에서 좋지 않아 교체가 필요함
  - CPU 코어 수를 구하는 함수는 하이퍼쓰레딩을 자체적으로 고려하고 있는데 함수 외부에서 하이퍼쓰레딩을 이중으로 고려하는 문제


- 1번 문제 원인
  - 사용자가 입력한 쓰레드 개수와 CPU 코어 수, cubrid.conf 파일에 설정된 max_clients 파라미터 값 중 가장 작은 값을
    백업에 사용될 쓰레드 개수로 설정하고, 해당 값을 출력해주고 있음
  - 사용자가 입력한 쓰레드 개수 값을 추가로 출력

- 2번 문제 원인
  - fileio_os_sysconf 함수는 플랫폼 별 구현이 따로 되어있어 추후 유지보수 측면을 고려하여 변경하는 것이 좋다고 판단
  - fileio_os_sysconf 함수를 호출하는 모든 코드를 수정

- 3번 문제 원인
  - CPU 코어 수를 구하는 함수에서 자체적으로 하이퍼쓰레딩을 고려하고 있는데 
    함수 외부에서 추가로 하이퍼쓰레딩을 고려하여 x2 를 해주고 있어 쓰레드 계산식이 잘못되는 문제가 발생함

---
### **_주요 함수 및 변수_**
- CPU 코어 수를 구하는 함수
  - fileio_os_sysconf()
  - cubthread::system_core_count()
- 사용자 CPU 코어 수
  - num_cpus 
- 사용자가 입력한 쓰레드 개수
  - num_threads
  - specified_thread_count
- max_clients 파라미터 값
  - NUM_NORMAL_TRANS
- 최종적으로 계산된 사용할 쓰레드 개수
  - thread_info_p->num_threads
  - session.read_thread_info.num_threads

---
### **_Implementation_**
- 사용자가 입력한 쓰레드 개수를 추가로 출력하도록 수정
- CPU 코어 수를 구하는 함수를 모두 fileio_os_sysconf 함수에서 cubthread::system_core_count로 변경
- fileio_os_sysconf 함수는 사용하는 곳이 없기 때문에 #if defined(ENABLE_UNUSED_FUNCTION) ~#endif 처리
- 백업에 사용될 쓰레드 개수를 정하는 계산식에서 하이퍼쓰레딩을 고려하여 위 함수를 통해 구한 CPU 코어 수에 x2 를 해주는 부분 삭제