### PR TITLE
[CBRD-25597] Fix the deadlock between recovery thread and pgbuf flush thread

### DIFF
--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -4526,6 +4526,8 @@ log_recovery_undo (THREAD_ENTRY * thread_p)
       tsc_start_time_usec (&info_logging_check_time);
     }
 
+  LOG_CS_EXIT (thread_p);
+
   while (!LSA_ISNULL (&max_undo_lsa))
     {
       /* Fetch the page where the LSA record to undo is located */
@@ -4949,6 +4951,8 @@ log_recovery_undo (THREAD_ENTRY * thread_p)
   er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_LOG_RECOVERY_PHASE_FINISHING_UP, 1, "UNDO");
 
   /* Flush all dirty pages */
+
+  LOG_CS_ENTER (thread_p);
 
   logpb_flush_pages_direct (thread_p);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25597

Purpose

recovery undo 스레드와 pgbuf flush daemon 간 데드락 상황이 발생한다. 

recovery undo 스레드는 LOG_CS 에 진입한 후 pgbuf flush가 완료될때까지 대기한다.
pgbuf flush daemon은 LOG_CS에 진입해야만 pgbuf flush를 수행할 수 있다.

따라서, 위 상황을 해결하기 위해 LOG_CS 범위를 조정한다.
