### PR TITLE
[CBRD-25507] Slip: 서버측 커서에 누락된 코드 수정 추가

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/impl/SUStatement.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/impl/SUStatement.java
@@ -359,9 +359,10 @@ public class SUStatement {
             // If fetchInfo.numFetched == 0, it means there are no remaining rows.
             fetchedStartCursorPosition = fetchInfo.tuples[0].tupleNumber() - 1;
             fetchedEndCursorPosition = fetchedStartCursorPosition + fetchedTupleNumber;
+
+            // update cursorPosition to the fetched start position
+            cursorPosition = fetchedStartCursorPosition;
         }
-        // update cursorPosition to the fetched start position
-        cursorPosition = fetchedStartCursorPosition;
     }
 
     public void moveCursor(int offset, int origin) {

--- a/src/method/method_invoke_java.cpp
+++ b/src/method/method_invoke_java.cpp
@@ -477,7 +477,7 @@ namespace cubmethod
       {
 	s_code = cursor->next_row ();
 	int tuple_index = cursor->get_current_index ();
-	if (s_code == S_END || tuple_index - start_index >= fetch_count)
+	if (s_code == S_END)
 	  {
 	    break;
 	  }
@@ -494,6 +494,11 @@ namespace cubmethod
 	else
 	  {
 	    info.tuples.emplace_back (tuple_index, tuple_values);
+	  }
+
+	if (tuple_index - start_index > fetch_count)
+	  {
+	    break;
 	  }
       }
 

--- a/src/method/method_invoke_java.cpp
+++ b/src/method/method_invoke_java.cpp
@@ -496,7 +496,7 @@ namespace cubmethod
 	    info.tuples.emplace_back (tuple_index, tuple_values);
 	  }
 
-	if (tuple_index - start_index > fetch_count)
+	if (tuple_index - start_index >= fetch_count - 1)
 	  {
 	    break;
 	  }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25507

이전 커밋에서 서버 측 커서에서 누락된 부분을 추가했습니다.

```
;server-output on
create or replace function demo_sum_ret() return bigint as 
sum_ret bigint := 0;
begin

    for r in (SELECT a FROM a1 ORDER BY a LIMIT 1002) loop
        sum_ret := sum_ret + 1;
        DBMS_OUTPUT.put_line (r.a);
    end loop;

    return sum_ret;
end;

SELECT demo_sum_ret ();
```

```
1001

<DBMS_OUTPUT>
1
2
3
4
...
1001
1002
```