### PR TITLE
[CBRD-25599] Fix the wrong range check in log_is_page_of_record_broken

### DIFF
--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -2532,7 +2532,7 @@ log_is_page_of_record_broken (THREAD_ENTRY * thread_p, const LOG_LSA * log_lsa,
   /* TODO - Do we need to handle NULL fwd_log_lsa? */
   if (!LSA_ISNULL (&fwd_log_lsa))
     {
-      if (LSA_GE (log_lsa, &fwd_log_lsa) || LSA_GE (&fwd_log_lsa, &log_Gl.hdr.eof_lsa))
+      if (LSA_GE (log_lsa, &fwd_log_lsa) || LSA_GT (&fwd_log_lsa, &log_Gl.hdr.eof_lsa))
 	{
 	  // check fwd_log_lsa value if it is corrupted or not
 	  is_log_page_broken = true;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25599

Purpose

log_Gl.hdr.eof_lsa 와 fwd_log_lsa가 같은 경우는 예외 처리하면 안된다.
log_Gl.hdr.eof_lsa에 위치한 로그레코드는 LOG_END_OF_LOG 이기 때문에 해당 로그레코드까지 순회해야한다. 

LOG_COMMIT - LOG_END_OF_LOG 순으로 로그가 남고 위와 같이 예외처리할 경우, 
LOG_COMMIT 레코드는 REDO 범위에 속하지만, 별도의 분석은 하지 않는다. 따라서, analysis 단계에서 LOG_COMMIT에 대한 처리 (transaction table 에서 제거)를 하지 않기 때문에 redo 단계에서 assertion fail이 발생한 것이다.

관련 PR : #5469