### PR TITLE
[CBRD-25607] When a super administrator (DBA) and member (Owner, DBA) grants/revokes privileges, make it behave as if the owner is performing the action.

### DIFF
--- a/src/object/authenticate_grant.cpp
+++ b/src/object/authenticate_grant.cpp
@@ -1891,6 +1891,8 @@ au_compare_grantor_and_return (MOP *grantor, MOP obj_mop, DB_AUTH type, MOP logi
   DB_SET *grants;
   int j, gsize;
 
+  assert (grantor != NULL && obj_mop != NULL && login_user != NULL && class_owner != NULL);
+
   *grantor = NULL;
 
   if (au_is_dba_group_member (login_user) || au_is_user_group_member (class_owner, login_user))


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25607

Purpose

권한을 부여할 수 있는 사용자
 - DBA 및 멤버(Owner, DBA)가 권한을 부여할 때, GRANTOR를 소유자로 변경됨

| 권한 부여자 | Grantor 결과 |
|--------------| --------------|
| DBA | Owner |
| Owner | Owner |
| Grantable User (WITH GRANT OPTION을 받은 사용자) | Grantable User |
| DBA 멤버 | Owner |
| Owner 멤버 | Owner |

권한을 회수할 때 동작 결과
- DBA 및 멤버(Owner, DBA)가 권한을 회수할 때, 소유자로 동작하도록 변경됨

|권한 회수자(Login user)|GRANTOR|GRANTEE|소유자.객체|회수 결과|
|--------------| --------------|--------------|--------------|--------------|
|DBA|owner|grantable|owner.tbl|O|
|DBA|grantable|temp_user|owner.tbl|X|
|Owner|Owner|grantable|owner.tbl|O|
|Owner|Owner|temp_user|owner.tbl|X|
|grantable|grantable|temp_user|owner.tbl|O|
|DBA Members|Owner|grantable|owner.tbl|O|
|DBA Members|grantable|temp_user|owner.tbl|X|
|Owner Members|Owner|grantable|owner.tbl|O|
|Owner Members|grantable|temp_user|owner.tbl|X|
|Grantable Members|grantable|temp_user|owner.tbl|X|

변경 기준
1. Grant 권한을 부여받지 않은 사용자는 권한을 부여하거나 회수할 수 없다.
   - 예외 사용자 : DBA, DBA 멤버, Owner 멤버
   - Grantable 사용자는 일반 사용자와 동일한 권한을 가집니다.
   - 즉, 다른 사용자에게 권한을 부여하거나 회수하려면 WITH GRANT OPTION이 필요합니다.

2. 멤버(DBA, Owner)가 WITH GRANT OPTION을 가진 경우
   - 권한 부여 시 멤버의 우선 순위가 WITH GRANT OPTION보다 높습니다.
   - Member > WITH GRANT OPTION

Implementation

기존에 권한을 체크하던 check_grant_option() 함수에서는 로그인 사용자가 어떤 그룹에 속해 있는지 알 수 없어서, AU_FULL_AUTHORIZATION 권한을 누구에게 받았는지 여부를 판단할 수 없었습니다.

따라서, au_compare_grantor_and_return() 함수를 추가하여 다음 세 가지 기능을 수행합니다.
1. DBA 및 멤버(Owner, DBA)인 경우 Grantor를 소유자로 변경
2. WITH GRANT OPTION이 있는 경우 Grantor를 로그인 사용자로 변경
3. 권한이 없는 경우 에러 메시지를 출력

Remarks

N/A