### PR TITLE
[CBRD-25435] slip: fix hour indicator in SimpleDateFormat objects

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/DateTimeParser.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/DateTimeParser.java
@@ -342,13 +342,22 @@ public class DateTimeParser {
     // for parsing time fragment
     // ------------------------------------------------------
 
+    // hour 0 ~ 11
+    private static final List<SimpleDateFormat> timeFormats11 =
+            Arrays.asList(
+                    new SimpleDateFormat("KK:mm aa", Locale.US),
+                    new SimpleDateFormat("KK:mm:ss aa", Locale.US),
+                    new SimpleDateFormat("KK:mm:ss.SSS aa", Locale.US) // must go at last
+                    );
+    // hour 1 ~ 12
     private static final List<SimpleDateFormat> timeFormats12 =
             Arrays.asList(
-                    new SimpleDateFormat("HH:mm aa", Locale.US),
-                    new SimpleDateFormat("HH:mm:ss aa", Locale.US),
-                    new SimpleDateFormat("HH:mm:ss.SSS aa", Locale.US) // must go at last
+                    new SimpleDateFormat("hh:mm aa", Locale.US),
+                    new SimpleDateFormat("hh:mm:ss aa", Locale.US),
+                    new SimpleDateFormat("hh:mm:ss.SSS aa", Locale.US) // must go at last
                     );
-    private static final List<SimpleDateFormat> timeFormats24 =
+    // hour 0 ~ 23
+    private static final List<SimpleDateFormat> timeFormats23 =
             Arrays.asList(
                     new SimpleDateFormat("HH:mm"),
                     new SimpleDateFormat("HH:mm:ss"),
@@ -356,11 +365,15 @@ public class DateTimeParser {
                     );
 
     static {
+        for (SimpleDateFormat f : timeFormats11) {
+            f.setLenient(false);
+            assert f.getCalendar() instanceof GregorianCalendar;
+        }
         for (SimpleDateFormat f : timeFormats12) {
             f.setLenient(false);
             assert f.getCalendar() instanceof GregorianCalendar;
         }
-        for (SimpleDateFormat f : timeFormats24) {
+        for (SimpleDateFormat f : timeFormats23) {
             f.setLenient(false);
             assert f.getCalendar() instanceof GregorianCalendar;
         }
@@ -369,7 +382,16 @@ public class DateTimeParser {
     private static LocalTime parseTimeFragment(String s, boolean millis) {
 
         s = s.trim();
-        List<SimpleDateFormat> formats = (s.indexOf(" ") >= 0) ? timeFormats12 : timeFormats24;
+        List<SimpleDateFormat> formats;
+        if (s.indexOf(" ") >= 0) {
+            if (s.startsWith("00")) {
+                formats = timeFormats11;
+            } else {
+                formats = timeFormats12;
+            }
+        } else {
+            formats = timeFormats23;
+        }
 
         int j = 0;
         for (SimpleDateFormat f : formats) {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/DateTimeParser.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/DateTimeParser.java
@@ -344,9 +344,9 @@ public class DateTimeParser {
 
     private static final List<SimpleDateFormat> timeFormats12 =
             Arrays.asList(
-                    new SimpleDateFormat("KK:mm aa", Locale.US),
-                    new SimpleDateFormat("KK:mm:ss aa", Locale.US),
-                    new SimpleDateFormat("KK:mm:ss.SSS aa", Locale.US) // must go at last
+                    new SimpleDateFormat("HH:mm aa", Locale.US),
+                    new SimpleDateFormat("HH:mm:ss aa", Locale.US),
+                    new SimpleDateFormat("HH:mm:ss.SSS aa", Locale.US) // must go at last
                     );
     private static final List<SimpleDateFormat> timeFormats24 =
             Arrays.asList(


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25435

시간 문자열을 파싱하는데 사용되는 SimpleDateFormat 중에 am/pm 을 사용하는 기존 형태에서
"12:**:** am/pm" 모양을 파싱하지 못하는 문제가 있었음.
기존 시간 표시자인 KK 가 (0~11) 까지만 유효하기 때문. 
새로운 시간 표시자 hh (1 ~ 12) 을 사용하는 format을 추가해서 해결.

참고: SimpleDateFormat in Java API doc
