### PR TITLE
[CBRD-25442] Introudce MemoryClass cache in PL server's SessionClassLoader

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/StoredProcedure.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/StoredProcedure.java
@@ -107,9 +107,12 @@ public class StoredProcedure {
         ClassNotFoundException ex = null;
         if (lang == LANG_PLCSQL) {
             try {
-                CompiledCodeSet codeset = ClassAccess.getObjectCode(conn, sig);
-                if (codeset != null) {
-                    c = ctx.getSessionCLManager().loadClass(codeset);
+                c = ctx.getSessionCLManager().findClass(sig.getClassName());
+                if (c == null) {
+                    CompiledCodeSet codeset = ClassAccess.getObjectCode(conn, sig);
+                    if (codeset != null) {
+                        c = ctx.getSessionCLManager().loadClass(codeset);
+                    }
                 }
             } catch (ClassNotFoundException e) {
                 ex = e;

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/classloader/SessionClassLoaderManager.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/classloader/SessionClassLoaderManager.java
@@ -26,14 +26,31 @@ public class SessionClassLoaderManager {
 
         String className = code.getMainClassName();
         MemoryClass mCls = null;
-        if (sessionScopedLoadedCode.containsKey(className)) {
-            mCls = sessionScopedLoadedCode.get(className);
-        } else {
+        if (!sessionScopedLoadedCode.containsKey(className)) {
             mCls = new MemoryClass(className);
             mCls.setCode(code);
+            sessionScopedLoadedCode.put(className, mCls);
         }
 
-        return sessionClassLoaderGroup.loadClass(code);
+        Class<?> loadedClass = sessionClassLoaderGroup.loadClass(code);
+        if (mCls != null && loadedClass != null) {
+            mCls.setLoadedClass(loadedClass);
+        }
+
+        return loadedClass;
+    }
+
+    public Class<?> findClass(String mainClassName) {
+        MemoryClass mCls = null;
+        if (sessionScopedLoadedCode.containsKey(mainClassName)) {
+            mCls = sessionScopedLoadedCode.get(mainClassName);
+        }
+
+        if (mCls != null) {
+            return mCls.getLoadedClass();
+        }
+
+        return null;
     }
 
     public void clear() {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/code/MemoryClass.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/code/MemoryClass.java
@@ -55,6 +55,10 @@ public class MemoryClass {
         return loadedClass;
     }
 
+    public void setLoadedClass(Class<?> loadedClass) {
+        this.loadedClass = loadedClass;
+    }
+
     public void clear() {
         if (this.loadedCode != null) {
             this.loadedCode.clear();


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25442

**Repro**
```
create or replace function my_length(s string) return string as
begin
  return LENGTH (s);
end;

select count(my_length(name)) from athlete;
```

**AS-IS**
CUBRID 11.4 (11.4.0.1521-39eb132)
```
=== <Result of SELECT Command in Line 1> ===

  count(my_length(name))
========================
                    6677

1 row selected. (7.820643 sec) Committed. (0.000000 sec)
```


**TO-BE**
```
=== <Result of SELECT Command in Line 1> ===

  count(my_length(name))
========================
                    6677

1 row selected. (3.569336 sec) Committed. (0.000983 sec) 
```
