### PR TITLE
[CBRD-25630] do not create default broker LOG dirs at broker start up

### DIFF
--- a/src/broker/broker_admin_pub.c
+++ b/src/broker/broker_admin_pub.c
@@ -299,7 +299,7 @@ admin_start_cmd (T_BROKER_INFO * br_info, int br_num, int master_shm_id, bool ac
 
   for (i = 0; i < br_num; i++)
     {
-      char path[PATH_MAX];
+      char dirpath[PATH_MAX];
 
 #if !defined(WINDOWS)
       /* prevent the broker from hanging due to an excessively long path socket path length =
@@ -312,8 +312,8 @@ admin_start_cmd (T_BROKER_INFO * br_info, int br_num, int master_shm_id, bool ac
 	  return -1;
 	}
 #endif /* !WINDOWS */
-      snprintf (path, PATH_MAX, "%s/query", br_info[i].log_dir);
-      broker_create_dir (path);
+      snprintf (dirpath, PATH_MAX, "%s/query", br_info[i].log_dir);
+      broker_create_dir (dirpath);
       broker_create_dir (br_info[i].slow_log_dir);
       broker_create_dir (br_info[i].err_log_dir);
       broker_create_dir (br_info[i].access_log_dir);

--- a/src/broker/broker_admin_pub.c
+++ b/src/broker/broker_admin_pub.c
@@ -312,7 +312,13 @@ admin_start_cmd (T_BROKER_INFO * br_info, int br_num, int master_shm_id, bool ac
 	  return -1;
 	}
 #endif /* !WINDOWS */
-      snprintf (dirpath, PATH_MAX, "%s/query", br_info[i].log_dir);
+
+#if defined (WINDOWS)
+      snprintf (dirpath, PATH_MAX, "%s", br_info[i].log_dir);
+#else
+      snprintf (dirpath, PATH_MAX, "%s%s", br_info[i].log_dir, br_info[i].sql_log2 ? "/query" : "");
+#endif
+
       broker_create_dir (dirpath);
       broker_create_dir (br_info[i].slow_log_dir);
       broker_create_dir (br_info[i].err_log_dir);

--- a/src/broker/broker_admin_pub.c
+++ b/src/broker/broker_admin_pub.c
@@ -318,7 +318,7 @@ admin_start_cmd (T_BROKER_INFO * br_info, int br_num, int master_shm_id, bool ac
 #else
       /*
        * broker_create_dir () creates all intermediate directories indicated in the path,
-       * as well as the leaf directory.
+       * as well as the leaf directory (.../sql_log, .../sql_log/query).
        */
       snprintf (dirpath, PATH_MAX, "%s%s", br_info[i].log_dir, br_info[i].sql_log2 ? "/query" : "");
 #endif

--- a/src/broker/broker_admin_pub.c
+++ b/src/broker/broker_admin_pub.c
@@ -320,7 +320,7 @@ admin_start_cmd (T_BROKER_INFO * br_info, int br_num, int master_shm_id, bool ac
        * broker_create_dir () creates all intermediate directories indicated in the path,
        * as well as the leaf directory (.../sql_log, .../sql_log/query).
        */
-      snprintf (dirpath, PATH_MAX, "%s%s", br_info[i].log_dir, br_info[i].sql_log2 ? "/query" : "");
+      snprintf (dirpath, PATH_MAX, "%s/query", br_info[i].log_dir);
 #endif
 
       broker_create_dir (dirpath);

--- a/src/broker/broker_admin_pub.c
+++ b/src/broker/broker_admin_pub.c
@@ -272,9 +272,6 @@ admin_start_cmd (T_BROKER_INFO * br_info, int br_num, int master_shm_id, bool ac
   broker_create_dir (get_cubrid_file (FID_VAR_DIR, path, BROKER_PATH_MAX));
   broker_create_dir (get_cubrid_file (FID_CAS_TMP_DIR, path, BROKER_PATH_MAX));
   broker_create_dir (get_cubrid_file (FID_AS_PID_DIR, path, BROKER_PATH_MAX));
-  broker_create_dir (get_cubrid_file (FID_SQL_LOG_DIR, path, BROKER_PATH_MAX));
-  broker_create_dir (get_cubrid_file (FID_SLOW_LOG_DIR, path, BROKER_PATH_MAX));
-  broker_create_dir (get_cubrid_file (FID_CUBRID_ERR_DIR, path, BROKER_PATH_MAX));
 
   if (admin_log_file != NULL)
     {
@@ -296,13 +293,14 @@ admin_start_cmd (T_BROKER_INFO * br_info, int br_num, int master_shm_id, bool ac
     }
 
 #if !defined(WINDOWS)
-  broker_create_dir (get_cubrid_file (FID_SQL_LOG2_DIR, path, BROKER_PATH_MAX));
   broker_create_dir (get_cubrid_file (FID_SOCK_DIR, path, BROKER_PATH_MAX));
 #endif /* !WINDOWS */
 
 
   for (i = 0; i < br_num; i++)
     {
+      char path[PATH_MAX];
+
 #if !defined(WINDOWS)
       /* prevent the broker from hanging due to an excessively long path socket path length =
        * sock_path[broker_name].[as_index] */
@@ -314,7 +312,8 @@ admin_start_cmd (T_BROKER_INFO * br_info, int br_num, int master_shm_id, bool ac
 	  return -1;
 	}
 #endif /* !WINDOWS */
-      broker_create_dir (br_info[i].log_dir);
+      snprintf (path, PATH_MAX, "%s/query", br_info[i].log_dir);
+      broker_create_dir (path);
       broker_create_dir (br_info[i].slow_log_dir);
       broker_create_dir (br_info[i].err_log_dir);
       broker_create_dir (br_info[i].access_log_dir);

--- a/src/broker/broker_admin_pub.c
+++ b/src/broker/broker_admin_pub.c
@@ -316,6 +316,10 @@ admin_start_cmd (T_BROKER_INFO * br_info, int br_num, int master_shm_id, bool ac
 #if defined (WINDOWS)
       snprintf (dirpath, PATH_MAX, "%s", br_info[i].log_dir);
 #else
+      /*
+       * broker_create_dir () creates all intermediate directories indicated in the path,
+       * as well as the leaf directory.
+       */
       snprintf (dirpath, PATH_MAX, "%s%s", br_info[i].log_dir, br_info[i].sql_log2 ? "/query" : "");
 #endif
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25630

**Description**
* remove following hard-coded broker log directory creation code (**BROKER-CONF-NAME default-dir**):
  * SQL_LOG: **$CUBRID/log/broker/sql_log**
  * SLOW_LOG: **$CUBRID/log/broker/sql_log**
  * ERROR_LOG: **$CUBRID/log/broker/error_log**
  * $CUBRID/log/broker/sql_log/query