### PR TITLE
[CBRD-25345] acl entry format validation check

### DIFF
--- a/src/broker/broker_acl.c
+++ b/src/broker/broker_acl.c
@@ -284,9 +284,11 @@ error:
 static bool
 is_invalid_acl_entry (const char *acl)
 {
+  char br_name[LINE_MAX];
   int len;
   int num_colon = 0;
   int i;
+  bool ret = false;
 
   if (acl == NULL || (len = strlen (acl)) == 0)
     {
@@ -295,7 +297,17 @@ is_invalid_acl_entry (const char *acl)
 
   if (acl[0] == '[')
     {
-      return (acl[len - 1] != ']');
+      if (sscanf (acl, "[%[^]]", br_name) != 1 || acl[len - 1] != ']')
+	{
+	  ret = true;
+	}
+
+      if (!ret && (br_name[0] != '%' || strchr (br_name, ' ') != NULL))
+	{
+	  ret = true;
+	}
+
+      return ret;
     }
 
   for (i = 0; i < len; i++)

--- a/src/broker/broker_acl.c
+++ b/src/broker/broker_acl.c
@@ -35,6 +35,8 @@
 #define ADMIN_ERR_MSG_SIZE	BROKER_PATH_MAX * 2
 #define ACCESS_FILE_DELIMITER ":"
 #define IP_FILE_DELIMITER ","
+#define COLON ':'
+#define NUM_COLON_EXPECTED 2
 
 ACCESS_INFO access_info[ACL_MAX_ITEM_COUNT];
 int num_access_info;
@@ -48,6 +50,7 @@ static int access_control_check_right_internal (T_SHM_APPL_SERVER * shm_as_p, ch
 static int access_control_check_ip (T_SHM_APPL_SERVER * shm_as_p, IP_INFO * ip_info, unsigned char *address,
 				    int info_index);
 static int record_ip_access_time (T_SHM_APPL_SERVER * shm_as_p, int info_index, int list_index);
+static bool is_invalid_acl_entry (const char *buf);
 
 int
 access_control_set_shm (T_SHM_APPL_SERVER * shm_as_p, T_BROKER_INFO * br_info_p, T_SHM_BROKER * shm_br,
@@ -116,7 +119,7 @@ access_control_read_config_file (T_SHM_APPL_SERVER * shm_appl, char *filename, c
   int num_access_list = 0, line = 0;
   ACCESS_INFO new_access_info[ACL_MAX_ITEM_COUNT];
   ACCESS_INFO *access_info;
-  bool is_current_broker_section;
+  bool is_current_broker_section = false;
 #if defined(WINDOWS)
   char acl_sem_name[BROKER_NAME_LEN];
 #endif
@@ -128,8 +131,6 @@ access_control_read_config_file (T_SHM_APPL_SERVER * shm_appl, char *filename, c
       sprintf (admin_err_msg, "%s: error while loading access control file(%s)", shm_appl->broker_name, filename);
       return -1;
     }
-
-  is_current_broker_section = false;
 
   memset (new_access_info, '\0', sizeof (new_access_info));
 
@@ -149,6 +150,12 @@ access_control_read_config_file (T_SHM_APPL_SERVER * shm_appl, char *filename, c
       if (buf[0] == '\0')
 	{
 	  continue;
+	}
+
+      if (is_invalid_acl_entry (buf))
+	{
+	  sprintf (admin_err_msg, "%s: invalid acl list entry: (%s:%d)", shm_appl->broker_name, filename, line);
+	  goto error;
 	}
 
       if (is_current_broker_section == false && strncmp (buf, "[%", 2) == 0 && buf[strlen (buf) - 1] == ']')
@@ -272,6 +279,34 @@ error:
   fclose (fd_access_list);
 
   return -1;
+}
+
+static bool
+is_invalid_acl_entry (const char *acl)
+{
+  int len;
+  int num_colon = 0;
+  int i;
+
+  if (acl == NULL || (len = strlen (acl)) == 0)
+    {
+      return false;
+    }
+
+  if (acl[0] == '[')
+    {
+      return (acl[len - 1] != ']');
+    }
+
+  for (i = 0; i < len; i++)
+    {
+      if (acl[i] == COLON)
+	{
+	  num_colon++;
+	}
+    }
+
+  return (num_colon != NUM_COLON_EXPECTED);
 }
 
 static void

--- a/src/broker/broker_acl.c
+++ b/src/broker/broker_acl.c
@@ -298,7 +298,7 @@ is_invalid_acl_entry (const char *acl)
     {
       bool ret = false;
 
-      if (sscanf(acl, "[%%%[^]]", br_name) != 1 || acl[len - 1] != ']' || strchr (br_name, ' ') != NULL)
+      if (sscanf (acl, "[%%%[^]]", br_name) != 1 || acl[len - 1] != ']' || strchr (br_name, ' ') != NULL)
 	{
 	  ret = true;
 	}

--- a/src/broker/broker_acl.c
+++ b/src/broker/broker_acl.c
@@ -288,7 +288,6 @@ is_invalid_acl_entry (const char *acl)
   int len;
   int num_colon = 0;
   int i;
-  bool ret = false;
 
   if (acl == NULL || (len = strlen (acl)) == 0)
     {
@@ -297,12 +296,9 @@ is_invalid_acl_entry (const char *acl)
 
   if (acl[0] == '[')
     {
-      if (sscanf (acl, "[%[^]]", br_name) != 1 || acl[len - 1] != ']')
-	{
-	  ret = true;
-	}
+      bool ret = false;
 
-      if (!ret && (br_name[0] != '%' || strchr (br_name, ' ') != NULL))
+      if (sscanf(acl, "[%%%[^]]", br_name) != 1 || acl[len - 1] != ']' || strchr (br_name, ' ') != NULL)
 	{
 	  ret = true;
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25345

**Description**
* do broker ACL entry format validation
1. **section name**: if it start with '[%', check whether it end with ']' without blank inside '[', ']'
2. The section name cannot contain blank ([broker 1] style is not allowed)
3. **acl entry**: check whether COLON appears 2 times

**Remarks**
* access control을 허용하기 위한 ip_list_file에서 사용하는 IP address에 대한 validation은 이미 실행중이다.
  * 각 숫자가 0 ~ 255 범위에 있는지
  * a.b.c.d.e 형태는 아닌지등
@mhoh3963 @airnet73 
* validation check에 사용될 rule이 더 있다면 comment 바랍니다.