### PR TITLE
[CBRD-25367] limit identifier length to 222

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -1400,7 +1400,7 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
         }
     }
 
-    private static final int ID_LEN_MAX = 222;  // see User Manual
+    private static final int ID_LEN_MAX = 222; // see User Manual
 
     @Override
     public Expr visitIdentifier(IdentifierContext ctx) {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -1400,8 +1400,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
         }
     }
 
-    private static final int ID_LEN_MAX = 222; // see User Manual
-
     @Override
     public Expr visitIdentifier(IdentifierContext ctx) {
         String name = Misc.getNormalizedText(ctx);
@@ -2271,6 +2269,8 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     // --------------------------------------------------------
     // Private Static
     // --------------------------------------------------------
+
+    private static final int ID_LEN_MAX = 222; // see User Manual
 
     private static final BigInteger UINT_LITERAL_MAX =
             new BigInteger("99999999999999999999999999999999999999");

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -1400,9 +1400,17 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
         }
     }
 
+    private static final int ID_LEN_MAX = 222;  // see User Manual
+
     @Override
     public Expr visitIdentifier(IdentifierContext ctx) {
         String name = Misc.getNormalizedText(ctx);
+
+        if (name.length() > ID_LEN_MAX) {
+            throw new SemanticError(
+                    Misc.getLineColumnOf(ctx), // s094
+                    "identifier length may not exceed " + ID_LEN_MAX);
+        }
 
         Decl decl = symbolStack.getDeclForIdExpr(name);
         if (decl == null) {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25367

식별자 길이를 사용자 매뉴얼대로 222까지로 제한
