### PR TITLE
[CBRD-25477] Fixed is_in_sp_func_type to be initialized when an error occurs.

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -1864,6 +1864,7 @@ stmt
 			parser_hidden_incr_list = NULL;
 
                         g_plcsql_text = NULL;
+                        is_in_sp_func_type = false;
                         assert(expecting_pl_lang_spec == 0); // initialized in parser_main() or parse_one_statement()
 		DBG_PRINT}}
 	stmt_


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25477

* Fixed is_in_sp_func_type to be initialized when an error occurs.


재현 케이스
```
;server-output on

create or replace procedure t(a boolean) as
begin
    null;
end;

select count(*) from db_stored_procedure where sp_name = 't';
```