### PR TITLE
[CBRD-24306] change fclose(stdout) lib call to close (STDOUT_FILENO) system call

### DIFF
--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -902,12 +902,12 @@ proc_execute_internal (const char *file, const char *args[], bool wait_child, bo
       signal (SIGCHLD, SIG_DFL);
       if (close_output)
 	{
-	  fclose (stdout);
+	  close (STDOUT_FILENO);
 	}
 
       if (close_err)
 	{
-	  fclose (stderr);
+	  close (STDERR_FILENO);
 	}
 
       if (execv (executable_path, (char *const *) args) == -1)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24306

Description
* fclose (stdout), fclose (stderr)를 close (STDOUT_FILENO), lose (STDERR_FILENO)로 변경

**Remarks**
* 이 issue의 문제는 
1. 'cubrid service status'와 달리 
2. 'cubrid service status > status.out'

의 결과가 다르다는 것이다.
* stdout을 redirection 한 경우는 같은 메시지를 2번 이상 출력한다.
* 처음엔 execv (3) library의 동작을 의심했는데, 그 위의 fclose (stdout) LINE도 의심하는 코드로 생각했다.
* 이 library 호출은 같은 결과인 close (1) 또는 close (STDOUT_FILENO)로 변경하여 시험해본 결과 메시지를 중복 출력하는 결과는 없어졌다 (명확한 설명은 어렵다).
* `fclose (stdout)`과  `close (STDOUT_FILENO)` 는 같은 기능의 코드라고 생각한다, 그렇지만 결과는 이 이슈를 해결한다
  (명확히 설명 못하는 것을 아쉽게 생각합니다)
* 이 이슈는 legacy issue 입니다 (10.x에도 동일하게 발생)