### PR TITLE
[CBRD-25647] Unmatch hex value after loading into a new database

### DIFF
--- a/src/executables/unload_object_file.c
+++ b/src/executables/unload_object_file.c
@@ -605,7 +605,7 @@ print_quoted_str (TEXT_OUTPUT * tout, const char *str, int len, int max_token_le
   tout->tail_ptr->count++;
 
   end = str + len;
-  for (st = str; str < end && *str; str++)
+  for (st = str; str < end; str++)
     {
       if (*str == '\'')
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25647

* Handling cases where data in char/varchar columns contains the '\0' character during unloaddb process
