### PR TITLE
[CBRD-25345] do broker ACL format validation check

### DIFF
--- a/src/broker/broker_acl.c
+++ b/src/broker/broker_acl.c
@@ -337,7 +337,7 @@ is_invalid_acl_entry (const char *acl, T_SHM_BROKER * shm_br)
 	}
     }
 
-  return (num_colon == NUM_COLON_EXPECTED) ? ACL_FMT_NO_ERROR : ACL_FMT_INVALID;
+  return ((num_colon == NUM_COLON_EXPECTED) && acl[len-1] != COLON) ? ACL_FMT_NO_ERROR : ACL_FMT_INVALID;
 }
 
 static void

--- a/src/broker/broker_acl.c
+++ b/src/broker/broker_acl.c
@@ -119,7 +119,8 @@ access_control_find_access_info (ACCESS_INFO ai[], int size, char *dbname, char 
 }
 
 int
-access_control_read_config_file (T_SHM_APPL_SERVER * shm_appl, char *filename, char *admin_err_msg, T_SHM_BROKER * shm_br)
+access_control_read_config_file (T_SHM_APPL_SERVER * shm_appl, char *filename, char *admin_err_msg,
+				 T_SHM_BROKER * shm_br)
 {
   char buf[1024], path_buf[BROKER_PATH_MAX], *files, *token, *save = NULL;
   FILE *fd_access_list;
@@ -163,7 +164,7 @@ access_control_read_config_file (T_SHM_APPL_SERVER * shm_appl, char *filename, c
       if ((ret = is_invalid_acl_entry (buf, shm_br)))
 	{
 	  sprintf (admin_err_msg, "%s: invalid acl list entry: (%s:%d)%s", shm_appl->broker_name, filename, line,
-		ret == ACL_FMT_UNKOWN_BROKER ? " (unknown broker)" : "");
+		   ret == ACL_FMT_UNKOWN_BROKER ? " (unknown broker)" : "");
 	  goto error;
 	}
 

--- a/src/broker/broker_acl.c
+++ b/src/broker/broker_acl.c
@@ -337,7 +337,7 @@ is_invalid_acl_entry (const char *acl, T_SHM_BROKER * shm_br)
 	}
     }
 
-  return ((num_colon == NUM_COLON_EXPECTED) && acl[len-1] != COLON) ? ACL_FMT_NO_ERROR : ACL_FMT_INVALID;
+  return ((num_colon == NUM_COLON_EXPECTED) && acl[len - 1] != COLON) ? ACL_FMT_NO_ERROR : ACL_FMT_INVALID;
 }
 
 static void

--- a/src/broker/broker_acl.c
+++ b/src/broker/broker_acl.c
@@ -46,7 +46,8 @@ typedef enum
 {
   ACL_FMT_NO_ERROR = 0,
   ACL_FMT_UNKOWN_BROKER,
-  ACL_FMT_INVALID
+  ACL_FMT_INVALID,
+  ACL_FMT_EMPTY_ELEM
 } ACL_FMT;
 
 static ACCESS_INFO *access_control_find_access_info (ACCESS_INFO ai[], int size, char *dbname, char *dbuser);
@@ -299,6 +300,7 @@ is_invalid_acl_entry (const char *acl, T_SHM_BROKER * shm_br)
   int num_colon = 0;
   int i;
   bool exist = false;
+  int next_invalid_pos = 0;
 
   if (acl == NULL || (len = strlen (acl)) == 0)
     {
@@ -333,7 +335,12 @@ is_invalid_acl_entry (const char *acl, T_SHM_BROKER * shm_br)
     {
       if (acl[i] == COLON)
 	{
+	  if (i == next_invalid_pos)
+	    {
+	      return ACL_FMT_EMPTY_ELEM;
+	    }
 	  num_colon++;
+	  next_invalid_pos = i + 1;
 	}
     }
 

--- a/src/broker/broker_acl.c
+++ b/src/broker/broker_acl.c
@@ -42,6 +42,13 @@ ACCESS_INFO access_info[ACL_MAX_ITEM_COUNT];
 int num_access_info;
 int access_info_changed;
 
+typedef enum
+{
+  ACL_FMT_NO_ERROR = 0,
+  ACL_FMT_UNKOWN_BROKER,
+  ACL_FMT_INVALID
+} ACL_FMT;
+
 static ACCESS_INFO *access_control_find_access_info (ACCESS_INFO ai[], int size, char *dbname, char *dbuser);
 static int access_control_read_ip_info (IP_INFO * ip_info, char *filename, char *admin_err_msg);
 static void access_control_repath_file (char *path);
@@ -50,7 +57,7 @@ static int access_control_check_right_internal (T_SHM_APPL_SERVER * shm_as_p, ch
 static int access_control_check_ip (T_SHM_APPL_SERVER * shm_as_p, IP_INFO * ip_info, unsigned char *address,
 				    int info_index);
 static int record_ip_access_time (T_SHM_APPL_SERVER * shm_as_p, int info_index, int list_index);
-static bool is_invalid_acl_entry (const char *buf);
+static ACL_FMT is_invalid_acl_entry (const char *buf, T_SHM_BROKER * shm_br);
 
 int
 access_control_set_shm (T_SHM_APPL_SERVER * shm_as_p, T_BROKER_INFO * br_info_p, T_SHM_BROKER * shm_br,
@@ -83,7 +90,7 @@ access_control_set_shm (T_SHM_APPL_SERVER * shm_as_p, T_BROKER_INFO * br_info_p,
 	{
 	  set_cubrid_file (FID_ACCESS_CONTROL_FILE, shm_br->access_control_file);
 	  access_file_name = get_cubrid_file_ptr (FID_ACCESS_CONTROL_FILE);
-	  if (access_control_read_config_file (shm_as_p, access_file_name, admin_err_msg) != 0)
+	  if (access_control_read_config_file (shm_as_p, access_file_name, admin_err_msg, shm_br) != 0)
 	    {
 	      return -1;
 	    }
@@ -112,7 +119,7 @@ access_control_find_access_info (ACCESS_INFO ai[], int size, char *dbname, char 
 }
 
 int
-access_control_read_config_file (T_SHM_APPL_SERVER * shm_appl, char *filename, char *admin_err_msg)
+access_control_read_config_file (T_SHM_APPL_SERVER * shm_appl, char *filename, char *admin_err_msg, T_SHM_BROKER * shm_br)
 {
   char buf[1024], path_buf[BROKER_PATH_MAX], *files, *token, *save = NULL;
   FILE *fd_access_list;
@@ -120,6 +127,7 @@ access_control_read_config_file (T_SHM_APPL_SERVER * shm_appl, char *filename, c
   ACCESS_INFO new_access_info[ACL_MAX_ITEM_COUNT];
   ACCESS_INFO *access_info;
   bool is_current_broker_section = false;
+  ACL_FMT ret = ACL_FMT_NO_ERROR;
 #if defined(WINDOWS)
   char acl_sem_name[BROKER_NAME_LEN];
 #endif
@@ -152,9 +160,10 @@ access_control_read_config_file (T_SHM_APPL_SERVER * shm_appl, char *filename, c
 	  continue;
 	}
 
-      if (is_invalid_acl_entry (buf))
+      if ((ret = is_invalid_acl_entry (buf, shm_br)))
 	{
-	  sprintf (admin_err_msg, "%s: invalid acl list entry: (%s:%d)", shm_appl->broker_name, filename, line);
+	  sprintf (admin_err_msg, "%s: invalid acl list entry: (%s:%d)%s", shm_appl->broker_name, filename, line,
+		ret == ACL_FMT_UNKOWN_BROKER ? " (unknown broker)" : "");
 	  goto error;
 	}
 
@@ -281,26 +290,39 @@ error:
   return -1;
 }
 
-static bool
-is_invalid_acl_entry (const char *acl)
+static ACL_FMT
+is_invalid_acl_entry (const char *acl, T_SHM_BROKER * shm_br)
 {
   char br_name[LINE_MAX];
   int len;
   int num_colon = 0;
   int i;
+  bool exist = false;
 
   if (acl == NULL || (len = strlen (acl)) == 0)
     {
-      return false;
+      return ACL_FMT_INVALID;;
     }
 
   if (acl[0] == '[')
     {
-      bool ret = false;
+      ACL_FMT ret = ACL_FMT_NO_ERROR;
 
       if (sscanf (acl, "[%%%[^]]", br_name) != 1 || acl[len - 1] != ']' || strchr (br_name, ' ') != NULL)
 	{
-	  ret = true;
+	  ret = ACL_FMT_INVALID;
+	}
+      else
+	{
+	  for (i = 0; i < shm_br->num_broker; i++)
+	    {
+	      if (strcasecmp (br_name, shm_br->br_info[i].name) == 0)
+		{
+		  exist = true;
+		  break;
+		}
+	    }
+	  ret = exist ? ACL_FMT_NO_ERROR : ACL_FMT_UNKOWN_BROKER;
 	}
 
       return ret;
@@ -314,7 +336,7 @@ is_invalid_acl_entry (const char *acl)
 	}
     }
 
-  return (num_colon != NUM_COLON_EXPECTED);
+  return (num_colon == NUM_COLON_EXPECTED) ? ACL_FMT_NO_ERROR : ACL_FMT_INVALID;
 }
 
 static void

--- a/src/broker/broker_acl.c
+++ b/src/broker/broker_acl.c
@@ -35,8 +35,7 @@
 #define ADMIN_ERR_MSG_SIZE	BROKER_PATH_MAX * 2
 #define ACCESS_FILE_DELIMITER ":"
 #define IP_FILE_DELIMITER ","
-#define COLON ':'
-#define NUM_COLON_EXPECTED 2
+#define NUM_ACL_ELEM	3
 
 ACCESS_INFO access_info[ACL_MAX_ITEM_COUNT];
 int num_access_info;
@@ -295,12 +294,11 @@ error:
 static ACL_FMT
 is_invalid_acl_entry (const char *acl, T_SHM_BROKER * shm_br)
 {
-  char br_name[LINE_MAX];
+  char br_name[LINE_MAX], db[LINE_MAX], user[LINE_MAX], file[LINE_MAX];
   int len;
-  int num_colon = 0;
   int i;
   bool exist = false;
-  int next_invalid_pos = 0;
+  ACL_FMT ret = ACL_FMT_NO_ERROR;
 
   if (acl == NULL || (len = strlen (acl)) == 0)
     {
@@ -309,8 +307,6 @@ is_invalid_acl_entry (const char *acl, T_SHM_BROKER * shm_br)
 
   if (acl[0] == '[')
     {
-      ACL_FMT ret = ACL_FMT_NO_ERROR;
-
       if (sscanf (acl, "[%%%[^]]", br_name) != 1 || acl[len - 1] != ']' || strchr (br_name, ' ') != NULL)
 	{
 	  ret = ACL_FMT_INVALID;
@@ -331,20 +327,12 @@ is_invalid_acl_entry (const char *acl, T_SHM_BROKER * shm_br)
       return ret;
     }
 
-  for (i = 0; i < len; i++)
+  if (sscanf (acl, "%[^: ]:%[^: ]:%s", db, user, file) != NUM_ACL_ELEM)
     {
-      if (acl[i] == COLON)
-	{
-	  if (i == next_invalid_pos)
-	    {
-	      return ACL_FMT_EMPTY_ELEM;
-	    }
-	  num_colon++;
-	  next_invalid_pos = i + 1;
-	}
+      ret = ACL_FMT_INVALID;
     }
 
-  return ((num_colon == NUM_COLON_EXPECTED) && acl[len - 1] != COLON) ? ACL_FMT_NO_ERROR : ACL_FMT_INVALID;
+  return ret;
 }
 
 static void

--- a/src/broker/broker_acl.h
+++ b/src/broker/broker_acl.h
@@ -30,7 +30,7 @@
 
 extern int access_control_set_shm (T_SHM_APPL_SERVER * shm_as_cp, T_BROKER_INFO * br_info_p, T_SHM_BROKER * shm_br,
 				   char *admin_err_msg);
-extern int access_control_read_config_file (T_SHM_APPL_SERVER * shm_appl, char *filename, char *admin_err_msg);
+extern int access_control_read_config_file (T_SHM_APPL_SERVER * shm_appl, char *filename, char *admin_err_msg, T_SHM_BROKER * shm_br);
 extern int access_control_check_right (T_SHM_APPL_SERVER * shm_as_p, char *dbname, char *dbuser,
 				       unsigned char *address);
 

--- a/src/broker/broker_acl.h
+++ b/src/broker/broker_acl.h
@@ -30,7 +30,8 @@
 
 extern int access_control_set_shm (T_SHM_APPL_SERVER * shm_as_cp, T_BROKER_INFO * br_info_p, T_SHM_BROKER * shm_br,
 				   char *admin_err_msg);
-extern int access_control_read_config_file (T_SHM_APPL_SERVER * shm_appl, char *filename, char *admin_err_msg, T_SHM_BROKER * shm_br);
+extern int access_control_read_config_file (T_SHM_APPL_SERVER * shm_appl, char *filename, char *admin_err_msg,
+					    T_SHM_BROKER * shm_br);
 extern int access_control_check_right (T_SHM_APPL_SERVER * shm_as_p, char *dbname, char *dbuser,
 				       unsigned char *address);
 

--- a/src/broker/broker_admin_pub.c
+++ b/src/broker/broker_admin_pub.c
@@ -2947,7 +2947,7 @@ admin_acl_reload_cmd (int master_shm_id, const char *broker_name)
 	      uw_shm_detach (shm_br);
 	      return -1;
 	    }
-	  if (access_control_read_config_file (shm_appl, access_file_name, admin_err_msg) != 0)
+	  if (access_control_read_config_file (shm_appl, access_file_name, admin_err_msg, shm_br) != 0)
 	    {
 	      uw_shm_detach (shm_appl);
 	      uw_shm_detach (shm_br);
@@ -2968,7 +2968,7 @@ admin_acl_reload_cmd (int master_shm_id, const char *broker_name)
 	  return -1;
 	}
 
-      if (access_control_read_config_file (shm_appl, access_file_name, admin_err_msg) != 0)
+      if (access_control_read_config_file (shm_appl, access_file_name, admin_err_msg, shm_br) != 0)
 	{
 	  uw_shm_detach (shm_appl);
 	  uw_shm_detach (shm_br);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25345

**Description**
* in addition to #5562
  * check whether the broker name defined in the acl list is registered in cubrid_broker.conf
  * check missing description of ip list file
 
**Remarks: new commit after review (0b1d780)**

1.  check for empty or blank db_name or user name, for example
2. following entries are invalid (empty or leading blanks)
 ```
:dba:cubrid_acl_ip.conf
demodb::cubrid_acl_ip.conf
demodb: dba:cubrid_acl_ip.conf
demodb:  : cubrid_acl_ip.conf
```
3. following entries will pass this validation check (blank after elements), however existing ACL validation code will check it
`demodb :dba :cubrid_acl_ip.conf`
