### PR TITLE
[CBRD-25386] Modified so that TBB is statically linked only to 'libcubrid.so'

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -476,7 +476,6 @@ if(WITH_LIBTBB STREQUAL "EXTERNAL")
       "${LIBTBB_BYPRODUCTS}"
     )
 
-    # Append include directories and libraries for libcubrid.so only
     list(APPEND TBB_TARGETS ${LIBTBB_TARGET})
     list(APPEND TBB_INCLUDES ${LIBTBB_INCLUDES})
     list(APPEND TBB_LIBS ${LIBTBB_LIBS})

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -475,9 +475,11 @@ if(WITH_LIBTBB STREQUAL "EXTERNAL")
       INSTALL_COMMAND      make -j install
       "${LIBTBB_BYPRODUCTS}"
     )
-    list(APPEND EP_TARGETS ${LIBTBB_TARGET})
-    list(APPEND EP_INCLUDES ${LIBTBB_INCLUDES})
-    list(APPEND EP_LIBS ${LIBTBB_LIBS})
+
+    # Append include directories and libraries for libcubrid.so only
+    list(APPEND TBB_TARGETS ${LIBTBB_TARGET})
+    list(APPEND TBB_INCLUDES ${LIBTBB_INCLUDES})
+    list(APPEND TBB_LIBS ${LIBTBB_LIBS})
   endif(UNIX)
 endif()
 
@@ -485,6 +487,15 @@ endif()
 set (EP_TARGETS ${EP_TARGETS} PARENT_SCOPE)
 set (EP_LIBS ${EP_LIBS} PARENT_SCOPE)
 set (EP_INCLUDES ${EP_INCLUDES} PARENT_SCOPE)
+
+# [TODO]
+# EP_TARGETS, EP_LIBS, and EP_INCLUDES are linked everywhere.
+# Howerver, TBB is only used on the server side, so it should only be linked to libcubrid.so.
+# Therefore, we separated it into a TBB list to ensure it links exclusively to libcubrid.so.
+# In the future, please separate any directories and libraries that are exclusively used on the server side into EP_SERVER_XXX.
+set (TBB_TARGETS ${TBB_TARGETS} PARENT_SCOPE)
+set (TBB_INCLUDES ${TBB_INCLUDES} PARENT_SCOPE)
+set (TBB_LIBS ${TBB_LIBS} PARENT_SCOPE)
 
 # Expose targets for sa - FIXME better solutions
 include (3rdparty_util)

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -488,11 +488,11 @@ set (EP_TARGETS ${EP_TARGETS} PARENT_SCOPE)
 set (EP_LIBS ${EP_LIBS} PARENT_SCOPE)
 set (EP_INCLUDES ${EP_INCLUDES} PARENT_SCOPE)
 
-# [TODO]
-# EP_TARGETS, EP_LIBS, and EP_INCLUDES are linked everywhere.
-# Howerver, TBB is only used on the server side, so it should only be linked to libcubrid.so.
-# Therefore, we separated it into a TBB list to ensure it links exclusively to libcubrid.so.
-# In the future, please separate any directories and libraries that are exclusively used on the server side into EP_SERVER_XXX.
+# TODO: EP_TARGETS, EP_LIBS, and EP_INCLUDES are currently linked across all targets.
+# However, TBB is only required on the server side and should only be linked to libcubrid.so.
+# To achieve this, TBB has been separated into a distinct list to ensure exclusive linking with libcubrid.so.
+# Going forward, directories and libraries strictly used on the server side should be categorized
+# under the EP_SERVER_XXX section.
 set (TBB_TARGETS ${TBB_TARGETS} PARENT_SCOPE)
 set (TBB_INCLUDES ${TBB_INCLUDES} PARENT_SCOPE)
 set (TBB_LIBS ${TBB_LIBS} PARENT_SCOPE)

--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -560,16 +560,16 @@ if(WIN32)
 endif(WIN32)
 target_include_directories(cubrid PRIVATE ${JAVA_INC} ${EP_INCLUDES} ${FLEX_INCLUDE_DIRS})
 
-# Add TBB
-target_include_directories(cubrid PUBLIC ${TBB_INCLUDES})
-target_link_libraries(cubrid LINK_PRIVATE ${TBB_LIBS})
-add_dependencies(cubrid ${TBB_TARGETS})
-
 if(UNIX)
   target_link_libraries(cubrid LINK_PRIVATE -Wl,-whole-archive ${EP_LIBS} -Wl,-no-whole-archive)
   target_link_libraries(cubrid LINK_PUBLIC ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
   target_link_libraries(cubrid PUBLIC stdc++fs)
   target_link_libraries(cubrid PUBLIC rt)
+
+  # Add TBB
+  target_include_directories(cubrid PUBLIC ${TBB_INCLUDES})
+  target_link_libraries(cubrid LINK_PRIVATE ${TBB_LIBS})
+  add_dependencies(cubrid ${TBB_TARGETS})
 else(UNIX)
   target_link_libraries(cubrid LINK_PRIVATE ${EP_LIBS})
 endif(UNIX)

--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -559,6 +559,12 @@ if(WIN32)
   set_target_properties(cubrid PROPERTIES LINK_FLAGS "/DEF:\"${CMAKE_SOURCE_DIR}/win/libcubrid/libcubrid.def\"" LINK_FLAGS_RELEASE "/NODEFAULTLIB:libcmt.lib" LINK_FLAGS_DEBUG "/NODEFAULTLIB:msvcrt.lib")
 endif(WIN32)
 target_include_directories(cubrid PRIVATE ${JAVA_INC} ${EP_INCLUDES} ${FLEX_INCLUDE_DIRS})
+
+# Add TBB
+target_include_directories(cubrid PUBLIC ${TBB_INCLUDES})
+target_link_libraries(cubrid LINK_PRIVATE ${TBB_LIBS})
+add_dependencies(cubrid ${TBB_TARGETS})
+
 if(UNIX)
   target_link_libraries(cubrid LINK_PRIVATE -Wl,-whole-archive ${EP_LIBS} -Wl,-no-whole-archive)
   target_link_libraries(cubrid LINK_PUBLIC ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -329,9 +329,9 @@ if(UNIX)
   target_include_directories(unittests_lf PRIVATE ${EP_INCLUDES})
   target_link_libraries(unittests_lf LINK_PRIVATE cubridcs)
 
-# Add TBB
+  # Add TBB
+  target_include_directories(unittests_lf PRIVATE ${TBB_INCLUDES})
   target_link_libraries(unittests_lf LINK_PRIVATE ${TBB_LIBS})
-  target_include_directories(unittests_lf PUBLIC ${TBB_INCLUDES})
   add_dependencies(unittests_lf ${TBB_TARGETS})
 
   set(UNITTESTS_AREA_SOURCES

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -329,6 +329,10 @@ if(UNIX)
   target_include_directories(unittests_lf PRIVATE ${EP_INCLUDES})
   target_link_libraries(unittests_lf LINK_PRIVATE cubridcs)
 
+# Add TBB
+  target_link_libraries(unittests_lf LINK_PRIVATE ${TBB_LIBS})
+  target_include_directories(unittests_lf PUBLIC ${TBB_INCLUDES})
+  add_dependencies(unittests_lf ${TBB_TARGETS})
 
   set(UNITTESTS_AREA_SOURCES
     ${BASE_DIR}/memory_monitor_api.cpp

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -327,12 +327,7 @@ if(UNIX)
   add_executable(unittests_lf ${UNITTESTS_LF_SOURCES})
   target_compile_definitions(unittests_lf PRIVATE UNITTEST_LF SERVER_MODE ${COMMON_DEFS})
   target_include_directories(unittests_lf PRIVATE ${EP_INCLUDES})
-  target_link_libraries(unittests_lf LINK_PRIVATE cubridcs)
-
-  # Add TBB
-  target_include_directories(unittests_lf PRIVATE ${TBB_INCLUDES})
-  target_link_libraries(unittests_lf LINK_PRIVATE ${TBB_LIBS})
-  add_dependencies(unittests_lf ${TBB_TARGETS})
+  target_link_libraries(unittests_lf LINK_PRIVATE cubrid)
 
   set(UNITTESTS_AREA_SOURCES
     ${BASE_DIR}/memory_monitor_api.cpp


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25386

### **_Purpose_**
- TBB를 사용하지 않는 CSQL에서 TBB관련 memory leak이 발견되었음
- 현재 3rdparty library들을 전부 모아 static link하고 있는데, 때문에 특정 library는 사용하지 않음에도 불구하고 static link되고 있음
- 따라서 libcubridcs.so에 TBB가 static link 되어있어 CSQL에서 TBB를 사용하지 않음에도 TBB 관련 leak이 발생하는 것으로 확인
- TBB를 사용하는 곳만 static link 되도록 수정해야 함
- unittests_lf에서도 TBB를 사용하기 때문에 추가로 link

### **_주요 코드_**
- list(APPEND TBB_XXX ${LIBTBB_XXX})
   - List(TBB_XXX)에 LIBTBB_XXX 추가
- set (TBB_XXX ${TBB_XXX} PARENT_SCOPE)
   - TBB_XXX를 상위 스코프에서 사용할 수 있게 함
- target_include_directories(cubrid PUBLIC ${TBB_INCLUDES})
   - libcubrid.so에 TBB_INLCUDES를 추가
- target_link_libraries(cubrid LINK_PRIVATE ${TBB_LIBS})
   - libcubrid.so에 TBB_LIBS를 추가
- add_dependencies(cubrid ${TBB_TARGETS})
   - libcurid.so에 TBB_TARGETS을 추가
- PUBLIC, (LINK)PRIVATE 차이
  - 예를 들어 libcubrid.so에 TBB_INCLUDES를 PUBLIC으로 추가 하게 되면 libcubrid.so를 링크하고 있는 다른 타겟에서
     TBB 헤더파일을 include할 수 있게 됩니다. 현재 libcubrid.so를 link하여 TBB 헤더파일을 사용하고 있는 곳이 있기 때문에
     cubrid/CMakeLists.txt에는 PUBLIC으로 추가하였습니다.