### PR TITLE
[CBRD-25650] RAISE instead of NULL in dummy PL/CSQL SP in unloaddb schema

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -491,8 +491,10 @@ public class SpLib {
         public $APP_ERROR(int code, String msg) {
             super(code, isEmptyStr(msg) ? MSG_APP_ERROR : msg);
             if (code < CODE_APP_ERROR_DEFAULT) {
-                throw new VALUE_ERROR(String.format("error codes below %d are reserved for system built-in errors",
-                    CODE_APP_ERROR_DEFAULT));
+                throw new VALUE_ERROR(
+                        String.format(
+                                "error codes below %d are reserved for system built-in errors",
+                                CODE_APP_ERROR_DEFAULT));
             }
         }
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -490,14 +490,18 @@ public class SpLib {
     public static class $APP_ERROR extends PlcsqlRuntimeError {
         public $APP_ERROR(int code, String msg) {
             super(code, isEmptyStr(msg) ? MSG_APP_ERROR : msg);
+            if (code < CODE_APP_ERROR_DEFAULT) {
+                throw new VALUE_ERROR(String.format("error codes below %d are reserved for system built-in errors",
+                    CODE_APP_ERROR_DEFAULT));
+            }
         }
 
         public $APP_ERROR(String msg) {
-            super(CODE_APP_ERROR, isEmptyStr(msg) ? MSG_APP_ERROR : msg);
+            this(CODE_APP_ERROR_DEFAULT, msg);
         }
 
         public $APP_ERROR() {
-            super(CODE_APP_ERROR, MSG_APP_ERROR);
+            this(CODE_APP_ERROR_DEFAULT, MSG_APP_ERROR);
         }
     }
 
@@ -3914,7 +3918,7 @@ public class SpLib {
     private static final int CODE_TOO_MANY_ROWS = 7;
     private static final int CODE_VALUE_ERROR = 8;
     private static final int CODE_ZERO_DIVIDE = 9;
-    private static final int CODE_APP_ERROR = 99;
+    private static final int CODE_APP_ERROR_DEFAULT = 1000;
 
     private static final String MSG_CASE_NOT_FOUND = "case not found";
     private static final String MSG_CURSOR_ALREADY_OPEN = "cursor already open";

--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -4520,7 +4520,7 @@ emit_stored_procedure_pre (extract_context & ctxt, print_output & output_ctx)
       if (sp_lang == SP_LANG_PLCSQL)
 	{
 	  output_ctx ("AS LANGUAGE PLCSQL BEGIN ");
-          output_ctx ("RAISE_APPLICATION_ERROR(1000, '%s.%s: incomplete during loaddb');", owner_name, sp_name);
+	  output_ctx ("RAISE_APPLICATION_ERROR(1000, '%s.%s: incomplete during loaddb');", owner_name, sp_name);
 	  output_ctx (" END;\n");
 	}
       else

--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -4520,14 +4520,7 @@ emit_stored_procedure_pre (extract_context & ctxt, print_output & output_ctx)
       if (sp_lang == SP_LANG_PLCSQL)
 	{
 	  output_ctx ("AS LANGUAGE PLCSQL BEGIN ");
-	  if (sp_type == SP_TYPE_PROCEDURE)
-	    {
-	      output_ctx ("NULL;");
-	    }
-	  else
-	    {
-	      output_ctx ("RETURN NULL;");
-	    }
+          output_ctx ("RAISE_APPLICATION_ERROR(100, '%s.%s: incomplete during loaddb');", owner_name, sp_name);
 	  output_ctx (" END;\n");
 	}
       else

--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -4520,7 +4520,7 @@ emit_stored_procedure_pre (extract_context & ctxt, print_output & output_ctx)
       if (sp_lang == SP_LANG_PLCSQL)
 	{
 	  output_ctx ("AS LANGUAGE PLCSQL BEGIN ");
-          output_ctx ("RAISE_APPLICATION_ERROR(100, '%s.%s: incomplete during loaddb');", owner_name, sp_name);
+          output_ctx ("RAISE_APPLICATION_ERROR(1000, '%s.%s: incomplete during loaddb');", owner_name, sp_name);
 	  output_ctx (" END;\n");
 	}
       else

--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -4520,7 +4520,8 @@ emit_stored_procedure_pre (extract_context & ctxt, print_output & output_ctx)
       if (sp_lang == SP_LANG_PLCSQL)
 	{
 	  output_ctx ("AS LANGUAGE PLCSQL BEGIN ");
-	  output_ctx ("RAISE_APPLICATION_ERROR(1000, '%s.%s: incomplete during loaddb');", owner_name, sp_name);
+	  output_ctx ("RAISE_APPLICATION_ERROR(1000, '%s.%s: incomplete during loaddb'); /* __CUBRID_NO_BODY__ */",
+		      owner_name, sp_name);
 	  output_ctx (" END;\n");
 	}
       else


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25650

loaddb 중 어떤 이유로 인해 PL/CSQL SP의 dummy CREATE 만 실행되고, 원래 CREATE 문이 실행되지 않았을 때, 
이 문제가 실행시간에 드러나도록 하기 위한 변경입니다. 
의미 있는 에러 메시지를 CSQL 등에 전달하기 위해 RAISE_APPLICATION_ERROR를 사용했는데, 
RAISE_APPLICATION_ERROR의 에러 코드가 빌트인 에러코드와 겹치지 않도록 하는 구현도 필요한 듯 해서 같이 수정했습니다. 
