### PR TITLE
[CBRD-25653] Modify unloaddb to extract other schema information for DBs without tables (including views)

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -627,7 +627,6 @@ get_ordered_classes (print_output & output_ctx, MOP * class_table)
       filter_system_classes (&classes);
       if (classes == NULL)
 	{			/* no user class */
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_NODATA_TOBE_UNLOADED, 0);
 	  return NULL;
 	}
 
@@ -1443,17 +1442,17 @@ extract_schema (extract_context & ctxt, print_output & schema_output_ctx)
       err_count++;
     }
 
-  emit_schema (ctxt, schema_output_ctx, EXTRACT_CLASS);
-  if (er_errid () != NO_ERROR)
+  if (ctxt.classes != NULL && (emit_schema (ctxt, schema_output_ctx, EXTRACT_CLASS), er_errid () != NO_ERROR))
     {
       err_count++;
     }
 
-  emit_class_query_spec (ctxt, schema_output_ctx, EXTRACT_CLASS);
-  if (er_errid () != NO_ERROR)
+
+  if (ctxt.classes != NULL && (emit_class_query_spec (ctxt, schema_output_ctx, EXTRACT_CLASS), er_errid () != NO_ERROR))
     {
       err_count++;
     }
+
 
   if (emit_class_alter_serial (ctxt, schema_output_ctx) < NO_ERROR)
     {
@@ -1465,8 +1464,7 @@ extract_schema (extract_context & ctxt, print_output & schema_output_ctx)
       err_count++;
     }
 
-  emit_schema (ctxt, schema_output_ctx, EXTRACT_VCLASS);
-  if (er_errid () != NO_ERROR)
+  if (ctxt.classes != NULL && (emit_schema (ctxt, schema_output_ctx, EXTRACT_VCLASS), er_errid () != NO_ERROR))
     {
       err_count++;
     }
@@ -1485,13 +1483,13 @@ extract_schema (extract_context & ctxt, print_output & schema_output_ctx)
 	}
     }
 
-  emit_class_query_spec (ctxt, schema_output_ctx, EXTRACT_VCLASS);
-  if (er_errid () != NO_ERROR)
+  if (ctxt.classes != NULL
+      && (emit_class_query_spec (ctxt, schema_output_ctx, EXTRACT_VCLASS), er_errid () != NO_ERROR))
     {
       err_count++;
     }
 
-  if (emit_foreign_key (ctxt, schema_output_ctx, ctxt.classes) != NO_ERROR)
+  if (ctxt.classes != NULL && (emit_foreign_key (ctxt, schema_output_ctx, ctxt.classes) != NO_ERROR))
     {
       err_count++;
     }
@@ -5288,14 +5286,17 @@ extract_class (extract_context & ctxt)
       err = get_classes (ctxt, output_ctx);
       if (err != NO_ERROR)
 	{
-	  if (output_file != NULL)
-	    {
-	      fclose (output_file);
-	      output_file = NULL;
-	      remove (output_filename);
-	      return ER_FAILED;
-	    }
+	  err = ER_FAILED;
 	}
+      else if (ctxt.classes == NULL)
+	{
+	  err = NO_ERROR;	// Skip object unloading.
+	}
+
+      fclose (output_file);
+      output_file = NULL;
+      remove (output_filename);
+      return err;
     }
 
   emit_schema (ctxt, output_ctx, EXTRACT_CLASS);
@@ -5386,14 +5387,17 @@ extract_vclass (extract_context & ctxt)
       err = get_classes (ctxt, output_ctx);
       if (err != NO_ERROR)
 	{
-	  if (output_file != NULL)
-	    {
-	      fclose (output_file);
-	      output_file = NULL;
-	      remove (output_filename);
-	      return ER_FAILED;
-	    }
+	  err = ER_FAILED;
 	}
+      else if (ctxt.classes == NULL)
+	{
+	  err = NO_ERROR;	// Skip object unloading.
+	}
+
+      fclose (output_file);
+      output_file = NULL;
+      remove (output_filename);
+      return err;
     }
 
   emit_schema (ctxt, output_ctx, EXTRACT_VCLASS);
@@ -5461,14 +5465,17 @@ extract_vclass_query_spec (extract_context & ctxt)
       err = get_classes (ctxt, output_ctx);
       if (err != NO_ERROR)
 	{
-	  if (output_file != NULL)
-	    {
-	      fclose (output_file);
-	      output_file = NULL;
-	      remove (output_filename);
-	      return ER_FAILED;
-	    }
+	  err = ER_FAILED;
 	}
+      else if (ctxt.classes == NULL)
+	{
+	  err = NO_ERROR;	// Skip object unloading.
+	}
+
+      fclose (output_file);
+      output_file = NULL;
+      remove (output_filename);
+      return err;
     }
 
   emit_class_query_spec (ctxt, output_ctx, EXTRACT_VCLASS);
@@ -5534,14 +5541,17 @@ extract_pk (extract_context & ctxt)
       err = get_classes (ctxt, output_ctx);
       if (err != NO_ERROR)
 	{
-	  if (output_file != NULL)
-	    {
-	      fclose (output_file);
-	      output_file = NULL;
-	      remove (output_filename);
-	      return ER_FAILED;
-	    }
+	  err = ER_FAILED;
 	}
+      else if (ctxt.classes == NULL)
+	{
+	  err = NO_ERROR;	// Skip object unloading.
+	}
+
+      fclose (output_file);
+      output_file = NULL;
+      remove (output_filename);
+      return err;
     }
 
   emit_primary_key (ctxt, output_ctx, ctxt.classes);
@@ -5606,14 +5616,17 @@ extract_fk (extract_context & ctxt)
       err = get_classes (ctxt, output_ctx);
       if (err != NO_ERROR)
 	{
-	  if (output_file != NULL)
-	    {
-	      fclose (output_file);
-	      output_file = NULL;
-	      remove (output_filename);
-	      return ER_FAILED;
-	    }
+	  err = ER_FAILED;
 	}
+      else if (ctxt.classes == NULL)
+	{
+	  err = NO_ERROR;	// Skip object unloading.
+	}
+
+      fclose (output_file);
+      output_file = NULL;
+      remove (output_filename);
+      return err;
     }
 
   err = emit_foreign_key (ctxt, output_ctx, ctxt.classes);
@@ -5678,14 +5691,17 @@ extract_uk (extract_context & ctxt)
       err = get_classes (ctxt, output_ctx);
       if (err != NO_ERROR)
 	{
-	  if (output_file != NULL)
-	    {
-	      fclose (output_file);
-	      output_file = NULL;
-	      remove (output_filename);
-	      return ER_FAILED;
-	    }
+	  err = ER_FAILED;
 	}
+      else if (ctxt.classes == NULL)
+	{
+	  err = NO_ERROR;	// Skip object unloading.
+	}
+
+      fclose (output_file);
+      output_file = NULL;
+      remove (output_filename);
+      return err;
     }
 
   emit_unique_key (ctxt, output_ctx, ctxt.classes);
@@ -5747,21 +5763,6 @@ extract_grant (extract_context & ctxt)
     }
 
   file_print_output output_ctx (output_file);
-
-  if (ctxt.classes == NULL)
-    {
-      err = get_classes (ctxt, output_ctx);
-      if (err != NO_ERROR)
-	{
-	  if (output_file != NULL)
-	    {
-	      fclose (output_file);
-	      output_file = NULL;
-	      remove (output_filename);
-	      return ER_FAILED;
-	    }
-	}
-    }
 
   err = emit_grant (ctxt, output_ctx, ctxt.classes);
 
@@ -6009,13 +6010,24 @@ extract_all_schema_file (extract_context & ctxt, const char *output_filename)
   file_print_output output_ctx (output_file);
   err_count = extract_schema (ctxt, output_ctx);
 
-  if (err_count == 0)
-    {
-      output_ctx ("\n");
-      output_ctx ("COMMIT WORK;\n");
-    }
 
-  fclose (output_file);
+  if (ftell (output_file) == 0)
+    {
+      fclose (output_file);
+      output_file = NULL;
+      remove (output_filename);
+    }
+  else
+    {
+      /* not empty */
+      if (err_count == 0)
+	{
+	  output_ctx ("\n");
+	  output_ctx ("COMMIT WORK;\n");
+	}
+      fclose (output_file);
+      output_file = NULL;
+    }
 
   return err_count;
 }
@@ -6031,23 +6043,32 @@ get_classes (extract_context & ctxt, print_output & output_ctx)
   ctxt.classes = get_ordered_classes (output_ctx, NULL);
   if (ctxt.classes == NULL)
     {
-      goto no_data;
+      if (db_error_code () != NO_ERROR)
+	{
+	  err = ER_FAILED;
+	  goto error;
+	}
+
     }
 
-  if (ctxt.is_dba_user == false && ctxt.is_dba_group_member == false)
+  if (!ctxt.is_dba_user && !ctxt.is_dba_group_member)
     {
       filter_user_classes (&ctxt.classes, ctxt.login_user);
       if (ctxt.classes == NULL)
 	{
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_NODATA_TOBE_UNLOADED, 0);
-	  goto no_data;
+	  int err_code = db_error_code ();
+	  if (err_code != NO_ERROR && err_code != ER_AU_SELECT_FAILURE)
+	    {
+	      err = ER_FAILED;
+	      goto error;
+	    }
 	}
     }
 
   er_clear ();
   return err;
 
-no_data:
+error:
   if (db_error_code () != NO_ERROR)
     {
       err = ER_FAILED;

--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -5287,7 +5287,6 @@ extract_class (extract_context & ctxt)
       if (err != NO_ERROR || ctxt.classes == NULL)
 	{
 	  fclose (output_file);
-	  output_file = NULL;
 	  remove (output_filename);
 	  return err;
 	}
@@ -5382,7 +5381,6 @@ extract_vclass (extract_context & ctxt)
       if (err != NO_ERROR || ctxt.classes == NULL)
 	{
 	  fclose (output_file);
-	  output_file = NULL;
 	  remove (output_filename);
 	  return err;
 	}
@@ -5454,7 +5452,6 @@ extract_vclass_query_spec (extract_context & ctxt)
       if (err != NO_ERROR || ctxt.classes == NULL)
 	{
 	  fclose (output_file);
-	  output_file = NULL;
 	  remove (output_filename);
 	  return err;
 	}
@@ -5524,7 +5521,6 @@ extract_pk (extract_context & ctxt)
       if (err != NO_ERROR || ctxt.classes == NULL)
 	{
 	  fclose (output_file);
-	  output_file = NULL;
 	  remove (output_filename);
 	  return err;
 	}
@@ -5593,7 +5589,6 @@ extract_fk (extract_context & ctxt)
       if (err != NO_ERROR || ctxt.classes == NULL)
 	{
 	  fclose (output_file);
-	  output_file = NULL;
 	  remove (output_filename);
 	  return err;
 	}
@@ -5662,7 +5657,6 @@ extract_uk (extract_context & ctxt)
       if (err != NO_ERROR || ctxt.classes == NULL)
 	{
 	  fclose (output_file);
-	  output_file = NULL;
 	  remove (output_filename);
 	  return err;
 	}

--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -6051,7 +6051,7 @@ get_classes (extract_context & ctxt, print_output & output_ctx)
 
     }
 
-  if (!ctxt.is_dba_user && !ctxt.is_dba_group_member)
+  if (ctxt.classes != NULL && !ctxt.is_dba_user && !ctxt.is_dba_group_member)
     {
       filter_user_classes (&ctxt.classes, ctxt.login_user);
       if (ctxt.classes == NULL)

--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -6041,14 +6041,9 @@ get_classes (extract_context & ctxt, print_output & output_ctx)
    * if we just built the initial list rather than using the table.
    */
   ctxt.classes = get_ordered_classes (output_ctx, NULL);
-  if (ctxt.classes == NULL)
+  if (ctxt.classes == NULL && db_error_code () != NO_ERROR)
     {
-      if (db_error_code () != NO_ERROR)
-	{
-	  err = ER_FAILED;
-	  goto error;
-	}
-
+      return ER_FAILED;
     }
 
   if (ctxt.classes != NULL && !ctxt.is_dba_user && !ctxt.is_dba_group_member)
@@ -6059,26 +6054,12 @@ get_classes (extract_context & ctxt, print_output & output_ctx)
 	  int err_code = db_error_code ();
 	  if (err_code != NO_ERROR && err_code != ER_AU_SELECT_FAILURE)
 	    {
-	      err = ER_FAILED;
-	      goto error;
+	      return ER_FAILED;
 	    }
 	}
     }
 
   er_clear ();
-  return err;
-
-error:
-  if (db_error_code () != NO_ERROR)
-    {
-      err = ER_FAILED;
-    }
-  else
-    {
-      fprintf (stderr, "%s: Unknown database error occurs " "but may not be database error.\n\n", ctxt.exec_name);
-      err = ER_FAILED;
-    }
-
   return err;
 }
 

--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -5284,19 +5284,13 @@ extract_class (extract_context & ctxt)
   if (ctxt.classes == NULL)
     {
       err = get_classes (ctxt, output_ctx);
-      if (err != NO_ERROR)
+      if (err != NO_ERROR || ctxt.classes == NULL)
 	{
-	  err = ER_FAILED;
+	  fclose (output_file);
+	  output_file = NULL;
+	  remove (output_filename);
+	  return err;
 	}
-      else if (ctxt.classes == NULL)
-	{
-	  err = NO_ERROR;	// Skip object unloading.
-	}
-
-      fclose (output_file);
-      output_file = NULL;
-      remove (output_filename);
-      return err;
     }
 
   emit_schema (ctxt, output_ctx, EXTRACT_CLASS);
@@ -5385,19 +5379,13 @@ extract_vclass (extract_context & ctxt)
   if (ctxt.classes == NULL)
     {
       err = get_classes (ctxt, output_ctx);
-      if (err != NO_ERROR)
+      if (err != NO_ERROR || ctxt.classes == NULL)
 	{
-	  err = ER_FAILED;
+	  fclose (output_file);
+	  output_file = NULL;
+	  remove (output_filename);
+	  return err;
 	}
-      else if (ctxt.classes == NULL)
-	{
-	  err = NO_ERROR;	// Skip object unloading.
-	}
-
-      fclose (output_file);
-      output_file = NULL;
-      remove (output_filename);
-      return err;
     }
 
   emit_schema (ctxt, output_ctx, EXTRACT_VCLASS);
@@ -5463,19 +5451,13 @@ extract_vclass_query_spec (extract_context & ctxt)
   if (ctxt.classes == NULL)
     {
       err = get_classes (ctxt, output_ctx);
-      if (err != NO_ERROR)
+      if (err != NO_ERROR || ctxt.classes == NULL)
 	{
-	  err = ER_FAILED;
+	  fclose (output_file);
+	  output_file = NULL;
+	  remove (output_filename);
+	  return err;
 	}
-      else if (ctxt.classes == NULL)
-	{
-	  err = NO_ERROR;	// Skip object unloading.
-	}
-
-      fclose (output_file);
-      output_file = NULL;
-      remove (output_filename);
-      return err;
     }
 
   emit_class_query_spec (ctxt, output_ctx, EXTRACT_VCLASS);
@@ -5539,19 +5521,13 @@ extract_pk (extract_context & ctxt)
   if (ctxt.classes == NULL)
     {
       err = get_classes (ctxt, output_ctx);
-      if (err != NO_ERROR)
+      if (err != NO_ERROR || ctxt.classes == NULL)
 	{
-	  err = ER_FAILED;
+	  fclose (output_file);
+	  output_file = NULL;
+	  remove (output_filename);
+	  return err;
 	}
-      else if (ctxt.classes == NULL)
-	{
-	  err = NO_ERROR;	// Skip object unloading.
-	}
-
-      fclose (output_file);
-      output_file = NULL;
-      remove (output_filename);
-      return err;
     }
 
   emit_primary_key (ctxt, output_ctx, ctxt.classes);
@@ -5614,19 +5590,13 @@ extract_fk (extract_context & ctxt)
   if (ctxt.classes == NULL)
     {
       err = get_classes (ctxt, output_ctx);
-      if (err != NO_ERROR)
+      if (err != NO_ERROR || ctxt.classes == NULL)
 	{
-	  err = ER_FAILED;
+	  fclose (output_file);
+	  output_file = NULL;
+	  remove (output_filename);
+	  return err;
 	}
-      else if (ctxt.classes == NULL)
-	{
-	  err = NO_ERROR;	// Skip object unloading.
-	}
-
-      fclose (output_file);
-      output_file = NULL;
-      remove (output_filename);
-      return err;
     }
 
   err = emit_foreign_key (ctxt, output_ctx, ctxt.classes);
@@ -5689,19 +5659,13 @@ extract_uk (extract_context & ctxt)
   if (ctxt.classes == NULL)
     {
       err = get_classes (ctxt, output_ctx);
-      if (err != NO_ERROR)
+      if (err != NO_ERROR || ctxt.classes == NULL)
 	{
-	  err = ER_FAILED;
+	  fclose (output_file);
+	  output_file = NULL;
+	  remove (output_filename);
+	  return err;
 	}
-      else if (ctxt.classes == NULL)
-	{
-	  err = NO_ERROR;	// Skip object unloading.
-	}
-
-      fclose (output_file);
-      output_file = NULL;
-      remove (output_filename);
-      return err;
     }
 
   emit_unique_key (ctxt, output_ctx, ctxt.classes);

--- a/src/executables/unloaddb.c
+++ b/src/executables/unloaddb.c
@@ -440,12 +440,14 @@ unloaddb (UTIL_FUNCTION_ARG * arg)
 	      status = 1;
 	    }
 
-	  if (!status && extract_triggers_to_file (unload_context, trigger_output_filename) != 0)
+	  if (!status && unload_context.classes &&
+	      extract_triggers_to_file (unload_context, trigger_output_filename) != 0)
 	    {
 	      status = 1;
 	    }
 
-	  if (!status && extract_indexes_to_file (unload_context, indexes_output_filename) != 0)
+	  if (!status && unload_context.classes
+	      && extract_indexes_to_file (unload_context, indexes_output_filename) != 0)
 	    {
 	      status = 1;
 	    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25653

Purpose
테이블이 없는 DB 에 대해서 unloaddb를 수행할때 table(view 포함)에 종속적이지 않는 다음과 같은 schema는 추출할 수 있어야 한다.
* user (dba 또는 dba group 인경우)
* serial
* stored procedure 
* server
* synonym
* grant (sp가 grant 대상)

Remarks
dba(dba group) 또는 일반 계정으로 아래의 옵션에 대해서 테스트가 필요 하다.
* --split-schema-files
* --input-class-file=FILE
* --input-class-file

