### PR TITLE
[CBRD-25486] To minimize unexpected side effects from the previous PR (#5574), we re-implemented it with an alternative approach.

### DIFF
--- a/src/compat/db_admin.c
+++ b/src/compat/db_admin.c
@@ -1971,7 +1971,7 @@ db_revoke_object (DB_OBJECT_TYPE object_type, MOP user, MOP obj_, AU_TYPE auth)
   CHECK_2ARGS_ERROR (user, obj_);
   CHECK_MODIFICATION_ERROR ();
 
-  if (object_type == DB_OBJECT_CLASS && !obj_->drop_object_statement)
+  if (object_type == DB_OBJECT_CLASS)
     {
       retval = do_check_partitioned_class (obj_, CHECK_PARTITION_SUBS, NULL);
     }

--- a/src/object/authenticate_access_auth.cpp
+++ b/src/object/authenticate_access_auth.cpp
@@ -637,7 +637,7 @@ au_object_revoke_all_privileges (MOP obj_mop, MOP grantor_mop)
 	  "SELECT [au].grantee, [au].object_type, [au].auth_type FROM [" CT_CLASSAUTH_NAME "] [au]"
 	  " WHERE [au].[grantor].[name] = ? AND [au].[object_of] = ?";
 
-  assert (obj_mop != NULL || grantor_mop != NULL);
+  assert (obj_mop != NULL && grantor_mop != NULL);
 
   for (i = 0; i < 2; i++)
     {

--- a/src/object/authenticate_access_auth.cpp
+++ b/src/object/authenticate_access_auth.cpp
@@ -611,10 +611,12 @@ exit:
  * au_object_revoke_all_privileges - drop a class, virtual class and procedure, or when changing the owner, all privileges are revoked.
  *   return: error code
  *   class_mop(in): a class object
+ *   class_owner(in): a class owner
  *   sp_mop(in): a stored procedure object
+ *   sp_owner(in): a stored procedure owner
  */
 int
-au_object_revoke_all_privileges (MOP class_mop, MOP sp_mop)
+au_object_revoke_all_privileges (MOP class_mop, MOP class_owner, MOP sp_mop, MOP sp_owner)
 {
   int error = NO_ERROR, save, len, i = 0;
   int object_type;
@@ -637,7 +639,7 @@ au_object_revoke_all_privileges (MOP class_mop, MOP sp_mop)
 	  "SELECT [au].grantee, [au].object_type, [au].auth_type FROM [" CT_CLASSAUTH_NAME "] [au]"
 	  " WHERE [au].[grantor].[name] = ? AND [au].[object_of] = ?";
 
-  assert (class_mop != NULL || sp_mop != NULL);
+  assert ((class_mop != NULL && class_owner != NULL) || (sp_mop != NULL && sp_owner != NULL));
 
   for (i = 0; i < 2; i++)
     {
@@ -651,39 +653,16 @@ au_object_revoke_all_privileges (MOP class_mop, MOP sp_mop)
   /* Disable the checking for internal authorization object access */
   AU_DISABLE (save);
 
-  if (class_mop != NULL)
+  if (class_mop != NULL && class_owner != NULL)
     {
-      class_name = db_get_class_name (class_mop);
-      if (class_name == NULL)
-	{
-	  error = ER_UNEXPECTED;
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 1, "Cannot get class name of mop.");
-	  goto exit;
-	}
-
       obj_mop = class_mop;
-      sm_qualifier_name (class_name, owner_name, DB_MAX_USER_LENGTH);
+      grantor_mop = class_owner;
     }
 
-  if (sp_mop != NULL)
+  if (sp_mop != NULL && sp_owner != NULL)
     {
-      if (jsp_get_unique_name (sp_mop, sp_name, DB_MAX_IDENTIFIER_LENGTH) == NULL)
-	{
-	  assert (er_errid () != NO_ERROR);
-	  error = ER_UNEXPECTED;
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 1, "Cannot get stored procedure name of mop.");
-	  goto exit;
-	}
-
       obj_mop = sp_mop;
-      sm_qualifier_name (sp_name, owner_name, DB_MAX_USER_LENGTH);
-    }
-
-  grantor_mop = au_find_user (owner_name);
-  if (grantor_mop == NULL)
-    {
-      ASSERT_ERROR_AND_SET (error);
-      goto exit;
+      grantor_mop = sp_owner;
     }
 
   /* Prepare DB_VALUEs for host variables */
@@ -841,7 +820,7 @@ au_object_revoke_all_privileges (MOP class_mop, MOP sp_mop)
       assert (obj_mop != NULL);
       assert (db_auth != DB_AUTH_NONE);
 
-      error = db_revoke_object (obj_type, grantee_mop, obj_mop, db_auth);
+      error = au_revoke (obj_type, grantee_mop, obj_mop, db_auth);
       if (error != NO_ERROR)
 	{
 	  goto release;

--- a/src/object/authenticate_access_auth.cpp
+++ b/src/object/authenticate_access_auth.cpp
@@ -610,13 +610,11 @@ exit:
 /*
  * au_object_revoke_all_privileges - drop a class, virtual class and procedure, or when changing the owner, all privileges are revoked.
  *   return: error code
- *   class_mop(in): a class object
- *   class_owner(in): a class owner
- *   sp_mop(in): a stored procedure object
- *   sp_owner(in): a stored procedure owner
+ *   obj_mop(in): a class/stored procedure object
+ *   grantor_mop(in): a class/stored procedure owner
  */
 int
-au_object_revoke_all_privileges (MOP class_mop, MOP class_owner, MOP sp_mop, MOP sp_owner)
+au_object_revoke_all_privileges (MOP obj_mop, MOP grantor_mop)
 {
   int error = NO_ERROR, save, len, i = 0;
   int object_type;
@@ -626,7 +624,7 @@ au_object_revoke_all_privileges (MOP class_mop, MOP class_owner, MOP sp_mop, MOP
   char sp_name[DB_MAX_IDENTIFIER_LENGTH + 1];
   sp_name[0] = '\0';
   DB_AUTH db_auth;
-  MOP grantee_mop, obj_mop, grantor_mop;
+  MOP grantee_mop;
   DB_VALUE val[2];
   DB_VALUE grantee_value, object_type_value, auth_type_value;
   DB_QUERY_RESULT *result = NULL;
@@ -639,7 +637,7 @@ au_object_revoke_all_privileges (MOP class_mop, MOP class_owner, MOP sp_mop, MOP
 	  "SELECT [au].grantee, [au].object_type, [au].auth_type FROM [" CT_CLASSAUTH_NAME "] [au]"
 	  " WHERE [au].[grantor].[name] = ? AND [au].[object_of] = ?";
 
-  assert ((class_mop != NULL && class_owner != NULL) || (sp_mop != NULL && sp_owner != NULL));
+  assert (obj_mop != NULL || grantor_mop != NULL);
 
   for (i = 0; i < 2; i++)
     {
@@ -652,18 +650,6 @@ au_object_revoke_all_privileges (MOP class_mop, MOP class_owner, MOP sp_mop, MOP
 
   /* Disable the checking for internal authorization object access */
   AU_DISABLE (save);
-
-  if (class_mop != NULL && class_owner != NULL)
-    {
-      obj_mop = class_mop;
-      grantor_mop = class_owner;
-    }
-
-  if (sp_mop != NULL && sp_owner != NULL)
-    {
-      obj_mop = sp_mop;
-      grantor_mop = sp_owner;
-    }
 
   /* Prepare DB_VALUEs for host variables */
   error = obj_get (grantor_mop, "name", &val[0]);

--- a/src/object/authenticate_access_auth.hpp
+++ b/src/object/authenticate_access_auth.hpp
@@ -99,6 +99,6 @@ extern int au_delete_auth_of_dropping_database_object (DB_OBJECT_TYPE obj_type, 
 /*
 * drop a class, virtual class and procedure, or when changing the owner, all privileges are revoked.
 */
-extern int au_object_revoke_all_privileges (MOP class_mop, MOP sp_mop);
+extern int au_object_revoke_all_privileges (MOP class_mop, MOP class_owner, MOP sp_mop, MOP sp_owner);
 
 #endif // _authenticate_access_auth_HPP_

--- a/src/object/authenticate_access_auth.hpp
+++ b/src/object/authenticate_access_auth.hpp
@@ -99,6 +99,6 @@ extern int au_delete_auth_of_dropping_database_object (DB_OBJECT_TYPE obj_type, 
 /*
 * drop a class, virtual class and procedure, or when changing the owner, all privileges are revoked.
 */
-extern int au_object_revoke_all_privileges (MOP class_mop, MOP class_owner, MOP sp_mop, MOP sp_owner);
+extern int au_object_revoke_all_privileges (MOP obj_mop, MOP grantor_mop);
 
 #endif // _authenticate_access_auth_HPP_

--- a/src/object/authenticate_grant.cpp
+++ b/src/object/authenticate_grant.cpp
@@ -564,7 +564,7 @@ au_revoke_class (MOP user, MOP class_mop, DB_AUTH type)
     }
 
   AU_DISABLE (save);
-  if (ws_is_same_object (user, Au_user) && !class_mop->drop_object_statement)
+  if (ws_is_same_object (user, Au_user))
     {
       error = ER_AU_CANT_REVOKE_SELF;
       er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, error, 0);
@@ -732,7 +732,7 @@ au_revoke_procedure (MOP user, MOP obj_mop, DB_AUTH type)
   MOP grantor = NULL;
 
   AU_DISABLE (save);
-  if (ws_is_same_object (user, Au_user) && !obj_mop->drop_object_statement)
+  if (ws_is_same_object (user, Au_user))
     {
       error = ER_AU_CANT_REVOKE_SELF;
       er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, error, 0);
@@ -1895,8 +1895,7 @@ au_compare_grantor_and_return (MOP *grantor, MOP obj_mop, DB_AUTH type, MOP logi
 
   *grantor = NULL;
 
-  if (obj_mop->drop_object_statement || au_is_dba_group_member (login_user)
-      || au_is_user_group_member (class_owner, login_user))
+  if (au_is_dba_group_member (login_user) || au_is_user_group_member (class_owner, login_user))
     {
       /*
        * DBA, DBA Member, Owner, Owner Memeber

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -13568,6 +13568,7 @@ sm_delete_class_mop (MOP op, bool is_cascade_constraints)
   SM_CLASS_CONSTRAINT *pk;
   char *fk_name = NULL;
   const char *table_name;
+  MOP save_user, owner;
 
   if (op == NULL)
     {
@@ -13827,13 +13828,26 @@ sm_delete_class_mop (MOP op, bool is_cascade_constraints)
     }
 
   /* before deleting an object, all permissions are revoked. */
-  op->drop_object_statement = 1;
-  error = au_object_revoke_all_privileges (op, NULL);
-  if (error != NO_ERROR)
+  owner = au_get_class_owner (op);
+  if (owner == NULL)
     {
-      op->drop_object_statement = 0;
+      assert (er_errid () != NO_ERROR);
+      error = er_errid ();
       goto end;
     }
+
+  save_user = Au_user;
+  if (AU_SET_USER (owner) == NO_ERROR)
+    {
+      error = au_object_revoke_all_privileges (op, owner, NULL, NULL);
+      if (error != NO_ERROR)
+	{
+	  AU_SET_USER (save_user);
+	  goto end;
+	}
+    }
+
+  AU_SET_USER (save_user);
 
   /* now delete _db_auth tuples refers to the table */
   error = au_delete_auth_of_dropping_database_object (DB_OBJECT_CLASS, table_name);

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -13839,7 +13839,7 @@ sm_delete_class_mop (MOP op, bool is_cascade_constraints)
   save_user = Au_user;
   if (AU_SET_USER (owner) == NO_ERROR)
     {
-      error = au_object_revoke_all_privileges (op, owner, NULL, NULL);
+      error = au_object_revoke_all_privileges (op, owner);
       if (error != NO_ERROR)
 	{
 	  AU_SET_USER (save_user);

--- a/src/object/work_space.c
+++ b/src/object/work_space.c
@@ -263,7 +263,6 @@ ws_make_mop (const OID * oid)
       op->mvcc_snapshot_version = ws_get_mvcc_snapshot_version () - 1;
 
       op->trigger_involved = 0;
-      op->drop_object_statement = 0;
 
       /* this is NULL only for the Null_object hack */
       if (oid != NULL)

--- a/src/object/work_space.h
+++ b/src/object/work_space.h
@@ -151,7 +151,6 @@ struct db_object
 				 * loader only */
   unsigned decached:1;		/* set if mop is decached by calling ws_decache function */
   unsigned trigger_involved:1;	/* set if mop is involved in trigger, it is used only for cdc */
-  unsigned drop_object_statement:1;	/* flag for revoking all privileges before deleting an object (for drop object statement) */
 };
 
 

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -10220,7 +10220,7 @@ do_alter_change_owner (PARSER_CONTEXT * const parser, PT_NODE * const alter)
   save_user = Au_user;
   if (AU_SET_USER (owner) == NO_ERROR)
     {
-      error = au_object_revoke_all_privileges (class_mop, owner, NULL, NULL);
+      error = au_object_revoke_all_privileges (class_mop, owner);
       if (error != NO_ERROR)
 	{
 	  AU_SET_USER (save_user);

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -10175,7 +10175,7 @@ do_alter_change_owner (PARSER_CONTEXT * const parser, PT_NODE * const alter)
 {
   int error = NO_ERROR;
   DB_OBJECT *obj = NULL;
-  MOP class_mop, user_mop;
+  MOP class_mop, user_mop, owner;
   PT_NODE *class_, *user;
   SM_CLASS *sm_class = NULL;
 
@@ -10209,7 +10209,15 @@ do_alter_change_owner (PARSER_CONTEXT * const parser, PT_NODE * const alter)
     }
 
   /* when changing the owner, all privileges are revoked */
-  error = au_object_revoke_all_privileges (class_mop, NULL);
+  owner = au_get_class_owner (class_mop);
+  if (owner == NULL)
+    {
+      assert (er_errid () != NO_ERROR);
+      error = er_errid ();
+      return error;
+    }
+
+  error = au_object_revoke_all_privileges (class_mop, owner, NULL, NULL);
   if (error != NO_ERROR)
     {
       return error;

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -10175,7 +10175,7 @@ do_alter_change_owner (PARSER_CONTEXT * const parser, PT_NODE * const alter)
 {
   int error = NO_ERROR;
   DB_OBJECT *obj = NULL;
-  MOP class_mop, user_mop, owner;
+  MOP class_mop, user_mop, save_user, owner;
   PT_NODE *class_, *user;
   SM_CLASS *sm_class = NULL;
 
@@ -10217,11 +10217,18 @@ do_alter_change_owner (PARSER_CONTEXT * const parser, PT_NODE * const alter)
       return error;
     }
 
-  error = au_object_revoke_all_privileges (class_mop, owner, NULL, NULL);
-  if (error != NO_ERROR)
+  save_user = Au_user;
+  if (AU_SET_USER (owner) == NO_ERROR)
     {
-      return error;
+      error = au_object_revoke_all_privileges (class_mop, owner, NULL, NULL);
+      if (error != NO_ERROR)
+	{
+	  AU_SET_USER (save_user);
+	  return error;
+	}
     }
+
+  AU_SET_USER (save_user);
 
   user_mop = au_find_user (user->info.name.original);
   if (user_mop == NULL)

--- a/src/sp/jsp_cl.cpp
+++ b/src/sp/jsp_cl.cpp
@@ -1040,7 +1040,7 @@ jsp_alter_stored_procedure (PARSER_CONTEXT *parser, PT_NODE *statement)
   downcase_owner_name[0] = '\0';
   PT_MISC_TYPE type;
   SP_TYPE_ENUM real_type;
-  MOP sp_mop = NULL, new_owner = NULL, owner = NULL;
+  MOP sp_mop = NULL, new_owner = NULL, owner = NULL, save_user = NULL;
   DB_VALUE user_val, sp_type_val, sp_lang_val, target_cls_val;
 
   assert (statement != NULL);
@@ -1106,11 +1106,18 @@ jsp_alter_stored_procedure (PARSER_CONTEXT *parser, PT_NODE *statement)
       goto error;
     }
 
-  err = au_object_revoke_all_privileges (NULL, NULL, sp_mop, owner);
-  if (err != NO_ERROR)
+  save_user = Au_user;
+  if (AU_SET_USER (owner) == NO_ERROR)
     {
-      goto error;
+      err = au_object_revoke_all_privileges (NULL, NULL, sp_mop, owner);
+      if (err != NO_ERROR)
+	{
+	  AU_SET_USER (save_user);
+	  goto error;
+	}
     }
+
+  AU_SET_USER (save_user);
 
   /* existence of new owner */
   if (sp_owner != NULL)

--- a/src/sp/jsp_cl.cpp
+++ b/src/sp/jsp_cl.cpp
@@ -1109,7 +1109,7 @@ jsp_alter_stored_procedure (PARSER_CONTEXT *parser, PT_NODE *statement)
   save_user = Au_user;
   if (AU_SET_USER (owner) == NO_ERROR)
     {
-      err = au_object_revoke_all_privileges (NULL, NULL, sp_mop, owner);
+      err = au_object_revoke_all_privileges (sp_mop, owner);
       if (err != NO_ERROR)
 	{
 	  AU_SET_USER (save_user);
@@ -1451,7 +1451,7 @@ drop_stored_procedure (const char *name, SP_TYPE_ENUM expected_type)
   save_user = Au_user;
   if (AU_SET_USER (owner) == NO_ERROR)
     {
-      err = au_object_revoke_all_privileges (NULL, NULL, sp_mop, owner);
+      err = au_object_revoke_all_privileges (sp_mop, owner);
       if (err != NO_ERROR)
 	{
 	  AU_SET_USER (save_user);

--- a/src/sp/jsp_cl.cpp
+++ b/src/sp/jsp_cl.cpp
@@ -1040,7 +1040,7 @@ jsp_alter_stored_procedure (PARSER_CONTEXT *parser, PT_NODE *statement)
   downcase_owner_name[0] = '\0';
   PT_MISC_TYPE type;
   SP_TYPE_ENUM real_type;
-  MOP sp_mop = NULL, new_owner = NULL;
+  MOP sp_mop = NULL, new_owner = NULL, owner = NULL;
   DB_VALUE user_val, sp_type_val, sp_lang_val, target_cls_val;
 
   assert (statement != NULL);
@@ -1099,7 +1099,14 @@ jsp_alter_stored_procedure (PARSER_CONTEXT *parser, PT_NODE *statement)
     }
 
   /* when changing the owner, all privileges are revoked */
-  err = au_object_revoke_all_privileges (NULL, sp_mop);
+  owner = jsp_get_owner (sp_mop);
+  if (owner == NULL)
+    {
+      err = ER_FAILED;
+      goto error;
+    }
+
+  err = au_object_revoke_all_privileges (NULL, NULL, sp_mop, owner);
   if (err != NO_ERROR)
     {
       goto error;
@@ -1315,7 +1322,7 @@ jsp_check_stored_procedure_name (const char *str)
 static int
 drop_stored_procedure (const char *name, SP_TYPE_ENUM expected_type)
 {
-  MOP sp_mop, arg_mop, owner;
+  MOP sp_mop, arg_mop, owner, save_user;
   DB_VALUE sp_type_val, arg_cnt_val, args_val, owner_val, generated_val, target_cls_val, lang_val, temp;
   SP_TYPE_ENUM real_type;
   std::string class_name;
@@ -1434,13 +1441,18 @@ drop_stored_procedure (const char *name, SP_TYPE_ENUM expected_type)
     }
 
   /* before deleting an object, all permissions are revoked. */
-  sp_mop->drop_object_statement = 1;
-  err = au_object_revoke_all_privileges (NULL, sp_mop);
-  if (err != NO_ERROR)
+  save_user = Au_user;
+  if (AU_SET_USER (owner) == NO_ERROR)
     {
-      sp_mop->drop_object_statement = 0;
-      goto error;
+      err = au_object_revoke_all_privileges (NULL, NULL, sp_mop, owner);
+      if (err != NO_ERROR)
+	{
+	  AU_SET_USER (save_user);
+	  goto error;
+	}
     }
+
+  AU_SET_USER (save_user);
 
   err = au_delete_auth_of_dropping_database_object (DB_OBJECT_PROCEDURE, name);
   if (err != NO_ERROR)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25486

Purpose

PR(#5574)에서 MOP에 drop_object_statement 플래그를 추가해 구현했지만, MOP가 여러 곳에서 많이 사용되고 cache로 재사용될 가능성이 있어 예상치 못한 side effect가 발생할 수 있습니다.

따라서, 이전의 두 가지 특이사항을 다른 방식으로 다시 구현했습니다.

Implementation
### 1. ALTER 권한을 부여받은 사용자가 객체를 삭제하는 경우
변경 전(drop_object_statement 플래그 사용)
- revoke 수행 시, Au_user(로그인 유저)와 user(FROM 사용자)가 동일한 경우 권한 회수가 실패하는 상황을 피하기 위해, drop_object_statement 플래그가 true인 경우를 스킵하도록 수정했습니다.

변경 후(AU_SET_USER 사용)
- DROP [TABLE|VIEW|PROCEDURE|FUNCTION] 수행 시 권한을 회수할 때, 임시로 Au_user(로그인 유저)를 소유자로 변경하도록 수정했습니다.

### 2. 파티션 테이블을 삭제할 때 권한 회수 문제

- 권한을 회수할 때 최상위 함수를 사용하는 것이 안전하다고 생각하여 db_revoke_object()를 사용했습니다. 
- 그러나 파티션을 스킵하기 위한 불필요한 조건을 추가하고 중복으로 여러 번 값을 확인하는 등의 비용이 많이 발생하는 것 같아 아래와 같이 수정했습니다.

변경 전 (drop_object_statement 플래그 사용)
- db_revoke_object()에서 drop_object_statement 플래그가 true인 경우, 파티션 확인(do_check_partitioned_class)을 스킵하도록 수정했습니다.

변경 후 (함수 변경)
- au_object_revoke_all_privileges() 내부에서 db_revoke_object()를 au_revoke()로 변경했습니다.


Remarks

N/A