### PR TITLE
[CBRD-25654] Add DB Name to CAS DDL Audit Log File Format

### DIFF
--- a/src/base/ddl_log.c
+++ b/src/base/ddl_log.c
@@ -1182,9 +1182,10 @@ logddl_create_log_msg (FILE * fp)
 	  snprintf (ddl_audit_handle.elapsed_time, sizeof (ddl_audit_handle.elapsed_time), "elapsed time 0.000");
 	}
 
-      fprintf (fp, "%s %s|%s|%s|%s|%s|%s\n",
+      fprintf (fp, "%s %s|%s|%s|%s|%s|%s|%s\n",
 	       ddl_audit_handle.str_qry_exec_begin_time,
 	       ddl_audit_handle.ip_addr,
+	       ddl_audit_handle.db_name,
 	       ddl_audit_handle.user_name, result, ddl_audit_handle.elapsed_time, ddl_audit_handle.msg,
 	       ddl_audit_handle.sql_text);
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25654

Purpose
현재 CAS를 통해 DDL Audit Log 가 생성될때 해당 로그에는 DB Name이 존재하지 않아 DDL 구문이 어떤 DB에서 실행되었는지 알수가 없어, CAS의 DDL Audit Log에 DB Name을 추가함

Implementation
현재 Log Format
[Time] [ip_addr]|[user_name]|[result]|[elapsed time]|[auto commit/rollback]|[sql_text]

변경 Log Format
[Time] [ip_addr]|**[db_name]**|[user_name]|[result]|[elapsed time]|[auto commit/rollback]|[sql_text]
