### PR TITLE
[CBRD-25469] 운영환경에서 백업본을 기반으로 신규 DB명으로 복구하는 스크립트(restore_to_newdb.sh)추가

### DIFF
--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -110,6 +110,7 @@ if(UNIX)
     ${CMAKE_SOURCE_DIR}/contrib/scripts/cubrid.sh
     ${CMAKE_SOURCE_DIR}/contrib/scripts/cubrid.csh
     ${CMAKE_SOURCE_DIR}/contrib/scripts/unloaddb.sh
+    ${CMAKE_SOURCE_DIR}/contrib/scripts/restore_to_newdb.sh
     ${CMAKE_SOURCE_DIR}/contrib/scripts/check_index_ovfps.sh
     DESTINATION ${CUBRID_DATADIR}/scripts/)
 endif(UNIX)

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -110,7 +110,6 @@ if(UNIX)
     ${CMAKE_SOURCE_DIR}/contrib/scripts/cubrid.sh
     ${CMAKE_SOURCE_DIR}/contrib/scripts/cubrid.csh
     ${CMAKE_SOURCE_DIR}/contrib/scripts/unloaddb.sh
-    ${CMAKE_SOURCE_DIR}/contrib/scripts/restore_to_newdb.sh
     ${CMAKE_SOURCE_DIR}/contrib/scripts/check_index_ovfps.sh
     DESTINATION ${CUBRID_DATADIR}/scripts/)
 endif(UNIX)

--- a/contrib/scripts/restore_to_newdb.sh
+++ b/contrib/scripts/restore_to_newdb.sh
@@ -1,0 +1,393 @@
+#!/bin/bash
+#
+#
+#  Copyright 2016 CUBRID Corporation
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# usage message
+function show_usage() {
+    echo "restore_to_newdb.sh : rename the database name after restoring the database"
+    echo "usage : sh $0 [OPTIONS] backuped-database-name new-database-name"
+    echo ""
+    echo "OPTIONS:"
+    echo "  -F path  directory for new database (default: current directory)"
+    echo "  -B path  directory for backup volumes (default: current directory)"
+    echo "  -d date  restore to specific date (dd-mm-yyyy:hh:mm:ss or 'backuptime')"
+    echo "  -l level backup level (0, 1, 2) default: 0 (full backup)"
+    echo "  -p       partial recovery if any log archive is absent"
+    echo "  -k path  path of key file (_keys) for tde (default: current directory)"
+    echo ""
+    echo " EXAMPLES"
+    echo "  sh $0 backupdb newdb"
+    echo "  sh $0 -B /home/cubrid/backup backupdb newdb"
+    exit 1
+}
+
+# default values
+initialize_variables() {
+    newdb_path=$(pwd)
+    backupdb_path=$(pwd)
+    up_to_date=""
+    level=0
+    partial_recovery=false
+    keys_file_path=""
+    positional_args=()
+}
+
+DEBUG=false
+
+print_debug_info() {
+    if [[ "$DEBUG" == "true" ]]; then
+    echo "Debug Information:"
+    echo "--------------------------"
+    echo "newdb_path: $newdb_path"
+    echo "backupdb_path: $backupdb_path"
+    echo "up_to_date: $up_to_date"
+    echo "level: $level"
+    echo "partial_recovery: $partial_recovery"
+    echo "keys_file_path: $keys_file_path"
+    echo "positional_args: ${positional_args[*]}"
+    echo "--------------------------"
+    fi
+}
+
+
+function check_files() {
+    search_file=$1
+    debug_str=$2
+
+    if [ -z "$search_file" ]; then
+        echo "error: ($debug_str) files not found."
+        exit 1
+    else
+        echo "confirmed: ($debug_str) files found."
+        for file in $search_file; do
+            printf "\tfile: %s\n" "$file"
+        done
+    fi
+}
+
+function check_volpath() {
+    local volpath="$1"
+    local datafile="$2"
+
+    # Verify that the databases.txt file exists
+    if [[ ! -f "$datafile" ]]; then
+        echo "Error: Database file $datafile not found."
+        exit 1
+    fi
+
+    # Check the vol-path in databases.txt
+    local match=$(awk -v path="$volpath" '$2 == path {print $2}' "$datafile")
+
+    # Error if same vol-path exists
+    if [[ -n "$match" ]]; then
+        echo "Error: newdb_path ($volpath) is the same as an existing vol-path ($match) in $datafile."
+        exit 1
+    else
+        echo ""
+        echo "Validation passed: newdb_path and vol-path are different."
+    fi
+}
+
+function check_dbname_uniqueness() {
+    local dbname="$1"
+    local datafile="$2"
+
+    # Search dbname in databases.txt
+    if grep -qw "$dbname" "$datafile"; then
+        echo "Error: Database name '$dbname' already exists in $datafile."
+        exit 1
+    else
+        echo ""
+        echo "Validation passed: '$dbname' does not exist in $datafile."
+    fi
+}
+
+# parse and validate command-line options and positional arguments
+function parse_and_validate_options() {
+    local data_file="$CUBRID_DATABASES/databases.txt"
+
+    # Parse command-line options
+    while [[ "$#" -gt 0 ]]; do
+        case "$1" in
+            -F)
+                if [[ -z "$2" || "$2" =~ ^- ]]; then
+                    echo "Error: -F option requires a value."
+                    show_usage
+                elif [[ ! -d "$2" ]]; then
+                    echo "Error: The directory specified in -F option does not exist: $2"
+                    show_usage
+                fi
+                newdb_path="$2"; shift 2;;
+            -B)
+                if [[ -z "$2" || "$2" =~ ^- ]]; then
+                    echo "Error: -B option requires a directory path."
+                    show_usage
+                elif [[ ! -d "$2" ]]; then
+                    echo "Error: The directory specified in -B option does not exist: $2"
+                    show_usage
+                fi
+                backupdb_path="$2"; shift 2;;
+            -d)
+                if [[ -z "$2" || "$2" =~ ^- ]]; then
+                    echo "Error: -d option requires a value."
+                    show_usage
+                elif [[ ! "$2" =~ ^([0-2][0-9]|3[0-1])-(0[1-9]|1[0-2])-[0-9]{4}:[0-2][0-9]:[0-5][0-9]:[0-5][0-9]$ ]]; then
+                    echo "Error: -d option value must be in the format dd-mm-yyyy:hh:mm:ss"
+                    show_usage
+                fi
+                up_to_date="$2"; shift 2;;
+            -l)
+                if [[ -z "$2" || "$2" =~ ^- ]]; then
+                    echo "Error: -l option requires a value."
+                    show_usage
+                elif [[ "$2" =~ ^[0-2]$ ]]; then
+                    level="$2"
+                    shift 2
+                else
+                    echo "Error: Invalid value for -l. Only 0, 1, or 2 are allowed."
+                    show_usage
+                fi
+                ;;
+            -p) partial_recovery=true; shift;;
+            -k)
+                if [[ -z "$2" || "$2" =~ ^- ]]; then
+                    echo "Error: -k option requires a value."
+                    show_usage
+                fi
+                keys_file_path="$2"; shift 2;;
+            -*) echo "Unknown option: $1"; show_usage;;
+            *) positional_args+=("$1"); shift;;
+        esac
+    done
+
+    # Validate required dbname arguments
+    if [[ "${#positional_args[@]}" -ne 2 ]]; then
+        echo "Error: Two positional arguments are required: <backuped-database-name> and <new-database-name>."
+        show_usage
+    fi
+    asis_dbname="${positional_args[0]}"
+    tobe_dbname="${positional_args[1]}"
+
+    # asis_dbname and tobe_dbname must not be the same.
+    if [[ "$asis_dbname" == "$tobe_dbname" ]]; then
+        echo "Error: 'backuped-database-name' and 'new-database-name' cannot be the same."
+        exit 1
+    fi
+
+    # If the -F option is exists, the vol-path that exists in databases.txt must not be the same as newdb_path.
+    if [[ -n "$newdb_path" ]]; then
+        # Check if newdb_path is the same as CUBRID_DATABASES path
+        if [[ "$newdb_path" == "$CUBRID_DATABASES" ]]; then
+            echo "Error: newdb_path ($newdb_path) cannot be the same as CUBRID_DATABASES path ($CUBRID_DATABASES)."
+            exit 1
+        fi
+        check_volpath "$newdb_path" "$data_file"
+    fi
+
+    # tobe_dbname should not exist in the databases.txt file
+    check_dbname_uniqueness "$tobe_dbname" "$data_file"
+}
+
+
+# verify files exist
+function verify_files() {
+    local required_files=()
+
+    # Check if the asis_dbname keyfile exists
+    if [[ -n "$keys_file_path" ]]; then
+        # Check for the presence of files in keys_file_path and assign to keys_files
+        keys_files=$(ls "$keys_file_path" 2>/dev/null)
+
+        # Pass the found files to check_files function
+        check_files "$keys_files" "Search keyfile"
+    fi
+
+    # Check if the tobe_dbname backup level file exists
+    if [[ "$level" -ge 0 ]]; then
+        required_files+=("$backupdb_path/${asis_dbname}_bk0v*")
+    fi
+    if [[ "$level" -ge 1 ]]; then
+        required_files+=("$backupdb_path/${asis_dbname}_bk1v*")
+    fi
+    if [[ "$level" -ge 2 ]]; then
+        required_files+=("$backupdb_path/${asis_dbname}_bk2v*")
+    fi
+
+    for pattern in "${required_files[@]}"; do
+        local files=$(ls $pattern 2>/dev/null)
+        if [[ -z "$files" ]]; then
+            echo "Error: Required files not found for pattern ($pattern)."
+            exit 1
+        else
+            echo "Confirmed: Files found for pattern ($pattern)."
+            for file in $files; do
+                printf "\tfile: %s\n" "$file"
+            done
+        fi
+    done
+
+
+}
+
+# copy and modify databases.txt
+function copy_and_modify_databases_txt() {
+    asis_cubrid_databases=$CUBRID_DATABASES
+
+    # Check if databases.txt already exists in $newdb_path
+    if [ -e "$newdb_path/databases.txt" ]; then
+        echo "Warning: $newdb_path/databases.txt already exists."
+        #exit 1 #delete
+
+        # Optionally, back up the existing file
+        mv "$newdb_path/databases.txt" "$newdb_path/databases.txt.bak" || {
+            echo "Failed to back up existing databases.txt."
+            #exit 1 #delete
+        }
+        echo "Existing databases.txt backed up as databases.txt.bak."
+    fi
+
+    # Copy the original databases.txt to $newdb_path
+    cp "$asis_cubrid_databases/databases.txt" "$newdb_path" || {
+        echo "failed to copy databases.txt."
+        exit 1
+    }
+
+}
+
+# edit databases.txt content
+function modify_databases_txt() {
+    local file_path="$newdb_path/databases.txt"
+    local temp_file=$(mktemp)
+    local lob_base_path="${newdb_path}/lob"
+    local asis_dbname=$asis_dbname
+
+    while IFS= read -r line; do
+        read -a fields <<< "$line"
+        if [[ "${fields[0]}" == "$asis_dbname" ]]; then
+            fields[1]=$newdb_path
+            fields[3]=$newdb_path
+            fields[4]="file:$lob_base_path"
+
+            echo "${fields[@]}" >> "$temp_file"
+        else
+            echo "$line" >> "$temp_file"
+        fi
+    done < "$file_path"
+    mv "$temp_file" "$file_path"
+}
+
+# update cubrid_databases environment variable
+function update_cubrid_databases() {
+    export CUBRID_DATABASES=$newdb_path || {
+        echo "failed to update cubrid_databases."
+        exit 1
+    }
+}
+
+# run restore database command
+function run_restore_db() {
+    local cmd="cubrid restoredb -B $backupdb_path"
+
+    [[ -n "$up_to_date" ]] && cmd+=" -d $up_to_date"
+    cmd+=" -l $level"
+    $partial_recovery && cmd+=" -p"
+    [[ -n "$keys_file_path" ]] && cmd+=" -k $keys_file_path"
+    cmd+=" -u -o db_$(date '+%y%m%d%H%M%S').log $asis_dbname"
+
+    eval "$cmd &"
+    local cmd_pid=$!
+    while kill -0 "$cmd_pid" 2>/dev/null; do
+        for s in '/' '-' '' '|'; do
+        echo -ne "\rRestoring... $s"
+        sleep 1
+        done
+    done
+    wait $cmd_pid
+    if [ $? -ne 0 ]; then
+        echo "restore db failed."
+        exit 1
+    fi
+}
+
+# rename database
+function rename_database() {
+    cubrid renamedb "$asis_dbname" "$tobe_dbname" || {
+        echo "failed to rename database."
+        exit 1
+    }
+}
+
+# rollback environment variable
+function rollback_cubrid_databases() {
+    export CUBRID_DATABASES=$asis_cubrid_databases
+}
+
+
+# Function to check file existence, find and append a specific line in databases.txt
+function rollback_databases_txt() {
+    local rollback_datafile="$CUBRID_DATABASES/databases.txt"
+    local newdb_datafile="$newdb_path/databases.txt"
+    local tobe_dbname="$tobe_dbname"
+    local temp_file=$(mktemp)
+
+    # Check if newdb_datafile exists
+    if [ ! -f "$newdb_datafile" ]; then
+        echo "Error: $newdb_datafile not found in $rollback_databfile"
+        exit 1
+    fi
+
+    # Check if tobe_dbname exists
+    check_dbname_uniqueness "$tobe_dbname" "$rollback_datafile"
+
+    # Find line number for tobe_dbname
+    local search_line
+    search_line=$(grep -n "^$tobe_dbname" "$newdb_datafile" | cut -d: -f1)
+
+    if [ -z "$search_line" ]; then
+        echo "Error: The specified line with $tobe_dbname not found in $newdb_datafile"
+        exit 1
+    fi
+
+    # Extract and append the specified line to rollback_datafile
+    local content
+    content=$(sed -n "${search_line}p" "$newdb_datafile")
+
+    cat "$rollback_datafile" > "$temp_file"
+    echo "$content" >> "$temp_file"
+    mv "$temp_file" "$rollback_datafile" || {
+        echo "Failed to update $rollback_datafile"
+        exit 1
+    }
+    echo "Updated $rollback_datafile successfully."
+}
+
+# main execution
+#################################################################################
+#
+
+    initialize_variables
+    parse_and_validate_options "$@"
+    verify_files
+    copy_and_modify_databases_txt
+    modify_databases_txt
+    update_cubrid_databases
+    run_restore_db
+    rename_database
+    rollback_cubrid_databases
+    rollback_databases_txt
+    echo "database restoration completed successfully."
+


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25469

[Describe] 
사용자 실수 및 시스템 오류로 인해 데이터 복구가 필요한 경우, "백업본"을 가지고 운영 중인 서버에 복구하기 위해서는 추가계정, 추가 엔진 설치등의 번거로운 작업이 선행되어야 한다. 이에 번거로운 선행 작업없이 CUBRID 설치된 계정(운영 계정)에서 백업본을 가지고 복구 후 신규 DB명으로 변경할 수 있는 스크립트를 제공한다.


[Usage]
restore_to_newdb.sh : rename the database name after restoring the database
usage : sh restore_to_newdb.sh [OPTION] backuped-database-name new-database-name

OPTIONS:
  -F path  directory for new database (default: current directory)
  -B path  directory for backup volumes (default: current directory)
  -d date  restore to specific date (dd-mm-yyyy:hh:mm:ss or 'backuptime')
  -l level backup level (0, 1, 2); default: 0 (full backup)
  -p       partial recovery if any log archive is absent
  -k path  path of key file (_keys) for tde (default: current)

 EXAMPLES
  restore_to_newdb.sh backupdb newdb


[Test Scenario]

1. 인자가 없는 경우 usage출력
2. 1개의 인자만 입력한 경우, usage출력
3. 2개를 초과한 입력값이 들어온 경우, usage출력
4. fullbackup파일이 존재, 기존에 없는 DB명으로 복구하는 경우 : 정상수행
5. 옵션이 뒤에 입력된 경우 : 정상수행
6. 스크립트 현 경로에 백업파일이 존재하지 않은 경우 : 에러 출력으로 정상
7. -F의 옵션을 현 디렉토리로 수행한 경우 : 정상수행
8. -F옵션이 없는 경우 : 정상수행
9. -d 30-10-2024:19:20:00 인 경우 : 정상수행
10. -l의 0이 기본값, -l 1로 옵션을 준 경우 : 완료
11. -p 를 준 경우
12. -k에서 key파일명이 누락된 경우 : 에러 출력으로 정상
13. -k에 정상적인 디렉토리와 파일명이 기입된 경우 : 정상수행
14. key를 백업파일과 다르게 기입한 경우 : 정상수행
15. 명령어 수행 수 db_date.log가 남겨져 있는가 : 정상
16. 작업 디렉토리내에 databases.txt 백업 되어져 있는가 : 정상
17. 작업 디렉토리내에 중복될 경우 databases.txt.bak이 존재하는가 : 정상

[Request]
코드 리뷰 및 다른 case의 테스트가 필요하다면 리뷰 요청 드립니다.