### PR TITLE
[CBRD-25657] Modify to cannot convert negative values to the time series domain

### DIFF
--- a/msg/en_US.utf8/cubrid.msg
+++ b/msg/en_US.utf8/cubrid.msg
@@ -1450,8 +1450,9 @@ Check the path of the key file (_keys) and make sure that it includes proper key
 1360 In line %1$d, column %2$d\nStored procedure compile error: %3$s
 
 1361 Invalid result cache for subquery.
+1362 Cannot coerce negative value to %1$s
 
-1362 Last Error
+1363 Last Error
 
 $set 6 MSGCAT_SET_INTERNAL
 1 Error in error subsystem (line %1$d):

--- a/msg/ko_KR.utf8/cubrid.msg
+++ b/msg/ko_KR.utf8/cubrid.msg
@@ -1450,8 +1450,9 @@ $ LOADDB
 1360 In line %1$d, column %2$d\nStored procedure compile error: %3$s
 
 1361 부질의 캐시가 잘못되었습니다.
+1362 음수값은 도메인(%1$s)로 변환할 수 없습니다.
 
-1362 마지막 에러
+1363 마지막 에러
 
 $set 6 MSGCAT_SET_INTERNAL
 1 에러 서브 시스템에 에러 발생(라인 %1$d):

--- a/src/base/error_code.h
+++ b/src/base/error_code.h
@@ -1740,8 +1740,9 @@
 #define ER_SP_COMPILE_ERROR                         -1360
 
 #define ER_QPROC_RESULT_CACHE_INVALID		    -1361
+#define ER_TP_CANT_COERCE_NEGATIVE_VALUE            -1362
 
-#define ER_LAST_ERROR                               -1362
+#define ER_LAST_ERROR                               -1363
 
 /*
  * CAUTION!

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -8156,7 +8156,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 		}
 	      else
 		{
-		  status = DOMAIN_INCOMPATIBLE;
+		  status = DOMAIN_NEGATIVE_VALUE;
 		}
 	    }
 	  break;
@@ -8280,7 +8280,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	      tmpint = db_get_int (target);
 	      if (tmpint < 0)
 		{
-		  status = DOMAIN_INCOMPATIBLE;
+		  status = DOMAIN_NEGATIVE_VALUE;
 		  break;
 		}
 	      v_timestamptz.timestamp = (DB_UTIME) tmpint;
@@ -8405,7 +8405,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 		}
 	      else
 		{
-		  status = DOMAIN_INCOMPATIBLE;
+		  status = DOMAIN_NEGATIVE_VALUE;
 		}
 	    }
 	  break;
@@ -8854,10 +8854,26 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    break;
 	  }
 	case DB_TYPE_SHORT:
-	  v_time = db_get_short (src) % SECONDS_IN_A_DAY;
-	  db_time_decode (&v_time, &hour, &minute, &second);
-	  db_make_time (target, hour, minute, second);
+        case DB_TYPE_INTEGER:
+        case DB_TYPE_BIGINT:
+        case DB_TYPE_FLOAT:
+        case DB_TYPE_DOUBLE:
+          status = tp_value_coerce ((DB_VALUE *) src, target, &tp_Integer_domain);
+          if (status == DOMAIN_COMPATIBLE)
+            {
+              if (db_get_int(target) >= 0)
+                {
+	          v_time = db_get_int (target) % SECONDS_IN_A_DAY;
+	          db_time_decode (&v_time, &hour, &minute, &second);
+	          db_make_time (target, hour, minute, second);
+                }
+              else
+                {
+                  status = DOMAIN_NEGATIVE_VALUE;
+                }
+            }
 	  break;
+#if 0
 	case DB_TYPE_INTEGER:
           if (db_get_int(src) < 0)
             {
@@ -8875,6 +8891,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  db_time_decode (&v_time, &hour, &minute, &second);
 	  db_make_time (target, hour, minute, second);
 	  break;
+#endif
 	case DB_TYPE_MONETARY:
 	  v_money = db_get_monetary (src);
 	  if (OR_CHECK_INT_OVERFLOW (v_money->amount))
@@ -8888,6 +8905,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	      db_make_time (target, hour, minute, second);
 	    }
 	  break;
+#if 0
 	case DB_TYPE_FLOAT:
 	  {
 	    float ftmp = db_get_float (src);
@@ -8918,6 +8936,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	      }
 	    break;
 	  }
+#endif
 	case DB_TYPE_VARCHAR:
 	case DB_TYPE_CHAR:
 	case DB_TYPE_NCHAR:

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -8854,44 +8854,25 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	    break;
 	  }
 	case DB_TYPE_SHORT:
-        case DB_TYPE_INTEGER:
-        case DB_TYPE_BIGINT:
-        case DB_TYPE_FLOAT:
-        case DB_TYPE_DOUBLE:
-          status = tp_value_coerce ((DB_VALUE *) src, target, &tp_Integer_domain);
-          if (status == DOMAIN_COMPATIBLE)
-            {
-              if (db_get_int(target) >= 0)
-                {
-	          v_time = db_get_int (target) % SECONDS_IN_A_DAY;
-	          db_time_decode (&v_time, &hour, &minute, &second);
-	          db_make_time (target, hour, minute, second);
-                }
-              else
-                {
-                  status = DOMAIN_NEGATIVE_VALUE;
-                }
-            }
-	  break;
-#if 0
 	case DB_TYPE_INTEGER:
-          if (db_get_int(src) < 0)
-            {
-              status = DOMAIN_NEGATIVE_VALUE;
-            }
-          else
-            {
-	      v_time = db_get_int (src) % SECONDS_IN_A_DAY;
-	      db_time_decode (&v_time, &hour, &minute, &second);
-	      db_make_time (target, hour, minute, second);
-            }
-	  break;
 	case DB_TYPE_BIGINT:
-	  v_time = db_get_bigint (src) % SECONDS_IN_A_DAY;
-	  db_time_decode (&v_time, &hour, &minute, &second);
-	  db_make_time (target, hour, minute, second);
+	case DB_TYPE_FLOAT:
+	case DB_TYPE_DOUBLE:
+	  status = tp_value_coerce ((DB_VALUE *) src, target, &tp_Integer_domain);
+	  if (status == DOMAIN_COMPATIBLE)
+	    {
+	      if (db_get_int (target) >= 0)
+		{
+		  v_time = db_get_int (target) % SECONDS_IN_A_DAY;
+		  db_time_decode (&v_time, &hour, &minute, &second);
+		  db_make_time (target, hour, minute, second);
+		}
+	      else
+		{
+		  status = DOMAIN_NEGATIVE_VALUE;
+		}
+	    }
 	  break;
-#endif
 	case DB_TYPE_MONETARY:
 	  v_money = db_get_monetary (src);
 	  if (OR_CHECK_INT_OVERFLOW (v_money->amount))
@@ -8905,38 +8886,6 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	      db_make_time (target, hour, minute, second);
 	    }
 	  break;
-#if 0
-	case DB_TYPE_FLOAT:
-	  {
-	    float ftmp = db_get_float (src);
-	    if (OR_CHECK_INT_OVERFLOW (ftmp))
-	      {
-		status = DOMAIN_OVERFLOW;
-	      }
-	    else
-	      {
-		v_time = ((int) ROUND (ftmp)) % SECONDS_IN_A_DAY;
-		db_time_decode (&v_time, &hour, &minute, &second);
-		db_make_time (target, hour, minute, second);
-	      }
-	    break;
-	  }
-	case DB_TYPE_DOUBLE:
-	  {
-	    double dtmp = db_get_double (src);
-	    if (OR_CHECK_INT_OVERFLOW (dtmp))
-	      {
-		status = DOMAIN_OVERFLOW;
-	      }
-	    else
-	      {
-		v_time = ((int) ROUND (dtmp)) % SECONDS_IN_A_DAY;
-		db_time_decode (&v_time, &hour, &minute, &second);
-		db_make_time (target, hour, minute, second);
-	      }
-	    break;
-	  }
-#endif
 	case DB_TYPE_VARCHAR:
 	case DB_TYPE_CHAR:
 	case DB_TYPE_NCHAR:

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -8859,9 +8859,16 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  db_make_time (target, hour, minute, second);
 	  break;
 	case DB_TYPE_INTEGER:
-	  v_time = db_get_int (src) % SECONDS_IN_A_DAY;
-	  db_time_decode (&v_time, &hour, &minute, &second);
-	  db_make_time (target, hour, minute, second);
+          if (db_get_int(src) < 0)
+            {
+              status = DOMAIN_NEGATIVE_VALUE;
+            }
+          else
+            {
+	      v_time = db_get_int (src) % SECONDS_IN_A_DAY;
+	      db_time_decode (&v_time, &hour, &minute, &second);
+	      db_make_time (target, hour, minute, second);
+            }
 	  break;
 	case DB_TYPE_BIGINT:
 	  v_time = db_get_bigint (src) % SECONDS_IN_A_DAY;
@@ -11784,6 +11791,11 @@ tp_domain_status_er_set (TP_DOMAIN_STATUS status, const char *file_name, const i
 
     case DOMAIN_OVERFLOW:
       error = ER_IT_DATA_OVERFLOW;
+      er_set (ER_ERROR_SEVERITY, file_name, line_no, error, 1, pr_type_name (TP_DOMAIN_TYPE (domain)));
+      break;
+
+    case DOMAIN_NEGATIVE_VALUE:
+      error = ER_TP_CANT_COERCE_NEGATIVE_VALUE;
       er_set (ER_ERROR_SEVERITY, file_name, line_no, error, 1, pr_type_name (TP_DOMAIN_TYPE (domain)));
       break;
 

--- a/src/object/object_domain.h
+++ b/src/object/object_domain.h
@@ -190,7 +190,7 @@ typedef enum tp_domain_status
   DOMAIN_COMPATIBLE = 0,	/* success */
   DOMAIN_INCOMPATIBLE,		/* can't be coerced */
   DOMAIN_OVERFLOW,		/* value out of range */
-  DOMAIN_NEGATIVE_VALUE,        /* negative value */
+  DOMAIN_NEGATIVE_VALUE,	/* negative value */
   DOMAIN_ERROR			/* an error has been set */
 } TP_DOMAIN_STATUS;
 

--- a/src/object/object_domain.h
+++ b/src/object/object_domain.h
@@ -190,6 +190,7 @@ typedef enum tp_domain_status
   DOMAIN_COMPATIBLE = 0,	/* success */
   DOMAIN_INCOMPATIBLE,		/* can't be coerced */
   DOMAIN_OVERFLOW,		/* value out of range */
+  DOMAIN_NEGATIVE_VALUE,        /* negative value */
   DOMAIN_ERROR			/* an error has been set */
 } TP_DOMAIN_STATUS;
 


### PR DESCRIPTION
    http://jira.cubrid.org/browse/CBRD-2565

    - if destination type is time, it is occurred error.
    - if destination type are timestamp, timestampltz and timestamptz, it is changed error message.
    - The error message is "Cannot coerce negative value to ..".
