### PR TITLE
[CBRD-24306] fflush after print_message () in printing cubrid services

### DIFF
--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -445,6 +445,7 @@ print_message (FILE * output, int message_id, ...)
   va_start (arg_list, message_id);
   vfprintf (output, format, arg_list);
   va_end (arg_list);
+  fflush (output);
 }
 
 /*


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24306

**Description**
* When we execute 2 commands
  `cubrid service status`
  `cubrid service status > out.txt; cat out.txt`
* We expect the same output appeared
* However, the order of messages is output differently in the two commands

Remarks
* The addition of fflush in **print_message** () resolves this gap.
