### PR TITLE
[CBRD-24941] slip: restore missing (by mistake) error messages

### DIFF
--- a/msg/en_US.utf8/cubrid.msg
+++ b/msg/en_US.utf8/cubrid.msg
@@ -1942,7 +1942,11 @@ $set 8 MSGCAT_SET_PARSER_SEMANTIC
 314 Synonym "%1$s" does not exist.
 315 Rename cannot change owner.
 316 Rename cannot be changed to the same name.
-317 Identifiers cannot be in a LIMIT clause.321 %TYPE type specification is allowed only for PL/CSQL
+317 Identifiers cannot be in a LIMIT clause.
+318 Only DBA and DBA group members can change the SERIAL OWNER.
+319 Unsupported argument type '%1$s' of the stored procedure
+320 Unsupported return type '%1$s' of the stored procedure
+321 %TYPE type specification is allowed only for PL/CSQL
 322 Table column '%1$s.%2$s' has not been defined
 323 Stored procedure/function '%1$s' has OUT or IN OUT arguments
 324 '%1$s' is not a record variable.


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24941
