### PR TITLE
[CBRD-25185] [bugfix] Run-time exception of expression ascii(53)

### DIFF
--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -26890,7 +26890,7 @@ db_ascii (const DB_VALUE * param, DB_VALUE * result)
 	  db_make_short (result, 0);
 	}
     }
-  else if (TP_IS_NUMERIC_TYPE (param_type))
+  else if (TP_IS_NUMERIC_TYPE (param_type) || TP_IS_DATE_OR_TIME_TYPE (param_type))
     {
       DB_VALUE new_value;
       const TP_DOMAIN *new_domain = tp_domain_resolve_default (DB_TYPE_CHAR);
@@ -26899,7 +26899,6 @@ db_ascii (const DB_VALUE * param, DB_VALUE * result)
       if (status != DOMAIN_COMPATIBLE)
 	{
 	  error_code = ER_QSTR_INVALID_DATA_TYPE;
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_code, 0);
 	  goto error;
 	}
 

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -26890,6 +26890,32 @@ db_ascii (const DB_VALUE * param, DB_VALUE * result)
 	  db_make_short (result, 0);
 	}
     }
+  else if (TP_IS_NUMERIC_TYPE (param_type))
+    {
+      DB_VALUE new_value;
+      const TP_DOMAIN *new_domain = tp_domain_resolve_default (DB_TYPE_CHAR);
+      db_make_null (&new_value);
+      TP_DOMAIN_STATUS status = tp_value_auto_cast (param, &new_value, new_domain);
+      if (status != DOMAIN_COMPATIBLE)
+	{
+	  error_code = ER_QSTR_INVALID_DATA_TYPE;
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_code, 0);
+	  goto error;
+	}
+
+      str_size = db_get_string_size (&new_value);
+      if (str_size > 0)
+	{
+	  str = db_get_string (&new_value);
+	  db_make_short (result, (unsigned char) str[0]);
+	}
+      else
+	{
+	  db_make_short (result, 0);
+	}
+
+      db_value_clear (&new_value);
+    }
   else
     {
       error_code = ER_QSTR_INVALID_DATA_TYPE;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25185

* Fix support error for numeric types in prepare-execute mode for ASCII() function

```
prepare st from 'select ASCII(?)';
execute st using 53;
execute st using DATE'2008-10-31';
execute st using TIME'00:00:00';
execute st using TIMESTAMP'2010-10-31 01:15:45';
execute st using DATETIME'2008-10-31 13:15:45';
execute st using datetimetz'10/15/1986 5:45:15.135 am +02:30:20';
execute st using datetimetz'10/15/1986 5:45:15.135 am +02:30';
execute st using datetimetz'10/15/1986 5:45:15.135 am +02';
execute st using datetimeltz'10/15/1986 5:45:15.135 am Europe/Bucharest';
execute st using datetimetz'2001-10-11 02:03:04 AM Europe/Bucharest EEST';
execute st using timestampltz'10/15/1986 5:45:15 am Europe/Bucharest';
execute st using timestamptz'10/15/1986 5:45:15 am Europe/Bucharest';
```