### PR TITLE
[CBRD-25652] Fix the incorrect calculation of log_Gl.hdr.avg_ntrans when transactions with top operations exist during checkpoint execution

### DIFF
--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -7080,7 +7080,7 @@ logpb_checkpoint (THREAD_ENTRY * thread_p)
 	}
 
       /* CHECKPOINTING THE TOP ACTIONS */
-      for (i = 0, ntrans = 0, ntops = 0; i < log_Gl.trantable.num_total_indices; i++)
+      for (i = 0, ntops = 0; i < log_Gl.trantable.num_total_indices; i++)
 	{
 	  /*
 	   * Don't checkpoint current system transaction. That is, the one of


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25652

- Purpose
  - 체크포인트 수행 시 logpb_checkpoint() 함수에서 평균 트랜잭션 개수(log_Gl.hdr.avg_ntrans)가 계산됨.
  - 평균 트랜잭션 개수는 log_Gl.hdr.avg_ntrans 값에 활성 트랜잭션 개수(ntrans)가 더해지면서 계산됨.
  - top 연산을 갖는 트랜잭션이 존재하는 경우, ntrans 값이 0으로 잘못 초기화 되는 문제가 있음.
  - 0으로 잘못 초기화 된 ntrans 값으로 평균 트랜잭션 개수가 잘못 계산되고 있음.
  - 평균 트랜잭션 개수가 정확하게 계산되도록 해야 함.

- Implementation
  - logpb_checkpoint() 함수에서 top 연산을 갖는 트랜잭션이 존재하는 경우, ntrans 값을 초기화하지 않도록 수정.

- Remarks

  - N/A