### PR TITLE
[CBRD-25663] remove grammar and early semantic check of dynamic SQL loop

### DIFF
--- a/pl_engine/pl_server/src/main/antlr/PlcParser.g4
+++ b/pl_engine/pl_server/src/main/antlr/PlcParser.g4
@@ -170,7 +170,6 @@ loop_statement
     | label_declaration? FOR iterator LOOP seq_of_statements END LOOP label_name?          # stmt_for_iter_loop
     | label_declaration? FOR for_cursor LOOP seq_of_statements END LOOP label_name?        # stmt_for_cursor_loop
     | label_declaration? FOR for_static_sql LOOP seq_of_statements END LOOP label_name?    # stmt_for_static_sql_loop
-    | label_declaration? FOR for_dynamic_sql LOOP seq_of_statements END LOOP label_name?   # stmt_for_dynamic_sql_loop
     ;
 
  // actually far more complicated according to the Spec.
@@ -184,10 +183,6 @@ for_cursor
 
 for_static_sql
     : record_name IN LPAREN static_sql RPAREN
-    ;
-
-for_dynamic_sql
-    : record_name IN LPAREN EXECUTE IMMEDIATE dyn_sql restricted_using_clause? RPAREN
     ;
 
 lower_bound

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -1796,48 +1796,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     }
 
     @Override
-    public StmtForSqlLoop visitStmt_for_dynamic_sql_loop(Stmt_for_dynamic_sql_loopContext ctx) {
-
-        connectionRequired = true;
-
-        symbolStack.pushSymbolTable("for_d_sql_loop", null);
-
-        ParserRuleContext recNameCtx = ctx.for_dynamic_sql().record_name();
-        String record = Misc.getNormalizedText(recNameCtx);
-
-        Expr dynSql = visitExpression(ctx.for_dynamic_sql().dyn_sql());
-
-        NodeList<Expr> usedExprList;
-        Restricted_using_clauseContext usingClause =
-                ctx.for_dynamic_sql().restricted_using_clause();
-        if (usingClause == null) {
-            usedExprList = null;
-        } else {
-            usedExprList = visitRestricted_using_clause(usingClause);
-        }
-
-        String label;
-        DeclLabel declLabel = visitLabel_declaration(ctx.label_declaration());
-        if (declLabel == null) {
-            label = null;
-        } else {
-            label = declLabel.name;
-            symbolStack.putDeclLabel(label, declLabel);
-        }
-
-        DeclDynamicRecord declForRecord = new DeclDynamicRecord(recNameCtx, record);
-        symbolStack.putDecl(record, declForRecord);
-
-        NodeList<Stmt> stmts = visitSeq_of_statements(ctx.seq_of_statements());
-        controlFlowBlocked =
-                false; // every loop is assumed not to block control flow in generated Java code
-
-        symbolStack.popSymbolTable();
-
-        return new StmtForDynamicSqlLoop(ctx, label, declForRecord, dynSql, usedExprList, stmts);
-    }
-
-    @Override
     public StmtNull visitNull_statement(Null_statementContext ctx) {
         return new StmtNull(ctx);
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25663

PM 팀과 협의하여 For Loop에서 EXECUTE IMMEDIATE 을 사용하는 기능을 제거하기로 결정하였습니다. 
관련 문법과 시맨틱 체크 부분을 삭제합니다. 

관련된 TC 11개 삭제 PR 은 별도로 진행합니다. 
