### PR TITLE
[CBRD-24306] add fflush (stdout) to sync messages redirected a file sequentially

### DIFF
--- a/src/executables/server.c
+++ b/src/executables/server.c
@@ -342,6 +342,7 @@ main (int argc, char **argv)
       }
 
     fprintf (stdout, "\nThis may take a long time depending on the amount " "of recovery works to do.\n");
+    fflush (stdout);
 
     /* save executable path */
     binary_name = basename (argv[0]);

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2766,6 +2766,7 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
       strncpy_size (format, msgcat_message (MSGCAT_CATALOG_CUBRID, MSGCAT_SET_GENERAL, MSGCAT_GENERAL_DATABASE_INIT),
 		    BOOT_FORMAT_MAX_LENGTH);
       fprintf (stdout, format, rel_name ());
+      fflush (stdout);
 #else /* NDEBUG */
       fprintf (stdout, "\n%s (%s) (%d %s build)\n\n", rel_name (), rel_build_number (), rel_bit_platform (),
 	       rel_build_type ());


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24306

**Description**
* refer #5593
* to resolve difference between what we can see in the TERMINAL and redirect to a FILE

**Remarks**
* reported by QA while running TestCases
```
  $ cubrid server start demodb
  $ cubrid server start demodb > status.txt; cat status.txt
```