### PR TITLE
[CBRD-25345] [win] restriction for absolute path - must specify drive letter

### DIFF
--- a/src/broker/broker_acl.c
+++ b/src/broker/broker_acl.c
@@ -250,6 +250,16 @@ access_control_read_config_file (T_SHM_APPL_SERVER * shm_appl, char *filename, c
 	      goto error;
 	    }
 
+#if defined (WINDOWS)
+	  if (token[0] == '\\' || token[0] == '/')
+	    {
+	      snprintf (admin_err_msg, ADMIN_ERR_MSG_SIZE,
+			"%s: error while loading access control file (%s)"
+			" - when using an absolute path name, the driver name must be specified (%s). ",
+			shm_appl->broker_name, filename, token);
+	      goto error;
+	    }
+#endif
 	  if (make_abs_path (path_buf, "conf", token, BROKER_PATH_MAX) < 0)
 	    {
 	      goto error;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25345

Description
* due to field separator of ACL record and Windows abs path are some character (:), 
* sometimes get confused about a field should be interpreted as a drive letter or a database name
* **When expressed as an absolute path, it must always include the DRIVE characters.**
* Valid
```
  [%BROKER1]
  demodb:dba:C:\CUBRID\conf\cubrid_acl_ip.conf

```
* Invalid
```
   [%BROKER1]
   demodb:C:\CUBRID\conf\cubrid_acl_ip.conf
```
