### PR TITLE
[CBRD-25541] Fixed unnecessary heap operations in show access status by passing NULL to the class_oid parameter

### DIFF
--- a/src/connection/connection_support.c
+++ b/src/connection/connection_support.c
@@ -2765,7 +2765,7 @@ css_make_access_status_exist_user (THREAD_ENTRY * thread_p, OID * class_oid, LAS
       goto end;
     }
 
-  error = heap_scancache_start (thread_p, &scan_cache, &hfid, NULL, true, mvcc_snapshot);
+  error = heap_scancache_start (thread_p, &scan_cache, &hfid, class_oid, true, mvcc_snapshot);
   if (error != NO_ERROR)
     {
       goto end;
@@ -2774,7 +2774,7 @@ css_make_access_status_exist_user (THREAD_ENTRY * thread_p, OID * class_oid, LAS
 
   while (true)
     {
-      scan = heap_next (thread_p, &hfid, NULL, &inst_oid, &recdes, &scan_cache, PEEK);
+      scan = heap_next (thread_p, &hfid, class_oid, &inst_oid, &recdes, &scan_cache, PEEK);
       if (scan == S_SUCCESS)
 	{
 	  error = heap_attrinfo_read_dbvalues (thread_p, &inst_oid, &recdes, &attr_info);

--- a/src/connection/connection_support.c
+++ b/src/connection/connection_support.c
@@ -2774,7 +2774,7 @@ css_make_access_status_exist_user (THREAD_ENTRY * thread_p, OID * class_oid, LAS
 
   while (true)
     {
-      scan = heap_next (thread_p, &hfid, class_oid, &inst_oid, &recdes, &scan_cache, PEEK);
+      scan = heap_next (thread_p, &hfid, NULL, &inst_oid, &recdes, &scan_cache, PEEK);
       if (scan == S_SUCCESS)
 	{
 	  error = heap_attrinfo_read_dbvalues (thread_p, &inst_oid, &recdes, &attr_info);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25541

- Purpose
    - show access status 수행 시 css_make_access_status_exist_user() 함수에서 heap_scancache_start(), heap_next() 함수를 호출함.
    - 두 함수 호출 시 class_oid 파라미터에 NULL을 전달하고 있음.
        - 이 경우 class_oid를 찾는 연산을 다시 수행해야 함.
    - css_make_access_status_exist_user() 함수에서 이미 class_oid를 인자로 전달받았기 때문에 class_oid를 두 함수에 전달함으로써 불필요하게 다시 class_oid를 찾는 연산을 제거해야 함
- Implementation
    - heap_scancache_start(), heap_next() 함수에서 class_oid 파라미터에 class_oid 값을 전달하게 함.
- Remarks
    - class_oid가 NULL이 아닌 정상적인 값으로 전달되어야 아래에서 수행된 최적화가 적용될 수 있음.
        - https://github.com/CUBRID/cubrid/pull/5394#discussion_r1732273704
        - http://jira.cubrid.org/browse/CBRD-25037?focusedCommentId=4767502&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-4767502