### PR TITLE
[CBRD-25676] SA 모드 loaddb에서 PL 서버 실행

### DIFF
--- a/src/loaddb/load_sa_loader.cpp
+++ b/src/loaddb/load_sa_loader.cpp
@@ -6544,6 +6544,8 @@ ldr_sa_load (load_args *args, int *status, bool *interrupted)
 
   ldr_final ();
 
+  pl_monitor_destroy ();
+
   if (ldr_Driver != NULL)
     {
       delete ldr_Driver;

--- a/src/loaddb/load_sa_loader.cpp
+++ b/src/loaddb/load_sa_loader.cpp
@@ -72,6 +72,7 @@
 #include "utility.h"
 #include "work_space.h"
 #include "schema_system_catalog_constants.h"
+#include "pl_sr.h"
 
 using namespace cubload;
 
@@ -6368,6 +6369,8 @@ ldr_sa_load (load_args *args, int *status, bool *interrupted)
 
   locator_Dont_check_foreign_key = true;
   ldr_init (args);
+
+  pl_monitor_init (NULL);
 
   /* set the flag to indicate what type of interrupts to raise If logging has been disabled set commit flag. If
    * logging is enabled set abort flag. */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25676

loaddb의 SA 모드에서 PL 서버를 구동하도록 변경

#5596 의 변경을 기반으로 합니다.