### PR TITLE
[CBRD-25658] SP 파라미터 기본값에 pseudo column 지원

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/ExecuteThread.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/ExecuteThread.java
@@ -448,7 +448,7 @@ public class ExecuteThread extends Thread {
     private void returnOutArgs(StoredProcedure sp, CUBRIDPacker packer)
             throws IOException, ExecuteException, TypeMismatchException {
         Value[] args = sp.getArgs();
-        for (int i = 0; i < args.length; i++) {
+        for (int i = 0; args != null && i < args.length; i++) {
             if (args[i].getMode() > Value.IN) {
                 Value v = sp.makeOutValue(args[i].getResolved());
                 packer.packValue(

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/ExecuteThread.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/ExecuteThread.java
@@ -428,7 +428,6 @@ public class ExecuteThread extends Thread {
         int paramCount = unpacker.unpackInt();
 
         Value[] arguments = prepareArgs.getArgs();
-        Value[] methodArgs = new Value[paramCount];
         for (int i = 0; i < paramCount; i++) {
             int mode = unpacker.unpackInt();
             int type = unpacker.unpackInt();
@@ -442,7 +441,7 @@ public class ExecuteThread extends Thread {
         boolean transactionControl = unpacker.unpackBool();
         getCurrentContext().setTransactionControl(transactionControl);
 
-        storedProcedure = new StoredProcedure(methodSig, lang, authUser, methodArgs, returnType);
+        storedProcedure = new StoredProcedure(methodSig, lang, authUser, arguments, returnType);
         return storedProcedure;
     }
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/ExecuteThread.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/ExecuteThread.java
@@ -49,8 +49,6 @@ import com.cubrid.jsp.exception.TypeMismatchException;
 import com.cubrid.jsp.protocol.Header;
 import com.cubrid.jsp.protocol.PrepareArgs;
 import com.cubrid.jsp.protocol.RequestCode;
-import com.cubrid.jsp.value.NullValue;
-import com.cubrid.jsp.value.StringValue;
 import com.cubrid.jsp.value.Value;
 import com.cubrid.jsp.value.ValueUtilities;
 import com.cubrid.plcsql.compiler.PlcsqlCompilerMain;
@@ -434,27 +432,10 @@ public class ExecuteThread extends Thread {
         for (int i = 0; i < paramCount; i++) {
             int mode = unpacker.unpackInt();
             int type = unpacker.unpackInt();
-            int defaultValSize = unpacker.unpackInt();
-            String defaultVal = null;
-
-            Value val = null;
-            if (defaultValSize == -1) {
-                val = arguments[i];
-            } else if (defaultValSize > 0) {
-                defaultVal = unpacker.unpackCString();
-                val = new StringValue(defaultVal);
-            } else if (defaultValSize == 0) {
-                val = new NullValue();
-            } else {
-                assert false;
-                // internal error
-                val = new NullValue();
-            }
+            Value val = arguments[i];
 
             val.setMode(mode);
             val.setDbType(type);
-
-            methodArgs[i] = val;
         }
         int returnType = unpacker.unpackInt();
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/StoredProcedure.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/StoredProcedure.java
@@ -157,7 +157,6 @@ public class StoredProcedure {
 
     private void checkArgs() throws TypeMismatchException {
         if (args == null) {
-            args = new Value[0];
             return;
         }
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/StoredProcedure.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/StoredProcedure.java
@@ -143,14 +143,24 @@ public class StoredProcedure {
     }
 
     public Object[] getResolved() {
+        if (args == null) {
+            return null;
+        }
+
         Object[] resolved = new Object[args.length];
         for (int i = 0; i < args.length; i++) {
             resolved[i] = args[i].getResolved();
         }
+
         return resolved;
     }
 
     private void checkArgs() throws TypeMismatchException {
+        if (args == null) {
+            args = new Value[0];
+            return;
+        }
+
         Class<?>[] argsTypes = target.getArgsTypes();
         if (argsTypes.length != args.length) {
             throw new TypeMismatchException(

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/protocol/PrepareArgs.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/protocol/PrepareArgs.java
@@ -24,7 +24,7 @@ public class PrepareArgs {
 
     public int getArgCount() {
         if (arguments == null) {
-            return -1;
+            return 0;
         } else {
             return arguments.length;
         }
@@ -47,6 +47,8 @@ public class PrepareArgs {
                 Value arg = unpacker.unpackValue(paramType);
                 arguments[i] = (arg);
             }
+        } else {
+            arguments = null;
         }
     }
 }

--- a/src/base/porting.c
+++ b/src/base/porting.c
@@ -2551,7 +2551,7 @@ strtof_win (const char *nptr, char **endptr)
 }
 
 char *
-strndup_win (char *src, int size)
+strndup_win (const char *src, size_t size)
 {
   char *dest = (char *) malloc (size + 1);
   if (dest == NULL)

--- a/src/base/porting.c
+++ b/src/base/porting.c
@@ -2549,6 +2549,22 @@ strtof_win (const char *nptr, char **endptr)
   f_val = (float) d_val;
   return f_val;
 }
+
+char *
+strndup_win (char *src, int size)
+{
+  char *dest = (char *) malloc (size + 1);
+  if (dest == NULL)
+    {
+      return NULL;
+    }
+
+  memcpy (dest, src, size);
+  dest[size] = '\0';
+
+  return dest;
+}
+
 #endif
 
 #ifndef HAVE_STRLCPY

--- a/src/base/porting.h
+++ b/src/base/porting.h
@@ -155,6 +155,8 @@ extern char *realpath (const char *path, char *resolved_path);
 #define vfprintf        _vfprintf_p
 #define vprintf         _vprintf_p
 #define strtof		strtof_win
+#define strndup         strndup_win
+
 #if defined (_WIN32)
 #define mktime         mktime_for_win32
 #endif

--- a/src/base/porting.h
+++ b/src/base/porting.h
@@ -999,7 +999,7 @@ extern int str_to_float (float *ret_p, char **end_p, const char *str_p);
 
 #if defined (WINDOWS)
 extern float strtof_win (const char *nptr, char **endptr);
-extern char *strndup_win (char *src, int size);
+extern char *strndup_win (const char *src, size_t size);
 #endif
 
 #ifndef HAVE_STRLCPY

--- a/src/base/porting.h
+++ b/src/base/porting.h
@@ -999,6 +999,7 @@ extern int str_to_float (float *ret_p, char **end_p, const char *str_p);
 
 #if defined (WINDOWS)
 extern float strtof_win (const char *nptr, char **endptr);
+extern char *strndup_win (char *src, int size);
 #endif
 
 #ifndef HAVE_STRLCPY

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -677,8 +677,8 @@ extern "C"
 						  int *continue_walk);
   extern void pt_get_default_expression_from_data_default_node (PARSER_CONTEXT * parser, PT_NODE * data_default_node,
 								DB_DEFAULT_EXPR * default_expr);
-  extern void pt_get_default_expression_from_string (PARSER_CONTEXT * parser, const char* str, const int str_size,
-						  DB_DEFAULT_EXPR * default_expr);
+  extern void pt_get_default_expression_from_string (PARSER_CONTEXT * parser, const char *str, const int str_size,
+						     DB_DEFAULT_EXPR * default_expr);
   extern PT_NODE *pt_has_name_oid (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);
 
   extern int pt_check_dblink_password (PARSER_CONTEXT * parser, const char *passwd, char *cipher, int ciper_size);

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -406,6 +406,7 @@ extern "C"
 
   extern int pt_find_attribute (PARSER_CONTEXT * parser, const PT_NODE * name, const PT_NODE * attributes);
 
+  extern PT_NODE *pt_make_null_value (PARSER_CONTEXT * parser);
   extern PT_NODE *pt_make_string_value (PARSER_CONTEXT * parser, const char *value_string);
 
   extern PT_NODE *pt_make_integer_value (PARSER_CONTEXT * parser, const int value_int);
@@ -677,6 +678,8 @@ extern "C"
 						  int *continue_walk);
   extern void pt_get_default_expression_from_data_default_node (PARSER_CONTEXT * parser, PT_NODE * data_default_node,
 								DB_DEFAULT_EXPR * default_expr);
+  extern void pt_get_default_expression_from_string (PARSER_CONTEXT * parser, const char* str, const int str_size,
+						  DB_DEFAULT_EXPR * default_expr);
   extern PT_NODE *pt_has_name_oid (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);
 
   extern int pt_check_dblink_password (PARSER_CONTEXT * parser, const char *passwd, char *cipher, int ciper_size);

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -406,7 +406,6 @@ extern "C"
 
   extern int pt_find_attribute (PARSER_CONTEXT * parser, const PT_NODE * name, const PT_NODE * attributes);
 
-  extern PT_NODE *pt_make_null_value (PARSER_CONTEXT * parser);
   extern PT_NODE *pt_make_string_value (PARSER_CONTEXT * parser, const char *value_string);
 
   extern PT_NODE *pt_make_integer_value (PARSER_CONTEXT * parser, const int value_int);

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -10303,7 +10303,6 @@ pt_has_non_groupby_column_node (PARSER_CONTEXT * parser, PT_NODE * node, void *a
   return node;
 }
 
-
 static DB_DEFAULT_EXPR_TYPE
 parse_default_expr_type (const char *str, const int str_size, int *next_len)
 {

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -10329,14 +10329,14 @@ parse_default_expr_type (const char *str, const int str_size, int *next_len)
 	      return DB_DEFAULT_SYSTIME;
 	    }
 	}
-      if (str_size >= 11 && strncmp (str, "SYS_DATETIME", 11) == 0)
-	{
-	  *next_len = 11;
-	  return DB_DEFAULT_SYSDATETIME;
-	}
-      if (str_size >= 12 && strncmp (str, "SYS_TIMESTAMP", 12) == 0)
+      if (str_size >= 12 && strncmp (str, "SYS_DATETIME", 12) == 0)
 	{
 	  *next_len = 12;
+	  return DB_DEFAULT_SYSDATETIME;
+	}
+      if (str_size >= 13 && strncmp (str, "SYS_TIMESTAMP", 13) == 0)
+	{
+	  *next_len = 13;
 	  return DB_DEFAULT_SYSTIMESTAMP;
 	}
       break;
@@ -10373,9 +10373,9 @@ parse_default_expr_type (const char *str, const int str_size, int *next_len)
       break;
 
     case 'U':
-      if (str_size >= 15 && strncmp (str, "UNIX_TIMESTAMP()", 15) == 0)
+      if (str_size >= 16 && strncmp (str, "UNIX_TIMESTAMP()", 16) == 0)
 	{
-	  *next_len = 15;
+	  *next_len = 16;
 	  return DB_DEFAULT_UNIX_TIMESTAMP;
 	}
       if (str_size >= 6 && strncmp (str, "USER()", 6) == 0)

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -10303,6 +10303,145 @@ pt_has_non_groupby_column_node (PARSER_CONTEXT * parser, PT_NODE * node, void *a
   return node;
 }
 
+
+static DB_DEFAULT_EXPR_TYPE
+parse_default_expr_type (const char *str, const int str_size, int *next_len)
+{
+  if (str_size < 4)
+    {
+      *next_len = 0;
+      return DB_DEFAULT_NONE;
+    }
+
+  switch (str[0])
+    {
+    case 'S':
+      if (str_size >= 8)
+	{
+	  if (strncmp (str, "SYS_DATE", 8) == 0)
+	    {
+	      *next_len = 8;
+	      return DB_DEFAULT_SYSDATE;
+	    }
+	  if (strncmp (str, "SYS_TIME", 8) == 0)
+	    {
+	      *next_len = 8;
+	      return DB_DEFAULT_SYSTIME;
+	    }
+	}
+      if (str_size >= 11 && strncmp (str, "SYS_DATETIME", 11) == 0)
+	{
+	  *next_len = 11;
+	  return DB_DEFAULT_SYSDATETIME;
+	}
+      if (str_size >= 12 && strncmp (str, "SYS_TIMESTAMP", 12) == 0)
+	{
+	  *next_len = 12;
+	  return DB_DEFAULT_SYSTIMESTAMP;
+	}
+      break;
+
+    case 'C':
+      if (str_size >= 12)
+	{
+	  if (strncmp (str, "CURRENT_DATE", 12) == 0)
+	    {
+	      *next_len = 12;
+	      return DB_DEFAULT_CURRENTDATE;
+	    }
+	  if (strncmp (str, "CURRENT_TIME", 12) == 0)
+	    {
+	      *next_len = 12;
+	      return DB_DEFAULT_CURRENTTIME;
+	    }
+	  if (strncmp (str, "CURRENT_USER", 12) == 0)
+	    {
+	      *next_len = 12;
+	      return DB_DEFAULT_CURR_USER;
+	    }
+	}
+      if (str_size >= 16 && strncmp (str, "CURRENT_DATETIME", 16) == 0)
+	{
+	  *next_len = 16;
+	  return DB_DEFAULT_CURRENTDATETIME;
+	}
+      if (str_size >= 17 && strncmp (str, "CURRENT_TIMESTAMP", 17) == 0)
+	{
+	  *next_len = 17;
+	  return DB_DEFAULT_CURRENTTIMESTAMP;
+	}
+      break;
+
+    case 'U':
+      if (str_size >= 15 && strncmp (str, "UNIX_TIMESTAMP()", 15) == 0)
+	{
+	  *next_len = 15;
+	  return DB_DEFAULT_UNIX_TIMESTAMP;
+	}
+      if (str_size >= 6 && strncmp (str, "USER()", 6) == 0)
+	{
+	  *next_len = 6;
+	  return DB_DEFAULT_USER;
+	}
+      if (str_size >= 4 && strncmp (str, "USER", 4) == 0)
+	{
+	  *next_len = 4;
+	  return DB_DEFAULT_CURR_USER;
+	}
+      break;
+    }
+
+  *next_len = 0;
+  return DB_DEFAULT_NONE;
+}
+
+/*
+ * pt_get_default_expression_from_string () - get default value from string
+ * return : error code or NO_ERROR
+ *
+ * parser (in)		  : parser context
+ * str (in) : default expression string
+ * str_size (in) : default expression string size
+ * default_expr (out)	  : default expression
+ */
+void
+pt_get_default_expression_from_string (PARSER_CONTEXT * parser, const char *str, const int str_size,
+				       DB_DEFAULT_EXPR * default_expr)
+{
+  assert (parser != NULL && default_expr != NULL);
+  assert (str != NULL && str_size > 0);
+
+  classobj_initialize_default_expr (default_expr);
+
+  std::string expr_str (str, str_size);
+
+  int curr_idx = 0;
+  int curr_len = str_size;
+
+  const int to_char_size = sizeof ("TO_CHAR(") - 1;
+  if (str_size > to_char_size && strncmp (str, "TO_CHAR(", to_char_size) == 0)
+    {
+      curr_idx += to_char_size;
+      curr_len -= to_char_size;
+      default_expr->default_expr_op = T_TO_CHAR;
+    }
+
+  int parsed_len;
+  default_expr->default_expr_type = parse_default_expr_type (&str[curr_idx], curr_len, &parsed_len);
+  curr_idx += parsed_len;
+  curr_len -= parsed_len;
+
+  if (default_expr->default_expr_op == T_TO_CHAR)
+    {
+      // find next ',' 
+      const char *formatted_string = strchr (&str[curr_idx], ',') + 1;
+
+      // get remaining length before the last ')'
+      int remaining_len = str_size - (formatted_string - &str[curr_idx]);
+      default_expr->default_expr_format = strndup (formatted_string, remaining_len - 1);
+    }
+}
+
 /*
  * pt_get_default_value_from_attrnode () - get default value from data default node
  * return : error code or NO_ERROR

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -9522,6 +9522,7 @@ pt_check_default_value_param_for_stored_procedure (PARSER_CONTEXT * parser, PT_N
 		       default_value_print, pt_get_type_name (param->type_enum, param->data_type));
 	}
     }
+#endif
 
   return error;
 }

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -9522,7 +9522,6 @@ pt_check_default_value_param_for_stored_procedure (PARSER_CONTEXT * parser, PT_N
 		       default_value_print, pt_get_type_name (param->type_enum, param->data_type));
 	}
     }
-#endif
 
   return error;
 }

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -6669,6 +6669,9 @@ pt_stored_procedure_to_regu (PARSER_CONTEXT * parser, PT_NODE * node)
 	  return NULL;
 	}
 
+      PT_NODE *default_next_node_list = jsp_get_default_expr_node_list (parser, *(sp->sig));
+      node->info.method_call.arg_list = parser_append_node (default_next_node_list, node->info.method_call.arg_list);
+
       DB_TYPE result_type = (DB_TYPE) sp->sig->result_type;
       if (result_type == DB_TYPE_RESULTSET)
 	{

--- a/src/sp/jsp_cl.cpp
+++ b/src/sp/jsp_cl.cpp
@@ -65,8 +65,6 @@
 #include "authenticate_access_auth.hpp"
 #include "pl_signature.hpp"
 #include "oid.h"
-#include "string_buffer.hpp"
-#include "db_value_printer.hpp"
 
 #define PT_NODE_SP_NAME(node) \
   (((node)->info.sp.name == NULL) ? "" : \

--- a/src/sp/jsp_cl.cpp
+++ b/src/sp/jsp_cl.cpp
@@ -65,6 +65,8 @@
 #include "authenticate_access_auth.hpp"
 #include "pl_signature.hpp"
 #include "oid.h"
+#include "string_buffer.hpp"
+#include "db_value_printer.hpp"
 
 #define PT_NODE_SP_NAME(node) \
   (((node)->info.sp.name == NULL) ? "" : \
@@ -132,6 +134,7 @@ static int drop_stored_procedure_code (const char *name);
 static int alter_stored_procedure_code (PARSER_CONTEXT *parser, MOP sp_mop, const char *name, const char *owner_str,
 					int sp_recompile);
 
+static int jsp_default_value_string (PARSER_CONTEXT *parser, PT_NODE *node, std::string &out);
 static int check_execute_authorization (const MOP sp_obj, const DB_AUTH au_type);
 
 extern bool ssl_client;
@@ -623,7 +626,7 @@ jsp_evaluate_arguments (PARSER_CONTEXT *parser, PT_NODE *statement,
 	  db_make_null (db_value);
 
 	  /* must call pt_evaluate_tree */
-	  pt_evaluate_tree (parser, vc, db_value, 1);
+	  pt_evaluate_tree_having_serial (parser, vc, db_value, 1);
 	  if (pt_has_error (parser))
 	    {
 	      /* to maintain the list to free all the allocated */
@@ -673,56 +676,60 @@ jsp_call_stored_procedure (PARSER_CONTEXT *parser, PT_NODE *statement)
   DB_VALUE ret_value;
   db_make_null (&ret_value);
 
+  /* call sp */
   std::vector <std::reference_wrapper <DB_VALUE>> args;
-
-  error = jsp_evaluate_arguments (parser, statement, args);
-  if (pt_has_error (parser))
-    {
-      pt_report_to_ersys (parser, PT_SEMANTIC);
-      error = er_errid ();
-    }
-  else
-    {
-      /* call sp */
-      cubpl::pl_signature sig;
-      error = jsp_make_pl_signature (parser, statement, NULL, sig);
-      if (error == NO_ERROR && locator_get_sig_interrupt () == 0)
-	{
-	  std::vector <DB_VALUE> out_args;
-	  error = pl_call (sig, args, out_args, ret_value);
-	  if (error == NO_ERROR)
-	    {
-	      for (int i = 0, j = 0; i < sig.arg.arg_size; i++)
-		{
-		  if (sig.arg.arg_mode[i] == SP_MODE_IN)
-		    {
-		      continue;
-		    }
-
-		  DB_VALUE &arg = args[i];
-		  DB_VALUE &out_arg = out_args[j++];
-
-		  db_value_clear (&arg);
-		  db_value_clone (&out_arg, &arg);
-		  db_value_clear (&out_arg);
-		}
-	    }
-	}
-    }
-
+  cubpl::pl_signature sig;
+  error = jsp_make_pl_signature (parser, statement, NULL, sig);
   if (error == NO_ERROR)
     {
-      PT_NODE *vc = statement->info.method_call.arg_list;
-      for (int i = 0; i < (int) args.size () && vc; i++)
+      PT_NODE *default_next_node_list = jsp_get_default_expr_node_list (parser, sig);
+      if (default_next_node_list != NULL)
 	{
-	  if (!PT_IS_CONST (vc))
-	    {
-	      DB_VALUE &arg = args[i];
-	      db_value_clear (&arg);
-	      free (&arg);
-	    }
-	  vc = vc->next;
+	  error = qp_get_server_info (parser, SI_SYS_DATETIME);
 	}
+      statement->info.method_call.arg_list = parser_append_node (default_next_node_list,
+					     statement->info.method_call.arg_list);
+      error = jsp_evaluate_arguments (parser, statement, args);
+      if (pt_has_error (parser))
+	{
+	  pt_report_to_ersys (parser, PT_SEMANTIC);
+	  error = er_errid ();
+	}
+    }
+
+  if (error == NO_ERROR && locator_get_sig_interrupt () == 0)
+    {
+      std::vector <DB_VALUE> out_args;
+      error = pl_call (sig, args, out_args, ret_value);
+      if (error == NO_ERROR)
+	{
+	  for (int i = 0, j = 0; i < sig.arg.arg_size; i++)
+	    {
+	      if (sig.arg.arg_mode[i] == SP_MODE_IN)
+		{
+		  continue;
+		}
+
+	      DB_VALUE &arg = args[i];
+	      DB_VALUE &out_arg = out_args[j++];
+
+	      db_value_clear (&arg);
+	      db_value_clone (&out_arg, &arg);
+	      db_value_clear (&out_arg);
+	    }
+	}
+    }
+
+  PT_NODE *vc = statement->info.method_call.arg_list;
+  for (int i = 0; i < (int) args.size () && vc; i++)
+    {
+      if (!PT_IS_CONST (vc))
+	{
+	  DB_VALUE &arg = args[i];
+	  db_value_clear (&arg);
+	  free (&arg);
+	}
+      vc = vc->next;
     }
 
   if (error == NO_ERROR)
@@ -795,6 +802,91 @@ jsp_drop_stored_procedure (PARSER_CONTEXT *parser, PT_NODE *statement)
     }
 
   return err;
+}
+
+/*
+ * jsp_default_value_string
+ *   return:
+ *   parser(in/out): parser environment
+ *   statement(in): a default_value node
+ *
+ * Note:
+ */
+static int
+jsp_default_value_string (PARSER_CONTEXT *parser, PT_NODE *node, std::string &out)
+{
+  int error = NO_ERROR;
+
+  DB_DEFAULT_EXPR default_expr;
+  pt_get_default_expression_from_data_default_node (parser, node, &default_expr);
+
+  out.clear ();
+  if (default_expr.default_expr_type != DB_DEFAULT_NONE)
+    {
+      if (default_expr.default_expr_type == NULL_DEFAULT_EXPRESSION_OPERATOR)
+	{
+	  DB_VALUE *value = pt_value_to_db (parser, node->info.data_default.default_value);
+	  if (!DB_IS_NULL (value))
+	    {
+	      string_buffer sb;
+	      sb.clear ();
+	      db_sprint_value (value, sb);
+
+	      out.append (sb.get_buffer ());
+	    }
+	  else
+	    {
+	      // empty out consider as NULL
+	    }
+	}
+      else
+	{
+	  if (default_expr.default_expr_op == T_TO_CHAR)
+	    {
+	      out.append ("TO_CHAR(");
+	    }
+
+	  const char *default_value_expr_type_string = db_default_expression_string (default_expr.default_expr_type);
+	  if (default_value_expr_type_string != NULL)
+	    {
+	      out.append (default_value_expr_type_string);
+	    }
+	  else
+	    {
+	      out.append (parser_print_tree (parser, node));
+	    }
+
+	  if (default_expr.default_expr_op == T_TO_CHAR)
+	    {
+	      if (default_expr.default_expr_format != NULL)
+		{
+		  out.append (", \'");
+		  out.append (default_expr.default_expr_format);
+		  out.append ("\'");
+		}
+
+	      out.append (")");
+	    }
+	}
+    }
+  else
+    {
+      DB_VALUE *value = pt_value_to_db (parser, node->info.data_default.default_value);
+      if (!DB_IS_NULL (value))
+	{
+	  string_buffer sb;
+	  sb.clear ();
+	  db_sprint_value (value, sb);
+
+	  out.append (sb.get_buffer ());
+	}
+      else
+	{
+	  // empty out consider as NULL
+	}
+    }
+
+  return error;
 }
 
 /*
@@ -886,12 +978,30 @@ jsp_create_stored_procedure (PARSER_CONTEXT *parser, PT_NODE *statement)
       PT_NODE *default_value = p->info.sp_param.default_value;
       if (default_value)
 	{
-	  pt_evaluate_tree (parser, default_value->info.data_default.default_value, &arg_info.default_value, 1);
-	  arg_info.is_optional = true;
+	  std::string default_value_str;
+	  if (jsp_default_value_string (parser, default_value, default_value_str) == NO_ERROR)
+	    {
+	      if (!default_value_str.empty ())
+		{
+		  db_make_string (&arg_info.default_value, ws_copy_string (default_value_str.c_str ()));
+		}
+	      else
+		{
+		  db_make_null (&arg_info.default_value);
+		}
+
+	      arg_info.is_optional = true;
+	    }
+	  else
+	    {
+	      ASSERT_ERROR ();
+	      goto error_exit;
+	    }
 	}
       else
 	{
 	  db_make_null (&arg_info.default_value);
+	  arg_info.is_optional = false; // explicitly
 	}
 
       arg_info.comment = (char *) PT_NODE_SP_ARG_COMMENT (p);
@@ -2168,4 +2278,91 @@ check_execute_authorization (const MOP sp_obj, const DB_AUTH au_type)
     }
 
   return error;
+}
+
+PT_NODE *
+jsp_get_default_expr_node_list (PARSER_CONTEXT *parser, cubpl::pl_signature &sig)
+{
+  PT_NODE *default_next_node_list = NULL;
+  PT_NODE *default_next_node = NULL;
+  for (int i = 0; i < sig.arg.arg_size; i++)
+    {
+      if (sig.arg.arg_default_value_size[i] == 0)
+	{
+	  default_next_node = pt_make_string_value (parser, NULL);
+	}
+      else if (sig.arg.arg_default_value_size[i] > 0)
+	{
+	  DB_DEFAULT_EXPR default_expr;
+	  pt_get_default_expression_from_string (parser, sig.arg.arg_default_value[i], sig.arg.arg_default_value_size[i],
+						 &default_expr);
+
+	  // from pt_resolve_default_value
+	  if (default_expr.default_expr_type != DB_DEFAULT_NONE)
+	    {
+	      PT_OP_TYPE op = pt_op_type_from_default_expr_type (default_expr.default_expr_type);
+	      PT_NODE *default_op_value_node = pt_expression_0 (parser, op);
+
+	      if (default_expr.default_expr_op == NULL_DEFAULT_EXPRESSION_OPERATOR)
+		{
+		  default_next_node = default_op_value_node;
+		}
+	      else
+		{
+		  PT_NODE *arg1, *arg2, *arg3;
+		  arg1 = default_op_value_node;
+		  bool has_user_format = default_expr.default_expr_format ? true : false;
+		  arg2 = pt_make_string_value (parser, default_expr.default_expr_format);
+
+		  if (arg2 == NULL)
+		    {
+		      parser_free_tree (parser, default_op_value_node);
+		      return NULL;
+		    }
+
+		  arg3 = parser_new_node (parser, PT_VALUE);
+		  if (arg3 == NULL)
+		    {
+		      parser_free_tree (parser, default_op_value_node);
+		      parser_free_tree (parser, arg2);
+		      return NULL;
+		    }
+
+		  arg3->type_enum = PT_TYPE_INTEGER;
+		  const char *lang_str = prm_get_string_value (PRM_ID_INTL_DATE_LANG);
+		  int flag = 0;
+		  lang_set_flag_from_lang (lang_str, has_user_format, 0, &flag);
+		  arg3->info.value.data_value.i = (long) flag;
+
+		  default_next_node = parser_make_expression (parser, PT_TO_CHAR, arg1, arg2, arg3);
+		  if (default_next_node == NULL)
+		    {
+		      parser_free_tree (parser, default_op_value_node);
+		      parser_free_tree (parser, arg2);
+		      parser_free_tree (parser, arg3);
+		      return NULL;
+		    }
+		}
+	    }
+	  else
+	    {
+	      default_next_node = pt_make_string_value (parser, sig.arg.arg_default_value[i]);
+	      default_next_node = pt_wrap_with_cast_op (parser, default_next_node, pt_db_to_type_enum ((DB_TYPE) sig.arg.arg_type[i]),
+				  TP_FLOATING_PRECISION_VALUE, 0, NULL);
+	    }
+	}
+
+      if (default_next_node != NULL)
+	{
+	  default_next_node = pt_semantic_type (parser, default_next_node, NULL);
+	  if (default_next_node == NULL)
+	    {
+	      return NULL;
+	    }
+
+	  default_next_node_list = parser_append_node (default_next_node, default_next_node_list);
+	}
+    }
+
+  return default_next_node_list;
 }

--- a/src/sp/jsp_cl.cpp
+++ b/src/sp/jsp_cl.cpp
@@ -65,6 +65,8 @@
 #include "authenticate_access_auth.hpp"
 #include "pl_signature.hpp"
 #include "oid.h"
+#include "string_buffer.hpp"
+#include "db_value_printer.hpp"
 
 #define PT_NODE_SP_NAME(node) \
   (((node)->info.sp.name == NULL) ? "" : \

--- a/src/sp/jsp_cl.h
+++ b/src/sp/jsp_cl.h
@@ -69,4 +69,5 @@ extern void jsp_set_prepare_call (void);
 extern void jsp_unset_prepare_call (void);
 extern bool jsp_is_prepare_call (void);
 
+extern PT_NODE *jsp_get_default_expr_node_list (PARSER_CONTEXT *parser, cubpl::pl_signature &sig);
 #endif /* _JSP_CL_H_ */

--- a/src/sp/jsp_cl.h
+++ b/src/sp/jsp_cl.h
@@ -69,5 +69,5 @@ extern void jsp_set_prepare_call (void);
 extern void jsp_unset_prepare_call (void);
 extern bool jsp_is_prepare_call (void);
 
-extern PT_NODE *jsp_get_default_expr_node_list (PARSER_CONTEXT *parser, cubpl::pl_signature &sig);
+extern PT_NODE *jsp_get_default_expr_node_list (PARSER_CONTEXT * parser, cubpl::pl_signature & sig);
 #endif /* _JSP_CL_H_ */

--- a/src/sp/pl_executor.cpp
+++ b/src/sp/pl_executor.cpp
@@ -56,15 +56,11 @@ namespace cubpl
     num_args = arg.arg_size;
     arg_mode.resize (num_args);
     arg_type.resize (num_args);
-    arg_default_size.resize (num_args);
-    arg_default.resize (num_args);
 
     for (int i = 0; i < num_args; i++)
       {
 	arg_mode[i] = arg.arg_mode[i];
 	arg_type[i] = arg.arg_type[i];
-	arg_default_size[i] = arg.arg_default_value_size[i];
-	arg_default[i] = arg.arg_default_value[i];
       }
 
     transaction_control = (lang == SP_LANG_PLCSQL) ? true : tc;
@@ -84,11 +80,6 @@ namespace cubpl
       {
 	serializator.pack_int (arg_mode[i]);
 	serializator.pack_int (arg_type[i]);
-	serializator.pack_int (arg_default_size[i]);
-	if (arg_default_size[i] > 0)
-	  {
-	    serializator.pack_c_string (arg_default[i], arg_default_size[i]);
-	  }
       }
 
     serializator.pack_int (result_type);
@@ -116,11 +107,6 @@ namespace cubpl
       {
 	size += serializator.get_packed_int_size (size); // arg_mode
 	size += serializator.get_packed_int_size (size); // arg_type
-	size += serializator.get_packed_int_size (size); // arg_default_size
-	if (arg_default_size[i] > 0)
-	  {
-	    size += serializator.get_packed_c_string_size (arg_default[i], arg_default_size[i], size); // arg_default
-	  }
       }
 
     size += serializator.get_packed_int_size (size); // return_type

--- a/src/sp/pl_executor.hpp
+++ b/src/sp/pl_executor.hpp
@@ -54,8 +54,6 @@ namespace cubpl
     int num_args;
     std::vector<int> arg_mode;
     std::vector<int> arg_type;
-    std::vector<int> arg_default_size;
-    std::vector<char *> arg_default;
     int result_type;
 
     bool transaction_control; // TODO: wrap it with proper structs

--- a/src/sp/pl_signature.cpp
+++ b/src/sp/pl_signature.cpp
@@ -69,15 +69,15 @@ namespace cubpl
       {
 	CHECK_NULL_AND_FREE (owner, arg_mode);
 	CHECK_NULL_AND_FREE (owner, arg_type);
-	for (int i = 0; i < arg_size; i++)
-	  {
-	    if (arg_default_value_size && arg_default_value_size[i] > 0)
-	      {
-		CHECK_NULL_AND_FREE (owner, arg_default_value[i]);
-	      }
-	  }
-	CHECK_NULL_AND_FREE (owner, arg_default_value_size);
-	CHECK_NULL_AND_FREE (owner, arg_default_value);
+       for (int i = 0; i < arg_size; i++)
+         {
+           if (arg_default_value_size && arg_default_value_size[i] > 0)
+             {
+               CHECK_NULL_AND_FREE (owner, arg_default_value[i]);
+             }
+         }
+       CHECK_NULL_AND_FREE (owner, arg_default_value_size);
+       CHECK_NULL_AND_FREE (owner, arg_default_value);
       }
   }
 
@@ -90,18 +90,6 @@ namespace cubpl
       {
 	serializator.pack_int_array (arg_mode, arg_size);
 	serializator.pack_int_array (arg_type, arg_size);
-	serializator.pack_int_array (arg_default_value_size, arg_size);
-	for (int i = 0; i < arg_size; i++)
-	  {
-	    if (arg_default_value_size[i] > 0)
-	      {
-		serializator.pack_c_string (arg_default_value[i], arg_default_value_size[i]);
-	      }
-	    else
-	      {
-		// do not pack anything
-	      }
-	  }
       }
   }
 
@@ -120,22 +108,6 @@ namespace cubpl
 
 	deserializator.unpack_int_array (arg_type, cnt);
 	assert (arg_size == cnt);
-
-	deserializator.unpack_int_array (arg_default_value_size, cnt);
-	assert (arg_size == cnt);
-
-	for (int i = 0; i < arg_size; i++)
-	  {
-	    if (arg_default_value_size[i] > 0)
-	      {
-		arg_default_value[i] = (char *) db_private_alloc (NULL, sizeof (char) * (arg_default_value_size[i] + 1));
-		deserializator.unpack_c_string (arg_default_value[i], SP_MAX_DEFAULT_VALUE_LEN);
-	      }
-	    else
-	      {
-		arg_default_value[i] = nullptr;
-	      }
-	  }
       }
   }
 
@@ -147,20 +119,6 @@ namespace cubpl
       {
 	size += serializator.get_packed_int_vector_size (size, arg_size); // arg_mode
 	size += serializator.get_packed_int_vector_size (size, arg_size); // arg_type
-	size += serializator.get_packed_int_vector_size (size, arg_size); // arg_default_value_size
-
-	for (int i = 0; i < arg_size; i++)
-	  {
-	    if (arg_default_value_size[i] > 0)
-	      {
-		size += serializator.get_packed_c_string_size ((const char *) arg_default_value[i],
-			(size_t) arg_default_value_size[i], size);
-	      }
-	    else
-	      {
-		size += serializator.get_packed_c_string_size (EMPTY_STRING, 0, size);
-	      }
-	  }
       }
     return size;
   }
@@ -174,15 +132,14 @@ namespace cubpl
 	arg_size = num_args;
 	arg_mode = (int *) db_private_alloc (NULL, (num_args) * sizeof (int));
 	arg_type = (int *) db_private_alloc (NULL, (num_args) * sizeof (int));
-	arg_default_value_size = (int *) db_private_alloc (NULL, (num_args) * sizeof (int));
-	arg_default_value = (char **) db_private_alloc (NULL, (num_args) * sizeof (char *));
-
+       arg_default_value_size = (int *) db_private_alloc (NULL, (num_args) * sizeof (int));
+       arg_default_value = (char **) db_private_alloc (NULL, (num_args) * sizeof (char *));
 	for (int i = 0; i < num_args; i++)
 	  {
 	    arg_mode[i] = 0;
 	    arg_type[i] = 0;
-	    arg_default_value_size[i] = 0;
-	    arg_default_value[i] = nullptr;
+           arg_default_value_size[i] = 0;
+           arg_default_value[i] = nullptr;
 	  }
       }
     else
@@ -190,8 +147,8 @@ namespace cubpl
 	arg_size = 0;
 	arg_mode = nullptr;
 	arg_type = nullptr;
-	arg_default_value_size = nullptr;
-	arg_default_value = nullptr;
+        arg_default_value_size = nullptr;
+        arg_default_value = nullptr;
       }
   }
 

--- a/src/sp/pl_signature.cpp
+++ b/src/sp/pl_signature.cpp
@@ -69,15 +69,15 @@ namespace cubpl
       {
 	CHECK_NULL_AND_FREE (owner, arg_mode);
 	CHECK_NULL_AND_FREE (owner, arg_type);
-       for (int i = 0; i < arg_size; i++)
-         {
-           if (arg_default_value_size && arg_default_value_size[i] > 0)
-             {
-               CHECK_NULL_AND_FREE (owner, arg_default_value[i]);
-             }
-         }
-       CHECK_NULL_AND_FREE (owner, arg_default_value_size);
-       CHECK_NULL_AND_FREE (owner, arg_default_value);
+	for (int i = 0; i < arg_size; i++)
+	  {
+	    if (arg_default_value_size && arg_default_value_size[i] > 0)
+	      {
+		CHECK_NULL_AND_FREE (owner, arg_default_value[i]);
+	      }
+	  }
+	CHECK_NULL_AND_FREE (owner, arg_default_value_size);
+	CHECK_NULL_AND_FREE (owner, arg_default_value);
       }
   }
 
@@ -132,14 +132,14 @@ namespace cubpl
 	arg_size = num_args;
 	arg_mode = (int *) db_private_alloc (NULL, (num_args) * sizeof (int));
 	arg_type = (int *) db_private_alloc (NULL, (num_args) * sizeof (int));
-       arg_default_value_size = (int *) db_private_alloc (NULL, (num_args) * sizeof (int));
-       arg_default_value = (char **) db_private_alloc (NULL, (num_args) * sizeof (char *));
+	arg_default_value_size = (int *) db_private_alloc (NULL, (num_args) * sizeof (int));
+	arg_default_value = (char **) db_private_alloc (NULL, (num_args) * sizeof (char *));
 	for (int i = 0; i < num_args; i++)
 	  {
 	    arg_mode[i] = 0;
 	    arg_type[i] = 0;
-           arg_default_value_size[i] = 0;
-           arg_default_value[i] = nullptr;
+	    arg_default_value_size[i] = 0;
+	    arg_default_value[i] = nullptr;
 	  }
       }
     else
@@ -147,8 +147,8 @@ namespace cubpl
 	arg_size = 0;
 	arg_mode = nullptr;
 	arg_type = nullptr;
-        arg_default_value_size = nullptr;
-        arg_default_value = nullptr;
+	arg_default_value_size = nullptr;
+	arg_default_value = nullptr;
       }
   }
 

--- a/src/sp/pl_signature.hpp
+++ b/src/sp/pl_signature.hpp
@@ -53,8 +53,10 @@ namespace cubpl
     int arg_size;
     int *arg_mode;  // array of (IN|OUT|IN/OUT)
     int *arg_type;  // array of DB_TYPE
-    int   *arg_default_value_size; // -1: Non-optional, 0: NULL, else: optional
-    char **arg_default_value; // array of VARCHAR (256)
+
+    // Only used in runtime
+    int   *arg_default_value_size;
+    char **arg_default_value;
 
     void pack (cubpacking::packer &serializator) const override;
     void unpack (cubpacking::unpacker &deserializator) override;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25658

Query executor와 PL executor에서는 SP 인수의 기본값이라는 맥락 없이 항상 인수 갯수만큼 이미 만들어진 값을 받도록 수정

- SP의 DEFAULT (:=) 인수에 대해 문자열로 저장
- 카탈로그에 저장된 표현식 (_db_stored_procedure_args.default_value)을 DB_DEFAULT_EXPR로 변환
  - CALL 구문의 경우 DB_DEFAULT_EXPR을 바로 평가 (evaluate) 하여 값 생성 후 인수 전달
  - 질의문의 경우 ARITH REGU_VAR로 만들어질 수 있도록 method_call.arg_list에 추가, query executor에서 evaluate