### PR TITLE
[CBRD-25680] When using a correlated subquery that includes columns from an outer table in the select clause, it is not selected as a cache key

### DIFF
--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -2784,11 +2784,12 @@ struct pt_name_info
 #define PT_NAME_DEFAULTF_ACCEPTS   4096	/* name of table/column that default function accepts: real table's, cte's */
 #define PT_NAME_INFO_USER_SPECIFIED 8192	/* resolved_name is added to original_name to make user_specified_name. */
 #define PT_NAME_INFO_SERVER_SPECIFIED 16384	/* server name is specified for dblink */
+#define PT_NAME_INFO_CORRELATED 0x8000	/* correlated attr */
 
-  short flag;
-#define PT_NAME_INFO_IS_FLAGED(e, f)    ((e)->info.name.flag & (short) (f))
-#define PT_NAME_INFO_SET_FLAG(e, f)     (e)->info.name.flag |= (short) (f)
-#define PT_NAME_INFO_CLEAR_FLAG(e, f)   (e)->info.name.flag &= (short) ~(f)
+  int flag;
+#define PT_NAME_INFO_IS_FLAGED(e, f)    ((e)->info.name.flag & (int) (f))
+#define PT_NAME_INFO_SET_FLAG(e, f)     (e)->info.name.flag |= (int) (f)
+#define PT_NAME_INFO_CLEAR_FLAG(e, f)   (e)->info.name.flag &= (int) ~(f)
   short location;		/* 0: WHERE; n: join condition of n-th FROM */
   short tag_click_counter;	/* 0: normal name, 1: click counter name */
   PT_NODE *indx_key_limit;	/* key limits for index name */

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -2768,22 +2768,22 @@ struct pt_name_info
   unsigned short correlation_level;	/* for correlated attributes */
   char hidden_column;		/* used for updates and deletes for the class OID column */
 
-#define PT_NAME_INFO_DOT_SPEC        1	/* x, y of x.y.z */
-#define PT_NAME_INFO_DOT_NAME        2	/* z of x.y.z */
-#define PT_NAME_INFO_STAR            4	/* * */
-#define PT_NAME_INFO_DOT_STAR        8	/* classname.* */
-#define PT_NAME_INFO_CONSTANT       16
-#define PT_NAME_INFO_EXTERNAL       32	/* in case of TEXT type at attr definition or attr.object at attr description */
-#define PT_NAME_INFO_DESC           64	/* DESC on an index column name */
-#define PT_NAME_INFO_FILL_DEFAULT  128	/* whether default_value should be filled in */
-#define PT_NAME_INFO_GENERATED_OID 256	/* set when a PT_NAME node that maps to an OID is generated internally for
-					 * statement processing and execution */
-#define PT_NAME_ALLOW_REUSABLE_OID 512	/* ignore the REUSABLE_OID restrictions for this name */
-#define PT_NAME_GENERATED_DERIVED_SPEC 1024	/* attribute generated from derived spec */
-#define PT_NAME_FOR_UPDATE	   2048	/* Table name in FOR UPDATE clause */
-#define PT_NAME_DEFAULTF_ACCEPTS   4096	/* name of table/column that default function accepts: real table's, cte's */
-#define PT_NAME_INFO_USER_SPECIFIED 8192	/* resolved_name is added to original_name to make user_specified_name. */
-#define PT_NAME_INFO_SERVER_SPECIFIED 16384	/* server name is specified for dblink */
+#define PT_NAME_INFO_DOT_SPEC        0x1	/* x, y of x.y.z */
+#define PT_NAME_INFO_DOT_NAME        0x2	/* z of x.y.z */
+#define PT_NAME_INFO_STAR            0x4	/* * */
+#define PT_NAME_INFO_DOT_STAR        0x8	/* classname.* */
+#define PT_NAME_INFO_CONSTANT       0x10
+#define PT_NAME_INFO_EXTERNAL       0x20	/* in case of TEXT type at attr definition or attr.object at attr description */
+#define PT_NAME_INFO_DESC           0x40	/* DESC on an index column name */
+#define PT_NAME_INFO_FILL_DEFAULT  0x80	/* whether default_value should be filled in */
+#define PT_NAME_INFO_GENERATED_OID 0x100	/* set when a PT_NAME node that maps to an OID is generated internally for
+						 * statement processing and execution */
+#define PT_NAME_ALLOW_REUSABLE_OID 0x200	/* ignore the REUSABLE_OID restrictions for this name */
+#define PT_NAME_GENERATED_DERIVED_SPEC 0x400	/* attribute generated from derived spec */
+#define PT_NAME_FOR_UPDATE	   0x800	/* Table name in FOR UPDATE clause */
+#define PT_NAME_DEFAULTF_ACCEPTS   0x1000	/* name of table/column that default function accepts: real table's, cte's */
+#define PT_NAME_INFO_USER_SPECIFIED 0x2000	/* resolved_name is added to original_name to make user_specified_name. */
+#define PT_NAME_INFO_SERVER_SPECIFIED 0x4000	/* server name is specified for dblink */
 #define PT_NAME_INFO_CORRELATED 0x8000	/* correlated attr */
 
   int flag;

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -2768,28 +2768,27 @@ struct pt_name_info
   unsigned short correlation_level;	/* for correlated attributes */
   char hidden_column;		/* used for updates and deletes for the class OID column */
 
-#define PT_NAME_INFO_DOT_SPEC        0x1	/* x, y of x.y.z */
-#define PT_NAME_INFO_DOT_NAME        0x2	/* z of x.y.z */
-#define PT_NAME_INFO_STAR            0x4	/* * */
-#define PT_NAME_INFO_DOT_STAR        0x8	/* classname.* */
-#define PT_NAME_INFO_CONSTANT       0x10
-#define PT_NAME_INFO_EXTERNAL       0x20	/* in case of TEXT type at attr definition or attr.object at attr description */
-#define PT_NAME_INFO_DESC           0x40	/* DESC on an index column name */
-#define PT_NAME_INFO_FILL_DEFAULT  0x80	/* whether default_value should be filled in */
-#define PT_NAME_INFO_GENERATED_OID 0x100	/* set when a PT_NAME node that maps to an OID is generated internally for
-						 * statement processing and execution */
-#define PT_NAME_ALLOW_REUSABLE_OID 0x200	/* ignore the REUSABLE_OID restrictions for this name */
-#define PT_NAME_GENERATED_DERIVED_SPEC 0x400	/* attribute generated from derived spec */
-#define PT_NAME_FOR_UPDATE	   0x800	/* Table name in FOR UPDATE clause */
-#define PT_NAME_DEFAULTF_ACCEPTS   0x1000	/* name of table/column that default function accepts: real table's, cte's */
-#define PT_NAME_INFO_USER_SPECIFIED 0x2000	/* resolved_name is added to original_name to make user_specified_name. */
-#define PT_NAME_INFO_SERVER_SPECIFIED 0x4000	/* server name is specified for dblink */
-#define PT_NAME_INFO_CORRELATED 0x8000	/* correlated attr */
+#define PT_NAME_INFO_DOT_SPEC        1	/* x, y of x.y.z */
+#define PT_NAME_INFO_DOT_NAME        2	/* z of x.y.z */
+#define PT_NAME_INFO_STAR            4	/* * */
+#define PT_NAME_INFO_DOT_STAR        8	/* classname.* */
+#define PT_NAME_INFO_CONSTANT       16
+#define PT_NAME_INFO_EXTERNAL       32	/* in case of TEXT type at attr definition or attr.object at attr description */
+#define PT_NAME_INFO_DESC           64	/* DESC on an index column name */
+#define PT_NAME_INFO_FILL_DEFAULT  128	/* whether default_value should be filled in */
+#define PT_NAME_INFO_GENERATED_OID 256	/* set when a PT_NAME node that maps to an OID is generated internally for
+					 * statement processing and execution */
+#define PT_NAME_ALLOW_REUSABLE_OID 512	/* ignore the REUSABLE_OID restrictions for this name */
+#define PT_NAME_GENERATED_DERIVED_SPEC 1024	/* attribute generated from derived spec */
+#define PT_NAME_FOR_UPDATE	   2048	/* Table name in FOR UPDATE clause */
+#define PT_NAME_DEFAULTF_ACCEPTS   4096	/* name of table/column that default function accepts: real table's, cte's */
+#define PT_NAME_INFO_USER_SPECIFIED 8192	/* resolved_name is added to original_name to make user_specified_name. */
+#define PT_NAME_INFO_SERVER_SPECIFIED 16384	/* server name is specified for dblink */
 
-  int flag;
-#define PT_NAME_INFO_IS_FLAGED(e, f)    ((e)->info.name.flag & (int) (f))
-#define PT_NAME_INFO_SET_FLAG(e, f)     (e)->info.name.flag |= (int) (f)
-#define PT_NAME_INFO_CLEAR_FLAG(e, f)   (e)->info.name.flag &= (int) ~(f)
+  short flag;
+#define PT_NAME_INFO_IS_FLAGED(e, f)    ((e)->info.name.flag & (short) (f))
+#define PT_NAME_INFO_SET_FLAG(e, f)     (e)->info.name.flag |= (short) (f)
+#define PT_NAME_INFO_CLEAR_FLAG(e, f)   (e)->info.name.flag &= (short) ~(f)
   short location;		/* 0: WHERE; n: join condition of n-th FROM */
   short tag_click_counter;	/* 0: normal name, 1: click counter name */
   PT_NODE *indx_key_limit;	/* key limits for index name */

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -4944,8 +4944,9 @@ mq_rewrite_aggregate_as_derived (PARSER_CONTEXT * parser, PT_NODE * agg_sel)
    * Therefore, the NO_MERGE hint is not moved to the derived subquery. 
    * Additionally, if the subquery has the QUERY_CACHE hint, it should not be merged, so it is treated together with the NO_MERGE hint.
    * All hints except for NO_MERGE and QUERY_CACHE are moved to the derived subquery. */
-  derived->info.query.q.select.hint = agg_sel->info.query.q.select.hint & ~(PT_HINT_NO_MERGE | PT_HINT_QUERY_CACHE);
-  agg_sel->info.query.q.select.hint &= (PT_HINT_NO_MERGE | PT_HINT_QUERY_CACHE);
+  derived->info.query.q.select.hint =
+    agg_sel->info.query.q.select.hint & ~(PT_HINT_NO_MERGE | PT_HINT_QUERY_CACHE | PT_HINT_NO_SUBQUERY_CACHE);
+  agg_sel->info.query.q.select.hint &= (PT_HINT_NO_MERGE | PT_HINT_QUERY_CACHE | PT_HINT_NO_SUBQUERY_CACHE);
 
   derived->info.query.q.select.leading = agg_sel->info.query.q.select.leading;
   agg_sel->info.query.q.select.leading = NULL;

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -10126,7 +10126,6 @@ pt_attribute_to_regu (PARSER_CONTEXT * parser, PT_NODE * attr)
 	      /* The attribute is correlated variable. Find it in an enclosing scope(s). Note that this subquery has
 	       * also just been determined to be a correlated subquery. */
 	      REGU_VARIABLE_SET_FLAG (regu, REGU_VARIABLE_CORRELATED);
-	      PT_NAME_INFO_SET_FLAG (attr, PT_NAME_INFO_CORRELATED);
 	      if (symbols->stack == NULL)
 		{
 		  if (!pt_has_error (parser))

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -27648,6 +27648,7 @@ pt_make_sq_cache_key_struct (QPROC_DB_VALUE_LIST key_struct, void *p, int type)
 	    {
 	      if (!regu_var_list_p)
 		{
+		  assert (false);
 		  return ER_FAILED;
 		}
 	      regu_src = &regu_var_list_p->value;

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -636,8 +636,7 @@ static int pt_make_sq_cache_key_struct (QPROC_DB_VALUE_LIST key_struct, void *p,
 static PT_NODE *pt_check_corr_subquery_not_cachable_expr (PARSER_CONTEXT * parser, PT_NODE * node, void *arg,
 							  int *continue_walk);
 static bool pt_check_derived_column_correlated (PARSER_CONTEXT * parser, PT_NODE * attr, TABLE_INFO * table_info);
-static PT_NODE *pt_is_correlated_name_node (PARSER_CONTEXT * parser, PT_NODE * tree, void *arg,
-						     int *continue_walk);
+static PT_NODE *pt_is_correlated_name_node (PARSER_CONTEXT * parser, PT_NODE * tree, void *arg, int *continue_walk);
 
 static void
 pt_init_xasl_supp_info ()

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -10125,6 +10125,7 @@ pt_attribute_to_regu (PARSER_CONTEXT * parser, PT_NODE * attr)
 	    {
 	      /* The attribute is correlated variable. Find it in an enclosing scope(s). Note that this subquery has
 	       * also just been determined to be a correlated subquery. */
+	      REGU_VARIABLE_SET_FLAG (regu, REGU_VARIABLE_CORRELATED);
 	      if (symbols->stack == NULL)
 		{
 		  if (!pt_has_error (parser))
@@ -27436,6 +27437,7 @@ pt_make_sq_cache_key_struct (QPROC_DB_VALUE_LIST key_struct, void *p, int type)
   ACCESS_SPEC_TYPE *spec;
   PRED_EXPR *pred_src;
   REGU_VARIABLE *regu_src;
+  REGU_VARIABLE_LIST regu_var_list_p;
   if (!p)
     {
       return 0;
@@ -27546,6 +27548,28 @@ pt_make_sq_cache_key_struct (QPROC_DB_VALUE_LIST key_struct, void *p, int type)
 	      cnt += ret;
 	    }
 	}
+      if (xasl_src->outptr_list)
+	{
+	  regu_var_list_p = xasl_src->outptr_list->valptrp;
+	  for (i = 0; i < xasl_src->outptr_list->valptr_cnt; i++)
+	    {
+	      if (!regu_var_list_p)
+		{
+		  return ER_FAILED;
+		}
+	      regu_src = &regu_var_list_p->value;
+	      ret = pt_make_sq_cache_key_struct (key_struct, (void *) regu_src, SQ_TYPE_REGU_VAR);
+	      if (ret == ER_FAILED)
+		{
+		  return ER_FAILED;
+		}
+	      else
+		{
+		  cnt += ret;
+		}
+	      regu_var_list_p = regu_var_list_p->next;
+	    }
+	}
       break;
     case SQ_TYPE_PRED:
       pred_src = (PRED_EXPR *) p;
@@ -27614,6 +27638,10 @@ pt_make_sq_cache_key_struct (QPROC_DB_VALUE_LIST key_struct, void *p, int type)
       switch (regu_src->type)
 	{
 	case TYPE_CONSTANT:
+	  if (!REGU_VARIABLE_IS_FLAGED (regu_src, REGU_VARIABLE_CORRELATED))
+	    {
+	      break;
+	    }
 	  ret = pt_make_sq_cache_key_struct (key_struct, (void *) regu_src->value.dbvalptr, SQ_TYPE_DBVAL);
 	  if (ret == ER_FAILED)
 	    {

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -27572,9 +27572,11 @@ pt_make_sq_cache_key_struct (QPROC_DB_VALUE_LIST key_struct, void *p, int type)
 	      regu_var_list_p = regu_var_list_p->next;
 	    }
 	}
-      if (xasl_src->type == BUILDVALUE_PROC)
+      if (xasl_src->type == BUILDVALUE_PROC || xasl_src->type == BUILDLIST_PROC)
 	{
-	  AGGREGATE_TYPE *agg_list = xasl_src->proc.buildvalue.agg_list;
+	  AGGREGATE_TYPE *agg_list =
+	    (xasl_src->type ==
+	     BUILDVALUE_PROC) ? xasl_src->proc.buildvalue.agg_list : xasl_src->proc.buildlist.g_agg_list;
 	  while (agg_list)
 	    {
 	      regu_var_list_p = agg_list->operands;

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -9960,16 +9960,13 @@ pt_to_regu_reserved_name (PARSER_CONTEXT * parser, PT_NODE * attr)
 }
 
 /*
- * pt_check_correlated_subquery_exists () - Checks if a parse tree contains a correlated subquery.
+ * pt_check_correlated_subquery_exists () - Checks if a parse tree contains a PT_NAME node with the PT_NAME_INFO_CORRELATED flag.
  *
  * return           : The same parse tree node.
  * parser (in)      : Parser context.
  * node (in)        : Current parse tree node being examined.
- * arg (in/out)     : Pointer to a bool flag; set to true if a correlated subquery is found.
- * continue_walk (out) : Control flag for tree traversal; set to PT_STOP_WALK if a correlated subquery is found.
- * 
- * NOTE: This function is used during tree traversal to identify the presence of correlated subqueries.
- * If a correlated column is detected, it sets the flag and stops further traversal.
+ * arg (in/out)     : Pointer to a bool flag; set to true if a correlated PT_NAME node is found.
+ * continue_walk (out) : Control flag for tree traversal; set to PT_STOP_WALK if such a node is found.
  */
 
 static PT_NODE *

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -9982,9 +9982,9 @@ pt_check_is_cachable_regu_variable (PARSER_CONTEXT * parser, PT_NODE * attr, TAB
   PT_NODE *derived_table;
   int attr_index, i;
   PT_NODE *cur_node;
-  bool cachable = true, exists = false;
+  bool cachable = true, exists = false, found = false;
 
-  if (!class_spec->info.spec.derived_table)
+  if (!class_spec->info.spec.derived_table || class_spec->info.spec.derived_table->node_type != PT_SELECT)
     {
       return true;
     }
@@ -10003,8 +10003,14 @@ pt_check_is_cachable_regu_variable (PARSER_CONTEXT * parser, PT_NODE * attr, TAB
     {
       if (pt_str_compare (cur_node->info.name.original, attr->info.name.original, CASE_INSENSITIVE) == 0)
 	{
+	  found = true;
 	  break;
 	}
+    }
+
+  if (!found)
+    {
+      return true;
     }
 
   for (cur_node = derived_table->info.query.q.select.list, i = 0; cur_node; cur_node = cur_node->next, i++)

--- a/src/query/regu_var.hpp
+++ b/src/query/regu_var.hpp
@@ -166,7 +166,8 @@ const int REGU_VARIABLE_FETCH_NOT_CONST = 0x80;	/* is not constant */
 const int REGU_VARIABLE_CLEAR_AT_CLONE_DECACHE = 0x100;	/* clears regu variable at clone decache */
 const int REGU_VARIABLE_UPD_INS_LIST = 0x200;	/* for update or insert query */
 const int REGU_VARIABLE_STRICT_TYPE_CAST = 0x400;/* for update or insert query */
-const int REGU_VARIABLE_CORRELATED = 0x800; /* for correlated scalar subquery */
+const int REGU_VARIABLE_CORRELATED = 0x800; /* for correleated scalar subquery cache */
+const int REGU_VARIABLE_DERIVED_COL_CORRELATED = 0x1000; /* for not caching in correleated scalar subquery cache */
 
 class regu_variable_node
 {

--- a/src/query/regu_var.hpp
+++ b/src/query/regu_var.hpp
@@ -166,6 +166,7 @@ const int REGU_VARIABLE_FETCH_NOT_CONST = 0x80;	/* is not constant */
 const int REGU_VARIABLE_CLEAR_AT_CLONE_DECACHE = 0x100;	/* clears regu variable at clone decache */
 const int REGU_VARIABLE_UPD_INS_LIST = 0x200;	/* for update or insert query */
 const int REGU_VARIABLE_STRICT_TYPE_CAST = 0x400;/* for update or insert query */
+const int REGU_VARIABLE_CORRELATED = 0x800; /* for correlated scalar subquery */
 
 class regu_variable_node
 {

--- a/src/query/regu_var.hpp
+++ b/src/query/regu_var.hpp
@@ -166,8 +166,7 @@ const int REGU_VARIABLE_FETCH_NOT_CONST = 0x80;	/* is not constant */
 const int REGU_VARIABLE_CLEAR_AT_CLONE_DECACHE = 0x100;	/* clears regu variable at clone decache */
 const int REGU_VARIABLE_UPD_INS_LIST = 0x200;	/* for update or insert query */
 const int REGU_VARIABLE_STRICT_TYPE_CAST = 0x400;/* for update or insert query */
-const int REGU_VARIABLE_CORRELATED = 0x800; /* for correleated scalar subquery cache */
-const int REGU_VARIABLE_DERIVED_COL_CORRELATED = 0x1000; /* for not caching in correleated scalar subquery cache */
+const int REGU_VARIABLE_CORRELATED = 0x800; /* for correlated scalar subquery cache */
 
 class regu_variable_node
 {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25680

select 절에서 외부 테이블 컬럼을 포함한 correlated subquery를 사용할 때, subquery cache가 해당 컬럼을 키로 사용하지 않아 캐싱이 제대로 이루어지지 않습니다. 이로 인해 예상되는 miss 상황에서도 cache hit가 발생하는 문제가 확인되었습니다. 이를 해결하기 위해 xasl outptr_list에 포함된 regu_var도 캐싱 키에 포함시키도록 수정했습니다. 또한 pred와는 다르게 xasl outptr_list는 조인 시 outer 테이블을 constant regu var로 사용하기 때문에 외부 컬럼이 아니더라도 캐시 키로 잘못 사용될 가능성이 있어, subquery 내부 테이블 중 스펙에 해당하는 테이블이 없는 경우에만 캐싱하도록 코드를 수정하였습니다.

When using a correlated subquery that includes columns from an outer table in the select clause, the subquery cache does not use those columns as keys, resulting in improper caching. Consequently, cache hits occur even in situations where cache misses are expected. To address this, we modified the code to include regu_var from xasl outptr_list as part of the caching key. Additionally, unlike pred, xasl outptr_list uses the outer table as a constant regu_var during joins, which could mistakenly utilize even non-outer columns as cache keys. Therefore, we adjusted the code to only enable caching when there is no table from the subquery that matches the specification.
