### PR TITLE
[CBRD-25681] There is an issue where, when selecting an SP, if there is even a single result in the _db_auth catalog, a user without permissions can still execute the SP.

### DIFF
--- a/src/sp/jsp_cl.cpp
+++ b/src/sp/jsp_cl.cpp
@@ -2067,15 +2067,16 @@ check_execute_authorization_by_query (const MOP sp_obj)
 {
   int error = NO_ERROR, save;
   const char *query = "SELECT [au] FROM " CT_CLASSAUTH_NAME
-		      " [au] WHERE [object_type] = ? and [auth_type] = 'EXECUTE' and [object_of] = ?";
+		      " [au] WHERE [object_type] = ? and [auth_type] = 'EXECUTE' and [object_of] = ? and [grantee] = ?";
   DB_QUERY_RESULT *result = NULL;
   DB_SESSION *session = NULL;
-  DB_VALUE val[2];
+  DB_VALUE val[3];
   int stmt_id;
   int cnt = 0;
 
   db_make_null (&val[0]);
   db_make_null (&val[1]);
+  db_make_null (&val[2]);
 
   /* Disable the checking for internal authorization object access */
   AU_DISABLE (save);
@@ -2102,8 +2103,9 @@ check_execute_authorization_by_query (const MOP sp_obj)
 
   db_make_int (&val[0], (int) DB_OBJECT_PROCEDURE);
   db_make_object (&val[1], sp_obj);
+  db_make_object (&val[2], Au_user);
 
-  error = db_push_values (session, 2, val);
+  error = db_push_values (session, 3, val);
   if (error != NO_ERROR)
     {
       goto release;
@@ -2124,6 +2126,7 @@ release:
     }
   pr_clear_value (&val[0]);
   pr_clear_value (&val[1]);
+  pr_clear_value (&val[2]);
 
   AU_ENABLE (save);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25681

Purpose

_db_auth 카탈로그 조회 결과에 1건이라도 존재할 경우, 권한이 없는 사용자도 SP를 실행할 수 있는 문제입니다.

Repro
```sql
call login('dba', '') on class db_user;
create user ungranted_user;
create user granted_user;

CREATE FUNCTION hello(s STRING) return string as language java name 
'SpTest.Length_STR(java.lang.String)';

grant execute on procedure dba.hello to granted_user;

call login('ungranted_user', '') on class db_user;
select dba.hello('a');
```

Expected
```
ERROR: EXECUTE authorization failure.
```

Actual
```
  hello('a')          
======================
  '1'     
```

Implementation

N/A

Remarks

N/A