### PR TITLE
[CBRD-25683] Fix the issue of duplicate error messages being displayed when a stored procedure execution fails.

### DIFF
--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -11050,7 +11050,7 @@ error:
     else
       {
 	std::string err_msg = executor.get_stack ()->get_error_message ();
-	if (err_msg.empty ())
+	if (err_msg.empty () && req_error != ER_SP_EXECUTE_ERROR)
 	  {
 	    err_msg.assign (er_msg ());
 	  }

--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -11018,7 +11018,14 @@ error:
       packing_unpacker unpacker (data_reply, (size_t) data_reply_size);
       int error_code;
       std::string error_msg;
-      unpacker.unpack_all (error_code, error_msg);
+      if (req_error != ER_SP_EXECUTE_ERROR)
+	{
+	  unpacker.unpack_all (error_code, error_msg);
+	}
+      else
+	{
+	  error_code = req_error;
+	}
       cubmethod::handle_method_error (error_code, error_msg);
     }
 

--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -11018,14 +11018,7 @@ error:
       packing_unpacker unpacker (data_reply, (size_t) data_reply_size);
       int error_code;
       std::string error_msg;
-      if (req_error != ER_SP_EXECUTE_ERROR)
-	{
-	  unpacker.unpack_all (error_code, error_msg);
-	}
-      else
-	{
-	  error_code = req_error;
-	}
+      unpacker.unpack_all (error_code, error_msg);
       cubmethod::handle_method_error (error_code, error_msg);
     }
 

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -10540,7 +10540,7 @@ spl_call (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen)
   else
     {
       std::string err_msg = executor.get_stack ()->get_error_message ();
-      if (err_msg.empty ())
+      if (err_msg.empty () && error_code != ER_SP_EXECUTE_ERROR)
 	{
 	  err_msg.assign (er_msg ());
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25683

### Purpose

ci/circleci: test_plcsql 의 실패한 TC를 확인 중 발견하였습니다.
SP 실행 실패 시 중복된 에러 메시지가 출력되는 문제입니다. (관련 TC 개수 : 20개)

Repro
```sql
create or replace procedure t_TIME_DATETIME(sql_type string, procedure_type string, param DATETIME ) as begin
dbms_output.put_line('sql_type = ' ||sql_type ||', procedure_type = '||procedure_type||', current_value = '|| param );
end;

call t_TIME_DATETIME('TIME', 'DATETIME', TIME'13:15:45' ) ;
```

Expected
```
Error:-889
Stored procedure execute error: 
```

Actual
```
Error:-889
Stored procedure execute error: Stored procedure execute error:
```

### Implementation
err_msg.assign(er_msg()) 함수에서 err_msg를 가져오기 위한 조건을 추가 합니다.

**AS-IS**
```c
void 
spl_call (...)
{
...
  if (err_msg.empty ())
    {
	  err_msg.assign (er_msg ());
    }
...
}
```

**TO-BE**
1. SA 모드
```c
int
pl_call (...)
{
...
  if (err_msg.empty () && req_error != ER_SP_EXECUTE_ERROR)
    {
	  err_msg.assign (er_msg ());
    }
...
}
```

2. CS 모드
```c
void 
spl_call (...)
{
...
  if (err_msg.empty () && error_code != ER_SP_EXECUTE_ERROR)
    {
	  err_msg.assign (er_msg ());
    }
...
}
```

### Remarks
코드 분석
1. executor.execute(ret_value) 함수 내부에서, 쿼리 실행이 실패하여 ER_SP_EXECUTE_ERROR(-889) 에러 코드가 설정됩니다.
2. err_msg.assign(er_msg()) 함수에서 ER_SP_EXECUTE_ERROR(-889)의 에러 메시지를 가져옵니다.
3. er_set(.., ER_SP_EXECUTE_ERROR, 1, err_msg)에서 에러 메시지가 중복으로 출력됩니다.

**1. SA 모드**

```c
/* call stack
do_call_method
-> jsp_call_stored_procedure
-> pl_call
*/
int
pl_call (...)
{
...
if (req_error == NO_ERROR)
  {
    req_error = executor.execute (ret_value); // 1. ER_SP_EXECUTE_ERROR(-889) 에러 코드 설정
  }
...
else
  {
    std::string err_msg = executor.get_stack ()->get_error_message ();
	if (err_msg.empty ())
	  {
	    err_msg.assign (er_msg ());  // 2. ER_SP_EXECUTE_ERROR(-889)의 에러 메세지를 가져옴
	  }
	
	if (req_error != ER_SM_INVALID_METHOD_ENV)
	  {
	    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_EXECUTE_ERROR, 1, err_msg); // 3. 중복으로 ER_SP_EXECUTE_ERROR(-889) 에러 메세지를 출력하게 됨
	  }
...
}
```

**2. CS 모드**
```c
/* call stack
--cas side
jsp_call_stored_procedure
-> pl_call
-> net_client_request_method_callback
-> css_receive_data_from_server

--server side
...
-> css_server_task::execute
-> css_Server_request_handler
-> spl_call
*/
void 
spl_call (...)
{
...
  cubpl::executor executor (sig);
  error_code = executor.fetch_args_peek (ref_args); // 1. ER_SP_EXECUTE_ERROR(-889) 에러 코드 설정
...
  if (error_code == NO_ERROR)
  ...
  else
    {
	  std::string err_msg = executor.get_stack ()->get_error_message ();
      if (err_msg.empty ())
	    {
	      err_msg.assign (er_msg ());  // 2. ER_SP_EXECUTE_ERROR(-889)의 에러 메세지를 가져옴
	    }

      if (error_code != ER_SM_INVALID_METHOD_ENV)
	    {
	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_EXECUTE_ERROR, 1, err_msg); // 3. 중복으로 ER_SP_EXECUTE_ERROR(-889) 에러 메세지를 출력하게 됨
	    }
	}
...
}
```