### PR TITLE
[CBRD-25682] keep precision and scale of the numeric type when it is a return type specified by %TYPE

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/TypeSpecPercent.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/TypeSpecPercent.java
@@ -42,13 +42,12 @@ public class TypeSpecPercent extends TypeSpec {
 
     public final String table;
     public final String column;
-    public final boolean forParameterOrReturn;
+    public final int typeVisitMode;
 
-    public TypeSpecPercent(
-            ParserRuleContext ctx, String table, String column, boolean forParameterOrReturn) {
+    public TypeSpecPercent(ParserRuleContext ctx, String table, String column, int typeVisitMode) {
         super(ctx, null); // null: unknown yet
         this.table = table;
         this.column = column;
-        this.forParameterOrReturn = forParameterOrReturn;
+        this.typeVisitMode = typeVisitMode;
     }
 }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
@@ -30,6 +30,7 @@
 
 package com.cubrid.plcsql.compiler.visitor;
 
+import com.cubrid.jsp.Server;
 import com.cubrid.jsp.data.ColumnInfo;
 import com.cubrid.plcsql.compiler.Coercion;
 import com.cubrid.plcsql.compiler.CoercionScheme;
@@ -641,6 +642,10 @@ public class TypeChecker extends AstVisitor<Type> {
 
             return ret;
         } else {
+            Server.log(
+                    String.format(
+                            "semantic check API returned an error (%d, %s) for '%s'",
+                            ss.errCode, ss.errMsg, sql));
             throw new SemanticError(
                     Misc.getLineColumnOf(node.ctx), // s235
                     "function "


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25682

저장 함수의 리턴 타입이 %TYPE 으로 지정된 NUMERIC 타입일 때 
인자와 리턴 타입에서 precision과 scale 을 무시하는 다른 경우와 달리 
예외적으로 precision과 scale 을 유지하도록 수정했습니다. 
(오라클 호환)
