### PR TITLE
[CBRD-25640] [Regression] restoredb hang when it try to restore to the saved point.

### DIFF
--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -2534,7 +2534,8 @@ log_is_page_of_record_broken (THREAD_ENTRY * thread_p, const LOG_LSA * log_lsa,
   /* TODO - Do we need to handle NULL fwd_log_lsa? */
   if (!LSA_ISNULL (&fwd_log_lsa))
     {
-      if (LSA_GE (log_lsa, &fwd_log_lsa) || LSA_GT (&fwd_log_lsa, &log_Gl.hdr.eof_lsa))
+      if (LSA_GE (log_lsa, &fwd_log_lsa)
+	  || (!LSA_ISNULL (&log_Gl.hdr.eof_lsa) && LSA_GT (&fwd_log_lsa, &log_Gl.hdr.eof_lsa)))
 	{
 	  // check fwd_log_lsa value if it is corrupted or not
 	  is_log_page_broken = true;

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -2534,6 +2534,7 @@ log_is_page_of_record_broken (THREAD_ENTRY * thread_p, const LOG_LSA * log_lsa,
   /* TODO - Do we need to handle NULL fwd_log_lsa? */
   if (!LSA_ISNULL (&fwd_log_lsa))
     {
+      /* log_Gl.hdr.eof_lsa can have a NULL_LSA value if recovery is started without an active log volume. Its value will be recovered during the log_recovery_analysis process. */
       if (LSA_GE (log_lsa, &fwd_log_lsa)
 	  || (!LSA_ISNULL (&log_Gl.hdr.eof_lsa) && LSA_GT (&fwd_log_lsa, &log_Gl.hdr.eof_lsa)))
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25640

**Purpose**
* shell/_06_issues/_19_2h/cbrd_23119/cases/cbrd_23119.sh 회귀 이슈 수정
* tc 및 qahome에서 수행 결과는 이슈에 기술된 링크 참고

**Implementation (with analysis)**
* 분석
  * restoredb의 recovery 시작 단계에서 active log 볼륨이 존재하지 않아 문제가 발생하는 특이 케이스
  * active log 볼륨의 마지막 로그 위치를 의미하는 log_Gl.hdr.eof_lsa값은 절대 NULL_LSA일 수 없음; 그러나 이 정보는 active log 볼륨 헤더에서 읽어와야 하나 active log 볼륨이 존재하지 않으므로, NULL_LSA로 초기화된 상태로 recovery 시작 됨
  * tc 기준 restoredb의 recovery 단계에서 active log 볼륨이 존재하지 않는 이유
    * backupdb 수행 시 db23118_lgar000까지 포함되며, 다음 archive log 볼륨 번호를 의미하는 log_Gl.hdr.nxarv_num는 1; 당연히 db23118_lgat 역시 포함됨
    * backupdb 완료 이후에 수행된 트랜잭션에 의해 db23118_lgar008까지 archive log 볼륨 생성 됨
    * tc에서 active log 볼륨 삭제 함
    * restoredb 수행
      * backup 볼륨에 백업된 active log 볼륨을 db23118_lgat_000_tmp 명으로 복구
      * db23118_lgat_000_tmp에서 active log 볼륨 헤더를 읽음; 이 때 log_Gl.hdr.nxarv_num는 1이며, 이 정보를 이용해서 db23118_lgar001가 존재하는지 확인; 이미 존재 함
      * 이 경우 복구된 active log 볼륨이 backupdb 수행된 이후에 이미 archive log 볼륨이 되었다고 판단
      * 이미 archive log 볼륨에 모든 로그가 보관되었기 때문에 복구된 active log 볼륨(db23118_lgat_000_tmp)은 불필요하다고 판단하여 삭제
        * logpb_restore() -> logpb_is_log_active_from_backup_useful() 참고
      * 이에 따라서, restoredb의 recovery 단계에 들어갔을 땐 active log 볼륨이 존재하지 않는 상태가 됨 
  * log_Gl.hdr.eof_lsa는 log_recovery_analysis() 과정에서 정상적으로 복구 됨
* 구현
  *  log_is_page_of_record_broken() 함수를 통해 로그 레코드의 유효성 검사 시 !LSA_ISNULL (&log_Gl.hdr.eof_lsa) 조건 검사 추가하여 NULL_LSA인 경우 조건 검사를 수행하지 않도록 처리

**Remarks**
* N/A