### PR TITLE
[CBRD-25662] remove trailing slash shown in cubrid broker info

### DIFF
--- a/src/broker/broker_filename.c
+++ b/src/broker/broker_filename.c
@@ -384,7 +384,7 @@ make_abs_path (char *dest, const char *subdir, const char *path, size_t dest_len
     {
       if (new_path[path_len] == '/' || new_path[path_len] == '\\')
 	{
-	  new_path [path_len] = '\0';
+	  new_path[path_len] = '\0';
 	}
       else
 	{

--- a/src/broker/broker_filename.c
+++ b/src/broker/broker_filename.c
@@ -350,6 +350,7 @@ make_abs_path (char *dest, const char *subdir, const char *path, size_t dest_len
   int ret = 0;
   char buf[BROKER_PATH_MAX * 4];
   char new_path[BROKER_PATH_MAX * 4];
+  int path_len;
 
   if (path == NULL || path[0] == 0)
     {
@@ -364,7 +365,6 @@ make_abs_path (char *dest, const char *subdir, const char *path, size_t dest_len
     }
   else
     {
-
       snprintf (buf, dest_len, "%s%s%s\\%s", get_cubrid_home (), subdir ? "\\" : "", subdir ? subdir : "", path);
       _fullpath (new_path, buf, dest_len);
     }
@@ -378,6 +378,20 @@ make_abs_path (char *dest, const char *subdir, const char *path, size_t dest_len
       snprintf (new_path, dest_len, "%s%s%s/%s", get_cubrid_home (), subdir ? "/" : "", subdir ? subdir : "", path);
     }
 #endif
+
+  path_len = strlen (new_path) - 1;
+  while (path_len > 0)
+    {
+      if (new_path[path_len] == '/' || new_path[path_len] == '\\')
+	{
+	  new_path [path_len] = '\0';
+	}
+      else
+	{
+	  break;
+	}
+      path_len--;
+    }
 
   if (strlen (new_path) < dest_len)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25662

**Description**
* in addition to
** #5601 
** #5608
* **remove trailing slash** shown in 'cubrid broker info' as follow:
```
 /home/cubrid/log/broker/error_log/ -> /home/cubrid/log/broker/error_log
 /home/cubrid/log/broker/error_log// -> /home/cubrid/log/broker/error_log
 C:\CUBRID\log\brokererror_log\\ -> C:\CUBRID\log\brokererror_log
```

**Remarks**
* changes to pass QA Regression Test (some cases checks directory without trailing '/' but some DIR has it.