### PR TITLE
[CBRD-25687] PL 유틸리티 명령어에 동작 변경에 따른 에러와 메시지 변경

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -475,9 +475,10 @@ if(WITH_LIBTBB STREQUAL "EXTERNAL")
       INSTALL_COMMAND      make -j install
       "${LIBTBB_BYPRODUCTS}"
     )
-    list(APPEND EP_TARGETS ${LIBTBB_TARGET})
-    list(APPEND EP_INCLUDES ${LIBTBB_INCLUDES})
-    list(APPEND EP_LIBS ${LIBTBB_LIBS})
+
+    list(APPEND TBB_TARGETS ${LIBTBB_TARGET})
+    list(APPEND TBB_INCLUDES ${LIBTBB_INCLUDES})
+    list(APPEND TBB_LIBS ${LIBTBB_LIBS})
   endif(UNIX)
 endif()
 
@@ -485,6 +486,15 @@ endif()
 set (EP_TARGETS ${EP_TARGETS} PARENT_SCOPE)
 set (EP_LIBS ${EP_LIBS} PARENT_SCOPE)
 set (EP_INCLUDES ${EP_INCLUDES} PARENT_SCOPE)
+
+# TODO: EP_TARGETS, EP_LIBS, and EP_INCLUDES are currently linked across all targets.
+# However, TBB is only required on the server side and should only be linked to libcubrid.so.
+# To achieve this, TBB has been separated into a distinct list to ensure exclusive linking with libcubrid.so.
+# Going forward, directories and libraries strictly used on the server side should be categorized
+# under the EP_SERVER_XXX section.
+set (TBB_TARGETS ${TBB_TARGETS} PARENT_SCOPE)
+set (TBB_INCLUDES ${TBB_INCLUDES} PARENT_SCOPE)
+set (TBB_LIBS ${TBB_LIBS} PARENT_SCOPE)
 
 # Expose targets for sa - FIXME better solutions
 include (3rdparty_util)

--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -567,11 +567,17 @@ if(WIN32)
   set_target_properties(cubrid PROPERTIES LINK_FLAGS "/DEF:\"${CMAKE_SOURCE_DIR}/win/libcubrid/libcubrid.def\"" LINK_FLAGS_RELEASE "/NODEFAULTLIB:libcmt.lib" LINK_FLAGS_DEBUG "/NODEFAULTLIB:msvcrt.lib")
 endif(WIN32)
 target_include_directories(cubrid PRIVATE ${JAVA_INC} ${EP_INCLUDES} ${FLEX_INCLUDE_DIRS})
+
 if(UNIX)
   target_link_libraries(cubrid LINK_PRIVATE -Wl,-whole-archive ${EP_LIBS} -Wl,-no-whole-archive)
   target_link_libraries(cubrid LINK_PUBLIC ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
   target_link_libraries(cubrid PUBLIC stdc++fs)
   target_link_libraries(cubrid PUBLIC rt)
+
+  # Add TBB
+  target_include_directories(cubrid PUBLIC ${TBB_INCLUDES})
+  target_link_libraries(cubrid LINK_PRIVATE ${TBB_LIBS})
+  add_dependencies(cubrid ${TBB_TARGETS})
 else(UNIX)
   target_link_libraries(cubrid LINK_PRIVATE ${EP_LIBS})
 endif(UNIX)

--- a/pl_engine/pl_server/src/main/antlr/PlcParser.g4
+++ b/pl_engine/pl_server/src/main/antlr/PlcParser.g4
@@ -180,7 +180,6 @@ loop_statement
     | label_declaration? FOR iterator LOOP seq_of_statements END LOOP label_name?          # stmt_for_iter_loop
     | label_declaration? FOR for_cursor LOOP seq_of_statements END LOOP label_name?        # stmt_for_cursor_loop
     | label_declaration? FOR for_static_sql LOOP seq_of_statements END LOOP label_name?    # stmt_for_static_sql_loop
-    | label_declaration? FOR for_dynamic_sql LOOP seq_of_statements END LOOP label_name?   # stmt_for_dynamic_sql_loop
     ;
 
  // actually far more complicated according to the Spec.
@@ -194,10 +193,6 @@ for_cursor
 
 for_static_sql
     : record_name IN LPAREN static_sql RPAREN
-    ;
-
-for_dynamic_sql
-    : record_name IN LPAREN EXECUTE IMMEDIATE dyn_sql restricted_using_clause? RPAREN
     ;
 
 lower_bound

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/BooleanValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/BooleanValue.java
@@ -34,6 +34,11 @@ package com.cubrid.jsp.value;
 import com.cubrid.jsp.exception.TypeMismatchException;
 
 public class BooleanValue extends Value {
+
+    protected String getTypeName() {
+        return TYPE_NAME_BOOLEAN;
+    }
+
     private byte value = 0;
 
     public BooleanValue(boolean b) {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/ByteValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/ByteValue.java
@@ -35,6 +35,11 @@ import com.cubrid.jsp.exception.TypeMismatchException;
 import java.math.BigDecimal;
 
 public class ByteValue extends Value {
+
+    protected String getTypeName() {
+        return TYPE_NAME_BYTE;
+    }
+
     private byte value;
 
     public ByteValue(byte value) {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/DateTimeParser.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/DateTimeParser.java
@@ -269,9 +269,22 @@ public class DateTimeParser {
         }
     }
 
+    private static int getCurrentYear() {
+        ZoneOffset timezone = Server.getSystemParameterTimezone(Server.SYS_PARAM_TIMEZONE);
+        return ZonedDateTime.now(timezone).getYear();
+    }
+
     private static LocalDate parseDateFragment(String s) {
 
         s = s.trim();
+
+        if (s.split("/").length == 2) {
+            // s can be of the form MM/dd (year omitted)
+            s = s + "/" + getCurrentYear();
+        } else if (s.split("-").length == 2) {
+            // s can be of the form MM-dd (year omitted)
+            s = getCurrentYear() + "-" + s;
+        }
 
         int i = 0;
         for (SimpleDateFormat f : dateFormats) {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/DateValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/DateValue.java
@@ -38,6 +38,11 @@ import java.sql.Timestamp;
 import java.util.Calendar;
 
 public class DateValue extends Value {
+
+    protected String getTypeName() {
+        return TYPE_NAME_DATE;
+    }
+
     private Date date;
 
     public DateValue(int year, int mon, int day) throws TypeMismatchException {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/DatetimeValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/DatetimeValue.java
@@ -39,6 +39,11 @@ import java.sql.Timestamp;
 import java.util.Calendar;
 
 public class DatetimeValue extends Value {
+
+    protected String getTypeName() {
+        return TYPE_NAME_DATETIME;
+    }
+
     private Timestamp timestamp;
 
     public DatetimeValue(int year, int mon, int day, int hour, int min, int sec, int msec)

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/DoubleValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/DoubleValue.java
@@ -38,6 +38,11 @@ import java.sql.Time;
 import java.sql.Timestamp;
 
 public class DoubleValue extends Value {
+
+    protected String getTypeName() {
+        return TYPE_NAME_DOUBLE;
+    }
+
     private double value;
 
     public DoubleValue(double value) throws TypeMismatchException {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/FloatValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/FloatValue.java
@@ -38,6 +38,11 @@ import java.sql.Time;
 import java.sql.Timestamp;
 
 public class FloatValue extends Value {
+
+    protected String getTypeName() {
+        return TYPE_NAME_FLOAT;
+    }
+
     private float value;
 
     public FloatValue(float value) throws TypeMismatchException {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/IntValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/IntValue.java
@@ -38,6 +38,11 @@ import java.sql.Time;
 import java.sql.Timestamp;
 
 public class IntValue extends Value {
+
+    protected String getTypeName() {
+        return TYPE_NAME_INT;
+    }
+
     private int value;
 
     public IntValue(int value) {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/LongValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/LongValue.java
@@ -38,6 +38,11 @@ import java.sql.Time;
 import java.sql.Timestamp;
 
 public class LongValue extends Value {
+
+    protected String getTypeName() {
+        return TYPE_NAME_BIGINT;
+    }
+
     private long value;
 
     public LongValue(long value) {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/NullValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/NullValue.java
@@ -41,6 +41,11 @@ import java.sql.Time;
 import java.sql.Timestamp;
 
 public class NullValue extends Value {
+
+    protected String getTypeName() {
+        return TYPE_NAME_NULL;
+    }
+
     public NullValue() {
         super();
     }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/NumericValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/NumericValue.java
@@ -37,6 +37,11 @@ import java.math.BigDecimal;
 import java.sql.Timestamp;
 
 public class NumericValue extends Value {
+
+    protected String getTypeName() {
+        return TYPE_NAME_NUMERIC;
+    }
+
     private BigDecimal value;
 
     public NumericValue(String value) {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/OidValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/OidValue.java
@@ -41,6 +41,11 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 
 public class OidValue extends Value {
+
+    protected String getTypeName() {
+        return TYPE_NAME_OID;
+    }
+
     private SOID oidValue = null;
     private CUBRIDOID oidObject = null;
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/ResultSetValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/ResultSetValue.java
@@ -37,6 +37,11 @@ import com.cubrid.jsp.jdbc.CUBRIDServerSideResultSet;
 import java.sql.ResultSet;
 
 public class ResultSetValue extends Value {
+
+    protected String getTypeName() {
+        return TYPE_NAME_RESULTSET;
+    }
+
     private long queryId;
     private ResultSet rset = null;
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/SetValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/SetValue.java
@@ -39,6 +39,11 @@ import java.sql.Time;
 import java.sql.Timestamp;
 
 public class SetValue extends Value {
+
+    protected String getTypeName() {
+        return TYPE_NAME_SET;
+    }
+
     private Object[] values;
 
     public SetValue(Value[] args) throws TypeMismatchException {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/ShortValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/ShortValue.java
@@ -38,6 +38,11 @@ import java.sql.Time;
 import java.sql.Timestamp;
 
 public class ShortValue extends Value {
+
+    protected String getTypeName() {
+        return TYPE_NAME_SHORT;
+    }
+
     private short value;
 
     public ShortValue(short value) {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/StringValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/StringValue.java
@@ -40,6 +40,10 @@ import java.sql.Timestamp;
 
 public class StringValue extends Value {
 
+    protected String getTypeName() {
+        return TYPE_NAME_STRING;
+    }
+
     private String value;
 
     public StringValue(String value) {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/TimeValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/TimeValue.java
@@ -37,6 +37,11 @@ import java.sql.Time;
 import java.util.Calendar;
 
 public class TimeValue extends Value {
+
+    protected String getTypeName() {
+        return TYPE_NAME_TIME;
+    }
+
     private Time time;
 
     public TimeValue(int hour, int min, int sec) {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/TimestampValue.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/TimestampValue.java
@@ -39,6 +39,11 @@ import java.sql.Timestamp;
 import java.util.Calendar;
 
 public class TimestampValue extends Value {
+
+    protected String getTypeName() {
+        return TYPE_NAME_TIMESTAMP;
+    }
+
     private Timestamp timestamp;
 
     public TimestampValue(int year, int mon, int day, int hour, int min, int sec)

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/Value.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/value/Value.java
@@ -66,31 +66,31 @@ public abstract class Value {
     }
 
     public byte toByte() throws TypeMismatchException {
-        throw new TypeMismatchException();
+        throw new TypeMismatchException(getCastErrMsg(TYPE_NAME_BYTE));
     }
 
     public short toShort() throws TypeMismatchException {
-        throw new TypeMismatchException();
+        throw new TypeMismatchException(getCastErrMsg(TYPE_NAME_SHORT));
     }
 
     public int toInt() throws TypeMismatchException {
-        throw new TypeMismatchException();
+        throw new TypeMismatchException(getCastErrMsg(TYPE_NAME_INT));
     }
 
     public long toLong() throws TypeMismatchException {
-        throw new TypeMismatchException();
+        throw new TypeMismatchException(getCastErrMsg(TYPE_NAME_BIGINT));
     }
 
     public float toFloat() throws TypeMismatchException {
-        throw new TypeMismatchException();
+        throw new TypeMismatchException(getCastErrMsg(TYPE_NAME_FLOAT));
     }
 
     public double toDouble() throws TypeMismatchException {
-        throw new TypeMismatchException();
+        throw new TypeMismatchException(getCastErrMsg(TYPE_NAME_DOUBLE));
     }
 
     public Byte toByteObject() throws TypeMismatchException {
-        throw new TypeMismatchException();
+        throw new TypeMismatchException(getCastErrMsg(TYPE_NAME_BYTE));
     }
 
     public byte[] toByteArray() throws TypeMismatchException {
@@ -102,7 +102,7 @@ public abstract class Value {
     }
 
     public Short toShortObject() throws TypeMismatchException {
-        throw new TypeMismatchException();
+        throw new TypeMismatchException(getCastErrMsg(TYPE_NAME_SHORT));
     }
 
     public short[] toShortArray() throws TypeMismatchException {
@@ -114,7 +114,7 @@ public abstract class Value {
     }
 
     public Integer toIntegerObject() throws TypeMismatchException {
-        throw new TypeMismatchException();
+        throw new TypeMismatchException(getCastErrMsg(TYPE_NAME_INT));
     }
 
     public int[] toIntegerArray() throws TypeMismatchException {
@@ -126,7 +126,7 @@ public abstract class Value {
     }
 
     public Long toLongObject() throws TypeMismatchException {
-        throw new TypeMismatchException();
+        throw new TypeMismatchException(getCastErrMsg(TYPE_NAME_BIGINT));
     }
 
     public long[] toLongArray() throws TypeMismatchException {
@@ -138,7 +138,7 @@ public abstract class Value {
     }
 
     public Float toFloatObject() throws TypeMismatchException {
-        throw new TypeMismatchException();
+        throw new TypeMismatchException(getCastErrMsg(TYPE_NAME_FLOAT));
     }
 
     public float[] toFloatArray() throws TypeMismatchException {
@@ -150,7 +150,7 @@ public abstract class Value {
     }
 
     public Double toDoubleObject() throws TypeMismatchException {
-        throw new TypeMismatchException();
+        throw new TypeMismatchException(getCastErrMsg(TYPE_NAME_DOUBLE));
     }
 
     public double[] toDoubleArray() throws TypeMismatchException {
@@ -162,7 +162,7 @@ public abstract class Value {
     }
 
     public Object toObject() throws TypeMismatchException {
-        throw new TypeMismatchException();
+        throw new TypeMismatchException(getCastErrMsg(TYPE_NAME_OBJECT));
     }
 
     public Object[] toObjectArray() throws TypeMismatchException {
@@ -174,7 +174,7 @@ public abstract class Value {
     }
 
     public Date toDate() throws TypeMismatchException {
-        throw new TypeMismatchException();
+        throw new TypeMismatchException(getCastErrMsg(TYPE_NAME_DATE));
     }
 
     public Date[] toDateArray() throws TypeMismatchException {
@@ -186,7 +186,7 @@ public abstract class Value {
     }
 
     public Time toTime() throws TypeMismatchException {
-        throw new TypeMismatchException();
+        throw new TypeMismatchException(getCastErrMsg(TYPE_NAME_TIME));
     }
 
     public Time[] toTimeArray() throws TypeMismatchException {
@@ -198,7 +198,7 @@ public abstract class Value {
     }
 
     public Timestamp toTimestamp() throws TypeMismatchException {
-        throw new TypeMismatchException();
+        throw new TypeMismatchException(getCastErrMsg(TYPE_NAME_TIMESTAMP));
     }
 
     public Timestamp[] toTimestampArray() throws TypeMismatchException {
@@ -210,7 +210,7 @@ public abstract class Value {
     }
 
     public Timestamp toDatetime() throws TypeMismatchException {
-        throw new TypeMismatchException();
+        throw new TypeMismatchException(getCastErrMsg(TYPE_NAME_DATETIME));
     }
 
     public Timestamp[] toDatetimeArray() throws TypeMismatchException {
@@ -222,7 +222,7 @@ public abstract class Value {
     }
 
     public BigDecimal toBigDecimal() throws TypeMismatchException {
-        throw new TypeMismatchException();
+        throw new TypeMismatchException(getCastErrMsg(TYPE_NAME_NUMERIC));
     }
 
     public BigDecimal[] toBigDecimalArray() throws TypeMismatchException {
@@ -290,7 +290,7 @@ public abstract class Value {
     }
 
     public CUBRIDOID toOid() throws TypeMismatchException {
-        throw new TypeMismatchException();
+        throw new TypeMismatchException(getCastErrMsg(TYPE_NAME_OID));
     }
 
     public CUBRIDOID[] toOidArray() throws TypeMismatchException {
@@ -302,7 +302,7 @@ public abstract class Value {
     }
 
     public ResultSet toResultSet(SUConnection ucon) throws TypeMismatchException {
-        throw new TypeMismatchException();
+        throw new TypeMismatchException(getCastErrMsg(TYPE_NAME_RESULTSET));
     }
 
     public ResultSet[] toResultSetArray(SUConnection ucon) throws TypeMismatchException {
@@ -328,4 +328,36 @@ public abstract class Value {
     public void setDbType(int type) {
         dbType = type;
     }
+
+    // -----------------------------------------------------
+
+    private String getCastErrMsg(String targetType) {
+        return String.format("cannot convert %s to %s", getTypeName(), targetType);
+    }
+
+    protected abstract String getTypeName();
+
+    protected static final String TYPE_NAME_NULL = "NULL";
+    protected static final String TYPE_NAME_OBJECT = "OBJECT";
+
+    protected static final String TYPE_NAME_BOOLEAN = "BOOLEAN";
+    protected static final String TYPE_NAME_STRING = "STRING";
+
+    protected static final String TYPE_NAME_BYTE = "BYTE";
+    protected static final String TYPE_NAME_SHORT = "SHORT";
+    protected static final String TYPE_NAME_INT = "INT";
+    protected static final String TYPE_NAME_BIGINT = "BIGINT";
+    protected static final String TYPE_NAME_FLOAT = "FLOAT";
+    protected static final String TYPE_NAME_DOUBLE = "DOUBLE";
+    protected static final String TYPE_NAME_NUMERIC = "NUMERIC";
+
+    protected static final String TYPE_NAME_DATE = "DATE";
+    protected static final String TYPE_NAME_TIME = "TIME";
+    protected static final String TYPE_NAME_DATETIME = "DATETIME";
+    protected static final String TYPE_NAME_TIMESTAMP = "TIMESTAMP";
+
+    protected static final String TYPE_NAME_OID = "OID";
+    protected static final String TYPE_NAME_RESULTSET = "RESULTSET";
+    protected static final String TYPE_NAME_SET =
+            "COLLECTION"; // actually, it is not only SET but also MULTISET and LIST
 }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -203,12 +203,14 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
 
                 assert node instanceof TypeSpecPercent;
                 TypeSpecPercent tsp = (TypeSpecPercent) node;
-                if (tsp.forParameterOrReturn) {
-                    tsp.type = DBTypeAdapter.getValueType(iStore, ct.colType.type);
-                } else {
+                if (tsp.typeVisitMode == TYPE_VISIT_NORMAL
+                        || (tsp.typeVisitMode == TYPE_VISIT_RETURN
+                                && ct.colType.type == DBType.DB_NUMERIC)) {
                     tsp.type =
                             DBTypeAdapter.getDeclType(
                                     iStore, ct.colType.type, ct.colType.prec, ct.colType.scale);
+                } else {
+                    tsp.type = DBTypeAdapter.getValueType(iStore, ct.colType.type);
                 }
             } else {
                 assert false : "unreachable";
@@ -285,10 +287,10 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
         String name = Misc.getNormalizedText(ctx.parameter_name());
         TypeSpec typeSpec;
         try {
-            forParameterOrReturn = true;
+            typeVisitMode = TYPE_VISIT_PARAM;
             typeSpec = (TypeSpec) visit(ctx.type_spec());
         } finally {
-            forParameterOrReturn = false;
+            typeVisitMode = TYPE_VISIT_NORMAL;
         }
 
         DeclParamIn ret = new DeclParamIn(ctx, name, typeSpec);
@@ -302,10 +304,10 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
         String name = Misc.getNormalizedText(ctx.parameter_name());
         TypeSpec typeSpec;
         try {
-            forParameterOrReturn = true;
+            typeVisitMode = TYPE_VISIT_PARAM;
             typeSpec = (TypeSpec) visit(ctx.type_spec());
         } finally {
-            forParameterOrReturn = false;
+            typeVisitMode = TYPE_VISIT_NORMAL;
         }
 
         DeclParamIn ret = new DeclParamIn(ctx, name, typeSpec);
@@ -319,10 +321,10 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
         String name = Misc.getNormalizedText(ctx.parameter_name());
         TypeSpec typeSpec;
         try {
-            forParameterOrReturn = true;
+            typeVisitMode = TYPE_VISIT_PARAM;
             typeSpec = (TypeSpec) visit(ctx.type_spec());
         } finally {
-            forParameterOrReturn = false;
+            typeVisitMode = TYPE_VISIT_NORMAL;
         }
 
         boolean alsoIn = ctx.IN() != null || ctx.INOUT() != null;
@@ -356,7 +358,7 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
             }
             String column = Misc.getNormalizedText(ctx.identifier());
 
-            TypeSpec ret = new TypeSpecPercent(ctx, table, column, forParameterOrReturn);
+            TypeSpec ret = new TypeSpecPercent(ctx, table, column, typeVisitMode);
             semanticQuestions.put(ret, new ServerAPI.ColumnType(table, column));
             return ret;
         }
@@ -422,7 +424,7 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     @Override
     public TypeSpec visitNumeric_type(Numeric_typeContext ctx) {
 
-        if (forParameterOrReturn) {
+        if (typeVisitMode != TYPE_VISIT_NORMAL) {
             if (ctx.precision != null) {
                 throw new SemanticError(
                         Misc.getLineColumnOf(ctx), // s091
@@ -464,7 +466,7 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     @Override
     public TypeSpec visitChar_type(Char_typeContext ctx) {
 
-        if (forParameterOrReturn) {
+        if (typeVisitMode != TYPE_VISIT_NORMAL) {
             if (ctx.length != null) {
                 throw new SemanticError(
                         Misc.getLineColumnOf(ctx), // s092
@@ -496,7 +498,7 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     @Override
     public TypeSpec visitVarchar_type(Varchar_typeContext ctx) {
 
-        if (forParameterOrReturn) {
+        if (typeVisitMode != TYPE_VISIT_NORMAL) {
             if (ctx.length != null) {
                 throw new SemanticError(
                         Misc.getLineColumnOf(ctx), // s093
@@ -1844,48 +1846,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     }
 
     @Override
-    public StmtForSqlLoop visitStmt_for_dynamic_sql_loop(Stmt_for_dynamic_sql_loopContext ctx) {
-
-        connectionRequired = true;
-
-        symbolStack.pushSymbolTable("for_d_sql_loop", null);
-
-        ParserRuleContext recNameCtx = ctx.for_dynamic_sql().record_name();
-        String record = Misc.getNormalizedText(recNameCtx);
-
-        Expr dynSql = visitExpression(ctx.for_dynamic_sql().dyn_sql());
-
-        NodeList<Expr> usedExprList;
-        Restricted_using_clauseContext usingClause =
-                ctx.for_dynamic_sql().restricted_using_clause();
-        if (usingClause == null) {
-            usedExprList = null;
-        } else {
-            usedExprList = visitRestricted_using_clause(usingClause);
-        }
-
-        String label;
-        DeclLabel declLabel = visitLabel_declaration(ctx.label_declaration());
-        if (declLabel == null) {
-            label = null;
-        } else {
-            label = declLabel.name;
-            symbolStack.putDeclLabel(label, declLabel);
-        }
-
-        DeclDynamicRecord declForRecord = new DeclDynamicRecord(recNameCtx, record);
-        symbolStack.putDecl(record, declForRecord);
-
-        NodeList<Stmt> stmts = visitSeq_of_statements(ctx.seq_of_statements());
-        controlFlowBlocked =
-                false; // every loop is assumed not to block control flow in generated Java code
-
-        symbolStack.popSymbolTable();
-
-        return new StmtForDynamicSqlLoop(ctx, label, declForRecord, dynSql, usedExprList, stmts);
-    }
-
-    @Override
     public StmtNull visitNull_statement(Null_statementContext ctx) {
         return new StmtNull(ctx);
     }
@@ -2448,12 +2408,16 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
         return val.replace("''", "'");
     }
 
+    private static final int TYPE_VISIT_NORMAL = 0;
+    private static final int TYPE_VISIT_PARAM = 1;
+    private static final int TYPE_VISIT_RETURN = 2;
+
     // --------------------------------------------------------
     // Private
     // --------------------------------------------------------
 
     private InstanceStore iStore;
-    private boolean forParameterOrReturn = false;
+    private int typeVisitMode = TYPE_VISIT_NORMAL;
 
     private static class UseAndDeclLevel {
         ParserRuleContext use;
@@ -2548,6 +2512,25 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
         symbolStack.putDecl(name, ret);
     }
 
+    private void previsitCursor_definition(Cursor_definitionContext ctx) {
+
+        String name = Misc.getNormalizedText(ctx.identifier());
+        symbolStack.pushSymbolTable("cursor_def", null);
+        NodeList<DeclParamIn> paramList = visitCursor_parameter_list(ctx.cursor_parameter_list());
+        SqlSemantics sws = getSqlSemanticsFromServer(ctx.static_sql());
+        assert sws != null;
+        assert sws.kind == ServerConstants.CUBRID_STMT_SELECT; // by syntax
+        if (sws.intoTargetStrs != null) {
+            throw new SemanticError(
+                    Misc.getLineColumnOf(ctx.static_sql()), // s015
+                    "SQL in a cursor definition may not have an INTO clause");
+        }
+        StaticSql staticSql = checkAndConvertStaticSql(sws, ctx.static_sql());
+        symbolStack.popSymbolTable();
+        DeclCursor ret = new DeclCursor(ctx, name, paramList, staticSql);
+        symbolStack.putDecl(name, ret);
+    }
+
     private void previsitRoutine_definition(
             Routine_definitionContext ctx, Map<String, DeclRoutine> store) {
 
@@ -2602,10 +2585,10 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
 
             TypeSpec retTypeSpec;
             try {
-                forParameterOrReturn = true;
+                typeVisitMode = TYPE_VISIT_RETURN;
                 retTypeSpec = (TypeSpec) visit(ctx.type_spec());
             } finally {
-                forParameterOrReturn = false;
+                typeVisitMode = TYPE_VISIT_NORMAL;
             }
 
             Type retType = retTypeSpec.type;
@@ -3095,6 +3078,9 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
             } else if ((d = ds.variable_declaration()) != null) {
                 // case of variable_declaration
                 previsitVariable_declaration((Variable_declarationContext) d);
+            } else if ((d = ds.cursor_definition()) != null) {
+                // case of variable_declaration
+                previsitCursor_definition((Cursor_definitionContext) d);
             } else if ((d = ds.routine_definition()) != null) {
                 // case of routine_definition
                 previsitRoutine_definition((Routine_definitionContext) d, ret);

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/TypeSpecPercent.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/TypeSpecPercent.java
@@ -42,13 +42,12 @@ public class TypeSpecPercent extends TypeSpec {
 
     public final String table;
     public final String column;
-    public final boolean forParameterOrReturn;
+    public final int typeVisitMode;
 
-    public TypeSpecPercent(
-            ParserRuleContext ctx, String table, String column, boolean forParameterOrReturn) {
+    public TypeSpecPercent(ParserRuleContext ctx, String table, String column, int typeVisitMode) {
         super(ctx, null); // null: unknown yet
         this.table = table;
         this.column = column;
-        this.forParameterOrReturn = forParameterOrReturn;
+        this.typeVisitMode = typeVisitMode;
     }
 }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
@@ -30,6 +30,7 @@
 
 package com.cubrid.plcsql.compiler.visitor;
 
+import com.cubrid.jsp.Server;
 import com.cubrid.jsp.data.ColumnInfo;
 import com.cubrid.plcsql.compiler.Coercion;
 import com.cubrid.plcsql.compiler.CoercionScheme;
@@ -641,6 +642,10 @@ public class TypeChecker extends AstVisitor<Type> {
 
             return ret;
         } else {
+            Server.log(
+                    String.format(
+                            "semantic check API returned an error (%d, %s) for '%s'",
+                            ss.errCode, ss.errMsg, sql));
             throw new SemanticError(
                     Misc.getLineColumnOf(node.ctx), // s235
                     "function "

--- a/src/broker/broker_admin_pub.c
+++ b/src/broker/broker_admin_pub.c
@@ -350,7 +350,7 @@ admin_start_cmd (T_BROKER_INFO * br_info, int br_num, int master_shm_id, bool ac
     }
 
   /* create master shared memory */
-  shm_br = broker_shm_initialize_shm_broker (master_shm_id, br_info, br_num, acl_flag, acl_file);
+  shm_br = broker_shm_initialize_shm_broker (master_shm_id, br_info, br_num, acl_flag, acl_file, admin_log_file);
 
   if (shm_br == NULL)
     {
@@ -1309,7 +1309,7 @@ admin_info_cmd (int master_shm_id)
       return -1;
     }
 
-  broker_config_dump (stdout, shm_br->br_info, shm_br->num_broker, master_shm_id);
+  broker_config_dump (stdout, shm_br->br_info, shm_br->num_broker, master_shm_id, shm_br->admin_log_file);
 
   uw_shm_detach (shm_br);
   return 0;

--- a/src/broker/broker_config.h
+++ b/src/broker/broker_config.h
@@ -316,7 +316,8 @@ struct t_broker_info
 extern int broker_config_read (const char *conf_file, T_BROKER_INFO * br_info, int *num_broker, int *br_shm_id,
 			       char *admin_log_file, char admin_flag, bool * acl_flag, char *acl_file,
 			       char *admin_err_msg);
-extern void broker_config_dump (FILE * fp, const T_BROKER_INFO * br_info, int num_broker, int br_shm_id);
+extern void broker_config_dump (FILE * fp, const T_BROKER_INFO * br_info, int num_broker, int br_shm_id,
+				char *admin_log_file);
 
 extern int conf_get_value_table_on_off (const char *value);
 extern int conf_get_value_table_allow_deny (const char *value);

--- a/src/broker/broker_filename.c
+++ b/src/broker/broker_filename.c
@@ -343,3 +343,64 @@ getenv_cubrid_broker ()
 
   return p;
 }
+
+int
+make_abs_path (char *dest, const char *subdir, const char *path, size_t dest_len)
+{
+  int ret = 0;
+  char buf[BROKER_PATH_MAX * 4];
+  char new_path[BROKER_PATH_MAX * 4];
+  int path_len;
+
+  if (path == NULL || path[0] == 0)
+    {
+      dest[0] = '\0';
+      return path ? 0 : -1;
+    }
+
+#if defined (WINDOWS)
+  if (IS_ABS_PATH (path))
+    {
+      _fullpath (new_path, path, dest_len);
+    }
+  else
+    {
+      snprintf (buf, dest_len, "%s%s%s\\%s", get_cubrid_home (), subdir ? "\\" : "", subdir ? subdir : "", path);
+      _fullpath (new_path, buf, dest_len);
+    }
+#else
+  if (IS_ABS_PATH (path))
+    {
+      snprintf (new_path, dest_len, "%s", path);
+    }
+  else
+    {
+      snprintf (new_path, dest_len, "%s%s%s/%s", get_cubrid_home (), subdir ? "/" : "", subdir ? subdir : "", path);
+    }
+#endif
+
+  path_len = strlen (new_path) - 1;
+  while (path_len > 0)
+    {
+      if (new_path[path_len] == '/' || new_path[path_len] == '\\')
+	{
+	  new_path[path_len] = '\0';
+	}
+      else
+	{
+	  break;
+	}
+      path_len--;
+    }
+
+  if (strlen (new_path) < dest_len)
+    {
+      snprintf (dest, dest_len, "%s", new_path);
+    }
+  else
+    {
+      ret = -1;
+    }
+
+  return ret;
+}

--- a/src/broker/broker_filename.c
+++ b/src/broker/broker_filename.c
@@ -350,6 +350,7 @@ make_abs_path (char *dest, const char *subdir, const char *path, size_t dest_len
   int ret = 0;
   char buf[BROKER_PATH_MAX * 4];
   char new_path[BROKER_PATH_MAX * 4];
+  int path_len;
 
   if (path == NULL || path[0] == 0)
     {
@@ -364,7 +365,6 @@ make_abs_path (char *dest, const char *subdir, const char *path, size_t dest_len
     }
   else
     {
-
       snprintf (buf, dest_len, "%s%s%s\\%s", get_cubrid_home (), subdir ? "\\" : "", subdir ? subdir : "", path);
       _fullpath (new_path, buf, dest_len);
     }
@@ -378,6 +378,20 @@ make_abs_path (char *dest, const char *subdir, const char *path, size_t dest_len
       snprintf (new_path, dest_len, "%s%s%s/%s", get_cubrid_home (), subdir ? "/" : "", subdir ? subdir : "", path);
     }
 #endif
+
+  path_len = strlen (new_path) - 1;
+  while (path_len > 0)
+    {
+      if (new_path[path_len] == '/' || new_path[path_len] == '\\')
+	{
+	  new_path[path_len] = '\0';
+	}
+      else
+	{
+	  break;
+	}
+      path_len--;
+    }
 
   if (strlen (new_path) < dest_len)
     {

--- a/src/broker/broker_filename.h
+++ b/src/broker/broker_filename.h
@@ -112,5 +112,6 @@ extern char *get_cubrid_file (T_CUBRID_FILE_ID fid, char *buf, size_t len);
 extern char *get_cubrid_file_ptr (T_CUBRID_FILE_ID fid);
 extern char *get_cubrid_home (void);
 extern const char *getenv_cubrid_broker (void);
+extern int make_abs_path (char *dst, const char *subdir, const char *path, size_t dest_len);
 
 #endif /* _BROKER_FILENAME_H_ */

--- a/src/broker/broker_shm.c
+++ b/src/broker/broker_shm.c
@@ -416,7 +416,8 @@ uw_shm_destroy (int shm_key)
 }
 
 T_SHM_BROKER *
-broker_shm_initialize_shm_broker (int master_shm_id, T_BROKER_INFO * br_info, int br_num, int acl_flag, char *acl_file)
+broker_shm_initialize_shm_broker (int master_shm_id, T_BROKER_INFO * br_info, int br_num, int acl_flag, char *acl_file,
+				  char *admin_log_file)
 {
   int i, shm_size;
   T_SHM_BROKER *shm_br = NULL;
@@ -448,6 +449,11 @@ broker_shm_initialize_shm_broker (int master_shm_id, T_BROKER_INFO * br_info, in
 
   shm_br->num_broker = br_num;
   shm_br->access_control = acl_flag;
+
+  if (admin_log_file != NULL)
+    {
+      strncpy (shm_br->admin_log_file, admin_log_file, sizeof (shm_br->admin_log_file) - 1);
+    }
 
   if (acl_file != NULL)
     {

--- a/src/broker/broker_shm.h
+++ b/src/broker/broker_shm.h
@@ -665,6 +665,7 @@ struct t_shm_broker
   uid_t owner_uid;
 #endif				/* !WINDOWS */
   int num_broker;		/* number of broker */
+  char admin_log_file[SHM_BROKER_PATH_MAX];
   char access_control_file[SHM_BROKER_PATH_MAX];
   bool access_control;
   T_BROKER_INFO br_info[1];
@@ -697,7 +698,7 @@ int uw_sem_post (sem_t * sem_t);
 int uw_sem_destroy (sem_t * sem_t);
 #endif
 T_SHM_BROKER *broker_shm_initialize_shm_broker (int master_shm_id, T_BROKER_INFO * br_info, int br_num, int acl_flag,
-						char *acl_file);
+						char *acl_file, char *admin_log_file);
 T_SHM_APPL_SERVER *broker_shm_initialize_shm_as (T_BROKER_INFO * br_info_p, T_SHM_PROXY * shm_proxy_p);
 
 #endif /* _BROKER_SHM_H_ */

--- a/src/compat/db_admin.c
+++ b/src/compat/db_admin.c
@@ -993,6 +993,8 @@ db_shutdown (void)
 {
   int error = NO_ERROR;
 
+  (void) db_end_session ();
+
   error = boot_shutdown_client (true);
   db_Database_name[0] = '\0';
   db_Connect_status = DB_CONNECTION_STATUS_NOT_CONNECTED;

--- a/src/compat/dbi_compat.h
+++ b/src/compat/dbi_compat.h
@@ -150,7 +150,6 @@ extern "C"
 			    const char *preferred_hosts, int client_type);
   extern SESSION_ID db_get_session_id (void);
   extern void db_set_session_id (const SESSION_ID session_id);
-  extern int db_end_session (void);
   extern int db_find_or_create_session (const char *db_user, const char *program_name);
   extern int db_get_row_count_cache (void);
   extern void db_update_row_count_cache (const int row_count);

--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -786,7 +786,6 @@ fatal_error:
 	}
     }
 
-  db_end_session ();
   db_shutdown ();
   csql_Database_connected = false;
   nonscr_display_error (csql_Scratch_text, SCRATCH_TEXT_LEN);
@@ -1034,7 +1033,6 @@ csql_do_session_cmd (char *line_read, CSQL_ARGUMENT * csql_arg)
       if (csql_Database_connected)
 	{
 	  csql_Database_connected = false;
-	  db_end_session ();
 	  db_shutdown ();
 	}
       er_init ("./csql.err", ER_NEVER_EXIT);
@@ -2731,7 +2729,6 @@ csql_exit_session (int error)
 	  histo_stop ();
 	}
     }
-  db_end_session ();
 
   if (db_shutdown () < 0)
     {
@@ -2814,7 +2811,6 @@ csql_exit_cleanup ()
 	}
 
       csql_Database_connected = false;
-      db_end_session ();
       db_shutdown ();
     }
 
@@ -3558,7 +3554,6 @@ csql_connect (char *argument, CSQL_ARGUMENT * csql_arg)
   if (csql_Database_connected)
     {
       csql_Database_connected = false;
-      db_end_session ();
       db_shutdown ();
 
     }

--- a/src/executables/server.c
+++ b/src/executables/server.c
@@ -342,6 +342,7 @@ main (int argc, char **argv)
       }
 
     fprintf (stdout, "\nThis may take a long time depending on the amount " "of recovery works to do.\n");
+    fflush (stdout);
 
     /* save executable path */
     binary_name = basename (argv[0]);

--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -377,6 +377,9 @@ command_string (int command_type)
     case START:
       command = PRINT_CMD_START;
       break;
+    case RESTART:
+      command = PRINT_CMD_RESTART;
+      break;
     case STATUS:
       command = PRINT_CMD_STATUS;
       break;
@@ -1361,7 +1364,7 @@ process_service (int command_type, bool process_window_service)
 	{
 	  if (!are_all_services_stopped (0, process_window_service))
 	    {
-	      (void) process_pl (command_type, 0, NULL, false, false, process_window_service, false);
+	      (void) process_pl (command_type, 0, NULL, false, true, process_window_service, false);
 
 	      if (strcmp (get_property (SERVICE_START_SERVER), PROPERTY_ON) == 0
 		  && us_Property_map[SERVER_START_LIST].property_value != NULL
@@ -2818,7 +2821,7 @@ is_pl_running (const char *server_name)
 }
 
 static int
-process_pl_stop (const char *db_name, bool suppress_message, bool process_window_service)
+process_pl_restart (const char *db_name, bool suppress_message, bool process_window_service)
 {
   int status = NO_ERROR;
   static const int wait_timeout = 5;
@@ -2826,7 +2829,7 @@ process_pl_stop (const char *db_name, bool suppress_message, bool process_window
 
   if (!suppress_message)
     {
-      print_message (stdout, MSGCAT_UTIL_GENERIC_START_STOP_3S, PRINT_PL_NAME, PRINT_CMD_STOP, db_name);
+      print_message (stdout, MSGCAT_UTIL_GENERIC_START_STOP_3S, PRINT_PL_NAME, PRINT_CMD_RESTART, db_name);
     }
   UTIL_PL_SERVER_STATUS_E pl_status = is_pl_running (db_name);
   if (pl_status == PL_SERVER_RUNNING)
@@ -2853,19 +2856,25 @@ process_pl_stop (const char *db_name, bool suppress_message, bool process_window
 	    }
 	  while (status != NO_ERROR && waited_secs < wait_timeout);
 	}
-      if (!suppress_message)
-	{
-	  print_result (PRINT_PL_NAME, status, STOP);
-	}
     }
   else
     {
       status = ER_GENERIC_ERROR;
-      if (!suppress_message)
+      util_log_write_errid (MSGCAT_UTIL_GENERIC_NOT_RUNNING_2S, PRINT_PL_NAME, db_name);
+    }
+
+  if (!suppress_message)
+    {
+      if (status == ER_GENERIC_ERROR)
 	{
 	  print_message (stdout, MSGCAT_UTIL_GENERIC_NOT_RUNNING_2S, PRINT_PL_NAME, db_name);
 	}
-      util_log_write_errid (MSGCAT_UTIL_GENERIC_NOT_RUNNING_2S, PRINT_PL_NAME, db_name);
+      else
+	{
+	  print_message (stdout, MSGCAT_UTIL_GENERIC_ALREADY_RUNNING_2S, PRINT_PL_NAME, db_name);
+	}
+
+      print_result (PRINT_PL_NAME, status, RESTART);
     }
 
   return status;
@@ -2946,10 +2955,19 @@ process_pl (int command_type, int argc, const char **argv, bool show_usage, bool
       switch (command_type)
 	{
 	case START:
+	  if (!suppress_message)
+	    {
+	      print_message (stderr, MSGCAT_UTIL_GENERIC_SERVICE_INVALID_CMD, PRINT_CMD_START);
+	    }
 	  break;
 	case STOP:
+	  if (!suppress_message)
+	    {
+	      print_message (stderr, MSGCAT_UTIL_GENERIC_SERVICE_INVALID_CMD, PRINT_CMD_STOP);
+	    }
+	  break;
 	case RESTART:
-	  status = process_pl_stop (db_name, suppress_message, process_window_service);
+	  status = process_pl_restart (db_name, suppress_message, process_window_service);
 	  break;
 	case STATUS:
 	  status = process_pl_status (db_name);

--- a/src/executables/utility.h
+++ b/src/executables/utility.h
@@ -921,6 +921,7 @@ typedef struct _ha_config
 #define PRINT_CMD_JAVASP        "javasp"
 
 #define PRINT_CMD_START         "start"
+#define PRINT_CMD_RESTART       "restart"
 #define PRINT_CMD_STOP          "stop"
 #define PRINT_CMD_STATUS        "status"
 #define PRINT_CMD_DEREG         "deregister"

--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -742,7 +742,6 @@ loaddb_internal (UTIL_FUNCTION_ARG * arg, int dba_mode)
       print_log_msg (1, "%s\n", db_error_string (3));
       util_log_write_errstr ("%s\n", db_error_string (3));
       status = 3;
-      db_end_session ();
       goto error_return;
     }
 
@@ -814,7 +813,6 @@ loaddb_internal (UTIL_FUNCTION_ARG * arg, int dba_mode)
       if (interrupted || status != 0)
 	{
 	  // failed
-	  db_end_session ();
 	  goto error_return;
 	}
     }
@@ -831,7 +829,6 @@ loaddb_internal (UTIL_FUNCTION_ARG * arg, int dba_mode)
 	  msg_format = "Error occurred during index loading." "Aborting current transaction...\n";
 	  util_log_write_errstr (msg_format);
 	  status = 3;
-	  db_end_session ();
 	  print_log_msg (1, " done.\n\nRestart loaddb with '-%c %s:%d' option\n", LOAD_INDEX_FILE_S,
 			 args.index_file.c_str (), index_file_start_line);
 	  logddl_write_end ();
@@ -865,7 +862,6 @@ loaddb_internal (UTIL_FUNCTION_ARG * arg, int dba_mode)
 	  msg_format = "Error occurred during trigger loading." "Aborting current transaction...\n";
 	  util_log_write_errstr (msg_format);
 	  status = 3;
-	  db_end_session ();
 	  print_log_msg (1, " done.\n\nRestart loaddb with '--%s %s:%d' option\n", LOAD_TRIGGER_FILE_L,
 			 args.trigger_file.c_str (), trigger_file_start_line);
 	  logddl_write_end ();
@@ -887,7 +883,6 @@ loaddb_internal (UTIL_FUNCTION_ARG * arg, int dba_mode)
     }
 
   print_log_msg ((int) args.verbose, msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_LOADDB, LOADDB_MSG_CLOSING));
-  (void) db_end_session ();
   (void) db_shutdown ();
 
   fclose_and_init (loaddb_log_file);
@@ -1608,7 +1603,6 @@ ldr_load_schema_file (FILE * schema_fp, int schema_file_start_line, load_args ar
       msg_format = "Error occurred during schema loading." "Aborting current transaction...\n";
       util_log_write_errstr (msg_format);
       status = 3;
-      db_end_session ();
       print_log_msg (1, " done.\n\nRestart loaddb with '-%c %s:%d' option\n", LOAD_SCHEMA_FILE_S,
 		     args.schema_file.c_str (), schema_file_start_line);
       logddl_write_end ();
@@ -1634,7 +1628,6 @@ ldr_load_schema_file (FILE * schema_fp, int schema_file_start_line, load_args ar
       if (ldr_compare_storage_order (schema_fp) != NO_ERROR)
 	{
 	  status = 3;
-	  db_end_session ();
 	  print_log_msg (1, "\nAborting current transaction...\n");
 	  return status;
 	}

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -164,6 +164,7 @@ static PT_NODE *pt_find_aggregate_analytic_pre (PARSER_CONTEXT * parser, PT_NODE
 static PT_NODE *pt_find_aggregate_analytic_post (PARSER_CONTEXT * parser, PT_NODE * tree, void *arg,
 						 int *continue_walk);
 static PT_NODE *pt_find_aggregate_analytic_in_where (PARSER_CONTEXT * parser, PT_NODE * node);
+static PT_NODE *pt_find_stored_procedure (PARSER_CONTEXT * parser, PT_NODE * tree, void *arg, int *continue_walk);
 static void pt_check_attribute_domain (PARSER_CONTEXT * parser, PT_NODE * attr_defs, PT_MISC_TYPE class_type,
 				       const char *self, const bool reuse_oid, PT_NODE * stmt);
 static void pt_check_mutable_attributes (PARSER_CONTEXT * parser, DB_OBJECT * cls, PT_NODE * attr_defs);
@@ -4064,6 +4065,17 @@ pt_check_data_default (PARSER_CONTEXT * parser, PT_NODE * data_default_list)
 	  goto end;
 	}
 
+      node_ptr = NULL;
+      parser_walk_tree (parser, default_value, pt_find_stored_procedure, &node_ptr, NULL, NULL);
+      if (node_ptr != NULL)
+	{
+	  PT_ERRORmf (parser,
+		      node_ptr,
+		      MSGCAT_SET_PARSER_SEMANTIC,
+		      MSGCAT_SEMANTIC_DEFAULT_EXPR_NOT_ALLOWED, parser_print_tree (parser, default_value));
+	  goto end;
+	}
+
     end:
       data_default->next = save_next;
       prev = data_default;
@@ -4182,6 +4194,35 @@ pt_attr_check_default_cs_coll (PARSER_CONTEXT * parser, PT_NODE * attr, int defa
   attr->data_type->info.data_type.collation_id = attr_coll;
 
   return err;
+}
+
+/*
+ * pt_find_stored_procedure () - search for a stored procedure
+ *
+ * result	  : parser tree node
+ * parser(in)	  : parser
+ * tree(in)	  : parser tree node
+ * arg(in/out)	  : true, if the stored procedure is found
+ * continue_walk  : Continue walk.
+ */
+static PT_NODE *
+pt_find_stored_procedure (PARSER_CONTEXT * parser, PT_NODE * tree, void *arg, int *continue_walk)
+{
+  PT_NODE **sp = (PT_NODE **) arg;
+
+  if (tree == NULL)
+    {
+      *continue_walk = PT_STOP_WALK;
+    }
+
+  if (tree->node_type == PT_METHOD_CALL || (tree->node_type == PT_FUNCTION && tree->info.function.function_type == PT_GENERIC)	/* not resolved yet */
+    )
+    {
+      *sp = tree;
+      *continue_walk = PT_STOP_WALK;
+    }
+
+  return tree;
 }
 
 /*

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -532,7 +532,7 @@ pt_get_expression_definition (const PT_OP_TYPE op, EXPRESSION_DEFINITION * def)
 
       /* arg1 */
       sig.arg1_type.type = pt_arg_type::GENERIC;
-      sig.arg1_type.val.generic_type = PT_GENERIC_TYPE_BIT;
+      sig.arg1_type.val.generic_type = PT_GENERIC_TYPE_STRING;
       /* return type */
 
       sig.return_type.type = pt_arg_type::NORMAL;
@@ -541,7 +541,7 @@ pt_get_expression_definition (const PT_OP_TYPE op, EXPRESSION_DEFINITION * def)
 
       /* arg1 */
       sig.arg1_type.type = pt_arg_type::GENERIC;
-      sig.arg1_type.val.generic_type = PT_GENERIC_TYPE_STRING;
+      sig.arg1_type.val.generic_type = PT_GENERIC_TYPE_BIT;
 
       /* return type */
       sig.return_type.type = pt_arg_type::NORMAL;
@@ -4987,17 +4987,14 @@ static bool
 pt_are_unmatchable_types (const PT_ARG_TYPE def_type, const PT_TYPE_ENUM op_type)
 {
   /* PT_TYPE_NONE does not match anything */
-  if (op_type == PT_TYPE_NONE && !(def_type.type == pt_arg_type::NORMAL && def_type.val.type == PT_TYPE_NONE))
+  if (def_type.type == pt_arg_type::NORMAL && def_type.val.type == PT_TYPE_NONE)
     {
-      return true;
+      return (op_type != PT_TYPE_NONE);
     }
-
-  if (op_type != PT_TYPE_NONE && def_type.type == pt_arg_type::NORMAL && def_type.val.type == PT_TYPE_NONE)
+  else
     {
-      return true;
+      return (op_type == PT_TYPE_NONE);
     }
-
-  return false;
 }
 
 static PT_NODE *
@@ -12484,8 +12481,12 @@ pt_eval_function_type (PARSER_CONTEXT * parser, PT_NODE * node)
   PT_NODE *arg_list = node->info.function.arg_list;
   if (!arg_list && !pt_is_function_no_arg (fcode))
     {
-      PT_ERRORmf (parser, node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_FUNCTION_NO_ARGS,
-		  pt_short_print (parser, node));
+      // Set parser error only if the function is not a generic function.
+      if (fcode != PT_GENERIC)
+	{
+	  PT_ERRORmf (parser, node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_FUNCTION_NO_ARGS,
+		      pt_short_print (parser, node));
+	}
       return node;
     }
 

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -4944,8 +4944,9 @@ mq_rewrite_aggregate_as_derived (PARSER_CONTEXT * parser, PT_NODE * agg_sel)
    * Therefore, the NO_MERGE hint is not moved to the derived subquery. 
    * Additionally, if the subquery has the QUERY_CACHE hint, it should not be merged, so it is treated together with the NO_MERGE hint.
    * All hints except for NO_MERGE and QUERY_CACHE are moved to the derived subquery. */
-  derived->info.query.q.select.hint = agg_sel->info.query.q.select.hint & ~(PT_HINT_NO_MERGE | PT_HINT_QUERY_CACHE);
-  agg_sel->info.query.q.select.hint &= (PT_HINT_NO_MERGE | PT_HINT_QUERY_CACHE);
+  derived->info.query.q.select.hint =
+    agg_sel->info.query.q.select.hint & ~(PT_HINT_NO_MERGE | PT_HINT_QUERY_CACHE | PT_HINT_NO_SUBQUERY_CACHE);
+  agg_sel->info.query.q.select.hint &= (PT_HINT_NO_MERGE | PT_HINT_QUERY_CACHE | PT_HINT_NO_SUBQUERY_CACHE);
 
   derived->info.query.q.select.leading = agg_sel->info.query.q.select.leading;
   agg_sel->info.query.q.select.leading = NULL;

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -4946,8 +4946,9 @@ mq_rewrite_aggregate_as_derived (PARSER_CONTEXT * parser, PT_NODE * agg_sel)
    * Therefore, the NO_MERGE hint is not moved to the derived subquery. 
    * Additionally, if the subquery has the QUERY_CACHE hint, it should not be merged, so it is treated together with the NO_MERGE hint.
    * All hints except for NO_MERGE and QUERY_CACHE are moved to the derived subquery. */
-  derived->info.query.q.select.hint = agg_sel->info.query.q.select.hint & ~(PT_HINT_NO_MERGE | PT_HINT_QUERY_CACHE);
-  agg_sel->info.query.q.select.hint &= (PT_HINT_NO_MERGE | PT_HINT_QUERY_CACHE);
+  derived->info.query.q.select.hint =
+    agg_sel->info.query.q.select.hint & ~(PT_HINT_NO_MERGE | PT_HINT_QUERY_CACHE | PT_HINT_NO_SUBQUERY_CACHE);
+  agg_sel->info.query.q.select.hint &= (PT_HINT_NO_MERGE | PT_HINT_QUERY_CACHE | PT_HINT_NO_SUBQUERY_CACHE);
 
   derived->info.query.q.select.leading = agg_sel->info.query.q.select.leading;
   agg_sel->info.query.q.select.leading = NULL;

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -9978,6 +9978,7 @@ pt_attribute_to_regu (PARSER_CONTEXT * parser, PT_NODE * attr)
 	    {
 	      /* The attribute is correlated variable. Find it in an enclosing scope(s). Note that this subquery has
 	       * also just been determined to be a correlated subquery. */
+	      REGU_VARIABLE_SET_FLAG (regu, REGU_VARIABLE_CORRELATED);
 	      if (symbols->stack == NULL)
 		{
 		  if (!pt_has_error (parser))
@@ -27328,6 +27329,7 @@ pt_make_sq_cache_key_struct (QPROC_DB_VALUE_LIST key_struct, void *p, int type)
   ACCESS_SPEC_TYPE *spec;
   PRED_EXPR *pred_src;
   REGU_VARIABLE *regu_src;
+  REGU_VARIABLE_LIST regu_var_list_p;
   if (!p)
     {
       return 0;
@@ -27438,6 +27440,54 @@ pt_make_sq_cache_key_struct (QPROC_DB_VALUE_LIST key_struct, void *p, int type)
 	      cnt += ret;
 	    }
 	}
+      if (xasl_src->outptr_list)
+	{
+	  regu_var_list_p = xasl_src->outptr_list->valptrp;
+	  for (i = 0; i < xasl_src->outptr_list->valptr_cnt; i++)
+	    {
+	      if (!regu_var_list_p)
+		{
+		  assert (false);
+		  return ER_FAILED;
+		}
+	      regu_src = &regu_var_list_p->value;
+	      ret = pt_make_sq_cache_key_struct (key_struct, (void *) regu_src, SQ_TYPE_REGU_VAR);
+	      if (ret == ER_FAILED)
+		{
+		  return ER_FAILED;
+		}
+	      else
+		{
+		  cnt += ret;
+		}
+	      regu_var_list_p = regu_var_list_p->next;
+	    }
+	}
+      if (xasl_src->type == BUILDVALUE_PROC || xasl_src->type == BUILDLIST_PROC)
+	{
+	  AGGREGATE_TYPE *agg_list =
+	    (xasl_src->type ==
+	     BUILDVALUE_PROC) ? xasl_src->proc.buildvalue.agg_list : xasl_src->proc.buildlist.g_agg_list;
+	  while (agg_list)
+	    {
+	      regu_var_list_p = agg_list->operands;
+	      while (regu_var_list_p)
+		{
+		  ret = pt_make_sq_cache_key_struct (key_struct, (void *) &regu_var_list_p->value, SQ_TYPE_REGU_VAR);
+		  if (ret == ER_FAILED)
+		    {
+		      return ER_FAILED;
+		    }
+		  else
+		    {
+		      cnt += ret;
+		    }
+		  regu_var_list_p = regu_var_list_p->next;
+		}
+	      agg_list = agg_list->next;
+	    }
+
+	}
       break;
     case SQ_TYPE_PRED:
       pred_src = (PRED_EXPR *) p;
@@ -27506,6 +27556,10 @@ pt_make_sq_cache_key_struct (QPROC_DB_VALUE_LIST key_struct, void *p, int type)
       switch (regu_src->type)
 	{
 	case TYPE_CONSTANT:
+	  if (!REGU_VARIABLE_IS_FLAGED (regu_src, REGU_VARIABLE_CORRELATED))
+	    {
+	      break;
+	    }
 	  ret = pt_make_sq_cache_key_struct (key_struct, (void *) regu_src->value.dbvalptr, SQ_TYPE_DBVAL);
 	  if (ret == ER_FAILED)
 	    {

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -16281,21 +16281,25 @@ qexec_check_limit_clause (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 	  return ER_FAILED;
 	}
 
-      cmp_with_zero = tp_value_compare (limit_valp, &zero_val, 1, 0);
-      if (cmp_with_zero != DB_GT && cmp_with_zero != DB_EQ)
-	{
-	  /* still want better error code */
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_PARAMETER, 0);
-	  return ER_FAILED;
-	}
+      /*
+       * The below routine is skipped for consistance with PL/CSQL's execution
+       * because OFFSET will be processed with 0 for negative value
+       *
+       * cmp_with_zero = tp_value_compare (limit_valp, &zero_val, 1, 0);
+       * if (cmp_with_zero != DB_GT && cmp_with_zero != DB_EQ)
+       * {
+       *   er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_PARAMETER, 0);
+       *   return ER_FAILED;
+       * }
+       *
+       */
     }
 
   if (xasl->limit_row_count != NULL)
     {
       /* When limit_row_count is
        *   > 0, go to execute the query.
-       *   = 0, no result will be generated. stop execution for optimization.
-       *   < 0, raise an error.
+       *   <= 0, no result will be generated. stop execution for optimization.
        */
       if (fetch_peek_dbval (thread_p, xasl->limit_row_count, &xasl_state->vd, NULL, NULL, NULL, &limit_valp) !=
 	  NO_ERROR)
@@ -16309,16 +16313,10 @@ qexec_check_limit_clause (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 	  /* validated */
 	  return NO_ERROR;
 	}
-      else if (cmp_with_zero == DB_EQ)
+      else
 	{
 	  *empty_result = true;
 	  return NO_ERROR;
-	}
-      else
-	{
-	  /* still want better error code */
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_PARAMETER, 0);
-	  return ER_FAILED;
 	}
     }
 

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -16299,21 +16299,25 @@ qexec_check_limit_clause (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 	  return ER_FAILED;
 	}
 
-      cmp_with_zero = tp_value_compare (limit_valp, &zero_val, 1, 0);
-      if (cmp_with_zero != DB_GT && cmp_with_zero != DB_EQ)
-	{
-	  /* still want better error code */
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_PARAMETER, 0);
-	  return ER_FAILED;
-	}
+      /*
+       * The below routine is skipped for consistance with PL/CSQL's execution
+       * because OFFSET will be processed with 0 for negative value
+       *
+       * cmp_with_zero = tp_value_compare (limit_valp, &zero_val, 1, 0);
+       * if (cmp_with_zero != DB_GT && cmp_with_zero != DB_EQ)
+       * {
+       *   er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_PARAMETER, 0);
+       *   return ER_FAILED;
+       * }
+       *
+       */
     }
 
   if (xasl->limit_row_count != NULL)
     {
       /* When limit_row_count is
        *   > 0, go to execute the query.
-       *   = 0, no result will be generated. stop execution for optimization.
-       *   < 0, raise an error.
+       *   <= 0, no result will be generated. stop execution for optimization.
        */
       if (fetch_peek_dbval (thread_p, xasl->limit_row_count, &xasl_state->vd, NULL, NULL, NULL, &limit_valp) !=
 	  NO_ERROR)
@@ -16327,16 +16331,10 @@ qexec_check_limit_clause (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 	  /* validated */
 	  return NO_ERROR;
 	}
-      else if (cmp_with_zero == DB_EQ)
+      else
 	{
 	  *empty_result = true;
 	  return NO_ERROR;
-	}
-      else
-	{
-	  /* still want better error code */
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_PARAMETER, 0);
-	  return ER_FAILED;
 	}
     }
 

--- a/src/query/regu_var.hpp
+++ b/src/query/regu_var.hpp
@@ -166,6 +166,7 @@ const int REGU_VARIABLE_FETCH_NOT_CONST = 0x80;	/* is not constant */
 const int REGU_VARIABLE_CLEAR_AT_CLONE_DECACHE = 0x100;	/* clears regu variable at clone decache */
 const int REGU_VARIABLE_UPD_INS_LIST = 0x200;	/* for update or insert query */
 const int REGU_VARIABLE_STRICT_TYPE_CAST = 0x400;/* for update or insert query */
+const int REGU_VARIABLE_CORRELATED = 0x800; /* for correlated scalar subquery cache */
 
 class regu_variable_node
 {

--- a/src/query/regu_var.hpp
+++ b/src/query/regu_var.hpp
@@ -168,6 +168,7 @@ const int REGU_VARIABLE_FETCH_NOT_CONST = 0x80;	/* is not constant */
 const int REGU_VARIABLE_CLEAR_AT_CLONE_DECACHE = 0x100;	/* clears regu variable at clone decache */
 const int REGU_VARIABLE_UPD_INS_LIST = 0x200;	/* for update or insert query */
 const int REGU_VARIABLE_STRICT_TYPE_CAST = 0x400;/* for update or insert query */
+const int REGU_VARIABLE_CORRELATED = 0x800; /* for correlated scalar subquery cache */
 
 class regu_variable_node
 {

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -931,7 +931,14 @@ session_remove_expired_sessions (THREAD_ENTRY * thread_p)
 
 	  if (is_expired)
 	    {
+	      /* Now we can destroy this session */
+	      assert (state->ref_count == 0);
+
 	      expired_sid_buffer[n_expired_sids++] = state->id;
+
+	      /* Destroy the session related resources like session parameters */
+	      (void) session_state_uninit (state);
+
 	      if (n_expired_sids == EXPIRED_SESSION_BUFFER_SIZE)
 		{
 		  /* No more room in buffer */

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2756,6 +2756,7 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
       strncpy_size (format, msgcat_message (MSGCAT_CATALOG_CUBRID, MSGCAT_SET_GENERAL, MSGCAT_GENERAL_DATABASE_INIT),
 		    BOOT_FORMAT_MAX_LENGTH);
       fprintf (stdout, format, rel_name ());
+      fflush (stdout);
 #else /* NDEBUG */
       fprintf (stdout, "\n%s (%s) (%d %s build)\n\n", rel_name (), rel_build_number (), rel_bit_platform (),
 	       rel_build_type ());

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -2534,7 +2534,9 @@ log_is_page_of_record_broken (THREAD_ENTRY * thread_p, const LOG_LSA * log_lsa,
   /* TODO - Do we need to handle NULL fwd_log_lsa? */
   if (!LSA_ISNULL (&fwd_log_lsa))
     {
-      if (LSA_GE (log_lsa, &fwd_log_lsa) || LSA_GT (&fwd_log_lsa, &log_Gl.hdr.eof_lsa))
+      /* log_Gl.hdr.eof_lsa can have a NULL_LSA value if recovery is started without an active log volume. Its value will be recovered during the log_recovery_analysis process. */
+      if (LSA_GE (log_lsa, &fwd_log_lsa)
+	  || (!LSA_ISNULL (&log_Gl.hdr.eof_lsa) && LSA_GT (&fwd_log_lsa, &log_Gl.hdr.eof_lsa)))
 	{
 	  // check fwd_log_lsa value if it is corrupted or not
 	  is_log_page_broken = true;

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -329,8 +329,7 @@ if(UNIX)
   add_executable(unittests_lf ${UNITTESTS_LF_SOURCES})
   target_compile_definitions(unittests_lf PRIVATE UNITTEST_LF SERVER_MODE ${COMMON_DEFS})
   target_include_directories(unittests_lf PRIVATE ${EP_INCLUDES})
-  target_link_libraries(unittests_lf LINK_PRIVATE cubridcs)
-
+  target_link_libraries(unittests_lf LINK_PRIVATE cubrid)
 
   set(UNITTESTS_AREA_SOURCES
     ${BASE_DIR}/memory_monitor_api.cpp


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25687

Java SP 서버에서 PL 서버의 요구사항 및 동작 변경으로 PL 서버 유틸리티 명령어의 start, stop 명령어를 지원하지 않음으로, 사용자에게 지원하지 않는 명령어라는 명확한 에러를 반환해야 한다.

start, stop 명령어를 인식하지 못하고, 지원하지 않는 명령어라는 에러를 반환
cubrid pl start demodb
cubrid pl stop demodb

위 명령어에 대해 인식하지 못하도록 에러 처리 필요

restart 명령어의 경우 다른 유틸리티와 같이 stop 후 start 명령어를 출력하지 않고, restart 성공 실패 여부만 출력

 TO-BE:
cubrid pl restart demodb

@ cubrid pl restart: demodb
++ cubrid server 'demodb' is not running. -- DB 서버 미구동인 경우

++ cubrid pl restart: success -- PL 서버 구동 및 ping 연결 성공 확인 시
++ cubrid pl restart: fail -- PL 서버 구동 및 ping 연결 실패 시