### PR TITLE
[CBRD-25602] Fix assert() when executing drop table with vacuum_disable=y

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -6068,6 +6068,11 @@ vacuum_log_add_dropped_file (THREAD_ENTRY * thread_p, const VFID * vfid, const O
   LOG_DATA_ADDR addr;
   VACUUM_DROPPED_FILES_RCV_DATA rcv_data;
 
+  if (prm_get_bool_value (PRM_ID_DISABLE_VACUUM))
+    {
+      return;
+    }
+
   vacuum_er_log (VACUUM_ER_LOG_DROPPED_FILES, "Append %s log from dropped file %d|%d.",
 		 pospone_or_undo ? "postpone" : "undo", vfid->volid, vfid->fileid);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25602

### Purpose
- vacuum_disable=y 설정 후 create table - drop table 수행 시 assert() 발생 수정
- 이슈에 첨부된 콜스택을 보면, vacuum_add_dropped_file()에서 assert() 발생
    - drop 된 heap 파일(테이블)을 vacuum에서 추적하려고 하는데, vacuum_disable=y 설정이라 추적을 위한 vacuum_Dropped_file 정보가 초기화되어 있지 않아 발생하는 문제   
- vacuum_disable은 hidden 파라미터이기 때문에 이슈의 재현 시나리오에서 assert()가 발생하지 않도록만 처리

### Implementation
- drop 시 vacuum의 vacuum_Dropped_file에 추가할 정보를 로깅하는데, vacuum_disable=y 설정일 경우 로깅을 생략하도록 처리

### Remarks
- N/A