### PR TITLE
[CBRD-25664] Excluded -1 from the valid range of the page_flush_interval system parameter

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -1197,7 +1197,7 @@ static unsigned int prm_pb_num_LRU_chains_flag = 0;
 
 int PRM_PAGE_BG_FLUSH_INTERVAL_MSEC = 1000;
 static int prm_page_bg_flush_interval_msec_default = 1000;
-static int prm_page_bg_flush_interval_msec_lower = -1;
+static int prm_page_bg_flush_interval_msec_lower = 0;
 static unsigned int prm_page_bg_flush_interval_msec_flag = 0;
 
 bool PRM_ADAPTIVE_FLUSH_CONTROL = true;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25664

- Purpose
    - page_flush_interval 시스템 파라미터는 pgbuf_Page_flush_daemon 데몬의 looper를 설정하고 있음
    - page_flush_interval 값의 설정 범위는 -1 ~ 1000이며, -1로 설정하면 assert가 발생하고 있음
        - cub_server: /home/hornetmj/work/cubrid/src/storage/page_buffer.c:15713: void pgbuf_get_page_flush_interval(bool&, cubthread::delta_time&): Assertion page_flush_interval_msecs >= 0' failed.`
    - 현재 page_flush_interval 값을 0 이하로 설정하면 pgbuf_Page_flush_daemon이 다른 쓰레드가 깨워줄 때까지 무한 대기하도록 구현되어 있음
    - 따라서, page_flush_interval 값을 -1 또는 0으로 설정하는 것은 동일한 결과를 얻으며, -1을 설정 범위에 포함할 필요가 없음
- Implementation
    - page_flush_interval 시스템 파라미터의 설정 범위에서 -1을 제외
- Remarks
    - N/A