### PR TITLE
[CBRD-25692] Add noexcept for operating new functions in memory_wrapper.hpp

### DIFF
--- a/src/base/memory_wrapper.hpp
+++ b/src/base/memory_wrapper.hpp
@@ -43,12 +43,12 @@
 // However, as CUBRID does not currently utilize such additional methods, they are not overloaded.
 // It has been decided that overloading will be undertaken should any issues arise from
 // the discovery of the utilization of these additional methods.
-inline void *operator new (size_t size, const char *file, const int line)
+inline void *operator new (size_t size, const char *file, const int line) noexcept
 {
   return cub_alloc (size, file, line);
 }
 
-inline void *operator new[] (size_t size, const char *file, const int line)
+inline void *operator new[] (size_t size, const char *file, const int line) noexcept
 {
   return cub_alloc (size, file, line);
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25692

Trivial change: 
- Add noexcept operator for a compile-time check. By this change, It is guaranteed that when you use `new` operator in server-side, adding (std::nothorw) is not required.