### PR TITLE
[CBRD-25653] Error handling when executing Unloaddb on an empty DB

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -5947,7 +5947,10 @@ extract_split_schema_files (extract_context & ctxt)
       err_count++;
     }
 
-  create_schema_info (ctxt);
+  if (create_schema_info (ctxt) != NO_ERROR)
+    {
+      err_count++;
+    }
 
   return err_count;
 }
@@ -5974,6 +5977,8 @@ extract_all_schema_file (extract_context & ctxt, const char *output_filename)
       fclose (output_file);
       output_file = NULL;
       remove (output_filename);
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_NODATA_TOBE_UNLOADED, 0);
+      err_count++;
     }
   else
     {
@@ -6131,6 +6136,8 @@ create_schema_info (extract_context & ctxt)
       fclose (output_file);
       output_file = NULL;
       remove (output_filename);
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_NODATA_TOBE_UNLOADED, 0);
+      err = ER_FAILED;
     }
   else
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25653

Purpose
DB를 생성하고 아무런 데이터를 입력하지 않은 상태에서 unloaddb를 수행했을때 마치 정상동작을 한것처럼 종료된다.
DB에 아무런 데이터가 없는 경우 아래의 문구가 출력되도록 수정하였다.
unloaddb: No data to be unloaded.

