### PR TITLE
[CBRD-25687] PL 유틸리티 명령어에 동작 변경에 따른 에러와 메시지 변경

### DIFF
--- a/src/executables/utility.h
+++ b/src/executables/utility.h
@@ -921,6 +921,7 @@ typedef struct _ha_config
 #define PRINT_CMD_JAVASP        "javasp"
 
 #define PRINT_CMD_START         "start"
+#define PRINT_CMD_RESTART       "restart"
 #define PRINT_CMD_STOP          "stop"
 #define PRINT_CMD_STATUS        "status"
 #define PRINT_CMD_DEREG         "deregister"


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25687

Java SP 서버에서 PL 서버의 요구사항 및 동작 변경으로 PL 서버 유틸리티 명령어의 start, stop 명령어를 지원하지 않음으로, 사용자에게 지원하지 않는 명령어라는 명확한 에러를 반환해야 한다.

start, stop 명령어를 인식하지 못하고, 지원하지 않는 명령어라는 에러를 반환
cubrid pl start demodb
cubrid pl stop demodb

위 명령어에 대해 인식하지 못하도록 에러 처리 필요

restart 명령어의 경우 다른 유틸리티와 같이 stop 후 start 명령어를 출력하지 않고, restart 성공 실패 여부만 출력

TO-BE:
cubrid pl restart demodb

@ cubrid pl restart: demodb
++ cubrid server 'demodb' is not running. -- DB 서버 미구동인 경우

++ cubrid pl restart: success -- PL 서버 구동 및 ping 연결 성공 확인 시
++ cubrid pl restart: fail -- PL 서버 구동 및 ping 연결 실패 시
