### PR TITLE
[CBRD-25697] TRUNCATE에서 불필요한 DELETE 동작 발생

### DIFF
--- a/src/object/schema_class_truncator.cpp
+++ b/src/object/schema_class_truncator.cpp
@@ -528,7 +528,7 @@ namespace cubschema
 	STATEMENT_ID stmt_id;
 	DB_VALUE value;
 	char select_query[DB_MAX_IDENTIFIER_LENGTH + 256] = { 0 };
-	constexpr int CNT_CATCLS_OBJECTS = 5;
+	constexpr int CNT_CATCLS_OBJECTS = 6;
 	DB_BIGINT cnt_refers = CNT_CATCLS_OBJECTS + 1;
 	int au_save;
 
@@ -544,13 +544,13 @@ namespace cubschema
 	 * To do this, we use an walkaround in which we count the number of general object domains in existing system catalogs
 	 * and if the SELECT result is over this, we asuume that there are some general object domain in some user class.
 	 *
-	 * The number is now 5 and hard-coded, so we MUST consider it when add or remove a general object domain in a system class.
+	 * The number is now 6 and hard-coded, so we MUST consider it when add or remove a general object domain in a system class.
 	 * If it is changed, we MUST also change the value of CNT_CATCLS_OBJECTS.
 	 *
-	 * We add a QA test case to confirm there are only 5 general object domains in system classes, which will help notice this constraint
+	 * We add a QA test case to confirm there are only 6 general object domains in system classes, which will help notice this constraint
 	 * and this test case also has to be changed along if CNT_CATCLS_OBJECTS is changed.
 	 *
-	 * See CBRD-23983 for the details.
+	 * See CBRD-23983 and CBRD-25697 for the details.
 	 */
 
 	AU_DISABLE (au_save);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25697

TRUNCATE 동작은 sm_truncate를 통해 class_truncate_context::truncate_heap을 호출합니다. 이 때, 아래의 쿼리를 통해 reference class를 확인합니다.

`SELECT COUNT(*) FROM [_db_domain] WHERE [data_type]=DB_TYPE_OBJECT AND ([class_of].[unique_name]=class-name OR [class_of] IS NULL) AND ROWNUM <= CNT_CATCLS_OBJECTS + 1; `

여기서, DB_TYPE_OBJECT는 5이고, class-name은 해당 테이블 명, 그리고 CNT_CATCLS_OBJECTS는 카탈로그 객체이 개수인데, 이 값은 현재 5로 하드 코딩이 되어 있습니다.

PL/CSQL이 추가되면서 카탈로그 내용이 변경되었고, 이를 반영하기 위해 현재 5로 되어 있는 CNT_CATCLS_OBJECTS 값을 6으로 변경해야 합니다.
