### PR TITLE
[CBRD-25699] [regression] AU_DISABLE_PASSWORDS () doesn't work because authenticate context's variables are reset again by au_init ()

### DIFF
--- a/src/object/authenticate.h
+++ b/src/object/authenticate.h
@@ -75,7 +75,7 @@ class print_output;
 #define Au_cache                        au_ctx ()->caches
 
 /* Functions */
-#define au_init                         au_ctx ()->init_ctx
+#define au_init                         au_ctx
 #define au_final                        au_ctx ()->final_ctx
 #define au_install                      au_ctx ()->install
 #define au_start                        au_ctx ()->start


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25699

In spacedb(), au_init()->reset() is called after AU_DISABLE_PASSWORD() is called. By this behavior, configuration of authenticate module is re-initialized.