### PR TITLE
[CBRD-25056] slip: fix UPDATE syntax for expanding a record variable in UPDATE statements

### DIFF
--- a/pl_engine/pl_server/src/main/antlr/StaticSqlWithRecords.g4
+++ b/pl_engine/pl_server/src/main/antlr/StaticSqlWithRecords.g4
@@ -94,7 +94,7 @@ stmt_w_record_values
     ;
 
 stmt_w_record_set
-    : UPDATE any* table_spec SET row_set any+ EOF
+    : UPDATE any* table_spec SET row_set any* EOF
     | INSERT any* table_spec SET row_set (ON DUPLICATE KEY UPDATE any+)? EOF
     | REPLACE any* table_spec SET row_set EOF
     ;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25056

. SET ROW = <r> 뒤에 한 단어 이상 와야 하는 것처럼 문법 구성이 잘못되어 수정합니다. 
. UPDATE tbl SET ROW = r; 처럼 'SET ROW = r' 뒤에 아무 내용이 없는 경우에 오동작하는 문제가 있었습니다. 
