### PR TITLE
[CBRD-25510] Removed unnecessary loop in heap_get_insert_location_with_lock() function execution

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -20521,37 +20521,37 @@ heap_get_insert_location_with_lock (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONT
   slot_count = spage_number_of_slots (context->home_page_watcher_p->pgptr);
 
   /* find REC_DELETED_WILL_REUSE slot or add new slot */
-      slot_id = spage_find_free_slot (context->home_page_watcher_p->pgptr, NULL, slot_id);
+  slot_id = spage_find_free_slot (context->home_page_watcher_p->pgptr, NULL, slot_id);
 
-      context->res_oid.slotid = slot_id;
+  context->res_oid.slotid = slot_id;
 
-      if (lock == NULL_LOCK)
-	{
-	  /* immediately return without locking it */
-	  return NO_ERROR;
-	}
+  if (lock == NULL_LOCK)
+    {
+      /* immediately return without locking it */
+      return NO_ERROR;
+    }
 
-      /* lock the object to be inserted conditionally */
-      lk_result = lock_object (thread_p, &context->res_oid, &context->class_oid, lock, LK_COND_LOCK);
-      if (lk_result == LK_GRANTED)
-	{
-	  /* successfully locked! */
-	  return NO_ERROR;
-	}
-      else if (lk_result != LK_NOTGRANTED_DUE_TIMEOUT)
-	{
+  /* lock the object to be inserted conditionally */
+  lk_result = lock_object (thread_p, &context->res_oid, &context->class_oid, lock, LK_COND_LOCK);
+  if (lk_result == LK_GRANTED)
+    {
+      /* successfully locked! */
+      return NO_ERROR;
+    }
+  else if (lk_result != LK_NOTGRANTED_DUE_TIMEOUT)
+    {
 #if !defined(NDEBUG)
-	  if (lk_result == LK_NOTGRANTED_DUE_ABORTED)
-	    {
-	      LOG_TDES *tdes = LOG_FIND_CURRENT_TDES (thread_p);
-	      assert (tdes->tran_abort_reason == TRAN_ABORT_DUE_ROLLBACK_ON_ESCALATION);
-	    }
-	  else
-	    {
-	      assert (false);	/* unknown locking error */
-	    }
-#endif
+      if (lk_result == LK_NOTGRANTED_DUE_ABORTED)
+	{
+	  LOG_TDES *tdes = LOG_FIND_CURRENT_TDES (thread_p);
+	  assert (tdes->tran_abort_reason == TRAN_ABORT_DUE_ROLLBACK_ON_ESCALATION);
 	}
+      else
+	{
+	  assert (false);	/* unknown locking error */
+	}
+#endif
+    }
 
   /* either lock error or no slot was found in page (which should not happen) */
   OID_SET_NULL (&context->res_oid);

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -20456,8 +20456,7 @@ static int
 heap_get_insert_location_with_lock (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context,
 				    PGBUF_WATCHER * home_hint_p)
 {
-  int slot_count, lk_result;
-  int slot_id = 0;
+  int slot_count, lk_result, slot_id = 0;
   LOCK lock;
   int error_code = NO_ERROR;
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -20519,32 +20519,35 @@ heap_get_insert_location_with_lock (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONT
   /* find REC_DELETED_WILL_REUSE slot or add new slot */
   slot_id = spage_find_free_slot (context->home_page_watcher_p->pgptr, NULL, slot_id);
 
-  context->res_oid.slotid = slot_id;
+  if (slot_id != SP_ERROR)
+    {
+      context->res_oid.slotid = slot_id;
 
-  if (lock == NULL_LOCK)
-    {
-      /* immediately return without locking it */
-      return NO_ERROR;
-    }
-
-  /* lock the object to be inserted conditionally */
-  lk_result = lock_object (thread_p, &context->res_oid, &context->class_oid, lock, LK_COND_LOCK);
-  if (lk_result == LK_GRANTED)
-    {
-      /* successfully locked! */
-      return NO_ERROR;
-    }
-#if !defined(NDEBUG)
-  else if (lk_result != LK_NOTGRANTED_DUE_TIMEOUT)
-    {
-      if (lk_result == LK_NOTGRANTED_DUE_ABORTED)
+      if (lock == NULL_LOCK)
 	{
-	  LOG_TDES *tdes = LOG_FIND_CURRENT_TDES (thread_p);
-	  assert (tdes->tran_abort_reason == TRAN_ABORT_DUE_ROLLBACK_ON_ESCALATION);
+	  /* immediately return without locking it */
+	  return NO_ERROR;
 	}
-      else
+
+      /* lock the object to be inserted conditionally */
+      lk_result = lock_object (thread_p, &context->res_oid, &context->class_oid, lock, LK_COND_LOCK);
+      if (lk_result == LK_GRANTED)
 	{
-	  assert (false);	/* unknown locking error */
+	  /* successfully locked! */
+	  return NO_ERROR;
+	}
+#if !defined(NDEBUG)
+      else if (lk_result != LK_NOTGRANTED_DUE_TIMEOUT)
+	{
+	  if (lk_result == LK_NOTGRANTED_DUE_ABORTED)
+	    {
+	      LOG_TDES *tdes = LOG_FIND_CURRENT_TDES (thread_p);
+	      assert (tdes->tran_abort_reason == TRAN_ABORT_DUE_ROLLBACK_ON_ESCALATION);
+	    }
+	  else
+	    {
+	      assert (false);	/* unknown locking error */
+	    }
 	}
     }
 #endif

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -20534,9 +20534,9 @@ heap_get_insert_location_with_lock (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONT
       /* successfully locked! */
       return NO_ERROR;
     }
+#if !defined(NDEBUG)
   else if (lk_result != LK_NOTGRANTED_DUE_TIMEOUT)
     {
-#if !defined(NDEBUG)
       if (lk_result == LK_NOTGRANTED_DUE_ABORTED)
 	{
 	  LOG_TDES *tdes = LOG_FIND_CURRENT_TDES (thread_p);
@@ -20546,8 +20546,8 @@ heap_get_insert_location_with_lock (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONT
 	{
 	  assert (false);	/* unknown locking error */
 	}
-#endif
     }
+#endif
 
   /* either lock error or no slot was found in page (which should not happen) */
   OID_SET_NULL (&context->res_oid);

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -20549,8 +20549,8 @@ heap_get_insert_location_with_lock (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONT
 	      assert (false);	/* unknown locking error */
 	    }
 	}
-    }
 #endif
+    }
 
   /* either lock error or no slot was found in page (which should not happen) */
   OID_SET_NULL (&context->res_oid);

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -20456,7 +20456,7 @@ static int
 heap_get_insert_location_with_lock (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context,
 				    PGBUF_WATCHER * home_hint_p)
 {
-  int slot_count, lk_result, slot_id = 0;
+  int lk_result, slot_id = 0;
   LOCK lock;
   int error_code = NO_ERROR;
 
@@ -20515,9 +20515,6 @@ heap_get_insert_location_with_lock (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONT
 	  lock = X_LOCK;
 	}
     }
-
-  /* retrieve number of slots in page */
-  slot_count = spage_number_of_slots (context->home_page_watcher_p->pgptr);
 
   /* find REC_DELETED_WILL_REUSE slot or add new slot */
   slot_id = spage_find_free_slot (context->home_page_watcher_p->pgptr, NULL, slot_id);

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -20456,7 +20456,8 @@ static int
 heap_get_insert_location_with_lock (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context,
 				    PGBUF_WATCHER * home_hint_p)
 {
-  int slot_count, slot_id, lk_result;
+  int slot_count, lk_result;
+  int slot_id = 0;
   LOCK lock;
   int error_code = NO_ERROR;
 
@@ -20520,14 +20521,7 @@ heap_get_insert_location_with_lock (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONT
   slot_count = spage_number_of_slots (context->home_page_watcher_p->pgptr);
 
   /* find REC_DELETED_WILL_REUSE slot or add new slot */
-  /* slot_id == slot_count means add new slot */
-  for (slot_id = 0; slot_id <= slot_count; slot_id++)
-    {
       slot_id = spage_find_free_slot (context->home_page_watcher_p->pgptr, NULL, slot_id);
-      if (slot_id == SP_ERROR)
-	{
-	  break;		/* this will not happen */
-	}
 
       context->res_oid.slotid = slot_id;
 
@@ -20557,9 +20551,7 @@ heap_get_insert_location_with_lock (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONT
 	      assert (false);	/* unknown locking error */
 	    }
 #endif
-	  break;		/* go to error case */
 	}
-    }
 
   /* either lock error or no slot was found in page (which should not happen) */
   OID_SET_NULL (&context->res_oid);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25510

### Purpose
- heap_get_insert_location_with_lock() 함수에서 slot_id를 구할 때 spage_find_free_slot() 함수를 반복해서 호출한다.
- spage_find_free_slot() 함수 내부에서 반복문으로 slot_id를 찾기 때문에 heap_get_insert_location_with_lock() 함수에서 반복 호출할 필요가 없다.

### Implementation
- heap_get_insert_location_with_lock() 함수 내에서 slot_id를 구할 때 반복으로 호출하지 않도록 처리

### Remarks
- N/A
