### PR TITLE
[CBRD-24764] Fix start_vpid to not return NULL when the max_bestspace_entries parameter is greater than zero

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -3751,6 +3751,7 @@ heap_stats_sync_bestspace (THREAD_ENTRY * thread_p, const HFID * hfid, HEAP_HDR_
 	  search_all = true;
 	  start_pos = -1;
 	  next_vpid = heap_hdr->estimates.full_search_vpid;
+	  start_vpid = next_vpid;
 	}
       else
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24764

### Purpose
- start_vpid 값은 heap_stats_sync_bestspace() 함수에서 디버그 로깅 목적으로 사용됨
- max_bestspace_entries 파라미터의 값이 0보다 클 때 start_vpid 값이 {NULL_PAGEID, NULL_VOLID}로 할당됨
- 이로 인해 예상치 못한 정보가 쓰여질 수 있음

### Implementation
- max_bestspace_entries 파라미터의 값이 0보다 클 때 start_vpid의 값에 next_vpid의 값을 할당하도록 구현

### Remarks
- N/A