### PR TITLE
[CBRD-24941] minor fixes

### DIFF
--- a/pl_engine/pl_server/src/main/antlr/PlcParser.g4
+++ b/pl_engine/pl_server/src/main/antlr/PlcParser.g4
@@ -109,6 +109,7 @@ label_declaration
 statement
     : block                                 # stmt_block
     | sql_statement                         # stmt_sql              // must go before procedure_call
+    | cursor_manipulation_statement         # stmt_cursor_manipulation
     | raise_application_error_statement     # stmt_raise_app_err    // must go before procedure_call
     | execute_immediate                     # stmt_exec_imme
     | assignment_statement                  # stmt_assign
@@ -227,7 +228,6 @@ block
 
 sql_statement
     : static_sql
-    | cursor_manipulation_statement
     | transaction_control_statement
     ;
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -529,17 +529,23 @@ public class SpLib {
     // builtin exceptions
     // ---------------------------------------------------------------------------------------
 
+    private static int checkAppErrCode(int code) {
+        if (code <= CODE_APP_ERROR) {
+            throw new VALUE_ERROR("exception codes below " + (CODE_APP_ERROR + 1) + " are reserved");
+        }
+
+        return code;
+    }
+
     // user defined exception
     public static class $APP_ERROR extends PlcsqlRuntimeError {
         public $APP_ERROR(int code, String msg) {
-            super(code, isEmptyStr(msg) ? MSG_APP_ERROR : msg);
-        }
-
-        public $APP_ERROR(String msg) {
-            super(CODE_APP_ERROR, isEmptyStr(msg) ? MSG_APP_ERROR : msg);
+            // called for raise_application_error(...)
+            super(checkAppErrCode(code), isEmptyStr(msg) ? MSG_APP_ERROR : msg);
         }
 
         public $APP_ERROR() {
+            // called for user defined exceptions
             super(CODE_APP_ERROR, MSG_APP_ERROR);
         }
     }
@@ -4125,7 +4131,7 @@ public class SpLib {
     private static final int CODE_TOO_MANY_ROWS = 7;
     private static final int CODE_VALUE_ERROR = 8;
     private static final int CODE_ZERO_DIVIDE = 9;
-    private static final int CODE_APP_ERROR = 99;
+    private static final int CODE_APP_ERROR = 1000;
 
     private static final String MSG_CASE_NOT_FOUND = "case not found";
     private static final String MSG_CURSOR_ALREADY_OPEN = "cursor already open";

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -531,7 +531,8 @@ public class SpLib {
 
     private static int checkAppErrCode(int code) {
         if (code <= CODE_APP_ERROR) {
-            throw new VALUE_ERROR("exception codes below " + (CODE_APP_ERROR + 1) + " are reserved");
+            throw new VALUE_ERROR(
+                    "exception codes below " + (CODE_APP_ERROR + 1) + " are reserved");
         }
 
         return code;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24941

사용자매뉴얼을 작성하던 중 매뉴얼 내용과 일치하기 위해 몇 가지 수정을 했습니다. 
. 커서조작문을 문법 계층상에서 한칸 위로 이동
. 사용자정의 exception의 코드를 99에서 1000으로 바꿈: 빌트인 exception code 가 이 값보다 작아야 하는데, 너무 작은 듯 해서.
. 1000 이하의 exception 코드를 raise_application_error 에 사용했을 때 에러: 빌트인 함수의 code 와 겹칠 수 있으므로
