### PR TITLE
[CBRD-27515] When executing diagdb -d 5, infinite blank space is output.

### DIFF
--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -1729,8 +1729,8 @@ locator_print_class_name (THREAD_ENTRY * thread_p, FILE * outfp, const void *key
   int *class_no_p = (int *) args;
   LOCATOR_CLASSNAME_ACTION *action;
   const char *str_action;
-  size_t i;
-  size_t key_size;
+  int i;
+  int key_size;
 
   assert (class_no_p != NULL);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25715

- It caused by modification of CBRD-21796.
- Type of local variables(i, key_len) is revert size_t to int.
