### PR TITLE
[CBRD-25716] Change "The stats is not updated" for tables not updated stats at info stats [table]

### DIFF
--- a/src/storage/statistics_cl.c
+++ b/src/storage/statistics_cl.c
@@ -324,7 +324,15 @@ stats_dump (const char *class_name_p, FILE * file_p)
 
   fprintf (file_p, "\nCLASS STATISTICS\n");
   fprintf (file_p, "****************\n");
-  fprintf (file_p, " Class name: %s Timestamp: %s", class_name_p, ctime (&tloc));
+  fprintf (file_p, " Class name: %s", class_name_p);
+  if (tloc == 0)
+    {
+      fprintf (file_p, " (The stats is not updated)\n");
+    }
+  else
+    {
+      fprintf (file_p, " Timestamps: %s", ctime (&tloc));
+    }
   fprintf (file_p, " Total pages in class heap: %d\n", class_stats_p->heap_num_pages);
   fprintf (file_p, " Total objects: %d\n", class_stats_p->heap_num_objects);
   fprintf (file_p, " Number of attributes: %d\n", class_stats_p->n_attrs);

--- a/src/storage/statistics_cl.c
+++ b/src/storage/statistics_cl.c
@@ -327,7 +327,7 @@ stats_dump (const char *class_name_p, FILE * file_p)
   fprintf (file_p, " Class name: %s", class_name_p);
   if (tloc == 0)
     {
-      fprintf (file_p, " (The stats is not updated)\n");
+      fprintf (file_p, " (The 'stats' is not updated)\n");
     }
   else
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25716

- Change the output to "The Stats is not updated" for tables not updated stats instead of timestamp at info stats [table].

