### PR TITLE
[CBRD-25718] REPEAT 함수의 리턴 타입은 VARCHAR타입이어야 함

### DIFF
--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -8874,11 +8874,11 @@ qstr_grow_string (DB_VALUE * src_string, DB_VALUE * result, int new_size)
     }
   if (QSTR_IS_NATIONAL_CHAR (src_type))
     {
-      result_type = DB_TYPE_NCHAR;
+      result_type = DB_TYPE_VARNCHAR;
     }
   else
     {
-      result_type = DB_TYPE_CHAR;
+      result_type = DB_TYPE_VARCHAR;
     }
 
   codeset = db_get_string_codeset (src_string);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25718

REPEAT 함수의 결과 타입이 매뉴얼에는 VARCHAR타입으로 되어 있는데, 실제 동작은 CHAR타입입니다. CHAR타입의 최대 길이를 2048로 제한하는 이슈([CBRD-25713](http://jira.cubrid.org/browse/CBRD-25713))에서 실패한 테스트 케이스를 분석 중 발견되었습니다.
