### PR TITLE
[CBRD-25714] 필터 인덱스 생성 중 core dump 발생

### DIFF
--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -3007,6 +3007,11 @@ classobj_make_index_filter_pred_info (DB_SEQ * pred_seq)
     {
       goto error;
     }
+
+  filter_predicate->pred_string = NULL;
+  filter_predicate->pred_stream = NULL;
+  filter_predicate->att_ids = NULL;
+
   if (val_str_len > 0)
     {
       filter_predicate->pred_string = (char *) db_ws_alloc (val_str_len + 1);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25714

[CBRD-25713](http://jira.cubrid.org/browse/CBRD-25713) 이슈를 수정하던 중 발생한 이슈로 10버전 혹은 그 이전 부터 가지고 있던 잠재적 버그로 인식이 됩니다.