### PR TITLE
[CBRD-25696] Remove unused variables in lock_manager.c

### DIFF
--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -3240,7 +3240,6 @@ lock_internal_perform_lock_object (THREAD_ENTRY * thread_p, int tran_index, cons
 {
   LF_TRAN_ENTRY *t_entry_ent = thread_get_tran_entry (thread_p, THREAD_TS_OBJ_LOCK_ENT);
   LK_RES_KEY search_key;
-  TRAN_ISOLATION isolation;
   int ret_val;
   LOCK group_mode, old_mode, new_mode;	/* lock mode */
   LK_RES *res_ptr;
@@ -3308,9 +3307,6 @@ lock_internal_perform_lock_object (THREAD_ENTRY * thread_p, int tran_index, cons
 	       wait_msecs);
     }
 #endif /* LK_DUMP */
-
-  /* isolation */
-  isolation = logtb_find_isolation (tran_index);
 
   /* initialize */
   *entry_addr_ptr = NULL;
@@ -5946,7 +5942,6 @@ lock_object (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LO
 #else /* !SERVER_MODE */
   int tran_index;
   int wait_msecs;
-  TRAN_ISOLATION isolation;
   LOCK new_class_lock;
   LOCK old_class_lock;
   int granted;
@@ -6028,7 +6023,6 @@ lock_object (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LO
     {
       wait_msecs = logtb_find_wait_msecs (tran_index);
     }
-  isolation = logtb_find_isolation (tran_index);
 
   /* check if the given oid is root class oid */
   if (OID_IS_ROOTOID (oid))
@@ -6160,7 +6154,6 @@ lock_subclass (THREAD_ENTRY * thread_p, const OID * subclass_oid, const OID * su
   int granted;
   int tran_index;
   int wait_msecs;
-  TRAN_ISOLATION isolation;
 #if defined (EnableThreadMonitoring)
   TSC_TICKS start_tick, end_tick;
   TSCTIMEVAL elapsed_time;
@@ -6199,7 +6192,6 @@ lock_subclass (THREAD_ENTRY * thread_p, const OID * subclass_oid, const OID * su
     {
       wait_msecs = logtb_find_wait_msecs (tran_index);
     }
-  isolation = logtb_find_isolation (tran_index);
 
   /* get the intentional lock mode to be acquired on class oid */
   if (lock <= S_LOCK)
@@ -6307,7 +6299,6 @@ lock_scan (THREAD_ENTRY * thread_p, const OID * class_oid, int cond_flag, LOCK c
 #else /* !SERVER_MODE */
   int tran_index;
   int wait_msecs;
-  TRAN_ISOLATION isolation;
   int granted;
   LK_ENTRY *root_class_entry = NULL;
   LK_ENTRY *class_entry = NULL;
@@ -6339,7 +6330,6 @@ lock_scan (THREAD_ENTRY * thread_p, const OID * class_oid, int cond_flag, LOCK c
       assert (cond_flag == LK_UNCOND_LOCK);
       wait_msecs = logtb_find_wait_msecs (tran_index);
     }
-  isolation = logtb_find_isolation (tran_index);
 
   /* acquire the lock on the class */
   /* NOTE that in case of acquiring a lock on a class object, the higher lock granule of the class object is not given. */
@@ -6396,7 +6386,6 @@ lock_classes_lock_hint (THREAD_ENTRY * thread_p, LC_LOCKHINT * lockhint)
 #else /* !SERVER_MODE */
   int tran_index;
   int wait_msecs;
-  TRAN_ISOLATION isolation;
   LK_LOCKINFO cls_lockinfo_space[LK_LOCKINFO_FIXED_COUNT];
   LK_LOCKINFO *cls_lockinfo;
   LK_ENTRY *root_class_entry = NULL;
@@ -6433,7 +6422,6 @@ lock_classes_lock_hint (THREAD_ENTRY * thread_p, LC_LOCKHINT * lockhint)
 
   tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
   wait_msecs = logtb_find_wait_msecs (tran_index);
-  isolation = logtb_find_isolation (tran_index);
 
   /* We do not want to rollback the transaction in the event of a deadlock. For now, let's just wait a long time. If
    * deadlock, the transaction is going to be notified of lock timeout instead of aborted. */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25696

### Purpose
- lock_manager.c 파일에 선언 및 할당만 되고 사용되지 않는 변수가 존재한다.
- 이를 정리하기 위해 해당 변수를 제거한다.

### Implementation
- 불필요하게 선언된 변수 제거
  - 제거된 변수가 존재하는 함수: lock_internal_perform_lock_object(), lock_object(), lock_subclass(), lock_scan(), lock_classes_lock_hint()

### Remarks
- N/A