### PR TITLE
[CBRD-25645] [bug-fix] Assert when restarting server after committing some XA transactions

### DIFF
--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -8272,8 +8272,10 @@ lock_reacquire_crash_locks (THREAD_ENTRY * thread_p, LK_ACQUIRED_LOCKS * acqlock
        * lock wait duration       : LK_INFINITE_WAIT
        * conditional lock request : false
        */
-      r = lock_internal_perform_lock_object (thread_p, tran_index, &acqlocks->obj[i].oid, &acqlocks->obj[i].class_oid,
-					     acqlocks->obj[i].lock, LK_INFINITE_WAIT, &dummy_ptr, NULL);
+      r =
+	lock_internal_perform_lock_object (thread_p, tran_index, &acqlocks->obj[i].oid,
+					   OID_IS_ROOTOID (&acqlocks->obj[i].oid) ? NULL : &acqlocks->obj[i].class_oid,
+					   acqlocks->obj[i].lock, LK_INFINITE_WAIT, &dummy_ptr, NULL);
       if (r != LK_GRANTED)
 	{
 	  er_log_debug (ARG_FILE_LINE, "lk_reacquire_crash_locks: The lock cannot be reacquired...");


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25645

### Description
- 2PC 테스트에서 서버 stop 시 발생하는 core 이슈 해결
- lock_internal_perform_lock_object() 호출 시 oid가 root class인 경우 class_oid는 NULL로 넘겨주어야 하나 처리하지 않아서 발생하는 문제

### Implementation
- 문제가 발생한 lock_reacquire_crash_locks() 함수에서 lock_internal_perform_lock_object() 호출 시 oid가 root class인 경우 class_oid는 NULL로 넘겨주도록 수정

### Remarks
- 테스트 과정 중 추가적인 core 이슈가 발견되었으며, 이는 별도의 PR 또는 이슈로 처리할 것임