### PR TITLE
[CBRD-25694] regression: SP에서 OID 인수에 대해 heap_next()에서 eval_data_filter()에 NULL OID가 전달되는 현상

### DIFF
--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -5321,6 +5321,11 @@ scan_next_heap_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
       /* evaluate the predicates to see if the object qualifies */
       scan_id->scan_stats.read_rows++;
 
+      if (OID_ISNULL (p_current_oid))
+	{
+	  COPY_OID (p_current_oid, &hsidp->curr_oid);
+	}
+
       ev_res = eval_data_filter (thread_p, p_current_oid, &recdes, &hsidp->scan_cache, &data_filter);
       if (ev_res == V_ERROR)
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25694

**Background**
target query: https://github.com/CUBRID/cubrid-testcases/blob/develop/sql/_08_javasp/cases/418-4.sql
test_oid1은 xoo의 OID를 그대로 반환합니다. xoo = testoid1(xoo) 가 조건이 true로 반환되어야 하지만 testoid1의 인수가 NULL OID가 전달되고 있습니다.
```
update xoo set id = 100 where xoo = testoid1(xoo);
```

scan_next_heap_scan () 의 최상단에서 p_current_oid를 초기화 하지만, 이때에는 hsidp->curr_oid가 NULL OID로 초기화 되어 있으며, 이후 스캔을 진행한 후 hsidp->curr_oid의 값이 올바르게 설정되므로, p_current_oid의 NULL OID 여부를 확인한 후 hsidp->curr_oid의 OID를 전달할 수 있도록 수정했습니다.
```
  if (scan_id->mvcc_select_lock_needed)
    {
      COPY_OID (&current_oid, &hsidp->curr_oid);
      p_current_oid = &current_oid;
    }
  else
    {
      p_current_oid = &hsidp->curr_oid;
    }
```
