### PR TITLE
[CBRD-25352] Fix the changes in the _db_stored_procedure_args catalog table in the check_reserved.sql file.

### DIFF
--- a/contrib/scripts/check_reserved.sql
+++ b/contrib/scripts/check_reserved.sql
@@ -31,7 +31,7 @@ UNION ALL
 SELECT 'stored_proc', sp_name, '', ''
 FROM   _db_stored_procedure WHERE sp_name IN :reserved
 UNION ALL
-SELECT 'stored_proc_arg', arg_name, '', sp_name
+SELECT 'stored_proc_arg', arg_name, '', sp_of.sp_name
 FROM   _db_stored_procedure_args WHERE arg_name IN :reserved
 UNION ALL
 SELECT 'user', name, '', ''


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25352

메뉴얼테스트를 진행하면서  "shell/_06_issues/_11_1h/bug_bts_5336/cases/bug_bts_5336.sh" TC의 오류를 수정합니다.

위 TC 스크립트에서 엔진에 포함된 ( $CUBRID/share/scripts/check_reserved.sql )를 실행합니다.

_db_stored_procedure_args 카탈로그 테이블의 변경으로 인한 오류를 수정합니다.

