### PR TITLE
[CBRD-25686] regression: WITH ROLLUP 구문에 의해 인수가 NULL로 입력되는 경우 처리

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/StoredProcedure.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/StoredProcedure.java
@@ -138,9 +138,26 @@ public class StoredProcedure {
         Object[] resolved = new Object[args.length];
         for (int i = 0; i < args.length; i++) {
             resolved[i] = args[i].getResolved();
+            if (resolved[i] == null && target.getArgsTypes()[i].isPrimitive()) {
+                resolved[i] = getDefaultValueForPrimitive(target.getArgsTypes()[i]);
+            }
         }
 
         return resolved;
+    }
+
+    private Object getDefaultValueForPrimitive(Class<?> primitiveType) {
+        if (primitiveType == boolean.class) return false;
+        if (primitiveType == char.class) return '\0';
+        if (primitiveType == byte.class) return (byte) 0;
+        if (primitiveType == short.class) return (short) 0;
+        if (primitiveType == int.class) return 0;
+        if (primitiveType == long.class) return 0L;
+        if (primitiveType == float.class) return 0f;
+        if (primitiveType == double.class) return 0d;
+
+        throw new IllegalArgumentException(
+                "Unsupported primitive type with null: " + primitiveType);
     }
 
     private void checkArgs() throws TypeMismatchException {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25686

WITH ROLLUP 구문에서 Primitive 타입 인수에 NULL을 전달하는 경우에 illegalArgumentException이 발생한다. 이 경우 해당 primitvie type의 기본값을 전달하여 -889 에러 대신 해당 primitive 타입의 기본값이 전달되도록 한다.