### PR TITLE
[CBRD-25028] Disable heap_chnguess_realloc() function, which is inaccessible from heap_Guesschn

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -670,7 +670,7 @@ static int heap_scancache_end_internal (THREAD_ENTRY * thread_p, HEAP_SCANCACHE 
 #if defined (ENABLE_UNUSED_FUNCTION)
 static SCAN_CODE heap_get_if_diff_chn (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, INT16 slotid, RECDES * recdes,
 				       bool ispeeking, int chn, MVCC_SNAPSHOT * mvcc_snapshot);
-#endif
+#endif /* ENABLE_UNUSED_FUNCTION */
 static int heap_estimate_avg_length (THREAD_ENTRY * thread_p, const HFID * hfid, int &avg_reclen);
 static int heap_get_capacity (THREAD_ENTRY * thread_p, const HFID * hfid, INT64 * num_recs, INT64 * num_recs_relocated,
 			      INT64 * num_recs_inovf, INT64 * num_pages, int *avg_freespace, int *avg_freespace_nolast,
@@ -723,7 +723,7 @@ static DISK_ISVALID heap_chkreloc_next (THREAD_ENTRY * thread_p, HEAP_CHKALL_REL
 static int heap_chnguess_initialize (void);
 #if defined(ENABLE_UNUSED_FUNCTION)
 static int heap_chnguess_realloc (void);
-#endif
+#endif /* ENABLE_UNUSED_FUNCTION */
 static int heap_chnguess_finalize (void);
 static int heap_chnguess_decache (const OID * oid);
 static int heap_chnguess_remove_entry (const void *oid_key, void *ent, void *xignore);
@@ -741,7 +741,7 @@ static int heap_stats_del_bestspace_by_vpid (THREAD_ENTRY * thread_p, VPID * vpi
 static int heap_stats_del_bestspace_by_hfid (THREAD_ENTRY * thread_p, const HFID * hfid);
 #if defined (ENABLE_UNUSED_FUNCTION)
 static HEAP_BESTSPACE heap_stats_get_bestspace_by_vpid (THREAD_ENTRY * thread_p, VPID * vpid);
-#endif
+#endif /* ENABLE_UNUSED_FUNCTION */
 static HEAP_STATS_ENTRY *heap_stats_add_bestspace (THREAD_ENTRY * thread_p, const HFID * hfid, VPID * vpid,
 						   int freespace);
 static int heap_stats_entry_free (THREAD_ENTRY * thread_p, void *data, void *args);

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -670,7 +670,7 @@ static int heap_scancache_end_internal (THREAD_ENTRY * thread_p, HEAP_SCANCACHE 
 #if defined (ENABLE_UNUSED_FUNCTION)
 static SCAN_CODE heap_get_if_diff_chn (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, INT16 slotid, RECDES * recdes,
 				       bool ispeeking, int chn, MVCC_SNAPSHOT * mvcc_snapshot);
-#endif /* ENABLE_UNUSED_FUNCTION */
+#endif
 static int heap_estimate_avg_length (THREAD_ENTRY * thread_p, const HFID * hfid, int &avg_reclen);
 static int heap_get_capacity (THREAD_ENTRY * thread_p, const HFID * hfid, INT64 * num_recs, INT64 * num_recs_relocated,
 			      INT64 * num_recs_inovf, INT64 * num_pages, int *avg_freespace, int *avg_freespace_nolast,
@@ -723,7 +723,7 @@ static DISK_ISVALID heap_chkreloc_next (THREAD_ENTRY * thread_p, HEAP_CHKALL_REL
 static int heap_chnguess_initialize (void);
 #if defined(ENABLE_UNUSED_FUNCTION)
 static int heap_chnguess_realloc (void);
-#endif /* #if defined (ENABLE_UNUSED_FUNCTION) */
+#endif
 static int heap_chnguess_finalize (void);
 static int heap_chnguess_decache (const OID * oid);
 static int heap_chnguess_remove_entry (const void *oid_key, void *ent, void *xignore);
@@ -741,7 +741,7 @@ static int heap_stats_del_bestspace_by_vpid (THREAD_ENTRY * thread_p, VPID * vpi
 static int heap_stats_del_bestspace_by_hfid (THREAD_ENTRY * thread_p, const HFID * hfid);
 #if defined (ENABLE_UNUSED_FUNCTION)
 static HEAP_BESTSPACE heap_stats_get_bestspace_by_vpid (THREAD_ENTRY * thread_p, VPID * vpid);
-#endif /* #if defined (ENABLE_UNUSED_FUNCTION) */
+#endif
 static HEAP_STATS_ENTRY *heap_stats_add_bestspace (THREAD_ENTRY * thread_p, const HFID * hfid, VPID * vpid,
 						   int freespace);
 static int heap_stats_entry_free (THREAD_ENTRY * thread_p, void *data, void *args);

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -721,7 +721,9 @@ static int heap_chkreloc_print_notfound (const void *ignore_reloc_oid, void *ent
 static DISK_ISVALID heap_chkreloc_next (THREAD_ENTRY * thread_p, HEAP_CHKALL_RELOCOIDS * chk, PAGE_PTR pgptr);
 
 static int heap_chnguess_initialize (void);
+#if defined(ENABLE_UNUSED_FUNCTION)
 static int heap_chnguess_realloc (void);
+#endif /* #if defined (ENABLE_UNUSED_FUNCTION) */
 static int heap_chnguess_finalize (void);
 static int heap_chnguess_decache (const OID * oid);
 static int heap_chnguess_remove_entry (const void *oid_key, void *ent, void *xignore);
@@ -15215,6 +15217,7 @@ exit_on_error:
   return (ret == NO_ERROR) ? ER_FAILED : ret;
 }
 
+#if defined(ENABLE_UNUSED_FUNCTION)
 /*
  * heap_chnguess_realloc () - More clients that currently maintained
  *   return: NO_ERROR
@@ -15296,6 +15299,7 @@ exit_on_error:
 
   return (ret == NO_ERROR && (ret = er_errid ()) == NO_ERROR) ? ER_FAILED : ret;
 }
+#endif /* ENABLE_UNUSED_FUNCTION */
 
 /*
  * heap_chnguess_finalize () - Finish chnguess information
@@ -15575,14 +15579,7 @@ heap_chnguess_get (THREAD_ENTRY * thread_p, const OID * oid, int tran_index)
 
   if (heap_Guesschn != NULL)
     {
-      if (heap_Guesschn->num_clients <= tran_index)
-	{
-	  if (heap_chnguess_realloc () != NO_ERROR)
-	    {
-	      csect_exit (thread_p, CSECT_HEAP_CHNGUESS);
-	      return NULL_CHN;
-	    }
-	}
+      assert (heap_Guesschn->num_clients > tran_index);
 
       /*
        * Do we have this entry in hash table, if we do then check corresponding
@@ -15630,14 +15627,7 @@ heap_chnguess_put (THREAD_ENTRY * thread_p, const OID * oid, int tran_index, int
       return NULL_CHN;
     }
 
-  if (heap_Guesschn->num_clients <= tran_index)
-    {
-      if (heap_chnguess_realloc () != NO_ERROR)
-	{
-	  csect_exit (thread_p, CSECT_HEAP_CHNGUESS);
-	  return NULL_CHN;
-	}
-    }
+  assert (heap_Guesschn->num_clients > tran_index);
 
   /*
    * Is the entry already in the chnguess hash table ?


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25028

### Purpose
- insert/delete/update 작업을 할 때 heap_Guesschn 캐시에 정보를 가져오거나 넣는다.
- 이때 조건에 따라 heap_chnguess_realloc() 함수를 실행시킨다.
- 이 조건은 (heap_Guesschn->num_clients <= tran_index) 인데, heap_Guesschn->num_clients 값은 부팅 과정에서 MAX_NTRANS로 초기화되고, tran_index 값은 MAX_NTRANS보다 작은 값으로 고정되기 때문에 해당 조건은 실행될 수 없다.

### Implementation
- 접근할 수 없는 heap_chnguess_realloc() 함수 비활성화

### Remarks
- N/A