### PR TITLE
[CUBVEC-12] Add VECTOR to Lexer and Parser

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -1093,6 +1093,7 @@ static char *g_plcsql_text;
 %type <c2> class_name_with_server_name
 %type <c2> opt_index_with_clause
 %type <c2> index_with_item_list
+%type <c2> opt_vector_args
 
 
 /*}}}*/
@@ -21890,7 +21891,7 @@ primitive_type
 
 			$$ = ctn;
 	  DBG_PRINT}}
-  | VECTOR
+  | VECTOR opt_vector_args
 		{{ DBG_TRACE_GRAMMAR(data_type, | vector_type);
 
 			container_2 ctn;
@@ -21899,6 +21900,37 @@ primitive_type
 
 		DBG_PRINT}}
 	;
+
+opt_vector_args
+  : /* empty */
+		{{ DBG_TRACE_GRAMMAR(opt_vector_args, : );
+
+			container_2 ctn;
+			SET_CONTAINER_2 (ctn, NULL, NULL);
+			$$ = ctn;
+
+		DBG_PRINT}}
+	| '(' unsigned_integer ')'
+		{{ DBG_TRACE_GRAMMAR(opt_vector_args, | '(' unsigned_integer ')' );
+
+			container_2 ctn;
+			SET_CONTAINER_2 (ctn, $2, NULL);
+			$$ = ctn;
+
+		DBG_PRINT}}
+	| '(' unsigned_integer ',' primitive_type ')'
+		{{ DBG_TRACE_GRAMMAR(opt_vector_args, | '(' unsigned_integer ',' primitive_type ')' );
+
+			container_2 ctn;
+      // TODO: primitive_type not yet handled.
+      container_2 primitive_type_container = $4;
+
+			SET_CONTAINER_2 (ctn, $2, NULL);
+			$$ = ctn;
+
+		DBG_PRINT}}
+	;
+
 
 opt_internal_external
 	: /* empty */

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -21919,7 +21919,7 @@ opt_vector_args
 
 		DBG_PRINT}}
 	| '(' unsigned_integer ',' FLOAT_ ')'
-		{{ DBG_TRACE_GRAMMAR(opt_vector_args, | '(' unsigned_integer ',' primitive_type ')' );
+		{{ DBG_TRACE_GRAMMAR(opt_vector_args, | '(' unsigned_integer ',' FLOAT_ ')' );
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, $2, FROM_NUMBER(PT_TYPE_FLOAT));

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -21905,28 +21905,19 @@ opt_vector_args
   : /* empty */
 		{{ DBG_TRACE_GRAMMAR(opt_vector_args, : );
 
-			container_2 ctn;
-			SET_CONTAINER_2 (ctn, NULL, NULL);
-			$$ = ctn;
+      // TODO
 
 		DBG_PRINT}}
 	| '(' unsigned_integer ')'
 		{{ DBG_TRACE_GRAMMAR(opt_vector_args, | '(' unsigned_integer ')' );
 
-			container_2 ctn;
-			SET_CONTAINER_2 (ctn, $2, NULL);
-			$$ = ctn;
+      // TODO
 
 		DBG_PRINT}}
 	| '(' unsigned_integer ',' primitive_type ')'
 		{{ DBG_TRACE_GRAMMAR(opt_vector_args, | '(' unsigned_integer ',' primitive_type ')' );
 
-			container_2 ctn;
-      // TODO: primitive_type not yet handled.
-      container_2 primitive_type_container = $4;
-
-			SET_CONTAINER_2 (ctn, $2, NULL);
-			$$ = ctn;
+      // TODO
 
 		DBG_PRINT}}
 	;

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -21905,19 +21905,25 @@ opt_vector_args
   : /* empty */
 		{{ DBG_TRACE_GRAMMAR(opt_vector_args, : );
 
-      // TODO
+			container_2 ctn;
+			SET_CONTAINER_2 (ctn, NULL, NULL);
+			$$ = ctn;
 
 		DBG_PRINT}}
 	| '(' unsigned_integer ')'
 		{{ DBG_TRACE_GRAMMAR(opt_vector_args, | '(' unsigned_integer ')' );
 
-      // TODO
+			container_2 ctn;
+			SET_CONTAINER_2 (ctn, $2, NULL);
+			$$ = ctn;
 
 		DBG_PRINT}}
-	| '(' unsigned_integer ',' primitive_type ')'
+	| '(' unsigned_integer ',' FLOAT_ ')'
 		{{ DBG_TRACE_GRAMMAR(opt_vector_args, | '(' unsigned_integer ',' primitive_type ')' );
 
-      // TODO
+			container_2 ctn;
+			SET_CONTAINER_2 (ctn, $2, FROM_NUMBER(PT_TYPE_FLOAT));
+			$$ = ctn;
 
 		DBG_PRINT}}
 	;

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -1461,6 +1461,7 @@ static char *g_plcsql_text;
 %token VARIABLE_
 %token VARYING
 %token VCLASS
+%token VECTOR
 %token VIEW
 %token WHEN
 %token WHENEVER
@@ -21889,6 +21890,14 @@ primitive_type
 
 			$$ = ctn;
 	  DBG_PRINT}}
+  | VECTOR
+		{{ DBG_TRACE_GRAMMAR(data_type, | vector_type);
+
+			container_2 ctn;
+			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_VECTOR), NULL);
+			$$ = ctn;
+
+		DBG_PRINT}}
 	;
 
 opt_internal_external

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -21898,6 +21898,11 @@ primitive_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_VECTOR), NULL);
 			$$ = ctn;
 
+            // TODO: The opt_vector_args are not covered in this milestone.
+			// Dimension and type validation for VECTOR arguments must be included
+			// in the milestone that checks user input for correctness.
+
+
 		DBG_PRINT}}
 	;
 

--- a/src/parser/csql_lexer.l
+++ b/src/parser/csql_lexer.l
@@ -1054,6 +1054,7 @@ IDL       [a-zA-Z0-9_]
 										return VARIANCE; }
 [vV][aA][rR][yY][iI][nN][gG]						{ begin_token(yytext);   return VARYING; }
 [vV][cC][lL][aA][sS][sS]						{ begin_token(yytext);   return VCLASS; }
+[vV][eE][cC][tT][oO][rR]						{ begin_token(yytext);   return VECTOR; }
 [vV][iI][eE][wW]							{ begin_token(yytext);   return VIEW; }
 [vV][iI][sS][iI][bB][lL][eE]						{ begin_token(yytext);
 										csql_yylval.cptr = pt_makename(yytext);

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -1106,6 +1106,7 @@ enum pt_type_enum
   PT_TYPE_LOGICAL,
   PT_TYPE_MAYBE,
   PT_TYPE_JSON,
+  PT_TYPE_VECTOR,
 
   /* special values */
   PT_TYPE_NA,			/* in SELECT NA */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-12

## Purpose

파서에서 `VECTOR` 데이터 타입을 지원하도록 추가하여, 향후 벡터 처리와 관련된 기능을 구현할 수 있는 기반을 마련합니다.

## Implementation

### 1. **VECTOR 타입 토큰 추가**
- **파일:** `src/parser/csql_lexer.l`
- **변경 내용:**
  ```c
  [vV][eE][cC][tT][oO][rR] { begin_token(yytext); return VECTOR; }
  ```

### 2. **VECTOR 토큰 정의**
- **파일:** `src/parser/csql_grammar.y`
- **변경 내용:**
  ```c
  %token VECTOR
  ```
  - VECTOR 키워드가 토큰으로 정의되었습니다.

### 3. **VECTOR 타입 문법 추가**
- **파일:** `src/parser/csql_grammar.y`
- **변경 내용:**
  ```c
  data_type
    ...
    | VECTOR opt_vector_args
        {{ DBG_TRACE_GRAMMAR(data_type, | vector_type);
          container_2 ctn;
          SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_VECTOR), NULL);
          $$ = ctn;
          DBG_PRINT}}
  ;
  ```
  - `VECTOR` 타입을 `data_type` 문법에 추가했습니다.
  - `VECTOR` 키워드 뒤에 `opt_vector_args`(선택적 인자)를 처리할 수 있도록 구현했습니다.
  - 반환 값은 `container_2` 구조체로 설정되며, 타입은 `PT_TYPE_VECTOR`로 지정됩니다.
  - NUMERIC을 모방했습니다.

> opt_vector_args는 현재 사용되지 않습니다. Syntax Error를 방지하는 역할만 수행하며, dimension과 type에 대한 validation은 추후 다른 마일스톤에 포함될 예정입니다.

### 4. **VECTOR 선택적 인자 처리**
- **파일:** `src/parser/csql_grammar.y`
- **변경 내용:**
  ```c
  opt_vector_args
    : /* empty */
        ...
    | '(' unsigned_integer ')'
        ...
    | '(' unsigned_integer ',' primitive_type ')'
        ...
  ;
  ```
  - `VECTOR` 뒤에 올 수 있는 선택적 인자를 처리하는 문법 규칙입니다.
  - 세 가지 경우를 처리:
    1. 인자가 없는 경우 (`/* empty */`).
    2. 정수 하나가 괄호 안에 오는 경우 (`(unsigned_integer)`).
    3. 정수와 데이터 타입이 함께 오는 경우 (`(unsigned_integer, primitive_type)`).
  - **TODO:** `primitive_type` 처리가 아직 구현되지 않았습니다.

### 5. **구문 트리 타입 추가**
- **파일:** `src/parser/parse_tree.h`
- **변경 내용:**
  ```c
  PT_TYPE_VECTOR,
  ```
  - 새로운 데이터 타입 `PT_TYPE_VECTOR`가 구문 트리의 타입(enum)에 추가되었습니다.

---

## 코드 실행 흐름

1. **토큰 처리 (Lexer 단계)**:
   - 입력에서 `VECTOR` 키워드를 인식하면 `VECTOR` 토큰이 반환
2. **구문 분석 (Parser 단계)**:
   - `data_type` 규칙에서 `VECTOR opt_vector_args`를 인식
   - `opt_vector_args`는 선택적 인자를 처리
3. **구문 트리 생성**:
   - 타입은 `PT_TYPE_VECTOR`로 설정

