### PR TITLE
[CBRD-25292] [CBRD-25389] COMMIT/ROLLBACK 시 PL에서 사용된 query handler를 지연해서 제거

### DIFF
--- a/src/communication/network_cl.c
+++ b/src/communication/network_cl.c
@@ -48,6 +48,7 @@
 #include "environment_variable.h"
 #include "boot_cl.h"
 #include "query_method.hpp"
+#include "method_callback.hpp"
 
 #include "release_string.h"
 #include "log_comm.h"
@@ -1714,6 +1715,15 @@ net_client_request_with_callback (int request, char *argbuf, int argsize, char *
 	}
       while (server_request != END_CALLBACK && server_request != QUERY_END);
 
+      /*
+       * delete deferred query handlers during PL execution
+       * TODO: move it to proper place
+       */
+      if (!tran_is_in_libcas ())
+	{
+	  cubmethod::get_callback_handler ()->free_deferred_query_handler ();
+	}
+
       if (histo_is_collecting ())
 	{
 	  int recevied = replysize
@@ -1906,6 +1916,15 @@ net_client_request_method_callback (int request, char *argbuf, int argsize, char
 	}
     }
   while (server_request != END_CALLBACK);
+
+  /*
+   * delete deferred query handlers during PL execution
+   * TODO: move it to proper place
+   */
+  if (!tran_is_in_libcas ())
+    {
+      cubmethod::get_callback_handler ()->free_deferred_query_handler ();
+    }
 
   if (histo_is_collecting ())
     {

--- a/src/method/method_callback.cpp
+++ b/src/method/method_callback.cpp
@@ -174,16 +174,16 @@ namespace cubmethod
   {
     std::string sql;
     int flag;
-    unpacker.unpack_all (sql, flag);
+    TRANID tid;
+    unpacker.unpack_all (sql, flag, tid);
 
     /* find in m_sql_handler_map */
-    query_handler *handler = get_query_handler_by_sql (sql);
-    if (handler != nullptr)
-      {
-	/* found in statement handler cache */
-	handler->set_is_occupied (true);
-      }
-    else
+    query_handler *handler = get_query_handler_by_sql (sql, [&] (query_handler *h)
+    {
+      return h->get_is_occupied() == false && (h->get_tran_id () == NULL_TRANID || h->get_tran_id() == tid);
+    });
+
+    if (handler == nullptr)
       {
 	/* not found in statement handler cache */
 	handler = new_query_handler ();
@@ -199,6 +199,7 @@ namespace cubmethod
 	      {
 		// add to statement handler cache
 		m_sql_handler_map.emplace (sql, handler->get_id ());
+		handler->set_tran_id (tid);
 	      }
 	    else
 	      {
@@ -207,9 +208,11 @@ namespace cubmethod
 	  }
       }
 
-    /* DDL audit */
-    if (handler)
+    if (handler != nullptr)
       {
+	handler->set_is_occupied (true);
+
+	/* DDL audit */
 	DB_SESSION *hdl_session = handler->get_db_session();
 	logddl_set_callback_stmt (handler->get_statement_type(), (char *) sql.c_str (), sql.size (), m_error_ctx.get_error (),
 				  ((hdl_session && hdl_session->parser) ?  & (hdl_session->parser->hide_pwd_info) : NULL));
@@ -982,7 +985,7 @@ exit:
 	    // clear <SQL string -> handler ID>
 	    m_sql_handler_map.erase (m_query_handlers[id]->get_sql_stmt());
 
-	    delete m_query_handlers[id];
+	    m_deferred_query_free_handler.push_back (m_query_handlers[id]);
 	    m_query_handlers[id] = nullptr;
 	  }
 	else
@@ -1001,6 +1004,16 @@ exit:
       }
   }
 
+  void
+  callback_handler::free_deferred_query_handler ()
+  {
+    for (auto it = m_deferred_query_free_handler.begin(); it != m_deferred_query_free_handler.end(); it++)
+      {
+	delete *it;
+      }
+    m_deferred_query_free_handler.clear();
+  }
+
   query_handler *
   callback_handler::get_query_handler_by_query_id (const uint64_t qid)
   {
@@ -1016,12 +1029,12 @@ exit:
   }
 
   query_handler *
-  callback_handler::get_query_handler_by_sql (const std::string &sql)
+  callback_handler::get_query_handler_by_sql (const std::string &sql, std::function<bool (query_handler *)> cond)
   {
     for (auto it = m_sql_handler_map.lower_bound (sql); it != m_sql_handler_map.upper_bound (sql); it++)
       {
 	query_handler *handler = get_query_handler_by_id (it->second);
-	if (handler != nullptr && handler->get_is_occupied() == false)
+	if (handler != nullptr && cond (handler))
 	  {
 	    /* found */
 	    return handler;

--- a/src/method/method_callback.hpp
+++ b/src/method/method_callback.hpp
@@ -29,6 +29,7 @@
 
 #include <unordered_map>
 #include <queue>
+#include <list>
 
 #include "method_error.hpp"
 #include "method_oid_handler.hpp"
@@ -71,11 +72,13 @@ namespace cubmethod
 
       void free_query_handle (int id, bool is_free);
       void free_query_handle_all (bool is_free);
+      void free_deferred_query_handler ();
 
       /* find query handler */
       query_handler *get_query_handler_by_id (const int id);
       query_handler *get_query_handler_by_query_id (const uint64_t qid); /* used for out resultset */
-      query_handler *get_query_handler_by_sql (const std::string &sql); /* used for statement handler cache */
+      query_handler *get_query_handler_by_sql (const std::string &sql,
+	  std::function<bool (query_handler *)> cond); /* used for statement handler cache */
 
       oid_handler *get_oid_handler ();
 
@@ -117,6 +120,8 @@ namespace cubmethod
       oid_handler *m_oid_handler;
 
       std::queue <cubmem::extensible_block> m_data_queue;
+
+      std::list <cubmethod::query_handler *> m_deferred_query_free_handler;
   };
 
   //////////////////////////////////////////////////////////////////////////

--- a/src/method/method_query_handler.cpp
+++ b/src/method/method_query_handler.cpp
@@ -36,6 +36,7 @@ namespace cubmethod
 {
   query_handler::query_handler (error_context &ctx, int id)
     : m_id (id)
+    , m_tid (NULL_TRANID)
     , m_error_ctx (ctx)
     , m_sql_stmt ()
     , m_stmt_type (CUBRID_STMT_NONE)
@@ -67,6 +68,7 @@ namespace cubmethod
   {
     end_qresult ();
     m_is_occupied = false;
+
   }
 
   query_result::query_result ()
@@ -130,6 +132,18 @@ namespace cubmethod
   void query_handler::set_is_occupied (bool flag)
   {
     m_is_occupied = flag;
+  }
+
+  TRANID
+  query_handler::get_tran_id ()
+  {
+    return m_tid;
+  }
+
+  void
+  query_handler::set_tran_id (TRANID tid)
+  {
+    m_tid = tid;
   }
 
   prepare_info &

--- a/src/method/method_query_handler.hpp
+++ b/src/method/method_query_handler.hpp
@@ -100,6 +100,10 @@ namespace cubmethod
       int get_num_markers ();
       bool get_is_occupied ();
       void set_is_occupied (bool flag);
+
+      TRANID get_tran_id ();
+      void set_tran_id (TRANID tid);
+
       DB_SESSION *get_db_session ();
       DB_QUERY_TYPE *get_column_info ();
 
@@ -148,6 +152,7 @@ namespace cubmethod
 
     private:
       int m_id;
+      TRANID m_tid;
 
       /* error */
       error_context &m_error_ctx;

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -3229,12 +3229,8 @@ session_stop_attached_threads (void *session_arg)
 
   if (session->pl_session_p != NULL)
     {
-
-// TODO (PL/CSQL): The following will be enabled after CBRD-25131
-#if 0
       session->pl_session_p->set_interrupt (er_errid ());
       session->pl_session_p->wait_for_interrupt ();
-#endif
 
       delete session->pl_session_p;
       session->pl_session_p = NULL;

--- a/src/sp/method_invoke_group.cpp
+++ b/src/sp/method_invoke_group.cpp
@@ -175,6 +175,10 @@ namespace cubmethod
 #endif
       }
 
+    if (m_stack)
+      {
+	delete m_stack;
+      }
 exit:
     return error;
   }

--- a/src/sp/pl_execution_stack_context.cpp
+++ b/src/sp/pl_execution_stack_context.cpp
@@ -60,6 +60,8 @@ namespace cubpl
       }
 
     destory_all_cursors ();
+
+    m_session->pop_and_destroy_stack (get_id ());
   }
 
   void

--- a/src/sp/pl_executor.cpp
+++ b/src/sp/pl_executor.cpp
@@ -122,13 +122,14 @@ namespace cubpl
 
   executor::~executor ()
   {
-    assert (m_stack != nullptr);
-
     // destory local resources
     pr_clear_value_vector (m_out_args);
 
     // exit stack
-    (void) get_session ()->pop_and_destroy_stack (m_stack);
+    if (m_stack != nullptr)
+      {
+	delete m_stack;
+      }
   }
 
   int
@@ -262,6 +263,11 @@ namespace cubpl
   executor::execute (DB_VALUE &value)
   {
     int error = NO_ERROR;
+
+    if (m_stack == NULL)
+      {
+	return ER_FAILED;
+      }
 
     // execution rights
     assert (m_sig.auth != NULL);
@@ -618,7 +624,7 @@ exit:
       return error;
     };
 
-    error = m_stack->send_data_to_client (get_prepare_info, code, sql, flag);
+    error = m_stack->send_data_to_client (get_prepare_info, code, sql, flag, m_stack->get_tran_id ());
     return error;
   }
 

--- a/src/sp/pl_session.cpp
+++ b/src/sp/pl_session.cpp
@@ -39,7 +39,7 @@ namespace cubpl
   session *get_session ()
   {
     session *s = nullptr;
-    cubthread::entry *thread_p  = thread_get_thread_entry_info ();
+    cubthread::entry *thread_p = thread_get_thread_entry_info ();
     session_get_pl_session (thread_p, s);
     return s;
   }
@@ -81,6 +81,8 @@ namespace cubpl
     if (is_interrupted () && m_stack_idx > -1)
       {
 	// block creating a new stack
+	set_local_error_for_interrupt ();
+	m_cond_var.notify_all ();
 	return nullptr;
       }
 
@@ -117,19 +119,22 @@ namespace cubpl
   }
 
   void
-  session::pop_and_destroy_stack (execution_stack *&claimed)
+  session::pop_and_destroy_stack (const PL_STACK_ID sid)
   {
-    std::unique_lock<std::mutex> ulock (m_mutex);
-
-    assert (claimed != nullptr);
+    if (m_stack_idx == -1)
+      {
+	// interrupted
+	return;
+      }
 
     auto pred = [&] () -> bool
     {
       // condition to check
-      return m_stack_idx == -1 || m_exec_stack[m_stack_idx] == claimed->get_id ();
+      return m_exec_stack[m_stack_idx] == sid;
     };
 
     // Guaranteed to be removed from the topmost element
+    std::unique_lock<std::mutex> ulock (m_mutex);
     m_cond_var.wait (ulock, pred);
 
     if (pred ())
@@ -140,13 +145,7 @@ namespace cubpl
 	    m_stack_idx--;
 	  }
 
-	m_stack_map.erase (claimed->get_id ());
-
-	if (claimed)
-	  {
-	    delete claimed;
-	    claimed = nullptr;
-	  }
+	m_stack_map.erase (sid);
       }
 
     if (m_stack_idx < 0)
@@ -158,6 +157,9 @@ namespace cubpl
 	m_interrupt_id = NO_ERROR;
 	m_interrupt_msg.clear ();
       }
+
+    ulock.unlock ();
+    m_cond_var.notify_all ();
   }
 
   execution_stack *
@@ -265,13 +267,15 @@ namespace cubpl
     auto pred = [this] () -> bool
     {
       // condition of finish
-      return m_exec_stack.empty () && is_running () == false;
+      return is_running () == false;
     };
 
     if (pred ())
       {
 	return;
       }
+
+    m_cond_var.notify_all ();
 
     std::unique_lock<std::mutex> ulock (m_mutex);
     m_cond_var.wait (ulock, pred);

--- a/src/sp/pl_session.hpp
+++ b/src/sp/pl_session.hpp
@@ -86,7 +86,7 @@ namespace cubpl
       // In the recursive call situation, each time the function is called, a new worker from the thread pool is assigned. With this code, you can easily know the current state.
       // In the future, these functions will resolve some cases when it is necessary to set an error for all threads participating in a recursive call e.g. interrupt
       execution_stack *create_and_push_stack (cubthread::entry *thread_p);
-      void pop_and_destroy_stack (execution_stack *&stack);
+      void pop_and_destroy_stack (const PL_STACK_ID sid);
       execution_stack *top_stack ();
 
       /* thread */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25292

**Description**
CBRD-25292, CBRD-25389는 COMMIT, ROLLBACK 시 PL의 Static SQL, Dynamic SQL 생성 시 만들어지는 method_query_handler 객체에 대해서, COMMIT , ROLLBACK 시 객체가 바로 제거되어서 이미 할당 해제된 메모리를 접근하기 때문에 발생한다.
COMMIT, ROLLBACK 되더라도, 이전에 생성한 질의 핸들러와 커서는 제한적으로 접근이 가능해야하기 때문에 바로 제거하지 않고, deferred free list에 넣어둔 후 libcas 모드 (PL 실행 모드) 를 벗어나는 시점에 지연하여 제거하도록 수정한다.

Implementation
- prepare 시 TRANID 전송
- query_handler 생성 시 TRANID 설정
- TRANID가 다르면 새로운 query_handler를 할당받도록 수정
- COMMIT/ROLLBACK/END SESSION 시 할당된 query_handler 목록을 모두 deferred_query_handler 리스트로 등록
- 메인 SQL 호출 종료 시 (libcas 모드가 아닌 경우), deferred_query_handler 리스트의 객체들을 모두 제거
  - 이 시점에 DB_SESSION, QUERY CURSOR 등의 자원이 제거됨

**Remarks**
이슈의 이유로 CAS core 발생 후 인터럽트 에러 처리 동기화 문제로, PL 세션 종료가 끝나지 않아 서버 종료가 되지 않는 문제로 regression 테스트가 진행되지 않으므로 CBRD-25272의 일부 변경을 적용했다.