### PR TITLE
[CBRD-25722] Enable correlated subquery caching with type_sp included in the subquery.

### DIFF
--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -27622,6 +27622,27 @@ pt_make_sq_cache_key_struct (QPROC_DB_VALUE_LIST key_struct, void *p, int type)
 		}
 	    }
 	  break;
+	case TYPE_SP:
+	  regu_var_list_p = regu_src->value.sp_ptr->args;
+	  while (regu_var_list_p)
+	    {
+	      if (!regu_var_list_p)
+		{
+		  return ER_FAILED;
+		}
+	      regu_src = &regu_var_list_p->value;
+	      ret = pt_make_sq_cache_key_struct (key_struct, (void *) regu_src, SQ_TYPE_REGU_VAR);
+	      if (ret == ER_FAILED)
+		{
+		  return ER_FAILED;
+		}
+	      else
+		{
+		  cnt += ret;
+		}
+	      regu_var_list_p = regu_var_list_p->next;
+	    }
+	  break;
 	case TYPE_POSITION:
 	case TYPE_LIST_ID:
 	  /* Currently not supported, implement later */
@@ -27644,8 +27665,6 @@ pt_make_sq_cache_key_struct (QPROC_DB_VALUE_LIST key_struct, void *p, int type)
 	case TYPE_CLASSOID:
 	case TYPE_REGUVAL_LIST:
 	case TYPE_REGU_VAR_LIST:
-
-	case TYPE_SP:
 	  /* Result Cache not supported */
 	  return ER_FAILED;
 	  break;

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -27626,10 +27626,6 @@ pt_make_sq_cache_key_struct (QPROC_DB_VALUE_LIST key_struct, void *p, int type)
 	  regu_var_list_p = regu_src->value.sp_ptr->args;
 	  while (regu_var_list_p)
 	    {
-	      if (!regu_var_list_p)
-		{
-		  return ER_FAILED;
-		}
 	      regu_src = &regu_var_list_p->value;
 	      ret = pt_make_sq_cache_key_struct (key_struct, (void *) regu_src, SQ_TYPE_REGU_VAR);
 	      if (ret == ER_FAILED)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25722

TYPE_SP를 포함한 correlated subquery의 캐싱이 가능하게 개선하는 이슈입니다.


