### PR TITLE
[CBRD-23944] Resource needs to  be upgreaded for build.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
     <<: *defaults
     environment:
       MAKEFLAGS: -j 8
-    resource_class: large
+    resource_class: xlarge
     steps:
       - checkout
       - run:


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23944

빌드 진행 중 에러 발생
cc: fatal error: Killed signal terminated program cc1 

조치 
빌드시 메모리 조정 (8G -> 16G) : resource_class : xlarge 