### PR TITLE
[CBRD-25743] Fix Heartbeat start failure due to the difference of packing server information between HA mode

### DIFF
--- a/src/connection/connection_globals.h
+++ b/src/connection/connection_globals.h
@@ -32,7 +32,7 @@
 
 #define CSS_MAX_CLIENT_COUNT   4000
 
-#define CSS_SERVER_PROC_REGISTER_INITIALIZER    {"", 0, "", "", -1}
+#define CSS_SERVER_PROC_REGISTER_INITIALIZER    {"", 0, -1, "", ""}
 
 typedef bool (*CSS_CHECK_CLIENT_TYPE) (BOOT_CLIENT_TYPE client_type);
 typedef int (*CSS_GET_MAX_CONN_NUM) (void);
@@ -73,10 +73,10 @@ struct css_server_proc_register
 
   char server_name[CSS_SERVER_MAX_SZ_SERVER_NAME];
   int server_name_length;
+  int pid;
 
   char exec_path[CSS_SERVER_MAX_SZ_PROC_EXEC_PATH];
   char args[CSS_SERVER_MAX_SZ_PROC_ARGS];
-  int pid;
 };
 
 extern int css_Service_id;

--- a/src/connection/connection_globals.h
+++ b/src/connection/connection_globals.h
@@ -32,7 +32,7 @@
 
 #define CSS_MAX_CLIENT_COUNT   4000
 
-#define CSS_SERVER_PROC_REGISTER_INITIALIZER    {-1, "", 0, "", ""}
+#define CSS_SERVER_PROC_REGISTER_INITIALIZER    {"", 0, "", "", -1}
 
 typedef bool (*CSS_CHECK_CLIENT_TYPE) (BOOT_CLIENT_TYPE client_type);
 typedef int (*CSS_GET_MAX_CONN_NUM) (void);
@@ -71,12 +71,12 @@ struct css_server_proc_register
   static constexpr int CSS_SERVER_MAX_SZ_PROC_EXEC_PATH = 128;
   static constexpr int CSS_SERVER_MAX_SZ_PROC_ARGS = 1024;
 
-  int pid;
   char server_name[CSS_SERVER_MAX_SZ_SERVER_NAME];
   int server_name_length;
 
   char exec_path[CSS_SERVER_MAX_SZ_PROC_EXEC_PATH];
   char args[CSS_SERVER_MAX_SZ_PROC_ARGS];
+  int pid;
 };
 
 extern int css_Service_id;

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -348,15 +348,15 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer,
 #if defined(DEBUG)
 	  css_Active_server_count++;
 #endif
-	  server_name = buffer;
-	  length = (int) strlen (server_name) + 1;
-	  css_add_request_to_socket_queue (datagram_conn, false, server_name, server_fd, READ_WRITE, 0,
+	  css_add_request_to_socket_queue (datagram_conn, false, buffer, server_fd, READ_WRITE, 0,
 					   &css_Master_socket_anchor);
 
 	  //  Note : server_name is usually packed(appended) information of server_name, version_string, env_var, pid,
 	  //  packed from css_pack_server_name(). Since there are some cases that returns server_name and server_name_length
 	  //  as NULL, we need to check if server_name is packed information or not.
 
+	  server_name = buffer;
+	  length = (int) strlen (server_name) + 1;
 	  assert (length <= DB_MAX_IDENTIFIER_LENGTH);
 
 	  if (length < buffer_length)

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -348,14 +348,14 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer,
 #if defined(DEBUG)
 	  css_Active_server_count++;
 #endif
-	  css_add_request_to_socket_queue (datagram_conn, false, buffer, server_fd, READ_WRITE, 0,
+	  server_name = buffer;
+	  length = (int) strlen (server_name) + 1;
+	  css_add_request_to_socket_queue (datagram_conn, false, server_name, server_fd, READ_WRITE, 0,
 					   &css_Master_socket_anchor);
 
 	  //  Note : server_name is usually packed(appended) information of server_name, version_string, env_var, pid,
 	  //  packed from css_pack_server_name(). Since there are some cases that returns server_name and server_name_length
 	  //  as NULL, we need to check if server_name is packed information or not.
-	  server_name = buffer;
-	  length = (int) strlen (server_name) + 1;
 
 	  assert (length <= DB_MAX_IDENTIFIER_LENGTH);
 

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -348,15 +348,15 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer,
 #if defined(DEBUG)
 	  css_Active_server_count++;
 #endif
-	  css_add_request_to_socket_queue (datagram_conn, false, buffer, server_fd, READ_WRITE, 0,
+	  server_name = buffer;
+	  length = (int) strlen (server_name) + 1;
+	  css_add_request_to_socket_queue (datagram_conn, false, server_name, server_fd, READ_WRITE, 0,
 					   &css_Master_socket_anchor);
 
 	  //  Note : server_name is usually packed(appended) information of server_name, version_string, env_var, pid,
 	  //  packed from css_pack_server_name(). Since there are some cases that returns server_name and server_name_length
 	  //  as NULL, we need to check if server_name is packed information or not.
 
-	  server_name = buffer;
-	  length = (int) strlen (server_name) + 1;
 	  assert (length <= DB_MAX_IDENTIFIER_LENGTH);
 
 	  if (length < buffer_length)

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -394,6 +394,12 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer,
 #if !defined(WINDOWS)
 	      if (auto_Restart_server)
 		{
+		  // TODO : Currently, server and client has different format of data payload to connect process to master.
+		  // Since both process is handled by this function, it could make confusion when requesting connection from process.
+		  // Two solution could be considered.
+		  // 1. Separte the request for server and client. (SERVER_REQUEST_FROM_CLIENT, SERVER_REQUEST_FROM_SERVER)
+		  // 2. Modify the data payload so that master can distinguish the request from server and client. (e.g. add flag character at the beginning of data)
+
 		  CSS_SERVER_PROC_REGISTER *proc_register = (CSS_SERVER_PROC_REGISTER *) buffer;
 		  /* *INDENT-OFF* */
 		  master_Server_monitor->produce_job (server_monitor::job_type::REGISTER_SERVER, proc_register->pid,


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25743

- Purpose
  - server revive 모듈 구현 이후, HA mode가 켜져 있을 시, heartbeat 구동이 안되는 문제
  - server revive를 위해 server 구동 시 넘겨주는 정보를 `CSS_SERVER_PROC_REGISTER`에 담아 보내도록 변경하였는데, copylogdb, applylogdb는 해당 방식과 다른 packing을 사용함.
    - copylogdb, applylogdb와 heartbeat server는 `connection_cl.c`의 `hb_pack_server_name` 함수를 사용하고, 이는 packing된 `server_name` string만을 보냄
    - non-HA server는 packing된 server_name string 외에 exec_path와 pid등의 정보를 함께 `CSS_SERVER_PROC_REGISTER`자료구조에 담아서 보냄
    - cub_master에서 각자 보낸 server 정보를 받아 처리하는 함수인 `css_accept_new_request`에서 두 case 구분 없이 `CSS_SERVER_PROC_REGISTER`로 변환해서 생긴 문제
  - server name 앞에 #, & 등의 문자를 붙여 ha server의 종류를 전달하던 기존 방식과 충돌하여 Ha server가 non-ha server로 인식되는 상황 발생
- Implementation
  - `CSS_SERVER_PROC_REGISTER`의 가장 첫 멤버 변수로서 packing된 `server_name` string이 오도록 순서 변경
  -  Heartbeat process가 등록되는 경우를 고려하여 각 case 모두에 작동할 수 있도록 unpack 코드 수정
  - 실제로 `CSS_SERVER_PROC_REGISTER`로 packing된 non-ha server에 경우에만 type conversion 진행 후, 해당 정보를 통해 server 등록하도록 변경