### PR TITLE
[CBRD-25700] Modify the behavior to retain the session when automatically restarting due to the CAS memory size limit

### DIFF
--- a/src/base/xserver_interface.h
+++ b/src/base/xserver_interface.h
@@ -264,6 +264,7 @@ extern int xsession_create_new (THREAD_ENTRY * thread_p, SESSION_ID * id);
 extern int xsession_check_session (THREAD_ENTRY * thread_p, const SESSION_ID id);
 extern int xsession_end_session (THREAD_ENTRY * thread, const SESSION_ID id, bool is_keep_session);
 
+extern int xsession_set_is_keep_session (THREAD_ENTRY * thread_p, bool is_keep_session);
 extern int xsession_set_row_count (THREAD_ENTRY * thread_p, int row_count);
 extern int xsession_get_row_count (THREAD_ENTRY * thread_p, int *row_count);
 extern int xsession_set_cur_insert_id (THREAD_ENTRY * thread_p, const DB_VALUE * value, bool force);

--- a/src/base/xserver_interface.h
+++ b/src/base/xserver_interface.h
@@ -262,7 +262,7 @@ extern int xlocator_upgrade_instances_domain (THREAD_ENTRY * thread_p, OID * cla
 
 extern int xsession_create_new (THREAD_ENTRY * thread_p, SESSION_ID * id);
 extern int xsession_check_session (THREAD_ENTRY * thread_p, const SESSION_ID id);
-extern int xsession_end_session (THREAD_ENTRY * thread, const SESSION_ID id);
+extern int xsession_end_session (THREAD_ENTRY * thread, const SESSION_ID id, bool is_keep_session);
 
 extern int xsession_set_row_count (THREAD_ENTRY * thread_p, int row_count);
 extern int xsession_get_row_count (THREAD_ENTRY * thread_p, int *row_count);

--- a/src/broker/cas.c
+++ b/src/broker/cas.c
@@ -2172,10 +2172,6 @@ process_request (SOCKET sock_fd, T_NET_BUF * net_buf, T_REQ_INFO * req_info)
   net_buf->client_version = req_info->client_version;
   set_hang_check_time ();
   fn_ret = (*server_fn) (sock_fd, argc, argv, net_buf, req_info);
-  if (fn_ret == FN_KEEP_SESS)
-    {
-      db_set_keep_session (true);
-    }
   set_hang_check_time ();
 
 #if !defined(CAS_FOR_ORACLE) && !defined(CAS_FOR_MYSQL)

--- a/src/broker/cas.c
+++ b/src/broker/cas.c
@@ -127,7 +127,6 @@ static void set_db_connection_info (void);
 static void clear_db_connection_info (void);
 static bool need_database_reconnect (void);
 
-extern bool db_Keep_session;
 extern bool ssl_client;
 extern int cas_init_ssl (int);
 extern void cas_ssl_close (int client_sock_fd);
@@ -1975,13 +1974,13 @@ process_request (SOCKET sock_fd, T_NET_BUF * net_buf, T_REQ_INFO * req_info)
 	      cas_log_msg = "RESET";
 	      cas_log_write_and_end (0, true, cas_log_msg);
 	      fn_ret = FN_KEEP_SESS;
-	      db_Keep_session = true;
+	      db_set_keep_session (true);
 	    }
 	  if (as_info->con_status == CON_STATUS_CLOSE_AND_CONNECT)
 	    {
 	      cas_log_msg = "CHANGE CLIENT";
 	      fn_ret = FN_KEEP_SESS;
-	      db_Keep_session = true;
+	      db_set_keep_session (true);
 	    }
 
 	  if (cas_log_msg == NULL)
@@ -2175,7 +2174,7 @@ process_request (SOCKET sock_fd, T_NET_BUF * net_buf, T_REQ_INFO * req_info)
   fn_ret = (*server_fn) (sock_fd, argc, argv, net_buf, req_info);
   if (fn_ret == FN_KEEP_SESS)
     {
-      db_Keep_session = true;
+      db_set_keep_session (true);
     }
   set_hang_check_time ();
 
@@ -2249,7 +2248,7 @@ process_request (SOCKET sock_fd, T_NET_BUF * net_buf, T_REQ_INFO * req_info)
 	  else if (restart_is_needed ())
 	    {
 	      fn_ret = FN_KEEP_SESS;
-	      db_Keep_session = true;
+	      db_set_keep_session (true);
 	    }
 	  if (shm_appl->sql_log2 != as_info->cur_sql_log2)
 	    {
@@ -2360,7 +2359,7 @@ process_request (SOCKET sock_fd, T_NET_BUF * net_buf, T_REQ_INFO * req_info)
     {
       cas_log_debug (ARG_FILE_LINE, "process_request: reset_flag && !CON_STATUS_IN_TRAN");
       fn_ret = FN_KEEP_SESS;
-      db_Keep_session = true;
+      db_set_keep_session (true);
       goto exit_on_end;
     }
 

--- a/src/broker/cas.c
+++ b/src/broker/cas.c
@@ -127,6 +127,7 @@ static void set_db_connection_info (void);
 static void clear_db_connection_info (void);
 static bool need_database_reconnect (void);
 
+extern bool db_Keep_session;
 extern bool ssl_client;
 extern int cas_init_ssl (int);
 extern void cas_ssl_close (int client_sock_fd);
@@ -1974,11 +1975,13 @@ process_request (SOCKET sock_fd, T_NET_BUF * net_buf, T_REQ_INFO * req_info)
 	      cas_log_msg = "RESET";
 	      cas_log_write_and_end (0, true, cas_log_msg);
 	      fn_ret = FN_KEEP_SESS;
+	      db_Keep_session = true;
 	    }
 	  if (as_info->con_status == CON_STATUS_CLOSE_AND_CONNECT)
 	    {
 	      cas_log_msg = "CHANGE CLIENT";
 	      fn_ret = FN_KEEP_SESS;
+	      db_Keep_session = true;
 	    }
 
 	  if (cas_log_msg == NULL)
@@ -2170,6 +2173,10 @@ process_request (SOCKET sock_fd, T_NET_BUF * net_buf, T_REQ_INFO * req_info)
   net_buf->client_version = req_info->client_version;
   set_hang_check_time ();
   fn_ret = (*server_fn) (sock_fd, argc, argv, net_buf, req_info);
+  if (fn_ret == FN_KEEP_SESS)
+    {
+      db_Keep_session = true;
+    }
   set_hang_check_time ();
 
 #if !defined(CAS_FOR_ORACLE) && !defined(CAS_FOR_MYSQL)
@@ -2242,6 +2249,7 @@ process_request (SOCKET sock_fd, T_NET_BUF * net_buf, T_REQ_INFO * req_info)
 	  else if (restart_is_needed ())
 	    {
 	      fn_ret = FN_KEEP_SESS;
+	      db_Keep_session = true;
 	    }
 	  if (shm_appl->sql_log2 != as_info->cur_sql_log2)
 	    {
@@ -2352,6 +2360,7 @@ process_request (SOCKET sock_fd, T_NET_BUF * net_buf, T_REQ_INFO * req_info)
     {
       cas_log_debug (ARG_FILE_LINE, "process_request: reset_flag && !CON_STATUS_IN_TRAN");
       fn_ret = FN_KEEP_SESS;
+      db_Keep_session = true;
       goto exit_on_end;
     }
 

--- a/src/broker/cas_function.c
+++ b/src/broker/cas_function.c
@@ -280,6 +280,7 @@ fn_end_tran (SOCKET sock_fd, int argc, void **argv, T_NET_BUF * net_buf, T_REQ_I
   else if (restart_is_needed () || as_info->reset_flag == TRUE)
     {
       cas_log_debug (ARG_FILE_LINE, "fn_end_tran: restart_is_needed() || reset_flag");
+      db_set_keep_session (true);
       return FN_KEEP_SESS;
     }
   return FN_KEEP_CONN;
@@ -2147,6 +2148,7 @@ fn_check_cas (SOCKET sock_fd, int argc, void **argv, T_NET_BUF * net_buf, T_REQ_
     {
       ERROR_INFO_SET (err_code, CAS_ERROR_INDICATOR);
       NET_BUF_ERR_SET (net_buf);
+      db_set_keep_session (true);
       return FN_KEEP_SESS;
     }
   else

--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -101,8 +101,6 @@ static int net_Deferred_end_queries_count = 0;
  */
 unsigned int db_on_server = 0;
 
-extern bool db_Keep_session;
-
 #if defined(CS_MODE)
 static char *pack_const_string (char *buffer, const char *cstring);
 static char *pack_string_with_null_padding (char *buffer, const char *stream, int len);
@@ -4738,7 +4736,7 @@ csession_find_or_create_session (SESSION_ID * session_id, int *row_count, char *
  * session_id (in) : the id of the session to end
  */
 int
-csession_end_session (SESSION_ID session_id)
+csession_end_session (SESSION_ID session_id, bool is_keep_session)
 {
 #if defined (CS_MODE)
   int req_error;
@@ -4752,7 +4750,7 @@ csession_end_session (SESSION_ID session_id)
   request = OR_ALIGNED_BUF_START (a_request);
 
   ptr = or_pack_int (request, session_id);
-  ptr = or_pack_int (ptr, db_Keep_session);
+  ptr = or_pack_int (ptr, is_keep_session);
 
   req_error =
     net_client_request (NET_SERVER_SES_END_SESSION, request, OR_ALIGNED_BUF_SIZE (a_request), reply,
@@ -4768,7 +4766,7 @@ csession_end_session (SESSION_ID session_id)
 
   THREAD_ENTRY *thread_p = enter_server ();
 
-  result = xsession_end_session (thread_p, session_id, db_Keep_session);
+  result = xsession_end_session (thread_p, session_id, is_keep_session);
 
   exit_server (*thread_p);
 

--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -101,6 +101,8 @@ static int net_Deferred_end_queries_count = 0;
  */
 unsigned int db_on_server = 0;
 
+extern bool db_Keep_session;
+
 #if defined(CS_MODE)
 static char *pack_const_string (char *buffer, const char *cstring);
 static char *pack_string_with_null_padding (char *buffer, const char *stream, int len);
@@ -4742,7 +4744,7 @@ csession_end_session (SESSION_ID session_id)
   int req_error;
   OR_ALIGNED_BUF (OR_INT_SIZE) a_reply;
   char *reply;
-  OR_ALIGNED_BUF (OR_INT_SIZE) a_request;
+  OR_ALIGNED_BUF (OR_INT_SIZE * 2) a_request;
   char *request;
   char *ptr;
 
@@ -4750,6 +4752,7 @@ csession_end_session (SESSION_ID session_id)
   request = OR_ALIGNED_BUF_START (a_request);
 
   ptr = or_pack_int (request, session_id);
+  ptr = or_pack_int (ptr, db_Keep_session);
 
   req_error =
     net_client_request (NET_SERVER_SES_END_SESSION, request, OR_ALIGNED_BUF_SIZE (a_request), reply,
@@ -4765,7 +4768,7 @@ csession_end_session (SESSION_ID session_id)
 
   THREAD_ENTRY *thread_p = enter_server ();
 
-  result = xsession_end_session (thread_p, session_id);
+  result = xsession_end_session (thread_p, session_id, db_Keep_session);
 
   exit_server (*thread_p);
 

--- a/src/communication/network_interface_cl.h
+++ b/src/communication/network_interface_cl.h
@@ -406,7 +406,7 @@ extern int boot_get_server_timezone_checksum (char *timezone_checksum);
 /* session state API */
 extern int csession_find_or_create_session (SESSION_ID * session_id, int *row_count, char *server_session_key,
 					    const char *db_user, const char *host, const char *program_name);
-extern int csession_end_session (SESSION_ID session_id);
+extern int csession_end_session (SESSION_ID session_id, bool is_keep_session);
 extern int csession_set_row_count (int rows);
 extern int csession_get_row_count (int *rows);
 extern int csession_get_last_insert_id (DB_VALUE * value, bool update_last_insert_id);

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -8993,7 +8993,7 @@ ssession_end_session (THREAD_ENTRY * thread_p, unsigned int rid, char *request, 
   char *ptr = NULL;
 
   ptr = or_unpack_int (request, (int *) &id);
-  ptr = or_unpack_int (ptr, (int *) &is_keep_session);
+  ptr = or_unpack_int (ptr, &is_keep_session);
 
   err = xsession_end_session (thread_p, id, (bool) is_keep_session);
 

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -8880,7 +8880,7 @@ ssession_find_or_create_session (THREAD_ENTRY * thread_p, unsigned int rid, char
 
   if (id == DB_EMPTY_SESSION
       || memcmp (server_session_key, xboot_get_server_session_key (), SERVER_SESSION_KEY_SIZE) != 0
-      || xsession_check_session (thread_p, id) != NO_ERROR)
+      || (error = xsession_check_session (thread_p, id)) != NO_ERROR)
     {
       /* not an error yet */
       er_clear ();
@@ -8890,6 +8890,10 @@ ssession_find_or_create_session (THREAD_ENTRY * thread_p, unsigned int rid, char
 	{
 	  (void) return_error_to_client (thread_p, rid);
 	}
+    }
+  else if (error == NO_ERROR)
+    {
+      xsession_set_is_keep_session (thread_p, false);
     }
 
   /* get row count */

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -8986,14 +8986,16 @@ void
 ssession_end_session (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen)
 {
   int err = NO_ERROR;
+  int is_keep_session;
   SESSION_ID id;
   OR_ALIGNED_BUF (OR_INT_SIZE) a_reply;
   char *reply = OR_ALIGNED_BUF_START (a_reply);
   char *ptr = NULL;
 
-  (void) or_unpack_int (request, (int *) &id);
+  ptr = or_unpack_int (request, (int *) &id);
+  ptr = or_unpack_int (ptr, (int *) &is_keep_session);
 
-  err = xsession_end_session (thread_p, id);
+  err = xsession_end_session (thread_p, id, (bool) is_keep_session);
 
   ptr = or_pack_int (reply, err);
   css_send_data_to_client (thread_p->conn_entry, rid, reply, OR_ALIGNED_BUF_SIZE (a_reply));

--- a/src/compat/db.h
+++ b/src/compat/db.h
@@ -49,6 +49,7 @@
 extern int db_Connect_status;
 
 extern SESSION_ID db_Session_id;
+extern bool db_Keep_session;
 
 extern int db_Row_count;
 

--- a/src/compat/db_admin.c
+++ b/src/compat/db_admin.c
@@ -101,8 +101,6 @@ struct db_host_status_list
  The macros for testing this variable were moved to db.h so the query
  interface functions can use them as well. */
 
-extern bool db_Keep_session;
-
 char db_Database_name[DB_MAX_IDENTIFIER_LENGTH + 1];
 char db_Program_name[PATH_MAX];
 char db_Client_ip_addr[16] = { 0 };
@@ -1064,7 +1062,7 @@ db_end_session (void)
 
   CHECK_CONNECT_ERROR ();
 
-  retval = csession_end_session (db_get_session_id ());
+  retval = csession_end_session (db_get_session_id (), db_get_keep_session ());
 
   cubmethod::get_callback_handler ()->free_query_handle_all (true);
 
@@ -3073,6 +3071,26 @@ void
 db_set_session_id (const SESSION_ID session_id)
 {
   db_Session_id = session_id;
+}
+
+/*
+ * db_get_keep_session () - get keep session flag
+ */
+bool
+db_get_keep_session (void)
+{
+  return db_Keep_session;
+}
+
+/*
+ * db_set_keep_session () - set keep session flag
+ * return : void
+ * keep_session (in): keep session flag
+ */
+void
+db_set_keep_session (const bool keep_session)
+{
+  db_Keep_session = keep_session;
 }
 
 /*

--- a/src/compat/db_admin.c
+++ b/src/compat/db_admin.c
@@ -101,6 +101,8 @@ struct db_host_status_list
  The macros for testing this variable were moved to db.h so the query
  interface functions can use them as well. */
 
+extern bool db_Keep_session;
+
 char db_Database_name[DB_MAX_IDENTIFIER_LENGTH + 1];
 char db_Program_name[PATH_MAX];
 char db_Client_ip_addr[16] = { 0 };

--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -79,6 +79,7 @@ struct valcnv_buffer
 };
 
 SESSION_ID db_Session_id = DB_EMPTY_SESSION;
+bool db_Keep_session = false;
 
 int db_Row_count = DB_ROW_COUNT_NOT_SET;
 
@@ -90,7 +91,6 @@ int db_Connect_status = DB_CONNECTION_STATUS_CONNECTED;
 int db_Connect_status = DB_CONNECTION_STATUS_NOT_CONNECTED;
 #endif
 int db_Disable_modifications = 0;
-bool db_Keep_session = false;
 
 static int transfer_string (char *dst, int *xflen, int *outlen,
 			    const int dstlen, const char *src,

--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -90,6 +90,7 @@ int db_Connect_status = DB_CONNECTION_STATUS_CONNECTED;
 int db_Connect_status = DB_CONNECTION_STATUS_NOT_CONNECTED;
 #endif
 int db_Disable_modifications = 0;
+bool db_Keep_session = false;
 
 static int transfer_string (char *dst, int *xflen, int *outlen,
 			    const int dstlen, const char *src,

--- a/src/compat/dbi.h
+++ b/src/compat/dbi.h
@@ -77,6 +77,8 @@ extern "C"
   extern char *db_get_server_session_key (void);
   extern SESSION_ID db_get_session_id (void);
   extern void db_set_session_id (const SESSION_ID session_id);
+  extern bool db_get_keep_session (void);
+  extern void db_set_keep_session (const bool keep_session);
   extern int db_end_session (void);
   extern int db_find_or_create_session (const char *db_user, const char *program_name);
   extern int db_get_row_count_cache (void);

--- a/src/compat/dbi_compat.h
+++ b/src/compat/dbi_compat.h
@@ -150,6 +150,8 @@ extern "C"
 			    const char *preferred_hosts, int client_type);
   extern SESSION_ID db_get_session_id (void);
   extern void db_set_session_id (const SESSION_ID session_id);
+  extern bool db_get_keep_session (void);
+  extern void db_set_keep_session (const bool keep_session);
   extern int db_find_or_create_session (const char *db_user, const char *program_name);
   extern int db_get_row_count_cache (void);
   extern void db_update_row_count_cache (const int row_count);

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -944,8 +944,6 @@ session_remove_expired_sessions (THREAD_ENTRY * thread_p)
 	      /* Now we can destroy this session */
 	      assert (state->ref_count == 0);
 
-	      expired_sid_buffer[n_expired_sids++] = state->id;
-
 	      if (state->is_keep_session == true)
 		{
 		  /* keep session */
@@ -954,6 +952,8 @@ session_remove_expired_sessions (THREAD_ENTRY * thread_p)
 		}
 	      else
 		{
+		  expired_sid_buffer[n_expired_sids++] = state->id;
+
 		  /* Destroy the session related resources like session parameters */
 		  (void) session_state_uninit (state);
 		}

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -118,6 +118,7 @@ struct session_state
   pthread_mutex_t mutex;	/* state mutex */
   UINT64 del_id;		/* delete transaction ID (for lock free) */
 
+  bool is_keep_session;
   bool is_trigger_involved;
   bool is_last_insert_id_generated;
   bool auto_commit;
@@ -302,6 +303,7 @@ session_state_init (void *st)
   /* initialize fields */
   db_make_null (&session_p->cur_insert_id);
   db_make_null (&session_p->last_insert_id);
+  session_p->is_keep_session = false;
   session_p->is_trigger_involved = false;
   session_p->is_last_insert_id_generated = false;
   session_p->row_count = -1;
@@ -743,9 +745,10 @@ session_state_create (THREAD_ENTRY * thread_p, SESSION_ID * id)
  * session_state_destroy () - close a session state
  *   return	    : NO_ERROR or error code
  *   id(in) : the identifier for the session
+ *   is_keep_session(in) : whether to keep the session
  */
 int
-session_state_destroy (THREAD_ENTRY * thread_p, const SESSION_ID id)
+session_state_destroy (THREAD_ENTRY * thread_p, const SESSION_ID id, bool is_keep_session)
 {
   SESSION_STATE *session_p;
   int error = NO_ERROR, success = 0;
@@ -760,6 +763,13 @@ session_state_destroy (THREAD_ENTRY * thread_p, const SESSION_ID id)
     {
       er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, ER_SES_SESSION_EXPIRED, 0);
       return ER_SES_SESSION_EXPIRED;
+    }
+
+  if (is_keep_session == true)
+    {
+      session_p->is_keep_session = true;
+      pthread_mutex_unlock (&session_p->mutex);
+      return NO_ERROR;
     }
 
 #if defined (SERVER_MODE)
@@ -936,8 +946,17 @@ session_remove_expired_sessions (THREAD_ENTRY * thread_p)
 
 	      expired_sid_buffer[n_expired_sids++] = state->id;
 
-	      /* Destroy the session related resources like session parameters */
-	      (void) session_state_uninit (state);
+	      if (state->is_keep_session == true)
+		{
+		  /* keep session */
+		  pthread_mutex_unlock (&state->mutex);
+		  continue;
+		}
+	      else
+		{
+		  /* Destroy the session related resources like session parameters */
+		  (void) session_state_uninit (state);
+		}
 
 	      if (n_expired_sids == EXPIRED_SESSION_BUFFER_SIZE)
 		{

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -873,9 +873,8 @@ session_check_session (THREAD_ENTRY * thread_p, const SESSION_ID id)
       return ER_SES_SESSION_EXPIRED;
     }
 
-  /* update session active time & is_keep_session */
+  /* update session active time */
   session_p->active_time = time (NULL);
-  session_p->is_keep_session = false;
 
 #if defined (SERVER_MODE)
 #if !defined (NDEBUG)
@@ -1631,6 +1630,27 @@ session_set_row_count (THREAD_ENTRY * thread_p, const int row_count)
 #endif
 
   state_p->row_count = row_count;
+
+  return NO_ERROR;
+}
+
+/*
+ * session_set_is_keep_session () - set the is_keep_session flag for a session
+ * return : NO_ERROR or error code
+ * thread_p (in) : thread that identifies the session
+ * is_keep_session (in) : whether to keep the session
+ */
+int
+session_set_is_keep_session (THREAD_ENTRY * thread_p, bool is_keep_session)
+{
+  SESSION_STATE *state_p = NULL;
+  state_p = session_get_session_state (thread_p);
+  if (state_p == NULL)
+    {
+      return ER_FAILED;
+    }
+
+  state_p->is_keep_session = is_keep_session;
 
   return NO_ERROR;
 }

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -873,8 +873,9 @@ session_check_session (THREAD_ENTRY * thread_p, const SESSION_ID id)
       return ER_SES_SESSION_EXPIRED;
     }
 
-  /* update session active time */
+  /* update session active time & is_keep_session */
   session_p->active_time = time (NULL);
+  session_p->is_keep_session = false;
 
 #if defined (SERVER_MODE)
 #if !defined (NDEBUG)

--- a/src/session/session.h
+++ b/src/session/session.h
@@ -41,7 +41,7 @@ struct xasl_cache_ent;
 extern void session_states_init (THREAD_ENTRY * thread_p);
 extern void session_states_finalize (THREAD_ENTRY * thread_p);
 extern int session_state_create (THREAD_ENTRY * thread_p, SESSION_ID * id);
-extern int session_state_destroy (THREAD_ENTRY * thread_p, const SESSION_ID id);
+extern int session_state_destroy (THREAD_ENTRY * thread_p, const SESSION_ID id, bool is_keep_session);
 extern int session_check_session (THREAD_ENTRY * thread_p, const SESSION_ID id);
 extern int session_get_session_id (THREAD_ENTRY * thread_p, SESSION_ID * id);
 extern int session_get_last_insert_id (THREAD_ENTRY * thread_p, DB_VALUE * value, bool update_last_insert_id);

--- a/src/session/session.h
+++ b/src/session/session.h
@@ -51,6 +51,7 @@ extern int session_begin_insert_values (THREAD_ENTRY * thread_p);
 extern int session_set_trigger_state (THREAD_ENTRY * thread_p, bool is_trigger);
 extern int session_get_row_count (THREAD_ENTRY * thread_p, int *row_count);
 extern int session_set_row_count (THREAD_ENTRY * thread_p, const int row_count);
+extern int session_set_is_keep_session (THREAD_ENTRY * thread_p, bool is_keep_session);
 extern int session_get_session_parameters (THREAD_ENTRY * thread_p, SESSION_PARAM ** session_parameters);
 extern int session_set_session_parameters (THREAD_ENTRY * thread_p, SESSION_PARAM * session_parameters);
 extern int session_create_prepared_statement (THREAD_ENTRY * thread_p, char *name, char *alias_print, SHA1Hash * sha1,

--- a/src/session/session_sr.c
+++ b/src/session/session_sr.c
@@ -70,6 +70,12 @@ xsession_end_session (THREAD_ENTRY * thread_p, const SESSION_ID id, bool is_keep
   return session_state_destroy (thread_p, id, is_keep_session);
 }
 
+int
+xsession_set_is_keep_session (THREAD_ENTRY * thread_p, bool is_keep_session)
+{
+  return session_set_is_keep_session (thread_p, is_keep_session);
+}
+
 /*
  *  xsession_set_row_count () - set the count of affected rows for the
  *				    session associated to thread_p

--- a/src/session/session_sr.c
+++ b/src/session/session_sr.c
@@ -62,11 +62,12 @@ xsession_check_session (THREAD_ENTRY * thread_p, const SESSION_ID id)
  *  return	    : error code
  *  id (in) : session id
  *  thread_p (in)
+ *  is_keep_session (in) : whether to keep the session
  */
 int
-xsession_end_session (THREAD_ENTRY * thread_p, const SESSION_ID id)
+xsession_end_session (THREAD_ENTRY * thread_p, const SESSION_ID id, bool is_keep_session)
 {
-  return session_state_destroy (thread_p, id);
+  return session_state_destroy (thread_p, id, is_keep_session);
 }
 
 /*

--- a/src/session/session_sr.c
+++ b/src/session/session_sr.c
@@ -70,6 +70,12 @@ xsession_end_session (THREAD_ENTRY * thread_p, const SESSION_ID id, bool is_keep
   return session_state_destroy (thread_p, id, is_keep_session);
 }
 
+/*
+ * xsession_set_is_keep_session () - set the keep session flag for the session
+ * return	        : error code
+ * thread_p (in)        : worker thread
+ * is_keep_session (in) : whether to keep the session
+ */
 int
 xsession_set_is_keep_session (THREAD_ENTRY * thread_p, bool is_keep_session)
 {

--- a/win/cubridcs/cubridcs.def
+++ b/win/cubridcs/cubridcs.def
@@ -299,6 +299,8 @@ EXPORTS
     db_restart_ex
     db_set_session_id
     db_get_session_id
+    db_set_keep_session
+    db_get_keep_session
     db_find_or_create_session
     db_end_session
     db_set_connect_status

--- a/win/cubridsa/cubridsa.def
+++ b/win/cubridsa/cubridsa.def
@@ -43,6 +43,8 @@ EXPORTS
     db_restart_ex
     db_set_session_id
     db_get_session_id
+    db_set_keep_session
+    db_get_keep_session
     db_find_or_create_session
     db_end_session
     db_set_server_session_key


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25700


### **_Purpose_**

- 문제 상황
  - cas가 메모리 사용량 한계치 초과로 인해 restart 될 때 기존 세션 정보를 유지하지 않아 생기는 문제

- 문제 원인
    - cas의 메모리 사용량 한계치를 초과하여 cas가 restart하게 될 때, 기존 cas에서 할당받은 세션 정보를 새로운 cas에서 재사용
    - 하지만 CBRD-25414 이슈로 인해 세션 정보를 free하도록 수정되어 유지되지 않아 문제가 발생
    - 세션 정보를 유지해야할 때는 세션정보를 free하지 않도록 수정

---
### **_주요 함수 및 변수_**
- db_Keep_session
  - 세션을 유지할 지 판단하는 전역변수
  - 클라이언트에서 서버쪽으로 보내진다
  - 서버쪽에서는 해당 값을 보고 session_state의 is_keep_session 값을 true로 변경
- FN_KEEP_SESS
  - 세션을 유지해야하는 상황에서의 리턴값
- XXX_end_session()
  - 세션 종료를 요청하는 함수
  - 최종적으로 session_state_destroy 함수를 호출하여 세션 정리
- session_state_destroy()
  - 세션정보 정리하는 함수
  - 함수 내부에서 is_keep_session 값이 true라면 session_state의 is_keep_session 값을 true로 변경
- session_state->is_keep_session
  - 아래 데몬에서 만료된 세션이더라도 삭제하지 않도록 하는 변수
- session_remove_expired_sessions()
  - 60초마다 만료된 세션을 찾아 정리하는 데몬에서 호출하는 함수
  - hashmap에서 session 정보를 불러와 session_check_timeout() 함수를 통해
    현재 시간과 session에 저장되어있는 active_time을 비교하여
    그 둘의 차이가 timeout 값 이상이면 만료된 세션이라고 판단하여 free하고 있음

---
### **_Implementation_**
- 세션을 유지해야하는 경우 (FN_KEEP_SESS)에 db_Keep_session 값을 true로 설정하여 서버에 전달
- 서버에서는 해당 값을 읽어 session_state의 is_keep_session 값을 설정
- 만료된 세션을 정리하는 데몬에서 만료된 세션이더라도 유지해야한다면 세션을 정리하지않도록 수정