### PR TITLE
[CBRD-25737] Backport from develop to 11.3 - When unloading serial and trigger as dba user, schema name is missing

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -685,6 +685,9 @@ export_serial (extract_context & ctxt, print_output & output_ctx)
   size_t uppercase_user_size = 0;
   size_t query_size = 0;
   char *query = NULL;
+  char owner_name[DB_MAX_IDENTIFIER_LENGTH] = { '\0' };
+  char *serial_name = NULL;
+  char output_owner[DB_MAX_USER_LENGTH + 4] = { '\0' };
 
   /*
    * You must check SERIAL_VALUE_INDEX enum defined on the top of this file
@@ -820,23 +823,27 @@ export_serial (extract_context & ctxt, print_output & output_ctx)
 		}
 	    }
 
-	  output_ctx ("\ncreate serial %s%s%s\n", PRINT_IDENTIFIER (db_get_string (&values[SERIAL_NAME])));
-	  output_ctx ("\t start with %s\n", numeric_db_value_print (&values[SERIAL_CURRENT_VAL], str_buf));
-	  output_ctx ("\t increment by %s\n", numeric_db_value_print (&values[SERIAL_INCREMENT_VAL], str_buf));
-	  output_ctx ("\t minvalue %s\n", numeric_db_value_print (&values[SERIAL_MIN_VAL], str_buf));
-	  output_ctx ("\t maxvalue %s\n", numeric_db_value_print (&values[SERIAL_MAX_VAL], str_buf));
-	  output_ctx ("\t %scycle\n", (db_get_int (&values[SERIAL_CYCLIC]) == 0 ? "no" : ""));
+	  SPLIT_USER_SPECIFIED_NAME (db_get_string (&values[SERIAL_UNIQUE_NAME]), owner_name, serial_name);
+	  PRINT_OWNER_NAME (owner_name, (ctxt.is_dba_user || ctxt.is_dba_group_member), output_owner,
+			    sizeof (output_owner));
+
+	  output_ctx ("\nCREATE SERIAL %s%s%s%s\n", output_owner, PRINT_IDENTIFIER (db_get_string (&values[SERIAL_NAME])));
+	  output_ctx ("\t START WITH %s\n", numeric_db_value_print (&values[SERIAL_CURRENT_VAL], str_buf));
+	  output_ctx ("\t INCREMENT BY %s\n", numeric_db_value_print (&values[SERIAL_INCREMENT_VAL], str_buf));
+	  output_ctx ("\t MINVALUE %s\n", numeric_db_value_print (&values[SERIAL_MIN_VAL], str_buf));
+	  output_ctx ("\t MAXVALUE %s\n", numeric_db_value_print (&values[SERIAL_MAX_VAL], str_buf));
+	  output_ctx ("\t %sCYCLE\n", (db_get_int (&values[SERIAL_CYCLIC]) == 0 ? "no" : ""));
 	  if (db_get_int (&values[SERIAL_CACHED_NUM]) <= 1)
 	    {
-	      output_ctx ("\t nocache\n");
+	      output_ctx ("\t NOCACHE\n");
 	    }
 	  else
 	    {
-	      output_ctx ("\t cache %d\n", db_get_int (&values[SERIAL_CACHED_NUM]));
+	      output_ctx ("\t CACHE %d\n", db_get_int (&values[SERIAL_CACHED_NUM]));
 	    }
 	  if (DB_IS_NULL (&values[SERIAL_COMMENT]) == false)
 	    {
-	      output_ctx ("\t comment ");
+	      output_ctx ("\t COMMENT ");
 	      desc_value_print (output_ctx, &values[SERIAL_COMMENT]);
 	    }
 	  output_ctx (";\n");
@@ -844,12 +851,6 @@ export_serial (extract_context & ctxt, print_output & output_ctx)
 	  if (db_get_int (&values[SERIAL_STARTED]) == 1)
 	    {
 	      output_ctx ("SELECT %s%s%s.NEXT_VALUE;\n", PRINT_IDENTIFIER (db_get_string (&values[SERIAL_NAME])));
-	    }
-
-	  if (ctxt.is_dba_user || ctxt.is_dba_group_member)
-	    {
-	      output_ctx ("call [change_serial_owner] ('%s', '%s') on class [db_serial];\n",
-			  db_get_string (&values[SERIAL_NAME]), db_get_string (&values[SERIAL_OWNER_NAME]));
 	    }
 
 	  db_value_clear (&diff_value);

--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -827,7 +827,8 @@ export_serial (extract_context & ctxt, print_output & output_ctx)
 	  PRINT_OWNER_NAME (owner_name, (ctxt.is_dba_user || ctxt.is_dba_group_member), output_owner,
 			    sizeof (output_owner));
 
-	  output_ctx ("\nCREATE SERIAL %s%s%s%s\n", output_owner, PRINT_IDENTIFIER (db_get_string (&values[SERIAL_NAME])));
+	  output_ctx ("\nCREATE SERIAL %s%s%s%s\n", output_owner,
+		      PRINT_IDENTIFIER (db_get_string (&values[SERIAL_NAME])));
 	  output_ctx ("\t START WITH %s\n", numeric_db_value_print (&values[SERIAL_CURRENT_VAL], str_buf));
 	  output_ctx ("\t INCREMENT BY %s\n", numeric_db_value_print (&values[SERIAL_INCREMENT_VAL], str_buf));
 	  output_ctx ("\t MINVALUE %s\n", numeric_db_value_print (&values[SERIAL_MIN_VAL], str_buf));


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25737

여러계정으로 동일명의 serial 및 trigger를 생성 후 dba user로 unloaddb 한 경우 schema 없이 serial 및 trigger 명만 출력됨
serial 및 trigger 에 schema 를 붙여서 추출되어야 한다.