### PR TITLE
[CBRD-25389] Slip: Set holdable for query handlers in PL

### DIFF
--- a/src/method/method_query_handler.cpp
+++ b/src/method/method_query_handler.cpp
@@ -831,6 +831,7 @@ namespace cubmethod
       }
 
     db_get_cacheinfo (m_session, stmt_id, &m_use_plan_cache, NULL);
+    db_session_set_holdable (m_session, true);
 
     /* prepare result set */
     m_num_markers = get_num_markers ();


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25389

PL 에서 생성한 query에 대해서 holdable로 설정하여 COMMIT/ROLLBACK에서 커서가 닫히지 않도록 합니다.

이슈의 Repro를 실행 후 정리되지 않은 holdable cursor가 있는지 다음의 방법으로 확인이 가능합니다
```
cubrid statdump -s cursor -i 1 demodb
```
