### PR TITLE
[CUBVEC-14] CREATE TABLE: 2. Show 'VECTOR' column type when 'desc'

### DIFF
--- a/src/compat/dbtype_def.h
+++ b/src/compat/dbtype_def.h
@@ -733,6 +733,7 @@ extern "C"
     DB_TYPE_DATETIMETZ = 38,
     DB_TYPE_DATETIMELTZ = 39,
     DB_TYPE_JSON = 40,
+    DB_TYPE_VECTOR = 41,
 
     /* aliases */
     DB_TYPE_LIST = DB_TYPE_SEQUENCE,
@@ -740,7 +741,7 @@ extern "C"
     DB_TYPE_VARCHAR = DB_TYPE_STRING,	/* SQL CHAR(n) VARYING values */
     DB_TYPE_UTIME = DB_TYPE_TIMESTAMP,	/* SQL TIMESTAMP */
 
-    DB_TYPE_LAST = DB_TYPE_JSON
+    DB_TYPE_LAST = DB_TYPE_VECTOR
   } DB_TYPE;
 
   /* Domain information stored in DB_VALUE structures. */

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -1790,6 +1790,7 @@ PR_TYPE *tp_Type_id_map[] = {
   &tp_Datetimetz,
   &tp_Datetimeltz,
   &tp_Json,
+  &tp_Vector,
 };
 
 PR_TYPE tp_ResultSet = {
@@ -8717,6 +8718,7 @@ pr_type_from_id (DB_TYPE id)
 {
   PR_TYPE *type = NULL;
 
+  assert((unsigned long)id < (sizeof (tp_Type_id_map) / sizeof *tp_Type_id_map));
   if (id <= DB_TYPE_LAST && id != DB_TYPE_TABLE)
     {
       type = tp_Type_id_map[(int) id];
@@ -17115,3 +17117,29 @@ mr_cmpval_json (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int total
   pr_clear_value (&scalar_value2);
   return cmp_result;
 }
+
+PR_TYPE tp_Vector = {
+  "vector", DB_TYPE_VECTOR, 1, sizeof (SETOBJ *), 0, 4,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+};
+
+PR_TYPE *tp_Type_vector = &tp_Vector;
+

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -17137,7 +17137,7 @@ PR_TYPE tp_Vector = {
   NULL,
   NULL,
   NULL,
-  NULL,
+  NULL
 };
 
 PR_TYPE *tp_Type_vector = &tp_Vector;

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -1640,6 +1640,31 @@ PR_TYPE tp_Sequence = {
 
 PR_TYPE *tp_Type_sequence = &tp_Sequence;
 
+PR_TYPE tp_Vector = {
+  "vector", DB_TYPE_VECTOR, 1, sizeof (SETOBJ *), 0, 4,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL
+};
+
+PR_TYPE *tp_Type_vector = &tp_Vector;
+
 PR_TYPE tp_Midxkey = {
   "midxkey", DB_TYPE_MIDXKEY, 1, 0, 0, 1,
   NULL,				/* initmem */
@@ -17116,29 +17141,4 @@ mr_cmpval_json (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int total
   pr_clear_value (&scalar_value2);
   return cmp_result;
 }
-
-PR_TYPE tp_Vector = {
-  "vector", DB_TYPE_VECTOR, 1, sizeof (SETOBJ *), 0, 4,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL
-};
-
-PR_TYPE *tp_Type_vector = &tp_Vector;
 

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -8718,7 +8718,6 @@ pr_type_from_id (DB_TYPE id)
 {
   PR_TYPE *type = NULL;
 
-  assert((unsigned long)id < (sizeof (tp_Type_id_map) / sizeof *tp_Type_id_map));
   if (id <= DB_TYPE_LAST && id != DB_TYPE_TABLE)
     {
       type = tp_Type_id_map[(int) id];

--- a/src/object/object_primitive.h
+++ b/src/object/object_primitive.h
@@ -225,6 +225,7 @@ extern PR_TYPE tp_Datetimeltz;
 extern PR_TYPE tp_Timetz;
 extern PR_TYPE tp_Timeltz;
 extern PR_TYPE tp_Json;
+extern PR_TYPE tp_Vector;
 
 extern PR_TYPE *tp_Type_null;
 extern PR_TYPE *tp_Type_integer;

--- a/src/object/object_printer.cpp
+++ b/src/object/object_printer.cpp
@@ -317,6 +317,10 @@ void object_printer::describe_domain (/*const*/tp_domain &domain, class_descript
 		}
 	    }
 	  break;
+	case DB_TYPE_VECTOR:
+	  strcpy (temp_buffer, temp_domain->type->name);
+	  m_buf ("%s", ustr_upper (temp_buffer));
+	  break;
 
 	case DB_TYPE_ENUMERATION:
 	  has_collation = 1;

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -22136,6 +22136,7 @@ primitive_type
 		DBG_PRINT}}
 	;
 
+<<<<<<< HEAD
 opt_vector_args
   : /* empty */
 		{{ DBG_TRACE_GRAMMAR(opt_vector_args, : );
@@ -22163,6 +22164,35 @@ opt_vector_args
 		DBG_PRINT}}
 	;
 
+opt_vector_args
+  : /* empty */
+		{{ DBG_TRACE_GRAMMAR(opt_vector_args, : );
+
+			container_2 ctn;
+			SET_CONTAINER_2 (ctn, NULL, NULL);
+			$$ = ctn;
+
+		DBG_PRINT}}
+	| '(' unsigned_integer ')'
+		{{ DBG_TRACE_GRAMMAR(opt_vector_args, | '(' unsigned_integer ')' );
+
+			container_2 ctn;
+			SET_CONTAINER_2 (ctn, $2, NULL);
+			$$ = ctn;
+
+		DBG_PRINT}}
+	| '(' unsigned_integer ',' primitive_type ')'
+		{{ DBG_TRACE_GRAMMAR(opt_vector_args, | '(' unsigned_integer ',' primitive_type ')' );
+
+			container_2 ctn;
+      // TODO: primitive_type not yet handled.
+      container_2 primitive_type_container = $4;
+
+			SET_CONTAINER_2 (ctn, $2, NULL);
+			$$ = ctn;
+
+		DBG_PRINT}}
+	;
 
 opt_internal_external
 	: /* empty */

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -22136,7 +22136,6 @@ primitive_type
 		DBG_PRINT}}
 	;
 
-<<<<<<< HEAD
 opt_vector_args
   : /* empty */
 		{{ DBG_TRACE_GRAMMAR(opt_vector_args, : );
@@ -22164,35 +22163,6 @@ opt_vector_args
 		DBG_PRINT}}
 	;
 
-opt_vector_args
-  : /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_vector_args, : );
-
-			container_2 ctn;
-			SET_CONTAINER_2 (ctn, NULL, NULL);
-			$$ = ctn;
-
-		DBG_PRINT}}
-	| '(' unsigned_integer ')'
-		{{ DBG_TRACE_GRAMMAR(opt_vector_args, | '(' unsigned_integer ')' );
-
-			container_2 ctn;
-			SET_CONTAINER_2 (ctn, $2, NULL);
-			$$ = ctn;
-
-		DBG_PRINT}}
-	| '(' unsigned_integer ',' primitive_type ')'
-		{{ DBG_TRACE_GRAMMAR(opt_vector_args, | '(' unsigned_integer ',' primitive_type ')' );
-
-			container_2 ctn;
-      // TODO: primitive_type not yet handled.
-      container_2 primitive_type_container = $4;
-
-			SET_CONTAINER_2 (ctn, $2, NULL);
-			$$ = ctn;
-
-		DBG_PRINT}}
-	;
 
 opt_internal_external
 	: /* empty */

--- a/src/parser/parse_dbi.c
+++ b/src/parser/parse_dbi.c
@@ -1602,6 +1602,7 @@ pt_type_enum_to_db_domain (const PT_TYPE_ENUM t)
     case DB_TYPE_OBJECT:
     case DB_TYPE_SET:
     case DB_TYPE_MULTISET:
+    case DB_TYPE_VECTOR:
     case DB_TYPE_SEQUENCE:
     case DB_TYPE_MIDXKEY:
     case DB_TYPE_ENUMERATION:
@@ -2378,6 +2379,10 @@ pt_type_enum_to_db (const PT_TYPE_ENUM t)
 
     case PT_TYPE_JSON:
       db_type = DB_TYPE_JSON;
+      break;
+
+    case PT_TYPE_VECTOR:
+      db_type = DB_TYPE_VECTOR;
       break;
 
     case PT_TYPE_OBJECT:

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -25042,6 +25042,9 @@ qexec_schema_get_type_name_from_id (DB_TYPE id)
     case DB_TYPE_SEQUENCE:
       return "SEQUENCE";
 
+    case DB_TYPE_VECTOR:
+      return "VECTOR";
+
     case DB_TYPE_NCHAR:
       return "NCHAR";
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-14

## **Purpose**  
현재 `desc` 명령을 실행할 때 **VECTOR** 데이터 타입이 **OBJECT**로 잘못 출력되는 문제를 해결합니다.  
이 변경 사항은 VECTOR 타입을 데이터베이스 시스템 전반에 걸쳐 올바르게 정의하고 출력하도록 수정합니다.  

---

## **Implementation** 

1. **VECTOR 타입 매핑 및 처리 로직 추가**  
   - `pt_type_enum_to_db()` 함수에 `PT_TYPE_VECTOR`를 `DB_TYPE_VECTOR`로 변환하는 로직을 추가했습니다.  
   - `pt_type_enum_to_db_domain()` 함수에 `DB_TYPE_VECTOR` 처리를 추가하여 도메인 매핑이 제대로 이루어지도록 했습니다.  

2. **VECTOR 타입 이름 반환**  
   - `qexec_schema_get_type_name_from_id()` 함수에 `DB_TYPE_VECTOR` 핸들링을 추가하여 `desc` 명령에서 `"VECTOR"` 문자열이 반환되도록 수정했습니다.  

3. **VECTOR 타입 시스템 등록**  
   - `tp_Type_id_map` 배열에 `tp_Vector`를 추가하여 데이터 타입 매핑 과정에서 누락되지 않도록 했습니다.  
   - `tp_Vector` 정의를 추가하여 VECTOR 타입이 시스템에 올바르게 등록되도록 처리했습니다.  

---

### **관련 코드 변경 사항**  
**`dbtype_def.h`**  
```c
+    DB_TYPE_VECTOR = 41,
-    DB_TYPE_LAST = DB_TYPE_JSON
+    DB_TYPE_LAST = DB_TYPE_VECTOR
```

**`object_primitive.c`**  
```c
+  &tp_Vector,
```

**`parse_dbi.c`**  
```c
+    case PT_TYPE_VECTOR:
+      db_type = DB_TYPE_VECTOR;
+      break;
```

**`query_executor.c`**  
```c
+    case DB_TYPE_VECTOR:
+      return "VECTOR";
```
---

## **Remarks**  
- 해당 수정은 시스템의 다른 기능에 영향을 주지 않으며, `VECTOR` 타입에 대한 정확한 처리만을 추가합니다.  
- 변경 사항이 적용된 후 `csql -u dba testdb -S -c 'desc vt;'` 명령을 실행하면 VECTOR 필드가 **VECTOR**로 정확하게 출력됩니다.  

---

### **Testing**  
- `desc` 명령 테스트: VECTOR 타입이 **VECTOR**로 출력되는지 확인했습니다. 

