### PR TITLE
[CBRD-25760] Fix grep command in check.yml to prevent false matches

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -268,7 +268,7 @@ jobs:
             fi
 
             filename=$(basename $f)
-            check_server_file=$(grep $filename cubrid/CMakeLists.txt)
+            check_server_file=$(grep -F $filename cubrid/CMakeLists.txt)
             if [ "$check_server_file" == "" ]; then
               result_for_f="PASS"
             fi


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25760

Description

memory_monitor_check 중 grep을 하는 과정에서 -F 옵션을 주지 않아

Period가 wildcard로 인식되어 원치 않는 문자열이 검색되고, 그로인해 FAIL이 발생합니다.

(e.g., 'cas.c' matching 'cascci')