### PR TITLE
[CBRD-25754] Regression: change structure for deadlock log.

### DIFF
--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -164,9 +164,6 @@ extern LOCK_COMPATIBILITY lock_Comp[12][12];
     } \
    while (0)
 
-#define OF_GET_LK_ENTRY_DEREF(p,o) \
-    (*((LK_ENTRY * volatile *) (((char *) (p)) + (o))))
-
 #endif /* SERVER_MODE */
 
 #define RESOURCE_ALLOC_WAIT_TIME 10	/* 10 msec */
@@ -288,8 +285,10 @@ struct lk_deadlock_victim
   TRANID tranid;		/* Transaction identifier */
   bool can_timeout;		/* Is abort or timeout */
 
-  LK_ENTRY *holder;		/* holder entries that cause deadlock */
-  LK_ENTRY *waiter;		/* waiter entries that cause deadlock */
+  /* for event log */
+  bool log_trunc;
+  int log_num_entries;		/* # of entries */
+  LK_ENTRY **log_entries;	/* entries that cause deadlock */
 };
 
 /*
@@ -547,8 +546,8 @@ static void lock_decrement_class_granules (LK_ENTRY * class_entry);
 static LK_ENTRY *lock_find_class_entry (int tran_index, const OID * class_oid);
 
 static void lock_event_log_tran_locks (THREAD_ENTRY * thread_p, FILE * log_fp, int tran_index);
-static void lock_event_log_deadlock_locks (THREAD_ENTRY * thread_p, FILE * log_fp, int tran_index, LK_ENTRY * holder,
-					   LK_ENTRY * waiter);
+static void lock_event_log_deadlock_locks (THREAD_ENTRY * thread_p, FILE * log_fp, int tran_index, bool log_trunc,
+					   int log_num_entries, LK_ENTRY ** log_entries);
 static void lock_event_log_blocked_lock (THREAD_ENTRY * thread_p, FILE * log_fp, LK_ENTRY * entry);
 static void lock_event_log_blocking_locks (THREAD_ENTRY * thread_p, FILE * log_fp, LK_ENTRY * wait_entry);
 static void lock_event_log_lock_info (THREAD_ENTRY * thread_p, FILE * log_fp, LK_ENTRY * entry);
@@ -4863,6 +4862,8 @@ lock_select_deadlock_victim (THREAD_ENTRY * thread_p, int s, int t)
   const char *client_prog_name, *client_user_name, *client_host_name;
   int client_pid;
   int next_node;
+  int log_max_entries, log_num_entries;
+  LK_ENTRY **log_entries;
   LK_ENTRY *holder, *waiter;
   int victim_tran_index;
   int tran_log_count, victim_tran_log_count;
@@ -5142,28 +5143,43 @@ lock_select_deadlock_victim (THREAD_ENTRY * thread_p, int s, int t)
 	  er_log_debug (ARG_FILE_LINE, "victim(index=%d) is old in deadlock cycle\n", victims[victim_count].tran_index);
 	}
 #endif /* CUBRID_DEBUG */
-      victims[victim_count].waiter = NULL;
-      victims[victim_count].holder = NULL;
-      for (v = s;;)
+
+      victims[victim_count].log_trunc = false;
+
+      log_max_entries = num_tran_in_cycle * 2;
+      if (log_max_entries > MAX_NUM_LOCKS_DUMP_TO_EVENT_LOG)
 	{
-	  holder = TWFG_edge[TWFG_node[v].current].holder;
-	  waiter = TWFG_edge[TWFG_node[v].current].waiter;
-
-	  assert (holder != NULL && waiter != NULL);
-
-	  /* In this case, entry is not on any stack (global or local). */
-	  /* we can link the lock lists using member accessible via of_local_next. */
-	  OF_GET_LK_ENTRY_DEREF (holder, obj_lock_entry_desc.of_local_next) = victims[victim_count].holder;
-	  victims[victim_count].holder = holder;
-
-	  OF_GET_LK_ENTRY_DEREF (waiter, obj_lock_entry_desc.of_local_next) = victims[victim_count].waiter;
-	  victims[victim_count].waiter = waiter;
-
-	  if (v == t)
-	    break;
-
-	  v = TWFG_node[v].ancestor;
+	  log_max_entries =
+	    MAX_NUM_LOCKS_DUMP_TO_EVENT_LOG % 2 ? MAX_NUM_LOCKS_DUMP_TO_EVENT_LOG - 1 : MAX_NUM_LOCKS_DUMP_TO_EVENT_LOG;
+	  victims[victim_count].log_trunc = true;
 	}
+
+      log_num_entries = 0;
+      log_entries = (LK_ENTRY **) malloc (sizeof (LK_ENTRY *) * log_max_entries);
+
+      if (log_entries != NULL)
+	{
+	  for (v = s;;)
+	    {
+	      holder = TWFG_edge[TWFG_node[v].current].holder;
+	      waiter = TWFG_edge[TWFG_node[v].current].waiter;
+
+	      assert (holder != NULL && waiter != NULL);
+
+	      log_entries[log_num_entries++] = holder;
+	      log_entries[log_num_entries++] = waiter;
+
+	      if (v == t || log_num_entries >= log_max_entries)
+		break;
+
+	      v = TWFG_node[v].ancestor;
+	    }
+
+	  assert (log_num_entries == log_max_entries);
+	}
+
+      victims[victim_count].log_num_entries = log_num_entries;
+      victims[victim_count].log_entries = log_entries;
 
       TWFG_node[victims[victim_count].tran_index].current = -1;
       victim_count++;
@@ -8011,7 +8027,7 @@ final_:
   /* dump deadlock cycle to event log file */
   for (k = 0; k < victim_count; k++)
     {
-      if (victims[k].holder == NULL && victims[k].waiter == NULL)
+      if (victims[k].log_num_entries == 0 || victims[k].log_entries == NULL)
 	{
 	  continue;
 	}
@@ -8019,9 +8035,12 @@ final_:
       log_fp = event_log_start (thread_p, "DEADLOCK");
       if (log_fp != NULL)
 	{
-	  lock_event_log_deadlock_locks (thread_p, log_fp, victims[k].tran_index, victims[k].holder, victims[k].waiter);
+	  lock_event_log_deadlock_locks (thread_p, log_fp, victims[k].tran_index, victims[k].log_trunc,
+					 victims[k].log_num_entries, victims[k].log_entries);
 	  event_log_end (thread_p);
 	}
+
+      free_and_init (victims[k].log_entries);
     }
 
   /* Now solve the deadlocks (cycles) by executing the cycle resolution function (e.g., aborting victim) */
@@ -9377,14 +9396,15 @@ lock_event_log_tran_locks (THREAD_ENTRY * thread_p, FILE * log_fp, int tran_inde
  *   thread_p(in): thread
  *   log_fp(in): file pointer (log)
  *   tran_index(in): transaction index selected as victim
- *   holder(in): holder list
- *   waiter(in): waiter list
+ *   log_trunc(in): is the entries truncated
+ *   log_num_entries(in): number of the entries
+ *   log_entries(in): entries
  *
  *   note: for deadlock
  */
 static void
-lock_event_log_deadlock_locks (THREAD_ENTRY * thread_p, FILE * log_fp, int tran_index, LK_ENTRY * holder,
-			       LK_ENTRY * waiter)
+lock_event_log_deadlock_locks (THREAD_ENTRY * thread_p, FILE * log_fp, int tran_index, bool log_trunc,
+			       int log_num_entries, LK_ENTRY ** log_entries)
 {
   const char *prog, *user, *host;
   int pid;
@@ -9395,12 +9415,13 @@ lock_event_log_deadlock_locks (THREAD_ENTRY * thread_p, FILE * log_fp, int tran_
   LK_ENTRY *entry;
 
   assert (csect_check_own (thread_p, CSECT_EVENT_LOG_FILE) == 1);
+  assert (log_num_entries && !(log_num_entries % 2));
+  assert (log_entries != NULL);
 
-  max_num_locks =
-    (MAX_NUM_LOCKS_DUMP_TO_EVENT_LOG % 2) ? MAX_NUM_LOCKS_DUMP_TO_EVENT_LOG + 1 : MAX_NUM_LOCKS_DUMP_TO_EVENT_LOG;
-  entry = holder;
-  for (i = 0; entry != NULL && i < max_num_locks; i++)
+  for (i = 0; i < log_num_entries; i++)
     {
+      entry = log_entries[i];
+
       /* holder and waiter are printed alternately */
       fprintf (log_fp, i % 2 ? "\nwait:\n" : "hold:\n");
 
@@ -9435,26 +9456,11 @@ lock_event_log_deadlock_locks (THREAD_ENTRY * thread_p, FILE * log_fp, int tran_
       pthread_mutex_unlock (&tran_lock->hold_mutex);
 
       fprintf (log_fp, i % 2 ? "\n" : "");
-
-      if (i % 2)
-	{
-	  /* waiter to holder */
-	  entry = holder;
-	  waiter = OF_GET_LK_ENTRY_DEREF (waiter, obj_lock_entry_desc.of_local_next);
-	}
-      else
-	{
-	  /* holder to waiter */
-	  entry = waiter;
-	  holder = OF_GET_LK_ENTRY_DEREF (holder, obj_lock_entry_desc.of_local_next);
-	}
     }
 
-  assert ((holder == NULL && waiter == NULL) || (holder != NULL && waiter != NULL));
-
-  if (holder != NULL && waiter != NULL)
+  if (log_trunc)
     {
-      fprintf (log_fp, "%*c...\n", indent, ' ');
+      fprintf (log_fp, "%*c...\n\n", indent, ' ');
     }
 }
 

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -8027,14 +8027,14 @@ final_:
   /* dump deadlock cycle to event log file */
   for (k = 0; k < victim_count; k++)
     {
-      if (victims[k].log_num_entries == 0 || victims[k].log_entries == NULL)
-	{
-	  continue;
-	}
-
       log_fp = event_log_start (thread_p, "DEADLOCK");
       if (log_fp != NULL)
 	{
+	  if (victims[k].log_entries == NULL)
+	    {
+	      event_log_end (thread_p);
+	      continue;
+	    }
 	  lock_event_log_deadlock_locks (thread_p, log_fp, victims[k].tran_index, victims[k].log_trunc,
 					 victims[k].log_num_entries, victims[k].log_entries);
 	  event_log_end (thread_p);

--- a/src/transaction/lock_manager.h
+++ b/src/transaction/lock_manager.h
@@ -86,13 +86,7 @@ struct lk_entry
   LOCK blocked_mode;		/* blocked lock mode */
   int count;			/* number of lock requests */
   UINT64 del_id;		/* delete transaction ID (for latch free) */
-
-  /* this member is usually used for the freelist, but can be used for other purposes as well. */
-  /* until the block is claimed, this member cannot be used because it may be used for the retired list. */
-  /* after the block is claimed, this member can be used for any purpose. currently, it is used for the following purposes... */
-  /*    1. linked list for deadlock logging */
-  LK_ENTRY *stack;
-
+  LK_ENTRY *stack;		/* pointer to retired stack */
   LK_ENTRY *next;		/* next entry */
   LK_ENTRY *tran_next;		/* list of locks that trans. holds */
   LK_ENTRY *tran_prev;		/* list of locks that trans. holds */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25754

**Purpose**
이슈 CBRD-25590로 인해 발생하는 오류를 제거하기 위해 구조를 변경

**Implementation**
[CBRD-25590](http://jira.cubrid.org/browse/CBRD-25590)에서 처리한 내용은 아래와 같습니다.
1. 사용되지 않는 코드들과 처리를 제거
2. deadlock 로그 간략화
3. malloc을 사용하지 않을 수 있도록 구조 변경

deadlock을 일으킨 잠금들을 추후 출력하기 위해서 victim (LK_DEADLOCK_VICTIM)은 deadlock cycle의 정보를 저장해야 합니다.
이를 위해 holder (LK_ENTRY *)와 waiter (LK_ENTRY *)멤버를 LK_DEADLOCK_VICTIM에 추가했습니다. (holder는 현재 잠금을 얻은 entry, waiter는 holder로 인해 잠금을 대기 중인 entry를 의미)
이때 초기화가 아닌 런타임에서 malloc을 호출하는 것을 피하기 위해 잠금 구조체 LK_ENTRY의 멤버 local next을 사용하여 연결 리스트로 구성하였습니다. (local next는 claim된 상황에서는 사용에 자유롭다)

최종적으로 LK_DEADLOCK_VICTIM 내부에서 holder와 waiter는 아래처럼 걸리고, 각각 holder1, waiter1이 짝이 됩니다.
`LK_ENTRY 연결 리스트`
holder - holder1 - holder2 - holder3 - NULL
waiter - waiter1 - waiter2 - waiter3 - NULL

</br>

그러나 deadlock 구조 상 하나의 잠금이 여러 개의 deadlock cycle에 기여할 수 있으며, victim selection에서 선택한 트랜잭션이 여러 개의 deadlock cycle에 걸친 잠금을 가진 트랜잭션이 아닐 경우 문제가 발생합니다. 따라서
[CBRD-25754](http://jira.cubrid.org/browse/CBRD-25754)에서는 연결 리스트 구조를 되돌리고 malloc을 사용하도록 변경하여 문제를 제거하였습니다.

이 경우 단순히 malloc으로 `deadlock에 참여한 트랜잭션의 개수 * 2` 만큼의 메모리를 할당 받고, 배열에 holder와 waiter를 번갈아가며 저장합니다.
`LK_ENTRY 배열`
log_trunc - false
log_num_entries - 6
log_entries - holder1 | waiter1 | holder2 | waiter2 | holder3 | waiter3

*log_trunc는 로그가 MAX_NUM_LOCKS_DUMP_TO_EVENT_LOG보다 많아 잘렸음을 의미

다만 malloc은 실패의 가능성이 존재하고, deadlock cycle 로그로 인해서 서버 전반이 다운되는 것은 과하므로 malloc을 실패할 경우 DEADLOCK이 있었다는 것만 출력하고 deadlock cycle은 출력하지 않도록 하였습니다.

**Remarks**
N/A