### PR TITLE
[CUBVEC-15] INSERT&SELECT: Convert DB_TYPE_VECTOR to PT_TYPE_VECTOR

### DIFF
--- a/src/parser/parse_dbi.c
+++ b/src/parser/parse_dbi.c
@@ -2677,6 +2677,9 @@ pt_db_to_type_enum (const DB_TYPE t)
     case DB_TYPE_SEQUENCE:
       pt_type = PT_TYPE_SEQUENCE;
       break;
+    case DB_TYPE_VECTOR:
+      pt_type = PT_TYPE_VECTOR;
+      break;
 
     case DB_TYPE_CHAR:
       pt_type = PT_TYPE_CHAR;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-15


## Purpose

지원되지 않는 `DB_TYPE_VECTOR` 타입을 처리하여,
DB Value와 Column Attribute 간의 호환이 되는지 Semantic Check를 하는 과정에서 사용됨.

## Implementation

1. `DB_TYPE_VECTOR` 타입을 처리할 수 있도록 `pt_db_to_type_enum` 함수에 새로운 로직 추가.
2. 시맨틱 체킹(Semantic Check) 과정에서 `DB_TYPE_VECTOR`가 `PT_TYPE_VECTOR`로 변환되도록 구현.

*변경된 코드 위치:*
- 파일: `src/parser/parse_dbi.c`
- 함수: `pt_db_to_type_enum`

### 변경 코드:
```c
@@ -2679,2 +2679,5 @@ pt_db_to_type_enum (const DB_TYPE t)
      break;
+    case DB_TYPE_VECTOR:
+      pt_type = PT_TYPE_VECTOR;
+      break;
```

## Remarks
N/A
