### PR TITLE
[CBRD-25757] check coercibility of SP parameter default values without actually coercing it

### DIFF
--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -9552,9 +9552,11 @@ pt_check_default_value_param_for_stored_procedure (PARSER_CONTEXT * parser, PT_N
     }
   else
     {
+      PT_NODE *dummy = parser_new_node (parser, PT_VALUE);
       error =
-	pt_coerce_value_for_default_value (parser, default_value, default_value, param->type_enum,
+	pt_coerce_value_for_default_value (parser, default_value, dummy, param->type_enum,
 					   param->data_type, default_value_node->info.data_default.default_expr_type);
+      parser_free_node (parser, dummy);
       if (error != NO_ERROR)
 	{
 	  error =

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -19440,7 +19440,7 @@ pt_coerce_value_for_default_value (PARSER_CONTEXT * parser, PT_NODE * src, PT_NO
       implicit_coercion = true;
     }
 
-  return pt_coerce_value_internal (parser, src, dest, desired_type, data_type, true, implicit_coercion);
+  return pt_coerce_value_internal (parser, src, dest, desired_type, data_type, false, implicit_coercion);
 }
 
 /*

--- a/src/sp/jsp_cl.cpp
+++ b/src/sp/jsp_cl.cpp
@@ -2425,8 +2425,6 @@ jsp_get_default_expr_node_list (PARSER_CONTEXT *parser, cubpl::pl_signature &sig
 	  else
 	    {
 	      default_next_node = pt_make_string_value (parser, sig.arg.arg_default_value[i]);
-	      default_next_node = pt_wrap_with_cast_op (parser, default_next_node, pt_db_to_type_enum ((DB_TYPE) sig.arg.arg_type[i]),
-				  TP_FLOATING_PRECISION_VALUE, 0, NULL);
 	    }
 	}
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25757

인자 타입에서의 NUMERIC, CHAR 는 실제로 NUMERIC(ANY, ANY), CHAR(ANY) 를 의미하나, 
NUMERIC(ANY, ANY), CHAR(ANY) 로의 형변환이 큐브리드에 아직 구현되지 않았기 때문에
일단, 현단계에서 CBRD-25690은 아래와 같이 해결한다.

- SP 인자의 디폴트 값이 파라메터 타입으로 형변환 가능한지 테스트만 하고 실제로 형변환은 하지 않음
  - 카탈로그 테이블에 사용자가 적어준 값이 형변환 되지 않고 그대로 문자열로 저장됨.
- SP 인자의 디폴트 값의 문자열 저장값을 파라메터 타입으로 cast 하지 않고 그대로 문자열인 채로 PL 서버로 보냄.
  - 필요한 형변환은 PL 서버에서 일어남 
  - 큐브리드 엔진에서의 형변환과 100% 일치하지 않는다는 문제는 있음 (시간 상 이유로 별도 이슈로 해결 요망)

