### PR TITLE
[CUBVEC-26] INSERT&SELECT: set_create_vector for DB_COLLECTION

### DIFF
--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -357,6 +357,7 @@ db_value_domain_init (DB_VALUE * value, const DB_TYPE type, const int precision,
     case DB_TYPE_SET:
     case DB_TYPE_MULTISET:
     case DB_TYPE_SEQUENCE:
+    case DB_TYPE_VECTOR:
     case DB_TYPE_MIDXKEY:
     case DB_TYPE_BLOB:
     case DB_TYPE_CLOB:

--- a/src/compat/dbtype_function.i
+++ b/src/compat/dbtype_function.i
@@ -120,6 +120,7 @@ STATIC_INLINE int db_make_oid (DB_VALUE * value, const OID * oid) __attribute__ 
 STATIC_INLINE int db_make_set (DB_VALUE * value, DB_C_SET * set) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int db_make_multiset (DB_VALUE * value, DB_C_SET * set) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int db_make_sequence (DB_VALUE * value, DB_C_SET * set) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE int db_make_vector (DB_VALUE * value, DB_C_SET * set) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int db_make_collection (DB_VALUE * value, DB_C_SET * set) __attribute__ ((ALWAYS_INLINE));
 
 STATIC_INLINE int db_make_elo (DB_VALUE * value, DB_TYPE type, const DB_ELO * elo) __attribute__ ((ALWAYS_INLINE));
@@ -1978,6 +1979,45 @@ db_make_sequence (DB_VALUE * value, DB_SET * set)
   if (set)
     {
       if ((set->set && setobj_type (set->set) == DB_TYPE_SEQUENCE) || set->disk_set)
+	{
+	  value->domain.general_info.is_null = 0;
+	}
+      else
+	{
+	  error = ER_QPROC_INVALID_DATATYPE;
+	  er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_DATATYPE, 0);
+	}
+    }
+  else
+    {
+      value->domain.general_info.is_null = 1;
+    }
+
+  value->need_clear = false;
+
+  return error;
+}
+
+/*
+ * db_make_vector() -
+ * return :
+ * value(out) :
+ * set(in):
+ */
+int
+db_make_vector (DB_VALUE * value, DB_SET * set)
+{
+  int error = NO_ERROR;
+
+#if defined (API_ACTIVE_CHECKS)
+  CHECK_1ARG_ERROR (value);
+#endif
+
+  value->domain.general_info.type = DB_TYPE_VECTOR;
+  value->data.set = set;
+  if (set)
+    {
+      if ((set->set && setobj_type (set->set) == DB_TYPE_VECTOR) || set->disk_set)
 	{
 	  value->domain.general_info.is_null = 0;
 	}

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -255,6 +255,8 @@ TP_DOMAIN tp_Multiset_domain = { NULL, NULL, &tp_Multiset, DOMAIN_INIT3 };
 
 TP_DOMAIN tp_Sequence_domain = { NULL, NULL, &tp_Sequence, DOMAIN_INIT3 };
 
+TP_DOMAIN tp_Vector_domain = { NULL, NULL, &tp_Vector, DOMAIN_INIT3 };
+
 TP_DOMAIN tp_Midxkey_domain_list_heads[TP_NUM_MIDXKEY_DOMAIN_LIST] = {
   {NULL, NULL, &tp_Midxkey, DOMAIN_INIT3},
   {NULL, NULL, &tp_Midxkey, DOMAIN_INIT3},

--- a/src/object/object_domain.h
+++ b/src/object/object_domain.h
@@ -152,6 +152,7 @@ extern TP_DOMAIN tp_Object_domain;
 extern TP_DOMAIN tp_Set_domain;
 extern TP_DOMAIN tp_Multiset_domain;
 extern TP_DOMAIN tp_Sequence_domain;
+extern TP_DOMAIN tp_Vector_domain;
 extern TP_DOMAIN tp_Elo_domain;
 extern TP_DOMAIN tp_Blob_domain;
 extern TP_DOMAIN tp_Clob_domain;
@@ -224,7 +225,9 @@ typedef enum tp_match
 
 #define TP_IS_SET_TYPE(typenum) \
   ((((typenum) == DB_TYPE_SET) || ((typenum) == DB_TYPE_MULTISET) || \
-    ((typenum) == DB_TYPE_SEQUENCE)) ? true : false)
+    ((typenum) == DB_TYPE_SEQUENCE) || \
+    ((typenum) == DB_TYPE_VECTOR)) \
+    ? true : false)
 
 /*
  * TP_IS_BIT_TYPE

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -17141,3 +17141,4 @@ mr_cmpval_json (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int total
   pr_clear_value (&scalar_value2);
   return cmp_result;
 }
+

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -17141,4 +17141,3 @@ mr_cmpval_json (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int total
   pr_clear_value (&scalar_value2);
   return cmp_result;
 }
-

--- a/src/object/set_object.c
+++ b/src/object/set_object.c
@@ -860,6 +860,9 @@ col_new (long size, int settype)
 	    case DB_TYPE_SEQUENCE:
 	      col->domain = &tp_Sequence_domain;
 	      break;
+	    case DB_TYPE_VECTOR:
+	      col->domain = &tp_Vector_domain;
+	      break;
 	    case DB_TYPE_VOBJ:
 	      col->domain = &tp_Vobj_domain;
 	      break;
@@ -2434,6 +2437,12 @@ DB_COLLECTION *
 set_create_sequence (int size)
 {
   return set_create (DB_TYPE_SEQUENCE, size);
+}
+
+DB_COLLECTION *
+set_create_vector (int size)
+{
+  return set_create (DB_TYPE_VECTOR, size);
 }
 
 DB_COLLECTION *

--- a/src/object/set_object.h
+++ b/src/object/set_object.h
@@ -115,6 +115,7 @@ extern void set_area_reset ();
 extern DB_COLLECTION *set_create_basic (void);
 extern DB_COLLECTION *set_create_multi (void);
 extern DB_COLLECTION *set_create_sequence (int size);
+extern DB_COLLECTION *set_create_vector (int size);
 extern DB_COLLECTION *set_create_with_domain (TP_DOMAIN * domain, int initial_size);
 extern DB_COLLECTION *set_make_reference (void);
 extern DB_COLLECTION *set_copy (DB_COLLECTION * set);

--- a/win/cubridcs/cubridcs.def
+++ b/win/cubridcs/cubridcs.def
@@ -237,6 +237,7 @@ EXPORTS
     db_make_null
     db_make_object
     db_make_sequence
+    db_make_vector
     db_make_set
     db_make_short
     db_make_string


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBVEC-26>

### Purpose

본 Pull Request는 CUBRID 데이터베이스 시스템에 새로운 데이터 타입인 `DB_TYPE_VECTOR`를 추가합니다. 기존의 `set` 구조(`setobj`)를 활용하여 코드 중복을 최소화하고, 일관성을 유지하며, 새로운 데이터 관리 방식을 지원할 수 있도록 설계되었습니다. 이로 인해 `VECTOR` 타입을 유효한 컬렉션 타입으로 추가하며, 기존 기능과의 호환성을 유지합니다.

---

### Implementation

#### 1. **`DB_TYPE_VECTOR` 타입 추가**

- 새로운 데이터 타입 `DB_TYPE_VECTOR`를 정의했습니다.
- `db_value_domain_init` 함수에 `DB_TYPE_VECTOR` 초기화 처리를 추가했습니다.

  ```c
  case DB_TYPE_VECTOR:
      // VECTOR 타입 초기화 처리
      break;
  ```

#### 2. **도메인 관리**

- `tp_Vector_domain`을 정의하여 `DB_TYPE_VECTOR`를 도메인으로 관리할 수 있도록 추가했습니다.
- `TP_IS_SET_TYPE` 매크로를 확장하여 `DB_TYPE_VECTOR`를 유효한 `set` 타입으로 간주했습니다.

  ```c
  TP_DOMAIN tp_Vector_domain = { NULL, NULL, &tp_Vector, DOMAIN_INIT3 };

  #define TP_IS_SET_TYPE(typenum) \
      ((((typenum) == DB_TYPE_SET) || ((typenum) == DB_TYPE_MULTISET) || \
        ((typenum) == DB_TYPE_SEQUENCE) || ((typenum) == DB_TYPE_VECTOR)) \
      ? true : false)
  ```

#### 3. **VECTOR 데이터 생성 지원**

- 새로운 함수 `set_create_vector`를 구현하여 `DB_TYPE_VECTOR` 타입의 컬렉션 데이터를 생성할 수 있도록 했습니다.
- 내부적으로 기존 `set_create` 함수를 호출하며, `DB_TYPE_VECTOR`를 명시적으로 전달합니다.

  ```c
  DB_COLLECTION *
  set_create_vector (int size)
  {
      return set_create (DB_TYPE_VECTOR, size);
  }
  ```

#### 4. **기존 코드와의 통합**

- `set_object.c`와 `set_object.h`를 수정하여 `DB_TYPE_VECTOR`를 처리하도록 확장했습니다.
- `col_new` 함수에 `DB_TYPE_VECTOR` 처리를 추가하고, 이를 `tp_Vector_domain`과 연결했습니다.

  ```c
  case DB_TYPE_VECTOR:
      col->domain = &tp_Vector_domain;
      break;
  ```

#### 5. **호환성 검증**

- 기존의 `set` 관련 함수(`set_create`, `col_new` 등)가 `DB_TYPE_VECTOR`와 함께 정상적으로 동작하도록 보장했습니다.
- 기존 도메인 관리 로직의 안정성을 유지했습니다.

#### 6. **`db_make_vector` 함수 구현**

   - VECTOR 타입의 DB_SET을 DB_VALUE로 변환하는 함수를 구현했습니다.
   - 입력받은 DB_SET이 유효한 VECTOR 타입인지 검증하고, 이를 DB_VALUE로 변환합니다.

   ```c
   int
   db_make_vector (DB_VALUE * value, DB_SET * set)
   {
       // DB_VALUE의 타입을 DB_TYPE_VECTOR로 설정
       value->domain.general_info.type = DB_TYPE_VECTOR;
       value->data.set = set;

       if (set)
       {
           // VECTOR 타입이거나 disk_set인 경우 정상 처리
           if ((set->set && setobj_type (set->set) == DB_TYPE_VECTOR)

               ...
   }
   ```

---

### Remarks

N/A
