### PR TITLE
[CBRD-25756] Update initialization method for 'lang_str'

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -13606,15 +13606,20 @@ cdc_compare_undoredo_dbvalue (const db_value * new_value, const db_value * old_v
 static int
 cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
 {
+  bool has_user_format = false;
+  bool has_user_lang = false;
   const char *src, *end;
+  char *lang_str = NULL;
   double d;
   char line[1025] = "\0";
   int line_length = 0;
   int func_type = 0;
+  int error_status = NO_ERROR;
+  int flag = 0;
 
   /*DATE, TIME */
   DB_VALUE format;
-  DB_VALUE lang_str;
+  DB_VALUE lang_val;
   DB_VALUE result;
   INTL_CODESET format_codeset = LANG_SYS_CODESET;
   const char *date_format = "YYYY-MM-DD";
@@ -13626,8 +13631,10 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
   const char *timestamp_frmt = "YYYY-MM-DD HH24:MI:SS";
   const char *timestamptz_frmt = "YYYY-MM-DD HH24:MI:SS TZH:TZM";
   const char *timestampltz_frmt = "YYYY-MM-DD HH24:MI:SS TZR";
-  db_make_int (&lang_str, 1);
-  db_make_null (&result);
+
+  lang_str = prm_get_string_value (PRM_ID_INTL_DATE_LANG);
+  lang_set_flag_from_lang (lang_str, has_user_format, has_user_lang, &flag);
+  db_make_int (&lang_val, flag);
 
   char *ptr = *data_ptr;
 
@@ -13778,7 +13785,12 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
     case DB_TYPE_TIME:
       db_make_char (&format, strlen (time_format), time_format,
 		    strlen (time_format), format_codeset, LANG_GET_BINARY_COLLATION (format_codeset));
-      db_to_char (new_value, &format, &lang_str, &result, &tp_Char_domain);
+
+      error_status = db_to_char (new_value, &format, &lang_val, &result, &tp_Char_domain);
+      if (error_status != NO_ERROR)
+	{
+	  return error_status;
+	}
 
       line_length = db_get_string_length (&result);
       strncpy (line, db_get_string (&result), line_length);
@@ -13793,7 +13805,12 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
     case DB_TYPE_TIMESTAMP:
       db_make_char (&format, strlen (timestamp_frmt), timestamp_frmt,
 		    strlen (timestamp_frmt), format_codeset, LANG_GET_BINARY_COLLATION (format_codeset));
-      db_to_char (new_value, &format, &lang_str, &result, &tp_Char_domain);
+
+      error_status = db_to_char (new_value, &format, &lang_val, &result, &tp_Char_domain);
+      if (error_status != NO_ERROR)
+	{
+	  return error_status;
+	}
 
       line_length = db_get_string_length (&result);
       strncpy (line, db_get_string (&result), line_length);
@@ -13808,7 +13825,12 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
     case DB_TYPE_DATETIME:
       db_make_char (&format, strlen (datetime_frmt), datetime_frmt,
 		    strlen (datetime_frmt), format_codeset, LANG_GET_BINARY_COLLATION (format_codeset));
-      db_to_char (new_value, &format, &lang_str, &result, &tp_Char_domain);
+
+      error_status = db_to_char (new_value, &format, &lang_val, &result, &tp_Char_domain);
+      if (error_status != NO_ERROR)
+	{
+	  return error_status;
+	}
 
       line_length = db_get_string_length (&result);
       strncpy (line, db_get_string (&result), line_length);
@@ -13823,7 +13845,12 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
     case DB_TYPE_TIMESTAMPTZ:
       db_make_char (&format, strlen (timestamptz_frmt), timestamptz_frmt,
 		    strlen (timestamptz_frmt), format_codeset, LANG_GET_BINARY_COLLATION (format_codeset));
-      db_to_char (new_value, &format, &lang_str, &result, &tp_Char_domain);
+
+      error_status = db_to_char (new_value, &format, &lang_val, &result, &tp_Char_domain);
+      if (error_status != NO_ERROR)
+	{
+	  return error_status;
+	}
 
       line_length = db_get_string_length (&result);
       strncpy (line, db_get_string (&result), line_length);
@@ -13838,7 +13865,13 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
     case DB_TYPE_DATETIMETZ:
       db_make_char (&format, strlen (datetimetz_frmt), datetimetz_frmt,
 		    strlen (datetimetz_frmt), format_codeset, LANG_GET_BINARY_COLLATION (format_codeset));
-      db_to_char (new_value, &format, &lang_str, &result, &tp_Char_domain);
+
+      error_status = db_to_char (new_value, &format, &lang_val, &result, &tp_Char_domain);
+      if (error_status != NO_ERROR)
+	{
+	  return error_status;
+	}
+
       line_length = db_get_string_length (&result);
       strncpy (line, db_get_string (&result), line_length);
 
@@ -13854,7 +13887,11 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
       db_make_char (&format, strlen (timestampltz_frmt), timestampltz_frmt,
 		    strlen (timestampltz_frmt), format_codeset, LANG_GET_BINARY_COLLATION (format_codeset));
 
-      db_to_char (new_value, &format, &lang_str, &result, &tp_Char_domain);
+      error_status = db_to_char (new_value, &format, &lang_val, &result, &tp_Char_domain);
+      if (error_status != NO_ERROR)
+	{
+	  return error_status;
+	}
 
       line_length = db_get_string_length (&result);
       strncpy (line, db_get_string (&result), line_length);
@@ -13870,7 +13907,12 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
       db_make_char (&format, strlen (datetimeltz_frmt), datetimeltz_frmt,
 		    strlen (datetimeltz_frmt), format_codeset, LANG_GET_BINARY_COLLATION (format_codeset));
 
-      db_to_char (new_value, &format, &lang_str, &result, &tp_Char_domain);
+      error_status = db_to_char (new_value, &format, &lang_val, &result, &tp_Char_domain);
+      if (error_status != NO_ERROR)
+	{
+	  return error_status;
+	}
+
       line_length = db_get_string_length (&result);
       strncpy (line, db_get_string (&result), line_length);
 
@@ -13882,10 +13924,14 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
 
       break;
     case DB_TYPE_DATE:
-
       db_make_char (&format, strlen (date_format), date_format,
 		    strlen (date_format), format_codeset, LANG_GET_BINARY_COLLATION (format_codeset));
-      db_to_char (new_value, &format, &lang_str, &result, &tp_Char_domain);
+
+      error_status = db_to_char (new_value, &format, &lang_val, &result, &tp_Char_domain);
+      if (error_status != NO_ERROR)
+	{
+	  return error_status;
+	}
 
       line_length = db_get_string_length (&result);
       strncpy (line, db_get_string (&result), line_length);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -13606,10 +13606,7 @@ cdc_compare_undoredo_dbvalue (const db_value * new_value, const db_value * old_v
 static int
 cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
 {
-  bool has_user_format = false;
-  bool has_user_lang = false;
   const char *src, *end;
-  char *lang_str = NULL;
   double d;
   char line[1025] = "\0";
   int line_length = 0;
@@ -13619,7 +13616,7 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
 
   /*DATE, TIME */
   DB_VALUE format;
-  DB_VALUE lang_val;
+  DB_VALUE lang_str;
   DB_VALUE result;
   INTL_CODESET format_codeset = LANG_SYS_CODESET;
   const char *date_format = "YYYY-MM-DD";
@@ -13632,8 +13629,9 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
   const char *timestamptz_frmt = "YYYY-MM-DD HH24:MI:SS TZH:TZM";
   const char *timestampltz_frmt = "YYYY-MM-DD HH24:MI:SS TZR";
 
-  lang_set_flag_from_lang (lang_str, has_user_format, has_user_lang, &flag);
-  db_make_int (&lang_val, flag);
+  lang_set_flag_from_lang (NULL, false, false, &flag);
+  db_make_int (&lang_str, flag);
+  db_make_null (&result);
 
   char *ptr = *data_ptr;
 
@@ -13785,7 +13783,7 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
       db_make_char (&format, strlen (time_format), time_format,
 		    strlen (time_format), format_codeset, LANG_GET_BINARY_COLLATION (format_codeset));
 
-      error_status = db_to_char (new_value, &format, &lang_val, &result, &tp_Char_domain);
+      error_status = db_to_char (new_value, &format, &lang_str, &result, &tp_Char_domain);
       if (error_status != NO_ERROR)
 	{
 	  return error_status;
@@ -13805,7 +13803,7 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
       db_make_char (&format, strlen (timestamp_frmt), timestamp_frmt,
 		    strlen (timestamp_frmt), format_codeset, LANG_GET_BINARY_COLLATION (format_codeset));
 
-      error_status = db_to_char (new_value, &format, &lang_val, &result, &tp_Char_domain);
+      error_status = db_to_char (new_value, &format, &lang_str, &result, &tp_Char_domain);
       if (error_status != NO_ERROR)
 	{
 	  return error_status;
@@ -13825,7 +13823,7 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
       db_make_char (&format, strlen (datetime_frmt), datetime_frmt,
 		    strlen (datetime_frmt), format_codeset, LANG_GET_BINARY_COLLATION (format_codeset));
 
-      error_status = db_to_char (new_value, &format, &lang_val, &result, &tp_Char_domain);
+      error_status = db_to_char (new_value, &format, &lang_str, &result, &tp_Char_domain);
       if (error_status != NO_ERROR)
 	{
 	  return error_status;
@@ -13845,7 +13843,7 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
       db_make_char (&format, strlen (timestamptz_frmt), timestamptz_frmt,
 		    strlen (timestamptz_frmt), format_codeset, LANG_GET_BINARY_COLLATION (format_codeset));
 
-      error_status = db_to_char (new_value, &format, &lang_val, &result, &tp_Char_domain);
+      error_status = db_to_char (new_value, &format, &lang_str, &result, &tp_Char_domain);
       if (error_status != NO_ERROR)
 	{
 	  return error_status;
@@ -13865,7 +13863,7 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
       db_make_char (&format, strlen (datetimetz_frmt), datetimetz_frmt,
 		    strlen (datetimetz_frmt), format_codeset, LANG_GET_BINARY_COLLATION (format_codeset));
 
-      error_status = db_to_char (new_value, &format, &lang_val, &result, &tp_Char_domain);
+      error_status = db_to_char (new_value, &format, &lang_str, &result, &tp_Char_domain);
       if (error_status != NO_ERROR)
 	{
 	  return error_status;
@@ -13886,7 +13884,7 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
       db_make_char (&format, strlen (timestampltz_frmt), timestampltz_frmt,
 		    strlen (timestampltz_frmt), format_codeset, LANG_GET_BINARY_COLLATION (format_codeset));
 
-      error_status = db_to_char (new_value, &format, &lang_val, &result, &tp_Char_domain);
+      error_status = db_to_char (new_value, &format, &lang_str, &result, &tp_Char_domain);
       if (error_status != NO_ERROR)
 	{
 	  return error_status;
@@ -13906,7 +13904,7 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
       db_make_char (&format, strlen (datetimeltz_frmt), datetimeltz_frmt,
 		    strlen (datetimeltz_frmt), format_codeset, LANG_GET_BINARY_COLLATION (format_codeset));
 
-      error_status = db_to_char (new_value, &format, &lang_val, &result, &tp_Char_domain);
+      error_status = db_to_char (new_value, &format, &lang_str, &result, &tp_Char_domain);
       if (error_status != NO_ERROR)
 	{
 	  return error_status;
@@ -13926,7 +13924,7 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
       db_make_char (&format, strlen (date_format), date_format,
 		    strlen (date_format), format_codeset, LANG_GET_BINARY_COLLATION (format_codeset));
 
-      error_status = db_to_char (new_value, &format, &lang_val, &result, &tp_Char_domain);
+      error_status = db_to_char (new_value, &format, &lang_str, &result, &tp_Char_domain);
       if (error_status != NO_ERROR)
 	{
 	  return error_status;

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -13632,7 +13632,6 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
   const char *timestamptz_frmt = "YYYY-MM-DD HH24:MI:SS TZH:TZM";
   const char *timestampltz_frmt = "YYYY-MM-DD HH24:MI:SS TZR";
 
-  lang_str = prm_get_string_value (PRM_ID_INTL_DATE_LANG);
   lang_set_flag_from_lang (lang_str, has_user_format, has_user_lang, &flag);
   db_make_int (&lang_val, flag);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25756

### **_Purpose_**

- 문제 원인
  - http://jira.cubrid.org/browse/CBRD-25302 해당 이슈에서 lang_string의 checksum을 확인하여 일치하지 않는 경우
    에러를 return하도록 수정
  - cdc_put_value_to_loginfo 함수에서 lang_str을 초기화 할 때 0으로 초기화를 해주고 있기 때문에
    checksum이 일치하지 않아 에러가 발생
  - 에러가 return 되어 NULL로 초기화된 result에 아무 데이터도 담기지 않음
  - 그렇기 때문에 strncpy (line, db_get_string (&result), line_length); 구문에서 segmentation fault가 발생하여 core파일 생성
 
---
### **_주요 함수 및 변수_**
- char *lang_str = NULL
  - lang_str이 NULL이라면 lang_set_flag_from_lang 함수에 의해 default(en_US)로 설정된다
  - en_US / ko_KR / tr_TR 등을 의미한다.
- has_user_format, has_user_lang
  - CDC loginfo 생성과정에서 사용자가 format이나 lang을 입력하지 않기 때문에 false로 설정
  - 기존 스펙에서 사용자가 따로 lang_str을 설정하지 않았었기 때문에 default(en_US)로 설정된다.
- lang_set_flag_from_lang (lang_str, has_user_format, has_user_lang, &flag);
  -  lang_str을 읽어 flag 설정
  - checksum 추가
- db_make_int (&lang_val, flag);
  - flag를 기반으로 lang_val 생성

---
### **_Implementation_**
- lang_val 변수 추가 및 초기화 방식 변경
- db_to_char 에러 처리 추가