### PR TITLE
[CBRD-25772] Implement class name extraction from input file using -i option in diagdb and call heap_dump_heap_file() function

### DIFF
--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1776,6 +1776,7 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 						     (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_DIAGDB,
 						      DIAGDB_MSG_UNKNOWN_CLASS), name);
 			    }
+			  goto error_exit;
 			}
 		    }
 
@@ -1802,7 +1803,7 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 	{
 	  fprintf (outfp, "\n*** DUMP OF ALL HEAPS ***\n");
 	  (void) file_tracker_dump_all_heap (thread_p, outfp, dump_records);
-        }
+	}
     }
 
   db_shutdown ();

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1519,8 +1519,8 @@ diagdb (UTIL_FUNCTION_ARG * arg)
   char er_msg_file[PATH_MAX];
   const char *db_name;
   const char *output_file = NULL;
-  FILE *input_file = NULL;
   const char *class_name;
+  FILE *infp = NULL;
   FILE *outfp = NULL;
   bool is_emergency = false;
   bool need_db_shutdown = false;
@@ -1751,14 +1751,14 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 	{
 	  char input_class[SM_MAX_IDENTIFIER_LENGTH];
 
-	  input_file = fopen (class_list_file, "r");
-	  if (input_file == NULL)
+	  infp = fopen (class_list_file, "r");
+	  if (infp == NULL)
 	    {
 	      perror (class_list_file);
 	      goto error_exit;
 	    }
 
-	  while (fgets (input_class, SM_MAX_IDENTIFIER_LENGTH, input_file) != NULL)
+	  while (fgets (input_class, SM_MAX_IDENTIFIER_LENGTH, infp) != NULL)
 	    {
 	      trim (input_class);
 
@@ -1804,9 +1804,9 @@ diagdb (UTIL_FUNCTION_ARG * arg)
     {
       fclose (outfp);
     }
-  if (input_file != NULL)
+  if (infp != NULL)
     {
-      fclose (input_file);
+      fclose (infp);
     }
 
   return EXIT_SUCCESS;
@@ -1826,9 +1826,9 @@ error_exit:
     {
       fclose (outfp);
     }
-  if (input_file != NULL)
+  if (infp != NULL)
     {
-      fclose (input_file);
+      fclose (infp);
     }
 
   return EXIT_FAILURE;

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1747,57 +1747,38 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 	}
       else if (class_list_file != NULL)
 	{
-	  FILE *fp = fopen (class_list_file, "r");
-	  int len = 0, file_getc = 0;
-	  char fget_name[SM_MAX_IDENTIFIER_LENGTH];
-	  char name[SM_MAX_IDENTIFIER_LENGTH] = { 0 };
-	  if (fp == NULL)
+	  FILE *input_file = fopen (class_list_file, "r");
+	  char class_name[SM_MAX_IDENTIFIER_LENGTH];
+	  if (input_file == NULL)
 	    {
 	      perror (class_list_file);
 	      goto error_exit;
 	    }
 
-	  while (file_getc != EOF)
+	  while (fgets ((char *) class_name, SM_MAX_IDENTIFIER_LENGTH, input_file) != NULL)
 	    {
-	      file_getc = fgetc (fp);
+	      trim (class_name);
 
-	      if (char_isspace2 (file_getc) || file_getc == ',')
+	      error_code = heap_dump_heap_file (thread_p, outfp, dump_records, class_name);
+
+	      if (error_code != NO_ERROR)
 		{
-		  if (len > 0)
+		  if (error_code == ER_LC_UNKNOWN_CLASSNAME)
 		    {
-		      fget_name[len] = '\0';
-		      strncpy (name, fget_name, len);
-		      error_code = heap_dump_heap_file (thread_p, outfp, dump_records, name);
-		      if (error_code != NO_ERROR)
-			{
-			  if (error_code == ER_LC_UNKNOWN_CLASSNAME)
-			    {
-			      PRINT_AND_LOG_ERR_MSG (msgcat_message
-						     (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_DIAGDB,
-						      DIAGDB_MSG_UNKNOWN_CLASS), name);
-			    }
-			  goto error_exit;
-			}
+		      PRINT_AND_LOG_ERR_MSG (msgcat_message
+					     (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_DIAGDB,
+					      DIAGDB_MSG_UNKNOWN_CLASS), class_name);
 		    }
-
-		  memset (name, '\0', sizeof (name));
-		  len = 0;
-		  continue;
-		}
-
-	      fget_name[len++] = file_getc;
-
-	      if (len == SM_MAX_IDENTIFIER_LENGTH)
-		{
-		  /* too long table name */
-		  if (utility_check_class_name (fget_name) != NO_ERROR)
-		    {
-		      fclose (fp);
-		      /* The util_log_write_errid function is called inside the utility_check_class_name function. */
-		      return ER_GENERIC_ERROR;
-		    }
+		  goto error_exit;
 		}
 	    }
+
+	  if (input_file != NULL)
+	    {
+	      fclose (input_file);
+	      input_file = NULL;
+	    }
+	  memset (class_name, 0, sizeof (class_name));
 	}
       else
 	{

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1786,7 +1786,6 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 	      fclose (input_file);
 	      input_file = NULL;
 	    }
-	  memset (input_class, 0, sizeof (input_class));
 	}
       else
 	{

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1724,12 +1724,7 @@ diagdb (UTIL_FUNCTION_ARG * arg)
       bool dump_records;
       dump_records = utility_get_option_bool_value (arg_map, DIAG_DUMP_RECORDS_S);
 
-      if (class_name == NULL && class_list_file == NULL)
-	{
-	  fprintf (outfp, "\n*** DUMP OF ALL HEAPS ***\n");
-	  (void) file_tracker_dump_all_heap (thread_p, outfp, dump_records);
-	}
-      else if (class_name != NULL)
+      if (class_name != NULL)
 	{
 	  if (!sm_check_system_class_by_name (class_name))
 	    {
@@ -1803,6 +1798,12 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 		}
 	    }
 	}
+
+      else
+	{
+	  fprintf (outfp, "\n*** DUMP OF ALL HEAPS ***\n");
+	  (void) file_tracker_dump_all_heap (thread_p, outfp, dump_records);
+        }
     }
 
   db_shutdown ();

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1750,15 +1750,15 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 	      goto error_exit;
 	    }
 	}
-      else if (fname != NULL)
+      else if (class_list_file != NULL)
 	{
-	  FILE *fp = fopen (fname, "r");
+	  FILE *fp = fopen (class_list_file, "r");
 	  int len = 0, file_getc = 0;
 	  char fget_name[SM_MAX_IDENTIFIER_LENGTH];
 	  char name[SM_MAX_IDENTIFIER_LENGTH] = { 0 };
 	  if (fp == NULL)
 	    {
-	      perror (fname);
+	      perror (class_list_file);
 	      goto error_exit;
 	    }
 

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1575,7 +1575,8 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 
   if (class_name && class_list_file)
     {
-      goto print_diag_usage;
+      PRINT_AND_LOG_ERR_MSG ("Error: The -n and -i options cannot be used together. Please choose only one option.\n");
+      goto error_exit;
     }
 
   if (check_database_name (db_name))

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1762,7 +1762,6 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 	      if (utility_check_class_name (input_class) != NO_ERROR)
 		{
 		  fclose (input_file);
-
 		  return ER_GENERIC_ERROR;
 		}
 
@@ -1775,6 +1774,8 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 		      PRINT_AND_LOG_ERR_MSG (msgcat_message
 					     (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_DIAGDB,
 					      DIAGDB_MSG_UNKNOWN_CLASS), input_class);
+
+		      fclose (input_file);
 		    }
 		  goto error_exit;
 		}

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1519,6 +1519,7 @@ diagdb (UTIL_FUNCTION_ARG * arg)
   char er_msg_file[PATH_MAX];
   const char *db_name;
   const char *output_file = NULL;
+  FILE *input_file = NULL;
   const char *class_name;
   FILE *outfp = NULL;
   bool is_emergency = false;
@@ -1748,7 +1749,6 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 	}
       else if (class_list_file != NULL)
 	{
-	  FILE *input_file;
 	  char input_class[SM_MAX_IDENTIFIER_LENGTH];
 
 	  input_file = fopen (class_list_file, "r");
@@ -1766,7 +1766,6 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 		{
 		  if (utility_check_class_name (input_class) != NO_ERROR)
 		    {
-		      fclose (input_file);
 		      goto error_exit;
 		    }
 		}
@@ -1780,17 +1779,9 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 		      PRINT_AND_LOG_ERR_MSG (msgcat_message
 					     (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_DIAGDB,
 					      DIAGDB_MSG_UNKNOWN_CLASS), input_class);
-
-		      fclose (input_file);
 		    }
 		  goto error_exit;
 		}
-	    }
-
-	  if (input_file != NULL)
-	    {
-	      fclose (input_file);
-	      input_file = NULL;
 	    }
 	}
       else
@@ -1806,6 +1797,10 @@ diagdb (UTIL_FUNCTION_ARG * arg)
   if (output_file != NULL && outfp != NULL && outfp != stdout)
     {
       fclose (outfp);
+    }
+  if (input_file != NULL)
+    {
+      fclose (input_file);
     }
 
   return EXIT_SUCCESS;
@@ -1824,6 +1819,10 @@ error_exit:
   if (output_file != NULL && outfp != NULL && outfp != stdout)
     {
       fclose (outfp);
+    }
+  if (input_file != NULL)
+    {
+      fclose (input_file);
     }
 
   return EXIT_FAILURE;

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1749,24 +1749,24 @@ diagdb (UTIL_FUNCTION_ARG * arg)
       else if (class_list_file != NULL)
 	{
 	  FILE *input_file = fopen (class_list_file, "r");
-	  char class_name[SM_MAX_IDENTIFIER_LENGTH];
+	  char input_class[SM_MAX_IDENTIFIER_LENGTH];
 	  if (input_file == NULL)
 	    {
 	      perror (class_list_file);
 	      goto error_exit;
 	    }
 
-	  while (fgets ((char *) class_name, SM_MAX_IDENTIFIER_LENGTH, input_file) != NULL)
+	  while (fgets ( input_class, SM_MAX_IDENTIFIER_LENGTH, input_file) != NULL)
 	    {
-	      trim (class_name);
-	      if (utility_check_class_name (class_name) != NO_ERROR)
+	      trim (input_class);
+	      if (utility_check_class_name (input_class) != NO_ERROR)
 		{
 		  fclose (input_file);
 
 		  return ER_GENERIC_ERROR;
 		}
 
-	      error_code = heap_dump_heap_file (thread_p, outfp, dump_records, class_name);
+	      error_code = heap_dump_heap_file (thread_p, outfp, dump_records, input_class);
 
 	      if (error_code != NO_ERROR)
 		{
@@ -1774,7 +1774,7 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 		    {
 		      PRINT_AND_LOG_ERR_MSG (msgcat_message
 					     (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_DIAGDB,
-					      DIAGDB_MSG_UNKNOWN_CLASS), class_name);
+					      DIAGDB_MSG_UNKNOWN_CLASS), input_class);
 		    }
 		  goto error_exit;
 		}
@@ -1785,7 +1785,7 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 	      fclose (input_file);
 	      input_file = NULL;
 	    }
-	  memset (class_name, 0, sizeof (class_name));
+	  memset (input_class, 0, sizeof (input_class));
 	}
       else
 	{

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1748,8 +1748,10 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 	}
       else if (class_list_file != NULL)
 	{
-	  FILE *input_file = fopen (class_list_file, "r");
+	  FILE *input_file;
 	  char input_class[SM_MAX_IDENTIFIER_LENGTH];
+
+	  input_file = fopen (class_list_file, "r");
 	  if (input_file == NULL)
 	    {
 	      perror (class_list_file);
@@ -1759,11 +1761,13 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 	  while (fgets (input_class, SM_MAX_IDENTIFIER_LENGTH, input_file) != NULL)
 	    {
 	      trim (input_class);
-	      if (utility_check_class_name (input_class) != NO_ERROR)
+
+	      error_code = utility_check_class_name (input_class);
+
+	      if (error_code != NO_ERROR)
 		{
 		  fclose (input_file);
-		  fclose (outfp);
-		  return ER_GENERIC_ERROR;
+		  goto error_exit;
 		}
 
 	      error_code = heap_dump_heap_file (thread_p, outfp, dump_records, input_class);

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1756,7 +1756,7 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 	      goto error_exit;
 	    }
 
-	  while (fgets ( input_class, SM_MAX_IDENTIFIER_LENGTH, input_file) != NULL)
+	  while (fgets (input_class, SM_MAX_IDENTIFIER_LENGTH, input_file) != NULL)
 	    {
 	      trim (input_class);
 	      if (utility_check_class_name (input_class) != NO_ERROR)

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1758,6 +1758,12 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 	  while (fgets ((char *) class_name, SM_MAX_IDENTIFIER_LENGTH, input_file) != NULL)
 	    {
 	      trim (class_name);
+	      if (utility_check_class_name (class_name) != NO_ERROR)
+		{
+		  fclose (input_file);
+
+		  return ER_GENERIC_ERROR;
+		}
 
 	      error_code = heap_dump_heap_file (thread_p, outfp, dump_records, class_name);
 

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1798,7 +1798,6 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 		}
 	    }
 	}
-
       else
 	{
 	  fprintf (outfp, "\n*** DUMP OF ALL HEAPS ***\n");

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1575,7 +1575,8 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 
   if (class_name && class_list_file)
     {
-      PRINT_AND_LOG_ERR_MSG ("Error: The -n and -i options cannot be used together. Please choose only one option.\n");
+      errno = EINVAL;
+      perror ("The -n and -i options cannot be used together.");
       goto error_exit;
     }
 

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1750,6 +1750,59 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 	      goto error_exit;
 	    }
 	}
+      else if (fname != NULL)
+	{
+	  FILE *fp = fopen (fname, "r");
+	  int len = 0, file_getc = 0;
+	  char fget_name[SM_MAX_IDENTIFIER_LENGTH];
+	  char name[SM_MAX_IDENTIFIER_LENGTH] = { 0 };
+	  if (fp == NULL)
+	    {
+	      perror (fname);
+	      goto error_exit;
+	    }
+
+	  while (file_getc != EOF)
+	    {
+	      file_getc = fgetc (fp);
+
+	      if (char_isspace2 (file_getc) || file_getc == ',')
+		{
+		  if (len > 0)
+		    {
+		      fget_name[len] = '\0';
+		      strncpy (name, fget_name, len);
+		      error_code = heap_dump_heap_file (thread_p, outfp, dump_records, name);
+		      if (error_code != NO_ERROR)
+			{
+			  if (error_code == ER_LC_UNKNOWN_CLASSNAME)
+			    {
+			      PRINT_AND_LOG_ERR_MSG (msgcat_message
+						     (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_DIAGDB,
+						      DIAGDB_MSG_UNKNOWN_CLASS), name);
+			    }
+			}
+		    }
+
+		  memset (name, '\0', sizeof (name));
+		  len = 0;
+		  continue;
+		}
+
+	      fget_name[len++] = file_getc;
+
+	      if (len == SM_MAX_IDENTIFIER_LENGTH)
+		{
+		  /* too long table name */
+		  if (utility_check_class_name (fget_name) != NO_ERROR)
+		    {
+		      fclose (fp);
+		      /* The util_log_write_errid function is called inside the utility_check_class_name function. */
+		      return ER_GENERIC_ERROR;
+		    }
+		}
+	    }
+	}
     }
 
   db_shutdown ();

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1750,6 +1750,7 @@ diagdb (UTIL_FUNCTION_ARG * arg)
       else if (class_list_file != NULL)
 	{
 	  char input_class[SM_MAX_IDENTIFIER_LENGTH];
+	  int class_len = 0;
 
 	  input_file = fopen (class_list_file, "r");
 	  if (input_file == NULL)
@@ -1761,6 +1762,13 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 	  while (fgets (input_class, SM_MAX_IDENTIFIER_LENGTH, input_file) != NULL)
 	    {
 	      trim (input_class);
+
+	      class_len = STATIC_CAST (int, strlen (input_class));
+	      if (class_len < 1)
+		{
+		  /* empty string */
+		  continue;
+		}
 
 	      if (!sm_check_system_class_by_name (input_class))
 		{

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1575,8 +1575,7 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 
   if (class_name && class_list_file)
     {
-      errno = EINVAL;
-      perror ("The -n and -i options cannot be used together. ");
+      fprintf (stderr, "The -n and -i options cannot be used together.\n");
       goto error_exit;
     }
 

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1750,7 +1750,6 @@ diagdb (UTIL_FUNCTION_ARG * arg)
       else if (class_list_file != NULL)
 	{
 	  char input_class[SM_MAX_IDENTIFIER_LENGTH];
-	  int class_len = 0;
 
 	  input_file = fopen (class_list_file, "r");
 	  if (input_file == NULL)
@@ -1763,8 +1762,7 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 	    {
 	      trim (input_class);
 
-	      class_len = STATIC_CAST (int, strlen (input_class));
-	      if (class_len < 1)
+	      if (strlen (input_class) < 1)
 		{
 		  /* empty string */
 		  continue;

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1762,6 +1762,7 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 	      if (utility_check_class_name (input_class) != NO_ERROR)
 		{
 		  fclose (input_file);
+		  fclose (outfp);
 		  return ER_GENERIC_ERROR;
 		}
 

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1763,12 +1763,13 @@ diagdb (UTIL_FUNCTION_ARG * arg)
 	    {
 	      trim (input_class);
 
-	      error_code = utility_check_class_name (input_class);
-
-	      if (error_code != NO_ERROR)
+	      if (!sm_check_system_class_by_name (input_class))
 		{
-		  fclose (input_file);
-		  goto error_exit;
+		  if (utility_check_class_name (input_class) != NO_ERROR)
+		    {
+		      fclose (input_file);
+		      goto error_exit;
+		    }
 		}
 
 	      error_code = heap_dump_heap_file (thread_p, outfp, dump_records, input_class);

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -1576,7 +1576,7 @@ diagdb (UTIL_FUNCTION_ARG * arg)
   if (class_name && class_list_file)
     {
       errno = EINVAL;
-      perror ("The -n and -i options cannot be used together.");
+      perror ("The -n and -i options cannot be used together. ");
       goto error_exit;
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25772

### Purpose
- diagdb -d 9 -i 옵션으로 전달된 파일에서 클래스명을 추출하고, 해당 클래스를 heap dump하도록 처리한다.
  - i 옵션으로 전달된 파일에서 클래스명을 추출한다.
    - 클래스명은 줄바꿈으로 구분한다.
    - 존재하지 않는 클래스명은 에러 메시지를 출력하고 종료한다.

### Implementation
- diagdb -d 9 -i 옵션으로 전달된 파일에서 클래스명을 추출하도록 구현
- heap dump 작업은 이전에 구현된 heap_dump_heap_file() 함수에 클래스명을 전달하여 호출

### Remarks
- N/A