### PR TITLE
[CBRD-25737] Backport from develop to 11.2 - When unloading serial and trigger as dba user, schema name is missing

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -598,6 +598,8 @@ export_serial (print_output & output_ctx)
   DB_VALUE values[SERIAL_VALUE_INDEX_MAX], diff_value, answer_value;
   DB_DOMAIN *domain;
   char str_buf[NUMERIC_MAX_STRING_SIZE];
+  char owner_name[DB_MAX_IDENTIFIER_LENGTH] = { '\0' };
+  char *serial_name = NULL;
 
   /*
    * You must check SERIAL_VALUE_INDEX enum defined on the top of this file
@@ -706,25 +708,28 @@ export_serial (print_output & output_ctx)
 
       output_ctx ("call [find_user]('%s') on class [db_user] to [auser];\n",
 		  db_get_string (&values[SERIAL_OWNER_NAME]));
-      output_ctx ("create serial %s%s%s\n", PRINT_IDENTIFIER (db_get_string (&values[SERIAL_NAME])));
-      output_ctx ("\t start with %s\n", numeric_db_value_print (&values[SERIAL_CURRENT_VAL], str_buf));
-      output_ctx ("\t increment by %s\n", numeric_db_value_print (&values[SERIAL_INCREMENT_VAL], str_buf));
-      output_ctx ("\t minvalue %s\n", numeric_db_value_print (&values[SERIAL_MIN_VAL], str_buf));
-      output_ctx ("\t maxvalue %s\n", numeric_db_value_print (&values[SERIAL_MAX_VAL], str_buf));
-      output_ctx ("\t %scycle\n", (db_get_int (&values[SERIAL_CYCLIC]) == 0 ? "no" : ""));
+      SPLIT_USER_SPECIFIED_NAME (db_get_string (&values[SERIAL_UNIQUE_NAME]), owner_name, serial_name);
+
+      output_ctx ("CREATE SERIAL %s%s%s.%s%s%s\n", PRINT_IDENTIFIER (owner_name),
+		  PRINT_IDENTIFIER (db_get_string (&values[SERIAL_NAME])));
+      output_ctx ("\t START WITH %s\n", numeric_db_value_print (&values[SERIAL_CURRENT_VAL], str_buf));
+      output_ctx ("\t INCREMENT BY %s\n", numeric_db_value_print (&values[SERIAL_INCREMENT_VAL], str_buf));
+      output_ctx ("\t MINVALUE %s\n", numeric_db_value_print (&values[SERIAL_MIN_VAL], str_buf));
+      output_ctx ("\t MAXVALUE %s\n", numeric_db_value_print (&values[SERIAL_MAX_VAL], str_buf));
+      output_ctx ("\t %sCYCLE\n", (db_get_int (&values[SERIAL_CYCLIC]) == 0 ? "no" : ""));
       if (db_get_int (&values[SERIAL_CACHED_NUM]) <= 1)
 	{
-	  output_ctx ("\t nocache\n");
+	  output_ctx ("\t NOCACHE\n");
 
 	}
       else
 	{
-	  output_ctx ("\t cache %d\n", db_get_int (&values[SERIAL_CACHED_NUM]));
+	  output_ctx ("\t CACHE %d\n", db_get_int (&values[SERIAL_CACHED_NUM]));
 
 	}
       if (DB_IS_NULL (&values[SERIAL_COMMENT]) == false)
 	{
-	  output_ctx ("\t comment ");
+	  output_ctx ("\t COMMENT ");
 	  desc_value_print (output_ctx, &values[SERIAL_COMMENT]);
 	}
       output_ctx (";\n");
@@ -733,8 +738,6 @@ export_serial (print_output & output_ctx)
 	{
 	  output_ctx ("SELECT %s%s%s.NEXT_VALUE;\n", PRINT_IDENTIFIER (db_get_string (&values[SERIAL_NAME])));
 	}
-      output_ctx ("call [change_serial_owner] ('%s', '%s') on class [db_serial];\n\n",
-		  db_get_string (&values[SERIAL_NAME]), db_get_string (&values[SERIAL_OWNER_NAME]));
 
       db_value_clear (&diff_value);
       db_value_clear (&answer_value);

--- a/src/object/trigger_description.cpp
+++ b/src/object/trigger_description.cpp
@@ -256,9 +256,20 @@ tr_dump_trigger (print_output &output_ctx, DB_OBJECT *trigger_object)
     }
   else if (trigger->status != TR_STATUS_INVALID)
     {
+      if (trigger->class_mop != NULL)
+	{
+	  name = db_get_class_name (trigger->class_mop);
+	  if (sm_qualifier_name (name, owner_name, DB_MAX_USER_LENGTH) == NULL)
+	    {
+	      ASSERT_ERROR_AND_SET (error);
+	      return error;
+	    }
+	  class_name = sm_remove_qualifier_name (name);
+	}
+
       /* automatically filter out invalid triggers */
       output_ctx ("CREATE TRIGGER ");
-      output_ctx ("[%s]\n", sm_remove_qualifier_name (trigger->name));
+      output_ctx ("[%s].[%s]\n", owner_name, sm_remove_qualifier_name (trigger->name));
       output_ctx ("  STATUS %s\n", tr_status_as_string (trigger->status));
       output_ctx ("  PRIORITY %f\n", trigger->priority);
 
@@ -277,13 +288,6 @@ tr_dump_trigger (print_output &output_ctx, DB_OBJECT *trigger_object)
 
       if (trigger->class_mop != NULL)
 	{
-	  name = db_get_class_name (trigger->class_mop);
-	  if (sm_qualifier_name (name, owner_name, DB_MAX_USER_LENGTH) == NULL)
-	    {
-	      ASSERT_ERROR_AND_SET (error);
-	      return error;
-	    }
-	  class_name = sm_remove_qualifier_name (name);
 	  output_ctx (" ON ");
 	  output_ctx ("[%s].[%s]", owner_name, class_name);
 
@@ -332,7 +336,7 @@ tr_dump_trigger (print_output &output_ctx, DB_OBJECT *trigger_object)
 	  help_print_describe_comment (output_ctx, trigger->comment);
 	}
 
-      output_ctx (";\n");
+      output_ctx (";\n\n");
     }
 
   AU_ENABLE (save);
@@ -416,8 +420,6 @@ tr_dump_selective_triggers (print_output &output_ctx, DB_OBJLIST *classes)
 		      if (trigger->status != TR_STATUS_INVALID)
 			{
 			  tr_dump_trigger (output_ctx, trigger_object);
-			  output_ctx ("call [change_trigger_owner]('%s'," " '%s') on class [db_root];\n\n",
-				      sm_remove_qualifier_name (trigger->name), get_user_name (trigger->owner));
 			}
 		    }
 		  else if (is_system_class < 0)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25737

여러계정으로 동일명의 serial 및 trigger를 생성 후 dba user로 unloaddb 한 경우 schema 없이 serial 및 trigger 명만 출력됨
serial 및 trigger 에 schema 를 붙여서 추출되어야 한다.