### PR TITLE
[CBRD-25766] Prevent assertions arising from differences in server name length definitions.

### DIFF
--- a/src/connection/connection_globals.h
+++ b/src/connection/connection_globals.h
@@ -67,7 +67,7 @@ typedef struct css_conn_rule_info
 typedef struct css_server_proc_register CSS_SERVER_PROC_REGISTER;
 struct css_server_proc_register
 {
-  static constexpr int CSS_SERVER_MAX_SZ_SERVER_NAME = 256;
+  static constexpr int CSS_SERVER_MAX_SZ_SERVER_NAME = 255;
   static constexpr int CSS_SERVER_MAX_SZ_PROC_EXEC_PATH = 128;
   static constexpr int CSS_SERVER_MAX_SZ_PROC_ARGS = 1024;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25766

- Purpose
  - server name 길이의 제한하는 두 가지 변수 사이에 1byte 만큼의 차이가 존재함
    - Server name의 길이 최댓값은 `DB_MAX_IDENTIFIER_LENGTH` (255) byte로 제한되어 있음
    - Server process의 정보를 master에 전달하는 자료 구조인 `CSS_SERVER_PROC_REGISTER`에 server name의 길이는 최대 `CSS_SERVER_MAX_SZ_SERVER_NAME` (256) byte 으로 제한되어 있음.
   - 둘 간의 차이로 인해 assertion이 발생할 가능성이 존재함. 
 
- Implementation
  - 'CSS_SERVER_MAX_SZ_SERVER_NAME`의 값을 255로 변경
