### PR TITLE
[CUBVEC-32] Implement tp_Vector function pointers

### DIFF
--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -357,6 +357,7 @@ db_value_domain_init (DB_VALUE * value, const DB_TYPE type, const int precision,
     case DB_TYPE_SET:
     case DB_TYPE_MULTISET:
     case DB_TYPE_SEQUENCE:
+    case DB_TYPE_VECTOR:
     case DB_TYPE_MIDXKEY:
     case DB_TYPE_BLOB:
     case DB_TYPE_CLOB:

--- a/src/compat/dbtype_function.i
+++ b/src/compat/dbtype_function.i
@@ -120,6 +120,7 @@ STATIC_INLINE int db_make_oid (DB_VALUE * value, const OID * oid) __attribute__ 
 STATIC_INLINE int db_make_set (DB_VALUE * value, DB_C_SET * set) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int db_make_multiset (DB_VALUE * value, DB_C_SET * set) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int db_make_sequence (DB_VALUE * value, DB_C_SET * set) __attribute__ ((ALWAYS_INLINE));
+STATIC_INLINE int db_make_vector (DB_VALUE * value, DB_C_SET * set) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int db_make_collection (DB_VALUE * value, DB_C_SET * set) __attribute__ ((ALWAYS_INLINE));
 
 STATIC_INLINE int db_make_elo (DB_VALUE * value, DB_TYPE type, const DB_ELO * elo) __attribute__ ((ALWAYS_INLINE));
@@ -1978,6 +1979,45 @@ db_make_sequence (DB_VALUE * value, DB_SET * set)
   if (set)
     {
       if ((set->set && setobj_type (set->set) == DB_TYPE_SEQUENCE) || set->disk_set)
+	{
+	  value->domain.general_info.is_null = 0;
+	}
+      else
+	{
+	  error = ER_QPROC_INVALID_DATATYPE;
+	  er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_DATATYPE, 0);
+	}
+    }
+  else
+    {
+      value->domain.general_info.is_null = 1;
+    }
+
+  value->need_clear = false;
+
+  return error;
+}
+
+/*
+ * db_make_vector() -
+ * return :
+ * value(out) :
+ * set(in):
+ */
+int
+db_make_vector (DB_VALUE * value, DB_SET * set)
+{
+  int error = NO_ERROR;
+
+#if defined (API_ACTIVE_CHECKS)
+  CHECK_1ARG_ERROR (value);
+#endif
+
+  value->domain.general_info.type = DB_TYPE_VECTOR;
+  value->data.set = set;
+  if (set)
+    {
+      if ((set->set && setobj_type (set->set) == DB_TYPE_VECTOR) || set->disk_set)
 	{
 	  value->domain.general_info.is_null = 0;
 	}

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -255,6 +255,8 @@ TP_DOMAIN tp_Multiset_domain = { NULL, NULL, &tp_Multiset, DOMAIN_INIT3 };
 
 TP_DOMAIN tp_Sequence_domain = { NULL, NULL, &tp_Sequence, DOMAIN_INIT3 };
 
+TP_DOMAIN tp_Vector_domain = { NULL, NULL, &tp_Vector, DOMAIN_INIT3 };
+
 TP_DOMAIN tp_Midxkey_domain_list_heads[TP_NUM_MIDXKEY_DOMAIN_LIST] = {
   {NULL, NULL, &tp_Midxkey, DOMAIN_INIT3},
   {NULL, NULL, &tp_Midxkey, DOMAIN_INIT3},

--- a/src/object/object_domain.h
+++ b/src/object/object_domain.h
@@ -152,6 +152,7 @@ extern TP_DOMAIN tp_Object_domain;
 extern TP_DOMAIN tp_Set_domain;
 extern TP_DOMAIN tp_Multiset_domain;
 extern TP_DOMAIN tp_Sequence_domain;
+extern TP_DOMAIN tp_Vector_domain;
 extern TP_DOMAIN tp_Elo_domain;
 extern TP_DOMAIN tp_Blob_domain;
 extern TP_DOMAIN tp_Clob_domain;
@@ -224,7 +225,9 @@ typedef enum tp_match
 
 #define TP_IS_SET_TYPE(typenum) \
   ((((typenum) == DB_TYPE_SET) || ((typenum) == DB_TYPE_MULTISET) || \
-    ((typenum) == DB_TYPE_SEQUENCE)) ? true : false)
+    ((typenum) == DB_TYPE_SEQUENCE) || \
+    ((typenum) == DB_TYPE_VECTOR)) \
+    ? true : false)
 
 /*
  * TP_IS_BIT_TYPE

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -1663,7 +1663,7 @@ PR_TYPE tp_Vector = {
   NULL,
   mr_freemem_set,
   NULL,
-  NULL,
+  NULL
 };
 
 PR_TYPE *tp_Type_vector = &tp_Vector;

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -826,6 +826,9 @@ static DB_VALUE_COMPARE_RESULT mr_data_cmpdisk_sequence (void *mem1, void *mem2,
 							 int total_order, int *start_colp);
 static DB_VALUE_COMPARE_RESULT mr_cmpval_sequence (DB_VALUE * value1, DB_VALUE * value2, int do_coercion,
 						   int total_order, int *start_colp, int collation);
+static void mr_initval_vector (DB_VALUE * value, int precision, int scale);
+static int mr_getmem_vector (void *memptr, TP_DOMAIN * domain, DB_VALUE * value, bool copy);
+static int mr_setval_vector (DB_VALUE * dest, const DB_VALUE * src, bool copy);
 static void mr_initval_midxkey (DB_VALUE * value, int precision, int scale);
 static int mr_setval_midxkey (DB_VALUE * dest, const DB_VALUE * src, bool copy);
 static int mr_data_lengthmem_midxkey (void *memptr, TP_DOMAIN * domain, int disk);
@@ -1642,25 +1645,25 @@ PR_TYPE *tp_Type_sequence = &tp_Sequence;
 
 PR_TYPE tp_Vector = {
   "vector", DB_TYPE_VECTOR, 1, sizeof (SETOBJ *), 0, 4,
+  mr_initmem_set,
+  mr_initval_vector,
+  mr_setmem_set,
+  mr_getmem_vector,
+  mr_setval_vector,
+  mr_data_lengthmem_set,
+  mr_data_lengthval_set,
+  mr_data_writemem_set,
+  mr_data_readmem_set,
+  mr_data_writeval_set,
+  mr_data_readval_set,
   NULL,
   NULL,
   NULL,
   NULL,
   NULL,
+  mr_freemem_set,
   NULL,
   NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL
 };
 
 PR_TYPE *tp_Type_vector = &tp_Vector;
@@ -6983,6 +6986,9 @@ mr_setval_set_internal (DB_VALUE * dest, const DB_VALUE * src, bool copy, DB_TYP
 	case DB_TYPE_SEQUENCE:
 	  db_make_sequence (dest, ref);
 	  break;
+	case DB_TYPE_VECTOR:
+	  db_make_vector (dest, ref);
+	  break;
 	default:
 	  break;
 	}
@@ -7286,6 +7292,9 @@ mr_data_readval_set (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain, int siz
 		    case DB_TYPE_SEQUENCE:
 		      db_make_sequence (value, ref);
 		      break;
+		    case DB_TYPE_VECTOR:
+		      db_make_vector (value, ref);
+		      break;
 		    default:
 		      break;
 		    }
@@ -7346,6 +7355,9 @@ mr_data_readval_set (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain, int siz
 		  break;
 		case DB_TYPE_SEQUENCE:
 		  db_make_sequence (value, ref);
+		  break;
+		case DB_TYPE_VECTOR:
+		  db_make_vector(value, ref);
 		  break;
 		default:
 		  break;
@@ -7537,6 +7549,58 @@ mr_cmpval_sequence (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int t
 		    int collation)
 {
   return set_seq_compare (db_get_set (value1), db_get_set (value2), do_coercion, total_order);
+}
+
+/*
+ * TYPE VECTOR
+ */
+
+static void
+mr_initval_vector (DB_VALUE * value, int precision, int scale)
+{
+  db_value_domain_init (value, DB_TYPE_VECTOR, precision, scale);
+  db_make_vector (value, NULL);
+}
+
+static int
+mr_getmem_vector (void *memptr, TP_DOMAIN * domain, DB_VALUE * value, bool copy)
+{
+  SETOBJ **mem = (SETOBJ **) memptr;
+  int error = NO_ERROR;
+  SETOBJ *set;
+  SETREF *ref;
+
+  set = *mem;
+  if (set == NULL)
+    {
+      error = db_make_vector (value, NULL);
+    }
+  else
+    {
+      ref = setobj_get_reference (set);
+      if (ref)
+	{
+	  error = db_make_vector (value, ref);
+	}
+      else
+	{
+	  assert (er_errid () != NO_ERROR);
+	  error = er_errid ();
+	  (void) db_make_vector (value, NULL);
+	}
+    }
+  /*
+   * NOTE: assumes that ownership info will already have been set or will
+   * be set by the caller
+   */
+
+  return error;
+}
+
+static int
+mr_setval_vector (DB_VALUE * dest, const DB_VALUE * src, bool copy)
+{
+  return mr_setval_set_internal (dest, src, copy, DB_TYPE_VECTOR);
 }
 
 /*

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -17141,4 +17141,3 @@ mr_cmpval_json (DB_VALUE * value1, DB_VALUE * value2, int do_coercion, int total
   pr_clear_value (&scalar_value2);
   return cmp_result;
 }
-

--- a/src/object/set_object.c
+++ b/src/object/set_object.c
@@ -860,6 +860,9 @@ col_new (long size, int settype)
 	    case DB_TYPE_SEQUENCE:
 	      col->domain = &tp_Sequence_domain;
 	      break;
+	    case DB_TYPE_VECTOR:
+	      col->domain = &tp_Vector_domain;
+	      break;
 	    case DB_TYPE_VOBJ:
 	      col->domain = &tp_Vobj_domain;
 	      break;
@@ -2434,6 +2437,12 @@ DB_COLLECTION *
 set_create_sequence (int size)
 {
   return set_create (DB_TYPE_SEQUENCE, size);
+}
+
+DB_COLLECTION *
+set_create_vector (int size)
+{
+  return set_create (DB_TYPE_VECTOR, size);
 }
 
 DB_COLLECTION *

--- a/src/object/set_object.h
+++ b/src/object/set_object.h
@@ -115,6 +115,7 @@ extern void set_area_reset ();
 extern DB_COLLECTION *set_create_basic (void);
 extern DB_COLLECTION *set_create_multi (void);
 extern DB_COLLECTION *set_create_sequence (int size);
+extern DB_COLLECTION *set_create_vector (int size);
 extern DB_COLLECTION *set_create_with_domain (TP_DOMAIN * domain, int initial_size);
 extern DB_COLLECTION *set_make_reference (void);
 extern DB_COLLECTION *set_copy (DB_COLLECTION * set);

--- a/src/parser/parse_dbi.c
+++ b/src/parser/parse_dbi.c
@@ -2677,6 +2677,9 @@ pt_db_to_type_enum (const DB_TYPE t)
     case DB_TYPE_SEQUENCE:
       pt_type = PT_TYPE_SEQUENCE;
       break;
+    case DB_TYPE_VECTOR:
+      pt_type = PT_TYPE_VECTOR;
+      break;
 
     case DB_TYPE_CHAR:
       pt_type = PT_TYPE_CHAR;

--- a/win/cubridcs/cubridcs.def
+++ b/win/cubridcs/cubridcs.def
@@ -237,6 +237,7 @@ EXPORTS
     db_make_null
     db_make_object
     db_make_sequence
+    db_make_vector
     db_make_set
     db_make_short
     db_make_string


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-32

# tp_Vector 기본 연산을 위한 함수 구현

## Purpose
- `DB_TYPE_VECTOR` 타입의 초기화, 데이터 접근, 설정을 위한 기본 함수들을 구현합니다.
- 특히 `mr_initval_vector`, `mr_getmem_vector`, `mr_setval_vector` 함수 구현에 초점을 맞춥니다.

## Implementation
- `tp_Vector` 구조체에 필수 함수 포인터 설정:
```c
PR_TYPE tp_Vector = {
  "vector", DB_TYPE_VECTOR, 1, sizeof (SETOBJ *), 0, 4,
  mr_initmem_set,
  mr_initval_vector,
  mr_setmem_set,
  mr_getmem_vector,
  mr_setval_vector,
  mr_data_lengthmem_set,
  // ...
};
```

- vector 타입 전용 함수 구현:
```c
static void
mr_initval_vector (DB_VALUE * value, int precision, int scale)
{
  db_value_domain_init (value, DB_TYPE_VECTOR, precision, scale);
  db_make_vector (value, NULL);
}

static int
mr_getmem_vector (void *memptr, TP_DOMAIN * domain, DB_VALUE * value, bool copy)
{
  SETOBJ **mem = (SETOBJ **) memptr;
  // ...
}
```

- set 관련 함수들에 `DB_TYPE_VECTOR` case 추가:
```c
// mr_setval_set_internal 함수 내부
case DB_TYPE_VECTOR:
  db_make_vector (dest, ref);
  break;

// mr_data_readval_set 함수 내부
case DB_TYPE_VECTOR:
  db_make_vector(value, ref);
  break;
```

## Remarks
- `tp_Sequence` 패턴을 따라 vector 타입의 기본 연산 함수들을 구현했습니다.
- 아직 구현되지 않은 나머지 함수 포인터들은 NULL로 설정되어 있습니다.
