### PR TITLE
[CUBVEC-33] Allow parse tree to convert to tp_Vector_domain

### DIFF
--- a/src/parser/parse_dbi.c
+++ b/src/parser/parse_dbi.c
@@ -615,6 +615,10 @@ pt_dbval_to_value (PARSER_CONTEXT * parser, const DB_VALUE * val)
       result->info.value.data_value.set = pt_set_elements_to_value (parser, val);
       pt_add_type_to_set (parser, result->info.value.data_value.set, &result->data_type);
       break;
+    case DB_TYPE_VECTOR:
+      result->info.value.data_value.set = pt_set_elements_to_value (parser, val);
+      pt_add_type_to_set (parser, result->info.value.data_value.set, &result->data_type);
+      break;
 
     case DB_TYPE_INTEGER:
       result->info.value.data_value.i = db_get_int (val);
@@ -1923,6 +1927,7 @@ pt_data_type_to_db_domain (PARSER_CONTEXT * parser, PT_NODE * dt, const char *cl
     case DB_TYPE_SET:
     case DB_TYPE_MULTISET:
     case DB_TYPE_SEQUENCE:
+    case DB_TYPE_VECTOR:
     case DB_TYPE_MIDXKEY:
       return pt_node_to_db_domain (parser, dt, class_name);
 
@@ -2261,6 +2266,7 @@ pt_node_to_db_domain (PARSER_CONTEXT * parser, PT_NODE * node, const char *class
 	case DB_TYPE_SET:
 	case DB_TYPE_MULTISET:
 	case DB_TYPE_SEQUENCE:
+	case DB_TYPE_VECTOR:
 	case DB_TYPE_MIDXKEY:
 	  /* Recursively build the setdomain */
 	  dt = node->data_type;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-33

## INSERT vector 파스 트리가 tp_Vector_domain 으로 변환될 수 있도록 보조 함수 지원

### Purpose
- `pt_node_to_db_domain`, `pt_data_type_to_db_domain`, `pt_dbval_to_value` 함수에 vector 타입 처리 로직을 추가합니다.
- INSERT 구문의 mq_translate 과정에서 vector 타입의 도메인 변환이 가능하도록 합니다.

### Implementation
- `pt_dbval_to_value`에 vector 타입 변환 로직 추가:
```c
case DB_TYPE_SEQUENCE:
  result->info.value.data_value.set = pt_set_elements_to_value (parser, val);
  pt_add_type_to_set (parser, result->info.value.data_value.set, &result->data_type);
  break;
case DB_TYPE_VECTOR:
  result->info.value.data_value.set = pt_set_elements_to_value (parser, val);
  pt_add_type_to_set (parser, result->info.value.data_value.set, &result->data_type);
  break;
```

- `pt_data_type_to_db_domain`에 vector 타입 도메인 변환 지원:
```c
case DB_TYPE_SEQUENCE:
case DB_TYPE_VECTOR:
case DB_TYPE_MIDXKEY:
  return pt_node_to_db_domain (parser, dt, class_name);
```

- `pt_node_to_db_domain`에 vector 타입 처리 로직 추가:
```c
case DB_TYPE_SET:
case DB_TYPE_MULTISET:
case DB_TYPE_SEQUENCE:
case DB_TYPE_VECTOR:
case DB_TYPE_MIDXKEY:
  dt = node->data_type;
```

### Remarks
- sequence 타입의 처리 패턴을 동일하게 적용하여 vector 타입을 처리합니다.
- sequence가 insert 되는 경우를 그대로 모방하여 구현했습니다.