### PR TITLE
[CBRD-25768] Separate server requests to the master between the server and the client

### DIFF
--- a/src/connection/connection_cl.c
+++ b/src/connection/connection_cl.c
@@ -895,7 +895,7 @@ css_connect_to_master_server (int master_port_id, const char *server_name, int n
     }
 
   /* select the connection protocol, for PC's this will always be new */
-  connection_protocol = ((css_Server_use_new_connection_protocol) ? SERVER_REQUEST_NEW : SERVER_REQUEST);
+  connection_protocol = ((css_Server_use_new_connection_protocol) ? SERVER_REQUEST_NEW : SERVER_REQUEST_FROM_CLIENT);
 
   if (css_common_connect (hname, conn, connection_protocol, server_name, name_length, master_port_id, 0, &rid, true)
       == NULL)

--- a/src/connection/connection_defs.h
+++ b/src/connection/connection_defs.h
@@ -68,8 +68,7 @@ enum css_command_type
   DATA_REQUEST = 2,		/* get data from the database server */
   SERVER_REQUEST_FROM_SERVER = 3,	/* let new server attach */
   SERVER_REQUEST_FROM_CLIENT = 4,	/* let new client process attach */
-  UNUSED_REQUEST = 5,		/* unused request - leave it for compatibility */
-  SERVER_REQUEST_NEW = 6,	/* new-style server request */
+  SERVER_REQUEST_NEW = 5,	/* new-style server request */
   MAX_REQUEST
 };
 

--- a/src/connection/connection_defs.h
+++ b/src/connection/connection_defs.h
@@ -66,9 +66,10 @@ enum css_command_type
   NULL_REQUEST = 0,
   INFO_REQUEST = 1,		/* get runtime info from the master server */
   DATA_REQUEST = 2,		/* get data from the database server */
-  SERVER_REQUEST = 3,		/* let new server attach */
-  UNUSED_REQUEST = 4,		/* unused request - leave it for compatibility */
-  SERVER_REQUEST_NEW = 5,	/* new-style server request */
+  SERVER_REQUEST_FROM_SERVER = 3,	/* let new server attach */
+  SERVER_REQUEST_FROM_CLIENT = 4,	/* let new client process attach */
+  UNUSED_REQUEST = 5,		/* unused request - leave it for compatibility */
+  SERVER_REQUEST_NEW = 6,	/* new-style server request */
   MAX_REQUEST
 };
 

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -1154,7 +1154,7 @@ css_connect_to_master_server (int master_port_id, const char *server_name, int n
   else
     {
       // Linux and Unix
-      connection_protocol = SERVER_REQUEST;
+      connection_protocol = SERVER_REQUEST_FROM_SERVER;
       css_set_proc_register (server_name, name_length, &proc_register);
       data = (const char *) &proc_register;
       data_length = sizeof (proc_register);

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -82,10 +82,11 @@ static int css_master_init (int cport, SOCKET * clientfd);
 static void css_reject_client_request (CSS_CONN_ENTRY * conn, unsigned short rid, int reason);
 static void css_reject_server_request (CSS_CONN_ENTRY * conn, int reason);
 static void css_accept_server_request (CSS_CONN_ENTRY * conn, int reason);
-static void css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer, int buffer_length);
+static void css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer, int buffer_length,
+				    bool is_client);
 static void css_accept_old_request (CSS_CONN_ENTRY * conn, unsigned short rid, SOCKET_QUEUE_ENTRY * entry,
 				    char *server_name, int server_name_length);
-static void css_register_new_server (CSS_CONN_ENTRY * conn, unsigned short rid);
+static void css_register_new_server (CSS_CONN_ENTRY * conn, unsigned short rid, bool is_client);
 static void css_register_new_server2 (CSS_CONN_ENTRY * conn, unsigned short rid);
 static bool css_send_new_request_to_server (SOCKET server_fd, SOCKET client_fd, unsigned short rid,
 					    CSS_SERVER_REQUEST request);
@@ -321,18 +322,22 @@ css_accept_server_request (CSS_CONN_ENTRY * conn, int reason)
  *   conn(in)
  *   rid(in)
  *   buffer(in)
+ *   buffer_length(in)
+ *   is_client(in)
  *
  */
 static void
-css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer, int buffer_length)
+css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer, int buffer_length, bool is_client)
 {
   char *datagram;
   char *server_name;
   int datagram_length;
   SOCKET server_fd = INVALID_SOCKET;
   int length;
+  int server_name_length;
   CSS_CONN_ENTRY *datagram_conn;
   SOCKET_QUEUE_ENTRY *entry;
+  CSS_SERVER_PROC_REGISTER *proc_register;
 
   datagram = NULL;
   datagram_length = 0;
@@ -348,7 +353,17 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer,
 #if defined(DEBUG)
 	  css_Active_server_count++;
 #endif
-	  server_name = buffer;
+	  if (is_client)
+	    {
+	      server_name = buffer;
+	      server_name_length = buffer_length;
+	    }
+	  else
+	    {
+	      proc_register = (CSS_SERVER_PROC_REGISTER *) buffer;
+	      server_name = proc_register->server_name;
+	      server_name_length = proc_register->server_name_length;
+	    }
 	  length = (int) strlen (server_name) + 1;
 	  css_add_request_to_socket_queue (datagram_conn, false, server_name, server_fd, READ_WRITE, 0,
 					   &css_Master_socket_anchor);
@@ -359,9 +374,8 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer,
 
 	  assert (length <= DB_MAX_IDENTIFIER_LENGTH);
 
-	  if (length < buffer_length)
+	  if (length < server_name_length)
 	    {
-
 	      entry = css_return_entry_of_server (server_name, css_Master_socket_anchor);
 	      if (entry != NULL)
 		{
@@ -394,13 +408,8 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer,
 #if !defined(WINDOWS)
 	      if (auto_Restart_server)
 		{
-		  // TODO : Currently, server and client has different format of data payload to connect process to master.
-		  // Since both process is handled by this function, it could make confusion when requesting connection from process.
-		  // Two solution could be considered.
-		  // 1. Separte the request for server and client. (SERVER_REQUEST_FROM_CLIENT, SERVER_REQUEST_FROM_SERVER)
-		  // 2. Modify the data payload so that master can distinguish the request from server and client. (e.g. add flag character at the beginning of data)
+		  assert (!is_client);
 
-		  CSS_SERVER_PROC_REGISTER *proc_register = (CSS_SERVER_PROC_REGISTER *) buffer;
 		  /* *INDENT-OFF* */
 		  master_Server_monitor->produce_job (server_monitor::job_type::REGISTER_SERVER, proc_register->pid,
 						      proc_register->exec_path, proc_register->args, proc_register->server_name);
@@ -468,11 +477,12 @@ css_accept_old_request (CSS_CONN_ENTRY * conn, unsigned short rid, SOCKET_QUEUE_
  *   return: none
  *   conn(in)
  *   rid(in)
+ *   is_client(in)
  *
  * Note: This will allow us to pass fds for future requests to the server.
  */
 static void
-css_register_new_server (CSS_CONN_ENTRY * conn, unsigned short rid)
+css_register_new_server (CSS_CONN_ENTRY * conn, unsigned short rid, bool is_client)
 {
   int data_length;
   char *data = NULL;
@@ -483,7 +493,6 @@ css_register_new_server (CSS_CONN_ENTRY * conn, unsigned short rid)
   //  2. When a new cub_server requests to register itself to cub_master.
   //  For the first situation, css_register_new_server() receives the server name as data.
   //  For the second situation, css_register_new_server() receives CSS_SERVER_PROC_REGISTER as data.
-  //  css_register_new_server determines which case it is by checking if the entry is NULL or not.
 
   if (css_receive_data (conn, rid, &data, &data_length, -1) == NO_ERRORS)
     {
@@ -512,7 +521,7 @@ css_register_new_server (CSS_CONN_ENTRY * conn, unsigned short rid)
 
 #else /* ! WINDOWS */
 	  /* accept a request from a new server */
-	  css_accept_new_request (conn, rid, data, data_length);
+	  css_accept_new_request (conn, rid, data, data_length, is_client);
 #endif /* ! WINDOWS */
 	}
     }
@@ -794,8 +803,11 @@ css_process_new_connection (SOCKET fd)
 	case DATA_REQUEST:	/* request from a remote client */
 	  css_send_to_existing_server (conn, rid, SERVER_START_NEW_CLIENT);
 	  break;
-	case SERVER_REQUEST:	/* request from a new server */
-	  css_register_new_server (conn, rid);
+	case SERVER_REQUEST_FROM_SERVER:	/* request from a new server */
+	  css_register_new_server (conn, rid, false);
+	  break;
+	case SERVER_REQUEST_FROM_CLIENT:	/* request from a new server */
+	  css_register_new_server (conn, rid, true);
 	  break;
 	case SERVER_REQUEST_NEW:	/* request from a new server */
 	  /* here the server wants to manage its own connection port */

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -360,7 +360,10 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer,
 	    }
 	  else
 	    {
+	      assert (buffer != NULL);
 	      proc_register = (CSS_SERVER_PROC_REGISTER *) buffer;
+	      
+	      assert (proc_register->server_name != NULL);
 	      server_name = proc_register->server_name;
 	      server_name_length = proc_register->server_name_length;
 	    }

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -362,7 +362,7 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer,
 	    {
 	      assert (buffer != NULL);
 	      proc_register = (CSS_SERVER_PROC_REGISTER *) buffer;
-	      
+
 	      assert (proc_register->server_name != NULL);
 	      server_name = proc_register->server_name;
 	      server_name_length = proc_register->server_name_length;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25768

- Purpose
  - `css_register_new_server`는 새로운 server process의 정보를 받아, cub_master에 등록하는 함수
  - 이 함수를 통해 `css_accept_new_reqeust`함수를 호출하여 packing 된 정보를 해체하여 cub_master에 정보를 등록한다. 이러한 상황은 두 가지로 분류된다.
    -  1.  새로운 Server가 등록되는 경우, server process는 `CSS_SERVER_PROC_REGISTER` 자료구조에 정보를 담아서 master에 정보를 보낸다. 
    - 2. copylogdb, applylogdb와 같은 client-side process가 등록되는 경우, server name만 master에 전송된다.
 - 위 두 상황은 서로 다른 format임에도 불구하고, 같은 request code인 `SERVER_REQUEST`로 전송되고 있다.

 
- Implementation
  - SERVER_REQUEST 요청의 분리
     - 새로운 Server가 등록되는 경우, `SERVER_REQUEST_FROM_SERVER` request를 통해 요청 전송
     - client process의 경우, `SERVER_REQUEST_FROM_CLIENT` request를 통해 요청 전송
  -  요청 처리 함수의 변경
     - 요청을 받는 함수인 `css_register_new_server`와, 정보를 unpack 하는 함수인 `css_accept_new_reqeust`에 `is_client` 변수를 추가로 받도록 변경하여, 다루고 있는 process가 client 인지 정보를 추가로 전달
     - client 정보라면, 전달 받은 `buffer`를  그대로 server name으로 인식하고, server라면, 전달 받은 `buffer`를 `CSS_SERVER_PROC_REGISTER`로 변환하여 정보를 unpack 한다.   