### PR TITLE
[CBRD-25606] check if the markers are not NULL before handling them

### DIFF
--- a/src/method/method_callback.cpp
+++ b/src/method/method_callback.cpp
@@ -517,7 +517,8 @@ namespace cubmethod
 	    DB_MARKER *marker = db_get_input_markers (db_session, 1);
 	    if (marker)
 	      {
-		/* The following markers_cnt is unreliable: it does not match the actual number of markers sometimes (CBRD-25606)
+		/* The following way of getting markers_cnt is unreliable:
+		 *      it does not match the actual number of markers sometimes (CBRD-25606)
 		 * TODO: figure out why.
 
 		int markers_cnt = parser->host_var_count + parser->auto_param_count;
@@ -543,7 +544,7 @@ namespace cubmethod
 		      {
 			error = ER_FAILED;
 			semantics.sql_type = error;
-			semantics.rewritten_query = "internal error: a host variable marker index is out of range";
+			semantics.rewritten_query = "internal error: a host variable marker index is out of valid range";
 			break;
 		      }
 

--- a/src/method/method_callback.cpp
+++ b/src/method/method_callback.cpp
@@ -499,17 +499,63 @@ namespace cubmethod
 		semantics.columns.emplace_back (c_info);
 	      }
 
-	    int markers_cnt = parser->host_var_count + parser->auto_param_count;
-	    DB_MARKER *marker = db_get_input_markers (db_session, 1);
-
-	    if (markers_cnt > 0)
+	    // into variable
+	    char **external_into_label = db_session->parser->external_into_label;
+	    if (external_into_label)
 	      {
+		for (int i = 0; i < db_session->parser->external_into_label_cnt; i++)
+		  {
+		    semantics.into_vars.push_back (external_into_label[i]);
+		    free (external_into_label[i]);
+		  }
+		free (external_into_label);
+	      }
+	    db_session->parser->external_into_label = NULL;
+	    db_session->parser->external_into_label_cnt = 0;
+
+	    // host/automatic variables
+	    DB_MARKER *marker = db_get_input_markers (db_session, 1);
+	    if (marker)
+	      {
+		/* The following markers_cnt is unreliable: it does not match the actual number of markers sometimes (CBRD-25606)
+		 * TODO: figure out why.
+
+		int markers_cnt = parser->host_var_count + parser->auto_param_count;
+
+		 * Instead, we count the actual number of markers as follows.
+		*/
+		int markers_cnt = 0;
+		DB_MARKER *marker_save = marker;
+		do
+		  {
+		    markers_cnt++;
+		    marker = db_marker_next (marker);
+		  }
+		while (marker);
+		marker = marker_save;
+
 		semantics.hvs.resize (markers_cnt);
 
-		while (marker)
+		do
 		  {
 		    int idx = marker->info.host_var.index;
+		    if (idx >= markers_cnt)
+		      {
+			error = ER_FAILED;
+			semantics.sql_type = error;
+			semantics.rewritten_query = "internal error: a host variable marker index is out of range";
+			break;
+		      }
+
+		    if (semantics.hvs[idx].mode != 0)
+		      {
+			error = ER_FAILED;
+			semantics.sql_type = error;
+			semantics.rewritten_query = "internal error: two different host variable markers have the same index";
+			break;
+		      }
 		    semantics.hvs[idx].mode = 1;
+
 		    if (marker->info.host_var.label)
 		      {
 			semantics.hvs[idx].name.assign ((char *) marker->info.host_var.label);
@@ -548,27 +594,11 @@ namespace cubmethod
 
 		    marker = db_marker_next (marker);
 		  }
+		while (marker);
 	      }
-
-	    // into variable
-	    char **external_into_label = db_session->parser->external_into_label;
-	    if (external_into_label)
-	      {
-		for (int i = 0; i < db_session->parser->external_into_label_cnt; i++)
-		  {
-		    semantics.into_vars.push_back (external_into_label[i]);
-		    free (external_into_label[i]);
-		  }
-		free (external_into_label);
-	      }
-	    db_session->parser->external_into_label = NULL;
-	    db_session->parser->external_into_label_cnt = 0;
 	  }
 	else
 	  {
-	    // clear previous infos
-	    semantics_vec.clear ();
-
 	    error = ER_FAILED;
 	    semantics.sql_type = m_error_ctx.get_error ();
 	    semantics.rewritten_query = m_error_ctx.get_error_msg ();


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25606

이슈의 TC는 markers_cnt > 0 이지만 marker 가 NULL 인 경우라 
marker 들을 다루기 전에 markers_cnt >0 여부 검사 대신 marker 가 NULL 인지 검사하도록 바꾸었습니다. 

그리고, markers_cnt 를 구하는 방식도 실제로 marker 리스트 element 를 세서 구하도록 바꾸었습니다. 

그리고, marker 중 범위를 벗어나는 index 를 갖거나 중복된 index 를 갖는 marker 가 있을 때는 에러 처리하였습니다. 

