### PR TITLE
[CBRD-25777] Static SQL를 컴파일 할 때 Auto Paramterize 하지 않도록 수정

### DIFF
--- a/src/method/method_callback.cpp
+++ b/src/method/method_callback.cpp
@@ -455,6 +455,68 @@ namespace cubmethod
 //////////////////////////////////////////////////////////////////////////
 // Compile
 //////////////////////////////////////////////////////////////////////////
+
+  static bool
+  is_supported_dbtype (const DB_TYPE type)
+  {
+    bool res = false;
+    switch (type)
+      {
+      case DB_TYPE_INTEGER:
+      case DB_TYPE_SHORT:
+      case DB_TYPE_BIGINT:
+      case DB_TYPE_FLOAT:
+      case DB_TYPE_DOUBLE:
+      case DB_TYPE_MONETARY:
+      case DB_TYPE_NUMERIC:
+      case DB_TYPE_CHAR:
+      case DB_TYPE_NCHAR:
+      case DB_TYPE_VARNCHAR:
+      case DB_TYPE_STRING:
+      case DB_TYPE_DATE:
+      case DB_TYPE_TIME:
+      case DB_TYPE_TIMESTAMP:
+      case DB_TYPE_DATETIME:
+      case DB_TYPE_SET:
+      case DB_TYPE_MULTISET:
+      case DB_TYPE_SEQUENCE:
+      case DB_TYPE_OID:
+      case DB_TYPE_OBJECT:
+      case DB_TYPE_RESULTSET:
+      case DB_TYPE_NULL:
+	res = true;
+	break;
+      // unsupported types
+      case DB_TYPE_BIT:
+      case DB_TYPE_VARBIT:
+      case DB_TYPE_TABLE:
+      case DB_TYPE_BLOB:
+      case DB_TYPE_CLOB:
+      case DB_TYPE_TIMESTAMPTZ:
+      case DB_TYPE_TIMESTAMPLTZ:
+      case DB_TYPE_DATETIMETZ:
+      case DB_TYPE_DATETIMELTZ:
+      case DB_TYPE_JSON:
+      case DB_TYPE_ENUMERATION:
+	res = false;
+	break;
+
+      // obsolete, internal, unused type
+      case DB_TYPE_ELO:
+      case DB_TYPE_VARIABLE:
+      case DB_TYPE_SUB:
+      case DB_TYPE_POINTER:
+      case DB_TYPE_ERROR:
+      case DB_TYPE_VOBJ:
+      case DB_TYPE_DB_VALUE:
+      case DB_TYPE_MIDXKEY:
+      default:
+	assert (false);
+	break;
+      }
+    return res;
+  }
+
   int
   callback_handler::get_sql_semantics (packing_unpacker &unpacker)
   {
@@ -580,6 +642,27 @@ namespace cubmethod
 	if (error != NO_ERROR)
 	  {
 	    break;
+	  }
+      }
+
+    for (sql_semantics &s : semantics_vec)
+      {
+	for (const cubpl::pl_parameter_info &hv : s.hvs)
+	  {
+	    if (is_supported_dbtype ((DB_TYPE) hv.type) == false)
+	      {
+		er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_NOT_SUPPORTED_ARG_TYPE, 1, pr_type_name ((DB_TYPE) hv.type));
+	      }
+	  }
+
+	if (er_errid () != NO_ERROR)
+	  {
+	    s.columns.clear ();
+	    s.hvs.clear ();
+	    s.into_vars.clear ();
+
+	    error = s.sql_type = er_errid ();
+	    s.rewritten_query = er_msg ();
 	  }
       }
 

--- a/src/optimizer/query_rewrite.c
+++ b/src/optimizer/query_rewrite.c
@@ -9475,7 +9475,8 @@ qo_optimize_queries (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *co
 
       /* auto-parameterization is safe when it is done as the last step of rewrite optimization */
       if (!prm_get_bool_value (PRM_ID_HOSTVAR_LATE_BINDING)
-	  && prm_get_integer_value (PRM_ID_XASL_CACHE_MAX_ENTRIES) > 0 && node->flag.cannot_prepare == 0)
+	  && prm_get_integer_value (PRM_ID_XASL_CACHE_MAX_ENTRIES) > 0 && node->flag.cannot_prepare == 0
+	  && parser->flag.is_parsing_static_sql == 0)
 	{
 	  call_auto_parameterize = true;
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25777

- Static SQL 컴파일 모드 (parser->flag.is_parsing_static_sql == 1) 에서는 auto parameterize 하지 않도록 수정
- Static SQL의 SQL semantic check 에서 DB_VALUE 검증에 대한 방어 코드 추가 (core 방지)
   (http://jira.cubrid.org/browse/CBRD-25040 관련)
