### PR TITLE
[CBRD-25760] github memory monitoring check bug fix

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -268,7 +268,7 @@ jobs:
             fi
 
             filename=$(basename $f)
-            check_server_file=$(grep -F $filename cubrid/CMakeLists.txt)
+            check_server_file=$(grep -qE "/$filename\$" cubrid/CMakeLists.txt)
             if [ "$check_server_file" == "" ]; then
               result_for_f="PASS"
             fi

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -268,7 +268,7 @@ jobs:
             fi
 
             filename=$(basename $f)
-            check_server_file=$(grep -qE "/$filename\$" cubrid/CMakeLists.txt)
+            check_server_file=$(grep -E "/$filename\$" cubrid/CMakeLists.txt)
             if [ "$check_server_file" == "" ]; then
               result_for_f="PASS"
             fi


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25760

### **_Purpose_**

- 문제 상황
  - grep에 -F 옵션을 추가하는 기존 PR에서도 예외상황이 발생
  - compile.c 파일을 grep -F로 검색했을 시 존재하지 않아야 정상인데 compile.cpp가 존재하기 때문에 존재하는 것으로 인식

### **_Implementation_**
 - grep 옵션 수정