### PR TITLE
[CUBVEC-34] Print Vector in Select

### DIFF
--- a/src/executables/csql_result_format.c
+++ b/src/executables/csql_result_format.c
@@ -226,6 +226,10 @@ static DB_TYPE_SET_PROFILE default_set_profile = {
   '{', '}', -1
 };
 
+static DB_TYPE_SET_PROFILE default_vector_profile = {
+  '[', ']', -1
+};
+
 
 /*
  * string type conversion profile
@@ -1665,7 +1669,9 @@ csql_db_value_as_string (DB_VALUE * value, int *length, const CSQL_ARGUMENT * cs
 	}
       break;
     case DB_TYPE_VECTOR:
-      result = set_to_string (value, '[', ']', default_set_profile.max_entries, csql_arg);
+      result =
+	set_to_string (value, default_vector_profile.begin_notation, default_vector_profile.end_notation,
+		       default_vector_profile.max_entries, csql_arg);
       if (result)
 	{
 	  len = strlen (result);

--- a/src/executables/csql_result_format.c
+++ b/src/executables/csql_result_format.c
@@ -1665,9 +1665,7 @@ csql_db_value_as_string (DB_VALUE * value, int *length, const CSQL_ARGUMENT * cs
 	}
       break;
     case DB_TYPE_VECTOR:
-      result =
-	set_to_string (value, '[', ']',
-		       default_set_profile.max_entries, csql_arg);
+      result = set_to_string (value, '[', ']', default_set_profile.max_entries, csql_arg);
       if (result)
 	{
 	  len = strlen (result);

--- a/src/executables/csql_result_format.c
+++ b/src/executables/csql_result_format.c
@@ -1664,6 +1664,15 @@ csql_db_value_as_string (DB_VALUE * value, int *length, const CSQL_ARGUMENT * cs
 	  len = strlen (result);
 	}
       break;
+    case DB_TYPE_VECTOR:
+      result =
+	set_to_string (value, '[', ']',
+		       default_set_profile.max_entries, csql_arg);
+      if (result)
+	{
+	  len = strlen (result);
+	}
+      break;
     case DB_TYPE_TIME:
       {
 	char buf[TIME_BUF_SIZE];


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-34

### Purpose  
CUBRID SQL 쿼리에서 벡터 타입의 데이터를 출력하기 위해 `csql_result_format.c` 파일의 `csql_db_value_as_string` 함수에서 `DB_TYPE_VECTOR` 타입을 지원하도록 개선합니다.

### Implementation  
`csql_result_format.c` 파일의 `csql_db_value_as_string` 함수에 아래와 같은 코드를 추가했습니다:

```c
case DB_TYPE_SEQUENCE:
    break;
case DB_TYPE_VECTOR:
    result = set_to_string (value, '[', ']', default_set_profile.max_entries, csql_arg);
    if (result)
    {
        len = strlen (result);
    }
    break;
```

### Remarks  
1. 벡터 타입의 출력 형식은 `[ ]`로 감싸도록 변경
2. 기존 시퀀스 타입과 유사하지만, 벡터의 특성을 반영하여 코드를 수정
3. 변경된 코드가 포함된 SELECT 문에서 출력 형식을 확인

### Definition of Done  
- 벡터 타입이 포함된 SELECT 문에서 결과가 `[ ]` 형식으로 올바르게 출력됨을 확인