### PR TITLE
[CBRD-25688] regression: Modify the system onnection pool for PL server status check to always reconnect

### DIFF
--- a/src/sp/pl_connection.cpp
+++ b/src/sp/pl_connection.cpp
@@ -273,7 +273,7 @@ namespace cubpl
   int
   connection::send_buffer (const cubmem::block &blk)
   {
-    if (!is_valid ())
+    if (!is_valid () || m_pool->is_system_pool ())
       {
 	do_reconnect ();
       }

--- a/src/sp/pl_sr.cpp
+++ b/src/sp/pl_sr.cpp
@@ -37,6 +37,7 @@
 #include "thread_entry.hpp"
 #include "thread_looper.hpp"
 #include "thread_daemon.hpp"
+#include "boot_sr.h"
 #else
 #include "dbi.h"
 #include "boot.h"
@@ -352,7 +353,13 @@ namespace cubpl
   void
   server_monitor_task::wait_for_ready ()
   {
-    auto pred = [this] () -> bool { return m_state == SERVER_MONITOR_STATE_RUNNING || m_state == SERVER_MONITOR_STATE_FAILED_TO_CONNECT; };
+#if defined (SERVER_MODE)
+    auto pred = [this] () -> bool { return m_state == SERVER_MONITOR_STATE_RUNNING ||
+					   (!BO_IS_SERVER_RESTARTED () && m_state == SERVER_MONITOR_STATE_FAILED_TO_CONNECT);
+				  };
+#else
+    auto pred = [this] () -> bool { return m_state == SERVER_MONITOR_STATE_RUNNING; };
+#endif
 
     std::unique_lock<std::mutex> ulock (m_monitor_mutex);
     m_monitor_cv.wait (ulock, pred);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25688

- Modify the behavior of wait_for_ready() during cubrid server start to release the wait when the SERVER_MONITOR_STATE_FAILED_TO_CONNECT state is encountered.
- For cubrid pl restart, ensure that the system connection pool properly verifies the restart of the PL server and sends the bootstrap request by always opening a new socket to confirm the connection status correctly.