### PR TITLE
[CBRD-25781] fix regression error

### DIFF
--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -4098,12 +4098,16 @@ fetch_peek_dbval (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, val_descr *
 	error = executor.fetch_args_peek (regu_var->value.sp_ptr->args, vd, obj_oid, tpl);
 	if (error != NO_ERROR)
 	  {
+	    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_EXECUTE_ERROR, 1,
+		    executor.get_stack ()->get_error_message ().c_str ());
 	    goto exit_on_error;
 	  }
 
 	error = executor.execute (*regu_var->value.sp_ptr->value);
 	if (error != NO_ERROR)
 	  {
+	    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_EXECUTE_ERROR, 1,
+		    executor.get_stack ()->get_error_message ().c_str ());
 	    goto exit_on_error;
 	  }
 

--- a/src/sp/pl_executor.cpp
+++ b/src/sp/pl_executor.cpp
@@ -452,7 +452,6 @@ exit:
 	std::string error_msg;
 	unpacker.unpack_string (error_msg);
 	m_stack->set_error_message (error_msg);
-	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_EXECUTE_ERROR, 1, error_msg.c_str ());
 	return ER_SP_EXECUTE_ERROR;
       }
     else

--- a/src/sp/sp_catalog.cpp
+++ b/src/sp/sp_catalog.cpp
@@ -990,8 +990,8 @@ void sp_normalize_name (std::string &s)
 void
 sp_split_target_signature (const std::string &s, std::string &target_cls, std::string &target_mth)
 {
-  auto pos = s.find_last_of ('(');
-  if (pos == std::string::npos)
+  auto pos1 = s.find_last_of ('(');
+  if (pos1 == std::string::npos)
     {
       // handle the case where '(' is not found, if necessary
       target_cls.clear();
@@ -999,8 +999,12 @@ sp_split_target_signature (const std::string &s, std::string &target_cls, std::s
       return;
     }
 
-  pos = s.substr (0, pos).find_last_of ('.');
-  if (pos == std::string::npos)
+  std::string tmp = s.substr (0, pos1);
+  tmp.erase (tmp.find_last_not_of(" ") + 1); // rtrim
+  tmp.erase (0, tmp.find_first_not_of(" ")); // ltrim
+
+  auto pos2 = tmp.find_last_of ('.');
+  if (pos2 == std::string::npos)
     {
       // handle the case where '.' is not found, if necessary
       target_cls.clear();
@@ -1008,8 +1012,8 @@ sp_split_target_signature (const std::string &s, std::string &target_cls, std::s
       return;
     }
 
-  target_cls = s.substr (0, pos);
-  target_mth = s.substr (pos + 1); // +1 to skip the '.'
+  target_cls = tmp.substr (0, pos2);
+  target_mth = tmp.substr (pos2 + 1) + s.substr (pos1); // remove spaces between method and (
 }
 
 std::string

--- a/src/sp/sp_catalog.cpp
+++ b/src/sp/sp_catalog.cpp
@@ -1000,8 +1000,8 @@ sp_split_target_signature (const std::string &s, std::string &target_cls, std::s
     }
 
   std::string tmp = s.substr (0, pos1);
-  tmp.erase (tmp.find_last_not_of(" ") + 1); // rtrim
-  tmp.erase (0, tmp.find_first_not_of(" ")); // ltrim
+  tmp.erase (tmp.find_last_not_of (" ") + 1); // rtrim
+  tmp.erase (0, tmp.find_first_not_of (" ")); // ltrim
 
   auto pos2 = tmp.find_last_of ('.');
   if (pos2 == std::string::npos)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25781

- When creating a function, remove the space between the method and ( from the signature
- When a SP execution error occurs, "Stored procedure execute error:" is now displayed as before.
