### PR TITLE
[CBRD-25785] Problem with view merging when ORDER BY clause in the subquery and the main query, and rownum is in the main query select list

### DIFF
--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -1891,8 +1891,9 @@ mq_is_pushable_subquery (PARSER_CONTEXT * parser, PT_NODE * subquery, PT_NODE * 
     }
   /* subquery has order_by and main query has inst_num or analytic or order-sensitive aggrigation */
   if (subquery->info.query.order_by
-      && ((!is_rownum_only && pt_has_inst_in_where_and_select_list (parser, mainquery)) || pt_has_analytic (parser, mainquery)
-	  || pt_has_order_sensitive_agg (parser, mainquery) || pt_has_expr_of_inst_in_sel_list (parser, select_list)))
+      && ((!is_rownum_only && pt_has_inst_in_where_and_select_list (parser, mainquery))
+	  || pt_has_analytic (parser, mainquery) || pt_has_order_sensitive_agg (parser, mainquery)
+	  || pt_has_expr_of_inst_in_sel_list (parser, select_list)))
     {
       /* not pushable */
       return NON_PUSHABLE;

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -1891,7 +1891,7 @@ mq_is_pushable_subquery (PARSER_CONTEXT * parser, PT_NODE * subquery, PT_NODE * 
     }
   /* subquery has order_by and main query has inst_num or analytic or order-sensitive aggrigation */
   if (subquery->info.query.order_by
-      && ((!is_rownum_only && pt_has_inst_num (parser, pred)) || pt_has_analytic (parser, mainquery)
+      && ((!is_rownum_only && pt_has_inst_in_where_and_select_list (parser, mainquery)) || pt_has_analytic (parser, mainquery)
 	  || pt_has_order_sensitive_agg (parser, mainquery) || pt_has_expr_of_inst_in_sel_list (parser, select_list)))
     {
       /* not pushable */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25785

If the subquery has an ORDER BY clause, and the main query has rownum and orderby_num(), the result will be affected by the data order. In this case, modify it so that it is not view merged.
```
as-is: Check whether WHERE of the subquery has rownum
to-be: Check the subquery's select-list and where clause
```