### PR TITLE
[CBRD-25788] keep precision and scale of types in Static SQL SELECT lists

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/DBTypeAdapter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/DBTypeAdapter.java
@@ -147,7 +147,7 @@ public class DBTypeAdapter {
             case DBType.DB_CHAR:
                 if (includePrecision) {
                     if (prec == -1) {
-                        prec = TypeChar.MAX_LEN;
+                        prec = TypeChar.DEFAULT_LEN;
                     }
                     assert prec >= 1 && prec <= TypeChar.MAX_LEN : ("invalid precision " + prec);
                     return TypeChar.getInstance(iStore, prec);
@@ -156,7 +156,9 @@ public class DBTypeAdapter {
                 }
             case DBType.DB_STRING:
                 if (includePrecision) {
-                    if (prec == -1 || prec == 0) { // 0 for STRING (by test)
+                    if (prec == -1) {
+                        prec = TypeVarchar.DEFAULT_LEN;
+                    } else if (prec == 0) { // 0 for STRING (by test)
                         prec = TypeVarchar.MAX_LEN;
                     }
                     assert prec >= 1 && prec <= TypeVarchar.MAX_LEN : ("invalid precision " + prec);

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -492,7 +492,7 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
             return new TypeSpec(ctx, Type.STRING_ANY);
         }
 
-        int length = 1; // default
+        int length = TypeChar.DEFAULT_LEN; // default
 
         try {
             if (ctx.length != null) {
@@ -524,7 +524,7 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
             return new TypeSpec(ctx, Type.STRING_ANY);
         }
 
-        int length = TypeVarchar.MAX_LEN; // default
+        int length = TypeVarchar.DEFAULT_LEN; // default
 
         try {
             if (ctx.length != null) {
@@ -2777,7 +2777,7 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
                     }
 
                 } else if (DBTypeAdapter.isSupported(ci.type)) {
-                    ty = DBTypeAdapter.getValueType(iStore, ci.type);
+                    ty = DBTypeAdapter.getDeclType(iStore, ci.type, ci.prec, ci.scale);
                 } else {
                     throw new SemanticError(
                             Misc.getLineColumnOf(ctx), // s426

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/type/TypeChar.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/type/TypeChar.java
@@ -35,6 +35,7 @@ import com.cubrid.plcsql.compiler.InstanceStore;
 public class TypeChar extends Type {
 
     public static final int MAX_LEN = 268435455;
+    public static final int DEFAULT_LEN = 1;
 
     public final int length;
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/type/TypeVarchar.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/type/TypeVarchar.java
@@ -35,6 +35,7 @@ import com.cubrid.plcsql.compiler.InstanceStore;
 public class TypeVarchar extends Type {
 
     public static final int MAX_LEN = 1073741823;
+    public static final int DEFAULT_LEN = MAX_LEN;
 
     public final int length;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25788

문제의 원인은 레코드 필드 타입들이 Server Semantic API를 통해 전달받은 precision과 scale 을 유지하지 않고 
NUMERIC(ANY, ANY), CHAR(ANY), VARCHAR(ANY) 로 되어 있다보니
길이 검사에 필요한 precision 정보가 없어 검사하는 코드가 생성되지 않던 것이었습니다. 
서버로부터 받은 precision, scale 정보를 버리지 않고 유지하도록 수정했습니다. 

아울러, CHAR, VARCHAR 의 default length를 나타내는 precision -1 의 경우 
readability를 높이기 위해 몇 가지 상수를 추가했습니다. 

