### PR TITLE
[CBRD-25795] Fixed an issue where the AU_DISABLE value was set to true when calling a non-existent stored procedure using the CALL statement.

### DIFF
--- a/src/object/authenticate.h
+++ b/src/object/authenticate.h
@@ -111,6 +111,7 @@ class print_output;
 #define AU_ENABLE(save) \
   do \
     { \
+      assert (save == 0 || save == 1); \
       Au_disable = save; \
     } \
   while (0)
@@ -131,6 +132,7 @@ class print_output;
 #define AU_RESTORE(save) \
   do \
     { \
+      assert (save == 0 || save == 1); \
       Au_disable = save; \
     } \
   while (0)

--- a/src/sp/jsp_cl.cpp
+++ b/src/sp/jsp_cl.cpp
@@ -2067,7 +2067,7 @@ pt_to_method_arglist (PARSER_CONTEXT *parser, PT_NODE *target, PT_NODE *node_lis
 int
 jsp_make_pl_signature (PARSER_CONTEXT *parser, PT_NODE *node, PT_NODE *subquery_as_attr_list, cubpl::pl_signature &sig)
 {
-  int save;
+  int save = 0;
   int error = NO_ERROR;
   char user_name_buffer [DB_MAX_USER_LENGTH + 1];
 

--- a/src/sp/jsp_cl.cpp
+++ b/src/sp/jsp_cl.cpp
@@ -2067,9 +2067,10 @@ pt_to_method_arglist (PARSER_CONTEXT *parser, PT_NODE *target, PT_NODE *node_lis
 int
 jsp_make_pl_signature (PARSER_CONTEXT *parser, PT_NODE *node, PT_NODE *subquery_as_attr_list, cubpl::pl_signature &sig)
 {
-  int save = 0;
+  int save;
   int error = NO_ERROR;
   char user_name_buffer [DB_MAX_USER_LENGTH + 1];
+  DB_OBJECT *mop_p = NULL;
 
   assert (node);
 
@@ -2087,7 +2088,7 @@ jsp_make_pl_signature (PARSER_CONTEXT *parser, PT_NODE *node, PT_NODE *subquery_
       }
     else
       {
-	DB_OBJECT *mop_p = jsp_find_stored_procedure (name, DB_AUTH_EXECUTE);
+	mop_p = jsp_find_stored_procedure (name, DB_AUTH_EXECUTE);
 	if (mop_p == NULL)
 	  {
 	    error = er_errid ();
@@ -2188,7 +2189,10 @@ jsp_make_pl_signature (PARSER_CONTEXT *parser, PT_NODE *node, PT_NODE *subquery_
   }
 
 exit:
-  AU_ENABLE (save);
+  if (mop_p != NULL)
+    {
+      AU_ENABLE (save);
+    }
   return error;
 }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25795

### Purpose

* QA 테스트 케이스 확인 중 발견된 문제입니다.

* save 변수를 초기화하지 않아 garbage 값으로 인해 AU_DISABLE 값이 true로 설정되는 문제로 오인했습니다.
* 핵심 문제는 AU_ENABLE과 AU_DISABLE 호출 간의 관계를 명확히 작성하는 것임을 확인하였으며, 이를 반영하여 수정했습니다.
  * AU_DISABLE 값이 true로 설정되면, 해당 세션에서 일반 사용자가 권한 검사를 우회하여 시스템 카탈로그 등 제한된 작업을 수행할 수 있게 됩니다.

### Implementation

N/A

### Remarks

N/A