### PR TITLE
[CBRD-25755] fix core dump with cte include sp

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -2211,6 +2211,24 @@ qexec_clear_agg_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl_p, AGGREGATE_TYP
   return pg_cnt;
 }
 
+static bool
+is_include_sp_in_cte (OUTPTR_LIST * plist)
+{
+  if (plist && plist->valptr_cnt > 0)
+    {
+      REGU_VARIABLE_LIST p;
+      for (p = plist->valptrp; p; p = p->next)
+	{
+	  if (p->value.type == TYPE_SP)
+	    {
+	      return true;
+	    }
+	}
+    }
+
+  return false;
+}
+
 /*
  * qexec_clear_xasl () -
  *   return: int
@@ -2652,11 +2670,14 @@ qexec_clear_xasl (THREAD_ENTRY * thread_p, xasl_node * xasl, bool is_final)
 	      XASL_SET_FLAG (xasl->proc.cte.non_recursive_part, XASL_DECACHE_CLONE);
 	      pg_cnt += qexec_clear_xasl (thread_p, xasl->proc.cte.non_recursive_part, is_final);
 	    }
-	  else if (!XASL_IS_FLAGED (xasl, XASL_DECACHE_CLONE)
-		   && xasl->proc.cte.non_recursive_part->status != XASL_INITIALIZED)
+	  else if (!XASL_IS_FLAGED (xasl, XASL_DECACHE_CLONE))
 	    {
-	      /* non_recursive_part not cleared yet. Set flag to clear the values allocated at unpacking. */
-	      pg_cnt += qexec_clear_xasl (thread_p, xasl->proc.cte.non_recursive_part, is_final);
+	      if ((xasl->proc.cte.non_recursive_part->status != XASL_INITIALIZED)
+		  || is_include_sp_in_cte (xasl->proc.cte.non_recursive_part->outptr_list))
+		{
+		  /* non_recursive_part not cleared yet. Set flag to clear the values allocated at unpacking. */
+		  pg_cnt += qexec_clear_xasl (thread_p, xasl->proc.cte.non_recursive_part, is_final);
+		}
 	    }
 	}
       if (xasl->proc.cte.recursive_part)
@@ -2672,11 +2693,14 @@ qexec_clear_xasl (THREAD_ENTRY * thread_p, xasl_node * xasl, bool is_final)
 	      XASL_SET_FLAG (xasl->proc.cte.recursive_part, XASL_DECACHE_CLONE);
 	      pg_cnt += qexec_clear_xasl (thread_p, xasl->proc.cte.recursive_part, is_final);
 	    }
-	  else if (!XASL_IS_FLAGED (xasl, XASL_DECACHE_CLONE)
-		   && xasl->proc.cte.recursive_part->status != XASL_INITIALIZED)
+	  else if (!XASL_IS_FLAGED (xasl, XASL_DECACHE_CLONE))
 	    {
-	      /* recursive_part not cleared yet. Set flag to clear the values allocated at unpacking. */
-	      pg_cnt += qexec_clear_xasl (thread_p, xasl->proc.cte.recursive_part, is_final);
+	      if ((xasl->proc.cte.recursive_part->status != XASL_INITIALIZED)
+		  || is_include_sp_in_cte (xasl->proc.cte.recursive_part->outptr_list))
+		{
+		  /* recursive_part not cleared yet. Set flag to clear the values allocated at unpacking. */
+		  pg_cnt += qexec_clear_xasl (thread_p, xasl->proc.cte.recursive_part, is_final);
+		}
 	    }
 	}
       if (xasl->list_id)

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -2212,7 +2212,7 @@ qexec_clear_agg_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl_p, AGGREGATE_TYP
 }
 
 static bool
-is_include_sp_in_cte (OUTPTR_LIST * plist)
+qexec_is_include_sp_in_cte (OUTPTR_LIST * plist)
 {
   if (plist && plist->valptr_cnt > 0)
     {
@@ -2673,7 +2673,7 @@ qexec_clear_xasl (THREAD_ENTRY * thread_p, xasl_node * xasl, bool is_final)
 	  else if (!XASL_IS_FLAGED (xasl, XASL_DECACHE_CLONE))
 	    {
 	      if ((xasl->proc.cte.non_recursive_part->status != XASL_INITIALIZED)
-		  || is_include_sp_in_cte (xasl->proc.cte.non_recursive_part->outptr_list))
+		  || qexec_is_include_sp_in_cte (xasl->proc.cte.non_recursive_part->outptr_list))
 		{
 		  /* non_recursive_part not cleared yet. Set flag to clear the values allocated at unpacking. */
 		  pg_cnt += qexec_clear_xasl (thread_p, xasl->proc.cte.non_recursive_part, is_final);
@@ -2696,7 +2696,7 @@ qexec_clear_xasl (THREAD_ENTRY * thread_p, xasl_node * xasl, bool is_final)
 	  else if (!XASL_IS_FLAGED (xasl, XASL_DECACHE_CLONE))
 	    {
 	      if ((xasl->proc.cte.recursive_part->status != XASL_INITIALIZED)
-		  || is_include_sp_in_cte (xasl->proc.cte.recursive_part->outptr_list))
+		  || qexec_is_include_sp_in_cte (xasl->proc.cte.recursive_part->outptr_list))
 		{
 		  /* recursive_part not cleared yet. Set flag to clear the values allocated at unpacking. */
 		  pg_cnt += qexec_clear_xasl (thread_p, xasl->proc.cte.recursive_part, is_final);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25755

* fix core dump 

- cte를 복수개 사용하는 경우 중간에 오류 발생시 생성된 메모리를 정리하지 못하는 이슈였음. 
  이때 문제가 되는 것은 앞쪽의 cte 구문 수행 중 오류로 이후 cte 구문이 수행되지 못한 상태로 있는 경우가 문제가 되는 것임.

case)
```
DROP TABLE IF EXISTS products;
CREATE TABLE products(id INTEGER PRIMARY KEY, parent_id INTEGER, item VARCHAR(100), price INTEGER);
INSERT INTO products VALUES (1, -1, 'Drone', 2000);
INSERT INTO products VALUES (2, 1, 'Blade', 10);


CREATE OR REPLACE FUNCTION test(i int) RETURN int as language java name 'TypeTest.testint(int) return int';
CREATE OR REPLACE FUNCTION test2(i int) RETURN int as language java name 'TypeTest.testint(int) return int';

WITH cte1 AS (SELECT test(id)  as id FROM products WHERE parent_id = 1),
	 cte2 AS (SELECT test2(id) as id FROM products WHERE parent_id = 2)
SELECT * FROM cte1;

```
