### PR TITLE
[CBRD-25781] Change error code, when occurring error of call()

### DIFF
--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -11026,6 +11026,7 @@ error:
 	{
 	  unpacker.unpack_all (error_code, error_msg);
 	  cubmethod::handle_method_error (error_code, error_msg);
+          req_error = error_code;
 	}
     }
 
@@ -11065,6 +11066,7 @@ error:
 	if (req_error != ER_SM_INVALID_METHOD_ENV)	/* FIXME: error possibly occured in builtin method, It should be handled at CAS */
 	  {
 	    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_EXECUTE_ERROR, 1, err_msg);
+            req_error = ER_SP_EXECUTE_ERROR;
 	  }
 
 	packer.set_buffer_and_pack_all (eb, er_errid (), err_msg);

--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -11026,7 +11026,7 @@ error:
 	{
 	  unpacker.unpack_all (error_code, error_msg);
 	  cubmethod::handle_method_error (error_code, error_msg);
-          req_error = error_code;
+	  req_error = error_code;
 	}
     }
 
@@ -11066,7 +11066,7 @@ error:
 	if (req_error != ER_SM_INVALID_METHOD_ENV)	/* FIXME: error possibly occured in builtin method, It should be handled at CAS */
 	  {
 	    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_EXECUTE_ERROR, 1, err_msg);
-            req_error = ER_SP_EXECUTE_ERROR;
+	    req_error = ER_SP_EXECUTE_ERROR;
 	  }
 
 	packer.set_buffer_and_pack_all (eb, er_errid (), err_msg);

--- a/src/method/method_error.cpp
+++ b/src/method/method_error.cpp
@@ -41,9 +41,13 @@ namespace cubmethod
       case ER_SP_CANNOT_CONNECT_JVM:
       case ER_SP_NETWORK_ERROR:
       case ER_OUT_OF_VIRTUAL_MEMORY:
-      case ER_SP_EXECUTE_ERROR:
 	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, err_id, 1, err_msg.c_str ());
 	break;
+
+      case ER_SP_EXECUTE_ERROR:
+	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_EXECUTE_ERROR, 1, err_msg.c_str ());
+	break;
+
       default:
 	/* do nothing */
 	break;

--- a/src/method/method_error.cpp
+++ b/src/method/method_error.cpp
@@ -41,11 +41,8 @@ namespace cubmethod
       case ER_SP_CANNOT_CONNECT_JVM:
       case ER_SP_NETWORK_ERROR:
       case ER_OUT_OF_VIRTUAL_MEMORY:
-	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, err_id, 1, err_msg.c_str ());
-	break;
-
       case ER_SP_EXECUTE_ERROR:
-	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_EXECUTE_ERROR, 1, err_msg.c_str ());
+	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, err_id, 1, err_msg.c_str ());
 	break;
 
       default:

--- a/src/method/method_error.cpp
+++ b/src/method/method_error.cpp
@@ -44,7 +44,6 @@ namespace cubmethod
       case ER_SP_EXECUTE_ERROR:
 	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, err_id, 1, err_msg.c_str ());
 	break;
-
       default:
 	/* do nothing */
 	break;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25781

- Same as the error code that occurs when executing select func(), the error code that occurs when executing call() is unified to -889 (ER_SP_EXECUTE_ERROR).
