### PR TITLE
[CBRD-25796] Prevent cub_pl startup failure due to fork() error and ensuring stable handling of abnormal situations

### DIFF
--- a/src/base/language_support.c
+++ b/src/base/language_support.c
@@ -2008,6 +2008,16 @@ lang_final (void)
 }
 
 /*
+ * lang_is_all_initialized - Checks if the all language support modules are initialized
+ *   return: true if the module has been initialized, false otherwise
+ */
+bool
+lang_is_all_initialized (void)
+{
+  return (lang_Initialized && lang_Builtin_initialized && lang_Charset_initialized && lang_Language_initialized && lang_Msg_env_initialized);
+}
+
+/*
  * lang_currency_symbol - Computes an appropriate printed representation for
  *                        a currency identifier
  *   return: currency string

--- a/src/base/language_support.c
+++ b/src/base/language_support.c
@@ -2014,7 +2014,8 @@ lang_final (void)
 bool
 lang_is_all_initialized (void)
 {
-  return (lang_Initialized && lang_Builtin_initialized && lang_Charset_initialized && lang_Language_initialized && lang_Msg_env_initialized);
+  return (lang_Initialized && lang_Builtin_initialized && lang_Charset_initialized && lang_Language_initialized
+	  && lang_Msg_env_initialized);
 }
 
 /*

--- a/src/base/language_support.h
+++ b/src/base/language_support.h
@@ -282,6 +282,7 @@ extern "C"
   extern int lang_set_charset (const INTL_CODESET codeset);
   extern int lang_set_language (const char *lang_str);
   extern void lang_final (void);
+  extern bool lang_is_all_initialized (void);
   extern int lang_locales_count (bool check_codeset);
   extern const char *lang_get_msg_Loc_name (void);
   extern const char *lang_get_Lang_name (void);

--- a/src/base/process_util.c
+++ b/src/base/process_util.c
@@ -39,6 +39,17 @@
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
 #include "memory_wrapper.hpp"
 
+/*
+ * create_child_process() - create a child process
+ *   return: process id of the child process, or 1 if failed
+ *   path(in): path to the executable
+ *   argv(in): arguments for the executable
+ *   wait_flag(in): flag to wait for the child process
+ *   stdin_file(in): file name for standard input
+ *   stdout_file(in): file name for standard output
+ *   stderr_file(in): file name for standard error
+ *   exit_status(out): exit status of the child process
+ */
 int
 create_child_process (const char *path, const char *const argv[], int wait_flag, const char *stdin_file,
 		      char *stdout_file, char *stderr_file, int *exit_status)

--- a/src/loaddb/load_sa_loader.cpp
+++ b/src/loaddb/load_sa_loader.cpp
@@ -6373,12 +6373,7 @@ ldr_sa_load (load_args *args, int *status, bool *interrupted)
       goto exit;
     }
 
-  if (pl_server_init (args->volume.c_str ()) != NO_ERROR)
-    {
-      goto exit;
-    }
-
-  if (pl_server_wait_for_ready () != NO_ERROR)
+  if (pl_server_init (args->volume.c_str ()) != NO_ERROR || pl_server_wait_for_ready () != NO_ERROR)
     {
       goto exit;
     }

--- a/src/loaddb/load_sa_loader.cpp
+++ b/src/loaddb/load_sa_loader.cpp
@@ -6368,9 +6368,20 @@ ldr_sa_load (load_args *args, int *status, bool *interrupted)
   ldr_init_driver ();
 
   locator_Dont_check_foreign_key = true;
-  ldr_init (args);
+  if (ldr_init (args) != NO_ERROR)
+    {
+      goto exit;
+    }
 
-  pl_server_init (args->volume.c_str ());
+  if (pl_server_init (args->volume.c_str ()) != NO_ERROR)
+    {
+      goto exit;
+    }
+
+  if (pl_server_wait_for_ready () != NO_ERROR)
+    {
+      goto exit;
+    }
 
   /* set the flag to indicate what type of interrupts to raise If logging has been disabled set commit flag. If
    * logging is enabled set abort flag. */
@@ -6541,6 +6552,8 @@ ldr_sa_load (load_args *args, int *status, bool *interrupted)
     {
       *status = 3;
     }
+
+exit:
 
   ldr_final ();
 

--- a/src/sp/pl_sr.cpp
+++ b/src/sp/pl_sr.cpp
@@ -632,11 +632,7 @@ pl_server_init (const char *db_name)
   pl_server_manager = new cubpl::server_manager (db_name);
   pl_server_manager->start ();
 
-#if defined (SA_MODE)
-  return pl_server_manager->wait_for_server_ready (); // wait until PL server ready at first
-#else
   return NO_ERROR;
-#endif
 }
 
 void

--- a/src/sp/pl_sr.cpp
+++ b/src/sp/pl_sr.cpp
@@ -103,7 +103,7 @@ namespace cubpl
       /*
       * get_pl_ctx_params() - get the PL context parameters
       */
-      SYSPRM_ASSIGN_VALUE *get_pl_ctx_params () const;
+      SYSPRM_ASSIGN_VALUE *get_pl_ctx_params ();
 
       /*
       * get_db_name () - get the database name
@@ -140,7 +140,9 @@ namespace cubpl
       {
 	SERVER_MONITOR_STATE_RUNNING,
 	SERVER_MONITOR_STATE_STOPPED,
-	SERVER_MONITOR_STATE_FAILED_TO_CONNECT,
+	SERVER_MONITOR_STATE_READY_TO_INITIALIZE,
+	SERVER_MONITOR_STATE_FAILED_TO_FORK,
+	SERVER_MONITOR_STATE_FAILED_TO_INITIALIZE,
 	SERVER_MONITOR_STATE_UNKNOWN
       };
 
@@ -168,7 +170,7 @@ namespace cubpl
       bool is_running () const;
 
     private:
-      void do_initialize ();
+      int do_initialize ();
 
       // check functions for PL server state
       void do_check_state (bool hang_check);
@@ -224,7 +226,6 @@ namespace cubpl
 #endif
     m_connection_pool = new connection_pool (server_manager::CONNECTION_POOL_SIZE, db_name);
 
-    m_pl_ctx_params = xsysprm_get_pl_context_parameters (PRM_ALL_FLAGS);
     assert (m_pl_ctx_params != nullptr);
   }
 
@@ -275,8 +276,13 @@ namespace cubpl
   }
 
   SYSPRM_ASSIGN_VALUE *
-  server_manager::get_pl_ctx_params () const
+  server_manager::get_pl_ctx_params ()
   {
+    if (m_pl_ctx_params)
+      {
+	/* late initialization */
+	m_pl_ctx_params = xsysprm_get_pl_context_parameters (PRM_ALL_FLAGS);
+      }
     return m_pl_ctx_params;
   }
 
@@ -333,20 +339,33 @@ namespace cubpl
   {
     (void) do_check_state (false);
 
-    if (m_state == SERVER_MONITOR_STATE_STOPPED)
+    if (m_state == SERVER_MONITOR_STATE_STOPPED || m_state == SERVER_MONITOR_STATE_FAILED_TO_FORK)
       {
 	int status;
 	int pid = create_child_process (m_executable_path.c_str (), m_argv, 0 /* do not wait */, nullptr, nullptr, nullptr,
 					&status);
-	if (pid <= 0)
-	  {
-	    // do nothing
-	  }
-	else // parent
+	if (pid > 1) // parent
 	  {
 	    m_pid = pid;
-	    do_initialize ();
+	    sleep (1);
+	    m_state = SERVER_MONITOR_STATE_READY_TO_INITIALIZE;
 	  }
+	else if (pid == 1) // fork error
+	  {
+	    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_CANNOT_FORK, 0);
+	    m_state = SERVER_MONITOR_STATE_FAILED_TO_FORK;
+	    m_failure_count++;
+	  }
+	else
+	  {
+	    // wait flag is not set, never reach here
+	    assert (false);
+	  }
+      }
+
+    if (m_state == SERVER_MONITOR_STATE_READY_TO_INITIALIZE && lang_is_all_initialized ())
+      {
+	do_initialize ();
       }
   }
 
@@ -355,7 +374,7 @@ namespace cubpl
   {
 #if defined (SERVER_MODE)
     auto pred = [this] () -> bool { return m_state == SERVER_MONITOR_STATE_RUNNING ||
-					   (!BO_IS_SERVER_RESTARTED () && m_state == SERVER_MONITOR_STATE_FAILED_TO_CONNECT);
+					   (!BO_IS_SERVER_RESTARTED () && m_state == SERVER_MONITOR_STATE_FAILED_TO_INITIALIZE);
 				  };
 #else
     auto pred = [this] () -> bool { return m_state == SERVER_MONITOR_STATE_RUNNING; };
@@ -371,7 +390,7 @@ namespace cubpl
     return m_state == SERVER_MONITOR_STATE_RUNNING;
   }
 
-  void
+  int
   server_monitor_task::do_initialize ()
   {
     int error = ER_FAILED;
@@ -392,7 +411,7 @@ namespace cubpl
 	    assert (m_sys_conn_pool);
 	    m_sys_conn_pool->set_port_disabled();
 
-	    (void) sleep (1);
+	    thread_sleep (1000);	/* 1000 msec */
 	  }
 	else
 	  {
@@ -423,6 +442,8 @@ namespace cubpl
     m_manager->get_connection_pool ()->increment_epoch ();
 
     m_monitor_cv.notify_all();
+
+    return error;
   }
 
   void
@@ -435,9 +456,10 @@ namespace cubpl
 	/* do nothing */
 	break;
       case SERVER_MONITOR_STATE_RUNNING:
+      case SERVER_MONITOR_STATE_READY_TO_INITIALIZE:
 	if (m_pid > 0 && !is_terminated_process (m_pid))
 	  {
-	    m_state = SERVER_MONITOR_STATE_RUNNING;
+	    // stay in the same state
 	  }
 	else
 	  {
@@ -445,8 +467,21 @@ namespace cubpl
 	  }
 	break;
 
+      case SERVER_MONITOR_STATE_FAILED_TO_FORK:
+      {
+	if (m_failure_count > 10)
+	  {
+	    // After several failed attempts, we should consider the PL server is not able to start
+	    m_state = SERVER_MONITOR_STATE_FAILED_TO_INITIALIZE;
+	    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_CANNOT_START_JVM, 1,
+		    "Failed to initialize the PL server. Verify that the server environment and configurations are properly set up");
+	    m_monitor_cv.notify_all ();
+	  }
+      }
+      break;
+
       case SERVER_MONITOR_STATE_UNKNOWN:
-      case SERVER_MONITOR_STATE_FAILED_TO_CONNECT:
+      case SERVER_MONITOR_STATE_FAILED_TO_INITIALIZE:
 	if (m_pid == -1 || (m_pid > 0 && is_terminated_process (m_pid)))
 	  {
 	    // PL server is terminated by user (cubrid pl restart)
@@ -459,7 +494,7 @@ namespace cubpl
 	    if (m_failure_count > 10)
 	      {
 		// After several failed attempts, we should consider the PL server is not able to start
-		m_state = SERVER_MONITOR_STATE_FAILED_TO_CONNECT;
+		m_state = SERVER_MONITOR_STATE_FAILED_TO_INITIALIZE;
 		er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_CANNOT_START_JVM, 1,
 			"Failed to initialize the PL server. Verify that the server environment and configurations are properly set up");
 		m_monitor_cv.notify_all ();
@@ -597,7 +632,11 @@ pl_server_init (const char *db_name)
   pl_server_manager = new cubpl::server_manager (db_name);
   pl_server_manager->start ();
 
+#if defined (SA_MODE)
   return pl_server_manager->wait_for_server_ready (); // wait until PL server ready at first
+#else
+  return NO_ERROR;
+#endif
 }
 
 void

--- a/src/sp/pl_sr.cpp
+++ b/src/sp/pl_sr.cpp
@@ -226,7 +226,7 @@ namespace cubpl
 #endif
     m_connection_pool = new connection_pool (server_manager::CONNECTION_POOL_SIZE, db_name);
 
-    assert (m_pl_ctx_params != nullptr);
+    m_pl_ctx_params = nullptr;
   }
 
   server_manager::~server_manager ()
@@ -278,7 +278,7 @@ namespace cubpl
   SYSPRM_ASSIGN_VALUE *
   server_manager::get_pl_ctx_params ()
   {
-    if (m_pl_ctx_params)
+    if (m_pl_ctx_params == nullptr)
       {
 	/* late initialization */
 	m_pl_ctx_params = xsysprm_get_pl_context_parameters (PRM_ALL_FLAGS);

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2073,8 +2073,6 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
   char timezone_checksum[32 + 1];
   const TZ_DATA *tzd;
   char *mk_path;
-  int pl_port;
-  bool pl;
 
   /* language data is loaded in context of server */
   if (lang_init () != NO_ERROR)
@@ -2313,6 +2311,12 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
       goto error;
     }
   /* *INDENT-ON* */
+
+  error_code = pl_server_init (db_name);
+  if (error_code != NO_ERROR)
+    {
+      goto error;
+    }
 
   pr_Enable_string_compression = prm_get_bool_value (PRM_ID_ENABLE_STRING_COMPRESSION);
 
@@ -2718,7 +2722,7 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
       goto error;
     }
 
-  error_code = pl_server_init (db_name);
+  error_code = pl_server_wait_for_ready ();
   if (error_code != NO_ERROR)
     {
       goto error;

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2312,6 +2312,23 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
     }
   /* *INDENT-ON* */
 
+  /*
+   * Call pl_server_init() before log_initialize() to avoid potential issues
+   * with large memory allocations impacting fork() system calls.
+   *
+   * Context:
+   * 1. During log_initialize(), large data buffer allocations might cause fork()
+   *    system call failures. To prevent this, pl_server_init() is invoked earlier.
+   *
+   * 2. In cases with large-scale databases such as those used for YCSB testing, 
+   *    the time taken by log_initialize() is nearly identical to the time taken 
+   *    to reach it via boot_start_server(). This suggests that other modules 
+   *    during server startup consume significant system resources, although the 
+   *    specifics are yet to be analyzed.
+   *
+   * 3. To enhance PL server initialization reliability, pl_server_init() is called 
+   *    before other modules’ initialization.
+   */
   error_code = pl_server_init (db_name);
   if (error_code != NO_ERROR)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25796

- pl_sr.cpp: fork() 실패 시 pid를 통한 프로세스 종료 루틴으로 SERVER_MONITOR_STATE_STOPPED 상태로 다시 돌아가 무한하게 재구동 요청하는 현상 해결, SERVER_MONITOR_STATE_FAILED_TO_FORK 상태 도입
- boot_sr.c: fork() 실패에 영향을 줄 수 있는 대량의 malloc을 요청하는 log_initialize () 이전에 PL 서버 구동을 시작하고, 모든 부팅 과정 이후에 PL 서버의 연결 상태를 체크하고 PL server bootstrap 을 수행할 수 있도록 수정
- PL server bootstrap 할 때 language support 모듈이 모두 초기화 되어 있어야 하므로, 모듈 초기화를 기다리도록 수정, 데몬 스레드가 1초마다 시작하므로, busy wait 처럼 보이나, 1초마다 lang_is_all_initialized () 를 통해 확인