### PR TITLE
[CBRD-25750] trivial: The same error message is shown twice in csql.err

### DIFF
--- a/src/sp/jsp_cl.cpp
+++ b/src/sp/jsp_cl.cpp
@@ -949,9 +949,7 @@ jsp_default_value_string (PARSER_CONTEXT *parser, PT_NODE *node, std::string &ou
 	      if (db_get_string_size (value) > 255)
 		{
 		  pt_reset_error (parser);
-		  PT_ERRORm (parser, default_value, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMATNIC_SP_PARAM_DEFAULT_STR_TOO_BIG);
-		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_PARAM_DEFAULT_STR_TOO_BIG, 0);
-		  return error;
+		  return ER_SP_PARAM_DEFAULT_STR_TOO_BIG;
 		}
 
 	      out.append (db_get_string (value));

--- a/src/sp/jsp_cl.cpp
+++ b/src/sp/jsp_cl.cpp
@@ -950,8 +950,7 @@ jsp_default_value_string (PARSER_CONTEXT *parser, PT_NODE *node, std::string &ou
 	{
 	  pt_reset_error (parser);
 	  PT_ERRORm (parser, default_value, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMATNIC_SP_PARAM_DEFAULT_STR_TOO_BIG);
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_PARAM_DEFAULT_STR_TOO_BIG, 0);
-	  return error;
+	  return ER_SP_PARAM_DEFAULT_STR_TOO_BIG;
 	}
 
       DB_VALUE *value = pt_value_to_db (parser, default_value);
@@ -1075,7 +1074,7 @@ jsp_create_stored_procedure (PARSER_CONTEXT *parser, PT_NODE *statement)
 	    }
 	  else
 	    {
-	      ASSERT_ERROR ();
+	      // MSGCAT_SEMANTIC_PREC_TOO_BIG
 	      goto error_exit;
 	    }
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25750

```
csql -u dba demodb
select 'error test, data overflow' from dual;
 create or replace procedure demo_default_value12 (
         a in varchar:= 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
) as
begin
     DBMS_OUTPUT.put_line(a);
 end;
```
```
tail -f csql.err
```

Expected
Only parser errors are shown (-492, -495)
```
ERROR CODE = -492
ERROR CODE = -495
```

Actual
```
ERROR CODE = -492
ERROR CODE = -495
ERROR CODE = -1366
```
