### PR TITLE
[CBRD-25804] [regression] Restrict to finding handlers by the same user in the Statement Handler Cache

### DIFF
--- a/src/method/method_callback.cpp
+++ b/src/method/method_callback.cpp
@@ -181,7 +181,8 @@ namespace cubmethod
     /* find in m_sql_handler_map */
     query_handler *handler = get_query_handler_by_sql (sql, [&] (query_handler *h)
     {
-      return h->get_is_occupied() == false && (h->get_tran_id () == NULL_TRANID || h->get_tran_id() == tid);
+      return h->get_is_occupied() == false && (h->get_tran_id () == NULL_TRANID || h->get_tran_id() == tid)
+	     && h->get_user_name ().compare (au_get_current_user_name ()) == 0;
     });
 
     if (handler == nullptr)

--- a/src/method/method_query_handler.cpp
+++ b/src/method/method_query_handler.cpp
@@ -20,6 +20,7 @@
 
 #include "parser.h"
 #include "api_compat.h" /* DB_SESSION */
+#include "authenticate.h"
 #include "db.h"
 #include "dbi.h"
 #include "dbtype.h"
@@ -37,6 +38,7 @@ namespace cubmethod
   query_handler::query_handler (error_context &ctx, int id)
     : m_id (id)
     , m_tid (NULL_TRANID)
+    , m_user ("")
     , m_error_ctx (ctx)
     , m_sql_stmt ()
     , m_stmt_type (CUBRID_STMT_NONE)
@@ -87,6 +89,12 @@ namespace cubmethod
   query_handler::get_id () const
   {
     return m_id;
+  }
+
+  std::string
+  query_handler::get_user_name () const
+  {
+    return m_user;
   }
 
   std::string
@@ -197,6 +205,7 @@ namespace cubmethod
 
     if (error == NO_ERROR)
       {
+	m_user = au_get_current_user_name ();
 	m_prepare_info.handle_id = get_id ();
 	m_prepare_info.stmt_type = m_query_result.stmt_type;
 	m_prepare_info.num_markers = get_num_markers ();

--- a/src/method/method_query_handler.hpp
+++ b/src/method/method_query_handler.hpp
@@ -94,6 +94,7 @@ namespace cubmethod
       int get_id () const;
       std::string get_sql_stmt () const;
       int get_statement_type () const;
+      std::string get_user_name () const;
 
       uint64_t get_query_id () const;
 
@@ -153,6 +154,9 @@ namespace cubmethod
     private:
       int m_id;
       TRANID m_tid;
+
+      /* user */
+      std::string m_user;
 
       /* error */
       error_context &m_error_ctx;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25804

