### PR TITLE
[CBRD-25806] Error handling is omitted for PT_FUNCTION in pt_bind_names()

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -3619,6 +3619,12 @@ pt_bind_names (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue
 			      pt_short_print (parser, node));
 		}
 	    }
+
+	  if (pt_has_error (parser))
+	    {
+	      node = NULL;
+	      *continue_walk = PT_STOP_WALK;
+	    }
 	}
       break;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25806