### PR TITLE
[CBRD-25750] slip: Missing parser semantic error setting for MSGCAT_SEMATNIC_SP_PARAM_DEFAULT_STR_TOO_BIG

### DIFF
--- a/src/sp/jsp_cl.cpp
+++ b/src/sp/jsp_cl.cpp
@@ -949,6 +949,7 @@ jsp_default_value_string (PARSER_CONTEXT *parser, PT_NODE *node, std::string &ou
 	      if (db_get_string_size (value) > 255)
 		{
 		  pt_reset_error (parser);
+		  PT_ERRORm (parser, default_value, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMATNIC_SP_PARAM_DEFAULT_STR_TOO_BIG);
 		  return ER_SP_PARAM_DEFAULT_STR_TOO_BIG;
 		}
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25750

