### PR TITLE
[CBRD-25658] Fix incorrect handling for empty string default value

### DIFF
--- a/src/sp/pl_signature.hpp
+++ b/src/sp/pl_signature.hpp
@@ -37,8 +37,8 @@ enum PL_TYPE
 
 enum PL_ARG_DEFAULT
 {
-  PL_ARG_DEFAULT_NONE = -1,
-  PL_ARG_DEFAULT_NULL = 0
+  PL_ARG_DEFAULT_NONE = -2,
+  PL_ARG_DEFAULT_NULL = -1
 };
 
 namespace cubpl


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25658
```
;server-output on

CREATE OR REPLACE PROCEDURE default_procedure_with_pseudo ( p_empty_string VARCHAR DEFAULT ''
) AS BEGIN
DBMS_OUTPUT.PUT_LINE('5: ' || p_empty_string);
END;

call  default_procedure_with_pseudo ();
```

Expected
```
  Result              
======================
  NULL                

<DBMS_OUTPUT>
====
5: 
```

Actual
```
  Result              
======================
  NULL                
```