### PR TITLE
[CBRD-25792] PL 서버의 상태를 확인하는 로직에서는 에러 로그를 쓰지 않도록 수정

### DIFF
--- a/src/sp/pl_comm.h
+++ b/src/sp/pl_comm.h
@@ -74,7 +74,7 @@ struct pl_status_info
 extern "C"
 {
 #endif
-  EXPORT_IMPORT SOCKET pl_connect_server (const char *db_name, int server_port);
+  EXPORT_IMPORT int pl_connect_server (const char *db_name, int server_port, SOCKET & out);
   EXPORT_IMPORT void pl_disconnect_server (SOCKET & sockfd);
   EXPORT_IMPORT int pl_writen (SOCKET fd, const void *vptr, int n);
   EXPORT_IMPORT int pl_readn (SOCKET fd, void *vptr, int n);

--- a/src/sp/pl_connection.cpp
+++ b/src/sp/pl_connection.cpp
@@ -402,6 +402,11 @@ namespace cubpl
       }
 
     int error = pl_connect_server (m_pool->get_db_name (), m_pool->get_db_port (), m_socket);
+    if (error != NO_ERROR && !m_pool->is_system_pool ())
+      {
+	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_CANNOT_CONNECT_JVM, 1, "connect()");
+      }
+
     if (m_socket != INVALID_SOCKET)
       {
 	m_epoch = m_pool->get_epoch ();

--- a/src/sp/pl_connection.cpp
+++ b/src/sp/pl_connection.cpp
@@ -401,7 +401,7 @@ namespace cubpl
 	pl_disconnect_server (m_socket);
       }
 
-    m_socket = pl_connect_server (m_pool->get_db_name (), m_pool->get_db_port ());
+    int error = pl_connect_server (m_pool->get_db_name (), m_pool->get_db_port (), m_socket);
     if (m_socket != INVALID_SOCKET)
       {
 	m_epoch = m_pool->get_epoch ();


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25792
