### PR TITLE
[CBRD-25813] Fix correct numeric storing method in system catalog

### DIFF
--- a/src/object/schema_system_catalog_install.cpp
+++ b/src/object/schema_system_catalog_install.cpp
@@ -944,13 +944,13 @@ namespace cubschema
       {
 	"current_val", format_numeric (DB_MAX_NUMERIC_PRECISION, 0), [] (DB_VALUE* val)
 	{
-	  return db_make_numeric (val, (DB_C_NUMERIC) "1", DB_MAX_NUMERIC_PRECISION, 0);
+	  return numeric_coerce_string_to_num ("1", 1, LANG_SYS_CODESET, val);
 	}
       },
       {
 	"increment_val", format_numeric (DB_MAX_NUMERIC_PRECISION, 0), [] (DB_VALUE* val)
 	{
-	  return db_make_numeric (val, (DB_C_NUMERIC) "1", DB_MAX_NUMERIC_PRECISION, 0);
+	  return numeric_coerce_string_to_num ("1", 1, LANG_SYS_CODESET, val);
 	}
       },
       {"max_val", format_numeric (DB_MAX_NUMERIC_PRECISION, 0)},


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25813


```
;sc db_serial
```

Expected
```
=== <Help: Schema of a Class> ===

...

  'current_val'         'NUMERIC(38,0)'       'NO'                  ''                    '1'  ''
  'increment_val'       'NUMERIC(38,0)'       'NO'                  ''                    '1'  ''

...
```

Actual
```
=== <Help: Schema of a Class> ===

...

  'current_val'         'NUMERIC(38,0)'       'NO'                  ''                    '65134451930272308853318581312987881333'  ''
  'increment_val'       'NUMERIC(38,0)'       'NO'                  ''                    '65134451930272308853318581312987881333'  ''

```
