### PR TITLE
[CBRD-25814] Fixed an issue where the AU_DISABLE value was set to true when a normal user's GRANT statement failed due to insufficient authorization.

### DIFF
--- a/src/object/authenticate_grant.cpp
+++ b/src/object/authenticate_grant.cpp
@@ -187,7 +187,7 @@ au_grant_class (MOP user, MOP class_mop, DB_AUTH type, bool grant_option)
 	  error = check_grant_option (class_mop, classobj, type);
 	  if (error != NO_ERROR)
 	    {
-	      return (error);
+	      goto fail_end;
 	    }
 	}
       else if (ws_is_same_object (classobj->owner, user))
@@ -198,7 +198,7 @@ au_grant_class (MOP user, MOP class_mop, DB_AUTH type, bool grant_option)
       else if ((error = au_compare_grantor_and_return (&grantor, class_mop, type, Au_user, classobj->owner,
 			NULL)) != NO_ERROR)
 	{
-	  return (error);
+	  goto fail_end;
 	}
       else
 	{
@@ -335,7 +335,7 @@ au_grant_procedure (MOP user, MOP obj_mop, DB_AUTH type, bool grant_option)
     {
       error = ER_AU_OWNER_ONLY_GRANT_PRIVILEGE;
       er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, error, 1, "EXECUTE");
-      return (error);
+      goto end;
     }
 
   if (ws_is_same_object (user, Au_user))
@@ -356,7 +356,7 @@ au_grant_procedure (MOP user, MOP obj_mop, DB_AUTH type, bool grant_option)
 	}
       else if ((error = au_compare_grantor_and_return (&grantor, obj_mop, type, Au_user, sp_owner, NULL)) != NO_ERROR)
 	{
-	  return (error);
+	  goto end;
 	}
       else
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25814

Purpose
QA 테스트 케이스 확인 중 발견된 문제입니다.

GRANT 구문 실행 시 권한 부족으로 실패할 경우, 에러를 반환하면서 AU_ENABLE 값으로 되돌리지 않아 AU_DISABLE 값이 true로 설정되는 문제를 해결했습니다.

Implementation
N/A

Remarks
N/A