### PR TITLE
[CBRD-25810] preliminary refactoring

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/StmtForCursorLoop.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/StmtForCursorLoop.java
@@ -34,13 +34,15 @@ import com.cubrid.plcsql.compiler.type.TypeRecord;
 import com.cubrid.plcsql.compiler.visitor.AstVisitor;
 import org.antlr.v4.runtime.ParserRuleContext;
 
-public class StmtForCursorLoop extends StmtCursorOpen {
+public class StmtForCursorLoop extends Stmt {
 
     @Override
     public <R> R accept(AstVisitor<R> visitor) {
         return visitor.visitStmtForCursorLoop(this);
     }
 
+    public final ExprId cursor;
+    public final NodeList<Expr> cursorArgs;
     public final String label;
     public final String record;
     public final TypeRecord recordType;
@@ -49,16 +51,19 @@ public class StmtForCursorLoop extends StmtCursorOpen {
     public StmtForCursorLoop(
             ParserRuleContext ctx,
             ExprId cursor,
-            NodeList<Expr> args,
+            NodeList<Expr> cursorArgs,
             String label,
             String record,
             TypeRecord recordType,
             NodeList<Stmt> stmts) {
 
-        super(ctx, cursor, args);
+        super(ctx);
 
-        assert args != null;
+        assert cursor.decl instanceof DeclCursor;
+        assert cursorArgs != null;
 
+        this.cursor = cursor;
+        this.cursorArgs = cursorArgs;
         this.label = label;
         this.record = record;
         this.recordType = recordType;

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -1385,7 +1385,8 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
 
             Object dupCursorArgs = getDupCursorArgs(node.args, decl.paramRefCounts);
             CodeTemplateList hostExprs =
-                    getHostExprs(node.cursor, node.args, decl.paramNumOfHostExpr, decl.paramRefCounts);
+                    getHostExprs(
+                            node.cursor, node.args, decl.paramNumOfHostExpr, decl.paramRefCounts);
 
             return new CodeTemplate(
                     "StmtCursorOpen",
@@ -1664,7 +1665,11 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
 
             Object dupCursorArgs = getDupCursorArgs(node.cursorArgs, decl.paramRefCounts);
             CodeTemplateList hostExprs =
-                    getHostExprs(node.cursor, node.cursorArgs, decl.paramNumOfHostExpr, decl.paramRefCounts);
+                    getHostExprs(
+                            node.cursor,
+                            node.cursorArgs,
+                            decl.paramNumOfHostExpr,
+                            decl.paramRefCounts);
 
             return new CodeTemplate(
                     "StmtForCursorLoop",

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -1383,9 +1383,9 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                     node.cursor.javaCode());
         } else {
 
-            Object dupCursorArgs = getDupCursorArgs(node, decl.paramRefCounts);
+            Object dupCursorArgs = getDupCursorArgs(node.args, decl.paramRefCounts);
             CodeTemplateList hostExprs =
-                    getHostExprs(node, decl.paramNumOfHostExpr, decl.paramRefCounts);
+                    getHostExprs(node.cursor, node.args, decl.paramNumOfHostExpr, decl.paramRefCounts);
 
             return new CodeTemplate(
                     "StmtCursorOpen",
@@ -1662,9 +1662,9 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                     visitNodeList(node.stmts));
         } else {
 
-            Object dupCursorArgs = getDupCursorArgs(node, decl.paramRefCounts);
+            Object dupCursorArgs = getDupCursorArgs(node.cursorArgs, decl.paramRefCounts);
             CodeTemplateList hostExprs =
-                    getHostExprs(node, decl.paramNumOfHostExpr, decl.paramRefCounts);
+                    getHostExprs(node.cursor, node.cursorArgs, decl.paramNumOfHostExpr, decl.paramRefCounts);
 
             return new CodeTemplate(
                     "StmtForCursorLoop",
@@ -2392,7 +2392,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
     private static String[] tmplDupCursorArg =
             new String[] {"Object a%'INDEX'%_%'LEVEL'% =", "  %'+ARG'%;"};
 
-    private Object getDupCursorArgs(StmtCursorOpen node, int[] paramRefCounts) {
+    private Object getDupCursorArgs(NodeList<Expr> args, int[] paramRefCounts) {
 
         CodeTemplateList ret = new CodeTemplateList();
 
@@ -2401,7 +2401,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
 
             if (paramRefCounts[i] > 1) {
 
-                Expr arg = node.args.nodes.get(i);
+                Expr arg = args.nodes.get(i);
                 ret.addElement(
                         new CodeTemplate(
                                 "duplicate cursor argument",
@@ -2418,12 +2418,12 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
     }
 
     public CodeTemplateList getHostExprs(
-            StmtCursorOpen node, int[] paramNumOfHostExpr, int[] paramRefCounts) {
+            ExprId cursor, NodeList<Expr> args, int[] paramNumOfHostExpr, int[] paramRefCounts) {
 
         int size = paramNumOfHostExpr.length;
         assert size > 0;
 
-        DeclCursor decl = (DeclCursor) node.cursor.decl;
+        DeclCursor decl = (DeclCursor) cursor.decl;
         ArrayList<Expr> hostExprs = new ArrayList<>(decl.staticSql.hostExprs.keySet());
         assert size == hostExprs.size();
 
@@ -2442,7 +2442,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                                     "a" + k + "_%'LEVEL'%"));
                 } else {
                     assert paramRefCounts[k] == 1;
-                    ret.addElement((CodeTemplate) visit(node.args.nodes.get(k)));
+                    ret.addElement((CodeTemplate) visit(args.nodes.get(k)));
                 }
             } else {
                 Expr e = hostExprs.get(i);

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
@@ -920,8 +920,7 @@ public class TypeChecker extends AstVisitor<Type> {
             if (c == null) {
                 throw new SemanticError(
                         Misc.getLineColumnOf(arg.ctx), // s219
-                        String.format(
-                                "argument %d to the cursor has an incompatible type", i + 1));
+                        String.format("argument %d to the cursor has an incompatible type", i + 1));
             } else {
                 arg.setCoercion(c);
             }
@@ -932,7 +931,7 @@ public class TypeChecker extends AstVisitor<Type> {
     public Type visitStmtCursorOpen(StmtCursorOpen node) {
         Type idType = visit(node.cursor);
         if (idType == Type.CURSOR) {
-            checkCursorArgs(node.cursor, node.args);    // s219
+            checkCursorArgs(node.cursor, node.args); // s219
         } else {
             assert false : "unreachable"; // by earlier check
             throw new RuntimeException("unreachable");
@@ -1039,7 +1038,7 @@ public class TypeChecker extends AstVisitor<Type> {
 
         Type idType = visit(node.cursor);
         if (idType == Type.CURSOR) {
-            checkCursorArgs(node.cursor, node.cursorArgs);    // s240
+            checkCursorArgs(node.cursor, node.cursorArgs); // s240
         } else {
             assert false : "unreachable"; // by earlier check
             throw new RuntimeException("unreachable");

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
@@ -907,27 +907,32 @@ public class TypeChecker extends AstVisitor<Type> {
         return null;
     }
 
+    private void checkCursorArgs(ExprId cursor, NodeList<Expr> args) {
+
+        DeclCursor declCursor = (DeclCursor) cursor.decl;
+        int len = args.nodes.size();
+        for (int i = 0; i < len; i++) {
+            Expr arg = args.nodes.get(i);
+            Type argType = visit(arg);
+            Type paramType = declCursor.paramList.nodes.get(i).typeSpec().type;
+            assert paramType != null;
+            Coercion c = Coercion.getCoercion(iStore, argType, paramType);
+            if (c == null) {
+                throw new SemanticError(
+                        Misc.getLineColumnOf(arg.ctx), // s219
+                        String.format(
+                                "argument %d to the cursor has an incompatible type", i + 1));
+            } else {
+                arg.setCoercion(c);
+            }
+        }
+    }
+
     @Override
     public Type visitStmtCursorOpen(StmtCursorOpen node) {
         Type idType = visit(node.cursor);
         if (idType == Type.CURSOR) {
-            DeclCursor declCursor = (DeclCursor) node.cursor.decl;
-            int len = node.args.nodes.size();
-            for (int i = 0; i < len; i++) {
-                Expr arg = node.args.nodes.get(i);
-                Type argType = visit(arg);
-                Type paramType = declCursor.paramList.nodes.get(i).typeSpec().type;
-                assert paramType != null;
-                Coercion c = Coercion.getCoercion(iStore, argType, paramType);
-                if (c == null) {
-                    throw new SemanticError(
-                            Misc.getLineColumnOf(arg.ctx), // s219
-                            String.format(
-                                    "argument %d to the cursor has an incompatible type", i + 1));
-                } else {
-                    arg.setCoercion(c);
-                }
-            }
+            checkCursorArgs(node.cursor, node.args);    // s219
         } else {
             assert false : "unreachable"; // by earlier check
             throw new RuntimeException("unreachable");
@@ -1031,8 +1036,17 @@ public class TypeChecker extends AstVisitor<Type> {
 
     @Override
     public Type visitStmtForCursorLoop(StmtForCursorLoop node) {
-        visitStmtCursorOpen(node); // StmtForCursorLoop extends StmtCursorOpen
+
+        Type idType = visit(node.cursor);
+        if (idType == Type.CURSOR) {
+            checkCursorArgs(node.cursor, node.cursorArgs);    // s240
+        } else {
+            assert false : "unreachable"; // by earlier check
+            throw new RuntimeException("unreachable");
+        }
+
         visitNodeList(node.stmts);
+
         return null;
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25810

본 구현을 하기 위해 필요한 간단한 리팩토링 입니다. 
StmtForCursorLoop 의 부모 클래스를 StmtLoop 으로 만들기 위해 기존의 부모 StmtCursorLoop 으로부터 떼어내는 작업입니다. 

