### PR TITLE
[CUBVEC-28] Vector DB 기능 구현 결과 검증을 위해 Circle CI의 cubrid-testcases 브랜치 설정: cubvec/cubvec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ test_defaults: &test_defaults
         shell: /bin/bash
         environment:
           _JAVA_OPTIONS: -Xmx1g
+          BRANCH_TESTCASES: cubvec/cubvec
         command: |
           ulimit -c 1
           /entrypoint.sh checkout


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-28

Implementation
- environment 설정으로 Circle CI가 cubrid-testcases:cubvec/cubvec의 테스트 케이스를 수행할 수 있도록 변경
