### PR TITLE
[CBRD-25821] Problems that occur when the location of a node in a subquery is unnecessary modified.

### DIFF
--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -7307,6 +7307,8 @@ mq_mark_location (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *conti
 {
   short *locp = (short *) arg;
 
+  *continue_walk = PT_CONTINUE_WALK;
+
   if (!locp && node->node_type == PT_SELECT)
     {
       short location = 0;
@@ -7354,6 +7356,11 @@ mq_mark_location (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *conti
 		}
 	    }
 	}
+    }
+  else if (node->node_type == PT_SELECT)
+    {
+      /* don't walk into subqueries */
+      *continue_walk = PT_LIST_WALK;
     }
   else if (locp)
     {
@@ -7652,7 +7659,8 @@ mq_translate_helper (PARSER_CONTEXT * parser, PT_NODE * node)
 
       mq_bump_order_dep_corr_lvl (parser, node);
 
-      node = parser_walk_tree (parser, node, mq_mark_location, NULL, mq_check_non_updatable_vclass_oid, &strict);
+      node = parser_walk_tree (parser, node, mq_mark_location, NULL, NULL, NULL);
+      node = parser_walk_tree (parser, node, NULL, NULL, mq_check_non_updatable_vclass_oid, &strict);
 
       if (pt_has_error (parser))
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25821

During the rewriting process, the location is reassigned through the mq_mark_location() function. At this time, the node in the subquery was set incorrectly. fix so that it does not walk into subqueries.
