### PR TITLE
[CBRD-25781] slip: For er_set(), std::string.c_str () should be used

### DIFF
--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -11065,7 +11065,7 @@ error:
 
 	if (req_error != ER_SM_INVALID_METHOD_ENV)	/* FIXME: error possibly occured in builtin method, It should be handled at CAS */
 	  {
-	    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_EXECUTE_ERROR, 1, err_msg);
+	    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_EXECUTE_ERROR, 1, err_msg.c_str ());
 	    req_error = ER_SP_EXECUTE_ERROR;
 	  }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25781

