### PR TITLE
[CBRD-25822] SP Function의 NUMERIC 리턴 타입 precision, scale을 특정 값으로 고정

### DIFF
--- a/src/compat/dbtype_def.h
+++ b/src/compat/dbtype_def.h
@@ -581,9 +581,9 @@ extern "C"
 /* This constant indicates that the system defined default for scale is to be used for a DB_VALUE. */
 #define DB_DEFAULT_SCALE -1
 
-/* This constant indecates that NUMERIC(*,*) means NUMERIC(any,any) */
-#define DB_NUMERIC_PRECISION_ANY 0
-#define DB_NUMERIC_SCALE_ANY 0
+/* This constant indecates that SP function's default NUMERIC domain */
+#define DB_NUMERIC_PRECISION_SP 38
+#define DB_NUMERIC_SCALE_SP 15
 
 /* This constant defines the default precision of DB_TYPE_NUMERIC. */
 #define DB_DEFAULT_NUMERIC_PRECISION 15

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -2463,6 +2463,7 @@ struct pt_expr_info
 #define PT_EXPR_INFO_DO_NOT_AUTOPARAM 65536	/* don't auto parameterize expr at qo_do_auto_parameterize() */
 #define PT_EXPR_INFO_CAST_WRAP 	131072	/* 0x20000, CAST is wrapped by compiling */
 #define PT_EXPR_INFO_ROWNUM_ONLY 262144	/* 0x40000, rownum only predicate */
+#define PT_EXPR_INFO_SP_NUMERIC 524288	/* 0x80000, CAST as NUMERIC for SP */
   int flag;			/* flags */
 #define PT_EXPR_INFO_IS_FLAGED(e, f)    ((e)->info.expr.flag & (int) (f))
 #define PT_EXPR_INFO_SET_FLAG(e, f)     (e)->info.expr.flag |= (int) (f)

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -7916,6 +7916,21 @@ pt_eval_type (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_
 
     case PT_METHOD_CALL:
       node = pt_eval_method_call_type (parser, node);
+
+      /* set CAST as NUMERIC(any,any) for NUMERIC type SP function */
+      if (node->info.method_call.method_type == PT_SP_FUNCTION
+	  && !PT_EXPR_INFO_IS_FLAGED (node, PT_EXPR_INFO_SP_NUMERIC) && node->type_enum == PT_TYPE_NUMERIC)
+	{
+	  PT_EXPR_INFO_SET_FLAG (node, PT_EXPR_INFO_SP_NUMERIC);
+	  node =
+	    pt_wrap_with_cast_op (parser, node, PT_TYPE_NUMERIC, DB_NUMERIC_PRECISION_SP, DB_NUMERIC_SCALE_SP, NULL);
+	  if (node == NULL)
+	    {
+	      assert (false);
+	      PT_INTERNAL_ERROR (parser, "pt_eval_type");
+	      return NULL;
+	    }
+	}
       break;
 
     case PT_CREATE_INDEX:

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -6697,8 +6697,8 @@ pt_stored_procedure_to_regu (PARSER_CONTEXT * parser, PT_NODE * node)
        * TO DO: We need to define a separate type for numeric(any,any) in the future.
        */
       regu->domain = pt_node_to_db_domain (parser, node, NULL);
-      regu->domain->precision = DB_NUMERIC_PRECISION_ANY;
-      regu->domain->scale = DB_NUMERIC_SCALE_ANY;
+      regu->domain->precision = DB_NUMERIC_PRECISION_SP;
+      regu->domain->scale = DB_NUMERIC_SCALE_SP;
     }
 
   return regu;

--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -6523,16 +6523,6 @@ qdata_get_dbval_from_constant_regu_variable (THREAD_ENTRY * thread_p, REGU_VARIA
 		  /* do not cast at here, is handled at analytic function evaluation later */
 		  ;
 		}
-	      else if (regu_var_p->type == TYPE_SP && val_type == DB_TYPE_NUMERIC)
-		{
-		  /*
-		   * When returning from SP as a Numeric type,
-		   * we must set the precision and scale of the actual returned value.
-		   * Otherwise, the decimal points will be truncated.
-		   */
-		  regu_var_p->domain->precision = peek_value_p->domain.numeric_info.precision;
-		  regu_var_p->domain->scale = peek_value_p->domain.numeric_info.scale;
-		}
 	      else
 		{
 		  if (REGU_VARIABLE_IS_FLAGED (regu_var_p, REGU_VARIABLE_CLEAR_AT_CLONE_DECACHE))


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25822

SP Function에서 NUMERIC을 리턴할 때, precision과 scale정보가 없어서 하나의 쿼리를 통해 SP의 결과가 precision과 scale에 변동이 발생하면 이를 반영할 수가 없습니다. 즉, VARCHAR 타입처럼 precision이 variable하게 동작할 수 없으므로 NUMERIC (any, any) 타입을 새로 추가를 하거나 VARNUM과 같은 타입을 구현해야 합니다.

**일단 NUMERIC(any,any)나 VARNUM 타입을 구현하기에 앞서 SP가 return하는 NUMERIC 타입의 precision과 scale 정보를 38, 15로 고정해서 처리합니다.**

추후 SYSTEM PARAM에서 default precision과 scale 값은 변동이 될 수도 있습니다.

이 이슈는 아래의 이슈로부터 파생되었습니다.
http://jira.cubrid.org/browse/CBRD-25690