### PR TITLE
[CBRD-25826] Improve astyle compatibility: -j option for brackets

### DIFF
--- a/.github/workflows/codestyle.sh
+++ b/.github/workflows/codestyle.sh
@@ -25,7 +25,7 @@ case $ext in
   indent -l120 -lc120 ${f}
 ;;
 .cpp|.hpp|.ipp)
-  astyle --style=gnu --mode=c --indent-namespaces --indent=spaces=2 -xT8 -xt4 --add-brackets --max-code-length=120 --align-pointer=name --indent-classes --pad-header --pad-first-paren-out ${f}
+  astyle --style=gnu --mode=c --indent-namespaces --indent=spaces=2 -xT8 -xt4 -j --max-code-length=120 --align-pointer=name --indent-classes --pad-header --pad-first-paren-out ${f}
 ;;
 .java)
   java -jar .github/workflows/google-java-format-1.7-all-deps.jar -a -r ${f}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25826

## Purpose

code-style.sh의 astyle 명령어에서 버전 호환성 개선을 위해 `--add-brackets` 옵션을 `-j`로 변경합니다.

- 최근 astyle이 2.0에서 3.0으로 버전업되면서, **`--add-brackets` 옵션이 `--add-braces`로 변경되었습니다**
- `-j`는 두 옵션의 약어로서 모든 버전의 astyle에서 동작합니다
- 이 변경으로 기존 기능을 유지하면서 이전 버전과 새로운 버전 모두에서 호환성을 확보할 수 있습니다

### Implementation
```diff
- astyle --style=gnu --mode=c --indent-namespaces --indent=spaces=2 -xT8 -xt4 --add-brackets --max-code-length=120 --align-pointer=name --indent-classes --pad-header --pad-first-paren-out ${f}
+ astyle --style=gnu --mode=c --indent-namespaces --indent=spaces=2 -xT8 -xt4 -j --max-code-length=120 --align-pointer=name --indent-classes --pad-header --pad-first-paren-out ${f}
```

### Remarks

다른 프로젝트에서도 유사한 변경이 있었습니다. 
- https://review-1.gerrithub.io/c/spdk/spdk/+/391477
- https://github.com/ARMmbed/mbed-os/blob/master/.astylerc