### PR TITLE
[CBRD-25823] bugfix: move lexer error check to the right position

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/PlcsqlCompilerMain.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/PlcsqlCompilerMain.java
@@ -94,19 +94,15 @@ public class PlcsqlCompilerMain {
 
         PlcLexerEx lexer = new PlcLexerEx(input);
 
-        LexerErrorIndicator lei = new LexerErrorIndicator();
-        lexer.removeErrorListeners();
+        SyntaxErrorIndicator lei = new SyntaxErrorIndicator();
+        lexer.removeErrorListeners(); // This removes unwanted console output
         lexer.addErrorListener(lei);
-
-        if (lei.hasError) {
-            throw new SyntaxError(lei.line, lei.column, lei.msg);
-        }
 
         CommonTokenStream tokens = new CommonTokenStream(lexer);
         PlcParser parser = new PlcParser(tokens);
 
         SyntaxErrorIndicator sei = new SyntaxErrorIndicator();
-        parser.removeErrorListeners();
+        parser.removeErrorListeners(); // This removes unwanted console output
         parser.addErrorListener(sei);
 
         if (verbose) {
@@ -119,6 +115,9 @@ public class PlcsqlCompilerMain {
             logElapsedTime(logStore, "  calling parser", t0);
         }
 
+        if (lei.hasError) {
+            throw new SyntaxError(lei.line, lei.column, lei.msg);
+        }
         if (sei.hasError) {
             throw new SyntaxError(sei.line, sei.column, sei.msg);
         }
@@ -248,31 +247,6 @@ public class PlcsqlCompilerMain {
                         unit.getClassName(),
                         javaSig);
         return info;
-    }
-
-    private static class LexerErrorIndicator extends BaseErrorListener {
-
-        boolean hasError;
-        int line;
-        int column;
-        String msg;
-
-        @Override
-        public void syntaxError(
-                Recognizer<?, ?> recognizer,
-                Object offendingSymbol,
-                int line,
-                int charPositionInLine,
-                String msg,
-                RecognitionException e) {
-
-            if (msg.startsWith("token recognition error")) {
-                this.hasError = true;
-                this.line = line;
-                this.column = charPositionInLine + 1; // charPositionInLine starts from 0
-                this.msg = msg;
-            }
-        }
     }
 
     private static class SyntaxErrorIndicator extends BaseErrorListener {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25823

- lexer 규칙에 의해 match 되지 않는 문자열에 대한 검사가 잘못된 위치에서 이루어지고 있어서 수정했습니다.
  "ParseTree ret = parser.sql_script();" 라인 후에 (파싱이 수행된 다음에) 검사가 이루어져야 합니다. 
  수정 전에는 match 되지 않는 문자열이 있어도 (lexer 에러가 있어도) 리포트되지 않고 '조용히' 무시하는 문제가 있었습니다. 
- 불필요한 LexerErrorListener 를 삭제했습니다. 
