### PR TITLE
[CBRD-25801] Problems that occur when a hidden column is generated due to ORDER BY clause in a subquery

### DIFF
--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -1459,6 +1459,7 @@ mq_remove_select_list_for_inline_view (PARSER_CONTEXT * parser, PT_NODE * statem
   PT_NODE *query_spec_columns, *tmp_query, *save_order_by, *save_select_list;
   PT_NODE *attributes, *attr, *as_attr_list;
   PT_NODE *col, *new_select_list, *spec, *pred, *subquery;
+  bool is_unset_hidden_col;
 
   assert (PT_IS_SELECT (statement));
   if (derived_spec == NULL || !PT_SPEC_IS_DERIVED (derived_spec))
@@ -1569,6 +1570,27 @@ mq_remove_select_list_for_inline_view (PARSER_CONTEXT * parser, PT_NODE * statem
       if (tmp_query == NULL)
 	{
 	  goto exit_on_error;
+	}
+    }
+
+  /* check whether to unset hidden col. If no hidden column in original, remove hidden settings */
+  is_unset_hidden_col = true;
+  for (col = subquery->info.query.q.select.list; col; col = col->next)
+    {
+      if (col->flag.is_hidden_column)
+	{
+	  is_unset_hidden_col = false;
+	  break;
+	}
+    }
+  if (is_unset_hidden_col)
+    {
+      for (col = tmp_query->info.query.q.select.list; col; col = col->next)
+	{
+	  if (col->flag.is_hidden_column)
+	    {
+	      col->flag.is_hidden_column = 0;
+	    }
 	}
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25801

In CBRD-24181, when optimizing the select list of a subquery, a column in ORDER BY is added. At that time, a hidden column property is added, and the query that has already been rewritten in qo_rewrite_hidden_col_as_derived() is unnessarary rewritten twice, causing an issue. Fix to remove the hidden property if the existing select list does not have it.

backport #5780