### PR TITLE
[CBRD-25831] Add Nix flake for reproducible development environments

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,42 @@
+{
+  description = "CUBRID development environment flake";
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs-old = {
+      url = "github:nixos/nixpkgs/0bcbb978795bab0f1a45accc211b8b0e349f1cdb";
+      flake = false; # Add this line because the old repo doesn't have flake.nix
+    };
+  };
+
+  outputs = { self, nixpkgs, nixpkgs-old }:
+    let
+      supportedSystems = [ "x86_64-linux" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+      nixpkgsOldFor =
+        forAllSystems (system: import nixpkgs-old { inherit system; });
+    in {
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor.${system};
+          pkgsOld = nixpkgsOldFor.${system};
+        in {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              flex
+              pkgsOld.bison # This will be version 3.0.5
+              ncurses
+              cmake
+              ninja
+              binutils
+              ccache
+              gcc13
+              direnv
+              git
+              elfutils
+              libsystemtap
+            ];
+          };
+        });
+    };
+}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25831

## Purpose

# Nix flake를 통한 재현 가능한 개발 환경 지원 추가

![image](https://github.com/user-attachments/assets/c35d1732-ef24-4675-a498-3465a36b0d7b)

https://www.youtube.com/watch?v=FJVFXsNzYZQ


개발자들이 서로 다른 시스템에서도 일관된, 재현 가능한 개발 환경을 사용할 수 있도록 Nix Flakes 지원을 추가합니다. 이를 통해 "내 환경에서는 잘 되는데" 문제를 해결하고 새로운 개발자들의 환경 설정 과정을 단순화합니다.

## 장점
- 서로 다른 환경에서도 재현 가능한 빌드
- 선언적인 개발 환경 구성
- 자동화된 의존성 관리
- 모든 개발자가 동일한 도구 버전 사용
- 격리된 빌드 환경

## 사용 방법

### 1. Nix 패키지 매니저 설치
```bash
sh <(curl -L https://nixos.org/nix/install) --no-daemon # multi-user server를 위한 daemon 방식도 있음
```
대략 5분 소요

### 2. Nix Flakes 활성화
`~/.config/nix/nix.conf` 또는 `/etc/nix/nix.conf`에 다음을 추가:
```
experimental-features = nix-command flakes
```

### 3. 개발 환경 진입
CUBRID 소스 디렉토리에서:
```bash
nix develop
```
첫 시도 시 대략 1분 소요될 수 있음.
두번째 시도부터 3초 안에 진입

### 4. CUBRID 빌드
```bash
./build.sh -m debug build
```

## Implementation
- 개발 환경을 정의하는 `flake.nix` 추가
- 필요한 모든 빌드 의존성과 도구 포함
- NixOS와 다른 Linux 배포판 모두 지원

### 테스트
- 깨끗한 Nix 환경에서 빌드 프로세스 검증
- 재현성 확인을 위해 여러 시스템에서 테스트
- debug와 release 구성 모두 성공적으로 빌드

## Remarks
- 기존 빌드 방식도 계속 사용 가능
- 기존 빌드에 전혀 영향을 주지 않음