### PR TITLE
[CBRD-25830] disallow a floating point number literal of the form '<integer> .' 

### DIFF
--- a/pl_engine/pl_server/src/main/antlr/PlcLexer.g4
+++ b/pl_engine/pl_server/src/main/antlr/PlcLexer.g4
@@ -267,7 +267,7 @@ SS_NON_STR:     ~( ';' | '\'' | ' ' | '\t' | '\r' | '\n' | '(' | ')' )+ {
 // Fragment rules
 // ************************
 
-fragment FPNUM_W_POINT  : (BASIC_UINT? '.' [0-9]+ | BASIC_UINT '.') ([eE] ('+'|'-')? BASIC_UINT)? [fF]?;
+fragment FPNUM_W_POINT  : (BASIC_UINT? '.' [0-9]+) ([eE] ('+'|'-')? BASIC_UINT)? [fF]?;
 fragment FPNUM_WO_POINT : BASIC_UINT [eE] ('+'|'-')? BASIC_UINT [fF]?;
 fragment BASIC_UINT     : '0'|[1-9][0-9]*;
 fragment NEWLINE_EOF    : NEWLINE | EOF;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25830

문제 해결을 위해 소수 리터럴 정규표현식을 수정했습니다. 
