### PR TITLE
[CBRD-25650] use a line comment instead of a block comment for the dummy SP definition in schema files of unload

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -4542,9 +4542,8 @@ emit_stored_procedure_pre (extract_context & ctxt, print_output & output_ctx)
 	{
 	  output_ctx ("AS LANGUAGE PLCSQL BEGIN ");
 	  output_ctx
-	    ("RAISE_APPLICATION_ERROR(1000, '%s%s%s%s: incomplete during loaddb'); /* __CUBRID_NO_BODY__ */",
+	    ("RAISE_APPLICATION_ERROR(1001, '%s%s%s%s: incomplete during loaddb'); END; -- __CUBRID_NO_BODY__\n",
 	     output_owner, PRINT_IDENTIFIER (sp_name));
-	  output_ctx (" END;\n");
 	}
       else
 	{

--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -4542,8 +4542,9 @@ emit_stored_procedure_pre (extract_context & ctxt, print_output & output_ctx)
 	{
 	  output_ctx ("AS LANGUAGE PLCSQL BEGIN ");
 	  output_ctx
-	    ("RAISE_APPLICATION_ERROR(1001, '%s%s%s%s: incomplete during loaddb'); END; -- __CUBRID_NO_BODY__\n",
+	    ("RAISE_APPLICATION_ERROR(1001, '%s%s%s%s: incomplete during loaddb'); /* __CUBRID_NO_BODY__ */",
 	     output_owner, PRINT_IDENTIFIER (sp_name));
+	  output_ctx (" END;\n");
 	}
       else
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25650

- dummy 식별을 위해 기존의 block comment 대신 line comment 를 사용했습니다. 
  - 윈도우즈 환경에서 loaddb 에러가 나던 문제 해소를 위함입니다.
  - block comment 가 왜 문제를 일으키는지는 아직 밝혀내지 못했습니다. 
- raise_application_error 의 첫번째 인자를 1000에서 1001 로 바꾸어 의도한 에러 메시지 "... incomplete during loaddb" 가 출력되도록 했습니다. 
  - 기존의 1000에 대해서는 의도하지 않게 raise_application_error 에서 검사하는 "1001 미만은 에러" 메시지가 출력되었습니다. 

