### PR TITLE
[CBRD-25764] Make cub_pl and cub_server share stdout and stderr on Windows

### DIFF
--- a/src/base/process_util.c
+++ b/src/base/process_util.c
@@ -89,6 +89,7 @@ create_child_process (const char *path, const char *const argv[], int wait_flag,
 
   GetStartupInfo (&start_info);
   start_info.wShowWindow = SW_HIDE;
+  start_info.dwFlags = STARTF_USESTDHANDLES;
 
   if (stdin_file)
     {
@@ -101,9 +102,7 @@ create_child_process (const char *path, const char *const argv[], int wait_flag,
 	}
 
       SetHandleInformation (hStdIn, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT);
-      start_info.dwFlags = STARTF_USESTDHANDLES;
       start_info.hStdInput = hStdIn;
-      inherit_flag = TRUE;
     }
   if (stdout_file)
     {
@@ -115,10 +114,14 @@ create_child_process (const char *path, const char *const argv[], int wait_flag,
 	  return 1;
 	}
       SetHandleInformation (hStdOut, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT);
-      start_info.dwFlags = STARTF_USESTDHANDLES;
       start_info.hStdOutput = hStdOut;
-      inherit_flag = TRUE;
     }
+  else
+    {
+      hStdOut = GetStdHandle (STD_OUTPUT_HANDLE);
+      start_info.hStdOutput = hStdOut;
+    }
+
   if (stderr_file)
     {
       hStdErr =
@@ -131,10 +134,15 @@ create_child_process (const char *path, const char *const argv[], int wait_flag,
 	}
 
       SetHandleInformation (hStdErr, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT);
-      start_info.dwFlags = STARTF_USESTDHANDLES;
       start_info.hStdError = hStdErr;
-      inherit_flag = TRUE;
     }
+  else
+    {
+      hStdErr = GetStdHandle (STD_ERROR_HANDLE);
+      start_info.hStdError = hStdErr;
+    }
+
+  inherit_flag = true;
 
   res =
     CreateProcess (path, cmd_arg_ptr, NULL, NULL, inherit_flag, CREATE_NO_WINDOW, NULL, NULL, &start_info, &proc_info);

--- a/src/executables/pl.cpp
+++ b/src/executables/pl.cpp
@@ -331,14 +331,13 @@ main (int argc, char *argv[])
 	PL_PRINT_ERR_MSG ("Invalid command: %s\n", command.c_str ());
 	status = ER_GENERIC_ERROR;
       }
-
-#if defined(WINDOWS)
-    // socket shutdown for windows
-    windows_socket_shutdown (pl_old_hook);
-#endif /* WINDOWS */
   }
 
 exit:
+#if defined(WINDOWS)
+  // socket shutdown for windows
+  windows_socket_shutdown (pl_old_hook);
+#endif /* WINDOWS */
 
   if (command.compare ("ping") == 0)
     {
@@ -460,6 +459,11 @@ pl_start_server (const PL_SERVER_INFO pl_info, const std::string &db_name, const
 
       er_clear (); // clear error before string JVM
       status = pl_start_jvm_server (db_name.c_str (), path.c_str (), pl_get_port_param ());
+      if (er_has_error())
+	{
+	  PL_PRINT_ERR_MSG ("%s\n", er_msg());
+	  er_clear();
+	}
 
       int port = (status == NO_ERROR) ? pl_server_port () : PL_PORT_DISABLED;
       PL_SERVER_INFO pl_new_info { getpid(), pl_server_port () };

--- a/src/sp/pl_sr_jvm.cpp
+++ b/src/sp/pl_sr_jvm.cpp
@@ -573,7 +573,6 @@ pl_start_jvm_server (const char *db_name, const char *path, int port)
     res = pl_create_java_vm (&env_p, &vm_arguments);
     delete[] options;
 
-#if !defined(WINDOWS)
     if (er_has_error ())
       {
 	if (locale != NULL)
@@ -582,7 +581,6 @@ pl_start_jvm_server (const char *db_name, const char *path, int port)
 	  }
 	return er_errid ();
       }
-#endif
 
     setlocale (LC_TIME, locale);
     if (locale != NULL)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25764

* Make cub_pl and cub_server share stdout and stderr  on Windows

- cub_pl 의 stdout, stderr 출력을 cub_server의 출력 스트림으로 출력할 수 있도록 함.
   > 테스트 시나리오의 cubrid server start db --for-windows-service 의 출력 리다이렉션을 위해서
- JVM 구동 실패 관련 에러시 리눅스와 동일하게 즉시 오류로 리턴 시키며 오류 로그도 즉시 남기도록 변경   
   
