### PR TITLE
[CBRD-25650] fix loaddb with pl function for windows

### DIFF
--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -251,7 +251,11 @@ ldr_check_file (std::string & file_name, int &error_code)
 
   if (!file_name.empty ())
     {
+#if defined(WINDOWS)
+      file_p = fopen (file_name.c_str (), "rb");
+#else
       file_p = fopen (file_name.c_str (), "r");
+#endif
       if (file_p == NULL)
 	{
 	  const char *msg_format = msgcat_message (MSGCAT_CATALOG_UTILS, MSGCAT_UTIL_SET_LOADDB, LOADDB_MSG_BAD_INFILE);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25650

* fix loaddb with pl function for windows


-  Window 버전에서 PL 함수가 포함된 경우 loaddb 실패 수정
-  윈도우인 경우 fopen( name, **"r"**) 대신  fopen( name, **"rb"**) 로 열도록 변경
  
```
-- demodb 준비
csql -u dba demodb -S -c "create procedure proc_test() as begin dbms_output.put_line('plcsql unload test'); end;"
cubrid unloaddb -S -udba demodb
 
cubrid deletedb demodb
cubrid createdb -r demodb --db-volume-size=20M --log-volume-size=20M en_US

cubrid loaddb -u dba -s demodb_schema -d demodb_objects -S demodb

```


```
PS C:\CUBRID\CubDB\databases> cubrid loaddb -u dba -s demodb_schema -d demodb_objects -S demodb

Start schema loading.
Total       50 statements executed.
Schema loading from demodb_schema finished.
Statistics for Catalog classes have been updated.


Start object loading.
Total 19202 object(s) inserted, 0 object(s) failed.
PS C:\CUBRID\CubDB\databases> csql -S -udba demodb

        CUBRID SQL Interpreter


Type `;help' for help messages.

csql> ;server-output on
SERVER OUTPUT IS ON
csql> select proc_test();

=== <Result of SELECT Command in Line 1> ===

  proc_test()
======================
  NULL

<DBMS_OUTPUT>
====
plcsql unload test

1 row selected. (2.412958 sec) Committed. (0.000021 sec)

1 command(s) successfully processed.
csql>
```