### PR TITLE
[CBRD-25833] Improve error handling for repeated interrupts across multiple sessions

### DIFF
--- a/src/session/session.c
+++ b/src/session/session.c
@@ -3266,8 +3266,8 @@ session_get_pl_session (THREAD_ENTRY * thread_p, REFPTR (PL_SESSION, pl_session_
       else if (state_p->pl_session_p->is_interrupted ())
 	{
 	  pl_session_ref_ptr = nullptr;
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_INTERRUPTING, 1, thread_p->index);
-	  error = ER_INTERRUPTING;
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_INTERRUPTED, 0);
+	  error = ER_INTERRUPTED;
 	}
 
       if (state_p->pl_session_p != NULL)

--- a/src/sp/pl_connection.hpp
+++ b/src/sp/pl_connection.hpp
@@ -99,15 +99,11 @@ namespace cubpl
       void create_new_connection (int index);
       connection_view get_connection_view (int index);
 
-
       void initialize_pool ();
       void cleanup_pool ();
 
       std::vector <connection *> m_pool;
       std::atomic<int> m_epoch; // Whenever PL server is restarted, server_manager increments this value
-
-      int m_min_conn_size; // minimum connection size
-      int m_inc_conn_size; // increment connection size for lazy initialization
 
       // for connection
       std::string m_db_name;

--- a/src/sp/pl_execution_stack_context.hpp
+++ b/src/sp/pl_execution_stack_context.hpp
@@ -64,11 +64,11 @@ namespace cubpl
       session *m_session;
 
       /* resources */
+      connection_view m_connection;
+
       std::unordered_set <int> m_stack_handler_id;
       std::unordered_set <std::uint64_t> m_stack_cursor_id;
       std::map <std::uint64_t, int> m_stack_cursor_map;
-
-      connection_view m_connection;
 
       /* error */
       std::string m_error_message;
@@ -141,7 +141,8 @@ namespace cubpl
 	connection_view &conn = get_connection();
 	if (!conn)
 	  {
-	    return ER_FAILED; // Handle the case where connection is unavailable
+	    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_CANNOT_CONNECT_JVM, 1, "connection pool");
+	    return ER_SP_CANNOT_CONNECT_JVM; // Handle the case where connection is unavailable
 	  }
 
 	return conn->send_buffer_args (m_java_header, std::forward<Args> (args)...);
@@ -153,7 +154,8 @@ namespace cubpl
 	connection_view &conn = get_connection();
 	if (!conn)
 	  {
-	    return ER_FAILED; // Handle the case where connection is unavailable
+	    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_CANNOT_CONNECT_JVM, 1, "connection pool");
+	    return ER_SP_CANNOT_CONNECT_JVM; // Handle the case where connection is unavailable
 	  }
 
 	pl_callback_func interrupt_func = [this]()

--- a/src/sp/pl_executor.cpp
+++ b/src/sp/pl_executor.cpp
@@ -146,7 +146,18 @@ namespace cubpl
 
     if (m_stack == NULL)
       {
-	return ER_FAILED;
+	// Check if the session is in an interrupting state by calling get_session()
+	// TODO: Verify the behavior of get_session() and validate this code flow.
+	session *sess = get_session ();
+	if (sess)
+	  {
+	    // If send_data_to_client() fails, it means the connection with CAS has been disconnected.
+	    // In this case, get_session() should return NULL.
+	    // According to the current analysis, the following code should be unreachable.
+	    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
+	  }
+
+	return er_errid ();
       }
 
     cubthread::entry *m_thread_p = m_stack->get_thread_entry ();
@@ -270,7 +281,18 @@ namespace cubpl
 
     if (m_stack == NULL)
       {
-	return ER_FAILED;
+	// Check if the session is in an interrupting state by calling get_session()
+	// TODO: Verify the behavior of get_session() and validate this code flow.
+	session *sess = get_session ();
+	if (sess)
+	  {
+	    // If send_data_to_client() fails, it means the connection with CAS has been disconnected.
+	    // In this case, get_session() should return NULL.
+	    // According to the current analysis, the following code should be unreachable.
+	    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
+	  }
+
+	return er_errid ();
       }
 
     // execution rights
@@ -335,6 +357,8 @@ exit:
 	    // According to the current analysis, the following code should be unreachable.
 	    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
 	  }
+
+	error = er_errid ();
       }
 
     return error;

--- a/src/sp/pl_session.cpp
+++ b/src/sp/pl_session.cpp
@@ -86,10 +86,7 @@ namespace cubpl
 
     destroy_pl_context_jvm ();
 
-    if (!m_session_connections.empty ())
-      {
-	m_session_connections.clear ();
-      }
+    m_session_connections.clear ();
   }
 
   execution_stack *
@@ -294,8 +291,6 @@ namespace cubpl
 	m_is_interrupted = true;
 	m_interrupt_id = reason;
 	m_interrupt_msg.assign ("");
-
-
 	break;
 
       /* 1 arg */

--- a/src/sp/pl_sr.cpp
+++ b/src/sp/pl_sr.cpp
@@ -73,7 +73,7 @@ namespace cubpl
   class server_manager final
   {
     public:
-      static constexpr std::size_t CONNECTION_POOL_SIZE = 100;
+      static constexpr std::size_t CONNECTION_POOL_SIZE = 10;
 
       explicit server_manager (const char *db_name);
 
@@ -479,6 +479,7 @@ namespace cubpl
 	  }
 	else
 	  {
+	    er_log_debug (ARG_FILE_LINE, "PL server is terminated. pid=%d\n", m_pid);
 	    m_state = SERVER_MONITOR_STATE_STOPPED;
 	  }
 	break;

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -2764,7 +2764,7 @@ logtb_set_tran_index_interrupt (THREAD_ENTRY * thread_p, int tran_index, bool se
 	      perfmon_inc_stat (thread_p, PSTAT_TRAN_NUM_INTERRUPTS);
 
 	      // Only TT_WORKER threads use pl_session
-	      if (thread_p->type == TT_WORKER)
+	      if (thread_p && thread_p->type == TT_WORKER)
 		{
 		  cubpl::session * session = cubpl::get_session ();
 		  if (session)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25833

- 이슈의 테스트 스크립트를 여러 세션에서 동시에 실행할 때 에러 핸들링 동작 개선
   - 인터럽트에 의해 스택 (m_stack) 이나 연결 (conn) 이 NULL인 경우 빈 에러 메시지 반환 개선
   - pl_executor.cpp: get_session () 후 에러 발생 시 명확한 에러 코드 반환
- 여러 세션 동시 동작에 대해서 connection_pool::claim() 개선 