### PR TITLE
[CBRD-25189] special handling of the second arguement to STR_TO_DATE

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
@@ -1240,6 +1240,8 @@ public class TypeChecker extends AstVisitor<Type> {
         return null;
     }
 
+    private static final int CASE_STR_TO_DATE = 1;
+
     private String checkArgsAndConvertToTypicalValuesStr(List<Expr> args, String funcName) {
         if (args.size() == 0) {
             if (SymbolStack.noParenBuiltInFunc.indexOf(funcName) >= 0) {
@@ -1252,12 +1254,17 @@ public class TypeChecker extends AstVisitor<Type> {
         StringBuilder sb = new StringBuilder();
         sb.append("(");
 
+        int specialCase = 0;
+        if (funcName.equals("STR_TO_DATE")) {
+            specialCase = CASE_STR_TO_DATE;
+        }
+
         int len = args.size();
         for (int i = 0; i < len; i++) {
+
             Expr arg = args.get(i);
 
-            // special handling
-            if (funcName.equals("STR_TO_DATE") && i == 1) {
+            if (specialCase == CASE_STR_TO_DATE && i == 1) {
 
                 // second argument of STR_TO_DATE
 
@@ -1269,25 +1276,26 @@ public class TypeChecker extends AstVisitor<Type> {
                             Misc.getLineColumnOf(arg.ctx), // s241
                             "second argument to STR_TO_DATE function must be a string literal");
                 }
+            } else {
 
-                continue;
+                // ordinary case
+
+                Type argType = visit(arg);
+
+                String typicalValueStr = argType.typicalValueStr;
+                if (typicalValueStr == null) {
+                    throw new SemanticError(
+                            Misc.getLineColumnOf(arg.ctx), // s234
+                            String.format(
+                                    "argument %d to the built-in function %s has an invalid type",
+                                    i + 1, funcName));
+                }
+
+                if (i > 0) {
+                    sb.append(", ");
+                }
+                sb.append(typicalValueStr);
             }
-
-            Type argType = visit(arg);
-
-            String typicalValueStr = argType.typicalValueStr;
-            if (typicalValueStr == null) {
-                throw new SemanticError(
-                        Misc.getLineColumnOf(arg.ctx), // s234
-                        String.format(
-                                "argument %d to the built-in function %s has an invalid type",
-                                i + 1, funcName));
-            }
-
-            if (i > 0) {
-                sb.append(", ");
-            }
-            sb.append(typicalValueStr);
         }
 
         sb.append(")");

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
@@ -1255,6 +1255,24 @@ public class TypeChecker extends AstVisitor<Type> {
         int len = args.size();
         for (int i = 0; i < len; i++) {
             Expr arg = args.get(i);
+
+            // special handling
+            if (funcName.equals("STR_TO_DATE") && i == 1) {
+
+                // second argument of STR_TO_DATE
+
+                if (arg instanceof ExprStr) {
+                    sb.append(", ");
+                    sb.append("'" + ((ExprStr) arg).val + "'");
+                } else {
+                    throw new SemanticError(
+                            Misc.getLineColumnOf(arg.ctx), // s241
+                            "second argument to STR_TO_DATE function must be a string literal");
+                }
+
+                continue;
+            }
+
             Type argType = visit(arg);
 
             String typicalValueStr = argType.typicalValueStr;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25189

빌트인 함수 호출의 타입 검사를 할 때 인자 타입을 나타내는 'cast(? as T)' 모양의 문자열을 인자 위치에 둔 query 문을 만들어
서버의 semantic check API 를 호출합니다. 
예를 들어, STR_TO_DATE('12:00:00 AM', '%r') 호출의 경우 
"select STR_TO_DATE(cast(? as char(268435455)), cast(? as char(268435455))) from dual"
문을 서버 API 를 사용해서 검사합니다. 
? 를 사용하는 이유는 constant folding 이 일어나는 것을 방지하기 위함입니다. 

그런데, STR_TO_DATE 의 경우 두 번째 인자가 문자열 타입일 것을 요구할 뿐 아니라 문자열 리터럴만을 허용합니다. 
예를 들어, 다음과 같은 호출은 에러를 일으킵니다. 
```
csql> select STR_TO_DATE('12:00:00 AM', '%' || 'r');

In line 1, column 27,

ERROR: before ' ; '
'str_to_date ' operator is not defined on types char with varchar and integer.
```
그래서, 서버 API 를 사용하여 STR_TO_DATE 함수 호출을 타입 검사를 할 때 
기본 방식대로 두번째 인자에 cast(? as char(268435455)) 를 사용하면 서버는 에러를 리턴한다는 문제가 있습니다. 

그래서, STR_TO_DATE 의 경우는 예외적으로 두번째 인자가 문자열 리터럴인지를 우선 검사한 후 
맞으면 인자값 그대로를 타입 검사에 사용하여 문제를 해소하였습니다. 

예를 들어,  STR_TO_DATE('12:00:00 AM', '%r') 호출의 경우 
"select STR_TO_DATE(cast(? as char(268435455)), '%r') from dual"
을 서버 semantic check API에 넘기게 됩니다. 




