### PR TITLE
[CBRD-25833] [regression] add lock_guard for connections in pl_session

### DIFF
--- a/src/sp/pl_session.hpp
+++ b/src/sp/pl_session.hpp
@@ -143,6 +143,7 @@ namespace cubpl
 
     private:
       execution_stack *top_stack_internal ();
+      void destroy_cursor_internal (cubthread::entry *thread_p, QUERY_ID query_id);
       void destroy_all_cursors ();
       void destroy_pl_context_jvm ();
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25833

- Fixed an issue where the session connection object of pl_session in claim_connection() and release_connection() was not protected by a lock, causing a core dump during interruptions.