### PR TITLE
[CBRD-25189] also allow NULL as the second argument to STR_TO_DATE built-in function

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
@@ -1271,6 +1271,9 @@ public class TypeChecker extends AstVisitor<Type> {
                 if (arg instanceof ExprStr) {
                     sb.append(", ");
                     sb.append("'" + ((ExprStr) arg).val + "'");
+                } else if (arg instanceof ExprNull) {
+                    sb.append(", ");
+                    sb.append("null");
                 } else {
                     throw new SemanticError(
                             Misc.getLineColumnOf(arg.ctx), // s241


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25189

현재 구현에서 STR_TO_DATE 의 두 번째 인자가 NULL 일 때 컴파일 에러가 나고 있어서 수정했습니다. 
