### PR TITLE
[CBRD-25835] Check if pl_session exists in logtb_set_tran_index_interrupt and then handle the interrupt

### DIFF
--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -163,10 +163,13 @@ stran_server_commit_internal (THREAD_ENTRY * thread_p, unsigned int rid, bool re
 
   state = xtran_server_commit (thread_p, retain_lock);
 
-  PL_SESSION *session = cubpl::get_session ();
-  if (!session || session->is_running () == false)
+  if (session_has_pl_session (thread_p))
     {
-      net_cleanup_server_queues (rid);
+      PL_SESSION *session = cubpl::get_session ();
+      if (!session || session->is_running () == false)
+	{
+	  net_cleanup_server_queues (rid);
+	}
     }
 
   if (state != TRAN_UNACTIVE_COMMITTED && state != TRAN_UNACTIVE_COMMITTED_INFORMING_PARTICIPANTS)
@@ -201,10 +204,13 @@ stran_server_abort_internal (THREAD_ENTRY * thread_p, unsigned int rid, bool * s
 
   state = xtran_server_abort (thread_p);
 
-  PL_SESSION *session = cubpl::get_session ();
-  if (!session || session->is_running () == false)
+  if (session_has_pl_session (thread_p))
     {
-      net_cleanup_server_queues (rid);
+      PL_SESSION *session = cubpl::get_session ();
+      if (!session || session->is_running () == false)
+	{
+	  net_cleanup_server_queues (rid);
+	}
     }
 
   if (state != TRAN_UNACTIVE_ABORTED && state != TRAN_UNACTIVE_ABORTED_INFORMING_PARTICIPANTS)

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -3243,6 +3243,20 @@ session_get_load_session (THREAD_ENTRY * thread_p, REFPTR (load_session, load_se
   return NO_ERROR;
 }
 
+bool
+session_has_pl_session (THREAD_ENTRY * thread_p)
+{
+  SESSION_STATE *state_p = NULL;
+
+  state_p = session_get_session_state (thread_p);
+  if (state_p == NULL)
+    {
+      return false;
+    }
+
+  return state_p->pl_session_p != NULL;
+}
+
 int
 session_get_pl_session (THREAD_ENTRY * thread_p, REFPTR (PL_SESSION, pl_session_ref_ptr))
 {

--- a/src/session/session.h
+++ b/src/session/session.h
@@ -92,6 +92,7 @@ extern int session_set_load_session (THREAD_ENTRY * thread_p, load_session * loa
 extern int session_get_load_session (THREAD_ENTRY * thread_p, REFPTR (load_session, load_session_ref_ptr));
 
 extern int session_get_pl_session (THREAD_ENTRY * thread_p, REFPTR (PL_SESSION, pl_session_ref_ptr));
+extern bool session_has_pl_session (THREAD_ENTRY * thread_p);
 #if defined (SERVER_MODE)
 extern void session_notify_pl_task_completion (const struct session_state *session_arg);
 #endif

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -77,6 +77,7 @@
 #include "thread_manager.hpp"
 #include "xasl.h"
 #include "xasl_cache.h"
+#include "session.h"
 #include "pl_session.hpp"
 
 // XXX: SHOULD BE THE LAST INCLUDE HEADER

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -2849,10 +2849,13 @@ logtb_is_interrupted_tdes (THREAD_ENTRY * thread_p, LOG_TDES * tdes, bool clear,
 #endif
 	}
 
-      cubpl::session * session = cubpl::get_session ();
-      if (session)
+      if (session_has_pl_session (thread_p))
 	{
-	  session->set_interrupt (ER_INTERRUPTED);
+	  cubpl::session * session = cubpl::get_session ();
+	  if (session)
+	    {
+	      session->set_interrupt (ER_INTERRUPTED);
+	    }
 	}
     }
   else if (interrupt == false && tdes->query_timeout > 0)
@@ -6092,7 +6095,7 @@ log_tdes::lock_topop ()
 // TODO [PL/CSQL]: It will be fixed at CBRD-25641.
 // The following code inside of #if block is a workaround for the issue.
 #if 1
-      if (rmutex_topop.owner != thread_id_t ())
+      if (rmutex_topop.owner != thread_id_t () && session_has_pl_session (thread_p))
       {
         cubpl::session *session = cubpl::get_session();
       if (session 
@@ -6116,7 +6119,7 @@ log_tdes::unlock_topop ()
 // TODO [PL/CSQL]: It will be fixed at CBRD-25641.
 // The following code inside of #if block is a workaround for the issue.
 #if 1
-      if (rmutex_topop.owner != thread_id_t ())
+      if (rmutex_topop.owner != thread_id_t () && session_has_pl_session (thread_p))
       {
         cubpl::session *session = cubpl::get_session();
       if (session 

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -2766,10 +2766,13 @@ logtb_set_tran_index_interrupt (THREAD_ENTRY * thread_p, int tran_index, bool se
 	      // Only TT_WORKER threads use pl_session
 	      if (thread_p && thread_p->type == TT_WORKER)
 		{
-		  cubpl::session * session = cubpl::get_session ();
-		  if (session)
+		  if (session_has_pl_session (thread_p))
 		    {
-		      session->set_interrupt (ER_INTERRUPTED);
+		      cubpl::session * session = cubpl::get_session ();
+		      if (session)
+			{
+			  session->set_interrupt (ER_INTERRUPTED);
+			}
 		    }
 		}
 	    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25835

This PR prevents cubpl::get_session() from creating an empty pl_session and entering an unnecessary interrupt handling routine.

