### PR TITLE
[CBRD-25848] Fix an issue where the loadjava tool would not output an error message when there was no class file

### DIFF
--- a/src/executables/loadjava.cpp
+++ b/src/executables/loadjava.cpp
@@ -183,6 +183,7 @@ copy_file (const fs::path &java_dir_path)
       fs::path src_path = fs::path (Src_class);
       if (fs::exists (src_path) == false)
 	{
+	  fprintf (stderr, "loadjava fail: '%s' is not exist.\n", src_path.c_str ());
 	  return ER_FAILED;
 	}
 

--- a/src/executables/loadjava.cpp
+++ b/src/executables/loadjava.cpp
@@ -187,6 +187,13 @@ copy_file (const fs::path &java_dir_path)
 	  return ER_FAILED;
 	}
 
+      std::string ext_nm = src_path.extension();
+      if ( ext_nm.empty() || ((ext_nm.compare (".class") != 0) && (ext_nm.compare (".jar") != 0)))
+	{
+	  fprintf (stderr, "loadjava fail: The extension name of '%s' is invalid.\n", src_path.c_str ());
+	  return ER_FAILED;
+	}
+
       std::string class_file_name = src_path.filename().generic_string();
       fs::path class_file_path = java_dir_path / class_file_name;
 

--- a/src/executables/loadjava.cpp
+++ b/src/executables/loadjava.cpp
@@ -183,7 +183,7 @@ copy_file (const fs::path &java_dir_path)
       fs::path src_path = fs::path (Src_class);
       if (fs::exists (src_path) == false)
 	{
-	  fprintf (stderr, "loadjava fail: '%s' is not exist.\n", src_path.c_str ());
+	  fprintf (stderr, "loadjava fail: '%s' does not exisit.\n", src_path.c_str ());
 	  return ER_FAILED;
 	}
 

--- a/src/executables/loadjava.cpp
+++ b/src/executables/loadjava.cpp
@@ -187,7 +187,7 @@ copy_file (const fs::path &java_dir_path)
 	  return ER_FAILED;
 	}
 
-      std::string ext_nm = src_path.extension();
+      std::string ext_nm = src_path.extension().generic_string();
       if ( ext_nm.empty() || ((ext_nm.compare (".class") != 0) && (ext_nm.compare (".jar") != 0)))
 	{
 	  fprintf (stderr, "loadjava fail: The extension name of '%s' is invalid.\n", src_path.c_str ());


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25848

*  Fix an issue where the loadjava tool would not output an error message when there was no class file
* Check file extensions (.class, .jar)

```
$ loadjava demodb xxx
 loadjava fail: 'xxx' is not exist.
$
$ loadjava demodb SpTest.java
loadjava fail: The extension name of 'SpTest.java' is invalid.
$
```