### PR TITLE
[CBRD-25852] Add freemem() in cubmem::block to simplify deleting memory routines

### DIFF
--- a/src/base/mem_block.hpp
+++ b/src/base/mem_block.hpp
@@ -68,6 +68,8 @@ namespace cubmem
 
       inline bool is_valid () const;
 
+      inline void freemem ();
+
       inline char *move_ptr ();                                    //NOT RECOMMENDED! use move semantics: std::move()
 
     private:
@@ -267,6 +269,17 @@ namespace cubmem
   block::is_valid () const
   {
     return (dim != 0 && ptr != NULL);
+  }
+
+  void
+  block::freemem ()
+  {
+    if (is_valid ())
+      {
+	delete[] ptr;
+	dim = 0;
+	ptr = NULL;
+      }
   }
 
   char *

--- a/src/sp/pl_compile_handler.cpp
+++ b/src/sp/pl_compile_handler.cpp
@@ -154,13 +154,8 @@ namespace cubpl
 	    m_stack->get_data_queue ().pop ();
 	  }
 
-	// free phase
-	if (response_blk.is_valid ())
-	  {
-	    delete [] response_blk.ptr;
-	    response_blk.ptr = NULL;
-	    response_blk.dim = 0;
-	  }
+	// free reponse block
+	response_blk.freemem ();
       }
     while (error_code == NO_ERROR && code != METHOD_REQUEST_COMPILE);
 

--- a/src/sp/pl_connection.hpp
+++ b/src/sp/pl_connection.hpp
@@ -145,12 +145,8 @@ namespace cubpl
       {
 	cubmem::block b = pack_data_block (std::forward<Args> (args)...);
 	int status = send_buffer (b);
-	if (b.is_valid ())
-	  {
-	    delete [] b.ptr;
-	    b.ptr = NULL;
-	    b.dim = 0;
-	  }
+	b.freemem ();
+
 	return status;
       }
 

--- a/src/sp/pl_executor.cpp
+++ b/src/sp/pl_executor.cpp
@@ -444,13 +444,8 @@ exit:
 	    m_stack->get_data_queue ().pop ();
 	  }
 
-	// free phase
-	if (response_blk.is_valid ())
-	  {
-	    delete [] response_blk.ptr;
-	    response_blk.ptr = NULL;
-	    response_blk.dim = 0;
-	  }
+	// free response block
+	response_blk.freemem ();
       }
     while (error_code == NO_ERROR && start_code == SP_CODE_INTERNAL_JDBC);
 
@@ -637,7 +632,7 @@ exit:
     if (blk.is_valid ())
       {
 	m_stack->send_data_to_java (blk);
-	delete[] blk.ptr;
+	blk.freemem ();
       }
 
     return error;
@@ -802,13 +797,7 @@ exit:
       }
 
     error = m_stack->send_data_to_java (blk);
-    if (blk.is_valid ())
-      {
-	delete [] blk.ptr;
-	blk.ptr = NULL;
-	blk.dim = 0;
-      }
-
+    blk.freemem ();
     return error;
   }
 
@@ -1026,11 +1015,7 @@ exit:
     db_value_clear (&res);
 
     error = m_stack->send_data_to_java (blk);
-
-    if (blk.is_valid ())
-      {
-	delete[]  blk.ptr;
-      }
+    blk.freemem ();
 
     return error;
   }

--- a/src/sp/pl_sr.cpp
+++ b/src/sp/pl_sr.cpp
@@ -570,12 +570,7 @@ namespace cubpl
       }
 
 exit:
-    if (ping_response.is_valid ())
-      {
-	delete [] ping_response.ptr;
-	ping_response.ptr = NULL;
-	ping_response.dim = 0;
-      }
+    ping_response.freemem ();
 
     cv.reset ();
 
@@ -605,6 +600,8 @@ exit:
       {
 	packing_unpacker deserializator (bootstrap_response);
 	deserializator.unpack_int (error);
+
+	bootstrap_response.freemem ();
       }
 
     return error;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25852

- Add freemem() not to check isValid(), to set ptr as NULL and len as 0 to make the cubmem::block invalid.
- Fix memory leak in do_bootstrap_request ()