### PR TITLE
[CBRD-25713] rev for pl: limit max length of CHAR type to 2048

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/type/TypeChar.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/type/TypeChar.java
@@ -34,7 +34,7 @@ import com.cubrid.plcsql.compiler.InstanceStore;
 
 public class TypeChar extends Type {
 
-    public static final int MAX_LEN = 268435455;
+    public static final int MAX_LEN = 2048;
     public static final int DEFAULT_LEN = 1;
 
     public final int length;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25713

CHAR 타입의 최대 길이를 2048로 변경하여 영향 받는 TC를 체크하고 수정하기 위해 PL부분의 해당 로직을 추가로 반영합니다.
