### PR TITLE
[CBRD-25857] Issue with LIMIT clause being ignored when using CONNECT BY with ORDER SIBLINGS BY

### DIFF
--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -7489,7 +7489,7 @@ pt_eval_type_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *conti
 	  PT_NODE *limit, *t_node;
 	  PT_NODE **expr_pred;
 
-	  if (node->info.query.order_by && !node->info.query.flag.order_siblings) /* when order siblings by */
+	  if (node->info.query.order_by && !node->info.query.flag.order_siblings)	/* when order siblings by */
 	    {
 	      expr_pred = &node->info.query.orderby_for;
 	      limit = pt_limit_to_numbering_expr (parser, node->info.query.limit, PT_ORDERBY_NUM, false);

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -7489,7 +7489,7 @@ pt_eval_type_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *conti
 	  PT_NODE *limit, *t_node;
 	  PT_NODE **expr_pred;
 
-	  if (node->info.query.order_by)
+	  if (node->info.query.order_by && !node->info.query.flag.order_siblings) /* when order siblings by */
 	    {
 	      expr_pred = &node->info.query.orderby_for;
 	      limit = pt_limit_to_numbering_expr (parser, node->info.query.limit, PT_ORDERBY_NUM, false);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25857

We aim to improve how LIMIT clauses are processed when used together with ORDER SIBLINGS BY in CONNECT BY queries. Currently, during the type checking phase, the LIMIT clause is converted to orderby_num() because CUBRID treats ORDER SIBLINGS BY as a variant of the regular ORDER BY clause.
However, during XASL generation and execution, when connect_by_ptr processes ORDER SIBLINGS BY, it does not include orderby_num(). As a result, the CONNECT BY clause, where ORDER SIBLINGS BY is actually performed, lacks both orderby_num() related information and execution routines, while orderby_num() exists only in the upper SELECT clause.
Therefore, we propose that LIMIT clauses used with ORDER SIBLINGS BY should be converted to inst_num() instead of orderby_num(), and we will modify the related logic accordingly.
