### PR TITLE
[CBRD-25867] Fix case mismatch in the function name of the INSERT() function

### DIFF
--- a/src/compat/db_function.cpp
+++ b/src/compat/db_function.cpp
@@ -119,7 +119,7 @@ fcode_get_uppercase_name (FUNC_CODE ftype)
     case F_CLASS_OF:
       return "F_CLASS_OF";
     case F_INSERT_SUBSTRING:
-      return "INSERT_SUBSTRING";
+      return "INSERT";
     case F_ELT:
       return "ELT";
     case F_BENCHMARK:


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25867

* Fix case mismatch in the function name of the INSERT() function

- fcode_get_uppercase_name()가 사용 되는 경우는 다음과 같습니다.
   - 에러가 발생했을 때 에러 메세지에 함수 이름을 넣기 위해
   - PRM_ID_XASL_DEBUG_DUMP가 설정되어 있으면  xasl dump 하기 위해
   - CUBRID_DEBUG 가 define 되어 있을 때

