### PR TITLE
[CBRD-25869] Check parser's error during walking the parser tree with pt_bind_names()

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -1988,12 +1988,12 @@ pt_bind_names (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue
   PT_NODE *method_name_node = NULL;
   const char *method_name;
 
-  *continue_walk = PT_CONTINUE_WALK;
-
-  if (!node || !parser)
+  if (!node || !parser || pt_has_error (parser))
     {
       return node;
     }
+
+  *continue_walk = PT_CONTINUE_WALK;
 
   /* treat scopes as the next outermost scope */
   scopestack.next = bind_arg->scopes;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25869

pt_bind_names() 에서 오류가 발생하더라도 하위 트리의 노드에 대해 walk와 name binding 로직을 계속 진행하는 문제를 수정합니다. segfault는 올바르게 만들어지지 않은 PT_EXPR 노드에 대해서 오류를 감지했음에도, 해당 노드가 올바르게 만들어졌다고 가정하고 인수 (arg1, arg2, arg3)에 대한 name binding을 계속 진행하여 올바르지 않은 메모리에 접근했습니다.