### PR TITLE
[CBRD-25872] apply system parameter to float numbers in several error messages

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -3220,7 +3220,7 @@ public class SpLib {
         try {
             return checkFloat(Float.valueOf(e.floatValue()));
         } catch (VALUE_ERROR ee) {
-            throw new VALUE_ERROR("data overflow on data type FLOAT: " + e);
+            throw new VALUE_ERROR("data overflow on data type FLOAT: " + convDoubleToString(e));
         }
     }
 
@@ -3304,7 +3304,7 @@ public class SpLib {
         try {
             return checkDouble(Double.valueOf(e.doubleValue()));
         } catch (VALUE_ERROR ee) {
-            throw new VALUE_ERROR("data overflow on data type DOUBLE: " + e);
+            throw new VALUE_ERROR("data overflow on data type DOUBLE: " + convFloatToString(e));
         }
     }
 
@@ -3378,7 +3378,7 @@ public class SpLib {
         try {
             return checkDouble(Double.valueOf(e.doubleValue()));
         } catch (VALUE_ERROR ee) {
-            throw new VALUE_ERROR("data overflow on data type DOUBLE: " + e);
+            throw new VALUE_ERROR("data overflow on data type DOUBLE: " + convNumericToString(e));
         }
     }
 
@@ -3390,7 +3390,7 @@ public class SpLib {
         try {
             return checkFloat(Float.valueOf(e.floatValue()));
         } catch (VALUE_ERROR ee) {
-            throw new VALUE_ERROR("data overflow on data type FLOAT: " + e);
+            throw new VALUE_ERROR("data overflow on data type FLOAT: " + convNumericToString(e));
         }
     }
 
@@ -4411,7 +4411,7 @@ public class SpLib {
         try {
             return bdp.longValueExact();
         } catch (ArithmeticException e) {
-            throw new VALUE_ERROR("data overflow on data type BIGINT: " + bd);
+            throw new VALUE_ERROR("data overflow on data type BIGINT: " + convNumericToString(bd));
         }
     }
 
@@ -4421,7 +4421,7 @@ public class SpLib {
         try {
             return bdp.intValueExact();
         } catch (ArithmeticException e) {
-            throw new VALUE_ERROR("data overflow on data type INTEGER: " + bd);
+            throw new VALUE_ERROR("data overflow on data type INTEGER: " + convNumericToString(bd));
         }
     }
 
@@ -4431,7 +4431,7 @@ public class SpLib {
         try {
             return bdp.shortValueExact();
         } catch (ArithmeticException e) {
-            throw new VALUE_ERROR("data overflow on data type SHORT: " + bd);
+            throw new VALUE_ERROR("data overflow on data type SHORT: " + convNumericToString(bd));
         }
     }
 
@@ -4441,7 +4441,7 @@ public class SpLib {
         try {
             return bdp.byteValueExact();
         } catch (ArithmeticException e) {
-            throw new VALUE_ERROR("data overflow on data type BYTE: " + bd);
+            throw new VALUE_ERROR("data overflow on data type BYTE: " + convNumericToString(bd));
         }
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25872

몇몇 에러 메시지에서 소수를 그냥 출력하던 것을 변환 함수 (convXtoY) 를 거치게 함으로써
시스템 파라메터, 특히, oracle_compat_number_behavior 가 적용되도록 수정하였습니다. 
