### PR TITLE
[CUBVEC-39] gh action should work for CUBVEC branches

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,6 +21,7 @@ on:
       - develop
       - 'release/11.**'
       - 'feature/**'
+      - 'cubvec/**'
 jobs:
   license:
     name: license


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-39

Description

현재 GitHub Actions 에서 진행하는 간단한 코드 검사들, 

예를 들어

codestyle.sh 등의 검사가 동작하지 않고 있습니다.

```
- 'cubvec/**'
```

위 한줄을 추가함으로써 이를 동작시킬 수 있습니다.