### PR TITLE
[CUBVEC-24] fix memory leak via handling DB_TYPE_VECTOR in pr_clear_value()

### DIFF
--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -2010,6 +2010,7 @@ pr_clear_value (DB_VALUE * value)
     case DB_TYPE_SET:
     case DB_TYPE_MULTISET:
     case DB_TYPE_SEQUENCE:
+    case DB_TYPE_VECTOR:
     case DB_TYPE_VOBJ:
       set_free (db_get_set (value));
       value->data.set = NULL;

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -7358,7 +7358,7 @@ mr_data_readval_set (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain, int siz
 		  db_make_sequence (value, ref);
 		  break;
 		case DB_TYPE_VECTOR:
-		  db_make_vector(value, ref);
+		  db_make_vector (value, ref);
 		  break;
 		default:
 		  break;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-24

CS 모드에서 메모리 누수를 발견했습니다.
object_primitive.c에 pr_clear_value()에서 DB_TYPE_VECTOR를 핸들링해 메모리 누수를 해결합니다.

Co-authored-by: @hgryoo 
Co-authored-by: @YeunjunLee 