### PR TITLE
[CBRD-25866] cut 'expecting' clauses in PL/CSQL syntax error messages

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/PlcsqlCompilerMain.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/PlcsqlCompilerMain.java
@@ -84,6 +84,26 @@ public class PlcsqlCompilerMain {
     private static final int OPT_VERBOSE = 1;
     private static final int OPT_PRINT_PARSE_TREE = 1 << 1;
 
+    private static String cutExpectingClause(String errMsg) {
+
+        int idx;
+        if (errMsg != null && (idx = errMsg.lastIndexOf(" expecting ")) > 0) {
+
+            String tail = errMsg.substring(idx + 11); // 11: length of " expecting "
+
+            if (tail.matches("[A-Z0-9_]+") /* single token name */
+                    || (tail.startsWith("'")
+                            && tail.endsWith("'")) /* single token of the form '...' */
+                    || (tail.startsWith("{")
+                            && tail.endsWith("}") /* multiple tokens of the form {...} */)) {
+
+                errMsg = errMsg.substring(0, idx);
+            }
+        }
+
+        return errMsg;
+    }
+
     private static ParseTree parse(
             CharStream input, boolean verbose, String[] sqlTemplate, StringBuilder logStore) {
 
@@ -119,11 +139,7 @@ public class PlcsqlCompilerMain {
             throw new SyntaxError(lei.line, lei.column, lei.msg);
         }
         if (sei.hasError) {
-            int cut;
-            String errMsg = sei.msg;
-            if (errMsg != null && (cut = errMsg.indexOf(" expecting {")) > 0) {
-                errMsg = errMsg.substring(0, cut);
-            }
+            String errMsg = cutExpectingClause(sei.msg);
             throw new SyntaxError(sei.line, sei.column, errMsg);
         }
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/PlcsqlCompilerMain.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/PlcsqlCompilerMain.java
@@ -84,12 +84,15 @@ public class PlcsqlCompilerMain {
     private static final int OPT_VERBOSE = 1;
     private static final int OPT_PRINT_PARSE_TREE = 1 << 1;
 
+    private static final String STR_EXPECTING = " expecting ";
+    private static final int STR_EXPECTING_LEN = STR_EXPECTING.length();
+
     private static String cutExpectingClause(String errMsg) {
 
         int idx;
-        if (errMsg != null && (idx = errMsg.lastIndexOf(" expecting ")) > 0) {
+        if (errMsg != null && (idx = errMsg.lastIndexOf(STR_EXPECTING)) > 0) {
 
-            String tail = errMsg.substring(idx + 11); // 11: length of " expecting "
+            String tail = errMsg.substring(idx + STR_EXPECTING_LEN);
 
             if (tail.matches("[A-Z0-9_]+") /* single token name */
                     || (tail.startsWith("'")

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/PlcsqlCompilerMain.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/PlcsqlCompilerMain.java
@@ -119,7 +119,12 @@ public class PlcsqlCompilerMain {
             throw new SyntaxError(lei.line, lei.column, lei.msg);
         }
         if (sei.hasError) {
-            throw new SyntaxError(sei.line, sei.column, sei.msg);
+            int cut;
+            String errMsg = sei.msg;
+            if (errMsg != null && (cut = errMsg.indexOf(" expecting {")) > 0) {
+                errMsg = errMsg.substring(0, cut);
+            }
+            throw new SyntaxError(sei.line, sei.column, errMsg);
         }
 
         sqlTemplate[0] = lexer.getCreateSqlTemplate();


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25866

PL/CSQL 컴파일러가 사용하고 있는 ANTLR 는 문법 에러가 발생했을 때 
'expecting' 뒤에 그 자리에 왔어야 할 토큰 목록을 나열합니다. 
예를 들면, 아래와 같은 에러 메시지에서 expecting 뒤에 { 와 } 사이에 토큰들을 나열합니다. 
```
Stored procedure compile error: extraneous input ';' expecting {WITH, SELECT, INSERT, UPDATE, DELETE, REPLACE, MERGE, T
RUNCATE, BEGIN, CASE, CLOSE, COMMIT, CONTINUE, DBMS_OUTPUT, DECLARE, EXECUTE, EXIT, FETCH, FOR, IF, LOOP, NULL_, OPEN, R
AISE, RAISE_APPLICATION_ERROR, RETURN, REVERSE, ROLLBACK, WHILE, DELIMITED_ID, '<<', REGULAR_ID}
```

이 부분은 동일한 에러 케이스에 대해서도 문법이 변경되면 달라지는 부분이라 
ANTLR의 문법의 일부 변경에도 SQL 테스트 TC 답안지의 대량 변경을 유발해 왔습니다. 
반면, expecting 정보가 사용자에게 크게 도움이 될 것 같아 보이지 않습니다. 

이 문제로 인해 ANTLR 문법 변경을 포함하는 CBRD-25866 의 변경에 의해 발생하는 답안지의 변경 중에 
expecting 뒤에 따라오는 토큰 목록 변경에 의한 것이 다수라 무엇이 의미있는 변경인지 파악하기가 어렵습니다. 

CBRD-25866 의 주 변경에 앞서 일단 문법 에러 메시지에서 변하는 부분을 지우고,
향후 두고두고 있을 TC 관리 부담을 없애는 것이 좋을 것 같습니다. 


