### PR TITLE
[CBRD-24483] Queries after backuptime are incorrectly included in restore

### DIFF
--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -1537,7 +1537,7 @@ log_rv_analysis_complete (THREAD_ENTRY * thread_p, int tran_id, LOG_LSA * log_ls
 
   donetime = (LOG_REC_DONETIME *) ((char *) log_page_p->area + log_lsa->offset);
   last_at_time = (time_t) donetime->at_time;
-  if (stop_at != NULL && *stop_at != (time_t) (-1) && difftime (*stop_at, last_at_time) < 0)
+  if (stop_at != NULL && *stop_at != (time_t) (-1) && difftime (*stop_at, last_at_time) <= 0)
     {
 #if !defined(NDEBUG)
       if (prm_get_bool_value (PRM_ID_LOG_TRACE_DEBUG))


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24483

### Purpose
- backuptime으로 restore 시, backupdb 이후 쿼리문이 commit되어도 log 시간이 같으면 recovery 대상으로 적용된다.
- log 시간이 같아도 backupdb 이후 시점에 수행된 쿼리문이라면 recovery 대상에 포함되지 않아야 한다.
### Implementation
- restore 시 목표 시점(stop_at)과 log commit 시점(last_at_time)을 비교할 때 time 값이 같아도 recovery 대상으로 포함하지 않고 log reset을 진행하도록 한다.

### Remarks
- N/A