### PR TITLE
[CUBVEC-47] Allow Casting Vector to Varchar

### DIFF
--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -9654,6 +9654,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 		    break;
 		  }
 
+                // check varchar's precision e.g.) 'select cast (vec as varchar (1)) from tbl;'
 		int new_string_len = oss.str ().size ();
 
 		if (db_value_precision (target) != TP_FLOATING_PRECISION_VALUE

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -9654,7 +9654,7 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 		    break;
 		  }
 
-                // check varchar's precision e.g.) 'select cast (vec as varchar (1)) from tbl;'
+		// check varchar's precision e.g.) 'select cast (vec as varchar (1)) from tbl;'
 		int new_string_len = oss.str ().size ();
 
 		if (db_value_precision (target) != TP_FLOATING_PRECISION_VALUE

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -9621,8 +9621,8 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 
 		oss << "[";
 
-		int cardinality = db_set_size (setref);
-		for (int i = 0; i < cardinality; i++)
+		int vector_dim = db_set_size (setref);
+		for (int i = 0; i < vector_dim; i++)
 		  {
 		    if (db_set_get (setref, i, &element) != NO_ERROR)
 		      {
@@ -9639,9 +9639,9 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 		      }
 
 		    oss << db_get_string (&str);
-		    if (i < cardinality - 1)
+		    if (i < vector_dim - 1)
 		      {
-			oss << ",";
+			oss << ", ";
 		      }
 		    db_value_clear (&str);
 		  }

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -5019,10 +5019,11 @@ tp_atovector (const DB_VALUE * src, DB_VALUE * result)
   DB_SET *vec = NULL;
   DB_VALUE e_val;
 
-  int error = db_string_to_vector(p, db_get_string_size(src), float_array, &count);
-  if (error != NO_ERROR) {
+  int error = db_string_to_vector (p, db_get_string_size (src), float_array, &count);
+  if (error != NO_ERROR)
+    {
       return ER_FAILED;
-  }
+    }
 
   // Create vector and populate it
   vec = db_vec_create (NULL, NULL, 0);
@@ -9605,6 +9606,76 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	      }
 	  }
 	  break;
+
+
+	case DB_TYPE_VECTOR:
+	  {
+	    DB_VALUE element;
+	    SETREF *setref = db_get_set (src);
+	    if (setref)
+	      {
+		DB_VALUE str;
+		db_value_domain_init (&str, DB_TYPE_VARCHAR, TP_FLOATING_PRECISION_VALUE, 0);
+
+		std::ostringstream oss;
+
+		oss << "[";
+
+		int cardinality = db_set_size (setref);
+		for (int i = 0; i < cardinality; i++)
+		  {
+		    if (db_set_get (setref, i, &element) != NO_ERROR)
+		      {
+			status = DOMAIN_ERROR;
+			break;
+		      }
+
+		    tp_ftoa (&element, &str);
+
+		    if (DB_IS_NULL (&str))
+		      {
+			status = DOMAIN_ERROR;
+			break;
+		      }
+
+		    oss << db_get_string (&str);
+		    if (i < cardinality - 1)
+		      {
+			oss << ",";
+		      }
+		    db_value_clear (&str);
+		  }
+		oss << "]";
+
+		char *new_string = db_private_strdup (NULL, oss.str ().c_str ());
+		if (!new_string)
+		  {
+		    status = DOMAIN_ERROR;
+		    break;
+		  }
+
+		int new_string_len = oss.str ().size ();
+
+		if (db_value_precision (target) != TP_FLOATING_PRECISION_VALUE
+		    && db_value_precision (target) < new_string_len)
+		  {
+		    status = DOMAIN_OVERFLOW;
+		    db_private_free_and_init (NULL, new_string);
+		  }
+		else
+		  {
+		    make_desired_string_db_value (desired_type, desired_domain, new_string, target, &status,
+						  &data_stat);
+		  }
+	      }
+	    else
+	      {
+		status = DOMAIN_ERROR;
+		break;
+	      }
+	  }
+	  break;
+
 
 	case DB_TYPE_DATE:
 	case DB_TYPE_TIME:


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-47

#### Purpose
현재 JDBC에서 `vector` 타입의 컬럼을 조회할 경우, CTP의 `Result`에서 벡터 출력이 구현되지 않아 `Null`이 반환됩니다. 이로 인해 테스트 결과를 확인하는 데 어려움이 있습니다. 이를 해결하기 위해 **벡터 타입을 `VARCHAR`로 변환하는 `CAST(vector AS VARCHAR)` 연산을 지원**하도록 변경합니다.

이 PR에서는 다음을 구현합니다:
- `CAST(vector AS VARCHAR)` 문법 추가  
- 벡터 데이터를 사람이 읽을 수 있는 문자열 형식으로 변환

---

#### Implementation

1. 벡터 → 문자열 변환 로직 추가
   - `tp_value_cast_internal`에서 `DB_TYPE_VECTOR`를 `DB_TYPE_VARCHAR`로 변환할 수 있도록 수정  
   - 벡터의 각 요소를 순회하면서:  
     - `tp_ftoa`를 사용하여 각 요소를 문자열로 변환  
     - 쉼표(`,`)로 구분된 리스트 형태(`[1.0, 2.0, 3.0]`)로 변환  
     - 적절한 메모리 할당 후 최종 문자열을 `DB_VALUE`에 저장  

2. 코드 변경 내용
   - **`tp_value_cast_internal`** (`object_domain.c` 수정)  
     - `src`가 `DB_TYPE_VECTOR`이고 `target`이 `DB_TYPE_VARCHAR`일 경우 변환을 수행  
     - `ostringstream`을 사용해 문자열 생성  
     - 메모리 할당 및 정밀도 검증 로직 추가  
   - **`tp_atovector`**  
     - 코드 가독성을 개선하고 에러 처리 방식 수정  

---

#### **Remarks
- 본 구현을 통해 JDBC에서도 벡터 데이터를 `Null`이 아닌 문자열 형태로 조회할 수 있음  
- 출력 문자열은 SQL에서 벡터 데이터를 일관되게 표현할 수 있도록 설계됨  
- 향후 벡터 데이터를 적절히 출력하는 기능이 추가될 때까지의 임시 해결책  
- 변환 과정에서 정밀도 제한 및 메모리 할당을 적절히 처리하여 안정성을 확보  

---

#### **수락 기준 (Acceptance Criteria)**  
- `SELECT CAST(vec AS VARCHAR) FROM vector_table;` 실행 시 정상적으로 벡터가 문자열로 변환되어 출력  
- 변환된 문자열이 벡터 데이터를 정확히 표현해야 함  
- JDBC를 통해 변환된 문자열을 정상적으로 읽을 수 있어야 함  
- 코드 리뷰 완료 후 반영  

---

#### **예제 (Example)**  
**변경 전:**  
```sql
SELECT vec FROM vector_table;
```
**출력:**  
```
Null
```

**변경 후:**  
```sql
SELECT CAST(vec AS VARCHAR) FROM vector_table;
```
**출력:**  
```
[1.5, 2, 3]
```
