### PR TITLE
[CBRD-25682] restore the semantics to the one before CBRD-25682

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -204,14 +204,14 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
 
                 assert node instanceof TypeSpecPercent;
                 TypeSpecPercent tsp = (TypeSpecPercent) node;
-                if (tsp.typeVisitMode == TYPE_VISIT_NORMAL
-                        || (tsp.typeVisitMode == TYPE_VISIT_RETURN
-                                && ct.colType.type == DBType.DB_NUMERIC)) {
+                if (tsp.typeVisitMode != TYPE_VISIT_NORMAL) {
+                    // Visiting a parameter type or return type.
+                    // Ignore specified precision and scale.
+                    tsp.type = DBTypeAdapter.getValueType(iStore, ct.colType.type);
+                } else {
                     tsp.type =
                             DBTypeAdapter.getDeclType(
                                     iStore, ct.colType.type, ct.colType.prec, ct.colType.scale);
-                } else {
-                    tsp.type = DBTypeAdapter.getValueType(iStore, ct.colType.type);
                 }
             } else {
                 assert false : "unreachable";

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -204,14 +204,14 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
 
                 assert node instanceof TypeSpecPercent;
                 TypeSpecPercent tsp = (TypeSpecPercent) node;
-                if (tsp.typeVisitMode != TYPE_VISIT_NORMAL) {
-                    // Visiting a parameter type or return type.
-                    // Ignore specified precision and scale.
-                    tsp.type = DBTypeAdapter.getValueType(iStore, ct.colType.type);
-                } else {
+                if (tsp.typeVisitMode == TYPE_VISIT_NORMAL) {
                     tsp.type =
                             DBTypeAdapter.getDeclType(
                                     iStore, ct.colType.type, ct.colType.prec, ct.colType.scale);
+                } else {
+                    // Visiting a parameter type or return type.
+                    // Ignore specified precision and scale.
+                    tsp.type = DBTypeAdapter.getValueType(iStore, ct.colType.type);
                 }
             } else {
                 assert false : "unreachable";


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25682

SP의 NUMERIC return type이 NUMERIC(38, 15)가 됨에 따라 
CBRD-25682에서 했던 변경 전 동작으로 되돌려 놓았습니다. 

