### PR TITLE
[CBRD-25903] Hide password when writing logs to cubrid_utiliity.log

### DIFF
--- a/src/base/util_func.h
+++ b/src/base/util_func.h
@@ -69,7 +69,7 @@ extern int util_log_write_result (int error);
 extern int util_log_write_errid (int message_id, ...);
 extern int util_log_write_errstr (const char *format, ...);
 extern int util_log_write_warnstr (const char *format, ...);
-extern int util_log_write_command (int argc, char *argv[]);
+extern int util_log_write_command (int argc, char *argv[], int util_name_pos);
 
 extern int util_bsearch (const void *key, const void *base, int n_elems, unsigned int sizeof_elem,
 			 int (*func_compare) (const void *, const void *), bool * out_found);

--- a/src/cm_common/cm_utils.c
+++ b/src/cm_common/cm_utils.c
@@ -728,7 +728,7 @@ cm_util_log_write_errstr (const char *format, ...)
 int
 cm_util_log_write_command (int argc, char *argv[])
 {
-  return util_log_write_command (argc, argv);
+  return util_log_write_command (argc, argv, 0);
 }
 
 /*

--- a/src/executables/util_service.c
+++ b/src/executables/util_service.c
@@ -537,6 +537,7 @@ main (int argc, char *argv[])
   bool process_window_service = false;
   pid_t pid = getpid ();
   char env_buf[16];
+  int util_name_pos = 0;
 
 #if defined (DO_NOT_USE_CUBRIDENV)
   char *envval;
@@ -591,13 +592,21 @@ main (int argc, char *argv[])
 	  print_message (stderr, MSGCAT_UTIL_GENERIC_SERVICE_INVALID_NAME, argv[1]);
 	  goto error;
 	}
+      if (util_type == ADMIN)
+	{
+	  util_name_pos = 2;
+	}
+    }
+  else if (util_type == ADMIN)
+    {
+      util_name_pos = 1;
     }
 
   if (load_properties () != NO_ERROR)
     {
       print_message (stderr, MSGCAT_UTIL_GENERIC_SERVICE_PROPERTY_FAIL);
 
-      util_log_write_command (argc, argv);
+      util_log_write_command (argc, argv, util_name_pos);
       util_log_write_errid (MSGCAT_UTIL_GENERIC_SERVICE_PROPERTY_FAIL);
 
       return EXIT_FAILURE;
@@ -607,7 +616,7 @@ main (int argc, char *argv[])
 
   if (util_type == ADMIN)
     {
-      util_log_write_command (argc, argv);
+      util_log_write_command (argc, argv, util_name_pos);
       status = process_admin (argc, argv);
       util_log_write_result (status);
 
@@ -647,7 +656,7 @@ main (int argc, char *argv[])
 	}
     }
 
-  util_log_write_command (argc, argv);
+  util_log_write_command (argc, argv, util_name_pos);
 
 #if defined(WINDOWS)
   if (css_windows_startup () < 0)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25903

* Hide password when writing logs to cubrid_utiliity.log
    - unloaddb, loaddb : -p PASS, --password=PASS
    - killtran, tde, flashback : -p PASS, --dba-password=PASS
