### PR TITLE
[CBRD-25847] add setting value for tuning memory management into cubrid.sh(.csh)

### DIFF
--- a/contrib/scripts/cubrid.csh
+++ b/contrib/scripts/cubrid.csh
@@ -29,3 +29,16 @@ set curses_lib=
 
 setenv SHLIB_PATH $LD_LIBRARY_PATH
 setenv LIBPATH $LD_LIBRARY_PATH
+
+#
+#  tuning setting for glib memory library
+#
+#setenv MALLOC_MMAP_MAX_ 65536           # default : 65536
+#setenv MALLOC_MMAP_THRESHOLD_ 131072    # default : 131072 (128K)
+setenv MALLOC_TRIM_THRESHOLD_ 0         # default : 131072 (128K)
+#setenv MALLOC_ARENA_MAX                 # default : core * 8
+
+#
+# preloading library for another memory library
+#
+#setenv LD_PRELOAD /usr/lib64/jemalloc.so.1

--- a/contrib/scripts/cubrid.sh
+++ b/contrib/scripts/cubrid.sh
@@ -23,3 +23,16 @@ SHLIB_PATH=$LD_LIBRARY_PATH
 LIBPATH=$LD_LIBRARY_PATH
 PATH=$CUBRID/bin:/usr/sbin:$PATH
 export LD_LIBRARY_PATH SHLIB_PATH LIBPATH PATH
+
+#
+#  tuning setting for glib memory library
+#
+#export MALLOC_MMAP_MAX_=65536            # default : 65536
+#export MALLOC_MMAP_THRESHOLD_=131072     # default : 131072 (128K)
+export MALLOC_TRIM_THRESHOLD_=0          # default : 131072 (128K)
+#export MALLOC_ARENA_MAX=                 # default : core * 8
+
+#
+# preloading library for another memory library
+#
+#export LD_PRELOAD=/usr/lib64/jemalloc.so.1


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25847

- add four tuning setting for glib memory library
- add example of LD_PRELOAD for using jemalloc library

