### PR TITLE
[CUBVEC-48] disable windows build in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,6 +150,6 @@ workflows:
           requires:
             - build
 
-      - build-windows:
-          requires:
-            - build
+      # - build-windows:
+      #     requires:
+      #       - build


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBVEC-48>

### Purpose

현재 FAISS 구성에서 Windows 빌드가 막혀 있음에도 불구하고 매 PR 커밋마다 10분 이상의 크레딧이 소모되고 있습니다. `.circleci/config.yml`에서 Windows 빌드 설정을 제거하여 불필요한 리소스 낭비를 방지하고자 합니다.

### Implementation

`.circleci/config.yml` 파일에서 `workflows.build_test.jobs` 목록의 `build-windows` 항목을 제거했습니다.

**변경 전:**

```yaml
- build-windows:
    requires:
      - build
```

**변경 후:**
해당 부분 삭제

### Remarks

이 변경으로 PR 및 CI 실행 시 Windows 빌드가 실행되지 않게 되어 크레딧 소모가 줄어듭니다.
