### PR TITLE
[CBRD-25911] [RocksDB] circle-ci 윈도우 빌드 제외

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,6 @@ workflows:
       - test_plcsql:
           requires:
             - build
-
-      - build-windows:
-          requires:
-            - build
+      #- build-windows:
+      #    requires:
+      #      - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,7 @@ workflows:
       - test_plcsql:
           requires:
             - build
+
       #- build-windows:
       #    requires:
       #      - build


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25911

### Purpose
* PoC 구현은 윈도우 환경을 고려하지 않음
* circle-ci의 윈도우 빌드 검증 제외