### PR TITLE
[CBRD-25925] [regression] Retry status check for PL server several times on SA_MODE

### DIFF
--- a/src/sp/pl_sr.cpp
+++ b/src/sp/pl_sr.cpp
@@ -412,7 +412,7 @@ namespace cubpl
 	  {
 	    do_monitor ();
 	  }
-	while (try_count < 10 && m_state != SERVER_MONITOR_STATE_RUNNING);
+	while (try_count++ < 10 && m_state != SERVER_MONITOR_STATE_RUNNING);
       }
 #endif
   }

--- a/src/sp/pl_sr.cpp
+++ b/src/sp/pl_sr.cpp
@@ -196,8 +196,10 @@ namespace cubpl
       connection_pool *m_sys_conn_pool;
       bootstrap_request *m_bootstrap_request;
 
+#if defined (SERVER_MODE)
       std::mutex m_monitor_mutex;
       std::condition_variable m_monitor_cv;
+#endif
   };
 
   struct bootstrap_request : public cubpacking::packable_object
@@ -314,8 +316,10 @@ namespace cubpl
     , m_failure_count (0)
     , m_sys_conn_pool {nullptr}
     , m_bootstrap_request {nullptr}
+#if defined (SERVER_MODE)
     , m_monitor_mutex {}
     , m_monitor_cv {}
+#endif
   {
     char executable_path[PATH_MAX];
     (void) envvar_bindir_file (executable_path, PATH_MAX, m_binary_name.c_str ());
@@ -396,12 +400,21 @@ namespace cubpl
     auto pred = [this] () -> bool { return m_state == SERVER_MONITOR_STATE_RUNNING ||
 					   (!BO_IS_SERVER_RESTARTED () && m_state == SERVER_MONITOR_STATE_FAILED_TO_INITIALIZE);
 				  };
-#else
-    auto pred = [this] () -> bool { return m_state == SERVER_MONITOR_STATE_RUNNING || m_state == SERVER_MONITOR_STATE_FAILED_TO_INITIALIZE; };
-#endif
 
     std::unique_lock<std::mutex> ulock (m_monitor_mutex);
     m_monitor_cv.wait (ulock, pred);
+#else
+    if (m_state != SERVER_MONITOR_STATE_RUNNING)
+      {
+	// retry starting pl server
+	int try_count = 0;
+	do
+	  {
+	    do_monitor ();
+	  }
+	while (try_count < 10 && m_state != SERVER_MONITOR_STATE_RUNNING);
+      }
+#endif
   }
 
   bool
@@ -421,7 +434,9 @@ namespace cubpl
 	return error;
       }
 
+#if defined (SERVER_MODE)
     std::lock_guard<std::mutex> lock (m_monitor_mutex);
+#endif
 
     // wait PL server is ready to accept connection (polling)
 
@@ -455,7 +470,9 @@ namespace cubpl
       }
     m_manager->get_connection_pool ()->increment_epoch ();
 
+#if defined (SERVER_MODE)
     m_monitor_cv.notify_all();
+#endif
 
     return error;
   }
@@ -470,7 +487,8 @@ namespace cubpl
 #if defined(SA_MODE)
 	if (do_check_connection (1) == NO_ERROR)
 	  {
-	    m_state = SERVER_MONITOR_STATE_RUNNING;
+	    // Waiting for PL server in shutdown state
+	    m_state = SERVER_MONITOR_STATE_UNKNOWN;
 	  }
 #else
 	/* do nothing */
@@ -497,7 +515,9 @@ namespace cubpl
 	    m_state = SERVER_MONITOR_STATE_FAILED_TO_INITIALIZE;
 	    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_CANNOT_START_PL_SERVER, 1,
 		    "Failed to initialize the PL server. Verify that the server environment and configurations are properly set up");
+#if defined (SERVER_MODE)
 	    m_monitor_cv.notify_all ();
+#endif
 	  }
       }
       break;
@@ -519,7 +539,9 @@ namespace cubpl
 		m_state = SERVER_MONITOR_STATE_FAILED_TO_INITIALIZE;
 		er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_CANNOT_START_PL_SERVER, 1,
 			"Failed to initialize the PL server. Verify that the server environment and configurations are properly set up");
+#if defined (SERVER_MODE)
 		m_monitor_cv.notify_all ();
+#endif
 	      }
 	    else
 	      {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25925

### Purpose

SA 모드에서 이전에 종료중인 PL 서버와 잘못 연결되어 미리 RUNNING 상태로 잘못 변경되는 것을 수정

### Implementation

- SA 모드에서 사용되지 않는 mutex, condition_variable 제거
- SA 모드의 wait_for_ready () 에서 do_monitor를 여러번 호출하는 방법으로 변경
- do_check_state () 에서 SA_MODE의 경우 STOPPED -> RUNNING으로 잘못 변경되던 것을 UNKNOWN으로 변경하여
wait_for_ready ()에서 PL 서버 연결과 시작을 재시도 하도록 변경

### Remarks

CBRD-25908의 regression 입니다. CBRD-25908의 요구사항은 그대로 만족하도록 변경