### PR TITLE
[CBRD-25931] Modify termination condition of PL server on Linux (including WSL)

### DIFF
--- a/src/executables/pl.cpp
+++ b/src/executables/pl.cpp
@@ -283,7 +283,7 @@ main (int argc, char *argv[])
     /* pl command main routine */
     if (command.compare ("start") == 0)
       {
-        pid_t ppid = getppid ();
+	pid_t ppid = getppid ();
 	(void) pl_start_server (pl_info, db_name, pathname);
 
 	command = "running";

--- a/src/executables/pl.cpp
+++ b/src/executables/pl.cpp
@@ -283,6 +283,7 @@ main (int argc, char *argv[])
     /* pl command main routine */
     if (command.compare ("start") == 0)
       {
+        pid_t ppid = getppid ();
 	(void) pl_start_server (pl_info, db_name, pathname);
 
 	command = "running";
@@ -308,7 +309,7 @@ main (int argc, char *argv[])
 		break;// parent process is terminated
 	      }
 #else
-	    if (getppid () == 1)
+	    if (getppid () != ppid)
 	      {
 		// parent process is terminated
 		break;

--- a/src/executables/pl.cpp
+++ b/src/executables/pl.cpp
@@ -283,7 +283,9 @@ main (int argc, char *argv[])
     /* pl command main routine */
     if (command.compare ("start") == 0)
       {
+#if !defined (WINDOWS)
 	pid_t ppid = getppid ();
+#endif
 	(void) pl_start_server (pl_info, db_name, pathname);
 
 	command = "running";


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25931

### Purpose

WSL에서 PL 서버가 좀비 프로세스가 되어 스스로 종료할 수 있도록 종료 조건을 수정

### Implementation

PID 1 (systemd) 만을 비교하지 않고, PL 서버 시작 시점에 ppid를 수집한 후, 이 ppid와 달라지면 종료하도록 조건을 번경

### Remarks

N/A
