### PR TITLE
[CBRD-25748] SP 에 대한 성능 트레이스 (trace on) 추가

### DIFF
--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -4089,9 +4089,17 @@ fetch_peek_dbval (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, val_descr *
 
     case TYPE_SP:		/* fetch stored procedure value */
       {
+	TSC_TICKS start_tick, end_tick;
+	TSCTIMEVAL tv_diff;
+
 	/* clear any value from a previous iteration */
 	pr_clear_value (regu_var->value.sp_ptr->value);
 	fetch_force_not_const_recursive (*regu_var);
+
+	if (thread_is_on_trace (thread_p))
+	  {
+	    tsc_getticks (&start_tick);
+	  }
 
 	cubpl::executor executor (*regu_var->value.sp_ptr->sig);
 	if (er_errid () != NO_ERROR)
@@ -4113,6 +4121,16 @@ fetch_peek_dbval (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, val_descr *
 	    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_EXECUTE_ERROR, 1,
 		    executor.get_stack ()->get_error_message ().c_str ());
 	    goto exit_on_error;
+	  }
+
+	if (thread_is_on_trace (thread_p))
+	  {
+	    tsc_getticks (&end_tick);
+	    tsc_elapsed_time_usec (&tv_diff, end_tick, start_tick);
+	    TSC_ADD_TIMEVAL (regu_var->regu_stats.sp.elapsed_time, tv_diff);
+	    regu_var->regu_stats.sp.cnt++;
+	    regu_var->regu_stats.sp.num_read += executor.m_num_read;
+	    regu_var->regu_stats.sp.num_write += executor.m_num_write;
 	  }
 
 	*peek_dbval = regu_var->value.sp_ptr->value;

--- a/src/query/query_dump.c
+++ b/src/query/query_dump.c
@@ -120,9 +120,12 @@ static void qdump_check_node (XASL_NODE * xasl, QDUMP_XASL_CHECK_NODE * chk_node
 static int qdump_print_inconsistencies (QDUMP_XASL_CHECK_NODE * chk_nodes[HASH_NUMBER]);
 #endif /* CUBRID_DEBUG */
 
+static void qdump_print_regu_var_in_agg_list_text (FILE * fp, AGGREGATE_TYPE * agg, int indent);
 static void qdump_print_regu_var_in_pred_expr_text (FILE * fp, PRED_EXPR * pred_p, int indent);
 static void qdump_print_regu_var_in_term_text (FILE * fp, PRED_EXPR * pred_p, int indent);
 static void qdump_print_regu_var_in_eval_term_text (FILE * fp, EVAL_TERM * term_p, int indent);
+static void qdump_print_regu_var_in_outptr_list_text (FILE * fp, OUTPTR_LIST * regu_var, int indent);
+
 static void qdump_print_regu_var_text (FILE * fp, REGU_VARIABLE * regu_var, int indent);
 static void qdump_print_regu_var_text (FILE * fp, REGU_VARIABLE_LIST regu_var_list, int indent);
 
@@ -3349,6 +3352,17 @@ qdump_print_stats_json (xasl_node * xasl_p, json_t * parent)
 }
 
 static void
+qdump_print_regu_var_in_outptr_list_text (FILE * fp, OUTPTR_LIST * ptr, int indent)
+{
+  if (ptr == NULL)
+    {
+      return;
+    }
+
+  qdump_print_regu_var_text (fp, ptr->valptrp, indent);
+}
+
+static void
 qdump_print_regu_var_text (FILE * fp, REGU_VARIABLE * regu_var, int indent)
 {
   if (regu_var == NULL)
@@ -3356,13 +3370,59 @@ qdump_print_regu_var_text (FILE * fp, REGU_VARIABLE * regu_var, int indent)
       return;
     }
 
-  if (regu_var->type == TYPE_SP)
+  switch (regu_var->type)
     {
+    case TYPE_INARITH:
+    case TYPE_OUTARITH:
+      if (regu_var->value.arithptr == NULL)
+	{
+	  return;
+	}
+      qdump_print_regu_var_text (fp, regu_var->value.arithptr->leftptr, indent);
+      qdump_print_regu_var_text (fp, regu_var->value.arithptr->rightptr, indent);
+      break;
+
+    case TYPE_SP:
+      if (regu_var->value.sp_ptr == NULL)
+	{
+	  return;
+	}
+
       fprintf (fp, "%*cSP (procedure: %s)", indent, ' ', regu_var->value.sp_ptr->sig->name);
       fprintf (fp, ", (time: %d, cnt: %lld, read: %lld, write: %lld)\n", TO_MSEC (regu_var->regu_stats.sp.elapsed_time),
 	       (unsigned long long int) regu_var->regu_stats.sp.cnt,
 	       (unsigned long long int) regu_var->regu_stats.sp.num_read,
 	       (unsigned long long int) regu_var->regu_stats.sp.num_write);
+      break;
+
+    case TYPE_FUNC:
+      if (regu_var->value.funcp == NULL)
+	{
+	  return;
+	}
+
+      qdump_print_regu_var_text (fp, regu_var->value.funcp->operand, indent);
+      break;
+
+    case TYPE_REGUVAL_LIST:
+      if (regu_var->value.reguval_list == NULL)
+	{
+	  return;
+	}
+
+      for (regu_value_item * item = regu_var->value.reguval_list->regu_list; item != NULL; item = item->next)
+	{
+	  qdump_print_regu_var_text (fp, item->value, indent);
+	}
+      break;
+
+    case TYPE_REGU_VAR_LIST:
+      qdump_print_regu_var_text (fp, regu_var->value.regu_var_list, indent);
+      break;
+
+    default:
+      // nothing
+      return;
     }
 }
 
@@ -3455,6 +3515,22 @@ qdump_print_regu_var_in_term_text (FILE * fp, PRED_EXPR * pred_p, int indent)
 }
 
 static void
+qdump_print_regu_var_in_agg_list_text (FILE * fp, AGGREGATE_TYPE * ptr, int indent)
+{
+  if (ptr == NULL)
+    {
+      return;
+    }
+
+  qdump_print_regu_var_text (fp, ptr->operands, indent);
+
+  if (ptr->next)
+    {
+      qdump_print_regu_var_in_agg_list_text (fp, ptr->next, indent);
+    }
+}
+
+static void
 qdump_print_regu_var_in_pred_expr_text (FILE * fp, PRED_EXPR * pred_p, int indent)
 {
   if (pred_p == NULL)
@@ -3520,7 +3596,7 @@ qdump_print_regu_var_in_scan_text (FILE * fp, SCAN_ID * s_id, int indent)
 
       if (s_id->s.isid.indx_cov.output_val_list != NULL)
 	{
-	  qdump_print_regu_var_text (fp, s_id->s.isid.indx_cov.output_val_list->valptrp, indent);
+	  qdump_print_regu_var_in_outptr_list_text (fp, s_id->s.isid.indx_cov.output_val_list, indent);
 	}
       break;
 
@@ -3533,6 +3609,118 @@ qdump_print_regu_var_in_scan_text (FILE * fp, SCAN_ID * s_id, int indent)
 
     case S_SET_SCAN:
       qdump_print_regu_var_text (fp, s_id->s.ssid.scan_pred.regu_list, indent);
+      break;
+
+    default:
+      break;
+    }
+}
+
+static void
+qdump_print_regu_var_in_xasl_text (FILE * fp, XASL_NODE * xasl_p, int indent)
+{
+  if (xasl_p == NULL)
+    {
+      return;
+    }
+
+  if (xasl_p->ordbynum_pred)
+    {
+      qdump_print_regu_var_in_pred_expr_text (fp, xasl_p->ordbynum_pred, indent);
+    }
+
+  if (xasl_p->orderby_limit)
+    {
+      qdump_print_regu_var_text (fp, xasl_p->orderby_limit, indent);
+    }
+
+  if (xasl_p->outptr_list != NULL)
+    {
+      qdump_print_regu_var_in_outptr_list_text (fp, xasl_p->outptr_list, indent);
+    }
+
+  if (xasl_p->during_join_pred)
+    {
+      qdump_print_regu_var_in_pred_expr_text (fp, xasl_p->during_join_pred, indent);
+    }
+
+  if (xasl_p->after_join_pred)
+    {
+      qdump_print_regu_var_in_pred_expr_text (fp, xasl_p->after_join_pred, indent);
+    }
+
+  if (xasl_p->if_pred)
+    {
+      qdump_print_regu_var_in_pred_expr_text (fp, xasl_p->if_pred, indent);
+    }
+
+  if (xasl_p->instnum_pred)
+    {
+      qdump_print_regu_var_in_pred_expr_text (fp, xasl_p->instnum_pred, indent);
+    }
+
+  if (xasl_p->level_regu)
+    {
+      qdump_print_regu_var_text (fp, xasl_p->level_regu, indent);
+    }
+
+  if (xasl_p->isleaf_regu)
+    {
+      qdump_print_regu_var_text (fp, xasl_p->isleaf_regu, indent);
+    }
+
+  if (xasl_p->iscycle_regu)
+    {
+      qdump_print_regu_var_text (fp, xasl_p->iscycle_regu, indent);
+    }
+
+  switch (xasl_p->type)
+    {
+    case OBJFETCH_PROC:
+      {
+	FETCH_PROC_NODE *node_p = &xasl_p->proc.fetch;
+	qdump_print_regu_var_in_pred_expr_text (fp, node_p->set_pred, indent);
+      }
+      break;
+
+    case BUILDLIST_PROC:
+      {
+	BUILDLIST_PROC_NODE *node_p = &xasl_p->proc.buildlist;
+	qdump_print_regu_var_in_outptr_list_text (fp, node_p->g_outptr_list, indent);
+	qdump_print_regu_var_text (fp, node_p->g_regu_list, indent);
+
+	qdump_print_regu_var_in_pred_expr_text (fp, node_p->g_grbynum_pred, indent);
+
+	qdump_print_regu_var_in_agg_list_text (fp, node_p->g_agg_list, indent);
+      }
+      break;
+
+    case BUILDVALUE_PROC:
+      {
+	BUILDVALUE_PROC_NODE *node_p = &xasl_p->proc.buildvalue;
+	qdump_print_regu_var_in_pred_expr_text (fp, node_p->having_pred, indent);
+	qdump_print_regu_var_in_agg_list_text (fp, node_p->agg_list, indent);
+	if (node_p->outarith_list)
+	  {
+	    ARITH_TYPE *arith_p = node_p->outarith_list;
+	    qdump_print_regu_var_text (fp, arith_p->leftptr, indent);
+	    qdump_print_regu_var_text (fp, arith_p->rightptr, indent);
+	  }
+      }
+      break;
+
+    case CONNECTBY_PROC:
+      {
+	CONNECTBY_PROC_NODE *node_p = &xasl_p->proc.connect_by;
+	qdump_print_regu_var_in_pred_expr_text (fp, node_p->start_with_pred, indent);
+	qdump_print_regu_var_in_pred_expr_text (fp, node_p->after_connect_by_pred, indent);
+	qdump_print_regu_var_text (fp, node_p->regu_list_pred, indent);
+	qdump_print_regu_var_text (fp, node_p->regu_list_rest, indent);
+	qdump_print_regu_var_in_outptr_list_text (fp, node_p->prior_outptr_list, indent);
+	qdump_print_regu_var_text (fp, node_p->prior_regu_list_pred, indent);
+	qdump_print_regu_var_text (fp, node_p->prior_regu_list_rest, indent);
+	qdump_print_regu_var_text (fp, node_p->after_cb_regu_list_rest, indent);
+      }
       break;
 
     default:
@@ -3820,10 +4008,7 @@ qdump_print_stats_text (FILE * fp, xasl_node * xasl_p, int indent)
       break;
     }
 
-  if (xasl_p->outptr_list != NULL)
-    {
-      qdump_print_regu_var_text (fp, xasl_p->outptr_list->valptrp, indent);
-    }
+  qdump_print_regu_var_in_xasl_text (fp, xasl_p, indent);
 
   if (xasl_p->sub_xasl_id && xasl_p->sub_cache_ref_count > 0)
     {

--- a/src/query/query_dump.c
+++ b/src/query/query_dump.c
@@ -120,6 +120,12 @@ static void qdump_check_node (XASL_NODE * xasl, QDUMP_XASL_CHECK_NODE * chk_node
 static int qdump_print_inconsistencies (QDUMP_XASL_CHECK_NODE * chk_nodes[HASH_NUMBER]);
 #endif /* CUBRID_DEBUG */
 
+static void qdump_print_regu_var_in_pred_expr_text (FILE * fp, PRED_EXPR * pred_p, int indent);
+static void qdump_print_regu_var_in_term_text (FILE * fp, PRED_EXPR * pred_p, int indent);
+static void qdump_print_regu_var_in_eval_term_text (FILE * fp, EVAL_TERM * term_p, int indent);
+static void qdump_print_regu_var_text (FILE * fp, REGU_VARIABLE * regu_var, int indent);
+static void qdump_print_regu_var_text (FILE * fp, REGU_VARIABLE_LIST regu_var_list, int indent);
+
 /*
  * qdump_print_xasl_type () -
  *   return:
@@ -3342,6 +3348,198 @@ qdump_print_stats_json (xasl_node * xasl_p, json_t * parent)
     }
 }
 
+static void
+qdump_print_regu_var_text (FILE * fp, REGU_VARIABLE * regu_var, int indent)
+{
+  if (regu_var == NULL)
+    {
+      return;
+    }
+
+  if (regu_var->type == TYPE_SP)
+    {
+      fprintf (fp, "%*cSP (procedure: %s)", indent, ' ', regu_var->value.sp_ptr->sig->name);
+      fprintf (fp, ", (time: %d, cnt: %lld, read: %lld, write: %lld)\n", TO_MSEC (regu_var->regu_stats.sp.elapsed_time),
+	       (unsigned long long int) regu_var->regu_stats.sp.cnt,
+	       (unsigned long long int) regu_var->regu_stats.sp.num_read,
+	       (unsigned long long int) regu_var->regu_stats.sp.num_write);
+    }
+}
+
+static void
+qdump_print_regu_var_text (FILE * fp, REGU_VARIABLE_LIST regu_var_list, int indent)
+{
+  for (REGU_VARIABLE_LIST list = regu_var_list; list; list = list->next)
+    {
+      indent -= 1;
+      qdump_print_regu_var_text (fp, &list->value, indent);
+      indent += 1;
+    }
+}
+
+static void
+qdump_print_regu_var_in_eval_term_text (FILE * fp, EVAL_TERM * term_p, int indent)
+{
+  if (term_p == NULL)
+    {
+      return;
+    }
+
+  switch (term_p->et_type)
+    {
+    case T_COMP_EVAL_TERM:
+      {
+	COMP_EVAL_TERM *et_comp_p = &term_p->et.et_comp;
+	qdump_print_regu_var_text (fp, et_comp_p->lhs, indent);
+	qdump_print_regu_var_text (fp, et_comp_p->rhs, indent);
+      }
+      break;
+
+    case T_ALSM_EVAL_TERM:
+      {
+	ALSM_EVAL_TERM *et_alsm_p = &term_p->et.et_alsm;
+	qdump_print_regu_var_text (fp, et_alsm_p->elem, indent);
+	qdump_print_regu_var_text (fp, et_alsm_p->elemset, indent);
+      }
+      break;
+
+    case T_LIKE_EVAL_TERM:
+      {
+	LIKE_EVAL_TERM *et_like_p = &term_p->et.et_like;
+	qdump_print_regu_var_text (fp, et_like_p->src, indent);
+	qdump_print_regu_var_text (fp, et_like_p->pattern, indent);
+	if (et_like_p->esc_char)
+	  {
+	    qdump_print_regu_var_text (fp, et_like_p->esc_char, indent);
+	  }
+      }
+      break;
+
+    case T_RLIKE_EVAL_TERM:
+      {
+	RLIKE_EVAL_TERM *et_rlike_p = &term_p->et.et_rlike;
+	qdump_print_regu_var_text (fp, et_rlike_p->src, indent);
+	qdump_print_regu_var_text (fp, et_rlike_p->pattern, indent);
+      }
+      break;
+
+    default:
+      break;
+    }
+}
+
+static void
+qdump_print_regu_var_in_term_text (FILE * fp, PRED_EXPR * pred_p, int indent)
+{
+  if (pred_p == NULL)
+    {
+      return;
+    }
+
+  switch (pred_p->type)
+    {
+    case T_EVAL_TERM:
+      {
+	qdump_print_regu_var_in_eval_term_text (fp, &pred_p->pe.m_eval_term, indent);
+      }
+      break;
+    case T_NOT_TERM:
+      {
+	qdump_print_regu_var_in_pred_expr_text (fp, pred_p->pe.m_not_term, indent);
+      }
+      break;
+
+    default:
+      break;
+    }
+}
+
+static void
+qdump_print_regu_var_in_pred_expr_text (FILE * fp, PRED_EXPR * pred_p, int indent)
+{
+  if (pred_p == NULL)
+    {
+      return;
+    }
+
+  switch (pred_p->type)
+    {
+    case T_PRED:
+      {
+	qdump_print_regu_var_in_pred_expr_text (fp, pred_p->pe.m_pred.lhs, indent);
+
+	/* Traverse right-linear chains of AND/OR terms */
+	for (pred_p = pred_p->pe.m_pred.rhs; pred_p->type == T_PRED; pred_p = pred_p->pe.m_pred.rhs)
+	  {
+	    qdump_print_regu_var_in_pred_expr_text (fp, pred_p->pe.m_pred.lhs, indent);
+	  }
+
+	/* rhs */
+	switch (pred_p->type)
+	  {
+	  case T_EVAL_TERM:
+	  case T_NOT_TERM:
+	    qdump_print_regu_var_in_term_text (fp, pred_p, indent);
+	    break;
+	  default:
+	    break;
+	  }
+      }
+      break;
+
+    case T_EVAL_TERM:
+    case T_NOT_TERM:
+      qdump_print_regu_var_in_term_text (fp, pred_p, indent);
+      break;
+
+    default:
+      break;
+    }
+}
+
+static void
+qdump_print_regu_var_in_scan_text (FILE * fp, SCAN_ID * s_id, int indent)
+{
+  switch (s_id->type)
+    {
+    case S_HEAP_SCAN:
+    case S_HEAP_SAMPLING_SCAN:
+      qdump_print_regu_var_text (fp, s_id->s.hsid.scan_pred.regu_list, indent);
+      qdump_print_regu_var_text (fp, s_id->s.hsid.rest_regu_list, indent);
+      break;
+
+    case S_INDX_SCAN:
+      qdump_print_regu_var_text (fp, s_id->s.isid.key_pred.regu_list, indent);
+      qdump_print_regu_var_text (fp, s_id->s.isid.scan_pred.regu_list, indent);
+      qdump_print_regu_var_text (fp, s_id->s.isid.rest_regu_list, indent);
+
+      if (s_id->s.isid.indx_cov.regu_val_list != NULL)
+	{
+	  qdump_print_regu_var_text (fp, s_id->s.isid.indx_cov.regu_val_list, indent);
+	}
+
+      if (s_id->s.isid.indx_cov.output_val_list != NULL)
+	{
+	  qdump_print_regu_var_text (fp, s_id->s.isid.indx_cov.output_val_list->valptrp, indent);
+	}
+      break;
+
+    case S_LIST_SCAN:
+      qdump_print_regu_var_text (fp, s_id->s.llsid.scan_pred.regu_list, indent);
+      qdump_print_regu_var_text (fp, s_id->s.llsid.rest_regu_list, indent);
+      qdump_print_regu_var_text (fp, s_id->s.llsid.hlsid.build_regu_list, indent);
+      qdump_print_regu_var_text (fp, s_id->s.llsid.hlsid.probe_regu_list, indent);
+      break;
+
+    case S_SET_SCAN:
+      qdump_print_regu_var_text (fp, s_id->s.ssid.scan_pred.regu_list, indent);
+      break;
+
+    default:
+      break;
+    }
+}
+
 /*
  * qdump_print_access_spec_stats_text () -
  *   return:
@@ -3421,13 +3619,23 @@ qdump_print_access_spec_stats_text (FILE * fp, ACCESS_SPEC_TYPE * spec_list_p, i
 	    {
 	      free_and_init (index_name);
 	    }
+	  fprintf (fp, "\n");
+
+	  qdump_print_regu_var_text (fp, cls_node->cls_regu_list_key, indent + 1);
+	  qdump_print_regu_var_text (fp, cls_node->cls_regu_list_pred, indent + 1);
+	  qdump_print_regu_var_text (fp, cls_node->cls_regu_list_rest, indent + 1);
 	}
       else
 	{
 	  scan_print_stats_text (fp, &spec->s_id);
+	  fprintf (fp, "\n");
 	}
 
-      fprintf (fp, "\n");
+      qdump_print_regu_var_in_scan_text (fp, &spec->s_id, indent + 1);
+
+      qdump_print_regu_var_in_pred_expr_text (fp, spec->where_key, indent + 1);
+      qdump_print_regu_var_in_pred_expr_text (fp, spec->where_pred, indent + 1);
+      qdump_print_regu_var_in_pred_expr_text (fp, spec->where_range, indent + 1);
     }
 
   return;
@@ -3610,6 +3818,11 @@ qdump_print_stats_text (FILE * fp, xasl_node * xasl_p, int indent)
     case OBJFETCH_PROC:
     default:
       break;
+    }
+
+  if (xasl_p->outptr_list != NULL)
+    {
+      qdump_print_regu_var_text (fp, xasl_p->outptr_list->valptrp, indent);
     }
 
   if (xasl_p->sub_xasl_id && xasl_p->sub_cache_ref_count > 0)

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -1670,6 +1670,8 @@ qexec_clear_regu_var (THREAD_ENTRY * thread_p, XASL_NODE * xasl_p, REGU_VARIABLE
       pr_clear_value (regu_var->vfetch_to);
     }
 
+  memset (&regu_var->regu_stats, 0, sizeof (REGU_VARIABLE_STATS));
+
   return pg_cnt;
 }
 

--- a/src/query/regu_var.cpp
+++ b/src/query/regu_var.cpp
@@ -200,6 +200,8 @@ regu_variable_node::clear_xasl_local ()
     }
 
   pr_clear_value (vfetch_to);
+
+  memset (&regu_stats, 0, sizeof (REGU_VARIABLE_STATS));
 }
 
 void

--- a/src/query/regu_var.hpp
+++ b/src/query/regu_var.hpp
@@ -170,6 +170,18 @@ const int REGU_VARIABLE_UPD_INS_LIST = 0x200;	/* for update or insert query */
 const int REGU_VARIABLE_STRICT_TYPE_CAST = 0x400;/* for update or insert query */
 const int REGU_VARIABLE_CORRELATED = 0x800; /* for correlated scalar subquery cache */
 
+typedef union regu_variable_stats REGU_VARIABLE_STATS;
+union regu_variable_stats
+{
+  struct
+  {
+    struct timeval elapsed_time;
+    UINT64 cnt;
+    UINT64 num_read;
+    UINT64 num_write;
+  } sp;
+};
+
 class regu_variable_node
 {
   public:
@@ -196,6 +208,8 @@ class regu_variable_node
       REGU_VARIABLE_LIST regu_var_list;	/* for CUME_DIST and PERCENT_RANK */
       cubxasl::sp_node *sp_ptr; /* stored procedure */
     } value;
+
+    REGU_VARIABLE_STATS regu_stats;
 
     regu_variable_node () = default;
 

--- a/src/query/stream_to_xasl.c
+++ b/src/query/stream_to_xasl.c
@@ -5550,6 +5550,8 @@ stx_build_regu_variable (THREAD_ENTRY * thread_p, char *ptr, REGU_VARIABLE * reg
 
   ptr = stx_unpack_regu_variable_value (thread_p, ptr, regu_var);
 
+  memset (&regu_var->regu_stats, 0, sizeof (regu_var->regu_stats));
+
   return ptr;
 
 error:

--- a/src/sp/pl_connection.cpp
+++ b/src/sp/pl_connection.cpp
@@ -182,6 +182,10 @@ namespace cubpl
 
     m_queue.push (conn->get_index ());
 
+    // for trace
+    conn->m_read = 0;
+    conn->m_write = 0;
+
     er_log_debug (ARG_FILE_LINE, "pl_connection_pool: connection retire (%d)\n", conn->get_index ());
   }
 
@@ -247,6 +251,9 @@ namespace cubpl
   {
     //
     do_reconnect ();
+
+    m_read = 0;
+    m_write = 0;
   }
 
   connection::~connection ()
@@ -306,6 +313,8 @@ namespace cubpl
       {
 	return do_handle_network_error (nbytes);
       }
+
+    m_write += blk.dim + OR_INT_SIZE;
 
     return NO_ERROR;
   }
@@ -393,6 +402,9 @@ namespace cubpl
     // Step 5: Move the data into the block
     cubmem::block blk (res_size, ext_blk.release_ptr());
     b = std::move (blk);
+
+    // for trace
+    m_read += res_size;
 
     return NO_ERROR; // Successfully received the buffer
   }

--- a/src/sp/pl_connection.hpp
+++ b/src/sp/pl_connection.hpp
@@ -152,6 +152,9 @@ namespace cubpl
 
       void invalidate ();
 
+      UINT64 m_read;
+      UINT64 m_write;
+
     private:
       explicit connection (connection_pool *pool, int index);
 

--- a/src/sp/pl_execution_stack_context.hpp
+++ b/src/sp/pl_execution_stack_context.hpp
@@ -122,6 +122,16 @@ namespace cubpl
       cubmethod::header m_java_header; // header sending to cub_javasp
       bool m_transaction_control;
 
+      UINT64 get_num_read () const
+      {
+	return m_connection ? m_connection->m_read : 0;
+      }
+
+      UINT64 get_num_write () const
+      {
+	return m_connection ? m_connection->m_write : 0;
+      }
+
       template <typename ... Args>
       int send_data_to_client (Args &&... args)
       {

--- a/src/sp/pl_executor.cpp
+++ b/src/sp/pl_executor.cpp
@@ -326,6 +326,11 @@ exit:
       {
 	error = er_errid ();
       }
+
+    // for trace
+    m_num_read = m_stack->get_num_read ();
+    m_num_write = m_stack->get_num_write ();
+
     return error;
   }
 

--- a/src/sp/pl_executor.hpp
+++ b/src/sp/pl_executor.hpp
@@ -85,6 +85,10 @@ namespace cubpl
       std::vector <DB_VALUE> &get_out_args ();
       execution_stack *get_stack ();
 
+      // trace
+      UINT64 m_num_read;
+      UINT64 m_num_write;
+
     private:
       execution_stack *m_stack;
       pl_signature &m_sig;

--- a/src/sp/pl_session.cpp
+++ b/src/sp/pl_session.cpp
@@ -237,6 +237,10 @@ namespace cubpl
 
     if (conn != nullptr)
       {
+	// for trace
+	conn->m_read = 0;
+	conn->m_write = 0;
+
 	m_session_connections.emplace_back (std::move (conn));
       }
   }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25748

### Purpose

SP를 호출하는 경우에 대한 성능 트레이스 정보를 추가합니다.

예시)

```
select name from athlete LIMIT 1;
select fn_string (name) from athlete LIMIT 1;

Trace Statistics:
  SELECT (time: 0, fetch: 4, fetch_time: 0, ioread: 0)
    SCAN (table: public.athlete), (heap time: 0, fetch: 4, ioread: 0, readrows: 3, rows: 3)

Trace Statistics:
  SELECT (time: 4, fetch: 12, fetch_time: 0, ioread: 0)
   SP (procedure: dba.fn_string), (time: 4, cnt: 3, read: 148, write: 2380)
    SCAN (table: public.athlete), (heap time: 0, fetch: 4, ioread: 0, readrows: 4, rows: 4)
```

```
select name from athlete where fn_string (name) = 'Fernandez Jesus';
select name from athlete where fn_int (code)  < 10900 LIMIT 5;
select fn_string(name) from athlete where fn_int (code)  < 10900 LIMIT 5;

Trace Statistics:
  SELECT (time: 442, fetch: 136, fetch_time: 0, ioread: 0)
    SCAN (table: public.athlete), (heap time: 442, fetch: 136, ioread: 0, readrows: 6677, rows: 1)
     SP (procedure: dba.fn_string), (time: 373, cnt: 6677, read: 219664, write: 1300652)

Trace Statistics:
  SELECT (time: 8, fetch: 12, fetch_time: 0, ioread: 0)
    SCAN (table: public.athlete), (heap time: 8, fetch: 12, ioread: 0, readrows: 106, rows: 6)
     SP (procedure: dba.fn_int), (time: 5, cnt: 106, read: 1744, write: 20020)

Trace Statistics:
  SELECT (time: 12, fetch: 20, fetch_time: 0, ioread: 0)
   SP (procedure: dba.fn_string), (time: 3, cnt: 5, read: 212, write: 2772)
    SCAN (table: public.athlete), (heap time: 9, fetch: 12, ioread: 0, readrows: 106, rows: 6)
     SP (procedure: dba.fn_int), (time: 8, cnt: 106, read: 1744, write: 20020)
```

```
SELECT dept_no, avg(fn_int(sales_amount))
FROM sales_tbl
GROUP BY dept_no HAVING fn_int (dept_no) > 0;

Trace Statistics:
  SELECT (time: 5, fetch: 208, fetch_time: 0, ioread: 0)
   SP (procedure: dba.fn_int), (time: 0, cnt: 12, read: 192, write: 2064)
    SCAN (index: dba.sales_tbl.pk_sales_tbl_dept_no_name_sales_month), (btree time: 4, fetch: 204, ioread: 0, readkeys: 12, filteredkeys: 0, rows: 12) (lookup time: 0, rows: 12)
     SP (procedure: dba.fn_int), (time: 2, cnt: 12, read: 240, write: 3852)
    GROUPBY (time: 0, hash: false, sort: false, rows: 3)
```

### Implementation

- **src/query/fetch.c**: SP 호출은 regu_var의 TYPE_SP 타입의 구조에서 수행되므로, REGU_VARIABLE에서 DB_VALUE로 만드는 fetch_peek_dbval에서 성능 정보를 수집
- **src/query/regu_var.cpp, hpp**:성능 정보는 REGU_VARIABLE에 REGU_VARIABLE_STATS 구조체를 추가하여 수집한다. 현재 union 타입이며, SP 성능 수집을 위한 정보만이 추가
- **src/query/query_dump.c**: XASL 노드의 REGU_VARIABLE 에 도달할 수 있는 모든 경로에 찾아가서 TYPE_SP인 경우 수집한 성능 정보를 출력할 수 있도록 로직 추가

- **src/sp**: PL 서버와 통신한 패킷의 크기는 cubpl::connection 객체에서 read/write를 패킷 크기 정보를 누적 수집하며, 단일 함수 호출 후 pl session에 cubpl::connection이 반납될 때 다시 초기화

### Remarks

- src/query/query_dump.c에 다음의 두 로직이 함께 섞여있습니다.
1) `;trace on`: trace 정보 출력
2) `;set xasl_debug_dump=yes` : XASL 노드 정보 출력

두 기능을 별도의 파일로 나누는 이슈를 별도로 진행하는 것이 좋을 것 같습니다.