### PR TITLE
[CUBVEC-52] create separate test_cubvec suite for rapid feedback cycle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
 
   build-windows:
     machine:
-      image: "windows-server-2019"
+      image: 'windows-server-2019'
       resource_class: windows.large
       shell: powershell.exe -ExecutionPolicy Bypass
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
 
   build-windows:
     machine:
-      image: 'windows-server-2019'
+      image: "windows-server-2019"
       resource_class: windows.large
       shell: powershell.exe -ExecutionPolicy Bypass
     environment:
@@ -154,6 +154,9 @@ workflows:
   build_test:
     jobs:
       - build
+      - test_cubvec:
+          requires:
+            - build
       - test_medium:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,10 +21,16 @@ test_defaults: &test_defaults
             # Hack way to run plcsql test without modifying CUBRID CI docker
             TEST_SUITE="sql"
             glob_path=cubrid-testcases/sql/{_05_plcsql,_35_fig_cake/plcsql}
+          elif [ $TEST_SUITE = "cubvec" ]
+          then
+            # Hack way to run cubvec test without modifying CUBRID CI docker
+            TEST_SUITE="sql"
+            glob_path=cubrid-testcases/sql/_36_cubvec
           elif [ $TEST_SUITE = "sql" ] 
           then
             rm -rf cubrid-testcases/$TEST_SUITE/_05_plcsql
             rm -rf cubrid-testcases/$TEST_SUITE/_35_fig_cake/plcsql
+            rm -rf cubrid-testcases/$TEST_SUITE/_36_cubvec
             glob_path="cubrid-testcases/$TEST_SUITE/_*"
           else
             glob_path="cubrid-testcases/$TEST_SUITE/_*"
@@ -78,6 +84,14 @@ jobs:
             - CUBRID
       - store_artifacts:
           path: /tmp/build_logs
+
+  test_cubvec:
+    <<: *defaults
+    environment:
+      TEST_SUITE: cubvec
+    resource_class: medium
+    <<: *test_defaults
+
   test_medium:
     <<: *defaults
     environment:


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-52

### Purpose

테스트 성능 최적화 및 CI/CD 파이프라인 개선 제안

현재 상황:
- 단일 테스트 케이스 수정 시에도 전체 test_sql 스위트가 실행되어야 함
- 이로 인한 불필요한 빌드 시간 소요 및 개발 피드백 루프 지연 발생
- 개발 생산성 저하로 이어지는 비효율적인 테스트 실행 구조

### Implementation

1. 테스트 분리 전략
   - cubvec 관련 테스트 케이스들을 독립적인 테스트 스위트로 분리
   - test_plcsql의 구조를 참조하여 새로운 테스트 프레임워크 구축
   - CircleCI 파이프라인 내 별도의 작업(job)으로 구성

2. 성능 목표
   - 테스트 실행 및 결과 피드백 시간을 1분 이내로 최적화
   - 빠른 피드백 루프를 통한 개발 생산성 향상

### Remarks

![image](https://github.com/user-attachments/assets/6f318d79-f41d-4492-8483-bddd599e6312)

> 1분 48초만에 test_cubvec 테스트 수행 완료 확인 가능합니다.

기대 효과:
- 테스트 실행 시간 단축
- 개발자 생산성 향상
- CI/CD 파이프라인 효율성 증대
- 리소스 사용 최적화

이러한 개선을 통해 더욱 효율적이고 신속한 개발 사이클을 구축할 수 있습니다.
