### PR TITLE
[CBRD-25918] end a transaction in RocksDB when CUBRID ends a transaction.

### DIFF
--- a/src/storage/cubrocks.cpp
+++ b/src/storage/cubrocks.cpp
@@ -71,7 +71,10 @@ cubrocks::context::context ()
 
 cubrocks::context::~context ()
 {
-  transactions_finalize ();
+  if (alive)
+    {
+      kv_close ();
+    }
 }
 
 void
@@ -206,6 +209,8 @@ cubrocks::context::kv_close ()
    * also, check if DestroyColumnFamilyHandle should be called. */
   assert (alive);
 
+  transactions_finalize ();
+
   rocksdb::WaitForCompactOptions opt_compact;
   rocksdb::FlushOptions opt_flush;
 
@@ -260,13 +265,24 @@ cubrocks::context::transactions_initialize (void)
 void
 cubrocks::context::transactions_finalize (void)
 {
+  bool status;
   int i;
+
+  if (!alive)
+    {
+      return ;
+    }
 
   for (i = 0; i < MAX_NTRANS; i++)
     {
       if (transactions[i].txn != nullptr)
 	{
+	  status = transactions[i].txn->Rollback ().ok ();
+	  assert (status);
 	  delete transactions[i].txn;
+	  transactions[i].txn = nullptr;
 	}
     }
+
+  delete[] transactions;
 }

--- a/src/storage/cubrocks.cpp
+++ b/src/storage/cubrocks.cpp
@@ -121,19 +121,24 @@ cubrocks::context::is_tran_started (int tran_index)
 void
 cubrocks::context::kv_tran_start (int tran_index)
 {
+  std::cout << "[kv_tran_start: " << tran_index << std::endl;
   rocksdb::WriteOptions write_options;
 
   assert (alive);
   assert (tran_index < MAX_NTRANS);
-  assert (transactions[tran_index].txn == nullptr);
+  assert (tran_index == LOG_SYSTEM_TRAN_INDEX || transactions[tran_index].txn == nullptr);
 
-  transactions[tran_index].txn = db->BeginTransaction (write_options);
-  assert (transactions[tran_index].txn != nullptr);
+  if (transactions[tran_index].txn == nullptr)
+    {
+      transactions[tran_index].txn = db->BeginTransaction (write_options);
+      assert (transactions[tran_index].txn != nullptr);
+    }
 }
 
 void
 cubrocks::context::kv_tran_commit (int tran_index)
 {
+  std::cout << "[kv_tran_commit: " << tran_index << std::endl;
   bool status;
 
   assert (alive);
@@ -154,6 +159,7 @@ cubrocks::context::kv_tran_commit (int tran_index)
 void
 cubrocks::context::kv_tran_abort (int tran_index)
 {
+  std::cout << "[kv_tran_abort: " << tran_index << std::endl;
   bool status;
 
   assert (alive);
@@ -182,9 +188,6 @@ cubrocks::context::kv_create (std::string path)
   /* db will be closed in context::close ( ... ) that is called from boot_.._finalize */
   alive = rocksdb::TransactionDB::Open (opt.db, opt.txndb, path, opt.cf_descriptor, &opt.cf_handles, &db).ok();
   assert (alive);
-
-  /* exception for SYSTEM TRANSACTION */
-  kv_tran_start (LOG_SYSTEM_TRAN_INDEX);
 }
 
 void
@@ -197,9 +200,6 @@ cubrocks::context::kv_open (std::string path)
 
   alive = rocksdb::TransactionDB::Open (opt.db, opt.txndb, path, opt.cf_descriptor, &opt.cf_handles, &db).ok();
   assert (alive);
-
-  /* exception for SYSTEM TRANSACTION */
-  kv_tran_start (LOG_SYSTEM_TRAN_INDEX);
 }
 
 void

--- a/src/storage/cubrocks.cpp
+++ b/src/storage/cubrocks.cpp
@@ -60,7 +60,7 @@ cubrocks::kv_postfix (char *path)
 cubrocks::context::context ()
 {
   kv_config ();
-  sessions_initialize ();
+  transactions_initialize ();
 
   alive = false;
 }
@@ -100,13 +100,35 @@ cubrocks::context::is_alive (void)
   return alive;
 }
 
+bool
+cubrocks::context::is_tran_active (int tran_index)
+{
+  return tran_index == LOG_SYSTEM_TRAN_INDEX || transactions[tran_index].active;
+}
+
+bool
+cubrocks::context::is_tran_started (int tran_index)
+{
+  return transactions[tran_index].txn != nullptr;
+}
+
 void
 cubrocks::context::kv_tran_activate (int tran_index)
 {
   assert (tran_index < MAX_NTRANS);
-  assert (!sessions[tran_index].active);
+  assert (tran_index == LOG_SYSTEM_TRAN_INDEX || !transactions[tran_index].active);
 
-  sessions[tran_index].active = true;
+  transactions[tran_index].active = true;
+}
+
+void
+cubrocks::context::kv_tran_deactivate (int tran_index)
+{
+  assert (tran_index < MAX_NTRANS);
+  assert (transactions[tran_index].active);
+  assert (transactions[tran_index].txn == nullptr);
+
+  transactions[tran_index].active = false;
 }
 
 bool
@@ -115,15 +137,52 @@ cubrocks::context::kv_tran_start (int tran_index)
   rocksdb::WriteOptions write_options;
 
   assert (tran_index < MAX_NTRANS);
-  assert (sessions[tran_index].active);
+  assert (transactions[tran_index].active);
+  assert (transactions[tran_index].txn == nullptr);
 
-  sessions[tran_index].txn = db->BeginTransaction (write_options);
-  if (sessions[tran_index].txn == nullptr)
+  transactions[tran_index].txn = db->BeginTransaction (write_options);
+
+  return (transactions[tran_index].txn != nullptr);
+}
+
+bool
+cubrocks::context::kv_tran_commit (int tran_index)
+{
+  bool status;
+
+  assert (tran_index < MAX_NTRANS);
+  assert (transactions[tran_index].active);
+
+  if (transactions[tran_index].txn == nullptr)
     {
-      return false;
+      return true;
     }
 
-  return true;
+  status = transactions[tran_index].txn->Commit ().ok ();
+  delete transactions[tran_index].txn;
+  transactions[tran_index].txn = nullptr;
+
+  return status;
+}
+
+bool
+cubrocks::context::kv_tran_abort (int tran_index)
+{
+  bool status;
+
+  assert (tran_index < MAX_NTRANS);
+  assert (transactions[tran_index].active);
+
+  if (transactions[tran_index].txn == nullptr)
+    {
+      return true;
+    }
+
+  status = transactions[tran_index].txn->Rollback ().ok ();
+  delete transactions[tran_index].txn;
+  transactions[tran_index].txn = nullptr;
+
+  return status;
 }
 
 bool
@@ -191,20 +250,23 @@ cubrocks::context::kv_destroy (std::string path)
 }
 
 bool
-cubrocks::context::sessions_initialize (void)
+cubrocks::context::transactions_initialize (void)
 {
   int i;
 
-  if ((sessions = new kv_session[MAX_NTRANS]) == nullptr)
+  if ((transactions = new kv_transaction[MAX_NTRANS]) == nullptr)
     {
       return false;
     }
 
   for (i = 0; i < MAX_NTRANS; i++)
     {
-      sessions[i].active = false;
-      sessions[i].txn = nullptr;
+      transactions[i].active = false;
+      transactions[i].txn = nullptr;
     }
+
+  /* system transaction */
+  kv_tran_activate (LOG_SYSTEM_TRAN_INDEX);
 
   return true;
 }

--- a/src/storage/cubrocks.cpp
+++ b/src/storage/cubrocks.cpp
@@ -144,6 +144,7 @@ cubrocks::context::kv_tran_commit (int tran_index)
 
   if (transactions[tran_index].txn == nullptr)
     {
+      assert (tran_index == LOG_SYSTEM_TRAN_INDEX);
       return ;
     }
 
@@ -164,6 +165,7 @@ cubrocks::context::kv_tran_abort (int tran_index)
 
   if (transactions[tran_index].txn == nullptr)
     {
+      assert (tran_index == LOG_SYSTEM_TRAN_INDEX);
       return ;
     }
 

--- a/src/storage/cubrocks.cpp
+++ b/src/storage/cubrocks.cpp
@@ -59,10 +59,19 @@ cubrocks::kv_postfix (char *path)
 
 cubrocks::context::context ()
 {
+  bool status;
+
   kv_config ();
-  transactions_initialize ();
+
+  status = transactions_initialize ();
+  assert (status);
 
   alive = false;
+}
+
+cubrocks::context::~context ()
+{
+  transactions_finalize ();
 }
 
 void
@@ -101,91 +110,65 @@ cubrocks::context::is_alive (void)
 }
 
 bool
-cubrocks::context::is_tran_active (int tran_index)
-{
-  return tran_index == LOG_SYSTEM_TRAN_INDEX || transactions[tran_index].active;
-}
-
-bool
 cubrocks::context::is_tran_started (int tran_index)
 {
   return transactions[tran_index].txn != nullptr;
 }
 
 void
-cubrocks::context::kv_tran_activate (int tran_index)
-{
-  assert (tran_index < MAX_NTRANS);
-  assert (tran_index == LOG_SYSTEM_TRAN_INDEX || !transactions[tran_index].active);
-
-  transactions[tran_index].active = true;
-}
-
-void
-cubrocks::context::kv_tran_deactivate (int tran_index)
-{
-  assert (tran_index < MAX_NTRANS);
-  assert (transactions[tran_index].active);
-  assert (transactions[tran_index].txn == nullptr);
-
-  transactions[tran_index].active = false;
-}
-
-bool
 cubrocks::context::kv_tran_start (int tran_index)
 {
   rocksdb::WriteOptions write_options;
 
+  assert (alive);
   assert (tran_index < MAX_NTRANS);
-  assert (transactions[tran_index].active);
   assert (transactions[tran_index].txn == nullptr);
 
   transactions[tran_index].txn = db->BeginTransaction (write_options);
-
-  return (transactions[tran_index].txn != nullptr);
+  assert (transactions[tran_index].txn != nullptr);
 }
 
-bool
+void
 cubrocks::context::kv_tran_commit (int tran_index)
 {
   bool status;
 
+  assert (alive);
   assert (tran_index < MAX_NTRANS);
-  assert (transactions[tran_index].active);
 
   if (transactions[tran_index].txn == nullptr)
     {
-      return true;
+      return ;
     }
 
   status = transactions[tran_index].txn->Commit ().ok ();
   delete transactions[tran_index].txn;
   transactions[tran_index].txn = nullptr;
 
-  return status;
+  assert (status);
 }
 
-bool
+void
 cubrocks::context::kv_tran_abort (int tran_index)
 {
   bool status;
 
+  assert (alive);
   assert (tran_index < MAX_NTRANS);
-  assert (transactions[tran_index].active);
 
   if (transactions[tran_index].txn == nullptr)
     {
-      return true;
+      return ;
     }
 
   status = transactions[tran_index].txn->Rollback ().ok ();
   delete transactions[tran_index].txn;
   transactions[tran_index].txn = nullptr;
 
-  return status;
+  assert (status);
 }
 
-bool
+void
 cubrocks::context::kv_create (std::string path)
 {
   assert (!alive);
@@ -195,10 +178,13 @@ cubrocks::context::kv_create (std::string path)
 
   /* db will be closed in context::close ( ... ) that is called from boot_.._finalize */
   alive = rocksdb::TransactionDB::Open (opt.db, opt.txndb, path, opt.cf_descriptor, &opt.cf_handles, &db).ok();
-  return alive;
+  assert (alive);
+
+  /* exception for SYSTEM TRANSACTION */
+  kv_tran_start (LOG_SYSTEM_TRAN_INDEX);
 }
 
-bool
+void
 cubrocks::context::kv_open (std::string path)
 {
   assert (!alive);
@@ -207,10 +193,13 @@ cubrocks::context::kv_open (std::string path)
   opt.db.error_if_exists = false;
 
   alive = rocksdb::TransactionDB::Open (opt.db, opt.txndb, path, opt.cf_descriptor, &opt.cf_handles, &db).ok();
-  return alive;
+  assert (alive);
+
+  /* exception for SYSTEM TRANSACTION */
+  kv_tran_start (LOG_SYSTEM_TRAN_INDEX);
 }
 
-bool
+void
 cubrocks::context::kv_close ()
 {
   /* it is not clear whether "Flush -> WaitForCompact" should be called in that order.
@@ -223,30 +212,31 @@ cubrocks::context::kv_close ()
   opt_flush.wait = true;
   if (!db->Flush (opt_flush, opt.cf_handles).ok ())
     {
-      return false;
+      assert (false);
     }
 
   opt_compact.close_db = true;
   if (!db->WaitForCompact (opt_compact).ok ())
     {
-      return false;
+      assert (false);
     }
 
   delete db;
 
   alive = false;
-
-  return true;
 }
 
-bool
+void
 cubrocks::context::kv_destroy (std::string path)
 {
   assert (!alive);
 
   rocksdb::Options options;
 
-  return rocksdb::DestroyDB (path, options).ok();
+  if (!rocksdb::DestroyDB (path, options).ok())
+    {
+      assert (false);
+    }
 }
 
 bool
@@ -261,13 +251,22 @@ cubrocks::context::transactions_initialize (void)
 
   for (i = 0; i < MAX_NTRANS; i++)
     {
-      transactions[i].active = false;
       transactions[i].txn = nullptr;
     }
-
-  /* system transaction */
-  kv_tran_activate (LOG_SYSTEM_TRAN_INDEX);
 
   return true;
 }
 
+void
+cubrocks::context::transactions_finalize (void)
+{
+  int i;
+
+  for (i = 0; i < MAX_NTRANS; i++)
+    {
+      if (transactions[i].txn != nullptr)
+	{
+	  delete transactions[i].txn;
+	}
+    }
+}

--- a/src/storage/cubrocks.cpp
+++ b/src/storage/cubrocks.cpp
@@ -121,7 +121,6 @@ cubrocks::context::is_tran_started (int tran_index)
 void
 cubrocks::context::kv_tran_start (int tran_index)
 {
-  std::cout << "[kv_tran_start: " << tran_index << std::endl;
   rocksdb::WriteOptions write_options;
 
   assert (alive);
@@ -138,7 +137,6 @@ cubrocks::context::kv_tran_start (int tran_index)
 void
 cubrocks::context::kv_tran_commit (int tran_index)
 {
-  std::cout << "[kv_tran_commit: " << tran_index << std::endl;
   bool status;
 
   assert (alive);
@@ -159,7 +157,6 @@ cubrocks::context::kv_tran_commit (int tran_index)
 void
 cubrocks::context::kv_tran_abort (int tran_index)
 {
-  std::cout << "[kv_tran_abort: " << tran_index << std::endl;
   bool status;
 
   assert (alive);

--- a/src/storage/cubrocks.hpp
+++ b/src/storage/cubrocks.hpp
@@ -33,7 +33,6 @@ namespace cubrocks
 {
   struct kv_transaction
   {
-    bool active;
     rocksdb::Transaction *txn;
   };
 
@@ -44,28 +43,25 @@ namespace cubrocks
   {
     public:
       context ();
+      ~context ();
 
       void kv_config ();
 
       /* for debug */
       bool is_alive ();
-      bool is_tran_active (int tran_index);
       bool is_tran_started (int tran_index);
 
       /* transaction */
-      void kv_tran_activate (int tran_index);
-      void kv_tran_deactivate (int tran_index);
+      void kv_tran_start (int tran_index);
 
-      bool kv_tran_start (int tran_index);
-
-      bool kv_tran_commit (int tran_index);
-      bool kv_tran_abort (int tran_index);
+      void kv_tran_commit (int tran_index);
+      void kv_tran_abort (int tran_index);
 
       /* basic */
-      bool kv_create (std::string path);
-      bool kv_open (std::string path);
-      bool kv_close ();
-      bool kv_destroy (std::string path);
+      void kv_create (std::string path);
+      void kv_open (std::string path);
+      void kv_close ();
+      void kv_destroy (std::string path);
 
     private:
       struct
@@ -84,6 +80,7 @@ namespace cubrocks
       bool alive;
 
       bool transactions_initialize ();
+      void transactions_finalize ();
   };
 
   extern context *ctx;

--- a/src/storage/cubrocks.hpp
+++ b/src/storage/cubrocks.hpp
@@ -17,7 +17,7 @@
  */
 
 /*
- * cubrocks.cpp - rocksdb for cubrid
+ * cubrocks.hpp - rocksdb for cubrid
  */
 
 #ifndef _CUBROCKS_HPP_
@@ -29,9 +29,11 @@
 #include "rocksdb/utilities/transaction.h"
 #include "rocksdb/utilities/transaction_db.h"
 
+//#define KV_TRANSACTION_
+
 namespace cubrocks
 {
-  struct kv_session
+  struct kv_transaction
   {
     bool active;
     rocksdb::Transaction *txn;
@@ -47,12 +49,19 @@ namespace cubrocks
 
       void kv_config ();
 
+      /* for debug */
       bool is_alive ();
+      bool is_tran_active (int tran_index);
+      bool is_tran_started (int tran_index);
 
       /* transaction */
       void kv_tran_activate (int tran_index);
+      void kv_tran_deactivate (int tran_index);
 
       bool kv_tran_start (int tran_index);
+
+      bool kv_tran_commit (int tran_index);
+      bool kv_tran_abort (int tran_index);
 
       /* basic */
       bool kv_create (std::string path);
@@ -72,11 +81,11 @@ namespace cubrocks
       } opt;
 
       rocksdb::TransactionDB *db;
-      kv_session *sessions;
+      kv_transaction *transactions;
 
       bool alive;
 
-      bool sessions_initialize ();
+      bool transactions_initialize ();
   };
 
   extern context *ctx;

--- a/src/storage/cubrocks.hpp
+++ b/src/storage/cubrocks.hpp
@@ -29,8 +29,6 @@
 #include "rocksdb/utilities/transaction.h"
 #include "rocksdb/utilities/transaction_db.h"
 
-//#define KV_TRANSACTION_
-
 namespace cubrocks
 {
   struct kv_transaction

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -19004,7 +19004,7 @@ heap_next (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * ne
   LOG_TDES *tdes_debug = NULL;
   assert (cubrocks::ctx->is_alive ());
   assert (tdes_debug = LOG_FIND_TDES (thread_p->tran_index));
-  assert (cubrocks::ctx->is_tran_started (tdes_debug->trid));
+  assert (cubrocks::ctx->is_tran_started (thread_p->tran_index));
 
   return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking, false, NULL, NULL);
 }
@@ -23049,7 +23049,7 @@ heap_insert_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context, 
   LOG_TDES *tdes_debug = NULL;
   assert (cubrocks::ctx->is_alive ());
   assert (tdes_debug = LOG_FIND_TDES (thread_p->tran_index));
-  assert (cubrocks::ctx->is_tran_started (tdes_debug->trid));
+  assert (cubrocks::ctx->is_tran_started (thread_p->tran_index));
 
   /* check required input */
   assert (context != NULL);
@@ -23268,7 +23268,7 @@ heap_delete_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context)
   LOG_TDES *tdes_debug = NULL;
   assert (cubrocks::ctx->is_alive ());
   assert (tdes_debug = LOG_FIND_TDES (thread_p->tran_index));
-  assert (cubrocks::ctx->is_tran_started (tdes_debug->trid));
+  assert (cubrocks::ctx->is_tran_started (thread_p->tran_index));
 
   /*
    * Check input
@@ -23466,7 +23466,7 @@ heap_update_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context)
   LOG_TDES *tdes_debug = NULL;
   assert (cubrocks::ctx->is_alive ());
   assert (tdes_debug = LOG_FIND_TDES (thread_p->tran_index));
-  assert (cubrocks::ctx->is_tran_started (tdes_debug->trid));
+  assert (cubrocks::ctx->is_tran_started (thread_p->tran_index));
 
   /*
    * Check input

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -19001,9 +19001,7 @@ heap_next (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * ne
 	   HEAP_SCANCACHE * scan_cache, int ispeeking)
 {
   /* in this scope, rocksdb must works. */
-  LOG_TDES *tdes_debug = NULL;
   assert (cubrocks::ctx->is_alive ());
-  assert (tdes_debug = LOG_FIND_TDES (thread_p->tran_index));
   assert (cubrocks::ctx->is_tran_started (thread_p->tran_index));
 
   return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking, false, NULL, NULL);
@@ -23046,9 +23044,7 @@ heap_insert_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context, 
   LOG_TDES *tdes = NULL;
 
   /* in this scope, rocksdb must works. */
-  LOG_TDES *tdes_debug = NULL;
   assert (cubrocks::ctx->is_alive ());
-  assert (tdes_debug = LOG_FIND_TDES (thread_p->tran_index));
   assert (cubrocks::ctx->is_tran_started (thread_p->tran_index));
 
   /* check required input */
@@ -23265,9 +23261,7 @@ heap_delete_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context)
   PERF_UTIME_TRACKER time_track;
 
   /* in this scope, rocksdb must works. */
-  LOG_TDES *tdes_debug = NULL;
   assert (cubrocks::ctx->is_alive ());
-  assert (tdes_debug = LOG_FIND_TDES (thread_p->tran_index));
   assert (cubrocks::ctx->is_tran_started (thread_p->tran_index));
 
   /*
@@ -23463,9 +23457,7 @@ heap_update_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context)
   bool is_mvcc_class;
 
   /* in this scope, rocksdb must works. */
-  LOG_TDES *tdes_debug = NULL;
   assert (cubrocks::ctx->is_alive ());
-  assert (tdes_debug = LOG_FIND_TDES (thread_p->tran_index));
   assert (cubrocks::ctx->is_tran_started (thread_p->tran_index));
 
   /*

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -19006,10 +19006,10 @@ heap_next (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * ne
   assert (cubrocks::ctx->is_alive ());
   assert (cubrocks::ctx->is_tran_active (thread_p->tran_index));
   if (!cubrocks::ctx->is_tran_started (thread_p->tran_index))
-  {
-    status = cubrocks::ctx->kv_tran_start (thread_p->tran_index);
-    assert (status);
-  }
+    {
+      status = cubrocks::ctx->kv_tran_start (thread_p->tran_index);
+      assert (status);
+    }
 
   return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking, false, NULL, NULL);
 }
@@ -23055,10 +23055,10 @@ heap_insert_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context, 
   assert (cubrocks::ctx->is_alive ());
   assert (cubrocks::ctx->is_tran_active (thread_p->tran_index));
   if (!cubrocks::ctx->is_tran_started (thread_p->tran_index))
-  {
-    status = cubrocks::ctx->kv_tran_start (thread_p->tran_index);
-    assert (status);
-  }
+    {
+      status = cubrocks::ctx->kv_tran_start (thread_p->tran_index);
+      assert (status);
+    }
 
   /* check required input */
   assert (context != NULL);
@@ -23278,10 +23278,10 @@ heap_delete_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context)
   assert (cubrocks::ctx->is_alive ());
   assert (cubrocks::ctx->is_tran_active (thread_p->tran_index));
   if (!cubrocks::ctx->is_tran_started (thread_p->tran_index))
-  {
-    status = cubrocks::ctx->kv_tran_start (thread_p->tran_index);
-    assert (status);
-  }
+    {
+      status = cubrocks::ctx->kv_tran_start (thread_p->tran_index);
+      assert (status);
+    }
 
   /*
    * Check input
@@ -23480,10 +23480,10 @@ heap_update_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context)
   assert (cubrocks::ctx->is_alive ());
   assert (cubrocks::ctx->is_tran_active (thread_p->tran_index));
   if (!cubrocks::ctx->is_tran_started (thread_p->tran_index))
-  {
-    status = cubrocks::ctx->kv_tran_start (thread_p->tran_index);
-    assert (status);
-  }
+    {
+      status = cubrocks::ctx->kv_tran_start (thread_p->tran_index);
+      assert (status);
+    }
 
   /*
    * Check input

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -19000,8 +19000,16 @@ SCAN_CODE
 heap_next (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * next_oid, RECDES * recdes,
 	   HEAP_SCANCACHE * scan_cache, int ispeeking)
 {
+  bool status;
+
   /* in this scope, rocksdb must works. */
   assert (cubrocks::ctx->is_alive ());
+  assert (cubrocks::ctx->is_tran_active (thread_p->tran_index));
+  if (!cubrocks::ctx->is_tran_started (thread_p->tran_index))
+  {
+    status = cubrocks::ctx->kv_tran_start (thread_p->tran_index);
+    assert (status);
+  }
 
   return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking, false, NULL, NULL);
 }
@@ -23039,11 +23047,18 @@ heap_insert_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context, 
   int rc = NO_ERROR;
   PERF_UTIME_TRACKER time_track;
   bool is_mvcc_class;
+  bool status;
 
   LOG_TDES *tdes = NULL;
 
   /* in this scope, rocksdb must works. */
   assert (cubrocks::ctx->is_alive ());
+  assert (cubrocks::ctx->is_tran_active (thread_p->tran_index));
+  if (!cubrocks::ctx->is_tran_started (thread_p->tran_index))
+  {
+    status = cubrocks::ctx->kv_tran_start (thread_p->tran_index);
+    assert (status);
+  }
 
   /* check required input */
   assert (context != NULL);
@@ -23257,9 +23272,16 @@ heap_delete_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context)
   bool is_mvcc_op;
   int rc = NO_ERROR;
   PERF_UTIME_TRACKER time_track;
+  bool status;
 
   /* in this scope, rocksdb must works. */
   assert (cubrocks::ctx->is_alive ());
+  assert (cubrocks::ctx->is_tran_active (thread_p->tran_index));
+  if (!cubrocks::ctx->is_tran_started (thread_p->tran_index))
+  {
+    status = cubrocks::ctx->kv_tran_start (thread_p->tran_index);
+    assert (status);
+  }
 
   /*
    * Check input
@@ -23452,9 +23474,16 @@ heap_update_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context)
   int rc = NO_ERROR;
   PERF_UTIME_TRACKER time_track;
   bool is_mvcc_class;
+  bool status;
 
   /* in this scope, rocksdb must works. */
   assert (cubrocks::ctx->is_alive ());
+  assert (cubrocks::ctx->is_tran_active (thread_p->tran_index));
+  if (!cubrocks::ctx->is_tran_started (thread_p->tran_index))
+  {
+    status = cubrocks::ctx->kv_tran_start (thread_p->tran_index);
+    assert (status);
+  }
 
   /*
    * Check input

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -19000,16 +19000,11 @@ SCAN_CODE
 heap_next (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * next_oid, RECDES * recdes,
 	   HEAP_SCANCACHE * scan_cache, int ispeeking)
 {
-  bool status;
-
   /* in this scope, rocksdb must works. */
+  LOG_TDES *tdes_debug = NULL;
   assert (cubrocks::ctx->is_alive ());
-  assert (cubrocks::ctx->is_tran_active (thread_p->tran_index));
-  if (!cubrocks::ctx->is_tran_started (thread_p->tran_index))
-    {
-      status = cubrocks::ctx->kv_tran_start (thread_p->tran_index);
-      assert (status);
-    }
+  assert (tdes_debug = LOG_FIND_TDES (thread_p->tran_index));
+  assert (cubrocks::ctx->is_tran_started (tdes_debug->trid));
 
   return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking, false, NULL, NULL);
 }
@@ -23047,18 +23042,14 @@ heap_insert_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context, 
   int rc = NO_ERROR;
   PERF_UTIME_TRACKER time_track;
   bool is_mvcc_class;
-  bool status;
 
   LOG_TDES *tdes = NULL;
 
   /* in this scope, rocksdb must works. */
+  LOG_TDES *tdes_debug = NULL;
   assert (cubrocks::ctx->is_alive ());
-  assert (cubrocks::ctx->is_tran_active (thread_p->tran_index));
-  if (!cubrocks::ctx->is_tran_started (thread_p->tran_index))
-    {
-      status = cubrocks::ctx->kv_tran_start (thread_p->tran_index);
-      assert (status);
-    }
+  assert (tdes_debug = LOG_FIND_TDES (thread_p->tran_index));
+  assert (cubrocks::ctx->is_tran_started (tdes_debug->trid));
 
   /* check required input */
   assert (context != NULL);
@@ -23272,16 +23263,12 @@ heap_delete_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context)
   bool is_mvcc_op;
   int rc = NO_ERROR;
   PERF_UTIME_TRACKER time_track;
-  bool status;
 
   /* in this scope, rocksdb must works. */
+  LOG_TDES *tdes_debug = NULL;
   assert (cubrocks::ctx->is_alive ());
-  assert (cubrocks::ctx->is_tran_active (thread_p->tran_index));
-  if (!cubrocks::ctx->is_tran_started (thread_p->tran_index))
-    {
-      status = cubrocks::ctx->kv_tran_start (thread_p->tran_index);
-      assert (status);
-    }
+  assert (tdes_debug = LOG_FIND_TDES (thread_p->tran_index));
+  assert (cubrocks::ctx->is_tran_started (tdes_debug->trid));
 
   /*
    * Check input
@@ -23474,16 +23461,12 @@ heap_update_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context)
   int rc = NO_ERROR;
   PERF_UTIME_TRACKER time_track;
   bool is_mvcc_class;
-  bool status;
 
   /* in this scope, rocksdb must works. */
+  LOG_TDES *tdes_debug = NULL;
   assert (cubrocks::ctx->is_alive ());
-  assert (cubrocks::ctx->is_tran_active (thread_p->tran_index));
-  if (!cubrocks::ctx->is_tran_started (thread_p->tran_index))
-    {
-      status = cubrocks::ctx->kv_tran_start (thread_p->tran_index);
-      assert (status);
-    }
+  assert (tdes_debug = LOG_FIND_TDES (thread_p->tran_index));
+  assert (cubrocks::ctx->is_tran_started (tdes_debug->trid));
 
   /*
    * Check input

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -1494,7 +1494,6 @@ xboot_initialize_server (const BOOT_CLIENT_CREDENTIAL * client_credential, BOOT_
   const char *db_path, *log_path, *lob_path;
   char *p;
   THREAD_ENTRY *thread_p = NULL;
-  bool status;
 
   assert (client_credential != NULL);
   assert (db_path_info != NULL);
@@ -1850,8 +1849,7 @@ xboot_initialize_server (const BOOT_CLIENT_CREDENTIAL * client_credential, BOOT_
   if (!boot_Init_server_is_canceled)
     {
       /* create the rocksdb dir and files */
-      status = cubrocks::ctx->kv_create (cubrocks::kv_postfix (boot_Db_full_name));
-      assert (status);
+      cubrocks::ctx->kv_create (cubrocks::kv_postfix (boot_Db_full_name));
 
       tran_index =
 	boot_create_all_volumes (thread_p, client_credential, db_path_info->db_comments, db_npages, file_addmore_vols,
@@ -2079,7 +2077,6 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
   char timezone_checksum[32 + 1];
   const TZ_DATA *tzd;
   char *mk_path;
-  bool status;
 
   /* language data is loaded in context of server */
   if (lang_init () != NO_ERROR)
@@ -2405,8 +2402,7 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
     }
 
   /* open the rocksdb storage layer */
-  status = cubrocks::ctx->kv_open (cubrocks::kv_postfix (boot_Db_full_name));
-  assert (status);
+  cubrocks::ctx->kv_open (cubrocks::kv_postfix (boot_Db_full_name));
 
   /* Find the location of the database parameters and read them */
   if (disk_get_boot_hfid (thread_p, LOG_DBFIRST_VOLID, &boot_Db_parm->hfid) == NULL)
@@ -3929,8 +3925,7 @@ boot_server_all_finalize (THREAD_ENTRY * thread_p, ER_FINAL_CODE is_er_final,
 
   if (cubrocks::ctx->is_alive ())
     {
-      status = cubrocks::ctx->kv_close ();
-      assert (status);
+      cubrocks::ctx->kv_close ();
     }
 
   (void) heap_manager_finalize ();
@@ -4897,8 +4892,7 @@ xboot_delete (const char *db_name, bool force_delete, BOOT_SERVER_SHUTDOWN_MODE 
     }
 
   /* destroy the rocksdb dir and files in the directory */
-  status = cubrocks::ctx->kv_destroy (cubrocks::kv_postfix (boot_Db_full_name));
-  assert (status);
+  cubrocks::ctx->kv_destroy (cubrocks::kv_postfix (boot_Db_full_name));
 
 #if defined (SA_MODE)
   cubthread::finalize ();
@@ -4921,8 +4915,7 @@ error_dirty_delete:
   er_stack_pop ();
 
   /* destroy the rocksdb dir and files in the directory */
-  status = cubrocks::ctx->kv_destroy (cubrocks::kv_postfix (boot_Db_full_name));
-  assert (status);
+  cubrocks::ctx->kv_destroy (cubrocks::kv_postfix (boot_Db_full_name));
 
 #if defined (SA_MODE)
   cubthread::finalize ();

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -1850,6 +1850,7 @@ xboot_initialize_server (const BOOT_CLIENT_CREDENTIAL * client_credential, BOOT_
     {
       /* create the rocksdb dir and files */
       cubrocks::ctx->kv_create (cubrocks::kv_postfix (boot_Db_full_name));
+      cubrocks::ctx->kv_tran_start (LOG_SYSTEM_TRAN_INDEX);
 
       tran_index =
 	boot_create_all_volumes (thread_p, client_credential, db_path_info->db_comments, db_npages, file_addmore_vols,
@@ -2403,6 +2404,7 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
 
   /* open the rocksdb storage layer */
   cubrocks::ctx->kv_open (cubrocks::kv_postfix (boot_Db_full_name));
+  cubrocks::ctx->kv_tran_start (LOG_SYSTEM_TRAN_INDEX);
 
   /* Find the location of the database parameters and read them */
   if (disk_get_boot_hfid (thread_p, LOG_DBFIRST_VOLID, &boot_Db_parm->hfid) == NULL)

--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -27,7 +27,6 @@
 #include "perf_monitor.h"
 #include "thread_entry.hpp"
 #include "thread_manager.hpp"
-#include "cubrocks.hpp"
 #include "vacuum.h"
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
 #include "memory_wrapper.hpp"
@@ -1622,9 +1621,6 @@ prior_lsa_start_append (THREAD_ENTRY *thread_p, LOG_PRIOR_NODE *node, LOG_TDES *
        */
       if (LSA_ISNULL (&tdes->head_lsa))
 	{
-	  /* start the transaction */
-	  cubrocks::ctx->kv_tran_start (tdes->tran_index);
-
 	  LSA_COPY (&tdes->head_lsa, &tdes->tail_lsa);
 	}
 

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -823,7 +823,6 @@ logtb_assign_tran_index (THREAD_ENTRY * thread_p, TRANID trid, TRAN_STATE state,
       LOG_SET_CURRENT_TRAN_INDEX (thread_p, LOG_SYSTEM_TRAN_INDEX);
     }
 
-  cubrocks::ctx->kv_tran_activate (tran_index);
   return tran_index;
 }
 
@@ -1015,6 +1014,8 @@ logtb_allocate_tran_index (THREAD_ENTRY * thread_p, TRANID trid, TRAN_STATE stat
       LOG_SET_CURRENT_TRAN_INDEX (thread_p, tran_index);
 
       tdes->tran_abort_reason = TRAN_NORMAL;
+
+      cubrocks::ctx->kv_tran_activate (tran_index);
     }
 
   return tran_index;
@@ -1263,6 +1264,7 @@ logtb_free_tran_index (THREAD_ENTRY * thread_p, int tran_index)
 
 	  LOG_SET_CURRENT_TRAN_INDEX (thread_p, log_tran_index);
 	}
+      cubrocks::ctx->kv_tran_deactivate (tran_index);
     }
 }
 

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -1238,6 +1238,8 @@ logtb_free_tran_index (THREAD_ENTRY * thread_p, int tran_index)
 
   if (tran_index != LOG_SYSTEM_TRAN_INDEX)
     {
+      cubrocks::ctx->kv_tran_abort (tran_index);
+
       tdes->trid = NULL_TRANID;
       tdes->client_id = -1;
 
@@ -1757,7 +1759,7 @@ logtb_get_new_tran_id (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
 
   tdes->trid = trid;
 
-  cubrocks::ctx->kv_tran_start (tdes->trid);
+  cubrocks::ctx->kv_tran_start (tdes->tran_index);
 
   return trid;
 #else
@@ -1776,7 +1778,7 @@ logtb_get_new_tran_id (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
 
   TR_TABLE_CS_EXIT (thread_p);
 
-  cubrocks::ctx->kv_tran_start (tdes->trid);
+  cubrocks::ctx->kv_tran_start (tdes->tran_index);
 
   return tdes->trid;
 #endif

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -1014,8 +1014,6 @@ logtb_allocate_tran_index (THREAD_ENTRY * thread_p, TRANID trid, TRAN_STATE stat
       LOG_SET_CURRENT_TRAN_INDEX (thread_p, tran_index);
 
       tdes->tran_abort_reason = TRAN_NORMAL;
-
-      cubrocks::ctx->kv_tran_activate (tran_index);
     }
 
   return tran_index;
@@ -1264,7 +1262,6 @@ logtb_free_tran_index (THREAD_ENTRY * thread_p, int tran_index)
 
 	  LOG_SET_CURRENT_TRAN_INDEX (thread_p, log_tran_index);
 	}
-      cubrocks::ctx->kv_tran_deactivate (tran_index);
     }
 }
 
@@ -1759,6 +1756,9 @@ logtb_get_new_tran_id (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
   assert (LOG_SYSTEM_TRANID + 1 <= trid && trid <= DB_INT32_MAX);
 
   tdes->trid = trid;
+
+  cubrocks::ctx->kv_tran_start (tdes->trid);
+
   return trid;
 #else
   TR_TABLE_CS_ENTER (thread_p);
@@ -1775,6 +1775,8 @@ logtb_get_new_tran_id (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
     }
 
   TR_TABLE_CS_EXIT (thread_p);
+
+  cubrocks::ctx->kv_tran_start (tdes->trid);
 
   return tdes->trid;
 #endif

--- a/src/transaction/transaction_sr.c
+++ b/src/transaction/transaction_sr.c
@@ -28,6 +28,7 @@
 
 #include "transaction_sr.h"
 
+#include "cubrocks.hpp"
 #include "locator_sr.h"
 #include "log_2pc.h"
 #include "log_lsa.hpp"
@@ -82,6 +83,8 @@ xtran_server_commit (THREAD_ENTRY * thread_p, bool retain_lock)
 
   state = log_commit (thread_p, tran_index, retain_lock);
 
+  cubrocks::ctx->kv_tran_commit (tran_index);
+
 #if defined(ENABLE_SYSTEMTAP)
   if (state == TRAN_UNACTIVE_COMMITTED || state == TRAN_UNACTIVE_COMMITTED_INFORMING_PARTICIPANTS)
     {
@@ -121,6 +124,8 @@ xtran_server_abort (THREAD_ENTRY * thread_p)
   tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
 
   state = log_abort (thread_p, tran_index);
+
+  cubrocks::ctx->kv_tran_abort (tran_index);
 
 #if defined(ENABLE_SYSTEMTAP)
   CUBRID_TRAN_ABORT (tran_index, state);

--- a/src/transaction/transaction_sr.c
+++ b/src/transaction/transaction_sr.c
@@ -72,7 +72,6 @@ TRAN_STATE
 xtran_server_commit (THREAD_ENTRY * thread_p, bool retain_lock)
 {
   TRAN_STATE state;
-  LOG_TDES *tdes;
   int tran_index;
 
   /*
@@ -82,10 +81,7 @@ xtran_server_commit (THREAD_ENTRY * thread_p, bool retain_lock)
 
   tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
 
-  tdes = LOG_FIND_TDES (tran_index);
-  assert (tdes);
-
-  cubrocks::ctx->kv_tran_commit (tdes->trid);
+  cubrocks::ctx->kv_tran_commit (tran_index);
 
   state = log_commit (thread_p, tran_index, retain_lock);
 
@@ -122,16 +118,12 @@ TRAN_STATE
 xtran_server_abort (THREAD_ENTRY * thread_p)
 {
   TRAN_STATE state;
-  LOG_TDES *tdes;
   int tran_index;
 
   /* Execute some few remaining actions before the log manager is notified of the commit */
   tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
 
-  tdes = LOG_FIND_TDES (tran_index);
-  assert (tdes);
-
-  cubrocks::ctx->kv_tran_abort (tdes->trid);
+  cubrocks::ctx->kv_tran_abort (tran_index);
 
   state = log_abort (thread_p, tran_index);
 

--- a/src/transaction/transaction_sr.c
+++ b/src/transaction/transaction_sr.c
@@ -72,6 +72,7 @@ TRAN_STATE
 xtran_server_commit (THREAD_ENTRY * thread_p, bool retain_lock)
 {
   TRAN_STATE state;
+  LOG_TDES *tdes;
   int tran_index;
 
   /*
@@ -81,9 +82,12 @@ xtran_server_commit (THREAD_ENTRY * thread_p, bool retain_lock)
 
   tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
 
-  state = log_commit (thread_p, tran_index, retain_lock);
+  tdes = LOG_FIND_TDES (tran_index);
+  assert (tdes);
 
-  cubrocks::ctx->kv_tran_commit (tran_index);
+  cubrocks::ctx->kv_tran_commit (tdes->trid);
+
+  state = log_commit (thread_p, tran_index, retain_lock);
 
 #if defined(ENABLE_SYSTEMTAP)
   if (state == TRAN_UNACTIVE_COMMITTED || state == TRAN_UNACTIVE_COMMITTED_INFORMING_PARTICIPANTS)
@@ -118,14 +122,18 @@ TRAN_STATE
 xtran_server_abort (THREAD_ENTRY * thread_p)
 {
   TRAN_STATE state;
+  LOG_TDES *tdes;
   int tran_index;
 
   /* Execute some few remaining actions before the log manager is notified of the commit */
   tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
 
-  state = log_abort (thread_p, tran_index);
+  tdes = LOG_FIND_TDES (tran_index);
+  assert (tdes);
 
-  cubrocks::ctx->kv_tran_abort (tran_index);
+  cubrocks::ctx->kv_tran_abort (tdes->trid);
+
+  state = log_abort (thread_p, tran_index);
 
 #if defined(ENABLE_SYSTEMTAP)
   CUBRID_TRAN_ABORT (tran_index, state);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-25918>

### Purpose

CUBRID에서 트랜잭션을 종료(commit, abort)할 때 RocksDB의 트랜잭션을 함께 종료합니다.

### Implementation

N/A

### Remarks

N/A