### PR TITLE
[CBRD-24519] slip: remove a keyword REVERSE from identifier

### DIFF
--- a/pl_engine/pl_server/src/main/antlr/PlcParser.g4
+++ b/pl_engine/pl_server/src/main/antlr/PlcParser.g4
@@ -681,7 +681,6 @@ quoted_string
 identifier
     : REGULAR_ID
     | DELIMITED_ID
-    | REVERSE
     ;
 
 

--- a/pl_engine/pl_server/src/main/antlr/PlcParser.g4
+++ b/pl_engine/pl_server/src/main/antlr/PlcParser.g4
@@ -411,6 +411,7 @@ reserved_builtin_func   /* those which cannot be an identifier */
     | POSITION
     | QUARTER
     | REPLACE
+    | REVERSE
     | SECOND
     | SUBDATE
     | TIME


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-24519>

현재 PL/CSQL의 lexer token (keyword. PlcLexer.g4에 정의) 들은 모두 reserved word 입니다. 
즉, 변수 이름으로 쓸 수 없습니다.
단, 알 수 없는 이유로 (아마도 실수로) REVERSE 만 identifier 가 될 수 있도록 추가되어 있었는데, 
일관성을 위해 삭제합니다. 