### PR TITLE
[CBRD-25854] result-cache enable 환경에서 DML 사용 시 memory leak 발생 (#5838)

### DIFF
--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -2141,7 +2141,7 @@ qmgr_clear_trans_wakeup (THREAD_ENTRY * thread_p, int tran_index, bool is_tran_d
   /* if the transaction is aborting, clear relative cache entries */
   if (tran_entry_p->modified_classes_p)
     {
-      if (!QFILE_IS_LIST_CACHE_DISABLED && !qfile_has_no_cache_entries ())
+      if (!is_abort && !QFILE_IS_LIST_CACHE_DISABLED && !qfile_has_no_cache_entries ())
 	{
 	  qmgr_clear_relative_cache_entries (thread_p, tran_entry_p);
 	}
@@ -2265,9 +2265,11 @@ qmgr_free_oid_block (THREAD_ENTRY * thread_p, OID_BLOCK_LIST * oid_block_p)
 {
   OID_BLOCK_LIST *p;
 
-  for (p = oid_block_p; p; p = p->next)
+  while (oid_block_p)
     {
-      p->last_oid_idx = 0;
+      p = oid_block_p;
+      oid_block_p = p->next;
+      free (p);
     }
 }
 

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -5959,7 +5959,7 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 			    "locator_update_force: qexec_clear_list_cache_by_class failed for class { %d %d %d }\n",
 			    class_oid->pageid, class_oid->slotid, class_oid->volid);
 	    }
-	  if (!OID_EQ (&superclass_oid, class_oid))
+	  if (!OID_ISNULL (&superclass_oid) && !OID_EQ (&superclass_oid, class_oid))
 	    {
 	      qmgr_add_modified_class (thread_p, &superclass_oid);
 	    }
@@ -6282,7 +6282,7 @@ locator_delete_force_internal (THREAD_ENTRY * thread_p, HFID * hfid, OID * oid, 
 	      goto error;
 	    }
 
-	  if (!OID_EQ (&superclass_oid, &class_oid))
+	  if (!OID_ISNULL (&superclass_oid) && !OID_EQ (&superclass_oid, &class_oid))
 	    {
 	      qmgr_add_modified_class (thread_p, &superclass_oid);
 	    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25854

result-cache가 enable 되어 있는 환경 (max_query_cache_entries = p, query_cache_size_in_pages = q, p > 0 and q > 0)에서 DML 쿼리 실행 시 memory leack이 발생합니다.

### Purpose

result-cache를 클리어하는 과정에서 사용하던 related-class 관련 메모리를 free할 수 있도록 한다.

### Implementation

Backport

### Remarks

Result-cache (query cache)에서 발생한 memory leak 이슈를 11.0.14 패치에 적용합니다.
