### PR TITLE
[CBRD-24795] When using a function under <= and >= conditions, the plan generator does not perform a range scan (#4365, #4830)

### DIFF
--- a/src/optimizer/query_rewrite.c
+++ b/src/optimizer/query_rewrite.c
@@ -2286,7 +2286,7 @@ qo_converse_sarg_terms (PARSER_CONTEXT * parser, PT_NODE * where)
 	      arg1 = arg1->info.expr.arg1;
 	    }
 
-	  if (op_type == PT_BETWEEN && arg1_arg1 && pt_is_attr (arg1))
+	  if (op_type == PT_BETWEEN && arg1_arg1 && (pt_is_attr (arg1) || pt_is_function_index_expression (arg1)))
 	    {
 	      /* term in the form of '-attr between opd1 and opd2' convert to '-attr >= opd1 and -attr <= opd2' */
 
@@ -2324,11 +2324,11 @@ qo_converse_sarg_terms (PARSER_CONTEXT * parser, PT_NODE * where)
 	  /* add sargable attribute to attr_list */
 	  if (arg1 && arg2 && pt_converse_op (op_type) != 0)
 	    {
-	      if (pt_is_attr (arg1))
+	      if (pt_is_attr (arg1) || pt_is_function_index_expression (arg1))
 		{
 		  for (attr = attr_list; attr; attr = attr->next)
 		    {
-		      if (pt_name_equal (parser, attr, arg1))
+		      if (pt_check_path_eq (parser, attr, arg1))
 			{
 			  attr->line_number++;	/* increase attribute count */
 			  break;
@@ -2348,11 +2348,11 @@ qo_converse_sarg_terms (PARSER_CONTEXT * parser, PT_NODE * where)
 		    }
 		}
 
-	      if (pt_is_attr (arg2))
+	      if (pt_is_attr (arg2) || pt_is_function_index_expression (arg2))
 		{
 		  for (attr = attr_list; attr; attr = attr->next)
 		    {
-		      if (pt_name_equal (parser, attr, arg2))
+		      if (pt_check_path_eq (parser, attr, arg2))
 			{
 			  attr->line_number++;	/* increase attribute count */
 			  break;
@@ -2437,7 +2437,7 @@ qo_converse_sarg_terms (PARSER_CONTEXT * parser, PT_NODE * where)
 		    }
 		}
 	      else if (op_type != 0 && arg1_arg1
-		       && (pt_is_attr (arg1_arg1)
+		       && ((pt_is_attr (arg1_arg1) || pt_is_function_index_expression (arg1_arg1))
 			   || (pt_is_expr_node (arg1_arg1) && arg1_arg1->info.expr.op == PT_UNARY_MINUS))
 		       && pt_is_const (arg2))
 		{
@@ -2463,7 +2463,7 @@ qo_converse_sarg_terms (PARSER_CONTEXT * parser, PT_NODE * where)
 		    }
 		}
 	      else if (op_type != 0 && arg2_arg1
-		       && (pt_is_attr (arg2->info.expr.arg1)
+		       && ((pt_is_attr (arg2_arg1) || pt_is_function_index_expression (arg2_arg1))
 			   || (pt_is_expr_node (arg2_arg1) && arg2_arg1->info.expr.op == PT_UNARY_MINUS))
 		       && pt_is_const (arg1))
 		{
@@ -2536,21 +2536,21 @@ qo_converse_sarg_terms (PARSER_CONTEXT * parser, PT_NODE * where)
 
 	    }
 	  /* sargable term, where 'op_type' is one of '=', '<' '<=', '>', or '>=' */
-	  else if (arg1 && arg2 && (op_type = pt_converse_op (op_type)) != 0 && pt_is_attr (arg2))
+	  else if (arg1 && arg2 && (op_type = pt_converse_op (op_type)) != 0
+		   && (pt_is_attr (arg2) || pt_is_function_index_expression (arg2)))
 	    {
-
-	      if (pt_is_attr (arg1))
+	      if (pt_is_attr (arg1) || pt_is_function_index_expression (arg1))
 		{
 		  /* term in the form of 'attr op attr' */
 
 		  arg1_cnt = arg2_cnt = 0;	/* init */
 		  for (attr = attr_list; attr; attr = attr->next)
 		    {
-		      if (pt_name_equal (parser, attr, arg1))
+		      if (pt_check_path_eq (parser, attr, arg1))
 			{
 			  arg1_cnt = attr->line_number;
 			}
-		      else if (pt_name_equal (parser, attr, arg2))
+		      else if (pt_check_path_eq (parser, attr, arg2))
 			{
 			  arg2_cnt = attr->line_number;
 			}
@@ -2802,7 +2802,7 @@ qo_search_comp_pair_term (PARSER_CONTEXT * parser, PT_NODE * start)
       arg2 = arg2->info.expr.arg1;
     }
   find_const = pt_is_const_expr_node (arg2);
-  find_attr = pt_is_attr (start->info.expr.arg2);
+  find_attr = (pt_is_attr (start->info.expr.arg2) || pt_is_function_index_expression (start->info.expr.arg2));
 
   arg_prior_start = start->info.expr.arg1;	/* original value */
   if (arg_prior_start->info.expr.op == PT_PRIOR)
@@ -2828,7 +2828,8 @@ qo_search_comp_pair_term (PARSER_CONTEXT * parser, PT_NODE * start)
 
       if (node->info.expr.op == op_type1 || node->info.expr.op == op_type2)
 	{
-	  if (find_const && pt_is_attr (arg_prior) && (pt_check_path_eq (parser, arg_prior_start, arg_prior) == 0))
+	  if (find_const && (pt_is_attr (arg_prior) || pt_is_function_index_expression (arg_prior))
+	      && (pt_check_path_eq (parser, arg_prior_start, arg_prior) == 0))
 	    {
 	      /* skip out unary minus expr */
 	      arg2 = node->info.expr.arg2;
@@ -2842,7 +2843,8 @@ qo_search_comp_pair_term (PARSER_CONTEXT * parser, PT_NODE * start)
 		  break;
 		}
 	    }
-	  if (find_attr && pt_is_attr (arg_prior) && pt_is_attr (node->info.expr.arg2)
+	  if (find_attr && (pt_is_attr (arg_prior) || pt_is_function_index_expression (arg_prior))
+	      && (pt_is_attr (node->info.expr.arg2) || pt_is_function_index_expression (node->info.expr.arg2))
 	      && (pt_check_path_eq (parser, arg_prior_start, node->info.expr.arg1) == 0)
 	      && (pt_check_class_eq (parser, start->info.expr.arg2, node->info.expr.arg2) == 0))
 	    {
@@ -2871,7 +2873,7 @@ qo_search_comp_pair_term (PARSER_CONTEXT * parser, PT_NODE * start)
 static void
 qo_reduce_comp_pair_terms (PARSER_CONTEXT * parser, PT_NODE ** wherep)
 {
-  PT_NODE *node, *pair, *lower, *upper, *prev, *next, *arg2;
+  PT_NODE *node, *pair, *lower, *upper, *prev, *next, *arg1, *arg2;
   int location;
   DB_VALUE *lower_val, *upper_val;
   DB_VALUE_COMPARE_RESULT cmp;
@@ -2879,12 +2881,17 @@ qo_reduce_comp_pair_terms (PARSER_CONTEXT * parser, PT_NODE ** wherep)
   /* traverse CNF list */
   for (node = *wherep; node; node = node->next)
     {
-      if (node->node_type != PT_EXPR
-	  || (!pt_is_attr (node->info.expr.arg1)
-	      && (!PT_IS_EXPR_WITH_PRIOR_ARG (node) || !pt_is_attr (node->info.expr.arg1->info.expr.arg1)))
-	  || node->or_next != NULL)
+      if (node->node_type != PT_EXPR || node->or_next != NULL)
 	{
-	  /* neither expression node, LHS is attribute, nor one predicate term */
+	  /* neither expression node nor one predicate term */
+	  continue;
+	}
+
+      arg1 = pt_get_first_arg_ignore_prior (node);
+
+      if (!pt_is_attr (arg1) && !pt_is_function_index_expression (arg1))
+	{
+	  /* LHS is not an attribute */
 	  continue;
 	}
 
@@ -4028,18 +4035,32 @@ qo_convert_to_range_helper (PARSER_CONTEXT * parser, PT_NODE * node)
 	}
       /* if node had prior check that sibling also contains prior and vice-versa */
 
-      if (!pt_is_attr (sibling_prior) && !pt_is_instnum (sibling_prior))
+      if (!pt_is_attr (sibling_prior) && !pt_is_function_index_expression (sibling_prior)
+	  && !pt_is_instnum (sibling_prior))
 	{
 	  /* LHS is not an attribute */
 	  prev = prev->or_next;
 	  continue;
 	}
 
-      if ((node_prior->node_type != sibling_prior->node_type)
-	  || (pt_is_attr (node_prior) && pt_is_attr (sibling_prior)
-	      && pt_check_path_eq (parser, node_prior, sibling_prior)))
+      if (node_prior->node_type != sibling_prior->node_type)
+	{
+	  prev = prev->or_next;
+	  continue;
+	}
+
+      if ((pt_is_attr (node_prior) || pt_is_function_index_expression (node_prior))
+	  && (pt_is_attr (sibling_prior) || pt_is_function_index_expression (sibling_prior))
+	  && pt_check_path_eq (parser, node_prior, sibling_prior))
 	{
 	  /* pt_check_path_eq() return non-zero if two are different */
+	  prev = prev->or_next;
+	  continue;
+	}
+
+      if ((pt_is_instnum (node_prior) && !pt_is_instnum (sibling_prior))
+	  || (!pt_is_instnum (node_prior) && pt_is_instnum (sibling_prior)))
+	{
 	  prev = prev->or_next;
 	  continue;
 	}
@@ -4743,7 +4764,7 @@ qo_convert_to_range (PARSER_CONTEXT * parser, PT_NODE ** wherep)
 	    }
 
 	  arg1_prior = pt_get_first_arg_ignore_prior (dnf_node);
-	  if (!pt_is_attr (arg1_prior) && !pt_is_instnum (arg1_prior))
+	  if (!(pt_is_attr (arg1_prior) || pt_is_function_index_expression (arg1_prior)) && !pt_is_instnum (arg1_prior))
 	    {
 	      /* LHS is not an attribute */
 	      dnf_prev = dnf_prev ? dnf_prev->or_next : dnf_node;
@@ -5220,12 +5241,10 @@ qo_apply_range_intersection (PARSER_CONTEXT * parser, PT_NODE ** wherep)
 
       arg1_prior = pt_get_first_arg_ignore_prior (node);
 
-      if (!pt_is_attr (arg1_prior) && !pt_is_instnum (arg1_prior))
+      if (!pt_is_attr (arg1_prior) && !pt_is_function_index_expression (arg1_prior) && !pt_is_instnum (arg1_prior))
 	{
 	  /* LHS is not an attribute */
-
 	  node_prev = node_prev ? node_prev->next : *wherep;
-
 	  continue;
 	}
 
@@ -5302,7 +5321,8 @@ qo_apply_range_intersection (PARSER_CONTEXT * parser, PT_NODE ** wherep)
 	    }
 	  /* if node had prior check that sibling also contains prior and vice-versa */
 
-	  if (!pt_is_attr (sibling_prior) && !pt_is_instnum (sibling_prior))
+	  if (!pt_is_attr (sibling_prior) && !pt_is_function_index_expression (sibling_prior)
+	      && !pt_is_instnum (sibling_prior))
 	    {
 	      /* LHS is not an attribute */
 	      sibling_prev = sibling_prev->next;
@@ -5315,11 +5335,24 @@ qo_apply_range_intersection (PARSER_CONTEXT * parser, PT_NODE ** wherep)
 	      continue;
 	    }
 
-	  if ((arg1_prior->node_type != sibling_prior->node_type)
-	      || (pt_is_attr (arg1_prior) && pt_is_attr (sibling_prior)
-		  && pt_check_path_eq (parser, arg1_prior, sibling_prior)))
+	  if (arg1_prior->node_type != sibling_prior->node_type)
+	    {
+	      sibling_prev = sibling_prev->next;
+	      continue;
+	    }
+
+	  if ((pt_is_attr (arg1_prior) || pt_is_function_index_expression (arg1_prior))
+	      && (pt_is_attr (sibling_prior) || pt_is_function_index_expression (sibling_prior))
+	      && pt_check_path_eq (parser, arg1_prior, sibling_prior))
 	    {
 	      /* pt_check_path_eq() return non-zero if two are different */
+	      sibling_prev = sibling_prev->next;
+	      continue;
+	    }
+
+	  if ((pt_is_instnum (arg1_prior) && !pt_is_instnum (sibling_prior))
+	      || (!pt_is_instnum (arg1_prior) && pt_is_instnum (sibling_prior)))
+	    {
 	      sibling_prev = sibling_prev->next;
 	      continue;
 	    }
@@ -6455,7 +6488,8 @@ qo_do_auto_parameterize (PARSER_CONTEXT * parser, PT_NODE * where)
 
 	  node_prior = pt_get_first_arg_ignore_prior (dnf_node);
 
-	  if (!pt_is_attr (node_prior) && !pt_is_instnum (node_prior) && !pt_is_orderbynum (node_prior))
+	  if (!pt_is_attr (node_prior) && !pt_is_function_index_expression (node_prior) && !pt_is_instnum (node_prior)
+	      && !pt_is_orderbynum (node_prior))
 	    {
 	      /* neither LHS is an attribute, inst_num, nor orderby_num */
 	      continue;

--- a/src/optimizer/query_rewrite.c
+++ b/src/optimizer/query_rewrite.c
@@ -2328,7 +2328,7 @@ qo_converse_sarg_terms (PARSER_CONTEXT * parser, PT_NODE * where)
 		{
 		  for (attr = attr_list; attr; attr = attr->next)
 		    {
-		      if (pt_check_path_eq (parser, attr, arg1))
+		      if (pt_check_path_eq (parser, attr, arg1) == 0)
 			{
 			  attr->line_number++;	/* increase attribute count */
 			  break;
@@ -2352,7 +2352,7 @@ qo_converse_sarg_terms (PARSER_CONTEXT * parser, PT_NODE * where)
 		{
 		  for (attr = attr_list; attr; attr = attr->next)
 		    {
-		      if (pt_check_path_eq (parser, attr, arg2))
+		      if (pt_check_path_eq (parser, attr, arg2) == 0)
 			{
 			  attr->line_number++;	/* increase attribute count */
 			  break;
@@ -2546,11 +2546,11 @@ qo_converse_sarg_terms (PARSER_CONTEXT * parser, PT_NODE * where)
 		  arg1_cnt = arg2_cnt = 0;	/* init */
 		  for (attr = attr_list; attr; attr = attr->next)
 		    {
-		      if (pt_check_path_eq (parser, attr, arg1))
+		      if (pt_check_path_eq (parser, attr, arg1) == 0)
 			{
 			  arg1_cnt = attr->line_number;
 			}
-		      else if (pt_check_path_eq (parser, attr, arg2))
+		      else if (pt_check_path_eq (parser, attr, arg2) == 0)
 			{
 			  arg2_cnt = attr->line_number;
 			}

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -12950,6 +12950,10 @@ pt_check_path_eq (PARSER_CONTEXT * parser, const PT_NODE * p, const PT_NODE * q)
     {
       /* if a name, the original and resolved fields must match */
     case PT_NAME:
+      if (p->info.name.spec_id != q->info.name.spec_id)
+	{
+	  return 1;
+	}
       if (pt_str_compare (p->info.name.original, q->info.name.original, CASE_INSENSITIVE))
 	{
 	  return 1;
@@ -12958,11 +12962,7 @@ pt_check_path_eq (PARSER_CONTEXT * parser, const PT_NODE * p, const PT_NODE * q)
 	{
 	  return 1;
 	}
-      if (p->info.name.spec_id != q->info.name.spec_id)
-	{
-	  return 1;
-	}
-      break;
+      break;			/* PT_NAME */
 
       /* EXPR must be X.Y.Z. */
     case PT_DOT_:
@@ -12989,7 +12989,52 @@ pt_check_path_eq (PARSER_CONTEXT * parser, const PT_NODE * p, const PT_NODE * q)
 	  return 1;
 	}
 
-      break;
+      break;			/* PT_DOT_ */
+
+    case PT_EXPR:
+      {
+	if (p->info.expr.op != q->info.expr.op)
+	  {
+	    return 1;
+	  }
+
+	if (pt_check_path_eq (parser, p->info.expr.arg1, q->info.expr.arg1))
+	  {
+	    return 1;
+	  }
+
+	if (pt_check_path_eq (parser, p->info.expr.arg2, q->info.expr.arg2))
+	  {
+	    return 1;
+	  }
+
+	if (pt_check_path_eq (parser, p->info.expr.arg3, q->info.expr.arg3))
+	  {
+	    return 1;
+	  }
+      }
+      break;			/* PT_EXPR */
+
+    case PT_VALUE:
+      {
+	const char *p_str = NULL;
+	const char *q_str = NULL;
+	unsigned int save_custom;
+
+	save_custom = parser->custom_print;	/* save */
+	parser->custom_print |= PT_CONVERT_RANGE;
+
+	p_str = parser_print_tree (parser, p);
+	q_str = parser_print_tree (parser, q);
+
+	parser->custom_print = save_custom;	/* restore */
+
+	if (pt_str_compare (p_str, q_str, CASE_INSENSITIVE))
+	  {
+	    return 1;
+	  }
+      }
+      break;			/* PT_VALUE */
 
     default:
       PT_ERRORmf (parser, p, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_SORT_SPEC_NAN_PATH,
@@ -13033,15 +13078,39 @@ pt_check_class_eq (PARSER_CONTEXT * parser, PT_NODE * p, PT_NODE * q)
     {
       /* if a name, the resolved (class name) fields must match */
     case PT_NAME:
-      if (pt_str_compare (p->info.name.resolved, q->info.name.resolved, CASE_INSENSITIVE))
-	{
-	  return 1;
-	}
       if (p->info.name.spec_id != q->info.name.spec_id)
 	{
 	  return 1;
 	}
-      break;
+      if (pt_str_compare (p->info.name.resolved, q->info.name.resolved, CASE_INSENSITIVE))
+	{
+	  return 1;
+	}
+      break;			/* PT_NAME */
+
+    case PT_EXPR:
+      {
+	if (p->info.expr.op != q->info.expr.op)
+	  {
+	    return 1;
+	  }
+
+	if (pt_check_class_eq (parser, p->info.expr.arg1, q->info.expr.arg1))
+	  {
+	    return 1;
+	  }
+
+	if (pt_check_class_eq (parser, p->info.expr.arg2, q->info.expr.arg2))
+	  {
+	    return 1;
+	  }
+
+	if (pt_check_class_eq (parser, p->info.expr.arg3, q->info.expr.arg3))
+	  {
+	    return 1;
+	  }
+      }
+      break;			/* PT_EXPR */
 
     default:
       PT_ERRORmf (parser, p, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_SORT_SPEC_NAN_PATH,

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -12939,6 +12939,9 @@ pt_check_path_eq (PARSER_CONTEXT * parser, const PT_NODE * p, const PT_NODE * q)
       return 1;
     }
 
+  CAST_POINTER_TO_NODE (p);
+  CAST_POINTER_TO_NODE (q);
+
   /* check node types are same */
   if (p->node_type != q->node_type)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24795
http://jira.cubrid.org/browse/CBRD-25116

backport #4365, #4830