### PR TITLE
[CBRD-25940] [p11_3] Fix JVM's ListenerThread could terminate abnormally due to a system error

### DIFF
--- a/src/executables/javasp.cpp
+++ b/src/executables/javasp.cpp
@@ -113,6 +113,7 @@ static std::string command;
 static std::string db_name;
 static JAVASP_SERVER_INFO running_info = JAVASP_SERVER_INFO_INITIALIZER;
 
+#if !defined(WINDOWS)
 static int
 unmask_signal (int signo)
 {
@@ -122,7 +123,7 @@ unmask_signal (int signo)
   sigaddset (&sigset, signo);
   return sigprocmask (SIG_UNBLOCK, &sigset, NULL);
 }
-
+#endif
 /*
  * main() - javasp main function
  */

--- a/src/executables/javasp.cpp
+++ b/src/executables/javasp.cpp
@@ -113,6 +113,16 @@ static std::string command;
 static std::string db_name;
 static JAVASP_SERVER_INFO running_info = JAVASP_SERVER_INFO_INITIALIZER;
 
+static int
+unmask_signal (int signo)
+{
+  sigset_t sigset;
+
+  sigemptyset (&sigset);
+  sigaddset (&sigset, signo);
+  return sigprocmask (SIG_UNBLOCK, &sigset, NULL);
+}
+
 /*
  * main() - javasp main function
  */
@@ -131,13 +141,26 @@ main (int argc, char *argv[])
       return ER_GENERIC_ERROR;
     }
 
+  if (os_set_signal_handler (SIGTRAP, SIG_IGN) == SIG_ERR)
+    {
+      return ER_GENERIC_ERROR;
+    }
+
+  if (os_set_signal_handler (SIGCHLD, SIG_IGN) == SIG_ERR)
+    {
+      return ER_GENERIC_ERROR;
+    }
+
   os_set_signal_handler (SIGABRT, javasp_signal_handler);
+
+  os_set_signal_handler (SIGTERM, javasp_signal_handler);
+
   os_set_signal_handler (SIGILL, javasp_signal_handler);
   os_set_signal_handler (SIGFPE, javasp_signal_handler);
   os_set_signal_handler (SIGBUS, javasp_signal_handler);
   os_set_signal_handler (SIGSEGV, javasp_signal_handler);
   os_set_signal_handler (SIGSYS, javasp_signal_handler);
-
+  os_set_signal_handler (SIGTERM, javasp_signal_handler);
 #endif /* WINDOWS */
   {
     /*
@@ -313,7 +336,7 @@ static void javasp_signal_handler (int sig)
 {
   JAVASP_SERVER_INFO jsp_info = JAVASP_SERVER_INFO_INITIALIZER;
 
-  if (os_set_signal_handler (sig, SIG_DFL) == SIG_ERR)
+  if (os_set_signal_handler (sig, SIG_IGN) == SIG_ERR)
     {
       return;
     }
@@ -327,6 +350,7 @@ static void javasp_signal_handler (int sig)
   if (status == NO_ERROR && jsp_info.pid != JAVASP_PID_DISABLED)
     {
       (void) envvar_bindir_file (executable_path, PATH_MAX, UTIL_JAVASP_NAME);
+
       if (command.compare ("running") != 0 || db_name.empty ())
 	{
 	  return;
@@ -344,8 +368,30 @@ static void javasp_signal_handler (int sig)
       int pid = fork ();
       if (pid == 0) // child
 	{
-	  execl (executable_path, UTIL_JAVASP_NAME, "start", db_name.c_str (), NULL);
-	  exit (0);
+	  pid_t ppid_begin = getppid ();
+	  do
+	    {
+	      // wait until parent process is terminated
+	      SLEEP_MILISEC (0, 100);
+	      pid_t ppid = getppid ();
+	      if (ppid == 1 || ppid != ppid_begin)
+		{
+		  break;
+		}
+	    }
+	  while (true);
+
+	  unmask_signal (sig);
+
+	  char *argvp[] = { UTIL_JAVASP_NAME, (char *) db_name.c_str (), NULL };
+	  execv (executable_path, argvp);
+	  perror ("execl failed");
+	  exit (1);
+	}
+      else if (pid < 0)
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_SERVER_CRASHED, 1, "fork failed");
+	  exit (1);
 	}
       else
 	{
@@ -357,7 +403,7 @@ static void javasp_signal_handler (int sig)
 	  char **symbols = backtrace_symbols (addresses, nn_addresses);
 
 	  err_msg += "pid (";
-	  err_msg += std::to_string (pid);
+	  err_msg += std::to_string (getpid ());
 	  err_msg += ")\n";
 
 	  for (int i = 0; i < nn_addresses; i++)
@@ -371,16 +417,13 @@ static void javasp_signal_handler (int sig)
 	  free (symbols);
 
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_SERVER_CRASHED, 1, err_msg.c_str ());
-
 	  exit (1);
 	}
     }
-  else
-    {
-      // resume signal hanlding
-      os_set_signal_handler (sig, javasp_signal_handler);
-      is_signal_handling = false;
-    }
+
+  // resume signal hanlding
+  os_set_signal_handler (sig, javasp_signal_handler);
+  is_signal_handling = false;
 }
 #endif
 

--- a/src/executables/javasp.cpp
+++ b/src/executables/javasp.cpp
@@ -152,15 +152,12 @@ main (int argc, char *argv[])
     }
 
   os_set_signal_handler (SIGABRT, javasp_signal_handler);
-
   os_set_signal_handler (SIGTERM, javasp_signal_handler);
-
   os_set_signal_handler (SIGILL, javasp_signal_handler);
   os_set_signal_handler (SIGFPE, javasp_signal_handler);
   os_set_signal_handler (SIGBUS, javasp_signal_handler);
   os_set_signal_handler (SIGSEGV, javasp_signal_handler);
   os_set_signal_handler (SIGSYS, javasp_signal_handler);
-  os_set_signal_handler (SIGTERM, javasp_signal_handler);
 #endif /* WINDOWS */
   {
     /*
@@ -350,7 +347,6 @@ static void javasp_signal_handler (int sig)
   if (status == NO_ERROR && jsp_info.pid != JAVASP_PID_DISABLED)
     {
       (void) envvar_bindir_file (executable_path, PATH_MAX, UTIL_JAVASP_NAME);
-
       if (command.compare ("running") != 0 || db_name.empty ())
 	{
 	  return;

--- a/src/jsp/com/cubrid/jsp/ListenerThread.java
+++ b/src/jsp/com/cubrid/jsp/ListenerThread.java
@@ -32,12 +32,27 @@
 package com.cubrid.jsp;
 
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
 import java.net.ServerSocket;
 import java.net.Socket;
 
 public class ListenerThread extends Thread {
 
     private ServerSocket serverSocket = null;
+
+    // Exponential Backoff
+    private static final int MAX_RETRIES = 5;
+    private static long[] backoff_times = new long[MAX_RETRIES];
+
+    private int attempt = 0;
+
+    static {
+        long initialDelay = 100; // 100ms
+        for (int i = 0; i < MAX_RETRIES; i++) {
+            backoff_times[i] = initialDelay * (1L << i);
+        }
+    }
 
     ListenerThread(ServerSocket serverSocket) {
         super();
@@ -47,14 +62,26 @@ public class ListenerThread extends Thread {
     @Override
     public void run() {
         Socket client = null;
-        while (!Thread.interrupted()) {
+        while (!Thread.interrupted() && attempt < MAX_RETRIES) {
             try {
                 client = serverSocket.accept();
                 client.setTcpNoDelay(true);
                 Thread execThread = new ExecuteThread(client);
                 execThread.start();
-            } catch (IOException e) {
+
+                if (attempt++ > 3) {
+                    throw new OutOfMemoryError();
+                }
+                // attempt = 0;
+            } catch (Throwable e) {
                 Server.log(e);
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                }
+                attempt++;
+
                 break;
             }
         }
@@ -65,9 +92,37 @@ public class ListenerThread extends Thread {
             // do nothing
         }
         serverSocket = null;
+
+        try {
+            killProcess();
+        } catch (Exception e) {
+            Server.log(e);
+        }
+        Server.stop(1);
     }
 
     public ServerSocket getServerSocket() {
         return serverSocket;
+    }
+
+    private static void killProcess() throws IOException, InterruptedException {
+        RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
+        String jvmName = runtimeMXBean.getName();
+        long pid = Long.parseLong(jvmName.split("@")[0]);
+
+        String command = null;
+        if (OSValidator.IS_UNIX) {
+            command = "kill -SIGABRT " + pid;
+        } else {
+            command = "taskkill /F /PID " + pid;
+        }
+        Server.log("Command: " + command);
+        Server.log("Process " + pid + " is going to be terminated");
+
+        Server.flushLog();
+
+        Thread.sleep(1000);
+
+        Runtime.getRuntime().exec(command);
     }
 }

--- a/src/jsp/com/cubrid/jsp/ListenerThread.java
+++ b/src/jsp/com/cubrid/jsp/ListenerThread.java
@@ -68,21 +68,15 @@ public class ListenerThread extends Thread {
                 client.setTcpNoDelay(true);
                 Thread execThread = new ExecuteThread(client);
                 execThread.start();
-
-                if (attempt++ > 3) {
-                    throw new OutOfMemoryError();
-                }
-                // attempt = 0;
+                attempt = 0;
             } catch (Throwable e) {
                 Server.log(e);
                 try {
-                    Thread.sleep(1);
+                    Thread.sleep(backoff_times[attempt]);
                 } catch (InterruptedException ie) {
                     Thread.currentThread().interrupt();
                 }
                 attempt++;
-
-                break;
             }
         }
 

--- a/src/jsp/com/cubrid/jsp/LoggingThread.java
+++ b/src/jsp/com/cubrid/jsp/LoggingThread.java
@@ -34,6 +34,7 @@ package com.cubrid.jsp;
 import java.io.IOException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.logging.FileHandler;
+import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -74,6 +75,12 @@ public class LoggingThread extends Thread {
         try {
             logQueue.put(str);
         } catch (InterruptedException e) {
+        }
+    }
+
+    public void flush() {
+        for (Handler handler : logger.getHandlers()) {
+            handler.flush();
         }
     }
 }

--- a/src/jsp/com/cubrid/jsp/Server.java
+++ b/src/jsp/com/cubrid/jsp/Server.java
@@ -115,11 +115,6 @@ public class Server {
         } catch (Exception e) {
             log(e);
             e.printStackTrace();
-
-            try {
-                Thread.sleep(500);
-            } catch (InterruptedException ie) {
-            }
             System.exit(1);
         }
 
@@ -134,12 +129,6 @@ public class Server {
 
         } else {
             /* error, serverSocket is not properly initialized */
-
-            try {
-                Thread.sleep(500);
-            } catch (InterruptedException ie) {
-            }
-
             System.exit(1);
         }
     }

--- a/src/jsp/com/cubrid/jsp/Server.java
+++ b/src/jsp/com/cubrid/jsp/Server.java
@@ -115,6 +115,11 @@ public class Server {
         } catch (Exception e) {
             log(e);
             e.printStackTrace();
+
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException ie) {
+            }
             System.exit(1);
         }
 
@@ -129,6 +134,12 @@ public class Server {
 
         } else {
             /* error, serverSocket is not properly initialized */
+
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException ie) {
+            }
+
             System.exit(1);
         }
     }
@@ -203,6 +214,10 @@ public class Server {
         Server.start(args);
     }
 
+    public static void log(String str) {
+        loggingThread.log(str);
+    }
+
     public static void log(Throwable ex) {
         StringWriter sw = new StringWriter();
         ex.printStackTrace(new PrintWriter(sw));
@@ -216,5 +231,9 @@ public class Server {
 
     public boolean getShutdown() {
         return shutdown.get();
+    }
+
+    public static void flushLog() {
+        loggingThread.flush();
     }
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25940

### Purpose

ListenrThread에서 OutOfMemory 등 JVM 및 시스템 관련 에러가 발생하는 경우에 IOException에 의해 자바 로그를 수집하지도 않고 종료될 수 있다. 이 경우 JVM은 DB 서버로부터 어떠한 요청을 받지도 못하고, 기능이 없는 빈 프로세스만 남을 수 있다.

이 PR에서 비정상적인 에러 발생 시 스스로 종료 후 재시작할 수 있도록 수정한다. 리눅스 환경에서 시그널 발생 시 프로세스를 재시작하는 기능은 구현되어 있으므로, 외부 명령어를 이용해 sigabort 명령어를 보내고 재시작할 수 있도록 수정한다.

### Implementation

- Throwable이 반복적으로 발생 시 (`backoff_times` 만큼 대기한 후 여러번 시도) 자기자신 프로세스에 signal을 보내는 코드 추가
- 종료된다는 로그를 강제로 쓰고 종료할 수 있도록 Server.flushLog () 추가
- javasp.cpp에서 signal handler 수정
  - 부모프로세스가 종료된 후 exec 할 수 있도록 수정
  - unmask_signal () 함수를 호출하여 여러번 실패하는 경우에도 계속 재시동 될 수 있도록 수정
  
### Remarks

- 테스트는 c344303에서 ListenerThread에서 소켓 연결을 받을 때 3번 이상 호출하는 경우 강제로 OutOfMemoryError가 발생하도록 하여 이 이슈에서 해결하려는 에러 상황을 재현함
