### PR TITLE
[CBRD-25940] Fix JVM's ListenerThread could terminate abnormally due to a system error

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/ListenerThread.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/ListenerThread.java
@@ -32,12 +32,27 @@
 package com.cubrid.jsp;
 
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
 import java.net.ServerSocket;
 import java.net.Socket;
 
 public class ListenerThread extends Thread {
 
     private ServerSocket serverSocket = null;
+
+    // Exponential Backoff
+    private static final int MAX_RETRIES = 5;
+    private static long[] backoff_times = new long[MAX_RETRIES];
+
+    private int attempt = 0;
+
+    static {
+        long initialDelay = 100; // 100ms
+        for (int i = 0; i < MAX_RETRIES; i++) {
+            backoff_times[i] = initialDelay * (1L << i); // 2의 i 제곱에 초기 지연 값을 곱한다
+        }
+    }
 
     ListenerThread(ServerSocket serverSocket) {
         super();
@@ -47,15 +62,21 @@ public class ListenerThread extends Thread {
     @Override
     public void run() {
         Socket client = null;
-        while (!Thread.interrupted()) {
+        while (!Thread.interrupted() && attempt < MAX_RETRIES) {
             try {
                 client = serverSocket.accept();
                 client.setTcpNoDelay(true);
                 Thread execThread = new ExecuteThread(client);
                 execThread.start();
-            } catch (IOException e) {
+                attempt = 0;
+            } catch (Throwable e) {
                 Server.log(e);
-                break;
+                try {
+                    Thread.sleep(backoff_times[attempt]);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                }
+                attempt++;
             }
         }
 
@@ -65,9 +86,38 @@ public class ListenerThread extends Thread {
             // do nothing
         }
         serverSocket = null;
+
+        try {
+            killProcess();
+        } catch (Exception e) {
+            Server.log(e);
+        }
+        Server.stop(1);
     }
 
     public ServerSocket getServerSocket() {
         return serverSocket;
+    }
+
+    private static void killProcess() throws IOException, InterruptedException {
+        RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
+        String jvmName = runtimeMXBean.getName();
+        long pid = Long.parseLong(jvmName.split("@")[0]);
+
+        Runtime.getRuntime().exec("kill -SIGABORT " + pid);
+        String command = null;
+        if (OSValidator.IS_UNIX) {
+            command = "kill -SIGABRT " + pid;
+        } else {
+            command = "taskkill /F /PID " + pid;
+        }
+
+        Process process = Runtime.getRuntime().exec(command);
+        int exitValue = process.waitFor();
+        if (exitValue == 0) {
+            Server.log("Process " + pid + " has been terminated successfully.");
+        } else {
+            Server.log("Failed to terminate process " + pid + ".");
+        }
     }
 }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/ListenerThread.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/ListenerThread.java
@@ -50,7 +50,7 @@ public class ListenerThread extends Thread {
     static {
         long initialDelay = 100; // 100ms
         for (int i = 0; i < MAX_RETRIES; i++) {
-            backoff_times[i] = initialDelay * (1L << i); // 2의 i 제곱에 초기 지연 값을 곱한다
+            backoff_times[i] = initialDelay * (1L << i);
         }
     }
 
@@ -104,20 +104,19 @@ public class ListenerThread extends Thread {
         String jvmName = runtimeMXBean.getName();
         long pid = Long.parseLong(jvmName.split("@")[0]);
 
-        Runtime.getRuntime().exec("kill -SIGABORT " + pid);
         String command = null;
         if (OSValidator.IS_UNIX) {
             command = "kill -SIGABRT " + pid;
         } else {
             command = "taskkill /F /PID " + pid;
         }
+        Server.log("Command: " + command);
+        Server.log("Process " + pid + " is going to be terminated");
 
-        Process process = Runtime.getRuntime().exec(command);
-        int exitValue = process.waitFor();
-        if (exitValue == 0) {
-            Server.log("Process " + pid + " has been terminated successfully.");
-        } else {
-            Server.log("Failed to terminate process " + pid + ".");
-        }
+        Server.flushLog();
+
+        Thread.sleep(1000);
+
+        Runtime.getRuntime().exec(command);
     }
 }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/LoggingThread.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/LoggingThread.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.logging.FileHandler;
+import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -78,6 +79,12 @@ public class LoggingThread extends Thread {
         try {
             logQueue.put(str);
         } catch (InterruptedException e) {
+        }
+    }
+
+    public void flush() {
+        for (Handler handler : logger.getHandlers()) {
+            handler.flush();
         }
     }
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/Server.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/Server.java
@@ -267,6 +267,10 @@ public class Server {
         loggingThread.log(str);
     }
 
+    public static void flushLog() {
+        loggingThread.flush();
+    }
+
     public void setShutdown() {
         shutdown.set(true);
     }

--- a/src/executables/pl.cpp
+++ b/src/executables/pl.cpp
@@ -165,12 +165,18 @@ main (int argc, char *argv[])
 #if defined(WINDOWS)
   FARPROC pl_old_hook = NULL;
 #else
-  if (os_set_signal_handler (SIGPIPE, SIG_IGN) == SIG_ERR)
+  if (os_set_signal_handler (SIGTRAP, SIG_IGN) == SIG_ERR)
+    {
+      return ER_GENERIC_ERROR;
+    }
+
+  if (os_set_signal_handler (SIGCHLD, SIG_IGN) == SIG_ERR)
     {
       return ER_GENERIC_ERROR;
     }
 
   os_set_signal_handler (SIGABRT, pl_signal_handler);
+  os_set_signal_handler (SIGTERM, pl_signal_handler);
   os_set_signal_handler (SIGILL, pl_signal_handler);
   os_set_signal_handler (SIGFPE, pl_signal_handler);
   os_set_signal_handler (SIGBUS, pl_signal_handler);
@@ -422,12 +428,10 @@ static void pl_signal_handler (int sig)
 
       exit (1);
     }
-  else
-    {
-      // resume signal hanlding
-      os_set_signal_handler (sig, pl_signal_handler);
-      is_signal_handling = false;
-    }
+
+  // resume signal hanlding
+  os_set_signal_handler (sig, pl_signal_handler);
+  is_signal_handling = false;
 }
 #endif
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25940

### Purpose

ListenrThread에서 OutOfMemory 등 JVM 및 시스템 관련 에러가 발생하는 경우에 IOException에 의해 자바 로그를 수집하지도 않고 종료될 수 있다. 이 경우 JVM은 DB 서버로부터 어떠한 요청을 받지도 못하고, 기능이 없는 빈 프로세스만 남을 수 있다.

이 PR에서 비정상적인 에러 발생 시 스스로 종료 후 DB 서버가 재시작할 수 있도록 수정한다. Java에서 Process를 통해 sigabort 시그널을 보내고 재시작할 수 있도록 한다.

### Implementation

- Throwable이 반복적으로 발생 시 (backoff_times 만큼 대기한 후 여러번 시도) 자기자신 프로세스에 signal을 보내는 코드 추가
- 종료된다는 로그를 강제로 쓰고 종료할 수 있도록 Server.flushLog () 추가
- pl.cpp
  - SIGTERM에 대한 핸들링 추가

### Remarks

N/A
