### PR TITLE
[CBRD-25955] print an error message when executing ;info schema/stats/ndv with not exist class

### DIFF
--- a/src/object/object_print.c
+++ b/src/object/object_print.c
@@ -622,6 +622,10 @@ help_print_info (const char *command, FILE * fpp)
 	    {
 	      help_print_obj (output_ctx, class_mop);
 	    }
+          else
+           {
+              fprintf (fpp, "\nERROR: Unknown class \"%s.%s\"\n", ustr_lower(db_get_user_name()), buffer);
+           }
 	}
     }
   else if (MATCH_TOKEN (buffer, "trigger"))

--- a/src/object/object_print.c
+++ b/src/object/object_print.c
@@ -622,10 +622,10 @@ help_print_info (const char *command, FILE * fpp)
 	    {
 	      help_print_obj (output_ctx, class_mop);
 	    }
-          else
-           {
-              fprintf (fpp, "\nERROR: Unknown class \"%s.%s\"\n", ustr_lower(db_get_user_name()), buffer);
-           }
+	  else
+	    {
+	      fprintf (fpp, "\nERROR: %s\n", er_msg ());
+	    }
 	}
     }
   else if (MATCH_TOKEN (buffer, "trigger"))

--- a/src/storage/statistics_cl.c
+++ b/src/storage/statistics_cl.c
@@ -305,7 +305,7 @@ stats_dump (const char *class_name_p, FILE * file_p)
   class_mop = sm_find_class (class_name_p);
   if (class_mop == NULL)
     {
-      fprintf (file_p, "ERROR: Unknown class \"%s\"\n", class_name_p);
+      fprintf (file_p, "\nERROR: %s\n", er_msg ());
       return;
     }
 
@@ -395,7 +395,7 @@ stats_ndv_dump (const char *class_name_p, FILE * file_p)
   class_mop = sm_find_class (class_name_p);
   if (class_mop == NULL)
     {
-      fprintf (file_p, "ERROR: Unknown class \"%s\"\n", class_name_p);
+      fprintf (file_p, "\nERROR: %s\n", er_msg ());
       return;
     }
 

--- a/src/storage/statistics_cl.c
+++ b/src/storage/statistics_cl.c
@@ -305,6 +305,7 @@ stats_dump (const char *class_name_p, FILE * file_p)
   class_mop = sm_find_class (class_name_p);
   if (class_mop == NULL)
     {
+      fprintf (file_p, "ERROR: Unknown class \"%s\"\n", class_name_p);
       return;
     }
 
@@ -394,6 +395,7 @@ stats_ndv_dump (const char *class_name_p, FILE * file_p)
   class_mop = sm_find_class (class_name_p);
   if (class_mop == NULL)
     {
+      fprintf (file_p, "ERROR: Unknown class \"%s\"\n", class_name_p);
       return;
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25955
