### PR TITLE
[CBRD-25930] Windows에서 cub_pl이 재시작되지 않는 문제 수정

### DIFF
--- a/src/base/process_util.c
+++ b/src/base/process_util.c
@@ -399,15 +399,17 @@ is_terminated_process (const int pid)
       return true;
     }
 
-    DWORD exit_code;
-    if (GetExitCodeProcess(h_process, &exit_code)) {
-        CloseHandle(h_process);
-        // if the process is terminated, return true
-        return (exit_code != STILL_ACTIVE);
+  DWORD exit_code;
+  if (GetExitCodeProcess (h_process, &exit_code))
+    {
+      CloseHandle (h_process);
+      return (exit_code != STILL_ACTIVE);
     }
-
-    CloseHandle (h_process);
-    return true;
+  else
+    {
+      CloseHandle (h_process);
+      return true;
+    }
 #else /* WINDOWS */
   if (kill (pid, 0) == -1)
     {

--- a/src/base/process_util.c
+++ b/src/base/process_util.c
@@ -398,11 +398,16 @@ is_terminated_process (const int pid)
     {
       return true;
     }
-  else
-    {
-      CloseHandle (h_process);
-      return false;
+
+    DWORD exit_code;
+    if (GetExitCodeProcess(h_process, &exit_code)) {
+        CloseHandle(h_process);
+        // if the process is terminated, return true
+        return (exit_code != STILL_ACTIVE);
     }
+
+    CloseHandle (h_process);
+    return true;
 #else /* WINDOWS */
   if (kill (pid, 0) == -1)
     {

--- a/src/sp/pl_sr.cpp
+++ b/src/sp/pl_sr.cpp
@@ -258,6 +258,7 @@ namespace cubpl
   void
   server_manager::start ()
   {
+    pl_reset_info (m_db_name.c_str ());
 #if defined (SERVER_MODE)
     cubthread::looper looper = cubthread::looper (std::chrono::milliseconds (1000));
     m_monitor_helper_daemon = cubthread::get_manager ()->create_daemon (looper, m_server_monitor_task, "pl_monitor");
@@ -529,6 +530,7 @@ namespace cubpl
 	  {
 	    // PL server is terminated by user (cubrid pl restart)
 	    m_state = SERVER_MONITOR_STATE_STOPPED;
+	    m_failure_count = 0;
 	  }
 
 	if (m_state == SERVER_MONITOR_STATE_UNKNOWN)

--- a/src/sp/pl_sr.cpp
+++ b/src/sp/pl_sr.cpp
@@ -258,7 +258,6 @@ namespace cubpl
   void
   server_manager::start ()
   {
-    pl_reset_info (m_db_name.c_str ());
 #if defined (SERVER_MODE)
     cubthread::looper looper = cubthread::looper (std::chrono::milliseconds (1000));
     m_monitor_helper_daemon = cubthread::get_manager ()->create_daemon (looper, m_server_monitor_task, "pl_monitor");
@@ -359,6 +358,7 @@ namespace cubpl
       {
 	int status;
 
+	pl_reset_info (m_db_name.c_str ());
 	int pid = create_child_process (m_executable_path.c_str (), m_argv, 0 /* do not wait */, nullptr, nullptr, nullptr,
 					&status);
 	if (pid > 1) // parent


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25930

### Purpose

- pid와 port 번호가 저장되어 있는 <db_name>_pl.info 파일이 모니터링 전에 초기화되지 않은 경우 cub_pl이 실행되지 않는 문제 수정
- 모니터링에서 cub_pl 구동 실패 시, cubrid pl restart에 의해 감지되어 STOPPED state가 되었음에도 m_failure_count가 초기화 되지 않아 바로 FAILED_TO_INITIALIZE 상태로 빠지는 문제 수정

### Implementation

N/A

### Remarks

N/A
