### PR TITLE
[CBRD-25951] PL/CSQL Static SQL Loop 내 CTE에서 SP 사용 시 Core Dump 발생

### DIFF
--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -21979,8 +21979,10 @@ parser_generate_xasl_post (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, i
       break;
 
     case PT_CTE:
-      assert (node->info.cte.xasl == NULL);
-
+      if (node->info.cte.xasl != NULL)
+	{
+	  assert (parser->host_var_count == 0 && parser->auto_param_count == 0);
+	}
       xasl = parser_generate_xasl_proc (parser, node, info->query_list);
       break;
 

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -21979,10 +21979,7 @@ parser_generate_xasl_post (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, i
       break;
 
     case PT_CTE:
-      if (node->info.cte.xasl != NULL)
-	{
-	  assert (parser->host_var_count == 0 && parser->auto_param_count == 0);
-	}
+      assert (node->info.cte.xasl == NULL || (parser->host_var_count == 0 && parser->auto_param_count == 0));
       xasl = parser_generate_xasl_proc (parser, node, info->query_list);
       break;
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-25951>

### Purpose

query plan이 캐쉬 되지 않는 경우, prepare 후 쿼리가 실행 될 때, 호스트 변수(auto param포함)가 없으면 반복 실행에서 assert 발생하는 이슈를 해결

### Implementation

xasl generation 과정에서 CTE xasl을 생성할 때, assert 체크에서 조건을 추가함
즉, CTE xasl이 NULL이 아닌 경우 assert (parser->host_var_count == 0 && parser->auto_param_count == 0)

### Remarks

- release mode에서는 발생 안함.
- SP 관련 쿼리 뿐만 아니라, 디버그 모드로 plan cache가 0으로 설정된 경우 호스트 변수가 없는 쿼리를 반복 실행할 때 발생할 수 있음.
