### PR TITLE
[CBRD-25953] trivial: correct logic for clearing Context in PL server

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/classloader/SessionClassLoaderGroup.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/classloader/SessionClassLoaderGroup.java
@@ -15,7 +15,7 @@ public class SessionClassLoaderGroup {
     public void clear() {
         if (classLoaders != null) {
             classLoaders.clear();
-            classLoaders = null;
+            classLoaders = new HashMap<>();
         }
     }
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/classloader/SessionClassLoaderGroup.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/classloader/SessionClassLoaderGroup.java
@@ -13,9 +13,7 @@ public class SessionClassLoaderGroup {
     }
 
     public void clear() {
-        if (classLoaders != null) {
-            classLoaders.clear();
-        }
+        classLoaders.clear();
     }
 
     public Class<?> loadClass(CompiledCodeSet code) throws ClassNotFoundException {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/classloader/SessionClassLoaderGroup.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/classloader/SessionClassLoaderGroup.java
@@ -13,8 +13,10 @@ public class SessionClassLoaderGroup {
     }
 
     public void clear() {
-        classLoaders.clear();
-        classLoaders = null;
+        if (classLoaders != null) {
+            classLoaders.clear();
+            classLoaders = null;
+        }
     }
 
     public Class<?> loadClass(CompiledCodeSet code) throws ClassNotFoundException {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/classloader/SessionClassLoaderGroup.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/classloader/SessionClassLoaderGroup.java
@@ -15,7 +15,6 @@ public class SessionClassLoaderGroup {
     public void clear() {
         if (classLoaders != null) {
             classLoaders.clear();
-            classLoaders = new HashMap<>();
         }
     }
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/context/ContextManager.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/context/ContextManager.java
@@ -61,13 +61,13 @@ public class ContextManager {
         }
     }
 
-    public static void destroyContext(long id) {
+    public static synchronized void destroyContext(long id) {
         if (hasContext(id)) {
             Context ctx = contextMap.get(id);
+            contextMap.remove(id);
             if (ctx != null) {
                 ctx.destroy();
             }
-            contextMap.remove(id);
             // System.out.println ("deleted session =" + id); // for debug
         }
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25953

### Purpose

- SessionClassLoaderGroup 에서 clear () 함수에서 NullPointerException이 발생할 수 있는 코드를 수정
- destoryContext () 함수가 여러 스레드에 의해 동시에 진행하지 않도록 수정

### Implementation

N/A

### Remarks

N/A
