### PR TITLE
[CBRD-25956] Fix coredump when removing entry which does not exists

### DIFF
--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -131,8 +131,10 @@ void
 server_monitor::remove_server_entry (const std::string &server_name)
 {
   auto entry = m_server_entry_map.find (server_name);
-  assert (entry != m_server_entry_map.end ());
 
+  // When the stop command for the same CUBRID server is invoked concurrently,
+  // the corresponding server entry may have already been removed.
+  // Therefore, the assertion should be skipped to avoid unnecessary failures.
   if (entry != m_server_entry_map.end ())
     {
       er_log_debug (ARG_FILE_LINE,

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -133,11 +133,14 @@ server_monitor::remove_server_entry (const std::string &server_name)
   auto entry = m_server_entry_map.find (server_name);
   assert (entry != m_server_entry_map.end ());
 
-  er_log_debug (ARG_FILE_LINE,
-		"[Server Monitor] [%s] Server entry has been unregistered. (pid : %d)",
-		server_name.c_str(), entry->second.get_pid());
+  if (entry != m_server_entry_map.end ())
+    {
+      er_log_debug (ARG_FILE_LINE,
+		    "[Server Monitor] [%s] Server entry has been unregistered. (pid : %d)",
+		    server_name.c_str(), entry->second.get_pid());
 
-  m_server_entry_map.erase (entry);
+      m_server_entry_map.erase (entry);
+    }
 }
 
 void


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-25956>

### Purpose

- 같은 server에 대한 정상 종료가 연속으로 발생하는 등의 timing issue에 대해서, `server_entry`가 존재하지 않을 때 제거를 시도하여 coredump가 발생할 가능성이 존재함
- cubrid-testcases-private/longcase/shell/other/bug_bts_6667/cases/bug_bts_6667.sh TC에 대하여 coredump가 발생함이 확인됨

### Implementation

- `remove_server_entry` 함수에 대하여, `server_entry`가 존재하는 경우에만 제거하도록 변경

