### PR TITLE
[CBRD-25958] UDS를 사용하지 않고 랜덤 포트로 연결할 때 PL 재시작 시 PL 서버에 연결이 안되는 문제 수정

### DIFF
--- a/src/executables/pl.cpp
+++ b/src/executables/pl.cpp
@@ -451,7 +451,6 @@ pl_start_server (const PL_SERVER_INFO pl_info, const std::string &db_name, const
 	  er_clear();
 	}
 
-      int port = (status == NO_ERROR) ? pl_server_port () : PL_PORT_DISABLED;
       PL_SERVER_INFO pl_new_info { getpid(), pl_server_port () };
 
       pl_unlink_info (db_name.c_str ());

--- a/src/sp/pl_connection.hpp
+++ b/src/sp/pl_connection.hpp
@@ -89,10 +89,6 @@ namespace cubpl
       void set_db_port (int port);
 
       bool is_system_pool () const;
-      void set_port_disabled()
-      {
-	m_db_port = PL_PORT_DISABLED;
-      }
 
     private:
       explicit connection_pool (int pool_size);

--- a/src/sp/pl_sr.cpp
+++ b/src/sp/pl_sr.cpp
@@ -561,14 +561,14 @@ namespace cubpl
     do
       {
 	error = do_ping_connection ();
-	if (error == NO_ERROR || ++c < fail_cnt)
+	if (error == NO_ERROR || ++c > fail_cnt)
 	  {
 	    break;
 	  }
 
 	/* The contents of the pl file may have changed, so set it to read again. */
 	assert (m_sys_conn_pool);
-	m_sys_conn_pool->set_port_disabled();
+	m_sys_conn_pool->set_db_port (pl_server_port_from_info ());
 
 	thread_sleep (1000);	/* 1000 msec */
       }

--- a/src/sp/pl_sr_jvm.cpp
+++ b/src/sp/pl_sr_jvm.cpp
@@ -109,7 +109,7 @@ typedef jint (*CREATE_VM_FUNC) (JavaVM **, void **, void *);
 	(ENV)->GetStringUTFLength(STRING)
 
 static JavaVM *jvm = NULL;
-static jint sp_port = -1;
+static jint sp_port = PL_PORT_DISABLED;
 static std::string err_msgs;
 
 #if defined(WINDOWS)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25958

### Purpose

PL 서버와의 연결에 TCP가 사용되고, 랜덤 포트로 연결될 때, PL 재시작시 새로운 포트가 할당되는데
이 정보를 올바르게 설정하지 않아 PL 재시작 시 연결되지 않는 문제를 수정함

### Implementation

- pl_sr.cpp
  - 잘못된 재시도 조건 수정
  - set_port_disabled () 함수 제거, 파일로 부터 port 번호를 가져오도록 수정
- sp_port의 초기값을 올바르게 수정: PL_PORT_DISABLED (-2)
- 사용되지 않는 다음 로직 수정 
  - `int port = (status == NO_ERROR) ? pl_server_port () : PL_PORT_DISABLED;`

### Remarks

N/A
