### PR TITLE
[CBRD-25934] Skip errors due to ownership change in unloaddb.

### DIFF
--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -8592,7 +8592,7 @@ au_export_grants (extract_context & ctxt, print_output & output_ctx, MOP class_m
   int error = NO_ERROR;
   CLASS_AUTH cl_auth;
   CLASS_USER *u;
-  int statements, ecount;
+  int statements;
   char *uname;
 
   cl_auth.class_mop = class_mop;
@@ -8611,7 +8611,7 @@ au_export_grants (extract_context & ctxt, print_output & output_ctx, MOP class_m
       while ((statements = class_grant_loop (ctxt, output_ctx, &cl_auth)))
 	;
 
-      for (u = cl_auth.users, ecount = 0; u != NULL; u = u->next)
+      for (u = cl_auth.users; u != NULL; u = u->next)
 	{
 	  if (u->grants != NULL)
 	    {
@@ -8627,11 +8627,6 @@ au_export_grants (extract_context & ctxt, print_output & output_ctx, MOP class_m
 	      output_ctx ("*/\n");
 	      ws_free_string (uname);
 	    }
-	}
-      if (ecount)
-	{
-	  error = ER_GENERIC_ERROR;
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 0);
 	}
     }
 

--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -8615,9 +8615,17 @@ au_export_grants (extract_context & ctxt, print_output & output_ctx, MOP class_m
 	{
 	  if (u->grants != NULL)
 	    {
-	      // No error handling.
-	      // This case can occur when changing table ownership via ALTER TABLE.
-	      continue;
+	      uname = au_get_user_name (u->obj);
+
+	      /*
+	       * should this be setting an error condition ?
+	       * for now, leave a comment in the output file
+	       */
+	      output_ctx ("/*");
+	      output_ctx (msgcat_message (MSGCAT_CATALOG_CUBRID, MSGCAT_SET_AUTHORIZATION,
+					  MSGCAT_AUTH_GRANT_DUMP_ERROR), uname);
+	      output_ctx ("*/\n");
+	      ws_free_string (uname);
 	    }
 	}
       if (ecount)

--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -8615,18 +8615,9 @@ au_export_grants (extract_context & ctxt, print_output & output_ctx, MOP class_m
 	{
 	  if (u->grants != NULL)
 	    {
-	      uname = au_get_user_name (u->obj);
-
-	      /*
-	       * should this be setting an error condition ?
-	       * for now, leave a comment in the output file
-	       */
-	      output_ctx ("/*");
-	      output_ctx (msgcat_message (MSGCAT_CATALOG_CUBRID, MSGCAT_SET_AUTHORIZATION,
-					  MSGCAT_AUTH_GRANT_DUMP_ERROR), uname);
-	      output_ctx ("*/\n");
-	      ws_free_string (uname);
-	      ecount++;
+	      // No error handling.
+	      // This case can occur when changing table ownership via ALTER TABLE.
+	      continue;
 	    }
 	}
       if (ecount)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25934

아래의 케이스를 보면 u1.t1 소유권을 u3에 넘기는 경우, unloaddb에서 에러 처리가 되어 unloaddb가 중단 되고 있다. 
에러 처리를 하지 않고, unloaddb를 진행 하도록 변경함

* 재현경로
1. csql -u dba demodb
$> create user user1;
$> create user user2;
$> create user user3;
2. csql -u user1 demodb
$> create table tbl1;
$> grant select on tbl1 to user3;
3. csql -u dba demodb
$> alter table user1.tbl1 owner to user2;

* unloaddb 결과

call [add_user](https://github.com/CUBRID/cubrid/pull/'U1',) on class [db_root];
call [add_user](https://github.com/CUBRID/cubrid/pull/'U2',) on class [db_root];
call [add_user](https://github.com/CUBRID/cubrid/pull/'U3',) on class [db_root];

CREATE CLASS [user2].[tbl1] REUSE_OID, COLLATE iso88591_bin;

/**** Couldn't issue all grants for user "U1"***
*/

COMMIT WORK;
