### PR TITLE
[CBRD-25845] fix cause of coredump in debug mode

### DIFF
--- a/src/broker/cas.c
+++ b/src/broker/cas.c
@@ -1698,14 +1698,11 @@ cas_free (bool from_sighandler)
 
   if (from_sighandler)
     {
-      cas_log_debug (ARG_FILE_LINE, "ux_database_shutdown: db_shutdown()");
-
-      as_info->database_name[0] = '\0';
-      as_info->database_host[0] = '\0';
-      as_info->database_user[0] = '\0';
-      as_info->database_passwd[0] = '\0';
-      as_info->last_connect_time = 0;
-
+      cas_log_debug (ARG_FILE_LINE, "request cas_free() from the signal handler");
+    }
+  else
+    {
+      cas_log_debug (ARG_FILE_LINE, "request cas_free() from the cas_final()");
     }
 
   if (as_info->cur_statement_pooling && !from_sighandler)

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -764,7 +764,10 @@ void
 ux_database_shutdown ()
 {
 #if !defined(CAS_FOR_CGW)
-  db_shutdown ();
+  if (db_get_connect_status() == 1) // only if connected to db
+    {
+      db_shutdown ();
+    }
   cas_log_debug (ARG_FILE_LINE, "ux_database_shutdown: db_shutdown()");
 
   as_info->database_name[0] = '\0';

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -764,7 +764,7 @@ void
 ux_database_shutdown ()
 {
 #if !defined(CAS_FOR_CGW)
-  if (db_get_connect_status() == 1) // only if connected to db
+  if (db_get_connect_status () == 1)	// only if connected to db
     {
       db_shutdown ();
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25945

- call db_shutdown(), only if connected to db in the ux_database_shutdown().
- remove duplicate variable initialization code caused by ux_database_sutdown() being called in cas_free().
