### PR TITLE
[CBRD-25786] Add authenticate cache for procedures

### DIFF
--- a/src/object/authenticate.h
+++ b/src/object/authenticate.h
@@ -194,6 +194,7 @@ extern int au_fetch_instance_force (MOP op, MOBJ * obj_ptr, AU_FETCHMODE fetchmo
 extern int au_check_class_authorization (MOP op, DB_AUTH auth);	// legacy name - au_check_authorization
 extern int au_check_serial_authorization (MOP serial_object);
 extern int au_check_server_authorization (MOP server_object);
+extern int au_check_procedure_authorization (MOP procedure_object);
 extern bool au_is_server_authorized_user (DB_VALUE * owner_val);
 //
 

--- a/src/object/authenticate_access_class.cpp
+++ b/src/object/authenticate_access_class.cpp
@@ -912,7 +912,7 @@ check_authorization (MOP classobj, SM_CLASS *sm_class, DB_AUTH type)
 	  if (*bits == AU_CACHE_INVALID)
 	    {
 	      /* update the cache and try again */
-	      error = Au_cache.update (classobj, sm_class);
+	      error = Au_cache.update (DB_OBJECT_CLASS, classobj, sm_class);
 	      if (error == NO_ERROR)
 		{
 		  bits = Au_cache.get_cache_bits (sm_class);
@@ -997,7 +997,7 @@ au_get_class_privilege (DB_OBJECT *mop, unsigned int *auth)
 
       if (*bits == AU_CACHE_INVALID)
 	{
-	  error = Au_cache.update (mop, class_);
+	  error = Au_cache.update (DB_OBJECT_CLASS, mop, class_);
 	  if (error == NO_ERROR)
 	    {
 	      bits = Au_cache.get_cache_bits (class_);

--- a/src/object/authenticate_cache.cpp
+++ b/src/object/authenticate_cache.cpp
@@ -448,7 +448,7 @@ authenticate_cache::get_procedure_cache_bits (MOP proc_mop)
     }
 
   bits->resize (cache_max, AU_CACHE_INVALID);
-  return &(*bits)[cache_index];
+  return & (*bits)[cache_index];
 }
 
 /*

--- a/src/object/authenticate_cache.cpp
+++ b/src/object/authenticate_cache.cpp
@@ -184,7 +184,7 @@ authenticate_cache::update (DB_OBJECT_TYPE obj_type, MOP mop, void *ptr)
       goto end;
     }
 
-  if (ws_is_same_object (Au_user, owner))
+  if (ws_is_same_object (Au_user, owner) || ws_is_same_object (Au_public_user, owner))
     {
       /* might want to allow grant/revoke on self */
       *bits = FULL_AUTH;

--- a/src/object/authenticate_cache.cpp
+++ b/src/object/authenticate_cache.cpp
@@ -444,7 +444,7 @@ authenticate_cache::get_procedure_cache_bits (MOP proc_mop)
     }
   else
     {
-      bits = procedure_cache[proc_mop];
+      bits = it->second;
     }
 
   bits->resize (cache_max, AU_CACHE_INVALID);

--- a/src/object/authenticate_cache.cpp
+++ b/src/object/authenticate_cache.cpp
@@ -448,7 +448,7 @@ authenticate_cache::get_procedure_cache_bits (MOP proc_mop)
     }
 
   bits->resize (cache_max, AU_CACHE_INVALID);
-  return &bits->at (cache_index);
+  return &(*bits)[cache_index];
 }
 
 /*

--- a/src/object/authenticate_cache.cpp
+++ b/src/object/authenticate_cache.cpp
@@ -91,6 +91,15 @@ authenticate_cache::flush (void)
     }
   user_name_cache.clear ();
 
+  for (auto &it : procedure_cache)
+    {
+      if (it.second)
+	{
+	  delete it.second;
+	}
+    }
+  procedure_cache.clear ();
+
   /* clear the associated globals */
   init ();
 }
@@ -107,7 +116,7 @@ authenticate_cache::flush (void)
  *   cache(in):
  */
 int
-authenticate_cache::update (MOP classop, SM_CLASS *sm_class)
+authenticate_cache::update (DB_OBJECT_TYPE obj_type, MOP mop, void *ptr)
 {
   int error = NO_ERROR;
   DB_SET *groups = NULL;
@@ -117,6 +126,9 @@ authenticate_cache::update (MOP classop, SM_CLASS *sm_class)
   bool is_member = false;
   unsigned int *bits = NULL;
   bool need_pop_er_stack = false;
+  MOP owner;
+
+  const unsigned int FULL_AUTH = (obj_type == DB_OBJECT_CLASS) ? AU_FULL_AUTHORIZATION : AU_EXECUTE;
 
   /*
    * must disable here because we may be updating the cache of the system
@@ -128,7 +140,18 @@ authenticate_cache::update (MOP classop, SM_CLASS *sm_class)
 
   need_pop_er_stack = true;
 
-  bits = get_cache_bits (sm_class);
+  if (obj_type == DB_OBJECT_CLASS)
+    {
+      SM_CLASS *sm_class = (SM_CLASS *) ptr;
+      bits = get_cache_bits ((SM_CLASS *) ptr);
+      owner = sm_class->owner;
+    }
+  else if (obj_type == DB_OBJECT_PROCEDURE)
+    {
+      bits = get_procedure_cache_bits (mop);
+      owner = (MOP) ptr;
+    }
+
   if (bits == NULL)
     {
       assert (false);
@@ -138,7 +161,7 @@ authenticate_cache::update (MOP classop, SM_CLASS *sm_class)
   /* initialize the cache bits */
   *bits = AU_NO_AUTHORIZATION;
 
-  if (sm_class->owner == NULL)
+  if (owner == NULL)
     {
       /* This shouldn't happen - assign it to the DBA */
       error = ER_AU_CLASS_WITH_NO_OWNER;
@@ -150,7 +173,7 @@ authenticate_cache::update (MOP classop, SM_CLASS *sm_class)
   is_member = au_is_dba_group_member (Au_user);
   if (is_member)
     {
-      *bits = AU_FULL_AUTHORIZATION;
+      *bits = FULL_AUTH;
       goto end;
     }
 
@@ -161,10 +184,10 @@ authenticate_cache::update (MOP classop, SM_CLASS *sm_class)
       goto end;
     }
 
-  if (ws_is_same_object (Au_user, sm_class->owner))
+  if (ws_is_same_object (Au_user, owner))
     {
       /* might want to allow grant/revoke on self */
-      *bits = AU_FULL_AUTHORIZATION;
+      *bits = FULL_AUTH;
       goto end;
     }
 
@@ -176,7 +199,7 @@ authenticate_cache::update (MOP classop, SM_CLASS *sm_class)
       goto end;
     }
 
-  db_make_object (&value, sm_class->owner);
+  db_make_object (&value, owner);
 
   is_member = set_ismember (groups, &value);
 
@@ -190,7 +213,7 @@ authenticate_cache::update (MOP classop, SM_CLASS *sm_class)
   if (is_member)
     {
       /* we're a member of the owning group */
-      *bits = AU_FULL_AUTHORIZATION;
+      *bits = FULL_AUTH;
     }
   else if (au_get_object (Au_user, "authorization", &auth) != NO_ERROR)
     {
@@ -200,7 +223,7 @@ authenticate_cache::update (MOP classop, SM_CLASS *sm_class)
   else
     {
       /* apply local grants */
-      error = apply_grants (auth, classop, bits);
+      error = apply_grants (auth, mop, bits);
       if (error != NO_ERROR)
 	{
 	  goto end;
@@ -228,7 +251,7 @@ authenticate_cache::update (MOP classop, SM_CLASS *sm_class)
 	  if (ws_is_same_object (group, Au_dba_user))
 	    {
 	      /* someones on the DBA member list, give them power */
-	      *bits = AU_FULL_AUTHORIZATION;
+	      *bits = FULL_AUTH;
 	    }
 	  else
 	    {
@@ -238,7 +261,7 @@ authenticate_cache::update (MOP classop, SM_CLASS *sm_class)
 		  goto end;
 		}
 
-	      error = apply_grants (auth, classop, bits);
+	      error = apply_grants (auth, mop, bits);
 	      if (error != NO_ERROR)
 		{
 		  goto end;
@@ -406,6 +429,26 @@ authenticate_cache::get_cache_bits (SM_CLASS *sm_class)
     }
 
   return &cache->data[cache_index];
+}
+
+unsigned int *
+authenticate_cache::get_procedure_cache_bits (MOP proc_mop)
+{
+  std::vector<unsigned int> *bits = nullptr;
+
+  auto it = procedure_cache.find (proc_mop);
+  if (it == procedure_cache.end ())
+    {
+      bits = new std::vector<unsigned int> (cache_max, AU_CACHE_INVALID);
+      procedure_cache[proc_mop] = bits;
+    }
+  else
+    {
+      bits = procedure_cache[proc_mop];
+    }
+
+  bits->resize (cache_max, AU_CACHE_INVALID);
+  return &bits->at (cache_index);
 }
 
 /*
@@ -665,6 +708,36 @@ authenticate_cache::reset_cache_for_user_and_class (SM_CLASS *sm_class)
     }
 }
 
+void
+authenticate_cache::reset_cache_for_user_and_procedure (MOP obj)
+{
+  AU_USER_CACHE *u;
+  AU_CLASS_CACHE *c;
+
+  for (auto &it : procedure_cache)
+    {
+      if (it.first == obj)
+	{
+	  /*
+	   * invalide every user's cache for this procedure mop, could be more
+	   * selective and do only the given user and its members
+	   */
+	  for (u = user_cache; u != NULL; u = u->next)
+	    {
+	      // NOTE: u->index is initalized as -1
+	      // This means that the user is cached in a context that is independent of the class,
+	      // for example, obtaining the user object in the execution context of another database object,
+	      // such as the owner's right of procedure or a user management method.
+	      if (u->index >= 0)
+		{
+		  it.second->resize (u->index + 1, AU_CACHE_INVALID); // safe guard
+		  it.second->at (u->index) = AU_CACHE_INVALID;
+		}
+	    }
+	}
+    }
+}
+
 /*
  * au_reset_authorization_caches - This is called by ws_clear_all_hints()
  *                                 and ws_abort_mops() on transaction
@@ -686,12 +759,20 @@ authenticate_cache::reset_authorization_caches (void)
   AU_CLASS_CACHE *c;
   int i;
 
+  // reset class cache
   for (c = class_caches; c != NULL; c = c->next)
     {
       for (i = 0; i < cache_depth; i++)
 	{
 	  c->data[i] = AU_CACHE_INVALID;
 	}
+    }
+
+  // reset procedure cache
+  for (auto &it : procedure_cache)
+    {
+      std::vector <unsigned int> *data = it.second;
+      std::fill (data->begin (), data->end(), AU_CACHE_INVALID);
     }
 }
 

--- a/src/object/authenticate_cache.hpp
+++ b/src/object/authenticate_cache.hpp
@@ -142,13 +142,14 @@ class authenticate_cache
 
     void init (void);
     void flush (void);
-    int update (MOP classop, SM_CLASS *sm_class);
+    int update (DB_OBJECT_TYPE obj_type, MOP mop, void *ptr);
 
     // setter/getter of cache_index
     int get_cache_index ();
     void set_cache_index (int idx);
 
     unsigned int *get_cache_bits (SM_CLASS *sm_class);
+    unsigned int *get_procedure_cache_bits (MOP proc_mop);
 
     void free_authorization_cache (void *cache);
 
@@ -159,6 +160,7 @@ class authenticate_cache
     int get_user_cache_index (AU_USER_CACHE *cache, int *index);
 
     void reset_cache_for_user_and_class (SM_CLASS *sm_class);
+    void reset_cache_for_user_and_procedure (MOP obj);
     void reset_authorization_caches (void);
 
     void remove_user_cache (MOP user);
@@ -167,6 +169,13 @@ class authenticate_cache
     void print_cache (int cache, FILE *fp);  // for debugging
 
   private:
+
+    // procedure cache
+    using procedure_cache_t = std::unordered_map<MOP, std::vector<unsigned int>*>; // <procedure, cache bits>
+
+    procedure_cache_t procedure_cache;
+    std::unordered_map<MOP, MOP> procedure_owner_map;
+
     // migrate static methods
     AU_CLASS_CACHE *make_class_cache (int depth);
     void free_class_cache (AU_CLASS_CACHE *cache);

--- a/src/object/authenticate_grant.cpp
+++ b/src/object/authenticate_grant.cpp
@@ -26,6 +26,7 @@
 #include "authenticate_cache.hpp"
 #include "authenticate_access_auth.hpp"
 
+#include "boot.h"
 #include "db.h" /* db_compile_and_execute_local () */
 #include "dbtype.h" /* DB_IS_STRING */
 // #include "dbtype_function.h"
@@ -446,10 +447,10 @@ au_grant_procedure (MOP user, MOP obj_mop, DB_AUTH type, bool grant_option)
 		}
 
 	      /*
-	       * clear the cache for this user/class pair to make sure we
+	       * clear the cache for this user/procedure pair to make sure we
 	       * recalculate it the next time it is referenced
 	       */
-	      //reset_cache_for_user_and_class (classobj);
+	      Au_cache.reset_cache_for_user_and_procedure (obj_mop);
 
 	      /*
 	       * Make sure any cached parse trees are rebuild.  This proabably
@@ -943,7 +944,7 @@ check_grant_option (MOP classop, SM_CLASS *sm_class, DB_AUTH type)
 
   if (*cache_bits == AU_CACHE_INVALID)
     {
-      if (Au_cache.update (classop, sm_class))
+      if (Au_cache.update (DB_OBJECT_CLASS, classop, sm_class))
 	{
 	  assert (er_errid () != NO_ERROR);
 	  return er_errid ();
@@ -2051,6 +2052,54 @@ au_print_grants (MOP auth, FILE *fp)
 	}
       set_free (grants);
     }
+}
+
+int
+au_check_procedure_authorization (MOP procedure_mop)
+{
+  int error = NO_ERROR;
+  DB_VALUE owner;
+  MOP owner_mop;
+
+  // if procedure cache does not exist, update the procedure cache
+  uint32_t *bits = Au_cache.get_procedure_cache_bits (procedure_mop);
+  if (bits == NULL)
+    {
+      assert (false);
+      return er_errid ();
+    }
+
+  if ((*bits & AU_EXECUTE) != AU_EXECUTE)
+    {
+      if (*bits == AU_CACHE_INVALID)
+	{
+	  error = db_get (procedure_mop, SP_ATTR_OWNER, &owner);
+	  owner_mop = db_get_object (&owner);
+
+	  /* update the cache and try again */
+	  error = Au_cache.update (DB_OBJECT_PROCEDURE, procedure_mop, owner_mop);
+	  if (error == NO_ERROR)
+	    {
+	      bits = Au_cache.get_procedure_cache_bits (procedure_mop);
+	      if (bits == NULL)
+		{
+		  return er_errid ();
+		}
+	      if ((*bits & AU_EXECUTE) != AU_EXECUTE)
+		{
+		  error = appropriate_error (*bits, AU_EXECUTE);
+		  er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, error, 0);
+		}
+	    }
+	}
+      else
+	{
+	  error = appropriate_error (*bits, AU_EXECUTE);
+	  er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, error, 0);
+	}
+    }
+
+  return error;
 }
 
 #if defined (SA_MODE)

--- a/src/object/schema_system_catalog_install.cpp
+++ b/src/object/schema_system_catalog_install.cpp
@@ -752,7 +752,7 @@ namespace cubschema
 // constraints
     {
       {DB_CONSTRAINT_INDEX, "", {"grantee", nullptr}, false},
-      {DB_CONSTRAINT_INDEX, "", {"object_of", nullptr}, false},
+      {DB_CONSTRAINT_INDEX, "", {"object_of", nullptr}, false}
     },
 // authorization
     {

--- a/src/sp/jsp_cl.cpp
+++ b/src/sp/jsp_cl.cpp
@@ -2260,77 +2260,6 @@ exit_on_error:
 }
 
 static int
-check_execute_authorization_by_query (const MOP sp_obj)
-{
-  int error = NO_ERROR, save;
-  const char *query = "SELECT [au] FROM " CT_CLASSAUTH_NAME
-		      " [au] WHERE [object_type] = ? and [auth_type] = 'EXECUTE' and [object_of] = ? and [grantee] = ?";
-  DB_QUERY_RESULT *result = NULL;
-  DB_SESSION *session = NULL;
-  DB_VALUE val[3];
-  int stmt_id;
-  int cnt = 0;
-
-  db_make_null (&val[0]);
-  db_make_null (&val[1]);
-  db_make_null (&val[2]);
-
-  /* Disable the checking for internal authorization object access */
-  AU_DISABLE (save);
-
-  session = db_open_buffer_local (query);
-  if (session == NULL)
-    {
-      ASSERT_ERROR_AND_SET (error);
-      goto release;
-    }
-
-  error = db_set_system_generated_statement (session);
-  if (error != NO_ERROR)
-    {
-      goto release;
-    }
-
-  stmt_id = db_compile_statement_local (session);
-  if (stmt_id < 0)
-    {
-      ASSERT_ERROR_AND_SET (error);
-      goto release;
-    }
-
-  db_make_int (&val[0], (int) DB_OBJECT_PROCEDURE);
-  db_make_object (&val[1], sp_obj);
-  db_make_object (&val[2], Au_user);
-
-  error = db_push_values (session, 3, val);
-  if (error != NO_ERROR)
-    {
-      goto release;
-    }
-
-  cnt = error = db_execute_statement_local (session, stmt_id, &result);
-  if (error < 0)
-    {
-      goto release;
-    }
-
-  error = db_query_end (result);
-
-release:
-  if (session != NULL)
-    {
-      db_close_session (session);
-    }
-  pr_clear_value (&val[0]);
-  pr_clear_value (&val[1]);
-  pr_clear_value (&val[2]);
-
-  AU_ENABLE (save);
-
-  return cnt;
-}
-
-static int
 check_execute_authorization (const MOP sp_obj, const DB_AUTH au_type)
 {
   int error = NO_ERROR;
@@ -2347,27 +2276,13 @@ check_execute_authorization (const MOP sp_obj, const DB_AUTH au_type)
       return NO_ERROR;
     }
 
-  error = db_get (sp_obj, SP_ATTR_OWNER, &owner);
-  if (error == NO_ERROR)
+// check execute authorization (Au_user is granted by owner)
+  if (au_check_procedure_authorization (sp_obj) == NO_ERROR)
     {
-      // check sp's owner is current user
-      owner_mop = db_get_object (&owner);
-      if (ws_is_same_object (owner_mop, Au_user) || ws_is_same_object (owner_mop, Au_public_user))
-	{
-	  return NO_ERROR;
-	}
-      else if (check_execute_authorization_by_query (sp_obj) == 0)
-	{
-	  error = ER_AU_EXECUTE_FAILURE;
-	  er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, error, 0);
-	}
-      else
-	{
-	  error = er_errid ();
-	}
+      return NO_ERROR;
     }
 
-  return error;
+  return ER_FAILED;
 }
 
 PT_NODE *


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25786

### Purpose

AU_CLASS_CACHE와 같이, CAS에서 프로시저에 대해서 권한 정보를 캐시하는 구조를 도입하고, 이 구조를 사용하여 프로시저의 권한 정보를 바로 가져올 수 있도록 수정한다.

### Implementation

- procedure cache: <MOP, vector<unsigned int>*> 타입을 가진 map 사용, AU_CLASS_CACHE와 동일하게 관리
  - authenticate_cache::update가 테이블과 프로시저에서 모두 사용 가능하도록 수정
  - 프로시저의 cache bits 구조를 할당하고 반환하는 get_procedure_cache_bits () 함수 추가
  - authenticate_cache::flush에 procedure cache 제거 루틴 추가
- au_check_procedure_authorization () 에서 권한 정보를 질의로 가져오는 check_execute_authorization_by_query () 대신 프로시저의 권한 캐시를 사용하도록 수정

### Remarks

N/A
