### PR TITLE
[CBRD-25945] prevent additional execution during executing csession_end_session()

### DIFF
--- a/src/compat/db_admin.c
+++ b/src/compat/db_admin.c
@@ -1052,6 +1052,7 @@ db_enable_modification (void)
  *
  * NOTE: This function ends the session identified by 'db_Session_id'
  */
+static int is_doing_end_session = -1;
 int
 db_end_session (void)
 {
@@ -1059,9 +1060,18 @@ db_end_session (void)
 
   CHECK_CONNECT_ERROR ();
 
+  /* prevent additional execution during execting csession_end_session() */
+  if (is_doing_end_session > 0 && is_doing_end_session == db_get_session_id ())
+    {
+      return NO_ERROR;
+    }
+  is_doing_end_session = db_get_session_id ();
+
   retval = csession_end_session (db_get_session_id (), db_get_keep_session ());
 
   cubmethod::get_callback_handler ()->free_query_handle_all (true);
+
+  is_doing_end_session = -1;
 
   return (retval);
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25945

- It was found that db_end_session() was called simultaneously due to add db_shutdown() in the signal handler of cas, so we modify to prevent addtional execution during executing cession_end_session() in the db_end_session().
