### PR TITLE
[CBRD-25964] fix CHECK_OVER_CODE_VALUE is always true

### DIFF
--- a/src/base/chartype.h
+++ b/src/base/chartype.h
@@ -57,7 +57,7 @@ extern "C"
   extern const unsigned char *iso8859_upper_mapper_ptr;
 
 #ifndef NDEBUG
-#define CHECK_OVER_CODE_VALUE(c)   assert((unsigned char)(c) < 256)
+#define CHECK_OVER_CODE_VALUE(c)   assert((unsigned int)(c) < 256)
 #else
 #define CHECK_OVER_CODE_VALUE(c)
 #endif

--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -38,10 +38,10 @@
 #define CONNECTED_STATE         0
 
 #define ODBC_SQLSUCCESS(rc) ((rc == SQL_SUCCESS) || (rc == SQL_SUCCESS_WITH_INFO) )
-#define SQL_CHK_ERR(h, ht, x)   {   RETCODE rc = x;\
+#define SQL_CHK_ERR(h, ht, x)   {   RETCODE rc = (x);\
                                 if (rc != SQL_SUCCESS) \
                                 { \
-                                    cgw_error_msg (h, ht, rc); \
+                                    cgw_error_msg ((h), (ht), rc); \
                                 } \
                                 if (rc <= SQL_ERROR) \
                                 { \

--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -3849,7 +3849,7 @@ emit_index_def (extract_context & ctxt, print_output & output_ctx, DB_OBJECT * c
       assert ((constraint->index_status == SM_ONLINE_INDEX_BUILDING_IN_PROGRESS)
 	      || (ctype != DB_CONSTRAINT_UNIQUE && ctype != DB_CONSTRAINT_REVERSE_UNIQUE));
 
-      if ((reserved_col_buf[0] == '\0') && !SM_IS_CONSTRAINT_UNIQUE_FAMILY (ctype))
+      if ((reserved_col_buf[0] == '\0') && !DB_IS_CONSTRAINT_UNIQUE_FAMILY (ctype))
 	{
 	  dk_print_deduplicate_key_info (reserved_col_buf, sizeof (reserved_col_buf), DEDUPLICATE_KEY_LEVEL_OFF);
 	}

--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -4189,7 +4189,7 @@ classobj_find_constraint_by_attrs (SM_CLASS_CONSTRAINT * cons_list, DB_CONSTRAIN
 	}
     }
 
-  is_uk_new = SM_IS_CONSTRAINT_UNIQUE_FAMILY (new_cons);
+  is_uk_new = DB_IS_CONSTRAINT_UNIQUE_FAMILY (new_cons);
 
   for (cons = cons_list; cons; cons = cons->next)
     {

--- a/src/object/deduplicate_key.c
+++ b/src/object/deduplicate_key.c
@@ -153,7 +153,7 @@ dk_get_deduplicate_key_value (OID * rec_oid, int att_id, DB_VALUE * value)
   bool is_test_for_developer = false;
   if (is_test_for_developer)
     {
-#define OID_2_BIGINT(oidptr) (((oidptr)->volid << 48) | ((oidptr)->pageid << 16) | (oidptr)->slotid)
+#define OID_2_BIGINT(oidp) ((((UINT64)(oidp)->volid) << 48) | (((UINT64)(oidp)->pageid) << 16) | (UINT64)((oidp)->slotid))
       assert (CALC_MOD_VALUE_FROM_LEVEL (level) <= SHRT_MAX);
       db_make_short (value, (short) (OID_2_BIGINT (rec_oid) % CALC_MOD_VALUE_FROM_LEVEL (level)));
 

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -9939,7 +9939,7 @@ qo_classify (PT_NODE * attr)
 	{
 	  return PC_ATTR;
 	}
-
+      /* fall through */
     default:
       return PC_OTHER;
     }

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -8610,35 +8610,35 @@ pt_print_datatype (PARSER_CONTEXT * parser, PT_NODE * p)
 	  q = pt_append_nulstring (parser, q, buf);
 	}
       break;
+
     case PT_TYPE_NCHAR:
-      if (parser->flag.is_parsing_unload_schema)
-	{
-	  q = pt_append_nulstring (parser, q, "national character");
-	  break;
-	}
     case PT_TYPE_VARNCHAR:
-      if (parser->flag.is_parsing_unload_schema)
-	{
-	  q = pt_append_nulstring (parser, q, "national character varying");
-	  break;
-	}
     case PT_TYPE_CHAR:
+    case PT_TYPE_VARCHAR:
       if (parser->flag.is_parsing_unload_schema)
 	{
-	  q = pt_append_nulstring (parser, q, "character");
+	  switch (p->type_enum)
+	    {
+	    case PT_TYPE_CHAR:
+	      q = pt_append_nulstring (parser, q, "character");
+	      break;
+	    case PT_TYPE_VARCHAR:
+	      q = pt_append_nulstring (parser, q, "character varying");
+	      break;
+	    case PT_TYPE_NCHAR:
+	      q = pt_append_nulstring (parser, q, "national character");
+	      break;
+	    case PT_TYPE_VARNCHAR:
+	      q = pt_append_nulstring (parser, q, "national character varying");
+	      break;
+	    default:
+	      assert (false);
+	    }
 	  break;
 	}
-    case PT_TYPE_VARCHAR:
-      if (!parser->flag.is_parsing_unload_schema)
-	{
-	  show_collation = true;
-	  /* FALLTHRU */
-	}
-      else
-	{
-	  q = pt_append_nulstring (parser, q, "character varying");
-	  break;
-	}
+
+      show_collation = true;
+      /* FALLTHRU */
     case PT_TYPE_BIT:
     case PT_TYPE_VARBIT:
     case PT_TYPE_FLOAT:

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -7796,11 +7796,13 @@ pt_fold_constants_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *
 	  // we want to test full execution of sub-tree; don't fold it!
 	  *continue_walk = PT_LIST_WALK;
 	}
+      break;
     case PT_EXPR:
       if (pt_is_dblink_related (node))
 	{
 	  parser_walk_tree (parser, node, pt_set_flag_do_not_fold_for_dblink, NULL, NULL, NULL);
 	}
+      break;
     default:
       // nope
       break;
@@ -17270,6 +17272,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	      cmp = 1;
 	      break;
 	    }
+	  /* fall through */
 	case PT_NE_ALL:
 	  cmp = set_issome (arg1, db_get_set (arg2), PT_EQ_SOME, 1);
 	  if (cmp == 1)

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -10786,6 +10786,7 @@ do_change_att_schema_only (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NOD
 	    {
 	      break;
 	    }
+	  /* fall through */
 
 	default:
 	  att = attribute->info.attr_def.attr_name;
@@ -11377,6 +11378,7 @@ build_attr_change_map (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NODE * 
 	  break;
 	case PT_CONSTRAIN_NULL:
 	  attr_chg_properties->p[P_NOT_NULL] = ATT_CHG_PROPERTY_LOST;
+	  /* fall through */
 	case PT_CONSTRAIN_NOT_NULL:
 	  constr_att_list = cnstr->info.constraint.un.not_null.attr;
 	  chg_prop_idx = P_NOT_NULL;

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -3029,7 +3029,7 @@ create_or_drop_index_helper (PARSER_CONTEXT * parser, const char *const constrai
 	      || !classobj_check_attr_in_unique_constraint (class_->constraints, attnames, func_index_info))
 	    {
 	      dk_create_index_level_adjust (idx_info, attnames, asc_desc, attrs_prefix_length, func_index_info,
-					    nnames, SM_IS_CONSTRAINT_REVERSE_INDEX_FAMILY (ctype));
+					    nnames, DB_IS_CONSTRAINT_REVERSE_INDEX_FAMILY (ctype));
 	    }
 	}
     }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-25964>

### Purpose

* fix CHECK_OVER_CODE_VALUE is always true

### Implementation

N/A

### Remarks
1) ((unsigned char) (c) < 256)은 항상 true이기 때문에 assert()의 의미가 없었습니다.
본래 의도 대로 ((unsigned int) (c) < 256)를 체크하도록 합니다.

2) case문에서 `/* fall through */`을 지정해서 warning 정리
     pt_print_datatype()에서 직관성을 위해 일부 재작성

