### PR TITLE
[CUBVEC-56] Drop HNSW Index

### DIFF
--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -10897,6 +10897,10 @@ deallocate_index (SM_CLASS_CONSTRAINT * cons, BTID * index)
 	}
     }
 
+  // TODO : Constraint with given BTID exists only once. If is not, ctype can be overwriten can call wrong index delete function.
+  // To prevent this, we need to refactor this code to guarantee that ctype is unique for given BTID.
+  assert (ref_count == 1);
+
   if (ref_count == 1)
     {
       if (ctype == SM_CONSTRAINT_VECTOR_INDEX)

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -10885,19 +10885,28 @@ deallocate_index (SM_CLASS_CONSTRAINT * cons, BTID * index)
 {
   int error = NO_ERROR;
   SM_CLASS_CONSTRAINT *con;
+  SM_CONSTRAINT_TYPE ctype;
   int ref_count = 0;
 
   for (con = cons; con != NULL; con = con->next)
     {
       if (BTID_IS_EQUAL (index, &con->index_btid))
 	{
+	  ctype = con->type;
 	  ref_count++;
 	}
     }
 
   if (ref_count == 1)
     {
-      error = btree_delete_index (index);
+      if (ctype == SM_CONSTRAINT_VECTOR_INDEX)
+	{
+	  error = hnsw_delete_index (index);
+	}
+      else
+	{
+	  error = btree_delete_index (index);
+	}
     }
 
   return error;
@@ -14054,6 +14063,12 @@ sm_drop_index (MOP classop, const char *constraint_name)
 
   if (found == NULL)
     {
+      ctype = SM_CONSTRAINT_VECTOR_INDEX;
+      found = classobj_find_class_constraint (class_->constraints, ctype, constraint_name);
+    }
+
+  if (found == NULL)
+    {
       ERROR1 (error, ER_SM_NO_INDEX, constraint_name);
     }
   else
@@ -15048,7 +15063,7 @@ sm_drop_constraint (MOP classop, DB_CONSTRAINT_TYPE constraint_type, const char 
   int error = NO_ERROR;
   SM_TEMPLATE *def = NULL;
 
-  if (mysql_index_name && constraint_type == DB_CONSTRAINT_INDEX)
+  if (mysql_index_name && (constraint_type == DB_CONSTRAINT_INDEX || constraint_type == DB_CONSTRAINT_VECTOR_INDEX))
     {
       SM_CLASS *smcls = NULL;
 
@@ -15075,6 +15090,7 @@ sm_drop_constraint (MOP classop, DB_CONSTRAINT_TYPE constraint_type, const char 
     {
     case DB_CONSTRAINT_INDEX:
     case DB_CONSTRAINT_REVERSE_INDEX:
+    case SM_CONSTRAINT_VECTOR_INDEX:
       error = sm_drop_index (classop, constraint_name);
       break;
 

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -3288,7 +3288,7 @@ do_drop_index (PARSER_CONTEXT * parser, const PT_NODE * statement)
       return error_code;
     }
 
-  if (index_type == DB_CONSTRAINT_INDEX)
+  if (index_type == DB_CONSTRAINT_INDEX || index_type == DB_CONSTRAINT_VECTOR_INDEX)
     {
       error_code = get_index_type_qualifiers (obj, &is_reverse, &is_unique, index_name);
       if (error_code != NO_ERROR)

--- a/src/storage/hnsw.cpp
+++ b/src/storage/hnsw.cpp
@@ -32,28 +32,36 @@ std::unordered_map<int, faiss::IndexHNSW *> hnsw_index_map;
 int hnsw_add_index (BTID *btid, int dimension = 10, int hnsw_M = 128, int hnsw_efConstruction = 40,
 		    enum faiss::MetricType metric_type = faiss::METRIC_L2)
 {
-  faiss::IndexHNSW index (dimension, hnsw_M, metric_type);
-  index.hnsw.efConstruction = hnsw_efConstruction;
+  faiss::IndexHNSW *index = new faiss::IndexHNSW (dimension, hnsw_M, metric_type);
+  index->hnsw.efConstruction = hnsw_efConstruction;
 
   btid->vfid.volid = -1;
   btid->vfid.fileid = -1;
   btid->root_pageid = ++hnsw_index_id;
 
-  hnsw_index_map[hnsw_index_id] = &index;
+  hnsw_index_map[hnsw_index_id] = index;
 
   return NO_ERROR;
 }
 
 int hnsw_delete_index (BTID *btid)
 {
-  if (hnsw_index_map.find (btid->root_pageid) != hnsw_index_map.end())
+  if (!btid)
     {
-      hnsw_index_map.erase (btid->root_pageid);
-      return NO_ERROR;
+      return ER_FAILED;
+    }
+
+  int hnsw_id = btid->root_pageid;
+  auto it = hnsw_index_map.find (hnsw_id);
+
+  if (it == hnsw_index_map.end())
+    {
+      return ER_FAILED;
     }
   else
     {
-      return ER_FAILED;
+      delete it->second;
+      hnsw_index_map.erase (it);
     }
 
   return NO_ERROR;

--- a/src/storage/hnsw.cpp
+++ b/src/storage/hnsw.cpp
@@ -56,6 +56,7 @@ int hnsw_delete_index (BTID *btid)
 
   if (it == hnsw_index_map.end())
     {
+      assert (false);
       return ER_FAILED;
     }
   else

--- a/src/storage/hnsw.cpp
+++ b/src/storage/hnsw.cpp
@@ -27,19 +27,19 @@
 //        such as duplicate hnsw_index_id when cub_server restarts.
 //        We need to consider a better way to identify the hnsw index.
 int hnsw_index_id = 0;
-std::unordered_map<int, faiss::IndexHNSW *> hnsw_index_map;
+std::unordered_map<int, std::unique_ptr<faiss::IndexHNSW>> hnsw_index_map;
 
 int hnsw_add_index (BTID *btid, int dimension = 10, int hnsw_M = 128, int hnsw_efConstruction = 40,
 		    enum faiss::MetricType metric_type = faiss::METRIC_L2)
 {
-  faiss::IndexHNSW *index = new faiss::IndexHNSW (dimension, hnsw_M, metric_type);
+  std::unique_ptr<faiss::IndexHNSW> index = std::make_unique<faiss::IndexHNSW> (dimension, hnsw_M, metric_type);
   index->hnsw.efConstruction = hnsw_efConstruction;
 
   btid->vfid.volid = -1;
   btid->vfid.fileid = -1;
   btid->root_pageid = ++hnsw_index_id;
 
-  hnsw_index_map[hnsw_index_id] = index;
+  hnsw_index_map[hnsw_index_id] = std::move (index);
 
   return NO_ERROR;
 }
@@ -60,7 +60,6 @@ int hnsw_delete_index (BTID *btid)
     }
   else
     {
-      delete it->second;
       hnsw_index_map.erase (it);
     }
 

--- a/src/storage/hnsw.cpp
+++ b/src/storage/hnsw.cpp
@@ -20,8 +20,6 @@
 // hnsw.cpp - implementation of HNSW index
 //
 
-#include <bits/stdc++.h>
-
 #include "hnsw.hpp"
 
 // TODO : When cub_server terminates, hnsw_index_id will be reset to 0.
@@ -29,6 +27,7 @@
 //        such as duplicate hnsw_index_id when cub_server restarts.
 //        We need to consider a better way to identify the hnsw index.
 int hnsw_index_id = 0;
+std::unordered_map<int, faiss::IndexHNSW *> hnsw_index_map;
 
 int hnsw_add_index (BTID *btid, int dimension = 10, int hnsw_M = 128, int hnsw_efConstruction = 40,
 		    enum faiss::MetricType metric_type = faiss::METRIC_L2)
@@ -39,6 +38,23 @@ int hnsw_add_index (BTID *btid, int dimension = 10, int hnsw_M = 128, int hnsw_e
   btid->vfid.volid = -1;
   btid->vfid.fileid = -1;
   btid->root_pageid = ++hnsw_index_id;
+
+  hnsw_index_map[hnsw_index_id] = &index;
+
+  return NO_ERROR;
+}
+
+int hnsw_delete_index (BTID *btid)
+{
+  if (hnsw_index_map.find (btid->root_pageid) != hnsw_index_map.end())
+    {
+      hnsw_index_map.erase (btid->root_pageid);
+      return NO_ERROR;
+    }
+  else
+    {
+      return ER_FAILED;
+    }
 
   return NO_ERROR;
 }

--- a/src/storage/hnsw.hpp
+++ b/src/storage/hnsw.hpp
@@ -23,13 +23,14 @@
 #ifndef _HNSW_HPP_
 #define _HNSW_HPP_
 
-#include <bits/stdc++.h>
+#include <unordered_map>
 
 #include "storage_common.h"
 #include "faiss/IndexHNSW.h"
 
 int hnsw_add_index (BTID *btid, int dimension, int hnsw_M, int hnsw_efConstruction, enum faiss::MetricType metric_type);
+int hnsw_delete_index (BTID *btid);
 
 extern int hnsw_index_id;
-
+extern std::unordered_map<int, faiss::IndexHNSW *> hnsw_index_map;
 #endif

--- a/src/storage/hnsw.hpp
+++ b/src/storage/hnsw.hpp
@@ -24,6 +24,7 @@
 #define _HNSW_HPP_
 
 #include <unordered_map>
+#include <memory>
 
 #include "storage_common.h"
 #include "faiss/IndexHNSW.h"
@@ -32,5 +33,5 @@ int hnsw_add_index (BTID *btid, int dimension, int hnsw_M, int hnsw_efConstructi
 int hnsw_delete_index (BTID *btid);
 
 extern int hnsw_index_id;
-extern std::unordered_map<int, faiss::IndexHNSW *> hnsw_index_map;
+extern std::unordered_map<int, std::unique_ptr<faiss::IndexHNSW>> hnsw_index_map;
 #endif


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBVEC-56>

### Purpose

HNSW 인덱스 제거 지원

### Implementation

- HNSW 인덱스 관리를 위한 자료구조 추가
  - HNSW id를 key로 가지고, HNSW Index object를 value로 하는 unordered map 생성
  - Index 생성, 제거 시, 해당 자료구조에 접급하여 삽입, 제거
- Vector index 명령어에 대해 Drop index 명령어 지원
  - `sm_drop_index` 함수에서 `SM_CONSTRAINT_VECTOR_INDEX`에 해당하는 constraint도 찾을 수 있도록 변경
  -  `deallocate_index ` 함수에서 constraint 확인 시 `SM_CONSTRAINT_VECTOR_INDEX`라면, `btree_delete_index` 함수 대신 `hnsw_delete_index` 함수를 호출하도록 변경

### Remarks

- CUBVEC-23 (CREATE INDEX 구문에 대한 parser 구현)이 병합되어야 검증이 가능함
- 개발자 test는 완료되었고, 아래와 같은 구문 실행 도중 디버깅 메시지를 통해 검증을 진행하였음
  - CREATE TABLE tbl (a int);
  - CREATE VECTOR INDEX idx_v ON tbl(a);
  - CREATE INDEX idx ON tbl(a);
  - DROP INDEX idx_v on tbl(a);
  - DROP INDEX idx on tbl(a); 
