### PR TITLE
[CBRD-25971] C++23 Standard Compatibility

### DIFF
--- a/src/base/filesys_temp.cpp
+++ b/src/base/filesys_temp.cpp
@@ -45,7 +45,7 @@ namespace
   {
     const char *cubrid_tmp = envvar_get (CUBRID_TMP_ENV);
 #ifdef LINUX
-    std::string filename = cubrid_tmp != nullptr ? cubrid_tmp : std::filesystem::temp_directory_path ().u8string ();
+    std::string filename = cubrid_tmp != nullptr ? cubrid_tmp : std::filesystem::temp_directory_path ().string ();
 
     filename += "/";
     filename += prefix;
@@ -112,7 +112,7 @@ std::pair<std::string, FILE *> filesys::open_temp_file (const char *prefix, cons
 std::string filesys::temp_directory_path (void)
 {
   const char *cubrid_tmp = envvar_get (CUBRID_TMP_ENV);
-  std::string pathname = cubrid_tmp != nullptr ? cubrid_tmp : std::filesystem::temp_directory_path ().u8string ();
+  std::string pathname = cubrid_tmp != nullptr ? cubrid_tmp : std::filesystem::temp_directory_path ().string ();
 
   return pathname;
 }

--- a/src/base/filesys_temp.cpp
+++ b/src/base/filesys_temp.cpp
@@ -46,17 +46,9 @@ namespace
     const char *cubrid_tmp = envvar_get (CUBRID_TMP_ENV);
 #ifdef LINUX
 
-    std::string filename;
-    if (cubrid_tmp != nullptr) 
-      {
-	filename = std::string(cubrid_tmp);
-      } 
-    else 
-      {
-	// Convert u8string to string if necessary
-	auto u8path = std::filesystem::temp_directory_path().u8string();
-	filename = std::string(reinterpret_cast<const char*>(u8path.c_str()), u8path.length());
-      }
+    std::string filename = cubrid_tmp != nullptr
+			   ? std::string (cubrid_tmp)
+			   :std::filesystem::temp_directory_path().string();
 
     filename += "/";
     filename += prefix;
@@ -123,7 +115,23 @@ std::pair<std::string, FILE *> filesys::open_temp_file (const char *prefix, cons
 std::string filesys::temp_directory_path (void)
 {
   const char *cubrid_tmp = envvar_get (CUBRID_TMP_ENV);
-  std::string pathname = cubrid_tmp != nullptr ? cubrid_tmp : std::filesystem::temp_directory_path ().string ();
+  // std::string pathname = cubrid_tmp != nullptr ? cubrid_tmp : std::filesystem::temp_directory_path ().u8string ();
+
+  std::filesystem::path temp_path = std::filesystem::temp_directory_path();
+  std::string pathname;
+  if (cubrid_tmp != nullptr)
+    {
+      pathname = std::string (cubrid_tmp);
+    }
+  else
+    {
+#ifdef _WIN32
+      std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
+      pathname = converter.to_bytes (temp_path.wstring()); // Convert UTF-16 to UTF-8
+#else
+      pathname = temp_path.string();  // On Linux/macOS, this is already UTF-8
+#endif
+    }
 
   return pathname;
 }

--- a/src/base/filesys_temp.cpp
+++ b/src/base/filesys_temp.cpp
@@ -45,7 +45,18 @@ namespace
   {
     const char *cubrid_tmp = envvar_get (CUBRID_TMP_ENV);
 #ifdef LINUX
-    std::string filename = cubrid_tmp != nullptr ? cubrid_tmp : std::filesystem::temp_directory_path ().string ();
+
+    std::string filename;
+    if (cubrid_tmp != nullptr) 
+      {
+	filename = std::string(cubrid_tmp);
+      } 
+    else 
+      {
+	// Convert u8string to string if necessary
+	auto u8path = std::filesystem::temp_directory_path().u8string();
+	filename = std::string(reinterpret_cast<const char*>(u8path.c_str()), u8path.length());
+      }
 
     filename += "/";
     filename += prefix;

--- a/src/loaddb/load_server_loader.hpp
+++ b/src/loaddb/load_server_loader.hpp
@@ -28,6 +28,7 @@
 #include "heap_file.h"
 #include "load_common.hpp"
 #include "memory_private_allocator.hpp"
+#include "record_descriptor.hpp"
 
 #include <vector>
 

--- a/src/sp/pl_connection.cpp
+++ b/src/sp/pl_connection.cpp
@@ -171,7 +171,7 @@ namespace cubpl
   bool
   connection_pool::is_system_pool () const
   {
-    return (m_epoch.load (std::memory_order::relaxed) == SYSTEM_REVISION);
+    return (m_epoch.load (std::memory_order_relaxed) == SYSTEM_REVISION);
   }
 
   // private

--- a/src/sp/pl_connection.cpp
+++ b/src/sp/pl_connection.cpp
@@ -171,7 +171,7 @@ namespace cubpl
   bool
   connection_pool::is_system_pool () const
   {
-    return (m_epoch.load (std::memory_order::memory_order_relaxed) == SYSTEM_REVISION);
+    return (m_epoch.load (std::memory_order::relaxed) == SYSTEM_REVISION);
   }
 
   // private


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-25971>

### Purpose

CUBRID should compile and build in C++23 standard.

### Implementation

변경 사항 요약

1. **임시 파일 경로 처리 개선 (`filesys_temp.cpp`)**  
   - 임시 파일 경로를 처리할 때 기존에는 `u8string()`을 사용했으나, 이를 플랫폼에 맞게 보다 안정적인 방식으로 변경함.
     - Linux/macOS: `temp_directory_path().string()` 사용 (기본적으로 UTF-8이므로 그대로 사용).
     - Windows: `wstring`을 UTF-8 문자열로 변환하기 위해 `std::wstring_convert`를 사용.

2. **헤더 파일 추가 (`load_server_loader.hpp`)**  
   - `record_descriptor.hpp` 헤더 파일이 새로 포함됨. 없을 경우 C++23에서는 fail

3. **메모리 오더 명시 간소화 (`pl_connection.cpp`)**  
     - 기존: `std::memory_order::memory_order_relaxed`
     - 변경: `std::memory_order_relaxed`
 
C++23에서는 std::memory_order::memory_order_relaxed가 사라지고  `std::memory_order_relaxed` 사용이 권장됨.
 `std::memory_order_relaxed`는 C++17에서도 동작함.

요약하면, **플랫폼 호환성 개선, 코드 정리**가 주요 변경 사항입니다.

### Remarks

GCC 8: Success (c++17)
GCC 14: Success
Clang 19: Success
Windows: Success