### PR TITLE
[CBRD-25934] Backport from develop to 11.2 - Skip errors due to ownership change in unloaddb.

### DIFF
--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -8381,7 +8381,7 @@ au_export_grants (print_output & output_ctx, MOP class_mop)
   int error = NO_ERROR;
   CLASS_AUTH cl_auth;
   CLASS_USER *u;
-  int statements, ecount;
+  int statements;
   char *uname;
 
   cl_auth.class_mop = class_mop;
@@ -8400,7 +8400,7 @@ au_export_grants (print_output & output_ctx, MOP class_mop)
       while ((statements = class_grant_loop (output_ctx, &cl_auth)))
 	;
 
-      for (u = cl_auth.users, ecount = 0; u != NULL; u = u->next)
+      for (u = cl_auth.users; u != NULL; u = u->next)
 	{
 	  if (u->grants != NULL)
 	    {
@@ -8415,13 +8415,7 @@ au_export_grants (print_output & output_ctx, MOP class_mop)
 					  MSGCAT_AUTH_GRANT_DUMP_ERROR), uname);
 	      output_ctx ("*/\n");
 	      ws_free_string (uname);
-	      ecount++;
 	    }
-	}
-      if (ecount)
-	{
-	  error = ER_GENERIC_ERROR;
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 0);
 	}
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25934

아래의 케이스를 보면 user1.tbl1 소유권을 user3에 넘기는 경우, unloaddb에서 에러 처리가 되어 unloaddb가 중단 되고 있다.
에러 처리를 하지 않고 unloaddb를 진행 하도록 변경함

재현경로
csql -u dba demodb
$> create user user1;
$> create user user2;
$> create user user3;
csql -u user1 demodb
$> create table tbl1;
$> grant select on tbl1 to user3;
csql -u dba demodb
$> alter table user1.tbl1 owner to user2;
unloaddb 결과

```
call [add_user]('USER2', '') on class [db_root];
call [add_user]('USER3', '') on class [db_root];
call [find_user]('PUBLIC') on class [db_user] to [g_public];

CREATE CLASS [user2].[tbl1] REUSE_OID, COLLATE iso88591_bin;

/**** Couldn't issue all grants for user "U1"***
*/

COMMIT WORK;
```