### PR TITLE
[CBRD-25659] slip: add a symbol to win/cubridsa/cubridsa.def

### DIFF
--- a/win/cubridsa/cubridsa.def
+++ b/win/cubridsa/cubridsa.def
@@ -831,4 +831,5 @@ EXPORTS
     getnameinfo_uhost
     pl_get_socket_file_path
     envvar_vmdir_file
+    envvar_logdir_file
 	


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-25659>

누락된 symbol 때문에 Windows 빌드가 실패하여 수정했습니다. 

