### PR TITLE
[CBRD-25881] Modify the SP loading process not to have the same Class in /java and /java_static

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/StoredProcedure.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/StoredProcedure.java
@@ -110,7 +110,6 @@ public class StoredProcedure {
                 // find a class in static directory first
                 c = ServerClassLoader.getInstance().loadClass(sig.getClassName());
             } catch (Exception e) {
-                ex = e;
             }
 
             try {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/StoredProcedure.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/StoredProcedure.java
@@ -109,7 +109,11 @@ public class StoredProcedure {
             try {
                 // find a class in static directory first
                 c = ServerClassLoader.getInstance().loadClass(sig.getClassName());
+            } catch (ClassNotFoundException e) {
+                ex = e;
+            }
 
+            try {
                 if (c == null) {
                     c = ctx.getOldClassLoader().loadClass(sig.getClassName());
                 }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/StoredProcedure.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/StoredProcedure.java
@@ -107,18 +107,18 @@ public class StoredProcedure {
             }
         } else if (lang == LANG_JAVASP) {
             try {
-                c = ctx.getOldClassLoader().loadClass(sig.getClassName());
+                // find a class in static directory first
+                c = ServerClassLoader.getInstance().loadClass(sig.getClassName());
+
+                if (c == null) {
+                    c = ctx.getOldClassLoader().loadClass(sig.getClassName());
+                }
             } catch (ClassNotFoundException e) {
                 ex = e;
             }
         } else {
             assert false;
             throw new ClassNotFoundException(sig.getClassName());
-        }
-
-        // find a class in static directory and system loader
-        if (c == null) {
-            c = ServerClassLoader.getInstance().loadClass(sig.getClassName());
         }
 
         if (c == null) {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/StoredProcedure.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/StoredProcedure.java
@@ -109,7 +109,7 @@ public class StoredProcedure {
             try {
                 // find a class in static directory first
                 c = ServerClassLoader.getInstance().loadClass(sig.getClassName());
-            } catch (ClassNotFoundException e) {
+            } catch (Exception e) {
                 ex = e;
             }
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/StoredProcedure.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/StoredProcedure.java
@@ -101,32 +101,29 @@ public class StoredProcedure {
             // do nothing
         }
 
-        if (lang == LANG_PLCSQL) {
-            try {
-                if (c == null) {
+        if (c == null) {
+            if (lang == LANG_PLCSQL) {
+                try {
                     c = ctx.getSessionCLManager().findClass(sig.getClassName());
-                }
-
-                if (c == null) {
-                    CompiledCodeSet codeset = ClassAccess.getObjectCode(conn, sig);
-                    if (codeset != null) {
-                        c = ctx.getSessionCLManager().loadClass(codeset);
+                    if (c == null) {
+                        CompiledCodeSet codeset = ClassAccess.getObjectCode(conn, sig);
+                        if (codeset != null) {
+                            c = ctx.getSessionCLManager().loadClass(codeset);
+                        }
                     }
+                } catch (ClassNotFoundException e) {
+                    ex = e;
                 }
-            } catch (ClassNotFoundException e) {
-                ex = e;
-            }
-        } else if (lang == LANG_JAVASP) {
-            try {
-                if (c == null) {
+            } else if (lang == LANG_JAVASP) {
+                try {
                     c = ctx.getOldClassLoader().loadClass(sig.getClassName());
+                } catch (ClassNotFoundException e) {
+                    ex = e;
                 }
-            } catch (ClassNotFoundException e) {
-                ex = e;
+            } else {
+                assert false;
+                throw new ClassNotFoundException(sig.getClassName());
             }
-        } else {
-            assert false;
-            throw new ClassNotFoundException(sig.getClassName());
         }
 
         if (c == null) {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/StoredProcedure.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/StoredProcedure.java
@@ -93,9 +93,20 @@ public class StoredProcedure {
 
         Class<?> c = null;
         ClassNotFoundException ex = null;
+
+        try {
+            // find a class in static directory first
+            c = ServerClassLoader.getInstance().loadClass(sig.getClassName());
+        } catch (ClassNotFoundException e) {
+            // do nothing
+        }
+
         if (lang == LANG_PLCSQL) {
             try {
-                c = ctx.getSessionCLManager().findClass(sig.getClassName());
+                if (c == null) {
+                    c = ctx.getSessionCLManager().findClass(sig.getClassName());
+                }
+
                 if (c == null) {
                     CompiledCodeSet codeset = ClassAccess.getObjectCode(conn, sig);
                     if (codeset != null) {
@@ -106,12 +117,6 @@ public class StoredProcedure {
                 ex = e;
             }
         } else if (lang == LANG_JAVASP) {
-            try {
-                // find a class in static directory first
-                c = ServerClassLoader.getInstance().loadClass(sig.getClassName());
-            } catch (Exception e) {
-            }
-
             try {
                 if (c == null) {
                     c = ctx.getOldClassLoader().loadClass(sig.getClassName());

--- a/src/executables/loadjava.cpp
+++ b/src/executables/loadjava.cpp
@@ -56,6 +56,7 @@ static const std::string SEPARATOR_STRING (SEPERATOR);
 static const std::string DYNAMIC_PATH = JAVA_DIR;
 static const std::string STATIC_PATH = JAVA_STATIC_DIR;
 
+static fs::path Root;
 static std::string Path;
 static char *Program_name = NULL;
 static char *Dbname = NULL;
@@ -106,6 +107,7 @@ parse_argument (int argc, char *argv[])
 	      goto exit;
 	    }
 
+	  // e.g. $CUBRID/demodb/java/org/cubrid/path/
 	  std::string package_name (optarg);
 	  if (!package_name.empty())
 	    {
@@ -143,10 +145,17 @@ parse_argument (int argc, char *argv[])
       goto exit;
     }
 
-  Program_name = argv[0];
-
 exit:
-  if (error != NO_ERROR)
+  if (error == NO_ERROR)
+    {
+      Program_name = argv[0];
+      // e.g. $CUBRID/demodb/java or e.g. $CUBRID/demodb/java_static
+      if (Path.empty())
+	{
+	  Path = DYNAMIC_PATH;
+	}
+    }
+  else
     {
       usage ();
     }
@@ -155,72 +164,153 @@ exit:
 }
 
 static int
-create_package_directories (const fs::path &java_dir_path)
+check_arguments ()
 {
-  try
+  DB_INFO *db = NULL;
+
+  // check whether database exists
+  if ((db = cfg_find_db (Dbname)) == NULL)
     {
-      if (fs::exists (java_dir_path) == false)
-	{
-	  fs::create_directories (java_dir_path);
-	  fs::permissions (java_dir_path,
-			   fs::perms::owner_all | fs::perms::group_read | fs::perms::others_read,
-			   fs::perm_options::add);	// mkdir (java_dir_path, 0744)
-	}
-    }
-  catch (fs::filesystem_error &e)
-    {
-      fprintf (stderr, "can't create directory: %s. %s\n", java_dir_path.generic_string ().c_str (), e.what ());
+      fprintf (stderr, "database '%s' does not exist.\n", Dbname);
       return ER_FAILED;
     }
-  return NO_ERROR;
-}
 
-static int
-copy_file (const fs::path &java_dir_path)
-{
+  // DB path e.g. $CUBRID/demodb
+  Root.assign (std::string (db->pathname));
+
+  // check the specified source path of the java class file (jar) exists
   try
     {
-      fs::path src_path = fs::path (Src_class);
-      if (fs::exists (src_path) == false)
+      fs::path src_path (Src_class);
+      if (!fs::exists (src_path))
 	{
 	  fprintf (stderr, "loadjava fail: '%s' does not exist.\n", src_path.generic_string().c_str ());
 	  return ER_FAILED;
 	}
 
       std::string ext_nm = src_path.extension().generic_string();
-      if ( ext_nm.empty() || ((ext_nm.compare (".class") != 0) && (ext_nm.compare (".jar") != 0)))
+      if (ext_nm.empty() || ((ext_nm.compare (".class") != 0) && (ext_nm.compare (".jar") != 0)))
 	{
 	  fprintf (stderr, "loadjava fail: The extension name of '%s' is invalid.\n", src_path.generic_string().c_str ());
 	  return ER_FAILED;
 	}
-
-      std::string class_file_name = src_path.filename().generic_string();
-      fs::path class_file_path = java_dir_path / class_file_name;
-
-      bool is_exists = fs::exists (class_file_path);
-      if (Force_overwrite == false && is_exists == true)
-	{
-	  fprintf (stdout, "'%s' is exist. overwrite? (y/n): ", class_file_path.generic_string().c_str ());
-	  char c = getchar ();
-	  if (c != 'Y' && c != 'y')
-	    {
-	      fprintf (stdout, "loadjava is canceled\n");
-	      return NO_ERROR;
-	    }
-	}
-
-      // remove the previous file (to update modified time of the JAVA directory: CBRD-24695)
-      if (is_exists && fs::is_directory (class_file_path) == false)
-	{
-	  fs::remove (class_file_path);
-	}
-
-      const auto copyOptions = fs::copy_options::overwrite_existing;
-      fs::copy (src_path, class_file_path, copyOptions);
     }
   catch (fs::filesystem_error &e)
     {
       fprintf (stderr, "loadjava fail: file operation error: %s\n", e.what ());
+      return ER_FAILED;
+    }
+
+  return NO_ERROR;
+}
+
+static int
+create_package_directories (const fs::path &dir_path)
+{
+  try
+    {
+      if (fs::exists (dir_path) == false)
+	{
+	  fs::create_directories (dir_path);
+	  fs::permissions (dir_path,
+			   fs::perms::owner_all | fs::perms::group_read | fs::perms::others_read,
+			   fs::perm_options::add);	// mkdir (java_dir_path, 0744)
+	}
+    }
+  catch (fs::filesystem_error &e)
+    {
+      fprintf (stderr, "can't create directory: %s. %s\n", dir_path.generic_string ().c_str (), e.what ());
+      return ER_FAILED;
+    }
+  return NO_ERROR;
+}
+
+static int
+check_overwrite (const std::string &package_path, const std::string &class_file_name)
+{
+  try
+    {
+      fs::path static_path = Root / STATIC_PATH / package_path / class_file_name;
+      fs::path dynamic_path = Root / DYNAMIC_PATH / package_path / class_file_name;
+
+      bool exists_static = fs::exists (static_path);
+      bool exists_dynamic = fs::exists (dynamic_path);
+
+      // check whether class name exists for either static path and dynamic path
+      std::string full_class_name = package_path + class_file_name;
+      if (exists_static || exists_dynamic)
+	{
+	  if (Force_overwrite == false)
+	    {
+	      std::string full_class_name = package_path.empty () ? class_file_name : (package_path + SEPERATOR + class_file_name);
+	      fprintf (stdout, "'%s' is exist. overwrite? (y/n): ", full_class_name.c_str ());
+	      char c = getchar ();
+	      if (c != 'Y' && c != 'y')
+		{
+		  fprintf (stdout, "loadjava is canceled\n");
+		  return ER_FAILED;
+		}
+	    }
+
+	  // remove the previous file (to update modified time of the JAVA directory: CBRD-24695)
+	  if (exists_static && fs::is_directory (static_path) == false)
+	    {
+	      fs::remove (static_path);
+	    }
+
+	  // remove the previous file (to update modified time of the JAVA directory: CBRD-24695)
+	  if (exists_dynamic && fs::is_directory (dynamic_path) == false)
+	    {
+	      fs::remove (dynamic_path);
+	    }
+	}
+    }
+  catch (fs::filesystem_error &e)
+    {
+      fprintf (stderr, "loadjava fail: file operation error: %s\n", e.what ());
+      return ER_FAILED;
+    }
+
+  return NO_ERROR;
+}
+
+static int
+copy_class_file (const fs::path &src_path, const fs::path &dest_path)
+{
+  try
+    {
+      const auto copyOptions = fs::copy_options::overwrite_existing;
+      fs::copy (src_path, dest_path, copyOptions);
+    }
+  catch (fs::filesystem_error &e)
+    {
+      fprintf (stderr, "loadjava fail: file operation error: %s\n", e.what ());
+      return ER_FAILED;
+    }
+
+  return NO_ERROR;
+}
+
+static int
+do_load_java ()
+{
+  fs::path src_path (Src_class);
+  std::string class_file_name = src_path.filename().generic_string();
+
+  if (check_overwrite (package_path, class_file_name) != NO_ERROR)
+    {
+      return ER_FAILED;
+    }
+
+  fs::path package_dir = Root / Path / package_path;
+  if (create_package_directories (package_dir) != NO_ERROR)
+    {
+      return ER_FAILED;
+    }
+
+  fs::path dest_path = package_dir / class_file_name;
+  if (copy_class_file (src_path, dest_path) != NO_ERROR)
+    {
       return ER_FAILED;
     }
 
@@ -235,8 +325,6 @@ int
 main (int argc, char *argv[])
 {
   int status = EXIT_FAILURE;
-  DB_INFO *db = NULL;
-  fs::path java_dir_path;
 
   /* initialize message catalog for argument parsing and usage() */
   if (utility_initialize () != NO_ERROR)
@@ -249,31 +337,12 @@ main (int argc, char *argv[])
       goto error;
     }
 
-  if ((db = cfg_find_db (Dbname)) == NULL)
-    {
-      fprintf (stderr, "database '%s' does not exist.\n", Dbname);
-      goto error;
-    }
-
-  // DB path e.g. $CUBRID/demodb
-  java_dir_path.assign (std::string (db->pathname));
-
-  // e.g. $CUBRID/demodb/java or e.g. $CUBRID/demodb/java_static
-  if (Path.empty())
-    {
-      Path = DYNAMIC_PATH;
-    }
-  java_dir_path.append (Path);
-
-  // e.g. $CUBRID/demodb/java/org/cubrid/path/
-  java_dir_path.append (package_path);
-
-  if (create_package_directories (java_dir_path) != NO_ERROR)
+  if (check_arguments () != NO_ERROR)
     {
       goto error;
     }
 
-  if (copy_file (java_dir_path) != NO_ERROR)
+  if (do_load_java () != NO_ERROR)
     {
       goto error;
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25881

### Purpose

- Java SP를 로딩할때 JNI anchor 클래스가 저장되어 있을 수 있는 ServerClassLoader에서 먼저 클래스를 로딩한 후, 없으면 ContextClassLoader (getOldClassLoader)를 찾아보도록 수정
- loadjava 시, /java와 /java_static에 대해서 모두 확인하여, 동일한 이름의 클래스를 등록할 때 overwrite 확인을 하도록 수정

### Implementation

- 다음의 코드를 세션 기반 클래스 로딩 (PL/CSQL, Java SP) 앞으로 이동
```
// find a class in static directory and system loader
        if (c == null) {
            c = ServerClassLoader.getInstance().loadClass(sig.getClassName());
        }
```
- loadjava의 로직 수정:
    - /java, /java_static 모두에서 동일한 클래스 이름이 있는지 확인
    - overwrite 하는 경우 기존의 클래스 제거

### Remarks

N/A
