### PR TITLE
[CBRD-25947] Problem with changing rownum to orderby_num even though order_by is deleted during view merge

### DIFF
--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -2251,7 +2251,7 @@ mq_update_order_by (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * quer
 	      /* remove unnecessary order */
 	      if (prev_order == NULL)
 		{
-		  statement->info.query.order_by = save_next;
+		  order_by = save_next;
 		}
 	      else
 		{
@@ -2290,7 +2290,6 @@ mq_update_order_by (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * quer
       order = save_next;
     }
 
-  statement->info.query.order_by = parser_append_node (order_by, statement->info.query.order_by);
 
   /* generate orderby_num(), inst_num() */
   if (!(ord_num = parser_new_node (parser, PT_EXPR)) || !(ins_num = parser_new_node (parser, PT_EXPR)))
@@ -2310,23 +2309,39 @@ mq_update_order_by (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * quer
   ins_num->info.expr.op = PT_INST_NUM;
   PT_EXPR_INFO_SET_FLAG (ins_num, PT_EXPR_INFO_INSTNUM_C);
 
-  /* replace rownum of select-list to orderby_num */
-  statement->info.query.q.select.list =
-    pt_lambda_with_arg (parser, statement->info.query.q.select.list, ins_num, ord_num, false, 2, false);
-
-  /* replace rownum of where to orderby_num */
-  where = statement->info.query.q.select.where;
-  if (where != NULL && PT_EXPR_INFO_IS_FLAGED (where, PT_EXPR_INFO_ROWNUM_ONLY) && statement->info.query.order_by)
+  /* Check whether orderby_num and rownum need to be changed */
+  if (statement->info.query.order_by == NULL && order_by != NULL)
     {
-      where = pt_lambda_with_arg (parser, where, ins_num, ord_num, false, 2, false);
+      /* case 1 : order by of mainquery is newly added ==> rownum of mainquery is changed to orderby_num */
+      statement->info.query.q.select.list =
+	pt_lambda_with_arg (parser, statement->info.query.q.select.list, ins_num, ord_num, false, 2, false);
 
-      /* move prev orderby_for to orderby_for */
-      prev_orderby_for = parser_copy_tree (parser, query_spec->info.query.orderby_for);
-      statement->info.query.orderby_for = parser_append_node (prev_orderby_for, statement->info.query.orderby_for);
-      /* move rownum only predicate to orderby_for */
-      statement->info.query.orderby_for = parser_append_node (where, statement->info.query.orderby_for);
-      statement->info.query.q.select.where = NULL;
+      /* replace rownum of where to orderby_num */
+      where = statement->info.query.q.select.where;
+      if (where != NULL && PT_EXPR_INFO_IS_FLAGED (where, PT_EXPR_INFO_ROWNUM_ONLY))
+	{
+	  where = pt_lambda_with_arg (parser, where, ins_num, ord_num, false, 2, false);
+
+	  /* move prev orderby_for to orderby_for */
+	  prev_orderby_for = parser_copy_tree (parser, query_spec->info.query.orderby_for);
+	  statement->info.query.orderby_for = parser_append_node (prev_orderby_for, statement->info.query.orderby_for);
+	  /* move rownum only predicate to orderby_for */
+	  statement->info.query.orderby_for = parser_append_node (where, statement->info.query.orderby_for);
+	  statement->info.query.q.select.where = NULL;
+	}
     }
+  else if (query_spec->info.query.order_by != NULL && order_by == NULL)
+    {
+      /* case 2 : order by of subqery is totally removed ==> orderby_num of subquery is changed to rownum */
+      /* if where of subquery has rownum, orderby_num, can not view-merged. so is not needed to change */
+      query_spec->info.query.q.select.list =
+	pt_lambda_with_arg (parser, query_spec->info.query.q.select.list, ord_num, ins_num, false, 2, false);
+    }
+
+  parser_free_tree (parser, ord_num);
+  parser_free_tree (parser, ins_num);
+
+  statement->info.query.order_by = parser_append_node (order_by, statement->info.query.order_by);
 
   if (free_node != NULL)
     {


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-25947>

### Purpose
뷰머지시 부질의의 order_by를 변환하는 과정에서 필요 없이 rownum과 orderby_num을 변환하고 있었습니다.

### Implementation
아래 경우에 대해서만 변환을 진행합니다.
```
case 1 : order by of mainquery is newly added ==> rownum of mainquery is changed to orderby_num
case 2 : order by of subqery is totally removed ==> orderby_num of subquery is changed to rownum
```

### Remarks
뷰머지시 부질의 데이터 정렬순서는 아래와 같은 기준으로 제거 혹은 유지됩니다.
```
1. 부질의의 데이터 정렬순서는 보장되지 않으며, 가능한 경우에만 주질의의 정렬에 포함됩니다.
2. 부질의안에서 정렬후 데이터 개수를 제한하는 경우(limit 등)에는 뷰머지를 진행하지 않고 부질의의 정렬를 보장합니다.
```
