### PR TITLE
[CBRD-25138] report the first syntax error when parsing PL/CSQL programs

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/PlcsqlCompilerMain.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/PlcsqlCompilerMain.java
@@ -46,7 +46,6 @@ import java.util.HashSet;
 import java.util.Set;
 import org.antlr.v4.runtime.*;
 import org.antlr.v4.runtime.tree.*;
-import org.antlr.v4.runtime.misc.ParseCancellationException;
 
 public class PlcsqlCompilerMain {
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/PlcsqlCompilerMain.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/PlcsqlCompilerMain.java
@@ -46,6 +46,7 @@ import java.util.HashSet;
 import java.util.Set;
 import org.antlr.v4.runtime.*;
 import org.antlr.v4.runtime.tree.*;
+import org.antlr.v4.runtime.misc.ParseCancellationException;
 
 public class PlcsqlCompilerMain {
 
@@ -120,14 +121,14 @@ public class PlcsqlCompilerMain {
 
         PlcLexerEx lexer = new PlcLexerEx(input);
 
-        SyntaxErrorIndicator lei = new SyntaxErrorIndicator();
+        SyntaxErrorIndicator lei = new SyntaxErrorIndicator(false);
         lexer.removeErrorListeners(); // This removes unwanted console output
         lexer.addErrorListener(lei);
 
         CommonTokenStream tokens = new CommonTokenStream(lexer);
         PlcParser parser = new PlcParser(tokens);
 
-        SyntaxErrorIndicator sei = new SyntaxErrorIndicator();
+        SyntaxErrorIndicator sei = new SyntaxErrorIndicator(true);
         parser.removeErrorListeners(); // This removes unwanted console output
         parser.addErrorListener(sei);
 
@@ -139,14 +140,6 @@ public class PlcsqlCompilerMain {
 
         if (verbose) {
             logElapsedTime(logStore, "  calling parser", t0);
-        }
-
-        if (lei.hasError) {
-            throw new SyntaxError(lei.line, lei.column, lei.msg);
-        }
-        if (sei.hasError) {
-            String errMsg = cutExpectingClause(sei.msg);
-            throw new SyntaxError(sei.line, sei.column, errMsg);
         }
 
         sqlTemplate[0] = lexer.getCreateSqlTemplate();
@@ -280,10 +273,12 @@ public class PlcsqlCompilerMain {
 
     private static class SyntaxErrorIndicator extends BaseErrorListener {
 
-        boolean hasError;
-        int line;
-        int column;
-        String msg;
+        final boolean forParser;
+
+        public SyntaxErrorIndicator(boolean forParser) {
+            super();
+            this.forParser = forParser;
+        }
 
         @Override
         public void syntaxError(
@@ -294,10 +289,9 @@ public class PlcsqlCompilerMain {
                 String msg,
                 RecognitionException e) {
 
-            this.hasError = true;
-            this.line = line;
-            this.column = charPositionInLine + 1; // charPositionInLine starts from 0
-            this.msg = msg;
+            // throw SyntaxError at the first syntax error
+            String errMsg = forParser ? cutExpectingClause(msg) : msg;
+            throw new SyntaxError(line, charPositionInLine + 1, errMsg);
         }
     }
 }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-25138>

### Purpose

일부 PL/CSQL TC에서 문법 에러의 위치가 잘못 리포트 되는 문제 수정

### Implementation

기존에 ANTLR 가 문법 에러를 만났을 때 멈추지 않고 복구해가며 파싱을 이어가다보니 
여러 건의 문법 에러가 인식되는 경우 그 중에 마지막 것의 위치가 기록되고 있었음.
최초 문법에러에서 파싱을 멈추고 에러를 리포트 하도록 구현 수정.

### Implementation

test_plcsql 의 실패 건은 https://github.com/CUBRID/cubrid-testcases/pull/2149 에서 답지 수정을 요청하였습니다. 
