### PR TITLE
[CBRD-25945] Modify to clear only client memory without requesting the server when a signal occurs.

### DIFF
--- a/src/broker/cas.c
+++ b/src/broker/cas.c
@@ -785,7 +785,7 @@ conn_retry:
 
 	if (as_info->reset_flag == TRUE || is_xa_prepared ())
 	  {
-	    ux_database_shutdown ();
+	    ux_database_shutdown (true);
 	    as_info->reset_flag = FALSE;
 	    cas_set_db_connect_status (-1);	/* DB_CONNECTION_STATUS_RESET */
 	  }
@@ -1496,13 +1496,13 @@ cas_main (void)
 #if !defined(CAS_FOR_CGW)
 	    if (is_xa_prepared ())
 	      {
-		ux_database_shutdown ();
+		ux_database_shutdown (true);
 		ux_database_connect (db_name, db_user, db_passwd, NULL);
 	      }
 
 	    if (as_info->reset_flag == TRUE)
 	      {
-		ux_database_shutdown ();
+		ux_database_shutdown (true);
 		as_info->reset_flag = FALSE;
 		cas_set_db_connect_status (-1);	/* DB_CONNECTION_STATUS_RESET */
 	      }
@@ -1658,10 +1658,17 @@ check_server_alive (const char *db_name, const char *db_host)
   return true;
 }
 
-
 static void
 cas_sig_handler (int signo)
 {
+  static int is_doing_signal_handler = 0;
+
+  if (is_doing_signal_handler)
+    {
+      return;
+    }
+  is_doing_signal_handler = 1;
+
   signal (signo, SIG_IGN);
   cas_free (true);
   as_info->pid = 0;
@@ -1822,7 +1829,14 @@ cas_free (bool from_sighandler)
 #if defined(CAS_FOR_CGW)
   cgw_cleanup ();
 #else
-  ux_database_shutdown ();
+  if (from_sighandler)
+    {
+      ux_database_shutdown (false);
+    }
+  else
+    {
+      ux_database_shutdown (true);
+    }
 #endif /* CAS_FOR_CGW */
 
 }
@@ -2898,7 +2912,7 @@ CreateMiniDump (struct _EXCEPTION_POINTERS * pException)
 
   CloseHandle (FileHandle);
 
-  ux_database_shutdown ();
+  ux_database_shutdown (true);
 
   return EXCEPTION_EXECUTE_HANDLER;
 }

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -484,7 +484,7 @@ ux_check_connection (void)
 	      cas_log_debug (ARG_FILE_LINE,
 			     "ux_check_connection: ux_database_shutdown()" " ux_database_connect(%s, %s)", dbname,
 			     dbuser);
-	      ux_database_shutdown ();
+	      ux_database_shutdown (true);
 	      ux_database_connect (dbname, dbuser, dbpasswd, NULL);
 	    }
 	}
@@ -536,7 +536,7 @@ ux_database_connect (char *db_name, char *db_user, char *db_passwd, char **db_er
 
       if (database_name[0] != '\0')
 	{
-	  ux_database_shutdown ();
+	  ux_database_shutdown (true);
 	}
 
       if (shm_appl->access_mode == READ_ONLY_ACCESS_MODE)
@@ -632,7 +632,7 @@ ux_database_connect (char *db_name, char *db_user, char *db_passwd, char **db_er
       err_code = au_login (db_user, db_passwd, true);
       if (err_code < 0)
 	{
-	  ux_database_shutdown ();
+	  ux_database_shutdown (true);
 
 	  return ux_database_connect (db_name, db_user, db_passwd, db_err_msg);
 	}
@@ -761,12 +761,19 @@ ux_set_default_setting ()
 }
 
 void
-ux_database_shutdown ()
+ux_database_shutdown (bool request_server)
 {
 #if !defined(CAS_FOR_CGW)
   if (db_get_connect_status () == 1)	// only if connected to db
     {
-      db_shutdown ();
+      if (request_server)
+	{
+	  db_shutdown ();
+	}
+      else
+	{
+	  db_shutdown_without_request_to_server ();
+	}
     }
   cas_log_debug (ARG_FILE_LINE, "ux_database_shutdown: db_shutdown()");
 

--- a/src/broker/cas_execute.h
+++ b/src/broker/cas_execute.h
@@ -113,7 +113,7 @@ extern int ux_fetch (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count,
 extern int ux_oid_get (int argc, void **argv, T_NET_BUF * net_buf);
 extern int ux_cursor (int srv_h_id, int offset, int origin, T_NET_BUF * net_buf);
 #endif /* !CAS_FOR_ORACLE && !CAS_FOR_MYSQL */
-extern void ux_database_shutdown (void);
+extern void ux_database_shutdown (bool request_server);
 extern int ux_get_db_version (T_NET_BUF * net_buf, T_REQ_INFO * req_info);
 #if !defined(CAS_FOR_ORACLE) && !defined(CAS_FOR_MYSQL)
 extern int ux_get_class_num_objs (char *class_name, int flag, T_NET_BUF * net_buf);

--- a/src/compat/db_admin.c
+++ b/src/compat/db_admin.c
@@ -1006,6 +1006,12 @@ db_shutdown (void)
   return (error);
 }
 
+void
+db_shutdown_without_request_to_server (void)
+{
+  boot_client_all_finalize (true);
+}
+
 int
 db_ping_server (int client_val, int *server_val)
 {

--- a/src/compat/dbi.h
+++ b/src/compat/dbi.h
@@ -87,6 +87,7 @@ extern "C"
   extern int db_get_last_insert_id (DB_VALUE * value);
   extern int db_get_variable (DB_VALUE * name, DB_VALUE * value);
   extern int db_shutdown (void);
+  extern void db_shutdown_without_request_to_server (void);
   extern int db_ping_server (int client_val, int *server_val);
   extern int db_disable_modification (void);
   extern int db_enable_modification (void);

--- a/src/compat/dbi_compat.h
+++ b/src/compat/dbi_compat.h
@@ -159,6 +159,7 @@ extern "C"
   extern int db_get_last_insert_id (DB_VALUE * value);
   extern int db_get_variable (DB_VALUE * name, DB_VALUE * value);
   extern int db_shutdown (void);
+  extern void db_shutdown_without_request_to_server (void);
   extern int db_ping_server (int client_val, int *server_val);
   extern int db_disable_modification (void);
   extern int db_enable_modification (void);

--- a/win/cubridcs/cubridcs.def
+++ b/win/cubridcs/cubridcs.def
@@ -344,6 +344,7 @@ EXPORTS
     db_set_connect_order
     db_set_client_ip_addr
     db_shutdown
+    db_shutdown_without_request_to_server
     db_string_free
     db_synchronize_cache
     db_time_decode

--- a/win/cubridsa/cubridsa.def
+++ b/win/cubridsa/cubridsa.def
@@ -54,6 +54,7 @@ EXPORTS
     db_set_size
     db_set_page_size
     db_shutdown
+    db_shutdown_without_request_to_server
     db_string_free
     db_trigger_action
     db_trigger_action_time


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25945

- add db_shutdown_without_request_to_server() for clearing only client memory without requesting the server.

