### PR TITLE
[CBRD-25982] %FOUND and %NOTFOUND cursor attributes must be null between open and fetch

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -1569,15 +1569,12 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
     private static String[] tmplStmtCursorFetch =
             new String[] {
                 "{ // cursor fetch",
-                "  if (%'CURSOR'% == null || !%'CURSOR'%.isOpen()) {",
-                "    throw new INVALID_CURSOR(\"tried to fetch values with an unopened cursor\");",
+                "  if (%'CURSOR'% == null) {",
+                "    throw new INVALID_CURSOR(\"the cursor is NULL\");",
                 "  }",
                 "  ResultSet rs = %'CURSOR'%.rs;",
-                "  if (rs.next()) {",
-                "    %'CURSOR'%.updateRowCount();",
+                "  if (%'CURSOR'%.fetch()) {",
                 "    %'+SET-INTO-VARIABLES'%",
-                "  } else {",
-                "    ;", // TODO: setting nulls to into-variables?
                 "  }",
                 "}"
             };
@@ -1925,8 +1922,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 "  %'CURSOR'%.open(conn, %'PSTMT-REF'%);",
                 "  ResultSet %'RECORD'%_r%'LEVEL'% = %'CURSOR'%.rs;",
                 "  %'LABEL'%",
-                "  while (%'RECORD'%_r%'LEVEL'%.next()) {",
-                "    %'CURSOR'%.updateRowCount();",
+                "  while (%'CURSOR'%.fetch()) {",
                 "    %'RECORD'%[0].set(",
                 "      %'+RECORD-FIELD-VALUES'%",
                 "    );",
@@ -1948,8 +1944,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 "    %'+HOST-EXPRS'%);",
                 "  ResultSet %'RECORD'%_r%'LEVEL'% = %'CURSOR'%.rs;",
                 "  %'LABEL'%",
-                "  while (%'RECORD'%_r%'LEVEL'%.next()) {",
-                "    %'CURSOR'%.updateRowCount();",
+                "  while (%'CURSOR'%.fetch()) {",
                 "    %'RECORD'%[0].set(",
                 "      %'+RECORD-FIELD-VALUES'%",
                 "    );",

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -609,7 +609,7 @@ public class SpLib {
     public static class Query {
         public final String query;
         public ResultSet rs;
-        public int rowCount;
+        public int rowCount = -1;
 
         private PreparedStatement myStmt;
 
@@ -685,26 +685,49 @@ public class SpLib {
             }
         }
 
-        public boolean found() {
+        public boolean fetch() {
+
+            if (!isOpen()) {
+                throw new INVALID_CURSOR("tried to fetch values with an unopened cursor");
+            }
+
             try {
-                if (!isOpen()) {
-                    throw new INVALID_CURSOR(
-                            "attempted to read an attribute of an unopened cursor");
+                if (rs.next()) {
+                    rowCount = rs.getRow();
+                    return true;
+                } else {
+                    if (rowCount < 0) {
+                        // never fetched
+                        rowCount = 0;
+                    }
+                    return false;
                 }
-                return rs.getRow() > 0;
             } catch (SQLException e) {
                 Server.log(e);
                 throw new SQL_ERROR(e.getMessage());
             }
         }
 
-        public boolean notFound() {
+        public Boolean found() {
             try {
                 if (!isOpen()) {
                     throw new INVALID_CURSOR(
                             "attempted to read an attribute of an unopened cursor");
                 }
-                return rs.getRow() == 0;
+                return rowCount < 0 ? null : (rs.getRow() > 0);
+            } catch (SQLException e) {
+                Server.log(e);
+                throw new SQL_ERROR(e.getMessage());
+            }
+        }
+
+        public Boolean notFound() {
+            try {
+                if (!isOpen()) {
+                    throw new INVALID_CURSOR(
+                            "attempted to read an attribute of an unopened cursor");
+                }
+                return rowCount < 0 ? null : (rs.getRow() == 0);
             } catch (SQLException e) {
                 Server.log(e);
                 throw new SQL_ERROR(e.getMessage());
@@ -715,7 +738,7 @@ public class SpLib {
             if (!isOpen()) {
                 throw new INVALID_CURSOR("attempted to read an attribute of an unopened cursor");
             }
-            return (long) rowCount;
+            return (long) rowCount < 0 ? 0 : rowCount;
         }
 
         public void updateRowCount() {


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-25982>

PL/CSQL 의 스펙 정의대로 커서의 open 과 fetch 사이에서 %FOUND와 %NOTFOUND 속성이 null 값을 갖도록 수정합니다. 
이 스펙은 오라클 스펙과 일치합니다.
test_plcsql 의 6건 실패는 답지 수정이 필요합니다. 

