### PR TITLE
[CBRD-25980] Prepared Statement error for TIME values ​​starting with '13:'

### DIFF
--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -7279,9 +7279,14 @@ qmgr_execute_query (const XASL_ID * xasl_id, QUERY_ID * query_idp, int dbval_cnt
 
 	  tran_set_latest_query_status (end_query_result, tran_state, should_conn_reset);
 
+	  /* check if dblink transaction is aborted */
 	  if (tran_state == TRAN_UNACTIVE_ABORTED_INFORMING_PARTICIPANTS)
 	    {
-	      /* dblink transaction is aborted */
+	      if (replydata_listid)
+		{
+		  free_and_init (replydata_listid);
+		}
+
 	      return NULL;
 	    }
 	}

--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -7278,28 +7278,26 @@ qmgr_execute_query (const XASL_ID * xasl_id, QUERY_ID * query_idp, int dbval_cnt
 	    }
 
 	  tran_set_latest_query_status (end_query_result, tran_state, should_conn_reset);
+
+	  if (tran_state == TRAN_UNACTIVE_ABORTED_INFORMING_PARTICIPANTS)
+	    {
+	      /* dblink transaction is aborted */
+	      return NULL;
+	    }
 	}
 
       if (replydata_listid && replydata_size_listid)
 	{
-	  if (tran_state == TRAN_UNACTIVE_ABORTED_INFORMING_PARTICIPANTS)
+	  /* unpack list file id of query result from the reply data */
+	  ptr = or_unpack_unbound_listid (replydata_listid, (void **) (&list_id));
+	  /* QFILE_LIST_ID shipped with last page */
+	  if (replydata_size_page)
 	    {
-	      /* dblink transaction is aborted */
-	      ;
+	      list_id->last_pgptr = replydata_page;
 	    }
 	  else
 	    {
-	      /* unpack list file id of query result from the reply data */
-	      ptr = or_unpack_unbound_listid (replydata_listid, (void **) (&list_id));
-	      /* QFILE_LIST_ID shipped with last page */
-	      if (replydata_size_page)
-		{
-		  list_id->last_pgptr = replydata_page;
-		}
-	      else
-		{
-		  list_id->last_pgptr = NULL;
-		}
+	      list_id->last_pgptr = NULL;
 	    }
 	  free_and_init (replydata_listid);
 	}


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-25980>

디버그 모드에서 auto commit on 환경에서 아래의 쿼리를 실행하면 unknow error 발생
```
create table md_time1(col1 time not null);
prepare stmt from 'insert into md_time1 values(?)';
execute stmt using '13:13:13';
```

### Implementation

qmgr_execute_query에서 AUTO COMMIT일 때만 트랜잭션 상태를 체크하도록 로직 수정

### Remarks

prepare execute 구문과 상관 없음.
