### PR TITLE
[CBRD-25503] Allows connection to a Broker that has not been set up.

### DIFF
--- a/contrib/collectd-plugin/cubrid_broker.c
+++ b/contrib/collectd-plugin/cubrid_broker.c
@@ -69,7 +69,7 @@ cubrid_broker_init (void)
   char err_msg[1024], admin_log_file[BROKER_PATH_MAX];
 
   if (broker_config_read (NULL, br_info, &num_broker, &master_shm_id,
-			  admin_log_file, 0, NULL, NULL, err_msg) < 0)
+			  admin_log_file, 0, NULL, NULL, NULL, err_msg) < 0)
     {
       ERROR ("cubrid_broker: %s", err_msg);
       return -1;

--- a/contrib/collectd-plugin/cubrid_broker.c
+++ b/contrib/collectd-plugin/cubrid_broker.c
@@ -43,8 +43,7 @@
 
 static int cubrid_broker_init (void);
 static int cubrid_broker_read (void);
-static void submit (char *type, char *type_instance, value_t * values,
-		    int value_cnt);
+static void submit (char *type, char *type_instance, value_t * values, int value_cnt);
 
 static int master_shm_id = 0;
 static unsigned long *old_transactions_processed = NULL;
@@ -68,8 +67,7 @@ cubrid_broker_init (void)
   int i;
   char err_msg[1024], admin_log_file[BROKER_PATH_MAX];
 
-  if (broker_config_read (NULL, br_info, &num_broker, &master_shm_id,
-			  admin_log_file, 0, NULL, NULL, NULL, err_msg) < 0)
+  if (broker_config_read (NULL, br_info, &num_broker, &master_shm_id, admin_log_file, 0, NULL, NULL, NULL, err_msg) < 0)
     {
       ERROR ("cubrid_broker: %s", err_msg);
       return -1;
@@ -77,13 +75,11 @@ cubrid_broker_init (void)
 
   if (old_transactions_processed == NULL)
     {
-      old_transactions_processed =
-	(unsigned long *) calloc (sizeof (unsigned long), num_broker);
+      old_transactions_processed = (unsigned long *) calloc (sizeof (unsigned long), num_broker);
     }
   if (old_queries_processed == NULL)
     {
-      old_queries_processed =
-	(unsigned long *) calloc (sizeof (unsigned long), num_broker);
+      old_queries_processed = (unsigned long *) calloc (sizeof (unsigned long), num_broker);
     }
   for (i = 0; i < num_broker; i++)
     {
@@ -107,9 +103,7 @@ cubrid_broker_read (void)
   value_t cas_status[5];
   time_t cur_time;
 
-  shm_br =
-    (T_SHM_BROKER *) uw_shm_open (master_shm_id, SHM_BROKER,
-				  SHM_MODE_MONITOR);
+  shm_br = (T_SHM_BROKER *) uw_shm_open (master_shm_id, SHM_BROKER, SHM_MODE_MONITOR);
   if (shm_br == NULL)
     {
       return 0;
@@ -125,8 +119,7 @@ cubrid_broker_read (void)
       memset (cas_status, 0, sizeof (cas_status));
 
       shm_appl = (T_SHM_APPL_SERVER *)
-	uw_shm_open (shm_br->br_info[i].appl_server_shm_id,
-		     SHM_APPL_SERVER, SHM_MODE_MONITOR);
+	uw_shm_open (shm_br->br_info[i].appl_server_shm_id, SHM_APPL_SERVER, SHM_MODE_MONITOR);
 
       if (shm_appl == NULL)
 	{
@@ -144,8 +137,7 @@ cubrid_broker_read (void)
 		{
 		  if (shm_br->br_info[i].appl_server == APPL_SERVER_CAS)
 		    {
-		      if (shm_appl->as_info[j].con_status ==
-			  CON_STATUS_OUT_TRAN)
+		      if (shm_appl->as_info[j].con_status == CON_STATUS_OUT_TRAN)
 			cas_status[CLOSE_WAIT].gauge++;
 		      else if (shm_appl->as_info[j].log_msg[0] == '\0')
 			cas_status[CLIENT_WAIT].gauge++;
@@ -172,9 +164,7 @@ cubrid_broker_read (void)
 	}
       else
 	{
-	  trs[0].gauge =
-	    ((total_trs - old_transactions_processed[i]) / difftime (cur_time,
-								     old_time));
+	  trs[0].gauge = ((total_trs - old_transactions_processed[i]) / difftime (cur_time, old_time));
 	}
       if (old_queries_processed[i] == -1)
 	{
@@ -182,9 +172,7 @@ cubrid_broker_read (void)
 	}
       else
 	{
-	  trs_for_qps[0].gauge =
-	    ((total_qps - old_queries_processed[i]) / difftime (cur_time,
-								old_time));
+	  trs_for_qps[0].gauge = ((total_qps - old_queries_processed[i]) / difftime (cur_time, old_time));
 	}
       old_transactions_processed[i] = total_trs;
       old_queries_processed[i] = total_qps;

--- a/src/broker/broker_acl.c
+++ b/src/broker/broker_acl.c
@@ -63,7 +63,7 @@ access_control_set_shm (T_SHM_APPL_SERVER * shm_as_p, T_BROKER_INFO * br_info_p,
 			char *admin_err_msg)
 {
   shm_as_p->access_control = shm_br->access_control;
-  shm_as_p->acl_broker_allow = shm_br->acl_broker_allow;
+  shm_as_p->access_control_default_policy = shm_br->access_control_default_policy;
   shm_as_p->acl_chn = 0;
 
   if (shm_br->access_control && shm_br->access_control_file[0] != '\0')
@@ -499,8 +499,8 @@ access_control_check_right_internal (T_SHM_APPL_SERVER * shm_as_p, char *dbname,
   int ret_val = -1;
   bool local_ip_flag = false;
 
-  // If there is no broker section in the ACL file and acl_broker_allow is ALLOW, access is allowed for all IPs.
-  if (num_access_info == 0 && shm_as_p->acl_broker_allow == ALLOW)
+  // If there is no broker section in the ACL file and access_control_default_policy is ALLOW, access is allowed for all IPs.
+  if (num_access_info == 0 && shm_as_p->access_control_default_policy == ALLOW)
     {
       return 0;
     }

--- a/src/broker/broker_acl.c
+++ b/src/broker/broker_acl.c
@@ -63,6 +63,7 @@ access_control_set_shm (T_SHM_APPL_SERVER * shm_as_p, T_BROKER_INFO * br_info_p,
 			char *admin_err_msg)
 {
   shm_as_p->access_control = shm_br->access_control;
+  shm_as_p->acl_broker_allow = shm_br->acl_broker_allow;
   shm_as_p->acl_chn = 0;
 
   if (shm_br->access_control && shm_br->access_control_file[0] != '\0')
@@ -499,7 +500,7 @@ access_control_check_right_internal (T_SHM_APPL_SERVER * shm_as_p, char *dbname,
   bool local_ip_flag = false;
 
   // If there is no broker section in the ACL file and acl_broker_allow is ALLOW, access is allowed for all IPs.
-  if (num_access_info == 0 && shm_as_p->acl_broker_allow == ALLOW)
+  if (num_access_info == 0 && shm_as_p->acl_broker_allow == ON)
     {
       return 0;
     }

--- a/src/broker/broker_acl.c
+++ b/src/broker/broker_acl.c
@@ -500,7 +500,7 @@ access_control_check_right_internal (T_SHM_APPL_SERVER * shm_as_p, char *dbname,
   bool local_ip_flag = false;
 
   // If there is no broker section in the ACL file and acl_broker_allow is ALLOW, access is allowed for all IPs.
-  if (num_access_info == 0 && shm_as_p->acl_broker_allow == ON)
+  if (num_access_info == 0 && shm_as_p->acl_broker_allow == ALLOW)
     {
       return 0;
     }

--- a/src/broker/broker_acl.c
+++ b/src/broker/broker_acl.c
@@ -63,7 +63,7 @@ access_control_set_shm (T_SHM_APPL_SERVER * shm_as_p, T_BROKER_INFO * br_info_p,
 			char *admin_err_msg)
 {
   shm_as_p->access_control = shm_br->access_control;
-  shm_as_p->access_control_default_policy = shm_br->access_control_default_policy;
+  shm_as_p->acl_default_policy = shm_br->acl_default_policy;
   shm_as_p->acl_chn = 0;
 
   if (shm_br->access_control && shm_br->access_control_file[0] != '\0')
@@ -499,8 +499,8 @@ access_control_check_right_internal (T_SHM_APPL_SERVER * shm_as_p, char *dbname,
   int ret_val = -1;
   bool local_ip_flag = false;
 
-  // If there is no broker section in the ACL file and access_control_default_policy is ALLOW, access is allowed for all IPs.
-  if (num_access_info == 0 && shm_as_p->access_control_default_policy == ALLOW)
+  // If there is no broker section in the ACL file and acl_default_policy is ALLOW, access is allowed for all IPs.
+  if (num_access_info == 0 && shm_as_p->acl_default_policy == ALLOW)
     {
       return 0;
     }

--- a/src/broker/broker_admin.c
+++ b/src/broker/broker_admin.c
@@ -156,8 +156,8 @@ main (int argc, char **argv)
 
       if (shm_br == NULL && uw_get_error_code () != UW_ER_SHM_OPEN_MAGIC)
 	{
-	  if (admin_start_cmd (br_info, num_broker, master_shm_id, acl_flag, acl_file, acl_default_policy, admin_log_file)
-	      < 0)
+	  if (admin_start_cmd
+	      (br_info, num_broker, master_shm_id, acl_flag, acl_file, acl_default_policy, admin_log_file) < 0)
 	    {
 	      PRINT_AND_LOG_ERR_MSG ("%s\n", admin_err_msg);
 	      return -1;

--- a/src/broker/broker_admin.c
+++ b/src/broker/broker_admin.c
@@ -79,7 +79,7 @@ main (int argc, char **argv)
   T_BROKER_INFO br_info[MAX_BROKER_NUM];
   char admin_log_file[BROKER_PATH_MAX];
   char acl_file[BROKER_PATH_MAX];
-  bool acl_flag;
+  bool acl_flag, acl_broker_allow;
   int num_broker, master_shm_id;
   int err;
   char msg_buf[256];
@@ -101,7 +101,9 @@ main (int argc, char **argv)
       return 0;
     }
 
-  err = broker_config_read (NULL, br_info, &num_broker, &master_shm_id, admin_log_file, 0, &acl_flag, acl_file, NULL);
+  err =
+    broker_config_read (NULL, br_info, &num_broker, &master_shm_id, admin_log_file, 0, &acl_flag, acl_file,
+			&acl_broker_allow, NULL);
   if (err < 0)
     {
 #if defined (FOR_ODBC_GATEWAY)
@@ -154,7 +156,8 @@ main (int argc, char **argv)
 
       if (shm_br == NULL && uw_get_error_code () != UW_ER_SHM_OPEN_MAGIC)
 	{
-	  if (admin_start_cmd (br_info, num_broker, master_shm_id, acl_flag, acl_file, admin_log_file) < 0)
+	  if (admin_start_cmd (br_info, num_broker, master_shm_id, acl_flag, acl_file, acl_broker_allow, admin_log_file)
+	      < 0)
 	    {
 	      PRINT_AND_LOG_ERR_MSG ("%s\n", admin_err_msg);
 	      return -1;

--- a/src/broker/broker_admin.c
+++ b/src/broker/broker_admin.c
@@ -79,7 +79,7 @@ main (int argc, char **argv)
   T_BROKER_INFO br_info[MAX_BROKER_NUM];
   char admin_log_file[BROKER_PATH_MAX];
   char acl_file[BROKER_PATH_MAX];
-  bool acl_flag, access_control_default_policy;
+  bool acl_flag, acl_default_policy;
   int num_broker, master_shm_id;
   int err;
   char msg_buf[256];
@@ -103,7 +103,7 @@ main (int argc, char **argv)
 
   err =
     broker_config_read (NULL, br_info, &num_broker, &master_shm_id, admin_log_file, 0, &acl_flag, acl_file,
-			&access_control_default_policy, NULL);
+			&acl_default_policy, NULL);
   if (err < 0)
     {
 #if defined (FOR_ODBC_GATEWAY)
@@ -156,9 +156,8 @@ main (int argc, char **argv)
 
       if (shm_br == NULL && uw_get_error_code () != UW_ER_SHM_OPEN_MAGIC)
 	{
-	  if (admin_start_cmd
-	      (br_info, num_broker, master_shm_id, acl_flag, acl_file, access_control_default_policy,
-	       admin_log_file) < 0)
+	  if (admin_start_cmd (br_info, num_broker, master_shm_id, acl_flag, acl_file, acl_default_policy, admin_log_file)
+	      < 0)
 	    {
 	      PRINT_AND_LOG_ERR_MSG ("%s\n", admin_err_msg);
 	      return -1;

--- a/src/broker/broker_admin.c
+++ b/src/broker/broker_admin.c
@@ -79,7 +79,7 @@ main (int argc, char **argv)
   T_BROKER_INFO br_info[MAX_BROKER_NUM];
   char admin_log_file[BROKER_PATH_MAX];
   char acl_file[BROKER_PATH_MAX];
-  bool acl_flag, acl_broker_allow;
+  bool acl_flag, access_control_default_policy;
   int num_broker, master_shm_id;
   int err;
   char msg_buf[256];
@@ -103,7 +103,7 @@ main (int argc, char **argv)
 
   err =
     broker_config_read (NULL, br_info, &num_broker, &master_shm_id, admin_log_file, 0, &acl_flag, acl_file,
-			&acl_broker_allow, NULL);
+			&access_control_default_policy, NULL);
   if (err < 0)
     {
 #if defined (FOR_ODBC_GATEWAY)
@@ -156,8 +156,9 @@ main (int argc, char **argv)
 
       if (shm_br == NULL && uw_get_error_code () != UW_ER_SHM_OPEN_MAGIC)
 	{
-	  if (admin_start_cmd (br_info, num_broker, master_shm_id, acl_flag, acl_file, acl_broker_allow, admin_log_file)
-	      < 0)
+	  if (admin_start_cmd
+	      (br_info, num_broker, master_shm_id, acl_flag, acl_file, access_control_default_policy,
+	       admin_log_file) < 0)
 	    {
 	      PRINT_AND_LOG_ERR_MSG ("%s\n", admin_err_msg);
 	      return -1;

--- a/src/broker/broker_admin_pub.c
+++ b/src/broker/broker_admin_pub.c
@@ -248,7 +248,7 @@ admin_isstarted_cmd (int master_shm_id)
 
 int
 admin_start_cmd (T_BROKER_INFO * br_info, int br_num, int master_shm_id, bool acl_flag, char *acl_file,
-		 char *admin_log_file)
+		 bool acl_broker_allow, char *admin_log_file)
 {
   int i;
   int res = 0;
@@ -350,7 +350,9 @@ admin_start_cmd (T_BROKER_INFO * br_info, int br_num, int master_shm_id, bool ac
     }
 
   /* create master shared memory */
-  shm_br = broker_shm_initialize_shm_broker (master_shm_id, br_info, br_num, acl_flag, acl_file, admin_log_file);
+  shm_br =
+    broker_shm_initialize_shm_broker (master_shm_id, br_info, br_num, acl_flag, acl_file, acl_broker_allow,
+				      admin_log_file);
 
   if (shm_br == NULL)
     {
@@ -2721,7 +2723,8 @@ admin_acl_status_cmd (int master_shm_id, const char *broker_name)
     }
 
   fprintf (stdout, "ACCESS_CONTROL=%s\n", (shm_br->access_control) ? "ON" : "OFF");
-  fprintf (stdout, "ACCESS_CONTROL_FILE=%s\n\n", shm_br->access_control_file);
+  fprintf (stdout, "ACCESS_CONTROL_FILE=%s\n", shm_br->access_control_file);
+  fprintf (stdout, "ACCESS_CONTROL_DEFAULT=%s\n\n", (shm_br->acl_broker_allow) ? "ON" : "OFF");
 
   if (shm_br->access_control == false || shm_br->access_control_file[0] == '\0')
     {
@@ -2747,10 +2750,6 @@ admin_acl_status_cmd (int master_shm_id, const char *broker_name)
 	      uw_shm_detach (shm_br);
 	      return -1;
 	    }
-
-	  fprintf (stdout, "[%%%s]\n", shm_appl->broker_name);
-	  fprintf (stdout, "ACCESS_CONTROL_BEHAVIOR_FOR_EMPTYBROKER=%s\n",
-		   (shm_appl->acl_broker_allow) ? "ALLOW" : "DENY");
 
 	  for (j = 0; j < shm_appl->num_access_info; j++)
 	    {

--- a/src/broker/broker_admin_pub.c
+++ b/src/broker/broker_admin_pub.c
@@ -248,7 +248,7 @@ admin_isstarted_cmd (int master_shm_id)
 
 int
 admin_start_cmd (T_BROKER_INFO * br_info, int br_num, int master_shm_id, bool acl_flag, char *acl_file,
-		 bool acl_broker_allow, char *admin_log_file)
+		 bool access_control_default_policy, char *admin_log_file)
 {
   int i;
   int res = 0;
@@ -351,7 +351,7 @@ admin_start_cmd (T_BROKER_INFO * br_info, int br_num, int master_shm_id, bool ac
 
   /* create master shared memory */
   shm_br =
-    broker_shm_initialize_shm_broker (master_shm_id, br_info, br_num, acl_flag, acl_file, acl_broker_allow,
+    broker_shm_initialize_shm_broker (master_shm_id, br_info, br_num, acl_flag, acl_file, access_control_default_policy,
 				      admin_log_file);
 
   if (shm_br == NULL)
@@ -2724,7 +2724,7 @@ admin_acl_status_cmd (int master_shm_id, const char *broker_name)
 
   fprintf (stdout, "ACCESS_CONTROL=%s\n", (shm_br->access_control) ? "ON" : "OFF");
   fprintf (stdout, "ACCESS_CONTROL_FILE=%s\n", shm_br->access_control_file);
-  fprintf (stdout, "ACCESS_CONTROL_DEFAULT=%s\n\n", (shm_br->acl_broker_allow) ? "ALLOW" : "DENY");
+  fprintf (stdout, "ACCESS_CONTROL_DEFAULT_POLICY=%s\n\n", (shm_br->access_control_default_policy) ? "ALLOW" : "DENY");
 
   if (shm_br->access_control == false || shm_br->access_control_file[0] == '\0')
     {

--- a/src/broker/broker_admin_pub.c
+++ b/src/broker/broker_admin_pub.c
@@ -248,7 +248,7 @@ admin_isstarted_cmd (int master_shm_id)
 
 int
 admin_start_cmd (T_BROKER_INFO * br_info, int br_num, int master_shm_id, bool acl_flag, char *acl_file,
-		 bool access_control_default_policy, char *admin_log_file)
+		 bool acl_default_policy, char *admin_log_file)
 {
   int i;
   int res = 0;
@@ -351,7 +351,7 @@ admin_start_cmd (T_BROKER_INFO * br_info, int br_num, int master_shm_id, bool ac
 
   /* create master shared memory */
   shm_br =
-    broker_shm_initialize_shm_broker (master_shm_id, br_info, br_num, acl_flag, acl_file, access_control_default_policy,
+    broker_shm_initialize_shm_broker (master_shm_id, br_info, br_num, acl_flag, acl_file, acl_default_policy,
 				      admin_log_file);
 
   if (shm_br == NULL)
@@ -2724,7 +2724,7 @@ admin_acl_status_cmd (int master_shm_id, const char *broker_name)
 
   fprintf (stdout, "ACCESS_CONTROL=%s\n", (shm_br->access_control) ? "ON" : "OFF");
   fprintf (stdout, "ACCESS_CONTROL_FILE=%s\n", shm_br->access_control_file);
-  fprintf (stdout, "ACCESS_CONTROL_DEFAULT_POLICY=%s\n\n", (shm_br->access_control_default_policy) ? "ALLOW" : "DENY");
+  fprintf (stdout, "acl_default_policy=%s\n\n", (shm_br->acl_default_policy) ? "ALLOW" : "DENY");
 
   if (shm_br->access_control == false || shm_br->access_control_file[0] == '\0')
     {

--- a/src/broker/broker_admin_pub.c
+++ b/src/broker/broker_admin_pub.c
@@ -2724,7 +2724,7 @@ admin_acl_status_cmd (int master_shm_id, const char *broker_name)
 
   fprintf (stdout, "ACCESS_CONTROL=%s\n", (shm_br->access_control) ? "ON" : "OFF");
   fprintf (stdout, "ACCESS_CONTROL_FILE=%s\n", shm_br->access_control_file);
-  fprintf (stdout, "ACCESS_CONTROL_DEFAULT=%s\n\n", (shm_br->acl_broker_allow) ? "ON" : "OFF");
+  fprintf (stdout, "ACCESS_CONTROL_DEFAULT=%s\n\n", (shm_br->acl_broker_allow) ? "ALLOW" : "DENY");
 
   if (shm_br->access_control == false || shm_br->access_control_file[0] == '\0')
     {

--- a/src/broker/broker_admin_pub.c
+++ b/src/broker/broker_admin_pub.c
@@ -2724,7 +2724,7 @@ admin_acl_status_cmd (int master_shm_id, const char *broker_name)
 
   fprintf (stdout, "ACCESS_CONTROL=%s\n", (shm_br->access_control) ? "ON" : "OFF");
   fprintf (stdout, "ACCESS_CONTROL_FILE=%s\n", shm_br->access_control_file);
-  fprintf (stdout, "acl_default_policy=%s\n\n", (shm_br->acl_default_policy) ? "ALLOW" : "DENY");
+  fprintf (stdout, "ACCESS_CONTROL_DEFAULT_POLICY=%s\n\n", (shm_br->acl_default_policy) ? "ALLOW" : "DENY");
 
   if (shm_br->access_control == false || shm_br->access_control_file[0] == '\0')
     {

--- a/src/broker/broker_admin_pub.h
+++ b/src/broker/broker_admin_pub.h
@@ -38,7 +38,7 @@
 int admin_isstarted_cmd (int);
 #endif
 
-int admin_start_cmd (T_BROKER_INFO *, int, int, bool, char *, char *);
+int admin_start_cmd (T_BROKER_INFO *, int, int, bool, char *, bool, char *);
 int admin_stop_cmd (int);
 int admin_add_cmd (int, const char *);
 int admin_restart_cmd (int, const char *, int);

--- a/src/broker/broker_admin_so.c
+++ b/src/broker/broker_admin_so.c
@@ -140,8 +140,7 @@
 
 static void admin_log_write (const char *log_file, const char *msg);
 static int admin_common (T_BROKER_INFO * br_info, int *num_broker, int *master_shm_id, char *admin_log_file,
-			 char *err_msg, char admin_flag, bool * acl_flag, char *acl_file,
-			 bool * access_control_default_policy);
+			 char *err_msg, char admin_flag, bool * acl_flag, char *acl_file, bool * acl_default_policy);
 static int copy_job_info (T_JOB_INFO ** job_info, T_MAX_HEAP_NODE * job_q);
 static int conf_copy_header (T_UC_CONF * unicas_conf, int master_shm_id, char *admin_log_file, char *err_msg);
 static int conf_copy_broker (T_UC_CONF * unicas_conf, T_BROKER_INFO * br_conf, int num_br, char *err_msg);
@@ -325,17 +324,15 @@ uc_start (char *err_msg)
   int num_broker, master_shm_id;
   char admin_log_file[BROKER_PATH_MAX];
   char acl_file[BROKER_PATH_MAX];
-  bool acl_flag, access_control_default_policy;
+  bool acl_flag, acl_default_policy;
 
   if (admin_common
-      (br_info, &num_broker, &master_shm_id, admin_log_file, err_msg, 1, &acl_flag, acl_file,
-       &access_control_default_policy) < 0)
+      (br_info, &num_broker, &master_shm_id, admin_log_file, err_msg, 1, &acl_flag, acl_file, &acl_default_policy) < 0)
     {
       return -1;
     }
 
-  if (admin_start_cmd
-      (br_info, num_broker, master_shm_id, acl_flag, acl_file, access_control_default_policy, admin_log_file) < 0)
+  if (admin_start_cmd (br_info, num_broker, master_shm_id, acl_flag, acl_file, acl_default_policy, admin_log_file) < 0)
     {
       CP_ADMIN_ERR_MSG (err_msg);
       return -1;
@@ -1151,10 +1148,10 @@ conf_copy_header (T_UC_CONF * unicas_conf, int master_shm_id, char *admin_log_fi
 
 static int
 admin_common (T_BROKER_INFO * br_info, int *num_broker, int *master_shm_id, char *admin_log_file, char *err_msg,
-	      char admin_flag, bool * acl_flag, char *acl_file, bool * access_control_default_policy)
+	      char admin_flag, bool * acl_flag, char *acl_file, bool * acl_default_policy)
 {
   if (broker_config_read (NULL, br_info, num_broker, master_shm_id, admin_log_file, admin_flag, acl_flag, acl_file,
-			  access_control_default_policy, err_msg) < 0)
+			  acl_default_policy, err_msg) < 0)
     {
       return -1;
     }

--- a/src/broker/broker_admin_so.c
+++ b/src/broker/broker_admin_so.c
@@ -140,7 +140,8 @@
 
 static void admin_log_write (const char *log_file, const char *msg);
 static int admin_common (T_BROKER_INFO * br_info, int *num_broker, int *master_shm_id, char *admin_log_file,
-			 char *err_msg, char admin_flag, bool * acl_flag, char *acl_file, bool * acl_broker_allow);
+			 char *err_msg, char admin_flag, bool * acl_flag, char *acl_file,
+			 bool * access_control_default_policy);
 static int copy_job_info (T_JOB_INFO ** job_info, T_MAX_HEAP_NODE * job_q);
 static int conf_copy_header (T_UC_CONF * unicas_conf, int master_shm_id, char *admin_log_file, char *err_msg);
 static int conf_copy_broker (T_UC_CONF * unicas_conf, T_BROKER_INFO * br_conf, int num_br, char *err_msg);
@@ -324,15 +325,17 @@ uc_start (char *err_msg)
   int num_broker, master_shm_id;
   char admin_log_file[BROKER_PATH_MAX];
   char acl_file[BROKER_PATH_MAX];
-  bool acl_flag, acl_broker_allow;
+  bool acl_flag, access_control_default_policy;
 
   if (admin_common
-      (br_info, &num_broker, &master_shm_id, admin_log_file, err_msg, 1, &acl_flag, acl_file, &acl_broker_allow) < 0)
+      (br_info, &num_broker, &master_shm_id, admin_log_file, err_msg, 1, &acl_flag, acl_file,
+       &access_control_default_policy) < 0)
     {
       return -1;
     }
 
-  if (admin_start_cmd (br_info, num_broker, master_shm_id, acl_flag, acl_file, acl_broker_allow, admin_log_file) < 0)
+  if (admin_start_cmd
+      (br_info, num_broker, master_shm_id, acl_flag, acl_file, access_control_default_policy, admin_log_file) < 0)
     {
       CP_ADMIN_ERR_MSG (err_msg);
       return -1;
@@ -1148,10 +1151,10 @@ conf_copy_header (T_UC_CONF * unicas_conf, int master_shm_id, char *admin_log_fi
 
 static int
 admin_common (T_BROKER_INFO * br_info, int *num_broker, int *master_shm_id, char *admin_log_file, char *err_msg,
-	      char admin_flag, bool * acl_flag, char *acl_file, bool * acl_broker_allow)
+	      char admin_flag, bool * acl_flag, char *acl_file, bool * access_control_default_policy)
 {
   if (broker_config_read (NULL, br_info, num_broker, master_shm_id, admin_log_file, admin_flag, acl_flag, acl_file,
-			  acl_broker_allow, err_msg) < 0)
+			  access_control_default_policy, err_msg) < 0)
     {
       return -1;
     }

--- a/src/broker/broker_admin_so.c
+++ b/src/broker/broker_admin_so.c
@@ -140,7 +140,7 @@
 
 static void admin_log_write (const char *log_file, const char *msg);
 static int admin_common (T_BROKER_INFO * br_info, int *num_broker, int *master_shm_id, char *admin_log_file,
-			 char *err_msg, char admin_flag, bool * acl_flag, char *acl_file);
+			 char *err_msg, char admin_flag, bool * acl_flag, char *acl_file, bool * acl_broker_allow);
 static int copy_job_info (T_JOB_INFO ** job_info, T_MAX_HEAP_NODE * job_q);
 static int conf_copy_header (T_UC_CONF * unicas_conf, int master_shm_id, char *admin_log_file, char *err_msg);
 static int conf_copy_broker (T_UC_CONF * unicas_conf, T_BROKER_INFO * br_conf, int num_br, char *err_msg);
@@ -168,7 +168,7 @@ uc_broker_shm_open (char *err_msg)
   char admin_log_file[BROKER_PATH_MAX];
   void *ret_val;
 
-  if (admin_common (br_conf, &num_broker, &master_shm_id, admin_log_file, err_msg, 0, NULL, NULL) < 0)
+  if (admin_common (br_conf, &num_broker, &master_shm_id, admin_log_file, err_msg, 0, NULL, NULL, NULL) < 0)
     {
       return NULL;
     }
@@ -324,14 +324,15 @@ uc_start (char *err_msg)
   int num_broker, master_shm_id;
   char admin_log_file[BROKER_PATH_MAX];
   char acl_file[BROKER_PATH_MAX];
-  bool acl_flag;
+  bool acl_flag, acl_broker_allow;
 
-  if (admin_common (br_info, &num_broker, &master_shm_id, admin_log_file, err_msg, 1, &acl_flag, acl_file) < 0)
+  if (admin_common
+      (br_info, &num_broker, &master_shm_id, admin_log_file, err_msg, 1, &acl_flag, acl_file, &acl_broker_allow) < 0)
     {
       return -1;
     }
 
-  if (admin_start_cmd (br_info, num_broker, master_shm_id, acl_flag, acl_file, admin_log_file) < 0)
+  if (admin_start_cmd (br_info, num_broker, master_shm_id, acl_flag, acl_file, acl_broker_allow, admin_log_file) < 0)
     {
       CP_ADMIN_ERR_MSG (err_msg);
       return -1;
@@ -349,7 +350,7 @@ uc_stop (char *err_msg)
   int num_broker, master_shm_id;
   char admin_log_file[BROKER_PATH_MAX];
 
-  if (admin_common (br_info, &num_broker, &master_shm_id, admin_log_file, err_msg, 1, NULL, NULL) < 0)
+  if (admin_common (br_info, &num_broker, &master_shm_id, admin_log_file, err_msg, 1, NULL, NULL, NULL) < 0)
     {
       return -1;
     }
@@ -373,7 +374,7 @@ uc_add (const char *br_name, char *err_msg)
   char admin_log_file[BROKER_PATH_MAX];
   char msg_buf[256];
 
-  if (admin_common (br_info, &num_broker, &master_shm_id, admin_log_file, err_msg, 1, NULL, NULL) < 0)
+  if (admin_common (br_info, &num_broker, &master_shm_id, admin_log_file, err_msg, 1, NULL, NULL, NULL) < 0)
     {
       return -1;
     }
@@ -398,7 +399,7 @@ uc_restart (const char *br_name, int as_index, char *err_msg)
   char admin_log_file[BROKER_PATH_MAX];
   char msg_buf[256];
 
-  if (admin_common (br_info, &num_broker, &master_shm_id, admin_log_file, err_msg, 1, NULL, NULL) < 0)
+  if (admin_common (br_info, &num_broker, &master_shm_id, admin_log_file, err_msg, 1, NULL, NULL, NULL) < 0)
     {
       return -1;
     }
@@ -423,7 +424,7 @@ uc_drop (const char *br_name, char *err_msg)
   char admin_log_file[256];
   char msg_buf[256];
 
-  if (admin_common (br_info, &num_broker, &master_shm_id, admin_log_file, err_msg, 1, NULL, NULL) < 0)
+  if (admin_common (br_info, &num_broker, &master_shm_id, admin_log_file, err_msg, 1, NULL, NULL, NULL) < 0)
     {
       return -1;
     }
@@ -448,7 +449,7 @@ uc_on (const char *br_name, char *err_msg)
   char admin_log_file[BROKER_PATH_MAX];
   char msg_buf[256];
 
-  if (admin_common (br_info, &num_broker, &master_shm_id, admin_log_file, err_msg, 1, NULL, NULL) < 0)
+  if (admin_common (br_info, &num_broker, &master_shm_id, admin_log_file, err_msg, 1, NULL, NULL, NULL) < 0)
     {
       return -1;
     }
@@ -473,7 +474,7 @@ uc_off (const char *br_name, char *err_msg)
   char admin_log_file[BROKER_PATH_MAX];
   char msg_buf[256];
 
-  if (admin_common (br_info, &num_broker, &master_shm_id, admin_log_file, err_msg, 1, NULL, NULL) < 0)
+  if (admin_common (br_info, &num_broker, &master_shm_id, admin_log_file, err_msg, 1, NULL, NULL, NULL) < 0)
     {
       return -1;
     }
@@ -503,7 +504,7 @@ uc_as_info (const char *br_name, T_AS_INFO ** ret_as_info, T_JOB_INFO ** job_inf
   T_AS_INFO *as_info = NULL;
   char client_ip_str[16];
 
-  if (admin_common (br_info, &num_broker, &master_shm_id, admin_log_file, err_msg, 0, NULL, NULL) < 0)
+  if (admin_common (br_info, &num_broker, &master_shm_id, admin_log_file, err_msg, 0, NULL, NULL, NULL) < 0)
     {
       return -1;
     }
@@ -689,7 +690,7 @@ uc_br_info (T_BR_INFO ** ret_br_info, char *err_msg)
   T_BR_INFO *br_info = NULL;
   char *p;
 
-  if (admin_common (br_conf, &num_broker, &master_shm_id, admin_log_file, err_msg, 0, NULL, NULL) < 0)
+  if (admin_common (br_conf, &num_broker, &master_shm_id, admin_log_file, err_msg, 0, NULL, NULL, NULL) < 0)
     {
       return -1;
     }
@@ -845,7 +846,7 @@ uc_unicas_conf (T_UC_CONF * unicas_conf, int *ret_mst_shmid, char *err_msg)
 
   memset (unicas_conf, 0, sizeof (T_UC_CONF));
 
-  if (admin_common (br_conf, &num_broker, &master_shm_id, admin_log_file, err_msg, 0, NULL, NULL) < 0)
+  if (admin_common (br_conf, &num_broker, &master_shm_id, admin_log_file, err_msg, 0, NULL, NULL, NULL) < 0)
     {
       return -1;
     }
@@ -999,7 +1000,7 @@ uc_del_cas_log (const char *br_name, int asid, char *err_msg)
 
   err_msg[0] = '\0';
 
-  if (admin_common (br_info, &num_broker, &master_shm_id, admin_log_file, err_msg, 0, NULL, NULL) < 0)
+  if (admin_common (br_info, &num_broker, &master_shm_id, admin_log_file, err_msg, 0, NULL, NULL, NULL) < 0)
     {
       return -1;
     }
@@ -1147,10 +1148,10 @@ conf_copy_header (T_UC_CONF * unicas_conf, int master_shm_id, char *admin_log_fi
 
 static int
 admin_common (T_BROKER_INFO * br_info, int *num_broker, int *master_shm_id, char *admin_log_file, char *err_msg,
-	      char admin_flag, bool * acl_flag, char *acl_file)
+	      char admin_flag, bool * acl_flag, char *acl_file, bool * acl_broker_allow)
 {
   if (broker_config_read (NULL, br_info, num_broker, master_shm_id, admin_log_file, admin_flag, acl_flag, acl_file,
-			  err_msg) < 0)
+			  acl_broker_allow, err_msg) < 0)
     {
       return -1;
     }
@@ -1325,7 +1326,7 @@ uc_changer_internal (const char *br_name, const char *name, const char *value, i
   int num_broker, master_shm_id;
   char admin_log_file[BROKER_PATH_MAX];
 
-  if (admin_common (br_info, &num_broker, &master_shm_id, admin_log_file, err_msg, 0, NULL, NULL) < 0)
+  if (admin_common (br_info, &num_broker, &master_shm_id, admin_log_file, err_msg, 0, NULL, NULL, NULL) < 0)
     {
       return -1;
     }

--- a/src/broker/broker_changer.c
+++ b/src/broker/broker_changer.c
@@ -67,7 +67,7 @@ main (int argc, char *argv[])
       exit (0);
     }
 
-  if (broker_config_read (NULL, br_info, &num_broker, &master_shm_id, NULL, 0, NULL, NULL, NULL) < 0)
+  if (broker_config_read (NULL, br_info, &num_broker, &master_shm_id, NULL, 0, NULL, NULL, NULL, NULL) < 0)
     {
       printf ("config file error\n");
       exit (0);

--- a/src/broker/broker_config.c
+++ b/src/broker/broker_config.c
@@ -140,11 +140,11 @@ static T_CONF_TABLE tbl_on_off[] = {
   {NULL, 0}
 };
 
-static T_CONF_TABLE tbl_allow_deny[] = {
-  {"ALLOW", ALLOW},
-  {"DENY", DENY},
-  {NULL, 0}
-};
+// static T_CONF_TABLE tbl_allow_deny[] = {
+//   {"ALLOW", ALLOW},
+//   {"DENY", DENY},
+//   {NULL, 0}
+// };
 
 static T_CONF_TABLE tbl_sql_log_mode[] = {
   {"ALL", SQL_LOG_MODE_ALL},
@@ -217,7 +217,7 @@ static char *conf_file_loaded[MAX_NUM_OF_CONF_FILE_LOADED];
 const char *broker_keywords[] = {
   "ACCESS_CONTROL",
   "ACCESS_CONTROL_FILE",
-  "ACCESS_CONTROL_BEHAVIOR_FOR_EMPTYBROKER",
+  "ACCESS_CONTROL_DEFAULT",
   "ADMIN_LOG_FILE",
   "MASTER_SHM_ID",
   "ACCESS_LIST",
@@ -441,11 +441,14 @@ get_conf_string (int value, T_CONF_TABLE * conf_table)
  *   br_shm_id(out):
  *   admin_log_file(out):
  *   admin_flag(in):
+ *   acl_flag(in):
+ *   acl_file(in):
+ *   acl_broker_allow(in):
  *   admin_err_msg(in):
  */
 static int
 broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int *num_broker, int *br_shm_id,
-			     char *admin_log_file, char admin_flag, bool * acl_flag, char *acl_file,
+			     char *admin_log_file, char admin_flag, bool * acl_flag, char *acl_file, bool * acl_broker_allow,
 			     char *admin_err_msg)
 {
 #if defined (_UC_ADMIN_SO_)
@@ -589,6 +592,18 @@ broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int
 	  goto conf_error;
 	}
     }
+
+  if (acl_broker_allow != NULL)
+    {
+      INI_GETSTR_CHK (s, ini, SECTION_NAME, "ACCESS_CONTROL_DEFAULT", "OFF", &lineno);
+      tmp_int = conf_get_value_table_on_off (s);
+      if (tmp_int < 0)
+	{
+	  errcode = PARAM_BAD_RANGE;
+	  goto conf_error;
+	}
+      *acl_broker_allow = tmp_int;
+    }  
 
   for (i = 0; i < ini->nsec; i++)
     {
@@ -867,14 +882,6 @@ broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int
       strncpy_bufsize (time_str, s);
       br_info[num_brs].time_to_kill = (int) ut_time_string_to_sec (time_str, "sec");
       if (br_info[num_brs].time_to_kill < 0)
-	{
-	  errcode = PARAM_BAD_VALUE;
-	  goto conf_error;
-	}
-
-      INI_GETSTR_CHK (s, ini, sec_name, "ACCESS_CONTROL_BEHAVIOR_FOR_EMPTYBROKER", "DENY", &lineno);
-      br_info[num_brs].acl_broker_allow = conf_get_value_table_allow_deny (s);
-      if (br_info[num_brs].acl_broker_allow < 0)
 	{
 	  errcode = PARAM_BAD_VALUE;
 	  goto conf_error;
@@ -1475,11 +1482,14 @@ clear_conf_cache_entry (int cid)
  *   br_shm_id(out):
  *   admin_log_file(out):
  *   admin_flag(in):
+ *   acl_flag(out):
+ *   acl_file(out):
+ *   acl_broker_allow(out):
  *   admin_err_msg(in):
  */
 int
 broker_config_read (const char *conf_file, T_BROKER_INFO * br_info, int *num_broker, int *br_shm_id,
-		    char *admin_log_file, char admin_flag, bool * acl_flag, char *acl_file, char *admin_err_msg)
+		    char *admin_log_file, char admin_flag, bool * acl_flag, char *acl_file, bool *acl_broker_allow, char *admin_err_msg)
 {
   int err = 0;
   char file_name[BROKER_PATH_MAX], file_being_dealt_with[BROKER_PATH_MAX];
@@ -1545,7 +1555,7 @@ broker_config_read (const char *conf_file, T_BROKER_INFO * br_info, int *num_bro
   memset (br_info, 0, sizeof (T_BROKER_INFO) * MAX_BROKER_NUM);
   err =
     broker_config_read_internal (file_being_dealt_with, br_info, num_broker, br_shm_id, admin_log_file, admin_flag,
-				 acl_flag, acl_file, admin_err_msg);
+				 acl_flag, acl_file, acl_broker_allow, admin_err_msg);
   if (err == 0)
     {
       write_conf_cache (file_being_dealt_with, acl_flag, num_broker, br_shm_id, admin_log_file, br_info,
@@ -1651,7 +1661,6 @@ broker_config_dump (FILE * fp, const T_BROKER_INFO * br_info, int num_broker, in
 	}
       fprintf (fp, "JOB_QUEUE_SIZE\t\t=%d\n", br_info[i].job_queue_size);
       fprintf (fp, "TIME_TO_KILL\t\t=%d\n", br_info[i].time_to_kill);
-      fprintf (fp, "ACCESS_CONTROL_BEHAVIOR_FOR_EMPTYBROKER\t=%s\n", br_info[i].acl_broker_allow ? "ALLOW" : "DENY");
       tmp_str = get_conf_string (br_info[i].access_log, tbl_on_off);
       if (tmp_str)
 	{
@@ -1832,17 +1841,6 @@ int
 conf_get_value_table_on_off (const char *value)
 {
   return (get_conf_value (value, tbl_on_off));
-}
-
-/*
-* conf_get_value_table_allow_deny - get value from allow/deny table
-*   return: 0, 1 or -1 if fail
-*   value(in):
-*/
-int
-conf_get_value_table_allow_deny (const char *value)
-{
-  return (get_conf_value (value, tbl_allow_deny));
 }
 
 /*

--- a/src/broker/broker_config.c
+++ b/src/broker/broker_config.c
@@ -101,7 +101,7 @@ struct br_conf_info
 {
   int num_broker;
   int acl_flag;
-  int acl_broker_allow;
+  int access_control_default_policy;
   int br_shm_id;
   char *conf_file;
   char *admin_log_file;
@@ -120,10 +120,10 @@ static void conf_file_has_been_loaded (const char *conf_path);
 static int check_port_number (T_BROKER_INFO * br_info, int num_brs);
 static int get_conf_value (const char *string, T_CONF_TABLE * conf_table);
 static const char *get_conf_string (int value, T_CONF_TABLE * conf_table);
-static void read_conf_cache (int cid, bool * acl, bool * acl_broker_allow, int *num_br, int *shm_id, char *log_file,
-			     T_BROKER_INFO * br_info);
-static void write_conf_cache (char *file, bool * acl_flag, bool * acl_broker_allow, int *num_broker, int *shm_id,
-			      char *alog, T_BROKER_INFO * br_info, time_t bf_mtime);
+static void read_conf_cache (int cid, bool * acl, bool * access_control_default_policy, int *num_br, int *shm_id,
+			     char *log_file, T_BROKER_INFO * br_info);
+static void write_conf_cache (char *file, bool * acl_flag, bool * access_control_default_policy, int *num_broker,
+			      int *shm_id, char *alog, T_BROKER_INFO * br_info, time_t bf_mtime);
 static void clear_conf_cache_entry (int cid);
 static bool is_invalid_buf_size (int size);
 
@@ -219,7 +219,7 @@ static char *conf_file_loaded[MAX_NUM_OF_CONF_FILE_LOADED];
 const char *broker_keywords[] = {
   "ACCESS_CONTROL",
   "ACCESS_CONTROL_FILE",
-  "ACCESS_CONTROL_DEFAULT",
+  "ACCESS_CONTROL_DEFAULT_POLICY",
   "ADMIN_LOG_FILE",
   "MASTER_SHM_ID",
   "ACCESS_LIST",
@@ -445,13 +445,13 @@ get_conf_string (int value, T_CONF_TABLE * conf_table)
  *   admin_flag(in):
  *   acl_flag(in):
  *   acl_file(in):
- *   acl_broker_allow(in):
+ *   access_control_default_policy(in):
  *   admin_err_msg(in):
  */
 static int
 broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int *num_broker, int *br_shm_id,
 			     char *admin_log_file, char admin_flag, bool * acl_flag, char *acl_file,
-			     bool * acl_broker_allow, char *admin_err_msg)
+			     bool * access_control_default_policy, char *admin_err_msg)
 {
 #if defined (_UC_ADMIN_SO_)
 #define PRINTERROR(...)	sprintf(admin_err_msg, __VA_ARGS__)
@@ -595,16 +595,16 @@ broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int
 	}
     }
 
-  if (acl_broker_allow != NULL)
+  if (access_control_default_policy != NULL)
     {
-      INI_GETSTR_CHK (s, ini, SECTION_NAME, "ACCESS_CONTROL_DEFAULT", "DENY", &lineno);
+      INI_GETSTR_CHK (s, ini, SECTION_NAME, "ACCESS_CONTROL_DEFAULT_POLICY", "DENY", &lineno);
       tmp_int = conf_get_value_table_allow_deny (s);
       if (tmp_int < 0)
 	{
 	  errcode = PARAM_BAD_RANGE;
 	  goto conf_error;
 	}
-      *acl_broker_allow = tmp_int;
+      *access_control_default_policy = tmp_int;
     }
 
   for (i = 0; i < ini->nsec; i++)
@@ -1395,8 +1395,8 @@ conf_error:
 }
 
 static void
-write_conf_cache (char *broker_conf_file, bool * acl_flag, bool * acl_broker_allow, int *num_broker, int *br_shm_id,
-		  char *admin_logfile, T_BROKER_INFO * br_info, time_t br_conf_mtime)
+write_conf_cache (char *broker_conf_file, bool * acl_flag, bool * access_control_default_policy, int *num_broker,
+		  int *br_shm_id, char *admin_logfile, T_BROKER_INFO * br_info, time_t br_conf_mtime)
 {
   if (broker_conf_file == NULL || num_broker == NULL || br_info == NULL || br_shm_id == NULL)
     {
@@ -1417,9 +1417,9 @@ write_conf_cache (char *broker_conf_file, bool * acl_flag, bool * acl_broker_all
 	      br_conf_info[i].acl_flag = *acl_flag;
 	    }
 
-	  if (acl_broker_allow)
+	  if (access_control_default_policy)
 	    {
-	      br_conf_info[i].acl_broker_allow = *acl_broker_allow;
+	      br_conf_info[i].access_control_default_policy = *access_control_default_policy;
 	    }
 
 	  if (admin_logfile)
@@ -1434,8 +1434,8 @@ write_conf_cache (char *broker_conf_file, bool * acl_flag, bool * acl_broker_all
 }
 
 static void
-read_conf_cache (int cid, bool * acl_flag, bool * acl_broker_allow, int *num_broker, int *br_shm_id, char *logfile,
-		 T_BROKER_INFO * br_info)
+read_conf_cache (int cid, bool * acl_flag, bool * access_control_default_policy, int *num_broker, int *br_shm_id,
+		 char *logfile, T_BROKER_INFO * br_info)
 {
   if (cid < 0 || cid >= MAX_NUM_CACHED_BROKER_FILES || br_shm_id == NULL || br_info == NULL)
     {
@@ -1447,9 +1447,9 @@ read_conf_cache (int cid, bool * acl_flag, bool * acl_broker_allow, int *num_bro
       *acl_flag = br_conf_info[cid].acl_flag;
     }
 
-  if (acl_broker_allow)
+  if (access_control_default_policy)
     {
-      *acl_broker_allow = br_conf_info[cid].acl_flag;
+      *access_control_default_policy = br_conf_info[cid].acl_flag;
     }
 
   if (logfile && br_conf_info[cid].admin_log_file)
@@ -1497,13 +1497,13 @@ clear_conf_cache_entry (int cid)
  *   admin_flag(in):
  *   acl_flag(out):
  *   acl_file(out):
- *   acl_broker_allow(out):
+ *   access_control_default_policy(out):
  *   admin_err_msg(in):
  */
 int
 broker_config_read (const char *conf_file, T_BROKER_INFO * br_info, int *num_broker, int *br_shm_id,
-		    char *admin_log_file, char admin_flag, bool * acl_flag, char *acl_file, bool * acl_broker_allow,
-		    char *admin_err_msg)
+		    char *admin_log_file, char admin_flag, bool * acl_flag, char *acl_file,
+		    bool * access_control_default_policy, char *admin_err_msg)
 {
   int err = 0;
   char file_name[BROKER_PATH_MAX], file_being_dealt_with[BROKER_PATH_MAX];
@@ -1554,7 +1554,8 @@ broker_config_read (const char *conf_file, T_BROKER_INFO * br_info, int *num_bro
 	{
 	  if (br_conf_info[cid].last_modified == stat_buf.st_mtime)
 	    {
-	      read_conf_cache (cid, acl_flag, acl_broker_allow, num_broker, br_shm_id, admin_log_file, br_info);
+	      read_conf_cache (cid, acl_flag, access_control_default_policy, num_broker, br_shm_id, admin_log_file,
+			       br_info);
 
 	      return 0;
 	    }
@@ -1569,11 +1570,11 @@ broker_config_read (const char *conf_file, T_BROKER_INFO * br_info, int *num_bro
   memset (br_info, 0, sizeof (T_BROKER_INFO) * MAX_BROKER_NUM);
   err =
     broker_config_read_internal (file_being_dealt_with, br_info, num_broker, br_shm_id, admin_log_file, admin_flag,
-				 acl_flag, acl_file, acl_broker_allow, admin_err_msg);
+				 acl_flag, acl_file, access_control_default_policy, admin_err_msg);
   if (err == 0)
     {
-      write_conf_cache (file_being_dealt_with, acl_flag, acl_broker_allow, num_broker, br_shm_id, admin_log_file,
-			br_info, stat_buf.st_mtime);
+      write_conf_cache (file_being_dealt_with, acl_flag, access_control_default_policy, num_broker, br_shm_id,
+			admin_log_file, br_info, stat_buf.st_mtime);
     }
 
   return err;

--- a/src/broker/broker_config.c
+++ b/src/broker/broker_config.c
@@ -140,6 +140,12 @@ static T_CONF_TABLE tbl_on_off[] = {
   {NULL, 0}
 };
 
+static T_CONF_TABLE tbl_allow_deny[] = {
+  {"ALLOW", ALLOW},
+  {"DENY", DENY},
+  {NULL, 0}
+};
+
 static T_CONF_TABLE tbl_sql_log_mode[] = {
   {"ALL", SQL_LOG_MODE_ALL},
   {"ON", SQL_LOG_MODE_ALL},
@@ -1835,6 +1841,17 @@ int
 conf_get_value_table_on_off (const char *value)
 {
   return (get_conf_value (value, tbl_on_off));
+}
+
+/*
+* conf_get_value_table_allow_deny - get value from allow/deny table
+*   return: 0, 1 or -1 if fail
+*   value(in):
+*/
+int
+conf_get_value_table_allow_deny (const char *value)
+{
+  return (get_conf_value (value, tbl_allow_deny));
 }
 
 /*

--- a/src/broker/broker_config.c
+++ b/src/broker/broker_config.c
@@ -219,7 +219,7 @@ static char *conf_file_loaded[MAX_NUM_OF_CONF_FILE_LOADED];
 const char *broker_keywords[] = {
   "ACCESS_CONTROL",
   "ACCESS_CONTROL_FILE",
-  "acl_default_policy",
+  "ACCESS_CONTROL_DEFAULT_POLICY",
   "ADMIN_LOG_FILE",
   "MASTER_SHM_ID",
   "ACCESS_LIST",
@@ -597,7 +597,7 @@ broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int
 
   if (acl_default_policy != NULL)
     {
-      INI_GETSTR_CHK (s, ini, SECTION_NAME, "acl_default_policy", "DENY", &lineno);
+      INI_GETSTR_CHK (s, ini, SECTION_NAME, "ACCESS_CONTROL_DEFAULT_POLICY", "DENY", &lineno);
       tmp_int = conf_get_value_table_allow_deny (s);
       if (tmp_int < 0)
 	{

--- a/src/broker/broker_config.c
+++ b/src/broker/broker_config.c
@@ -101,7 +101,7 @@ struct br_conf_info
 {
   int num_broker;
   int acl_flag;
-  int access_control_default_policy;
+  int acl_default_policy;
   int br_shm_id;
   char *conf_file;
   char *admin_log_file;
@@ -120,10 +120,10 @@ static void conf_file_has_been_loaded (const char *conf_path);
 static int check_port_number (T_BROKER_INFO * br_info, int num_brs);
 static int get_conf_value (const char *string, T_CONF_TABLE * conf_table);
 static const char *get_conf_string (int value, T_CONF_TABLE * conf_table);
-static void read_conf_cache (int cid, bool * acl, bool * access_control_default_policy, int *num_br, int *shm_id,
-			     char *log_file, T_BROKER_INFO * br_info);
-static void write_conf_cache (char *file, bool * acl_flag, bool * access_control_default_policy, int *num_broker,
-			      int *shm_id, char *alog, T_BROKER_INFO * br_info, time_t bf_mtime);
+static void read_conf_cache (int cid, bool * acl, bool * acl_default_policy, int *num_br, int *shm_id, char *log_file,
+			     T_BROKER_INFO * br_info);
+static void write_conf_cache (char *file, bool * acl_flag, bool * acl_default_policy, int *num_broker, int *shm_id,
+			      char *alog, T_BROKER_INFO * br_info, time_t bf_mtime);
 static void clear_conf_cache_entry (int cid);
 static bool is_invalid_buf_size (int size);
 
@@ -219,7 +219,7 @@ static char *conf_file_loaded[MAX_NUM_OF_CONF_FILE_LOADED];
 const char *broker_keywords[] = {
   "ACCESS_CONTROL",
   "ACCESS_CONTROL_FILE",
-  "ACCESS_CONTROL_DEFAULT_POLICY",
+  "acl_default_policy",
   "ADMIN_LOG_FILE",
   "MASTER_SHM_ID",
   "ACCESS_LIST",
@@ -445,13 +445,13 @@ get_conf_string (int value, T_CONF_TABLE * conf_table)
  *   admin_flag(in):
  *   acl_flag(in):
  *   acl_file(in):
- *   access_control_default_policy(in):
+ *   acl_default_policy(in):
  *   admin_err_msg(in):
  */
 static int
 broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int *num_broker, int *br_shm_id,
 			     char *admin_log_file, char admin_flag, bool * acl_flag, char *acl_file,
-			     bool * access_control_default_policy, char *admin_err_msg)
+			     bool * acl_default_policy, char *admin_err_msg)
 {
 #if defined (_UC_ADMIN_SO_)
 #define PRINTERROR(...)	sprintf(admin_err_msg, __VA_ARGS__)
@@ -595,16 +595,16 @@ broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int
 	}
     }
 
-  if (access_control_default_policy != NULL)
+  if (acl_default_policy != NULL)
     {
-      INI_GETSTR_CHK (s, ini, SECTION_NAME, "ACCESS_CONTROL_DEFAULT_POLICY", "DENY", &lineno);
+      INI_GETSTR_CHK (s, ini, SECTION_NAME, "acl_default_policy", "DENY", &lineno);
       tmp_int = conf_get_value_table_allow_deny (s);
       if (tmp_int < 0)
 	{
 	  errcode = PARAM_BAD_RANGE;
 	  goto conf_error;
 	}
-      *access_control_default_policy = tmp_int;
+      *acl_default_policy = tmp_int;
     }
 
   for (i = 0; i < ini->nsec; i++)
@@ -1395,8 +1395,8 @@ conf_error:
 }
 
 static void
-write_conf_cache (char *broker_conf_file, bool * acl_flag, bool * access_control_default_policy, int *num_broker,
-		  int *br_shm_id, char *admin_logfile, T_BROKER_INFO * br_info, time_t br_conf_mtime)
+write_conf_cache (char *broker_conf_file, bool * acl_flag, bool * acl_default_policy, int *num_broker, int *br_shm_id,
+		  char *admin_logfile, T_BROKER_INFO * br_info, time_t br_conf_mtime)
 {
   if (broker_conf_file == NULL || num_broker == NULL || br_info == NULL || br_shm_id == NULL)
     {
@@ -1417,9 +1417,9 @@ write_conf_cache (char *broker_conf_file, bool * acl_flag, bool * access_control
 	      br_conf_info[i].acl_flag = *acl_flag;
 	    }
 
-	  if (access_control_default_policy)
+	  if (acl_default_policy)
 	    {
-	      br_conf_info[i].access_control_default_policy = *access_control_default_policy;
+	      br_conf_info[i].acl_default_policy = *acl_default_policy;
 	    }
 
 	  if (admin_logfile)
@@ -1434,8 +1434,8 @@ write_conf_cache (char *broker_conf_file, bool * acl_flag, bool * access_control
 }
 
 static void
-read_conf_cache (int cid, bool * acl_flag, bool * access_control_default_policy, int *num_broker, int *br_shm_id,
-		 char *logfile, T_BROKER_INFO * br_info)
+read_conf_cache (int cid, bool * acl_flag, bool * acl_default_policy, int *num_broker, int *br_shm_id, char *logfile,
+		 T_BROKER_INFO * br_info)
 {
   if (cid < 0 || cid >= MAX_NUM_CACHED_BROKER_FILES || br_shm_id == NULL || br_info == NULL)
     {
@@ -1447,9 +1447,9 @@ read_conf_cache (int cid, bool * acl_flag, bool * access_control_default_policy,
       *acl_flag = br_conf_info[cid].acl_flag;
     }
 
-  if (access_control_default_policy)
+  if (acl_default_policy)
     {
-      *access_control_default_policy = br_conf_info[cid].acl_flag;
+      *acl_default_policy = br_conf_info[cid].acl_flag;
     }
 
   if (logfile && br_conf_info[cid].admin_log_file)
@@ -1497,13 +1497,13 @@ clear_conf_cache_entry (int cid)
  *   admin_flag(in):
  *   acl_flag(out):
  *   acl_file(out):
- *   access_control_default_policy(out):
+ *   acl_default_policy(out):
  *   admin_err_msg(in):
  */
 int
 broker_config_read (const char *conf_file, T_BROKER_INFO * br_info, int *num_broker, int *br_shm_id,
-		    char *admin_log_file, char admin_flag, bool * acl_flag, char *acl_file,
-		    bool * access_control_default_policy, char *admin_err_msg)
+		    char *admin_log_file, char admin_flag, bool * acl_flag, char *acl_file, bool * acl_default_policy,
+		    char *admin_err_msg)
 {
   int err = 0;
   char file_name[BROKER_PATH_MAX], file_being_dealt_with[BROKER_PATH_MAX];
@@ -1554,8 +1554,7 @@ broker_config_read (const char *conf_file, T_BROKER_INFO * br_info, int *num_bro
 	{
 	  if (br_conf_info[cid].last_modified == stat_buf.st_mtime)
 	    {
-	      read_conf_cache (cid, acl_flag, access_control_default_policy, num_broker, br_shm_id, admin_log_file,
-			       br_info);
+	      read_conf_cache (cid, acl_flag, acl_default_policy, num_broker, br_shm_id, admin_log_file, br_info);
 
 	      return 0;
 	    }
@@ -1570,11 +1569,11 @@ broker_config_read (const char *conf_file, T_BROKER_INFO * br_info, int *num_bro
   memset (br_info, 0, sizeof (T_BROKER_INFO) * MAX_BROKER_NUM);
   err =
     broker_config_read_internal (file_being_dealt_with, br_info, num_broker, br_shm_id, admin_log_file, admin_flag,
-				 acl_flag, acl_file, access_control_default_policy, admin_err_msg);
+				 acl_flag, acl_file, acl_default_policy, admin_err_msg);
   if (err == 0)
     {
-      write_conf_cache (file_being_dealt_with, acl_flag, access_control_default_policy, num_broker, br_shm_id,
-			admin_log_file, br_info, stat_buf.st_mtime);
+      write_conf_cache (file_being_dealt_with, acl_flag, acl_default_policy, num_broker, br_shm_id, admin_log_file,
+			br_info, stat_buf.st_mtime);
     }
 
   return err;

--- a/src/broker/broker_config.c
+++ b/src/broker/broker_config.c
@@ -140,12 +140,6 @@ static T_CONF_TABLE tbl_on_off[] = {
   {NULL, 0}
 };
 
-// static T_CONF_TABLE tbl_allow_deny[] = {
-//   {"ALLOW", ALLOW},
-//   {"DENY", DENY},
-//   {NULL, 0}
-// };
-
 static T_CONF_TABLE tbl_sql_log_mode[] = {
   {"ALL", SQL_LOG_MODE_ALL},
   {"ON", SQL_LOG_MODE_ALL},

--- a/src/broker/broker_config.c
+++ b/src/broker/broker_config.c
@@ -101,6 +101,7 @@ struct br_conf_info
 {
   int num_broker;
   int acl_flag;
+  int acl_broker_allow;
   int br_shm_id;
   char *conf_file;
   char *admin_log_file;
@@ -119,9 +120,10 @@ static void conf_file_has_been_loaded (const char *conf_path);
 static int check_port_number (T_BROKER_INFO * br_info, int num_brs);
 static int get_conf_value (const char *string, T_CONF_TABLE * conf_table);
 static const char *get_conf_string (int value, T_CONF_TABLE * conf_table);
-static void read_conf_cache (int cid, bool * acl, int *num_br, int *shm_id, char *log_file, T_BROKER_INFO * br_info);
-static void write_conf_cache (char *file, bool * acl_flag, int *num_broker, int *shm_id, char *alog,
-			      T_BROKER_INFO * br_info, time_t bf_mtime);
+static void read_conf_cache (int cid, bool * acl, bool * acl_broker_allow, int *num_br, int *shm_id, char *log_file,
+			     T_BROKER_INFO * br_info);
+static void write_conf_cache (char *file, bool * acl_flag, bool * acl_broker_allow, int *num_broker, int *shm_id,
+			      char *alog, T_BROKER_INFO * br_info, time_t bf_mtime);
 static void clear_conf_cache_entry (int cid);
 static bool is_invalid_buf_size (int size);
 
@@ -448,8 +450,8 @@ get_conf_string (int value, T_CONF_TABLE * conf_table)
  */
 static int
 broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int *num_broker, int *br_shm_id,
-			     char *admin_log_file, char admin_flag, bool * acl_flag, char *acl_file, bool * acl_broker_allow,
-			     char *admin_err_msg)
+			     char *admin_log_file, char admin_flag, bool * acl_flag, char *acl_file,
+			     bool * acl_broker_allow, char *admin_err_msg)
 {
 #if defined (_UC_ADMIN_SO_)
 #define PRINTERROR(...)	sprintf(admin_err_msg, __VA_ARGS__)
@@ -595,15 +597,15 @@ broker_config_read_internal (const char *conf_file, T_BROKER_INFO * br_info, int
 
   if (acl_broker_allow != NULL)
     {
-      INI_GETSTR_CHK (s, ini, SECTION_NAME, "ACCESS_CONTROL_DEFAULT", "OFF", &lineno);
-      tmp_int = conf_get_value_table_on_off (s);
+      INI_GETSTR_CHK (s, ini, SECTION_NAME, "ACCESS_CONTROL_DEFAULT", "DENY", &lineno);
+      tmp_int = conf_get_value_table_allow_deny (s);
       if (tmp_int < 0)
 	{
 	  errcode = PARAM_BAD_RANGE;
 	  goto conf_error;
 	}
       *acl_broker_allow = tmp_int;
-    }  
+    }
 
   for (i = 0; i < ini->nsec; i++)
     {
@@ -1393,8 +1395,8 @@ conf_error:
 }
 
 static void
-write_conf_cache (char *broker_conf_file, bool * acl_flag, int *num_broker, int *br_shm_id, char *admin_logfile,
-		  T_BROKER_INFO * br_info, time_t br_conf_mtime)
+write_conf_cache (char *broker_conf_file, bool * acl_flag, bool * acl_broker_allow, int *num_broker, int *br_shm_id,
+		  char *admin_logfile, T_BROKER_INFO * br_info, time_t br_conf_mtime)
 {
   if (broker_conf_file == NULL || num_broker == NULL || br_info == NULL || br_shm_id == NULL)
     {
@@ -1415,6 +1417,11 @@ write_conf_cache (char *broker_conf_file, bool * acl_flag, int *num_broker, int 
 	      br_conf_info[i].acl_flag = *acl_flag;
 	    }
 
+	  if (acl_broker_allow)
+	    {
+	      br_conf_info[i].acl_broker_allow = *acl_broker_allow;
+	    }
+
 	  if (admin_logfile)
 	    {
 	      br_conf_info[i].admin_log_file = strdup (admin_logfile);
@@ -1427,7 +1434,8 @@ write_conf_cache (char *broker_conf_file, bool * acl_flag, int *num_broker, int 
 }
 
 static void
-read_conf_cache (int cid, bool * acl_flag, int *num_broker, int *br_shm_id, char *logfile, T_BROKER_INFO * br_info)
+read_conf_cache (int cid, bool * acl_flag, bool * acl_broker_allow, int *num_broker, int *br_shm_id, char *logfile,
+		 T_BROKER_INFO * br_info)
 {
   if (cid < 0 || cid >= MAX_NUM_CACHED_BROKER_FILES || br_shm_id == NULL || br_info == NULL)
     {
@@ -1437,6 +1445,11 @@ read_conf_cache (int cid, bool * acl_flag, int *num_broker, int *br_shm_id, char
   if (acl_flag)
     {
       *acl_flag = br_conf_info[cid].acl_flag;
+    }
+
+  if (acl_broker_allow)
+    {
+      *acl_broker_allow = br_conf_info[cid].acl_flag;
     }
 
   if (logfile && br_conf_info[cid].admin_log_file)
@@ -1489,7 +1502,8 @@ clear_conf_cache_entry (int cid)
  */
 int
 broker_config_read (const char *conf_file, T_BROKER_INFO * br_info, int *num_broker, int *br_shm_id,
-		    char *admin_log_file, char admin_flag, bool * acl_flag, char *acl_file, bool *acl_broker_allow, char *admin_err_msg)
+		    char *admin_log_file, char admin_flag, bool * acl_flag, char *acl_file, bool * acl_broker_allow,
+		    char *admin_err_msg)
 {
   int err = 0;
   char file_name[BROKER_PATH_MAX], file_being_dealt_with[BROKER_PATH_MAX];
@@ -1540,7 +1554,7 @@ broker_config_read (const char *conf_file, T_BROKER_INFO * br_info, int *num_bro
 	{
 	  if (br_conf_info[cid].last_modified == stat_buf.st_mtime)
 	    {
-	      read_conf_cache (cid, acl_flag, num_broker, br_shm_id, admin_log_file, br_info);
+	      read_conf_cache (cid, acl_flag, acl_broker_allow, num_broker, br_shm_id, admin_log_file, br_info);
 
 	      return 0;
 	    }
@@ -1558,8 +1572,8 @@ broker_config_read (const char *conf_file, T_BROKER_INFO * br_info, int *num_bro
 				 acl_flag, acl_file, acl_broker_allow, admin_err_msg);
   if (err == 0)
     {
-      write_conf_cache (file_being_dealt_with, acl_flag, num_broker, br_shm_id, admin_log_file, br_info,
-			stat_buf.st_mtime);
+      write_conf_cache (file_being_dealt_with, acl_flag, acl_broker_allow, num_broker, br_shm_id, admin_log_file,
+			br_info, stat_buf.st_mtime);
     }
 
   return err;

--- a/src/broker/broker_config.h
+++ b/src/broker/broker_config.h
@@ -309,18 +309,15 @@ struct t_broker_info
   char cgw_link_server_port[CGW_LINK_SERVER_PORT_LEN];
   char cgw_link_odbc_driver_name[CGW_LINK_ODBC_DRIVER_NAME_LEN];
   char cgw_link_connect_url_property[CGW_LINK_CONNECT_URL_PROPERTY_LEN];
-
-  char acl_broker_allow;
 };
 
 extern int broker_config_read (const char *conf_file, T_BROKER_INFO * br_info, int *num_broker, int *br_shm_id,
 			       char *admin_log_file, char admin_flag, bool * acl_flag, char *acl_file,
-			       char *admin_err_msg);
+			       bool * acl_broker_allow, char *admin_err_msg);
 extern void broker_config_dump (FILE * fp, const T_BROKER_INFO * br_info, int num_broker, int br_shm_id,
 				char *admin_log_file);
 
 extern int conf_get_value_table_on_off (const char *value);
-extern int conf_get_value_table_allow_deny (const char *value);
 extern int conf_get_value_sql_log_mode (const char *value);
 extern int conf_get_value_keep_con (const char *value);
 extern int conf_get_value_access_mode (const char *value);

--- a/src/broker/broker_config.h
+++ b/src/broker/broker_config.h
@@ -318,6 +318,7 @@ extern void broker_config_dump (FILE * fp, const T_BROKER_INFO * br_info, int nu
 				char *admin_log_file);
 
 extern int conf_get_value_table_on_off (const char *value);
+extern int conf_get_value_table_allow_deny (const char *value);
 extern int conf_get_value_sql_log_mode (const char *value);
 extern int conf_get_value_keep_con (const char *value);
 extern int conf_get_value_access_mode (const char *value);

--- a/src/broker/broker_config.h
+++ b/src/broker/broker_config.h
@@ -313,7 +313,7 @@ struct t_broker_info
 
 extern int broker_config_read (const char *conf_file, T_BROKER_INFO * br_info, int *num_broker, int *br_shm_id,
 			       char *admin_log_file, char admin_flag, bool * acl_flag, char *acl_file,
-			       bool * acl_broker_allow, char *admin_err_msg);
+			       bool * access_control_default_policy, char *admin_err_msg);
 extern void broker_config_dump (FILE * fp, const T_BROKER_INFO * br_info, int num_broker, int br_shm_id,
 				char *admin_log_file);
 

--- a/src/broker/broker_config.h
+++ b/src/broker/broker_config.h
@@ -313,7 +313,7 @@ struct t_broker_info
 
 extern int broker_config_read (const char *conf_file, T_BROKER_INFO * br_info, int *num_broker, int *br_shm_id,
 			       char *admin_log_file, char admin_flag, bool * acl_flag, char *acl_file,
-			       bool * access_control_default_policy, char *admin_err_msg);
+			       bool * acl_default_policy, char *admin_err_msg);
 extern void broker_config_dump (FILE * fp, const T_BROKER_INFO * br_info, int num_broker, int br_shm_id,
 				char *admin_log_file);
 

--- a/src/broker/broker_monitor.c
+++ b/src/broker/broker_monitor.c
@@ -501,7 +501,7 @@ main (int argc, char **argv)
       return 3;
     }
 
-  err = broker_config_read (NULL, br_info, &num_broker, &master_shm_id, NULL, 0, NULL, NULL, NULL);
+  err = broker_config_read (NULL, br_info, &num_broker, &master_shm_id, NULL, 0, NULL, NULL, NULL, NULL);
   if (err < 0)
     {
       return 2;

--- a/src/broker/broker_shm.c
+++ b/src/broker/broker_shm.c
@@ -417,7 +417,7 @@ uw_shm_destroy (int shm_key)
 
 T_SHM_BROKER *
 broker_shm_initialize_shm_broker (int master_shm_id, T_BROKER_INFO * br_info, int br_num, int acl_flag, char *acl_file,
-				  int acl_broker_allow, char *admin_log_file)
+				  int access_control_default_policy, char *admin_log_file)
 {
   int i, shm_size;
   T_SHM_BROKER *shm_br = NULL;
@@ -449,7 +449,7 @@ broker_shm_initialize_shm_broker (int master_shm_id, T_BROKER_INFO * br_info, in
 
   shm_br->num_broker = br_num;
   shm_br->access_control = acl_flag;
-  shm_br->acl_broker_allow = acl_broker_allow;
+  shm_br->access_control_default_policy = access_control_default_policy;
 
   if (admin_log_file != NULL)
     {

--- a/src/broker/broker_shm.c
+++ b/src/broker/broker_shm.c
@@ -417,7 +417,7 @@ uw_shm_destroy (int shm_key)
 
 T_SHM_BROKER *
 broker_shm_initialize_shm_broker (int master_shm_id, T_BROKER_INFO * br_info, int br_num, int acl_flag, char *acl_file,
-				  char *admin_log_file)
+				  int acl_broker_allow, char *admin_log_file)
 {
   int i, shm_size;
   T_SHM_BROKER *shm_br = NULL;
@@ -449,6 +449,7 @@ broker_shm_initialize_shm_broker (int master_shm_id, T_BROKER_INFO * br_info, in
 
   shm_br->num_broker = br_num;
   shm_br->access_control = acl_flag;
+  shm_br->acl_broker_allow = acl_broker_allow;
 
   if (admin_log_file != NULL)
     {
@@ -572,8 +573,6 @@ broker_shm_initialize_shm_as (T_BROKER_INFO * br_info_p, T_SHM_PROXY * shm_proxy
   strcpy (shm_as_p->cgw_link_odbc_driver_name, br_info_p->cgw_link_odbc_driver_name);
   strcpy (shm_as_p->cgw_link_connect_url_property, br_info_p->cgw_link_connect_url_property);
 #endif
-
-  shm_as_p->acl_broker_allow = br_info_p->acl_broker_allow;
 
   if (shm_as_p->shard_flag == OFF)
     {

--- a/src/broker/broker_shm.c
+++ b/src/broker/broker_shm.c
@@ -417,7 +417,7 @@ uw_shm_destroy (int shm_key)
 
 T_SHM_BROKER *
 broker_shm_initialize_shm_broker (int master_shm_id, T_BROKER_INFO * br_info, int br_num, int acl_flag, char *acl_file,
-				  int access_control_default_policy, char *admin_log_file)
+				  int acl_default_policy, char *admin_log_file)
 {
   int i, shm_size;
   T_SHM_BROKER *shm_br = NULL;
@@ -449,7 +449,7 @@ broker_shm_initialize_shm_broker (int master_shm_id, T_BROKER_INFO * br_info, in
 
   shm_br->num_broker = br_num;
   shm_br->access_control = acl_flag;
-  shm_br->access_control_default_policy = access_control_default_policy;
+  shm_br->acl_default_policy = acl_default_policy;
 
   if (admin_log_file != NULL)
     {

--- a/src/broker/broker_shm.h
+++ b/src/broker/broker_shm.h
@@ -572,7 +572,7 @@ struct t_shm_appl_server
   char cci_default_autocommit;
   char shard_flag;
   bool access_control;
-  bool access_control_default_policy;
+  bool acl_default_policy;
   int jdbc_cache_life_time;
   int connect_order;
   int replica_only_flag;
@@ -667,7 +667,7 @@ struct t_shm_broker
   char admin_log_file[SHM_BROKER_PATH_MAX];
   char access_control_file[SHM_BROKER_PATH_MAX];
   bool access_control;
-  bool access_control_default_policy;	/* Determines whether to allow or deny access to brokers that are not set in access_control_file. */
+  bool acl_default_policy;	/* Determines whether to allow or deny access to brokers that are not set in access_control_file. */
   T_BROKER_INFO br_info[1];
 };
 
@@ -698,8 +698,7 @@ int uw_sem_post (sem_t * sem_t);
 int uw_sem_destroy (sem_t * sem_t);
 #endif
 T_SHM_BROKER *broker_shm_initialize_shm_broker (int master_shm_id, T_BROKER_INFO * br_info, int br_num, int acl_flag,
-						char *acl_file, int access_control_default_policy,
-						char *admin_log_file);
+						char *acl_file, int acl_default_policy, char *admin_log_file);
 T_SHM_APPL_SERVER *broker_shm_initialize_shm_as (T_BROKER_INFO * br_info_p, T_SHM_PROXY * shm_proxy_p);
 
 #endif /* _BROKER_SHM_H_ */

--- a/src/broker/broker_shm.h
+++ b/src/broker/broker_shm.h
@@ -572,7 +572,7 @@ struct t_shm_appl_server
   char cci_default_autocommit;
   char shard_flag;
   bool access_control;
-  bool acl_broker_allow;
+  bool access_control_default_policy;
   int jdbc_cache_life_time;
   int connect_order;
   int replica_only_flag;
@@ -667,7 +667,7 @@ struct t_shm_broker
   char admin_log_file[SHM_BROKER_PATH_MAX];
   char access_control_file[SHM_BROKER_PATH_MAX];
   bool access_control;
-  bool acl_broker_allow;	/* Determines whether to allow or deny access to brokers that are not set in access_control_file. */
+  bool access_control_default_policy;	/* Determines whether to allow or deny access to brokers that are not set in access_control_file. */
   T_BROKER_INFO br_info[1];
 };
 
@@ -698,7 +698,8 @@ int uw_sem_post (sem_t * sem_t);
 int uw_sem_destroy (sem_t * sem_t);
 #endif
 T_SHM_BROKER *broker_shm_initialize_shm_broker (int master_shm_id, T_BROKER_INFO * br_info, int br_num, int acl_flag,
-						char *acl_file, int acl_broker_allow, char *admin_log_file);
+						char *acl_file, int access_control_default_policy,
+						char *admin_log_file);
 T_SHM_APPL_SERVER *broker_shm_initialize_shm_as (T_BROKER_INFO * br_info_p, T_SHM_PROXY * shm_proxy_p);
 
 #endif /* _BROKER_SHM_H_ */

--- a/src/broker/broker_shm.h
+++ b/src/broker/broker_shm.h
@@ -572,6 +572,7 @@ struct t_shm_appl_server
   char cci_default_autocommit;
   char shard_flag;
   bool access_control;
+  bool acl_broker_allow;
   int jdbc_cache_life_time;
   int connect_order;
   int replica_only_flag;
@@ -639,8 +640,6 @@ struct t_shm_appl_server
   char cgw_link_odbc_driver_name[CGW_LINK_ODBC_DRIVER_NAME_LEN];
   char cgw_link_connect_url_property[CGW_LINK_CONNECT_URL_PROPERTY_LEN];
 
-  char acl_broker_allow;
-
   ACCESS_INFO access_info[ACL_MAX_ITEM_COUNT];
 
   T_MAX_HEAP_NODE job_queue[JOB_QUEUE_MAX_SIZE + 1];
@@ -668,6 +667,7 @@ struct t_shm_broker
   char admin_log_file[SHM_BROKER_PATH_MAX];
   char access_control_file[SHM_BROKER_PATH_MAX];
   bool access_control;
+  bool acl_broker_allow;	/* Determines whether to allow or deny access to brokers that are not set in access_control_file. */
   T_BROKER_INFO br_info[1];
 };
 
@@ -698,7 +698,7 @@ int uw_sem_post (sem_t * sem_t);
 int uw_sem_destroy (sem_t * sem_t);
 #endif
 T_SHM_BROKER *broker_shm_initialize_shm_broker (int master_shm_id, T_BROKER_INFO * br_info, int br_num, int acl_flag,
-						char *acl_file, char *admin_log_file);
+						char *acl_file, int acl_broker_allow, char *admin_log_file);
 T_SHM_APPL_SERVER *broker_shm_initialize_shm_as (T_BROKER_INFO * br_info_p, T_SHM_PROXY * shm_proxy_p);
 
 #endif /* _BROKER_SHM_H_ */

--- a/src/broker/cas_common.h
+++ b/src/broker/cas_common.h
@@ -46,6 +46,9 @@
 #define ON	1
 #define OFF	0
 
+#define ALLOW	1
+#define DENY	0
+
 #define TRUE	1
 #define FALSE	0
 

--- a/src/broker/cas_common.h
+++ b/src/broker/cas_common.h
@@ -46,9 +46,6 @@
 #define ON	1
 #define OFF	0
 
-#define ALLOW	1
-#define DENY	0
-
 #define TRUE	1
 #define FALSE	0
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25503

브로커 서버 접속 제한을 설정할때 ACCESS_CONTROL_FILE 에 설정한 파일에 broker 별로 설정을 하도록 되어 있다.
ACCESS_CONTROL_FILE 에 broker가 설정 되어 있지 않은 경우, 현재는 모두 접속을 허용하지 않는다.
추가된 스펙은 broker 섹션에 ACCESS_CONTROL_DEFAULT_POLICY를 ALLOW 으로 설정하는 경우  ACCESS_CONTROL_FILE 설정되지 않은 broker에 대해서 접속을 허용한다. Default는 DENY이다.