### PR TITLE
[CBRD-25732] Create pl_session if it is empty when setting PL_CONTEXT system parameter

### DIFF
--- a/src/session/session.c
+++ b/src/session/session.c
@@ -3109,7 +3109,19 @@ session_set_pl_session_parameter (THREAD_ENTRY * thread_p, PARAM_ID id)
       return ER_FAILED;
     }
 
-  if (state_p->pl_session_p != NULL)
+// *INDENT-OFF*
+  cubpl::session *s = NULL;
+// *INDENT-ON*
+  if (state_p->pl_session_p == NULL)
+    {
+      session_get_pl_session (thread_p, s);
+    }
+  else
+    {
+      s = state_p->pl_session_p;
+    }
+
+  if (s != NULL)
     {
       state_p->pl_session_p->mark_session_param_changed (id);
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25732

### Purpose

PL_CONTEXT 시스템 파라미터를 설정할 때, pl_session이 만들어지지 않은 경우, 파라미터 변경이 무시되는 현상

### Implementation

pl_session을 생성하도록 수정

### Remarks

N/A
