### PR TITLE
[CBRD-25175] remove line and column from PL/CSQL compile error messages

### DIFF
--- a/msg/en_US.utf8/cubrid.msg
+++ b/msg/en_US.utf8/cubrid.msg
@@ -1447,7 +1447,7 @@ Check the path of the key file (_keys) and make sure that it includes proper key
 1358 Number of rows affected is unknown.
 
 1359 PL server crashed: %1$s
-1360 In line %1$d, column %2$d\nStored procedure compile error: %3$s
+1360 Stored procedure compile error: %1$s
 
 1361 Invalid result cache for subquery.
 

--- a/msg/ko_KR.utf8/cubrid.msg
+++ b/msg/ko_KR.utf8/cubrid.msg
@@ -1447,7 +1447,7 @@ $ LOADDB
 1358 영향을 받은 행 수를 알 수 없음.
 
 1359 PL 서버에 장애가 발생함. : %1$s
-1360 In line %1$d, column %2$d\nStored procedure compile error: %3$s
+1360 Stored procedure compile error: %1$s
 
 1361 부질의 캐시가 잘못되었습니다.
 1362 언어 '%1$s'에 대한 로캘은 사용 가능하지 않습니다.

--- a/src/sp/jsp_cl.cpp
+++ b/src/sp/jsp_cl.cpp
@@ -1138,8 +1138,7 @@ jsp_create_stored_procedure (PARSER_CONTEXT *parser, PT_NODE *statement)
       else
 	{
 	  err = ER_SP_COMPILE_ERROR;
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_COMPILE_ERROR, 3, compile_response.err_line,
-		  compile_response.err_column, compile_response.err_msg.c_str ());
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_COMPILE_ERROR, 1, compile_response.err_msg.c_str ());
 	  pt_record_error (parser, parser->statement_number, compile_response.err_line, compile_response.err_column, er_msg (),
 			   NULL);
 	  goto error_exit;
@@ -1810,8 +1809,7 @@ alter_stored_procedure_code (PARSER_CONTEXT *parser, MOP sp_mop, const char *nam
       else
 	{
 	  err = ER_SP_COMPILE_ERROR;
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_COMPILE_ERROR, 3, compile_response.err_line,
-		  compile_response.err_column, compile_response.err_msg.c_str ());
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_COMPILE_ERROR, 1, compile_response.err_msg.c_str ());
 	  pt_record_error (parser, parser->statement_number, compile_response.err_line, compile_response.err_column, er_msg (),
 			   NULL);
 	  goto error;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-25175>

CSQL에서 보여주는 line, column 정보와 중복되므로
Stored procedure compile error 메시지에서 line column 정보를 삭제합니다. 

478 건의 SQL 테스트 답지 수정이 필요합니다. (TC PR: https://github.com/CUBRID/cubrid-testcases/pull/2159)
