### PR TITLE
[CBRD-25979] au_change_class_owner_including_partitions 함수에서 db_private_strdup 함수 실패 시, AU_ENABLE 누락

### DIFF
--- a/src/object/authenticate_access_class.cpp
+++ b/src/object/authenticate_access_class.cpp
@@ -163,7 +163,7 @@ au_change_class_owner_including_partitions (MOP class_mop, MOP owner_mop)
   if (class_new_name == NULL)
     {
       ASSERT_ERROR_AND_SET (error);
-      return error;
+      goto end;
     }
 
   obj = locator_prepare_rename_class (class_mop, class_old_name, class_new_name);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25979

### Purpose

방어 코드 차원에서 AU_ENABLE로 가도록 처리

### Implementation

return 문을 기존에 AU_ENABLE 부분을 처리하는 goto 문으로 수정

### Remarks

N/A
