### PR TITLE
[CBRD-25922] rev: DBLink Auto-commit OFF Handling

### DIFF
--- a/src/connection/connection_defs.h
+++ b/src/connection/connection_defs.h
@@ -419,21 +419,6 @@ struct css_queue_entry
 struct session_state;
 #endif
 
-#define MAX_LEN_CONNECTION_URL 512
-/*
- * This data structure is the connection interface for dblink
- */
-typedef struct dblink_conn_entry DBLINK_CONN_ENTRY;
-struct dblink_conn_entry
-{
-  int conn_handle;
-  char conn_url[MAX_LEN_CONNECTION_URL + 1];
-  char user_name[DB_MAX_USER_LENGTH + 1];
-  char password[DB_MAX_PASSWORD_LENGTH + 1];
-
-  DBLINK_CONN_ENTRY *next;
-};
-
 /*
  * This data structure is the interface between the client and the
  * communication software to identify the data connection.

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -581,51 +581,6 @@ dblink_end_tran (DBLINK_CONN_ENTRY * dblink, bool is_abort)
   return (tran_error == NO_ERROR) ? rc : tran_error;
 }
 
-static int
-dblink_find_conn_handle (char *conn_url, char *user_name, char *password)
-{
-  THREAD_ENTRY *thread_p = thread_get_thread_entry_info ();
-  DBLINK_CONN_ENTRY *dblink = thread_p->dblink_entry;
-
-  while (dblink)
-    {
-      if (!strcmp (dblink->conn_url, conn_url) && !strcmp (dblink->user_name, user_name)
-	  && !strcmp (dblink->password, password))
-	{
-	  return dblink->conn_handle;
-	}
-
-      dblink = dblink->next;
-    }
-
-  return -1;
-}
-
-static int
-dblink_add_conn_handle (int conn_handle, char *conn_url, char *user_name, char *password)
-{
-  THREAD_ENTRY *thread_p = thread_get_thread_entry_info ();
-  DBLINK_CONN_ENTRY *dblink_conn_entry;
-
-  dblink_conn_entry = (DBLINK_CONN_ENTRY *) malloc (sizeof (DBLINK_CONN_ENTRY));
-  if (dblink_conn_entry == NULL)
-    {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (DBLINK_CONN_ENTRY));
-      return ER_OUT_OF_VIRTUAL_MEMORY;
-    }
-
-  dblink_conn_entry->conn_handle = conn_handle;
-
-  strcpy (dblink_conn_entry->conn_url, conn_url);
-  strcpy (dblink_conn_entry->user_name, user_name);
-  strcpy (dblink_conn_entry->password, password);
-
-  dblink_conn_entry->next = thread_p->dblink_entry;
-  thread_p->dblink_entry = dblink_conn_entry;
-
-  return NO_ERROR;
-}
-
 int
 dblink_execute_query (THREAD_ENTRY * thread_p, struct access_spec_node *spec, VAL_DESCR * vd,
 		      DBLINK_HOST_VARS * host_vars)

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -24,6 +24,7 @@
 // dblink connection handling for distributed transaction
 #include "connection_defs.h"
 #include "thread_manager.hpp"
+#include "query_manager.h"
 #include "dblink_scan.h"
 
 #include "xasl.h"
@@ -626,7 +627,8 @@ dblink_add_conn_handle (int conn_handle, char *conn_url, char *user_name, char *
 }
 
 int
-dblink_execute_query (struct access_spec_node *spec, VAL_DESCR * vd, DBLINK_HOST_VARS * host_vars)
+dblink_execute_query (THREAD_ENTRY * thread_p, struct access_spec_node *spec, VAL_DESCR * vd,
+		      DBLINK_HOST_VARS * host_vars)
 {
   static bool auto_commit = prm_get_bool_value (PRM_ID_DBLINK_AUTO_COMMIT);
   int ret = NO_ERROR, result, conn_handle, stmt_handle;
@@ -637,6 +639,7 @@ dblink_execute_query (struct access_spec_node *spec, VAL_DESCR * vd, DBLINK_HOST
   char *sql_text = spec->s.dblink_node.conn_sql;
 
   char *find = strstr (spec->s.dblink_node.conn_url, ":?");
+
   if (find)
     {
       snprintf (conn_url, MAX_LEN_CONNECTION_URL, "%s%s", spec->s.dblink_node.conn_url, "&__gateway=true");
@@ -650,7 +653,7 @@ dblink_execute_query (struct access_spec_node *spec, VAL_DESCR * vd, DBLINK_HOST
 
   if (!auto_commit)
     {
-      conn_handle = dblink_find_conn_handle (spec->s.dblink_node.conn_url, user_name, password);
+      conn_handle = qmgr_dblink_find_conn_handle (thread_p, spec->s.dblink_node.conn_url, user_name, password);
     }
 
   if (conn_handle < 0)
@@ -671,7 +674,7 @@ dblink_execute_query (struct access_spec_node *spec, VAL_DESCR * vd, DBLINK_HOST
 
       if (!auto_commit)
 	{
-	  ret = dblink_add_conn_handle (conn_handle, spec->s.dblink_node.conn_url, user_name, password);
+	  ret = qmgr_dblink_add_conn_handle (thread_p, conn_handle, spec->s.dblink_node.conn_url, user_name, password);
 	  if (ret < 0)
 	    {
 	      /* malloc error */
@@ -733,7 +736,7 @@ error_exit:
  *   sql_text(in)	 : SQL text for dblink
  */
 int
-dblink_open_scan (DBLINK_SCAN_INFO * scan_info, struct access_spec_node *spec,
+dblink_open_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_INFO * scan_info, struct access_spec_node *spec,
 		  VAL_DESCR * vd, DBLINK_HOST_VARS * host_vars)
 {
   static bool auto_commit = prm_get_bool_value (PRM_ID_DBLINK_AUTO_COMMIT);
@@ -759,7 +762,8 @@ dblink_open_scan (DBLINK_SCAN_INFO * scan_info, struct access_spec_node *spec,
 
   if (!auto_commit)
     {
-      scan_info->conn_handle = dblink_find_conn_handle (spec->s.dblink_node.conn_url, user_name, password);
+      scan_info->conn_handle =
+	qmgr_dblink_find_conn_handle (thread_p, spec->s.dblink_node.conn_url, user_name, password);
     }
 
   if (scan_info->conn_handle < 0)
@@ -780,7 +784,9 @@ dblink_open_scan (DBLINK_SCAN_INFO * scan_info, struct access_spec_node *spec,
 
       if (!auto_commit)
 	{
-	  ret = dblink_add_conn_handle (scan_info->conn_handle, spec->s.dblink_node.conn_url, user_name, password);
+	  ret =
+	    qmgr_dblink_add_conn_handle (thread_p, scan_info->conn_handle, spec->s.dblink_node.conn_url, user_name,
+					 password);
 	  if (ret < 0)
 	    {
 	      return ER_DBLINK;

--- a/src/query/dblink_scan.h
+++ b/src/query/dblink_scan.h
@@ -60,9 +60,26 @@ struct dblink_scan_info
   void *col_info;		/* column information T_CCI_COL_INFO */
 };
 
+#define MAX_LEN_CONNECTION_URL 512
+
+/*
+ * This data structure is the connection interface for dblink
+ */
+typedef struct dblink_conn_entry DBLINK_CONN_ENTRY;
+struct dblink_conn_entry
+{
+  int conn_handle;
+  char conn_url[MAX_LEN_CONNECTION_URL + 1];
+  char user_name[DB_MAX_USER_LENGTH + 1];
+  char password[DB_MAX_PASSWORD_LENGTH + 1];
+
+  DBLINK_CONN_ENTRY *next;
+};
+
 extern int dblink_end_tran (DBLINK_CONN_ENTRY * dblink, bool is_abort);
-extern int dblink_execute_query (struct access_spec_node *spec, VAL_DESCR * vd, DBLINK_HOST_VARS * host_vars);
-extern int dblink_open_scan (DBLINK_SCAN_INFO * scan_info, struct access_spec_node *spec,
+extern int dblink_execute_query (THREAD_ENTRY * thread_p, struct access_spec_node *spec, VAL_DESCR * vd,
+				 DBLINK_HOST_VARS * host_vars);
+extern int dblink_open_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_INFO * scan_info, struct access_spec_node *spec,
 			     VAL_DESCR * vd, DBLINK_HOST_VARS * host_vars);
 extern int dblink_close_scan (DBLINK_SCAN_INFO * scan_info);
 extern SCAN_CODE dblink_scan_next (DBLINK_SCAN_INFO * scan_info, val_list_node * val_list);

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -16368,7 +16368,7 @@ qexec_check_limit_clause (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 }
 
 static int
-qexec_execute_dblink_query (XASL_NODE * xasl, XASL_STATE * xasl_state)
+qexec_execute_dblink_query (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_state)
 {
   int res;
   DBLINK_HOST_VARS host_vars;
@@ -16376,7 +16376,7 @@ qexec_execute_dblink_query (XASL_NODE * xasl, XASL_STATE * xasl_state)
   host_vars.count = xasl->spec_list->s.dblink_node.host_var_count;
   host_vars.index = xasl->spec_list->s.dblink_node.host_var_index;
 
-  res = dblink_execute_query (xasl->spec_list, &xasl_state->vd, &host_vars);
+  res = dblink_execute_query (thread_p, xasl->spec_list, &xasl_state->vd, &host_vars);
   if (res < 0)
     {
       return res;
@@ -16466,7 +16466,7 @@ qexec_execute_mainblock_internal (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
 
       if (xasl->spec_list && xasl->spec_list->type == TARGET_DBLINK)
 	{
-	  error = qexec_execute_dblink_query (xasl, xasl_state);
+	  error = qexec_execute_dblink_query (thread_p, xasl, xasl_state);
 	}
       else
 	{
@@ -16500,7 +16500,7 @@ qexec_execute_mainblock_internal (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
 
       if (xasl->spec_list && xasl->spec_list->type == TARGET_DBLINK)
 	{
-	  error = qexec_execute_dblink_query (xasl, xasl_state);
+	  error = qexec_execute_dblink_query (thread_p, xasl, xasl_state);
 	}
       else
 	{
@@ -16536,7 +16536,7 @@ qexec_execute_mainblock_internal (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
 
       if (xasl->spec_list && xasl->spec_list->type == TARGET_DBLINK)
 	{
-	  error = qexec_execute_dblink_query (xasl, xasl_state);
+	  error = qexec_execute_dblink_query (thread_p, xasl, xasl_state);
 	}
       else
 	{
@@ -16591,7 +16591,7 @@ qexec_execute_mainblock_internal (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
       /* execute merge */
       if (xasl->spec_list && xasl->spec_list->type == TARGET_DBLINK)
 	{
-	  error = qexec_execute_dblink_query (xasl, xasl_state);
+	  error = qexec_execute_dblink_query (thread_p, xasl, xasl_state);
 	}
       else
 	{

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -104,6 +104,8 @@ struct qmgr_tran_entry
   QMGR_QUERY_ENTRY *query_entry_list_p;	/* linked list of query entries */
   QMGR_QUERY_ENTRY *free_query_entry_list_p;	/* free query entry list */
 
+  DBLINK_CONN_ENTRY *dblink_entry;	/* for dblink tranaction */
+
   OID_BLOCK_LIST *modified_classes_p;	/* array of class OIDs */
   pthread_mutex_t mutex;
 };
@@ -2184,8 +2186,11 @@ qmgr_is_related_class_modified (THREAD_ENTRY * thread_p, XASL_CACHE_ENTRY * xasl
 QMGR_TRAN_STATUS
 qmgr_check_dblink_trans (THREAD_ENTRY * thread_p, bool is_abort)
 {
+  int tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
+  QMGR_TRAN_ENTRY *tran_entry_p = &qmgr_Query_table.tran_entries_p[tran_index];
+  int rc = dblink_end_tran (tran_entry_p->dblink_entry, is_abort);
+
   QMGR_TRAN_STATUS status = QMGR_TRAN_TERMINATED;
-  int rc = dblink_end_tran (thread_p->dblink_entry, is_abort);
 
   if (rc == ER_DBLINK_TRAN)
     {
@@ -2199,7 +2204,7 @@ qmgr_check_dblink_trans (THREAD_ENTRY * thread_p, bool is_abort)
       er_log_debug (ARG_FILE_LINE, "dblink transaction is completed with some errors !\n");
     }
 
-  thread_p->dblink_entry = NULL;
+  tran_entry_p->dblink_entry = NULL;
 
   return status;
 }
@@ -3690,4 +3695,53 @@ qmgr_get_query_sql_user_text (THREAD_ENTRY * thread_p, QUERY_ID query_id, int tr
     }
 
   return query_str;
+}
+
+int
+qmgr_dblink_find_conn_handle (THREAD_ENTRY * thread_p, char *conn_url, char *user_name, char *password)
+{
+  int tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
+  QMGR_TRAN_ENTRY *tran_entry_p = &qmgr_Query_table.tran_entries_p[tran_index];
+  DBLINK_CONN_ENTRY *dblink = tran_entry_p->dblink_entry;
+
+  while (dblink)
+    {
+      if (!strcmp (dblink->conn_url, conn_url) && !strcmp (dblink->user_name, user_name)
+	  && !strcmp (dblink->password, password))
+	{
+	  return dblink->conn_handle;
+	}
+
+      dblink = dblink->next;
+    }
+
+  return -1;
+}
+
+int
+qmgr_dblink_add_conn_handle (THREAD_ENTRY * thread_p, int conn_handle, char *conn_url, char *user_name, char *password)
+{
+  int tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
+  QMGR_TRAN_ENTRY *tran_entry_p = &qmgr_Query_table.tran_entries_p[tran_index];
+
+  DBLINK_CONN_ENTRY *dblink_conn_entry;
+
+  dblink_conn_entry = (DBLINK_CONN_ENTRY *) malloc (sizeof (DBLINK_CONN_ENTRY));
+  if (dblink_conn_entry == NULL)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (DBLINK_CONN_ENTRY));
+      return ER_OUT_OF_VIRTUAL_MEMORY;
+    }
+
+  dblink_conn_entry->conn_handle = conn_handle;
+
+  strcpy (dblink_conn_entry->conn_url, conn_url);
+  strcpy (dblink_conn_entry->user_name, user_name);
+  strcpy (dblink_conn_entry->password, password);
+
+  dblink_conn_entry->next = tran_entry_p->dblink_entry;
+
+  tran_entry_p->dblink_entry = dblink_conn_entry;
+
+  return NO_ERROR;
 }

--- a/src/query/query_manager.h
+++ b/src/query/query_manager.h
@@ -176,5 +176,8 @@ extern struct drand48_data *qmgr_get_rand_buf (THREAD_ENTRY * thread_p);
 extern QUERY_ID qmgr_get_current_query_id (THREAD_ENTRY * thread_p);
 extern char *qmgr_get_query_sql_user_text (THREAD_ENTRY * thread_p, QUERY_ID query_id, int tran_index);
 extern QMGR_TRAN_STATUS qmgr_check_dblink_trans (THREAD_ENTRY * thread_p, bool is_abort);
+extern int qmgr_dblink_find_conn_handle (THREAD_ENTRY * thread_p, char *conn_url, char *user_name, char *password);
+extern int qmgr_dblink_add_conn_handle (THREAD_ENTRY * thread_p, int conn_handle, char *conn_url, char *user_name,
+					char *password);
 
 #endif /* _QUERY_MANAGER_H_ */

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -4066,7 +4066,7 @@ scan_open_dblink_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
   scan_init_scan_pred (&dblid->scan_pred, NULL, spec->where_pred,
 		       ((spec->where_pred) ? eval_fnc (thread_p, spec->where_pred, &single_node_type) : NULL));
 
-  return dblink_open_scan (&scan_id->s.dblid.scan_info, spec, vd, host_vars);
+  return dblink_open_scan (thread_p, &scan_id->s.dblid.scan_info, spec, vd, host_vars);
 }
 
 /*

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -92,7 +92,6 @@ namespace cubthread
     , private_heap_id (0)
     , cnv_adj_buffer ()
     , conn_entry (NULL)
-    , dblink_entry (NULL)
     , xasl_unpack_info_ptr (NULL)
     , xasl_errcode (0)
     , xasl_recursion_depth (0)

--- a/src/thread/thread_entry.hpp
+++ b/src/thread/thread_entry.hpp
@@ -230,7 +230,6 @@ namespace cubthread
       adj_array *cnv_adj_buffer[3];	/* conversion buffer */
 
       css_conn_entry *conn_entry;	/* conn entry ptr */
-      dblink_conn_entry *dblink_entry;  /* conn entry ptr for dblink */
 
       xasl_unpack_info *xasl_unpack_info_ptr;     /* XASL_UNPACK_INFO * */
       int xasl_errcode;		/* xasl errorcode */

--- a/src/transaction/transaction_sr.c
+++ b/src/transaction/transaction_sr.c
@@ -80,20 +80,17 @@ xtran_server_commit (THREAD_ENTRY * thread_p, bool retain_lock)
 
   tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
 
-  if (thread_p->dblink_entry)
-    {
-      /* dblink transaction commit first */
-      QMGR_TRAN_STATUS dblink_tran = qmgr_check_dblink_trans (thread_p, false);
+  /* dblink transaction commit first */
+  QMGR_TRAN_STATUS dblink_tran = qmgr_check_dblink_trans (thread_p, false);
 
-      if (dblink_tran == QMGR_TRAN_DBLINK_ABORTED)
-	{
-	  /* transaction is aborted for dblink commit fail */
-	  state = log_abort (thread_p, tran_index);
+  if (dblink_tran == QMGR_TRAN_DBLINK_ABORTED)
+    {
+      /* transaction is aborted for dblink commit fail */
+      state = log_abort (thread_p, tran_index);
 #if defined(ENABLE_SYSTEMTAP)
-	  CUBRID_TRAN_ABORT (tran_index, TRAN_UNACTIVE_ABORTED_INFORMING_PARTICIPANTS);
+      CUBRID_TRAN_ABORT (tran_index, TRAN_UNACTIVE_ABORTED_INFORMING_PARTICIPANTS);
 #endif /* ENABLE_SYSTEMTAP */
-	  return TRAN_UNACTIVE_ABORTED_INFORMING_PARTICIPANTS;
-	}
+      return TRAN_UNACTIVE_ABORTED_INFORMING_PARTICIPANTS;
     }
 
   state = log_commit (thread_p, tran_index, retain_lock);
@@ -136,11 +133,8 @@ xtran_server_abort (THREAD_ENTRY * thread_p)
   /* Execute some few remaining actions before the log manager is notified of the commit */
   tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
 
-  if (thread_p->dblink_entry)
-    {
-      /* dblink transaction abort first */
-      (void) qmgr_check_dblink_trans (thread_p, true);
-    }
+  /* dblink transaction abort first */
+  (void) qmgr_check_dblink_trans (thread_p, true);
 
   state = log_abort (thread_p, tran_index);
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-25922>

#### Purpose
> DBLink의 분산 처리를 하기 위해, 원격 DML을 실행할 때 Auto-commit 모드를 선택적으로 OFF하도록 한다. Auto-commit 모드의 > ON/OFF는 시스템 파라미터를 추가하여 선택할 수 있도록 한다.

> 시스템 파라미터의 명칭은 "DBLINK_AUTO_COMMIT"으로 정의한다. bool 타입으로 ON/OFF를 설정한다.

이 PR에서 추가된 내용
- PL에서 commit을 할 때, PL 외부의 dblink 쿼리에 대해서도 commit을 할 수 있도록.

#### Implementation
> 시스템 파라미터를 추가

> dblkink_execute_query에서 DBLINK_AUTO_COMMIT 파라미터 값에 따라 cci_set_autocommit (conn_handle, CCI_AUTOCOMMIT_TRUE) 혹은 cci_set_autocommit (conn_handle, CCI_AUTOCOMMIT_FALSE) 호출

> dblink_end_tran 함수를 추가해서, xqmgr_end_query에서 DBLINK 쿼리를 체크하여 dblink_end_tran을 호출하는 로직 추가

이 PR에서 추가된 내용
AS-IS:
dblink_entry: thread에 저장
TO-BE:
dblink_entry: query_manager에 저장

#### Remarks
PL에서 commit할 때, PL 외부에서 실행됐던 dblink query가 commit 되는지 TC로 확인할 필요 있음.
