### PR TITLE
[CBRD-25981] bugfix: applied Java string escape twice. fixed to apply it just once.

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -63,7 +63,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import org.antlr.v4.runtime.*;
 import org.antlr.v4.runtime.tree.*;
-import org.apache.commons.text.StringEscapeUtils;
 
 // parse tree --> AST converter
 public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
@@ -3122,8 +3121,7 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
             }
         }
 
-        String rewritten = StringEscapeUtils.escapeJava(sws.rewritten);
-        return new StaticSql(ctx, sws.kind, rewritten, hostExprs, selectList, intoTargetList);
+        return new StaticSql(ctx, sws.kind, sws.rewritten, hostExprs, selectList, intoTargetList);
     }
 
     private static final Expr SP_PARAM_DEFAULT_VAL_DUMMY =

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -46,6 +46,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import org.antlr.v4.runtime.ParserRuleContext;
+import org.apache.commons.text.StringEscapeUtils;
 
 public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
 
@@ -445,7 +446,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 String.format(
                         "final Query %s = new Query(\"%s\"); // param-ref-counts: %s, param-num-of-host-expr: %s",
                         node.name,
-                        node.staticSql.rewritten,
+                        StringEscapeUtils.escapeJava(node.staticSql.rewritten),
                         Arrays.toString(node.paramRefCounts),
                         Arrays.toString(node.paramNumOfHostExpr));
         return new CodeTemplate("DeclCursor", Misc.UNKNOWN_LINE_COLUMN, code);
@@ -2488,7 +2489,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                     "%'REF-CURSOR'%",
                     node.id.javaCode(),
                     "%'QUERY'%",
-                    '"' + node.staticSql.rewritten + '"');
+                    '"' + StringEscapeUtils.escapeJava(node.staticSql.rewritten) + '"');
         } else {
 
             CodeTemplateList hostExprs = new CodeTemplateList();
@@ -2503,7 +2504,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                     "%'REF-CURSOR'%",
                     node.id.javaCode(),
                     "%'QUERY'%",
-                    '"' + node.staticSql.rewritten + '"',
+                    '"' + StringEscapeUtils.escapeJava(node.staticSql.rewritten) + '"',
                     "%'+HOST-EXPRS'%",
                     hostExprs.setDelimiter(","));
         }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-25981>

### Purpose

static sql 에 쌍따옴표가 포함되어 있는 경우 오동작 문제 수정

### Implementation

- static sql 의 텍스트에 Java 문자열 escape 가 두 번 적용되던 문제 있었음. 한번만 적용되도록 수정
- 기존에 한번만 적용되던 open for 문과 decl cursor 문에도 적용 갯수 변경되어 원래대로 한번 적용되도록 수정

