### PR TITLE
[CBRD-25834] Fix security issue exposing procedure source code to EXECUTE-only users

### DIFF
--- a/src/object/schema_system_catalog_install_query_spec.cpp
+++ b/src/object/schema_system_catalog_install_query_spec.cpp
@@ -1221,7 +1221,7 @@ sm_define_view_partition_spec (void)
 const char *
 sm_define_view_stored_procedure_spec (void)
 {
-  static char stmt [2048];
+  static char stmt [2500];
 
   // *INDENT-OFF*
   sprintf (stmt,
@@ -1244,7 +1244,45 @@ sm_define_view_stored_procedure_spec (void)
 	    "ELSE CONCAT ([sp].[target_class], '.', [sp].[target_method]) "
 	    "END AS [target], "
 	  "CAST ([sp].[owner].[name] AS VARCHAR(255)) AS [owner], " /* string -> varchar(255) */
-          "[sp_code].[scode] AS [code], "
+          "CASE "
+	    "WHEN {'DBA'} SUBSETEQ ("
+	      "SELECT "
+	        "SET {CURRENT_USER} + COALESCE (SUM (SET {[t].[g].[name]}), SET {}) "
+	      "FROM "
+	        /* AU_USER_CLASS_NAME */
+		"[%s] AS [u], TABLE ([u].[groups]) AS [t] ([g]) "
+	      "WHERE "
+	        "[u].[name] = CURRENT_USER"
+	    ") THEN [sp_code].[scode] "
+	    "WHEN {[sp].[owner].[name]} SUBSETEQ ("
+	      "SELECT "
+	        "SET {CURRENT_USER} + COALESCE (SUM (SET {[t].[g].[name]}), SET {}) "
+	      "FROM "
+	        /* AU_USER_CLASS_NAME */
+		"[%s] AS [u], TABLE ([u].[groups]) AS [t] ([g]) "
+	      "WHERE "
+	        "[u].[name] = CURRENT_USER"
+	    ") THEN [sp_code].[scode] "
+	    "WHEN {[sp]} SUBSETEQ ("
+	       "SELECT "
+	         "SUM (SET {[au].[object_of]}) "
+	      "FROM "
+	        /* CT_CLASSAUTH_NAME */
+		"[%s] AS [au] "
+	      "WHERE "
+	        "{[au].[grantee].[name]} SUBSETEQ ("
+		    "SELECT "
+		      "SET {CURRENT_USER} + COALESCE (SUM (SET {[t].[g].[name]}), SET {}) "
+		    "FROM "
+		      /* AU_USER_CLASS_NAME */
+		      "[%s] AS [u], TABLE ([u].[groups]) AS [t] ([g]) "
+		    "WHERE "
+		      "[u].[name] = CURRENT_USER"
+		  ") "
+		"AND [au].[auth_type] = 'EXECUTE'"
+	    ") THEN NULL "
+	    "ELSE NULL "
+	    "END AS [code], "
 	  "[sp].[comment] AS [comment] "
 	"FROM "
 	  /* CT_STORED_PROC_NAME */
@@ -1292,6 +1330,10 @@ sm_define_view_stored_procedure_spec (void)
 		")"
 	    ")",
 	CT_DATATYPE_NAME,
+	AU_USER_CLASS_NAME,
+	AU_USER_CLASS_NAME,
+	CT_CLASSAUTH_NAME,
+	AU_USER_CLASS_NAME,
 	CT_STORED_PROC_NAME,
         CT_STORED_PROC_CODE_NAME,
         AU_USER_CLASS_NAME,

--- a/src/object/schema_system_catalog_install_query_spec.cpp
+++ b/src/object/schema_system_catalog_install_query_spec.cpp
@@ -1221,7 +1221,7 @@ sm_define_view_partition_spec (void)
 const char *
 sm_define_view_stored_procedure_spec (void)
 {
-  static char stmt [2500];
+  static char stmt [2200];
 
   // *INDENT-OFF*
   sprintf (stmt,
@@ -1263,24 +1263,6 @@ sm_define_view_stored_procedure_spec (void)
 	      "WHERE "
 	        "[u].[name] = CURRENT_USER"
 	    ") THEN [sp_code].[scode] "
-	    "WHEN {[sp]} SUBSETEQ ("
-	       "SELECT "
-	         "SUM (SET {[au].[object_of]}) "
-	      "FROM "
-	        /* CT_CLASSAUTH_NAME */
-		"[%s] AS [au] "
-	      "WHERE "
-	        "{[au].[grantee].[name]} SUBSETEQ ("
-		    "SELECT "
-		      "SET {CURRENT_USER} + COALESCE (SUM (SET {[t].[g].[name]}), SET {}) "
-		    "FROM "
-		      /* AU_USER_CLASS_NAME */
-		      "[%s] AS [u], TABLE ([u].[groups]) AS [t] ([g]) "
-		    "WHERE "
-		      "[u].[name] = CURRENT_USER"
-		  ") "
-		"AND [au].[auth_type] = 'EXECUTE'"
-	    ") THEN NULL "
 	    "ELSE NULL "
 	    "END AS [code], "
 	  "[sp].[comment] AS [comment] "
@@ -1331,8 +1313,6 @@ sm_define_view_stored_procedure_spec (void)
 	    ")",
 	CT_DATATYPE_NAME,
 	AU_USER_CLASS_NAME,
-	AU_USER_CLASS_NAME,
-	CT_CLASSAUTH_NAME,
 	AU_USER_CLASS_NAME,
 	CT_STORED_PROC_NAME,
         CT_STORED_PROC_CODE_NAME,


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25834

### Purpose

- db_stored_procedure 뷰의 code 컬럼이 EXECUTE 권한만 가진 사용자에게도 노출되어 SP 소스 코드가 유출될 수 있는 보안 이슈를 수정합니다.

#### 변경 전 (AS-IS): 다음 사용자들이 code 컬럼을 조회할 수 있음
1. DBA,
2. DBA MEMBER,
3. SP의 Owner,
4. Owner MEMBER,
5. EXECUTE 권한을 가진 사용자

#### 변경 후 (TO-BE): code 컬럼은 아래 사용자에게만 조회 가능
* EXECUTE 권한만 가진 사용자는 code 컬럼은 NULL로 조회되며, 그 외 정보는 그대로 확인할 수 있습니다.
1. DBA,
2. DBA MEMBER,
3. SP의 Owner,
4. Owner MEMBER

### Implementation

N/A

### Remarks

N/A