### PR TITLE
[CBRD-25358] backport: (no error for system class): error handling when using for update clause for inline view (#6047)

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -9247,15 +9247,17 @@ pt_resolve_names (PARSER_CONTEXT * parser, PT_NODE * statement, SEMANTIC_CHK_INF
 	  /* Flag all specs */
 	  for (spec = statement->info.query.q.select.from; spec != NULL; spec = spec->next)
 	    {
-	      spec->info.spec.flag = (PT_SPEC_FLAG) (spec->info.spec.flag | PT_SPEC_FLAG_FOR_UPDATE_CLAUSE);
 	      for (entity = spec->info.spec.flat_entity_list; entity; entity = entity->next)
 		{
 		  if (sm_check_system_class_by_name (entity->info.name.original))
 		    {
-		      PT_ERRORmf2 (parser, entity, MSGCAT_SET_PARSER_RUNTIME, MSGCAT_RUNTIME_IS_NOT_AUTHORIZED_ON,
-				   "UPDATE", entity->info.name.original);
-		      return NULL;
+		      /* exclude update for system class or view */
+		      break;
 		    }
+		}
+
+	      if (entity == NULL)
+		{
 		  spec->info.spec.flag = (PT_SPEC_FLAG) (spec->info.spec.flag | PT_SPEC_FLAG_FOR_UPDATE_CLAUSE);
 		}
 	    }

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -7851,7 +7851,20 @@ pt_for_update_prepare_query_internal (PARSER_CONTEXT * parser, PT_NODE * query)
 	}
       else
 	{
-	  spec->info.spec.flag = (PT_SPEC_FLAG) (spec->info.spec.flag | PT_SPEC_FLAG_FOR_UPDATE_CLAUSE);
+	  PT_NODE *entity;
+
+	  for (entity = spec->info.spec.flat_entity_list; entity; entity = entity->next)
+	    {
+	      if (sm_check_system_class_by_name (entity->info.name.original))
+		{
+		  break;
+		}
+	    }
+
+	  if (entity == NULL)
+	    {
+	      spec->info.spec.flag = (PT_SPEC_FLAG) (spec->info.spec.flag | PT_SPEC_FLAG_FOR_UPDATE_CLAUSE);
+	    }
 	}
     }
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-25358>

### Purpose

11.3 패치 (11.3.3)
FOR UPDATE 구문에서 인라인 뷰에 시스템 클래스나 뷰가 포함되어 있을 경우, 시스템 클래스와 뷰를 UPDATE 대상에서 제외함

### Implementation

develop으로부터 11.3에 백포트

### Remarks

N/A
