### PR TITLE
[CBRD-25989] Worker Thread (TT_WORKER)인 경우에만 method runtime context를 제거하도록 수정

### DIFF
--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -10442,7 +10442,7 @@ sloaddb_update_stats (THREAD_ENTRY * thread_p, unsigned int rid, char *request, 
 void
 ssession_stop_attached_threads (void *session)
 {
-  session_stop_attached_threads (session, false);
+  session_stop_attached_threads (NULL, session, false);
 }
 
 static bool

--- a/src/communication/network_sr.c
+++ b/src/communication/network_sr.c
@@ -930,10 +930,7 @@ net_server_conn_down (THREAD_ENTRY * thread_p, CSS_THREAD_ARG arg)
 
   if (conn_p->session_p != NULL)
     {
-      if (thread_p && thread_p->type != TT_SERVER)
-	{
-	  ssession_stop_attached_threads (conn_p->session_p);
-	}
+      ssession_stop_attached_threads (conn_p->session_p);
     }
 
 loop:

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -339,7 +339,7 @@ session_state_uninit (void *st)
   er_log_debug (ARG_FILE_LINE, "session_free_session %u\n", session->id);
 #endif /* SESSION_DEBUG */
 
-  session_stop_attached_threads (session, true);
+  session_stop_attached_threads (thread_p, session, true);
 
   /* free session variables */
   vcurent = session->session_variables;
@@ -3229,7 +3229,7 @@ session_has_method_runtime_context (THREAD_ENTRY * thread_p)
  *
  */
 void
-session_stop_attached_threads (void *session_arg, bool force_interrupt)
+session_stop_attached_threads (THREAD_ENTRY * thread_p, void *session_arg, bool force_interrupt)
 {
 #if defined (SERVER_MODE)
   SESSION_STATE *session = (SESSION_STATE *) session_arg;
@@ -3246,7 +3246,12 @@ session_stop_attached_threads (void *session_arg, bool force_interrupt)
       session->load_session_p = NULL;
     }
 
-  if (session->method_rctx_p != NULL)
+  if (thread_p == NULL)
+    {
+      thread_p = thread_get_thread_entry_info ();
+    }
+
+  if (thread_p && thread_p->type == TT_WORKER && session->method_rctx_p != NULL)
     {
       session->method_rctx_p->set_interrupt (force_interrupt ? ER_SES_SESSION_EXPIRED : er_errid ());
       session->method_rctx_p->wait_for_interrupt ();

--- a/src/session/session.h
+++ b/src/session/session.h
@@ -94,7 +94,7 @@ extern int session_get_method_runtime_context (THREAD_ENTRY * thread_p,
 extern bool session_has_method_runtime_context (THREAD_ENTRY * thread_p);
 
 
-extern void session_stop_attached_threads (void *session, bool force_interrupt);
+extern void session_stop_attached_threads (THREAD_ENTRY * thread_p, void *session, bool force_interrupt);
 #if defined (SERVER_MODE)
 extern void session_notify_method_task_completion (const struct session_state *session_arg);
 #endif


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25989

### Purpose

- TT_SERVER 만이 아닌 서버의 메인 스레드인 TT_MASTER도 잘못된 세션 ID를 가지고 method rutnime context를 제거하는 로직에 빠져버립니다. 이 때문에 TT_MASTER가 호출한 session_stop_attached_threads ()에 의해 cubrid server stop 시 종료되지 못하고 wait에서 멈추어 버리는 현상이 발생하고 있습니다.

### Implementation

- TT_WORKER인 경우에만 method runtime context를 제거

### Remarks

N/A
