### PR TITLE
[CBRD-26000] fix the error message on serial value query failures

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -1159,7 +1159,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 "      return ret;",
                 "    } catch (SQLException e) {",
                 "      Server.log(e);",
-                "      throw new SQL_ERROR(e.getMessage());",
+                "      throw new SQL_ERROR(\"serial value unavailable\");",
                 "    } finally {",
                 "      if (pstmt_%'SQL-SERIAL-NO'% != null) {",
                 "        pstmt_%'SQL-SERIAL-NO'%.close();",
@@ -1194,7 +1194,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 "      return ret;",
                 "    } catch (SQLException e) {",
                 "      Server.log(e);",
-                "      throw new SQL_ERROR(e.getMessage());",
+                "      throw new SQL_ERROR(\"serial value unavailable\");",
                 // no Statement.close() call in a finally clause: it is done right after the
                 // outermost loop
                 "    }",


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26000>

### Purpose

Serial 값 조회가 실패했을 때 서버에서 온 에러메시지를 보여주던 것을 
고정된 문자열 'serial value unavailable' 을 보여주도록 수정했습니다. 

### Implementation

N/A

### Remarks

해당 TC 답지 변경 PR : https://github.com/CUBRID/cubrid-testcases/pull/2168
