### PR TITLE
[CBRD-25989] Slip: error handling and add null checking during interrupt

### DIFF
--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -10488,7 +10488,6 @@ smethod_invoke_fold_constants (THREAD_ENTRY * thread_p, unsigned int rid, char *
       /* might be interrupted and session is already freed */
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_INTERRUPTED, 0);
       error_code = ER_INTERRUPTED;
-      assert (false);		// oops
     }
 
   packing_packer packer;
@@ -10517,7 +10516,7 @@ smethod_invoke_fold_constants (THREAD_ENTRY * thread_p, unsigned int rid, char *
       /* 4) pack */
       packer.set_buffer_and_pack_all (eb, ret_value, out_args);
     }
-  else
+  else if (rctx)
     {
       if (rctx->is_interrupted ())
 	{

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -10516,9 +10516,9 @@ smethod_invoke_fold_constants (THREAD_ENTRY * thread_p, unsigned int rid, char *
       /* 4) pack */
       packer.set_buffer_and_pack_all (eb, ret_value, out_args);
     }
-  else if (rctx)
+  else
     {
-      if (rctx->is_interrupted ())
+      if (rctx && rctx->is_interrupted ())
 	{
 	  rctx->set_local_error_for_interrupt ();
 	}

--- a/src/method/method_invoke_group.cpp
+++ b/src/method/method_invoke_group.cpp
@@ -333,7 +333,10 @@ namespace cubmethod
 	if (error != NO_ERROR)
 	  {
 	    // if error is not interrupt reason, interrupt is not set
-	    rctx->set_interrupt (error, (er_has_error () && er_msg ()) ? er_msg () : "");
+	    if (rctx)
+	      {
+		rctx->set_interrupt (error, (er_has_error () && er_msg ()) ? er_msg () : "");
+	      }
 	    break;
 	  }
       }
@@ -375,6 +378,10 @@ namespace cubmethod
 	      {
 		m_connection = pool->claim();
 	      }
+	    else
+	      {
+		return ER_FAILED;
+	      }
 	  }
 
 	// check javasp server's status
@@ -388,6 +395,7 @@ namespace cubmethod
 	      {
 		rctx->set_interrupt (ER_SP_NOT_RUNNING_JVM);
 	      }
+	    return ER_FAILED;
 	  }
       }
 

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -3192,7 +3192,7 @@ session_get_method_runtime_context (THREAD_ENTRY * thread_p,
       else if (state_p->method_rctx_p->is_running () && state_p->method_rctx_p->is_interrupted ())
 	{
 	  method_runtime_context_ref_ptr = nullptr;
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_INTERRUPTED, 0);
+	  state_p->method_rctx_p->set_local_error_for_interrupt ();
 	  error = ER_INTERRUPTED;
 	}
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25989

### Purpose

11.4에 인터럽트 개선 포팅 중 일부 잘못 처리된 에러와 빠진 NULL 체크 추가

### Implementation

- **network_interface_sr.c, method_invoke_group.cpp**: runtime context에 대해서 null 체크가 빠진 부분 수정
- **session.c**: 인터럽트 코드를 ER_INTERRUPTED로 잘못 덮어버리는 코드 수정

### Remarks

N/A
