### PR TITLE
[CBRD-25989] Remove max recursion error handling in server-side

### DIFF
--- a/src/method/method_runtime_context.cpp
+++ b/src/method/method_runtime_context.cpp
@@ -107,14 +107,6 @@ namespace cubmethod
 
     std::unique_lock<std::mutex> ulock (m_mutex);
 
-    if (m_group_stack.size () >= METHOD_MAX_RECURSION_DEPTH)
-      {
-	ulock.unlock ();
-	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_TOO_MANY_NESTED_CALL, 0);
-	set_interrupt (ER_SP_TOO_MANY_NESTED_CALL);
-	return ER_SP_TOO_MANY_NESTED_CALL;
-      }
-
     if (m_is_running == false && m_group_stack.empty ())
       {
 	// clear previous interrupt state


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25989

### Purpose

11.4에서는 서버측에서 모든 인터럽트 에러를 핸들링 하지만, 11.3에서 max recursion 에러의 경우에 CAS에서 재귀 호출 callback의 횟수를 관리하여 반환합니다. 11.3 버전의 push_stack에서 method_invoke_group이 만들어지지 않으며 바로 반환하는 경우, 예상하지 않은 에러 반환으로 인해 이후 루틴에서 잘못된 주소 참조가 일어날 수 있습니다.

### Implementation

11.4 버전에서 백포트한 코드 중 11.3 버전에서 포함되지 않아야 하는 코드를 제거합니다.

### Remarks

N/A
