### PR TITLE
[CBRD-26001] [Regression][shell] Core dumped in dblink_end_tran

### DIFF
--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -551,7 +551,7 @@ dblink_bind_param (int stmt_handle, VAL_DESCR * vd, DBLINK_HOST_VARS * host_vars
 int
 dblink_end_tran (DBLINK_CONN_ENTRY * dblink, bool is_abort)
 {
-  int tran_error = NO_ERROR, rc;
+  int tran_error = NO_ERROR, rc = NO_ERROR;
   T_CCI_ERROR err_buf;
   DBLINK_CONN_ENTRY *prev;
 

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -635,7 +635,7 @@ qmgr_initialize_tran_entry (QMGR_TRAN_ENTRY * tran_entry_p)
   tran_entry_p->num_query_entries = 0;
   tran_entry_p->query_entry_list_p = NULL;
   tran_entry_p->free_query_entry_list_p = NULL;
-  tran_entry_p->dblink_entry = NULL:
+  tran_entry_p->dblink_entry = NULL;
   tran_entry_p->modified_classes_p = NULL;
   pthread_mutex_init (&tran_entry_p->mutex, NULL);
 }

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -635,6 +635,7 @@ qmgr_initialize_tran_entry (QMGR_TRAN_ENTRY * tran_entry_p)
   tran_entry_p->num_query_entries = 0;
   tran_entry_p->query_entry_list_p = NULL;
   tran_entry_p->free_query_entry_list_p = NULL;
+tran_entry_p->dblink_entry = NULL:
   tran_entry_p->modified_classes_p = NULL;
   pthread_mutex_init (&tran_entry_p->mutex, NULL);
 }

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -635,7 +635,7 @@ qmgr_initialize_tran_entry (QMGR_TRAN_ENTRY * tran_entry_p)
   tran_entry_p->num_query_entries = 0;
   tran_entry_p->query_entry_list_p = NULL;
   tran_entry_p->free_query_entry_list_p = NULL;
-tran_entry_p->dblink_entry = NULL:
+  tran_entry_p->dblink_entry = NULL:
   tran_entry_p->modified_classes_p = NULL;
   pthread_mutex_init (&tran_entry_p->mutex, NULL);
 }

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -452,6 +452,26 @@ qmgr_deallocate_query_entries (QMGR_QUERY_ENTRY * query_p)
 }
 
 /*
+ * qmgr_deallocate_dblink_entries () -
+ *   return:
+ *   dblink_p(in)  : dblink entry pointer
+ *
+ * Note: Free the area allocated for the dblink entry list
+ */
+static void
+qmgr_deallocate_dblink_entries (DBLINK_CONN_ENTRY * dblink_p)
+{
+  DBLINK_CONN_ENTRY *p;
+
+  while (dblink_p)
+    {
+      p = dblink_p;
+      dblink_p = dblink_p->next;
+      free (p);
+    }
+}
+
+/*
  * qmgr_add_query_entry () -
  *   return:
  *   q_ptr(in)  : Query Entry Pointer
@@ -729,6 +749,7 @@ qmgr_free_tran_entries (void)
       qmgr_deallocate_query_entries (tran_entry_p->query_entry_list_p);
       qmgr_deallocate_query_entries (tran_entry_p->free_query_entry_list_p);
       qmgr_deallocate_oid_blocks (tran_entry_p->modified_classes_p);
+      qmgr_deallocate_dblink_entries (tran_entry_p->dblink_entry);
 
       pthread_mutex_destroy (&tran_entry_p->mutex);
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26001>

### Purpose

dblink 트랜잭션 commit / rollback 체크 중 core 발생 이슈를 해결

### Implementation

- qmgr_tran_entry의 dblink_entry를 초기화
- dblink_end_tran에서 rc 값이 초기화 되지 않는 것을 NO_ERROR로 초기화

### Remarks

N/A
