### PR TITLE
[CUBVEC-41] fix: allow case insensitive VECTOR_DISTANCE metric (strcmp -> strcasecmp)

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -25845,19 +25845,19 @@ vector_distance_metric
 			const char* metric_name = identifier->info.name.original;
 
 			assert(metric_name != NULL);
-			if (strcmp(metric_name, "cosine") == 0)
+			if (strcasecmp(metric_name, "cosine") == 0)
 			  {
 			    metric = METRIC_COSINE;
 			  }
-			else if (strcmp(metric_name, "dot") == 0)
+			else if (strcasecmp(metric_name, "dot") == 0)
 			  {
 			    metric = METRIC_DOT;
 			  }
-			else if (strcmp(metric_name, "euclidean") == 0)
+			else if (strcasecmp(metric_name, "euclidean") == 0)
 			  {
 			    metric = METRIC_EUCLIDEAN;
 			  }
-			else if (strcmp(metric_name, "manhattan") == 0)
+			else if (strcasecmp(metric_name, "manhattan") == 0)
 			  {
 			    metric = METRIC_MANHATTAN;
 			  }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBVEC-41>

### Purpose

https://github.com/CUBRID/cubrid/pull/6069

위 PR에서 언급된 Case Insensitive String Comparison 스펙이 착각으로 인해 누락되어 현 PR에서 Fix합니다.
identifier는 case sensitive하게 정보를 저장하는 것이 맞습니다.

#### As Is
```sql
VECTOR_DISTANCE('[1, 2]', '[0, 0]', cosine); -- 성공
VECTOR_DISTANCE('[1, 2]', '[0, 0]', COSINE); -- 실패
```

#### To Be
```sql
VECTOR_DISTANCE('[1, 2]', '[0, 0]', cosine); -- 성공
VECTOR_DISTANCE('[1, 2]', '[0, 0]', COSINE); -- 성공
```

### Implementation

착오로 인해 누락된 @hgryoo 님의 피드백을 반영합니다.

```c
strcmp() -> strcasecmp()
```

### Remarks

테스트 케이스

```sql
SELECT vector_distance('[1, 2, 3]', '[0, 0, 0]', cosine);
SELECT vector_distance('[1, 2, 3]', '[0, 0, 0]', COSINE);
... -- 다른 distance metrics
```