### PR TITLE
[CBRD-25734] Fix assert on CUBRID server stop with incomplete XA transactions

### DIFF
--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -3431,7 +3431,7 @@ xboot_unregister_client (REFPTR (THREAD_ENTRY, thread_p), int tran_index)
 #endif /* SERVER_MODE */
 
       /* If the transaction is active or unactive_2pc_prepare abort it */
-      if (LOG_ISTRAN_ACTIVE (tdes) || LOG_ISTRAN_2PC_PREPARE(tdes))
+      if (LOG_ISTRAN_ACTIVE (tdes) || LOG_ISTRAN_2PC_PREPARE (tdes))
 	{
 	  (void) xtran_server_abort (thread_p);
 	}

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -3431,10 +3431,12 @@ xboot_unregister_client (REFPTR (THREAD_ENTRY, thread_p), int tran_index)
 #endif /* SERVER_MODE */
 
       /* If the transaction is active abort it */
+      /* FIXME:
+       * Don't abort transactions in LOG_ISTRAN_2PC_PREPARE arbitrarily.
+       * Currently follows a temporary recovery policy (no coordinator).
+       * Must follow proper 2PC rules once coordinator is implemented.
+       */
       if (LOG_ISTRAN_ACTIVE (tdes) || LOG_ISTRAN_2PC_PREPARE (tdes))	/* logtb_is_current_active (thread_p) */
-	// FIXME: If the server shuts down while in the 2PC_PREPARE state, an assert will occur.
-	// Once the 2PC and server shutdown routine are fully implemented,
-	// the LOG_ISTRAN_2PC_PREPARE (tdes) condition should be removed.
 	{
 	  (void) xtran_server_abort (thread_p);
 	}

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -3430,8 +3430,11 @@ xboot_unregister_client (REFPTR (THREAD_ENTRY, thread_p), int tran_index)
 	}
 #endif /* SERVER_MODE */
 
-      /* If the transaction is active or unactive_2pc_prepare abort it */
-      if (LOG_ISTRAN_ACTIVE (tdes) || LOG_ISTRAN_2PC_PREPARE (tdes))
+      /* If the transaction is active abort it */
+      if (LOG_ISTRAN_ACTIVE (tdes) || LOG_ISTRAN_2PC_PREPARE (tdes))	/* logtb_is_current_active (thread_p) */
+	// FIXME: If the server shuts down while in the 2PC_PREPARE state, an assert will occur.
+	// Once the 2PC and server shutdown routine are fully implemented,
+	// the LOG_ISTRAN_2PC_PREPARE (tdes) condition should be removed.
 	{
 	  (void) xtran_server_abort (thread_p);
 	}

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -3430,8 +3430,8 @@ xboot_unregister_client (REFPTR (THREAD_ENTRY, thread_p), int tran_index)
 	}
 #endif /* SERVER_MODE */
 
-      /* If the transaction is active abort it */
-      if (LOG_ISTRAN_ACTIVE (tdes))	/* logtb_is_current_active (thread_p) */
+      /* If the transaction is active or unactive_2pc_prepare abort it */
+      if (LOG_ISTRAN_ACTIVE (tdes) || LOG_ISTRAN_2PC_PREPARE(tdes))	/* logtb_is_current_active (thread_p) */
 	{
 	  (void) xtran_server_abort (thread_p);
 	}

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -3431,7 +3431,7 @@ xboot_unregister_client (REFPTR (THREAD_ENTRY, thread_p), int tran_index)
 #endif /* SERVER_MODE */
 
       /* If the transaction is active or unactive_2pc_prepare abort it */
-      if (LOG_ISTRAN_ACTIVE (tdes) || LOG_ISTRAN_2PC_PREPARE(tdes))	/* logtb_is_current_active (thread_p) */
+      if (LOG_ISTRAN_ACTIVE (tdes) || LOG_ISTRAN_2PC_PREPARE(tdes))
 	{
 	  (void) xtran_server_abort (thread_p);
 	}

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -8306,8 +8306,10 @@ lock_reacquire_crash_locks (THREAD_ENTRY * thread_p, LK_ACQUIRED_LOCKS * acqlock
        * lock wait duration       : LK_INFINITE_WAIT
        * conditional lock request : false
        */
-      r = lock_internal_perform_lock_object (thread_p, tran_index, &acqlocks->obj[i].oid, &acqlocks->obj[i].class_oid,
-					     acqlocks->obj[i].lock, LK_INFINITE_WAIT, &dummy_ptr, NULL);
+      r =
+	lock_internal_perform_lock_object (thread_p, tran_index, &acqlocks->obj[i].oid,
+					   OID_IS_ROOTOID (&acqlocks->obj[i].oid) ? NULL : &acqlocks->obj[i].class_oid,
+					   acqlocks->obj[i].lock, LK_INFINITE_WAIT, &dummy_ptr, NULL);
       if (r != LK_GRANTED)
 	{
 	  er_log_debug (ARG_FILE_LINE, "lk_reacquire_crash_locks: The lock cannot be reacquired...");


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25734

### Purpose

- XA 트랜잭션이 완료되지 않은 상태에서 트랜잭션의 연결이 끊기면 트랜잭션 정보가 초기화되지 않고 있음
    - 이 상태로 cubrid server stop 시 assert 발생(자세한 과정은 jira issue 참고)
- assert 발생을 막기 위해 완료되지 않은 XA 트랜잭션 연결이 끊기면 abort로 초기화되도록 함

### Implementation

- XA 트랜잭션 연결이 종료될 때 완료되지 않은 상태(2PC_PREPARE)의 트랜잭션도 abort로 초기화하도록 구현

### Remarks

- 일반 XA 트랜잭션은 2PC를 활용하기 위해 coordinator를 사용합니다. 이때 완료되지 않은 트랜잭션이 종료되면 recovery 시 coordinator의 명령에 따라 commit/abort 여부를 결정하고 진행합니다.
- 현재 CUBRID 코드에는 XA 트랜잭션을 위한 coordinator가 활용되지 않고 있으며, recovery 시 abort를 발생시키도록 구현됐기 때문에, 완료되지 않은 XA 트랜잭션은 server stop 시 abort로 초기화 되도록 구현하였습니다.

- 본 PR의 코드 수정은 https://github.com/CUBRID/cubrid/pull/5677 PR을 cherry-pick 하여 진행되었으니 리뷰시 참고 부탁드립니다.