### PR TITLE
[CBRD-25360] Backport to 11.0 - Modify the method of obtaining schema information for tables with auto_increment using unloaddb

### DIFF
--- a/src/compat/db_vdb.c
+++ b/src/compat/db_vdb.c
@@ -302,6 +302,7 @@ db_parse_one_statement (DB_SESSION * session)
       if (session->type_list)
 	{
 	  db_free_query_format (session->type_list[0]);
+    session->type_list[0] = NULL;
 	}
       if (session->statements[0])
 	{

--- a/src/compat/db_vdb.c
+++ b/src/compat/db_vdb.c
@@ -302,7 +302,7 @@ db_parse_one_statement (DB_SESSION * session)
       if (session->type_list)
 	{
 	  db_free_query_format (session->type_list[0]);
-    session->type_list[0] = NULL;
+	  session->type_list[0] = NULL;
 	}
       if (session->statements[0])
 	{

--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -1932,47 +1932,6 @@ emit_instance_attributes (print_output & output_ctx, DB_OBJECT * class_, const c
 		  continue;
 		}
 
-	      if (db_get_int (&started_val) == 1)
-		{
-		  DB_VALUE diff_val, answer_val;
-
-		  db_make_null (&diff_val);
-		  sr_error = numeric_db_value_sub (&max_val, &cur_val, &diff_val);
-		  if (sr_error == ER_IT_DATA_OVERFLOW)
-		    {
-		      // max - cur might be flooded.
-		      diff_val = max_val;
-		      er_clear ();
-		    }
-		  else if (sr_error != NO_ERROR)
-		    {
-		      pr_clear_value (&sr_name);
-		      continue;
-		    }
-		  sr_error = numeric_db_value_compare (&inc_val, &diff_val, &answer_val);
-		  if (sr_error != NO_ERROR)
-		    {
-		      pr_clear_value (&sr_name);
-		      continue;
-		    }
-		  /* auto_increment is always non-cyclic */
-		  if (db_get_int (&answer_val) > 0)
-		    {
-		      pr_clear_value (&sr_name);
-		      continue;
-		    }
-
-		  sr_error = numeric_db_value_add (&cur_val, &inc_val, &answer_val);
-		  if (sr_error != NO_ERROR)
-		    {
-		      pr_clear_value (&sr_name);
-		      continue;
-		    }
-
-		  pr_clear_value (&cur_val);
-		  cur_val = answer_val;
-		}
-
 	      start_with = numeric_db_value_print (&cur_val, str_buf);
 	      if (start_with[0] == '\0')
 		{
@@ -1982,6 +1941,10 @@ emit_instance_attributes (print_output & output_ctx, DB_OBJECT * class_, const c
 	      output_ctx ("ALTER SERIAL %s%s%s START WITH %s;\n",
 			  PRINT_IDENTIFIER (db_get_string (&sr_name)), start_with);
 
+          if (db_get_int (&started_val) == 1)
+           {
+             output_ctx ("SELECT %s%s%s.NEXT_VALUE;\n ", PRINT_IDENTIFIER (db_get_string (&sr_name)));
+           }
 	      pr_clear_value (&sr_name);
 	    }
 	}

--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -1171,7 +1171,12 @@ emit_schema (print_output & output_ctx, DB_OBJLIST * classes, int do_auth, DB_OB
 	{
 	  emit_class_meta (output_ctx, cl->op);
 	}
-      output_ctx ("\n");
+
+      if (do_auth)
+	{
+	  emit_class_owner (output_ctx, cl->op);
+	  output_ctx ("\n");
+	}
     }
 
   output_ctx ("\n");
@@ -1219,16 +1224,6 @@ emit_schema (print_output & output_ctx, DB_OBJLIST * classes, int do_auth, DB_OB
       if (is_partitioned)
 	{
 	  emit_partition_info (output_ctx, cl->op);
-	}
-
-      /*
-       * change_owner method should be called after adding all columns.
-       * If some column has auto_increment attribute, change_owner method
-       * will change serial object's owner related to that attribute.
-       */
-      if (do_auth)
-	{
-	  emit_class_owner (output_ctx, cl->op);
 	}
     }
 
@@ -1941,10 +1936,10 @@ emit_instance_attributes (print_output & output_ctx, DB_OBJECT * class_, const c
 	      output_ctx ("ALTER SERIAL %s%s%s START WITH %s;\n",
 			  PRINT_IDENTIFIER (db_get_string (&sr_name)), start_with);
 
-          if (db_get_int (&started_val) == 1)
-           {
-             output_ctx ("SELECT %s%s%s.NEXT_VALUE;\n ", PRINT_IDENTIFIER (db_get_string (&sr_name)));
-           }
+	      if (db_get_int (&started_val) == 1)
+		{
+		  output_ctx ("SELECT %s%s%s.NEXT_VALUE;\n ", PRINT_IDENTIFIER (db_get_string (&sr_name)));
+		}
 	      pr_clear_value (&sr_name);
 	    }
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25360

Purpose
Modify the method of obtaining schema information for tables with auto_increment using unloaddb

Implementation
Add the following content to the schema file
* SELECT [tbl_ai_id].NEXT_VALUE;

Change the location of the call method [change_owner] to below "CREATE CLASS"

CREATE CLASS [t1] REUSE_OID, COLLATE iso88591_bin;
call [change_owner]('t1', 'DBA') on class [db_root];

