### PR TITLE
[CBRD-25990] The problem where for orderby_num() in inline views gets removed due to view merging

### DIFF
--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -2354,8 +2354,8 @@ mq_update_order_by (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * quer
     }
   else
     {
-      /* impossible case : if both the main and subqueries have order by, can't be view-merged */
-      assert (false);
+      /* if both the main and subqueries have order by, should not have orderby_for. can't be view-merged */
+      assert (query_spec->info.query.orderby_for == NULL);
     }
 
   parser_free_tree (parser, ord_num);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-25990>

### Purpose

주질의와 부질의 모두 order by절이 있을 경우 뷰머지 가능하나, 부질의에 limit등이 포함되어 orderby_for가 있을경우 뷰머지 불가합니다. assert의 내용을 수정합니다.

### Implementation

N/A

### Remarks

N/A
