### PR TITLE
[CBRD-26003] Fix assert error caused by scan manager's open() does not expect error code

### DIFF
--- a/src/method/method_scan.cpp
+++ b/src/method/method_scan.cpp
@@ -127,8 +127,8 @@ namespace cubscan
       error = qfile_open_list_scan (m_list_id, &m_scan_id);
 
       // connect
-      error = m_method_group->begin ();
-      return error;
+      (void) m_method_group->begin ();
+      return NO_ERROR;
     }
 
     int


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26003

### Purpose

scan manager에서 open () 함수에 대해서 반환 값에 대해서 에러 코드를 기대하지 않고 assert 에러를 반환합니다. scan manager는 대신 에러 매니저에 설정된 에러를 반환하는 er_errid () 함수를 통해 SCAN_ID에 대해서 에러 여부를 판단합니다.

### Implementation

- 에러를 반환하지 않도록 변경

### Remarks

N/A
