### PR TITLE
[CBRD-25068] temp removal cub_alloc wrapper for QA test purpose

### DIFF
--- a/src/base/memory_cwrapper.h
+++ b/src/base/memory_cwrapper.h
@@ -74,6 +74,8 @@ get_allocated_size (void *ptr)
     }
 }
 
+#if 0
+
 inline void
 cub_free (void *ptr)
 {
@@ -191,3 +193,5 @@ cub_strdup (const char *str, const char *file, const int line)
 #endif // !WINDOWS
 
 #endif // _MEMORY_CWRAPPER_H_
+
+#endif

--- a/src/base/memory_wrapper.hpp
+++ b/src/base/memory_wrapper.hpp
@@ -20,6 +20,8 @@
  * memory_wrapper.hpp - Overloading operator new, delete with all wrapping allocation functions
  */
 
+#if 0
+
 #ifndef _MEMORY_WRAPPER_HPP_
 #define _MEMORY_WRAPPER_HPP_
 
@@ -82,3 +84,5 @@ inline void operator delete [] (void *ptr, size_t sz) noexcept
 #endif // !WINDOWS
 
 #endif // _MEMORY_WRAPPER_HPP_
+
+#endif

--- a/src/heaplayers/customheaps.cpp
+++ b/src/heaplayers/customheaps.cpp
@@ -141,5 +141,9 @@ hl_ostk_free (UINTPTR heap_id, void *ptr)
     }
 }
 
+#if 0
+
 #define malloc(sz) cub_alloc(sz, __FILE__, __LINE__)
 #define free(ptr) cub_free(ptr)
+
+#endif


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25068

### Purpose
- 테스트 목적으로 cub_alloc 계열 래퍼 주석 처리
- 테스트 완료 후 revert 대상

### Remarks
- 기본적으로, memory_wrapper.h를 사용하나 일부 예외적으로 memory_cwapper.h를 포함하는 경우들이 있습니다. hole 발생에 의한 우회 처리였던 것으로 기억됩니다.
```
compat/dbtype_function.i:#include "memory_cwrapper.h"
query/xasl.h:#include "memory_cwrapper.h"
```