### PR TITLE
[CBRD-25970] Revert "print errcode in the server error log for debugging purpose"

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -3362,9 +3362,6 @@ heap_stats_find_page_in_bestspace (THREAD_ENTRY * thread_p, const HFID * hfid, H
 	      break;
 	    }
 #if defined (SERVER_MODE)
-#if !defined (NDEBUG)
-	  _er_log_debug (ARG_FILE_LINE, "[CBRD-25970] errid=%d\n", er_errid_if_has_error ());
-#endif
 	  // ignores a warning and expects no other errors
 	  assert (er_errid_if_has_error () == NO_ERROR);
 #endif /* SERVER_MODE */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25970

위 이슈 해결을 위한 PR이며, 해당 이슈는 resolved 되었기 때문에 revert합니다.