### PR TITLE
[CBRD-25500] Change Bind Var Count when Caching Subquery

### DIFF
--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -2744,10 +2744,24 @@ parser_print_tree (PARSER_CONTEXT * parser, const PT_NODE * node)
 	}
       if ((parser->custom_print & PT_PRINT_HOST_VAR_COUNT) != 0)
 	{
-	  char host_var_count[12];
-	  snprintf (host_var_count, sizeof (host_var_count), "%d", parser->host_var_count + parser->auto_param_count);
-	  string = pt_append_nulstring (parser, string, ";bind_var_cnt=");
-	  string = pt_append_nulstring (parser, string, host_var_count);
+	  if ((node->info.query.is_subquery == PT_IS_SUBQUERY || node->info.query.is_subquery == PT_IS_UNION_QUERY
+	       || node->info.query.is_subquery == PT_IS_UNION_SUBQUERY
+	       || node->info.query.is_subquery == PT_IS_CTE_NON_REC_SUBQUERY) && node->info.query.correlation_level == 0
+	      && (node->info.query.hint & PT_HINT_QUERY_CACHE))
+	    {
+	      char host_var_count[12];
+	      snprintf (host_var_count, sizeof (host_var_count), "%d", parser->host_var_count);
+	      string = pt_append_nulstring (parser, string, ";bind_var_cnt=");
+	      string = pt_append_nulstring (parser, string, host_var_count);
+	    }
+	  else
+	    {
+	      char host_var_count[12];
+	      snprintf (host_var_count, sizeof (host_var_count), "%d",
+			parser->host_var_count + parser->auto_param_count);
+	      string = pt_append_nulstring (parser, string, ";bind_var_cnt=");
+	      string = pt_append_nulstring (parser, string, host_var_count);
+	    }
 	}
       return (char *) string->bytes;
     }

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -2750,6 +2750,11 @@ parser_print_tree (PARSER_CONTEXT * parser, const PT_NODE * node)
 	       || node->info.query.is_subquery == PT_IS_CTE_NON_REC_SUBQUERY) && node->info.query.correlation_level == 0
 	      && (node->info.query.hint & PT_HINT_QUERY_CACHE))
 	    {
+	      /* 
+	       * This condition is identical to the one used in do_prepare_subquery_pre function to call do_prepare_subquery.
+	       * Both functions must maintain the same condition to ensure consistency.
+	       * Be careful not to modify only one of them.
+	       */
 	      snprintf (host_var_count, sizeof (host_var_count), "%d", parser->host_var_count);
 	    }
 	  else

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -2744,24 +2744,21 @@ parser_print_tree (PARSER_CONTEXT * parser, const PT_NODE * node)
 	}
       if ((parser->custom_print & PT_PRINT_HOST_VAR_COUNT) != 0)
 	{
+	  char host_var_count[12];
 	  if ((node->info.query.is_subquery == PT_IS_SUBQUERY || node->info.query.is_subquery == PT_IS_UNION_QUERY
 	       || node->info.query.is_subquery == PT_IS_UNION_SUBQUERY
 	       || node->info.query.is_subquery == PT_IS_CTE_NON_REC_SUBQUERY) && node->info.query.correlation_level == 0
 	      && (node->info.query.hint & PT_HINT_QUERY_CACHE))
 	    {
-	      char host_var_count[12];
 	      snprintf (host_var_count, sizeof (host_var_count), "%d", parser->host_var_count);
-	      string = pt_append_nulstring (parser, string, ";bind_var_cnt=");
-	      string = pt_append_nulstring (parser, string, host_var_count);
 	    }
 	  else
 	    {
-	      char host_var_count[12];
 	      snprintf (host_var_count, sizeof (host_var_count), "%d",
 			parser->host_var_count + parser->auto_param_count);
-	      string = pt_append_nulstring (parser, string, ";bind_var_cnt=");
-	      string = pt_append_nulstring (parser, string, host_var_count);
 	    }
+	  string = pt_append_nulstring (parser, string, ";bind_var_cnt=");
+	  string = pt_append_nulstring (parser, string, host_var_count);
 	}
       return (char *) string->bytes;
     }

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -3636,6 +3636,11 @@ do_prepare_subquery_pre (PARSER_CONTEXT * parser, PT_NODE * stmt, void *arg, int
        || stmt->info.query.is_subquery == PT_IS_CTE_NON_REC_SUBQUERY) && stmt->info.query.correlation_level == 0
       && (stmt->info.query.hint & PT_HINT_QUERY_CACHE))
     {
+      /* 
+       * This condition is identical to the one used in parser_print_tree.
+       * Both functions must maintain the same condition to ensure consistency.
+       * Be careful not to modify only one of them.
+       */
       *err = do_prepare_subquery (parser, stmt);
 
       if (*err != NO_ERROR)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-25500>

### Purpose

subquery cache시 xasl hash의 값은 subquery에 초점이 맞추어져야한다.

select cola from tbl_a where cola = (select /*+ query_cache */ cola from tbl_b where colb = 20 and cola = 10) and colb > 0; select /*+ query_cache */ cola from tbl_b where colb = 20 and cola = 10;

의 bind_var_cnt는 동일해야 한다.

### Implementation

select cola from tbl_a where cola = (select /*+ query_cache */ cola from tbl_b where colb = 20 and cola = 10) and colb > 0; 

host var count는 subquery의 auto parameter count로 설정됨. (2개)
auto parameter count는 모든 auto parameter count의 합임. (3개)

select /*+ query_cache */ cola from tbl_b where colb = 20 and cola = 10;
auto parameter count는 2개

따라서 서브쿼리 캐싱을 사용하는 경우에 한하여, bind var count계산 로직을 변경해 주어야 함.

### Remarks

테스트시 부작용 확인 필요
