### PR TITLE
[CBRD-25358] rev (error for system class / view in inline view): error handling when using for update clause for system tables such as db_root, dual, etc. (#6094)

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -9244,23 +9244,9 @@ pt_resolve_names (PARSER_CONTEXT * parser, PT_NODE * statement, SEMANTIC_CHK_INF
 	}
       else
 	{
-	  /* Flag all specs */
-	  for (spec = statement->info.query.q.select.from; spec != NULL; spec = spec->next)
-	    {
-	      for (entity = spec->info.spec.flat_entity_list; entity; entity = entity->next)
-		{
-		  if (sm_check_system_class_by_name (entity->info.name.original))
-		    {
-		      /* exclude update for system class or view */
-		      break;
-		    }
-		}
-
-	      if (entity == NULL)
-		{
-		  spec->info.spec.flag = (PT_SPEC_FLAG) (spec->info.spec.flag | PT_SPEC_FLAG_FOR_UPDATE_CLAUSE);
-		}
-	    }
+	  /* to process the clause "FOR UPDATE"
+	   * it will be checked at pt_for_update_prepare_query
+	   */
 	}
     }
 

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -7836,11 +7836,6 @@ pt_for_update_prepare_query_internal (PARSER_CONTEXT * parser, PT_NODE * query)
   from = query->info.query.q.select.from;
   for (spec = from; spec != NULL; spec = spec->next)
     {
-      if (has_for_update && !(spec->info.spec.flag & PT_SPEC_FLAG_FOR_UPDATE_CLAUSE))
-	{
-	  /* skip if the spec is not flagged for FOR UPDATE */
-	  continue;
-	}
       if (spec->info.spec.derived_table != NULL)
 	{
 	  err = pt_for_update_prepare_query_internal (parser, spec->info.spec.derived_table);
@@ -7849,22 +7844,22 @@ pt_for_update_prepare_query_internal (PARSER_CONTEXT * parser, PT_NODE * query)
 	      return err;
 	    }
 	}
-      else
+      else if (has_for_update)
 	{
 	  PT_NODE *entity;
 
 	  for (entity = spec->info.spec.flat_entity_list; entity; entity = entity->next)
 	    {
+	      /* for system class / view, return error */
 	      if (sm_check_system_class_by_name (entity->info.name.original))
 		{
-		  break;
+		  PT_ERRORmf2 (parser, entity, MSGCAT_SET_PARSER_RUNTIME, MSGCAT_RUNTIME_IS_NOT_AUTHORIZED_ON, "UPDATE",
+			       entity->info.name.original);
+		  return MSGCAT_SET_PARSER_RUNTIME;
 		}
 	    }
 
-	  if (entity == NULL)
-	    {
-	      spec->info.spec.flag = (PT_SPEC_FLAG) (spec->info.spec.flag | PT_SPEC_FLAG_FOR_UPDATE_CLAUSE);
-	    }
+	  spec->info.spec.flag = (PT_SPEC_FLAG) (spec->info.spec.flag | PT_SPEC_FLAG_FOR_UPDATE_CLAUSE);
 	}
     }
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-25358>

### Purpose

아래와 같이 11.3.3 패치 (스펙 변경)

인라인 뷰에 대한 FOR UPDATE 구문에서 시스템 클래스 / 뷰가 포함된 경우 처리 방식

AS-IS: 해당 시스템 클래스에 대한 잠금을 회피하도록 처리하고 쿼리를 정상 수행
TO-BE: 해당 쿼리 에러 처리

### Implementation

develop으로부터 Backport

### Remarks

스펙 변경으로 테스트 케이스 체크할 필요가 있음.
