### PR TITLE
[CBRD-26010] Fix backup hang with different max_clients settings in [common] and [@db] sections in conf file

### DIFF
--- a/src/communication/network_sr.c
+++ b/src/communication/network_sr.c
@@ -1117,7 +1117,7 @@ net_server_start (const char *server_name)
       goto end;
     }
 
-  sysprm_load_and_init (NULL, NULL, SYSPRM_LOAD_ALL);
+  sysprm_load_and_init (server_name, NULL, SYSPRM_LOAD_ALL);
   sysprm_set_er_log_file (server_name);
 
   if (sync_initialize_sync_stats () != NO_ERROR)

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2104,7 +2104,7 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
     }
 
 #if defined(SERVER_MODE)
-  if (sysprm_load_and_init (NULL, NULL, SYSPRM_LOAD_ALL) != NO_ERROR)
+  if (sysprm_load_and_init (db_name, NULL, SYSPRM_LOAD_ALL) != NO_ERROR)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_BO_CANT_LOAD_SYSPRM, 0);
       error_code = ER_BO_CANT_LOAD_SYSPRM;

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2222,13 +2222,6 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
    * recovery managers
    */
 #if defined(SERVER_MODE)
-  if (sysprm_load_and_init (boot_Db_full_name, NULL, SYSPRM_LOAD_ALL) != NO_ERROR)
-    {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_BO_CANT_LOAD_SYSPRM, 0);
-      error_code = ER_BO_CANT_LOAD_SYSPRM;
-      goto error;
-    }
-
   if (common_ha_mode != prm_get_integer_value (PRM_ID_HA_MODE) && !HA_DISABLED ())
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_PRM_CONFLICT_EXISTS_ON_MULTIPLE_SECTIONS, 6, "cubrid.conf", "common",


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26010

### Purpose

- cubrid.conf 파일 구성 시 [common] 섹션과 [@db] 섹션의 max_clients 값을 다르게 설정하면 backup 수행 시 hang이 발생합니다.
- 이는 서버 시작 시 core의 개수를 설정할 때 [common] 섹션의 max_clients 값만 참조하기 때문입니다.
- 이에 core의 개수 설정 시 cubrid.conf 파일의 [@db] 섹션까지 참조하도록 합니다.

### Implementation

- 처음 cubrid.conf 파일 load 시 [@db] 섹션까지 참조하도록 구현

### Remarks

N/A
