### PR TITLE
[CUBVEC-23] Fix Create Vector Index - With statement side-effects

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -2944,7 +2944,8 @@ create_stmt
 			    node->info.index.where = $12;
 			    node->info.index.column_names = col;
 
-                            node->info.index.deduplicate_level = CONTAINER_AT_1($13);
+                            // node->info.index.deduplicate_level = CONTAINER_AT_1($13);
+                            node->info.index.deduplicate_level = NULL;
 			    // TODO: node->info.index.hnsw.m = 30;
 			    // TODO: node->info.index.hnsw.ef_con = 100;
 
@@ -2955,8 +2956,10 @@ create_stmt
 
 			    node->info.index.comment = $15;
 
-                            int with_online_ret = CONTAINER_AT_0($13);  // 0 for normal, 1 for online no parallel,
+                            // TODO: this breaks CS mode when creating vector index with 'with' clause.
+                            // int with_online_ret = CONTAINER_AT_0($13);  // 0 for normal, 1 for online no parallel,
                                                         // thread_count + 1 for parallel
+			    int with_online_ret = 0;
                             bool is_online = with_online_ret > 0;
                             bool is_invisible = $14;
 
@@ -22840,7 +22843,7 @@ opt_index_with_clause
         : /* empty */
           { DBG_TRACE_GRAMMAR(opt_index_with_clause, : );
             container_2 ctn;
-            SET_CONTAINER_2(ctn, 0, DEDUPLICATE_OPTION_AUTO);
+            // SET_CONTAINER_2(ctn, 0, DEDUPLICATE_OPTION_AUTO);
             $$ = ctn; }
         | WITH index_with_item_list
           {  DBG_TRACE_GRAMMAR(opt_index_with_clause, | WITH index_with_item_list );
@@ -22852,7 +22855,7 @@ opt_vector_index_with_clause
         : /* empty */
           { DBG_TRACE_GRAMMAR(opt_index_with_clause, : );
             container_2 ctn;
-            SET_CONTAINER_2(ctn, 0, DEDUPLICATE_OPTION_AUTO);
+            // SET_CONTAINER_2(ctn, 0, DEDUPLICATE_OPTION_AUTO);
             $$ = ctn; }
         | WITH '(' vector_index_with_item_list ')'
           {  DBG_TRACE_GRAMMAR(opt_index_with_clause, | WITH index_with_item_list );

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -22843,7 +22843,7 @@ opt_index_with_clause
         : /* empty */
           { DBG_TRACE_GRAMMAR(opt_index_with_clause, : );
             container_2 ctn;
-            // SET_CONTAINER_2(ctn, 0, DEDUPLICATE_OPTION_AUTO);
+            SET_CONTAINER_2(ctn, 0, DEDUPLICATE_OPTION_AUTO);
             $$ = ctn; }
         | WITH index_with_item_list
           {  DBG_TRACE_GRAMMAR(opt_index_with_clause, | WITH index_with_item_list );

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -2814,6 +2814,13 @@ create_stmt
 			PT_NODE *ocs = parser_new_node(this_parser, PT_SPEC);
 			PARSER_SAVE_ERR_CONTEXT (node, @$.buffer_pos)
 
+			// TODO: CUBVEC - Old opt_index_with_clause ($13) not handled in this CREATE VECTOR INDEX statement.
+			// Therefore we cannot set deduplication level for the index.
+			// Also, we cannot specify online / offline option for the index.
+			container_2 rule_13;
+			// TODO: CUBVEC - Initialize the rule 13 as it was not set.
+			SET_CONTAINER_2 (rule_13, 0, DEDUPLICATE_OPTION_AUTO);
+
 			assert(node != NULL);
 
 			/* Initialize vector_index_info (now an embedded structure) */
@@ -2944,8 +2951,12 @@ create_stmt
 			    node->info.index.where = $12;
 			    node->info.index.column_names = col;
 
-                            // node->info.index.deduplicate_level = CONTAINER_AT_1($13);
-                            node->info.index.deduplicate_level = NULL;
+			    // TODO: CUBVEC - Use rule_13 instead of $13
+                            // original code: 
+			    // node->info.index.deduplicate_level = CONTAINER_AT_1($13);
+                            node->info.index.deduplicate_level = CONTAINER_AT_1(rule_13);
+
+			    // TODO: CUBVEC - $13 contains parameter infos such as m and ef_construction
 			    // TODO: node->info.index.hnsw.m = 30;
 			    // TODO: node->info.index.hnsw.ef_con = 100;
 
@@ -2956,10 +2967,12 @@ create_stmt
 
 			    node->info.index.comment = $15;
 
-                            // TODO: this breaks CS mode when creating vector index with 'with' clause.
+			    // TODO: CUBVEC - Use rule_13 instead of $13
+			    // original code:
                             // int with_online_ret = CONTAINER_AT_0($13);  // 0 for normal, 1 for online no parallel,
                                                         // thread_count + 1 for parallel
-                            int with_online_ret = 0;
+                            int with_online_ret = CONTAINER_AT_0(rule_13);  // 0 for normal, 1 for online no parallel,
+                                                        // thread_count + 1 for parallel
                             bool is_online = with_online_ret > 0;
                             bool is_invisible = $14;
 

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -2959,7 +2959,7 @@ create_stmt
                             // TODO: this breaks CS mode when creating vector index with 'with' clause.
                             // int with_online_ret = CONTAINER_AT_0($13);  // 0 for normal, 1 for online no parallel,
                                                         // thread_count + 1 for parallel
-			    int with_online_ret = 0;
+                            int with_online_ret = 0;
                             bool is_online = with_online_ret > 0;
                             bool is_invisible = $14;
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBVEC-23>

### Purpose

CREATE VECTOR INDEX... WITH (...)

위처럼 vector index를 생성할 시 WITH 구문을 사용할 경우,
CS모드에서 에러가 발생한다. (따라서 CTP 에러를 유발한다.)

Parser의 Create Vector Index 룰에서

With 구문을 받는 $13 룰을 사용하는 부분에 대한

세심한 처리를 하지 않아 생기는 버그이다.

How to reproduce:
```
-- CS Mode
create vector index idx on tbl(vec cosine) with (m = 30, ef_construction = 100);
```

Results in:
```
csql: /home/vimkim/gh/cb/cubvec/src/communication/network_interface_cl.c:6252: int btree_load_index(BTID *, const char *, TP_DOMAIN *, OID *, int, int, int *, int *, HFID *, int, int, OID *, BTID *, const char *, char *, int, char *, int, int, int, SM_INDEX_STATUS): Assertion `index_status != SM_ONLINE_INDEX_BUILDING_IN_PROGRESS || !BTID_IS_NULL (btid)' failed.
```

### Implementation

create vector index with 구문의 역할은 m, ef_construction 등 vector index 생성에 필요한 인자를 받는 것과 같이, 기존 with rule과 매우 다르기 때문에,

기존  with rule ($13) 이 주던 영향을 삭제한다.

```diff 
- //node->info.index.deduplicate_level = CONTAINER_AT_1($13);
+ node->info.index.deduplicate_level = NULL;

...

- // int with_online_ret = CONTAINER_AT_0($13);
+ int with_online_ret = 0;
```

### Remarks

N/A
