### PR TITLE
[CBRD-25358] rev (error check at resolve names): error handling when using for update clause for inline view (#6107)

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -9244,9 +9244,20 @@ pt_resolve_names (PARSER_CONTEXT * parser, PT_NODE * statement, SEMANTIC_CHK_INF
 	}
       else
 	{
-	  /* to process the clause "FOR UPDATE"
-	   * it will be checked at pt_for_update_prepare_query
-	   */
+	  /* Flag all specs */
+	  for (spec = statement->info.query.q.select.from; spec != NULL; spec = spec->next)
+	    {
+	      for (entity = spec->info.spec.flat_entity_list; entity; entity = entity->next)
+		{
+		  if (sm_check_system_class_by_name (entity->info.name.original))
+		    {
+		      PT_ERRORmf2 (parser, entity, MSGCAT_SET_PARSER_RUNTIME, MSGCAT_RUNTIME_IS_NOT_AUTHORIZED_ON,
+				   "UPDATE", entity->info.name.original);
+		      return NULL;
+		    }
+		}
+	      spec->info.spec.flag = (PT_SPEC_FLAG) (spec->info.spec.flag | PT_SPEC_FLAG_FOR_UPDATE_CLAUSE);
+	    }
 	}
     }
 

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -7836,6 +7836,11 @@ pt_for_update_prepare_query_internal (PARSER_CONTEXT * parser, PT_NODE * query)
   from = query->info.query.q.select.from;
   for (spec = from; spec != NULL; spec = spec->next)
     {
+      if (has_for_update && !(spec->info.spec.flag & PT_SPEC_FLAG_FOR_UPDATE_CLAUSE))
+	{
+	  /* skip if the spec is not flagged for FOR UPDATE */
+	  continue;
+	}
       if (spec->info.spec.derived_table != NULL)
 	{
 	  err = pt_for_update_prepare_query_internal (parser, spec->info.spec.derived_table);
@@ -7844,21 +7849,8 @@ pt_for_update_prepare_query_internal (PARSER_CONTEXT * parser, PT_NODE * query)
 	      return err;
 	    }
 	}
-      else if (has_for_update)
+      else
 	{
-	  PT_NODE *entity;
-
-	  for (entity = spec->info.spec.flat_entity_list; entity; entity = entity->next)
-	    {
-	      /* for system class / view, return error */
-	      if (sm_check_system_class_by_name (entity->info.name.original))
-		{
-		  PT_ERRORmf2 (parser, entity, MSGCAT_SET_PARSER_RUNTIME, MSGCAT_RUNTIME_IS_NOT_AUTHORIZED_ON, "UPDATE",
-			       entity->info.name.original);
-		  return MSGCAT_SET_PARSER_RUNTIME;
-		}
-	    }
-
 	  spec->info.spec.flag = (PT_SPEC_FLAG) (spec->info.spec.flag | PT_SPEC_FLAG_FOR_UPDATE_CLAUSE);
 	}
     }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-25358>

#### Purpose
아래의 두 개 문제를 해결

- SELECT r.a FROM db_attribute, (SELECT * FROM t1) r FOR UPDATE OF r 쿼리에서 에러 발생 (정상 처리되어야 함)
- SELECT * FROM db_attribute FOR UPDATE 쿼리에서 "not authorized _db_class" 에러 발생 (db_attribute가 나와야 함)
#### Implementation
Backport from develop

#### Remarks
본 이슈에서 제시된 예시 쿼리 형태의 TC를 만들어 체크할 필요가 있음.