### PR TITLE
[CBRD-26014] bugfix: give a legal identifier name to a column when necessary

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -61,6 +61,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.antlr.v4.runtime.*;
 import org.antlr.v4.runtime.tree.*;
 
@@ -2592,6 +2594,10 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     // Private Static
     // --------------------------------------------------------
 
+    private static String regexId =
+            "^[A-Za-z_\uAC00-\uD7A3][A-Za-z_0-9\uAC00-\uD7A3]*$"; // \uAC00-\uD7A3: Korean
+    private static Pattern patternId = Pattern.compile(regexId);
+
     private static final int ID_LEN_MAX = 222; // see User Manual
 
     private static final BigInteger UINT_LITERAL_MAX =
@@ -2948,11 +2954,12 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
             String afterDot = colName.substring(dotIdx + 1);
             if (afterDot.equalsIgnoreCase(ci.attrName)) {
                 // In this case, colName must be of the form <table name alias>.<attr name>
-                return ci.attrName;
+                colName = ci.attrName;
             }
         }
 
-        return colName;
+        Matcher matcher = patternId.matcher(colName);
+        return matcher.matches() ? colName : null;
     }
 
     private Expr getHostExprFromText(String s, ParserRuleContext ctx) {
@@ -3018,8 +3025,18 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
 
             // convert select list
             selectList = new ArrayList<>();
+            int i = 0;
             for (ColumnInfo ci : sws.selectList) {
-                String col = Misc.getNormalizedText(getColumnNameInSelectList(ci));
+
+                i++;
+
+                String col = getColumnNameInSelectList(ci);
+                if (col == null) {
+                    // column name cannot be a Java identifier
+                    col = "$anonymous" + i;
+                } else {
+                    col = Misc.getNormalizedText(col);
+                }
 
                 // get type of the column
                 Type ty;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26014>

### Purpose

Static SQL SELECT 문의 결과 column 중에 이름이 적법한 PL/CSQL identifier 가 아닌 경우, 
해당 레코드 타입을 정의하는 Java 코드에서  컴파일 에러가 나는 문제 수정

### Implementation

Static SQL SELECT 문의 결과 column 중에 이름이 적법한 PL/CSQL identifier 가 아닌 경우, 
그 column 에 "$anonymous<컬럼순번>" 형태의 이름을 주어 Javac 컴파일 에러가 나지 않도록 함.

### Remarks

문제의 경우 해당 컬럼은 어짜피 적법한 PL/CSQL identifier 로 참조가 불가능하므로 
"$anonymous<n>" 형태의 이름을 주어도 상관없음. 
이 이름은 참조될 일이 없고, Javac 컴파일 에러를 피하기 위한 목적.
