### PR TITLE
[CBRD-26015] Fix flashback utility unable to restart when previous execution isn't terminated after forced quit (Ctrl+C)

### DIFF
--- a/src/transaction/flashback.c
+++ b/src/transaction/flashback.c
@@ -301,6 +301,8 @@ flashback_make_summary_list (THREAD_ENTRY * thread_p, FLASHBACK_SUMMARY_CONTEXT 
 
   log_page_p = (LOG_PAGE *) PTR_ALIGN (log_pgbuf, MAX_ALIGNMENT);
 
+  LOG_TDES *tdes = LOG_FIND_CURRENT_TDES (thread_p);
+
   assert (!LSA_ISNULL (&context->end_lsa));
 
   LSA_COPY (&process_lsa, &(context->end_lsa));
@@ -315,6 +317,12 @@ flashback_make_summary_list (THREAD_ENTRY * thread_p, FLASHBACK_SUMMARY_CONTEXT 
 
   while (LSA_GE (&process_lsa, &context->start_lsa))
     {
+      if (tdes->interrupt == true)
+	{
+	  error = ER_INTERRUPTED;
+	  goto exit;
+	}
+
       LSA_COPY (&cur_log_rec_lsa, &process_lsa);
       log_rec_header = LOG_GET_LOG_RECORD_HEADER (log_page_p, &process_lsa);
 
@@ -776,6 +784,8 @@ flashback_make_loginfo (THREAD_ENTRY * thread_p, FLASHBACK_LOGINFO_CONTEXT * con
 
   OID classoid;
 
+  LOG_TDES *tdes = LOG_FIND_CURRENT_TDES (thread_p);
+
   if (LSA_ISNULL (&context->start_lsa))
     {
       error = flashback_find_start_lsa (thread_p, context);
@@ -815,6 +825,12 @@ flashback_make_loginfo (THREAD_ENTRY * thread_p, FLASHBACK_LOGINFO_CONTEXT * con
 
   while (!LSA_ISNULL (&process_lsa) && (LSA_LE (&process_lsa, &context->end_lsa) || num_loginfo < context->num_loginfo))
     {
+      if (tdes->interrupt == true)
+	{
+	  error = ER_INTERRUPTED;
+	  goto error;
+	}
+
       if (log_page_p->hdr.logical_pageid != process_lsa.pageid)
 	{
 	  error = logpb_fetch_page (thread_p, &process_lsa, LOG_CS_SAFE_READER, log_page_p);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26015

### Purpose

 flashback 유틸리티 실행 중 Ctrl+C를 눌러 강제 종료한 후 다시 flashback을 실행하면 프로세스는 존재하지 않으나

"Flashback is already running. Flashback cannot be run by two processes." 메시지가 출력되며 실행되지 않는 문제가 발생합니다.

먼저 수행한 flashback이 종료된 이후에 다시 실행 가능합니다.

### Implementation

client와 server 간 연결이 끊기게 되면 net_server_conn_down에서 log_tdes의 interrupt를 true로 변경해준다.
이 값을 이용해서 flashback 작업을 수행하는 도중에 interrupt check를 하는 작업을 추가

### Remarks

N/A
