### PR TITLE
[CBRD-26016] optional clear objects at the signal handler of cas

### DIFF
--- a/src/broker/cas.c
+++ b/src/broker/cas.c
@@ -1670,11 +1670,15 @@ cas_sig_handler (int signo)
   is_doing_signal_handler = 1;
 
   signal (signo, SIG_IGN);
-  cas_free (true);
-  as_info->pid = 0;
-  as_info->uts_status = UTS_STATUS_RESTART;
 
   er_print_crash_callstack (signo);
+
+  if (signo == SIGTERM || signo == SIGABRT || signo == SIGINT)
+    {
+      cas_free (true);
+    }
+  as_info->pid = 0;
+  as_info->uts_status = UTS_STATUS_RESTART;
 
 #ifdef _GCOV
   exit (0);

--- a/src/compat/db_admin.c
+++ b/src/compat/db_admin.c
@@ -1009,7 +1009,7 @@ db_shutdown (void)
 void
 db_shutdown_without_request_to_server (void)
 {
-  boot_client_all_finalize (true);
+  boot_client_all_finalize (OPTIONAL_FINALIZATION);
 }
 
 int

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -272,7 +272,7 @@ boot_initialize_client (BOOT_CLIENT_CREDENTIAL * client_credential, BOOT_DB_PATH
 
   if (!boot_Is_client_all_final)
     {
-      boot_client_all_finalize (true);
+      boot_client_all_finalize (ALL_FINALIZATION);
     }
 
 #if defined(WINDOWS)
@@ -715,7 +715,7 @@ boot_restart_client (BOOT_CLIENT_CREDENTIAL * client_credential)
 
   if (!boot_Is_client_all_final)
     {
-      boot_client_all_finalize (true);
+      boot_client_all_finalize (ALL_FINALIZATION);
     }
 
 #if defined(WINDOWS)
@@ -1387,7 +1387,7 @@ boot_shutdown_client (bool is_er_final)
 #endif /* !CS_MODE */
 	}
 
-      boot_client_all_finalize (is_er_final);
+      boot_client_all_finalize (is_er_final ? ALL_FINALIZATION : EXCEPT_ER_FINALIZATION);
     }
 
   return NO_ERROR;
@@ -1475,14 +1475,16 @@ boot_server_die_or_changed (void)
  *
  * return : nothing
  *
- *   is_er_final(in): Terminate the error module..
- *
+ *   final_level(in): finalizing objects level
+ *                    ALL_FINALIZATION       : all finalization
+ *                    EXCEPT_ER_FINALIZATION : except er_final()
+ *                    OPTIONAL_FINALIZATION  : finalize only objects that are not cleared while running
  *
  * Note: Terminate every single module of the client. This function is called
  *       during the shutdown of the client.
  */
 void
-boot_client_all_finalize (bool is_er_final)
+boot_client_all_finalize (int final_level)
 {
   if (BOOT_IS_CLIENT_RESTARTED () || boot_Is_client_all_final == false)
     {
@@ -1508,12 +1510,16 @@ boot_client_all_finalize (bool is_er_final)
       sm_flush_static_methods ();
       set_final ();
       parser_final ();
-      tr_final ();
-      au_final ();
-      sm_final ();
-      ws_final ();
-      es_final ();
-      tp_final ();
+
+      if (final_level != OPTIONAL_FINALIZATION)
+	{
+	  tr_final ();
+	  au_final ();
+	  sm_final ();
+	  ws_final ();
+	  es_final ();
+	  tp_final ();
+	}
 
 #if !defined(WINDOWS)
       (void) dl_destroy_module ();
@@ -1525,7 +1531,7 @@ boot_client_all_finalize (bool is_er_final)
       area_final ();
 
       msgcat_final ();
-      if (is_er_final)
+      if (final_level != EXCEPT_ER_FINALIZATION)
 	{
 	  er_final (ER_ALL_FINAL);
 	}
@@ -1549,7 +1555,6 @@ boot_client_all_finalize (bool is_er_final)
       boot_client (NULL_TRAN_INDEX, TRAN_LOCK_INFINITE_WAIT, TRAN_DEFAULT_ISOLATION_LEVEL ());
       boot_Is_client_all_final = true;
     }
-
 }
 
 #if defined(CS_MODE)

--- a/src/transaction/boot_cl.h
+++ b/src/transaction/boot_cl.h
@@ -41,6 +41,13 @@
 
 #define BOOT_IS_CLIENT_RESTARTED() (tm_Tran_index != NULL_TRAN_INDEX)
 
+enum
+{
+  ALL_FINALIZATION = 0,
+  EXCEPT_ER_FINALIZATION = 1,
+  OPTIONAL_FINALIZATION = 2
+};
+
 /* Volume assigned for new files/objects  (e.g., heap files) */
 extern VOLID boot_User_volid;
 #if defined(CS_MODE)
@@ -53,10 +60,10 @@ extern int boot_initialize_client (BOOT_CLIENT_CREDENTIAL * client_credential, B
 				   PGLENGTH db_desired_pagesize, DKNPAGES log_npages, PGLENGTH db_desired_log_page_size,
 				   const char *lang_charset);
 extern int boot_restart_client (BOOT_CLIENT_CREDENTIAL * client_credential);
-extern int boot_shutdown_client (bool iserfinal);
+extern int boot_shutdown_client (bool is_er_final);
 extern void boot_donot_shutdown_client_at_exit (void);
 extern void boot_server_die_or_changed (void);
-extern void boot_client_all_finalize (bool iserfinal);
+extern void boot_client_all_finalize (int final_level);
 #if defined(CS_MODE)
 extern char *boot_get_host_connected (void);
 #if defined(ENABLE_UNUSED_FUNCTION)

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -143,7 +143,7 @@ extern int catcls_get_db_collation (THREAD_ENTRY * thread_p, LANG_COLL_COMPAT **
 extern int catcls_find_and_set_cached_class_oid (THREAD_ENTRY * thread_p);
 
 #if defined(SA_MODE)
-extern void boot_client_all_finalize (bool is_er_final);
+extern void boot_client_all_finalize (int final_level);
 #endif /* SA_MODE */
 
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26016

- Since signal handlers occur randomly, it is possible for the task's object clearing and the signal handler's object clearing to occur at the same time.
- Therefore, I modify that objects that can be cleared during operation are excluded to clearing it in the signal handler.
