### PR TITLE
[CBRD-25864] The problem that an empty structure table is scanned for the first time, when a partition table is joined

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -9091,6 +9091,7 @@ qexec_open_scan (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * curr_spec, VAL_LIST
   bool mvcc_select_lock_needed = false;
   int error_code = NO_ERROR;
   DBLINK_HOST_VARS host_vars;
+  SCAN_CODE s_parts;
 
   if (curr_spec->pruning_type == DB_PARTITIONED_CLASS && !curr_spec->pruned)
     {
@@ -9393,6 +9394,16 @@ qexec_open_scan (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * curr_spec, VAL_LIST
   if (p_mvcc_select_lock_needed)
     {
       *p_mvcc_select_lock_needed = mvcc_select_lock_needed;
+    }
+
+  if (scan_op_type == S_SELECT && curr_spec->pruning_type == DB_PARTITIONED_CLASS && curr_spec->pruned)
+    {
+      s_parts = qexec_init_next_partition (thread_p, curr_spec);
+      if (s_parts != S_SUCCESS)
+	{
+	  ASSERT_ERROR ();
+	  goto exit_on_error;
+	}
     }
 
   return NO_ERROR;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-25864>

### Purpose

파티션 테이블을 사용할 경우 성능 저하가 발생하는 원인에 대한 개선입니다.
Nested Loop 조인에서 파티션 테이블이 후행 테이블로 사용될 때, 첫 번째로 빈 구조의 파티션 테이블을 조회하는 과정에서 선행 테이블 전체를 불필요하게 스캔하게 되는 문제가 있었습니다.

### Implementation

SELECT 쿼리 실행 중 partitioned table(≠ partition table)에 대해 qexec_open_scan()을 호출하는 시점에 pruning이 완료된 경우, 접근할 첫 번째 파티션을 spec->current에 미리 저장하도록 변경하였습니다. 이를 통해 초기 접근 시 불필요한 빈 파티션을 조회하지 않도록 했습니다.

### Remarks

기존 구현에서는 빈 partitioned table을 먼저 조회하여 S_END를 반환받은 후, qexec_init_next_partition()에서 다음 partition table을 spec->current에 설정하고 다시 접근하는 방식이었습니다. 이 과정이 불필요한 오버헤드를 유발하였기 때문에 개선이 필요했습니다.
