### PR TITLE
[CBRD-26018] Fix incorrect database name used during Server Revive restart

### DIFF
--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -411,6 +411,18 @@ server_entry (int pid, const std::string &exec_path, const std::string &args,
     }
 }
 
+server_monitor::server_entry::~server_entry ()
+{
+  if (m_argv)
+    {
+      for (int i = 0; m_argv[i] != nullptr; i++)
+	{
+	  delete[] m_argv[i];
+	}
+      m_argv.reset();
+    }
+}
+
 int
 server_monitor::server_entry::get_pid () const
 {

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -477,6 +477,7 @@ server_monitor::server_entry::proc_make_arg (const std::string &args)
     {
       m_argv[i] = new char[arg.size () + 1];
       std::copy (arg.begin (), arg.end (), m_argv[i]);
+      m_argv[i][arg.size()] = '\0';
       i++;
     }
   m_argv[args.size()] = nullptr;

--- a/src/executables/master_server_monitor.cpp
+++ b/src/executables/master_server_monitor.cpp
@@ -492,5 +492,5 @@ server_monitor::server_entry::proc_make_arg (const std::string &args)
       m_argv[i][arg.size()] = '\0';
       i++;
     }
-  m_argv[args.size()] = nullptr;
+  m_argv[i] = NULL;
 }

--- a/src/executables/master_server_monitor.hpp
+++ b/src/executables/master_server_monitor.hpp
@@ -117,7 +117,7 @@ class server_monitor
       public:
 	server_entry (int pid, const std::string &exec_path, const std::string &args,
 		      std::chrono::steady_clock::time_point revive_time);
-	~server_entry () {};
+	~server_entry ();
 
 	server_entry (const server_entry &) = delete;
 	server_entry (server_entry &&) = default;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26018>

### Purpose

- Server Revive 기능을 통한 데이터베이스 재구동이 반복되는 상황에서, 잘못된 데이터베이스 이름으로 재구동을 시도하는 현상이 발견됨.
  - 해당 문제는 `server_entry`의 `args` 값을 `argv`로 변환하는 과정에서 각 token의 뒤에 `nullptr`를 추가하지 않아서 생기는 문제임.

### Implementation

- `proc_make_arg` 함수 수정
  - `argv`의 각 token 뒤에 `\0` character 추가
