### PR TITLE
[CBRD-26019] Remove incorrect PARSER_VARCHAR *val declarations in plcsql_text_part

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -12993,28 +12993,28 @@ plcsql_text_part
 		DBG_PRINT}}
         | CHAR_STRING
 		{{ DBG_TRACE_GRAMMAR(plcsql_text_part, | CHAR_STRING);
-                    PARSER_VARCHAR * val = pt_append_string(this_parser, NULL, "'");
+                    char* val = pt_append_string(this_parser, NULL, "'");
                     val = pt_append_string(this_parser, val, $1);
                     val = pt_append_string(this_parser, val, "'");
                     $$ = val;
 		DBG_PRINT}}
         | DelimitedIdName
 		{{ DBG_TRACE_GRAMMAR(plcsql_text_part, | DelimitedIdName);
-                    PARSER_VARCHAR * val = pt_append_string(this_parser, NULL, "\"");
+                    char* val = pt_append_string(this_parser, NULL, "\"");
                     val = pt_append_string(this_parser, val, $1);
                     val = pt_append_string(this_parser, val, "\"");
                     $$ = val;
 		DBG_PRINT}}
         | BracketDelimitedIdName
 		{{ DBG_TRACE_GRAMMAR(plcsql_text_part, | BracketDelimitedIdName);
-                    PARSER_VARCHAR * val = pt_append_string(this_parser, NULL, "[");
+                    char* val = pt_append_string(this_parser, NULL, "[");
                     val = pt_append_string(this_parser, val, $1);
                     val = pt_append_string(this_parser, val, "]");
                     $$ = val;
 		DBG_PRINT}}
         | BacktickDelimitedIdName
 		{{ DBG_TRACE_GRAMMAR(plcsql_text_part, | BacktickDelimitedIdName);
-                    PARSER_VARCHAR * val = pt_append_string(this_parser, NULL, "`");
+                    char* val = pt_append_string(this_parser, NULL, "`");
                     val = pt_append_string(this_parser, val, $1);
                     val = pt_append_string(this_parser, val, "`");
                     $$ = val;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26019

### Purpose

- Since pt_append_string() returns a char*, declaring PARSER_VARCHAR *val was misleading and unnecessary.

### Implementation

- trivial: revise from PARSER_VARCHAR* to char* for the val

### Remarks

N/A
