### PR TITLE
[CBRD-26026] perf: Reduce sizeof DB_VALUE by 8 bytes

### DIFF
--- a/src/compat/dbtype_def.h
+++ b/src/compat/dbtype_def.h
@@ -1020,8 +1020,8 @@ extern "C"
       unsigned char compressed_need_clear;
       int size;
       const char *buf;
-      int compressed_size;
       char *compressed_buf;
+      int compressed_size;
       int length;		/* Only Use for group_concat() now */
     } medium;
     struct


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26026>

### Purpose

DB_CHAR 유니온 내의 int와 char * 선언을 교환하면,
DB_CHAR의 크기가 8바이트 감소하고 (40 -> 32),
그 결과 DB_ENUM_ELEMENT의 크기가 8바이트 감소하며 (48 -> 40),
이어서 DB_DATA(유니온)의 크기가 8바이트 감소하고 (48 -> 40),
최종적으로 DB_VALUE의 크기가 8바이트 감소합니다 (72 -> 64).

---

As Is
```
sizeof DB_VALUE: 72
sizeof DB_DATA: 48
sizeof DB_ENUM_ELEMENT: 48
sizeof DB_CHAR: 40
...

```

To Be
```
- sizeof DB_CHAR
Before: 40 bytes
After: 32 bytes

- sizeof DB_DATA
Before: 48 bytes
After: 40 bytes

...
```

### Implementation

![image](https://github.com/user-attachments/assets/2d1bb178-9202-42c7-aa42-37d295853fc8)

### Remarks

@hgryoo 의 피드백: DB_DATA의 Union의 사이즈가 성능에 영향을 줄 수 있다.

위 피드백을 토대로 CUBVEC 프로젝트에서 DB_DATA에 담기는 DB_VECTOR_FLOAT을 최적화하는 과정에서 발견했습니다.

#### 확인 방법

```c
  printf("sizeof DB_VALUE: %zu\n", sizeof (DB_VALUE));
  printf("sizeof DB_DATA: %zu\n", sizeof (DB_DATA));
  printf("sizeof DB_ENUM_ELEMENT: %zu\n", sizeof (DB_ENUM_ELEMENT));
  printf("sizeof DB_CHAR: %zu\n", sizeof (DB_CHAR));
```


