### PR TITLE
[CBRD-25985] Fix memory leak caused in method_scan

### DIFF
--- a/src/method/method_scan.cpp
+++ b/src/method/method_scan.cpp
@@ -66,8 +66,14 @@ namespace cubscan
 	  m_list_id = list_id;
 	  int arg_count = m_arg_count = m_list_id->type_list.type_cnt;
 
+	  if (m_arg_vector)
+	    {
 	  m_arg_vector = (DB_VALUE *) db_private_alloc (thread_p, sizeof (DB_VALUE) * arg_count);
+	    }
+	  if (m_arg_dom_vector)
+	    {
 	  m_arg_dom_vector = (TP_DOMAIN **) db_private_alloc (thread_p, sizeof (TP_DOMAIN *) * arg_count);
+	    }
 
 	  for (int i = 0; i < arg_count; i++)
 	    {

--- a/src/method/method_scan.cpp
+++ b/src/method/method_scan.cpp
@@ -66,11 +66,12 @@ namespace cubscan
 	  m_list_id = list_id;
 	  int arg_count = m_arg_count = m_list_id->type_list.type_cnt;
 
-	  if (m_arg_vector)
+	  if (!m_arg_vector)
 	    {
 	  m_arg_vector = (DB_VALUE *) db_private_alloc (thread_p, sizeof (DB_VALUE) * arg_count);
 	    }
-	  if (m_arg_dom_vector)
+
+	  if (!m_arg_dom_vector)
 	    {
 	  m_arg_dom_vector = (TP_DOMAIN **) db_private_alloc (thread_p, sizeof (TP_DOMAIN *) * arg_count);
 	    }

--- a/src/method/method_scan.cpp
+++ b/src/method/method_scan.cpp
@@ -217,7 +217,6 @@ namespace cubscan
 	{
 	  db_value_clear (&m_arg_vector[i]);
 	  db_make_null (&m_arg_vector[i]);
-	  m_arg_dom_vector[i] = nullptr;
 	}
 
       return scan_code;

--- a/src/method/method_scan.cpp
+++ b/src/method/method_scan.cpp
@@ -68,12 +68,12 @@ namespace cubscan
 
 	  if (!m_arg_vector)
 	    {
-	  m_arg_vector = (DB_VALUE *) db_private_alloc (thread_p, sizeof (DB_VALUE) * arg_count);
+	      m_arg_vector = (DB_VALUE *) db_private_alloc (thread_p, sizeof (DB_VALUE) * arg_count);
 	    }
 
 	  if (!m_arg_dom_vector)
 	    {
-	  m_arg_dom_vector = (TP_DOMAIN **) db_private_alloc (thread_p, sizeof (TP_DOMAIN *) * arg_count);
+	      m_arg_dom_vector = (TP_DOMAIN **) db_private_alloc (thread_p, sizeof (TP_DOMAIN *) * arg_count);
 	    }
 
 	  for (int i = 0; i < arg_count; i++)

--- a/src/method/method_scan.cpp
+++ b/src/method/method_scan.cpp
@@ -52,7 +52,7 @@ namespace cubscan
 
       if (m_method_group == nullptr) // signature is not initialized
 	{
-	  m_method_group = new cubmethod::method_invoke_group (*sig_array);
+	  m_method_group = new cubmethod::method_invoke_group (sig_array);
 	  if (!m_method_group)
 	    {
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1,
@@ -64,12 +64,14 @@ namespace cubscan
       if (m_list_id == nullptr)
 	{
 	  m_list_id = list_id;
-	  int arg_count = m_list_id->type_list.type_cnt;
-	  m_arg_vector.resize (arg_count);
-	  m_arg_dom_vector.resize (arg_count);
+	  int arg_count = m_arg_count = m_list_id->type_list.type_cnt;
+
+	  m_arg_vector = (DB_VALUE *) db_private_alloc (thread_p, sizeof (DB_VALUE) * arg_count);
+	  m_arg_dom_vector = (TP_DOMAIN **) db_private_alloc (thread_p, sizeof (TP_DOMAIN *) * arg_count);
 
 	  for (int i = 0; i < arg_count; i++)
 	    {
+	      db_make_null (&m_arg_vector [i]);
 	      TP_DOMAIN *domain = list_id->type_list.domp[i];
 	      if (domain == NULL || domain->type == NULL)
 		{
@@ -78,18 +80,6 @@ namespace cubscan
 	      m_arg_dom_vector[i] = domain;
 	    }
 	}
-
-#if 0 // TODO
-      for (int i = 0; i < sig_array->num_sigs; i++)
-	{
-	  cubpl::pl_signature &sig = sig_array->sigs[i];
-	  for (int j = 0; j < sig.arg.arg_size; j++)
-	    {
-	      int idx = sig.ext.method.arg_pos[i];
-	      m_arg_use_vector [idx] = true;
-	    }
-	}
-#endif
 
       if (m_dbval_list == nullptr)
 	{
@@ -102,6 +92,7 @@ namespace cubscan
 	      return ER_OUT_OF_VIRTUAL_MEMORY;
 	    }
 	}
+
       return NO_ERROR;
     }
 
@@ -109,20 +100,36 @@ namespace cubscan
     scanner::clear (bool is_final)
     {
       close_value_array ();
-      pr_clear_value_vector (m_arg_vector);
 
-      if (is_final && m_method_group)
+      for (int i = 0; m_arg_vector && i < m_arg_count; i++)
 	{
-	  m_method_group->reset (true);
-	  m_method_group->end ();
+	  db_value_clear (&m_arg_vector[i]);
+	  db_make_null (&m_arg_vector[i]);
+	}
 
-// TODO
-#if 0
-	  cubmethod::runtime_context *rctx = m_method_group->get_runtime_context ();
-	  rctx->pop_stack (m_thread_p, m_method_group);
-#endif
 
-	  m_method_group = nullptr; // will be destroyed by cubmethod::runtime_context
+      if (is_final)
+	{
+	  if (m_method_group)
+	    {
+	      m_method_group->reset (true);
+	      m_method_group->end ();
+
+	      delete m_method_group;
+	      m_method_group = nullptr; // will be destroyed by cubmethod::runtime_context
+	    }
+
+	  if (m_arg_vector)
+	    {
+	      db_private_free_and_init (m_thread_p, m_arg_vector);
+	    }
+
+	  if (m_arg_dom_vector)
+	    {
+	      // freeing elements is not required.
+	      // TP_DOMAIN is managed by another module.
+	      db_private_free_and_init (m_thread_p, m_arg_dom_vector);
+	    }
 	}
     }
 
@@ -159,7 +166,7 @@ namespace cubscan
 
       int error = NO_ERROR;
 
-      std::vector<std::reference_wrapper<DB_VALUE>> arg_wrapper (m_arg_vector.begin (), m_arg_vector.end ());
+      std::vector<std::reference_wrapper<DB_VALUE>> arg_wrapper (m_arg_vector, m_arg_vector + m_arg_count);
 
       if (scan_code == S_SUCCESS && (error = m_method_group->execute (arg_wrapper)) != NO_ERROR)
 	{
@@ -206,7 +213,12 @@ namespace cubscan
 	}
 
       // clear
-      pr_clear_value_vector (m_arg_vector);
+      for (int i = 0; i < m_arg_count; i++)
+	{
+	  db_value_clear (&m_arg_vector[i]);
+	  db_make_null (&m_arg_vector[i]);
+	  m_arg_dom_vector[i] = nullptr;
+	}
 
       return scan_code;
     }

--- a/src/method/method_scan.hpp
+++ b/src/method/method_scan.hpp
@@ -93,9 +93,9 @@ namespace cubscan
 	qfile_list_id *m_list_id; 		/* list file from cselect */
 	qfile_list_scan_id m_scan_id;	/* for scanning list file */
 
-	std::vector<TP_DOMAIN *> m_arg_dom_vector; /* arg value's domain */
-	std::vector<DB_VALUE> m_arg_vector;        /* arg value */
-	std::vector<bool> m_arg_use_vector;        /* arg is used for method, should be prepared */
+	int m_arg_count;
+	TP_DOMAIN **m_arg_dom_vector; /* arg value's domain */
+	DB_VALUE *m_arg_vector;        /* arg value */
 
 	qproc_db_value_list *m_dbval_list; /* result */
     };

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -12781,7 +12781,8 @@ pt_to_cselect_table_spec_list (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE 
   XASL_NODE *subquery_proc;
   REGU_VARIABLE_LIST regu_attributes;
   ACCESS_SPEC_TYPE *access;
-  PL_SIGNATURE_ARRAY_TYPE *sig_array;
+  PL_SIGNATURE_ARRAY_TYPE *sig_array = NULL;
+  PL_SIGNATURE_TYPE *sig_list = NULL;
   int idx = 0;
 
   /* every cselect must have a subquery for its source list file, this is pointed to by the methods of the cselect */
@@ -12792,10 +12793,21 @@ pt_to_cselect_table_spec_list (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE 
 
   subquery_proc = (XASL_NODE *) src_derived_tbl->info.spec.derived_table->info.query.xasl;
 
-  regu_new (sig_array, pt_length_of_list (cselect));
+  regu_alloc (sig_array);
   if (sig_array == NULL)
     {
       return NULL;
+    }
+  new (sig_array) cubpl::pl_signature_array ();
+
+  sig_array->num_sigs = pt_length_of_list (cselect);
+
+  regu_array_alloc (&sig_list, sig_array->num_sigs);
+  sig_array->sigs = sig_list;
+
+  for (int i = 0; i < sig_array->num_sigs; i++)
+    {
+      new (&sig_array->sigs[i]) cubpl::pl_signature ();
     }
 
   for (PT_NODE * node = cselect; node != NULL; node = node->next)
@@ -12803,7 +12815,6 @@ pt_to_cselect_table_spec_list (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE 
       int error = jsp_make_pl_signature (parser, node, src_derived_tbl->info.spec.as_attr_list, sig_array->sigs[idx]);
       if (error != NO_ERROR)
 	{
-	  regu_delete (sig_array);
 	  return NULL;
 	}
       idx++;
@@ -12816,11 +12827,7 @@ pt_to_cselect_table_spec_list (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE 
   access =
     pt_make_cselect_access_spec (subquery_proc, sig_array, ACCESS_METHOD_SEQUENTIAL, NULL, NULL, regu_attributes);
 
-  if (!access)
-    {
-      regu_delete (sig_array);
-    }
-  else if (subquery_proc && sig_array && (regu_attributes || !spec->info.spec.as_attr_list))
+  if (subquery_proc && sig_array && (regu_attributes || !spec->info.spec.as_attr_list))
     {
       return access;
     }

--- a/src/parser/xasl_regu_alloc.cpp
+++ b/src/parser/xasl_regu_alloc.cpp
@@ -291,8 +291,25 @@ regu_init (cubxasl::sp_node &sp)
   regu_alloc (sp.sig);
   if (sp.sig)
     {
-      new (sp.sig) PL_SIGNATURE_TYPE ();
+      new (sp.sig) cubpl::pl_signature();
+      regu_init (*sp.sig);
     }
+}
+
+void
+regu_init (cubpl::pl_signature &sig)
+{
+  sig.name = NULL;
+  sig.auth = NULL;
+  sig.type = PL_TYPE_NONE;
+  sig.result_type = 0;
+}
+
+void
+regu_init (cubpl::pl_signature_array &sig_array)
+{
+  sig_array.sigs = NULL;
+  sig_array.num_sigs = 0;
 }
 
 void

--- a/src/parser/xasl_regu_alloc.hpp
+++ b/src/parser/xasl_regu_alloc.hpp
@@ -79,18 +79,14 @@ void regu_init (xasl_node &node);
 void regu_init (sort_list &sl);
 void regu_init (qfile_list_id &list_id);
 void regu_init (access_spec_node &spec);
+void regu_init (cubpl::pl_signature &sig);
+void regu_init (cubpl::pl_signature_array &sig_array);
 
 template <typename T>
 void regu_alloc (T *&ptr);
 
 template <typename T>
 void regu_array_alloc (T **ptr, size_t size);
-
-template <typename T, typename ... Args>
-void regu_new (T *&ptr, Args &&... args);
-
-template <typename T>
-void regu_delete (T *&ptr);
 
 /* for regu_machead_array () */
 int *regu_int_array_alloc (int size);
@@ -125,26 +121,6 @@ regu_alloc (T *&ptr)
       return;
     }
   regu_init (*ptr);
-}
-
-template <typename T, typename ... Args>
-void
-regu_new (T *&ptr, Args &&... args)
-{
-  ptr = reinterpret_cast<T *> (pt_alloc_packing_buf ((int) sizeof (T)));
-  if (ptr == NULL)
-    {
-      regu_set_error_with_zero_args (ER_REGU_NO_SPACE);
-      return;
-    }
-  new (ptr) T (std::forward<Args> (args)...);
-}
-
-template <typename T>
-void
-regu_delete (T *&ptr)
-{
-  ptr->~T (); // call destructor, placement new in regu_new ()
 }
 
 template <typename T>

--- a/src/sp/method_invoke_group.cpp
+++ b/src/sp/method_invoke_group.cpp
@@ -45,24 +45,24 @@ namespace cubmethod
 //////////////////////////////////////////////////////////////////////////
 // Method Group to invoke together
 //////////////////////////////////////////////////////////////////////////
-  method_invoke_group::method_invoke_group (cubpl::pl_signature_array &sig_array)
+  method_invoke_group::method_invoke_group (cubpl::pl_signature_array *sig_array)
     : m_id ((std::uint64_t) this)
     , m_stack (nullptr)
     , m_sig_array (sig_array)
   {
-    assert (sig_array.num_sigs > 0);
+    assert (sig_array->num_sigs > 0);
 
     // assert
 #if !defined (NDEBUG)
-    for (int i = 0; i < sig_array.num_sigs; i++)
+    for (int i = 0; i < sig_array->num_sigs; i++)
       {
-	assert (PL_TYPE_IS_METHOD (sig_array.sigs[i].type));
+	assert (PL_TYPE_IS_METHOD (sig_array->sigs[i].type));
       }
 #endif
 
     DB_VALUE v;
     db_make_null (&v);
-    m_result_vector.resize (sig_array.num_sigs, v);
+    m_result_vector.resize (sig_array->num_sigs, v);
   }
 
   method_invoke_group::~method_invoke_group ()
@@ -73,7 +73,7 @@ namespace cubmethod
   DB_VALUE &
   method_invoke_group::get_return_value (int index)
   {
-    assert (index >= 0 && index < (int) m_sig_array.num_sigs);
+    assert (index >= 0 && index < (int) m_sig_array->num_sigs);
     return m_result_vector[index];
   }
 
@@ -122,12 +122,12 @@ namespace cubmethod
 	goto exit;
       }
 
-    for (int i = 0; i < m_sig_array.num_sigs; i++)
+    for (int i = 0; i < m_sig_array->num_sigs; i++)
       {
 	int req_id = m_stack->get_and_increment_request_id ();
 	// invoke
 	cubmethod::header header (s_id, METHOD_REQUEST_INVOKE /* default */, 0);
-	error = xs_callback_send_args (m_stack->get_thread_entry (), header, m_id, m_sig_array.sigs[i]);
+	error = xs_callback_send_args (m_stack->get_thread_entry (), header, m_id, m_sig_array->sigs[i]);
 	if (error != NO_ERROR)
 	  {
 	    break;
@@ -229,7 +229,7 @@ exit:
   int
   method_invoke_group::get_num_methods ()
   {
-    return m_sig_array.num_sigs;
+    return m_sig_array->num_sigs;
   }
 
   std::string

--- a/src/sp/method_invoke_group.hpp
+++ b/src/sp/method_invoke_group.hpp
@@ -67,7 +67,7 @@ namespace cubmethod
   {
     public:
       method_invoke_group () = delete; // Not DefaultConstructible
-      method_invoke_group (cubpl::pl_signature_array &sig);
+      method_invoke_group (cubpl::pl_signature_array *sig);
 
       method_invoke_group (method_invoke_group &&other) = delete; // Not MoveConstructible
       method_invoke_group (const method_invoke_group &copy) = delete; // Not CopyConstructible
@@ -104,7 +104,7 @@ namespace cubmethod
 
       METHOD_GROUP_ID m_id;
       cubpl::execution_stack *m_stack;
-      cubpl::pl_signature_array &m_sig_array;
+      cubpl::pl_signature_array *m_sig_array;
 
       std::vector <DB_VALUE> m_result_vector;	/* placeholder for result value */
   };

--- a/src/sp/pl_signature.cpp
+++ b/src/sp/pl_signature.cpp
@@ -388,32 +388,14 @@ namespace cubpl
   }
 
   pl_signature_array::pl_signature_array ()
-    :pl_signature_array (0)
-  {}
-
-  pl_signature_array::pl_signature_array (int num)
-    : num_sigs {num}
+    : num_sigs {0}
+    , sigs {nullptr}
   {
 #if defined (SERVER_MODE)
     is_disposable = (thread_get_thread_entry_info ()->private_heap_id != 0);
 #else
     is_disposable = true;
 #endif
-
-    if (num <= 0)
-      {
-	sigs = nullptr;
-      }
-    else
-      {
-#if defined(MMON_DEBUG_LEVEL)
-	sigs = new  pl_signature[num];
-#else
-	sigs = new (std::nothrow) pl_signature[num];
-#endif
-
-	assert_release (sigs != NULL);
-      }
   }
 
   pl_signature_array::~pl_signature_array ()


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25985

### Purpose

- cubmethod::scanner::init 에서 보고되는 메모리 릭 수정
- destructor가 호출되지 않아 method_scan 객체의 메모리 공간은 제거되지만, 그 C++ STL 멤버 변수들이 할당한 공간이 제거되지 않음
- SCAN_ID와 관련 구조를 memset 으로 한꺼번에 날려버리는 패턴이 있으므로 C++ STL을 사용하는 부분을 제거하고 POD struct로 변경

### Implementation

- C++ 객체가 아닌 모두 C 구조로 변경하고 명시적인 제거 코드 추가

### Remarks

N/A
