### PR TITLE
[CBRD-26030] upgrade action runner image version refer to the deprecated image.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -137,14 +137,13 @@ jobs:
         run: |
           sudo apt-get install -yq wget build-essential
 
-          # Download cppcheck-2.4.1 source
+          # Download cppcheck-2.13.0 source
           wd=`pwd`
           cd ..
-          # wget https://github.com/CUBRID/3rdparty/raw/develop/cppcheck/2.4.1.tar.gz
-          wget https://github.com/danmar/cppcheck/archive/refs/tags/2.13.0.tar.gz
+          wget https://github.com/CUBRID/3rdparty/raw/develop/cppcheck/2.13.0.tar.gz
           tar xf 2.13.0.tar.gz
 
-          # build cppcheck-2.4.1
+          # build cppcheck-2.13.0
           cd cppcheck-2.13.0
           make -j4 MATCHCOMPILER=yes CFGDIR=cfg CXXFLAGS="-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function"
           echo "CPPCHECK_PATH=`pwd`" >> $GITHUB_ENV

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -146,7 +146,7 @@ jobs:
 
           # build cppcheck-2.4.1
           cd cppcheck-2.13.0
-          make -j4 SRCDIR=build CFGDIR=cfg CXXFLAGS="-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function"
+          make -j4 MATCHCOMPILER=yes CFGDIR=cfg CXXFLAGS="-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function"
           echo "CPPCHECK_PATH=`pwd`" >> $GITHUB_ENV
 
           cd $wd

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -140,11 +140,12 @@ jobs:
           # Download cppcheck-2.4.1 source
           wd=`pwd`
           cd ..
-          wget https://github.com/CUBRID/3rdparty/raw/develop/cppcheck/2.4.1.tar.gz
-          tar xf 2.4.1.tar.gz
+          # wget https://github.com/CUBRID/3rdparty/raw/develop/cppcheck/2.4.1.tar.gz
+          wget https://github.com/danmar/cppcheck/archive/refs/tags/2.13.0.tar.gz
+          tar xf 2.13.0.tar.gz
 
           # build cppcheck-2.4.1
-          cd cppcheck-2.4.1
+          cd cppcheck-2.13.0
           make -j4 SRCDIR=build CFGDIR=cfg CXXFLAGS="-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function"
           echo "CPPCHECK_PATH=`pwd`" >> $GITHUB_ENV
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   license:
     name: license
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - uses: jitterbit/get-changed-files@v1
@@ -78,14 +78,14 @@ jobs:
           test $result = "PASS" # if non-zero, fail
   pr-style:
     name: pr-style
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: deepakputhraya/action-pr-title@master
         with:
           regex: '^\[[A-Z]+-\d+\]\s.+' # Regex the title should match.
   code-style:
     name: code-style
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       working-directory: .github/workflows
     steps:
@@ -131,7 +131,7 @@ jobs:
           tool_name: code-style (indent, astyle, google-java-format)
   cppcheck:
     name: cppcheck
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install packages
         run: |
@@ -216,7 +216,7 @@ jobs:
             ${{ steps.get-comment-body.outputs.body }}
   memory-monitor-check:
     name: memory-monitor-check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - uses: jitterbit/get-changed-files@v1

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   license:
     name: license
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: jitterbit/get-changed-files@v1
@@ -78,14 +78,14 @@ jobs:
           test $result = "PASS" # if non-zero, fail
   pr-style:
     name: pr-style
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: deepakputhraya/action-pr-title@master
         with:
           regex: '^\[[A-Z]+-\d+\]\s.+' # Regex the title should match.
   code-style:
     name: code-style
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     env:
       working-directory: .github/workflows
     steps:
@@ -131,7 +131,7 @@ jobs:
           tool_name: code-style (indent, astyle, google-java-format)
   cppcheck:
     name: cppcheck
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Install packages
         run: |
@@ -216,7 +216,7 @@ jobs:
             ${{ steps.get-comment-body.outputs.body }}
   memory-monitor-check:
     name: memory-monitor-check
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: jitterbit/get-changed-files@v1

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -137,7 +137,7 @@ jobs:
         run: |
           sudo apt-get install -yq wget build-essential
 
-          # Download cppcheck-2.13.0 source 
+          # Download cppcheck-2.13.0 source
           wd=`pwd`
           cd ..
           wget https://github.com/CUBRID/3rdparty/raw/develop/cppcheck/2.13.0.tar.gz

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -137,7 +137,7 @@ jobs:
         run: |
           sudo apt-get install -yq wget build-essential
 
-          # Download cppcheck-2.13.0 source
+          # Download cppcheck-2.13.0 source 
           wd=`pwd`
           cd ..
           wget https://github.com/CUBRID/3rdparty/raw/develop/cppcheck/2.13.0.tar.gz

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   license:
     name: license
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - uses: jitterbit/get-changed-files@v1
@@ -78,14 +78,14 @@ jobs:
           test $result = "PASS" # if non-zero, fail
   pr-style:
     name: pr-style
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: deepakputhraya/action-pr-title@master
         with:
           regex: '^\[[A-Z]+-\d+\]\s.+' # Regex the title should match.
   code-style:
     name: code-style
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       working-directory: .github/workflows
     steps:
@@ -131,7 +131,7 @@ jobs:
           tool_name: code-style (indent, astyle, google-java-format)
   cppcheck:
     name: cppcheck
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install packages
         run: |
@@ -216,7 +216,7 @@ jobs:
             ${{ steps.get-comment-body.outputs.body }}
   memory-monitor-check:
     name: memory-monitor-check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - uses: jitterbit/get-changed-files@v1


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26030>

### Purpose

runner image 'ubuntu 20.04' 가 deprecated 처리됨에 따라 'ubuntu 24.04' 로 업그레이드

### Implementation

- 'ubuntu 24.04' upgrade
- 'cppcheck 2.13.0' upgrade

### Remarks

N/A
