### PR TITLE
[CBRD-26030] backport from develop to 11.3 upgrade action runner image version refer to the deprecated image. (#6121)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   license:
     name: license
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - uses: jitterbit/get-changed-files@v1
@@ -66,14 +66,14 @@ jobs:
           test $result = "PASS" # if non-zero, fail
   pr-style:
     name: pr-style
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: deepakputhraya/action-pr-title@master
         with:
           regex: '^\[[A-Z]+-\d+\]\s.+' # Regex the title should match.
   code-style:
     name: code-style
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       working-directory: .github/workflows
     steps:
@@ -119,21 +119,21 @@ jobs:
           tool_name: code-style (indent, astyle, google-java-format)
   cppcheck:
     name: cppcheck
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install packages
         run: |
           sudo apt-get install -yq wget build-essential
 
-          # Download cppcheck-2.4.1 source
+          # Download cppcheck-2.13.0 source
           wd=`pwd`
           cd ..
-          wget https://github.com/danmar/cppcheck/archive/2.4.1.tar.gz
-          tar xf 2.4.1.tar.gz
+          wget https://github.com/CUBRID/3rdparty/raw/develop/cppcheck/2.13.0.tar.gz
+          tar xf 2.13.0.tar.gz
 
-          # build cppcheck-2.4.1
-          cd cppcheck-2.4.1
-          make -j4 SRCDIR=build CFGDIR=cfg CXXFLAGS="-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function"
+          # build cppcheck-2.13.0
+          cd cppcheck-2.13.0
+          make -j4 MATCHCOMPILER=yes CFGDIR=cfg CXXFLAGS="-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function"
           echo "CPPCHECK_PATH=`pwd`" >> $GITHUB_ENV
 
           cd $wd


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26030

* modify ubuntu version from 20.04 to 24.04 refer to deprecated image.
* cppcheck package upgrade 2.13.0 
Conflicts:
	.github/workflows/check.yml