### PR TITLE
[CBRD-26030] backport from develop to 11.2 upgrade action runner image version refer to the deprecated image. (#6121)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   license:
     name: license
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - uses: jitterbit/get-changed-files@v1
@@ -66,14 +66,20 @@ jobs:
           test $result = "PASS" # if non-zero, fail
   pr-style:
     name: pr-style
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: deepakputhraya/action-pr-title@master
         with:
           regex: '^\[[A-Z]+-\d+\]\s.+' # Regex the title should match.
   code-style:
     name: code-style
+<<<<<<< HEAD
     runs-on: ubuntu-20.04
+=======
+    runs-on: ubuntu-24.04
+    env:
+      working-directory: .github/workflows
+>>>>>>> 948f4d5... [CBRD-26030] upgrade action runner image version refer to the deprecated image. (#6121)
     steps:
       - name: Install packages
         run: |
@@ -109,21 +115,26 @@ jobs:
           tool_name: code-style (indent, astyle)
   cppcheck:
     name: cppcheck
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install packages
         run: |
           sudo apt-get install -yq wget build-essential
 
-          # Download cppcheck-2.4.1 source
+          # Download cppcheck-2.13.0 source
           wd=`pwd`
           cd ..
+<<<<<<< HEAD
           wget https://github.com/danmar/cppcheck/archive/2.4.1.tar.gz
           tar xf 2.4.1.tar.gz
+=======
+          wget https://github.com/CUBRID/3rdparty/raw/develop/cppcheck/2.13.0.tar.gz
+          tar xf 2.13.0.tar.gz
+>>>>>>> 948f4d5... [CBRD-26030] upgrade action runner image version refer to the deprecated image. (#6121)
 
-          # build cppcheck-2.4.1
-          cd cppcheck-2.4.1
-          make -j4 SRCDIR=build CFGDIR=cfg CXXFLAGS="-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function"
+          # build cppcheck-2.13.0
+          cd cppcheck-2.13.0
+          make -j4 MATCHCOMPILER=yes CFGDIR=cfg CXXFLAGS="-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function"
           echo "CPPCHECK_PATH=`pwd`" >> $GITHUB_ENV
 
           cd $wd
@@ -185,3 +196,80 @@ jobs:
           msg: |
             **cppcheck**
             ${{ steps.get-comment-body.outputs.body }}
+<<<<<<< HEAD
+=======
+  memory-monitor-check:
+    name: memory-monitor-check
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: jitterbit/get-changed-files@v1
+        id: files
+        continue-on-error: true
+      - name: Check memory header include
+        run: |
+          set +e # make this step proceed even if a command returns non-zero
+          memory_header_include=.github/workflows/memory_header_include
+          result="PASS"
+
+          for f in ${{ steps.files.outputs.added_modified }}; do
+            if [ -d "$f" ]; then
+              continue
+            fi
+
+            ext=$(expr $f : ".*\(\..*\)")
+            case $ext in
+            .c|.cpp|.C|.CPP) true;; # only these formats are checked.
+            *) continue ;; # skip others
+            esac
+
+            result_for_f="FAIL"
+            for header in `find $memory_header_include -type f`; do
+              cat $f | grep "#include" | grep "memory_wrapper.hpp" | diff -w - $header 2>&1 1>/dev/null
+              if [ $? -eq 0 ]; then
+                result_for_f="PASS"
+                break
+              fi
+            done
+
+            # [exception case] lea_heap.c is third party code
+            if [ "$f" != "src/heaplayers/lea_heap.c" ]; then
+              # "strict_warnings_(on|off).hpp" should be able to come after memory_wrapper.hpp
+              # Refer to CBRD-25966
+              last_include_line=$(
+                grep -n "^#include" "$f" \
+                | grep -v -E "strict_warnings_(on|off)\.hpp" \
+                | cut -d':' -f1 \
+                | tail -1
+              )
+              wrapper_include_line=$(cat $f | grep -n "^#include" | grep "memory_wrapper.hpp" | cut -d':' -f1)
+              if [ "$last_include_line" != "$wrapper_include_line" ]; then
+                result_for_f="FAIL"
+              else # if equal, check warning comment
+                warning_comment=$(head -n $wrapper_include_line $f | tail -2 | head -1)
+                if [ "$warning_comment" != "// XXX: SHOULD BE THE LAST INCLUDE HEADER" ]; then
+                  result_for_f="FAIL"
+                fi
+              fi
+            fi
+
+            # [exception case] memory_monitor_sr.cpp / memory_monitor_api.cpp is base file of memory monitoring module
+            if [ "$f" == "src/base/memory_monitor_sr.cpp" ] || [ "$f" == "src/base/memory_monitor_api.cpp" ]; then
+              result_for_f="PASS"
+            fi
+
+            filename=$(basename $f)
+            check_server_file=$(grep -E "/$filename\$" cubrid/CMakeLists.txt)
+            if [ "$check_server_file" == "" ]; then
+              result_for_f="PASS"
+            fi
+
+            echo "$f: $result_for_f"
+            if [ "$result_for_f" = "FAIL" ]; then
+              result="FAIL"
+              echo "Error: .c/.cpp file in cubrid/CMakeLists.txt must include memory_wrapper.hpp with XXX comment"
+            fi
+          done
+
+          test $result = "PASS" # if non-zero, fail
+>>>>>>> 948f4d5... [CBRD-26030] upgrade action runner image version refer to the deprecated image. (#6121)

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -73,13 +73,9 @@ jobs:
           regex: '^\[[A-Z]+-\d+\]\s.+' # Regex the title should match.
   code-style:
     name: code-style
-<<<<<<< HEAD
-    runs-on: ubuntu-20.04
-=======
     runs-on: ubuntu-24.04
     env:
       working-directory: .github/workflows
->>>>>>> 948f4d5... [CBRD-26030] upgrade action runner image version refer to the deprecated image. (#6121)
     steps:
       - name: Install packages
         run: |
@@ -124,13 +120,8 @@ jobs:
           # Download cppcheck-2.13.0 source
           wd=`pwd`
           cd ..
-<<<<<<< HEAD
-          wget https://github.com/danmar/cppcheck/archive/2.4.1.tar.gz
-          tar xf 2.4.1.tar.gz
-=======
           wget https://github.com/CUBRID/3rdparty/raw/develop/cppcheck/2.13.0.tar.gz
           tar xf 2.13.0.tar.gz
->>>>>>> 948f4d5... [CBRD-26030] upgrade action runner image version refer to the deprecated image. (#6121)
 
           # build cppcheck-2.13.0
           cd cppcheck-2.13.0
@@ -196,80 +187,3 @@ jobs:
           msg: |
             **cppcheck**
             ${{ steps.get-comment-body.outputs.body }}
-<<<<<<< HEAD
-=======
-  memory-monitor-check:
-    name: memory-monitor-check
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: jitterbit/get-changed-files@v1
-        id: files
-        continue-on-error: true
-      - name: Check memory header include
-        run: |
-          set +e # make this step proceed even if a command returns non-zero
-          memory_header_include=.github/workflows/memory_header_include
-          result="PASS"
-
-          for f in ${{ steps.files.outputs.added_modified }}; do
-            if [ -d "$f" ]; then
-              continue
-            fi
-
-            ext=$(expr $f : ".*\(\..*\)")
-            case $ext in
-            .c|.cpp|.C|.CPP) true;; # only these formats are checked.
-            *) continue ;; # skip others
-            esac
-
-            result_for_f="FAIL"
-            for header in `find $memory_header_include -type f`; do
-              cat $f | grep "#include" | grep "memory_wrapper.hpp" | diff -w - $header 2>&1 1>/dev/null
-              if [ $? -eq 0 ]; then
-                result_for_f="PASS"
-                break
-              fi
-            done
-
-            # [exception case] lea_heap.c is third party code
-            if [ "$f" != "src/heaplayers/lea_heap.c" ]; then
-              # "strict_warnings_(on|off).hpp" should be able to come after memory_wrapper.hpp
-              # Refer to CBRD-25966
-              last_include_line=$(
-                grep -n "^#include" "$f" \
-                | grep -v -E "strict_warnings_(on|off)\.hpp" \
-                | cut -d':' -f1 \
-                | tail -1
-              )
-              wrapper_include_line=$(cat $f | grep -n "^#include" | grep "memory_wrapper.hpp" | cut -d':' -f1)
-              if [ "$last_include_line" != "$wrapper_include_line" ]; then
-                result_for_f="FAIL"
-              else # if equal, check warning comment
-                warning_comment=$(head -n $wrapper_include_line $f | tail -2 | head -1)
-                if [ "$warning_comment" != "// XXX: SHOULD BE THE LAST INCLUDE HEADER" ]; then
-                  result_for_f="FAIL"
-                fi
-              fi
-            fi
-
-            # [exception case] memory_monitor_sr.cpp / memory_monitor_api.cpp is base file of memory monitoring module
-            if [ "$f" == "src/base/memory_monitor_sr.cpp" ] || [ "$f" == "src/base/memory_monitor_api.cpp" ]; then
-              result_for_f="PASS"
-            fi
-
-            filename=$(basename $f)
-            check_server_file=$(grep -E "/$filename\$" cubrid/CMakeLists.txt)
-            if [ "$check_server_file" == "" ]; then
-              result_for_f="PASS"
-            fi
-
-            echo "$f: $result_for_f"
-            if [ "$result_for_f" = "FAIL" ]; then
-              result="FAIL"
-              echo "Error: .c/.cpp file in cubrid/CMakeLists.txt must include memory_wrapper.hpp with XXX comment"
-            fi
-          done
-
-          test $result = "PASS" # if non-zero, fail
->>>>>>> 948f4d5... [CBRD-26030] upgrade action runner image version refer to the deprecated image. (#6121)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26030

* modify ubuntu version from 20.04 to 24.04 refer to deprecated image.
* cppcheck package upgrade 2.13.0 
Conflicts:
	.github/workflows/check.yml