### PR TITLE
[CBRD-26028] remove minus in lob locator suffix

### DIFF
--- a/src/storage/es_posix.c
+++ b/src/storage/es_posix.c
@@ -91,6 +91,9 @@ es_get_unique_name (char *dirname1, char *dirname2, const char *metaname, char *
   r = rand ();
 #endif
 
+  /* defensive, we don't want minus in filename */
+  r = r < 0 ? r * (-1) : r;
+
   /* get unique numbers */
   unum = es_get_unique_num ();
 

--- a/src/storage/es_posix.c
+++ b/src/storage/es_posix.c
@@ -91,8 +91,10 @@ es_get_unique_name (char *dirname1, char *dirname2, const char *metaname, char *
   r = rand ();
 #endif
 
+#if defined (WINDOWS)
   /* defensive, we don't want minus in filename */
   r = r < 0 ? r * (-1) : r;
+#endif
 
   /* get unique numbers */
   unum = es_get_unique_num ();

--- a/src/storage/es_posix.c
+++ b/src/storage/es_posix.c
@@ -91,10 +91,8 @@ es_get_unique_name (char *dirname1, char *dirname2, const char *metaname, char *
   r = rand ();
 #endif
 
-#if defined (WINDOWS)
   /* defensive, we don't want minus in filename */
   r = r < 0 ? r * (-1) : r;
-#endif
 
   /* get unique numbers */
   unum = es_get_unique_num ();


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26028 >

### Purpose
* [Windows] remove unexpected minus character in lob locator
* Windows do not support rand_r (), it is implemented locally in src/base/rand.c
* For whatever reason, there are cases where it returns a negative value.

### Implementation

N/A

### Remarks

N/A
