### PR TITLE
[CBRD-26005] Add log record type EOL check

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -7202,7 +7202,7 @@ xlog_dump (THREAD_ENTRY * thread_p, FILE * out_fp, int isforward, LOG_PAGEID sta
 	  log_rec = LOG_GET_LOG_RECORD_HEADER (log_pgptr, &log_lsa);
 	  type = log_rec->type;
 
-	  if (LSA_ISNULL (&log_rec->forw_lsa) && type != LOG_END_OF_LOG)
+	  if (type != LOG_END_OF_LOG)
 	    {
 	      /*
 	       * The following is just for debugging next address calculations

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -7202,22 +7202,23 @@ xlog_dump (THREAD_ENTRY * thread_p, FILE * out_fp, int isforward, LOG_PAGEID sta
 	  log_rec = LOG_GET_LOG_RECORD_HEADER (log_pgptr, &log_lsa);
 	  type = log_rec->type;
 
-	  {
-	    /*
-	     * The following is just for debugging next address calculations
-	     */
-	    LOG_LSA next_lsa;
+	  if (LSA_ISNULL (&log_rec->forw_lsa) && type != LOG_END_OF_LOG)
+	    {
+	      /*
+	       * The following is just for debugging next address calculations
+	       */
+	      LOG_LSA next_lsa;
 
-	    LSA_COPY (&next_lsa, &lsa);
-	    if (log_startof_nxrec (thread_p, &next_lsa, false) == NULL
-		|| (!LSA_EQ (&next_lsa, &log_rec->forw_lsa) && !LSA_ISNULL (&log_rec->forw_lsa)))
-	      {
-		fprintf (out_fp, "\n\n>>>>>****\n");
-		fprintf (out_fp, "Guess next address = %lld|%d for LSA = %lld|%d\n",
-			 LSA_AS_ARGS (&next_lsa), LSA_AS_ARGS (&lsa));
-		fprintf (out_fp, "<<<<<****\n");
-	      }
-	  }
+	      LSA_COPY (&next_lsa, &lsa);
+	      if (log_startof_nxrec (thread_p, &next_lsa, false) == NULL
+		  || (!LSA_EQ (&next_lsa, &log_rec->forw_lsa) && !LSA_ISNULL (&log_rec->forw_lsa)))
+		{
+		  fprintf (out_fp, "\n\n>>>>>****\n");
+		  fprintf (out_fp, "Guess next address = %lld|%d for LSA = %lld|%d\n",
+			   LSA_AS_ARGS (&next_lsa), LSA_AS_ARGS (&lsa));
+		  fprintf (out_fp, "<<<<<****\n");
+		}
+	    }
 
 	  /* Find the next log record to dump .. after current one is dumped */
 	  if (isforward != false)

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -5722,8 +5722,11 @@ log_startof_nxrec (THREAD_ENTRY * thread_p, LOG_LSA * lsa, bool canuse_forwaddr)
     case LOG_DUMMY_CRASH_RECOVERY:
     case LOG_DUMMY_OVF_RECORD:
     case LOG_DUMMY_GENERIC:
-    case LOG_END_OF_LOG:
     case LOG_SYSOP_ATOMIC_START:
+      break;
+
+    case LOG_END_OF_LOG:
+      assert (false);
       break;
 
     case LOG_REPLICATION_DATA:


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26005

### Purpose

- Log record를 읽어오는 과정에서 현재 log record의 타입이 EOL 임에도 불구하고 
   next log record를 읽어오려다 존재하지 않는 page를 fetch하여 에러가 발생하는 문제를 수정

### Implementation

- next reocrd를 가져오기 전 EOL check 추가
- 혹시 모를 상황을 대비하여 next record를 가져오는 함수 내부에서 
   log record의 type이 EOL 인 경우 assert 발생하도록 수정

### Remarks

N/A
