### PR TITLE
[CBRD-26026] Revert - perf: Reduce sizeof DB_VALUE by 8 bytes

### DIFF
--- a/src/compat/dbtype_def.h
+++ b/src/compat/dbtype_def.h
@@ -1020,8 +1020,8 @@ extern "C"
       unsigned char compressed_need_clear;
       int size;
       const char *buf;
-      char *compressed_buf;
       int compressed_size;
+      char *compressed_buf;
       int length;		/* Only Use for group_concat() now */
     } medium;
     struct


### PR DESCRIPTION
Reverts CUBRID/cubrid#6119

http://jira.cubrid.org/browse/CBRD-26026

Fig Cake 대신 Guava 에 적용합니다.