### PR TITLE
[CBRD-26034] Fix memory leak in session_set_pl_session ()

### DIFF
--- a/src/session/session.c
+++ b/src/session/session.c
@@ -3346,13 +3346,16 @@ session_stop_attached_threads (THREAD_ENTRY * thread_p, void *session_arg)
       session->load_session_p = NULL;
     }
 
-  if (thread_p->type == TT_WORKER && session->pl_session_p != NULL)
+  if (session->pl_session_p != NULL)
     {
-      session->pl_session_p->set_interrupt (er_errid ());
-      session->pl_session_p->wait_for_interrupt ();
-
+      if (thread_p->type == TT_WORKER)
+	{
+	  session->pl_session_p->set_interrupt (er_errid ());
+	  session->pl_session_p->wait_for_interrupt ();
+	}
       delete session->pl_session_p;
       session->pl_session_p = NULL;
     }
+
 #endif
 }

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -3348,7 +3348,7 @@ session_stop_attached_threads (THREAD_ENTRY * thread_p, void *session_arg)
 
   if (session->pl_session_p != NULL)
     {
-      if (thread_p->type == TT_WORKER)
+      if (thread_p && thread_p->type == TT_WORKER)
 	{
 	  session->pl_session_p->set_interrupt (er_errid ());
 	  session->pl_session_p->wait_for_interrupt ();


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26034

### Purpose

TT_WORKER가 아닌 다른 thread 타입에서도 pl_session이 만들어졌다면 제거하도록 코드를 수정합니다.

### Implementation

session_stop_attached_threads  ()에서 `delete session->pl_session_p` 을 위한 조건 분리

### Remarks

N/A
