### PR TITLE
[CBRD-26031] When entering Korean characters using bind variables in DBLINK, Korean characters are broken

### DIFF
--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -1234,13 +1234,31 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
       {
 	char *value;
 	int val_size;
+	wchar_t *out_string = NULL;
+	size_t out_length = 0;
 
 	net_arg_get_str (&value, &val_size, net_value);
 
-	c_data_type = SQL_C_CHAR;
-	sql_bind_type = SQL_CHAR;
+	c_data_type = SQL_C_WCHAR;
+	sql_bind_type = SQL_WVARCHAR;
 
-	value_list->string_val = value;
+	out_length = (strlen (value) + 1) * sizeof (wchar_t);
+	out_string = (wchar_t *) malloc (out_length);
+	if (out_string == NULL)
+	  {
+	    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_INTERFACE_NO_MORE_MEMORY, 0);
+	    return ER_INTERFACE_NO_MORE_MEMORY;
+	  }
+
+	err_code = cgw_utf8_to_unicode (value, out_string, out_length);
+
+	if (err_code < 0)
+	  {
+	    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CGW_SQL_CONV_ERROR, 0);
+	    goto ODBC_ERROR;
+	  }
+
+	value_list->wchar_val = out_string;
 
 	SQL_CHK_ERR (handle->hstmt,
 		     SQL_HANDLE_STMT,
@@ -1248,7 +1266,7 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 						  bind_num,
 						  SQL_PARAM_INPUT,
 						  c_data_type,
-						  sql_bind_type, val_size + 1, 0, value_list->string_val, 0, NULL));
+						  sql_bind_type, out_length, 0, (SQLWCHAR *) out_string, 0, NULL));
       }
       break;
       /* Not Support Type */
@@ -1257,13 +1275,31 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
       {
 	char *value;
 	int val_size;
+	wchar_t *out_string = NULL;
+	size_t out_length = 0;
 
 	net_arg_get_str (&value, &val_size, net_value);
 
-	c_data_type = SQL_C_CHAR;
-	sql_bind_type = SQL_CHAR;
+	c_data_type = SQL_C_WCHAR;
+	sql_bind_type = SQL_WVARCHAR;
 
-	value_list->string_val = value;
+	out_length = (strlen (value) + 1) * sizeof (wchar_t);
+	out_string = (wchar_t *) malloc (out_length);
+	if (out_string == NULL)
+	  {
+	    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_INTERFACE_NO_MORE_MEMORY, 0);
+	    return ER_INTERFACE_NO_MORE_MEMORY;
+	  }
+
+	err_code = cgw_utf8_to_unicode (value, out_string, out_length);
+
+	if (err_code < 0)
+	  {
+	    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CGW_SQL_CONV_ERROR, 0);
+	    goto ODBC_ERROR;
+	  }
+
+	value_list->wchar_val = out_string;
 
 	SQL_CHK_ERR (handle->hstmt,
 		     SQL_HANDLE_STMT,
@@ -1271,7 +1307,7 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 						  bind_num,
 						  SQL_PARAM_INPUT,
 						  c_data_type,
-						  sql_bind_type, val_size + 1, 0, value_list->string_val, 0, NULL));
+						  sql_bind_type, out_length, 0, (SQLWCHAR *) out_string, 0, NULL));
       }
       break;
     case CCI_U_TYPE_NULL:
@@ -1720,7 +1756,7 @@ cgw_sql_prepare (SQLCHAR * sql_stmt)
   SQLRETURN err_code;
   wchar_t *out_string = NULL;
   char *in_string = NULL;
-  int out_length = 0;
+  size_t out_length = 0;
 
   in_string = (char *) sql_stmt;
 
@@ -1731,7 +1767,7 @@ cgw_sql_prepare (SQLCHAR * sql_stmt)
 		   err_code = SQLAllocHandle (SQL_HANDLE_STMT, local_odbc_handle->hdbc, &local_odbc_handle->hstmt));
     }
 
-  out_length = strlen (in_string) * sizeof (wchar_t) + 1;
+  out_length = (strlen (in_string) + 1) * sizeof (wchar_t);
   out_string = (wchar_t *) malloc (out_length);
   if (out_string == NULL)
     {
@@ -1813,6 +1849,8 @@ cgw_make_bind_value (T_CGW_HANDLE * handle, int num_bind, int argc, void **argv,
       return ER_INTERFACE_NO_MORE_MEMORY;
     }
 
+  memset (bind_value_list, 0, sizeof (ODBC_BIND_INFO) * num_bind);
+
   for (i = 0; i < num_bind; i++)
     {
       type_idx = 2 * i;
@@ -1820,6 +1858,13 @@ cgw_make_bind_value (T_CGW_HANDLE * handle, int num_bind, int argc, void **argv,
       err_code = cgw_set_bindparam (handle, i + 1, argv[type_idx], argv[val_idx], &(bind_value_list[i]));
       if (err_code < 0)
 	{
+	  for (int j = 0; j < i; j++)
+	    {
+	      if (bind_value_list[j].wchar_val)
+		{
+		  FREE_MEM (bind_value_list[j].wchar_val);
+		}
+	    }
 	  FREE_MEM (bind_value_list);
 	  return err_code;
 	}
@@ -2742,6 +2787,8 @@ cgw_utf8_to_unicode (const char *in_utf8_str, wchar_t * out_unicode_str, size_t 
       iconv_close (conv);
       return -1;
     }
+
+  *((wchar_t *) out_buf) = L'\0';
 
   iconv_close (conv);
 #endif

--- a/src/broker/cas_cgw.h
+++ b/src/broker/cas_cgw.h
@@ -120,10 +120,11 @@ struct t_odbc_col_info
   SQLSMALLINT is_not_null;
 };
 
-typedef union odbc_bind_info ODBC_BIND_INFO;
-union odbc_bind_info
+typedef struct odbc_bind_info ODBC_BIND_INFO;
+struct odbc_bind_info
 {
   char *string_val;
+  wchar_t *wchar_val;
   SQLSMALLINT smallInt_val;
   SQLINTEGER integer_val;
   SQLREAL real_val;

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -1437,6 +1437,13 @@ ux_cgw_execute (T_SRV_HANDLE * srv_handle, char flag, int max_col_size, int max_
 
   if (bind_data_list)
     {
+      for (int i = 0; i < num_bind; i++)
+	{
+	  if (bind_data_list[i].wchar_val)
+	    {
+	      FREE_MEM (bind_data_list[i].wchar_val);
+	    }
+	}
       FREE_MEM (bind_data_list);
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26031

Purpose
gateway와 이기종 DB 간에는 odbc unicode driver를 이용한다. 이기종 DB에 한글을  insert 할때 한글을 unicode로 변환하여 전송해야한다. 그런데 bind 변수를 사용하는 경우,  unicode로 변환을 하고 있지 않아 한글이 깨지는 현상이 발생함

Implementation
bind 변수 값을 unicode로 변환하여 전송하도록 변경함

