### PR TITLE
[CUBVEC-70] Create a new access spec for vector index (HNSW) and select the plan in optimizer

### DIFF
--- a/src/optimizer/plan_generation.c
+++ b/src/optimizer/plan_generation.c
@@ -1716,6 +1716,13 @@ make_pred_from_plan (QO_ENV * env, QO_PLAN * plan, PT_NODE ** key_predp, PT_NODE
       return;
     }
 
+  if (plan->plan_un.scan.scan_method == QO_SCANMETHOD_VECTOR_INDEX_SCAN)
+    {
+      // TODO (CUBVEC)
+      // predicates for vector index scan are not required (for now)
+      return;
+    }
+
   /* This is safe guard code - DO NOT DELETE ME */
   do
     {
@@ -3521,6 +3528,23 @@ qo_get_xasl_index_info (QO_ENV * env, QO_PLAN * plan)
   /* number of indexed segments */
   nsegs = index_entryp->nsegs;	/* nsegs == nterms ? */
 
+  /* allocate QO_XASL_INDEX_INFO structure */
+  index_infop = (QO_XASL_INDEX_INFO *) malloc (sizeof (QO_XASL_INDEX_INFO));
+  if (index_infop == NULL)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (QO_XASL_INDEX_INFO));
+      goto error;
+    }
+
+  if (plan->plan_un.scan.scan_method == QO_SCANMETHOD_VECTOR_INDEX_SCAN)
+    {
+      index_infop->nterms = 0;
+      index_infop->term_exprs = NULL;
+      index_infop->multi_col_pos = NULL;
+      index_infop->ni_entry = ni_entryp;
+      return index_infop;
+    }
+
   /* support also full range indexes */
   if (nterms <= 0 && nkfterms <= 0 && bitset_cardinality (&(plan->sarged_terms)) == 0)
     {
@@ -3537,14 +3561,6 @@ qo_get_xasl_index_info (QO_ENV * env, QO_PLAN * plan)
 	  assert (false);
 	  return NULL;		/* give up */
 	}
-    }
-
-  /* allocate QO_XASL_INDEX_INFO structure */
-  index_infop = (QO_XASL_INDEX_INFO *) malloc (sizeof (QO_XASL_INDEX_INFO));
-  if (index_infop == NULL)
-    {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (QO_XASL_INDEX_INFO));
-      goto error;
     }
 
   if (qo_is_index_iss_scan (plan))

--- a/src/optimizer/query_graph.h
+++ b/src/optimizer/query_graph.h
@@ -913,6 +913,7 @@ struct qo_env
 
   /* true if we should consider generating SORT-LIMIT plans */
   QO_SORT_LIMIT_USE use_sort_limit;
+
   /*
    * True iff we found a conjunct which was not an expression.  We assume
    * that this is a false conjunct and we don't need to optimize a query

--- a/src/optimizer/query_graph.h
+++ b/src/optimizer/query_graph.h
@@ -913,7 +913,6 @@ struct qo_env
 
   /* true if we should consider generating SORT-LIMIT plans */
   QO_SORT_LIMIT_USE use_sort_limit;
-
   /*
    * True iff we found a conjunct which was not an expression.  We assume
    * that this is a false conjunct and we don't need to optimize a query

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -301,8 +301,8 @@ static QO_PLAN_VTBL qo_vector_index_scan_plan_vtbl = {
   qo_scan_fprint,
   qo_scan_walk,
   qo_scan_free,
-  qo_zero_cost, // TODO (CUBVEC): always use vector index scan instead of sequential scan
-  qo_zero_cost, // TODO (CUBVEC): always use vector index scan instead of sequential scan
+  qo_zero_cost,			// TODO (CUBVEC): always use vector index scan instead of sequential scan
+  qo_zero_cost,			// TODO (CUBVEC): always use vector index scan instead of sequential scan
   qo_scan_info,
   "Vector index scan"
 };
@@ -2122,10 +2122,10 @@ qo_scan_fprint (QO_PLAN * plan, FILE * f, int howfar)
       fprintf (f, "%s ", plan->plan_un.scan.index->head->constraints->name);
 
       if (plan->plan_un.scan.scan_method == QO_SCANMETHOD_VECTOR_INDEX_SCAN)
-      {
-        // TODO (CUBVEC)
-        // print attributes of vector index scan
-      }
+	{
+	  // TODO (CUBVEC)
+	  // print attributes of vector index scan
+	}
 
       /* print key limit */
       if (plan->plan_un.scan.index->head->key_limit)

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -10382,6 +10382,8 @@ qo_validate_index_for_vector_index (QO_ENV * env, QO_NODE_INDEX_ENTRY * ni_entry
   int pos;
   PT_NODE *node = NULL;
   PT_NODE *arg_list = NULL;
+  PT_NODE *order_by = NULL;
+  PT_NODE *order_by_for = NULL;
 
   assert (ni_entryp != NULL);
   assert (ni_entryp->head != NULL);
@@ -10390,7 +10392,21 @@ qo_validate_index_for_vector_index (QO_ENV * env, QO_NODE_INDEX_ENTRY * ni_entry
   index_entryp = ni_entryp->head;
   index_class = index_entryp->class_;
 
-  if (!QO_ENV_PT_TREE (env) || !QO_ENV_PT_TREE (env)->info.query.order_by)
+  if (!QO_ENV_PT_TREE (env))
+    {
+      goto end;
+    }
+
+  order_by = QO_ENV_PT_TREE (env)->info.query.order_by;
+  order_by_for = QO_ENV_PT_TREE (env)->info.query.orderby_for;
+
+  if (!order_by || !order_by_for)
+    {
+      goto end;
+    }
+
+  /* limit a, b */
+  if (order_by_for->next != NULL)
     {
       goto end;
     }

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -242,6 +242,8 @@ static bool qo_validate_index_term_notnull (QO_ENV * env, QO_INDEX_ENTRY * index
 static bool qo_validate_index_attr_notnull (QO_ENV * env, QO_INDEX_ENTRY * index_entryp, PT_NODE * col);
 static int qo_validate_index_for_orderby (QO_ENV * env, QO_NODE_INDEX_ENTRY * ni_entryp);
 static int qo_validate_index_for_groupby (QO_ENV * env, QO_NODE_INDEX_ENTRY * ni_entryp);
+static int qo_validate_index_for_vector_index (QO_ENV * env, QO_NODE_INDEX_ENTRY * ni_entryp);
+
 static PT_NODE *qo_search_isnull_key_expr (PARSER_CONTEXT * parser, PT_NODE * tree, void *arg, int *continue_walk);
 static bool qo_check_orderby_skip_descending (QO_PLAN * plan);
 static bool qo_check_skip_term (QO_ENV * env, BITSET visited_segs, QO_TERM * term, BITSET * visited_terms,
@@ -292,6 +294,17 @@ static QO_PLAN_VTBL qo_index_scan_plan_vtbl = {
   qo_iscan_cost,
   qo_scan_info,
   "Index scan"
+};
+
+static QO_PLAN_VTBL qo_vector_index_scan_plan_vtbl = {
+  "viscan",
+  qo_scan_fprint,
+  qo_scan_walk,
+  qo_scan_free,
+  qo_zero_cost, // TODO (CUBVEC): always use vector index scan instead of sequential scan
+  qo_zero_cost, // TODO (CUBVEC): always use vector index scan instead of sequential scan
+  qo_scan_info,
+  "Vector index scan"
 };
 
 static QO_PLAN_VTBL qo_sort_plan_vtbl = {
@@ -397,7 +410,8 @@ QO_PLAN_VTBL *all_vtbls[] = {
   &qo_hash_join_plan_vtbl,
   &qo_follow_plan_vtbl,
   &qo_set_follow_plan_vtbl,
-  &qo_worst_plan_vtbl
+  &qo_worst_plan_vtbl,
+  &qo_vector_index_scan_plan_vtbl
 };
 
 #define DEFAULT_NULL_SELECTIVITY (double) 0.01
@@ -1608,15 +1622,29 @@ qo_index_scan_new (QO_INFO * info, QO_NODE * node, QO_NODE_INDEX_ENTRY * ni_entr
   assert (ni_entry->head != NULL);
 
   assert (scan_method == QO_SCANMETHOD_INDEX_SCAN || scan_method == QO_SCANMETHOD_INDEX_ORDERBY_SCAN
-	  || scan_method == QO_SCANMETHOD_INDEX_GROUPBY_SCAN || scan_method == QO_SCANMETHOD_INDEX_SCAN_INSPECT);
+	  || scan_method == QO_SCANMETHOD_INDEX_GROUPBY_SCAN || scan_method == QO_SCANMETHOD_INDEX_SCAN_INSPECT
+	  || scan_method == QO_SCANMETHOD_VECTOR_INDEX_SCAN);
 
   assert (scan_method != QO_SCANMETHOD_INDEX_SCAN || !(ni_entry->head->force < 0));
-  assert (scan_method == QO_SCANMETHOD_INDEX_SCAN_INSPECT || range_terms != NULL);
+  assert (scan_method == QO_SCANMETHOD_INDEX_SCAN_INSPECT || scan_method == QO_SCANMETHOD_VECTOR_INDEX_SCAN
+	  || range_terms != NULL);
 
   plan = qo_scan_new (info, node, scan_method);
   if (plan == NULL)
     {
       return NULL;
+    }
+
+  if (scan_method == QO_SCANMETHOD_VECTOR_INDEX_SCAN)
+    {
+      /*
+       * This is, in essence, the selectivity of the index.  We
+       * really need to do a better job of figuring out the cost of
+       * an indexed scan.
+       */
+      plan->vtbl = &qo_vector_index_scan_plan_vtbl;
+      plan->plan_un.scan.index = ni_entry;
+      goto exit;
     }
 
   bitset_init (&index_segs, env);
@@ -1870,6 +1898,8 @@ qo_index_scan_new (QO_INFO * info, QO_NODE * node, QO_NODE_INDEX_ENTRY * ni_entr
 
   assert (plan->plan_un.scan.index != NULL);
 
+exit:
+
   qo_plan_compute_cost (plan);
 
   plan = qo_top_plan_new (plan);
@@ -2090,6 +2120,12 @@ qo_scan_fprint (QO_PLAN * plan, FILE * f, int howfar)
     {
       fprintf (f, "\n" INDENTED_TITLE_FMT, (int) howfar, ' ', "index: ");
       fprintf (f, "%s ", plan->plan_un.scan.index->head->constraints->name);
+
+      if (plan->plan_un.scan.scan_method == QO_SCANMETHOD_VECTOR_INDEX_SCAN)
+      {
+        // TODO (CUBVEC)
+        // print attributes of vector index scan
+      }
 
       /* print key limit */
       if (plan->plan_un.scan.index->head->key_limit)
@@ -8084,6 +8120,22 @@ qo_is_iscan (QO_PLAN * plan)
 }
 
 /*
+ * qo_is_viscan ()
+ *   return: true/false
+ *   plan(in):
+ */
+bool
+qo_is_viscan (QO_PLAN * plan)
+{
+  if (plan && plan->plan_type == QO_PLANTYPE_SCAN
+      && (plan->plan_un.scan.scan_method == QO_SCANMETHOD_VECTOR_INDEX_SCAN))
+    {
+      return true;
+    }
+  return false;
+}
+
+/*
  * qo_generate_index_scan () - With index information, generates index scan plan
  *   return: num of index scan plans
  *   infop(in): pointer to QO_INFO (environment info node which holds plans)
@@ -8229,6 +8281,34 @@ qo_generate_loose_index_scan (QO_INFO * infop, QO_NODE * nodep, QO_NODE_INDEX_EN
   n = qo_check_plan_on_info (infop, planp);
 
   bitset_delset (&range_terms);
+
+  return n;
+}
+
+/*
+ * qo_generate_vector_index_scan () - generate vector index scan plan
+ *   return: number of vector index scan plans
+ *   infop(in): pointer to QO_INFO (environment info node which holds plans)
+ *   nodep(in): pointer to QO_NODE (node in the join graph)
+ *   ni_entryp(in): pointer to QO_NODE_INDEX_ENTRY (node index entry)
+ */
+static int
+qo_generate_vector_index_scan (QO_INFO * infop, QO_NODE * nodep, QO_NODE_INDEX_ENTRY * ni_entryp)
+{
+  QO_INDEX_ENTRY *index_entryp;
+  int n = 0;
+  QO_PLAN *planp;
+
+  index_entryp = (ni_entryp)->head;
+  if (index_entryp->force < 0)
+    {
+      assert (false);
+      return 0;
+    }
+
+  planp = qo_index_scan_new (infop, nodep, ni_entryp, QO_SCANMETHOD_VECTOR_INDEX_SCAN, NULL /* &vec_term */ , NULL);
+
+  n = qo_check_plan_on_info (infop, planp);
 
   return n;
 }
@@ -8552,6 +8632,11 @@ qo_search_planner (QO_PLANNER * planner)
 		  assert (bitset_is_empty (&seg_terms));
 
 		  n = qo_generate_loose_index_scan (info, node, ni_entry);
+		}
+	      else if (index_entry->constraints->type == SM_CONSTRAINT_VECTOR_INDEX
+		       && qo_validate_index_for_vector_index (info->env, ni_entry))
+		{
+		  n = qo_generate_vector_index_scan (info, node, ni_entry);
 		}
 	      else
 		{
@@ -10283,6 +10368,80 @@ qo_validate_index_attr_notnull (QO_ENV * env, QO_INDEX_ENTRY * index_entryp, PT_
 }
 
 /*
+ * qo_validate_index_for_vector_index () - checks for isnull(key) or not null flag
+ *  env(in): pointer to the optimizer environment
+ *  ni_entryp(in): pointer to QO_NODE_INDEX_ENTRY (node index entry)
+ *  return: 1 if the index can be used, 0 elseware
+ */
+static int
+qo_validate_index_for_vector_index (QO_ENV * env, QO_NODE_INDEX_ENTRY * ni_entryp)
+{
+  QO_INDEX_ENTRY *index_entryp;
+  QO_CLASS_INFO_ENTRY *index_class;
+
+  int pos;
+  PT_NODE *node = NULL;
+  PT_NODE *arg_list = NULL;
+
+  assert (ni_entryp != NULL);
+  assert (ni_entryp->head != NULL);
+  assert (ni_entryp->head->class_ != NULL);
+
+  index_entryp = ni_entryp->head;
+  index_class = index_entryp->class_;
+
+  if (!QO_ENV_PT_TREE (env) || !QO_ENV_PT_TREE (env)->info.query.order_by)
+    {
+      goto end;
+    }
+
+  pos = QO_ENV_PT_TREE (env)->info.query.order_by->info.sort_spec.pos_descr.pos_no;
+  node = QO_ENV_PT_TREE (env)->info.query.q.select.list;
+
+  while (pos > 1 && node)
+    {
+      node = node->next;
+      pos--;
+    }
+  if (!node)
+    {
+      goto end;
+    }
+
+  if (node->node_type == PT_EXPR)
+    {
+      // FUNCTION HOLDER
+      node = node->info.expr.arg1;
+      if (!node)
+	{
+	  goto end;
+	}
+    }
+
+  if (!pt_is_vector_function (QO_ENV_PARSER (env), node))
+    {
+      goto end;
+    }
+
+  // naiive check for vector index
+  arg_list = node->info.function.arg_list;
+  if (arg_list->node_type == PT_NAME && arg_list->next->node_type == PT_NAME)
+    {
+      goto end;
+    }
+
+  if (arg_list->node_type == PT_VALUE && arg_list->next->node_type == PT_VALUE)
+    {
+      goto end;
+    }
+
+  return 1;
+
+end:
+  return 0;
+}
+
+/*
  * qo_validate_index_for_orderby () - checks for isnull(key) or not null flag
  *  env(in): pointer to the optimizer environment
  *  ni_entryp(in): pointer to QO_NODE_INDEX_ENTRY (node index entry)
@@ -11319,7 +11478,7 @@ exit_on_end:
 bool
 qo_is_interesting_order_scan (QO_PLAN * plan)
 {
-  if (qo_is_iscan (plan) || qo_is_iscan_from_groupby (plan) || qo_is_iscan_from_orderby (plan))
+  if (qo_is_iscan (plan) || qo_is_iscan_from_groupby (plan) || qo_is_iscan_from_orderby (plan) || qo_is_viscan (plan))
     {
       return true;
     }
@@ -11458,6 +11617,10 @@ qo_plan_scan_print_json (QO_PLAN * plan)
     {
     case QO_SCANMETHOD_SEQ_SCAN:
       scan_string = "TABLE SCAN";
+      break;
+
+    case QO_SCANMETHOD_VECTOR_INDEX_SCAN:
+      scan_string = "VECTOR INDEX SCAN";
       break;
 
     case QO_SCANMETHOD_INDEX_SCAN:
@@ -11784,6 +11947,10 @@ qo_plan_scan_print_text (FILE * fp, QO_PLAN * plan, int indent)
     {
     case QO_SCANMETHOD_SEQ_SCAN:
       fprintf (fp, "TABLE SCAN (%s)", class_name);
+      break;
+
+    case QO_SCANMETHOD_VECTOR_INDEX_SCAN:
+      fprintf (fp, "VECTOR INDEX SCAN (%s)", class_name);
       break;
 
     case QO_SCANMETHOD_INDEX_SCAN:

--- a/src/optimizer/query_planner.h
+++ b/src/optimizer/query_planner.h
@@ -55,7 +55,8 @@ typedef enum
   QO_SCANMETHOD_INDEX_SCAN,
   QO_SCANMETHOD_INDEX_ORDERBY_SCAN,
   QO_SCANMETHOD_INDEX_GROUPBY_SCAN,
-  QO_SCANMETHOD_INDEX_SCAN_INSPECT
+  QO_SCANMETHOD_INDEX_SCAN_INSPECT,
+  QO_SCANMETHOD_VECTOR_INDEX_SCAN
 } QO_SCANMETHOD;
 
 typedef enum
@@ -398,6 +399,8 @@ extern void qo_info_stats (FILE *);
 
 extern bool qo_is_seq_scan (QO_PLAN *);
 extern bool qo_is_iscan (QO_PLAN *);
+extern bool qo_is_viscan (QO_PLAN *);
+
 extern bool qo_is_iscan_from_groupby (QO_PLAN *);
 extern bool qo_is_iscan_from_orderby (QO_PLAN *);
 extern bool qo_is_interesting_order_scan (QO_PLAN *);

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -16732,8 +16732,7 @@ pt_print_value (PARSER_CONTEXT * parser, PT_NODE * p)
       q = pt_append_nulstring (parser, q, "\'");
       break;
     case PT_TYPE_VECTOR:
-      std::string str = db_vector_float_to_string (p->info.value.data_value.vector_float);
-      q = pt_append_nulstring (parser, q, str.c_str ());
+      q = pt_append_nulstring (parser, q, db_vector_float_to_string (p->info.value.data_value.vector_float).c_str ());
       break;
     default:
       q = pt_append_nulstring (parser, q, "-- Unknown value type --");

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -55,6 +55,7 @@
 #include "parser_allocator.hpp"
 #include "tde.h"
 #include "jsp_cl.h"
+#include "db_vector.hpp"
 
 #include <malloc.h>
 
@@ -16731,7 +16732,8 @@ pt_print_value (PARSER_CONTEXT * parser, PT_NODE * p)
       q = pt_append_nulstring (parser, q, "\'");
       break;
     case PT_TYPE_VECTOR:
-      q = pt_append_nulstring (parser, q, (char *) p->info.value.data_value.str->bytes);
+      std::string str = db_vector_float_to_string (p->info.value.data_value.vector_float);
+      q = pt_append_nulstring (parser, q, str.c_str ());
       break;
     default:
       q = pt_append_nulstring (parser, q, "-- Unknown value type --");

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -16728,6 +16728,9 @@ pt_print_value (PARSER_CONTEXT * parser, PT_NODE * p)
       q = pt_append_nulstring (parser, q, (char *) p->info.value.data_value.str->bytes);
       q = pt_append_nulstring (parser, q, "\'");
       break;
+    case PT_TYPE_VECTOR:
+      q = pt_append_nulstring (parser, q, (char *) p->info.value.data_value.str->bytes);
+      break;
     default:
       q = pt_append_nulstring (parser, q, "-- Unknown value type --");
       parser->flag.print_type_ambiguity = 1;

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -434,7 +434,10 @@ extern "C"
   extern bool pt_is_aggregate_function (PARSER_CONTEXT * parser, const PT_NODE * node);
   extern bool pt_is_analytic_function (PARSER_CONTEXT * parser, const PT_NODE * node);
   extern bool pt_is_expr_wrapped_function (PARSER_CONTEXT * parser, const PT_NODE * node);
+
+  extern bool pt_is_vector_function (PARSER_CONTEXT * parser, const PT_NODE * node);
   extern bool pt_is_json_function (PARSER_CONTEXT * parser, const PT_NODE * node);
+
   extern PT_NODE *pt_find_spec (PARSER_CONTEXT * parser, const PT_NODE * from, const PT_NODE * name);
   extern PT_NODE *pt_find_spec_in_statement (PARSER_CONTEXT * parser, const PT_NODE * stmt, const PT_NODE * name);
   extern PT_NODE *pt_find_aggregate_names (PARSER_CONTEXT * parser, PT_NODE * tree, void *arg, int *continue_walk);

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -710,13 +710,25 @@ pt_is_expr_wrapped_function (PARSER_CONTEXT * parser, const PT_NODE * node)
 	  || function_type == F_JSON_SET
 	  || function_type == F_JSON_TYPE || function_type == F_JSON_UNQUOTE || function_type == F_JSON_VALID
 	  || function_type == F_REGEXP_COUNT || function_type == F_REGEXP_INSTR || function_type == F_REGEXP_LIKE
-	  || function_type == F_REGEXP_REPLACE || function_type == F_REGEXP_SUBSTR)
+	  || function_type == F_REGEXP_REPLACE || function_type == F_REGEXP_SUBSTR
+	  || function_type == F_VECTOR_DISTANCE || function_type == F_L1_DISTANCE || function_type == F_L2_DISTANCE
+	  || function_type == F_INNER_PRODUCT || function_type == F_COSINE_DISTANCE)
 	{
 	  return true;
 	}
     }
 
   return false;
+}
+
+bool
+pt_is_vector_function (PARSER_CONTEXT * parser, const PT_NODE * node)
+{
+  return node->node_type == PT_FUNCTION && (node->info.function.function_type == F_VECTOR_DISTANCE
+					    || node->info.function.function_type == F_L1_DISTANCE
+					    || node->info.function.function_type == F_L2_DISTANCE
+					    || node->info.function.function_type == F_INNER_PRODUCT
+					    || node->info.function.function_type == F_COSINE_DISTANCE);
 }
 
 /*

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -12438,8 +12438,9 @@ pt_to_class_spec_list (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * where_
 	      // assert (false);
 	      access =
 		pt_make_class_access_spec (parser, flat, class_->info.name.db_object, TARGET_CLASS,
-					   ACCESS_METHOD_VECTOR_INDEX_SCAN, NULL, NULL, where, NULL, NULL, NULL, NULL,
-					   NULL, output_val_list, NULL, NULL, NULL, NULL, NULL, NO_SCHEMA, NULL, NULL);
+					   ACCESS_METHOD_VECTOR_INDEX_SCAN, index_info, NULL, where, NULL, NULL, NULL,
+					   NULL, NULL, output_val_list, NULL, NULL, NULL, NULL, NULL, NO_SCHEMA, NULL,
+					   NULL);
 	    }
 	  else
 	    {

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -12427,9 +12427,19 @@ pt_to_class_spec_list (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * where_
 	      index_info = pt_to_index_info (parser, class_->info.name.db_object, where, plan, index_pred);
 	      access =
 		pt_make_class_access_spec (parser, flat, class_->info.name.db_object, TARGET_CLASS, access_method,
-					   index_info, NULL, where, NULL, NULL, NULL, NULL, NULL, output_val_list, NULL,
-					   NULL, NULL, NULL, NULL, NO_SCHEMA, db_values_array_p,
+					   index_info, NULL, where, NULL, NULL, NULL, NULL, NULL, output_val_list,
+					   NULL, NULL, NULL, NULL, NULL, NO_SCHEMA, db_values_array_p,
 					   regu_attributes_reserved);
+	    }
+	  else if (plan->plan_un.scan.scan_method == QO_SCANMETHOD_VECTOR_INDEX_SCAN)
+	    {
+	      /* TODO (CUBVEC) */
+	      // very happy!
+	      // assert (false);
+	      access =
+		pt_make_class_access_spec (parser, flat, class_->info.name.db_object, TARGET_CLASS,
+					   ACCESS_METHOD_VECTOR_INDEX_SCAN, NULL, NULL, where, NULL, NULL, NULL, NULL,
+					   NULL, output_val_list, NULL, NULL, NULL, NULL, NULL, NO_SCHEMA, NULL, NULL);
 	    }
 	  else
 	    {
@@ -12563,11 +12573,11 @@ pt_to_class_spec_list (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * where_
 
 	      assert (index_info != NULL);
 	      access =
-		pt_make_class_access_spec (parser, flat, class_->info.name.db_object, TARGET_CLASS, ACCESS_METHOD_INDEX,
-					   index_info, where_key, where, where_range, regu_attributes_key,
-					   regu_attributes_pred, regu_attributes_rest, regu_attributes_range,
-					   output_val_list, regu_var_list, cache_key, cache_pred, cache_rest,
-					   cache_range, NO_SCHEMA, NULL, NULL);
+		pt_make_class_access_spec (parser, flat, class_->info.name.db_object, TARGET_CLASS,
+					   ACCESS_METHOD_INDEX, index_info, where_key, where, where_range,
+					   regu_attributes_key, regu_attributes_pred, regu_attributes_rest,
+					   regu_attributes_range, output_val_list, regu_var_list, cache_key,
+					   cache_pred, cache_rest, cache_range, NO_SCHEMA, NULL, NULL);
 
 	      if (ipl_where_part)
 		{

--- a/src/query/query_dump.c
+++ b/src/query/query_dump.c
@@ -527,6 +527,8 @@ qdump_access_method_string (ACCESS_METHOD access)
       return "sequential sampling scan";
     case ACCESS_METHOD_SEQUENTIAL_PAGE_SCAN:
       return "sequential page scan";
+    case ACCESS_METHOD_VECTOR_INDEX_SCAN:
+      return "vindex";
     default:
       return "undefined";
     }

--- a/src/query/xasl.h
+++ b/src/query/xasl.h
@@ -818,12 +818,16 @@ typedef enum
   ACCESS_METHOD_SEQUENTIAL_PAGE_SCAN,	/* sequential scan access that only scans pages without accessing record data */
   ACCESS_METHOD_INDEX_KEY_INFO,	/* indexed access to obtain key information */
   ACCESS_METHOD_INDEX_NODE_INFO,	/* indexed access to obtain b-tree node info */
-  ACCESS_METHOD_SEQUENTIAL_SAMPLING_SCAN	/* sequential sampling scan */
+  ACCESS_METHOD_SEQUENTIAL_SAMPLING_SCAN,	/* sequential sampling scan */
+  ACCESS_METHOD_VECTOR_INDEX_SCAN,	/* vector index scan */
 } ACCESS_METHOD;
 
 #define IS_ANY_INDEX_ACCESS(access_) \
   ((access_) == ACCESS_METHOD_INDEX || (access_) == ACCESS_METHOD_INDEX_KEY_INFO \
    || (access_) == ACCESS_METHOD_INDEX_NODE_INFO)
+
+#define IS_VECTOR_INDEX_ACCESS(access_) \
+  ((access_) == ACCESS_METHOD_VECTOR_INDEX_SCAN)
 
 typedef enum
 {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-70

### Purpose

```
CREATE TABLE items (id int, vc1 vector);
CREATE VECTOR INDEX idx_v ON items(vc1 EUCLIDEAN);

INSERT INTO items VALUES (1, '[1,2,3]');
INSERT INTO items VALUES (2, '[2,3,4]');
INSERT INTO items VALUES (3, '[3,4,5]');
INSERT INTO items VALUES (4, '[4,5,6]');
INSERT INTO items VALUES (5, '[5,6,7]');
```

다음 질의에서 벡터 인덱스로 items를 스캔하는 쿼리 플랜을 생성할 수 있도록 새로운 루틴을 추가합니다. 
```
;plan detail
SELECT id, l2_distance(vc1, '[1,2,3]') AS distance FROM items ORDER by distance LIMIT 3;
```

### Implementation

* vector index로 쿼리 플랜을 만들것인지 판단하는 함수: qo_validate_index_for_vector_index ()
* vector index scan 플랜 생성: qo_generate_vector_index_scan ()
```
// query_planner.c 참고
static QO_PLAN_VTBL qo_vector_index_scan_plan_vtbl = {
  "viscan",
  qo_scan_fprint,
  qo_scan_walk,
  qo_scan_free,
  qo_zero_cost, // TODO (CUBVEC): always use vector index scan instead of sequential scan
  qo_zero_cost, // TODO (CUBVEC): always use vector index scan instead of sequential scan
  qo_scan_info,
  "Vector index scan"
};
```
** qo_zero_cost 로 해당 조건일 때 항상 vector index 플랜을 선택하도록 수정

### Remarks

N/A
