### PR TITLE
[CBRD-26025] Fix HY090 error when inserting null in Windows

### DIFF
--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -1318,18 +1318,33 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 
 	net_arg_get_str (&value, &val_size, net_value);
 
-	c_data_type = SQL_C_CHAR;
-	sql_bind_type = SQL_VARCHAR;
+	c_data_type = SQL_C_WCHAR;
+	sql_bind_type = SQL_WVARCHAR;
 
 	value_list->string_val = value;
 
-	SQL_CHK_ERR (handle->hstmt,
-		     SQL_HANDLE_STMT,
-		     err_code = SQLBindParameter (handle->hstmt,
-						  bind_num,
-						  SQL_PARAM_INPUT,
-						  c_data_type,
-						  sql_bind_type, val_size + 1, 0, value_list->string_val, 0, &cbValue));
+	if (curr_dbms_type == CAS_CGW_DBMS_ORACLE)
+	  {
+	    SQL_CHK_ERR (handle->hstmt,
+			 SQL_HANDLE_STMT,
+			 err_code = SQLBindParameter (handle->hstmt,
+						      bind_num,
+						      SQL_PARAM_INPUT,
+						      c_data_type,
+						      sql_bind_type, val_size + 1, 0, (SQLWCHAR *) "", 1, &cbValue));
+	  }
+	else
+	  {
+	    SQL_CHK_ERR (handle->hstmt,
+			 SQL_HANDLE_STMT,
+			 err_code = SQLBindParameter (handle->hstmt,
+						      bind_num,
+						      SQL_PARAM_INPUT,
+						      c_data_type,
+						      sql_bind_type, val_size + 1, 0,
+						      (SQLWCHAR *) value_list->string_val, 0, &cbValue));
+
+	  }
       }
       break;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26025

Purpose
Oracle의 경우 varchar type에 null 또는 "" 을 입력하면 null 이 들어간다.
Windows Server 2012 R2에서 발생하는 에러 HY090 를 수정하기 위해서 bind value에 null 대신 "" 을 입력 하도록 변경함

Implementation
oracle와 mysql, mariadb 코드를 분리함

Remarks
자세한 내용은 CBRD-26025 의 comment를 확인해 주세요