### PR TITLE
[CBRD-26040] do not push for dblink query

### DIFF
--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -4458,6 +4458,11 @@ mq_copypush_sargable_terms_helper (PARSER_CONTEXT * parser, PT_NODE * statement,
       /* check for dblink's function term */
       if (in_spec->info.spec.derived_table_type == PT_DERIVED_DBLINK_TABLE)
 	{
+	  if (parser->flag.is_parsing_static_sql)
+	    {
+	      continue;
+	    }
+
 	  if (!mq_is_dblink_pushable_term (parser, term))
 	    {
 	      continue;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26040>

해당 이슈의 문제 발생을 막기 위해 
compile시 static SQL에서 DBLink 테이블 사용시 push 기능을 동작하지 않게 처리
