### PR TITLE
[CBRD-26042] prohibit DBLink in PL/CSQL Static SQL DML

### DIFF
--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -12079,7 +12079,7 @@ pt_rewrite_for_dblink (PARSER_CONTEXT * parser, PT_NODE * stmt)
 	{
 	  if (snl.has_dblink_query || snl.server_node_cnt > 0)
 	    {
-	      PT_ERROR (parser, stmt, "DBLink DML is not yet supported for PL/CSQL Static SQL");
+	      PT_ERROR (parser, stmt, "DBLink DML is not yet supported for PL/CSQL Static SQL.");
 	      return;
 	    }
 	}

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -12071,6 +12071,15 @@ pt_rewrite_for_dblink (PARSER_CONTEXT * parser, PT_NODE * stmt)
 	{
 	  return;
 	}
+      if (parser->flag.is_parsing_static_sql)
+	{
+	  if (snl.has_dblink_query || snl.server_node_cnt > 0)
+	    {
+	      PT_ERROR (parser, stmt, "DBLink DML is not yet supported for PL/CSQL Static SQL");
+	      return;
+	    }
+	}
+
       break;
     case PT_DIFFERENCE:
     case PT_INTERSECTION:

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -12071,6 +12071,10 @@ pt_rewrite_for_dblink (PARSER_CONTEXT * parser, PT_NODE * stmt)
 	{
 	  return;
 	}
+      // Under the current implementation of DBLink, host variables cannot be idenfified at compile time
+      // due to the lack of schema information of the remote tables.
+      // Therefore, DBLink in Static SQL DML is prohibited for now.
+      // Note that this is not the case for Static SQL SELECT statements.
       if (parser->flag.is_parsing_static_sql)
 	{
 	  if (snl.has_dblink_query || snl.server_node_cnt > 0)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26042>

### Purpose

현재 DBLink 구현 상 PL/CSQL Static SQL DML에 포함된 호스트 변수를 구분할 수 없기 때문에, 
일단 이 부분을 막는다. 

### Implementation

CREATE PROCEDURE/FUNCTION 문 실행 시
PL/CSQL Static SQL DML에 DBLink 기능을 사용했으면 시맨틱 에러 발생시킴
