### PR TITLE
[CUBVEC-62] fix build fail - syntax error inside assert stmt

### DIFF
--- a/src/query/vector_opfunc.cpp
+++ b/src/query/vector_opfunc.cpp
@@ -124,7 +124,7 @@ static int vector_distance_internal (DB_VALUE *result, DB_VALUE *args[], int num
   const DB_VECTOR_FLOAT *vf2 = db_get_vector_float (args[1]);
   const auto arr2 = vf2->float_array;
 
-  assert (vf2->dim1 == vf2->dim2);
+  ASSERT_CUBVEC (vf1->dim == vf2->dim);
 
   float distance = 0.0f;
   try


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBVEC-62>

### Purpose

Syntax error typo (mistake) inside an assert statement leads to build failure in Debug mode.

### Implementation

![image](https://github.com/user-attachments/assets/fc5fc98d-b202-492c-89bf-e0f5fb1a2452)

### Remarks

퍼포먼스 벤치마킹을 위해서 모두가 Release 모드로 테스트했기에 해당 Syntax error를 잡아내지 못한 것으로 보입니다.

Release 모드에서도 Syntax error가 발생하도록 CircleCI에 설정해둔 ASSERT_CUBVEC()을 사용하면 해당 실수를 방지할 수 있습니다.