### PR TITLE
[CBRD-26011] Union, intersection, difference 문의 하위 select에서도 parallel heap scan이 가능하게 변경

### DIFF
--- a/src/query/parallel/px_heap_scan/px_heap_scan_checker.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_checker.cpp
@@ -545,6 +545,7 @@ namespace parallel_heap_scan
       case UNION_PROC:
       case DIFFERENCE_PROC:
       case INTERSECTION_PROC:
+	break;
       case OBJFETCH_PROC:
       case MERGELIST_PROC:
       case UPDATE_PROC:


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26011>

### Purpose

현재 CUBRID의 Parallel Heap Scan 기능은 UNION/DIFFERENCE/INTERSECTION 쿼리에 대해 적용되지 않습니다.
본 개선은 UNION/DIFFERENCE/INTERSECTION 쿼리에 대해서도 Parallel Heap Scan이 적용될 수 있도록 하여, 대용량 데이터 처리 성능을 향상시키는 것을 목표로 합니다.

### Implementation

_checker.cpp 모듈에서 UNION/DIFFERENCE/INTERSECTION 쿼리를 가능하게 허용합니다.

### Remarks

N/A
