### PR TITLE
[CBRD-26012] partitioned table에 대한 parallel heap scan 지원

### DIFF
--- a/src/query/parallel/px_heap_scan/px_heap_scan_checker.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_checker.cpp
@@ -567,7 +567,7 @@ namespace parallel_heap_scan
 	|| XASL_IS_FLAGED (xasl, XASL_MULTI_UPDATE_AGG))
       {
 	result = CHECK_RESULT::CANNOT_PARALLEL;
-	setter.set (xasl, CHECK_RESULT::CANNOT_PARALLEL);
+	setter.set_cannot_parallel_recursive (xasl);
       }
     CHECK_RESULT aptr_result = CHECK_RESULT::NONE;
     for (XASL_NODE *xaslp = xasl->aptr_list; xaslp; xaslp = xaslp->next)

--- a/src/query/parallel/px_heap_scan/px_heap_scan_manager.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_manager.cpp
@@ -469,7 +469,14 @@ scan_close_parallel_heap_scan (THREAD_ENTRY *thread_p, SCAN_ID *scan_id)
   if (thread_is_on_trace (thread_p))
     {
       std::size_t parallelism = scan_id->s.phsid.manager->m_parallelism;
-      scan_id->s.phsid.perf_monitor = new parallel_heap_scan::perf_monitor (scan_id, parallelism);
+      if (scan_id->s.phsid.perf_monitor == nullptr)
+	{
+	  scan_id->s.phsid.perf_monitor = new parallel_heap_scan::perf_monitor (scan_id, parallelism);
+	}
+      else
+	{
+	  scan_id->s.phsid.perf_monitor->add_statistics (scan_id, parallelism);
+	}
       /* should be deleted in qdump_print_access_specs_text or json */
     }
   orig_heap_id = db_change_private_heap (thread_p, 0);
@@ -528,6 +535,10 @@ scan_open_parallel_heap_scan (THREAD_ENTRY *thread_p, SCAN_ID *scan_id,
 	  assert (false);
 	}
       db_change_private_heap (thread_p, orig_heap_id);
+    }
+  else
+    {
+      qfile_reopen_list_as_append_mode (thread_p, xasl->list_id);
     }
   return ret;
 }

--- a/src/query/parallel/px_heap_scan/px_heap_scan_memory_mapper.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_memory_mapper.cpp
@@ -562,6 +562,9 @@ namespace parallel_heap_scan
     scan_id = (SCAN_ID *) malloc (sizeof (SCAN_ID));
     memcpy (scan_id, scan_idp, sizeof (SCAN_ID));
     scan_id->type = S_HEAP_SCAN;
+    scan_id->scan_stats.elapsed_scan = {0, 0};
+    scan_id->scan_stats.read_rows = 0;
+    scan_id->scan_stats.qualified_rows = 0;
     HEAP_SCAN_ID *hsid = (HEAP_SCAN_ID *) &scan_id->s.hsid;
     orig_val_descr_ptr = scan_idp->vd;
     scan_id->vd = copy_and_map (scan_idp->vd);

--- a/src/query/parallel/px_heap_scan/px_heap_scan_perf_monitor.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_perf_monitor.cpp
@@ -44,6 +44,18 @@ namespace parallel_heap_scan
   {
   }
 
+  void perf_monitor::add_statistics (SCAN_ID *scan_id, std::size_t parallelism)
+  {
+    SCAN_STATS *new_scan_stats;
+    for (std::size_t i = 0; i < parallelism; i++)
+      {
+	new_scan_stats = &scan_id->s.phsid.manager->m_memory_mappers[i]->get_scan_id()->scan_stats;
+	TSC_ADD_TIMEVAL (m_scan_stats[i].elapsed_scan, new_scan_stats->elapsed_scan);
+	m_scan_stats[i].read_rows += new_scan_stats->read_rows;
+	m_scan_stats[i].qualified_rows += new_scan_stats->qualified_rows;
+      }
+  }
+
   void perf_monitor::print_text (FILE *fp, int indent, char *class_name, bool is_list_merge)
   {
     UINT64 min_elapsed_scan = std::numeric_limits<UINT64>::max();

--- a/src/query/parallel/px_heap_scan/px_heap_scan_perf_monitor.hpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_perf_monitor.hpp
@@ -36,6 +36,7 @@ namespace parallel_heap_scan
     public:
       perf_monitor (SCAN_ID *scan_id, std::size_t parallelism);
       ~perf_monitor();
+      void add_statistics (SCAN_ID *scan_id, std::size_t parallelism);
       void print_text (FILE *fp, int indent, char *class_name, bool is_list_merge);
       void print_json (json_t *scan, char *class_name, bool is_list_merge);
     private:

--- a/src/query/parallel/px_list_merger.cpp
+++ b/src/query/parallel/px_list_merger.cpp
@@ -68,6 +68,14 @@ namespace parallel_query
 	    list_id->type_list = tmp_type_list;
 	  }
       }
+    if (m_head_list_id->last_pgptr != NULL)
+      {
+	qfile_close_list (m_thread_p, m_head_list_id);
+      }
+    if (list_id->last_pgptr != NULL)
+      {
+	qfile_close_list (m_thread_p, list_id);
+      }
     /* head last page -> list_id first page (next) */
     PAGE_PTR head_last_pgptr = pgbuf_fix (m_thread_p, &m_head_list_id->last_vpid, OLD_PAGE, PGBUF_LATCH_WRITE,
 					  PGBUF_UNCONDITIONAL_LATCH);
@@ -85,7 +93,6 @@ namespace parallel_query
     m_head_list_id->tuple_cnt += list_id->tuple_cnt;
     m_head_list_id->page_cnt += list_id->page_cnt;
     m_head_list_id->last_vpid = list_id->last_vpid;
-    m_head_list_id->last_pgptr = list_id->last_pgptr;
     m_head_list_id->last_offset = list_id->last_offset;
     m_head_list_id->lasttpl_len = list_id->lasttpl_len;
     assert (m_head_list_id->query_id == list_id->query_id);
@@ -104,7 +111,18 @@ namespace parallel_query
 
   void list_merger::swap_and_destroy_list_id (THREAD_ENTRY *thread_p, QFILE_LIST_ID **orig_list, QFILE_LIST_ID **new_list)
   {
-    qfile_destroy_list (thread_p, *orig_list);
-    qfile_copy_list_id (*orig_list, *new_list, false);
+    QFILE_LIST_ID *ret;
+    if ((*orig_list) != NULL && (*orig_list)->tuple_cnt != 0)
+      {
+	list_merger merger (thread_p);
+	merger.add_list_id (*orig_list);
+	merger.add_list_id (*new_list);
+	(void) merger.get_merged_list_id ();
+      }
+    else
+      {
+	qfile_destroy_list (thread_p, *orig_list);
+	qfile_copy_list_id (*orig_list, *new_list, false);
+      }
   }
 }

--- a/src/query/parallel/px_list_merger.cpp
+++ b/src/query/parallel/px_list_merger.cpp
@@ -117,7 +117,7 @@ namespace parallel_query
 	list_merger merger (thread_p);
 	merger.add_list_id (*orig_list);
 	merger.add_list_id (*new_list);
-	(void) merger.get_merged_list_id ();
+	merger.clear();
       }
     else
       {

--- a/src/query/parallel/px_list_merger.hpp
+++ b/src/query/parallel/px_list_merger.hpp
@@ -39,6 +39,11 @@ namespace parallel_query
       void add_list_id (QFILE_LIST_ID *list_id);
       QFILE_LIST_ID *get_merged_list_id ();
       static void swap_and_destroy_list_id (THREAD_ENTRY *thread_p, QFILE_LIST_ID **orig_list, QFILE_LIST_ID **new_list);
+      inline void clear()
+      {
+	m_head_list_id = nullptr;
+	m_thread_p = nullptr;
+      }
 
     private:
       THREAD_ENTRY *m_thread_p;

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -628,7 +628,7 @@ static int qexec_prune_spec (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * spec, V
 static int qexec_process_partition_unique_stats (THREAD_ENTRY * thread_p, PRUNING_CONTEXT * pcontext);
 static int qexec_process_unique_stats (THREAD_ENTRY * thread_p, const OID * class_oid,
 				       UPDDEL_CLASS_INFO_INTERNAL * class_);
-static SCAN_CODE qexec_init_next_partition (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * spec);
+static SCAN_CODE qexec_init_next_partition (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * spec, XASL_NODE * xasl);
 
 static int qexec_check_limit_clause (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_state,
 				     bool * empty_result);
@@ -9152,13 +9152,32 @@ qexec_open_scan (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * curr_spec, VAL_LIST
 
 	      if (curr_spec->num_parallel_threads > 1)
 		{
-		  if (!curr_spec->parts && !oid_is_system_class (&curr_spec->s.cls_node.cls_oid) && !mvcc_is_mvcc_disabled_class (&curr_spec->s.cls_node.cls_oid) && !mvcc_select_lock_needed && thread_p->private_heap_id != 0)	/* Only for User table */
+		  if (xasl->topn_items || XASL_IS_FLAGED (xasl, XASL_TO_BE_CACHED))
+		    {
+		      curr_spec->flags = (ACCESS_SPEC_FLAG) (curr_spec->flags & ~ACCESS_SPEC_FLAG_MERGED_LIST);
+		    }
+		  if (curr_spec->pruning_type != DB_PARTITIONED_CLASS && !oid_is_system_class (&curr_spec->s.cls_node.cls_oid) && !mvcc_is_mvcc_disabled_class (&curr_spec->s.cls_node.cls_oid) && !mvcc_select_lock_needed && thread_p->private_heap_id != 0)	/* Only for User table */
 		    {
 		      /* Why thread_p->private_heap_id != 0? 
 		       * Because, if it is 0, it means that the scan is not executed in main thread.
 		       * So, we can't use parallel heap scan.
 		       */
 		      scan_type = S_PARALLEL_HEAP_SCAN;
+		    }
+		  else
+		    {
+		      if (curr_spec->pruning_type == DB_PARTITIONED_CLASS
+			  && !oid_is_system_class (&curr_spec->s.cls_node.cls_oid)
+			  && !mvcc_is_mvcc_disabled_class (&curr_spec->s.cls_node.cls_oid) && !mvcc_select_lock_needed
+			  && thread_p->private_heap_id != 0)
+			{
+			  /* DB_PARTITION_CLASS will be parallel-heap-scanned */
+			}
+		      else
+			{
+			  curr_spec->flags =
+			    (ACCESS_SPEC_FLAG) (curr_spec->flags | ACCESS_SPEC_FLAG_NO_PARALLEL_HEAP_SCAN);
+			}
 		    }
 		}
 	    }
@@ -9721,7 +9740,7 @@ qexec_next_scan_block (THREAD_ENTRY * thread_p, XASL_NODE * xasl)
       else if (sb_scan == S_END)
 	{
 	  /* if curr_spec is a partitioned class, do not move to the next spec unless we went through all partitions */
-	  SCAN_CODE s_parts = qexec_init_next_partition (thread_p, xasl->curr_spec);
+	  SCAN_CODE s_parts = qexec_init_next_partition (thread_p, xasl->curr_spec, xasl);
 	  if (s_parts == S_SUCCESS)
 	    {
 	      /* successfully moved to the next partition */
@@ -10322,7 +10341,7 @@ qexec_prune_spec (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * spec, VAL_DESCR * 
  * spec (in)	 : spec for which to move to the next partition
  */
 static SCAN_CODE
-qexec_init_next_partition (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * spec)
+qexec_init_next_partition (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * spec, XASL_NODE * xasl)
 {
   int error = NO_ERROR;
   SCAN_OPERATION_TYPE scan_op_type = spec->s_id.scan_op_type;
@@ -10420,14 +10439,66 @@ qexec_init_next_partition (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * spec)
 	}
       hsidp->scancache_inited = false;
 
+#if SERVER_MODE && !WINDOWS
+      if (scan_type == S_HEAP_SCAN)
+	{
+	  if (!(spec->flags & ACCESS_SPEC_FLAG_NO_PARALLEL_HEAP_SCAN) && spec->curent != NULL)
+	    {
+	      scan_type = S_PARALLEL_HEAP_SCAN;
+	      parallel_heap_scan::RESULT_GET_METHOD result_get_method =
+		parallel_heap_scan::RESULT_GET_METHOD::LIST_PAGE;
+	      query_id = spec->s_id.vd->xasl_state->query_id;
+	      if (spec->flags & ACCESS_SPEC_FLAG_MERGED_LIST)
+		{
+		  result_get_method = parallel_heap_scan::RESULT_GET_METHOD::LIST_MERGE;
+		}
+	      error =
+		scan_open_parallel_heap_scan (thread_p, &spec->s_id, mvcc_select_lock_needed, scan_op_type, fixed,
+					      grouped, single_fetch, spec->s_dbval, val_list, vd, &class_oid,
+					      &class_hfid, spec->s.cls_node.cls_regu_list_pred, spec->where_pred,
+					      spec->s.cls_node.cls_regu_list_rest, spec->s.cls_node.num_attrs_pred,
+					      spec->s.cls_node.attrids_pred, spec->s.cls_node.cache_pred,
+					      spec->s.cls_node.num_attrs_rest, spec->s.cls_node.attrids_rest,
+					      spec->s.cls_node.cache_rest, scan_type, spec->s.cls_node.cache_reserved,
+					      spec->s.cls_node.cls_regu_list_reserved, true, query_id,
+					      spec->num_parallel_threads, result_get_method, xasl);
+	    }
+	  else if (spec->curent != NULL)
+	    {
+	      error =
+		scan_open_heap_scan (thread_p, &spec->s_id, mvcc_select_lock_needed, scan_op_type, fixed, grouped,
+				     single_fetch, spec->s_dbval, val_list, vd, &class_oid, &class_hfid,
+				     spec->s.cls_node.cls_regu_list_pred, spec->where_pred,
+				     spec->s.cls_node.cls_regu_list_rest, spec->s.cls_node.num_attrs_pred,
+				     spec->s.cls_node.attrids_pred, spec->s.cls_node.cache_pred,
+				     spec->s.cls_node.num_attrs_rest, spec->s.cls_node.attrids_rest,
+				     spec->s.cls_node.cache_rest, scan_type, spec->s.cls_node.cache_reserved,
+				     spec->s.cls_node.cls_regu_list_reserved, true);
+	    }
+	}
+      else
+	{
+	  error =
+	    scan_open_heap_scan (thread_p, &spec->s_id, mvcc_select_lock_needed, scan_op_type, fixed, grouped,
+				 single_fetch, spec->s_dbval, val_list, vd, &class_oid, &class_hfid,
+				 spec->s.cls_node.cls_regu_list_pred, spec->where_pred,
+				 spec->s.cls_node.cls_regu_list_rest, spec->s.cls_node.num_attrs_pred,
+				 spec->s.cls_node.attrids_pred, spec->s.cls_node.cache_pred,
+				 spec->s.cls_node.num_attrs_rest, spec->s.cls_node.attrids_rest,
+				 spec->s.cls_node.cache_rest, scan_type, spec->s.cls_node.cache_reserved,
+				 spec->s.cls_node.cls_regu_list_reserved, true);
+	}
+#else
       error =
-	scan_open_heap_scan (thread_p, &spec->s_id, mvcc_select_lock_needed, scan_op_type, fixed, grouped, single_fetch,
-			     spec->s_dbval, val_list, vd, &class_oid, &class_hfid, spec->s.cls_node.cls_regu_list_pred,
-			     spec->where_pred, spec->s.cls_node.cls_regu_list_rest,
-			     spec->s.cls_node.num_attrs_pred, spec->s.cls_node.attrids_pred,
-			     spec->s.cls_node.cache_pred, spec->s.cls_node.num_attrs_rest,
-			     spec->s.cls_node.attrids_rest, spec->s.cls_node.cache_rest,
-			     scan_type, spec->s.cls_node.cache_reserved, spec->s.cls_node.cls_regu_list_reserved, true);
+	scan_open_heap_scan (thread_p, &spec->s_id, mvcc_select_lock_needed, scan_op_type, fixed, grouped,
+			     single_fetch, spec->s_dbval, val_list, vd, &class_oid, &class_hfid,
+			     spec->s.cls_node.cls_regu_list_pred, spec->where_pred,
+			     spec->s.cls_node.cls_regu_list_rest, spec->s.cls_node.num_attrs_pred,
+			     spec->s.cls_node.attrids_pred, spec->s.cls_node.cache_pred,
+			     spec->s.cls_node.num_attrs_rest, spec->s.cls_node.attrids_rest,
+			     spec->s.cls_node.cache_rest, scan_type, spec->s.cls_node.cache_reserved,
+			     spec->s.cls_node.cls_regu_list_reserved, true);
+#endif
     }
   else if (spec->type == TARGET_CLASS && spec->access == ACCESS_METHOD_SEQUENTIAL_PAGE_SCAN)
     {

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -9156,28 +9156,24 @@ qexec_open_scan (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * curr_spec, VAL_LIST
 		    {
 		      curr_spec->flags = (ACCESS_SPEC_FLAG) (curr_spec->flags & ~ACCESS_SPEC_FLAG_MERGED_LIST);
 		    }
-		  if (curr_spec->pruning_type != DB_PARTITIONED_CLASS && !oid_is_system_class (&curr_spec->s.cls_node.cls_oid) && !mvcc_is_mvcc_disabled_class (&curr_spec->s.cls_node.cls_oid) && !mvcc_select_lock_needed && thread_p->private_heap_id != 0)	/* Only for User table */
+		  if (!oid_is_system_class (&curr_spec->s.cls_node.cls_oid) && !mvcc_is_mvcc_disabled_class (&curr_spec->s.cls_node.cls_oid) && !mvcc_select_lock_needed && thread_p->private_heap_id != 0)	/* Only for User table */
 		    {
-		      /* Why thread_p->private_heap_id != 0? 
-		       * Because, if it is 0, it means that the scan is not executed in main thread.
-		       * So, we can't use parallel heap scan.
-		       */
-		      scan_type = S_PARALLEL_HEAP_SCAN;
-		    }
-		  else
-		    {
-		      if (curr_spec->pruning_type == DB_PARTITIONED_CLASS
-			  && !oid_is_system_class (&curr_spec->s.cls_node.cls_oid)
-			  && !mvcc_is_mvcc_disabled_class (&curr_spec->s.cls_node.cls_oid) && !mvcc_select_lock_needed
-			  && thread_p->private_heap_id != 0)
+		      if (curr_spec->pruning_type == DB_PARTITIONED_CLASS)
 			{
-			  /* DB_PARTITION_CLASS will be parallel-heap-scanned */
+			  /* DB_PARTITION_CLASS will be parallel-heap-scanned, not DB_PARTITIONED_CLASS */
 			}
 		      else
 			{
-			  curr_spec->flags =
-			    (ACCESS_SPEC_FLAG) (curr_spec->flags | ACCESS_SPEC_FLAG_NO_PARALLEL_HEAP_SCAN);
+			  /* Why thread_p->private_heap_id != 0? 
+			   * Because, if it is 0, it means that the scan is not executed in main thread.
+			   * So, we can't use parallel heap scan.
+			   */
+			  scan_type = S_PARALLEL_HEAP_SCAN;
 			}
+		    }
+		  else
+		    {
+		      curr_spec->flags = (ACCESS_SPEC_FLAG) (curr_spec->flags | ACCESS_SPEC_FLAG_NO_PARALLEL_HEAP_SCAN);
 		    }
 		}
 	    }

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -10438,41 +10438,17 @@ qexec_init_next_partition (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * spec, XAS
 #if SERVER_MODE && !WINDOWS
       if (scan_type == S_HEAP_SCAN)
 	{
-	  if (!(spec->flags & ACCESS_SPEC_FLAG_NO_PARALLEL_HEAP_SCAN) && spec->curent != NULL)
+	  if (spec->curent != NULL)
 	    {
-	      scan_type = S_PARALLEL_HEAP_SCAN;
-	      parallel_heap_scan::RESULT_GET_METHOD result_get_method =
-		parallel_heap_scan::RESULT_GET_METHOD::LIST_PAGE;
-	      query_id = spec->s_id.vd->xasl_state->query_id;
-	      if (spec->flags & ACCESS_SPEC_FLAG_MERGED_LIST)
+	      if (!(spec->flags & ACCESS_SPEC_FLAG_NO_PARALLEL_HEAP_SCAN))
 		{
-		  result_get_method = parallel_heap_scan::RESULT_GET_METHOD::LIST_MERGE;
+		  scan_type = S_PARALLEL_HEAP_SCAN;
 		}
-	      error =
-		scan_open_parallel_heap_scan (thread_p, &spec->s_id, mvcc_select_lock_needed, scan_op_type, fixed,
-					      grouped, single_fetch, spec->s_dbval, val_list, vd, &class_oid,
-					      &class_hfid, spec->s.cls_node.cls_regu_list_pred, spec->where_pred,
-					      spec->s.cls_node.cls_regu_list_rest, spec->s.cls_node.num_attrs_pred,
-					      spec->s.cls_node.attrids_pred, spec->s.cls_node.cache_pred,
-					      spec->s.cls_node.num_attrs_rest, spec->s.cls_node.attrids_rest,
-					      spec->s.cls_node.cache_rest, scan_type, spec->s.cls_node.cache_reserved,
-					      spec->s.cls_node.cls_regu_list_reserved, true, query_id,
-					      spec->num_parallel_threads, result_get_method, xasl);
-	    }
-	  else if (spec->curent != NULL)
-	    {
-	      error =
-		scan_open_heap_scan (thread_p, &spec->s_id, mvcc_select_lock_needed, scan_op_type, fixed, grouped,
-				     single_fetch, spec->s_dbval, val_list, vd, &class_oid, &class_hfid,
-				     spec->s.cls_node.cls_regu_list_pred, spec->where_pred,
-				     spec->s.cls_node.cls_regu_list_rest, spec->s.cls_node.num_attrs_pred,
-				     spec->s.cls_node.attrids_pred, spec->s.cls_node.cache_pred,
-				     spec->s.cls_node.num_attrs_rest, spec->s.cls_node.attrids_rest,
-				     spec->s.cls_node.cache_rest, scan_type, spec->s.cls_node.cache_reserved,
-				     spec->s.cls_node.cls_regu_list_reserved, true);
 	    }
 	}
-      else
+#endif
+      if (scan_type == S_HEAP_SCAN || spec->access == ACCESS_METHOD_SEQUENTIAL_RECORD_INFO
+	  || spec->access == ACCESS_METHOD_SEQUENTIAL_SAMPLING_SCAN)
 	{
 	  error =
 	    scan_open_heap_scan (thread_p, &spec->s_id, mvcc_select_lock_needed, scan_op_type, fixed, grouped,
@@ -10484,16 +10460,27 @@ qexec_init_next_partition (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * spec, XAS
 				 spec->s.cls_node.cache_rest, scan_type, spec->s.cls_node.cache_reserved,
 				 spec->s.cls_node.cls_regu_list_reserved, true);
 	}
-#else
-      error =
-	scan_open_heap_scan (thread_p, &spec->s_id, mvcc_select_lock_needed, scan_op_type, fixed, grouped,
-			     single_fetch, spec->s_dbval, val_list, vd, &class_oid, &class_hfid,
-			     spec->s.cls_node.cls_regu_list_pred, spec->where_pred,
-			     spec->s.cls_node.cls_regu_list_rest, spec->s.cls_node.num_attrs_pred,
-			     spec->s.cls_node.attrids_pred, spec->s.cls_node.cache_pred,
-			     spec->s.cls_node.num_attrs_rest, spec->s.cls_node.attrids_rest,
-			     spec->s.cls_node.cache_rest, scan_type, spec->s.cls_node.cache_reserved,
-			     spec->s.cls_node.cls_regu_list_reserved, true);
+#if SERVER_MODE && !WINDOWS
+      else
+	{
+	  assert (scan_type == S_PARALLEL_HEAP_SCAN);
+	  parallel_heap_scan::RESULT_GET_METHOD result_get_method = parallel_heap_scan::RESULT_GET_METHOD::LIST_PAGE;
+	  query_id = spec->s_id.vd->xasl_state->query_id;
+	  if (spec->flags & ACCESS_SPEC_FLAG_MERGED_LIST)
+	    {
+	      result_get_method = parallel_heap_scan::RESULT_GET_METHOD::LIST_MERGE;
+	    }
+	  error =
+	    scan_open_parallel_heap_scan (thread_p, &spec->s_id, mvcc_select_lock_needed, scan_op_type, fixed,
+					  grouped, single_fetch, spec->s_dbval, val_list, vd, &class_oid,
+					  &class_hfid, spec->s.cls_node.cls_regu_list_pred, spec->where_pred,
+					  spec->s.cls_node.cls_regu_list_rest, spec->s.cls_node.num_attrs_pred,
+					  spec->s.cls_node.attrids_pred, spec->s.cls_node.cache_pred,
+					  spec->s.cls_node.num_attrs_rest, spec->s.cls_node.attrids_rest,
+					  spec->s.cls_node.cache_rest, scan_type, spec->s.cls_node.cache_reserved,
+					  spec->s.cls_node.cls_regu_list_reserved, true, query_id,
+					  spec->num_parallel_threads, result_get_method, xasl);
+	}
 #endif
     }
   else if (spec->type == TARGET_CLASS && spec->access == ACCESS_METHOD_SEQUENTIAL_PAGE_SCAN)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26012>

### Purpose

현재 CUBRID의 Parallel Heap Scan 기능은 Partitioned Table에 대해 적용되지 않습니다.
본 개선은 Partitioned Table에 대해서도 Parallel Heap Scan이 적용될 수 있도록 하여, 대용량 데이터 처리 성능을 향상시키는 것을 목표로 합니다.

### Implementation

qexec_next_scan_block() 및 qexec_init_next_partition() 에 parallel heap scan 관련 코드를 추가합니다.

### Remarks

32페이지가 넘지 않는 파티션에 대해 heap scan을 하다가, 다음 파티션은 32페이지가 넘어 parallel heap scan을 하는 경우 list가 close 되어있는 문제가 발생하여 관련 오류를 해결하였습니다.
