### PR TITLE
[CBRD-25837] Prevent logging of temp volume creation on slave node

### DIFF
--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -1152,7 +1152,6 @@ boot_remove_temp_volumes (THREAD_ENTRY * thread_p)
   const char *temp_path;
   const char *temp_name;
   char *alloc_tempath = NULL;
-  int num_vols;
 
   /*
    * Get the name of the extension: ext_path|dbname|"ext"|volid
@@ -1171,17 +1170,13 @@ boot_remove_temp_volumes (THREAD_ENTRY * thread_p)
     }
   temp_name = fileio_get_base_file_name (boot_Db_full_name);
 
-  for (num_vols = boot_Db_parm->temp_last_volid; num_vols <= LOG_MAX_DBVOLID; num_vols++)
+  for (temp_volid = boot_Db_parm->temp_last_volid; temp_volid <= LOG_MAX_DBVOLID; temp_volid++)
     {
-      temp_volid = (VOLID) num_vols;
-      if (temp_volid != NULL_VOLID)
-	{
-	  fileio_make_volume_temp_name (temp_vol_fullname, temp_path, temp_name, temp_volid);
-	  if (fileio_is_volume_exist (temp_vol_fullname) == true)
-	    {			/* Call the remove function */
-	      (void) boot_remove_temp_volume (thread_p, temp_volid, temp_vol_fullname);
-	    }
-	}
+      fileio_make_volume_temp_name (temp_vol_fullname, temp_path, temp_name, temp_volid);
+      if (fileio_is_volume_exist (temp_vol_fullname) == true)
+        {			/* Call the remove function */
+          (void) boot_remove_temp_volume (thread_p, temp_volid, temp_vol_fullname);
+        }
     }
 
   if (alloc_tempath)

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -193,7 +193,7 @@ static int boot_find_rest_permanent_volumes (THREAD_ENTRY * thread_p, bool newvo
 					     int (*fun) (THREAD_ENTRY * thread_p, VOLID xvolid, const char *vlabel,
 							 void *args), void *args);
 
-static void boot_find_rest_temp_volumes (THREAD_ENTRY * thread_p, VOLID volid,
+static void boot_find_rest_temp_volumes (THREAD_ENTRY * thread_p,
 					 bool forward_dir, bool check_before_access);
 static int boot_check_permanent_volumes (THREAD_ENTRY * thread_p);
 static int boot_mount (THREAD_ENTRY * thread_p, VOLID volid, const char *vlabel, void *ignore_arg);
@@ -921,7 +921,7 @@ boot_remove_all_temp_volumes (THREAD_ENTRY * thread_p, REMOVE_TEMP_VOL_ACTION de
       return NO_ERROR;
     }
 
-  boot_find_rest_temp_volumes (thread_p, NULL_VOLID, true, true);
+  boot_find_rest_temp_volumes (thread_p, true, true);
 
   if (delete_action == ONLY_PHYSICAL_REMOVE_TEMP_VOL_ACTION)
     {
@@ -1160,14 +1160,13 @@ boot_find_rest_permanent_volumes (THREAD_ENTRY * thread_p, bool newvolpath, bool
 /*
  * bo_find_rest_tempvols () - call function on the rest of temporary vols of the database
  *
- *   volid(in): Volume identifier
  *   forward_dir(in): direction of accessing the tempvols (forward/backward)
  *   check_before_access(in): if true, check the existence of volume before access
  *
  * Note: The given function is called for every single temporary volume which is different from the given one.
  */
 static void
-boot_find_rest_temp_volumes (THREAD_ENTRY * thread_p, VOLID volid, bool forward_dir, bool check_before_access)
+boot_find_rest_temp_volumes (THREAD_ENTRY * thread_p, bool forward_dir, bool check_before_access)
 {
   VOLID temp_volid;
   char temp_vol_fullname[PATH_MAX];
@@ -1200,7 +1199,7 @@ boot_find_rest_temp_volumes (THREAD_ENTRY * thread_p, VOLID volid, bool forward_
       for (num_vols = boot_Db_parm->temp_last_volid; num_vols <= LOG_MAX_DBVOLID; num_vols++)
 	{
 	  temp_volid = (VOLID) num_vols;
-	  if (temp_volid != volid)
+	  if (temp_volid != NULL_VOLID)
 	    {
 	      /* Find the name of the volume */
 	      fileio_make_volume_temp_name (temp_vol_fullname, temp_path, temp_name, temp_volid);
@@ -1228,7 +1227,7 @@ boot_find_rest_temp_volumes (THREAD_ENTRY * thread_p, VOLID volid, bool forward_
       for (num_vols = LOG_MAX_DBVOLID; num_vols >= boot_Db_parm->temp_last_volid; num_vols--)
 	{
 	  temp_volid = (VOLID) num_vols;
-	  if (temp_volid != volid)
+	  if (temp_volid != NULL_VOLID)
 	    {
 	      /* Find the name of the volume */
 	      fileio_make_volume_temp_name (temp_vol_fullname, temp_path, temp_name, temp_volid);

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -1174,9 +1174,9 @@ boot_remove_temp_volumes (THREAD_ENTRY * thread_p)
     {
       fileio_make_volume_temp_name (temp_vol_fullname, temp_path, temp_name, temp_volid);
       if (fileio_is_volume_exist (temp_vol_fullname) == true)
-        {			/* Call the remove function */
-          (void) boot_remove_temp_volume (thread_p, temp_volid, temp_vol_fullname);
-        }
+	{			/* Call the remove function */
+	  (void) boot_remove_temp_volume (thread_p, temp_volid, temp_vol_fullname);
+	}
     }
 
   if (alloc_tempath)

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -913,13 +913,11 @@ boot_remove_all_temp_volumes (THREAD_ENTRY * thread_p, REMOVE_TEMP_VOL_ACTION de
       boot_remove_unknown_temp_volumes (thread_p);
     }
 
-  /* if (boot_Db_parm->temp_nvols == 0)
-     {
-     assert (boot_Db_parm->temp_last_volid == NULL_VOLID);
-     return NO_ERROR;
-     }
-     TODO: Even when boot_Db_parm->temp_nvols == 0, temp volumes are still removed, so they should always be subject to removal
-   */
+  if (boot_Db_parm->temp_nvols == 0)
+    {
+      assert (boot_Db_parm->temp_last_volid == NULL_VOLID);
+      return NO_ERROR;
+    }
 
   boot_find_and_remove_temp_volumes (thread_p);
 

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -182,7 +182,6 @@ static int boot_get_db_parm (THREAD_ENTRY * thread_p, BOOT_DB_PARM * dbparm, OID
 static int boot_remove_temp_volume (THREAD_ENTRY * thread_p, VOLID volid, const char *vlabel);
 
 static int boot_remove_all_temp_volumes (THREAD_ENTRY * thread_p, REMOVE_TEMP_VOL_ACTION delete_action);
-static int boot_xremove_temp_volume (THREAD_ENTRY * thread_p, VOLID volid, const char *vlabel);
 static void boot_make_temp_volume_fullname (char *temp_vol_fullname, VOLID temp_volid);
 static void boot_remove_unknown_temp_volumes (THREAD_ENTRY * thread_p);
 static int boot_parse_add_volume_extensions (THREAD_ENTRY * thread_p, const char *filename_addmore_vols);
@@ -946,22 +945,6 @@ boot_remove_all_temp_volumes (THREAD_ENTRY * thread_p, REMOVE_TEMP_VOL_ACTION de
   return error_code;
 }
 
-/*
- * boot_xremove_temp_volume () - remove a temporary volume from the database
- *
- * return : NO_ERROR if all OK, ER_ status otherwise
- *
- *   volid(in): Volume identifier to remove
- *   vlabel(in): Volume label
- *
- * Note: Pass control to boot_remove_temp_volume to remove the temporary volume.
- */
-static int
-boot_xremove_temp_volume (THREAD_ENTRY * thread_p, VOLID volid, const char *vlabel)
-{
-  return boot_remove_temp_volume (thread_p, volid, vlabel);
-}
-
 static void
 boot_make_temp_volume_fullname (char *temp_vol_fullname, VOLID temp_volid)
 {
@@ -1159,7 +1142,7 @@ boot_find_rest_permanent_volumes (THREAD_ENTRY * thread_p, bool newvolpath, bool
 }
 
 /*
- * boot_find_and_remove_temp_volumes () - Find temporary volumes and remove them using boot_xremove_temp_volume()
+ * boot_find_and_remove_temp_volumes () - Find temporary volumes and remove them using boot_remove_temp_volume()
  *
  * Note: The given function is called for every single temporary volume which is different from the given one.
  */
@@ -1198,7 +1181,7 @@ boot_find_and_remove_temp_volumes (THREAD_ENTRY * thread_p)
 	  fileio_make_volume_temp_name (temp_vol_fullname, temp_path, temp_name, temp_volid);
 	  if (fileio_is_volume_exist (temp_vol_fullname) == true)
 	    {			/* Call the remove function */
-              (void) boot_xremove_temp_volume (thread_p, temp_volid, temp_vol_fullname);
+              (void) boot_remove_temp_volume (thread_p, temp_volid, temp_vol_fullname);
 	    }
 	}
     }

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -6120,6 +6120,18 @@ boot_dbparm_save_volume (THREAD_ENTRY * thread_p, DB_VOLTYPE voltype, VOLID voli
 	}
       boot_Db_parm->last_volid = volid;
       boot_Db_parm->nvols++;
+
+      /* todo: is flush needed? */
+      VPID_GET_FROM_OID (&vpid_boot_bp_parm, boot_Db_parm_oid);
+      log_append_undo_data2 (thread_p, RVPGBUF_FLUSH_PAGE, NULL, NULL, 0, sizeof (vpid_boot_bp_parm),
+			     &vpid_boot_bp_parm);
+
+      error_code = boot_db_parm_update_heap (thread_p);
+
+      /* flush the boot_Db_parm object. this is not necessary but it is recommended in order to mount every known volume
+       * during restart. that may not be possible during media crash though. */
+      heap_flush (thread_p, boot_Db_parm_oid);
+      fileio_synchronize (thread_p, fileio_get_volume_descriptor (boot_Db_parm_oid->volid), NULL, FILEIO_SYNC_ALSO_FLUSH_DWB);	/* label? */
     }
   else
     {
@@ -6135,22 +6147,12 @@ boot_dbparm_save_volume (THREAD_ENTRY * thread_p, DB_VOLTYPE voltype, VOLID voli
       boot_Db_parm->temp_last_volid = volid;
     }
 
-  /* todo: is flush needed? */
-  VPID_GET_FROM_OID (&vpid_boot_bp_parm, boot_Db_parm_oid);
-  log_append_undo_data2 (thread_p, RVPGBUF_FLUSH_PAGE, NULL, NULL, 0, sizeof (vpid_boot_bp_parm), &vpid_boot_bp_parm);
-
-  error_code = boot_db_parm_update_heap (thread_p);
   if (error_code != NO_ERROR)
     {
       ASSERT_ERROR ();
       *boot_Db_parm = save_boot_db_parm;
       goto exit;
     }
-
-  /* flush the boot_Db_parm object. this is not necessary but it is recommended in order to mount every known volume
-   * during restart. that may not be possible during media crash though. */
-  heap_flush (thread_p, boot_Db_parm_oid);
-  fileio_synchronize (thread_p, fileio_get_volume_descriptor (boot_Db_parm_oid->volid), NULL, FILEIO_SYNC_ALSO_FLUSH_DWB);	/* label? */
 
 exit:
   return error_code;

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -1191,7 +1191,6 @@ boot_find_and_remove_temp_volumes (THREAD_ENTRY * thread_p)
     }
   temp_name = fileio_get_base_file_name (boot_Db_full_name);
 
-  /* Cycle over all temporarily volumes, skip the given one */
   for (num_vols = boot_Db_parm->temp_last_volid; num_vols <= LOG_MAX_DBVOLID; num_vols++)
     {
       temp_volid = (VOLID) num_vols;

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -6041,7 +6041,6 @@ boot_dbparm_save_volume (THREAD_ENTRY * thread_p, DB_VOLTYPE voltype, VOLID voli
       boot_Db_parm->last_volid = volid;
       boot_Db_parm->nvols++;
 
-      /* todo: is flush needed? */
       VPID_GET_FROM_OID (&vpid_boot_bp_parm, boot_Db_parm_oid);
       log_append_undo_data2 (thread_p, RVPGBUF_FLUSH_PAGE, NULL, NULL, 0, sizeof (vpid_boot_bp_parm),
 			     &vpid_boot_bp_parm);

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -193,8 +193,7 @@ static int boot_find_rest_permanent_volumes (THREAD_ENTRY * thread_p, bool newvo
 					     int (*fun) (THREAD_ENTRY * thread_p, VOLID xvolid, const char *vlabel,
 							 void *args), void *args);
 
-static void boot_find_rest_temp_volumes (THREAD_ENTRY * thread_p,
-					 bool forward_dir, bool check_before_access);
+static void boot_find_rest_temp_volumes (THREAD_ENTRY * thread_p, bool forward_dir);
 static int boot_check_permanent_volumes (THREAD_ENTRY * thread_p);
 static int boot_mount (THREAD_ENTRY * thread_p, VOLID volid, const char *vlabel, void *ignore_arg);
 static char *boot_find_new_db_path (char *db_pathbuf, const char *fileof_vols_and_wherepaths);
@@ -921,7 +920,7 @@ boot_remove_all_temp_volumes (THREAD_ENTRY * thread_p, REMOVE_TEMP_VOL_ACTION de
       return NO_ERROR;
     }
 
-  boot_find_rest_temp_volumes (thread_p, true, true);
+  boot_find_rest_temp_volumes (thread_p, true);
 
   if (delete_action == ONLY_PHYSICAL_REMOVE_TEMP_VOL_ACTION)
     {
@@ -1161,12 +1160,11 @@ boot_find_rest_permanent_volumes (THREAD_ENTRY * thread_p, bool newvolpath, bool
  * bo_find_rest_tempvols () - call function on the rest of temporary vols of the database
  *
  *   forward_dir(in): direction of accessing the tempvols (forward/backward)
- *   check_before_access(in): if true, check the existence of volume before access
  *
  * Note: The given function is called for every single temporary volume which is different from the given one.
  */
 static void
-boot_find_rest_temp_volumes (THREAD_ENTRY * thread_p, bool forward_dir, bool check_before_access)
+boot_find_rest_temp_volumes (THREAD_ENTRY * thread_p, bool forward_dir)
 {
   VOLID temp_volid;
   char temp_vol_fullname[PATH_MAX];
@@ -1204,17 +1202,10 @@ boot_find_rest_temp_volumes (THREAD_ENTRY * thread_p, bool forward_dir, bool che
 	      /* Find the name of the volume */
 	      fileio_make_volume_temp_name (temp_vol_fullname, temp_path, temp_name, temp_volid);
 	      go_to_access = false;
-	      if (check_before_access)
-		{
-		  if (fileio_is_volume_exist (temp_vol_fullname) == true)
-		    {
-		      go_to_access = true;
-		    }
-		}
-	      else
-		{
-		  go_to_access = true;
-		}
+              if (fileio_is_volume_exist (temp_vol_fullname) == true)
+                {
+                  go_to_access = true;
+                }
 	      if (go_to_access)
 		{		/* Call the function */
 		  (void) boot_xremove_temp_volume (thread_p, temp_volid, temp_vol_fullname);
@@ -1232,17 +1223,10 @@ boot_find_rest_temp_volumes (THREAD_ENTRY * thread_p, bool forward_dir, bool che
 	      /* Find the name of the volume */
 	      fileio_make_volume_temp_name (temp_vol_fullname, temp_path, temp_name, temp_volid);
 	      go_to_access = false;
-	      if (check_before_access)
-		{
-		  if (fileio_is_volume_exist (temp_vol_fullname) == true)
-		    {
-		      go_to_access = true;
-		    }
-		}
-	      else
-		{
-		  go_to_access = true;
-		}
+              if (fileio_is_volume_exist (temp_vol_fullname) == true)
+                {
+                  go_to_access = true;
+                }
 	      if (go_to_access)
 		{		/* Call the function */
 		  (void) boot_xremove_temp_volume (thread_p, temp_volid, temp_vol_fullname);

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -6080,7 +6080,7 @@ boot_dbparm_save_volume (THREAD_ENTRY * thread_p, DB_VOLTYPE voltype, VOLID voli
       boot_Db_parm->temp_last_volid = volid;
     }
 
-  return error_code;
+  return NO_ERROR;
 
 error:
 

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -1196,7 +1196,6 @@ boot_find_and_remove_temp_volumes (THREAD_ENTRY * thread_p)
       temp_volid = (VOLID) num_vols;
       if (temp_volid != NULL_VOLID)
 	{
-	  /* Find the name of the volume */
 	  fileio_make_volume_temp_name (temp_vol_fullname, temp_path, temp_name, temp_volid);
 	  go_to_access = false;
 	  if (fileio_is_volume_exist (temp_vol_fullname) == true)

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -192,7 +192,7 @@ static int boot_find_rest_permanent_volumes (THREAD_ENTRY * thread_p, bool newvo
 					     int (*fun) (THREAD_ENTRY * thread_p, VOLID xvolid, const char *vlabel,
 							 void *args), void *args);
 
-static void boot_find_and_remove_temp_volumes (THREAD_ENTRY * thread_p);
+static void boot_remove_temp_volumes (THREAD_ENTRY * thread_p);
 static int boot_check_permanent_volumes (THREAD_ENTRY * thread_p);
 static int boot_mount (THREAD_ENTRY * thread_p, VOLID volid, const char *vlabel, void *ignore_arg);
 static char *boot_find_new_db_path (char *db_pathbuf, const char *fileof_vols_and_wherepaths);
@@ -919,7 +919,7 @@ boot_remove_all_temp_volumes (THREAD_ENTRY * thread_p, REMOVE_TEMP_VOL_ACTION de
       return NO_ERROR;
     }
 
-  boot_find_and_remove_temp_volumes (thread_p);
+  boot_remove_temp_volumes (thread_p);
 
   if (delete_action == ONLY_PHYSICAL_REMOVE_TEMP_VOL_ACTION)
     {
@@ -1140,12 +1140,12 @@ boot_find_rest_permanent_volumes (THREAD_ENTRY * thread_p, bool newvolpath, bool
 }
 
 /*
- * boot_find_and_remove_temp_volumes () - Find temporary volumes and remove them using boot_remove_temp_volume()
+ * boot_remove_temp_volumes () - Find temporary volumes and remove them using boot_remove_temp_volume()
  *
  * Note: The given function is called for every single temporary volume which is different from the given one.
  */
 static void
-boot_find_and_remove_temp_volumes (THREAD_ENTRY * thread_p)
+boot_remove_temp_volumes (THREAD_ENTRY * thread_p)
 {
   VOLID temp_volid;
   char temp_vol_fullname[PATH_MAX];

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -914,13 +914,13 @@ boot_remove_all_temp_volumes (THREAD_ENTRY * thread_p, REMOVE_TEMP_VOL_ACTION de
       boot_remove_unknown_temp_volumes (thread_p);
     }
 
+  boot_find_rest_temp_volumes (thread_p);
+
   if (boot_Db_parm->temp_nvols == 0)
     {
       assert (boot_Db_parm->temp_last_volid == NULL_VOLID);
       return NO_ERROR;
     }
-
-  boot_find_rest_temp_volumes (thread_p);
 
   if (delete_action == ONLY_PHYSICAL_REMOVE_TEMP_VOL_ACTION)
     {

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -1172,7 +1172,6 @@ boot_find_and_remove_temp_volumes (THREAD_ENTRY * thread_p)
   const char *temp_name;
   char *alloc_tempath = NULL;
   int num_vols;
-  bool go_to_access;
 
   /*
    * Get the name of the extension: ext_path|dbname|"ext"|volid
@@ -1197,14 +1196,9 @@ boot_find_and_remove_temp_volumes (THREAD_ENTRY * thread_p)
       if (temp_volid != NULL_VOLID)
 	{
 	  fileio_make_volume_temp_name (temp_vol_fullname, temp_path, temp_name, temp_volid);
-	  go_to_access = false;
 	  if (fileio_is_volume_exist (temp_vol_fullname) == true)
-	    {
-	      go_to_access = true;
-	    }
-	  if (go_to_access)
-	    {			/* Call the function */
-	      (void) boot_xremove_temp_volume (thread_p, temp_volid, temp_vol_fullname);
+	    {			/* Call the remove function */
+              (void) boot_xremove_temp_volume (thread_p, temp_volid, temp_vol_fullname);
 	    }
 	}
     }

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -1194,19 +1194,19 @@ boot_find_rest_temp_volumes (THREAD_ENTRY * thread_p)
     {
       temp_volid = (VOLID) num_vols;
       if (temp_volid != NULL_VOLID)
-        {
-          /* Find the name of the volume */
-          fileio_make_volume_temp_name (temp_vol_fullname, temp_path, temp_name, temp_volid);
-          go_to_access = false;
-          if (fileio_is_volume_exist (temp_vol_fullname) == true)
-            {
-              go_to_access = true;
-            }
-          if (go_to_access)
-            {		/* Call the function */
-              (void) boot_xremove_temp_volume (thread_p, temp_volid, temp_vol_fullname);
-            }
-        }
+	{
+	  /* Find the name of the volume */
+	  fileio_make_volume_temp_name (temp_vol_fullname, temp_path, temp_name, temp_volid);
+	  go_to_access = false;
+	  if (fileio_is_volume_exist (temp_vol_fullname) == true)
+	    {
+	      go_to_access = true;
+	    }
+	  if (go_to_access)
+	    {			/* Call the function */
+	      (void) boot_xremove_temp_volume (thread_p, temp_volid, temp_vol_fullname);
+	    }
+	}
     }
 
   if (alloc_tempath)

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -6043,7 +6043,7 @@ boot_dbparm_save_volume (THREAD_ENTRY * thread_p, DB_VOLTYPE voltype, VOLID voli
 	{
 	  assert_release (false);
 	  error_code = ER_FAILED;
-	  goto exit;
+	  goto error;
 	}
       boot_Db_parm->last_volid = volid;
       boot_Db_parm->nvols++;
@@ -6058,8 +6058,7 @@ boot_dbparm_save_volume (THREAD_ENTRY * thread_p, DB_VOLTYPE voltype, VOLID voli
       if (error_code != NO_ERROR)
 	{
 	  ASSERT_ERROR ();
-	  *boot_Db_parm = save_boot_db_parm;
-	  goto exit;
+	  goto error;
 	}
 
       /* flush the boot_Db_parm object. this is not necessary but it is recommended in order to mount every known volume
@@ -6075,13 +6074,18 @@ boot_dbparm_save_volume (THREAD_ENTRY * thread_p, DB_VOLTYPE voltype, VOLID voli
 	  /* invalid volid */
 	  assert_release (false);
 	  error_code = ER_FAILED;
-	  goto exit;
+	  goto error;
 	}
       boot_Db_parm->temp_nvols++;
       boot_Db_parm->temp_last_volid = volid;
     }
 
-exit:
+  return error_code;
+
+error:
+
+  *boot_Db_parm = save_boot_db_parm;
+
   return error_code;
 }
 

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -193,7 +193,7 @@ static int boot_find_rest_permanent_volumes (THREAD_ENTRY * thread_p, bool newvo
 					     int (*fun) (THREAD_ENTRY * thread_p, VOLID xvolid, const char *vlabel,
 							 void *args), void *args);
 
-static void boot_find_rest_temp_volumes (THREAD_ENTRY * thread_p);
+static void boot_find_and_remove_temp_volumes (THREAD_ENTRY * thread_p);
 static int boot_check_permanent_volumes (THREAD_ENTRY * thread_p);
 static int boot_mount (THREAD_ENTRY * thread_p, VOLID volid, const char *vlabel, void *ignore_arg);
 static char *boot_find_new_db_path (char *db_pathbuf, const char *fileof_vols_and_wherepaths);
@@ -922,7 +922,7 @@ boot_remove_all_temp_volumes (THREAD_ENTRY * thread_p, REMOVE_TEMP_VOL_ACTION de
     TODO: Even when boot_Db_parm->temp_nvols == 0, temp volumes are still removed, so they should always be subject to removal
    */
 
-  boot_find_rest_temp_volumes (thread_p);
+  boot_find_and_remove_temp_volumes (thread_p);
 
   if (delete_action == ONLY_PHYSICAL_REMOVE_TEMP_VOL_ACTION)
     {
@@ -1159,12 +1159,12 @@ boot_find_rest_permanent_volumes (THREAD_ENTRY * thread_p, bool newvolpath, bool
 }
 
 /*
- * bo_find_rest_tempvols () - call function on the rest of temporary vols of the database
+ * boot_find_and_remove_temp_volumes () - Find temporary volumes and remove them using boot_xremove_temp_volume()
  *
  * Note: The given function is called for every single temporary volume which is different from the given one.
  */
 static void
-boot_find_rest_temp_volumes (THREAD_ENTRY * thread_p)
+boot_find_and_remove_temp_volumes (THREAD_ENTRY * thread_p)
 {
   VOLID temp_volid;
   char temp_vol_fullname[PATH_MAX];

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -193,7 +193,7 @@ static int boot_find_rest_permanent_volumes (THREAD_ENTRY * thread_p, bool newvo
 					     int (*fun) (THREAD_ENTRY * thread_p, VOLID xvolid, const char *vlabel,
 							 void *args), void *args);
 
-static void boot_find_rest_temp_volumes (THREAD_ENTRY * thread_p, bool forward_dir);
+static void boot_find_rest_temp_volumes (THREAD_ENTRY * thread_p);
 static int boot_check_permanent_volumes (THREAD_ENTRY * thread_p);
 static int boot_mount (THREAD_ENTRY * thread_p, VOLID volid, const char *vlabel, void *ignore_arg);
 static char *boot_find_new_db_path (char *db_pathbuf, const char *fileof_vols_and_wherepaths);
@@ -920,7 +920,7 @@ boot_remove_all_temp_volumes (THREAD_ENTRY * thread_p, REMOVE_TEMP_VOL_ACTION de
       return NO_ERROR;
     }
 
-  boot_find_rest_temp_volumes (thread_p, true);
+  boot_find_rest_temp_volumes (thread_p);
 
   if (delete_action == ONLY_PHYSICAL_REMOVE_TEMP_VOL_ACTION)
     {
@@ -1159,12 +1159,10 @@ boot_find_rest_permanent_volumes (THREAD_ENTRY * thread_p, bool newvolpath, bool
 /*
  * bo_find_rest_tempvols () - call function on the rest of temporary vols of the database
  *
- *   forward_dir(in): direction of accessing the tempvols (forward/backward)
- *
  * Note: The given function is called for every single temporary volume which is different from the given one.
  */
 static void
-boot_find_rest_temp_volumes (THREAD_ENTRY * thread_p, bool forward_dir)
+boot_find_rest_temp_volumes (THREAD_ENTRY * thread_p)
 {
   VOLID temp_volid;
   char temp_vol_fullname[PATH_MAX];
@@ -1192,47 +1190,23 @@ boot_find_rest_temp_volumes (THREAD_ENTRY * thread_p, bool forward_dir)
   temp_name = fileio_get_base_file_name (boot_Db_full_name);
 
   /* Cycle over all temporarily volumes, skip the given one */
-  if (forward_dir)
+  for (num_vols = boot_Db_parm->temp_last_volid; num_vols <= LOG_MAX_DBVOLID; num_vols++)
     {
-      for (num_vols = boot_Db_parm->temp_last_volid; num_vols <= LOG_MAX_DBVOLID; num_vols++)
-	{
-	  temp_volid = (VOLID) num_vols;
-	  if (temp_volid != NULL_VOLID)
-	    {
-	      /* Find the name of the volume */
-	      fileio_make_volume_temp_name (temp_vol_fullname, temp_path, temp_name, temp_volid);
-	      go_to_access = false;
-              if (fileio_is_volume_exist (temp_vol_fullname) == true)
-                {
-                  go_to_access = true;
-                }
-	      if (go_to_access)
-		{		/* Call the function */
-		  (void) boot_xremove_temp_volume (thread_p, temp_volid, temp_vol_fullname);
-		}
-	    }
-	}
-    }
-  else
-    {
-      for (num_vols = LOG_MAX_DBVOLID; num_vols >= boot_Db_parm->temp_last_volid; num_vols--)
-	{
-	  temp_volid = (VOLID) num_vols;
-	  if (temp_volid != NULL_VOLID)
-	    {
-	      /* Find the name of the volume */
-	      fileio_make_volume_temp_name (temp_vol_fullname, temp_path, temp_name, temp_volid);
-	      go_to_access = false;
-              if (fileio_is_volume_exist (temp_vol_fullname) == true)
-                {
-                  go_to_access = true;
-                }
-	      if (go_to_access)
-		{		/* Call the function */
-		  (void) boot_xremove_temp_volume (thread_p, temp_volid, temp_vol_fullname);
-		}
-	    }
-	}
+      temp_volid = (VOLID) num_vols;
+      if (temp_volid != NULL_VOLID)
+        {
+          /* Find the name of the volume */
+          fileio_make_volume_temp_name (temp_vol_fullname, temp_path, temp_name, temp_volid);
+          go_to_access = false;
+          if (fileio_is_volume_exist (temp_vol_fullname) == true)
+            {
+              go_to_access = true;
+            }
+          if (go_to_access)
+            {		/* Call the function */
+              (void) boot_xremove_temp_volume (thread_p, temp_volid, temp_vol_fullname);
+            }
+        }
     }
 
   if (alloc_tempath)

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -194,7 +194,6 @@ static int boot_find_rest_permanent_volumes (THREAD_ENTRY * thread_p, bool newvo
 							 void *args), void *args);
 
 static void boot_find_rest_temp_volumes (THREAD_ENTRY * thread_p, VOLID volid,
-					 int (*fun) (THREAD_ENTRY * thread_p, VOLID xvolid, const char *vlabel),
 					 bool forward_dir, bool check_before_access);
 static int boot_check_permanent_volumes (THREAD_ENTRY * thread_p);
 static int boot_mount (THREAD_ENTRY * thread_p, VOLID volid, const char *vlabel, void *ignore_arg);
@@ -922,7 +921,7 @@ boot_remove_all_temp_volumes (THREAD_ENTRY * thread_p, REMOVE_TEMP_VOL_ACTION de
       return NO_ERROR;
     }
 
-  boot_find_rest_temp_volumes (thread_p, NULL_VOLID, boot_xremove_temp_volume, true, true);
+  boot_find_rest_temp_volumes (thread_p, NULL_VOLID, true, true);
 
   if (delete_action == ONLY_PHYSICAL_REMOVE_TEMP_VOL_ACTION)
     {
@@ -1162,16 +1161,13 @@ boot_find_rest_permanent_volumes (THREAD_ENTRY * thread_p, bool newvolpath, bool
  * bo_find_rest_tempvols () - call function on the rest of temporary vols of the database
  *
  *   volid(in): Volume identifier
- *   fun(in): Function to call on volid, vlabel, and arguments
  *   forward_dir(in): direction of accessing the tempvols (forward/backward)
  *   check_before_access(in): if true, check the existence of volume before access
  *
  * Note: The given function is called for every single temporary volume which is different from the given one.
  */
 static void
-boot_find_rest_temp_volumes (THREAD_ENTRY * thread_p, VOLID volid,
-			     int (*fun) (THREAD_ENTRY * thread_p, VOLID xvolid, const char *vlabel),
-			     bool forward_dir, bool check_before_access)
+boot_find_rest_temp_volumes (THREAD_ENTRY * thread_p, VOLID volid, bool forward_dir, bool check_before_access)
 {
   VOLID temp_volid;
   char temp_vol_fullname[PATH_MAX];
@@ -1222,7 +1218,7 @@ boot_find_rest_temp_volumes (THREAD_ENTRY * thread_p, VOLID volid,
 		}
 	      if (go_to_access)
 		{		/* Call the function */
-		  (void) (*fun) (thread_p, temp_volid, temp_vol_fullname);
+		  (void) boot_xremove_temp_volume (thread_p, temp_volid, temp_vol_fullname);
 		}
 	    }
 	}
@@ -1250,7 +1246,7 @@ boot_find_rest_temp_volumes (THREAD_ENTRY * thread_p, VOLID volid,
 		}
 	      if (go_to_access)
 		{		/* Call the function */
-		  (void) (*fun) (thread_p, temp_volid, temp_vol_fullname);
+		  (void) boot_xremove_temp_volume (thread_p, temp_volid, temp_vol_fullname);
 		}
 	    }
 	}

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -1198,62 +1198,59 @@ boot_find_rest_temp_volumes (THREAD_ENTRY * thread_p, VOLID volid,
     }
   temp_name = fileio_get_base_file_name (boot_Db_full_name);
 
-  if (boot_Db_parm->temp_nvols > 0)
+  /* Cycle over all temporarily volumes, skip the given one */
+  if (forward_dir)
     {
-      /* Cycle over all temporarily volumes, skip the given one */
-      if (forward_dir)
+      for (num_vols = boot_Db_parm->temp_last_volid; num_vols <= LOG_MAX_DBVOLID; num_vols++)
 	{
-	  for (num_vols = boot_Db_parm->temp_last_volid; num_vols <= LOG_MAX_DBVOLID; num_vols++)
+	  temp_volid = (VOLID) num_vols;
+	  if (temp_volid != volid)
 	    {
-	      temp_volid = (VOLID) num_vols;
-	      if (temp_volid != volid)
+	      /* Find the name of the volume */
+	      fileio_make_volume_temp_name (temp_vol_fullname, temp_path, temp_name, temp_volid);
+	      go_to_access = false;
+	      if (check_before_access)
 		{
-		  /* Find the name of the volume */
-		  fileio_make_volume_temp_name (temp_vol_fullname, temp_path, temp_name, temp_volid);
-		  go_to_access = false;
-		  if (check_before_access)
-		    {
-		      if (fileio_is_volume_exist (temp_vol_fullname) == true)
-			{
-			  go_to_access = true;
-			}
-		    }
-		  else
+		  if (fileio_is_volume_exist (temp_vol_fullname) == true)
 		    {
 		      go_to_access = true;
 		    }
-		  if (go_to_access)
-		    {		/* Call the function */
-		      (void) (*fun) (thread_p, temp_volid, temp_vol_fullname);
-		    }
+		}
+	      else
+		{
+		  go_to_access = true;
+		}
+	      if (go_to_access)
+		{		/* Call the function */
+		  (void) (*fun) (thread_p, temp_volid, temp_vol_fullname);
 		}
 	    }
 	}
-      else
+    }
+  else
+    {
+      for (num_vols = LOG_MAX_DBVOLID; num_vols >= boot_Db_parm->temp_last_volid; num_vols--)
 	{
-	  for (num_vols = LOG_MAX_DBVOLID; num_vols >= boot_Db_parm->temp_last_volid; num_vols--)
+	  temp_volid = (VOLID) num_vols;
+	  if (temp_volid != volid)
 	    {
-	      temp_volid = (VOLID) num_vols;
-	      if (temp_volid != volid)
+	      /* Find the name of the volume */
+	      fileio_make_volume_temp_name (temp_vol_fullname, temp_path, temp_name, temp_volid);
+	      go_to_access = false;
+	      if (check_before_access)
 		{
-		  /* Find the name of the volume */
-		  fileio_make_volume_temp_name (temp_vol_fullname, temp_path, temp_name, temp_volid);
-		  go_to_access = false;
-		  if (check_before_access)
-		    {
-		      if (fileio_is_volume_exist (temp_vol_fullname) == true)
-			{
-			  go_to_access = true;
-			}
-		    }
-		  else
+		  if (fileio_is_volume_exist (temp_vol_fullname) == true)
 		    {
 		      go_to_access = true;
 		    }
-		  if (go_to_access)
-		    {		/* Call the function */
-		      (void) (*fun) (thread_p, temp_volid, temp_vol_fullname);
-		    }
+		}
+	      else
+		{
+		  go_to_access = true;
+		}
+	      if (go_to_access)
+		{		/* Call the function */
+		  (void) (*fun) (thread_p, temp_volid, temp_vol_fullname);
 		}
 	    }
 	}

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -914,13 +914,15 @@ boot_remove_all_temp_volumes (THREAD_ENTRY * thread_p, REMOVE_TEMP_VOL_ACTION de
       boot_remove_unknown_temp_volumes (thread_p);
     }
 
-  boot_find_rest_temp_volumes (thread_p);
-
-  if (boot_Db_parm->temp_nvols == 0)
+  /* if (boot_Db_parm->temp_nvols == 0)
     {
       assert (boot_Db_parm->temp_last_volid == NULL_VOLID);
       return NO_ERROR;
     }
+    TODO: Even when boot_Db_parm->temp_nvols == 0, temp volumes are still removed, so they should always be subject to removal
+   */
+
+  boot_find_rest_temp_volumes (thread_p);
 
   if (delete_action == ONLY_PHYSICAL_REMOVE_TEMP_VOL_ACTION)
     {

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -914,11 +914,11 @@ boot_remove_all_temp_volumes (THREAD_ENTRY * thread_p, REMOVE_TEMP_VOL_ACTION de
     }
 
   /* if (boot_Db_parm->temp_nvols == 0)
-    {
-      assert (boot_Db_parm->temp_last_volid == NULL_VOLID);
-      return NO_ERROR;
-    }
-    TODO: Even when boot_Db_parm->temp_nvols == 0, temp volumes are still removed, so they should always be subject to removal
+     {
+     assert (boot_Db_parm->temp_last_volid == NULL_VOLID);
+     return NO_ERROR;
+     }
+     TODO: Even when boot_Db_parm->temp_nvols == 0, temp volumes are still removed, so they should always be subject to removal
    */
 
   boot_find_and_remove_temp_volumes (thread_p);
@@ -1181,7 +1181,7 @@ boot_find_and_remove_temp_volumes (THREAD_ENTRY * thread_p)
 	  fileio_make_volume_temp_name (temp_vol_fullname, temp_path, temp_name, temp_volid);
 	  if (fileio_is_volume_exist (temp_vol_fullname) == true)
 	    {			/* Call the remove function */
-              (void) boot_remove_temp_volume (thread_p, temp_volid, temp_vol_fullname);
+	      (void) boot_remove_temp_volume (thread_p, temp_volid, temp_vol_fullname);
 	    }
 	}
     }

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -6121,6 +6121,13 @@ boot_dbparm_save_volume (THREAD_ENTRY * thread_p, DB_VOLTYPE voltype, VOLID voli
 
       error_code = boot_db_parm_update_heap (thread_p);
 
+      if (error_code != NO_ERROR)
+	{
+	  ASSERT_ERROR ();
+	  *boot_Db_parm = save_boot_db_parm;
+	  goto exit;
+	}
+
       /* flush the boot_Db_parm object. this is not necessary but it is recommended in order to mount every known volume
        * during restart. that may not be possible during media crash though. */
       heap_flush (thread_p, boot_Db_parm_oid);
@@ -6138,13 +6145,6 @@ boot_dbparm_save_volume (THREAD_ENTRY * thread_p, DB_VOLTYPE voltype, VOLID voli
 	}
       boot_Db_parm->temp_nvols++;
       boot_Db_parm->temp_last_volid = volid;
-    }
-
-  if (error_code != NO_ERROR)
-    {
-      ASSERT_ERROR ();
-      *boot_Db_parm = save_boot_db_parm;
-      goto exit;
     }
 
 exit:

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -1140,7 +1140,7 @@ boot_find_rest_permanent_volumes (THREAD_ENTRY * thread_p, bool newvolpath, bool
 }
 
 /*
- * boot_remove_temp_volumes () - Find temporary volumes and remove them using boot_remove_temp_volume()
+ * boot_remove_temp_volumes () - Find temporary volumes and remove them
  *
  * Note: The given function is called for every single temporary volume which is different from the given one.
  */
@@ -1174,7 +1174,7 @@ boot_remove_temp_volumes (THREAD_ENTRY * thread_p)
     {
       fileio_make_volume_temp_name (temp_vol_fullname, temp_path, temp_name, temp_volid);
       if (fileio_is_volume_exist (temp_vol_fullname) == true)
-	{			/* Call the remove function */
+	{
 	  (void) boot_remove_temp_volume (thread_p, temp_volid, temp_vol_fullname);
 	}
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25837

### Purpose

1. HA 모드의 Slave node에서 많은 데이터를 조회할 때 temp volume을 생성하는데, 이때 log가 남게 되어 Slave node에서 update가 진행됩니다. Slave node는 update가 불가능하기 때문에 에러가 발생합니다.

    - temp volume 생성 시 log를 남기지 않도록 합니다.

2. 1번 해결 방안으로 처리 시, temp volume에 대한 정보를 log로 남기지 않기 때문에 temp volume 삭제 시 참조할 정보가 없게 됩니다. 그렇기 때문에 temp volume이 의미없이 삭제되지 않고 남아 있을 수 있습니다.

    - temp volume 삭제 시 temp volume에 대한 정보를 참조 없이 모두 삭제하도록 합니다.


### Implementation

1. temp volume 생성 시 log 남기는 로직 제거
2. temp volume 삭제 시 호출되는 boot_find_rest_temp_volumes() 함수에서 boot_Db_parm->temp_nvols의 값이 0 이하여도 삭제 진행하도록 구현

### Remarks

boot_find_rest_temp_volumes() 함수는 boot_Db_parm->temp_nvols의 값이 0 이상이면(temp volume의 개수가 0 이상) temp volume 삭제 루틴을 수행합니다.