### PR TITLE
[CBRD-26051] Remove build-windows workflow on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,41 +99,6 @@ jobs:
     resource_class: medium
     <<: *test_defaults
 
-  build-windows:
-    machine:
-      image: 'windows-server-2019'
-      resource_class: windows.large
-      shell: powershell.exe -ExecutionPolicy Bypass
-    environment:
-      - CMAKE_GENERATOR: "Visual Studio 15 2017"
-      - CMAKE_BUILD_PARALLEL_LEVEL: 10
-      - WITH_CCI: true
-    steps:
-      - checkout
-      - run:
-          name: Submodules
-          command: |
-            git submodule update --init --recursive
-            git rm -f cubridmanager
-      - run:
-          name: Install dependencies
-          command: |
-            choco upgrade chocolatey -y
-            choco install openjdk8redhatbuild --no-progress -y
-            choco install cmake --version=3.26.3 --installargs 'ADD_CMAKE_TO_PATH=System' --no-progress -y
-            choco install winflexbison wixtoolset --no-progress -y
-            choco install ant --ignore-dependencies --no-progress -y
-            choco install visualstudio2017buildtools --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.ATLMFC --includeRecommended" --no-progress -y
-      - run:
-          name: CMake Configure
-          command: |
-            cmake -E make_directory build
-            cmake -E chdir build cmake -G $env:CMAKE_GENERATOR -A x64 -DWITH_CCI=$env:WITH_CCI -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
-      - run:
-          name: CMake Build
-          command: |
-            cmake --build build --config RelWithDebInfo --parallel $env:CMAKE_BUILD_PARALLEL_LEVEL
-
 workflows:
   version: 2
   build_test:
@@ -146,9 +111,5 @@ workflows:
           requires:
             - build
       - test_plcsql:
-          requires:
-            - build
-
-      - build-windows:
           requires:
             - build


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26051>

### Purpose

Remove the build-windows workflow so that Windows builds are not supported from version guava(11.5).

### Implementation

N/A

### Remarks

N/A
