### PR TITLE
[CBRD-25997] Skip end_one_iteration when it's possible in parallel heap scan

### DIFF
--- a/src/query/parallel/px_heap_scan/px_heap_scan_memory_mapper.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_memory_mapper.cpp
@@ -641,31 +641,63 @@ namespace parallel_heap_scan
     m_resolved_dbval_map.clear();
   }
 
-  void memory_mapper::add_resolved_dbval_all()
+  bool memory_mapper::add_resolved_dbval_all()
   {
+    bool all_vfetch_to_domain_resolved = true;
     for (auto &pair : m_map)
       {
 	if (pair.second.type == Type::REGU_VARIABLE)
 	  {
 	    REGU_VARIABLE *clone = (REGU_VARIABLE *)pair.second.ptr;
-	    if (clone->vfetch_to && !clone->vfetch_to->domain.general_info.is_null)
+	    if (clone->vfetch_to)
 	      {
-		DB_VALUE *dbval = (DB_VALUE *)malloc (sizeof (DB_VALUE));
-		pr_clone_value (clone->vfetch_to, dbval);
-		m_resolved_dbval_map[ (void *)clone->vfetch_to] = dbval;
+		auto it = m_resolved_dbval_map.find ((void *)clone->vfetch_to);
+		if (it != m_resolved_dbval_map.end())
+		  {
+		    /* dbvalue already stored in m_resolved_dbval_map */
+		  }
+		else
+		  {
+		    if (clone->vfetch_to->domain.general_info.is_null)
+		      {
+			all_vfetch_to_domain_resolved = false;
+		      }
+		    else
+		      {
+			DB_VALUE *dbval = (DB_VALUE *)malloc (sizeof (DB_VALUE));
+			pr_clone_value (clone->vfetch_to, dbval);
+			m_resolved_dbval_map[ (void *)clone->vfetch_to] = dbval;
+		      }
+		  }
 	      }
 	  }
 	if (pair.second.type == Type::REGU_VARIABLE_LIST)
 	  {
 	    REGU_VARIABLE *clone = & ((REGU_VARIABLE_LIST)pair.second.ptr)->value;
-	    if (clone->vfetch_to && !clone->vfetch_to->domain.general_info.is_null)
+	    if (clone->vfetch_to)
 	      {
-		DB_VALUE *dbval = (DB_VALUE *)malloc (sizeof (DB_VALUE));
-		pr_clone_value (clone->vfetch_to, dbval);
-		m_resolved_dbval_map[ (void *)clone->vfetch_to] = dbval;
+		auto it = m_resolved_dbval_map.find ((void *)clone->vfetch_to);
+		if (it != m_resolved_dbval_map.end())
+		  {
+		    /* dbvalue already stored in m_resolved_dbval_map */
+		  }
+		else
+		  {
+		    if (clone->vfetch_to->domain.general_info.is_null)
+		      {
+			all_vfetch_to_domain_resolved = false;
+		      }
+		    else
+		      {
+			DB_VALUE *dbval = (DB_VALUE *)malloc (sizeof (DB_VALUE));
+			pr_clone_value (clone->vfetch_to, dbval);
+			m_resolved_dbval_map[ (void *)clone->vfetch_to] = dbval;
+		      }
+		  }
 	      }
 	  }
       }
+    return all_vfetch_to_domain_resolved;
   }
 
   void memory_mapper::set_all_regu_var_domain_refer_to_clone()

--- a/src/query/parallel/px_heap_scan/px_heap_scan_memory_mapper.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_memory_mapper.cpp
@@ -644,55 +644,39 @@ namespace parallel_heap_scan
   bool memory_mapper::add_resolved_dbval_all()
   {
     bool all_vfetch_to_domain_resolved = true;
+    REGU_VARIABLE *clone = nullptr;
     for (auto &pair : m_map)
       {
-	if (pair.second.type == Type::REGU_VARIABLE)
-	  {
-	    REGU_VARIABLE *clone = (REGU_VARIABLE *)pair.second.ptr;
-	    if (clone->vfetch_to)
-	      {
-		auto it = m_resolved_dbval_map.find ((void *)clone->vfetch_to);
-		if (it != m_resolved_dbval_map.end())
-		  {
-		    /* dbvalue already stored in m_resolved_dbval_map */
-		  }
-		else
-		  {
-		    if (clone->vfetch_to->domain.general_info.is_null)
-		      {
-			all_vfetch_to_domain_resolved = false;
-		      }
-		    else
-		      {
-			DB_VALUE *dbval = (DB_VALUE *)malloc (sizeof (DB_VALUE));
-			pr_clone_value (clone->vfetch_to, dbval);
-			m_resolved_dbval_map[ (void *)clone->vfetch_to] = dbval;
-		      }
-		  }
-	      }
-	  }
 	if (pair.second.type == Type::REGU_VARIABLE_LIST)
 	  {
-	    REGU_VARIABLE *clone = & ((REGU_VARIABLE_LIST)pair.second.ptr)->value;
-	    if (clone->vfetch_to)
+	    clone = & ((REGU_VARIABLE_LIST)pair.second.ptr)->value;
+	  }
+	else if (pair.second.type == Type::REGU_VARIABLE)
+	  {
+	    clone = (REGU_VARIABLE *)pair.second.ptr;
+	  }
+	else
+	  {
+	    continue;
+	  }
+	if (clone->vfetch_to)
+	  {
+	    auto it = m_resolved_dbval_map.find ((void *)clone->vfetch_to);
+	    if (it != m_resolved_dbval_map.end())
 	      {
-		auto it = m_resolved_dbval_map.find ((void *)clone->vfetch_to);
-		if (it != m_resolved_dbval_map.end())
+		/* dbvalue already stored in m_resolved_dbval_map */
+	      }
+	    else
+	      {
+		if (clone->vfetch_to->domain.general_info.is_null)
 		  {
-		    /* dbvalue already stored in m_resolved_dbval_map */
+		    all_vfetch_to_domain_resolved = false;
 		  }
 		else
 		  {
-		    if (clone->vfetch_to->domain.general_info.is_null)
-		      {
-			all_vfetch_to_domain_resolved = false;
-		      }
-		    else
-		      {
-			DB_VALUE *dbval = (DB_VALUE *)malloc (sizeof (DB_VALUE));
-			pr_clone_value (clone->vfetch_to, dbval);
-			m_resolved_dbval_map[ (void *)clone->vfetch_to] = dbval;
-		      }
+		    DB_VALUE *dbval = (DB_VALUE *)malloc (sizeof (DB_VALUE));
+		    pr_clone_value (clone->vfetch_to, dbval);
+		    m_resolved_dbval_map[ (void *)clone->vfetch_to] = dbval;
 		  }
 	      }
 	  }
@@ -702,61 +686,46 @@ namespace parallel_heap_scan
 
   void memory_mapper::set_all_regu_var_domain_refer_to_clone()
   {
+    REGU_VARIABLE *orig = nullptr;
+    REGU_VARIABLE *clone = nullptr;
     for (auto &pair : m_map)
       {
-	if (pair.second.type == Type::REGU_VARIABLE)
-	  {
-	    REGU_VARIABLE *orig = (REGU_VARIABLE *)pair.first;
-	    REGU_VARIABLE *clone = (REGU_VARIABLE *)pair.second.ptr;
-	    if (TP_DOMAIN_TYPE (orig->domain) == DB_TYPE_VARIABLE
-		|| TP_DOMAIN_COLLATION_FLAG (orig->domain) != TP_DOMAIN_COLL_NORMAL)
-	      {
-		if (TP_DOMAIN_TYPE (clone->domain) != DB_TYPE_VARIABLE
-		    && TP_DOMAIN_COLLATION_FLAG (clone->domain) == TP_DOMAIN_COLL_NORMAL)
-		  {
-		    orig->domain = clone->domain;
-		  }
-	      }
-	    if (clone->vfetch_to)
-	      {
-		auto it = m_resolved_dbval_map.find ((void *)clone->vfetch_to);
-		if (it != m_resolved_dbval_map.end())
-		  {
-		    if (DB_IS_NULL (orig->vfetch_to))
-		      {
-			pr_clone_value (it->second, orig->vfetch_to);
-		      }
-		  }
-	      }
-	  }
 	if (pair.second.type == Type::REGU_VARIABLE_LIST)
 	  {
-	    REGU_VARIABLE *orig = & ((REGU_VARIABLE_LIST)pair.first)->value;
-	    REGU_VARIABLE *clone = & ((REGU_VARIABLE_LIST)pair.second.ptr)->value;
-	    if (TP_DOMAIN_TYPE (orig->domain) == DB_TYPE_VARIABLE
-		|| TP_DOMAIN_COLLATION_FLAG (orig->domain) != TP_DOMAIN_COLL_NORMAL)
+	    orig = & ((REGU_VARIABLE_LIST)pair.first)->value;
+	    clone = & ((REGU_VARIABLE_LIST)pair.second.ptr)->value;
+	  }
+	else if (pair.second.type == Type::REGU_VARIABLE)
+	  {
+	    orig = (REGU_VARIABLE *)pair.first;
+	    clone = (REGU_VARIABLE *)pair.second.ptr;
+	  }
+	else
+	  {
+	    continue;
+	  }
+	if (TP_DOMAIN_TYPE (orig->domain) == DB_TYPE_VARIABLE
+	    || TP_DOMAIN_COLLATION_FLAG (orig->domain) != TP_DOMAIN_COLL_NORMAL)
+	  {
+	    if (TP_DOMAIN_TYPE (clone->domain) != DB_TYPE_VARIABLE
+		&& TP_DOMAIN_COLLATION_FLAG (clone->domain) == TP_DOMAIN_COLL_NORMAL)
 	      {
-		if (TP_DOMAIN_TYPE (clone->domain) != DB_TYPE_VARIABLE
-		    && TP_DOMAIN_COLLATION_FLAG (clone->domain) == TP_DOMAIN_COLL_NORMAL)
-		  {
-		    orig->domain = clone->domain;
-		  }
+		orig->domain = clone->domain;
 	      }
-	    if (clone->vfetch_to)
+	  }
+	if (clone->vfetch_to)
+	  {
+	    auto it = m_resolved_dbval_map.find ((void *)clone->vfetch_to);
+	    if (it != m_resolved_dbval_map.end())
 	      {
-		auto it = m_resolved_dbval_map.find ((void *)clone->vfetch_to);
-		if (it != m_resolved_dbval_map.end())
+		if (DB_IS_NULL (orig->vfetch_to))
 		  {
-		    if (DB_IS_NULL (orig->vfetch_to))
-		      {
-			pr_clone_value (it->second, orig->vfetch_to);
-		      }
+		    pr_clone_value (it->second, orig->vfetch_to);
 		  }
 	      }
 	  }
       }
   }
-
 }
 
 #endif /* SERVER_MODE && !WINDOWS */

--- a/src/query/parallel/px_heap_scan/px_heap_scan_memory_mapper.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_memory_mapper.cpp
@@ -689,11 +689,10 @@ namespace parallel_heap_scan
 		auto it = m_resolved_dbval_map.find ((void *)clone->vfetch_to);
 		if (it != m_resolved_dbval_map.end())
 		  {
-		    if (orig->vfetch_to->need_clear)
+		    if (DB_IS_NULL (orig->vfetch_to))
 		      {
-			pr_clear_value (orig->vfetch_to);
+			pr_clone_value (it->second, orig->vfetch_to);
 		      }
-		    pr_clone_value (it->second, orig->vfetch_to);
 		  }
 	      }
 	  }
@@ -715,11 +714,10 @@ namespace parallel_heap_scan
 		auto it = m_resolved_dbval_map.find ((void *)clone->vfetch_to);
 		if (it != m_resolved_dbval_map.end())
 		  {
-		    if (orig->vfetch_to->need_clear)
+		    if (DB_IS_NULL (orig->vfetch_to))
 		      {
-			pr_clear_value (orig->vfetch_to);
+			pr_clone_value (it->second, orig->vfetch_to);
 		      }
-		    pr_clone_value (it->second, orig->vfetch_to);
 		  }
 	      }
 	  }

--- a/src/query/parallel/px_heap_scan/px_heap_scan_memory_mapper.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_memory_mapper.cpp
@@ -689,6 +689,10 @@ namespace parallel_heap_scan
 		auto it = m_resolved_dbval_map.find ((void *)clone->vfetch_to);
 		if (it != m_resolved_dbval_map.end())
 		  {
+		    if (orig->vfetch_to->need_clear)
+		      {
+			pr_clear_value (orig->vfetch_to);
+		      }
 		    pr_clone_value (it->second, orig->vfetch_to);
 		  }
 	      }
@@ -711,6 +715,10 @@ namespace parallel_heap_scan
 		auto it = m_resolved_dbval_map.find ((void *)clone->vfetch_to);
 		if (it != m_resolved_dbval_map.end())
 		  {
+		    if (orig->vfetch_to->need_clear)
+		      {
+			pr_clear_value (orig->vfetch_to);
+		      }
 		    pr_clone_value (it->second, orig->vfetch_to);
 		  }
 	      }

--- a/src/query/parallel/px_heap_scan/px_heap_scan_memory_mapper.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_memory_mapper.cpp
@@ -27,6 +27,7 @@
 #include "regu_var.hpp"
 #include "query_executor.h"
 #include "xasl_predicate.hpp"
+#include "dbtype.h"
 
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
 #include "memory_wrapper.hpp"

--- a/src/query/parallel/px_heap_scan/px_heap_scan_memory_mapper.hpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_memory_mapper.hpp
@@ -113,7 +113,7 @@ namespace parallel_heap_scan
       REGU_VARIABLE *copy_and_map (REGU_VARIABLE *regu_var);
       OUTPTR_LIST *copy_and_map (OUTPTR_LIST *src);
 
-      void add_resolved_dbval_all();
+      bool add_resolved_dbval_all();
 
       void set_all_regu_var_domain_refer_to_clone();
 

--- a/src/query/parallel/px_heap_scan/px_heap_scan_task.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_task.cpp
@@ -229,10 +229,9 @@ namespace parallel_heap_scan
 		  {
 		    writer_error_code = m_mergable_list_writer->write (thread_p);
 
-		    if (!resolved_dbval_stored && m_mergable_list_writer->is_outptr_domain_resolved())
+		    if (!resolved_dbval_stored)
 		      {
-			m_memory_mapper->add_resolved_dbval_all();
-			resolved_dbval_stored = true;
+			resolved_dbval_stored = m_memory_mapper->add_resolved_dbval_all();
 		      }
 
 		    if (writer_error_code != NO_ERROR)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-25997>

### Purpose

#6091 PR 이후 restrack assertion이 발생하여 확인해본 결과, dbval을 덮어씌우기 전 clear를 수행하지 않은 코드를 발견하였습니다. 이를 수정합니다.
또한, null인 column이 많은 상황에서 유효한 dbval만 저장할 수 있도록 코드를 수정합니다.

### Implementation

NULL 인 경우에만 복사를 수행하게끔 변경
null이 아닌 dbval을 모두 저장할 수 있을 때 까지 domain resolve 용 dbvalue 복사를 시도하게끔 변경

### Remarks

> null이 아닌 dbval을 모두 저장할 수 있을 때 까지 domain resolve 용 dbvalue 복사를 시도하게끔 변경

이 때문에, group by aggregate가 포함된 쿼리를 null이 많은 table 대상으로 수행할 때 parallel heap scan 성능이 낮아질 위험이 있습니다. (계속 domain resolve를 시도하기 때문)
