### PR TITLE
[CUBVEC-77] Modify HNSW index vector ID from incremental ID to OID

### DIFF
--- a/src/storage/hnsw.cpp
+++ b/src/storage/hnsw.cpp
@@ -155,12 +155,12 @@ faiss::idx_t encode_oid (const OID &oid)
 	 (static_cast<uint16_t> (oid.volid));
 }
 
-OID *decode_oid (faiss::idx_t encoded_oid)
+OID decode_oid (faiss::idx_t encoded_oid)
 {
-  OID *oid = new OID;
-  oid->pageid = static_cast<int32_t> (encoded_oid >> 32);
-  oid->slotid = static_cast<int16_t> ((encoded_oid >> 16) & 0xFFFF);
-  oid->volid = static_cast<int16_t> (encoded_oid & 0xFFFF);
+  OID oid;
+  oid.pageid = static_cast<int32_t> (encoded_oid >> 32);
+  oid.slotid = static_cast<int16_t> ((encoded_oid >> 16) & 0xFFFF);
+  oid.volid = static_cast<int16_t> (encoded_oid & 0xFFFF);
 
   return oid;
 }

--- a/src/storage/hnsw.cpp
+++ b/src/storage/hnsw.cpp
@@ -36,7 +36,7 @@ int hnsw_index_id = 0;
 std::unordered_map<int, std::unique_ptr<faiss::IndexIDMap>> hnsw_index_map;
 
 static faiss::idx_t encode_oid (const OID &oid);
-static OID decode_oid (faiss::idx_t encoded_oid);
+//static OID decode_oid (faiss::idx_t encoded_oid);
 
 BTID *
 xhnsw_add_index (THREAD_ENTRY *thread_p, BTID *btid, int dimension = 10, int hnsw_M = 128, int hnsw_efConstruction = 40,
@@ -158,6 +158,7 @@ static faiss::idx_t encode_oid (const OID &oid)
 	 (static_cast<uint16_t> (oid.volid));
 }
 
+/*
 static OID decode_oid (faiss::idx_t encoded_oid)
 {
   OID oid;
@@ -167,5 +168,6 @@ static OID decode_oid (faiss::idx_t encoded_oid)
 
   return oid;
 }
+*/
 
 #include "strict_warnings_off.hpp"

--- a/src/storage/hnsw.cpp
+++ b/src/storage/hnsw.cpp
@@ -33,14 +33,16 @@
 //        such as duplicate hnsw_index_id when cub_server restarts.
 //        We need to consider a better way to identify the hnsw index.
 int hnsw_index_id = 0;
-std::unordered_map<int, std::unique_ptr<faiss::IndexHNSWFlat>> hnsw_index_map;
+std::unordered_map<int, std::unique_ptr<faiss::IndexIDMap>> hnsw_index_map;
 
 BTID *
 xhnsw_add_index (THREAD_ENTRY *thread_p, BTID *btid, int dimension = 10, int hnsw_M = 128, int hnsw_efConstruction = 40,
 		 enum faiss::MetricType metric_type = faiss::METRIC_L2)
 {
-  std::unique_ptr<faiss::IndexHNSWFlat> index = std::make_unique<faiss::IndexHNSWFlat> (dimension, hnsw_M, metric_type);
-  index->hnsw.efConstruction = hnsw_efConstruction;
+  auto hnsw_index = new faiss::IndexHNSWFlat (dimension, hnsw_M, metric_type);
+  hnsw_index->hnsw.efConstruction = hnsw_efConstruction;
+
+  auto index = std::make_unique<faiss::IndexIDMap> (hnsw_index);
 
   btid->vfid.volid = -1;
   btid->vfid.fileid = -1;
@@ -100,23 +102,25 @@ int hnsw_print_index_info (BTID *btid)
 
   else
     {
-      std::unique_ptr<faiss::IndexHNSWFlat> &index = it->second;
+      std::unique_ptr<faiss::IndexIDMap> &index = it->second;
+      auto *hnsw_index = static_cast<faiss::IndexHNSWFlat *> (index->index);
 
       er_log_debug (ARG_FILE_LINE, "HNSW Index Information for ID %d:", hnsw_id);
       er_log_debug (ARG_FILE_LINE, "  - Dimension: %d", index->d);
       er_log_debug (ARG_FILE_LINE, "  - Metric Type: %d", index->metric_type);
       er_log_debug (ARG_FILE_LINE, "  - Total Elements: %d", index->ntotal);
-      er_log_debug (ARG_FILE_LINE, "  - HNSW efConstruction: %d", index->hnsw.efConstruction);
-      er_log_debug (ARG_FILE_LINE, "  - HNSW efSearch: %d", index->hnsw.efSearch);
+      er_log_debug (ARG_FILE_LINE, "  - HNSW efConstruction: %d", hnsw_index->hnsw.efConstruction);
+      er_log_debug (ARG_FILE_LINE, "  - HNSW efSearch: %d", hnsw_index->hnsw.efSearch);
     }
 
   return NO_ERROR;
 }
 
-int hnsw_add_element (BTID *btid, DB_VALUE *key_dbvalue)
+int hnsw_add_element (BTID *btid, DB_VALUE *key_dbvalue, OID *oid)
 {
   std::vector<float> fvec;
   int hnsw_id;
+  faiss::idx_t encoded_oid = encode_oid (*oid);
 
   if (!btid)
     {
@@ -136,11 +140,29 @@ int hnsw_add_element (BTID *btid, DB_VALUE *key_dbvalue)
       return ER_FAILED;
     }
 
-  std::unique_ptr<faiss::IndexHNSWFlat> &index = it->second;
+  std::unique_ptr<faiss::IndexIDMap> &index = it->second;
 
-  index->add (fvec.size(), fvec.data());
+  index->add_with_ids (1, fvec.data(), &encoded_oid);
+  er_log_debug (ARG_FILE_LINE, "Added element with ID %lld to HNSW Index.", static_cast<long long> (encoded_oid));
 
   return NO_ERROR;
+}
+
+faiss::idx_t encode_oid (const OID &oid)
+{
+  return (static_cast<int64_t> (oid.pageid) << 32) |
+	 (static_cast<uint32_t> (oid.slotid) << 16) |
+	 (static_cast<uint16_t> (oid.volid));
+}
+
+OID *decode_oid (faiss::idx_t encoded_oid)
+{
+  OID *oid = new OID;
+  oid->pageid = static_cast<int32_t> (encoded_oid >> 32);
+  oid->slotid = static_cast<int16_t> ((encoded_oid >> 16) & 0xFFFF);
+  oid->volid = static_cast<int16_t> (encoded_oid & 0xFFFF);
+
+  return oid;
 }
 
 #include "strict_warnings_off.hpp"

--- a/src/storage/hnsw.cpp
+++ b/src/storage/hnsw.cpp
@@ -35,6 +35,9 @@
 int hnsw_index_id = 0;
 std::unordered_map<int, std::unique_ptr<faiss::IndexIDMap>> hnsw_index_map;
 
+static faiss::idx_t encode_oid (const OID &oid);
+static OID decode_oid (faiss::idx_t encoded_oid);
+
 BTID *
 xhnsw_add_index (THREAD_ENTRY *thread_p, BTID *btid, int dimension = 10, int hnsw_M = 128, int hnsw_efConstruction = 40,
 		 enum faiss::MetricType metric_type = faiss::METRIC_L2)
@@ -116,7 +119,7 @@ int hnsw_print_index_info (BTID *btid)
   return NO_ERROR;
 }
 
-int hnsw_add_element (BTID *btid, DB_VALUE *key_dbvalue, OID *oid)
+int hnsw_add_element (BTID *btid, OID *oid, DB_VALUE *key_dbvalue)
 {
   std::vector<float> fvec;
   int hnsw_id;
@@ -148,14 +151,14 @@ int hnsw_add_element (BTID *btid, DB_VALUE *key_dbvalue, OID *oid)
   return NO_ERROR;
 }
 
-faiss::idx_t encode_oid (const OID &oid)
+static faiss::idx_t encode_oid (const OID &oid)
 {
   return (static_cast<int64_t> (oid.pageid) << 32) |
 	 (static_cast<uint32_t> (oid.slotid) << 16) |
 	 (static_cast<uint16_t> (oid.volid));
 }
 
-OID decode_oid (faiss::idx_t encoded_oid)
+static OID decode_oid (faiss::idx_t encoded_oid)
 {
   OID oid;
   oid.pageid = static_cast<int32_t> (encoded_oid >> 32);

--- a/src/storage/hnsw.hpp
+++ b/src/storage/hnsw.hpp
@@ -42,7 +42,7 @@ int xhnsw_delete_index (THREAD_ENTRY *thread_p, BTID *btid);
 int hnsw_print_index_info (BTID *btid);
 int hnsw_add_element (BTID *btid, DB_VALUE *key_dbvalue, OID *oid);
 faiss::idx_t encode_oid (const OID &oid);
-OID *decode_oid (faiss::idx_t encoded_oid);
+OID decode_oid (faiss::idx_t encoded_oid);
 
 
 #endif

--- a/src/storage/hnsw.hpp
+++ b/src/storage/hnsw.hpp
@@ -40,9 +40,6 @@ BTID *xhnsw_add_index (THREAD_ENTRY *thread_p, BTID *btid, int dimension, int hn
 		       enum faiss::MetricType metric_type);
 int xhnsw_delete_index (THREAD_ENTRY *thread_p, BTID *btid);
 int hnsw_print_index_info (BTID *btid);
-int hnsw_add_element (BTID *btid, DB_VALUE *key_dbvalue, OID *oid);
-faiss::idx_t encode_oid (const OID &oid);
-OID decode_oid (faiss::idx_t encoded_oid);
-
+int hnsw_add_element (BTID *btid, OID *oid, DB_VALUE *key_dbvalue);
 
 #endif

--- a/src/storage/hnsw.hpp
+++ b/src/storage/hnsw.hpp
@@ -34,12 +34,15 @@
 #include "dbtype_def.h"
 #include "thread_compat.hpp"
 #include "faiss/IndexHNSW.h"
+#include "faiss/IndexIDMap.h"
 
 BTID *xhnsw_add_index (THREAD_ENTRY *thread_p, BTID *btid, int dimension, int hnsw_M, int hnsw_efConstruction,
 		       enum faiss::MetricType metric_type);
 int xhnsw_delete_index (THREAD_ENTRY *thread_p, BTID *btid);
 int hnsw_print_index_info (BTID *btid);
-int hnsw_add_element (BTID *btid, DB_VALUE *key_dbvalue);
+int hnsw_add_element (BTID *btid, DB_VALUE *key_dbvalue, OID *oid);
+faiss::idx_t encode_oid (const OID &oid);
+OID *decode_oid (faiss::idx_t encoded_oid);
 
 
 #endif

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -7932,43 +7932,43 @@ locator_add_or_remove_index_internal (THREAD_ENTRY * thread_p, RECDES * recdes, 
 #if defined(ENABLE_SYSTEMTAP)
 	      CUBRID_IDX_INSERT_START (classname, index->btname);
 #endif /* ENABLE_SYSTEMTAP */
-              // *INDENT-OFF*
 	      if (BTID_IS_VECTOR_INDEX (&index->btid))
 		{
-		  error_code = hnsw_add_element (&btid, key_dbvalue);
+                  // *INDENT-OFF*
+		  error_code = hnsw_add_element (&btid, key_dbvalue, inst_oid);
 		  if (error_code != NO_ERROR)
 		    {
 		      goto error;
 		    }
+                  // *INDENT-ON*
 		}
-              // *INDENT-ON*
 	      else
-	      {
-		if (index->type == BTREE_FOREIGN_KEY && !skip_checking_fk)
-		  {
-		    if (lock_object (thread_p, inst_oid, class_oid, X_LOCK, LK_UNCOND_LOCK) != LK_GRANTED)
-		      {
-			goto error;
-		      }
-		  }
+		{
+		  if (index->type == BTREE_FOREIGN_KEY && !skip_checking_fk)
+		    {
+		      if (lock_object (thread_p, inst_oid, class_oid, X_LOCK, LK_UNCOND_LOCK) != LK_GRANTED)
+			{
+			  goto error;
+			}
+		    }
 
-		if (index->index_status == OR_ONLINE_INDEX_BUILDING_IN_PROGRESS)
-		  {
-		    /* Online index is currently loading. */
-		    error_code =
-		      btree_online_index_dispatcher (thread_p, &btid, key_dbvalue, class_oid, inst_oid, unique_pk,
-						     BTREE_OP_ONLINE_INDEX_TRAN_INSERT, NULL);
-		  }
-		else
-		  {
-		    error_code =
-		      btree_insert (thread_p, &btid, key_dbvalue, class_oid, inst_oid, op_type, unique_stat_info,
-				    &unique_pk, p_mvcc_rec_header);
-		  }
+		  if (index->index_status == OR_ONLINE_INDEX_BUILDING_IN_PROGRESS)
+		    {
+		      /* Online index is currently loading. */
+		      error_code =
+			btree_online_index_dispatcher (thread_p, &btid, key_dbvalue, class_oid, inst_oid, unique_pk,
+						       BTREE_OP_ONLINE_INDEX_TRAN_INSERT, NULL);
+		    }
+		  else
+		    {
+		      error_code =
+			btree_insert (thread_p, &btid, key_dbvalue, class_oid, inst_oid, op_type, unique_stat_info,
+				      &unique_pk, p_mvcc_rec_header);
+		    }
 #if defined(ENABLE_SYSTEMTAP)
-		CUBRID_IDX_INSERT_END (classname, index->btname, (error_code != NO_ERROR));
+		  CUBRID_IDX_INSERT_END (classname, index->btname, (error_code != NO_ERROR));
 #endif /* ENABLE_SYSTEMTAP */
-	      }
+		}
 	    }
 	  else
 	    {

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -7935,7 +7935,7 @@ locator_add_or_remove_index_internal (THREAD_ENTRY * thread_p, RECDES * recdes, 
 	      if (BTID_IS_VECTOR_INDEX (&index->btid))
 		{
                   // *INDENT-OFF*
-		  error_code = hnsw_add_element (&btid, key_dbvalue, inst_oid);
+		  error_code = hnsw_add_element (&btid, inst_oid, key_dbvalue);
 		  if (error_code != NO_ERROR)
 		    {
 		      goto error;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBVEC-77>

### Purpose

FAISS 라이브러리의 HNSW index에 vector를 삽입 할 때, record의 OID를 ID로 갖도록 변경

### Implementation

- OID를 `faiss::idx_t`로 변환하는 encode, decode 함수 구현
- `faiss::add_with_ids` 인터페이스를 사용하여 id를 부여하면서 vector 삽입
   -  `faiss::add_with_ids` 인터페이스를 사용하기 위해 HNSW Index 구조체인 `faiss::IndexHNSWFlat`를 `faiss::IndexIDMap`으로 래핑

### Remarks

N/A
