### PR TITLE
[CUBVEC-65] Euclidean Operator (<->)

### DIFF
--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -4046,7 +4046,6 @@ pt_is_pseudo_const (PT_NODE * expr)
 	case PT_INET_NTOA:
 	  return pt_is_pseudo_const (expr->info.expr.arg1);
 	default:
-	  ASSERT_CUBVEC (false);
 	  return false;
 	}
 

--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -60,6 +60,8 @@
 #include "dbtype.h"
 #include "xasl.h"
 
+#include "cubvec_assert.h"
+
 /* figure out how many bytes a QO_USING_INDEX struct with n entries requires */
 #define SIZEOF_USING_INDEX(n) \
     (sizeof(QO_USING_INDEX) + (((n)-1) * sizeof(QO_USING_INDEX_ENTRY)))
@@ -2188,6 +2190,12 @@ qo_analyze_term (QO_TERM * term, int term_type)
 		    case PT_EQ:
 		    case PT_IS_IN:
 		    case PT_EQ_SOME:
+		    case PT_DISTANCE_OP_EUCLIDEAN:
+		      if (op_type == PT_DISTANCE_OP_EUCLIDEAN)
+			{
+			  // CUBVEC todo: not yet analyzed
+			  ASSERT_CUBVEC (false);
+			}
 		    case PT_NULLSAFE_EQ:
 		      break;
 		    case PT_RANGE:
@@ -3189,6 +3197,12 @@ get_opcode_rank (PT_OP_TYPE opcode)
     case PT_ROWNUM:
     case PT_ORDERBY_NUM:
 
+    case PT_DISTANCE_OP_EUCLIDEAN:
+      if (opcode == PT_DISTANCE_OP_EUCLIDEAN)
+	{
+	  // CUBVEC todo: not yet analyzed
+	  ASSERT_CUBVEC (false);
+	}
     case PT_MODULUS:
     case PT_RAND:
     case PT_DRAND:
@@ -3801,6 +3815,14 @@ pt_is_pseudo_const (PT_NODE * expr)
 	case PT_BETWEEN_GE_INF:
 	case PT_BETWEEN_GT_INF:
 	  return pt_is_pseudo_const (expr->info.expr.arg1);
+	case PT_DISTANCE_OP_EUCLIDEAN:
+	  {
+	    if (expr->info.expr.op == PT_DISTANCE_OP_EUCLIDEAN)
+	      {
+		// CUBVEC todo: not yet analyzed
+		ASSERT_CUBVEC (false);
+	      }
+	  }
 	case PT_MODULUS:
 	  return (pt_is_pseudo_const (expr->info.expr.arg1)
 		  && pt_is_pseudo_const (expr->info.expr.arg2)) ? true : false;
@@ -4024,6 +4046,7 @@ pt_is_pseudo_const (PT_NODE * expr)
 	case PT_INET_NTOA:
 	  return pt_is_pseudo_const (expr->info.expr.arg1);
 	default:
+	  ASSERT_CUBVEC (false);
 	  return false;
 	}
 

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -52,6 +52,8 @@
 #include "dbtype.h"
 #include "regu_var.hpp"
 
+#include "cubvec_assert.h"
+
 #define INDENT_INCR		4
 #define INDENT_FMT		"%*c"
 #define TITLE_WIDTH		7
@@ -9288,6 +9290,13 @@ qo_expr_selectivity (QO_ENV * env, PT_NODE * pt_expr)
 	  lhs_selectivity = qo_equal_selectivity (env, node);
 	  selectivity = qo_not_selectivity (env, lhs_selectivity);
 	  break;
+
+	case PT_DISTANCE_OP_EUCLIDEAN:
+	  if (node->info.expr.op == PT_DISTANCE_OP_EUCLIDEAN)
+	    {
+	      // CUBVEC todo: not yet analyzed
+	      ASSERT_CUBVEC (false);
+	    }
 
 	case PT_NULLSAFE_EQ:
 	  selectivity = qo_equal_selectivity (env, node);

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -871,6 +871,7 @@ static int g_plcsql_text_pos;
 %type <node> sort_spec_list
 %type <node> expression_
 %type <node> normal_expression
+%type <node> expression_vector_distance
 %type <node> expression_strcat
 %type <node> expression_add_sub
 %type <node> expression_bitshift
@@ -1222,6 +1223,10 @@ static int g_plcsql_text_pos;
 %token DIAGNOSTICS
 %token DIFFERENCE_
 %token DISCONNECT
+%token DISTANCE_OP_COSINE
+%token DISTANCE_OP_EUCLIDEAN
+%token DISTANCE_OP_MANHATTAN
+%token DISTANCE_OP_NEG_INNER_PROD
 %token DISTINCT
 %token DIV
 %token DO
@@ -16947,13 +16952,33 @@ normal_expression
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
 		DBG_PRINT}}
-	| expression_strcat
-		{{ DBG_TRACE_GRAMMAR(normal_expression, | expression_strcat);
+	| expression_vector_distance
+	        {{
 
-			$$ = $1;
+	                $$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
+	// | expression_strcat
+	// 	{{ DBG_TRACE_GRAMMAR(normal_expression, | expression_strcat);
+	//
+	// 		$$ = $1;
+	// 		PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
+	//
+	// 	DBG_PRINT}}
+	;
+
+expression_vector_distance
+	: expression_vector_distance DISTANCE_OP_EUCLIDEAN expression_strcat
+		{{
+			$$ = parser_make_expression (this_parser, PT_DISTANCE_OP_EUCLIDEAN, $1, $3, NULL);
+			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
+		}}
+	| expression_strcat
+		{{
+			$$ = $1;
+			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
+		}}
 	;
 
 expression_strcat
@@ -20945,6 +20970,12 @@ comp_op
 			$$ = PT_NULLSAFE_EQ;
 
 		DBG_PRINT}}
+	// | DISTANCE_OP_EUCLIDEAN opt_of_all_some_any
+	// 	{{
+	//
+	// 		$$ = PT_DISTANCE_OP_EUCLIDEAN;
+	//
+	// 	}}
 	;
 
 opt_of_all_some_any
@@ -25900,6 +25931,7 @@ vector_distance_metric
 
 %%
 
+// int yydebug = 1;
 
 extern FILE *yyin;
 

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -16953,20 +16953,13 @@ normal_expression
 
 		DBG_PRINT}}
 	| expression_vector_distance
-	        {{
+		{{
 
-	                $$ = $1;
+			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		}}
-	// | expression_strcat
-	// 	{{ DBG_TRACE_GRAMMAR(normal_expression, | expression_strcat);
-	//
-	// 		$$ = $1;
-	// 		PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-	//
-	// 	DBG_PRINT}}
-	;
+		 }}
+;
 
 expression_vector_distance
 	: expression_vector_distance DISTANCE_OP_EUCLIDEAN expression_strcat
@@ -20970,12 +20963,6 @@ comp_op
 			$$ = PT_NULLSAFE_EQ;
 
 		DBG_PRINT}}
-	// | DISTANCE_OP_EUCLIDEAN opt_of_all_some_any
-	// 	{{
-	//
-	// 		$$ = PT_DISTANCE_OP_EUCLIDEAN;
-	//
-	// 	}}
 	;
 
 opt_of_all_some_any
@@ -25931,7 +25918,6 @@ vector_distance_metric
 
 %%
 
-// int yydebug = 1;
 
 extern FILE *yyin;
 

--- a/src/parser/csql_lexer.l
+++ b/src/parser/csql_lexer.l
@@ -1147,6 +1147,9 @@ IDL       [a-zA-Z0-9_]
 ">>"									{ begin_token(yytext);	 return BITSHIFT_RIGHT; }
 "%"									{ begin_token(yytext);	 return MOD; }
 "<=>"									{ begin_token(yytext);	 return COMP_NULLSAFE_EQ; }
+"<#>"									{ begin_token(yytext);	 return DISTANCE_OP_NEG_INNER_PROD; }
+"<+>"									{ begin_token(yytext);	 return DISTANCE_OP_MANHATTAN; }
+"<->"									{ begin_token(yytext);	 return DISTANCE_OP_EUCLIDEAN; }
 "&&"									{ begin_token(yytext);	 return AND; }
 ":="									{ begin_token(yytext);	 return VAR_ASSIGN; }
 

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -1692,6 +1692,12 @@ typedef enum
   PT_SCHEMA_DEF,
   PT_CONV_TZ,
 
+  /* CUBVEC */
+  PT_DISTANCE_OP_COSINE,
+  PT_DISTANCE_OP_EUCLIDEAN,
+  PT_DISTANCE_OP_MANHATTAN,
+  PT_DISTANCE_OP_NEG_INNER_PROD,
+
   /* This is the last entry. Please add a new one before it. */
   PT_LAST_OPCODE
 } PT_OP_TYPE;

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -4044,6 +4044,8 @@ pt_show_binopcode (PT_OP_TYPE n)
       return "schema_def";
     case PT_CONV_TZ:
       return "conv_tz";
+    case PT_DISTANCE_OP_EUCLIDEAN:
+      return " <-> ";
     default:
       assert (false);
       return "unknown opcode";
@@ -17750,6 +17752,13 @@ pt_is_const_expr_node (PT_NODE * node)
 	case PT_GT:
 	case PT_LT:
 	case PT_LE:
+	case PT_DISTANCE_OP_EUCLIDEAN:
+	  if (node->info.expr.op == PT_DISTANCE_OP_EUCLIDEAN)
+	    {
+	      // CUBVEC todo: not yet analyzed
+	      ASSERT_CUBVEC (false);
+	    }
+
 	case PT_NULLSAFE_EQ:
 	  return (pt_is_const_expr_node (node->info.expr.arg1)
 		  && pt_is_const_expr_node (node->info.expr.arg2)) ? true : false;

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -62,6 +62,8 @@
 #include "parser_allocator.hpp"
 #include "execute_schema.h"
 
+#include "cubvec_assert.h"
+
 #if defined (SUPPRESS_STRLEN_WARNING)
 #define strlen(s1)  ((int) strlen(s1))
 #endif /* defined (SUPPRESS_STRLEN_WARNING) */
@@ -8433,6 +8435,11 @@ pt_is_operator_arith (PT_OP_TYPE op)
 {
   switch (op)
     {
+    case PT_DISTANCE_OP_EUCLIDEAN:
+      {
+	vimkim_log ("PT_DISTANCE_OP_EUCLIDEAN is arithmetic.");
+	return true;
+      }
     case PT_PLUS:
     case PT_MINUS:
     case PT_TIMES:
@@ -8490,6 +8497,12 @@ pt_is_operator_logical (PT_OP_TYPE op)
     case PT_LE:
     case PT_LE_ALL:
     case PT_LE_SOME:
+    case PT_DISTANCE_OP_EUCLIDEAN:
+      if (op == PT_DISTANCE_OP_EUCLIDEAN)
+	{
+	  vimkim_log ("PT_DISTANCE_OP_EUCLIDEAN is not logical.\n");
+	  return false;
+	}
     case PT_NULLSAFE_EQ:
     case PT_IS_NOT_NULL:
     case PT_IS_NULL:

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -16696,7 +16696,6 @@ pt_check_filter_index_expr_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *a
 	case PT_GT:
 	case PT_LT:
 	case PT_LE:
-
 	case PT_NULLSAFE_EQ:
 	case PT_PLUS:
 	case PT_MINUS:

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -5556,8 +5556,8 @@ pt_find_partition_column_count (PT_NODE * expr, PT_NODE ** name_node)
       {
 	if (expr->info.expr.op == PT_DISTANCE_OP_EUCLIDEAN)
 	  {
-	    vimkim_log ("column count?\n");
-	    assert (false);
+	    vimkim_log ("find partition column count\n");
+	    ASSERT_CUBVEC (false);
 	  }
       }
     case PT_MODULUS:
@@ -16726,7 +16726,9 @@ pt_check_filter_index_expr_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *a
 	case PT_DISTANCE_OP_EUCLIDEAN:
 	  if (node->info.expr.op == PT_DISTANCE_OP_EUCLIDEAN)
 	    {
-	      assert (false);
+	      // CUBVEC todo: not yet analyzed.
+	      vimkim_log("check filter index expr pre\n");
+	      ASSERT_CUBVEC (false);
 	    }
 	case PT_MODULUS:
 	case PT_POSITION:

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -5679,7 +5679,6 @@ pt_find_partition_column_count (PT_NODE * expr, PT_NODE ** name_node)
       break;
 
     default:
-      ASSERT_CUBVEC (false);
       return -1;		/* unsupported expression */
     }
 

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -48,6 +48,8 @@
 #include "db_client_type.hpp"
 #include "msgcat_glossary.hpp"
 
+#include "cubvec_assert.h"
+
 #include "dbtype.h"
 #define PT_CHAIN_LENGTH 10
 
@@ -5550,6 +5552,14 @@ pt_find_partition_column_count (PT_NODE * expr, PT_NODE ** name_node)
     case PT_TIMEF:
     case PT_DATEDIFF:
     case PT_TIMEDIFF:
+    case PT_DISTANCE_OP_EUCLIDEAN:
+      {
+	if (expr->info.expr.op == PT_DISTANCE_OP_EUCLIDEAN)
+	  {
+	    vimkim_log ("column count?\n");
+	    assert (false);
+	  }
+      }
     case PT_MODULUS:
     case PT_POSITION:
     case PT_FINDINSET:
@@ -5669,6 +5679,7 @@ pt_find_partition_column_count (PT_NODE * expr, PT_NODE ** name_node)
       break;
 
     default:
+      ASSERT_CUBVEC (false);
       return -1;		/* unsupported expression */
     }
 
@@ -16685,6 +16696,7 @@ pt_check_filter_index_expr_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *a
 	case PT_GT:
 	case PT_LT:
 	case PT_LE:
+
 	case PT_NULLSAFE_EQ:
 	case PT_PLUS:
 	case PT_MINUS:
@@ -16712,6 +16724,11 @@ pt_check_filter_index_expr_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *a
 	case PT_BETWEEN_GE_INF:
 	case PT_BETWEEN_GT_INF:
 	case PT_RANGE:
+	case PT_DISTANCE_OP_EUCLIDEAN:
+	  if (node->info.expr.op == PT_DISTANCE_OP_EUCLIDEAN)
+	    {
+	      assert (false);
+	    }
 	case PT_MODULUS:
 	case PT_POSITION:
 	case PT_SUBSTRING:

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -16724,12 +16724,6 @@ pt_check_filter_index_expr_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *a
 	case PT_BETWEEN_GT_INF:
 	case PT_RANGE:
 	case PT_DISTANCE_OP_EUCLIDEAN:
-	  if (node->info.expr.op == PT_DISTANCE_OP_EUCLIDEAN)
-	    {
-	      // CUBVEC todo: not yet analyzed.
-	      vimkim_log ("check filter index expr pre\n");
-	      ASSERT_CUBVEC (false);
-	    }
 	case PT_MODULUS:
 	case PT_POSITION:
 	case PT_SUBSTRING:

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -16727,7 +16727,7 @@ pt_check_filter_index_expr_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *a
 	  if (node->info.expr.op == PT_DISTANCE_OP_EUCLIDEAN)
 	    {
 	      // CUBVEC todo: not yet analyzed.
-	      vimkim_log("check filter index expr pre\n");
+	      vimkim_log ("check filter index expr pre\n");
 	      ASSERT_CUBVEC (false);
 	    }
 	case PT_MODULUS:

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -6025,11 +6025,6 @@ pt_is_range_or_comp (PT_OP_TYPE op)
     case PT_LT:
     case PT_LE:
     case PT_DISTANCE_OP_EUCLIDEAN:
-      if (op == PT_DISTANCE_OP_EUCLIDEAN)
-	{
-	  vimkim_log ("PT_DISTANCE_OP_EUCLIDEAN is not a range nor comp.\n");
-	  return false;
-	}
     case PT_NULLSAFE_EQ:
     case PT_GT_INF:
     case PT_LT_INF:
@@ -6044,6 +6039,10 @@ pt_is_range_or_comp (PT_OP_TYPE op)
     case PT_BETWEEN_GT_INF:
       return true;
     default:
+      if (op == PT_DISTANCE_OP_EUCLIDEAN)
+	{
+	  vimkim_log ("PT_DISTANCE_OP_EUCLIDEAN is not a range nor comp.\n");
+	}
       return false;
     }
 }

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -63,6 +63,8 @@
 #include "tz_support.h"
 #include "func_type.hpp"
 
+#include "cubvec_assert.h"
+
 #include "dbtype.h"
 
 #define SET_EXPECTED_DOMAIN(node, dom) \
@@ -1647,6 +1649,22 @@ pt_get_expression_definition (const PT_OP_TYPE op, EXPRESSION_DEFINITION * def)
 
       sig.return_type.type = pt_arg_type::NORMAL;
       sig.return_type.val.type = PT_TYPE_MULTISET;
+      def->overloads[num++] = sig;
+
+      def->overloads_count = num;
+      break;
+
+    case PT_DISTANCE_OP_EUCLIDEAN:
+      num = 0;
+      vimkim_log ("op: %s\n", pt_show_binopcode (op));
+
+      sig.arg1_type.type = pt_arg_type::NORMAL;
+      sig.arg1_type.val.type = PT_TYPE_VECTOR;
+      sig.arg2_type.type = pt_arg_type::NORMAL;
+      sig.arg2_type.val.type = PT_TYPE_VECTOR;
+      sig.return_type.type = pt_arg_type::NORMAL;
+      sig.return_type.val.type = PT_TYPE_FLOAT;
+
       def->overloads[num++] = sig;
 
       def->overloads_count = num;
@@ -6006,6 +6024,12 @@ pt_is_range_or_comp (PT_OP_TYPE op)
     case PT_GT:
     case PT_LT:
     case PT_LE:
+    case PT_DISTANCE_OP_EUCLIDEAN:
+      if (op == PT_DISTANCE_OP_EUCLIDEAN)
+	{
+	  vimkim_log ("PT_DISTANCE_OP_EUCLIDEAN is not a range nor comp.\n");
+	  return false;
+	}
     case PT_NULLSAFE_EQ:
     case PT_GT_INF:
     case PT_LT_INF:
@@ -10422,6 +10446,15 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
       node->type_enum = node->info.expr.arg1->type_enum;
       break;
 
+    case PT_DISTANCE_OP_EUCLIDEAN:
+      {
+	vimkim_log ("why null?");
+	node->info.expr.arg1 = arg1;
+	node->info.expr.arg2 = arg2;
+	node->type_enum = PT_TYPE_VECTOR;
+	goto error;
+      }
+
     default:
       node->type_enum = PT_TYPE_NONE;
       break;
@@ -12696,6 +12729,19 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 
   switch (op)
     {
+
+    case PT_DISTANCE_OP_EUCLIDEAN:
+      {
+	DB_VALUE *arr[2] = { arg1, arg2 };
+	error = vector_l2_distance (result, arr, 2);
+	if (error != NO_ERROR)
+	  {
+	    PT_ERRORc (parser, o1, er_msg ());
+	    return 0;
+	  }
+	break;
+      }
+
     case PT_NOT:
       if (typ1 == DB_TYPE_NULL)
 	{

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -10448,7 +10448,6 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
 
     case PT_DISTANCE_OP_EUCLIDEAN:
       {
-	vimkim_log ("why null?");
 	node->info.expr.arg1 = arg1;
 	node->info.expr.arg2 = arg2;
 	node->type_enum = PT_TYPE_VECTOR;

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -73,6 +73,8 @@
 #include "wintcp.h"
 #endif /* WINDOWS */
 
+#include "cubvec_assert.h"
+
 #include "dbtype.h"
 
 extern void qo_plan_lite_print (QO_PLAN * plan, FILE * f, int howfar);
@@ -1542,6 +1544,12 @@ pt_to_pred_expr_local_with_arg (PARSER_CONTEXT * parser, PT_NODE * node, int *ar
 	  saved_etc = parser->etc;
 	  parser->etc = NULL;
 
+	  if (node->info.expr.op == PT_DISTANCE_OP_EUCLIDEAN)
+	    {
+	      // CUBVEC todo: not yet analyzed
+	      ASSERT_CUBVEC (false);
+	    }
+
 	  /* set regu variables */
 	  if (node->info.expr.op == PT_SETEQ || node->info.expr.op == PT_EQ || node->info.expr.op == PT_SETNEQ
 	      || node->info.expr.op == PT_NE || node->info.expr.op == PT_GE || node->info.expr.op == PT_GT
@@ -1599,6 +1607,12 @@ pt_to_pred_expr_local_with_arg (PARSER_CONTEXT * parser, PT_NODE * node, int *ar
 					((node->info.expr.qualifier == PT_EQ_TORDER) ? R_EQ_TORDER : R_EQ), data_type);
 	      break;
 
+	    case PT_DISTANCE_OP_EUCLIDEAN:
+	      if (node->info.expr.op == PT_DISTANCE_OP_EUCLIDEAN)
+		{
+		  // CUBVEC todo: not yet analyzed
+		  ASSERT_CUBVEC (false);
+		}
 	    case PT_NULLSAFE_EQ:
 	      pred = pt_make_pred_term_comp (regu_var1, regu_var2, R_NULLSAFE_EQ, data_type);
 	      break;
@@ -6392,6 +6406,11 @@ REGU_VARIABLE *
 pt_make_regu_arith (const REGU_VARIABLE * arg1, const REGU_VARIABLE * arg2, const REGU_VARIABLE * arg3,
 		    const OPERATOR_TYPE op, const TP_DOMAIN * domain)
 {
+  if (op == T_DISTANCE_OP_EUCLIDEAN)
+    {
+      vimkim_log ("inside make regu func\n");
+    }
+
   REGU_VARIABLE *regu = NULL;
   ARITH_TYPE *arith;
   DB_VALUE *dbval;
@@ -7616,6 +7635,10 @@ pt_to_regu_variable (PARSER_CONTEXT * parser, PT_NODE * node, UNBOX unbox)
 	      break;
 
 	    case PT_EXPR:
+	      if (node->info.expr.op == PT_DISTANCE_OP_EUCLIDEAN)
+		{
+		  vimkim_log ("op is PT_DISTANCE_OP_EUCLIDEAN and the vector is operated against a column.\n");
+		}
 	      if (node->info.expr.op == PT_FUNCTION_HOLDER)
 		{
 		  //TODO FIND WHY NEXT WASN'T RESTORED
@@ -7664,11 +7687,12 @@ pt_to_regu_variable (PARSER_CONTEXT * parser, PT_NODE * node, UNBOX unbox)
 	      domain = NULL;
 	      if (node->info.expr.op == PT_PLUS || node->info.expr.op == PT_MINUS || node->info.expr.op == PT_TIMES
 		  || node->info.expr.op == PT_DIVIDE || node->info.expr.op == PT_MODULUS
-		  || node->info.expr.op == PT_POWER || node->info.expr.op == PT_AES_ENCRYPT
-		  || node->info.expr.op == PT_AES_DECRYPT || node->info.expr.op == PT_SHA_TWO
-		  || node->info.expr.op == PT_ROUND || node->info.expr.op == PT_LOG || node->info.expr.op == PT_TRUNC
-		  || node->info.expr.op == PT_POSITION || node->info.expr.op == PT_FINDINSET
-		  || node->info.expr.op == PT_LPAD || node->info.expr.op == PT_RPAD || node->info.expr.op == PT_REPLACE
+		  || node->info.expr.op == PT_POWER
+		  || node->info.expr.op == PT_AES_ENCRYPT || node->info.expr.op == PT_AES_DECRYPT
+		  || node->info.expr.op == PT_SHA_TWO || node->info.expr.op == PT_ROUND || node->info.expr.op == PT_LOG
+		  || node->info.expr.op == PT_TRUNC || node->info.expr.op == PT_POSITION
+		  || node->info.expr.op == PT_FINDINSET || node->info.expr.op == PT_LPAD
+		  || node->info.expr.op == PT_RPAD || node->info.expr.op == PT_REPLACE
 		  || node->info.expr.op == PT_TRANSLATE || node->info.expr.op == PT_ADD_MONTHS
 		  || node->info.expr.op == PT_MONTHS_BETWEEN || node->info.expr.op == PT_FORMAT
 		  || node->info.expr.op == PT_ATAN || node->info.expr.op == PT_ATAN2
@@ -7688,7 +7712,8 @@ pt_to_regu_variable (PARSER_CONTEXT * parser, PT_NODE * node, UNBOX unbox)
 		  || node->info.expr.op == PT_WEEKF || node->info.expr.op == PT_MAKEDATE
 		  || node->info.expr.op == PT_ADDTIME || node->info.expr.op == PT_DEFINE_VARIABLE
 		  || node->info.expr.op == PT_CHR || node->info.expr.op == PT_CLOB_TO_CHAR
-		  || node->info.expr.op == PT_INDEX_PREFIX || node->info.expr.op == PT_FROM_TZ)
+		  || node->info.expr.op == PT_INDEX_PREFIX || node->info.expr.op == PT_FROM_TZ
+		  || node->info.expr.op == PT_DISTANCE_OP_EUCLIDEAN)
 		{
 		  r1 = pt_to_regu_variable (parser, node->info.expr.arg1, unbox);
 		  if ((node->info.expr.op == PT_CONCAT) && node->info.expr.arg2 == NULL)
@@ -8092,6 +8117,10 @@ pt_to_regu_variable (PARSER_CONTEXT * parser, PT_NODE * node, UNBOX unbox)
 		{
 		case PT_PLUS:
 		  regu = pt_make_regu_arith (r1, r2, NULL, T_ADD, domain);
+		  break;
+
+		case PT_DISTANCE_OP_EUCLIDEAN:
+		  regu = pt_make_regu_arith (r1, r2, NULL, T_DISTANCE_OP_EUCLIDEAN, domain);
 		  break;
 
 		case PT_MINUS:

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -6408,7 +6408,7 @@ pt_make_regu_arith (const REGU_VARIABLE * arg1, const REGU_VARIABLE * arg2, cons
 {
   if (op == T_DISTANCE_OP_EUCLIDEAN)
     {
-      vimkim_log ("inside make regu func\n");
+      vimkim_log ("inside make regu func.\n");
     }
 
   REGU_VARIABLE *regu = NULL;

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -57,6 +57,9 @@
 #include "subquery_cache.h"
 #include "pl_executor.hpp"
 
+#include "cubvec_assert.h"
+#include "vector_opfunc.hpp"
+
 #include "dbtype.h"
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
 #include "memory_wrapper.hpp"
@@ -180,6 +183,13 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, val_descr *
     case T_MUL:
     case T_DIV:
     case T_MOD:
+    case T_DISTANCE_OP_EUCLIDEAN:
+      {
+	if (arithptr->opcode == T_DISTANCE_OP_EUCLIDEAN)
+	  {
+	    vimkim_log ("here\n");
+	  }
+      }
     case T_POSITION:
     case T_FINDINSET:
     case T_ADD_MONTHS:
@@ -812,6 +822,17 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, val_descr *
 	{
 	  goto error;
 	}
+      break;
+
+    case T_DISTANCE_OP_EUCLIDEAN:
+      {
+	DB_VALUE *args[2] = { peek_left, peek_right };
+	int err = vector_l2_distance (arithptr->value, args, 2);
+	if (err != NO_ERROR)
+	  {
+	    goto error;
+	  }
+      }
       break;
 
     case T_MOD:

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -187,7 +187,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, val_descr *
       {
 	if (arithptr->opcode == T_DISTANCE_OP_EUCLIDEAN)
 	  {
-	    vimkim_log ("here\n");
+	    vimkim_log ("fetch peek arith.\n");
 	  }
       }
     case T_POSITION:

--- a/src/storage/storage_common.h
+++ b/src/storage/storage_common.h
@@ -893,6 +893,7 @@ typedef enum
   T_CURRENT_DATE,
   T_CURRENT_TIME,
   T_CONV_TZ,
+  T_DISTANCE_OP_EUCLIDEAN,
 } OPERATOR_TYPE;		/* arithmetic operator types */
 
 /************************************************************************/


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBVEC-65>

### Purpose

벡터 거리 연산을 위한 `<->` L2 distance operator를 구현합니다.

```make
run-euclidean-operator:
    csql.sh -c "select '[1, 2, 3]' <-> '[2, 3, 4]';"

run-create-table:
    csql.sh -c "drop table if exists tbl; create table tbl (id int, vec vector); insert into tbl values (1, '[1, 2, 3]'), (2, '[2, 3, 4]'); select * from tbl;"

run-euclidean-operator-col:
    csql.sh -c "select '[1, 2, 3]' <-> vec from tbl;"

run-order-by-euclidean-operator:
    csql.sh -c "select * from tbl order by '[1, 2, 3]' <-> vec;"
```

```sh
 csql.sh -c "select '[1, 2, 3]' <-> '[2, 3, 4]';"

##### CS MODE to db: testdb

=== <Result of SELECT Command in Line 1> ===

  '[1, 2, 3]' <-> '[2, 3, 4]'
=============================
                 1.732051e+00

1 row selected. (0.004180 sec) Committed. (0.000000 sec)
```

```sh
csql.sh -c "select '[1, 2, 3]' <-> vec from tbl;"

##### CS MODE to db: testdb

=== <Result of SELECT Command in Line 1> ===

  '[1, 2, 3]' <-> vec
=====================
         0.000000e+00
         1.732051e+00

2 rows selected. (0.004623 sec) Committed. (0.000000 sec)
```

```sh
csql.sh -c "select * from tbl order by '[1, 2, 3]' <-> vec;"

##### CS MODE to db: testdb

=== <Result of SELECT Command in Line 1> ===

           id  vec
===================================
            1  [dim: 3] [1.000000, 2.000000, 3.000000]
            2  [dim: 3] [2.000000, 3.000000, 4.000000]

2 rows selected. (0.005307 sec) Committed. (0.000000 sec)
```

```sh
csql.sh -c "select * from tbl order by '[2, 3, 4]' <-> vec;"
##### CS MODE to db: testdb

=== <Result of SELECT Command in Line 1> ===

           id  vec
===================================
            2  [dim: 3] [2.000000, 3.000000, 4.000000]
            1  [dim: 3] [1.000000, 2.000000, 3.000000]

2 rows selected. (0.005225 sec) Committed. (0.000000 sec)
```

### Implementation

#### 두 인자가 모두 Literal일 경우
![image](https://github.com/user-attachments/assets/6b054f13-b584-4cf3-8309-60843a550ed6)

#### 두 인자 중 적어도 하나가 column type일 경우
![image](https://github.com/user-attachments/assets/51f049ac-e8d9-432c-b723-fda712d32146)


### Remarks

```bash
csql.sh -c "select * from tbl order by '[2, 3, 4]' <-> vec;"
csql.sh -c "select * from tbl order by '[1, 2, 3]' <-> vec;"
```
두 경우 정렬이 서로 다르게 나오는 것을 확인해야 한다.