### PR TITLE
[CUBVEC-76] Creating HNSW index: Considering dimension of VECTOR type

### DIFF
--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -258,7 +258,7 @@ TP_DOMAIN tp_Multiset_domain = { NULL, NULL, &tp_Multiset, DOMAIN_INIT3 };
 TP_DOMAIN tp_Sequence_domain = { NULL, NULL, &tp_Sequence, DOMAIN_INIT3 };
 
 // TODO: CUBVEC: DOMAIN or DOMAIN_INIT3? Not analyzed yet.
-TP_DOMAIN tp_Vector_domain = { NULL, NULL, &tp_Vector, DOMAIN_INIT };
+TP_DOMAIN tp_Vector_domain = { NULL, NULL, &tp_Vector, DOMAIN_INIT4 (DB_DEFAULT_PRECISION, 0) };
 
 TP_DOMAIN tp_Midxkey_domain_list_heads[TP_NUM_MIDXKEY_DOMAIN_LIST] = {
   {NULL, NULL, &tp_Midxkey, DOMAIN_INIT3},
@@ -1543,11 +1543,6 @@ tp_domain_match_internal (const TP_DOMAIN * dom1, const TP_DOMAIN * dom2, TP_MAT
   switch (TP_DOMAIN_TYPE (dom1))
     {
 
-    case DB_TYPE_VECTOR:
-      {
-	ASSERT_CUBVEC (false);
-      }
-
     case DB_TYPE_NULL:
     case DB_TYPE_INTEGER:
     case DB_TYPE_BIGINT:
@@ -1574,6 +1569,12 @@ tp_domain_match_internal (const TP_DOMAIN * dom1, const TP_DOMAIN * dom2, TP_MAT
 
     case DB_TYPE_JSON:
       match = (int) db_json_are_validators_equal (dom1->json_validator, dom2->json_validator);
+      break;
+
+
+    case DB_TYPE_VECTOR:
+      // TODO (CUBVEC): Only precision is considered for now.
+      match = ((dom1->precision == dom2->precision));
       break;
 
     case DB_TYPE_VOBJ:
@@ -1964,7 +1965,6 @@ tp_is_domain_cached (TP_DOMAIN * dlist, TP_DOMAIN * transient, TP_MATCH exact, T
   switch (TP_DOMAIN_TYPE (domain))
     {
 
-    case DB_TYPE_VECTOR:
     case DB_TYPE_NULL:
     case DB_TYPE_INTEGER:
     case DB_TYPE_BIGINT:
@@ -2236,6 +2236,21 @@ tp_is_domain_cached (TP_DOMAIN * dlist, TP_DOMAIN * transient, TP_MATCH exact, T
       while (domain)
 	{
 	  match = (int) db_json_are_validators_equal (transient->json_validator, domain->json_validator);
+
+	  if (match)
+	    {
+	      break;
+	    }
+	  *ins_pos = domain;
+	  domain = domain->next_list;
+	}
+      break;
+
+    case DB_TYPE_VECTOR:
+      while (domain)
+	{
+	  // TODO (CUBVEC): Only precision is considered for now.
+	  match = ((domain->precision == transient->precision));
 
 	  if (match)
 	    {
@@ -11491,6 +11506,17 @@ fprint_domain (FILE * fp, TP_DOMAIN * domain)
 
 	case DB_TYPE_NUMERIC:
 	  fprintf (fp, "%s(%d,%d)", d->type->name, d->precision, d->scale);
+	  break;
+
+	case DB_TYPE_VECTOR:
+	  if (d->precision == 0 || d->precision == DB_DEFAULT_PRECISION)
+	    {
+	      fprintf (fp, "%s", d->type->name);
+	    }
+	  else
+	    {
+	      fprintf (fp, "%s(%d)", d->type->name, d->precision);
+	    }
 	  break;
 
 	default:

--- a/src/object/object_printer.cpp
+++ b/src/object/object_printer.cpp
@@ -320,7 +320,7 @@ void object_printer::describe_domain (/*const*/tp_domain &domain, class_descript
 
 	case DB_TYPE_VECTOR:
 	  strcpy (temp_buffer, temp_domain->type->name);
-	  m_buf ("%s", ustr_upper (temp_buffer));
+	  m_buf ("%s(%d)", ustr_upper (temp_buffer), temp_domain->precision);
 	  break;
 
 	case DB_TYPE_ENUMERATION:

--- a/src/object/object_printer.cpp
+++ b/src/object/object_printer.cpp
@@ -320,7 +320,14 @@ void object_printer::describe_domain (/*const*/tp_domain &domain, class_descript
 
 	case DB_TYPE_VECTOR:
 	  strcpy (temp_buffer, temp_domain->type->name);
-	  m_buf ("%s(%d)", ustr_upper (temp_buffer), temp_domain->precision);
+	  if (temp_domain->precision == 0 || temp_domain->precision == DB_DEFAULT_PRECISION)
+	    {
+	      m_buf ("%s", ustr_upper (temp_buffer));
+	    }
+	  else
+	    {
+	      m_buf ("%s(%d)", ustr_upper (temp_buffer), temp_domain->precision);
+	    }
 	  break;
 
 	case DB_TYPE_ENUMERATION:

--- a/src/object/object_representation.c
+++ b/src/object/object_representation.c
@@ -2820,6 +2820,10 @@ or_packed_domain_size (TP_DOMAIN * domain, int include_classoids)
 	  size += or_packed_json_validator_length (d->json_validator);
 	  break;
 
+	case DB_TYPE_VECTOR:
+	  precision = d->precision;
+	  break;
+
 	default:
 	  break;
 	}
@@ -3006,7 +3010,7 @@ or_put_domain (OR_BUF * buf, TP_DOMAIN * domain, int include_classoids, int is_n
 	  break;
 
 	case DB_TYPE_VECTOR:
-	  vimkim_log ("WARNING: not analyzed.\n");
+	  precision = d->precision;
 	  break;
 
 	case DB_TYPE_SET:
@@ -3324,6 +3328,10 @@ unpack_domain_2 (OR_BUF * buf, int *is_null)
 
 	    case DB_TYPE_JSON:
 	      has_schema = (carrier & OR_DOMAIN_SCHEMA_FLAG) != 0;
+	      break;
+
+	    case DB_TYPE_VECTOR:
+	      precision = (carrier & OR_DOMAIN_PRECISION_MASK) >> OR_DOMAIN_PRECISION_SHIFT;
 	      break;
 
 	    default:

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -10815,7 +10815,14 @@ allocate_index (MOP classop, SM_CLASS * class_, DB_OBJLIST * subclasses, SM_CLAS
     {
       if (con->type == SM_CONSTRAINT_VECTOR_INDEX)
 	{
-	  error = hnsw_add_index (index, 10, 32, 100, faiss::METRIC_L2);
+	  if (domain->precision < 1)
+	    {
+              // TODO (CUBVEC): set proper error code
+	      error = ER_SM_INVALID_INDEX_TYPE;
+	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 1, domain->type->name);
+	      return error;
+	    }
+	  error = hnsw_add_index (index, domain->precision, 32, 100, faiss::METRIC_L2);
 	}
       else
 	{

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -10817,7 +10817,7 @@ allocate_index (MOP classop, SM_CLASS * class_, DB_OBJLIST * subclasses, SM_CLAS
 	{
 	  if (domain->precision < 1)
 	    {
-              // TODO (CUBVEC): set proper error code
+	      // TODO (CUBVEC): set proper error code
 	      error = ER_SM_INVALID_INDEX_TYPE;
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 1, domain->type->name);
 	      return error;

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -10819,7 +10819,8 @@ allocate_index (MOP classop, SM_CLASS * class_, DB_OBJLIST * subclasses, SM_CLAS
 	    {
 	      // TODO (CUBVEC): set proper error code
 	      error = ER_SM_INVALID_INDEX_TYPE;
-	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 1, domain->type->name);
+	      std::string error_msg = std::string (domain->type->name) + "(" + std::to_string (domain->precision) + ")";
+	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 1, error_msg.c_str ());
 	      return error;
 	    }
 	  error = hnsw_add_index (index, domain->precision, 32, 100, faiss::METRIC_L2);

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -22551,13 +22551,29 @@ primitive_type
 		{{ DBG_TRACE_GRAMMAR(data_type, | vector_type);
 
 			container_2 ctn;
-			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_VECTOR), NULL);
+			PT_TYPE_ENUM type;
+			PT_NODE *prec, *vec_type, *dt;
+
+			prec = CONTAINER_AT_0 ($2);
+			vec_type = CONTAINER_AT_1 ($2);
+
+			dt = parser_new_node (this_parser, PT_DATA_TYPE);
+			type = PT_TYPE_VECTOR;
+
+			if (dt)
+			  {
+			    assert (prec);
+
+			    dt->type_enum = type;
+			    dt->info.data_type.precision = prec->info.value.data_value.i;
+			  }
+
+			SET_CONTAINER_2 (ctn, FROM_NUMBER (type), dt);
 			$$ = ctn;
 
-            // TODO: The opt_vector_args are not covered in this milestone.
+			// TODO: The opt_vector_args are not covered in this milestone.
 			// Dimension and type validation for VECTOR arguments must be included
 			// in the milestone that checks user input for correctness.
-
 
 		DBG_PRINT}}
 	;
@@ -22567,7 +22583,13 @@ opt_vector_args
 		{{ DBG_TRACE_GRAMMAR(opt_vector_args, : );
 
 			container_2 ctn;
-			SET_CONTAINER_2 (ctn, NULL, NULL);
+			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
+			if (val)
+                          {
+			    val->info.value.data_value.i = DB_DEFAULT_PRECISION; /* -1 */
+                          }
+
+			SET_CONTAINER_2 (ctn, val, FROM_NUMBER(PT_TYPE_FLOAT));
 			$$ = ctn;
 
 		DBG_PRINT}}
@@ -22575,7 +22597,7 @@ opt_vector_args
 		{{ DBG_TRACE_GRAMMAR(opt_vector_args, | '(' unsigned_integer ')' );
 
 			container_2 ctn;
-			SET_CONTAINER_2 (ctn, $2, NULL);
+			SET_CONTAINER_2 (ctn, $2, FROM_NUMBER(PT_TYPE_FLOAT));
 			$$ = ctn;
 
 		DBG_PRINT}}

--- a/src/parser/parse_dbi.c
+++ b/src/parser/parse_dbi.c
@@ -1948,6 +1948,7 @@ pt_data_type_to_db_domain (PARSER_CONTEXT * parser, PT_NODE * dt, const char *cl
       break;
 
     case DB_TYPE_VECTOR:
+      precision = dt->info.data_type.precision;
       break;
 
     case DB_TYPE_SET:
@@ -2134,6 +2135,11 @@ pt_node_data_type_to_db_domain (PARSER_CONTEXT * parser, PT_NODE * dt, PT_TYPE_E
 	{
 	  return pt_type_enum_to_db_domain (dt->type_enum);
 	}
+
+    case DB_TYPE_VECTOR:
+      /* TODO (CUBVEC): Only precision is considered for now. */
+      precision = dt->info.data_type.precision;
+      break;
 
     case DB_TYPE_OBJECT:
       /* first check if its a VOBJ */

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -6757,6 +6757,20 @@ pt_print_attr_def (PARSER_CONTEXT * parser, PT_NODE * p)
       q = pt_append_varchar (parser, q, r1);
       q = pt_append_nulstring (parser, q, ")");
       break;
+    case PT_TYPE_VECTOR:
+      q = pt_append_nulstring (parser, q, pt_show_type_enum (p->type_enum));
+      if (p->data_type)
+	{
+	  int precision = p->data_type->info.data_type.precision;
+	  if (precision != 0 && precision != DB_DEFAULT_PRECISION)
+	    {
+	      q = pt_append_nulstring (parser, q, "(");
+	      sprintf (s, "%d", precision);
+	      q = pt_append_nulstring (parser, q, s);
+	      q = pt_append_nulstring (parser, q, ")");
+	    }
+	}
+      break;
     default:
       q = pt_append_nulstring (parser, q, pt_show_type_enum (p->type_enum));
       if (p->data_type)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-76

### Purpose

- HNSW 인덱스 생성 시 벡터 타입의 dimension을 고려하여 만들 수 있도록, 테이블 생성 시에 벡터 타입의 dimension을 올바르게 저장하도록 수정
- HNSW 생성 함수에 dimension 전달

### Implementation

- csql_grammer.y: VECTOR 타입에 대해서 data_type 노드 생성, precision 반영
- parse_dbi.c: VECTOR 타입에 대하여 data_type 노드에서 TP_DOMAIN으로 변환하는 부분 구현
- object_representation.c: VECTOR 타입의 TP_DOMAIN에 대한 pack, unpack 에서 precision 고려
- object_domain.c: 동일한 dimesnion을 가진 DB_TYPE_VECTOR에 대한 TP_DOMAIN에 대해 중복해서 만들어지지 않도록 domain cache에 대한 비교 룰 추가
- schema_manager.c
   - dimension 없이 정의한 테이블의 VECTOR 타입에 대해 인덱스를 만들지 못하도록 에러 추가
   - domain->precision을 HNSW 생성 함수 (hnsw_add_index) 에 전달

### Remarks

- 코드 디버깅 및 ;sc와 같은 스키마 정보를 보는 명령어에서 dimension을 고려하여 벡터 데이터의 타입을 출력할 수 있도록, 출력과 관련한 함수도 함께 수정
  - parse_tree_cl.c
  - object_printer.cpp