### PR TITLE
[CBRD-26060] la_apply_log_file 중 초기화 루틴 리팩토링

### DIFF
--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -8027,29 +8027,29 @@ check_reinit_copylog (void)
 }
 
 static inline void
-set_la_slave_db_name (const char *database_name)
+set_la_slave_db_name (char *dest, const char *src)
 {
-  const char *at = strchr (database_name, '@');
+  const char *at = strchr (src, '@');
   size_t len;
 
   if (at != NULL)
     {
-      len = at - database_name;
+      len = at - src;
     }
   else
     {
       len = DB_MAX_IDENTIFIER_LENGTH;
     }
 
-  snprintf (la_slave_db_name, DB_MAX_IDENTIFIER_LENGTH, "%.*s", (int) len, database_name);
+  snprintf (dest, DB_MAX_IDENTIFIER_LENGTH, "%.*s", (int) len, src);
 }
 
 static inline void
-set_la_peer_host (const char *log_path)
+set_la_peer_host (char *dest, const char *src)
 {
-  const char *host = la_get_hostname_from_log_path ((char *) log_path);
+  const char *host = la_get_hostname_from_log_path ((char *) src);
 
-  snprintf (la_peer_host, CUB_MAXHOSTNAMELEN, "%s", host ? host : "unknown");
+  snprintf (dest, CUB_MAXHOSTNAMELEN, "%s", host ? host : "unknown");
 }
 
 static inline void
@@ -8115,8 +8115,8 @@ la_apply_log_file (const char *database_name, const char *log_path, const int ma
   (void) os_set_signal_handler (SIGPIPE, SIG_IGN);
 #endif /* ! WINDOWS */
 
-  set_la_slave_db_name (database_name);
-  set_la_peer_host (log_path);
+  set_la_slave_db_name (la_slave_db_name, database_name);
+  set_la_peer_host (la_peer_host, log_path);
 
   /* init la_Info */
   la_init (log_path, max_mem_size);

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -8006,24 +8006,16 @@ la_destroy_repl_filter (void)
 static int
 check_reinit_copylog (void)
 {
-  int error = NO_ERROR;
+	if (la_fetch_log_hdr(&la_Info.act_log) != NO_ERROR)
+		return ER_FAILED;
 
-  /* fetch header */
-  error = la_fetch_log_hdr (&la_Info.act_log);
-  if (error != NO_ERROR)
-    {
-      error = ER_FAILED;
-      return error;
-    }
+	if (la_Info.act_log.log_hdr->mark_will_del)
+	{
+		la_Info.reinit_copylog = true;
+		return ER_FAILED;
+	}
 
-  if (la_Info.act_log.log_hdr->mark_will_del == true)
-    {
-      la_Info.reinit_copylog = true;
-      error = ER_FAILED;
-      return error;
-    }
-
-  return error;
+	return NO_ERROR;
 }
 
 static inline void la_extract_db_name(char *dest, const char *src){

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -8053,7 +8053,7 @@ la_set_peer_host (char *dest, const char *src)
 }
 
 static inline void
-init_delay_history (int *delay_history)
+la_init_delay_history (int *delay_history)
 {
   for (int i = 0; i < LA_NUM_DELAY_HISTORY; i++)
     {
@@ -8196,7 +8196,7 @@ la_apply_log_file (const char *database_name, const char *log_path, const int ma
       return error;
     }
 
-  init_delay_history (delay_hist);
+  la_init_delay_history (delay_hist);
 
   time_commit_interval = prm_get_integer_value (PRM_ID_HA_APPLYLOGDB_MAX_COMMIT_INTERVAL_IN_MSECS);
 

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -8036,6 +8036,11 @@ static inline void la_extract_peer_host(char *dest, const char *log_path){
 		strncpy(la_peer_host, "unknown", CUB_MAXHOSTNAMELEN);
 }
 
+static inline void init_delay_hist(int *delay_hist){
+	for (int i = 0; i < LA_NUM_DELAY_HISTORY; i++)
+		delay_hist[i] = -1;
+}
+
 /*
  * la_apply_log_file() - apply the transaction log to the slave
  *   return: int
@@ -8071,7 +8076,6 @@ la_apply_log_file (const char *database_name, const char *log_path, const int ma
   LOG_LSA last_eof_lsa;
   int time_commit_interval;
   int delay_hist[LA_NUM_DELAY_HISTORY];
-  int i;
   int remove_arv_interval_in_secs;
   int max_arv_count_to_delete = 0;
 
@@ -8172,10 +8176,8 @@ la_apply_log_file (const char *database_name, const char *log_path, const int ma
       return error;
     }
 
-  for (i = 0; i < LA_NUM_DELAY_HISTORY; i++)
-    {
-      delay_hist[i] = -1;
-    }
+  init_delay_hist(delay_hist);
+  
   time_commit_interval = prm_get_integer_value (PRM_ID_HA_APPLYLOGDB_MAX_COMMIT_INTERVAL_IN_MSECS);
 
   if (prm_get_integer_value (PRM_ID_HA_REPL_FILTER_TYPE) != REPL_FILTER_NONE)

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -8006,16 +8006,24 @@ la_destroy_repl_filter (void)
 static int
 check_reinit_copylog (void)
 {
-  if (la_fetch_log_hdr (&la_Info.act_log) != NO_ERROR)
-    return ER_FAILED;
+  int error = NO_ERROR;
 
-  if (la_Info.act_log.log_hdr->mark_will_del)
+  /* fetch header */
+  error = la_fetch_log_hdr (&la_Info.act_log);
+  if (error != NO_ERROR)
     {
-      la_Info.reinit_copylog = true;
-      return ER_FAILED;
+      error = ER_FAILED;
+      return error;
     }
 
-  return NO_ERROR;
+  if (la_Info.act_log.log_hdr->mark_will_del == true)
+    {
+      la_Info.reinit_copylog = true;
+      error = ER_FAILED;
+      return error;
+    }
+
+	return NO_ERROR;
 }
 
 static inline void

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -8023,7 +8023,7 @@ check_reinit_copylog (void)
       return error;
     }
 
-	return NO_ERROR;
+  return error;
 }
 
 static inline void

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -8027,7 +8027,7 @@ check_reinit_copylog (void)
 }
 
 static inline void
-set_la_slave_db_name (char *dest, const char *src)
+la_set_slave_db_name (char *dest, const char *src)
 {
   const char *at = strchr (src, '@');
   size_t len;
@@ -8045,7 +8045,7 @@ set_la_slave_db_name (char *dest, const char *src)
 }
 
 static inline void
-set_la_peer_host (char *dest, const char *src)
+la_set_peer_host (char *dest, const char *src)
 {
   const char *host = la_get_hostname_from_log_path ((char *) src);
 
@@ -8115,8 +8115,8 @@ la_apply_log_file (const char *database_name, const char *log_path, const int ma
   (void) os_set_signal_handler (SIGPIPE, SIG_IGN);
 #endif /* ! WINDOWS */
 
-  set_la_slave_db_name (la_slave_db_name, database_name);
-  set_la_peer_host (la_peer_host, log_path);
+  la_set_slave_db_name (la_slave_db_name, database_name);
+  la_set_peer_host (la_peer_host, log_path);
 
   /* init la_Info */
   la_init (log_path, max_mem_size);

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -8026,6 +8026,24 @@ check_reinit_copylog (void)
   return error;
 }
 
+static inline void la_extract_db_name(char *dest, const char *src){
+	char *at;
+
+	strncpy(dest, src, DB_MAX_IDENTIFIER_LENGTH);
+	at = strchr(dest, '@');
+	if (at)
+		*at = '\0';
+}
+
+static inline void la_extract_peer_host(char *dest, const char *log_path){
+	const char *host = la_get_hostname_from_log_path ((char *) log_path);
+	
+	if (host)
+		strncpy (la_peer_host, host, CUB_MAXHOSTNAMELEN);
+	else
+		strncpy(la_peer_host, "unknown", CUB_MAXHOSTNAMELEN);
+}
+
 /*
  * la_apply_log_file() - apply the transaction log to the slave
  *   return: int
@@ -8055,7 +8073,6 @@ la_apply_log_file (const char *database_name, const char *log_path, const int ma
   };
   LOG_LSA prev_final;
   struct timeval time_commit;
-  char *s;
   int last_nxarv_num = 0;
   bool clear_owner;
   int now = 0, last_eof_time = 0;
@@ -8082,22 +8099,8 @@ la_apply_log_file (const char *database_name, const char *log_path, const int ma
   (void) os_set_signal_handler (SIGPIPE, SIG_IGN);
 #endif /* ! WINDOWS */
 
-  strncpy (la_slave_db_name, database_name, DB_MAX_IDENTIFIER_LENGTH);
-  s = strchr (la_slave_db_name, '@');
-  if (s)
-    {
-      *s = '\0';
-    }
-
-  s = la_get_hostname_from_log_path ((char *) log_path);
-  if (s)
-    {
-      strncpy (la_peer_host, s, CUB_MAXHOSTNAMELEN);
-    }
-  else
-    {
-      strncpy (la_peer_host, "unknown", CUB_MAXHOSTNAMELEN);
-    }
+  la_extract_db_name(la_slave_db_name, database_name);
+  la_extract_peer_host(la_peer_host, log_path);
 
   /* init la_Info */
   la_init (log_path, max_mem_size);

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -8006,39 +8006,45 @@ la_destroy_repl_filter (void)
 static int
 check_reinit_copylog (void)
 {
-	if (la_fetch_log_hdr(&la_Info.act_log) != NO_ERROR)
-		return ER_FAILED;
+  if (la_fetch_log_hdr (&la_Info.act_log) != NO_ERROR)
+    return ER_FAILED;
 
-	if (la_Info.act_log.log_hdr->mark_will_del)
-	{
-		la_Info.reinit_copylog = true;
-		return ER_FAILED;
-	}
+  if (la_Info.act_log.log_hdr->mark_will_del)
+    {
+      la_Info.reinit_copylog = true;
+      return ER_FAILED;
+    }
 
-	return NO_ERROR;
+  return NO_ERROR;
 }
 
-static inline void la_extract_db_name(char *dest, const char *src){
-	char *at;
+static inline void
+la_extract_db_name (char *dest, const char *src)
+{
+  char *at;
 
-	strncpy(dest, src, DB_MAX_IDENTIFIER_LENGTH);
-	at = strchr(dest, '@');
-	if (at)
-		*at = '\0';
+  strncpy (dest, src, DB_MAX_IDENTIFIER_LENGTH);
+  at = strchr (dest, '@');
+  if (at)
+    *at = '\0';
 }
 
-static inline void la_extract_peer_host(char *dest, const char *log_path){
-	const char *host = la_get_hostname_from_log_path ((char *) log_path);
-	
-	if (host)
-		strncpy (la_peer_host, host, CUB_MAXHOSTNAMELEN);
-	else
-		strncpy(la_peer_host, "unknown", CUB_MAXHOSTNAMELEN);
+static inline void
+la_extract_peer_host (char *dest, const char *log_path)
+{
+  const char *host = la_get_hostname_from_log_path ((char *) log_path);
+
+  if (host)
+    strncpy (la_peer_host, host, CUB_MAXHOSTNAMELEN);
+  else
+    strncpy (la_peer_host, "unknown", CUB_MAXHOSTNAMELEN);
 }
 
-static inline void init_delay_hist(int *delay_hist){
-	for (int i = 0; i < LA_NUM_DELAY_HISTORY; i++)
-		delay_hist[i] = -1;
+static inline void
+init_delay_hist (int *delay_hist)
+{
+  for (int i = 0; i < LA_NUM_DELAY_HISTORY; i++)
+    delay_hist[i] = -1;
 }
 
 /*
@@ -8095,8 +8101,8 @@ la_apply_log_file (const char *database_name, const char *log_path, const int ma
   (void) os_set_signal_handler (SIGPIPE, SIG_IGN);
 #endif /* ! WINDOWS */
 
-  la_extract_db_name(la_slave_db_name, database_name);
-  la_extract_peer_host(la_peer_host, log_path);
+  la_extract_db_name (la_slave_db_name, database_name);
+  la_extract_peer_host (la_peer_host, log_path);
 
   /* init la_Info */
   la_init (log_path, max_mem_size);
@@ -8176,8 +8182,8 @@ la_apply_log_file (const char *database_name, const char *log_path, const int ma
       return error;
     }
 
-  init_delay_hist(delay_hist);
-  
+  init_delay_hist (delay_hist);
+
   time_commit_interval = prm_get_integer_value (PRM_ID_HA_APPLYLOGDB_MAX_COMMIT_INTERVAL_IN_MSECS);
 
   if (prm_get_integer_value (PRM_ID_HA_REPL_FILTER_TYPE) != REPL_FILTER_NONE)

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -8027,32 +8027,38 @@ check_reinit_copylog (void)
 }
 
 static inline void
-la_extract_db_name (char *dest, const char *src)
+set_la_slave_db_name (const char *database_name)
 {
-  char *at;
+  const char *at = strchr (database_name, '@');
+  size_t len;
 
-  strncpy (dest, src, DB_MAX_IDENTIFIER_LENGTH);
-  at = strchr (dest, '@');
-  if (at)
-    *at = '\0';
+  if (at != NULL)
+    {
+      len = at - database_name;
+    }
+  else
+    {
+      len = DB_MAX_IDENTIFIER_LENGTH;
+    }
+
+  snprintf (la_slave_db_name, DB_MAX_IDENTIFIER_LENGTH, "%.*s", (int) len, database_name);
 }
 
 static inline void
-la_extract_peer_host (char *dest, const char *log_path)
+set_la_peer_host (const char *log_path)
 {
   const char *host = la_get_hostname_from_log_path ((char *) log_path);
 
-  if (host)
-    strncpy (la_peer_host, host, CUB_MAXHOSTNAMELEN);
-  else
-    strncpy (la_peer_host, "unknown", CUB_MAXHOSTNAMELEN);
+  snprintf (la_peer_host, CUB_MAXHOSTNAMELEN, "%s", host ? host : "unknown");
 }
 
 static inline void
-init_delay_hist (int *delay_hist)
+init_delay_history (int *delay_history)
 {
   for (int i = 0; i < LA_NUM_DELAY_HISTORY; i++)
-    delay_hist[i] = -1;
+    {
+      delay_history[i] = -1;
+    }
 }
 
 /*
@@ -8109,8 +8115,8 @@ la_apply_log_file (const char *database_name, const char *log_path, const int ma
   (void) os_set_signal_handler (SIGPIPE, SIG_IGN);
 #endif /* ! WINDOWS */
 
-  la_extract_db_name (la_slave_db_name, database_name);
-  la_extract_peer_host (la_peer_host, log_path);
+  set_la_slave_db_name (database_name);
+  set_la_peer_host (log_path);
 
   /* init la_Info */
   la_init (log_path, max_mem_size);
@@ -8190,7 +8196,7 @@ la_apply_log_file (const char *database_name, const char *log_path, const int ma
       return error;
     }
 
-  init_delay_hist (delay_hist);
+  init_delay_history (delay_hist);
 
   time_commit_interval = prm_get_integer_value (PRM_ID_HA_APPLYLOGDB_MAX_COMMIT_INTERVAL_IN_MSECS);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26060

### Purpose
다음 목적으로 리팩토링을 진행하였습니다.
* 명확한 단일 기능을 갖는 코드를 함수로 분리
* 임시적으로 사용되는 변수를 삭제

### Implementation
새 함수 추가
*  la_extract_db_name()
* init_delay_hist()
* la_extract_peer_host() 

임시적으로 사용되는 변수 삭제
la_apply_log_file() 내의 char *s 와 int i 가 제거되었습니다.
함수 내에 변수가 너무 많고, 초기에 한번만 사용되는 함수들이라 
코드를 읽는 과정에서 불필요한 정보를 준다고 생각합니다

### Remarks
