### PR TITLE
[CBRD-26061] github action의 cppcheck 시, #error directive 무시

### DIFF
--- a/.github/workflows/cppcheck-spr-list
+++ b/.github/workflows/cppcheck-spr-list
@@ -2,3 +2,4 @@ syntaxError
 objectIndex
 unknownMacro
 internalAstError
+preprocessorErrorDirective


### PR DESCRIPTION
[http://jira.cubrid.org/browse/CBRD-26061](http://jira.cubrid.org/browse/CBRD-26061)

### Purpose

현재 코드를 github에 push 하면 변경된 파일만 `cppcheck` 프로그램을 사용하여 코드 정적 분석을 하고 있습니다.
만약 그 파일 안에 아래와 같이 `#error` directive가 있다면, 현재 사용 중인 2.13.0 버전의 `cppcheck`는 `SERVER_MODE`가 정의되지 않았더라도 하위 블럭을 검사합니다.
```c
#if defined (SERVER_MODE)
#error this is error
#endif
```
따라서 아래와 같이 `SERVER_MODE`가 명시되지 않았음에도 `cppcheck`에서는 `#if defined (SERVER_MODE)`의 하위 블럭을 읽으려고 시도합니다.

```sh
// cppcheck --verbose
Checking src/object/authenticate.h ... 
Defines: 
Undefines: 
Includes: 
Platform:native
 
src/object/authenticate.h:31:2: error: #error Does not belong to server module [preprocessorErrorDirective] #error Does not belong to server module
```
`cppcheck`는 단지 코드의 정적 분석을 위한 것임으로, CUBRID에서 빌드 방지 용도로 사용하고 있는 `#error` directive는 무시되어야 합니다.


### Implementation

`.github/workflows/cppcheck-spr-list` 에 preprocessorErrorDirective 추가

```sh
// 기존
syntaxError
objectIndex
unknownMacro
internalAstError
// 추가
preprocessorErrorDirective
```