### PR TITLE
[CUBVEC-73] Accept M, ef_construction, metric when CREATE VECTOR INDEX

### DIFF
--- a/cs/CMakeLists.txt
+++ b/cs/CMakeLists.txt
@@ -226,6 +226,7 @@ set(PARSER_SOURCES
   ${PARSER_DIR}/xasl_regu_alloc.cpp
   ${PARSER_DIR}/xasl_generation.c
   ${PARSER_DIR}/func_type.cpp
+  ${PARSER_DIR}/parser_kv_pair.c
   )
 set(PARSER_HEADERS
   ${PARSER_DIR}/func_type.hpp

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -236,6 +236,7 @@ set(PARSER_SOURCES
   ${PARSER_DIR}/view_transform.c
   ${PARSER_DIR}/xasl_regu_alloc.cpp
   ${PARSER_DIR}/xasl_generation.c
+  ${PARSER_DIR}/parser_kv_pair.c
   )
 set(PARSER_HEADERS
   ${PARSER_DIR}/func_type.hpp

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -7718,7 +7718,6 @@ mr_data_readmem_vector_float (OR_BUF * buf, void *memptr, TP_DOMAIN * domain, in
 static void
 mr_freemem_vector_float (void *memptr)
 {
-  vimkim_log ("freeing %p\n", mem);
 
   // TODO (CUBVEC): The following code causes segfault when shutting down the CAS.
   // We need to figure out why.

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -100,6 +100,13 @@
          support CREATE SCHEMA, SET SCHEMA, and associated statements.
  */
 
+namespace hnsw
+{
+  extern int m;
+  extern int ef_construction;
+  extern enum DB_VECTOR_DISTANCE_METRIC metric;
+};
+
 typedef struct schema_def
 {
 
@@ -10823,6 +10830,17 @@ allocate_index (MOP classop, SM_CLASS * class_, DB_OBJLIST * subclasses, SM_CLAS
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 1, error_msg.c_str ());
 	      return error;
 	    }
+
+#if !defined(NDEBUG)
+	  {
+	    auto m = hnsw::m;
+	    auto ef_construction = hnsw::ef_construction;
+	    auto metric = hnsw::metric;
+
+	    vimkim_log ("m, ef_construction, metric: %d, %d, %d\n", m, ef_construction, metric);
+	  }
+#endif
+
 	  error = hnsw_add_index (index, domain->precision, 32, 100, faiss::METRIC_L2);
 	}
       else
@@ -14807,6 +14825,7 @@ sm_add_constraint (MOP classop, DB_CONSTRAINT_TYPE constraint_type, const char *
     case DB_CONSTRAINT_REVERSE_UNIQUE:
     case DB_CONSTRAINT_PRIMARY_KEY:
     case DB_CONSTRAINT_VECTOR_INDEX:
+
       DB_AUTH auth;
       bool is_secondary_index;
 

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -10831,17 +10831,35 @@ allocate_index (MOP classop, SM_CLASS * class_, DB_OBJLIST * subclasses, SM_CLAS
 	      return error;
 	    }
 
-#if !defined(NDEBUG)
-	  {
-	    auto m = hnsw::m;
-	    auto ef_construction = hnsw::ef_construction;
-	    auto metric = hnsw::metric;
+	  auto m = hnsw::m;
+	  auto ef_construction = hnsw::ef_construction;
+	  auto metric = hnsw::metric;
 
-	    vimkim_log ("m, ef_construction, metric: %d, %d, %d\n", m, ef_construction, metric);
-	  }
-#endif
+	  vimkim_log ("m, ef_construction, metric: %d, %d, %d\n", m, ef_construction, metric);
 
-	  error = hnsw_add_index (index, domain->precision, 32, 100, faiss::METRIC_L2);
+	  faiss::MetricType faiss_metric;
+	  switch (metric)
+	    {
+	    case METRIC_UNKNOWN:
+	    case METRIC_COSINE:
+	    case METRIC_DOT:
+	      // TODO (CUBVEC): Faiss does not support cosine distance directly?
+	      faiss_metric = faiss::METRIC_INNER_PRODUCT;
+	      break;
+
+	    case METRIC_EUCLIDEAN:
+	      faiss_metric = faiss::METRIC_L2;
+	      break;
+
+	    case METRIC_MANHATTAN:
+	      faiss_metric = faiss::METRIC_L1;
+	      break;
+
+	    default:
+	      ASSERT_CUBVEC (false);
+	    }
+
+	  error = hnsw_add_index (index, domain->precision, m, ef_construction, faiss_metric);
 	}
       else
 	{

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -77,6 +77,7 @@
 #include "db.h"
 #include "object_accessor.h"
 #include "boot_cl.h"
+#include "parse_tree.h"
 #include "faiss/IndexHNSW.h"
 
 #if defined (SUPPRESS_STRLEN_WARNING)
@@ -102,9 +103,7 @@
 
 namespace hnsw
 {
-  extern int m;
-  extern int ef_construction;
-  extern enum DB_VECTOR_DISTANCE_METRIC metric;
+  extern PT_VECTOR_INDEX_INFO vindex_info;
 };
 
 typedef struct schema_def
@@ -10831,9 +10830,9 @@ allocate_index (MOP classop, SM_CLASS * class_, DB_OBJLIST * subclasses, SM_CLAS
 	      return error;
 	    }
 
-	  auto m = hnsw::m;
-	  auto ef_construction = hnsw::ef_construction;
-	  auto metric = hnsw::metric;
+	  auto m = hnsw::vindex_info.hnsw_m;
+	  auto ef_construction = hnsw::vindex_info.hnsw_ef_construction;
+	  auto metric = hnsw::vindex_info.metric;
 
 	  vimkim_log ("m, ef_construction, metric: %d, %d, %d\n", m, ef_construction, metric);
 

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -2837,13 +2837,16 @@ create_stmt
 			if (kvp) 
 			  {
 			    PT_NODE *m_node = kv_pair_lookup(kvp, "m");
-
-			    int m = m_node ? m_node->info.value.data_value.i : 30;
-
-			    node->info.index.vector_index.hnsw_m = m;
 			    PT_NODE *ef_construction_node = kv_pair_lookup(kvp, "ef_construction");
 
-			    int ef_con = ef_construction_node ? ef_construction_node->info.value.data_value.i : 100;
+			    // TODO (CUBVEC): default m and ef_con?
+			    int default_m = 30;
+			    int default_ef_con = 100;
+
+			    int m = m_node ? m_node->info.value.data_value.i : default_m;
+			    int ef_con = ef_construction_node ? ef_construction_node->info.value.data_value.i : default_ef_con;
+
+			    node->info.index.vector_index.hnsw_m = m;
 			    node->info.index.vector_index.hnsw_ef_construction = ef_con;
 			  }
 
@@ -2974,10 +2977,6 @@ create_stmt
                             // original code: 
 			    // node->info.index.deduplicate_level = CONTAINER_AT_1($13);
                             node->info.index.deduplicate_level = CONTAINER_AT_1(rule_13);
-
-			    // TODO: CUBVEC - $13 contains parameter infos such as m and ef_construction
-			    // TODO: node->info.index.hnsw.m = 30;
-			    // TODO: node->info.index.hnsw.ef_con = 100;
 
                              if (opt_unique && (node->info.index.deduplicate_level >= DEDUPLICATE_KEY_LEVEL_OFF && node->info.index.deduplicate_level <= DEDUPLICATE_KEY_LEVEL_MAX))
                               {
@@ -22921,8 +22920,6 @@ opt_index_with_clause
 opt_vector_index_with_clause
         : /* empty */
           { DBG_TRACE_GRAMMAR(opt_index_with_clause, : );
-            container_2 ctn;
-            // SET_CONTAINER_2(ctn, 0, DEDUPLICATE_OPTION_AUTO);
 	    $$ = NULL;
 	  DBG_PRINT}
         | WITH '(' vector_index_with_item_list ')'

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -25,7 +25,7 @@
 %{/*%CODE_REQUIRES_START%*/
 #include "json_table_def.h"
 #include "parser.h"
-#include "parse_vector.h"
+#include "parser_kv_pair.h"
 
 /*
  * The default YYLTYPE structure is extended so that locations can hold

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -685,7 +685,7 @@ static int g_plcsql_text_pos;
 %type <node> drop_stmt
 %type <node> opt_index_column_name_list
 %type <node> index_column_name_list
-%type <node> vector_index_column_with_metric
+%type <c2> vector_index_column_with_metric
 %type <node> update_statistics_stmt
 %type <node> only_class_name_list
 %type <node> opt_level_spec
@@ -2885,7 +2885,13 @@ create_stmt
 				node->info.index.index_name->info.name.meta_class = PT_INDEX_NAME;
 			      }
 
-			    col = $11;
+			    col = CONTAINER_AT_0 ($11);
+			    PT_NODE *metric_node = CONTAINER_AT_1 ($11);
+
+			    const char* metric_name = metric_node->info.name.original;
+			    enum DB_VECTOR_DISTANCE_METRIC metric = string_to_vector_distance_metric (metric_name);
+			    node->info.index.vector_index.metric = metric;
+
 			    if (node->info.index.unique)
 			      {
 			        for (temp = col; temp != NULL; temp = temp->next)
@@ -5258,7 +5264,9 @@ index_column_name_list
 vector_index_column_with_metric
 	: '(' sort_spec identifier ')'
 	    {{
-	       $$ = $2;
+	       container_2 cnt2;
+	       SET_CONTAINER_2(cnt2, $2, $3);
+	       $$ = cnt2;
 	    }}
 	// TODO: : '(' sort_spec vector_distance_metric ')'
 

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -25,6 +25,7 @@
 %{/*%CODE_REQUIRES_START%*/
 #include "json_table_def.h"
 #include "parser.h"
+#include "parse_vector.h"
 
 /*
  * The default YYLTYPE structure is extended so that locations can hold
@@ -573,6 +574,7 @@ static int g_plcsql_text_pos;
   container_10 c10;
   container_11 c11;
   struct json_table_column_behavior jtcb;
+  kv_pair *kvp;
 }
 
 
@@ -1107,10 +1109,10 @@ static int g_plcsql_text_pos;
 %type <c2> opt_create_synonym
 %type <c2> class_name_with_server_name
 %type <c2> opt_index_with_clause
-%type <c2> opt_vector_index_with_clause
+%type <kvp> opt_vector_index_with_clause
 %type <c2> index_with_item_list
-%type <c2> vector_index_with_item_list
-%type <c2> vector_index_with_item
+%type <kvp> vector_index_with_item_list
+%type <kvp> vector_index_with_item
 %type <c2> opt_vector_args
 %type <c2> opt_authid_and_deterministic
 
@@ -2828,10 +2830,22 @@ create_stmt
 
 			assert(node != NULL);
 
-			/* Initialize vector_index_info (now an embedded structure) */
+
 			node->info.index.is_vector_index = true;
-			node->info.index.vector_index.hnsw_m = 16;                /* Example default value */
-			node->info.index.vector_index.hnsw_ef_construction = 200; /* Example default value */
+
+			kv_pair *kvp = $13; // opt_vector_index_with_clause
+			if (kvp) 
+			  {
+			    PT_NODE *m_node = kv_pair_lookup(kvp, "m");
+
+			    int m = m_node ? m_node->info.value.data_value.i : 30;
+
+			    node->info.index.vector_index.hnsw_m = m;
+			    PT_NODE *ef_construction_node = kv_pair_lookup(kvp, "ef_construction");
+
+			    int ef_con = ef_construction_node ? ef_construction_node->info.value.data_value.i : 100;
+			    node->info.index.vector_index.hnsw_ef_construction = ef_con;
+			  }
 
 			bool opt_unique = false; // original $5
 
@@ -22909,9 +22923,10 @@ opt_vector_index_with_clause
           { DBG_TRACE_GRAMMAR(opt_index_with_clause, : );
             container_2 ctn;
             // SET_CONTAINER_2(ctn, 0, DEDUPLICATE_OPTION_AUTO);
-            $$ = ctn; }
+	    $$ = NULL;
+	  DBG_PRINT}
         | WITH '(' vector_index_with_item_list ')'
-          {  DBG_TRACE_GRAMMAR(opt_index_with_clause, | WITH index_with_item_list );
+          {  DBG_TRACE_GRAMMAR(opt_index_with_clause, | WITH '(' vector_index_with_item_list ')' );
              $$ = $3;
           DBG_PRINT}
         ;
@@ -22919,31 +22934,20 @@ opt_vector_index_with_clause
 vector_index_with_item_list
 	: vector_index_with_item
 	  {
-	    DBG_TRACE_GRAMMAR(vector_index_with_item_list, vector_index_with_item);
-	    container_2 ctn;
-	    // init_container_2(&ctn);
-	    // add_to_container_2(&ctn, $1);
-	    $$ = ctn;
+	    $$ = $1;
 	  }
 	| vector_index_with_item_list ',' vector_index_with_item
 	  {
 	    DBG_TRACE_GRAMMAR(vector_index_with_item_list, vector_index_with_item_list ',' vector_index_with_item);
-	    // add_to_container_2(&($1), $3);
-	    // $$ = $1;
-	    container_2 cnt2;
-	    $$ = (container_2)cnt2;
+	    $$ = kv_pair_push_back($1, $3);
 	  }
 	;
 
 vector_index_with_item
 	: identifier '=' unsigned_integer
 	  {
-	    DBG_TRACE_GRAMMAR(vector_index_with_item, IDENTIFIER '=' NUMBER);
-	    // Create a structure to hold the option and its value
-	    // option_item *opt = create_option_item($1, $3);
-	    //$$ = opt;
-	    container_2 cnt2;
-	    $$ = (container_2)cnt2;
+	    DBG_TRACE_GRAMMAR(vector_index_with_item, identifier '=' number);
+	    $$ = kv_pair_make($1, $3);
 	  }
 	;
 

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -2840,8 +2840,8 @@ create_stmt
 			    PT_NODE *ef_construction_node = kv_pair_lookup(kvp, "ef_construction");
 
 			    // TODO (CUBVEC): default m and ef_con?
-			    int default_m = 30;
-			    int default_ef_con = 100;
+			    int default_m = 16;
+			    int default_ef_con = 64;
 
 			    int m = m_node ? m_node->info.value.data_value.i : default_m;
 			    int ef_con = ef_construction_node ? ef_construction_node->info.value.data_value.i : default_ef_con;

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -685,7 +685,6 @@ static int g_plcsql_text_pos;
 %type <node> drop_stmt
 %type <node> opt_index_column_name_list
 %type <node> index_column_name_list
-%type <c2> vector_index_column_with_metric
 %type <node> update_statistics_stmt
 %type <node> only_class_name_list
 %type <node> opt_level_spec
@@ -1109,12 +1108,13 @@ static int g_plcsql_text_pos;
 %type <c2> opt_create_synonym
 %type <c2> class_name_with_server_name
 %type <c2> opt_index_with_clause
-%type <kvp> opt_vector_index_with_clause
 %type <c2> index_with_item_list
-%type <kvp> vector_index_with_item_list
-%type <kvp> vector_index_with_item
 %type <c2> opt_vector_args
 %type <c2> opt_authid_and_deterministic
+%type <c2> vector_index_column_with_metric
+%type <kvp> opt_vector_index_with_clause
+%type <kvp> vector_index_with_item_list
+%type <kvp> vector_index_with_item
 
 /*}}}*/
 

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -43,6 +43,8 @@
 #include "system_parameter.h"
 #include "hide_password.h"
 
+#include "vector_distance_enum.h"
+
 // forward definitions
 struct json_t;
 
@@ -2155,6 +2157,7 @@ typedef struct pt_vector_index_info
 {
   int hnsw_m;
   int hnsw_ef_construction;
+  enum DB_VECTOR_DISTANCE_METRIC metric;
 } PT_VECTOR_INDEX_INFO;
 
 /* CREATE/DROP INDEX INFO */

--- a/src/parser/parse_vector.h
+++ b/src/parser/parse_vector.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+
+/*
+ * parse_vector.h
+ */
+
+#ifndef _PARSE_VECTOR_H_
+#define _PARSE_VECTOR_H_
+
+#ident "$Id$"
+
+#include "parse_tree.h"
+
+typedef struct kv_pair
+{
+  PT_NODE *key;
+  PT_NODE *value;
+  struct kv_pair *next;
+} kv_pair;
+
+/* Helper – make one pair */
+static kv_pair *
+kv_pair_make (PT_NODE * k, PT_NODE * v)
+{
+  kv_pair *p = (kv_pair *) malloc (sizeof (kv_pair));
+  if (!p)
+    {
+      perror ("malloc");
+      exit (EXIT_FAILURE);
+    }
+  p->key = k;
+  p->value = v;
+  p->next = NULL;
+  return p;
+}
+
+static kv_pair *
+kv_pair_push_back (kv_pair * list, kv_pair * item)
+{
+  if (!list)
+    return item;
+  kv_pair *cur = list;
+  while (cur->next)
+    cur = cur->next;
+  cur->next = item;
+  return list;
+}
+
+static kv_pair *
+kv_pair_push_front (kv_pair * list, kv_pair * item)
+{
+  if (!item)
+    return list;
+  item->next = list;
+  return item;
+}
+
+static int
+kv_pair_count (const kv_pair * list)
+{
+  int n = 0;
+  while (list)
+    {
+      ++n;
+      list = list->next;
+    }
+  return n;
+}
+
+static PT_NODE *
+kv_pair_lookup (const kv_pair * list, const char *key_name)
+{
+  for (const kv_pair * cur = list; cur; cur = cur->next)
+    {
+
+      PT_NODE *key = cur->key;
+      printf ("%s\n", cur->key->info.name.original);
+
+      if (cur->key && cur->key->node_type == PT_NAME && strcasecmp (cur->key->info.name.original, key_name) == 0)
+	{
+	  printf ("found %s\n", cur->key->info.name.original);
+	  return cur->value;
+	}
+    }
+  return NULL;
+}
+
+#endif /* _PARSE_VECTOR_H_ */

--- a/src/parser/parser_kv_pair.c
+++ b/src/parser/parser_kv_pair.c
@@ -1,3 +1,26 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+
+/*
+ * parser_kv_pair.c
+ */
+
 #include "parser_kv_pair.h"
 
 /* Helper – make one pair */

--- a/src/parser/parser_kv_pair.c
+++ b/src/parser/parser_kv_pair.c
@@ -1,0 +1,66 @@
+#include "parser_kv_pair.h"
+
+/* Helper – make one pair */
+kv_pair *
+kv_pair_make (PT_NODE * k, PT_NODE * v)
+{
+  kv_pair *p = (kv_pair *) malloc (sizeof (kv_pair));
+  if (!p)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (PT_NODE));
+      return NULL;
+    }
+  p->key = k;
+  p->value = v;
+  p->next = NULL;
+  return p;
+}
+
+kv_pair *
+kv_pair_push_back (kv_pair * list, kv_pair * item)
+{
+  if (!list)
+    return item;
+  kv_pair *cur = list;
+  while (cur->next)
+    cur = cur->next;
+  cur->next = item;
+  return list;
+}
+
+kv_pair *
+kv_pair_push_front (kv_pair * list, kv_pair * item)
+{
+  if (!item)
+    return list;
+  item->next = list;
+  return item;
+}
+
+int
+kv_pair_count (const kv_pair * list)
+{
+  int n = 0;
+  while (list)
+    {
+      ++n;
+      list = list->next;
+    }
+  return n;
+}
+
+PT_NODE *
+kv_pair_lookup (const kv_pair * list, const char *key_name)
+{
+  for (const kv_pair * cur = list; cur; cur = cur->next)
+    {
+
+      PT_NODE *key = cur->key;
+
+      if (cur->key && cur->key->node_type == PT_NAME && strcasecmp (cur->key->info.name.original, key_name) == 0)
+	{
+	  return cur->value;
+	}
+    }
+  return NULL;
+}

--- a/src/parser/parser_kv_pair.h
+++ b/src/parser/parser_kv_pair.h
@@ -18,13 +18,11 @@
 
 
 /*
- * parse_vector.h
+ * parser_kv_pair.h
  */
 
-#ifndef _PARSE_VECTOR_H_
-#define _PARSE_VECTOR_H_
-
-#ident "$Id$"
+#ifndef _PARSER_KV_PAIR_H_
+#define _PARSER_KV_PAIR_H_
 
 #include "parse_tree.h"
 
@@ -91,15 +89,14 @@ kv_pair_lookup (const kv_pair * list, const char *key_name)
     {
 
       PT_NODE *key = cur->key;
-      printf ("%s\n", cur->key->info.name.original);
 
       if (cur->key && cur->key->node_type == PT_NAME && strcasecmp (cur->key->info.name.original, key_name) == 0)
 	{
-	  printf ("found %s\n", cur->key->info.name.original);
 	  return cur->value;
 	}
     }
   return NULL;
 }
 
-#endif /* _PARSE_VECTOR_H_ */
+#endif /* _PARSER_KV_PAIR_H_ */
+

--- a/src/parser/parser_kv_pair.h
+++ b/src/parser/parser_kv_pair.h
@@ -33,69 +33,14 @@ typedef struct kv_pair
   struct kv_pair *next;
 } kv_pair;
 
-/* Helper – make one pair */
-static kv_pair *
-kv_pair_make (PT_NODE * k, PT_NODE * v)
-{
-  kv_pair *p = (kv_pair *) malloc (sizeof (kv_pair));
-  if (!p)
-    {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (PT_NODE));
-      return NULL;
-    }
-  p->key = k;
-  p->value = v;
-  p->next = NULL;
-  return p;
-}
+kv_pair *kv_pair_make (PT_NODE * k, PT_NODE * v);
 
-static kv_pair *
-kv_pair_push_back (kv_pair * list, kv_pair * item)
-{
-  if (!list)
-    return item;
-  kv_pair *cur = list;
-  while (cur->next)
-    cur = cur->next;
-  cur->next = item;
-  return list;
-}
+kv_pair *kv_pair_push_back (kv_pair * list, kv_pair * item);
 
-static kv_pair *
-kv_pair_push_front (kv_pair * list, kv_pair * item)
-{
-  if (!item)
-    return list;
-  item->next = list;
-  return item;
-}
+kv_pair *kv_pair_push_front (kv_pair * list, kv_pair * item);
 
-static int
-kv_pair_count (const kv_pair * list)
-{
-  int n = 0;
-  while (list)
-    {
-      ++n;
-      list = list->next;
-    }
-  return n;
-}
+int kv_pair_count (const kv_pair * list);
 
-static PT_NODE *
-kv_pair_lookup (const kv_pair * list, const char *key_name)
-{
-  for (const kv_pair * cur = list; cur; cur = cur->next)
-    {
-
-      PT_NODE *key = cur->key;
-
-      if (cur->key && cur->key->node_type == PT_NAME && strcasecmp (cur->key->info.name.original, key_name) == 0)
-	{
-	  return cur->value;
-	}
-    }
-  return NULL;
-}
+PT_NODE *kv_pair_lookup (const kv_pair * list, const char *key_name);
 
 #endif /* _PARSER_KV_PAIR_H_ */

--- a/src/parser/parser_kv_pair.h
+++ b/src/parser/parser_kv_pair.h
@@ -40,8 +40,8 @@ kv_pair_make (PT_NODE * k, PT_NODE * v)
   kv_pair *p = (kv_pair *) malloc (sizeof (kv_pair));
   if (!p)
     {
-      perror ("malloc");
-      exit (EXIT_FAILURE);
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (PT_NODE));
+      return NULL;
     }
   p->key = k;
   p->value = v;
@@ -99,4 +99,3 @@ kv_pair_lookup (const kv_pair * list, const char *key_name)
 }
 
 #endif /* _PARSER_KV_PAIR_H_ */
-

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -61,6 +61,7 @@
 #include "dbtype.h"
 #include "jsp_cl.h"
 #include "msgcat_glossary.hpp"
+#include "parse_tree.h"
 
 #if defined (SUPPRESS_STRLEN_WARNING)
 #define strlen(s1)  ((int) strlen(s1))
@@ -90,9 +91,7 @@
 
 namespace hnsw
 {
-  int m;
-  int ef_construction;
-  enum DB_VECTOR_DISTANCE_METRIC metric;
+  PT_VECTOR_INDEX_INFO vindex_info;
 };
 
 typedef enum
@@ -3245,10 +3244,9 @@ do_create_vector_index (PARSER_CONTEXT * parser, const PT_NODE * statement)
 
   // TODO (CUBVEC): pass these values to create_vector_index
   // TODO (CUBVEC): temporarily use global variables for quick prototype.
-  hnsw::m = statement->info.index.vector_index.hnsw_m;
-  hnsw::ef_construction = statement->info.index.vector_index.hnsw_ef_construction;
-  hnsw::metric = statement->info.index.vector_index.metric;
-  vimkim_log ("m, efcon, metric: %d, %d, %d\n", hnsw::m, hnsw::ef_construction, hnsw::metric);
+  hnsw::vindex_info.hnsw_m = statement->info.index.vector_index.hnsw_m;
+  hnsw::vindex_info.hnsw_ef_construction = statement->info.index.vector_index.hnsw_ef_construction;
+  hnsw::vindex_info.metric = statement->info.index.vector_index.metric;
 
   error = create_or_drop_index_helper (parser, index_name, statement->info.index.reverse, statement->info.index.unique,
 				       &statement->info.index, obj, DO_VECTOR_INDEX_CREATE);

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -88,6 +88,13 @@
 #define MAX_FILTER_PREDICATE_STRING_LENGTH (1073741823)
 #define MAX_FUNCTION_EXPRESSION_STRING_LENGTH 1024
 
+namespace hnsw
+{
+  int m;
+  int ef_construction;
+  enum DB_VECTOR_DISTANCE_METRIC metric;
+};
+
 typedef enum
 {
   DO_INDEX_CREATE, DO_INDEX_DROP, DO_VECTOR_INDEX_CREATE
@@ -3237,10 +3244,11 @@ do_create_vector_index (PARSER_CONTEXT * parser, const PT_NODE * statement)
   index_name = statement->info.index.index_name ? statement->info.index.index_name->info.name.original : NULL;
 
   // TODO (CUBVEC): pass these values to create_vector_index
-  // auto m = statement->info.index.vector_index.hnsw_m;
-  // auto efcon = statement->info.index.vector_index.hnsw_ef_construction;
-  // auto metric = statement->info.index.vector_index.metric;
-  // printf("m, efcon, metric: %d, %d, %d\n", m, efcon, metric);
+  // TODO (CUBVEC): temporarily use global variables for quick prototype.
+  hnsw::m = statement->info.index.vector_index.hnsw_m;
+  hnsw::ef_construction = statement->info.index.vector_index.hnsw_ef_construction;
+  hnsw::metric = statement->info.index.vector_index.metric;
+  vimkim_log ("m, efcon, metric: %d, %d, %d\n", hnsw::m, hnsw::ef_construction, hnsw::metric);
 
   error = create_or_drop_index_helper (parser, index_name, statement->info.index.reverse, statement->info.index.unique,
 				       &statement->info.index, obj, DO_VECTOR_INDEX_CREATE);

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -3236,6 +3236,12 @@ do_create_vector_index (PARSER_CONTEXT * parser, const PT_NODE * statement)
 
   index_name = statement->info.index.index_name ? statement->info.index.index_name->info.name.original : NULL;
 
+  // TODO (CUBVEC): pass these values to create_vector_index
+  // auto m = statement->info.index.vector_index.hnsw_m;
+  // auto efcon = statement->info.index.vector_index.hnsw_ef_construction;
+  // auto metric = statement->info.index.vector_index.metric;
+  // printf("m, efcon, metric: %d, %d, %d\n", m, efcon, metric);
+
   error = create_or_drop_index_helper (parser, index_name, statement->info.index.reverse, statement->info.index.unique,
 				       &statement->info.index, obj, DO_VECTOR_INDEX_CREATE);
   return error;

--- a/src/query/vector_distance_enum.h
+++ b/src/query/vector_distance_enum.h
@@ -23,8 +23,11 @@
 #ifndef _VECTOR_DISTANCE_ENUM_H_
 #define _VECTOR_DISTANCE_ENUM_H_
 
+#include <string.h>
+
 enum DB_VECTOR_DISTANCE_METRIC
 {
+  METRIC_UNKNOWN = 0,
   METRIC_COSINE = 1,
   METRIC_DOT = 2,
   METRIC_EUCLIDEAN = 3,
@@ -33,5 +36,34 @@ enum DB_VECTOR_DISTANCE_METRIC
   METRIC_MANHATTAN = 6,
   // METRIC_JACCARD = 7
 };
+
+typedef struct
+{
+  const char *name;
+  enum DB_VECTOR_DISTANCE_METRIC metric;
+} metric_entry;
+
+static const metric_entry metric_table[] = {
+  { "cosine", METRIC_COSINE },
+  { "dot", METRIC_DOT },
+  { "euclidean", METRIC_EUCLIDEAN },
+  { "manhattan", METRIC_MANHATTAN },
+  { NULL, METRIC_UNKNOWN } // sentinel
+};
+
+static enum DB_VECTOR_DISTANCE_METRIC
+string_to_distance_metric (const char *name)
+{
+  if (name == NULL)
+    return METRIC_UNKNOWN;
+
+  for (int i = 0; metric_table[i].name != NULL; ++i)
+    {
+      if (strcasecmp(name, metric_table[i].name) == 0)
+        return metric_table[i].metric;
+    }
+
+  return METRIC_UNKNOWN;
+}
 
 #endif // _VECOTR_DISTANCE_ENUM_H_

--- a/src/query/vector_distance_enum.h
+++ b/src/query/vector_distance_enum.h
@@ -44,23 +44,23 @@ typedef struct
 } metric_entry;
 
 static const metric_entry metric_table[] = {
-  { "cosine", METRIC_COSINE },
-  { "dot", METRIC_DOT },
-  { "euclidean", METRIC_EUCLIDEAN },
-  { "manhattan", METRIC_MANHATTAN },
-  { NULL, METRIC_UNKNOWN } // sentinel
+  {"cosine", METRIC_COSINE},
+  {"dot", METRIC_DOT},
+  {"euclidean", METRIC_EUCLIDEAN},
+  {"manhattan", METRIC_MANHATTAN},
+  {NULL, METRIC_UNKNOWN}	// sentinel
 };
 
 static enum DB_VECTOR_DISTANCE_METRIC
-string_to_distance_metric (const char *name)
+string_to_vector_distance_metric (const char *name)
 {
   if (name == NULL)
     return METRIC_UNKNOWN;
 
   for (int i = 0; metric_table[i].name != NULL; ++i)
     {
-      if (strcasecmp(name, metric_table[i].name) == 0)
-        return metric_table[i].metric;
+      if (strcasecmp (name, metric_table[i].name) == 0)
+	return metric_table[i].metric;
     }
 
   return METRIC_UNKNOWN;

--- a/src/storage/hnsw.cpp
+++ b/src/storage/hnsw.cpp
@@ -42,7 +42,7 @@ static OID decode_oid (faiss::idx_t encoded_oid);
 static std::mutex hnsw_elem_mutex;
 
 BTID *
-xhnsw_add_index (THREAD_ENTRY *thread_p, BTID *btid, int dimension = 10, int hnsw_M = 128, int hnsw_efConstruction = 40,
+xhnsw_add_index (THREAD_ENTRY *thread_p, BTID *btid, int dimension = 10, int hnsw_M = 16, int hnsw_efConstruction = 64,
 		 enum faiss::MetricType metric_type = faiss::METRIC_L2)
 {
   auto hnsw_index = new faiss::IndexHNSWFlat (dimension, hnsw_M, metric_type);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBVEC-73>

### Purpose

m과 ef_construction, metric을 CREATE VECTOR INDEX의 WITH절에 받을 수 있다.

```sql
create vector index idx on tbl(vec EUCLIDEAN) with (m = 1234, ef_construction = 4321);
```

```c
node->info.index.vector_index.hnsw_m = m;
node->info.index.vector_index.hnsw_ef_construction = ef_con;
node->info.index.vector_index.metric = metric;
```

위 코드에서 보이는 것과 같이, node->info.index.vector_index.hsnw_m 등에 정보가 저장된다.

m과 ef_construction을 명시하지 않으면 기본값으로 16과 48을 넣는다.

### Implementation

WITH 절 뒤에 들어오는 a = 1, b = 2, c = 3 ... 을 kv_pair 연결리스트로 저장하여
최상위 create vector index 룰에 전달합니다.

### Limitation

m, ef_construction 이외에 정의되지 않은 변수들을 작성하더라도 오류를 내지 않습니다.
ef_construction에 오타를 내면 오류 없이 실행되는 위험이 있습니다.

### Remarks

do_create_vector_index() 에서 hsnw_add_index를 호출하는 경우 임시로 전역 변수를 호출하고 이는 추후 리팩토링 대상임.
