### PR TITLE
[CUBRIDQA-1263] fix bug for branch name

### DIFF
--- a/.github/workflows/comment_trigger.yml
+++ b/.github/workflows/comment_trigger.yml
@@ -12,13 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Get Branch Name and Test Type
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          BRANCH_NAME=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-            "${{ github.event.issue.pull_request.url }}" | jq -r .head.ref)
-          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
-          
+        run: |         
           # Get comment
           COMMENT="${{ github.event.comment.body }}"
           echo "[debug] Comment: $COMMENT"
@@ -68,7 +62,7 @@ jobs:
       - name: Trigger CircleCI Test
         env:
           CIRCLECI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
-          BRANCH_NAME: ${{ env.BRANCH_NAME }}
+          BRANCH_NAME: pull/${{ github.event.pull_request.number }}
           TEST_JSON: ${{ env.TEST_JSON }}
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/comment_trigger.yml
+++ b/.github/workflows/comment_trigger.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Trigger CircleCI Test
         env:
           CIRCLECI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
-          BRANCH_NAME: pull/${{ github.event.issue.number }}
+          BRANCH_NAME: pull/${{ github.event.issue.number }}/head
           TEST_JSON: ${{ env.TEST_JSON }}
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/comment_trigger.yml
+++ b/.github/workflows/comment_trigger.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Trigger CircleCI Test
         env:
           CIRCLECI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
-          BRANCH_NAME: pull/${{ github.event.pull_request.number }}
+          BRANCH_NAME: pull/${{ github.event.issue.number }}
           TEST_JSON: ${{ env.TEST_JSON }}
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1263>

### Purpose

forked repo 의 브랜치명이 아닌 pr 번호로 브랜치가 호출되어야 정상적인 트리거 작동.

### Implementation

api 호출에 사용되는 branch 명 변경.

### Remarks

N/A
