### PR TITLE
[CUBVEC-72] Support Dump / Load function for HNSW Indices

### DIFF
--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -32,6 +32,7 @@
 #include "thread_entry.hpp"
 #include "thread_manager.hpp"
 #include "thread_worker_pool.hpp"
+#include "hnsw.hpp"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -1401,7 +1402,7 @@ shutdown:
    * start to shutdown server
    */
   css_start_shutdown_server ();
-
+  dump_all_hnsw_indices_to_files ();
   // stop threads; in first phase we need to stop active workers, but keep log writers for a while longer to make sure
   // all log is transfered
   css_stop_all_workers (*thread_p, THREAD_STOP_WORKERS_EXCEPT_LOGWR);

--- a/src/storage/hnsw.cpp
+++ b/src/storage/hnsw.cpp
@@ -24,6 +24,7 @@
 #include "error_manager.h"
 #include "system_parameter.h"
 #include "vector_opfunc.hpp"
+#include "boot_sr.h"
 #include <fstream>
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
 #include "memory_wrapper.hpp"
@@ -36,6 +37,8 @@
 int hnsw_index_id = 0;
 std::unordered_map<int, std::unique_ptr<faiss::IndexIDMap>> hnsw_index_map;
 
+static int load_hnsw_index_from_file (int hnsw_id);
+static bool is_hnsw_index_file_exists (int hnsw_id);
 static faiss::idx_t encode_oid (const OID &oid);
 //static OID decode_oid (faiss::idx_t encoded_oid);
 
@@ -48,13 +51,36 @@ xhnsw_add_index (THREAD_ENTRY *thread_p, BTID *btid, int dimension = 10, int hns
 
   auto index = std::make_unique<faiss::IndexIDMap> (hnsw_index);
 
+  while (true)
+    {
+      if (is_hnsw_index_file_exists (hnsw_index_id))
+	{
+	  hnsw_index_id++;
+	  continue;
+	}
+      else
+	{
+	  if (hnsw_index_map.find (hnsw_index_id) == hnsw_index_map.end())
+	    {
+	      break;
+	    }
+	  else
+	    {
+	      hnsw_index_id++;
+	      continue;
+	    }
+	}
+    }
+
   btid->vfid.volid = -1;
   btid->vfid.fileid = -1;
-  btid->root_pageid = ++hnsw_index_id;
+  btid->root_pageid = hnsw_index_id;
 
   hnsw_index_map[hnsw_index_id] = std::move (index);
   er_log_debug (ARG_FILE_LINE, "HNSW Index added with ID %d", hnsw_index_id);
   hnsw_print_index_info (btid);
+
+  hnsw_index_id++;
 
   return btid;
 }
@@ -72,10 +98,9 @@ int xhnsw_delete_index (THREAD_ENTRY *thread_p, BTID *btid)
 
   if (it == hnsw_index_map.end())
     {
-      std::string filename = "hnsw_index_" + std::to_string (hnsw_id) + ".bin";
-      if (std::ifstream (filename))
+      std::string filename = "hnsw_index_" + std::string (boot_db_name()) + "_" + std::to_string (hnsw_id) + ".bin";
+      if (is_hnsw_index_file_exists (hnsw_id))
 	{
-	  // Remove the file
 	  std::remove (filename.c_str());
 	}
       else
@@ -189,15 +214,15 @@ void dump_all_hnsw_indices_to_files ()
     {
       int hnsw_id = pair.first;
       auto &index = pair.second;
-      std::string filename = "hnsw_index_" + std::to_string (hnsw_id) + ".bin";
+      std::string filename = "hnsw_index_" + std::string (boot_db_name()) + "_" + std::to_string (hnsw_id) + ".bin";
       faiss::write_index (index.get(), filename.c_str());
       er_log_debug (ARG_FILE_LINE, "Dumped HNSW Index to file %s", filename.c_str());
     }
 }
 
-int load_hnsw_index_from_file (int hnsw_id)
+static int load_hnsw_index_from_file (int hnsw_id)
 {
-  std::string filename = "hnsw_index_" + std::to_string (hnsw_id) + ".bin";
+  std::string filename = "hnsw_index_" + std::string (boot_db_name()) + "_" + std::to_string (hnsw_id) + ".bin";
 
   // Check if already loaded
   if (hnsw_index_map.find (hnsw_id) != hnsw_index_map.end())
@@ -207,7 +232,7 @@ int load_hnsw_index_from_file (int hnsw_id)
 
   try
     {
-      if (std::ifstream (filename)) // File exists
+      if (is_hnsw_index_file_exists (hnsw_id)) // File exists
 	{
 	  faiss::Index *raw_index = faiss::read_index (filename.c_str());
 
@@ -237,6 +262,12 @@ int load_hnsw_index_from_file (int hnsw_id)
     }
 
   return NO_ERROR;
+}
+
+static bool is_hnsw_index_file_exists (int hnsw_id)
+{
+  std::string filename = "hnsw_index_" + std::string (boot_db_name()) + "_" + std::to_string (hnsw_id) + ".bin";
+  return std::ifstream (filename).good();
 }
 
 static faiss::idx_t encode_oid (const OID &oid)

--- a/src/storage/hnsw.cpp
+++ b/src/storage/hnsw.cpp
@@ -26,6 +26,7 @@
 #include "vector_opfunc.hpp"
 #include "boot_sr.h"
 #include <fstream>
+#include <filesystem>
 #include "dbtype.h"
 
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
@@ -41,6 +42,7 @@ std::unordered_map<int, std::unique_ptr<faiss::IndexIDMap>> hnsw_index_map;
 
 static int load_hnsw_index_from_file (int hnsw_id);
 static bool is_hnsw_index_file_exists (int hnsw_id);
+static std::string get_hnsw_index_file_path (int hnsw_id);
 static faiss::idx_t encode_oid (const OID &oid);
 static OID decode_oid (faiss::idx_t encoded_oid);
 static std::mutex hnsw_elem_mutex;
@@ -49,6 +51,7 @@ BTID *
 xhnsw_add_index (THREAD_ENTRY *thread_p, BTID *btid, int dimension = 10, int hnsw_M = 128, int hnsw_efConstruction = 40,
 		 enum faiss::MetricType metric_type = faiss::METRIC_L2)
 {
+  fprintf (stderr, "%s\n", boot_get_lob_path());
   auto hnsw_index = new faiss::IndexHNSWFlat (dimension, hnsw_M, metric_type);
   hnsw_index->hnsw.efConstruction = hnsw_efConstruction;
 
@@ -101,10 +104,10 @@ int xhnsw_delete_index (THREAD_ENTRY *thread_p, BTID *btid)
 
   if (it == hnsw_index_map.end())
     {
-      std::string filename = "hnsw_index_" + std::string (boot_db_name()) + "_" + std::to_string (hnsw_id) + ".bin";
+      std::string filepath = get_hnsw_index_file_path (hnsw_id);
       if (is_hnsw_index_file_exists (hnsw_id))
 	{
-	  std::remove (filename.c_str());
+	  std::remove (filepath.c_str());
 	}
       else
 	{
@@ -249,15 +252,32 @@ void dump_all_hnsw_indices_to_files ()
     {
       int hnsw_id = pair.first;
       auto &index = pair.second;
-      std::string filename = "hnsw_index_" + std::string (boot_db_name()) + "_" + std::to_string (hnsw_id) + ".bin";
-      faiss::write_index (index.get(), filename.c_str());
-      er_log_debug (ARG_FILE_LINE, "Dumped HNSW Index to file %s", filename.c_str());
+      std::string filepath = get_hnsw_index_file_path (hnsw_id);
+      if (filepath.empty())
+	{
+	  er_log_debug (ARG_FILE_LINE, "Failed to get HNSW Index file path for ID %d", hnsw_id);
+	  continue;
+	}
+      // Create directory if it doesn't exist
+      std::string dir = filepath.substr (0, filepath.find_last_of ('/'));
+      if (!std::filesystem::exists (dir))
+	{
+	  std::filesystem::create_directories (dir);
+	}
+
+      faiss::write_index (index.get(), filepath.c_str());
+      er_log_debug (ARG_FILE_LINE, "Dumped HNSW Index to file %s", filepath.c_str());
     }
 }
 
 static int load_hnsw_index_from_file (int hnsw_id)
 {
-  std::string filename = "hnsw_index_" + std::string (boot_db_name()) + "_" + std::to_string (hnsw_id) + ".bin";
+  std::string filepath = get_hnsw_index_file_path (hnsw_id);
+  if (filepath.empty())
+    {
+      er_log_debug (ARG_FILE_LINE, "Failed to get HNSW Index file path for ID %d", hnsw_id);
+      return ER_FAILED;
+    }
 
   // Check if already loaded
   if (hnsw_index_map.find (hnsw_id) != hnsw_index_map.end())
@@ -269,19 +289,19 @@ static int load_hnsw_index_from_file (int hnsw_id)
     {
       if (is_hnsw_index_file_exists (hnsw_id)) // File exists
 	{
-	  faiss::Index *raw_index = faiss::read_index (filename.c_str());
+	  faiss::Index *raw_index = faiss::read_index (filepath.c_str());
 
 	  // Ensure it is IndexIDMap
 	  faiss::IndexIDMap *idmap = dynamic_cast<faiss::IndexIDMap *> (raw_index);
 	  if (idmap == nullptr)
 	    {
-	      er_log_debug (ARG_FILE_LINE, "Invalid index format in file %s", filename.c_str());
+	      er_log_debug (ARG_FILE_LINE, "Invalid index format in file %s", filepath.c_str());
 	      delete raw_index;
 	      return ER_FAILED;
 	    }
 
 	  hnsw_index_map[hnsw_id] = std::unique_ptr<faiss::IndexIDMap> (idmap);
-	  er_log_debug (ARG_FILE_LINE, "Loaded HNSW Index ID %d from file %s", hnsw_id, filename.c_str());
+	  er_log_debug (ARG_FILE_LINE, "Loaded HNSW Index ID %d from file %s", hnsw_id, filepath.c_str());
 	}
       else
 	{
@@ -301,8 +321,51 @@ static int load_hnsw_index_from_file (int hnsw_id)
 
 static bool is_hnsw_index_file_exists (int hnsw_id)
 {
-  std::string filename = "hnsw_index_" + std::string (boot_db_name()) + "_" + std::to_string (hnsw_id) + ".bin";
+  std::string filename = get_hnsw_index_file_path (hnsw_id);
+  if (filename.empty())
+    {
+      return false;
+    }
   return std::ifstream (filename).good();
+}
+
+static std::string get_hnsw_index_file_path (int hnsw_id)
+{
+  const char *uri = boot_get_lob_path();
+  if (uri == nullptr)
+    {
+      return "";
+    }
+
+  std::string path = uri;
+
+  // Remove "file:" URI scheme if present
+  const std::string file_prefix = "file:";
+  if (path.rfind (file_prefix, 0) == 0)
+    {
+      path = path.substr (file_prefix.length());
+    }
+  else
+    {
+      return "";
+    }
+
+  // Replace trailing "/lob" with "/vindex"
+  const std::string lob = "/lob";
+  const std::string vindex = "/vindex";
+  if (path.size() >= lob.size() &&
+      path.compare (path.size() - lob.size(), lob.size(), lob) == 0)
+    {
+      path.replace (path.size() - lob.size(), lob.size(), vindex);
+    }
+  else
+    {
+      return "";
+    }
+
+  // Append db name and the index file name
+  path += "/" + std::string (boot_db_name()) + "/hnsw_" + std::to_string (hnsw_id) + ".bin";
+  return path;
 }
 
 static faiss::idx_t encode_oid (const OID &oid)

--- a/src/storage/hnsw.cpp
+++ b/src/storage/hnsw.cpp
@@ -51,6 +51,7 @@ static int create_hnsw_index_directory ();
 static bool is_hnsw_index_file_exists (int hnsw_id);
 static int load_hnsw_index_from_file (int hnsw_id);
 static int hnsw_check_and_load_index (int hnsw_id);
+static void get_new_hnsw_index_id ();
 static faiss::idx_t encode_oid (const OID &oid);
 static OID decode_oid (faiss::idx_t encoded_oid);
 
@@ -58,31 +59,12 @@ BTID *
 xhnsw_add_index (THREAD_ENTRY *thread_p, BTID *btid, int dimension = 10, int hnsw_M = 128, int hnsw_efConstruction = 40,
 		 enum faiss::MetricType metric_type = faiss::METRIC_L2)
 {
+  get_new_hnsw_index_id ();
+
   auto hnsw_index = new faiss::IndexHNSWFlat (dimension, hnsw_M, metric_type);
   hnsw_index->hnsw.efConstruction = hnsw_efConstruction;
 
   auto index = std::make_unique<faiss::IndexIDMap> (hnsw_index);
-
-  while (true)
-    {
-      if (is_hnsw_index_file_exists (hnsw_index_id))
-	{
-	  hnsw_index_id++;
-	  continue;
-	}
-      else
-	{
-	  if (hnsw_index_map.find (hnsw_index_id) == hnsw_index_map.end())
-	    {
-	      break;
-	    }
-	  else
-	    {
-	      hnsw_index_id++;
-	      continue;
-	    }
-	}
-    }
 
   btid->vfid.volid = -1;
   btid->vfid.fileid = -1;
@@ -424,6 +406,30 @@ int hnsw_search_element (int hnsw_id, DB_VALUE *key_dbvalue, int k, OID *rec_oid
       delete[] uids;
     }
   return NO_ERROR;
+}
+
+static void get_new_hnsw_index_id ()
+{
+  while (true)
+    {
+      if (is_hnsw_index_file_exists (hnsw_index_id))
+	{
+	  hnsw_index_id++;
+	  continue;
+	}
+      else
+	{
+	  if (hnsw_index_map.find (hnsw_index_id) == hnsw_index_map.end())
+	    {
+	      break;
+	    }
+	  else
+	    {
+	      hnsw_index_id++;
+	      continue;
+	    }
+	}
+    }
 }
 
 static faiss::idx_t encode_oid (const OID &oid)

--- a/src/storage/hnsw.cpp
+++ b/src/storage/hnsw.cpp
@@ -24,6 +24,7 @@
 #include "error_manager.h"
 #include "system_parameter.h"
 #include "vector_opfunc.hpp"
+#include <fstream>
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
 #include "memory_wrapper.hpp"
 
@@ -71,9 +72,18 @@ int xhnsw_delete_index (THREAD_ENTRY *thread_p, BTID *btid)
 
   if (it == hnsw_index_map.end())
     {
-      er_log_debug (ARG_FILE_LINE, "HNSW Index not found with ID %d", hnsw_id);
-      assert (false);
-      return ER_FAILED;
+      std::string filename = "hnsw_index_" + std::to_string (hnsw_id) + ".bin";
+      if (std::ifstream (filename))
+	{
+	  // Remove the file
+	  std::remove (filename.c_str());
+	}
+      else
+	{
+	  er_log_debug (ARG_FILE_LINE, "HNSW Index not found with ID %d", hnsw_id);
+	  assert (false);
+	  return ER_FAILED;
+	}
     }
   else
     {
@@ -95,26 +105,32 @@ int hnsw_print_index_info (BTID *btid)
     }
 
   int hnsw_id = btid->root_pageid;
-  auto it = hnsw_index_map.find (hnsw_id);
 
-  if (it == hnsw_index_map.end())
+  if (hnsw_index_map.find (hnsw_id) == hnsw_index_map.end())
     {
-      er_log_debug (ARG_FILE_LINE, "HNSW Index not found with ID %d", hnsw_id);
+      if (load_hnsw_index_from_file (hnsw_id) != NO_ERROR)
+	{
+	  er_log_debug (ARG_FILE_LINE, "Failed to load HNSW Index with ID %d", hnsw_id);
+	  return ER_FAILED;
+	}
+    }
+
+  auto it = hnsw_index_map.find (hnsw_id);
+  if (it == hnsw_index_map.end() || it->second == nullptr)
+    {
+      er_log_debug (ARG_FILE_LINE, "HNSW Index missing or null after load for ID %d", hnsw_id);
       return ER_FAILED;
     }
 
-  else
-    {
-      std::unique_ptr<faiss::IndexIDMap> &index = it->second;
-      auto *hnsw_index = static_cast<faiss::IndexHNSWFlat *> (index->index);
+  std::unique_ptr<faiss::IndexIDMap> &index = it->second;
+  auto *hnsw_index = static_cast<faiss::IndexHNSWFlat *> (index->index);
 
-      er_log_debug (ARG_FILE_LINE, "HNSW Index Information for ID %d:", hnsw_id);
-      er_log_debug (ARG_FILE_LINE, "  - Dimension: %d", index->d);
-      er_log_debug (ARG_FILE_LINE, "  - Metric Type: %d", index->metric_type);
-      er_log_debug (ARG_FILE_LINE, "  - Total Elements: %d", index->ntotal);
-      er_log_debug (ARG_FILE_LINE, "  - HNSW efConstruction: %d", hnsw_index->hnsw.efConstruction);
-      er_log_debug (ARG_FILE_LINE, "  - HNSW efSearch: %d", hnsw_index->hnsw.efSearch);
-    }
+  er_log_debug (ARG_FILE_LINE, "HNSW Index Information for ID %d:", hnsw_id);
+  er_log_debug (ARG_FILE_LINE, "  - Dimension: %d", index->d);
+  er_log_debug (ARG_FILE_LINE, "  - Metric Type: %d", index->metric_type);
+  er_log_debug (ARG_FILE_LINE, "  - Total Elements: %d", index->ntotal);
+  er_log_debug (ARG_FILE_LINE, "  - HNSW efConstruction: %d", hnsw_index->hnsw.efConstruction);
+  er_log_debug (ARG_FILE_LINE, "  - HNSW efSearch: %d", hnsw_index->hnsw.efSearch);
 
   return NO_ERROR;
 }
@@ -134,19 +150,91 @@ int hnsw_add_element (BTID *btid, OID *oid, DB_VALUE *key_dbvalue)
   fvec = db_value_get_stdvector_float (key_dbvalue);
   hnsw_id = btid->root_pageid;
 
-  auto it = hnsw_index_map.find (hnsw_id);
-
-  if (it == hnsw_index_map.end())
+  if (hnsw_index_map.find (hnsw_id) == hnsw_index_map.end())
     {
-      er_log_debug (ARG_FILE_LINE, "HNSW Index not found with ID %d", hnsw_id);
-      assert (false);
+      if (load_hnsw_index_from_file (hnsw_id) != NO_ERROR)
+	{
+	  er_log_debug (ARG_FILE_LINE, "Failed to load HNSW Index with ID %d", hnsw_id);
+	  return ER_FAILED;
+	}
+    }
+
+  auto it = hnsw_index_map.find (hnsw_id);
+  if (it == hnsw_index_map.end() || it->second == nullptr)
+    {
+      er_log_debug (ARG_FILE_LINE, "HNSW Index missing or null after load for ID %d", hnsw_id);
       return ER_FAILED;
     }
 
-  std::unique_ptr<faiss::IndexIDMap> &index = it->second;
+  try
+    {
+      std::unique_ptr<faiss::IndexIDMap> &index = it->second;
+      index->add_with_ids (1, fvec.data(), &encoded_oid);
 
-  index->add_with_ids (1, fvec.data(), &encoded_oid);
-  er_log_debug (ARG_FILE_LINE, "Added element with ID %lld to HNSW Index.", static_cast<long long> (encoded_oid));
+      er_log_debug (ARG_FILE_LINE, "Added element with OID %lld to HNSW Index ID %d.",
+		    static_cast<long long> (encoded_oid), hnsw_id);
+    }
+  catch (const faiss::FaissException &e)
+    {
+      er_log_debug (ARG_FILE_LINE, "FAISS exception during add_with_ids: %s", e.what());
+      return ER_FAILED;
+    }
+
+  return NO_ERROR;
+}
+
+void dump_all_hnsw_indices_to_files ()
+{
+  for (const auto &pair : hnsw_index_map)
+    {
+      int hnsw_id = pair.first;
+      auto &index = pair.second;
+      std::string filename = "hnsw_index_" + std::to_string (hnsw_id) + ".bin";
+      faiss::write_index (index.get(), filename.c_str());
+      er_log_debug (ARG_FILE_LINE, "Dumped HNSW Index to file %s", filename.c_str());
+    }
+}
+
+int load_hnsw_index_from_file (int hnsw_id)
+{
+  std::string filename = "hnsw_index_" + std::to_string (hnsw_id) + ".bin";
+
+  // Check if already loaded
+  if (hnsw_index_map.find (hnsw_id) != hnsw_index_map.end())
+    {
+      return NO_ERROR;
+    }
+
+  try
+    {
+      if (std::ifstream (filename)) // File exists
+	{
+	  faiss::Index *raw_index = faiss::read_index (filename.c_str());
+
+	  // Ensure it is IndexIDMap
+	  faiss::IndexIDMap *idmap = dynamic_cast<faiss::IndexIDMap *> (raw_index);
+	  if (idmap == nullptr)
+	    {
+	      er_log_debug (ARG_FILE_LINE, "Invalid index format in file %s", filename.c_str());
+	      delete raw_index;
+	      return ER_FAILED;
+	    }
+
+	  hnsw_index_map[hnsw_id] = std::unique_ptr<faiss::IndexIDMap> (idmap);
+	  er_log_debug (ARG_FILE_LINE, "Loaded HNSW Index ID %d from file %s", hnsw_id, filename.c_str());
+	}
+      else
+	{
+	  assert (false);
+	  er_log_debug (ARG_FILE_LINE, "Dump file not found for HNSW Index ID %d", hnsw_id);
+	  return ER_FAILED;
+	}
+    }
+  catch (const faiss::FaissException &e)
+    {
+      er_log_debug (ARG_FILE_LINE, "Failed to load/create HNSW Index %d: %s", hnsw_id, e.what());
+      return ER_FAILED;
+    }
 
   return NO_ERROR;
 }

--- a/src/storage/hnsw.cpp
+++ b/src/storage/hnsw.cpp
@@ -25,9 +25,11 @@
 #include "system_parameter.h"
 #include "vector_opfunc.hpp"
 #include "boot_sr.h"
+#include "file_io.h"
+#include "dbtype.h"
+#include "porting.h"
 #include <fstream>
 #include <filesystem>
-#include "dbtype.h"
 
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
 #include "memory_wrapper.hpp"
@@ -39,19 +41,23 @@
 //        We need to consider a better way to identify the hnsw index.
 int hnsw_index_id = 0;
 std::unordered_map<int, std::unique_ptr<faiss::IndexIDMap>> hnsw_index_map;
+char hnsw_index_directory[PATH_MAX] = {0};
+bool hnsw_index_directory_created = false;
+static std::mutex hnsw_elem_mutex;
 
-static int load_hnsw_index_from_file (int hnsw_id);
+static int dump_hnsw_index (int hnsw_id, faiss::IndexIDMap *index);
+static int get_hnsw_index_file_path (int hnsw_id, char *out_path);
+static int create_hnsw_index_directory ();
 static bool is_hnsw_index_file_exists (int hnsw_id);
-static std::string get_hnsw_index_file_path (int hnsw_id);
+static int load_hnsw_index_from_file (int hnsw_id);
+static int hnsw_check_and_load_index (int hnsw_id);
 static faiss::idx_t encode_oid (const OID &oid);
 static OID decode_oid (faiss::idx_t encoded_oid);
-static std::mutex hnsw_elem_mutex;
 
 BTID *
 xhnsw_add_index (THREAD_ENTRY *thread_p, BTID *btid, int dimension = 10, int hnsw_M = 128, int hnsw_efConstruction = 40,
 		 enum faiss::MetricType metric_type = faiss::METRIC_L2)
 {
-  fprintf (stderr, "%s\n", boot_get_lob_path());
   auto hnsw_index = new faiss::IndexHNSWFlat (dimension, hnsw_M, metric_type);
   hnsw_index->hnsw.efConstruction = hnsw_efConstruction;
 
@@ -93,6 +99,17 @@ xhnsw_add_index (THREAD_ENTRY *thread_p, BTID *btid, int dimension = 10, int hns
 
 int xhnsw_delete_index (THREAD_ENTRY *thread_p, BTID *btid)
 {
+  char filepath[PATH_MAX];
+
+  if (!hnsw_index_directory_created)
+    {
+      if (create_hnsw_index_directory () != NO_ERROR)
+	{
+	  er_log_debug (ARG_FILE_LINE, "Failed to create HNSW Index directory");
+	  return ER_FAILED;
+	}
+    }
+
   if (!btid)
     {
       assert (false);
@@ -102,21 +119,7 @@ int xhnsw_delete_index (THREAD_ENTRY *thread_p, BTID *btid)
   int hnsw_id = btid->root_pageid;
   auto it = hnsw_index_map.find (hnsw_id);
 
-  if (it == hnsw_index_map.end())
-    {
-      std::string filepath = get_hnsw_index_file_path (hnsw_id);
-      if (is_hnsw_index_file_exists (hnsw_id))
-	{
-	  std::remove (filepath.c_str());
-	}
-      else
-	{
-	  er_log_debug (ARG_FILE_LINE, "HNSW Index not found with ID %d", hnsw_id);
-	  assert (false);
-	  return ER_FAILED;
-	}
-    }
-  else
+  if (it != hnsw_index_map.end())
     {
       er_log_debug (ARG_FILE_LINE, "HNSW Index deleted with ID %d", hnsw_id);
       hnsw_print_index_info (btid);
@@ -124,9 +127,19 @@ int xhnsw_delete_index (THREAD_ENTRY *thread_p, BTID *btid)
       hnsw_index_map.erase (it);
     }
 
+  if (hnsw_index_directory_created)
+    {
+      if (get_hnsw_index_file_path (hnsw_id, filepath) != NO_ERROR)
+	{
+	  _er_log_debug (ARG_FILE_LINE, "Failed to get HNSW Index file path for ID %d", hnsw_id);
+	  return ER_FAILED;
+	}
+
+      std::filesystem::remove (filepath);
+    }
+
   return NO_ERROR;
 }
-
 
 int hnsw_print_index_info (BTID *btid)
 {
@@ -137,19 +150,14 @@ int hnsw_print_index_info (BTID *btid)
 
   int hnsw_id = btid->root_pageid;
 
-  if (hnsw_index_map.find (hnsw_id) == hnsw_index_map.end())
+  if (hnsw_check_and_load_index (hnsw_id) != NO_ERROR)
     {
-      if (load_hnsw_index_from_file (hnsw_id) != NO_ERROR)
-	{
-	  er_log_debug (ARG_FILE_LINE, "Failed to load HNSW Index with ID %d", hnsw_id);
-	  return ER_FAILED;
-	}
+      return ER_FAILED;
     }
 
   auto it = hnsw_index_map.find (hnsw_id);
   if (it == hnsw_index_map.end() || it->second == nullptr)
     {
-      er_log_debug (ARG_FILE_LINE, "HNSW Index missing or null after load for ID %d", hnsw_id);
       return ER_FAILED;
     }
 
@@ -162,6 +170,165 @@ int hnsw_print_index_info (BTID *btid)
   er_log_debug (ARG_FILE_LINE, "  - Total Elements: %d", index->ntotal);
   er_log_debug (ARG_FILE_LINE, "  - HNSW efConstruction: %d", hnsw_index->hnsw.efConstruction);
   er_log_debug (ARG_FILE_LINE, "  - HNSW efSearch: %d", hnsw_index->hnsw.efSearch);
+
+  return NO_ERROR;
+}
+
+void dump_all_hnsw_indices_to_files ()
+{
+  if (!hnsw_index_directory_created)
+    {
+      if (create_hnsw_index_directory () != NO_ERROR)
+	{
+	  assert (false);
+	  _er_log_debug (ARG_FILE_LINE, "Failed to create HNSW Index directory");
+	  return;
+	}
+    }
+
+  for (const auto &pair : hnsw_index_map)
+    {
+      int hnsw_id = pair.first;
+      auto &index = pair.second;
+
+      if (dump_hnsw_index (hnsw_id, index.get()) != NO_ERROR)
+	{
+	  assert (false);
+	  _er_log_debug (ARG_FILE_LINE, "Failed to dump HNSW Index with ID %d", hnsw_id);
+	}
+    }
+}
+
+static int dump_hnsw_index (int hnsw_id, faiss::IndexIDMap *index)
+{
+  char filepath[PATH_MAX];
+
+  if (!index)
+    {
+      return ER_FAILED;
+    }
+
+  if (get_hnsw_index_file_path (hnsw_id, filepath) != NO_ERROR)
+    {
+      return ER_FAILED;
+    }
+
+  faiss::write_index (index, filepath);
+
+  return NO_ERROR;
+}
+
+static int get_hnsw_index_file_path (int hnsw_id, char *out_path)
+{
+  int written = snprintf (out_path, PATH_MAX, "%s%c%s_hnsw_%d.bin", hnsw_index_directory, PATH_SEPARATOR, boot_db_name(),
+			  hnsw_id);
+  if (written < 0 || written >= PATH_MAX)
+    {
+      er_log_debug (ARG_FILE_LINE, "Failed to create path for dumping HNSW Index %d since path is too long", hnsw_id);
+      return ER_FAILED;
+    }
+
+  return NO_ERROR;
+}
+
+static int create_hnsw_index_directory ()
+{
+  char db_path[PATH_MAX];
+
+  if (hnsw_index_directory_created)
+    {
+      return NO_ERROR;
+    }
+  else
+    {
+      fileio_get_directory_path (db_path, boot_db_full_name());
+      int written = snprintf (hnsw_index_directory, PATH_MAX, "%s%cvindex", db_path, PATH_SEPARATOR);
+      if (written < 0 || written >= PATH_MAX)
+	{
+	  er_log_debug (ARG_FILE_LINE, "Failed to create path for HNSW Index directory since path is too long");
+	  return ER_FAILED;
+	}
+
+      if (std::filesystem::exists (hnsw_index_directory))
+	{
+	  hnsw_index_directory_created = true;
+	  return NO_ERROR;
+	}
+
+      if (std::filesystem::create_directory (hnsw_index_directory))
+	{
+	  hnsw_index_directory_created = true;
+	  return NO_ERROR;
+	}
+      else
+	{
+	  assert (false);
+	  _er_log_debug (ARG_FILE_LINE, "Failed to create HNSW Index directory");
+	  return ER_FAILED;
+	}
+    }
+}
+
+static bool is_hnsw_index_file_exists (int hnsw_id)
+{
+  char filepath[PATH_MAX];
+
+  if (get_hnsw_index_file_path (hnsw_id, filepath) != NO_ERROR)
+    {
+      return false;
+    }
+
+  return std::filesystem::exists (filepath);
+}
+
+static int load_hnsw_index_from_file (int hnsw_id)
+{
+  char filepath[PATH_MAX];
+
+  if (!hnsw_index_directory_created)
+    {
+      if (create_hnsw_index_directory () != NO_ERROR)
+	{
+	  return ER_FAILED;
+	}
+    }
+
+  if (get_hnsw_index_file_path (hnsw_id, filepath) != NO_ERROR)
+    {
+      return ER_FAILED;
+    }
+
+  if (!std::filesystem::exists (filepath))
+    {
+      assert (false);
+      _er_log_debug (ARG_FILE_LINE, "HNSW Index file does not exist for ID %d in %s", hnsw_id, filepath);
+      return ER_FAILED;
+    }
+
+  try
+    {
+      faiss::Index *raw_index = faiss::read_index (filepath);
+
+      faiss::IndexIDMap *idmap = dynamic_cast<faiss::IndexIDMap *> (raw_index);
+      if (idmap == nullptr)
+	{
+	  assert (false);
+	  _er_log_debug (ARG_FILE_LINE, "Invalid HNSW Index file format for ID %d in %s", hnsw_id, filepath);
+
+	  delete raw_index;
+	  return ER_FAILED;
+	}
+
+      hnsw_index_map[hnsw_id] = std::unique_ptr<faiss::IndexIDMap> (idmap);
+      er_log_debug (ARG_FILE_LINE, "HNSW Index loaded from file for ID %d in %s", hnsw_id, filepath);
+
+      return NO_ERROR;
+    }
+  catch (const faiss::FaissException &e)
+    {
+      er_log_debug (ARG_FILE_LINE, "Failed to load/create HNSW Index %d: %s", hnsw_id, e.what());
+      return ER_FAILED;
+    }
 
   return NO_ERROR;
 }
@@ -182,25 +349,22 @@ hnsw_add_element (BTID *btid, OID *oid, DB_VALUE *key_dbvalue)
 
   hnsw_id = btid->root_pageid;
 
-  if (hnsw_index_map.find (hnsw_id) == hnsw_index_map.end())
+  if (hnsw_check_and_load_index (hnsw_id) != NO_ERROR)
     {
-      if (load_hnsw_index_from_file (hnsw_id) != NO_ERROR)
-	{
-	  er_log_debug (ARG_FILE_LINE, "Failed to load HNSW Index with ID %d", hnsw_id);
-	  return ER_FAILED;
-	}
+      return ER_FAILED;
     }
 
   auto it = hnsw_index_map.find (hnsw_id);
   if (it == hnsw_index_map.end() || it->second == nullptr)
     {
-      er_log_debug (ARG_FILE_LINE, "HNSW Index missing or null after load for ID %d", hnsw_id);
       return ER_FAILED;
     }
 
   try
     {
       std::unique_ptr<faiss::IndexIDMap> &index = it->second;
+      std::lock_guard<std::mutex> lock (hnsw_elem_mutex);
+
       index->add_with_ids (1, vf->float_array, &encoded_oid);
 
       er_log_debug (ARG_FILE_LINE, "Added element with OID %lld to HNSW Index ID %d.",
@@ -210,6 +374,22 @@ hnsw_add_element (BTID *btid, OID *oid, DB_VALUE *key_dbvalue)
     {
       er_log_debug (ARG_FILE_LINE, "FAISS exception during add_with_ids: %s", e.what());
       return ER_FAILED;
+    }
+
+  return NO_ERROR;
+}
+
+static int hnsw_check_and_load_index (int hnsw_id)
+{
+  if (hnsw_index_map.find (hnsw_id) == hnsw_index_map.end())
+    {
+      assert (hnsw_index_directory_created);
+      if (load_hnsw_index_from_file (hnsw_id) != NO_ERROR)
+	{
+	  assert (false);
+	  _er_log_debug (ARG_FILE_LINE, "Failed to load HNSW Index with ID %d", hnsw_id);
+	  return ER_FAILED;
+	}
     }
 
   return NO_ERROR;
@@ -244,128 +424,6 @@ int hnsw_search_element (int hnsw_id, DB_VALUE *key_dbvalue, int k, OID *rec_oid
       delete[] uids;
     }
   return NO_ERROR;
-}
-
-void dump_all_hnsw_indices_to_files ()
-{
-  for (const auto &pair : hnsw_index_map)
-    {
-      int hnsw_id = pair.first;
-      auto &index = pair.second;
-      std::string filepath = get_hnsw_index_file_path (hnsw_id);
-      if (filepath.empty())
-	{
-	  er_log_debug (ARG_FILE_LINE, "Failed to get HNSW Index file path for ID %d", hnsw_id);
-	  continue;
-	}
-      // Create directory if it doesn't exist
-      std::string dir = filepath.substr (0, filepath.find_last_of ('/'));
-      if (!std::filesystem::exists (dir))
-	{
-	  std::filesystem::create_directories (dir);
-	}
-
-      faiss::write_index (index.get(), filepath.c_str());
-      er_log_debug (ARG_FILE_LINE, "Dumped HNSW Index to file %s", filepath.c_str());
-    }
-}
-
-static int load_hnsw_index_from_file (int hnsw_id)
-{
-  std::string filepath = get_hnsw_index_file_path (hnsw_id);
-  if (filepath.empty())
-    {
-      er_log_debug (ARG_FILE_LINE, "Failed to get HNSW Index file path for ID %d", hnsw_id);
-      return ER_FAILED;
-    }
-
-  // Check if already loaded
-  if (hnsw_index_map.find (hnsw_id) != hnsw_index_map.end())
-    {
-      return NO_ERROR;
-    }
-
-  try
-    {
-      if (is_hnsw_index_file_exists (hnsw_id)) // File exists
-	{
-	  faiss::Index *raw_index = faiss::read_index (filepath.c_str());
-
-	  // Ensure it is IndexIDMap
-	  faiss::IndexIDMap *idmap = dynamic_cast<faiss::IndexIDMap *> (raw_index);
-	  if (idmap == nullptr)
-	    {
-	      er_log_debug (ARG_FILE_LINE, "Invalid index format in file %s", filepath.c_str());
-	      delete raw_index;
-	      return ER_FAILED;
-	    }
-
-	  hnsw_index_map[hnsw_id] = std::unique_ptr<faiss::IndexIDMap> (idmap);
-	  er_log_debug (ARG_FILE_LINE, "Loaded HNSW Index ID %d from file %s", hnsw_id, filepath.c_str());
-	}
-      else
-	{
-	  assert (false);
-	  er_log_debug (ARG_FILE_LINE, "Dump file not found for HNSW Index ID %d", hnsw_id);
-	  return ER_FAILED;
-	}
-    }
-  catch (const faiss::FaissException &e)
-    {
-      er_log_debug (ARG_FILE_LINE, "Failed to load/create HNSW Index %d: %s", hnsw_id, e.what());
-      return ER_FAILED;
-    }
-
-  return NO_ERROR;
-}
-
-static bool is_hnsw_index_file_exists (int hnsw_id)
-{
-  std::string filename = get_hnsw_index_file_path (hnsw_id);
-  if (filename.empty())
-    {
-      return false;
-    }
-  return std::ifstream (filename).good();
-}
-
-static std::string get_hnsw_index_file_path (int hnsw_id)
-{
-  const char *uri = boot_get_lob_path();
-  if (uri == nullptr)
-    {
-      return "";
-    }
-
-  std::string path = uri;
-
-  // Remove "file:" URI scheme if present
-  const std::string file_prefix = "file:";
-  if (path.rfind (file_prefix, 0) == 0)
-    {
-      path = path.substr (file_prefix.length());
-    }
-  else
-    {
-      return "";
-    }
-
-  // Replace trailing "/lob" with "/vindex"
-  const std::string lob = "/lob";
-  const std::string vindex = "/vindex";
-  if (path.size() >= lob.size() &&
-      path.compare (path.size() - lob.size(), lob.size(), lob) == 0)
-    {
-      path.replace (path.size() - lob.size(), lob.size(), vindex);
-    }
-  else
-    {
-      return "";
-    }
-
-  // Append db name and the index file name
-  path += "/" + std::string (boot_db_name()) + "/hnsw_" + std::to_string (hnsw_id) + ".bin";
-  return path;
 }
 
 static faiss::idx_t encode_oid (const OID &oid)

--- a/src/storage/hnsw.cpp
+++ b/src/storage/hnsw.cpp
@@ -74,8 +74,6 @@ xhnsw_add_index (THREAD_ENTRY *thread_p, BTID *btid, int dimension = 10, int hns
   er_log_debug (ARG_FILE_LINE, "HNSW Index added with ID %d", hnsw_index_id);
   hnsw_print_index_info (btid);
 
-  hnsw_index_id++;
-
   return btid;
 }
 
@@ -382,6 +380,13 @@ int hnsw_search_element (int hnsw_id, DB_VALUE *key_dbvalue, int k, OID *rec_oid
   const DB_VECTOR_FLOAT *vf = db_get_vector_float (key_dbvalue);
 
   assert (hnsw_id > 0);
+
+  if (hnsw_check_and_load_index (hnsw_id) != NO_ERROR)
+    {
+      er_log_debug (ARG_FILE_LINE, "HNSW Index not found with ID %d", hnsw_id);
+      assert (false);
+      return ER_FAILED;
+    }
 
   auto it = hnsw_index_map.find (hnsw_id);
 

--- a/src/storage/hnsw.hpp
+++ b/src/storage/hnsw.hpp
@@ -35,11 +35,14 @@
 #include "thread_compat.hpp"
 #include "faiss/IndexHNSW.h"
 #include "faiss/IndexIDMap.h"
+#include "faiss/index_io.h"
 
 BTID *xhnsw_add_index (THREAD_ENTRY *thread_p, BTID *btid, int dimension, int hnsw_M, int hnsw_efConstruction,
 		       enum faiss::MetricType metric_type);
 int xhnsw_delete_index (THREAD_ENTRY *thread_p, BTID *btid);
 int hnsw_print_index_info (BTID *btid);
 int hnsw_add_element (BTID *btid, OID *oid, DB_VALUE *key_dbvalue);
+void dump_all_hnsw_indices_to_files ();
+int load_hnsw_index_from_file (int hnsw_id);
 
 #endif

--- a/src/storage/hnsw.hpp
+++ b/src/storage/hnsw.hpp
@@ -43,6 +43,5 @@ int xhnsw_delete_index (THREAD_ENTRY *thread_p, BTID *btid);
 int hnsw_print_index_info (BTID *btid);
 int hnsw_add_element (BTID *btid, OID *oid, DB_VALUE *key_dbvalue);
 void dump_all_hnsw_indices_to_files ();
-int load_hnsw_index_from_file (int hnsw_id);
 
 #endif


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBVEC-72>

### Purpose

server가 종료된 후 다시 재구동 되었을 때도, Vector Index에 대한 매핑을 유지할 수 있도록 HNSW 인덱스에 대한 덤프 및 로드 기능 구현

### Implementation

- 서버가 종료할 때, 매핑에 존재하는 모든 HNSW 인덱스를 덤프 (`dump_all_hnsw_indices_to_files`)
  -  파일이름에 id를 포함하도록 하여 인식이 기능하도록 함 (ex. hnsw_demodb_1.bin)
-  재구동 이후, HNSW index 매핑이 필요할 떄 index를 lazy하게 로드
  -  id를 통해 파일 이름을 검색하여, 덤프된 인덱스 파일이 존재한다면, 해당 파일을 통한 인덱스 로드
-  drop index 요청에 대하여, 아직 로드되지 않은 인덱스라면, 해당 인덱스 덤프파일을 확인하여 삭제   

### Remarks

N/A
