### PR TITLE
[CUBRIDQA-1274] fix bug for globing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
                         esac
 
                         echo "[debug] split tests for parallel execution"
-                        circleci tests glob \$glob_path | sed "s|^\$base_dir/||" | circleci tests split | tee tc.list
+                        circleci tests glob \$glob_path | sed "s|^\$base_dir/||" | circleci tests split --split-by=name | tee tc.list
                  
                         echo "[debug] Remove tests that are not in the list"
                         if [ "\$TEST_SUITE" = "shell" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
                         esac
 
                         echo "[debug] split tests for parallel execution"
-                        circleci tests glob \$glob_path | sed "s|^\$base_dir/||" | circleci tests split --split-by=name | tee tc.list
+                        circleci tests glob "\$glob_path" | sed "s|^\$base_dir/||" | circleci tests split --split-by=name | tee tc.list
                  
                         echo "[debug] Remove tests that are not in the list"
                         if [ "\$TEST_SUITE" = "shell" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,8 @@ jobs:
                         esac
 
                         echo "[debug] split tests for parallel execution"
-                        circleci tests glob \$glob_path | sed "s|^\$base_dir/||" | circleci tests split | tee tc.list
+                        circleci tests glob \$glob_path | sed "s|^\$base_dir/||" > all.list
+                        circleci tests split all.list | tee tc.list
                  
                         echo "[debug] Remove tests that are not in the list"
                         if [ "\$TEST_SUITE" = "shell" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ jobs:
                           circleci tests glob "\$glob_path" | sed "s|^\$base_dir/||" | grep -P '/([^/]+)/cases/\1\.sh$' | circleci tests split --split-by=name | tee tc.list
                           cat tc.list | xargs -n1 dirname > tc_dirs.list
                           echo "[debug] Remove tests that are not in the list"
-                          find \$base_dir -name "cases" -type d| grep -v -f tc_dirs.list | xargs -r rm -rvf
+                          find \$base_dir -name "cases" -type d | grep -v -f tc_dirs.list | xargs -r rm -rvf
                         else
                           echo "[debug] split tests for parallel execution"
                           circleci tests glob "\$glob_path" | circleci tests split --split-by=name | tee tc.list

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,8 +122,7 @@ jobs:
                         esac
 
                         echo "[debug] split tests for parallel execution"
-                        circleci tests glob \$glob_path | sed "s|^\$base_dir/||" > all.list
-                        circleci tests split all.list | tee tc.list
+                        circleci tests glob \$glob_path | sed "s|^\$base_dir/||" | circleci tests split | tee tc.list
                  
                         echo "[debug] Remove tests that are not in the list"
                         if [ "\$TEST_SUITE" = "shell" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,36 +103,36 @@ jobs:
                           plcsql)
                             TEST_SUITE="sql"
                             base_dir="cubrid-testcases"
-                            glob_path="\$base_dir/sql/{_05_plcsql,_35_fig_cake/plcsql}/**/*.sql"
+                            glob_path="\$base_dir/sql/{_05_plcsql,_35_fig_cake/plcsql}"
                             ;;
                           sql)
                             base_dir="cubrid-testcases"
                             rm -rf \$base_dir/sql/_05_plcsql \$base_dir/sql/_35_fig_cake/plcsql
-                            glob_path="\$base_dir/\$TEST_SUITE/_*/**/*.sql"
+                            glob_path="\$base_dir/\$TEST_SUITE/_*"
                             ;;
                           shell)
                             base_dir="cubrid-testcases-private-ex"
                             rm -rf \$base_dir/shell/_25_unstable
                             #glob_path="\$(find \$base_dir/shell/_* -type f -path "*/*/cases/*.sh" | grep -P '/([^/]+)/cases/\1\.sh\$')"
-                            glob_path="\$base_dir/\$TEST_SUITE/_*/**/cases/*.sh"
+                            glob_path="\$base_dir/\$TEST_SUITE/_*/**/*.sh"
                             ;;
                           *)
                             base_dir="cubrid-testcases"
-                            glob_path="\$base_dir/\$TEST_SUITE/_*/**/*.sql"
+                            glob_path="\$base_dir/\$TEST_SUITE/_*"
                             ;;
                         esac
 
-                        echo "[debug] split tests for parallel execution"
-                        # circleci tests glob "\$glob_path" | sed "s|^\$base_dir/||" | grep -P '/([^/]+)/cases/\1\.sh$' | circleci tests split --split-by=name | tee tc.list
-                 
-                        echo "[debug] Remove tests that are not in the list"
                         if [ "\$TEST_SUITE" = "shell" ]; then
+                          echo "[debug] split tests for parallel execution"
                           circleci tests glob "\$glob_path" | sed "s|^\$base_dir/||" | grep -P '/([^/]+)/cases/\1\.sh$' | circleci tests split --split-by=name | tee tc.list
                           cat tc.list | xargs -n1 dirname > tc_dirs.list
+                          echo "[debug] Remove tests that are not in the list"
                           find \$base_dir -name "cases" -type d| grep -v -f tc_dirs.list | xargs -r rm -rf
                         else
-                          circleci tests glob "\$glob_path" | sed "s|^\$base_dir/||" | circleci tests split --split-by=name | tee tc.list
-                          find \$base_dir -name "*.sql" -type f | grep -v -f tc.list | xargs -r rm -rf
+                          echo "[debug] split tests for parallel execution"
+                          circleci tests glob "\$glob_path" | circleci tests split --split-by=name | tee tc.list
+                          echo "[debug] Remove tests that are not in the list"
+                          find \$base_dir/\$TEST_SUITE/_* -maxdepth 0 -type d -print0 | grep -vzZ -f tc.list | xargs -0 rm -rf
                         fi
 
                         echo "[debug] Run the tests"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,6 @@ jobs:
                           shell)
                             base_dir="cubrid-testcases-private-ex"
                             rm -rf \$base_dir/shell/_25_unstable
-                            #glob_path="\$(find \$base_dir/shell/_* -type f -path "*/*/cases/*.sh" | grep -P '/([^/]+)/cases/\1\.sh\$')"
                             glob_path="\$base_dir/\$TEST_SUITE/_*/**/*.sh"
                             ;;
                           *)
@@ -127,12 +126,12 @@ jobs:
                           circleci tests glob "\$glob_path" | sed "s|^\$base_dir/||" | grep -P '/([^/]+)/cases/\1\.sh$' | circleci tests split --split-by=name | tee tc.list
                           cat tc.list | xargs -n1 dirname > tc_dirs.list
                           echo "[debug] Remove tests that are not in the list"
-                          find \$base_dir -name "cases" -type d| grep -v -f tc_dirs.list | xargs -r rm -rf
+                          find \$base_dir -name "cases" -type d| grep -v -f tc_dirs.list | xargs -r rm -rvf
                         else
                           echo "[debug] split tests for parallel execution"
                           circleci tests glob "\$glob_path" | circleci tests split --split-by=name | tee tc.list
                           echo "[debug] Remove tests that are not in the list"
-                          find \$base_dir/\$TEST_SUITE/_* -maxdepth 0 -type d -print0 | grep -vzZ -f tc.list | xargs -0 rm -rf
+                          find \$base_dir/\$TEST_SUITE/_* -maxdepth 0 -type d -print0 | grep -vzZ -f tc.list | xargs -0 rm -rvf
                         fi
 
                         echo "[debug] Run the tests"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,8 @@ jobs:
                           shell)
                             base_dir="cubrid-testcases-private-ex"
                             rm -rf \$base_dir/shell/_25_unstable
-                            glob_path="\$(find \$base_dir/shell/_* -type f -path "*/*/cases/*.sh" | grep -P '/([^/]+)/cases/\1\.sh\$')"
+                            #glob_path="\$(find \$base_dir/shell/_* -type f -path "*/*/cases/*.sh" | grep -P '/([^/]+)/cases/\1\.sh\$')"
+                            glob_path="\$base_dir/\$TEST_SUITE/_*/**/cases/*.sh"
                             ;;
                           *)
                             base_dir="cubrid-testcases"
@@ -122,13 +123,15 @@ jobs:
                         esac
 
                         echo "[debug] split tests for parallel execution"
-                        circleci tests glob "\$glob_path" | sed "s|^\$base_dir/||" | circleci tests split --split-by=name | tee tc.list
+                        # circleci tests glob "\$glob_path" | sed "s|^\$base_dir/||" | grep -P '/([^/]+)/cases/\1\.sh$' | circleci tests split --split-by=name | tee tc.list
                  
                         echo "[debug] Remove tests that are not in the list"
                         if [ "\$TEST_SUITE" = "shell" ]; then
-                          cat tc.list | xargs -n1 dirname | uniq> tc_dirs.list
+                          circleci tests glob "\$glob_path" | sed "s|^\$base_dir/||" | grep -P '/([^/]+)/cases/\1\.sh$' | circleci tests split --split-by=name | tee tc.list
+                          cat tc.list | xargs -n1 dirname > tc_dirs.list
                           find \$base_dir -name "cases" -type d| grep -v -f tc_dirs.list | xargs -r rm -rf
                         else
+                          circleci tests glob "\$glob_path" | sed "s|^\$base_dir/||" | circleci tests split --split-by=name | tee tc.list
                           find \$base_dir -name "*.sql" -type f | grep -v -f tc.list | xargs -r rm -rf
                         fi
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1274>

### Purpose
병렬수행을 위한 기능인 'circleci test split' 에 사용되는 'circleci test glob "PATTERN" ' 사용시 패턴 매칭 실패 버그 수정.

### Implementation
sql 테스트 케이스 특성상 .sql 파일 이외에 .queryPlan 파일이 지워지면 정상수행이 안되는 문제 발생.
sql 은 이전 로직으로 원복.
shell 은 향후 split by timing 기능 사용을 위해 세분화된 테스트케이스 패턴 매칭 사용.

### Remarks

N/A
