### PR TITLE
[CBRD-26026] perf: Reduce sizeof DB_VALUE by 8 bytes (2nd trial)

### DIFF
--- a/src/compat/dbtype_def.h
+++ b/src/compat/dbtype_def.h
@@ -1020,8 +1020,8 @@ extern "C"
       unsigned char compressed_need_clear;
       int size;
       const char *buf;
-      int compressed_size;
       char *compressed_buf;
+      int compressed_size;
       int length;		/* Only Use for group_concat() now */
     } medium;
     struct


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26026

Reverts CUBRID/cubrid#6132

해당 이슈는 모든 리뷰를 통과했으나, figcake에 잘못 반영이 되어 Revert 된 

https://github.com/CUBRID/cubrid/pull/6119

위 PR을 guava에 재반영하는 PR입니다.

자세한 내용은

https://github.com/CUBRID/cubrid/pull/6119

위 PR의 설명을 참고 바랍니다.

---

현재 test_shell 통과하지 못한 사유로 hold