### PR TITLE
[CUBVEC-78] Fix segfault when inserting into a table with a vector index during loaddb exeuction in CS mode

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -7004,7 +7004,11 @@ heap_scancache_start_modify (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cach
 	  /* initialize the structure */
 	  for (i = 0; i < scan_cache->num_btids; i++)
 	    {
-	      scan_cache->m_index_stats->add_empty (classrepr->indexes[i].btid);
+	      // TODO (CUBVEC): refactor this code
+	      if (!BTID_IS_VECTOR_INDEX (&index->btid))
+		{
+		  scan_cache->m_index_stats->add_empty (classrepr->indexes[i].btid);
+		}
 	    }
 	}
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -7005,7 +7005,7 @@ heap_scancache_start_modify (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cach
 	  for (i = 0; i < scan_cache->num_btids; i++)
 	    {
 	      // TODO (CUBVEC): refactor this code
-	      if (!BTID_IS_VECTOR_INDEX (&index->btid))
+	      if (!BTID_IS_VECTOR_INDEX (&classrepr->indexes[i].btid))
 		{
 		  scan_cache->m_index_stats->add_empty (classrepr->indexes[i].btid);
 		}

--- a/src/storage/hnsw.cpp
+++ b/src/storage/hnsw.cpp
@@ -37,6 +37,7 @@ std::unordered_map<int, std::unique_ptr<faiss::IndexIDMap>> hnsw_index_map;
 
 static faiss::idx_t encode_oid (const OID &oid);
 //static OID decode_oid (faiss::idx_t encoded_oid);
+static std::mutex hnsw_elem_mutex;
 
 BTID *
 xhnsw_add_index (THREAD_ENTRY *thread_p, BTID *btid, int dimension = 10, int hnsw_M = 128, int hnsw_efConstruction = 40,
@@ -119,7 +120,8 @@ int hnsw_print_index_info (BTID *btid)
   return NO_ERROR;
 }
 
-int hnsw_add_element (BTID *btid, OID *oid, DB_VALUE *key_dbvalue)
+int
+hnsw_add_element (BTID *btid, OID *oid, DB_VALUE *key_dbvalue)
 {
   std::vector<float> fvec;
   int hnsw_id;
@@ -144,6 +146,8 @@ int hnsw_add_element (BTID *btid, OID *oid, DB_VALUE *key_dbvalue)
     }
 
   std::unique_ptr<faiss::IndexIDMap> &index = it->second;
+
+  std::lock_guard<std::mutex> lock (hnsw_elem_mutex);
 
   index->add_with_ids (1, fvec.data(), &encoded_oid);
   er_log_debug (ARG_FILE_LINE, "Added element with ID %lld to HNSW Index.", static_cast<long long> (encoded_oid));

--- a/src/storage/storage_common.h
+++ b/src/storage/storage_common.h
@@ -316,7 +316,7 @@ struct lorecdes
   (((b1)->vfid.fileid == (b2)->vfid.fileid) && \
    ((b1)->vfid.volid == (b2)->vfid.volid))
 
-#define BTID_IS_VECTOR_INDEX(btid)  ((btid)->vfid.volid == -1)
+#define BTID_IS_VECTOR_INDEX(btid)  ((btid)->vfid.volid == NULL_VOLID)
 
 #define DISK_VOLPURPOSE DB_VOLPURPOSE
 

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -7904,7 +7904,12 @@ locator_add_or_remove_index_internal (THREAD_ENTRY * thread_p, RECDES * recdes, 
 	      if (op_type == MULTI_ROW_UPDATE || op_type == MULTI_ROW_INSERT || op_type == MULTI_ROW_DELETE)
 		{
 		  assert (scan_cache->m_index_stats != NULL);
-		  unique_stat_info = &scan_cache->m_index_stats->get_stats_of (index->btid);
+
+		  // TODO (CUBVEC): refactor this code
+		  if (!BTID_IS_VECTOR_INDEX (&index->btid))
+		    {
+		      unique_stat_info = &scan_cache->m_index_stats->get_stats_of (index->btid);
+		    }
 		}
 	      else
 		{
@@ -8540,7 +8545,11 @@ locator_update_index (THREAD_ENTRY * thread_p, RECDES * new_recdes, RECDES * old
 	  if (op_type == MULTI_ROW_UPDATE || op_type == MULTI_ROW_INSERT || op_type == MULTI_ROW_DELETE)
 	    {
 	      assert (scan_cache->m_index_stats != NULL);
-	      unique_stat_info = &scan_cache->m_index_stats->get_stats_of (index->btid);
+	      // TODO (CUBVEC): refactor this code
+	      if (!BTID_IS_VECTOR_INDEX (&index->btid))
+		{
+		  unique_stat_info = &scan_cache->m_index_stats->get_stats_of (index->btid);
+		}
 	    }
 	  else
 	    {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-78

### Purpose

CS 모드로 loaddb 수행 시 MULTI_ROW_INSERT 가 되며 여러 스레드가 동시에 데이터를 입력한다. 이 때 발생할 수 있는 segfault를 수정한다. CS 모드에서 동시에 입력하지 않으면 실험을 위한 벡터 데이터의 ROW 수가 아주 많고 용량이 크기 때문에 실험 준비를 위해 필요한 시간이 매우 크므로, 생산성을 위해 간단한 패치로 동시 입력 수행이 가능하도록 한다.

### Implementation

- add_with_ids () 함수가 thread-safe 하지 않으므로 mutex 선언 후 lock_guard로 보호
- m_index_stats 객체 사용 시 BTID가 NULL인 경우는 벡터 인덱스이므로, btree unique에 대한 stat을 기록하는 이 객체는 사용하지 않도록 우회

### Remarks

N/A
