### PR TITLE
[CBRD-26059] Remove comments about server information from the rewritten string of a DBLINK query

### DIFF
--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -965,7 +965,8 @@ enum pt_custom_print
   PT_PRINT_SUPPRESS_SERIAL_CONV = (0x1 << 26),
   /* suppress print various generated functions including suppress delete targe for dblink */
   PT_PRINT_SUPPRESS_FOR_DBLINK = (0x1 << 27),
-  PT_PRINT_HOST_VAR_COUNT = (0x1 << 28)
+  PT_PRINT_HOST_VAR_COUNT = (0x1 << 28),
+  PT_PRINT_DBLINK_INFO = (0x1 << 29)	/* If you use DBLINK, specify it when generating the SHA hash value. */
 };
 
 /* all statement node types should be assigned their API statement enumeration */
@@ -3998,6 +3999,7 @@ struct parser_context
   REMOTE_COLS *dblink_remote;	/* for dblink, remote column list */
 
   HIDE_PWD_INFO hide_pwd_info;
+  PARSER_VARCHAR *dblink_server_text;	/* Contains access information to be used in generating SHA hash values ​​when using the Server name in DBLINK. */
 
   struct
   {

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -2705,6 +2705,41 @@ pt_print_alias (PARSER_CONTEXT * parser, const PT_NODE * node)
   return NULL;
 }
 
+
+static PARSER_VARCHAR *
+pt_conv_server_2_hash_text (PARSER_CONTEXT * parser)
+{
+  unsigned int hash1 = 5381;
+  unsigned int hash2 = 5381;
+  unsigned char *s, *ps;
+  char buf[64];
+
+  assert (parser->dblink_server_text != NULL);
+  assert (parser->dblink_server_text->bytes != NULL);
+
+  ps = parser->dblink_server_text->bytes;
+  if (!ps || *ps == '\0')
+    {
+      return NULL;
+    }
+
+  // original
+  for (s = ps; *s; ++s)
+    {
+      hash1 = ((hash1 << 5) + hash1) + *s;	/* hash * 33 + c */
+    }
+
+  // reverse 
+  for (s--; s >= ps; s--)
+    {
+      hash2 = ((hash2 << 5) - hash2) + *s;	/* hash * 31 + c */
+    }
+
+  sprintf (buf, "%u,%u", hash1, hash2);
+
+  return pt_append_nulstring (parser, NULL, buf);
+}
+
 /*
  * parser_print_tree() -
  *   return:
@@ -2770,7 +2805,7 @@ parser_print_tree (PARSER_CONTEXT * parser, const PT_NODE * node)
       if ((parser->custom_print & PT_PRINT_DBLINK_INFO) && parser->dblink_server_text)
 	{
 	  string = pt_append_nulstring (parser, string, ";remote={");
-	  string = pt_append_varchar (parser, string, parser->dblink_server_text);
+	  string = pt_append_varchar (parser, string, pt_conv_server_2_hash_text (parser));
 	  string = pt_append_bytes (parser, string, "}", 1);
 	  parser->dblink_server_text = NULL;
 	}

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -2724,6 +2724,7 @@ parser_print_tree (PARSER_CONTEXT * parser, const PT_NODE * node)
   PARSER_VARCHAR *string;
   char user_text_buffer[PT_QUERY_STRING_USER_TEXT];
 
+  assert (parser->dblink_server_text == NULL);
   string = pt_print_bytes (parser, node);
   if (string)
     {
@@ -2765,6 +2766,15 @@ parser_print_tree (PARSER_CONTEXT * parser, const PT_NODE * node)
 	  string = pt_append_nulstring (parser, string, ";bind_var_cnt=");
 	  string = pt_append_nulstring (parser, string, host_var_count);
 	}
+
+      if ((parser->custom_print & PT_PRINT_DBLINK_INFO) && parser->dblink_server_text)
+	{
+	  string = pt_append_nulstring (parser, string, ";remote={");
+	  string = pt_append_varchar (parser, string, parser->dblink_server_text);
+	  string = pt_append_bytes (parser, string, "}", 1);
+	  parser->dblink_server_text = NULL;
+	}
+
       return (char *) string->bytes;
     }
   return NULL;
@@ -19206,9 +19216,61 @@ pt_apply_dblink_table (PARSER_CONTEXT * parser, PT_NODE * p, void *arg)
 }
 
 static PARSER_VARCHAR *
+pt_print_remote_info (PARSER_CONTEXT * parser, PT_DBLINK_INFO * pt, bool is_dml)
+{
+  PARSER_VARCHAR *var = 0;
+  char *t, *s;
+
+  var = pt_append_bytes (parser, var, "'", 1);
+
+  // "cci:CUBRID:{HOST}:{PORT}:{DBNAME}:<user-name>:<password>:{PROPERITIES}"
+  s = (char *) pt->url->info.value.data_value.str->bytes;
+  // skip cci:
+  s = strchr (s, ':');
+  // skip CUBRID:
+  s = strchr (s + 1, ':');
+
+  t = ++s;
+  // host           
+  s = strchr (s, ':');
+  // port           
+  s = strchr (s + 1, ':');
+  // dbname           
+  s = strchr (s + 1, ':');
+  var = pt_append_bytes (parser, var, t, (int) (s - t));
+  t = s + 2;
+
+  var = pt_append_nulstring (parser, var, ":");
+  var =
+    pt_append_bytes (parser, var, (char *) pt->user->info.value.data_value.str->bytes,
+		     pt->user->info.value.data_value.str->length);
+  var = pt_append_nulstring (parser, var, ":");
+
+  if (pt->is_name || is_dml)
+    {
+      var = pt_append_nulstring (parser, var, "*");
+    }
+  else
+    {
+      var = pt_append_bytes (parser, var, (char *) pt->pwd->info.value.data_value.str->bytes,
+			     pt->pwd->info.value.data_value.str->length);
+    }
+
+  // properties
+  if (!is_dml)
+    {
+      var = pt_append_nulstring (parser, var, t);
+    }
+
+  var = pt_append_bytes (parser, var, "'", 1);
+
+  return var;
+}
+
+static PARSER_VARCHAR *
 pt_print_dblink_table (PARSER_CONTEXT * parser, PT_NODE * p)
 {
-  PARSER_VARCHAR *q = 0, *r;
+  PARSER_VARCHAR *q = 0, *var = 0, *r;
   PT_DBLINK_INFO *pt = &(p->info.dblink_table);
   bool print_detail = true;
 
@@ -19225,7 +19287,7 @@ pt_print_dblink_table (PARSER_CONTEXT * parser, PT_NODE * p)
       r = pt_print_bytes (parser, p->info.dblink_table.conn);
       q = pt_append_varchar (parser, q, r);
 
-      if (!pt->url || !pt->user || !pt->pwd)
+      if (((parser->custom_print & PT_PRINT_DBLINK_INFO) == 0) || !pt->url || !pt->user || !pt->pwd)
 	{
 	  print_detail = false;
 	}
@@ -19234,58 +19296,32 @@ pt_print_dblink_table (PARSER_CONTEXT * parser, PT_NODE * p)
 	  /* For Query-cache:
 	   * Separate comments have been added 
 	   * for cases where there is no change in the query but information on the server has changed. */
-	  q = pt_append_bytes (parser, q, " /* ", 4);
 	}
     }
 
   if (print_detail)
     {
-      q = pt_append_bytes (parser, q, "'", 1);
+      var = pt_print_remote_info (parser, pt, false);
+    }
 
-      char *t, *s;
-
-      // "cci:CUBRID:{HOST}:{PORT}:{DBNAME}:<user-name>:<password>:{PROPERITIES}"
-      s = (char *) pt->url->info.value.data_value.str->bytes;
-      // skip cci:
-      s = strchr (s, ':');
-      // skip CUBRID:
-      s = strchr (s + 1, ':');
-
-      t = ++s;
-      // host           
-      s = strchr (s, ':');
-      // port           
-      s = strchr (s + 1, ':');
-      // dbname           
-      s = strchr (s + 1, ':');
-      q = pt_append_bytes (parser, q, t, (int) (s - t));
-      t = s + 2;
-
-      q = pt_append_nulstring (parser, q, ":");
-      q =
-	pt_append_bytes (parser, q, (char *) pt->user->info.value.data_value.str->bytes,
-			 pt->user->info.value.data_value.str->length);
-      q = pt_append_nulstring (parser, q, ":");
-
-      if (p->info.dblink_table.is_name)
+  if ((parser->custom_print & PT_PRINT_DBLINK_INFO) == 0)
+    {
+      q = pt_append_varchar (parser, q, var);
+    }
+  else
+    {
+      if (parser->dblink_server_text == NULL)
 	{
-	  q = pt_append_nulstring (parser, q, "*");
+	  parser->dblink_server_text = var;
 	}
       else
 	{
-	  q = pt_append_bytes (parser, q, (char *) pt->pwd->info.value.data_value.str->bytes,
-			       pt->pwd->info.value.data_value.str->length);
+	  if (var)
+	    {
+	      parser->dblink_server_text = pt_append_nulstring (parser, parser->dblink_server_text, ",");
+	    }
+	  parser->dblink_server_text = pt_append_varchar (parser, parser->dblink_server_text, var);
 	}
-
-      // properties
-      q = pt_append_nulstring (parser, q, t);
-
-      q = pt_append_bytes (parser, q, "'", 1);
-    }
-
-  if (p->info.dblink_table.is_name && print_detail)
-    {
-      q = pt_append_bytes (parser, q, " */ ", 4);
     }
 
   q = pt_append_bytes (parser, q, ", ", 2);
@@ -19328,44 +19364,23 @@ pt_print_dblink_table_dml (PARSER_CONTEXT * parser, PT_NODE * p)
   /* For Query-cache:
    * Separate comments have been added 
    * for cases where there is no change in the query but information on the server has changed. */
-  q = pt_append_nulstring (parser, q, " /* DBLINK(");
-
-  if (pt->url && pt->user && pt->pwd)
+  if ((parser->custom_print & PT_PRINT_DBLINK_INFO) && (pt->url && pt->user && pt->pwd))
     {
-      q = pt_append_bytes (parser, q, "'", 1);
+      PARSER_VARCHAR *var = pt_print_remote_info (parser, pt, true);
 
-      char *t, *s;
-
-      // "cci:CUBRID:{HOST}:{PORT}:{DBNAME}:<user-name>:<password>:{PROPERITIES}"
-      s = (char *) pt->url->info.value.data_value.str->bytes;
-      // skip cci:
-      s = strchr (s, ':');
-      // skip CUBRID:
-      s = strchr (s + 1, ':');
-
-      t = ++s;
-      // host           
-      s = strchr (s, ':');
-      // port           
-      s = strchr (s + 1, ':');
-      // dbname           
-      s = strchr (s + 1, ':');
-      q = pt_append_bytes (parser, q, t, (int) (s - t));
-      t = s + 2;
-      // user
-      q = pt_append_nulstring (parser, q, ":");
-      q = pt_append_bytes (parser, q, (char *) pt->user->info.value.data_value.str->bytes,
-			   pt->user->info.value.data_value.str->length);
-      // password                           
-      q = pt_append_nulstring (parser, q, ":");
-      q = pt_append_nulstring (parser, q, "*");
-      // properties
-      //q = pt_append_nulstring (parser, q, t);
-
-      q = pt_append_bytes (parser, q, "'", 1);
+      if (parser->dblink_server_text == NULL)
+	{
+	  parser->dblink_server_text = var;
+	}
+      else
+	{
+	  if (var)
+	    {
+	      parser->dblink_server_text = pt_append_nulstring (parser, parser->dblink_server_text, ",");
+	    }
+	  parser->dblink_server_text = pt_append_varchar (parser, parser->dblink_server_text, var);
+	}
     }
-
-  q = pt_append_bytes (parser, q, ") */ ", 5);
 
   return q;
 }

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -100,6 +100,8 @@
 #define DB_SERIAL_MIN "-99999999999999999999999999999999999999"
 
 #define UNIQUE_SAVEPOINT_ALTER_TRIGGER "aLTERtRIGGER"
+
+#define CUSTOM_PRINT_4_SHA_COMPUTE (PT_CONVERT_RANGE | PT_PRINT_QUOTES | PT_PRINT_USER | PT_PRINT_HOST_VAR_COUNT | PT_PRINT_DBLINK_INFO)
 /*
  * Function Group:
  * Do create/alter/drop serial statement
@@ -9308,8 +9310,7 @@ do_prepare_update (PARSER_CONTEXT * parser, PT_NODE * statement)
 	  parser->flag.dont_prt_long_string = 1;
 	  parser->flag.long_string_skipped = 0;
 	  parser->flag.print_type_ambiguity = 0;
-	  PT_NODE_PRINT_TO_ALIAS (parser, statement,
-				  (PT_CONVERT_RANGE | PT_PRINT_QUOTES | PT_PRINT_USER | PT_PRINT_HOST_VAR_COUNT));
+	  PT_NODE_PRINT_TO_ALIAS (parser, statement, CUSTOM_PRINT_4_SHA_COMPUTE);
 	  contextp->sql_hash_text = (char *) statement->alias_print;
 	  err =
 	    SHA1Compute ((unsigned char *) contextp->sql_hash_text, (unsigned) strlen (contextp->sql_hash_text),
@@ -10672,8 +10673,7 @@ do_prepare_delete (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * paren
 	  parser->flag.dont_prt_long_string = 1;
 	  parser->flag.long_string_skipped = 0;
 	  parser->flag.print_type_ambiguity = 0;
-	  PT_NODE_PRINT_TO_ALIAS (parser, statement,
-				  (PT_CONVERT_RANGE | PT_PRINT_QUOTES | PT_PRINT_USER | PT_PRINT_HOST_VAR_COUNT));
+	  PT_NODE_PRINT_TO_ALIAS (parser, statement, CUSTOM_PRINT_4_SHA_COMPUTE);
 	  contextp->sql_hash_text = (char *) statement->alias_print;
 	  err =
 	    SHA1Compute ((unsigned char *) contextp->sql_hash_text, (unsigned) strlen (contextp->sql_hash_text),
@@ -11320,8 +11320,7 @@ do_prepare_insert_internal (PARSER_CONTEXT * parser, PT_NODE * statement)
   parser->flag.dont_prt_long_string = 1;
   parser->flag.long_string_skipped = 0;
   parser->flag.print_type_ambiguity = 0;
-  PT_NODE_PRINT_TO_ALIAS (parser, statement,
-			  (PT_CONVERT_RANGE | PT_PRINT_QUOTES | PT_PRINT_USER | PT_PRINT_HOST_VAR_COUNT));
+  PT_NODE_PRINT_TO_ALIAS (parser, statement, CUSTOM_PRINT_4_SHA_COMPUTE);
   contextp->sql_hash_text = (char *) statement->alias_print;
   error =
     SHA1Compute ((unsigned char *) contextp->sql_hash_text, (unsigned) strlen (contextp->sql_hash_text),
@@ -14537,9 +14536,7 @@ do_prepare_select (PARSER_CONTEXT * parser, PT_NODE * statement)
   parser->flag.long_string_skipped = 0;
   parser->flag.print_type_ambiguity = 0;
 
-  PT_NODE_PRINT_TO_ALIAS (parser, statement,
-			  (PT_CONVERT_RANGE | PT_PRINT_QUOTES | PT_PRINT_DIFFERENT_SYSTEM_PARAMETERS | PT_PRINT_USER |
-			   PT_PRINT_HOST_VAR_COUNT));
+  PT_NODE_PRINT_TO_ALIAS (parser, statement, (CUSTOM_PRINT_4_SHA_COMPUTE | PT_PRINT_DIFFERENT_SYSTEM_PARAMETERS));
 
   contextp->sql_hash_text = (char *) statement->alias_print;
   err =
@@ -17542,8 +17539,7 @@ do_prepare_merge (PARSER_CONTEXT * parser, PT_NODE * statement)
       parser->flag.dont_prt_long_string = 1;
       parser->flag.long_string_skipped = 0;
       parser->flag.print_type_ambiguity = 0;
-      PT_NODE_PRINT_TO_ALIAS (parser, statement,
-			      (PT_CONVERT_RANGE | PT_PRINT_QUOTES | PT_PRINT_USER | PT_PRINT_HOST_VAR_COUNT));
+      PT_NODE_PRINT_TO_ALIAS (parser, statement, CUSTOM_PRINT_4_SHA_COMPUTE);
       contextp->sql_hash_text = (char *) statement->alias_print;
       err = SHA1Compute ((unsigned char *) contextp->sql_hash_text, (unsigned) strlen (contextp->sql_hash_text),
 			 &contextp->sha1);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26059>

### Purpose

- 쿼리에 SERVER명을 사용했을 때 dblink 접속 정보가 노출되지 않도록 숨긴다 
- query plan과 같은 rewritten query string을 얻을 때 접속 정보를 보여주지 않도록 한다.
- XASL 캐쉬를 조회 할 때 해당 정보를 사용했었기에, plan dump에서도 노출되지 않도록 해쉬를 이용해서 가독성을 없앤다.

### Implementation

N/A

### Remarks

N/A
