### PR TITLE
[CBRD-26039] Backport from develop to 11.4 - fix error that occurs when inserting NULL using setNull() method in jdbc

### DIFF
--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -1314,13 +1314,13 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
       {
 	char *value;
 	int val_size;
-	SQLLEN cbValue = SQL_NULL_DATA;
 
 	net_arg_get_str (&value, &val_size, net_value);
 
-	c_data_type = SQL_C_CHAR;
-	sql_bind_type = SQL_VARCHAR;
+	c_data_type = SQL_C_WCHAR;
+	sql_bind_type = SQL_WVARCHAR;
 
+	value_list->cbValue = SQL_NULL_DATA;
 	value_list->string_val = value;
 
 	SQL_CHK_ERR (handle->hstmt,
@@ -1329,7 +1329,8 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 						  bind_num,
 						  SQL_PARAM_INPUT,
 						  c_data_type,
-						  sql_bind_type, val_size + 1, 0, value_list->string_val, 0, &cbValue));
+						  sql_bind_type, val_size + 1, 0, value_list->string_val, 0,
+						  &value_list->cbValue));
       }
       break;
 

--- a/src/broker/cas_cgw.h
+++ b/src/broker/cas_cgw.h
@@ -125,6 +125,8 @@ struct odbc_bind_info
 {
   char *string_val;
   wchar_t *wchar_val;
+  SQLLEN cbValue;
+
   SQLSMALLINT smallInt_val;
   SQLINTEGER integer_val;
   SQLREAL real_val;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26039

Purpose
JDBC에서 setNull() 메서드로 컬럼에 null 추가 할 수 있다. gateway에서는 SQLBindParameter() 함수를 이용하여 null  추가 할수 있으나, 이 함수의 마지막 파라메터인 pcbValue 에 로컬 변수를 지정하여 에러가 발생함.

Implementation
pcbValue 파라메터에 전역 변수를 할당 하도록 변경함

Remarks