### PR TITLE
[CBRD-25905] fix buffer size on locator_fetch_all function

### DIFF
--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -401,7 +401,7 @@ locator_fetch_all (const HFID * hfid, LOCK * lock, LC_FETCH_VERSION_TYPE fetch_v
   char *ptr;
   int return_value = ER_FAILED;
   int client_endian = (int) get_endian_type ();
-  OR_ALIGNED_BUF (OR_HFID_SIZE + (OR_INT_SIZE * 5) + (OR_OID_SIZE * 2)) a_request;
+  OR_ALIGNED_BUF (OR_HFID_SIZE + (OR_INT_SIZE * 6) + (OR_OID_SIZE * 2)) a_request;
   char *request;
   OR_ALIGNED_BUF (NET_COPY_AREA_SENDRECV_SIZE + (OR_INT_SIZE * 5) + OR_OID_SIZE) a_reply;
   char *reply;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-25905>

### Purpose

N/A

### Implementation

N/A

### Remarks
추가된 정보가 2개인데, 버퍼의 크기를 잡을 때는 한 개만 더 추가된 것으로 수정된 것이 문제였습니다.

