### PR TITLE
Revert - The phenomenon that position numbers within the analytic function become incorrect occurs when the analytic function is included in the view (#5590)

### DIFF
--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -238,6 +238,7 @@ static PT_NODE *pt_check_vclass_union_spec (PARSER_CONTEXT * parser, PT_NODE * q
 static int pt_check_group_concat_order_by (PARSER_CONTEXT * parser, PT_NODE * func);
 static bool pt_has_parameters (PARSER_CONTEXT * parser, PT_NODE * stmt);
 static PT_NODE *pt_is_parameter_node (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);
+static PT_NODE *pt_resolve_sort_spec_expr (PARSER_CONTEXT * parser, PT_NODE * sort_spec, PT_NODE * select_list);
 static bool pt_compare_sort_spec_expr (PARSER_CONTEXT * parser, PT_NODE * expr1, PT_NODE * expr2);
 static PT_NODE *pt_find_matching_sort_spec (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * spec_list,
 					    PT_NODE * select_list);
@@ -14283,7 +14284,7 @@ pt_is_parameter_node (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *c
  *  sort_spec(in): PT_SORT_SPEC node whose expression must be resolved
  *  select_list(in): statement's select list for PT_VALUE lookup
  */
-PT_NODE *
+static PT_NODE *
 pt_resolve_sort_spec_expr (PARSER_CONTEXT * parser, PT_NODE * sort_spec, PT_NODE * select_list)
 {
   PT_NODE *expr, *resolved;

--- a/src/parser/semantic_check.h
+++ b/src/parser/semantic_check.h
@@ -74,6 +74,4 @@ extern STATEMENT_SET_FOLD pt_check_union_is_foldable (PARSER_CONTEXT * parser, P
 
 extern PT_NODE *pt_fold_union (PARSER_CONTEXT * parser, PT_NODE * union_node, STATEMENT_SET_FOLD fold_as);
 
-extern PT_NODE *pt_resolve_sort_spec_expr (PARSER_CONTEXT * parser, PT_NODE * sort_spec, PT_NODE * select_list);
-
 #endif /* _SEMANTIC_CHECK_H_ */

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -378,8 +378,6 @@ static PT_NODE *mq_replace_virtual_oid_with_real_oid (PARSER_CONTEXT * parser, P
 
 static void mq_copy_view_error_msgs (PARSER_CONTEXT * parser, PARSER_CONTEXT * query_cache);
 
-static PT_NODE *mq_update_analytic_sort_spec_expr (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * old_attrs);
-
 /*
  * mq_is_outer_join_spec () - determine if a spec is outer joined in a spec list
  *  returns: boolean
@@ -1613,7 +1611,6 @@ mq_substitute_subquery_in_statement (PARSER_CONTEXT * parser, PT_NODE * statemen
   PT_NODE *tmp_result, *result, *arg1, *arg2, *statement_next;
   PT_NODE *class_spec, *statement_spec = NULL;
   PT_NODE *derived_table, *derived_spec, *derived_class;
-  PT_NODE *attributes;
   bool is_pushable_query, is_outer_joined;
   bool is_only_spec, rewrite_as_derived;
   bool is_index_ss, is_index_ls;
@@ -1816,28 +1813,6 @@ mq_substitute_subquery_in_statement (PARSER_CONTEXT * parser, PT_NODE * statemen
 	  if (derived_table == NULL)
 	    {			/* error */
 	      goto exit_on_error;
-	    }
-
-	  if (pt_has_analytic (parser, derived_table))
-	    {
-	      attributes = mq_fetch_attributes (parser, class_);
-	      if (attributes == NULL)
-		{
-		  goto exit_on_error;
-		}
-
-	      /* exclude the first oid attr */
-	      if (attributes->type_enum == PT_TYPE_OBJECT)
-		{
-		  attributes = attributes->next;	/* skip oid attr */
-		}
-
-	      derived_table->info.query.q.select.list =
-		mq_update_analytic_sort_spec_expr (parser, class_spec, attributes);
-	      if (derived_table->info.query.q.select.list == NULL)
-		{		/* error */
-		  goto exit_on_error;
-		}
 	    }
 
 	  if (PT_IS_QUERY (derived_table))
@@ -11871,92 +11846,4 @@ mq_copy_view_error_msgs (PARSER_CONTEXT * parser, PARSER_CONTEXT * query_cache)
   error_msg = pt_get_next_error (error_msg, &stmt_no, &line_no, &col_no, &msg);
 
   pt_record_error (parser, stmt_no, line_no, col_no, msg, NULL);
-}
-
-/*
- * mq_update_analytic_sort_spec_expr() - update PT_VALUE located within the OVER clause of the analytic function.
- *   return:
- *   parser(in):
- *   spec(in): 
- *   class_(in):
- * 
- * NOTE: After calling mq_rewrite_vclass_spec_as_derived(), the order of nodes in the select list may change.
- * When analytic functions are included, query results can vary based on the order of nodes in the select list.
- * Therefore, it is necessary to update the sort_spec expression of the analytic functions.
- */
-static PT_NODE *
-mq_update_analytic_sort_spec_expr (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * old_attrs)
-{
-  PT_NODE *partition_by, *order_by;
-  PT_NODE *col, *link, *order_list, *order, *value;
-  PT_NODE *derived_table, *new_attrs;
-
-  derived_table = spec->info.spec.derived_table;
-  new_attrs = spec->info.spec.as_attr_list;
-
-  for (col = derived_table->info.query.q.select.list; col; col = col->next)
-    {
-      if (PT_IS_ANALYTIC_NODE (col))
-	{
-	  partition_by = col->info.function.analytic.partition_by;
-	  order_by = col->info.function.analytic.order_by;
-
-	  /* link partition and order lists together */
-	  for (link = partition_by; link && link->next; link = link->next)
-	    {
-	      ;			/* move link to the last node of partition_by list */
-	    }
-	  if (link)
-	    {
-	      order_list = partition_by;
-	      link->next = order_by;
-	    }
-	  else
-	    {
-	      order_list = order_by;
-	    }
-
-	  for (order = order_list; order; order = order->next)
-	    {
-	      PT_NODE *old_attr, *new_attr;
-	      int index;
-
-	      if (!PT_IS_VALUE_NODE (order->info.sort_spec.expr))
-		{
-		  continue;
-		}
-
-	      value = order->info.sort_spec.expr;
-	      /* retrieve the order-th node from the old_attrs */
-	      old_attr = pt_resolve_sort_spec_expr (parser, order, old_attrs);
-	      if (old_attr == NULL)
-		{
-		  assert (false);
-		  return NULL;
-		}
-
-	      /* find the position of sort_spec expr in the new_attrs and update it with that position number */
-	      for (new_attr = new_attrs, index = 1; new_attr; new_attr = new_attr->next, index++)
-		{
-		  if (pt_str_compare (old_attr->info.name.original, new_attr->info.name.original, CASE_INSENSITIVE) ==
-		      0)
-		    {
-		      value->info.value.data_value.i = index;
-		      order->info.sort_spec.pos_descr.pos_no = index;
-
-		      break;
-		    }
-		}
-	      assert (new_attr != NULL);
-	    }
-
-	  /* un-link */
-	  if (link)
-	    {
-	      link->next = NULL;
-	    }
-	}
-    }
-
-  return derived_table->info.query.q.select.list;
 }


### PR DESCRIPTION
Reverts CUBRID/cubrid#5985

http://jira.cubrid.org/browse/CBRD-25617

10.2 와 11.2 이후 버전에서의 원인이 다르기 때문에,  10.2에 백포트 되더라도 쿼리 결과의 차이가 없습니다.