### PR TITLE
[CBRD-26087] [Regression] Core dumped in qfile_reopen_list_as_append_mode at src/query/list_file.c:1348

### DIFF
--- a/src/query/parallel/px_heap_scan/px_heap_scan_manager.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_manager.cpp
@@ -538,7 +538,11 @@ scan_open_parallel_heap_scan (THREAD_ENTRY *thread_p, SCAN_ID *scan_id,
     }
   else
     {
-      qfile_reopen_list_as_append_mode (thread_p, xasl->list_id);
+      if (result_get_method == parallel_heap_scan::RESULT_GET_METHOD::LIST_MERGE && xasl->list_id->tfile_vfid != NULL
+	  && !VPID_ISNULL (&xasl->list_id->first_vpid))
+	{
+	  qfile_reopen_list_as_append_mode (thread_p, xasl->list_id);
+	}
     }
   return ret;
 }

--- a/src/query/parallel/px_heap_scan/px_heap_scan_manager.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_manager.cpp
@@ -539,7 +539,7 @@ scan_open_parallel_heap_scan (THREAD_ENTRY *thread_p, SCAN_ID *scan_id,
   else
     {
       if (result_get_method == parallel_heap_scan::RESULT_GET_METHOD::LIST_MERGE && xasl->list_id->tfile_vfid != NULL
-	  && !VPID_ISNULL (&xasl->list_id->first_vpid))
+	  )
 	{
 	  qfile_reopen_list_as_append_mode (thread_p, xasl->list_id);
 	}

--- a/src/query/parallel/px_heap_scan/px_heap_scan_manager.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_manager.cpp
@@ -539,7 +539,7 @@ scan_open_parallel_heap_scan (THREAD_ENTRY *thread_p, SCAN_ID *scan_id,
   else
     {
       if (result_get_method == parallel_heap_scan::RESULT_GET_METHOD::LIST_MERGE && xasl->list_id->tfile_vfid != NULL
-	  )
+	  && !VPID_ISNULL (&xasl->list_id->first_vpid))
 	{
 	  qfile_reopen_list_as_append_mode (thread_p, xasl->list_id);
 	}


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-XXXX>

### Purpose

reopen() 함수 내부에 list-id가 초기화되지 않은 경우 assert(0) 등이 발생해 debug 모드에서 core dump가 발생합니다. 이를 수정합니다.

### Implementation

list_id가 초기화 되지 않거나, mergable-list 방식이 아닌 경우 reopen 하지 않도록 변경합니다.

### Remarks

N/A
