### PR TITLE
[CBRD-26060] Refactor: simplify check_reinit_copylog logic

### DIFF
--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -8003,6 +8003,15 @@ la_destroy_repl_filter (void)
   return;
 }
 
+/* 
+ * check_reinit_copylog() - check if the copy log is reinitialized.
+ *   return: NO_ERROR or error code
+ *
+ * Note:
+ *   In copylogdb, the 'mark_will_del' flag in the log header is set
+ *   when an error occurs during log retrieval.
+ * 
+ */
 static int
 check_reinit_copylog (void)
 {

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -8006,24 +8006,16 @@ la_destroy_repl_filter (void)
 static int
 check_reinit_copylog (void)
 {
-  int error = NO_ERROR;
+	if (la_fetch_log_hdr(&la_Info.act_log) != NO_ERROR)
+		return ER_FAILED;
 
-  /* fetch header */
-  error = la_fetch_log_hdr (&la_Info.act_log);
-  if (error != NO_ERROR)
-    {
-      error = ER_FAILED;
-      return error;
-    }
+	if (la_Info.act_log.log_hdr->mark_will_del)
+	{
+		la_Info.reinit_copylog = true;
+		return ER_FAILED;
+	}
 
-  if (la_Info.act_log.log_hdr->mark_will_del == true)
-    {
-      la_Info.reinit_copylog = true;
-      error = ER_FAILED;
-      return error;
-    }
-
-  return error;
+	return NO_ERROR;
 }
 
 /*

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -8008,7 +8008,7 @@ la_destroy_repl_filter (void)
  *   return: NO_ERROR or error code
  *
  * Note:
- *   In copylogdb, the 'mark_will_del' flag in the log header is set
+ *   In copylogdb, the 'mark_will_del' flag in the act log header is set
  *   when an error occurs during log retrieval.
  * 
  */

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -8006,16 +8006,16 @@ la_destroy_repl_filter (void)
 static int
 check_reinit_copylog (void)
 {
-	if (la_fetch_log_hdr(&la_Info.act_log) != NO_ERROR)
-		return ER_FAILED;
+  if (la_fetch_log_hdr (&la_Info.act_log) != NO_ERROR)
+    return ER_FAILED;
 
-	if (la_Info.act_log.log_hdr->mark_will_del)
-	{
-		la_Info.reinit_copylog = true;
-		return ER_FAILED;
-	}
+  if (la_Info.act_log.log_hdr->mark_will_del)
+    {
+      la_Info.reinit_copylog = true;
+      return ER_FAILED;
+    }
 
-	return NO_ERROR;
+  return NO_ERROR;
 }
 
 /*

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -8016,10 +8016,10 @@ static int
 check_reinit_copylog (void)
 {
   if (la_fetch_log_hdr (&la_Info.act_log) != NO_ERROR)
-  {
-    return ER_FAILED;
-  }
-  
+    {
+      return ER_FAILED;
+    }
+
   if (la_Info.act_log.log_hdr->mark_will_del)
     {
       la_Info.reinit_copylog = true;

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -8016,8 +8016,10 @@ static int
 check_reinit_copylog (void)
 {
   if (la_fetch_log_hdr (&la_Info.act_log) != NO_ERROR)
+  {
     return ER_FAILED;
-
+  }
+  
   if (la_Info.act_log.log_hdr->mark_will_del)
     {
       la_Info.reinit_copylog = true;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26060>

### Purpose

check_reinit_copylog() 함수 리팩토링

### Implementation

함수 내에서 불필요한 변수 선언과 값 대입이 이뤄지고 있습니다. 
return 에 직접적으로 에러 값을 명시할 경우 불필요한 코드를 줄일 수 있습니다.

### Remarks

N/A
