### PR TITLE
[CUBVEC-66] Cosine Operator (<c>)

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -16983,7 +16983,12 @@ normal_expression
 ;
 
 expression_vector_distance
-	: expression_vector_distance DISTANCE_OP_EUCLIDEAN expression_strcat
+	: expression_vector_distance DISTANCE_OP_COSINE expression_strcat
+		{{
+			$$ = parser_make_expression (this_parser, PT_DISTANCE_OP_COSINE, $1, $3, NULL);
+			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
+		}}
+	| expression_vector_distance DISTANCE_OP_EUCLIDEAN expression_strcat
 		{{
 			$$ = parser_make_expression (this_parser, PT_DISTANCE_OP_EUCLIDEAN, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)

--- a/src/parser/csql_lexer.l
+++ b/src/parser/csql_lexer.l
@@ -1147,6 +1147,7 @@ IDL       [a-zA-Z0-9_]
 ">>"									{ begin_token(yytext);	 return BITSHIFT_RIGHT; }
 "%"									{ begin_token(yytext);	 return MOD; }
 "<=>"									{ begin_token(yytext);	 return COMP_NULLSAFE_EQ; }
+"<c>"									{ begin_token(yytext);	 return DISTANCE_OP_COSINE; }
 "<#>"									{ begin_token(yytext);	 return DISTANCE_OP_NEG_INNER_PROD; }
 "<+>"									{ begin_token(yytext);	 return DISTANCE_OP_MANHATTAN; }
 "<->"									{ begin_token(yytext);	 return DISTANCE_OP_EUCLIDEAN; }

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -4044,6 +4044,8 @@ pt_show_binopcode (PT_OP_TYPE n)
       return "schema_def";
     case PT_CONV_TZ:
       return "conv_tz";
+    case PT_DISTANCE_OP_COSINE:
+      return " <c> ";
     case PT_DISTANCE_OP_EUCLIDEAN:
       return " <-> ";
     default:

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -8435,9 +8435,10 @@ pt_is_operator_arith (PT_OP_TYPE op)
 {
   switch (op)
     {
+    case PT_DISTANCE_OP_COSINE:
     case PT_DISTANCE_OP_EUCLIDEAN:
       {
-	vimkim_log ("PT_DISTANCE_OP_EUCLIDEAN is arithmetic.");
+	vimkim_log ("PT_DISTANCE_OP_<vector metric> is arithmetic.");
 	return true;
       }
     case PT_PLUS:

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -1654,6 +1654,7 @@ pt_get_expression_definition (const PT_OP_TYPE op, EXPRESSION_DEFINITION * def)
       def->overloads_count = num;
       break;
 
+    case PT_DISTANCE_OP_COSINE:
     case PT_DISTANCE_OP_EUCLIDEAN:
       num = 0;
       vimkim_log ("op: %s\n", pt_show_binopcode (op));
@@ -10445,6 +10446,7 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
       node->type_enum = node->info.expr.arg1->type_enum;
       break;
 
+    case PT_DISTANCE_OP_COSINE:
     case PT_DISTANCE_OP_EUCLIDEAN:
       {
 	node->info.expr.arg1 = arg1;
@@ -12727,6 +12729,18 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 
   switch (op)
     {
+
+    case PT_DISTANCE_OP_COSINE:
+      {
+	DB_VALUE *arr[2] = { arg1, arg2 };
+	error = vector_cosine_distance (result, arr, 2);
+	if (error != NO_ERROR)
+	  {
+	    PT_ERRORc (parser, o1, er_msg ());
+	    return 0;
+	  }
+	break;
+      }
 
     case PT_DISTANCE_OP_EUCLIDEAN:
       {

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -7717,7 +7717,7 @@ pt_to_regu_variable (PARSER_CONTEXT * parser, PT_NODE * node, UNBOX unbox)
 		  || node->info.expr.op == PT_ADDTIME || node->info.expr.op == PT_DEFINE_VARIABLE
 		  || node->info.expr.op == PT_CHR || node->info.expr.op == PT_CLOB_TO_CHAR
 		  || node->info.expr.op == PT_INDEX_PREFIX || node->info.expr.op == PT_FROM_TZ
-		  || node->info.expr.op == PT_DISTANCE_OP_EUCLIDEAN)
+		  || node->info.expr.op == PT_DISTANCE_OP_COSINE || node->info.expr.op == PT_DISTANCE_OP_EUCLIDEAN)
 		{
 		  r1 = pt_to_regu_variable (parser, node->info.expr.arg1, unbox);
 		  if ((node->info.expr.op == PT_CONCAT) && node->info.expr.arg2 == NULL)
@@ -8123,10 +8123,6 @@ pt_to_regu_variable (PARSER_CONTEXT * parser, PT_NODE * node, UNBOX unbox)
 		  regu = pt_make_regu_arith (r1, r2, NULL, T_ADD, domain);
 		  break;
 
-		case PT_DISTANCE_OP_EUCLIDEAN:
-		  regu = pt_make_regu_arith (r1, r2, NULL, T_DISTANCE_OP_EUCLIDEAN, domain);
-		  break;
-
 		case PT_MINUS:
 		  regu = pt_make_regu_arith (r1, r2, NULL, T_SUB, domain);
 		  break;
@@ -8173,6 +8169,14 @@ pt_to_regu_variable (PARSER_CONTEXT * parser, PT_NODE * node, UNBOX unbox)
 
 		case PT_MOD:
 		  regu = pt_make_regu_arith (r1, r2, NULL, T_INTMOD, domain);
+		  break;
+
+		case PT_DISTANCE_OP_COSINE:
+		  regu = pt_make_regu_arith (r1, r2, NULL, T_DISTANCE_OP_COSINE, domain);
+		  break;
+
+		case PT_DISTANCE_OP_EUCLIDEAN:
+		  regu = pt_make_regu_arith (r1, r2, NULL, T_DISTANCE_OP_EUCLIDEAN, domain);
 		  break;
 
 		case PT_IF:

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -183,6 +183,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, val_descr *
     case T_MUL:
     case T_DIV:
     case T_MOD:
+    case T_DISTANCE_OP_COSINE:
     case T_DISTANCE_OP_EUCLIDEAN:
       {
 	if (arithptr->opcode == T_DISTANCE_OP_EUCLIDEAN)
@@ -822,6 +823,17 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, val_descr *
 	{
 	  goto error;
 	}
+      break;
+
+    case T_DISTANCE_OP_COSINE:
+      {
+	DB_VALUE *args[2] = { peek_left, peek_right };
+	int err = vector_cosine_distance (arithptr->value, args, 2);
+	if (err != NO_ERROR)
+	  {
+	    goto error;
+	  }
+      }
       break;
 
     case T_DISTANCE_OP_EUCLIDEAN:

--- a/src/storage/storage_common.h
+++ b/src/storage/storage_common.h
@@ -893,6 +893,7 @@ typedef enum
   T_CURRENT_DATE,
   T_CURRENT_TIME,
   T_CONV_TZ,
+  T_DISTANCE_OP_COSINE,
   T_DISTANCE_OP_EUCLIDEAN,
 } OPERATOR_TYPE;		/* arithmetic operator types */
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBVEC-66>

### Purpose

벡터 거리 연산을 위한 `<c>` cosine distance operator를 구현합니다.

```sql
drop table if exists tbl; 
create table tbl (id int, vec vector);
insert into tbl values (1, '[1, 2, 3]'), (2, '[2, 3, 4]'); 

select '[1, 2, 3]' <c> '[2, 3, 4]';
select '[1, 2, 3]' <c> vec from tbl;

```

```sh
Execute OK. (0.044434 sec) Committed. (0.002167 sec)
Execute OK. (0.007586 sec) Committed. (0.001084 sec)
2 rows affected. (0.001084 sec) Committed. (0.000000 sec)

=== <Result of SELECT Command in Line 5> ===

  '[1, 2, 3]' <c> '[2, 3, 4]'
=============================
                 7.416725e-03

1 row selected. (0.001083 sec) Committed. (0.000000 sec)

=== <Result of SELECT Command in Line 6> ===

  '[1, 2, 3]' <c> vec
=====================
         5.960464e-08
         7.416725e-03

2 rows selected. (0.001084 sec) Committed. (0.000000 sec)
```

### order by case

```sql
-- Drop existing table if any
DROP IF EXISTS tbl;

-- Create test table with 3D vectors
CREATE TABLE tbl (
    id INT,
    label VARCHAR(20),
    vec VECTOR(3)
);

-- Insert various test vectors
INSERT INTO tbl VALUES (1, 'same_as_input', '[1, 2, 3]');
INSERT INTO tbl VALUES (2, 'reverse',        '[3, 2, 1]');
INSERT INTO tbl VALUES (3, 'orthogonal',     '[3, -6, 3]');
INSERT INTO tbl VALUES (4, 'unit',           '[0.2673, 0.5345, 0.8018]'); -- normalized version of [1,2,3]
INSERT INTO tbl VALUES (5, 'zero',           '[0, 0, 0]');
INSERT INTO tbl VALUES (6, 'ones',           '[1, 1, 1]');
INSERT INTO tbl VALUES (7, 'negated_input',  '[-1, -2, -3]');
INSERT INTO tbl VALUES (8, 'random',         '[4, 5, 6]');

SELECT id, label, '[1, 2, 3]' <c> vec AS similarity
FROM tbl
ORDER BY similarity DESC;
```

```sh
           id  label                    similarity
==================================================
            7  'negated_input'        2.000000e+00
            3  'orthogonal'           1.000000e+00
            5  'zero'                 1.000000e+00
            2  'reverse'              2.857143e-01
            6  'ones'                 7.417989e-02
            8  'random'               2.536821e-02
            1  'same_as_input'        5.960464e-08
            4  'unit'                 0.000000e+00
```

### Implementation
#6168 와 동일
### Remarks

N/A
