### PR TITLE
[CUBVEC-67] Negative Inner Product Operator (<#>) 

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -16985,6 +16985,11 @@ expression_vector_distance
 			$$ = parser_make_expression (this_parser, PT_DISTANCE_OP_EUCLIDEAN, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
+	| expression_vector_distance DISTANCE_OP_NEG_INNER_PROD expression_strcat
+		{{
+			$$ = parser_make_expression (this_parser, PT_DISTANCE_OP_NEG_INNER_PROD, $1, $3, NULL);
+			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
+		}}
 	| expression_strcat
 		{{
 			$$ = $1;

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -4093,6 +4093,8 @@ pt_show_binopcode (PT_OP_TYPE n)
       return " <c> ";
     case PT_DISTANCE_OP_EUCLIDEAN:
       return " <-> ";
+    case PT_DISTANCE_OP_NEG_INNER_PROD:
+      return " <#> ";
     default:
       assert (false);
       return "unknown opcode";

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -8437,6 +8437,7 @@ pt_is_operator_arith (PT_OP_TYPE op)
     {
     case PT_DISTANCE_OP_COSINE:
     case PT_DISTANCE_OP_EUCLIDEAN:
+    case PT_DISTANCE_OP_NEG_INNER_PROD:
       {
 	vimkim_log ("PT_DISTANCE_OP_<vector metric> is arithmetic.");
 	return true;

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -1656,6 +1656,7 @@ pt_get_expression_definition (const PT_OP_TYPE op, EXPRESSION_DEFINITION * def)
 
     case PT_DISTANCE_OP_COSINE:
     case PT_DISTANCE_OP_EUCLIDEAN:
+    case PT_DISTANCE_OP_NEG_INNER_PROD:
       num = 0;
       vimkim_log ("op: %s\n", pt_show_binopcode (op));
 
@@ -10451,6 +10452,7 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
 
     case PT_DISTANCE_OP_COSINE:
     case PT_DISTANCE_OP_EUCLIDEAN:
+    case PT_DISTANCE_OP_NEG_INNER_PROD:
       {
 	node->info.expr.arg1 = arg1;
 	node->info.expr.arg2 = arg2;
@@ -12749,6 +12751,18 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
       {
 	DB_VALUE *arr[2] = { arg1, arg2 };
 	error = vector_l2_distance (result, arr, 2);
+	if (error != NO_ERROR)
+	  {
+	    PT_ERRORc (parser, o1, er_msg ());
+	    return 0;
+	  }
+	break;
+      }
+
+    case PT_DISTANCE_OP_NEG_INNER_PROD:
+      {
+	DB_VALUE *arr[2] = { arg1, arg2 };
+	error = vector_negative_inner_product (result, arr, 2);
 	if (error != NO_ERROR)
 	  {
 	    PT_ERRORc (parser, o1, er_msg ());

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -7718,7 +7718,8 @@ pt_to_regu_variable (PARSER_CONTEXT * parser, PT_NODE * node, UNBOX unbox)
 		  || node->info.expr.op == PT_ADDTIME || node->info.expr.op == PT_DEFINE_VARIABLE
 		  || node->info.expr.op == PT_CHR || node->info.expr.op == PT_CLOB_TO_CHAR
 		  || node->info.expr.op == PT_INDEX_PREFIX || node->info.expr.op == PT_FROM_TZ
-		  || node->info.expr.op == PT_DISTANCE_OP_COSINE || node->info.expr.op == PT_DISTANCE_OP_EUCLIDEAN)
+		  || node->info.expr.op == PT_DISTANCE_OP_COSINE || node->info.expr.op == PT_DISTANCE_OP_EUCLIDEAN
+		  || node->info.expr.op == PT_DISTANCE_OP_NEG_INNER_PROD)
 		{
 		  r1 = pt_to_regu_variable (parser, node->info.expr.arg1, unbox);
 		  if ((node->info.expr.op == PT_CONCAT) && node->info.expr.arg2 == NULL)
@@ -8178,6 +8179,10 @@ pt_to_regu_variable (PARSER_CONTEXT * parser, PT_NODE * node, UNBOX unbox)
 
 		case PT_DISTANCE_OP_EUCLIDEAN:
 		  regu = pt_make_regu_arith (r1, r2, NULL, T_DISTANCE_OP_EUCLIDEAN, domain);
+		  break;
+
+		case PT_DISTANCE_OP_NEG_INNER_PROD:
+		  regu = pt_make_regu_arith (r1, r2, NULL, T_DISTANCE_OP_NEG_INNER_PROD, domain);
 		  break;
 
 		case PT_IF:

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -185,6 +185,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, val_descr *
     case T_MOD:
     case T_DISTANCE_OP_COSINE:
     case T_DISTANCE_OP_EUCLIDEAN:
+    case T_DISTANCE_OP_NEG_INNER_PROD:
       {
 	if (arithptr->opcode == T_DISTANCE_OP_EUCLIDEAN)
 	  {
@@ -840,6 +841,17 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, val_descr *
       {
 	DB_VALUE *args[2] = { peek_left, peek_right };
 	int err = vector_l2_distance (arithptr->value, args, 2);
+	if (err != NO_ERROR)
+	  {
+	    goto error;
+	  }
+      }
+      break;
+
+    case T_DISTANCE_OP_NEG_INNER_PROD:
+      {
+	DB_VALUE *args[2] = { peek_left, peek_right };
+	int err = vector_negative_inner_product (arithptr->value, args, 2);
 	if (err != NO_ERROR)
 	  {
 	    goto error;

--- a/src/storage/storage_common.h
+++ b/src/storage/storage_common.h
@@ -895,6 +895,7 @@ typedef enum
   T_CONV_TZ,
   T_DISTANCE_OP_COSINE,
   T_DISTANCE_OP_EUCLIDEAN,
+  T_DISTANCE_OP_NEG_INNER_PROD,
 } OPERATOR_TYPE;		/* arithmetic operator types */
 
 /************************************************************************/


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBVEC-67>

### Purpose

벡터 거리 연산을 위한 <#> inner product operator를 구현합니다.

```sql
drop table if exists tbl; 
create table tbl (id int, vec vector);
insert into tbl values (1, '[1, 2, 3]'), (2, '[2, 3, 4]'); 

select '[1, 2, 3]' <#> '[2, 3, 4]';
select '[1, 2, 3]' <#> vec from tbl;
```

```sh
Execute OK. (0.018600 sec) Committed. (0.001094 sec)
Execute OK. (0.006565 sec) Committed. (0.001094 sec)
2 rows affected. (0.002189 sec) Committed. (0.000000 sec)

=== <Result of SELECT Command in Line 5> ===

  '[1, 2, 3]' <#> '[2, 3, 4]'
=============================
                -2.000000e+01

1 row selected. (0.002188 sec) Committed. (0.000000 sec)

=== <Result of SELECT Command in Line 6> ===

  '[1, 2, 3]' <#> vec
=====================
        -1.400000e+01
        -2.000000e+01

2 rows selected. (0.001094 sec) Committed. (0.000000 sec)
```

### order by case

```sql
CREATE TABLE tbl (
    id INT,
    label VARCHAR(20),
    vec VECTOR(3)
);

-- Insert various test vectors
INSERT INTO tbl VALUES (1, 'same_as_input', '[1, 2, 3]');
INSERT INTO tbl VALUES (2, 'reverse',        '[3, 2, 1]');
INSERT INTO tbl VALUES (3, 'orthogonal',     '[3, -6, 3]');
INSERT INTO tbl VALUES (4, 'unit',           '[0.2673, 0.5345, 0.8018]'); -- normalized version of [1,2,3]
INSERT INTO tbl VALUES (5, 'zero',           '[0, 0, 0]');
INSERT INTO tbl VALUES (6, 'ones',           '[1, 1, 1]');
INSERT INTO tbl VALUES (7, 'negated_input',  '[-1, -2, -3]');
INSERT INTO tbl VALUES (8, 'random',         '[4, 5, 6]');

SELECT id, label, '[1, 2, 3]' <#> vec AS dot_prod
FROM tbl
ORDER BY dot_prod DESC;


```

```sh
=== <Result of SELECT Command in Line 64> ===

           id  label                      dot_prod
==================================================
            7  'negated_input'        1.400000e+01
            3  'orthogonal'          -0.000000e+00
            5  'zero'                -0.000000e+00
            4  'unit'                -3.741700e+00
            6  'ones'                -6.000000e+00
            2  'reverse'             -1.000000e+01
            1  'same_as_input'       -1.400000e+01
            8  'random'              -3.200000e+01

8 rows selected. (0.000976 sec) Committed. (0.000000 sec)
```

### Implementation

#6168 와 동일

### Remarks

N/A
