### PR TITLE
[CUBVEC-68] Support Manhattan Operator (<+>) 

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -16985,6 +16985,11 @@ expression_vector_distance
 			$$ = parser_make_expression (this_parser, PT_DISTANCE_OP_EUCLIDEAN, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
+	| expression_vector_distance DISTANCE_OP_MANHATTAN expression_strcat
+		{{
+			$$ = parser_make_expression (this_parser, PT_DISTANCE_OP_MANHATTAN, $1, $3, NULL);
+			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
+		}}
 	| expression_vector_distance DISTANCE_OP_NEG_INNER_PROD expression_strcat
 		{{
 			$$ = parser_make_expression (this_parser, PT_DISTANCE_OP_NEG_INNER_PROD, $1, $3, NULL);

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -4093,6 +4093,8 @@ pt_show_binopcode (PT_OP_TYPE n)
       return " <c> ";
     case PT_DISTANCE_OP_EUCLIDEAN:
       return " <-> ";
+    case PT_DISTANCE_OP_MANHATTAN:
+      return " <+> ";
     case PT_DISTANCE_OP_NEG_INNER_PROD:
       return " <#> ";
     default:

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -8437,6 +8437,7 @@ pt_is_operator_arith (PT_OP_TYPE op)
     {
     case PT_DISTANCE_OP_COSINE:
     case PT_DISTANCE_OP_EUCLIDEAN:
+    case PT_DISTANCE_OP_MANHATTAN:
     case PT_DISTANCE_OP_NEG_INNER_PROD:
       {
 	vimkim_log ("PT_DISTANCE_OP_<vector metric> is arithmetic.");

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -1656,6 +1656,7 @@ pt_get_expression_definition (const PT_OP_TYPE op, EXPRESSION_DEFINITION * def)
 
     case PT_DISTANCE_OP_COSINE:
     case PT_DISTANCE_OP_EUCLIDEAN:
+    case PT_DISTANCE_OP_MANHATTAN:
     case PT_DISTANCE_OP_NEG_INNER_PROD:
       num = 0;
       vimkim_log ("op: %s\n", pt_show_binopcode (op));
@@ -10452,6 +10453,7 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
 
     case PT_DISTANCE_OP_COSINE:
     case PT_DISTANCE_OP_EUCLIDEAN:
+    case PT_DISTANCE_OP_MANHATTAN:
     case PT_DISTANCE_OP_NEG_INNER_PROD:
       {
 	node->info.expr.arg1 = arg1;
@@ -12751,6 +12753,18 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
       {
 	DB_VALUE *arr[2] = { arg1, arg2 };
 	error = vector_l2_distance (result, arr, 2);
+	if (error != NO_ERROR)
+	  {
+	    PT_ERRORc (parser, o1, er_msg ());
+	    return 0;
+	  }
+	break;
+      }
+
+    case PT_DISTANCE_OP_MANHATTAN:
+      {
+	DB_VALUE *arr[2] = { arg1, arg2 };
+	error = vector_l1_distance (result, arr, 2);
 	if (error != NO_ERROR)
 	  {
 	    PT_ERRORc (parser, o1, er_msg ());

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -7719,6 +7719,7 @@ pt_to_regu_variable (PARSER_CONTEXT * parser, PT_NODE * node, UNBOX unbox)
 		  || node->info.expr.op == PT_CHR || node->info.expr.op == PT_CLOB_TO_CHAR
 		  || node->info.expr.op == PT_INDEX_PREFIX || node->info.expr.op == PT_FROM_TZ
 		  || node->info.expr.op == PT_DISTANCE_OP_COSINE || node->info.expr.op == PT_DISTANCE_OP_EUCLIDEAN
+		  || node->info.expr.op == PT_DISTANCE_OP_MANHATTAN
 		  || node->info.expr.op == PT_DISTANCE_OP_NEG_INNER_PROD)
 		{
 		  r1 = pt_to_regu_variable (parser, node->info.expr.arg1, unbox);
@@ -8179,6 +8180,10 @@ pt_to_regu_variable (PARSER_CONTEXT * parser, PT_NODE * node, UNBOX unbox)
 
 		case PT_DISTANCE_OP_EUCLIDEAN:
 		  regu = pt_make_regu_arith (r1, r2, NULL, T_DISTANCE_OP_EUCLIDEAN, domain);
+		  break;
+
+		case PT_DISTANCE_OP_MANHATTAN:
+		  regu = pt_make_regu_arith (r1, r2, NULL, T_DISTANCE_OP_MANHATTAN, domain);
 		  break;
 
 		case PT_DISTANCE_OP_NEG_INNER_PROD:

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -185,6 +185,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, val_descr *
     case T_MOD:
     case T_DISTANCE_OP_COSINE:
     case T_DISTANCE_OP_EUCLIDEAN:
+    case T_DISTANCE_OP_MANHATTAN:
     case T_DISTANCE_OP_NEG_INNER_PROD:
       {
 	if (arithptr->opcode == T_DISTANCE_OP_EUCLIDEAN)
@@ -841,6 +842,17 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, val_descr *
       {
 	DB_VALUE *args[2] = { peek_left, peek_right };
 	int err = vector_l2_distance (arithptr->value, args, 2);
+	if (err != NO_ERROR)
+	  {
+	    goto error;
+	  }
+      }
+      break;
+
+    case T_DISTANCE_OP_MANHATTAN:
+      {
+	DB_VALUE *args[2] = { peek_left, peek_right };
+	int err = vector_l1_distance (arithptr->value, args, 2);
 	if (err != NO_ERROR)
 	  {
 	    goto error;

--- a/src/storage/storage_common.h
+++ b/src/storage/storage_common.h
@@ -895,6 +895,7 @@ typedef enum
   T_CONV_TZ,
   T_DISTANCE_OP_COSINE,
   T_DISTANCE_OP_EUCLIDEAN,
+  T_DISTANCE_OP_MANHATTAN,
   T_DISTANCE_OP_NEG_INNER_PROD,
 } OPERATOR_TYPE;		/* arithmetic operator types */
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBVEC-68>

### Purpose


벡터 거리 연산을 위한 <+> Manhattan distance operator를 구현합니다.

```sql
drop table if exists tbl; 
create table tbl (id int, vec vector);
insert into tbl values (1, '[1, 2, 3]'), (2, '[2, 3, 4]'); 

select '[1, 2, 3]' <+> '[2, 3, 4]';
select '[1, 2, 3]' <+> vec from tbl;
```

```sh
Execute OK. (0.001098 sec) Committed. (0.000000 sec)
Execute OK. (0.017567 sec) Committed. (0.001097 sec)
2 rows affected. (0.003294 sec) Committed. (0.000000 sec)

=== <Result of SELECT Command in Line 5> ===

  '[1, 2, 3]' <+> '[2, 3, 4]'
=============================
                 3.000000e+00

1 row selected. (0.001098 sec) Committed. (0.000000 sec)

=== <Result of SELECT Command in Line 6> ===

  '[1, 2, 3]' <+> vec
=====================
         0.000000e+00
         3.000000e+00

2 rows selected. (0.001098 sec) Committed. (0.000000 sec)
```

### order by case

```sql
CREATE TABLE tbl (
    id INT,
    label VARCHAR(20),
    vec VECTOR(3)
);

-- Insert various test vectors
INSERT INTO tbl VALUES (1, 'same_as_input', '[1, 2, 3]');
INSERT INTO tbl VALUES (2, 'reverse',        '[3, 2, 1]');
INSERT INTO tbl VALUES (3, 'orthogonal',     '[3, -6, 3]');
INSERT INTO tbl VALUES (4, 'unit',           '[0.2673, 0.5345, 0.8018]'); -- normalized version of [1,2,3]
INSERT INTO tbl VALUES (5, 'zero',           '[0, 0, 0]');
INSERT INTO tbl VALUES (6, 'ones',           '[1, 1, 1]');
INSERT INTO tbl VALUES (7, 'negated_input',  '[-1, -2, -3]');
INSERT INTO tbl VALUES (8, 'random',         '[4, 5, 6]');

SELECT id, label, '[1, 2, 3]' <+> vec AS l1_dist
FROM tbl
ORDER BY l1_dist ASC;
```

```sh
           id  label                       l1_dist
==================================================
            1  'same_as_input'        0.000000e+00
            6  'ones'                 3.000000e+00
            2  'reverse'              4.000000e+00
            4  'unit'                 4.396400e+00
            5  'zero'                 6.000000e+00
            8  'random'               9.000000e+00
            3  'orthogonal'           1.000000e+01
            7  'negated_input'        1.200000e+01
```

### Implementation

#6168 와 동일

### Remarks

N/A
