### PR TITLE
[CUBVEC-hotfix] Fix typo (missing quote) for circleci config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ jobs:
                           cubvec)
                             TEST_SUITE="sql"
                             base_dir="cubrid-testcases"
-                            glob_path="\$base_dir/sql/_36_cubvec
+                            glob_path="\$base_dir/sql/_36_cubvec"
                             ;;
                           plcsql)
                             TEST_SUITE="sql"


### PR DESCRIPTION
cubvec hotfix

### Purpose

.circleci/config.yml 파일이 comment_trigger 시스템으로 바뀐 이후 해당 변경 사항을 cubvec 브랜치에 반영했습니다.

반영 도중 발생한 오타를 긴급 수정합니다.

### Implementation

![image](https://github.com/user-attachments/assets/a27a2718-6961-41ad-a163-740c0d26dd79)


### Remarks

N/A
