### PR TITLE
[CUBRIDQA-1263] add comment trigger 'cubvec'

### DIFF
--- a/.github/workflows/comment_trigger.yml
+++ b/.github/workflows/comment_trigger.yml
@@ -18,7 +18,7 @@ jobs:
           echo "[debug] Comment: $COMMENT"
           
           # Define test types
-          TEST_TYPES="shell sql medium plcsql"
+          TEST_TYPES="shell sql medium cubvec plcsql"
           TEST_JSON="{"
           
           # Check for 'all' keyword or parse individual test types


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1263

### Purpose

기존에 모든 ci 로직을 관리했던 .circleci/config.yml과 다르게,
github actions는 머지할 branch의 comment_trigger.yml에 적힌 내용을 무시하고
기본 브랜치 (cubrid의 경우 develop)을 기준으로 ci를 작동시키는 것으로 추정됩니다.

https://github.com/CUBRID/cubrid/actions/runs/15274241358/workflow

위 actions 링크에서도 확인하실 수 있듯이, cubvec/cubvec 브랜치의 comment_trigger.yml 파일에는 이미 cubvec 키워드가 추가되어 있음에도 불구하고 develop의 comment_trigger.yml을 기준으로 ci가 작동합니다.
(이는 CI의 권한을 develop에서만 제어할 수 있도록 설정한, 보안 상 이해되는 동작 방식입니다.)

따라서 github actions comment-trigger.yml 파일에 test_cubvec 트리거 키워드를 develop 브랜치에 추가합니다.

해당 트리거를 통해 test_cubvec 을 실행시킬 수 있습니다.

### Implementation

![image](https://github.com/user-attachments/assets/3e8a61e7-22f0-424d-a542-55249dcd4a9f)


TEST_TYPES="shell sql medium cubvec plcsql"

### Remarks

이 경우 test_cubvec 이 없는 다른 브랜치들에 안 좋은 영향을 주는 경우가 없는지 확인해야 합니다.
