### PR TITLE
[CUBRIDQA-1268]fix key value caused by cache corruption

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,8 +320,8 @@ jobs:
                 steps:
                   - restore_cache:
                       keys:
-                        - "cubrid-testcases-private-ex-${TC_PRIVATE_SHA}"
-                        - "cubrid-testcases-private-ex-"
+                        - "cubrid-testcases-private-ex-develop-${TC_PRIVATE_SHA}"
+                        - "cubrid-testcases-private-ex-develop-"
                   - attach-and-run-tests
                   - run:
                       name: Clean up tc before save_cache
@@ -330,7 +330,7 @@ jobs:
                         git clean -fd
                         git reset --hard
                   - save_cache:
-                      key: "cubrid-testcases-private-ex-${TC_PRIVATE_SHA}"
+                      key: "cubrid-testcases-private-ex-develop-${TC_PRIVATE_SHA}"
                       paths:
                         - cubrid-testcases-private-ex
             

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,14 +245,12 @@ jobs:
                 resource_class: medium
                 parallelism: 1
                 environment:
-                  BASELINE: << pipeline.parameters.baseline >>
                   TEST_SUITE: "medium"
-                  GITHUB_TOKEN: \$GHI_TOKEN
                 steps:
                   - restore_cache:
                       keys:
-                        - "cubrid-testcases-${TC_SHA}"
-                        - "cubrid-testcases-"
+                        - "cubrid-testcases-develop-${TC_SHA}"
+                        - "cubrid-testcases-develop-"
                   - attach-and-run-tests
                   - run:
                       name: Clean up tc before save_cache
@@ -261,7 +259,7 @@ jobs:
                         git clean -fd
                         git reset --hard
                   - save_cache:
-                      key: "cubrid-testcases-${TC_SHA}"
+                      key: "cubrid-testcases-develop-${TC_SHA}"
                       paths:
                         - cubrid-testcases
                       
@@ -270,14 +268,12 @@ jobs:
                 resource_class: medium
                 parallelism: 8
                 environment:
-                  BASELINE: << pipeline.parameters.baseline >>
                   TEST_SUITE: "sql"
-                  GITHUB_TOKEN: \$GHI_TOKEN
                 steps:
                   - restore_cache:
                       keys:
-                        - "cubrid-testcases-${TC_SHA}"
-                        - "cubrid-testcases-"
+                        - "cubrid-testcases-develop-${TC_SHA}"
+                        - "cubrid-testcases-develop-"
                   - attach-and-run-tests
                   - run:
                       name: Clean up tc before save_cache
@@ -286,7 +282,7 @@ jobs:
                         git clean -fd
                         git reset --hard
                   - save_cache:
-                      key: "cubrid-testcases-${TC_SHA}"
+                      key: "cubrid-testcases-develop-${TC_SHA}"
                       paths:
                         - cubrid-testcases
                       
@@ -295,14 +291,12 @@ jobs:
                 resource_class: medium
                 parallelism: 1
                 environment:
-                  BASELINE: << pipeline.parameters.baseline >>
                   TEST_SUITE: "plcsql"
-                  GITHUB_TOKEN: \$GHI_TOKEN
                 steps:
                   - restore_cache:
                       keys:
-                        - "cubrid-testcases-${TC_SHA}"
-                        - "cubrid-testcases-"
+                        - "cubrid-testcases-develop-${TC_SHA}"
+                        - "cubrid-testcases-develop-"
                   - attach-and-run-tests
                   - run:
                       name: Clean up tc before save_cache
@@ -311,7 +305,7 @@ jobs:
                         git clean -fd
                         git reset --hard
                   - save_cache:
-                      key: "cubrid-testcases-${TC_SHA}"
+                      key: "cubrid-testcases-develop-${TC_SHA}"
                       paths:
                         - cubrid-testcases
                       


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1268>

### Purpose
https://github.com/CUBRID/cubrid/pull/6217
의 원인으로 tc 캐시가 오염됨.


### Implementation
키값에 브랜치명을 명시하여 분리.

### Remarks

N/A
