### PR TITLE
[CBRD-26095] Insert select 문의 parallel heap scan 지원

### DIFF
--- a/src/query/parallel/px_heap_scan/px_heap_scan_checker.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_checker.cpp
@@ -545,12 +545,12 @@ namespace parallel_heap_scan
       case UNION_PROC:
       case DIFFERENCE_PROC:
       case INTERSECTION_PROC:
+      case INSERT_PROC:
 	break;
       case OBJFETCH_PROC:
       case MERGELIST_PROC:
       case UPDATE_PROC:
       case DELETE_PROC:
-      case INSERT_PROC:
       case CONNECTBY_PROC:
       case DO_PROC:
       case MERGE_PROC:


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26095>

### Purpose

현재 CUBRID의 Parallel Heap Scan 기능은 Insert select문에 대해 적용되지 않습니다.
본 개선은 Insert select문에 대해서도 Parallel Heap Scan이 적용될 수 있도록 하여, 대용량 데이터 처리 성능을 향상시키는 것을 목표로 합니다.

### Implementation

scan_check_parallel_heap_scan_possible에 insert 문 제약을 해제합니다.
