### PR TITLE
[CBRD-26097] memory leak of au_change_class_owner function

### DIFF
--- a/src/object/authenticate_owner.cpp
+++ b/src/object/authenticate_owner.cpp
@@ -446,7 +446,7 @@ au_change_class_owner (MOP class_mop, MOP owner_mop)
 	  if (owner == NULL)
 	    {
 	      ASSERT_ERROR_AND_SET (error);
-	      return error;
+	      goto end;
 	    }
 
 	  table_name = sm_get_ch_name (sub_partitions[i]);
@@ -477,21 +477,21 @@ au_change_class_owner (MOP class_mop, MOP owner_mop)
   if (owner == NULL)
     {
       ASSERT_ERROR_AND_SET (error);
-      return error;
+      goto end;
     }
 
   table_name = sm_get_ch_name (class_mop);
   if (table_name == NULL)
     {
       ASSERT_ERROR_AND_SET (error);
-      return error;
+      goto end;
     }
 
   error = au_object_owner_change_privileges (DB_OBJECT_CLASS, class_mop, owner, owner_mop, table_name);
   if (error != NO_ERROR)
     {
       ASSERT_ERROR_AND_SET (error);
-      return error;
+      goto end;
     }
 
   /* change the owner of a class */


### PR DESCRIPTION
[<http://jira.cubrid.org/browse/CBRD-26097>
](http://jira.cubrid.org/browse/CBRD-26097)

### Purpose
au_change_class_owner 함수에서 memory leak을 유발하는 있는 부분이 있어서 수정이 필요합니다.

```c
MOP* sub_partitions;
...

// sub_partitions 메모리 할당
error = sm_partitioned_class_type (class_mop, &is_partition, NULL, &sub_partitions);

...

// memory leak 을 유발하는 부분
if (something)
{
   return error;
}

end:
  if (sub_partitions)
  {
     // sub_partitons 메모리 해제
  }
...
```

### Implementation

`early return`이 아닌 `goto end`로 사용