### PR TITLE
[CUBVEC-73] fix crash when m, efcon is not provided

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -2833,21 +2833,24 @@ create_stmt
 
 			node->info.index.is_vector_index = true;
 
+			node->info.index.vector_index.hnsw_m = HNSW_DEFAULT_M;
+			node->info.index.vector_index.hnsw_ef_construction = HNSW_DEFAULT_EF_CONSTRUCTION;
+
 			kv_pair *kvp = $13; // opt_vector_index_with_clause
 			if (kvp) 
 			  {
 			    PT_NODE *m_node = kv_pair_lookup(kvp, "m");
+			    if (m_node != NULL)
+			      {
+				int m = m_node->info.value.data_value.i;
+				node->info.index.vector_index.hnsw_m = m;
+			      }
 			    PT_NODE *ef_construction_node = kv_pair_lookup(kvp, "ef_construction");
-
-			    // TODO (CUBVEC): default m and ef_con?
-			    int default_m = 16;
-			    int default_ef_con = 64;
-
-			    int m = m_node ? m_node->info.value.data_value.i : default_m;
-			    int ef_con = ef_construction_node ? ef_construction_node->info.value.data_value.i : default_ef_con;
-
-			    node->info.index.vector_index.hnsw_m = m;
-			    node->info.index.vector_index.hnsw_ef_construction = ef_con;
+			    if (ef_construction_node != NULL)
+			      {
+				int ef_con = ef_construction_node->info.value.data_value.i;
+				node->info.index.vector_index.hnsw_ef_construction = ef_con;
+			      }
 			  }
 
 			bool opt_unique = false; // original $5

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -2164,6 +2164,9 @@ struct pt_create_entity_info
   unsigned if_not_exists:1;	/* IF NOT EXISTS clause for create table | class */
 };
 
+#define HNSW_DEFAULT_M 16
+#define HNSW_DEFAULT_EF_CONSTRUCTION 64
+
 /* Structure for vector index specific information */
 typedef struct pt_vector_index_info
 {

--- a/src/storage/hnsw.cpp
+++ b/src/storage/hnsw.cpp
@@ -151,6 +151,49 @@ int hnsw_print_index_info (BTID *btid)
   er_log_debug (ARG_FILE_LINE, "  - HNSW efConstruction: %d", hnsw_index->hnsw.efConstruction);
   er_log_debug (ARG_FILE_LINE, "  - HNSW efSearch: %d", hnsw_index->hnsw.efSearch);
 
+  /*
+  This works because, in faiss/impl/HNSW.cpp
+
+  ```cpp
+
+  // initialize the assign_probas and cum_nneighbor_per_level to
+  // have 2*M links on level 0 and M links on levels > 0
+  void HNSW::set_default_probas(int M, float levelMult) {
+    int nn = 0;
+    cum_nneighbor_per_level.push_back(0);
+    for (int level = 0;; level++) {
+        float proba = exp(-level / levelMult) * (1 - exp(-1 / levelMult));
+        if (proba < 1e-9)
+            break;
+        assign_probas.push_back(proba);
+        nn += level == 0 ? M * 2 : M;
+        cum_nneighbor_per_level.push_back(nn);
+    }
+  }
+
+  ```
+
+  */
+
+  const auto& neighbor_counts = hnsw_index->hnsw.cum_nneighbor_per_level;
+
+  std::string output = "  - HNSW neighbor_counts: [";
+  for (size_t i = 0; i < neighbor_counts.size(); ++i)
+    {
+      output += std::to_string (neighbor_counts[i]);
+      if (i + 1 < neighbor_counts.size())
+	{
+	  output += ", ";
+	}
+    }
+  output += "]";
+
+  er_log_debug (ARG_FILE_LINE, "%s", output.c_str());
+  if (neighbor_counts.size() > 1)
+    {
+      er_log_debug (ARG_FILE_LINE, "  - HNSW M is assumed to be %d", neighbor_counts[1] / 2);
+    }
+
   return NO_ERROR;
 }
 

--- a/src/storage/hnsw.cpp
+++ b/src/storage/hnsw.cpp
@@ -144,17 +144,18 @@ int hnsw_print_index_info (BTID *btid)
   std::unique_ptr<faiss::IndexIDMap> &index = it->second;
   auto *hnsw_index = static_cast<faiss::IndexHNSWFlat *> (index->index);
 
-  er_log_debug (ARG_FILE_LINE, "HNSW Index Information for ID %d:", hnsw_id);
-  er_log_debug (ARG_FILE_LINE, "  - Dimension: %d", index->d);
-  er_log_debug (ARG_FILE_LINE, "  - Metric Type: %d", index->metric_type);
-  er_log_debug (ARG_FILE_LINE, "  - Total Elements: %d", index->ntotal);
-  er_log_debug (ARG_FILE_LINE, "  - HNSW efConstruction: %d", hnsw_index->hnsw.efConstruction);
-  er_log_debug (ARG_FILE_LINE, "  - HNSW efSearch: %d", hnsw_index->hnsw.efSearch);
+  std::ostringstream oss;
+
+  oss << "HNSW Index Information for ID " << hnsw_id << ":\n";
+  oss << "  - Dimension: " << index->d << "\n";
+  oss << "  - Metric Type: " << index->metric_type << "\n";
+  oss << "  - Total Elements: " << index->ntotal << "\n";
+  oss << "  - HNSW efConstruction: " << hnsw_index->hnsw.efConstruction << "\n";
+  oss << "  - HNSW efSearch: " << hnsw_index->hnsw.efSearch << "\n";
 
   /*
-  This works because, in faiss/impl/HNSW.cpp
-
-  ```cpp
+  * This works because, in faiss/impl/HNSW.cpp, HNSW is initialized with
+  * set_default_probas(M, ...);
 
   // initialize the assign_probas and cum_nneighbor_per_level to
   // have 2*M links on level 0 and M links on levels > 0
@@ -170,29 +171,27 @@ int hnsw_print_index_info (BTID *btid)
         cum_nneighbor_per_level.push_back(nn);
     }
   }
-
-  ```
-
   */
 
-  const auto& neighbor_counts = hnsw_index->hnsw.cum_nneighbor_per_level;
-
-  std::string output = "  - HNSW neighbor_counts: [";
+  // Print neighbor counts
+  const auto &neighbor_counts = hnsw_index->hnsw.cum_nneighbor_per_level;
+  oss << "  - HNSW neighbor_counts: [";
   for (size_t i = 0; i < neighbor_counts.size(); ++i)
     {
-      output += std::to_string (neighbor_counts[i]);
+      oss << neighbor_counts[i];
       if (i + 1 < neighbor_counts.size())
 	{
-	  output += ", ";
+	  oss << ", ";
 	}
     }
-  output += "]";
+  oss << "]\n";
 
-  er_log_debug (ARG_FILE_LINE, "%s", output.c_str());
   if (neighbor_counts.size() > 1)
     {
-      er_log_debug (ARG_FILE_LINE, "  - HNSW M is assumed to be %d", neighbor_counts[1] / 2);
+      oss << "  - HNSW M is assumed to be " << (neighbor_counts[1] / 2) << "\n";
     }
+
+  er_log_debug (ARG_FILE_LINE, "%s", oss.str().c_str());
 
   return NO_ERROR;
 }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBVEC-73>

### Purpose

m, efcon 설정을 안하면 서버쪽에 0이 넘어옵니다.
문법에 아무것도 설정되지 않았을 때 기본값 설정 로직이 누락되었습니다. 이를 수정합니다.

### Implementation

kvp (csql rule $13) 이 null 이 아닐 경우에만 default m 과 default ef_con을 설정한 실수를 제거함.

### Remarks

```sql
DROP if exists items;
CREATE TABLE items (id int, vc1 vector(3)) DONT_REUSE_OID;
CREATE VECTOR INDEX idx_v ON items(vc1 EUCLIDEAN);

INSERT INTO items VALUES (1, '[1,2,3]');
INSERT INTO items VALUES (2, '[1,0,2]');
```

위 sql 문에서 crash가 일어나지 않아야 함.