### PR TITLE
[CUBVEC-84] Modify the vector operator to enable the use of vector indexes

### DIFF
--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -10390,9 +10390,10 @@ qo_validate_index_for_vector_index (QO_ENV * env, QO_NODE_INDEX_ENTRY * ni_entry
 
   int pos;
   PT_NODE *node = NULL;
-  PT_NODE *arg_list = NULL;
   PT_NODE *order_by = NULL;
   PT_NODE *order_by_for = NULL;
+  PT_NODE *arg1 = NULL;
+  PT_NODE *arg2 = NULL;
 
   assert (ni_entryp != NULL);
   assert (ni_entryp->head != NULL);
@@ -10433,7 +10434,7 @@ qo_validate_index_for_vector_index (QO_ENV * env, QO_NODE_INDEX_ENTRY * ni_entry
       goto end;
     }
 
-  if (node->node_type == PT_EXPR)
+  if (node->node_type == PT_EXPR && node->info.expr.op == PT_FUNCTION_HOLDER)
     {
       // FUNCTION HOLDER
       node = node->info.expr.arg1;
@@ -10443,22 +10444,36 @@ qo_validate_index_for_vector_index (QO_ENV * env, QO_NODE_INDEX_ENTRY * ni_entry
 	}
     }
 
-  if (!pt_is_vector_function (QO_ENV_PARSER (env), node))
+  if (pt_is_vector_distance_function (QO_ENV_PARSER (env), node))
     {
-      goto end;
+      // naiive check for vector index
+      PT_NODE *arg_list = node->info.function.arg_list;
+      arg1 = arg_list;
+      arg2 = arg_list->next;
+    }
+  else if (pt_is_vector_distance_expr (QO_ENV_PARSER (env), node))
+    {
+      arg1 = node->info.expr.arg1;
+      arg2 = node->info.expr.arg2;
     }
 
-  // naiive check for vector index
-  arg_list = node->info.function.arg_list;
-  if (arg_list->node_type == PT_NAME && arg_list->next->node_type == PT_NAME)
-    {
-      goto end;
-    }
+  // check arg1 and arg2
+  {
+    if (arg1 == NULL || arg2 == NULL)
+      {
+	goto end;
+      }
 
-  if (arg_list->node_type == PT_VALUE && arg_list->next->node_type == PT_VALUE)
-    {
-      goto end;
-    }
+    if (arg1->node_type == PT_NAME && arg2->node_type == PT_NAME)
+      {
+	goto end;
+      }
+
+    if (arg1->node_type == PT_VALUE && arg2->node_type == PT_VALUE)
+      {
+	goto end;
+      }
+  }
 
   return 1;
 

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -435,7 +435,9 @@ extern "C"
   extern bool pt_is_analytic_function (PARSER_CONTEXT * parser, const PT_NODE * node);
   extern bool pt_is_expr_wrapped_function (PARSER_CONTEXT * parser, const PT_NODE * node);
 
-  extern bool pt_is_vector_function (PARSER_CONTEXT * parser, const PT_NODE * node);
+  extern bool pt_is_vector_distance_function (PARSER_CONTEXT * parser, const PT_NODE * node);
+  extern bool pt_is_vector_distance_expr (PARSER_CONTEXT * parser, const PT_NODE * node);
+
   extern bool pt_is_json_function (PARSER_CONTEXT * parser, const PT_NODE * node);
 
   extern PT_NODE *pt_find_spec (PARSER_CONTEXT * parser, const PT_NODE * from, const PT_NODE * name);

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -724,13 +724,22 @@ pt_is_expr_wrapped_function (PARSER_CONTEXT * parser, const PT_NODE * node)
 }
 
 bool
-pt_is_vector_function (PARSER_CONTEXT * parser, const PT_NODE * node)
+pt_is_vector_distance_function (PARSER_CONTEXT * parser, const PT_NODE * node)
 {
   return node->node_type == PT_FUNCTION && (node->info.function.function_type == F_VECTOR_DISTANCE
 					    || node->info.function.function_type == F_L1_DISTANCE
 					    || node->info.function.function_type == F_L2_DISTANCE
 					    || node->info.function.function_type == F_INNER_PRODUCT
 					    || node->info.function.function_type == F_COSINE_DISTANCE);
+}
+
+bool
+pt_is_vector_distance_expr (PARSER_CONTEXT * parser, const PT_NODE * node)
+{
+  return node->node_type == PT_EXPR && (node->info.expr.op == PT_DISTANCE_OP_COSINE
+					|| node->info.expr.op == PT_DISTANCE_OP_EUCLIDEAN
+					|| node->info.expr.op == PT_DISTANCE_OP_MANHATTAN
+					|| node->info.expr.op == PT_DISTANCE_OP_NEG_INNER_PROD);
 }
 
 /*

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -11920,7 +11920,6 @@ pt_to_vector_index_info (PARSER_CONTEXT * parser, DB_OBJECT * class_, PRED_EXPR 
 	  {
 	    PT_NODE *arg1 = node->info.expr.arg1;
 	    PT_NODE *arg2 = node->info.expr.arg2;
-	    
 	    assert (arg1->node_type == PT_NAME || arg1->node_type == PT_VALUE);
 	    assert (arg2->node_type == PT_NAME || arg2->node_type == PT_VALUE);
 

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -11892,7 +11892,7 @@ pt_to_vector_index_info (PARSER_CONTEXT * parser, DB_OBJECT * class_, PRED_EXPR 
 	col->next = NULL;
 
 	PT_NODE *node = col;
-	if (node->node_type == PT_EXPR)
+	if (node->node_type == PT_EXPR && node->info.expr.op == PT_FUNCTION_HOLDER)
 	  {
 	    // FUNCTION HOLDER
 	    node = node->info.expr.arg1;
@@ -11902,10 +11902,11 @@ pt_to_vector_index_info (PARSER_CONTEXT * parser, DB_OBJECT * class_, PRED_EXPR 
 	      }
 	  }
 
-	if (pt_is_vector_function (parser, node))
+	if (pt_is_vector_distance_function (parser, node))
 	  {
 	    arg_list = node->info.function.arg_list;
 
+	    // TODO (CUBVEC): imporve the following logic
 	    if (arg_list->node_type == PT_NAME)
 	      {
 		vector_query = arg_list->next;
@@ -11913,6 +11914,21 @@ pt_to_vector_index_info (PARSER_CONTEXT * parser, DB_OBJECT * class_, PRED_EXPR 
 	    else if (arg_list->node_type == PT_VALUE)
 	      {
 		vector_query = arg_list;
+	      }
+	  }
+	else if (pt_is_vector_distance_expr (parser, node))
+	  {
+	    PT_NODE *arg1 = node->info.expr.arg1;
+	    PT_NODE *arg2 = node->info.expr.arg2;
+
+	    // TODO (CUBVEC): imporve the following logic
+	    if (arg1->node_type == PT_NAME)
+	      {
+		vector_query = arg2;
+	      }
+	    else if (arg1->node_type == PT_VALUE)
+	      {
+		vector_query = arg1;
 	      }
 	  }
 

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -11920,6 +11920,9 @@ pt_to_vector_index_info (PARSER_CONTEXT * parser, DB_OBJECT * class_, PRED_EXPR 
 	  {
 	    PT_NODE *arg1 = node->info.expr.arg1;
 	    PT_NODE *arg2 = node->info.expr.arg2;
+	    
+	    assert (arg1->node_type == PT_NAME || arg1->node_type == PT_VALUE);
+	    assert (arg2->node_type == PT_NAME || arg2->node_type == PT_VALUE);
 
 	    // TODO (CUBVEC): imporve the following logic
 	    if (arg1->node_type == PT_NAME)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-84

### Purpose

벡터 연산자도 벡터 인덱스를 수행할 수 있도록 수정

### Implementation

- PT_EXPR 노드가 벡터 거리 연산자인지 확인하는 pt_is_vector_distance_expr () 함수 구현
- 가독성을 위해 pt_is_vector_function () -> pt_is_vector_distance_function () 로 이름 변경
- qo_validate_index_for_vector_index ()와 pt_to_vector_index_info ()에 PT_EXPR인 경우에 pt_is_vector_distance_expr () 함수를 활용해 확인 후 벡터 인덱스를 사용하도록 구현

### Remarks

N/A
