### PR TITLE
[CBRD-26107] [REGRESSION] [DEBUG_SQL]  Prevent duplicate deletion in xasl cache

### DIFF
--- a/src/query/xasl_cache.c
+++ b/src/query/xasl_cache.c
@@ -1263,8 +1263,7 @@ xcache_entry_mark_deleted (THREAD_ENTRY * thread_p, XASL_CACHE_ENTRY * xcache_en
 
   /* The entry can be deleted if the only fixer is this transaction. */
   ATOMIC_INC_32 (&xcache_Memory_usage_cache, -xcache_entry_get_entrysize (xcache_entry));
-  assert (new_cache_flag == XCACHE_ENTRY_DELETED_BY_ME);
-  return true;
+  return (new_cache_flag == XCACHE_ENTRY_DELETED_BY_ME);
 }
 
 /*


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26107>

### Purpose

Regression Issue of CBRD-25888

### Implementation

fixed decache logic

### Remarks
