### PR TITLE
[CUBVEC-85] Fix assertion when insert vectors in table after rebooting server

### DIFF
--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1368,7 +1368,6 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
 
   css_Server_connection_socket = INVALID_SOCKET;
 
-  init_hnsw_index_path ();
   conn = css_connect_to_master_server (port_id, server_name, name_length);
   if (conn != NULL)
     {

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1368,6 +1368,7 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
 
   css_Server_connection_socket = INVALID_SOCKET;
 
+  init_hnsw_index_path ();
   conn = css_connect_to_master_server (port_id, server_name, name_length);
   if (conn != NULL)
     {

--- a/src/storage/hnsw.hpp
+++ b/src/storage/hnsw.hpp
@@ -42,5 +42,6 @@ int hnsw_print_index_info (BTID *btid);
 int hnsw_search_element (int hnsw_id, DB_VALUE *key_dbvalue, int k, OID *rec_oids, float *distances);
 int hnsw_add_element (BTID *btid, OID *oid, DB_VALUE *key_dbvalue);
 void dump_all_hnsw_indices_to_files ();
+void init_hnsw_index_path ();
 
 #endif

--- a/src/storage/hnsw_faiss.cpp
+++ b/src/storage/hnsw_faiss.cpp
@@ -226,6 +226,27 @@ void dump_all_hnsw_indices_to_files ()
     }
 }
 
+void init_hnsw_index_path ()
+{
+  char db_path[PATH_MAX];
+  fileio_get_directory_path (db_path, boot_db_full_name());
+  int written = snprintf (hnsw_index_directory, PATH_MAX, "%s%cvindex", db_path, PATH_SEPARATOR);
+  if (written < 0 || written >= PATH_MAX)
+    {
+      assert (false);
+      _er_log_debug (ARG_FILE_LINE, "Failed to create path for HNSW Index directory since path is too long");
+    }
+
+  if (std::filesystem::exists (hnsw_index_directory))
+    {
+      hnsw_index_directory_created = true;
+    }
+  else
+    {
+      hnsw_index_directory_created = false;
+    }
+}
+
 static int dump_hnsw_index (int hnsw_id, faiss::IndexIDMap *index)
 {
   char filepath[PATH_MAX];

--- a/src/storage/hnsw_faiss.cpp
+++ b/src/storage/hnsw_faiss.cpp
@@ -86,15 +86,6 @@ int xhnsw_delete_index (THREAD_ENTRY *thread_p, BTID *btid)
 {
   char filepath[PATH_MAX];
 
-  if (!hnsw_index_directory_created)
-    {
-      if (create_hnsw_index_directory () != NO_ERROR)
-	{
-	  er_log_debug (ARG_FILE_LINE, "Failed to create HNSW Index directory");
-	  return ER_FAILED;
-	}
-    }
-
   if (!btid)
     {
       assert (false);

--- a/src/storage/hnsw_usearch.cpp
+++ b/src/storage/hnsw_usearch.cpp
@@ -126,15 +126,6 @@ int xhnsw_delete_index (THREAD_ENTRY *thread_p, BTID *btid)
 {
   char filepath[PATH_MAX];
 
-  if (!hnsw_index_directory_created)
-    {
-      if (create_hnsw_index_directory () != NO_ERROR)
-	{
-	  er_log_debug (ARG_FILE_LINE, "Failed to create HNSW Index directory");
-	  return ER_FAILED;
-	}
-    }
-
   if (!btid)
     {
       assert (false);

--- a/src/storage/hnsw_usearch.cpp
+++ b/src/storage/hnsw_usearch.cpp
@@ -227,6 +227,28 @@ void dump_all_hnsw_indices_to_files ()
     }
 }
 
+void init_hnsw_index_path ()
+{
+  char db_path[PATH_MAX];
+  fileio_get_directory_path (db_path, boot_db_full_name());
+  int written = snprintf (hnsw_index_directory, PATH_MAX, "%s%cvindex", db_path, PATH_SEPARATOR);
+  if (written < 0 || written >= PATH_MAX)
+    {
+      assert (false);
+      _er_log_debug (ARG_FILE_LINE, "Failed to create path for HNSW Index directory since path is too long");
+      return;
+    }
+
+  if (std::filesystem::exists (hnsw_index_directory))
+    {
+      hnsw_index_directory_created = true;
+    }
+  else
+    {
+      hnsw_index_directory_created = false;
+    }
+}
+
 static int dump_hnsw_index (int hnsw_id, const std::unique_ptr<usearch::index_dense_t> &index)
 {
   char filepath[PATH_MAX];

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2523,6 +2523,8 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
       goto error;
     }
 
+  init_hnsw_index_path ();
+
   /*
    * Initialize the catalog manager, the query evaluator, and install meta
    * classes


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBVEC-85>

### Purpose

- 재구동된 server에 존재하는 (vector index가 걸려있는) table에 대해, Inserting 수행 시, assertion 발생
- 재구동 시, HNSW index를 dump하는 경로에 대한 정보와, 생성여부를 판단하는 변수가 초기화되면서 발생하는 현상 

### Implementation

- 서버 구동시, HNSW index dump와 관련된 변수를 체크하고, 설정하는 함수인 `init_hnsw_index_path` 함수 구현
- 서버 구동시 해당 함수 호출

### Remarks

N/A
