### PR TITLE
[CBRD-26120] 시스템 카탈로그 클래스 조회 시, Case-sensitive로 동작되는 현상

### DIFF
--- a/src/object/identifier_store.cpp
+++ b/src/object/identifier_store.cpp
@@ -106,7 +106,7 @@ namespace cubbase
     else
       {
 	// check _db
-	if (str.rfind (SYSTEM_CLASS_PREFIX, 0) != 0)
+	if (strncasecmp (str.data(), SYSTEM_CLASS_PREFIX.c_str(), SYSTEM_CLASS_PREFIX.length()) != 0)
 	  {
 	    int size = str.size ();
 	    for (int i = 0; i < size; i++)
@@ -117,8 +117,6 @@ namespace cubbase
 		  }
 	      }
 	  }
-
-
       }
     return true;
   }

--- a/src/object/schema_system_catalog.cpp
+++ b/src/object/schema_system_catalog.cpp
@@ -122,12 +122,12 @@ bool sm_check_system_class_by_name (const std::string_view name)
   char downcase_name[SM_MAX_IDENTIFIER_LENGTH] = {'\0'};
   const char *name_ptr = name.data();  // 'name' is a null-terminated string, so it's safe to use string_view::data()
 
-  assert (name_ptr != NULL);
   if (name.length() < 4)
     {
       return false;
     }
 
+  assert (name_ptr != NULL);
   if (*name_ptr == '_')
     {
       name_ptr++;
@@ -138,7 +138,7 @@ bool sm_check_system_class_by_name (const std::string_view name)
       return false;
     }
 
-  if (name_ptr[2] != '_' && strcasecmp (name_ptr, CT_DUAL_NAME) != 0)
+  if (name_ptr[2] != '_' && (strcasecmp (name.data(), CT_DUAL_NAME) != 0))
     {
       return false;
     }

--- a/src/object/schema_system_catalog.cpp
+++ b/src/object/schema_system_catalog.cpp
@@ -119,33 +119,9 @@ namespace cubschema
 
 bool sm_check_system_class_by_name (const std::string_view name)
 {
-  char downcase_name[SM_MAX_IDENTIFIER_LENGTH] = {'\0'};
-  const char *name_ptr = name.data();  // 'name' is a null-terminated string, so it's safe to use string_view::data()
-
-  if (name.length() < 4)
-    {
-      return false;
-    }
-
-  assert (name_ptr != NULL);
-  if (*name_ptr == '_')
-    {
-      name_ptr++;
-    }
-
-  if (name_ptr[0] != 'd' && name_ptr[0] != 'D')
-    {
-      return false;
-    }
-
-  if (name_ptr[2] != '_' && (strcasecmp (name.data(), CT_DUAL_NAME) != 0))
-    {
-      return false;
-    }
-
-  intl_identifier_lower (name.data(), downcase_name);
-
-  return (sm_is_system_class (downcase_name) || sm_is_system_vclass (downcase_name));
+  // TODO: bool is_enclosed = identifier_store::is_enclosed (name);
+  return identifier_store::check_identifier_is_valid (name, false)
+	 && (sm_is_system_class (name) || sm_is_system_vclass (name));
 }
 
 bool sm_is_system_class (const std::string_view name)

--- a/src/object/schema_system_catalog.cpp
+++ b/src/object/schema_system_catalog.cpp
@@ -117,22 +117,35 @@ namespace cubschema
   static const identifier_store sm_catalog_vclass_names (sm_system_vclass_names, false);
 }
 
-// 'name' is a null-terminated string, so it's safe to use string_view::data()
 bool sm_check_system_class_by_name (const std::string_view name)
 {
-  // TODO: bool is_enclosed = identifier_store::is_enclosed (name);
-  char downcase_name[SM_MAX_IDENTIFIER_LENGTH - SM_MAX_USER_LENGTH] = {'\0'};
+  char downcase_name[SM_MAX_IDENTIFIER_LENGTH] = {'\0'};
+  const char *name_ptr = name.data();  // 'name' is a null-terminated string, so it's safe to use string_view::data()
 
-  // The user-specified name is not a system class name.
-  if (strchr (name.data(), '.') != NULL)
+  assert (name_ptr != NULL);
+  if (name.length() < 4)
+    {
+      return false;
+    }
+
+  if (*name_ptr == '_')
+    {
+      name_ptr++;
+    }
+
+  if (name_ptr[0] != 'd' && name_ptr[0] != 'D')
+    {
+      return false;
+    }
+
+  if (name_ptr[2] != '_' && strcasecmp (name_ptr, CT_DUAL_NAME) != 0)
     {
       return false;
     }
 
   intl_identifier_lower (name.data(), downcase_name);
 
-  return identifier_store::check_identifier_is_valid (downcase_name, false)
-	 && (sm_is_system_class (downcase_name) || sm_is_system_vclass (downcase_name));
+  return (sm_is_system_class (downcase_name) || sm_is_system_vclass (downcase_name));
 }
 
 bool sm_is_system_class (const std::string_view name)

--- a/src/object/schema_system_catalog.cpp
+++ b/src/object/schema_system_catalog.cpp
@@ -117,12 +117,18 @@ namespace cubschema
   static const identifier_store sm_catalog_vclass_names (sm_system_vclass_names, false);
 }
 
+// 'name' is a null-terminated string, so it's safe to use string_view::data()
 bool sm_check_system_class_by_name (const std::string_view name)
 {
   // TODO: bool is_enclosed = identifier_store::is_enclosed (name);
-
   char downcase_name[SM_MAX_IDENTIFIER_LENGTH - SM_MAX_USER_LENGTH] = {'\0'};
-  // 'name' is a null-terminated string, so it's safe to use string_view::data()
+
+  // The user-specified name is not a system class name.
+  if (strchr (name.data(), '.') != NULL)
+    {
+      return false;
+    }
+
   intl_identifier_lower (name.data(), downcase_name);
 
   return identifier_store::check_identifier_is_valid (downcase_name, false)

--- a/src/object/schema_system_catalog.cpp
+++ b/src/object/schema_system_catalog.cpp
@@ -120,8 +120,13 @@ namespace cubschema
 bool sm_check_system_class_by_name (const std::string_view name)
 {
   // TODO: bool is_enclosed = identifier_store::is_enclosed (name);
-  return identifier_store::check_identifier_is_valid (name, false)
-	 && (sm_is_system_class (name) || sm_is_system_vclass (name));
+
+  char downcase_name[SM_MAX_IDENTIFIER_LENGTH - SM_MAX_USER_LENGTH] = {'\0'};
+  // 'name' is a null-terminated string, so it's safe to use string_view::data()
+  intl_identifier_lower (name.data(), downcase_name);
+
+  return identifier_store::check_identifier_is_valid (downcase_name, false)
+	 && (sm_is_system_class (downcase_name) || sm_is_system_vclass (downcase_name));
 }
 
 bool sm_is_system_class (const std::string_view name)


### PR DESCRIPTION
[http://jira.cubrid.org/browse/CBRD-26120](http://jira.cubrid.org/browse/CBRD-26120)

### Purpose
11.4의 수정 사항으로 인해 발생한 시스템 카탈로그 조회 시, Case-sensitive로 동작되는 현상을 수정합니다.