### PR TITLE
[CBRD-26056] restore installation of cm_stat.h to $CUBIRD/include

### DIFF
--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -692,6 +692,10 @@ install(FILES
   ${API_DIR}/cubrid_log.h
   DESTINATION ${CUBRID_INCLUDEDIR} COMPONENT Header
   )
+install(FILES
+  ${CM_COMMON_DIR}/cm_stat.h
+  DESTINATION ${CUBRID_INCLUDEDIR} COMPONENT Header
+  )
 
 # install pdb files for debugging on windows
 if(WIN32)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26056>

### Purpose

해당 이슈의 이전 commit 에서 $CUBRID/include 아래로 인스톨하지 않도록 수정했던 세 개의 헤더 파일 중에
cm_stat.h 는 shell TC 중 하나에서 사용되고 있는 것이 발견되어 다시 인스톨하도록 수정합니다. 

### Implementation

cm_stat.h 를 $CUBRID/include로 인스톨하도록 cubrid/CMakeLists.txt 수정 

### Remarks

N/A
