### PR TITLE
[CUBRIDQA-1268] Rollback build environment to centos6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,7 @@ jobs:
             executors:
               cubrid-default:
                 docker:
-                  - image: cubridci/cubridci:develop_cl7.9
+                  - image: cubridci/cubridci:develop
                 working_directory: /home
 
               cubrid-test-shell:
@@ -212,7 +212,8 @@ jobs:
                   CC: "ccache gcc"
                   CXX: "ccache g++"
                   CCACHE_DIR: /home/.ccache
-                  CCACHE_MAXSIZE: "5G"
+                  CCACHE_COMPILERCHECK: content
+                  CCACHE_HARDLINK: 1
                 steps:
                   - checkout
                   - restore_cache:
@@ -228,6 +229,7 @@ jobs:
                       name: Build
                       command: |
                         mkdir -p \$CCACHE_DIR
+                        ccache --max-size=5G
                         ccache -z
                         scl enable devtoolset-8 -- /entrypoint.sh build
                         ccache -s


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1268>

### Purpose
jenkins 빌드이미지와 circleci 의 이미지를 통일하기 위해 centos6 적용.
centos6 에서 사용가능한 ccache 3.1.6 을 적용.

### Implementation

N/A

### Remarks
https://github.com/CUBRID/cubridci/pull/72
머지가 선행되어야함.