### PR TITLE
[CBRD-26131] use fdatasync when syncing only data.

### DIFF
--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -771,7 +771,7 @@ disk_format (THREAD_ENTRY * thread_p, const char *dbname, VOLID volid, DBDEF_VOL
   /* Flush all pages that were formatted. This is not needed, but it is done for security reasons to identify the volume
    * in case of a system crash. Note that the identification may not be possible during media crashes */
   (void) pgbuf_flush_all (thread_p, volid);
-  (void) fileio_synchronize (thread_p, vdes, vol_fullname, FILEIO_SYNC_ALSO_FLUSH_DWB);
+  (void) fileio_synchronize (thread_p, vdes, vol_fullname, FILEIO_SYNC_VOLUME_AND_FLUSH_DWB, FILEIO_SYNC_ALL);
 
   fault_inject_random_crash ();
 

--- a/src/storage/double_write_buffer.c
+++ b/src/storage/double_write_buffer.c
@@ -2284,7 +2284,7 @@ dwb_flush_block (THREAD_ENTRY * thread_p, DWB_BLOCK * block, bool file_sync_help
 		{
 		  (void) fileio_synchronize (thread_p,
 					     dwb_Global.file_sync_helper_block->flush_volumes_info[i].vdes, NULL,
-					     FILEIO_SYNC_ONLY);
+					     FILEIO_SYNC_VOLUME_ONLY);
 
 		  dwb_log ("dwb_flush_block: Synchronized volume %d\n",
 			   dwb_Global.file_sync_helper_block->flush_volumes_info[i].vdes);
@@ -2327,7 +2327,7 @@ dwb_flush_block (THREAD_ENTRY * thread_p, DWB_BLOCK * block, bool file_sync_help
   /* Increment statistics after writing in double write volume. */
   perfmon_add_stat (thread_p, PSTAT_PB_NUM_IOWRITES, block->count_wb_pages);
 
-  if (fileio_synchronize (thread_p, dwb_Global.vdes, dwb_Volume_name, FILEIO_SYNC_ONLY) != dwb_Global.vdes)
+  if (fileio_synchronize (thread_p, dwb_Global.vdes, dwb_Volume_name, FILEIO_SYNC_VOLUME_ONLY) != dwb_Global.vdes)
     {
       assert (false);
       /* Something wrong happened. */
@@ -2385,7 +2385,7 @@ dwb_flush_block (THREAD_ENTRY * thread_p, DWB_BLOCK * block, bool file_sync_help
       num_pages = ATOMIC_TAS_32 (&block->flush_volumes_info[i].num_pages, 0);
       assert (num_pages != 0);
 
-      (void) fileio_synchronize (thread_p, block->flush_volumes_info[i].vdes, NULL, FILEIO_SYNC_ONLY);
+      (void) fileio_synchronize (thread_p, block->flush_volumes_info[i].vdes, NULL, FILEIO_SYNC_VOLUME_ONLY);
 
       dwb_log ("dwb_flush_block: Synchronized volume %d\n", block->flush_volumes_info[i].vdes);
     }
@@ -3257,7 +3257,7 @@ dwb_load_and_recover_pages (THREAD_ENTRY * thread_p, const char *dwb_path_p, con
 	      for (i = 0; i < rcv_block->count_flush_volumes_info; i++)
 		{
 		  if (fileio_synchronize (thread_p, rcv_block->flush_volumes_info[i].vdes, NULL,
-					  FILEIO_SYNC_ONLY) == NULL_VOLDES)
+					  FILEIO_SYNC_VOLUME_ONLY) == NULL_VOLDES)
 		    {
 		      error_code = ER_FAILED;
 		      goto end;
@@ -3771,7 +3771,7 @@ dwb_file_sync_helper (THREAD_ENTRY * thread_p)
 	   * Flush the volume. If not all volume pages are available now, continue with next volume, if any,
 	   * and then resume the current one.
 	   */
-	  (void) fileio_synchronize (thread_p, current_flush_volume_info->vdes, NULL, FILEIO_SYNC_ONLY);
+	  (void) fileio_synchronize (thread_p, current_flush_volume_info->vdes, NULL, FILEIO_SYNC_VOLUME_ONLY);
 
 	  dwb_log ("dwb_file_sync_helper: Synchronized volume %d\n", current_flush_volume_info->vdes);
 	}

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -2826,7 +2826,7 @@ fileio_copy_volume (THREAD_ENTRY * thread_p, int from_vol_desc, DKNPAGES npages,
 	}
     }
 
-  if (fileio_synchronize (thread_p, to_vol_desc, to_vol_label_p, FILEIO_SYNC_ALSO_FLUSH_DWB) != to_vol_desc)
+  if (fileio_synchronize (thread_p, to_vol_desc, to_vol_label_p, FILEIO_SYNC_VOLUME_AND_FLUSH_DWB, FILEIO_SYNC_ALL) != to_vol_desc)
     {
       goto error;
     }
@@ -2890,7 +2890,7 @@ fileio_reset_volume (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel, DK
     }
   free_and_init (malloc_io_page_p);
 
-  if (fileio_synchronize (thread_p, vol_fd, vlabel, FILEIO_SYNC_ALSO_FLUSH_DWB) != vol_fd)
+  if (fileio_synchronize (thread_p, vol_fd, vlabel, FILEIO_SYNC_VOLUME_AND_FLUSH_DWB) != vol_fd)
     {
       success = ER_FAILED;
     }
@@ -3100,7 +3100,7 @@ fileio_dismount (THREAD_ENTRY * thread_p, int vol_fd)
    */
   vlabel = fileio_get_volume_label_by_fd (vol_fd, PEEK);
 
-  (void) fileio_synchronize (thread_p, vol_fd, vlabel, FILEIO_SYNC_ALSO_FLUSH_DWB);
+  (void) fileio_synchronize (thread_p, vol_fd, vlabel, FILEIO_SYNC_VOLUME_AND_FLUSH_DWB, FILEIO_SYNC_ALL);
 
 #if !defined(WINDOWS)
   lockf_type = fileio_get_lockf_type (vol_fd);
@@ -3302,7 +3302,7 @@ fileio_dismount_volume (THREAD_ENTRY * thread_p, FILEIO_VOLUME_INFO * vol_info_p
 {
   if (vol_info_p->vdes != NULL_VOLDES)
     {
-      (void) fileio_synchronize (thread_p, vol_info_p->vdes, vol_info_p->vlabel, FILEIO_SYNC_ALSO_FLUSH_DWB);
+      (void) fileio_synchronize (thread_p, vol_info_p->vdes, vol_info_p->vlabel, FILEIO_SYNC_VOLUME_AND_FLUSH_DWB, FILEIO_SYNC_ALL);
 
 #if !defined(WINDOWS)
       if (vol_info_p->lockf_type != FILEIO_NOT_LOCKF)
@@ -3344,7 +3344,7 @@ fileio_dismount_all (THREAD_ENTRY * thread_p)
       if (sys_vol_info_p->vdes != NULL_VOLDES)
 	{
 	  /* System volume. No need to sync DWB. */
-	  (void) fileio_synchronize (thread_p, sys_vol_info_p->vdes, sys_vol_info_p->vlabel, FILEIO_SYNC_ONLY);
+	  (void) fileio_synchronize (thread_p, sys_vol_info_p->vdes, sys_vol_info_p->vlabel, FILEIO_SYNC_VOLUME_ONLY, FILEIO_SYNC_ALL);
 
 #if !defined(WINDOWS)
 	  if (sys_vol_info_p->lockf_type != FILEIO_NOT_LOCKF)
@@ -3647,7 +3647,7 @@ pwrite_with_injected_fault (THREAD_ENTRY * thread_p, int fd, const void *buf, si
 	      er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_FAILED_ASSERTION, 1, msg);
 
 	      // exit handler
-	      (void) fileio_synchronize (thread_p, fd, vlabel, FILEIO_SYNC_ONLY);
+	      (void) fileio_synchronize (thread_p, fd, vlabel, FILEIO_SYNC_VOLUME_ONLY);
 
 #if !defined(NDEBUG)
 	      if (prm_get_bool_value (PRM_ID_ER_LOG_DEBUG))
@@ -4386,10 +4386,11 @@ fileio_writev (THREAD_ENTRY * thread_p, int vol_fd, void **io_page_array, PAGEID
  *   return: vdes or NULL_VOLDES
  *   vol_fd(in): Volume descriptor
  *   vlabel(in): Volume label
- *   sync_dwb(in): FILEIO_SYNC_ALSO_FLUSH_DWB if needs sync dwb
+ *   sync_target(in): sync target
+ *   sync_scope(in): sync scope
  */
 int
-fileio_synchronize (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel, FILEIO_SYNC_OPTION sync_dwb)
+fileio_synchronize (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel, FILEIO_SYNC_TARGET sync_target, FILEIO_SYNC_SCOPE sync_scope)
 {
   int ret = NO_ERROR;
   bool all_sync = false;
@@ -4402,6 +4403,9 @@ fileio_synchronize (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel, FIL
   int r;
 #endif
   static int inc_cnt = 0;
+
+  assert (sync_target == FILEIO_SYNC_VOLUME_ONLY || sync_target == FILEIO_SYNC_VOLUME_AND_FLUSH_DWB);
+  assert (sync_scope == FILEIO_SYNC_ALL || sync_scope == FILEIO_SYNC_DATA);
 
   if (prm_get_integer_value (PRM_ID_SUPPRESS_FSYNC) > 0)
     {
@@ -4432,7 +4436,7 @@ fileio_synchronize (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel, FIL
 #endif
 
 #if !defined (CS_MODE)
-  if (sync_dwb == FILEIO_SYNC_ALSO_FLUSH_DWB && fileio_is_permanent_volume_descriptor (thread_p, vol_fd))
+  if (sync_target == FILEIO_SYNC_VOLUME_AND_FLUSH_DWB && fileio_is_permanent_volume_descriptor (thread_p, vol_fd))
     {
       ret = dwb_flush_force (thread_p, &all_sync);
     }
@@ -4441,7 +4445,14 @@ fileio_synchronize (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel, FIL
   /* If all_sync is true, everything was synchronized. This happens when DWB is completely flushed. */
   if (ret == NO_ERROR && all_sync == false)
     {
-      ret = fsync (vol_fd);
+      if (sync_scope == FILEIO_SYNC_ALL)
+	{
+	  ret = fsync (vol_fd);
+	}
+      else
+	{
+	  ret = fdatasync (vol_fd);
+	}
     }
 
 #if defined (EnableThreadMonitoring)
@@ -4517,7 +4528,7 @@ fileio_synchronize_sys_volume (THREAD_ENTRY * thread_p, FILEIO_SYSTEM_VOLUME_INF
 
 
       /* System volume. No need to sync DWB. */
-      fileio_synchronize (thread_p, sys_vol_info_p->vdes, sys_vol_info_p->vlabel, FILEIO_SYNC_ONLY);
+      fileio_synchronize (thread_p, sys_vol_info_p->vdes, sys_vol_info_p->vlabel, FILEIO_SYNC_VOLUME_ONLY, FILEIO_SYNC_ALL);
     }
 
   return found;
@@ -4553,7 +4564,7 @@ fileio_synchronize_volume (THREAD_ENTRY * thread_p, FILEIO_VOLUME_INFO * vol_inf
 	  return false;
 	}
 
-      fileio_synchronize (thread_p, vol_info_p->vdes, vol_info_p->vlabel, FILEIO_SYNC_ONLY);
+      fileio_synchronize (thread_p, vol_info_p->vdes, vol_info_p->vlabel, FILEIO_SYNC_VOLUME_ONLY, FILEIO_SYNC_ALL);
     }
 
   return found;
@@ -7350,7 +7361,7 @@ fileio_finish_backup (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session_p
 	}
 
       if (fileio_synchronize (thread_p, session_p->bkup.vdes, session_p->bkup.name,
-			      FILEIO_SYNC_ONLY) != session_p->bkup.vdes)
+			      FILEIO_SYNC_VOLUME_ONLY, FILEIO_SYNC_ALL) != session_p->bkup.vdes)
 	{
 	  return NULL;
 	}

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -2826,7 +2826,8 @@ fileio_copy_volume (THREAD_ENTRY * thread_p, int from_vol_desc, DKNPAGES npages,
 	}
     }
 
-  if (fileio_synchronize (thread_p, to_vol_desc, to_vol_label_p, FILEIO_SYNC_VOLUME_AND_FLUSH_DWB, FILEIO_SYNC_ALL) != to_vol_desc)
+  if (fileio_synchronize (thread_p, to_vol_desc, to_vol_label_p, FILEIO_SYNC_VOLUME_AND_FLUSH_DWB, FILEIO_SYNC_ALL) !=
+      to_vol_desc)
     {
       goto error;
     }
@@ -3302,7 +3303,8 @@ fileio_dismount_volume (THREAD_ENTRY * thread_p, FILEIO_VOLUME_INFO * vol_info_p
 {
   if (vol_info_p->vdes != NULL_VOLDES)
     {
-      (void) fileio_synchronize (thread_p, vol_info_p->vdes, vol_info_p->vlabel, FILEIO_SYNC_VOLUME_AND_FLUSH_DWB, FILEIO_SYNC_ALL);
+      (void) fileio_synchronize (thread_p, vol_info_p->vdes, vol_info_p->vlabel, FILEIO_SYNC_VOLUME_AND_FLUSH_DWB,
+				 FILEIO_SYNC_ALL);
 
 #if !defined(WINDOWS)
       if (vol_info_p->lockf_type != FILEIO_NOT_LOCKF)
@@ -3344,7 +3346,8 @@ fileio_dismount_all (THREAD_ENTRY * thread_p)
       if (sys_vol_info_p->vdes != NULL_VOLDES)
 	{
 	  /* System volume. No need to sync DWB. */
-	  (void) fileio_synchronize (thread_p, sys_vol_info_p->vdes, sys_vol_info_p->vlabel, FILEIO_SYNC_VOLUME_ONLY, FILEIO_SYNC_ALL);
+	  (void) fileio_synchronize (thread_p, sys_vol_info_p->vdes, sys_vol_info_p->vlabel, FILEIO_SYNC_VOLUME_ONLY,
+				     FILEIO_SYNC_ALL);
 
 #if !defined(WINDOWS)
 	  if (sys_vol_info_p->lockf_type != FILEIO_NOT_LOCKF)
@@ -4390,7 +4393,8 @@ fileio_writev (THREAD_ENTRY * thread_p, int vol_fd, void **io_page_array, PAGEID
  *   sync_scope(in): sync scope
  */
 int
-fileio_synchronize (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel, FILEIO_SYNC_TARGET sync_target, FILEIO_SYNC_SCOPE sync_scope)
+fileio_synchronize (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel, FILEIO_SYNC_TARGET sync_target,
+		    FILEIO_SYNC_SCOPE sync_scope)
 {
   int ret = NO_ERROR;
   bool all_sync = false;
@@ -4528,7 +4532,8 @@ fileio_synchronize_sys_volume (THREAD_ENTRY * thread_p, FILEIO_SYSTEM_VOLUME_INF
 
 
       /* System volume. No need to sync DWB. */
-      fileio_synchronize (thread_p, sys_vol_info_p->vdes, sys_vol_info_p->vlabel, FILEIO_SYNC_VOLUME_ONLY, FILEIO_SYNC_ALL);
+      fileio_synchronize (thread_p, sys_vol_info_p->vdes, sys_vol_info_p->vlabel, FILEIO_SYNC_VOLUME_ONLY,
+			  FILEIO_SYNC_ALL);
     }
 
   return found;

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -2074,7 +2074,8 @@ fileio_create (THREAD_ENTRY * thread_p, const char *db_full_name_p, const char *
 	       bool is_do_lock, bool is_do_sync)
 {
   int tmp_vol_desc = NULL_VOLDES;
-  int vol_fd;
+  int vol_fd, dir_fd;
+  char dir_path[PATH_MAX];
   FILEIO_LOCKF_TYPE lockf_type = FILEIO_NOT_LOCKF;
 #if defined(WINDOWS)
   int sh_flag;
@@ -2165,6 +2166,24 @@ fileio_create (THREAD_ENTRY * thread_p, const char *db_full_name_p, const char *
 	    }
 	}
 #endif /* !WINDOWS */
+
+      /* we must sync the parent directory to ensure the link to the new file is written to disk. */
+      if (cub_dirname_r (vol_label_p, dir_path, PATH_MAX) < 0)
+	{
+	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_IO_FORMAT_FAIL, 3, vol_label_p, -1, -1LL);
+	}
+      /* get the fd for the parent directory */
+      dir_fd = fileio_open (dir_path, O_RDONLY, FILEIO_DISK_PROTECTION_MODE);
+      if (dir_fd == NULL_VOLDES)
+	{
+	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_IO_FORMAT_FAIL, 3, vol_label_p, -1, -1LL);
+	}
+      /* use fsync */
+      if (fileio_synchronize (thread_p, dir_fd, dir_path, FILEIO_SYNC_VOLUME_ONLY, FILEIO_SYNC_ALL) != dir_fd)
+	{
+	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_IO_FORMAT_FAIL, 3, vol_label_p, -1, -1LL);
+	}
+      fileio_close (dir_fd);
 
 #if !defined(CS_MODE)
       if (fileio_cache (vol_id, vol_label_p, vol_fd, lockf_type) != vol_fd)
@@ -2588,6 +2607,10 @@ fileio_expand_to (THREAD_ENTRY * thread_p, VOLID vol_id, DKNPAGES size_npages, D
   start_pageid = (PAGEID) (current_size / IO_PAGESIZE);
   last_pageid = ((PAGEID) (new_size / IO_PAGESIZE) - 1);
 
+  /* we need to sync every changes including metadata for safety */
+  fileio_truncate (vol_fd, last_pageid);
+  fileio_synchronize (thread_p, vol_fd, vol_label_p, FILEIO_SYNC_VOLUME_ONLY, FILEIO_SYNC_ALL);
+
   if (voltype == DB_TEMPORARY_VOLTYPE)
     {
       /* Write the last page */
@@ -2614,7 +2637,6 @@ fileio_expand_to (THREAD_ENTRY * thread_p, VOLID vol_id, DKNPAGES size_npages, D
 }
 #endif /* not CS_MODE */
 
-#if defined(ENABLE_UNUSED_FUNCTION)
 /*
  * fileio_truncate () -  TRUNCATE A TEMPORARY VOLUME
  *   return: npages
@@ -2663,7 +2685,6 @@ fileio_truncate (VOLID vol_id, DKNPAGES npages_to_resize)
     }
   return npages_to_resize;
 }
-#endif
 
 /*
  * fileio_unformat () - DESTROY A VOLUME
@@ -4467,7 +4488,7 @@ fileio_synchronize (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel, FIL
     }
 #endif
 
-  if (ret != 0)
+  if (ret < 0)
     {
       /* sync error is not alwasy handled and I am not sure a proper safe handling is possible: raise as fatal error */
       er_set_with_oserror (ER_FATAL_ERROR_SEVERITY, ARG_FILE_LINE, ER_IO_SYNC, 1, (vlabel ? vlabel : "Unknown"));

--- a/src/storage/file_io.h
+++ b/src/storage/file_io.h
@@ -158,9 +158,15 @@ typedef enum
 
 typedef enum
 {
-  FILEIO_SYNC_ONLY,
-  FILEIO_SYNC_ALSO_FLUSH_DWB
-} FILEIO_SYNC_OPTION;
+  FILEIO_SYNC_VOLUME_ONLY,
+  FILEIO_SYNC_VOLUME_AND_FLUSH_DWB
+} FILEIO_SYNC_TARGET;
+
+typedef enum
+{
+  FILEIO_SYNC_ALL,   /* sync both data and metadata (fsync) */
+  FILEIO_SYNC_DATA   /* sync data only, skip metadata (fdatasync) */
+} FILEIO_SYNC_SCOPE;
 
 typedef enum
 {
@@ -496,7 +502,7 @@ extern void *fileio_write_pages (THREAD_ENTRY * thread_p, int vol_fd, char *io_p
 extern void *fileio_writev (THREAD_ENTRY * thread_p, int vdes, void **arrayof_io_pgptr, PAGEID start_pageid,
 			    DKNPAGES npages, size_t page_size);
 extern int fileio_synchronize (THREAD_ENTRY * thread_p, int vdes, const char *vlabel,
-			       FILEIO_SYNC_OPTION check_sync_dwb);
+			       FILEIO_SYNC_TARGET sync_target, FILEIO_SYNC_SCOPE sync_scope = FILEIO_SYNC_DATA);
 extern int fileio_synchronize_all (THREAD_ENTRY * thread_p, bool include_log);
 #if defined (ENABLE_UNUSED_FUNCTION)
 extern void *fileio_read_user_area (THREAD_ENTRY * thread_p, int vdes, PAGEID pageid, off_t start_offset, size_t nbytes,

--- a/src/storage/file_io.h
+++ b/src/storage/file_io.h
@@ -476,9 +476,7 @@ extern int fileio_expand_to (THREAD_ENTRY * threda_p, VOLID volid, DKNPAGES npag
 extern void *fileio_initialize_pages (THREAD_ENTRY * thread_p, int vdes, FILEIO_PAGE * io_pgptr, DKNPAGES start_pageid,
 				      DKNPAGES npages, size_t page_size, int kbytes_to_be_written_per_sec);
 extern void fileio_initialize_res (THREAD_ENTRY * thread_p, FILEIO_PAGE * io_page, PGLENGTH page_size);
-#if defined (ENABLE_UNUSED_FUNCTION)
 extern DKNPAGES fileio_truncate (VOLID volid, DKNPAGES npages_to_resize);
-#endif
 extern void fileio_unformat (THREAD_ENTRY * thread_p, const char *vlabel);
 extern void fileio_unformat_and_rename (THREAD_ENTRY * thread_p, const char *vlabel, const char *new_vlabel);
 extern int fileio_copy_volume (THREAD_ENTRY * thread_p, int from_vdes, DKNPAGES npages, const char *to_vlabel,

--- a/src/storage/file_io.h
+++ b/src/storage/file_io.h
@@ -164,8 +164,8 @@ typedef enum
 
 typedef enum
 {
-  FILEIO_SYNC_ALL,   /* sync both data and metadata (fsync) */
-  FILEIO_SYNC_DATA   /* sync data only, skip metadata (fdatasync) */
+  FILEIO_SYNC_ALL,		/* sync both data and metadata (fsync) */
+  FILEIO_SYNC_DATA		/* sync data only, skip metadata (fdatasync) */
 } FILEIO_SYNC_SCOPE;
 
 typedef enum

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -6150,7 +6150,7 @@ boot_dbparm_save_volume (THREAD_ENTRY * thread_p, DB_VOLTYPE voltype, VOLID voli
   /* flush the boot_Db_parm object. this is not necessary but it is recommended in order to mount every known volume
    * during restart. that may not be possible during media crash though. */
   heap_flush (thread_p, boot_Db_parm_oid);
-  fileio_synchronize (thread_p, fileio_get_volume_descriptor (boot_Db_parm_oid->volid), NULL, FILEIO_SYNC_ALSO_FLUSH_DWB);	/* label? */
+  fileio_synchronize (thread_p, fileio_get_volume_descriptor (boot_Db_parm_oid->volid), NULL, FILEIO_SYNC_VOLUME_AND_FLUSH_DWB);	/* label? */
 
 exit:
   return error_code;

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -2959,7 +2959,7 @@ logpb_write_toflush_pages_to_archive (THREAD_ENTRY * thread_p)
   if ((bg_arv_info->current_page_id - bg_arv_info->last_sync_pageid) > prm_get_integer_value (PRM_ID_PB_SYNC_ON_NFLUSH))
     {
       /* System volume. No need to sync DWB. */
-      fileio_synchronize (thread_p, bg_arv_info->vdes, log_Name_bg_archive, FILEIO_SYNC_ONLY);
+      fileio_synchronize (thread_p, bg_arv_info->vdes, log_Name_bg_archive, FILEIO_SYNC_VOLUME_ONLY);
       bg_arv_info->last_sync_pageid = bg_arv_info->current_page_id;
     }
 }
@@ -3706,7 +3706,7 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
 	  || (log_Stat.total_sync_count % prm_get_integer_value (PRM_ID_SUPPRESS_FSYNC) == 0))
 	{
 	  /* System volume. No need to sync DWB. */
-	  if (fileio_synchronize (thread_p, log_Gl.append.vdes, log_Name_active, FILEIO_SYNC_ONLY) == NULL_VOLDES)
+	  if (fileio_synchronize (thread_p, log_Gl.append.vdes, log_Name_active, FILEIO_SYNC_VOLUME_ONLY) == NULL_VOLDES)
 	    {
 	      error_code = ER_FAILED;
 	      goto error;
@@ -3769,7 +3769,7 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
 	}
 
       /* we need to also sync again */
-      if (fileio_synchronize (thread_p, log_Gl.append.vdes, log_Name_active, FILEIO_SYNC_ONLY) == NULL_VOLDES)
+      if (fileio_synchronize (thread_p, log_Gl.append.vdes, log_Name_active, FILEIO_SYNC_VOLUME_ONLY) == NULL_VOLDES)
 	{
 	  error_code = ER_FAILED;
 	  goto error;
@@ -5826,7 +5826,7 @@ logpb_archive_active_log (THREAD_ENTRY * thread_p)
        * Make sure that the whole log archive is in physical storage at this
        * moment. System volume. No need to sync DWB.
        */
-      if (fileio_synchronize (thread_p, vdes, arv_name, FILEIO_SYNC_ONLY) == NULL_VOLDES)
+      if (fileio_synchronize (thread_p, vdes, arv_name, FILEIO_SYNC_VOLUME_ONLY, FILEIO_SYNC_ALL) == NULL_VOLDES)
 	{
 	  goto error;
 	}
@@ -5853,7 +5853,7 @@ logpb_archive_active_log (THREAD_ENTRY * thread_p)
 #if 0
   if (prm_get_integer_value (PRM_ID_SUPPRESS_FSYNC) != 0)
     {
-      fileio_synchronize (thread_p, log_Gl.append.vdes, FILEIO_SYNC_ONLY);
+      fileio_synchronize (thread_p, log_Gl.append.vdes, FILEIO_SYNC_VOLUME_ONLY);
     }
 #endif
 
@@ -7237,7 +7237,7 @@ logpb_checkpoint (THREAD_ENTRY * thread_p)
        * due to volume header page modification).
        */
       vdes = fileio_get_volume_descriptor (volid);
-      if (fileio_synchronize (thread_p, vdes, fileio_get_volume_label (vdes, PEEK), FILEIO_SYNC_ALSO_FLUSH_DWB) != vdes)
+      if (fileio_synchronize (thread_p, vdes, fileio_get_volume_label (vdes, PEEK), FILEIO_SYNC_VOLUME_AND_FLUSH_DWB) != vdes)
 	{
 	  goto error_cannot_chkpt;
 	}
@@ -7503,7 +7503,7 @@ logpb_backup_for_volume (THREAD_ENTRY * thread_p, VOLID volid, LOG_LSA * chkpt_l
     }
 
   vdes = fileio_get_volume_descriptor (volid);
-  if (fileio_synchronize (thread_p, vdes, fileio_get_volume_label (vdes, PEEK), FILEIO_SYNC_ALSO_FLUSH_DWB) != vdes)
+  if (fileio_synchronize (thread_p, vdes, fileio_get_volume_label (vdes, PEEK), FILEIO_SYNC_VOLUME_AND_FLUSH_DWB) != vdes)
     {
       return ER_FAILED;
     }
@@ -9315,7 +9315,7 @@ logpb_copy_volume (THREAD_ENTRY * thread_p, VOLID from_volid, const char *to_vol
     }
 
   if (fileio_synchronize (thread_p, from_vdes, fileio_get_volume_label (from_vdes, PEEK),
-			  FILEIO_SYNC_ALSO_FLUSH_DWB) != from_vdes)
+			  FILEIO_SYNC_VOLUME_AND_FLUSH_DWB) != from_vdes)
     {
       return ER_FAILED;
     }
@@ -9691,7 +9691,7 @@ logpb_copy_database (THREAD_ENTRY * thread_p, VOLID num_perm_vols, const char *t
 		  fileio_dismount (thread_p, to_vdes);
 		  goto error;
 		}
-	      if (fileio_synchronize (thread_p, to_vdes, to_volname, FILEIO_SYNC_ALSO_FLUSH_DWB) != to_vdes)
+	      if (fileio_synchronize (thread_p, to_vdes, to_volname, FILEIO_SYNC_VOLUME_AND_FLUSH_DWB, FILEIO_SYNC_ALL) != to_vdes)
 		{
 		  fileio_dismount (thread_p, to_vdes);
 		  error_code = ER_FAILED;
@@ -10149,7 +10149,7 @@ logpb_rename_all_volumes_files (THREAD_ENTRY * thread_p, VOLID num_perm_vols, co
 	  goto error;
 	}
       if (fileio_synchronize (thread_p, fileio_get_volume_descriptor (volid), fileio_get_volume_label (volid, PEEK),
-			      FILEIO_SYNC_ALSO_FLUSH_DWB) == NULL_VOLDES)
+			      FILEIO_SYNC_VOLUME_AND_FLUSH_DWB, FILEIO_SYNC_ALL) == NULL_VOLDES)
 	{
 	  error_code = ER_FAILED;
 	  goto error;

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -3706,7 +3706,8 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
 	  || (log_Stat.total_sync_count % prm_get_integer_value (PRM_ID_SUPPRESS_FSYNC) == 0))
 	{
 	  /* System volume. No need to sync DWB. */
-	  if (fileio_synchronize (thread_p, log_Gl.append.vdes, log_Name_active, FILEIO_SYNC_VOLUME_ONLY) == NULL_VOLDES)
+	  if (fileio_synchronize (thread_p, log_Gl.append.vdes, log_Name_active, FILEIO_SYNC_VOLUME_ONLY) ==
+	      NULL_VOLDES)
 	    {
 	      error_code = ER_FAILED;
 	      goto error;
@@ -7237,7 +7238,8 @@ logpb_checkpoint (THREAD_ENTRY * thread_p)
        * due to volume header page modification).
        */
       vdes = fileio_get_volume_descriptor (volid);
-      if (fileio_synchronize (thread_p, vdes, fileio_get_volume_label (vdes, PEEK), FILEIO_SYNC_VOLUME_AND_FLUSH_DWB) != vdes)
+      if (fileio_synchronize (thread_p, vdes, fileio_get_volume_label (vdes, PEEK), FILEIO_SYNC_VOLUME_AND_FLUSH_DWB) !=
+	  vdes)
 	{
 	  goto error_cannot_chkpt;
 	}
@@ -7503,7 +7505,8 @@ logpb_backup_for_volume (THREAD_ENTRY * thread_p, VOLID volid, LOG_LSA * chkpt_l
     }
 
   vdes = fileio_get_volume_descriptor (volid);
-  if (fileio_synchronize (thread_p, vdes, fileio_get_volume_label (vdes, PEEK), FILEIO_SYNC_VOLUME_AND_FLUSH_DWB) != vdes)
+  if (fileio_synchronize (thread_p, vdes, fileio_get_volume_label (vdes, PEEK), FILEIO_SYNC_VOLUME_AND_FLUSH_DWB) !=
+      vdes)
     {
       return ER_FAILED;
     }
@@ -9691,7 +9694,8 @@ logpb_copy_database (THREAD_ENTRY * thread_p, VOLID num_perm_vols, const char *t
 		  fileio_dismount (thread_p, to_vdes);
 		  goto error;
 		}
-	      if (fileio_synchronize (thread_p, to_vdes, to_volname, FILEIO_SYNC_VOLUME_AND_FLUSH_DWB, FILEIO_SYNC_ALL) != to_vdes)
+	      if (fileio_synchronize (thread_p, to_vdes, to_volname, FILEIO_SYNC_VOLUME_AND_FLUSH_DWB, FILEIO_SYNC_ALL)
+		  != to_vdes)
 		{
 		  fileio_dismount (thread_p, to_vdes);
 		  error_code = ER_FAILED;

--- a/src/transaction/log_writer.c
+++ b/src/transaction/log_writer.c
@@ -1108,7 +1108,7 @@ logwr_flush_all_append_pages (void)
    * future log writes. That is, the pages should be stored on physical disk.
    */
   if (need_sync == true
-      && fileio_synchronize (NULL, logwr_Gl.append_vdes, logwr_Gl.active_name, FILEIO_SYNC_ONLY) == NULL_VOLDES)
+      && fileio_synchronize (NULL, logwr_Gl.append_vdes, logwr_Gl.active_name, FILEIO_SYNC_VOLUME_ONLY) == NULL_VOLDES)
     {
       assert (er_errid () != NO_ERROR);
       return er_errid ();
@@ -1118,7 +1118,7 @@ logwr_flush_all_append_pages (void)
   if (need_sync == true && prm_get_bool_value (PRM_ID_LOG_BACKGROUND_ARCHIVING))
     {
       if (fileio_synchronize (NULL, logwr_Gl.bg_archive_info.vdes, logwr_Gl.bg_archive_name,
-			      FILEIO_SYNC_ONLY) == NULL_VOLDES)
+			      FILEIO_SYNC_VOLUME_ONLY) == NULL_VOLDES)
 	{
 	  assert (er_errid () != NO_ERROR);
 	  return er_errid ();
@@ -1179,7 +1179,7 @@ logwr_flush_bgarv_header_page (void)
 
   if (fileio_write (NULL, bg_arv_info->vdes, log_pgptr, phy_pageid, LOG_PAGESIZE,
 		    FILEIO_WRITE_NO_COMPENSATE_WRITE) == NULL
-      || fileio_synchronize (NULL, bg_arv_info->vdes, logwr_Gl.bg_archive_name, FILEIO_SYNC_ONLY) == NULL_VOLDES)
+      || fileio_synchronize (NULL, bg_arv_info->vdes, logwr_Gl.bg_archive_name, FILEIO_SYNC_VOLUME_ONLY) == NULL_VOLDES)
     {
       if (er_errid () == ER_IO_WRITE_OUT_OF_SPACE)
 	{
@@ -1232,7 +1232,7 @@ logwr_flush_header_page (void)
   /* logwr_Gl.append_vdes is only changed while starting or finishing or recovering server. So, log cs is not needed. */
   if (fileio_write (NULL, logwr_Gl.append_vdes, logwr_Gl.loghdr_pgptr, phy_pageid, LOG_PAGESIZE,
 		    FILEIO_WRITE_NO_COMPENSATE_WRITE) == NULL
-      || fileio_synchronize (NULL, logwr_Gl.append_vdes, logwr_Gl.active_name, FILEIO_SYNC_ONLY) == NULL_VOLDES)
+      || fileio_synchronize (NULL, logwr_Gl.append_vdes, logwr_Gl.active_name, FILEIO_SYNC_VOLUME_ONLY) == NULL_VOLDES)
     {
 
       if (er_errid () == ER_IO_WRITE_OUT_OF_SPACE)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26131

### Purpose

CUBRID는 OS file 메타데이터를 기반으로 하는 처리가 없으며, 처음부터 볼륨을 일정 크기로 생성하여 사용하므로 fdatasync를 사용하여도 데이터 소실 없이 일관성을 유지할 수 있다.

### Implementation

단순히 데이터 sync를 수행할 때는 fdatasync를 사용하도록 한다. 다만, volume을 처음으로 생성한 경우나 전체적인 변경 사항을 적용할 때에는 fsync를 사용하도록 하였다.

또, 변수의 목적을 조금 더 명확히 하기 위하여 FILEIO_SYNC_OPTION을 FILEIO_SYNC_TARGET으로 변경하였고, sync 범위를 결정할 수 있도록 enum FILEIO_SYNC_SCOPE를 추가하였다.
```
typedef enum
{
  FILEIO_SYNC_VOLUME_ONLY,
  FILEIO_SYNC_VOLUME_AND_FLUSH_DWB
} FILEIO_SYNC_TARGET;

typedef enum
{
  FILEIO_SYNC_ALL,   /* sync both data and metadata (fsync) */
  FILEIO_SYNC_DATA   /* sync data only, skip metadata (fdatasync) */
} FILEIO_SYNC_SCOPE;
```

### Remarks

file io layer가 DWB를 호출하는 것은 이상하나 전부 refactoring하기에는 고쳐야 할 부분이 너무 많아 제외하였다.