### PR TITLE
[CBRD-26129] bugfix: duplicate PL server log java0.log in $HOME directory

### DIFF
--- a/pl_engine/pl_server/src/main/resources/logging.properties
+++ b/pl_engine/pl_server/src/main/resources/logging.properties
@@ -16,7 +16,7 @@
 # By default we only configure a ConsoleHandler, which will only
 # show messages at the INFO and above levels.
 #handlers= java.util.logging.ConsoleHandler
-handlers= java.util.logging.FileHandler
+#handlers= java.util.logging.FileHandler
 
 # To also add the FileHandler, use the following line instead.
 #handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26129>

### Purpose

PL 서버 로그가 $HOME/java0.log 로 중복해서 생성되는 문제 해결

### Implementation

logging.properties 파일 안의 handlers 항목 설정 삭제

### Remarks

N/A
