### PR TITLE
[CBRD-26133] Ensure that AU_DISABLE_PASSWORDS() is correctly set to prevent unnecessary password authentication prompts during server access.

### DIFF
--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -2759,16 +2759,7 @@ copylogdb (UTIL_FUNCTION_ARG * arg)
   os_set_signal_handler (SIGBUS, crash_handler);
   os_set_signal_handler (SIGSEGV, crash_handler);
   os_set_signal_handler (SIGSYS, crash_handler);
-#endif
 
-  AU_DISABLE_PASSWORDS ();
-  db_set_client_type (DB_CLIENT_TYPE_LOG_COPIER);
-  if (db_login ("DBA", NULL) != NO_ERROR)
-    {
-      PRINT_AND_LOG_ERR_MSG ("%s\n", db_error_string (3));
-      goto error_exit;
-    }
-#if !defined(WINDOWS)
   /* save executable path */
   binary_name = basename (arg->argv0);
   (void) envvar_bindir_file (executable_path, PATH_MAX, binary_name);
@@ -2808,6 +2799,14 @@ copylogdb (UTIL_FUNCTION_ARG * arg)
 #endif
 
 retry:
+  AU_DISABLE_PASSWORDS ();
+  db_set_client_type (DB_CLIENT_TYPE_LOG_COPIER);
+  if (db_login ("DBA", NULL) != NO_ERROR)
+    {
+      PRINT_AND_LOG_ERR_MSG ("%s\n", db_error_string (3));
+      goto error_exit;
+    }
+
   error = db_restart (arg->command_name, TRUE, database_name);
   if (error != NO_ERROR)
     {
@@ -2969,17 +2968,7 @@ applylogdb (UTIL_FUNCTION_ARG * arg)
   os_set_signal_handler (SIGBUS, crash_handler);
   os_set_signal_handler (SIGSEGV, crash_handler);
   os_set_signal_handler (SIGSYS, crash_handler);
-#endif
 
-  AU_DISABLE_PASSWORDS ();
-  db_set_client_type (DB_CLIENT_TYPE_LOG_APPLIER);
-  if (db_login ("DBA", NULL) != NO_ERROR)
-    {
-      PRINT_AND_LOG_ERR_MSG ("%s\n", db_error_string (3));
-      goto error_exit;
-    }
-
-#if !defined(WINDOWS)
   /* save executable path */
   binary_name = basename (arg->argv0);
   (void) envvar_bindir_file (executable_path, PATH_MAX, binary_name);
@@ -3029,6 +3018,14 @@ applylogdb (UTIL_FUNCTION_ARG * arg)
 #endif
 
 retry:
+  AU_DISABLE_PASSWORDS ();
+  db_set_client_type (DB_CLIENT_TYPE_LOG_APPLIER);
+  if (db_login ("DBA", NULL) != NO_ERROR)
+    {
+      PRINT_AND_LOG_ERR_MSG ("%s\n", db_error_string (3));
+      goto error_exit;
+    }
+
   error = db_restart (arg->command_name, TRUE, database_name);
   if (error != NO_ERROR)
     {
@@ -3287,9 +3284,6 @@ applyinfo (UTIL_FUNCTION_ARG * arg)
 	}
     }
 
-  AU_DISABLE_PASSWORDS ();
-  db_set_client_type (DB_CLIENT_TYPE_ADMIN_UTILITY);
-
   /* error message log file */
   sprintf (er_msg_file, "%s_%s.err", database_name, arg->command_name);
   er_init (er_msg_file, ER_NEVER_EXIT);
@@ -3316,6 +3310,9 @@ applyinfo (UTIL_FUNCTION_ARG * arg)
 	    {
 	      goto check_applied_info_end;
 	    }
+
+	  AU_DISABLE_PASSWORDS ();
+	  db_set_client_type (DB_CLIENT_TYPE_ADMIN_UTILITY);
 
 	  error = db_login ("DBA", NULL);
 	  if (error != NO_ERROR)
@@ -3384,6 +3381,9 @@ applyinfo (UTIL_FUNCTION_ARG * arg)
 	    {
 	      goto check_master_info_end;
 	    }
+
+	  AU_DISABLE_PASSWORDS ();
+	  db_set_client_type (DB_CLIENT_TYPE_ADMIN_UTILITY);
 
 	  if (db_login ("DBA", NULL) != NO_ERROR)
 	    {

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -4976,10 +4976,6 @@ gen_tz (UTIL_FUNCTION_ARG * arg)
 
   if (tz_gen_type == TZ_GEN_TYPE_EXTEND && checksum[0] != '\0')
     {
-      AU_DISABLE_PASSWORDS ();
-      db_set_client_type (DB_CLIENT_TYPE_ADMIN_UTILITY);
-      db_login ("DBA", NULL);
-
       if (db_name != NULL)
 	{
 	  dir = (DB_INFO *) calloc (1, sizeof (DB_INFO));
@@ -5007,6 +5003,10 @@ gen_tz (UTIL_FUNCTION_ARG * arg)
 
       for (db_info_p = dir; db_info_p != NULL; db_info_p = db_info_p->next)
 	{
+	  AU_DISABLE_PASSWORDS ();
+	  db_set_client_type (DB_CLIENT_TYPE_ADMIN_UTILITY);
+	  db_login ("DBA", NULL);
+
 	  if (db_restart (arg->command_name, TRUE, db_info_p->name) != NO_ERROR)
 	    {
 	      need_db_shutdown = true;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26133

### Purpose
* AU_DISABLE_PASSWORDS() 설정이 db_shutdown()에 의해 리셋된 후 다시 db_restart()가 호출되는 경우 disable 적용이 안되어 있음

### Implementation
* db_restart() 전에 항상 AU_DISABLE_PASSWORDS() 보장되도록 수정
