### PR TITLE
[CBRD-26132] create error message table earlier than any threads that use it

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/jdbc/CUBRIDServerSideJDBCErrorCode.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/jdbc/CUBRIDServerSideJDBCErrorCode.java
@@ -74,6 +74,7 @@ public class CUBRIDServerSideJDBCErrorCode {
     public static final int ER_ARGUMENT_ZERO = -21128;
 
     private static final HashMap<Integer, String> messageString = new HashMap<Integer, String>();
+
     static {
         messageString.put(ER_UNKNOWN, "Error");
         messageString.put(ER_NO_ERROR, "No Error");
@@ -138,12 +139,11 @@ public class CUBRIDServerSideJDBCErrorCode {
             // default error message
             String ret = messageString.get(index);
             if (ret == null) {
-                assert false: String.format("unknown error code %d", index);
+                assert false : String.format("unknown error code %d", index);
                 return String.format("unknown error code %d", index);
             } else {
                 return ret;
             }
         }
     }
-
 }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/jdbc/CUBRIDServerSideJDBCErrorCode.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/jdbc/CUBRIDServerSideJDBCErrorCode.java
@@ -73,30 +73,8 @@ public class CUBRIDServerSideJDBCErrorCode {
     public static final int ER_NOT_COLLECTION = -21121;
     public static final int ER_ARGUMENT_ZERO = -21128;
 
-    private static HashMap<Integer, String> messageString = null;
-
-    public static String codeToMessage(int index) {
-        if (messageString == null) setMessageHash();
-        return messageString.get(index);
-    }
-
-    public static String codeToMessage(int index, String msg) {
-        if (messageString == null) {
-            setMessageHash();
-        }
-
-        if (index == ER_DBMS && msg != null) {
-            // received error message from DB server
-            return msg;
-        } else {
-            // default error message
-            return messageString.get(index);
-        }
-    }
-
-    private static void setMessageHash() {
-        messageString = new HashMap<Integer, String>();
-
+    private static final HashMap<Integer, String> messageString = new HashMap<Integer, String>();
+    static {
         messageString.put(ER_UNKNOWN, "Error");
         messageString.put(ER_NO_ERROR, "No Error");
         messageString.put(ER_DBMS, "Server error");
@@ -147,4 +125,25 @@ public class CUBRIDServerSideJDBCErrorCode {
         messageString.put(ER_NOT_COLLECTION, "The type of the column should be a collection type.");
         messageString.put(ER_ARGUMENT_ZERO, "The argument row can not be zero.");
     }
+
+    public static String codeToMessage(int index) {
+        return messageString.get(index);
+    }
+
+    public static String codeToMessage(int index, String msg) {
+        if (index == ER_DBMS && msg != null) {
+            // received error message from DB server
+            return msg;
+        } else {
+            // default error message
+            String ret = messageString.get(index);
+            if (ret == null) {
+                assert false: String.format("unknown error code %d", index);
+                return String.format("unknown error code %d", index);
+            } else {
+                return ret;
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26132>

### Purpose

CUBRIDServerSideException에 사용되는 에러메시지 테이블이 그 것을 참조하는 여러 ExecuteThread 들이
각자 독립적으로 생성할 수 있다는 동기화 문제를 해결한다. 

### Implementation

참조하는 thread 가 생기기 전인 클래스 초기화 시간에 그 테이블을 미리 만들어 두어 동기화 문제를 회피한다.
기존에는 에러 메시지를 참조하는 시점에 테이블이 안 만들어져 있으면 그 때 만드는 방식이었음. (테이블 생성을 사용 시점까지 미룸)

### Remarks

N/A
