### PR TITLE
[CBRD-26060] log applier 모듈에 에러 매크로 추가

### DIFF
--- a/src/base/error_manager.h
+++ b/src/base/error_manager.h
@@ -246,7 +246,8 @@ typedef void (*PTR_FNERLOG) (int err_id);
   ((err) == ER_TM_SERVER_DOWN_UNILATERALLY_ABORTED \
    || (err) == ER_NET_SERVER_CRASHED \
    || (err) == ER_OBJ_NO_CONNECT \
-   || (err) == ER_BO_CONNECT_FAILED)
+   || (err) == ER_BO_CONNECT_FAILED \
+   || (err) == ER_NET_CANT_CONNECT_SERVER)
 
 /* Macros to assert that error is set. */
 #define ASSERT_ERROR() \

--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -2903,8 +2903,8 @@ error_exit:
     }
 #endif
 
-  if (logwr_force_shutdown () == false
-      && (error == ER_NET_SERVER_CRASHED || error == ER_NET_CANT_CONNECT_SERVER || error == ER_BO_CONNECT_FAILED
+  if (!logwr_force_shutdown ()
+      && (ER_IS_SERVER_DOWN_ERROR (error)
 	  || error == ERR_CSS_TCP_CANNOT_CONNECT_TO_MASTER || error == ERR_CSS_TCP_CONNECT_TIMEDOUT))
     {
       (void) sleep (sleep_nsecs);
@@ -3126,9 +3126,9 @@ error_exit:
     }
 #endif
 
-  if (la_force_shutdown () == false
-      && (error == ER_NET_SERVER_CRASHED || error == ER_NET_CANT_CONNECT_SERVER
-	  || error == ERR_CSS_TCP_CANNOT_CONNECT_TO_MASTER || error == ER_BO_CONNECT_FAILED
+  if (!la_force_shutdown ()
+      && (ER_IS_SERVER_DOWN_ERROR (error)
+	  || error == ERR_CSS_TCP_CANNOT_CONNECT_TO_MASTER
 	  || error == ER_NET_SERVER_COMM_ERROR || error == ER_LC_PARTIALLY_FAILED_TO_FLUSH))
     {
       (void) sleep (sleep_nsecs);

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -20777,8 +20777,7 @@ do_create_server (PARSER_CONTEXT * parser, PT_NODE * statement)
       if (owner_obj == NULL)
 	{
 	  assert (er_errid () != NO_ERROR);
-	  error = er_errid ();
-	  if (error == ER_NET_CANT_CONNECT_SERVER || error == ER_OBJ_NO_CONNECT)
+	  if (ER_IS_SERVER_DOWN_ERROR (er_errid ()))
 	    {
 	      error = ER_NET_CANT_CONNECT_SERVER;
 	    }
@@ -21249,8 +21248,7 @@ do_alter_server (PARSER_CONTEXT * parser, PT_NODE * statement)
       if (user == NULL)
 	{
 	  assert (er_errid () != NO_ERROR);
-	  error = er_errid ();
-	  if (error == ER_NET_CANT_CONNECT_SERVER || error == ER_OBJ_NO_CONNECT)
+	  if (ER_IS_SERVER_DOWN_ERROR (er_errid ()))
 	    {
 	      error = ER_NET_CANT_CONNECT_SERVER;
 	    }

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -21248,7 +21248,8 @@ do_alter_server (PARSER_CONTEXT * parser, PT_NODE * statement)
       if (user == NULL)
 	{
 	  assert (er_errid () != NO_ERROR);
-	  if (ER_IS_SERVER_DOWN_ERROR (er_errid ()))
+	  error = er_errid ();
+	  if (ER_IS_SERVER_DOWN_ERROR (error))
 	    {
 	      error = ER_NET_CANT_CONNECT_SERVER;
 	    }

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -173,6 +173,12 @@
     } \
   while (0)
 
+#define IS_CONNECTION_ERROR(err) \
+  ((err) == ER_NET_CANT_CONNECT_SERVER || (err) == ER_OBJ_NO_CONNECT)
+
+#define IS_LA_FLUSH_ERROR(err) \
+  ((err) == ER_LC_PARTIALLY_FAILED_TO_FLUSH || (err) == ER_LC_FAILED_TO_FLUSH_REPL_ITEMS)
+
 typedef struct la_cache_buffer LA_CACHE_BUFFER;
 struct la_cache_buffer
 {
@@ -5171,7 +5177,7 @@ end:
 
       la_Info.fail_counter++;
 
-      if (error == ER_NET_CANT_CONNECT_SERVER || error == ER_OBJ_NO_CONNECT)
+      if (IS_CONNECTION_ERROR (error))
 	{
 	  error = ER_NET_CANT_CONNECT_SERVER;
 	}
@@ -5390,7 +5396,7 @@ end:
 
       la_Info.fail_counter++;
 
-      if (error == ER_NET_CANT_CONNECT_SERVER || error == ER_OBJ_NO_CONNECT)
+      if (IS_CONNECTION_ERROR (error))
 	{
 	  error = ER_NET_CANT_CONNECT_SERVER;
 	}
@@ -5607,7 +5613,7 @@ la_apply_statement_log (LA_ITEM * item)
 	  user = au_find_user (item->db_user);
 	  if (user == NULL)
 	    {
-	      if (er_errid () == ER_NET_CANT_CONNECT_SERVER || er_errid () == ER_OBJ_NO_CONNECT)
+	      if (IS_CONNECTION_ERROR (er_errid ()))
 		{
 		  error = ER_NET_CANT_CONNECT_SERVER;
 		}
@@ -5671,7 +5677,7 @@ la_apply_statement_log (LA_ITEM * item)
 	  assert (er_errid () != NO_ERROR);
 	  error = er_errid ();
 	  error_msg = er_msg ();
-	  if (error == ER_NET_CANT_CONNECT_SERVER || error == ER_OBJ_NO_CONNECT)
+	  if (IS_CONNECTION_ERROR (error))
 	    {
 	      error = ER_NET_CANT_CONNECT_SERVER;
 	    }
@@ -5855,7 +5861,7 @@ la_apply_repl_log (int tranid, int rectype, LOG_LSA * commit_lsa, int *total_row
 	  else
 	    {
 	      /* reconnect to server due to error while flushing repl items */
-	      if (error == ER_LC_PARTIALLY_FAILED_TO_FLUSH || error == ER_LC_FAILED_TO_FLUSH_REPL_ITEMS)
+	      if (IS_LA_FLUSH_ERROR (error))
 		{
 		  goto end;
 		}
@@ -5868,7 +5874,7 @@ la_apply_repl_log (int tranid, int rectype, LOG_LSA * commit_lsa, int *total_row
 	      sprintf (error_string, "[%s,%s] %s", item->class_name, sb.get_buffer (), db_error_string (1));
 	      er_log_debug (ARG_FILE_LINE, "Internal system failure: %s", error_string);
 
-	      if (errid == ER_NET_CANT_CONNECT_SERVER || errid == ER_OBJ_NO_CONNECT)
+	      if (IS_CONNECTION_ERROR (errid))
 		{
 		  error = ER_NET_CANT_CONNECT_SERVER;
 		  goto end;
@@ -6254,7 +6260,7 @@ la_log_record_process (LOG_RECORD_HEADER * lrec, LOG_LSA * final, LOG_PAGE * pg_
 		  la_applier_need_shutdown = true;
 		  return error;
 		}
-	      else if (error == ER_LC_PARTIALLY_FAILED_TO_FLUSH || error == ER_LC_FAILED_TO_FLUSH_REPL_ITEMS)
+	      else if (IS_LA_FLUSH_ERROR (error))
 		{
 		  return error;
 		}
@@ -6574,7 +6580,7 @@ la_log_commit (bool update_commit_time)
 
       er_log_debug (ARG_FILE_LINE, "log applied but cannot update last committed LSA (%d|%d)",
 		    la_Info.committed_lsa.pageid, la_Info.committed_lsa.offset);
-      if (res == ER_NET_CANT_CONNECT_SERVER || res == ER_OBJ_NO_CONNECT)
+      if (IS_CONNECTION_ERROR (res))
 	{
 	  error = ER_NET_CANT_CONNECT_SERVER;
 	}
@@ -8331,8 +8337,7 @@ la_apply_log_file (const char *database_name, const char *log_path, const int ma
 				(long long int) la_Info.committed_lsa.pageid);
 
 		  error = la_log_commit (false);
-		  if (error == ER_NET_CANT_CONNECT_SERVER || error == ER_OBJ_NO_CONNECT
-		      || error == ER_LC_PARTIALLY_FAILED_TO_FLUSH || error == ER_LC_FAILED_TO_FLUSH_REPL_ITEMS)
+		  if (IS_CONNECTION_ERROR (error) || IS_LA_FLUSH_ERROR (error))
 		    {
 		      la_shutdown ();
 		      return error;
@@ -8519,8 +8524,7 @@ la_apply_log_file (const char *database_name, const char *log_path, const int ma
 	      error = la_log_record_process (lrec, &la_Info.final_lsa, pg_ptr);
 	      if (error != NO_ERROR)
 		{
-		  /* check connection error */
-		  if (error == ER_NET_CANT_CONNECT_SERVER || error == ER_OBJ_NO_CONNECT)
+		  if (IS_CONNECTION_ERROR (error))
 		    {
 		      la_shutdown ();
 		      return ER_NET_CANT_CONNECT_SERVER;
@@ -8530,7 +8534,7 @@ la_apply_log_file (const char *database_name, const char *log_path, const int ma
 		      la_applier_need_shutdown = true;
 		      break;
 		    }
-		  else if (error == ER_LC_PARTIALLY_FAILED_TO_FLUSH || error == ER_LC_FAILED_TO_FLUSH_REPL_ITEMS)
+		  else if (IS_LA_FLUSH_ERROR (error))
 		    {
 		      la_shutdown ();
 		      return error;
@@ -8573,9 +8577,7 @@ la_apply_log_file (const char *database_name, const char *log_path, const int ma
 	  error = la_check_time_commit (&time_commit, time_commit_interval);
 	  if (error != NO_ERROR)
 	    {
-	      /* check connection error */
-	      if (error == ER_NET_CANT_CONNECT_SERVER || error == ER_OBJ_NO_CONNECT
-		  || error == ER_LC_PARTIALLY_FAILED_TO_FLUSH || error == ER_LC_FAILED_TO_FLUSH_REPL_ITEMS)
+	      if (IS_CONNECTION_ERROR (error) || IS_LA_FLUSH_ERROR (error))
 		{
 		  la_shutdown ();
 		  return error;
@@ -8592,8 +8594,7 @@ la_apply_log_file (const char *database_name, const char *log_path, const int ma
 
 	  /* check and change state */
 	  error = la_change_state ();
-	  if (error == ER_NET_CANT_CONNECT_SERVER || error == ER_OBJ_NO_CONNECT
-	      || error == ER_LC_PARTIALLY_FAILED_TO_FLUSH || error == ER_LC_FAILED_TO_FLUSH_REPL_ITEMS)
+	  if (IS_CONNECTION_ERROR (error) || IS_LA_FLUSH_ERROR (error))
 	    {
 	      la_shutdown ();
 	      return error;

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -173,10 +173,7 @@
     } \
   while (0)
 
-#define IS_CONNECTION_ERROR(err) \
-  ((err) == ER_NET_CANT_CONNECT_SERVER || (err) == ER_OBJ_NO_CONNECT)
-
-#define IS_LA_FLUSH_ERROR(err) \
+#define LA_IS_FLUSH_ERROR(err) \
   ((err) == ER_LC_PARTIALLY_FAILED_TO_FLUSH || (err) == ER_LC_FAILED_TO_FLUSH_REPL_ITEMS)
 
 typedef struct la_cache_buffer LA_CACHE_BUFFER;
@@ -5177,7 +5174,7 @@ end:
 
       la_Info.fail_counter++;
 
-      if (IS_CONNECTION_ERROR (error))
+      if (ER_IS_SERVER_DOWN_ERROR (error))
 	{
 	  error = ER_NET_CANT_CONNECT_SERVER;
 	}
@@ -5396,7 +5393,7 @@ end:
 
       la_Info.fail_counter++;
 
-      if (IS_CONNECTION_ERROR (error))
+      if (ER_IS_SERVER_DOWN_ERROR (error))
 	{
 	  error = ER_NET_CANT_CONNECT_SERVER;
 	}
@@ -5613,7 +5610,7 @@ la_apply_statement_log (LA_ITEM * item)
 	  user = au_find_user (item->db_user);
 	  if (user == NULL)
 	    {
-	      if (IS_CONNECTION_ERROR (er_errid ()))
+	      if (ER_IS_SERVER_DOWN_ERROR (er_errid ()))
 		{
 		  error = ER_NET_CANT_CONNECT_SERVER;
 		}
@@ -5677,7 +5674,7 @@ la_apply_statement_log (LA_ITEM * item)
 	  assert (er_errid () != NO_ERROR);
 	  error = er_errid ();
 	  error_msg = er_msg ();
-	  if (IS_CONNECTION_ERROR (error))
+	  if (ER_IS_SERVER_DOWN_ERROR (error))
 	    {
 	      error = ER_NET_CANT_CONNECT_SERVER;
 	    }
@@ -5861,7 +5858,7 @@ la_apply_repl_log (int tranid, int rectype, LOG_LSA * commit_lsa, int *total_row
 	  else
 	    {
 	      /* reconnect to server due to error while flushing repl items */
-	      if (IS_LA_FLUSH_ERROR (error))
+	      if (LA_IS_FLUSH_ERROR (error))
 		{
 		  goto end;
 		}
@@ -5874,7 +5871,7 @@ la_apply_repl_log (int tranid, int rectype, LOG_LSA * commit_lsa, int *total_row
 	      sprintf (error_string, "[%s,%s] %s", item->class_name, sb.get_buffer (), db_error_string (1));
 	      er_log_debug (ARG_FILE_LINE, "Internal system failure: %s", error_string);
 
-	      if (IS_CONNECTION_ERROR (errid))
+	      if (ER_IS_SERVER_DOWN_ERROR (errid))
 		{
 		  error = ER_NET_CANT_CONNECT_SERVER;
 		  goto end;
@@ -6260,7 +6257,7 @@ la_log_record_process (LOG_RECORD_HEADER * lrec, LOG_LSA * final, LOG_PAGE * pg_
 		  la_applier_need_shutdown = true;
 		  return error;
 		}
-	      else if (IS_LA_FLUSH_ERROR (error))
+	      else if (LA_IS_FLUSH_ERROR (error))
 		{
 		  return error;
 		}
@@ -6580,7 +6577,7 @@ la_log_commit (bool update_commit_time)
 
       er_log_debug (ARG_FILE_LINE, "log applied but cannot update last committed LSA (%d|%d)",
 		    la_Info.committed_lsa.pageid, la_Info.committed_lsa.offset);
-      if (IS_CONNECTION_ERROR (res))
+      if (ER_IS_SERVER_DOWN_ERROR (res))
 	{
 	  error = ER_NET_CANT_CONNECT_SERVER;
 	}
@@ -8337,7 +8334,7 @@ la_apply_log_file (const char *database_name, const char *log_path, const int ma
 				(long long int) la_Info.committed_lsa.pageid);
 
 		  error = la_log_commit (false);
-		  if (IS_CONNECTION_ERROR (error) || IS_LA_FLUSH_ERROR (error))
+		  if (ER_IS_SERVER_DOWN_ERROR (error) || LA_IS_FLUSH_ERROR (error))
 		    {
 		      la_shutdown ();
 		      return error;
@@ -8524,7 +8521,7 @@ la_apply_log_file (const char *database_name, const char *log_path, const int ma
 	      error = la_log_record_process (lrec, &la_Info.final_lsa, pg_ptr);
 	      if (error != NO_ERROR)
 		{
-		  if (IS_CONNECTION_ERROR (error))
+		  if (ER_IS_SERVER_DOWN_ERROR (error))
 		    {
 		      la_shutdown ();
 		      return ER_NET_CANT_CONNECT_SERVER;
@@ -8534,7 +8531,7 @@ la_apply_log_file (const char *database_name, const char *log_path, const int ma
 		      la_applier_need_shutdown = true;
 		      break;
 		    }
-		  else if (IS_LA_FLUSH_ERROR (error))
+		  else if (LA_IS_FLUSH_ERROR (error))
 		    {
 		      la_shutdown ();
 		      return error;
@@ -8577,7 +8574,7 @@ la_apply_log_file (const char *database_name, const char *log_path, const int ma
 	  error = la_check_time_commit (&time_commit, time_commit_interval);
 	  if (error != NO_ERROR)
 	    {
-	      if (IS_CONNECTION_ERROR (error) || IS_LA_FLUSH_ERROR (error))
+	      if (ER_IS_SERVER_DOWN_ERROR (error) || LA_IS_FLUSH_ERROR (error))
 		{
 		  la_shutdown ();
 		  return error;
@@ -8594,7 +8591,7 @@ la_apply_log_file (const char *database_name, const char *log_path, const int ma
 
 	  /* check and change state */
 	  error = la_change_state ();
-	  if (IS_CONNECTION_ERROR (error) || IS_LA_FLUSH_ERROR (error))
+	  if (ER_IS_SERVER_DOWN_ERROR (error) || LA_IS_FLUSH_ERROR (error))
 	    {
 	      la_shutdown ();
 	      return error;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26060
### Purpose

제어문에 조건식이 길어 파악하는데 어려움이 있는 코드 일부 리팩토링을 하였습니다.

### Implementation

IS_CONNECTION_ERROR, IS_LA_FLUSH_ERROR 두 매크로를 추가하였습니다.

IS_CONNECTION_ERROR는 네트워크 연결 과정에서 발생하는 에러 
ER_NET_CANT_CONNECT_SERVER 혹은 ER_OBJ_NO_CONNECT 인 경우를 의미하고

IS_LA_FLUSH_ERROR는 리플 객체를 플러시하는 과정에서 발생하는 에러
ER_LC_PARTIALLY_FAILED_TO_FLUSH 혹은 ER_LC_FAILED_TO_FLUSH_REPL_ITEMS를 의미합니다


### Remarks

* flush 는 다른 모듈에서도 발생할 수 있는 에러라고 생각되어 LA 키워드를 포함시켰습니다.
* 코드상 /* check connection error */는 매크로(혹은 기존 코드에서) 역할이 명확하기에 불필요한 주석이라고 생각되어 삭제했습니다.

