### PR TITLE
[CBRD-26130] 불필요 변수 삭제

### DIFF
--- a/src/communication/network_cl.c
+++ b/src/communication/network_cl.c
@@ -2067,24 +2067,16 @@ net_client_check_log_header (LOGWR_CONTEXT * ctx_ptr, char *argbuf, int argsize,
  */
 int
 net_client_request_with_logwr_context (LOGWR_CONTEXT * ctx_ptr, int request, char *argbuf, int argsize, char *replybuf,
-				       int replysize, char *databuf1, int datasize1, char *databuf2, int datasize2,
-				       char **replydata_ptr1, int *replydatasize_ptr1, char **replydata_ptr2,
-				       int *replydatasize_ptr2)
+				       int replysize, char *databuf1, int datasize1, char *databuf2, int datasize2)
 {
   unsigned int rc;
   int size;
-  int error;
+  int error = NO_ERROR;
   int request_error;
   char *reply = NULL, *ptr;
   QUERY_SERVER_REQUEST server_request;
   int server_request_num;
   bool do_read;
-
-  error = 0;
-  *replydata_ptr1 = NULL;
-  *replydata_ptr2 = NULL;
-  *replydatasize_ptr1 = 0;
-  *replydatasize_ptr2 = 0;
 
   if (net_Server_name[0] == '\0')
     {
@@ -2209,9 +2201,7 @@ net_client_request_with_logwr_context (LOGWR_CONTEXT * ctx_ptr, int request, cha
 
       if (histo_is_collecting ())
 	{
-	  int recevied = replysize
-	    + (replydatasize_ptr1 ? *replydatasize_ptr1 : 0) + (replydatasize_ptr2 ? *replydatasize_ptr2 : 0);
-	  histo_finish_request (request, recevied);
+	  histo_finish_request (request, replysize);
 	}
     }
   return error;

--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -9370,8 +9370,6 @@ logwr_get_log_pages (LOGWR_CONTEXT * ctx_ptr)
   OR_ALIGNED_BUF (OR_INT64_SIZE + OR_INT_SIZE * 2) a_request;
   OR_ALIGNED_BUF (OR_INT_SIZE * 2) a_reply;
   char *request, *reply;
-  char *replydata1, *replydata2;
-  int replydata_size1, replydata_size2;
   char *ptr;
   LOG_PAGEID first_pageid_torecv;
   LOGWR_MODE mode, save_mode;
@@ -9445,7 +9443,7 @@ logwr_get_log_pages (LOGWR_CONTEXT * ctx_ptr)
   req_error =
     net_client_request_with_logwr_context (ctx_ptr, NET_SERVER_LOGWR_GET_LOG_PAGES, request,
 					   OR_ALIGNED_BUF_SIZE (a_request), reply, OR_ALIGNED_BUF_SIZE (a_reply), NULL,
-					   0, NULL, 0, &replydata1, &replydata_size1, &replydata2, &replydata_size2);
+					   0, NULL, 0);
 
   logwr_Gl.mode = save_mode;
 

--- a/src/communication/network_interface_cl.h
+++ b/src/communication/network_interface_cl.h
@@ -332,9 +332,7 @@ extern int net_client_check_log_header (LOGWR_CONTEXT * ctx_ptr, char *argbuf, i
 					int replysize, char **logpg_area_buf, bool verbose);
 extern int net_client_request_with_logwr_context (LOGWR_CONTEXT * ctx_ptr, int request, char *argbuf, int argsize,
 						  char *replybuf, int replysize, char *databuf1, int datasize1,
-						  char *databuf2, int datasize2, char **replydata_ptr1,
-						  int *replydatasize_ptr1, char **replydata_ptr2,
-						  int *replydatasize_ptr2);
+						  char *databuf2, int datasize2);
 extern void net_client_logwr_send_end_msg (int rc, int error);
 extern int net_client_get_next_log_pages (int rc, char *replybuf, int replysize, int length);
 #if defined(ENABLE_UNUSED_FUNCTION)

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -4250,7 +4250,6 @@ la_get_overflow_recdes (LOG_RECORD_HEADER * log_record, void *logs, RECDES * rec
   LA_OVF_PAGE_LIST *ovf_list_tail = NULL;
   LA_OVF_PAGE_LIST *ovf_list_data = NULL;
   void *log_info;
-  VPID prev_vpid;
   bool first = true;
   int copyed_len;
   int area_len;
@@ -4259,8 +4258,6 @@ la_get_overflow_recdes (LOG_RECORD_HEADER * log_record, void *logs, RECDES * rec
   int length = 0;
 
   LSA_COPY (&current_lsa, &log_record->prev_tranlsa);
-  prev_vpid.pageid = ((LOG_REC_UNDOREDO *) logs)->data.pageid;
-  prev_vpid.volid = ((LOG_REC_UNDOREDO *) logs)->data.volid;
 
   while (!LSA_ISNULL (&current_lsa))
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26130

### Purpose

copylogdb, applylogdb 의 불필요 변수 삭제

### Implementation

copylogdb - net_client_request_with_logwr_context 에서 불필요 변수를 삭제했습니다.
- replydata_ptr1
- replydatasize_ptr1
- replydata_ptr2
- replydatasize_ptr2


applylogdb - la_get_overflow_recdes 에서 불필요 변수 삭제했습니다.
- prev_vpid

### Remarks

* 이슈 주제에서 벗어나는 범위가 있지만 리뷰에 큰 어려움이 없을것이라고 판단해 하나의 이슈로 진행했습니다.
