### PR TITLE
[CBRD-25862] add sql_data_access attribute to _db_stored_procedure

### DIFF
--- a/src/object/schema_system_catalog_install.cpp
+++ b/src/object/schema_system_catalog_install.cpp
@@ -28,6 +28,7 @@
 #include "db.h"
 #include "dbtype_function.h"
 #include "schema_system_catalog_constants.h"
+#include "sp_constants.hpp"
 #include "work_space.h"
 #include "schema_manager.h"
 #include "schema_system_catalog_builder.hpp"
@@ -812,6 +813,7 @@ namespace cubschema
       {"target_class", format_varchar (1024)},
       {"target_method", format_varchar (1024)},
       {"owner", AU_USER_CLASS_NAME},
+      {SP_ATTR_SQL_DATA_ACCESS, "integer"},
       {"comment", format_varchar (1024)},
       {"created_time", "datetime"},
       {"updated_time", "datetime"},

--- a/src/sp/sp_catalog.cpp
+++ b/src/sp/sp_catalog.cpp
@@ -101,7 +101,7 @@ static int sp_builtin_init ()
   v.is_system_generated = true;
   v.directive = SP_DIRECTIVE_RIGHTS_OWNER;
   v.owner = Au_public_user;
-  v.sql_data_access = SP_SQL_TYPE_NONE;
+  v.sql_data_access = SP_SQL_TYPE_UNKNOWN;
   v.comment = "";
   v.target_class = "com.cubrid.plcsql.builtin.DBMS_OUTPUT";
   v.created_time = *db_get_datetime (&current_datetime);

--- a/src/sp/sp_catalog.cpp
+++ b/src/sp/sp_catalog.cpp
@@ -33,6 +33,7 @@
 #include "object_accessor.h"
 #include "set_object.h"
 #include "locator_cl.h"
+#include "sp_constants.hpp"
 #include "transaction_cl.h"
 #include "schema_manager.h"
 #include "dbtype.h"
@@ -57,6 +58,7 @@ static const std::vector<std::string> sp_entry_names
   SP_ATTR_TARGET_CLASS,
   SP_ATTR_TARGET_METHOD,
   SP_ATTR_DIRECTIVE,
+  SP_ATTR_SQL_DATA_ACCESS,
   SP_ATTR_OWNER,
   SP_ATTR_COMMENT,
   SP_ATTR_CREATED_TIME,
@@ -90,14 +92,20 @@ static int sp_builtin_init ()
 
   sp_info v;
   sp_arg_info a;
+  DB_VALUE current_datetime;
+
+  db_sys_datetime (&current_datetime);
 
   // common
-  v.is_system_generated = true;
   v.lang = SP_LANG_PLCSQL;
-  v.owner = Au_public_user;
-  v.comment = "";
+  v.is_system_generated = true;
   v.directive = SP_DIRECTIVE_RIGHTS_OWNER;
+  v.owner = Au_public_user;
+  v.sql_data_access = SP_SQL_TYPE_NONE;
+  v.comment = "";
   v.target_class = "com.cubrid.plcsql.builtin.DBMS_OUTPUT";
+  v.created_time = *db_get_datetime (&current_datetime);
+  v.updated_time = *db_get_datetime (&current_datetime);
 
   a.is_system_generated = true;
 
@@ -547,6 +555,14 @@ sp_add_stored_procedure_internal (SP_INFO &info, bool has_savepoint)
 	goto error;
       }
 
+    db_make_int (&value, info.sql_data_access);
+    err = dbt_put_internal (obt_p, SP_ATTR_SQL_DATA_ACCESS, &value);
+    pr_clear_value (&value);
+    if (err != NO_ERROR)
+      {
+	goto error;
+      }
+
     if (!info.comment.empty ())
       {
 	db_make_string (&value, info.comment.data ());
@@ -560,6 +576,7 @@ sp_add_stored_procedure_internal (SP_INFO &info, bool has_savepoint)
 
     db_make_datetime (&value, &info.created_time);
     err = dbt_put_internal (obt_p, SP_ATTR_CREATED_TIME, &value);
+    pr_clear_value (&value);
     if (err != NO_ERROR)
       {
 	goto error;
@@ -567,6 +584,7 @@ sp_add_stored_procedure_internal (SP_INFO &info, bool has_savepoint)
 
     db_make_datetime (&value, &info.updated_time);
     err = dbt_put_internal (obt_p, SP_ATTR_UPDATED_TIME, &value);
+    pr_clear_value (&value);
     if (err != NO_ERROR)
       {
 	goto error;

--- a/src/sp/sp_catalog.cpp
+++ b/src/sp/sp_catalog.cpp
@@ -92,9 +92,6 @@ static int sp_builtin_init ()
 
   sp_info v;
   sp_arg_info a;
-  DB_VALUE current_datetime;
-
-  db_sys_datetime (&current_datetime);
 
   // common
   v.lang = SP_LANG_PLCSQL;
@@ -104,8 +101,6 @@ static int sp_builtin_init ()
   v.sql_data_access = SP_SQL_TYPE_UNKNOWN;
   v.comment = "";
   v.target_class = "com.cubrid.plcsql.builtin.DBMS_OUTPUT";
-  v.created_time = *db_get_datetime (&current_datetime);
-  v.updated_time = *db_get_datetime (&current_datetime);
 
   a.is_system_generated = true;
 
@@ -568,7 +563,6 @@ sp_add_stored_procedure_internal (SP_INFO &info, bool has_savepoint)
 	db_make_string (&value, info.comment.data ());
       }
     err = dbt_put_internal (obt_p, SP_ATTR_COMMENT, &value);
-    pr_clear_value (&value);
     if (err != NO_ERROR)
       {
 	goto error;
@@ -576,7 +570,6 @@ sp_add_stored_procedure_internal (SP_INFO &info, bool has_savepoint)
 
     db_make_datetime (&value, &info.created_time);
     err = dbt_put_internal (obt_p, SP_ATTR_CREATED_TIME, &value);
-    pr_clear_value (&value);
     if (err != NO_ERROR)
       {
 	goto error;

--- a/src/sp/sp_catalog.hpp
+++ b/src/sp/sp_catalog.hpp
@@ -159,6 +159,7 @@ struct sp_info
   std::string target_method;
   SP_DIRECTIVE_ENUM directive;
   MOP owner;
+  SP_SQL_DATA_ACCESS_TYPE sql_data_access;
   std::string comment;
   DB_DATETIME created_time;
   DB_DATETIME updated_time;
@@ -176,6 +177,7 @@ struct sp_info
   , target_method {}
   , directive {SP_DIRECTIVE_ENUM::SP_DIRECTIVE_RIGHTS_OWNER}
   , owner {nullptr}
+  , sql_data_access {SP_SQL_TYPE_NONE}
   , comment {}
   , created_time {0, 0}
   , updated_time {0, 0}

--- a/src/sp/sp_catalog.hpp
+++ b/src/sp/sp_catalog.hpp
@@ -177,7 +177,7 @@ struct sp_info
   , target_method {}
   , directive {SP_DIRECTIVE_ENUM::SP_DIRECTIVE_RIGHTS_OWNER}
   , owner {nullptr}
-  , sql_data_access {SP_SQL_TYPE_NONE}
+  , sql_data_access {SP_SQL_TYPE_UNKNOWN}
   , comment {}
   , created_time {0, 0}
   , updated_time {0, 0}

--- a/src/sp/sp_constants.hpp
+++ b/src/sp/sp_constants.hpp
@@ -81,7 +81,7 @@ typedef enum
 
 typedef enum
 {
-  SP_SQL_TYPE_NONE = -1,
+  SP_SQL_TYPE_UNKNOWN = -1,
   SP_SQL_TYPE_NO_SQL,
   SP_SQL_TYPE_CONTAINS_SQL,
   SP_SQL_TYPE_READS_SQL_DATA,

--- a/src/sp/sp_constants.hpp
+++ b/src/sp/sp_constants.hpp
@@ -36,6 +36,7 @@
 #define SP_ATTR_TARGET_METHOD           "target_method"
 #define SP_ATTR_DIRECTIVE               "directive"
 #define SP_ATTR_OWNER                   "owner"
+#define SP_ATTR_SQL_DATA_ACCESS         "sql_data_access"
 #define SP_ATTR_COMMENT                 "comment"
 #define SP_ATTR_CREATED_TIME            "created_time"
 #define SP_ATTR_UPDATED_TIME            "updated_time"
@@ -77,6 +78,15 @@ typedef enum
   SP_LANG_PLCSQL = 0,
   SP_LANG_JAVA = 1
 } SP_LANG_ENUM;
+
+typedef enum
+{
+  SP_SQL_TYPE_NONE = -1,
+  SP_SQL_TYPE_NO_SQL,
+  SP_SQL_TYPE_CONTAINS_SQL,
+  SP_SQL_TYPE_READS_SQL_DATA,
+  SP_SQL_TYPE_MODIFIES_SQL_DATA
+} SP_SQL_DATA_ACCESS_TYPE;
 
 // refactor following
 


### PR DESCRIPTION
[<http://jira.cubrid.org/browse/CBRD-25862>
](http://jira.cubrid.org/browse/CBRD-25862)

### Purpose
system class `_db_stored_procedure`에 `sql_data_access`를 추가
- `sql_data_access`: SQL 실행 권한 (NO SQL, CONTAINS SQL, READS SQL DATA, MODIFIES SQL DATA)  

### Implementation
 총 5가지 상태가 있으며, 아직 SP의 SQL 타입을 결정하는 로직은 미구현
```c
SP_SQL_TYPE_UNKNOWN,
SP_SQL_TYPE_NO_SQL,
SP_SQL_TYPE_CONTAINS_SQL,
SP_SQL_TYPE_READS_SQL_DATA,
SP_SQL_TYPE_MODIFIES_SQL_DATA
```