### PR TITLE
[CBRD-25862] add class_partition_type attribute to _db_partition

### DIFF
--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -8717,7 +8717,7 @@ classobj_make_partition_info (void)
     }
 
   partition_info->partition_type = -1;
-  partition_info->depth = SM_PARTITION_UNKOWN;
+  partition_info->depth = SM_PARTITION_UNKNOWN;
   partition_info->values = NULL;
   partition_info->pname = NULL;
   partition_info->comment = NULL;

--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -8717,7 +8717,7 @@ classobj_make_partition_info (void)
     }
 
   partition_info->partition_type = -1;
-  partition_info->depth = SM_PARTITION_UNKNOWN;
+  partition_info->class_partition_type = DB_NOT_PARTITIONED_CLASS;
   partition_info->values = NULL;
   partition_info->pname = NULL;
   partition_info->comment = NULL;
@@ -8779,7 +8779,7 @@ classobj_copy_partition_info (SM_PARTITION * partition_info)
 
   new_partition_info->partition_type = partition_info->partition_type;
 
-  new_partition_info->depth = partition_info->depth;
+  new_partition_info->class_partition_type = partition_info->class_partition_type;
 
   if (partition_info->comment != NULL)
     {

--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -8717,6 +8717,7 @@ classobj_make_partition_info (void)
     }
 
   partition_info->partition_type = -1;
+  partition_info->depth = SM_PARTITION_UNKOWN;
   partition_info->values = NULL;
   partition_info->pname = NULL;
   partition_info->comment = NULL;
@@ -8777,6 +8778,8 @@ classobj_copy_partition_info (SM_PARTITION * partition_info)
     }
 
   new_partition_info->partition_type = partition_info->partition_type;
+
+  new_partition_info->depth = partition_info->depth;
 
   if (partition_info->comment != NULL)
     {

--- a/src/object/class_object.h
+++ b/src/object/class_object.h
@@ -531,7 +531,7 @@ typedef enum
 
 typedef enum
 {
-  SM_PARTITION_UNKOWN = -1,	// Uninitialized or invalid
+  SM_PARTITION_UNKNOWN = -1,	// Uninitialized or invalid
   SM_PARTITION_ROOT = 0,	// Root class
   SM_PARTITION_PARTITON = 1,	// First-level partition
 } SM_PARTITON_DEPTH;

--- a/src/object/class_object.h
+++ b/src/object/class_object.h
@@ -529,6 +529,13 @@ typedef enum
   SM_LAST_INDEX_STATUS = 10
 } SM_INDEX_STATUS;
 
+typedef enum
+{
+  SM_PARTITION_UNKOWN = -1,	// Uninitialized or invalid
+  SM_PARTITION_ROOT = 0,	// Root class
+  SM_PARTITION_PARTITON = 1,	// First-level partition
+} SM_PARTITON_DEPTH;
+
 /* Property list format: { property_name, constraint... }
  * - property_name: SM_CONSTRAINT_TYPE (ex. "*U", "*I", ...)
  * - constraint: { name, info }
@@ -713,6 +720,7 @@ struct sm_partition
   struct sm_partition *next;	/* currently not used, always NULL */
   const char *pname;		/* partition name */
   int partition_type;		/* partition type (range, list, hash) */
+  SM_PARTITON_DEPTH depth;
   DB_SEQ *values;		/* values for range and list partition types */
   const char *expr;		/* partition expression */
   const char *comment;

--- a/src/object/class_object.h
+++ b/src/object/class_object.h
@@ -529,13 +529,6 @@ typedef enum
   SM_LAST_INDEX_STATUS = 10
 } SM_INDEX_STATUS;
 
-typedef enum
-{
-  SM_PARTITION_UNKNOWN = -1,	// Uninitialized or invalid
-  SM_PARTITION_ROOT = 0,	// Root class
-  SM_PARTITION_PARTITON = 1,	// First-level partition
-} SM_PARTITON_DEPTH;
-
 /* Property list format: { property_name, constraint... }
  * - property_name: SM_CONSTRAINT_TYPE (ex. "*U", "*I", ...)
  * - constraint: { name, info }
@@ -720,7 +713,7 @@ struct sm_partition
   struct sm_partition *next;	/* currently not used, always NULL */
   const char *pname;		/* partition name */
   int partition_type;		/* partition type (range, list, hash) */
-  SM_PARTITON_DEPTH depth;
+  DB_CLASS_PARTITION_TYPE class_partition_type;	/* class partition type (partitioned class, partition class) */
   DB_SEQ *values;		/* values for range and list partition types */
   const char *expr;		/* partition expression */
   const char *comment;

--- a/src/object/schema_system_catalog_install.cpp
+++ b/src/object/schema_system_catalog_install.cpp
@@ -752,6 +752,7 @@ namespace cubschema
       {"ptype", "integer"},
       {"pexpr", format_varchar (2048)},
       {"pvalues", format_sequence ("")},
+      {"depth", "integer"},
       {"comment", format_varchar (1024)},
     },
 // constraints

--- a/src/object/schema_system_catalog_install.cpp
+++ b/src/object/schema_system_catalog_install.cpp
@@ -752,7 +752,7 @@ namespace cubschema
       {"ptype", "integer"},
       {"pexpr", format_varchar (2048)},
       {"pvalues", format_sequence ("")},
-      {"depth", "integer"},
+      {"class_partition_type", "integer"},
       {"comment", format_varchar (1024)},
     },
 // constraints

--- a/src/object/transform.c
+++ b/src/object/transform.c
@@ -239,7 +239,7 @@ META_CLASS tf_Metaclass_query_spec = { META_QUERY_SPEC_NAME, {META_PAGE_QUERY_SP
 /* PARTITION */
 static META_ATTRIBUTE partition_atts[] = {
   {"ptype", DB_TYPE_INTEGER, 1, NULL, 0, 0, NULL},
-  {"depth", DB_TYPE_INTEGER, 1, NULL, 0, 0, NULL},
+  {"class_partition_type", DB_TYPE_INTEGER, 1, NULL, 0, 0, NULL},
   {"pname", DB_TYPE_STRING, 1, NULL, 0, 0, NULL},
   {"pexpr", DB_TYPE_STRING, 1, NULL, 0, 0, NULL},
   {"pvalues", DB_TYPE_SEQUENCE, 0, NULL, 0, 0, NULL},
@@ -419,7 +419,7 @@ static CT_ATTR ct_indexkey_atts[] = {
 static CT_ATTR ct_partition_atts[] = {
   {"index_of", NULL_ATTRID, DB_TYPE_OBJECT},
   {"ptype", NULL_ATTRID, DB_TYPE_INTEGER},
-  {"depth", NULL_ATTRID, DB_TYPE_INTEGER},
+  {"class_partition_type", NULL_ATTRID, DB_TYPE_INTEGER},
   {"pname", NULL_ATTRID, DB_TYPE_VARCHAR},
   {"pexpr", NULL_ATTRID, DB_TYPE_VARCHAR},
   {"pvalues", NULL_ATTRID, DB_TYPE_SEQUENCE},

--- a/src/object/transform.c
+++ b/src/object/transform.c
@@ -239,6 +239,7 @@ META_CLASS tf_Metaclass_query_spec = { META_QUERY_SPEC_NAME, {META_PAGE_QUERY_SP
 /* PARTITION */
 static META_ATTRIBUTE partition_atts[] = {
   {"ptype", DB_TYPE_INTEGER, 1, NULL, 0, 0, NULL},
+  {"depth", DB_TYPE_INTEGER, 1, NULL, 0, 0, NULL},
   {"pname", DB_TYPE_STRING, 1, NULL, 0, 0, NULL},
   {"pexpr", DB_TYPE_STRING, 1, NULL, 0, 0, NULL},
   {"pvalues", DB_TYPE_SEQUENCE, 0, NULL, 0, 0, NULL},
@@ -418,6 +419,7 @@ static CT_ATTR ct_indexkey_atts[] = {
 static CT_ATTR ct_partition_atts[] = {
   {"index_of", NULL_ATTRID, DB_TYPE_OBJECT},
   {"ptype", NULL_ATTRID, DB_TYPE_INTEGER},
+  {"depth", NULL_ATTRID, DB_TYPE_INTEGER},
   {"pname", NULL_ATTRID, DB_TYPE_VARCHAR},
   {"pexpr", NULL_ATTRID, DB_TYPE_VARCHAR},
   {"pvalues", NULL_ATTRID, DB_TYPE_SEQUENCE},

--- a/src/object/transform_cl.c
+++ b/src/object/transform_cl.c
@@ -4907,6 +4907,7 @@ partition_info_to_disk (OR_BUF * buf, SM_PARTITION * partition_info)
 
   /* ATTRIBUTES */
   or_put_int (buf, partition_info->partition_type);
+  or_put_int (buf, partition_info->depth);
 
   put_string (buf, partition_info->pname);
   put_string (buf, partition_info->expr);
@@ -4976,8 +4977,6 @@ disk_to_partition_info (OR_BUF * buf)
       return NULL;
     }
 
-  assert (vars != NULL);
-
   partition_info = classobj_make_partition_info ();
   if (partition_info == NULL)
     {
@@ -4987,6 +4986,14 @@ disk_to_partition_info (OR_BUF * buf)
   else
     {
       partition_info->partition_type = or_get_int (buf, &error);
+      if (error != NO_ERROR)
+	{
+	  free_var_table (vars);
+	  classobj_free_partition_info (partition_info);
+	  return NULL;
+	}
+
+      partition_info->depth = (SM_PARTITON_DEPTH) or_get_int (buf, &error);
       if (error != NO_ERROR)
 	{
 	  free_var_table (vars);

--- a/src/object/transform_cl.c
+++ b/src/object/transform_cl.c
@@ -4907,7 +4907,7 @@ partition_info_to_disk (OR_BUF * buf, SM_PARTITION * partition_info)
 
   /* ATTRIBUTES */
   or_put_int (buf, partition_info->partition_type);
-  or_put_int (buf, partition_info->depth);
+  or_put_int (buf, partition_info->class_partition_type);
 
   put_string (buf, partition_info->pname);
   put_string (buf, partition_info->expr);
@@ -4993,13 +4993,15 @@ disk_to_partition_info (OR_BUF * buf)
 	  return NULL;
 	}
 
-      partition_info->depth = (SM_PARTITON_DEPTH) or_get_int (buf, &error);
+      partition_info->class_partition_type = (DB_CLASS_PARTITION_TYPE) or_get_int (buf, &error);
       if (error != NO_ERROR)
 	{
 	  free_var_table (vars);
 	  classobj_free_partition_info (partition_info);
 	  return NULL;
 	}
+      assert (partition_info->class_partition_type >= DB_PARTITIONED_CLASS
+	      && partition_info->class_partition_type <= DB_PARTITION_CLASS);
 
       partition_info->pname = get_string (buf, vars[ORC_PARTITION_NAME_INDEX].length);
       partition_info->expr = get_string (buf, vars[ORC_PARTITION_EXPR_INDEX].length);

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -15439,10 +15439,12 @@ pt_node_to_partition_info (PARSER_CONTEXT * parser, PT_NODE * node, PT_NODE * en
   if (node->node_type == PT_PARTITION)
     {
       partition->partition_type = node->info.partition.type;
+      partition->depth = SM_PARTITION_ROOT;
     }
   else
     {
       partition->partition_type = node->info.parts.type;
+      partition->depth = SM_PARTITION_PARTITON;
     }
 
   if (node->node_type == PT_PARTITION)

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -15439,12 +15439,12 @@ pt_node_to_partition_info (PARSER_CONTEXT * parser, PT_NODE * node, PT_NODE * en
   if (node->node_type == PT_PARTITION)
     {
       partition->partition_type = node->info.partition.type;
-      partition->depth = SM_PARTITION_ROOT;
+      partition->class_partition_type = DB_PARTITIONED_CLASS;
     }
   else
     {
       partition->partition_type = node->info.parts.type;
-      partition->depth = SM_PARTITION_PARTITON;
+      partition->class_partition_type = DB_PARTITION_CLASS;
     }
 
   if (node->node_type == PT_PARTITION)

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -5424,7 +5424,7 @@ catcls_get_or_value_from_partition (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
   error = catcls_expand_or_value_by_def (value_p, &ct_Partition);
   if (error != NO_ERROR)
     {
-      goto error;
+      goto end;
     }
 
   attrs = value_p->sub.value;
@@ -5438,43 +5438,39 @@ catcls_get_or_value_from_partition (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
 
       error = ER_OUT_OF_VIRTUAL_MEMORY;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 1, msize);
-      goto error;
+      goto end;
     }
 
   /* type */
   tp_Integer.data_readval (buf_p, &attrs[1].value, NULL, -1, true, NULL, 0);
 
+  /* depth */
+  tp_Integer.data_readval (buf_p, &attrs[2].value, NULL, -1, true, NULL, 0);
+
   /* name */
-  attr_val_p = &attrs[2].value;
+  attr_val_p = &attrs[3].value;
   tp_String.data_readval (buf_p, attr_val_p, NULL, vars[ORC_PARTITION_NAME_INDEX].length, true, NULL, 0);
   db_string_truncate (attr_val_p, DB_MAX_SPEC_LENGTH);
 
   /* expr */
-  attr_val_p = &attrs[3].value;
+  attr_val_p = &attrs[4].value;
   tp_String.data_readval (buf_p, attr_val_p, NULL, vars[ORC_PARTITION_EXPR_INDEX].length, true, NULL, 0);
   assert (DB_IS_NULL (attr_val_p) || db_get_string_length (attr_val_p) <= DB_MAX_PARTITION_EXPR_LENGTH);
 
   /* values */
-  attr_val_p = &attrs[4].value;
+  attr_val_p = &attrs[5].value;
   error = or_get_value (buf_p, attr_val_p, NULL, vars[ORC_PARTITION_VALUES_INDEX].length, true);
   if (error != NO_ERROR)
     {
-      goto error;
+      goto end;
     }
 
   /* comment */
-  attr_val_p = &attrs[5].value;
+  attr_val_p = &attrs[6].value;
   tp_String.data_readval (buf_p, attr_val_p, NULL, vars[ORC_PARTITION_COMMENT_INDEX].length, true, NULL, 0);
   db_string_truncate (attr_val_p, DB_MAX_SPEC_LENGTH);
 
-  if (vars)
-    {
-      free_and_init (vars);
-    }
-
-  return NO_ERROR;
-
-error:
+end:
 
   if (vars)
     {


### PR DESCRIPTION
[<http://jira.cubrid.org/browse/CBRD-25862>
](http://jira.cubrid.org/browse/CBRD-25862)

### Purpose
system class `_db_partition`에 ~`depth`~  `class_partition_type`를 추가
- ~`depth`: 파티션의 깊이(0(루트 클래스) ,1(파티션))~
- `class_partition_type`: 파티션 클래스의 타입(1: 루트 클래스, 2: 파티션 클래스)

### Remark
`depth`에서 `class_partition_type`로 이름을 바꾼 이유는 다음과 같습니다.
- `class_partition_type`의 개념은 기존 코드에 존재하던 내용입니다.
- `class_partition_type`을 통해 파티션 객체가 클래스에 종속되는 관계를 표현할 수 있습니다.
-  추후 서브 파티션을 지원하게 되었을 때, 해당 정보도 기존 코드의 일관성을 유지하며 제공할 수 있습니다.