### PR TITLE
[CBRD-25862]  add start_val attribute to db_serial

### DIFF
--- a/src/object/schema_system_catalog_install.cpp
+++ b/src/object/schema_system_catalog_install.cpp
@@ -35,13 +35,33 @@
 #include "authenticate.h"
 #include "locator_cl.h"
 
+#define CT_DUAL_DUMMY   "dummy"
+
 using namespace std::literals;
+
+static std::function<int (DB_VALUE *)>
+make_int_value_fn (int num)
+{
+  return [num] (DB_VALUE* val)
+  {
+    return db_make_int (val, num);
+  };
+}
+
+static std::function<int (DB_VALUE *)>
+make_numeric_value_fn (const char *str)
+{
+  return [str] (DB_VALUE *val)
+  {
+    return numeric_coerce_string_to_num (str, 1, LANG_SYS_CODESET, val);
+  };
+}
 
 /* ========================================================================== */
 /* NEW DEFINITION (initializers for CLASS) */
 /* ========================================================================== */
 int
-catcls_add_data_type (struct db_object *class_mop)
+catcls_add_data_type (DB_OBJECT *class_mop)
 {
   DB_OBJECT *obj;
   DB_VALUE val;
@@ -86,7 +106,7 @@ catcls_add_data_type (struct db_object *class_mop)
 }
 
 int
-catcls_add_collations (struct db_object *class_mop)
+catcls_add_collations (DB_OBJECT *class_mop)
 {
   int i;
   int count_collations;
@@ -148,6 +168,32 @@ catcls_add_collations (struct db_object *class_mop)
   assert (found_coll == count_collations);
 
   return NO_ERROR;
+}
+
+static int
+catcls_add_dual (DB_OBJECT *class_mop)
+{
+  DB_VALUE val;
+  int error_code = NO_ERROR;
+  DB_OBJECT *obj = db_create_internal (class_mop);
+  const char *dummy = "X";
+  if (obj == NULL)
+    {
+      assert (er_errid () != NO_ERROR);
+      return er_errid ();
+    }
+  error_code = db_make_varchar (&val, 1, dummy, strlen (dummy), LANG_SYS_CODESET, LANG_SYS_COLLATION);
+  if (error_code != NO_ERROR)
+    {
+      return error_code;
+    }
+
+  error_code = db_put_internal (obj, CT_DUAL_DUMMY, &val);
+  if (error_code != NO_ERROR)
+    {
+      return error_code;
+    }
+  return error_code;
 }
 
 int
@@ -687,12 +733,7 @@ namespace cubschema
       {"key_attr_name", format_varchar (255)},
       {"key_order", "integer"},
       {"asc_desc", "integer"},
-      {
-	"key_prefix_length", "integer", [] (DB_VALUE* val)
-	{
-	  return db_make_int (val, -1);
-	}
-      },
+      {"key_prefix_length", "integer", make_int_value_fn (-1)},
       {"func", format_varchar (1023)}
     },
 // constraints
@@ -905,41 +946,17 @@ namespace cubschema
       {"unique_name", "string"},
       {"name", "string"},
       {"owner", AU_USER_CLASS_NAME},
-      {
-	"current_val", format_numeric (DB_MAX_NUMERIC_PRECISION, 0), [] (DB_VALUE* val)
-	{
-	  return numeric_coerce_string_to_num ("1", 1, LANG_SYS_CODESET, val);
-	}
-      },
-      {
-	"increment_val", format_numeric (DB_MAX_NUMERIC_PRECISION, 0), [] (DB_VALUE* val)
-	{
-	  return numeric_coerce_string_to_num ("1", 1, LANG_SYS_CODESET, val);
-	}
-      },
+      {"current_val", format_numeric (DB_MAX_NUMERIC_PRECISION, 0), make_numeric_value_fn ("1")},
+      {"increment_val", format_numeric (DB_MAX_NUMERIC_PRECISION, 0), make_numeric_value_fn ("1")},
       {"max_val", format_numeric (DB_MAX_NUMERIC_PRECISION, 0)},
       {"min_val", format_numeric (DB_MAX_NUMERIC_PRECISION, 0)},
-      {
-	"cyclic", "integer", [] (DB_VALUE* val)
-	{
-	  return db_make_int (val, 0);
-	}
-      },
-      {
-	"started", "integer", [] (DB_VALUE* val)
-	{
-	  return db_make_int (val, 0);
-	}
-      },
+      {"start_val", format_numeric (DB_MAX_NUMERIC_PRECISION, 0), make_numeric_value_fn ("1")},
+      {"cyclic", "integer", make_int_value_fn (0)},
+      {"started", "integer", make_int_value_fn (0)},
       {"class_name", "string"},
       {"attr_name", "string"},
       {attribute_kind::CLASS_METHOD, "change_serial_owner", "au_change_serial_owner_method"},
-      {
-	"cached_num", "integer", [] (DB_VALUE* val)
-	{
-	  return db_make_int (val, 0);
-	}
-      },
+      {"cached_num", "integer",	make_int_value_fn (0)},
       {"comment", format_varchar (1024)},
       {"created_time", "datetime"},
       {"updated_time", "datetime"}
@@ -1083,7 +1100,6 @@ namespace cubschema
   system_catalog_definition
   system_catalog_initializer::get_dual ()
   {
-#define CT_DUAL_DUMMY   "dummy"
     return system_catalog_definition (
 		   // name
 		   CT_DUAL_NAME,
@@ -1102,30 +1118,7 @@ namespace cubschema
       }
     },
 // initializer
-    [] (MOP class_mop)
-    {
-      DB_VALUE val;
-      int error_code = NO_ERROR;
-      DB_OBJECT *obj = db_create_internal (class_mop);
-      const char *dummy = "X";
-      if (obj == NULL)
-	{
-	  assert (er_errid () != NO_ERROR);
-	  return er_errid ();
-	}
-      error_code = db_make_varchar (&val, 1, dummy, strlen (dummy), LANG_SYS_CODESET, LANG_SYS_COLLATION);
-      if (error_code != NO_ERROR)
-	{
-	  return error_code;
-	}
-
-      error_code = db_put_internal (obj, CT_DUAL_DUMMY, &val);
-      if (error_code != NO_ERROR)
-	{
-	  return error_code;
-	}
-      return error_code;
-    }
+    catcls_add_dual
 	   );
   }
 
@@ -1140,12 +1133,7 @@ namespace cubschema
       {"unique_name", format_varchar (255)},
       {"name", format_varchar (255)},
       {"owner", AU_USER_CLASS_NAME},
-      {
-	"is_public", "integer", [] (DB_VALUE* val)
-	{
-	  return db_make_int (val, 0);
-	}
-      },
+      {"is_public", "integer", make_int_value_fn (0)},
       {"target_unique_name", format_varchar (255)},
       {"target_name", format_varchar (255)},
       {"target_owner", AU_USER_CLASS_NAME},

--- a/src/object/schema_system_catalog_install.cpp
+++ b/src/object/schema_system_catalog_install.cpp
@@ -53,7 +53,7 @@ make_numeric_value_fn (const char *str)
 {
   return [str] (DB_VALUE *val)
   {
-    return numeric_coerce_string_to_num (str, 1, LANG_SYS_CODESET, val);
+    return numeric_coerce_string_to_num (str, strlen (str), LANG_SYS_CODESET, val);
   };
 }
 
@@ -183,16 +183,11 @@ catcls_add_dual (DB_OBJECT *class_mop)
       return er_errid ();
     }
   error_code = db_make_varchar (&val, 1, dummy, strlen (dummy), LANG_SYS_CODESET, LANG_SYS_COLLATION);
-  if (error_code != NO_ERROR)
+  if (error_code == NO_ERROR)
     {
-      return error_code;
+      error_code = db_put_internal (obj, CT_DUAL_DUMMY, &val);
     }
 
-  error_code = db_put_internal (obj, CT_DUAL_DUMMY, &val);
-  if (error_code != NO_ERROR)
-    {
-      return error_code;
-    }
   return error_code;
 }
 

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -669,20 +669,19 @@ do_evaluate_default_expr (PARSER_CONTEXT * parser, PT_NODE * class_name)
  * Note:
  */
 static int
-do_create_serial_internal (MOP * serial_object, const char *serial_name, DB_VALUE * current_val, DB_VALUE * inc_val,
+do_create_serial_internal (MOP * serial_object, const char *serial_name, DB_VALUE * start_val, DB_VALUE * inc_val,
 			   DB_VALUE * min_val, DB_VALUE * max_val, const int cyclic, const int cached_num,
 			   const int started, const char *comment, const char *class_name, const char *att_name)
 {
   DB_OBJECT *ret_obj = NULL;
   DB_OTMPL *obj_tmpl = NULL;
-  DB_VALUE value, *start_val;
+  DB_VALUE value;
   DB_OBJECT *serial_class = NULL;
   char owner_name[DB_MAX_USER_LENGTH] = { '\0' };
   MOP owner = NULL;
   int au_save, error = NO_ERROR;
 
   db_make_null (&value);
-  start_val = current_val;
 
   /* temporarily disable authorization to access db_serial class */
   AU_DISABLE (au_save);
@@ -740,7 +739,7 @@ do_create_serial_internal (MOP * serial_object, const char *serial_name, DB_VALU
     }
 
   /* current_val */
-  error = dbt_put_internal (obj_tmpl, SERIAL_ATTR_CURRENT_VAL, current_val);
+  error = dbt_put_internal (obj_tmpl, SERIAL_ATTR_CURRENT_VAL, start_val);
   if (error != NO_ERROR)
     {
       goto end;

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -675,13 +675,14 @@ do_create_serial_internal (MOP * serial_object, const char *serial_name, DB_VALU
 {
   DB_OBJECT *ret_obj = NULL;
   DB_OTMPL *obj_tmpl = NULL;
-  DB_VALUE value;
+  DB_VALUE value, *start_val;
   DB_OBJECT *serial_class = NULL;
   char owner_name[DB_MAX_USER_LENGTH] = { '\0' };
   MOP owner = NULL;
   int au_save, error = NO_ERROR;
 
   db_make_null (&value);
+  start_val = current_val;
 
   /* temporarily disable authorization to access db_serial class */
   AU_DISABLE (au_save);
@@ -761,6 +762,13 @@ do_create_serial_internal (MOP * serial_object, const char *serial_name, DB_VALU
 
   /* max_val */
   error = dbt_put_internal (obj_tmpl, SERIAL_ATTR_MAX_VAL, max_val);
+  if (error != NO_ERROR)
+    {
+      goto end;
+    }
+
+  /* start_val */
+  error = dbt_put_internal (obj_tmpl, SERIAL_ATTR_START_VAL, start_val);
   if (error != NO_ERROR)
     {
       goto end;

--- a/src/storage/storage_common.h
+++ b/src/storage/storage_common.h
@@ -1098,6 +1098,7 @@ typedef enum
 #define SERIAL_ATTR_INCREMENT_VAL   "increment_val"
 #define SERIAL_ATTR_MAX_VAL         "max_val"
 #define SERIAL_ATTR_MIN_VAL         "min_val"
+#define SERIAL_ATTR_START_VAL       "start_val"
 #define SERIAL_ATTR_CYCLIC          "cyclic"
 #define SERIAL_ATTR_STARTED         "started"
 #define SERIAL_ATTR_CLASS_NAME      "class_name"


### PR DESCRIPTION
[<http://jira.cubrid.org/browse/CBRD-25862>
](http://jira.cubrid.org/browse/CBRD-25862)

### Purpose
system class `db_serial`에 `start_val`를 추가
- `start_val`: 시리얼의 시작 값 (시리얼이 처음 생성될 때의 값) 

### Implementation
default 값은 `current_val` 과 동일