### PR TITLE
[CBRD-25862] add timestamp handling code for built-in stored procedure

### DIFF
--- a/src/sp/sp_catalog.cpp
+++ b/src/sp/sp_catalog.cpp
@@ -90,6 +90,9 @@ static int sp_builtin_init ()
 
   sp_info v;
   sp_arg_info a;
+  DB_VALUE current_datetime;
+
+  db_sys_datetime (&current_datetime);
 
   // common
   v.is_system_generated = true;
@@ -98,6 +101,8 @@ static int sp_builtin_init ()
   v.comment = "";
   v.directive = SP_DIRECTIVE_RIGHTS_OWNER;
   v.target_class = "com.cubrid.plcsql.builtin.DBMS_OUTPUT";
+  v.created_time = *db_get_datetime (&current_datetime);
+  v.updated_time = *db_get_datetime (&current_datetime);
 
   a.is_system_generated = true;
 
@@ -560,6 +565,7 @@ sp_add_stored_procedure_internal (SP_INFO &info, bool has_savepoint)
 
     db_make_datetime (&value, &info.created_time);
     err = dbt_put_internal (obt_p, SP_ATTR_CREATED_TIME, &value);
+    pr_clear_value (&value);
     if (err != NO_ERROR)
       {
 	goto error;
@@ -567,6 +573,7 @@ sp_add_stored_procedure_internal (SP_INFO &info, bool has_savepoint)
 
     db_make_datetime (&value, &info.updated_time);
     err = dbt_put_internal (obt_p, SP_ATTR_UPDATED_TIME, &value);
+    pr_clear_value (&value);
     if (err != NO_ERROR)
       {
 	goto error;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25862

### Purpose
https://github.com/CUBRID/cubrid/pull/6234 해당 PR에서 built-in stored procedure의 timestamp의 처리를 누락한 부분을 추가합니다.

