### PR TITLE
[CBRD-26139] define daemon's m_func_on_stop using lambda

### DIFF
--- a/src/thread/thread_daemon.hpp
+++ b/src/thread/thread_daemon.hpp
@@ -172,8 +172,10 @@ namespace cubthread
     Context &context = context_manager_arg->create_context ();
 
     // now that we have access to context we can set the callback function on stop
-    daemon_arg->m_func_on_stop = std::bind (&context_manager<Context>::stop_execution, std::ref (*context_manager_arg),
-					    std::ref (context));
+    daemon_arg->m_func_on_stop = [&context_manager_arg, &context]()
+    {
+      context_manager_arg->stop_execution (context);
+    };
 
     daemon_arg->register_stat_start ();
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26139>

### Purpose

CBRD-26139 의 코어 발생 문제를 디버깅하는데 있어서 현재 std::bind 를 사용한 정의는 stack trace 에서 의미를 알기 어려운
`#0  0x0000000000000000 in ?? ()` 로 끝나기 때문에 stack trace에 서 추가적인 정보를 얻기 위해 
동일한 동작을 하면서도 실제 함수 호출이 드러나게 되는 람다로 교체

### Implementation

```
daemon_arg->m_func_on_stop = std::bind (&context_manager<Context>::stop_execution, 
    std::ref (*context_manager_arg), std::ref (context));
```
를 아래 코드로 교체
```
daemon_arg->m_func_on_stop = [&context_manager_arg, &context]() {
            context_manager_arg->stop_execution(context);
    };
```

### Remarks

N/A
