### PR TITLE
[CBRD-26145] align the memory address for DWB and LOG.

### DIFF
--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -2171,7 +2171,7 @@ alterdbhost (UTIL_FUNCTION_ARG * arg)
     }
 
   if ((log_vdes =
-       fileio_mount (NULL, BO_DB_FULLNAME, log_Name_active, LOG_DBLOG_ACTIVE_VOLID, true, false)) == NULL_VOLDES)
+       fileio_mount (NULL, BO_DB_FULLNAME, log_Name_active, LOG_DBLOG_ACTIVE_VOLID, true, false, true)) == NULL_VOLDES)
     {
       goto error;
     }

--- a/src/storage/double_write_buffer.c
+++ b/src/storage/double_write_buffer.c
@@ -1044,8 +1044,7 @@ dwb_create_blocks (THREAD_ENTRY * thread_p, unsigned int num_blocks, unsigned in
   block_buffer_size = num_block_pages * IO_PAGESIZE;
   for (i = 0; i < num_blocks; i++)
     {
-      blocks_write_buffer[i] = (char *) malloc (block_buffer_size * sizeof (char));
-      if (blocks_write_buffer[i] == NULL)
+      if (posix_memalign ((void **) &blocks_write_buffer[i], 4096, block_buffer_size) != 0)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, block_buffer_size * sizeof (char));
 	  error_code = ER_OUT_OF_VIRTUAL_MEMORY;
@@ -3125,7 +3124,7 @@ dwb_load_and_recover_pages (THREAD_ENTRY * thread_p, const char *dwb_path_p, con
   if (fileio_is_volume_exist (dwb_Volume_name))
     {
       /* Open DWB volume first */
-      read_fd = fileio_mount (thread_p, boot_db_full_name (), dwb_Volume_name, LOG_DBDWB_VOLID, false, false);
+      read_fd = fileio_mount (thread_p, boot_db_full_name (), dwb_Volume_name, LOG_DBDWB_VOLID, false, false, true);
       if (read_fd == NULL_VOLDES)
 	{
 	  return ER_IO_MOUNT_FAIL;

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -35,6 +35,7 @@
 #include <sys/stat.h>
 #include <assert.h>
 #include <signal.h>
+#include <stdlib.h>
 
 #if defined(WINDOWS)
 #include <io.h>
@@ -473,7 +474,7 @@ static pthread_mutex_t *fileio_get_volume_mutex (THREAD_ENTRY * thread_p, int vd
 static int fileio_initialize_volume_info_cache (void);
 static void fileio_make_volume_lock_name (char *vol_lockname, const char *vol_fullname);
 static int fileio_create (THREAD_ENTRY * thread_p, const char *db_fullname, const char *vlabel, VOLID volid,
-			  bool dolock, bool dosync);
+			  bool dolock, bool dosync, bool is_direct = false);
 static int fileio_create_backup_volume (THREAD_ENTRY * thread_p, const char *db_fullname, const char *vlabel,
 					VOLID volid, bool dolock, bool dosync, int atleast_pages);
 static int fileio_max_permanent_volumes (int index, int num_permanent_volums);
@@ -2071,7 +2072,7 @@ fileio_close (int vol_fd)
  */
 static int
 fileio_create (THREAD_ENTRY * thread_p, const char *db_full_name_p, const char *vol_label_p, VOLID vol_id,
-	       bool is_do_lock, bool is_do_sync)
+	       bool is_do_lock, bool is_do_sync, bool is_direct)
 {
   int tmp_vol_desc = NULL_VOLDES;
   int vol_fd;
@@ -2115,7 +2116,7 @@ fileio_create (THREAD_ENTRY * thread_p, const char *db_full_name_p, const char *
   /* If the file exist make sure that nobody else is using it, before it is truncated */
   if (is_do_lock != false)
     {
-      tmp_vol_desc = fileio_open (vol_label_p, O_RDWR | o_sync, 0);
+      tmp_vol_desc = fileio_open (vol_label_p, O_RDWR | o_sync | (is_direct ? O_DIRECT : 0), 0);
       if (tmp_vol_desc != NULL_VOLDES)
 	{
 	  /* The volume (file) already exist. Make sure that nobody is using it before the old one is destroyed */
@@ -2129,7 +2130,9 @@ fileio_create (THREAD_ENTRY * thread_p, const char *db_full_name_p, const char *
 	}
     }
 
-  vol_fd = fileio_open (vol_label_p, FILEIO_DISK_FORMAT_MODE | o_sync, FILEIO_DISK_PROTECTION_MODE);
+  vol_fd =
+    fileio_open (vol_label_p, FILEIO_DISK_FORMAT_MODE | o_sync | (is_direct ? O_DIRECT : 0),
+		 FILEIO_DISK_PROTECTION_MODE);
   if (vol_fd == NULL_VOLDES)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_IO_FORMAT_FAIL, 3, vol_label_p, -1, -1LL);
@@ -2366,8 +2369,8 @@ fileio_format (THREAD_ENTRY * thread_p, const char *db_full_name_p, const char *
       return NULL_VOLDES;
     }
 
-  malloc_io_page_p = (FILEIO_PAGE *) malloc (page_size);
-  if (malloc_io_page_p == NULL)
+  assert (page_size % 4096 == 0);
+  if (posix_memalign ((void **) &malloc_io_page_p, 4096, page_size) != 0)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, page_size);
       return NULL_VOLDES;
@@ -2376,7 +2379,7 @@ fileio_format (THREAD_ENTRY * thread_p, const char *db_full_name_p, const char *
   memset ((char *) malloc_io_page_p, 0, page_size);
   (void) fileio_initialize_res (thread_p, malloc_io_page_p, (PGLENGTH) page_size);
 
-  vol_fd = fileio_create (thread_p, db_full_name_p, vol_label_p, vol_id, is_do_lock, is_do_sync);
+  vol_fd = fileio_create (thread_p, db_full_name_p, vol_label_p, vol_id, is_do_lock, is_do_sync, true);
   FI_TEST (thread_p, FI_TEST_FILE_IO_FORMAT, 0);
   if (vol_fd != NULL_VOLDES)
     {
@@ -2431,7 +2434,7 @@ fileio_format (THREAD_ENTRY * thread_p, const char *db_full_name_p, const char *
 
 #if defined(WINDOWS)
       fileio_dismount (thread_p, vol_fd);
-      vol_fd = fileio_mount (thread_p, NULL, vol_label_p, vol_id, false, false);
+      vol_fd = fileio_mount (thread_p, NULL, vol_label_p, vol_id, false, false, true);
 #endif /* WINDOWS */
     }
   else
@@ -2910,7 +2913,7 @@ fileio_reset_volume (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel, DK
  */
 int
 fileio_mount (THREAD_ENTRY * thread_p, const char *db_full_name_p, const char *vol_label_p, VOLID vol_id, int lock_wait,
-	      bool is_do_sync)
+	      bool is_do_sync, bool is_direct)
 {
 #if defined(WINDOWS)
   int vol_fd;
@@ -2979,7 +2982,7 @@ fileio_mount (THREAD_ENTRY * thread_p, const char *db_full_name_p, const char *v
 
   /* OPEN THE DISK VOLUME PARTITION OR FILE SIMULATED VOLUME */
 start:
-  vol_fd = fileio_open (vol_label_p, O_RDWR | o_sync, 0600);
+  vol_fd = fileio_open (vol_label_p, O_RDWR | o_sync | (is_direct ? O_DIRECT : 0), 0600);
   if (vol_fd == NULL_VOLDES)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_IO_MOUNT_FAIL, 1, vol_label_p);
@@ -10240,7 +10243,7 @@ fileio_restore_volume (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session_
   else
     {
       session_p->dbfile.vdes =
-	fileio_mount (thread_p, NULL, session_p->dbfile.vlabel, session_p->dbfile.volid, false, false);
+	fileio_mount (thread_p, NULL, session_p->dbfile.vlabel, session_p->dbfile.volid, false, false, true);
     }
 
   if (session_p->dbfile.vdes == NULL_VOLDES)
@@ -10378,7 +10381,7 @@ fileio_restore_volume (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session_
 
 	      /* previous vol */
 	      prev_volid = fileio_find_previous_perm_volume (thread_p, volid);
-	      prev_vdes = fileio_mount (thread_p, NULL, prev_vol_label_p, prev_volid, false, false);
+	      prev_vdes = fileio_mount (thread_p, NULL, prev_vol_label_p, prev_volid, false, false, true);
 	      if (prev_vdes == NULL_VOLDES)
 		{
 		  goto error;

--- a/src/storage/file_io.h
+++ b/src/storage/file_io.h
@@ -480,7 +480,7 @@ extern int fileio_copy_volume (THREAD_ENTRY * thread_p, int from_vdes, DKNPAGES 
 extern int fileio_reset_volume (THREAD_ENTRY * thread_p, int vdes, const char *vlabel, DKNPAGES npages,
 				const LOG_LSA * reset_lsa);
 extern int fileio_mount (THREAD_ENTRY * thread_p, const char *db_fullname, const char *vlabel, VOLID volid,
-			 int lockwait, bool dosync);
+			 int lockwait, bool dosync, bool isdirect = false);
 extern void fileio_dismount (THREAD_ENTRY * thread_p, int vdes);
 extern void fileio_dismount_without_fsync (THREAD_ENTRY * thread_p, int vdes);
 extern void fileio_dismount_all (THREAD_ENTRY * thread_p);

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -1350,7 +1350,7 @@ boot_mount (THREAD_ENTRY * thread_p, VOLID volid, const char *vlabel, void *igno
   char check_vlabel[PATH_MAX];
   int vdes;
 
-  vdes = fileio_mount (thread_p, boot_Db_full_name, vlabel, volid, false, false);
+  vdes = fileio_mount (thread_p, boot_Db_full_name, vlabel, volid, false, false, true);
   if (vdes == NULL_VOLDES)
     {
       return ER_FAILED;

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1133,8 +1133,7 @@ log_initialize_internal (THREAD_ENTRY * thread_p, const char *db_fullname, const
   log_Gl.run_nxchkpt_atpageid = NULL_PAGEID;	/* Don't run the checkpoint */
   log_Gl.rcv_phase = LOG_RECOVERY_ANALYSIS_PHASE;
 
-  log_Gl.loghdr_pgptr = (LOG_PAGE *) malloc (LOG_PAGESIZE);
-  if (log_Gl.loghdr_pgptr == NULL)
+  if (posix_memalign ((void **) &log_Gl.loghdr_pgptr, 4096, LOG_PAGESIZE) != 0)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, (size_t) LOG_PAGESIZE);
       logpb_fatal_error (thread_p, !init_emergency, ARG_FILE_LINE, "log_xinit");
@@ -1148,7 +1147,7 @@ log_initialize_internal (THREAD_ENTRY * thread_p, const char *db_fullname, const
     }
 
   /* Mount the active log and read the log header */
-  log_Gl.append.vdes = fileio_mount (thread_p, db_fullname, log_Name_active, LOG_DBLOG_ACTIVE_VOLID, true, false);
+  log_Gl.append.vdes = fileio_mount (thread_p, db_fullname, log_Name_active, LOG_DBLOG_ACTIVE_VOLID, true, false, true);
   if (log_Gl.append.vdes == NULL_VOLDES)
     {
       if (ismedia_crash != false)
@@ -14357,7 +14356,7 @@ cdc_check_lsa_range (THREAD_ENTRY * thread_p, LOG_LSA * lsa)
 
       if (fileio_is_volume_exist (arv_name) == true)
 	{
-	  vdes = fileio_mount (thread_p, log_Db_fullname, arv_name, LOG_DBLOG_ARCHIVE_VOLID, false, false);
+	  vdes = fileio_mount (thread_p, log_Db_fullname, arv_name, LOG_DBLOG_ARCHIVE_VOLID, false, false, true);
 	  if (vdes != NULL_VOLDES)
 	    {
 	      if (fileio_read (thread_p, vdes, hdr_pgptr, 0, IO_MAX_PAGE_SIZE) == NULL)
@@ -14613,7 +14612,7 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
 
 	  if (fileio_is_volume_exist (arv_name) == true)
 	    {
-	      vdes = fileio_mount (thread_p, log_Db_fullname, arv_name, LOG_DBLOG_ARCHIVE_VOLID, false, false);
+	      vdes = fileio_mount (thread_p, log_Db_fullname, arv_name, LOG_DBLOG_ARCHIVE_VOLID, false, false, true);
 	      if (vdes != NULL_VOLDES)
 		{
 		  if (fileio_read (thread_p, vdes, hdr_pgptr, 0, IO_MAX_PAGE_SIZE) == NULL)

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -583,8 +583,7 @@ logpb_initialize_pool (THREAD_ENTRY * thread_p)
     }
 
   size = ((size_t) log_Pb.num_buffers * (LOG_PAGESIZE));
-  log_Pb.pages_area = (LOG_PAGE *) malloc (size);
-  if (log_Pb.pages_area == NULL)
+  if (posix_memalign ((void **) &log_Pb.pages_area, 4096, size) != 0)
     {
       free_and_init (log_Pb.buffers);
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, size);
@@ -600,8 +599,7 @@ logpb_initialize_pool (THREAD_ENTRY * thread_p)
     }
 
   size = LOG_PAGESIZE;
-  log_Pb.header_page = (LOG_PAGE *) malloc (size);
-  if (log_Pb.header_page == NULL)
+  if (posix_memalign ((void **) &log_Pb.header_page, 4096, size) != 0)
     {
       free_and_init (log_Pb.buffers);
       free_and_init (log_Pb.pages_area);
@@ -1533,7 +1531,7 @@ logpb_fetch_header_from_active_log (THREAD_ENTRY * thread_p, const char *db_full
       goto error;
     }
 
-  log_Gl.append.vdes = fileio_mount (thread_p, db_fullname, log_Name_active, LOG_DBLOG_ACTIVE_VOLID, true, false);
+  log_Gl.append.vdes = fileio_mount (thread_p, db_fullname, log_Name_active, LOG_DBLOG_ACTIVE_VOLID, true, false, true);
   if (log_Gl.append.vdes == NULL_VOLDES)
     {
       error_code = ER_FAILED;
@@ -5244,7 +5242,7 @@ logpb_fetch_from_archive (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, LOG_PAGE *
       error_code = ER_FAILED;
       if (logpb_is_archive_available (thread_p, *ret_arv_num) == true && fileio_is_volume_exist (arv_name) == true)
 	{
-	  vdes = fileio_mount (thread_p, log_Db_fullname, arv_name, LOG_DBLOG_ARCHIVE_VOLID, false, false);
+	  vdes = fileio_mount (thread_p, log_Db_fullname, arv_name, LOG_DBLOG_ARCHIVE_VOLID, false, false, true);
 	  if (vdes != NULL_VOLDES)
 	    {
 	      if (fileio_read (thread_p, vdes, hdr_pgptr, 0, LOG_PAGESIZE) == NULL)
@@ -5484,7 +5482,7 @@ logpb_fetch_from_archive (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, LOG_PAGE *
 	  while (retry != 0 && retry != 1
 		 && (vdes =
 		     fileio_mount (thread_p, log_Db_fullname, arv_name, LOG_DBLOG_ARCHIVE_VOLID, false,
-				   false)) == NULL_VOLDES)
+				   false, true)) == NULL_VOLDES)
 	    {
 	      char line_buf[PATH_MAX * 2];
 	      bool is_in_crash_recovery;
@@ -5814,7 +5812,7 @@ logpb_archive_active_log (THREAD_ENTRY * thread_p)
 	  goto error;
 	}
 
-      vdes = fileio_mount (thread_p, log_Db_fullname, arv_name, LOG_DBLOG_ARCHIVE_VOLID, 0, false);
+      vdes = fileio_mount (thread_p, log_Db_fullname, arv_name, LOG_DBLOG_ARCHIVE_VOLID, 0, false, true);
       if (vdes == NULL_VOLDES)
 	{
 	  goto error;
@@ -8485,7 +8483,7 @@ logpb_restore (THREAD_ENTRY * thread_p, const char *db_fullname, const char *log
    */
   if (fileio_is_volume_exist (log_Name_active))
     {
-      lgat_vdes = fileio_mount (thread_p, db_fullname, log_Name_active, LOG_DBLOG_ACTIVE_VOLID, true, false);
+      lgat_vdes = fileio_mount (thread_p, db_fullname, log_Name_active, LOG_DBLOG_ACTIVE_VOLID, true, false, true);
       if (lgat_vdes == NULL_VOLDES)
 	{
 	  error_code = ER_FAILED;
@@ -8915,7 +8913,7 @@ logpb_restore (THREAD_ENTRY * thread_p, const char *db_fullname, const char *log
       prev_volname = volnames.second.c_str();
 
       prev_volid = fileio_find_previous_perm_volume (thread_p, volid);
-      prev_vdes = fileio_mount (thread_p, NULL, prev_volname, prev_volid, false, false);
+      prev_vdes = fileio_mount (thread_p, NULL, prev_volname, prev_volid, false, false, true);
       if (prev_vdes == NULL_VOLDES)
 	{
 	  goto error;
@@ -9711,7 +9709,7 @@ logpb_copy_database (THREAD_ENTRY * thread_p, VOLID num_perm_vols, const char *t
 	   */
 	  volid = (VOLID) fromfile_volid;
 
-	  to_vdes = fileio_mount (thread_p, log_Db_fullname, to_volname, LOG_DBCOPY_VOLID, false, false);
+	  to_vdes = fileio_mount (thread_p, log_Db_fullname, to_volname, LOG_DBCOPY_VOLID, false, false, true);
 	  if (to_vdes == NULL_VOLDES)
 	    {
 	      error_code = ER_FAILED;
@@ -9991,12 +9989,13 @@ logpb_rename_all_volumes_files (THREAD_ENTRY * thread_p, VOLID num_perm_vols, co
       fileio_make_log_active_name (to_volname, to_logpath, to_prefix_logname);
       if (fileio_rename (LOG_DBLOG_ACTIVE_VOLID, log_Name_active, to_volname) != NULL)
 	{
-	  log_Gl.append.vdes = fileio_mount (thread_p, to_db_fullname, to_volname, LOG_DBLOG_ACTIVE_VOLID, true, false);
+	  log_Gl.append.vdes =
+	    fileio_mount (thread_p, to_db_fullname, to_volname, LOG_DBLOG_ACTIVE_VOLID, true, false, true);
 	}
       else
 	{
 	  log_Gl.append.vdes =
-	    fileio_mount (thread_p, log_Db_fullname, log_Name_active, LOG_DBLOG_ACTIVE_VOLID, true, false);
+	    fileio_mount (thread_p, log_Db_fullname, log_Name_active, LOG_DBLOG_ACTIVE_VOLID, true, false, true);
 	  error_code = ER_FAILED;
 	  goto error;
 	}
@@ -10162,11 +10161,11 @@ logpb_rename_all_volumes_files (THREAD_ENTRY * thread_p, VOLID num_perm_vols, co
 	  fileio_dismount (thread_p, fileio_get_volume_descriptor (volid));
 	  if (fileio_rename (volid, from_volname, to_volname) != NULL)
 	    {
-	      (void) fileio_mount (thread_p, to_db_fullname, to_volname, volid, false, false);
+	      (void) fileio_mount (thread_p, to_db_fullname, to_volname, volid, false, false, true);
 	    }
 	  else
 	    {
-	      (void) fileio_mount (thread_p, log_Db_fullname, from_volname, volid, false, false);
+	      (void) fileio_mount (thread_p, log_Db_fullname, from_volname, volid, false, false, true);
 	      error_code = ER_FAILED;
 	      goto error;
 	    }
@@ -10289,7 +10288,7 @@ logpb_delete (THREAD_ENTRY * thread_p, VOLID num_perm_vols, const char *db_fulln
       if (fileio_is_volume_exist (log_Name_active) == false
 	  || (log_Gl.append.vdes =
 	      fileio_mount (thread_p, db_fullname, log_Name_active, LOG_DBLOG_ACTIVE_VOLID, true,
-			    false)) == NULL_VOLDES)
+			    false, true)) == NULL_VOLDES)
 	{
 	  /* Unable to mount the active log */
 	  if (er_errid () == ER_IO_MOUNT_LOCKED)
@@ -11309,7 +11308,7 @@ logpb_find_oldest_available_page_id (THREAD_ENTRY * thread_p)
 
   fileio_make_log_archive_name (arv_name, log_Archive_path, log_Prefix, arv_num);
 
-  vdes = fileio_mount (thread_p, log_Db_fullname, arv_name, LOG_DBLOG_ARCHIVE_VOLID, false, false);
+  vdes = fileio_mount (thread_p, log_Db_fullname, arv_name, LOG_DBLOG_ARCHIVE_VOLID, false, false, true);
   if (vdes != NULL_VOLDES)
     {
       if (fileio_read (thread_p, vdes, arv_hdr_pgptr, 0, LOG_PAGESIZE) == NULL)
@@ -11414,7 +11413,8 @@ logpb_remove_all_in_log_path (THREAD_ENTRY * thread_p, const char *db_fullname, 
 
   if (fileio_is_volume_exist (log_Name_active)
       && (log_Gl.append.vdes =
-	  fileio_mount (thread_p, db_fullname, log_Name_active, LOG_DBLOG_ACTIVE_VOLID, true, false)) != NULL_VOLDES)
+	  fileio_mount (thread_p, db_fullname, log_Name_active, LOG_DBLOG_ACTIVE_VOLID, true, false,
+			true)) != NULL_VOLDES)
     {
       char log_pgbuf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT], *aligned_log_pgbuf;
       LOG_PAGE *log_pgptr;

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -5176,7 +5176,7 @@ log_recovery_notpartof_volumes (THREAD_ENTRY * thread_p)
 	  break;
 	}
 
-      vdes = fileio_mount (thread_p, log_Db_fullname, vol_fullname, volid, false, false);
+      vdes = fileio_mount (thread_p, log_Db_fullname, vol_fullname, volid, false, false, true);
       if (vdes != NULL_VOLDES)
 	{
 	  ret = disk_get_db_creation (thread_p, volid, &vol_dbcreation);

--- a/src/transaction/log_writer.c
+++ b/src/transaction/log_writer.c
@@ -305,7 +305,7 @@ logwr_read_log_header (void)
     {
       /* Mount the active log and read the log header */
       logwr_Gl.append_vdes =
-	fileio_mount (NULL, logwr_Gl.db_name, logwr_Gl.active_name, LOG_DBLOG_ACTIVE_VOLID, true, false);
+	fileio_mount (NULL, logwr_Gl.db_name, logwr_Gl.active_name, LOG_DBLOG_ACTIVE_VOLID, true, false, true);
       if (logwr_Gl.append_vdes == NULL_VOLDES)
 	{
 	  /* Unable to mount the active log */
@@ -525,7 +525,7 @@ logwr_initialize (const char *db_name, const char *log_path, int mode, LOG_PAGEI
 	{
 	  bg_arv_info->vdes =
 	    fileio_mount (NULL, logwr_Gl.bg_archive_name, logwr_Gl.bg_archive_name, LOG_DBLOG_ARCHIVE_VOLID, true,
-			  false);
+			  false, true);
 	  if (bg_arv_info->vdes == NULL_VOLDES)
 	    {
 	      return ER_IO_MOUNT_FAIL;
@@ -1340,7 +1340,7 @@ logwr_archive_active_log (void)
     {
       if (fileio_is_volume_exist (archive_name) == true)
 	{
-	  vdes = fileio_mount (NULL, archive_name, archive_name, LOG_DBLOG_ARCHIVE_VOLID, true, false);
+	  vdes = fileio_mount (NULL, archive_name, archive_name, LOG_DBLOG_ARCHIVE_VOLID, true, false, true);
 	  if (vdes == NULL_VOLDES)
 	    {
 	      error_code = ER_IO_MOUNT_FAIL;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26145

### Purpose

DWB와 LOG의 page를 할당할 때 4KB 경계에 맞춰 할당하도록 합니다.

### Implementation

POC이므로 4KB에 맞췄고, 아직 경계에 맞지 않는 buffer가 많으므로 정상적으로 동작하지 않아야 합니다.

### Remarks

N/A
