### PR TITLE
[CBRD-26146] align the pages of page buffer to 4096 boundaries.

### DIFF
--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -2171,7 +2171,7 @@ alterdbhost (UTIL_FUNCTION_ARG * arg)
     }
 
   if ((log_vdes =
-       fileio_mount (NULL, BO_DB_FULLNAME, log_Name_active, LOG_DBLOG_ACTIVE_VOLID, true, false)) == NULL_VOLDES)
+       fileio_mount (NULL, BO_DB_FULLNAME, log_Name_active, LOG_DBLOG_ACTIVE_VOLID, true, false, true)) == NULL_VOLDES)
     {
       goto error;
     }

--- a/src/storage/double_write_buffer.c
+++ b/src/storage/double_write_buffer.c
@@ -1044,8 +1044,7 @@ dwb_create_blocks (THREAD_ENTRY * thread_p, unsigned int num_blocks, unsigned in
   block_buffer_size = num_block_pages * IO_PAGESIZE;
   for (i = 0; i < num_blocks; i++)
     {
-      blocks_write_buffer[i] = (char *) malloc (block_buffer_size * sizeof (char));
-      if (blocks_write_buffer[i] == NULL)
+      if (posix_memalign ((void **) &blocks_write_buffer[i], 4096, block_buffer_size) != 0)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, block_buffer_size * sizeof (char));
 	  error_code = ER_OUT_OF_VIRTUAL_MEMORY;
@@ -3125,7 +3124,7 @@ dwb_load_and_recover_pages (THREAD_ENTRY * thread_p, const char *dwb_path_p, con
   if (fileio_is_volume_exist (dwb_Volume_name))
     {
       /* Open DWB volume first */
-      read_fd = fileio_mount (thread_p, boot_db_full_name (), dwb_Volume_name, LOG_DBDWB_VOLID, false, false);
+      read_fd = fileio_mount (thread_p, boot_db_full_name (), dwb_Volume_name, LOG_DBDWB_VOLID, false, false, true);
       if (read_fd == NULL_VOLDES)
 	{
 	  return ER_IO_MOUNT_FAIL;

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -35,6 +35,7 @@
 #include <sys/stat.h>
 #include <assert.h>
 #include <signal.h>
+#include <stdlib.h>
 
 #if defined(WINDOWS)
 #include <io.h>
@@ -473,7 +474,7 @@ static pthread_mutex_t *fileio_get_volume_mutex (THREAD_ENTRY * thread_p, int vd
 static int fileio_initialize_volume_info_cache (void);
 static void fileio_make_volume_lock_name (char *vol_lockname, const char *vol_fullname);
 static int fileio_create (THREAD_ENTRY * thread_p, const char *db_fullname, const char *vlabel, VOLID volid,
-			  bool dolock, bool dosync);
+			  bool dolock, bool dosync, bool is_direct = false);
 static int fileio_create_backup_volume (THREAD_ENTRY * thread_p, const char *db_fullname, const char *vlabel,
 					VOLID volid, bool dolock, bool dosync, int atleast_pages);
 static int fileio_max_permanent_volumes (int index, int num_permanent_volums);
@@ -2071,7 +2072,7 @@ fileio_close (int vol_fd)
  */
 static int
 fileio_create (THREAD_ENTRY * thread_p, const char *db_full_name_p, const char *vol_label_p, VOLID vol_id,
-	       bool is_do_lock, bool is_do_sync)
+	       bool is_do_lock, bool is_do_sync, bool is_direct)
 {
   int tmp_vol_desc = NULL_VOLDES;
   int vol_fd;
@@ -2115,7 +2116,7 @@ fileio_create (THREAD_ENTRY * thread_p, const char *db_full_name_p, const char *
   /* If the file exist make sure that nobody else is using it, before it is truncated */
   if (is_do_lock != false)
     {
-      tmp_vol_desc = fileio_open (vol_label_p, O_RDWR | o_sync, 0);
+      tmp_vol_desc = fileio_open (vol_label_p, O_RDWR | o_sync | (is_direct ? O_DIRECT : 0), 0);
       if (tmp_vol_desc != NULL_VOLDES)
 	{
 	  /* The volume (file) already exist. Make sure that nobody is using it before the old one is destroyed */
@@ -2129,7 +2130,9 @@ fileio_create (THREAD_ENTRY * thread_p, const char *db_full_name_p, const char *
 	}
     }
 
-  vol_fd = fileio_open (vol_label_p, FILEIO_DISK_FORMAT_MODE | o_sync, FILEIO_DISK_PROTECTION_MODE);
+  vol_fd =
+    fileio_open (vol_label_p, FILEIO_DISK_FORMAT_MODE | o_sync | (is_direct ? O_DIRECT : 0),
+		 FILEIO_DISK_PROTECTION_MODE);
   if (vol_fd == NULL_VOLDES)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_IO_FORMAT_FAIL, 3, vol_label_p, -1, -1LL);
@@ -2366,8 +2369,8 @@ fileio_format (THREAD_ENTRY * thread_p, const char *db_full_name_p, const char *
       return NULL_VOLDES;
     }
 
-  malloc_io_page_p = (FILEIO_PAGE *) malloc (page_size);
-  if (malloc_io_page_p == NULL)
+  assert (page_size % 4096 == 0);
+  if (posix_memalign ((void **) &malloc_io_page_p, 4096, page_size) != 0)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, page_size);
       return NULL_VOLDES;
@@ -2376,7 +2379,7 @@ fileio_format (THREAD_ENTRY * thread_p, const char *db_full_name_p, const char *
   memset ((char *) malloc_io_page_p, 0, page_size);
   (void) fileio_initialize_res (thread_p, malloc_io_page_p, (PGLENGTH) page_size);
 
-  vol_fd = fileio_create (thread_p, db_full_name_p, vol_label_p, vol_id, is_do_lock, is_do_sync);
+  vol_fd = fileio_create (thread_p, db_full_name_p, vol_label_p, vol_id, is_do_lock, is_do_sync, true);
   FI_TEST (thread_p, FI_TEST_FILE_IO_FORMAT, 0);
   if (vol_fd != NULL_VOLDES)
     {
@@ -2431,7 +2434,7 @@ fileio_format (THREAD_ENTRY * thread_p, const char *db_full_name_p, const char *
 
 #if defined(WINDOWS)
       fileio_dismount (thread_p, vol_fd);
-      vol_fd = fileio_mount (thread_p, NULL, vol_label_p, vol_id, false, false);
+      vol_fd = fileio_mount (thread_p, NULL, vol_label_p, vol_id, false, false, true);
 #endif /* WINDOWS */
     }
   else
@@ -2910,7 +2913,7 @@ fileio_reset_volume (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel, DK
  */
 int
 fileio_mount (THREAD_ENTRY * thread_p, const char *db_full_name_p, const char *vol_label_p, VOLID vol_id, int lock_wait,
-	      bool is_do_sync)
+	      bool is_do_sync, bool is_direct)
 {
 #if defined(WINDOWS)
   int vol_fd;
@@ -2979,7 +2982,7 @@ fileio_mount (THREAD_ENTRY * thread_p, const char *db_full_name_p, const char *v
 
   /* OPEN THE DISK VOLUME PARTITION OR FILE SIMULATED VOLUME */
 start:
-  vol_fd = fileio_open (vol_label_p, O_RDWR | o_sync, 0600);
+  vol_fd = fileio_open (vol_label_p, O_RDWR | o_sync | (is_direct ? O_DIRECT : 0), 0600);
   if (vol_fd == NULL_VOLDES)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_IO_MOUNT_FAIL, 1, vol_label_p);
@@ -10240,7 +10243,7 @@ fileio_restore_volume (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session_
   else
     {
       session_p->dbfile.vdes =
-	fileio_mount (thread_p, NULL, session_p->dbfile.vlabel, session_p->dbfile.volid, false, false);
+	fileio_mount (thread_p, NULL, session_p->dbfile.vlabel, session_p->dbfile.volid, false, false, true);
     }
 
   if (session_p->dbfile.vdes == NULL_VOLDES)
@@ -10378,7 +10381,7 @@ fileio_restore_volume (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session_
 
 	      /* previous vol */
 	      prev_volid = fileio_find_previous_perm_volume (thread_p, volid);
-	      prev_vdes = fileio_mount (thread_p, NULL, prev_vol_label_p, prev_volid, false, false);
+	      prev_vdes = fileio_mount (thread_p, NULL, prev_vol_label_p, prev_volid, false, false, true);
 	      if (prev_vdes == NULL_VOLDES)
 		{
 		  goto error;

--- a/src/storage/file_io.h
+++ b/src/storage/file_io.h
@@ -480,7 +480,7 @@ extern int fileio_copy_volume (THREAD_ENTRY * thread_p, int from_vdes, DKNPAGES 
 extern int fileio_reset_volume (THREAD_ENTRY * thread_p, int vdes, const char *vlabel, DKNPAGES npages,
 				const LOG_LSA * reset_lsa);
 extern int fileio_mount (THREAD_ENTRY * thread_p, const char *db_fullname, const char *vlabel, VOLID volid,
-			 int lockwait, bool dosync);
+			 int lockwait, bool dosync, bool isdirect = false);
 extern void fileio_dismount (THREAD_ENTRY * thread_p, int vdes);
 extern void fileio_dismount_without_fsync (THREAD_ENTRY * thread_p, int vdes);
 extern void fileio_dismount_all (THREAD_ENTRY * thread_p);

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -110,9 +110,7 @@ static int rv;
 
 /* size of one buffer page <BCB, page> */
 #define PGBUF_BCB_SIZEOF       (sizeof (PGBUF_BCB))
-#define PGBUF_IOPAGE_BUFFER_SIZE \
-  ((size_t)(offsetof (PGBUF_IOPAGE_BUFFER, iopage) + \
-  SIZEOF_IOPAGE_PAGESIZE_AND_GUARD()))
+#define PGBUF_IOPAGE_BUFFER_SIZE  SIZEOF_IOPAGE_PAGESIZE_AND_GUARD()))
 /* size of buffer hash entry */
 #define PGBUF_BUFFER_HASH_SIZEOF       (sizeof (PGBUF_BUFFER_HASH))
 /* size of buffer lock record */
@@ -131,22 +129,20 @@ static int rv;
   ((PGBUF_BCB *) ((char *) &(pgbuf_Pool.BCB_table[0]) + (PGBUF_BCB_SIZEOF * (i))))
 
 #define PGBUF_FIND_IOPAGE_PTR(i) \
-  ((PGBUF_IOPAGE_BUFFER *) ((char *) &(pgbuf_Pool.iopage_table[0]) + (PGBUF_IOPAGE_BUFFER_SIZE * (i))))
+  ((FILEIO_PAGE *) ((char *) &(pgbuf_Pool.iopage_table[0]) + (IO_PAGESIZE * (i))))
 
 #define PGBUF_FIND_BUFFER_GUARD(bufptr) \
-  (&bufptr->iopage_buffer->iopage.page[DB_PAGESIZE])
+  (&bufptr->iopage->page[DB_PAGESIZE])
 
 /* macros for casting pointers */
 #define CAST_PGPTR_TO_BFPTR(bufptr, pgptr) \
   do { \
-    (bufptr) = ((PGBUF_BCB *) ((PGBUF_IOPAGE_BUFFER *) \
-      ((char *) pgptr - offsetof (PGBUF_IOPAGE_BUFFER, iopage.page)))->bcb); \
-    assert ((bufptr) == (bufptr)->iopage_buffer->bcb); \
+    (bufptr) = PGBUF_FIND_BCB_PTR ((((FILEIO_PAGE *) ((char *) (pgptr) - offsetof (FILEIO_PAGE, page))) - pgbuf_Pool.iopage_table)); \
   } while (0)
 
 #define CAST_PGPTR_TO_IOPGPTR(io_pgptr, pgptr) \
   do { \
-    (io_pgptr) = (FILEIO_PAGE *) ((char *) pgptr - offsetof (FILEIO_PAGE, page)); \
+    (io_pgptr) = (FILEIO_PAGE *) ((char *) (pgptr) - offsetof (FILEIO_PAGE, page)); \
   } while (0)
 
 #define CAST_IOPGPTR_TO_PGPTR(pgptr, io_pgptr) \
@@ -156,8 +152,7 @@ static int rv;
 
 #define CAST_BFPTR_TO_PGPTR(pgptr, bufptr) \
   do { \
-    assert ((bufptr) == (bufptr)->iopage_buffer->bcb); \
-    (pgptr) = ((PAGE_PTR) ((char *) (bufptr->iopage_buffer) + offsetof (PGBUF_IOPAGE_BUFFER, iopage.page))); \
+    (pgptr) = ((PAGE_PTR) ((char *) ((bufptr)->iopage) + offsetof (FILEIO_PAGE, page))); \
   } while (0)
 
 /* check whether the given volume is auxiliary volume */
@@ -345,7 +340,6 @@ typedef struct pgbuf_holder_anchor PGBUF_HOLDER_ANCHOR;
 typedef struct pgbuf_holder_set PGBUF_HOLDER_SET;
 
 typedef struct pgbuf_bcb PGBUF_BCB;
-typedef struct pgbuf_iopage_buffer PGBUF_IOPAGE_BUFFER;
 typedef struct pgbuf_aout_buf PGBUF_AOUT_BUF;
 
 typedef struct pgbuf_buffer_lock PGBUF_BUFFER_LOCK;
@@ -499,19 +493,7 @@ struct pgbuf_bcb
   int hit_age;			/* age of last hit (used to compute activities and quotas) */
 
   LOG_LSA oldest_unflush_lsa;	/* The oldest LSA record of the page that has not been written to disk */
-  PGBUF_IOPAGE_BUFFER *iopage_buffer;	/* pointer to iopage buffer structure */
-};
-
-/* iopage buffer structure */
-struct pgbuf_iopage_buffer
-{
-  PGBUF_BCB *bcb;		/* pointer to BCB structure */
-#if (__WORDSIZE == 32)
-  int dummy;			/* for 8byte align of iopage */
-#elif !defined(LINUX) && !defined(WINDOWS) && !defined(AIX)
-#error "you must check that iopage is aligned by 8byte !!"
-#endif
-  FILEIO_PAGE iopage;		/* The actual buffered io page */
+  FILEIO_PAGE *iopage;		/* pointer to iopage buffer structure */
 };
 
 /* buffer lock record (or entry) structure
@@ -721,7 +703,7 @@ struct pgbuf_buffer_pool
   PGBUF_BCB *BCB_table;		/* BCB table */
   PGBUF_BUFFER_HASH *buf_hash_table;	/* buffer hash table */
   PGBUF_BUFFER_LOCK *buf_lock_table;	/* buffer lock table */
-  PGBUF_IOPAGE_BUFFER *iopage_table;	/* IO page table */
+  FILEIO_PAGE *iopage_table;	/* IO page table */
   int num_LRU_list;		/* number of shared LRU lists */
   float ratio_lru1;		/* ratio for lru 1 zone */
   float ratio_lru2;		/* ratio for lru 2 zone */
@@ -2007,8 +1989,6 @@ try_again:
       perf.holder_wait_time = perf.tv_diff.tv_sec * 1000000LL + perf.tv_diff.tv_usec;
     }
 
-  assert (bufptr == bufptr->iopage_buffer->bcb);
-
   /* In case of NO_ERROR, bufptr->mutex has been released. */
 
   /* Dirty Pages Table Registration Pass */
@@ -2054,7 +2034,7 @@ try_again:
   thread_p->get_pgbuf_tracker ().increment (caller_file, caller_line, pgptr);
 #endif // !NDEBUG
 
-  if (bufptr->iopage_buffer->iopage.prv.ptype == PAGE_UNKNOWN)
+  if (bufptr->iopage->prv.ptype == PAGE_UNKNOWN)
     {
       /* deallocated page */
       switch (fetch_mode)
@@ -2481,9 +2461,9 @@ pgbuf_unfix (THREAD_ENTRY * thread_p, PAGE_PTR pgptr)
    * has not changed since the database restart, a warning is given about
    * lack of logging
    */
-  if (pgbuf_bcb_is_dirty (bufptr) && !pgbuf_is_temp_lsa (bufptr->iopage_buffer->iopage.prv.lsa)
+  if (pgbuf_bcb_is_dirty (bufptr) && !pgbuf_is_temp_lsa (bufptr->iopage->prv.lsa)
       && PGBUF_IS_AUXILIARY_VOLUME (bufptr->vpid.volid) == false
-      && !log_is_logged_since_restart (&bufptr->iopage_buffer->iopage.prv.lsa))
+      && !log_is_logged_since_restart (&bufptr->iopage->prv.lsa))
     {
       er_log_debug (ARG_FILE_LINE,
 		    "pgbuf_unfix: WARNING: No logging on dirty pageid = %d of Volume = %s.\n Recovery problems"
@@ -2494,7 +2474,7 @@ pgbuf_unfix (THREAD_ENTRY * thread_p, PAGE_PTR pgptr)
        */
       pgbuf_set_lsa (thread_p, pgptr, log_get_restart_lsa ());
       pgbuf_set_lsa (thread_p, pgptr, &restart_lsa);
-      LSA_COPY (&bufptr->oldest_unflush_lsa, &bufptr->iopage_buffer->iopage.prv.lsa);
+      LSA_COPY (&bufptr->oldest_unflush_lsa, &bufptr->iopage->prv.lsa);
     }
 
   /* Check for over runs */
@@ -2610,7 +2590,7 @@ pgbuf_unfix (THREAD_ENTRY * thread_p, PAGE_PTR pgptr)
 		  PGBUF_BCB_LOCK (bufptr);
 		}
 
-	      pgbuf_scramble (&bufptr->iopage_buffer->iopage);
+	      pgbuf_scramble (bufptr->iopage);
 
 	      /*
 	       * Note that the buffer is not declared for immediate
@@ -2690,9 +2670,8 @@ pgbuf_unfix_all (THREAD_ENTRY * thread_p)
 			pgbuf_bcb_get_pool_index (bufptr), bufptr->vpid.volid, bufptr->vpid.pageid, bufptr->fcnt,
 			latch_mode_str, (int) pgbuf_bcb_is_dirty (bufptr), (int) pgbuf_bcb_is_flushing (bufptr),
 			(int) pgbuf_bcb_is_async_flush_request (bufptr), zone_str,
-			LSA_AS_ARGS (&bufptr->iopage_buffer->iopage.prv.lsa), consistent_str, (void *) bufptr,
-			(void *) (&bufptr->iopage_buffer->iopage.page[0]),
-			(void *) (&bufptr->iopage_buffer->iopage.page[DB_PAGESIZE - 1]));
+			LSA_AS_ARGS (&bufptr->iopage->prv.lsa), consistent_str, (void *) bufptr,
+			(void *) (&bufptr->iopage->page[0]), (void *) (&bufptr->iopage->page[DB_PAGESIZE - 1]));
 
 	  holder = holder->thrd_link;
 #endif /* NDEBUG */
@@ -2809,7 +2788,7 @@ pgbuf_invalidate (THREAD_ENTRY * thread_p, PAGE_PTR pgptr)
     }
 
 #if defined(CUBRID_DEBUG)
-  pgbuf_scramble (&bufptr->iopage_buffer->iopage);
+  pgbuf_scramble (bufptr->iopage);
 #endif /* CUBRID_DEBUG */
 
   /* Now, invalidation task is performed after holding a page latch with PGBUF_LATCH_INVALID mode. */
@@ -2887,7 +2866,7 @@ pgbuf_invalidate_all (THREAD_ENTRY * thread_p, VOLID volid)
 	}
 
 #if defined(CUBRID_DEBUG)
-      pgbuf_scramble (&bufptr->iopage_buffer->iopage);
+      pgbuf_scramble (bufptr->iopage);
 #endif /* CUBRID_DEBUG */
 
       /* Now, page invalidation task is performed while holding a page latch with PGBUF_LATCH_INVALID mode. */
@@ -3036,7 +3015,7 @@ pgbuf_flush_all_helper (THREAD_ENTRY * thread_p, VOLID volid, bool is_unfixed_on
       if (is_set_lsa_as_null)
 	{
 	  /* set PageLSA as NULL value */
-	  fileio_init_lsa_of_page (&bufptr->iopage_buffer->iopage, IO_PAGESIZE);
+	  fileio_init_lsa_of_page (bufptr->iopage, IO_PAGESIZE);
 	}
 
       /* flush */
@@ -3411,14 +3390,14 @@ repeat:
 	  continue;
 	}
 
-      if (logpb_need_wal (&bufptr->iopage_buffer->iopage.prv.lsa))
+      if (logpb_need_wal (&bufptr->iopage->prv.lsa))
 	{
 	  /* we cannot flush a page unless log has been flushed up until page LSA. otherwise we might have recovery
 	   * issues. */
 	  count_need_wal++;
-	  if (LSA_ISNULL (&lsa_need_wal) || LSA_LE (&lsa_need_wal, &(bufptr->iopage_buffer->iopage.prv.lsa)))
+	  if (LSA_ISNULL (&lsa_need_wal) || LSA_LE (&lsa_need_wal, &(bufptr->iopage->prv.lsa)))
 	    {
-	      LSA_COPY (&lsa_need_wal, &(bufptr->iopage_buffer->iopage.prv.lsa));
+	      LSA_COPY (&lsa_need_wal, &(bufptr->iopage->prv.lsa));
 	    }
 	  PGBUF_BCB_UNLOCK (bufptr);
 	  ++num_skipped_need_wal;
@@ -4365,8 +4344,7 @@ pgbuf_set_lsa (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, const LOG_LSA * lsa_ptr)
    * Don't change LSA of temporary volumes or auxiliary volumes.
    * (e.g., those of copydb, backupdb).
    */
-  if (pgbuf_is_temp_lsa (bufptr->iopage_buffer->iopage.prv.lsa)
-      || PGBUF_IS_AUXILIARY_VOLUME (bufptr->vpid.volid) == true)
+  if (pgbuf_is_temp_lsa (bufptr->iopage->prv.lsa) || PGBUF_IS_AUXILIARY_VOLUME (bufptr->vpid.volid) == true)
     {
       return NULL;
     }
@@ -4377,14 +4355,14 @@ pgbuf_set_lsa (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, const LOG_LSA * lsa_ptr)
    */
   if (pgbuf_is_temporary_volume (bufptr->vpid.volid) == true)
     {
-      pgbuf_init_temp_page_lsa (&bufptr->iopage_buffer->iopage, IO_PAGESIZE);
+      pgbuf_init_temp_page_lsa (bufptr->iopage, IO_PAGESIZE);
       if (logtb_is_current_active (thread_p))
 	{
 	  return NULL;
 	}
     }
 
-  fileio_set_page_lsa (&bufptr->iopage_buffer->iopage, lsa_ptr, IO_PAGESIZE);
+  fileio_set_page_lsa (bufptr->iopage, lsa_ptr, IO_PAGESIZE);
 
   /*
    * If this is the first time the page is set dirty, record the new LSA
@@ -4440,7 +4418,7 @@ pgbuf_reset_temp_lsa (PAGE_PTR pgptr)
   PGBUF_BCB *bufptr;
 
   CAST_PGPTR_TO_BFPTR (bufptr, pgptr);
-  pgbuf_init_temp_page_lsa (&bufptr->iopage_buffer->iopage, IO_PAGESIZE);
+  pgbuf_init_temp_page_lsa (bufptr->iopage, IO_PAGESIZE);
 }
 
 /*
@@ -4669,7 +4647,7 @@ pgbuf_get_page_ptype (THREAD_ENTRY * thread_p, PAGE_PTR pgptr)
   CAST_PGPTR_TO_BFPTR (bufptr, pgptr);
   assert_release (pgbuf_check_bcb_page_vpid (bufptr, false) == true);
 
-  ptype = (PAGE_TYPE) (bufptr->iopage_buffer->iopage.prv.ptype);
+  ptype = (PAGE_TYPE) (bufptr->iopage->prv.ptype);
 
   assert (PAGE_UNKNOWN <= (int) ptype);
   assert (ptype <= PAGE_LAST);
@@ -4773,7 +4751,7 @@ pgbuf_set_lsa_as_temporary (THREAD_ENTRY * thread_p, PAGE_PTR pgptr)
   CAST_PGPTR_TO_BFPTR (bufptr, pgptr);
   assert (!VPID_ISNULL (&bufptr->vpid));
 
-  pgbuf_init_temp_page_lsa (&bufptr->iopage_buffer->iopage, IO_PAGESIZE);
+  pgbuf_init_temp_page_lsa (bufptr->iopage, IO_PAGESIZE);
   pgbuf_set_dirty_buffer_ptr (thread_p, bufptr);
 }
 
@@ -4797,23 +4775,22 @@ pgbuf_set_bcb_page_vpid (PGBUF_BCB * bufptr)
   if (bufptr->vpid.volid > NULL_VOLID)
     {
       /* Check if is the first time */
-      if (bufptr->iopage_buffer->iopage.prv.pageid == NULL_PAGEID
-	  && bufptr->iopage_buffer->iopage.prv.volid == NULL_VOLID)
+      if (bufptr->iopage->prv.pageid == NULL_PAGEID && bufptr->iopage->prv.volid == NULL_VOLID)
 	{
 	  /* Set Page identifier */
-	  bufptr->iopage_buffer->iopage.prv.pageid = bufptr->vpid.pageid;
-	  bufptr->iopage_buffer->iopage.prv.volid = bufptr->vpid.volid;
+	  bufptr->iopage->prv.pageid = bufptr->vpid.pageid;
+	  bufptr->iopage->prv.volid = bufptr->vpid.volid;
 
-	  bufptr->iopage_buffer->iopage.prv.ptype = PAGE_UNKNOWN;
-	  bufptr->iopage_buffer->iopage.prv.p_reserve_1 = 0;
-	  bufptr->iopage_buffer->iopage.prv.p_reserve_2 = 0;
-	  bufptr->iopage_buffer->iopage.prv.tde_nonce = 0;
+	  bufptr->iopage->prv.ptype = PAGE_UNKNOWN;
+	  bufptr->iopage->prv.p_reserve_1 = 0;
+	  bufptr->iopage->prv.p_reserve_2 = 0;
+	  bufptr->iopage->prv.tde_nonce = 0;
 	}
       else
 	{
 	  /* values not reset upon page deallocation */
-	  assert (bufptr->iopage_buffer->iopage.prv.volid == bufptr->vpid.volid);
-	  assert (bufptr->iopage_buffer->iopage.prv.pageid == bufptr->vpid.pageid);
+	  assert (bufptr->iopage->prv.volid == bufptr->vpid.volid);
+	  assert (bufptr->iopage->prv.pageid == bufptr->vpid.pageid);
 	}
     }
 }
@@ -4854,9 +4831,9 @@ pgbuf_set_page_ptype (THREAD_ENTRY * thread_p, PAGE_PTR pgptr, PAGE_TYPE ptype)
       return;
     }
 
-  bufptr->iopage_buffer->iopage.prv.ptype = (unsigned char) ptype;
+  bufptr->iopage->prv.ptype = (unsigned char) ptype;
 
-  assert_release (bufptr->iopage_buffer->iopage.prv.ptype == ptype);
+  assert_release (bufptr->iopage->prv.ptype == ptype);
 }
 
 /*
@@ -4871,8 +4848,7 @@ pgbuf_is_lsa_temporary (PAGE_PTR pgptr)
 
   CAST_PGPTR_TO_BFPTR (bufptr, pgptr);
 
-  if (pgbuf_is_temp_lsa (bufptr->iopage_buffer->iopage.prv.lsa)
-      || pgbuf_is_temporary_volume (bufptr->vpid.volid) == true)
+  if (pgbuf_is_temp_lsa (bufptr->iopage->prv.lsa) || pgbuf_is_temporary_volume (bufptr->vpid.volid) == true)
     {
       return true;
     }
@@ -4907,7 +4883,7 @@ static int
 pgbuf_initialize_bcb_table (void)
 {
   PGBUF_BCB *bufptr;
-  PGBUF_IOPAGE_BUFFER *ioptr;
+  FILEIO_PAGE *ioptr;
   int i;
   long long unsigned alloc_size;
 
@@ -4926,7 +4902,7 @@ pgbuf_initialize_bcb_table (void)
     }
 
   /* allocate space for io page buffers */
-  alloc_size = (long long unsigned) pgbuf_Pool.num_buffers * PGBUF_IOPAGE_BUFFER_SIZE;
+  alloc_size = (long long unsigned) pgbuf_Pool.num_buffers * IO_PAGESIZE;
   if (!MEM_SIZE_IS_VALID (alloc_size))
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_PRM_BAD_VALUE, 1, "data_buffer_pages");
@@ -4936,8 +4912,8 @@ pgbuf_initialize_bcb_table (void)
 	}
       return ER_PRM_BAD_VALUE;
     }
-  pgbuf_Pool.iopage_table = (PGBUF_IOPAGE_BUFFER *) malloc ((size_t) alloc_size);
-  if (pgbuf_Pool.iopage_table == NULL)
+  assert (alloc_size % 4096 == 0);
+  if (posix_memalign ((void **) &pgbuf_Pool.iopage_table, 4096, alloc_size) != 0)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, (size_t) alloc_size);
       if (pgbuf_Pool.BCB_table != NULL)
@@ -4986,24 +4962,23 @@ pgbuf_initialize_bcb_table (void)
       /* link BCB and iopage buffer */
       ioptr = PGBUF_FIND_IOPAGE_PTR (i);
 
-      fileio_init_lsa_of_page (&ioptr->iopage, IO_PAGESIZE);
+      fileio_init_lsa_of_page (ioptr, IO_PAGESIZE);
 
       /* Init Page identifier */
-      ioptr->iopage.prv.pageid = -1;
-      ioptr->iopage.prv.volid = -1;
+      ioptr->prv.pageid = -1;
+      ioptr->prv.volid = -1;
 
-      ioptr->iopage.prv.ptype = (unsigned char) PAGE_UNKNOWN;
-      ioptr->iopage.prv.pflag = '\0';
-      ioptr->iopage.prv.p_reserve_1 = 0;
-      ioptr->iopage.prv.p_reserve_2 = 0;
-      ioptr->iopage.prv.tde_nonce = 0;
+      ioptr->prv.ptype = (unsigned char) PAGE_UNKNOWN;
+      ioptr->prv.pflag = '\0';
+      ioptr->prv.p_reserve_1 = 0;
+      ioptr->prv.p_reserve_2 = 0;
+      ioptr->prv.tde_nonce = 0;
 
-      bufptr->iopage_buffer = ioptr;
-      ioptr->bcb = bufptr;
+      bufptr->iopage = ioptr;
 
 #if defined(CUBRID_DEBUG)
       /* Reinitizalize the buffer */
-      pgbuf_scramble (&bufptr->iopage_buffer->iopage);
+      pgbuf_scramble (bufptr->iopage);
       memcpy (PGBUF_FIND_BUFFER_GUARD (bufptr), pgbuf_Guard, sizeof (pgbuf_Guard));
 #endif /* CUBRID_DEBUG */
     }
@@ -7659,7 +7634,7 @@ pgbuf_claim_bcb_for_fix (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_
 	}
 #endif /* ENABLE_SYSTEMTAP */
 
-      if (dwb_read_page (thread_p, vpid, &bufptr->iopage_buffer->iopage, &success) != NO_ERROR)
+      if (dwb_read_page (thread_p, vpid, bufptr->iopage, &success) != NO_ERROR)
 	{
 	  /* Should not happen */
 	  assert (false);
@@ -7669,7 +7644,7 @@ pgbuf_claim_bcb_for_fix (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_
 	{
 	  /* Nothing to do, copied from DWB */
 	}
-      else if (fileio_read (thread_p, fileio_get_volume_descriptor (vpid->volid), &bufptr->iopage_buffer->iopage,
+      else if (fileio_read (thread_p, fileio_get_volume_descriptor (vpid->volid), bufptr->iopage,
 			    vpid->pageid, IO_PAGESIZE) == NULL)
 	{
 	  /* There was an error in reading the page. Clean the buffer... since it may have been corrupted */
@@ -7696,13 +7671,12 @@ pgbuf_claim_bcb_for_fix (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_
 	  return NULL;
 	}
 
-      CAST_IOPGPTR_TO_PGPTR (pgptr, &bufptr->iopage_buffer->iopage);
+      CAST_IOPGPTR_TO_PGPTR (pgptr, bufptr->iopage);
       tde_algo = pgbuf_get_tde_algorithm (pgptr);
       if (tde_algo != TDE_ALGORITHM_NONE)
 	{
 	  if (tde_decrypt_data_page
-	      (&bufptr->iopage_buffer->iopage, tde_algo, pgbuf_is_temporary_volume (vpid->volid),
-	       &bufptr->iopage_buffer->iopage) != NO_ERROR)
+	      (bufptr->iopage, tde_algo, pgbuf_is_temporary_volume (vpid->volid), bufptr->iopage) != NO_ERROR)
 	    {
 	      ASSERT_ERROR ();
 	      pgbuf_put_bcb_into_invalid_list (thread_p, bufptr);
@@ -7721,9 +7695,9 @@ pgbuf_claim_bcb_for_fix (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_
       if (pgbuf_is_temporary_volume (vpid->volid) == true)
 	{
 	  /* Check if the first time to access */
-	  if (!pgbuf_is_temp_lsa (bufptr->iopage_buffer->iopage.prv.lsa))
+	  if (!pgbuf_is_temp_lsa (bufptr->iopage->prv.lsa))
 	    {
-	      pgbuf_init_temp_page_lsa (&bufptr->iopage_buffer->iopage, IO_PAGESIZE);
+	      pgbuf_init_temp_page_lsa (bufptr->iopage, IO_PAGESIZE);
 	      pgbuf_set_dirty_buffer_ptr (thread_p, bufptr);
 	    }
 	}
@@ -7734,10 +7708,10 @@ pgbuf_claim_bcb_for_fix (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_
 	{
 	  if (!log_is_in_crash_recovery ())
 	    {
-	      if (!LSA_ISNULL (&bufptr->iopage_buffer->iopage.prv.lsa))
+	      if (!LSA_ISNULL (&bufptr->iopage->prv.lsa))
 		{
-		  assert (bufptr->iopage_buffer->iopage.prv.pageid != -1);
-		  assert (bufptr->iopage_buffer->iopage.prv.volid != -1);
+		  assert (bufptr->iopage->prv.pageid != -1);
+		  assert (bufptr->iopage->prv.volid != -1);
 		}
 	    }
 	}
@@ -7753,25 +7727,25 @@ pgbuf_claim_bcb_for_fix (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_
       /* the caller is holding bufptr->mutex */
 
 #if defined(CUBRID_DEBUG)
-      pgbuf_scramble (&bufptr->iopage_buffer->iopage);
+      pgbuf_scramble (bufptr->iopage);
 #endif /* CUBRID_DEBUG */
 
       /* Don't need to read page from disk since it is a new page. */
       if (pgbuf_is_temporary_volume (vpid->volid) == true)
 	{
-	  pgbuf_init_temp_page_lsa (&bufptr->iopage_buffer->iopage, IO_PAGESIZE);
+	  pgbuf_init_temp_page_lsa (bufptr->iopage, IO_PAGESIZE);
 	}
       else
 	{
-	  fileio_init_lsa_of_page (&bufptr->iopage_buffer->iopage, IO_PAGESIZE);
+	  fileio_init_lsa_of_page (bufptr->iopage, IO_PAGESIZE);
 	}
 
       /* perm volume */
       if (bufptr->vpid.volid > NULL_VOLID)
 	{
 	  /* Init Page identifier of NEW_PAGE */
-	  bufptr->iopage_buffer->iopage.prv.pageid = -1;
-	  bufptr->iopage_buffer->iopage.prv.volid = -1;
+	  bufptr->iopage->prv.pageid = -1;
+	  bufptr->iopage->prv.volid = -1;
 	}
 
       if (thread_get_sort_stats_active (thread_p))
@@ -9923,7 +9897,7 @@ start_copy_page:
   tde_algo = pgbuf_get_tde_algorithm (pgptr);
   if (tde_algo != TDE_ALGORITHM_NONE)
     {
-      error = tde_encrypt_data_page (&bufptr->iopage_buffer->iopage, tde_algo, is_temp, iopage);
+      error = tde_encrypt_data_page (bufptr->iopage, tde_algo, is_temp, iopage);
       if (error != NO_ERROR)
 	{
 	  ASSERT_ERROR ();
@@ -9932,7 +9906,7 @@ start_copy_page:
     }
   else
     {
-      memcpy ((void *) iopage, (void *) (&bufptr->iopage_buffer->iopage), IO_PAGESIZE);
+      memcpy ((void *) iopage, (void *) (bufptr->iopage), IO_PAGESIZE);
     }
   if (uses_dwb)
     {
@@ -9949,7 +9923,7 @@ start_copy_page:
     }
 
 copy_unflushed_lsa:
-  LSA_COPY (&lsa, &(bufptr->iopage_buffer->iopage.prv.lsa));
+  LSA_COPY (&lsa, &(bufptr->iopage->prv.lsa));
   LSA_COPY (&oldest_unflush_lsa, &bufptr->oldest_unflush_lsa);
   LSA_SET_NULL (&bufptr->oldest_unflush_lsa);
 
@@ -10223,7 +10197,7 @@ pgbuf_is_valid_page_ptr (const PAGE_PTR pgptr)
       bufptr = PGBUF_FIND_BCB_PTR (bufid);
       PGBUF_BCB_LOCK (bufptr);
 
-      if (((PAGE_PTR) (&(bufptr->iopage_buffer->iopage.page[0]))) == pgptr)
+      if (((PAGE_PTR) (&(bufptr->iopage->page[0]))) == pgptr)
 	{
 	  if (bufptr->fcnt <= 0)
 	    {
@@ -10327,7 +10301,7 @@ pgbuf_check_page_ptype_internal (PAGE_PTR pgptr, PAGE_TYPE ptype, bool no_error)
 
   if (pgbuf_check_bcb_page_vpid (bufptr, false) == true)
     {
-      if (bufptr->iopage_buffer->iopage.prv.ptype != PAGE_UNKNOWN && bufptr->iopage_buffer->iopage.prv.ptype != ptype)
+      if (bufptr->iopage->prv.ptype != PAGE_UNKNOWN && bufptr->iopage->prv.ptype != ptype)
 	{
 	  assert_release (no_error);
 	  return false;
@@ -10366,14 +10340,13 @@ pgbuf_check_bcb_page_vpid (PGBUF_BCB * bufptr, bool maybe_deallocated)
     {
       /* Check Page identifier */
       assert ((maybe_deallocated && log_is_in_crash_recovery_and_not_yet_completes_redo ())
-	      || (bufptr->vpid.pageid == bufptr->iopage_buffer->iopage.prv.pageid
-		  && bufptr->vpid.volid == bufptr->iopage_buffer->iopage.prv.volid));
+	      || (bufptr->vpid.pageid == bufptr->iopage->prv.pageid
+		  && bufptr->vpid.volid == bufptr->iopage->prv.volid));
 
-      assert (bufptr->iopage_buffer->iopage.prv.p_reserve_1 == 0);
-      assert (bufptr->iopage_buffer->iopage.prv.p_reserve_2 == 0);
+      assert (bufptr->iopage->prv.p_reserve_1 == 0);
+      assert (bufptr->iopage->prv.p_reserve_2 == 0);
 
-      return (bufptr->vpid.pageid == bufptr->iopage_buffer->iopage.prv.pageid
-	      && bufptr->vpid.volid == bufptr->iopage_buffer->iopage.prv.volid);
+      return (bufptr->vpid.pageid == bufptr->iopage->prv.pageid && bufptr->vpid.volid == bufptr->iopage->prv.volid);
     }
   else
     {
@@ -10538,9 +10511,8 @@ pgbuf_dump (void)
 		   pgbuf_bcb_get_pool_index (bufptr), VPID_AS_ARGS (&bufptr->vpid), bufptr->fcnt, latch_mode_str,
 		   pgbuf_bcb_is_dirty (bufptr), (int) pgbuf_bcb_is_flushing (bufptr),
 		   (int) pgbuf_bcb_is_async_flush_request (bufptr), zone_str,
-		   LSA_AS_ARGS (&bufptr->iopage_buffer->iopage.prv.lsa), consistent_str, (void *) bufptr,
-		   (void *) (&bufptr->iopage_buffer->iopage.page[0]),
-		   (void *) (&bufptr->iopage_buffer->iopage.page[DB_PAGESIZE - 1]));
+		   LSA_AS_ARGS (&bufptr->iopage->prv.lsa), consistent_str, (void *) bufptr,
+		   (void *) (&bufptr->iopage->page[0]), (void *) (&bufptr->iopage->page[DB_PAGESIZE - 1]));
 	}
       PGBUF_BCB_UNLOCK (bufptr);
     }
@@ -10600,8 +10572,8 @@ pgbuf_is_consistent (const PGBUF_BCB * bufptr, int likely_bad_after_fixcnt)
       else
 	{
 	  /* If page is dirty, it should be different from the one on disk */
-	  if (!LSA_EQ (&malloc_io_pgptr->prv.lsa, &bufptr->iopage_buffer->iopage.prv.lsa)
-	      || memcmp (malloc_io_pgptr->page, bufptr->iopage_buffer->iopage.page, DB_PAGESIZE) != 0)
+	  if (!LSA_EQ (&malloc_io_pgptr->prv.lsa, &bufptr->iopage->prv.lsa)
+	      || memcmp (malloc_io_pgptr->page, bufptr->iopage->page, DB_PAGESIZE) != 0)
 	    {
 	      consistent = (pgbuf_bcb_is_dirty (bufptr) ? PGBUF_CONTENT_GOOD : PGBUF_CONTENT_BAD);
 
@@ -10636,7 +10608,7 @@ pgbuf_is_consistent (const PGBUF_BCB * bufptr, int likely_bad_after_fixcnt)
 	  /* The page should be scrambled, otherwise some one step on it */
 	  for (i = 0; i < DB_PAGESIZE; i++)
 	    {
-	      if (bufptr->iopage_buffer->iopage.page[i] != MEM_REGION_SCRAMBLE_MARK)
+	      if (bufptr->iopage->page[i] != MEM_REGION_SCRAMBLE_MARK)
 		{
 		  /* The page has been stepped by someone */
 		  consistent = PGBUF_CONTENT_BAD;
@@ -10823,7 +10795,7 @@ pgbuf_has_perm_pages_fixed (THREAD_ENTRY * thread_p)
 
   for (holder = pgbuf_Pool.thrd_holder_info[thrd_idx].thrd_hold_list; holder != NULL; holder = holder->thrd_link)
     {
-      if (holder->bufptr->iopage_buffer->iopage.prv.ptype != PAGE_QRESULT)
+      if (holder->bufptr->iopage->prv.ptype != PAGE_QRESULT)
 	{
 	  return true;
 	}
@@ -10859,25 +10831,24 @@ pgbuf_is_thread_high_priority (THREAD_ENTRY * thread_p)
 	  return true;
 	}
 
-      if (holder->bufptr->iopage_buffer->iopage.prv.ptype == PAGE_VOLHEADER)
+      if (holder->bufptr->iopage->prv.ptype == PAGE_VOLHEADER)
 	{
 	  /* has volume header */
 	  return true;
 	}
-      if (holder->bufptr->iopage_buffer->iopage.prv.ptype == PAGE_FTAB)
+      if (holder->bufptr->iopage->prv.ptype == PAGE_FTAB)
 	{
 	  /* holds a file header page */
 	  return true;
 	}
-      if (holder->bufptr->iopage_buffer->iopage.prv.ptype == PAGE_BTREE
-	  && (btree_get_perf_btree_page_type (thread_p, holder->bufptr->iopage_buffer->iopage.page)
-	      == PERF_PAGE_BTREE_ROOT))
+      if (holder->bufptr->iopage->prv.ptype == PAGE_BTREE
+	  && (btree_get_perf_btree_page_type (thread_p, holder->bufptr->iopage->page) == PERF_PAGE_BTREE_ROOT))
 	{
 	  /* holds b-tree root */
 	  return true;
 	}
-      if (holder->bufptr->iopage_buffer->iopage.prv.ptype == PAGE_HEAP
-	  && heap_is_page_header (thread_p, holder->bufptr->iopage_buffer->iopage.page))
+      if (holder->bufptr->iopage->prv.ptype == PAGE_HEAP
+	  && heap_is_page_header (thread_p, holder->bufptr->iopage->page))
 	{
 	  /* heap file header */
 	  return true;
@@ -11467,7 +11438,7 @@ pgbuf_ordered_fix_release (THREAD_ENTRY * thread_p, const VPID * req_vpid, PAGE_
 
 	  if (VPID_EQ (req_vpid, &(holder->bufptr->vpid)))
 	    {
-	      assert (PGBUF_IS_ORDERED_PAGETYPE (holder->bufptr->iopage_buffer->iopage.prv.ptype));
+	      assert (PGBUF_IS_ORDERED_PAGETYPE (holder->bufptr->iopage->prv.ptype));
 
 	      if (req_page_has_group == false && holder->first_watcher != NULL)
 		{
@@ -11564,7 +11535,7 @@ pgbuf_ordered_fix_release (THREAD_ENTRY * thread_p, const VPID * req_vpid, PAGE_
 	  continue;
 	}
 
-      assert (PGBUF_IS_ORDERED_PAGETYPE (holder->bufptr->iopage_buffer->iopage.prv.ptype));
+      assert (PGBUF_IS_ORDERED_PAGETYPE (holder->bufptr->iopage->prv.ptype));
 
       if (saved_pages_cnt >= PGBUF_MAX_PAGE_FIXED_BY_TRAN)
 	{
@@ -11716,7 +11687,7 @@ pgbuf_ordered_fix_release (THREAD_ENTRY * thread_p, const VPID * req_vpid, PAGE_
 	  if (diff < 0)
 	    {
 	      ordered_holders_info[saved_pages_cnt].watch_count = holder->watch_count;
-	      ordered_holders_info[saved_pages_cnt].ptype = (PAGE_TYPE) holder->bufptr->iopage_buffer->iopage.prv.ptype;
+	      ordered_holders_info[saved_pages_cnt].ptype = (PAGE_TYPE) holder->bufptr->iopage->prv.ptype;
 
 #if defined(PGBUF_ORDERED_DEBUG)
 	      _er_log_debug (__FILE__, __LINE__,
@@ -13934,7 +13905,7 @@ pgbuf_dealloc_page (THREAD_ENTRY * thread_p, PAGE_PTR page_dealloc)
   CAST_PGPTR_TO_BFPTR (bcb, page_dealloc);
   assert (bcb->fcnt == 1);
 
-  prv = &bcb->iopage_buffer->iopage.prv;
+  prv = &bcb->iopage->prv;
   assert (prv->ptype != PAGE_UNKNOWN);
 
   udata.pageid = prv->pageid;
@@ -13947,7 +13918,7 @@ pgbuf_dealloc_page (THREAD_ENTRY * thread_p, PAGE_PTR page_dealloc)
   PGBUF_BCB_LOCK (bcb);
 
 #if !defined(NDEBUG)
-  if (bcb->iopage_buffer->iopage.prv.pflag & FILEIO_PAGE_FLAG_ENCRYPTED_MASK)
+  if (bcb->iopage->prv.pflag & FILEIO_PAGE_FLAG_ENCRYPTED_MASK)
     {
       tde_er_log ("pgbuf_dealloc_page(): clear tde bit in pflag, VPID = %d|%d, tde_algorithm = %s\n",
 		  VPID_AS_ARGS (&bcb->vpid), tde_get_algorithm_name (pgbuf_get_tde_algorithm (page_dealloc)));
@@ -13955,9 +13926,9 @@ pgbuf_dealloc_page (THREAD_ENTRY * thread_p, PAGE_PTR page_dealloc)
 #endif /* !NDEBUG */
 
   /* set unknown type */
-  bcb->iopage_buffer->iopage.prv.ptype = (unsigned char) PAGE_UNKNOWN;
+  bcb->iopage->prv.ptype = (unsigned char) PAGE_UNKNOWN;
   /* clear page flags (now only tde algorithm) */
-  bcb->iopage_buffer->iopage.prv.pflag = (unsigned char) 0;
+  bcb->iopage->prv.pflag = (unsigned char) 0;
 
   /* set dirty and mark to move to the bottom of lru */
   pgbuf_bcb_update_flags (thread_p, bcb, PGBUF_BCB_DIRTY_FLAG | PGBUF_BCB_MOVE_TO_LRU_BOTTOM_FLAG, 0);
@@ -16063,7 +16034,7 @@ pgbuf_scan_bcb_table ()
   for (bufid = 0; bufid < pgbuf_Pool.num_buffers; bufid++)
     {
       bufptr = PGBUF_FIND_BCB_PTR (bufid);
-      page_type = (PAGE_TYPE) (bufptr->iopage_buffer->iopage.prv.ptype);
+      page_type = (PAGE_TYPE) (bufptr->iopage->prv.ptype);
       vpid = bufptr->vpid;
       flags = bufptr->flags;
 
@@ -16215,7 +16186,7 @@ pgbuf_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** arg_values, int
   db_make_int (&vals[idx], pgbuf_Pool.num_buffers);
   idx++;
 
-  db_make_int (&vals[idx], PGBUF_IOPAGE_BUFFER_SIZE);
+  db_make_int (&vals[idx], IO_PAGESIZE);
   idx++;
 
   db_make_int (&vals[idx], status_snapshot->free_pages);

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -137,7 +137,7 @@ static int rv;
 /* macros for casting pointers */
 #define CAST_PGPTR_TO_BFPTR(bufptr, pgptr) \
   do { \
-    (bufptr) = PGBUF_FIND_BCB_PTR ((((FILEIO_PAGE *) ((char *) (pgptr) - offsetof (FILEIO_PAGE, page))) - pgbuf_Pool.iopage_table)); \
+    (bufptr) = PGBUF_FIND_BCB_PTR ((((unsigned long) (pgptr) - offsetof (FILEIO_PAGE, page)) - (unsigned long) pgbuf_Pool.iopage_table) / IO_PAGESIZE) ; \
   } while (0)
 
 #define CAST_PGPTR_TO_IOPGPTR(io_pgptr, pgptr) \

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -1350,7 +1350,7 @@ boot_mount (THREAD_ENTRY * thread_p, VOLID volid, const char *vlabel, void *igno
   char check_vlabel[PATH_MAX];
   int vdes;
 
-  vdes = fileio_mount (thread_p, boot_Db_full_name, vlabel, volid, false, false);
+  vdes = fileio_mount (thread_p, boot_Db_full_name, vlabel, volid, false, false, true);
   if (vdes == NULL_VOLDES)
     {
       return ER_FAILED;

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1133,8 +1133,7 @@ log_initialize_internal (THREAD_ENTRY * thread_p, const char *db_fullname, const
   log_Gl.run_nxchkpt_atpageid = NULL_PAGEID;	/* Don't run the checkpoint */
   log_Gl.rcv_phase = LOG_RECOVERY_ANALYSIS_PHASE;
 
-  log_Gl.loghdr_pgptr = (LOG_PAGE *) malloc (LOG_PAGESIZE);
-  if (log_Gl.loghdr_pgptr == NULL)
+  if (posix_memalign ((void **) &log_Gl.loghdr_pgptr, 4096, LOG_PAGESIZE) != 0)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, (size_t) LOG_PAGESIZE);
       logpb_fatal_error (thread_p, !init_emergency, ARG_FILE_LINE, "log_xinit");
@@ -1148,7 +1147,7 @@ log_initialize_internal (THREAD_ENTRY * thread_p, const char *db_fullname, const
     }
 
   /* Mount the active log and read the log header */
-  log_Gl.append.vdes = fileio_mount (thread_p, db_fullname, log_Name_active, LOG_DBLOG_ACTIVE_VOLID, true, false);
+  log_Gl.append.vdes = fileio_mount (thread_p, db_fullname, log_Name_active, LOG_DBLOG_ACTIVE_VOLID, true, false, true);
   if (log_Gl.append.vdes == NULL_VOLDES)
     {
       if (ismedia_crash != false)
@@ -14357,7 +14356,7 @@ cdc_check_lsa_range (THREAD_ENTRY * thread_p, LOG_LSA * lsa)
 
       if (fileio_is_volume_exist (arv_name) == true)
 	{
-	  vdes = fileio_mount (thread_p, log_Db_fullname, arv_name, LOG_DBLOG_ARCHIVE_VOLID, false, false);
+	  vdes = fileio_mount (thread_p, log_Db_fullname, arv_name, LOG_DBLOG_ARCHIVE_VOLID, false, false, true);
 	  if (vdes != NULL_VOLDES)
 	    {
 	      if (fileio_read (thread_p, vdes, hdr_pgptr, 0, IO_MAX_PAGE_SIZE) == NULL)
@@ -14613,7 +14612,7 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
 
 	  if (fileio_is_volume_exist (arv_name) == true)
 	    {
-	      vdes = fileio_mount (thread_p, log_Db_fullname, arv_name, LOG_DBLOG_ARCHIVE_VOLID, false, false);
+	      vdes = fileio_mount (thread_p, log_Db_fullname, arv_name, LOG_DBLOG_ARCHIVE_VOLID, false, false, true);
 	      if (vdes != NULL_VOLDES)
 		{
 		  if (fileio_read (thread_p, vdes, hdr_pgptr, 0, IO_MAX_PAGE_SIZE) == NULL)

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -583,8 +583,7 @@ logpb_initialize_pool (THREAD_ENTRY * thread_p)
     }
 
   size = ((size_t) log_Pb.num_buffers * (LOG_PAGESIZE));
-  log_Pb.pages_area = (LOG_PAGE *) malloc (size);
-  if (log_Pb.pages_area == NULL)
+  if (posix_memalign ((void **) &log_Pb.pages_area, 4096, size) != 0)
     {
       free_and_init (log_Pb.buffers);
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, size);
@@ -600,8 +599,7 @@ logpb_initialize_pool (THREAD_ENTRY * thread_p)
     }
 
   size = LOG_PAGESIZE;
-  log_Pb.header_page = (LOG_PAGE *) malloc (size);
-  if (log_Pb.header_page == NULL)
+  if (posix_memalign ((void **) &log_Pb.header_page, 4096, size) != 0)
     {
       free_and_init (log_Pb.buffers);
       free_and_init (log_Pb.pages_area);
@@ -1533,7 +1531,7 @@ logpb_fetch_header_from_active_log (THREAD_ENTRY * thread_p, const char *db_full
       goto error;
     }
 
-  log_Gl.append.vdes = fileio_mount (thread_p, db_fullname, log_Name_active, LOG_DBLOG_ACTIVE_VOLID, true, false);
+  log_Gl.append.vdes = fileio_mount (thread_p, db_fullname, log_Name_active, LOG_DBLOG_ACTIVE_VOLID, true, false, true);
   if (log_Gl.append.vdes == NULL_VOLDES)
     {
       error_code = ER_FAILED;
@@ -5244,7 +5242,7 @@ logpb_fetch_from_archive (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, LOG_PAGE *
       error_code = ER_FAILED;
       if (logpb_is_archive_available (thread_p, *ret_arv_num) == true && fileio_is_volume_exist (arv_name) == true)
 	{
-	  vdes = fileio_mount (thread_p, log_Db_fullname, arv_name, LOG_DBLOG_ARCHIVE_VOLID, false, false);
+	  vdes = fileio_mount (thread_p, log_Db_fullname, arv_name, LOG_DBLOG_ARCHIVE_VOLID, false, false, true);
 	  if (vdes != NULL_VOLDES)
 	    {
 	      if (fileio_read (thread_p, vdes, hdr_pgptr, 0, LOG_PAGESIZE) == NULL)
@@ -5484,7 +5482,7 @@ logpb_fetch_from_archive (THREAD_ENTRY * thread_p, LOG_PAGEID pageid, LOG_PAGE *
 	  while (retry != 0 && retry != 1
 		 && (vdes =
 		     fileio_mount (thread_p, log_Db_fullname, arv_name, LOG_DBLOG_ARCHIVE_VOLID, false,
-				   false)) == NULL_VOLDES)
+				   false, true)) == NULL_VOLDES)
 	    {
 	      char line_buf[PATH_MAX * 2];
 	      bool is_in_crash_recovery;
@@ -5814,7 +5812,7 @@ logpb_archive_active_log (THREAD_ENTRY * thread_p)
 	  goto error;
 	}
 
-      vdes = fileio_mount (thread_p, log_Db_fullname, arv_name, LOG_DBLOG_ARCHIVE_VOLID, 0, false);
+      vdes = fileio_mount (thread_p, log_Db_fullname, arv_name, LOG_DBLOG_ARCHIVE_VOLID, 0, false, true);
       if (vdes == NULL_VOLDES)
 	{
 	  goto error;
@@ -8485,7 +8483,7 @@ logpb_restore (THREAD_ENTRY * thread_p, const char *db_fullname, const char *log
    */
   if (fileio_is_volume_exist (log_Name_active))
     {
-      lgat_vdes = fileio_mount (thread_p, db_fullname, log_Name_active, LOG_DBLOG_ACTIVE_VOLID, true, false);
+      lgat_vdes = fileio_mount (thread_p, db_fullname, log_Name_active, LOG_DBLOG_ACTIVE_VOLID, true, false, true);
       if (lgat_vdes == NULL_VOLDES)
 	{
 	  error_code = ER_FAILED;
@@ -8915,7 +8913,7 @@ logpb_restore (THREAD_ENTRY * thread_p, const char *db_fullname, const char *log
       prev_volname = volnames.second.c_str();
 
       prev_volid = fileio_find_previous_perm_volume (thread_p, volid);
-      prev_vdes = fileio_mount (thread_p, NULL, prev_volname, prev_volid, false, false);
+      prev_vdes = fileio_mount (thread_p, NULL, prev_volname, prev_volid, false, false, true);
       if (prev_vdes == NULL_VOLDES)
 	{
 	  goto error;
@@ -9711,7 +9709,7 @@ logpb_copy_database (THREAD_ENTRY * thread_p, VOLID num_perm_vols, const char *t
 	   */
 	  volid = (VOLID) fromfile_volid;
 
-	  to_vdes = fileio_mount (thread_p, log_Db_fullname, to_volname, LOG_DBCOPY_VOLID, false, false);
+	  to_vdes = fileio_mount (thread_p, log_Db_fullname, to_volname, LOG_DBCOPY_VOLID, false, false, true);
 	  if (to_vdes == NULL_VOLDES)
 	    {
 	      error_code = ER_FAILED;
@@ -9991,12 +9989,13 @@ logpb_rename_all_volumes_files (THREAD_ENTRY * thread_p, VOLID num_perm_vols, co
       fileio_make_log_active_name (to_volname, to_logpath, to_prefix_logname);
       if (fileio_rename (LOG_DBLOG_ACTIVE_VOLID, log_Name_active, to_volname) != NULL)
 	{
-	  log_Gl.append.vdes = fileio_mount (thread_p, to_db_fullname, to_volname, LOG_DBLOG_ACTIVE_VOLID, true, false);
+	  log_Gl.append.vdes =
+	    fileio_mount (thread_p, to_db_fullname, to_volname, LOG_DBLOG_ACTIVE_VOLID, true, false, true);
 	}
       else
 	{
 	  log_Gl.append.vdes =
-	    fileio_mount (thread_p, log_Db_fullname, log_Name_active, LOG_DBLOG_ACTIVE_VOLID, true, false);
+	    fileio_mount (thread_p, log_Db_fullname, log_Name_active, LOG_DBLOG_ACTIVE_VOLID, true, false, true);
 	  error_code = ER_FAILED;
 	  goto error;
 	}
@@ -10162,11 +10161,11 @@ logpb_rename_all_volumes_files (THREAD_ENTRY * thread_p, VOLID num_perm_vols, co
 	  fileio_dismount (thread_p, fileio_get_volume_descriptor (volid));
 	  if (fileio_rename (volid, from_volname, to_volname) != NULL)
 	    {
-	      (void) fileio_mount (thread_p, to_db_fullname, to_volname, volid, false, false);
+	      (void) fileio_mount (thread_p, to_db_fullname, to_volname, volid, false, false, true);
 	    }
 	  else
 	    {
-	      (void) fileio_mount (thread_p, log_Db_fullname, from_volname, volid, false, false);
+	      (void) fileio_mount (thread_p, log_Db_fullname, from_volname, volid, false, false, true);
 	      error_code = ER_FAILED;
 	      goto error;
 	    }
@@ -10289,7 +10288,7 @@ logpb_delete (THREAD_ENTRY * thread_p, VOLID num_perm_vols, const char *db_fulln
       if (fileio_is_volume_exist (log_Name_active) == false
 	  || (log_Gl.append.vdes =
 	      fileio_mount (thread_p, db_fullname, log_Name_active, LOG_DBLOG_ACTIVE_VOLID, true,
-			    false)) == NULL_VOLDES)
+			    false, true)) == NULL_VOLDES)
 	{
 	  /* Unable to mount the active log */
 	  if (er_errid () == ER_IO_MOUNT_LOCKED)
@@ -11309,7 +11308,7 @@ logpb_find_oldest_available_page_id (THREAD_ENTRY * thread_p)
 
   fileio_make_log_archive_name (arv_name, log_Archive_path, log_Prefix, arv_num);
 
-  vdes = fileio_mount (thread_p, log_Db_fullname, arv_name, LOG_DBLOG_ARCHIVE_VOLID, false, false);
+  vdes = fileio_mount (thread_p, log_Db_fullname, arv_name, LOG_DBLOG_ARCHIVE_VOLID, false, false, true);
   if (vdes != NULL_VOLDES)
     {
       if (fileio_read (thread_p, vdes, arv_hdr_pgptr, 0, LOG_PAGESIZE) == NULL)
@@ -11414,7 +11413,8 @@ logpb_remove_all_in_log_path (THREAD_ENTRY * thread_p, const char *db_fullname, 
 
   if (fileio_is_volume_exist (log_Name_active)
       && (log_Gl.append.vdes =
-	  fileio_mount (thread_p, db_fullname, log_Name_active, LOG_DBLOG_ACTIVE_VOLID, true, false)) != NULL_VOLDES)
+	  fileio_mount (thread_p, db_fullname, log_Name_active, LOG_DBLOG_ACTIVE_VOLID, true, false,
+			true)) != NULL_VOLDES)
     {
       char log_pgbuf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT], *aligned_log_pgbuf;
       LOG_PAGE *log_pgptr;

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -5176,7 +5176,7 @@ log_recovery_notpartof_volumes (THREAD_ENTRY * thread_p)
 	  break;
 	}
 
-      vdes = fileio_mount (thread_p, log_Db_fullname, vol_fullname, volid, false, false);
+      vdes = fileio_mount (thread_p, log_Db_fullname, vol_fullname, volid, false, false, true);
       if (vdes != NULL_VOLDES)
 	{
 	  ret = disk_get_db_creation (thread_p, volid, &vol_dbcreation);

--- a/src/transaction/log_writer.c
+++ b/src/transaction/log_writer.c
@@ -305,7 +305,7 @@ logwr_read_log_header (void)
     {
       /* Mount the active log and read the log header */
       logwr_Gl.append_vdes =
-	fileio_mount (NULL, logwr_Gl.db_name, logwr_Gl.active_name, LOG_DBLOG_ACTIVE_VOLID, true, false);
+	fileio_mount (NULL, logwr_Gl.db_name, logwr_Gl.active_name, LOG_DBLOG_ACTIVE_VOLID, true, false, true);
       if (logwr_Gl.append_vdes == NULL_VOLDES)
 	{
 	  /* Unable to mount the active log */
@@ -525,7 +525,7 @@ logwr_initialize (const char *db_name, const char *log_path, int mode, LOG_PAGEI
 	{
 	  bg_arv_info->vdes =
 	    fileio_mount (NULL, logwr_Gl.bg_archive_name, logwr_Gl.bg_archive_name, LOG_DBLOG_ARCHIVE_VOLID, true,
-			  false);
+			  false, true);
 	  if (bg_arv_info->vdes == NULL_VOLDES)
 	    {
 	      return ER_IO_MOUNT_FAIL;
@@ -1340,7 +1340,7 @@ logwr_archive_active_log (void)
     {
       if (fileio_is_volume_exist (archive_name) == true)
 	{
-	  vdes = fileio_mount (NULL, archive_name, archive_name, LOG_DBLOG_ARCHIVE_VOLID, true, false);
+	  vdes = fileio_mount (NULL, archive_name, archive_name, LOG_DBLOG_ARCHIVE_VOLID, true, false, true);
 	  if (vdes == NULL_VOLDES)
 	    {
 	      error_code = ER_IO_MOUNT_FAIL;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26146

Purpose
Page Buffer의 페이지들이 4KB 경계에 맞도록 한다.

Implementation
페이지 구조 자체를 변경하여 PGBUF_IOPAGE_BUFFER 구조체를 제거하고 BCB가 IOPAGE를 직접 다루도록 한다.
역으로 페이지에서는 단순한 인덱스 연산을 통해 BCB에 접근할 수 있다.

Remarks
N/A
