### PR TITLE
[CBRD-26068] use struct instead of class in a forward declaration of db_parameter_info

### DIFF
--- a/src/sp/pl_session.hpp
+++ b/src/sp/pl_session.hpp
@@ -51,7 +51,7 @@ namespace cubthread
 namespace cubmethod
 {
   class method_invoke_group;
-  class db_parameter_info;
+  struct db_parameter_info;
 }
 
 namespace cubpl


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26068>

### Purpose

오타 수정 - 원래 선언이 struct 인 것을 forward declaration에서 class 로 잘못 쓰고 있었던 것을 수정.

### Implementation

N/A

### Remarks

N/A
