### PR TITLE
[CBRD-26137] [Regression] Core dumped in pgbuf_is_valid_page at src/storage/page_buffer.c:10186

### DIFF
--- a/src/query/parallel/px_list_merger.cpp
+++ b/src/query/parallel/px_list_merger.cpp
@@ -24,6 +24,7 @@
 #include "page_buffer.h"
 #include "object_representation.h"
 #include "thread_manager.hpp"
+#include "query_manager.h"
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
 #include "memory_wrapper.hpp"
 

--- a/src/query/parallel/px_list_merger.cpp
+++ b/src/query/parallel/px_list_merger.cpp
@@ -77,16 +77,16 @@ namespace parallel_query
 	qfile_close_list (m_thread_p, list_id);
       }
     /* head last page -> list_id first page (next) */
-    PAGE_PTR head_last_pgptr = pgbuf_fix (m_thread_p, &m_head_list_id->last_vpid, OLD_PAGE, PGBUF_LATCH_WRITE,
-					  PGBUF_UNCONDITIONAL_LATCH);
+    PAGE_PTR head_last_pgptr = qmgr_get_old_page (m_thread_p, &m_head_list_id->last_vpid, m_head_list_id->tfile_vfid);
     assert (head_last_pgptr != NULL);
     QFILE_PUT_NEXT_VPID (head_last_pgptr, &list_id->first_vpid);
     pgbuf_set_dirty (m_thread_p, head_last_pgptr, FREE);
 
     /* list_id first page -> head last page (prev) */
-    PAGE_PTR list_id_first_pgptr = pgbuf_fix (m_thread_p, &list_id->first_vpid, OLD_PAGE, PGBUF_LATCH_WRITE,
-				   PGBUF_UNCONDITIONAL_LATCH);
+    PAGE_PTR list_id_first_pgptr = qmgr_get_old_page (m_thread_p, &list_id->first_vpid, list_id->tfile_vfid);
     assert (list_id_first_pgptr != NULL);
+    /* The list_id to be appended must not use membuf. */
+    assert (list_id->first_vpid.volid != NULL_VOLID);
     QFILE_PUT_PREV_VPID (list_id_first_pgptr, &m_head_list_id->last_vpid);
     pgbuf_set_dirty (m_thread_p, list_id_first_pgptr, FREE);
     /* append list_id to m_head_list_id */


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26137>

### Purpose

add_list_id에서 head_list_id(현재 상황에서는 기존 레거시 코드에 따라 동작하던 xasl->list_id)의 마지막 페이지를 fix한 다음, 해당 페이지의 next에 새로 추가된 list_id의 첫 번째 vpid를 연결합니다.
그런데 parallel thread에서 생성된 list_id들은 NOT_USE_MEMBUF 플래그가 설정되어 있어, vpid가 membuf 내 페이지를 가리키지 않습니다.
반면 기존의 xasl->list_id는 membuf를 사용하는 방식으로 되어 있어, 이 경우 vpid의 볼륨 번호가 -1로 설정됩니다.
이런 상태의 vpid를 fix 할 경우 membuf를 fix 하도록 변경합니다.
