### PR TITLE
[CUBVEC-96] Fix COSINE metric issues with all-zero vectors

### DIFF
--- a/src/compat/db_vector.cpp
+++ b/src/compat/db_vector.cpp
@@ -23,6 +23,8 @@
 
 #include "cubvec_assert.h"
 #include "error_code.h"
+
+#include <algorithm>
 #include <cmath>
 #include <limits>
 #include <sstream>
@@ -169,3 +171,10 @@ std::string db_vector_float_to_string (const DB_VECTOR_FLOAT &vf)
   return oss.str();
 }
 
+bool db_vector_is_all_zeros (const DB_VECTOR_FLOAT *vf)
+{
+  return std::all_of (vf->float_array, vf->float_array + vf->dim, [] (float f)
+  {
+    return f == 0.0f;
+  });
+}

--- a/src/compat/db_vector.hpp
+++ b/src/compat/db_vector.hpp
@@ -32,4 +32,6 @@ extern int db_string_to_vector (const char *p, int str_len, float *vector, int *
 
 std::string db_vector_float_to_string (const DB_VECTOR_FLOAT &vf);
 
+bool db_vector_is_all_zeros (const DB_VECTOR_FLOAT *vf);
+
 #endif /* _DB_VECTOR_HPP_ */

--- a/src/query/vector_opfunc.cpp
+++ b/src/query/vector_opfunc.cpp
@@ -178,6 +178,14 @@ int vector_negative_inner_product (DB_VALUE *result, DB_VALUE *args[], int num_a
 
 int vector_cosine_distance (DB_VALUE *result, DB_VALUE *args[], int num_args)
 {
+  if (db_vector_is_all_zeros (db_get_vector_float (args[0])) || db_vector_is_all_zeros (db_get_vector_float (args[1])))
+    {
+      // infinite distance
+      // TODO: hmm.. is it correct?
+      db_make_double (result, std::numeric_limits<double>::infinity());
+      return NO_ERROR;
+    }
+
   return vector_distance_internal (result, args, num_args, cubvec_cosine_distance);
 }
 

--- a/src/query/vector_opfunc.cpp
+++ b/src/query/vector_opfunc.cpp
@@ -20,6 +20,7 @@
 #include "vector_opfunc.hpp"
 #include "dbtype.h"
 #include "dbtype_def.h"
+#include "db_vector.hpp"
 #include "faiss/utils/distances.h"
 #include "vector_distance_enum.h"
 // XXX: SHOULD BE THE LAST INCLUDE HEADER

--- a/src/query/vector_opfunc.cpp
+++ b/src/query/vector_opfunc.cpp
@@ -144,8 +144,15 @@ static int vector_distance_internal (DB_VALUE *result, DB_VALUE *args[], int num
       std::abort();
     }
 
+  if (std::isnan (distance))
+    {
+      db_make_null (result);
+    }
+  else
+    {
+      db_make_double (result, static_cast<double> (distance));
+    }
 
-  db_make_double (result, static_cast<double> (distance));
   return NO_ERROR;
 }
 
@@ -179,14 +186,6 @@ int vector_negative_inner_product (DB_VALUE *result, DB_VALUE *args[], int num_a
 
 int vector_cosine_distance (DB_VALUE *result, DB_VALUE *args[], int num_args)
 {
-  if (db_vector_is_all_zeros (db_get_vector_float (args[0])) || db_vector_is_all_zeros (db_get_vector_float (args[1])))
-    {
-      // infinite distance
-      // TODO: hmm.. is it correct?
-      db_make_null (result);
-      return NO_ERROR;
-    }
-
   return vector_distance_internal (result, args, num_args, cubvec_cosine_distance);
 }
 
@@ -200,7 +199,8 @@ static float cubvec_cosine_distance (const float *vec1, const float *vec2, size_
   // Handle zero vectors to avoid division by zero
   if (norm1 == 0.0f || norm2 == 0.0f)
     {
-      return 1.0f; // Maximum distance
+      // NaN distance
+      return std::numeric_limits<float>::quiet_NaN();
     }
 
   float similarity = ip / (sqrtf (norm1) * sqrtf (norm2));

--- a/src/query/vector_opfunc.cpp
+++ b/src/query/vector_opfunc.cpp
@@ -182,7 +182,7 @@ int vector_cosine_distance (DB_VALUE *result, DB_VALUE *args[], int num_args)
     {
       // infinite distance
       // TODO: hmm.. is it correct?
-      db_make_double (result, std::numeric_limits<double>::infinity());
+      db_make_null (result);
       return NO_ERROR;
     }
 

--- a/src/storage/hnsw_faiss.cpp
+++ b/src/storage/hnsw_faiss.cpp
@@ -402,6 +402,12 @@ hnsw_add_element (BTID *btid, OID *oid, DB_VALUE *key_dbvalue)
   try
     {
       std::unique_ptr<faiss::IndexIDMap> &index = it->second;
+      if (index->metric_type == faiss::METRIC_COSINE && db_vector_is_all_zeros (vf))
+	{
+	  er_log_debug (ARG_FILE_LINE, "Vector is all zeros, skipping add");
+	  return NO_ERROR;
+	}
+
       std::lock_guard<std::mutex> lock (hnsw_elem_mutex);
 
       index->add_with_ids (1, vf->float_array, &encoded_oid);
@@ -457,6 +463,13 @@ int hnsw_search_element (int hnsw_id, DB_VALUE *key_dbvalue, int k, OID *rec_oid
     }
 
   std::unique_ptr<faiss::IndexIDMap> &index = it->second;
+
+  if (index->metric_type == faiss::METRIC_COSINE && db_vector_is_all_zeros (vf))
+    {
+      er_log_debug (ARG_FILE_LINE, "Vector is all zeros, skipping search");
+      return NO_ERROR;
+    }
+
   auto *hnsw_index = static_cast<faiss::IndexHNSWFlat *> (index->index);
   hnsw_index->hnsw.efSearch = prm_get_integer_value (PRM_ID_VECTOR_INDEX_EF_SEARCH);
 

--- a/src/storage/hnsw_faiss.cpp
+++ b/src/storage/hnsw_faiss.cpp
@@ -403,7 +403,7 @@ hnsw_add_element (BTID *btid, OID *oid, DB_VALUE *key_dbvalue)
   try
     {
       std::unique_ptr<faiss::IndexIDMap> &index = it->second;
-      if (index->metric_type == faiss::METRIC_COSINE && db_vector_is_all_zeros (vf))
+      if (index->metric_type == faiss::METRIC_INNER_PRODUCT && db_vector_is_all_zeros (vf))
 	{
 	  er_log_debug (ARG_FILE_LINE, "Vector is all zeros, skipping add");
 	  return NO_ERROR;
@@ -465,7 +465,7 @@ int hnsw_search_element (int hnsw_id, DB_VALUE *key_dbvalue, int k, OID *rec_oid
 
   std::unique_ptr<faiss::IndexIDMap> &index = it->second;
 
-  if (index->metric_type == faiss::METRIC_COSINE && db_vector_is_all_zeros (vf))
+  if (index->metric_type == faiss::METRIC_INNER_PRODUCT && db_vector_is_all_zeros (vf))
     {
       er_log_debug (ARG_FILE_LINE, "Vector is all zeros, skipping search");
       return NO_ERROR;

--- a/src/storage/hnsw_faiss.cpp
+++ b/src/storage/hnsw_faiss.cpp
@@ -28,6 +28,7 @@
 #include "file_io.h"
 #include "system_parameter.h"
 #include "dbtype.h"
+#include "db_vector.hpp"
 #include "porting.h"
 #include <fstream>
 #include <filesystem>

--- a/src/storage/hnsw_usearch.cpp
+++ b/src/storage/hnsw_usearch.cpp
@@ -396,6 +396,11 @@ hnsw_add_element (BTID *btid, OID *oid, DB_VALUE *key_dbvalue)
   try
     {
       std::unique_ptr<usearch::index_dense_t> &index = it->second;
+      if (index->metric_kind() == usearch::metric_kind_t::cos_k && db_vector_is_all_zeros (vf))
+	{
+	  er_log_debug (ARG_FILE_LINE, "Vector is all zeros, skipping add");
+	  return NO_ERROR;
+	}
 
       std::lock_guard<std::mutex> lock (hnsw_elem_mutex);
       if (index->size() >= index->capacity())
@@ -456,6 +461,13 @@ int hnsw_search_element (int hnsw_id, DB_VALUE *key_dbvalue, int k, OID *rec_oid
     }
 
   std::unique_ptr<usearch::index_dense_t> &index = it->second;
+
+  if (index->metric_kind() == usearch::metric_kind_t::cos_k && db_vector_is_all_zeros (vf))
+    {
+      er_log_debug (ARG_FILE_LINE, "Vector is all zeros, skipping search");
+      return NO_ERROR;
+    }
+
   index->change_expansion_search (prm_get_integer_value (PRM_ID_VECTOR_INDEX_EF_SEARCH));
 
   auto results = index->search (vf->float_array, k);

--- a/src/storage/hnsw_usearch.cpp
+++ b/src/storage/hnsw_usearch.cpp
@@ -105,7 +105,7 @@ xhnsw_add_index (THREAD_ENTRY *thread_p, BTID *btid, int dimension = 10, int hns
   config.expansion_add = hnsw_efConstruction;
 
   auto index_ptr = std::make_unique<usearch::index_dense_t> (
-			   usearch::index_dense_t::make (metric, config)
+			   usearch::index_dense_t::make (metric_punned, config)
 		   );
 
   index_ptr->reserve (10000);

--- a/src/storage/hnsw_usearch.cpp
+++ b/src/storage/hnsw_usearch.cpp
@@ -28,6 +28,7 @@
 #include "file_io.h"
 #include "system_parameter.h"
 #include "dbtype.h"
+#include "db_vector.hpp"
 #include "porting.h"
 #include "vector_distance_enum.h"
 #include <fstream>


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-96

### Purpose

- 코사인 메트릭의 인덱스 연산 및 거리 연산에서 all zero vector가 입력될 때 수학적으로 정의되지 않아 예상하지 않은 결과를 반환할 수 있는 문제를 제거
  - all zero vector에 대해서 인덱스에 삽입하지 않고, 인덱스 조건에 사용되는 경우에도 연산 결과를 반환하지 않도록 수정
  - all zero vector에 대해서 cosine distance 거리 연산와 거리 함수에서 NULL 값을 반환

### Implementation

- hnsw_add_element, hnsw_search_element에서 cosine metric과 all zero vector 확인 후 바로 반환
- vector_cosine_distance 에서 args에 대해 all zero vector 확인 후 NULL 값 반환

### Remarks

N/A
