### PR TITLE
[CUBVEC-85] Fix slip: usearch::metric_punned_t should be passed to usearch::index_dense_t::make ()'s 1st argument

### DIFF
--- a/src/storage/hnsw_usearch.cpp
+++ b/src/storage/hnsw_usearch.cpp
@@ -105,7 +105,7 @@ xhnsw_add_index (THREAD_ENTRY *thread_p, BTID *btid, int dimension = 10, int hns
   config.expansion_add = hnsw_efConstruction;
 
   auto index_ptr = std::make_unique<usearch::index_dense_t> (
-			   usearch::index_dense_t::make (metric, config)
+			   usearch::index_dense_t::make (metric_punned, config)
 		   );
 
   index_ptr->reserve (10000);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-85

### Purpose

- metric_punned_t 객체를 make () 함수에 전달하지 않아 metric이 올바르게 설정되지 못한 문제를 수정합니다.

### Implementation

- usearch::index_dense_t::make () 함수에 잘못된 metric 대신 metric_punned 객체 전달

### Remarks

N/A
