### PR TITLE
[CUBVEC-97] Add host variable support to HNSW index scan conditions

### DIFF
--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -10471,11 +10471,11 @@ qo_validate_index_for_vector_index (QO_ENV * env, QO_NODE_INDEX_ENTRY * ni_entry
 
     if (arg1->node_type == PT_NAME && PT_IS_CONST (arg2))
       {
-        // ok
+         // ok
       }
     else if (PT_IS_CONST (arg1) && (arg2->node_type == PT_NAME))
       {
-        // ok
+         // ok
       }
     else
       {

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -10471,11 +10471,11 @@ qo_validate_index_for_vector_index (QO_ENV * env, QO_NODE_INDEX_ENTRY * ni_entry
 
     if (arg1->node_type == PT_NAME && PT_IS_CONST (arg2))
       {
-         // ok
+	// ok
       }
     else if (PT_IS_CONST (arg1) && (arg2->node_type == PT_NAME))
       {
-         // ok
+	// ok
       }
     else
       {

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -10464,12 +10464,20 @@ qo_validate_index_for_vector_index (QO_ENV * env, QO_NODE_INDEX_ENTRY * ni_entry
 	goto end;
       }
 
-    if (arg1->node_type == PT_NAME && arg2->node_type == PT_NAME)
+    if (arg1->node_type == arg2->node_type)
       {
 	goto end;
       }
 
-    if (arg1->node_type == PT_VALUE && arg2->node_type == PT_VALUE)
+    if (arg1->node_type == PT_NAME && PT_IS_CONST (arg2))
+      {
+        // ok
+      }
+    else if (PT_IS_CONST (arg1) && (arg2->node_type == PT_NAME))
+      {
+        // ok
+      }
+    else
       {
 	goto end;
       }

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -11921,7 +11921,8 @@ pt_to_vector_index_info (PARSER_CONTEXT * parser, DB_OBJECT * class_, PRED_EXPR 
 	    PT_NODE *arg1 = node->info.expr.arg1;
 	    PT_NODE *arg2 = node->info.expr.arg2;
 
-	    assert ((arg1->node_type == PT_NAME && PT_IS_CONST (arg2)) || (arg2->node_type == PT_NAME && PT_IS_CONST (arg1)));
+	    assert ((arg1->node_type == PT_NAME && PT_IS_CONST (arg2))
+		    || (arg2->node_type == PT_NAME && PT_IS_CONST (arg1)));
 
 	    // TODO (CUBVEC): imporve the following logic
 	    if (arg1->node_type == PT_NAME)

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -11920,15 +11920,15 @@ pt_to_vector_index_info (PARSER_CONTEXT * parser, DB_OBJECT * class_, PRED_EXPR 
 	  {
 	    PT_NODE *arg1 = node->info.expr.arg1;
 	    PT_NODE *arg2 = node->info.expr.arg2;
-	    assert (arg1->node_type == PT_NAME || arg1->node_type == PT_VALUE);
-	    assert (arg2->node_type == PT_NAME || arg2->node_type == PT_VALUE);
+
+	    assert ((arg1->node_type == PT_NAME && PT_IS_CONST (arg2)) || (arg2->node_type == PT_NAME && PT_IS_CONST (arg1)));
 
 	    // TODO (CUBVEC): imporve the following logic
 	    if (arg1->node_type == PT_NAME)
 	      {
 		vector_query = arg2;
 	      }
-	    else if (arg1->node_type == PT_VALUE)
+	    else if (PT_IS_CONST (arg1))
 	      {
 		vector_query = arg1;
 	      }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-97

### Purpose

- HNSW 인덱스 선택 조건에 리터럴 값 (PT_VALUE) 뿐 아니라 호스트 변수 (PT_HOSTVAR) 도 추가

### Implementation

- query_planner와 xasl_generation에서 PT_VALUE만 체크하던 로직을 PT_IS_CONST 매크로 (PT_HOST_VAR 포함) 를 사용하도록 변경

### Remarks

N/A
