### PR TITLE
[CBRD-26161] [Regression] Core dumped in mspace_free at src/heaplayers/malloc_2_8_3.c:5025

### DIFF
--- a/src/query/parallel/px_heap_scan/px_heap_scan_task.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_task.cpp
@@ -313,7 +313,6 @@ namespace parallel_heap_scan
     scan_end_scan (thread_p, scan_id);
     scan_close_scan (thread_p, scan_id);
     db_change_private_heap (thread_p, orig_heap_id);
-    thread_p->tran_index = orig_tran_index;
     thread_p->conn_entry = orig_conn_entry;
     thread_p->m_parallel_stats = NULL;
 #if PARALLEL_HEAP_SCAN_LOG

--- a/src/query/parallel/px_list_merger.cpp
+++ b/src/query/parallel/px_list_merger.cpp
@@ -83,7 +83,10 @@ namespace parallel_query
     PAGE_PTR head_last_pgptr = qmgr_get_old_page (m_thread_p, &m_head_list_id->last_vpid, m_head_list_id->tfile_vfid);
     assert (head_last_pgptr != NULL);
     QFILE_PUT_NEXT_VPID (head_last_pgptr, &list_id->first_vpid);
-    pgbuf_set_dirty (m_thread_p, head_last_pgptr, FREE);
+    if (m_head_list_id->last_vpid.volid != NULL_VOLID)
+      {
+	pgbuf_set_dirty (m_thread_p, head_last_pgptr, FREE);
+      }
 
     /* list_id first page -> head last page (prev) */
     PAGE_PTR list_id_first_pgptr = qmgr_get_old_page (m_thread_p, &list_id->first_vpid, list_id->tfile_vfid);

--- a/src/query/parallel/px_query_execute/px_query_executor.cpp
+++ b/src/query/parallel/px_query_execute/px_query_executor.cpp
@@ -22,6 +22,7 @@
 #if SERVER_MODE
 #include "px_query_executor.hpp"
 #include <algorithm>
+#include "xasl_cache.h"
 
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
 #include "memory_wrapper.hpp"
@@ -696,6 +697,10 @@ namespace parallel_query_execute
   {
     try
       {
+	if (!xcache_uses_clones ())
+	  {
+	    return false;
+	  }
 	add_xasl_recursive (xasl);
 	if (!m_is_parallel_executable)
 	  {

--- a/src/query/parallel/px_query_execute/px_query_executor.cpp
+++ b/src/query/parallel/px_query_execute/px_query_executor.cpp
@@ -334,20 +334,7 @@ namespace parallel_query_execute
   int query_executor::run_tasks (THREAD_ENTRY *thread_p)
   {
     int err;
-    try
-      {
-	err = m_task_queue.execute_tasks (thread_p);
-      }
-    catch (const std::system_error &e)
-      {
-	er_print_callstack (ARG_FILE_LINE, "run_tasks - throws err = %d: %s\n", e.code (), e.what ());
-	return ER_FAILED;
-      }
-    catch (const std::exception &e)
-      {
-	er_print_callstack (ARG_FILE_LINE, "run_tasks - throws err = %s\n", e.what ());
-	return ER_FAILED;
-      }
+    err = m_task_queue.execute_tasks (thread_p);
     if (err != NO_ERROR)
       {
 	return err;

--- a/src/query/parallel/px_query_execute/px_query_executor.cpp
+++ b/src/query/parallel/px_query_execute/px_query_executor.cpp
@@ -213,7 +213,10 @@ namespace parallel_query_execute
 	  {
 	    for (XASL_NODE *xptr2 = xptr->aptr_list; xptr2 != nullptr; xptr2 = xptr2->next)
 	      {
-		make_parallel_query_executor_recursively (thread_p, xptr2, worker_manager_p, xasl->px_executor, parallelism);
+		if (!XASL_IS_FLAGED (xptr2, XASL_LINK_TO_REGU_VARIABLE))
+		  {
+		    make_parallel_query_executor_recursively (thread_p, xptr2, worker_manager_p, xasl->px_executor, parallelism);
+		  }
 	      }
 	  }
 	if (xasl->type == CTE_PROC)
@@ -238,7 +241,10 @@ namespace parallel_query_execute
 	  {
 	    for (XASL_NODE *xptr2 = xptr->aptr_list; xptr2 != nullptr; xptr2 = xptr2->next)
 	      {
-		make_parallel_query_executor_recursively (thread_p, xptr2, worker_manager_p, xasl->px_executor, parallelism);
+		if (!XASL_IS_FLAGED (xptr2, XASL_LINK_TO_REGU_VARIABLE))
+		  {
+		    make_parallel_query_executor_recursively (thread_p, xptr2, worker_manager_p, xasl->px_executor, parallelism);
+		  }
 	      }
 	  }
 	if (xasl->type == CTE_PROC)
@@ -305,15 +311,43 @@ namespace parallel_query_execute
       }
   }
 
-  void query_executor::add_task (XASL_NODE *xasl, xasl_state *xasl_state)
+  bool query_executor::add_task (XASL_NODE *xasl, xasl_state *xasl_state)
   {
-    task_tuple *task_tuple_p = m_task_queue.add_task (m_thread_p, xasl, xasl_state, m_mutex_p, m_error_messages_p);
-    m_task_queue_global_p->add_task (task_tuple_p);
+    try
+      {
+	task_tuple *task_tuple_p = m_task_queue.add_task (m_thread_p, xasl, xasl_state, m_mutex_p, m_error_messages_p);
+	m_task_queue_global_p->add_task (task_tuple_p);
+      }
+    catch (const std::system_error &e)
+      {
+	er_print_callstack (ARG_FILE_LINE, "add_task - throws err = %d: %s\n", e.code (), e.what ());
+	return false;
+      }
+    catch (const std::exception &e)
+      {
+	er_print_callstack (ARG_FILE_LINE, "add_task - throws err = %s\n", e.what ());
+	return false;
+      }
+    return true;
   }
 
   int query_executor::run_tasks (THREAD_ENTRY *thread_p)
   {
-    int err = m_task_queue.execute_tasks (thread_p);
+    int err;
+    try
+      {
+	err = m_task_queue.execute_tasks (thread_p);
+      }
+    catch (const std::system_error &e)
+      {
+	er_print_callstack (ARG_FILE_LINE, "run_tasks - throws err = %d: %s\n", e.code (), e.what ());
+	return ER_FAILED;
+      }
+    catch (const std::exception &e)
+      {
+	er_print_callstack (ARG_FILE_LINE, "run_tasks - throws err = %s\n", e.what ());
+	return ER_FAILED;
+      }
     if (err != NO_ERROR)
       {
 	return err;

--- a/src/query/parallel/px_query_execute/px_query_executor.hpp
+++ b/src/query/parallel/px_query_execute/px_query_executor.hpp
@@ -47,7 +47,7 @@ namespace parallel_query_execute
 		      int parallelism);
       query_executor (query_executor *);
       ~query_executor ();
-      void add_task (XASL_NODE *xasl, xasl_state *xasl_state);
+      bool add_task (XASL_NODE *xasl, xasl_state *xasl_state);
       int run_tasks (THREAD_ENTRY *thread_p);
       inline int get_recursion_level() const
       {

--- a/src/query/parallel/px_query_execute/px_query_task.cpp
+++ b/src/query/parallel/px_query_execute/px_query_task.cpp
@@ -71,7 +71,6 @@ namespace parallel_query_execute
       }
     pthread_mutex_unlock (m_mutex_p);
     int err = 0;
-    int temp_tran_index = thread_ref.tran_index;
     css_conn_entry *temp_conn_entry = thread_ref.conn_entry;
     int enter_qlist_count = thread_ref.m_qlist_count;
     QFILE_LIST_ID list_id;
@@ -131,7 +130,6 @@ namespace parallel_query_execute
 
     if (is_on_parallel_worker)
       {
-	thread_ref.tran_index = temp_tran_index;
 	thread_ref.conn_entry = temp_conn_entry;
 	thread_ref.on_trace = orig_on_trace;
       }
@@ -152,7 +150,6 @@ namespace parallel_query_execute
     pthread_mutex_unlock (m_mutex_p);
 
     int err = 0;
-    int temp_tran_index = thread_ref.tran_index;
     css_conn_entry *temp_conn_entry = thread_ref.conn_entry;
     bool temp_on_trace = thread_ref.on_trace;
     int enter_qlist_count = thread_ref.m_qlist_count;
@@ -207,7 +204,6 @@ namespace parallel_query_execute
 #endif
       }
 
-    thread_ref.tran_index = temp_tran_index;
     thread_ref.conn_entry = temp_conn_entry;
     thread_ref.on_trace = temp_on_trace;
 

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -14901,7 +14901,17 @@ qexec_execute_mainblock_internal (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
 			}
 		      if (xasl->px_executor)
 			{
-			  xasl->px_executor->add_task (xptr2, xasl_state);
+			  if (!xasl->px_executor->add_task (xptr2, xasl_state))
+			    {
+			      if (tplrec.tpl)
+				{
+				  db_private_free_and_init (thread_p, tplrec.tpl);
+				}
+			      delete xasl->px_executor;
+			      xasl->px_executor = nullptr;
+			      qexec_failure_line (__LINE__, xasl_state);
+			      GOTO_EXIT_ON_ERROR;
+			    }
 			}
 		      else
 			{
@@ -16831,7 +16841,13 @@ qexec_execute_cte (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_
 #if SERVER_MODE
 	  if (xasl->px_executor)
 	    {
-	      xasl->px_executor->add_task (non_recursive_part, xasl_state);
+	      if (!xasl->px_executor->add_task (non_recursive_part, xasl_state))
+		{
+		  delete xasl->px_executor;
+		  xasl->px_executor = nullptr;
+		  GOTO_EXIT_ON_ERROR;
+		}
+
 	      if (xasl->px_executor->run_tasks (thread_p) != NO_ERROR)
 		{
 		  if (xasl->px_executor->get_recursion_level () == 0)

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -14903,14 +14903,15 @@ qexec_execute_mainblock_internal (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
 			{
 			  if (!xasl->px_executor->add_task (xptr2, xasl_state))
 			    {
-			      if (tplrec.tpl)
+			      if (qexec_execute_mainblock (thread_p, xptr2, xasl_state, NULL) != NO_ERROR)
 				{
-				  db_private_free_and_init (thread_p, tplrec.tpl);
+				  if (tplrec.tpl)
+				    {
+				      db_private_free_and_init (thread_p, tplrec.tpl);
+				    }
+				  qexec_failure_line (__LINE__, xasl_state);
+				  GOTO_EXIT_ON_ERROR;
 				}
-			      delete xasl->px_executor;
-			      xasl->px_executor = nullptr;
-			      qexec_failure_line (__LINE__, xasl_state);
-			      GOTO_EXIT_ON_ERROR;
 			    }
 			}
 		      else
@@ -16843,12 +16844,13 @@ qexec_execute_cte (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_
 	    {
 	      if (!xasl->px_executor->add_task (non_recursive_part, xasl_state))
 		{
-		  delete xasl->px_executor;
-		  xasl->px_executor = nullptr;
-		  GOTO_EXIT_ON_ERROR;
+		  if (qexec_execute_mainblock (thread_p, non_recursive_part, xasl_state, NULL) != NO_ERROR)
+		    {
+		      qexec_failure_line (__LINE__, xasl_state);
+		      GOTO_EXIT_ON_ERROR;
+		    }
 		}
-
-	      if (xasl->px_executor->run_tasks (thread_p) != NO_ERROR)
+	      else if (xasl->px_executor->run_tasks (thread_p) != NO_ERROR)
 		{
 		  if (xasl->px_executor->get_recursion_level () == 0)
 		    {


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26161>
<http://jira.cubrid.org/browse/CBRD-26163>
<http://jira.cubrid.org/browse/CBRD-26164>
<http://jira.cubrid.org/browse/CBRD-26167>

### Purpose

Regression 테스트에서 발생한 4건의 코어 원인을 해결합니다.

### Implementation

1. tran_index가 -1로 리셋된 다음 temp file을 dequeue하여 할당되지 않은 메모리에 접근하는 문제를 해결합니다.
2. XASL clone을 사용하지 않는 상황에서 aptr을 실행한 다음 child thread에서 clear 시 xasl 전부를 clear하여 메모리 소유권 문제가 발생하는 것을 해결합니다. (xasl clone 미 사용시 parallel aptr 불가능하게 하는 제약사항 또한 추가됩니다.)
3. membuf를 fix한 경우 pgbuf_set_dirty를 수행하지 않도록 변경하여 관련 코어 상황 발생을 방지합니다.
4. add_task에서 발생하는 exception을 catch하고, XASL이 regu_var와 link 된 경우 parallel execution을 방지합니다.
