### PR TITLE
[CBRD-26168] clear warnings on circle ci

### DIFF
--- a/src/base/dtoa.c
+++ b/src/base/dtoa.c
@@ -391,7 +391,7 @@ _DEFUN (_dtoa_r, (ptr, _d, mode, ndigits, decpt, sign, rve, float_type),
       break;
     case 2:
       leftright = 0;
-      /* FALLTHRU */
+      [[fallthrough]];
     case 4:
       if (ndigits <= 0)
 	ndigits = 1;
@@ -399,7 +399,7 @@ _DEFUN (_dtoa_r, (ptr, _d, mode, ndigits, decpt, sign, rve, float_type),
       break;
     case 3:
       leftright = 0;
-      /* FALLTHRU */
+      [[fallthrough]];
     case 5:
       i = ndigits + k + 1;
       ilim = i;

--- a/src/base/message_catalog.c
+++ b/src/base/message_catalog.c
@@ -234,7 +234,7 @@ cub_catopen (const char *name, int type)
 		      break;
 		    case '%':
 		      ++nlspath;
-		      /* fallthrough */
+		      [[fallthrough]];
 		    default:
 		      if (pathP - path >= PATH_MAX - 1)
 			{

--- a/src/base/variable_string.c
+++ b/src/base/variable_string.c
@@ -171,7 +171,7 @@ vs_do_sprintf (varstring * vstr, const char *fmt, va_list args)
 		default:
 		  break;
 		}
-	      /* Fall through */
+	      [[fallthrough]];
 
 	    case '\0':
 	      *p = '\0';

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -8196,13 +8196,13 @@ get_domain_str (DB_DOMAIN * domain)
 
     case DB_TYPE_SET:
       collection_str = "set";
-      /* fall through */
+      [[fallthrough]];
     case DB_TYPE_MULTISET:
       if (collection_str == NULL)
 	{
 	  collection_str = "multiset";
 	}
-      /* fall through */
+      [[fallthrough]];
     case DB_TYPE_SEQUENCE:	/* DB_TYPE_LIST */
       if (collection_str == NULL)
 	{
@@ -8258,7 +8258,7 @@ get_domain_str (DB_DOMAIN * domain)
 
     case DB_TYPE_NUMERIC:
       sprintf (scale_str, "%d", scale);
-      /* fall through */
+      [[fallthrough]];
     default:
       p = (char *) db_get_type_name (dtype);
       if (p == NULL)

--- a/src/communication/network_cl.c
+++ b/src/communication/network_cl.c
@@ -152,7 +152,7 @@ set_server_error (int error)
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, server_error, 1, "");
 	  return server_error;
 	}
-      /* FALLTHRU */
+      [[fallthrough]];
     default:
       server_error = ER_NET_SERVER_CRASHED;
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, server_error, 0);

--- a/src/compat/db_date.c
+++ b/src/compat/db_date.c
@@ -2347,58 +2347,58 @@ parse_explicit_mtime_compact (char const *str, char const *strend, unsigned int 
 	    case 14:
 	      /* YYYY-MM-DD HH:MM:SS */
 	      y += DECODE (*p++);
-	      /* FALLTHRU */
+	      [[fallthrough]];
 	    case 13:
 	      y *= 10;
 	      y += DECODE (*p++);
-	      /* FALLTHRU */
+	      [[fallthrough]];
 	    case 12:
 	      /* YY-MM-DD HH:MM:SS */
 	      y *= 10;
 	      y += DECODE (*p++);
-	      /* FALLTHRU */
+	      [[fallthrough]];
 	    case 11:
 	      y *= 10;
 	      y += DECODE (*p++);
-	      /* FALLTHRU */
+	      [[fallthrough]];
 	    case 10:
 	      /* MM-DD HH:MM:SS */
 	      mo += DECODE (*p++);
-	      /* FALLTHRU */
+	      [[fallthrough]];
 	    case 9:
 	      /* M-DD HH:MM:SS */
 	      mo *= 10;
 	      mo += DECODE (*p++);
 	      d += DECODE (*p++) * 10;
 	      d += DECODE (*p++);
-	      /* FALLTHRU */
+	      [[fallthrough]];
 	    case 6:
 	      /* HH:MM:SS */
 	      h += DECODE (*p++);
-	      /* FALLTHRU */
+	      [[fallthrough]];
 	    case 5:
 	      /* H:MM:SS */
 	      h *= 10;
 	      h += DECODE (*p++);
-	      /* FALLTHRU */
+	      [[fallthrough]];
 	    case 4:
 	      /* MM:SS */
 	      m += DECODE (*p++);
-	      /* FALLTHRU */
+	      [[fallthrough]];
 	    case 3:
 	      /* M:SS */
 	      m *= 10;
 	      m += DECODE (*p++);
-	      /* FALLTHRU */
+	      [[fallthrough]];
 	    case 2:
 	      /* SS */
 	      s += DECODE (*p++);
-	      /* FALLTHRU */
+	      [[fallthrough]];
 	    case 1:
 	      /* S */
 	      s *= 10;
 	      s += DECODE (*p++);
-	      /* FALLTHRU */
+	      [[fallthrough]];
 	    case 0:
 	      if (*p == '.')
 		{
@@ -2592,21 +2592,21 @@ parse_timestamp_compact (char const *str, char const *strend, DB_DATE * date, un
       /* YYY MM DD */
       y *= 10;
       y += DECODE (*p++);
-      /* FALLTHRU */
+      [[fallthrough]];
     case 6:
       /* YY MM DD */
       y *= 10;
       y += DECODE (*p++);
-      /* FALLTHRU */
+      [[fallthrough]];
     case 5:
       /* Y MM DD */
       y *= 10;
       y += DECODE (*p++);
-      /* FALLTHRU */
+      [[fallthrough]];
     case 4:
       /* MM DD */
       mo += DECODE (*p++);
-      /* FALLTHRU */
+      [[fallthrough]];
     case 3:
       /* M DD */
       mo *= 10;

--- a/src/compat/db_value_printer.cpp
+++ b/src/compat/db_value_printer.cpp
@@ -523,7 +523,7 @@ void db_value_printer::describe_data (const db_value *value)
 
     case DB_TYPE_VOBJ:
       m_buf ("vid:");
-    /* FALLTHRU */
+      [[fallthrough]];
     case DB_TYPE_SET:
     case DB_TYPE_MULTISET:
     case DB_TYPE_SEQUENCE:

--- a/src/executables/loadjava.cpp
+++ b/src/executables/loadjava.cpp
@@ -127,7 +127,7 @@ parse_argument (int argc, char *argv[])
 	  Path = STATIC_PATH;
 	  break;
 	case 'h':
-	/* fall through */
+	  [[fallthrough]];
 	default:
 	  error = ER_FAILED;
 	  goto exit;

--- a/src/executables/unload_object_file.c
+++ b/src/executables/unload_object_file.c
@@ -773,7 +773,7 @@ fprint_special_strings (TEXT_OUTPUT * tout, DB_VALUE * value)
     case DB_TYPE_NCHAR:
     case DB_TYPE_VARNCHAR:
       CHECK_PRINT_ERROR (text_print (tout, "N", 1, NULL));
-      /* fall through */
+      [[fallthrough]];
     case DB_TYPE_CHAR:
     case DB_TYPE_VARCHAR:
       str_ptr = db_get_string (value);

--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -3960,7 +3960,7 @@ emit_domain_def (extract_context & ctxt, print_output & output_ctx, DB_DOMAIN * 
 	    case DB_TYPE_NCHAR:
 	    case DB_TYPE_VARNCHAR:
 	      has_collation = 1;
-	      /* FALLTHRU */
+	      [[fallthrough]];
 	    case DB_TYPE_BIT:
 	    case DB_TYPE_VARBIT:
 	      precision = db_domain_precision (domain);

--- a/src/loaddb/load_lexer.l
+++ b/src/loaddb/load_lexer.l
@@ -58,7 +58,8 @@ using token = cubload::parser::token;
   #define BEGIN_SUPPRESS_WARNING_BISON_FLEX             \
     _Pragma("GCC diagnostic push")                      \
     _Pragma("GCC diagnostic ignored \"-Wsign-compare\"")\
-    _Pragma("GCC diagnostic ignored \"-Wregister\"")
+    _Pragma("GCC diagnostic ignored \"-Wregister\"")    \
+    _Pragma("GCC diagnostic ignored \"-Wimplicit-fallthrough=\"")
 
   #define END_SUPPRESS_WARNING_BISON_FLEX               \
     _Pragma("GCC diagnostic pop")

--- a/src/loaddb/load_lexer.l
+++ b/src/loaddb/load_lexer.l
@@ -57,7 +57,8 @@ using token = cubload::parser::token;
 #if defined(__GNUC__) || defined(__clang__)
   #define BEGIN_SUPPRESS_WARNING_BISON_FLEX             \
     _Pragma("GCC diagnostic push")                      \
-    _Pragma("GCC diagnostic ignored \"-Wsign-compare\"")
+    _Pragma("GCC diagnostic ignored \"-Wsign-compare\"")\
+    _Pragma("GCC diagnostic ignored \"-Wregister\"")
 
   #define END_SUPPRESS_WARNING_BISON_FLEX               \
     _Pragma("GCC diagnostic pop")

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -1444,7 +1444,7 @@ tp_value_slam_domain (DB_VALUE * value, const DB_DOMAIN * domain)
 	{
 	  db_string_put_cs_and_collation (value, TP_DOMAIN_CODESET (domain), TP_DOMAIN_COLLATION (domain));
 	}
-      /* FALLTHRU */
+      [[fallthrough]];
     case DB_TYPE_BIT:
     case DB_TYPE_VARBIT:
       value->domain.char_info.type = TP_DOMAIN_TYPE (domain);
@@ -1745,7 +1745,7 @@ tp_domain_match_internal (const TP_DOMAIN * dom1, const TP_DOMAIN * dom2, TP_MAT
 	  match = 0;
 	  break;
 	}
-      /* fall through */
+      [[fallthrough]];
     case DB_TYPE_VARBIT:
       if (exact == TP_EXACT_MATCH || exact == TP_SET_MATCH)
 	{
@@ -1779,7 +1779,7 @@ tp_domain_match_internal (const TP_DOMAIN * dom1, const TP_DOMAIN * dom2, TP_MAT
 	  match = 0;
 	  break;
 	}
-      /* fall through */
+      [[fallthrough]];
     case DB_TYPE_BIT:
       /*
        * Unlike varchar, we have to be a little tighter on domain matches for

--- a/src/object/object_printer.cpp
+++ b/src/object/object_printer.cpp
@@ -259,12 +259,12 @@ void object_printer::describe_domain (/*const*/tp_domain &domain, class_descript
 	      m_buf ("STRING");
 	      break;
 	    }
-	/* FALLTHRU */
+	  [[fallthrough]];
 	case DB_TYPE_CHAR:
 	case DB_TYPE_NCHAR:
 	case DB_TYPE_VARNCHAR:
 	  has_collation = 1;
-	/* FALLTHRU */
+	  [[fallthrough]];
 	case DB_TYPE_BIT:
 	case DB_TYPE_VARBIT:
 	  strcpy (temp_buffer, temp_domain->type->name);

--- a/src/object/object_representation.c
+++ b/src/object/object_representation.c
@@ -2629,7 +2629,7 @@ or_packed_domain_size (TP_DOMAIN * domain, int include_classoids)
 	case DB_TYPE_VARCHAR:
 	  /* collation id */
 	  size += OR_INT_SIZE;
-	  /* FALLTHRU */
+	  [[fallthrough]];
 	case DB_TYPE_BIT:
 	case DB_TYPE_VARBIT:
 	  /*
@@ -2819,7 +2819,7 @@ or_put_domain (OR_BUF * buf, TP_DOMAIN * domain, int include_classoids, int is_n
 	case DB_TYPE_CHAR:
 	case DB_TYPE_VARCHAR:
 	  has_collation = true;
-	  /* FALLTHRU */
+	  [[fallthrough]];
 	case DB_TYPE_BIT:
 	case DB_TYPE_VARBIT:
 	  carrier |= ((int) (d->codeset)) << OR_DOMAIN_CODSET_SHIFT;
@@ -3127,7 +3127,7 @@ unpack_domain_2 (OR_BUF * buf, int *is_null)
 	    case DB_TYPE_CHAR:
 	    case DB_TYPE_VARCHAR:
 	      has_collation = true;
-	      /* FALLTHRU */
+	      [[fallthrough]];
 	    case DB_TYPE_BIT:
 	    case DB_TYPE_VARBIT:
 	      codeset = (carrier & OR_DOMAIN_CODSET_MASK) >> OR_DOMAIN_CODSET_SHIFT;
@@ -3446,7 +3446,7 @@ unpack_domain (OR_BUF * buf, int *is_null)
 	    case DB_TYPE_DATETIMELTZ:
 	    case DB_TYPE_MONETARY:
 	      precision = tp_get_fixed_precision (type);
-	      /* FALLTHRU */
+	      [[fallthrough]];
 
 	    case DB_TYPE_NULL:
 	    case DB_TYPE_BLOB:
@@ -3502,7 +3502,7 @@ unpack_domain (OR_BUF * buf, int *is_null)
 		{
 		  collation_flag = TP_DOMAIN_COLL_NORMAL;
 		}
-	      /* FALLTHRU */
+	      [[fallthrough]];
 
 	    case DB_TYPE_BIT:
 	    case DB_TYPE_VARBIT:
@@ -3691,7 +3691,7 @@ unpack_domain (OR_BUF * buf, int *is_null)
 		case DB_TYPE_VARCHAR:
 		  dom->collation_id = collation_id;
 		  dom->collation_flag = (TP_DOMAIN_COLL_ACTION) collation_flag;
-		  /* FALLTHRU */
+		  [[fallthrough]];
 		case DB_TYPE_BIT:
 		case DB_TYPE_VARBIT:
 		  dom->codeset = codeset;

--- a/src/optimizer/plan_generation.c
+++ b/src/optimizer/plan_generation.c
@@ -2091,7 +2091,7 @@ gen_outer (QO_ENV * env, QO_PLAN * plan, BITSET * subqueries, XASL_NODE * inner_
 	      xasl = pt_gen_simple_merge_plan (parser, QO_ENV_PT_TREE (env), plan, xasl);
 	      break;
 	    }
-	  /* FALLTHRU */
+	  [[fallthrough]];
 	case QO_JOINMETHOD_IDX_JOIN:
 	  for (i = bitset_iterate (&(plan->plan_un.join.join_terms), &bi); i != -1; i = bitset_next_member (&bi))
 	    {

--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -2040,14 +2040,14 @@ qo_analyze_term (QO_TERM * term, int term_type)
 	  /* operators classified as lhs- and rhs-indexable */
 	case PT_EQ:
 	  QO_TERM_SET_FLAG (term, QO_TERM_EQUAL_OP);
-	  /* FALLTHRU */
+	  [[fallthrough]];
 	case PT_LT:
 	case PT_LE:
 	case PT_GT:
 	case PT_GE:
 	  /* temporary guess; RHS could be a indexable segment */
 	  rhs_indexable = true;
-	  /* FALLTHRU */
+	  [[fallthrough]];
 
 	  /* operators classified as rhs-indexable */
 	case PT_BETWEEN:
@@ -2082,7 +2082,7 @@ qo_analyze_term (QO_TERM * term, int term_type)
 		    }
 		}
 	    }
-	  /* FALLTHRU */
+	  [[fallthrough]];
 	case PT_IS_IN:
 	case PT_EQ_SOME:
 	  /* temporary guess; LHS could be a indexable segment */
@@ -2092,7 +2092,7 @@ qo_analyze_term (QO_TERM * term, int term_type)
 	      QO_TERM_SET_FLAG (term, QO_TERM_RANGELIST);
 	    }
 	  lhs_indexable = true;
-	  /* FALLTHRU */
+	  [[fallthrough]];
 
 	  /* operators classified as not-indexable */
 	case PT_NOT_BETWEEN:
@@ -2126,7 +2126,7 @@ qo_analyze_term (QO_TERM * term, int term_type)
 	  rhs_expr = pt_expr->info.expr.arg2;
 	  /* get segments from RHS of the expression */
 	  qo_expr_segs (env, rhs_expr, &rhs_segs);
-	  /* FALLTHRU */
+	  [[fallthrough]];
 
 	case PT_IS_NULL:
 	case PT_IS_NOT_NULL:
@@ -2142,7 +2142,7 @@ qo_analyze_term (QO_TERM * term, int term_type)
 
 	case PT_OR:
 	  QO_TERM_SET_FLAG (term, QO_TERM_OR_PRED);
-	  /* FALLTHRU */
+	  [[fallthrough]];
 	case PT_NOT:
 	case PT_XOR:
 	  /* get segments from the expression itself */
@@ -2747,7 +2747,7 @@ wrapup:
 	      }
 	  }
       }
-      /* FALL THROUGH */
+      [[fallthrough]];
     case PT_PATH_OUTER_WEASEL:
       /* These can't be implemented with index scans regardless because an index scan won't properly implement the
        * left-outer semantics of the path...

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -10001,7 +10001,7 @@ qo_classify (PT_NODE * attr)
 	{
 	  return PC_ATTR;
 	}
-      /* fall through */
+      [[fallthrough]];
     default:
       return PC_OTHER;
     }

--- a/src/optimizer/rewriter/query_rewrite.c
+++ b/src/optimizer/rewriter/query_rewrite.c
@@ -221,7 +221,7 @@ qo_rewrite_queries (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *con
 	case PT_NE:
 	case PT_NULLSAFE_EQ:
 	  node->info.expr.arg1 = qo_rewrite_hidden_col_as_derived (parser, node->info.expr.arg1, node);
-	  /* fall through */
+	  [[fallthrough]];
 
 	  /* keep out hidden column subquery from UPDATE assignment */
 	case PT_ASSIGN:

--- a/src/optimizer/rewriter/query_rewrite_select.c
+++ b/src/optimizer/rewriter/query_rewrite_select.c
@@ -2312,22 +2312,15 @@ qo_check_pk_ref_by_fk_in_parent_spec (PARSER_CONTEXT * parser, PT_NODE * query,
   switch (PT_SPEC_JOIN_TYPE (curr_pk_spec))
     {
     case PT_JOIN_NONE:
-      /* fallthrough */
     case PT_JOIN_INNER:
-      /* fallthrough */
     case PT_JOIN_NATURAL:
       break;
 
     case PT_JOIN_CROSS:
-      /* fallthrough */
     case PT_JOIN_LEFT_OUTER:
-      /* fallthrough */
     case PT_JOIN_RIGHT_OUTER:
-      /* fallthrough */
     case PT_JOIN_FULL_OUTER:
-      /* fallthrough */
     case PT_JOIN_UNION:
-      /* fallthrough */
     default:
       goto exit_on_fail_with_exclude;
     }
@@ -2560,7 +2553,6 @@ exit_on_fail_with_cleanup:
       parent_pred_point_list = NULL;
     }
 
-exit_on_fail:
   return false;
 }
 
@@ -2617,22 +2609,16 @@ qo_check_fks_ref_pk_in_child_spec (PARSER_CONTEXT * parser, PT_NODE * query,
   switch (PT_SPEC_JOIN_TYPE (curr_fk_spec))
     {
     case PT_JOIN_NONE:
-      /* fallthrough */
     case PT_JOIN_INNER:
-      /* fallthrough */
     case PT_JOIN_NATURAL:
       break;
 
     case PT_JOIN_CROSS:
-      /* fallthrough */
     case PT_JOIN_LEFT_OUTER:
-      /* fallthrough */
     case PT_JOIN_RIGHT_OUTER:
-      /* fallthrough */
     case PT_JOIN_FULL_OUTER:
-      /* fallthrough */
     case PT_JOIN_UNION:
-      /* fallthrough */
+      [[fallthrough]];
     default:
       goto exit_on_fail_with_exclude;
     }
@@ -3108,7 +3094,6 @@ exit_on_fail_with_cleanup:
     }
   /* fallthrough */
 
-exit_on_fail:
   return false;
 }
 

--- a/src/optimizer/rewriter/query_rewrite_term.c
+++ b/src/optimizer/rewriter/query_rewrite_term.c
@@ -83,8 +83,7 @@ qo_collect_name_spec (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *c
 	{
 	  break;		/* impossible case, give up */
 	}
-
-      /* FALL THROUGH */
+      [[fallthrough]];
 
     case PT_NAME:
       if (info->c_name->info.name.location > 0 && info->c_name->info.name.location < node->info.name.location)

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -553,6 +553,22 @@ static int g_plcsql_text_pos;
 	PARSER_SAVE_ERR_CONTEXT ((rv), (b_p))                                   \
 } while (0)
 
+/* TODO: 
+ * For now, I've set it to ignore warnings in the automatically generated code. 
+ * If possible, let's remove warnings normally instead of setting it to ignore. */
+#if defined(__GNUC__) || defined(__clang__)
+  #define BEGIN_SUPPRESS_WARNING_BISON_FLEX             \
+    _Pragma("GCC diagnostic push")                      \
+    _Pragma("GCC diagnostic ignored \"-Wimplicit-fallthrough=\"")
+
+  #define END_SUPPRESS_WARNING_BISON_FLEX               \
+    _Pragma("GCC diagnostic pop")
+#else
+  #define BEGIN_SUPPRESS_WARNING_BISON_FLEX
+  #define END_SUPPRESS_WARNING_BISON_FLEX
+#endif
+
+BEGIN_SUPPRESS_WARNING_BISON_FLEX
 %}
 
 %locations
@@ -25167,6 +25183,9 @@ opt_alter_synonym
 		DBG_PRINT}}
 
 %%
+
+END_SUPPRESS_WARNING_BISON_FLEX
+
 
 extern FILE *yyin;
 

--- a/src/parser/csql_lexer.l
+++ b/src/parser/csql_lexer.l
@@ -83,7 +83,8 @@ int expecting_pl_lang_spec = 0;
   #define BEGIN_SUPPRESS_WARNING_BISON_FLEX                \
     _Pragma("GCC diagnostic push")                         \
     _Pragma("GCC diagnostic ignored \"-Wsign-compare\"")   \
-    _Pragma("GCC diagnostic ignored \"-Wredundant-decls\"")
+    _Pragma("GCC diagnostic ignored \"-Wredundant-decls\"")\
+    _Pragma("GCC diagnostic ignored \"-Wimplicit-fallthrough=\"")
 
   #define END_SUPPRESS_WARNING_BISON_FLEX                  \
     _Pragma("GCC diagnostic pop")

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -6107,7 +6107,7 @@ pt_print_alter_one_clause (PARSER_CONTEXT * parser, PT_NODE * p)
 	  q = pt_append_nulstring (parser, q, pt_show_misc_type (p->info.alter.alter_clause.rename.meta));
 	  q = pt_append_nulstring (parser, q, " ");
 	  q = pt_append_varchar (parser, q, r2);
-	  /* FALLTHRU */
+	  [[fallthrough]];
 	case PT_FILE_RENAME:
 	  r1 = pt_print_bytes (parser, p->info.alter.alter_clause.rename.old_name);
 	  q = pt_append_varchar (parser, q, r1);
@@ -8715,7 +8715,7 @@ pt_print_datatype (PARSER_CONTEXT * parser, PT_NODE * p)
 	}
 
       show_collation = true;
-      /* FALLTHRU */
+      [[fallthrough]];
     case PT_TYPE_BIT:
     case PT_TYPE_VARBIT:
     case PT_TYPE_FLOAT:
@@ -12203,7 +12203,7 @@ pt_print_expr (PARSER_CONTEXT * parser, PT_NODE * p)
 	  /* break case PT_RANGE */
 	  break;
 	}
-      /* FALLTHRU */
+      [[fallthrough]];
     default:
       r1 = pt_print_bytes (parser, p->info.expr.arg1);
       r2 = pt_print_bytes (parser, p->info.expr.arg2);
@@ -18452,7 +18452,7 @@ pt_expr_is_allowed_as_function_index (const PT_NODE * expr)
 	{
 	  break;
 	}
-      /* FALLTHRU */
+      [[fallthrough]];
     case PT_MOD:
     case PT_LEFT:
     case PT_RIGHT:

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -2616,7 +2616,7 @@ pt_print_db_value (PARSER_CONTEXT * parser, const struct db_value * val)
     case DB_TYPE_SET:
     case DB_TYPE_MULTISET:
       sb ("%s", pt_show_type_enum (pt_db_to_type_enum (DB_VALUE_TYPE (val))));
-      /* fall thru */
+      [[fallthrough]];
     case DB_TYPE_SEQUENCE:
       sb ("{");
 

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -9925,18 +9925,16 @@ pt_get_query_limit_from_orderby_for (PARSER_CONTEXT * parser, PT_NODE * orderby_
   else if (op == PT_BETWEEN)
     {
       PT_NODE *between_and = orderby_for->info.expr.arg2;
-      PT_NODE *between_upper = NULL;
       int between_op;
 
       assert (between_and != NULL && between_and->node_type == PT_EXPR);
-      between_upper = between_and->info.expr.arg2;
       between_op = between_and->info.expr.op;
       switch (between_op)
 	{
 	case PT_BETWEEN_GT_LT:
 	case PT_BETWEEN_GE_LT:
 	  lt = true;
-	  /* fall through */
+	  [[fallthrough]];
 	case PT_BETWEEN_AND:
 	case PT_BETWEEN_GE_LE:
 	case PT_BETWEEN_GT_LE:

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -4485,8 +4485,7 @@ pt_find_aggregate_analytic_in_where (PARSER_CONTEXT * parser, PT_NODE * node)
 	  find = node;
 	  break;
 	}
-
-      /* FALLTHRU */
+      [[fallthrough]];
 
     case PT_EXPR:
     case PT_MERGE:
@@ -5137,8 +5136,8 @@ pt_check_alter (PARSER_CONTEXT * parser, PT_NODE * alter)
 	      AU_SET_USER (me);
 	    }
 	}
+      [[fallthrough]];
 
-      /* FALLTHRU */
     case PT_DROP_QUERY:
       if (type == PT_CLASS)
 	{
@@ -12097,7 +12096,7 @@ pt_check_with_info (PARSER_CONTEXT * parser, PT_NODE * node, SEMANTIC_CHK_INFO *
 	{
 	  pt_resolve_object (parser, node);
 	}
-      /* FALLTHRU */
+      [[fallthrough]];
 
     case PT_HOST_VAR:
     case PT_EXPR:

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -4918,7 +4918,7 @@ pt_check_alter (PARSER_CONTEXT * parser, PT_NODE * alter)
       alter->info.alter.alter_clause.ch_attr_def.data_default_list =
 	pt_check_data_default (parser, alter->info.alter.alter_clause.ch_attr_def.data_default_list);
 
-      /* FALL THRU */
+      [[fallthrough]];
 
     case PT_MODIFY_DEFAULT:
       pt_resolve_default_external (parser, alter);

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -12011,7 +12011,7 @@ pt_upd_domain_info (PARSER_CONTEXT * parser, PT_NODE * arg1, PT_NODE * arg2, PT_
     case PT_TYPEOF:
     case PT_HEX:
       do_detect_collation = false;
-      /* FALLTHRU */
+      [[fallthrough]];
     case PT_TRIM:
     case PT_LTRIM:
     case PT_RTRIM:
@@ -13338,7 +13338,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	  db_make_null (result);
 	  break;
 	}
-      /* FALLTHRU */
+      [[fallthrough]];
     case PT_CONCAT:
       if (typ1 == DB_TYPE_NULL || (typ2 == DB_TYPE_NULL && o2))
 	{
@@ -17166,7 +17166,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	      break;
 	    }
 
-	  /* fall through */
+	  [[fallthrough]];
 	case PT_SETEQ:
 	  cmp_result = (DB_VALUE_COMPARE_RESULT) db_value_compare (arg1, arg2);
 	  cmp = (cmp_result == DB_UNK) ? -1 : (cmp_result == DB_EQ) ? 1 : 0;
@@ -17275,7 +17275,7 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	      cmp = 1;
 	      break;
 	    }
-	  /* fall through */
+	  [[fallthrough]];
 	case PT_NE_ALL:
 	  cmp = set_issome (arg1, db_get_set (arg2), PT_EQ_SOME, 1);
 	  if (cmp == 1)
@@ -17363,10 +17363,10 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	      {
 	      case NO_ERROR:
 		break;
-	      case ER_REGEX_COMPILE_ERROR:	/* fall through */
+	      case ER_REGEX_COMPILE_ERROR:
 	      case ER_REGEX_EXEC_ERROR:
 		PT_ERRORc (parser, o1, er_msg ());
-		/* FALLTHRU */
+		[[fallthrough]];
 	      default:
 		return 0;
 	      }
@@ -18296,7 +18296,7 @@ pt_fold_const_expr (PARSER_CONTEXT * parser, PT_NODE * expr, void *arg)
 	    expr->info.expr.arg3 = opd3;
 	  }
 
-	  /* fall through */
+	  [[fallthrough]];
 	default:
 	  db_make_null (&dummy);
 	  arg2 = &dummy;
@@ -19599,7 +19599,7 @@ pt_coerce_value_internal (PARSER_CONTEXT * parser, PT_NODE * src, PT_NODE * dest
 	  return NO_ERROR;
 	}
 
-      /* FALLTHRU */
+      [[fallthrough]];
 
     case PT_VALUE:
       {
@@ -20909,7 +20909,7 @@ pt_get_collation_info (const PT_NODE * node, PT_COLL_INFER * coll_infer)
 	    }
 	  break;
 	}
-      /* fall through */
+      [[fallthrough]];
     case PT_SELECT:
     case PT_UNION:
     case PT_DIFFERENCE:
@@ -22770,7 +22770,7 @@ coerce_result:
 	  expr = new_node;
 	  break;
 	}
-      /* fall through */
+      [[fallthrough]];
     case PT_PLUS:
       if (expr->type_enum == PT_TYPE_MAYBE)
 	{
@@ -22783,7 +22783,7 @@ coerce_result:
 	{
 	  break;
 	}
-      /* fall through */
+      [[fallthrough]];
     case PT_CONCAT:
     case PT_CONCAT_WS:
     case PT_RPAD:
@@ -23350,7 +23350,7 @@ pt_fix_enumeration_comparison (PARSER_CONTEXT * parser, PT_NODE * expr)
 	  parser_free_tree (parser, arg2);
 	  arg2 = node;
 
-	  /* fall through */
+	  [[fallthrough]];
 
 	case PT_FUNCTION:
 	  list = arg2->info.function.arg_list;

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -20952,7 +20952,7 @@ pt_get_collation_info (const PT_NODE * node, PT_COLL_INFER * coll_infer)
 	  coll_infer->coerc_level = PT_COLLATION_L5_COERC;
 	  break;
 	}
-      /* Fall through */
+      [[fallthrough]];
     case PT_DOT_:
       if (coll_infer->coll_id == LANG_COLL_BINARY)
 	{

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -1023,7 +1023,7 @@ mq_rewrite_agg_names_post (PARSER_CONTEXT * parser, PT_NODE * node, void *void_a
     {
     case PT_SELECT:
       info->select_stack = pt_pointer_stack_pop (parser, info->select_stack, NULL);
-      /* FALLTHRU */
+      [[fallthrough]];
 
     case PT_UNION:
     case PT_DIFFERENCE:
@@ -3809,7 +3809,7 @@ pt_find_only_name_id (PARSER_CONTEXT * parser, PT_NODE * tree, void *arg, int *c
 	  /* nothing found ... */
 	  break;
 	}
-      /* FALLTHRU */
+      [[fallthrough]];
 
     case PT_NAME:
       spec = infop->in.spec;
@@ -7998,7 +7998,7 @@ mq_translate_helper (PARSER_CONTEXT * parser, PT_NODE * node)
       /* only translate translatable statements */
     case PT_SELECT:
       strict = !PT_SELECT_INFO_IS_FLAGED (node, PT_SELECT_INFO_NO_STRICT_OID_CHECK);
-      /* FALLTHRU */
+      [[fallthrough]];
 
     case PT_UNION:
     case PT_DIFFERENCE:

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -1684,7 +1684,7 @@ pt_to_pred_expr_local_with_arg (PARSER_CONTEXT * parser, PT_NODE * node, int *ar
 	      *argp |= PT_PRED_ARG_INSTNUM_CONTINUE;
 	      *argp |= PT_PRED_ARG_GRBYNUM_CONTINUE;
 	      *argp |= PT_PRED_ARG_ORDBYNUM_CONTINUE;
-	      /* FALLTHRU */
+	      [[fallthrough]];
 
 	    case PT_BETWEEN:
 	    case PT_RANGE:
@@ -1904,7 +1904,7 @@ pt_to_pred_expr_local_with_arg (PARSER_CONTEXT * parser, PT_NODE * node, int *ar
 			  {
 			    break;
 			  }
-			/* FALLTHRU */
+			[[fallthrough]];
 		      case PT_TYPE_NCHAR:
 		      case PT_TYPE_VARNCHAR:
 			node->type_enum = PT_TYPE_NCHAR;
@@ -7351,7 +7351,7 @@ pt_to_regu_resolve_domain (int *p_precision, int *p_scale, const PT_NODE * node)
 		    {
 		      break;
 		    }
-		  /* FALLTHRU */
+		  [[fallthrough]];
 
 		default:
 		  maybe_sci_notation = 1;
@@ -10617,7 +10617,7 @@ pt_to_list_key (PARSER_CONTEXT * parser, PT_NODE ** term_exprs, int nterms, bool
 	{
 	  goto error;
 	}
-      /* FALLTHRU */
+      [[fallthrough]];
 
     case PT_VALUE:
       p = (rhs->node_type == PT_NAME) ? pt_find_value_of_label (rhs->info.name.original) : &rhs->info.value.db_value;
@@ -22014,7 +22014,7 @@ parser_generate_xasl_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, in
       PT_NODE_PRINT_TO_ALIAS (parser, node, PT_CONVERT_RANGE);
 #endif /* CUBRID_DEBUG */
 
-      /* fall through */
+      [[fallthrough]];
     case PT_UNION:
     case PT_DIFFERENCE:
     case PT_INTERSECTION:

--- a/src/query/arithmetic.c
+++ b/src/query/arithmetic.c
@@ -130,7 +130,7 @@ db_floor_dbval (DB_VALUE * result, DB_VALUE * value)
 
       value = &cast_value;
 
-      /* fall through */
+      [[fallthrough]];
 
     case DB_TYPE_DOUBLE:
       dtmp = floor (db_get_double (value));
@@ -297,7 +297,7 @@ db_ceil_dbval (DB_VALUE * result, DB_VALUE * value)
 
       value = &cast_value;
 
-      /* fall through */
+      [[fallthrough]];
 
     case DB_TYPE_DOUBLE:
       dtmp = ceil (db_get_double (value));
@@ -619,7 +619,7 @@ db_abs_dbval (DB_VALUE * result, DB_VALUE * value)
 
       value = &cast_value;
 
-      /* fall through */
+      [[fallthrough]];
 
     case DB_TYPE_DOUBLE:
       dtmp = db_get_double (value);
@@ -997,7 +997,7 @@ db_mod_short (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 
       value2 = &cast_value2;
 
-      /* fall through */
+      [[fallthrough]];
 
     case DB_TYPE_DOUBLE:
       d2 = db_get_double (value2);
@@ -1146,7 +1146,7 @@ db_mod_int (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 
       value2 = &cast_value2;
 
-      /* fall through */
+      [[fallthrough]];
 
     case DB_TYPE_DOUBLE:
       d2 = db_get_double (value2);
@@ -1295,7 +1295,7 @@ db_mod_bigint (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 
       value2 = &cast_value2;
 
-      /* fall through */
+      [[fallthrough]];
 
     case DB_TYPE_DOUBLE:
       d2 = db_get_double (value2);
@@ -1440,7 +1440,7 @@ db_mod_float (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 
       value2 = &cast_value2;
 
-      /* fall through */
+      [[fallthrough]];
 
     case DB_TYPE_DOUBLE:
       d2 = db_get_double (value2);
@@ -1584,7 +1584,7 @@ db_mod_double (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 
       value2 = &cast_value2;
 
-      /* fall through */
+      [[fallthrough]];
 
     case DB_TYPE_DOUBLE:
       d2 = db_get_double (value2);
@@ -1775,7 +1775,7 @@ db_mod_numeric (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 
       value2 = &cast_value2;
 
-      /* fall through */
+      [[fallthrough]];
 
     case DB_TYPE_DOUBLE:
       d2 = db_get_double (value2);
@@ -1886,7 +1886,7 @@ db_mod_monetary (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 
       value2 = &cast_value2;
 
-      /* fall through */
+      [[fallthrough]];
 
     case DB_TYPE_DOUBLE:
       d2 = db_get_double (value2);
@@ -2475,7 +2475,7 @@ db_round_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
       assert (type1 == DB_TYPE_DOUBLE);
       value1 = &cast_value;
 
-      /* fall through */
+      [[fallthrough]];
     case DB_TYPE_DOUBLE:
       d1 = db_get_double (value1);
       dtmp = round_double (d1, d2);
@@ -4266,7 +4266,7 @@ db_bit_count_dbval (DB_VALUE * result, DB_VALUE * value)
 	      return ER_FAILED;
 	    }
 	  tmpval_p = &tmpval;
-	  /* FALLTHRU */
+	  [[fallthrough]];
 	case DB_TYPE_DOUBLE:
 	  d = db_get_double (tmpval_p);
 	  if (d < 0)

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -5994,7 +5994,7 @@ do_alter_partitioning_post (PARSER_CONTEXT * parser, PT_NODE * alter, SM_PARTITI
 	{
 	  return error;
 	}
-      /* fall through */
+      [[fallthrough]];
     case PT_ADD_HASHPARTITION:
       error = do_redistribute_partitions_data (entity_name, pinfo->keycol, NULL, 0, PT_ADD_HASHPARTITION, true, false);
       break;
@@ -10787,7 +10787,7 @@ do_change_att_schema_only (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NOD
 	    {
 	      break;
 	    }
-	  /* fall through */
+	  [[fallthrough]];
 
 	default:
 	  att = attribute->info.attr_def.attr_name;
@@ -11379,7 +11379,7 @@ build_attr_change_map (PARSER_CONTEXT * parser, DB_CTMPL * ctemplate, PT_NODE * 
 	  break;
 	case PT_CONSTRAIN_NULL:
 	  attr_chg_properties->p[P_NOT_NULL] = ATT_CHG_PROPERTY_LOST;
-	  /* fall through */
+	  [[fallthrough]];
 	case PT_CONSTRAIN_NOT_NULL:
 	  constr_att_list = cnstr->info.constraint.un.not_null.attr;
 	  chg_prop_idx = P_NOT_NULL;

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -5450,7 +5450,7 @@ set_iso_level (PARSER_CONTEXT * parser, DB_TRAN_ISOLATION * tran_isolation, bool
 	  tran_get_tran_settings (&dummy_lktimeout, tran_isolation, &dummy_aws);
 	  break;
 	}
-      /* fall through */
+      [[fallthrough]];
     case 1:			/* unsupported ones */
     case 2:
     case 3:

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -172,7 +172,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, val_descr *
 	{
 	  goto error;
 	}
-      /* FALLTHRU */
+      [[fallthrough]];
 
     case T_ADD:
     case T_SUB:

--- a/src/query/query_dump.c
+++ b/src/query/query_dump.c
@@ -3000,7 +3000,6 @@ qdump_print_access_spec_stats_json (ACCESS_SPEC_TYPE * spec_list_p)
 		      }
 
 		    default:
-		      /* fall through */
 		      break;
 		    }
 
@@ -3509,7 +3508,6 @@ qdump_print_access_spec_stats_text (FILE * fp, ACCESS_SPEC_TYPE * spec_list_p, i
 		      }
 
 		    default:
-		      /* fall through */
 		      break;
 		    }
 

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -14139,7 +14139,7 @@ qexec_end_mainblock_iterations (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_
 	{
 	  qexec_destroy_upddel_ehash_files (thread_p, xasl);
 	}
-      /* fall through */
+      [[fallthrough]];
     case CONNECTBY_PROC:
     case BUILD_SCHEMA_PROC:
       /* close the list file */
@@ -14259,7 +14259,7 @@ qexec_clear_mainblock_iterations (THREAD_ENTRY * thread_p, XASL_NODE * xasl)
 	{
 	  qexec_destroy_upddel_ehash_files (thread_p, xasl);
 	}
-      /* fall through */
+      [[fallthrough]];
     case CONNECTBY_PROC:
       qfile_close_list (thread_p, xasl->list_id);
       break;
@@ -23325,7 +23325,7 @@ qexec_schema_get_type_desc (DB_TYPE id, TP_DOMAIN * domain, DB_VALUE * result)
     {
     case DB_TYPE_NUMERIC:
       scale = domain->scale;
-      /* fall through */
+      [[fallthrough]];
 
     case DB_TYPE_VARCHAR:
     case DB_TYPE_CHAR:

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -1527,7 +1527,7 @@ qexec_clear_regu_var (THREAD_ENTRY * thread_p, XASL_NODE * xasl_p, REGU_VARIABLE
 	      (void) pr_clear_value (regu_var->value.dbvalptr);
 	    }
 	}
-      /* Fall through */
+      [[fallthrough]];
     case TYPE_LIST_ID:
       if (regu_var->xasl != NULL)
 	{

--- a/src/query/query_hash_join.c
+++ b/src/query/query_hash_join.c
@@ -364,7 +364,7 @@ qexec_hash_join (THREAD_ENTRY * thread_p, XASL_NODE * xasl, QUERY_ID query_id, V
       break;
 
     case HASHJOIN_STATUS_ERROR:
-      /* fall through */
+      [[fallthrough]];
     default:
       /* impossible case */
       assert_release (false);
@@ -2296,7 +2296,7 @@ hjoin_build_key (THREAD_ENTRY * thread_p, HASH_LIST_SCAN * hash_scan, QFILE_LIST
       break;
 
     case HASH_METH_NOT_USE:
-      /* fall through */
+      [[fallthrough]];
     default:
       /* impossible case */
       assert_release (false);
@@ -2999,7 +2999,7 @@ hjoin_probe_key (THREAD_ENTRY * thread_p, HASH_LIST_SCAN * hash_scan, QFILE_LIST
       break;			/* HASH_METH_HASH_FILE */
 
     case HASH_METH_NOT_USE:
-      /* fall through */
+      [[fallthrough]];
     default:
       /* impossible case */
       assert_release (false);

--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -5968,7 +5968,7 @@ qdata_unary_minus_dbval (DB_VALUE * result_p, DB_VALUE * dbval_p)
 
       dbval_p = &cast_value;
 
-      /* fall through */
+      [[fallthrough]];
 
     case DB_TYPE_DOUBLE:
       db_make_double (result_p, (-1) * db_get_double (dbval_p));

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -5256,7 +5256,6 @@ scan_next_scan_local (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 	      break;
 
 	    default:
-	      /* fall through */
 	      break;
 	    }
 

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -19441,7 +19441,7 @@ get_number_token (const INTL_LANG lang, char *fsp, int *length, char *last_posit
 	{
 	  return N_INVALID;
 	}
-      /* FALLTHRU */
+      [[fallthrough]];
 
     case '9':
     case '0':
@@ -24706,10 +24706,10 @@ parse_time_string (const char *timestr, int timestr_size, int *sign, int *h, int
 
 	case 1:
 	  ms_string[1] = '0';
-	  /* FALLTHRU */
+	  [[fallthrough]];
 	case 2:
 	  ms_string[2] = '0';
-	  /* FALLTHRU */
+	  [[fallthrough]];
 	default:
 	  *ms = atoi (ms_string);
 	}
@@ -28472,7 +28472,7 @@ db_string_extract_dbval (const MISC_OPERAND extr_operand, DB_VALUE * dbval_p, DB
 		db_time_decode (&time, &extvar[HOUR], &extvar[MINUTE], &extvar[SECOND]);
 		break;
 	      }
-	    /* fall through */
+	    [[fallthrough]];
 	  case MILLISECOND:
 	    if (db_string_to_datetime_ex (str_date, str_date_len, &datetime_s) == NO_ERROR)
 	      {

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -244,25 +244,6 @@ struct vacuum_data_page
       (data_page) = NULL; \
     } while (0)
 
-/* Set page dirty [and free it]. First and last vacuum data page are not freed. */
-#define vacuum_set_dirty_data_pagex(thread_p, data_page, free) \
-  do \
-    { \
-      if ((data_page) != vacuum_Data.first_page && (data_page) != vacuum_Data.last_page) \
-	{ \
-	  pgbuf_set_dirty (thread_p, (PAGE_PTR) (data_page), free); \
-	} \
-      else  \
-	{ \
-	  /* Do not unfix first or last page. */ \
-	  pgbuf_set_dirty (thread_p, (PAGE_PTR) (data_page), DONT_FREE); \
-	} \
-      if ((free) == FREE) \
-	{ \
-	  (data_page) = NULL; \
-	} \
-    } while (0)
-
 static inline void
 vacuum_set_dirty_data_page_dont_free (cubthread::entry * thread_p, vacuum_data_page * data_page)
 {
@@ -437,6 +418,7 @@ struct vacuum_data
 static VACUUM_DATA vacuum_Data;
 // *INDENT-ON*
 
+/* Set page dirty [and free it]. First and last vacuum data page are not freed. */
 static void
 vacuum_set_dirty_data_page (cubthread::entry * thread_p, vacuum_data_page * data_page, bool free)
 {

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -419,7 +419,7 @@ static VACUUM_DATA vacuum_Data;
 // *INDENT-ON*
 
 /* Set page dirty [and free it]. First and last vacuum data page are not freed. */
-static void
+static inline void
 vacuum_set_dirty_data_page (cubthread::entry * thread_p, vacuum_data_page * data_page, bool free)
 {
   if ((data_page) != vacuum_Data.first_page && (data_page) != vacuum_Data.last_page)

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -245,7 +245,7 @@ struct vacuum_data_page
     } while (0)
 
 /* Set page dirty [and free it]. First and last vacuum data page are not freed. */
-#define vacuum_set_dirty_data_page(thread_p, data_page, free) \
+#define vacuum_set_dirty_data_pagex(thread_p, data_page, free) \
   do \
     { \
       if ((data_page) != vacuum_Data.first_page && (data_page) != vacuum_Data.last_page) \
@@ -436,6 +436,24 @@ struct vacuum_data
 };
 static VACUUM_DATA vacuum_Data;
 // *INDENT-ON*
+
+static void
+vacuum_set_dirty_data_page (cubthread::entry * thread_p, vacuum_data_page * data_page, bool free)
+{
+  if ((data_page) != vacuum_Data.first_page && (data_page) != vacuum_Data.last_page)
+    {
+      pgbuf_set_dirty (thread_p, (PAGE_PTR) (data_page), free);
+    }
+  else
+    {
+      /* Do not unfix first or last page. */
+      pgbuf_set_dirty (thread_p, (PAGE_PTR) (data_page), DONT_FREE);
+    }
+  if ((free) == FREE)
+    {
+      (data_page) = NULL;
+    }
+}
 
 /* vacuum data load */
 typedef struct vacuum_data_load VACUUM_DATA_LOAD;

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -23788,7 +23788,7 @@ btree_key_find_and_lock_unique_of_unique (THREAD_ENTRY * thread_p, BTID_INT * bt
 	  /* Object is being inserted/deleted. We need to lock and suspend until it's fate is decided. */
 	  assert (!lock_has_lock_on_object (&unique_oid, &unique_class_oid, find_unique_helper->lock_mode));
 #endif /* SERVER_MODE */
-	  /* Fall through. */
+	  [[fallthrough]];
 	case DELETE_RECORD_CAN_DELETE:
 #if defined (SERVER_MODE)
 	  /* Must lock object. */
@@ -24100,7 +24100,7 @@ btree_key_find_and_lock_unique_of_non_unique (THREAD_ENTRY * thread_p, BTID_INT 
 	  /* Object is being inserted/deleted. We need to lock and suspend until it's fate is decided. */
 	  assert (!lock_has_lock_on_object (&unique_oid, &unique_class_oid, find_unique_helper->lock_mode));
 #endif /* SERVER_MODE */
-	  /* Fall through. */
+	  [[fallthrough]];
 	case DELETE_RECORD_CAN_DELETE:
 #if defined (SERVER_MODE)
 	  /* Must lock object. */
@@ -27015,7 +27015,7 @@ btree_insert_internal (THREAD_ENTRY * thread_p, BTID * btid, DB_VALUE * key, OID
       /* Set undo_nxlsa. */
       assert (undo_nxlsa != NULL);
       LSA_COPY (&insert_helper.compensate_undo_nxlsa, undo_nxlsa);
-      /* Fall through. */
+      [[fallthrough]];
     case BTREE_OP_INSERT_NEW_OBJECT:
       key_insert_func = btree_key_insert_new_object;
       break;
@@ -30551,7 +30551,7 @@ btree_delete_internal (THREAD_ENTRY * thread_p, BTID * btid, OID * oid, OID * cl
       /* Set ref_lsa. */
       assert (ref_lsa != NULL);
       LSA_COPY (&delete_helper.reference_lsa, ref_lsa);
-      /* Fall through. */
+      [[fallthrough]];
     case BTREE_OP_DELETE_OBJECT_PHYSICAL:
     case BTREE_OP_DELETE_VACUUM_OBJECT:
       key_func = btree_key_delete_remove_object;

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -17733,7 +17733,7 @@ int
 btree_rv_update_tran_stats (THREAD_ENTRY * thread_p, LOG_RCV * recv)
 {
   char *datap;
-  long long num_nulls, num_oids, num_keys;
+  long long num_nulls = 0, num_oids = 0, num_keys = 0;
   BTID btid;
 
   assert (recv->length >= (3 * OR_BIGINT_SIZE) + OR_BTID_ALIGNED_SIZE);
@@ -23120,7 +23120,7 @@ int
 btree_rv_redo_global_unique_stats_commit (THREAD_ENTRY * thread_p, LOG_RCV * recv)
 {
   char *datap;
-  long long num_nulls, num_oids, num_keys;
+  long long num_nulls = 0, num_oids = 0, num_keys = 0;
   BTID btid;
 
   assert (recv->length >= (3 * OR_BIGINT_SIZE) + OR_BTID_ALIGNED_SIZE);

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -7675,7 +7675,7 @@ try_again:
 	  return S_DOESNT_EXIST;
 	}
       /* REC_NEWHOME are only allowed to be accessed through REC_RELOCATION slots. */
-      /* FALLTHRU */
+      [[fallthrough]];
     default:
       /* Unexpected case. */
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HEAP_BAD_OBJECT_TYPE, 3, context->oid_p->volid,
@@ -23855,7 +23855,7 @@ heap_update_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context)
     case REC_ASSIGN_ADDRESS:
       /* it's not an old record, it was inserted in this transaction */
       context->is_logical_old = false;
-      /* FALLTHRU */
+      [[fallthrough]];
     case REC_HOME:
       rc = heap_update_home (thread_p, context, is_mvcc_op);
       break;

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -1700,7 +1700,7 @@ boot_client_initialize_css (DB_INFO * db, int client_type, bool check_capabiliti
 	case ER_NET_SERVER_HAND_SHAKE:
 	case ER_NET_HS_UNKNOWN_SERVER_REL:
 	  cap_error = true;
-	  /* FALLTHRU */
+	  [[fallthrough]];
 	case ER_NET_DIFFERENT_RELEASE:
 	case ER_NET_NO_SERVER_HOST:
 	case ER_NET_CANT_CONNECT_SERVER:

--- a/src/transaction/locator_cl.c
+++ b/src/transaction/locator_cl.c
@@ -2092,7 +2092,7 @@ locator_fetch_mode_to_lock (DB_FETCH_MODE purpose, LC_OBJTYPE type, LC_FETCH_VER
     default:
       assert (DB_FETCH_READ <= purpose && purpose <= DB_FETCH_EXCLUSIVE_SCAN);
       /* for release build, assume DB_FETCH_READ */
-      /* fall through */
+      [[fallthrough]];
 
     case DB_FETCH_READ:
       if (type == LC_CLASS)

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -7568,7 +7568,7 @@ locator_attribute_info_force (THREAD_ENTRY * thread_p, const HFID * hfid, OID * 
 
       old_recdes = &copy_recdes;
 
-      /* Fall through */
+      [[fallthrough]];
 
     case LC_FLUSH_INSERT:
     case LC_FLUSH_INSERT_PRUNE:

--- a/src/transaction/log_2pc.c
+++ b/src/transaction/log_2pc.c
@@ -2388,7 +2388,7 @@ log_2pc_recovery (THREAD_ENTRY * thread_p)
 	   * TRAN_UNACTIVE_COMMITTED_INFORMING_PARTICIPANTS case
 	   */
 
-	  /* FALLTHRU */
+	  [[fallthrough]];
 
 	case TRAN_UNACTIVE_COMMITTED_INFORMING_PARTICIPANTS:
 	  log_2pc_recovery_committed_informing_participants (thread_p, tdes);

--- a/src/transaction/log_append.cpp
+++ b/src/transaction/log_append.cpp
@@ -867,7 +867,7 @@ prior_lsa_gen_undoredo_record_from_crumbs (THREAD_ENTRY *thread_p, LOG_PRIOR_NOD
       /* Must also fill MVCCID field */
       mvccid_p = &mvcc_undo_p->mvccid;
 
-    /* Fall through */
+      [[fallthrough]];
     case LOG_UNDO_DATA:
       undo_p = (node->log_header.type == LOG_UNDO_DATA ? (LOG_REC_UNDO *) node->data_header : &mvcc_undo_p->undo);
 
@@ -882,7 +882,7 @@ prior_lsa_gen_undoredo_record_from_crumbs (THREAD_ENTRY *thread_p, LOG_PRIOR_NOD
       /* Must also fill MVCCID field */
       mvccid_p = &mvcc_redo_p->mvccid;
 
-    /* Fall through */
+      [[fallthrough]];
     case LOG_REDO_DATA:
       redo_p = (node->log_header.type == LOG_REDO_DATA ? (LOG_REC_REDO *) node->data_header : &mvcc_redo_p->redo);
 
@@ -901,7 +901,7 @@ prior_lsa_gen_undoredo_record_from_crumbs (THREAD_ENTRY *thread_p, LOG_PRIOR_NOD
       /* Must also fill MVCCID field */
       mvccid_p = &mvcc_undoredo_p->mvccid;
 
-    /* Fall through */
+      [[fallthrough]];
     case LOG_UNDOREDO_DATA:
     case LOG_DIFF_UNDOREDO_DATA:
       undoredo_p = ((node->log_header.type == LOG_UNDOREDO_DATA || node->log_header.type == LOG_DIFF_UNDOREDO_DATA)

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -5574,7 +5574,7 @@ la_apply_statement_log (LA_ITEM * item)
 
     case CUBRID_STMT_UPDATE_STATS:
       is_ddl = true;
-      /* FALLTHRU */
+      [[fallthrough]];
 
     case CUBRID_STMT_INSERT:
     case CUBRID_STMT_DELETE:

--- a/src/transaction/transaction_cl.c
+++ b/src/transaction/transaction_cl.c
@@ -342,7 +342,7 @@ tran_commit (bool retain_lock)
 	      ASSERT_ERROR_AND_SET (error_code);
 	      break;
 	    }
-	  /* Fall Thru */
+	  [[fallthrough]];
 	case TRAN_RECOVERY:
 	case TRAN_ACTIVE:
 	case TRAN_UNACTIVE_COMMITTED_WITH_POSTPONE:
@@ -474,7 +474,7 @@ tran_abort (void)
 	      ASSERT_ERROR_AND_SET (error_code);
 	      break;
 	    }
-	  /* Fall Thru */
+	  [[fallthrough]];
 	case TRAN_RECOVERY:
 	case TRAN_ACTIVE:
 	case TRAN_UNACTIVE_COMMITTED:
@@ -782,7 +782,7 @@ tran_2pc_prepare (void)
 	  error_code = er_errid ();
 	  break;
 	}
-      /* fall thru */
+      [[fallthrough]];
 
     case TRAN_RECOVERY:
     case TRAN_UNACTIVE_COMMITTED_WITH_POSTPONE:
@@ -940,7 +940,7 @@ tran_2pc_prepare_global_tran (int gtrid)
 	  error_code = er_errid ();
 	  break;
 	}
-      /* Fall Thru */
+      [[fallthrough]];
 
     case TRAN_RECOVERY:
     case TRAN_UNACTIVE_COMMITTED_WITH_POSTPONE:


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26168>

### Purpose

* circle ci에서 빌드 될 때 warning이 발생되지 않도록 코드 수정.
* 추후 모든 warning을 error로 간주되도록 할 예정이기에 warning을 정리하는 것임.

### Implementation
[-Wregister]
     flex에서 자동 생성하는 코드에서 `register` 키워드가 추가 되는 것으로 수정이 불가능하기 때문에
     자동 생성되는 코드 영역에 대해서 해당 경고가 발생하지 않도록 disable함.

[-Wuninitialized]
      선언과 동시에 초기값으로 0을 지정

[-Wtautological-compare]
    `vacuum_set_dirty_data_page`를 매크로에서 inline function으로 변경

[-Wimplicit-fallthrough=]
   주석 형태로  다양한 표현이 존재 했는데 이에 대해 circle ci에서 빌드시 warning이 발생하여 `[[fallthrough]];`로 통일 시킴
   변경 대상은 아래와 같음
 ```
    /* FALLTHRU */
     /* FALL THROUGH */
     /* fallthrough */
     /* fall through */
```
     다만, 일부분의 코드에서는 /* fall through */를 case문과 상관없이 로직의 진행을 나타내기 위한 주석으로 사용한 부분이 있기에 이런 내용은 그대로 유지
     
     flex, bison에 의해 자동으로 생성되는 코드에서도 /* fall through */ 형식이 있어서
     이 부분은 자동 생성 코드에 대해서 해당 경고를 disable 처리함.

### Remarks
