### PR TITLE
[CBRD-26173] [Regression] Core dumped in file_tempcache_lock_tran_entry at src/storage/file_manager.c:9649

### DIFF
--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -9786,10 +9786,10 @@ STATIC_INLINE void
 file_tempcache_unlock_tran_entry (FILE_TEMPCACHE_TRAN_ENTRY * tran_entry)
 {
   assert (tran_entry->owner_mutex == thread_get_current_entry_index ());
-  pthread_mutex_unlock (&tran_entry->mutex);
 #if !defined (NDEBUG)
   tran_entry->owner_mutex = -1;
 #endif /* !NDEBUG */
+  pthread_mutex_unlock (&tran_entry->mutex);
 }
 
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26173>

### Purpose

기존 코드에서는 debug 모드에서 tran_entry에 대한 unlock을 수행한 이후에 mutex의 owner를 바꿔주는데, unlock 이전에 바꿔줘야 thread-safety 합니다.

### Implementation

unlock과 owner_mutex assign의 순서를 변경합니다.

