### PR TITLE
[CBRD-25862] Improve performance of system catalog view query

### DIFF
--- a/src/object/schema_system_catalog_install.cpp
+++ b/src/object/schema_system_catalog_install.cpp
@@ -465,7 +465,8 @@ namespace cubschema
       *  Currently, it is solved by creating only general indexes, not primary keys or unique indexes.
       */
       {DB_CONSTRAINT_INDEX, "i__db_class_unique_name", {"unique_name", nullptr}, false},
-      {DB_CONSTRAINT_INDEX, "", {"class_name", "owner", nullptr}, false}
+      {DB_CONSTRAINT_INDEX, "", {"class_name", "owner", nullptr}, false},
+      {DB_CONSTRAINT_INDEX, "", {"class_of", nullptr}, false}
     },
 // authorization
     {
@@ -818,7 +819,9 @@ namespace cubschema
       {"type_name", format_varchar (16)}
     },
 // constraints
-    {},
+    {
+      {DB_CONSTRAINT_PRIMARY_KEY, "", {"type_id", nullptr}, false}
+    },
 // authorization
     {
       // owner, grants
@@ -1059,7 +1062,9 @@ namespace cubschema
       {CT_DBCOLL_CHECKSUM_COLUMN, format_varchar (32)}
     },
 // constraints
-    {},
+    {
+      {DB_CONSTRAINT_PRIMARY_KEY, "", {CT_DBCOLL_COLL_ID_COLUMN, nullptr}, false},
+    },
 // authorization
     {
       // owner, grants

--- a/src/object/schema_system_catalog_install.cpp
+++ b/src/object/schema_system_catalog_install.cpp
@@ -820,7 +820,7 @@ namespace cubschema
     },
 // constraints
     {
-      {DB_CONSTRAINT_PRIMARY_KEY, "", {"type_id", nullptr}, false}
+      {DB_CONSTRAINT_PRIMARY_KEY, "", {"type_id", "type_name", nullptr}, false}
     },
 // authorization
     {

--- a/src/object/schema_system_catalog_install.cpp
+++ b/src/object/schema_system_catalog_install.cpp
@@ -465,8 +465,7 @@ namespace cubschema
       *  Currently, it is solved by creating only general indexes, not primary keys or unique indexes.
       */
       {DB_CONSTRAINT_INDEX, "i__db_class_unique_name", {"unique_name", nullptr}, false},
-      {DB_CONSTRAINT_INDEX, "", {"class_name", "owner", nullptr}, false},
-      {DB_CONSTRAINT_INDEX, "", {"class_of", nullptr}, false}
+      {DB_CONSTRAINT_INDEX, "", {"class_name", "owner", nullptr}, false}
     },
 // authorization
     {
@@ -819,9 +818,7 @@ namespace cubschema
       {"type_name", format_varchar (16)}
     },
 // constraints
-    {
-      {DB_CONSTRAINT_PRIMARY_KEY, "", {"type_id", nullptr}, false}
-    },
+    {},
 // authorization
     {
       // owner, grants
@@ -1062,9 +1059,7 @@ namespace cubschema
       {CT_DBCOLL_CHECKSUM_COLUMN, format_varchar (32)}
     },
 // constraints
-    {
-      {DB_CONSTRAINT_PRIMARY_KEY, "", {CT_DBCOLL_COLL_ID_COLUMN, nullptr}, false},
-    },
+    {},
 // authorization
     {
       // owner, grants

--- a/src/object/schema_system_catalog_install.cpp
+++ b/src/object/schema_system_catalog_install.cpp
@@ -465,7 +465,8 @@ namespace cubschema
       *  Currently, it is solved by creating only general indexes, not primary keys or unique indexes.
       */
       {DB_CONSTRAINT_INDEX, "i__db_class_unique_name", {"unique_name", nullptr}, false},
-      {DB_CONSTRAINT_INDEX, "", {"class_name", "owner", nullptr}, false}
+      {DB_CONSTRAINT_INDEX, "", {"class_name", "owner", nullptr}, false},
+      {DB_CONSTRAINT_INDEX, "", {"class_of",nullptr}, false}
     },
 // authorization
     {

--- a/src/object/schema_system_catalog_install.cpp
+++ b/src/object/schema_system_catalog_install.cpp
@@ -818,7 +818,9 @@ namespace cubschema
       {"type_name", format_varchar (16)}
     },
 // constraints
-    {},
+    {
+      {DB_CONSTRAINT_PRIMARY_KEY, "", {"type_id", nullptr}, false}
+    },
 // authorization
     {
       // owner, grants

--- a/src/object/schema_system_catalog_install.cpp
+++ b/src/object/schema_system_catalog_install.cpp
@@ -1059,7 +1059,9 @@ namespace cubschema
       {CT_DBCOLL_CHECKSUM_COLUMN, format_varchar (32)}
     },
 // constraints
-    {},
+    {
+      {DB_CONSTRAINT_PRIMARY_KEY, "", {CT_DBCOLL_COLL_ID_COLUMN, nullptr}, false},
+    },
 // authorization
     {
       // owner, grants

--- a/src/object/schema_system_catalog_install.cpp
+++ b/src/object/schema_system_catalog_install.cpp
@@ -466,7 +466,7 @@ namespace cubschema
       */
       {DB_CONSTRAINT_INDEX, "i__db_class_unique_name", {"unique_name", nullptr}, false},
       {DB_CONSTRAINT_INDEX, "", {"class_name", "owner", nullptr}, false},
-      {DB_CONSTRAINT_INDEX, "", {"class_of",nullptr}, false}
+      {DB_CONSTRAINT_INDEX, "", {"class_of", nullptr}, false}
     },
 // authorization
     {

--- a/src/object/schema_system_catalog_install_query_spec.cpp
+++ b/src/object/schema_system_catalog_install_query_spec.cpp
@@ -65,7 +65,7 @@ sm_define_view_class_spec (void)
 
   // *INDENT-OFF*
   sprintf (stmt,
-	"SELECT /*+ USE_HASH(coll) */ "
+	"SELECT "
 	  "[c].[class_name] AS [class_name], "
 	  "CAST ([c].[owner].[name] AS VARCHAR(255)) AS [owner_name], " /* string -> varchar(255) */
 	  "CASE [c].[class_type] WHEN 0 THEN 'CLASS' WHEN 1 THEN 'VCLASS' ELSE 'UNKNOWN' END AS [class_type], "
@@ -269,11 +269,11 @@ sm_define_view_vclass_spec (void)
 const char *
 sm_define_view_attribute_spec (void)
 {
-  static char stmt [4096];
+  static char stmt [2048];
 
   // *INDENT-OFF*
   sprintf (stmt,
-	"SELECT /*+ USE_HASH(t) */ "
+	"SELECT "
 	  "[a].[attr_name] AS [attr_name], "
 	  "[c].[class_name] AS [class_name], "
 	  "CAST ([c].[owner].[name] AS VARCHAR(255)) AS [owner_name], " /* string -> varchar(255) */

--- a/src/object/schema_system_catalog_install_query_spec.cpp
+++ b/src/object/schema_system_catalog_install_query_spec.cpp
@@ -65,7 +65,7 @@ sm_define_view_class_spec (void)
 
   // *INDENT-OFF*
   sprintf (stmt,
-	"SELECT "
+	"SELECT /*+ USE_HASH(coll) */ "
 	  "[c].[class_name] AS [class_name], "
 	  "CAST ([c].[owner].[name] AS VARCHAR(255)) AS [owner_name], " /* string -> varchar(255) */
 	  "CASE [c].[class_type] WHEN 0 THEN 'CLASS' WHEN 1 THEN 'VCLASS' ELSE 'UNKNOWN' END AS [class_type], "
@@ -269,11 +269,11 @@ sm_define_view_vclass_spec (void)
 const char *
 sm_define_view_attribute_spec (void)
 {
-  static char stmt [2048];
+  static char stmt [4096];
 
   // *INDENT-OFF*
   sprintf (stmt,
-	"SELECT "
+	"SELECT /*+ USE_HASH(t) */ "
 	  "[a].[attr_name] AS [attr_name], "
 	  "[c].[class_name] AS [class_name], "
 	  "CAST ([c].[owner].[name] AS VARCHAR(255)) AS [owner_name], " /* string -> varchar(255) */


### PR DESCRIPTION
[<http://jira.cubrid.org/browse/CBRD-25862>
](http://jira.cubrid.org/browse/CBRD-25862)
### Purpose

system catalog view 의 조회 성능 개선

### Implementation

~사용자에 의해 많은 결과가 나올 수 있는 view에 USE_HASH 힌트 추가~
  ~- db_class~
  ~- db_attribute~
 
~Hash Join 사용 이유~
  ~- Index Join 보다 성능이 좋고, 불필요한 Index 를 생성하지 않아도 됨~

db_class - `_db_collation`에 `coll_id` 속성 인덱스 추가
db_attribute - `_db_data_type`에 (`type_id`, `type_name`) 속성 인덱스 추가
db_trigger - `_db_class`에 `class_of` 속성 인덱스 추가


### Remark

조회 성능 비교 결과는 jira.org 참고바랍니다.