### PR TITLE
[CBRD-26179] add error check to unpacking PL server responses to PL/CSQL compilation requests

### DIFF
--- a/src/sp/pl_compile_handler.cpp
+++ b/src/sp/pl_compile_handler.cpp
@@ -51,7 +51,6 @@ namespace cubpl
 	return ER_FAILED;
       }
 
-    cubpacking::unpacker unpacker (response_blk);
     if (!response_blk.is_valid ())
       {
 	error_code = ER_SP_NETWORK_ERROR;
@@ -59,6 +58,7 @@ namespace cubpl
       }
     else
       {
+	cubpacking::unpacker unpacker (response_blk);
 	unpacker.unpack_int (code);
 	(void) m_stack->read_payload_block (unpacker);
       }
@@ -112,41 +112,48 @@ namespace cubpl
     do
       {
 	error_code = read_request (response_blk, code);
-
-	cubmem::block &payload_blk = m_stack->get_data_queue().front ();
-
-	if (code == METHOD_REQUEST_COMPILE)
+	if (error_code == NO_ERROR)
 	  {
-	    if (payload_blk.dim > 0)
+
+	    cubmem::block &payload_blk = m_stack->get_data_queue().front ();
+
+	    if (code == METHOD_REQUEST_COMPILE)
 	      {
-		out_blk.extend_to (payload_blk.dim);
-		std::memcpy (out_blk.get_ptr (), payload_blk.ptr, payload_blk.dim);
+		if (payload_blk.dim > 0)
+		  {
+		    out_blk.extend_to (payload_blk.dim);
+		    std::memcpy (out_blk.get_ptr (), payload_blk.ptr, payload_blk.dim);
+		  }
+		else
+		  {
+		    create_error_response (out_blk, error_code);
+		  }
+	      }
+	    else if (code == METHOD_REQUEST_SQL_SEMANTICS)
+	      {
+		packing_unpacker respone_unpacker (payload_blk);
+		sql_semantics_request request;
+		respone_unpacker.unpack_all (request);
+
+		error_code = m_stack->send_data_to_client_recv (bypass_block, request);
+	      }
+	    else if (code == METHOD_REQUEST_GLOBAL_SEMANTICS)
+	      {
+		packing_unpacker respone_unpacker (payload_blk);
+		global_semantics_request request;
+		respone_unpacker.unpack_all (request);
+
+		error_code = m_stack->send_data_to_client_recv (bypass_block, request);
 	      }
 	    else
 	      {
-		create_error_response (out_blk, error_code);
+		assert (code == METHOD_REQUEST_ERROR);
+		error_code = ER_FAILED;
 	      }
-	  }
-	else if (code == METHOD_REQUEST_SQL_SEMANTICS)
-	  {
-	    packing_unpacker respone_unpacker (payload_blk);
-	    sql_semantics_request request;
-	    respone_unpacker.unpack_all (request);
-
-	    error_code = m_stack->send_data_to_client_recv (bypass_block, request);
-	  }
-	else if (code == METHOD_REQUEST_GLOBAL_SEMANTICS)
-	  {
-	    packing_unpacker respone_unpacker (payload_blk);
-	    global_semantics_request request;
-	    respone_unpacker.unpack_all (request);
-
-	    error_code = m_stack->send_data_to_client_recv (bypass_block, request);
 	  }
 	else
 	  {
-	    assert (code == METHOD_REQUEST_ERROR);
-	    error_code = ER_FAILED;
+	    create_error_response (out_blk, error_code);
 	  }
 
 	if (m_stack->get_data_queue ().empty() == false)
@@ -158,8 +165,6 @@ namespace cubpl
 	response_blk.freemem ();
       }
     while (error_code == NO_ERROR && code != METHOD_REQUEST_COMPILE);
-
-exit:
 
     return error_code;
   }

--- a/src/sp/pl_compile_handler.cpp
+++ b/src/sp/pl_compile_handler.cpp
@@ -147,7 +147,11 @@ namespace cubpl
 	      }
 	    else
 	      {
-		assert (code == METHOD_REQUEST_ERROR);
+		if (code != METHOD_REQUEST_ERROR)
+		  {
+		    er_log_debug (ARG_FILE_LINE, "wrong code %d in a response to COMPILE request\n", code);
+		    assert (false);
+		  }
 		error_code = ER_FAILED;
 	      }
 	  }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26179>

### Purpose

PL/CSQL 프로그램의 compilation 요청에 대해서 PL server 가 적법하지 않은 응답 코드를 리턴하여 
assertion fail 이 나는 현상이 관찰되었으나, 재현이 되지 않고, 원인이 명확하지 않다.
PL server 의 응답 packet decoding 과정에서 에러가 발생했다면 그 사실이 드러나도록 에러 처리를 추가한다. 

