### PR TITLE
[CBRD-26140] Add defensive null-check for process_lsa

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -11063,6 +11063,7 @@ cdc_loginfo_producer_execute (cubthread::entry & thread_ref)
   thread_p->is_cdc_daemon = true;
 
   int error = NO_ERROR;
+  int count = 0;
 
   cdc_Gl.producer.state = CDC_PRODUCER_STATE_RUN;
 
@@ -11130,6 +11131,24 @@ cdc_loginfo_producer_execute (cubthread::entry & thread_ref)
 
       LSA_COPY (&cur_log_rec_lsa, &cdc_Gl.producer.next_extraction_lsa);
       LSA_COPY (&process_lsa, &cur_log_rec_lsa);
+
+      /*
+       * Prevent the producer thread from attempting to extract CDC logs using a NULL cdc_Gl.producer.next_extraction_lsa.
+       * The race occurs when the cdc_cleanup process overlaps in timing with the log extraction process.
+       *
+       * TODO: Investigate and fix the root cause of process_lsa being NULL
+       */
+      if (LSA_ISNULL (&process_lsa))
+	{
+	  count++;
+
+	  if (count < 10)
+	    {
+	      continue;
+	    }
+
+	  assert (false);
+	}
 
       error = cdc_log_extract (thread_p, &process_lsa, &log_info_entry);
       if (!(error == NO_ERROR || error == ER_CDC_LOGINFO_ENTRY_GENERATED))

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -11142,12 +11142,16 @@ cdc_loginfo_producer_execute (cubthread::entry & thread_ref)
 	{
 	  count++;
 
-	  if (count < 10)
+	  if (count >= 10)
 	    {
-	      continue;
+	      er_log_debug (ARG_FILE_LINE,
+			    "cdc_loginfo_producer_execute : process_lsa is NULL_LSA (producer.request : %d, producer.state : %d)",
+			    cdc_Gl.producer.request, cdc_Gl.producer.state);
+
+	      assert (false);
 	    }
 
-	  assert (false);
+	  continue;
 	}
 
       error = cdc_log_extract (thread_p, &process_lsa, &log_info_entry);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -11142,11 +11142,11 @@ cdc_loginfo_producer_execute (cubthread::entry & thread_ref)
 	{
 	  count++;
 
-	  if (count >= 10)
+	  if ((count % 10) == 0)
 	    {
-	      er_log_debug (ARG_FILE_LINE,
-			    "cdc_loginfo_producer_execute : process_lsa is NULL_LSA (producer.request : %d, producer.state : %d)",
-			    cdc_Gl.producer.request, cdc_Gl.producer.state);
+	      _er_log_debug (ARG_FILE_LINE,
+			     "cdc_loginfo_producer_execute : process_lsa is NULL_LSA (producer.request : %d, producer.state : %d)",
+			     cdc_Gl.producer.request, cdc_Gl.producer.state);
 
 	      assert (false);
 	    }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26140

### Purpose

- cdc_Gl.producer.next_extraction_lsa가 NULL인 상태에서 producer가 CDC log를 추출하는 것을 방지하는 코드입니다.

### Implementation

- process_lsa의 NULL check 구문을 추가
- 혹시 모를 무한루프 상황이 있을 수 있기 때문에 count 변수 추가하여 무한루프 상황 방지

### Remarks

N/A
