### PR TITLE
[CBRD-26195] [Regression] Core dumped in pgbuf_fix_debug at src/storage/page_buffer.c:2079

### DIFF
--- a/src/query/parallel/px_heap_scan/px_heap_scan_task.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_task.cpp
@@ -28,6 +28,7 @@
 #include <memory>
 #include "thread_entry.hpp"
 #include "perf_monitor.h"
+#include "page_buffer.h"
 
 #define PARALLEL_HEAP_SCAN_LOG 0
 #if PARALLEL_HEAP_SCAN_LOG
@@ -63,8 +64,13 @@ namespace parallel_heap_scan
   {
     std::unique_lock<std::mutex> lock (m_context->m_locked_vpid.mutex);
     HEAP_SCANCACHE *scan_cache = &scan_id->s.hsid.scan_cache;
+    SCAN_CODE page_scan_code;
     if (m_context->m_locked_vpid.is_ended)
       {
+	if (m_old_page_watcher.pgptr != NULL)
+	  {
+	    pgbuf_ordered_unfix (thread_p, &m_old_page_watcher);
+	  }
 	return S_END;
       }
     if (VPID_ISNULL (&m_context->m_locked_vpid.vpid))
@@ -74,7 +80,16 @@ namespace parallel_heap_scan
 	m_context->m_locked_vpid.vpid.volid = hfid->vfid.volid;
       }
     VPID_COPY (vpid, &m_context->m_locked_vpid.vpid);
-    SCAN_CODE page_scan_code = heap_page_next_fix_old (thread_p, hfid, &m_context->m_locked_vpid.vpid, scan_cache);
+    if (scan_cache->page_watcher.pgptr != NULL)
+      {
+	pgbuf_replace_watcher (thread_p, &scan_cache->page_watcher, &m_old_page_watcher);
+      }
+    page_scan_code = heap_page_next_fix_old (thread_p, hfid, &m_context->m_locked_vpid.vpid, scan_cache);
+    if (m_old_page_watcher.pgptr != NULL)
+      {
+	pgbuf_ordered_unfix (thread_p, &m_old_page_watcher);
+      }
+
     if (page_scan_code == S_END)
       {
 	m_context->m_locked_vpid.is_ended = true;
@@ -177,6 +192,7 @@ namespace parallel_heap_scan
     ret = scan_start_scan (thread_p, scan_id);
     /* lock because of mvcc_snapshot */
     lock.unlock();
+    PGBUF_INIT_WATCHER (&m_old_page_watcher, PGBUF_ORDERED_HEAP_NORMAL, &hsidp->hfid);
     hfid = phsidp->hfid;
     OID_SET_NULL (&hsidp->curr_oid);
     VPID_SET_NULL (&vpid);

--- a/src/query/parallel/px_heap_scan/px_heap_scan_task.hpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_task.hpp
@@ -63,6 +63,7 @@ namespace parallel_heap_scan
       std::shared_ptr<list_id_wrapper> m_list_id_wrapper;
       mergable_list_writer *m_mergable_list_writer;
       parallel_query::worker_manager *m_worker_manager;
+      PGBUF_WATCHER m_old_page_watcher;
   };
 }
 #endif /* SERVER_MODE && !WINDOWS */

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -8207,8 +8207,9 @@ heap_page_next_fix_old (THREAD_ENTRY * thread_p, HFID * hfid, VPID * curr_vpid, 
     }
   else
     {
-      scan_cache->page_watcher.pgptr = heap_scan_pb_lock_and_fetch (thread_p, curr_vpid, OLD_PAGE, S_LOCK, NULL,
-								    &scan_cache->page_watcher);
+      scan_cache->page_watcher.pgptr =
+	heap_scan_pb_lock_and_fetch (thread_p, curr_vpid, OLD_PAGE_PREVENT_DEALLOC, S_LOCK, NULL,
+				     &scan_cache->page_watcher);
       if (scan_cache->page_watcher.pgptr == NULL)
 	{
 	  return S_ERROR;
@@ -8347,13 +8348,13 @@ heap_next_1page (THREAD_ENTRY * thread_p, const HFID * hfid, const VPID * vpid, 
 		{
 		  /* must be last slot of page, end scanning */
 		  OID_SET_NULL (next_oid);
-		  pgbuf_ordered_unfix (thread_p, &scan_cache->page_watcher);
+		  /* not unfix page here cause fix page executed on parallel heap scan task */
 		  return scan;
 		}
 	      else
 		{
 		  /* Error, stop scanning */
-		  pgbuf_ordered_unfix (thread_p, &scan_cache->page_watcher);
+		  /* not unfix page here cause fix page executed on parallel heap scan task */
 		  return scan;
 		}
 	    }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26195>

### Purpose

기존 parallel heap scan 소스코드에서는 새로운 페이지를 fix하기 전에 이전 페이지를 모두 읽으면 unfix했지만, 이 경우 새로운 페이지의 vpid가 vacuum에 의해 invalidate될 위험이 있습니다. 
또한, OLD_PAGE로 fix하면 ordered fix/unfix 과정에서 fix된 페이지가 invalidate될 수 있어, 기존 heap scan에서는 heap page를 fix할 때 OLD_PAGE_PREVENT_DEALLOC을 사용합니다. 
이에 따라 parallel heap scan에서도 동일하게 OLD_PAGE_PREVENT_DEALLOC으로 fix하도록 변경합니다.

