### PR TITLE
[CBRD-26056] minor: delete DB_CLIENT_TYPE_PLCSQL_HELPER from client types enumeration

### DIFF
--- a/src/compat/db_client_type.hpp
+++ b/src/compat/db_client_type.hpp
@@ -48,7 +48,6 @@ enum db_client_type
   DB_CLIENT_TYPE_ADMIN_LOADDB_COMPAT = 18, /* loaddb with --no-user-specified-name option */
   DB_CLIENT_TYPE_ADMIN_CSQL_REBUILD_CATALOG = 19,
   DB_CLIENT_TYPE_LOADDB_UTILITY = 20,
-  DB_CLIENT_TYPE_PLCSQL_HELPER = 21,
 
   DB_CLIENT_TYPE_MAX
 };

--- a/src/method/method_callback.cpp
+++ b/src/method/method_callback.cpp
@@ -269,6 +269,7 @@ namespace cubmethod
 	    if (error != NO_ERROR)
 	      {
 		m_error_ctx.set_error (db_error_code (), db_error_string (1), __FILE__, __LINE__);
+                fprintf(stderr, "err code (%d), err msg (%s)\n", db_error_code (), db_error_string (1));
 	      }
 	  }
 

--- a/src/sp/pl_session.cpp
+++ b/src/sp/pl_session.cpp
@@ -316,7 +316,7 @@ namespace cubpl
   void
   session::set_interrupt (int reason, std::string msg)
   {
-    if (m_is_interrupted)
+    if (m_is_interrupted)       // !!! synchronize
       {
 	// do not overwrite interrupt
 	return;
@@ -344,7 +344,7 @@ namespace cubpl
 	m_interrupt_msg.assign (msg);
 	break;
       default:
-	/* do nothing */
+	/* do nothing */        // !!! assert false
 	break;
       }
 

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -2768,7 +2768,7 @@ logtb_set_tran_index_interrupt (THREAD_ENTRY * thread_p, int tran_index, bool se
 	      perfmon_inc_stat (thread_p, PSTAT_TRAN_NUM_INTERRUPTS);
 
 	      // Only TT_WORKER threads use pl_session
-	      if (thread_p && thread_p->type == TT_WORKER)
+	      if (thread_p && thread_p->type == TT_WORKER)      // ??? is the other case possible?
 		{
 		  if (session_has_pl_session (thread_p))
 		    {


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26056>

### Purpose

이제는 사용되지 않는 PLCSQL helper utility 를 삭제하면서 지웠어야 할 코드 한 줄 삭제입니다. 
