### PR TITLE
[CBRD-26056] minor: delete DB_CLIENT_TYPE_PLCSQL_HELPER from the client type enumeration

### DIFF
--- a/src/compat/db_client_type.hpp
+++ b/src/compat/db_client_type.hpp
@@ -48,7 +48,6 @@ enum db_client_type
   DB_CLIENT_TYPE_ADMIN_LOADDB_COMPAT = 18, /* loaddb with --no-user-specified-name option */
   DB_CLIENT_TYPE_ADMIN_CSQL_REBUILD_CATALOG = 19,
   DB_CLIENT_TYPE_LOADDB_UTILITY = 20,
-  DB_CLIENT_TYPE_PLCSQL_HELPER = 21,
 
   DB_CLIENT_TYPE_MAX
 };


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26056>

### Purpose

이제는 사용되지 않는 PLCSQL helper utility 를 삭제하면서 지웠어야 할 코드 한 줄 삭제입니다.

