### PR TITLE
[CBRD-26199] uncorrelated subquery parallel execution 실행 시, parallelism을 2로 고정

### DIFF
--- a/src/query/parallel/px_query_execute/px_query_executor.hpp
+++ b/src/query/parallel/px_query_execute/px_query_executor.hpp
@@ -38,6 +38,9 @@ namespace parallel_query_execute
   using pool = parallel_query::worker_manager_with_dedicated_pool;
 
   using err_desc_t = std::pair<int, cuberr::er_message *>;
+
+  const int max_parallelism = 2;
+
   class query_executor
   {
     public:

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -14879,7 +14879,9 @@ qexec_execute_mainblock_internal (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
 			    {
 			      using dpool = parallel_query::worker_manager_with_dedicated_pool;
 			      using pexec = parallel_query_execute::query_executor;
-
+			      /* TODO: Temporarily limited to 2. 
+			       * Remove this when exact parallel count is available 
+			       * for better performance with many uncorrelated subqueries.*/
 			      n_workers_to_reserve = parallel_query_execute::max_parallelism - 1;
 
 			      dpool *px_worker_manager_p = &dpool::get_manager ();

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -14879,6 +14879,9 @@ qexec_execute_mainblock_internal (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
 			    {
 			      using dpool = parallel_query::worker_manager_with_dedicated_pool;
 			      using pexec = parallel_query_execute::query_executor;
+
+			      n_workers_to_reserve = parallel_query_execute::max_parallelism - 1;
+
 			      dpool *px_worker_manager_p = &dpool::get_manager ();
 			      if (pexec::make_parallel_query_executor_recursively
 				  (thread_p, xasl, px_worker_manager_p, nullptr, n_workers_to_reserve) != true)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26199>

### Purpose

uncorrelated subquery parallel execution 시, uncorrelated subquery가 2개임에도 불구하고 질의에 parallel(32) 힌트를 주면 32개의 parallel worker를 reserve하는 문제가 있습니다. 하지만 실제 사용할 worker 수의 상한을 정확히 계산하려면 XASL tree를 순회하여 동시에 실행 가능한 부질의와 불가능한 부질의를 구분해야 하며, 이는 복잡한 과정을 요구합니다. 따라서 최대 2개만 reserve하도록 수정합니다.