### PR TITLE
[CBRD-26083] test commit to test a new processing of a user interrupt

### DIFF
--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -2778,7 +2778,7 @@ css_server_task::execute (context_type &thread_ref)
   pthread_mutex_lock (&thread_ref.tran_index_lock);
   (void) css_internal_request_handler (thread_ref, m_conn);
 
-  (void) session_notify_pl_task_completion (session_p);
+  //(void) session_notify_pl_task_completion (session_p);
 
   thread_ref.conn_entry = NULL;
   thread_ref.m_status = cubthread::entry::status::TS_FREE;

--- a/src/sp/pl_execution_stack_context.hpp
+++ b/src/sp/pl_execution_stack_context.hpp
@@ -78,6 +78,9 @@ namespace cubpl
       int interrupt_handler ();
 
     public:
+      // temp
+      int m_level = -1;
+
       execution_stack () = delete; // Not DefaultConstructible
       execution_stack (cubthread::entry *thread_p);
 

--- a/src/sp/pl_executor.cpp
+++ b/src/sp/pl_executor.cpp
@@ -412,7 +412,9 @@ exit:
     do
       {
 	cubmem::block response_blk;
+	er_log_debug (ARG_FILE_LINE, "ttt before reading from java: stack level=%d\n", m_stack->m_level);
 	error_code = m_stack->read_data_from_java (response_blk);
+	er_log_debug (ARG_FILE_LINE, "ttt after reading from java: stack level=%d\n", m_stack->m_level);
 	if (error_code != NO_ERROR)
 	  {
 	    break;
@@ -433,14 +435,19 @@ exit:
 	/* processing */
 	if (start_code == SP_CODE_INTERNAL_JDBC)
 	  {
+	    er_log_debug (ARG_FILE_LINE, "ttt SP_CODE_INTERNAL_JDBC\n");
 	    error_code = response_callback_command ();
+	    er_log_debug (ARG_FILE_LINE, "ttt answered SP_CODE_INTERNAL_JDBC: stack level=%d\n",
+			  m_stack->m_level);
 	  }
 	else if (start_code == SP_CODE_RESULT || start_code == SP_CODE_ERROR)
 	  {
+	    er_log_debug (ARG_FILE_LINE, "ttt %s\n", start_code == SP_CODE_RESULT ? "SP_CODE_RESULT" : "SP_CODE_ERROR");
 	    error_code = response_result (start_code, value);
 	  }
 	else
 	  {
+	    er_log_debug (ARG_FILE_LINE, "ttt (network?) ERROR\n");
 	    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_NETWORK_ERROR, 1,
 		    start_code);
 	    error_code = ER_SP_NETWORK_ERROR;
@@ -537,55 +544,69 @@ exit:
       */
 
       case METHOD_CALLBACK_GET_DB_PARAMETER:
+	er_log_debug (ARG_FILE_LINE, "ttt METHOD_CALLBACK_GET_DB_PARAMETER\n");
 	error_code = callback_get_db_parameter (thread_ref, unpacker);
 	break;
 
       case METHOD_CALLBACK_QUERY_PREPARE:
+	er_log_debug (ARG_FILE_LINE, "ttt METHOD_CALLBACK_QUERY_PREPARE\n");
 	error_code = callback_prepare (thread_ref, unpacker);
 	break;
 
       case METHOD_CALLBACK_QUERY_EXECUTE:
+	er_log_debug (ARG_FILE_LINE, "ttt METHOD_CALLBACK_QUERY_EXECUTE\n");
 	error_code = callback_execute (thread_ref, unpacker);
 	break;
 
       case METHOD_CALLBACK_FETCH:
+	er_log_debug (ARG_FILE_LINE, "ttt METHOD_CALLBACK_FETCH\n");
 	error_code = callback_fetch (thread_ref, unpacker);
 	break;
 
       case METHOD_CALLBACK_OID_GET:
+	er_log_debug (ARG_FILE_LINE, "ttt METHOD_CALLBACK_OID_GET\n");
 	error_code = callback_oid_get (thread_ref, unpacker);
 	break;
 
       case METHOD_CALLBACK_OID_PUT:
+	er_log_debug (ARG_FILE_LINE, "ttt METHOD_CALLBACK_OID_PUT\n");
 	error_code = callback_oid_put (thread_ref, unpacker);
 	break;
 
       case METHOD_CALLBACK_OID_CMD:
+	er_log_debug (ARG_FILE_LINE, "ttt METHOD_CALLBACK_OID_CMD\n");
 	error_code = callback_oid_cmd (thread_ref, unpacker);
 	break;
 
       case METHOD_CALLBACK_COLLECTION:
+	er_log_debug (ARG_FILE_LINE, "ttt METHOD_CALLBACK_COLLECTION\n");
 	error_code = callback_collection_cmd (thread_ref, unpacker);
 	break;
 
       case METHOD_CALLBACK_MAKE_OUT_RS:
+	er_log_debug (ARG_FILE_LINE, "ttt METHOD_CALLBACK_MAKE_OUT_RS\n");
 	error_code = callback_make_outresult (thread_ref, unpacker);
 	break;
 
       case METHOD_CALLBACK_GET_GENERATED_KEYS:
+	er_log_debug (ARG_FILE_LINE, "ttt METHOD_CALLBACK_GET_GENERATED_KEYS\n");
 	error_code = callback_get_generated_keys (thread_ref, unpacker);
 	break;
       case METHOD_CALLBACK_END_TRANSACTION:
+	er_log_debug (ARG_FILE_LINE, "ttt METHOD_CALLBACK_END_TRANSACTION\n");
 	error_code = callback_end_transaction (thread_ref, unpacker);
 	break;
       case METHOD_CALLBACK_CHANGE_RIGHTS:
+	er_log_debug (ARG_FILE_LINE, "ttt METHOD_CALLBACK_CHANGE_RIGHTS\n");
 	error_code = callback_change_auth_rights (thread_ref, unpacker);
 	break;
       case METHOD_CALLBACK_GET_CODE_ATTR:
+	er_log_debug (ARG_FILE_LINE, "ttt METHOD_CALLBACK_GET_CODE_ATTR\n");
 	error_code = callback_get_code_attr (thread_ref, unpacker);
 	break;
 
       case METHOD_CALLBACK_SET_PL_SESSION_PARAM:
+	er_log_debug (ARG_FILE_LINE, "ttt METHOD_CALLBACK_SET_PL_SESSION_PARAM\n");
 	error_code = callback_set_pl_session_param (thread_ref, unpacker);
 	break;
       default:

--- a/src/sp/pl_session.cpp
+++ b/src/sp/pl_session.cpp
@@ -99,12 +99,11 @@ namespace cubpl
 	thread_p = thread_get_thread_entry_info ();
       }
 
-
-    std::unique_lock<std::mutex> lock (m_mutex);
+    //std::unique_lock<std::mutex> lock (m_mutex);
 
     if (m_stack_idx >= METHOD_MAX_RECURSION_DEPTH)
       {
-	lock.unlock ();
+	//lock.unlock ();
 	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_TOO_MANY_NESTED_CALL, 0);
 	set_interrupt (ER_SP_TOO_MANY_NESTED_CALL);
 	return nullptr;
@@ -121,7 +120,7 @@ namespace cubpl
       {
 	// block creating a new stack
 	set_local_error_for_interrupt ();
-	m_cond_var.notify_all ();
+	//m_cond_var.notify_all ();
 	return nullptr;
       }
 
@@ -136,6 +135,7 @@ namespace cubpl
 	// push to exec_stack
 	int stack_size = (int) m_exec_stack.size ();
 	PL_STACK_ID stack_id = stack->get_id ();
+	er_log_debug (ARG_FILE_LINE, "ttt pushing: m_stack_idx=%d, stack_id=%ld\n", m_stack_idx, stack_id);
 	if (m_stack_idx < stack_size)
 	  {
 	    m_exec_stack [m_stack_idx] = stack_id;
@@ -144,6 +144,8 @@ namespace cubpl
 	  {
 	    m_exec_stack.emplace_back (stack_id);
 	  }
+	// temp
+	stack->m_level = m_stack_idx;
 
 	m_is_running = true;
       }
@@ -167,27 +169,28 @@ namespace cubpl
     auto pred = [&] () -> bool
     {
       // condition to check
-      return m_exec_stack[m_stack_idx] == sid;
+      //return m_exec_stack[m_stack_idx] == sid;
+      bool b = m_exec_stack[m_stack_idx] == sid;  // ??? if m_stack_idx reaches -1, then this causes core dump
+      er_log_debug (ARG_FILE_LINE, "ttt poping %s: m_stack_idx=%d, stack_id=%ld\n", b ? "okay" : "fail", m_stack_idx, sid);
+      return b;
     };
 
     // Guaranteed to be removed from the topmost element
-    std::unique_lock<std::mutex> ulock (m_mutex);
-    m_cond_var.wait (ulock, pred);
+    //std::unique_lock<std::mutex> ulock (m_mutex);
+    //m_cond_var.wait (ulock, pred);
 
-    if (pred ())
-      {
-	if (m_stack_idx > -1)
-	  {
-	    m_exec_stack[m_stack_idx] = -1;
-	    m_stack_idx--;
-	  }
+    //if (pred ())
+    assert (pred());
+    assert (m_stack_idx > -1);
+    m_exec_stack[m_stack_idx] = -1;
+    m_stack_idx--;
 
-	m_stack_map.erase (sid);
-      }
+    m_stack_map.erase (sid);
 
     if (m_stack_idx < 0)
       {
 	m_is_running = false;
+	m_cond_var.notify_all();        // temp
 
 	// clear interrupt
 	clear_interrupt ();
@@ -197,7 +200,7 @@ namespace cubpl
   execution_stack *
   session::top_stack ()
   {
-    std::lock_guard<std::mutex> lock (m_mutex);
+    //std::lock_guard<std::mutex> lock (m_mutex);
 
     return top_stack_internal ();
   }
@@ -205,13 +208,14 @@ namespace cubpl
   void
   session::notify_waiting_stacks ()
   {
-    m_cond_var.notify_all ();
+    assert (false);
+    //m_cond_var.notify_all ();
   }
 
   connection_view
   session::claim_connection ()
   {
-    std::lock_guard<std::mutex> lock (m_mutex);
+    //std::lock_guard<std::mutex> lock (m_mutex);
 
     connection_view cv = nullptr;
     if (m_session_connections.empty ())
@@ -240,7 +244,7 @@ namespace cubpl
   void
   session::release_connection (connection_view &conn)
   {
-    std::lock_guard<std::mutex> lock (m_mutex);
+    //std::lock_guard<std::mutex> lock (m_mutex);
 
     if (conn != nullptr)
       {
@@ -299,7 +303,7 @@ namespace cubpl
   bool
   session::is_thread_involved (thread_id_t id)
   {
-    std::lock_guard<std::mutex> lock (m_mutex);
+    //std::lock_guard<std::mutex> lock (m_mutex);
 
     for (const auto &it : m_stack_map)
       {
@@ -404,7 +408,7 @@ namespace cubpl
 	return;
       }
 
-    m_cond_var.notify_all ();
+    //m_cond_var.notify_all ();
 
     std::unique_lock<std::mutex> ulock (m_mutex);
     m_cond_var.wait (ulock, pred);
@@ -436,7 +440,7 @@ namespace cubpl
 	return nullptr;
       }
 
-    std::lock_guard<std::mutex> lock (m_mutex);
+    //std::lock_guard<std::mutex> lock (m_mutex);
 
     // find in map
     auto search = m_cursor_map.find (query_id);
@@ -458,7 +462,7 @@ namespace cubpl
 	return nullptr;
       }
 
-    std::lock_guard<std::mutex> lock (m_mutex);
+    //std::lock_guard<std::mutex> lock (m_mutex);
     query_cursor *cursor = nullptr;
 
     // find in map
@@ -495,7 +499,7 @@ namespace cubpl
 	return;
       }
 
-    std::lock_guard<std::mutex> ulock (m_mutex);
+    //std::lock_guard<std::mutex> ulock (m_mutex);
     return destroy_cursor_internal (thread_p, query_id);
   }
 
@@ -526,7 +530,7 @@ namespace cubpl
 	return;
       }
 
-    std::lock_guard<std::mutex> ulock (m_mutex);
+    //std::lock_guard<std::mutex> ulock (m_mutex);
     m_session_cursors.insert (query_id);
   }
 
@@ -539,14 +543,14 @@ namespace cubpl
 	return;
       }
 
-    std::lock_guard<std::mutex> ulock (m_mutex);
+    //std::lock_guard<std::mutex> ulock (m_mutex);
     m_session_cursors.erase (query_id);
   }
 
   bool
   session::is_session_cursor (QUERY_ID query_id)
   {
-    std::lock_guard<std::mutex> ulock (m_mutex);
+    //std::lock_guard<std::mutex> ulock (m_mutex);
     if (m_session_cursors.find (query_id) != m_session_cursors.end ())
       {
 	return true;
@@ -560,7 +564,7 @@ namespace cubpl
   void
   session::destroy_all_cursors ()
   {
-    std::unique_lock<std::mutex> ulock (m_mutex);
+    //std::unique_lock<std::mutex> ulock (m_mutex);
 
     for (auto &it : m_cursor_map)
       {


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26083>

### Purpose

refactoring: cubpl:session 안의 로직에서 lock 사용을 줄였습니다. 

### Implementation

N/A

### Remarks

N/A
