### PR TITLE
[CBRD-26216] [Regression] Core dumped during SQL test in cub_free at src/base/memory_cwrapper.h:85

### DIFF
--- a/src/communication/network_cl.c
+++ b/src/communication/network_cl.c
@@ -420,8 +420,7 @@ net_client_request_no_reply (int request, char *argbuf, int argsize)
 
   error = NO_ERROR;
 
-  assert (request == NET_SERVER_LOG_SET_INTERRUPT || request == NET_SERVER_LD_INTERRUPT
-	  || request == NET_SERVER_TDES_SET_QUERY_START_INFO || request == NET_SERVER_TDES_RESET_QUERY_START_INFO);
+  assert (request == NET_SERVER_LOG_SET_INTERRUPT || request == NET_SERVER_LD_INTERRUPT);
 
   if (net_Server_name[0] == '\0')
     {

--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -11581,7 +11581,7 @@ tdes_set_query_start_info (char *sql_user_text)
   ptr = or_pack_string (request, sql_user_text);
   assert (ptr <= request + request_len);
 
-  net_client_request_no_reply (NET_SERVER_TDES_SET_QUERY_START_INFO, request, request_len);
+  net_client_request (NET_SERVER_TDES_SET_QUERY_START_INFO, request, request_len);
 
   free_and_init (request);
 #endif /* !CS_MODE */
@@ -11598,7 +11598,7 @@ tdes_reset_query_start_info (PT_NODE * node)
 #if defined(CS_MODE)
   if (pt_is_ddl_statement (node))
     {
-      net_client_request_no_reply (NET_SERVER_TDES_RESET_QUERY_START_INFO, NULL, 0);
+      net_client_request (NET_SERVER_TDES_RESET_QUERY_START_INFO, NULL, 0);
     }
 #endif
 }

--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -11581,7 +11581,7 @@ tdes_set_query_start_info (char *sql_user_text)
   ptr = or_pack_string (request, sql_user_text);
   assert (ptr <= request + request_len);
 
-  net_client_request (NET_SERVER_TDES_SET_QUERY_START_INFO, request, request_len);
+  net_client_request (NET_SERVER_TDES_SET_QUERY_START_INFO, request, request_len, NULL, 0, NULL, 0, NULL, 0);
 
   free_and_init (request);
 #endif /* !CS_MODE */
@@ -11598,7 +11598,7 @@ tdes_reset_query_start_info (PT_NODE * node)
 #if defined(CS_MODE)
   if (pt_is_ddl_statement (node))
     {
-      net_client_request (NET_SERVER_TDES_RESET_QUERY_START_INFO, NULL, 0);
+      net_client_request (NET_SERVER_TDES_RESET_QUERY_START_INFO, NULL, 0, NULL, 0, NULL, 0, NULL, 0);
     }
 #endif
 }

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -11545,6 +11545,9 @@ stdes_set_query_start_info (THREAD_ENTRY * thread_p, unsigned int rid, char *req
 	  tdes_p->ddl_sql_user_text = strdup (sql_user_text);
 	}
     }
+
+  css_send_data_to_client (thread_p->conn_entry, rid, NULL, 0);
+
 }
 
 /*
@@ -11573,4 +11576,7 @@ stdes_reset_query_start_info (THREAD_ENTRY * thread_p, unsigned int rid, char *r
 	  free_and_init (tdes_p->ddl_sql_user_text);
 	}
     }
+
+  css_send_data_to_client (thread_p->conn_entry, rid, NULL, 0);
+
 }

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -11568,6 +11568,9 @@ stdes_reset_query_start_info (THREAD_ENTRY * thread_p, unsigned int rid, char *r
   if (tdes_p)
     {
       tdes_p->query_start_time = 0;
-      free_and_init (tdes_p->ddl_sql_user_text);
+      if (tdes_p->ddl_sql_user_text)
+	{
+	  free_and_init (tdes_p->ddl_sql_user_text);
+	}
     }
 }

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -1570,7 +1570,10 @@ logtb_clear_tdes (THREAD_ENTRY * thread_p, LOG_TDES * tdes)
   tdes->suppress_replication = 0;
   tdes->m_log_postpone_cache.reset ();
   tdes->has_supplemental_log = false;
-  free_and_init (tdes->ddl_sql_user_text);
+  if (tdes->ddl_sql_user_text)
+    {
+      free_and_init (tdes->ddl_sql_user_text);
+    }
   logtb_tran_clear_update_stats (&tdes->log_upd_stats);
 
   assert (tdes->mvccinfo.id == MVCCID_NULL);


### PR DESCRIPTION
[<http://jira.cubrid.org/browse/CBRD-26216>](http://jira.cubrid.org/browse/CBRD-26216)

### Purpose

tdes 구조체 reset 중 free 동작에서 발생한 regression 이슈에 대한 건입니다.
현재 재현되지는 않지만 예상되는 리스크를 제거하였습니다.

### Implementation

tranlist를 위한 정보를 기록하기 위해 기존에는 서버-클라이언트 통신을 no_reply로 하였는데, 모종의 이유로 타이밍 이슈가 발생해 정보의 정합성이 깨질 것을 우려해 응답을 기다리는 통신으로 변경하였습니다.

또한 tdes 구조체 reset 시 free하기 전 NULL 체크를 추가하였습니다.

### Remarks

N/A
