### PR TITLE
[CBRD-26214] commit with an open cursor (backport to 11.4)

### DIFF
--- a/src/method/method_query_handler.cpp
+++ b/src/method/method_query_handler.cpp
@@ -839,7 +839,7 @@ namespace cubmethod
       }
 
     db_get_cacheinfo (m_session, stmt_id, &m_use_plan_cache, NULL);
-    db_session_set_holdable (m_session, false);
+    db_session_set_holdable (m_session, true);
 
     /* prepare result set */
     m_num_markers = get_num_markers ();

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -3288,7 +3288,6 @@ session_get_pl_session (THREAD_ENTRY * thread_p, REFPTR (PL_SESSION, pl_session_
       if (state_p->pl_session_p == NULL)
 	{
 	  state_p->pl_session_p = new PL_SESSION (state_p->id);
-	  er_log_debug (ARG_FILE_LINE, "pl_session (create): %d\n", state_p->id);
 	}
       else if (state_p->pl_session_p->is_running () == true && state_p->pl_session_p->is_interrupted ())
 	{

--- a/src/sp/pl_query_cursor.cpp
+++ b/src/sp/pl_query_cursor.cpp
@@ -87,6 +87,11 @@ namespace cubpl
       {
 	qfile_close_scan (m_thread, &m_scan_id);
 
+        if (m_query_entry->list_id == NULL) {
+            int tran_index = LOG_FIND_THREAD_TRAN_INDEX (m_thread);
+            m_query_entry = qmgr_get_query_entry (m_thread, m_query_id, tran_index);
+        }
+
 	if (m_query_entry->list_id)
 	  {
 	    // Since the list was not created in this thread, incrementing the count of the list (m_qlist_count) is required
@@ -195,7 +200,11 @@ namespace cubpl
 	OR_BUF buf;
 
 	assert (m_query_entry != NULL);
-	assert (m_query_entry->list_id != NULL);
+        if (m_query_entry->list_id == NULL) {
+            int tran_index = LOG_FIND_THREAD_TRAN_INDEX (m_thread);
+            m_query_entry = qmgr_get_query_entry (m_thread, m_query_id, tran_index);
+        }
+
 	QFILE_LIST_ID *list_id = m_query_entry->list_id;
 	for (int i = 0; i < list_id->type_list.type_cnt; i++)
 	  {

--- a/src/sp/pl_query_cursor.cpp
+++ b/src/sp/pl_query_cursor.cpp
@@ -87,10 +87,11 @@ namespace cubpl
       {
 	qfile_close_scan (m_thread, &m_scan_id);
 
-        if (m_query_entry->list_id == NULL) {
-            int tran_index = LOG_FIND_THREAD_TRAN_INDEX (m_thread);
-            m_query_entry = qmgr_get_query_entry (m_thread, m_query_id, tran_index);
-        }
+	if (m_query_entry->list_id == NULL)
+	  {
+	    int tran_index = LOG_FIND_THREAD_TRAN_INDEX (m_thread);
+	    m_query_entry = qmgr_get_query_entry (m_thread, m_query_id, tran_index);
+	  }
 
 	if (m_query_entry->list_id)
 	  {
@@ -140,10 +141,11 @@ namespace cubpl
 	OR_BUF buf;
 
 	assert (m_query_entry != NULL);
-        if (m_query_entry->list_id == NULL) {
-            int tran_index = LOG_FIND_THREAD_TRAN_INDEX (m_thread);
-            m_query_entry = qmgr_get_query_entry (m_thread, m_query_id, tran_index);
-        }
+	if (m_query_entry->list_id == NULL)
+	  {
+	    int tran_index = LOG_FIND_THREAD_TRAN_INDEX (m_thread);
+	    m_query_entry = qmgr_get_query_entry (m_thread, m_query_id, tran_index);
+	  }
 
 	QFILE_LIST_ID *list_id = m_query_entry->list_id;
 	for (int i = 0; i < list_id->type_list.type_cnt; i++)
@@ -204,10 +206,11 @@ namespace cubpl
 	OR_BUF buf;
 
 	assert (m_query_entry != NULL);
-        if (m_query_entry->list_id == NULL) {
-            int tran_index = LOG_FIND_THREAD_TRAN_INDEX (m_thread);
-            m_query_entry = qmgr_get_query_entry (m_thread, m_query_id, tran_index);
-        }
+	if (m_query_entry->list_id == NULL)
+	  {
+	    int tran_index = LOG_FIND_THREAD_TRAN_INDEX (m_thread);
+	    m_query_entry = qmgr_get_query_entry (m_thread, m_query_id, tran_index);
+	  }
 
 	QFILE_LIST_ID *list_id = m_query_entry->list_id;
 	for (int i = 0; i < list_id->type_list.type_cnt; i++)

--- a/src/sp/pl_query_cursor.cpp
+++ b/src/sp/pl_query_cursor.cpp
@@ -140,7 +140,11 @@ namespace cubpl
 	OR_BUF buf;
 
 	assert (m_query_entry != NULL);
-	assert (m_query_entry->list_id != NULL);
+        if (m_query_entry->list_id == NULL) {
+            int tran_index = LOG_FIND_THREAD_TRAN_INDEX (m_thread);
+            m_query_entry = qmgr_get_query_entry (m_thread, m_query_id, tran_index);
+        }
+
 	QFILE_LIST_ID *list_id = m_query_entry->list_id;
 	for (int i = 0; i < list_id->type_list.type_cnt; i++)
 	  {

--- a/src/sp/pl_session.cpp
+++ b/src/sp/pl_session.cpp
@@ -80,6 +80,7 @@ namespace cubpl
     , m_all_session_params_required {true}
   {
     m_exec_stack.reserve (METHOD_MAX_RECURSION_DEPTH + 1);
+    er_log_debug (ARG_FILE_LINE, "pl_session (create): %d\n", m_id);
   }
 
   session::~session ()


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26214>

### Purpose

PL/CSQL 커서가 열린 상태에서 COMMIT 을 할 때 커서 FETCH에서 cub_server 가 crash 하는 문제 해결. 
COMMIT 을 통해 현재 트랜잭션에 속한 커서의 자원이 해제되는 과정이 문제 유발.

### Implementation

서버사이드 JDBC에서 query prepare 를 할 때 holdable 옵션을 적용함으로서 COMMIT 문이 커서 자원 해제를 하지 않도록 수정

### Remarks

SP 호출에 해당하는 call stack 이 pop 될 때 해당 call stack에 속한 커서가 모두 close 되므로 
holdable cursor로 바뀌어도 stack 이 pop 될 때 관련 자원은 해제된다. 

