### PR TITLE
[CBRD-26199] uncorrelated subquery parallel execution 실행 시, parallelism을 2로 고정

### DIFF
--- a/src/query/parallel/px_heap_scan/px_heap_scan_manager.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_manager.cpp
@@ -526,7 +526,10 @@ scan_open_parallel_heap_scan (THREAD_ENTRY *thread_p, SCAN_ID *scan_id,
 	{
 	  return ret;
 	}
-      thread_p->m_px_orig_thread_entry = thread_p;
+      if (thread_p->m_px_orig_thread_entry == NULL)
+	{
+	  thread_p->m_px_orig_thread_entry = thread_p;
+	}
       scan_id->type = S_PARALLEL_HEAP_SCAN;
       orig_heap_id = db_change_private_heap (thread_p, 0);
       if (result_get_method == parallel_heap_scan::RESULT_GET_METHOD::LIST_PAGE)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26199>

### Purpose

parallel heap scan을 시작하기 전 이미 parallel aptr execution 에서 thread_p->m_px_orig_thread_entry 가 self가 아닌 parent thread로 설정되어 있다가, self를 바라보게 되어 m_qlist_count 관련 core가 발생합니다. 이를 방지합니다.

