### PR TITLE
[CBRD-26226] Core dump in src/executables/server.c:264 during MAX() on varchar

### DIFF
--- a/src/query/query_aggregate.cpp
+++ b/src/query/query_aggregate.cpp
@@ -674,24 +674,7 @@ qdata_evaluate_aggregate_list (cubthread::entry *thread_p, cubxasl::aggregate_li
 	    case PT_MIN:
 	      if (use_desc_index == agg_p->flag.part_key_descending)
 		{
-		  DB_TYPE type = DB_VALUE_DOMAIN_TYPE (&db_values[0]);
-		  pr_clear_value (accumulator->value);
-
-		  if (TP_DOMAIN_TYPE (agg_p->domain) != type)
-		    {
-		      int coerce_error = db_value_coerce (&db_values[0], accumulator->value, agg_p->domain);
-		      if (coerce_error != NO_ERROR)
-			{
-			  /* set error here */
-			  return ER_FAILED;
-			}
-		    }
-		  else
-		    {
-		      pr_clone_value (&db_values[0], accumulator->value);
-		    }
 		  agg_p->is_ended = true;
-		  continue;
 		}
 
 	      break;
@@ -699,24 +682,7 @@ qdata_evaluate_aggregate_list (cubthread::entry *thread_p, cubxasl::aggregate_li
 	    case PT_MAX:
 	      if (use_desc_index != agg_p->flag.part_key_descending)
 		{
-		  DB_TYPE type = DB_VALUE_DOMAIN_TYPE (&db_values[0]);
-		  pr_clear_value (accumulator->value);
-
-		  if (TP_DOMAIN_TYPE (agg_p->domain) != type)
-		    {
-		      int coerce_error = db_value_coerce (&db_values[0], accumulator->value, agg_p->domain);
-		      if (coerce_error != NO_ERROR)
-			{
-			  /* set error here */
-			  return ER_FAILED;
-			}
-		    }
-		  else
-		    {
-		      pr_clone_value (&db_values[0], accumulator->value);
-		    }
 		  agg_p->is_ended = true;
-		  continue;
 		}
 	      break;
 

--- a/src/query/query_aggregate.cpp
+++ b/src/query/query_aggregate.cpp
@@ -674,7 +674,25 @@ qdata_evaluate_aggregate_list (cubthread::entry *thread_p, cubxasl::aggregate_li
 	    case PT_MIN:
 	      if (use_desc_index == agg_p->flag.part_key_descending)
 		{
+		  DB_TYPE type = DB_VALUE_DOMAIN_TYPE (&db_values[0]);
+		  pr_clear_value (accumulator->value);
+
+		  if (TP_DOMAIN_TYPE (agg_p->domain) != type)
+		    {
+		      int coerce_error = db_value_coerce (&db_values[0], accumulator->value, agg_p->domain);
+		      if (coerce_error != NO_ERROR)
+			{
+			  /* set error here */
+			  return ER_FAILED;
+			}
+		    }
+		  else
+		    {
+		      pr_clone_value (&db_values[0], accumulator->value);
+		    }
 		  agg_p->is_ended = true;
+		  pr_clear_value_vector (db_values);
+		  continue;
 		}
 
 	      break;
@@ -682,7 +700,25 @@ qdata_evaluate_aggregate_list (cubthread::entry *thread_p, cubxasl::aggregate_li
 	    case PT_MAX:
 	      if (use_desc_index != agg_p->flag.part_key_descending)
 		{
+		  DB_TYPE type = DB_VALUE_DOMAIN_TYPE (&db_values[0]);
+		  pr_clear_value (accumulator->value);
+
+		  if (TP_DOMAIN_TYPE (agg_p->domain) != type)
+		    {
+		      int coerce_error = db_value_coerce (&db_values[0], accumulator->value, agg_p->domain);
+		      if (coerce_error != NO_ERROR)
+			{
+			  /* set error here */
+			  return ER_FAILED;
+			}
+		    }
+		  else
+		    {
+		      pr_clone_value (&db_values[0], accumulator->value);
+		    }
 		  agg_p->is_ended = true;
+		  pr_clear_value_vector (db_values);
+		  continue;
 		}
 	      break;
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26226>

### Purpose

- 자원 클린 로직이 q_evaluate_aggregate_list 에서 호출되지 않고 skip되는 현상 발생

### Implementation

- 기존 로직을 재사용 하는 선에서 끝나게 변경하였으므로 정상 작동 예상

### Remarks

N/A
