### PR TITLE
[CBRD-26228] Fix buffer overflows in snprintf and strncpy with proper bounds checking

### DIFF
--- a/src/sp/pl_sr_jvm.cpp
+++ b/src/sp/pl_sr_jvm.cpp
@@ -341,9 +341,9 @@ pl_get_create_java_vm_function_ptr ()
 
       // under jdk 11
       if (snprintf (jvm_library_path, PATH_MAX, "%s/%s/%s", java_home, JVM_LIB_PATH, JVM_LIB_FILE) >= PATH_MAX)
-        {
-          return NULL;
-        }
+	{
+	  return NULL;
+	}
       libVM_p = dlopen (jvm_library_path, RTLD_NOW | RTLD_LOCAL);
       if (libVM_p != NULL)
 	{
@@ -357,9 +357,9 @@ pl_get_create_java_vm_function_ptr ()
 
       // from jdk 11
       if (snprintf (jvm_library_path, PATH_MAX, "%s/%s/%s", java_home, JVM_LIB_PATH_JDK11, JVM_LIB_FILE) >= PATH_MAX)
-        {
-          return NULL;
-        }
+	{
+	  return NULL;
+	}
       libVM_p = dlopen (jvm_library_path, RTLD_NOW | RTLD_LOCAL);
       if (libVM_p != NULL)
 	{

--- a/src/sp/pl_sr_jvm.cpp
+++ b/src/sp/pl_sr_jvm.cpp
@@ -340,7 +340,10 @@ pl_get_create_java_vm_function_ptr ()
       err_msgs.append ("\n\tFailed to load libjvm from 'CUBRID_JAVA_HOME' environment variable: ");
 
       // under jdk 11
-      snprintf (jvm_library_path, PATH_MAX - 1, "%s/%s/%s", java_home, JVM_LIB_PATH, JVM_LIB_FILE);
+      if (snprintf (jvm_library_path, PATH_MAX, "%s/%s/%s", java_home, JVM_LIB_PATH, JVM_LIB_FILE) >= PATH_MAX)
+        {
+          return NULL;
+        }
       libVM_p = dlopen (jvm_library_path, RTLD_NOW | RTLD_LOCAL);
       if (libVM_p != NULL)
 	{
@@ -353,7 +356,10 @@ pl_get_create_java_vm_function_ptr ()
 	}
 
       // from jdk 11
-      snprintf (jvm_library_path, PATH_MAX - 1, "%s/%s/%s", java_home, JVM_LIB_PATH_JDK11, JVM_LIB_FILE);
+      if (snprintf (jvm_library_path, PATH_MAX, "%s/%s/%s", java_home, JVM_LIB_PATH_JDK11, JVM_LIB_FILE) >= PATH_MAX)
+        {
+          return NULL;
+        }
       libVM_p = dlopen (jvm_library_path, RTLD_NOW | RTLD_LOCAL);
       if (libVM_p != NULL)
 	{

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -9049,7 +9049,10 @@ fileio_read_restore (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session_p,
 			  /* Probably a tape device, let user mount new one */
 			  if (next_vol_p != NULL)
 			    {
-			      strncpy (session_p->bkup.name, next_vol_p, PATH_MAX - 1);
+			      if (snprintf (session_p->bkup.name, PATH_MAX, "%s", next_vol_p) >= PATH_MAX)
+				{
+				  return ER_FAILED;
+				}
 			    }
 			  if (fileio_find_restore_volume (thread_p, session_p->bkup.bkuphdr->db_fullname,
 							  session_p->bkup.name, session_p->bkup.bkuphdr->unit_num + 1,
@@ -9061,7 +9064,10 @@ fileio_read_restore (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session_p,
 			}
 		      else
 			{
-			  strncpy (session_p->bkup.name, next_vol_p, PATH_MAX - 1);
+			  if (snprintf (session_p->bkup.name, PATH_MAX, "%s", next_vol_p) >= PATH_MAX)
+			    {
+			      return ER_FAILED;
+			    }
 			}
 
 		      /* Reset session count, etc */
@@ -10969,7 +10975,10 @@ fileio_add_volume_to_backup_info (const char *name_p, FILEIO_BACKUP_LEVEL level,
 	}
     }
 
-  strncpy (node_p->bkvol_name, name_p, PATH_MAX - 1);
+  if (snprintf (node_p->bkvol_name, PATH_MAX, "%s", name_p) >= PATH_MAX)
+    {
+      return ER_FAILED;
+    }
   node_p->unit_num = unit_num;
 
   /* Put it on the queue for that level */

--- a/src/transaction/log_applier_sql_log.c
+++ b/src/transaction/log_applier_sql_log.c
@@ -707,7 +707,8 @@ sl_create_sql_log_dir (const char *repl_log_path, char *path_buf, int path_buf_s
       log_path = repl_log_path;
     }
 
-  if (snprintf (path_buf, path_buf_size, "%s%s%s", log_path, FILEIO_PATH_SEPARATOR (log_path), path_base_name) >= path_buf_size)
+  int n = snprintf (path_buf, path_buf_size, "%s%s%s", log_path, FILEIO_PATH_SEPARATOR (log_path), path_base_name);
+  if (n >= path_buf_size)
     {
       snprintf (er_msg, sizeof (er_msg), "Too long the SQL log path \'%s\'", log_path);
 

--- a/src/transaction/log_applier_sql_log.c
+++ b/src/transaction/log_applier_sql_log.c
@@ -707,9 +707,9 @@ sl_create_sql_log_dir (const char *repl_log_path, char *path_buf, int path_buf_s
       log_path = repl_log_path;
     }
 
-  if (strlen (log_path) + 1 + strlen (path_base_name) >= (size_t) path_buf_size)
+  if (snprintf (path_buf, path_buf_size, "%s%s%s", log_path, FILEIO_PATH_SEPARATOR (log_path), path_base_name) >= path_buf_size)
     {
-      snprintf (er_msg, sizeof (er_msg), "Too long the SQL log path \'%s\'", path_buf);
+      snprintf (er_msg, sizeof (er_msg), "Too long the SQL log path \'%s\'", log_path);
 
       er_stack_push ();
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HA_GENERIC_ERROR, 1, er_msg);
@@ -717,8 +717,6 @@ sl_create_sql_log_dir (const char *repl_log_path, char *path_buf, int path_buf_s
 
       return ER_FAILED;
     }
-
-  snprintf (path_buf, path_buf_size, "%s%s%s", log_path, FILEIO_PATH_SEPARATOR (log_path), path_base_name);
 
   p = path_buf;
   if (*p == PATH_SEPARATOR)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26228

### Purpose

This PR replaces potentially unsafe `snprintf `and `strncpy` calls with safer patterns by explicitly checking return values against buffer sizes. This eliminates compile-time warnings related to buffer overflows and ensures safe string handling

### Implementation

- src/transaction/log_applier_sql_log.c: for `path_buf`, checks the log_path by using `snprintf`; removes the logic for length check.
- src/storage/file_io.c: checks for `session_p->bkup.name` and `node_p->bkvol_name`
- src/sp/pl_sr_jvm.cpp: JVM library path construction logic

### Remarks

N/A
