### PR TITLE
[CBRD-26238] Exclude jdbc/release directory from install output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -807,6 +807,7 @@ if(WITH_JDBC AND EXISTS ${CMAKE_SOURCE_DIR}/cubrid-jdbc/src)
     PATTERN "cmake" EXCLUDE
     PATTERN "src" EXCLUDE
     PATTERN "output" EXCLUDE
+    PATTERN "release" EXCLUDE
   )
 endif()
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26238>

### Purpose
`$CUBRID/jdbc` 설치 결과물에 `release/` 빈 디렉터리가 포함되는 문제를 해결합니다.

### Implementation
기존 JDBC의 디렉터리 제외 방법과 동일한 방식으로 `release/` 디렉터리가 복사되지 않도록 수정합니다.

### Remarks
N/A
