### PR TITLE
[CBRD-25097] fix warning: use &s to avoid unnecessary string copying

### DIFF
--- a/src/method/method_callback.cpp
+++ b/src/method/method_callback.cpp
@@ -527,7 +527,7 @@ namespace cubmethod
     int error = NO_ERROR;
 
     std::vector<sql_semantics> semantics_vec;
-    for (const std::string s : request.sqls)
+    for (const std::string &s : request.sqls)
       {
 	i++;
 	query_handler *handler = new_query_handler ();


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-25097>

### Purpose

method_callback.cpp에서 request.sqls를 순회할 때 불필요한 문자열 복사가 발생하던 문제를 수정하였습니다.
기존에는 const std::string s로 값 복사가 이루어져 Clang에서 경고가 발생했으며, 참조(const std::string &)로 변경하여 복사를 방지합니다.

```
warning: loop variable 's' of type 'const std::string' (aka 'const basic_string<char>') 
creates a copy from type 'const std::string' [-Wrange-loop-analysis]
note: use reference type 'const std::string &' to prevent copying
```

### Implementation

다음과 같이 수정하였습니다:

```cpp
// Before
for (const std::string s : request.sqls)

// After
for (const std::string &s : request.sqls)
```

참조를 사용함으로써 불필요한 복사가 제거되고 메모리 사용 및 실행 효율이 향상됩니다.

### Remarks

N/A
