### PR TITLE
[CBRD-26233] Prevent buffer overflow in error logging (snprintf)

### DIFF
--- a/src/base/error_manager.c
+++ b/src/base/error_manager.c
@@ -1690,8 +1690,16 @@ er_log (int err_id)
   else
     {
       gettimeofday (&tv, NULL);
-      snprintf (time_array + strftime (time_array, 128, "%m/%d/%y %H:%M:%S", er_tm_p), 127, ".%03ld",
-		tv.tv_usec / 1000);
+
+      size_t bufsize = sizeof (time_array);
+      size_t len = strftime (time_array, bufsize, "%m/%d/%y %H:%M:%S", er_tm_p);
+
+      if (len > 0 && len < bufsize)
+	{
+	  // space left includes the null terminator, snprintf will overwrite it safely
+	  int remaining = (int) (bufsize - len);
+	  snprintf (time_array + len, remaining, ".%03ld", tv.tv_usec / 1000);
+	}
     }
 
   more_info_p = (char *) "";
@@ -2050,8 +2058,16 @@ _er_log_debug_internal (const char *file_name, const int line_no, const char *fm
   else
     {
       gettimeofday (&tv, NULL);
-      snprintf (time_array + strftime (time_array, 128, "%m/%d/%y %H:%M:%S", er_tm_p), 127, ".%03ld",
-		tv.tv_usec / 1000);
+
+      size_t bufsize = sizeof (time_array);
+      size_t len = strftime (time_array, bufsize, "%m/%d/%y %H:%M:%S", er_tm_p);
+
+      if (len > 0 && len < bufsize)
+	{
+	  // space left includes the null terminator, snprintf will overwrite it safely
+	  int remaining = (int) (bufsize - len);
+	  snprintf (time_array + len, remaining, ".%03ld", tv.tv_usec / 1000);
+	}
     }
 
   fprintf (out, er_Cached_msg[ER_LOG_DEBUG_NOTIFY], time_array, file_name, line_no);

--- a/src/base/error_manager.c
+++ b/src/base/error_manager.c
@@ -1690,7 +1690,7 @@ er_log (int err_id)
   else
     {
       gettimeofday (&tv, NULL);
-      snprintf (time_array + strftime (time_array, 128, "%m/%d/%y %H:%M:%S", er_tm_p), 255, ".%03ld",
+      snprintf (time_array + strftime (time_array, 128, "%m/%d/%y %H:%M:%S", er_tm_p), 127, ".%03ld",
 		tv.tv_usec / 1000);
     }
 
@@ -2050,7 +2050,7 @@ _er_log_debug_internal (const char *file_name, const int line_no, const char *fm
   else
     {
       gettimeofday (&tv, NULL);
-      snprintf (time_array + strftime (time_array, 128, "%m/%d/%y %H:%M:%S", er_tm_p), 255, ".%03ld",
+      snprintf (time_array + strftime (time_array, 128, "%m/%d/%y %H:%M:%S", er_tm_p), 127, ".%03ld",
 		tv.tv_usec / 1000);
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26233

## Purpose

`error_manager.c`의 `er_log` 함수에서 발생하는 `snprintf` 인자 오류로 인해 **버퍼 오버플로우**가 발생하는 문제를 수정합니다.
Ubuntu 24.04에서 `_FORTIFY_SOURCE=3` 강화된 보안 검증에 따라 런타임 시점에서 감지되며, CUBRID 서버 실행이 중단되는 현상을 방지하기 위함입니다.

---

## Implementation

* `snprintf` 호출 시, 남은 버퍼 크기를 고려하여 크기 인자를 정확히 계산하도록 수정

  ```cpp
  gettimeofday(&tv, NULL);
  snprintf(time_array + strftime(time_array, 128, "%m/%d/%y %H:%M:%S", er_tm_p),
           127, ".%03ld", tv.tv_usec / 1000);
  ```
* 기존에는 최대 255바이트를 잘못 전달하여, 실제 남은 공간(약 128바이트)을 초과할 수 있었음
* 이로 인해 glibc의 보안 보호 메커니즘이 동작하며 프로세스가 종료되던 문제를 제거

---

## Remarks

* Ubuntu 24.04 환경에서 `demodb` 실행 시 재현 가능
    * Ubuntu 환경은 CUBVEC Benchmark SIMD native build 도커 환경을 위해 필요
* `_FORTIFY_SOURCE=3` 환경에서 강화된 런타임 검사에 대응
