### PR TITLE
[CBRD-26245] Fix filteredkeys always reported as 0 in TRACE statistics

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -25390,6 +25390,9 @@ btree_range_scan_advance_over_filtered_keys (THREAD_ENTRY * thread_p, BTREE_SCAN
 	      ASSERT_ERROR ();
 	      return error_code;
 	    }
+
+	  bts->read_keys++;
+
 	  error_code =
 	    btree_apply_key_range_and_filter (thread_p, bts, BTS_IS_INDEX_ISS (bts), &is_range_satisfied,
 					      &is_filter_satisfied);
@@ -25410,7 +25413,7 @@ btree_range_scan_advance_over_filtered_keys (THREAD_ENTRY * thread_p, BTREE_SCAN
 	  if (is_filter_satisfied)
 	    {
 	      /* Filter is satisfied, which means key can be used. */
-	      bts->read_keys++;
+	      bts->qualified_keys++;
 	      bts->key_status = BTS_KEY_IS_VERIFIED;
 	      return NO_ERROR;
 	    }
@@ -25423,6 +25426,10 @@ btree_range_scan_advance_over_filtered_keys (THREAD_ENTRY * thread_p, BTREE_SCAN
 	  /* Safe guard: Fence keys can be only first or last keys in page, but never first or last in entire index. */
 	  assert ((bts->slot_id == 1 && !VPID_ISNULL (&node_header->prev_vpid))
 		  || (bts->slot_id == key_count && !VPID_ISNULL (&node_header->next_vpid)));
+
+	  /* Increment read_keys for fence keys */
+	  bts->read_keys++;
+
 	  /* Fall through. */
 
 	  /* TODO: Get key info should be able to obtain fences too. */

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -25426,10 +25426,6 @@ btree_range_scan_advance_over_filtered_keys (THREAD_ENTRY * thread_p, BTREE_SCAN
 	  /* Safe guard: Fence keys can be only first or last keys in page, but never first or last in entire index. */
 	  assert ((bts->slot_id == 1 && !VPID_ISNULL (&node_header->prev_vpid))
 		  || (bts->slot_id == key_count && !VPID_ISNULL (&node_header->next_vpid)));
-
-	  /* Increment read_keys for fence keys */
-	  bts->read_keys++;
-
 	  /* Fall through. */
 
 	  /* TODO: Get key info should be able to obtain fences too. */


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26245>

### Purpose

TRACE 통계에서 filteredkeys가 항상 0으로 나오고, readkeys에 filteredkeys 값이 출력되는 현상 해결

### Implementation

- readkeys로 출력되던 filteredkeys의 값이 올바르게 출력되도록 수정
- 누락되어 있던 readkeys 값 계산 단계 추가

### Remarks

N/A