### PR TITLE
[CUBVEC-122] Support session variables for vector index

### DIFF
--- a/src/object/object_domain.h
+++ b/src/object/object_domain.h
@@ -293,6 +293,9 @@ typedef enum tp_match
   (((typeid) == DB_TYPE_INTEGER) || ((typeid) == DB_TYPE_SMALLINT) \
    || ((typeid) == DB_TYPE_BIGINT))
 
+#define TP_IS_VECTOR_TYPE(typeid) \
+  (((typeid) == DB_TYPE_VECTOR))
+
 /*
  * Precision for non-parameterized predefined types
  *

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -10533,6 +10533,24 @@ qo_validate_index_for_vector_index (QO_ENV * env, QO_NODE_INDEX_ENTRY * ni_entry
 	goto end;
       }
 
+    /* session variable */
+    if (arg1->node_type == PT_EXPR && arg1->info.expr.op == PT_CAST)
+      {
+	arg1 = arg1->info.expr.arg1;
+	if (arg1->node_type == PT_EXPR && arg1->info.expr.op == PT_EVALUATE_VARIABLE)
+	  {
+	    arg1 = arg1->info.expr.arg1;
+	  }
+      }
+    if (arg2->node_type == PT_EXPR && arg2->info.expr.op == PT_CAST)
+      {
+	arg2 = arg2->info.expr.arg1;
+	if (arg2->node_type == PT_EXPR && arg2->info.expr.op == PT_EVALUATE_VARIABLE)
+	  {
+	    arg2 = arg2->info.expr.arg1;
+	  }
+      }
+
     if (arg1->node_type == PT_NAME && PT_IS_CONST (arg2))
       {
 	// ok

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -12006,7 +12006,7 @@ pt_to_vector_index_info (PARSER_CONTEXT * parser, DB_OBJECT * class_, PRED_EXPR 
 	      {
 		vector_query = arg_list->next;
 	      }
-	    else if (arg_list->node_type == PT_VALUE)
+	    else if (PT_IS_CONST (arg_list) || pt_is_pseudo_const (arg_list))
 	      {
 		vector_query = arg_list;
 	      }
@@ -12016,15 +12016,15 @@ pt_to_vector_index_info (PARSER_CONTEXT * parser, DB_OBJECT * class_, PRED_EXPR 
 	    PT_NODE *arg1 = node->info.expr.arg1;
 	    PT_NODE *arg2 = node->info.expr.arg2;
 
-	    assert ((arg1->node_type == PT_NAME && PT_IS_CONST (arg2))
-		    || (arg2->node_type == PT_NAME && PT_IS_CONST (arg1)));
+	    assert ((arg1->node_type == PT_NAME && (pt_is_pseudo_const (arg2) || PT_IS_CONST (arg2)))
+		    || (arg2->node_type == PT_NAME && (pt_is_pseudo_const (arg1) || PT_IS_CONST (arg1))));
 
 	    // TODO (CUBVEC): imporve the following logic
 	    if (arg1->node_type == PT_NAME)
 	      {
 		vector_query = arg2;
 	      }
-	    else if (PT_IS_CONST (arg1))
+	    else if (PT_IS_CONST (arg1) || pt_is_pseudo_const (arg1))
 	      {
 		vector_query = arg1;
 	      }

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -3717,27 +3717,11 @@ scan_open_vector_index_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
   visid->rest_regu_list = regu_list_rest;
   /* index scan info */
 
-  KEY_INFO *key_infop = &indx_info->key_info;
-  KEY_RANGE *key_ranges = key_infop->key_ranges;
-
   assert (key_ranges[0].range == K_NN);
-
-  if (fetch_peek_dbval (thread_p, key_ranges[0].key1, vd, NULL, NULL, NULL, &visid->query_dbvalue) != NO_ERROR)
-    {
-      goto exit_on_error;
-    }
-  if (fetch_peek_dbval (thread_p, key_ranges[0].key2, vd, NULL, NULL, NULL, &visid->k_dbvalue) != NO_ERROR)
-    {
-      goto exit_on_error;
-    }
 
   visid->hnsw_id = indx_info->btid.root_pageid;
 
   return NO_ERROR;
-
-exit_on_error:
-
-  return ER_FAILED;
 }
 
 /*
@@ -4892,6 +4876,16 @@ scan_end_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 	{
 	  (void) heap_scancache_end (thread_p, &visidp->scan_cache);
 	}
+#if 0
+      if (visidp->query_dbvalue)
+	{
+	  pr_clear_value (visidp->query_dbvalue);
+	}
+      if (visidp->k_dbvalue)
+	{
+	  pr_clear_value (visidp->k_dbvalue);
+	}
+#endif
       break;
 
     case S_INDX_SCAN:
@@ -6374,6 +6368,24 @@ scan_next_vector_index_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 
   if (visid->oidp == NULL)
     {
+      KEY_INFO *key_infop = &visid->indx_info->key_info;
+      KEY_RANGE *key_ranges = key_infop->key_ranges;
+
+      if (key_ranges[0].key1 == NULL || key_ranges[0].key2 == NULL)
+	{
+	  return S_ERROR;
+	}
+
+      if (fetch_peek_dbval (thread_p, key_ranges[0].key1, scan_id->vd, NULL, NULL, NULL, &visid->query_dbvalue) !=
+	  NO_ERROR)
+	{
+	  return S_ERROR;
+	}
+      if (fetch_peek_dbval (thread_p, key_ranges[0].key2, scan_id->vd, NULL, NULL, NULL, &visid->k_dbvalue) != NO_ERROR)
+	{
+	  return S_ERROR;
+	}
+
       if (visid->k_dbvalue == NULL || visid->query_dbvalue == NULL)
 	{
 	  return S_END;

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -4876,16 +4876,6 @@ scan_end_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 	{
 	  (void) heap_scancache_end (thread_p, &visidp->scan_cache);
 	}
-#if 0
-      if (visidp->query_dbvalue)
-	{
-	  pr_clear_value (visidp->query_dbvalue);
-	}
-      if (visidp->k_dbvalue)
-	{
-	  pr_clear_value (visidp->k_dbvalue);
-	}
-#endif
       break;
 
     case S_INDX_SCAN:

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -3722,14 +3722,22 @@ scan_open_vector_index_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
 
   assert (key_ranges[0].range == K_NN);
 
-  fetch_peek_dbval (thread_p, key_ranges[0].key1, vd, NULL, NULL, NULL, &visid->query_dbvalue);
-  fetch_peek_dbval (thread_p, key_ranges[0].key2, vd, NULL, NULL, NULL, &visid->k_dbvalue);
+  if (fetch_peek_dbval (thread_p, key_ranges[0].key1, vd, NULL, NULL, NULL, &visid->query_dbvalue) != NO_ERROR)
+    {
+      goto exit_on_error;
+    }
+  if (fetch_peek_dbval (thread_p, key_ranges[0].key2, vd, NULL, NULL, NULL, &visid->k_dbvalue) != NO_ERROR)
+    {
+      goto exit_on_error;
+    }
 
   visid->hnsw_id = indx_info->btid.root_pageid;
 
+  return NO_ERROR;
+
 exit_on_error:
 
-  return NO_ERROR;
+  return ER_FAILED;
 }
 
 /*
@@ -6366,6 +6374,11 @@ scan_next_vector_index_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 
   if (visid->oidp == NULL)
     {
+      if (visid->k_dbvalue == NULL || visid->query_dbvalue == NULL)
+	{
+	  return S_END;
+	}
+
       int k = db_get_int (visid->k_dbvalue);
       if (k > 0)
 	{

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -1227,7 +1227,7 @@ db_value_alloc_and_copy (const DB_VALUE * src)
       return dest;
     }
 
-  if (TP_IS_NUMERIC_TYPE (src_dbtype))
+  if (TP_IS_NUMERIC_TYPE (src_dbtype) || TP_IS_VECTOR_TYPE (src_dbtype))
     {
       pr_clone_value ((DB_VALUE *) src, dest);
       return dest;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-122

### Purpose

- session variable로 쿼리 조건 사용 시 벡터 인덱스 사용 가능하도록 수정
- session variable 초기화 여부에 따라 서버 segfault 발생할 수 있는 부분 수정
- session variable이 ANN 쿼리의 조건으로 사용되었을 때 segfault 발생할 수 있는 부분 수정

### Implementation

- query planner에서 session variable 관련 조건 추가
- scan manager에서 쿼리 조건 regu var를 fetch 할 때 성공 여부 확인
- query_executor에서 index info의 조건들이 올바르게 제거되도록 수정

### Remarks

N/A
