### PR TITLE
[CBRD-26240] Core dump occurs when using like_match_upper_bound(empty-string) in a query

### DIFF
--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -10426,6 +10426,7 @@ mr_setval_string (DB_VALUE * dest, const DB_VALUE * src, bool copy)
       error = db_value_domain_init (dest, DB_TYPE_VARCHAR, db_value_precision (src), 0);
       if (src->data.ch.info.is_max_string)
 	{
+	  dest->data.ch.info.style = MEDIUM_STRING;
 	  dest->data.ch.info.is_max_string = true;
 	  dest->domain.general_info.is_null = 0;
 	  dest->domain.char_info.collation_id = db_get_string_collation (src);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26240>

### Purpose

아래의 쿼리를 실행했을 때, assert에 의한 core dump 발생을 해결
select like_match_upper_bound('') from dual;

### Implementation

스트링 값을 세팅하는 setval의 연결 함수인 mr_setval_string에서 누락된 info.style = MEDIUM_STRING 코드를 추가

### Remarks

레거시 버그로 10.2 ~ 11.4에 이르기 까지 체크하여 반영할 필요가 있음.
DB_VALUE에서 string 타입의 경우, 현재 사용하지 않는 SMALL_STRING과 LARGE_STRING을 제거하여 union을 단순화할 필요가 있음.
