### PR TITLE
[CBRD-26283] shorten the string stored in _db_stored_procedure.target_method when it exeeds column length 1024

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/TargetMethod.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/TargetMethod.java
@@ -205,8 +205,12 @@ public class TargetMethod {
         argClassMap.put("[LTimestamp;", Timestamp[].class);
         argClassMap.put("[LCUBRIDOID;", CUBRIDOID[].class);
 
+        // why not add other array-array types? TODO
         argClassMap.put("[[Ljava.lang.Integer;", Integer[][].class);
         argClassMap.put("[[Ljava.lang.Float;", Float[][].class);
+
+        argClassMap.put("[[LInteger;", Integer[][].class);
+        argClassMap.put("[[LFloat;", Float[][].class);
     }
 
     private static void initdescriptorMap() {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/TargetMethod.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/TargetMethod.java
@@ -165,6 +165,12 @@ public class TargetMethod {
         argClassMap.put("java.sql.Timestamp", Timestamp.class);
         argClassMap.put("cubrid.sql.CUBRIDOID", CUBRIDOID.class);
 
+        argClassMap.put("BigDecimal", BigDecimal.class);
+        argClassMap.put("Date", Date.class);
+        argClassMap.put("Time", Time.class);
+        argClassMap.put("Timestamp", Timestamp.class);
+        argClassMap.put("CUBRIDOID", CUBRIDOID.class);
+
         argClassMap.put("[Ljava.lang.Boolean;", Boolean[].class);
         argClassMap.put("[Ljava.lang.Byte;", Byte[].class);
         argClassMap.put("[Ljava.lang.Character;", Character[].class);
@@ -193,8 +199,45 @@ public class TargetMethod {
         argClassMap.put("[Ljava.sql.Timestamp;", Timestamp[].class);
         argClassMap.put("[Lcubrid.sql.CUBRIDOID;", CUBRIDOID[].class);
 
+        argClassMap.put("[LBigDecimal;", BigDecimal[].class);
+        argClassMap.put("[LDate;", Date[].class);
+        argClassMap.put("[LTime;", Time[].class);
+        argClassMap.put("[LTimestamp;", Timestamp[].class);
+        argClassMap.put("[LCUBRIDOID;", CUBRIDOID[].class);
+
+        argClassMap.put("[[Ljava.lang.Boolean;", Boolean[][].class);
+        argClassMap.put("[[Ljava.lang.Byte;", Byte[][].class);
+        argClassMap.put("[[Ljava.lang.Character;", Character[][].class);
+        argClassMap.put("[[Ljava.lang.Short;", Short[][].class);
         argClassMap.put("[[Ljava.lang.Integer;", Integer[][].class);
+        argClassMap.put("[[Ljava.lang.Long;", Long[][].class);
         argClassMap.put("[[Ljava.lang.Float;", Float[][].class);
+        argClassMap.put("[[Ljava.lang.Double;", Double[][].class);
+        argClassMap.put("[[Ljava.lang.String;", String[][].class);
+        argClassMap.put("[[Ljava.lang.Object;", Object[][].class);
+
+        argClassMap.put("[[LBoolean;", Boolean[][].class);
+        argClassMap.put("[[LByte;", Byte[][].class);
+        argClassMap.put("[[LCharacter;", Character[][].class);
+        argClassMap.put("[[LShort;", Short[][].class);
+        argClassMap.put("[[LInteger;", Integer[][].class);
+        argClassMap.put("[[LLong;", Long[][].class);
+        argClassMap.put("[[LFloat;", Float[][].class);
+        argClassMap.put("[[LDouble;", Double[][].class);
+        argClassMap.put("[[LString;", String[][].class);
+        argClassMap.put("[[LObject;", Object[][].class);
+
+        argClassMap.put("[[Ljava.math.BigDecimal;", BigDecimal[][].class);
+        argClassMap.put("[[Ljava.sql.Date;", Date[][].class);
+        argClassMap.put("[[Ljava.sql.Time;", Time[][].class);
+        argClassMap.put("[[Ljava.sql.Timestamp;", Timestamp[][].class);
+        argClassMap.put("[[Lcubrid.sql.CUBRIDOID;", CUBRIDOID[][].class);
+
+        argClassMap.put("[[LBigDecimal;", BigDecimal[][].class);
+        argClassMap.put("[[LDate;", Date[][].class);
+        argClassMap.put("[[LTime;", Time[][].class);
+        argClassMap.put("[[LTimestamp;", Timestamp[][].class);
+        argClassMap.put("[[LCUBRIDOID;", CUBRIDOID[][].class);
     }
 
     private static void initdescriptorMap() {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/TargetMethod.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/TargetMethod.java
@@ -205,39 +205,8 @@ public class TargetMethod {
         argClassMap.put("[LTimestamp;", Timestamp[].class);
         argClassMap.put("[LCUBRIDOID;", CUBRIDOID[].class);
 
-        argClassMap.put("[[Ljava.lang.Boolean;", Boolean[][].class);
-        argClassMap.put("[[Ljava.lang.Byte;", Byte[][].class);
-        argClassMap.put("[[Ljava.lang.Character;", Character[][].class);
-        argClassMap.put("[[Ljava.lang.Short;", Short[][].class);
         argClassMap.put("[[Ljava.lang.Integer;", Integer[][].class);
-        argClassMap.put("[[Ljava.lang.Long;", Long[][].class);
         argClassMap.put("[[Ljava.lang.Float;", Float[][].class);
-        argClassMap.put("[[Ljava.lang.Double;", Double[][].class);
-        argClassMap.put("[[Ljava.lang.String;", String[][].class);
-        argClassMap.put("[[Ljava.lang.Object;", Object[][].class);
-
-        argClassMap.put("[[LBoolean;", Boolean[][].class);
-        argClassMap.put("[[LByte;", Byte[][].class);
-        argClassMap.put("[[LCharacter;", Character[][].class);
-        argClassMap.put("[[LShort;", Short[][].class);
-        argClassMap.put("[[LInteger;", Integer[][].class);
-        argClassMap.put("[[LLong;", Long[][].class);
-        argClassMap.put("[[LFloat;", Float[][].class);
-        argClassMap.put("[[LDouble;", Double[][].class);
-        argClassMap.put("[[LString;", String[][].class);
-        argClassMap.put("[[LObject;", Object[][].class);
-
-        argClassMap.put("[[Ljava.math.BigDecimal;", BigDecimal[][].class);
-        argClassMap.put("[[Ljava.sql.Date;", Date[][].class);
-        argClassMap.put("[[Ljava.sql.Time;", Time[][].class);
-        argClassMap.put("[[Ljava.sql.Timestamp;", Timestamp[][].class);
-        argClassMap.put("[[Lcubrid.sql.CUBRIDOID;", CUBRIDOID[][].class);
-
-        argClassMap.put("[[LBigDecimal;", BigDecimal[][].class);
-        argClassMap.put("[[LDate;", Date[][].class);
-        argClassMap.put("[[LTime;", Time[][].class);
-        argClassMap.put("[[LTimestamp;", Timestamp[][].class);
-        argClassMap.put("[[LCUBRIDOID;", CUBRIDOID[][].class);
     }
 
     private static void initdescriptorMap() {

--- a/src/object/schema_system_catalog_constants.h
+++ b/src/object/schema_system_catalog_constants.h
@@ -92,4 +92,6 @@
 #define CT_DBCHARSET_DEFAULT_COLLATION	  "default_collation"
 #define CT_DBCHARSET_CHAR_SIZE		  "char_size"
 
+#define SP_ATTR_TARGET_METHOD_LEN       (1024)
+
 #endif /* _SCHEMA_SYSTEM_CATALOG_CONSTANTS_H_ */

--- a/src/object/schema_system_catalog_install.cpp
+++ b/src/object/schema_system_catalog_install.cpp
@@ -845,7 +845,7 @@ namespace cubschema
       {"is_system_generated", "integer"},
       {"directive", "integer"},
       {"target_class", format_varchar (1024)},
-      {"target_method", format_varchar (1024)},
+      {"target_method", format_varchar (SP_ATTR_TARGET_METHOD_LEN)},
       {"owner", AU_USER_CLASS_NAME},
       {"comment", format_varchar (1024)}
     },

--- a/src/sp/sp_catalog.cpp
+++ b/src/sp/sp_catalog.cpp
@@ -1001,37 +1001,16 @@ sp_split_target_signature (const std::string &s, std::string &target_cls, std::s
     {
       // shorten target_mth by erasing package name prefixes in parameter types
 
-      std::regex RE_COMMA_JAVA_LANG (",java\\.lang\\.");
-      std::regex RE_PAREN_JAVA_LANG ("\\(java\\.lang\\.");
-
-      std::regex RE_COMMA_JAVA_MATH (",java\\.math\\.");
-      std::regex RE_PAREN_JAVA_MATH ("\\(java\\.math\\.");
-
-      std::regex RE_COMMA_JAVA_SQL (",java\\.sql\\.");
-      std::regex RE_PAREN_JAVA_SQL ("\\(java\\.sql\\.");
-
-      std::regex RE_COMMA_CUBRID_SQL (",cubrid\\.sql\\.");
-      std::regex RE_PAREN_CUBRID_SQL ("\\(cubrid\\.sql\\.");
+      std::regex RE_COMMA_PACKAGE (",(java\\.lang|java\\.math|java\\.sql|cubrid\\.sql)\\.");
+      std::regex RE_PAREN_PACKAGE ("\\((java\\.lang|java\\.math|java\\.sql|cubrid\\.sql)\\.");
 
       // param types: from '(' to ')' : parameter types
       std::string param_types = s.substr (pos_lparen, pos_rparen + 1 - pos_lparen);
+
+      // get shorter target_mth by erasing the package name at the start of type names
       param_types = std::regex_replace (param_types, RE_SPACES, ""); // remove spaces
-
-      // get shorter target_mth by erasing "java.lang." at the start of the type name
-      param_types = std::regex_replace (param_types, RE_COMMA_JAVA_LANG, ",");
-      param_types = std::regex_replace (param_types, RE_PAREN_JAVA_LANG, "(");
-
-      // erasing "java.math." in java.math.BigDecimal
-      param_types = std::regex_replace (param_types, RE_COMMA_JAVA_MATH, ",");
-      param_types = std::regex_replace (param_types, RE_PAREN_JAVA_MATH, "(");
-
-      // erasing "java.sql." in java.sql.{Date, Time, Timestamp}
-      param_types = std::regex_replace (param_types, RE_COMMA_JAVA_SQL, ",");
-      param_types = std::regex_replace (param_types, RE_PAREN_JAVA_SQL, "(");
-
-      // erasing "cubrid.sql." in cubrid.sql.CUBRIDOID
-      param_types = std::regex_replace (param_types, RE_COMMA_CUBRID_SQL, ",");
-      param_types = std::regex_replace (param_types, RE_PAREN_CUBRID_SQL, "(");
+      param_types = std::regex_replace (param_types, RE_COMMA_PACKAGE, ",");
+      param_types = std::regex_replace (param_types, RE_PAREN_PACKAGE, "(");
 
       size_t pos_return = s.find ("return", pos_rparen);
       if (pos_return == std::string::npos)
@@ -1040,18 +1019,11 @@ sp_split_target_signature (const std::string &s, std::string &target_cls, std::s
 	}
       else
 	{
-	  std::regex RE_PREFIX_JAVA_LANG ("^java\\.lang\\.");
-	  std::regex RE_PREFIX_JAVA_MATH ("^java\\.math\\.");
-	  std::regex RE_PREFIX_JAVA_SQL ("^java\\.sql\\.");
-	  std::regex RE_PREFIX_CUBRID_SQL ("^cubrid\\.sql\\.");
+	  std::regex RE_PREFIX_PACKAGE ("^(java\\.lang|java\\.math|java\\.sql|cubrid\\.sql)\\.");
 
 	  std::string ret_type = s.substr (pos_return + 6);   // 6: length of "return"
 	  ret_type = std::regex_replace (ret_type, RE_SPACES, "");
-
-	  ret_type = std::regex_replace (ret_type, RE_PREFIX_JAVA_LANG, "");
-	  ret_type = std::regex_replace (ret_type, RE_PREFIX_JAVA_MATH, "");
-	  ret_type = std::regex_replace (ret_type, RE_PREFIX_JAVA_SQL, "");
-	  ret_type = std::regex_replace (ret_type, RE_PREFIX_CUBRID_SQL, "");
+	  ret_type = std::regex_replace (ret_type, RE_PREFIX_PACKAGE, "");
 
 	  target_mth = class_and_mth.substr (pos_dot + 1) + param_types + ret_type;
 	}

--- a/src/sp/sp_catalog.cpp
+++ b/src/sp/sp_catalog.cpp
@@ -970,7 +970,7 @@ void sp_normalize_name (std::string &s)
 void
 sp_split_target_signature (const std::string &s, std::string &target_cls, std::string &target_mth)
 {
-  static std::regex RE_SPACES ("\\s+");
+  std::regex RE_SPACES ("\\s+");
 
   auto pos_lparen = s.find_last_of ('(');
   auto pos_rparen = s.find_last_of (')');
@@ -1001,17 +1001,17 @@ sp_split_target_signature (const std::string &s, std::string &target_cls, std::s
     {
       // shorten target_mth by erasing package name prefixes in parameter types
 
-      static std::regex RE_COMMA_JAVA_LANG (",java\\.lang\\.");
-      static std::regex RE_PAREN_JAVA_LANG ("\\(java\\.lang\\.");
+      std::regex RE_COMMA_JAVA_LANG (",java\\.lang\\.");
+      std::regex RE_PAREN_JAVA_LANG ("\\(java\\.lang\\.");
 
-      static std::regex RE_COMMA_JAVA_MATH (",java\\.math\\.");
-      static std::regex RE_PAREN_JAVA_MATH ("\\(java\\.math\\.");
+      std::regex RE_COMMA_JAVA_MATH (",java\\.math\\.");
+      std::regex RE_PAREN_JAVA_MATH ("\\(java\\.math\\.");
 
-      static std::regex RE_COMMA_JAVA_SQL (",java\\.sql\\.");
-      static std::regex RE_PAREN_JAVA_SQL ("\\(java\\.sql\\.");
+      std::regex RE_COMMA_JAVA_SQL (",java\\.sql\\.");
+      std::regex RE_PAREN_JAVA_SQL ("\\(java\\.sql\\.");
 
-      static std::regex RE_COMMA_CUBRID_SQL (",cubrid\\.sql\\.");
-      static std::regex RE_PAREN_CUBRID_SQL ("\\(cubrid\\.sql\\.");
+      std::regex RE_COMMA_CUBRID_SQL (",cubrid\\.sql\\.");
+      std::regex RE_PAREN_CUBRID_SQL ("\\(cubrid\\.sql\\.");
 
       // param types: from '(' to ')' : parameter types
       std::string param_types = s.substr (pos_lparen, pos_rparen + 1 - pos_lparen);
@@ -1040,10 +1040,10 @@ sp_split_target_signature (const std::string &s, std::string &target_cls, std::s
 	}
       else
 	{
-	  static std::regex RE_PREFIX_JAVA_LANG ("^java\\.lang\\.");
-	  static std::regex RE_PREFIX_JAVA_MATH ("^java\\.math\\.");
-	  static std::regex RE_PREFIX_JAVA_SQL ("^java\\.sql\\.");
-	  static std::regex RE_PREFIX_CUBRID_SQL ("^cubrid\\.sql\\.");
+	  std::regex RE_PREFIX_JAVA_LANG ("^java\\.lang\\.");
+	  std::regex RE_PREFIX_JAVA_MATH ("^java\\.math\\.");
+	  std::regex RE_PREFIX_JAVA_SQL ("^java\\.sql\\.");
+	  std::regex RE_PREFIX_CUBRID_SQL ("^cubrid\\.sql\\.");
 
 	  std::string ret_type = s.substr (pos_return + 6);   // 6: length of "return"
 	  ret_type = std::regex_replace (ret_type, RE_SPACES, "");

--- a/src/sp/sp_catalog.cpp
+++ b/src/sp/sp_catalog.cpp
@@ -36,6 +36,7 @@
 #include "transaction_cl.h"
 #include "schema_manager.h"
 #include "dbtype.h"
+#include "schema_system_catalog_constants.h"    // for SP_ATTR_TARGET_METHOD_LEN
 
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
 #include "memory_wrapper.hpp"
@@ -969,8 +970,11 @@ void sp_normalize_name (std::string &s)
 void
 sp_split_target_signature (const std::string &s, std::string &target_cls, std::string &target_mth)
 {
-  auto pos1 = s.find_last_of ('(');
-  if (pos1 == std::string::npos)
+  static std::regex RE_SPACES ("\\s+");
+
+  auto pos_lparen = s.find_last_of ('(');
+  auto pos_rparen = s.find_last_of (')');
+  if (pos_lparen == std::string::npos || pos_rparen == std::string::npos)
     {
       // handle the case where '(' is not found, if necessary
       target_cls.clear();
@@ -978,12 +982,11 @@ sp_split_target_signature (const std::string &s, std::string &target_cls, std::s
       return;
     }
 
-  std::string tmp = s.substr (0, pos1);
-  tmp.erase (tmp.find_last_not_of (" ") + 1); // rtrim
-  tmp.erase (0, tmp.find_first_not_of (" ")); // ltrim
+  std::string class_and_mth = s.substr (0, pos_lparen);
+  class_and_mth = std::regex_replace (class_and_mth, RE_SPACES, ""); // remove spaces
 
-  auto pos2 = tmp.find_last_of ('.');
-  if (pos2 == std::string::npos)
+  auto pos_dot = class_and_mth.find_last_of ('.');
+  if (pos_dot == std::string::npos)
     {
       // handle the case where '.' is not found, if necessary
       target_cls.clear();
@@ -991,8 +994,68 @@ sp_split_target_signature (const std::string &s, std::string &target_cls, std::s
       return;
     }
 
-  target_cls = tmp.substr (0, pos2);
-  target_mth = tmp.substr (pos2 + 1) + s.substr (pos1); // remove spaces between method and (
+  target_cls = class_and_mth.substr (0, pos_dot);
+  target_mth = class_and_mth.substr (pos_dot + 1) + s.substr (pos_lparen); // remove spaces between method and (
+
+  if (target_mth.length() > SP_ATTR_TARGET_METHOD_LEN)
+    {
+      // shorten target_mth by erasing package name prefixes in parameter types
+
+      static std::regex RE_COMMA_JAVA_LANG (",java\\.lang\\.");
+      static std::regex RE_PAREN_JAVA_LANG ("\\(java\\.lang\\.");
+
+      static std::regex RE_COMMA_JAVA_MATH (",java\\.math\\.");
+      static std::regex RE_PAREN_JAVA_MATH ("\\(java\\.math\\.");
+
+      static std::regex RE_COMMA_JAVA_SQL (",java\\.sql\\.");
+      static std::regex RE_PAREN_JAVA_SQL ("\\(java\\.sql\\.");
+
+      static std::regex RE_COMMA_CUBRID_SQL (",cubrid\\.sql\\.");
+      static std::regex RE_PAREN_CUBRID_SQL ("\\(cubrid\\.sql\\.");
+
+      // param types: from '(' to ')' : parameter types
+      std::string param_types = s.substr (pos_lparen, pos_rparen + 1 - pos_lparen);
+      param_types = std::regex_replace (param_types, RE_SPACES, ""); // remove spaces
+
+      // get shorter target_mth by erasing "java.lang." at the start of the type name
+      param_types = std::regex_replace (param_types, RE_COMMA_JAVA_LANG, ",");
+      param_types = std::regex_replace (param_types, RE_PAREN_JAVA_LANG, "(");
+
+      // erasing "java.math." in java.math.BigDecimal
+      param_types = std::regex_replace (param_types, RE_COMMA_JAVA_MATH, ",");
+      param_types = std::regex_replace (param_types, RE_PAREN_JAVA_MATH, "(");
+
+      // erasing "java.sql." in java.sql.{Date, Time, Timestamp}
+      param_types = std::regex_replace (param_types, RE_COMMA_JAVA_SQL, ",");
+      param_types = std::regex_replace (param_types, RE_PAREN_JAVA_SQL, "(");
+
+      // erasing "cubrid.sql." in cubrid.sql.CUBRIDOID
+      param_types = std::regex_replace (param_types, RE_COMMA_CUBRID_SQL, ",");
+      param_types = std::regex_replace (param_types, RE_PAREN_CUBRID_SQL, "(");
+
+      size_t pos_return = s.find ("return", pos_rparen);
+      if (pos_return == std::string::npos)
+	{
+	  target_mth = class_and_mth.substr (pos_dot + 1) + param_types;
+	}
+      else
+	{
+	  static std::regex RE_PREFIX_JAVA_LANG ("^java\\.lang\\.");
+	  static std::regex RE_PREFIX_JAVA_MATH ("^java\\.math\\.");
+	  static std::regex RE_PREFIX_JAVA_SQL ("^java\\.sql\\.");
+	  static std::regex RE_PREFIX_CUBRID_SQL ("^cubrid\\.sql\\.");
+
+	  std::string ret_type = s.substr (pos_return + 6);   // 6: length of "return"
+	  ret_type = std::regex_replace (ret_type, RE_SPACES, "");
+
+	  ret_type = std::regex_replace (ret_type, RE_PREFIX_JAVA_LANG, "");
+	  ret_type = std::regex_replace (ret_type, RE_PREFIX_JAVA_MATH, "");
+	  ret_type = std::regex_replace (ret_type, RE_PREFIX_JAVA_SQL, "");
+	  ret_type = std::regex_replace (ret_type, RE_PREFIX_CUBRID_SQL, "");
+
+	  target_mth = class_and_mth.substr (pos_dot + 1) + param_types + ret_type;
+	}
+    }
 }
 
 std::string

--- a/src/sp/sp_constants.hpp
+++ b/src/sp/sp_constants.hpp
@@ -55,8 +55,6 @@
 #define SP_ATTR_OBJECT_TYPE             "otype"
 #define SP_ATTR_OBJECT_CODE             "ocode"
 
-#define SP_MAX_DEFAULT_VALUE_LEN        (255)
-
 typedef enum
 {
   SP_TYPE_PROCEDURE = 1,

--- a/src/sp/sp_constants.hpp
+++ b/src/sp/sp_constants.hpp
@@ -55,7 +55,7 @@
 #define SP_ATTR_OBJECT_TYPE             "otype"
 #define SP_ATTR_OBJECT_CODE             "ocode"
 
-#define SP_MAX_DEFAULT_VALUE_LEN        255
+#define SP_MAX_DEFAULT_VALUE_LEN        (255)
 
 typedef enum
 {


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26283>

### Purpose

_db_stored_procedure 의 target_method 컬럼은 SP 의 Java 시그니쳐 (이름, 인자타입, 리턴타입) 을 저장하며, 그 타입은 varchar(1024) 로 정의되어 있다. 이 시그니쳐의 이름과 인자 타입은 SP 실행시에 Java .class 파일에서 target method 를 찾아내는데 쓰인다. (참고: 시그니쳐 안의 return 타입은 현재 쓰이는 곳이 없음) 
SP 의 인자의 갯수가 많을 경우에 시그니쳐의 길이가 1024 길이를 넘어갈 수 있고 이 경우에 Data overflow on data type "character varying" 라는 메시지로 에러가 발생한다. 본 PR 에서 이 문제를 수정한다. 

### Implementation

Java 시그니쳐가 1024 길이를 넘어가는 경우에 저장되는 길이를 줄이기 위해서 시그니쳐 문자열에 다음 변경을 가한다.
- Java 타입 이름에서 java.lang. , java.math. 같은 패키지 이름을 생략, 그리고, PL server 쪽에서 축약된 이름을 인식하도록 구현 추가
- return 타입 지정이 있는 경우 (function) return 키워드를 생략 : 
- 공란 (space character) 를 모두 제거

### Remarks

본 PR 은 11.4 에 대한 것임. 
develop 에 대해서는 target_method 컬럼의 길이 확장과 함께 저장되는 데이터의 일관성을 위해서 본 PR과 동일 변경을 적용 예정. 
싸이트에 이미 배포된 11.4 버전과의 데이터 호환성 문제로 11.4에 대해서는 target_method 컬럼 길이 확장을 적용할 수 없음.
