### PR TITLE
[CBRD-24771] fix that the allocated count of heap pages increases unnecessarily if the unique violation occurs frequently (#4298)

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -15714,12 +15714,42 @@ int
 heap_rv_undo_insert (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
 {
   INT16 slotid;
+  int free_space = 0;
+
+  if (LOG_ISRESTARTED ())
+    {
+      free_space = spage_get_free_space_without_saving (thread_p, rcv->pgptr, NULL);
+    }
 
   slotid = rcv->offset;
   /* Clear HEAP_RV_FLAG_VACUUM_STATUS_CHANGE */
   slotid = slotid & (~HEAP_RV_FLAG_VACUUM_STATUS_CHANGE);
   (void) spage_delete_for_recovery (thread_p, rcv->pgptr, slotid);
   pgbuf_set_dirty (thread_p, rcv->pgptr, DONT_FREE);
+
+  if (LOG_ISRESTARTED ())
+    {
+      HFID hfid = HFID_INITIALIZER;
+      OID class_oid = OID_INITIALIZER;
+
+      if (heap_get_class_oid_from_page (thread_p, rcv->pgptr, &class_oid) != NO_ERROR)
+	{
+	  goto end;
+	}
+
+      if (heap_get_class_info (thread_p, &class_oid, &hfid, NULL, NULL) != NO_ERROR)
+	{
+	  goto end;
+	}
+      assert (!HFID_IS_NULL (&hfid));
+#if defined(CUBRID_DEBUG)
+      assert (heap_hfid_isvalid (&hfid) == DISK_VALID);
+#endif
+
+      heap_stats_update (thread_p, rcv->pgptr, &hfid, free_space);
+    }
+
+end:
 
   return NO_ERROR;
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24771

### Purpose
backport #4298

### Remarks
.circleci/config.yml이 10.1 릴리즈 브랜치에 없어 circleci 돌지 않음