### PR TITLE
[CBRD-26283] shorten the string stored in _db_stored_procedure.target_method

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/TargetMethod.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/TargetMethod.java
@@ -165,6 +165,12 @@ public class TargetMethod {
         argClassMap.put("java.sql.Timestamp", Timestamp.class);
         argClassMap.put("cubrid.sql.CUBRIDOID", CUBRIDOID.class);
 
+        argClassMap.put("BigDecimal", BigDecimal.class);
+        argClassMap.put("Date", Date.class);
+        argClassMap.put("Time", Time.class);
+        argClassMap.put("Timestamp", Timestamp.class);
+        argClassMap.put("CUBRIDOID", CUBRIDOID.class);
+
         argClassMap.put("[Ljava.lang.Boolean;", Boolean[].class);
         argClassMap.put("[Ljava.lang.Byte;", Byte[].class);
         argClassMap.put("[Ljava.lang.Character;", Character[].class);
@@ -193,8 +199,18 @@ public class TargetMethod {
         argClassMap.put("[Ljava.sql.Timestamp;", Timestamp[].class);
         argClassMap.put("[Lcubrid.sql.CUBRIDOID;", CUBRIDOID[].class);
 
+        argClassMap.put("[LBigDecimal;", BigDecimal[].class);
+        argClassMap.put("[LDate;", Date[].class);
+        argClassMap.put("[LTime;", Time[].class);
+        argClassMap.put("[LTimestamp;", Timestamp[].class);
+        argClassMap.put("[LCUBRIDOID;", CUBRIDOID[].class);
+
+        // why not add other array-array types? TODO
         argClassMap.put("[[Ljava.lang.Integer;", Integer[][].class);
         argClassMap.put("[[Ljava.lang.Float;", Float[][].class);
+
+        argClassMap.put("[[LInteger;", Integer[][].class);
+        argClassMap.put("[[LFloat;", Float[][].class);
     }
 
     private static void initdescriptorMap() {

--- a/src/object/schema_system_catalog_constants.h
+++ b/src/object/schema_system_catalog_constants.h
@@ -92,4 +92,6 @@
 #define CT_DBCHARSET_DEFAULT_COLLATION	  "default_collation"
 #define CT_DBCHARSET_CHAR_SIZE		  "char_size"
 
+#define SP_ATTR_TARGET_METHOD_LEN       (1024)
+
 #endif /* _SCHEMA_SYSTEM_CATALOG_CONSTANTS_H_ */

--- a/src/object/schema_system_catalog_constants.h
+++ b/src/object/schema_system_catalog_constants.h
@@ -92,6 +92,6 @@
 #define CT_DBCHARSET_DEFAULT_COLLATION	  "default_collation"
 #define CT_DBCHARSET_CHAR_SIZE		  "char_size"
 
-#define SP_ATTR_TARGET_METHOD_LEN       (1024)
+#define SP_ATTR_TARGET_METHOD_LEN       (4096)
 
 #endif /* _SCHEMA_SYSTEM_CATALOG_CONSTANTS_H_ */

--- a/src/object/schema_system_catalog_install.cpp
+++ b/src/object/schema_system_catalog_install.cpp
@@ -845,7 +845,7 @@ namespace cubschema
       {"is_system_generated", "integer"},
       {"directive", "integer"},
       {"target_class", format_varchar (1024)},
-      {"target_method", format_varchar (1024)},
+      {"target_method", format_varchar (SP_ATTR_TARGET_METHOD_LEN)},
       {"owner", AU_USER_CLASS_NAME},
       {"comment", format_varchar (1024)}
     },

--- a/src/sp/sp_catalog.cpp
+++ b/src/sp/sp_catalog.cpp
@@ -36,6 +36,7 @@
 #include "transaction_cl.h"
 #include "schema_manager.h"
 #include "dbtype.h"
+#include "schema_system_catalog_constants.h"    // for SP_ATTR_TARGET_METHOD_LEN
 
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
 #include "memory_wrapper.hpp"
@@ -969,8 +970,11 @@ void sp_normalize_name (std::string &s)
 void
 sp_split_target_signature (const std::string &s, std::string &target_cls, std::string &target_mth)
 {
-  auto pos1 = s.find_last_of ('(');
-  if (pos1 == std::string::npos)
+  std::regex RE_SPACES ("\\s+");
+
+  auto pos_lparen = s.find_last_of ('(');
+  auto pos_rparen = s.find_last_of (')');
+  if (pos_lparen == std::string::npos || pos_rparen == std::string::npos)
     {
       // handle the case where '(' is not found, if necessary
       target_cls.clear();
@@ -978,12 +982,11 @@ sp_split_target_signature (const std::string &s, std::string &target_cls, std::s
       return;
     }
 
-  std::string tmp = s.substr (0, pos1);
-  tmp.erase (tmp.find_last_not_of (" ") + 1); // rtrim
-  tmp.erase (0, tmp.find_first_not_of (" ")); // ltrim
+  std::string class_and_mth = s.substr (0, pos_lparen);
+  class_and_mth = std::regex_replace (class_and_mth, RE_SPACES, ""); // remove spaces
 
-  auto pos2 = tmp.find_last_of ('.');
-  if (pos2 == std::string::npos)
+  auto pos_dot = class_and_mth.find_last_of ('.');
+  if (pos_dot == std::string::npos)
     {
       // handle the case where '.' is not found, if necessary
       target_cls.clear();
@@ -991,8 +994,40 @@ sp_split_target_signature (const std::string &s, std::string &target_cls, std::s
       return;
     }
 
-  target_cls = tmp.substr (0, pos2);
-  target_mth = tmp.substr (pos2 + 1) + s.substr (pos1); // remove spaces between method and (
+  target_cls = class_and_mth.substr (0, pos_dot);
+  target_mth = class_and_mth.substr (pos_dot + 1) + s.substr (pos_lparen); // remove spaces between method and (
+
+  if (target_mth.length() > SP_ATTR_TARGET_METHOD_LEN)
+    {
+      // shorten target_mth by erasing package name prefixes in parameter types
+
+      std::regex RE_COMMA_PACKAGE (",(java\\.lang|java\\.math|java\\.sql|cubrid\\.sql)\\.");
+      std::regex RE_PAREN_PACKAGE ("\\((java\\.lang|java\\.math|java\\.sql|cubrid\\.sql)\\.");
+
+      // param types: from '(' to ')' : parameter types
+      std::string param_types = s.substr (pos_lparen, pos_rparen + 1 - pos_lparen);
+
+      // get shorter target_mth by erasing the package name at the start of type names
+      param_types = std::regex_replace (param_types, RE_SPACES, ""); // remove spaces
+      param_types = std::regex_replace (param_types, RE_COMMA_PACKAGE, ",");
+      param_types = std::regex_replace (param_types, RE_PAREN_PACKAGE, "(");
+
+      size_t pos_return = s.find ("return", pos_rparen);
+      if (pos_return == std::string::npos)
+	{
+	  target_mth = class_and_mth.substr (pos_dot + 1) + param_types;
+	}
+      else
+	{
+	  std::regex RE_PREFIX_PACKAGE ("^(java\\.lang|java\\.math|java\\.sql|cubrid\\.sql)\\.");
+
+	  std::string ret_type = s.substr (pos_return + 6);   // 6: length of "return"
+	  ret_type = std::regex_replace (ret_type, RE_SPACES, "");
+	  ret_type = std::regex_replace (ret_type, RE_PREFIX_PACKAGE, "");
+
+	  target_mth = class_and_mth.substr (pos_dot + 1) + param_types + ret_type;
+	}
+    }
 }
 
 std::string

--- a/src/sp/sp_constants.hpp
+++ b/src/sp/sp_constants.hpp
@@ -55,8 +55,6 @@
 #define SP_ATTR_OBJECT_TYPE             "otype"
 #define SP_ATTR_OBJECT_CODE             "ocode"
 
-#define SP_MAX_DEFAULT_VALUE_LEN        255
-
 typedef enum
 {
   SP_TYPE_PROCEDURE = 1,


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26283>

### Purpose

이슈 CBRD-26283에 대하여 release/11.4 에 적용했던 동일 변경 적용 + 컬럼 사이즈 확장

### Implementation

. git cherry-pick 으로 동일 변경 적용 
. _db_stored_procedure.target_method 의 크기도 1024에서 4096으로 늘림
