### PR TITLE
[CBRD-26248] fix when no dependencies on PR(return dependency information of PL/CSQL SPs in their compilation results)

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -3355,12 +3355,15 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
         assert sqlSemantics.size() == 1;
 
         SqlSemantics ss = sqlSemantics.get(0);
-        if (ss.errCode == 0) {
-            dependenciesOfStaticSql.addAll(ss.dependencies);
-            return ss;
-        } else {
+        if (ss.errCode != 0) {
             throw new SemanticError(Misc.getLineColumnOf(ctx), ss.errMsg); // s435
         }
+
+        if (ss.dependencies != null) {
+            dependenciesOfStaticSql.addAll(ss.dependencies);
+        }
+
+        return ss;
     }
 
     private static class SyntaxErrorIndicator extends BaseErrorListener {


### PR DESCRIPTION
[<http://jira.cubrid.org/browse/CBRD-26248>
](http://jira.cubrid.org/browse/CBRD-26248)

### Purpose
참조된 PR(https://github.com/CUBRID/cubrid/pull/6390) 에서 function/procedure 에 의존성이 없을 경우 addAll 에서 `internal error`가 발생하는 문제를 해결합니다.
