### PR TITLE
[CBRD-26249] Fix diagdb disk bitmap output bug and add function to check empty volume

### DIFF
--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -2484,7 +2484,13 @@ disk_volume_is_empty (THREAD_ENTRY * thread_p, VOLID volid)
       return true;
     }
 
-  (void) disk_get_volheader (thread_p, volid, PGBUF_LATCH_READ, &pgptr, &volheader);
+  if (disk_get_volheader (thread_p, volid, PGBUF_LATCH_READ, &pgptr, &volheader) != NO_ERROR)
+    {
+      assert (false);
+      er_clear ();
+
+      return false;
+    }
 
   disk_stab_cursor_set_at_sectid (volheader, SECTOR_FROM_PAGEID (volheader->sys_lastpage) + 1, &start_cursor);
   disk_stab_cursor_set_at_end (volheader, &end_cursor);

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -406,6 +406,7 @@ static int disk_stab_iterate_units_all (THREAD_ENTRY * thread_p, const DISK_VOLU
 					PGBUF_LATCH_MODE mode, DISK_STAB_UNIT_FUNC f_unit, void *f_unit_args);
 static int disk_stab_dump_unit (THREAD_ENTRY * thread_p, DISK_STAB_CURSOR * cursor, bool * stop, void *args);
 static int disk_stab_count_free (THREAD_ENTRY * thread_p, DISK_STAB_CURSOR * cursor, bool * stop, void *args);
+static int disk_stab_has_used (THREAD_ENTRY * thread_p, DISK_STAB_CURSOR * cursor, bool * stop, void *args);
 static int disk_stab_set_bits_contiguous (THREAD_ENTRY * thread_p, DISK_STAB_CURSOR * cursor, bool * stop, void *args);
 
 /************************************************************************/
@@ -2461,6 +2462,38 @@ exit:
   return error_code;
 }
 
+static bool
+disk_volume_is_empty (THREAD_ENTRY * thread_p, VOLID volid)
+{
+  DISK_VOLUME_HEADER *volheader = NULL;
+  DISK_STAB_CURSOR start_cursor = DISK_STAB_CURSOR_INITIALIZER;
+  DISK_STAB_CURSOR end_cursor = DISK_STAB_CURSOR_INITIALIZER;
+  PAGE_PTR pgptr = NULL;
+  bool has_used = false;
+
+  if (xdisk_is_volume_exist (thread_p, volid) == false)
+    {
+      return has_used;
+    }
+
+  (void) disk_get_volheader (thread_p, volid, PGBUF_LATCH_READ, &pgptr, &volheader);
+
+  disk_stab_cursor_set_at_sectid (volheader, SECTOR_FROM_PAGEID (volheader->sys_lastpage) + 1, &start_cursor);
+  disk_stab_cursor_set_at_end (volheader, &end_cursor);
+
+  (void) disk_stab_iterate_units (thread_p, volheader, PGBUF_LATCH_READ, &start_cursor, &end_cursor, disk_stab_has_used,
+				  &has_used);
+
+  if (pgptr != NULL)
+    {
+      pgbuf_unfix (thread_p, pgptr);
+    }
+
+  printf ("volid=%d, is_empty=%d\n", volid, has_used ? 0 : 1);
+
+  return has_used ? false : true;
+}
+
 /************************************************************************/
 /* Disk cache section                                                   */
 /************************************************************************/
@@ -2868,6 +2901,8 @@ disk_volume_header_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** ar
       error = ER_DIAG_VOLID_NOT_EXIST;
       goto exit_on_error;
     }
+
+  (void) disk_volume_is_empty (thread_p, ctx->volume_id);
 
   *ptr = ctx;
   return NO_ERROR;
@@ -3582,8 +3617,8 @@ disk_stab_iterate_units (THREAD_ENTRY * thread_p, const DISK_VOLUME_HEADER * vol
   int error_code = NO_ERROR;
 
   assert (volheader != NULL);
-  assert (start->offset_to_bit == 0);
-  assert (end->offset_to_bit == 0);
+  assert (start->offset_to_bit >= 0);
+  assert (end->offset_to_bit >= 0);
   assert (disk_stab_cursor_compare (start, end) < 0);
 
   /* iterate through pages */
@@ -3675,6 +3710,26 @@ disk_stab_count_free (THREAD_ENTRY * thread_p, DISK_STAB_CURSOR * cursor, bool *
   return NO_ERROR;
 }
 
+static int
+disk_stab_has_used (THREAD_ENTRY * thread_p, DISK_STAB_CURSOR * cursor, bool * stop, void *args)
+{
+  bool *has_used = (bool *) args;
+
+  *has_used = false;
+
+  for (; cursor->offset_to_bit < DISK_STAB_UNIT_BIT_COUNT; cursor->offset_to_bit++, cursor->sectid++)
+    {
+      if (disk_stab_cursor_is_bit_set (cursor))
+	{
+	  *has_used = *stop = true;
+
+	  break;
+	}
+    }
+
+  return NO_ERROR;
+}
+
 /*
  * disk_stab_set_bits_contiguous () - set first bits
  *
@@ -3717,16 +3772,18 @@ static int
 disk_stab_dump_unit (THREAD_ENTRY * thread_p, DISK_STAB_CURSOR * cursor, bool * stop, void *args)
 {
   FILE *fp = (FILE *) args;
-  int bit;
+
+  assert (cursor->offset_to_bit == 0);
 
   fprintf (fp, "\n%10d", cursor->sectid);
 
-  for (bit = 0; bit < DISK_STAB_UNIT_BIT_COUNT; bit++)
+  for (; cursor->offset_to_bit < DISK_STAB_UNIT_BIT_COUNT; cursor->offset_to_bit++, cursor->sectid++)
     {
-      if (bit % CHAR_BIT == 0)
+      if (cursor->offset_to_bit % CHAR_BIT == 0)
 	{
 	  fprintf (fp, " ");
 	}
+
       fprintf (fp, "%d", disk_stab_cursor_is_bit_set (cursor) ? 1 : 0);
     }
 

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -2503,8 +2503,6 @@ disk_volume_is_empty (THREAD_ENTRY * thread_p, VOLID volid)
       pgbuf_unfix (thread_p, pgptr);
     }
 
-  printf ("volid=%d, is_empty=%d\n", volid, has_used ? 0 : 1);
-
   return has_used ? false : true;
 }
 
@@ -2915,8 +2913,6 @@ disk_volume_header_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** ar
       error = ER_DIAG_VOLID_NOT_EXIST;
       goto exit_on_error;
     }
-
-  (void) disk_volume_is_empty (thread_p, ctx->volume_id);
 
   *ptr = ctx;
   return NO_ERROR;

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -2465,8 +2465,8 @@ exit:
 /*
  * disk_volume_is_empty () - Check whether a disk volume is empty.
  *
- * return        : true if the volume is empty (no data),
- *                 false if the volume is in use (contains data)
+ * return        : true if the volume does not exist or is empty (no data),
+ *                 false if the volume exists and contains data
  * thread_p (in) : thread entry
  * volid (in)    : volume identifier
  */

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -2462,6 +2462,14 @@ exit:
   return error_code;
 }
 
+/*
+ * disk_volume_is_empty () - Check whether a disk volume is empty.
+ *
+ * return        : true if the volume is empty (no data),
+ *                 false if the volume is in use (contains data)
+ * thread_p (in) : thread entry
+ * volid (in)    : volume identifier
+ */
 static bool
 disk_volume_is_empty (THREAD_ENTRY * thread_p, VOLID volid)
 {
@@ -2469,11 +2477,11 @@ disk_volume_is_empty (THREAD_ENTRY * thread_p, VOLID volid)
   DISK_STAB_CURSOR start_cursor = DISK_STAB_CURSOR_INITIALIZER;
   DISK_STAB_CURSOR end_cursor = DISK_STAB_CURSOR_INITIALIZER;
   PAGE_PTR pgptr = NULL;
-  bool has_used = false;
+  bool has_used = true;
 
   if (xdisk_is_volume_exist (thread_p, volid) == false)
     {
-      return has_used;
+      return true;
     }
 
   (void) disk_get_volheader (thread_p, volid, PGBUF_LATCH_READ, &pgptr, &volheader);
@@ -3710,6 +3718,15 @@ disk_stab_count_free (THREAD_ENTRY * thread_p, DISK_STAB_CURSOR * cursor, bool *
   return NO_ERROR;
 }
 
+/*
+ * disk_stab_has_used () - DISK_STAB_UNIT_FUNC to determine whether at least one sector in the unit is in use
+ *
+ * return        : NO_ERROR
+ * thread_p (in) : thread entry
+ * cursor (in)   : disk sector table cursor
+ * stop (out)    : output true when at least one sector in the unit is in use
+ * args (out)    : output true when at least one sector in the unit is in use
+ */
 static int
 disk_stab_has_used (THREAD_ENTRY * thread_p, DISK_STAB_CURSOR * cursor, bool * stop, void *args)
 {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26249

### Purpose
- delvoldb 개발 지원

### Implementation
- volume이 사용되지 않는지 확인할 수 있는 disk_volume_is_empty() 함수 구현
- diagdb -d 6 으로 disk bitmaps 출력 시 사용되지 않는데, 사용되는 것으로 출력되는 버그 수정

### Remarks
- 디버깅 편의성을 위해 화면 출력한 부분은 병합 시 제거 예정
- show volume header of 명령어 수행 시 디버깅 메시지로 빈 볼륨 여부 확인 가능 (printf 사용했음)
```
csql> show volume header of 0;
volid=0, is_empty=0

csql> show volume header of 1;
volid=1, is_empty=1
```
