### PR TITLE
[CUBRIDQA-1266] run only failed case with same commit.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,10 +127,19 @@ jobs:
 
                         if [ "\$TEST_SUITE" = "shell" ]; then
                           echo "[debug] split tests for parallel execution"
-                          circleci tests glob "\$glob_path" | sed "s|^\$base_dir/||" | grep -P '/([^/]+)/cases/\1\.sh$' | circleci tests split --split-by=timings --timings-type=testname | tee tc.list
-                          cat tc.list | xargs -n1 dirname > tc_dirs.list
-                          echo "[debug] Remove tests that are not in the list"
-                          find \$base_dir -name "cases" -type d | grep -v -f tc_dirs.list | xargs -r rm -rf
+                          circleci tests glob "$glob_path" \
+                            | grep -P '/([^/]+)/cases/\1\.sh$' \
+                            | circleci tests run \
+                                --command=">tc.list xargs echo" \
+                                --verbose \
+                                --split-by=timings \
+                                --timings-type=file
+                          echo "[debug] Leave only the directories to be executed"
+                          if [ -s tc.list ]; then
+                            awk -F'/cases/' '{print $1"/cases"}' tc.list | sort -u > tc_dirs.list
+                            echo "[debug] Remove tests that are not in the list"
+                            find "$base_dir" -name "cases" -type d | grep -v -f tc_dirs.list | xargs -r rm -rf
+                          fi
                         else
                           echo "[debug] split tests for parallel execution"
                           circleci tests glob "\$glob_path" | circleci tests split --split-by=name | tee tc.list

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,12 +127,17 @@ jobs:
 
                         if [ "\$TEST_SUITE" = "shell" ]; then
                           echo "[debug] split tests for parallel execution"
+                          circleci version
+                          circleci tests run --help
+                          echo "[debug] split tests for parallel execution"
                           circleci tests glob "\$glob_path" | grep -P '/([^/]+)/cases/\1\.sh$' \
                             | circleci tests run --command="tee tc.list" --verbose --split-by=timings --timings-type=file
-                          echo "[debug] Leave only the directories to be executed"
+                          echo "[debug] cat tc.list"
                           cat tc.list
+                          echo "[debug] Leave only the directories to be executed"
                           if [ -s tc.list ]; then
                             awk -F'/cases/' '{print \$1"/cases"}' tc.list | sort -u > tc_dirs.list
+                            echo "[debug] cat tc_dirs.list"
                             cat tc_dirs.list
                             echo "[debug] Remove tests that are not in the list"
                             find "\$base_dir" -name "cases" -type d | grep -v -f tc_dirs.list | xargs -r rm -rvf

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,7 @@ jobs:
                           cat tc.list | xargs -n1 dirname > tc_dirs.list
                           echo "[debug] total testcases: \$(wc -l tc_dirs.list)"
                           echo "[debug] Remove tests that are not in the list"
-                          find "\$base_dir" -name "cases" -type d | grep -v -f tc_dirs.list | xargs -r rm -rf
+                          find \$base_dir -name "cases" -type d | grep -v -f tc_dirs.list | xargs -r rm -rf
                         else
                           echo "[debug] split tests for parallel execution"
                           circleci tests glob "\$glob_path" | circleci tests split --split-by=name | tee tc.list

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ jobs:
 
                         if [ "\$TEST_SUITE" = "shell" ]; then
                           echo "[debug] split tests for parallel execution"
-                          circleci tests glob "$glob_path" \
+                          circleci tests glob "\$glob_path" \
                             | grep -P '/([^/]+)/cases/\1\.sh$' \
                             | circleci tests run \
                                 --command=">tc.list xargs echo" \
@@ -136,9 +136,9 @@ jobs:
                                 --timings-type=file
                           echo "[debug] Leave only the directories to be executed"
                           if [ -s tc.list ]; then
-                            awk -F'/cases/' '{print $1"/cases"}' tc.list | sort -u > tc_dirs.list
+                            awk -F'/cases/' '{print \$1"/cases"}' tc.list | sort -u > tc_dirs.list
                             echo "[debug] Remove tests that are not in the list"
-                            find "$base_dir" -name "cases" -type d | grep -v -f tc_dirs.list | xargs -r rm -rf
+                            find "\$base_dir" -name "cases" -type d | grep -v -f tc_dirs.list | xargs -r rm -rf
                           fi
                         else
                           echo "[debug] split tests for parallel execution"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,11 +132,9 @@ jobs:
                           echo "[debug] split tests for parallel execution"
                           circleci tests glob "\$glob_path" | grep -P '/([^/]+)/cases/\1\.sh$' \
                             | circleci tests run --command="tee tc.list" --verbose --split-by=timings --timings-type=file
-                          echo "[debug] cat tc.list"
-                          cat tc.list
                           echo "[debug] Leave only the directories to be executed"
                           if [ -s tc.list ]; then
-                            awk -F'/cases/' '{print \$1"/cases"}' tc.list | sort -u > tc_dirs.list
+                            cat tc.list | xargs -n1 dirname > tc_dirs.list
                             echo "[debug] cat tc_dirs.list"
                             cat tc_dirs.list
                             echo "[debug] Remove tests that are not in the list"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,19 +127,12 @@ jobs:
 
                         if [ "\$TEST_SUITE" = "shell" ]; then
                           echo "[debug] split tests for parallel execution"
-                          circleci version
-                          circleci tests run --help
-                          echo "[debug] split tests for parallel execution"
                           circleci tests glob "\$glob_path" | grep -P '/([^/]+)/cases/\1\.sh$' \
-                            | circleci tests run --command="tee tc.list" --verbose --split-by=timings --timings-type=file
-                          echo "[debug] Leave only the directories to be executed"
-                          if [ -s tc.list ]; then
-                            cat tc.list | xargs -n1 dirname > tc_dirs.list
-                            echo "[debug] cat tc_dirs.list"
-                            cat tc_dirs.list
-                            echo "[debug] Remove tests that are not in the list"
-                            find "\$base_dir" -name "cases" -type d | grep -v -f tc_dirs.list | xargs -r rm -rvf
-                          fi
+                            | circleci tests run --command="tee tc.list" --verbose --split-by=timings --timings-type=name
+                          cat tc.list | xargs -n1 dirname > tc_dirs.list
+                          echo "[debug] total testcases: \$(wc -l tc_dirs.list)"
+                          echo "[debug] Remove tests that are not in the list"
+                          find "\$base_dir" -name "cases" -type d | grep -v -f tc_dirs.list | xargs -r rm -rf
                         else
                           echo "[debug] split tests for parallel execution"
                           circleci tests glob "\$glob_path" | circleci tests split --split-by=name | tee tc.list

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,11 +130,12 @@ jobs:
                           circleci tests glob "\$glob_path" | grep -P '/([^/]+)/cases/\1\.sh$' \
                             | circleci tests run --command="tee tc.list" --verbose --split-by=timings --timings-type=file
                           echo "[debug] Leave only the directories to be executed"
+                          cat tc.list
                           if [ -s tc.list ]; then
                             awk -F'/cases/' '{print \$1"/cases"}' tc.list | sort -u > tc_dirs.list
                             cat tc_dirs.list
                             echo "[debug] Remove tests that are not in the list"
-                            find "\$base_dir" -name "cases" -type d | grep -v -f tc_dirs.list | xargs -r rm -rf
+                            find "\$base_dir" -name "cases" -type d | grep -v -f tc_dirs.list | xargs -r rm -rvf
                           fi
                         else
                           echo "[debug] split tests for parallel execution"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,16 +127,12 @@ jobs:
 
                         if [ "\$TEST_SUITE" = "shell" ]; then
                           echo "[debug] split tests for parallel execution"
-                          circleci tests glob "\$glob_path" \
-                            | grep -P '/([^/]+)/cases/\1\.sh$' \
-                            | circleci tests run \
-                                --command=">tc.list xargs echo" \
-                                --verbose \
-                                --split-by=timings \
-                                --timings-type=file
+                          circleci tests glob "\$glob_path" | grep -P '/([^/]+)/cases/\1\.sh$' \
+                            | circleci tests run --command="tee tc.list" --verbose --split-by=timings --timings-type=file
                           echo "[debug] Leave only the directories to be executed"
                           if [ -s tc.list ]; then
                             awk -F'/cases/' '{print \$1"/cases"}' tc.list | sort -u > tc_dirs.list
+                            cat tc_dirs.list
                             echo "[debug] Remove tests that are not in the list"
                             find "\$base_dir" -name "cases" -type d | grep -v -f tc_dirs.list | xargs -r rm -rf
                           fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
                         if [ "\$TEST_SUITE" = "shell" ]; then
                           echo "[debug] split tests for parallel execution"
                           circleci tests glob "\$glob_path" | grep -P '/([^/]+)/cases/\1\.sh$' \
-                            | circleci tests run --command="tee tc.list" --verbose --split-by=timings --timings-type=name
+                            | circleci tests run --command="tee tc.list" --verbose --split-by=timings --timings-type=file
                           cat tc.list | xargs -n1 dirname > tc_dirs.list
                           echo "[debug] total testcases: \$(wc -l tc_dirs.list)"
                           echo "[debug] Remove tests that are not in the list"


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1266>

### Purpose
전체 테스트케이스를 재수행하는것이 아닌 실패한 테스트케이스들만 재수행하는 기능을 활성화함.
동일한 커밋에 대하여 실패한 케이스들만 재수행하는기능.

### Implementation
<img width="354" height="247" alt="image" src="https://github.com/user-attachments/assets/5ce77c90-efd8-452d-bd81-8b89706aee53" />

shell 테스트에 한하여 circleci 웹앱 화면에서 'Rerun' -> 'Rerun failed test' 를 클릭하여 수행.

### Remarks

N/A
