### PR TITLE
[CBRD-24771] Fix build error in #6412 backport PR merge

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -15737,7 +15737,7 @@ heap_rv_undo_insert (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
 	  goto end;
 	}
 
-      if (heap_get_class_info (thread_p, &class_oid, &hfid, NULL, NULL) != NO_ERROR)
+      if (heap_get_class_info (thread_p, &class_oid, &hfid, NULL) != NO_ERROR)
 	{
 	  goto end;
 	}
@@ -16667,6 +16667,30 @@ heap_attrinfo_set_uninitialized_global (THREAD_ENTRY * thread_p, OID * inst_oid,
     }
 
   return heap_attrinfo_set_uninitialized (thread_p, inst_oid, recdes, attr_info);
+}
+
+/*
+ * heap_get_class_info () - get HFID and file type for class.
+ *
+ * return             : error code
+ * thread_p (in)      : thread entry
+ * class_oid (in)     : class OID
+ * hfid_out (out)     : output heap file identifier
+ * ftype_out (out)    : output heap file type
+ */
+int
+heap_get_class_info (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid_out, FILE_TYPE * ftype_out)
+{
+  int error_code = NO_ERROR;
+
+  error_code = heap_hfid_cache_get (thread_p, class_oid, hfid_out, ftype_out);
+  if (error_code != NO_ERROR)
+    {
+      ASSERT_ERROR_AND_SET (error_code);
+      return error_code;
+    }
+
+  return error_code;
 }
 
 /*

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -589,6 +589,7 @@ extern void heap_rv_dump_reuse_page (FILE * fp, int ignore_length, void *data);
 extern int heap_rv_mark_deleted_on_undo (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 extern int heap_rv_mark_deleted_on_postpone (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 
+extern int heap_get_class_info (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid_out, FILE_TYPE * ftype_out);
 extern int heap_get_hfid_from_class_oid (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid);
 extern int heap_get_hfid_and_file_type_from_class_oid (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid_out,
 						       FILE_TYPE * ftype_out);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24771

### Purpose
- #6412 백포트 빌드 에러 수정

### Implementation
- 10.2 이상 버전에만 존재하는 heap_get_class_info() 함수가 10.1에 존재하지 않아 추가