### PR TITLE
[CBRD-26258] Skip ORDER BY Is Not Used in Joins Without Index Scan Conditions

### DIFF
--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -979,8 +979,6 @@ qo_top_plan_new (QO_PLAN * plan)
 	}			/* for (t = ...) */
       found_instnum = (t == -1) ? false : true;
 
-      plan->iscan_sort_list = qo_plan_compute_iscan_sort_list (plan, NULL, &is_index_w_prefix, false);
-
       /* GROUP BY */
       /* if we have rollup, we do not skip the group by */
       if (group_by && !group_by->flag.with_rollup)
@@ -1034,6 +1032,12 @@ qo_top_plan_new (QO_PLAN * plan)
 	    }
 	  else
 	    {
+	      if (plan->iscan_sort_list)
+		{
+		  parser_free_tree (parser, plan->iscan_sort_list);
+		  plan->iscan_sort_list = NULL;
+		}
+
 	      /* if the order by is not skipped we drop the plan because it didn't helped us */
 	      if (qo_is_iscan_from_groupby (plan) || qo_is_iscan_from_orderby (plan))
 		{
@@ -1049,7 +1053,11 @@ qo_top_plan_new (QO_PLAN * plan)
       /* DISTINCT, ORDER BY */
       if (all_distinct == PT_DISTINCT || order_by)
 	{
-	  if (plan->iscan_sort_list)
+	  PT_NODE *iscan_sort_list = NULL;
+
+	  iscan_sort_list = qo_plan_compute_iscan_sort_list (plan, NULL, &is_index_w_prefix, false);
+
+	  if (iscan_sort_list)
 	    {			/* need to check */
 	      if (all_distinct == PT_DISTINCT)
 		{
@@ -1088,6 +1096,8 @@ qo_top_plan_new (QO_PLAN * plan)
 			}
 		    }
 		}
+
+	      parser_free_tree (parser, iscan_sort_list);
 	    }
 
 	  if (orderby_skip)
@@ -1130,12 +1140,6 @@ qo_top_plan_new (QO_PLAN * plan)
 	      plan = qo_sort_new (plan, QO_UNORDERED, all_distinct == PT_DISTINCT ? SORT_DISTINCT : SORT_ORDERBY);
 	    }
 	}
-    }
-
-  if (plan->iscan_sort_list)
-    {
-      parser_free_tree (parser, plan->iscan_sort_list);
-      plan->iscan_sort_list = NULL;
     }
 
   return plan;
@@ -2385,8 +2389,6 @@ qo_sort_new (QO_PLAN * root, QO_EQCLASS * order, SORT_TYPE sort_type)
     {
       return NULL;
     }
-
-  assert (subplan->iscan_sort_list == NULL);
 
   plan = qo_plan_malloc ((subplan->info)->env);
   if (plan == NULL)

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -3767,6 +3767,15 @@ qo_plan_cmp (QO_PLAN * a, QO_PLAN * b)
   tb = bf + ba;
   if (ta > 0 && tb > 0 && QO_PLAN_HAS_LIMIT (a) && QO_PLAN_HAS_LIMIT (b))
     {
+      if (qo_is_iscan_from_orderby (a) && qo_plan_is_orderby_skip_candidate (a) && !qo_is_iscan_from_orderby (b))
+	{
+	  return PLAN_COMP_LT;
+	}
+      else if (!qo_is_iscan_from_orderby (a) && qo_is_iscan_from_orderby (b) && qo_plan_is_orderby_skip_candidate (b))
+	{
+	  return PLAN_COMP_GT;
+	}
+
       if (ta * RBO_CHECK_LIMIT_RATIO <= tb)
 	{
 	  return PLAN_COMP_LT;
@@ -5578,12 +5587,14 @@ qo_check_plan_on_info (QO_INFO * info, QO_PLAN * plan)
   best_info = info->planner->best_info;
   plan_order = plan->order;
 
+#if 0
   /* if the plan is of type QO_SCANMETHOD_INDEX_ORDERBY_SCAN but it doesn't skip the orderby, we release the plan. */
   if (qo_is_iscan_from_orderby (plan) && !plan->plan_un.scan.index->head->orderby_skip)
     {
       qo_plan_release (plan);
       return 0;
     }
+#endif
 
   /* if the plan is of type QO_SCANMETHOD_INDEX_GRUOPBY_SCAN but it doesn't skip the groupby, we release the plan. */
   if (qo_is_iscan_from_groupby (plan) && !plan->plan_un.scan.index->head->groupby_skip)
@@ -11870,38 +11881,46 @@ qo_plan_scan_print_text (FILE * fp, QO_PLAN * plan, int indent)
       env = (plan->info)->env;
       fprintf (fp, " (");
 
+      bool first = true;
+
       for (i = bitset_iterate (&(plan->plan_un.scan.terms), &bi); i != -1; i = bitset_next_member (&bi))
 	{
 	  fprintf (fp, "key range: %s", qo_term_string (QO_ENV_TERM (env, i)));
+	  first = false;
 	}
 
       if (bitset_cardinality (&(plan->plan_un.scan.kf_terms)) > 0)
 	{
 	  for (i = bitset_iterate (&(plan->plan_un.scan.kf_terms), &bi); i != -1; i = bitset_next_member (&bi))
 	    {
-	      fprintf (fp, ", key filter: %s", qo_term_string (QO_ENV_TERM (env, i)));
+	      fprintf (fp, "%skey filter: %s", first ? "" : ", ", qo_term_string (QO_ENV_TERM (env, i)));
 	    }
+	  first = false;
 	}
 
       if (qo_is_index_covering_scan (plan))
 	{
-	  fprintf (fp, ", covered: true");
+	  fprintf (fp, "%scovered: true", first ? "" : ", ");
+	  first = false;
 	}
 
       if (plan->plan_un.scan.index && plan->plan_un.scan.index->head->use_descending)
 	{
-	  fprintf (fp, ", desc_index: true");
+	  fprintf (fp, "%sdesc_index: true", first ? "" : ", ");
 	  natural_desc_index = true;
+	  first = false;
 	}
 
       if (!natural_desc_index && (QO_ENV_PT_TREE (plan->info->env)->info.query.q.select.hint & PT_HINT_USE_IDX_DESC))
 	{
-	  fprintf (fp, ", desc_index forced: true");
+	  fprintf (fp, "%sdesc_index forced: true", first ? "" : ", ");
+	  first = false;
 	}
 
       if (qo_is_index_loose_scan (plan))
 	{
-	  fprintf (fp, ", loose: true");
+	  fprintf (fp, "%sloose: true", first ? "" : ", ");
+	  first = false;
 	}
 
       fprintf (fp, ")");

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -1556,6 +1556,23 @@ qo_sscan_cost (QO_PLAN * planp)
       planp->variable_cpu_cost = (double) QO_NODE_NCARD (nodep) * (double) QO_CPU_WEIGHT;
     }
   planp->variable_io_cost = (double) QO_NODE_TCARD (nodep);
+
+#if TEST_DUMP_PLAN_COST
+  fprintf (stdout, "\nSequential Scan Cost: \n");
+  fprintf (stdout, "  -    Fixed CPU Cost: %lf\n", planp->fixed_cpu_cost);
+  fprintf (stdout, "  -    Fixed I/O Cost: %lf\n", planp->fixed_io_cost);
+  fprintf (stdout, "  - Variable CPU Cost: %lf\n", planp->variable_cpu_cost);
+  fprintf (stdout, "  - Variable I/O Cost: %lf\n", planp->variable_io_cost);
+  fprintf (stdout, "  -    Total     Cost: %lf\n",
+	   planp->fixed_cpu_cost + planp->fixed_io_cost + planp->variable_cpu_cost + planp->variable_io_cost);
+  if (planp->vtbl != NULL)
+    {
+      // qo_plan_lite_print (planp, stdout, 0);
+      qo_plan_fprint (planp, stdout, 0, NULL);
+      fprintf (stdout, "\n");
+    }
+  fprintf (stdout, "\n");
+#endif /* TEST_DUMP_PLAN_COST */
 }
 
 /*
@@ -1895,6 +1912,7 @@ qo_iscan_cost (QO_PLAN * planp)
   QO_ATTR_CUM_STATS *cum_statsp;
   QO_INDEX_ENTRY *index_entryp;
   double sel, sel_limit, height, leaves, opages, filter_sel, leaf_access, heap_access;
+  double guessed_result_cardinality = DBL_MAX;
   double object_IO, index_IO;
   QO_TERM *termp;
   BITSET_ITERATOR iter;
@@ -2016,8 +2034,13 @@ qo_iscan_cost (QO_PLAN * planp)
       filter_sel *= QO_TERM_SELECTIVITY (termp);
     }
 
+  if (qo_plan_is_orderby_skip_candidate (planp) && QO_PLAN_HAS_LIMIT (planp))
+    {
+      guessed_result_cardinality = (double) db_get_bigint (&QO_ENV_LIMIT_VALUE (planp->info->env));
+    }
+
   /* number of leaf to be selected */
-  leaf_access = sel * (double) QO_NODE_NCARD (nodep);
+  leaf_access = MIN (sel * (double) QO_NODE_NCARD (nodep), guessed_result_cardinality);
   /* height of the B+tree */
   height = (double) cum_statsp->height - 1;
   if (height < 0)
@@ -2055,7 +2078,9 @@ qo_iscan_cost (QO_PLAN * planp)
   else
     {
       object_IO = opages * sel * filter_sel;
-      heap_access = (double) QO_NODE_NCARD (nodep) * sel * filter_sel * (double) ISCAN_OID_ACCESS_OVERHEAD;
+      heap_access =
+	MIN ((double) QO_NODE_NCARD (nodep) * sel * filter_sel,
+	     guessed_result_cardinality) * (double) ISCAN_OID_ACCESS_OVERHEAD;
     }
   object_IO = MAX (1.0, object_IO);
 
@@ -2064,6 +2089,23 @@ qo_iscan_cost (QO_PLAN * planp)
   planp->fixed_io_cost = index_IO;
   planp->variable_cpu_cost = (leaf_access + heap_access) * (double) QO_CPU_WEIGHT;
   planp->variable_io_cost = object_IO;
+
+#if TEST_DUMP_PLAN_COST
+  fprintf (stdout, "\nIndex Scan Cost: \n");
+  fprintf (stdout, "  -    Fixed CPU Cost: %lf\n", planp->fixed_cpu_cost);
+  fprintf (stdout, "  -    Fixed I/O Cost: %lf\n", planp->fixed_io_cost);
+  fprintf (stdout, "  - Variable CPU Cost: %lf\n", planp->variable_cpu_cost);
+  fprintf (stdout, "  - Variable I/O Cost: %lf\n", planp->variable_io_cost);
+  fprintf (stdout, "  -    Total     Cost: %lf\n",
+	   planp->fixed_cpu_cost + planp->fixed_io_cost + planp->variable_cpu_cost + planp->variable_io_cost);
+  if (planp->vtbl != NULL)
+    {
+      // qo_plan_lite_print (planp, stdout, 0);
+      qo_plan_fprint (planp, stdout, 0, NULL);
+      fprintf (stdout, "\n");
+    }
+  fprintf (stdout, "\n");
+#endif /* TEST_DUMP_PLAN_COST */
 }
 
 
@@ -2588,6 +2630,23 @@ qo_sort_cost (QO_PLAN * planp)
 	  planp->fixed_io_cost += sort_io;
 	}
     }
+
+#if TEST_DUMP_PLAN_COST
+  fprintf (stdout, "\nSort Cost: \n");
+  fprintf (stdout, "  -    Fixed CPU Cost: %lf\n", planp->fixed_cpu_cost);
+  fprintf (stdout, "  -    Fixed I/O Cost: %lf\n", planp->fixed_io_cost);
+  fprintf (stdout, "  - Variable CPU Cost: %lf\n", planp->variable_cpu_cost);
+  fprintf (stdout, "  - Variable I/O Cost: %lf\n", planp->variable_io_cost);
+  fprintf (stdout, "  -    Total     Cost: %lf\n",
+	   planp->fixed_cpu_cost + planp->fixed_io_cost + planp->variable_cpu_cost + planp->variable_io_cost);
+  if (planp->vtbl != NULL)
+    {
+      // qo_plan_lite_print (planp, stdout, 0);
+      qo_plan_fprint (planp, stdout, 0, NULL);
+      fprintf (stdout, "\n");
+    }
+  fprintf (stdout, "\n");
+#endif /* TEST_DUMP_PLAN_COST */
 }
 
 /*
@@ -3093,7 +3152,8 @@ qo_nljoin_cost (QO_PLAN * planp)
 	   planp->fixed_cpu_cost + planp->fixed_io_cost + planp->variable_cpu_cost + planp->variable_io_cost);
   if (planp->vtbl != NULL)
     {
-      qo_plan_lite_print (planp, stdout, 0);
+      // qo_plan_lite_print (planp, stdout, 0);
+      qo_plan_fprint (planp, stdout, 0, NULL);
       fprintf (stdout, "\n");
     }
   fprintf (stdout, "\n");
@@ -3171,7 +3231,8 @@ qo_mjoin_cost (QO_PLAN * planp)
 	   planp->fixed_cpu_cost + planp->fixed_io_cost + planp->variable_cpu_cost + planp->variable_io_cost);
   if (planp->vtbl != NULL)
     {
-      qo_plan_lite_print (planp, stdout, 0);
+      // qo_plan_lite_print (planp, stdout, 0);
+      qo_plan_fprint (planp, stdout, 0, NULL);
       fprintf (stdout, "\n");
     }
   fprintf (stdout, "\n");
@@ -3298,7 +3359,8 @@ qo_hjoin_cost (QO_PLAN * plan_p)
 	   plan_p->fixed_cpu_cost + plan_p->fixed_io_cost + plan_p->variable_cpu_cost + plan_p->variable_io_cost);
   if (plan_p->vtbl != NULL)
     {
-      qo_plan_lite_print (plan_p, stdout, 0);
+      // qo_plan_lite_print (plan_p, stdout, 0);
+      qo_plan_fprint (plan_p, stdout, 0, NULL);
       fprintf (stdout, "\n");
     }
   fprintf (stdout, "\n");
@@ -3767,14 +3829,18 @@ qo_plan_cmp (QO_PLAN * a, QO_PLAN * b)
   tb = bf + ba;
   if (ta > 0 && tb > 0 && QO_PLAN_HAS_LIMIT (a) && QO_PLAN_HAS_LIMIT (b))
     {
-      if (qo_is_iscan_from_orderby (a) && qo_plan_is_orderby_skip_candidate (a) && !qo_is_iscan_from_orderby (b))
+#if 0
+      if ((qo_is_iscan (a) || qo_is_iscan_from_orderby (a) || qo_is_iscan_from_groupby (a))
+	  && qo_plan_is_orderby_skip_candidate (a) && qo_is_seq_scan (b))
 	{
 	  return PLAN_COMP_LT;
 	}
-      else if (!qo_is_iscan_from_orderby (a) && qo_is_iscan_from_orderby (b) && qo_plan_is_orderby_skip_candidate (b))
+      else if (qo_is_seq_scan (a) && (qo_is_iscan (b) || qo_is_iscan_from_orderby (b) || qo_is_iscan_from_groupby (b))
+	       && qo_plan_is_orderby_skip_candidate (b))
 	{
 	  return PLAN_COMP_GT;
 	}
+#endif
 
       if (ta * RBO_CHECK_LIMIT_RATIO <= tb)
 	{
@@ -4011,12 +4077,12 @@ qo_plan_cmp (QO_PLAN * a, QO_PLAN * b)
 	}
 
       /* check index scan */
-      if (qo_is_iscan (a) && qo_is_seq_scan (b))
+      if ((qo_is_iscan (a) || qo_is_iscan_from_orderby (a) || qo_is_iscan_from_groupby (a)) && qo_is_seq_scan (b))
 	{
 	  QO_PLAN_CMP_CHECK_COST (af + aa, bf + ba);
 	  return PLAN_COMP_LT;
 	}
-      if (qo_is_iscan (b) && qo_is_seq_scan (a))
+      if ((qo_is_iscan (b) || qo_is_iscan_from_orderby (b) || qo_is_iscan_from_groupby (b)) && qo_is_seq_scan (a))
 	{
 	  QO_PLAN_CMP_CHECK_COST (bf + ba, af + aa);
 	  return PLAN_COMP_GT;
@@ -8690,7 +8756,7 @@ qo_search_planner (QO_PLANNER * planner)
 	  QO_PLAN *best_plan;
 	  best_plan = qo_find_best_plan_on_info (info, QO_UNORDERED, 1.0);
 	  if (best_plan->plan_type == QO_PLANTYPE_SCAN && !qo_plan_multi_range_opt (best_plan)
-	      && !qo_is_iscan_from_orderby (best_plan) && !qo_is_iscan_from_groupby (best_plan))
+	      && !qo_plan_is_orderby_skip_candidate (best_plan) && !qo_is_iscan_from_groupby (best_plan))
 	    {
 	      qo_generate_sort_limit_plan (planner->env, info, best_plan);
 	    }
@@ -10768,9 +10834,9 @@ qo_order_by_skip_plans_cmp (QO_PLAN * a, QO_PLAN * b)
       return PLAN_COMP_UNK;
     }
 
-  if (a_ent->orderby_skip)
+  if (a_ent->orderby_skip || qo_plan_is_orderby_skip_candidate (a))
     {
-      if (b_ent->orderby_skip)
+      if (b_ent->orderby_skip || qo_plan_is_orderby_skip_candidate (b))
 	{
 	  return qo_plan_iscan_terms_cmp (a, b);
 	}
@@ -10781,7 +10847,7 @@ qo_order_by_skip_plans_cmp (QO_PLAN * a, QO_PLAN * b)
     }
   else
     {
-      if (b_ent->orderby_skip)
+      if (b_ent->orderby_skip || qo_plan_is_orderby_skip_candidate (b))
 	{
 	  return PLAN_COMP_GT;
 	}

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -509,6 +509,7 @@ qo_plan_malloc (QO_ENV * env)
   plan->parallel_opt_use = PLAN_PARALLEL_OPT_NO;
 
   plan->has_sort_limit = false;
+  plan->is_orderby_skip_candidate = false;
   plan->use_iscan_descending = false;
 
   return plan;
@@ -1032,12 +1033,6 @@ qo_top_plan_new (QO_PLAN * plan)
 	    }
 	  else
 	    {
-	      if (plan->iscan_sort_list)
-		{
-		  parser_free_tree (parser, plan->iscan_sort_list);
-		  plan->iscan_sort_list = NULL;
-		}
-
 	      /* if the order by is not skipped we drop the plan because it didn't helped us */
 	      if (qo_is_iscan_from_groupby (plan) || qo_is_iscan_from_orderby (plan))
 		{
@@ -1053,11 +1048,8 @@ qo_top_plan_new (QO_PLAN * plan)
       /* DISTINCT, ORDER BY */
       if (all_distinct == PT_DISTINCT || order_by)
 	{
-	  PT_NODE *iscan_sort_list = NULL;
-
-	  iscan_sort_list = qo_plan_compute_iscan_sort_list (plan, NULL, &is_index_w_prefix, false);
-
-	  if (iscan_sort_list)
+	  plan->iscan_sort_list = qo_plan_compute_iscan_sort_list (plan, NULL, &is_index_w_prefix, false);
+	  if (plan->iscan_sort_list)
 	    {			/* need to check */
 	      if (all_distinct == PT_DISTINCT)
 		{
@@ -1097,7 +1089,11 @@ qo_top_plan_new (QO_PLAN * plan)
 		    }
 		}
 
-	      parser_free_tree (parser, iscan_sort_list);
+	      if (plan->iscan_sort_list)
+		{
+		  parser_free_tree (parser, plan->iscan_sort_list);
+		  plan->iscan_sort_list = NULL;
+		}
 	    }
 
 	  if (orderby_skip)

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -1132,6 +1132,12 @@ qo_top_plan_new (QO_PLAN * plan)
 	}
     }
 
+  if (plan->iscan_sort_list)
+    {
+      parser_free_tree (parser, plan->iscan_sort_list);
+      plan->iscan_sort_list = NULL;
+    }
+
   return plan;
 }
 
@@ -2379,6 +2385,8 @@ qo_sort_new (QO_PLAN * root, QO_EQCLASS * order, SORT_TYPE sort_type)
     {
       return NULL;
     }
+
+  assert (subplan->iscan_sort_list == NULL);
 
   plan = qo_plan_malloc ((subplan->info)->env);
   if (plan == NULL)
@@ -4059,18 +4067,6 @@ qo_plan_cmp (QO_PLAN * a, QO_PLAN * b)
 	  return PLAN_COMP_LT;
 	}
       if (qo_is_index_covering_scan (b) && qo_is_seq_scan (a))
-	{
-	  QO_PLAN_CMP_CHECK_COST (bf + ba, af + aa);
-	  return PLAN_COMP_GT;
-	}
-
-      /* check index scan */
-      if (qo_is_iscan (a) && qo_is_seq_scan (b))
-	{
-	  QO_PLAN_CMP_CHECK_COST (af + aa, bf + ba);
-	  return PLAN_COMP_LT;
-	}
-      if (qo_is_iscan (b) && qo_is_seq_scan (a))
 	{
 	  QO_PLAN_CMP_CHECK_COST (bf + ba, af + aa);
 	  return PLAN_COMP_GT;
@@ -11499,6 +11495,11 @@ qo_plan_is_orderby_skip_candidate (QO_PLAN * plan)
       return false;
     }
 
+  if (plan->is_orderby_skip_candidate)
+    {
+      return true;
+    }
+
   env = plan->info->env;
   parser = QO_ENV_PARSER (env);
   statement = QO_ENV_PT_TREE (env);
@@ -11525,6 +11526,9 @@ cleanup:
       parser_free_tree (parser, plan->iscan_sort_list);
       plan->iscan_sort_list = NULL;
     }
+
+  plan->is_orderby_skip_candidate = is_orderby_skip;
+
   return is_orderby_skip;
 }
 

--- a/src/optimizer/query_planner.h
+++ b/src/optimizer/query_planner.h
@@ -209,6 +209,7 @@ struct qo_plan
   cubxasl::analytic_eval_type *analytic_eval_list;	/* analytic evaluation list */
   // *INDENT-ON*
   bool has_sort_limit;		/* true if this plan or one if its subplans is a SORT-LIMIT plan */
+  bool is_orderby_skip_candidate;	/* true if this plan is a candidate for orderby skip */
   bool use_iscan_descending;
 };
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26258

### Purpose

인덱스 스캔 조건이 없는 조인 질의에서는 skip ORDER BY를 하지 않는 문제를 해결합니다.

### Implementation

TODO

### Remarks

N/A