### PR TITLE
[CBRD-26280] An error occurs when encountering data of a specific format when executing with the loaddb -C option (#6402)

### DIFF
--- a/src/loaddb/load_common.cpp
+++ b/src/loaddb/load_common.cpp
@@ -701,75 +701,65 @@ namespace cubload
 
     for (std::string line; std::getline (object_file, line); ++lineno, ++one_row_lineno)
       {
-	bool is_id_line = starts_with (line, "%id") || starts_with (line, "%ID");
-	bool is_class_line = starts_with (line, "%class") || starts_with (line, "%CLASS");
-
-	if (is_id_line || is_class_line)
+	if (single_quote_checker == 0)
 	  {
-	    if (one_row_buffer.empty() == false)
+	    bool is_id_line = starts_with (line, "%id") || starts_with (line, "%ID");
+	    bool is_class_line = starts_with (line, "%class") || starts_with (line, "%CLASS");
+
+	    if (is_id_line || is_class_line)
 	      {
-		error_code = append_incomplete_row (batch_buffer, one_row_buffer, b_handler, clsid, batch_id,
-						    lineno, one_row_lineno, batch_start_offset, batch_rows);
+		if (one_row_buffer.empty() == false)
+		  {
+		    error_code = append_incomplete_row (batch_buffer, one_row_buffer, b_handler, clsid, batch_id,
+							lineno, one_row_lineno, batch_start_offset, batch_rows);
+		    if (error_code != NO_ERROR)
+		      {
+			object_file.close ();
+			return error_code;
+		      }
+		  }
+
+		if (is_class_line)
+		  {
+		    // in case of class line collect remaining for current class
+		    // and start new batch for the new class
+
+		    error_code = handle_batch (b_handler, clsid, batch_buffer, batch_id, batch_start_offset, batch_rows);
+		    if (error_code != NO_ERROR)
+		      {
+			object_file.close ();
+			return error_code;
+		      }
+
+		    ++clsid;
+		    batch_buffer.reserve (DEFAULT_STRING_SZ);
+		    size_bk = DEFAULT_STRING_SZ;
+		  }
+
+		// New class so we check if the previous one was ignored.
+		// If so, then we should empty the current batch since we do not send it to the server.
+
+		line.append ("\n"); // feed lexer with new line
+		batch c_batch (batch_id, clsid, line, lineno, 1);
+		error_code = c_handler (c_batch, class_is_ignored);
 		if (error_code != NO_ERROR)
 		  {
 		    object_file.close ();
 		    return error_code;
 		  }
+
+		// Next batch should start from the following line.
+		batch_start_offset = lineno + 1;
+		continue;
 	      }
-
-	    if (is_class_line)
-	      {
-		// in case of class line collect remaining for current class
-		// and start new batch for the new class
-
-		error_code = handle_batch (b_handler, clsid, batch_buffer, batch_id, batch_start_offset, batch_rows);
-		if (error_code != NO_ERROR)
-		  {
-		    object_file.close ();
-		    return error_code;
-		  }
-
-		++clsid;
-		batch_buffer.reserve (DEFAULT_STRING_SZ);
-		size_bk = DEFAULT_STRING_SZ;
-	      }
-
-	    // New class so we check if the previous one was ignored.
-	    // If so, then we should empty the current batch since we do not send it to the server.
-
-	    line.append ("\n"); // feed lexer with new line
-	    batch c_batch (batch_id, clsid, line, lineno, 1);
-	    error_code = c_handler (c_batch, class_is_ignored);
-	    if (error_code != NO_ERROR)
-	      {
-		object_file.close ();
-		return error_code;
-	      }
-
-	    // Next batch should start from the following line.
-	    batch_start_offset = lineno + 1;
-	    continue;
 	  }
 
 	if (class_is_ignored)
 	  {
+	    assert (single_quote_checker == 0);
 	    // Skip the remaining lines until we find another class.
 	    continue;
 	  }
-
-	// strip trailing whitespace
-	rtrim (line);
-
-	if (line.empty ())
-	  {
-	    continue;
-	  }
-
-	// it is a line containing row data so append it
-	one_row_buffer.append (line);
-
-	// since std::getline eats end line character, add it back in order to make loaddb lexer happy
-	one_row_buffer.append ("\n");
 
 	// check for matching single quotes
 	for (const char &c: line)
@@ -779,6 +769,23 @@ namespace cubload
 		single_quote_checker ^= 1;
 	      }
 	  }
+
+	if (single_quote_checker == 0)
+	  {
+	    // strip trailing whitespace
+	    rtrim (line);
+
+	    if (line.empty ())
+	      {
+		continue;
+	      }
+	  }
+
+	// it is a line containing row data so append it
+	one_row_buffer.append (line);
+
+	// since std::getline eats end line character, add it back in order to make loaddb lexer happy
+	one_row_buffer.append ("\n");
 
 	// it could be that a row is wrapped on the next line,
 	// this means that the row ends on the last line that does not end with '+' (plus) character

--- a/src/loaddb/load_error_handler.cpp
+++ b/src/loaddb/load_error_handler.cpp
@@ -89,8 +89,8 @@ namespace cubload
     if (m_syntax_check)
       {
 	// just log er_msg ()
-	std::string er_msg;
-	log_error_message (er_msg, false, use_scanner_line);
+	std::string empty;
+	log_error_message (empty, false, use_scanner_line);
 	er_clear ();
 	return;
       }
@@ -122,6 +122,12 @@ namespace cubload
 	err_msg.append (format (get_message_from_catalog (LOADDB_MSG_LINE), lineno));
 	err_msg.append (std::string (er_msg ()));
 	err_msg.append ("\n");
+
+	er_clear ();
+      }
+    else if (!err_msg.empty() && err_msg.back() != '\n')
+      {
+	err_msg.append ("\n");
       }
 
     m_session.on_error (err_msg);
@@ -140,7 +146,14 @@ namespace cubload
 	ldr_increment_err_total ();
       }
 
-    fprintf (stderr, "%s", err_msg.c_str ());
+    if (!err_msg.empty() && err_msg.back() != '\n')
+      {
+	fprintf (stderr, "%s\n", err_msg.c_str ());
+      }
+    else
+      {
+	fprintf (stderr, "%s", err_msg.c_str ());
+      }
 #endif
   }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26280

* Fixed an issue where an error would be thrown if a string literal contained a newline and the first string after the newline began with %id or %class.
* Fixed an issue where string literals contained a newline and trimmed blank lines or lines containing only whitespace after the newline.
* Resolved duplicate error messages.

### Purpose

* backport #6402 

### Implementation

N/A

### Remarks

N/A
