### PR TITLE
[CBRD-26240] rev: Core dump occurs when using like_match_upper_bound(empty-string) in a query

### DIFF
--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -10434,6 +10434,8 @@ mr_setval_string (DB_VALUE * dest, const DB_VALUE * src, bool copy)
 	  dest->data.ch.medium.codeset = db_get_string_codeset (src);
 	  dest->data.ch.medium.compressed_size = DB_UNCOMPRESSABLE;
 	  dest->data.ch.info.compressed_need_clear = false;
+	  dest->data.ch.medium.size = 0;
+	  dest->data.ch.medium.length = -1;
 	}
     }
   else

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -10436,6 +10436,7 @@ mr_setval_string (DB_VALUE * dest, const DB_VALUE * src, bool copy)
 	  dest->data.ch.info.compressed_need_clear = false;
 	  dest->data.ch.medium.size = 0;
 	  dest->data.ch.medium.length = -1;
+	  dest->data.ch.medium.buf = NULL;
 	}
     }
   else


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26240>

### Purpose

select like_match_upper_bound('') from dual;
select like_match_upper_bound('abcd') from dual;
위 두 쿼리 실행 후
select /*+ RECOMPILE */  like_match_upper_bound('') from dual;
이 쿼리 실행하면 결과가 ''(empty string)이 아닌 '           만 나오는 문제를 해결

### Implementation

스트링 값을 세팅하는 setval의 연결 함수인 mr_setval_string에서 누락된 아래의 코드를 추가
ch.medium.size = 0;
ch.medium.lenght = -1;

### Remarks

레거시 버그로 10.2 ~ 11.4에 이르기 까지 체크하여 반영할 필요가 있음.
