### PR TITLE
[CBRD-26214] fix a omitted null check while closing a cursor

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -1569,7 +1569,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
 
     private static String[] tmplStmtCursorFetch =
             new String[] {
-                "{ // cursor fetch",
+                "try { // cursor fetch",
                 "  if (%'CURSOR'% == null) {",
                 "    throw new INVALID_CURSOR(\"the cursor is NULL\");",
                 "  }",
@@ -1577,6 +1577,9 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 "  if (%'CURSOR'%.fetch()) {",
                 "    %'+SET-INTO-VARIABLES'%",
                 "  }",
+                "} catch (SQLException e) {",
+                "  Server.log(e);",
+                "  throw new SQL_ERROR(e.getMessage());",
                 "}"
             };
 
@@ -1636,10 +1639,13 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
 
     private static String[] tmplStmtCursorOpenWithHostExprs =
             new String[] {
-                "{ // cursor open",
+                "try { // cursor open",
                 "  %'+DUPLICATE-CURSOR-ARG'%",
                 "  %'CURSOR'%.open(conn, null, new Object[] {",
                 "    %'+HOST-EXPRS'%});",
+                "} catch (SQLException e) {",
+                "  Server.log(e);",
+                "  throw new SQL_ERROR(e.getMessage());",
                 "}"
             };
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -1639,13 +1639,10 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
 
     private static String[] tmplStmtCursorOpenWithHostExprs =
             new String[] {
-                "try { // cursor open",
+                "{ // cursor open",
                 "  %'+DUPLICATE-CURSOR-ARG'%",
                 "  %'CURSOR'%.open(conn, null, new Object[] {",
                 "    %'+HOST-EXPRS'%});",
-                "} catch (SQLException e) {",
-                "  Server.log(e);",
-                "  throw new SQL_ERROR(e.getMessage());",
                 "}"
             };
 

--- a/src/sp/pl_executor.cpp
+++ b/src/sp/pl_executor.cpp
@@ -636,7 +636,7 @@ exit:
       }
     else
       {
-	blk = std::move (pack_data_block (METHOD_RESPONSE_ERROR, ER_FAILED, "unknown error",
+	blk = std::move (pack_data_block (METHOD_RESPONSE_ERROR, ER_FAILED, std::string ("unknown error"),
 					  ARG_FILE_LINE));
       }
 
@@ -743,7 +743,7 @@ exit:
     if (cursor == nullptr)
       {
 	assert (false);
-	cubmem::block b = std::move (pack_data_block (METHOD_RESPONSE_ERROR, ER_FAILED, "unknown error",
+	cubmem::block b = std::move (pack_data_block (METHOD_RESPONSE_ERROR, ER_FAILED, std:string ("no cursor for the query"),
 				     ARG_FILE_LINE));
 	error = m_stack->send_data_to_java (b);
 	return error;
@@ -803,7 +803,7 @@ exit:
       }
     else
       {
-	blk = std::move (pack_data_block (METHOD_RESPONSE_ERROR, ER_FAILED, "unknown error",
+	blk = std::move (pack_data_block (METHOD_RESPONSE_ERROR, ER_FAILED, std::string ("fetch failed"),
 					  ARG_FILE_LINE));
       }
 

--- a/src/sp/pl_executor.cpp
+++ b/src/sp/pl_executor.cpp
@@ -743,7 +743,7 @@ exit:
     if (cursor == nullptr)
       {
 	assert (false);
-	cubmem::block b = std::move (pack_data_block (METHOD_RESPONSE_ERROR, ER_FAILED, std:string ("no cursor for the query"),
+	cubmem::block b = std::move (pack_data_block (METHOD_RESPONSE_ERROR, ER_FAILED, std::string ("no cursor for the query"),
 				     ARG_FILE_LINE));
 	error = m_stack->send_data_to_java (b);
 	return error;

--- a/src/sp/pl_query_cursor.cpp
+++ b/src/sp/pl_query_cursor.cpp
@@ -229,7 +229,7 @@ namespace cubpl
 	    else
 	      {
 		qfile_close_scan (m_thread, &m_scan_id);
-		return S_ERROR;
+		return S_ERROR; // control reaches here when this method is called after ROLLBACK
 	      }
 	  }
 

--- a/src/sp/pl_query_cursor.cpp
+++ b/src/sp/pl_query_cursor.cpp
@@ -89,7 +89,7 @@ namespace cubpl
       {
 	qfile_close_scan (m_thread, &m_scan_id);
 
-	if (m_query_entry->list_id == NULL || m_query_entry->alloc_no != m_query_entry_no)
+	if (m_query_entry && (m_query_entry->list_id == NULL || m_query_entry->alloc_no != m_query_entry_no))
 	  {
 	    int tran_index = LOG_FIND_THREAD_TRAN_INDEX (m_thread);
 	    m_query_entry = qmgr_get_query_entry (m_thread, m_query_id, tran_index);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26214>

### Purpose

PL/CSQL 커서에서 fetch 도중 rollback 을 하면 다음 번 fetch 시도에서 커서 내부에 query entry 가 NULL 이 되며 실패를 한다. 
이후 커서를 close 하는 과정에서 NULL 포인터 dereference 가 발생하여 코어 덤프하게 된다. 
본 PR 에서 이 문제를 수정한다. 
그리고, 커서 open과 fetch 과정에서 발생한 에러에 대해 에러메시지가 사용자에게 전달되지 않는 문제가 있었는데 함께 수정한다. 

### Implementation

- 커서 close 과정에  query entry NULL 체크 추가
- 에러 메시지가 PL 서버로 전달되지 않는 문제 수정
  - char* 타입의 에러 메시지가 pack_data_block 에 의해서 bool 로 인식되어 pack 되는 문제 발견 (별도 이슈로 해결 필요)
    - std::string 으로 만들어 회피 가능
  - 커서 open 과 fetch 에 해당하는 Java 코드에서 exception catch 추가.

### Remarks

11.4.1 hotfix 를 위한 변경 입니다. 
