### PR TITLE
[CBRD-25862] Move trigger system catalog install logic from trigger manager to schema system catalog module

### DIFF
--- a/src/object/schema_system_catalog_install.cpp
+++ b/src/object/schema_system_catalog_install.cpp
@@ -28,6 +28,7 @@
 #include "dbtype_function.h"
 #include "schema_system_catalog_constants.h"
 #include "sp_constants.hpp"
+#include "trigger_manager.h"
 #include "work_space.h"
 #include "schema_system_catalog_builder.hpp"
 #include "schema_system_catalog_definition.hpp"
@@ -43,6 +44,15 @@ make_int_value_fn (int num)
   return [num] (DB_VALUE* val)
   {
     return db_make_int (val, num);
+  };
+}
+
+static std::function<int (DB_VALUE *)>
+make_double_value_fn (double num)
+{
+  return [num] (DB_VALUE* val)
+  {
+    return db_make_double (val, num);
   };
 }
 
@@ -256,6 +266,7 @@ catcls_init (void)
   ADD_TABLE_DEFINITION (CT_INDEX_NAME, system_catalog_initializer::get_index ());
   ADD_TABLE_DEFINITION (CT_INDEXKEY_NAME, system_catalog_initializer::get_index_key ());
   ADD_TABLE_DEFINITION (CT_CLASSAUTH_NAME, system_catalog_initializer::get_auth ());
+  ADD_TABLE_DEFINITION (CT_TRIGGER_NAME, system_catalog_initializer::get_trigger ());
   ADD_TABLE_DEFINITION (CT_PARTITION_NAME, system_catalog_initializer::get_partition ());
   ADD_TABLE_DEFINITION (CT_DATATYPE_NAME, system_catalog_initializer::get_data_type ());
   ADD_TABLE_DEFINITION (CT_STORED_PROC_NAME, system_catalog_initializer::get_stored_procedure ());
@@ -764,6 +775,45 @@ namespace cubschema
       {DB_CONSTRAINT_INDEX, "", {"grantee", nullptr}, false},
       {DB_CONSTRAINT_INDEX, "", {"object_of", nullptr}, false}
     },
+// authorization
+    {
+      // owner, grants
+      Au_dba_user, {}
+    },
+// initializers
+    nullptr
+	   );
+  }
+
+  system_catalog_definition
+  system_catalog_initializer::get_trigger ()
+  {
+    return system_catalog_definition (
+		   // name
+		   CT_TRIGGER_NAME,
+		   // columns
+    {
+      {TR_ATT_UNIQUE_NAME, "string"},
+      {TR_ATT_OWNER, AU_USER_CLASS_NAME},
+      {TR_ATT_NAME, "string"},
+      {TR_ATT_STATUS, "integer", make_int_value_fn (TR_STATUS_ACTIVE)},
+      {TR_ATT_PRIORITY, "double", make_double_value_fn (TR_LOWEST_PRIORITY)},
+      {TR_ATT_EVENT, "integer", make_int_value_fn (TR_EVENT_NULL)},
+      {TR_ATT_CLASS, "object"},
+      {TR_ATT_ATTRIBUTE, "string"},
+      {TR_ATT_CLASS_ATTRIBUTE, "integer", make_int_value_fn (0)},
+      {TR_ATT_CONDITION_TYPE, "integer"},
+      {TR_ATT_CONDITION, "string"},
+      {TR_ATT_CONDITION_TIME, "integer"},
+      {TR_ATT_ACTION_TYPE, "integer"},
+      {TR_ATT_ACTION, "string"},
+      {TR_ATT_ACTION_TIME, "integer"},
+      {TR_ATT_COMMENT, format_varchar (1024)},
+      {TR_ATT_CREATED_TIME, "datetime"},
+      {TR_ATT_UPDATED_TIME, "datetime"}
+    },
+// constraints
+    {},
 // authorization
     {
       // owner, grants

--- a/src/object/schema_system_catalog_install.hpp
+++ b/src/object/schema_system_catalog_install.hpp
@@ -44,6 +44,7 @@ namespace cubschema
       static system_catalog_definition get_index ();
       static system_catalog_definition get_index_key ();
       static system_catalog_definition get_auth ();
+      static system_catalog_definition get_trigger ();
       static system_catalog_definition get_partition ();
       static system_catalog_definition get_data_type ();
       static system_catalog_definition get_stored_procedure ();

--- a/src/object/trigger_manager.c
+++ b/src/object/trigger_manager.c
@@ -101,14 +101,6 @@ static const int TR_RETURN_ERROR = -1;
 static const int TR_RETURN_FALSE = 0;
 static const int TR_RETURN_TRUE = 1;
 
-/*
- * tr_init
- *
- * Note: Trigger initialization function.
- *              This function should be called at the beginning of a
- *              transaction.
- */
-
 static const int TR_EST_MAP_SIZE = 1024;
 
 static const char *OBJ_REFERENCE_NAME = "obj";
@@ -247,7 +239,6 @@ static void tr_finish (TR_STATE * state);
 static int its_deleted (DB_OBJECT * object);
 
 static int map_flush_helper (const void *key, void *data, void *args);
-static int define_trigger_classes (void);
 
 static TR_RECURSION_DECISION tr_check_recursivity (OID oid, OID stack[], int stack_size, bool is_statement);
 static int tr_set_trigger_timestamps (TR_TRIGGER * trigger);
@@ -7386,169 +7377,6 @@ tr_dump (FILE * fpp)
 	    }
 	}
     }
-}
-
-
-/*
- * TRIGGER DATABASE INSTALLATION
- */
-
-/*
- * define_trigger_classes() - This defines the classes necessary for storing triggers.
- *    return: error code
- *
- * Note:
- *    Currently there is only a single trigger object class.
- *    This should only be called during createdb.
- */
-static int
-define_trigger_classes (void)
-{
-  DB_CTMPL *tmp;
-  DB_OBJECT *class_mop;
-  DB_VALUE value;
-
-  tmp = NULL;
-
-  tmp = dbt_create_class (TR_CLASS_NAME);
-  if (tmp == NULL)
-    {
-      goto tmp_error;
-    }
-
-  if (dbt_add_attribute (tmp, TR_ATT_UNIQUE_NAME, "string", NULL))
-    {
-      goto tmp_error;
-    }
-
-  if (dbt_add_attribute (tmp, TR_ATT_OWNER, AU_USER_CLASS_NAME, NULL))
-    {
-      goto tmp_error;
-    }
-
-  if (dbt_add_attribute (tmp, TR_ATT_NAME, "string", NULL))
-    {
-      goto tmp_error;
-    }
-
-  db_make_int (&value, TR_STATUS_ACTIVE);
-  if (dbt_add_attribute (tmp, TR_ATT_STATUS, "integer", &value))
-    {
-      goto tmp_error;
-    }
-
-  db_make_float (&value, TR_LOWEST_PRIORITY);
-  if (dbt_add_attribute (tmp, TR_ATT_PRIORITY, "double", &value))
-    {
-      goto tmp_error;
-    }
-
-  db_make_int (&value, TR_EVENT_NULL);
-  if (dbt_add_attribute (tmp, TR_ATT_EVENT, "integer", &value))
-    {
-      goto tmp_error;
-    }
-
-  if (dbt_add_attribute (tmp, TR_ATT_CLASS, "object", NULL))
-    {
-      goto tmp_error;
-    }
-
-  if (dbt_add_attribute (tmp, TR_ATT_ATTRIBUTE, "string", NULL))
-    {
-      goto tmp_error;
-    }
-
-  db_make_int (&value, 0);
-  if (dbt_add_attribute (tmp, TR_ATT_CLASS_ATTRIBUTE, "integer", &value))
-    {
-      goto tmp_error;
-    }
-
-  if (dbt_add_attribute (tmp, TR_ATT_CONDITION_TYPE, "integer", NULL))
-    {
-      goto tmp_error;
-    }
-
-  if (dbt_add_attribute (tmp, TR_ATT_CONDITION, "string", NULL))
-    {
-      goto tmp_error;
-    }
-
-  db_make_int (&value, TR_TIME_AFTER);
-  if (dbt_add_attribute (tmp, TR_ATT_CONDITION_TIME, "integer", NULL))
-    {
-      goto tmp_error;
-    }
-
-  if (dbt_add_attribute (tmp, TR_ATT_ACTION_TYPE, "integer", NULL))
-    {
-      goto tmp_error;
-    }
-
-  if (dbt_add_attribute (tmp, TR_ATT_ACTION, "string", NULL))
-    {
-      goto tmp_error;
-    }
-
-  db_make_int (&value, TR_TIME_AFTER);
-  if (dbt_add_attribute (tmp, TR_ATT_ACTION_TIME, "integer", NULL))
-    {
-      goto tmp_error;
-    }
-
-  if (dbt_add_attribute (tmp, TR_ATT_COMMENT, "varchar(1024)", NULL))
-    {
-      goto tmp_error;
-    }
-
-  if (dbt_add_attribute (tmp, TR_ATT_CREATED_TIME, "datetime", NULL))
-    {
-      goto tmp_error;
-    }
-
-  if (dbt_add_attribute (tmp, TR_ATT_UPDATED_TIME, "datetime", NULL))
-    {
-      goto tmp_error;
-    }
-
-  class_mop = dbt_finish_class (tmp);
-  if (class_mop == NULL)
-    {
-      goto tmp_error;
-    }
-
-  sm_mark_system_class (class_mop, 1);
-
-  if (locator_create_heap_if_needed (class_mop, false) == NULL)
-    {
-      goto tmp_error;
-    }
-
-  return NO_ERROR;
-
-tmp_error:
-  if (tmp != NULL)
-    {
-      dbt_abort_class (tmp);
-    }
-
-  ASSERT_ERROR ();
-  return er_errid ();
-}
-
-/*
- * tr_install() - Trigger installation function.
- *    return: error code
- *
- * Note:
- *    A system class called TRIGGER is created, and initialized.
- *    The function should be called exactly once in createdb.
- */
-int
-tr_install (void)
-{
-  return (define_trigger_classes ());
 }
 
 /*

--- a/src/object/trigger_manager.h
+++ b/src/object/trigger_manager.h
@@ -221,6 +221,8 @@ extern const char *TR_ATT_ACTION;
 extern const char *TR_ATT_ACTION_OLD;
 extern const char *TR_ATT_PROPERTIES;
 extern const char *TR_ATT_COMMENT;
+extern const char *TR_ATT_CREATED_TIME;
+extern const char *TR_ATT_UPDATED_TIME;
 
 extern int tr_Current_depth;
 extern int tr_Maximum_depth;
@@ -255,7 +257,6 @@ extern const char *EVAL_SUFFIX;
 extern void tr_init (void);
 extern void tr_final (void);
 extern void tr_dump (FILE * fpp);	/* debug status */
-extern int tr_install (void);
 
 /* Global trigger firing state : enable/disable functions */
 

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -160,6 +160,7 @@ static bool boot_Set_client_at_exit = false;
 static int boot_Process_id = -1;
 
 static int boot_client (int tran_index, int lock_wait, TRAN_ISOLATION tran_isolation);
+static int install_system_metadata (void);
 static void boot_shutdown_client_at_exit (void);
 #if defined(CS_MODE)
 static int boot_client_initialize_css (DB_INFO * db, int client_type, bool check_capabilities, int opt_cap,
@@ -197,6 +198,36 @@ boot_client (int tran_index, int lock_wait, TRAN_ISOLATION tran_isolation)
   boot_Set_client_at_exit = true;
   boot_Process_id = getpid ();
   atexit (boot_shutdown_client_at_exit);
+
+  return NO_ERROR;
+}
+
+static int
+install_system_metadata (void)
+{
+  int error = NO_ERROR;
+
+  /* Create system classes such as the root and authorization classes */
+  au_init ();
+  error = au_install ();
+  if (error != NO_ERROR)
+    {
+      return error;
+    }
+  /* Create authorization classes and enable authorization */
+  error = au_start ();
+  if (error != NO_ERROR)
+    {
+      return error;
+    }
+
+  tr_init ();
+  catcls_init ();
+  error = catcls_install ();
+  if (error != NO_ERROR)
+    {
+      return error;
+    }
 
   return NO_ERROR;
 }
@@ -538,38 +569,18 @@ boot_initialize_client (BOOT_CLIENT_CREDENTIAL * client_credential, BOOT_DB_PATH
   OID_INIT_TEMPID ();
 
   error_code = ws_init ();
-
   if (error_code == NO_ERROR)
     {
-      /* Create system classes such as the root and authorization classes */
-
       sm_create_root (&rootclass_oid, &rootclass_hfid);
-      au_init ();
-
-      /* Create authorization classes and enable authorization */
-      error_code = au_install ();
+      error_code = install_system_metadata ();
       if (error_code == NO_ERROR)
 	{
-	  error_code = au_start ();
+	  error_code = tran_commit (false);
 	}
+
       if (error_code == NO_ERROR)
 	{
-	  tr_init ();
-	  error_code = tr_install ();
-	  if (error_code == NO_ERROR)
-	    {
-	      catcls_init ();
-	      error_code = catcls_install ();
-	      if (error_code == NO_ERROR)
-		{
-		  error_code = tran_commit (false);
-		}
-
-	      if (error_code == NO_ERROR)
-		{
-		  error_code = sp_builtin_install ();
-		}
-	    }
+	  error_code = sp_builtin_install ();
 	}
     }
 


### PR DESCRIPTION
[<http://jira.cubrid.org/browse/CBRD-25862>
](http://jira.cubrid.org/browse/CBRD-25862)

### Purpose
system catalog install 로직을 모두 schema system catalog module 에서 수행하도록 trigger system catalog install logic 을 옮깁니다.

### Remarks
- 예외: authorization system catalog install logic 은 authorization module 에서 진행
- information schema 작업 시, information schema init 및 install도 install_metadata() 내부에 추가 예정