### PR TITLE
[CBRD-26295] Terminate transactions suspended in THREAD_PGBUF_SUSPENDED state when killed by killtran or client shutdown (#6446)

### DIFF
--- a/src/communication/network_sr.c
+++ b/src/communication/network_sr.c
@@ -1165,7 +1165,6 @@ loop:
 		    case THREAD_CSECT_WRITER_SUSPENDED:
 		    case THREAD_CSECT_PROMOTER_SUSPENDED:
 		    case THREAD_LOCK_SUSPENDED:
-		    case THREAD_PGBUF_SUSPENDED:
 		    case THREAD_JOB_QUEUE_SUSPENDED:
 		      /* never try to wake thread up while the thread is waiting for a critical section or a lock. */
 		      wakeup_now = false;
@@ -1174,6 +1173,7 @@ loop:
 		    case THREAD_HEAP_CLSREPR_SUSPENDED:
 		    case THREAD_LOGWR_SUSPENDED:
 		    case THREAD_ALLOC_BCB_SUSPENDED:
+		    case THREAD_PGBUF_SUSPENDED:
 		      wakeup_now = true;
 		      break;
 

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -91,7 +91,7 @@ static int rv;
 
 /* default timeout seconds for infinite wait */
 #define PGBUF_FIX_COUNT_THRESHOLD           64	/* fix count threshold. used as indicator for hot pages. */
-static int pgbuf_latch_timeout = 300 * 1000;		/* timeout seconds */
+static int pgbuf_latch_timeout = 300 * 1000;	/* timeout seconds */
 
 /* size of io page */
 #if defined(CUBRID_DEBUG)
@@ -6554,9 +6554,7 @@ pgbuf_timed_sleep (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr, THREAD_ENTRY * t
   char *client_user_name;	/* Client user name for tran */
   char *client_host_name;	/* Client host for tran */
   int client_pid;		/* Client process identifier for tran */
-
-  TSC_TICKS start_tick, end_tick;
-  TSCTIMEVAL tv_diff;
+  bool old_check_interrupt;
 
   /* After holding the mutex associated with conditional variable, release the bufptr->mutex. */
   thread_lock_entry (thrd_entry);
@@ -6580,23 +6578,16 @@ try_again:
   to.tv_sec = (int) time (NULL) + wait_secs;
   to.tv_nsec = 0;
 
-  if (thrd_entry->event_stats.trace_slow_query == true)
-    {
-      tsc_getticks (&start_tick);
-    }
+  old_check_interrupt = logtb_set_check_interrupt (thread_p, true);
 
   thrd_entry->resume_status = THREAD_PGBUF_SUSPENDED;
-  r = pthread_cond_timedwait (&thrd_entry->wakeup_cond, &thrd_entry->th_entry_lock, &to);
+  r = thread_suspend_timeout_wakeup_and_unlock_entry (thread_p, &to, THREAD_PGBUF_SUSPENDED);
 
-  if (thrd_entry->event_stats.trace_slow_query == true)
-    {
-      tsc_getticks (&end_tick);
-      tsc_elapsed_time_usec (&tv_diff, end_tick, start_tick);
-      TSC_ADD_TIMEVAL (thrd_entry->event_stats.latch_waits, tv_diff);
-    }
+  logtb_set_check_interrupt (thread_p, old_check_interrupt);
 
-  if (r == 0)
+  if (r == NO_ERROR)
     {
+      thread_lock_entry (thrd_entry);
       /* someone wakes up me */
       if (thrd_entry->resume_status == THREAD_PGBUF_RESUMED)
 	{
@@ -6606,7 +6597,6 @@ try_again:
 
       /* interrupt operation */
       thrd_entry->request_latch_mode = PGBUF_NO_LATCH;
-      thrd_entry->resume_status = THREAD_PGBUF_RESUMED;
       thread_unlock_entry (thrd_entry);
 
       if (pgbuf_timed_sleep_error_handling (thread_p, bufptr, thrd_entry) == NO_ERROR)
@@ -6617,7 +6607,7 @@ try_again:
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_INTERRUPTED, 0);
       return ER_FAILED;
     }
-  else if (r == ETIMEDOUT)
+  else if (r == ER_CSS_PTHREAD_COND_TIMEDOUT)
     {
       /* rollback operation, postpone operation, etc. */
       if (thrd_entry->resume_status == THREAD_PGBUF_RESUMED)

--- a/src/thread/thread.c
+++ b/src/thread/thread.c
@@ -1664,6 +1664,8 @@ thread_suspend_timeout_wakeup_and_unlock_entry (THREAD_ENTRY * thread_p, struct 
 {
   int r;
   int old_status;
+  TSC_TICKS start_tick, end_tick;
+  TSCTIMEVAL tv_diff;
   int error = NO_ERROR;
 
   assert (thread_p->status == TS_RUN || thread_p->status == TS_CHECK);
@@ -1672,7 +1674,20 @@ thread_suspend_timeout_wakeup_and_unlock_entry (THREAD_ENTRY * thread_p, struct 
 
   thread_p->resume_status = suspended_reason;
 
+  if (thread_p->event_stats.trace_slow_query == true && suspended_reason == THREAD_PGBUF_SUSPENDED)
+    {
+      tsc_getticks (&start_tick);
+    }
+
   r = pthread_cond_timedwait (&thread_p->wakeup_cond, &thread_p->th_entry_lock, time_p);
+
+  if (thread_p->event_stats.trace_slow_query == true && suspended_reason == THREAD_PGBUF_SUSPENDED)
+    {
+      tsc_getticks (&end_tick);
+      tsc_elapsed_time_usec (&tv_diff, end_tick, start_tick);
+
+      TSC_ADD_TIMEVAL (thread_p->event_stats.latch_waits, tv_diff);
+    }
 
   if (r != 0 && r != ETIMEDOUT)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26295

backport: #6446