### PR TITLE
[CBRD-26290] When inserting into a bit or bit varying type on a remote server using the prepare statement via dblink, an incorrect value is entered.

### DIFF
--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -386,7 +386,7 @@ dblink_make_date_time_tz (T_CCI_U_TYPE utype, DB_VALUE * value_p, T_CCI_DATE_TZ 
 static int
 dblink_bind_param (int stmt_handle, VAL_DESCR * vd, DBLINK_HOST_VARS * host_vars)
 {
-  int i, n, ret;
+  int i, n, ret, num_size = 0;
   T_CCI_A_TYPE a_type;
   T_CCI_U_TYPE u_type;
   void *value;
@@ -399,7 +399,9 @@ dblink_bind_param (int stmt_handle, VAL_DESCR * vd, DBLINK_HOST_VARS * host_vars
   DB_DATE date;
   DB_TIME time;
   T_CCI_DATE cci_date;
-  char num_str[40];
+  T_CCI_BIT cci_bit;
+  char num_str[NUMERIC_MAX_STRING_SIZE];
+
   unsigned char type;
 
   for (n = 0; n < host_vars->count; n++)
@@ -411,16 +413,11 @@ dblink_bind_param (int stmt_handle, VAL_DESCR * vd, DBLINK_HOST_VARS * host_vars
 	{
 	case DB_TYPE_BIT:
 	case DB_TYPE_VARBIT:
-	  {
-	    int num_size = 0;
-	    T_CCI_BIT cci_bit;
-
-	    a_type = CCI_A_TYPE_BIT;
-	    u_type = (type == DB_TYPE_BIT) ? CCI_U_TYPE_BIT : CCI_U_TYPE_VARBIT;
-	    value = (void *) &cci_bit;
-	    cci_bit.buf = (char *) db_get_bit (&vd->dbval_ptr[i], &num_size);
-	    cci_bit.size = QSTR_NUM_BYTES (num_size);
-	  }
+	  a_type = CCI_A_TYPE_BIT;
+	  u_type = (type == DB_TYPE_BIT) ? CCI_U_TYPE_BIT : CCI_U_TYPE_VARBIT;
+	  value = (void *) &cci_bit;
+	  cci_bit.buf = (char *) db_get_bit (&vd->dbval_ptr[i], &num_size);
+	  cci_bit.size = QSTR_NUM_BYTES (num_size);
 	  break;
 	case DB_TYPE_JSON:
 	  a_type = CCI_A_TYPE_STR;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26290>

### Purpose

아래의 쿼리를 실행 후 원격 테이블에 비정상적인 값이 입력되는 현상 해결

prepare st from
'insert into type_support@srv1 (T_BIT,T_BITVARYING) values (?,?)';
execute st using B'1',0xbb;

### Implementation

dblink 호스트 변수 바인딩에서 switch 구문 안쪽에 선언된 로컬 변수를 switch 바깥으로 이동

### Remarks

NUMERIC타입 확장을 대비하여, char num_str[40]으로 되어 있는 부분도 char num_str[NUMERIC_MAX_STRING_SIZE] 으로 변경
