### PR TITLE
[CUBVEC-132] [BugFix] 벡터 인덱스 실행 후 INDX_INFO의 REGU_VAR 들을 초기화

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -2051,7 +2051,7 @@ qexec_clear_access_spec_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl_p, ACCES
 	  pg_cnt += qexec_clear_regu_list (thread_p, xasl_p, p->s.cls_node.cls_regu_list_key, is_final);
 	  pg_cnt += qexec_clear_regu_list (thread_p, xasl_p, p->s.cls_node.cls_regu_list_pred, is_final);
 	  pg_cnt += qexec_clear_regu_list (thread_p, xasl_p, p->s.cls_node.cls_regu_list_rest, is_final);
-	  if (p->access == ACCESS_METHOD_INDEX)
+	  if (p->access == ACCESS_METHOD_INDEX || p->access == ACCESS_METHOD_VECTOR_INDEX_SCAN)
 	    {
 	      INDX_INFO *indx_info;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-132

### Purpose

벡터 인덱스로 쿼리를 수행할 때 recompile 힌트가 없어, XASL을 재사용하는 경우, REGU_VAR가 적절히 초기화되지 않아 segfault가 발생하는 문제를 수정

### Implementation

```
typedef struct indx_info INDX_INFO;
struct indx_info
{
  BTID btid;			/* index identifier */
  int coverage;			/* index coverage state */
  QFILE_LIST_ID *cov_list_id;	/* list file id for index coverage */
  OID class_oid;
  RANGE_TYPE range_type;	/* range type */
  KEY_INFO key_info;		/* key information */
  int orderby_desc;		/* first column of the order by is desc */
  int groupby_desc;		/* first column of the group by is desc */
  int use_desc_index;		/* using descending index */
  int orderby_skip;		/* order by skip information */
  int groupby_skip;		/* group by skip information */
  int use_iss;			/* flag set if using index skip scan */
  int func_idx_col_id;		/* function expression column position, if the index is a function index */
  KEY_RANGE iss_range;		/* placeholder range used for ISS; must be created on the broker */
  int ils_prefix_len;		/* index loose scan prefix length */
};				/* index information structure */

typedef struct key_info KEY_INFO;
struct key_info
{
  key_range *key_ranges;	/* a list of key ranges */
  KEY_VAL_RANGE *key_vals;	/* a list of key values */
  int key_cnt;			/* key count */
  bool is_constant;		/* every key value is a constant */
  bool key_limit_reset;		/* should key limit reset at each range */
  bool is_user_given_keylimit;	/* true if user specifies key limit */
  regu_variable_node *key_limit_l;	/* lower key limit */
  regu_variable_node *key_limit_u;	/* upper key limit */
};				/* key information structure */

typedef struct key_range KEY_RANGE;
struct key_range
{
  regu_variable_node *key1;		/* pointer to first key value */
  regu_variable_node *key2;		/* pointer to second key value */
  RANGE range;			/* range spec; GE_LE, GT_LE, GE_LT, GT_LT, GE_INF, GT_INF, INF_LT, INF_LE, INF_INF */
};				/* key range structure */
```

key_range의 key1과 key2에 각각 k와 vector 가 설정되는데, 이 REGU_VAR 구조에 대해서 쿼리 실행 후 초기화가 필요하다.
기존의 B-tree 인덱스의 초기화 루틴으로 동일하게 진행하도록 수정했다.

### Remarks

N/A
