### PR TITLE
[CUBVEC-122] Bugfix build error on vector index scan

### DIFF
--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -3717,8 +3717,6 @@ scan_open_vector_index_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
   visid->rest_regu_list = regu_list_rest;
   /* index scan info */
 
-  assert (key_ranges[0].range == K_NN);
-
   visid->hnsw_id = indx_info->btid.root_pageid;
 
   return NO_ERROR;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBVEC-122>

### Purpose

- Vector Index Scan 관련 코드에서 Build Error 발생
  -  #6386 의 변경에 인해 발생한 문제

### Implementation

-  사용되지 않는 변수인 `key_ranges`에 대한 assertion 제거

### Remarks

N/A
