### PR TITLE
[CBRD-26295] Fix bug: vacuum thread incorrectly allows interrupts via thread_set_check_interrupt()

### DIFF
--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -6578,12 +6578,18 @@ try_again:
   to.tv_sec = (int) time (NULL) + wait_secs;
   to.tv_nsec = 0;
 
-  old_check_interrupt = thread_set_check_interrupt (thread_p, true);
+  if (!VACUUM_IS_THREAD_VACUUM (thread_p))
+    {
+      old_check_interrupt = thread_set_check_interrupt (thread_p, true);
+    }
 
   thrd_entry->resume_status = THREAD_PGBUF_SUSPENDED;
   r = thread_suspend_timeout_wakeup_and_unlock_entry (thread_p, &to, THREAD_PGBUF_SUSPENDED);
 
-  thread_set_check_interrupt (thread_p, old_check_interrupt);
+  if (!VACUUM_IS_THREAD_VACUUM (thread_p))
+    {
+      thread_set_check_interrupt (thread_p, old_check_interrupt);
+    }
 
   if (r == NO_ERROR)
     {

--- a/src/thread/thread.c
+++ b/src/thread/thread.c
@@ -2398,6 +2398,7 @@ thread_get_sort_stats_active (THREAD_ENTRY * thread_p)
 bool
 thread_set_check_interrupt (THREAD_ENTRY * thread_p, bool flag)
 {
+#if defined (SERVER_MODE)
   bool old_val = true;
 
   if (BO_IS_SERVER_RESTARTED ())
@@ -2414,6 +2415,9 @@ thread_set_check_interrupt (THREAD_ENTRY * thread_p, bool flag)
     }
 
   return old_val;
+#else // not SERVER_MODE = SA_MODE
+  return tran_set_check_interrupt (flag);
+#endif // not SERVER_MODE = SA_MODE
 }
 
 /*
@@ -2423,6 +2427,7 @@ thread_set_check_interrupt (THREAD_ENTRY * thread_p, bool flag)
 bool
 thread_get_check_interrupt (THREAD_ENTRY * thread_p)
 {
+#if defined (SERVER_MODE)
   bool ret_val = true;
 
   if (BO_IS_SERVER_RESTARTED ())
@@ -2436,6 +2441,9 @@ thread_get_check_interrupt (THREAD_ENTRY * thread_p)
     }
 
   return ret_val;
+#else // not SERVER_MODE = SA_MODE
+  return tran_get_check_interrupt ();
+#endif // not SERVER_MODE = SA_MODE
 }
 
 /*


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26295

### Purpose
- bug 수정
    - vacuum 쓰레드가 thread_set_check_interrupt() 호출을 통해 인터럽트를 허용하게 하면 안되나 이전 수정 코드에서 vacuum 쓰레드인지 확인을 안함