### PR TITLE
[CBRD-26308] [Regression] Core dumped in or_advance at src/base/object_representation.h:1485

### DIFF
--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -1695,7 +1695,7 @@ static int
 qfile_save_normal_tuple (QFILE_TUPLE_DESCRIPTOR * tuple_descr_p, char *tuple_p, char *page_p, int tuple_length)
 {
   int i, tuple_value_size;
-
+  int total_tuple_value_size = 0;
   for (i = 0; i < tuple_descr_p->f_cnt; i++)
     {
       if (qdata_copy_db_value_to_tuple_value (tuple_descr_p->f_valp[i],
@@ -1704,9 +1704,11 @@ qfile_save_normal_tuple (QFILE_TUPLE_DESCRIPTOR * tuple_descr_p, char *tuple_p, 
 	{
 	  return ER_FAILED;
 	}
+      total_tuple_value_size += tuple_value_size;
       tuple_p += tuple_value_size;
     }
 
+  assert_release (total_tuple_value_size <= tuple_length);
   QFILE_PUT_TUPLE_LENGTH (page_p, tuple_length);
   return NO_ERROR;
 }

--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -393,21 +393,6 @@ qdata_copy_db_value_to_tuple_value (DB_VALUE * dbval_p, bool clear_compressed_st
 	  return ER_FAILED;
 	}
 
-      /* Good moment to clear the compressed_string that might have been stored in the DB_VALUE */
-      if (clear_compressed_string)
-	{
-	  if (dbval_type == DB_TYPE_VARCHAR || dbval_type == DB_TYPE_VARNCHAR)
-	    {
-	      rc = pr_clear_compressed_string (dbval_p);
-	      if (rc != NO_ERROR)
-		{
-		  /* This should not happen for now */
-		  assert (false);
-		  return ER_FAILED;
-		}
-	    }
-	}
-
       /* I don't know if the following is still true. */
       /* since each tuple data value field is already aligned with MAX_ALIGNMENT, val_size by itself can be used to
        * find the maximum alignment for the following field which is next val_header */


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26308>

### Purpose

compressed_string = y->n으로 변경되는 시스템 파라미터가 힙 → 인덱스 생성 → 조회(qdata_copy_db_value_to_tuple_value) (변경시)에 다음과 같은 조건, (같은 컬럼이 GROUP BY 출력 튜플에 중복(n회 이상) 사용되는 조건) 하에 잘못 초기화/공유되어 데이터 손상(길이/버퍼 불일치) 이 발생하는 문제를 수정합니다.

### Implementation

Compressed_string을 중도 해제하는 로직 삭제.
Safety Check 추가.

### Remarks

메모리 누수 테스트 필요.
해당 이슈는 [CBRD-20497](http://jira.cubrid.org/browse/CBRD-20497) 의 Regression 입니다.