### PR TITLE
[CBRD-26284] Blob is too big to copy for logging.

### DIFF
--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -5106,6 +5106,8 @@ event_log_extend_pages (THREAD_ENTRY * thread_p, EXECUTION_INFO * info)
   fprintf (log_fp, "%*ctime: %dms\n", indent, ' ', TO_MSEC (thread_p->event_stats.extend_time));
   fprintf (log_fp, "%*cpages: %d\n\n", indent, ' ', thread_p->event_stats.extend_pages);
 
+  /* printing bind values for placeholders (?) is skipped due to performance issues when logging long column values (e.g. LOB) in event_log_bind_values(). */
+
   event_log_end (thread_p);
 }
 

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -5103,12 +5103,6 @@ event_log_extend_pages (THREAD_ENTRY * thread_p, EXECUTION_INFO * info)
 
   event_log_print_client_info (tran_index, indent);
   fprintf (log_fp, "%*csql: %s\n", indent, ' ', info->sql_hash_text ? info->sql_hash_text : "(UNKNOWN HASH_TEXT)");
-
-  if (tdes->num_exec_queries <= MAX_NUM_EXEC_QUERY_HISTORY)
-    {
-      event_log_bind_values (log_fp, tran_index, tdes->num_exec_queries - 1);
-    }
-
   fprintf (log_fp, "%*ctime: %dms\n", indent, ' ', TO_MSEC (thread_p->event_stats.extend_time));
   fprintf (log_fp, "%*cpages: %d\n\n", indent, ' ', thread_p->event_stats.extend_pages);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26284

### Purpose
https://github.com/CUBRID/cubrid/pull/6418에서 발생한 문제를 해결하기 위한 PR입니다.
볼륨 확장 발생 시 확장을 일으킨 쿼리를 .event에 남기는데, 이때 blob과 같은 문자열 기반 데이터가 사용되면 전부 로그에 남기게 되고, 이 과정에서 대량의 복사가 일어나 hang에 걸린 것처럼 보이게 됩니다.
transaction과 client 정보는 그대로 남기고 있으므로, event_log_bind_values를 제거합니다.

#0  0x00007faca1ae5d7e in __memmove_sse2_unaligned_erms () from /lib64/libc.so.6
#1  0x00007faca2829080 in pt_append_bytes_for (new_tail_length=2, new_tail=0x7fac674fff90 "00", old_string=0x7fac28000048, parser=0x7fac546f6200)
    at /home/jenkins/workspace/cubrid_release_10.1/src/parser/parse_tree.c:698
#2  pt_append_bytes (parser=0x7fac546f6200, old_string=0x7fac28000048, new_tail=0x7fac674fff90 "00", new_tail_length=2) at /home/jenkins/workspace/cubrid_release_10.1/src/parser/parse_tree.c:1012
#3  0x00007faca28f7066 in describe_bit_string (value=<optimized out>, buffer=0x7fac28000048, parser=0x7fac546f6200) at /home/jenkins/workspace/cubrid_release_10.1/src/object/object_print.c:3850
#4  describe_data (parser=0x7fac546f6200, buffer=<optimized out>, value=<optimized out>) at /home/jenkins/workspace/cubrid_release_10.1/src/object/object_print.c:3944
#5  0x00007faca28f72d9 in describe_value (parser=0x7fac546f6200, buffer=<optimized out>, value=0x7fac5406ca20) at /home/jenkins/workspace/cubrid_release_10.1/src/object/object_print.c:4267
#6  0x00007faca28f76c3 in help_sprint_value (value=0x7fac5406ca20, buffer=0x7fac5c000b90 "@\323Ŧ\253\177", max_length=32) at /home/jenkins/workspace/cubrid_release_10.1/src/object/object_print.c:4474
#7  0x00007faca2914ec1 in pr_valstring (val=0x7fac5406ca20) at /home/jenkins/workspace/cubrid_release_10.1/src/object/object_primitive.c:10500
#8  0x00007faca27c094d in event_log_bind_values (log_fp=0x1afe6f0, tran_index=<optimized out>, bind_index=<optimized out>) at /home/jenkins/workspace/cubrid_release_10.1/src/base/event_log.c:414
#9  0x00007faca28211ee in event_log_extend_pages (info=<optimized out>, thread_p=0x1b2c4a8) at /home/jenkins/workspace/cubrid_release_10.1/src/communication/network_interface_sr.c:5109
#10 sqmgr_execute_query (thread_p=0x1b2c4a8, rid=65576, request=<optimized out>, reqlen=<optimized out>) at /home/jenkins/workspace/cubrid_release_10.1/src/communication/network_interface_sr.c:4882
#11 0x00007faca2828172 in net_server_request (thread_p=0x1b2c4a8, rid=65576, request=<optimized out>, size=<optimized out>, buffer=0x7fac5c0012b0 "\310ȑ_u\251+Ei\211\366x\024\021\003\024U>Heh\322\033\023")
    at /home/jenkins/workspace/cubrid_release_10.1/src/communication/network_sr.c:1048
#12 0x00007faca281304d in css_internal_request_handler (thread_p=0x1b2c4a8, arg=0x25a4c98) at /home/jenkins/workspace/cubrid_release_10.1/src/connection/server_support.c:1824
#13 0x00007faca27adf74 in thread_worker (arg_p=0x1b2c4a8) at /home/jenkins/workspace/cubrid_release_10.1/src/thread/thread.c:2516
#14 0x00007faca20a41ca in start_thread () from /lib64/libpthread.so.0
#15 0x00007faca1afa8d3 in clone () from /lib64/libc.so.6

### Implementation
N/A

### Remarks
N/A