### PR TITLE
[CBRD-26313] rownum을 제외한 조회조건이 있어도 뷰머징되는 문제

### DIFF
--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -4231,7 +4231,7 @@ mq_is_rownum_only_predicate (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * 
       return false;
     }
 
-  where = parser_copy_tree (parser, node->info.query.q.select.where);
+  where = parser_copy_tree_list (parser, node->info.query.q.select.where);
 
   /* substitute attributes for query_spec_columns in statement */
   where = mq_lambda (parser, where, attributes, query_spec_columns);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26313>

### Purpose

조회조건에 rownum만 존재할 경우 뷰머징 최적화가 진행된다. 하지만 rownum을 제외한 조회조건이 있어도 뷰머징되는 문제가 있어 처리한다.

### Implementation

parser_copy_tree_list() 사용
