### PR TITLE
[CBRD-26247] avoid NULL mop for revoke

### DIFF
--- a/src/cm_common/cm_dep_tasks.c
+++ b/src/cm_common/cm_dep_tasks.c
@@ -2808,7 +2808,7 @@ revoke_all_from_user (DB_OBJECT * user)
     {
       db_seq_get (col, GRANT_ENTRY_CLASS (i), &v);
       obj = db_get_object (&v);
-      if (obj->class_mop == NULL || is_class_entry (col, i) && db_is_system_class (obj))
+      if (obj->class_mop == NULL || (is_class_entry (col, i) && db_is_system_class (obj)))
 	{
 	  continue;
 	}

--- a/src/cm_common/cm_dep_tasks.c
+++ b/src/cm_common/cm_dep_tasks.c
@@ -2808,7 +2808,7 @@ revoke_all_from_user (DB_OBJECT * user)
     {
       db_seq_get (col, GRANT_ENTRY_CLASS (i), &v);
       obj = db_get_object (&v);
-      if (is_class_entry (col, i) && db_is_system_class (obj))
+      if (obj->class_mop == NULL || is_class_entry (col, i) && db_is_system_class (obj))
 	{
 	  continue;
 	}


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26247>

### Purpose
* add defensive code before call **_db_revoke ()_**

### Implementation


### Remarks
* @junsklee 님이 작성한 shell testcase (cubrid-testcases-private-ex/shell/_06_issues/_25_2h/cbrd_26247/cases)를 실행하니 core 발생
* 아마도 준석님 testcase에 procedure에 대한 grant가 포함되어있어서 fail (coredump) 되는 결과가 나오지 않았나 추측.
```
#0  0x00007f71d9b3152f in raise () from /lib64/libc.so.6
#1  0x00007f71d9b04e65 in abort () from /lib64/libc.so.6
#2  0x00007f71d9b04d39 in __assert_fail_base.cold.0 () from /lib64/libc.so.6
#3  0x00007f71d9b29e86 in __assert_fail () from /lib64/libc.so.6
#4  0x00007f71dbb06fee in db_get_object_type (obj_=0x7f71bc0cf2a0) at /home/kshanrel/test5/src/compat/db_admin.c:1849
#5  0x00007f71dbb074b4 in db_revoke (user=0x7f71bc0cbff0, obj_=0x7f71bc0cf2a0, auth=127) at /home/kshanrel/test5/src/compat/db_admin.c:1966
#6  0x00007f71dcb11ae0 in revoke_all_from_user (user=0x7f71bc0cbff0) at /home/kshanrel/test5/src/cm_common/cm_dep_tasks.c:2826
#7  0x00007f71dcb0db67 in cm_ts_update_user (req=0x7f71bc004540, res=0x7f71bc02d270, _dbmt_error=0x7f71c3ffda90 "?")
    at /home/kshanrel/test5/src/cm_common/cm_dep_tasks.c:1131
#8  0x000000000042231e in ts_update_user (req=0x7f71bc004540, res=0x7f71bc02d270, _dbmt_error=0x7f71c3ffda90 "?")
    at /home/kshanrel/test5/cubridmanager/server/src/cm_job_task.cpp:832
#9  0x000000000046c134 in ch_process_request (req=req@entry=0x7f71bc004540, res=res@entry=0x7f71bc02d270)
    at /home/kshanrel/test5/cubridmanager/server/src/cm_server_interface.cpp:298
#10 0x000000000046c8fc in cm_async_request_handler (lpArg=0x7f71c40154f0) at /home/kshanrel/test5/cubridmanager/server/src/cm_server_interface.cpp:493
#11 0x00007f71da7f11ca in start_thread () from /lib64/libpthread.so.0
#12 0x00007f71d9b1c8d3 in clone () from /lib64/libc.so.6

```

