### PR TITLE
[CUBRIDQA-1301] increase core file size to 10mb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,8 +94,8 @@ jobs:
                       shell: /bin/bash
                       no_output_timeout: 45m
                       command: |
-                        # Limit core files
-                        ulimit -c 1
+                        # Limit core files to 10mb
+                        ulimit -c 10485760
 
                         echo "[debug] Check out testcases and testtools"
                         /entrypoint.sh checkout


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1301>

### Purpose

call stack trace 정보만 남도록 코어사이즈를 10mb 로 제한.

### Implementation

N/A

### Remarks
장애 조치 및 적용배경 설명 
http://jira.cubrid.org/browse/CUBRIDQA-1301?focusedCommentId=4772249&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-4772249