### PR TITLE
[CBRD-26318] 뷰머지 이후 추가된 부질의에 대해서 인덱스 스캔이 안되는 문제

### DIFF
--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -186,6 +186,7 @@ static void get_term_rank (QO_ENV * env, QO_TERM * term);
 static PT_NODE *check_subquery_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);
 static bool is_local_name (QO_ENV * env, PT_NODE * expr);
 static void get_local_subqueries (QO_ENV * env, PT_NODE * tree);
+static PT_NODE *get_local_subqueries_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);
 static void get_rank (QO_ENV * env);
 static PT_NODE *get_referenced_attrs (PT_NODE * entity);
 static bool expr_is_mergable (PT_NODE * pt_expr);
@@ -447,6 +448,9 @@ qo_optimize_helper (QO_ENV * env)
   (void) parser_walk_tree (parser, tree, build_query_graph_function_index, &local_env, NULL, NULL);
   (void) add_hint (env, tree);
   add_using_index (env, tree->info.query.q.select.using_index);
+
+  /* adjust correlation level before analyzing term. TO_DO: add routines to adjust in mq_translate() */
+  parser_walk_leaves (parser, tree, get_local_subqueries_pre, env, NULL, NULL);
 
   /* add dep term */
   {

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -14012,7 +14012,6 @@ mq_rewrite_order_dependent_query (PARSER_CONTEXT * parser, PT_NODE * select, int
 
 /*
  * mq_bump_order_dep_corr_lvl_pre - walk_tree function for bumping correlation
- *                                  levels of order dependent SELECTs
  *   parser(in): parser context
  *   node(in): node
  *   arg(in/out): parent node stack
@@ -14071,45 +14070,42 @@ mq_bump_order_dep_corr_lvl_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *a
     }
 
   /* process node */
-  if (PT_IS_ORDER_DEPENDENT (node))
+  PT_NODE *item = NULL, *prev = NULL;
+  int corr_diff = 0;
+
+  stack_item = stack_end;
+  while (stack_item != NULL && stack_item->info.expr.arg2 != NULL)
     {
-      PT_NODE *item = NULL, *prev = NULL;
-      int corr_diff = 0;
-
-      stack_item = stack_end;
-      while (stack_item != NULL && stack_item->info.expr.arg2 != NULL)
+      /* due to the walk_tree function, all items in lists are pushed in the stack before any of them is popped;
+       * here, we skip same-level nodes */
+      stack_prev = stack_item->info.expr.arg2;
+      while (stack_prev && stack_prev->info.expr.arg1->next == stack_prev->next->info.expr.arg1)
 	{
-	  /* due to the walk_tree function, all items in lists are pushed in the stack before any of them is popped;
-	   * here, we skip same-level nodes */
-	  stack_prev = stack_item->info.expr.arg2;
-	  while (stack_prev && stack_prev->info.expr.arg1->next == stack_prev->next->info.expr.arg1)
-	    {
-	      stack_prev = stack_prev->info.expr.arg2;
-	    }
-
-	  if (stack_prev == NULL)
-	    {
-	      /* stack_item is in top level list; should never get here ... */
-	      assert (false);
-	      break;
-	    }
-
-	  /* get node and previous node */
-	  item = stack_item->info.expr.arg1;
-	  prev = stack_prev->info.expr.arg1;
-	  corr_diff = item->info.query.correlation_level - prev->info.query.correlation_level;
-
-	  /* check correlation levels */
-	  if (item != NULL && prev != NULL && corr_diff <= 0 && item->info.query.correlation_level != 0)
-	    {
-	      /* same correlation level or parent has greater correlation level; not acceptable */
-	      corr_diff = -corr_diff + 1;
-	      (void) mq_bump_correlation_level (parser, item, corr_diff, item->info.query.correlation_level);
-	    }
-
-	  /* peek back in stack list */
-	  stack_item = stack_prev;
+	  stack_prev = stack_prev->info.expr.arg2;
 	}
+
+      if (stack_prev == NULL)
+	{
+	  /* stack_item is in top level list; should never get here ... */
+	  assert (false);
+	  break;
+	}
+
+      /* get node and previous node */
+      item = stack_item->info.expr.arg1;
+      prev = stack_prev->info.expr.arg1;
+      corr_diff = item->info.query.correlation_level - prev->info.query.correlation_level;
+
+      /* check correlation levels */
+      if (item != NULL && prev != NULL && corr_diff <= 0 && item->info.query.correlation_level != 0)
+	{
+	  /* same correlation level or parent has greater correlation level; not acceptable */
+	  corr_diff = -corr_diff + 1;
+	  (void) mq_bump_correlation_level (parser, item, corr_diff, item->info.query.correlation_level);
+	}
+
+      /* peek back in stack list */
+      stack_item = stack_prev;
     }
 
   return node;
@@ -14117,8 +14113,7 @@ mq_bump_order_dep_corr_lvl_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *a
 
 /*
  * mq_bump_order_dep_corr_lvl_post - walk_tree post function for bumping
- *                                   correlation levels of order dependent
- *                                   SELECTs
+ *                                   correlation levels
  *   parser(in): parser context
  *   node(in): node
  *   arg(in/out): parent node stack
@@ -14162,8 +14157,7 @@ mq_bump_order_dep_corr_lvl_post (PARSER_CONTEXT * parser, PT_NODE * node, void *
 }
 
 /*
- * mq_bump_order_dep_corr_lvl - bump correlation levels for order dependent
- *                              SELECTs
+ * mq_bump_order_dep_corr_lvl - bump correlation levels for SELECTs
  *   parser(in): parser context
  *   node(in): root node
  */
@@ -14172,7 +14166,6 @@ mq_bump_order_dep_corr_lvl (PARSER_CONTEXT * parser, PT_NODE * node)
 {
   PT_NODE *stack = NULL;
 
-  /* bump order dependent SELECTs */
   (void) parser_walk_tree (parser, node, mq_bump_order_dep_corr_lvl_pre, (void *) &stack,
 			   mq_bump_order_dep_corr_lvl_post, (void *) &stack);
 }

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -14012,7 +14012,7 @@ mq_rewrite_order_dependent_query (PARSER_CONTEXT * parser, PT_NODE * select, int
 
 /*
  * mq_bump_order_dep_corr_lvl_pre - walk_tree function for bumping correlation
- * levels of order dependent SELECTs
+ *                                  levels of order dependent SELECTs
  *   parser(in): parser context
  *   node(in): node
  *   arg(in/out): parent node stack

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -14070,44 +14070,46 @@ mq_bump_order_dep_corr_lvl_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *a
     }
 
   /* process node */
-  PT_NODE *item = NULL, *prev = NULL;
-  int corr_diff = 0;
-
-  stack_item = stack_end;
-  while (stack_item != NULL && stack_item->info.expr.arg2 != NULL)
+  if (PT_IS_ORDER_DEPENDENT (node))
     {
-      /* due to the walk_tree function, all items in lists are pushed in the stack before any of them is popped;
-       * here, we skip same-level nodes */
-      stack_prev = stack_item->info.expr.arg2;
-      while (stack_prev && stack_prev->info.expr.arg1->next == stack_prev->next->info.expr.arg1)
+      PT_NODE *item = NULL, *prev = NULL;
+      int corr_diff = 0;
+
+      stack_item = stack_end;
+      while (stack_item != NULL && stack_item->info.expr.arg2 != NULL)
 	{
-	  stack_prev = stack_prev->info.expr.arg2;
+	  /* due to the walk_tree function, all items in lists are pushed in the stack before any of them is popped;
+	   * here, we skip same-level nodes */
+	  stack_prev = stack_item->info.expr.arg2;
+	  while (stack_prev && stack_prev->info.expr.arg1->next == stack_prev->next->info.expr.arg1)
+	    {
+	      stack_prev = stack_prev->info.expr.arg2;
+	    }
+
+	  if (stack_prev == NULL)
+	    {
+	      /* stack_item is in top level list; should never get here ... */
+	      assert (false);
+	      break;
+	    }
+
+	  /* get node and previous node */
+	  item = stack_item->info.expr.arg1;
+	  prev = stack_prev->info.expr.arg1;
+	  corr_diff = item->info.query.correlation_level - prev->info.query.correlation_level;
+
+	  /* check correlation levels */
+	  if (item != NULL && prev != NULL && corr_diff <= 0 && item->info.query.correlation_level != 0)
+	    {
+	      /* same correlation level or parent has greater correlation level; not acceptable */
+	      corr_diff = -corr_diff + 1;
+	      (void) mq_bump_correlation_level (parser, item, corr_diff, item->info.query.correlation_level);
+	    }
+
+	  /* peek back in stack list */
+	  stack_item = stack_prev;
 	}
-
-      if (stack_prev == NULL)
-	{
-	  /* stack_item is in top level list; should never get here ... */
-	  assert (false);
-	  break;
-	}
-
-      /* get node and previous node */
-      item = stack_item->info.expr.arg1;
-      prev = stack_prev->info.expr.arg1;
-      corr_diff = item->info.query.correlation_level - prev->info.query.correlation_level;
-
-      /* check correlation levels */
-      if (item != NULL && prev != NULL && corr_diff <= 0 && item->info.query.correlation_level != 0)
-	{
-	  /* same correlation level or parent has greater correlation level; not acceptable */
-	  corr_diff = -corr_diff + 1;
-	  (void) mq_bump_correlation_level (parser, item, corr_diff, item->info.query.correlation_level);
-	}
-
-      /* peek back in stack list */
-      stack_item = stack_prev;
     }
-
   return node;
 }
 

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -14012,6 +14012,7 @@ mq_rewrite_order_dependent_query (PARSER_CONTEXT * parser, PT_NODE * select, int
 
 /*
  * mq_bump_order_dep_corr_lvl_pre - walk_tree function for bumping correlation
+ * levels of order dependent SELECTs
  *   parser(in): parser context
  *   node(in): node
  *   arg(in/out): parent node stack
@@ -14110,12 +14111,14 @@ mq_bump_order_dep_corr_lvl_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *a
 	  stack_item = stack_prev;
 	}
     }
+
   return node;
 }
 
 /*
  * mq_bump_order_dep_corr_lvl_post - walk_tree post function for bumping
- *                                   correlation levels
+ *                                   correlation levels of order dependent
+ *                                   SELECTs
  *   parser(in): parser context
  *   node(in): node
  *   arg(in/out): parent node stack
@@ -14159,7 +14162,8 @@ mq_bump_order_dep_corr_lvl_post (PARSER_CONTEXT * parser, PT_NODE * node, void *
 }
 
 /*
- * mq_bump_order_dep_corr_lvl - bump correlation levels for SELECTs
+ * mq_bump_order_dep_corr_lvl - bump correlation levels for order dependent
+ *                              SELECTs
  *   parser(in): parser context
  *   node(in): root node
  */
@@ -14168,6 +14172,7 @@ mq_bump_order_dep_corr_lvl (PARSER_CONTEXT * parser, PT_NODE * node)
 {
   PT_NODE *stack = NULL;
 
+  /* bump order dependent SELECTs */
   (void) parser_walk_tree (parser, node, mq_bump_order_dep_corr_lvl_pre, (void *) &stack,
 			   mq_bump_order_dep_corr_lvl_post, (void *) &stack);
 }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26318>

뷰 머징(View Merging) 이후 인덱스 스캔이 동작하지 않는 문제가 발생했다.
부질의(subquery)는 correlated subquery, uncorrelated subquery, nested subquery로 구분되는데, 이 중 correlated subquery는 인덱스 스캔이 불가능하다. 이는 데이터 조회 후 dptr를 통해 부질의를 실행해야 하므로, 힙 스캔만 사용할 수 있기 때문이다.
반면, 참조 컬럼이 없는 uncorrelated subquery나 참조 컬럼이 두 개 이상의 부질의 외부에 존재하는 경우, 해당 부질의는 aptr로 분류되어 이미 실행된 상태이므로 인덱스 스캔이 가능하다.

문제의 원인은 뷰 머징 이후 correlation_level을 재조정하지 않기 때문이다. 이 문제는 뷰 머징이 가능했던 9.3 버전에서도 존재했으며, 11.2 버전에서 뷰 머징이 inline view로 확장되어 기능 사용 빈도가 높아지면서 본격적으로 드러나게 되었다.

### Implementation

뷰머징이 이후 correlation_level 재조정

### Remarks

N/A
