### PR TITLE
[CBRD-26229] move PL related log files into a separate directory

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/ServerConfig.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/ServerConfig.java
@@ -41,7 +41,7 @@ import org.apache.commons.lang3.StringUtils;
 
 public class ServerConfig {
 
-    private static final String LOG_DIR = "log";
+    private static final String LOG_DIR = "log/pl";
 
     private final String name;
     private final String version;

--- a/src/executables/pl.cpp
+++ b/src/executables/pl.cpp
@@ -215,7 +215,7 @@ main (int argc, char *argv[])
 
 	/* error message log file */
 	char er_msg_file[PATH_MAX];
-	snprintf (er_msg_file, sizeof (er_msg_file) - 1, "%s_pl.err", db_name.c_str ());
+	snprintf (er_msg_file, sizeof (er_msg_file) - 1, "pl/%s_pl.err", db_name.c_str ());
 	er_init (er_msg_file, ER_NEVER_EXIT);
       }
 

--- a/src/sp/pl_file.c
+++ b/src/sp/pl_file.c
@@ -113,36 +113,6 @@ pl_get_info_file (char *buf, size_t len, const char *db_name)
 }
 
 bool
-pl_get_error_file (char *buf, size_t len, const char *db_name)
-{
-  char pl_logdir[PATH_MAX];
-  envvar_logdir_file (pl_logdir, sizeof (pl_logdir), "");
-
-  if (snprintf (buf, len, "%s/%s_pl.err", pl_logdir, db_name) < 0)
-    {
-      assert (false);
-      buf[0] = '\0';
-      return false;
-    }
-  return true;
-}
-
-bool
-pl_get_log_file (char *buf, size_t len, const char *db_name)
-{
-  char pl_logdir[PATH_MAX];
-  envvar_logdir_file (pl_logdir, sizeof (pl_logdir), "");
-
-  if (snprintf (buf, len, "%s/%s_pl.log", pl_logdir, db_name) < 0)
-    {
-      assert (false);
-      buf[0] = '\0';
-      return false;
-    }
-  return true;
-}
-
-bool
 pl_read_info (const char *db_name, PL_SERVER_INFO & info)
 {
   FILE *fp = NULL;

--- a/src/sp/pl_file.h
+++ b/src/sp/pl_file.h
@@ -59,8 +59,6 @@ extern "C"
   extern EXPORT_IMPORT bool pl_reset_info (const char *db_name);
 
   extern EXPORT_IMPORT bool pl_get_info_file (char *buf, size_t len, const char *db_name);
-  extern EXPORT_IMPORT bool pl_get_error_file (char *buf, size_t len, const char *db_name);
-  extern EXPORT_IMPORT bool pl_get_log_file (char *buf, size_t len, const char *db_name);
 
 #ifdef __cplusplus
 }

--- a/win/cubridsa/cubridsa.def
+++ b/win/cubridsa/cubridsa.def
@@ -140,7 +140,6 @@ EXPORTS
     pl_writen
     pl_readn
     pl_get_info_file
-    pl_get_error_file
     pl_open_info_dir
     pl_open_info
     pl_read_info


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26229>

### Purpose

DB 인스턴스마다 PL 관련 로그 파일이 네 종류 (<dbname>_pl.(access|err|log|log.lck) ) 가 생깁니다.
인스턴스가 많은 경우 혼란의 여지가 있어 server 디렉토리처럼 별도의 pl 디렉토리 아래에 로그가 생기도록 수정했습니다.

### Remark

- 확장자 .err 은 C 모듈에서 쓰는 로그 파일로서 cubrid pl (start|stop|restart|ping) \<dbname\> 을 실행했을 때 사용됩니다. 
  - .access 파일은 .err 파일에 부가적으로 큐브리드 로깅 시스템이 만드는 파일입니다.
- 확장자 .log 는 Java 모듈에서 쓰는 로그 파일입니다. 
  - .log.lck 는 .log 파일에 부가적으로 java.util.logging.Logger 라이브러리가 만드는 파일입니다. 
