### PR TITLE
[CBRD-25271] Core occurs when applying nvl function index to char type column (#5047)

### DIFF
--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -507,19 +507,11 @@ db_string_unique_prefix (const DB_VALUE * db_string1, const DB_VALUE * db_string
   precision = DB_VALUE_PRECISION (db_string1);
   /* Determine the result type */
   result_type = DB_VALUE_DOMAIN_TYPE (db_string1);
-  if (QSTR_IS_CHAR (result_type))
-    {
-      result_type = DB_TYPE_VARCHAR;
-    }
-  else if (QSTR_IS_NATIONAL_CHAR (result_type))
-    {
-      result_type = DB_TYPE_VARNCHAR;
-    }
-  else if (QSTR_IS_BIT (result_type))
+  if (QSTR_IS_BIT (result_type))
     {
       result_type = DB_TYPE_VARBIT;
     }
-  else
+  else if (!QSTR_IS_CHAR (result_type) && !QSTR_IS_NATIONAL_CHAR (result_type))
     {
       DB_MAKE_NULL (db_result);
 #if defined(CUBRID_DEBUG)

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -5592,22 +5592,9 @@ btree_generate_prefix_domain (BTID_INT * btid)
   dbtype = TP_DOMAIN_TYPE (domain);
 
   /* varying domains did not come into use until btree revision level 1 */
-  if (dbtype == DB_TYPE_CHAR || dbtype == DB_TYPE_NCHAR || dbtype == DB_TYPE_BIT)
+  if (dbtype == DB_TYPE_BIT)
     {
-      switch (dbtype)
-	{
-	case DB_TYPE_CHAR:
-	  vartype = DB_TYPE_VARCHAR;
-	  break;
-	case DB_TYPE_NCHAR:
-	  vartype = DB_TYPE_VARNCHAR;
-	  break;
-	case DB_TYPE_BIT:
-	  vartype = DB_TYPE_VARBIT;
-	  break;
-	default:
-	  return NULL;
-	}
+      vartype = DB_TYPE_VARBIT;
 
       var_domain =
 	tp_domain_resolve (vartype, domain->class_mop, domain->precision, domain->scale, domain->setdomain,


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-25271>

### Purpose

to patch "core dump" crash at following query sequence.

```
-- must be charset is utf8
cubrid createdb testdb ko_KR.utf8

CREATE TABLE nvl_tbl (code char(7));
CREATE INDEX idx_nvl ON nvl_tbl (nvl(code, '0'));

csql -u dba -i nvl_tbl.sql testdb 
```

### Implementation

10.2 버전에서 백포트 

### Remarks

N/A
