### PR TITLE
[CBRD-26319] fix core dump left join or use function index (#6497)

### DIFF
--- a/src/optimizer/query_bitset.c
+++ b/src/optimizer/query_bitset.c
@@ -610,7 +610,7 @@ bitset_delset (BITSET * s)
       s->nwords = NWORDS;
       BITSET_CLEAR (*s);
     }
-#if 0 // Disable using BITSET_MEMBER() after bitset_delset() until we can fix the issue.
+#if 0				// Disable using BITSET_MEMBER() after bitset_delset() until we can fix the issue.
 #if !defined(NDEBUG)
   s->nwords = 0;
   assert (BITSET_IS_VALID (s) == false);

--- a/src/optimizer/query_bitset.c
+++ b/src/optimizer/query_bitset.c
@@ -38,6 +38,9 @@
 #define bitset_malloc(env, size) malloc(size)
 #define bitset_free(ptr)         free_and_init(ptr)
 
+#define BITSET_IS_VALID(p)    ((p)->nwords > 0)
+
+
 /*
  * The number of one bits in a four-bit nibble.
  */
@@ -93,6 +96,8 @@ bitset_extend (BITSET * dst, int nwords)
 {
   BITSET_CARRIER *words;
 
+  assert (BITSET_IS_VALID (dst));
+
   words = (BITSET_CARRIER *) malloc (NBYTES (nwords));
   if (words == NULL)
     {
@@ -119,6 +124,8 @@ bitset_extend (BITSET * dst, int nwords)
 void
 bitset_assign (BITSET * dst, const BITSET * src)
 {
+  assert (BITSET_IS_VALID (dst));
+  assert (BITSET_IS_VALID (src));
   if (dst->nwords < src->nwords)
     {
       bitset_extend (dst, src->nwords);
@@ -138,6 +145,7 @@ void
 bitset_add (BITSET * dst, int x)
 {
   int n;
+  assert (BITSET_IS_VALID (dst));
 
   n = _WORD (x);
   if (n >= dst->nwords)
@@ -159,6 +167,8 @@ bitset_remove (BITSET * dst, int x)
 {
   int n;
 
+  assert (BITSET_IS_VALID (dst));
+
   n = _WORD (x);
   if (n < dst->nwords)
     {
@@ -176,6 +186,9 @@ void
 bitset_union (BITSET * dst, const BITSET * src)
 {
   int nwords;
+
+  assert (BITSET_IS_VALID (dst));
+  assert (BITSET_IS_VALID (src));
 
   if (dst->nwords < src->nwords)
     {
@@ -201,6 +214,9 @@ bitset_intersect (BITSET * dst, const BITSET * src)
 {
   int nwords;
 
+  assert (BITSET_IS_VALID (dst));
+  assert (BITSET_IS_VALID (src));
+
   nwords = dst->nwords;
   while (nwords > src->nwords)
     {
@@ -224,6 +240,9 @@ void
 bitset_difference (BITSET * dst, const BITSET * src)
 {
   int nwords;
+
+  assert (BITSET_IS_VALID (dst));
+  assert (BITSET_IS_VALID (src));
 
   nwords = MIN (dst->nwords, src->nwords);
   while (nwords)
@@ -264,6 +283,9 @@ bitset_subset (const BITSET * r, const BITSET * s)
 {
   int nwords;
 
+  assert (BITSET_IS_VALID (s));
+  assert (BITSET_IS_VALID (r));
+
   nwords = s->nwords;
   while (nwords > r->nwords)
     {
@@ -296,6 +318,9 @@ bitset_intersects (const BITSET * r, const BITSET * s)
 {
   int nwords;
 
+  assert (BITSET_IS_VALID (s));
+  assert (BITSET_IS_VALID (r));
+
   nwords = MIN (r->nwords, s->nwords);
   while (nwords)
     {
@@ -318,6 +343,8 @@ int
 bitset_is_empty (const BITSET * s)
 {
   int nwords;
+
+  assert (BITSET_IS_VALID (s));
 
   nwords = s->nwords;
   while (nwords)
@@ -342,6 +369,9 @@ int
 bitset_is_equivalent (const BITSET * r, const BITSET * s)
 {
   int nwords;
+
+  assert (BITSET_IS_VALID (s));
+  assert (BITSET_IS_VALID (r));
 
   if (r->nwords < s->nwords)
     {
@@ -393,6 +423,8 @@ int
 bitset_cardinality (const BITSET * s)
 {
   int nwords, card;
+
+  assert (BITSET_IS_VALID (s));
 
   nwords = s->nwords;
   card = 0;
@@ -488,6 +520,7 @@ bitset_next_member (BITSET_ITERATOR * si)
       return -1;
     }
 
+  assert (BITSET_IS_VALID (si->set));
   nwords = si->set->nwords;
   for (m = _WORD (current); m < nwords; current = _WORDSIZE * ++m)
     {
@@ -573,6 +606,11 @@ bitset_delset (BITSET * s)
   if (s->setp != s->set.word)
     {
       bitset_free (s->setp);
-      s->setp = NULL;
+      assert (s->setp == NULL);
     }
+
+#if !defined(NDEBUG)
+  s->nwords = 0;
+  assert (BITSET_IS_VALID (s) == false);
+#endif
 }

--- a/src/optimizer/query_bitset.c
+++ b/src/optimizer/query_bitset.c
@@ -606,11 +606,14 @@ bitset_delset (BITSET * s)
   if (s->setp != s->set.word)
     {
       bitset_free (s->setp);
-      assert (s->setp == NULL);
+      s->setp = s->set.word;
+      s->nwords = NWORDS;
+      BITSET_CLEAR (*s);
     }
-
+#if 0 // Disable using BITSET_MEMBER() after bitset_delset() until we can fix the issue.
 #if !defined(NDEBUG)
   s->nwords = 0;
   assert (BITSET_IS_VALID (s) == false);
+#endif
 #endif
 }

--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -6747,7 +6747,6 @@ qo_find_index_segs (QO_ENV * env, SM_CLASS_CONSTRAINT * consp, QO_NODE * nodep, 
   /* for each attribute of this constraint */
   for (i = 0; *nseg_idxp < seg_idx_num; i++)
     {
-
       if (consp->func_index_info && i == consp->func_index_info->col_id)
 	{
 	  matched = false;
@@ -6764,7 +6763,6 @@ qo_find_index_segs (QO_ENV * env, SM_CLASS_CONSTRAINT * consp, QO_NODE * nodep, 
 		  /* If we're handling with a multi-column index, then only equality expressions are allowed except for
 		   * the last matching segment.
 		   */
-		  bitset_delset (&working);
 		  matched = true;
 		  count_matched_index_attributes++;
 		  break;
@@ -6775,19 +6773,19 @@ qo_find_index_segs (QO_ENV * env, SM_CLASS_CONSTRAINT * consp, QO_NODE * nodep, 
 	      seg_idx[*nseg_idxp] = -1;	/* not found matched segment */
 	      (*nseg_idxp)++;	/* number of index segments, 'seg_idx[]' */
 	    }			/* if (!matched) */
+
+	  if (*nseg_idxp == seg_idx_num)
+	    {
+	      break;
+	    }
 	}
 
-      if (*nseg_idxp == seg_idx_num)
-	{
-	  break;
-	}
       attrp = consp->attributes[i];
 
       matched = false;
       /* for each indexed segments of this node, compare the name of the segment with the one of the attribute */
       for (iseg = bitset_iterate (&working, &iter); iseg != -1; iseg = bitset_next_member (&iter))
 	{
-
 	  segp = QO_ENV_SEG (env, iseg);
 
 	  if (!intl_identifier_casecmp (QO_SEG_NAME (segp), attrp->header.name))
@@ -8726,8 +8724,6 @@ qo_discover_sort_limit_nodes (QO_ENV * env)
       goto abandon_stop_limit;
     }
 
-  bitset_delset (&order_nodes);
-
   /* In order to create a SORT-LIMIT plan, the query must have a valid limit. All other conditions for creating the
    * plan have been met.
    */
@@ -8762,10 +8758,12 @@ qo_discover_sort_limit_nodes (QO_ENV * env)
     }
 
   env->use_sort_limit = QO_SL_USE;
+  bitset_delset (&order_nodes);
   return;
 
 sort_limit_possible:
   env->use_sort_limit = QO_SL_POSSIBLE;
+  bitset_delset (&order_nodes);
   bitset_delset (&QO_ENV_SORT_LIMIT_NODES (env));
   return;
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26319>

### Purpose

* Fixed a core dump issue that occurred when reusing a BITSET variable that had been cleared using bitset_delset().
* backport #6497

### Implementation

N/A

### Remarks

N/A
