### PR TITLE
[CBRD-26324] use LZ4_compress_fast_extState instead of LZ4_compress_default and add compression interface.

### DIFF
--- a/.nvim.lua
+++ b/.nvim.lua
@@ -1,0 +1,64 @@
+local grp = vim.api.nvim_create_augroup("ProjectCStyle", { clear = true })
+
+vim.api.nvim_create_autocmd({ "FileType" }, {
+	group = grp,
+	-- pattern = { "c", "cpp", "cmake", "sh" },
+	pattern = { "cmake", "sh" },
+	callback = function()
+		vim.b.autoformat = false
+	end,
+})
+
+vim.api.nvim_create_autocmd({ "FileType" }, {
+	group = grp,
+	-- pattern = { "c", "cpp", "cmake", "sh" },
+	pattern = { "c", "cpp" },
+	callback = function()
+		vim.b.autoformat = true
+	end,
+})
+
+-- Set tab settings specifically for C and C++ files
+vim.api.nvim_create_autocmd("FileType", {
+	group = grp,
+	pattern = { "c", "cpp", "yacc", "lex" },
+	callback = function()
+		vim.bo.cindent = true
+		vim.bo.indentexpr = ""
+		vim.bo.cinoptions = "j1,f0,^-2,{2,>4,:4,n-2,(0,t0"
+		vim.bo.shiftwidth = 2
+		vim.bo.tabstop = 8
+		vim.bo.expandtab = false
+	end,
+})
+
+-- Optional: shell files separate (C-style cindent is wrong for sh)
+vim.api.nvim_create_autocmd("FileType", {
+	group = grp,
+	pattern = { "sh" },
+	callback = function()
+		-- no cindent for shell files
+		vim.bo.expandtab = true
+		vim.bo.shiftwidth = 2
+		vim.bo.softtabstop = 2
+		vim.bo.tabstop = 2
+	end,
+})
+
+vim.filetype.add({
+	extension = { i = "c" },
+})
+
+local conform = require("conform")
+
+-- install indent <= 2.2.11
+-- for example, nix indent 2.2.10 is
+-- nix profile install nixpkgs/22f65339f3773f5b691f55b8b3a139e5582ae85b#indent
+conform.formatters.cubrid_c = {
+	command = "cubrid-format-codestyle.sh",
+	args = { "$FILENAME" },
+	stdin = false,
+}
+
+conform.formatters_by_ft.c = { "cubrid_c" }
+conform.formatters_by_ft.cpp = { "cubrid_c" }

--- a/cs/CMakeLists.txt
+++ b/cs/CMakeLists.txt
@@ -137,6 +137,7 @@ set(BASE_SOURCES
   )
 
 set(BASE_HEADERS
+  ${BASE_DIR}/compressor.hpp
   ${BASE_DIR}/error_code.h
   ${BASE_DIR}/error_context.hpp
   ${BASE_DIR}/error_manager.h

--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -133,6 +133,7 @@ set(BASE_SOURCES
   ${BASE_DIR}/xml_parser.c
   )
 set (BASE_HEADERS
+  ${BASE_DIR}/compressor.hpp
   ${BASE_DIR}/error_code.h
   ${BASE_DIR}/error_context.hpp
   ${BASE_DIR}/error_manager.h

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -131,6 +131,7 @@ set(BASE_SOURCES
   ${BASE_DIR}/ddl_log.c
   )
 set(BASE_HEADERS
+  ${BASE_DIR}/compressor.hpp
   ${BASE_DIR}/error_code.h
   ${BASE_DIR}/error_context.hpp
   ${BASE_DIR}/error_manager.h

--- a/src/base/compressor.hpp
+++ b/src/base/compressor.hpp
@@ -37,7 +37,7 @@ namespace cubcompress
   /* options */
   struct lz4_options
   {
-    int accel;
+    int accel = 1;
   };
   /* add here */
 
@@ -95,6 +95,7 @@ namespace cubcompress
     if (compressed_size <= 0)
       {
 	/* failed to compress */
+	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 1, "failed to compress with LZ4_compress_fast_extState");
 	return 0;
       }
     return compressed_size;
@@ -108,6 +109,7 @@ namespace cubcompress
     if (decompressed_size <= 0)
       {
 	/* failed to decompress */
+	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 1, "failed to decompress with LZ4_decompress_safe");
 	return 0;
       }
     return decompressed_size;
@@ -125,8 +127,6 @@ namespace cubcompress
       {
 	return lz4_bound (size);
       }
-
-    assert_release (false);
     return 0;
   }
 
@@ -143,8 +143,6 @@ namespace cubcompress
 				 lz4_option->accel);
 	  }
       }
-
-    assert_release (false);
     return 0;
   }
 
@@ -155,12 +153,9 @@ namespace cubcompress
 
     if constexpr (std::is_same<T, LZ4>::value)
       {
-	lz4_options option = /* default */ { 1 };
-
+	lz4_options option;
 	return compress<T> (src, src_size, dst, dst_capacity, option);
       }
-
-    assert_release (false);
     return 0;
   }
 
@@ -173,8 +168,6 @@ namespace cubcompress
       {
 	return lz4_decompress (static_cast<const char *> (src), static_cast<char *> (dst), src_size, dst_capacity);
       }
-
-    assert_release (false);
     return 0;
   }
 }

--- a/src/base/compressor.hpp
+++ b/src/base/compressor.hpp
@@ -96,7 +96,6 @@ namespace cubcompress
       {
 	/* failed to compress */
 	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 1, "failed to compress with LZ4_compress_fast_extState");
-	return 0;
       }
     return compressed_size;
   }
@@ -106,11 +105,10 @@ namespace cubcompress
     int decompressed_size;
 
     decompressed_size = LZ4_decompress_safe (src, dst, compressed_size, dst_capacity);
-    if (decompressed_size <= 0)
+    if (decompressed_size < 0)
       {
 	/* failed to decompress */
 	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 1, "failed to decompress with LZ4_decompress_safe");
-	return 0;
       }
     return decompressed_size;
   }
@@ -127,7 +125,7 @@ namespace cubcompress
       {
 	return lz4_bound (size);
       }
-    return 0;
+    return -1;
   }
 
   template <typename T>
@@ -143,7 +141,7 @@ namespace cubcompress
 				 lz4_option->accel);
 	  }
       }
-    return 0;
+    return -1;
   }
 
   template <typename T>
@@ -156,7 +154,7 @@ namespace cubcompress
 	lz4_options option;
 	return compress<T> (src, src_size, dst, dst_capacity, option);
       }
-    return 0;
+    return -1;
   }
 
   template <typename T>
@@ -168,7 +166,7 @@ namespace cubcompress
       {
 	return lz4_decompress (static_cast<const char *> (src), static_cast<char *> (dst), src_size, dst_capacity);
       }
-    return 0;
+    return -1;
   }
 }
 

--- a/src/base/compressor.hpp
+++ b/src/base/compressor.hpp
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+/*
+ * compressor.hpp
+ */
+
+#ifndef _BASE_COMPRESSOR_HPP_
+#define _BASE_COMPRESSOR_HPP_
+
+#include "lz4.h"
+#include "error_manager.h"
+
+#include <memory>
+#include <variant>
+
+namespace cubcompress
+{
+  struct LZ4 {};
+  /* add here */
+
+  /* options */
+  struct lz4_options
+  {
+    int accel;
+  };
+  /* add here */
+
+  using options = std::variant<lz4_options /*, add here */>;
+
+  /* ---------------------------------------------------------------------------- */
+  /* LZ4									  */
+  /* ---------------------------------------------------------------------------- */
+  struct LZ4ContextDeleter
+  {
+    void operator () (LZ4_stream_t *ctx) const noexcept
+    {
+      if (ctx)
+	{
+	  (void) LZ4_freeStream (ctx);
+	}
+    }
+  };
+
+  inline LZ4_stream_t *lz4_stream ()
+  {
+    thread_local std::unique_ptr<LZ4_stream_t, LZ4ContextDeleter> context { nullptr };
+
+    if (!context)
+      {
+	context.reset (LZ4_createStream ());
+	if (!context)
+	  {
+	    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 1, "failed to create LZ4 stream context");
+	  }
+      }
+    return context.get ();
+  }
+
+  inline int lz4_bound (int size)
+  {
+    return LZ4_compressBound (size);
+  }
+
+  inline int lz4_compress (const char *src, char *dst, int src_size, int dst_capacity, int accel)
+  {
+    LZ4_stream_t *ctx;
+    int compressed_size;
+
+    ctx = lz4_stream ();
+    if (!ctx)
+      {
+	/* failed to get lz4 stream (context) */
+	return 0;
+      }
+
+    LZ4_resetStream_fast (ctx);
+
+    compressed_size = LZ4_compress_fast_extState (ctx, src, dst, src_size, dst_capacity, accel);
+    if (compressed_size <= 0)
+      {
+	/* failed to compress */
+	return 0;
+      }
+    return compressed_size;
+  }
+
+  inline int lz4_decompress (const char *src, char *dst, int compressed_size, int dst_capacity)
+  {
+    int decompressed_size;
+
+    decompressed_size = LZ4_decompress_safe (src, dst, compressed_size, dst_capacity);
+    if (decompressed_size <= 0)
+      {
+	/* failed to decompress */
+	return 0;
+      }
+    return decompressed_size;
+  }
+
+  /* ---------------------------------------------------------------------------- */
+  /* interface									  */
+  /* ---------------------------------------------------------------------------- */
+  template <typename T>
+  inline int bound (int size)
+  {
+    static_assert (std::is_same_v<T, LZ4>, "T must be LZ4");
+
+    if constexpr (std::is_same<T, LZ4>::value)
+      {
+	return lz4_bound (size);
+      }
+
+    assert_release (false);
+    return 0;
+  }
+
+  template <typename T>
+  inline int compress (const void *src, int src_size, void *dst, int dst_capacity, const options &option)
+  {
+    static_assert (std::is_same_v<T, LZ4>, "T must be LZ4");
+
+    if constexpr (std::is_same<T, LZ4>::value)
+      {
+	if (auto *lz4_option = std::get_if<lz4_options> (&option))
+	  {
+	    return lz4_compress (static_cast<const char *> (src), static_cast<char *> (dst), src_size, dst_capacity,
+				 lz4_option->accel);
+	  }
+      }
+
+    assert_release (false);
+    return 0;
+  }
+
+  template <typename T>
+  inline int compress (const void *src, int src_size, void *dst, int dst_capacity)
+  {
+    static_assert (std::is_same_v<T, LZ4>, "T must be LZ4");
+
+    if constexpr (std::is_same<T, LZ4>::value)
+      {
+	lz4_options option = /* default */ { 1 };
+
+	return compress<T> (src, src_size, dst, dst_capacity, option);
+      }
+
+    assert_release (false);
+    return 0;
+  }
+
+  template <typename T>
+  inline int decompress (const void *src, int src_size, void *dst, int dst_capacity)
+  {
+    static_assert (std::is_same_v<T, LZ4>, "T must be LZ4");
+
+    if constexpr (std::is_same<T, LZ4>::value)
+      {
+	return lz4_decompress (static_cast<const char *> (src), static_cast<char *> (dst), src_size, dst_capacity);
+      }
+
+    assert_release (false);
+    return 0;
+  }
+}
+
+#endif

--- a/src/base/compressor.hpp
+++ b/src/base/compressor.hpp
@@ -20,8 +20,8 @@
  * compressor.hpp
  */
 
-#ifndef _BASE_COMPRESSOR_HPP_
-#define _BASE_COMPRESSOR_HPP_
+#ifndef _COMPRESSOR_HPP_
+#define _COMPRESSOR_HPP_
 
 #include "lz4.h"
 #include "error_manager.h"
@@ -37,6 +37,9 @@ namespace cubcompress
   /* options */
   struct lz4_options
   {
+    /* accel must be a value between 1 and LZ4_ACCELERATION_MAX (usually 65537).  */
+    /* trade-off: accel ≈ 1 = best compression ratio.				  */
+    /*		  larger accel = higher throughput.				  */
     int accel = 1;
   };
   /* add here */

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -26,14 +26,12 @@
 
 #include "config.h"
 
-
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
 
 #include "object_primitive.h"
 
-#include "compressor.hpp"
 #include "area_alloc.h"
 #include "db_value_printer.hpp"
 #include "db_json.hpp"

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -10844,9 +10844,11 @@ mr_readval_string_internal (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain, 
 		    }
 
 		  /* decompressing the string */
+		  // *INDENT-OFF*
 		  decompressed_size =
-		    cubcompress::decompress < cubcompress::LZ4 > (new_, compressed_size, decompressed_string,
-								  expected_decompressed_size);
+		    cubcompress::decompress<cubcompress::LZ4> (new_, compressed_size, decompressed_string,
+							       expected_decompressed_size);
+		  // *INDENT-ON*
 		  if (decompressed_size < 0)
 		    {
 		      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_IO_LZ4_DECOMPRESS_FAIL, 0);
@@ -13946,8 +13948,10 @@ pr_get_compressed_data_from_buffer (struct or_buf *buf, char *data, int compress
       /* Handle decompression */
 
       /* decompressing the string */
+      // *INDENT-OFF*
       decompressed_size =
-	cubcompress::decompress < cubcompress::LZ4 > (buf->ptr, compressed_size, data, expected_decompressed_size);
+	cubcompress::decompress<cubcompress::LZ4> (buf->ptr, compressed_size, data, expected_decompressed_size);
+      // *INDENT-ON*
       if (decompressed_size < 0)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_IO_LZ4_DECOMPRESS_FAIL, 0);
@@ -13993,7 +13997,9 @@ pr_get_compression_length (const char *string, int str_length)
     }
 
   /* Alloc memory for the compressed string */
-  compress_buffer_size = cubcompress::bound < cubcompress::LZ4 > (str_length);
+  // *INDENT-OFF*
+  compress_buffer_size = cubcompress::bound<cubcompress::LZ4> (str_length);
+  // *INDENT-ON*
   compressed_string = (char *) malloc (compress_buffer_size);
   if (compressed_string == NULL)
     {
@@ -14002,8 +14008,10 @@ pr_get_compression_length (const char *string, int str_length)
     }
 
   /* Compress the string */
+  // *INDENT-OFF*
   compressed_length =
-    cubcompress::compress < cubcompress::LZ4 > (string, str_length, compressed_string, compress_buffer_size);
+    cubcompress::compress<cubcompress::LZ4> (string, str_length, compressed_string, compress_buffer_size);
+  // *INDENT-ON*
   if (compressed_length <= 0)
     {
       /* We should not be having any kind of errors here. Because if this compression fails, there is not warranty
@@ -14079,7 +14087,9 @@ pr_get_size_and_write_string_to_buffer (struct or_buf *buf, char *val_p, DB_VALU
 
   /* Step 1 : Compress, if possible, the dbvalue */
   /* Alloc memory for the compressed string */
-  compress_buffer_size = cubcompress::bound < cubcompress::LZ4 > (str_length);
+  // *INDENT-OFF*
+  compress_buffer_size = cubcompress::bound<cubcompress::LZ4> (str_length);
+  // *INDENT-ON*
   compressed_string = (char *) malloc (compress_buffer_size);
   if (compressed_string == NULL)
     {
@@ -14088,8 +14098,10 @@ pr_get_size_and_write_string_to_buffer (struct or_buf *buf, char *val_p, DB_VALU
       goto cleanup;
     }
 
+  // *INDENT-OFF*
   compression_length =
-    cubcompress::compress < cubcompress::LZ4 > (string, str_length, compressed_string, compress_buffer_size);
+    cubcompress::compress<cubcompress::LZ4> (string, str_length, compressed_string, compress_buffer_size);
+  // *INDENT-ON*
   if (compression_length <= 0)
     {
       /* We should not be having any kind of errors here. Because if this compression fails, there is not warranty
@@ -14320,8 +14332,10 @@ pr_data_compress_string (const char *string, int str_length, char *compressed_st
     }
 
   /* Compress the string */
+  // *INDENT-OFF*
   compressed_length_local =
-    cubcompress::compress < cubcompress::LZ4 > (string, str_length, compressed_string, compress_buffer_size);
+    cubcompress::compress<cubcompress::LZ4> (string, str_length, compressed_string, compress_buffer_size);
+  // *INDENT-ON*
   if (compressed_length_local <= 0)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_IO_LZ4_COMPRESS_FAIL, 4, FILEIO_ZIP_LZ4_METHOD,
@@ -14442,7 +14456,9 @@ pr_do_db_value_string_compression (DB_VALUE * value)
     }
 
   /* Alloc memory for compression */
-  compressed_size = cubcompress::bound < cubcompress::LZ4 > (src_size);
+  // *INDENT-OFF*
+  compressed_size = cubcompress::bound<cubcompress::LZ4> (src_size);
+  // *INDENT-ON*
   compressed_string = (char *) db_private_alloc (NULL, compressed_size);
   if (compressed_string == NULL)
     {

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -33,12 +33,14 @@
 
 #include "object_primitive.h"
 
+#include "compressor.hpp"
 #include "area_alloc.h"
 #include "db_value_printer.hpp"
 #include "db_json.hpp"
 #include "elo.h"
 #include "error_manager.h"
 #include "file_io.h"
+#include "compressor.hpp"
 #include "mem_block.hpp"
 #include "object_representation.h"
 #include "set_object.h"
@@ -10845,7 +10847,8 @@ mr_readval_string_internal (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain, 
 
 		  /* decompressing the string */
 		  decompressed_size =
-		    LZ4_decompress_safe (new_, decompressed_string, compressed_size, expected_decompressed_size);
+		    cubcompress::decompress < cubcompress::LZ4 > (new_, compressed_size, decompressed_string,
+								  expected_decompressed_size);
 		  if (decompressed_size < 0)
 		    {
 		      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_IO_LZ4_DECOMPRESS_FAIL, 0);
@@ -13945,7 +13948,8 @@ pr_get_compressed_data_from_buffer (struct or_buf *buf, char *data, int compress
       /* Handle decompression */
 
       /* decompressing the string */
-      decompressed_size = LZ4_decompress_safe (buf->ptr, data, compressed_size, expected_decompressed_size);
+      decompressed_size =
+	cubcompress::decompress < cubcompress::LZ4 > (buf->ptr, compressed_size, data, expected_decompressed_size);
       if (decompressed_size < 0)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_IO_LZ4_DECOMPRESS_FAIL, 0);
@@ -13991,7 +13995,7 @@ pr_get_compression_length (const char *string, int str_length)
     }
 
   /* Alloc memory for the compressed string */
-  compress_buffer_size = LZ4_compressBound (str_length);
+  compress_buffer_size = cubcompress::bound < cubcompress::LZ4 > (str_length);
   compressed_string = (char *) malloc (compress_buffer_size);
   if (compressed_string == NULL)
     {
@@ -14000,7 +14004,8 @@ pr_get_compression_length (const char *string, int str_length)
     }
 
   /* Compress the string */
-  compressed_length = LZ4_compress_default (string, compressed_string, str_length, compress_buffer_size);
+  compressed_length =
+    cubcompress::compress < cubcompress::LZ4 > (string, str_length, compressed_string, compress_buffer_size);
   if (compressed_length <= 0)
     {
       /* We should not be having any kind of errors here. Because if this compression fails, there is not warranty
@@ -14076,7 +14081,7 @@ pr_get_size_and_write_string_to_buffer (struct or_buf *buf, char *val_p, DB_VALU
 
   /* Step 1 : Compress, if possible, the dbvalue */
   /* Alloc memory for the compressed string */
-  compress_buffer_size = LZ4_compressBound (str_length);
+  compress_buffer_size = cubcompress::bound < cubcompress::LZ4 > (str_length);
   compressed_string = (char *) malloc (compress_buffer_size);
   if (compressed_string == NULL)
     {
@@ -14085,7 +14090,8 @@ pr_get_size_and_write_string_to_buffer (struct or_buf *buf, char *val_p, DB_VALU
       goto cleanup;
     }
 
-  compression_length = LZ4_compress_default (string, compressed_string, str_length, compress_buffer_size);
+  compression_length =
+    cubcompress::compress < cubcompress::LZ4 > (string, str_length, compressed_string, compress_buffer_size);
   if (compression_length <= 0)
     {
       /* We should not be having any kind of errors here. Because if this compression fails, there is not warranty
@@ -14316,7 +14322,8 @@ pr_data_compress_string (const char *string, int str_length, char *compressed_st
     }
 
   /* Compress the string */
-  compressed_length_local = LZ4_compress_default (string, compressed_string, str_length, compress_buffer_size);
+  compressed_length_local =
+    cubcompress::compress < cubcompress::LZ4 > (string, str_length, compressed_string, compress_buffer_size);
   if (compressed_length_local <= 0)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_IO_LZ4_COMPRESS_FAIL, 4, FILEIO_ZIP_LZ4_METHOD,
@@ -14437,7 +14444,7 @@ pr_do_db_value_string_compression (DB_VALUE * value)
     }
 
   /* Alloc memory for compression */
-  compressed_size = LZ4_compressBound (src_size);
+  compressed_size = cubcompress::bound < cubcompress::LZ4 > (src_size);
   compressed_string = (char *) db_private_alloc (NULL, compressed_size);
   if (compressed_string == NULL)
     {

--- a/src/object/object_representation.c
+++ b/src/object/object_representation.c
@@ -38,6 +38,7 @@
 #include "file_io.h"
 #include "log_lsa.hpp"
 
+#include "compressor.hpp"
 #include "object_primitive.h"
 #include "object_representation.h"
 #include "oid.h"
@@ -819,7 +820,7 @@ or_put_varchar_internal (OR_BUF * buf, char *string, int charlen, int align)
       assert (OR_IS_STRING_LENGTH_COMPRESSABLE (charlen));
 
       /* Alloc memory for the compressed string */
-      compress_buffer_size = LZ4_compressBound (charlen);
+      compress_buffer_size = cubcompress::bound < cubcompress::LZ4 > (charlen);
       compressed_string = (char *) malloc (compress_buffer_size);
       if (compressed_string == NULL)
 	{
@@ -829,7 +830,8 @@ or_put_varchar_internal (OR_BUF * buf, char *string, int charlen, int align)
 	}
 
       /* Compress the string */
-      compressed_length = LZ4_compress_default (string, compressed_string, charlen, compress_buffer_size);
+      compressed_length =
+	cubcompress::compress < cubcompress::LZ4 > (string, charlen, compressed_string, compress_buffer_size);
       if (compressed_length <= 0)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_IO_LZ4_COMPRESS_FAIL, 4, FILEIO_ZIP_LZ4_METHOD,

--- a/src/object/object_representation.c
+++ b/src/object/object_representation.c
@@ -820,7 +820,10 @@ or_put_varchar_internal (OR_BUF * buf, char *string, int charlen, int align)
       assert (OR_IS_STRING_LENGTH_COMPRESSABLE (charlen));
 
       /* Alloc memory for the compressed string */
-      compress_buffer_size = cubcompress::bound < cubcompress::LZ4 > (charlen);
+
+      // *INDENT-OFF*
+      compress_buffer_size = cubcompress::bound<cubcompress::LZ4> (charlen);
+      // *INDENT-ON*
       compressed_string = (char *) malloc (compress_buffer_size);
       if (compressed_string == NULL)
 	{
@@ -830,8 +833,10 @@ or_put_varchar_internal (OR_BUF * buf, char *string, int charlen, int align)
 	}
 
       /* Compress the string */
+      // *INDENT-OFF*
       compressed_length =
-	cubcompress::compress < cubcompress::LZ4 > (string, charlen, compressed_string, compress_buffer_size);
+	cubcompress::compress<cubcompress::LZ4> (string, charlen, compressed_string, compress_buffer_size);
+      // *INDENT-ON*
       if (compressed_length <= 0)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_IO_LZ4_COMPRESS_FAIL, 4, FILEIO_ZIP_LZ4_METHOD,

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -70,6 +70,7 @@
 #include "chartype.h"
 #include "connection_globals.h"
 #include "file_io.h"
+#include "compressor.hpp"
 #include "storage_common.h"
 #include "memory_alloc.h"
 #include "error_manager.h"
@@ -7479,7 +7480,7 @@ fileio_allocate_node (FILEIO_QUEUE * queue_p, FILEIO_BACKUP_HEADER * backup_head
     {
     case FILEIO_ZIP_LZ4_METHOD:
       assert (size <= LZ4_MAX_INPUT_SIZE);
-      buf_size = LZ4_compressBound (size);
+      buf_size = cubcompress::bound < cubcompress::LZ4 > (size);
       zip_info_size = offsetof (FILEIO_ZIP_INFO, zip_page) + sizeof (int) + buf_size;
       node_p->zip_info = (FILEIO_ZIP_INFO *) malloc (zip_info_size);
       if (node_p->zip_info == NULL)
@@ -7628,7 +7629,8 @@ fileio_compress_backup_node (FILEIO_NODE * node_p, FILEIO_BACKUP_HEADER * backup
     case FILEIO_ZIP_LZ4_METHOD:
       /* The alternative is compress faster - best speed, but, require more memory alloc */
       local_buf_len =
-	LZ4_compress_default ((char *) node_p->area, zip_page->buf, (int) node_p->nread, node_p->zip_info->buf_size);
+	cubcompress::compress < cubcompress::LZ4 > ((char *) node_p->area, (int) node_p->nread, zip_page->buf,
+						    node_p->zip_info->buf_size);
       if (local_buf_len <= 0)
 	{
 	  /* best reduction */
@@ -10122,8 +10124,9 @@ fileio_decompress_restore_volume (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION
 
 	    /* decompress - use safe decompressor as data might be corrupted during a file transfer */
 	    unzip_len =
-	      LZ4_decompress_safe ((const char *) zip_page->buf, (char *) session_p->dbfile.area, zip_page->buf_len,
-				   nbytes);
+	      cubcompress::decompress < cubcompress::LZ4 > ((const char *) zip_page->buf, zip_page->buf_len,
+							    (char *) session_p->dbfile.area, nbytes);
+
 	    if (unzip_len < 0 || unzip_len != nbytes)
 	      {
 		error = ER_IO_LZ4_DECOMPRESS_FAIL;

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -7480,7 +7480,9 @@ fileio_allocate_node (FILEIO_QUEUE * queue_p, FILEIO_BACKUP_HEADER * backup_head
     {
     case FILEIO_ZIP_LZ4_METHOD:
       assert (size <= LZ4_MAX_INPUT_SIZE);
-      buf_size = cubcompress::bound < cubcompress::LZ4 > (size);
+      // *INDENT-OFF*
+      buf_size = cubcompress::bound<cubcompress::LZ4> (size);
+      // *INDENT-ON*
       zip_info_size = offsetof (FILEIO_ZIP_INFO, zip_page) + sizeof (int) + buf_size;
       node_p->zip_info = (FILEIO_ZIP_INFO *) malloc (zip_info_size);
       if (node_p->zip_info == NULL)
@@ -7628,9 +7630,11 @@ fileio_compress_backup_node (FILEIO_NODE * node_p, FILEIO_BACKUP_HEADER * backup
     {
     case FILEIO_ZIP_LZ4_METHOD:
       /* The alternative is compress faster - best speed, but, require more memory alloc */
+      // *INDENT-OFF*
       local_buf_len =
-	cubcompress::compress < cubcompress::LZ4 > ((char *) node_p->area, (int) node_p->nread, zip_page->buf,
-						    node_p->zip_info->buf_size);
+	cubcompress::compress<cubcompress::LZ4> ((char *) node_p->area, (int) node_p->nread, zip_page->buf,
+						 node_p->zip_info->buf_size);
+      // *INDENT-ON*
       if (local_buf_len <= 0)
 	{
 	  /* best reduction */
@@ -10123,9 +10127,11 @@ fileio_decompress_restore_volume (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION
 	      }
 
 	    /* decompress - use safe decompressor as data might be corrupted during a file transfer */
+	    // *INDENT-OFF*
 	    unzip_len =
-	      cubcompress::decompress < cubcompress::LZ4 > ((const char *) zip_page->buf, zip_page->buf_len,
-							    (char *) session_p->dbfile.area, nbytes);
+	      cubcompress::decompress<cubcompress::LZ4> ((const char *) zip_page->buf, zip_page->buf_len,
+							 (char *) session_p->dbfile.area, nbytes);
+	    // *INDENT-ON*
 
 	    if (unzip_len < 0 || unzip_len != nbytes)
 	      {

--- a/src/transaction/log_compress.c
+++ b/src/transaction/log_compress.c
@@ -27,7 +27,6 @@
 #include <string.h>
 #include <assert.h>
 
-#include "compressor.hpp"
 #include "log_compress.h"
 #include "error_manager.h"
 #include "memory_alloc.h"
@@ -79,9 +78,12 @@ log_zip (LOG_ZIP * log_zip, LOG_ZIP_SIZE_T length, const void *data)
   /* save original data length */
   memcpy (log_zip->log_data, &length, sizeof (LOG_ZIP_SIZE_T));
 
+  // *INDENT-OFF*
   zip_len =
-    cubcompress::compress < cubcompress::LZ4 > (data, length, log_zip->log_data + sizeof (LOG_ZIP_SIZE_T),
-						buf_size - sizeof (LOG_ZIP_SIZE_T));
+    cubcompress::compress<cubcompress::LZ4> (data, length, log_zip->log_data + sizeof (LOG_ZIP_SIZE_T),
+					     buf_size - sizeof (LOG_ZIP_SIZE_T));
+  // *INDENT-ON*
+
   if (zip_len > 0)
     {
       log_zip->data_length = (LOG_ZIP_SIZE_T) zip_len + sizeof (LOG_ZIP_SIZE_T);
@@ -140,9 +142,11 @@ log_unzip (LOG_ZIP * log_unzip, LOG_ZIP_SIZE_T length, const void *data)
 
   decompressed = false;
 
+  // *INDENT-OFF*
   unzip_len =
-    cubcompress::decompress < cubcompress::LZ4 > ((const char *) data + sizeof (LOG_ZIP_SIZE_T), length,
-						  (char *) log_unzip->log_data, buf_size);
+    cubcompress::decompress<cubcompress::LZ4> ((const char *) data + sizeof (LOG_ZIP_SIZE_T), length,
+					       (char *) log_unzip->log_data, buf_size);
+  // *INDENT-ON*
   if (unzip_len >= 0)
     {
       log_unzip->data_length = (LOG_ZIP_SIZE_T) unzip_len;

--- a/src/transaction/log_compress.c
+++ b/src/transaction/log_compress.c
@@ -27,6 +27,7 @@
 #include <string.h>
 #include <assert.h>
 
+#include "compressor.hpp"
 #include "log_compress.h"
 #include "error_manager.h"
 #include "memory_alloc.h"
@@ -62,7 +63,7 @@ log_zip (LOG_ZIP * log_zip, LOG_ZIP_SIZE_T length, const void *data)
 
   log_zip->data_length = 0;
 
-  buf_size = LOG_ZIP_BUF_SIZE (length);
+  buf_size = LOG_ZIP_BUF_SIZE (LZ4, length);
 
   if (!log_zip_realloc_if_needed (*log_zip, buf_size))
     {
@@ -79,8 +80,8 @@ log_zip (LOG_ZIP * log_zip, LOG_ZIP_SIZE_T length, const void *data)
   memcpy (log_zip->log_data, &length, sizeof (LOG_ZIP_SIZE_T));
 
   zip_len =
-    LZ4_compress_default ((const char *) data, log_zip->log_data + sizeof (LOG_ZIP_SIZE_T), length,
-			  buf_size - sizeof (LOG_ZIP_SIZE_T));
+    cubcompress::compress < cubcompress::LZ4 > (data, length, log_zip->log_data + sizeof (LOG_ZIP_SIZE_T),
+						buf_size - sizeof (LOG_ZIP_SIZE_T));
   if (zip_len > 0)
     {
       log_zip->data_length = (LOG_ZIP_SIZE_T) zip_len + sizeof (LOG_ZIP_SIZE_T);
@@ -140,7 +141,8 @@ log_unzip (LOG_ZIP * log_unzip, LOG_ZIP_SIZE_T length, const void *data)
   decompressed = false;
 
   unzip_len =
-    LZ4_decompress_safe ((const char *) data + sizeof (LOG_ZIP_SIZE_T), (char *) log_unzip->log_data, length, buf_size);
+    cubcompress::decompress < cubcompress::LZ4 > ((const char *) data + sizeof (LOG_ZIP_SIZE_T), length,
+						  (char *) log_unzip->log_data, buf_size);
   if (unzip_len >= 0)
     {
       log_unzip->data_length = (LOG_ZIP_SIZE_T) unzip_len;
@@ -200,7 +202,7 @@ log_zip_realloc_if_needed (LOG_ZIP & log_zip, LOG_ZIP_SIZE_T new_size)
 
   if (new_size > 0 && new_size > log_zip.buf_size)
     {
-      const LOG_ZIP_SIZE_T buf_size = LOG_ZIP_BUF_SIZE (new_size);
+      const LOG_ZIP_SIZE_T buf_size = LOG_ZIP_BUF_SIZE (LZ4, new_size);
       assert (buf_size <= LZ4_MAX_INPUT_SIZE);
 
       log_zip.log_data = (char *) realloc (log_zip.log_data, buf_size);

--- a/src/transaction/log_compress.h
+++ b/src/transaction/log_compress.h
@@ -42,7 +42,7 @@
 
 /* plus compression overhead to log_zip data size */
 #define LOG_ZIP_BUF_SIZE(type, length) \
-        (cubcompress::bound<cubcompress::type> ((length) + sizeof (LOG_ZIP_SIZE_T)))
+        (cubcompress::bound<cubcompress::type> (length) + sizeof (LOG_ZIP_SIZE_T))
 
 #define LOG_ZIP_SIZE_T int
 

--- a/src/transaction/log_compress.h
+++ b/src/transaction/log_compress.h
@@ -29,6 +29,7 @@
 #ident "$Id$"
 
 #include "lz4.h"
+#include "compressor.hpp"
 
 #define MAKE_ZIP_LEN(length)                                                  \
          ((length) | 0x80000000)
@@ -39,9 +40,9 @@
 #define ZIP_CHECK(length)                                                     \
          (((length) & 0x80000000) ? true : false)
 
-/* plus lz4 overhead to log_zip data size */
-#define LOG_ZIP_BUF_SIZE(length) \
-        (LZ4_compressBound(length) + sizeof(LOG_ZIP_SIZE_T))
+/* plus compression overhead to log_zip data size */
+#define LOG_ZIP_BUF_SIZE(type, length) \
+        (cubcompress::bound<cubcompress::type> ((length) + sizeof(LOG_ZIP_SIZE_T)))
 
 #define LOG_ZIP_SIZE_T int
 

--- a/src/transaction/log_compress.h
+++ b/src/transaction/log_compress.h
@@ -42,7 +42,7 @@
 
 /* plus compression overhead to log_zip data size */
 #define LOG_ZIP_BUF_SIZE(type, length) \
-        (cubcompress::bound<cubcompress::type> ((length) + sizeof(LOG_ZIP_SIZE_T)))
+        (cubcompress::bound<cubcompress::type> ((length) + sizeof (LOG_ZIP_SIZE_T)))
 
 #define LOG_ZIP_SIZE_T int
 

--- a/src/transaction/log_compress.h
+++ b/src/transaction/log_compress.h
@@ -28,7 +28,6 @@
 
 #ident "$Id$"
 
-#include "lz4.h"
 #include "compressor.hpp"
 
 #define MAKE_ZIP_LEN(length)                                                  \


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26324>

### Purpose

LZ4_compress_default는 내부적으로 매번 초기화를 반복하므로 LZ4_compress_fast_extState를 사용하여 초기화를 수행하지 않도록 한다.

### Implementation

compress이 실제로 호출될 때 thread_local에 context를 초기화하도록 한다. 이후 해당 context를 재사용하여 전역 초기화를 회피한다.

### Remarks

추후 압축 알고리즘이 추가될 것을 고려하여 인터페이스를 정리하였다. path는 컴파일 타임에 결정되므로 부하가 전혀 없다.