### PR TITLE
[CBRD-26328] suppress quote for proc unique name

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -3301,9 +3301,15 @@ pt_bind_names (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue
        */
       method_name_node = node->info.method_call.method_name;
       // parser_print_tree is for built-in package names such as DBMS_OUTPUT
-      method_name = PT_NAME_RESOLVED (method_name_node) ? parser_print_tree (parser,
-									     method_name_node) :
-	PT_NAME_ORIGINAL (method_name_node);
+      if (PT_NAME_RESOLVED (method_name_node)) {
+          int custom_print_saved = parser->custom_print;
+          parser->custom_print |= PT_SUPPRESS_QUOTES;
+          parser->custom_print &= ~PT_PRINT_QUOTES;
+          method_name = parser_print_tree (parser, method_name_node);
+          parser->custom_print = custom_print_saved;
+      } else {
+          method_name = PT_NAME_ORIGINAL (method_name_node);
+      }
       if (!node->info.method_call.on_call_target && jsp_is_exist_stored_procedure (method_name))
 	{
 	  method_name_node->info.name.spec_id = (UINTPTR) method_name_node;

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -3301,15 +3301,18 @@ pt_bind_names (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue
        */
       method_name_node = node->info.method_call.method_name;
       // parser_print_tree is for built-in package names such as DBMS_OUTPUT
-      if (PT_NAME_RESOLVED (method_name_node)) {
-          int custom_print_saved = parser->custom_print;
-          parser->custom_print |= PT_SUPPRESS_QUOTES;
-          parser->custom_print &= ~PT_PRINT_QUOTES;
-          method_name = parser_print_tree (parser, method_name_node);
-          parser->custom_print = custom_print_saved;
-      } else {
-          method_name = PT_NAME_ORIGINAL (method_name_node);
-      }
+      if (PT_NAME_RESOLVED (method_name_node))
+	{
+	  int custom_print_saved = parser->custom_print;
+	  parser->custom_print |= PT_SUPPRESS_QUOTES;
+	  parser->custom_print &= ~PT_PRINT_QUOTES;
+	  method_name = parser_print_tree (parser, method_name_node);
+	  parser->custom_print = custom_print_saved;
+	}
+      else
+	{
+	  method_name = PT_NAME_ORIGINAL (method_name_node);
+	}
       if (!node->info.method_call.on_call_target && jsp_is_exist_stored_procedure (method_name))
 	{
 	  method_name_node->info.name.spec_id = (UINTPTR) method_name_node;

--- a/src/sp/jsp_cl.cpp
+++ b/src/sp/jsp_cl.cpp
@@ -2037,15 +2037,18 @@ jsp_make_pl_signature (PARSER_CONTEXT *parser, PT_NODE *node, PT_NODE *subquery_
     PT_NODE *method_name_node = node->info.method_call.method_name;
 
     const char *name;
-    if (PT_NAME_RESOLVED (method_name_node)) {
-        int custom_print_saved = parser->custom_print;
-        parser->custom_print |= PT_SUPPRESS_QUOTES;
-        parser->custom_print &= ~PT_PRINT_QUOTES;
-        name = parser_print_tree (parser, method_name_node);
-        parser->custom_print = custom_print_saved;
-    } else {
-        name = PT_NAME_ORIGINAL (method_name_node);
-    }
+    if (PT_NAME_RESOLVED (method_name_node))
+      {
+	int custom_print_saved = parser->custom_print;
+	parser->custom_print |= PT_SUPPRESS_QUOTES;
+	parser->custom_print &= ~PT_PRINT_QUOTES;
+	name = parser_print_tree (parser, method_name_node);
+	parser->custom_print = custom_print_saved;
+      }
+    else
+      {
+	name = PT_NAME_ORIGINAL (method_name_node);
+      }
 
     sig.name = db_private_strdup (NULL, name);
     if (PT_IS_METHOD (node))

--- a/src/sp/jsp_cl.cpp
+++ b/src/sp/jsp_cl.cpp
@@ -2035,8 +2035,17 @@ jsp_make_pl_signature (PARSER_CONTEXT *parser, PT_NODE *node, PT_NODE *subquery_
 
   {
     PT_NODE *method_name_node = node->info.method_call.method_name;
-    const char *name = PT_NAME_RESOLVED (method_name_node) ? parser_print_tree (parser,
-		       method_name_node) : PT_NAME_ORIGINAL (method_name_node);
+
+    const char *name;
+    if (PT_NAME_RESOLVED (method_name_node)) {
+        int custom_print_saved = parser->custom_print;
+        parser->custom_print |= PT_SUPPRESS_QUOTES;
+        parser->custom_print &= ~PT_PRINT_QUOTES;
+        name = parser_print_tree (parser, method_name_node);
+        parser->custom_print = custom_print_saved;
+    } else {
+        name = PT_NAME_ORIGINAL (method_name_node);
+    }
 
     sig.name = db_private_strdup (NULL, name);
     if (PT_IS_METHOD (node))


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26328>

### Purpose

CALL 문의 실행과정에서 PT_NODE 로부터 procedure 의 unique name 을 얻는 단계가 있다. 이 과정에서 사용자 이름이 우연히 CUBRID keyword 일 때 pt_append_name() 함수 안에서 사용자 이름을 bracket 으로 감싸서 출력하기 때문에 _DB_STORED_PROCEDURE 의 컬럼 unique_name 에 저장된 값과 차이가 생긴다. 
이 PR 에서 그 문제를 해결한다. 

### Implementation

unique_name 과 비교할 문자열을 parser_print_tree() 로 구할 때에는 print option 을 조절하여 quote 을 출력하지 않게 함.

### Remarks

N/A
