### PR TITLE
[CBRD-26304] fix error to unloaddb: Empty component list in class

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -1686,6 +1686,10 @@ emit_indexes (extract_context & ctxt, print_output & output_ctx, DB_OBJLIST * cl
     {
       emit_query_specs_has_using_index (ctxt, output_ctx, vclass_list_has_using_index);
     }
+  if (er_errid () == ER_OBJ_NO_COMPONENTS)
+    {
+      er_clear ();
+    }
 
   return err_count;
 }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26304>

### Purpose

* 계승 관계에 있을 때 해당 클래스의 인덱스 여부 조회시  ER_OBJ_NO_COMPONENTS 에러가 설정되는데,
  이 값이 object를 내려 받을 때 영향을 줌.
* er_clear()로 지워줌.  

### Implementation

N/A

### Remarks

N/A
