### PR TITLE
[CBRD-26326] [Regression] Core dumped in cubbase::restrack_assert at src/base/resource_tracker.hpp:455

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -18109,7 +18109,7 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 	    {
 	      /* not START WITH tuples but a previous generation of children, now parents. They have the index string
 	       * column written. */
-	      if (!DB_IS_NULL (index_valp) && index_valp->need_clear == true)
+	      if (DB_NEED_CLEAR (index_valp))
 		{
 		  pr_clear_value (index_valp);
 		}
@@ -18176,7 +18176,7 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 		{
 		  if (listfile1 == connect_by->start_with_list_id)
 		    {
-		      if (!DB_IS_NULL (index_valp) && index_valp->need_clear == true)
+		      if (DB_NEED_CLEAR (index_valp))
 			{
 			  pr_clear_value (index_valp);
 			}
@@ -18239,7 +18239,7 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 			  GOTO_EXIT_ON_ERROR;
 			}
 
-		      if (!DB_IS_NULL (index_valp) && index_valp->need_clear == true)
+		      if (DB_NEED_CLEAR (index_valp))
 			{
 			  pr_clear_value (index_valp);
 			}
@@ -18281,7 +18281,7 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 
 	      if (listfile1 == connect_by->start_with_list_id)
 		{
-		  if (!DB_IS_NULL (index_valp) && index_valp->need_clear == true)
+		  if (DB_NEED_CLEAR (index_valp))
 		    {
 		      pr_clear_value (index_valp);
 		    }
@@ -18362,7 +18362,7 @@ qexec_execute_connect_by (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE 
 		      GOTO_EXIT_ON_ERROR;
 		    }
 
-		  if (!DB_IS_NULL (index_valp) && index_valp->need_clear == true)
+		  if (DB_NEED_CLEAR (index_valp))
 		    {
 		      pr_clear_value (index_valp);
 		    }
@@ -18615,7 +18615,7 @@ exit_on_error:
 	}
     }
 
-  if (!index_valp && !DB_IS_NULL (index_valp) && index_valp->need_clear == true)
+  if (!index_valp && DB_NEED_CLEAR (index_valp))
     {
       pr_clear_value (index_valp);
     }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26326>

Purpose
connect by 수행 시, index valp (compressed string)의 값이 자원 해제되지 않던 문제 해결.

Implementation
pr_clear_value를 사용하여 정상적으로 해제해도록 구현되었습니다.
기존의 동작은 값을 쓸때 compressed string이 있으면 pr_clear_value를 통해서가 아니라 임시적으로 해제하는 로직이 존재하였으나, 해당 로직을 수정하면서 생긴 문제에 대해서 수정하였습니다.

Remarks
압축되지 않은 문자열을 읽어서 압축하는 경우에만 발생하는 문제로 보입니다.
이미 압축된 문자열을 읽는 경우에는 그 자체를 peek으로 읽으므로 문제가 발생하지 않습니다
