### PR TITLE
[CBRD-26297] Refactor: unlock thread_entry after thread_suspend_timeout_wakeup_and_unlock_entry()/thread_suspend_wakeup_and_unlock_entry() returns

### DIFF
--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -2802,6 +2802,7 @@ css_return_queued_data_timeout (CSS_CONN_ENTRY * conn, unsigned short rid,
 	      if (waitsec < 0)
 		{
 		  thread_suspend_wakeup (thrd, THREAD_CSS_QUEUE_SUSPENDED);
+		  thread_unlock_entry (thrd);
 
 		  if (thrd->resume_status != THREAD_CSS_QUEUE_RESUMED)
 		    {
@@ -2816,8 +2817,6 @@ css_return_queued_data_timeout (CSS_CONN_ENTRY * conn, unsigned short rid,
 		    {
 		      assert (thrd->resume_status == THREAD_CSS_QUEUE_RESUMED);
 		    }
-
-		  thread_unlock_entry (thrd);
 		}
 	      else
 		{
@@ -2828,6 +2827,7 @@ css_return_queued_data_timeout (CSS_CONN_ENTRY * conn, unsigned short rid,
 		  abstime.tv_nsec = 0;
 
 		  r = thread_suspend_timeout_wakeup (thrd, &abstime, THREAD_CSS_QUEUE_SUSPENDED);
+		  thread_unlock_entry (thrd);
 
 		  if (r == ER_CSS_PTHREAD_COND_TIMEDOUT)
 		    {
@@ -2850,8 +2850,6 @@ css_return_queued_data_timeout (CSS_CONN_ENTRY * conn, unsigned short rid,
 		    {
 		      assert (thrd->resume_status == THREAD_CSS_QUEUE_RESUMED);
 		    }
-
-		  thread_unlock_entry (thrd);
 		}
 
 	      if (*buffer == NULL || *bufsize < 0)

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -2817,7 +2817,7 @@ css_return_queued_data_timeout (CSS_CONN_ENTRY * conn, unsigned short rid,
 		      assert (thrd->resume_status == THREAD_CSS_QUEUE_RESUMED);
 		    }
 
-                  thread_unlock_entry (thrd);
+		  thread_unlock_entry (thrd);
 		}
 	      else
 		{
@@ -2850,7 +2850,7 @@ css_return_queued_data_timeout (CSS_CONN_ENTRY * conn, unsigned short rid,
 		    {
 		      assert (thrd->resume_status == THREAD_CSS_QUEUE_RESUMED);
 		    }
-                  thread_unlock_entry (thrd);
+		  thread_unlock_entry (thrd);
 		}
 
 	      if (*buffer == NULL || *bufsize < 0)

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -2801,7 +2801,8 @@ css_return_queued_data_timeout (CSS_CONN_ENTRY * conn, unsigned short rid,
 	       * data */
 	      if (waitsec < 0)
 		{
-		  thread_suspend_wakeup_and_unlock_entry (thrd, THREAD_CSS_QUEUE_SUSPENDED);
+		  thread_suspend_wakeup (thrd, THREAD_CSS_QUEUE_SUSPENDED);
+		  thread_unlock_entry (thrd);
 
 		  if (thrd->resume_status != THREAD_CSS_QUEUE_RESUMED)
 		    {
@@ -2826,7 +2827,7 @@ css_return_queued_data_timeout (CSS_CONN_ENTRY * conn, unsigned short rid,
 		  abstime.tv_nsec = 0;
 
 		  r = thread_suspend_timeout_wakeup (thrd, &abstime, THREAD_CSS_QUEUE_SUSPENDED);
-                  thread_unlock_entry (thrd);
+		  thread_unlock_entry (thrd);
 
 		  if (r == ER_CSS_PTHREAD_COND_TIMEDOUT)
 		    {

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -2826,7 +2826,7 @@ css_return_queued_data_timeout (CSS_CONN_ENTRY * conn, unsigned short rid,
 		  abstime.tv_sec = (int) time (NULL) + waitsec;
 		  abstime.tv_nsec = 0;
 
-		  r = thread_suspend_timeout_wakeup (thrd, &abstime, THREAD_CSS_QUEUE_SUSPENDED);
+		  r = thread_timed_suspend (thrd, &abstime, THREAD_CSS_QUEUE_SUSPENDED);
 		  thread_unlock_entry (thrd);
 
 		  if (r == ER_CSS_PTHREAD_COND_TIMEDOUT)

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -2850,6 +2850,7 @@ css_return_queued_data_timeout (CSS_CONN_ENTRY * conn, unsigned short rid,
 		    {
 		      assert (thrd->resume_status == THREAD_CSS_QUEUE_RESUMED);
 		    }
+
 		  thread_unlock_entry (thrd);
 		}
 

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -2825,7 +2825,8 @@ css_return_queued_data_timeout (CSS_CONN_ENTRY * conn, unsigned short rid,
 		  abstime.tv_sec = (int) time (NULL) + waitsec;
 		  abstime.tv_nsec = 0;
 
-		  r = thread_suspend_timeout_wakeup_and_unlock_entry (thrd, &abstime, THREAD_CSS_QUEUE_SUSPENDED);
+		  r = thread_suspend_timeout_wakeup (thrd, &abstime, THREAD_CSS_QUEUE_SUSPENDED);
+                  thread_unlock_entry (thrd);
 
 		  if (r == ER_CSS_PTHREAD_COND_TIMEDOUT)
 		    {

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -2802,7 +2802,6 @@ css_return_queued_data_timeout (CSS_CONN_ENTRY * conn, unsigned short rid,
 	      if (waitsec < 0)
 		{
 		  thread_suspend_wakeup (thrd, THREAD_CSS_QUEUE_SUSPENDED);
-		  thread_unlock_entry (thrd);
 
 		  if (thrd->resume_status != THREAD_CSS_QUEUE_RESUMED)
 		    {
@@ -2817,6 +2816,8 @@ css_return_queued_data_timeout (CSS_CONN_ENTRY * conn, unsigned short rid,
 		    {
 		      assert (thrd->resume_status == THREAD_CSS_QUEUE_RESUMED);
 		    }
+
+                  thread_unlock_entry (thrd);
 		}
 	      else
 		{
@@ -2827,7 +2828,6 @@ css_return_queued_data_timeout (CSS_CONN_ENTRY * conn, unsigned short rid,
 		  abstime.tv_nsec = 0;
 
 		  r = thread_suspend_timeout_wakeup (thrd, &abstime, THREAD_CSS_QUEUE_SUSPENDED);
-		  thread_unlock_entry (thrd);
 
 		  if (r == ER_CSS_PTHREAD_COND_TIMEDOUT)
 		    {
@@ -2850,6 +2850,7 @@ css_return_queued_data_timeout (CSS_CONN_ENTRY * conn, unsigned short rid,
 		    {
 		      assert (thrd->resume_status == THREAD_CSS_QUEUE_RESUMED);
 		    }
+                  thread_unlock_entry (thrd);
 		}
 
 	      if (*buffer == NULL || *bufsize < 0)

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -2801,8 +2801,7 @@ css_return_queued_data_timeout (CSS_CONN_ENTRY * conn, unsigned short rid,
 	       * data */
 	      if (waitsec < 0)
 		{
-		  thread_suspend (thrd, THREAD_CSS_QUEUE_SUSPENDED);
-		  thread_unlock_entry (thrd);
+		  thread_suspend_and_unlock_entry (thrd, THREAD_CSS_QUEUE_SUSPENDED);
 
 		  if (thrd->resume_status != THREAD_CSS_QUEUE_RESUMED)
 		    {
@@ -2826,8 +2825,7 @@ css_return_queued_data_timeout (CSS_CONN_ENTRY * conn, unsigned short rid,
 		  abstime.tv_sec = (int) time (NULL) + waitsec;
 		  abstime.tv_nsec = 0;
 
-		  r = thread_timed_suspend (thrd, &abstime, THREAD_CSS_QUEUE_SUSPENDED);
-		  thread_unlock_entry (thrd);
+		  r = thread_timed_suspend_and_unlock_entry (thrd, &abstime, THREAD_CSS_QUEUE_SUSPENDED);
 
 		  if (r == ER_CSS_PTHREAD_COND_TIMEDOUT)
 		    {

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -2801,7 +2801,7 @@ css_return_queued_data_timeout (CSS_CONN_ENTRY * conn, unsigned short rid,
 	       * data */
 	      if (waitsec < 0)
 		{
-		  thread_suspend_wakeup (thrd, THREAD_CSS_QUEUE_SUSPENDED);
+		  thread_suspend (thrd, THREAD_CSS_QUEUE_SUSPENDED);
 		  thread_unlock_entry (thrd);
 
 		  if (thrd->resume_status != THREAD_CSS_QUEUE_RESUMED)

--- a/src/storage/double_write_buffer.cpp
+++ b/src/storage/double_write_buffer.cpp
@@ -1596,8 +1596,7 @@ dwb_wait_for_block_completion (THREAD_ENTRY *thread_p, unsigned int block_no)
   timeval_add_msec (&timeval_timeout, &timeval_crt, 20);
   timeval_to_timespec (&to, &timeval_timeout);
 
-  r = thread_timed_suspend (thread_p, &to, THREAD_DWB_QUEUE_SUSPENDED);
-  thread_unlock_entry (thread_p);
+  r = thread_timed_suspend_and_unlock_entry (thread_p, &to, THREAD_DWB_QUEUE_SUSPENDED);
 
   (void) logtb_set_check_interrupt (thread_p, save_check_interrupt);
 
@@ -1738,8 +1737,7 @@ dwb_wait_for_strucure_modification (THREAD_ENTRY *thread_p)
   timeval_add_msec (&timeval_timeout, &timeval_crt, 10);
   timeval_to_timespec (&to, &timeval_timeout);
 
-  r = thread_timed_suspend (thread_p, &to, THREAD_DWB_QUEUE_SUSPENDED);
-  thread_unlock_entry (thread_p);
+  r = thread_timed_suspend_and_unlock_entry (thread_p, &to, THREAD_DWB_QUEUE_SUSPENDED);
 
   (void) logtb_set_check_interrupt (thread_p, save_check_interrupt);
   if (r == ER_CSS_PTHREAD_COND_TIMEDOUT)

--- a/src/storage/double_write_buffer.cpp
+++ b/src/storage/double_write_buffer.cpp
@@ -1596,7 +1596,8 @@ dwb_wait_for_block_completion (THREAD_ENTRY *thread_p, unsigned int block_no)
   timeval_add_msec (&timeval_timeout, &timeval_crt, 20);
   timeval_to_timespec (&to, &timeval_timeout);
 
-  r = thread_suspend_timeout_wakeup_and_unlock_entry (thread_p, &to, THREAD_DWB_QUEUE_SUSPENDED);
+  r = thread_suspend_timeout_wakeup (thread_p, &to, THREAD_DWB_QUEUE_SUSPENDED);
+  thread_unlock_entry (thread_p);
 
   (void) logtb_set_check_interrupt (thread_p, save_check_interrupt);
 
@@ -1737,7 +1738,8 @@ dwb_wait_for_strucure_modification (THREAD_ENTRY *thread_p)
   timeval_add_msec (&timeval_timeout, &timeval_crt, 10);
   timeval_to_timespec (&to, &timeval_timeout);
 
-  r = thread_suspend_timeout_wakeup_and_unlock_entry (thread_p, &to, THREAD_DWB_QUEUE_SUSPENDED);
+  r = thread_suspend_timeout_wakeup (thread_p, &to, THREAD_DWB_QUEUE_SUSPENDED);
+  thread_unlock_entry (thread_p);
 
   (void) logtb_set_check_interrupt (thread_p, save_check_interrupt);
   if (r == ER_CSS_PTHREAD_COND_TIMEDOUT)

--- a/src/storage/double_write_buffer.cpp
+++ b/src/storage/double_write_buffer.cpp
@@ -1596,7 +1596,7 @@ dwb_wait_for_block_completion (THREAD_ENTRY *thread_p, unsigned int block_no)
   timeval_add_msec (&timeval_timeout, &timeval_crt, 20);
   timeval_to_timespec (&to, &timeval_timeout);
 
-  r = thread_suspend_timeout_wakeup (thread_p, &to, THREAD_DWB_QUEUE_SUSPENDED);
+  r = thread_timed_suspend (thread_p, &to, THREAD_DWB_QUEUE_SUSPENDED);
   thread_unlock_entry (thread_p);
 
   (void) logtb_set_check_interrupt (thread_p, save_check_interrupt);
@@ -1738,7 +1738,7 @@ dwb_wait_for_strucure_modification (THREAD_ENTRY *thread_p)
   timeval_add_msec (&timeval_timeout, &timeval_crt, 10);
   timeval_to_timespec (&to, &timeval_timeout);
 
-  r = thread_suspend_timeout_wakeup (thread_p, &to, THREAD_DWB_QUEUE_SUSPENDED);
+  r = thread_timed_suspend (thread_p, &to, THREAD_DWB_QUEUE_SUSPENDED);
   thread_unlock_entry (thread_p);
 
   (void) logtb_set_check_interrupt (thread_p, save_check_interrupt);

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -2016,8 +2016,7 @@ heap_classrepr_lock_class (THREAD_ENTRY * thread_p, HEAP_CLASSREPR_HASH * hash_a
 
 	  thread_lock_entry (cur_thrd_entry);
 	  pthread_mutex_unlock (&hash_anchor->hash_mutex);
-	  thread_suspend (cur_thrd_entry, THREAD_HEAP_CLSREPR_SUSPENDED);
-	  thread_unlock_entry (cur_thrd_entry);
+	  thread_suspend_and_unlock_entry (cur_thrd_entry, THREAD_HEAP_CLSREPR_SUSPENDED);
 
 	  if (cur_thrd_entry->resume_status == THREAD_HEAP_CLSREPR_RESUMED)
 	    {

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -2016,7 +2016,7 @@ heap_classrepr_lock_class (THREAD_ENTRY * thread_p, HEAP_CLASSREPR_HASH * hash_a
 
 	  thread_lock_entry (cur_thrd_entry);
 	  pthread_mutex_unlock (&hash_anchor->hash_mutex);
-	  thread_suspend_wakeup (cur_thrd_entry, THREAD_HEAP_CLSREPR_SUSPENDED);
+	  thread_suspend (cur_thrd_entry, THREAD_HEAP_CLSREPR_SUSPENDED);
 	  thread_unlock_entry (cur_thrd_entry);
 
 	  if (cur_thrd_entry->resume_status == THREAD_HEAP_CLSREPR_RESUMED)

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -2016,7 +2016,8 @@ heap_classrepr_lock_class (THREAD_ENTRY * thread_p, HEAP_CLASSREPR_HASH * hash_a
 
 	  thread_lock_entry (cur_thrd_entry);
 	  pthread_mutex_unlock (&hash_anchor->hash_mutex);
-	  thread_suspend_wakeup_and_unlock_entry (cur_thrd_entry, THREAD_HEAP_CLSREPR_SUSPENDED);
+	  thread_suspend_wakeup (cur_thrd_entry, THREAD_HEAP_CLSREPR_SUSPENDED);
+	  thread_unlock_entry (cur_thrd_entry);
 
 	  if (cur_thrd_entry->resume_status == THREAD_HEAP_CLSREPR_RESUMED)
 	    {

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -6587,8 +6587,7 @@ pgbuf_block_bcb (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr, PGBUF_LATCH_MODE r
       /* is it safe to use infinite wait instead of timed sleep? */
       thread_lock_entry (cur_thrd_entry);
       PGBUF_BCB_UNLOCK (bufptr);
-
-      thread_suspend_wakeup (cur_thrd_entry, THREAD_PGBUF_SUSPENDED);
+      thread_suspend (cur_thrd_entry, THREAD_PGBUF_SUSPENDED);
       thread_unlock_entry (cur_thrd_entry);
 
       if (cur_thrd_entry->resume_status != THREAD_PGBUF_RESUMED)
@@ -10857,7 +10856,7 @@ pgbuf_sleep (THREAD_ENTRY * thread_p, pthread_mutex_t * mutex_p)
   thread_lock_entry (thread_p);
   pthread_mutex_unlock (mutex_p);
 
-  thread_suspend_wakeup (thread_p, THREAD_PGBUF_SUSPENDED);
+  thread_suspend (thread_p, THREAD_PGBUF_SUSPENDED);
   thread_unlock_entry (thread_p);
 }
 

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -6588,8 +6588,8 @@ pgbuf_block_bcb (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr, PGBUF_LATCH_MODE r
       thread_lock_entry (cur_thrd_entry);
       PGBUF_BCB_UNLOCK (bufptr);
 
-      thread_suspend_wakeup (thread_p, THREAD_PGBUF_SUSPENDED);
-      thread_unlock_entry (thread_p);
+      thread_suspend_wakeup (cur_thrd_entry, THREAD_PGBUF_SUSPENDED);
+      thread_unlock_entry (cur_thrd_entry);
 
       if (cur_thrd_entry->resume_status != THREAD_PGBUF_RESUMED)
 	{

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -6587,8 +6587,7 @@ pgbuf_block_bcb (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr, PGBUF_LATCH_MODE r
       /* is it safe to use infinite wait instead of timed sleep? */
       thread_lock_entry (cur_thrd_entry);
       PGBUF_BCB_UNLOCK (bufptr);
-      thread_suspend (cur_thrd_entry, THREAD_PGBUF_SUSPENDED);
-      thread_unlock_entry (cur_thrd_entry);
+      thread_suspend_and_unlock_entry (cur_thrd_entry, THREAD_PGBUF_SUSPENDED);
 
       if (cur_thrd_entry->resume_status != THREAD_PGBUF_RESUMED)
 	{
@@ -7622,8 +7621,7 @@ pgbuf_allocate_bcb (THREAD_ENTRY * thread_p, const VPID * src_vpid)
 
       show_status->num_flusher_waiting_threads++;
 
-      r = thread_timed_suspend (thread_p, &to, THREAD_ALLOC_BCB_SUSPENDED);
-      thread_unlock_entry (thread_p);
+      r = thread_timed_suspend_and_unlock_entry (thread_p, &to, THREAD_ALLOC_BCB_SUSPENDED);
 
       show_status->num_flusher_waiting_threads--;
 
@@ -10856,8 +10854,7 @@ pgbuf_sleep (THREAD_ENTRY * thread_p, pthread_mutex_t * mutex_p)
   thread_lock_entry (thread_p);
   pthread_mutex_unlock (mutex_p);
 
-  thread_suspend (thread_p, THREAD_PGBUF_SUSPENDED);
-  thread_unlock_entry (thread_p);
+  thread_suspend_and_unlock_entry (thread_p, THREAD_PGBUF_SUSPENDED);
 }
 
 STATIC_INLINE int

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -7623,7 +7623,7 @@ pgbuf_allocate_bcb (THREAD_ENTRY * thread_p, const VPID * src_vpid)
 
       show_status->num_flusher_waiting_threads++;
 
-      r = thread_suspend_timeout_wakeup (thread_p, &to, THREAD_ALLOC_BCB_SUSPENDED);
+      r = thread_timed_suspend (thread_p, &to, THREAD_ALLOC_BCB_SUSPENDED);
       thread_unlock_entry (thread_p);
 
       show_status->num_flusher_waiting_threads--;

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -6771,7 +6771,7 @@ try_again:
     }
 
   thread_p->resume_status = THREAD_PGBUF_SUSPENDED;
-  r = thread_suspend_timeout_wakeup_and_unlock_entry (thread_p, &to, THREAD_PGBUF_SUSPENDED);
+  r = thread_timed_suspend_and_unlock_entry (thread_p, &to, THREAD_PGBUF_SUSPENDED);
 
   if (thread_p->type == TT_WORKER)
     {

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -7621,7 +7621,8 @@ pgbuf_allocate_bcb (THREAD_ENTRY * thread_p, const VPID * src_vpid)
 
       show_status->num_flusher_waiting_threads++;
 
-      r = thread_suspend_timeout_wakeup_and_unlock_entry (thread_p, &to, THREAD_ALLOC_BCB_SUSPENDED);
+      r = thread_suspend_timeout_wakeup (thread_p, &to, THREAD_ALLOC_BCB_SUSPENDED);
+      thread_unlock_entry (thread_p);
 
       show_status->num_flusher_waiting_threads--;
 

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -6587,7 +6587,9 @@ pgbuf_block_bcb (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr, PGBUF_LATCH_MODE r
       /* is it safe to use infinite wait instead of timed sleep? */
       thread_lock_entry (cur_thrd_entry);
       PGBUF_BCB_UNLOCK (bufptr);
-      thread_suspend_wakeup_and_unlock_entry (cur_thrd_entry, THREAD_PGBUF_SUSPENDED);
+
+      thread_suspend_wakeup (thread_p, THREAD_PGBUF_SUSPENDED);
+      thread_unlock_entry (thread_p);
 
       if (cur_thrd_entry->resume_status != THREAD_PGBUF_RESUMED)
 	{
@@ -10855,7 +10857,8 @@ pgbuf_sleep (THREAD_ENTRY * thread_p, pthread_mutex_t * mutex_p)
   thread_lock_entry (thread_p);
   pthread_mutex_unlock (mutex_p);
 
-  thread_suspend_wakeup_and_unlock_entry (thread_p, THREAD_PGBUF_SUSPENDED);
+  thread_suspend_wakeup (thread_p, THREAD_PGBUF_SUSPENDED);
+  thread_unlock_entry (thread_p);
 }
 
 STATIC_INLINE int

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -475,7 +475,7 @@ thread_timeval_add_usec (const std::chrono::microseconds &usec, struct timeval &
 }
 
 /*
- * thread_suspend_wakeup() -
+ * thread_suspend() -
  *   return:
  *   thread_p(in):
  *   suspended_reason(in):
@@ -483,7 +483,7 @@ thread_timeval_add_usec (const std::chrono::microseconds &usec, struct timeval &
  * Note: this function must be called by current thread also, the lock must have already been acquired.
  */
 void
-thread_suspend_wakeup (cubthread::entry *thread_p, thread_resume_suspend_status suspended_reason)
+thread_suspend (cubthread::entry *thread_p, thread_resume_suspend_status suspended_reason)
 {
   cubthread::entry::status old_status;
 
@@ -530,7 +530,7 @@ thread_suspend_wakeup (cubthread::entry *thread_p, thread_resume_suspend_status 
  */
 int
 thread_timed_suspend (cubthread::entry *thread_p, struct timespec *time_p,
-			       thread_resume_suspend_status suspended_reason)
+		      thread_resume_suspend_status suspended_reason)
 {
   int r;
   cubthread::entry::status old_status;

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -522,14 +522,14 @@ thread_suspend_wakeup (cubthread::entry *thread_p, thread_resume_suspend_status 
 }
 
 /*
- * thread_suspend_timeout_wakeup() -
+ * thread_timed_suspend() -
  *   return:
  *   thread_p(in):
  *   time_p(in):
  *   suspended_reason(in):
  */
 int
-thread_suspend_timeout_wakeup (cubthread::entry *thread_p, struct timespec *time_p,
+thread_timed_suspend (cubthread::entry *thread_p, struct timespec *time_p,
 			       thread_resume_suspend_status suspended_reason)
 {
   int r;

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -528,14 +528,14 @@ thread_suspend_wakeup_and_unlock_entry (cubthread::entry *thread_p, thread_resum
 }
 
 /*
- * thread_suspend_timeout_wakeup_and_unlock_entry() -
+ * thread_suspend_timeout_wakeup() -
  *   return:
  *   thread_p(in):
  *   time_p(in):
  *   suspended_reason(in):
  */
 int
-thread_suspend_timeout_wakeup_and_unlock_entry (cubthread::entry *thread_p, struct timespec *time_p,
+thread_suspend_timeout_wakeup (cubthread::entry *thread_p, struct timespec *time_p,
     thread_resume_suspend_status suspended_reason)
 {
   int r;
@@ -567,18 +567,24 @@ thread_suspend_timeout_wakeup_and_unlock_entry (cubthread::entry *thread_p, stru
 
   if (r != 0 && r != ETIMEDOUT)
     {
+      thread_p->m_status = old_status;
+
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_COND_TIMEDWAIT, 0);
-      return ER_CSS_PTHREAD_COND_TIMEDWAIT;
+      error = ER_CSS_PTHREAD_COND_TIMEDWAIT;
+
+      return error;
     }
 
   if (r == ETIMEDOUT)
     {
+      thread_p->m_status = old_status;
+
       error = ER_CSS_PTHREAD_COND_TIMEDOUT;
+
+      return error;
     }
 
   thread_p->m_status = old_status;
-
-  pthread_mutex_unlock (&thread_p->th_entry_lock);
 
   return error;
 }

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -552,6 +552,8 @@ thread_suspend_timeout_wakeup (cubthread::entry *thread_p, struct timespec *time
 
   r = pthread_cond_timedwait (&thread_p->wakeup_cond, &thread_p->th_entry_lock, time_p);
 
+  thread_p->m_status = old_status;
+
   if (thread_p->event_stats.trace_slow_query == true && suspended_reason == THREAD_PGBUF_SUSPENDED)
     {
       usecs = std::chrono::duration_cast < std::chrono::microseconds > (thread_clock_type::now () - start_time_pt);
@@ -561,24 +563,13 @@ thread_suspend_timeout_wakeup (cubthread::entry *thread_p, struct timespec *time
 
   if (r != 0 && r != ETIMEDOUT)
     {
-      thread_p->m_status = old_status;
-
       error = ER_CSS_PTHREAD_COND_TIMEDWAIT;
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 0);
-
-      return error;
     }
-
-  if (r == ETIMEDOUT)
+  else if (r == ETIMEDOUT)
     {
-      thread_p->m_status = old_status;
-
       error = ER_CSS_PTHREAD_COND_TIMEDOUT;
-
-      return error;
     }
-
-  thread_p->m_status = old_status;
 
   return error;
 }

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -603,7 +603,7 @@ thread_wakeup_internal (cubthread::entry *thread_p, thread_resume_suspend_status
  *   resume_reason:
  *   suspend_reason:
  */
-static void
+void
 thread_check_suspend_reason_and_wakeup (cubthread::entry *thread_p,
 					thread_resume_suspend_status resume_reason,
 					thread_resume_suspend_status suspend_reason)

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -460,10 +460,6 @@ using thread_clock_type = std::chrono::system_clock;
 
 static void thread_wakeup_internal (cubthread::entry *thread_p, thread_resume_suspend_status resume_reason,
 				    bool had_mutex);
-static void thread_check_suspend_reason_and_wakeup_internal (cubthread::entry *thread_p,
-    thread_resume_suspend_status resume_reason,
-    thread_resume_suspend_status suspend_reason,
-    bool had_mutex);
 
 // todo - remove timeval and use std::chrono
 static void
@@ -611,22 +607,17 @@ thread_wakeup_internal (cubthread::entry *thread_p, thread_resume_suspend_status
 }
 
 /*
- * thread_check_suspend_reason_and_wakeup_internal () -
- *   return:
+ * thread_check_suspend_reason_and_wakeup () -
  *   thread_p(in):
  *   resume_reason:
  *   suspend_reason:
- *   had_mutex:
  */
 static void
-thread_check_suspend_reason_and_wakeup_internal (cubthread::entry *thread_p,
+thread_check_suspend_reason_and_wakeup (cubthread::entry *thread_p,
     thread_resume_suspend_status resume_reason,
-    thread_resume_suspend_status suspend_reason, bool had_mutex)
+    thread_resume_suspend_status suspend_reason)
 {
-  if (had_mutex == false)
-    {
-      thread_lock_entry (thread_p);
-    }
+  thread_lock_entry (thread_p);
 
   if (thread_p->resume_status != suspend_reason)
     {
@@ -653,12 +644,6 @@ thread_wakeup (cubthread::entry *thread_p, thread_resume_suspend_status resume_r
   thread_wakeup_internal (thread_p, resume_reason, false);
 }
 
-void
-thread_check_suspend_reason_and_wakeup (cubthread::entry *thread_p, thread_resume_suspend_status resume_reason,
-					thread_resume_suspend_status suspend_reason)
-{
-  thread_check_suspend_reason_and_wakeup_internal (thread_p, resume_reason, suspend_reason, false);
-}
 
 /*
  * thread_wakeup_already_had_mutex () -

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -561,14 +561,17 @@ thread_suspend_timeout_wakeup (cubthread::entry *thread_p, struct timespec *time
       thread_timeval_add_usec (usecs, thread_p->event_stats.latch_waits);
     }
 
-  if (r != 0 && r != ETIMEDOUT)
+  if (r != 0)
     {
-      error = ER_CSS_PTHREAD_COND_TIMEDWAIT;
-      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 0);
-    }
-  else if (r == ETIMEDOUT)
-    {
-      error = ER_CSS_PTHREAD_COND_TIMEDOUT;
+      if (r != ETIMEDOUT)
+	{
+	  error = ER_CSS_PTHREAD_COND_TIMEDWAIT;
+	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 0);
+	}
+      else
+	{
+	  error = ER_CSS_PTHREAD_COND_TIMEDOUT;
+	}
     }
 
   return error;

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -605,8 +605,8 @@ thread_wakeup_internal (cubthread::entry *thread_p, thread_resume_suspend_status
  */
 static void
 thread_check_suspend_reason_and_wakeup (cubthread::entry *thread_p,
-    thread_resume_suspend_status resume_reason,
-    thread_resume_suspend_status suspend_reason)
+					thread_resume_suspend_status resume_reason,
+					thread_resume_suspend_status suspend_reason)
 {
   thread_lock_entry (thread_p);
 

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -567,8 +567,8 @@ thread_suspend_timeout_wakeup (cubthread::entry *thread_p, struct timespec *time
     {
       thread_p->m_status = old_status;
 
-      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_COND_TIMEDWAIT, 0);
       error = ER_CSS_PTHREAD_COND_TIMEDWAIT;
+      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 0);
 
       return error;
     }

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -479,7 +479,7 @@ thread_timeval_add_usec (const std::chrono::microseconds &usec, struct timeval &
 }
 
 /*
- * thread_suspend_wakeup_and_unlock_entry() -
+ * thread_suspend_wakeup() -
  *   return:
  *   thread_p(in):
  *   suspended_reason(in):
@@ -487,7 +487,7 @@ thread_timeval_add_usec (const std::chrono::microseconds &usec, struct timeval &
  * Note: this function must be called by current thread also, the lock must have already been acquired.
  */
 void
-thread_suspend_wakeup_and_unlock_entry (cubthread::entry *thread_p, thread_resume_suspend_status suspended_reason)
+thread_suspend_wakeup (cubthread::entry *thread_p, thread_resume_suspend_status suspended_reason)
 {
   cubthread::entry::status old_status;
 
@@ -523,8 +523,6 @@ thread_suspend_wakeup_and_unlock_entry (cubthread::entry *thread_p, thread_resum
     }
 
   thread_p->m_status = old_status;
-
-  pthread_mutex_unlock (&thread_p->th_entry_lock);
 }
 
 /*
@@ -536,7 +534,7 @@ thread_suspend_wakeup_and_unlock_entry (cubthread::entry *thread_p, thread_resum
  */
 int
 thread_suspend_timeout_wakeup (cubthread::entry *thread_p, struct timespec *time_p,
-    thread_resume_suspend_status suspended_reason)
+			       thread_resume_suspend_status suspended_reason)
 {
   int r;
   cubthread::entry::status old_status;

--- a/src/thread/thread_entry.hpp
+++ b/src/thread/thread_entry.hpp
@@ -480,9 +480,9 @@ thread_unlock_entry (cubthread::entry *thread_p)
   thread_p->unlock ();
 }
 
-void thread_suspend_wakeup_and_unlock_entry (cubthread::entry *p, thread_resume_suspend_status suspended_reason);
+void thread_suspend_wakeup (cubthread::entry *p, thread_resume_suspend_status suspended_reason);
 int thread_suspend_timeout_wakeup (cubthread::entry *p, struct timespec *t,
-    thread_resume_suspend_status suspended_reason);
+				   thread_resume_suspend_status suspended_reason);
 void thread_wakeup (cubthread::entry *p, thread_resume_suspend_status resume_reason);
 void thread_check_suspend_reason_and_wakeup (cubthread::entry *thread_p, thread_resume_suspend_status resume_reason,
     thread_resume_suspend_status suspend_reason);

--- a/src/thread/thread_entry.hpp
+++ b/src/thread/thread_entry.hpp
@@ -486,6 +486,17 @@ int thread_timed_suspend (cubthread::entry *p, struct timespec *t,
 void thread_wakeup (cubthread::entry *p, thread_resume_suspend_status resume_reason);
 void thread_check_suspend_reason_and_wakeup (cubthread::entry *thread_p, thread_resume_suspend_status resume_reason,
     thread_resume_suspend_status suspend_reason);
+#define thread_suspend_and_unlock_entry(thread_p,suspended_reason) \
+  ({ \
+    thread_suspend((thread_p), (suspended_reason)); \
+    thread_unlock_entry((thread_p)); \
+  })
+#define thread_timed_suspend_and_unlock_entry(thread_p, t, suspended_reason) \
+  ({ \
+    int __r = thread_timed_suspend((thread_p), (t), (suspended_reason)); \
+    thread_unlock_entry((thread_p)); \
+    __r; \
+  })
 void thread_wakeup_already_had_mutex (cubthread::entry *p, thread_resume_suspend_status resume_reason);
 int thread_suspend_with_other_mutex (cubthread::entry *p, pthread_mutex_t *mutexp, int timeout, struct timespec *to,
 				     thread_resume_suspend_status suspended_reason);

--- a/src/thread/thread_entry.hpp
+++ b/src/thread/thread_entry.hpp
@@ -481,7 +481,7 @@ thread_unlock_entry (cubthread::entry *thread_p)
 }
 
 void thread_suspend_wakeup_and_unlock_entry (cubthread::entry *p, thread_resume_suspend_status suspended_reason);
-int thread_suspend_timeout_wakeup_and_unlock_entry (cubthread::entry *p, struct timespec *t,
+int thread_suspend_timeout_wakeup (cubthread::entry *p, struct timespec *t,
     thread_resume_suspend_status suspended_reason);
 void thread_wakeup (cubthread::entry *p, thread_resume_suspend_status resume_reason);
 void thread_check_suspend_reason_and_wakeup (cubthread::entry *thread_p, thread_resume_suspend_status resume_reason,

--- a/src/thread/thread_entry.hpp
+++ b/src/thread/thread_entry.hpp
@@ -481,7 +481,7 @@ thread_unlock_entry (cubthread::entry *thread_p)
 }
 
 void thread_suspend_wakeup (cubthread::entry *p, thread_resume_suspend_status suspended_reason);
-int thread_suspend_timeout_wakeup (cubthread::entry *p, struct timespec *t,
+int thread_timed_suspend (cubthread::entry *p, struct timespec *t,
 				   thread_resume_suspend_status suspended_reason);
 void thread_wakeup (cubthread::entry *p, thread_resume_suspend_status resume_reason);
 void thread_check_suspend_reason_and_wakeup (cubthread::entry *thread_p, thread_resume_suspend_status resume_reason,

--- a/src/thread/thread_entry.hpp
+++ b/src/thread/thread_entry.hpp
@@ -480,9 +480,9 @@ thread_unlock_entry (cubthread::entry *thread_p)
   thread_p->unlock ();
 }
 
-void thread_suspend_wakeup (cubthread::entry *p, thread_resume_suspend_status suspended_reason);
+void thread_suspend (cubthread::entry *p, thread_resume_suspend_status suspended_reason);
 int thread_timed_suspend (cubthread::entry *p, struct timespec *t,
-				   thread_resume_suspend_status suspended_reason);
+			  thread_resume_suspend_status suspended_reason);
 void thread_wakeup (cubthread::entry *p, thread_resume_suspend_status resume_reason);
 void thread_check_suspend_reason_and_wakeup (cubthread::entry *thread_p, thread_resume_suspend_status resume_reason,
     thread_resume_suspend_status suspend_reason);

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -2168,6 +2168,8 @@ lock_suspend (THREAD_ENTRY * thread_p, LK_ENTRY * entry_ptr, int wait_msecs)
   int client_id;
   LOG_TDES *tdes;
 
+  thread_lock_entry (entry_ptr->thrd_entry);
+
   /* The threads must not hold a page latch to be blocked on a lock request. */
   assert (lock_is_safe_lock_with_page (thread_p, entry_ptr) || !pgbuf_has_perm_pages_fixed (thread_p));
 
@@ -2213,7 +2215,8 @@ lock_suspend (THREAD_ENTRY * thread_p, LK_ENTRY * entry_ptr, int wait_msecs)
   lock_event_set_tran_wait_entry (entry_ptr->tran_index, entry_ptr);
 
   /* suspend the worker thread (transaction) */
-  thread_suspend_wakeup_and_unlock_entry (entry_ptr->thrd_entry, THREAD_LOCK_SUSPENDED);
+  thread_suspend_wakeup (entry_ptr->thrd_entry, THREAD_LOCK_SUSPENDED);
+  thread_unlock_entry (entry_ptr->thrd_entry);
 
   lk_Gl.deadlock_and_timeout_detector--;
   lk_Gl.TWFG_node[entry_ptr->tran_index].thrd_wait_stime = 0;
@@ -3572,7 +3575,9 @@ start:
 	  pthread_mutex_unlock (&res_ptr->res_mutex);
 	  is_res_mutex_locked = false;
 
-	  thread_suspend_wakeup_and_unlock_entry (thrd_entry, THREAD_LOCK_SUSPENDED);
+	  thread_suspend_wakeup (thrd_entry, THREAD_LOCK_SUSPENDED);
+          thread_unlock_entry (thrd_entry);
+
 	  if (entry_ptr)
 	    {
 	      if (entry_ptr->thrd_entry->resume_status == THREAD_RESUME_DUE_TO_INTERRUPT)
@@ -3780,7 +3785,9 @@ lock_tran_lk_entry:
       pthread_mutex_unlock (&res_ptr->res_mutex);
       is_res_mutex_locked = false;
 
-      thread_suspend_wakeup_and_unlock_entry (thrd_entry, THREAD_LOCK_SUSPENDED);
+      thread_suspend_wakeup (thrd_entry, THREAD_LOCK_SUSPENDED);
+      thread_unlock_entry (thrd_entry);
+
       if (thrd_entry->resume_status == THREAD_RESUME_DUE_TO_INTERRUPT)
 	{
 	  /* a shutdown thread wakes me up */
@@ -3855,7 +3862,6 @@ blocked:
   LK_MSG_LOCK_WAITFOR (entry_ptr);
 #endif /* LK_TRACE_OBJECT */
 
-  thread_lock_entry (entry_ptr->thrd_entry);
   if (is_res_mutex_locked)
     {
       pthread_mutex_unlock (&res_ptr->res_mutex);

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -3576,7 +3576,7 @@ start:
 	  is_res_mutex_locked = false;
 
 	  thread_suspend_wakeup (thrd_entry, THREAD_LOCK_SUSPENDED);
-          thread_unlock_entry (thrd_entry);
+	  thread_unlock_entry (thrd_entry);
 
 	  if (entry_ptr)
 	    {

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -2215,7 +2215,7 @@ lock_suspend (THREAD_ENTRY * thread_p, LK_ENTRY * entry_ptr, int wait_msecs)
   lock_event_set_tran_wait_entry (entry_ptr->tran_index, entry_ptr);
 
   /* suspend the worker thread (transaction) */
-  thread_suspend_wakeup (entry_ptr->thrd_entry, THREAD_LOCK_SUSPENDED);
+  thread_suspend (entry_ptr->thrd_entry, THREAD_LOCK_SUSPENDED);
   thread_unlock_entry (entry_ptr->thrd_entry);
 
   lk_Gl.deadlock_and_timeout_detector--;
@@ -3575,7 +3575,7 @@ start:
 	  pthread_mutex_unlock (&res_ptr->res_mutex);
 	  is_res_mutex_locked = false;
 
-	  thread_suspend_wakeup (thrd_entry, THREAD_LOCK_SUSPENDED);
+	  thread_suspend (thrd_entry, THREAD_LOCK_SUSPENDED);
 	  thread_unlock_entry (thrd_entry);
 
 	  if (entry_ptr)
@@ -3785,7 +3785,7 @@ lock_tran_lk_entry:
       pthread_mutex_unlock (&res_ptr->res_mutex);
       is_res_mutex_locked = false;
 
-      thread_suspend_wakeup (thrd_entry, THREAD_LOCK_SUSPENDED);
+      thread_suspend (thrd_entry, THREAD_LOCK_SUSPENDED);
       thread_unlock_entry (thrd_entry);
 
       if (thrd_entry->resume_status == THREAD_RESUME_DUE_TO_INTERRUPT)

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -2215,8 +2215,7 @@ lock_suspend (THREAD_ENTRY * thread_p, LK_ENTRY * entry_ptr, int wait_msecs)
   lock_event_set_tran_wait_entry (entry_ptr->tran_index, entry_ptr);
 
   /* suspend the worker thread (transaction) */
-  thread_suspend (entry_ptr->thrd_entry, THREAD_LOCK_SUSPENDED);
-  thread_unlock_entry (entry_ptr->thrd_entry);
+  thread_suspend_and_unlock_entry (entry_ptr->thrd_entry, THREAD_LOCK_SUSPENDED);
 
   lk_Gl.deadlock_and_timeout_detector--;
   lk_Gl.TWFG_node[entry_ptr->tran_index].thrd_wait_stime = 0;
@@ -3575,8 +3574,7 @@ start:
 	  pthread_mutex_unlock (&res_ptr->res_mutex);
 	  is_res_mutex_locked = false;
 
-	  thread_suspend (thrd_entry, THREAD_LOCK_SUSPENDED);
-	  thread_unlock_entry (thrd_entry);
+	  thread_suspend_and_unlock_entry (thrd_entry, THREAD_LOCK_SUSPENDED);
 
 	  if (entry_ptr)
 	    {
@@ -3785,8 +3783,7 @@ lock_tran_lk_entry:
       pthread_mutex_unlock (&res_ptr->res_mutex);
       is_res_mutex_locked = false;
 
-      thread_suspend (thrd_entry, THREAD_LOCK_SUSPENDED);
-      thread_unlock_entry (thrd_entry);
+      thread_suspend_and_unlock_entry (thrd_entry, THREAD_LOCK_SUSPENDED);
 
       if (thrd_entry->resume_status == THREAD_RESUME_DUE_TO_INTERRUPT)
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26297

### Purpose

thread_suspend_timeout_wakeup_and_unlock_entry()/thread_suspend_wakeup_and_unlock_entry() 함수는 caller에서 thread_entry lock을 획득하고 진행되며, 함수 종료 전에 lock을 해제한다.
위 두 함수 caller에서 lock을 획득/해제하도록 리팩토링한다.

### Implementation

1. 함수 내에서 thread_entry를 unlock하지 않고, 함수 caller가 함수 종료 후에 unlock하도록 변경
2. 더 이상 함수에서 thread_entry를 unlock하지 않기 때문에 함수 이름 변경
thread_suspend_timeout_wakeup_and_unlock_entry() -> thread_timed_suspend()
thread_suspend_wakeup_and_unlock_entry() -> thread_suspend()

### Remarks

N/A
