### PR TITLE
[CBRD-25862] Fix deadlock of updating statistics

### DIFF
--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -5821,7 +5821,7 @@ stats_update_statistics (MOP classop, int with_fullscan)
 #if defined(CS_MODE)
   int error = ER_NET_CLIENT_DATA_RECEIVE;
   int req_error;
-  char *request;
+  char *request = NULL;
   OR_ALIGNED_BUF (OR_INT_SIZE) a_reply;
   char *reply;
   char *ptr;
@@ -5831,11 +5831,8 @@ stats_update_statistics (MOP classop, int with_fullscan)
   /* get NDV by query */
   if (stats_get_ndv_by_query (classop, &class_attr_ndv, NULL, with_fullscan) != NO_ERROR)
     {
-      if (class_attr_ndv.attr_ndv != NULL)
-	{
-	  free_and_init (class_attr_ndv.attr_ndv);
-	}
-      return ER_FAILED;
+      error = ER_FAILED;
+      goto end;
     }
 
   request_size = OR_INT_SIZE + (sizeof (ATTR_NDV) * (class_attr_ndv.attr_cnt + 1)) + OR_INT_SIZE + OR_OID_SIZE;
@@ -5872,38 +5869,36 @@ end:
       free_and_init (class_attr_ndv.attr_ndv);
     }
 
-  free_and_init (request);
+  if (request)
+    {
+      free_and_init (request);
+    }
 
   return error;
 #else /* CS_MODE */
-  int success;
+  int error = NO_ERROR;
   CLASS_ATTR_NDV class_attr_ndv = CLASS_ATTR_NDV_INITIALIZER;
+  THREAD_ENTRY *thread_p;
 
   /* get NDV by query */
   if (stats_get_ndv_by_query (classop, &class_attr_ndv, NULL, with_fullscan) != NO_ERROR)
     {
-      if (class_attr_ndv.attr_ndv != NULL)
-	{
-	  free_and_init (class_attr_ndv.attr_ndv);
-	}
-      return ER_FAILED;
+      error = ER_FAILED;
+      goto end;
     }
 
-
-  THREAD_ENTRY *thread_p = enter_server ();
-
-  success =
-    xstats_update_statistics (thread_p, WS_OID (classop), (with_fullscan ? STATS_WITH_FULLSCAN : STATS_WITH_SAMPLING),
-			      &class_attr_ndv);
-
+  thread_p = enter_server ();
+  error =
+    xstats_update_statistics (thread_p, WS_OID (classop), with_fullscan, &class_attr_ndv);
   exit_server (*thread_p);
 
+end:
   if (class_attr_ndv.attr_ndv != NULL)
     {
       free_and_init (class_attr_ndv.attr_ndv);
     }
 
-  return success;
+  return error;
 #endif /* !CS_MODE */
 }
 
@@ -5918,133 +5913,30 @@ end:
 int
 stats_update_all_statistics (int with_fullscan)
 {
-#if defined(CS_MODE)
-  int error = ER_NET_CLIENT_DATA_RECEIVE;
-  int req_error;
-  char *request;
-  OR_ALIGNED_BUF (OR_INT_SIZE) a_reply;
-  char *reply;
-  char *ptr;
-  CLASS_ATTR_NDV class_attr_ndv = CLASS_ATTR_NDV_INITIALIZER;
-  const char *query = "select c.unique_name from _db_class as c where c.class_type = 0 and [partition] is null "
-    "union "
-    "select c.unique_name from _db_class as c, TABLE(c.partition) as g(x) where c.class_type = 0 and x.pname is null;";
-  DB_QUERY_RESULT *query_result = NULL;
-  DB_QUERY_ERROR query_error;
-  DB_VALUE class_name_val;
-  MOP class_mop;
-  int request_size;
-
-  memset (&query_error, 0, sizeof (DB_QUERY_ERROR));
-  db_make_null (&class_name_val);
-
-  error = db_compile_and_execute_local (query, &query_result, &query_error);
-  if (error < 0)
-    {
-      goto end;
-    }
-
-  error = db_query_first_tuple (query_result);
-  if (error != DB_CURSOR_SUCCESS)
-    {
-      goto end;
-    }
-
-  do
-    {
-      const char *class_name = NULL;
-
-      /* class_name */
-      error = db_query_get_tuple_value (query_result, 0, &class_name_val);
-      if (error != NO_ERROR)
-	{
-	  goto end;
-	}
-      class_name = db_get_string (&class_name_val);
-
-      class_mop = db_find_class (class_name);
-      if (class_mop == NULL)
-	{
-	  error = ER_FAILED;
-	  goto end;
-	}
-
-      /* get NDV by query */
-      if (stats_get_ndv_by_query (class_mop, &class_attr_ndv, NULL, with_fullscan) != NO_ERROR)
-	{
-	  error = ER_FAILED;
-	  goto end;
-	}
-
-      request_size = OR_INT_SIZE + (sizeof (ATTR_NDV) * (class_attr_ndv.attr_cnt + 1)) + OR_INT_SIZE + OR_OID_SIZE;
-      request = (char *) malloc (request_size);
-      if (request == NULL)
-	{
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, (size_t) request_size);
-	  error = ER_OUT_OF_VIRTUAL_MEMORY;
-	  goto end;
-	}
-
-      ptr = or_pack_int (request, class_attr_ndv.attr_cnt);
-      for (int i = 0; i < class_attr_ndv.attr_cnt + 1; i++)
-	{
-	  ptr = or_pack_int (ptr, class_attr_ndv.attr_ndv[i].id);
-	  ptr = or_pack_int64 (ptr, class_attr_ndv.attr_ndv[i].ndv);
-	}
-      ptr = or_pack_oid (ptr, WS_OID (class_mop));
-      ptr = or_pack_int (ptr, with_fullscan);
-
-      reply = OR_ALIGNED_BUF_START (a_reply);
-
-      req_error =
-	net_client_request (NET_SERVER_QST_UPDATE_STATISTICS, request, request_size, reply,
-			    OR_ALIGNED_BUF_SIZE (a_reply), NULL, 0, NULL, 0);
-      if (!req_error)
-	{
-	  or_unpack_errcode (reply, &error);
-	}
-      if (class_attr_ndv.attr_ndv != NULL)
-	{
-	  free_and_init (class_attr_ndv.attr_ndv);
-	}
-      free_and_init (request);
-      db_value_clear (&class_name_val);
-
-      if (error != NO_ERROR)
-	{
-	  goto end;
-	}
-    }
-  while ((error = db_query_next_tuple (query_result)) == DB_CURSOR_SUCCESS);
-
-end:
-  if (query_result)
-    {
-      db_query_end (query_result);
-      query_result = NULL;
-    }
-  if (class_attr_ndv.attr_ndv != NULL)
-    {
-      free_and_init (class_attr_ndv.attr_ndv);
-    }
-  if (request)
-    {
-      free_and_init (request);
-    }
-
-  return (error == DB_CURSOR_END) ? NO_ERROR : error;
-
-#else /* CS_MODE */
   int error = NO_ERROR;
-  CLASS_ATTR_NDV class_attr_ndv = CLASS_ATTR_NDV_INITIALIZER;
   const char *query = "select c.unique_name from _db_class as c where c.class_type = 0 and [partition] is null "
     "union "
     "select c.unique_name from _db_class as c, TABLE(c.partition) as g(x) where c.class_type = 0 and x.pname is null;";
   DB_QUERY_RESULT *query_result = NULL;
   DB_QUERY_ERROR query_error;
   DB_VALUE class_name_val;
-  THREAD_ENTRY *thread_p;
   MOP class_mop;
+  const char *class_name = NULL;
+
+  memset (&query_error, 0, sizeof (DB_QUERY_ERROR));
+  db_make_null (&class_name_val);
+
+  error = db_compile_and_execute_local (query, &query_result, &query_error);
+  if (error < 0)
+    {
+      goto end;
+    }
+
+  error = db_query_first_tuple (query_result);
+  if (error != DB_CURSOR_SUCCESS)
+    {
+      goto end;
+    }
 
   memset (&query_error, 0, sizeof (DB_QUERY_ERROR));
   db_make_null (&class_name_val);
@@ -6063,8 +5955,6 @@ end:
 
   do
     {
-      const char *class_name = NULL;
-
       /* class_name */
       error = db_query_get_tuple_value (query_result, 0, &class_name_val);
       if (error != NO_ERROR)
@@ -6077,31 +5967,11 @@ end:
       if (class_mop == NULL)
 	{
 	  error = ER_FAILED;
+          db_value_clear (&class_name_val);
 	  goto end;
 	}
 
-      /* get NDV by query */
-      if (stats_get_ndv_by_query (class_mop, &class_attr_ndv, NULL, with_fullscan) != NO_ERROR)
-	{
-	  if (class_attr_ndv.attr_ndv != NULL)
-	    {
-	      free_and_init (class_attr_ndv.attr_ndv);
-	    }
-	  error = ER_FAILED;
-	  goto end;
-	}
-
-      thread_p = enter_server ();
-      error =
-	xstats_update_statistics (thread_p, WS_OID (class_mop),
-				  (with_fullscan ? STATS_WITH_FULLSCAN : STATS_WITH_SAMPLING), &class_attr_ndv);
-      exit_server (*thread_p);
-
-      if (class_attr_ndv.attr_ndv != NULL)
-	{
-	  free_and_init (class_attr_ndv.attr_ndv);
-	}
-
+      error = stats_update_statistics (class_mop, with_fullscan);
       db_value_clear (&class_name_val);
       if (error != NO_ERROR)
 	{
@@ -6116,13 +5986,8 @@ end:
       db_query_end (query_result);
       query_result = NULL;
     }
-  if (class_attr_ndv.attr_ndv != NULL)
-    {
-      free_and_init (class_attr_ndv.attr_ndv);
-    }
 
   return (error == DB_CURSOR_END) ? NO_ERROR : error;
-#endif /* !CS_MODE */
 }
 
 /*
@@ -10975,7 +10840,7 @@ loaddb_update_stats (bool verbose)
 		  fflush (stdout);
 		}
 	    }
-	  stats_update_statistics (classop, 0);
+	  stats_update_statistics (classop, STATS_WITH_SAMPLING);
 	}
     }
 

--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -81,6 +81,7 @@
 #include "message_catalog.h"
 #include "utility.h"
 #include "sp_constants.hpp"
+#include "locator_cl.h"
 
 /*
  * Use db_clear_private_heap instead of db_destroy_private_heap
@@ -113,6 +114,7 @@ static THREAD_ENTRY *enter_server (void);
 static void exit_server_no_thread_entry (void);
 static void exit_server (const THREAD_ENTRY & thread_ref);
 #endif // SERVER_MODE
+static int is_top_level_class (MOBJ mobj);
 
 #if defined (SA_MODE)
 //
@@ -5888,8 +5890,7 @@ end:
     }
 
   thread_p = enter_server ();
-  error =
-    xstats_update_statistics (thread_p, WS_OID (classop), with_fullscan, &class_attr_ndv);
+  error = xstats_update_statistics (thread_p, WS_OID (classop), with_fullscan, &class_attr_ndv);
   exit_server (*thread_p);
 
 end:
@@ -5900,6 +5901,19 @@ end:
 
   return error;
 #endif /* !CS_MODE */
+}
+
+static int
+is_top_level_class (MOBJ mobj)
+{
+  assert (mobj != NULL);
+
+  SM_CLASS *class_ = (SM_CLASS *) mobj;
+  bool is_class = class_->class_type == SM_CLASS_CT;
+  bool is_root_partition_class = (class_->partition == NULL ||
+				  class_->partition->class_partition_type == DB_PARTITIONED_CLASS);
+
+  return (is_class && is_root_partition_class);
 }
 
 /*
@@ -5914,80 +5928,28 @@ int
 stats_update_all_statistics (int with_fullscan)
 {
   int error = NO_ERROR;
-  const char *query = "select c.unique_name from _db_class as c where c.class_type = 0 and [partition] is null "
-    "union "
-    "select c.unique_name from _db_class as c, TABLE(c.partition) as g(x) where c.class_type = 0 and x.pname is null;";
-  DB_QUERY_RESULT *query_result = NULL;
-  DB_QUERY_ERROR query_error;
-  DB_VALUE class_name_val;
-  MOP class_mop;
-  const char *class_name = NULL;
+  MOP class_mop = NULL;
+  LIST_MOPS *lmops = NULL;
 
-  memset (&query_error, 0, sizeof (DB_QUERY_ERROR));
-  db_make_null (&class_name_val);
-
-  error = db_compile_and_execute_local (query, &query_result, &query_error);
-  if (error < 0)
+  lmops = locator_get_all_class_mops (DB_FETCH_READ, is_top_level_class);
+  if (lmops == NULL)
     {
-      goto end;
+      return ER_FAILED;
     }
 
-  error = db_query_first_tuple (query_result);
-  if (error != DB_CURSOR_SUCCESS)
+  for (int i = 0; i < lmops->num; i++)
     {
-      goto end;
-    }
-
-  memset (&query_error, 0, sizeof (DB_QUERY_ERROR));
-  db_make_null (&class_name_val);
-
-  error = db_compile_and_execute_local (query, &query_result, &query_error);
-  if (error < 0)
-    {
-      goto end;
-    }
-
-  error = db_query_first_tuple (query_result);
-  if (error != DB_CURSOR_SUCCESS)
-    {
-      goto end;
-    }
-
-  do
-    {
-      /* class_name */
-      error = db_query_get_tuple_value (query_result, 0, &class_name_val);
-      if (error != NO_ERROR)
-	{
-	  goto end;
-	}
-      class_name = db_get_string (&class_name_val);
-
-      class_mop = db_find_class (class_name);
-      if (class_mop == NULL)
-	{
-	  error = ER_FAILED;
-          db_value_clear (&class_name_val);
-	  goto end;
-	}
-
+      class_mop = lmops->mops[i];
       error = stats_update_statistics (class_mop, with_fullscan);
-      db_value_clear (&class_name_val);
       if (error != NO_ERROR)
 	{
-	  goto end;
+	  break;
 	}
     }
-  while ((error = db_query_next_tuple (query_result)) == DB_CURSOR_SUCCESS);
 
-end:
-  if (query_result)
-    {
-      db_query_end (query_result);
-      query_result = NULL;
-    }
+  locator_free_list_mops (lmops);
 
-  return (error == DB_CURSOR_END) ? NO_ERROR : error;
+  return error;
 }
 
 /*

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -4443,7 +4443,7 @@ sm_update_all_statistics (bool with_fullscan)
 /*
  * sm_update_all_catalog_statistics()
  *   return: NO_ERROR on success, non-zero for ERROR
- *   with_fullscan(in): true if WITH FULLSCAN
+ *   with_fullscan(in): true iff WITH FULLSCAN
  */
 
 int
@@ -4475,7 +4475,7 @@ sm_update_all_catalog_statistics (bool with_fullscan)
  * sm_update_catalog_statistics()
  *   return: NO_ERROR on success, non-zero for ERROR
  *   class_name(in):
- *   with_fullscan(in): true if WITH FULLSCAN
+ *   with_fullscan(in): true iff WITH FULLSCAN
  */
 
 int

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -16776,7 +16776,7 @@ set_checked_time_with_strategy (MOP _db_class, const char *class_name, CLASS_STA
       goto end;
     }
 
-  db_make_int(&statistics_strategy_val, with_fullscan);
+  db_make_int (&statistics_strategy_val, with_fullscan);
   error = obj_set (inst, "statistics_strategy", &statistics_strategy_val);
   if (error != NO_ERROR)
     {

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -16753,7 +16753,7 @@ set_checked_time_with_strategy (MOP _db_class, const char *class_name, CLASS_STA
   int error = NO_ERROR;
   DB_VALUE class_name_val;
   int save;
-  DB_VALUE timestamp_val, current_datetime_val;
+  DB_VALUE timestamp_val, current_datetime_val, statistics_strategy_val;
 
   AU_DISABLE (save);
   db_make_string (&class_name_val, class_name);
@@ -16770,12 +16770,19 @@ set_checked_time_with_strategy (MOP _db_class, const char *class_name, CLASS_STA
     {
       goto end;
     }
-
   error = obj_set (inst, "checked_time", &current_datetime_val);
   if (error != NO_ERROR)
     {
       goto end;
     }
+
+  db_make_int(&statistics_strategy_val, with_fullscan);
+  error = obj_set (inst, "statistics_strategy", &statistics_strategy_val);
+  if (error != NO_ERROR)
+    {
+      goto end;
+    }
+
   error = locator_flush_instance (inst);
 
 end:

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -4226,7 +4226,6 @@ sm_update_statistics (MOP classop, bool with_fullscan)
     }
   if (is_class > 0)
     {
-
       /* make sure the workspace is flushed before calculating stats */
       if (locator_flush_all_instances (classop, DONT_DECACHE) != NO_ERROR)
 	{
@@ -4234,7 +4233,7 @@ sm_update_statistics (MOP classop, bool with_fullscan)
 	  return er_errid ();
 	}
 
-      error = stats_update_statistics (classop, (with_fullscan ? 1 : 0));
+      error = stats_update_statistics (classop, with_fullscan);
       if (error == NO_ERROR)
 	{
 	  /* only recache if the class itself is cached */
@@ -4370,7 +4369,7 @@ sm_update_all_statistics (bool with_fullscan)
       return er_errid ();
     }
 
-  error = stats_update_all_statistics ((with_fullscan ? 1 : 0));
+  error = stats_update_all_statistics (with_fullscan);
   if (error == NO_ERROR)
     {
       /* Need to reset the statistics cache for all resident classes */
@@ -4415,7 +4414,7 @@ sm_update_all_statistics (bool with_fullscan)
 /*
  * sm_update_all_catalog_statistics()
  *   return: NO_ERROR on success, non-zero for ERROR
- *   with_fullscan(in): true iff WITH FULLSCAN
+ *   with_fullscan(in): true if WITH FULLSCAN
  */
 
 int
@@ -4447,7 +4446,7 @@ sm_update_all_catalog_statistics (bool with_fullscan)
  * sm_update_catalog_statistics()
  *   return: NO_ERROR on success, non-zero for ERROR
  *   class_name(in):
- *   with_fullscan(in): true iff WITH FULLSCAN
+ *   with_fullscan(in): true if WITH FULLSCAN
  */
 
 int

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -4275,7 +4275,7 @@ sm_update_statistics (MOP classop, bool with_fullscan)
 		      return error;
 		    }
 
-		  // class_->stats is NULL if class doesn't have attributes.
+		  /* class_->stats is NULL if class doesn't have attributes. */
 		  if (class_->stats != NULL)
 		    {
 		      class_name = sm_ch_name ((MOBJ) class_);
@@ -4422,7 +4422,7 @@ sm_update_all_statistics (bool with_fullscan)
 		      return error;
 		    }
 
-		  // class_->stats is NULL if class doesn't have attributes.
+		  /* class_->stats is NULL if class doesn't have attributes. */
 		  if (class_->stats != NULL)
 		    {
 		      class_name = sm_ch_name ((MOBJ) class_);

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -443,7 +443,8 @@ static int sm_flush_and_decache_objects_internal (MOP obj, MOP obj_class_mop, in
 
 static void sm_free_resident_classes_virtual_query_cache (void);
 static int sm_set_class_timestamps (SM_CLASS * class_);
-static int set_checked_time_with_strategy (MOP op, bool with_fullscan);
+static int set_checked_time_with_strategy (MOP _db_class, const char *class_name, CLASS_STATS * stats,
+					   bool with_fullscan);
 
 
 /*
@@ -4210,6 +4211,8 @@ sm_update_statistics (MOP classop, bool with_fullscan)
 {
   int error = NO_ERROR, is_class = 0;
   SM_CLASS *class_;
+  MOP _db_class;
+  const char *class_name = NULL;
 
   assert_release (classop != NULL);
 
@@ -4231,6 +4234,13 @@ sm_update_statistics (MOP classop, bool with_fullscan)
 	{
 	  assert (er_errid () != NO_ERROR);
 	  return er_errid ();
+	}
+
+      _db_class = sm_find_class_with_purpose (CT_CLASS_NAME, true);
+      if (_db_class == NULL)
+	{
+	  ASSERT_ERROR_AND_SET (error);
+	  return error;
 	}
 
       error = stats_update_statistics (classop, with_fullscan);
@@ -4265,10 +4275,15 @@ sm_update_statistics (MOP classop, bool with_fullscan)
 		      return error;
 		    }
 
-		  error = set_checked_time_with_strategy (classop, with_fullscan);
-		  if (error != NO_ERROR)
+		  // class_->stats is NULL if class doesn't have attributes.
+		  if (class_->stats != NULL)
 		    {
-		      return error;
+		      class_name = sm_ch_name ((MOBJ) class_);
+		      error = set_checked_time_with_strategy (_db_class, class_name, class_->stats, with_fullscan);
+		      if (error != NO_ERROR)
+			{
+			  return error;
+			}
 		    }
 		}
 	    }
@@ -4361,12 +4376,21 @@ sm_update_all_statistics (bool with_fullscan)
   int error = NO_ERROR;
   DB_OBJLIST *cl;
   SM_CLASS *class_;
+  MOP _db_class;
+  const char *class_name = NULL;
 
   /* make sure the workspace is flushed before calculating stats */
   if (locator_all_flush () != NO_ERROR)
     {
       assert (er_errid () != NO_ERROR);
       return er_errid ();
+    }
+
+  _db_class = sm_find_class_with_purpose (CT_CLASS_NAME, true);
+  if (_db_class == NULL)
+    {
+      ASSERT_ERROR_AND_SET (error);
+      return error;
     }
 
   error = stats_update_all_statistics (with_fullscan);
@@ -4398,10 +4422,15 @@ sm_update_all_statistics (bool with_fullscan)
 		      return error;
 		    }
 
-		  error = set_checked_time_with_strategy (cl->op, with_fullscan);
-		  if (error != NO_ERROR)
+		  // class_->stats is NULL if class doesn't have attributes.
+		  if (class_->stats != NULL)
 		    {
-		      return error;
+		      class_name = sm_ch_name ((MOBJ) class_);
+		      error = set_checked_time_with_strategy (_db_class, class_name, class_->stats, with_fullscan);
+		      if (error != NO_ERROR)
+			{
+			  return error;
+			}
 		    }
 		}
 	    }
@@ -16718,38 +16747,40 @@ sm_update_class_timestamp (SM_CLASS * class_)
 }
 
 static int
-set_checked_time_with_strategy (MOP op, bool with_fullscan)
+set_checked_time_with_strategy (MOP _db_class, const char *class_name, CLASS_STATS * stats, bool with_fullscan)
 {
-  SM_CLASS *class_ = NULL;
-  time_t sec;
-  DB_VALUE timestamp, current_datetime;
-  DB_DATETIME checked_time = (DB_DATETIME) { 0, 0 };
+  MOP inst;
+  int error = NO_ERROR;
+  DB_VALUE class_name_val;
+  int save;
+  DB_VALUE timestamp_val, current_datetime_val;
 
-  if (au_fetch_class_force (op, &class_, AU_FETCH_UPDATE) != NO_ERROR)
+  AU_DISABLE (save);
+  db_make_string (&class_name_val, class_name);
+  inst = db_find_unique (_db_class, "unique_name", &class_name_val);
+  if (inst == NULL)
     {
-      return ER_FAILED;
+      ASSERT_ERROR_AND_SET (error);
+      goto end;
     }
 
-  if (class_->stats != NULL && class_->stats->time_stamp != 0)
+  db_make_timestamp (&timestamp_val, stats->time_stamp);
+  error = db_timestamp_to_datetime (&timestamp_val, &current_datetime_val);
+  if (error != NO_ERROR)
     {
-      sec = (time_t) class_->stats->time_stamp;
-      db_make_timestamp (&timestamp, (DB_TIMESTAMP) sec);
-      if (db_timestamp_to_datetime (&timestamp, &current_datetime) != NO_ERROR)
-	{
-	  return ER_FAILED;
-	}
-
-      checked_time = *db_get_datetime (&current_datetime);
+      goto end;
     }
 
-  class_->checked_time = checked_time;
-  class_->statistics_strategy = (int) with_fullscan;
-
-  if (locator_flush_class (op) != NO_ERROR)
+  error = obj_set (inst, "checked_time", &current_datetime_val);
+  if (error != NO_ERROR)
     {
-      assert (er_errid () != NO_ERROR);
-      return er_errid ();
+      goto end;
     }
+  error = locator_flush_instance (inst);
 
-  return NO_ERROR;
+end:
+  db_value_clear (&class_name_val);
+  AU_ENABLE (save);
+
+  return error;
 }

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -3161,8 +3161,8 @@ struct pt_update_info
 struct pt_update_stats_info
 {
   PT_NODE *class_list;		/* PT_NAME */
-  int all_classes;		/* 1 iff ALL CLASSES */
-  int with_fullscan;		/* 1 iff WITH FULLSCAN */
+  int all_classes;		/* 1 if ALL CLASSES */
+  int with_fullscan;		/* 1 if WITH FULLSCAN */
 };
 
 /* GET STATISTICS INFO */

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -3161,8 +3161,8 @@ struct pt_update_info
 struct pt_update_stats_info
 {
   PT_NODE *class_list;		/* PT_NAME */
-  int all_classes;		/* 1 if ALL CLASSES */
-  int with_fullscan;		/* 1 if WITH FULLSCAN */
+  int all_classes;		/* 1 iff ALL CLASSES */
+  int with_fullscan;		/* 1 iff WITH FULLSCAN */
 };
 
 /* GET STATISTICS INFO */

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -16125,7 +16125,7 @@ pt_print_update_stats (PARSER_CONTEXT * parser, PT_NODE * p)
 
   if (p->info.update_stats.with_fullscan > 0)
     {
-      assert (p->info.update_stats.with_fullscan == 1);
+      assert (p->info.update_stats.with_fullscan == STATS_WITH_FULLSCAN);
       b = pt_append_nulstring (parser, b, " with fullscan");
     }
 

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -4480,8 +4480,7 @@ do_update_stats (PARSER_CONTEXT * parser, PT_NODE * statement)
 
 	  if (class_type == SM_CLASS_CT)
 	    {
-	      error = sm_update_statistics (class_mop, (statement->info.update_stats.with_fullscan
-							? STATS_WITH_FULLSCAN : STATS_WITH_SAMPLING));
+	      error = sm_update_statistics (class_mop, statement->info.update_stats.with_fullscan);
 	    }
 	}
 

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -11182,17 +11182,20 @@ db_timestamp_to_datetime (const DB_VALUE * src_timestamp, DB_VALUE * result_date
 {
   time_t sec;
   struct tm tm_val;
-  DB_DATETIME datetime;
+  DB_DATETIME datetime = (DB_DATETIME) { 0, 0 };
 
   sec = (time_t) * db_get_timestamp (src_timestamp);
-  if (localtime_r (&sec, &tm_val) == NULL)
+  if (sec != 0)
     {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SYSTEM_DATE, 0);
-      return ER_SYSTEM_DATE;
-    }
+      if (localtime_r (&sec, &tm_val) == NULL)
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SYSTEM_DATE, 0);
+	  return ER_SYSTEM_DATE;
+	}
 
-  db_datetime_encode (&datetime, tm_val.tm_mon + 1, tm_val.tm_mday, tm_val.tm_year + 1900,
-		      tm_val.tm_hour, tm_val.tm_min, tm_val.tm_sec, 0);
+      db_datetime_encode (&datetime, tm_val.tm_mon + 1, tm_val.tm_mday,
+			  tm_val.tm_year + 1900, tm_val.tm_hour, tm_val.tm_min, tm_val.tm_sec, 0);
+    }
   db_make_datetime (result_datetime, &datetime);
 
   return NO_ERROR;


### PR DESCRIPTION
[<http://jira.cubrid.org/browse/CBRD-25862>
](http://jira.cubrid.org/browse/CBRD-25862)

### Purpose
https://github.com/CUBRID/cubrid/commit/76231ba571372e3e9c7344a633b948abac26dfbf 에서 발생한 여러 세션에서 동시에 통계 정보 갱신 시 발생하는 deadlock 문제를 해결합니다.

### Implementation
기존 방식: `checked_time` 갱신 시, 해당 클래스를 통하여  쓰기 작업 수행
수정된 방식: `checked_time` 갱신 시, `_db_class` 에서 클래스의 레코드를 찾아 `_db_class` 에 쓰기 작업 수행 (`_db_class` 에만 쓰기 권한 획득)

### Remarks
- refactoring
  - [c779bc1](https://github.com/CUBRID/cubrid/pull/6546/commits/c779bc16ec739a8837d5d64b68dc9093e1c84478): 중복되는 코드를 통합 
  - [dcadaab](https://github.com/CUBRID/cubrid/pull/6546/commits/dcadaab284cd8a04b26fbb25a36052e5813af8de): 모든 클래스의 통계 정보 갱신 시 사용하는 쿼리를 내부 API로 변경
