### PR TITLE
[CBRD-25862] refactor: remove code about clearing timestamp of CAS statistics when heap_num_objects == 0 || heap_num_pages == 0

### DIFF
--- a/src/storage/statistics_cl.c
+++ b/src/storage/statistics_cl.c
@@ -119,12 +119,6 @@ stats_client_unpack_statistics (char *buf_p)
       class_stats_p->heap_num_pages = 0;
     }
 
-  /* to get the doubtful statistics to be updated, need to clear timestamp */
-  if (class_stats_p->heap_num_objects == 0 || class_stats_p->heap_num_pages == 0)
-    {
-      class_stats_p->time_stamp = 0;
-    }
-
   class_stats_p->n_attrs = OR_GET_INT (buf_p);
   buf_p += OR_INT_SIZE;
   if (class_stats_p->n_attrs == 0)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-25862>

### Purpose

서버의 통계 정보 갱신 시간과 클라이언트(CAS)의 통계 정보 갱신 시간의 값을 동일하게 유지하기 위함

### Implementation
기존: 통계 정보 갱신 시, 레코드나 할당된 페이지가 없으면 서버의 통계 정보 갱신 시간은 업데이트하지만 CAS 는 0으로 설정
수정: 통계 정보 갱신 시, 서버와 CAS 의 통계 정보 갱신 시간을 동일하게 유지

### Remarks
- 테이블에 컬럼이 없는 경우에 서버에서는 통계 정보 갱신 시간을 업데이트하지만, CAS에서는 클래스의 통계 정보를 NULL 로 만듦. 따라서 이 경우는 서버와 CAS의 통계 정보 갱신 시간을 동일하게 유지하지 않음