### PR TITLE
[CBRD-26346] Encryption when master key is lost (#6557)

### DIFF
--- a/src/query/crypt_opfunc.c
+++ b/src/query/crypt_opfunc.c
@@ -731,8 +731,18 @@ init_dblink_cipher (EVP_CIPHER_CTX ** ctx, const EVP_CIPHER ** cipher_type, bool
       extern int dblink_get_cipher_master_key ();	// declared in "network_interface_cl.c"
       if ((err = dblink_get_cipher_master_key ()) != NO_ERROR)
 	{
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, err, 0);
-	  return err;
+	  if (err != ER_TDE_CIPHER_IS_NOT_LOADED)
+	    {
+	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, err, 0);
+	      return err;
+	    }
+
+	  /* TODO: 
+	   * We need to analyze why er_errid() returns -1 even though no error was set. 
+	   * Until then, let's clear the error. 
+	   * err = er_errid();
+	   */
+	  er_clearid ();	/* er_clear() */
 	}
     }
 #endif


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26346

### Purpose

* master key 파일을 분실하여 TDE를 사용하지 못하는 경우의 SERVER 패스워드의 암호화 처리 지원
* backport #6557

### Implementation

N/A

### Remarks

N/A
