### PR TITLE
[CBRD-26310] ha_make_slavedb.sh에서 발생하는 오류 수정-11.4 반영-백포트

### DIFF
--- a/contrib/scripts/ha/ha_make_slavedb.sh
+++ b/contrib/scripts/ha/ha_make_slavedb.sh
@@ -292,12 +292,65 @@ function check_args()
 	fi
 }
 
+function check_backup_dest_path()
+{
+    # Check Directory backup_dest_path
+    if [ ! -d "$backup_dest_path" ]; then
+		error "The backup path ‘$backup_dest_path’ does not exist or is not a directory. Please create the path or specify a valid path."
+    fi
+}
+
+function check_db_name() {
+    # It updates the global 'db_name' to be only the first valid database name found.
+    local original_input="$db_name"
+    local first_db_found=""
+
+    # e.g., db_name='"db1, db2"' becomes `db1, db2`
+    original_input="$(echo "$original_input")"
+
+    # To handle the last item correctly, append a comma
+    local temp_input="${original_input},"
+    local db_count=0
+    while [[ -n "$temp_input" ]]; do
+        # Extract part before the first comma
+        local part="${temp_input%%,*}"
+        # Remove the extracted part from the beginning
+        temp_input="${temp_input#*,}"
+
+        # Trim leading and trailing whitespace (pure bash)
+        part="${part#"${part%%[![:space:]]*}"}" # leading
+        part="${part%"${part##*[![:space:]]}"}" # trailing
+
+        # If the part is not empty after trimming, it's a valid DB name.
+        if [[ -n "$part" ]]; then
+            # Check if the part is a case-insensitive "null" string.
+            if [[ "${part,,}" == "null" ]]; then
+                # Treat "null" as an invalid name and skip it.
+                continue
+            fi
+            ((db_count++))
+            # Store the first valid DB name found.
+            [ -z "$first_db_found" ] && first_db_found="$part"
+        fi
+    done
+
+    # Update the global db_name variable
+    db_name="$first_db_found"
+
+    # If multiple DBs were in the original input, issue a warning.
+    if [[ -n "$original_input" && "$db_count" -gt 1 ]]; then
+        echo "WARNING: Multiple DBs were specified: '$original_input'."
+        echo "         Only the first valid DB ('$db_name') will be used. Others are ignored."
+    fi
+}
+
 function init_conf()
 {
 	# init path
 	backup_dest_path=${backup_dest_path:-$ha_temp_home/backup}
 	mkdir -p $ha_temp_home $backup_dest_path
-	repl_log_home=${repl_log_home%%/}
+	check_backup_dest_path
+ 	repl_log_home=${repl_log_home%%/}
 	backup_dest_path=${backup_dest_path%%/}
 	backup_dest_path=$(readlink -f $backup_dest_path)
 	
@@ -306,7 +359,6 @@ function init_conf()
 		error "Cannot find cubrid_ha.conf in $CUBRID/conf."
 	fi
 	
-	node_index=1
 	while read line
 	do
 		if [[ "${line:0:1}" != "#" && "${line:0:1}" != "" ]]; then
@@ -319,23 +371,23 @@ function init_conf()
 					hosts=$(echo ${conf[1]} | cut -d '@' -f 2)
 					master_host=$(echo $hosts | cut -d ':' -f 1)
 					slave_host=$(echo $hosts | cut -d ':' -f 2)
-					if [ "$slave_host" == "$target_host" ]; then
-						node_index=2
-					fi
 					;;
 				"ha_replica_list") replica_hosts=$(echo ${conf[1]} | cut -d '@' -f 2);;
 				"ha_db_list")
-					if [ -z $db_name ]; then
+					if [ -z "$db_name" ]; then
 						db_name=${conf[1]}
-						db_name=$(echo $db_name | cut -d ',' -f 1)
+						echo "INFO: 'db_name' is not specified. Using DB list from ha_db_list in cubrid_ha.conf: '$db_name'"
 					fi
 					;;
 			esac
 		fi
 	done < $CUBRID/conf/cubrid_ha.conf
 
+	# Sanitize the db_name, extracting the first valid one if multiple are given.
+	check_db_name
+
 	if [ -z $db_name ]; then
-		error "The db_name is null."
+		error "The db_name is null. Please specify 'db_name' variable or set 'ha_db_list' in cubrid_ha.conf."
 	fi
 	
 	# check the master and slave host is valid
@@ -841,7 +893,7 @@ function copy_active_log_from_master()
 
 	# 2. copy all transaction logs from master.
 	echo -ne "\n - 2. copy all transaction logs from master.\n\n"
-	execute "cub_admin copylogdb -L ${repl_log_path} -m async --start-page-id=-1 ${db_name}@${master_host}"
+	execute "cubrid copylogdb -L ${repl_log_path} -m async --start-page-id=-1 ${db_name}@${master_host}"
 }
 
 function show_complete()
@@ -875,3 +927,4 @@ for ((n= 0, size = ${#step_func[@]}; n < size; n++)) do
 	echo -ne "\n\n"
 done
 echo -ne "###### END ######\n\n" >> time.output
+


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26310

**Purpose**
ha_make_slavedb.sh 에서 발생하는 오류를 수정합니다.

1. check_db_name
- func check_db_name를 추가
- db_name이 null인 경우, ha_db_list의 첫번째(구분자 ,) 의 db명을 사용
- db_name이 null이 아닌 경우, check_db_name()으로 점검 부분 추가
2. 불필요한 변수 삭제
- node_index 사용하는 곳 없어 삭제 처리
3.명령어 일관성
- cub_admin 부분을 cubrid로 변경
- "execute "cub_admin copylogdb -L ${repl_log_path}"
4. target_host
- check_args()에서 설정 여부만 판단
- 문자열 점검로직 추가, /etc/hosts에 존재하지 않는 경우 Error, 존재하는 경우에만 정상 진행하도록
5. backup_dest_path
- 비어있는 경우 $HOME/.ha/backup 으로 설정됨
6. get_output_from_replica --> from-replica-to-slave에 수행, 현재 해당 범위는 미지원으로 코드 원복
- 로컬 파일 경로를 ${호스트명}.output 형식으로 명확하게 정의하여 로직이 단순하고 직관적임.
- 파일 복사(scp)가 실패해도 오류를 인지하지 못하고 다음 단계로 진행하여, 나중에 원인 불명의 오류를 유발할 수 있음.
- 파일 복사 직후 결과 파일의 존재 여부를 확인하여, 실패 시 즉시 스크립트를 중단시키므로 안정성이 높음.

**Implementation**
- func check_db_name 구현
- func check_backup_dest_path
- function get_output_from_replica() 개선

**Remarks**
- 다중슬레이브/다중레플리카 지원범위 확대에 대한 것은 차후에 지원 하기로 함.