### PR TITLE
[CBRD-26272] loaddb & unload 사용시 복제 옵션 출력 및 적용

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -1777,6 +1777,11 @@ emit_schema (extract_context & ctxt, print_output & output_ctx, EXTRACT_CLASS_TY
 	      output_ctx (" DONT_REUSE_OID");
 	    }
 
+	  if (class_ != NULL)
+	    {
+	      output_ctx (", COLLATE %s", lang_get_collation_name (class_->collation_id));
+	    }
+
 	  if (sm_is_replication_class (cl->op))
 	    {
 	      output_ctx (", REPLICATION=ON");
@@ -1784,11 +1789,6 @@ emit_schema (extract_context & ctxt, print_output & output_ctx, EXTRACT_CLASS_TY
 	  else
 	    {
 	      output_ctx (", REPLICATION=OFF");
-	    }
-
-	  if (class_ != NULL)
-	    {
-	      output_ctx (", COLLATE %s", lang_get_collation_name (class_->collation_id));
 	    }
 
 	  if (class_ != NULL)

--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -1777,6 +1777,15 @@ emit_schema (extract_context & ctxt, print_output & output_ctx, EXTRACT_CLASS_TY
 	      output_ctx (" DONT_REUSE_OID");
 	    }
 
+	  if (sm_is_replication_class (cl->op))
+	    {
+	      output_ctx (", REPLICATION=ON");
+	    }
+	  else
+	    {
+	      output_ctx (", REPLICATION=OFF");
+	    }
+
 	  if (class_ != NULL)
 	    {
 	      output_ctx (", COLLATE %s", lang_get_collation_name (class_->collation_id));

--- a/src/object/object_printer.cpp
+++ b/src/object/object_printer.cpp
@@ -1126,11 +1126,11 @@ void object_printer::describe_class (struct db_object *class_op)
   /* replication */
   if (sm_is_replication_class (class_op))
     {
-      m_buf (" REPLICATION=ON");
+      m_buf (", REPLICATION=ON");
     }
   else
     {
-      m_buf (" REPLICATION=OFF");
+      m_buf (", REPLICATION=OFF");
     }
 
   /* tde_algorithm */


### PR DESCRIPTION
[<http://jira.cubrid.org/browse/CBRD-26272>](http://jira.cubrid.org/browse/CBRD-26272)

### Purpose

unloaddb 유틸리티 사용시 replication 옵션을 함께 출력하며, loaddb는 이 옵션을 새 데이터베이스에 반영할 수 있도록 합니다.

### Implementation

unloaddb 에서 스키마 출력을 담당하는 emit_schema() 함수에 복제 정보(REPLICATION={ON|OFF})를 출력할 수 있는 코드를 추가했습니다.
복제 옵션이 적용된 코드에서 unloaddb를 실행하면 다음과 같은 스키마 정보의 파일을 얻을 수 있습니다.
`
CREATE CLASS [dba].[repl_on_without_rk] REUSE_OID, REPLICATION=ON, COLLATE iso88591_bin;
`
또는
`
CREATE CLASS [dba].[repl_off_without_rk] REUSE_OID, REPLICATION=OFF, COLLATE iso88591_bin;
`

loaddb는 별도의 추가작업 없이 이 옵션을 데이터베이스에 로드할 수 있습니다.
추가로 이전 버전에서 unloaddb를 수행할 경우 출력되는 복제 옵션이 없는데, 이 경우 자동으로 복제 ON으로 등록됩니다.

### Remarks

N/A
