### PR TITLE
[CBRD-26279] Exclude pager time from CSQL's query time display

### DIFF
--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -2121,14 +2121,13 @@ csql_execute_statements (const CSQL_ARGUMENT * csql_arg, int type, const void *s
 	  goto error;
 	}
 
-      snprintf (stmt_msg, LINE_BUFFER_SIZE, "Execute OK.");
-
       if (csql_Is_time_on)
 	{
 	  tsc_getticks (&end_tick);
 	  tsc_elapsed_time_usec (&elapsed_time, end_tick, start_tick);
 	}
 
+      snprintf (stmt_msg, LINE_BUFFER_SIZE, "Execute OK.");
       csql_Row_count = 0;
       switch (stmt_type)
 	{

--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -2123,6 +2123,12 @@ csql_execute_statements (const CSQL_ARGUMENT * csql_arg, int type, const void *s
 
       snprintf (stmt_msg, LINE_BUFFER_SIZE, "Execute OK.");
 
+      if (csql_Is_time_on)
+	{
+	  tsc_getticks (&end_tick);
+	  tsc_elapsed_time_usec (&elapsed_time, end_tick, start_tick);
+	}
+
       csql_Row_count = 0;
       switch (stmt_type)
 	{
@@ -2204,9 +2210,6 @@ csql_execute_statements (const CSQL_ARGUMENT * csql_arg, int type, const void *s
       if (csql_Is_time_on)
 	{
 	  char time[100];
-
-	  tsc_getticks (&end_tick);
-	  tsc_elapsed_time_usec (&elapsed_time, end_tick, start_tick);
 
 	  sprintf (time, " (%ld.%06ld sec) ", elapsed_time.tv_sec, elapsed_time.tv_usec);
 	  strncat (stmt_msg, time, sizeof (stmt_msg) - strlen (stmt_msg) - 1);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26279

### Purpose

CSQL의 쿼리 시간 표시가 pager에 영향을 받는 문제 수정

### Implementation

측정하는 쿼리 실행 시간에 결과를 페이징하는 `csql_results()`가 포함되지 않도록 쿼리 실행 완료 (db_execute_statement) 전까지의 시간을 측정한 값을 저장하고 표시한다.

### Remarks

N/A
