### PR TITLE
[CBRD-26365] [Regression] Core dumped in cub_free at src/base/memory_cwrapper.h:85

### DIFF
--- a/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
@@ -143,7 +143,14 @@ namespace parallel_heap_scan
   {
     if constexpr (result_type == RESULT_TYPE::MERGEABLE_LIST)
       {
-	/* do nothing */
+	for (QFILE_LIST_ID *list_id : m_.writer_results)
+	  {
+	    if (list_id != nullptr && list_id->type_list.type_cnt > 0)
+	      {
+		qfile_destroy_list (thread_p, list_id);
+	      }
+	  }
+	m_.writer_results.clear();
       }
     else if constexpr (result_type == RESULT_TYPE::XASL_SNAPSHOT)
       {
@@ -221,7 +228,7 @@ namespace parallel_heap_scan
 	    }
 	}
 	size = tl.writer_result_p->type_list.type_cnt * DB_SIZEOF (DB_VALUE *);
-	tl.writer_result_p->tpl_descr.f_valp = (DB_VALUE **) db_private_alloc (thread_p, size);
+	tl.writer_result_p->tpl_descr.f_valp = (DB_VALUE **) malloc (size);
 	if (tl.writer_result_p->tpl_descr.f_valp == NULL)
 	  {
 	    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, size);
@@ -231,7 +238,7 @@ namespace parallel_heap_scan
 	    return;
 	  }
 	size = tl.writer_result_p->type_list.type_cnt * sizeof (bool);
-	tl.writer_result_p->tpl_descr.clear_f_val_at_clone_decache = (bool *) db_private_alloc (thread_p, size);
+	tl.writer_result_p->tpl_descr.clear_f_val_at_clone_decache = (bool *) malloc (size);
 	if (tl.writer_result_p->tpl_descr.clear_f_val_at_clone_decache == NULL)
 	  {
 	    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, size);
@@ -292,10 +299,8 @@ namespace parallel_heap_scan
 	assert (tl.writer_result_p->last_pgptr == nullptr);
 	if (tl.writer_result_p != nullptr && tl.writer_result_p->tpl_descr.f_valp != nullptr)
 	  {
-	    db_private_free (thread_p, tl.writer_result_p->tpl_descr.f_valp);
-	    db_private_free (thread_p, tl.writer_result_p->tpl_descr.clear_f_val_at_clone_decache);
-	    tl.writer_result_p->tpl_descr.f_valp = nullptr;
-	    tl.writer_result_p->tpl_descr.clear_f_val_at_clone_decache = nullptr;
+	    free_and_init (tl.writer_result_p->tpl_descr.f_valp);
+	    free_and_init (tl.writer_result_p->tpl_descr.clear_f_val_at_clone_decache);
 	  }
 	tl.writer_result_p = nullptr;
 	if (tl.tpl_buf.tpl != nullptr)
@@ -473,15 +478,6 @@ namespace parallel_heap_scan
 		  m_result_cv.wait_for (lock, std::chrono::microseconds (50));
 		  if (m_interrupt_p->get_code() != parallel_query::interrupt::interrupt_code::NO_INTERRUPT)
 		    {
-		      for (QFILE_LIST_ID *list_id : m_.writer_results)
-			{
-			  if (list_id != nullptr && list_id->type_list.type_cnt > 0)
-			    {
-			      qfile_destroy_list (thread_p, list_id);
-			    }
-			}
-		      m_.writer_results.clear();
-		      m_.result_p = nullptr;
 		      return S_ERROR;
 		    }
 		}
@@ -507,6 +503,7 @@ namespace parallel_heap_scan
 		qfile_destroy_list (thread_p, list_id);
 	      }
 	  }
+	m_.writer_results.clear();
 	if (m_.result_p != nullptr)
 	  {
 	    if (dest->tuple_cnt > 0)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26365>

### Purpose

core dump를 해결합니다.

### Implementation

mergeable list에서, 에러가 발생했을 경우 child thread에서 아직 write를 수행중인데도 main thread에서 관련 자료구조를 free하는 문제가 있습니다. child thread가 종료된 후에 해당 자료구조 (list_file)을 free하도록 변경합니다.
또한 list_file의 tpl_descr 관련 자료구조들은 malloc() free() 로 관리되지만 parallel heap scan에서 db_private_alloc을 사용하여 core가 발생하는 현상을 해결합니다.


