### PR TITLE
[CBRD-26366] change delimiter ' ' -> '\t'

### DIFF
--- a/conf/cubrid_hosts.conf
+++ b/conf/cubrid_hosts.conf
@@ -15,4 +15,4 @@
 #
 #
 127.0.0.1	localhost
-0.0.0.0         your-hostname
+0.0.0.0		your-hostname

--- a/conf/cubrid_hosts.conf
+++ b/conf/cubrid_hosts.conf
@@ -15,4 +15,4 @@
 #
 #
 127.0.0.1	localhost
-0.0.0.0		your-hostname
+0.0.0.0		your-hostname 

--- a/conf/cubrid_hosts.conf
+++ b/conf/cubrid_hosts.conf
@@ -15,4 +15,4 @@
 #
 #
 127.0.0.1	localhost
-0.0.0.0		your-hostname 
+0.0.0.0		your-hostname


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26366>

### Purpose

cubrid_hosts.conf 파일 내에서 ip, hostname 의 구분자로 공백(' ')과 탭('\t') 을 함께 사용 된 부분에 대해 탭으로 통일. 

### Implementation

N/A

### Remarks

N/A
