### PR TITLE
[CBRD-26368] [Regression] Remove redundant IS NOT NULL predicates on columns declared NOT NULL

### DIFF
--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -11514,7 +11514,7 @@ qo_check_like_recompile_candidate (QO_PLAN * plan, void *arg)
   BITSET_ITERATOR terms_iter;
   QO_ENV *env;
   QO_TERM *termp;
-  PT_NODE *expr, *left;
+  PT_NODE *expr;
   QO_SEGMENT *seg;
 
   bool *result = (bool *) arg;

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -11514,7 +11514,7 @@ qo_check_like_recompile_candidate (QO_PLAN * plan, void *arg)
   BITSET_ITERATOR terms_iter;
   QO_ENV *env;
   QO_TERM *termp;
-  PT_NODE *expr;
+  PT_NODE *expr, *left;
   QO_SEGMENT *seg;
 
   bool *result = (bool *) arg;
@@ -11542,7 +11542,18 @@ qo_check_like_recompile_candidate (QO_PLAN * plan, void *arg)
 	  continue;
 	}
 
-      qo_expr_segs (env, pt_left_part (expr), &temp_segs_set);
+      left = pt_left_part (expr);
+      while (left && left->node_type == PT_EXPR && left->info.expr.op == PT_CAST && left->info.expr.arg1)
+	{
+	  left = pt_left_part (left);
+	}
+
+      if (!pt_is_attr (left))
+	{
+	  continue;
+	}
+
+      qo_expr_segs (env, left, &temp_segs_set);
       seg_idx = bitset_first_member (&temp_segs_set);
       if (seg_idx == -1)
 	{

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -11542,22 +11542,10 @@ qo_check_like_recompile_candidate (QO_PLAN * plan, void *arg)
 	  continue;
 	}
 
-      left = pt_left_part (expr);
-      while (left && left->node_type == PT_EXPR && left->info.expr.op == PT_CAST && left->info.expr.arg1)
-	{
-	  left = pt_left_part (left);
-	}
-
-      if (!pt_is_attr (left))
-	{
-	  continue;
-	}
-
-      qo_expr_segs (env, left, &temp_segs_set);
+      qo_expr_segs (env, pt_left_part (expr), &temp_segs_set);
       seg_idx = bitset_first_member (&temp_segs_set);
       if (seg_idx == -1)
 	{
-	  assert (false);
 	  continue;
 	}
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26368>

### Purpose

sql_debug 에서 발생한 assertion fail 을 해결합니다.

### Implementation

LIKE 표현식의 좌변에 `PT_NAME` 노드가 포함되어 있지 않고 `PT_VALUE`, `PT_HOST_VAR` 만 포함되어 있는 경우 `bitset_first_member()` 에서 유효하지 않은 인덱스 -1 을 반환합니다.

LIKE 표현식의 좌변에 PT_VALUE, PT_HOST_VAR, PT_EXPR 등 다른 타입의 노드가 있더라도 문제가 없으므로 assert(false) 를 제거합니다.
~~좌변이 컬럼이거나, CAST() 함수로 감싸진 컬럼일 경우에만 segment의 인덱스를 찾도록 수정합니다.~~

### Remarks

N/A
