### PR TITLE
[CBRD-26364] fix an issue where disk_size() was not stable when using a session variable

### DIFF
--- a/src/parser/parse_evaluate.c
+++ b/src/parser/parse_evaluate.c
@@ -599,6 +599,26 @@ pt_associate_label_with_value_check_reference (const char *label, DB_VALUE * val
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_REFERENCE_TO_NON_REFERABLE_NOT_ALLOWED, 0);
       return ER_REFERENCE_TO_NON_REFERABLE_NOT_ALLOWED;
     }
+
+  if (val->domain.general_info.type == DB_TYPE_STRING)
+    {
+      if (pr_Enable_string_compression)
+	{
+	  if (val->data.ch.medium.compressed_size == DB_UNCOMPRESSABLE)
+	    {
+	      assert (val->data.ch.medium.compressed_buf == NULL);
+	      val->data.ch.medium.compressed_size = DB_NOT_YET_COMPRESSED;
+	    }
+	}
+      else if (val->data.ch.medium.compressed_size > 0)
+	{
+	  assert (val->data.ch.medium.compressed_buf != NULL);
+	  db_private_free_and_init (NULL, val->data.ch.medium.compressed_buf);
+	  val->data.ch.medium.compressed_buf = NULL;
+	  val->data.ch.medium.compressed_size = DB_NOT_YET_COMPRESSED;
+	}
+    }
+
   return pt_associate_label_with_value (label, val);
 }
 

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -7561,13 +7561,6 @@ pt_fold_constants_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *
 		}
 	    }
 	}
-      else if (node->info.expr.op == PT_DISK_SIZE)
-	{
-	  if (node->info.expr.arg1->node_type == PT_VALUE && node->info.expr.arg1->type_enum == PT_TYPE_VARCHAR)
-	    {
-	      node->flag.do_not_fold = 1;
-	    }
-	}
       break;
     default:
       // nope

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -7561,6 +7561,13 @@ pt_fold_constants_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *
 		}
 	    }
 	}
+      else if (node->info.expr.op == PT_DISK_SIZE)
+	{
+	  if (node->info.expr.arg1->node_type == PT_VALUE && node->info.expr.arg1->type_enum == PT_TYPE_VARCHAR)
+	    {
+	      node->flag.do_not_fold = 1;
+	    }
+	}
       break;
     default:
       // nope


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26364>

### Purpose

* fix an issue where disk_size() was not stable when using a session variable
* pt_associate_label_with_value_check_reference() 에서 `enable_string_compression`설정에 따라 처리 

### Implementation

N/A

### Remarks

N/A
