### PR TITLE
[CBRD-26355] [Regression] Core dumped in qexec_execute_query at src/query/query_executor.c:16009

### DIFF
--- a/src/query/parallel/px_heap_scan/px_heap_scan_slot_iterator.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_slot_iterator.cpp
@@ -108,6 +108,7 @@ namespace parallel_heap_scan
       {
 	COPY_OID (&retry_oid, & m_cur_oid);
 restart_scan_oid:
+	m_recdes = RECDES_INITIALIZER;
 	slot_code = heap_next_1page (thread_p, & m_hfid, & m_vpid, & m_class_oid,
 				     & m_cur_oid, & m_recdes,
 				     m_scan_cache,  m_is_peeking);

--- a/src/query/parallel/px_heap_scan/px_heap_scan_slot_iterator.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_slot_iterator.cpp
@@ -108,6 +108,7 @@ namespace parallel_heap_scan
       {
 	COPY_OID (&retry_oid, & m_cur_oid);
 restart_scan_oid:
+
 	m_recdes = RECDES_INITIALIZER;
 	slot_code = heap_next_1page (thread_p, & m_hfid, & m_vpid, & m_class_oid,
 				     & m_cur_oid, & m_recdes,

--- a/src/query/parallel/px_heap_scan/px_heap_scan_slot_iterator.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_slot_iterator.cpp
@@ -108,7 +108,6 @@ namespace parallel_heap_scan
       {
 	COPY_OID (&retry_oid, & m_cur_oid);
 restart_scan_oid:
-
 	m_recdes = RECDES_INITIALIZER;
 	slot_code = heap_next_1page (thread_p, & m_hfid, & m_vpid, & m_class_oid,
 				     & m_cur_oid, & m_recdes,


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26355>

### Purpose

isolation 관련 버그를 수정합니다.
