### PR TITLE
[CBRD-26372] When a VIEW query contains an uppercase stored procedure name, an SP undefined error occurs when running loaddb with the --no-user-specified-name option.

### DIFF
--- a/src/sp/jsp_cl.cpp
+++ b/src/sp/jsp_cl.cpp
@@ -197,7 +197,7 @@ jsp_find_stored_procedure (const char *name, DB_AUTH purpose)
       /* This is the case when the loaddb utility is executed with the --no-user-specified-name option as the dba user. */
       if (db_get_client_type () == DB_CLIENT_TYPE_ADMIN_LOADDB_COMPAT)
 	{
-	  err = jsp_find_sp_of_another_owner (name, &mop);
+	  err = jsp_find_sp_of_another_owner (checked_name, &mop);
 	}
       else
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26372

### Purpose
- `jsp_find_stored_procedure()`함수가 전달받은 `name` 인자가 항상 소문자로 들어올 것으로 예상했으나,
VIEW 쿼리에 대문자로 작성된 SP 이름이 포함된 unload 파일을 `--no-user-specified-name` 옵션으로 loaddb 수행 시,
소문자 변환 없이 _db_stored_procedure 카탈로그에서 SP 존재 여부를 확인하여 undefined error가 발생하는 문제를 수정합니다.

### Implementation

- unload 파일에 아래와 같은 VIEW 쿼리가 포함된 상태에서 --no-user-specified-name 옵션으로 loaddb를 수행할 경우 동작 로직은 다음과 같습니다.
```
ALTER VCLASS [v1] CHANGE QUERY 1 select [Sp_int](1) from [t1] [t1] ;
```

1) `jsp_find_stored_procedure()` 함수의 name 인자에는 `Sp_int` 값이 전달됩니다.

2) `jsp_check_stored_procedure_name()` 함수에서 반환 결과를 저장하는 `checked_name`에는 `dba.sp_int` 값이 저장됩니다.

3) `--no-user-specified-name` 옵션이 지정된 경우 `if (db_get_client_type() == DB_CLIENT_TYPE_ADMIN_LOADDB_COMPAT)` 조건을 만족하게 되어, `jsp_find_sp_of_another_owner() → do_find_stored_procedure_by_query()` 순으로 함수가 호출됩니다.

4) `do_find_stored_procedure_by_query()` 내의 `sp_name = sm_remove_qualifier_name(name);` 코드에서 `checked_name`의 `user schema(dba)`를 제거함으로써 `sp_int`로 변환된 이름으로 `_db_stored_procedure` 카탈로그를 조회할 수 있게 됩니다.

### Remarks

N/A
