### PR TITLE
[CBRD-26273] ALTER TABLE 로 복제 키 제거 시 제약사항 추가

### DIFF
--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -1331,9 +1331,9 @@ do_alter_one_clause_with_template (PARSER_CONTEXT * parser, PT_NODE * alter)
       return error;
     }
 
-  if (!HA_DISABLED () && !check_ha_repl_fk_ref_all_replicated (vclass))
+  error = check_ha_repl_constraint (vclass);
+  if (error != NO_ERROR)
     {
-      error = ER_HA_FK_CONSTRAINT_VIOLATION;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 0);
       return error;
     }


### PR DESCRIPTION
[<http://jira.cubrid.org/browse/CBRD-26273 >](http://jira.cubrid.org/browse/CBRD-26273)

### Purpose

HA 환경에서 복제 테이블을 ALTER TABLE을 이용해 복제 키 컬럼 혹은 복제키 CONSTRAINT 를 삭제시도할 경우 제약사항이 추가됩니다.
- 삭제 시 다른 복제 후보키가 존재한다면 삭제 가능 (이후 다음 복제키를 이용해 repl log 생성)
- 삭제 시 다른 복제 후보키가 존재하지 않는다면 삭제 불가능

### Implementation

CBRD-26256 이슈에서 처리한 외래키 변경과 호출 로직이 동일해 check_ha_repl_fk_ref_all_replicated() 를 check_ha_repl_constraint()로 대체합니다.

### Remarks

