### PR TITLE
[CBRD-26316] [BugFix] [Regression] Core dumped in cdc_loginfo_producer_execute at src/transaction/log_manager.c:11151

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -11063,7 +11063,6 @@ cdc_loginfo_producer_execute (cubthread::entry & thread_ref)
   thread_p->is_cdc_daemon = true;
 
   int error = NO_ERROR;
-  int count = 0;
 
   cdc_Gl.producer.state = CDC_PRODUCER_STATE_RUN;
 
@@ -11111,10 +11110,14 @@ cdc_loginfo_producer_execute (cubthread::entry & thread_ref)
 
       nxio_lsa = log_Gl.append.get_nxio_lsa ();
 
-      if (LSA_GE (&cdc_Gl.producer.next_extraction_lsa, &nxio_lsa))
+      pthread_mutex_lock (&cdc_Gl.producer.lock);
+
+      if (LSA_ISNULL (&cdc_Gl.producer.next_extraction_lsa) || LSA_GE (&cdc_Gl.producer.next_extraction_lsa, &nxio_lsa))
 	{
 	  /* LOG_HA_DUMMY_SERVER_STATUS is appended every 1 seconds and flushed.
 	   * So it is expected to be woken up by looper within period of looper */
+
+	  pthread_mutex_unlock (&cdc_Gl.producer.lock);
 
 	  cdc_log
 	    ("cdc_loginfo_producer_execute : next_extraction_lsa (%lld | %d)  is greater or equal than nxio_lsa (%lld | %d)",
@@ -11129,30 +11132,18 @@ cdc_loginfo_producer_execute (cubthread::entry & thread_ref)
       LSA_SET_NULL (&log_info_entry.next_lsa);
       log_info_entry.log_info = NULL;
 
-      LSA_COPY (&cur_log_rec_lsa, &cdc_Gl.producer.next_extraction_lsa);
-      LSA_COPY (&process_lsa, &cur_log_rec_lsa);
-
-      /*
-       * Prevent the producer thread from attempting to extract CDC logs using a NULL cdc_Gl.producer.next_extraction_lsa.
-       * The race occurs when the cdc_cleanup process overlaps in timing with the log extraction process.
-       *
-       * TODO: Investigate and fix the root cause of process_lsa being NULL
-       */
       if (LSA_ISNULL (&process_lsa))
 	{
-	  count++;
-
-	  if ((count % 10) == 0)
-	    {
-	      _er_log_debug (ARG_FILE_LINE,
-			     "cdc_loginfo_producer_execute : process_lsa is NULL_LSA (producer.request : %d, producer.state : %d)",
-			     cdc_Gl.producer.request, cdc_Gl.producer.state);
-
-	      assert (false);
-	    }
-
-	  continue;
+	  LSA_COPY (&process_lsa, &cdc_Gl.producer.next_extraction_lsa);
 	}
+      else
+	{
+	  LSA_COPY (&cdc_Gl.producer.next_extraction_lsa, &process_lsa);
+	}
+
+      LSA_COPY (&cur_log_rec_lsa, &cdc_Gl.producer.next_extraction_lsa);
+
+      pthread_mutex_unlock (&cdc_Gl.producer.lock);
 
       error = cdc_log_extract (thread_p, &process_lsa, &log_info_entry);
       if (!(error == NO_ERROR || error == ER_CDC_LOGINFO_ENTRY_GENERATED))
@@ -11208,8 +11199,6 @@ cdc_loginfo_producer_execute (cubthread::entry & thread_ref)
 	  cdc_log ("cdc_loginfo_producer_execute : log info is produced on LOG_LSA (%lld | %d)",
 		   LSA_AS_ARGS (&process_lsa));
 	}
-
-      LSA_COPY (&cdc_Gl.producer.next_extraction_lsa, &process_lsa);
     }
 
   cdc_Gl.producer.state = CDC_PRODUCER_STATE_DEAD;
@@ -14462,7 +14451,10 @@ cdc_validate_lsa (THREAD_ENTRY * thread_p, LOG_LSA * lsa)
 int
 cdc_set_extraction_lsa (LOG_LSA * lsa)
 {
+  pthread_mutex_lock (&cdc_Gl.producer.lock);
   LSA_COPY (&cdc_Gl.producer.next_extraction_lsa, lsa);
+  pthread_mutex_unlock (&cdc_Gl.producer.lock);
+
   LSA_COPY (&cdc_Gl.consumer.next_lsa, lsa);
 
   cdc_log ("cdc_set_extraction_lsa : set LOG_LSA (%lld | %d) to produce ", LSA_AS_ARGS (lsa));
@@ -15049,7 +15041,9 @@ cdc_cleanup ()
   LSA_SET_NULL (&cdc_Gl.first_loginfo_queue_lsa);
   LSA_SET_NULL (&cdc_Gl.last_loginfo_queue_lsa);
 
+  pthread_mutex_lock (&cdc_Gl.producer.lock);
   LSA_SET_NULL (&cdc_Gl.producer.next_extraction_lsa);
+  pthread_mutex_unlock (&cdc_Gl.producer.lock);
 
   /*communication buffer from server to client initialization */
   cdc_cleanup_consumer ();
@@ -15121,7 +15115,10 @@ cdc_finalize ()
   cdc_Gl.consumer.consumed_queue_size = 0;
   cdc_Gl.producer.produced_queue_size = 0;
 
+  pthread_mutex_lock (&cdc_Gl.producer.lock);
   LSA_SET_NULL (&cdc_Gl.producer.next_extraction_lsa);
+  pthread_mutex_unlock (&cdc_Gl.producer.lock);
+
   LSA_SET_NULL (&cdc_Gl.last_loginfo_queue_lsa);
   LSA_SET_NULL (&cdc_Gl.first_loginfo_queue_lsa);
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -11141,7 +11141,8 @@ cdc_loginfo_producer_execute (cubthread::entry & thread_ref)
 	  LSA_COPY (&cdc_Gl.producer.next_extraction_lsa, &process_lsa);
 	}
 
-      LSA_COPY (&cur_log_rec_lsa, &cdc_Gl.producer.next_extraction_lsa);
+      assert (!LSA_ISNULL (&process_lsa));
+      LSA_COPY (&cur_log_rec_lsa, &process_lsa);
 
       pthread_mutex_unlock (&cdc_Gl.producer.lock);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26316

### Purpose
- 리그레션 이슈
- CBRD-26140 선행 이슈에서 우회처리하였으나 유사한 리그레션 이슈 발생하여 처리

### Implementation
- cdc_Gl.producer.next_extraction_lsa 전역 변수에 대해 동시성 제어가 되지 않아 null lsa 처리 시도 후 assert
- cdc_Gl.producer.lock 뮤텍스로 보호