### PR TITLE
[CBRD-26150] sync 시 double write buffer와 fileio 간의 호출을 제거

### DIFF
--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -778,7 +778,7 @@ disk_format (THREAD_ENTRY * thread_p, const char *dbname, VOLID volid, DBDEF_VOL
   /* Flush all pages that were formatted. This is not needed, but it is done for security reasons to identify the volume
    * in case of a system crash. Note that the identification may not be possible during media crashes */
   (void) pgbuf_flush_all (thread_p, volid);
-  (void) fileio_synchronize (thread_p, vdes, vol_fullname, FILEIO_SYNC_ALSO_FLUSH_DWB);
+  (void) dwb_synchronize (thread_p, vdes, vol_fullname);
 
   fault_inject_random_crash ();
 

--- a/src/storage/double_write_buffer.cpp
+++ b/src/storage/double_write_buffer.cpp
@@ -1194,7 +1194,7 @@ dwb_create_internal (THREAD_ENTRY *thread_p, const char *dwb_volume_name, UINT64
     }
 
   /* Needs to flush dirty page before activating DWB. */
-  fileio_synchronize_all (thread_p, false);
+  fileio_synchronize_all (thread_p);
 
   /* Create DWB blocks */
   error_code = dwb_create_blocks (thread_p, num_blocks, num_block_pages, &blocks);

--- a/src/storage/double_write_buffer.cpp
+++ b/src/storage/double_write_buffer.cpp
@@ -2276,8 +2276,7 @@ dwb_flush_block (THREAD_ENTRY *thread_p, DWB_BLOCK *block, bool file_sync_helper
 	      if (ATOMIC_INC_32 (& (dwb_Global.file_sync_helper_block->flush_volumes_info[i].num_pages), 0) >= 0)
 		{
 		  (void) fileio_synchronize (thread_p,
-					     dwb_Global.file_sync_helper_block->flush_volumes_info[i].vdes, NULL,
-					     FILEIO_SYNC_ONLY);
+					     dwb_Global.file_sync_helper_block->flush_volumes_info[i].vdes, NULL);
 
 		  dwb_log ("dwb_flush_block: Synchronized volume %d\n",
 			   dwb_Global.file_sync_helper_block->flush_volumes_info[i].vdes);
@@ -2320,7 +2319,7 @@ dwb_flush_block (THREAD_ENTRY *thread_p, DWB_BLOCK *block, bool file_sync_helper
   /* Increment statistics after writing in double write volume. */
   perfmon_add_stat (thread_p, PSTAT_PB_NUM_IOWRITES, block->count_wb_pages);
 
-  if (fileio_synchronize (thread_p, dwb_Global.vdes, dwb_Volume_name, FILEIO_SYNC_ONLY) != dwb_Global.vdes)
+  if (fileio_synchronize (thread_p, dwb_Global.vdes, dwb_Volume_name) != dwb_Global.vdes)
     {
       assert (false);
       /* Something wrong happened. */
@@ -2378,7 +2377,7 @@ dwb_flush_block (THREAD_ENTRY *thread_p, DWB_BLOCK *block, bool file_sync_helper
       num_pages = ATOMIC_TAS_32 (&block->flush_volumes_info[i].num_pages, 0);
       assert (num_pages != 0);
 
-      (void) fileio_synchronize (thread_p, block->flush_volumes_info[i].vdes, NULL, FILEIO_SYNC_ONLY);
+      (void) fileio_synchronize (thread_p, block->flush_volumes_info[i].vdes, NULL);
 
       dwb_log ("dwb_flush_block: Synchronized volume %d\n", block->flush_volumes_info[i].vdes);
     }
@@ -2802,6 +2801,79 @@ dwb_add_page (THREAD_ENTRY *thread_p, FILEIO_PAGE *io_page_p, VPID *vpid, DWB_SL
   dwb_log ("Successfully flushed DWB block = %d having version %lld\n", block->block_no, block->version);
 
   return NO_ERROR;
+}
+
+/*
+ * dwb_synchronize () - synchronize the DWB and volume.
+ *
+ * return   : Error code.
+ * thread_p (in): The thread entry.
+ * vol_fd(in): Volume descriptor
+ * vlabel(in): Volume label
+ *
+ * NOTE: try to sync the DWB and the volume, but sync only
+ *	 the volume if failed to sync the DWB.
+ */
+int dwb_synchronize (THREAD_ENTRY *thread_p, int vol_fd, const char *vlabel)
+{
+#if defined (EnableThreadMonitoring)
+  TSC_TICKS start_tick, end_tick;
+  TSCTIMEVAL elapsed_time;
+#endif
+  bool complete = false;
+  int error = NO_ERROR;
+
+  /* should fsync ? */
+  if (fileio_fsync_pending ())
+    {
+      return vol_fd;
+    }
+
+#if defined (EnableThreadMonitoring)
+  if (0 < prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD))
+    {
+      tsc_getticks (&start_tick);
+    }
+#endif
+
+#if !defined (CS_MODE)
+  if (fileio_is_permanent_volume_descriptor (thread_p, vol_fd))
+    {
+      error = dwb_flush_force (thread_p, &complete);
+    }
+#endif
+
+  /* If complete is true, everything was synchronized. if not, directly sync the volume */
+  if (error == NO_ERROR && complete == false)
+    {
+      error = fsync (vol_fd);
+    }
+
+#if defined (EnableThreadMonitoring)
+  if (0 < prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD))
+    {
+      tsc_getticks (&end_tick);
+      tsc_elapsed_time_usec (&elapsed_time, end_tick, start_tick);
+    }
+#endif
+
+  if (error != NO_ERROR)
+    {
+      /* sync error is not alwasy handled and I am not sure a proper safe handling is possible: raise as fatal error */
+      er_set_with_oserror (ER_FATAL_ERROR_SEVERITY, ARG_FILE_LINE, ER_IO_SYNC, 1, (vlabel ? vlabel : "Unknown"));
+      return NULL_VOLDES;
+    }
+
+#if defined (EnableThreadMonitoring)
+  if (MONITOR_WAITING_THREAD (elapsed_time))
+    {
+      er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 3, __func__,
+	      prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD), TO_MSEC (elapsed_time));
+    }
+#endif
+
+  perfmon_inc_stat (thread_p, PSTAT_FILE_NUM_IOSYNCHES);
+  return vol_fd;
 }
 
 /*
@@ -3249,8 +3321,7 @@ dwb_load_and_recover_pages (THREAD_ENTRY *thread_p, const char *dwb_path_p, cons
 	      /* Now, flush the volumes having pages in current block. */
 	      for (i = 0; i < rcv_block->count_flush_volumes_info; i++)
 		{
-		  if (fileio_synchronize (thread_p, rcv_block->flush_volumes_info[i].vdes, NULL,
-					  FILEIO_SYNC_ONLY) == NULL_VOLDES)
+		  if (fileio_synchronize (thread_p, rcv_block->flush_volumes_info[i].vdes, NULL) == NULL_VOLDES)
 		    {
 		      error_code = ER_FAILED;
 		      goto end;
@@ -3764,7 +3835,7 @@ dwb_file_sync_helper (THREAD_ENTRY *thread_p)
 	   * Flush the volume. If not all volume pages are available now, continue with next volume, if any,
 	   * and then resume the current one.
 	   */
-	  (void) fileio_synchronize (thread_p, current_flush_volume_info->vdes, NULL, FILEIO_SYNC_ONLY);
+	  (void) fileio_synchronize (thread_p, current_flush_volume_info->vdes, NULL);
 
 	  dwb_log ("dwb_file_sync_helper: Synchronized volume %d\n", current_flush_volume_info->vdes);
 	}

--- a/src/storage/double_write_buffer.hpp
+++ b/src/storage/double_write_buffer.hpp
@@ -52,6 +52,8 @@ extern int dwb_set_data_on_next_slot (THREAD_ENTRY *thread_p, FILEIO_PAGE *io_pa
 				      DWB_SLOT **p_dwb_slot);
 extern int dwb_add_page (THREAD_ENTRY *thread_p, FILEIO_PAGE *io_page_p, VPID *vpid, DWB_SLOT **p_dwb_slot);
 
+extern int dwb_synchronize (THREAD_ENTRY *thread_p, int vol_fd, const char *vlabel);
+
 #if defined (SERVER_MODE)
 extern void dwb_daemons_init ();
 extern void dwb_daemons_destroy ();

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -647,7 +647,7 @@ fileio_compensate_flush (THREAD_ENTRY * thread_p, int fd, int npage)
 
   if (need_sync)
     {
-      fileio_synchronize_all (thread_p, false);
+      fileio_synchronize_all (thread_p);
     }
 #endif /* SERVER_MODE */
 }
@@ -4562,10 +4562,9 @@ fileio_synchronize_volume (THREAD_ENTRY * thread_p, FILEIO_VOLUME_INFO * vol_inf
 /*
  * fileio_synchronize_all () - Synchronize all database volumes with disk
  *   return:
- *   include_log(in):
  */
 int
-fileio_synchronize_all (THREAD_ENTRY * thread_p, bool is_include)
+fileio_synchronize_all (THREAD_ENTRY * thread_p)
 {
   int success = NO_ERROR;
   bool all_sync = false;
@@ -4579,12 +4578,6 @@ fileio_synchronize_all (THREAD_ENTRY * thread_p, bool is_include)
   arg.vol_id = NULL_VOLID;
 
   er_stack_push ();
-
-  if (is_include)
-    {
-      /* Flush logs. */
-      (void) fileio_traverse_system_volume (thread_p, fileio_synchronize_sys_volume, &arg);
-    }
 
 #if !defined (CS_MODE)
   /* Flush DWB before volume data. */
@@ -9640,7 +9633,7 @@ fileio_finish_restore (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session_
 {
   int success;
 
-  success = fileio_synchronize_all (thread_p, false);
+  success = fileio_synchronize_all (thread_p);
   fileio_abort_restore (thread_p, session_p);
 
   return success;

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -24,6 +24,7 @@
 
 #include "config.h"
 
+#include <atomic>
 #include <stdlib.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -2826,7 +2827,7 @@ fileio_copy_volume (THREAD_ENTRY * thread_p, int from_vol_desc, DKNPAGES npages,
 	}
     }
 
-  if (fileio_synchronize (thread_p, to_vol_desc, to_vol_label_p, FILEIO_SYNC_ALSO_FLUSH_DWB) != to_vol_desc)
+  if (dwb_synchronize (thread_p, to_vol_desc, to_vol_label_p) != to_vol_desc)
     {
       goto error;
     }
@@ -2890,7 +2891,7 @@ fileio_reset_volume (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel, DK
     }
   free_and_init (malloc_io_page_p);
 
-  if (fileio_synchronize (thread_p, vol_fd, vlabel, FILEIO_SYNC_ALSO_FLUSH_DWB) != vol_fd)
+  if (dwb_synchronize (thread_p, vol_fd, vlabel) != vol_fd)
     {
       success = ER_FAILED;
     }
@@ -3100,7 +3101,7 @@ fileio_dismount (THREAD_ENTRY * thread_p, int vol_fd)
    */
   vlabel = fileio_get_volume_label_by_fd (vol_fd, PEEK);
 
-  (void) fileio_synchronize (thread_p, vol_fd, vlabel, FILEIO_SYNC_ALSO_FLUSH_DWB);
+  (void) dwb_synchronize (thread_p, vol_fd, vlabel);
 
 #if !defined(WINDOWS)
   lockf_type = fileio_get_lockf_type (vol_fd);
@@ -3302,7 +3303,7 @@ fileio_dismount_volume (THREAD_ENTRY * thread_p, FILEIO_VOLUME_INFO * vol_info_p
 {
   if (vol_info_p->vdes != NULL_VOLDES)
     {
-      (void) fileio_synchronize (thread_p, vol_info_p->vdes, vol_info_p->vlabel, FILEIO_SYNC_ALSO_FLUSH_DWB);
+      (void) dwb_synchronize (thread_p, vol_info_p->vdes, vol_info_p->vlabel);
 
 #if !defined(WINDOWS)
       if (vol_info_p->lockf_type != FILEIO_NOT_LOCKF)
@@ -3344,7 +3345,7 @@ fileio_dismount_all (THREAD_ENTRY * thread_p)
       if (sys_vol_info_p->vdes != NULL_VOLDES)
 	{
 	  /* System volume. No need to sync DWB. */
-	  (void) fileio_synchronize (thread_p, sys_vol_info_p->vdes, sys_vol_info_p->vlabel, FILEIO_SYNC_ONLY);
+	  (void) fileio_synchronize (thread_p, sys_vol_info_p->vdes, sys_vol_info_p->vlabel);
 
 #if !defined(WINDOWS)
 	  if (sys_vol_info_p->lockf_type != FILEIO_NOT_LOCKF)
@@ -3647,7 +3648,7 @@ pwrite_with_injected_fault (THREAD_ENTRY * thread_p, int fd, const void *buf, si
 	      er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_FAILED_ASSERTION, 1, msg);
 
 	      // exit handler
-	      (void) fileio_synchronize (thread_p, fd, vlabel, FILEIO_SYNC_ONLY);
+	      (void) fileio_synchronize (thread_p, fd, vlabel);
 
 #if !defined(NDEBUG)
 	      if (prm_get_bool_value (PRM_ID_ER_LOG_DEBUG))
@@ -4381,6 +4382,38 @@ fileio_writev (THREAD_ENTRY * thread_p, int vol_fd, void **io_page_array, PAGEID
   return io_page_array[0];
 }
 
+bool
+fileio_fsync_pending (void)
+{
+#if defined (SERVER_MODE)
+// *INDENT-OFF*
+  static std::atomic<uint64_t> counter (0);
+// *INDENT-ON*
+#else
+  static uint64_t counter (0);
+#endif
+  uint64_t prev_counter;
+  uint64_t threshold;
+
+  threshold = prm_get_integer_value (PRM_ID_SUPPRESS_FSYNC);
+  if (threshold <= 0)
+    {
+      return false;
+    }
+
+#if defined (SERVER_MODE)
+  prev_counter = counter.fetch_add (1, std::memory_order_relaxed);
+#else
+  prev_counter = counter++;
+#endif
+
+  if (!(prev_counter % threshold))
+    {
+      return false;
+    }
+  return true;
+}
+
 /*
  * fileio_synchronize () - Synchronize a database volume's state with that on disk
  *   return: vdes or NULL_VOLDES
@@ -4389,39 +4422,18 @@ fileio_writev (THREAD_ENTRY * thread_p, int vol_fd, void **io_page_array, PAGEID
  *   sync_dwb(in): FILEIO_SYNC_ALSO_FLUSH_DWB if needs sync dwb
  */
 int
-fileio_synchronize (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel, FILEIO_SYNC_OPTION sync_dwb)
+fileio_synchronize (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel)
 {
-  int ret = NO_ERROR;
-  bool all_sync = false;
 #if defined (EnableThreadMonitoring)
   TSC_TICKS start_tick, end_tick;
   TSCTIMEVAL elapsed_time;
 #endif
-#if defined (SERVER_MODE)
-  static pthread_mutex_t inc_cnt_mutex = PTHREAD_MUTEX_INITIALIZER;
-  int r;
-#endif
-  static int inc_cnt = 0;
+  int error = NO_ERROR;
 
-  if (prm_get_integer_value (PRM_ID_SUPPRESS_FSYNC) > 0)
+  /* should fsync ? */
+  if (fileio_fsync_pending ())
     {
-#if defined (SERVER_MODE)
-      r = pthread_mutex_lock (&inc_cnt_mutex);
-#endif
-      if (++inc_cnt >= prm_get_integer_value (PRM_ID_SUPPRESS_FSYNC))
-	{
-	  inc_cnt = 0;
-	}
-      else
-	{
-#if defined (SERVER_MODE)
-	  pthread_mutex_unlock (&inc_cnt_mutex);
-#endif
-	  return vol_fd;
-	}
-#if defined (SERVER_MODE)
-      pthread_mutex_unlock (&inc_cnt_mutex);
-#endif
+      return vol_fd;
     }
 
 #if defined (EnableThreadMonitoring)
@@ -4431,18 +4443,7 @@ fileio_synchronize (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel, FIL
     }
 #endif
 
-#if !defined (CS_MODE)
-  if (sync_dwb == FILEIO_SYNC_ALSO_FLUSH_DWB && fileio_is_permanent_volume_descriptor (thread_p, vol_fd))
-    {
-      ret = dwb_flush_force (thread_p, &all_sync);
-    }
-#endif
-
-  /* If all_sync is true, everything was synchronized. This happens when DWB is completely flushed. */
-  if (ret == NO_ERROR && all_sync == false)
-    {
-      ret = fsync (vol_fd);
-    }
+  error = fsync (vol_fd);
 
 #if defined (EnableThreadMonitoring)
   if (0 < prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD))
@@ -4452,25 +4453,23 @@ fileio_synchronize (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel, FIL
     }
 #endif
 
-  if (ret != 0)
+  if (error != NO_ERROR)
     {
       /* sync error is not alwasy handled and I am not sure a proper safe handling is possible: raise as fatal error */
       er_set_with_oserror (ER_FATAL_ERROR_SEVERITY, ARG_FILE_LINE, ER_IO_SYNC, 1, (vlabel ? vlabel : "Unknown"));
       return NULL_VOLDES;
     }
-  else
-    {
+
 #if defined (EnableThreadMonitoring)
-      if (MONITOR_WAITING_THREAD (elapsed_time))
-	{
-	  er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 3, __func__,
-		  prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD), TO_MSEC (elapsed_time));
-	}
+  if (MONITOR_WAITING_THREAD (elapsed_time))
+    {
+      er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, ER_MNT_WAITING_THREAD, 3, __func__,
+	      prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD), TO_MSEC (elapsed_time));
+    }
 #endif
 
-      perfmon_inc_stat (thread_p, PSTAT_FILE_NUM_IOSYNCHES);
-      return vol_fd;
-    }
+  perfmon_inc_stat (thread_p, PSTAT_FILE_NUM_IOSYNCHES);
+  return vol_fd;
 }
 
 /*
@@ -4517,7 +4516,7 @@ fileio_synchronize_sys_volume (THREAD_ENTRY * thread_p, FILEIO_SYSTEM_VOLUME_INF
 
 
       /* System volume. No need to sync DWB. */
-      fileio_synchronize (thread_p, sys_vol_info_p->vdes, sys_vol_info_p->vlabel, FILEIO_SYNC_ONLY);
+      fileio_synchronize (thread_p, sys_vol_info_p->vdes, sys_vol_info_p->vlabel);
     }
 
   return found;
@@ -4553,7 +4552,7 @@ fileio_synchronize_volume (THREAD_ENTRY * thread_p, FILEIO_VOLUME_INFO * vol_inf
 	  return false;
 	}
 
-      fileio_synchronize (thread_p, vol_info_p->vdes, vol_info_p->vlabel, FILEIO_SYNC_ONLY);
+      fileio_synchronize (thread_p, vol_info_p->vdes, vol_info_p->vlabel);
     }
 
   return found;
@@ -7342,8 +7341,7 @@ fileio_finish_backup (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session_p
 	  return NULL;
 	}
 
-      if (fileio_synchronize (thread_p, session_p->bkup.vdes, session_p->bkup.name,
-			      FILEIO_SYNC_ONLY) != session_p->bkup.vdes)
+      if (fileio_synchronize (thread_p, session_p->bkup.vdes, session_p->bkup.name) != session_p->bkup.vdes)
 	{
 	  return NULL;
 	}

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -2827,7 +2827,11 @@ fileio_copy_volume (THREAD_ENTRY * thread_p, int from_vol_desc, DKNPAGES npages,
 	}
     }
 
+#if !defined(CS_MODE)
   if (dwb_synchronize (thread_p, to_vol_desc, to_vol_label_p) != to_vol_desc)
+#else
+  if (fileio_synchronize (thread_p, to_vol_desc, to_vol_label_p) != to_vol_desc)
+#endif
     {
       goto error;
     }
@@ -2891,7 +2895,11 @@ fileio_reset_volume (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel, DK
     }
   free_and_init (malloc_io_page_p);
 
+#if !defined(CS_MODE)
   if (dwb_synchronize (thread_p, vol_fd, vlabel) != vol_fd)
+#else
+  if (fileio_synchronize (thread_p, vol_fd, vlabel) != vol_fd)
+#endif
     {
       success = ER_FAILED;
     }
@@ -3101,7 +3109,11 @@ fileio_dismount (THREAD_ENTRY * thread_p, int vol_fd)
    */
   vlabel = fileio_get_volume_label_by_fd (vol_fd, PEEK);
 
+#if !defined(CS_MODE)
   (void) dwb_synchronize (thread_p, vol_fd, vlabel);
+#else
+  (void) fileio_synchronize (thread_p, vol_fd, vlabel);
+#endif
 
 #if !defined(WINDOWS)
   lockf_type = fileio_get_lockf_type (vol_fd);
@@ -3303,7 +3315,11 @@ fileio_dismount_volume (THREAD_ENTRY * thread_p, FILEIO_VOLUME_INFO * vol_info_p
 {
   if (vol_info_p->vdes != NULL_VOLDES)
     {
+#if !defined(CS_MODE)
       (void) dwb_synchronize (thread_p, vol_info_p->vdes, vol_info_p->vlabel);
+#else
+      (void) fileio_synchronize (thread_p, vol_info_p->vdes, vol_info_p->vlabel);
+#endif
 
 #if !defined(WINDOWS)
       if (vol_info_p->lockf_type != FILEIO_NOT_LOCKF)
@@ -4393,7 +4409,7 @@ fileio_fsync_pending (void)
   static uint64_t counter (0);
 #endif
   uint64_t prev_counter;
-  uint64_t threshold;
+  int threshold;
 
   threshold = prm_get_integer_value (PRM_ID_SUPPRESS_FSYNC);
   if (threshold <= 0)
@@ -4407,7 +4423,7 @@ fileio_fsync_pending (void)
   prev_counter = counter++;
 #endif
 
-  if (!(prev_counter % threshold))
+  if (!(prev_counter % (uint64_t) threshold))
     {
       return false;
     }
@@ -4419,7 +4435,6 @@ fileio_fsync_pending (void)
  *   return: vdes or NULL_VOLDES
  *   vol_fd(in): Volume descriptor
  *   vlabel(in): Volume label
- *   sync_dwb(in): FILEIO_SYNC_ALSO_FLUSH_DWB if needs sync dwb
  */
 int
 fileio_synchronize (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel)

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -4423,7 +4423,7 @@ fileio_fsync_pending (void)
   prev_counter = counter++;
 #endif
 
-  if (!(prev_counter % (uint64_t) threshold))
+  if (!((prev_counter + 1) % (uint64_t) threshold))
     {
       return false;
     }

--- a/src/storage/file_io.h
+++ b/src/storage/file_io.h
@@ -497,7 +497,7 @@ extern void *fileio_writev (THREAD_ENTRY * thread_p, int vdes, void **arrayof_io
 			    DKNPAGES npages, size_t page_size);
 extern int fileio_synchronize (THREAD_ENTRY * thread_p, int vdes, const char *vlabel,
 			       FILEIO_SYNC_OPTION check_sync_dwb);
-extern int fileio_synchronize_all (THREAD_ENTRY * thread_p, bool include_log);
+extern int fileio_synchronize_all (THREAD_ENTRY * thread_p);
 #if defined (ENABLE_UNUSED_FUNCTION)
 extern void *fileio_read_user_area (THREAD_ENTRY * thread_p, int vdes, PAGEID pageid, off_t start_offset, size_t nbytes,
 				    void *area);

--- a/src/storage/file_io.h
+++ b/src/storage/file_io.h
@@ -158,12 +158,6 @@ typedef enum
 
 typedef enum
 {
-  FILEIO_SYNC_ONLY,
-  FILEIO_SYNC_ALSO_FLUSH_DWB
-} FILEIO_SYNC_OPTION;
-
-typedef enum
-{
   FILEIO_WRITE_DEFAULT_WRITE,	/* default write mode does compensate write including sync */
   FILEIO_WRITE_NO_COMPENSATE_WRITE	/* skips */
 } FILEIO_WRITE_MODE;
@@ -495,8 +489,8 @@ extern void *fileio_write_pages (THREAD_ENTRY * thread_p, int vol_fd, char *io_p
 				 size_t page_size, FILEIO_WRITE_MODE write_mode);
 extern void *fileio_writev (THREAD_ENTRY * thread_p, int vdes, void **arrayof_io_pgptr, PAGEID start_pageid,
 			    DKNPAGES npages, size_t page_size);
-extern int fileio_synchronize (THREAD_ENTRY * thread_p, int vdes, const char *vlabel,
-			       FILEIO_SYNC_OPTION check_sync_dwb);
+extern bool fileio_fsync_pending (void);
+extern int fileio_synchronize (THREAD_ENTRY * thread_p, int vdes, const char *vlabel);
 extern int fileio_synchronize_all (THREAD_ENTRY * thread_p);
 #if defined (ENABLE_UNUSED_FUNCTION)
 extern void *fileio_read_user_area (THREAD_ENTRY * thread_p, int vdes, PAGEID pageid, off_t start_offset, size_t nbytes,

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -5097,7 +5097,7 @@ boot_create_all_volumes (THREAD_ENTRY * thread_p, const BOOT_CLIENT_CREDENTIAL *
 
   logpb_force_flush_pages (thread_p);
   (void) pgbuf_flush_all (thread_p, NULL_VOLID);
-  (void) fileio_synchronize_all (thread_p, false);
+  (void) fileio_synchronize_all (thread_p);
 
   (void) logpb_checkpoint (thread_p);
   boot_server_status (BOOT_SERVER_UP);

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -6056,7 +6056,7 @@ boot_dbparm_save_volume (THREAD_ENTRY * thread_p, DB_VOLTYPE voltype, VOLID voli
       /* flush the boot_Db_parm object. this is not necessary but it is recommended in order to mount every known volume
        * during restart. that may not be possible during media crash though. */
       heap_flush (thread_p, boot_Db_parm_oid);
-      fileio_synchronize (thread_p, fileio_get_volume_descriptor (boot_Db_parm_oid->volid), NULL, FILEIO_SYNC_ALSO_FLUSH_DWB);	/* label? */
+      dwb_synchronize (thread_p, fileio_get_volume_descriptor (boot_Db_parm_oid->volid), NULL);	/* label? */
     }
   else
     {

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1793,7 +1793,7 @@ log_final (THREAD_ENTRY * thread_p)
   error_code = pgbuf_flush_all (thread_p, NULL_VOLID);
   if (error_code == NO_ERROR)
     {
-      error_code = fileio_synchronize_all (thread_p, false);
+      error_code = fileio_synchronize_all (thread_p);
     }
 
   logpb_decache_archive_info (thread_p);
@@ -8928,7 +8928,7 @@ log_recreate (THREAD_ENTRY * thread_p, const char *db_fullname, const char *logp
     }
 
   (void) pgbuf_flush_all (thread_p, NULL_VOLID);
-  (void) fileio_synchronize_all (thread_p, false);
+  (void) fileio_synchronize_all (thread_p);
   (void) log_commit (thread_p, NULL_TRAN_INDEX, false);
 
   return ret;
@@ -9177,7 +9177,7 @@ log_simulate_crash (THREAD_ENTRY * thread_p, int flush_log, int flush_data_pages
   if (flush_data_pages)
     {
       (void) pgbuf_flush_all (thread_p, NULL_VOLID);
-      (void) fileio_synchronize_all (thread_p, false);
+      (void) fileio_synchronize_all (thread_p);
     }
 
   /* Undefine log buffer pool and transaction table */

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -2961,7 +2961,7 @@ logpb_write_toflush_pages_to_archive (THREAD_ENTRY * thread_p)
   if ((bg_arv_info->current_page_id - bg_arv_info->last_sync_pageid) > prm_get_integer_value (PRM_ID_PB_SYNC_ON_NFLUSH))
     {
       /* System volume. No need to sync DWB. */
-      fileio_synchronize (thread_p, bg_arv_info->vdes, log_Name_bg_archive, FILEIO_SYNC_ONLY);
+      fileio_synchronize (thread_p, bg_arv_info->vdes, log_Name_bg_archive);
       bg_arv_info->last_sync_pageid = bg_arv_info->current_page_id;
     }
 }
@@ -3708,7 +3708,7 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
 	  || (log_Stat.total_sync_count % prm_get_integer_value (PRM_ID_SUPPRESS_FSYNC) == 0))
 	{
 	  /* System volume. No need to sync DWB. */
-	  if (fileio_synchronize (thread_p, log_Gl.append.vdes, log_Name_active, FILEIO_SYNC_ONLY) == NULL_VOLDES)
+	  if (fileio_synchronize (thread_p, log_Gl.append.vdes, log_Name_active) == NULL_VOLDES)
 	    {
 	      error_code = ER_FAILED;
 	      goto error;
@@ -3771,7 +3771,7 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
 	}
 
       /* we need to also sync again */
-      if (fileio_synchronize (thread_p, log_Gl.append.vdes, log_Name_active, FILEIO_SYNC_ONLY) == NULL_VOLDES)
+      if (fileio_synchronize (thread_p, log_Gl.append.vdes, log_Name_active) == NULL_VOLDES)
 	{
 	  error_code = ER_FAILED;
 	  goto error;
@@ -5828,7 +5828,7 @@ logpb_archive_active_log (THREAD_ENTRY * thread_p)
        * Make sure that the whole log archive is in physical storage at this
        * moment. System volume. No need to sync DWB.
        */
-      if (fileio_synchronize (thread_p, vdes, arv_name, FILEIO_SYNC_ONLY) == NULL_VOLDES)
+      if (fileio_synchronize (thread_p, vdes, arv_name) == NULL_VOLDES)
 	{
 	  goto error;
 	}
@@ -7232,7 +7232,7 @@ logpb_checkpoint (THREAD_ENTRY * thread_p)
        * due to volume header page modification).
        */
       vdes = fileio_get_volume_descriptor (volid);
-      if (fileio_synchronize (thread_p, vdes, fileio_get_volume_label (vdes, PEEK), FILEIO_SYNC_ALSO_FLUSH_DWB) != vdes)
+      if (dwb_synchronize (thread_p, vdes, fileio_get_volume_label (vdes, PEEK)) != vdes)
 	{
 	  goto error_cannot_chkpt;
 	}
@@ -7493,7 +7493,7 @@ logpb_backup_for_volume (THREAD_ENTRY * thread_p, VOLID volid, LOG_LSA * chkpt_l
     }
 
   vdes = fileio_get_volume_descriptor (volid);
-  if (fileio_synchronize (thread_p, vdes, fileio_get_volume_label (vdes, PEEK), FILEIO_SYNC_ALSO_FLUSH_DWB) != vdes)
+  if (dwb_synchronize (thread_p, vdes, fileio_get_volume_label (vdes, PEEK)) != vdes)
     {
       return ER_FAILED;
     }
@@ -9304,8 +9304,7 @@ logpb_copy_volume (THREAD_ENTRY * thread_p, VOLID from_volid, const char *to_vol
       return error_code;
     }
 
-  if (fileio_synchronize (thread_p, from_vdes, fileio_get_volume_label (from_vdes, PEEK),
-			  FILEIO_SYNC_ALSO_FLUSH_DWB) != from_vdes)
+  if (dwb_synchronize (thread_p, from_vdes, fileio_get_volume_label (from_vdes, PEEK)) != from_vdes)
     {
       return ER_FAILED;
     }
@@ -9681,7 +9680,7 @@ logpb_copy_database (THREAD_ENTRY * thread_p, VOLID num_perm_vols, const char *t
 		  fileio_dismount (thread_p, to_vdes);
 		  goto error;
 		}
-	      if (fileio_synchronize (thread_p, to_vdes, to_volname, FILEIO_SYNC_ALSO_FLUSH_DWB) != to_vdes)
+	      if (dwb_synchronize (thread_p, to_vdes, to_volname) != to_vdes)
 		{
 		  fileio_dismount (thread_p, to_vdes);
 		  error_code = ER_FAILED;
@@ -10138,8 +10137,8 @@ logpb_rename_all_volumes_files (THREAD_ENTRY * thread_p, VOLID num_perm_vols, co
 	{
 	  goto error;
 	}
-      if (fileio_synchronize (thread_p, fileio_get_volume_descriptor (volid), fileio_get_volume_label (volid, PEEK),
-			      FILEIO_SYNC_ALSO_FLUSH_DWB) == NULL_VOLDES)
+      if (dwb_synchronize (thread_p, fileio_get_volume_descriptor (volid), fileio_get_volume_label (volid, PEEK)) ==
+	  NULL_VOLDES)
 	{
 	  error_code = ER_FAILED;
 	  goto error;

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -5852,13 +5852,6 @@ logpb_archive_active_log (THREAD_ENTRY * thread_p)
   /* Flush the log header to reflect the archive */
   logpb_flush_header (thread_p);
 
-#if 0
-  if (prm_get_integer_value (PRM_ID_SUPPRESS_FSYNC) != 0)
-    {
-      fileio_synchronize (thread_p, log_Gl.append.vdes, FILEIO_SYNC_ONLY);
-    }
-#endif
-
   er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_LOG_ARCHIVE_CREATED, 3, arv_name, arvhdr->fpageid, last_pageid);
 
   /* Cast the archive information. May be used again */
@@ -6255,7 +6248,7 @@ logpb_remove_archive_logs (THREAD_ENTRY * thread_p, const char *info_reason)
   pgbuf_flush_checkpoint (thread_p, &flush_upto_lsa, NULL, &newflush_upto_lsa, NULL);
 
   if ((!LSA_ISNULL (&newflush_upto_lsa) && LSA_LT (&newflush_upto_lsa, &flush_upto_lsa))
-      || (fileio_synchronize_all (thread_p, false) != NO_ERROR))
+      || (fileio_synchronize_all (thread_p) != NO_ERROR))
     {
       /* Cannot remove the archives at this moment */
       return;
@@ -6994,7 +6987,7 @@ logpb_checkpoint (THREAD_ENTRY * thread_p)
     }
 
   detailed_er_log ("logpb_checkpoint: call fileio_synchronize_all()\n");
-  if (fileio_synchronize_all (thread_p, false) != NO_ERROR)
+  if (fileio_synchronize_all (thread_p) != NO_ERROR)
     {
       goto error_cannot_chkpt;
     }
@@ -7358,11 +7351,6 @@ logpb_checkpoint (THREAD_ENTRY * thread_p)
   logtb_clear_tdes (thread_p, tdes);
 
   LOG_CS_EXIT (thread_p);
-
-#if 0
-  /* have to sync log vol, data vol */
-  fileio_synchronize_all (thread_p, true /* include_log */ );
-#endif
 
   perfmon_inc_stat (thread_p, PSTAT_LOG_NUM_END_CHECKPOINTS);
 
@@ -10676,7 +10664,7 @@ logpb_fatal_error_internal (THREAD_ENTRY * thread_p, bool log_exit, bool need_fl
 	}
     }
 
-  fileio_synchronize_all (thread_p, false);
+  fileio_synchronize_all (thread_p);
 
   fflush (stderr);
   fflush (stdout);

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -925,7 +925,7 @@ log_recovery (THREAD_ENTRY * thread_p, int ismedia_crash, time_t * stopat)
   /* Flush all dirty pages */
   logpb_flush_pages_direct (thread_p);
   (void) pgbuf_flush_all (thread_p, NULL_VOLID);
-  (void) fileio_synchronize_all (thread_p, false);
+  (void) fileio_synchronize_all (thread_p);
 
   logpb_flush_header (thread_p);
 

--- a/src/transaction/log_writer.c
+++ b/src/transaction/log_writer.c
@@ -1107,8 +1107,7 @@ logwr_flush_all_append_pages (void)
    * Make sure that all of the above log writes are synchronized with any
    * future log writes. That is, the pages should be stored on physical disk.
    */
-  if (need_sync == true
-      && fileio_synchronize (NULL, logwr_Gl.append_vdes, logwr_Gl.active_name, FILEIO_SYNC_ONLY) == NULL_VOLDES)
+  if (need_sync == true && fileio_synchronize (NULL, logwr_Gl.append_vdes, logwr_Gl.active_name) == NULL_VOLDES)
     {
       assert (er_errid () != NO_ERROR);
       return er_errid ();
@@ -1117,8 +1116,7 @@ logwr_flush_all_append_pages (void)
   /* It's for dual write. */
   if (need_sync == true && prm_get_bool_value (PRM_ID_LOG_BACKGROUND_ARCHIVING))
     {
-      if (fileio_synchronize (NULL, logwr_Gl.bg_archive_info.vdes, logwr_Gl.bg_archive_name,
-			      FILEIO_SYNC_ONLY) == NULL_VOLDES)
+      if (fileio_synchronize (NULL, logwr_Gl.bg_archive_info.vdes, logwr_Gl.bg_archive_name) == NULL_VOLDES)
 	{
 	  assert (er_errid () != NO_ERROR);
 	  return er_errid ();
@@ -1179,7 +1177,7 @@ logwr_flush_bgarv_header_page (void)
 
   if (fileio_write (NULL, bg_arv_info->vdes, log_pgptr, phy_pageid, LOG_PAGESIZE,
 		    FILEIO_WRITE_NO_COMPENSATE_WRITE) == NULL
-      || fileio_synchronize (NULL, bg_arv_info->vdes, logwr_Gl.bg_archive_name, FILEIO_SYNC_ONLY) == NULL_VOLDES)
+      || fileio_synchronize (NULL, bg_arv_info->vdes, logwr_Gl.bg_archive_name) == NULL_VOLDES)
     {
       if (er_errid () == ER_IO_WRITE_OUT_OF_SPACE)
 	{
@@ -1232,7 +1230,7 @@ logwr_flush_header_page (void)
   /* logwr_Gl.append_vdes is only changed while starting or finishing or recovering server. So, log cs is not needed. */
   if (fileio_write (NULL, logwr_Gl.append_vdes, logwr_Gl.loghdr_pgptr, phy_pageid, LOG_PAGESIZE,
 		    FILEIO_WRITE_NO_COMPENSATE_WRITE) == NULL
-      || fileio_synchronize (NULL, logwr_Gl.append_vdes, logwr_Gl.active_name, FILEIO_SYNC_ONLY) == NULL_VOLDES)
+      || fileio_synchronize (NULL, logwr_Gl.append_vdes, logwr_Gl.active_name) == NULL_VOLDES)
     {
 
       if (er_errid () == ER_IO_WRITE_OUT_OF_SPACE)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26150>

### Purpose

sync 시 fileio와 dwb 간의 순환 호출이 존재하여 흐름에 대한 변경이 복잡해집니다. 따라서 이 부분을 변경합니다.
간략하게 정리했고, 아래처럼 callee 자체를 변경하였습니다.

fileio_synchronize (FILEIO_SYNC_ONLY) -> fileio_synchronize
fileio_synchronize (FILEIO_SYNC_ALSO_FLUSH_DWB) -> dwb_synchronize

### Implementation

N/A

### Remarks

N/A
