### PR TITLE
[CBRD-26075] Problem with incorrect results being retrieved when comparing columns in the main query in the having clause

### DIFF
--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -544,6 +544,8 @@ extern "C"
   extern bool pt_has_inst_num (PARSER_CONTEXT * parser, PT_NODE * node);
   extern bool pt_has_expr_of_inst_in_sel_list (PARSER_CONTEXT * parser, PT_NODE * select_list);
   extern bool pt_has_inst_in_where_and_select_list (PARSER_CONTEXT * parser, PT_NODE * node);
+  extern bool pt_has_having (PARSER_CONTEXT * parser, PT_NODE * node);
+
   extern bool pt_has_inst_or_orderby_num_in_where (PARSER_CONTEXT * parser, PT_NODE * node);
   extern void pt_set_correlation_level (PARSER_CONTEXT * parser, PT_NODE * subquery, int level);
   extern void pt_set_pred_order (PARSER_CONTEXT * parser, PT_NODE * pre_pred, int pre_order);

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -3452,6 +3452,42 @@ pt_has_inst_in_where_and_select_list (PARSER_CONTEXT * parser, PT_NODE * node)
 }
 
 /*
+ * pt_has_having ()
+ *          - check if tree has an HAVING
+ *   return: true if tree has HAVING
+ *   parser(in):
+ *   node(in):
+ */
+
+bool
+pt_has_having (PARSER_CONTEXT * parser, PT_NODE * node)
+{
+  bool has_having = false;
+
+  switch (node->node_type)
+    {
+    case PT_SELECT:
+      if (node->info.query.q.select.having != NULL)
+	{
+	  return true;
+	}
+      break;
+
+    case PT_UNION:
+    case PT_DIFFERENCE:
+    case PT_INTERSECTION:
+      has_having |= pt_has_having (parser, node->info.query.q.union_.arg1);
+      has_having |= pt_has_having (parser, node->info.query.q.union_.arg2);
+      break;
+
+    default:
+      break;
+    }
+
+  return has_having;
+}
+
+/*
  * pt_has_inst_or_orderby_num_in_where ()
  *          - check if tree has an INST_NUM or ORDERBY_NUM or GROUPBY_NUM node in where
  *   return: true if tree has INST_NUM/ORDERBY_NUM

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -1669,7 +1669,7 @@ pt_to_pred_expr_local_with_arg (PARSER_CONTEXT * parser, PT_NODE * node, int *ar
 	      pred = pt_make_pred_term_comp (regu_var1, NULL, R_EXISTS, data_type);
 
 	      /* exists op must fetch one tuple */
-	      if (regu_var1 && regu_var1->xasl)
+	      if (!pt_has_having (parser, node->info.expr.arg1) && regu_var1 && regu_var1->xasl)
 		{
 		  XASL_SET_FLAG (regu_var1->xasl, XASL_NEED_SINGLE_TUPLE_SCAN);
 		}


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26075>

### Purpose
exists 부질의에 HAVING 절이 있을 경우 잘못된 결과 출력하는 현상 수정

### Implementation
exists 부질의에 HAVING 절이 있을 경우  NEED_SINGLE_TUPLE_SCAN 최적화를 하지 않도록 수정

### Remarks
N/A
