### PR TITLE
[CUBRIDQA-1318] modify split type from timing to name refer to reduce flakey tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
                             | circleci tests run --command="xargs -n1 >> tc.list" --verbose --split-by=name
                           echo "[debug] total testcases: \$(wc -l tc.list)"
                           echo "[debug] Remove tests that are not in the list"
-                          find \$base_dir/\$TEST_SUITE/_* -maxdepth 0 -type d | grep -v -F -f tc.list | xargs -r rm -rf
+                          find \$base_dir -name "*.sql" -type f | grep -v -F -f tc.list | xargs -r rm -rf
                         fi
 
                         echo "[debug] Run the tests"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
                             ;;
                           sql)
                             base_dir="cubrid-testcases"
-                            glob_path="\$base_dir/\$TEST_SUITE/_*/**/*.sql"
+                            glob_path="\$base_dir/\$TEST_SUITE/_*"
                             ;;
                           shell)
                             base_dir="cubrid-testcases-private-ex"
@@ -107,7 +107,7 @@ jobs:
                             ;;
                           *)
                             base_dir="cubrid-testcases"
-                            glob_path="\$base_dir/\$TEST_SUITE/_*/**/*.sql"
+                            glob_path="\$base_dir/\$TEST_SUITE/_*"
                             ;;
                         esac
 
@@ -121,11 +121,11 @@ jobs:
                           find \$base_dir -name "cases" -type d | grep -v -F -f tc_dirs.list | xargs -r rm -rf
                         else
                           echo "[debug] split tests for parallel execution"
-                          circleci tests glob "\$glob_path" | grep -P '/cases/[^/]+\.sql$' \
+                          circleci tests glob "\$glob_path" \
                             | circleci tests run --command="xargs -n1 >> tc.list" --verbose --split-by=name
                           echo "[debug] total testcases: \$(wc -l tc.list)"
                           echo "[debug] Remove tests that are not in the list"
-                          find \$base_dir -name "*.sql" -type f | grep -v -F -f tc.list | xargs -r rm -rf
+                          find \$base_dir/\$TEST_SUITE/_* -maxdepth 0 -type d | grep -v -F -f tc.list | xargs -r rm -rf
                         fi
 
                         echo "[debug] Run the tests"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
                         else
                           echo "[debug] split tests for parallel execution"
                           circleci tests glob "\$glob_path" | grep -P '/cases/[^/]+\.sql$' \
-                            | circleci tests run --command="xargs -n1 >> tc.list" --verbose --split-by=timings --timings-type=file
+                            | circleci tests run --command="xargs -n1 >> tc.list" --verbose --split-by=name
                           echo "[debug] total testcases: \$(wc -l tc.list)"
                           echo "[debug] Remove tests that are not in the list"
                           find \$base_dir -name "*.sql" -type f | grep -v -F -f tc.list | xargs -r rm -rf
@@ -258,7 +258,7 @@ jobs:
               test_sql:
                 executor: cubrid-default
                 resource_class: medium
-                parallelism: 8
+                parallelism: 10
                 environment:
                   TEST_SUITE: "sql"
                 steps:


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1318>

### Purpose
타이밍 기반 랜덤 분할 시 tc 에 존재하는 flakey test 로 인해 많은 실패가 발생.
이전 수행방식과 동일하게 최상위 디렉토리 별로 분할하여 수행하도록변경.

### Implementation
tc 가 몰려있는 _05 plcsql 과 _13 issues 이 한 컨테이너에서 수행되지 않도록 parrarel 값 변경 (8->10)

### Remarks

N/A
