### PR TITLE
[CBRD-26382] refactor scope_exit

### DIFF
--- a/src/base/scope_exit.hpp
+++ b/src/base/scope_exit.hpp
@@ -20,51 +20,62 @@
  * scope_exit.hpp
  */
 
-#ifndef _SCOPE_EXIT_HPP_
-#define _SCOPE_EXIT_HPP_
+#pragma once
 
-// Scope Guard: execute something when it goes out of scope (no extra cost when optimization is enabled)
 #include <type_traits>
 #include <utility>
 
-template<typename Callable>//Callable=function, function address, function pointer, functor, lambda, std::function
-class scope_exit final
+template<class F>
+class scope_exit
 {
   public:
-    explicit scope_exit (Callable &&callable) noexcept
-      : m_valid (true)
-      , m_callable (std::is_lvalue_reference<decltype (callable)>::value ? callable : std::forward<Callable> (callable))
-    {}
+    using fun_t = std::decay_t<F>;
 
-    scope_exit (scope_exit &&sg) noexcept
-      : m_valid (sg.m_valid)
-      , m_callable (sg.m_callable)
+    // constructors
+    explicit constexpr scope_exit (F &&f) noexcept (std::is_nothrow_constructible_v<fun_t, F &&>)
+      : active_ (true), f_ (std::forward<F> (f)) {}
+
+    scope_exit (const scope_exit &) = delete;
+    scope_exit &operator= (const scope_exit &) = delete;
+    scope_exit &operator= (scope_exit &&) = delete; // avoid double-run on assign
+
+    constexpr scope_exit (scope_exit &&other) noexcept (std::is_nothrow_move_constructible_v<fun_t>)
+      : active_ (other.active_), f_ (std::move (other.f_))
     {
-      sg.m_valid = false;
+      other.release();
     }
 
-    ~scope_exit() noexcept
+    // destructor calls the functor if engaged
+    ~scope_exit() noexcept (noexcept (std::declval<fun_t &>()()))
     {
-      if (m_valid)
+      if (active_)
 	{
-	  m_callable();
+	  f_();
 	}
     }
 
-    void release() noexcept
+    // control
+    constexpr void release() noexcept
     {
-      m_valid = false;
+      active_ = false;
     }
+    [[nodiscard]] constexpr bool engaged() const noexcept
+    {
+      return active_;
+    }
+
   private:
-    using func_t = std::function<void (void)>;
-
-    bool m_valid;
-    func_t m_callable;
-
-    scope_exit() = delete;
-    scope_exit (scope_exit &) = delete;
-    scope_exit &operator= (const scope_exit &) = delete;
-    scope_exit &operator= (scope_exit &&) = delete;
+    bool active_{false};
+    [[no_unique_address]] fun_t f_; // EBO when possible
 };
 
-#endif /* _SCOPE_EXIT_HPP_ */
+// CTAD: scope_exit se{[]{}};
+template<class F>
+scope_exit (F) -> scope_exit<std::decay_t<F>>;
+
+template<class F>
+[[nodiscard]] constexpr auto make_scope_exit (F &&f) -> scope_exit<std::decay_t<F>>
+{
+  return scope_exit<std::decay_t<F>> (std::forward<F> (f));
+}
+

--- a/src/base/scope_exit.hpp
+++ b/src/base/scope_exit.hpp
@@ -66,7 +66,8 @@ class scope_exit
 
   private:
     bool active_{false};
-    [[no_unique_address]] fun_t f_; // EBO when possible
+    // [[no_unique_address]] fun_t f_; // EBO when possible <- use this line when C++20 is available later.
+    fun_t f_;
 };
 
 // CTAD: scope_exit se{[]{}};

--- a/src/transaction/log_recovery_redo.hpp
+++ b/src/transaction/log_recovery_redo.hpp
@@ -614,12 +614,7 @@ void log_rv_redo_record_sync (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_
   {
     [&thread_p, &rcv] ()
     {
-      if (rcv.pgptr != nullptr)
-	{
-	  // could have used pgbuf_unfix_and_init if it were a function
-	  pgbuf_unfix (thread_p, rcv.pgptr);
-	  rcv.pgptr = nullptr;
-	}
+      pgbuf_unfix_and_init_after_check (thread_p, rcv.pgptr);
     }
   };
 

--- a/src/transaction/log_recovery_redo.hpp
+++ b/src/transaction/log_recovery_redo.hpp
@@ -610,16 +610,18 @@ void log_rv_redo_record_sync (THREAD_ENTRY *thread_p, log_rv_redo_context &redo_
 
   /* will take care of unfixing the page, will be correctly de-allocated as it is the same
    * storage class as 'rcv' and allocated on the stack after 'rcv' */
-  scope_exit <std::function<void (void)>> unfix_rcv_pgptr (
-      // could have used pgbuf_unfix_and_init if it were a function
-      [&thread_p, &rcv] ()
+  scope_exit unfix_rcv_pgptr
   {
-    if (rcv.pgptr != nullptr)
-      {
-	pgbuf_unfix (thread_p, rcv.pgptr);
-	rcv.pgptr = nullptr;
-      }
-  });
+    [&thread_p, &rcv] ()
+    {
+      if (rcv.pgptr != nullptr)
+	{
+	  // could have used pgbuf_unfix_and_init if it were a function
+	  pgbuf_unfix (thread_p, rcv.pgptr);
+	  rcv.pgptr = nullptr;
+	}
+    }
+  };
 
   rcv.length = log_rv_get_log_rec_redo_length<T> (record_info.m_logrec);
   rcv.mvcc_id = log_rv_get_log_rec_mvccid<T> (record_info.m_logrec);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26382

### Purpose

cpp23에 표준으로 들어온 std::scope_exit를
cpp17을 사용하는 큐브리드에서는 사용할 수 없어,
큐브리드와 LETS 프로젝트에서는 scope_exit을 자체 구현하여 사용했습니다.
 
그런데, 기존 코드는 모든 callable 타입들을 std::function<void(void)> 로 강제 변환시켜 
type erasing
heap allocation cost
runtime dispatch cost
등의 문제가 있어
scope_exit 에서 std::function<> 을 제거합니다.

### Implementation

std::function -> T

### Remarks

N/A
