### PR TITLE
[CBRD-26274] 멀티 ALTER TABLE 을 이용한 PK 변경 허용

### DIFF
--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -1644,7 +1644,7 @@ do_alter (PARSER_CONTEXT * parser, PT_NODE * alter)
   bool do_semantic_checks = false;
   bool do_rollback = false;
   DB_OBJECT *vclass;
-  const char *entity_name;
+  const char *entity_name = alter->info.alter.entity_name->info.name.original;
 
   CHECK_MODIFICATION_ERROR ();
 
@@ -1681,6 +1681,13 @@ do_alter (PARSER_CONTEXT * parser, PT_NODE * alter)
       switch (alter_code)
 	{
 	case PT_RENAME_ENTITY:
+	  /* 
+	   * entity_name is required for performing the HA replication constraint check 
+	   * after all ALTER clauses have been processed. 
+	   * Since the check must be based on the final table name, 
+	   * entity_name is continuously updated as each RENAME clause is applied.
+	   */
+	  entity_name = crt_clause->info.alter.alter_clause.rename.new_name->info.name.original;
 	  error_code = do_alter_clause_rename_entity (parser, crt_clause);
 	  break;
 	case PT_ADD_INDEX_CLAUSE:
@@ -1727,13 +1734,12 @@ do_alter (PARSER_CONTEXT * parser, PT_NODE * alter)
       do_semantic_checks = true;
     }
 
-  entity_name = alter->info.alter.entity_name->info.name.original;
   vclass = db_find_class (entity_name);
   error_code = check_ha_repl_constraint (vclass);
   if (error_code != NO_ERROR)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_code, 0);
-      return error_code;
+      goto error_exit;
     }
 
   return error_code;

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -1331,13 +1331,6 @@ do_alter_one_clause_with_template (PARSER_CONTEXT * parser, PT_NODE * alter)
       return error;
     }
 
-  error = check_ha_repl_constraint (vclass);
-  if (error != NO_ERROR)
-    {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 0);
-      return error;
-    }
-
   /* If we have an ADD COLUMN x NOT NULL without a default value, the existing rows will be filled with NULL for the
    * new column by default. For compatibility with MySQL, we can auto-fill some column types with "hard defaults", like
    * 0 for integer types. THIS CAN TAKE A LONG TIME (it runs an UPDATE), and can be turned off by setting
@@ -1637,7 +1630,6 @@ change_ai_error:
   return error;
 }
 
-
 /*
  * do_alter() -
  *   return: Error code
@@ -1651,6 +1643,8 @@ do_alter (PARSER_CONTEXT * parser, PT_NODE * alter)
   PT_NODE *crt_clause = NULL;
   bool do_semantic_checks = false;
   bool do_rollback = false;
+  DB_OBJECT *vclass;
+  const char *entity_name;
 
   CHECK_MODIFICATION_ERROR ();
 
@@ -1731,6 +1725,15 @@ do_alter (PARSER_CONTEXT * parser, PT_NODE * alter)
 	  goto error_exit;
 	}
       do_semantic_checks = true;
+    }
+
+  entity_name = alter->info.alter.entity_name->info.name.original;
+  vclass = db_find_class (entity_name);
+  error_code = check_ha_repl_constraint (vclass);
+  if (error_code != NO_ERROR)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_code, 0);
+      return error_code;
     }
 
   return error_code;

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -417,7 +417,7 @@ int ib_thread_count = 0;
  *       dedicated processing functions. See do_alter() for details.
  */
 static int
-do_alter_one_clause_with_template (PARSER_CONTEXT * parser, PT_NODE * alter)
+do_alter_one_clause_with_template (PARSER_CONTEXT * parser, PT_NODE * alter, bool * need_check_repl_constraint)
 {
   const char *entity_name, *new_query;
   const char *attr_name, *mthd_name, *mthd_file, *attr_mthd_name;
@@ -640,6 +640,9 @@ do_alter_one_clause_with_template (PARSER_CONTEXT * parser, PT_NODE * alter)
 
 	  assert (alter->info.alter.create_index == NULL);
 	}
+
+      *need_check_repl_constraint = true;
+
       break;
 
     case PT_RESET_QUERY:
@@ -761,6 +764,8 @@ do_alter_one_clause_with_template (PARSER_CONTEXT * parser, PT_NODE * alter)
 	      return error;
 	    }
 	}
+
+      *need_check_repl_constraint = true;
 
       break;
 
@@ -1237,6 +1242,12 @@ do_alter_one_clause_with_template (PARSER_CONTEXT * parser, PT_NODE * alter)
 	    error = er_errid ();
 	  }
       }
+
+      if (alter_code == PT_DROP_CONSTRAINT || alter_code == PT_DROP_PRIMARY_CLAUSE)
+	{
+	  *need_check_repl_constraint = true;
+	}
+
       break;
 
     case PT_APPLY_PARTITION:
@@ -1393,6 +1404,7 @@ do_alter_one_clause_with_template (PARSER_CONTEXT * parser, PT_NODE * alter)
 	{
 	  goto alter_partition_fail;
 	}
+
       break;
 
     default:
@@ -1644,6 +1656,7 @@ do_alter (PARSER_CONTEXT * parser, PT_NODE * alter)
   bool do_semantic_checks = false;
   bool do_rollback = false;
   DB_OBJECT *vclass;
+  bool need_check_repl_constraint = false;
   const char *entity_name = alter->info.alter.entity_name->info.name.original;
 
   CHECK_MODIFICATION_ERROR ();
@@ -1689,6 +1702,7 @@ do_alter (PARSER_CONTEXT * parser, PT_NODE * alter)
 	   */
 	  entity_name = crt_clause->info.alter.alter_clause.rename.new_name->info.name.original;
 	  error_code = do_alter_clause_rename_entity (parser, crt_clause);
+	  need_check_repl_constraint = true;
 	  break;
 	case PT_ADD_INDEX_CLAUSE:
 	  error_code = do_alter_clause_add_index (parser, crt_clause);
@@ -1722,7 +1736,7 @@ do_alter (PARSER_CONTEXT * parser, PT_NODE * alter)
 	   * its execution just to be on the safe side. */
 	  crt_clause->next = NULL;
 
-	  error_code = do_alter_one_clause_with_template (parser, crt_clause);
+	  error_code = do_alter_one_clause_with_template (parser, crt_clause, &need_check_repl_constraint);
 
 	  crt_clause->next = save_next;
 	}
@@ -1734,12 +1748,15 @@ do_alter (PARSER_CONTEXT * parser, PT_NODE * alter)
       do_semantic_checks = true;
     }
 
-  vclass = db_find_class (entity_name);
-  error_code = check_ha_repl_constraint (vclass);
-  if (error_code != NO_ERROR)
+  if (error_code == NO_ERROR && need_check_repl_constraint)
     {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_code, 0);
-      goto error_exit;
+      vclass = db_find_class (entity_name);
+      error_code = check_ha_repl_constraint (vclass);
+      if (error_code != NO_ERROR)
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_code, 0);
+	  goto error_exit;
+	}
     }
 
   return error_code;

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -100,6 +100,18 @@
 #define IS_ALTER_STMT_SET_REPL_OPTION(_node) \
   ((_node)->info.value.data_value.i )
 
+/* 
+ * IS_REPL_CONSTRAINT_RELATED_ALTER() 
+ *    return: true if ALTER clause affects replication constraints
+ *    code(in): PT_ALTER_CODE value
+ */
+#define IS_REPL_CONSTRAINT_RELATED_ALTER(code)              \
+  ( ((code) == PT_ADD_ATTR_MTHD)         ||                 \
+    ((code) == PT_DROP_ATTR_MTHD)        ||                 \
+    ((code) == PT_DROP_CONSTRAINT)       ||                 \
+    ((code) == PT_DROP_PRIMARY_CLAUSE)                     \
+  )
+
 typedef enum
 {
   DO_INDEX_CREATE, DO_INDEX_DROP
@@ -417,7 +429,7 @@ int ib_thread_count = 0;
  *       dedicated processing functions. See do_alter() for details.
  */
 static int
-do_alter_one_clause_with_template (PARSER_CONTEXT * parser, PT_NODE * alter, bool * need_check_repl_constraint)
+do_alter_one_clause_with_template (PARSER_CONTEXT * parser, PT_NODE * alter)
 {
   const char *entity_name, *new_query;
   const char *attr_name, *mthd_name, *mthd_file, *attr_mthd_name;
@@ -640,9 +652,6 @@ do_alter_one_clause_with_template (PARSER_CONTEXT * parser, PT_NODE * alter, boo
 
 	  assert (alter->info.alter.create_index == NULL);
 	}
-
-      *need_check_repl_constraint = true;
-
       break;
 
     case PT_RESET_QUERY:
@@ -764,8 +773,6 @@ do_alter_one_clause_with_template (PARSER_CONTEXT * parser, PT_NODE * alter, boo
 	      return error;
 	    }
 	}
-
-      *need_check_repl_constraint = true;
 
       break;
 
@@ -1242,12 +1249,6 @@ do_alter_one_clause_with_template (PARSER_CONTEXT * parser, PT_NODE * alter, boo
 	    error = er_errid ();
 	  }
       }
-
-      if (alter_code == PT_DROP_CONSTRAINT || alter_code == PT_DROP_PRIMARY_CLAUSE)
-	{
-	  *need_check_repl_constraint = true;
-	}
-
       break;
 
     case PT_APPLY_PARTITION:
@@ -1404,7 +1405,6 @@ do_alter_one_clause_with_template (PARSER_CONTEXT * parser, PT_NODE * alter, boo
 	{
 	  goto alter_partition_fail;
 	}
-
       break;
 
     default:
@@ -1702,7 +1702,6 @@ do_alter (PARSER_CONTEXT * parser, PT_NODE * alter)
 	   */
 	  entity_name = crt_clause->info.alter.alter_clause.rename.new_name->info.name.original;
 	  error_code = do_alter_clause_rename_entity (parser, crt_clause);
-	  need_check_repl_constraint = true;
 	  break;
 	case PT_ADD_INDEX_CLAUSE:
 	  error_code = do_alter_clause_add_index (parser, crt_clause);
@@ -1736,7 +1735,7 @@ do_alter (PARSER_CONTEXT * parser, PT_NODE * alter)
 	   * its execution just to be on the safe side. */
 	  crt_clause->next = NULL;
 
-	  error_code = do_alter_one_clause_with_template (parser, crt_clause, &need_check_repl_constraint);
+	  error_code = do_alter_one_clause_with_template (parser, crt_clause);
 
 	  crt_clause->next = save_next;
 	}
@@ -1745,10 +1744,16 @@ do_alter (PARSER_CONTEXT * parser, PT_NODE * alter)
 	{
 	  goto error_exit;
 	}
+
+      if (!need_check_repl_constraint && IS_REPL_CONSTRAINT_RELATED_ALTER (alter->info.alter.code))
+	{
+	  need_check_repl_constraint = true;
+	}
+
       do_semantic_checks = true;
     }
 
-  if (error_code == NO_ERROR && need_check_repl_constraint)
+  if (need_check_repl_constraint)
     {
       vclass = db_find_class (entity_name);
       error_code = check_ha_repl_constraint (vclass);


### PR DESCRIPTION
[<http://jira.cubrid.org/browse/CBRD-26274>](http://jira.cubrid.org/browse/CBRD-26274)

### Purpose

HA 환경에서는 do_alter_one_clause_with_template() 함수에서 멀티 ALTER TABLE 을 이용해 PK 를 변경할 수 없습니다.

이는 DROP PRIMARY KEY를 수행한 직후 HA에 대한 제약조건을 확인하는 코드가 수행되기때문입니다.

이를 해결하기위해 HA 제약사항 확인 함수를 do_alter_one_clause_with_template()함수의 상위 함수인

do_alter() 함수로 이동합니다.

### Implementation

do_alter() 함수에서 alter에 대한 모든 clause 를 확인 한 후 수행 완료된 vclass에 대한 HA 제약사항을 확인하도록 수정합니다.

### Remarks
1. 위치상 HA제약과 관련 없는 작업에도 매번 수행되어야하는 루틴이지만 alter table 은 빈번한 호출이 아니라 괜찮을거란 주간 회의중 의견이 있었습니다. 

2. check_ha_repl_constraint() 함수를 호출하기위해 vclass() 도 함께 호출되고있는데 
이 부분을 check_ha_repl_constraint_with_name(char * entity_name) 과같은 함수로 한번 더 감쌀지 고민중입니다. 의견있으시면 부탁드립니다. 