### PR TITLE
[CBRD-26391] refactor: use EP_LIBS in sa/CMakeLists.txt

### DIFF
--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -724,21 +724,16 @@ target_external_dependencies(cubridsa
   LIBEDIT
   )
 endif(UNIX)
-target_external_dependencies(cubridsa
-  LIBEXPAT
-  LIBJANSSON
-  LIBEDIT
-  LIBOPENSSL
-  LZ4
-  RAPIDJSON
-  RE2
-  )
 target_include_directories(cubridsa PRIVATE
   ${FLEX_INCLUDE_DIRS}
+  )
+target_include_directories(cubridsa PRIVATE
+  ${EP_INCLUDES}
   )
 if(UNIX)
   # find out what this means:
   # target_link_libraries(cubridsa LINK_PRIVATE -Wl,-whole-archive cas ${EP_LIBS} -Wl,-no-whole-archive)
+  target_link_libraries(cubridsa PRIVATE ${EP_LIBS})
   target_link_libraries(cubridsa LINK_PUBLIC ${CMAKE_DL_LIBS})
   target_link_libraries(cubridsa PUBLIC stdc++fs)
   target_link_libraries(cubridsa PUBLIC rt)
@@ -747,7 +742,7 @@ endif(UNIX)
 target_link_libraries(cubridsa PUBLIC cascci)
 
 add_dependencies(cubridsa gen_csql_grammar gen_csql_lexer gen_loader_grammar gen_loader_lexer)
-#add_dependencies(cubridsa ${EP_TARGETS})
+add_dependencies(cubridsa ${EP_TARGETS})
 
 if(ENABLE_SYSTEMTAP)
   target_include_directories(cubridsa PRIVATE ${CMAKE_BINARY_DIR})

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -718,33 +718,26 @@ endif(WIN32)
 # include target_external_dependencies function
 include (expand_dependency)
 
-if(UNIX)
-target_external_dependencies(cubridsa
-  LIBNCURSES
-  LIBEDIT
-  )
-endif(UNIX)
-target_link_libraries(cubridsa PRIVATE ${EP_LIBS})
 target_include_directories(cubridsa PRIVATE
   ${FLEX_INCLUDE_DIRS}
-  )
-target_include_directories(cubridsa PRIVATE
   ${EP_INCLUDES}
   )
-if(UNIX)
-  # find out what this means:
-  # target_link_libraries(cubridsa LINK_PRIVATE -Wl,-whole-archive cas ${EP_LIBS} -Wl,-no-whole-archive)
-  # The above line is deprecated and it causes multiple definition errors.
-  # we use this instead: target_link_libraries(cubridsa PRIVATE ${EP_LIBS}), outside the if(UNIX) block.
-  target_link_libraries(cubridsa LINK_PUBLIC ${CMAKE_DL_LIBS})
-  target_link_libraries(cubridsa PUBLIC stdc++fs)
-  target_link_libraries(cubridsa PUBLIC rt)
-endif(UNIX)
-# for dblink
-target_link_libraries(cubridsa PUBLIC cascci)
 
-add_dependencies(cubridsa gen_csql_grammar gen_csql_lexer gen_loader_grammar gen_loader_lexer)
-add_dependencies(cubridsa ${EP_TARGETS})
+target_link_libraries(cubridsa PRIVATE ${EP_LIBS})
+target_link_libraries(cubridsa PUBLIC
+  ${CMAKE_DL_LIBS}
+  stdc++fs 
+  rt
+  cascci
+  )
+
+add_dependencies(cubridsa
+  gen_csql_grammar
+  gen_csql_lexer
+  gen_loader_grammar
+  gen_loader_lexer
+  ${EP_TARGETS}
+)
 
 if(ENABLE_SYSTEMTAP)
   target_include_directories(cubridsa PRIVATE ${CMAKE_BINARY_DIR})

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -716,19 +716,22 @@ if(WIN32)
 endif(WIN32)
 
 # include target_external_dependencies function
-include (expand_dependency)
+include(expand_dependency)
 
-target_include_directories(cubridsa PRIVATE
-  ${FLEX_INCLUDE_DIRS}
-  ${EP_INCLUDES}
+target_include_directories(cubridsa
+  PRIVATE
+    ${FLEX_INCLUDE_DIRS}
+    ${EP_INCLUDES}
   )
 
-target_link_libraries(cubridsa PRIVATE ${EP_LIBS})
-target_link_libraries(cubridsa PUBLIC
-  ${CMAKE_DL_LIBS}
-  stdc++fs 
-  rt
-  cascci
+target_link_libraries(cubridsa
+  PRIVATE
+    ${EP_LIBS}
+  PUBLIC
+    ${CMAKE_DL_LIBS}
+    stdc++fs
+    rt
+    cascci
   )
 
 add_dependencies(cubridsa
@@ -737,7 +740,7 @@ add_dependencies(cubridsa
   gen_loader_grammar
   gen_loader_lexer
   ${EP_TARGETS}
-)
+  )
 
 if(ENABLE_SYSTEMTAP)
   target_include_directories(cubridsa PRIVATE ${CMAKE_BINARY_DIR})

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -724,6 +724,7 @@ target_external_dependencies(cubridsa
   LIBEDIT
   )
 endif(UNIX)
+target_link_libraries(cubridsa PRIVATE ${EP_LIBS})
 target_include_directories(cubridsa PRIVATE
   ${FLEX_INCLUDE_DIRS}
   )
@@ -733,7 +734,8 @@ target_include_directories(cubridsa PRIVATE
 if(UNIX)
   # find out what this means:
   # target_link_libraries(cubridsa LINK_PRIVATE -Wl,-whole-archive cas ${EP_LIBS} -Wl,-no-whole-archive)
-  target_link_libraries(cubridsa PRIVATE ${EP_LIBS})
+  # The above line is deprecated and it causes multiple definition errors.
+  # we use this instead: target_link_libraries(cubridsa PRIVATE ${EP_LIBS}), outside the if(UNIX) block.
   target_link_libraries(cubridsa LINK_PUBLIC ${CMAKE_DL_LIBS})
   target_link_libraries(cubridsa PUBLIC stdc++fs)
   target_link_libraries(cubridsa PUBLIC rt)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26391

### Purpose

현재 sa/CMakeLists.txt 에서만 EP_LIBS를 사용하지 않고 있어, 3rdparty dependency를 추가할 때마다

cubrid/CMakeLists.txt
cs/CMakeLists.txt
에는 자동으로 서드파티가 추가되어 링킹되는데,

sa모드에는 수동으로 따로 넣어줘야 하는 번거로움이 있습니다.

서드파티를 테스트해줄 때마다 sa/CMakeLists.txt 에 3줄을 더 추가해주어야 하는 번거로움이 있어 이를 개선합니다.

TO BE

3rdparty/CMakeLists.txt

위 파일에 서드파티를 추가하고 EP_* list 변수에 append 해주면
자동으로 sa 모드 링킹도 성공해야 한다.


### Implementation

```cmake
target_include_directories(cubridsa PRIVATE
  ${EP_INCLUDES}
  )
target_link_libraries(cubridsa PRIVATE ${EP_LIBS})
add_dependencies(cubridsa ${EP_TARGETS})
```

### Remarks

큐브리드 서드파티 관련 확인해야 할 3가지 사항들

- [x] EP_LIBS 를 target_link_libraries 를 통해 링크 시켰는가?
- [x] EP_INCLUDES 를 target_include_directories 를 통해 포함시켰는가?
- [x] EP_TARGETS 를 add_dependencies 를 통해 의존 관계를 추가했는가?

Q: 그런데 target_link_libraries 가 자동으로 add_dependencies를 잡아주지 않나요?
A: 과거 CMake 버전이 낮을 때 어쩔 수 없이 사용한 ExternalProject_Add 의 한계로 인하여 아님.
- EP_LIBS가 CMake 타겟일 경우 자동으로 잡아준다. <- True
- 그러나 EP_LIBS가 단순 경로일 경우 자동으로 잡아주지 않는다. 따라서 add_dependencies 가 필요하다.
