### PR TITLE
[CBRD-26377] When loading an objects file online without the user name option, loaddb fails to find the target tables (#6626)

### DIFF
--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -1143,7 +1143,7 @@ get_loaddb_args (UTIL_ARG_MAP * arg_map, load_args * args)
 
   args->volume = volume ? volume : empty;
   args->input_file = input_file ? input_file : empty;
-  args->user_name = user_name ? user_name : empty;
+  args->user_name = user_name ? user_name : AU_PUBLIC_USER_NAME;
   args->password = password ? password : empty;
   args->syntax_check = utility_get_option_bool_value (arg_map, LOAD_CHECK_ONLY_S);
   args->load_only = utility_get_option_bool_value (arg_map, LOAD_LOAD_ONLY_S);

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -134,13 +134,17 @@ namespace cubload
 	 */
 
 	char user_specified_name[DB_MAX_IDENTIFIER_LENGTH] = { '\0' };
+	char realname[DB_MAX_IDENTIFIER_LENGTH] = { '\0' };
 
 	const char *user_name = m_session.get_args ().user_name.c_str ();
-	assert (user_name != NULL);
+	assert (user_name != NULL && user_name[0] != '\0');
 
 	snprintf (user_specified_name, DB_MAX_IDENTIFIER_LENGTH, "%s.%s", user_name, class_name);
 
-	found = xlocator_find_class_oid (&thread_ref, user_specified_name, &class_oid, BU_LOCK);
+	assert (intl_identifier_lower_string_size (user_name) < DB_MAX_USER_LENGTH);
+	intl_identifier_lower (user_specified_name, realname);
+
+	found = xlocator_find_class_oid (&thread_ref, realname, &class_oid, BU_LOCK);
       }
 
     if (found == LC_CLASSNAME_EXIST)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26377

backport #6626