### PR TITLE
[CBRD-26381] error on floating-number expressed as exponents (#6635)

### DIFF
--- a/src/executables/unload_object_file.c
+++ b/src/executables/unload_object_file.c
@@ -669,6 +669,20 @@ exit_on_error:
 
 #define INTERNAL_BUFFER_SIZE (400)	/* bigger than DBL_MAX_DIGITS */
 
+inline bool
+need_append_dot (const char *val)
+{
+  while (*val)
+    {
+      if (*val == '.' || *val == 'e' || *val == 'E')
+	{
+	  return false;
+	}
+      val++;
+    }
+  return true;
+}
+
 /*
  * fprint_special_strings - print special DB_VALUE to TEXT_OUTPUT
  *    return: NO_ERROR if successful, error code otherwise
@@ -706,21 +720,25 @@ fprint_special_strings (TEXT_OUTPUT * tout, DB_VALUE * value)
     case DB_TYPE_FLOAT:
     case DB_TYPE_DOUBLE:
       {
-	char *pos;
+	char *pos = NULL;
+	TEXT_BUFFER_BLK *tail_ptr_bk = NULL;
 
-	if (tout->tail_ptr == NULL)
+	if (tout->tail_ptr)
 	  {
-	    assert (tout->head_ptr == NULL);
-	    CHECK_PRINT_ERROR (get_text_output_mem (tout, -1));
+	    tail_ptr_bk = tout->tail_ptr;
+	    pos = tout->tail_ptr->ptr;
 	  }
-
-	pos = tout->tail_ptr->ptr;
 	CHECK_PRINT_ERROR (text_print
 			   (tout, NULL, 0, "%.*g", (type == DB_TYPE_FLOAT) ? 10 : 17,
 			    (type == DB_TYPE_FLOAT) ? db_get_float (value) : db_get_double (value)));
 	/* if tout flushed, then this float/double should be the first content */
-	if ((pos < tout->tail_ptr->ptr && !strchr (pos, '.'))
-	    || (pos > tout->tail_ptr->ptr && !strchr (tout->tail_ptr->buffer, '.')))
+	if (pos == NULL || tail_ptr_bk != tout->tail_ptr)
+	  {
+	    assert (tout->tail_ptr != NULL);
+	    pos = tout->tail_ptr->buffer;
+	  }
+
+	if (need_append_dot (pos))
 	  {
 	    CHECK_PRINT_ERROR (text_print (tout, ".", 1, NULL));
 	  }

--- a/src/loaddb/load_lexer.l
+++ b/src/loaddb/load_lexer.l
@@ -212,7 +212,7 @@ using token = cubload::parser::token;
     return token::END_PAREN;
 }
 
-[\+\-]?(([0-9]+[Ee][\+\-]?[0-9]+[fFlL]?)|([0-9]*\.[0-9]+([Ee][\+\-]?[0-9]+)?[fFlL]?)|([0-9]+\.[0-9]*([Ee][\+\-]?[0-9]+)?[fFlL]?)) {
+[\+\-]?(([0-9]+[Ee][\+\-]?[0-9]+[.fFlL]?)|([0-9]*\.[0-9]+([Ee][\+\-]?[0-9]+)?[fFlL]?)|([0-9]+\.[0-9]*([Ee][\+\-]?[0-9]+)?[fFlL]?)) {
     PRINT ("REAL_LIT %s\n", yytext);
     yylval->string = m_semantic_helper.make_string_by_yytext (yytext, yyleng);
     return token::REAL_LIT;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26381

* When executing unloaddb, prevent decimal points from being added when outputting float and double types in exponential format.
* When executing loaddb, allow decimal points at the end of exponents when inputting real numbers (e.g., 1e+12).
* backport #6635 

### Purpose

N/A

### Implementation

N/A

### Remarks

N/A
