### PR TITLE
[CBRD-26373] [Regression] Core dumped in qexec_analytic_add_tuple at src/query/query_executor.c:21527

### DIFF
--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -62,7 +62,7 @@ static int rv;
 #endif /* not SERVER_MODE */
 
 #define QFILE_CHECK_LIST_FILE_IS_CLOSED(list_id) \
-  assert (!VPID_ISNULL(&list_id->last_vpid) ? (list_id->last_pgptr != NULL) : true)
+  assert (list_id != NULL &&(!VPID_ISNULL(&list_id->last_vpid) ? (list_id->last_pgptr != NULL) : true))
 
 #define QFILE_DEFAULT_PAGES 4
 

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -61,7 +61,8 @@ static int rv;
 #define thread_sleep(a)
 #endif /* not SERVER_MODE */
 
-#define QFILE_CHECK_LIST_FILE_IS_CLOSED(list_id)
+#define QFILE_CHECK_LIST_FILE_IS_CLOSED(list_id) \
+  assert (!VPID_ISNULL(&list_id->last_vpid) ? (list_id->last_pgptr != NULL) : true)
 
 #define QFILE_DEFAULT_PAGES 4
 

--- a/src/storage/external_sort.c
+++ b/src/storage/external_sort.c
@@ -4567,6 +4567,12 @@ sort_merge_run_for_parallel (THREAD_ENTRY * thread_p, SORT_PARAM * px_sort_param
 	  sort_info_p->output_file = NULL;
 	}
     }
+  /* reopen final output file */
+  error = qfile_reopen_list_as_append_mode (thread_p, origin_list_id);
+  if (error != NO_ERROR)
+    {
+      goto cleanup;
+    }
 
 cleanup:
   /* clear input_file for px */


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26373>

병렬 정렬후 출력파일이 닫힌 상태에서 리턴되어 분석함수 로직에서 문제가 발생한다. reopen하여 이전과 동일한 상태를 유지한다.

