### PR TITLE
[CBRD-26345] Implement memoize

### DIFF
--- a/src/optimizer/plan_generation.c
+++ b/src/optimizer/plan_generation.c
@@ -38,8 +38,6 @@
 #include "xasl_generation.h"
 #include "xasl_predicate.hpp"
 
-#define MEMOIZE_NDV_RATIO_THRESHOLD (double) 2
-
 typedef int (*ELIGIBILITY_FN) (QO_TERM *);
 
 static XASL_NODE *make_scan_proc (QO_ENV * env);
@@ -1962,16 +1960,12 @@ gen_outer (QO_ENV * env, QO_PLAN * plan, BITSET * subqueries, XASL_NODE * inner_
   QO_PLAN *outer, *inner;
   JOIN_TYPE join_type = NO_JOIN;
   QO_TERM *term;
-  int i, i2;
-  BITSET_ITERATOR bi, bi2;
+  int i;
+  BITSET_ITERATOR bi;
   BITSET new_subqueries;
   BITSET fake_subqueries;
   BITSET predset;
   BITSET taj_terms;
-  double join_outer_table_terms_duplicate_ratio = 1.0;
-  BITSET temp_segs_set;
-  QO_SEGMENT *seg;
-  bool join_term_exists = false;
 
   if (env == NULL)
     {
@@ -1988,7 +1982,6 @@ gen_outer (QO_ENV * env, QO_PLAN * plan, BITSET * subqueries, XASL_NODE * inner_
   bitset_init (&fake_subqueries, env);
   bitset_init (&predset, env);
   bitset_init (&taj_terms, env);
-  bitset_init (&temp_segs_set, env);
 
   /* set subqueries */
   bitset_assign (&new_subqueries, subqueries);
@@ -2127,41 +2120,12 @@ gen_outer (QO_ENV * env, QO_PLAN * plan, BITSET * subqueries, XASL_NODE * inner_
 	    }
 	  [[fallthrough]];
 	case QO_JOINMETHOD_IDX_JOIN:
-	  if (outer != NULL && outer->plan_un.scan.node != NULL)
-	    {
-	      join_outer_table_terms_duplicate_ratio *= outer->plan_un.scan.node->ncard;
-	    }
-
 	  for (i = bitset_iterate (&(plan->plan_un.join.join_terms), &bi); i != -1; i = bitset_next_member (&bi))
 	    {
 	      term = QO_ENV_TERM (env, i);
 	      if (QO_IS_FAKE_TERM (term))
 		{
 		  bitset_union (&fake_subqueries, &(QO_TERM_SUBQUERIES (term)));
-		}
-
-	      if (term->segments.nwords > 0)
-		{
-		  bitset_assign (&temp_segs_set, &QO_TERM_SEGS (term));
-
-		  for (i2 = bitset_iterate (&temp_segs_set, &bi2); i2 != -1; i2 = bitset_next_member (&bi2))
-		    {
-		      seg = QO_ENV_SEG (env, i2);
-		      if ((seg != NULL && seg->head != NULL && seg->info != NULL && outer != NULL
-			   && outer->plan_un.scan.node != NULL) && seg->head->idx == outer->plan_un.scan.node->idx)
-			{
-			  if (seg->info->ndv != 0)
-			    {
-			      join_outer_table_terms_duplicate_ratio /= (double) seg->info->ndv;
-			      join_term_exists = true;
-			    }
-			  else
-			    {
-			      join_outer_table_terms_duplicate_ratio = 1.0;
-			      break;
-			    }
-			}
-		    }
 		}
 	    }
 
@@ -2238,10 +2202,6 @@ gen_outer (QO_ENV * env, QO_PLAN * plan, BITSET * subqueries, XASL_NODE * inner_
 	      if (IS_OUTER_JOIN_TYPE (join_type))
 		{
 		  mark_access_as_outer_join (parser, scan);
-		}
-	      if (join_term_exists && join_outer_table_terms_duplicate_ratio > MEMOIZE_NDV_RATIO_THRESHOLD)
-		{
-		  XASL_SET_FLAG (scan, XASL_MEMOIZE_STORAGE);
 		}
 	    }
 	  bitset_assign (&new_subqueries, &fake_subqueries);

--- a/src/query/memoize.cpp
+++ b/src/query/memoize.cpp
@@ -19,14 +19,17 @@
 #include "memoize.hpp"
 
 #include "error_code.h"
+#include "memory_alloc.h"
 #include "memory_hash.h"
 #include "object_primitive.h"
 #include "query_evaluator.h"
 #include "regu_var.hpp"
+#include "system.h"
 #include "system_parameter.h"
 #include "thread_compat.hpp"
 #include "thread_manager.hpp"
 #include "xasl.h"
+#include "scope_exit.hpp"
 
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
 #include "memory_wrapper.hpp"
@@ -161,10 +164,9 @@ namespace memoize
   struct key_maker
   {
     int operator() (THREAD_ENTRY *thread_p, xasl_node *xasl,
-		    pvector<DB_VALUE *> &key_ptr_src) const noexcept
+		    std::vector<DB_VALUE *> &key_ptr_src) const noexcept
     {
-      allocator<REGU_VARIABLE *> vector_allocator (thread_p);
-      pvector<REGU_VARIABLE *> const_regu_var_vector (vector_allocator);
+      std::vector<REGU_VARIABLE *> const_regu_var_vector;
       ACCESS_SPEC_TYPE *spec = xasl->curr_spec ? xasl->curr_spec : xasl->spec_list;
       PRED_EXPR *if_pred = xasl->if_pred;
       PRED_EXPR *after_join_pred = xasl->after_join_pred;
@@ -272,15 +274,14 @@ namespace memoize
     }
 
     void operator() (THREAD_ENTRY *thread_p, xasl_node *subquery,
-		     pvector<REGU_VARIABLE *> &const_regu_var_vector) const noexcept
+		     std::vector<REGU_VARIABLE *> &const_regu_var_vector) const noexcept
     {
       if (subquery == NULL)
 	{
 	  return;
 	}
 
-      allocator<REGU_VARIABLE *> vector_allocator (thread_p);
-      pvector<REGU_VARIABLE *> subquery_const_regu_var_vector (vector_allocator);
+      std::vector<REGU_VARIABLE *> subquery_const_regu_var_vector;
       ACCESS_SPEC_TYPE *spec = subquery->curr_spec ? subquery->curr_spec : subquery->spec_list;
       PRED_EXPR *if_pred = subquery->if_pred;
       PRED_EXPR *after_join_pred = subquery->after_join_pred;
@@ -402,7 +403,7 @@ namespace memoize
     }
 
     void operator() (cubxasl::pred_expr *pred_expr,
-		     pvector<REGU_VARIABLE *> &const_regu_var_vector) const noexcept
+		     std::vector<REGU_VARIABLE *> &const_regu_var_vector) const noexcept
     {
       if (pred_expr == NULL)
 	{
@@ -427,14 +428,14 @@ namespace memoize
     }
 
     void operator() (cubxasl::pred *pred,
-		     pvector<REGU_VARIABLE *> &const_regu_var_vector) const noexcept
+		     std::vector<REGU_VARIABLE *> &const_regu_var_vector) const noexcept
     {
       (*this) (pred->lhs, const_regu_var_vector);
       (*this) (pred->rhs, const_regu_var_vector);
     }
 
     void operator() (cubxasl::eval_term *eval_term,
-		     pvector<REGU_VARIABLE *> &const_regu_var_vector) const noexcept
+		     std::vector<REGU_VARIABLE *> &const_regu_var_vector) const noexcept
     {
       switch (eval_term->et_type)
 	{
@@ -459,21 +460,21 @@ namespace memoize
     }
 
     void operator() (cubxasl::comp_eval_term *comp_eval_term,
-		     pvector<REGU_VARIABLE *> &const_regu_var_vector) const noexcept
+		     std::vector<REGU_VARIABLE *> &const_regu_var_vector) const noexcept
     {
       (*this) (comp_eval_term->lhs, const_regu_var_vector);
       (*this) (comp_eval_term->rhs, const_regu_var_vector);
     }
 
     void operator() (cubxasl::alsm_eval_term *alsm_eval_term,
-		     pvector<REGU_VARIABLE *> &const_regu_var_vector) const noexcept
+		     std::vector<REGU_VARIABLE *> &const_regu_var_vector) const noexcept
     {
       (*this) (alsm_eval_term->elem, const_regu_var_vector);
       (*this) (alsm_eval_term->elemset, const_regu_var_vector);
     }
 
     void operator() (cubxasl::like_eval_term *like_eval_term,
-		     pvector<REGU_VARIABLE *> &const_regu_var_vector) const noexcept
+		     std::vector<REGU_VARIABLE *> &const_regu_var_vector) const noexcept
     {
       (*this) (like_eval_term->src, const_regu_var_vector);
       (*this) (like_eval_term->pattern, const_regu_var_vector);
@@ -481,7 +482,7 @@ namespace memoize
     }
 
     void operator() (cubxasl::rlike_eval_term *rlike_eval_term,
-		     pvector<REGU_VARIABLE *> &const_regu_var_vector) const noexcept
+		     std::vector<REGU_VARIABLE *> &const_regu_var_vector) const noexcept
     {
       (*this) (rlike_eval_term->src, const_regu_var_vector);
       (*this) (rlike_eval_term->pattern, const_regu_var_vector);
@@ -489,7 +490,7 @@ namespace memoize
     }
 
     void operator() (regu_variable_node *regu_var,
-		     pvector<REGU_VARIABLE *> &const_regu_var_vector) const noexcept
+		     std::vector<REGU_VARIABLE *> &const_regu_var_vector) const noexcept
     {
       if (regu_var == NULL)
 	{
@@ -551,7 +552,7 @@ namespace memoize
     }
 
     void operator() (ARITH_TYPE *arith,
-		     pvector<REGU_VARIABLE *> &const_regu_var_vector) const noexcept
+		     std::vector<REGU_VARIABLE *> &const_regu_var_vector) const noexcept
     {
       (*this) (arith->leftptr, const_regu_var_vector);
       (*this) (arith->rightptr, const_regu_var_vector);
@@ -561,7 +562,7 @@ namespace memoize
     }
 
     void operator() (REGU_VARIABLE_LIST regu_var_list,
-		     pvector<REGU_VARIABLE *> &const_regu_var_vector) const noexcept
+		     std::vector<REGU_VARIABLE *> &const_regu_var_vector) const noexcept
     {
       while (regu_var_list != NULL)
 	{
@@ -572,7 +573,7 @@ namespace memoize
     }
 
     void operator() (REGU_VALUE_LIST *regu_value_list,
-		     pvector<REGU_VARIABLE *> &const_regu_var_vector) const noexcept
+		     std::vector<REGU_VARIABLE *> &const_regu_var_vector) const noexcept
     {
       REGU_VALUE_ITEM *regu_value_item = regu_value_list->regu_list;
       while (regu_value_item != NULL)
@@ -584,14 +585,14 @@ namespace memoize
     }
 
     void operator() (struct function_node *function_node,
-		     pvector<REGU_VARIABLE *> &const_regu_var_vector) const noexcept
+		     std::vector<REGU_VARIABLE *> &const_regu_var_vector) const noexcept
     {
       (*this) (function_node->operand, const_regu_var_vector);
       return;
     }
 
     void operator() (cubxasl::sp_node *sp_node,
-		     pvector<REGU_VARIABLE *> &const_regu_var_vector) const noexcept
+		     std::vector<REGU_VARIABLE *> &const_regu_var_vector) const noexcept
     {
       (*this) (sp_node->args, const_regu_var_vector);
       return;
@@ -600,9 +601,8 @@ namespace memoize
   key_maker<TARGET_CLASS> const cls_key_maker;
   key_maker<TARGET_LIST> const list_key_maker;
 
-  key::key (allocator<DB_VALUE> *allocator_p)
-    : m_values (*allocator_p)
-    , m_size (0)
+  key::key ()
+    : m_size (0)
   {
   }
 
@@ -632,9 +632,8 @@ namespace memoize
     return m_size;
   }
 
-  value::value (allocator<DB_VALUE> *allocator_p)
-    : m_values (*allocator_p),
-      m_size (0)
+  value::value ()
+    : m_size (0)
   {
   }
 
@@ -696,8 +695,7 @@ namespace memoize
     ACCESS_SPEC_TYPE *spec = xasl->curr_spec ? xasl->curr_spec : xasl->spec_list;
     VAL_LIST *val_list = xasl->val_list;
     int key_cnt, value_cnt;
-    allocator<DB_VALUE *> vector_allocator (thread_p);
-    pvector<DB_VALUE *> key_ptr_src (vector_allocator);
+    std::vector<DB_VALUE *> key_ptr_src;
 
     if (!checker (xasl))
       {
@@ -725,7 +723,7 @@ namespace memoize
 	return nullptr;
       }
 
-    storage *storage_p = (storage *) db_private_alloc (thread_p, sizeof (storage));
+    storage *storage_p = (storage *) malloc (sizeof (storage));
 
     if (storage_p == NULL)
       {
@@ -745,18 +743,14 @@ namespace memoize
     , m_value_cnt (value_cnt)
     , m_thread_p (thread_p)
     , m_val_list (val_list)
-    , m_dbval_p_allocator (thread_p)
-    , m_dbval_allocator (thread_p)
-    , m_value_allocator (thread_p)
-    , m_key_value_allocator (thread_p)
-    , m_key_fixed_allocator (thread_p)
+    , m_key_fixed_allocator ()
     , m_key_sz (0)
     , m_value_sz (0)
     , m_hash_sz (0)
     , m_last_key (nullptr)
-    , m_keyptr_src (m_dbval_p_allocator)
-    , m_key_value_map (m_key_value_allocator)
-    , m_current_value_list (m_value_allocator)
+    , m_keyptr_src ()
+    , m_key_value_map ()
+    , m_current_value_list ()
     , disabled (false)
     , has_range (false)
     , key_changed (false)
@@ -783,7 +777,7 @@ namespace memoize
 	if (it->second != nullptr)
 	  {
 	    it->second->~value();
-	    db_private_free (m_thread_p, it->second);
+	    free (it->second);
 	  }
 	m_key_fixed_allocator.deallocate (it->first);
       }
@@ -806,7 +800,7 @@ namespace memoize
     TSC_ADD_TIMEVAL (m_elapsed_time, tv_diff);
   }
 
-  void storage::init (pvector<DB_VALUE *> &arg_key_ptr_src)
+  void storage::init (std::vector<DB_VALUE *> &arg_key_ptr_src)
   {
     for (auto &dbval : arg_key_ptr_src)
       {
@@ -816,6 +810,11 @@ namespace memoize
 
   result_code storage::get ()
   {
+    HL_HEAPID heap_id = db_change_private_heap (m_thread_p, 0);
+    scope_exit restore_heap_id ([heap_id, this]()
+    {
+      db_change_private_heap (this->m_thread_p, heap_id);
+    });
     value *v;
     if (disabled || get_current_size() >= m_max_storage_size)
       {
@@ -860,6 +859,7 @@ namespace memoize
 
 	hit++;
 	has_range = true;
+	db_change_private_heap (this->m_thread_p, heap_id);
 	return set_value (v);
       }
 
@@ -877,6 +877,7 @@ namespace memoize
 	  }
 	v = m_current_value_list.back();
 	m_current_value_list.pop_back();
+	db_change_private_heap (this->m_thread_p, heap_id);
 	return set_value (v);
       }
     else
@@ -887,12 +888,26 @@ namespace memoize
 
   result_code storage::put()
   {
+    HL_HEAPID heap_id = db_change_private_heap (m_thread_p, 0);
+    scope_exit restore_heap_id ([heap_id, this]()
+    {
+      db_change_private_heap (this->m_thread_p, heap_id);
+    });
+
     try
       {
 	if (disabled || get_current_size() >= m_max_storage_size)
 	  {
 	    disabled = true;
 	    return result_code::FULL;
+	  }
+	if (hit+miss > MEMOIZE_FREE_ITERATION_LIMIT)
+	  {
+	    if (((double)hit)/ (hit+miss) < MEMOIZE_HIT_RATIO_THRESHOLD)
+	      {
+		disabled = true;
+		return result_code::FULL;
+	      }
 	  }
 
 	current_key_joined = true;
@@ -917,6 +932,12 @@ namespace memoize
 
   result_code storage::put_nullptr()
   {
+    HL_HEAPID heap_id = db_change_private_heap (m_thread_p, 0);
+    scope_exit restore_heap_id ([heap_id, this]()
+    {
+      db_change_private_heap (this->m_thread_p, heap_id);
+    });
+
     try
       {
 	if (!current_key_joined)
@@ -925,6 +946,15 @@ namespace memoize
 	      {
 		disabled = true;
 		return result_code::FULL;
+	      }
+
+	    if (hit+miss > MEMOIZE_FREE_ITERATION_LIMIT)
+	      {
+		if (((double)hit)/ (hit+miss) < MEMOIZE_HIT_RATIO_THRESHOLD)
+		  {
+		    disabled = true;
+		    return result_code::FULL;
+		  }
 	      }
 
 	    assert (m_last_key != nullptr);
@@ -953,7 +983,7 @@ namespace memoize
 	return nullptr;
       }
 
-    k = placement_new (k,&m_dbval_allocator);
+    k = placement_new (k);
     k->m_values.reserve (m_key_cnt);
 
     for (auto dbvalp : m_keyptr_src)
@@ -968,14 +998,14 @@ namespace memoize
 
   value *storage::get_value()
   {
-    value *v = (value *)db_private_alloc (m_thread_p, sizeof (value));
+    value *v = (value *)malloc (sizeof (value));
 
     if (v==nullptr)
       {
 	return nullptr;
       }
 
-    v = placement_new (v,&m_dbval_allocator);
+    v = placement_new (v);
     v->m_values.reserve (m_value_cnt);
 
     for (QPROC_DB_VALUE_LIST it = m_val_list->valp; it!=nullptr; it=it->next)
@@ -1010,12 +1040,7 @@ extern "C"
   using namespace memoize;
   int new_memoize_storage (THREAD_ENTRY *thread_p, xasl_node *xasl)
   {
-    UINT64 storage_size; /* system parameter need*/
-    if (!XASL_IS_FLAGED (xasl, XASL_MEMOIZE_STORAGE))
-      {
-	return NO_ERROR;
-      }
-    storage_size = prm_get_bigint_value (PRM_ID_MEMOIZE_MEMORY_LIMIT);
+    UINT64 storage_size = prm_get_bigint_value (PRM_ID_MEMOIZE_MEMORY_LIMIT);
 
     if (storage_size == 0)
       {
@@ -1036,9 +1061,11 @@ extern "C"
   {
     if (xasl->memoize_storage)
       {
+	HL_HEAPID heap_id = db_change_private_heap (thread_p, 0);
 	xasl->memoize_storage->storage::~storage();
-	db_private_free (thread_p, xasl->memoize_storage);
+	free (xasl->memoize_storage);
 	xasl->memoize_storage = nullptr;
+	db_change_private_heap (thread_p, heap_id);
       }
   }
 
@@ -1074,7 +1101,6 @@ extern "C"
 	  {
 	    xasl->memoize_storage->stop_timer();
 	  }
-	clear_memoize_storage (thread_get_thread_entry_info(), xasl);
 	return NO_ERROR;
 	break;
 
@@ -1126,7 +1152,6 @@ extern "C"
 	  {
 	    xasl->memoize_storage->stop_timer();
 	  }
-	clear_memoize_storage (thread_get_thread_entry_info(), xasl);
 	return NO_ERROR;
 	break;
 
@@ -1174,7 +1199,6 @@ extern "C"
 	  {
 	    xasl->memoize_storage->stop_timer();
 	  }
-	clear_memoize_storage (thread_get_thread_entry_info(), xasl);
 	return NO_ERROR;
 	break;
 

--- a/src/query/memoize.cpp
+++ b/src/query/memoize.cpp
@@ -860,6 +860,7 @@ namespace memoize
 	hit++;
 	has_range = true;
 	db_change_private_heap (this->m_thread_p, heap_id);
+	restore_heap_id.release();
 	return set_value (v);
       }
 
@@ -878,6 +879,7 @@ namespace memoize
 	v = m_current_value_list.back();
 	m_current_value_list.pop_back();
 	db_change_private_heap (this->m_thread_p, heap_id);
+	restore_heap_id.release();
 	return set_value (v);
       }
     else

--- a/src/query/memoize.cpp
+++ b/src/query/memoize.cpp
@@ -764,7 +764,7 @@ namespace memoize
 
   storage::~storage()
   {
-    HL_HEAPID heap_id = db_change_private_heap (m_thread_p, 0);
+    HL_HEAPID heap_id = db_change_private_heap (thread_get_thread_entry_info(), 0);
     if (m_last_key != nullptr)
       {
 	m_last_key->~key();
@@ -785,7 +785,7 @@ namespace memoize
 
     m_keyptr_src.clear();
     m_key_value_map.clear();
-    db_change_private_heap (m_thread_p, heap_id);
+    db_change_private_heap (thread_get_thread_entry_info(), heap_id);
   }
 
   void storage::start_timer()
@@ -812,10 +812,10 @@ namespace memoize
 
   result_code storage::get ()
   {
-    HL_HEAPID heap_id = db_change_private_heap (m_thread_p, 0);
+    HL_HEAPID heap_id = db_change_private_heap (thread_get_thread_entry_info(), 0);
     scope_exit restore_heap_id ([heap_id, this]()
     {
-      db_change_private_heap (this->m_thread_p, heap_id);
+      db_change_private_heap (thread_get_thread_entry_info(), heap_id);
     });
     value *v;
     if (disabled || get_current_size() >= m_max_storage_size)
@@ -861,7 +861,7 @@ namespace memoize
 
 	hit++;
 	has_range = true;
-	db_change_private_heap (this->m_thread_p, heap_id);
+	db_change_private_heap (thread_get_thread_entry_info(), heap_id);
 	restore_heap_id.release();
 	return set_value (v);
       }
@@ -880,7 +880,7 @@ namespace memoize
 	  }
 	v = m_current_value_list.back();
 	m_current_value_list.pop_back();
-	db_change_private_heap (this->m_thread_p, heap_id);
+	db_change_private_heap (thread_get_thread_entry_info(), heap_id);
 	restore_heap_id.release();
 	return set_value (v);
       }
@@ -892,10 +892,10 @@ namespace memoize
 
   result_code storage::put()
   {
-    HL_HEAPID heap_id = db_change_private_heap (m_thread_p, 0);
+    HL_HEAPID heap_id = db_change_private_heap (thread_get_thread_entry_info(), 0);
     scope_exit restore_heap_id ([heap_id, this]()
     {
-      db_change_private_heap (this->m_thread_p, heap_id);
+      db_change_private_heap (thread_get_thread_entry_info(), heap_id);
     });
 
     try
@@ -936,10 +936,10 @@ namespace memoize
 
   result_code storage::put_nullptr()
   {
-    HL_HEAPID heap_id = db_change_private_heap (m_thread_p, 0);
+    HL_HEAPID heap_id = db_change_private_heap (thread_get_thread_entry_info(), 0);
     scope_exit restore_heap_id ([heap_id, this]()
     {
-      db_change_private_heap (this->m_thread_p, heap_id);
+      db_change_private_heap (thread_get_thread_entry_info(), heap_id);
     });
 
     try

--- a/src/query/memoize.cpp
+++ b/src/query/memoize.cpp
@@ -764,6 +764,7 @@ namespace memoize
 
   storage::~storage()
   {
+    HL_HEAPID heap_id = db_change_private_heap (m_thread_p, 0);
     if (m_last_key != nullptr)
       {
 	m_last_key->~key();
@@ -784,6 +785,7 @@ namespace memoize
 
     m_keyptr_src.clear();
     m_key_value_map.clear();
+    db_change_private_heap (m_thread_p, heap_id);
   }
 
   void storage::start_timer()
@@ -1063,11 +1065,9 @@ extern "C"
   {
     if (xasl->memoize_storage)
       {
-	HL_HEAPID heap_id = db_change_private_heap (thread_p, 0);
 	xasl->memoize_storage->storage::~storage();
 	free (xasl->memoize_storage);
 	xasl->memoize_storage = nullptr;
-	db_change_private_heap (thread_p, heap_id);
       }
   }
 

--- a/src/query/memoize.hpp
+++ b/src/query/memoize.hpp
@@ -29,14 +29,11 @@
 
 namespace memoize
 {
-  template <typename T>
-  using allocator = cubmem::private_allocator<T>;
+  constexpr size_t MEMOIZE_FREE_ITERATION_LIMIT = 1000;
+  constexpr double MEMOIZE_HIT_RATIO_THRESHOLD = 0.5;
 
   template <typename T>
-  using pvector = std::vector<T, allocator<T>>; /* private-memory vector */
-
-  template <typename T>
-  using fixed_allocator = cubmem::fixed_size_alloc::allocator<T, true>;
+  using fixed_allocator = cubmem::fixed_size_alloc::allocator<T, false>;
 
   enum class result_code
   {
@@ -50,11 +47,10 @@ namespace memoize
   class key
   {
     public:
-      key () = delete;
-      key (allocator<DB_VALUE> *allocator_p);
+      key ();
       ~key ();
 
-      pvector<DB_VALUE> m_values;
+      std::vector<DB_VALUE> m_values;
       size_t m_size;
       size_t get_size ();
 
@@ -71,13 +67,12 @@ namespace memoize
   struct value
   {
     public:
-      value () = delete;
-      value (allocator<DB_VALUE> *allocator_p);
+      value ();
       ~value ();
 
       size_t get_size ();
 
-      pvector<DB_VALUE> m_values;
+      std::vector<DB_VALUE> m_values;
       size_t m_size;
   };
 
@@ -89,7 +84,7 @@ namespace memoize
       storage (THREAD_ENTRY *thread_p, size_t max_storage_size, int key_cnt, int value_cnt, VAL_LIST *val_list);
       ~storage();
       static storage *new_storage (THREAD_ENTRY *thread_p, size_t max_storage_size, xasl_node *xasl);
-      void init (pvector<DB_VALUE *> &key_ptr_src);
+      void init (std::vector<DB_VALUE *> &key_ptr_src);
       result_code get ();
       result_code put();
       void start_timer();
@@ -119,19 +114,14 @@ namespace memoize
       THREAD_ENTRY *m_thread_p;
       VAL_LIST *m_val_list;
 
-      allocator<DB_VALUE *> m_dbval_p_allocator;
-      allocator<DB_VALUE> m_dbval_allocator;
-      allocator<value *> m_value_allocator;
-      allocator<std::pair<key *const, value *>> m_key_value_allocator;
       fixed_allocator<key> m_key_fixed_allocator;
       size_t m_key_sz;
       size_t m_value_sz;
       size_t m_hash_sz;
       key *m_last_key;
-      pvector<DB_VALUE *> m_keyptr_src;
-      std::unordered_multimap<key *, value *, key::hash, key::equal, cubmem::private_allocator<std::pair<key *const, value *>>>
-      m_key_value_map;
-      pvector<value *> m_current_value_list;
+      std::vector<DB_VALUE *> m_keyptr_src;
+      std::unordered_multimap<key *, value *, key::hash, key::equal> m_key_value_map;
+      std::vector<value *> m_current_value_list;
       bool disabled;
       bool has_range;
       bool key_changed;

--- a/src/query/query_dump.c
+++ b/src/query/query_dump.c
@@ -3255,7 +3255,7 @@ qdump_print_stats_json (xasl_node * xasl_p, json_t * parent)
       scan = qdump_print_access_spec_stats_json (xasl_p->merge_spec);
     }
 
-  if (xasl_p->memoize_storage && xasl_p->memoize_storage->is_disabled () == false)
+  if (xasl_p->memoize_storage)
     {
       memoize = json_object ();
       json_object_set_new (memoize, "time", json_integer (TO_MSEC (xasl_p->memoize_storage->m_elapsed_time)));

--- a/src/query/query_dump.c
+++ b/src/query/query_dump.c
@@ -3255,13 +3255,14 @@ qdump_print_stats_json (xasl_node * xasl_p, json_t * parent)
       scan = qdump_print_access_spec_stats_json (xasl_p->merge_spec);
     }
 
-  if (xasl_p->memoize_storage)
+  if (xasl_p->memoize_storage && xasl_p->memoize_storage->is_disabled () == false)
     {
       memoize = json_object ();
       json_object_set_new (memoize, "time", json_integer (TO_MSEC (xasl_p->memoize_storage->m_elapsed_time)));
       json_object_set_new (memoize, "hit", json_integer (xasl_p->memoize_storage->hit));
       json_object_set_new (memoize, "miss", json_integer (xasl_p->memoize_storage->miss));
       json_object_set_new (memoize, "size", json_integer (xasl_p->memoize_storage->get_current_size () / 1024));
+      json_object_set_new (memoize, "enabled", json_boolean (xasl_p->memoize_storage->is_disabled ()? false : true));
       json_object_set_new (proc, "MEMOIZE", memoize);
     }
 
@@ -3742,9 +3743,10 @@ qdump_print_stats_text (FILE * fp, xasl_node * xasl_p, int indent)
   if (xasl_p->memoize_storage)
     {
       fprintf (fp, "%*c", indent, ' ');
-      fprintf (fp, "MEMOIZE (time: %d, hit: %lu, miss: %lu, size: %luKB)\n",
+      fprintf (fp, "MEMOIZE (time: %d, hit: %lu, miss: %lu, size: %luKB, enabled: %s)\n",
 	       TO_MSEC (xasl_p->memoize_storage->m_elapsed_time), xasl_p->memoize_storage->hit,
-	       xasl_p->memoize_storage->miss, xasl_p->memoize_storage->get_current_size () / 1024);
+	       xasl_p->memoize_storage->miss, xasl_p->memoize_storage->get_current_size () / 1024,
+	       xasl_p->memoize_storage->is_disabled ()? "false" : "true");
     }
 
   qdump_print_stats_text (fp, xasl_p->scan_ptr, indent);

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -2824,10 +2824,6 @@ qexec_clear_xasl_for_parallel_aptr (THREAD_ENTRY * thread_p, XASL_NODE * xasl, b
   assert (xasl->composite_lock.lockcomp.class_list == NULL);
   lock_abort_composite_lock (&xasl->composite_lock);
 #endif /* defined (ENABLE_COMPOSITE_LOCK) */
-  if (xasl->memoize_storage)
-    {
-      clear_memoize_storage (thread_p, xasl);
-    }
   /* clear subquery's result-cache */
   if (xasl->sub_xasl_id)
     {

--- a/src/query/xasl.h
+++ b/src/query/xasl.h
@@ -515,7 +515,6 @@ struct cte_proc_node
 #define XASL_SAMPLING_SCAN	       (0x1 << 17)	/* is sampling scan */
 #define XASL_USES_SQ_CACHE	       (0x1 << 18)	/* subquery uses result cache */
 #define XASL_NO_PARALLEL_SUBQUERY       (0x1 << 19)	/* disable parallel subquery */
-#define XASL_MEMOIZE_STORAGE	       (0x1 << 20)	/* enable memoize storage */
 
 #define XASL_IS_FLAGED(x, f)        (((x)->flag & (int) (f)) != 0)
 #define XASL_SET_FLAG(x, f)         (x)->flag |= (int) (f)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26345>

### Purpose

3가지 수정을 진행합니다.

1. memoize storage clear를 query 종료 시점으로 변경 (storage full 시 clear하지 않음)
2. memoize storage를 malloc()으로 할당하게 변경 (parallel aptr 등에서 clear 시 trace가 나타나지 않고, runtime에 할당해제하는 부하가 추가되기 때문)
3. memoize를 ndv로 막지 않고, 1000번 수행하여 hit ratio가 50%가 미달될 시 block하게 변경 (join 테이블 수가 3개 이상일 경우, 현재 예상 중복률을 구할 수 없기 때문)

