### PR TITLE
[CBRD-26390] Avoid error and treat as NO-OP when a non-owner grantor attempts to GRANT an owner’s class while running loaddb with --no-user-specified-name

### DIFF
--- a/src/object/authenticate_grant.cpp
+++ b/src/object/authenticate_grant.cpp
@@ -191,8 +191,15 @@ au_grant_class (MOP user, MOP class_mop, DB_AUTH type, bool grant_option)
 	}
       else if (ws_is_same_object (classobj->owner, user))
 	{
-	  error = ER_AU_CANT_GRANT_OWNER;
-	  er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, error, 1, MSGCAT_GET_GLOSSARY_MSG (MSGCAT_GLOSSARY_CLASS));
+	  if (db_get_client_type () == DB_CLIENT_TYPE_ADMIN_LOADDB_COMPAT)
+	    {
+	      goto fail_end;
+	    }
+	  else
+	    {
+	      error = ER_AU_CANT_GRANT_OWNER;
+	      er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, error, 1, MSGCAT_GET_GLOSSARY_MSG (MSGCAT_GLOSSARY_CLASS));
+	    }
 	}
       else if ((error = au_compare_grantor_and_return (&grantor, class_mop, type, Au_user, classobj->owner,
 			NULL)) != NO_ERROR)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26390

### Purpose

11.0v 이하에서 unload된 스키마가 소유자에게 동일 클래스를 다시 GRANT하려 할 때 발생하던 오류를, --no-user-specified-name 옵션 사용 시 NO-OP으로 처리하도록 수정 합니다.

```
$ cat testdb_schema
call [add_user]('USER1', '') on class [db_root];
call [find_user]('PUBLIC') on class [db_user] to [g_public];

CREATE CLASS [tbl] COLLATE utf8_bin;

ALTER CLASS [tbl] ADD ATTRIBUTE
       [i] integer;
call [change_owner]('tbl', 'USER1') on class [db_root];

GRANT SELECT ON [tbl] TO [USER1];

COMMIT WORK;

$ cubrid loaddb -u dba  -s testdb_schema  --no-user-specified-name testdb
Start schema loading.
Total        7 statements executed.
Schema loading from testdb_schema finished.
Statistics for Catalog classes have been updated.
```

### Implementation

N/A

### Remarks

- csql 에서 쿼리를 수행할 때는 기존과 동일한 에러가 출력 됩니다.
```sql
csql> create user user1;
Execute OK. (0.001000 sec) Committed. (0.002000 sec) 

1 command(s) successfully processed.
csql> create table user1.tbl (i int);
Execute OK. (0.003000 sec) Committed. (0.001000 sec) 

1 command(s) successfully processed.
csql> grant select on user1.tbl to user1;

In the command from line 1,

ERROR: Cannot issue GRANT/REVOKE to owner of a class.
```