### PR TITLE
[CBRD-26390] (backport) Avoid error and treat as NO-OP when a non-owner grantor attempts to GRANT an owner’s class while running loaddb with --no-user-specified-name

### DIFF
--- a/.github/workflows/cppcheck-spr-list
+++ b/.github/workflows/cppcheck-spr-list
@@ -2,3 +2,4 @@ syntaxError
 objectIndex
 unknownMacro
 internalAstError
+preprocessorErrorDirective

--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -4658,8 +4658,15 @@ au_grant (MOP user, MOP class_mop, DB_AUTH type, bool grant_option)
     {
       if (ws_is_same_object (classobj->owner, user))
 	{
-	  error = ER_AU_CANT_GRANT_OWNER;
-	  er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, error, 0);
+	  if (db_get_client_type () == DB_CLIENT_TYPE_ADMIN_LOADDB_COMPAT)
+	    {
+	      goto fail_end;
+	    }
+	  else
+	    {
+	      error = ER_AU_CANT_GRANT_OWNER;
+	      er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, error, 0);
+	    }
 	}
       else if ((error = check_grant_option (class_mop, classobj, type)) == NO_ERROR)
 	{
@@ -5018,6 +5025,25 @@ propagate_revoke (AU_GRANT * grant_list, MOP owner, DB_AUTH mask)
   DB_SET *grants;
   AU_GRANT *g;
   int i, length;
+
+  /* 
+   * This function immediately returns NO_ERROR to skip propagate_revoke() for the following two reasons.
+   *
+   * 1. In versions 11.3 and below, propagate_revoke (cascade revoke) does not work correctly.
+   *    (fixed to work correctly from version 11.4 onwards)
+   * 2. In debug mode, when the granter is different from the owner, propagate_revoke executes and
+   *    an assert statement in au_propagate_del_new_auth() triggers, causing a core dump.
+   *    Example:
+   *       CALL LOGIN('dba','') on class db_user;
+   *       CREATE USER user1;
+   *       CREATE USER user2;
+   *       CREATE USER user3;
+   *       CREATE TABLE user1.tbl (i int);
+   *       GRANT select ON user1.tbl TO user2;
+   *       GRANT select ON user1.tbl TO user3;
+   *       REVOKE select ON user1.tbl FROM user2;
+   */
+  return NO_ERROR;
 
   /* determine invalid grants */
   map_grant_list (grant_list, owner);

--- a/src/object/authenticate.c
+++ b/src/object/authenticate.c
@@ -5045,6 +5045,7 @@ propagate_revoke (AU_GRANT * grant_list, MOP owner, DB_AUTH mask)
    */
   return NO_ERROR;
 
+#if 0
   /* determine invalid grants */
   map_grant_list (grant_list, owner);
 
@@ -5133,6 +5134,7 @@ propagate_revoke (AU_GRANT * grant_list, MOP owner, DB_AUTH mask)
     }
 
   return (error);
+#endif
 }
 
 /*

--- a/src/object/authenticate.h
+++ b/src/object/authenticate.h
@@ -31,6 +31,10 @@
 #error Does not belong to server module
 #endif /* defined (SERVER_MODE) */
 
+#ifndef __cplusplus
+#error Requires C++
+#endif // not c++
+
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/src/object/authenticate.h
+++ b/src/object/authenticate.h
@@ -31,10 +31,6 @@
 #error Does not belong to server module
 #endif /* defined (SERVER_MODE) */
 
-#ifndef __cplusplus
-#error Requires C++
-#endif // not c++
-
 #include <stdio.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26390

### Purpose
- pr (https://github.com/CUBRID/cubrid/pull/6654) 의 내용을 백포트 합니다.

- 11.0v 이하에서 unload된 스키마가 소유자에게 동일 클래스를 다시 GRANT하려 할 때 발생하던 오류를, --no-user-specified-name 옵션 사용 시 NO-OP으로 처리하도록 수정 합니다.

### Implementation

N/A

### Remarks

1. csql 에서 쿼리를 수행할 때는 기존과 동일한 에러가 출력 됩니다.
```sql
csql> create user user1;
Execute OK. (0.001000 sec) Committed. (0.000000 sec) 

1 command(s) successfully processed.
csql> create table user1.tbl (i int);
Execute OK. (0.004000 sec) Committed. (0.000000 sec) 

1 command(s) successfully processed.
csql> grant select on user1.tbl to user1;

In the command from line 1,

ERROR: Cannot issue GRANT/REVOKE to owner of a class.
```
#### 2. 아래 두 가지 이유로 propagate_revoke() 함수를 바로 NO_ERROR를 반환하여 skip하도록 수정합니다.
- 11.3 이하 버전에서는 propagate_revoke (cascade revoke) 수행이 정상적으로 동작하지 않습니다. (11.4 버전부터 정상적으로 동작하도록 수정됨)
- debug mode에서 grantor가 owner와 다르고, grantor가 2개 이상일 때 revoke를 수행하면 propagate_revoke가 동작하며, au_propagate_del_new_auth() 함수 내에서 assert 문이 실행되어 core dump가 발생합니다.
```sql
CALL LOGIN('dba','') on class db_user;
CREATE USER user1;
CREATE USER user2;
CREATE USER user3;
CREATE TABLE user1.tbl (i int);
GRANT select ON user1.tbl TO user2;
GRANT select ON user1.tbl TO user3;
REVOKE select ON user1.tbl FROM user2; // propagate_revoke() -> au_propagate_del_new_auth() -> db_get_int() 함수 내에서 assert 문이 동작하여 core dump가 발생한다.
```