### PR TITLE
[CBRD-26396] enhance throughput performance when scan multi-key index using domain caching

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -2008,17 +2008,17 @@ qexec_clear_access_spec_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl_p, ACCES
 	      heap_attrinfo_end (thread_p, isidp->rest_attrs.attr_cache);
 	      isidp->caches_inited = false;
 	    }
-	  if (isidp->outer_table_midxkey_build_domains)
+	  if (isidp->prebuilt_midxkey_domains)
 	    {
 	      for (int i = 0; i < isidp->indx_info->key_info.key_cnt; i++)
 		{
-		  if (isidp->outer_table_midxkey_build_domains[i])
+		  if (isidp->prebuilt_midxkey_domains[i])
 		    {
-		      tp_domain_free (isidp->outer_table_midxkey_build_domains[i]);
-		      isidp->outer_table_midxkey_build_domains[i] = NULL;
+		      tp_domain_free (isidp->prebuilt_midxkey_domains[i]);
+		      isidp->prebuilt_midxkey_domains[i] = NULL;
 		    }
 		}
-	      db_private_free_and_init (thread_p, isidp->outer_table_midxkey_build_domains);
+	      db_private_free_and_init (thread_p, isidp->prebuilt_midxkey_domains);
 	    }
 	  break;
 	case S_INDX_KEY_INFO_SCAN:

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -2004,6 +2004,11 @@ qexec_clear_access_spec_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl_p, ACCES
 	      heap_attrinfo_end (thread_p, isidp->rest_attrs.attr_cache);
 	      isidp->caches_inited = false;
 	    }
+	  if (isidp->outer_table_midxkey_build_domain)
+	    {
+	      tp_domain_free (isidp->outer_table_midxkey_build_domain);
+	      isidp->outer_table_midxkey_build_domain = NULL;
+	    }
 	  break;
 	case S_INDX_KEY_INFO_SCAN:
 	  isidp = &p->s_id.s.isid;

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -2004,10 +2004,17 @@ qexec_clear_access_spec_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl_p, ACCES
 	      heap_attrinfo_end (thread_p, isidp->rest_attrs.attr_cache);
 	      isidp->caches_inited = false;
 	    }
-	  if (isidp->outer_table_midxkey_build_domain)
+	  if (isidp->outer_table_midxkey_build_domains)
 	    {
-	      tp_domain_free (isidp->outer_table_midxkey_build_domain);
-	      isidp->outer_table_midxkey_build_domain = NULL;
+	      for (int i = 0; i < isidp->indx_info->key_info.key_cnt; i++)
+		{
+		  if (isidp->outer_table_midxkey_build_domains[i])
+		    {
+		      tp_domain_free (isidp->outer_table_midxkey_build_domains[i]);
+		      isidp->outer_table_midxkey_build_domains[i] = NULL;
+		    }
+		}
+	      db_private_free_and_init (thread_p, isidp->outer_table_midxkey_build_domains);
 	    }
 	  break;
 	case S_INDX_KEY_INFO_SCAN:

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -165,7 +165,8 @@ static int scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, b
 				   TP_DOMAIN * btree_domainp, int num_term, REGU_VARIABLE * func, VAL_DESCR * vd,
 				   int key_minmax, bool is_iss, TP_DOMAIN ** outer_table_midxkey_build_domain);
 static int scan_regu_key_to_index_key (THREAD_ENTRY * thread_p, KEY_RANGE * key_ranges, KEY_VAL_RANGE * key_val_range,
-				       INDX_SCAN_ID * iscan_id, TP_DOMAIN * btree_domainp, VAL_DESCR * vd);
+				       INDX_SCAN_ID * iscan_id, TP_DOMAIN * btree_domainp, VAL_DESCR * vd,
+				       int key_range_idx);
 static int scan_get_index_oidset (THREAD_ENTRY * thread_p, SCAN_ID * s_id, DB_BIGINT * key_limit_upper,
 				  DB_BIGINT * key_limit_lower);
 static void scan_init_scan_id (SCAN_ID * scan_id, bool force_select_lock, SCAN_OPERATION_TYPE scan_op_type, int fixed,
@@ -305,7 +306,7 @@ scan_init_index_scan (INDX_SCAN_ID * isidp, struct btree_iscan_oid_list *oid_lis
   isidp->need_count_only = false;
   isidp->check_not_vacuumed = false;
   isidp->not_vacuumed_res = DISK_VALID;
-  isidp->outer_table_midxkey_build_domain = NULL;
+  isidp->outer_table_midxkey_build_domains = NULL;
 }
 
 /*
@@ -1488,7 +1489,7 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
   TP_DOMAIN dom_buf;
   DB_VALUE *coerced_values = NULL;
   bool *has_coerced_values = NULL;
-  bool new_setdomain_built = *outer_table_midxkey_build_domain != NULL;
+  bool new_setdomain_built = *outer_table_midxkey_build_domain != NULL && !is_iss;
 
   *indexable = false;
 
@@ -1645,6 +1646,10 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
    * Remaining key values including MAX_COLUMN position will be filled as NULL
    * by btree_coerce_key at the end of this function.
    */
+  if (!need_new_setdomain)
+    {
+      new_setdomain_built = false;
+    }
   if (new_setdomain_built)
     {
       prebuilt_domain = (*outer_table_midxkey_build_domain)->setdomain;
@@ -1909,7 +1914,7 @@ err_exit:
  */
 static int
 scan_regu_key_to_index_key (THREAD_ENTRY * thread_p, KEY_RANGE * key_ranges, KEY_VAL_RANGE * key_val_range,
-			    INDX_SCAN_ID * iscan_id, TP_DOMAIN * btree_domainp, VAL_DESCR * vd)
+			    INDX_SCAN_ID * iscan_id, TP_DOMAIN * btree_domainp, VAL_DESCR * vd, int key_range_idx)
 {
   bool indexable = true;
   int key_minmax;
@@ -1978,7 +1983,7 @@ scan_regu_key_to_index_key (THREAD_ENTRY * thread_p, KEY_RANGE * key_ranges, KEY
 	  ret =
 	    scan_dbvals_to_midxkey (thread_p, &key_val_range->key1, &indexable, btree_domainp,
 				    key_val_range->num_index_term, key_ranges->key1, vd, key_minmax, iscan_id->iss.use,
-				    &iscan_id->outer_table_midxkey_build_domain);
+				    &(iscan_id->outer_table_midxkey_build_domains[key_range_idx]));
 	}
       else
 	{
@@ -2026,7 +2031,7 @@ scan_regu_key_to_index_key (THREAD_ENTRY * thread_p, KEY_RANGE * key_ranges, KEY
 	  ret =
 	    scan_dbvals_to_midxkey (thread_p, &key_val_range->key2, &indexable, btree_domainp,
 				    key_val_range->num_index_term, key_ranges->key2, vd, key_minmax, iscan_id->iss.use,
-				    &iscan_id->outer_table_midxkey_build_domain);
+				    &(iscan_id->outer_table_midxkey_build_domains[key_range_idx]));
 	}
       else
 	{
@@ -2271,7 +2276,7 @@ scan_get_index_oidset (THREAD_ENTRY * thread_p, SCAN_ID * s_id, DB_BIGINT * key_
 
 	  ret =
 	    scan_regu_key_to_index_key (thread_p, &key_ranges[i], &key_vals[i], iscan_id, bts->btid_int.key_type,
-					s_id->vd);
+					s_id->vd, i);
 
 	  if (ret != NO_ERROR)
 	    {
@@ -3330,6 +3335,20 @@ scan_open_index_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
 
     scan_id->scan_stats.multi_range_opt = isidp->multi_range_opt.use;
   }
+
+  if (isidp->outer_table_midxkey_build_domains == NULL && isidp->indx_info->key_info.key_cnt > 0)
+    {
+      isidp->outer_table_midxkey_build_domains =
+	(TP_DOMAIN **) db_private_alloc (thread_p, isidp->indx_info->key_info.key_cnt * sizeof (TP_DOMAIN *));
+      if (isidp->outer_table_midxkey_build_domains == NULL)
+	{
+	  return ER_FAILED;
+	}
+      for (int i = 0; i < isidp->indx_info->key_info.key_cnt; i++)
+	{
+	  isidp->outer_table_midxkey_build_domains[i] = NULL;
+	}
+    }
 
   return ret;
 
@@ -4855,6 +4874,21 @@ scan_close_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 
     case S_INDX_SCAN:
       isidp = &scan_id->s.isid;
+
+      if (isidp->outer_table_midxkey_build_domains != NULL)
+	{
+	  for (int i = 0; i < isidp->indx_info->key_info.key_cnt; i++)
+	    {
+	      if (isidp->outer_table_midxkey_build_domains[i])
+		{
+		  tp_domain_free (isidp->outer_table_midxkey_build_domains[i]);
+		  isidp->outer_table_midxkey_build_domains[i] = NULL;
+		}
+	    }
+	  db_private_free_and_init (thread_p, isidp->outer_table_midxkey_build_domains);
+	  isidp->outer_table_midxkey_build_domains = NULL;
+	}
+
       if (isidp->key_vals)
 	{
 	  isidp->key_vals = NULL;

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -163,7 +163,7 @@ static int reverse_key_list (KEY_VAL_RANGE * key_vals, int key_cnt);
 static int check_key_vals (KEY_VAL_RANGE * key_vals, int key_cnt, QPROC_KEY_VAL_FU * chk_fn);
 static int scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * indexal,
 				   TP_DOMAIN * btree_domainp, int num_term, REGU_VARIABLE * func, VAL_DESCR * vd,
-				   int key_minmax, bool is_iss);
+				   int key_minmax, bool is_iss, TP_DOMAIN ** outer_table_midxkey_build_domain);
 static int scan_regu_key_to_index_key (THREAD_ENTRY * thread_p, KEY_RANGE * key_ranges, KEY_VAL_RANGE * key_val_range,
 				       INDX_SCAN_ID * iscan_id, TP_DOMAIN * btree_domainp, VAL_DESCR * vd);
 static int scan_get_index_oidset (THREAD_ENTRY * thread_p, SCAN_ID * s_id, DB_BIGINT * key_limit_upper,
@@ -305,6 +305,7 @@ scan_init_index_scan (INDX_SCAN_ID * isidp, struct btree_iscan_oid_list *oid_lis
   isidp->need_count_only = false;
   isidp->check_not_vacuumed = false;
   isidp->not_vacuumed_res = DISK_VALID;
+  isidp->outer_table_midxkey_build_domain = NULL;
 }
 
 /*
@@ -1463,7 +1464,8 @@ check_key_vals (KEY_VAL_RANGE * key_vals, int key_cnt, QPROC_KEY_VAL_FU * key_va
  */
 static int
 scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * indexable, TP_DOMAIN * btree_domainp,
-			int num_term, REGU_VARIABLE * func, VAL_DESCR * vd, int key_minmax, bool is_iss)
+			int num_term, REGU_VARIABLE * func, VAL_DESCR * vd, int key_minmax, bool is_iss,
+			TP_DOMAIN ** outer_table_midxkey_build_domain)
 {
   int ret = NO_ERROR;
   DB_VALUE *val = NULL;
@@ -1481,11 +1483,12 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
 
   bool need_new_setdomain = false;
   TP_DOMAIN *idx_setdomain = NULL, *vals_setdomain = NULL;
-  TP_DOMAIN *idx_dom = NULL, *val_dom = NULL, *dom = NULL, *next = NULL;
+  TP_DOMAIN *idx_dom = NULL, *val_dom = NULL, *dom = NULL, *next = NULL, *prebuilt_domain = NULL;
   DB_TYPE idx_type_id;
   TP_DOMAIN dom_buf;
   DB_VALUE *coerced_values = NULL;
   bool *has_coerced_values = NULL;
+  bool new_setdomain_built = *outer_table_midxkey_build_domain != NULL;
 
   *indexable = false;
 
@@ -1642,6 +1645,10 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
    * Remaining key values including MAX_COLUMN position will be filled as NULL
    * by btree_coerce_key at the end of this function.
    */
+  if (new_setdomain_built)
+    {
+      prebuilt_domain = (*outer_table_midxkey_build_domain)->setdomain;
+    }
   for (operand = func->value.funcp->operand, idx_dom = idx_setdomain, natts = 0;
        operand != NULL && idx_dom != NULL
        && (midxkey.min_max_val.position == -1 || natts < midxkey.min_max_val.position);
@@ -1662,7 +1669,12 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
 	    }
 	}
 
-      if (need_new_setdomain == true)
+      if (new_setdomain_built)
+	{
+	  dom = prebuilt_domain;
+	  prebuilt_domain = prebuilt_domain->next;
+	}
+      else if (need_new_setdomain == true)
 	{
 	  /* make a value's domain */
 	  val_dom = tp_domain_resolve_value (val, &dom_buf);
@@ -1716,7 +1728,7 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
     }
 
   /* add more domain to setdomain for partial key */
-  if (need_new_setdomain == true)
+  if (need_new_setdomain == true && !new_setdomain_built)
     {
       assert (dom != NULL);
       if (idx_dom != NULL)
@@ -1748,7 +1760,16 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
   or_advance (&buf, or_multi_header_size (idx_ncols));
 
   /* generate multi columns key (values -> midxkey.buf) */
-  for (operand = func->value.funcp->operand, i = 0, dom = (vals_setdomain != NULL) ? vals_setdomain : idx_setdomain;
+  if (new_setdomain_built)
+    {
+      dom = (*outer_table_midxkey_build_domain)->setdomain;
+    }
+  else
+    {
+      dom = (vals_setdomain != NULL) ? vals_setdomain : idx_setdomain;
+    }
+
+  for (operand = func->value.funcp->operand, i = 0;
        operand != NULL && dom != NULL && (i < natts); operand = operand->next, dom = dom->next, i++)
     {
       if (has_coerced_values != NULL && has_coerced_values[i] == true)
@@ -1810,10 +1831,16 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
 	}
 
       midxkey.domain = tp_domain_cache (midxkey.domain);
+      *outer_table_midxkey_build_domain = midxkey.domain;
     }
   else
     {
       midxkey.domain = btree_domainp;
+    }
+
+  if (new_setdomain_built)
+    {
+      midxkey.domain = *outer_table_midxkey_build_domain;
     }
 
   ret = db_make_midxkey (retval, &midxkey);
@@ -1950,7 +1977,8 @@ scan_regu_key_to_index_key (THREAD_ENTRY * thread_p, KEY_RANGE * key_ranges, KEY
 
 	  ret =
 	    scan_dbvals_to_midxkey (thread_p, &key_val_range->key1, &indexable, btree_domainp,
-				    key_val_range->num_index_term, key_ranges->key1, vd, key_minmax, iscan_id->iss.use);
+				    key_val_range->num_index_term, key_ranges->key1, vd, key_minmax, iscan_id->iss.use,
+				    &iscan_id->outer_table_midxkey_build_domain);
 	}
       else
 	{
@@ -1997,7 +2025,8 @@ scan_regu_key_to_index_key (THREAD_ENTRY * thread_p, KEY_RANGE * key_ranges, KEY
 
 	  ret =
 	    scan_dbvals_to_midxkey (thread_p, &key_val_range->key2, &indexable, btree_domainp,
-				    key_val_range->num_index_term, key_ranges->key2, vd, key_minmax, iscan_id->iss.use);
+				    key_val_range->num_index_term, key_ranges->key2, vd, key_minmax, iscan_id->iss.use,
+				    &iscan_id->outer_table_midxkey_build_domain);
 	}
       else
 	{

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -163,7 +163,7 @@ static int reverse_key_list (KEY_VAL_RANGE * key_vals, int key_cnt);
 static int check_key_vals (KEY_VAL_RANGE * key_vals, int key_cnt, QPROC_KEY_VAL_FU * chk_fn);
 static int scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * indexal,
 				   TP_DOMAIN * btree_domainp, int num_term, REGU_VARIABLE * func, VAL_DESCR * vd,
-				   int key_minmax, bool is_iss, TP_DOMAIN ** outer_table_midxkey_build_domain);
+				   int key_minmax, bool is_iss, TP_DOMAIN ** prebuilt_midxkey_domain);
 static int scan_regu_key_to_index_key (THREAD_ENTRY * thread_p, KEY_RANGE * key_ranges, KEY_VAL_RANGE * key_val_range,
 				       INDX_SCAN_ID * iscan_id, TP_DOMAIN * btree_domainp, VAL_DESCR * vd,
 				       int key_range_idx);
@@ -306,7 +306,7 @@ scan_init_index_scan (INDX_SCAN_ID * isidp, struct btree_iscan_oid_list *oid_lis
   isidp->need_count_only = false;
   isidp->check_not_vacuumed = false;
   isidp->not_vacuumed_res = DISK_VALID;
-  isidp->outer_table_midxkey_build_domains = NULL;
+  isidp->prebuilt_midxkey_domains = NULL;
 }
 
 /*
@@ -1466,7 +1466,7 @@ check_key_vals (KEY_VAL_RANGE * key_vals, int key_cnt, QPROC_KEY_VAL_FU * key_va
 static int
 scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * indexable, TP_DOMAIN * btree_domainp,
 			int num_term, REGU_VARIABLE * func, VAL_DESCR * vd, int key_minmax, bool is_iss,
-			TP_DOMAIN ** outer_table_midxkey_build_domain)
+			TP_DOMAIN ** prebuilt_midxkey_domain)
 {
   int ret = NO_ERROR;
   DB_VALUE *val = NULL;
@@ -1489,7 +1489,7 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
   TP_DOMAIN dom_buf;
   DB_VALUE *coerced_values = NULL;
   bool *has_coerced_values = NULL;
-  bool new_setdomain_built = *outer_table_midxkey_build_domain != NULL;
+  bool new_setdomain_built = *prebuilt_midxkey_domain != NULL;
 
   *indexable = false;
 
@@ -1652,7 +1652,7 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
     }
   if (new_setdomain_built)
     {
-      prebuilt_domain = (*outer_table_midxkey_build_domain)->setdomain;
+      prebuilt_domain = (*prebuilt_midxkey_domain)->setdomain;
     }
   for (operand = func->value.funcp->operand, idx_dom = idx_setdomain, natts = 0;
        operand != NULL && idx_dom != NULL
@@ -1775,7 +1775,7 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
   /* generate multi columns key (values -> midxkey.buf) */
   if (new_setdomain_built)
     {
-      dom = (*outer_table_midxkey_build_domain)->setdomain;
+      dom = (*prebuilt_midxkey_domain)->setdomain;
     }
   else
     {
@@ -1844,7 +1844,7 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
 	}
 
       midxkey.domain = tp_domain_cache (midxkey.domain);
-      *outer_table_midxkey_build_domain = midxkey.domain;
+      *prebuilt_midxkey_domain = midxkey.domain;
     }
   else
     {
@@ -1853,7 +1853,7 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
 
   if (new_setdomain_built)
     {
-      midxkey.domain = *outer_table_midxkey_build_domain;
+      midxkey.domain = *prebuilt_midxkey_domain;
     }
 
   ret = db_make_midxkey (retval, &midxkey);
@@ -1991,7 +1991,7 @@ scan_regu_key_to_index_key (THREAD_ENTRY * thread_p, KEY_RANGE * key_ranges, KEY
 	  ret =
 	    scan_dbvals_to_midxkey (thread_p, &key_val_range->key1, &indexable, btree_domainp,
 				    key_val_range->num_index_term, key_ranges->key1, vd, key_minmax, iscan_id->iss.use,
-				    &(iscan_id->outer_table_midxkey_build_domains[key_range_idx]));
+				    &(iscan_id->prebuilt_midxkey_domains[key_range_idx]));
 	}
       else
 	{
@@ -2039,7 +2039,7 @@ scan_regu_key_to_index_key (THREAD_ENTRY * thread_p, KEY_RANGE * key_ranges, KEY
 	  ret =
 	    scan_dbvals_to_midxkey (thread_p, &key_val_range->key2, &indexable, btree_domainp,
 				    key_val_range->num_index_term, key_ranges->key2, vd, key_minmax, iscan_id->iss.use,
-				    &(iscan_id->outer_table_midxkey_build_domains[key_range_idx]));
+				    &(iscan_id->prebuilt_midxkey_domains[key_range_idx]));
 	}
       else
 	{
@@ -3344,17 +3344,17 @@ scan_open_index_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
     scan_id->scan_stats.multi_range_opt = isidp->multi_range_opt.use;
   }
 
-  if (isidp->outer_table_midxkey_build_domains == NULL && isidp->indx_info->key_info.key_cnt > 0)
+  if (isidp->prebuilt_midxkey_domains == NULL && isidp->indx_info->key_info.key_cnt > 0)
     {
-      isidp->outer_table_midxkey_build_domains =
+      isidp->prebuilt_midxkey_domains =
 	(TP_DOMAIN **) db_private_alloc (thread_p, isidp->indx_info->key_info.key_cnt * sizeof (TP_DOMAIN *));
-      if (isidp->outer_table_midxkey_build_domains == NULL)
+      if (isidp->prebuilt_midxkey_domains == NULL)
 	{
 	  return ER_FAILED;
 	}
       for (int i = 0; i < isidp->indx_info->key_info.key_cnt; i++)
 	{
-	  isidp->outer_table_midxkey_build_domains[i] = NULL;
+	  isidp->prebuilt_midxkey_domains[i] = NULL;
 	}
     }
 
@@ -4883,18 +4883,17 @@ scan_close_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
     case S_INDX_SCAN:
       isidp = &scan_id->s.isid;
 
-      if (isidp->outer_table_midxkey_build_domains != NULL)
+      if (isidp->prebuilt_midxkey_domains != NULL)
 	{
 	  for (int i = 0; i < isidp->indx_info->key_info.key_cnt; i++)
 	    {
-	      if (isidp->outer_table_midxkey_build_domains[i])
+	      if (isidp->prebuilt_midxkey_domains[i])
 		{
-		  tp_domain_free (isidp->outer_table_midxkey_build_domains[i]);
-		  isidp->outer_table_midxkey_build_domains[i] = NULL;
+		  tp_domain_free (isidp->prebuilt_midxkey_domains[i]);
+		  isidp->prebuilt_midxkey_domains[i] = NULL;
 		}
 	    }
-	  db_private_free_and_init (thread_p, isidp->outer_table_midxkey_build_domains);
-	  isidp->outer_table_midxkey_build_domains = NULL;
+	  db_private_free_and_init (thread_p, isidp->prebuilt_midxkey_domains);
 	}
 
       if (isidp->key_vals)

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -1489,7 +1489,7 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
   TP_DOMAIN dom_buf;
   DB_VALUE *coerced_values = NULL;
   bool *has_coerced_values = NULL;
-  bool new_setdomain_built = *outer_table_midxkey_build_domain != NULL && !is_iss;
+  bool new_setdomain_built = *outer_table_midxkey_build_domain != NULL;
 
   *indexable = false;
 
@@ -1660,6 +1660,7 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
        operand = operand->next, idx_dom = idx_dom->next, natts++)
     {
       /* If there is coerced value, we will use it regardless of whether a new setdomain is required or not. */
+    retry:
       if (has_coerced_values != NULL && has_coerced_values[natts] == true)
 	{
 	  assert (coerced_values != NULL);
@@ -1678,6 +1679,13 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
 	{
 	  dom = prebuilt_domain;
 	  prebuilt_domain = prebuilt_domain->next;
+	  if (natts == 0 && dom->type->id == DB_TYPE_NULL && !DB_IS_NULL (val))
+	    {
+	      need_new_setdomain = true;
+	      new_setdomain_built = false;
+	      dom = NULL;
+	      goto retry;
+	    }
 	}
       else if (need_new_setdomain == true)
 	{
@@ -1793,7 +1801,7 @@ scan_dbvals_to_midxkey (THREAD_ENTRY * thread_p, DB_VALUE * retval, bool * index
 
       or_multi_put_element_offset (nullmap_ptr, idx_ncols, CAST_BUFLEN (buf.ptr - buf.buffer), i);
 
-      if (DB_IS_NULL (val))
+      if (DB_IS_NULL (val) || dom->type->id == DB_TYPE_NULL)
 	{
 	  if (is_iss && i == 0)
 	    {

--- a/src/query/scan_manager.h
+++ b/src/query/scan_manager.h
@@ -273,7 +273,7 @@ struct indx_scan_id
   bool check_not_vacuumed;	/* if true then during index scan, the entries will be checked if they should've been
 				 * vacuumed. Used in checkdb. */
   DISK_ISVALID not_vacuumed_res;	/* The result of not vacuumed checking operation */
-  TP_DOMAIN **outer_table_midxkey_build_domains;
+  TP_DOMAIN **prebuilt_midxkey_domains;
 };
 
 typedef struct index_node_scan_id INDEX_NODE_SCAN_ID;

--- a/src/query/scan_manager.h
+++ b/src/query/scan_manager.h
@@ -273,7 +273,7 @@ struct indx_scan_id
   bool check_not_vacuumed;	/* if true then during index scan, the entries will be checked if they should've been
 				 * vacuumed. Used in checkdb. */
   DISK_ISVALID not_vacuumed_res;	/* The result of not vacuumed checking operation */
-  TP_DOMAIN *outer_table_midxkey_build_domain;
+  TP_DOMAIN **outer_table_midxkey_build_domains;
 };
 
 typedef struct index_node_scan_id INDEX_NODE_SCAN_ID;

--- a/src/query/scan_manager.h
+++ b/src/query/scan_manager.h
@@ -273,6 +273,7 @@ struct indx_scan_id
   bool check_not_vacuumed;	/* if true then during index scan, the entries will be checked if they should've been
 				 * vacuumed. Used in checkdb. */
   DISK_ISVALID not_vacuumed_res;	/* The result of not vacuumed checking operation */
+  TP_DOMAIN *outer_table_midxkey_build_domain;
 };
 
 typedef struct index_node_scan_id INDEX_NODE_SCAN_ID;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26396>

### Purpose

t1→t2 조인에서 t2의 multi-key index scan이 필요하고, host variable과의 equal 조건 평가로 인해 coerce가 수행되는 경우, multi-key index의 domain 재구성이 요구되면 t1의 각 row마다 t2 index scan용 domain을 매번 재구성하게 된다.
그 결과, 쿼리 실행 동안 t1 결과 건수 × multi-key index 컬럼 수 만큼 tp_domain_alloc이 호출되며, 동시에 실행되는 경우 area_alloc 호출 증가로 성능 병목이 발생한다.
coerce 후 재구성된 domain을 index scan id에 캐싱하면, tp_domain_alloc 호출을 최초 index scan 시 1회로 제한할 수 있다.

### Implementation

isidp->outer_table_midxkey_build_domains를 추가하여, 각 key_range마다 빌드한 coerce domain을 캐싱한다.
