### PR TITLE
[CBRD-26398] 커버링 인덱스 스캔 reset 시 list_id를 truncate 하도록 수정

### DIFF
--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -3201,6 +3201,90 @@ error_exit:
   return er_errid ();
 }
 
+int
+qfile_truncate_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID * list_id)
+{
+  int error_code = NO_ERROR;
+  int i;
+  PAGE_PTR page_p;
+  QFILE_PAGE_HEADER pgheader = { 0, NULL_PAGEID, NULL_PAGEID, 0, NULL_PAGEID, NULL_VOLID, NULL_VOLID, NULL_VOLID };
+  QMGR_TEMP_FILE *tfile_vfid_p = list_id->tfile_vfid;
+  if (list_id->last_pgptr != NULL)
+    {
+      qfile_close_list (thread_p, list_id);
+    }
+
+  list_id->tuple_cnt = 0;
+  list_id->page_cnt = 0;
+  list_id->first_vpid.pageid = NULL_PAGEID;
+  list_id->first_vpid.volid = NULL_VOLID;
+  list_id->last_vpid.pageid = NULL_PAGEID;
+  list_id->last_vpid.volid = NULL_VOLID;
+  list_id->last_pgptr = NULL;
+  list_id->last_offset = QFILE_NULL_PAGE_OFFSET;
+  list_id->lasttpl_len = 0;
+
+  switch (tfile_vfid_p->membuf_type)
+    {
+    case TEMP_FILE_MEMBUF_NONE:
+      break;
+    case TEMP_FILE_MEMBUF_NORMAL:
+      {
+	tfile_vfid_p->membuf_last = -1;
+	page_p = (PAGE_PTR) ((PAGE_PTR) tfile_vfid_p->membuf
+			     + DB_ALIGN (sizeof (PAGE_PTR) * tfile_vfid_p->membuf_npages, MAX_ALIGNMENT));
+	for (i = 0; i < tfile_vfid_p->membuf_npages; i++)
+	  {
+	    tfile_vfid_p->membuf[i] = page_p;
+	    OR_PUT_INT ((page_p) + QFILE_TUPLE_COUNT_OFFSET, pgheader.pg_tplcnt);
+	    OR_PUT_INT ((page_p) + QFILE_PREV_PAGE_ID_OFFSET, pgheader.prev_pgid);
+	    OR_PUT_INT ((page_p) + QFILE_NEXT_PAGE_ID_OFFSET, pgheader.next_pgid);
+	    OR_PUT_INT ((page_p) + QFILE_LAST_TUPLE_OFFSET, pgheader.lasttpl_off);
+	    OR_PUT_INT ((page_p) + QFILE_OVERFLOW_PAGE_ID_OFFSET, pgheader.ovfl_pgid);
+	    OR_PUT_SHORT ((page_p) + QFILE_PREV_VOL_ID_OFFSET, pgheader.prev_volid);
+	    OR_PUT_SHORT ((page_p) + QFILE_NEXT_VOL_ID_OFFSET, pgheader.next_volid);
+	    OR_PUT_SHORT ((page_p) + QFILE_OVERFLOW_VOL_ID_OFFSET, pgheader.ovfl_volid);
+#if !defined(NDEBUG)
+	    /* suppress valgrind UMW error */
+	    memset (page_p + QFILE_RESERVED_OFFSET, 0, QFILE_PAGE_HEADER_SIZE - QFILE_RESERVED_OFFSET);
+#endif
+	    page_p += DB_PAGESIZE;
+	  }
+      }
+      break;
+    case TEMP_FILE_MEMBUF_KEY_BUFFER:
+      {
+	tfile_vfid_p->membuf_last = -1;
+	page_p = (PAGE_PTR) ((PAGE_PTR) tfile_vfid_p->membuf
+			     + DB_ALIGN (sizeof (PAGE_PTR) * tfile_vfid_p->membuf_npages, MAX_ALIGNMENT));
+	for (i = 0; i < tfile_vfid_p->membuf_npages; i++)
+	  {
+	    tfile_vfid_p->membuf[i] = page_p;
+	    OR_PUT_INT ((page_p) + QFILE_TUPLE_COUNT_OFFSET, pgheader.pg_tplcnt);
+	    OR_PUT_INT ((page_p) + QFILE_PREV_PAGE_ID_OFFSET, pgheader.prev_pgid);
+	    OR_PUT_INT ((page_p) + QFILE_NEXT_PAGE_ID_OFFSET, pgheader.next_pgid);
+	    OR_PUT_INT ((page_p) + QFILE_LAST_TUPLE_OFFSET, pgheader.lasttpl_off);
+	    OR_PUT_INT ((page_p) + QFILE_OVERFLOW_PAGE_ID_OFFSET, pgheader.ovfl_pgid);
+	    OR_PUT_SHORT ((page_p) + QFILE_PREV_VOL_ID_OFFSET, pgheader.prev_volid);
+	    OR_PUT_SHORT ((page_p) + QFILE_NEXT_VOL_ID_OFFSET, pgheader.next_volid);
+	    OR_PUT_SHORT ((page_p) + QFILE_OVERFLOW_VOL_ID_OFFSET, pgheader.ovfl_volid);
+#if !defined(NDEBUG)
+	    /* suppress valgrind UMW error */
+	    memset (page_p + QFILE_RESERVED_OFFSET, 0, QFILE_PAGE_HEADER_SIZE - QFILE_RESERVED_OFFSET);
+#endif
+	    page_p += DB_PAGESIZE;
+	  }
+      }
+      break;
+    default:
+      assert (false);
+      break;
+    }
+
+  error_code = file_temp_truncate (thread_p, &list_id->temp_vfid);
+  return error_code;
+}
+
 /*
  * qfile_copy_tuple_descr_to_tuple () - generate a tuple into a tuple record
  *                                      structure from a tuple descriptor

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -3281,7 +3281,7 @@ qfile_truncate_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID * list_id)
       break;
     }
 
-  error_code = file_temp_truncate (thread_p, &list_id->temp_vfid);
+  error_code = file_temp_truncate (thread_p, &tfile_vfid_p->temp_vfid);
   return error_code;
 }
 

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -3207,7 +3207,6 @@ qfile_truncate_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID * list_id)
   int error_code = NO_ERROR;
   int i;
   PAGE_PTR page_p;
-  QFILE_PAGE_HEADER pgheader = { 0, NULL_PAGEID, NULL_PAGEID, 0, NULL_PAGEID, NULL_VOLID, NULL_VOLID, NULL_VOLID };
   QMGR_TEMP_FILE *tfile_vfid_p = list_id->tfile_vfid;
   if (list_id->last_pgptr != NULL)
     {

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -3228,31 +3228,8 @@ qfile_truncate_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID * list_id)
     {
     case TEMP_FILE_MEMBUF_NONE:
       break;
-    case TEMP_FILE_MEMBUF_NORMAL:
-      {
-	tfile_vfid_p->membuf_last = -1;
-	page_p = (PAGE_PTR) ((PAGE_PTR) tfile_vfid_p->membuf
-			     + DB_ALIGN (sizeof (PAGE_PTR) * tfile_vfid_p->membuf_npages, MAX_ALIGNMENT));
-	for (i = 0; i < tfile_vfid_p->membuf_npages; i++)
-	  {
-	    tfile_vfid_p->membuf[i] = page_p;
-	    OR_PUT_INT ((page_p) + QFILE_TUPLE_COUNT_OFFSET, pgheader.pg_tplcnt);
-	    OR_PUT_INT ((page_p) + QFILE_PREV_PAGE_ID_OFFSET, pgheader.prev_pgid);
-	    OR_PUT_INT ((page_p) + QFILE_NEXT_PAGE_ID_OFFSET, pgheader.next_pgid);
-	    OR_PUT_INT ((page_p) + QFILE_LAST_TUPLE_OFFSET, pgheader.lasttpl_off);
-	    OR_PUT_INT ((page_p) + QFILE_OVERFLOW_PAGE_ID_OFFSET, pgheader.ovfl_pgid);
-	    OR_PUT_SHORT ((page_p) + QFILE_PREV_VOL_ID_OFFSET, pgheader.prev_volid);
-	    OR_PUT_SHORT ((page_p) + QFILE_NEXT_VOL_ID_OFFSET, pgheader.next_volid);
-	    OR_PUT_SHORT ((page_p) + QFILE_OVERFLOW_VOL_ID_OFFSET, pgheader.ovfl_volid);
-#if !defined(NDEBUG)
-	    /* suppress valgrind UMW error */
-	    memset (page_p + QFILE_RESERVED_OFFSET, 0, QFILE_PAGE_HEADER_SIZE - QFILE_RESERVED_OFFSET);
-#endif
-	    page_p += DB_PAGESIZE;
-	  }
-      }
-      break;
     case TEMP_FILE_MEMBUF_KEY_BUFFER:
+    case TEMP_FILE_MEMBUF_NORMAL:
       {
 	tfile_vfid_p->membuf_last = -1;
 	page_p = (PAGE_PTR) ((PAGE_PTR) tfile_vfid_p->membuf

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -3232,25 +3232,6 @@ qfile_truncate_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID * list_id)
     case TEMP_FILE_MEMBUF_NORMAL:
       {
 	tfile_vfid_p->membuf_last = -1;
-	page_p = (PAGE_PTR) ((PAGE_PTR) tfile_vfid_p->membuf
-			     + DB_ALIGN (sizeof (PAGE_PTR) * tfile_vfid_p->membuf_npages, MAX_ALIGNMENT));
-	for (i = 0; i < tfile_vfid_p->membuf_npages; i++)
-	  {
-	    tfile_vfid_p->membuf[i] = page_p;
-	    OR_PUT_INT ((page_p) + QFILE_TUPLE_COUNT_OFFSET, pgheader.pg_tplcnt);
-	    OR_PUT_INT ((page_p) + QFILE_PREV_PAGE_ID_OFFSET, pgheader.prev_pgid);
-	    OR_PUT_INT ((page_p) + QFILE_NEXT_PAGE_ID_OFFSET, pgheader.next_pgid);
-	    OR_PUT_INT ((page_p) + QFILE_LAST_TUPLE_OFFSET, pgheader.lasttpl_off);
-	    OR_PUT_INT ((page_p) + QFILE_OVERFLOW_PAGE_ID_OFFSET, pgheader.ovfl_pgid);
-	    OR_PUT_SHORT ((page_p) + QFILE_PREV_VOL_ID_OFFSET, pgheader.prev_volid);
-	    OR_PUT_SHORT ((page_p) + QFILE_NEXT_VOL_ID_OFFSET, pgheader.next_volid);
-	    OR_PUT_SHORT ((page_p) + QFILE_OVERFLOW_VOL_ID_OFFSET, pgheader.ovfl_volid);
-#if !defined(NDEBUG)
-	    /* suppress valgrind UMW error */
-	    memset (page_p + QFILE_RESERVED_OFFSET, 0, QFILE_PAGE_HEADER_SIZE - QFILE_RESERVED_OFFSET);
-#endif
-	    page_p += DB_PAGESIZE;
-	  }
       }
       break;
     default:

--- a/src/query/list_file.h
+++ b/src/query/list_file.h
@@ -201,6 +201,7 @@ extern QFILE_LIST_ID *qfile_combine_two_list (THREAD_ENTRY * thread_p, QFILE_LIS
 					      QFILE_LIST_ID * rhs_file, int flag);
 extern int qfile_append_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID * base_list_id, QFILE_LIST_ID * append_list_id);
 extern int qfile_connect_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID * base_list_id, QFILE_LIST_ID * append_list_id);
+extern int qfile_truncate_list (THREAD_ENTRY * thread_p, QFILE_LIST_ID * list_id);
 extern int qfile_copy_tuple_descr_to_tuple (THREAD_ENTRY * thread_p, QFILE_TUPLE_DESCRIPTOR * tpl_descr,
 					    QFILE_TUPLE_RECORD * tplrec);
 extern int qfile_reallocate_tuple (QFILE_TUPLE_RECORD * tplrec, int tpl_size);

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -6043,11 +6043,12 @@ scan_next_index_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 			  INDX_COV *indx_cov_p = &isidp->indx_cov;
 			  static int temp_cache_max_pages = prm_get_integer_value (PRM_ID_MAX_PAGES_IN_TEMP_FILE_CACHE);
 
+			  qfile_close_scan (thread_p, indx_cov_p->lsid);
+
 			  if (indx_cov_p->list_id->page_cnt - indx_cov_p->list_id->tfile_vfid->membuf_npages >
 			      temp_cache_max_pages)
 			    {
 			      /* close current list and start a new one */
-			      qfile_close_scan (thread_p, indx_cov_p->lsid);
 			      qfile_destroy_list (thread_p, indx_cov_p->list_id);
 
 			      indx_cov_p->list_id =

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -4460,8 +4460,8 @@ scan_reset_scan_block (THREAD_ENTRY * thread_p, SCAN_ID * s_id)
 
 	  if (indx_cov_p->list_id != NULL)
 	    {
-	      if (indx_cov_p->list_id->page_cnt - indx_cov_p->list_id->tfile_vfid->membuf_npages >
-		  prm_get_integer_value (PRM_ID_MAX_PAGES_IN_TEMP_FILE_CACHE))
+	      static int temp_cache_max_pages = prm_get_integer_value (PRM_ID_MAX_PAGES_IN_TEMP_FILE_CACHE);
+	      if (indx_cov_p->list_id->page_cnt - indx_cov_p->list_id->tfile_vfid->membuf_npages > temp_cache_max_pages)
 		{
 		  qfile_destroy_list (thread_p, indx_cov_p->list_id);
 

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -6040,13 +6040,25 @@ scan_next_index_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 
 		      if (SCAN_IS_INDEX_COVERED (isidp))
 			{
-			  /* close current list and start a new one */
-			  qfile_close_scan (thread_p, isidp->indx_cov.lsid);
-			  qfile_destroy_list (thread_p, isidp->indx_cov.list_id);
-			  isidp->indx_cov.list_id =
-			    qfile_open_list (thread_p, isidp->indx_cov.type_list, NULL, isidp->indx_cov.query_id, 0,
-					     isidp->indx_cov.list_id);
-			  if (isidp->indx_cov.list_id == NULL)
+			  INDX_COV *indx_cov_p = &isidp->indx_cov;
+			  static int temp_cache_max_pages = prm_get_integer_value (PRM_ID_MAX_PAGES_IN_TEMP_FILE_CACHE);
+
+			  if (indx_cov_p->list_id->page_cnt - indx_cov_p->list_id->tfile_vfid->membuf_npages >
+			      temp_cache_max_pages)
+			    {
+			      /* close current list and start a new one */
+			      qfile_close_scan (thread_p, indx_cov_p->lsid);
+			      qfile_destroy_list (thread_p, indx_cov_p->list_id);
+
+			      indx_cov_p->list_id =
+				qfile_open_list (thread_p, indx_cov_p->type_list, NULL, indx_cov_p->query_id, 0,
+						 indx_cov_p->list_id);
+			      if (indx_cov_p->list_id == NULL)
+				{
+				  return S_ERROR;
+				}
+			    }
+			  else if (qfile_truncate_list (thread_p, indx_cov_p->list_id) != NO_ERROR)
 			    {
 			      return S_ERROR;
 			    }

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -4460,7 +4460,21 @@ scan_reset_scan_block (THREAD_ENTRY * thread_p, SCAN_ID * s_id)
 
 	  if (indx_cov_p->list_id != NULL)
 	    {
-	      if (qfile_truncate_list (thread_p, indx_cov_p->list_id) != NO_ERROR)
+	      if (indx_cov_p->list_id->page_cnt - indx_cov_p->list_id->tfile_vfid->membuf_npages >
+		  prm_get_integer_value (PRM_ID_MAX_PAGES_IN_TEMP_FILE_CACHE))
+		{
+		  qfile_destroy_list (thread_p, indx_cov_p->list_id);
+
+		  indx_cov_p->list_id =
+		    qfile_open_list (thread_p, indx_cov_p->type_list, NULL, indx_cov_p->query_id, 0,
+				     indx_cov_p->list_id);
+		  if (indx_cov_p->list_id == NULL)
+		    {
+		      status = S_ERROR;
+		      break;
+		    }
+		}
+	      else if (qfile_truncate_list (thread_p, indx_cov_p->list_id) != NO_ERROR)
 		{
 		  status = S_ERROR;
 		  break;

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -4460,13 +4460,10 @@ scan_reset_scan_block (THREAD_ENTRY * thread_p, SCAN_ID * s_id)
 
 	  if (indx_cov_p->list_id != NULL)
 	    {
-	      qfile_destroy_list (thread_p, indx_cov_p->list_id);
-
-	      indx_cov_p->list_id =
-		qfile_open_list (thread_p, indx_cov_p->type_list, NULL, indx_cov_p->query_id, 0, indx_cov_p->list_id);
-	      if (indx_cov_p->list_id == NULL)
+	      if (qfile_truncate_list (thread_p, indx_cov_p->list_id) != NO_ERROR)
 		{
 		  status = S_ERROR;
+		  break;
 		}
 	    }
 	}

--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -4452,6 +4452,22 @@ file_temp_retire_preserved (THREAD_ENTRY * thread_p, const VFID * vfid)
   return file_temp_retire_internal (thread_p, vfid, true);
 }
 
+int
+file_temp_truncate (THREAD_ENTRY * thread_p, const VFID * vfid)
+{
+  int error_code = NO_ERROR;
+  if (vfid == NULL || VFID_ISNULL (vfid))
+    {
+      return NO_ERROR;
+    }
+  error_code = file_temp_reset_user_pages (thread_p, vfid);
+  if (error_code != NO_ERROR)
+    {
+      assert (false);
+    }
+  return error_code;
+}
+
 /*
  * file_temp_retire_internal () - retire temporary file. put it in cache is possible or destroy the file.
  *

--- a/src/storage/file_manager.h
+++ b/src/storage/file_manager.h
@@ -171,6 +171,7 @@ extern void file_postpone_destroy (THREAD_ENTRY * thread_p, const VFID * vfid);
 extern int file_destroy (THREAD_ENTRY * thread_p, const VFID * vfid, bool is_temp);
 extern int file_temp_retire (THREAD_ENTRY * thread_p, const VFID * vfid);
 extern int file_temp_retire_preserved (THREAD_ENTRY * thread_p, const VFID * vfid);
+extern int file_temp_truncate (THREAD_ENTRY * thread_p, const VFID * vfid);
 
 extern int file_init_page_type (THREAD_ENTRY * thread_p, PAGE_PTR page, void *args);
 extern int file_init_temp_page_type (THREAD_ENTRY * thread_p, PAGE_PTR page, void *args);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26398>

### Purpose

a→b 테이블 NL 조인에서 a의 각 row가 바뀔 때마다 b에 대한 index scan이 초기화됩니다. 이때 covering index scan이라면, 인덱스 키를 value로 변환해 저장해 두는 임시 파일(list_id)을 destroy 후 다시 open하게 되며, 이 과정에서 tempcache 접근 시 mutex를 획득합니다. 그 결과 여러 세션/클라이언트가 동시에 covering index 기반 NL 조인을 수행하면 mutex 경합으로 병목이 발생합니다. 이를 개선합니다.

### Implementation

file_temp_truncate(), qfile_truncate_list() 구현
index scan reset 시 indx_cov_p->list_id != NULL 인 경우 destroy->open 하던 루틴을 qfile_truncate_list() 하도록 변경
