### PR TITLE
[CBRD-26403] optimizer에서 correlated subquery의 cost 계산식 수정

### DIFF
--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -3178,8 +3178,9 @@ qo_nljoin_cost (QO_PLAN * planp)
 	subq_io_cost += temp_io_cost;
       }
 
-    planp->variable_cpu_cost += MAX (0.0, guessed_result_cardinality - 1.0) * subq_cpu_cost;
-    planp->variable_io_cost += MAX (0.0, guessed_result_cardinality - 1.0) * subq_io_cost;	/* assume IO as # blocks */
+    /* subq cost is already included in the inner. so add it for the cardinality excluded due to ISCAN_IO_HIT_RATIO. */
+    planp->variable_cpu_cost += guessed_result_cardinality * ISCAN_IO_HIT_RATIO * subq_cpu_cost;
+    planp->variable_io_cost += guessed_result_cardinality * ISCAN_IO_HIT_RATIO * subq_io_cost;	/* assume IO as # blocks */
   }
 
 #if TEST_DUMP_PLAN_JOIN_COST

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -3179,7 +3179,7 @@ qo_nljoin_cost (QO_PLAN * planp)
       }
 
     planp->variable_cpu_cost += MAX (0.0, guessed_result_cardinality - 1.0) * subq_cpu_cost;
-    planp->variable_io_cost += MAX (0.0, outer->variable_io_cost - 1.0) * subq_io_cost;	/* assume IO as # blocks */
+    planp->variable_io_cost += MAX (0.0, guessed_result_cardinality - 1.0) * subq_io_cost;	/* assume IO as # blocks */
   }
 
 #if TEST_DUMP_PLAN_JOIN_COST

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -2109,7 +2109,7 @@ qo_iscan_cost (QO_PLAN * planp)
   planp->fixed_io_cost = index_IO;
   planp->variable_cpu_cost = (leaf_access + heap_access) * (double) QO_CPU_WEIGHT;
   planp->variable_io_cost = object_IO;
-  planp->info->scan_rows = MAX (1, heap_access);
+  planp->info->scan_rows = MAX (1, (double) QO_NODE_NCARD (nodep) * sel * filter_sel);
 
 #if TEST_DUMP_PLAN_SCAN_COST
   fprintf (stdout, "\nIndex Scan Cost: \n");

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -649,12 +649,12 @@ qo_plan_compute_cost (QO_PLAN * plan)
   (*(plan->vtbl)->cost_fn) (plan);
 
   /* Now add in the subquery costs; this cost is incurred for each row produced by this plan, so multiply it by the
-   * estimated cardinality and add it to the access cost.
+   * estimated scan_rows and add it to the access cost.
    */
   if (plan->info)
     {
-      plan->variable_cpu_cost += (plan->info)->cardinality * subq_cpu_cost;
-      plan->variable_io_cost += (plan->info)->cardinality * subq_io_cost;
+      plan->variable_cpu_cost += (plan->info)->scan_rows * subq_cpu_cost;
+      plan->variable_io_cost += (plan->info)->scan_rows * subq_io_cost;
     }
 }
 
@@ -1583,6 +1583,7 @@ qo_sscan_cost (QO_PLAN * planp)
       planp->variable_cpu_cost = (double) QO_NODE_NCARD (nodep) * (double) QO_CPU_WEIGHT;
     }
   planp->variable_io_cost = (double) QO_NODE_TCARD (nodep);
+  planp->info->scan_rows = MAX (1, QO_NODE_NCARD (nodep));
 
 #if TEST_DUMP_PLAN_SCAN_COST
   fprintf (stdout, "\nSequential Scan Cost: \n");
@@ -2108,6 +2109,7 @@ qo_iscan_cost (QO_PLAN * planp)
   planp->fixed_io_cost = index_IO;
   planp->variable_cpu_cost = (leaf_access + heap_access) * (double) QO_CPU_WEIGHT;
   planp->variable_io_cost = object_IO;
+  planp->info->scan_rows = MAX (1, heap_access);
 
 #if TEST_DUMP_PLAN_SCAN_COST
   fprintf (stdout, "\nIndex Scan Cost: \n");
@@ -5479,6 +5481,7 @@ qo_alloc_info (QO_PLANNER * planner, BITSET * nodes, BITSET * terms, BITSET * eq
   qo_compute_projected_segs (planner, nodes, terms, &info->projected_segs);
   info->projected_size = qo_compute_projected_size (planner, &info->projected_segs);
   info->cardinality = cardinality;
+  info->scan_rows = cardinality;	/* after iscan_cost, sscan_cost. it'll be replaced accurately */
 
   qo_init_planvec (&info->best_no_order);
 

--- a/src/optimizer/query_planner.h
+++ b/src/optimizer/query_planner.h
@@ -299,7 +299,8 @@ struct qo_info
    * by plans at this node.
    */
   BITSET projected_segs;
-  double cardinality;
+  double cardinality;		/* Number of rows expected after scanning */
+  double scan_rows;		/* Number of rows required for scanning */
 
   /*
    * One plan for each equivalence class, in each case the best we have


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26403>

### Purpose
상관 부질의는 기준 행 수만큼 반복 실행된다. 그러나 현재는 필터 적용 후의 예측 결과 행 수를 곱하고 있어 cost 계산이 잘못되어 있다. 힙 스캔의 경우 기준이 되는 값은 전체 테이블 행 수가 되어야 하며, 인덱스 스캔의 경우에는 인덱스 조건을 통과하여 실제 힙에 접근하는 행 수를 곱해야 한다. 이에 따라 아래와 같이 cost 산정 기준을 변경한다.
```
as-is : subquery cost * Number of rows expected after scanning
to-be : subquery cost * Number of rows required for scanning
```

### Implementation
scan_rows 값을 새로 추가하고, 힙 스캔일 경우에는 여기에 전체 테이블 행 수를 설정하며, 인덱스 스캔일 경우에는 실제로 힙에 접근하게 되는 행 수를 넣도록 한다.

### Remarks
N/A
