### PR TITLE
[CBRD-26404] IS NOT NULL condition incorrectly removed for inner table columns in outer join queries

### DIFF
--- a/src/optimizer/rewriter/query_rewrite_term.c
+++ b/src/optimizer/rewriter/query_rewrite_term.c
@@ -1536,10 +1536,17 @@ qo_fold_is_and_not_null (PARSER_CONTEXT * parser, PT_NODE * from, PT_NODE ** whe
 	}
       else
 	{
-	  node_prior =
-	    (PT_IS_EXPR_NODE_WITH_OPERATOR (node_prior, PT_CAST)) ? node_prior->info.expr.
-	    arg1 : pt_get_end_path_node (node_prior);
-	  if (node_prior->node_type == PT_NAME)
+	  spec = NULL;
+	  if (PT_IS_EXPR_NODE_WITH_OPERATOR (node_prior, PT_CAST))
+	    {
+	      node_prior = node_prior->info.expr.arg1;
+	    }
+	  else
+	    {
+	      node_prior = pt_get_end_path_node (node_prior);
+	    }
+
+	  if (PT_IS_NAME_NODE (node_prior))
 	    {
 	      spec = pt_find_entity (parser, from, node_prior->info.name.spec_id);
 	    }

--- a/src/optimizer/rewriter/query_rewrite_term.c
+++ b/src/optimizer/rewriter/query_rewrite_term.c
@@ -1447,6 +1447,7 @@ qo_fold_is_and_not_null (PARSER_CONTEXT * parser, PT_NODE * from, PT_NODE ** whe
   DB_VALUE value;
   bool found;
   PT_NODE *node_prior, *sibling_prior;
+  PT_NODE *spec;
 
   /* traverse CNF list and keep track of the pointer to previous node */
   prev = NULL;
@@ -1535,7 +1536,16 @@ qo_fold_is_and_not_null (PARSER_CONTEXT * parser, PT_NODE * from, PT_NODE ** whe
 	}
       else
 	{
-	  if (node->info.expr.op == PT_IS_NOT_NULL && pt_check_not_null_constraint (parser, from, node_prior))
+	  node_prior =
+	    (PT_IS_EXPR_NODE_WITH_OPERATOR (node_prior, PT_CAST)) ? node_prior->info.
+	    expr.arg1 : pt_get_end_path_node (node_prior);
+	  if (node_prior->node_type == PT_NAME)
+	    {
+	      spec = pt_find_entity (parser, from, node_prior->info.name.spec_id);
+	    }
+
+	  if (node->info.expr.op == PT_IS_NOT_NULL && spec && !mq_is_outer_join_spec (parser, spec)
+	      && pt_check_not_null_constraint (parser, from, node_prior))
 	    {
 	      db_make_int (&value, true);
 	    }

--- a/src/optimizer/rewriter/query_rewrite_term.c
+++ b/src/optimizer/rewriter/query_rewrite_term.c
@@ -1447,7 +1447,7 @@ qo_fold_is_and_not_null (PARSER_CONTEXT * parser, PT_NODE * from, PT_NODE ** whe
   DB_VALUE value;
   bool found;
   PT_NODE *node_prior, *sibling_prior;
-  PT_NODE *spec;
+  PT_NODE *spec = NULL;
 
   /* traverse CNF list and keep track of the pointer to previous node */
   prev = NULL;
@@ -1537,8 +1537,8 @@ qo_fold_is_and_not_null (PARSER_CONTEXT * parser, PT_NODE * from, PT_NODE ** whe
       else
 	{
 	  node_prior =
-	    (PT_IS_EXPR_NODE_WITH_OPERATOR (node_prior, PT_CAST)) ? node_prior->info.
-	    expr.arg1 : pt_get_end_path_node (node_prior);
+	    (PT_IS_EXPR_NODE_WITH_OPERATOR (node_prior, PT_CAST)) ? node_prior->info.expr.
+	    arg1 : pt_get_end_path_node (node_prior);
 	  if (node_prior->node_type == PT_NAME)
 	    {
 	      spec = pt_find_entity (parser, from, node_prior->info.name.spec_id);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26404>

### Purpose

LEFT OUTER JOIN, RIGHT OUTER JOIN 쿼리에서, 이너 테이블에 대한 IS NOT NULL 조건이 제거되어 쿼리 결과가 잘못 출력됩니다.

```sql
create table t1(c1 int, c2 int not null);
insert into t1 values(1, 1), (2, 2), (3, 3);

create table t2(c1 int, c2 int not null);
insert into t2 values(2, 2), (4, 4);

-- qo_rewrite_outerjoin() 에서 inner join 으로 재작성되어야 하지만, is not null 이 제거되어 inner join으로 재작성되지 못함
select /*+ recompile */ a.*, b.* from t1 a left outer join t2 b on a.c1 = b.c1 where b.c2 is not null;
```

### Implementation

아우터 조인 쿼리에서  IS NOT NULL 표현식에 사용된 컬럼이 이너 테이블의 컬럼이면 제거하지 못하도록 수정

### Remarks

N/A
