### PR TITLE
[CBRD-25698] Enable preprocessor macro information in debug build by adding the -ggdb3 option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,9 +220,9 @@ if(UNIX)
     set(CMAKE_CXX_COMMON_FLAGS "${CMAKE_C_COMMON_FLAGS} -std=c++17")
 
     # C flags for debug build
-    set(CMAKE_C_DEBUG_FLAGS "-Wall -fno-inline ${CMAKE_C_COMMON_FLAGS}")
+    set(CMAKE_C_DEBUG_FLAGS "-ggdb3 -Wall -fno-inline ${CMAKE_C_COMMON_FLAGS}")
     # C++ flags for debug build
-    set(CMAKE_CXX_DEBUG_FLAGS "-Wall -fno-inline ${CMAKE_CXX_COMMON_FLAGS}")
+    set(CMAKE_CXX_DEBUG_FLAGS "-ggdb3 -Wall -fno-inline ${CMAKE_CXX_COMMON_FLAGS}")
 
     # C flags for release build
     set(CMAKE_C_RELEASE_FLAGS "-O2 -DNDEBUG -finline-functions ${CMAKE_C_COMMON_FLAGS}")


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25698

### Purpose
- debug 빌드 시 디버깅 정보에 매크로 정보를 추가하기 위해 -ggdb3 옵션 추가
- AS-IS
```
(gdb) info macro PAGE_PTR
The symbol `PAGE_PTR' has no definition as a C/C++ preprocessor macro
at <user-defined>:-1
```
- TO-BE
```
(gdb) info macro pgbuf_fix
Defined at /home/hornetmj/work/cubrid/src/storage/page_buffer.h:275
included at /home/hornetmj/work/cubrid/src/storage/page_buffer.c:32
#define pgbuf_fix(thread_p, vpid, fetch_mode, requestmode, condition) pgbuf_fix_debug(thread_p, vpid, fetch_mode, requestmode,
condition, ARG_FILE_LINE_FUNC)
```

### Implementation
- N/A

### Remarks
- N/A
