### PR TITLE
[CBRD-26131] Use fdatasync when a metadata of the volume is unchanged.

### DIFF
--- a/src/storage/double_write_buffer.cpp
+++ b/src/storage/double_write_buffer.cpp
@@ -204,6 +204,7 @@ struct flush_volume_info
   int vdes;			/* The volume descriptor. */
   volatile int num_pages;	/* The number of pages to flush in volume. */
   volatile bool all_pages_written;	/* True, if all pages written. */
+  volatile bool metadata;	/* Include metadata when syncing */
   volatile FLUSH_VOLUME_STATUS flushed_status;	/* Flush status. */
 };
 
@@ -348,7 +349,7 @@ STATIC_INLINE int dwb_block_create_ordered_slots (DWB_BLOCK *block, DWB_SLOT **p
     unsigned int *p_ordered_slots_length) __attribute__ ((ALWAYS_INLINE));
 static int dwb_compare_vol_fd (const void *v1, const void *v2);
 STATIC_INLINE FLUSH_VOLUME_INFO *dwb_add_volume_to_block_flush_area (THREAD_ENTRY *thread_p, DWB_BLOCK *block,
-    int vol_fd) __attribute__ ((ALWAYS_INLINE));
+    int vol_fd, bool metadata) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int dwb_write_block (THREAD_ENTRY *thread_p, DWB_BLOCK *block, DWB_SLOT *p_dwb_slots,
 				   unsigned int ordered_slots_length, bool file_sync_helper_can_flush,
 				   bool remove_from_hash) __attribute__ ((ALWAYS_INLINE));
@@ -358,7 +359,7 @@ STATIC_INLINE void dwb_init_slot (DWB_SLOT *slot) __attribute__ ((ALWAYS_INLINE)
 STATIC_INLINE int dwb_acquire_next_slot (THREAD_ENTRY *thread_p, bool can_wait, DWB_SLOT **p_dwb_slot)
 __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE void dwb_set_slot_data (THREAD_ENTRY *thread_p, DWB_SLOT *dwb_slot,
-				      FILEIO_PAGE *io_page_p) __attribute__ ((ALWAYS_INLINE));
+				      FILEIO_PAGE *io_page_p, bool metadata) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int dwb_wait_for_strucure_modification (THREAD_ENTRY *thread_p) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE void dwb_signal_structure_modificated (THREAD_ENTRY *thread_p) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int dwb_starts_structure_modification (THREAD_ENTRY *thread_p, UINT64 *current_position_with_flags)
@@ -1439,6 +1440,9 @@ dwb_slots_hash_insert (THREAD_ENTRY *thread_p, VPID *vpid, DWB_SLOT *slot, bool 
 	    }
 	}
 
+      /* If a metadata sync was requested, the metadata must be synced even if the slot is replaced */
+      slot->metadata = slot->metadata || slots_hash_entry->slot->metadata;
+
       dwb_log ("Replace hash key (%d, %d), the new LSA=(%lld,%d), the old LSA = (%lld,%d)",
 	       vpid->volid, vpid->pageid, slot->lsa.pageid, slot->lsa.offset,
 	       slots_hash_entry->slot->lsa.pageid, slots_hash_entry->slot->lsa.offset);
@@ -1824,6 +1828,16 @@ dwb_compare_slots (const void *arg1, const void *arg2)
       return -1;
     }
 
+  diff2 = slot1->metadata - slot2->metadata;
+  if (diff2 > 0)
+    {
+      return 1;
+    }
+  else if (diff2 < 0)
+    {
+      return -1;
+    }
+
   return 0;
 }
 
@@ -1950,7 +1964,7 @@ dwb_compare_vol_fd (const void *v1, const void *v2)
  * Note: The volume is added if is not already in block flush area.
  */
 STATIC_INLINE FLUSH_VOLUME_INFO *
-dwb_add_volume_to_block_flush_area (THREAD_ENTRY *thread_p, DWB_BLOCK *block, int vol_fd)
+dwb_add_volume_to_block_flush_area (THREAD_ENTRY *thread_p, DWB_BLOCK *block, int vol_fd, bool metadata)
 {
   FLUSH_VOLUME_INFO *flush_new_volume_info;
 #if !defined (NDEBUG)
@@ -1969,6 +1983,7 @@ dwb_add_volume_to_block_flush_area (THREAD_ENTRY *thread_p, DWB_BLOCK *block, in
   flush_new_volume_info->vdes = vol_fd;
   flush_new_volume_info->num_pages = 0;
   flush_new_volume_info->all_pages_written = false;
+  flush_new_volume_info->metadata = metadata;
   flush_new_volume_info->flushed_status = VOLUME_NOT_FLUSHED;
 
   /* There is only a writer and several (currently 2) readers on flush_new_volume_info array.
@@ -2007,6 +2022,7 @@ dwb_write_block (THREAD_ENTRY *thread_p, DWB_BLOCK *block, DWB_SLOT *p_dwb_order
   int count_writes = 0, num_pages_to_sync;
   FLUSH_VOLUME_INFO *current_flush_volume_info = NULL;
   bool can_flush_volume = false;
+  bool metadata;
 
   assert (block != NULL && p_dwb_ordered_slots != NULL);
 
@@ -2034,6 +2050,7 @@ dwb_write_block (THREAD_ENTRY *thread_p, DWB_BLOCK *block, DWB_SLOT *p_dwb_order
 
       assert (VPID_ISNULL (&p_dwb_ordered_slots[i + 1].vpid) || VPID_LT (vpid, &p_dwb_ordered_slots[i + 1].vpid));
 
+      metadata = p_dwb_ordered_slots[i].metadata;
       if (last_written_volid != vpid->volid)
 	{
 	  /* Get the volume descriptor. */
@@ -2056,8 +2073,12 @@ dwb_write_block (THREAD_ENTRY *thread_p, DWB_BLOCK *block, DWB_SLOT *p_dwb_order
 	  last_written_volid = vpid->volid;
 	  last_written_vol_fd = vol_fd;
 
-	  current_flush_volume_info = dwb_add_volume_to_block_flush_area (thread_p, block, last_written_vol_fd);
+	  current_flush_volume_info = dwb_add_volume_to_block_flush_area (thread_p, block, last_written_vol_fd, metadata);
 	}
+
+      assert (current_flush_volume_info != NULL);
+
+      current_flush_volume_info->metadata = current_flush_volume_info->metadata || metadata;
 
       assert (last_written_vol_fd != NULL_VOLDES);
 
@@ -2083,8 +2104,6 @@ dwb_write_block (THREAD_ENTRY *thread_p, DWB_BLOCK *block, DWB_SLOT *p_dwb_order
 	       (int) p_dwb_ordered_slots[i].io_page->prv.lsa.offset);
 
 #if defined (SERVER_MODE)
-      assert (current_flush_volume_info != NULL);
-
       ATOMIC_INC_32 (&current_flush_volume_info->num_pages, 1);
       count_writes++;
 
@@ -2234,6 +2253,8 @@ dwb_flush_block (THREAD_ENTRY *thread_p, DWB_BLOCK *block, bool file_sync_helper
 	  VPID_SET_NULL (& (block->slots[s1->position_in_block].vpid));
 
 	  fileio_initialize_res (thread_p, s1->io_page, IO_PAGESIZE);
+
+	  s2->metadata = s1->metadata || s2->metadata;
 	}
 
       /* Check for WAL protocol. */
@@ -2276,7 +2297,9 @@ dwb_flush_block (THREAD_ENTRY *thread_p, DWB_BLOCK *block, bool file_sync_helper
 	      if (ATOMIC_INC_32 (& (dwb_Global.file_sync_helper_block->flush_volumes_info[i].num_pages), 0) >= 0)
 		{
 		  (void) fileio_synchronize (thread_p,
-					     dwb_Global.file_sync_helper_block->flush_volumes_info[i].vdes, NULL);
+					     dwb_Global.file_sync_helper_block->flush_volumes_info[i].vdes,
+					     NULL,
+					     dwb_Global.file_sync_helper_block->flush_volumes_info[i].metadata);
 
 		  dwb_log ("dwb_flush_block: Synchronized volume %d\n",
 			   dwb_Global.file_sync_helper_block->flush_volumes_info[i].vdes);
@@ -2319,7 +2342,7 @@ dwb_flush_block (THREAD_ENTRY *thread_p, DWB_BLOCK *block, bool file_sync_helper
   /* Increment statistics after writing in double write volume. */
   perfmon_add_stat (thread_p, PSTAT_PB_NUM_IOWRITES, block->count_wb_pages);
 
-  if (fileio_synchronize (thread_p, dwb_Global.vdes, dwb_Volume_name) != dwb_Global.vdes)
+  if (fileio_synchronize (thread_p, dwb_Global.vdes, dwb_Volume_name, false) != dwb_Global.vdes)
     {
       assert (false);
       /* Something wrong happened. */
@@ -2377,7 +2400,7 @@ dwb_flush_block (THREAD_ENTRY *thread_p, DWB_BLOCK *block, bool file_sync_helper
       num_pages = ATOMIC_TAS_32 (&block->flush_volumes_info[i].num_pages, 0);
       assert (num_pages != 0);
 
-      (void) fileio_synchronize (thread_p, block->flush_volumes_info[i].vdes, NULL);
+      (void) fileio_synchronize (thread_p, block->flush_volumes_info[i].vdes, NULL, block->flush_volumes_info[i].metadata);
 
       dwb_log ("dwb_flush_block: Synchronized volume %d\n", block->flush_volumes_info[i].vdes);
     }
@@ -2590,7 +2613,7 @@ start:
  * io_page_p(in): The data.
  */
 STATIC_INLINE void
-dwb_set_slot_data (THREAD_ENTRY *thread_p, DWB_SLOT *dwb_slot, FILEIO_PAGE *io_page_p)
+dwb_set_slot_data (THREAD_ENTRY *thread_p, DWB_SLOT *dwb_slot, FILEIO_PAGE *io_page_p, bool metadata)
 {
   assert (dwb_slot != NULL && io_page_p != NULL);
 
@@ -2609,6 +2632,8 @@ dwb_set_slot_data (THREAD_ENTRY *thread_p, DWB_SLOT *dwb_slot, FILEIO_PAGE *io_p
   assert (fileio_is_page_sane (io_page_p, IO_PAGESIZE));
   LSA_COPY (&dwb_slot->lsa, &io_page_p->prv.lsa);
   VPID_SET (&dwb_slot->vpid, io_page_p->prv.volid, io_page_p->prv.pageid);
+
+  dwb_slot->metadata = metadata;
 }
 
 /*
@@ -2661,7 +2686,8 @@ dwb_get_next_block_for_flush (THREAD_ENTRY *thread_p, unsigned int *block_no)
  * p_dwb_slot(out): Pointer to the next free DWB slot.
  */
 int
-dwb_set_data_on_next_slot (THREAD_ENTRY *thread_p, FILEIO_PAGE *io_page_p, bool can_wait, DWB_SLOT **p_dwb_slot)
+dwb_set_data_on_next_slot (THREAD_ENTRY *thread_p, FILEIO_PAGE *io_page_p, bool can_wait, bool metadata,
+			   DWB_SLOT **p_dwb_slot)
 {
   int error_code;
 
@@ -2682,7 +2708,7 @@ dwb_set_data_on_next_slot (THREAD_ENTRY *thread_p, FILEIO_PAGE *io_page_p, bool 
     }
 
   /* Set data on slot. */
-  dwb_set_slot_data (thread_p, *p_dwb_slot, io_page_p);
+  dwb_set_slot_data (thread_p, *p_dwb_slot, io_page_p, metadata);
 
   return NO_ERROR;
 }
@@ -2699,7 +2725,7 @@ dwb_set_data_on_next_slot (THREAD_ENTRY *thread_p, FILEIO_PAGE *io_page_p, bool 
  *  Note: thread may flush the block, if flush thread is not available or we are in stand alone.
  */
 int
-dwb_add_page (THREAD_ENTRY *thread_p, FILEIO_PAGE *io_page_p, VPID *vpid, DWB_SLOT **p_dwb_slot)
+dwb_add_page (THREAD_ENTRY *thread_p, FILEIO_PAGE *io_page_p, VPID *vpid, bool metadata, DWB_SLOT **p_dwb_slot)
 {
   unsigned int count_wb_pages;
   int error_code = NO_ERROR;
@@ -2717,7 +2743,7 @@ dwb_add_page (THREAD_ENTRY *thread_p, FILEIO_PAGE *io_page_p, VPID *vpid, DWB_SL
 
   if (*p_dwb_slot == NULL)
     {
-      error_code = dwb_set_data_on_next_slot (thread_p, io_page_p, true, p_dwb_slot);
+      error_code = dwb_set_data_on_next_slot (thread_p, io_page_p, true, metadata, p_dwb_slot);
       if (error_code != NO_ERROR)
 	{
 	  return error_code;
@@ -3321,7 +3347,8 @@ dwb_load_and_recover_pages (THREAD_ENTRY *thread_p, const char *dwb_path_p, cons
 	      /* Now, flush the volumes having pages in current block. */
 	      for (i = 0; i < rcv_block->count_flush_volumes_info; i++)
 		{
-		  if (fileio_synchronize (thread_p, rcv_block->flush_volumes_info[i].vdes, NULL) == NULL_VOLDES)
+		  if (fileio_synchronize (thread_p, rcv_block->flush_volumes_info[i].vdes, NULL,
+					  rcv_block->flush_volumes_info[i].metadata) == NULL_VOLDES)
 		    {
 		      error_code = ER_FAILED;
 		      goto end;
@@ -3677,7 +3704,7 @@ check_flushed_blocks:
       /* The system didn't advanced, add null pages to force flush block. */
       dwb_slot = NULL;
 
-      error_code = dwb_add_page (thread_p, iopage, &null_vpid, &dwb_slot);
+      error_code = dwb_add_page (thread_p, iopage, &null_vpid, false, &dwb_slot);
       if (error_code != NO_ERROR)
 	{
 	  dwb_log_error ("dwb_flush_force : Error %d while adding page = %lld\n",
@@ -3835,7 +3862,7 @@ dwb_file_sync_helper (THREAD_ENTRY *thread_p)
 	   * Flush the volume. If not all volume pages are available now, continue with next volume, if any,
 	   * and then resume the current one.
 	   */
-	  (void) fileio_synchronize (thread_p, current_flush_volume_info->vdes, NULL);
+	  (void) fileio_synchronize (thread_p, current_flush_volume_info->vdes, NULL, current_flush_volume_info->metadata);
 
 	  dwb_log ("dwb_file_sync_helper: Synchronized volume %d\n", current_flush_volume_info->vdes);
 	}

--- a/src/storage/double_write_buffer.cpp
+++ b/src/storage/double_write_buffer.cpp
@@ -359,7 +359,7 @@ STATIC_INLINE void dwb_init_slot (DWB_SLOT *slot) __attribute__ ((ALWAYS_INLINE)
 STATIC_INLINE int dwb_acquire_next_slot (THREAD_ENTRY *thread_p, bool can_wait, DWB_SLOT **p_dwb_slot)
 __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE void dwb_set_slot_data (THREAD_ENTRY *thread_p, DWB_SLOT *dwb_slot,
-				      FILEIO_PAGE *io_page_p, bool metadata) __attribute__ ((ALWAYS_INLINE));
+				      FILEIO_PAGE *io_page_p, bool ensure_metadata) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int dwb_wait_for_strucure_modification (THREAD_ENTRY *thread_p) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE void dwb_signal_structure_modificated (THREAD_ENTRY *thread_p) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int dwb_starts_structure_modification (THREAD_ENTRY *thread_p, UINT64 *current_position_with_flags)
@@ -1441,7 +1441,7 @@ dwb_slots_hash_insert (THREAD_ENTRY *thread_p, VPID *vpid, DWB_SLOT *slot, bool 
 	}
 
       /* If a metadata sync was requested, the metadata must be synced even if the slot is replaced */
-      slot->metadata = slot->metadata || slots_hash_entry->slot->metadata;
+      slot->ensure_metadata = slot->ensure_metadata || slots_hash_entry->slot->ensure_metadata;
 
       dwb_log ("Replace hash key (%d, %d), the new LSA=(%lld,%d), the old LSA = (%lld,%d)",
 	       vpid->volid, vpid->pageid, slot->lsa.pageid, slot->lsa.offset,
@@ -2013,7 +2013,7 @@ dwb_write_block (THREAD_ENTRY *thread_p, DWB_BLOCK *block, DWB_SLOT *p_dwb_order
   int count_writes = 0, num_pages_to_sync;
   FLUSH_VOLUME_INFO *current_flush_volume_info = NULL;
   bool can_flush_volume = false;
-  bool metadata;
+  bool ensure_metadata;
 
   assert (block != NULL && p_dwb_ordered_slots != NULL);
 
@@ -2041,7 +2041,7 @@ dwb_write_block (THREAD_ENTRY *thread_p, DWB_BLOCK *block, DWB_SLOT *p_dwb_order
 
       assert (VPID_ISNULL (&p_dwb_ordered_slots[i + 1].vpid) || VPID_LT (vpid, &p_dwb_ordered_slots[i + 1].vpid));
 
-      metadata = p_dwb_ordered_slots[i].metadata;
+      ensure_metadata = p_dwb_ordered_slots[i].ensure_metadata;
       if (last_written_volid != vpid->volid)
 	{
 	  /* Get the volume descriptor. */
@@ -2064,13 +2064,13 @@ dwb_write_block (THREAD_ENTRY *thread_p, DWB_BLOCK *block, DWB_SLOT *p_dwb_order
 	  last_written_volid = vpid->volid;
 	  last_written_vol_fd = vol_fd;
 
-	  current_flush_volume_info = dwb_add_volume_to_block_flush_area (thread_p, block, last_written_vol_fd, metadata);
+	  current_flush_volume_info = dwb_add_volume_to_block_flush_area (thread_p, block, last_written_vol_fd, ensure_metadata);
 	}
       else
 	{
 	  assert (current_flush_volume_info != NULL);
 
-	  current_flush_volume_info->metadata = current_flush_volume_info->metadata || metadata;
+	  current_flush_volume_info->metadata = current_flush_volume_info->metadata || ensure_metadata;
 	}
 
       assert (last_written_vol_fd != NULL_VOLDES);
@@ -2247,7 +2247,7 @@ dwb_flush_block (THREAD_ENTRY *thread_p, DWB_BLOCK *block, bool file_sync_helper
 
 	  fileio_initialize_res (thread_p, s1->io_page, IO_PAGESIZE);
 
-	  s2->metadata = s1->metadata || s2->metadata;
+	  s2->ensure_metadata = s1->ensure_metadata || s2->ensure_metadata;
 	}
 
       /* Check for WAL protocol. */
@@ -2604,10 +2604,10 @@ start:
  * thread_p(in): Thread entry
  * dwb_slot(in/out): DWB slot that contains the location where the data must be set.
  * io_page_p(in): The data.
- * metadata(in): Include metadata when syncing.
+ * ensure_metadata(in): Include metadata when syncing.
  */
 STATIC_INLINE void
-dwb_set_slot_data (THREAD_ENTRY *thread_p, DWB_SLOT *dwb_slot, FILEIO_PAGE *io_page_p, bool metadata)
+dwb_set_slot_data (THREAD_ENTRY *thread_p, DWB_SLOT *dwb_slot, FILEIO_PAGE *io_page_p, bool ensure_metadata)
 {
   assert (dwb_slot != NULL && io_page_p != NULL);
 
@@ -2627,7 +2627,7 @@ dwb_set_slot_data (THREAD_ENTRY *thread_p, DWB_SLOT *dwb_slot, FILEIO_PAGE *io_p
   LSA_COPY (&dwb_slot->lsa, &io_page_p->prv.lsa);
   VPID_SET (&dwb_slot->vpid, io_page_p->prv.volid, io_page_p->prv.pageid);
 
-  dwb_slot->metadata = metadata;
+  dwb_slot->ensure_metadata = ensure_metadata;
 }
 
 /*
@@ -2677,11 +2677,11 @@ dwb_get_next_block_for_flush (THREAD_ENTRY *thread_p, unsigned int *block_no)
  * thread_p(in): The thread entry.
  * io_page_p(in): The data that will be set on next slot.
  * can_wait(in): True, if waiting is allowed.
- * metadata(in): Include metadata when syncing.
+ * ensure_metadata(in): Include metadata when syncing.
  * p_dwb_slot(out): Pointer to the next free DWB slot.
  */
 int
-dwb_set_data_on_next_slot (THREAD_ENTRY *thread_p, FILEIO_PAGE *io_page_p, bool can_wait, bool metadata,
+dwb_set_data_on_next_slot (THREAD_ENTRY *thread_p, FILEIO_PAGE *io_page_p, bool can_wait, bool ensure_metadata,
 			   DWB_SLOT **p_dwb_slot)
 {
   int error_code;
@@ -2703,7 +2703,7 @@ dwb_set_data_on_next_slot (THREAD_ENTRY *thread_p, FILEIO_PAGE *io_page_p, bool 
     }
 
   /* Set data on slot. */
-  dwb_set_slot_data (thread_p, *p_dwb_slot, io_page_p, metadata);
+  dwb_set_slot_data (thread_p, *p_dwb_slot, io_page_p, ensure_metadata);
 
   return NO_ERROR;
 }
@@ -2715,13 +2715,13 @@ dwb_set_data_on_next_slot (THREAD_ENTRY *thread_p, FILEIO_PAGE *io_page_p, bool 
  * thread_p (in): The thread entry.
  * io_page_p(in): In-memory address where the current content of page resides.
  * vpid(in): Page identifier.
- * metadata(in): Include metadata when syncing.
+ * ensure_metadata(in): Include metadata when syncing.
  * p_dwb_slot(in/out): DWB slot where the page content must be added.
  *
  *  Note: thread may flush the block, if flush thread is not available or we are in stand alone.
  */
 int
-dwb_add_page (THREAD_ENTRY *thread_p, FILEIO_PAGE *io_page_p, VPID *vpid, bool metadata, DWB_SLOT **p_dwb_slot)
+dwb_add_page (THREAD_ENTRY *thread_p, FILEIO_PAGE *io_page_p, VPID *vpid, bool ensure_metadata, DWB_SLOT **p_dwb_slot)
 {
   unsigned int count_wb_pages;
   int error_code = NO_ERROR;
@@ -2739,7 +2739,7 @@ dwb_add_page (THREAD_ENTRY *thread_p, FILEIO_PAGE *io_page_p, VPID *vpid, bool m
 
   if (*p_dwb_slot == NULL)
     {
-      error_code = dwb_set_data_on_next_slot (thread_p, io_page_p, true, metadata, p_dwb_slot);
+      error_code = dwb_set_data_on_next_slot (thread_p, io_page_p, true, ensure_metadata, p_dwb_slot);
       if (error_code != NO_ERROR)
 	{
 	  return error_code;

--- a/src/storage/double_write_buffer.cpp
+++ b/src/storage/double_write_buffer.cpp
@@ -1828,16 +1828,6 @@ dwb_compare_slots (const void *arg1, const void *arg2)
       return -1;
     }
 
-  diff2 = slot1->metadata - slot2->metadata;
-  if (diff2 > 0)
-    {
-      return 1;
-    }
-  else if (diff2 < 0)
-    {
-      return -1;
-    }
-
   return 0;
 }
 
@@ -1960,6 +1950,7 @@ dwb_compare_vol_fd (const void *v1, const void *v2)
  * thread_p (in): The thread entry.
  * block(in): The block where the flush area reside.
  * vol_fd(in): The volume to add.
+ * metadata(in): Include metadata when syncing.
  *
  * Note: The volume is added if is not already in block flush area.
  */
@@ -2611,6 +2602,7 @@ start:
  * thread_p(in): Thread entry
  * dwb_slot(in/out): DWB slot that contains the location where the data must be set.
  * io_page_p(in): The data.
+ * metadata(in): Include metadata when syncing.
  */
 STATIC_INLINE void
 dwb_set_slot_data (THREAD_ENTRY *thread_p, DWB_SLOT *dwb_slot, FILEIO_PAGE *io_page_p, bool metadata)
@@ -2683,6 +2675,7 @@ dwb_get_next_block_for_flush (THREAD_ENTRY *thread_p, unsigned int *block_no)
  * thread_p(in): The thread entry.
  * io_page_p(in): The data that will be set on next slot.
  * can_wait(in): True, if waiting is allowed.
+ * metadata(in): Include metadata when syncing.
  * p_dwb_slot(out): Pointer to the next free DWB slot.
  */
 int
@@ -2720,6 +2713,7 @@ dwb_set_data_on_next_slot (THREAD_ENTRY *thread_p, FILEIO_PAGE *io_page_p, bool 
  * thread_p (in): The thread entry.
  * io_page_p(in): In-memory address where the current content of page resides.
  * vpid(in): Page identifier.
+ * metadata(in): Include metadata when syncing.
  * p_dwb_slot(in/out): DWB slot where the page content must be added.
  *
  *  Note: thread may flush the block, if flush thread is not available or we are in stand alone.

--- a/src/storage/double_write_buffer.cpp
+++ b/src/storage/double_write_buffer.cpp
@@ -3347,8 +3347,8 @@ dwb_load_and_recover_pages (THREAD_ENTRY *thread_p, const char *dwb_path_p, cons
 	      /* Now, flush the volumes having pages in current block. */
 	      for (i = 0; i < rcv_block->count_flush_volumes_info; i++)
 		{
-		  if (fileio_synchronize (thread_p, rcv_block->flush_volumes_info[i].vdes, NULL,
-					  rcv_block->flush_volumes_info[i].metadata) == NULL_VOLDES)
+		  /* rcv_block->flush_volumes_info[i].metadata is invalid at this point */
+		  if (fileio_synchronize (thread_p, rcv_block->flush_volumes_info[i].vdes, NULL, true) == NULL_VOLDES)
 		    {
 		      error_code = ER_FAILED;
 		      goto end;

--- a/src/storage/double_write_buffer.cpp
+++ b/src/storage/double_write_buffer.cpp
@@ -2066,10 +2066,12 @@ dwb_write_block (THREAD_ENTRY *thread_p, DWB_BLOCK *block, DWB_SLOT *p_dwb_order
 
 	  current_flush_volume_info = dwb_add_volume_to_block_flush_area (thread_p, block, last_written_vol_fd, metadata);
 	}
+      else
+	{
+	  assert (current_flush_volume_info != NULL);
 
-      assert (current_flush_volume_info != NULL);
-
-      current_flush_volume_info->metadata = current_flush_volume_info->metadata || metadata;
+	  current_flush_volume_info->metadata = current_flush_volume_info->metadata || metadata;
+	}
 
       assert (last_written_vol_fd != NULL_VOLDES);
 

--- a/src/storage/double_write_buffer.cpp
+++ b/src/storage/double_write_buffer.cpp
@@ -349,7 +349,7 @@ STATIC_INLINE int dwb_block_create_ordered_slots (DWB_BLOCK *block, DWB_SLOT **p
     unsigned int *p_ordered_slots_length) __attribute__ ((ALWAYS_INLINE));
 static int dwb_compare_vol_fd (const void *v1, const void *v2);
 STATIC_INLINE FLUSH_VOLUME_INFO *dwb_add_volume_to_block_flush_area (THREAD_ENTRY *thread_p, DWB_BLOCK *block,
-    int vol_fd, bool metadata) __attribute__ ((ALWAYS_INLINE));
+    int vol_fd, bool ensure_metadata) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int dwb_write_block (THREAD_ENTRY *thread_p, DWB_BLOCK *block, DWB_SLOT *p_dwb_slots,
 				   unsigned int ordered_slots_length, bool file_sync_helper_can_flush,
 				   bool remove_from_hash) __attribute__ ((ALWAYS_INLINE));
@@ -1950,12 +1950,12 @@ dwb_compare_vol_fd (const void *v1, const void *v2)
  * thread_p (in): The thread entry.
  * block(in): The block where the flush area reside.
  * vol_fd(in): The volume to add.
- * metadata(in): Include metadata when syncing.
+ * ensure_metadata(in): Include metadata when syncing.
  *
  * Note: The volume is added if is not already in block flush area.
  */
 STATIC_INLINE FLUSH_VOLUME_INFO *
-dwb_add_volume_to_block_flush_area (THREAD_ENTRY *thread_p, DWB_BLOCK *block, int vol_fd, bool metadata)
+dwb_add_volume_to_block_flush_area (THREAD_ENTRY *thread_p, DWB_BLOCK *block, int vol_fd, bool ensure_metadata)
 {
   FLUSH_VOLUME_INFO *flush_new_volume_info;
 #if !defined (NDEBUG)
@@ -1974,7 +1974,7 @@ dwb_add_volume_to_block_flush_area (THREAD_ENTRY *thread_p, DWB_BLOCK *block, in
   flush_new_volume_info->vdes = vol_fd;
   flush_new_volume_info->num_pages = 0;
   flush_new_volume_info->all_pages_written = false;
-  flush_new_volume_info->metadata = metadata;
+  flush_new_volume_info->metadata = ensure_metadata;
   flush_new_volume_info->flushed_status = VOLUME_NOT_FLUSHED;
 
   /* There is only a writer and several (currently 2) readers on flush_new_volume_info array.

--- a/src/storage/double_write_buffer.hpp
+++ b/src/storage/double_write_buffer.hpp
@@ -35,6 +35,7 @@ struct double_write_slot
   FILEIO_PAGE *io_page;		/* The contained page or NULL. */
   VPID vpid;			/* The page identifier. */
   LOG_LSA lsa;			/* The page LSA */
+  bool metadata;		/* Include metadata when syncing */
   unsigned int position_in_block;	/* The position in block. */
   unsigned int block_no;	/* The number of the block where the slot reside. */
 };
@@ -48,9 +49,10 @@ extern int dwb_destroy (THREAD_ENTRY *thread_p);
 extern char *dwb_get_volume_name (void);
 extern int dwb_flush_force (THREAD_ENTRY *thread_p, bool *all_sync);
 extern int dwb_read_page (THREAD_ENTRY *thread_p, const VPID *vpid, void *io_page, bool *success);
-extern int dwb_set_data_on_next_slot (THREAD_ENTRY *thread_p, FILEIO_PAGE *io_page_p, bool can_wait,
+extern int dwb_set_data_on_next_slot (THREAD_ENTRY *thread_p, FILEIO_PAGE *io_page_p, bool can_wait, bool metadata,
 				      DWB_SLOT **p_dwb_slot);
-extern int dwb_add_page (THREAD_ENTRY *thread_p, FILEIO_PAGE *io_page_p, VPID *vpid, DWB_SLOT **p_dwb_slot);
+extern int dwb_add_page (THREAD_ENTRY *thread_p, FILEIO_PAGE *io_page_p, VPID *vpid, bool metadata,
+			 DWB_SLOT **p_dwb_slot);
 
 extern int dwb_synchronize (THREAD_ENTRY *thread_p, int vol_fd, const char *vlabel);
 

--- a/src/storage/double_write_buffer.hpp
+++ b/src/storage/double_write_buffer.hpp
@@ -35,7 +35,7 @@ struct double_write_slot
   FILEIO_PAGE *io_page;		/* The contained page or NULL. */
   VPID vpid;			/* The page identifier. */
   LOG_LSA lsa;			/* The page LSA */
-  bool metadata;		/* Include metadata when syncing */
+  bool ensure_metadata;		/* Include metadata when syncing */
   unsigned int position_in_block;	/* The position in block. */
   unsigned int block_no;	/* The number of the block where the slot reside. */
 };
@@ -49,9 +49,9 @@ extern int dwb_destroy (THREAD_ENTRY *thread_p);
 extern char *dwb_get_volume_name (void);
 extern int dwb_flush_force (THREAD_ENTRY *thread_p, bool *all_sync);
 extern int dwb_read_page (THREAD_ENTRY *thread_p, const VPID *vpid, void *io_page, bool *success);
-extern int dwb_set_data_on_next_slot (THREAD_ENTRY *thread_p, FILEIO_PAGE *io_page_p, bool can_wait, bool metadata,
-				      DWB_SLOT **p_dwb_slot);
-extern int dwb_add_page (THREAD_ENTRY *thread_p, FILEIO_PAGE *io_page_p, VPID *vpid, bool metadata,
+extern int dwb_set_data_on_next_slot (THREAD_ENTRY *thread_p, FILEIO_PAGE *io_page_p, bool can_wait,
+				      bool ensure_metadata, DWB_SLOT **p_dwb_slot);
+extern int dwb_add_page (THREAD_ENTRY *thread_p, FILEIO_PAGE *io_page_p, VPID *vpid, bool ensure_metadata,
 			 DWB_SLOT **p_dwb_slot);
 
 extern int dwb_synchronize (THREAD_ENTRY *thread_p, int vol_fd, const char *vlabel);

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -2402,11 +2402,19 @@ fileio_format (THREAD_ENTRY * thread_p, const char *db_full_name_p, const char *
 	  return NULL_VOLDES;
 	}
 
+#if defined(HPUX)
+      if ((is_sweep_clean == true
+	   && !fileio_initialize_pages (vol_fd, malloc_io_page_p, npages, page_size, false,
+					kbytes_to_be_written_per_sec)) ||
+	  (is_sweep_clean == false
+	   && !fileio_write (vol_fd, malloc_io_page_p, npages - 1, page_size, FILEIO_WRITE_DEFAULT_WRITE)))
+#else /* HPUX */
       if (!((fileio_write_or_add_to_dwb (thread_p, vol_fd, malloc_io_page_p, npages - 1, page_size, true) ==
 	     malloc_io_page_p) && (is_sweep_clean == false
 				   || fileio_initialize_pages (thread_p, vol_fd, malloc_io_page_p, 0, npages, page_size,
 							       false,
 							       kbytes_to_be_written_per_sec) == malloc_io_page_p)))
+#endif /* !HPUX */
 	{
 	  /* It is likely that we run of space. The partition where the volume was created has been used since we
 	   * checked above. */
@@ -4500,7 +4508,7 @@ fileio_synchronize_directory (THREAD_ENTRY * thread_p, const char *label)
     {
       return ER_FAILED;
     }
-  if (fileio_synchronize (thread_p, fd, path, true) != fd)
+  if (fileio_synchronize (thread_p, fd, path, true) == NULL_VOLDES)
     {
       fileio_close (fd);
       return ER_FAILED;

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -1829,6 +1829,7 @@ fileio_unlock (const char *vol_label_p, int vol_fd, FILEIO_LOCKF_TYPE lockf_type
  *   vdes(in): Volume descriptor
  *   io_pgptr(in): Initialization content of all pages
  *   npages(in): Number of pages to initialize
+ *   metadata(in): Include metadata when syncing.
  *   kbytes_to_be_written_per_sec : size to add volume per sec
  */
 void *
@@ -3980,6 +3981,7 @@ fileio_read (THREAD_ENTRY * thread_p, int vol_fd, void *io_page_p, PAGEID page_i
  *   io_page_p(in): In-memory address where the current content of page resides
  *   page_id(in): Page identifier
  *   page_size(in): Page size
+ *   metadata(in): Include metadata when syncing.
  *
  */
 void *
@@ -4426,6 +4428,7 @@ fileio_fsync_pending (void)
  *   return: vdes or NULL_VOLDES
  *   vol_fd(in): Volume descriptor
  *   vlabel(in): Volume label
+ *   metadata(in): Include metadata when syncing.
  */
 int
 fileio_synchronize (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel, bool metadata)

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -4499,6 +4499,7 @@ fileio_synchronize_directory (THREAD_ENTRY * thread_p, const char *label)
     }
   if (fileio_synchronize (thread_p, fd, path, true) != fd)
     {
+      fileio_close (fd);
       return ER_FAILED;
     }
   fileio_close (fd);

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -1829,12 +1829,12 @@ fileio_unlock (const char *vol_label_p, int vol_fd, FILEIO_LOCKF_TYPE lockf_type
  *   vdes(in): Volume descriptor
  *   io_pgptr(in): Initialization content of all pages
  *   npages(in): Number of pages to initialize
- *   metadata(in): Include metadata when syncing.
+ *   ensure_metadata(in): Include metadata when syncing.
  *   kbytes_to_be_written_per_sec : size to add volume per sec
  */
 void *
 fileio_initialize_pages (THREAD_ENTRY * thread_p, int vol_fd, FILEIO_PAGE * io_page_p, DKNPAGES start_pageid,
-			 DKNPAGES npages, size_t page_size, bool metadata, int kbytes_to_be_written_per_sec)
+			 DKNPAGES npages, size_t page_size, bool ensure_metadata, int kbytes_to_be_written_per_sec)
 {
   PAGEID page_id;
   bool skip_flush = false;
@@ -1890,7 +1890,7 @@ fileio_initialize_pages (THREAD_ENTRY * thread_p, int vol_fd, FILEIO_PAGE * io_p
 	}
 #endif
 
-      if (fileio_write_or_add_to_dwb (thread_p, vol_fd, io_page_p, page_id, page_size, metadata) == NULL)
+      if (fileio_write_or_add_to_dwb (thread_p, vol_fd, io_page_p, page_id, page_size, ensure_metadata) == NULL)
 	{
 	  return NULL;
 	}
@@ -3989,12 +3989,12 @@ fileio_read (THREAD_ENTRY * thread_p, int vol_fd, void *io_page_p, PAGEID page_i
  *   io_page_p(in): In-memory address where the current content of page resides
  *   page_id(in): Page identifier
  *   page_size(in): Page size
- *   metadata(in): Include metadata when syncing.
+ *   ensure_metadata(in): Include metadata when syncing.
  *
  */
 void *
 fileio_write_or_add_to_dwb (THREAD_ENTRY * thread_p, int vol_fd, FILEIO_PAGE * io_page_p, PAGEID page_id,
-			    size_t page_size, bool metadata)
+			    size_t page_size, bool ensure_metadata)
 {
 #if !defined (CS_MODE)
   bool skip_flush = false;
@@ -4022,7 +4022,7 @@ fileio_write_or_add_to_dwb (THREAD_ENTRY * thread_p, int vol_fd, FILEIO_PAGE * i
 	  io_page_p->prv.volid = vol_info_p->volid;
 	  io_page_p->prv.pageid = page_id;
 
-	  error_code = dwb_add_page (thread_p, io_page_p, &vpid, metadata, &p_dwb_slot);
+	  error_code = dwb_add_page (thread_p, io_page_p, &vpid, ensure_metadata, &p_dwb_slot);
 	  if (error_code != NO_ERROR)
 	    {
 	      return NULL;
@@ -4436,10 +4436,10 @@ fileio_fsync_pending (void)
  *   return: vdes or NULL_VOLDES
  *   vol_fd(in): Volume descriptor
  *   vlabel(in): Volume label
- *   metadata(in): Include metadata when syncing.
+ *   ensure_metadata(in): Include metadata when syncing.
  */
 int
-fileio_synchronize (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel, bool metadata)
+fileio_synchronize (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel, bool ensure_metadata)
 {
 #if defined (EnableThreadMonitoring)
   TSC_TICKS start_tick, end_tick;
@@ -4460,7 +4460,7 @@ fileio_synchronize (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel, boo
     }
 #endif
 
-  error = metadata ? fsync (vol_fd) : fdatasync (vol_fd);
+  error = ensure_metadata ? fsync (vol_fd) : fdatasync (vol_fd);
 
 #if defined (EnableThreadMonitoring)
   if (0 < prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD))

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -1833,7 +1833,7 @@ fileio_unlock (const char *vol_label_p, int vol_fd, FILEIO_LOCKF_TYPE lockf_type
  */
 void *
 fileio_initialize_pages (THREAD_ENTRY * thread_p, int vol_fd, FILEIO_PAGE * io_page_p, DKNPAGES start_pageid,
-			 DKNPAGES npages, size_t page_size, int kbytes_to_be_written_per_sec)
+			 DKNPAGES npages, size_t page_size, bool metadata, int kbytes_to_be_written_per_sec)
 {
   PAGEID page_id;
   bool skip_flush = false;
@@ -1889,7 +1889,7 @@ fileio_initialize_pages (THREAD_ENTRY * thread_p, int vol_fd, FILEIO_PAGE * io_p
 	}
 #endif
 
-      if (fileio_write_or_add_to_dwb (thread_p, vol_fd, io_page_p, page_id, page_size) == NULL)
+      if (fileio_write_or_add_to_dwb (thread_p, vol_fd, io_page_p, page_id, page_size, metadata) == NULL)
 	{
 	  return NULL;
 	}
@@ -2290,9 +2290,7 @@ fileio_format (THREAD_ENTRY * thread_p, const char *db_full_name_p, const char *
   FILEIO_PAGE *malloc_io_page_p;
   off_t offset;
   DKNPAGES max_npages;
-#if !defined(WINDOWS)
   struct stat buf;
-#endif
   bool is_raw_device = false;
 
   /* Check for bad number of pages...and overflow */
@@ -2305,7 +2303,6 @@ fileio_format (THREAD_ENTRY * thread_p, const char *db_full_name_p, const char *
   if (fileio_is_volume_exist (vol_label_p) == true && reuse_file == false)
     {
       /* The volume that we are trying to create already exist. Remove it and try again */
-#if !defined(WINDOWS)
       if (lstat (vol_label_p, &buf) != 0)
 	{
 	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_IO_MOUNT_FAIL, 1, vol_label_p);
@@ -2324,10 +2321,6 @@ fileio_format (THREAD_ENTRY * thread_p, const char *db_full_name_p, const char *
 
 	  is_raw_device = S_ISCHR (buf.st_mode);
 	}
-#else /* !WINDOWS */
-      fileio_unformat (thread_p, vol_label_p);
-      is_raw_device = false;
-#endif /* !WINDOWS */
     }
 
   if (is_raw_device)
@@ -2382,59 +2375,54 @@ fileio_format (THREAD_ENTRY * thread_p, const char *db_full_name_p, const char *
   FI_TEST (thread_p, FI_TEST_FILE_IO_FORMAT, 0);
   if (vol_fd != NULL_VOLDES)
     {
+      if (fileio_synchronize_directory (thread_p, vol_label_p) != NO_ERROR)
+	{
+	  fileio_dismount (thread_p, vol_fd);
+	  fileio_unformat (thread_p, vol_label_p);
+	  free_and_init (malloc_io_page_p);
+	  return NULL_VOLDES;
+	}
+
       /* initialize the pages of the volume. */
 
       /* initialize at least two pages, the header page and the last page. in case of is_sweep_clean == true, every
        * page of the volume will be written. */
 
-      if (fileio_write_or_add_to_dwb (thread_p, vol_fd, malloc_io_page_p, 0, page_size) == NULL)
+      if (fileio_write_or_add_to_dwb (thread_p, vol_fd, malloc_io_page_p, 0, page_size, false) == NULL)
 	{
-	  fileio_dismount (thread_p, vol_fd);
-	  fileio_unformat (thread_p, vol_label_p);
-	  free_and_init (malloc_io_page_p);
-
 	  if (er_errid () != ER_INTERRUPTED)
 	    {
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_IO_WRITE, 2, 0, vol_id);
 	    }
 
-	  vol_fd = NULL_VOLDES;
-	  return vol_fd;
+	  fileio_dismount (thread_p, vol_fd);
+	  fileio_unformat (thread_p, vol_label_p);
+	  free_and_init (malloc_io_page_p);
+	  return NULL_VOLDES;
 	}
 
-#if defined(HPUX)
-      if ((is_sweep_clean == true
-	   && !fileio_initialize_pages (vol_fd, malloc_io_page_p, npages, page_size, kbytes_to_be_written_per_sec))
-	  || (is_sweep_clean == false
-	      && !fileio_write (vol_fd, malloc_io_page_p, npages - 1, page_size, FILEIO_WRITE_DEFAULT_WRITE)))
-#else /* HPUX */
-      if (!((fileio_write_or_add_to_dwb (thread_p, vol_fd, malloc_io_page_p, npages - 1, page_size) == malloc_io_page_p)
-	    && (is_sweep_clean == false
-		|| fileio_initialize_pages (thread_p, vol_fd, malloc_io_page_p, 0, npages, page_size,
-					    kbytes_to_be_written_per_sec) == malloc_io_page_p)))
-#endif /* HPUX */
+      if (!((fileio_write_or_add_to_dwb (thread_p, vol_fd, malloc_io_page_p, npages - 1, page_size, true) ==
+	     malloc_io_page_p) && (is_sweep_clean == false
+				   || fileio_initialize_pages (thread_p, vol_fd, malloc_io_page_p, 0, npages, page_size,
+							       false,
+							       kbytes_to_be_written_per_sec) == malloc_io_page_p)))
 	{
 	  /* It is likely that we run of space. The partition where the volume was created has been used since we
 	   * checked above. */
 
 	  max_npages = fileio_get_number_of_partition_free_pages (vol_label_p, page_size);
 
-	  fileio_dismount (thread_p, vol_fd);
-	  fileio_unformat (thread_p, vol_label_p);
-	  free_and_init (malloc_io_page_p);
 	  if (er_errid () != ER_INTERRUPTED)
 	    {
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_IO_FORMAT_OUT_OF_SPACE, 5, vol_label_p, npages,
 		      (offset / 1024), max_npages, (long long) ((page_size / 1024) * max_npages));
 	    }
-	  vol_fd = NULL_VOLDES;
-	  return vol_fd;
-	}
 
-#if defined(WINDOWS)
-      fileio_dismount (thread_p, vol_fd);
-      vol_fd = fileio_mount (thread_p, NULL, vol_label_p, vol_id, false, false);
-#endif /* WINDOWS */
+	  fileio_dismount (thread_p, vol_fd);
+	  fileio_unformat (thread_p, vol_label_p);
+	  free_and_init (malloc_io_page_p);
+	  return NULL_VOLDES;
+	}
     }
   else
     {
@@ -2593,7 +2581,7 @@ fileio_expand_to (THREAD_ENTRY * thread_p, VOLID vol_id, DKNPAGES size_npages, D
   if (voltype == DB_TEMPORARY_VOLTYPE)
     {
       /* Write the last page */
-      if (fileio_write_or_add_to_dwb (thread_p, vol_fd, io_page_p, last_pageid, IO_PAGESIZE) != io_page_p)
+      if (fileio_write_or_add_to_dwb (thread_p, vol_fd, io_page_p, last_pageid, IO_PAGESIZE, false) != io_page_p)
 	{
 	  ASSERT_ERROR_AND_SET (error_code);
 	}
@@ -2604,7 +2592,7 @@ fileio_expand_to (THREAD_ENTRY * thread_p, VOLID vol_id, DKNPAGES size_npages, D
       assert_release (voltype == DB_PERMANENT_VOLTYPE);
 
       if (fileio_initialize_pages (thread_p, vol_fd, io_page_p, start_pageid, last_pageid - start_pageid + 1,
-				   IO_PAGESIZE, -1) == NULL)
+				   IO_PAGESIZE, true, -1) == NULL)
 	{
 	  ASSERT_ERROR_AND_SET (error_code);
 	}
@@ -2802,7 +2790,8 @@ fileio_copy_volume (THREAD_ENTRY * thread_p, int from_vol_desc, DKNPAGES npages,
       for (page_id = 0; page_id < npages; page_id++)
 	{
 	  if (fileio_read (thread_p, from_vol_desc, malloc_io_page_p, page_id, IO_PAGESIZE) == NULL
-	      || fileio_write_or_add_to_dwb (thread_p, to_vol_desc, malloc_io_page_p, page_id, IO_PAGESIZE) == NULL)
+	      || fileio_write_or_add_to_dwb (thread_p, to_vol_desc, malloc_io_page_p, page_id, IO_PAGESIZE,
+					     false) == NULL)
 	    {
 	      goto error;
 	    }
@@ -2820,7 +2809,8 @@ fileio_copy_volume (THREAD_ENTRY * thread_p, int from_vol_desc, DKNPAGES npages,
 	  else
 	    {
 	      fileio_reset_page_lsa (malloc_io_page_p, IO_PAGESIZE);
-	      if (fileio_write_or_add_to_dwb (thread_p, to_vol_desc, malloc_io_page_p, page_id, IO_PAGESIZE) == NULL)
+	      if (fileio_write_or_add_to_dwb (thread_p, to_vol_desc, malloc_io_page_p, page_id, IO_PAGESIZE, false) ==
+		  NULL)
 		{
 		  goto error;
 		}
@@ -2831,7 +2821,7 @@ fileio_copy_volume (THREAD_ENTRY * thread_p, int from_vol_desc, DKNPAGES npages,
 #if !defined(CS_MODE)
   if (dwb_synchronize (thread_p, to_vol_desc, to_vol_label_p) != to_vol_desc)
 #else
-  if (fileio_synchronize (thread_p, to_vol_desc, to_vol_label_p) != to_vol_desc)
+  if (fileio_synchronize (thread_p, to_vol_desc, to_vol_label_p, true) != to_vol_desc)
 #endif
     {
       goto error;
@@ -2882,7 +2872,7 @@ fileio_reset_volume (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel, DK
 	{
 	  fileio_set_page_lsa (malloc_io_page_p, reset_lsa_p, IO_PAGESIZE);
 
-	  if (fileio_write_or_add_to_dwb (thread_p, vol_fd, malloc_io_page_p, page_id, IO_PAGESIZE) == NULL)
+	  if (fileio_write_or_add_to_dwb (thread_p, vol_fd, malloc_io_page_p, page_id, IO_PAGESIZE, false) == NULL)
 	    {
 	      success = ER_FAILED;
 	      break;
@@ -2899,7 +2889,7 @@ fileio_reset_volume (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel, DK
 #if !defined(CS_MODE)
   if (dwb_synchronize (thread_p, vol_fd, vlabel) != vol_fd)
 #else
-  if (fileio_synchronize (thread_p, vol_fd, vlabel) != vol_fd)
+  if (fileio_synchronize (thread_p, vol_fd, vlabel, true) != vol_fd)
 #endif
     {
       success = ER_FAILED;
@@ -3113,7 +3103,7 @@ fileio_dismount (THREAD_ENTRY * thread_p, int vol_fd)
 #if !defined(CS_MODE)
   (void) dwb_synchronize (thread_p, vol_fd, vlabel);
 #else
-  (void) fileio_synchronize (thread_p, vol_fd, vlabel);
+  (void) fileio_synchronize (thread_p, vol_fd, vlabel, true);
 #endif
 
 #if !defined(WINDOWS)
@@ -3319,7 +3309,7 @@ fileio_dismount_volume (THREAD_ENTRY * thread_p, FILEIO_VOLUME_INFO * vol_info_p
 #if !defined(CS_MODE)
       (void) dwb_synchronize (thread_p, vol_info_p->vdes, vol_info_p->vlabel);
 #else
-      (void) fileio_synchronize (thread_p, vol_info_p->vdes, vol_info_p->vlabel);
+      (void) fileio_synchronize (thread_p, vol_info_p->vdes, vol_info_p->vlabel, true);
 #endif
 
 #if !defined(WINDOWS)
@@ -3362,7 +3352,7 @@ fileio_dismount_all (THREAD_ENTRY * thread_p)
       if (sys_vol_info_p->vdes != NULL_VOLDES)
 	{
 	  /* System volume. No need to sync DWB. */
-	  (void) fileio_synchronize (thread_p, sys_vol_info_p->vdes, sys_vol_info_p->vlabel);
+	  (void) fileio_synchronize (thread_p, sys_vol_info_p->vdes, sys_vol_info_p->vlabel, true);
 
 #if !defined(WINDOWS)
 	  if (sys_vol_info_p->lockf_type != FILEIO_NOT_LOCKF)
@@ -3665,7 +3655,7 @@ pwrite_with_injected_fault (THREAD_ENTRY * thread_p, int fd, const void *buf, si
 	      er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_FAILED_ASSERTION, 1, msg);
 
 	      // exit handler
-	      (void) fileio_synchronize (thread_p, fd, vlabel);
+	      (void) fileio_synchronize (thread_p, fd, vlabel, false);
 
 #if !defined(NDEBUG)
 	      if (prm_get_bool_value (PRM_ID_ER_LOG_DEBUG))
@@ -3994,7 +3984,7 @@ fileio_read (THREAD_ENTRY * thread_p, int vol_fd, void *io_page_p, PAGEID page_i
  */
 void *
 fileio_write_or_add_to_dwb (THREAD_ENTRY * thread_p, int vol_fd, FILEIO_PAGE * io_page_p, PAGEID page_id,
-			    size_t page_size)
+			    size_t page_size, bool metadata)
 {
 #if !defined (CS_MODE)
   bool skip_flush = false;
@@ -4022,7 +4012,7 @@ fileio_write_or_add_to_dwb (THREAD_ENTRY * thread_p, int vol_fd, FILEIO_PAGE * i
 	  io_page_p->prv.volid = vol_info_p->volid;
 	  io_page_p->prv.pageid = page_id;
 
-	  error_code = dwb_add_page (thread_p, io_page_p, &vpid, &p_dwb_slot);
+	  error_code = dwb_add_page (thread_p, io_page_p, &vpid, metadata, &p_dwb_slot);
 	  if (error_code != NO_ERROR)
 	    {
 	      return NULL;
@@ -4438,7 +4428,7 @@ fileio_fsync_pending (void)
  *   vlabel(in): Volume label
  */
 int
-fileio_synchronize (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel)
+fileio_synchronize (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel, bool metadata)
 {
 #if defined (EnableThreadMonitoring)
   TSC_TICKS start_tick, end_tick;
@@ -4459,7 +4449,7 @@ fileio_synchronize (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel)
     }
 #endif
 
-  error = fsync (vol_fd);
+  error = metadata ? fsync (vol_fd) : fdatasync (vol_fd);
 
 #if defined (EnableThreadMonitoring)
   if (0 < prm_get_integer_value (PRM_ID_MNT_WAITING_THREAD))
@@ -4486,6 +4476,34 @@ fileio_synchronize (THREAD_ENTRY * thread_p, int vol_fd, const char *vlabel)
 
   perfmon_inc_stat (thread_p, PSTAT_FILE_NUM_IOSYNCHES);
   return vol_fd;
+}
+
+/*
+ * fileio_synchronize_directory () - Synchronize a directory where the volume is located 
+ *   return: ER_FAILED or NO_ERROR 
+ *   label(in): Volume label
+ */
+int
+fileio_synchronize_directory (THREAD_ENTRY * thread_p, const char *label)
+{
+  char path[PATH_MAX + 1];
+  int fd;
+
+  (void) fileio_get_directory_path (path, label);
+
+  /* get the fd for the parent directory */
+  fd = fileio_open (path, O_RDONLY, FILEIO_DISK_PROTECTION_MODE);
+  if (fd == NULL_VOLDES)
+    {
+      return ER_FAILED;
+    }
+  if (fileio_synchronize (thread_p, fd, path, true) != fd)
+    {
+      return ER_FAILED;
+    }
+  fileio_close (fd);
+
+  return NO_ERROR;
 }
 
 /*
@@ -4532,7 +4550,7 @@ fileio_synchronize_sys_volume (THREAD_ENTRY * thread_p, FILEIO_SYSTEM_VOLUME_INF
 
 
       /* System volume. No need to sync DWB. */
-      fileio_synchronize (thread_p, sys_vol_info_p->vdes, sys_vol_info_p->vlabel);
+      fileio_synchronize (thread_p, sys_vol_info_p->vdes, sys_vol_info_p->vlabel, false);
     }
 
   return found;
@@ -4568,7 +4586,7 @@ fileio_synchronize_volume (THREAD_ENTRY * thread_p, FILEIO_VOLUME_INFO * vol_inf
 	  return false;
 	}
 
-      fileio_synchronize (thread_p, vol_info_p->vdes, vol_info_p->vlabel);
+      fileio_synchronize (thread_p, vol_info_p->vdes, vol_info_p->vlabel, false);
     }
 
   return found;
@@ -7358,7 +7376,7 @@ fileio_finish_backup (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session_p
 	  return NULL;
 	}
 
-      if (fileio_synchronize (thread_p, session_p->bkup.vdes, session_p->bkup.name) != session_p->bkup.vdes)
+      if (fileio_synchronize (thread_p, session_p->bkup.vdes, session_p->bkup.name, true) != session_p->bkup.vdes)
 	{
 	  return NULL;
 	}

--- a/src/storage/file_io.h
+++ b/src/storage/file_io.h
@@ -462,7 +462,8 @@ extern int fileio_format (THREAD_ENTRY * thread_p, const char *db_fullname, cons
 extern int fileio_expand_to (THREAD_ENTRY * threda_p, VOLID volid, DKNPAGES npages_toadd, DB_VOLTYPE voltype);
 #endif /* not CS_MODE */
 extern void *fileio_initialize_pages (THREAD_ENTRY * thread_p, int vdes, FILEIO_PAGE * io_pgptr, DKNPAGES start_pageid,
-				      DKNPAGES npages, size_t page_size, int kbytes_to_be_written_per_sec);
+				      DKNPAGES npages, size_t page_size, bool metadata,
+				      int kbytes_to_be_written_per_sec);
 extern void fileio_initialize_res (THREAD_ENTRY * thread_p, FILEIO_PAGE * io_page, PGLENGTH page_size);
 #if defined (ENABLE_UNUSED_FUNCTION)
 extern DKNPAGES fileio_truncate (VOLID volid, DKNPAGES npages_to_resize);
@@ -480,7 +481,7 @@ extern void fileio_dismount_without_fsync (THREAD_ENTRY * thread_p, int vdes);
 extern void fileio_dismount_all (THREAD_ENTRY * thread_p);
 extern void *fileio_read (THREAD_ENTRY * thread_p, int vol_fd, void *io_page_p, PAGEID page_id, size_t page_size);
 extern void *fileio_write_or_add_to_dwb (THREAD_ENTRY * thread_p, int vol_fd, FILEIO_PAGE * io_page_p, PAGEID page_id,
-					 size_t page_size);
+					 size_t page_size, bool metadata);
 extern void *fileio_write (THREAD_ENTRY * thread_p, int vol_fd, void *io_page_p, PAGEID page_id, size_t page_size,
 			   FILEIO_WRITE_MODE write_mode);
 extern void *fileio_read_pages (THREAD_ENTRY * thread_p, int vol_fd, char *io_pages_p, PAGEID page_id, int num_pages,
@@ -490,7 +491,8 @@ extern void *fileio_write_pages (THREAD_ENTRY * thread_p, int vol_fd, char *io_p
 extern void *fileio_writev (THREAD_ENTRY * thread_p, int vdes, void **arrayof_io_pgptr, PAGEID start_pageid,
 			    DKNPAGES npages, size_t page_size);
 extern bool fileio_fsync_pending (void);
-extern int fileio_synchronize (THREAD_ENTRY * thread_p, int vdes, const char *vlabel);
+extern int fileio_synchronize_directory (THREAD_ENTRY * thread_p, const char *label);
+extern int fileio_synchronize (THREAD_ENTRY * thread_p, int vdes, const char *vlabel, bool metadata);
 extern int fileio_synchronize_all (THREAD_ENTRY * thread_p);
 #if defined (ENABLE_UNUSED_FUNCTION)
 extern void *fileio_read_user_area (THREAD_ENTRY * thread_p, int vdes, PAGEID pageid, off_t start_offset, size_t nbytes,

--- a/src/storage/file_io.h
+++ b/src/storage/file_io.h
@@ -462,7 +462,7 @@ extern int fileio_format (THREAD_ENTRY * thread_p, const char *db_fullname, cons
 extern int fileio_expand_to (THREAD_ENTRY * threda_p, VOLID volid, DKNPAGES npages_toadd, DB_VOLTYPE voltype);
 #endif /* not CS_MODE */
 extern void *fileio_initialize_pages (THREAD_ENTRY * thread_p, int vdes, FILEIO_PAGE * io_pgptr, DKNPAGES start_pageid,
-				      DKNPAGES npages, size_t page_size, bool metadata,
+				      DKNPAGES npages, size_t page_size, bool ensure_metadata,
 				      int kbytes_to_be_written_per_sec);
 extern void fileio_initialize_res (THREAD_ENTRY * thread_p, FILEIO_PAGE * io_page, PGLENGTH page_size);
 #if defined (ENABLE_UNUSED_FUNCTION)
@@ -481,7 +481,7 @@ extern void fileio_dismount_without_fsync (THREAD_ENTRY * thread_p, int vdes);
 extern void fileio_dismount_all (THREAD_ENTRY * thread_p);
 extern void *fileio_read (THREAD_ENTRY * thread_p, int vol_fd, void *io_page_p, PAGEID page_id, size_t page_size);
 extern void *fileio_write_or_add_to_dwb (THREAD_ENTRY * thread_p, int vol_fd, FILEIO_PAGE * io_page_p, PAGEID page_id,
-					 size_t page_size, bool metadata);
+					 size_t page_size, bool ensure_metadata);
 extern void *fileio_write (THREAD_ENTRY * thread_p, int vol_fd, void *io_page_p, PAGEID page_id, size_t page_size,
 			   FILEIO_WRITE_MODE write_mode);
 extern void *fileio_read_pages (THREAD_ENTRY * thread_p, int vol_fd, char *io_pages_p, PAGEID page_id, int num_pages,
@@ -492,7 +492,7 @@ extern void *fileio_writev (THREAD_ENTRY * thread_p, int vdes, void **arrayof_io
 			    DKNPAGES npages, size_t page_size);
 extern bool fileio_fsync_pending (void);
 extern int fileio_synchronize_directory (THREAD_ENTRY * thread_p, const char *label);
-extern int fileio_synchronize (THREAD_ENTRY * thread_p, int vdes, const char *vlabel, bool metadata);
+extern int fileio_synchronize (THREAD_ENTRY * thread_p, int vdes, const char *vlabel, bool ensure_metadata);
 extern int fileio_synchronize_all (THREAD_ENTRY * thread_p);
 #if defined (ENABLE_UNUSED_FUNCTION)
 extern void *fileio_read_user_area (THREAD_ENTRY * thread_p, int vdes, PAGEID pageid, off_t start_offset, size_t nbytes,

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -10103,7 +10103,7 @@ start_copy_page:
     }
   if (uses_dwb)
     {
-      error = dwb_set_data_on_next_slot (thread_p, iopage, false, &dwb_slot);
+      error = dwb_set_data_on_next_slot (thread_p, iopage, false, false, &dwb_slot);
       if (error != NO_ERROR)
 	{
 	  return error;
@@ -10152,7 +10152,7 @@ copy_unflushed_lsa:
    */
   if (uses_dwb)
     {
-      error = dwb_add_page (thread_p, iopage, &bufptr->vpid, &dwb_slot);
+      error = dwb_add_page (thread_p, iopage, &bufptr->vpid, false, &dwb_slot);
       if (error == NO_ERROR)
 	{
 	  if (dwb_slot == NULL)

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -2961,7 +2961,7 @@ logpb_write_toflush_pages_to_archive (THREAD_ENTRY * thread_p)
   if ((bg_arv_info->current_page_id - bg_arv_info->last_sync_pageid) > prm_get_integer_value (PRM_ID_PB_SYNC_ON_NFLUSH))
     {
       /* System volume. No need to sync DWB. */
-      fileio_synchronize (thread_p, bg_arv_info->vdes, log_Name_bg_archive);
+      fileio_synchronize (thread_p, bg_arv_info->vdes, log_Name_bg_archive, false);
       bg_arv_info->last_sync_pageid = bg_arv_info->current_page_id;
     }
 }
@@ -3708,7 +3708,7 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
 	  || (log_Stat.total_sync_count % prm_get_integer_value (PRM_ID_SUPPRESS_FSYNC) == 0))
 	{
 	  /* System volume. No need to sync DWB. */
-	  if (fileio_synchronize (thread_p, log_Gl.append.vdes, log_Name_active) == NULL_VOLDES)
+	  if (fileio_synchronize (thread_p, log_Gl.append.vdes, log_Name_active, false) == NULL_VOLDES)
 	    {
 	      error_code = ER_FAILED;
 	      goto error;
@@ -3771,7 +3771,7 @@ logpb_flush_all_append_pages (THREAD_ENTRY * thread_p)
 	}
 
       /* we need to also sync again */
-      if (fileio_synchronize (thread_p, log_Gl.append.vdes, log_Name_active) == NULL_VOLDES)
+      if (fileio_synchronize (thread_p, log_Gl.append.vdes, log_Name_active, false) == NULL_VOLDES)
 	{
 	  error_code = ER_FAILED;
 	  goto error;
@@ -5828,7 +5828,7 @@ logpb_archive_active_log (THREAD_ENTRY * thread_p)
        * Make sure that the whole log archive is in physical storage at this
        * moment. System volume. No need to sync DWB.
        */
-      if (fileio_synchronize (thread_p, vdes, arv_name) == NULL_VOLDES)
+      if (fileio_synchronize (thread_p, vdes, arv_name, false) == NULL_VOLDES)
 	{
 	  goto error;
 	}

--- a/src/transaction/log_writer.c
+++ b/src/transaction/log_writer.c
@@ -1107,7 +1107,7 @@ logwr_flush_all_append_pages (void)
    * Make sure that all of the above log writes are synchronized with any
    * future log writes. That is, the pages should be stored on physical disk.
    */
-  if (need_sync == true && fileio_synchronize (NULL, logwr_Gl.append_vdes, logwr_Gl.active_name) == NULL_VOLDES)
+  if (need_sync == true && fileio_synchronize (NULL, logwr_Gl.append_vdes, logwr_Gl.active_name, false) == NULL_VOLDES)
     {
       assert (er_errid () != NO_ERROR);
       return er_errid ();
@@ -1116,7 +1116,7 @@ logwr_flush_all_append_pages (void)
   /* It's for dual write. */
   if (need_sync == true && prm_get_bool_value (PRM_ID_LOG_BACKGROUND_ARCHIVING))
     {
-      if (fileio_synchronize (NULL, logwr_Gl.bg_archive_info.vdes, logwr_Gl.bg_archive_name) == NULL_VOLDES)
+      if (fileio_synchronize (NULL, logwr_Gl.bg_archive_info.vdes, logwr_Gl.bg_archive_name, false) == NULL_VOLDES)
 	{
 	  assert (er_errid () != NO_ERROR);
 	  return er_errid ();
@@ -1177,7 +1177,7 @@ logwr_flush_bgarv_header_page (void)
 
   if (fileio_write (NULL, bg_arv_info->vdes, log_pgptr, phy_pageid, LOG_PAGESIZE,
 		    FILEIO_WRITE_NO_COMPENSATE_WRITE) == NULL
-      || fileio_synchronize (NULL, bg_arv_info->vdes, logwr_Gl.bg_archive_name) == NULL_VOLDES)
+      || fileio_synchronize (NULL, bg_arv_info->vdes, logwr_Gl.bg_archive_name, false) == NULL_VOLDES)
     {
       if (er_errid () == ER_IO_WRITE_OUT_OF_SPACE)
 	{
@@ -1230,7 +1230,7 @@ logwr_flush_header_page (void)
   /* logwr_Gl.append_vdes is only changed while starting or finishing or recovering server. So, log cs is not needed. */
   if (fileio_write (NULL, logwr_Gl.append_vdes, logwr_Gl.loghdr_pgptr, phy_pageid, LOG_PAGESIZE,
 		    FILEIO_WRITE_NO_COMPENSATE_WRITE) == NULL
-      || fileio_synchronize (NULL, logwr_Gl.append_vdes, logwr_Gl.active_name) == NULL_VOLDES)
+      || fileio_synchronize (NULL, logwr_Gl.append_vdes, logwr_Gl.active_name, false) == NULL_VOLDES)
     {
 
       if (er_errid () == ER_IO_WRITE_OUT_OF_SPACE)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26131>

### Purpose
볼륨의 메타데이터가 변경되지 않았다면 fdatasync를 사용해 데이터만 sync하도록 합니다.

일반적으로 fdatasync를 사용하고, 아래 케이스들에 대해 fsync를 사용합니다.
1. 볼륨 생성 시
2. 볼륨 확장 시 (파일 크기 변경 시)
3. recovery 시 (metadata sync 여부를 확인할 수 없으므로 전부 sync)
4. 유틸리티 사용 시 (backup, copy)

볼륨 생성 시 볼륨이 존재하는 directory를 sync하여 볼륨이 누락되는 경우를 회피합니다.

### Implementation
DWB를 수정하여 페이지를 넣을 때 페이지 별로 sync 여부를 지정할 수 있도록 하였습니다. 이 지정은 `bool metadata`를 통해 할 수 있으며 페이지에 저장되지 않는 정보이므로 서버가 종료되었을 시 저장되지 않습니다. (recovery path)

### Remarks
N/A