### PR TITLE
[CUBRIDQA-1211] fix feature branch filter logic

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
   environment {
     OUTPUT_DIR = 'packages'
     TEST_REPORT = 'reports'
-    JUNIT_REQUIRED = 'true'
+    JUNIT_REQUIRED = "${BRANCH_NAME =~ /^feature\/.*/ ? 'false' : 'true'}"
   }
 
   stages {
@@ -39,7 +39,6 @@ pipeline {
             script {
               if (env.BRANCH_NAME ==~ /^feature\/.*/) {
                 echo 'Skip testing for feature branch'
-                JUNIT_REQUIRED = 'false'
               } else {
             	echo 'Testing...'
             	sh '/entrypoint.sh test || echo "$? failed"'
@@ -81,7 +80,6 @@ pipeline {
             script {
               if (env.BRANCH_NAME ==~ /^feature\/.*/) {
                 echo 'Skip testing for feature branch'
-                JUNIT_REQUIRED = 'false'
               } else {
             	echo 'Testing...'
             	sh '/entrypoint.sh test || echo "$? failed"'


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1211>

### Purpose
feature 브랜치 빌드시 테스트 스킵 로직이 환경변수 JUNIT_REQUIRED 값에 따라 분기되는데,
true 로 고정되어있어 jenkins 에러가 발생.

### Implementation
환경변수 설정시에 브랜치명을 필터링하여 값을 정하도록 변경.

### Remarks

N/A
