### PR TITLE
[CBRD-26242] Performance Bottleneck Caused by Concurrent Access to the Same Page in the Data Buffer

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -9971,6 +9971,7 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
   bool need_locking;
   UPDDEL_CLASS_INSTANCE_LOCK_INFO class_instance_lock_info, *p_class_instance_lock_info = NULL;
 
+  thread_p->m_enable_cached_fix = false;
   thread_p->no_logging = (bool) update->no_logging;
 
   thread_p->no_supplemental_log = (bool) update->no_supplemental_log;
@@ -10834,6 +10835,7 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
   bool need_locking;
   UPDDEL_CLASS_INSTANCE_LOCK_INFO class_instance_lock_info, *p_class_instance_lock_info = NULL;
 
+  thread_p->m_enable_cached_fix = false;
   thread_p->no_logging = (bool) delete_->no_logging;
 
   thread_p->no_supplemental_log = (bool) delete_->no_supplemental_log;
@@ -12114,6 +12116,7 @@ qexec_execute_insert (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
   TP_DOMAIN *result_domain;
   bool has_user_format;
 
+  thread_p->m_enable_cached_fix = false;
   thread_p->no_logging = (bool) insert->no_logging;
 
   aptr = xasl->aptr_list;
@@ -16061,6 +16064,7 @@ qexec_execute_query (THREAD_ENTRY * thread_p, xasl_node * xasl, int dbval_cnt, c
   int client_id = -1;
   const char *db_user = NULL;
   LOG_TDES *tdes = NULL;
+  thread_p->m_enable_cached_fix = true;
 
   tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
   tdes = LOG_FIND_TDES (tran_index);
@@ -16194,6 +16198,7 @@ qexec_execute_query (THREAD_ENTRY * thread_p, xasl_node * xasl, int dbval_cnt, c
   xasl->query_in_progress = true;
   stat = qexec_execute_mainblock (thread_p, xasl, &xasl_state, NULL);
   xasl->query_in_progress = false;
+  thread_p->m_enable_cached_fix = false;
 
 #if defined(SERVER_MODE)
   if (thread_is_on_trace (thread_p))
@@ -24893,6 +24898,7 @@ qexec_execute_merge (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xas
   int savepoint_used = 0;
   LOG_LSA lsa;
 
+  thread_p->m_enable_cached_fix = false;
   /* start a topop */
   error = xtran_server_start_topop (thread_p, &lsa);
   if (error != NO_ERROR)

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -3042,6 +3042,8 @@ scan_open_index_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
   int func_index_col_id;
   static bool oracle_style_empty_string = prm_get_bool_value (PRM_ID_ORACLE_STYLE_EMPTY_STRING);
 
+  pgbuf_cache_initialize (thread_p);
+
   /* scan type is INDEX SCAN */
   scan_id->type = S_INDX_SCAN;
 

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -1866,7 +1866,7 @@ btree_fix_root_with_info (THREAD_ENTRY * thread_p, BTID * btid, PGBUF_LATCH_MODE
   root_vpid_p->volid = btid->vfid.volid;
 
   /* Fix root page. */
-  root_page = pgbuf_fix (thread_p, root_vpid_p, OLD_PAGE, latch_mode, PGBUF_UNCONDITIONAL_LATCH);
+  root_page = pgbuf_cached_fix (thread_p, root_vpid_p, OLD_PAGE, latch_mode, PGBUF_UNCONDITIONAL_LATCH);
   if (root_page == NULL)
     {
       /* Failed fixing root page. */
@@ -23507,7 +23507,8 @@ btree_advance_and_find_key (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB_VAL
 
       /* Advance to child. */
       assert (!VPID_ISNULL (&child_vpid));
-      *advance_to_page = pgbuf_fix (thread_p, &child_vpid, OLD_PAGE, PGBUF_LATCH_READ, PGBUF_UNCONDITIONAL_LATCH);
+      *advance_to_page =
+	pgbuf_cached_fix (thread_p, &child_vpid, OLD_PAGE, PGBUF_LATCH_READ, PGBUF_UNCONDITIONAL_LATCH);
       if (*advance_to_page == NULL)
 	{
 	  /* Error fixing child. */

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -28,6 +28,7 @@
 #include <stddef.h>
 #include <string.h>
 #include <assert.h>
+#include <atomic>
 
 #include "page_buffer.h"
 
@@ -504,7 +505,8 @@ struct pgbuf_bcb
 						 * be changed atomically... 2-byte sized atomic operations are not
 						 * common. */
   int hit_age;			/* age of last hit (used to compute activities and quotas) */
-
+    std::atomic_uint64_t write_seq;	/* write sequence number for pgbuf cache */
+  bool is_cached_fake_bcb;
   LOG_LSA oldest_unflush_lsa;	/* The oldest LSA record of the page that has not been written to disk */
   PGBUF_IOPAGE_BUFFER *iopage_buffer;	/* pointer to iopage buffer structure */
 };
@@ -716,6 +718,35 @@ struct pgbuf_direct_victim
 };
 #define PGBUF_FLUSHED_BCBS_BUFFER_SIZE (8 * 1024)	/* 8k */
 #endif /* SERVER_MODE */
+
+typedef struct pgbuf_cache_entry PGBUF_CACHE_ENTRY;
+struct pgbuf_cache_entry
+{
+  VPID vpid;
+  uint64_t write_seq;
+  PGBUF_BCB *orig_bcb;
+  PGBUF_BCB *fake_bcb;
+  PGBUF_IOPAGE_BUFFER *iopage_buffer;
+  char *page_p;
+};
+
+typedef struct pgbuf_cache_array PGBUF_CACHE_ARRAY;
+struct pgbuf_cache_array
+{
+  PGBUF_CACHE_ENTRY *entries;
+  uint32_t count;
+  uint32_t max_count;
+};
+
+typedef struct pgbuf_cache PGBUF_CACHE;
+struct pgbuf_cache
+{
+  PGBUF_CACHE_ARRAY *cache_arrays;	/* cache_arrays [thread_p->index] */
+    std::atomic_uint64_t cache_used_pages;	/* used size of cache */
+  uint64_t cache_max_pages;	/* max size of cache */
+};
+
+static PGBUF_CACHE pgbuf_Cache;
 
 /* The buffer Pool */
 struct pgbuf_buffer_pool
@@ -1235,6 +1266,10 @@ static cubthread::daemon *pgbuf_Flush_control_daemon = NULL;
 
 static bool pgbuf_is_page_flush_daemon_available ();
 
+STATIC_INLINE int pgbuf_cache_entry (PGBUF_CACHE_ENTRY * entry, PAGE_PTR pgptr) __attribute__ ((ALWAYS_INLINE));
+static int pgbuf_cache_global_initialize (void);
+static int pgbuf_cache_global_finalize (void);
+static void pgbuf_unfix_without_cache (THREAD_ENTRY * thread_p, PAGE_PTR pgptr);
 /*
  * pgbuf_hash_func_mirror () - Hash VPID into hash anchor
  *   return: hash value
@@ -1520,6 +1555,11 @@ pgbuf_initialize (void)
   pthread_mutex_init (&pgbuf_Pool.show_status_mutex, NULL);
 #endif
 
+  if (pgbuf_cache_global_initialize () != NO_ERROR)
+    {
+      goto error;
+    }
+
   return NO_ERROR;
 
 error:
@@ -1716,6 +1756,8 @@ pgbuf_finalize (void)
       free (pgbuf_Pool.show_status);
       pgbuf_Pool.show_status = NULL;
     }
+
+  (void) pgbuf_cache_global_finalize ();
 
 #if defined(SERVER_MODE)
   pthread_mutex_destroy (&pgbuf_Pool.show_status_mutex);
@@ -2178,6 +2220,235 @@ try_again:
   return pgptr;
 }
 
+#define PGBUF_INIT_CACHE_ENTRY(entry) \
+  (entry)->vpid = vpid_Null_vpid; \
+  (entry)->write_seq = 0; \
+  (entry)->orig_bcb = NULL; \
+  (entry)->fake_bcb = NULL; \
+  (entry)->iopage_buffer = NULL; \
+  (entry)->page_p = NULL;
+
+int
+pgbuf_cache_global_initialize (void)
+{
+  size_t max_thread_entry_count = thread_get_manager ()->get_max_thread_count ();
+  pgbuf_Cache.cache_max_pages = 64 * 1024;	/* 16KB pages * 64 * 1024 = 1GB */
+  placement_new (&pgbuf_Cache.cache_used_pages);
+  pgbuf_Cache.cache_arrays = (PGBUF_CACHE_ARRAY *) malloc (max_thread_entry_count * sizeof (PGBUF_CACHE_ARRAY));
+  for (size_t i = 0; i < max_thread_entry_count; i++)
+    {
+      pgbuf_Cache.cache_arrays[i].entries = NULL;
+      pgbuf_Cache.cache_arrays[i].count = 0;
+      pgbuf_Cache.cache_arrays[i].max_count = 0;
+    }
+  return NO_ERROR;
+}
+
+int
+pgbuf_cache_global_finalize (void)
+{
+#if !defined (NDEBUG)
+  size_t max_thread_entry_count = thread_get_manager ()->get_max_thread_count ();
+  for (size_t i = 0; i < max_thread_entry_count; i++)
+    {
+      assert (pgbuf_Cache.cache_arrays[i].entries == NULL);
+    }
+#endif
+  free (pgbuf_Cache.cache_arrays);
+  pgbuf_Cache.cache_arrays = NULL;
+  pgbuf_Cache.cache_used_pages.store (0);
+  return NO_ERROR;
+}
+
+int
+pgbuf_cache_initialize (THREAD_ENTRY * thread_p)
+{
+  size_t thread_entry_index = thread_get_entry_index (thread_p);
+  const uint32_t default_page_request_count = 128;
+
+  if (pgbuf_Cache.cache_arrays[thread_entry_index].entries != NULL)
+    {
+      /* already initialized */
+      return NO_ERROR;
+    }
+  uint64_t used_page_count = pgbuf_Cache.cache_used_pages.load ();
+  if (used_page_count + (uint64_t) default_page_request_count > pgbuf_Cache.cache_max_pages)
+    {
+      /* cache is full */
+      return NO_ERROR;
+    }
+  if (!pgbuf_Cache.cache_used_pages.compare_exchange_strong (used_page_count,
+							     used_page_count + (uint64_t) default_page_request_count))
+    {
+      return NO_ERROR;
+    }
+  PGBUF_CACHE_ARRAY *cache_array = &pgbuf_Cache.cache_arrays[thread_entry_index];
+  cache_array->entries = (PGBUF_CACHE_ENTRY *) malloc (default_page_request_count * sizeof (PGBUF_CACHE_ENTRY));
+  cache_array->count = 0;
+  cache_array->max_count = default_page_request_count;
+  for (uint32_t i = 0; i < default_page_request_count; i++)
+    {
+      PGBUF_INIT_CACHE_ENTRY (&(cache_array->entries[i]));
+    }
+  return NO_ERROR;
+}
+
+int
+pgbuf_cache_finalize (THREAD_ENTRY * thread_p)
+{
+  size_t thread_entry_index = thread_get_entry_index (thread_p);
+  PGBUF_CACHE_ARRAY *cache_array = &pgbuf_Cache.cache_arrays[thread_entry_index];
+  if (cache_array->entries != NULL)
+    {
+      for (uint32_t i = 0; i < cache_array->max_count; i++)
+	{
+	  PGBUF_CACHE_ENTRY *entry = &cache_array->entries[i];
+	  if (entry->iopage_buffer != NULL)
+	    {
+	      free (entry->iopage_buffer);
+	      entry->iopage_buffer = NULL;
+	    }
+	  if (entry->fake_bcb != NULL)
+	    {
+	      free (entry->fake_bcb);
+	      entry->fake_bcb = NULL;
+	    }
+	}
+      free (cache_array->entries);
+      cache_array->entries = NULL;
+      cache_array->count = 0;
+      cache_array->max_count = 0;
+    }
+  return NO_ERROR;
+}
+
+STATIC_INLINE int
+pgbuf_cache_entry (PGBUF_CACHE_ENTRY * entry, PAGE_PTR pgptr)
+{
+  PGBUF_BCB *bufptr;
+
+  CAST_PGPTR_TO_BFPTR (bufptr, pgptr);
+
+  entry->orig_bcb = bufptr;
+  entry->write_seq = bufptr->write_seq.load ();
+  entry->vpid = bufptr->vpid;
+
+  entry->iopage_buffer = (PGBUF_IOPAGE_BUFFER *) malloc (PGBUF_IOPAGE_BUFFER_SIZE);
+  if (entry->iopage_buffer == NULL)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, IO_PAGESIZE);
+      return ER_FAILED;
+    }
+  memcpy (entry->iopage_buffer, bufptr->iopage_buffer, IO_PAGESIZE);
+  entry->fake_bcb = (PGBUF_BCB *) malloc (PGBUF_BCB_SIZEOF);
+  if (entry->fake_bcb == NULL)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, PGBUF_BCB_SIZEOF);
+      return ER_FAILED;
+    }
+  memcpy (entry->fake_bcb, bufptr, PGBUF_BCB_SIZEOF);
+  entry->iopage_buffer->bcb = entry->fake_bcb;
+  entry->fake_bcb->iopage_buffer = entry->iopage_buffer;
+  CAST_BFPTR_TO_PGPTR (entry->page_p, entry->fake_bcb);
+  entry->fake_bcb->is_cached_fake_bcb = true;
+  return NO_ERROR;
+}
+
+PAGE_PTR
+pgbuf_cached_fix (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_MODE fetch_mode,
+		  PGBUF_LATCH_MODE requestmode, PGBUF_LATCH_CONDITION condition)
+{
+  if ((fetch_mode != OLD_PAGE_PREVENT_DEALLOC && fetch_mode != OLD_PAGE)
+      || requestmode != PGBUF_LATCH_READ || condition != PGBUF_UNCONDITIONAL_LATCH)
+    {
+      return pgbuf_fix (thread_p, vpid, fetch_mode, requestmode, condition);
+    }
+
+  size_t thread_entry_index = thread_get_entry_index (thread_p);
+  PGBUF_CACHE_ARRAY *cache_array = &pgbuf_Cache.cache_arrays[thread_entry_index];
+  PGBUF_CACHE_ENTRY *entry = NULL;
+  PAGE_PTR pgptr = NULL;
+  bool found = false;
+
+  if (cache_array->max_count == 0)
+    {
+      /* not target */
+      return pgbuf_fix (thread_p, vpid, fetch_mode, requestmode, condition);
+    }
+
+  for (uint32_t i = 0; i < cache_array->max_count; i++)
+    {
+      if (VPID_EQ (vpid, &cache_array->entries[i].vpid))
+	{
+	  found = true;
+	  entry = &cache_array->entries[i];
+	  break;
+	}
+    }
+  if (found)
+    {
+      /* 1. check write sequence number changed */
+      if (entry->write_seq != entry->orig_bcb->write_seq.load ())
+	{
+	  goto recache_page;
+	}
+      /* 2. check bcb has exactly that page? */
+      if (!VPID_EQ (&entry->vpid, &entry->orig_bcb->vpid))
+	{
+	  goto recache_page;
+	}
+      /* TODO: further check needed? */
+      return entry->page_p;
+    }
+  else
+    {
+      found = false;
+      for (uint32_t i = 0; i < cache_array->max_count; i++)
+	{
+	  if (cache_array->entries[i].vpid.pageid == NULL_PAGEID)
+	    {
+	      entry = &cache_array->entries[i];
+	      found = true;
+	      break;
+	    }
+	}
+      if (!found)
+	{
+	  /* cache is full */
+	  return pgbuf_fix (thread_p, vpid, fetch_mode, requestmode, condition);
+	}
+      pgptr = pgbuf_fix (thread_p, vpid, fetch_mode, requestmode, condition);
+      if (pgptr != NULL)
+	{
+	  pgbuf_cache_entry (entry, pgptr);
+	  pgbuf_unfix_without_cache (thread_p, pgptr);
+	  cache_array->count++;
+	  return entry->page_p;
+	}
+      return pgptr;
+    }
+  return pgptr;
+
+recache_page:
+  PGBUF_INIT_CACHE_ENTRY (entry);
+  pgptr = pgbuf_fix (thread_p, vpid, fetch_mode, requestmode, condition);
+  if (pgptr != NULL)
+    {
+      pgbuf_cache_entry (entry, pgptr);
+      pgbuf_unfix_without_cache (thread_p, pgptr);
+      return entry->page_p;
+    }
+  return pgptr;
+}
+
+bool
+pgbuf_cached_unfix (THREAD_ENTRY * thread_p, PAGE_PTR pgptr)
+{
+  PGBUF_BCB *bufptr;
+  CAST_PGPTR_TO_BFPTR (bufptr, pgptr);
+  return bufptr->is_cached_fake_bcb;
+}
+
 /*
  * pgbuf_simple_fix () - Copy a portion of a page to the given area
  *   return: area or NULL
@@ -2606,6 +2877,11 @@ pgbuf_unfix (THREAD_ENTRY * thread_p, PAGE_PTR pgptr)
   LOG_LSA restart_lsa;
 #endif /* CUBRID_DEBUG */
 
+  if (pgbuf_cached_unfix (thread_p, pgptr))
+    {
+      return;
+    }
+
 #if !defined (NDEBUG)
   assert (pgptr != NULL);
 
@@ -2785,6 +3061,91 @@ pgbuf_unfix (THREAD_ENTRY * thread_p, PAGE_PTR pgptr)
       PGBUF_BCB_UNLOCK (bufptr);
     }
 #endif /* CUBRID_DEBUG */
+}
+
+
+static void
+pgbuf_unfix_without_cache (THREAD_ENTRY * thread_p, PAGE_PTR pgptr)
+{
+  PGBUF_BCB *bufptr;
+  int holder_status;
+  PERF_HOLDER_LATCH perf_holder_latch;
+  PGBUF_HOLDER *holder;
+  PGBUF_WATCHER *watcher;
+  PGBUF_HOLDER_STAT holder_perf_stat;
+  PERF_PAGE_TYPE perf_page_type = PERF_PAGE_UNKNOWN;
+  bool is_perf_tracking;
+
+#if !defined (NDEBUG)
+  assert (pgptr != NULL);
+
+  if (pgbuf_get_check_page_validation_level (PGBUF_DEBUG_PAGE_VALIDATION_FREE))
+    {
+      if (pgbuf_is_valid_page_ptr (pgptr) == false)
+	{
+	  return;
+	}
+    }
+
+  holder = pgbuf_get_holder (thread_p, pgptr);
+
+  assert (holder != NULL);
+
+  watcher = holder->last_watcher;
+  while (watcher != NULL)
+    {
+      assert (watcher->magic == PGBUF_WATCHER_MAGIC_NUMBER);
+      watcher = watcher->prev;
+    }
+#else /* !NDEBUG */
+  if (pgptr == NULL)
+    {
+      return;
+    }
+#endif /* !NDEBUG */
+
+  /* Get the address of the buffer from the page and free the buffer */
+  CAST_PGPTR_TO_BFPTR (bufptr, pgptr);
+  assert (!VPID_ISNULL (&bufptr->vpid));
+
+  is_perf_tracking = perfmon_is_perf_tracking ();
+  if (is_perf_tracking)
+    {
+      perf_page_type = pgbuf_get_page_type_for_stat (thread_p, pgptr);
+    }
+  INIT_HOLDER_STAT (&holder_perf_stat);
+  holder_status = pgbuf_unlatch_thrd_holder (thread_p, bufptr, &holder_perf_stat);
+
+  assert (holder_perf_stat.hold_has_write_latch == 1 || holder_perf_stat.hold_has_read_latch == 1);
+
+  if (is_perf_tracking)
+    {
+      if (holder_perf_stat.hold_has_read_latch && holder_perf_stat.hold_has_write_latch)
+	{
+	  perf_holder_latch = PERF_HOLDER_LATCH_MIXED;
+	}
+      else if (holder_perf_stat.hold_has_read_latch)
+	{
+	  perf_holder_latch = PERF_HOLDER_LATCH_READ;
+	}
+      else
+	{
+	  assert (holder_perf_stat.hold_has_write_latch);
+	  perf_holder_latch = PERF_HOLDER_LATCH_WRITE;
+	}
+      perfmon_pbx_unfix (thread_p, perf_page_type, holder_perf_stat.dirty_before_hold,
+			 holder_perf_stat.dirtied_by_holder, perf_holder_latch);
+    }
+
+  PGBUF_BCB_LOCK (bufptr);
+
+#if !defined (NDEBUG)
+  thread_p->get_pgbuf_tracker ().decrement (pgptr);
+#endif // !NDEBUG
+  (void) pgbuf_unlatch_bcb_upon_unfix (thread_p, bufptr, holder_status);
+  /* bufptr->mutex has been released in above function. */
+
+  PGBUF_BCB_CHECK_MUTEX_LEAKS ();
 }
 
 /*
@@ -5143,6 +5504,8 @@ pgbuf_initialize_bcb_table (void)
       bufptr->flags = PGBUF_BCB_INIT_FLAGS;
       bufptr->count_fix_and_avoid_dealloc = 0;
       bufptr->hit_age = 0;
+      placement_new (&bufptr->write_seq, 0);
+      bufptr->is_cached_fake_bcb = false;
       LSA_SET_NULL (&bufptr->oldest_unflush_lsa);
 
       bufptr->tick_lru3 = 0;
@@ -5846,6 +6209,12 @@ pgbuf_latch_bcb_upon_fix (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr, PGBUF_LAT
 
   /* the caller is holding bufptr->mutex */
   is_page_idle = false;
+
+  if (request_mode != PGBUF_LATCH_READ)
+    {
+      bufptr->write_seq.fetch_add (1);
+    }
+
   if (buf_lock_acquired || bufptr->latch_mode == PGBUF_NO_LATCH)
     {
       is_page_idle = true;
@@ -7805,6 +8174,7 @@ pgbuf_claim_bcb_for_fix (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_
 
   /* initialize the BCB */
   bufptr->vpid = *vpid;
+  bufptr->write_seq.store (0);
   assert (!pgbuf_bcb_avoid_victim (bufptr));
   bufptr->latch_mode = PGBUF_NO_LATCH;
   pgbuf_bcb_update_flags (thread_p, bufptr, 0, PGBUF_BCB_ASYNC_FLUSH_REQ);	/* todo: why this?? */
@@ -10030,6 +10400,7 @@ pgbuf_bcb_flush_with_wal (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr, bool is_p
   TDE_ALGORITHM tde_algo = TDE_ALGORITHM_NONE;
   int tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
   PGBUF_STATUS *show_status = &pgbuf_Pool.show_status[tran_index];
+  bufptr->write_seq.fetch_add (1);
 
 
   PGBUF_BCB_CHECK_OWN (bufptr);

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -734,8 +734,6 @@ typedef struct pgbuf_cache_array PGBUF_CACHE_ARRAY;
 struct pgbuf_cache_array
 {
   PGBUF_CACHE_ENTRY *entries;
-  uint32_t count;
-  uint32_t max_count;
 };
 
 typedef struct pgbuf_cache PGBUF_CACHE;
@@ -2284,8 +2282,6 @@ pgbuf_cache_global_initialize (void)
   for (size_t i = 0; i < max_thread_entry_count; i++)
     {
       pgbuf_Cache.cache_arrays[i].entries = NULL;
-      pgbuf_Cache.cache_arrays[i].count = 0;
-      pgbuf_Cache.cache_arrays[i].max_count = 0;
     }
   return NO_ERROR;
 }
@@ -2336,8 +2332,9 @@ pgbuf_cache_initialize (THREAD_ENTRY * thread_p)
     }
   PGBUF_CACHE_ARRAY *cache_array = &pgbuf_Cache.cache_arrays[thread_entry_index];
   cache_array->entries = (PGBUF_CACHE_ENTRY *) malloc (default_page_request_count * sizeof (PGBUF_CACHE_ENTRY));
-  cache_array->count = 0;
-  cache_array->max_count = default_page_request_count;
+  thread_p->m_pgbuf_cache_count = 0;
+  thread_p->m_pgbuf_cache_max = default_page_request_count;
+  thread_p->m_pgbuf_cache_entries = (void *) cache_array->entries;
   for (uint32_t i = 0; i < default_page_request_count; i++)
     {
       PGBUF_INIT_CACHE_ENTRY (&(cache_array->entries[i]));
@@ -2353,9 +2350,9 @@ pgbuf_cache_finalize (THREAD_ENTRY * thread_p)
 #endif
   size_t thread_entry_index = thread_get_entry_index (thread_p);
   PGBUF_CACHE_ARRAY *cache_array = &pgbuf_Cache.cache_arrays[thread_entry_index];
-  if (cache_array->entries != NULL)
+  if (thread_p->m_pgbuf_cache_max != 0)
     {
-      for (uint32_t i = 0; i < cache_array->max_count; i++)
+      for (uint32_t i = 0; i < thread_p->m_pgbuf_cache_max; i++)
 	{
 	  PGBUF_CACHE_ENTRY *entry = &cache_array->entries[i];
 	  if (entry->iopage_buffer != NULL)
@@ -2371,8 +2368,9 @@ pgbuf_cache_finalize (THREAD_ENTRY * thread_p)
 	}
       free (cache_array->entries);
       cache_array->entries = NULL;
-      cache_array->count = 0;
-      cache_array->max_count = 0;
+      thread_p->m_pgbuf_cache_count = 0;
+      thread_p->m_pgbuf_cache_max = 0;
+      thread_p->m_pgbuf_cache_entries = NULL;
     }
   return NO_ERROR;
 }
@@ -2422,24 +2420,24 @@ pgbuf_cached_fix (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_MODE fe
       return pgbuf_fix (thread_p, vpid, fetch_mode, requestmode, condition);
     }
 
-  size_t thread_entry_index = thread_get_entry_index (thread_p);
-  PGBUF_CACHE_ARRAY *cache_array = &pgbuf_Cache.cache_arrays[thread_entry_index];
+  PGBUF_CACHE_ENTRY *entries = (PGBUF_CACHE_ENTRY *) thread_p->m_pgbuf_cache_entries;
   PGBUF_CACHE_ENTRY *entry = NULL;
   PAGE_PTR pgptr = NULL;
   bool found = false;
+  uint32_t max_count = thread_p->m_pgbuf_cache_max, count = thread_p->m_pgbuf_cache_count;
 
-  if (cache_array->max_count == 0)
+  if (max_count == 0)
     {
       /* not target */
       return pgbuf_fix (thread_p, vpid, fetch_mode, requestmode, condition);
     }
 
-  for (uint32_t i = 0; i < cache_array->max_count; i++)
+  for (uint32_t i = 0; i < count; i++)
     {
-      if (VPID_EQ (vpid, &cache_array->entries[i].vpid))
+      if (vpid->pageid == entries[i].vpid.pageid && vpid->volid == entries[i].vpid.volid)
 	{
 	  found = true;
-	  entry = &cache_array->entries[i];
+	  entry = &entries[i];
 	  break;
 	}
     }
@@ -2461,11 +2459,11 @@ pgbuf_cached_fix (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_MODE fe
   else
     {
       found = false;
-      for (uint32_t i = 0; i < cache_array->max_count; i++)
+      for (uint32_t i = count; i < max_count; i++)
 	{
-	  if (cache_array->entries[i].vpid.pageid == NULL_PAGEID)
+	  if (likely(entries[i].vpid.pageid == NULL_PAGEID))
 	    {
-	      entry = &cache_array->entries[i];
+	      entry = &entries[i];
 	      found = true;
 	      break;
 	    }
@@ -2480,7 +2478,7 @@ pgbuf_cached_fix (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_MODE fe
 	{
 	  pgbuf_cache_entry (entry, pgptr);
 	  pgbuf_unfix_without_cache (thread_p, pgptr);
-	  cache_array->count++;
+	  thread_p->m_pgbuf_cache_count++;
 	  return entry->page_p;
 	}
       return pgptr;

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -2228,6 +2228,49 @@ try_again:
   (entry)->iopage_buffer = NULL; \
   (entry)->page_p = NULL;
 
+#if defined(SERVER_MODE)
+#define PGBUF_COPY_BCB(dest, src) \
+  do { \
+    (dest)->vpid = (src)->vpid; \
+    (dest)->fcnt = (src)->fcnt; \
+    (dest)->latch_mode = (src)->latch_mode; \
+    (dest)->flags = (src)->flags; \
+    (dest)->owner_mutex = (src)->owner_mutex; \
+    (dest)->mutex = (src)->mutex; \
+    (dest)->next_wait_thrd = (src)->next_wait_thrd; \
+    (dest)->hash_next = (src)->hash_next; \
+    (dest)->prev_BCB = (src)->prev_BCB; \
+    (dest)->next_BCB = (src)->next_BCB; \
+    (dest)->tick_lru_list = (src)->tick_lru_list; \
+    (dest)->tick_lru3 = (src)->tick_lru3; \
+    (dest)->count_fix_and_avoid_dealloc = (src)->count_fix_and_avoid_dealloc; \
+    (dest)->hit_age = (src)->hit_age; \
+    (dest)->write_seq = (src)->write_seq.load (); \
+    (dest)->is_cached_fake_bcb = (src)->is_cached_fake_bcb; \
+    (dest)->oldest_unflush_lsa = (src)->oldest_unflush_lsa; \
+    (dest)->iopage_buffer = (src)->iopage_buffer; \
+  } while (0)
+#else /* SERVER_MODE */
+#define PGBUF_COPY_BCB(dest, src) \
+  do { \
+    (dest)->vpid = (src)->vpid; \
+    (dest)->fcnt = (src)->fcnt; \
+    (dest)->latch_mode = (src)->latch_mode; \
+    (dest)->flags = (src)->flags; \
+    (dest)->hash_next = (src)->hash_next; \
+    (dest)->prev_BCB = (src)->prev_BCB; \
+    (dest)->next_BCB = (src)->next_BCB; \
+    (dest)->tick_lru_list = (src)->tick_lru_list; \
+    (dest)->tick_lru3 = (src)->tick_lru3; \
+    (dest)->count_fix_and_avoid_dealloc = (src)->count_fix_and_avoid_dealloc; \
+    (dest)->hit_age = (src)->hit_age; \
+    (dest)->write_seq = (src)->write_seq.load (); \
+    (dest)->is_cached_fake_bcb = (src)->is_cached_fake_bcb; \
+    (dest)->oldest_unflush_lsa = (src)->oldest_unflush_lsa; \
+    (dest)->iopage_buffer = (src)->iopage_buffer; \
+  } while (0)
+#endif /* SERVER_MODE */
+
 int
 pgbuf_cache_global_initialize (void)
 {
@@ -2346,7 +2389,7 @@ pgbuf_cache_entry (PGBUF_CACHE_ENTRY * entry, PAGE_PTR pgptr)
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, PGBUF_BCB_SIZEOF);
       return ER_FAILED;
     }
-  memcpy (entry->fake_bcb, bufptr, PGBUF_BCB_SIZEOF);
+  PGBUF_COPY_BCB (entry->fake_bcb, bufptr);
   entry->iopage_buffer->bcb = entry->fake_bcb;
   entry->fake_bcb->iopage_buffer = entry->iopage_buffer;
   CAST_BFPTR_TO_PGPTR (entry->page_p, entry->fake_bcb);

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -2461,7 +2461,7 @@ pgbuf_cached_fix (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_MODE fe
       found = false;
       for (uint32_t i = count; i < max_count; i++)
 	{
-	  if (likely(entries[i].vpid.pageid == NULL_PAGEID))
+	  if (likely (entries[i].vpid.pageid == NULL_PAGEID))
 	    {
 	      entry = &entries[i];
 	      found = true;

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -2718,6 +2718,7 @@ pgbuf_promote_read_latch_release (THREAD_ENTRY * thread_p, PAGE_PTR * pgptr_p, P
     {
       *pgptr_p = pgbuf_fix (thread_p, &bufptr->vpid, OLD_PAGE, PGBUF_LATCH_READ, PGBUF_UNCONDITIONAL_LATCH);
       CAST_PGPTR_TO_BFPTR (bufptr, *pgptr_p);
+      bufptr->write_seq.fetch_add (1);
     }
   assert (!VPID_ISNULL (&bufptr->vpid));
 

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -2653,6 +2653,11 @@ pgbuf_promote_read_latch_release (THREAD_ENTRY * thread_p, PAGE_PTR * pgptr_p, P
 
   /* fetch BCB from page pointer */
   CAST_PGPTR_TO_BFPTR (bufptr, *pgptr_p);
+  if (bufptr->is_cached_fake_bcb)
+    {
+      *pgptr_p = pgbuf_fix (thread_p, &bufptr->vpid, OLD_PAGE, PGBUF_LATCH_READ, PGBUF_UNCONDITIONAL_LATCH);
+      CAST_PGPTR_TO_BFPTR (bufptr, *pgptr_p);
+    }
   assert (!VPID_ISNULL (&bufptr->vpid));
 
   /* check latch mode - no need for BCB mutex, page is already latched */
@@ -2784,6 +2789,7 @@ pgbuf_promote_read_latch_release (THREAD_ENTRY * thread_p, PAGE_PTR * pgptr_p, P
 	      thread_p->wait_for_latch_promote = false;
 	      return ER_FAILED;
 	    }
+	  bufptr->write_seq.fetch_add (1);
 
 	  /* NOTE: BCB mutex is no longer held at this point */
 

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -2274,6 +2274,9 @@ try_again:
 int
 pgbuf_cache_global_initialize (void)
 {
+#if defined(SA_MODE)
+  return NO_ERROR;
+#endif
   size_t max_thread_entry_count = thread_get_manager ()->get_max_thread_count ();
   pgbuf_Cache.cache_max_pages = 64 * 1024;	/* 16KB pages * 64 * 1024 = 1GB */
   placement_new (&pgbuf_Cache.cache_used_pages);
@@ -2290,6 +2293,9 @@ pgbuf_cache_global_initialize (void)
 int
 pgbuf_cache_global_finalize (void)
 {
+#if defined(SA_MODE)
+  return NO_ERROR;
+#endif
 #if !defined (NDEBUG)
   size_t max_thread_entry_count = thread_get_manager ()->get_max_thread_count ();
   for (size_t i = 0; i < max_thread_entry_count; i++)
@@ -2306,6 +2312,9 @@ pgbuf_cache_global_finalize (void)
 int
 pgbuf_cache_initialize (THREAD_ENTRY * thread_p)
 {
+#if defined(SA_MODE)
+  return NO_ERROR;
+#endif
   size_t thread_entry_index = thread_get_entry_index (thread_p);
   const uint32_t default_page_request_count = 128;
 
@@ -2339,6 +2348,9 @@ pgbuf_cache_initialize (THREAD_ENTRY * thread_p)
 int
 pgbuf_cache_finalize (THREAD_ENTRY * thread_p)
 {
+#if defined(SA_MODE)
+  return NO_ERROR;
+#endif
   size_t thread_entry_index = thread_get_entry_index (thread_p);
   PGBUF_CACHE_ARRAY *cache_array = &pgbuf_Cache.cache_arrays[thread_entry_index];
   if (cache_array->entries != NULL)
@@ -2401,6 +2413,9 @@ PAGE_PTR
 pgbuf_cached_fix (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_MODE fetch_mode,
 		  PGBUF_LATCH_MODE requestmode, PGBUF_LATCH_CONDITION condition)
 {
+#if defined(SA_MODE)
+  return pgbuf_fix (thread_p, vpid, fetch_mode, requestmode, condition);
+#endif
   if ((fetch_mode != OLD_PAGE_PREVENT_DEALLOC && fetch_mode != OLD_PAGE)
       || requestmode != PGBUF_LATCH_READ || condition != PGBUF_UNCONDITIONAL_LATCH)
     {
@@ -2487,6 +2502,9 @@ recache_page:
 bool
 pgbuf_cached_unfix (THREAD_ENTRY * thread_p, PAGE_PTR pgptr)
 {
+#if defined(SA_MODE)
+  return false;
+#endif
   PGBUF_BCB *bufptr;
   CAST_PGPTR_TO_BFPTR (bufptr, pgptr);
   return bufptr->is_cached_fake_bcb;

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -2416,7 +2416,7 @@ pgbuf_cached_fix (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_MODE fe
 #if defined(SA_MODE)
   return pgbuf_fix (thread_p, vpid, fetch_mode, requestmode, condition);
 #endif
-  if ((fetch_mode != OLD_PAGE_PREVENT_DEALLOC && fetch_mode != OLD_PAGE)
+  if (!thread_p->m_enable_cached_fix || (fetch_mode != OLD_PAGE_PREVENT_DEALLOC && fetch_mode != OLD_PAGE)
       || requestmode != PGBUF_LATCH_READ || condition != PGBUF_UNCONDITIONAL_LATCH)
     {
       return pgbuf_fix (thread_p, vpid, fetch_mode, requestmode, condition);

--- a/src/storage/page_buffer.h
+++ b/src/storage/page_buffer.h
@@ -495,4 +495,10 @@ extern void pgbuf_daemons_destroy ();
 
 extern int pgbuf_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** arg_values, int arg_cnt, void **ptr);
 
+extern int pgbuf_cache_initialize (THREAD_ENTRY * thread_p);
+extern int pgbuf_cache_finalize (THREAD_ENTRY * thread_p);
+extern PAGE_PTR pgbuf_cached_fix (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_MODE fetch_mode,
+				  PGBUF_LATCH_MODE requestmode, PGBUF_LATCH_CONDITION condition);
+extern bool pgbuf_cached_unfix (THREAD_ENTRY * thread_p, PAGE_PTR pgptr);
+
 #endif /* _PAGE_BUFFER_H_ */

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -140,6 +140,7 @@ namespace cubthread
     , m_px_orig_thread_entry (NULL)
     , m_uses_px_stats (false)
     , m_skip_end_resource_tracks_in_recycle (false)
+    , m_enable_cached_fix (false)
       // private:
     , m_id ()
     , m_error ()

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -141,6 +141,9 @@ namespace cubthread
     , m_uses_px_stats (false)
     , m_skip_end_resource_tracks_in_recycle (false)
     , m_enable_cached_fix (false)
+    , m_pgbuf_cache_count (0)
+    , m_pgbuf_cache_max (0)
+    , m_pgbuf_cache_entries (NULL)
       // private:
     , m_id ()
     , m_error ()

--- a/src/thread/thread_entry.hpp
+++ b/src/thread/thread_entry.hpp
@@ -308,6 +308,9 @@ namespace cubthread
 
       bool m_skip_end_resource_tracks_in_recycle;
       bool m_enable_cached_fix;
+      uint32_t m_pgbuf_cache_count;
+      uint32_t m_pgbuf_cache_max;
+      void *m_pgbuf_cache_entries;
 
       thread_id_t get_id ();
       pthread_t get_posix_id ();

--- a/src/thread/thread_entry.hpp
+++ b/src/thread/thread_entry.hpp
@@ -307,6 +307,7 @@ namespace cubthread
       bool m_uses_px_stats;
 
       bool m_skip_end_resource_tracks_in_recycle;
+      bool m_enable_cached_fix;
 
       thread_id_t get_id ();
       pthread_t get_posix_id ();

--- a/src/thread/thread_entry_task.cpp
+++ b/src/thread/thread_entry_task.cpp
@@ -28,6 +28,7 @@
 #include "porting.h"
 #include "thread_entry.hpp"
 #include "thread_manager.hpp"
+#include "page_buffer.h"
 
 #include <cstring>
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
@@ -95,6 +96,7 @@ namespace cubthread
     std::memset (&context.event_stats, 0, sizeof (context.event_stats));  // clear even stats
     context.tran_index = NULL_TRAN_INDEX;    // clear transaction ID
     context.private_lru_index = -1;
+    pgbuf_cache_finalize (&context);
 #if defined (SERVER_MODE)
     context.resume_status = THREAD_RESUME_NONE;
     context.m_px_orig_thread_entry = NULL;

--- a/src/thread/thread_entry_task.cpp
+++ b/src/thread/thread_entry_task.cpp
@@ -96,6 +96,7 @@ namespace cubthread
     std::memset (&context.event_stats, 0, sizeof (context.event_stats));  // clear even stats
     context.tran_index = NULL_TRAN_INDEX;    // clear transaction ID
     context.private_lru_index = -1;
+    context.m_enable_cached_fix = false;
     pgbuf_cache_finalize (&context);
 #if defined (SERVER_MODE)
     context.resume_status = THREAD_RESUME_NONE;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26242>

### Purpose

N/A

### Implementation

N/A

### Remarks

N/A
