### PR TITLE
[CBRD-24584] Improved to minimize the impact of query execution speed when setting sql_trace_slow (#4002)

### DIFF
--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -983,6 +983,30 @@ perfmon_server_get_stats (THREAD_ENTRY * thread_p)
 }
 
 /*
+ *   xperfmon_server_copy_stats_for - Copy recorded server statistics for trace
+ *				on the numbers of fetches, ioreads, and iowrites
+ *   return: none
+ *   to_stats(out): buffer to copy
+ */
+void
+xperfmon_server_copy_stats_for_trace (THREAD_ENTRY * thread_p, UINT64 * to_stats)
+{
+  UINT64 *from_stats;
+
+  from_stats = perfmon_server_get_stats (thread_p);
+
+  if (from_stats != NULL)
+    {
+      to_stats[pstat_Metadata[PSTAT_PB_NUM_FETCHES].start_offset] =
+	from_stats[pstat_Metadata[PSTAT_PB_NUM_FETCHES].start_offset];
+      to_stats[pstat_Metadata[PSTAT_PB_NUM_IOREADS].start_offset] =
+	from_stats[pstat_Metadata[PSTAT_PB_NUM_IOREADS].start_offset];
+      to_stats[pstat_Metadata[PSTAT_PB_NUM_IOWRITES].start_offset] =
+	from_stats[pstat_Metadata[PSTAT_PB_NUM_IOWRITES].start_offset];
+    }
+}
+
+/*
  *   xperfmon_server_copy_stats - Copy recorded server statistics for the current
  *				  transaction index
  *   return: none
@@ -1316,6 +1340,31 @@ perfmon_db_flushed_block_volumes (THREAD_ENTRY * thread_p, int num_volumes)
   perfmon_add_stat_at_offset (thread_p, PSTAT_DWB_FLUSHED_BLOCK_NUM_VOLUMES, offset, 1);
 }
 #endif /* SERVER_MODE || SA_MODE */
+
+int
+perfmon_calc_diff_stats_for_trace (UINT64 * stats_diff, UINT64 * new_stats, UINT64 * old_stats)
+{
+  int i;
+  int index[3] = {
+    pstat_Metadata[PSTAT_PB_NUM_FETCHES].start_offset,
+    pstat_Metadata[PSTAT_PB_NUM_IOREADS].start_offset,
+    pstat_Metadata[PSTAT_PB_NUM_IOWRITES].start_offset
+  };
+
+  for (i = 0; i < 3; i++)
+    {
+      if (new_stats[index[i]] >= old_stats[index[i]])
+	{
+	  stats_diff[index[i]] = new_stats[index[i]] - old_stats[index[i]];
+	}
+      else
+	{
+	  stats_diff[index[i]] = 0;
+	}
+    }
+
+  return NO_ERROR;
+}
 
 int
 perfmon_calc_diff_stats (UINT64 * stats_diff, UINT64 * new_stats, UINT64 * old_stats)

--- a/src/base/perf_monitor.h
+++ b/src/base/perf_monitor.h
@@ -815,6 +815,7 @@ extern void perfmon_server_dump_stats_to_buffer (const UINT64 * stats, char *buf
 extern void perfmon_get_current_times (time_t * cpu_usr_time, time_t * cpu_sys_time, time_t * elapsed_time);
 
 extern int perfmon_calc_diff_stats (UINT64 * stats_diff, UINT64 * new_stats, UINT64 * old_stats);
+extern int perfmon_calc_diff_stats_for_trace (UINT64 * stats_diff, UINT64 * new_stats, UINT64 * old_stats);
 extern int perfmon_initialize (int num_trans);
 extern void perfmon_finalize (void);
 extern int perfmon_get_number_of_statistic_values (void);

--- a/src/base/xserver_interface.h
+++ b/src/base/xserver_interface.h
@@ -229,6 +229,7 @@ extern void xqmgr_dump_query_cache (THREAD_ENTRY * thread_p, FILE * outfp);
 
 /* server execution statistics */
 extern void xperfmon_server_copy_stats (THREAD_ENTRY * thread_p, UINT64 * to_stats);
+extern void xperfmon_server_copy_stats_for_trace (THREAD_ENTRY * thread_p, UINT64 * to_stats);
 extern void xperfmon_server_copy_global_stats (UINT64 * to_stats);
 /* catalog manager interface */
 

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -5011,7 +5011,14 @@ sqmgr_execute_query (THREAD_ENTRY * thread_p, unsigned int rid, char *request, i
 	  css_send_abort_to_client (thread_p->conn_entry, rid);
 	  return;
 	}
-      xperfmon_server_copy_stats (thread_p, base_stats);
+      if (prm_get_bool_value (PRM_ID_SQL_TRACE_EXECUTION_PLAN) == true)
+	{
+	  xperfmon_server_copy_stats (thread_p, base_stats);
+	}
+      else
+	{
+	  xperfmon_server_copy_stats_for_trace (thread_p, base_stats);
+	}
 
       tsc_getticks (&start_tick);
 
@@ -5254,8 +5261,16 @@ null_list:
 	      goto exit;
 	    }
 
-	  xperfmon_server_copy_stats (thread_p, current_stats);
-	  perfmon_calc_diff_stats (diff_stats, current_stats, base_stats);
+	  if (prm_get_bool_value (PRM_ID_SQL_TRACE_EXECUTION_PLAN) == true)
+	    {
+	      xperfmon_server_copy_stats (thread_p, current_stats);
+	      perfmon_calc_diff_stats (diff_stats, current_stats, base_stats);
+	    }
+	  else
+	    {
+	      xperfmon_server_copy_stats_for_trace (thread_p, current_stats);
+	      perfmon_calc_diff_stats_for_trace (diff_stats, current_stats, base_stats);
+	    }
 
 	  if (response_time >= trace_slow_msec)
 	    {


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-24584>

### Purpose

When setting the sql_trace_slow value in cubrid.conf to a positive number other than -1, the query performance is highly affected compared to 9.x.

The reason for the increased impact on query performance compared to 9.x is that statdump information is calculated before starting a query and after finishing query execution.

Therefore, it is necessary to minimize the impact on query performance by improving it to calculate only the information necessary for setting sql_trace_slow.

### Implementation

backport from 11.3

### Remarks
