### PR TITLE
[CBRD-26413] [Regression] Core dumped in locator_attribute_info_force at src/transaction/locator_sr.c:7514

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,6 +33,7 @@
 /src/query/query_hash_scan.* @shparkcubrid
 /src/query/scan_manager.* @shparkcubrid
 /src/query/subquery_cache.* @shparkcubrid
+/src/query/memoize.* @shparkcubrid
 /src/query/parallel/ @shparkcubrid
 /src/query/vacuum.* @hornetmj
 /src/storage/ @hornetmj

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -15565,7 +15565,7 @@ qexec_execute_mainblock_internal (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
 			      p_class_instance_lock_info->instances_locked = true;
 			    }
 			}
-		      if (spec_level == 0 && level >= 1)
+		      if (spec_level == 0 && level >= 1 && !mvcc_select_lock_needed)
 			{
 			  if (new_memoize_storage (thread_p, xptr) != NO_ERROR)
 			    {


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26413>

### Purpose

select 대상에 lock이 필요한 테이블에 대하여, memoize를 비활성화한다.
