### PR TITLE
[CBRD-26142] close a cursor after all the DB_VALUEs from the cursor are used

### DIFF
--- a/src/sp/pl_executor.cpp
+++ b/src/sp/pl_executor.cpp
@@ -803,6 +803,11 @@ exit:
 					  std::string ("cursor closed"), ARG_FILE_LINE));
       }
 
+    if (s_code == S_END || s_code == S_ERROR)
+      {
+	cursor->close();
+      }
+
     error = m_stack->send_data_to_java (blk);
     blk.freemem ();
     return error;

--- a/src/sp/pl_query_cursor.cpp
+++ b/src/sp/pl_query_cursor.cpp
@@ -193,11 +193,6 @@ namespace cubpl
 	  }
       }
 
-    if (scan_code == S_END || scan_code == S_ERROR)
-      {
-	close ();
-      }
-
     return scan_code;
   }
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26142>

### Purpose

- PL 서버로부터의 fetch 요청에 대해서 커서로부터 얻어진 DB_VALUE가 모두 pack 되고 난 이후에 커서를 닫도록 수정
  - 변경 이전에는 cursor의 next_row() 안에서 마지막 row 다음에 close 하도록 구현되어 있었음
- 수정 이유:
  - pack 과정에서 문자열 buf의 주소가 접근 불가하여 segmentation fault 가 나는 문제
  - 디버깅 결과, buf 의 주소가 접근 불가로 바뀌는 것은 cursor의 close 과정 (특히, xqmgr_end_query 호출) 도중인 것으로 파악

### Implementation

cursor close 과정을 cursor의 next_row() 로부터 callback_fetch() 의 데이터 pack 이후로 이동.

### Remarks

cursor 의 next_row() 호출은 callback_fetch() 내부 단 한 군데. 즉, callback_fetch() 이외에 다른 곳을 고칠 곳은 없음.
