### PR TITLE
[CBRD-26075] Problem with incorrect results being retrieved when comparing columns in the main query in the having clause

### DIFF
--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -539,7 +539,6 @@ extern "C"
   extern bool pt_has_inst_in_where_and_select_list (PARSER_CONTEXT * parser, PT_NODE * node);
   extern bool pt_has_having (PARSER_CONTEXT * parser, PT_NODE * node);
 
-  extern bool pt_has_inst_or_orderby_num_in_where (PARSER_CONTEXT * parser, PT_NODE * node);
   extern void pt_set_correlation_level (PARSER_CONTEXT * parser, PT_NODE * subquery, int level);
   extern bool pt_has_nullable_term (PARSER_CONTEXT * parser, PT_NODE * node);
   extern bool pt_has_define_vars (PARSER_CONTEXT * parser, PT_NODE * stmt);

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -537,6 +537,9 @@ extern "C"
   extern bool pt_has_inst_num (PARSER_CONTEXT * parser, PT_NODE * node);
   extern bool pt_has_expr_of_inst_in_sel_list (PARSER_CONTEXT * parser, PT_NODE * select_list);
   extern bool pt_has_inst_in_where_and_select_list (PARSER_CONTEXT * parser, PT_NODE * node);
+  extern bool pt_has_having (PARSER_CONTEXT * parser, PT_NODE * node);
+
+  extern bool pt_has_inst_or_orderby_num_in_where (PARSER_CONTEXT * parser, PT_NODE * node);
   extern void pt_set_correlation_level (PARSER_CONTEXT * parser, PT_NODE * subquery, int level);
   extern bool pt_has_nullable_term (PARSER_CONTEXT * parser, PT_NODE * node);
   extern bool pt_has_define_vars (PARSER_CONTEXT * parser, PT_NODE * stmt);

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -3442,6 +3442,93 @@ pt_has_inst_in_where_and_select_list (PARSER_CONTEXT * parser, PT_NODE * node)
 }
 
 /*
+ * pt_has_having ()
+ *          - check if tree has an HAVING
+ *   return: true if tree has HAVING
+ *   parser(in):
+ *   node(in):
+ */
+
+bool
+pt_has_having (PARSER_CONTEXT * parser, PT_NODE * node)
+{
+  bool has_having = false;
+
+  switch (node->node_type)
+    {
+    case PT_SELECT:
+      if (node->info.query.q.select.having != NULL)
+	{
+	  return true;
+	}
+      break;
+
+    case PT_UNION:
+    case PT_DIFFERENCE:
+    case PT_INTERSECTION:
+      has_having |= pt_has_having (parser, node->info.query.q.union_.arg1);
+      has_having |= pt_has_having (parser, node->info.query.q.union_.arg2);
+      break;
+
+    default:
+      break;
+    }
+
+  return has_having;
+}
+
+/*
+ * pt_has_inst_or_orderby_num_in_where ()
+ *          - check if tree has an INST_NUM or ORDERBY_NUM or GROUPBY_NUM node in where
+ *   return: true if tree has INST_NUM/ORDERBY_NUM
+ *   parser(in):
+ *   node(in):
+ */
+
+bool
+pt_has_inst_or_orderby_num_in_where (PARSER_CONTEXT * parser, PT_NODE * node)
+{
+  bool has_inst_orderby_num = false;
+  PT_NODE *where, *select_list, *orderby_for, *having, *using_index;
+
+  switch (node->node_type)
+    {
+    case PT_SELECT:
+      using_index = node->info.query.q.select.using_index;
+      if (using_index != NULL && using_index->info.name.indx_key_limit != NULL)
+	{
+	  return true;
+	}
+      where = node->info.query.q.select.where;
+      (void) parser_walk_tree (parser, where, pt_is_inst_or_inst_num_node, &has_inst_orderby_num,
+			       pt_is_inst_or_orderby_num_node_post, &has_inst_orderby_num);
+      orderby_for = node->info.query.orderby_for;
+      (void) parser_walk_tree (parser, orderby_for, pt_is_inst_or_inst_num_node, &has_inst_orderby_num,
+			       pt_is_inst_or_orderby_num_node_post, &has_inst_orderby_num);
+      having = node->info.query.q.select.having;
+      (void) parser_walk_tree (parser, having, pt_is_inst_or_inst_num_node, &has_inst_orderby_num,
+			       pt_is_inst_or_orderby_num_node_post, &has_inst_orderby_num);
+      break;
+
+    case PT_UNION:
+    case PT_DIFFERENCE:
+    case PT_INTERSECTION:
+      if (node->info.query.limit)
+	{
+	  return true;
+	}
+      has_inst_orderby_num |= pt_has_inst_or_orderby_num_in_where (parser, node->info.query.q.union_.arg1);
+      has_inst_orderby_num |= pt_has_inst_or_orderby_num_in_where (parser, node->info.query.q.union_.arg2);
+      break;
+
+    default:
+      break;
+    }
+
+  return has_inst_orderby_num;
+}
+
+/*
  * pt_set_correlation_level ()
  *          - set correlation level
  *   parser(in):
@@ -3493,7 +3580,6 @@ pt_has_nullable_term (PARSER_CONTEXT * parser, PT_NODE * node)
 }
 
 /*
->>>>>>> upstream/develop
  * pt_insert_host_var () - insert a host_var into a list based on
  *                         its ordinal position
  *   return: a list of PT_HOST_VAR type nodes

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -3478,57 +3478,6 @@ pt_has_having (PARSER_CONTEXT * parser, PT_NODE * node)
 }
 
 /*
- * pt_has_inst_or_orderby_num_in_where ()
- *          - check if tree has an INST_NUM or ORDERBY_NUM or GROUPBY_NUM node in where
- *   return: true if tree has INST_NUM/ORDERBY_NUM
- *   parser(in):
- *   node(in):
- */
-
-bool
-pt_has_inst_or_orderby_num_in_where (PARSER_CONTEXT * parser, PT_NODE * node)
-{
-  bool has_inst_orderby_num = false;
-  PT_NODE *where, *select_list, *orderby_for, *having, *using_index;
-
-  switch (node->node_type)
-    {
-    case PT_SELECT:
-      using_index = node->info.query.q.select.using_index;
-      if (using_index != NULL && using_index->info.name.indx_key_limit != NULL)
-	{
-	  return true;
-	}
-      where = node->info.query.q.select.where;
-      (void) parser_walk_tree (parser, where, pt_is_inst_or_inst_num_node, &has_inst_orderby_num,
-			       pt_is_inst_or_orderby_num_node_post, &has_inst_orderby_num);
-      orderby_for = node->info.query.orderby_for;
-      (void) parser_walk_tree (parser, orderby_for, pt_is_inst_or_inst_num_node, &has_inst_orderby_num,
-			       pt_is_inst_or_orderby_num_node_post, &has_inst_orderby_num);
-      having = node->info.query.q.select.having;
-      (void) parser_walk_tree (parser, having, pt_is_inst_or_inst_num_node, &has_inst_orderby_num,
-			       pt_is_inst_or_orderby_num_node_post, &has_inst_orderby_num);
-      break;
-
-    case PT_UNION:
-    case PT_DIFFERENCE:
-    case PT_INTERSECTION:
-      if (node->info.query.limit)
-	{
-	  return true;
-	}
-      has_inst_orderby_num |= pt_has_inst_or_orderby_num_in_where (parser, node->info.query.q.union_.arg1);
-      has_inst_orderby_num |= pt_has_inst_or_orderby_num_in_where (parser, node->info.query.q.union_.arg2);
-      break;
-
-    default:
-      break;
-    }
-
-  return has_inst_orderby_num;
-}
-
-/*
  * pt_set_correlation_level ()
  *          - set correlation level
  *   parser(in):

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -1658,7 +1658,7 @@ pt_to_pred_expr_local_with_arg (PARSER_CONTEXT * parser, PT_NODE * node, int *ar
 	      pred = pt_make_pred_term_comp (regu_var1, NULL, R_EXISTS, data_type);
 
 	      /* exists op must fetch one tuple */
-	      if (regu_var1 && regu_var1->xasl)
+	      if (!pt_has_having (parser, node->info.expr.arg1) && regu_var1 && regu_var1->xasl)
 		{
 		  XASL_SET_FLAG (regu_var1->xasl, XASL_NEED_SINGLE_TUPLE_SCAN);
 		}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26075

Purpose
exists 부질의에 HAVING 절이 있을 경우 잘못된 결과 출력하는 현상 수정

Implementation
exists 부질의에 HAVING 절이 있을 경우 NEED_SINGLE_TUPLE_SCAN 최적화를 하지 않도록 수정

Remarks
N/A