### PR TITLE
[CBRD-26075] Problem with incorrect results being retrieved when comparing columns in the main query in the having clause

### DIFF
--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -520,6 +520,7 @@ extern "C"
   extern bool pt_has_aggregate (PARSER_CONTEXT * parser, PT_NODE * node);
   extern bool pt_has_analytic (PARSER_CONTEXT * parser, PT_NODE * node);
   extern bool pt_has_inst_or_orderby_num (PARSER_CONTEXT * parser, PT_NODE * node);
+  extern bool pt_has_having (PARSER_CONTEXT * parser, PT_NODE * node);
 
   extern void pt_preset_hostvar (PARSER_CONTEXT * parser, PT_NODE * hv_node);
   extern void pt_set_expected_domain (PT_NODE * node, TP_DOMAIN * domain);

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -3010,6 +3010,42 @@ pt_has_inst_or_orderby_num (PARSER_CONTEXT * parser, PT_NODE * node)
 }
 
 /*
+ * pt_has_having ()
+ *          - check if tree has an HAVING
+ *   return: true if tree has HAVING
+ *   parser(in):
+ *   node(in):
+ */
+
+bool
+pt_has_having (PARSER_CONTEXT * parser, PT_NODE * node)
+{
+  bool has_having = false;
+
+  switch (node->node_type)
+    {
+    case PT_SELECT:
+      if (node->info.query.q.select.having != NULL)
+	{
+	  return true;
+	}
+      break;
+
+    case PT_UNION:
+    case PT_DIFFERENCE:
+    case PT_INTERSECTION:
+      has_having |= pt_has_having (parser, node->info.query.q.union_.arg1);
+      has_having |= pt_has_having (parser, node->info.query.q.union_.arg2);
+      break;
+
+    default:
+      break;
+    }
+
+  return has_having;
+}
+
+/*
  * pt_insert_host_var () - insert a host_var into a list based on
  *                         its ordinal position
  *   return: a list of PT_HOST_VAR type nodes

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -1631,7 +1631,7 @@ pt_to_pred_expr_local_with_arg (PARSER_CONTEXT * parser, PT_NODE * node, int *ar
 	      pred = pt_make_pred_term_comp (regu_var1, NULL, R_EXISTS, data_type);
 
 	      /* exists op must fetch one tuple */
-	      if (regu_var1 && regu_var1->xasl)
+	      if (!pt_has_having (parser, node->info.expr.arg1) && regu_var1 && regu_var1->xasl)
 		{
 		  XASL_SET_FLAG (regu_var1->xasl, XASL_NEED_SINGLE_TUPLE_SCAN);
 		}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26075

Purpose
exists 부질의에 HAVING 절이 있을 경우 잘못된 결과 출력하는 현상 수정

Implementation
exists 부질의에 HAVING 절이 있을 경우 NEED_SINGLE_TUPLE_SCAN 최적화를 하지 않도록 수정

Remarks
N/A