### PR TITLE
[CUBRIDQA-1326] Enhance CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,11 +83,9 @@ jobs:
                       at: .
                   - run:
                       name: Test
-                      shell: /bin/bash
+                      # shell: /bin/bash
                       no_output_timeout: 45m
                       command: |
-                        set -euo pipefail
-
                         # Limit core files to 10mb
                         ulimit -c 10485760
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,8 @@ jobs:
                       shell: /bin/bash
                       no_output_timeout: 45m
                       command: |
+                        set -euo pipefail
+
                         # Limit core files to 10mb
                         ulimit -c 10485760
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,6 @@ jobs:
                       at: .
                   - run:
                       name: Test
-                      # shell: /bin/bash
                       no_output_timeout: 45m
                       command: |
                         # Limit core files to 10mb


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1326>

### Purpose
비정상 종료로 인해 rerun 할 목록(xml파일) 이 제출되지 않은 상황에서 
test split 과같은 커맨드 fail 이 나는 경우를 보완.
https://app.circleci.com/pipelines/github/CUBRID/cubrid/24550/workflows/bb55ddb5-385b-4892-ac29-ab1022dc0576/jobs/111148/parallel-runs/0/steps/0-103

### Implementation
circleci default : /bin/bash -eo pipefail
코드 상태 :     shell:/bin/bash

코드에 지정되어있는 shell 부분을 삭제하여 default 로 동작하게 수정함.

### Remarks
Test 단계의 커맨드가 수행도중 실패시 해당 단계를 fail 처리하여 실패이지만 pass 로 표기되는 현상을 해결.