### PR TITLE
[CUBRIDQA-1326] fix bug for test run steps.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,12 @@ jobs:
                           echo "[debug] split tests for parallel execution"
                           circleci tests glob "\$glob_path" | grep -P '/([^/]+)/cases/\1\.sh$' \
                             | circleci tests run --command="tee tc.list" --verbose --split-by=timings --timings-type=file
+
+                          # Check if tc.list exists and is not empty (tests were assigned to this node)
+                          if [ ! -s tc.list ]; then
+                            echo "[debug] No tests assigned to this node"
+                            circleci-agent step halt
+                          fi
                           cat tc.list | xargs -n1 dirname > tc_dirs.list
                           echo "[debug] total testcases: \$(wc -l tc_dirs.list)"
                           echo "[debug] Remove tests that are not in the list"
@@ -122,18 +128,19 @@ jobs:
                           echo "[debug] split tests for parallel execution"
                           circleci tests glob "\$glob_path" \
                             | circleci tests run --command="xargs -n1 >> tc.list" --verbose --split-by=name
+                            
+                          # Check if tc.list exists and is not empty (tests were assigned to this node)
+                          if [ ! -s tc.list ]; then
+                            echo "[debug] No tests assigned to this node"
+                            circleci-agent step halt
+                          fi
                           echo "[debug] total testcases: \$(wc -l tc.list)"
                           echo "[debug] Remove tests that are not in the list"
                           find \$base_dir -name "*.sql" -type f | grep -v -F -f tc.list | xargs -r rm -rf
                         fi
 
                         echo "[debug] Run the tests"
-                        if [ -s tc.list ]; then
-                          /entrypoint.sh test
-                        else
-                          echo "[debug]No tests to run"
-                          circleci-agent step halt
-                        fi
+                        /entrypoint.sh test
                   - run:
                       name: Collect Logs
                       when: on_fail


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1326>
http://jira.cubrid.org/browse/CUBRIDQA-1326?focusedCommentId=4773121&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-4773121

### Purpose
아래의 상태 제보로 인한 버그인식 및 문제확인.
https://app.circleci.com/pipelines/github/CUBRID/cubrid/24640/workflows/e00ef867-72d8-48e3-b937-b415c38bfcb3/jobs/111400/parallel-runs/1?filterBy=FAILED

할당할게 없는 컨테이너는 tc.list 가 비어있게 된다. 
하지만 이후 수행하는 커맨드의 에러를 커맨드 블록의 default 인 '#!/bin/bash -eo pipefail' 로 수행하다보니
커맨드에러로 인한 exit 이 되어 Test 블록이 실패, 전체 파이프라인이 실패하게된다. 

```
circleci-tests-plugin-cli plugin Installed. Version: 1.0.11028-065c8a7
INFO[2025-12-11T12:35:31+09:00] received failed tests from workflow e00ef867-72d8-48e3-b937-b415c38bfcb3 
INFO[2025-12-11T12:35:31+09:00] 1 test(s) failed out of 1 total tests. Rerunning tests from 1 file 
DEBU[2025-12-11T12:35:31+09:00] if all tests are being run instead of only failed tests, ensure your JUnit XML has a file or classname attribute. 
DEBU[2025-12-11T12:35:31+09:00] starting execution                           
DEBU[2025-12-11T12:35:31+09:00] There were no tests found in the bucket for node 1 
DEBU[2025-12-11T12:35:31+09:00] ending execution                             
cat: tc.list: No such file or directory
dirname: missing operand
Try 'dirname --help' for more information.

Exited with code exit status 123
```

### Implementation
tc.list 의 존재를 확인 후 비었다면 halt 상태(skip) 로 컨테이너를 종료 및 circleci 에서 통과로 인식되는 상태로 수정.

### Remarks

N/A
