### PR TITLE
[CBRD-26049] disk image incompatibilty with the previous version.

### DIFF
--- a/src/base/release_string.c
+++ b/src/base/release_string.c
@@ -102,7 +102,7 @@ static REL_COMPATIBILITY rel_get_compatible_internal (const char *base_rel_str, 
 /*
  * Disk (database image) Version Compatibility
  */
-static float disk_compatibility_level = 11.4f;
+static float disk_compatibility_level = 11.5f;
 
 /*
  * rel_copy_version_string - version string of the product


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26049

