### PR TITLE
[CBRD-26428] upgrade Netty version

### DIFF
--- a/pl_engine/pl_server/build.gradle.kts
+++ b/pl_engine/pl_server/build.gradle.kts
@@ -61,7 +61,7 @@ dependencies {
     implementation("cubrid:cubrid-jdbc:latest.integration")
 
     // netty
-    implementation("io.netty:netty-buffer:4.1.95.Final")
+    implementation("io.netty:netty-buffer:4.1.115.Final")
 }
 
 // Antlr


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26428>

### Purpose

자바 라이브러리 중 하나인 io.netty:netty-buffer 의 버전을 4.1.95.Final 에서 4.1.115.Final 로 업그레이드 합니다. 

### Implementation

graddle 설정 파일 수정
