### PR TITLE
[CBRD-26431] COUNT(alias) 사용 시, 서브쿼리 표현식이 재작성되며 결과가 0으로 계산되는 문제	

### DIFF
--- a/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
@@ -36,6 +36,7 @@
 #include <atomic>
 #include <chrono>
 #include "dbtype.h"
+#include "fetch.h"
 #include "query_aggregate.hpp"
 #include "xasl_aggregate.hpp"
 
@@ -947,8 +948,19 @@ namespace parallel_heap_scan
 	      {
 		for (REGU_VARIABLE_LIST operand = agg_node->operands; operand != NULL; operand = operand->next)
 		  {
-		    assert (operand->value.type == TYPE_CONSTANT);
-		    DB_VALUE *db_value_p = operand->value.value.dbvalptr;
+		    DB_VALUE *db_value_p;
+		    if (operand->value.type == TYPE_CONSTANT)
+		      {
+			db_value_p = operand->value.value.dbvalptr;
+		      }
+		    else
+		      {
+			int err_code = fetch_peek_dbval (thread_p, &operand->value, tl_vd, NULL, NULL, tl_tpl_buf.tpl, &db_value_p);
+			if (err_code != NO_ERROR)
+			  {
+			    return false;
+			  }
+		      }
 		    if (DB_IS_NULL (db_value_p))
 		      {
 			continue;
@@ -971,7 +983,21 @@ namespace parallel_heap_scan
 	      }
 	    else
 	      {
-		if (DB_IS_NULL (agg_node->operands->value.value.dbvalptr))
+		DB_VALUE *db_value_p;
+		if (agg_node->operands->value.type == TYPE_CONSTANT)
+		  {
+		    db_value_p = agg_node->operands->value.value.dbvalptr;
+		  }
+		else
+		  {
+		    int err_code = fetch_peek_dbval (thread_p, &agg_node->operands->value, tl_vd, NULL, NULL, tl_tpl_buf.tpl, &db_value_p);
+		    if (err_code != NO_ERROR)
+		      {
+			return false;
+		      }
+		  }
+
+		if (DB_IS_NULL (db_value_p))
 		  {
 		    continue;
 		  }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26431>

### Purpose

parallel heap scan count() 최적화 시, count(expr) 형태의 처리가 안되던 오류를 수정합니다.
