### PR TITLE
[CUBRIDQA-1326] Revert "[CUBRIDQA-1326] Enhance CircleCI configuration (#6697)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,7 @@ jobs:
                       at: .
                   - run:
                       name: Test
+                      shell: /bin/bash
                       no_output_timeout: 45m
                       command: |
                         # Limit core files to 10mb


### PR DESCRIPTION
This reverts commit 24cf2127f989fd686abc0aad32fdcd500430d252.

<http://jira.cubrid.org/browse/CUBRIDQA-1326>

### Purpose
fix bug

only check tc.list.
Pipefail occurs when unscheduled pods fail.

### Implementation

N/A

### Remarks

N/A
