### PR TITLE
[CBRD-26427] incorrect result when large record-size in plcsql (#6702)

### DIFF
--- a/src/sp/pl_query_cursor.cpp
+++ b/src/sp/pl_query_cursor.cpp
@@ -183,11 +183,15 @@ namespace cubpl
 
 		or_init (&buf, ptr, length);
 
-		if (pr_type->data_readval (&buf, value, domain, -1, false /* Don't copy */, NULL, 0) != NO_ERROR)
+		if (pr_type->data_readval (&buf, value, domain, -1, true, NULL, 0) != NO_ERROR)
 		  {
 		    scan_code = S_ERROR;
 		    break;
 		  }
+	      }
+	    else
+	      {
+		db_make_null (value);
 	      }
 	  }
       }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26427

* Resolves an issue where the result value is not guaranteed when the size of the result record executed with PL/CSQL exceeds one page.
* Resolves a malfunction when a column with a NULL value is included during PL/CSQL processing.
* backport #6702
*
