### PR TITLE
Revert "[CBRD-26297] Refactor: unlock thread_entry after thread_suspend_timeout_wakeup_and_unlock_entry()/thread_suspend_wakeup_and_unlock_entry() returns"

### DIFF
--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -2801,7 +2801,7 @@ css_return_queued_data_timeout (CSS_CONN_ENTRY * conn, unsigned short rid,
 	       * data */
 	      if (waitsec < 0)
 		{
-		  thread_suspend_and_unlock_entry (thrd, THREAD_CSS_QUEUE_SUSPENDED);
+		  thread_suspend_wakeup_and_unlock_entry (thrd, THREAD_CSS_QUEUE_SUSPENDED);
 
 		  if (thrd->resume_status != THREAD_CSS_QUEUE_RESUMED)
 		    {
@@ -2825,7 +2825,7 @@ css_return_queued_data_timeout (CSS_CONN_ENTRY * conn, unsigned short rid,
 		  abstime.tv_sec = (int) time (NULL) + waitsec;
 		  abstime.tv_nsec = 0;
 
-		  r = thread_timed_suspend_and_unlock_entry (thrd, &abstime, THREAD_CSS_QUEUE_SUSPENDED);
+		  r = thread_suspend_timeout_wakeup_and_unlock_entry (thrd, &abstime, THREAD_CSS_QUEUE_SUSPENDED);
 
 		  if (r == ER_CSS_PTHREAD_COND_TIMEDOUT)
 		    {

--- a/src/storage/double_write_buffer.cpp
+++ b/src/storage/double_write_buffer.cpp
@@ -1600,7 +1600,7 @@ dwb_wait_for_block_completion (THREAD_ENTRY *thread_p, unsigned int block_no)
   timeval_add_msec (&timeval_timeout, &timeval_crt, 20);
   timeval_to_timespec (&to, &timeval_timeout);
 
-  r = thread_timed_suspend_and_unlock_entry (thread_p, &to, THREAD_DWB_QUEUE_SUSPENDED);
+  r = thread_suspend_timeout_wakeup_and_unlock_entry (thread_p, &to, THREAD_DWB_QUEUE_SUSPENDED);
 
   (void) logtb_set_check_interrupt (thread_p, save_check_interrupt);
 
@@ -1741,7 +1741,7 @@ dwb_wait_for_strucure_modification (THREAD_ENTRY *thread_p)
   timeval_add_msec (&timeval_timeout, &timeval_crt, 10);
   timeval_to_timespec (&to, &timeval_timeout);
 
-  r = thread_timed_suspend_and_unlock_entry (thread_p, &to, THREAD_DWB_QUEUE_SUSPENDED);
+  r = thread_suspend_timeout_wakeup_and_unlock_entry (thread_p, &to, THREAD_DWB_QUEUE_SUSPENDED);
 
   (void) logtb_set_check_interrupt (thread_p, save_check_interrupt);
   if (r == ER_CSS_PTHREAD_COND_TIMEDOUT)

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -2042,7 +2042,7 @@ heap_classrepr_lock_class (THREAD_ENTRY * thread_p, HEAP_CLASSREPR_HASH * hash_a
 
 	  thread_lock_entry (cur_thrd_entry);
 	  pthread_mutex_unlock (&hash_anchor->hash_mutex);
-	  thread_suspend_and_unlock_entry (cur_thrd_entry, THREAD_HEAP_CLSREPR_SUSPENDED);
+	  thread_suspend_wakeup_and_unlock_entry (cur_thrd_entry, THREAD_HEAP_CLSREPR_SUSPENDED);
 
 	  if (cur_thrd_entry->resume_status == THREAD_HEAP_CLSREPR_RESUMED)
 	    {

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -6596,7 +6596,7 @@ pgbuf_block_bcb (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr, PGBUF_LATCH_MODE r
       /* is it safe to use infinite wait instead of timed sleep? */
       thread_lock_entry (cur_thrd_entry);
       PGBUF_BCB_UNLOCK (bufptr);
-      thread_suspend_and_unlock_entry (cur_thrd_entry, THREAD_PGBUF_SUSPENDED);
+      thread_suspend_wakeup_and_unlock_entry (cur_thrd_entry, THREAD_PGBUF_SUSPENDED);
 
       if (cur_thrd_entry->resume_status != THREAD_PGBUF_RESUMED)
 	{
@@ -6780,7 +6780,7 @@ try_again:
     }
 
   thread_p->resume_status = THREAD_PGBUF_SUSPENDED;
-  r = thread_timed_suspend_and_unlock_entry (thread_p, &to, THREAD_PGBUF_SUSPENDED);
+  r = thread_suspend_timeout_wakeup_and_unlock_entry (thread_p, &to, THREAD_PGBUF_SUSPENDED);
 
   if (thread_p->type == TT_WORKER)
     {
@@ -7630,7 +7630,7 @@ pgbuf_allocate_bcb (THREAD_ENTRY * thread_p, const VPID * src_vpid)
 
       show_status->num_flusher_waiting_threads++;
 
-      r = thread_timed_suspend_and_unlock_entry (thread_p, &to, THREAD_ALLOC_BCB_SUSPENDED);
+      r = thread_suspend_timeout_wakeup_and_unlock_entry (thread_p, &to, THREAD_ALLOC_BCB_SUSPENDED);
 
       show_status->num_flusher_waiting_threads--;
 
@@ -10869,7 +10869,7 @@ pgbuf_sleep (THREAD_ENTRY * thread_p, pthread_mutex_t * mutex_p)
   thread_lock_entry (thread_p);
   pthread_mutex_unlock (mutex_p);
 
-  thread_suspend_and_unlock_entry (thread_p, THREAD_PGBUF_SUSPENDED);
+  thread_suspend_wakeup_and_unlock_entry (thread_p, THREAD_PGBUF_SUSPENDED);
 }
 
 STATIC_INLINE int

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -460,6 +460,10 @@ using thread_clock_type = std::chrono::system_clock;
 
 static void thread_wakeup_internal (cubthread::entry *thread_p, thread_resume_suspend_status resume_reason,
 				    bool had_mutex);
+static void thread_check_suspend_reason_and_wakeup_internal (cubthread::entry *thread_p,
+    thread_resume_suspend_status resume_reason,
+    thread_resume_suspend_status suspend_reason,
+    bool had_mutex);
 
 // todo - remove timeval and use std::chrono
 static void
@@ -475,7 +479,7 @@ thread_timeval_add_usec (const std::chrono::microseconds &usec, struct timeval &
 }
 
 /*
- * thread_suspend() -
+ * thread_suspend_wakeup_and_unlock_entry() -
  *   return:
  *   thread_p(in):
  *   suspended_reason(in):
@@ -483,7 +487,7 @@ thread_timeval_add_usec (const std::chrono::microseconds &usec, struct timeval &
  * Note: this function must be called by current thread also, the lock must have already been acquired.
  */
 void
-thread_suspend (cubthread::entry *thread_p, thread_resume_suspend_status suspended_reason)
+thread_suspend_wakeup_and_unlock_entry (cubthread::entry *thread_p, thread_resume_suspend_status suspended_reason)
 {
   cubthread::entry::status old_status;
 
@@ -519,18 +523,20 @@ thread_suspend (cubthread::entry *thread_p, thread_resume_suspend_status suspend
     }
 
   thread_p->m_status = old_status;
+
+  pthread_mutex_unlock (&thread_p->th_entry_lock);
 }
 
 /*
- * thread_timed_suspend() -
+ * thread_suspend_timeout_wakeup_and_unlock_entry() -
  *   return:
  *   thread_p(in):
  *   time_p(in):
  *   suspended_reason(in):
  */
 int
-thread_timed_suspend (cubthread::entry *thread_p, struct timespec *time_p,
-		      thread_resume_suspend_status suspended_reason)
+thread_suspend_timeout_wakeup_and_unlock_entry (cubthread::entry *thread_p, struct timespec *time_p,
+    thread_resume_suspend_status suspended_reason)
 {
   int r;
   cubthread::entry::status old_status;
@@ -552,8 +558,6 @@ thread_timed_suspend (cubthread::entry *thread_p, struct timespec *time_p,
 
   r = pthread_cond_timedwait (&thread_p->wakeup_cond, &thread_p->th_entry_lock, time_p);
 
-  thread_p->m_status = old_status;
-
   if (thread_p->event_stats.trace_slow_query == true && suspended_reason == THREAD_PGBUF_SUSPENDED)
     {
       usecs = std::chrono::duration_cast < std::chrono::microseconds > (thread_clock_type::now () - start_time_pt);
@@ -561,18 +565,20 @@ thread_timed_suspend (cubthread::entry *thread_p, struct timespec *time_p,
       thread_timeval_add_usec (usecs, thread_p->event_stats.latch_waits);
     }
 
-  if (r != 0)
+  if (r != 0 && r != ETIMEDOUT)
     {
-      if (r != ETIMEDOUT)
-	{
-	  error = ER_CSS_PTHREAD_COND_TIMEDWAIT;
-	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 0);
-	}
-      else
-	{
-	  error = ER_CSS_PTHREAD_COND_TIMEDOUT;
-	}
+      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_COND_TIMEDWAIT, 0);
+      return ER_CSS_PTHREAD_COND_TIMEDWAIT;
     }
+
+  if (r == ETIMEDOUT)
+    {
+      error = ER_CSS_PTHREAD_COND_TIMEDOUT;
+    }
+
+  thread_p->m_status = old_status;
+
+  pthread_mutex_unlock (&thread_p->th_entry_lock);
 
   return error;
 }
@@ -601,17 +607,22 @@ thread_wakeup_internal (cubthread::entry *thread_p, thread_resume_suspend_status
 }
 
 /*
- * thread_check_suspend_reason_and_wakeup () -
+ * thread_check_suspend_reason_and_wakeup_internal () -
+ *   return:
  *   thread_p(in):
  *   resume_reason:
  *   suspend_reason:
+ *   had_mutex:
  */
-void
-thread_check_suspend_reason_and_wakeup (cubthread::entry *thread_p,
-					thread_resume_suspend_status resume_reason,
-					thread_resume_suspend_status suspend_reason)
+static void
+thread_check_suspend_reason_and_wakeup_internal (cubthread::entry *thread_p,
+    thread_resume_suspend_status resume_reason,
+    thread_resume_suspend_status suspend_reason, bool had_mutex)
 {
-  thread_lock_entry (thread_p);
+  if (had_mutex == false)
+    {
+      thread_lock_entry (thread_p);
+    }
 
   if (thread_p->resume_status != suspend_reason)
     {
@@ -638,6 +649,12 @@ thread_wakeup (cubthread::entry *thread_p, thread_resume_suspend_status resume_r
   thread_wakeup_internal (thread_p, resume_reason, false);
 }
 
+void
+thread_check_suspend_reason_and_wakeup (cubthread::entry *thread_p, thread_resume_suspend_status resume_reason,
+					thread_resume_suspend_status suspend_reason)
+{
+  thread_check_suspend_reason_and_wakeup_internal (thread_p, resume_reason, suspend_reason, false);
+}
 
 /*
  * thread_wakeup_already_had_mutex () -

--- a/src/thread/thread_entry.hpp
+++ b/src/thread/thread_entry.hpp
@@ -480,23 +480,12 @@ thread_unlock_entry (cubthread::entry *thread_p)
   thread_p->unlock ();
 }
 
-void thread_suspend (cubthread::entry *p, thread_resume_suspend_status suspended_reason);
-int thread_timed_suspend (cubthread::entry *p, struct timespec *t,
-			  thread_resume_suspend_status suspended_reason);
+void thread_suspend_wakeup_and_unlock_entry (cubthread::entry *p, thread_resume_suspend_status suspended_reason);
+int thread_suspend_timeout_wakeup_and_unlock_entry (cubthread::entry *p, struct timespec *t,
+    thread_resume_suspend_status suspended_reason);
 void thread_wakeup (cubthread::entry *p, thread_resume_suspend_status resume_reason);
 void thread_check_suspend_reason_and_wakeup (cubthread::entry *thread_p, thread_resume_suspend_status resume_reason,
     thread_resume_suspend_status suspend_reason);
-#define thread_suspend_and_unlock_entry(thread_p,suspended_reason) \
-  ({ \
-    thread_suspend((thread_p), (suspended_reason)); \
-    thread_unlock_entry((thread_p)); \
-  })
-#define thread_timed_suspend_and_unlock_entry(thread_p, t, suspended_reason) \
-  ({ \
-    int __r = thread_timed_suspend((thread_p), (t), (suspended_reason)); \
-    thread_unlock_entry((thread_p)); \
-    __r; \
-  })
 void thread_wakeup_already_had_mutex (cubthread::entry *p, thread_resume_suspend_status resume_reason);
 int thread_suspend_with_other_mutex (cubthread::entry *p, pthread_mutex_t *mutexp, int timeout, struct timespec *to,
 				     thread_resume_suspend_status suspended_reason);

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -2168,8 +2168,6 @@ lock_suspend (THREAD_ENTRY * thread_p, LK_ENTRY * entry_ptr, int wait_msecs)
   int client_id;
   LOG_TDES *tdes;
 
-  thread_lock_entry (entry_ptr->thrd_entry);
-
   /* The threads must not hold a page latch to be blocked on a lock request. */
   assert (lock_is_safe_lock_with_page (thread_p, entry_ptr) || !pgbuf_has_perm_pages_fixed (thread_p));
 
@@ -2215,7 +2213,7 @@ lock_suspend (THREAD_ENTRY * thread_p, LK_ENTRY * entry_ptr, int wait_msecs)
   lock_event_set_tran_wait_entry (entry_ptr->tran_index, entry_ptr);
 
   /* suspend the worker thread (transaction) */
-  thread_suspend_and_unlock_entry (entry_ptr->thrd_entry, THREAD_LOCK_SUSPENDED);
+  thread_suspend_wakeup_and_unlock_entry (entry_ptr->thrd_entry, THREAD_LOCK_SUSPENDED);
 
   lk_Gl.deadlock_and_timeout_detector--;
   lk_Gl.TWFG_node[entry_ptr->tran_index].thrd_wait_stime = 0;
@@ -3574,8 +3572,7 @@ start:
 	  pthread_mutex_unlock (&res_ptr->res_mutex);
 	  is_res_mutex_locked = false;
 
-	  thread_suspend_and_unlock_entry (thrd_entry, THREAD_LOCK_SUSPENDED);
-
+	  thread_suspend_wakeup_and_unlock_entry (thrd_entry, THREAD_LOCK_SUSPENDED);
 	  if (entry_ptr)
 	    {
 	      if (entry_ptr->thrd_entry->resume_status == THREAD_RESUME_DUE_TO_INTERRUPT)
@@ -3783,8 +3780,7 @@ lock_tran_lk_entry:
       pthread_mutex_unlock (&res_ptr->res_mutex);
       is_res_mutex_locked = false;
 
-      thread_suspend_and_unlock_entry (thrd_entry, THREAD_LOCK_SUSPENDED);
-
+      thread_suspend_wakeup_and_unlock_entry (thrd_entry, THREAD_LOCK_SUSPENDED);
       if (thrd_entry->resume_status == THREAD_RESUME_DUE_TO_INTERRUPT)
 	{
 	  /* a shutdown thread wakes me up */
@@ -3859,6 +3855,7 @@ blocked:
   LK_MSG_LOCK_WAITFOR (entry_ptr);
 #endif /* LK_TRACE_OBJECT */
 
+  thread_lock_entry (entry_ptr->thrd_entry);
   if (is_res_mutex_locked)
     {
       pthread_mutex_unlock (&res_ptr->res_mutex);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26297

develop 안정화를 위해 잠시 revert 처리합니다.
Reverts CUBRID/cubrid#6537