### PR TITLE
[CBRD-26445] Fixing an issue where dblink queries fail after changing a password with ALTER SERVER

### DIFF
--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -19350,16 +19350,8 @@ pt_print_remote_info (PARSER_CONTEXT * parser, PT_DBLINK_INFO * pt, bool is_dml)
 		     pt->user->info.value.data_value.str->length);
   var = pt_append_nulstring (parser, var, ":");
 
-  if (pt->is_name || is_dml)
-    {
-      var = pt_append_nulstring (parser, var, "*");
-    }
-  else
-    {
-      var = pt_append_bytes (parser, var, (char *) pt->pwd->info.value.data_value.str->bytes,
-			     pt->pwd->info.value.data_value.str->length);
-    }
-
+  var = pt_append_bytes (parser, var, (char *) pt->pwd->info.value.data_value.str->bytes,
+			 pt->pwd->info.value.data_value.str->length);
   // properties
   if (!is_dml)
     {


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26445>

### Purpose

* ALTER SERVER 구문으로 패스워드를 변경했을 때 기존의 XASL 캐쉬가 사용되지 않도록 변경 

### Implementation

N/A

### Remarks

hash값을 만들 때 아래와 같은 문자열을 이용하고 있었습니다.
이때 마지막의 remote 항목에 두개의 숫자가 나옵니다.
select [t].[col1] from (select [_dbl].[col1] from DBLINK([srv], 'SELECT count FROM tbl') as [_dbl]([col1] integer)) [t] ([col1])?193="ko_KR";194="ko_KR";249="Asia/Seoul";user=0|833|1;bind_var_cnt=0;remote=**{3965891967,2497129067}**

이 숫자를 만들 때 접속 정보를 출력한 문자열을 이용하는데 이 문자열을 만들 때 암호는 '*'로 출력했었습니다.
이런 이유로 암호가 바뀌어도 여전히 '*'로 출력되기 때문에 계속해서 동일하다고 판단하게 되는 문제가 있었습니다.
그래서 암호가 출력된 문자열을 이용하도록 바뀐 것입니다.
참고로, 이렇게 만든 문자열은 어디 기록되지 않고 오직 저 두 개의 숫자를 생성하는 데에만 사용됩니다. 