### PR TITLE
[CBRD-26299] Missing cgw initialization

### DIFF
--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -234,7 +234,7 @@ main (int argc, char *argv[])
 
   if (cgw_cas_init () < 0)
     {
-      fprintf (stderr, "CAS initialization failed. Exiting.\n");
+      fprintf (stderr, "CGW initialization failed. Exiting.\n");
       return -1;
     }
 

--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -232,9 +232,9 @@ main (int argc, char *argv[])
   signal (SIGXFSZ, SIG_IGN);
 #endif /* WINDOWS */
 
-  if (cgw_init () < 0)
+  if (cgw_cas_init () < 0)
     {
-      fprintf (stderr, "CGW initialization failed. Exiting.\n");
+      fprintf (stderr, "CAS initialization failed. Exiting.\n");
       return -1;
     }
 

--- a/src/broker/cas_common_main.c
+++ b/src/broker/cas_common_main.c
@@ -68,9 +68,6 @@
 #include <netinet/tcp.h>
 #endif
 
-// static char cas_db_name[MAX_HA_DBINFO_LENGTH];
-// static char cas_db_user[SRV_CON_DBUSER_SIZE];
-// static char cas_db_passwd[SRV_CON_DBPASSWD_SIZE];
 static int query_sequence_num;
 
 #if defined(WINDOWS)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26299

### Purpose
cgw 의 초기화 함수 누락으로 인해 cgw 실행이 되지 않는 오류 수정
* cgw_init은 cgw에서 사용하는 odbc 관련 초기화 함수
* cgw_cas_init은 cgw 초기화 함수


### Implementation
* cgw 초기화 함수 이름 변경 : cgw_init() -> cgw_cas_init()

### Remarks
CAS 리팩토링 후,  함수이름 정리 과정에서 함수 이름 잘 못 변경함.
