### PR TITLE
[CUBVEC-147] Disk-based HNSW Performance: Co-locate Node and Vector Data

### DIFF
--- a/src/storage/index_hnsw/hnsw_algo.hpp
+++ b/src/storage/index_hnsw/hnsw_algo.hpp
@@ -277,7 +277,8 @@ namespace cubhnsw
       inline distance_t compute_distance_from_query_ (const float *query, const slot_id_t &slot) const
       {
 	pinned_t vec_blk = m_storage->get_vector_by_slot_id (slot, lock_mode::shared);
-	return compute_distance_ (query, reinterpret_cast<const float *> (vec_blk->data));
+	node_type node = node_type (vec_blk->data);
+	return compute_distance_ (query, node.get_vector());
       }
 
       inline distance_t compute_distance_between (const slot_id_t &a, const slot_id_t &b) const
@@ -285,7 +286,8 @@ namespace cubhnsw
 	auto get_vec = [&] (const slot_id_t &slot) -> const float *
 	{
 	  pinned_t vec_blk = m_storage->get_vector_by_slot_id (slot, lock_mode::shared);
-	  return reinterpret_cast<const float *> (vec_blk->data);
+	  node_type node = node_type (vec_blk->data);
+	  return node.get_vector();
 	};
 
 	return compute_distance_ (get_vec (a), get_vec (b));

--- a/src/storage/index_hnsw/hnsw_graph_base.hpp
+++ b/src/storage/index_hnsw/hnsw_graph_base.hpp
@@ -160,9 +160,13 @@ namespace cubhnsw
       {
 	return tape_;
       }
+      byte_t *vector_tape () const noexcept
+      {
+	return tape_ + offset_vector;
+      }
       byte_t *neighbors_tape() const noexcept
       {
-	return tape_ + offset_neighbors;
+	return tape_ + get_neighbors_offset ();
       }
       explicit operator bool() const noexcept
       {
@@ -180,9 +184,10 @@ namespace cubhnsw
       node_t &operator= (node_t &&) noexcept = default;
 
       static constexpr std::size_t offset_key = 0;
-      static constexpr std::size_t offset_vec_slot = sizeof (OID);
-      static constexpr std::size_t offset_level = offset_vec_slot + sizeof (slot_id_t);
-      static constexpr std::size_t offset_neighbors = offset_level + sizeof (level_t);
+      static constexpr std::size_t offset_level = offset_key + sizeof (slot_id_t);
+      static constexpr std::size_t offset_neighbors_offset = offset_level + sizeof (level_t);
+      static constexpr std::size_t offset_vector = offset_neighbors_offset + sizeof (std::size_t);
+      static constexpr std::size_t offset_header_end = offset_vector;
 
       OID get_key() const noexcept
       {
@@ -193,15 +198,6 @@ namespace cubhnsw
 	return misaligned_store<OID> (tape_, v);
       }
 
-      slot_id_t get_vec_slot() const noexcept
-      {
-	return misaligned_load<slot_id_t> (tape_ + offset_vec_slot);
-      }
-      void set_vec_slot (slot_id_t v) noexcept
-      {
-	return misaligned_store<slot_id_t> (tape_ + offset_vec_slot, v);
-      }
-
       level_t get_level() const noexcept
       {
 	return misaligned_load<level_t> (tape_ + offset_level);
@@ -210,16 +206,36 @@ namespace cubhnsw
       {
 	return misaligned_store<level_t> (tape_ + offset_level, v);
       }
-
-      static constexpr std::size_t get_size() noexcept
+      const float *get_vector() const noexcept
       {
-	return offset_neighbors;
+	return reinterpret_cast<const float *> (vector_tape());
+      }
+      void set_vector (const float *v, std::size_t dim) noexcept
+      {
+	std::size_t offset = offset_header_end + sizeof (float) * dim;
+	set_neighbors_offset (offset);
+	std::memcpy (vector_tape(), v, dim * sizeof (float));
+      }
+
+      std::size_t get_neighbors_offset () const noexcept
+      {
+	return misaligned_load<std::size_t> (tape_ + offset_neighbors_offset);
+      }
+
+      void set_neighbors_offset (std::size_t offset) noexcept
+      {
+	return misaligned_store<std::size_t> (tape_ + offset_neighbors_offset, offset);
+      }
+
+      static constexpr std::size_t get_size (std::size_t dim, std::size_t neighbors_count) noexcept
+      {
+	return offset_vector + sizeof (float) * dim;
       }
 
       std::string dump() const noexcept
       {
 	std::stringstream ss;
-	ss << "key: " << dump_oid (get_key()) << ", vec_slot: " << dump_slot (get_vec_slot()) << ", level: " << get_level();
+	ss << "key: " << dump_oid (get_key()) << ", level: " << get_level() << ", neighbors_offset: " << get_neighbors_offset();
 	return ss.str();
       }
 

--- a/src/storage/index_hnsw/hnsw_graph_base.hpp
+++ b/src/storage/index_hnsw/hnsw_graph_base.hpp
@@ -60,8 +60,51 @@ namespace cubhnsw
   }
 
   // =====================================================================
-  // graph
+  // graph layout
   // =====================================================================
+  /*
+   * Design note: span-based, extensible layouts
+   *
+   * All graph-related structures in this file are span-based views over a
+   * contiguous memory region ("tape_").
+   *
+   * - Each structure defines a fixed-size header.
+   * - Variable-sized data (vectors, neighbors, metadata) is stored after
+   *   the header and accessed via explicit offsets.
+   *
+   * This design intentionally allows:
+   * - Appending additional fields after the existing layout
+   * - Extending layouts via inheritance without breaking compatibility
+   * - Safe reuse of the same underlying buffer across derived views
+   *
+   * In other words:
+   *   base_layout | extension_1 | extension_2 | ...
+   *
+   * As long as the base header remains unchanged, derived layouts can
+   * safely interpret and extend the memory span.
+   */
+
+  // =====================================================================
+
+  /*
+   * Root node layout (serialized on tape_)
+   *
+   * | hnsw_build_params | max_level | entry_point |
+   *
+   * - hnsw_build_params:
+   *   Global build-time parameters for the HNSW index (M, efConstruction, etc).
+   *
+   * - max_level (level_t):
+   *   The highest level currently present in the graph.
+   *
+   * - entry_point (slot_id_t):
+   *   Slot identifier of the entry node at max_level.
+   *   - storage_kind::disk   -> OID
+   *   - storage_kind::memory -> std::size_t
+   *
+   * This structure represents the minimal persistent metadata required
+   * to bootstrap traversal of the HNSW graph.
+   */
   template <typename ID_TRAITS>
   class root_t
   {
@@ -143,6 +186,34 @@ namespace cubhnsw
       }
   };
 
+  /*
+  * Graph node layout (serialized on tape_)
+  *
+  * | key | level | neighbors_offset | vector | neighbors... |
+  *
+  * - key (OID):
+  *   Logical identifier of the indexed object.
+  *   This is the primary reference used to map graph nodes back to
+  *   database tuples.
+  *
+  * - level (level_t):
+  *   Maximum HNSW level of this node.
+  *
+  * - neighbors_offset (std::size_t):
+  *   Byte offset from tape_ to the beginning of the neighbors array.
+  *   Allows variable-sized vectors without fixing the header layout.
+  *
+  * - vector (float[dim]):
+  *   Stored embedding vector (raw, already normalized if required).
+  *
+  * - neighbors:
+  *   Adjacency lists for each level, stored separately and accessed
+  *   via neighbors_ref_t.
+  *
+  * Notes:
+  * - The header is fixed-size; vector and neighbors are variable-size.
+  * - neighbors_offset decouples vector dimension from graph topology.
+  */
   template <class ID_TRAITS>
   class node_t
   {
@@ -217,6 +288,13 @@ namespace cubhnsw
 	std::memcpy (vector_tape(), v, dim * sizeof (float));
       }
 
+      /*
+      * neighbors_offset:
+      *
+      * - Enables variable-length vectors without duplicating node headers.
+      * - Allows future extension (e.g., quantized vectors, metadata blocks).
+      * - Keeps neighbor lists naturally aligned after vector storage.
+      */
       std::size_t get_neighbors_offset () const noexcept
       {
 	return misaligned_load<std::size_t> (tape_ + offset_neighbors_offset);
@@ -246,6 +324,25 @@ namespace cubhnsw
       }
   };
 
+  /*
+  * Neighbor list layout (serialized on tape_)
+  *
+  * | count | slot_0 | slot_1 | ... | slot_(count-1) |
+  *
+  * - count (neighbors_count_t):
+  *   Number of valid neighbor entries.
+  *
+  * - slot_i (slot_id_t):
+  *   Slot identifiers of adjacent nodes.
+  *   Interpretation depends on storage backend:
+  *     - disk   -> OID
+  *     - memory -> std::size_t
+  *
+  * Notes:
+  * - Compact, contiguous memory layout for cache efficiency.
+  * - No pointers: fully relocatable and disk-friendly.
+  * - Erase and push_back operate in-place.
+  */
   template <class ID_TRAITS>
   class neighbors_ref_t
   {

--- a/src/storage/index_hnsw/hnsw_storage.hpp
+++ b/src/storage/index_hnsw/hnsw_storage.hpp
@@ -163,14 +163,14 @@ namespace cubhnsw
 	return level > 0 ? node_neighbors_bytes_ (level - 1) : 0;
       }
 
-      inline std::size_t node_bytes_ (level_t level) const noexcept
+      inline std::size_t node_bytes_ (level_t level, std::size_t dim, std::size_t neighbors_count) const noexcept
       {
-	return node_head_bytes_() + node_neighbors_bytes_ (level);
+	return node_head_bytes_ (dim, neighbors_count) + node_neighbors_bytes_ (level);
       }
 
-      inline std::size_t node_head_bytes_() const noexcept
+      inline std::size_t node_head_bytes_ (std::size_t dim, std::size_t neighbors_count) const noexcept
       {
-	return node_t<Traits>::get_size();
+	return node_t<Traits>::get_size (dim, neighbors_count);
       }
 
     protected:

--- a/src/storage/index_hnsw/hnsw_storage_disk.cpp
+++ b/src/storage/index_hnsw/hnsw_storage_disk.cpp
@@ -34,9 +34,6 @@ namespace cubhnsw
     m_vfid = giid.vfid;
     m_root_vpid = VPID { giid.root_pageid, giid.vfid.volid };
     m_last_node_vpid = m_root_vpid;
-
-    m_vec_pool_vfid = VFID_INITIALIZER;
-    m_last_vec_vpid = VPID_INITIALIZER;
   }
 
   disk_storage::~disk_storage ()
@@ -56,9 +53,6 @@ namespace cubhnsw
   disk_storage::init_root (std::byte *root_block, std::size_t &root_size)
   {
     root_disk_t<disk_traits_t> root { reinterpret_cast<byte_t *> (root_block) };
-
-    (void) create_continous_file (m_thread_p, m_vec_pool_vfid, m_last_vec_vpid);
-    root.set_vec_pool_vfid (m_vec_pool_vfid);
 
     root_size = root.get_size();
   }
@@ -141,18 +135,8 @@ namespace cubhnsw
   disk_storage::slot_id_t
   disk_storage::add_node (const OID &key, const float *vector, const level_t &level)
   {
-    // insert vector first
-    slot_id_t vec_slot = add_vector (key, vector);
-#if 0
-    if (vec_slot.pageid == -1)
-      {
-	assert (false);
-	return slot_id_t { -1, -1, -1 };
-      }
-#endif
-
     // insert node
-    std::size_t bytes = this->node_bytes_ (level);
+    std::size_t bytes = this->node_bytes_ (level, get_dimension(), get_connectivity());
     page_handle page_ptr = get_page_to_insert (m_vfid, m_last_node_vpid, bytes);
 
     RECDES recdes;
@@ -167,8 +151,8 @@ namespace cubhnsw
 
     node_t<disk_traits_t> node { reinterpret_cast<byte_t *> (rec_buf) };
     node.set_key (key);
-    node.set_vec_slot (vec_slot);
     node.set_level (level);
+    node.set_vector (vector, get_dimension());
 
     PGSLOTID slot_id;
 
@@ -258,32 +242,7 @@ namespace cubhnsw
   disk_storage::get_vector_by_slot_id (const slot_id_t &slot, const lock_mode &mode)
   {
     // get node by slot id
-    pinned_t node_blk = get_node_by_slot_id (slot, lock_mode::shared);
-    node_t<disk_traits_t> node = node_t<disk_traits_t> (node_blk.get().data);
-    slot_id_t vec_slot = node.get_vec_slot();
-
-    // =====================================================================
-
-    VPID vpid = { vec_slot.pageid, vec_slot.volid };
-
-    // updating vectors is not allowed
-    assert (mode == lock_mode::shared);
-
-    PAGE_PTR vec_page_ptr = pgbuf_fix (m_thread_p, &vpid, OLD_PAGE, PGBUF_LATCH_READ, PGBUF_UNCONDITIONAL_LATCH);
-    assert (vec_page_ptr != nullptr);
-
-    SPAGE_SLOT *slotp = spage_get_slot (vec_page_ptr, vec_slot.slotid);
-    assert (slotp != nullptr);
-
-    return make_pinned_block<disk_traits_t> (vec_slot, (std::byte *) vec_page_ptr + slotp->offset_to_record,
-	   slotp->record_length, mode,
-	   [this, vec_page_ptr] (auto& blk) noexcept
-    {
-      assert (blk.mode == lock_mode::shared);
-      pgbuf_unfix (m_thread_p, reinterpret_cast<PAGE_PTR> (vec_page_ptr));
-    }
-
-					    );
+    return get_node_by_slot_id (slot, lock_mode::shared);
   }
 
   // promote lockmode from shared to exclusive

--- a/src/storage/index_hnsw/hnsw_storage_disk.hpp
+++ b/src/storage/index_hnsw/hnsw_storage_disk.hpp
@@ -51,31 +51,13 @@ namespace cubhnsw
 
       explicit root_disk_t (byte_t *tape) noexcept : root_t<ID_TRAITS> (tape) {}
 
-      static constexpr std::size_t offset_vec_pool_id = root_t<ID_TRAITS>::offset_entry + sizeof (slot_id_t);
-      static constexpr std::size_t offset_vec_bucket_id = offset_vec_pool_id + sizeof (block_group_id_t);
+      static constexpr std::size_t offset_begin = root_t<ID_TRAITS>::get_size();
 
-      misaligned_ref_gt<block_group_id_t> get_vec_pool_vfid() const noexcept
-      {
-	return {this->tape() + offset_vec_pool_id};
-      }
-
-      void set_vec_pool_vfid (block_group_id_t vfid) noexcept
-      {
-	return misaligned_store<block_group_id_t> (this->tape() + offset_vec_pool_id, vfid);
-      }
-
-      misaligned_ref_gt<block_id_t> get_last_vec_vpid() const noexcept
-      {
-	return {this->tape() + offset_vec_bucket_id};
-      }
-      void set_last_vec_bucket_vpid (block_id_t vpid) noexcept
-      {
-	return misaligned_store<VPID> (this->tape() + offset_vec_bucket_id, vpid);
-      }
+      // TODO: extract extra data from root
 
       static constexpr std::size_t get_bytes() noexcept
       {
-	return root_t<ID_TRAITS>::get_size() + sizeof (block_group_id_t) + sizeof (block_id_t);
+	return root_t<ID_TRAITS>::get_size();
       }
   };
 

--- a/src/storage/index_hnsw/hnsw_storage_disk.hpp
+++ b/src/storage/index_hnsw/hnsw_storage_disk.hpp
@@ -24,7 +24,7 @@
 #include <unordered_map>
 #include <cstring>
 
-#include "hnsw_storage.hpp"          // storage<memory_id_traits>
+#include "hnsw_storage.hpp"
 #include "thread_compat.hpp"
 
 namespace cubhnsw
@@ -58,6 +58,7 @@ namespace cubhnsw
       {
 	return {this->tape() + offset_vec_pool_id};
       }
+
       void set_vec_pool_vfid (block_group_id_t vfid) noexcept
       {
 	return misaligned_store<block_group_id_t> (this->tape() + offset_vec_pool_id, vfid);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-147

### Purpose

In CUBVEC-138, the disk-based HNSW vector index was initially implemented by storing
graph node metadata (neighbor links) and vector data in separate pages.

While this design simplified the initial implementation, it introduced noticeable performance overhead during search due to:
- Additional I/O required to access vector pages after loading graph nodes
- Increased page buffer fix/unfix operations
- Poor cache locality during graph traversal

### Implementation

This PR modifies the storage layout to store vector data together with HNSW node metadata in the same page (or block).

Changes:
- struct node_t: Co-locate graph node information and its corresponding vector payload
- get_vector_by_slot_id ()
  - Eliminate extra page accesses for vector retrieval during search
  - Reduce page buffer operations and improve cache locality

### Remarks

N/A
