### PR TITLE
[CBRD-26299]  Socket timeout due to incorrect file descriptor used in poll()

### DIFF
--- a/src/broker/cas.c
+++ b/src/broker/cas.c
@@ -69,12 +69,6 @@ static char cas_db_name[MAX_HA_DBINFO_LENGTH];
 static char cas_db_user[SRV_CON_DBUSER_SIZE];
 static char cas_db_passwd[SRV_CON_DBPASSWD_SIZE];
 
-#if defined(WINDOWS)
-static int cas_req_count;	/* Request count for restart check (WINDOWS only) */
-#endif /* WINDOWS */
-
-static SOCKET srv_sock_fd;
-
 /* ========================================================================
  * Function Tables
  * ======================================================================== */
@@ -930,7 +924,7 @@ process_request (SOCKET sock_fd, T_NET_BUF * net_buf, T_REQ_INFO * req_info)
       unset_hang_check_time ();
       if (as_info->cur_keep_con == KEEP_CON_AUTO)
 	{
-	  err_code = net_read_int_keep_con_auto (sock_fd, &client_msg_header, req_info, srv_sock_fd);
+	  err_code = net_read_int_keep_con_auto (sock_fd, &client_msg_header, req_info);
 	}
       else
 	{

--- a/src/broker/cas.c
+++ b/src/broker/cas.c
@@ -170,7 +170,7 @@ static const char *server_func_name[] = {
 static void set_db_connection_info (void);
 static void clear_db_connection_info (void);
 static bool need_database_reconnect (void);
-static FN_RETURN process_request (SOCKET sock_fd, T_NET_BUF * net_buf, T_REQ_INFO * req_info);
+static FN_RETURN process_request (SOCKET sock_fd, T_NET_BUF * net_buf, T_REQ_INFO * req_info, SOCKET srv_sock_fd);
 
 #if defined(WINDOWS)
 LONG WINAPI CreateMiniDump (struct _EXCEPTION_POINTERS *pException);
@@ -647,7 +647,7 @@ conn_retry:
 	    signal (SIGUSR1, query_cancel);
 #endif /* !WINDOWS */
 
-	    fn_ret = process_request (proxy_sock_fd, &net_buf, &req_info);
+	    fn_ret = process_request (proxy_sock_fd, &net_buf, &req_info, INVALID_SOCKET);
 	    cas_log_error_handler_clear ();
 #if !defined(WINDOWS)
 	    signal (SIGUSR1, SIG_IGN);
@@ -833,7 +833,7 @@ return_error:
 }
 
 static FN_RETURN
-process_request (SOCKET sock_fd, T_NET_BUF * net_buf, T_REQ_INFO * req_info)
+process_request (SOCKET sock_fd, T_NET_BUF * net_buf, T_REQ_INFO * req_info, SOCKET srv_sock_fd)
 {
   MSG_HEADER client_msg_header;
   MSG_HEADER cas_msg_header;
@@ -924,7 +924,7 @@ process_request (SOCKET sock_fd, T_NET_BUF * net_buf, T_REQ_INFO * req_info)
       unset_hang_check_time ();
       if (as_info->cur_keep_con == KEEP_CON_AUTO)
 	{
-	  err_code = net_read_int_keep_con_auto (sock_fd, &client_msg_header, req_info);
+	  err_code = net_read_int_keep_con_auto (sock_fd, &client_msg_header, req_info, srv_sock_fd);
 	}
       else
 	{

--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -87,7 +87,6 @@ static char cas_db_passwd[SRV_CON_DBPASSWD_SIZE];
 /* ========================================================================
  * Static Variable Definitions
  * ======================================================================== */
-static SOCKET srv_sock_fd;
 static CGW_CONTEXT *cgw_current_ctx = NULL;	/* Global CGW context for db_connect callback */
 
 /* ========================================================================
@@ -504,7 +503,7 @@ process_request (SOCKET sock_fd, T_NET_BUF * net_buf, T_REQ_INFO * req_info)
       unset_hang_check_time ();
       if (as_info->cur_keep_con == KEEP_CON_AUTO)
 	{
-	  err_code = net_read_int_keep_con_auto (sock_fd, &client_msg_header, req_info, srv_sock_fd);
+	  err_code = net_read_int_keep_con_auto (sock_fd, &client_msg_header, req_info);
 	}
       else
 	{

--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -200,7 +200,7 @@ static void cgw_post_db_connect (void *context, struct timeval *cas_start_time, 
 static void cgw_cleanup_session (void);
 
 static void cas_send_connect_reply_to_driver (T_CAS_PROTOCOL protocol, SOCKET client_sock_fd, char *cas_info);
-static FN_RETURN process_request (SOCKET sock_fd, T_NET_BUF * net_buf, T_REQ_INFO * req_info);
+static FN_RETURN process_request (SOCKET sock_fd, T_NET_BUF * net_buf, T_REQ_INFO * req_info, SOCKET srv_sock_fd);
 
 
 #if defined(WINDOWS)
@@ -473,7 +473,7 @@ cgw_cleanup_session (void)
 }
 
 static FN_RETURN
-process_request (SOCKET sock_fd, T_NET_BUF * net_buf, T_REQ_INFO * req_info)
+process_request (SOCKET sock_fd, T_NET_BUF * net_buf, T_REQ_INFO * req_info, SOCKET srv_sock_fd)
 {
   MSG_HEADER client_msg_header;
   MSG_HEADER cas_msg_header;
@@ -503,7 +503,7 @@ process_request (SOCKET sock_fd, T_NET_BUF * net_buf, T_REQ_INFO * req_info)
       unset_hang_check_time ();
       if (as_info->cur_keep_con == KEEP_CON_AUTO)
 	{
-	  err_code = net_read_int_keep_con_auto (sock_fd, &client_msg_header, req_info);
+	  err_code = net_read_int_keep_con_auto (sock_fd, &client_msg_header, req_info, srv_sock_fd);
 	}
       else
 	{

--- a/src/broker/cas_common_main.c
+++ b/src/broker/cas_common_main.c
@@ -1223,7 +1223,8 @@ cas_get_db_connect_status (void)
 }
 
 int
-net_read_int_keep_con_auto (SOCKET clt_sock_fd, MSG_HEADER * client_msg_header, T_REQ_INFO * req_info, SOCKET srv_sock_fd)
+net_read_int_keep_con_auto (SOCKET clt_sock_fd, MSG_HEADER * client_msg_header, T_REQ_INFO * req_info,
+			    SOCKET srv_sock_fd)
 {
   int ret_value = 0;
 

--- a/src/broker/cas_common_main.c
+++ b/src/broker/cas_common_main.c
@@ -378,7 +378,7 @@ cas_main_loop (CAS_MAIN_OPS * ops)
 	cas_log_close (true);
 	cas_slow_log_close ();
 	sql_log2_end (true);
-#if defined(WINDOWS)	
+#if defined(WINDOWS)
 	cas_req_count++;
 #endif /* WINDOWS */
 

--- a/src/broker/cas_common_main.c
+++ b/src/broker/cas_common_main.c
@@ -70,10 +70,6 @@
 
 static int query_sequence_num;
 
-#if defined(WINDOWS)
-static int cas_req_count;	/* Request count for restart check (WINDOWS only) */
-#endif /* WINDOWS */
-
 FN_RETURN cas_main_fn_ret = FN_KEEP_CONN;
 
 static cas_cleanup_callback_t cleanup_callback = NULL;
@@ -83,7 +79,7 @@ int
 cas_main_loop (CAS_MAIN_OPS * ops)
 {
   T_NET_BUF net_buf;
-  SOCKET srv_sock_fd, br_sock_fd, client_sock_fd;
+  SOCKET br_sock_fd, client_sock_fd;
   char read_buf[1024];
   int err_code;
   int one = 1, db_info_size;
@@ -100,7 +96,7 @@ cas_main_loop (CAS_MAIN_OPS * ops)
   prev_cas_info[CAS_INFO_STATUS] = CAS_INFO_RESERVED_DEFAULT;
 
   /* Initialize */
-  if (cas_main_init (&net_buf, &srv_sock_fd) < 0)
+  if (cas_main_init (&net_buf) < 0)
     {
       return -1;
     }
@@ -382,7 +378,7 @@ cas_main_loop (CAS_MAIN_OPS * ops)
 	cas_log_close (true);
 	cas_slow_log_close ();
 	sql_log2_end (true);
-#if defined(WINDOWS)
+#if defined(WINDOWS)	
 	cas_req_count++;
 #endif /* WINDOWS */
 
@@ -426,7 +422,7 @@ cas_main_loop (CAS_MAIN_OPS * ops)
 
 /* cas_main() common initialization */
 int
-cas_main_init (T_NET_BUF * net_buf, SOCKET * srv_sock_fd)
+cas_main_init (T_NET_BUF * net_buf)
 {
 #if defined(WINDOWS)
   int new_port;
@@ -446,9 +442,9 @@ cas_main_init (T_NET_BUF * net_buf, SOCKET * srv_sock_fd)
   *srv_sock_fd = net_init_env (&new_port);
 #else /* WINDOWS */
   ut_get_as_port_name (port_name, broker_name, shm_as_index, BROKER_PATH_MAX);
-  *srv_sock_fd = net_init_env (port_name);
+  srv_sock_fd = net_init_env (port_name);
 #endif /* WINDOWS */
-  if (IS_INVALID_SOCKET (*srv_sock_fd))
+  if (IS_INVALID_SOCKET (srv_sock_fd))
     {
       return -1;
     }
@@ -1227,8 +1223,7 @@ cas_get_db_connect_status (void)
 }
 
 int
-net_read_int_keep_con_auto (SOCKET clt_sock_fd, MSG_HEADER * client_msg_header, T_REQ_INFO * req_info,
-			    SOCKET srv_sock_fd)
+net_read_int_keep_con_auto (SOCKET clt_sock_fd, MSG_HEADER * client_msg_header, T_REQ_INFO * req_info)
 {
   int ret_value = 0;
 

--- a/src/broker/cas_common_main.c
+++ b/src/broker/cas_common_main.c
@@ -79,7 +79,7 @@ int
 cas_main_loop (CAS_MAIN_OPS * ops)
 {
   T_NET_BUF net_buf;
-  SOCKET br_sock_fd, client_sock_fd;
+  SOCKET srv_sock_fd, br_sock_fd, client_sock_fd;
   char read_buf[1024];
   int err_code;
   int one = 1, db_info_size;
@@ -96,7 +96,7 @@ cas_main_loop (CAS_MAIN_OPS * ops)
   prev_cas_info[CAS_INFO_STATUS] = CAS_INFO_RESERVED_DEFAULT;
 
   /* Initialize */
-  if (cas_main_init (&net_buf) < 0)
+  if (cas_main_init (&net_buf, &srv_sock_fd) < 0)
     {
       return -1;
     }
@@ -328,7 +328,7 @@ cas_main_loop (CAS_MAIN_OPS * ops)
 		signal (SIGUSR1, query_cancel);
 #endif /* !WINDOWS */
 
-		fn_ret = ops->process_request (client_sock_fd, &net_buf, &req_info);
+		fn_ret = ops->process_request (client_sock_fd, &net_buf, &req_info, srv_sock_fd);
 		cas_main_fn_ret = fn_ret;
 		as_info->fn_status = FN_STATUS_DONE;
 
@@ -422,7 +422,7 @@ cas_main_loop (CAS_MAIN_OPS * ops)
 
 /* cas_main() common initialization */
 int
-cas_main_init (T_NET_BUF * net_buf)
+cas_main_init (T_NET_BUF * net_buf, SOCKET * srv_sock_fd)
 {
 #if defined(WINDOWS)
   int new_port;
@@ -442,9 +442,9 @@ cas_main_init (T_NET_BUF * net_buf)
   *srv_sock_fd = net_init_env (&new_port);
 #else /* WINDOWS */
   ut_get_as_port_name (port_name, broker_name, shm_as_index, BROKER_PATH_MAX);
-  srv_sock_fd = net_init_env (port_name);
+  *srv_sock_fd = net_init_env (port_name);
 #endif /* WINDOWS */
-  if (IS_INVALID_SOCKET (srv_sock_fd))
+  if (IS_INVALID_SOCKET (*srv_sock_fd))
     {
       return -1;
     }
@@ -1223,7 +1223,7 @@ cas_get_db_connect_status (void)
 }
 
 int
-net_read_int_keep_con_auto (SOCKET clt_sock_fd, MSG_HEADER * client_msg_header, T_REQ_INFO * req_info)
+net_read_int_keep_con_auto (SOCKET clt_sock_fd, MSG_HEADER * client_msg_header, T_REQ_INFO * req_info, SOCKET srv_sock_fd)
 {
   int ret_value = 0;
 

--- a/src/broker/cas_common_main.h
+++ b/src/broker/cas_common_main.h
@@ -49,8 +49,7 @@ extern int query_seq_num_next_value (void);
 extern int query_seq_num_current_value (void);
 T_BROKER_VERSION cas_get_client_version (void);
 int net_read_header_keep_con_on (SOCKET clt_sock_fd, MSG_HEADER * client_msg_header);
-int net_read_int_keep_con_auto (SOCKET clt_sock_fd, MSG_HEADER * client_msg_header, T_REQ_INFO * req_info,
-				SOCKET srv_sock_fd);
+int net_read_int_keep_con_auto (SOCKET clt_sock_fd, MSG_HEADER * client_msg_header, T_REQ_INFO * req_info);
 void set_cas_info_size (void);
 #if !defined(WINDOWS)
 void query_cancel (int signo);
@@ -107,7 +106,7 @@ typedef struct
 } CAS_MAIN_OPS;
 
 int cas_main_loop (CAS_MAIN_OPS * ops);
-int cas_main_init (T_NET_BUF * net_buf, SOCKET * srv_sock_fd);
+int cas_main_init (T_NET_BUF * net_buf);
 int cas_accept_client (SOCKET br_sock_fd, SOCKET * client_sock_fd, int *client_ip_addr);
 int cas_parse_db_info (char *read_buf, int db_info_size, T_REQ_INFO * req_info, DB_CONN_INFO * conn_info);
 int cas_handle_db_connection (SOCKET client_sock_fd, T_REQ_INFO * req_info,

--- a/src/broker/cas_common_main.h
+++ b/src/broker/cas_common_main.h
@@ -49,7 +49,8 @@ extern int query_seq_num_next_value (void);
 extern int query_seq_num_current_value (void);
 T_BROKER_VERSION cas_get_client_version (void);
 int net_read_header_keep_con_on (SOCKET clt_sock_fd, MSG_HEADER * client_msg_header);
-int net_read_int_keep_con_auto (SOCKET clt_sock_fd, MSG_HEADER * client_msg_header, T_REQ_INFO * req_info, SOCKET srv_sock_fd);
+int net_read_int_keep_con_auto (SOCKET clt_sock_fd, MSG_HEADER * client_msg_header, T_REQ_INFO * req_info,
+				SOCKET srv_sock_fd);
 void set_cas_info_size (void);
 #if !defined(WINDOWS)
 void query_cancel (int signo);
@@ -87,7 +88,8 @@ typedef void (*cas_db_post_connect_fn_t) (void *context, struct timeval * cas_st
 					  int client_ip_addr, char *db_name, char *db_user, const char *url,
 					  bool is_new_connection);
 typedef void (*cas_cleanup_session_fn_t) (void);
-typedef FN_RETURN (*cas_process_request_fn_t) (SOCKET sock_fd, T_NET_BUF * net_buf, T_REQ_INFO * req_info, SOCKET srv_sock_fd);
+typedef FN_RETURN (*cas_process_request_fn_t) (SOCKET sock_fd, T_NET_BUF * net_buf, T_REQ_INFO * req_info,
+					       SOCKET srv_sock_fd);
 typedef void (*cas_set_session_id_fn_t) (T_CAS_PROTOCOL protocol, char *session);
 typedef void (*cas_send_connect_reply_fn_t) (T_CAS_PROTOCOL protocol, SOCKET client_sock_fd, char *cas_info);
 

--- a/src/broker/cas_common_main.h
+++ b/src/broker/cas_common_main.h
@@ -49,7 +49,7 @@ extern int query_seq_num_next_value (void);
 extern int query_seq_num_current_value (void);
 T_BROKER_VERSION cas_get_client_version (void);
 int net_read_header_keep_con_on (SOCKET clt_sock_fd, MSG_HEADER * client_msg_header);
-int net_read_int_keep_con_auto (SOCKET clt_sock_fd, MSG_HEADER * client_msg_header, T_REQ_INFO * req_info);
+int net_read_int_keep_con_auto (SOCKET clt_sock_fd, MSG_HEADER * client_msg_header, T_REQ_INFO * req_info, SOCKET srv_sock_fd);
 void set_cas_info_size (void);
 #if !defined(WINDOWS)
 void query_cancel (int signo);
@@ -87,7 +87,7 @@ typedef void (*cas_db_post_connect_fn_t) (void *context, struct timeval * cas_st
 					  int client_ip_addr, char *db_name, char *db_user, const char *url,
 					  bool is_new_connection);
 typedef void (*cas_cleanup_session_fn_t) (void);
-typedef FN_RETURN (*cas_process_request_fn_t) (SOCKET sock_fd, T_NET_BUF * net_buf, T_REQ_INFO * req_info);
+typedef FN_RETURN (*cas_process_request_fn_t) (SOCKET sock_fd, T_NET_BUF * net_buf, T_REQ_INFO * req_info, SOCKET srv_sock_fd);
 typedef void (*cas_set_session_id_fn_t) (T_CAS_PROTOCOL protocol, char *session);
 typedef void (*cas_send_connect_reply_fn_t) (T_CAS_PROTOCOL protocol, SOCKET client_sock_fd, char *cas_info);
 
@@ -106,7 +106,7 @@ typedef struct
 } CAS_MAIN_OPS;
 
 int cas_main_loop (CAS_MAIN_OPS * ops);
-int cas_main_init (T_NET_BUF * net_buf);
+int cas_main_init (T_NET_BUF * net_buf, SOCKET * srv_sock_fd);
 int cas_accept_client (SOCKET br_sock_fd, SOCKET * client_sock_fd, int *client_ip_addr);
 int cas_parse_db_info (char *read_buf, int db_info_size, T_REQ_INFO * req_info, DB_CONN_INFO * conn_info);
 int cas_handle_db_connection (SOCKET client_sock_fd, T_REQ_INFO * req_info,

--- a/src/broker/cas_common_vars.c
+++ b/src/broker/cas_common_vars.c
@@ -63,6 +63,12 @@ char prev_cas_info[CAS_INFO_SIZE];
 
 /* Network socket */
 SOCKET new_req_sock_fd = INVALID_SOCKET;
+SOCKET srv_sock_fd = INVALID_SOCKET;
+
+#if defined(WINDOWS)
+/* Request count for restart check (WINDOWS only) */
+int cas_req_count = 0;
+#endif /* WINDOWS */
 
 /* Program info */
 const char *program_name;

--- a/src/broker/cas_common_vars.c
+++ b/src/broker/cas_common_vars.c
@@ -63,7 +63,6 @@ char prev_cas_info[CAS_INFO_SIZE];
 
 /* Network socket */
 SOCKET new_req_sock_fd = INVALID_SOCKET;
-SOCKET srv_sock_fd = INVALID_SOCKET;
 
 #if defined(WINDOWS)
 /* Request count for restart check (WINDOWS only) */

--- a/src/broker/cas_common_vars.h
+++ b/src/broker/cas_common_vars.h
@@ -94,6 +94,12 @@ extern char prev_cas_info[CAS_INFO_SIZE];
 
 /* Network socket */
 extern SOCKET new_req_sock_fd;
+extern SOCKET srv_sock_fd;
+
+#if defined(WINDOWS)
+/* Request count for restart check (WINDOWS only) */
+extern int cas_req_count;
+#endif /* WINDOWS */
 
 /* Program info */
 extern const char *program_name;

--- a/src/broker/cas_common_vars.h
+++ b/src/broker/cas_common_vars.h
@@ -94,7 +94,6 @@ extern char prev_cas_info[CAS_INFO_SIZE];
 
 /* Network socket */
 extern SOCKET new_req_sock_fd;
-extern SOCKET srv_sock_fd;
 
 #if defined(WINDOWS)
 /* Request count for restart check (WINDOWS only) */
@@ -126,8 +125,5 @@ extern bool autocommit_deferred;
 /* Common functions */
 extern void cas_set_db_connect_status (int status);
 extern int cas_get_db_connect_status (void);
-// extern T_BROKER_VERSION cas_get_client_version (void);
-/* restart_is_needed(), set_hang_check_time(), and unset_hang_check_time() are now declared in cas_common_main.h */
-
 
 #endif /* _CAS_COMMON_VARS_H_ */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26299

### Purpose
cas 에서 사용하는 socket 정의를 두 곳에 선언하고 사용함
이로 인해 read_buffer()의 poll()에서 잘못된 파일 디스크립터를 사용하여 socket timeout (CCI_ER_LOGIN_TIMEOUT) 이 발생함 

### Implementation
두 곳에 선언되어 있는 socket 선언을 삭제하고,  cas_common_vars.c/h 에 선언함

### Remarks
* 아래의 이슈에서 socket timeout (CCI_ER_LOGIN_TIMEOUT)이 발생하였음
https://github.com/CUBRID/cubrid-testcases-private-ex/blob/develop/shell_perf/_06_issues/_23_1h/apis_945/cases/apis_945.sh
* windows에서만 사용는 cas_req_count 도 cas_common_vars.c/h 에 선언함