### PR TITLE
[CBRD-25482] (Backport) When a general user unloads a view, remove the owner's schema from query_spec.

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -1955,13 +1955,16 @@ emit_query_specs (extract_context & ctxt, print_output & output_ctx, DB_OBJLIST 
   PARSER_CONTEXT *parser;
   PT_NODE **query_ptr;
   const char *name;
-  char owner_name[DB_MAX_IDENTIFIER_LENGTH] = { '\0' };
+  char owner_name[DB_MAX_IDENTIFIER_LENGTH];
+  owner_name[0] = '\0';
   char *class_name = NULL;
   const char *null_spec;
   bool has_using_index;
   bool change_vclass_spec;
   int i;
-  char output_owner[DB_MAX_USER_LENGTH + 4] = { '\0' };
+  char output_owner[DB_MAX_USER_LENGTH + 4];
+  output_owner[0] = '\0';
+  char *query_ptr_result;
 
   /*
    * pass 1, emit NULL spec lists for vclasses that have attribute
@@ -2023,6 +2026,11 @@ emit_query_specs (extract_context & ctxt, print_output & output_ctx, DB_OBJLIST 
 		  continue;
 		}
 
+	      if (ctxt.is_dba_user == false && ctxt.is_dba_group_member == false)
+		{
+		  parser->custom_print |= PT_PRINT_NO_CURRENT_USER_NAME;
+		}
+
 	      query_ptr = parser_parse_string (parser, db_query_spec_string (s));
 	      if (query_ptr != NULL)
 		{
@@ -2069,22 +2077,46 @@ emit_query_specs (extract_context & ctxt, print_output & output_ctx, DB_OBJLIST 
       for (s = specs, i = 1; s != NULL; s = db_query_spec_next (s), i++)
 	{
 	  SPLIT_USER_SPECIFIED_NAME (name, owner_name, class_name);
-	  if (change_vclass_spec)
-	    {			/* change the existing spec lists */
-	      PRINT_OWNER_NAME (owner_name, (ctxt.is_dba_user || ctxt.is_dba_group_member), output_owner,
-				sizeof (output_owner));
 
-	      output_ctx ("ALTER VCLASS %s%s%s%s CHANGE QUERY %d %s ;\n", output_owner,
-			  PRINT_IDENTIFIER (class_name), i, db_query_spec_string (s));
+	  parser = parser_create_parser ();
+	  if (parser == NULL)
+	    {
+	      output_ctx ("/* ERROR : ALTER VCLASS %s%s%s ADD QUERY ... */\n", PRINT_IDENTIFIER (name));
+	      continue;
+	    }
+
+	  if (ctxt.is_dba_user == false && ctxt.is_dba_group_member == false)
+	    {
+	      parser->custom_print |= PT_PRINT_NO_CURRENT_USER_NAME;
+	    }
+
+	  query_ptr = parser_parse_string (parser, db_query_spec_string (s));
+	  if (query_ptr != NULL)
+	    {
+	      query_ptr_result = parser_print_tree_with_quotes (parser, *query_ptr);
+	      if (change_vclass_spec)
+		{		/* change the existing spec lists */
+		  PRINT_OWNER_NAME (owner_name, (ctxt.is_dba_user || ctxt.is_dba_group_member), output_owner,
+				    sizeof (output_owner));
+
+		  output_ctx ("ALTER VCLASS %s%s%s%s CHANGE QUERY %d %s ;\n", output_owner,
+			      PRINT_IDENTIFIER (class_name), i, query_ptr_result);
+		}
+	      else
+		{		/* emit the usual statements */
+		  PRINT_OWNER_NAME (owner_name, (ctxt.is_dba_user || ctxt.is_dba_group_member), output_owner,
+				    sizeof (output_owner));
+
+		  output_ctx ("ALTER VCLASS %s%s%s%s ADD QUERY %s ;\n", output_owner,
+			      PRINT_IDENTIFIER (class_name), query_ptr_result);
+		}
 	    }
 	  else
-	    {			/* emit the usual statements */
-	      PRINT_OWNER_NAME (owner_name, (ctxt.is_dba_user || ctxt.is_dba_group_member), output_owner,
-				sizeof (output_owner));
-
-	      output_ctx ("ALTER VCLASS %s%s%s%s ADD QUERY %s ;\n", output_owner,
-			  PRINT_IDENTIFIER (class_name), db_query_spec_string (s));
+	    {
+	      output_ctx ("/* ERROR : ALTER VCLASS %s%s%s ADD QUERY ... */\n", PRINT_IDENTIFIER (name));
 	    }
+
+	  parser_free_parser (parser);
 	}
     }
 
@@ -2112,6 +2144,7 @@ emit_query_specs_has_using_index (extract_context & ctxt, print_output & output_
   bool change_vclass_spec;
   int i;
   char output_owner[DB_MAX_USER_LENGTH + 4] = { '\0' };
+  char *query_ptr_result;
 
   /*
    * pass 1, emit NULL spec lists for vclasses that have attribute
@@ -2148,6 +2181,12 @@ emit_query_specs_has_using_index (extract_context & ctxt, print_output & output_
 	    {
 	      continue;
 	    }
+
+	  if (ctxt.is_dba_user == false && ctxt.is_dba_group_member == false)
+	    {
+	      parser->custom_print |= PT_PRINT_NO_CURRENT_USER_NAME;
+	    }
+
 	  query_ptr = parser_parse_string (parser, db_query_spec_string (s));
 	  if (query_ptr != NULL)
 	    {
@@ -2183,22 +2222,47 @@ emit_query_specs_has_using_index (extract_context & ctxt, print_output & output_
       for (s = specs, i = 1; s; s = db_query_spec_next (s), i++)
 	{
 	  SPLIT_USER_SPECIFIED_NAME (name, owner_name, class_name);
-	  if (change_vclass_spec)
-	    {			/* change the existing spec lists */
-	      PRINT_OWNER_NAME (owner_name, (ctxt.is_dba_user || ctxt.is_dba_group_member), output_owner,
-				sizeof (output_owner));
 
-	      output_ctx ("ALTER VCLASS %s%s%s%s CHANGE QUERY %d %s ;\n", output_owner,
-			  PRINT_IDENTIFIER (class_name), i, db_query_spec_string (s));
+	  parser = parser_create_parser ();
+	  if (parser == NULL)
+	    {
+	      output_ctx ("/* ERROR : ALTER VCLASS %s%s%s ADD QUERY ... */\n", PRINT_IDENTIFIER (name));
+	      continue;
+	    }
+
+	  if (ctxt.is_dba_user == false && ctxt.is_dba_group_member == false)
+	    {
+	      parser->custom_print |= PT_PRINT_NO_CURRENT_USER_NAME;
+	    }
+
+	  query_ptr = parser_parse_string (parser, db_query_spec_string (s));
+	  if (query_ptr != NULL)
+	    {
+	      query_ptr_result = parser_print_tree_with_quotes (parser, *query_ptr);
+
+	      if (change_vclass_spec)
+		{		/* change the existing spec lists */
+		  PRINT_OWNER_NAME (owner_name, (ctxt.is_dba_user || ctxt.is_dba_group_member), output_owner,
+				    sizeof (output_owner));
+
+		  output_ctx ("ALTER VCLASS %s%s%s%s CHANGE QUERY %d %s ;\n", output_owner,
+			      PRINT_IDENTIFIER (class_name), i, query_ptr_result);
+		}
+	      else
+		{		/* emit the usual statements */
+		  PRINT_OWNER_NAME (owner_name, (ctxt.is_dba_user || ctxt.is_dba_group_member), output_owner,
+				    sizeof (output_owner));
+
+		  output_ctx ("ALTER VCLASS %s%s%s%s ADD QUERY %s ;\n", output_owner,
+			      PRINT_IDENTIFIER (class_name), query_ptr_result);
+		}
 	    }
 	  else
-	    {			/* emit the usual statements */
-	      PRINT_OWNER_NAME (owner_name, (ctxt.is_dba_user || ctxt.is_dba_group_member), output_owner,
-				sizeof (output_owner));
-
-	      output_ctx ("ALTER VCLASS %s%s%s%s ADD QUERY %s ;\n", output_owner,
-			  PRINT_IDENTIFIER (class_name), db_query_spec_string (s));
+	    {
+	      output_ctx ("/* ERROR : ALTER VCLASS %s%s%s ADD QUERY ... */\n", PRINT_IDENTIFIER (name));
 	    }
+
+	  parser_free_parser (parser);
 	}
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25482

### Purpose

11.4v 에서 반영된 pr 2건(#5360, #5569)을 백포트 합니다.

- 일반 사용자가 View 를 unload 할 경우, view_name 에서는 소유자 schema 가 제거되나 query_spec 에서는 제거되지 않는 문제 존재 합니다.
- 따라서, query_spec 역시 view 소유자의 schema 를 제거하도록 수정 합니다.

AS-IS
`ALTER VCLASS [v1] ADD QUERY select [u1.t1].[col1], [u1.t1].[col2] from [u1.t1] [u1.t1] ;`

TO-BE
`ALTER VCLASS [v1] ADD QUERY select [t1].[col1], [t1].[col2] from [t1] [t1] ;`

### Implementation

N/A

### Remarks

N/A
