### PR TITLE
[CBRD-25762] (Backport) When a general user performs a trigger unload, remove [user_schema] from condition and action_definition if the owner is the user themselves.

### DIFF
--- a/src/object/trigger_manager.c
+++ b/src/object/trigger_manager.c
@@ -125,8 +125,8 @@ static const char *OLD_REFERENCE_NAME = "old";
  * Currently, the evaluate grammar must have parens surrounding the expression.
  */
 
-static const char *EVAL_PREFIX = "EVALUATE ( ";
-static const char *EVAL_SUFFIX = " ) ";
+const char *EVAL_PREFIX = "EVALUATE ( ";
+const char *EVAL_SUFFIX = " ) ";
 
 const char *TR_CLASS_NAME = "db_trigger";
 const char *TR_ATT_UNIQUE_NAME = "unique_name";
@@ -7569,3 +7569,53 @@ tr_downcase_all_trigger_info (void)
   return ((mop == NULL) ? NO_ERROR : ER_FAILED);
 }
 #endif /* ENABLE_UNUSED_FUNCTION */
+
+/*
+ * remove_appended_trigger_evaluate () - remove appended trigger evaluate
+ *   trigger_stmt_str(in/out):
+ *   with_evaluate(in):
+ */
+char *
+remove_appended_trigger_evaluate (char *trigger_stmt_str, int with_evaluate)
+{
+  size_t remove_eval_suffix_len;
+  /* while performing the query rewrite, the characters “EVALUATE” are changed to lowercase. */
+  const char *remove_eval_prefix = "evaluate (";
+  char *p = NULL;
+
+  if (trigger_stmt_str == NULL)
+    {
+      assert (trigger_stmt_str != NULL);
+      return NULL;
+    }
+
+  if (with_evaluate)
+    {
+      p = strstr (trigger_stmt_str, remove_eval_prefix);
+      if (p == NULL)
+	{
+	  assert (p != NULL);
+	  return NULL;
+	}
+
+      remove_eval_suffix_len = strlen (p) - strlen (remove_eval_prefix);
+      if (remove_eval_suffix_len > (size_t) strlen (p))
+	{
+	  assert (0);
+	  return NULL;
+	}
+
+      p = (char *) memmove (p, p + strlen (remove_eval_prefix), remove_eval_suffix_len + 1);
+
+      if (p[remove_eval_suffix_len - 1] == ')')
+	{
+	  p[remove_eval_suffix_len - 1] = '\0';
+	}
+      else
+	{
+	  return NULL;
+	}
+    }
+
+  return trigger_stmt_str;
+}

--- a/src/object/trigger_manager.h
+++ b/src/object/trigger_manager.h
@@ -236,6 +236,16 @@ extern int tr_Recursion_level_max;
 extern TR_TRIGLIST *tr_Deferred_triggers;
 extern TR_TRIGLIST *tr_Deferred_triggers_tail;
 
+/*
+* EVAL_PREFIX, EVAL_SUFFIX
+*
+* Note:
+*    This is used to replace the condition clause with an evaluate clause when creating or unloading a trigger.
+*/
+
+extern const char *EVAL_PREFIX;
+extern const char *EVAL_SUFFIX;
+
 /* INTERFACE FUNCTIONS */
 
 /* Module control */
@@ -380,5 +390,8 @@ extern const char *tr_get_class_name (void);
 extern int tr_reset_schema_cache (TR_SCHEMA_CACHE * cache);
 extern int tr_downcase_all_trigger_info (void);
 #endif
+
+/* Remove appended trigger evaluate info */
+extern char *remove_appended_trigger_evaluate (char *trigger_stmt_str, int with_evaluate);
 
 #endif /* _TRIGGER_MANAGER_H_ */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25762

### Purpose

11.4v 에서 반영된 pr 1건(#5731)을 백포트 합니다.

- 일반 사용자가 Trigger를 unload 수행하는 경우 name과 target_class에서 [user_schema]가 제거되지만, condition 및 action_definition에 사용된 쿼리 내 [user_schema]는 제거되지 않는 문제를 수정 합니다.

AS-IS
```sql
CREATE TRIGGER [trigger]
  STATUS ACTIVE
  PRIORITY 0.000000
  AFTER INSERT ON [t1]
IF 100<(select count(*) from (select /*+ NO_MERGE */ [col1] as [col1], 1 as [col2] from [u1.t2]) [tbl] where [tbl].[col1] is not null )
  EXECUTE insert into [u1.t2] select * from [u1.t1];
```

TO-BE
```sql
CREATE TRIGGER [trigger]
  STATUS ACTIVE
  PRIORITY 0.000000
  AFTER INSERT ON [t1]
IF 100<(select count(*) from (select /*+ NO_MERGE */ [col1] as [col1], 1 as [col2] from [t2]) [tbl] where [tbl].[col1] is not null )
  EXECUTE insert into [t2] select * from [t1];
```

### Implementation

N/A

### Remarks

N/A
