### PR TITLE
[CBRD-26445] Fixing an issue where dblink queries fail after changing a password with ALTER SERVER (#6721)

### DIFF
--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -19281,16 +19281,8 @@ pt_print_remote_info (PARSER_CONTEXT * parser, PT_DBLINK_INFO * pt, bool is_dml)
 		     pt->user->info.value.data_value.str->length);
   var = pt_append_nulstring (parser, var, ":");
 
-  if (pt->is_name || is_dml)
-    {
-      var = pt_append_nulstring (parser, var, "*");
-    }
-  else
-    {
-      var = pt_append_bytes (parser, var, (char *) pt->pwd->info.value.data_value.str->bytes,
-			     pt->pwd->info.value.data_value.str->length);
-    }
-
+  var = pt_append_bytes (parser, var, (char *) pt->pwd->info.value.data_value.str->bytes,
+			 pt->pwd->info.value.data_value.str->length);
   // properties
   if (!is_dml)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26445

* Changed to prevent the existing XASL cache from being used when changing a password using the ALTER SERVER statement.
* backport #6721

### Purpose

N/A

### Implementation

N/A

### Remarks

N/A
