### PR TITLE
[CBRD-25719] (Backport) Fix an issue where [user_schema] was incorrectly stored or missing in the condition and action_definition columns of the db_trigger catalog during trigger creation or loaddb execution with legacy unload files

### DIFF
--- a/src/object/trigger_manager.c
+++ b/src/object/trigger_manager.c
@@ -1668,7 +1668,8 @@ compile_trigger_activity (TR_TRIGGER * trigger, TR_ACTIVITY * activity, int with
       class_mop = ((curname == NULL && tempname == NULL) ? NULL : trigger->class_mop);
 
       activity->statement =
-	pt_compile_trigger_stmt ((PARSER_CONTEXT *) activity->parser, text, class_mop, curname, tempname);
+	pt_compile_trigger_stmt ((PARSER_CONTEXT *) activity->parser, text, class_mop, curname, tempname,
+				 &activity->source, with_evaluate);
       if (activity->statement == NULL || pt_has_error ((PARSER_CONTEXT *) activity->parser))
 	{
 	  error = er_errid ();

--- a/src/parser/compile.c
+++ b/src/parser/compile.c
@@ -83,6 +83,7 @@ static PT_NODE *pt_find_lck_class_from_partition (PARSER_CONTEXT * parser, PT_NO
 static int pt_in_lck_array (PT_CLASS_LOCKS * lcks, const char *str, LC_PREFETCH_FLAGS flags);
 
 static void remove_appended_trigger_info (char *msg, int with_evaluate);
+static char *change_trigger_action_query (PARSER_CONTEXT * parser, PT_NODE * statement, int with_evaluate);
 
 static PT_NODE *pt_set_trigger_obj_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);
 static PT_NODE *pt_set_trigger_obj_post (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);
@@ -1044,6 +1045,55 @@ remove_appended_trigger_info (char *msg, int with_evaluate)
 }
 
 /*
+ * change_trigger_action_query () - remove appended trigger info
+ *   parser(in):
+ *   action_stmt(in):
+ *   with_evaluate(in):
+ */
+static char *
+change_trigger_action_query (PARSER_CONTEXT * parser, PT_NODE * statement, int with_evaluate)
+{
+  int result_len = 0;
+  char *result = NULL;
+  char *new_trigger_stmt_str = NULL;
+  unsigned int save_custom;
+
+  assert (parser != NULL || statement != NULL);
+
+  save_custom = parser->custom_print;
+  parser->flag.is_parsing_trigger = 1;
+
+  result = parser_print_tree_with_quotes (parser, statement);
+
+  parser->flag.is_parsing_trigger = 0;
+  parser->custom_print = save_custom;
+
+  /* remove appended trigger evaluate info */
+  result = remove_appended_trigger_evaluate (result, with_evaluate);
+  if (result == NULL)
+    {
+      return NULL;
+    }
+
+  result_len = strlen (result) + 1;
+  if (result_len < 0)
+    {
+      return NULL;
+    }
+
+  new_trigger_stmt_str = (char *) malloc (result_len);
+  if (new_trigger_stmt_str == NULL)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, (size_t) result_len);
+      return NULL;
+    }
+
+  snprintf (new_trigger_stmt_str, result_len, "%s", result);
+
+  return new_trigger_stmt_str;
+}
+
+/*
  * pt_compile_trigger_stmt () - Compiles the trigger_stmt so that it can be
  * 	executed by pt_exec_trigger_stmt
  *   return:
@@ -1052,21 +1102,22 @@ remove_appended_trigger_info (char *msg, int with_evaluate)
  *   class_op(in): class name to resolve name1 and name2 to
  *   name1(in): name to resolve
  *   name2(in): name to resolve
+ *   new_trigger_stmt(in):
+ *   with_evaluate(in):
  *
  */
 
 PT_NODE *
 pt_compile_trigger_stmt (PARSER_CONTEXT * parser, const char *trigger_stmt, DB_OBJECT * class_op, const char *name1,
-			 const char *name2)
+			 const char *name2, char **new_trigger_stmt, int with_evaluate)
 {
   char *stmt_str = NULL;
   const char *class_name;
   PT_NODE **statement_p, *statement;
   int is_update_object;
   PT_NODE *err_node;
-  int with_evaluate;
 
-  assert (parser != NULL);
+  assert (parser != NULL && new_trigger_stmt != NULL);
 
   if (!trigger_stmt)
     return NULL;
@@ -1160,7 +1211,12 @@ pt_compile_trigger_stmt (PARSER_CONTEXT * parser, const char *trigger_stmt, DB_O
       upd->info.update.spec = entity;
     }
 
+  /* prevents forced cast() within the code. (parser->flag.is_parsing_trigger == 1 && p->info.expr.flag != 0) */
+  parser->flag.is_parsing_trigger = 1;
+
   statement = pt_compile (parser, statement);
+
+  parser->flag.is_parsing_trigger = 0;
 
   /* Remove those info we append, which users can't understand them */
   if (pt_has_error (parser))
@@ -1177,6 +1233,18 @@ pt_compile_trigger_stmt (PARSER_CONTEXT * parser, const char *trigger_stmt, DB_O
   /* We need to do view translation here on the expression to be executed. */
   if (statement)
     {
+      char *new_trigger_stmt_str = NULL;
+
+      new_trigger_stmt_str =
+	change_trigger_action_query (parser, statement->info.scope.stmt->info.trigger_action.expression, with_evaluate);
+      if (new_trigger_stmt_str == NULL)
+	{
+	  assert (false);
+	  return NULL;
+	}
+
+      *new_trigger_stmt = new_trigger_stmt_str;
+
       statement->info.scope.stmt->info.trigger_action.expression =
 	mq_translate (parser, statement->info.scope.stmt->info.trigger_action.expression);
       /*

--- a/src/parser/parse_tree.c
+++ b/src/parser/parse_tree.c
@@ -1227,6 +1227,7 @@ parser_create_parser (void)
   parser->flag.has_internal_error = 0;
   parser->max_print_len = 0;
   parser->flag.is_auto_commit = 0;
+  parser->flag.is_parsing_trigger = 0;
 
   return parser;
 }

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -3938,6 +3938,7 @@ struct parser_context
     unsigned return_generated_keys:1;
     unsigned is_system_generated_stmt:1;
     unsigned is_auto_commit:1;	/* set to true, if auto commit. */
+    unsigned is_parsing_trigger:1;
   } flag;
 };
 

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -11362,6 +11362,12 @@ pt_print_expr (PARSER_CONTEXT * parser, PT_NODE * p)
 	}
       else
 	{
+	  if (parser->flag.is_parsing_trigger && p->info.expr.flag)
+	    {
+	      q = pt_append_varchar (parser, q, r1);
+	      break;
+	    }
+
 	  r2 = pt_print_bytes (parser, p->info.expr.cast_type);
 	  q = pt_append_nulstring (parser, q, " cast(");
 	  q = pt_append_varchar (parser, q, r1);
@@ -12706,8 +12712,17 @@ pt_print_insert (PARSER_CONTEXT * parser, PT_NODE * p)
   PT_NODE *crt_list = NULL;
   bool is_first_list = true, multiple_values_insert = false;
 
+  unsigned int save_custom = parser->custom_print;
+  if (parser->flag.is_parsing_trigger)
+    {
+      parser->custom_print |= PT_SUPPRESS_RESOLVED;
+      parser->custom_print & ~PT_PRINT_ALIAS;
+    }
+
   r1 = pt_print_bytes (parser, p->info.insert.spec);
   r2 = pt_print_bytes_l (parser, p->info.insert.attr_list);
+
+  parser->custom_print = save_custom;
 
   if (p->info.insert.is_subinsert == PT_IS_SUBINSERT)
     {
@@ -13249,8 +13264,6 @@ pt_print_name (PARSER_CONTEXT * parser, PT_NODE * p)
 {
   PARSER_VARCHAR *q = NULL, *r1;
   unsigned int save_custom = parser->custom_print;
-
-  char *dot = NULL;
 
   parser->custom_print = parser->custom_print | p->info.name.custom_print;
 

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -200,7 +200,8 @@ extern "C"
   extern PT_NODE *pt_class_pre_fetch (PARSER_CONTEXT * parser, PT_NODE * statement);
 
   extern PT_NODE *pt_compile_trigger_stmt (PARSER_CONTEXT * parser, const char *trigger_stmt, DB_OBJECT * class_op,
-					   const char *name1, const char *name2);
+					   const char *name1, const char *name2, char **new_trigger_stmt,
+					   int with_evaluate);
   extern int pt_exec_trigger_stmt (PARSER_CONTEXT * parser, PT_NODE * trigger_stmt, DB_OBJECT * object1,
 				   DB_OBJECT * object2, DB_VALUE * result);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25719

### Purpose

11.4v 에서 반영된 pr 1건(#5729)을 백포트 합니다.
- 과거의 unload 파일을 loaddb --no-user-specified-name 유틸리티를 사용해 트리거를 생성할 때, 실제 소유자를 찾아 db_trigger 카탈로그에 저장하도록 수정합니다.
- 11.3v 에서는 SP에 user_schema가 없어 제외 됩니다.

### Implementation

N/A

### Remarks

N/A
