### PR TITLE
[CBRD-26476] Incorrect Value Reads in UPDATE Uncorrelated Subqueries Caused by Hidden Columns (#6751)

### DIFF
--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -1368,6 +1368,11 @@ pt_point_l (PARSER_CONTEXT * parser, const PT_NODE * in_tree)
   list = NULL;
   for (node = tree; node; node = node->next)
     {
+      if (node->flag.is_hidden_column)
+	{
+	  continue;
+	}
+
       pointer = pt_point (parser, node);
       if (!pointer)
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26476

backport https://github.com/CUBRID/cubrid/pull/6751
