### PR TITLE
[CBRD-26479] [Regression][ha_repl] Core dumped in sort_exphase_merge at src/storage/external_sort.c:3792

### DIFF
--- a/src/storage/external_sort.c
+++ b/src/storage/external_sort.c
@@ -4682,6 +4682,11 @@ sort_check_parallelism (THREAD_ENTRY * thread_p, SORT_PARAM * sort_param)
 	  /* single process */
 	  return 1;
 	}
+      /* check tuple_cnt */
+      if (sort_info_p->input_file->tuple_cnt <= parallel_num)
+	{
+	  return 1;
+	}
 
       /* check worker */
       sort_param->px_worker_manager = parallel_query::worker_manager::try_reserve_workers (parallel_num);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26479>

parallel sort 기준에 tuple 개수 추가