### PR TITLE
[CBRD-26479] [Regression][ha_repl] Core dumped in sort_exphase_merge at src/storage/external_sort.c:3792

### DIFF
--- a/src/storage/external_sort.c
+++ b/src/storage/external_sort.c
@@ -1426,12 +1426,12 @@ sort_listfile (THREAD_ENTRY * thread_p, INT16 volid, int est_inp_pg_cnt, SORT_GE
 
   /* The size of a sort buffer is limited to PRM_SR_NBUFFERS. */
   sort_param->tot_buffers = MIN (prm_get_integer_value (PRM_ID_SR_NBUFFERS), input_pages);
-  sort_param->tot_buffers = MAX (4, sort_param->tot_buffers);
+  sort_param->tot_buffers = MAX (16, sort_param->tot_buffers);
 
   sort_param->internal_memory = (char *) malloc ((size_t) sort_param->tot_buffers * (size_t) DB_PAGESIZE);
   if (sort_param->internal_memory == NULL)
     {
-      sort_param->tot_buffers = 4;
+      sort_param->tot_buffers = 16;
 
       sort_param->internal_memory = (char *) malloc (sort_param->tot_buffers * DB_PAGESIZE);
       if (sort_param->internal_memory == NULL)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26479

sort buffer의 최소 크기를 4개에서 16개로 수정합니다.
병렬정렬에서 최대 4개의 임시파일을 병합하는데, 이때 필요한 page개수는 inbuff 4개 outbuff 4개로 8개입니다. 4개로 고정되어 있어 메모리가 부족한 현상이 있었습니다.
추후 병합파일 개수가 늘어날 것을 생각해 16개로 여유있게 변경했습니다.