### PR TITLE
[CUBVEC-148] Enable SIMD vectorization for distance functions correctly

### DIFF
--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -466,6 +466,7 @@ set(STORAGE_SOURCES
   ${STORAGE_DIR}/tde.c
 
   # ${STORAGE_DIR}/hnsw_usearch.cpp
+  ${INDEX_HNSW_DIR}/vector_distance_omp_simd.cpp
   ${INDEX_HNSW_DIR}/hnsw_usearch_ng.cpp
   ${INDEX_HNSW_DIR}/hnsw.cpp
   ${INDEX_HNSW_DIR}/hnsw_api.cpp
@@ -485,11 +486,11 @@ set(STORAGE_HEADERS
 
 if(USE_SIMD_NATIVE)
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    set_source_files_properties(${INDEX_HNSW_DIR}/hnsw_usearch_ng.cpp
+    set_source_files_properties(${INDEX_HNSW_DIR}/vector_distance_omp_simd.cpp
         PROPERTIES COMPILE_FLAGS "-march=native -O3 -ftree-vectorize -mprefer-vector-width=512 -ffast-math -fno-trapping-math -funroll-loops -fassociative-math -fno-signed-zeros"
     )
   elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set_source_files_properties(${INDEX_HNSW_DIR}/hnsw_usearch_ng.cpp
+    set_source_files_properties(${INDEX_HNSW_DIR}/vector_distance_omp_simd.cpp
         PROPERTIES COMPILE_FLAGS "-march=native -O3 -fvectorize -mprefer-vector-width=512 -ffast-math -fno-trapping-math -funroll-loops -fassociative-math -fno-signed-zeros"
     )
   endif()

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -516,6 +516,7 @@ set(STORAGE_SOURCES
   ${STORAGE_DIR}/system_catalog.c
   ${STORAGE_DIR}/tde.c
 
+  ${INDEX_HNSW_DIR}/vector_distance_omp_simd.cpp
   ${INDEX_HNSW_DIR}/hnsw_usearch_ng.cpp
   ${INDEX_HNSW_DIR}/hnsw.cpp
   ${INDEX_HNSW_DIR}/hnsw_api.cpp
@@ -533,11 +534,11 @@ set(STORAGE_HEADERS
 
 if(USE_SIMD_NATIVE)
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    set_source_files_properties(${INDEX_HNSW_DIR}/hnsw_usearch_ng.cpp
+    set_source_files_properties(${INDEX_HNSW_DIR}/vector_distance_omp_simd.cpp
         PROPERTIES COMPILE_FLAGS "-march=native -O3 -ftree-vectorize -mprefer-vector-width=512 -ffast-math -fno-trapping-math -funroll-loops -fassociative-math -fno-signed-zeros"
     )
   elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set_source_files_properties(${INDEX_HNSW_DIR}/hnsw_usearch_ng.cpp
+    set_source_files_properties(${INDEX_HNSW_DIR}/vector_distance_omp_simd.cpp
         PROPERTIES COMPILE_FLAGS "-march=native -O3 -fvectorize -mprefer-vector-width=512 -ffast-math -fno-trapping-math -funroll-loops -fassociative-math -fno-signed-zeros"
     )
   endif()

--- a/src/storage/index_hnsw/hnsw_algo.hpp
+++ b/src/storage/index_hnsw/hnsw_algo.hpp
@@ -269,6 +269,9 @@ namespace cubhnsw
       case METRIC_EUCLIDEAN:
 	m_metric = vector_distance_metric_t::EUCLIDEAN;
 	break;
+      case METRIC_DOT:
+	m_metric = vector_distance_metric_t::DOT;
+	break;
       default:
 	assert (false);
       }

--- a/src/storage/index_hnsw/hnsw_algo.hpp
+++ b/src/storage/index_hnsw/hnsw_algo.hpp
@@ -30,77 +30,13 @@
 #include "hnsw_utils.hpp"
 #include "hnsw_graph_base.hpp"
 #include "hnsw_storage.hpp" // storage_t
-
-#include "faiss/utils/distances.h" // faiss
+#include "vector_distance.hpp"
 
 #define HNSW_ALGO_DEBUG 0
 #define HNSW_ALGO_PRINT(fmt, ...) do { if (HNSW_ALGO_DEBUG) { fprintf (stdout, fmt, ##__VA_ARGS__); fflush (stdout); } } while (0)
 
 namespace cubhnsw
 {
-
-// =====================================================================
-// distance
-// =====================================================================
-
-  enum class vector_distance_metric_t
-  {
-    COSINE,
-    EUCLIDEAN,
-    MAX
-  };
-
-  inline float
-  cubvec_cosine_distance (const float *vec1, const float *vec2, size_t dim)
-  {
-    float dot = 0.0f;
-    float norm1_sq = 0.0f;
-    float norm2_sq = 0.0f;
-
-    #pragma omp simd reduction(+ : dot, norm1_sq, norm2_sq)
-    for (size_t i = 0; i < dim; ++i)
-      {
-	const float a = vec1[i];
-	const float b = vec2[i];
-
-	dot       += a * b;
-	norm1_sq  += a * a;
-	norm2_sq  += b * b;
-      }
-
-    // zero-vector handling
-    if (norm1_sq == 0.0f && norm2_sq == 0.0f)
-      {
-	return 0.0f;   // identical zero vectors
-      }
-    if (norm1_sq == 0.0f || norm2_sq == 0.0f)
-      {
-	return 1.0f;   // maximally distant
-      }
-
-    const float inv_norm =
-	    1.0f / (std::sqrt (norm1_sq) * std::sqrt (norm2_sq));
-
-    const float cosine_similarity = dot * inv_norm;
-    return 1.0f - cosine_similarity;
-  }
-
-  inline float
-  cubvec_l2_distance (const float *vec1, const float *vec2, size_t dim)
-  {
-    float l2 = faiss::fvec_L2sqr (vec1, vec2, dim);
-    return std::sqrt (l2);
-  }
-
-  using distance_t = float;
-  using Fn = distance_t (*) (const float *, const float *, size_t);
-
-  constexpr std::array<Fn, static_cast<size_t> (vector_distance_metric_t::MAX)> metric_table =
-  {
-    cubvec_cosine_distance,
-    cubvec_l2_distance
-  };
-
   // =====================================================================
   // algo's base structs
   // =====================================================================

--- a/src/storage/index_hnsw/vector_distance.hpp
+++ b/src/storage/index_hnsw/vector_distance.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+namespace cubhnsw
+{
+
+  enum class vector_distance_metric_t
+  {
+    COSINE,
+    EUCLIDEAN,
+    MAX
+  };
+
+  using distance_t = float;
+  using distance_fn_t = distance_t (*) (const float *, const float *, std::size_t);
+
+  distance_t
+  cubvec_cosine_distance (const float *vec1, const float *vec2, std::size_t dim);
+
+  distance_t
+  cubvec_l2_distance (const float *vec1, const float *vec2, std::size_t dim);
+
+  extern const std::array<distance_fn_t,
+	 static_cast<std::size_t> (vector_distance_metric_t::MAX)>
+	 metric_table;
+
+} // namespace cubhnsw

--- a/src/storage/index_hnsw/vector_distance.hpp
+++ b/src/storage/index_hnsw/vector_distance.hpp
@@ -1,3 +1,21 @@
+/*
+ *
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
 #pragma once
 
 #include <array>

--- a/src/storage/index_hnsw/vector_distance.hpp
+++ b/src/storage/index_hnsw/vector_distance.hpp
@@ -10,17 +10,12 @@ namespace cubhnsw
   {
     COSINE,
     EUCLIDEAN,
+    DOT,
     MAX
   };
 
   using distance_t = float;
   using distance_fn_t = distance_t (*) (const float *, const float *, std::size_t);
-
-  distance_t
-  cubvec_cosine_distance (const float *vec1, const float *vec2, std::size_t dim);
-
-  distance_t
-  cubvec_l2_distance (const float *vec1, const float *vec2, std::size_t dim);
 
   extern const std::array<distance_fn_t,
 	 static_cast<std::size_t> (vector_distance_metric_t::MAX)>

--- a/src/storage/index_hnsw/vector_distance_omp_simd.cpp
+++ b/src/storage/index_hnsw/vector_distance_omp_simd.cpp
@@ -1,0 +1,62 @@
+#include "vector_distance.hpp"
+
+#include <cmath>
+#include <omp.h>
+
+namespace cubhnsw
+{
+
+  distance_t
+  cubvec_cosine_distance (const float *vec1, const float *vec2, std::size_t dim)
+  {
+    float dot = 0.0f;
+    float norm1_sq = 0.0f;
+    float norm2_sq = 0.0f;
+
+    #pragma omp simd reduction(+ : dot, norm1_sq, norm2_sq)
+    for (std::size_t i = 0; i < dim; ++i)
+      {
+	const float a = vec1[i];
+	const float b = vec2[i];
+	dot      += a * b;
+	norm1_sq += a * a;
+	norm2_sq += b * b;
+      }
+
+    if (norm1_sq == 0.0f && norm2_sq == 0.0f)
+      {
+	return 0.0f;
+      }
+    if (norm1_sq == 0.0f || norm2_sq == 0.0f)
+      {
+	return 1.0f;
+      }
+
+    const float inv_norm =
+	    1.0f / (std::sqrt (norm1_sq) * std::sqrt (norm2_sq));
+
+    return 1.0f - dot * inv_norm;
+  }
+
+  distance_t
+  cubvec_l2_distance (const float *vec1, const float *vec2, std::size_t dim)
+  {
+    float sum = 0.0f;
+    #pragma omp simd reduction(+ : sum)
+    for (std::size_t i = 0; i < dim; ++i)
+      {
+	const float d = vec1[i] - vec2[i];
+	sum += d * d;
+      }
+    return sum;
+  }
+
+  const std::array<distance_fn_t,
+	static_cast<std::size_t> (vector_distance_metric_t::MAX)>
+	metric_table =
+  {
+    cubvec_cosine_distance,
+    cubvec_l2_distance
+  };
+
+} // namespace cubhnsw

--- a/src/storage/index_hnsw/vector_distance_omp_simd.cpp
+++ b/src/storage/index_hnsw/vector_distance_omp_simd.cpp
@@ -2,11 +2,13 @@
 
 #include <cmath>
 #include <omp.h>
+#include <algorithm>
+
+#include "porting_inline.hpp"
 
 namespace cubhnsw
 {
-
-  distance_t
+  STATIC_INLINE distance_t __attribute__ ((ALWAYS_INLINE))
   cubvec_cosine_distance (const float *vec1, const float *vec2, std::size_t dim)
   {
     float dot = 0.0f;
@@ -23,22 +25,31 @@ namespace cubhnsw
 	norm2_sq += b * b;
       }
 
-    if (norm1_sq == 0.0f && norm2_sq == 0.0f)
-      {
-	return 0.0f;
-      }
-    if (norm1_sq == 0.0f || norm2_sq == 0.0f)
+    constexpr float eps = 1e-12f;
+    if (norm1_sq < eps || norm2_sq < eps)
       {
 	return 1.0f;
       }
 
-    const float inv_norm =
-	    1.0f / (std::sqrt (norm1_sq) * std::sqrt (norm2_sq));
-
-    return 1.0f - dot * inv_norm;
+    float cosine = dot / std::sqrt (norm1_sq * norm2_sq);
+    cosine = std::clamp (cosine, -1.0f, 1.0f);
+    return 1.0f - cosine;
   }
 
-  distance_t
+  STATIC_INLINE distance_t __attribute__ ((ALWAYS_INLINE))
+  cubvec_inner_product_distance (const float *vec1, const float *vec2, std::size_t dim)
+  {
+    float sum = 0.0f;
+
+    #pragma omp simd reduction(+ : sum)
+    for (std::size_t i = 0; i < dim; ++i)
+      {
+	sum += vec1[i] * vec2[i];
+      }
+    return sum;
+  };
+
+  STATIC_INLINE distance_t __attribute__ ((ALWAYS_INLINE))
   cubvec_l2_distance (const float *vec1, const float *vec2, std::size_t dim)
   {
     float sum = 0.0f;
@@ -56,7 +67,8 @@ namespace cubhnsw
 	metric_table =
   {
     cubvec_cosine_distance,
-    cubvec_l2_distance
+    cubvec_l2_distance,
+    cubvec_inner_product_distance
   };
 
 } // namespace cubhnsw

--- a/src/storage/index_hnsw/vector_distance_omp_simd.cpp
+++ b/src/storage/index_hnsw/vector_distance_omp_simd.cpp
@@ -1,3 +1,21 @@
+/*
+ *
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
 #include "vector_distance.hpp"
 
 #include <cmath>
@@ -5,6 +23,9 @@
 #include <algorithm>
 
 #include "porting_inline.hpp"
+
+// XXX: SHOULD BE THE LAST INCLUDE HEADER
+#include "memory_wrapper.hpp"
 
 namespace cubhnsw
 {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-148

### Purpose

vector distance functions using #pragma omp simd were observed (via perf annotate) to be compiled with SSE2 instead of wider SIMD instructions such as AVX2, resulting in suboptimal performance.

### Implementation

Refactored vector distance implementations into a dedicated translation unit:
- vector_distance_omp_simd.cpp
- Introduced a clean, centralized distance interface:
  - vector_distance.hpp
  - vector_distance_metric_t now supports COSINE, EUCLIDEAN, and DOT
- Applied per-source SIMD-native compile flags (-march=native, vector width preference, fast-math, unrolling, etc.) only to the distance implementation file
- Removed dependency on FAISS distance helpers for L2 computation and replaced them with SIMD-friendly loops
  - FAISS dependency will be erased later.
- Improved numerical robustness (epsilon checks, clamping for cosine similarity)
  - Normalize ahead will be handled in another issue.

### Remarks

- Verified via perf annotate that vectorized code paths now use wider SIMD instructions instead of SSE2