### PR TITLE
[CUBVEC-152] Use cubthread for parallelize insertion when loading Vector Index

### DIFF
--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -419,7 +419,6 @@ set(THREAD_SOURCES
   ${THREAD_DIR}/thread_entry_task.cpp
   ${THREAD_DIR}/thread_lockfree_hash_map.cpp
   ${THREAD_DIR}/thread_manager.cpp
-  ${THREAD_DIR}/thread_worker_pool.cpp
   )
 set(THREAD_HEADERS
   ${THREAD_DIR}/critical_section_tracker.hpp
@@ -427,7 +426,6 @@ set(THREAD_HEADERS
   ${THREAD_DIR}/thread_entry.hpp
   ${THREAD_DIR}/thread_lockfree_hash_map.hpp
   ${THREAD_DIR}/thread_manager.hpp
-  ${THREAD_DIR}/thread_worker_pool.hpp
   )
 
 set(TRANSACTION_SOURCES

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -419,6 +419,7 @@ set(THREAD_SOURCES
   ${THREAD_DIR}/thread_entry_task.cpp
   ${THREAD_DIR}/thread_lockfree_hash_map.cpp
   ${THREAD_DIR}/thread_manager.cpp
+  ${THREAD_DIR}/thread_worker_pool.cpp
   )
 set(THREAD_HEADERS
   ${THREAD_DIR}/critical_section_tracker.hpp
@@ -426,6 +427,7 @@ set(THREAD_HEADERS
   ${THREAD_DIR}/thread_entry.hpp
   ${THREAD_DIR}/thread_lockfree_hash_map.hpp
   ${THREAD_DIR}/thread_manager.hpp
+  ${THREAD_DIR}/thread_worker_pool.hpp
   )
 
 set(TRANSACTION_SOURCES

--- a/src/storage/index_hnsw/hnsw_algo.hpp
+++ b/src/storage/index_hnsw/hnsw_algo.hpp
@@ -554,8 +554,7 @@ namespace cubhnsw
   template <typename Traits>
   int
   algo<Traits>::seek_on_layer_ (algo_context_t<Traits> &context, const float *query, const slot_id_t &start_slot,
-				const level_t level,
-				const std::size_t expansion_limit)
+				const level_t level, const std::size_t expansion_limit)
   {
     next_candidates_t<Traits> &next = context.m_next_candidates;
     top_candidates_t<Traits> &top = context.m_top_candidates;

--- a/src/storage/index_hnsw/hnsw_algo.hpp
+++ b/src/storage/index_hnsw/hnsw_algo.hpp
@@ -30,6 +30,7 @@
 #include "hnsw_utils.hpp"
 #include "hnsw_graph_base.hpp"
 #include "hnsw_storage.hpp" // storage_t
+#include "thread_entry.hpp"
 
 #include "faiss/utils/distances.h" // faiss
 
@@ -241,7 +242,8 @@ namespace cubhnsw
       algo (const hnsw_build_params &build_params);
 
       // high-level APIs
-      add_result_t<Traits> add (const key_id_t &oid, const float *vector, const std::size_t expansion);
+      add_result_t<Traits> add (cubthread::entry &thread_ref, const key_id_t &oid, const float *vector,
+				const std::size_t expansion);
       search_result_t<Traits> search (const float *query, const std::size_t k, const std::size_t expansion);
 
       void set_storage (storage_t *storage) noexcept
@@ -348,11 +350,11 @@ namespace cubhnsw
 
   template <typename Traits>
   add_result_t<Traits>
-  algo<Traits>::add (const key_id_t &key, const float *vector, const std::size_t expansion)
+  algo<Traits>::add (cubthread::entry &thread_ref, const key_id_t &key, const float *vector, const std::size_t expansion)
   {
     add_result_t<Traits> result;
 
-    m_storage->set_thread_entry (thread_get_thread_entry_info());
+    m_storage->set_thread_entry (&thread_ref);
 
     m_context.clear_candidates();
     top_candidates_t<Traits> &top = m_context.m_top_candidates;
@@ -375,7 +377,7 @@ namespace cubhnsw
     level_t curr_max_level, new_target_level;
     slot_id_t entry_slot, new_slot;
 
-    pinned_t root_block = m_storage->get_root (lock_mode::exclusive);
+    pinned_t root_block = m_storage->get_root (&thread_ref, lock_mode::exclusive);
     root_type root_node = root_type (root_block->data);
     {
       curr_max_level = root_node.get_level(); // get max_level from root page
@@ -493,7 +495,7 @@ namespace cubhnsw
     slot_id_t entry_slot;
     level_t root_level;
     {
-      pinned_t root_block = m_storage->get_root (lock_mode::shared);
+      pinned_t root_block = m_storage->get_root (nullptr, lock_mode::shared);
       root_type root_node = root_type (root_block->data);
       entry_slot = root_node.get_entry();
       root_level = root_node.get_level();

--- a/src/storage/index_hnsw/hnsw_algo.hpp
+++ b/src/storage/index_hnsw/hnsw_algo.hpp
@@ -202,6 +202,24 @@ namespace cubhnsw
     std::vector<OID> oids {};
   };
 
+  template <typename Traits>
+  struct algo_context_t
+  {
+    top_candidates_t<Traits> m_top_candidates;
+    top_candidates_t<Traits> m_top_for_refine;
+    next_candidates_t<Traits> m_next_candidates;
+    visited_set_t<Traits> m_visits;
+    std::default_random_engine m_level_generator;
+    cubthread::entry *m_thread_p {nullptr};
+
+    void clear_candidates ()
+    {
+      m_top_candidates.clear ();
+      m_next_candidates.clear();
+      m_visits.clear();
+    }
+  };
+
   /* this class is modified version of the usearch implementation */
   // =====================================================================
   // algo class definition
@@ -242,7 +260,7 @@ namespace cubhnsw
       algo (const hnsw_build_params &build_params);
 
       // high-level APIs
-      add_result_t<Traits> add (cubthread::entry &thread_ref, const key_id_t &oid, const float *vector,
+      add_result_t<Traits> add (cubthread::entry *thread_p, const key_id_t &oid, const float *vector,
 				const std::size_t expansion);
       search_result_t<Traits> search (const float *query, const std::size_t k, const std::size_t expansion);
 
@@ -254,18 +272,23 @@ namespace cubhnsw
     protected:
 
       // horizontal seeking
-      int seek_on_layer_ (const float *query, const slot_id_t &start_slot, const level_t level,
+      int seek_on_layer_ (algo_context_t<Traits> &context, const float *query, const slot_id_t &start_slot,
+			  const level_t level,
 			  const std::size_t expansion_limit);
 
       // vertical seeking
-      int seek_down_ (const float *query, const slot_id_t &start_slot, const level_t begin_level,
+      int seek_down_ (algo_context_t<Traits> &context, const float *query, const slot_id_t &start_slot,
+		      const level_t begin_level,
 		      const level_t end_level, slot_id_t &closest_slot);
 
       // refining links
-      void form_links_to_closest_ (const pinned_t &new_slot, const level_t level, candidates_view_t<Traits> &out);
-      int form_reverse_links_ (const pinned_t &new_slot, const float *value, candidates_view_t<Traits> &new_neighbors,
+      void form_links_to_closest_ (algo_context_t<Traits> &context, const pinned_t &new_slot, const level_t level,
+				   candidates_view_t<Traits> &out);
+      int form_reverse_links_ (algo_context_t<Traits> &context, const pinned_t &new_slot, const float *value,
+			       candidates_view_t<Traits> &new_neighbors,
 			       level_t level);
-      void refine_ (std::size_t needed, top_candidates_t<Traits> &top, candidates_view_t<Traits> &out) const;
+      void refine_ (cubthread::entry *thread_p, std::size_t needed, top_candidates_t<Traits> &top,
+		    candidates_view_t<Traits> &out) const;
 
       // random level generation
       level_t choose_random_level_ (std::default_random_engine &generator, double inverse_log_connectivity);
@@ -276,18 +299,19 @@ namespace cubhnsw
 	return metric_table[static_cast<size_t> (m_metric)] (v1, v2, m_dimension);
       }
 
-      inline distance_t compute_distance_from_query_ (const float *query, const slot_id_t &slot) const
+      inline distance_t compute_distance_from_query_ (cubthread::entry *thread_p, const float *query,
+	  const slot_id_t &slot) const
       {
-	pinned_t vec_blk = m_storage->get_vector_by_slot_id (slot, lock_mode::shared);
+	pinned_t vec_blk = m_storage->get_vector_by_slot_id (thread_p, slot, lock_mode::shared);
 	node_type node = node_type (vec_blk->data);
 	return compute_distance_ (query, node.get_vector());
       }
 
-      inline distance_t compute_distance_between (const slot_id_t &a, const slot_id_t &b) const
+      inline distance_t compute_distance_between (cubthread::entry *thread_p, const slot_id_t &a, const slot_id_t &b) const
       {
 	auto get_vec = [&] (const slot_id_t &slot) -> const float *
 	{
-	  pinned_t vec_blk = m_storage->get_vector_by_slot_id (slot, lock_mode::shared);
+	  pinned_t vec_blk = m_storage->get_vector_by_slot_id (thread_p, slot, lock_mode::shared);
 	  node_type node = node_type (vec_blk->data);
 	  return node.get_vector();
 	};
@@ -307,7 +331,6 @@ namespace cubhnsw
       }
 
       // variables
-      context_t m_context;
       storage_t *m_storage {nullptr};
 
       // from build_params
@@ -344,21 +367,21 @@ namespace cubhnsw
     // precompute inverse log connectivity
     m_inverse_log_connectivity = 1.0 / std::log (static_cast<double> (build_params.m));
 
-    // pre-reserve top_for_refine
-    m_context.m_top_for_refine.reserve (m_connectivity + 1);
   }
 
   template <typename Traits>
   add_result_t<Traits>
-  algo<Traits>::add (cubthread::entry &thread_ref, const key_id_t &key, const float *vector, const std::size_t expansion)
+  algo<Traits>::add (cubthread::entry *thread_p, const key_id_t &key, const float *vector, const std::size_t expansion)
   {
     add_result_t<Traits> result;
 
-    m_storage->set_thread_entry (&thread_ref);
+    algo_context_t<Traits> context;
+    context.m_thread_p = thread_p;
+    context.clear_candidates();
+    context.m_top_for_refine.reserve (m_connectivity + 1);
 
-    m_context.clear_candidates();
-    top_candidates_t<Traits> &top = m_context.m_top_candidates;
-    next_candidates_t<Traits> &next = m_context.m_next_candidates;
+    top_candidates_t<Traits> &top = context.m_top_candidates;
+    next_candidates_t<Traits> &next = context.m_next_candidates;
 
     // TODO: now, connectivity_base is not considered.
     // std::size_t connecitvity_max = m_connectivity;
@@ -377,11 +400,11 @@ namespace cubhnsw
     level_t curr_max_level, new_target_level;
     slot_id_t entry_slot, new_slot;
 
-    pinned_t root_block = m_storage->get_root (&thread_ref, lock_mode::exclusive);
+    pinned_t root_block = m_storage->get_root (context.m_thread_p, lock_mode::exclusive);
     root_type root_node = root_type (root_block->data);
     {
       curr_max_level = root_node.get_level(); // get max_level from root page
-      new_target_level = choose_random_level_ (m_context.m_level_generator, m_inverse_log_connectivity);
+      new_target_level = choose_random_level_ (context.m_level_generator, m_inverse_log_connectivity);
       entry_slot = root_node.get_entry();
       if (new_target_level > MAX_LEVELS)
 	{
@@ -390,7 +413,7 @@ namespace cubhnsw
 	}
 
       //
-      new_slot = m_storage->add_node (key, vector, new_target_level);
+      new_slot = m_storage->add_node (context.m_thread_p, key, vector, new_target_level);
       //
 
       if (m_storage->is_empty())
@@ -418,25 +441,25 @@ namespace cubhnsw
       slot_id_t closest_slot {};
       {
 	// TODO: error handling
-	(void) seek_down_ (vector, entry_slot, curr_max_level, new_target_level, closest_slot);
+	(void) seek_down_ (context, vector, entry_slot, curr_max_level, new_target_level, closest_slot);
       }
 
       level_t level = (std::min) (new_target_level, curr_max_level);
 
-      pinned_t new_node_blk = m_storage->get_node_by_slot_id (new_slot, lock_mode::exclusive);
+      pinned_t new_node_blk = m_storage->get_node_by_slot_id (context.m_thread_p, new_slot, lock_mode::exclusive);
       while (true)
 	{
-	  (void) seek_on_layer_ (vector, closest_slot, level, top_limit);
+	  (void) seek_on_layer_ (context, vector, closest_slot, level, top_limit);
 
 	  candidates_view_t<Traits> closest_view;
 	  {
 	    neighbors_ref_type neighbors = get_neighbors (new_node_blk, level);
 	    neighbors.clear();
 
-	    form_links_to_closest_ (new_node_blk, level, closest_view);
+	    form_links_to_closest_ (context, new_node_blk, level, closest_view);
 	    closest_slot = closest_view[0].slot;
 	  }
-	  form_reverse_links_ (new_node_blk, vector, closest_view, level);
+	  form_reverse_links_ (context, new_node_blk, vector, closest_view, level);
 	  if (level == 0)
 	    {
 	      break;
@@ -472,13 +495,15 @@ namespace cubhnsw
 	return result;
       }
 
-    m_storage->set_thread_entry (thread_get_thread_entry_info());
+    algo_context_t<Traits> context;
+    context.m_thread_p = thread_get_thread_entry_info();
+    context.clear_candidates();
+    context.m_top_for_refine.reserve (m_connectivity + 1);
 
-    top_candidates_t<Traits> &top = m_context.m_top_candidates;
-    next_candidates_t<Traits> &next = m_context.m_next_candidates;
+    top_candidates_t<Traits> &top = context.m_top_candidates;
+    next_candidates_t<Traits> &next = context.m_next_candidates;
+
     std::size_t expansion_size = std::max (k, expansion);
-
-    m_context.clear_candidates();
 
     if (!top.reserve (expansion_size))
       {
@@ -495,20 +520,20 @@ namespace cubhnsw
     slot_id_t entry_slot;
     level_t root_level;
     {
-      pinned_t root_block = m_storage->get_root (nullptr, lock_mode::shared);
+      pinned_t root_block = m_storage->get_root (context.m_thread_p, lock_mode::shared);
       root_type root_node = root_type (root_block->data);
       entry_slot = root_node.get_entry();
       root_level = root_node.get_level();
     }
 
     slot_id_t closest_slot;
-    if (seek_down_ (query, entry_slot, root_level, 0, closest_slot) != NO_ERROR)
+    if (seek_down_ (context, query, entry_slot, root_level, 0, closest_slot) != NO_ERROR)
       {
 	// TODO: error handling
 	assert (false);
       }
 
-    if (seek_on_layer_ (query, closest_slot, 0, expansion_size) != NO_ERROR)
+    if (seek_on_layer_ (context, query, closest_slot, 0, expansion_size) != NO_ERROR)
       {
 	// TODO: error handling
 	assert (false);
@@ -520,7 +545,7 @@ namespace cubhnsw
     result.results.assign (top.data(), top.data() + top.size());
     for (std::size_t i = 0; i < top.size (); ++i)
       {
-	pinned_t node_blk = m_storage->get_node_by_slot_id (result.results[i].slot, lock_mode::shared);
+	pinned_t node_blk = m_storage->get_node_by_slot_id (context.m_thread_p, result.results[i].slot, lock_mode::shared);
 	result.oids.push_back (node_type (node_blk->data).get_key());
       }
     return result;
@@ -528,16 +553,18 @@ namespace cubhnsw
 
   template <typename Traits>
   int
-  algo<Traits>::seek_on_layer_ (const float *query, const slot_id_t &start_slot, const level_t level,
+  algo<Traits>::seek_on_layer_ (algo_context_t<Traits> &context, const float *query, const slot_id_t &start_slot,
+				const level_t level,
 				const std::size_t expansion_limit)
   {
-    next_candidates_t<Traits> &next = m_context.m_next_candidates;
-    top_candidates_t<Traits> &top = m_context.m_top_candidates;
-    visited_set_t<Traits> &visits = m_context.m_visits;
+    next_candidates_t<Traits> &next = context.m_next_candidates;
+    top_candidates_t<Traits> &top = context.m_top_candidates;
+    visited_set_t<Traits> &visits = context.m_visits;
+    cubthread::entry *thread_p = context.m_thread_p;
 
-    m_context.clear_candidates();
+    context.clear_candidates();
 
-    distance_t radius = compute_distance_from_query_ (query, start_slot);
+    distance_t radius = compute_distance_from_query_ (context.m_thread_p, query, start_slot);
 
     next.insert_reserved (candidate_t<Traits> (-radius, start_slot));
     top.insert_reserved (candidate_t<Traits> (radius, start_slot));
@@ -554,7 +581,7 @@ namespace cubhnsw
 	next.pop ();
 
 	slot_id_t candidate_slot = candidacy.slot;
-	pinned_t candidate_node_blk = m_storage->get_node_by_slot_id (candidate_slot, lock_mode::shared);
+	pinned_t candidate_node_blk = m_storage->get_node_by_slot_id (thread_p, candidate_slot, lock_mode::shared);
 	neighbors_ref_type candidate_neighbors = get_neighbors (candidate_node_blk, level);
 	for (std::size_t i = 0; i < candidate_neighbors.size (); ++i)
 	  {
@@ -570,7 +597,7 @@ namespace cubhnsw
 		visits.insert (successor_slot);
 	      }
 
-	    distance_t sucessor_dist = compute_distance_from_query_ (query, successor_slot);
+	    distance_t sucessor_dist = compute_distance_from_query_ (thread_p, query, successor_slot);
 	    if (top.size () < expansion_limit || sucessor_dist < radius)
 	      {
 		next.insert (candidate_t<Traits> (-sucessor_dist, successor_slot));
@@ -589,14 +616,16 @@ namespace cubhnsw
 
   template <typename Traits>
   int
-  algo<Traits>::seek_down_ (const float *query, const slot_id_t &start_slot, const level_t begin_level,
+  algo<Traits>::seek_down_ (algo_context_t<Traits> &context, const float *query, const slot_id_t &start_slot,
+			    const level_t begin_level,
 			    const level_t end_level, slot_id_t &out_slot)
   {
-    visited_set_t<Traits> &visits = m_context.m_visits;
+    visited_set_t<Traits> &visits = context.m_visits;
+    cubthread::entry *thread_p = context.m_thread_p;
     visits.clear ();
 
     slot_id_t closest_slot = start_slot;
-    distance_t closest_dist = compute_distance_from_query_ (query, closest_slot);
+    distance_t closest_dist = compute_distance_from_query_ (thread_p, query, closest_slot);
     for (level_t level = begin_level; level > end_level; --level)
       {
 	bool changed = false;
@@ -604,13 +633,13 @@ namespace cubhnsw
 	  {
 	    changed = false;
 
-	    pinned_t closest_node_blk = m_storage->get_node_by_slot_id (closest_slot, lock_mode::shared);
+	    pinned_t closest_node_blk = m_storage->get_node_by_slot_id (thread_p, closest_slot, lock_mode::shared);
 	    neighbors_ref_type neighbors = get_neighbors (closest_node_blk, level);
 	    for (std::size_t i = 0; i < neighbors.size (); ++i)
 	      {
 		slot_id_t neighbor_id = neighbors.at (i);
 
-		distance_t candidate_dist = compute_distance_from_query_ (query, neighbor_id);
+		distance_t candidate_dist = compute_distance_from_query_ (thread_p, query, neighbor_id);
 		if (candidate_dist < closest_dist)
 		  {
 		    closest_dist = candidate_dist;
@@ -628,11 +657,13 @@ namespace cubhnsw
 
   template <typename Traits>
   void
-  algo<Traits>::form_links_to_closest_ (const pinned_t &new_node_blk, const level_t level,
+  algo<Traits>::form_links_to_closest_ (algo_context_t<Traits> &context, const pinned_t &new_node_blk,
+					const level_t level,
 					candidates_view_t<Traits> &top_view)
   {
-    top_candidates_t<Traits> &top = m_context.m_top_candidates;
-    refine_ (m_connectivity,top, top_view);
+    top_candidates_t<Traits> &top = context.m_top_candidates;
+    cubthread::entry *thread_p = context.m_thread_p;
+    refine_ (thread_p, m_connectivity,top, top_view);
 
     // outgoing links from new node
     neighbors_ref_type new_neighbors = get_neighbors (new_node_blk, level);
@@ -644,10 +675,12 @@ namespace cubhnsw
 
   template <typename Traits>
   int
-  algo<Traits>::form_reverse_links_ (const pinned_t &new_node_blk, const float *value,
+  algo<Traits>::form_reverse_links_ (algo_context_t<Traits> &context, const pinned_t &new_node_blk, const float *value,
 				     candidates_view_t<Traits> &new_neighbors,
 				     level_t level)
   {
+    cubthread::entry *thread_p = context.m_thread_p;
+
     for (auto n : new_neighbors)
       {
 	slot_id_t close_slot = n.slot;
@@ -660,7 +693,7 @@ namespace cubhnsw
 	neighbors_ref_type close_header;
 	{
 	  // TODO: exclusive??
-	  pinned_t close_node_blk = m_storage->get_node_by_slot_id (close_slot, lock_mode::exclusive);
+	  pinned_t close_node_blk = m_storage->get_node_by_slot_id (thread_p, close_slot, lock_mode::exclusive);
 	  close_header = get_neighbors (close_node_blk, level);
 	  if (close_header.size () < m_connectivity)
 	    {
@@ -669,24 +702,24 @@ namespace cubhnsw
 	    }
 	}
 
-	top_candidates_t<Traits> &top_for_refine = m_context.m_top_for_refine;
+	top_candidates_t<Traits> &top_for_refine = context.m_top_for_refine;
 	top_for_refine.clear ();
 
-	distance_t dist = compute_distance_from_query_ (value, close_slot);
+	distance_t dist = compute_distance_from_query_ (thread_p, value, close_slot);
 
 	top_for_refine.insert_reserved (candidate_t<Traits> (dist, close_slot));
 
 	for (std::size_t i = 0; i < close_header.size (); i++)
 	  {
 	    slot_id_t successor_slot = close_header.at (i);
-	    dist = compute_distance_between (close_slot, successor_slot);
+	    dist = compute_distance_between (thread_p, close_slot, successor_slot);
 	    top_for_refine.insert_reserved (candidate_t<Traits> (dist, successor_slot));
 	  }
 
 	// remove all neighbors from close_header
 	close_header.clear();
 	candidates_view_t<Traits> top_view;
-	(void) refine_ (m_connectivity, top_for_refine, top_view);
+	(void) refine_ (thread_p, m_connectivity, top_for_refine, top_view);
 	for (std::size_t i = 0; i != top_view.size (); i++)
 	  {
 	    close_header.push_back (top_view[i].slot);
@@ -698,7 +731,8 @@ namespace cubhnsw
 
   template <typename Traits>
   void
-  algo<Traits>::refine_ (std::size_t needed, top_candidates_t<Traits> &top, candidates_view_t<Traits> &out) const
+  algo<Traits>::refine_ (cubthread::entry *thread_p, std::size_t needed, top_candidates_t<Traits> &top,
+			 candidates_view_t<Traits> &out) const
   {
     out = {};
 
@@ -723,7 +757,7 @@ namespace cubhnsw
 	  {
 	    candidate_t submitted = top_data[idx];
 
-	    distance_t inter_result_dist = compute_distance_between (candidate.slot, submitted.slot);
+	    distance_t inter_result_dist = compute_distance_between (thread_p, candidate.slot, submitted.slot);
 	    if (inter_result_dist < candidate.distance)
 	      {
 		good = false;

--- a/src/storage/index_hnsw/hnsw_algo.hpp
+++ b/src/storage/index_hnsw/hnsw_algo.hpp
@@ -617,8 +617,7 @@ namespace cubhnsw
   template <typename Traits>
   int
   algo<Traits>::seek_down_ (algo_context_t<Traits> &context, const float *query, const slot_id_t &start_slot,
-			    const level_t begin_level,
-			    const level_t end_level, slot_id_t &out_slot)
+			    const level_t begin_level, const level_t end_level, slot_id_t &out_slot)
   {
     visited_set_t<Traits> &visits = context.m_visits;
     cubthread::entry *thread_p = context.m_thread_p;
@@ -658,8 +657,7 @@ namespace cubhnsw
   template <typename Traits>
   void
   algo<Traits>::form_links_to_closest_ (algo_context_t<Traits> &context, const pinned_t &new_node_blk,
-					const level_t level,
-					candidates_view_t<Traits> &top_view)
+					const level_t level, candidates_view_t<Traits> &top_view)
   {
     top_candidates_t<Traits> &top = context.m_top_candidates;
     cubthread::entry *thread_p = context.m_thread_p;
@@ -676,8 +674,7 @@ namespace cubhnsw
   template <typename Traits>
   int
   algo<Traits>::form_reverse_links_ (algo_context_t<Traits> &context, const pinned_t &new_node_blk, const float *value,
-				     candidates_view_t<Traits> &new_neighbors,
-				     level_t level)
+				     candidates_view_t<Traits> &new_neighbors, level_t level)
   {
     cubthread::entry *thread_p = context.m_thread_p;
 

--- a/src/storage/index_hnsw/hnsw_storage.hpp
+++ b/src/storage/index_hnsw/hnsw_storage.hpp
@@ -119,7 +119,7 @@ namespace cubhnsw
       virtual void init_root (std::byte *root_block, std::size_t &root_size) = 0;
       virtual slot_id_t add_node (const OID &key, const float *vector, const level_t &level) = 0;
 
-      virtual pinned_t get_root (lock_mode mode) = 0;
+      virtual pinned_t get_root (cubthread::entry *thread_ref, lock_mode mode) = 0;
       virtual pinned_t get_node_by_slot_id (const slot_id_t &slot_id, const lock_mode &mode) = 0;
       virtual pinned_t get_vector_by_slot_id (const slot_id_t &slot_id, const lock_mode &mode) = 0;
 

--- a/src/storage/index_hnsw/hnsw_storage.hpp
+++ b/src/storage/index_hnsw/hnsw_storage.hpp
@@ -117,24 +117,16 @@ namespace cubhnsw
       virtual void set_empty (bool is_empty) noexcept = 0;
 
       virtual void init_root (std::byte *root_block, std::size_t &root_size) = 0;
-      virtual slot_id_t add_node (const OID &key, const float *vector, const level_t &level) = 0;
+      virtual slot_id_t add_node (cubthread::entry *thread_ref, const OID &key, const float *vector,
+				  const level_t &level) = 0;
 
       virtual pinned_t get_root (cubthread::entry *thread_ref, lock_mode mode) = 0;
-      virtual pinned_t get_node_by_slot_id (const slot_id_t &slot_id, const lock_mode &mode) = 0;
-      virtual pinned_t get_vector_by_slot_id (const slot_id_t &slot_id, const lock_mode &mode) = 0;
+      virtual pinned_t get_node_by_slot_id (cubthread::entry *thread_p, const slot_id_t &slot_id, const lock_mode &mode) = 0;
+      virtual pinned_t get_vector_by_slot_id (cubthread::entry *thread_p, const slot_id_t &slot_id,
+					      const lock_mode &mode) = 0;
 
       // promote lockmode from shared to exclusive
       virtual void promote_root (pinned_t &root) = 0;
-
-      virtual void set_thread_entry (cubthread::entry *thread_p)
-      {
-	m_thread_p = thread_p;
-      }
-
-      virtual cubthread::entry *get_thread_entry() const noexcept
-      {
-	return m_thread_p;
-      }
 
       short get_max_level () const
       {
@@ -175,7 +167,6 @@ namespace cubhnsw
 
     protected:
 
-      cubthread::entry *m_thread_p;
       BTID m_giid; // general index identifier
       hnsw_build_params m_build_params;
   };

--- a/src/storage/index_hnsw/hnsw_storage_disk.cpp
+++ b/src/storage/index_hnsw/hnsw_storage_disk.cpp
@@ -58,7 +58,7 @@ namespace cubhnsw
   }
 
   disk_storage::slot_id_t
-  disk_storage::add_vector (const OID &key, const float *vector)
+  disk_storage::add_vector (cubthread::entry *thread_p, const OID &key, const float *vector)
   {
     std::size_t bytes = this->get_dimension () * sizeof (float);
 
@@ -68,13 +68,13 @@ namespace cubhnsw
 	return slot_id_t { -1, -1, -1 };
       }
 
-    page_handle page_ptr = get_page_to_insert (m_vec_pool_vfid, m_last_vec_vpid, bytes);
+    page_handle page_ptr = get_page_to_insert (thread_p, m_vec_pool_vfid, m_last_vec_vpid, bytes);
     assert (page_ptr.get() != nullptr);
 
     RECDES recdes = { IO_MAX_PAGE_SIZE, (int) bytes, REC_HOME, (char *) vector };
     PGSLOTID slot_id;
 
-    int error_code = spage_insert (m_thread_p, page_ptr.get(), &recdes, &slot_id);
+    int error_code = spage_insert (thread_p, page_ptr.get(), &recdes, &slot_id);
     if (error_code != SP_SUCCESS)
       {
 	assert (false);
@@ -85,38 +85,38 @@ namespace cubhnsw
   }
 
   disk_storage::page_handle
-  disk_storage::get_page_to_insert (VFID &vfid, VPID &last_vpid, std::size_t bytes)
+  disk_storage::get_page_to_insert (cubthread::entry *thread_p, VFID &vfid, VPID &last_vpid, std::size_t bytes)
   {
     PAGE_PTR page_ptr = nullptr;
 
     if (VPID_ISNULL (&last_vpid))
       {
 	// alloc a new page in case of root page
-	page_ptr = alloc_new_page (vfid, last_vpid);
+	page_ptr = alloc_new_page (thread_p, vfid, last_vpid);
       }
     else
       {
-	page_ptr = pgbuf_fix (m_thread_p, &last_vpid, OLD_PAGE, PGBUF_LATCH_WRITE, PGBUF_UNCONDITIONAL_LATCH);
-	if (spage_get_free_space (m_thread_p, page_ptr) < static_cast<int> (bytes))
+	page_ptr = pgbuf_fix (thread_p, &last_vpid, OLD_PAGE, PGBUF_LATCH_WRITE, PGBUF_UNCONDITIONAL_LATCH);
+	if (spage_get_free_space (thread_p, page_ptr) < static_cast<int> (bytes))
 	  {
 	    // not enough
-	    pgbuf_unfix (m_thread_p, page_ptr);
-	    page_ptr = alloc_new_page (vfid, last_vpid);
+	    pgbuf_unfix (thread_p, page_ptr);
+	    page_ptr = alloc_new_page (thread_p, vfid, last_vpid);
 	  }
       }
 
-    return page_handle (page_ptr, [this] (PAGE_PTR page_ptr) noexcept
+    return page_handle (page_ptr, [this, thread_p] (PAGE_PTR page_ptr) noexcept
     {
-      pgbuf_set_dirty (m_thread_p, page_ptr, FREE);
+      pgbuf_set_dirty (thread_p, page_ptr, FREE);
     });
   }
 
   PAGE_PTR
-  disk_storage::alloc_new_page (VFID &vfid, VPID &vpid)
+  disk_storage::alloc_new_page (cubthread::entry *thread_p, VFID &vfid, VPID &vpid)
   {
     PAGE_PTR page_ptr = NULL;
 
-    (void) file_alloc (m_thread_p, &vfid, initialize_new_page, NULL, &vpid, &page_ptr);
+    (void) file_alloc (thread_p, &vfid, initialize_new_page, NULL, &vpid, &page_ptr);
     assert (page_ptr != NULL);
 
     if (page_ptr == NULL)
@@ -126,18 +126,18 @@ namespace cubhnsw
       }
 
 #if !defined (NDEBUG)
-    pgbuf_check_page_ptype (m_thread_p, page_ptr, PAGE_HNSW);
+    pgbuf_check_page_ptype (thread_p, page_ptr, PAGE_HNSW);
 #endif /* !NDEBUG */
 
     return page_ptr;
   }
 
   disk_storage::slot_id_t
-  disk_storage::add_node (const OID &key, const float *vector, const level_t &level)
+  disk_storage::add_node (cubthread::entry *thread_p, const OID &key, const float *vector, const level_t &level)
   {
     // insert node
     std::size_t bytes = this->node_bytes_ (level, get_dimension(), get_connectivity());
-    page_handle page_ptr = get_page_to_insert (m_vfid, m_last_node_vpid, bytes);
+    page_handle page_ptr = get_page_to_insert (thread_p, m_vfid, m_last_node_vpid, bytes);
 
     RECDES recdes;
     char rec_buf[IO_MAX_PAGE_SIZE];
@@ -156,7 +156,7 @@ namespace cubhnsw
 
     PGSLOTID slot_id;
 
-    int error_code = spage_insert (m_thread_p, page_ptr.get(), &recdes, &slot_id);
+    int error_code = spage_insert (thread_p, page_ptr.get(), &recdes, &slot_id);
     if (error_code != SP_SUCCESS)
       {
 	ASSERT_ERROR ();
@@ -167,17 +167,8 @@ namespace cubhnsw
   }
 
   disk_storage::pinned_t
-  disk_storage::get_root (cubthread::entry *thread_ref, lock_mode mode)
+  disk_storage::get_root (cubthread::entry *thread_p, lock_mode mode)
   {
-    if (thread_ref != nullptr)
-      {
-	m_thread_p = thread_ref;
-      }
-    else
-      {
-	set_thread_entry (thread_get_thread_entry_info());
-      }
-
     VPID root_vpid = m_root_vpid;
 
     PGBUF_LATCH_MODE pgbuf_mode = PGBUF_LATCH_READ;
@@ -186,7 +177,7 @@ namespace cubhnsw
 	pgbuf_mode = PGBUF_LATCH_WRITE;
       }
 
-    PAGE_PTR root_page_ptr = pgbuf_fix (m_thread_p, &root_vpid, OLD_PAGE, pgbuf_mode, PGBUF_UNCONDITIONAL_LATCH);
+    PAGE_PTR root_page_ptr = pgbuf_fix (thread_p, &root_vpid, OLD_PAGE, pgbuf_mode, PGBUF_UNCONDITIONAL_LATCH);
     assert (root_page_ptr != nullptr);
 
     // TODO: hardcoded slot id 1
@@ -197,15 +188,15 @@ namespace cubhnsw
 
     return make_pinned_block<disk_traits_t> (oid, (std::byte *) root_page_ptr + slotp->offset_to_record,
 	   slotp->record_length, mode,
-	   [this, root_page_ptr] (auto& blk) noexcept
+	   [this, root_page_ptr, thread_p] (auto& blk) noexcept
     {
       if (blk.mode == lock_mode::exclusive)
 	{
-	  pgbuf_set_dirty (m_thread_p, reinterpret_cast<PAGE_PTR> (root_page_ptr), FREE);
+	  pgbuf_set_dirty (thread_p, reinterpret_cast<PAGE_PTR> (root_page_ptr), FREE);
 	}
       else
 	{
-	  pgbuf_unfix (m_thread_p, reinterpret_cast<PAGE_PTR> (root_page_ptr));
+	  pgbuf_unfix (thread_p, reinterpret_cast<PAGE_PTR> (root_page_ptr));
 	}
     }
 
@@ -213,7 +204,7 @@ namespace cubhnsw
   }
 
   disk_storage::pinned_t
-  disk_storage::get_node_by_slot_id (const slot_id_t &id, const lock_mode &mode)
+  disk_storage::get_node_by_slot_id (cubthread::entry *thread_p, const slot_id_t &id, const lock_mode &mode)
   {
     VPID vpid = { id.pageid, id.volid };
 
@@ -223,7 +214,7 @@ namespace cubhnsw
 	pgbuf_mode = PGBUF_LATCH_WRITE;
       }
 
-    PAGE_PTR node_page_ptr = pgbuf_fix (m_thread_p, &vpid, OLD_PAGE, pgbuf_mode, PGBUF_UNCONDITIONAL_LATCH);
+    PAGE_PTR node_page_ptr = pgbuf_fix (thread_p, &vpid, OLD_PAGE, pgbuf_mode, PGBUF_UNCONDITIONAL_LATCH);
     assert (node_page_ptr != nullptr);
 
     SPAGE_SLOT *slotp = spage_get_slot (node_page_ptr, id.slotid);
@@ -231,15 +222,15 @@ namespace cubhnsw
 
     return make_pinned_block<disk_traits_t> (id, (std::byte *) node_page_ptr + slotp->offset_to_record,
 	   slotp->record_length, mode,
-	   [this, node_page_ptr] (auto& blk) noexcept
+	   [this, node_page_ptr, thread_p] (auto& blk) noexcept
     {
       if (blk.mode == lock_mode::exclusive)
 	{
-	  pgbuf_set_dirty (m_thread_p, reinterpret_cast<PAGE_PTR> (node_page_ptr), FREE);
+	  pgbuf_set_dirty (thread_p, reinterpret_cast<PAGE_PTR> (node_page_ptr), FREE);
 	}
       else
 	{
-	  pgbuf_unfix (m_thread_p, reinterpret_cast<PAGE_PTR> (node_page_ptr));
+	  pgbuf_unfix (thread_p, reinterpret_cast<PAGE_PTR> (node_page_ptr));
 	}
     }
 
@@ -248,10 +239,10 @@ namespace cubhnsw
   }
 
   disk_storage::pinned_t
-  disk_storage::get_vector_by_slot_id (const slot_id_t &slot, const lock_mode &mode)
+  disk_storage::get_vector_by_slot_id (cubthread::entry *thread_p, const slot_id_t &slot, const lock_mode &mode)
   {
     // get node by slot id
-    return get_node_by_slot_id (slot, lock_mode::shared);
+    return get_node_by_slot_id (thread_p, slot, lock_mode::shared);
   }
 
   // promote lockmode from shared to exclusive

--- a/src/storage/index_hnsw/hnsw_storage_disk.cpp
+++ b/src/storage/index_hnsw/hnsw_storage_disk.cpp
@@ -167,8 +167,17 @@ namespace cubhnsw
   }
 
   disk_storage::pinned_t
-  disk_storage::get_root (lock_mode mode)
+  disk_storage::get_root (cubthread::entry *thread_ref, lock_mode mode)
   {
+    if (thread_ref != nullptr)
+      {
+	m_thread_p = thread_ref;
+      }
+    else
+      {
+	set_thread_entry (thread_get_thread_entry_info());
+      }
+
     VPID root_vpid = m_root_vpid;
 
     PGBUF_LATCH_MODE pgbuf_mode = PGBUF_LATCH_READ;

--- a/src/storage/index_hnsw/hnsw_storage_disk.hpp
+++ b/src/storage/index_hnsw/hnsw_storage_disk.hpp
@@ -84,11 +84,14 @@ namespace cubhnsw
 
       virtual void init_root (std::byte *root_block, std::size_t &root_size) override;
 
-      virtual slot_id_t add_node (const OID &key, const float *vector, const level_t &level) override;
+      virtual slot_id_t add_node (cubthread::entry *thread_p, const OID &key, const float *vector,
+				  const level_t &level) override;
 
-      virtual pinned_t get_root (cubthread::entry *thread_ref, lock_mode mode) override;
-      virtual pinned_t get_node_by_slot_id (const slot_id_t &slot_id, const lock_mode &mode) override;
-      virtual pinned_t get_vector_by_slot_id (const slot_id_t &slot_id, const lock_mode &mode) override;
+      virtual pinned_t get_root (cubthread::entry *thread_p, lock_mode mode) override;
+      virtual pinned_t get_node_by_slot_id (cubthread::entry *thread_p, const slot_id_t &slot_id,
+					    const lock_mode &mode) override;
+      virtual pinned_t get_vector_by_slot_id (cubthread::entry *thread_p, const slot_id_t &slot_id,
+					      const lock_mode &mode) override;
 
       // promote lockmode from shared to exclusive
       // TODO: not implemented
@@ -96,14 +99,14 @@ namespace cubhnsw
 
     protected:
 
-      slot_id_t add_vector (const OID &key, const float *vector);
+      slot_id_t add_vector (cubthread::entry *thread_p, const OID &key, const float *vector);
 
       // page alloc helpers
       static int initialize_new_page (THREAD_ENTRY *thread_p, PAGE_PTR page, void *args);
 
       int create_continous_file (THREAD_ENTRY *thread_p, VFID &vfid, VPID &vpid);
-      PAGE_PTR alloc_new_page (VFID &vfid, VPID &vpid);
-      page_handle get_page_to_insert (VFID &vfid, VPID &last_vpid, std::size_t bytes);
+      PAGE_PTR alloc_new_page (cubthread::entry *thread_p, VFID &vfid, VPID &vpid);
+      page_handle get_page_to_insert (cubthread::entry *thread_p, VFID &vfid, VPID &last_vpid, std::size_t bytes);
 
     private:
       VFID m_vfid;

--- a/src/storage/index_hnsw/hnsw_storage_disk.hpp
+++ b/src/storage/index_hnsw/hnsw_storage_disk.hpp
@@ -86,7 +86,7 @@ namespace cubhnsw
 
       virtual slot_id_t add_node (const OID &key, const float *vector, const level_t &level) override;
 
-      virtual pinned_t get_root (lock_mode mode) override;
+      virtual pinned_t get_root (cubthread::entry *thread_ref, lock_mode mode) override;
       virtual pinned_t get_node_by_slot_id (const slot_id_t &slot_id, const lock_mode &mode) override;
       virtual pinned_t get_vector_by_slot_id (const slot_id_t &slot_id, const lock_mode &mode) override;
 

--- a/src/storage/index_hnsw/hnsw_storage_mem.cpp
+++ b/src/storage/index_hnsw/hnsw_storage_mem.cpp
@@ -60,7 +60,7 @@ namespace cubhnsw
   }
 
   memory_storage::root_type
-  memory_storage::get_root ()
+  memory_storage::get_root (cubthread::entry *thread_ref, lock_mode mode)
   {
     return root_type { reinterpret_cast<byte_t *> (m_root_block) };
   }

--- a/src/storage/index_hnsw/hnsw_storage_mem.cpp
+++ b/src/storage/index_hnsw/hnsw_storage_mem.cpp
@@ -82,7 +82,7 @@ namespace cubhnsw
   // VECTOR STORAGE
   // -------------------------------------------------------------------
   memory_storage::slot_id_t
-  memory_storage::add_vector (const OID &oid, const float *vector)
+  memory_storage::add_vector (cubthread::entry *thread_ref, const OID &oid, const float *vector)
   {
     slot_id_t new_id;
 
@@ -119,7 +119,7 @@ namespace cubhnsw
   // -------------------------------------------------------------------
   // NODE STORAGE
   // -------------------------------------------------------------------
-  memory_storage::slot_id_t memory_storage::add_node (const OID &key, const level_t &level)
+  memory_storage::slot_id_t memory_storage::add_node (cubthread::entry *thread_ref, const OID &key, const level_t &level)
   {
     std::size_t bytes = this->node_bytes_ (level);
 

--- a/src/storage/index_hnsw/hnsw_storage_mem.hpp
+++ b/src/storage/index_hnsw/hnsw_storage_mem.hpp
@@ -55,12 +55,12 @@ namespace cubhnsw
       virtual bool is_empty() override;
 
       // Vector storage
-      virtual slot_id_t add_vector (const OID &oid, const float *vector) override;
+      virtual slot_id_t add_vector (cubthread::entry *thread_p, const OID &oid, const float *vector) override;
       virtual const float *get_vector (const slot_id_t &at) const override;
       virtual slot_id_t vector_at (const OID &oid) const override;
 
       // Node storage
-      virtual slot_id_t add_node (const OID &key, const level_t &level) override;
+      virtual slot_id_t add_node (cubthread::entry *thread_p, const OID &key, const level_t &level) override;
       virtual node_type get_node (const slot_id_t &at) const override;
       virtual slot_id_t node_at (const OID &oid) override;
 

--- a/src/storage/index_hnsw/hnsw_usearch_ng.cpp
+++ b/src/storage/index_hnsw/hnsw_usearch_ng.cpp
@@ -37,7 +37,7 @@
 #include "slotted_page.h"
 
 #include "db_vector.hpp"	// db_vector_is_all_zeros
-
+#include "thread_worker_pool.hpp"
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
 #include "memory_wrapper.hpp"
 
@@ -87,7 +87,7 @@ class hnsw_usearch_ng final:public hnsw_index
 				const float *vector) override;
     virtual int add (int n_vectors, const OID *oid,
 		     const float *vector) override;
-
+    int add_vector (cubthread::entry &thread_ref, const OID oid, const float *vector);
     virtual int search (const float *query, const int k, const int ef_search,
 			OID *rec_oids, float *distances) override;
     virtual int remove (const OID *oid) override;
@@ -107,6 +107,8 @@ class hnsw_usearch_ng final:public hnsw_index
 
     std::unique_ptr < algo_type > m_algo;
     std::unique_ptr < storage_type > m_storage;
+    std::unique_ptr<cubthread::entry_workpool> m_worker_pool;
+    size_t m_worker_pool_size;
 };
 
 // =====================================================================
@@ -193,6 +195,11 @@ hnsw_usearch_ng::hnsw_usearch_ng (hnsw_index_backend &backend, const BTID &btid,
 
   m_algo = std::make_unique < algo_type > (build_params);
   m_algo->set_storage (m_storage.get ());
+
+  m_worker_pool_size = std::thread::hardware_concurrency ();
+  m_worker_pool = std::unique_ptr<cubthread::entry_workpool> (cubthread::get_manager()->create_worker_pool (
+			  m_worker_pool_size, m_worker_pool_size, "hnsw insertion worker pool", NULL, 1, false));
+  assert (m_worker_pool != nullptr);
 }
 
 int
@@ -206,20 +213,29 @@ hnsw_usearch_ng::prepare_to_add (int n_vectors, const OID *oid,
 int
 hnsw_usearch_ng::add (int n_vectors, const OID *oid, const float *vector)
 {
-  #pragma omp parallel
-  #pragma omp for
+
+  // Push insert each vector insertion task to worker pool
+
   for (int i = 0; i < n_vectors; ++i)
     {
-      if (m_build_params.metric == DB_VECTOR_DISTANCE_METRIC::METRIC_COSINE
-	  && db_vector_is_all_zeros (vector + i * m_build_params.dimension,
-				     m_build_params.dimension))
-	{
-	  er_log_debug (ARG_FILE_LINE, "Vector is all zeros, skipping search");
-	  continue;
-	}
-      m_algo->add (oid[i], vector + i * m_build_params.dimension,
-		   m_build_params.ef_construction);
+      auto exec_f = std::bind (&hnsw_usearch_ng::add_vector, std::ref (*this), std::placeholders::_1, oid[i],
+			       vector + i * m_build_params.dimension);
+      cubthread::entry_callable_task *task = new cubthread::entry_callable_task (exec_f);
+      cubthread::get_manager()->push_task (m_worker_pool.get(), task);
     }
+  return NO_ERROR;
+}
+
+int
+hnsw_usearch_ng::add_vector (cubthread::entry &thread_ref, const OID oid, const float *vector)
+{
+  if (m_build_params.metric == DB_VECTOR_DISTANCE_METRIC::METRIC_COSINE
+      && db_vector_is_all_zeros (vector, m_build_params.dimension))
+    {
+      er_log_debug (ARG_FILE_LINE, "Vector is all zeros, skipping search");
+      return NO_ERROR;
+    }
+  m_algo->add (oid, vector, m_build_params.ef_construction);
   return NO_ERROR;
 }
 

--- a/src/storage/index_hnsw/hnsw_usearch_ng.cpp
+++ b/src/storage/index_hnsw/hnsw_usearch_ng.cpp
@@ -81,13 +81,13 @@ class hnsw_usearch_ng final:public hnsw_index
 		     const std::string &name,
 		     const hnsw_build_params &build_params,
 		     PAGE_PTR page_ptr, RECDES &rec);
-    ~hnsw_usearch_ng () = default;
+    ~hnsw_usearch_ng () override;
 
     virtual int prepare_to_add (int n_vectors, const OID *oid,
 				const float *vector) override;
     virtual int add (int n_vectors, const OID *oid,
 		     const float *vector) override;
-    int add_vector (cubthread::entry &thread_ref, const OID oid, const float *vector);
+    int add_vector (cubthread::entry &thread_ref, const OID oid, const float *vector, const int tran_index);
     virtual int search (const float *query, const int k, const int ef_search,
 			OID *rec_oids, float *distances) override;
     virtual int remove (const OID *oid) override;
@@ -107,7 +107,7 @@ class hnsw_usearch_ng final:public hnsw_index
 
     std::unique_ptr < algo_type > m_algo;
     std::unique_ptr < storage_type > m_storage;
-    std::unique_ptr<cubthread::entry_workpool> m_worker_pool;
+    cubthread::entry_workpool *m_worker_pool;
     size_t m_worker_pool_size;
 };
 
@@ -178,7 +178,6 @@ hnsw_usearch_ng::hnsw_usearch_ng (hnsw_index_backend &backend, const BTID &btid,
   this->m_thread_p = thread_get_thread_entry_info ();
 
   m_storage = std::make_unique < storage_type > (btid, build_params);
-  m_storage->set_thread_entry (thread_get_thread_entry_info ());
 
   std::size_t root_size;
   m_storage->init_root (reinterpret_cast < std::byte * > (rec.data),
@@ -197,9 +196,13 @@ hnsw_usearch_ng::hnsw_usearch_ng (hnsw_index_backend &backend, const BTID &btid,
   m_algo->set_storage (m_storage.get ());
 
   m_worker_pool_size = std::thread::hardware_concurrency ();
-  m_worker_pool = std::unique_ptr<cubthread::entry_workpool> (cubthread::get_manager()->create_worker_pool (
-			  m_worker_pool_size, m_worker_pool_size, "hnsw insertion worker pool", NULL, 1, false));
-  assert (m_worker_pool != nullptr);
+  m_worker_pool = cubthread::get_manager ()->create_worker_pool (
+			  m_worker_pool_size, m_worker_pool_size, "hnsw insertion worker pool", NULL, 1, false);
+}
+
+hnsw_usearch_ng::~hnsw_usearch_ng ()
+{
+  cubthread::get_manager()->destroy_worker_pool (m_worker_pool);
 }
 
 int
@@ -219,23 +222,26 @@ hnsw_usearch_ng::add (int n_vectors, const OID *oid, const float *vector)
   for (int i = 0; i < n_vectors; ++i)
     {
       auto exec_f = std::bind (&hnsw_usearch_ng::add_vector, std::ref (*this), std::placeholders::_1, oid[i],
-			       vector + i * m_build_params.dimension);
+			       vector + i * m_build_params.dimension, m_thread_p->tran_index);
       cubthread::entry_callable_task *task = new cubthread::entry_callable_task (exec_f);
-      cubthread::get_manager()->push_task (m_worker_pool.get(), task);
+      cubthread::get_manager()->push_task (m_worker_pool, task);
     }
   return NO_ERROR;
 }
 
 int
-hnsw_usearch_ng::add_vector (cubthread::entry &thread_ref, const OID oid, const float *vector)
+hnsw_usearch_ng::add_vector (cubthread::entry &thread_ref, const OID oid, const float *vector, const int tran_index)
 {
+  thread_ref.tran_index = tran_index;
+
   if (m_build_params.metric == DB_VECTOR_DISTANCE_METRIC::METRIC_COSINE
       && db_vector_is_all_zeros (vector, m_build_params.dimension))
     {
       er_log_debug (ARG_FILE_LINE, "Vector is all zeros, skipping search");
       return NO_ERROR;
     }
-  m_algo->add (thread_ref, oid, vector, m_build_params.ef_construction);
+
+  m_algo->add (&thread_ref, oid, vector, m_build_params.ef_construction);
   return NO_ERROR;
 }
 

--- a/src/storage/index_hnsw/hnsw_usearch_ng.cpp
+++ b/src/storage/index_hnsw/hnsw_usearch_ng.cpp
@@ -37,7 +37,9 @@
 #include "slotted_page.h"
 
 #include "db_vector.hpp"	// db_vector_is_all_zeros
+#if defined (SERVER_MODE)
 #include "thread_worker_pool.hpp"
+#endif
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
 #include "memory_wrapper.hpp"
 

--- a/src/storage/index_hnsw/hnsw_usearch_ng.cpp
+++ b/src/storage/index_hnsw/hnsw_usearch_ng.cpp
@@ -235,7 +235,7 @@ hnsw_usearch_ng::add_vector (cubthread::entry &thread_ref, const OID oid, const 
       er_log_debug (ARG_FILE_LINE, "Vector is all zeros, skipping search");
       return NO_ERROR;
     }
-  m_algo->add (oid, vector, m_build_params.ef_construction);
+  m_algo->add (thread_ref, oid, vector, m_build_params.ef_construction);
   return NO_ERROR;
 }
 

--- a/src/storage/index_hnsw/hnsw_usearch_ng.cpp
+++ b/src/storage/index_hnsw/hnsw_usearch_ng.cpp
@@ -107,8 +107,11 @@ class hnsw_usearch_ng final:public hnsw_index
 
     std::unique_ptr < algo_type > m_algo;
     std::unique_ptr < storage_type > m_storage;
+
+#if defined (SERVER_MODE)
     cubthread::entry_workpool *m_worker_pool;
     size_t m_worker_pool_size;
+#endif
 };
 
 // =====================================================================
@@ -195,14 +198,18 @@ hnsw_usearch_ng::hnsw_usearch_ng (hnsw_index_backend &backend, const BTID &btid,
   m_algo = std::make_unique < algo_type > (build_params);
   m_algo->set_storage (m_storage.get ());
 
+#if defined (SERVER_MODE)
   m_worker_pool_size = std::thread::hardware_concurrency ();
   m_worker_pool = cubthread::get_manager ()->create_worker_pool (
 			  m_worker_pool_size, m_worker_pool_size, "hnsw insertion worker pool", NULL, 1, false);
+#endif
 }
 
 hnsw_usearch_ng::~hnsw_usearch_ng ()
 {
+#if defined (SERVER_MODE)
   cubthread::get_manager()->destroy_worker_pool (m_worker_pool);
+#endif
 }
 
 int
@@ -221,10 +228,20 @@ hnsw_usearch_ng::add (int n_vectors, const OID *oid, const float *vector)
 
   for (int i = 0; i < n_vectors; ++i)
     {
+#if defined (SERVER_MODE)
       auto exec_f = std::bind (&hnsw_usearch_ng::add_vector, std::ref (*this), std::placeholders::_1, oid[i],
 			       vector + i * m_build_params.dimension, m_thread_p->tran_index);
       cubthread::entry_callable_task *task = new cubthread::entry_callable_task (exec_f);
       cubthread::get_manager()->push_task (m_worker_pool, task);
+#else
+      if (m_build_params.metric == DB_VECTOR_DISTANCE_METRIC::METRIC_COSINE
+	  && db_vector_is_all_zeros (vector + i * m_build_params.dimension, m_build_params.dimension))
+	{
+	  er_log_debug (ARG_FILE_LINE, "Vector is all zeros, skipping search");
+	  continue;
+	}
+      m_algo->add (m_thread_p, oid[i], vector + i * m_build_params.dimension, m_build_params.ef_construction);
+#endif
     }
   return NO_ERROR;
 }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBVEC-152>

### Purpose

데이터 입력이 되어 있는 테이블로부터 벡터 인덱스 생성 시, 인덱스 로드를 하는 과정에 사용되는 병렬화를 OMP에서 cubthread로 변경한다.

OMP는 CUBRID의 thread manager를 통해서 스레드를 생성하지 않기 때문에, 올바르게 `thread_entry`를 접근해서 찾지 못하는 문제가 발생하여, 이를 해결하고자 병렬화 방식을 변경한다. 
### Implementation

- `cubthread`를 통한 worker pool 생성
  -  `entry_callable_task`를 통해 `add_vector` 함수를 task로 수행하는 worker pool을 생성한다.
  - `hnsw_usearch_ng` 클래스 안의 멤버 변수로 생성하며, 해당 클래스 소멸자에서 worker pool 제거
-  multi-threading에 맞게 코드 수정
  - 기존에 Index당 하나만 생성되던 context들을 각 task마다 생성 (`algo_context_t`)
  - worker pool을 통해 생성된 thread에 대해 `thread_entry`를 아래단 함수들로 전달
    - `pgbuf_fix`
    -  `pgbuf_unfix`
    -  `spage_insert` 등

### Remarks

해당 수정 후 아래와 같은 TC가 정상적으로 수행된다. 

```
DROP IF EXISTS test_empty_table;
CREATE TABLE test_empty_table (
    id INT,
    vector_data VECTOR(3)
);

INSERT INTO test_empty_table VALUES (1, '[1,2,3]');
INSERT INTO test_empty_table VALUES (2, '[1,0,2]');
INSERT INTO test_empty_table VALUES (3, '[3,4,5]');
INSERT INTO test_empty_table VALUES (4, '[0,0,1]');
INSERT INTO test_empty_table VALUES (5, '[5,6,7]');
INSERT INTO test_empty_table VALUES (6, '[9,8,7]');
INSERT INTO test_empty_table VALUES (7, '[1,1,0]');
INSERT INTO test_empty_table VALUES (8, '[0,1,0]');
INSERT INTO test_empty_table VALUES (9, '[1,1,1]');
INSERT INTO test_empty_table VALUES (10, '[1,0,1]');
INSERT INTO test_empty_table VALUES (11, '[2,3,4]');
INSERT INTO test_empty_table VALUES (12, '[1,1,1]');

CREATE VECTOR INDEX idx_vector_index ON test_empty_table(vector_data EUCLIDEAN);

set trace on;

SELECT id FROM test_empty_table ORDER by l2_distance(vector_data, '[0,0,0]') LIMIT 3;

show trace;  -- VECTOR INDEX SCAN

DROP INDEX idx_vector_index ON test_empty_table(vector_data);
``` 
