### PR TITLE
[CUBVEC-151] Fix recall degradation on nytimes-256-angular dataset

### DIFF
--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -483,17 +483,17 @@ set(STORAGE_HEADERS
   ${INDEX_HNSW_DIR}/hnsw_api.hpp
 )
 
-if(USE_SIMD_NATIVE)
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    set_source_files_properties(${INDEX_HNSW_DIR}/hnsw_usearch_ng.cpp
-        PROPERTIES COMPILE_FLAGS "-march=native -O3 -ftree-vectorize -mprefer-vector-width=512 -ffast-math -fno-trapping-math -funroll-loops -fassociative-math -fno-signed-zeros"
-    )
-  elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set_source_files_properties(${INDEX_HNSW_DIR}/hnsw_usearch_ng.cpp
-        PROPERTIES COMPILE_FLAGS "-march=native -O3 -fvectorize -mprefer-vector-width=512 -ffast-math -fno-trapping-math -funroll-loops -fassociative-math -fno-signed-zeros"
-    )
-  endif()
-endif()
+#if(USE_SIMD_NATIVE)
+#  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+#    set_source_files_properties(${INDEX_HNSW_DIR}/hnsw_usearch_ng.cpp
+#        PROPERTIES COMPILE_FLAGS "-march=native -O3 -ftree-vectorize -mprefer-vector-width=512 -ffast-math -fno-trapping-math -funroll-loops -fassociative-math -fno-signed-zeros"
+#    )
+#  elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+#    set_source_files_properties(${INDEX_HNSW_DIR}/hnsw_usearch_ng.cpp
+#        PROPERTIES COMPILE_FLAGS "-march=native -O3 -fvectorize -mprefer-vector-width=512 -ffast-math -fno-trapping-math -funroll-loops -fassociative-math -fno-signed-zeros"
+#    )
+#  endif()
+#endif()
 
 set(SESSION_SOURCES
   ${SESSION_DIR}/session.c

--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -483,17 +483,17 @@ set(STORAGE_HEADERS
   ${INDEX_HNSW_DIR}/hnsw_api.hpp
 )
 
-#if(USE_SIMD_NATIVE)
-#  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-#    set_source_files_properties(${INDEX_HNSW_DIR}/hnsw_usearch_ng.cpp
-#        PROPERTIES COMPILE_FLAGS "-march=native -O3 -ftree-vectorize -mprefer-vector-width=512 -ffast-math -fno-trapping-math -funroll-loops -fassociative-math -fno-signed-zeros"
-#    )
-#  elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-#    set_source_files_properties(${INDEX_HNSW_DIR}/hnsw_usearch_ng.cpp
-#        PROPERTIES COMPILE_FLAGS "-march=native -O3 -fvectorize -mprefer-vector-width=512 -ffast-math -fno-trapping-math -funroll-loops -fassociative-math -fno-signed-zeros"
-#    )
-#  endif()
-#endif()
+if(USE_SIMD_NATIVE)
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set_source_files_properties(${INDEX_HNSW_DIR}/hnsw_usearch_ng.cpp
+        PROPERTIES COMPILE_FLAGS "-march=native -O3 -ftree-vectorize -mprefer-vector-width=512 -ffast-math -fno-trapping-math -funroll-loops -fassociative-math -fno-signed-zeros"
+    )
+  elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set_source_files_properties(${INDEX_HNSW_DIR}/hnsw_usearch_ng.cpp
+        PROPERTIES COMPILE_FLAGS "-march=native -O3 -fvectorize -mprefer-vector-width=512 -ffast-math -fno-trapping-math -funroll-loops -fassociative-math -fno-signed-zeros"
+    )
+  endif()
+endif()
 
 set(SESSION_SOURCES
   ${SESSION_DIR}/session.c

--- a/cubvec_examples/demodb_loaddb.log
+++ b/cubvec_examples/demodb_loaddb.log
@@ -1,1 +1,0 @@
-Can't open file 'nytimes_256_angular_schema'

--- a/cubvec_examples/demodb_loaddb.log
+++ b/cubvec_examples/demodb_loaddb.log
@@ -1,0 +1,1 @@
+Can't open file 'nytimes_256_angular_schema'

--- a/cubvec_examples/test.sh
+++ b/cubvec_examples/test.sh
@@ -19,10 +19,34 @@ set @a = (select vec from random_xs_20_angular_train limit 1); \
 select /*+ recompile no_parallel_heap_scan */ id, vec <c> @a from random_xs_20_angular_train order by vec <c> @a limit 5; "
 
 # loaddb test
-cubrid loaddb -h nytimes-256-angular.hdf5 -C -u dba demodb
-cubrid loaddb -s nytimes_256_angular_schema -d nytimes_256_angular_object -C -u dba demodb -v
+select /*+ recompile no_parallel_heap_scan */ id, vec <c> @a from random_xs_20_angular_train order by vec <c> @a limit 5;
+SELECT /*+ no_parallel_heap_scan */ vec FROM nytimes_256_angular_test where id = ?;
 
 cubrid loaddb -s random_xs_20_angular_schema -d random_xs_20_angular_object -C -u dba demodb -v
 
 # memory leak test
 valgrind --leak-check=full --track-origins=yes --trace-children=yes --log-file=valgrind.log cubrid server start demodb
+
+# ann benchmarks locally test
+wget http://ann-benchmarks.com/nytimes-256-angular.hdf5
+cubrid loaddb -h nytimes-256-angular.hdf5 -C -u dba demodb
+echo "CREATE VECTOR INDEX vidx_nytimes_train ON nytimes_256_angular_train (vec COSINE) WITH (M = 16, ef_construction = 200);" >> nytimes_256_angular_schema
+cubrid loaddb -s nytimes_256_angular_schema -d nytimes_256_angular_object -C -u dba demodb -v --no-statistics --no-user-specified-name
+;set print_object_as_oid=yes
+prepare q1 from '
+    SELECT tr, tr.id, tr.vec <c> ?:0 as dist
+    FROM nytimes_256_angular_train tr
+    ORDER BY dist
+    LIMIT ?:1;
+';
+prepare q2 from '
+    SELECT neighbor_id, neighbor_distance
+    FROM nytimes_256_angular_answer
+    WHERE id = ?:0
+    ORDER BY neighbor_distance
+    LIMIT ?:1
+';
+set @id = 1; -- 0 ~ n
+set @v = (SELECT vec FROM nytimes_256_angular_test WHERE id = @id);
+execute q1 using @v, 5;
+execute q2 using @id, 5;

--- a/src/compat/db_vector.cpp
+++ b/src/compat/db_vector.cpp
@@ -173,8 +173,13 @@ std::string db_vector_float_to_string (const DB_VECTOR_FLOAT &vf)
 
 bool db_vector_is_all_zeros (const float *vf, int dim)
 {
-  return std::all_of (vf, vf + dim, [] (float f)
-  {
-    return f == 0.0f;
-  });
+  constexpr float eps = 1e-12f;
+  for (int i = 0; i < dim; ++i)
+    {
+      if (std::fabs (vf[i]) > eps)
+	{
+	  return false;
+	}
+    }
+  return true;
 }

--- a/src/storage/index_hnsw/hnsw_algo.hpp
+++ b/src/storage/index_hnsw/hnsw_algo.hpp
@@ -398,13 +398,9 @@ namespace cubhnsw
     // TODO: now, connectivity_base is not considered.
     // std::size_t connecitvity_max = m_connectivity;
     std::size_t top_limit = std::max (connectivity_max, m_expansion);
-    if (!top.reserve (top_limit))
+    if (!top.reserve (top_limit) || !next.reserve (top_limit))
       {
-	assert (false);
-	return {ER_FAILED, OID_INITIALIZER};
-      }
-    if (!next.reserve (m_expansion))
-      {
+	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, top_limit * sizeof (candidate_t<Traits>));
 	assert (false);
 	return {ER_FAILED, OID_INITIALIZER};
       }

--- a/src/storage/index_hnsw/hnsw_algo.hpp
+++ b/src/storage/index_hnsw/hnsw_algo.hpp
@@ -250,7 +250,7 @@ namespace cubhnsw
       algo (const hnsw_build_params &build_params);
 
       // high-level APIs
-      add_result_t<Traits> add (const key_id_t &oid, const float *vector, const std::size_t expansion);
+      add_result_t<Traits> add (const key_id_t &oid, const float *vector);
       search_result_t<Traits> search (const float *query, const std::size_t k, const std::size_t expansion);
 
       void set_storage (storage_t *storage) noexcept
@@ -357,7 +357,7 @@ namespace cubhnsw
 
   template <typename Traits>
   add_result_t<Traits>
-  algo<Traits>::add (const key_id_t &key, const float *vector, const std::size_t expansion)
+  algo<Traits>::add (const key_id_t &key, const float *vector)
   {
     add_result_t<Traits> result;
 
@@ -369,13 +369,13 @@ namespace cubhnsw
 
     // TODO: now, connectivity_base is not considered.
     // std::size_t connecitvity_max = m_connectivity;
-    std::size_t top_limit = std::max (m_connectivity * 2 + 1, expansion);
+    std::size_t top_limit = std::max (m_connectivity * 2 + 1, m_expansion);
     if (!top.reserve (top_limit))
       {
 	assert (false);
 	return {ER_FAILED, OID_INITIALIZER};
       }
-    if (!next.reserve (expansion))
+    if (!next.reserve (m_expansion))
       {
 	assert (false);
 	return {ER_FAILED, OID_INITIALIZER};

--- a/src/storage/index_hnsw/hnsw_algo.hpp
+++ b/src/storage/index_hnsw/hnsw_algo.hpp
@@ -532,6 +532,14 @@ namespace cubhnsw
       root_level = root_node.get_level();
     }
 
+    if (m_metric == vector_distance_metric_t::COSINE)
+      {
+	if (!cubvec_cosine_normalize ((float *) query, m_dimension))
+	  {
+	    abort ();
+	  }
+      }
+
     slot_id_t closest_slot;
     if (seek_down_ (query, entry_slot, root_level, 0, closest_slot) != NO_ERROR)
       {

--- a/src/storage/index_hnsw/hnsw_algo.hpp
+++ b/src/storage/index_hnsw/hnsw_algo.hpp
@@ -51,38 +51,24 @@ namespace cubhnsw
   };
 
   inline float
-  cubvec_cosine_distance (const float *vec1, const float *vec2, size_t dim)
+  cubvec_cosine_distance (const float *__restrict vec1,
+			  const float *__restrict vec2,
+			  std::size_t dim)
   {
     float dot = 0.0f;
-    float norm1_sq = 0.0f;
-    float norm2_sq = 0.0f;
 
-    #pragma omp simd reduction(+ : dot, norm1_sq, norm2_sq)
-    for (size_t i = 0; i < dim; ++i)
+    #pragma omp simd reduction(+ : dot)
+    for (std::size_t i = 0; i < dim; ++i)
       {
-	const float a = vec1[i];
-	const float b = vec2[i];
-
-	dot       += a * b;
-	norm1_sq  += a * a;
-	norm2_sq  += b * b;
+	dot += vec1[i] * vec2[i];
       }
 
-    // zero-vector handling
-    if (norm1_sq == 0.0f && norm2_sq == 0.0f)
-      {
-	return 0.0f;   // identical zero vectors
-      }
-    if (norm1_sq == 0.0f || norm2_sq == 0.0f)
-      {
-	return 1.0f;   // maximally distant
-      }
+    // Numerical safety (optional but recommended with fast-math/SIMD)
+    dot = std::min (1.0f, std::max (-1.0f, dot));
 
-    const float inv_norm =
-	    1.0f / (std::sqrt (norm1_sq) * std::sqrt (norm2_sq));
-
-    const float cosine_similarity = dot * inv_norm;
-    return 1.0f - cosine_similarity;
+    // HNSW expects "smaller is better"
+    // cosine similarity maximize <=> minimize (-dot)
+    return -dot;
   }
 
   inline float
@@ -93,7 +79,7 @@ namespace cubhnsw
   }
 
   inline bool
-  cubvec_cosine_normalize (float *vec, std::size_t dim)
+  cubvec_cosine_normalize (float *__restrict vec, std::size_t dim)
   {
     float norm_sq = 0.0f;
 
@@ -106,10 +92,11 @@ namespace cubhnsw
     constexpr float eps = 1e-12f;
     if (norm_sq < eps)
       {
-	return false;		// zero vector
+	// zero / near-zero vector is invalid for cosine/IP
+	return false;
       }
 
-    float inv_norm = 1.0f / std::sqrt (norm_sq);
+    const float inv_norm = 1.0f / std::sqrt (norm_sq);
 
     #pragma omp simd
     for (std::size_t i = 0; i < dim; ++i)
@@ -117,7 +104,7 @@ namespace cubhnsw
 	vec[i] *= inv_norm;
       }
 
-    return true;		// unit vector
+    return true;  // unit vector
   }
 
   using distance_t = float;

--- a/src/storage/index_hnsw/hnsw_algo.hpp
+++ b/src/storage/index_hnsw/hnsw_algo.hpp
@@ -654,7 +654,8 @@ namespace cubhnsw
 					candidates_view_t<Traits> &top_view)
   {
     top_candidates_t<Traits> &top = m_context.m_top_candidates;
-    refine_ (m_connectivity * 2 + 1,top, top_view);
+    std::size_t layer_connectivity = level == 0 ? m_connectivity * 2 : m_connectivity;
+    refine_ (layer_connectivity,top, top_view);
 
     // outgoing links from new node
     neighbors_ref_type new_neighbors = get_neighbors (new_node_blk, level);

--- a/src/storage/index_hnsw/hnsw_algo.hpp
+++ b/src/storage/index_hnsw/hnsw_algo.hpp
@@ -56,19 +56,12 @@ namespace cubhnsw
 			  std::size_t dim)
   {
     float dot = 0.0f;
-
     #pragma omp simd reduction(+ : dot)
-    for (std::size_t i = 0; i < dim; ++i)
+    for (std::size_t i = 0; i != dim; ++i)
       {
 	dot += vec1[i] * vec2[i];
       }
-
-    // Numerical safety (optional but recommended with fast-math/SIMD)
-    dot = std::min (1.0f, std::max (-1.0f, dot));
-
-    // HNSW expects "smaller is better"
-    // cosine similarity maximize <=> minimize (-dot)
-    return -dot;
+    return 1.0f - dot;
   }
 
   inline float
@@ -358,7 +351,7 @@ namespace cubhnsw
     m_inverse_log_connectivity = 1.0 / std::log (static_cast<double> (build_params.m));
 
     // pre-reserve top_for_refine
-    m_context.m_top_for_refine.reserve (m_connectivity + 1);
+    m_context.m_top_for_refine.reserve (m_connectivity * 2 + 1);
   }
 
   template <typename Traits>
@@ -375,7 +368,7 @@ namespace cubhnsw
 
     // TODO: now, connectivity_base is not considered.
     // std::size_t connecitvity_max = m_connectivity;
-    std::size_t top_limit = std::max (m_connectivity + 1, expansion);
+    std::size_t top_limit = std::max (m_connectivity * 2 + 1, expansion);
     if (!top.reserve (top_limit))
       {
 	assert (false);
@@ -660,7 +653,7 @@ namespace cubhnsw
 					candidates_view_t<Traits> &top_view)
   {
     top_candidates_t<Traits> &top = m_context.m_top_candidates;
-    refine_ (m_connectivity,top, top_view);
+    refine_ (m_connectivity * 2 + 1,top, top_view);
 
     // outgoing links from new node
     neighbors_ref_type new_neighbors = get_neighbors (new_node_blk, level);
@@ -676,6 +669,7 @@ namespace cubhnsw
 				     candidates_view_t<Traits> &new_neighbors,
 				     level_t level)
   {
+    std::size_t layer_connectivity = level == 0 ? m_connectivity * 2 : m_connectivity;
     for (auto n : new_neighbors)
       {
 	slot_id_t close_slot = n.slot;
@@ -690,7 +684,7 @@ namespace cubhnsw
 	  // TODO: exclusive??
 	  pinned_t close_node_blk = m_storage->get_node_by_slot_id (close_slot, lock_mode::exclusive);
 	  close_header = get_neighbors (close_node_blk, level);
-	  if (close_header.size () < m_connectivity)
+	  if (close_header.size () < layer_connectivity)
 	    {
 	      close_header.push_back (new_slot);
 	      continue;
@@ -714,7 +708,7 @@ namespace cubhnsw
 	// remove all neighbors from close_header
 	close_header.clear();
 	candidates_view_t<Traits> top_view;
-	(void) refine_ (m_connectivity, top_for_refine, top_view);
+	(void) refine_ (layer_connectivity, top_for_refine, top_view);
 	for (std::size_t i = 0; i != top_view.size (); i++)
 	  {
 	    close_header.push_back (top_view[i].slot);

--- a/src/storage/index_hnsw/hnsw_algo.hpp
+++ b/src/storage/index_hnsw/hnsw_algo.hpp
@@ -525,7 +525,7 @@ namespace cubhnsw
     if (!top.reserve (expansion_size) || !next.reserve (expansion_size))
       {
 	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, expansion_size * sizeof (candidate_t<Traits>));
-        assert (false);
+	assert (false);
 	return result;
       }
 

--- a/src/storage/index_hnsw/hnsw_algo.hpp
+++ b/src/storage/index_hnsw/hnsw_algo.hpp
@@ -56,8 +56,9 @@ namespace cubhnsw
 			  std::size_t dim)
   {
     float dot = 0.0f;
+
     #pragma omp simd reduction(+ : dot)
-    for (std::size_t i = 0; i != dim; ++i)
+    for (std::size_t i = 0; i < dim; ++i)
       {
 	dot += vec1[i] * vec2[i];
       }

--- a/src/storage/index_hnsw/hnsw_algo.hpp
+++ b/src/storage/index_hnsw/hnsw_algo.hpp
@@ -375,12 +375,6 @@ namespace cubhnsw
 
     // precompute inverse log connectivity
     m_inverse_log_connectivity = 1.0 / std::log (static_cast<double> (build_params.m));
-    <<<<<<< HEAD
-    =======
-
-	    // pre-reserve top_for_refine
-	    m_context.m_top_for_refine.reserve (m_connectivity * 2 + 1);
-    >>>>>>> hgryoo/CUBVEC-151
   }
 
   template <typename Traits>
@@ -524,23 +518,14 @@ namespace cubhnsw
     context.m_thread_p = thread_p;
     context.clear_candidates();
 
-    std::size_t connectivity_max = m_connectivity * 2 + 1;
-    context.m_top_for_refine.reserve (connectivity_max);
-
     top_candidates_t<Traits> &top = context.m_top_candidates;
     next_candidates_t<Traits> &next = context.m_next_candidates;
 
     std::size_t expansion_size = std::max (k, expansion);
-
-    if (!top.reserve (expansion_size))
+    if (!top.reserve (expansion_size) || !next.reserve (expansion_size))
       {
-	// TODO: error handling
-	assert (false);
-	return result;
-      }
-    if (!next.reserve (expansion_size))
-      {
-	assert (false);
+	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, expansion_size * sizeof (candidate_t<Traits>));
+        assert (false);
 	return result;
       }
 

--- a/src/storage/index_hnsw/hnsw_algo.hpp
+++ b/src/storage/index_hnsw/hnsw_algo.hpp
@@ -92,6 +92,34 @@ namespace cubhnsw
     return std::sqrt (l2);
   }
 
+  inline bool
+  cubvec_cosine_normalize (float *vec, std::size_t dim)
+  {
+    float norm_sq = 0.0f;
+
+    #pragma omp simd reduction(+ : norm_sq)
+    for (std::size_t i = 0; i < dim; ++i)
+      {
+	norm_sq += vec[i] * vec[i];
+      }
+
+    constexpr float eps = 1e-12f;
+    if (norm_sq < eps)
+      {
+	return false;		// zero vector
+      }
+
+    float inv_norm = 1.0f / std::sqrt (norm_sq);
+
+    #pragma omp simd
+    for (std::size_t i = 0; i < dim; ++i)
+      {
+	vec[i] *= inv_norm;
+      }
+
+    return true;		// unit vector
+  }
+
   using distance_t = float;
   using Fn = distance_t (*) (const float *, const float *, size_t);
 
@@ -385,6 +413,13 @@ namespace cubhnsw
 	  new_target_level = MAX_LEVELS;
 	}
 
+      if (m_metric == vector_distance_metric_t::COSINE)
+	{
+	  if (!cubvec_cosine_normalize ((float *) vector, m_dimension))
+	    {
+	      abort ();
+	    }
+	}
       //
       new_slot = m_storage->add_node (key, vector, new_target_level);
       //

--- a/src/storage/index_hnsw/hnsw_storage.hpp
+++ b/src/storage/index_hnsw/hnsw_storage.hpp
@@ -153,8 +153,9 @@ namespace cubhnsw
 
       inline std::size_t node_neighbors_bytes_ (level_t level) const noexcept
       {
-	std::size_t neighbors_byte = get_connectivity() * sizeof (slot_id_t) + sizeof (neighbors_count_t);
-	return neighbors_byte * (level + 1);
+	std::size_t neighbors_byte_base = get_connectivity() * sizeof (slot_id_t) * 2 + sizeof (neighbors_count_t);
+	std::size_t neighbors_byte_non_base = get_connectivity() * sizeof (slot_id_t) + sizeof (neighbors_count_t);
+	return neighbors_byte_base + neighbors_byte_non_base * level;
       }
 
       inline std::size_t node_neighbors_offset_ (level_t level) const noexcept

--- a/src/storage/index_hnsw/hnsw_usearch_ng.cpp
+++ b/src/storage/index_hnsw/hnsw_usearch_ng.cpp
@@ -214,13 +214,7 @@ hnsw_usearch_ng::add (int n_vectors, const OID *oid, const float *vector)
 	  && db_vector_is_all_zeros (vector + i * m_build_params.dimension,
 				     m_build_params.dimension))
 	{
-	  er_log_debug (ARG_FILE_LINE, "Vector is all zeros, skipping search");
-	  fprintf (stdout, "Vector is all zeros, skipping add\n");
-	  for (int i = 0; i < m_build_params.dimension; ++i)
-	    {
-	      fprintf (stdout, "%f ", vector[i]);
-	    }
-	  fprintf (stdout, "\n");
+	  er_log_debug (ARG_FILE_LINE, "Vector is all zeros, skipping add");
 	  continue;
 	}
       m_algo->add (oid[i], vector + i * m_build_params.dimension,
@@ -237,12 +231,6 @@ hnsw_usearch_ng::search (const float *query, const int k, const int ef_search,
       && db_vector_is_all_zeros (query, m_build_params.dimension))
     {
       er_log_debug (ARG_FILE_LINE, "Vector is all zeros, skipping search");
-      fprintf (stdout, "Vector is all zeros, skipping search\n");
-      for (int i = 0; i < m_build_params.dimension; ++i)
-	{
-	  fprintf (stdout, "%f ", query[i]);
-	}
-      fprintf (stdout, "\n");
       return NO_ERROR;
     }
 

--- a/src/storage/index_hnsw/hnsw_usearch_ng.cpp
+++ b/src/storage/index_hnsw/hnsw_usearch_ng.cpp
@@ -217,8 +217,7 @@ hnsw_usearch_ng::add (int n_vectors, const OID *oid, const float *vector)
 	  er_log_debug (ARG_FILE_LINE, "Vector is all zeros, skipping add");
 	  continue;
 	}
-      m_algo->add (oid[i], vector + i * m_build_params.dimension,
-		   m_build_params.ef_construction);
+      m_algo->add (oid[i], vector + i * m_build_params.dimension);
     }
   return NO_ERROR;
 }

--- a/src/storage/index_hnsw/hnsw_usearch_ng.cpp
+++ b/src/storage/index_hnsw/hnsw_usearch_ng.cpp
@@ -251,17 +251,8 @@ hnsw_usearch_ng::add (cubthread::entry *thread_p, int n_vectors, const OID *oid,
 	  er_log_debug (ARG_FILE_LINE, "Vector is all zeros, skipping add");
 	  continue;
 	}
-      <<<<<<< HEAD
-      <<<<<<< HEAD
-      m_algo->add (oid[i], vector + i * m_build_params.dimension);
-      =======
-	      m_algo->add (thread_p, oid[i], vector + i * m_build_params.dimension, m_build_params.ef_construction);
+      m_algo->add (thread_p, oid[i], vector + i * m_build_params.dimension);
 #endif
-      >>>>>>> origin/cubvec/cubvec
-      =======
-	      m_algo->add (m_thread_p, oid[i], vector + i * m_build_params.dimension);
-#endif
-      >>>>>>> hgryoo/CUBVEC-151
     }
   return NO_ERROR;
 }
@@ -293,7 +284,7 @@ hnsw_usearch_ng::search (cubthread::entry *thread_p, const float *query, const i
       return NO_ERROR;
     }
 
-  auto results = m_algo->search (query, k, ef_search);
+  auto results = m_algo->search (thread_p, query, k, ef_search);
   if (results.error != NO_ERROR)
     {
       er_log_debug (ARG_FILE_LINE, "Error during search: %s", results.error);

--- a/src/storage/index_hnsw/hnsw_usearch_ng.cpp
+++ b/src/storage/index_hnsw/hnsw_usearch_ng.cpp
@@ -215,6 +215,12 @@ hnsw_usearch_ng::add (int n_vectors, const OID *oid, const float *vector)
 				     m_build_params.dimension))
 	{
 	  er_log_debug (ARG_FILE_LINE, "Vector is all zeros, skipping search");
+	  fprintf (stdout, "Vector is all zeros, skipping add\n");
+	  for (int i = 0; i < m_build_params.dimension; ++i)
+	    {
+	      fprintf (stdout, "%f ", vector[i]);
+	    }
+	  fprintf (stdout, "\n");
 	  continue;
 	}
       m_algo->add (oid[i], vector + i * m_build_params.dimension,
@@ -231,6 +237,12 @@ hnsw_usearch_ng::search (const float *query, const int k, const int ef_search,
       && db_vector_is_all_zeros (query, m_build_params.dimension))
     {
       er_log_debug (ARG_FILE_LINE, "Vector is all zeros, skipping search");
+      fprintf (stdout, "Vector is all zeros, skipping search\n");
+      for (int i = 0; i < m_build_params.dimension; ++i)
+	{
+	  fprintf (stdout, "%f ", query[i]);
+	}
+      fprintf (stdout, "\n");
       return NO_ERROR;
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-151

### Purpose

Recall on the nytimes-256-angular dataset was severely degraded, in some cases approaching zero. The primary root cause was graph disconnection at layer 0.
- Due to the data distribution characteristics of the nytimes-256-angular dataset, the graph constructed at layer 0 could become partially disconnected.
- Since layer 0 serves as the final navigation layer for ANN search, this disconnection critically limited reachability and caused search to terminate in isolated subgraphs, resulting in near-zero recall.

### Implementation

Improve layer-0 graph connectivity (primary fix)
- The maximum number of neighbors allowed at layer 0 is increased to 2× the previous limit.
- This significantly reduces the risk of graph disconnection and improves navigability for skewed or clustered data distributions.

Enforce consistent normalization for COSINE metric (supporting fix)
- Vectors are normalized before being stored in the index.
- User-provided query vectors are normalized at query time to ensure correct cosine similarity semantics.

### Remarks

N/A
