### PR TITLE
[CUBVEC-154] Add thread_entry parameter to hnsw_index interfaces

### DIFF
--- a/src/storage/index_hnsw/hnsw.cpp
+++ b/src/storage/index_hnsw/hnsw.cpp
@@ -87,7 +87,7 @@ class hnsw_index_manager
     hnsw_index *get_index (const BTID *btid) const;
     int delete_index (const BTID *btid);
 
-    void print_index_info (const BTID *btid);
+    void print_index_info (THREAD_ENTRY *thread_p, const BTID *btid);
 
     // index management on disk
     int save_index (THREAD_ENTRY *thread_p, hnsw_index *index);
@@ -198,7 +198,7 @@ xhnsw_add_index (THREAD_ENTRY *thread_p, const OID *class_oid, const int attrid,
 #if !defined(NDEBUG)
   _er_log_debug (ARG_FILE_LINE, "HNSW Index added with ID %d", btid_out.root_pageid);
 
-  index_manager->print_index_info (&btid_out);
+  index_manager->print_index_info (thread_p, &btid_out);
 #endif
 
   return NO_ERROR;
@@ -405,13 +405,13 @@ hnsw_add_element (THREAD_ENTRY *thread_p, BTID *btid, OID *oid, float *vector, i
 	}
     }
 
-  if (index->prepare_to_add (n_vectors, oid, vector) != NO_ERROR)
+  if (index->prepare_to_add (thread_p, n_vectors, oid, vector) != NO_ERROR)
     {
       assert (false);
       return ER_FAILED;
     }
 
-  return index->add (n_vectors, oid, vector);
+  return index->add (thread_p, n_vectors, oid, vector);
 }
 
 int
@@ -438,7 +438,7 @@ hnsw_search_element (THREAD_ENTRY *thread_p, BTID *btid, DB_VALUE *key_dbvalue, 
   assert (vf != NULL && vf->dim == index->get_dimension());
 
   int ef_search = prm_get_integer_value (PRM_ID_VECTOR_INDEX_EF_SEARCH);
-  return index->search (vf->float_array, k, ef_search, rec_oids, distances);
+  return index->search (thread_p, vf->float_array, k, ef_search, rec_oids, distances);
 }
 
 // =====================================================================
@@ -552,11 +552,11 @@ hnsw_index_manager::delete_index (const BTID *btid)
 }
 
 void
-hnsw_index_manager::print_index_info (const BTID *btid)
+hnsw_index_manager::print_index_info (THREAD_ENTRY *thread_p, const BTID *btid)
 {
   if (is_index_loaded (btid))
     {
-      m_index_map.at (*btid)->dump (stdout);
+      m_index_map.at (*btid)->dump (thread_p, stdout);
     }
 }
 
@@ -637,7 +637,7 @@ int hnsw_index_manager::save_index (THREAD_ENTRY *thread_p, hnsw_index *index)
 {
   std::string prefix = index->get_backend().get_id();
   const BTID &btid = index->get_id();
-  index->save (get_index_file_path (prefix, &btid).string());
+  index->save (thread_p, get_index_file_path (prefix, &btid).string());
   return NO_ERROR;
 }
 
@@ -669,7 +669,7 @@ int hnsw_index_manager::load_index (THREAD_ENTRY *thread_p, const BTID *btid, hn
     {
       return ER_FAILED;
     }
-  if (index_out->load (get_index_file_path (meta.backend_id, btid).string()) != NO_ERROR)
+  if (index_out->load (thread_p, get_index_file_path (meta.backend_id, btid).string()) != NO_ERROR)
     {
       return ER_FAILED;
     }

--- a/src/storage/index_hnsw/hnsw_api.hpp
+++ b/src/storage/index_hnsw/hnsw_api.hpp
@@ -167,21 +167,21 @@ class hnsw_index
     virtual const hnsw_index_backend &get_backend() const;
 
     // operations
-    virtual int prepare_to_add (int n_vectors, const OID *oid, const float *vector)=0;
-    virtual int add (int n_vectors, const OID *oid, const float *vector)=0;
+    virtual int prepare_to_add (cubthread::entry *thread_p, int n_vectors, const OID *oid, const float *vector)=0;
+    virtual int add (cubthread::entry *thread_p, int n_vectors, const OID *oid, const float *vector)=0;
 
-    virtual int search (const float *query, const int k, const int ef_search, OID *rec_oids, float *distances)=0;
-    virtual int remove (const OID *oid)=0;
-    virtual int update (const OID *oid, const float *vector)=0;
+    virtual int search (cubthread::entry *thread_p, const float *query, const int k, const int ef_search, OID *rec_oids, float *distances)=0;
+    virtual int remove (cubthread::entry *thread_p, const OID *oid)=0;
+    virtual int update (cubthread::entry *thread_p, const OID *oid, const float *vector)=0;
 
     // SCAN_PRED from query_evaluator.h
-    virtual int filtered_search (const float *query, const int k, const SCAN_PRED &filter, OID *rec_oids,
+    virtual int filtered_search (cubthread::entry *thread_p, const float *query, const int k, const SCAN_PRED &filter, OID *rec_oids,
 				 float *distances)=0;
-    virtual int dump (FILE *fp)=0;
+    virtual int dump (cubthread::entry *thread_p, FILE *fp) { return NO_ERROR; }
 
     // serialize
-    virtual int save (const std::string &path)=0;
-    virtual int load (const std::string &path)=0;
+    virtual int save (cubthread::entry *thread_p, const std::string &path) { return NO_ERROR; }
+    virtual int load (cubthread::entry *thread_p, const std::string &path) { return NO_ERROR; }
 
   protected:
     hnsw_index (hnsw_index_backend &backend, const BTID &btid, const std::string &name,

--- a/src/storage/index_hnsw/hnsw_api.hpp
+++ b/src/storage/index_hnsw/hnsw_api.hpp
@@ -170,18 +170,29 @@ class hnsw_index
     virtual int prepare_to_add (cubthread::entry *thread_p, int n_vectors, const OID *oid, const float *vector)=0;
     virtual int add (cubthread::entry *thread_p, int n_vectors, const OID *oid, const float *vector)=0;
 
-    virtual int search (cubthread::entry *thread_p, const float *query, const int k, const int ef_search, OID *rec_oids, float *distances)=0;
+    virtual int search (cubthread::entry *thread_p, const float *query, const int k, const int ef_search, OID *rec_oids,
+			float *distances)=0;
     virtual int remove (cubthread::entry *thread_p, const OID *oid)=0;
     virtual int update (cubthread::entry *thread_p, const OID *oid, const float *vector)=0;
 
     // SCAN_PRED from query_evaluator.h
-    virtual int filtered_search (cubthread::entry *thread_p, const float *query, const int k, const SCAN_PRED &filter, OID *rec_oids,
+    virtual int filtered_search (cubthread::entry *thread_p, const float *query, const int k, const SCAN_PRED &filter,
+				 OID *rec_oids,
 				 float *distances)=0;
-    virtual int dump (cubthread::entry *thread_p, FILE *fp) { return NO_ERROR; }
+    virtual int dump (cubthread::entry *thread_p, FILE *fp)
+    {
+      return NO_ERROR;
+    }
 
     // serialize
-    virtual int save (cubthread::entry *thread_p, const std::string &path) { return NO_ERROR; }
-    virtual int load (cubthread::entry *thread_p, const std::string &path) { return NO_ERROR; }
+    virtual int save (cubthread::entry *thread_p, const std::string &path)
+    {
+      return NO_ERROR;
+    }
+    virtual int load (cubthread::entry *thread_p, const std::string &path)
+    {
+      return NO_ERROR;
+    }
 
   protected:
     hnsw_index (hnsw_index_backend &backend, const BTID &btid, const std::string &name,

--- a/src/storage/index_hnsw/hnsw_usearch_ng.cpp
+++ b/src/storage/index_hnsw/hnsw_usearch_ng.cpp
@@ -79,30 +79,27 @@ class hnsw_usearch_ng final:public hnsw_index
 
     hnsw_usearch_ng (hnsw_index_backend &backend, const BTID &btid,
 		     const std::string &name,
-		     const hnsw_build_params &build_params,
-		     PAGE_PTR page_ptr, RECDES &rec);
+		     const hnsw_build_params &build_params);
     ~hnsw_usearch_ng () = default;
 
-    virtual int prepare_to_add (int n_vectors, const OID *oid,
+    int init (cubthread::entry *thread_p, PAGE_PTR page_ptr, RECDES &rec);
+
+    virtual int prepare_to_add (cubthread::entry *thread_p, int n_vectors, const OID *oid,
 				const float *vector) override;
-    virtual int add (int n_vectors, const OID *oid,
+    virtual int add (cubthread::entry *thread_p, int n_vectors, const OID *oid,
 		     const float *vector) override;
 
-    virtual int search (const float *query, const int k, const int ef_search,
+    virtual int search (cubthread::entry *thread_p, const float *query, const int k, const int ef_search,
 			OID *rec_oids, float *distances) override;
-    virtual int remove (const OID *oid) override;
-    virtual int update (const OID *oid, const float *vector) override;
+    virtual int remove (cubthread::entry *thread_p, const OID *oid) override;
+    virtual int update (cubthread::entry *thread_p, const OID *oid, const float *vector) override;
 
     // SCAN_PRED from query_evaluator.h
-    virtual int filtered_search (const float *query, const int k,
+    virtual int filtered_search (cubthread::entry *thread_p, const float *query, const int k,
 				 const SCAN_PRED &filter, OID *rec_oids,
 				 float *distances) override;
-    virtual int dump (FILE *fp) override;
+    virtual int dump (cubthread::entry *thread_p, FILE *fp) override;
 
-    virtual int save (const std::string &path) override;
-    virtual int load (const std::string &path) override;
-
-    THREAD_ENTRY *m_thread_p;
     VPID m_root_vpid;
 
     std::unique_ptr < algo_type > m_algo;
@@ -151,8 +148,14 @@ hnsw_usearch_ng_backend::create_index (THREAD_ENTRY *thread_p,
   {
     DB_PAGESIZE, 0, REC_HOME, PTR_ALIGN (rec_buf, INT_ALIGNMENT)};
 
-  hnsw_index *index =
-	  new hnsw_usearch_ng (*this, *btid, name, build_params, page_ptr, rec);
+  hnsw_usearch_ng *index =
+	  new hnsw_usearch_ng (*this, *btid, name, build_params);
+
+  if (index->init (thread_p, page_ptr, rec) != NO_ERROR)
+    {
+      ASSERT_ERROR ();
+      return NULL;
+    }
 
   // pgbuf_unfix_and_init_after_check (thread_p, page_ptr);
   //log_sysop_attach_to_outer (thread_p);
@@ -166,37 +169,41 @@ hnsw_usearch_ng_backend::create_index (THREAD_ENTRY *thread_p,
 // =====================================================================
 
 hnsw_usearch_ng::hnsw_usearch_ng (hnsw_index_backend &backend, const BTID &btid, const std::string &name,
-				  const hnsw_build_params &build_params, PAGE_PTR page_ptr, RECDES &rec):hnsw_index (backend, btid, name,
+				  const hnsw_build_params &build_params):hnsw_index (backend, btid, name,
 					build_params)
 {
   m_root_vpid =
   {
     btid.root_pageid, btid.vfid.volid
   };
-  this->m_thread_p = thread_get_thread_entry_info ();
-
+  
   m_storage = std::make_unique < storage_type > (btid, build_params);
-  m_storage->set_thread_entry (thread_get_thread_entry_info ());
+  m_algo = std::make_unique < algo_type > (build_params);
+}
 
+int
+hnsw_usearch_ng::init (cubthread::entry *thread_p, PAGE_PTR page_ptr, RECDES &rec)
+{
   std::size_t root_size;
   m_storage->init_root (reinterpret_cast < std::byte * > (rec.data),
 			root_size);
   rec.length = (int) root_size;
 
-  if (spage_insert_at (this->m_thread_p, page_ptr, 1, &rec) != SP_SUCCESS)
+  if (spage_insert_at (thread_p, page_ptr, 1, &rec) != SP_SUCCESS)
     {
       assert (false);
+      return ER_FAILED;
     }
 
-  pgbuf_set_dirty (this->m_thread_p, page_ptr, FREE);
-  page_ptr = NULL;
+  pgbuf_set_dirty (thread_p, page_ptr, FREE);
 
-  m_algo = std::make_unique < algo_type > (build_params);
   m_algo->set_storage (m_storage.get ());
+
+  return NO_ERROR;
 }
 
 int
-hnsw_usearch_ng::prepare_to_add (int n_vectors, const OID *oid,
+hnsw_usearch_ng::prepare_to_add (cubthread::entry *thread_p, int n_vectors, const OID *oid,
 				 const float *vector)
 {
   // do nothing
@@ -204,7 +211,7 @@ hnsw_usearch_ng::prepare_to_add (int n_vectors, const OID *oid,
 }
 
 int
-hnsw_usearch_ng::add (int n_vectors, const OID *oid, const float *vector)
+hnsw_usearch_ng::add (cubthread::entry *thread_p, int n_vectors, const OID *oid, const float *vector)
 {
   #pragma omp parallel
   #pragma omp for
@@ -224,7 +231,7 @@ hnsw_usearch_ng::add (int n_vectors, const OID *oid, const float *vector)
 }
 
 int
-hnsw_usearch_ng::search (const float *query, const int k, const int ef_search,
+hnsw_usearch_ng::search (cubthread::entry *thread_p, const float *query, const int k, const int ef_search,
 			 OID *rec_oids, float *distances)
 {
   if (m_build_params.metric == DB_VECTOR_DISTANCE_METRIC::METRIC_COSINE
@@ -253,19 +260,19 @@ hnsw_usearch_ng::search (const float *query, const int k, const int ef_search,
 }
 
 int
-hnsw_usearch_ng::remove (const OID *oid)
+hnsw_usearch_ng::remove (cubthread::entry *thread_p, const OID *oid)
 {
   return ER_FAILED;
 }
 
 int
-hnsw_usearch_ng::update (const OID *oid, const float *vector)
+hnsw_usearch_ng::update (cubthread::entry *thread_p, const OID *oid, const float *vector)
 {
   return ER_FAILED;
 }
 
 int
-hnsw_usearch_ng::filtered_search (const float *query, const int k,
+hnsw_usearch_ng::filtered_search (cubthread::entry *thread_p, const float *query, const int k,
 				  const SCAN_PRED &filter, OID *rec_oids,
 				  float *distances)
 {
@@ -273,19 +280,7 @@ hnsw_usearch_ng::filtered_search (const float *query, const int k,
 }
 
 int
-hnsw_usearch_ng::dump (FILE *fp)
-{
-  return ER_FAILED;
-}
-
-int
-hnsw_usearch_ng::save (const std::string &path)
-{
-  return ER_FAILED;
-}
-
-int
-hnsw_usearch_ng::load (const std::string &path)
+hnsw_usearch_ng::dump (cubthread::entry *thread_p, FILE *fp)
 {
   return ER_FAILED;
 }

--- a/src/storage/index_hnsw/hnsw_usearch_ng.cpp
+++ b/src/storage/index_hnsw/hnsw_usearch_ng.cpp
@@ -91,25 +91,25 @@ class hnsw_usearch_ng final:public hnsw_index
     virtual int add (cubthread::entry *thread_p, int n_vectors, const OID *oid,
 		     const float *vector) override;
     virtual int search (cubthread::entry *thread_p, const float *query, const int k, const int ef_search,
-    virtual int remove (cubthread::entry *thread_p, const OID *oid) override;
-    virtual int update (cubthread::entry *thread_p, const OID *oid, const float *vector) override;
+			virtual int remove (cubthread::entry *thread_p, const OID *oid) override;
+			virtual int update (cubthread::entry *thread_p, const OID *oid, const float *vector) override;
 
-    // SCAN_PRED from query_evaluator.h
-    virtual int filtered_search (cubthread::entry *thread_p, const float *query, const int k,
-				 const SCAN_PRED &filter, OID *rec_oids,
-				 float *distances) override;
-    virtual int dump (cubthread::entry *thread_p, FILE *fp) override;
-    
-    int add_vector (cubthread::entry &thread_ref, const OID oid, const float *vector, const int tran_index);
+			// SCAN_PRED from query_evaluator.h
+			virtual int filtered_search (cubthread::entry *thread_p, const float *query, const int k,
+			    const SCAN_PRED &filter, OID *rec_oids,
+			    float *distances) override;
+			virtual int dump (cubthread::entry *thread_p, FILE *fp) override;
 
-    VPID m_root_vpid;
+			int add_vector (cubthread::entry &thread_ref, const OID oid, const float *vector, const int tran_index);
 
-    std::unique_ptr < algo_type > m_algo;
-    std::unique_ptr < storage_type > m_storage;
+			VPID m_root_vpid;
+
+			std::unique_ptr < algo_type > m_algo;
+			std::unique_ptr < storage_type > m_storage;
 
 #if defined (SERVER_MODE)
-    cubthread::entry_workpool *m_worker_pool;
-    size_t m_worker_pool_size;
+			cubthread::entry_workpool *m_worker_pool;
+			size_t m_worker_pool_size;
 #endif
 };
 
@@ -186,6 +186,7 @@ hnsw_usearch_ng::hnsw_usearch_ng (hnsw_index_backend &backend, const BTID &btid,
 
   m_storage = std::make_unique < storage_type > (btid, build_params);
   m_algo = std::make_unique < algo_type > (build_params);
+}
 
 int
 hnsw_usearch_ng::init (cubthread::entry *thread_p, PAGE_PTR page_ptr, RECDES &rec)

--- a/src/storage/index_hnsw/hnsw_usearch_ng.cpp
+++ b/src/storage/index_hnsw/hnsw_usearch_ng.cpp
@@ -176,7 +176,7 @@ hnsw_usearch_ng::hnsw_usearch_ng (hnsw_index_backend &backend, const BTID &btid,
   {
     btid.root_pageid, btid.vfid.volid
   };
-  
+
   m_storage = std::make_unique < storage_type > (btid, build_params);
   m_algo = std::make_unique < algo_type > (build_params);
 }

--- a/src/storage/index_hnsw/hnsw_usearch_ng.cpp
+++ b/src/storage/index_hnsw/hnsw_usearch_ng.cpp
@@ -91,25 +91,27 @@ class hnsw_usearch_ng final:public hnsw_index
     virtual int add (cubthread::entry *thread_p, int n_vectors, const OID *oid,
 		     const float *vector) override;
     virtual int search (cubthread::entry *thread_p, const float *query, const int k, const int ef_search,
-			virtual int remove (cubthread::entry *thread_p, const OID *oid) override;
-			virtual int update (cubthread::entry *thread_p, const OID *oid, const float *vector) override;
+			OID *rec_oids, float *distances) override;
 
-			// SCAN_PRED from query_evaluator.h
-			virtual int filtered_search (cubthread::entry *thread_p, const float *query, const int k,
-			    const SCAN_PRED &filter, OID *rec_oids,
-			    float *distances) override;
-			virtual int dump (cubthread::entry *thread_p, FILE *fp) override;
+    virtual int remove (cubthread::entry *thread_p, const OID *oid) override;
+    virtual int update (cubthread::entry *thread_p, const OID *oid, const float *vector) override;
 
-			int add_vector (cubthread::entry &thread_ref, const OID oid, const float *vector, const int tran_index);
+    // SCAN_PRED from query_evaluator.h
+    virtual int filtered_search (cubthread::entry *thread_p, const float *query, const int k,
+				 const SCAN_PRED &filter, OID *rec_oids,
+				 float *distances) override;
+    virtual int dump (cubthread::entry *thread_p, FILE *fp) override;
 
-			VPID m_root_vpid;
+    int add_vector (cubthread::entry &thread_ref, const OID oid, const float *vector, const int tran_index);
 
-			std::unique_ptr < algo_type > m_algo;
-			std::unique_ptr < storage_type > m_storage;
+    VPID m_root_vpid;
+
+    std::unique_ptr < algo_type > m_algo;
+    std::unique_ptr < storage_type > m_storage;
 
 #if defined (SERVER_MODE)
-			cubthread::entry_workpool *m_worker_pool;
-			size_t m_worker_pool_size;
+    cubthread::entry_workpool *m_worker_pool;
+    size_t m_worker_pool_size;
 #endif
 };
 
@@ -211,6 +213,7 @@ hnsw_usearch_ng::init (cubthread::entry *thread_p, PAGE_PTR page_ptr, RECDES &re
   m_worker_pool = cubthread::get_manager ()->create_worker_pool (
 			  m_worker_pool_size, m_worker_pool_size, "hnsw insertion worker pool", NULL, 1, false);
 #endif
+  return NO_ERROR;
 }
 
 hnsw_usearch_ng::~hnsw_usearch_ng ()
@@ -238,7 +241,7 @@ hnsw_usearch_ng::add (cubthread::entry *thread_p, int n_vectors, const OID *oid,
     {
 #if defined (SERVER_MODE)
       auto exec_f = std::bind (&hnsw_usearch_ng::add_vector, std::ref (*this), std::placeholders::_1, oid[i],
-			       vector + i * m_build_params.dimension, m_thread_p->tran_index);
+			       vector + i * m_build_params.dimension, thread_p->tran_index);
       cubthread::entry_callable_task *task = new cubthread::entry_callable_task (exec_f);
       cubthread::get_manager()->push_task (m_worker_pool, task);
 #else
@@ -248,12 +251,13 @@ hnsw_usearch_ng::add (cubthread::entry *thread_p, int n_vectors, const OID *oid,
 	  er_log_debug (ARG_FILE_LINE, "Vector is all zeros, skipping search");
 	  continue;
 	}
-      m_algo->add (m_thread_p, oid[i], vector + i * m_build_params.dimension, m_build_params.ef_construction);
+      m_algo->add (thread_p, oid[i], vector + i * m_build_params.dimension, m_build_params.ef_construction);
 #endif
     }
   return NO_ERROR;
 }
 
+int
 hnsw_usearch_ng::add_vector (cubthread::entry &thread_ref, const OID oid, const float *vector, const int tran_index)
 {
   thread_ref.tran_index = tran_index;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-154

### Purpose

when data is loaded in parallel using the loaddb -C option, concurrent data insertion into a vector index is not properly handled. In this scenario, multiple loader threads concurrently access a shared THREAD_ENTRY member variable inside the index object, which leads to race conditions and ultimately causes a core dump.

This PR enables safe parallel insertion of vector data into vector indexes created via loaddb -C.

### Implementation

- The cubhnsw::hnsw_index and cubhnsw::hnsw_usearch_ng class, which represents the HNSW index object context and concrete implementation respectively, no longer stores THREAD_ENTRY as a member variable.
- Instead, THREAD_ENTRY is passed explicitly as a parameter to each public interface function.
- This change ensures that each concurrent loader thread operates with its own THREAD_ENTRY, eliminating unsafe shared state and preventing crashes during parallel data loading.

### Remarks

N/A
