### PR TITLE
[CBRD-26494] remove a code that prints a semicolon at the end of SP bodies

### DIFF
--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -8082,11 +8082,6 @@ pt_print_sp_body (PARSER_CONTEXT * parser, PT_NODE * p)
 
   q = pt_append_varchar (parser, q, r1);
 
-  if (!parser->flag.is_parsing_unload_schema)
-    {
-      q = pt_append_nulstring (parser, q, ";");
-    }
-
   return q;
 }
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26494>

### Purpose

SP Body 출력 끝에 세미콜론을 출력하는 코드를 삭제합니다. 
