### PR TITLE
[CBRD-26474] Fix inconsistent error message formats

### DIFF
--- a/msg/en_US.utf8/cubrid.msg
+++ b/msg/en_US.utf8/cubrid.msg
@@ -2122,18 +2122,18 @@ $set 14 MSGCAT_SET_LOCK
 16 Object type: Class = %1$s.\n
 17 Object type: Instance of class (%1$2d|%2$6d|%3$4d) = %4$s.\n
 18 Object type: Unknown.\n
-19 Total mode of holders = %1$8s, Total mode of waiters = %2$8s.\n
+19 Total mode of holders = %1$10s, Total mode of waiters = %2$10s.\n
 20 Num holders=%1$3d, Num blocked-holders=%2$3d, Num waiters=%3$3d\n
 21 LOCK HOLDERS:\n
 22 BLOCKED LOCK HOLDERS:\n
 23 LOCK WAITERS:\n
 24 NON_2PL_RELEASED:\n
-25 %1$4sTran_index = %2$3d, Granted_mode =%3$8s, Count = %4$3d\n
-26 %1$4sTran_index = %2$3d, Granted_mode =%3$8s, Count = %4$3d, Nsubgranules = %5$2d\n
-27 %1$4sTran_index = %2$3d, Granted_mode =%3$8s, Count = %4$3d\n\t%5$13s Blocked_mode = %6$8s\n\t%7$17s Start_waiting_at = %8$-30s\n\t%9$17s Wait_for_secs = %10$.2f\n
-28 %1$4sTran_index = %2$3d, Granted_mode =%3$8s, Count = %4$3d, Nsubgranules = %5$2d\n\t%6$13s Blocked_mode =%7$8s\n\t%8$13s Start_waiting_at = %9$-30s\n\t%10$13s Wait_for_secs = %11$.2f\n
-29 %1$4sTran_index = %2$3d, Blocked_mode =%3$8s \n\t%4$13s Start_waiting_at = %5$-30s \n\t%6$13s Wait_for_secs = %7$.2f\n
-30 %1$4sTran_index = %2$3d, Non_2_phase_lock =%3$8s\n
+25 %1$4sTran_index = %2$3d, Granted_mode = %3$10s, Count = %4$3d\n
+26 %1$4sTran_index = %2$3d, Granted_mode = %3$10s, Count = %4$3d, Nsubgranules = %5$2d\n
+27 %1$4sTran_index = %2$3d, Granted_mode = %3$10s, Count = %4$3d\n\t%5$13s Blocked_mode = %6$10s\n\t%7$17s Start_waiting_at = %8$-30s\n\t%9$17s Wait_for_secs = %10$.2f\n
+28 %1$4sTran_index = %2$3d, Granted_mode = %3$10s, Count = %4$3d, Nsubgranules = %5$2d\n\t%6$13s Blocked_mode = %7$10s\n\t%8$13s Start_waiting_at = %9$-30s\n\t%10$13s Wait_for_secs = %11$.2f\n
+29 %1$4sTran_index = %2$3d, Blocked_mode = %3$10s \n\t%4$13s Start_waiting_at = %5$-30s \n\t%6$13s Wait_for_secs = %7$.2f\n
+30 %1$4sTran_index = %2$3d, Non_2_phase_lock = %3$10s\n
 31 VPID (volid|pageid) = %1$3d|%2$6d.\n
 32 *** Lock Table Dump ***\n Lock Escalation at = %1$d, Run Deadlock interval = %2$5.2f\n
 33 Transaction (index %1$2d, %2$s, %3$s@%4$s|%5$d)\n

--- a/msg/ko_KR.utf8/cubrid.msg
+++ b/msg/ko_KR.utf8/cubrid.msg
@@ -2122,18 +2122,18 @@ $set 14 MSGCAT_SET_LOCK
 16 락 대상: Class = %1$s.\n
 17 락 대상: Instance of class (%1$2d|%2$6d|%3$4d) = %4$s.\n
 18 락 대상: Unknown.\n
-19 Total mode of holders = %1$8s, Total mode of waiters = %2$8s.\n
+19 Total mode of holders = %1$10s, Total mode of waiters = %2$10s.\n
 20 Num holders=%1$3d, Num blocked-holders=%2$3d, Num waiters=%3$3d\n
 21 LOCK HOLDERS:\n
 22 BLOCKED LOCK HOLDERS:\n
 23 LOCK WAITERS:\n
 24 NON_2PL_RELEASED:\n
-25 %1$4sTran_index = %2$3d, Granted_mode =%3$8s, Count = %4$3d\n
-26 %1$4sTran_index = %2$3d, Granted_mode =%3$8s, Count = %4$3d, Nsubgranules = %5$2d\n
-27 %1$4sTran_index = %2$3d, Granted_mode =%3$8s, Count = %4$3d\n\t%5$13s Blocked_mode = %6$8s\n\t%7$17s Start_waiting_at = %8$-30s\n\t%9$17s Wait_for_secs = %10$.2f\n
-28 %1$4sTran_index = %2$3d, Granted_mode =%3$8s, Count = %4$3d, Nsubgranules = %5$2d\n\t%6$13s Blocked_mode =%7$8s\n\t%8$13s Start_waiting_at = %9$-30s\n\t%10$13s Wait_for_secs = %11$.2f\n
-29 %1$4sTran_index = %2$3d, Blocked_mode =%3$8s \n\t%4$13s Start_waiting_at = %5$-30s \n\t%6$13s Wait_for_secs = %7$.2f\n
-30 %1$4sTran_index = %2$3d, Non_2_phase_lock =%3$8s\n
+25 %1$4sTran_index = %2$3d, Granted_mode = %3$10s, Count = %4$3d\n
+26 %1$4sTran_index = %2$3d, Granted_mode = %3$10s, Count = %4$3d, Nsubgranules = %5$2d\n
+27 %1$4sTran_index = %2$3d, Granted_mode = %3$10s, Count = %4$3d\n\t%5$13s Blocked_mode = %6$10s\n\t%7$17s Start_waiting_at = %8$-30s\n\t%9$17s Wait_for_secs = %10$.2f\n
+28 %1$4sTran_index = %2$3d, Granted_mode = %3$10s, Count = %4$3d, Nsubgranules = %5$2d\n\t%6$13s Blocked_mode = %7$10s\n\t%8$13s Start_waiting_at = %9$-30s\n\t%10$13s Wait_for_secs = %11$.2f\n
+29 %1$4sTran_index = %2$3d, Blocked_mode = %3$10s \n\t%4$13s Start_waiting_at = %5$-30s \n\t%6$13s Wait_for_secs = %7$.2f\n
+30 %1$4sTran_index = %2$3d, Non_2_phase_lock = %3$10s\n
 31 VPID (volid|pageid) = %1$3d|%2$6d.\n
 32 *** 락 테이블 덤프  ***\n 락 상승    = %1$d, Run Deadlock interval = %2$5.2f\n
 33 트랜잭션 (인덱스 %1$2d, %2$s, %3$s@%4$s|%5$d)\n

--- a/src/query/show_scan.c
+++ b/src/query/show_scan.c
@@ -714,7 +714,8 @@ thread_scan_mapfunc (THREAD_ENTRY & thread_ref, bool & stop_mapper, THREAD_ENTRY
   if (lockwait != NULL)
     {
       /* lockwait_blocked_mode */
-      snprintf (buffer, buf_len, "%s", lock_to_lockmode_string ((LOCK) lockwait->blocked_mode));
+      snprintf (buffer, buf_len, "%*s", LOCK_MODE_STR_MAX_LENGTH,
+		lock_to_lockmode_string ((LOCK) lockwait->blocked_mode));
       error = db_make_string_copy (&vals[idx], buffer);
       if (error != NO_ERROR)
 	{

--- a/src/query/xasl_cache.c
+++ b/src/query/xasl_cache.c
@@ -266,14 +266,15 @@ static LF_ENTRY_DESCRIPTOR xcache_Entry_descriptor = {
 #define XCACHE_LOG_CLONE_ARGS(xclone) XASL_CLONE_AS_ARGS (xclone)
 
 #define XCACHE_LOG_OBJECT_TEXT		  "\t\t\t oid = %d|%d|%d \n"					  \
-					  "\t\t\t lock = %s \n"						  \
+					  "\t\t\t lock = %*s \n"					  \
 					  "\t\t\t tcard = %d \n"
 #define XCACHE_LOG_ENTRY_OBJECT_TEXT(msg)								  \
   "\t\t " msg ": \n"											  \
   XCACHE_LOG_OBJECT_TEXT
 #define XCACHE_LOG_ENTRY_OBJECT_ARGS(xent, oidx)							  \
   OID_AS_ARGS (&(xent)->related_objects[oidx].oid),							  \
-  lock_to_lockmode_string ((xent)->related_objects[oidx].lock),						  \
+  LOCK_MODE_STR_MAX_LENGTH,                                                                               \
+  lock_to_lockmode_string ((xent)->related_objects[oidx].lock),				                  \
   (xent)->related_objects[oidx].tcard
 
 static bool xcache_entry_mark_deleted (THREAD_ENTRY * thread_p, XASL_CACHE_ENTRY * xcache_entry);
@@ -2176,8 +2177,9 @@ xcache_dump (THREAD_ENTRY * thread_p, FILE * fp)
       fprintf (fp, "  OID_LIST (count = %d): \n", xcache_entry->n_related_objects);
       for (oid_index = 0; oid_index < xcache_entry->n_related_objects; oid_index++)
 	{
-	  fprintf (fp, "    OID = %d|%d|%d, LOCK = %s, TCARD = %8d \n",
+	  fprintf (fp, "    OID = %d|%d|%d, LOCK = %*s, TCARD = %8d \n",
 		   OID_AS_ARGS (&xcache_entry->related_objects[oid_index].oid),
+		   LOCK_MODE_STR_MAX_LENGTH,
 		   lock_to_lockmode_string (xcache_entry->related_objects[oid_index].lock),
 		   xcache_entry->related_objects[oid_index].tcard);
 	}

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -9302,7 +9302,8 @@ lock_event_log_tran_locks (THREAD_ENTRY * thread_p, FILE * log_fp, int tran_inde
     {
       assert (tran_index == entry->tran_index);
 
-      fprintf (log_fp, "%*clock: %s", indent, ' ', lock_to_lockmode_string (entry->granted_mode));
+      fprintf (log_fp, "%*clock: %*s", indent, ' ', LOCK_MODE_STR_MAX_LENGTH,
+	       lock_to_lockmode_string (entry->granted_mode));
 
       SET_EMULATE_THREAD_WITH_LOCK_ENTRY (thread_p, entry);
       lock_event_log_lock_info (thread_p, log_fp, entry);
@@ -9324,7 +9325,8 @@ lock_event_log_tran_locks (THREAD_ENTRY * thread_p, FILE * log_fp, int tran_inde
   if (entry != NULL)
     {
       fprintf (log_fp, "wait:\n");
-      fprintf (log_fp, "%*clock: %s", indent, ' ', lock_to_lockmode_string (entry->blocked_mode));
+      fprintf (log_fp, "%*clock: %*s", indent, ' ', LOCK_MODE_STR_MAX_LENGTH,
+	       lock_to_lockmode_string (entry->blocked_mode));
 
       SET_EMULATE_THREAD_WITH_LOCK_ENTRY (thread_p, entry);
 
@@ -9434,7 +9436,8 @@ lock_event_log_blocked_lock (THREAD_ENTRY * thread_p, FILE * log_fp, LK_ENTRY * 
   fprintf (log_fp, "waiter:\n");
   event_log_print_client_info (entry->tran_index, indent);
 
-  fprintf (log_fp, "%*clock: %s", indent, ' ', lock_to_lockmode_string (entry->blocked_mode));
+  fprintf (log_fp, "%*clock: %*s", indent, ' ', LOCK_MODE_STR_MAX_LENGTH,
+	   lock_to_lockmode_string (entry->blocked_mode));
   lock_event_log_lock_info (thread_p, log_fp, entry);
 
   event_log_sql_string (thread_p, log_fp, &entry->xasl_id, indent);
@@ -9483,7 +9486,8 @@ lock_event_log_blocking_locks (THREAD_ENTRY * thread_p, FILE * log_fp, LK_ENTRY 
 	{
 	  event_log_print_client_info (entry->tran_index, indent);
 
-	  fprintf (log_fp, "%*clock: %s", indent, ' ', lock_to_lockmode_string (entry->granted_mode));
+	  fprintf (log_fp, "%*clock: %*s", indent, ' ', LOCK_MODE_STR_MAX_LENGTH,
+		   lock_to_lockmode_string (entry->granted_mode));
 
 	  SET_EMULATE_THREAD_WITH_LOCK_ENTRY (thread_p, entry);
 
@@ -9518,7 +9522,8 @@ lock_event_log_blocking_locks (THREAD_ENTRY * thread_p, FILE * log_fp, LK_ENTRY 
 
 	  event_log_print_client_info (entry->tran_index, indent);
 
-	  fprintf (log_fp, "%*clock: %s", indent, ' ', lock_to_lockmode_string (entry->blocked_mode));
+	  fprintf (log_fp, "%*clock: %*s", indent, ' ', LOCK_MODE_STR_MAX_LENGTH,
+		   lock_to_lockmode_string (entry->blocked_mode));
 
 	  SET_EMULATE_THREAD_WITH_LOCK_ENTRY (thread_p, entry);
 

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -9386,13 +9386,12 @@ lock_event_log_deadlock_locks (THREAD_ENTRY * thread_p, FILE * log_fp, int tran_
 	}
       fprintf (log_fp, "\n");
 
-      for (lock_name =
-	   i % 2 ? lock_to_lockmode_string (entry->blocked_mode) : lock_to_lockmode_string (entry->granted_mode);
-	   *lock_name == ' '; lock_name++);
+      lock_name =
+	(i % 2) ? lock_to_lockmode_string (entry->blocked_mode) : lock_to_lockmode_string (entry->granted_mode);
       fprintf (log_fp, "%*clock: %s", indent, ' ', lock_name);
       if (!(i % 2) && entry->blocked_mode != NULL_LOCK)
 	{
-	  for (lock_name = lock_to_lockmode_string (entry->blocked_mode); *lock_name == ' '; lock_name++);
+	  lock_name = lock_to_lockmode_string (entry->blocked_mode);
 	  fprintf (log_fp, "|waiting for lock conversion to %s", lock_name);
 	}
       SET_EMULATE_THREAD_WITH_LOCK_ENTRY (thread_p, entry);

--- a/src/transaction/lock_table.h
+++ b/src/transaction/lock_table.h
@@ -69,6 +69,9 @@ lock_compat (LOCK requested, LOCK current)
   return lock_Comp[requested][current];
 }
 
+#define LOCK_MODE_STR_MAX_LENGTH 10	/* SCH_S_LOCK, SCH_M_LOCK */
+#define LOCK_MODE_STR_FMT "%*s"
+
 inline const char *
 lock_to_lockmode_string (LOCK lock)
 {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26474

### Purpose

When printing lock modes as strings in error messages, the following issues were identified:
- The longest lock mode string is 10 characters (SCH_S_LOCK, SCH_M_LOCK), but the output is formatted with a fixed width of 8 characters, resulting in misaligned messages.
- The existing function that returns lock mode strings includes leading spaces, which, when combined with the error message format specifiers, produces inconsistent and confusing output.

### Implementation

- Revise alignment of error messages
- Return raw lock mode strings without alignment padding except for error message output.

### Remarks

N/A
