### PR TITLE
[CBRD-26491] Replace bison debugging method

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,8 +323,13 @@ set(CSQL_GRAMMAR_INPUT ${CMAKE_CURRENT_BINARY_DIR}/csql_grammar.yy)
 # whenever csql_grammar.y is modified, bison and flex will be
 # run to create new outputs
 
+set(BISON_CSQL_FLAGS "--no-lines --name-prefix=csql_yy -d -r all")
+if(CMAKE_BUILD_TYPE MATCHES "Debug")
+  set(BISON_CSQL_FLAGS "${BISON_CSQL_FLAGS} --debug")
+endif()
+
 bison_target(csql_grammar ${CSQL_GRAMMAR_INPUT} ${CSQL_GRAMMAR_OUTPUT}
-  COMPILE_FLAGS "--no-lines --name-prefix=csql_yy -d -r all")
+  COMPILE_FLAGS "${BISON_CSQL_FLAGS}")
 flex_target(csql_lexer ${CSQL_LEXER_INPUT} ${CSQL_LEXER_OUTPUT}
   COMPILE_FLAGS "--noline --never-interactive --prefix=csql_yy")
 add_flex_bison_dependency(csql_lexer csql_grammar)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,8 +337,13 @@ add_custom_target(gen_csql_grammar DEPENDS ${BISON_csql_grammar_OUTPUTS})
 add_custom_target(gen_csql_lexer DEPENDS ${FLEX_csql_lexer_OUTPUTS})
 
 # Loader FLEX/BISON targets
+set(BISON_LOADER_FLAGS "-d -r all")
+if(CMAKE_BUILD_TYPE MATCHES "Debug")
+  set(BISON_LOADER_FLAGS "${BISON_LOADER_FLAGS} --debug")
+endif()
+
 bison_target(loader_grammar ${LOADER_GRAMMAR_INPUT} ${LOADER_GRAMMAR_OUTPUT}
-  COMPILE_FLAGS "-d -r all")
+  COMPILE_FLAGS "${BISON_LOADER_FLAGS}")
 flex_target(loader_lexer ${LOADER_LEXER_INPUT} ${LOADER_LEXER_OUTPUT}
   COMPILE_FLAGS "--noline")
 add_flex_bison_dependency(loader_lexer loader_grammar)

--- a/src/loaddb/load_grammar.yy
+++ b/src/loaddb/load_grammar.yy
@@ -32,6 +32,12 @@
 
 %define parse.assert
 
+%initial-action {
+#if YYDEBUG
+  set_debug_level (loader_init_yydebug ());
+#endif
+}
+
 %union {
   int int_val;
   string_type *string;
@@ -57,8 +63,29 @@ namespace cubload
 #include "dbtype.h"
 #include "load_driver.hpp"
 
+#include <cstdlib>
+
 #undef yylex
 #define yylex m_driver.get_scanner ().yylex
+
+#if YYDEBUG
+static int
+loader_init_yydebug (void)
+{
+  static int initialized = 0;
+  static int debug_level = 0;
+  if (!initialized)
+    {
+      const char *env = std::getenv ("CUBRID_LOADER_DEBUG");
+      if (env && env[0] == '1')
+        {
+          debug_level = 1;
+        }
+      initialized = 1;
+    }
+  return debug_level;
+}
+#endif
 }
 
 %token NL

--- a/src/loaddb/load_grammar.yy
+++ b/src/loaddb/load_grammar.yy
@@ -59,14 +59,6 @@ namespace cubload
 
 #undef yylex
 #define yylex m_driver.get_scanner ().yylex
-
-/*#define PARSER_DEBUG*/
-
-#ifdef PARSER_DEBUG
-#define DBG_PRINT(s) printf("rule: %s\n", (s));
-#else
-#define DBG_PRINT(s)
-#endif
 }
 
 %token NL
@@ -197,12 +189,10 @@ loader_start :
 loader_lines :
   line
   {
-    DBG_PRINT ("line");
   }
   |
   loader_lines line
   {
-    DBG_PRINT ("line_list line");
   }
   ;
 
@@ -212,7 +202,6 @@ line :
   }
   one_line NL
   {
-    DBG_PRINT ("one_line");
     m_driver.get_semantic_helper ().set_in_instance_line (true);
   }
   |
@@ -225,13 +214,11 @@ line :
 one_line :
   command_line
   {
-    DBG_PRINT ("command_line");
     m_driver.get_semantic_helper ().reset_after_line ();
   }
   |
   instance_line
   {
-    DBG_PRINT ("instance_line");
     m_driver.get_object_loader ().finish_line ();
     m_driver.get_semantic_helper ().reset_after_line ();
   }
@@ -240,19 +227,16 @@ one_line :
 command_line :
   class_command
   {
-    DBG_PRINT ("class_command");
   }
   |
   id_command
   {
-    DBG_PRINT ("id_command");
   }
   ;
 
 id_command :
   CMD_ID IDENTIFIER DOT IDENTIFIER INT_LIT
   {
-    DBG_PRINT ("CMD_ID IDENTIFIER DOT IDENTIFIER INT_LIT");
     std::string name;
     name.reserve($2->size + sizeof (".") + $4->size);
     name.append ($2->val).append (".").append ($4->val);
@@ -261,7 +245,6 @@ id_command :
   |
   CMD_ID IDENTIFIER INT_LIT
   {
-    DBG_PRINT ("CMD_ID IDENTIFIER INT_LIT");
     m_driver.get_class_installer ().check_class ($2->val, atoi ($3->val));
   }
   ;
@@ -269,7 +252,6 @@ id_command :
 class_command :
   CMD_CLASS IDENTIFIER DOT IDENTIFIER class_command_spec
   {
-    DBG_PRINT ("CMD_CLASS IDENTIFIER DOT IDENTIFIER class_command_spec");
     std::string name;
     name.reserve($2->size + sizeof (".") + $4->size);
     name.append ($2->val).append (".").append ($4->val);
@@ -282,7 +264,6 @@ class_command :
   |
   CMD_CLASS IDENTIFIER class_command_spec
   {
-    DBG_PRINT ("CMD_CLASS IDENTIFIER class_command_spec");
     m_driver.get_class_installer ().install_class ($2, $3);
 
     delete $3;
@@ -293,25 +274,21 @@ class_command :
 class_command_spec :
   attribute_list
   {
-    DBG_PRINT ("attribute_list");
     $$ = new class_command_spec_type (LDR_ATTRIBUTE_ANY, $1, NULL);
   }
   |
   attribute_list constructor_spec
   {
-    DBG_PRINT ("attribute_list constructor_spec");
     $$ = new class_command_spec_type (LDR_ATTRIBUTE_ANY, $1, $2);
   }
   |
   attribute_list_type attribute_list
   {
-    DBG_PRINT ("attribute_list_type attribute_list");
     $$ = new class_command_spec_type ($1, $2, NULL);
   }
   |
   attribute_list_type attribute_list constructor_spec
   {
-    DBG_PRINT ("attribute_list_type attribute_list constructor_spec");
     $$ = new class_command_spec_type ($1, $2, $3);
   }
   ;
@@ -319,19 +296,16 @@ class_command_spec :
 attribute_list_type :
   CLASS
   {
-    DBG_PRINT ("CLASS");
     $$ = LDR_ATTRIBUTE_CLASS;
   }
   |
   SHARED
   {
-    DBG_PRINT ("SHARED");
     $$ = LDR_ATTRIBUTE_SHARED;
   }
   |
   DEFAULT
   {
-    DBG_PRINT ("DEFAULT");
     $$ = LDR_ATTRIBUTE_DEFAULT;
   }
   ;
@@ -351,19 +325,16 @@ attribute_list :
 attribute_names :
   attribute_name
   {
-    DBG_PRINT ("attribute_name");
     $$ = m_driver.get_semantic_helper ().append_string_list (NULL, $1);
   }
   |
   attribute_names attribute_name
   {
-    DBG_PRINT ("attribute_names attribute_name");
     $$ = m_driver.get_semantic_helper ().append_string_list ($1, $2);
   }
   |
   attribute_names COMMA attribute_name
   {
-    DBG_PRINT ("attribute_names COMMA attribute_name");
     $$ = m_driver.get_semantic_helper ().append_string_list ($1, $3);
   }
   ;
@@ -397,19 +368,16 @@ constructor_argument_list :
 argument_names :
   argument_name
   {
-    DBG_PRINT ("argument_name");
     $$ = m_driver.get_semantic_helper ().append_string_list (NULL, $1);
   }
   |
   argument_names argument_name
   {
-    DBG_PRINT ("argument_names argument_name");
     $$ = m_driver.get_semantic_helper ().append_string_list ($1, $2);
   }
   |
   argument_names COMMA argument_name
   {
-    DBG_PRINT ("argument_names COMMA argument_name");
     $$ = m_driver.get_semantic_helper ().append_string_list ($1, $3);
   }
   ;
@@ -450,13 +418,11 @@ object_id :
 constant_list :
   constant
   {
-    DBG_PRINT ("constant");
     $$ = m_driver.get_semantic_helper ().append_constant_list (NULL, $1);
   }
   |
   constant_list constant
   {
-    DBG_PRINT ("constant_list constant");
     $$ = m_driver.get_semantic_helper ().append_constant_list ($1, $2);
   }
   ;
@@ -634,31 +600,26 @@ set_constant :
 set_elements:
   constant
   {
-    DBG_PRINT ("constant");
     $$ = m_driver.get_semantic_helper ().append_constant_list (NULL, $1);
   }
   |
   set_elements constant
   {
-    DBG_PRINT ("set_elements constant");
     $$ = m_driver.get_semantic_helper ().append_constant_list ($1, $2);
   }
   |
   set_elements COMMA constant
   {
-    DBG_PRINT ("set_elements COMMA constant");
     $$ = m_driver.get_semantic_helper ().append_constant_list ($1, $3);
   }
   |
   set_elements NL constant
   {
-    DBG_PRINT ("set_elements NL constant");
     $$ = m_driver.get_semantic_helper ().append_constant_list ($1, $3);
   }
   |
   set_elements COMMA NL constant
   {
-    DBG_PRINT ("set_elements COMMA NL constant");
     $$ = m_driver.get_semantic_helper ().append_constant_list ($1, $4);
   }
   ;

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -26363,6 +26363,23 @@ parser_make_number_lang (const int argc)
   return number_lang;
 }
 
+#if YYDEBUG
+static void
+parser_init_yydebug (void)
+{
+  static int initialized = 0;
+  if (!initialized)
+    {
+      const char *env = getenv ("CUBRID_PARSER_DEBUG");
+      if (env && env[0] == '1')
+        {
+          yydebug = 1;
+        }
+      initialized = 1;
+    }
+}
+#endif
+
 PT_NODE **
 parser_main (PARSER_CONTEXT * parser)
 {
@@ -26395,6 +26412,9 @@ parser_main (PARSER_CONTEXT * parser)
   g_original_buffer_len = 0;
 
   pt_initialize_hint(parser, parser_hint_table); 
+#if YYDEBUG
+  parser_init_yydebug ();
+#endif
   rv = yyparse ();
 
   // parser_main can be reentered while executing statements loaded by loaddb -s.

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -149,8 +149,6 @@ static void pt_fill_conn_info_container(PARSER_CONTEXT *parser, int buffer_pos, 
 %{
 #define YYMAXDEPTH	1000000
 
-/* #define PARSER_DEBUG */
-
 #include "config.h"
 
 #include <stdio.h>
@@ -199,18 +197,6 @@ static void pt_fill_conn_info_container(PARSER_CONTEXT *parser, int buffer_pos, 
 #define COLUMN_CONSTRAINT_SHARED_DEFAULT_AI	(0x70)
 #define COLUMN_CONSTRAINT_COMMENT       (0x80)
 #define COLUMN_CONSTRAINT_ON_UPDATE     (0x100)
-
-#ifdef PARSER_DEBUG
-#define DBG_PRINT printf("rule matched at line: %d\n", __LINE__);
-#define PRINT_(a) printf(a)
-#define PRINT_1(a, b) printf(a, b)
-#define PRINT_2(a, b, c) printf(a, b, c)
-#else
-#define DBG_PRINT
-#define PRINT_(a)
-#define PRINT_1(a, b)
-#define PRINT_2(a, b, c)
-#endif
 
 #define STACK_SIZE	128
 
@@ -548,7 +534,6 @@ static int g_plcsql_text_pos;
              (rv)->info.name.original = (iv);           \
      }                                                  \
    PARSER_SAVE_ERR_CONTEXT ((rv), (b_p))                \
-   DBG_PRINT                                            \
 } while (0)
 
 #define MAKE_MONETARY_LITERAL(rv, iv, b_p, sign_text, currency_type) do {    \
@@ -1795,13 +1780,9 @@ stmt_list
 			      }
 
 			    pt_push (this_parser, $3);
-
-			#ifdef PARSER_DEBUG
-			    printf ("node: %s\n", parser_print_tree (this_parser, $3));
-			#endif
 			  }
 
-		DBG_PRINT}}
+		}}
 	| stmt %dprec 3
 		{{
 
@@ -1817,13 +1798,9 @@ stmt_list
 			      }
 
 			    pt_push (this_parser, $1);
-
-			#ifdef PARSER_DEBUG
-			    printf ("node: %s\n", parser_print_tree (this_parser, $1));
-			#endif
 			  }
 
-		DBG_PRINT}}
+		}}
         | SEMICOLON
                 {{ /* empty line*/ }}
 	;
@@ -1871,7 +1848,7 @@ stmt
 			      }
 			  }
 
-		DBG_PRINT}}
+		}}
 		{{
 
 			parser_initialize_parser_context ();
@@ -1905,14 +1882,9 @@ stmt
                         g_plcsql_text_pos = -1;
                         is_in_sp_func_type = false;
                         assert(expecting_pl_lang_spec == 0); // initialized in parser_main() or parse_one_statement()
-		DBG_PRINT}}
+		}}
 	stmt_
 		{{ DBG_TRACE_GRAMMAR(stmt, stmt_ );
-
-			#ifdef PARSER_DEBUG
-			if (msg_ptr == 0)
-			  printf ("Good!!!\n");
-			#endif
 
 			if (msg_ptr > 0)
 			  {
@@ -1951,7 +1923,7 @@ stmt
 			      }
 			  }
 
-		DBG_PRINT}}
+		}}
 		{{
 
 			PT_NODE *node = $3;
@@ -1970,7 +1942,7 @@ stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 stmt_
 	: create_stmt
@@ -2001,7 +1973,7 @@ stmt_
 			    stmt->info.query.with = with_clause;
 			  }
 			$$ = stmt;
-	  DBG_PRINT}}
+	  }}
 	| evaluate_stmt
 		{ DBG_TRACE_GRAMMAR(stmt_, | evaluate_stmt);
                   $$ = $1; }
@@ -2024,7 +1996,7 @@ stmt_
 			    stmt->info.update.with = with_clause;
 			  }
 			$$ = stmt;
-	  DBG_PRINT}}
+	  }}
 	| opt_with_clause
 	  delete_stmt
 		{{ DBG_TRACE_GRAMMAR(stmt_, | opt_with_clause delete_stmt);
@@ -2035,7 +2007,7 @@ stmt_
 			    stmt->info.delete_.with = with_clause;
 			  }
 			$$ = stmt;
-	  DBG_PRINT}}
+	  }}
 	| show_stmt
 		{ DBG_TRACE_GRAMMAR(stmt_, | show_stmt);
                   $$ = $1; }
@@ -2105,7 +2077,7 @@ stmt_
 			$$ = dt;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| ATTACH
 		{ push_msg(MSGCAT_SYNTAX_INVALID_ATTACH); }
 	  unsigned_integer
@@ -2122,7 +2094,7 @@ stmt_
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| PREPARE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_PREPARE); }
 	  opt_to COMMIT unsigned_integer
@@ -2139,7 +2111,7 @@ stmt_
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| EXECUTE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_EXECUTE); }
 	  DEFERRED TRIGGER trigger_spec_list
@@ -2156,7 +2128,7 @@ stmt_
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SCOPE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SCOPE); }
 	  trigger_action opt_from_table_spec_list
@@ -2174,7 +2146,7 @@ stmt_
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| vacuum_stmt
 		{ DBG_TRACE_GRAMMAR(stmt_, | vacuum_stmt);
                   $$ = $1; }
@@ -2194,7 +2166,7 @@ stmt_
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SET Time ZONE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SET_TIMEZONE); }
 	  char_string_literal
@@ -2209,7 +2181,7 @@ stmt_
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 
@@ -2239,7 +2211,7 @@ set_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SET OPTIMIZATION
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SET_OPT_COST); }
 	  COST opt_of char_string_literal opt_of_to_eq literal_
@@ -2258,7 +2230,7 @@ set_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SET
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SET_SYS_PARAM); }
 	  SYSTEM PARAMETERS char_string_literal_list
@@ -2271,7 +2243,7 @@ set_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SET
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SET_TRAN); }
 	  TRANSACTION transaction_mode_list
@@ -2288,7 +2260,7 @@ set_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SET TRIGGER
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SET_TRIGGER_TRACE); }
 	  TRACE trace_spec
@@ -2306,7 +2278,7 @@ set_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SET TRIGGER
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SET_TRIGGER_DEPTH); }
 	  opt_maximum DEPTH depth_spec
@@ -2324,7 +2296,7 @@ set_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SET session_variable_assignment_list
 		{{ DBG_TRACE_GRAMMAR(set_stmt, | SET session_variable_assignment_list);
 
@@ -2337,7 +2309,7 @@ set_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SET NAMES BINARY
 		{{ DBG_TRACE_GRAMMAR(set_stmt, | SET NAMES BINARY);
 
@@ -2364,7 +2336,7 @@ set_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SET
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SET_NAMES); }
 	  NAMES char_string_literal
@@ -2382,7 +2354,7 @@ set_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SET
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SET_NAMES); }
 	  NAMES IdName
@@ -2413,7 +2385,7 @@ set_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SET TRACE query_trace_spec opt_trace_output_format
 		{{ DBG_TRACE_GRAMMAR(set_stmt, | SET TRACE query_trace_spec opt_trace_output_format);
 
@@ -2427,33 +2399,33 @@ set_stmt
 
 			$$ = node;
 
-		DBG_PRINT}}
+		}}
 	;
 
 query_trace_spec
 	: ON_
 		{{ DBG_TRACE_GRAMMAR(query_trace_spec, : ON_);
 			$$ = PT_TRACE_ON;
-		DBG_PRINT}}
+		}}
 	| OFF_
 		{{ DBG_TRACE_GRAMMAR(query_trace_spec, | OFF_);
 			$$ = PT_TRACE_OFF;
-		DBG_PRINT}}
+		}}
 	;
 
 opt_trace_output_format
 	: /* empty */
 		{{ DBG_TRACE_GRAMMAR(opt_trace_output_format, : );
 			$$ = PT_TRACE_FORMAT_TEXT;
-		DBG_PRINT}}
+		}}
 	| OUTPUT TEXT
 		{{ DBG_TRACE_GRAMMAR(opt_trace_output_format, | OUTPUT TEXT);
 			$$ = PT_TRACE_FORMAT_TEXT;
-		DBG_PRINT}}
+		}}
 	| OUTPUT JSON
 		{{ DBG_TRACE_GRAMMAR(opt_trace_output_format, | OUTPUT JSON);
 			$$ = PT_TRACE_FORMAT_JSON;
-		DBG_PRINT}}
+		}}
 	;
 
 session_variable_assignment_list
@@ -2463,7 +2435,7 @@ session_variable_assignment_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 
 	| session_variable_assignment
 		{{ DBG_TRACE_GRAMMAR(session_variable_assignment_list, | session_variable_assignment);
@@ -2471,7 +2443,7 @@ session_variable_assignment_list
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 session_variable_assignment
@@ -2484,14 +2456,14 @@ session_variable_assignment
 			$$ = expr;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| session_variable_definition
 		{{ DBG_TRACE_GRAMMAR(session_variable_assignment, | session_variable_definition);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 session_variable_definition
@@ -2504,7 +2476,7 @@ session_variable_definition
 			$$ = expr;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 session_variable_expression
@@ -2518,7 +2490,7 @@ session_variable_expression
 			$$ = expr;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 session_variable_list
@@ -2528,14 +2500,14 @@ session_variable_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| session_variable
 		{{ DBG_TRACE_GRAMMAR(session_variable_list, | session_variable);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 session_variable
@@ -2559,7 +2531,7 @@ session_variable
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 get_stmt
@@ -2579,7 +2551,7 @@ get_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| GET OPTIMIZATION
 		{ push_msg(MSGCAT_SYNTAX_INVALID_GET_OPT_LEVEL); }
 	  LEVEL into_clause_opt
@@ -2596,7 +2568,7 @@ get_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| GET OPTIMIZATION
 		{ push_msg(MSGCAT_SYNTAX_INVALID_GET_OPT_COST); }
 	  COST opt_of char_string_literal into_clause_opt
@@ -2613,7 +2585,7 @@ get_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| GET TRANSACTION
 		{ push_msg(MSGCAT_SYNTAX_INVALID_GET_TRAN_ISOL); }
 	  ISOLATION LEVEL into_clause_opt
@@ -2631,7 +2603,7 @@ get_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| GET TRANSACTION
 		{ push_msg(MSGCAT_SYNTAX_INVALID_GET_TRAN_LOCK); }
 	  LOCK_ TIMEOUT into_clause_opt
@@ -2649,7 +2621,7 @@ get_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| GET TRIGGER
 		{ push_msg(MSGCAT_SYNTAX_INVALID_GET_TRIGGER_TRACE); }
 	  TRACE into_clause_opt
@@ -2667,7 +2639,7 @@ get_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| GET TRIGGER
 		{ push_msg(MSGCAT_SYNTAX_INVALID_GET_TRIGGER_DEPTH); }
 	  opt_maximum DEPTH into_clause_opt
@@ -2685,7 +2657,7 @@ get_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 
@@ -2753,7 +2725,7 @@ create_stmt
 
 			$$ = qc;
 
-		DBG_PRINT}}
+		}}
 	| CREATE 					/* 1 */
 	  opt_or_replace				/* 2 */
 	  of_view_vclass 				/* 3 */
@@ -2795,7 +2767,7 @@ create_stmt
 			$$ = qc;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| CREATE					/* 1 */
 		{					/* 2 */
                         DBG_TRACE_GRAMMAR(create_stmt, | CREATE);
@@ -2977,7 +2949,7 @@ create_stmt
 			  }
 		      $$ = node;
 
-		DBG_PRINT}}
+		}}
 	| CREATE			/* 1 */
 	  USER				/* 2 */
 		{
@@ -3006,7 +2978,7 @@ create_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| CREATE					/* 1 */
 		{ push_msg(MSGCAT_SYNTAX_INVALID_CREATE_TRIGGER); }	/* 2 */
 	  TRIGGER 					/* 3 */
@@ -3042,7 +3014,7 @@ create_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| CREATE					/* 1 */
 		{ push_msg(MSGCAT_SYNTAX_INVALID_CREATE_SERIAL); }	/* 2 */
 	  SERIAL 					/* 3 */
@@ -3087,7 +3059,7 @@ create_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| CREATE					/* 1 */
 	  opt_or_replace               		        /* 2 */
 	  PROCEDURE					/* 3 */
@@ -3150,7 +3122,7 @@ create_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| CREATE                        		/* 1 */
 	  opt_or_replace                		/* 2 */
 	  FUNCTION					/* 3 */
@@ -3214,14 +3186,14 @@ create_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| CREATE IdName
 		{{ DBG_TRACE_GRAMMAR(create_stmt, | CREATE IdName);
 
 			push_msg (MSGCAT_SYNTAX_INVALID_CREATE);
 			csql_yyerror_explicit (@2.first_line, @2.first_column);
 
-		DBG_PRINT}}
+		}}
 	| CREATE					/* 1 */
 		{					/* 2 */
 			PT_NODE* qc = parser_new_node(this_parser, PT_CREATE_ENTITY);
@@ -3248,7 +3220,7 @@ create_stmt
 			$$ = qc;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| CREATE					/* 1 */
 		{					/* 2 */
 			PT_NODE* qc = parser_new_node(this_parser, PT_CREATE_ENTITY);
@@ -3277,7 +3249,7 @@ create_stmt
 			$$ = qc;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| CREATE SERVER dblink_server_name '(' connect_info ')'
 		{{ DBG_TRACE_GRAMMAR(create_stmt, | CREATE SERVER dblink_server_name '(' connect_info ')' );
                         PT_NODE *node = parser_new_node (this_parser, PT_CREATE_SERVER);
@@ -3342,7 +3314,7 @@ create_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| CREATE			/* 1 */
 	  opt_create_synonym		/* 2 */
 	  SYNONYM			/* 3 */
@@ -3381,7 +3353,7 @@ create_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 class_name_for_synonym
@@ -3537,7 +3509,7 @@ serial_option_list
 
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| of_serial_option
 		{{ DBG_TRACE_GRAMMAR(serial_option_list, | of_serial_option);
 			/* container order
@@ -3594,7 +3566,7 @@ serial_option_list
 
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	;
 
 of_serial_option
@@ -3603,37 +3575,37 @@ of_serial_option
 			container_3 ctn;
 			SET_CONTAINER_3(ctn, FROM_NUMBER(SERIAL_START), $1, NULL);
 			$$ = ctn;
-		DBG_PRINT}}
+		}}
 	| serial_increment
 		{{ DBG_TRACE_GRAMMAR(of_serial_option, | serial_increment);
 			container_3 ctn;
 			SET_CONTAINER_3(ctn, FROM_NUMBER(SERIAL_INC), $1, NULL);
 			$$ = ctn;
-		DBG_PRINT}}
+		}}
 	| serial_min
 		{{ DBG_TRACE_GRAMMAR(of_serial_option, | serial_min);
 			container_3 ctn;
 			SET_CONTAINER_3(ctn, FROM_NUMBER(SERIAL_MIN), CONTAINER_AT_0($1), CONTAINER_AT_1($1));
 			$$ = ctn;
-		DBG_PRINT}}
+		}}
 	| serial_max
 		{{ DBG_TRACE_GRAMMAR(of_serial_option, | serial_max);
 			container_3 ctn;
 			SET_CONTAINER_3(ctn, FROM_NUMBER(SERIAL_MAX), CONTAINER_AT_0($1), CONTAINER_AT_1($1));
 			$$ = ctn;
-		DBG_PRINT}}
+		}}
 	| of_cycle_nocycle
 		{{ DBG_TRACE_GRAMMAR(of_serial_option, | of_cycle_nocycle);
 			container_3 ctn;
 			SET_CONTAINER_3(ctn, FROM_NUMBER(SERIAL_CYCLE), CONTAINER_AT_0($1), CONTAINER_AT_1($1));
 			$$ = ctn;
-		DBG_PRINT}}
+		}}
 	| of_cached_num
 		{{ DBG_TRACE_GRAMMAR(of_serial_option, | of_cached_num);
 			container_3 ctn;
 			SET_CONTAINER_3(ctn, FROM_NUMBER(SERIAL_CACHE), CONTAINER_AT_0($1), CONTAINER_AT_1($1));
 			$$ = ctn;
-		DBG_PRINT}}
+		}}
 	;
 
 serial_owner_clause
@@ -3670,7 +3642,7 @@ serial_owner_clause
 
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	;
 
 of_serial_owner_clause
@@ -3679,7 +3651,7 @@ of_serial_owner_clause
 			container_3 ctn;
 			SET_CONTAINER_3(ctn, FROM_NUMBER(SERIAL_CHANGE_OWNER), $3, NULL);
 			$$ = ctn;
-	        DBG_PRINT}}
+	        }}
 	;
 
 opt_replace
@@ -3688,13 +3660,13 @@ opt_replace
 
 			$$ = PT_CREATE_SELECT_NO_ACTION;
 
-		DBG_PRINT}}
+		}}
 	| REPLACE
 		{{ DBG_TRACE_GRAMMAR(opt_replace, | REPLACE);
 
 			$$ = PT_CREATE_SELECT_REPLACE;
 
-		DBG_PRINT}}
+		}}
 	;
 
 alter_stmt
@@ -3719,7 +3691,7 @@ alter_stmt
 
 			parser_save_alter_node (node);
 
-		DBG_PRINT}}
+		}}
 	  alter_clause_cubrid_specific
 		{{ DBG_TRACE_GRAMMAR(alter_stmt,  ~ alter_clause_cubrid_specific);
 
@@ -3732,7 +3704,7 @@ alter_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| ALTER						/* 1 */
 		{					/* 2 */
 			PT_NODE* node = parser_new_node(this_parser, PT_ALTER);
@@ -3795,7 +3767,7 @@ alter_stmt
 			$$ = $6;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| ALTER				/* 1 */
 	  USER				/* 2 */
 	  identifier	        	/* 3 */
@@ -3821,7 +3793,7 @@ alter_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| ALTER				/* 1 */
 	  USER				/* 2 */
 	  identifier	        	/* 3 */
@@ -3846,7 +3818,7 @@ alter_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| ALTER				/* 1 */
 	  USER				/* 2 */
 	  identifier	        	/* 3 */
@@ -3871,7 +3843,7 @@ alter_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| ALTER						/* 1 */
 	  TRIGGER					/* 2 */
 	  trigger_name_list				/* 3 */
@@ -3899,7 +3871,7 @@ alter_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| ALTER				/* 1 */
 	  TRIGGER			/* 2 */
 	  trigger_name			/* 3 */
@@ -3923,7 +3895,7 @@ alter_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| ALTER						/* 1 */
 	  SERIAL					/* 2 */
 	  serial_name					/* 3 */
@@ -3989,7 +3961,7 @@ alter_stmt
 			        node->info.serial.code = PT_CHANGE_OWNER;
 			      }
 			  }
-		DBG_PRINT}}
+		}}
 	| ALTER						/* 1 */
 		{					/* 2 */
 			PT_NODE* node = parser_new_node(this_parser, PT_ALTER_INDEX);
@@ -4033,7 +4005,7 @@ alter_stmt
 
 		  $$ = node;
 		  PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
 	| ALTER						/* 1 */
 	  INDEX						/* 2 */
 	  identifier					/* 3 */
@@ -4068,7 +4040,7 @@ alter_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| ALTER				/* 1 */
 	  INDEX				/* 2 */
 	  identifier			/* 3 */
@@ -4103,7 +4075,7 @@ alter_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| ALTER				/* 1 */
 	  INDEX				/* 2 */
 	  identifier			/* 3 */
@@ -4138,7 +4110,7 @@ alter_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| ALTER						/* 1 */
 	  view_or_vclass				/* 2 */
 	  class_name					/* 3 */
@@ -4163,7 +4135,7 @@ alter_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| ALTER
 	  view_or_vclass
 	  class_name
@@ -4183,7 +4155,7 @@ alter_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| ALTER				/* 1 */
 	  procedure_or_function		/* 2 */
 	  procedure_or_function_name    /* 3 */
@@ -4212,7 +4184,7 @@ alter_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| ALTER				/* 1 */
 	  procedure_or_function		/* 2 */
 	  procedure_or_function_name    /* 3 */
@@ -4232,7 +4204,7 @@ alter_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| ALTER  SERVER  dblink_server_name alter_server_list
                 {{ DBG_TRACE_GRAMMAR(alter_stmt, | ALTER  SERVER  dblink_server_name alter_server_list);
                         PT_NODE *node = parser_new_node (this_parser, PT_ALTER_SERVER);
@@ -4324,7 +4296,7 @@ alter_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| ALTER				/* 1 */
 	  opt_access_modifier		/* 2 */
 	  SYNONYM			/* 3 */
@@ -4368,7 +4340,7 @@ alter_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 view_or_vclass
@@ -4383,7 +4355,7 @@ alter_clause_list
 			$$ = parser_make_link ($1, parser_get_alter_node ());
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| /* The first node in the list is the one that was pushed for hints. */
 		{
 
@@ -4396,7 +4368,7 @@ alter_clause_list
 			$$ = parser_get_alter_node ();
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 prepare_alter_node
@@ -4406,7 +4378,7 @@ prepare_alter_node
 			PT_NODE *node = parser_new_node (this_parser, PT_ALTER);
 			parser_save_alter_node (node);
 
-		DBG_PRINT}}
+		}}
 	;
 
 only_class_name
@@ -4438,7 +4410,7 @@ only_class_name_or_with_server_name
                     
                         $$ = scs;                       
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-                DBG_PRINT}}
+                }}
 
 	;
 
@@ -4457,7 +4429,7 @@ rename_stmt
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| RENAME TRIGGER trigger_name as_or_to trigger_name
 		{{ DBG_TRACE_GRAMMAR(rename_stmt, | RENAME TRIGGER trigger_name as_or_to trigger_name);
 
@@ -4472,7 +4444,7 @@ rename_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| RENAME SERVER dblink_server_name as_or_to identifier_without_dot
 		{{ DBG_TRACE_GRAMMAR(rename_stmt, | RENAME SERVER dblink_server_name as_or_to identifier_without_dot);
 			PT_NODE *node = parser_new_node (this_parser, PT_RENAME_SERVER);
@@ -4486,7 +4458,7 @@ rename_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
 	| RENAME			/* 1 */
 	  opt_access_modifier		/* 2 */
 	  SYNONYM			/* 3 */
@@ -4515,7 +4487,7 @@ rename_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
 	;
 
 rename_class_list
@@ -4525,14 +4497,14 @@ rename_class_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| rename_class_pair
 		{{ DBG_TRACE_GRAMMAR(rename_class_list, | rename_class_pair);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 rename_class_pair
@@ -4550,7 +4522,7 @@ rename_class_pair
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 procedure_or_function
@@ -4559,13 +4531,13 @@ procedure_or_function
 
 			$$ = 1;
 
-		DBG_PRINT}}
+		}}
 	| FUNCTION
 		{{ DBG_TRACE_GRAMMAR(procedure_or_function, | FUNCTION);
 
 			$$ = 2;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_owner_clause
@@ -4596,7 +4568,7 @@ truncate_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 do_stmt
@@ -4626,7 +4598,7 @@ do_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 drop_stmt
@@ -4649,7 +4621,7 @@ drop_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| DROP					/* 1 */
 		{				/* 2 */
 			PT_NODE* node = parser_new_node(this_parser, PT_DROP_INDEX);
@@ -4714,7 +4686,7 @@ drop_stmt
 			    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 			  }
 
-		DBG_PRINT}}
+		}}
 	| DROP USER identifier
 		{{ DBG_TRACE_GRAMMAR(drop_stmt, | DROP USER identifier);
 
@@ -4728,7 +4700,7 @@ drop_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| DROP TRIGGER trigger_name_list
 		{{ DBG_TRACE_GRAMMAR(drop_stmt, | DROP TRIGGER trigger_name_list);
 
@@ -4748,7 +4720,7 @@ drop_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| DROP DEFERRED TRIGGER trigger_spec_list
 		{{ DBG_TRACE_GRAMMAR(drop_stmt, | DROP DEFERRED TRIGGER trigger_spec_list);
 
@@ -4762,7 +4734,7 @@ drop_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| DROP VARIABLE_ identifier_list
 		{{ DBG_TRACE_GRAMMAR(drop_stmt, | DROP VARIABLE_ identifier_list);
 
@@ -4772,7 +4744,7 @@ drop_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| DROP SERIAL opt_if_exists serial_name
 		{{ DBG_TRACE_GRAMMAR(drop_stmt, | DROP SERIAL opt_if_exists serial_name);
 
@@ -4785,7 +4757,7 @@ drop_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| DROP PROCEDURE procedure_or_function_name_list
 		{{ DBG_TRACE_GRAMMAR(drop_stmt, | DROP PROCEDURE procedure_or_function_name_list);
 
@@ -4801,7 +4773,7 @@ drop_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| DROP FUNCTION procedure_or_function_name_list
 		{{ DBG_TRACE_GRAMMAR(drop_stmt, | DROP FUNCTION procedure_or_function_name_list);
 
@@ -4817,7 +4789,7 @@ drop_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| DROP SERVER opt_if_exists dblink_server_name
 		{{ DBG_TRACE_GRAMMAR(drop_stmt, | DROP SERVER opt_if_exists dblink_server_name);
                         PT_NODE *node = parser_new_node (this_parser, PT_DROP_SERVER);
@@ -4836,7 +4808,7 @@ drop_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| DROP				/* 1 */
 	  opt_access_modifier		/* 2 */
 	  SYNONYM			/* 3 */
@@ -4866,7 +4838,7 @@ drop_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| deallocate_or_drop PREPARE identifier
 		{{ DBG_TRACE_GRAMMAR(drop_stmt, | deallocate_or_drop PREPARE identifier);
 
@@ -4881,7 +4853,7 @@ drop_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| deallocate_or_drop VARIABLE_ session_variable_list
 		{{ DBG_TRACE_GRAMMAR(drop_stmt, | deallocate_or_drop VARIABLE_ session_variable_list);
 
@@ -4894,7 +4866,7 @@ drop_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 deallocate_or_drop
@@ -4909,14 +4881,14 @@ opt_reverse
 			parser_save_is_reverse (false);
 			$$ = false;
 
-		DBG_PRINT}}
+		}}
 	| REVERSE
 		{{ DBG_TRACE_GRAMMAR(opt_reverse, | REVERSE);
 
 			parser_save_is_reverse (true);
 			$$ = true;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_unique
@@ -4925,13 +4897,13 @@ opt_unique
 
 			$$ = false;
 
-		DBG_PRINT}}
+		}}
 	| UNIQUE
 		{{ DBG_TRACE_GRAMMAR(opt_unique, | UNIQUE);
 
 			$$ = true;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_index_column_name_list
@@ -4940,14 +4912,14 @@ opt_index_column_name_list
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| index_column_name_list
 		{{ DBG_TRACE_GRAMMAR(opt_index_column_name_list, | index_column_name_list);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 index_column_name_list
@@ -4965,7 +4937,7 @@ index_column_name_list
 		      $$ = $2;
 		      PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 update_statistics_stmt
@@ -4982,7 +4954,7 @@ update_statistics_stmt
 			$$ = ups;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| UPDATE STATISTICS ON_ ALL CLASSES opt_with_fullscan
 		{{ DBG_TRACE_GRAMMAR(update_statistics_stmt, | UPDATE STATISTICS ON_ ALL CLASSES opt_with_fullscan);
 
@@ -4996,7 +4968,7 @@ update_statistics_stmt
 			$$ = ups;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| UPDATE STATISTICS ON_ CATALOG CLASSES opt_with_fullscan
 		{{ DBG_TRACE_GRAMMAR(update_statistics_stmt, | UPDATE STATISTICS ON_ CATALOG CLASSES opt_with_fullscan);
 
@@ -5010,7 +4982,7 @@ update_statistics_stmt
 			$$ = ups;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 only_class_name_list
@@ -5020,14 +4992,14 @@ only_class_name_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| only_class_name
 		{{ DBG_TRACE_GRAMMAR(only_class_name_list, | only_class_name);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_invisible
@@ -5035,13 +5007,13 @@ opt_invisible
 		{{ DBG_TRACE_GRAMMAR(opt_invisible, : );
  			$$ = false;
 
-		DBG_PRINT}}
+		}}
 	| INVISIBLE
 		{{ DBG_TRACE_GRAMMAR(opt_invisible, | INVISIBLE);
 
 			$$ = true;
 
-		DBG_PRINT}}
+		}}
 	;
 
 
@@ -5051,13 +5023,13 @@ opt_with_fullscan
 
                         $$ = 0;
 
-                DBG_PRINT}}
+                }}
         | WITH FULLSCAN
                 {{ DBG_TRACE_GRAMMAR(opt_with_fullscan, |  WITH FULLSCAN);
 
                         $$ = 1;
 
-                DBG_PRINT}}
+                }}
         ;
 
 opt_of_to_eq
@@ -5076,7 +5048,7 @@ opt_level_spec
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| OFF_
 		{{ DBG_TRACE_GRAMMAR(opt_level_spec, | OFF_ );
 
@@ -5086,28 +5058,28 @@ opt_level_spec
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| unsigned_integer
 		{{ DBG_TRACE_GRAMMAR(opt_level_spec, |  unsigned_integer);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| param_
 		{{ DBG_TRACE_GRAMMAR(opt_level_spec, |  param_ );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| host_param_input
 		{{ DBG_TRACE_GRAMMAR(opt_level_spec, |  host_param_input);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 char_string_literal_list
@@ -5117,14 +5089,14 @@ char_string_literal_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| char_string_literal
 		{{ DBG_TRACE_GRAMMAR(char_string_literal_list, | char_string_literal);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 table_spec_list
@@ -5134,14 +5106,14 @@ table_spec_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| table_spec
 		{{ DBG_TRACE_GRAMMAR(table_spec_list, |  table_spec);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 extended_table_spec_list
@@ -5155,7 +5127,7 @@ extended_table_spec_list
 			SET_CONTAINER_2 (ctn, parser_make_link (n1, n2), FROM_NUMBER (number));
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| extended_table_spec_list join_table_spec
 		{{ DBG_TRACE_GRAMMAR(extended_table_spec_list, | extended_table_spec_list join_table_spec);
 
@@ -5165,7 +5137,7 @@ extended_table_spec_list
 			SET_CONTAINER_2 (ctn, parser_make_link (n1, n2), FROM_NUMBER (1));
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| '(' extended_table_spec_list join_table_spec ')'
 		{{ DBG_TRACE_GRAMMAR(extended_table_spec_list, | '(' extended_table_spec_list join_table_spec ')');
 
@@ -5175,7 +5147,7 @@ extended_table_spec_list
 			SET_CONTAINER_2 (ctn, parser_make_link (n1, n2), FROM_NUMBER (1));
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| table_spec
 		{{ DBG_TRACE_GRAMMAR(extended_table_spec_list, | table_spec);
 
@@ -5183,7 +5155,7 @@ extended_table_spec_list
 			SET_CONTAINER_2 (ctn, $1, FROM_NUMBER (0));
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	;
 
 join_table_spec
@@ -5196,7 +5168,7 @@ join_table_spec
 			$$ = sopt;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| opt_of_inner_left_right JOIN table_spec join_condition
 		{{ DBG_TRACE_GRAMMAR(join_table_spec, | opt_of_inner_left_right JOIN table_spec join_condition);
 
@@ -5225,7 +5197,7 @@ join_table_spec
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 			parser_restore_pseudoc ();
 
-		DBG_PRINT}}
+		}}
 	| NATURAL opt_of_inner_left_right JOIN table_spec
 		{{ DBG_TRACE_GRAMMAR(join_table_spec, | NATURAL opt_of_inner_left_right JOIN table_spec );
 
@@ -5240,7 +5212,7 @@ join_table_spec
 			  }
 			$$ = sopt;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
 	;
 
 join_condition
@@ -5248,13 +5220,13 @@ join_condition
 		{{ DBG_TRACE_GRAMMAR(join_condition, : );
 			parser_save_and_set_pseudoc (0);
 			$$ = NULL;   /* just return NULL */
-		DBG_PRINT}}
+		}}
 	| ON_
 		{{
 			parser_save_and_set_pseudoc (0);
 			parser_save_and_set_wjc (1);
 			parser_save_and_set_ic (1);
-		DBG_PRINT}}
+		}}
 	  search_condition
 		{{ DBG_TRACE_GRAMMAR(join_condition, | ON_ search_condition);
 			PT_NODE *condition = $3;
@@ -5275,7 +5247,7 @@ join_condition
 
 			$$ = condition;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
 
 
 	;
@@ -5285,25 +5257,25 @@ opt_of_inner_left_right
 		{{ DBG_TRACE_GRAMMAR(opt_of_inner_left_right, : );
 			$$ = PT_JOIN_INNER;
 
-		DBG_PRINT}}
+		}}
 	| INNER opt_outer
 		{{ DBG_TRACE_GRAMMAR(opt_of_inner_left_right, | INNER opt_outer );
 
 			$$ = PT_JOIN_INNER;
 
-		DBG_PRINT}}
+		}}
 	| LEFT opt_outer
 		{{ DBG_TRACE_GRAMMAR(opt_of_inner_left_right, | LEFT opt_outer );
 
 			$$ = PT_JOIN_LEFT_OUTER;
 
-		DBG_PRINT}}
+		}}
 	| RIGHT opt_outer
 		{{ DBG_TRACE_GRAMMAR(opt_of_inner_left_right, |  RIGHT opt_outer );
 
 			$$ = PT_JOIN_RIGHT_OUTER;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_outer
@@ -5318,14 +5290,14 @@ table_spec
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| original_table_spec %dprec 2
 		{{ DBG_TRACE_GRAMMAR(table_spec, | original_table_spec);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 
 original_table_spec
 	: class_spec opt_as_identifier_attr_name opt_table_spec_index_hint_list
@@ -5430,7 +5402,7 @@ original_table_spec
 			$$ = ent;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| meta_class_spec opt_as_identifier_attr_name
 		{{ DBG_TRACE_GRAMMAR(original_table_spec, | meta_class_spec opt_as_identifier_attr_name);
 
@@ -5457,7 +5429,7 @@ original_table_spec
 			$$ = ent;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| subquery opt_as_identifier_attr_name
 		{{ DBG_TRACE_GRAMMAR(original_table_spec, | subquery opt_as_identifier_attr_name);
 
@@ -5487,7 +5459,7 @@ original_table_spec
 			$$ = ent;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| TABLE '(' expression_ ')' opt_as_identifier_attr_name
 		{{ DBG_TRACE_GRAMMAR(original_table_spec, | TABLE '(' expression_ ')' opt_as_identifier_attr_name);
 
@@ -5505,7 +5477,7 @@ original_table_spec
 			$$ = ent;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| JSON_TABLE json_table_rule opt_as identifier
 		{{ DBG_TRACE_GRAMMAR(original_table_spec, | JSON_TABLE json_table_rule opt_as identifier);
 			PT_NODE *ent = parser_new_node (this_parser, PT_SPEC);
@@ -5518,7 +5490,7 @@ original_table_spec
 			$$ = ent;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
         | DBLINK  '('  dblink_expr ')'   dblink_identifier_col_attrs 
                 {{ DBG_TRACE_GRAMMAR(original_table_spec, | DBLINK  '('  dblink_expr ')' dblink_identifier_col_attrs );                       
 			PT_NODE *ent = parser_new_node (this_parser, PT_SPEC);
@@ -5531,7 +5503,7 @@ original_table_spec
 			  }
 			$$ = ent;                        
 		        PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
 	;
 
 opt_table_spec_index_hint
@@ -5548,7 +5520,7 @@ opt_table_spec_index_hint
 			$$ = $4;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| FORCE index_or_key '(' identifier_list ')'
 		{{ DBG_TRACE_GRAMMAR(opt_table_spec_index_hint, | FORCE index_or_key '(' identifier_list ')' );
 
@@ -5563,7 +5535,7 @@ opt_table_spec_index_hint
 			$$ = $4;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| IGNORE_ index_or_key '(' identifier_list ')'
 		{{ DBG_TRACE_GRAMMAR(opt_table_spec_index_hint, | IGNORE_ index_or_key '(' identifier_list ')' );
 
@@ -5578,7 +5550,7 @@ opt_table_spec_index_hint
 			  $$ = $4;
 			  PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_table_spec_index_hint_list
@@ -5588,21 +5560,21 @@ opt_table_spec_index_hint_list
 			$$ = 0;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| opt_table_spec_index_hint_list ',' opt_table_spec_index_hint
 		{{ DBG_TRACE_GRAMMAR(opt_table_spec_index_hint_list, | opt_table_spec_index_hint_list ',' opt_table_spec_index_hint );
 
 			$$ = parser_make_link($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos);
 
-		DBG_PRINT}}
+		}}
 	| opt_table_spec_index_hint
 		{{ DBG_TRACE_GRAMMAR(opt_table_spec_index_hint_list, | opt_table_spec_index_hint );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos);
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_as_identifier_attr_name
@@ -5613,7 +5585,7 @@ opt_as_identifier_attr_name
 			SET_CONTAINER_2 (ctn, NULL, NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| opt_as identifier '(' identifier_list ')'
 		{{ DBG_TRACE_GRAMMAR(opt_as_identifier_attr_name, | opt_as identifier '(' identifier_list ')' );
 
@@ -5621,7 +5593,7 @@ opt_as_identifier_attr_name
 			SET_CONTAINER_2 (ctn, $2, $4);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| opt_as identifier
 		{{ DBG_TRACE_GRAMMAR(opt_as_identifier_attr_name, | opt_as identifier);
 
@@ -5629,7 +5601,7 @@ opt_as_identifier_attr_name
 			SET_CONTAINER_2 (ctn, $2, NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_as
@@ -5644,14 +5616,14 @@ class_spec_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| class_spec_without_server_name
 		{{ DBG_TRACE_GRAMMAR(class_spec_list, | class_spec );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 class_spec_without_server_name
@@ -5661,14 +5633,14 @@ class_spec_without_server_name
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| '(' only_all_class_spec_list ')'
 		{{ DBG_TRACE_GRAMMAR(class_spec, | '(' only_all_class_spec_list ')' );
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 class_spec
@@ -5678,21 +5650,21 @@ class_spec
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| only_all_class_spec_with_server
 		{{ DBG_TRACE_GRAMMAR(class_spec, : only_all_class_spec_with_server );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| '(' only_all_class_spec_list ')'
 		{{ DBG_TRACE_GRAMMAR(class_spec, | '(' only_all_class_spec_list ')' );
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 only_all_class_spec_list
@@ -5706,14 +5678,14 @@ only_all_class_spec_list
 			$$ = p;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| only_all_class_spec
 		{{ DBG_TRACE_GRAMMAR(only_all_class_spec_list, | only_all_class_spec );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 meta_class_spec
@@ -5731,7 +5703,7 @@ meta_class_spec
 			$$ = ocs;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 only_all_class_spec_with_server
@@ -5750,7 +5722,7 @@ only_all_class_spec_with_server
 
 			$$ = ocs;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
 	;
 
 only_all_class_spec
@@ -5773,7 +5745,7 @@ only_all_class_spec
 			$$ = ocs;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| ALL class_name '(' EXCEPT class_spec_list ')'
 		{{ DBG_TRACE_GRAMMAR(only_all_class_spec, | ALL class_name '(' EXCEPT class_spec_list ')' );
 
@@ -5789,7 +5761,7 @@ only_all_class_spec
 			$$ = acs;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| ALL class_name
 		{{ DBG_TRACE_GRAMMAR(only_all_class_spec, | class_name);
 
@@ -5804,7 +5776,7 @@ only_all_class_spec
 			$$ = acs;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 class_name_with_server_name
@@ -5816,7 +5788,7 @@ class_name_with_server_name
                 PT_NAME_INFO_CLEAR_FLAG($1, PT_NAME_INFO_USER_SPECIFIED);
                 SET_CONTAINER_2 (ctn, $1, $3);
                 $$ = ctn;
-                DBG_PRINT}}
+                }}
         ;
 
 object_name
@@ -5835,14 +5807,14 @@ object_name
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| identifier
 		{{ DBG_TRACE_GRAMMAR(object_name, | identifier);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 user_specified_name_without_dot
@@ -5863,7 +5835,7 @@ user_specified_name_without_dot
 			$$ = name;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| identifier_without_dot
 		{{ DBG_TRACE_GRAMMAR(user_specified_name_without_dot, | identifier_without_dot);
 
@@ -5877,7 +5849,7 @@ user_specified_name_without_dot
 			$$ = name;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 user_specified_name
@@ -5894,7 +5866,7 @@ user_specified_name
 			$$ = name;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 class_name_without_dot
@@ -5914,14 +5886,14 @@ class_name_list
 			$$ = parser_make_link($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| class_name
 		{{ DBG_TRACE_GRAMMAR(class_name_list, | class_name);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 index_name
@@ -5938,7 +5910,7 @@ index_name
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 trigger_name_without_dot
@@ -5958,14 +5930,14 @@ trigger_name_list
 			$$ = parser_make_link($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| trigger_name
 		{{
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 serial_name_without_dot
@@ -6013,14 +5985,14 @@ procedure_or_function_name_list
 			$$ = parser_make_link($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| procedure_or_function_name
 		{{ DBG_TRACE_GRAMMAR(procedure_or_function_name_list, : procedure_or_function_name);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_partition_spec
@@ -6032,7 +6004,7 @@ opt_partition_spec
 		{{ DBG_TRACE_GRAMMAR(opt_partition_spec, | PARTITION '(' identifier ')' );
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
 	;
 
 opt_class_type
@@ -6041,31 +6013,31 @@ opt_class_type
 
 			$$ = PT_EMPTY;
 
-		DBG_PRINT}}
+		}}
 	| VCLASS
 		{{ DBG_TRACE_GRAMMAR(opt_class_type, | VCLASS);
 
 			$$ = PT_VCLASS;
 
-		DBG_PRINT}}
+		}}
 	| VIEW
 		{{ DBG_TRACE_GRAMMAR(opt_class_type, | VIEW );
 
 			$$ = PT_VCLASS;
 
-		DBG_PRINT}}
+		}}
 	| CLASS
 		{{ DBG_TRACE_GRAMMAR(opt_class_type, | CLASS );
 
 			$$ = PT_CLASS;
 
-		DBG_PRINT}}
+		}}
 	| TABLE
 		{{ DBG_TRACE_GRAMMAR(opt_class_type, | TABLE );
 
 			$$ = PT_CLASS;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_table_type
@@ -6074,19 +6046,19 @@ opt_table_type
 
 			$$ = PT_EMPTY;
 
-		DBG_PRINT}}
+		}}
 	| CLASS
 		{{ DBG_TRACE_GRAMMAR(opt_table_type, | CLASS );
 
 			$$ = PT_CLASS;
 
-		DBG_PRINT}}
+		}}
 	| TABLE
 		{{ DBG_TRACE_GRAMMAR(opt_table_type, | TABLE );
 
 			$$ = PT_CLASS;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_cascade
@@ -6095,13 +6067,13 @@ opt_cascade
 
 			$$ = false;
 
-		DBG_PRINT}}
+		}}
 	| CASCADE
 		{{ DBG_TRACE_GRAMMAR(opt_cascade, | CASCADE );
 
 			$$ = true;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_cascade_constraints
@@ -6110,13 +6082,13 @@ opt_cascade_constraints
 
 			$$ = false;
 
-		DBG_PRINT}}
+		}}
 	| CASCADE CONSTRAINTS
 		{{ DBG_TRACE_GRAMMAR(opt_cascade_constraints, | CASCADE CONSTRAINTS );
 
 			$$ = true;
 
-		DBG_PRINT}}
+		}}
 	;
 
 alter_clause_for_alter_list
@@ -6139,7 +6111,7 @@ alter_clause_for_alter_list
 			    alt->info.alter.code = PT_CHANGE_OWNER;
 			    alt->info.alter.alter_clause.user.user_name = $3;
 			  }
-		DBG_PRINT}}
+		}}
 	| charset_spec opt_collation
 		{{ DBG_TRACE_GRAMMAR(alter_clause_for_alter_list, | charset_spec opt_collation );
 			PT_NODE *node = parser_get_alter_node();
@@ -6169,7 +6141,7 @@ alter_clause_for_alter_list
 				  }
 			      }
 			  }
-		DBG_PRINT}}
+		}}
 	| collation_spec
 		{{ DBG_TRACE_GRAMMAR(alter_clause_for_alter_list, | collation_spec );
 			PT_NODE *node = parser_get_alter_node();
@@ -6193,7 +6165,7 @@ alter_clause_for_alter_list
 				node->info.alter.alter_clause.collation.collation_id = coll_id;
 			      }
 			  }
-		DBG_PRINT}}
+		}}
 	| class_comment_spec
 		{{ DBG_TRACE_GRAMMAR(alter_clause_for_alter_list, | class_comment_spec );
 			PT_NODE *alter_node = parser_get_alter_node();
@@ -6203,7 +6175,7 @@ alter_clause_for_alter_list
 				alter_node->info.alter.code = PT_CHANGE_TABLE_COMMENT;
 				alter_node->info.alter.alter_clause.comment.tbl_comment = $1;
 			  }
-		DBG_PRINT}}
+		}}
 	;
 
 alter_clause_cubrid_specific
@@ -6224,7 +6196,7 @@ alter_clause_cubrid_specific
 			    alt->info.alter.super.resolution_list = $1;
 			  }
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_resolution_list_for_alter
@@ -6243,7 +6215,7 @@ resolution_list_for_alter
 			    alt->info.alter.super.resolution_list = $1;
 			  }
 
-		DBG_PRINT}}
+		}}
 	;
 
 alter_rename_clause_mysql_specific
@@ -6258,7 +6230,7 @@ alter_rename_clause_mysql_specific
 			    node->info.alter.alter_clause.rename.new_name = $2;
 			  }
 
-		DBG_PRINT}}
+		}}
 	;
 
 alter_auto_increment_mysql_specific
@@ -6282,7 +6254,7 @@ alter_auto_increment_mysql_specific
 			    node->info.alter.alter_clause.auto_increment.start_value = val;
 			  }
 
-	      DBG_PRINT}}
+	      }}
 	;
 
 alter_rename_clause_allow_multiple
@@ -6309,7 +6281,7 @@ alter_rename_clause_allow_multiple
 			    node->info.alter.alter_clause.rename.old_name = $3;
 			  }
 
-		DBG_PRINT}}
+		}}
 	;
 
 alter_rename_clause_cubrid_specific
@@ -6332,7 +6304,7 @@ alter_rename_clause_cubrid_specific
 			    node->info.alter.alter_clause.rename.old_name = $2;
 			  }
 
-		DBG_PRINT}}
+		}}
 	| File file_path_name AS file_path_name
 		{{ DBG_TRACE_GRAMMAR(alter_rename_clause_cubrid_specific, | File file_path_name AS file_path_name);
 
@@ -6346,7 +6318,7 @@ alter_rename_clause_cubrid_specific
 			    node->info.alter.alter_clause.rename.old_name = $2;
 			  }
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_of_attr_column_method
@@ -6355,24 +6327,24 @@ opt_of_attr_column_method
 
 			$$ = PT_EMPTY;
 
-		DBG_PRINT}}
+		}}
 	| ATTRIBUTE
 		{{ DBG_TRACE_GRAMMAR(opt_of_attr_column_method, | ATTRIBUTE );
 
 			$$ = PT_ATTRIBUTE;
 
-		DBG_PRINT}}
+		}}
 	| COLUMN
 		{{ DBG_TRACE_GRAMMAR(opt_of_attr_column_method, | COLUMN );
 
 			$$ = PT_ATTRIBUTE;
 
-		DBG_PRINT}}
+		}}
 	| METHOD
 		{{ DBG_TRACE_GRAMMAR(opt_of_attr_column_method, | METHOD );
 
 			$$ = PT_METHOD;
-		DBG_PRINT}}
+		}}
 	;
 
 opt_class
@@ -6381,13 +6353,13 @@ opt_class
 
 			$$ = 0;
 
-		DBG_PRINT}}
+		}}
 	| CLASS
 		{{ DBG_TRACE_GRAMMAR(opt_class, | CLASS );
 
 			$$ = 1;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_identifier
@@ -6396,14 +6368,14 @@ opt_identifier
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| identifier
 		{{ DBG_TRACE_GRAMMAR(opt_identifier, | identifier );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 alter_add_clause_for_alter_list
@@ -6420,7 +6392,7 @@ alter_add_clause_for_alter_list
 			    node->info.alter.alter_clause.attr_mthd.attr_def_list = $5;
 			  }
 
-		DBG_PRINT}}
+		}}
 	| CLASS ATTRIBUTE
 		{ parser_attr_type = PT_META_ATTR; }
 	  attr_def
@@ -6434,7 +6406,7 @@ alter_add_clause_for_alter_list
 			    node->info.alter.alter_clause.attr_mthd.attr_def_list = $4;
 			  }
 
-		DBG_PRINT}}
+		}}
 	| opt_of_column_attribute
 	  		{ allow_attribute_ordering = true; }
 	  '(' attr_def_list ')'
@@ -6448,7 +6420,7 @@ alter_add_clause_for_alter_list
 			    node->info.alter.alter_clause.attr_mthd.attr_def_list = $4;
 			  }
 
-		DBG_PRINT}}
+		}}
 	| opt_of_column_attribute
 			{ allow_attribute_ordering = true; }
 	  attr_def
@@ -6462,7 +6434,7 @@ alter_add_clause_for_alter_list
 			    node->info.alter.alter_clause.attr_mthd.attr_def_list = $3;
 			  }
 
-		DBG_PRINT}}
+		}}
 	;
 
 alter_add_clause_cubrid_specific
@@ -6477,7 +6449,7 @@ alter_add_clause_cubrid_specific
 			    node->info.alter.alter_clause.attr_mthd.mthd_file_list = $2;
 			  }
 
-		DBG_PRINT}}
+		}}
 	| METHOD method_def_list
 		{{ DBG_TRACE_GRAMMAR(alter_add_clause_cubrid_specific, | METHOD method_def_list);
 
@@ -6488,7 +6460,7 @@ alter_add_clause_cubrid_specific
 			    node->info.alter.alter_clause.attr_mthd.mthd_def_list = $2;
 			  }
 
-		DBG_PRINT}}
+		}}
 	| METHOD method_def_list File method_file_list
 		{{ DBG_TRACE_GRAMMAR(alter_add_clause_cubrid_specific, | METHOD method_def_list File method_file_list);
 
@@ -6501,7 +6473,7 @@ alter_add_clause_cubrid_specific
 			    node->info.alter.alter_clause.attr_mthd.mthd_def_list = $2;
 			  }
 
-		DBG_PRINT}}
+		}}
 	| SUPERCLASS only_class_name_list
 		{{ DBG_TRACE_GRAMMAR(alter_add_clause_cubrid_specific, | SUPERCLASS only_class_name_list );
 
@@ -6513,7 +6485,7 @@ alter_add_clause_cubrid_specific
 			    node->info.alter.super.sup_class_list = $2;
 			  }
 
-		DBG_PRINT}}
+		}}
 	| QUERY csql_query opt_vclass_comment_spec
 		{{ DBG_TRACE_GRAMMAR(alter_add_clause_cubrid_specific, | QUERY csql_query opt_vclass_comment_spec );
 
@@ -6526,7 +6498,7 @@ alter_add_clause_cubrid_specific
 			    node->info.alter.alter_clause.query.view_comment = $3;
 			  }
 
-		DBG_PRINT}}
+		}}
 	| CLASS ATTRIBUTE
 		{ parser_attr_type = PT_META_ATTR; }
 	  attr_def_list_with_commas
@@ -6540,7 +6512,7 @@ alter_add_clause_cubrid_specific
 			    node->info.alter.alter_clause.attr_mthd.attr_def_list = $4;
 			  }
 
-		DBG_PRINT}}
+		}}
 	| opt_of_column_attribute attr_def_list_with_commas
 		{{ DBG_TRACE_GRAMMAR(alter_add_clause_cubrid_specific, | opt_of_column_attribute attr_def_list_with_commas );
 
@@ -6551,7 +6523,7 @@ alter_add_clause_cubrid_specific
 			    node->info.alter.alter_clause.attr_mthd.attr_def_list = $2;
 			  }
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_of_column_attribute
@@ -6568,7 +6540,7 @@ add_partition_clause
 			node->info.alter.code = PT_ADD_HASHPARTITION;
 			node->info.alter.alter_clause.partition.size = $2;
 
-		DBG_PRINT}}
+		}}
 	| '(' partition_def_list ')'
 		{{ DBG_TRACE_GRAMMAR(add_partition_clause, | '(' partition_def_list ')' );
 
@@ -6576,7 +6548,7 @@ add_partition_clause
 			node->info.alter.code = PT_ADD_PARTITION;
 			node->info.alter.alter_clause.partition.parts = $2;
 
-		DBG_PRINT}}
+		}}
 	;
 
 alter_drop_clause_mysql_specific
@@ -6593,7 +6565,7 @@ alter_drop_clause_mysql_specific
 			    node->info.alter.constraint_list = $4;
 			  }
 
-		DBG_PRINT}}
+		}}
 	| PRIMARY KEY
 		{{ DBG_TRACE_GRAMMAR(alter_drop_clause_mysql_specific, | PRIMARY KEY );
 
@@ -6604,7 +6576,7 @@ alter_drop_clause_mysql_specific
 			    node->info.alter.code = PT_DROP_PRIMARY_CLAUSE;
 			  }
 
-		DBG_PRINT}}
+		}}
 	| FOREIGN KEY identifier
 		{{ DBG_TRACE_GRAMMAR(alter_drop_clause_mysql_specific, | FOREIGN KEY identifier );
 
@@ -6616,7 +6588,7 @@ alter_drop_clause_mysql_specific
 			    node->info.alter.constraint_list = $3;
 			  }
 
-		DBG_PRINT}}
+		}}
 	;
 
 alter_drop_clause_for_alter_list
@@ -6631,7 +6603,7 @@ alter_drop_clause_for_alter_list
 			    node->info.alter.alter_clause.attr_mthd.attr_mthd_name_list = $2;
 			  }
 
-		DBG_PRINT}}
+		}}
 	| CONSTRAINT identifier
 		{{ DBG_TRACE_GRAMMAR(alter_drop_clause_for_alter_list, | CONSTRAINT identifier );
 
@@ -6643,7 +6615,7 @@ alter_drop_clause_for_alter_list
 			    node->info.alter.constraint_list = $2;
 			  }
 
-		DBG_PRINT}}
+		}}
 	| PARTITION identifier_list
 		{{ DBG_TRACE_GRAMMAR(alter_drop_clause_for_alter_list, | PARTITION identifier_list );
 
@@ -6655,7 +6627,7 @@ alter_drop_clause_for_alter_list
 			    node->info.alter.alter_clause.partition.name_list = $2;
 			  }
 
-		DBG_PRINT}}
+		}}
 	;
 
 alter_drop_clause_cubrid_specific
@@ -6670,7 +6642,7 @@ alter_drop_clause_cubrid_specific
 			    node->info.alter.alter_clause.attr_mthd.attr_mthd_name_list = $2;
 			  }
 
-		DBG_PRINT}}
+		}}
 	| File method_file_list
 		{{ DBG_TRACE_GRAMMAR(alter_drop_clause_cubrid_specific, | File method_file_list);
 
@@ -6682,7 +6654,7 @@ alter_drop_clause_cubrid_specific
 			    node->info.alter.alter_clause.attr_mthd.mthd_file_list = $2;
 			  }
 
-		DBG_PRINT}}
+		}}
 	| SUPERCLASS only_class_name_list
 		{{ DBG_TRACE_GRAMMAR(alter_drop_clause_cubrid_specific, | SUPERCLASS only_class_name_list);
 
@@ -6694,7 +6666,7 @@ alter_drop_clause_cubrid_specific
 			    node->info.alter.super.sup_class_list = $2;
 			  }
 
-		DBG_PRINT}}
+		}}
 	| QUERY query_number_list
 		{{ DBG_TRACE_GRAMMAR(alter_drop_clause_cubrid_specific, | QUERY query_number_list);
 
@@ -6706,7 +6678,7 @@ alter_drop_clause_cubrid_specific
 			    node->info.alter.alter_clause.query.query_no_list = $2;
 			  }
 
-		DBG_PRINT}}
+		}}
 	| QUERY
 		{{ DBG_TRACE_GRAMMAR(alter_drop_clause_cubrid_specific, | QUERY );
 
@@ -6718,7 +6690,7 @@ alter_drop_clause_cubrid_specific
 			    node->info.alter.alter_clause.query.query_no_list = NULL;
 			  }
 
-		DBG_PRINT}}
+		}}
 	;
 
 normal_or_class_attr_list_with_commas
@@ -6728,14 +6700,14 @@ normal_or_class_attr_list_with_commas
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| normal_or_class_attr ',' normal_or_class_attr
 		{{ DBG_TRACE_GRAMMAR(normal_or_class_attr_list_with_commas, | normal_or_class_attr ',' normal_or_class_attr);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 alter_modify_clause_for_alter_list
@@ -6754,7 +6726,7 @@ alter_modify_clause_for_alter_list
 			    /* no name change for MODIFY */
 			  }
 
-		DBG_PRINT}}
+		}}
 	| CLASS ATTRIBUTE
 	  { allow_attribute_ordering = true; }
 	  attr_def_one
@@ -6773,7 +6745,7 @@ alter_modify_clause_for_alter_list
 				info.attr_def.attr_type = PT_META_ATTR;
 			  }
 
-		DBG_PRINT}}
+		}}
 	;
 
 alter_change_clause_for_alter_list
@@ -6798,7 +6770,7 @@ alter_change_clause_for_alter_list
 			      node->info.alter.alter_clause.attr_mthd.attr_old_name->info.name.meta_class;
 			  }
 
-		DBG_PRINT}}
+		}}
 	;
 
 alter_change_clause_cubrid_specific
@@ -6813,7 +6785,7 @@ alter_change_clause_cubrid_specific
 			    node->info.alter.alter_clause.attr_mthd.mthd_def_list = $2;
 			  }
 
-		DBG_PRINT}}
+		}}
 	| QUERY unsigned_integer csql_query opt_vclass_comment_spec
 		{{ DBG_TRACE_GRAMMAR(alter_change_clause_cubrid_specific, | QUERY unsigned_integer csql_query opt_vclass_comment_spec);
 
@@ -6827,7 +6799,7 @@ alter_change_clause_cubrid_specific
 			    node->info.alter.alter_clause.query.view_comment = $4;
 			  }
 
-		DBG_PRINT}}
+		}}
 	| QUERY csql_query opt_vclass_comment_spec
 		{{ DBG_TRACE_GRAMMAR(alter_change_clause_cubrid_specific, | QUERY csql_query opt_vclass_comment_spec);
 
@@ -6841,7 +6813,7 @@ alter_change_clause_cubrid_specific
 			    node->info.alter.alter_clause.query.view_comment = $3;
 			  }
 
-		DBG_PRINT}}
+		}}
 	| File file_path_name AS file_path_name
 		{{ DBG_TRACE_GRAMMAR(alter_change_clause_cubrid_specific, | File file_path_name AS file_path_name);
 
@@ -6855,7 +6827,7 @@ alter_change_clause_cubrid_specific
 			    node->info.alter.alter_clause.rename.old_name = $2;
 			  }
 
-		DBG_PRINT}}
+		}}
 	;
 
 normal_or_class_attr
@@ -6870,7 +6842,7 @@ normal_or_class_attr
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 query_number_list
@@ -6880,14 +6852,14 @@ query_number_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| unsigned_integer
 		{{ DBG_TRACE_GRAMMAR(query_number_list, | unsigned_integer);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 alter_column_clause_mysql_specific
@@ -6981,7 +6953,7 @@ alter_column_clause_mysql_specific
 			    alter_node->info.alter.alter_clause.ch_attr_def.data_default_list = node;
 			  }
 
-		DBG_PRINT}}
+		}}
 	;
 
 normal_column_or_class_attribute
@@ -6996,7 +6968,7 @@ normal_column_or_class_attribute
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| CLASS ATTRIBUTE identifier
 		{{ DBG_TRACE_GRAMMAR(normal_column_or_class_attribute, | CLASS ATTRIBUTE identifier);
 
@@ -7008,7 +6980,7 @@ normal_column_or_class_attribute
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 insert_or_replace_stmt
@@ -7026,7 +6998,7 @@ insert_or_replace_stmt
 			$$ = ins;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| insert_name_clause insert_stmt_value_clause into_clause_opt
 		{{ DBG_TRACE_GRAMMAR(insert_or_replace_stmt, | insert_name_clause insert_stmt_value_clause into_clause_opt);
 
@@ -7041,7 +7013,7 @@ insert_or_replace_stmt
 			$$ = ins;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| replace_name_clause insert_stmt_value_clause into_clause_opt
 		{{ DBG_TRACE_GRAMMAR(insert_or_replace_stmt, | replace_name_clause insert_stmt_value_clause into_clause_opt);
 
@@ -7056,7 +7028,7 @@ insert_or_replace_stmt
 			$$ = ins;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| insert_set_stmt on_duplicate_key_update
 		{{ DBG_TRACE_GRAMMAR(insert_or_replace_stmt, | insert_set_stmt on_duplicate_key_update);
 
@@ -7069,7 +7041,7 @@ insert_or_replace_stmt
 			$$ = ins;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| insert_set_stmt into_clause_opt
 		{{ DBG_TRACE_GRAMMAR(insert_or_replace_stmt, | insert_set_stmt into_clause_opt);
 
@@ -7083,7 +7055,7 @@ insert_or_replace_stmt
 			$$ = ins;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| replace_set_stmt into_clause_opt
 		{{ DBG_TRACE_GRAMMAR(insert_or_replace_stmt, | replace_set_stmt into_clause_opt);
 
@@ -7097,7 +7069,7 @@ insert_or_replace_stmt
 			$$ = ins;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 insert_set_stmt
@@ -7176,7 +7148,7 @@ insert_set_stmt_header
 			$$ = ins;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 insert_assignment_list
@@ -7188,7 +7160,7 @@ insert_assignment_list
 
 			$$ = $1;
 
-		DBG_PRINT}}
+		}}
 	| insert_assignment_list ',' identifier '=' DEFAULT
 		{{ DBG_TRACE_GRAMMAR(insert_assignment_list, | insert_assignment_list ',' identifier '=' DEFAULT );
 			PT_NODE *arg = parser_copy_tree (this_parser, $3);
@@ -7203,7 +7175,7 @@ insert_assignment_list
 
 			$$ = $1;
 
-		DBG_PRINT}}
+		}}
 	| identifier '=' expression_
 		{{ DBG_TRACE_GRAMMAR(insert_assignment_list, | identifier '=' expression_ );
 
@@ -7212,7 +7184,7 @@ insert_assignment_list
 
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| identifier '=' DEFAULT
 		{{ DBG_TRACE_GRAMMAR(insert_assignment_list, | identifier '=' DEFAULT);
 
@@ -7228,7 +7200,7 @@ insert_assignment_list
 
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	;
 
 on_duplicate_key_update
@@ -7239,7 +7211,7 @@ on_duplicate_key_update
 			$$ = $5;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 insert_expression
@@ -7256,7 +7228,7 @@ insert_expression
 			$$ = ins;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| '(' insert_name_clause insert_expression_value_clause into_clause_opt ')'
 		{{ DBG_TRACE_GRAMMAR(insert_expression, | '(' insert_name_clause insert_expression_value_clause into_clause_opt ')');
 
@@ -7271,7 +7243,7 @@ insert_expression
 			$$ = ins;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 insert_name_clause
@@ -7332,7 +7304,7 @@ insert_name_clause_header
 			$$ = ins;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_attr_list
@@ -7341,20 +7313,20 @@ opt_attr_list
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| '(' ')'
 		{{ DBG_TRACE_GRAMMAR(opt_attr_list, | '(' ')' );
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| '(' identifier_list ')'
 		{{ DBG_TRACE_GRAMMAR(opt_attr_list, | '(' identifier_list ')' );
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_path_attr_list
@@ -7363,20 +7335,20 @@ opt_path_attr_list
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| '(' ')'
 		{{ DBG_TRACE_GRAMMAR(opt_path_attr_list, |  '(' ')' );
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| '(' simple_path_id_list ')'
 		{{ DBG_TRACE_GRAMMAR(opt_path_attr_list, | '(' simple_path_id_list ')' );
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 insert_stmt_value_clause
@@ -7386,7 +7358,7 @@ insert_stmt_value_clause
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| opt_with_clause
 	  csql_query_without_values_and_single_subquery
 		{{ DBG_TRACE_GRAMMAR(insert_stmt_value_clause, |  opt_with_clause csql_query_without_values_and_single_subquery);
@@ -7399,7 +7371,7 @@ insert_stmt_value_clause
 			$$ = nls;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| '(' opt_with_clause
 	  csql_query_without_values_query_no_with_clause ')'
 		{{ DBG_TRACE_GRAMMAR(insert_stmt_value_clause, |  '(' opt_with_clause csql_query_without_values_query_no_with_clause ')');
@@ -7411,7 +7383,7 @@ insert_stmt_value_clause
 			$$ = nls;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 insert_expression_value_clause
@@ -7421,7 +7393,7 @@ insert_expression_value_clause
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| DEFAULT opt_values
 		{{ DBG_TRACE_GRAMMAR(insert_expression_value_clause, | DEFAULT opt_values);
 
@@ -7429,7 +7401,7 @@ insert_expression_value_clause
 			$$ = nls;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 of_value_values
@@ -7452,21 +7424,21 @@ into_clause_opt
 		{{ DBG_TRACE_GRAMMAR(into_clause_opt, : );
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| INTO to_param
 		{{ DBG_TRACE_GRAMMAR(into_clause_opt, | INTO to_param );
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| TO to_param
 		{{ DBG_TRACE_GRAMMAR(into_clause_opt, | TO to_param );
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 insert_value_clause_list
@@ -7476,14 +7448,14 @@ insert_value_clause_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| insert_value_clause
 		{{ DBG_TRACE_GRAMMAR(insert_value_clause_list, | insert_value_clause);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 insert_value_clause
@@ -7494,7 +7466,7 @@ insert_value_clause
 			$$ = nls;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| '('')'
 		{{ DBG_TRACE_GRAMMAR(insert_value_clause, | '('')' );
 
@@ -7512,7 +7484,7 @@ insert_value_clause
 			$$ = nls;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| DEFAULT opt_values
 		{{ DBG_TRACE_GRAMMAR(insert_value_clause, | DEFAULT opt_values);
 
@@ -7520,7 +7492,7 @@ insert_value_clause
 			$$ = nls;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 insert_value_list
@@ -7530,14 +7502,14 @@ insert_value_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| insert_value
 		{{ DBG_TRACE_GRAMMAR(insert_value_list, | insert_value);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 insert_value
@@ -7547,14 +7519,14 @@ insert_value
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| normal_expression
 		{{ DBG_TRACE_GRAMMAR(insert_value, | normal_expression);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| DEFAULT
 		{{ DBG_TRACE_GRAMMAR(insert_value, | DEFAULT);
 
@@ -7564,7 +7536,7 @@ insert_value
 			$$ = parser_make_expression (this_parser, PT_DEFAULTF, NULL, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 show_stmt
@@ -7582,7 +7554,7 @@ show_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SHOW
 	  opt_full
 	  TABLES
@@ -7600,7 +7572,7 @@ show_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SHOW
 	  opt_full
 	  TABLES
@@ -7618,7 +7590,7 @@ show_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SHOW
 	  opt_full
 	  COLUMNS
@@ -7637,7 +7609,7 @@ show_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SHOW
 	  opt_full
 	  COLUMNS
@@ -7659,7 +7631,7 @@ show_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SHOW
 	  opt_full
 	  COLUMNS
@@ -7681,7 +7653,7 @@ show_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| of_describe_desc_explain
 	  class_name
 		{{ DBG_TRACE_GRAMMAR(show_stmt, | of_describe_desc_explain class_name);
@@ -7695,7 +7667,7 @@ show_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| of_describe_desc_explain
 	  class_name
 	  identifier
@@ -7710,7 +7682,7 @@ show_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| of_describe_desc_explain
 	  class_name
 	  char_string_literal
@@ -7731,7 +7703,7 @@ show_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SHOW
 	  COLLATION
 		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW COLLATION);
@@ -7743,7 +7715,7 @@ show_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SHOW
 	  COLLATION
 	  LIKE
@@ -7761,7 +7733,7 @@ show_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SHOW
 	  COLLATION
 	  WHERE
@@ -7778,7 +7750,7 @@ show_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SHOW
 	  CREATE
 	  TABLE
@@ -7791,7 +7763,7 @@ show_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SHOW
 	  CREATE
 	  VIEW
@@ -7806,7 +7778,7 @@ show_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SHOW
 	  GRANTS
 	  For
@@ -7824,7 +7796,7 @@ show_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SHOW
 	  GRANTS
 	  opt_for_current_user
@@ -7837,7 +7809,7 @@ show_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SHOW
 	  of_index_indexes_keys
 	  of_from_in
@@ -7851,7 +7823,7 @@ show_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
 	| SHOW EXEC STATISTICS ALL
 		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW EXEC STATISTICS ALL);
 			PT_NODE *node = NULL;
@@ -7861,7 +7833,7 @@ show_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SHOW EXEC STATISTICS
 		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW EXEC STATISTICS);
 			PT_NODE *node = NULL;
@@ -7871,7 +7843,7 @@ show_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SHOW TRACE
 		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW TRACE);
 			PT_NODE *node = NULL;
@@ -7880,7 +7852,7 @@ show_stmt
 
 			$$ = node;
 
-		DBG_PRINT}}
+		}}
 	| SHOW show_type
 		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW show_type);
 			int type = $2;
@@ -7889,7 +7861,7 @@ show_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SHOW show_type_of_like LIKE expression_
 		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW show_type_of_like LIKE expression_);
 
@@ -7902,7 +7874,7 @@ show_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SHOW show_type_of_where WHERE search_condition
 		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW show_type_of_where WHERE search_condition);
 			const int like_where_syntax = 2;  /* is WHERE */
@@ -7914,7 +7886,7 @@ show_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SHOW show_type_arg1 OF arg_value
 		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW show_type_arg1 OF arg_value);
 			int type = $2;
@@ -7924,7 +7896,7 @@ show_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SHOW show_type_arg1_opt opt_arg_value
 		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW show_type_arg1_opt opt_arg_value);
 			PT_NODE *node = NULL;
@@ -7936,7 +7908,7 @@ show_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SHOW show_type_arg_named of_or_where named_args
 		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW show_type_arg_named of_or_where named_args);
 			PT_NODE *node = NULL;
@@ -7948,7 +7920,7 @@ show_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SHOW show_type_id OF class_name
 		{{
 			int type = $2;
@@ -7959,7 +7931,7 @@ show_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SHOW show_type_id_dot_id OF class_name DOT identifier
 		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW show_type_id_dot_id OF class_name DOT identifier);
 			int type = $2;
@@ -7971,7 +7943,7 @@ show_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 kill_stmt
@@ -7987,7 +7959,7 @@ kill_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| KILL kill_type arg_value_list
 		{{ DBG_TRACE_GRAMMAR(kill_stmt, | KILL kill_type arg_value_list);
 			int type = $2;
@@ -8002,7 +7974,7 @@ kill_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 show_type
@@ -8179,11 +8151,11 @@ named_args
 	: named_arg
 		{{ DBG_TRACE_GRAMMAR(named_args, | named_arg);
 			$$ = $1;
-		DBG_PRINT}}
+		}}
 	| named_args AND named_arg
 		{{ DBG_TRACE_GRAMMAR(named_args, | named_args AND named_arg);
 			$$ = parser_make_link ($1, $3);
-		DBG_PRINT}}
+		}}
 	;
 
 named_arg
@@ -8193,7 +8165,7 @@ named_arg
 			node->info.named_arg.name = $1;
 			node->info.named_arg.value = $3;
 			$$ = node;
-		DBG_PRINT}}
+		}}
 	;
 
 opt_arg_value
@@ -8218,29 +8190,29 @@ arg_value_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| arg_value
 		{{ DBG_TRACE_GRAMMAR(arg_value_list, | arg_value);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 arg_value
 	: char_string_literal
 		{{ DBG_TRACE_GRAMMAR(arg_value, : char_string_literal);
 			$$ = $1;
-		DBG_PRINT}}
+		}}
 	| unsigned_integer
 		{{ DBG_TRACE_GRAMMAR(arg_value, | unsigned_integer);
 			$$ = $1;
-		DBG_PRINT}}
+		}}
 	| identifier
 		{{ DBG_TRACE_GRAMMAR(arg_value, | identifier);
 			$$ = $1;
-		DBG_PRINT}}
+		}}
 	;
 
 opt_full
@@ -8249,13 +8221,13 @@ opt_full
 
 			$$ = 0;
 
-		DBG_PRINT}}
+		}}
 	| FULL
 		{{ DBG_TRACE_GRAMMAR(arg_vopt_fullalue, | FULL);
 
 			$$ = 1;
 
-		DBG_PRINT}}
+		}}
 	;
 
 of_from_in
@@ -8398,7 +8370,7 @@ update_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| update_head
 	  OBJECT
 	  from_param
@@ -8416,7 +8388,7 @@ update_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 
@@ -8428,24 +8400,22 @@ opt_of_where_cursor
 			SET_CONTAINER_2 (ctn, 0, NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| WHERE
 		{ DBG_TRACE_GRAMMAR(opt_of_where_cursor, | WHERE );
 			parser_save_and_set_ic(1);
-			DBG_PRINT
-		}
+			}
 	  search_condition
 	  	{
 			parser_restore_ic();
-			DBG_PRINT
-		}
+			}
 		{{ DBG_TRACE_GRAMMAR(opt_of_where_cursor, search_condition);
 
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (1), $3);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| WHERE CURRENT OF identifier
 		{{ DBG_TRACE_GRAMMAR(opt_of_where_cursor, | WHERE CURRENT OF identifier);
 
@@ -8453,7 +8423,7 @@ opt_of_where_cursor
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (0), $4);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_as_identifier
@@ -8462,21 +8432,21 @@ opt_as_identifier
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| AS identifier
 		{{ DBG_TRACE_GRAMMAR(opt_as_identifier, | AS identifier);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| identifier
 		{{ DBG_TRACE_GRAMMAR(opt_as_identifier, | identifier);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 update_assignment_list
@@ -8486,13 +8456,13 @@ update_assignment_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| update_assignment
 		{{ DBG_TRACE_GRAMMAR(update_assignment_list, | update_assignment);
 
 			$$ = $1;
 
-		DBG_PRINT}}
+		}}
 	;
 
 update_assignment
@@ -8502,7 +8472,7 @@ update_assignment
 			$$ = parser_make_expression (this_parser, PT_ASSIGN, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| simple_path_id '=' DEFAULT
 		{{ DBG_TRACE_GRAMMAR("update_assignment", "| simple_path_id '=' DEFAULT ");
 
@@ -8516,7 +8486,7 @@ update_assignment
 			$$ = parser_make_expression (this_parser, PT_ASSIGN, $1, node_df, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| paren_path_expression_set '=' primary_w_collate
 		{{ DBG_TRACE_GRAMMAR(update_assignment, | paren_path_expression_set '=' primary_w_collate);
 
@@ -8625,7 +8595,7 @@ update_assignment
 			      }
 			  }
 
-		DBG_PRINT}}
+		}}
 	;
 
 paren_path_expression_set
@@ -8644,7 +8614,7 @@ paren_path_expression_set
 			$$ = p;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 path_expression_list
@@ -8654,13 +8624,13 @@ path_expression_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| path_expression
 		{{ DBG_TRACE_GRAMMAR(path_expression_list, | path_expression);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
 	;
 
 delete_name
@@ -8672,7 +8642,7 @@ delete_name
 
 			$$ = node;
 
-		DBG_PRINT}}
+		}}
 	| identifier DOT '*'
 		{{ DBG_TRACE_GRAMMAR(delete_name, | identifier DOT '*');
 
@@ -8681,7 +8651,7 @@ delete_name
 
 			$$ = node;
 
-		DBG_PRINT}}
+		}}
 	;
 
 delete_name_list
@@ -8690,13 +8660,13 @@ delete_name_list
 
 			$$ = parser_make_link ($1, $3);
 
-		DBG_PRINT}}
+		}}
 	| delete_name
 		{{ DBG_TRACE_GRAMMAR(delete_name_list, | delete_name);
 
 			$$ = $1;
 
-		DBG_PRINT}}
+		}}
 	;
 
 delete_from_using
@@ -8708,7 +8678,7 @@ delete_from_using
 
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| FROM delete_name_list USING extended_table_spec_list
 		{{ DBG_TRACE_GRAMMAR(delete_from_using, | FROM delete_name_list USING extended_table_spec_list);
 
@@ -8717,7 +8687,7 @@ delete_from_using
 
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| FROM table_spec
 		{{ DBG_TRACE_GRAMMAR(delete_from_using, | FROM table_spec);
 
@@ -8726,7 +8696,7 @@ delete_from_using
 
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| table_spec
 		{{ DBG_TRACE_GRAMMAR(delete_from_using, | table_spec);
 
@@ -8735,7 +8705,7 @@ delete_from_using
 
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	;
 
 delete_stmt
@@ -8843,7 +8813,7 @@ delete_stmt
 			$$ = del;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 merge_stmt
@@ -8873,24 +8843,24 @@ merge_stmt
 			$$ = merge;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 merge_update_insert_clause
 	: merge_update_clause
 		{{ DBG_TRACE_GRAMMAR(merge_update_insert_clause, : merge_update_clause);
-		DBG_PRINT}}
+		}}
 	| merge_insert_clause
 		{{ DBG_TRACE_GRAMMAR(merge_update_insert_clause, | merge_insert_clause);
-		DBG_PRINT}}
+		}}
 	| merge_update_clause
 	  merge_insert_clause
 		{{ DBG_TRACE_GRAMMAR(merge_update_insert_clause, | merge_update_clause merge_insert_clause);
-		DBG_PRINT}}
+		}}
 	| merge_insert_clause
 	  merge_update_clause
 		{{ DBG_TRACE_GRAMMAR(merge_update_insert_clause, | merge_insert_clause merge_update_clause);
-		DBG_PRINT}}
+		}}
 	;
 
 merge_update_clause
@@ -8912,7 +8882,7 @@ merge_update_clause
 			      }
 			  }
 
-		DBG_PRINT}}
+		}}
 	;
 
 merge_insert_clause
@@ -8930,7 +8900,7 @@ merge_insert_clause
 			    merge->info.merge.insert.search_cond = $8;
 			  }
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_merge_delete_clause
@@ -8939,14 +8909,14 @@ opt_merge_delete_clause
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| DELETE_ WHERE search_condition
 		{{ DBG_TRACE_GRAMMAR(opt_merge_delete_clause, | DELETE_ WHERE search_condition);
 
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 auth_stmt
@@ -8966,7 +8936,7 @@ auth_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| revoke_cmd on_class_list from_id_list
 		{{ DBG_TRACE_GRAMMAR(auth_stmt, | revoke_cmd on_class_list from_id_list);
 
@@ -8982,7 +8952,7 @@ auth_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| revoke_cmd from_id_list on_class_list
 		{{ DBG_TRACE_GRAMMAR(auth_stmt, | revoke_cmd from_id_list on_class_list);
 
@@ -8998,7 +8968,7 @@ auth_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
         | revoke_proc_cmd procedure_or_function_name_list from_id_list
 		{{ DBG_TRACE_GRAMMAR(auth_stmt, | revoke_proc_cmd procedure_or_function_name_list from_id_list);
 
@@ -9014,7 +8984,7 @@ auth_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 revoke_cmd
@@ -9068,7 +9038,7 @@ grant_head
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| grant_cmd to_id_list on_class_list
 		{{ DBG_TRACE_GRAMMAR(grant_head, | grant_cmd to_id_list on_class_list);
 
@@ -9084,7 +9054,7 @@ grant_head
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
         | grant_cmd to_id_list
 		{{ DBG_TRACE_GRAMMAR(grant_head, | grant_cmd to_id_list);
 
@@ -9100,7 +9070,7 @@ grant_head
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
         | grant_proc_cmd procedure_or_function_name_list to_id_list
 		{{ DBG_TRACE_GRAMMAR(grant_head, | grant_proc_cmd procedure_or_function_name_list to_id_list);
 
@@ -9116,7 +9086,7 @@ grant_head
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_with_grant_option
@@ -9125,13 +9095,13 @@ opt_with_grant_option
 
 			$$ = 0;
 
-		DBG_PRINT}}
+		}}
 	| WITH GRANT OPTION
 		{{ DBG_TRACE_GRAMMAR(opt_with_grant_option, | WITH GRANT OPTION);
 
 			$$ = 1;
 
-		DBG_PRINT}}
+		}}
 	;
 
 on_class_list
@@ -9168,14 +9138,14 @@ author_cmd_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| authorized_cmd
 		{{ DBG_TRACE_GRAMMAR(author_cmd_list, | authorized_cmd);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 authorized_execute_procedure_cmd
@@ -9189,7 +9159,7 @@ authorized_execute_procedure_cmd
 			  }
                         $$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-                DBG_PRINT }}
+                }}
         ;
 
 authorized_cmd
@@ -9202,7 +9172,7 @@ authorized_cmd
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| INSERT
 		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | INSERT);
 
@@ -9217,7 +9187,7 @@ authorized_cmd
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| INDEX
 		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | INDEX);
 
@@ -9232,7 +9202,7 @@ authorized_cmd
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| DELETE_
 		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | DELETE_);
 
@@ -9247,7 +9217,7 @@ authorized_cmd
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 
 	| UPDATE '(' identifier_list ')'
 		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | UPDATE '(' identifier_list ')');
@@ -9266,7 +9236,7 @@ authorized_cmd
 
 			$$ = node;
 
-		DBG_PRINT}}
+		}}
 	| UPDATE
 		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | UPDATE);
 
@@ -9281,7 +9251,7 @@ authorized_cmd
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| ALTER
 		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | ALTER);
 
@@ -9296,7 +9266,7 @@ authorized_cmd
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| ADD
 		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | ADD);
 
@@ -9311,7 +9281,7 @@ authorized_cmd
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| DROP
 		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | DROP);
 
@@ -9326,7 +9296,7 @@ authorized_cmd
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 
 	| EXECUTE
 		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | EXECUTE);
@@ -9342,7 +9312,7 @@ authorized_cmd
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| REFERENCES
 		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | REFERENCES);
 
@@ -9357,7 +9327,7 @@ authorized_cmd
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| ALL PRIVILEGES
 		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | ALL PRIVILEGES);
 
@@ -9372,7 +9342,7 @@ authorized_cmd
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| ALL
 		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | ALL);
 
@@ -9387,7 +9357,7 @@ authorized_cmd
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_password
@@ -9402,7 +9372,7 @@ opt_password
                            pt_add_password_offset(pwd_info.pwd_start_offset, pwd_info.pwd_end_offset, false, en_user_password);
                         }
 
-		DBG_PRINT}}
+		}}
 	| PASSWORD
 		{ push_msg(MSGCAT_SYNTAX_INVALID_PASSWORD);
                   pwd_info.pwd_start_offset = (@$.buffer_pos);
@@ -9416,7 +9386,7 @@ opt_password
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_groups
@@ -9425,7 +9395,7 @@ opt_groups
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| GROUPS
 		{ push_msg(MSGCAT_SYNTAX_INVALID_GROUPS); }
 	  identifier_list
@@ -9435,7 +9405,7 @@ opt_groups
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_members
@@ -9444,7 +9414,7 @@ opt_members
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| MEMBERS
 		{ push_msg(MSGCAT_SYNTAX_INVALID_MEMBERS); }
 	  identifier_list
@@ -9454,7 +9424,7 @@ opt_members
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 call_stmt
@@ -9493,7 +9463,7 @@ call_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_class_or_normal_attr_def_list
@@ -9502,14 +9472,14 @@ opt_class_or_normal_attr_def_list
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| '(' class_or_normal_attr_def_list ')'
 		{{ DBG_TRACE_GRAMMAR(opt_class_or_normal_attr_def_list, | '(' class_or_normal_attr_def_list ')');
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_method_def_list
@@ -9518,14 +9488,14 @@ opt_method_def_list
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| METHOD method_def_list
 		{{ DBG_TRACE_GRAMMAR(opt_method_def_list, | METHOD method_def_list);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_method_files
@@ -9534,14 +9504,14 @@ opt_method_files
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| File method_file_list
 		{{ DBG_TRACE_GRAMMAR(opt_method_files, | File method_file_list);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_inherit_resolution_list
@@ -9550,14 +9520,14 @@ opt_inherit_resolution_list
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| inherit_resolution_list
 		{{ DBG_TRACE_GRAMMAR(opt_inherit_resolution_list, | inherit_resolution_list);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_table_option_list
@@ -9567,7 +9537,7 @@ opt_table_option_list
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| table_option_list
 		{{ DBG_TRACE_GRAMMAR(opt_table_option_list, | table_option_list);
 
@@ -9575,7 +9545,7 @@ opt_table_option_list
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_partition_clause
@@ -9584,14 +9554,14 @@ opt_partition_clause
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| partition_clause
 		{{ DBG_TRACE_GRAMMAR(opt_partition_clause, | partition_clause);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_create_as_clause
@@ -9602,13 +9572,13 @@ opt_create_as_clause
 			SET_CONTAINER_2(ctn, NULL, NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| create_as_clause
 		{{ DBG_TRACE_GRAMMAR(opt_create_as_clause, | create_as_clause);
 
 			$$ = $1;
 
-		DBG_PRINT}}
+		}}
 	;
 
 of_class_table_type
@@ -9617,13 +9587,13 @@ of_class_table_type
 
 			$$ = PT_CLASS;
 
-		DBG_PRINT}}
+		}}
 	| TABLE
 		{{ DBG_TRACE_GRAMMAR(of_class_table_type, | TABLE);
 
 			$$ = PT_CLASS;
 
-		DBG_PRINT}}
+		}}
 	;
 
 of_view_vclass
@@ -9637,13 +9607,13 @@ opt_or_replace
 
 			$$ = 0;
 
-		DBG_PRINT}}
+		}}
 	| OR REPLACE
 		{{ DBG_TRACE_GRAMMAR(opt_or_replace, | OR REPLACE);
 
 			$$ = 1;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_if_not_exists
@@ -9652,13 +9622,13 @@ opt_if_not_exists
 
 			$$ = 0;
 
-		DBG_PRINT}}
+		}}
 	| IF NOT EXISTS
 		{{ DBG_TRACE_GRAMMAR(opt_if_not_exists, |  IF NOT EXISTS);
 
 			$$ = 1;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_if_exists
@@ -9667,13 +9637,13 @@ opt_if_exists
 
 			$$ = 0;
 
-		DBG_PRINT}}
+		}}
 	| IF EXISTS
 		{{ DBG_TRACE_GRAMMAR(opt_if_exists, | IF EXISTS);
 
 			$$ = 1;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_paren_view_attr_def_list
@@ -9682,14 +9652,14 @@ opt_paren_view_attr_def_list
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| '(' view_attr_def_list ')'
 		{{ DBG_TRACE_GRAMMAR(opt_opt_paren_view_attr_def_listif_exists, | '(' view_attr_def_list ')');
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_as_query_list
@@ -9698,14 +9668,14 @@ opt_as_query_list
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| AS query_list
 		{{ DBG_TRACE_GRAMMAR(opt_as_query_list, | AS query_list);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_with_levels_clause
@@ -9714,25 +9684,25 @@ opt_with_levels_clause
 
 			$$ = PT_EMPTY;
 
-		DBG_PRINT}}
+		}}
 	| WITH LOCAL CHECK OPTION
 		{{ DBG_TRACE_GRAMMAR(opt_with_levels_clause, | WITH LOCAL CHECK OPTION);
 
 			$$ = PT_LOCAL;
 
-		DBG_PRINT}}
+		}}
 	| WITH CASCADED CHECK OPTION
 		{{ DBG_TRACE_GRAMMAR(opt_with_levels_clause, | WITH CASCADED CHECK OPTION);
 
 			$$ = PT_CASCADED;
 
-		DBG_PRINT}}
+		}}
 	| WITH CHECK OPTION
 		{{ DBG_TRACE_GRAMMAR(opt_with_levels_clause, | WITH CHECK OPTION);
 
 			$$ = PT_CASCADED;
 
-		DBG_PRINT}}
+		}}
 	;
 
 query_list
@@ -9742,14 +9712,14 @@ query_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| csql_query
 		{{ DBG_TRACE_GRAMMAR(query_list, | csql_query);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 inherit_resolution_list
@@ -9759,14 +9729,14 @@ inherit_resolution_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| INHERIT inherit_resolution
 		{{ DBG_TRACE_GRAMMAR(inherit_resolution_list, | INHERIT inherit_resolution);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 inherit_resolution
@@ -9790,7 +9760,7 @@ inherit_resolution
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| opt_class identifier OF class_name
 		{{ DBG_TRACE_GRAMMAR(inherit_resolution, | opt_class identifier OF class_name);
 
@@ -9810,7 +9780,7 @@ inherit_resolution
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 table_option_list
@@ -9820,21 +9790,21 @@ table_option_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| table_option_list table_option
 		{{ DBG_TRACE_GRAMMAR(table_option_list, | table_option_list table_option);
 
 			$$ = parser_make_link ($1, $2);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| table_option
 		{{ DBG_TRACE_GRAMMAR(table_option_list, | table_option);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 table_option
@@ -9844,14 +9814,14 @@ table_option
 			$$ = pt_table_option (this_parser, PT_TABLE_OPTION_REUSE_OID, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| DONT_REUSE_OID
 		{{ DBG_TRACE_GRAMMAR(table_option, | DONT_REUSE_OID);
 
 			$$ = pt_table_option (this_parser, PT_TABLE_OPTION_DONT_REUSE_OID, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| AUTO_INCREMENT '=' UNSIGNED_INTEGER
 		{{ DBG_TRACE_GRAMMAR(table_option, | AUTO_INCREMENT '=' UNSIGNED_INTEGER);
 
@@ -9868,35 +9838,35 @@ table_option
 			$$ = pt_table_option (this_parser, PT_TABLE_OPTION_AUTO_INCREMENT, val);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		  DBG_PRINT}}
+		  }}
 	| class_encrypt_spec
                 {{ DBG_TRACE_GRAMMAR(table_option, | class_encrypt_spec);
 	
                         $$ = pt_table_option (this_parser, PT_TABLE_OPTION_ENCRYPT, $1);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		  DBG_PRINT}}
+		  }}
 	| charset_spec
 		{{ DBG_TRACE_GRAMMAR(table_option, | charset_spec);
 
 			$$ = pt_table_option (this_parser, PT_TABLE_OPTION_CHARSET, $1);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		  DBG_PRINT}}
+		  }}
 	| collation_spec
 		{{ DBG_TRACE_GRAMMAR(table_option, | collation_spec);
 
 			$$ = pt_table_option (this_parser, PT_TABLE_OPTION_COLLATION, $1);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		  DBG_PRINT}}
+		  }}
 	| class_comment_spec
 		{{ DBG_TRACE_GRAMMAR(table_option, | class_comment_spec);
 
 			$$ = pt_table_option (this_parser, PT_TABLE_OPTION_COMMENT, $1);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-	      DBG_PRINT}}
+	      }}
 	;
 
 opt_subtable_clause
@@ -9905,21 +9875,21 @@ opt_subtable_clause
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| UNDER only_class_name_list
 		{{ DBG_TRACE_GRAMMAR(opt_subtable_clause, | UNDER only_class_name_list);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| AS SUBCLASS OF only_class_name_list
 		{{ DBG_TRACE_GRAMMAR(opt_subtable_clause, | AS SUBCLASS OF only_class_name_list);
 
 			$$ = $4;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_constraint_id
@@ -9928,14 +9898,14 @@ opt_constraint_id
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| CONSTRAINT identifier
 		{{ DBG_TRACE_GRAMMAR(opt_constraint_id, | CONSTRAINT identifier);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_constraint_opt_id
@@ -9944,14 +9914,14 @@ opt_constraint_opt_id
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| CONSTRAINT opt_identifier
 		{{ DBG_TRACE_GRAMMAR(opt_constraint_opt_id, | CONSTRAINT opt_identifier);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 of_unique_foreign_check
@@ -9961,21 +9931,21 @@ of_unique_foreign_check
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| foreign_key_constraint
 		{{ DBG_TRACE_GRAMMAR(of_unique_foreign_check, | foreign_key_constraint);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| check_constraint
 		{{ DBG_TRACE_GRAMMAR(of_unique_foreign_check, | check_constraint);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_constraint_attr_list
@@ -9987,13 +9957,13 @@ opt_constraint_attr_list
 					 FROM_NUMBER (0));
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| constraint_attr_list
 		{{ DBG_TRACE_GRAMMAR(opt_constraint_attr_list, | constraint_attr_list);
 
 			$$ = $1;
 
-		DBG_PRINT}}
+		}}
 	;
 
 constraint_attr_list
@@ -10017,13 +9987,13 @@ constraint_attr_list
 
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| constraint_attr
 		{{ DBG_TRACE_GRAMMAR(constraint_attr_list, | constraint_attr);
 
 			$$ = $1;
 
-		DBG_PRINT}}
+		}}
 	;
 
 unique_constraint
@@ -10042,7 +10012,7 @@ unique_constraint
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| UNIQUE opt_of_index_key opt_identifier index_column_name_list
 		{{ DBG_TRACE_GRAMMAR(unique_constraint, | UNIQUE opt_of_index_key opt_identifier index_column_name_list);
 
@@ -10112,7 +10082,7 @@ unique_constraint
 
 			$$ = node;
 
-		DBG_PRINT}}
+		}}
 	;
 
 foreign_key_constraint
@@ -10147,7 +10117,7 @@ foreign_key_constraint
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 index_column_identifier_list
@@ -10157,14 +10127,14 @@ index_column_identifier_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| index_column_identifier
 		{{ DBG_TRACE_GRAMMAR(index_column_identifier_list, | index_column_identifier);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 index_column_identifier
@@ -10178,7 +10148,7 @@ index_column_identifier
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_asc_or_desc
@@ -10187,19 +10157,19 @@ opt_asc_or_desc
 
 			$$ = 0;
 
-		DBG_PRINT}}
+		}}
 	| ASC
 		{{ DBG_TRACE_GRAMMAR(opt_asc_or_desc, | ASC);
 
 			$$ = 0;
 
-		DBG_PRINT}}
+		}}
 	| DESC
 		{{ DBG_TRACE_GRAMMAR(opt_asc_or_desc, | DESC);
 
 			$$ = 1;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_paren_attr_list
@@ -10208,14 +10178,14 @@ opt_paren_attr_list
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| '(' identifier_list ')'
 		{{ DBG_TRACE_GRAMMAR(opt_paren_attr_list, | '(' identifier_list ')');
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_ref_rule_list
@@ -10227,7 +10197,7 @@ opt_ref_rule_list
 					 FROM_NUMBER (PT_RULE_RESTRICT), NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| ref_rule_list
 		{{ DBG_TRACE_GRAMMAR(opt_ref_rule_list, | ref_rule_list);
 
@@ -10238,7 +10208,7 @@ opt_ref_rule_list
 			  ctn.c2 = FROM_NUMBER (PT_RULE_RESTRICT);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	;
 
 ref_rule_list
@@ -10255,7 +10225,7 @@ ref_rule_list
 			ctn.c1 = FROM_NUMBER (PT_RULE_CASCADE);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| ref_rule_list ON_ DELETE_ NO ACTION
 		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ref_rule_list ON_ DELETE_ NO ACTION);
 
@@ -10269,7 +10239,7 @@ ref_rule_list
 			ctn.c1 = FROM_NUMBER (PT_RULE_NO_ACTION);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| ref_rule_list ON_ DELETE_ RESTRICT
 		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ref_rule_list ON_ DELETE_ RESTRICT);
 
@@ -10283,7 +10253,7 @@ ref_rule_list
 			ctn.c1 = FROM_NUMBER (PT_RULE_RESTRICT);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| ref_rule_list ON_ DELETE_ SET Null
 		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ref_rule_list ON_ DELETE_ SET Null);
 
@@ -10297,7 +10267,7 @@ ref_rule_list
 			ctn.c1 = FROM_NUMBER (PT_RULE_SET_NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| ref_rule_list ON_ UPDATE NO ACTION
 		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ref_rule_list ON_ UPDATE NO ACTION);
 
@@ -10311,7 +10281,7 @@ ref_rule_list
 			ctn.c2 = FROM_NUMBER (PT_RULE_NO_ACTION);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| ref_rule_list ON_ UPDATE RESTRICT
 		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ref_rule_list ON_ UPDATE RESTRICT);
 
@@ -10325,7 +10295,7 @@ ref_rule_list
 			ctn.c2 = FROM_NUMBER (PT_RULE_RESTRICT);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| ref_rule_list ON_ UPDATE SET Null
 		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ref_rule_list ON_ UPDATE SET Null);
 
@@ -10339,7 +10309,7 @@ ref_rule_list
 			ctn.c2 = FROM_NUMBER (PT_RULE_SET_NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| ON_ DELETE_ CASCADE
 		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ON_ DELETE_ CASCADE);
 
@@ -10347,7 +10317,7 @@ ref_rule_list
 			SET_CONTAINER_3 (ctn, FROM_NUMBER (PT_RULE_CASCADE), NULL, NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| ON_ DELETE_ NO ACTION
 		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ON_ DELETE_ NO ACTION);
 
@@ -10355,7 +10325,7 @@ ref_rule_list
 			SET_CONTAINER_3 (ctn, FROM_NUMBER (PT_RULE_NO_ACTION), NULL, NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| ON_ DELETE_ RESTRICT
 		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ON_ DELETE_ RESTRICT);
 
@@ -10363,7 +10333,7 @@ ref_rule_list
 			SET_CONTAINER_3 (ctn, FROM_NUMBER (PT_RULE_RESTRICT), NULL, NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| ON_ DELETE_ SET Null
 		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ON_ DELETE_ SET Null);
 
@@ -10371,7 +10341,7 @@ ref_rule_list
 			SET_CONTAINER_3 (ctn, FROM_NUMBER (PT_RULE_SET_NULL), NULL, NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| ON_ UPDATE NO ACTION
 		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ON_ UPDATE NO ACTION);
 
@@ -10379,7 +10349,7 @@ ref_rule_list
 			SET_CONTAINER_3 (ctn, NULL, FROM_NUMBER (PT_RULE_NO_ACTION), NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| ON_ UPDATE RESTRICT
 		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ON_ UPDATE RESTRICT);
 
@@ -10387,7 +10357,7 @@ ref_rule_list
 			SET_CONTAINER_3 (ctn, NULL, FROM_NUMBER (PT_RULE_RESTRICT), NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| ON_ UPDATE SET Null
 		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ON_ UPDATE SET Null);
 
@@ -10395,7 +10365,7 @@ ref_rule_list
 			SET_CONTAINER_3 (ctn, NULL, FROM_NUMBER (PT_RULE_SET_NULL), NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	;
 
 
@@ -10414,7 +10384,7 @@ check_constraint
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 
@@ -10430,7 +10400,7 @@ constraint_attr
 			ctn.c4 = FROM_NUMBER (0);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| DEFERRABLE
 		{{ DBG_TRACE_GRAMMAR(constraint_attr, | DEFERRABLE);
 
@@ -10441,7 +10411,7 @@ constraint_attr
 			ctn.c4 = FROM_NUMBER (0);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| INITIALLY DEFERRED
 		{{ DBG_TRACE_GRAMMAR(constraint_attr, | INITIALLY DEFERRED);
 
@@ -10452,7 +10422,7 @@ constraint_attr
 			ctn.c4 = FROM_NUMBER (1);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| INITIALLY IMMEDIATE
 		{{ DBG_TRACE_GRAMMAR(constraint_attr, | INITIALLY IMMEDIATE);
 
@@ -10463,7 +10433,7 @@ constraint_attr
 			ctn.c4 = FROM_NUMBER (0);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	;
 
 method_def_list
@@ -10473,14 +10443,14 @@ method_def_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| method_def
 		{{ DBG_TRACE_GRAMMAR(method_def_list, | method_def);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 method_def
@@ -10508,7 +10478,7 @@ method_def
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_method_def_arg_list
@@ -10517,20 +10487,20 @@ opt_method_def_arg_list
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| '(' arg_type_list ')'
 		{{ DBG_TRACE_GRAMMAR(opt_method_def_arg_list, | '(' arg_type_list ')');
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| '(' ')'
 		{{ DBG_TRACE_GRAMMAR(opt_method_def_arg_list, | '(' ')');
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	;
 
 arg_type_list
@@ -10540,14 +10510,14 @@ arg_type_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| inout_data_type
 		{{ DBG_TRACE_GRAMMAR(arg_type_list, | inout_data_type);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 inout_data_type
@@ -10566,7 +10536,7 @@ inout_data_type
 			$$ = at;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_data_type
@@ -10577,13 +10547,13 @@ opt_data_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_NONE), NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| data_type
 		{{ DBG_TRACE_GRAMMAR(opt_data_type, | data_type);
 
 			$$ = $1;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_function_identifier
@@ -10592,14 +10562,14 @@ opt_function_identifier
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| FUNCTION identifier
 		{{ DBG_TRACE_GRAMMAR(opt_function_identifier, | FUNCTION identifier);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 method_file_list
@@ -10609,14 +10579,14 @@ method_file_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| file_path_name
 		{{ DBG_TRACE_GRAMMAR(method_file_list, | file_path_name);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 file_path_name
@@ -10629,7 +10599,7 @@ file_path_name
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_class_attr_def_list
@@ -10638,7 +10608,7 @@ opt_class_attr_def_list
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| CLASS
 	  ATTRIBUTE
 		{ parser_attr_type = PT_META_ATTR; }
@@ -10649,7 +10619,7 @@ opt_class_attr_def_list
 			$$ = $5;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 class_or_normal_attr_def_list
@@ -10659,14 +10629,14 @@ class_or_normal_attr_def_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| class_or_normal_attr_def
 		{{ DBG_TRACE_GRAMMAR(class_or_normal_attr_def_list, | class_or_normal_attr_def);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 class_or_normal_attr_def
@@ -10676,14 +10646,14 @@ class_or_normal_attr_def
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| attr_def
 		{{ DBG_TRACE_GRAMMAR(class_or_normal_attr_def, | attr_def);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 view_attr_def_list
@@ -10693,14 +10663,14 @@ view_attr_def_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| view_attr_def
 		{{ DBG_TRACE_GRAMMAR(class_or_normal_attr_def, | view_attr_def);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 view_attr_def
@@ -10710,7 +10680,7 @@ view_attr_def
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| identifier opt_comment_spec
 		{{ DBG_TRACE_GRAMMAR(view_attr_def, | identifier opt_comment_spec);
 
@@ -10728,7 +10698,7 @@ view_attr_def
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 attr_def_list_with_commas
@@ -10738,14 +10708,14 @@ attr_def_list_with_commas
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| attr_def ','  attr_def
 		{{ DBG_TRACE_GRAMMAR(attr_def_list_with_commas, | attr_def ','  attr_def);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 attr_def_list
@@ -10755,14 +10725,14 @@ attr_def_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| attr_def
 		{{ DBG_TRACE_GRAMMAR(attr_def_list, | attr_def);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 attr_def
@@ -10772,21 +10742,21 @@ attr_def
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| attr_index_def
 		{{ DBG_TRACE_GRAMMAR(attr_def, | attr_index_def);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| attr_def_one
 		{{ DBG_TRACE_GRAMMAR(attr_def, | attr_def_one);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 attr_constraint_def
@@ -10849,7 +10819,7 @@ attr_constraint_def
 			$$ = constraint;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 attr_index_def
@@ -10923,7 +10893,7 @@ attr_index_def
 			  }
 			$$ = node;
 
-		DBG_PRINT}}
+		}}
 	;
 
 attr_def_one
@@ -10953,7 +10923,7 @@ attr_def_one
 
 			parser_save_attr_def_one (node);
 
-		DBG_PRINT}}
+		}}
 	  opt_constraint_list_and_opt_column_comment
 	  opt_attr_ordering_info
 		{{ DBG_TRACE_GRAMMAR(attr_def_one, opt_constraint_list_and_opt_column_comment opt_attr_ordering_info);
@@ -10971,7 +10941,7 @@ attr_def_one
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_attr_ordering_info
@@ -10980,7 +10950,7 @@ opt_attr_ordering_info
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| FIRST
 		{{ DBG_TRACE_GRAMMAR(opt_attr_ordering_info, | FIRST);
 
@@ -10999,7 +10969,7 @@ opt_attr_ordering_info
 
 			$$ = ord;
 
-		DBG_PRINT}}
+		}}
 	| AFTER identifier
 		{{ DBG_TRACE_GRAMMAR(opt_attr_ordering_info, | AFTER identifier);
 
@@ -11018,7 +10988,7 @@ opt_attr_ordering_info
 
 			$$ = ord;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_constraint_list_and_opt_column_comment
@@ -11149,7 +11119,7 @@ column_unique_constraint_def
 
 			parser_make_link (node, constraint);
 
-		DBG_PRINT}}
+		}}
 	;
 
 column_primary_constraint_def
@@ -11183,7 +11153,7 @@ column_primary_constraint_def
 
 			parser_make_link (node, constraint);
 
-		DBG_PRINT}}
+		}}
 	;
 
 column_null_constraint_def
@@ -11215,7 +11185,7 @@ column_null_constraint_def
 
 			parser_make_link (node, constraint);
 
-		DBG_PRINT}}
+		}}
 	| opt_constraint_id NOT Null opt_constraint_attr_list
 		{{ DBG_TRACE_GRAMMAR(column_null_constraint_def, | opt_constraint_id NOT Null opt_constraint_attr_list);
 
@@ -11252,7 +11222,7 @@ column_null_constraint_def
 
 			parser_make_link (node, constraint);
 
-		DBG_PRINT}}
+		}}
 	;
 
 column_other_constraint_def
@@ -11285,7 +11255,7 @@ column_other_constraint_def
 
 			parser_make_link (node, constraint);
 
-		DBG_PRINT}}
+		}}
 	| opt_constraint_id			/* 1 */
 	  opt_foreign_key			/* 2 */
           opt_index_with_clause_no_online       /* 3 */
@@ -11328,7 +11298,7 @@ column_other_constraint_def
 
 			parser_make_link (node, constraint);
 
-		DBG_PRINT}}
+		}}
 	;
 
 index_or_key
@@ -11392,7 +11362,7 @@ column_ai_constraint_def
 				       MSGCAT_SEMANTIC_CLASS_ATT_CANT_BE_AUTOINC);
 			  }
 
-		DBG_PRINT}}
+		}}
 	| AUTO_INCREMENT
 		{{ DBG_TRACE_GRAMMAR(column_ai_constraint_def, | AUTO_INCREMENT);
 
@@ -11409,7 +11379,7 @@ column_ai_constraint_def
 				       MSGCAT_SEMANTIC_CLASS_ATT_CANT_BE_AUTOINC);
 			  }
 
-		DBG_PRINT}}
+		}}
 	;
 
 column_shared_constraint_def
@@ -11429,7 +11399,7 @@ column_shared_constraint_def
 			attr_node->info.attr_def.data_default = node;
 			attr_node->info.attr_def.attr_type = PT_SHARED;
 
-		DBG_PRINT}}
+		}}
 	;
 
 column_on_update_def
@@ -11480,7 +11450,7 @@ column_on_update_def
 
 			attr_node->info.attr_def.on_update = default_expr_type;
 
-		DBG_PRINT}}
+		}}
 	;
 
 column_default_constraint_def
@@ -11570,7 +11540,7 @@ column_default_constraint_def
 			attr_node = parser_get_attr_def_one ();
 			attr_node->info.attr_def.data_default = node;
 
-		DBG_PRINT}}
+		}}
 	;
 
 attr_def_comment_list
@@ -11580,14 +11550,14 @@ attr_def_comment_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos);
 
-		DBG_PRINT}}
+		}}
 	| attr_def_comment
 		{{ DBG_TRACE_GRAMMAR(attr_def_comment_list, | attr_def_comment);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos);
 
-		DBG_PRINT}}
+		}}
 	;
 
 attr_def_comment
@@ -11607,7 +11577,7 @@ attr_def_comment
 			$$ = attr_node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos);
 
-		DBG_PRINT}}
+		}}
 	;
 
 column_comment_def
@@ -11618,7 +11588,7 @@ column_comment_def
 			attr_node = parser_get_attr_def_one ();
 			attr_node->info.attr_def.comment = $2;
 
-		DBG_PRINT}}
+		}}
 	;
 
 transaction_mode_list
@@ -11628,14 +11598,14 @@ transaction_mode_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| transaction_mode						%dprec 2
 		{{ DBG_TRACE_GRAMMAR(transaction_mode_list, | transaction_mode);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 transaction_mode
@@ -11718,7 +11688,7 @@ transaction_mode
 
 			$$ = tm;
 
-		DBG_PRINT}}
+		}}
 	| ISOLATION LEVEL isolation_level_spec			%dprec 2
 		{{ DBG_TRACE_GRAMMAR(transaction_mode, | ISOLATION LEVEL isolation_level_spec);
 
@@ -11744,7 +11714,7 @@ transaction_mode
 
 			$$ = tm;
 
-		DBG_PRINT}}
+		}}
 	| LOCK_ TIMEOUT timeout_spec
 		{{ DBG_TRACE_GRAMMAR(transaction_mode, | LOCK_ TIMEOUT timeout_spec);
 
@@ -11758,7 +11728,7 @@ transaction_mode
 			$$ = tm;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 
@@ -11772,7 +11742,7 @@ isolation_level_spec
 					 FROM_NUMBER (PT_NO_ISOLATION_LEVEL), FROM_NUMBER (0));
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| ASYNC WORKSPACE
 		{{ DBG_TRACE_GRAMMAR(isolation_level_spec, | ASYNC WORKSPACE);
 
@@ -11781,7 +11751,7 @@ isolation_level_spec
 					 FROM_NUMBER (PT_NO_ISOLATION_LEVEL), FROM_NUMBER (1));
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| SERIALIZABLE
 		{{ DBG_TRACE_GRAMMAR(isolation_level_spec, | SERIALIZABLE);
 
@@ -11790,7 +11760,7 @@ isolation_level_spec
 					 FROM_NUMBER (PT_SERIALIZABLE), FROM_NUMBER (0));
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| CURSOR STABILITY
 		{{ DBG_TRACE_GRAMMAR(isolation_level_spec, | CURSOR STABILITY);
 
@@ -11799,7 +11769,7 @@ isolation_level_spec
 					 FROM_NUMBER (PT_READ_COMMITTED), FROM_NUMBER (0));
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| isolation_level_name								%dprec 1
 		{{ DBG_TRACE_GRAMMAR(isolation_level_spec, | isolation_level_name);
 
@@ -11812,7 +11782,7 @@ isolation_level_spec
 					 FROM_NUMBER (level), FROM_NUMBER (0));
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| isolation_level_name of_schema_class 						%dprec 1
 		{{ DBG_TRACE_GRAMMAR(isolation_level_spec, | isolation_level_name of_schema_class);
 
@@ -11829,7 +11799,7 @@ isolation_level_spec
 					 FROM_NUMBER (error));
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| isolation_level_name INSTANCES						%dprec 1
 		{{ DBG_TRACE_GRAMMAR(isolation_level_spec, | isolation_level_name INSTANCES);
 
@@ -11844,7 +11814,7 @@ isolation_level_spec
 					 FROM_NUMBER (0));
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| isolation_level_name of_schema_class ',' isolation_level_name INSTANCES	%dprec 10
 		{{ DBG_TRACE_GRAMMAR(isolation_level_spec, | isolation_level_name of_schema_class ',' isolation_level_name INSTANCES);
 
@@ -11860,7 +11830,7 @@ isolation_level_spec
 					 FROM_NUMBER (error));
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| isolation_level_name INSTANCES ',' isolation_level_name of_schema_class	%dprec 10
 		{{ DBG_TRACE_GRAMMAR(isolation_level_spec, | isolation_level_name INSTANCES ',' isolation_level_name of_schema_class);
 			container_4 ctn;
@@ -11875,7 +11845,7 @@ isolation_level_spec
 					 FROM_NUMBER (error));
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	;
 
 of_schema_class
@@ -11889,13 +11859,13 @@ isolation_level_name
 
 			$$ = PT_REPEATABLE_READ;
 
-		DBG_PRINT}}
+		}}
 	| READ COMMITTED
 		{{ DBG_TRACE_GRAMMAR(isolation_level_name, | READ COMMITTED); 
 
 			$$ = PT_READ_COMMITTED;
 
-		DBG_PRINT}}
+		}}
 	;
 
 timeout_spec
@@ -11913,7 +11883,7 @@ timeout_spec
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| OFF_
 		{{ DBG_TRACE_GRAMMAR(timeout_spec, | OFF_);
 
@@ -11928,35 +11898,35 @@ timeout_spec
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| unsigned_integer
 		{{ DBG_TRACE_GRAMMAR(timeout_spec, | unsigned_integer);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| unsigned_real
 		{{ DBG_TRACE_GRAMMAR(timeout_spec, | unsigned_real);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| param_
 		{{ DBG_TRACE_GRAMMAR(timeout_spec, | param_);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| host_param_input
 		{{ DBG_TRACE_GRAMMAR(timeout_spec, | host_param_input);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 
@@ -11974,7 +11944,7 @@ transaction_stmt
 			$$ = comm;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| COMMIT opt_work
 		{{ DBG_TRACE_GRAMMAR(timeout_spec, | COMMIT opt_work);
 
@@ -11982,7 +11952,7 @@ transaction_stmt
 			$$ = comm;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| ROLLBACK opt_work TO opt_savepoint expression_
 		{{ DBG_TRACE_GRAMMAR(timeout_spec, | ROLLBACK opt_work TO opt_savepoint expression_);
 
@@ -11996,7 +11966,7 @@ transaction_stmt
 			$$ = roll;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| ROLLBACK opt_work
 		{{ DBG_TRACE_GRAMMAR(timeout_spec, | ROLLBACK opt_work);
 
@@ -12004,7 +11974,7 @@ transaction_stmt
 			$$ = roll;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SAVEPOINT expression_
 		{{ DBG_TRACE_GRAMMAR(timeout_spec, | expression_);
 
@@ -12018,7 +11988,7 @@ transaction_stmt
 			$$ = svpt;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 
@@ -12052,7 +12022,7 @@ evaluate_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 prepare_stmt
@@ -12070,7 +12040,7 @@ prepare_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 execute_stmt
@@ -12090,7 +12060,7 @@ execute_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_using
@@ -12100,7 +12070,7 @@ opt_using
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| USING
 		{ parser_save_and_set_hvar (0); }
 		execute_using_list
@@ -12124,7 +12094,7 @@ opt_using
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_status
@@ -12133,13 +12103,13 @@ opt_status
 
 			$$ = PT_MISC_DUMMY;
 
-		DBG_PRINT}}
+		}}
 	| trigger_status
 		{{ DBG_TRACE_GRAMMAR(opt_status, | trigger_status);
 
 			$$ = $1;
 
-		DBG_PRINT}}
+		}}
 	;
 
 trigger_status
@@ -12148,13 +12118,13 @@ trigger_status
 
 			$$ = PT_ACTIVE;
 
-		DBG_PRINT}}
+		}}
 	| STATUS INACTIVE
 		{{ DBG_TRACE_GRAMMAR(trigger_status, | STATUS INACTIVE);
 
 			$$ = PT_INACTIVE;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_priority
@@ -12163,14 +12133,14 @@ opt_priority
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| trigger_priority
 		{{ DBG_TRACE_GRAMMAR(opt_priority, | trigger_priority);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 trigger_priority
@@ -12180,7 +12150,7 @@ trigger_priority
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_if_trigger_condition
@@ -12189,14 +12159,14 @@ opt_if_trigger_condition
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| IF trigger_condition
 		{{ DBG_TRACE_GRAMMAR(opt_if_trigger_condition, |   IF trigger_condition);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 trigger_time
@@ -12205,19 +12175,19 @@ trigger_time
 
 			$$ = PT_BEFORE;
 
-		DBG_PRINT}}
+		}}
 	| AFTER
 		{{ DBG_TRACE_GRAMMAR(trigger_time, | AFTER);
 
 			$$ = PT_AFTER;
 
-		DBG_PRINT}}
+		}}
 	| DEFERRED
 		{{ DBG_TRACE_GRAMMAR(trigger_time, | DEFERRED);
 
 			$$ = PT_DEFERRED;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_trigger_action_time
@@ -12226,19 +12196,19 @@ opt_trigger_action_time
 
 			$$ = PT_MISC_DUMMY;
 
-		DBG_PRINT}}
+		}}
 	| AFTER
 		{{ DBG_TRACE_GRAMMAR(opt_trigger_action_time, | AFTER);
 
 			$$ = PT_AFTER;
 
-		DBG_PRINT}}
+		}}
 	| DEFERRED
 		{{ DBG_TRACE_GRAMMAR(opt_trigger_action_time, | DEFERRED);
 
 			$$ = PT_DEFERRED;
 
-		DBG_PRINT}}
+		}}
 	;
 
 event_spec
@@ -12255,7 +12225,7 @@ event_spec
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| event_type event_target
 		{{ DBG_TRACE_GRAMMAR(opt_trigger_aevent_specction_time, | event_type event_target);
 
@@ -12270,7 +12240,7 @@ event_spec
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 event_type
@@ -12279,49 +12249,49 @@ event_type
 
 			$$ = PT_EV_INSERT;
 
-		DBG_PRINT}}
+		}}
 	| STATEMENT INSERT
 		{{ DBG_TRACE_GRAMMAR(event_type, | STATEMENT INSERT);
 
 			$$ = PT_EV_STMT_INSERT;
 
-		DBG_PRINT}}
+		}}
 	| DELETE_
 		{{ DBG_TRACE_GRAMMAR(event_type, | DELETE_);
 
 			$$ = PT_EV_DELETE;
 
-		DBG_PRINT}}
+		}}
 	| STATEMENT DELETE_
 		{{ DBG_TRACE_GRAMMAR(event_type, | STATEMENT DELETE_);
 
 			$$ = PT_EV_STMT_DELETE;
 
-		DBG_PRINT}}
+		}}
 	| UPDATE
 		{{ DBG_TRACE_GRAMMAR(event_type, | UPDATE);
 
 			$$ = PT_EV_UPDATE;
 
-		DBG_PRINT}}
+		}}
 	| STATEMENT UPDATE
 		{{ DBG_TRACE_GRAMMAR(event_type, | STATEMENT UPDATE);
 
 			$$ = PT_EV_STMT_UPDATE;
 
-		DBG_PRINT}}
+		}}
 	| COMMIT
 		{{ DBG_TRACE_GRAMMAR(event_type, | COMMIT);
 
 			$$ = PT_EV_COMMIT;
 
-		DBG_PRINT}}
+		}}
 	| ROLLBACK
 		{{ DBG_TRACE_GRAMMAR(event_type, | ROLLBACK);
 
 			$$ = PT_EV_ROLLBACK;
 
-		DBG_PRINT}}
+		}}
 	;
 
 event_target
@@ -12339,7 +12309,7 @@ event_target
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| ON_ class_name
 		{{ DBG_TRACE_GRAMMAR(event_target, | ON_ class_name);
 
@@ -12353,7 +12323,7 @@ event_target
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 trigger_condition
@@ -12363,14 +12333,14 @@ trigger_condition
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| call_stmt
 		{{ DBG_TRACE_GRAMMAR(trigger_condition, | call_stmt);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 trigger_action_in
@@ -12387,7 +12357,7 @@ trigger_action_in
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| INVALIDATE TRANSACTION
 		{{ DBG_TRACE_GRAMMAR(trigger_action, | INVALIDATE TRANSACTION);
 
@@ -12401,7 +12371,7 @@ trigger_action_in
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| PRINT char_string_literal
 		{{ DBG_TRACE_GRAMMAR(trigger_action, | PRINT char_string_literal);
 
@@ -12416,7 +12386,7 @@ trigger_action_in
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| evaluate_stmt
 		{{ DBG_TRACE_GRAMMAR(trigger_action, | evaluate_stmt);
 
@@ -12431,7 +12401,7 @@ trigger_action_in
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| insert_or_replace_stmt
 		{{ DBG_TRACE_GRAMMAR(trigger_action, | insert_or_replace_stmt);
 
@@ -12446,7 +12416,7 @@ trigger_action_in
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| update_stmt
 		{{ DBG_TRACE_GRAMMAR(trigger_action, | update_stmt);
 
@@ -12461,7 +12431,7 @@ trigger_action_in
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| delete_stmt
 		{{ DBG_TRACE_GRAMMAR(trigger_action, | delete_stmt);
 
@@ -12476,7 +12446,7 @@ trigger_action_in
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| call_stmt
 		{{ DBG_TRACE_GRAMMAR(trigger_action, | call_stmt);
 
@@ -12491,7 +12461,7 @@ trigger_action_in
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| merge_stmt
 		{{ DBG_TRACE_GRAMMAR(trigger_action, | merge_stmt);
 
@@ -12506,7 +12476,7 @@ trigger_action_in
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 trigger_action
@@ -12514,7 +12484,7 @@ trigger_action
 	    {{ DBG_TRACE_GRAMMAR(trigger_action, : trigger_action_in);
 		$$ = $1;
 		PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-	     DBG_PRINT}}
+	     }}
 	;
 
 trigger_spec_list
@@ -12532,7 +12502,7 @@ trigger_spec_list
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| ALL TRIGGERS
 		{{ DBG_TRACE_GRAMMAR(trigger_spec_list, | ALL TRIGGERS);
 
@@ -12546,7 +12516,7 @@ trigger_spec_list
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 trigger_status_or_priority_or_change_owner
@@ -12557,7 +12527,7 @@ trigger_status_or_priority_or_change_owner
 			SET_CONTAINER_3 (ctn, FROM_NUMBER ($1), NULL, NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| trigger_priority
 		{{ DBG_TRACE_GRAMMAR(trigger_status_or_priority_or_change_owner, | trigger_priority);
 
@@ -12565,7 +12535,7 @@ trigger_status_or_priority_or_change_owner
 			SET_CONTAINER_3 (ctn, FROM_NUMBER (PT_MISC_DUMMY), $1, NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| OWNER TO identifier
 		{{ DBG_TRACE_GRAMMAR(trigger_status_or_priority_or_change_owner, | OWNER TO identifier);
 
@@ -12573,7 +12543,7 @@ trigger_status_or_priority_or_change_owner
 			SET_CONTAINER_3 (ctn, FROM_NUMBER (PT_MISC_DUMMY), NULL, $3);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_maximum
@@ -12596,7 +12566,7 @@ trace_spec
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| OFF_
 		{{ DBG_TRACE_GRAMMAR(trace_spec, | OFF_);
 
@@ -12611,28 +12581,28 @@ trace_spec
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| unsigned_integer
 		{{ DBG_TRACE_GRAMMAR(trace_spec, | unsigned_integer);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| param_
 		{{ DBG_TRACE_GRAMMAR(trace_spec, | param_);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| host_param_input
 		{{ DBG_TRACE_GRAMMAR(trace_spec, | host_param_input);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 depth_spec
@@ -12642,21 +12612,21 @@ depth_spec
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| param_
 		{{ DBG_TRACE_GRAMMAR(depth_spec, | param_);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| host_param_input
 		{{ DBG_TRACE_GRAMMAR(depth_spec, | host_param_input);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 serial_start
@@ -12676,7 +12646,7 @@ serial_start
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 serial_increment
@@ -12696,7 +12666,7 @@ serial_increment
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 
@@ -12718,7 +12688,7 @@ serial_min
 			SET_CONTAINER_2 (ctn, node, FROM_NUMBER (0));
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| NOMINVALUE
 		{{ DBG_TRACE_GRAMMAR(serial_min, | NOMINVALUE);
 
@@ -12726,7 +12696,7 @@ serial_min
 			SET_CONTAINER_2 (ctn, NULL, FROM_NUMBER (1));
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	;
 
 serial_max
@@ -12747,7 +12717,7 @@ serial_max
 			SET_CONTAINER_2 (ctn, node, FROM_NUMBER (0));
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| NOMAXVALUE
 		{{ DBG_TRACE_GRAMMAR(serial_max, | NOMAXVALUE);
 
@@ -12755,7 +12725,7 @@ serial_max
 			SET_CONTAINER_2 (ctn, NULL, FROM_NUMBER (1));
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	;
 
 of_cycle_nocycle
@@ -12766,7 +12736,7 @@ of_cycle_nocycle
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (1), FROM_NUMBER (0));
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| NOCYCLE
 		{{ DBG_TRACE_GRAMMAR(of_cycle_nocycle, | NOCYCLE);
 
@@ -12774,7 +12744,7 @@ of_cycle_nocycle
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (0), FROM_NUMBER (1));
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	;
 
 of_cached_num
@@ -12785,14 +12755,14 @@ of_cached_num
 			SET_CONTAINER_2 (ctn, $2, FROM_NUMBER (0));
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| NOCACHE
 		{{ DBG_TRACE_GRAMMAR(of_cached_num, | NOCACHE);
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, NULL, FROM_NUMBER (1));
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	;
 
 integer_text
@@ -12801,13 +12771,13 @@ integer_text
 
 			$$ = $2;
 
-		DBG_PRINT}}
+		}}
 	| '-' UNSIGNED_INTEGER
 		{{ DBG_TRACE_GRAMMAR(integer_text, | '-' UNSIGNED_INTEGER);
 
 			$$ = pt_append_string (this_parser, (char *) "-", $2);
 
-		DBG_PRINT}}
+		}}
 	;
 
 uint_text
@@ -12816,7 +12786,7 @@ uint_text
 
 			$$ = $1;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_plus
@@ -12835,7 +12805,7 @@ sp_return_type
                         is_in_sp_func_type = false;
 			$$ = $2;
 
-                DBG_PRINT}}
+                }}
         | CURSOR
                 {{ DBG_TRACE_GRAMMAR(sp_return_type, | CURSOR);
 
@@ -12843,7 +12813,7 @@ sp_return_type
 			SET_CONTAINER_2(ctn, FROM_NUMBER(PT_TYPE_RESULTSET), NULL);
 			$$ = ctn;
 
-                DBG_PRINT}}
+                }}
         | table_column MOD TYPE
 		{{ DBG_TRACE_GRAMMAR(sp_return_type, | table_column MOD TYPE);
 
@@ -12860,37 +12830,37 @@ sp_return_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_NONE), dt); // PT_TYPE_NONE: unknown yet
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
         ;
 
 opt_authid
         : AUTHID DEFINER
                 {{ DBG_TRACE_GRAMMAR(opt_authid, : AUTHID DEFINER);
                         $$ = PT_AUTHID_OWNER; 
-                DBG_PRINT}}
+                }}
         | AUTHID OWNER
                 {{ DBG_TRACE_GRAMMAR(opt_authid, : AUTHID OWNER);
                         $$ = PT_AUTHID_OWNER; 
-                DBG_PRINT}}
+                }}
         | AUTHID CALLER
                 {{ DBG_TRACE_GRAMMAR(opt_authid, : AUTHID CALLER);
                         $$ = PT_AUTHID_CALLER; 
-                DBG_PRINT}}
+                }}
         | AUTHID CURRENT_USER
                 {{ DBG_TRACE_GRAMMAR(opt_authid, : AUTHID CURRENT_USER);
                         $$ = PT_AUTHID_CALLER; 
-                DBG_PRINT}}
+                }}
         ;
 
 opt_deterministic
         : NOT DETERMINISTIC
                 {{ DBG_TRACE_GRAMMAR(opt_deterministic, : NOT DETERMINISTIC);
                         $$ = PT_NOT_DETERMINISTIC; 
-                DBG_PRINT}}
+                }}
         | DETERMINISTIC
                 {{ DBG_TRACE_GRAMMAR(opt_deterministic, : DETERMINISTIC);
                         $$ = PT_DETERMINISTIC; 
-                DBG_PRINT}}
+                }}
         ;
 
 opt_authid_and_deterministic
@@ -12899,45 +12869,45 @@ opt_authid_and_deterministic
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, NULL, NULL);
 			$$ = ctn;
-		DBG_PRINT}}
+		}}
         | opt_authid opt_deterministic
 		{{ DBG_TRACE_GRAMMAR(opt_authid_and_deterministic, : opt_authid opt_deterministic);
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER($1), FROM_NUMBER($2));
 			$$ = ctn;
-		DBG_PRINT}}
+		}}
         | opt_deterministic opt_authid
 		{{ DBG_TRACE_GRAMMAR(opt_authid_and_deterministic, : opt_deterministic opt_authid);
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER($2), FROM_NUMBER($1));
 			$$ = ctn;
-		DBG_PRINT}}
+		}}
         | opt_authid
 		{{ DBG_TRACE_GRAMMAR(opt_authid_and_deterministic, : opt_authid);
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER($1), NULL);
 			$$ = ctn;
-		DBG_PRINT}}
+		}}
         | opt_deterministic
 		{{ DBG_TRACE_GRAMMAR(opt_authid_and_deterministic, : opt_deterministic);
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, NULL, FROM_NUMBER($1));
 			$$ = ctn;
-		DBG_PRINT}}
+		}}
         ;
 
 is_or_as
 	: IS          
-                { DBG_TRACE_GRAMMAR(is_or_as, : IS); DBG_PRINT}
+                { DBG_TRACE_GRAMMAR(is_or_as, : IS); }
 	| AS          
-                { DBG_TRACE_GRAMMAR(is_or_as, : AS); DBG_PRINT}
+                { DBG_TRACE_GRAMMAR(is_or_as, : AS); }
 	;
 
 opt_lang_plcsql
         : /* empty */          
-                { DBG_TRACE_GRAMMAR(opt_lang_plcsql, : ); DBG_PRINT}
+                { DBG_TRACE_GRAMMAR(opt_lang_plcsql, : ); }
         | LANGUAGE PLCSQL
-                { DBG_TRACE_GRAMMAR(opt_lang_plcsql, : LANGUAGE PLCSQL); DBG_PRINT}
+                { DBG_TRACE_GRAMMAR(opt_lang_plcsql, : LANGUAGE PLCSQL); }
         ;
 
 pl_language_spec
@@ -12961,7 +12931,7 @@ pl_language_spec
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| LANGUAGE JAVA 		/* 1, 2 */
 	  NAME char_string_literal	/* 3, 4 */
 		{{ DBG_TRACE_GRAMMAR(pl_language_spec, : LANGAUGE JAVA );
@@ -12978,7 +12948,7 @@ pl_language_spec
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 plcsql_text
@@ -12987,7 +12957,7 @@ plcsql_text
 
                         $$ = $1 + strlen($2);
 
-		DBG_PRINT}}
+		}}
         | plcsql_text_part
 		{{ DBG_TRACE_GRAMMAR(plcsql_text, | plcsql_text_part);
 
@@ -12995,42 +12965,42 @@ plcsql_text
                         $$ = strlen($1);
                         g_plcsql_text_pos = @$.buffer_pos - $$;
 
-		DBG_PRINT}}
+		}}
         ;
 
 plcsql_text_part
         : PLCSQL_TEXT_SOME
 		{{ DBG_TRACE_GRAMMAR(plcsql_text_part, : PLCSQL_TEXT_SOME);
                     $$ = $1;
-		DBG_PRINT}}
+		}}
         | CHAR_STRING
 		{{ DBG_TRACE_GRAMMAR(plcsql_text_part, | CHAR_STRING);
                     char* val = pt_append_string(this_parser, NULL, "'");
                     val = pt_append_string(this_parser, val, $1);
                     val = pt_append_string(this_parser, val, "'");
                     $$ = val;
-		DBG_PRINT}}
+		}}
         | DelimitedIdName
 		{{ DBG_TRACE_GRAMMAR(plcsql_text_part, | DelimitedIdName);
                     char* val = pt_append_string(this_parser, NULL, "\"");
                     val = pt_append_string(this_parser, val, $1);
                     val = pt_append_string(this_parser, val, "\"");
                     $$ = val;
-		DBG_PRINT}}
+		}}
         | BracketDelimitedIdName
 		{{ DBG_TRACE_GRAMMAR(plcsql_text_part, | BracketDelimitedIdName);
                     char* val = pt_append_string(this_parser, NULL, "[");
                     val = pt_append_string(this_parser, val, $1);
                     val = pt_append_string(this_parser, val, "]");
                     $$ = val;
-		DBG_PRINT}}
+		}}
         | BacktickDelimitedIdName
 		{{ DBG_TRACE_GRAMMAR(plcsql_text_part, | BacktickDelimitedIdName);
                     char* val = pt_append_string(this_parser, NULL, "`");
                     val = pt_append_string(this_parser, val, $1);
                     val = pt_append_string(this_parser, val, "`");
                     $$ = val;
-		DBG_PRINT}}
+		}}
         ;
 
 opt_sp_param_list
@@ -13039,20 +13009,20 @@ opt_sp_param_list
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
         | '(' ')'
 		{{ DBG_TRACE_GRAMMAR(opt_sp_param_list, | '(' ')' );
 
 			$$ = NULL;  // same as the empty case
 
-		DBG_PRINT}}
+		}}
 	| '(' sp_param_list ')'
 		{{ DBG_TRACE_GRAMMAR(opt_sp_param_list, | '(' sp_param_list ')' );
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 sp_param_list
@@ -13062,14 +13032,14 @@ sp_param_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| sp_param_def
 		{{ DBG_TRACE_GRAMMAR(sp_param_list, | sp_param_def); 
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 sp_param_def
@@ -13095,7 +13065,7 @@ sp_param_def
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 sp_param_type
@@ -13109,7 +13079,7 @@ sp_param_type
                         is_in_sp_func_type = false;
                         $$ = $2;
 
-		DBG_PRINT}}
+		}}
         | CURSOR
 		{{ DBG_TRACE_GRAMMAR(sp_param_type, | CURSOR);
 
@@ -13117,7 +13087,7 @@ sp_param_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_RESULTSET), NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
         | table_column MOD TYPE
 		{{ DBG_TRACE_GRAMMAR(sp_param_type, | table_column MOD TYPE);
 
@@ -13134,7 +13104,7 @@ sp_param_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_NONE), dt); // PT_TYPE_NONE: unknown yet
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
         ;
 
 table_column
@@ -13151,7 +13121,7 @@ table_column
                         $$ = dot;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
         ;
 
 opt_sp_in_out
@@ -13160,34 +13130,34 @@ opt_sp_in_out
 
 			$$ = $1;
 
-		DBG_PRINT}}
+		}}
 	| IN_ OUT_
 		{{ DBG_TRACE_GRAMMAR(opt_sp_in_out, | IN_ OUT_); 
 
 			$$ = PT_INPUTOUTPUT;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_sp_default_value
         : /* empty */
 		{{
 			$$ = NULL;
-		DBG_PRINT}}
+		}}
 	| DEFAULT
           expression_
 		{{
                         PT_NODE *node = pt_make_data_default_expr_node (this_parser, $2);
                         PARSER_SAVE_ERR_CONTEXT (node, @2.buffer_pos)
 			$$ = node;
-		DBG_PRINT}}
+		}}
 	| VAR_ASSIGN
           expression_
 		{{
                         PT_NODE *node = pt_make_data_default_expr_node (this_parser, $2);
                         PARSER_SAVE_ERR_CONTEXT (node, @2.buffer_pos)
 			$$ = node;
-		DBG_PRINT}}
+		}}
 
 esql_query_stmt
 	: 	{ parser_select_level++; }
@@ -13197,7 +13167,7 @@ esql_query_stmt
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 			parser_select_level--;
 
-		DBG_PRINT}}
+		}}
 	;
 
 csql_query
@@ -13216,14 +13186,14 @@ csql_query
 			parser_save_and_set_sqc (1);
 			parser_save_and_set_pseudoc (1);
 
-		DBG_PRINT}}
+		}}
 	  select_expression_opt_with
 		{{ DBG_TRACE_GRAMMAR(csql_query, : select_expression_opt_with);
 
 			PT_NODE *node = $2;
 			parser_push_orderby_node (node);
 
-		DBG_PRINT}}
+		}}
 	  opt_orderby_clause
 		{{ DBG_TRACE_GRAMMAR(csql_query, opt_orderby_clause);
 
@@ -13276,7 +13246,7 @@ csql_query
 
 			parser_push_orderby_node (node);
 
-		DBG_PRINT}}
+		}}
 	opt_select_limit_clause
 	opt_for_update_clause
 		{{ DBG_TRACE_GRAMMAR(csql_query, opt_select_limit_clause opt_for_update_clause);
@@ -13285,7 +13255,7 @@ csql_query
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 csql_query_select_has_no_with_clause
@@ -13304,14 +13274,14 @@ csql_query_select_has_no_with_clause
 			parser_save_and_set_sqc (1);
 			parser_save_and_set_pseudoc (1);
 
-		DBG_PRINT}}
+		}}
 	  select_expression
 		{{ DBG_TRACE_GRAMMAR(csql_query_select_has_no_with_clause, : select_expression);
 
 			PT_NODE *node = $2;
 			parser_push_orderby_node (node);
 
-		DBG_PRINT}}
+		}}
 	  opt_orderby_clause
 		{{ DBG_TRACE_GRAMMAR(csql_query_select_has_no_with_clause, opt_orderby_clause);
 
@@ -13364,7 +13334,7 @@ csql_query_select_has_no_with_clause
 
 			parser_push_orderby_node (node);
 
-		DBG_PRINT}}
+		}}
 	opt_select_limit_clause
 	opt_for_update_clause
 		{{ DBG_TRACE_GRAMMAR(csql_query_select_has_no_with_clause, opt_select_limit_clause opt_for_update_clause);
@@ -13373,7 +13343,7 @@ csql_query_select_has_no_with_clause
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 csql_query_without_subquery_and_with_clause
@@ -13392,14 +13362,14 @@ csql_query_without_subquery_and_with_clause
 			parser_save_and_set_sqc (1);
 			parser_save_and_set_pseudoc (1);
 
-		DBG_PRINT}}
+		}}
 	  select_expression_without_subquery
 		{{ DBG_TRACE_GRAMMAR(csql_query_without_subquery_and_with_clause, : select_expression_without_subquery);
 
 			PT_NODE *node = $2;
 			parser_push_orderby_node (node);
 
-		DBG_PRINT}}
+		}}
 	  opt_orderby_clause
 		{{ DBG_TRACE_GRAMMAR(csql_query_without_subquery_and_with_clause, opt_orderby_clause);
 
@@ -13452,7 +13422,7 @@ csql_query_without_subquery_and_with_clause
 
 			parser_push_orderby_node (node);
 
-		DBG_PRINT}}
+		}}
 	opt_select_limit_clause
 	opt_for_update_clause
 		{{ DBG_TRACE_GRAMMAR(csql_query_without_subquery_and_with_clause, opt_select_limit_clause opt_for_update_clause);
@@ -13461,7 +13431,7 @@ csql_query_without_subquery_and_with_clause
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 csql_query_without_values_query_no_with_clause
@@ -13480,14 +13450,14 @@ csql_query_without_values_query_no_with_clause
 			parser_save_and_set_sqc (1);
 			parser_save_and_set_pseudoc (1);
 
-		DBG_PRINT}}
+		}}
 	  select_expression_without_values_query_no_with_clause
 		{{ DBG_TRACE_GRAMMAR(csql_query_without_values_query_no_with_clause, : select_expression_without_values_query_no_with_clause);
 
 			PT_NODE *node = $2;
 			parser_push_orderby_node (node);
 
-		DBG_PRINT}}
+		}}
 	  opt_orderby_clause
 		{{ DBG_TRACE_GRAMMAR(csql_query_without_values_query_no_with_clause, opt_orderby_clause);
 
@@ -13540,7 +13510,7 @@ csql_query_without_values_query_no_with_clause
 
 			parser_push_orderby_node (node);
 
-		DBG_PRINT}}
+		}}
 	  opt_select_limit_clause
 	  opt_for_update_clause
 		{{ DBG_TRACE_GRAMMAR(csql_query_without_values_query_no_with_clause, opt_select_limit_clause opt_for_update_clause);
@@ -13549,7 +13519,7 @@ csql_query_without_values_query_no_with_clause
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 csql_query_without_values_and_single_subquery
@@ -13568,14 +13538,14 @@ csql_query_without_values_and_single_subquery
 			parser_save_and_set_sqc (1);
 			parser_save_and_set_pseudoc (1);
 
-		DBG_PRINT}}
+		}}
 	  select_expression_without_values_and_single_subquery
 		{{ DBG_TRACE_GRAMMAR(csql_query_without_values_and_single_subquery, : select_expression_without_values_and_single_subquery);
 
 			PT_NODE *node = $2;
 			parser_push_orderby_node (node);
 
-		DBG_PRINT}}
+		}}
 	  opt_orderby_clause
 		{{ DBG_TRACE_GRAMMAR(csql_query_without_values_and_single_subquery,  opt_orderby_clause);
 
@@ -13627,7 +13597,7 @@ csql_query_without_values_and_single_subquery
 
 			parser_push_orderby_node (node);
 
-		DBG_PRINT}}
+		}}
 	  opt_select_limit_clause
 	  opt_for_update_clause
 		{{ DBG_TRACE_GRAMMAR(csql_query_without_values_and_single_subquery,  opt_select_limit_clause opt_for_update_clause);
@@ -13636,7 +13606,7 @@ csql_query_without_values_and_single_subquery
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 
@@ -13654,7 +13624,7 @@ select_expression_opt_with
 
 			$$ = stmt;
 
-		DBG_PRINT}}
+		}}
 	;
 
 select_expression_without_subquery
@@ -13703,7 +13673,7 @@ select_expression_without_subquery
 
 			parser_push_orderby_node (node);
 
-		DBG_PRINT}}
+		}}
 
           opt_select_limit_clause
           opt_for_update_clause
@@ -13713,7 +13683,7 @@ select_expression_without_subquery
 			$<node>$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($<node>$, @$.buffer_pos)
 
-                DBG_PRINT}}
+                }}
 
           table_op select_or_values_query
                 {{ DBG_TRACE_GRAMMAR(select_expression_without_subquery,  select_or_values_query);
@@ -13742,13 +13712,13 @@ select_expression_without_subquery
 			$$ = stmt;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| select_or_values_query
 		{{ DBG_TRACE_GRAMMAR(select_expression_without_subquery, | select_or_values_query);
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 select_expression
@@ -13797,7 +13767,7 @@ select_expression
 
 			parser_push_orderby_node (node);
 
-		DBG_PRINT}}
+		}}
 	  opt_select_limit_clause
 	  opt_for_update_clause
 		{{ DBG_TRACE_GRAMMAR(select_expression, opt_select_limit_clause opt_for_update_clause);
@@ -13806,7 +13776,7 @@ select_expression
 			$<node>$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($<node>$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	  table_op select_or_subquery
 		{{ DBG_TRACE_GRAMMAR(select_expression, table_op select_or_subquery);
 
@@ -13833,14 +13803,14 @@ select_expression
 			$$ = stmt;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| select_or_subquery
 		{{ DBG_TRACE_GRAMMAR(select_expression, | select_or_subquery);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 select_expression_without_values_query_no_with_clause
@@ -13888,7 +13858,7 @@ select_expression_without_values_query_no_with_clause
 
 			parser_push_orderby_node (node);
 
-		DBG_PRINT}}
+		}}
 	  opt_select_limit_clause
 	  opt_for_update_clause
 		{{ DBG_TRACE_GRAMMAR(select_expression_without_values_query_no_with_clause, opt_select_limit_clause opt_for_update_clause);
@@ -13897,7 +13867,7 @@ select_expression_without_values_query_no_with_clause
 			$<node>$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($<node>$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	  table_op select_or_subquery_without_values_query_no_with_clause
 		{{ DBG_TRACE_GRAMMAR(select_expression_without_values_query_no_with_clause, table_op select_or_subquery_without_values_query_no_with_clause);
 
@@ -13924,14 +13894,14 @@ select_expression_without_values_query_no_with_clause
 			$$ = stmt;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| select_or_subquery_without_values_query_no_with_clause
 		{{ DBG_TRACE_GRAMMAR(select_expression_without_values_query_no_with_clause, | select_or_subquery_without_values_query_no_with_clause);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 select_expression_without_values_and_single_subquery
@@ -13980,7 +13950,7 @@ select_expression_without_values_and_single_subquery
 
 			parser_push_orderby_node (node);
 
-		DBG_PRINT}}
+		}}
 	  opt_select_limit_clause
 	  opt_for_update_clause
 		{{ DBG_TRACE_GRAMMAR(select_expression_without_values_and_single_subquery, opt_select_limit_clause opt_for_update_clause);
@@ -13989,7 +13959,7 @@ select_expression_without_values_and_single_subquery
 			$<node>$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($<node>$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	  table_op select_or_subquery_without_values_query_no_with_clause
 		{{ DBG_TRACE_GRAMMAR(select_expression_without_values_and_single_subquery, table_op select_or_subquery_without_values_query_no_with_clause);
 
@@ -14016,14 +13986,14 @@ select_expression_without_values_and_single_subquery
 			$$ = stmt;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| select_or_nested_values_query
 		{{ DBG_TRACE_GRAMMAR(select_expression_without_values_and_single_subquery, | select_or_nested_values_query);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 table_op
@@ -14041,7 +14011,7 @@ table_op
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| DIFFERENCE_ all_distinct
 		{{ DBG_TRACE_GRAMMAR(table_op, | DIFFERENCE_ all_distinct);
 
@@ -14057,7 +14027,7 @@ table_op
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| EXCEPT all_distinct
 		{{ DBG_TRACE_GRAMMAR(table_op, | EXCEPT all_distinct);
 
@@ -14073,7 +14043,7 @@ table_op
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| INTERSECTION all_distinct
 		{{ DBG_TRACE_GRAMMAR(table_op, | INTERSECTION all_distinct);
 
@@ -14089,7 +14059,7 @@ table_op
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| INTERSECT all_distinct
 		{{ DBG_TRACE_GRAMMAR(table_op, | INTERSECT all_distinct);
 
@@ -14105,7 +14075,7 @@ table_op
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 select_or_subquery
@@ -14115,19 +14085,19 @@ select_or_subquery
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| subquery
 		{{ DBG_TRACE_GRAMMAR(select_or_subquery, | subquery);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| values_query
 		{{ DBG_TRACE_GRAMMAR(select_or_subquery, | values_query);
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
 	;
 
 select_or_values_query
@@ -14135,14 +14105,14 @@ select_or_values_query
 		{{ DBG_TRACE_GRAMMAR(select_or_values_query, : values_query);
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
 	| select_stmt
 		{{ DBG_TRACE_GRAMMAR(select_or_values_query, | select_stmt);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 select_or_subquery_without_values_query_no_with_clause
@@ -14152,14 +14122,14 @@ select_or_subquery_without_values_query_no_with_clause
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| subquery_without_subquery_and_with_clause
 		{{ DBG_TRACE_GRAMMAR(select_or_subquery_without_values_query_no_with_clause, | subquery_without_subquery_and_with_clause);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 select_or_nested_values_query
@@ -14169,12 +14139,12 @@ select_or_nested_values_query
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| '(' values_query ')'
 		{{ DBG_TRACE_GRAMMAR(select_or_nested_values_query, | '(' values_query ')');
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
 	;
 
 values_query
@@ -14197,7 +14167,7 @@ values_query
 
 			  parser_push_select_stmt_node (node);
 			  parser_push_hint_node (node);
-		DBG_PRINT}}
+		}}
 		values_expression
 			{{ DBG_TRACE_GRAMMAR(values_query, values_expression);
 				/* $3 node of type PT_NODE_LIST */
@@ -14241,7 +14211,7 @@ values_query
 				  parser_select_level--;
 
 				$$ = node;
-			DBG_PRINT}}
+			}}
 	;
 
 values_expression
@@ -14252,11 +14222,11 @@ values_expression
 			parser_make_link (node1, node2);
 
 			$$ = node1;
-		DBG_PRINT}}
+		}}
 	| values_expr_item
 		{{ DBG_TRACE_GRAMMAR(values_expression, | values_expr_item);
 			$$ = $1;
-		DBG_PRINT}}
+		}}
 	;
 
 values_expr_item
@@ -14276,7 +14246,7 @@ values_expr_item
 			PT_SET_VALUE_QUERY(node);
 
 			$$ = node;
-		DBG_PRINT}}
+		}}
 	;
 
 select_stmt
@@ -14301,7 +14271,7 @@ select_stmt
 			parser_push_select_stmt_node (node);
 			parser_push_hint_node (node);
 
-		DBG_PRINT}}
+		}}
 	opt_hint_list 		/* $3 */
 	all_distinct            /* $4 */
 	select_list 		/* $5 */
@@ -14338,7 +14308,7 @@ opt_with_clause
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| WITH            /* $1 */
 	  opt_recursive   /* $2 */
 	  cte_definition_list   /* $3 */
@@ -14357,7 +14327,7 @@ opt_with_clause
 
 			$$ = node;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_recursive
@@ -14365,12 +14335,12 @@ opt_recursive
 		{{ DBG_TRACE_GRAMMAR(opt_recursive, : );
 			$$ = 0;
 
-		DBG_PRINT}}
+		}}
 	| RECURSIVE
 		{{ DBG_TRACE_GRAMMAR(opt_recursive, | RECURSIVE);
 			$$ = 1;
 
-		DBG_PRINT}}
+		}}
 	;
 
 cte_definition_list
@@ -14380,14 +14350,14 @@ cte_definition_list
 			$$ = parser_make_link($1, $3);
 			PARSER_SAVE_ERR_CONTEXT($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| cte_definition
 		{{ DBG_TRACE_GRAMMAR(cte_definition_list, | cte_definition);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
   	;
 
 cte_definition
@@ -14411,7 +14381,7 @@ cte_definition
 
 			$$ = node;
 
-		DBG_PRINT}}
+		}}
   	;
 
 cte_query_list
@@ -14433,14 +14403,14 @@ cte_query_list
 			$$ = stmt;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| select_or_subquery
 		{{ DBG_TRACE_GRAMMAR(cte_query_list, | select_or_subquery);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT($$, @$.buffer_pos);
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_from_clause
@@ -14481,14 +14451,14 @@ opt_from_clause
 
 			$$ = node;
 
-		DBG_PRINT}}
+		}}
 	| FROM				/* $1 */
 	  extended_table_spec_list	/* $2 */
 		{{			/* $3 */
                     DBG_TRACE_GRAMMAR(opt_from_clause, | FROM extended_table_spec_list);
 			parser_found_Oracle_outer = false;
 
-		DBG_PRINT}}
+		}}
 	  opt_where_clause		/* $4 */
 	  opt_startwith_connectby_clause/* $5 */
 	  opt_groupby_clause		/* $6 */
@@ -14609,7 +14579,7 @@ opt_from_clause
 
 			$$ = node;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_select_param_list
@@ -14618,21 +14588,21 @@ opt_select_param_list
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| INTO to_param_list
 		{{ DBG_TRACE_GRAMMAR(opt_select_param_list, | INTO to_param_list);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| TO to_param_list
 		{{ DBG_TRACE_GRAMMAR(opt_select_param_list, | TO to_param_list);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_hint_list
@@ -14650,7 +14620,7 @@ hint_list
 			char *hint_comment = $2;
 			(void) pt_get_hint (hint_comment, parser_hint_table, node);
 
-		DBG_PRINT}}
+		}}
 	| hint_list SQL_STYLE_HINT
 		{{ DBG_TRACE_GRAMMAR(hint_list, | hint_list SQL_STYLE_HINT);
 
@@ -14658,7 +14628,7 @@ hint_list
 			char *hint_comment = $2;
 			(void) pt_get_hint (hint_comment, parser_hint_table, node);
 
-		DBG_PRINT}}
+		}}
 	| hint_list C_STYLE_HINT
 		{{ DBG_TRACE_GRAMMAR(hint_list, | hint_list C_STYLE_HINT);
 
@@ -14666,7 +14636,7 @@ hint_list
 			char *hint_comment = $2;
 			(void) pt_get_hint (hint_comment, parser_hint_table, node);
 
-		DBG_PRINT}}
+		}}
 	| CPP_STYLE_HINT
 		{{ DBG_TRACE_GRAMMAR(hint_list, | CPP_STYLE_HINT);
 
@@ -14674,7 +14644,7 @@ hint_list
 			char *hint_comment = $1;
 			(void) pt_get_hint (hint_comment, parser_hint_table, node);
 
-		DBG_PRINT}}
+		}}
 	| SQL_STYLE_HINT
 		{{ DBG_TRACE_GRAMMAR(hint_list, | SQL_STYLE_HINT);
 
@@ -14682,7 +14652,7 @@ hint_list
 			char *hint_comment = $1;
 			(void) pt_get_hint (hint_comment, parser_hint_table, node);
 
-		DBG_PRINT}}
+		}}
 	| C_STYLE_HINT
 		{{ DBG_TRACE_GRAMMAR(hint_list, | C_STYLE_HINT);
 
@@ -14690,7 +14660,7 @@ hint_list
 			char *hint_comment = $1;
 			(void) pt_get_hint (hint_comment, parser_hint_table, node);
 
-		DBG_PRINT}}
+		}}
 	;
 
 all_distinct
@@ -14699,25 +14669,25 @@ all_distinct
 
 			$$ = PT_EMPTY;
 
-		DBG_PRINT}}
+		}}
 	| ALL
 		{{ DBG_TRACE_GRAMMAR(all_distinct, | ALL);
 
 			$$ = PT_ALL;
 
-		DBG_PRINT}}
+		}}
 	| DISTINCT
 		{{ DBG_TRACE_GRAMMAR(all_distinct, | DISTINCT);
 
 			$$ = PT_DISTINCT;
 
-		DBG_PRINT}}
+		}}
 	| UNIQUE
 		{{ DBG_TRACE_GRAMMAR(all_distinct, | UNIQUE);
 
 			$$ = PT_DISTINCT;
 
-		DBG_PRINT}}
+		}}
 	;
 
 select_list
@@ -14730,7 +14700,7 @@ select_list
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 
 	| '*' ',' alias_enabled_expression_list_top
 		{{ DBG_TRACE_GRAMMAR(select_list, | '*' ',' alias_enabled_expression_list_top);
@@ -14742,13 +14712,13 @@ select_list
 			$$ = parser_make_link (node, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 
 	| alias_enabled_expression_list_top
 		{{ DBG_TRACE_GRAMMAR(select_list, | alias_enabled_expression_list_top);
 			 $$ = $1;
 			 PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
 	;
 
 alias_enabled_expression_list_top
@@ -14762,7 +14732,7 @@ alias_enabled_expression_list_top
 			parser_save_and_set_prc (1);
 			parser_save_and_set_cbrc (1);
 
-		DBG_PRINT}}
+		}}
 	  alias_enabled_expression_list
 		{{ DBG_TRACE_GRAMMAR(alias_enabled_expression_list_top, alias_enabled_expression_list);
 
@@ -14775,7 +14745,7 @@ alias_enabled_expression_list_top
 			parser_restore_prc ();
 			parser_restore_cbrc ();
 
-		DBG_PRINT}}
+		}}
 	;
 
 alias_enabled_expression_list
@@ -14785,7 +14755,7 @@ alias_enabled_expression_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| alias_enabled_expression_
 		{{ DBG_TRACE_GRAMMAR(alias_enabled_expression_list, | alias_enabled_expression_);
 
@@ -14797,7 +14767,7 @@ alias_enabled_expression_list
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 alias_enabled_expression_
@@ -14845,7 +14815,7 @@ alias_enabled_expression_
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| predicate_expression opt_as_identifier %dprec 1
 		{{ DBG_TRACE_GRAMMAR(alias_enabled_expression_, | predicate_expression opt_as_identifier);
 
@@ -14862,7 +14832,7 @@ alias_enabled_expression_
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 expression_list
@@ -14871,7 +14841,7 @@ expression_list
 
 			$$ = CONTAINER_AT_0($1);
 
-		DBG_PRINT}}
+		}}
 	;
 
 expression_queue
@@ -14887,7 +14857,7 @@ expression_queue
 			$$ = new_q;
 			PARSER_SAVE_ERR_CONTEXT (q_head, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| expression_
 		{{ DBG_TRACE_GRAMMAR(expression_queue, | expression_);
 			container_2 new_q;
@@ -14896,7 +14866,7 @@ expression_queue
 			$$ = new_q;
 			PARSER_SAVE_ERR_CONTEXT ($1, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;        
 
 expression_list_for_call
@@ -14905,7 +14875,7 @@ expression_list_for_call
 
 			$$ = CONTAINER_AT_0($1);
 
-		DBG_PRINT}}
+		}}
 	;
 
 expression_queue_for_call
@@ -14936,7 +14906,7 @@ expression_queue_for_call
 			$$ = new_q;
 			PARSER_SAVE_ERR_CONTEXT (q_head, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| 
            {{ 
                 if(pwd_info.parser_call_check)
@@ -14960,7 +14930,7 @@ expression_queue_for_call
 			$$ = new_q;
 			PARSER_SAVE_ERR_CONTEXT ($2, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 to_param_list
@@ -14970,14 +14940,14 @@ to_param_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| to_param
 		{{ DBG_TRACE_GRAMMAR(to_param_list, | to_param);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 to_param
@@ -14988,7 +14958,7 @@ to_param
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| param_
 		{{ DBG_TRACE_GRAMMAR(to_param, | param_);
 
@@ -15004,7 +14974,7 @@ to_param
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
         | identifier DOT identifier
 		{{ DBG_TRACE_GRAMMAR(to_param, | identifier DOT identifier);
 
@@ -15036,7 +15006,7 @@ to_param
                         $$ = val;  
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 
 	| identifier
 		{{ DBG_TRACE_GRAMMAR(to_param, | identifier);
@@ -15053,7 +15023,7 @@ to_param
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 from_param
@@ -15071,7 +15041,7 @@ from_param
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| param_
 		{{ DBG_TRACE_GRAMMAR(from_param, | param_);
 
@@ -15086,7 +15056,7 @@ from_param
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	/*
 	 * It must be changed to "CLASS class_name" by User Schema support.
 	 * However, it is difficult to change to "CLASS class_name"
@@ -15107,7 +15077,7 @@ from_param
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| identifier
 		{{ DBG_TRACE_GRAMMAR(from_param, | identifier);
 
@@ -15122,7 +15092,7 @@ from_param
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 
@@ -15147,7 +15117,7 @@ host_param_input
 
 			$$ = node;
 
-		DBG_PRINT}}
+		}}
 	| PARAM_HEADER uint_text
 		{{ DBG_TRACE_GRAMMAR(host_param_input, | PARAM_HEADER uint_text);
 
@@ -15172,7 +15142,7 @@ host_param_input
 
 			$$ = node;
 
-		DBG_PRINT}}
+		}}
 	;
 
 host_param_output
@@ -15191,7 +15161,7 @@ host_param_output
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| PARAM_HEADER uint_text
 		{{ DBG_TRACE_GRAMMAR(host_param_output, | PARAM_HEADER uint_text);
 
@@ -15217,7 +15187,7 @@ host_param_output
 
 			$$ = node;
 
-		DBG_PRINT}}
+		}}
 	;
 
 param_
@@ -15228,7 +15198,7 @@ param_
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_where_clause
@@ -15237,7 +15207,7 @@ opt_where_clause
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	|	{ DBG_TRACE_GRAMMAR(opt_where_clause, | );
 			parser_save_and_set_ic (1);
 			assert (parser_prior_check == 0);
@@ -15256,7 +15226,7 @@ opt_where_clause
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_startwith_connectby_clause
@@ -15267,7 +15237,7 @@ opt_startwith_connectby_clause
 			SET_CONTAINER_2 (ctn, NULL, NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| startwith_clause connectby_clause
 		{{ DBG_TRACE_GRAMMAR(opt_startwith_connectby_clause, |  startwith_clause connectby_clause);
 
@@ -15275,7 +15245,7 @@ opt_startwith_connectby_clause
 			SET_CONTAINER_2 (ctn, $1, $2);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| connectby_clause startwith_clause
 		{{ DBG_TRACE_GRAMMAR(opt_startwith_connectby_clause, |  connectby_clause startwith_clause);
 
@@ -15283,7 +15253,7 @@ opt_startwith_connectby_clause
 			SET_CONTAINER_2 (ctn, $2, $1);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| connectby_clause
 		{{ DBG_TRACE_GRAMMAR(opt_startwith_connectby_clause, |  connectby_clause);
 
@@ -15291,7 +15261,7 @@ opt_startwith_connectby_clause
 			SET_CONTAINER_2 (ctn, NULL, $1);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 
 startwith_clause
 	:	{ DBG_TRACE_GRAMMAR(startwith_clause, : );
@@ -15304,7 +15274,7 @@ startwith_clause
 			$$ = $4;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 connectby_clause
@@ -15324,7 +15294,7 @@ connectby_clause
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 connectby_clause_with_option
@@ -15338,12 +15308,12 @@ connectby_clause_with_option
 		  }
 
                 $$=$4;
-		DBG_PRINT}}
+		}}
 
         | CONNECT BY search_condition %dprec 1
         {{ DBG_TRACE_GRAMMAR(connectby_clause_with_option, | CONNECT BY search_condition);
                 $$=$3;
-		DBG_PRINT}}
+		}}
         ;
 
 opt_groupby_clause
@@ -15352,14 +15322,14 @@ opt_groupby_clause
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| GROUP_ BY group_spec_list
 		{{ DBG_TRACE_GRAMMAR(opt_groupby_clause, |  GROUP_ BY group_spec_list);
 
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_with_rollup
@@ -15368,13 +15338,13 @@ opt_with_rollup
 
 			$$ = 0;
 
-		DBG_PRINT}}
+		}}
 	| WITH ROLLUP
 		{{ DBG_TRACE_GRAMMAR(opt_with_rollup, |  WITH ROLLUP);
 
 			$$ = 1;
 
-		DBG_PRINT}}
+		}}
 	;
 
 group_spec_list
@@ -15384,14 +15354,14 @@ group_spec_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| group_spec
 		{{ DBG_TRACE_GRAMMAR(group_spec_list, |  group_spec);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 
@@ -15448,7 +15418,7 @@ group_spec
 
 			$$ = node;
 
-		DBG_PRINT}}
+		}}
 	;
 
 
@@ -15458,7 +15428,7 @@ opt_having_clause
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	|	{ parser_save_and_set_gc(1); }
 	  HAVING search_condition
 		{{ DBG_TRACE_GRAMMAR(opt_having_clause, | HAVING search_condition);
@@ -15467,7 +15437,7 @@ opt_having_clause
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_using_index_clause
@@ -15476,14 +15446,14 @@ opt_using_index_clause
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| USING INDEX index_hint_name_keylimit_list
 		{{ DBG_TRACE_GRAMMAR(opt_using_index_clause, | USING INDEX index_hint_name_keylimit_list);
 
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| USING INDEX NONE
 		{{ DBG_TRACE_GRAMMAR(opt_using_index_clause, | USING INDEX NONE);
 
@@ -15500,7 +15470,7 @@ opt_using_index_clause
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| USING INDEX ALL EXCEPT index_hint_name_list
 		{{ DBG_TRACE_GRAMMAR(opt_using_index_clause, | USING INDEX ALL EXCEPT index_hint_name_list);
 			PT_NODE *curr;
@@ -15536,7 +15506,7 @@ opt_using_index_clause
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 index_hint_name_keylimit_list
@@ -15546,14 +15516,14 @@ index_hint_name_keylimit_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| index_hint_name_keylimit
 		{{ DBG_TRACE_GRAMMAR(index_hint_name_keylimit_list, | index_hint_name_keylimit);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 index_hint_name_list
@@ -15563,14 +15533,14 @@ index_hint_name_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| index_hint_name
 		{{ DBG_TRACE_GRAMMAR(index_hint_name_list, | index_hint_name);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 index_hint_name_keylimit
@@ -15599,7 +15569,7 @@ index_hint_name_keylimit
 			  }
 			$$ = node;
 
-		DBG_PRINT}}
+		}}
 	| index_hint_name KEYLIMIT limit_expr ',' limit_expr
 		{{ DBG_TRACE_GRAMMAR(index_hint_name_keylimit, | index_hint_name KEYLIMIT limit_expr ',' limit_expr);
 
@@ -15624,14 +15594,14 @@ index_hint_name_keylimit
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| index_hint_name
 		{{ DBG_TRACE_GRAMMAR(index_hint_name_keylimit, | index_hint_name);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 index_hint_name
@@ -15643,7 +15613,7 @@ index_hint_name
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| index_name paren_minus
 		{{ DBG_TRACE_GRAMMAR(index_name, | index_name paren_minus);
 
@@ -15652,7 +15622,7 @@ index_hint_name
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| index_name
 		{{ DBG_TRACE_GRAMMAR(index_hint_name, | index_name);
 
@@ -15661,7 +15631,7 @@ index_hint_name
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| identifier DOT NONE
 		{{ DBG_TRACE_GRAMMAR(index_name, | identifier DOT NONE);
 
@@ -15673,7 +15643,7 @@ index_hint_name
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_with_increment_clause
@@ -15682,21 +15652,21 @@ opt_with_increment_clause
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| WITH INCREMENT For incr_arg_name_list__inc
 		{{ DBG_TRACE_GRAMMAR(opt_with_increment_clause, | WITH INCREMENT For incr_arg_name_list__inc);
 
 			$$ = $4;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| WITH DECREMENT For incr_arg_name_list__dec
 		{{ DBG_TRACE_GRAMMAR(opt_with_increment_clause, | WITH DECREMENT For incr_arg_name_list__dec);
 
 			$$ = $4;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_for_update_clause
@@ -15720,7 +15690,7 @@ opt_for_update_clause
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| For UPDATE OF class_name_list
 		{{ DBG_TRACE_GRAMMAR(opt_for_update_clause, | For UPDATE OF class_name_list);
 
@@ -15761,7 +15731,7 @@ opt_for_update_clause
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 incr_arg_name_list__inc
@@ -15771,14 +15741,14 @@ incr_arg_name_list__inc
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| incr_arg_name__inc
 		{{ DBG_TRACE_GRAMMAR(incr_arg_name_list__inc, | incr_arg_name__inc);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 incr_arg_name__inc
@@ -15803,7 +15773,7 @@ incr_arg_name__inc
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
 	;
 
 incr_arg_name_list__dec
@@ -15813,14 +15783,14 @@ incr_arg_name_list__dec
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| incr_arg_name__dec
 		{{ DBG_TRACE_GRAMMAR(incr_arg_name_list__dec, | incr_arg_name__dec);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 incr_arg_name__dec
@@ -15845,7 +15815,7 @@ incr_arg_name__dec
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
 	;
 
 opt_update_orderby_clause
@@ -15866,7 +15836,7 @@ opt_update_orderby_clause
 
 			$$ = stmt;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
 	;
 
 opt_orderby_clause
@@ -15898,7 +15868,7 @@ opt_orderby_clause
 				MSGCAT_SET_PARSER_SEMANTIC,
 				MSGCAT_SEMANTIC_NOT_ALLOWED_HERE, "ORDER BY");
 
-		DBG_PRINT}}
+		}}
 	  sort_spec_list
 		{{ DBG_TRACE_GRAMMAR(opt_orderby_clause, sort_spec_list);
 
@@ -15910,7 +15880,7 @@ opt_orderby_clause
 			parser_restore_pseudoc ();
 			parser_save_and_set_oc (1);
 
-		DBG_PRINT}}
+		}}
 	  opt_for_search_condition
 		{{ DBG_TRACE_GRAMMAR(opt_orderby_clause, opt_for_search_condition);
 
@@ -16071,7 +16041,7 @@ opt_orderby_clause
 			$$ = stmt;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_siblings
@@ -16089,7 +16059,7 @@ opt_siblings
 				    "SIBLINGS");
 			    }
 
-		DBG_PRINT}}
+		}}
 	;
 
 limit_expr
@@ -16098,19 +16068,19 @@ limit_expr
                         $$ = parser_make_expression (this_parser, PT_PLUS, $1, $3, NULL);
                         PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-                DBG_PRINT}}
+                }}
         | limit_expr '-' limit_term
                 {{ DBG_TRACE_GRAMMAR(limit_expr, | limit_expr '-' limit_term);
                         $$ = parser_make_expression (this_parser, PT_MINUS, $1, $3, NULL);
                         PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-                DBG_PRINT}}
+                }}
         | limit_term
                 {{ DBG_TRACE_GRAMMAR(limit_expr, | limit_term);
                         $$ = $1;
                         PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-                DBG_PRINT}}
+                }}
         ;
 
 limit_term
@@ -16119,19 +16089,19 @@ limit_term
                         $$ = parser_make_expression (this_parser, PT_TIMES, $1, $3, NULL);
                         PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-                DBG_PRINT}}
+                }}
         | limit_term '/' limit_factor
                 {{ DBG_TRACE_GRAMMAR(limit_term, | limit_term '/' limit_factor);
                         $$ = parser_make_expression (this_parser, PT_DIV, $1, $3, NULL);
                         PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-                DBG_PRINT}}
+                }}
         | limit_factor
                 {{ DBG_TRACE_GRAMMAR(limit_term, | limit_factor);
                         $$ = $1;
                         PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-                DBG_PRINT}}
+                }}
           ;
 
 limit_factor
@@ -16141,14 +16111,14 @@ limit_factor
                         $$ = $1;
                         PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-                DBG_PRINT}}
+                }}
         | unsigned_integer
                 {{ DBG_TRACE_GRAMMAR(limit_factor, | unsigned_integer);
 
                         $$ = $1;
                         PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-                DBG_PRINT}}
+                }}
         | identifier_without_dot    /* for PL/CSQL Static SQL only */
                 {{ DBG_TRACE_GRAMMAR(limit_factor, | identifier_without_dot);
 
@@ -16177,7 +16147,7 @@ limit_factor
                             $$ = NULL;
                         }
 
-                DBG_PRINT}}
+                }}
         | '(' limit_expr ')'
                 {{ DBG_TRACE_GRAMMAR(limit_factor, | '(' limit_expr ')');
 			PT_NODE *exp = $2;
@@ -16190,14 +16160,14 @@ limit_factor
                         $$ = exp;
                         PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-                DBG_PRINT}}
+                }}
         ;
 
 opt_select_limit_clause
 	: /* empty */
            {{ DBG_TRACE_GRAMMAR(opt_select_limit_clause, : );
                   $$ = NULL; 
-                  DBG_PRINT }}
+                  }}
 	| LIMIT limit_options
 	        {{ DBG_TRACE_GRAMMAR(opt_select_limit_clause, | LIMIT limit_options);
 
@@ -16264,7 +16234,7 @@ opt_select_limit_clause
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 limit_options
@@ -16280,7 +16250,7 @@ limit_options
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| limit_expr ',' limit_expr
 		{{ DBG_TRACE_GRAMMAR(limit_options, | limit_expr ',' limit_expr);
 
@@ -16299,7 +16269,7 @@ limit_options
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| limit_expr OFFSET limit_expr
 		{{ DBG_TRACE_GRAMMAR(limit_options, | limit_expr OFFSET limit_expr);
 
@@ -16318,7 +16288,7 @@ limit_options
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_upd_del_limit_clause
@@ -16331,7 +16301,7 @@ opt_upd_del_limit_clause
 			  $$ = $2;
 			  PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_for_search_condition
@@ -16356,7 +16326,7 @@ opt_for_search_condition
 			     }
 			  }
 			$$ = $2;
-		DBG_PRINT}}
+		}}
 	;
 
 sort_spec_list
@@ -16366,14 +16336,14 @@ sort_spec_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| sort_spec
 		{{ DBG_TRACE_GRAMMAR(sort_spec_list, | sort_spec);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 sort_spec
@@ -16391,7 +16361,7 @@ sort_spec
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| expression_ DESC opt_nulls_first_or_last
 		{{ DBG_TRACE_GRAMMAR(sort_spec, | expression_ DESC opt_nulls_first_or_last);
 
@@ -16407,7 +16377,7 @@ sort_spec
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| expression_ opt_nulls_first_or_last
 		{{ DBG_TRACE_GRAMMAR(sort_spec, | expression_ opt_nulls_first_or_last);
 
@@ -16423,7 +16393,7 @@ sort_spec
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_nulls_first_or_last
@@ -16432,19 +16402,19 @@ opt_nulls_first_or_last
 
 			$$ = PT_NULLS_DEFAULT;
 
-		DBG_PRINT}}
+		}}
 	| NULLS FIRST
 		{{ DBG_TRACE_GRAMMAR(opt_nulls_first_or_last, | NULLS FIRST);
 
 			$$ = PT_NULLS_FIRST;
 
-		DBG_PRINT}}
+		}}
 	| NULLS LAST
 		{{ DBG_TRACE_GRAMMAR(opt_nulls_first_or_last, | NULLS LAST);
 
 			$$ = PT_NULLS_LAST;
 
-		DBG_PRINT}}
+		}}
 	;
 
 expression_
@@ -16454,14 +16424,14 @@ expression_
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| predicate_expression
 		{{DBG_TRACE_GRAMMAR(expression_, | predicate_expression);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 
@@ -16472,14 +16442,14 @@ normal_expression
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| expression_strcat
 		{{ DBG_TRACE_GRAMMAR(normal_expression, | expression_strcat);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 expression_strcat
@@ -16489,14 +16459,14 @@ expression_strcat
 			$$ = parser_make_expression (this_parser, PT_STRCAT, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| expression_bitor
 		{{ DBG_TRACE_GRAMMAR(expression_strcat, | expression_bitor);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 expression_bitor
@@ -16506,14 +16476,14 @@ expression_bitor
 			$$ = parser_make_expression (this_parser, PT_BIT_OR, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| expression_bitand
 		{{ DBG_TRACE_GRAMMAR(expression_bitor, | expression_bitand);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 expression_bitand
@@ -16523,14 +16493,14 @@ expression_bitand
 			$$ = parser_make_expression (this_parser, PT_BIT_AND, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| expression_bitshift
 		{{ DBG_TRACE_GRAMMAR(expression_bitand, | expression_bitshift);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 expression_bitshift
@@ -16540,21 +16510,21 @@ expression_bitshift
 			$$ = parser_make_expression (this_parser, PT_BITSHIFT_LEFT, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| expression_bitshift BITSHIFT_RIGHT expression_add_sub
 		{{ DBG_TRACE_GRAMMAR(expression_bitshift, | expression_bitshift BITSHIFT_RIGHT expression_add_sub);
 
 			$$ = parser_make_expression (this_parser, PT_BITSHIFT_RIGHT, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| expression_add_sub
 		{{ DBG_TRACE_GRAMMAR(expression_bitshift, | expression_add_sub);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 expression_add_sub
@@ -16564,21 +16534,21 @@ expression_add_sub
 			$$ = parser_make_expression (this_parser, PT_PLUS, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| expression_add_sub '-' term
 		{{ DBG_TRACE_GRAMMAR(expression_add_sub, | expression_add_sub '-' term);
 
 			$$ = parser_make_expression (this_parser, PT_MINUS, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| term
 		{{ DBG_TRACE_GRAMMAR(expression_add_sub, | term);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 term
@@ -16588,35 +16558,35 @@ term
 			$$ = parser_make_expression (this_parser, PT_TIMES, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| term '/' factor
 		{{ DBG_TRACE_GRAMMAR(term, | term '/' factor);
 
 			$$ = parser_make_expression (this_parser, PT_DIVIDE, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| term DIV factor
 		{{ DBG_TRACE_GRAMMAR(term, | term DIV factor);
 
 			$$ = parser_make_expression (this_parser, PT_DIV, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| term MOD factor
 		{{ DBG_TRACE_GRAMMAR(term, | term MOD factor);
 
 			$$ = parser_make_expression (this_parser, PT_MOD, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| factor
 		{{ DBG_TRACE_GRAMMAR(term, | factor);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 factor
@@ -16626,14 +16596,14 @@ factor
 			$$ = parser_make_expression (this_parser, PT_BIT_XOR, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| factor_
 		{{ DBG_TRACE_GRAMMAR(factor, | factor_);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 factor_
@@ -16643,28 +16613,28 @@ factor_
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| '-' factor_
 		{{ DBG_TRACE_GRAMMAR(factor_, | '-' factor_);
 
 			$$ = parser_make_expression (this_parser, PT_UNARY_MINUS, $2, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| '+' factor_
 		{{ DBG_TRACE_GRAMMAR(factor_, | '+' factor_);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| '~' primary
 		{{ DBG_TRACE_GRAMMAR(factor_, | '~' primary);
 
 			$$ = parser_make_expression (this_parser, PT_BIT_NOT, $2, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| PRIOR
 		{{ DBG_TRACE_GRAMMAR(factor_, | PRIOR);
 
@@ -16673,7 +16643,7 @@ factor_
 			parser_save_and_set_cbrc (0);
 			parser_save_and_set_pseudoc (0);
 
-		DBG_PRINT}}
+		}}
 	  primary_w_collate
 		{{ DBG_TRACE_GRAMMAR(factor_, primary_w_collate);
 
@@ -16693,7 +16663,7 @@ factor_
 
 			$$ = node;
 
-		DBG_PRINT}}
+		}}
 	| CONNECT_BY_ROOT
 		{{ DBG_TRACE_GRAMMAR(factor_, | CONNECT_BY_ROOT);
 
@@ -16702,7 +16672,7 @@ factor_
 			parser_save_and_set_cbrc (0);
 			parser_save_and_set_pseudoc (0);
 
-		DBG_PRINT}}
+		}}
 	  primary_w_collate
 		{{ DBG_TRACE_GRAMMAR(factor_, primary_w_collate);
 
@@ -16722,7 +16692,7 @@ factor_
 
 			$$ = node;
 
-		DBG_PRINT}}
+		}}
 	;
 
 primary_w_collate
@@ -16744,7 +16714,7 @@ primary_w_collate
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 
 primary
 	: pseudo_column		%dprec 11
@@ -16757,35 +16727,35 @@ primary
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| reserved_func		%dprec 10
 		{{ DBG_TRACE_GRAMMAR(primary, | reserved_func);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| case_expr		%dprec 9
 		{{ DBG_TRACE_GRAMMAR(primary, | case_expr);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| extract_expr		%dprec 8
 		{{ DBG_TRACE_GRAMMAR(primary, | extract_expr);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| literal_w_o_param	%dprec 7
 		{{ DBG_TRACE_GRAMMAR(primary, | literal_w_o_param);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| insert_expression	%dprec 6
 		{{ DBG_TRACE_GRAMMAR(primary, | insert_expression);
 
@@ -16794,14 +16764,14 @@ primary
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 			parser_groupby_exception = PT_IS_SUBINSERT;
 
-		DBG_PRINT}}
+		}}
 	| path_expression	%dprec 5
 		{{ DBG_TRACE_GRAMMAR(primary, | path_expression);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| '(' expression_list ')' %dprec 4
 		{{ DBG_TRACE_GRAMMAR(primary, | '(' expression_list ')');
 			PT_NODE *exp = $2;
@@ -16809,7 +16779,7 @@ primary
 			$$ = exp;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| ROW '(' expression_list ')' %dprec 4
 		{{ DBG_TRACE_GRAMMAR(primary, | ROW '(' expression_list ')');
 			PT_NODE *exp = $3;
@@ -16817,7 +16787,7 @@ primary
 			$$ = exp;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| '(' search_condition_query ')' %dprec 2
 		{{ DBG_TRACE_GRAMMAR(primary, | '(' search_condition_query ')');
 
@@ -16832,13 +16802,13 @@ primary
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 			parser_groupby_exception = PT_EXPR;
 
-		DBG_PRINT}}
+		}}
 	| subquery    %dprec 1
 		{{ DBG_TRACE_GRAMMAR(primary, | subquery);
 			parser_groupby_exception = PT_IS_SUBQUERY;
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
 	| session_variable_expression
 		{{ DBG_TRACE_GRAMMAR(primary, | session_variable_expression);
 
@@ -16855,7 +16825,7 @@ search_condition_query
 			PT_NODE *node = $1;
 			parser_push_orderby_node (node);
 
-		DBG_PRINT}}
+		}}
 	  opt_orderby_clause
 		{{ DBG_TRACE_GRAMMAR(search_condition_query, opt_orderby_clause);
 
@@ -16863,7 +16833,7 @@ search_condition_query
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 search_condition_expression
@@ -16873,7 +16843,7 @@ search_condition_expression
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 pseudo_column
@@ -16883,21 +16853,21 @@ pseudo_column
 			$$ = parser_make_expression (this_parser, PT_CONNECT_BY_ISCYCLE, NULL, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| CONNECT_BY_ISLEAF
 		{{ DBG_TRACE_GRAMMAR(pseudo_column, | CONNECT_BY_ISLEAF);
 
 			$$ = parser_make_expression (this_parser, PT_CONNECT_BY_ISLEAF, NULL, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| LEVEL
 		{{ DBG_TRACE_GRAMMAR(pseudo_column, | LEVEL);
 
 			$$ = parser_make_expression (this_parser, PT_LEVEL, NULL, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 
@@ -16918,7 +16888,7 @@ reserved_func
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 			parser_groupby_exception = PT_COUNT;
 
-		DBG_PRINT}}
+		}}
 	| COUNT '(' '*' ')' OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | COUNT '(' '*' ')' OVER '(' opt_analytic_partition_by opt_analytic_order_by ')');
 
@@ -16937,7 +16907,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| COUNT '(' of_distinct_unique expression_ ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | COUNT '(' of_distinct_unique expression_ ')');
 
@@ -16954,7 +16924,7 @@ reserved_func
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 			parser_groupby_exception = PT_COUNT;
 
-		DBG_PRINT}}
+		}}
 	| COUNT '(' of_distinct_unique expression_ ')' OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | COUNT '(' of_distinct_unique expression_ ')' OVER '(' ~ ')');
 
@@ -16973,7 +16943,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| COUNT '(' opt_all expression_ ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | COUNT '(' opt_all expression_ ')');
 
@@ -16990,7 +16960,7 @@ reserved_func
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 			parser_groupby_exception = PT_COUNT;
 
-		DBG_PRINT}}
+		}}
 	| COUNT '(' opt_all expression_ ')' OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | COUNT '(' opt_all expression_ ')' OVER '(' ~ ')');
 
@@ -17009,7 +16979,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| of_avg_max_etc '(' of_distinct_unique expression_ ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_avg_max_etc '(' of_distinct_unique expression_ ')');
 
@@ -17031,7 +17001,7 @@ reserved_func
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 			parser_groupby_exception = PT_COUNT;
 
-		DBG_PRINT}}
+		}}
 	| of_avg_max_etc '(' opt_all expression_ ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_avg_max_etc '(' opt_all expression_ ')');
 
@@ -17048,7 +17018,7 @@ reserved_func
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 			parser_groupby_exception = PT_COUNT;
 
-		DBG_PRINT}}
+		}}
 	| of_analytic '(' of_distinct_unique expression_ ')' OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_analytic '(' of_distinct_unique expression_ ')' OVER '(' ~ ')');
 
@@ -17070,7 +17040,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| of_analytic '(' opt_all expression_ ')' OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_analytic '(' opt_all expression_ ')' OVER '(' ~ ')');
 
@@ -17089,7 +17059,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| of_analytic_first_last '(' expression_ ')' opt_analytic_ignore_nulls OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_analytic_first_last '(' expression_ ')' opt_analytic_ignore_nulls OVER '(' ~ ')');
 
@@ -17111,7 +17081,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| of_analytic_nth_value '(' expression_ ',' expression_ ')' opt_analytic_from_last opt_analytic_ignore_nulls OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_analytic_nth_value '(' expression_ ',' expression_ ')' opt_analytic_from_last opt_analytic_ignore_nulls OVER '(' ~ ')');
 
@@ -17142,7 +17112,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| of_analytic_lead_lag '(' expression_ ')' OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_analytic_lead_lag '(' expression_ ')' OVER '(' ~ ')');
 
@@ -17175,7 +17145,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| of_analytic_lead_lag '(' expression_ ',' expression_ ')' OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_analytic_lead_lag '(' expression_ ',' expression_ ')' OVER '(' ~ ')');
 
@@ -17202,7 +17172,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| of_analytic_lead_lag '(' expression_ ',' expression_ ',' expression_ ')' OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_analytic_lead_lag '(' expression_ ',' expression_ ',' expression_ ')' OVER '(' ~ ')');
 
@@ -17223,7 +17193,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| of_analytic_no_args '(' ')' OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_analytic_no_args '(' ')' OVER '(' ~ ')');
 
@@ -17252,7 +17222,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| GROUP_CONCAT
 		{ push_msg(MSGCAT_SYNTAX_INVALID_GROUP_CONCAT); }
 		'(' of_distinct_unique expression_ opt_agg_order_by opt_group_concat_separator ')'
@@ -17272,7 +17242,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| GROUP_CONCAT '(' opt_all opt_expression_list opt_agg_order_by opt_group_concat_separator ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | GROUP_CONCAT '(' opt_all opt_expression_list opt_agg_order_by opt_group_concat_separator ')' );
 
@@ -17297,7 +17267,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| JSON_ARRAYAGG '(' expression_ ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_ARRAYAGG '(' expression_ ')' );
 
@@ -17313,7 +17283,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| JSON_OBJECTAGG '(' expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_OBJECTAGG '(' expression_list ')' );
  			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
@@ -17334,7 +17304,7 @@ reserved_func
 
  			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
- 		DBG_PRINT}}
+ 		}}
 	| of_percentile '(' expression_ ')' WITHIN GROUP_ '(' ORDER BY sort_spec ')' opt_over_analytic_partition_by
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_percentile '(' expression_ ')' WITHIN GROUP_ '(' ORDER BY sort_spec ')' ~ );
 
@@ -17383,7 +17353,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos);
 
-		DBG_PRINT}}
+		}}
 	| INSERT
 	  { push_msg(MSGCAT_SYNTAX_INVALID_INSERT_SUBSTRING); }
 	  '(' expression_list ')'
@@ -17391,19 +17361,19 @@ reserved_func
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | INSERT '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count (this_parser, F_INSERT_SUBSTRING, $4, 4, 4);
                     PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
 	| ELT '(' opt_expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | ELT '(' opt_expression_list ')' );
                     $$ = parser_make_func_with_arg_count (this_parser, F_ELT, $3, 1, 0);
                     PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
 	| POSITION '(' expression_ IN_ expression_ ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | POSITION '(' expression_ IN_ expression_ ')' );
 
 			$$ = parser_make_expression (this_parser, PT_POSITION, $3, $5, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SUBSTRING_
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SUBSTRING); }
 	  '(' expression_ FROM expression_ For expression_ ')'
@@ -17416,7 +17386,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SUBSTRING_
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SUBSTRING); }
 	  '(' expression_ FROM expression_ ')'
@@ -17429,7 +17399,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SUBSTRING_
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SUBSTRING); }
 	  '(' expression_ ',' expression_ ',' expression_ ')'
@@ -17442,7 +17412,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SUBSTRING_
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SUBSTRING); }
 	  '(' expression_ ',' expression_ ')'
@@ -17455,7 +17425,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| Date
 		{ push_msg(MSGCAT_SYNTAX_INVALID_DATE); }
 	  '(' expression_ ')'
@@ -17467,7 +17437,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| Time
 		{ push_msg(MSGCAT_SYNTAX_INVALID_TIME); }
 	  '(' expression_ ')'
@@ -17479,7 +17449,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| ADDDATE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_ADDDATE); }
 	  '(' expression_ ',' expression_ ')'
@@ -17491,7 +17461,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| adddate_name
 		{ push_msg(MSGCAT_SYNTAX_INVALID_DATE_ADD); }
 	  '(' expression_ ',' INTERVAL expression_ datetime_field ')'
@@ -17512,7 +17482,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SUBDATE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SUBDATE); }
 	  '(' expression_ ',' expression_ ')'
@@ -17524,7 +17494,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| subdate_name
 		{ push_msg(MSGCAT_SYNTAX_INVALID_DATE_SUB); }
 	  '(' expression_ ',' INTERVAL expression_ datetime_field ')'
@@ -17545,7 +17515,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| TIMESTAMP
 		{ push_msg(MSGCAT_SYNTAX_INVALID_TIMESTAMP); }
 		'(' expression_ ')'
@@ -17564,7 +17534,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| TIMESTAMP
 		{ push_msg(MSGCAT_SYNTAX_INVALID_TIMESTAMP); }
 		'(' expression_ ',' expression_ ')'
@@ -17576,7 +17546,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| YEAR_
 		{ push_msg(MSGCAT_SYNTAX_INVALID_YEAR); }
 		'(' expression_ ')'
@@ -17588,7 +17558,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| MONTH_
 		{ push_msg(MSGCAT_SYNTAX_INVALID_MONTH); }
 		'(' expression_ ')'
@@ -17600,7 +17570,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| DAY_
 		{ push_msg(MSGCAT_SYNTAX_INVALID_DAY); }
 		'(' expression_ ')'
@@ -17612,7 +17582,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| HOUR_
 		{ push_msg(MSGCAT_SYNTAX_INVALID_HOUR); }
 		'(' expression_ ')'
@@ -17624,7 +17594,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| MINUTE_
 		{ push_msg(MSGCAT_SYNTAX_INVALID_MINUTE); }
 		'(' expression_ ')'
@@ -17636,7 +17606,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SECOND_
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SECOND); }
 		'(' expression_ ')'
@@ -17648,7 +17618,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| DATABASE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_DATABASE); }
 	  '(' ')'
@@ -17660,7 +17630,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SCHEMA
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SCHEMA); }
 	  '(' ')'
@@ -17672,7 +17642,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| TRIM
 		{ push_msg(MSGCAT_SYNTAX_INVALID_TRIM); }
 	  '(' of_leading_trailing_both expression_ FROM expression_ ')'
@@ -17685,7 +17655,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| TRIM
 		{ push_msg(MSGCAT_SYNTAX_INVALID_TRIM); }
 	  '(' of_leading_trailing_both FROM expression_ ')'
@@ -17698,7 +17668,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| TRIM
 		{ push_msg(MSGCAT_SYNTAX_INVALID_TRIM); }
 	  '(' expression_ FROM  expression_ ')'
@@ -17711,7 +17681,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| TRIM
 		{ push_msg(MSGCAT_SYNTAX_INVALID_TRIM); }
 	  '(' expression_ ')'
@@ -17724,7 +17694,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| CHR
 		{ push_msg(MSGCAT_SYNTAX_INVALID_CHR); }
 	  '(' expression_ opt_using_charset ')'
@@ -17736,7 +17706,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| CLOB_TO_CHAR
 		{ push_msg(MSGCAT_SYNTAX_INVALID_CLOB_TO_CHAR); }
 	  '(' expression_ opt_using_charset ')'
@@ -17748,7 +17718,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| CAST
 		{ push_msg(MSGCAT_SYNTAX_INVALID_CAST); }
 	  '(' expression_ AS of_cast_data_type ')'
@@ -17783,7 +17753,7 @@ reserved_func
 			$$ = expr;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| CLASS '(' identifier ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | CLASS '(' identifier ')' );
 
@@ -17792,7 +17762,7 @@ reserved_func
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 			parser_groupby_exception = PT_OID_ATTR;
 
-		DBG_PRINT}}
+		}}
 	| SYS_DATE
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | SYS_DATE );
 
@@ -17800,7 +17770,7 @@ reserved_func
 			$$ = expr;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| of_current_date
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_current_date );
 
@@ -17808,7 +17778,7 @@ reserved_func
 			$$ = expr;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SYS_TIME_
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | SYS_TIME_ );
 
@@ -17816,7 +17786,7 @@ reserved_func
 			$$ = expr;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| of_current_time
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_current_time );
 
@@ -17824,7 +17794,7 @@ reserved_func
 			$$ = expr;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| of_db_timezone_
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_db_timezone_ );
 
@@ -17832,7 +17802,7 @@ reserved_func
 			$$ = expr;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| of_session_timezone_
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_session_timezone_ );
 
@@ -17840,7 +17810,7 @@ reserved_func
 			$$ = expr;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SYS_TIMESTAMP
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | SYS_TIMESTAMP );
 
@@ -17848,7 +17818,7 @@ reserved_func
 			$$ = expr;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| of_current_timestamps
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_current_timestamps );
 
@@ -17856,7 +17826,7 @@ reserved_func
 			$$ = expr;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SYS_DATETIME
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | SYS_DATETIME );
 
@@ -17864,7 +17834,7 @@ reserved_func
 			$$ = expr;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| of_current_datetime
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_current_datetime );
 
@@ -17872,7 +17842,7 @@ reserved_func
 			$$ = expr;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| of_users
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_users );
 
@@ -17884,7 +17854,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| of_users
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SYSTEM_USER); }
 	  '(' ')'
@@ -17896,7 +17866,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| DEFAULT '('
 		{ push_msg(MSGCAT_SYNTAX_INVALID_DEFAULT); }
 	  simple_path_id ')'
@@ -17916,7 +17886,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| LOCAL_TRANSACTION_ID
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | LOCAL_TRANSACTION_ID);
 
@@ -17929,7 +17899,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| ROWNUM
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | ROWNUM);
 
@@ -17950,7 +17920,7 @@ reserved_func
 				       MSGCAT_SEMANTIC_INSTNUM_COMPATIBILITY_ERR,
 				       "INST_NUM() or ROWNUM", "INST_NUM() or ROWNUM");
 
-		DBG_PRINT}}
+		}}
 	| ADD_MONTHS
 		{ push_msg(MSGCAT_SYNTAX_INVALID_ADD_MONTHS); }
 	  '(' expression_ ',' expression_ ')'
@@ -17960,7 +17930,7 @@ reserved_func
 			$$ = parser_make_expression (this_parser, PT_ADD_MONTHS, $4, $6, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| OCTET_LENGTH
 		{ push_msg(MSGCAT_SYNTAX_INVALID_OCTET_LENGTH); }
 	  '(' expression_ ')'
@@ -17970,7 +17940,7 @@ reserved_func
 			$$ = parser_make_expression (this_parser, PT_OCTET_LENGTH, $4, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| BIT_LENGTH
 		{ push_msg(MSGCAT_SYNTAX_INVALID_BIT_LENGTH); }
 	  '(' expression_ ')'
@@ -17980,7 +17950,7 @@ reserved_func
 			$$ = parser_make_expression (this_parser, PT_BIT_LENGTH, $4, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| LOWER
 		{ push_msg(MSGCAT_SYNTAX_INVALID_LOWER); }
 	  '(' expression_ ')'
@@ -17990,7 +17960,7 @@ reserved_func
 			$$ = parser_make_expression (this_parser, PT_LOWER, $4, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| LCASE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_LOWER); }
 	  '(' expression_ ')'
@@ -18000,7 +17970,7 @@ reserved_func
 			$$ = parser_make_expression (this_parser, PT_LOWER, $4, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| UPPER
 		{ push_msg(MSGCAT_SYNTAX_INVALID_UPPER); }
 	  '(' expression_ ')'
@@ -18010,7 +17980,7 @@ reserved_func
 			$$ = parser_make_expression (this_parser, PT_UPPER, $4, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| UCASE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_UPPER); }
 	  '(' expression_ ')'
@@ -18020,7 +17990,7 @@ reserved_func
 			$$ = parser_make_expression (this_parser, PT_UPPER, $4, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SYS_CONNECT_BY_PATH
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | SYS_CONNECT_BY_PATH );
 
@@ -18054,7 +18024,7 @@ reserved_func
 			  }
 			$$ = node;
 
-		DBG_PRINT}}
+		}}
 	| IF
 		{ push_msg (MSGCAT_SYNTAX_INVALID_IF); }
 	  '(' search_condition ',' expression_ ',' expression_ ')'
@@ -18064,7 +18034,7 @@ reserved_func
 			$$ = parser_make_expression (this_parser, PT_IF, $4, $6, $8);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| IFNULL
 		{ push_msg (MSGCAT_SYNTAX_INVALID_IFNULL); }
 	  '(' expression_ ',' expression_ ')'
@@ -18074,7 +18044,7 @@ reserved_func
 			$$ = parser_make_expression (this_parser, PT_IFNULL, $4, $6, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| ISNULL
 		{ push_msg (MSGCAT_SYNTAX_INVALID_ISNULL); }
 	  '(' expression_ ')'
@@ -18084,7 +18054,7 @@ reserved_func
 			$$ = parser_make_expression (this_parser, PT_ISNULL, $4, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| LEFT
 		{ push_msg(MSGCAT_SYNTAX_INVALID_LEFT); }
 	  '(' expression_ ',' expression_ ')'
@@ -18096,7 +18066,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| RIGHT
 		{ push_msg(MSGCAT_SYNTAX_INVALID_RIGHT); }
 	  '(' expression_ ',' expression_ ')'
@@ -18108,7 +18078,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| MOD
 		{ push_msg(MSGCAT_SYNTAX_INVALID_MODULUS); }
 	  '(' expression_ ',' expression_ ')'
@@ -18120,7 +18090,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| TRUNCATE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_TRUNCATE); }
 	  '(' expression_ ',' expression_ ')'
@@ -18130,7 +18100,7 @@ reserved_func
 			$$ = parser_make_expression (this_parser, PT_TRUNC, $4, $6, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| TRANSLATE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_TRANSLATE); }
 	  '(' expression_  ',' expression_ ',' expression_ ')'
@@ -18140,7 +18110,7 @@ reserved_func
 			$$ = parser_make_expression (this_parser, PT_TRANSLATE, $4, $6, $8);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| REPLACE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_TRANSLATE); }
 	  '(' expression_  ',' expression_ ',' expression_ ')'
@@ -18150,7 +18120,7 @@ reserved_func
 			$$ = parser_make_expression (this_parser, PT_REPLACE, $4, $6, $8);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| REPLACE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_REPLACE); }
 	  '(' expression_  ',' expression_ ')'
@@ -18160,7 +18130,7 @@ reserved_func
 			$$ = parser_make_expression (this_parser, PT_REPLACE, $4, $6, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| STR_TO_DATE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_STRTODATE); }
 	  '(' expression_  ',' string_literal_or_input_hv ')'
@@ -18170,7 +18140,7 @@ reserved_func
 			$$ = parser_make_expression (this_parser, PT_STR_TO_DATE, $4, $6, parser_make_date_lang (2, NULL));
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| STR_TO_DATE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_STRTODATE); }
 	  '(' expression_  ',' Null ')'
@@ -18186,7 +18156,7 @@ reserved_func
 			$$ = parser_make_expression (this_parser, PT_STR_TO_DATE, $4, node, parser_make_date_lang (2, NULL));
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| CHARSET
 		{ push_msg(MSGCAT_SYNTAX_INVALID_CHARSET); }
 	  '(' expression_ ')'
@@ -18198,7 +18168,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| COLLATION
 		{ push_msg(MSGCAT_SYNTAX_INVALID_COLLATION); }
 	  '(' expression_ ')'
@@ -18210,7 +18180,7 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| of_cume_dist_percent_rank_function '(' expression_list ')' WITHIN GROUP_ '('ORDER BY sort_spec_list')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_cume_dist_percent_rank_function '(' expression_list ')' WITHIN GROUP_ '('ORDER BY sort_spec_list')' );
 
@@ -18226,7 +18196,7 @@ reserved_func
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-        DBG_PRINT}}
+        }}
 	| INDEX_PREFIX
 		{ push_msg(MSGCAT_SYNTAX_INVALID_INDEX_PREFIX); }
 	  '(' expression_  ',' expression_ ',' expression_ ')'
@@ -18236,127 +18206,127 @@ reserved_func
 			$$ = parser_make_expression (this_parser, PT_INDEX_PREFIX, $4, $6, $8);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
         | JSON_ARRAY_APPEND '(' expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_ARRAY_APPEND '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count_mod2 (this_parser, F_JSON_ARRAY_APPEND, $3, 3, 0, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
         | JSON_ARRAY_INSERT '(' expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_ARRAY_INSERT '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count_mod2 (this_parser, F_JSON_ARRAY_INSERT, $3, 3, 0, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
         | JSON_ARRAY_LEX '(' opt_expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_ARRAY_LEX '(' opt_expression_list ')' );
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_ARRAY, $3, 0, 0);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
 	| JSON_CONTAINS '(' expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_CONTAINS '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_CONTAINS, $3, 2, 3);
                     PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-	      DBG_PRINT}}
+	      }}
 	| JSON_CONTAINS_PATH '(' expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_CONTAINS_PATH '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_CONTAINS_PATH, $3, 3, 0);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
         | JSON_DEPTH '(' expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_DEPTH '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_DEPTH, $3, 1, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
         | JSON_EXTRACT '(' expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_EXTRACT '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_EXTRACT, $3, 2, 0);
                     PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
         | JSON_GET_ALL_PATHS '(' expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_GET_ALL_PATHS '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_GET_ALL_PATHS, $3, 1, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
         | JSON_INSERT '(' expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_INSERT '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count_mod2 (this_parser, F_JSON_INSERT, $3, 3, 0, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
         | JSON_KEYS '(' expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_KEYS '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_KEYS, $3, 0, 2);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
         | JSON_LENGTH '(' expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_LENGTH '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_LENGTH, $3, 1, 2);
                     PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
         | JSON_MERGE '(' expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_MERGE '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_MERGE, $3, 2, 0);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
         | JSON_MERGE_PATCH '(' expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_MERGE_PATCH '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_MERGE_PATCH, $3, 2, 0);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
         | JSON_MERGE_PRESERVE '(' expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_MERGE_PRESERVE '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_MERGE, $3, 2, 0);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
         | JSON_OBJECT_LEX '(' opt_expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_OBJECT_LEX '(' opt_expression_list ')');
                     $$ = parser_make_func_with_arg_count_mod2 (this_parser, F_JSON_OBJECT, $3, 0, 0, 0);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
         | JSON_PRETTY '(' expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_PRETTY '(' expression_list ')');
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_PRETTY, $3, 1, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
         | JSON_QUOTE '(' expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_QUOTE '(' expression_list ')');
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_QUOTE, $3, 1, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
         | JSON_REMOVE '(' expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_REMOVE '(' expression_list ')');
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_REMOVE, $3, 2, 0);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
         | JSON_REPLACE '(' expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_REPLACE '(' expression_list ')');
                     $$ = parser_make_func_with_arg_count_mod2 (this_parser, F_JSON_REPLACE, $3, 3, 0, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
         | JSON_SET '(' expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_SET '(' expression_list ')');
                     $$ = parser_make_func_with_arg_count_mod2 (this_parser, F_JSON_SET, $3, 3, 0, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
         | JSON_SEARCH '(' expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_SEARCH '(' expression_list ')');
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_SEARCH, $3, 3, 0);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
         | JSON_TYPE '(' expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_TYPE '(' expression_list ')');
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_TYPE, $3, 1, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
         | JSON_UNQUOTE '(' expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_UNQUOTE '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_UNQUOTE, $3, 1, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
         | JSON_VALID '(' expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_VALID '(' expression_list ')' );
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_VALID, $3, 1, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
         | simple_path_id RIGHT_ARROW CHAR_STRING
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | simple_path_id RIGHT_ARROW CHAR_STRING);
 		    PT_NODE *matcher = parser_new_node (this_parser, PT_VALUE);
@@ -18371,7 +18341,7 @@ reserved_func
                     first_arg->next = matcher;
 		    $$ = parser_make_expr_with_func (this_parser, F_JSON_EXTRACT, first_arg);
                     PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-                DBG_PRINT}}
+                }}
         | simple_path_id DOUBLE_RIGHT_ARROW CHAR_STRING
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | simple_path_id DOUBLE_RIGHT_ARROW CHAR_STRING);
                     PT_NODE *matcher = parser_new_node (this_parser, PT_VALUE);
@@ -18387,49 +18357,49 @@ reserved_func
 		    PT_NODE *extract_expr = parser_make_expr_with_func (this_parser, F_JSON_EXTRACT, first_arg);
 		    $$ = parser_make_expr_with_func (this_parser, F_JSON_UNQUOTE, extract_expr);
                     PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
         | BENCHMARK '(' expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | BENCHMARK '(' expression_list ')');
                     $$ = parser_make_func_with_arg_count (this_parser, F_BENCHMARK, $3, 2, 2);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
 	| REGEXP_COUNT '(' expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | REGEXP_COUNT '(' expression_list ')');
 			$$ = parser_make_func_with_arg_count (this_parser, F_REGEXP_COUNT, $3, 2, 4);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
 	| REGEXP_INSTR '(' expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | REGEXP_INSTR '(' expression_list ')');
 			$$ = parser_make_func_with_arg_count (this_parser, F_REGEXP_INSTR, $3, 2, 6);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
 	| REGEXP_LIKE '(' expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | REGEXP_LIKE '(' expression_list ')');
 			$$ = parser_make_func_with_arg_count (this_parser, F_REGEXP_LIKE, $3, 2, 3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
 	| REGEXP_REPLACE '(' expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | REGEXP_REPLACE '(' expression_list ')');
 			$$ = parser_make_func_with_arg_count (this_parser, F_REGEXP_REPLACE, $3, 3, 6);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
 	| REGEXP_SUBSTR '(' expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(reserved_func, | REGEXP_SUBSTR '(' expression_list ')');
 			$$ = parser_make_func_with_arg_count (this_parser, F_REGEXP_SUBSTR, $3, 2, 5);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
 	;
 
 of_cume_dist_percent_rank_function
 	: CUME_DIST
 		{{ DBG_TRACE_GRAMMAR(of_cume_dist_percent_rank_function, : CUME_DIST);
 			$$ = PT_CUME_DIST;
-		DBG_PRINT}}
+		}}
 
 	| PERCENT_RANK
 		{{ DBG_TRACE_GRAMMAR(of_cume_dist_percent_rank_function, | PERCENT_RANK);
 			$$ = PT_PERCENT_RANK;
-		DBG_PRINT}}
+		}}
     ;
 
 of_current_date
@@ -18501,85 +18471,85 @@ of_avg_max_etc
 
 			$$ = PT_AVG;
 
-		DBG_PRINT}}
+		}}
 	| Max
 		{{
 
 			$$ = PT_MAX;
 
-		DBG_PRINT}}
+		}}
 	| Min
 		{{
 
 			$$ = PT_MIN;
 
-		DBG_PRINT}}
+		}}
 	| SUM
 		{{
 
 			$$ = PT_SUM;
 
-		DBG_PRINT}}
+		}}
 	| STDDEV
 		{{
 
 			$$ = PT_STDDEV;
 
-		DBG_PRINT}}
+		}}
 	| STDDEV_POP
 		{{
 
 			$$ = PT_STDDEV_POP;
 
-		DBG_PRINT}}
+		}}
 	| STDDEV_SAMP
 		{{
 
 			$$ = PT_STDDEV_SAMP;
 
-		DBG_PRINT}}
+		}}
 	| VAR_POP
 		{{
 
 			$$ = PT_VAR_POP;
 
-		DBG_PRINT}}
+		}}
 	| VAR_SAMP
 		{{
 
 			$$ = PT_VAR_SAMP;
 
-		DBG_PRINT}}
+		}}
 	| VARIANCE
 		{{
 
 			$$ = PT_VARIANCE;
 
-		DBG_PRINT}}
+		}}
 	| BIT_AND
 		{{
 
 			$$ = PT_AGG_BIT_AND;
 
-		DBG_PRINT}}
+		}}
 	| BIT_OR
 		{{
 
 			$$ = PT_AGG_BIT_OR;
 
-		DBG_PRINT}}
+		}}
 	| BIT_XOR
 		{{
 
 			$$ = PT_AGG_BIT_XOR;
 
-		DBG_PRINT}}
+		}}
 	| MEDIAN
 		{{
 
 			$$ = PT_MEDIAN;
 
-		DBG_PRINT}}
+		}}
 	;
 
 of_analytic
@@ -18588,73 +18558,73 @@ of_analytic
 
 			$$ = PT_AVG;
 
-		DBG_PRINT}}
+		}}
 	| Max
 		{{
 
 			$$ = PT_MAX;
 
-		DBG_PRINT}}
+		}}
 	| Min
 		{{
 
 			$$ = PT_MIN;
 
-		DBG_PRINT}}
+		}}
 	| SUM
 		{{
 
 			$$ = PT_SUM;
 
-		DBG_PRINT}}
+		}}
 	| STDDEV
 		{{
 
 			$$ = PT_STDDEV;
 
-		DBG_PRINT}}
+		}}
 	| STDDEV_POP
 		{{
 
 			$$ = PT_STDDEV_POP;
 
-		DBG_PRINT}}
+		}}
 	| STDDEV_SAMP
 		{{
 
 			$$ = PT_STDDEV_SAMP;
 
-		DBG_PRINT}}
+		}}
 	| VAR_POP
 		{{
 
 			$$ = PT_VAR_POP;
 
-		DBG_PRINT}}
+		}}
 	| VAR_SAMP
 		{{
 
 			$$ = PT_VAR_SAMP;
 
-		DBG_PRINT}}
+		}}
 	| VARIANCE
 		{{
 
 			$$ = PT_VARIANCE;
 
-		DBG_PRINT}}
+		}}
 	| NTILE
 		{{
 
 			$$ = PT_NTILE;
 
-		DBG_PRINT}}
+		}}
 	| MEDIAN
 		{{
 
 			$$ = PT_MEDIAN;
 
-		DBG_PRINT}}
+		}}
 	/* add other analytic functions here */
 	;
 
@@ -18664,13 +18634,13 @@ of_analytic_first_last
 
 			$$ = PT_FIRST_VALUE;
 
-		DBG_PRINT}}
+		}}
 	| LAST_VALUE
 		{{
 
 			$$ = PT_LAST_VALUE;
 
-		DBG_PRINT}}
+		}}
 	;
 
 of_analytic_nth_value
@@ -18679,7 +18649,7 @@ of_analytic_nth_value
 
 			$$ = PT_NTH_VALUE;
 
-		DBG_PRINT}}
+		}}
 	;
 
 of_analytic_lead_lag
@@ -18688,13 +18658,13 @@ of_analytic_lead_lag
 
 			$$ = PT_LEAD;
 
-		DBG_PRINT}}
+		}}
 	| LAG
 		{{
 
 			$$ = PT_LAG;
 
-		DBG_PRINT}}
+		}}
 	/* functions that use other row values */
 	;
 
@@ -18704,13 +18674,13 @@ of_percentile
 
 			$$ = PT_PERCENTILE_CONT;
 
-		DBG_PRINT}}
+		}}
 	| PERCENTILE_DISC
 		{{
 
 			$$ = PT_PERCENTILE_DISC;
 
-		DBG_PRINT}}
+		}}
 	;
 
 of_analytic_no_args
@@ -18719,29 +18689,29 @@ of_analytic_no_args
 
 			$$ = PT_ROW_NUMBER;
 
-		DBG_PRINT}}
+		}}
 	| RANK
 		{{
 
 			$$ = PT_RANK;
 
-		DBG_PRINT}}
+		}}
 	| DENSE_RANK
 		{{
 
 			$$ = PT_DENSE_RANK;
 
-		DBG_PRINT}}
+		}}
 	| CUME_DIST
 		{{
 			$$ = PT_CUME_DIST;
 
-		DBG_PRINT}}
+		}}
 	| PERCENT_RANK
 		{{
 			$$ = PT_PERCENT_RANK;
 
-		DBG_PRINT}}
+		}}
 	/* add other analytic functions here */
 	;
 
@@ -18756,21 +18726,21 @@ opt_group_concat_separator
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| SEPARATOR char_string
 		{{ DBG_TRACE_GRAMMAR(opt_group_concat_separator, | SEPARATOR char_string);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SEPARATOR bit_string_literal
 		{{ DBG_TRACE_GRAMMAR(opt_group_concat_separator, | SEPARATOR bit_string_literal);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_agg_order_by
@@ -18779,14 +18749,14 @@ opt_agg_order_by
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| ORDER BY sort_spec
 		{{ DBG_TRACE_GRAMMAR(opt_agg_order_by, | ORDER BY sort_spec);
 
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_analytic_from_last
@@ -18795,19 +18765,19 @@ opt_analytic_from_last
 
 			$$ = false;
 
-		DBG_PRINT}}
+		}}
 	| FROM FIRST
 		{{ DBG_TRACE_GRAMMAR(opt_analytic_from_last, | FROM FIRST);
 
 			$$ = false;
 
-		DBG_PRINT}}
+		}}
 	| FROM LAST
 		{{ DBG_TRACE_GRAMMAR(opt_analytic_from_last, | FROM LAST);
 
 			$$ = true;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_analytic_ignore_nulls
@@ -18816,19 +18786,19 @@ opt_analytic_ignore_nulls
 
 			$$ = false;
 
-		DBG_PRINT}}
+		}}
 	| RESPECT NULLS
 		{{ DBG_TRACE_GRAMMAR(opt_analytic_ignore_nulls, | RESPECT NULLS);
 
 			$$ = false;
 
-		DBG_PRINT}}
+		}}
 	| IGNORE_ NULLS
 		{{ DBG_TRACE_GRAMMAR(opt_analytic_ignore_nulls, | IGNORE_ NULLS);
 
 			$$ = true;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_analytic_partition_by
@@ -18837,7 +18807,7 @@ opt_analytic_partition_by
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| PARTITION BY sort_spec_list
 		{{ DBG_TRACE_GRAMMAR(opt_analytic_partition_by, | PARTITION BY sort_spec_list);
 
@@ -18854,7 +18824,7 @@ opt_analytic_partition_by
 
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_over_analytic_partition_by
@@ -18864,14 +18834,14 @@ opt_over_analytic_partition_by
 			is_analytic_function = false;
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| OVER '(' opt_analytic_partition_by ')'
 		{{ DBG_TRACE_GRAMMAR(opt_over_analytic_partition_by, | OVER '(' opt_analytic_partition_by ')' );
 
 			is_analytic_function = true;
 			$$= $3;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_analytic_order_by
@@ -18880,7 +18850,7 @@ opt_analytic_order_by
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| ORDER BY sort_spec_list
 		{{ DBG_TRACE_GRAMMAR(opt_analytic_order_by, | ORDER BY sort_spec_list );
 
@@ -18896,7 +18866,7 @@ opt_analytic_order_by
 			  }
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 of_leading_trailing_both
@@ -18905,19 +18875,19 @@ of_leading_trailing_both
 
 			$$ = PT_LEADING;
 
-		DBG_PRINT}}
+		}}
 	| TRAILING_
 		{{ DBG_TRACE_GRAMMAR(of_leading_trailing_both, | TRAILING_);
 
 			$$ = PT_TRAILING;
 
-		DBG_PRINT}}
+		}}
 	| BOTH_
 		{{ DBG_TRACE_GRAMMAR(of_leading_trailing_both, | BOTH_ );
 
 			$$ = PT_BOTH;
 
-		DBG_PRINT}}
+		}}
 	;
 
 case_expr
@@ -18925,7 +18895,7 @@ case_expr
 		{{ DBG_TRACE_GRAMMAR(case_expr, : NULLIF '(' expression_ ',' expression_ ')' );
 			$$ = parser_make_expression (this_parser, PT_NULLIF, $3, $5, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
 	| COALESCE '(' expression_list ')'
 		{{ DBG_TRACE_GRAMMAR(case_expr, | COALESCE '(' expression_list ')' );
 			PT_NODE *prev, *expr, *arg, *tmp;
@@ -18991,7 +18961,7 @@ case_expr
 			$$ = expr;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| CASE expression_ simple_when_clause_list opt_else_expr END
 		{{ DBG_TRACE_GRAMMAR(case_expr, | CASE expression_ simple_when_clause_list opt_else_expr END );
 
@@ -19049,7 +19019,7 @@ case_expr
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| CASE searched_when_clause_list opt_else_expr END
 		{{ DBG_TRACE_GRAMMAR(case_expr, | CASE searched_when_clause_list opt_else_expr END );
 
@@ -19094,7 +19064,7 @@ case_expr
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_else_expr
@@ -19103,14 +19073,14 @@ opt_else_expr
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| ELSE expression_
 		{{ DBG_TRACE_GRAMMAR(opt_else_expr, | ELSE expression_);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 simple_when_clause_list
@@ -19120,14 +19090,14 @@ simple_when_clause_list
 			$$ = parser_make_link ($1, $2);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| simple_when_clause
 		{{ DBG_TRACE_GRAMMAR(simple_when_clause_list, | simple_when_clause);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 simple_when_clause
@@ -19159,7 +19129,7 @@ simple_when_clause
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 searched_when_clause_list
@@ -19169,14 +19139,14 @@ searched_when_clause_list
 			$$ = parser_make_link ($1, $2);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| searched_when_clause
 		{{ DBG_TRACE_GRAMMAR(searched_when_clause_list, | searched_when_clause);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 searched_when_clause
@@ -19204,7 +19174,7 @@ searched_when_clause
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 
@@ -19219,7 +19189,7 @@ extract_expr
 			$$ = tmp;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 adddate_name
@@ -19238,121 +19208,121 @@ datetime_field
 
 			$$ = PT_YEAR;
 
-		DBG_PRINT}}
+		}}
 	| MONTH_
 		{{
 
 			$$ = PT_MONTH;
 
-		DBG_PRINT}}
+		}}
 	| DAY_
 		{{
 
 			$$ = PT_DAY;
 
-		DBG_PRINT}}
+		}}
 	| HOUR_
 		{{
 
 			$$ = PT_HOUR;
 
-		DBG_PRINT}}
+		}}
 	| MINUTE_
 		{{
 
 			$$ = PT_MINUTE;
 
-		DBG_PRINT}}
+		}}
 	| SECOND_
 		{{
 
 			$$ = PT_SECOND;
 
-		DBG_PRINT}}
+		}}
 	| MILLISECOND_
 		{{
 
 			$$ = PT_MILLISECOND;
 
-		DBG_PRINT}}
+		}}
 	| WEEK
 		{{
 
 			$$ = PT_WEEK;
 
-		DBG_PRINT}}
+		}}
 	| QUARTER
 		{{
 
 			$$ = PT_QUARTER;
 
-    		DBG_PRINT}}
+    		}}
         | SECOND_MILLISECOND
 		{{
 
 			$$ = PT_SECOND_MILLISECOND;
 
-    		DBG_PRINT}}
+    		}}
 	| MINUTE_MILLISECOND
 		{{
 
 			$$ = PT_MINUTE_MILLISECOND;
 
-    		DBG_PRINT}}
+    		}}
 	| MINUTE_SECOND
 		{{
 
 			$$ = PT_MINUTE_SECOND;
 
-    		DBG_PRINT}}
+    		}}
 	| HOUR_MILLISECOND
 		{{
 
 			$$ = PT_HOUR_MILLISECOND;
 
-    		DBG_PRINT}}
+    		}}
 	| HOUR_SECOND
 		{{
 
 			$$ = PT_HOUR_SECOND;
 
-    		DBG_PRINT}}
+    		}}
 	| HOUR_MINUTE
 		{{
 
 			$$ = PT_HOUR_MINUTE;
 
-    		DBG_PRINT}}
+    		}}
 	| DAY_MILLISECOND
 		{{
 
 			$$ = PT_DAY_MILLISECOND;
 
-    		DBG_PRINT}}
+    		}}
 	| DAY_SECOND
 		{{
 
 			$$ = PT_DAY_SECOND;
 
-    		DBG_PRINT}}
+    		}}
 	| DAY_MINUTE
 		{{
 
 			$$ = PT_DAY_MINUTE;
 
-    		DBG_PRINT}}
+    		}}
 	| DAY_HOUR
 		{{
 
 			$$ = PT_DAY_HOUR;
 
-    		DBG_PRINT}}
+    		}}
 	| YEAR_MONTH
 		{{
 
 			$$ = PT_YEAR_MONTH;
 
-    		DBG_PRINT}}
+    		}}
 	;
 
 opt_on_target
@@ -19361,14 +19331,14 @@ opt_on_target
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| ON_ primary
 		{{ DBG_TRACE_GRAMMAR(opt_on_target, | ON_ primary);
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 generic_function
@@ -19403,7 +19373,7 @@ generic_function
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 generic_function_for_call        
@@ -19462,7 +19432,7 @@ generic_function_for_call
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 generic_function_id
@@ -19504,7 +19474,7 @@ generic_function_id
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_expression_list
@@ -19513,14 +19483,14 @@ opt_expression_list
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| expression_list
 		{{ DBG_TRACE_GRAMMAR(opt_expression_list, | expression_list );
                         
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_expression_list_for_call
@@ -19529,7 +19499,7 @@ opt_expression_list_for_call
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| expression_list_for_call
 		{{ DBG_TRACE_GRAMMAR(opt_expression_list_for_call, | expression_list );
                         
@@ -19543,7 +19513,7 @@ opt_expression_list_for_call
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 table_set_function_call
@@ -19560,7 +19530,7 @@ table_set_function_call
 			$$ = func_node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| SEQUENCE subquery
 		{{ DBG_TRACE_GRAMMAR(table_set_function_call, | SEQUENCE subquery );
 
@@ -19574,7 +19544,7 @@ table_set_function_call
 			$$ = func_node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| LIST subquery
 		{{ DBG_TRACE_GRAMMAR(table_set_function_call, | LIST subquery );
 
@@ -19588,7 +19558,7 @@ table_set_function_call
 			$$ = func_node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| MULTISET subquery
 		{{ DBG_TRACE_GRAMMAR(table_set_function_call, | MULTISET subquery );
 
@@ -19602,7 +19572,7 @@ table_set_function_call
 			$$ = func_node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 search_condition
@@ -19613,13 +19583,13 @@ search_condition
 			$$ = parser_make_expression (this_parser, PT_OR, arg1, arg2, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| boolean_term_xor
 		{{DBG_TRACE_GRAMMAR(search_condition, | boolean_term_xor);
 			$$ = pt_check_non_logical_expr(this_parser, $1);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 boolean_term_xor
@@ -19630,13 +19600,13 @@ boolean_term_xor
 			$$ = parser_make_expression (this_parser, PT_XOR, arg1, arg2, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| boolean_term_is
 		{{DBG_TRACE_GRAMMAR(boolean_term_xor, | boolean_term_is);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
 	;
 
 boolean_term_is
@@ -19646,14 +19616,14 @@ boolean_term_is
 			$$ = parser_make_expression (this_parser, $2, arg, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| boolean_term
 		{{DBG_TRACE_GRAMMAR(boolean_term_xor, | boolean_term_is);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 is_op
@@ -19662,13 +19632,13 @@ is_op
 
 			$$ = PT_IS_NOT;
 
-		DBG_PRINT}}
+		}}
 	| IS
 		{{ DBG_TRACE_GRAMMAR(is_op, | IS);
 
 			$$ = PT_IS;
 
-		DBG_PRINT}}
+		}}
 	;
 
 boolean_term
@@ -19679,14 +19649,14 @@ boolean_term
 			$$ = parser_make_expression (this_parser, PT_AND, arg1, arg2, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| boolean_factor
 		{{DBG_TRACE_GRAMMAR(boolean_term, | boolean_factor);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 boolean_factor
@@ -19697,7 +19667,7 @@ boolean_factor
 			$$ = parser_make_expression (this_parser, PT_NOT, arg, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| '!' predicate
 		{{DBG_TRACE_GRAMMAR(boolean_factor, | '!' predicate);
 
@@ -19705,14 +19675,14 @@ boolean_factor
 			$$ = parser_make_expression (this_parser, PT_NOT, arg, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| predicate
 		{{DBG_TRACE_GRAMMAR(boolean_factor, | predicate);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 predicate
@@ -19721,14 +19691,14 @@ predicate
 			$$ = parser_make_expression (this_parser, PT_EXISTS, $2, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| expression_
 		{{ DBG_TRACE_GRAMMAR(predicate, | expression_);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 predicate_expression
@@ -19739,7 +19709,7 @@ predicate_expression
 			if (join_type == PT_JOIN_RIGHT_OUTER)
 			  parser_restore_wjc ();
 
-		DBG_PRINT}}
+		}}
 	  opt_paren_plus
 		{{ DBG_TRACE_GRAMMAR(predicate_expression, opt_paren_plus);
 
@@ -19822,7 +19792,7 @@ predicate_expression
 			$$ = e;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 
@@ -19965,7 +19935,7 @@ predicate_expr_sub
 			$$ = e;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| pred_lhs like_op normal_expression ESCAPE escape_literal
 		{{ DBG_TRACE_GRAMMAR(predicate_expr_sub, | pred_lhs like_op normal_expression ESCAPE escape_literal);
 
@@ -19974,7 +19944,7 @@ predicate_expr_sub
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| pred_lhs like_op normal_expression
 		{{ DBG_TRACE_GRAMMAR(predicate_expr_sub, | pred_lhs like_op normal_expression);
 
@@ -19989,7 +19959,7 @@ predicate_expr_sub
 			$$ = parser_make_expression (this_parser, $2, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| pred_lhs rlike_op normal_expression
 		{{ DBG_TRACE_GRAMMAR(predicate_expr_sub, | pred_lhs rlike_op normal_expression);
 
@@ -20009,21 +19979,21 @@ predicate_expr_sub
 			  }
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| pred_lhs null_op
 		{{ DBG_TRACE_GRAMMAR(predicate_expr_sub, | pred_lhs null_op);
 
 			$$ = parser_make_expression (this_parser, $2, $1, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| pred_lhs set_op normal_expression
 		{{ DBG_TRACE_GRAMMAR(predicate_expr_sub, | pred_lhs set_op normal_expression);
 
 			$$ = parser_make_expression (this_parser, $2, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| pred_lhs between_op normal_expression AND normal_expression
 		{{ DBG_TRACE_GRAMMAR(predicate_expr_sub, | pred_lhs between_op normal_expression AND normal_expression);
 
@@ -20031,7 +20001,7 @@ predicate_expr_sub
 			$$ = parser_make_expression (this_parser, $2, $1, node, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| pred_lhs in_op in_pred_operand
 		{{ DBG_TRACE_GRAMMAR(predicate_expr_sub, | pred_lhs in_op in_pred_operand);
 
@@ -20226,7 +20196,7 @@ predicate_expr_sub
 
 			$$ = node;
 
-		DBG_PRINT}}
+		}}
 	;
 	| pred_lhs RANGE_ '(' range_list ')'
 		{{ DBG_TRACE_GRAMMAR(predicate_expr_sub, | pred_lhs RANGE_ '(' range_list ')');
@@ -20234,13 +20204,13 @@ predicate_expr_sub
 			$$ = parser_make_expression (this_parser, PT_RANGE, $1, $4, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| pred_lhs IdName
 		{{ DBG_TRACE_GRAMMAR(predicate_expr_sub, | pred_lhs IdName);
 			PT_ERRORm (this_parser, $1, MSGCAT_SET_PARSER_SYNTAX,
 				    MSGCAT_SYNTAX_INVALID_RELATIONAL_OP);
 
-		DBG_PRINT}}
+		}}
 	;
 
 pred_lhs
@@ -20259,7 +20229,7 @@ pred_lhs
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_paren_plus
@@ -20268,13 +20238,13 @@ opt_paren_plus
 
 			$$ = 0;
 
-		DBG_PRINT}}
+		}}
 	| paren_plus
 		{{ DBG_TRACE_GRAMMAR(opt_paren_plus, | paren_plus);
 
 			$$ = 1;
 
-		DBG_PRINT}}
+		}}
 	;
 
 comp_op
@@ -20297,7 +20267,7 @@ comp_op
 			    break;
 			  }
 
-		DBG_PRINT}}
+		}}
 	| COMP_NOT_EQ opt_of_all_some_any
 		{{ DBG_TRACE_GRAMMAR(comp_op, | COMP_NOT_EQ opt_of_all_some_any);
 
@@ -20317,7 +20287,7 @@ comp_op
 			    break;
 			  }
 
-		DBG_PRINT}}
+		}}
 	| '>' opt_of_all_some_any
 		{{ DBG_TRACE_GRAMMAR(comp_op, | '>' opt_of_all_some_any);
 
@@ -20337,7 +20307,7 @@ comp_op
 			    break;
 			  }
 
-		DBG_PRINT}}
+		}}
 	| COMP_GE opt_of_all_some_any
 		{{ DBG_TRACE_GRAMMAR(comp_op, | COMP_GE opt_of_all_some_any);
 
@@ -20357,7 +20327,7 @@ comp_op
 			    break;
 			  }
 
-		DBG_PRINT}}
+		}}
 	| '<'  opt_of_all_some_any
 		{{ DBG_TRACE_GRAMMAR(comp_op, | '<'  opt_of_all_some_any);
 
@@ -20377,7 +20347,7 @@ comp_op
 			    break;
 			  }
 
-		DBG_PRINT}}
+		}}
 	| COMP_LE opt_of_all_some_any
 		{{ DBG_TRACE_GRAMMAR(comp_op, | COMP_LE opt_of_all_some_any);
 
@@ -20397,27 +20367,27 @@ comp_op
 			    break;
 			  }
 
-		DBG_PRINT}}
+		}}
 	| '=''=' opt_of_all_some_any
 		{{ DBG_TRACE_GRAMMAR(comp_op, | '=''=' opt_of_all_some_any);
 
 			push_msg (MSGCAT_SYNTAX_INVALID_EQUAL_OP);
 			csql_yyerror_explicit (@1.first_line, @1.first_column);
 
-		DBG_PRINT}}
+		}}
 	| '!''=' opt_of_all_some_any
 		{{ DBG_TRACE_GRAMMAR(comp_op, | '!''=' opt_of_all_some_any);
 
 			push_msg (MSGCAT_SYNTAX_INVALID_NOT_EQUAL);
 			csql_yyerror_explicit (@1.first_line, @1.first_column);
 
-		DBG_PRINT}}
+		}}
 	| COMP_NULLSAFE_EQ opt_of_all_some_any
 		{{ DBG_TRACE_GRAMMAR(comp_op, | COMP_NULLSAFE_EQ opt_of_all_some_any);
 
 			$$ = PT_NULLSAFE_EQ;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_of_all_some_any
@@ -20426,25 +20396,25 @@ opt_of_all_some_any
 
 			$$ = 0;
 
-		DBG_PRINT}}
+		}}
 	| ALL
 		{{ DBG_TRACE_GRAMMAR(opt_of_all_some_any, | ALL );
 
 			$$ = 1;
 
-		DBG_PRINT}}
+		}}
 	| SOME
 		{{ DBG_TRACE_GRAMMAR(opt_of_all_some_any, | SOME );
 
 			$$ = 2;
 
-		DBG_PRINT}}
+		}}
 	| ANY
 		{{ DBG_TRACE_GRAMMAR(opt_of_all_some_any, | ANY );
 
 			$$ = 3;
 
-		DBG_PRINT}}
+		}}
 	;
 
 like_op
@@ -20453,13 +20423,13 @@ like_op
 
 			$$ = PT_NOT_LIKE;
 
-		DBG_PRINT}}
+		}}
 	| LIKE
 		{{ DBG_TRACE_GRAMMAR(like_op, | LIKE );
 
 			$$ = PT_LIKE;
 
-		DBG_PRINT}}
+		}}
 	;
 
 rlike_op
@@ -20468,25 +20438,25 @@ rlike_op
 
 			$$ = PT_RLIKE;
 
-		DBG_PRINT}}
+		}}
 	| NOT rlike_or_regexp
 		{{ DBG_TRACE_GRAMMAR(rlike_op, | NOT rlike_or_regexp);
 
 			$$ = PT_NOT_RLIKE;
 
-		DBG_PRINT}}
+		}}
 	| rlike_or_regexp BINARY
 		{{ DBG_TRACE_GRAMMAR(rlike_op, | rlike_or_regexp BINARY );
 
 			$$ = PT_RLIKE_BINARY;
 
-		DBG_PRINT}}
+		}}
 	| NOT rlike_or_regexp BINARY
 		{{ DBG_TRACE_GRAMMAR(rlike_op, | NOT rlike_or_regexp BINARY);
 
 			$$ = PT_NOT_RLIKE_BINARY;
 
-		DBG_PRINT}}
+		}}
 	;
 
 rlike_or_regexp
@@ -20500,13 +20470,13 @@ null_op
 
 			$$ = PT_IS_NOT_NULL;
 
-		DBG_PRINT}}
+		}}
 	| IS Null
 		{{ DBG_TRACE_GRAMMAR(null_op, | IS Null);
 
 			$$ = PT_IS_NULL;
 
-		DBG_PRINT}}
+		}}
 	;
 
 
@@ -20516,13 +20486,13 @@ between_op
 
 			$$ = PT_NOT_BETWEEN;
 
-		DBG_PRINT}}
+		}}
 	| BETWEEN
 		{{ DBG_TRACE_GRAMMAR(between_op, | BETWEEN);
 
 			$$ = PT_BETWEEN;
 
-		DBG_PRINT}}
+		}}
 	;
 
 in_op
@@ -20531,13 +20501,13 @@ in_op
 
 			$$ = PT_IS_IN;
 
-		DBG_PRINT}}
+		}}
 	| NOT IN_
 		{{ DBG_TRACE_GRAMMAR(in_op, | NOT IN_);
 
 			$$ = PT_IS_NOT_IN;
 
-		DBG_PRINT}}
+		}}
 	;
 
 in_pred_operand
@@ -20555,7 +20525,7 @@ in_pred_operand
 			  }
 
 			$$ = ctn;
-		DBG_PRINT}}
+		}}
 	;
 
 range_list
@@ -20565,14 +20535,14 @@ range_list
 			$$ = parser_make_link_or ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| range_
 		{{ DBG_TRACE_GRAMMAR(range_list, | range_);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 range_
@@ -20582,63 +20552,63 @@ range_
 			$$ = parser_make_expression (this_parser, PT_BETWEEN_GE_LE, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| expression_ GE_LT_ expression_
 		{{ DBG_TRACE_GRAMMAR(range_, | expression_ GE_LT_ expression_);
 
 			$$ = parser_make_expression (this_parser, PT_BETWEEN_GE_LT, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| expression_ GT_LE_ expression_
 		{{ DBG_TRACE_GRAMMAR(range_, | expression_ GT_LE_ expression_);
 
 			$$ = parser_make_expression (this_parser, PT_BETWEEN_GT_LE, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| expression_ GT_LT_ expression_
 		{{ DBG_TRACE_GRAMMAR(range_, | expression_ GT_LT_ expression_);
 
 			$$ = parser_make_expression (this_parser, PT_BETWEEN_GT_LT, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| expression_ '='
 		{{ DBG_TRACE_GRAMMAR(range_, | expression_ '=');
 
 			$$ = parser_make_expression (this_parser, PT_BETWEEN_EQ_NA, $1, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| expression_ GE_INF_ Max
 		{{ DBG_TRACE_GRAMMAR(range_, | expression_ GE_INF_ Max);
 
 			$$ = parser_make_expression (this_parser, PT_BETWEEN_GE_INF, $1, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| expression_ GT_INF_ Max
 		{{ DBG_TRACE_GRAMMAR(range_, | expression_ GT_INF_ Max);
 
 			$$ = parser_make_expression (this_parser, PT_BETWEEN_GT_INF, $1, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| Min INF_LE_ expression_
 		{{ DBG_TRACE_GRAMMAR(range_, | Min INF_LE_ expression_);
 
 			$$ = parser_make_expression (this_parser, PT_BETWEEN_INF_LE, $3, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| Min INF_LT_ expression_
 		{{ DBG_TRACE_GRAMMAR(range_, | Min INF_LT_ expression_);
 
 			$$ = parser_make_expression (this_parser, PT_BETWEEN_INF_LT, $3, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 set_op
@@ -20647,37 +20617,37 @@ set_op
 
 			$$ = PT_SETEQ;
 
-		DBG_PRINT}}
+		}}
 	| SETNEQ
 		{{
 
 			$$ = PT_SETNEQ;
 
-		DBG_PRINT}}
+		}}
 	| SUBSET
 		{{
 
 			$$ = PT_SUBSET;
 
-		DBG_PRINT}}
+		}}
 	| SUBSETEQ
 		{{
 
 			$$ = PT_SUBSETEQ;
 
-		DBG_PRINT}}
+		}}
 	| SUPERSETEQ
 		{{
 
 			$$ = PT_SUPERSETEQ;
 
-		DBG_PRINT}}
+		}}
 	| SUPERSET
 		{{
 
 			$$ = PT_SUPERSET;
 
-		DBG_PRINT}}
+		}}
 	;
 
 subquery
@@ -20697,7 +20667,7 @@ subquery
 			$$ = stmt;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 subquery_without_subquery_and_with_clause
@@ -20717,7 +20687,7 @@ subquery_without_subquery_and_with_clause
 			$$ = stmt;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 
@@ -20733,14 +20703,14 @@ path_expression
 			$$ = p;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| path_header path_dot IDENTITY		%dprec 5
 		{{ DBG_TRACE_GRAMMAR(path_expression, | path_header path_dot IDENTITY);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| path_header path_dot OBJECT		%dprec 4
 		{{ DBG_TRACE_GRAMMAR(path_expression, | path_header path_dot OBJECT);
 
@@ -20753,7 +20723,7 @@ path_expression
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| path_header DOT '*'			%dprec 3
 		{{ DBG_TRACE_GRAMMAR(path_expression, | path_header DOT '*');
 
@@ -20773,7 +20743,7 @@ path_expression
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| path_id_list				%dprec 2
 		{{ DBG_TRACE_GRAMMAR(path_expression, | path_id_list);
 			PT_NODE *dot;
@@ -20848,7 +20818,7 @@ path_expression
 			$$ = dot;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 path_id_list
@@ -20865,14 +20835,14 @@ path_id_list
 			$$ = dot;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| path_header					%dprec 2
 		{{ DBG_TRACE_GRAMMAR(path_id_list, | path_header);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 path_header
@@ -20882,7 +20852,7 @@ path_header
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| CLASS path_id
 		{{ DBG_TRACE_GRAMMAR(path_header, | CLASS path_id);
 
@@ -20891,7 +20861,7 @@ path_header
 			  node->info.name.meta_class = PT_META_CLASS;
 			$$ = node;
 
-		DBG_PRINT}}
+		}}
 	| path_id
 		{{ DBG_TRACE_GRAMMAR(path_header, | path_id);
 
@@ -20901,7 +20871,7 @@ path_header
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 path_dot
@@ -20921,28 +20891,28 @@ path_id
 			$$ = name;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| identifier
 		{{ DBG_TRACE_GRAMMAR(path_id, | identifier);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| generic_function_id
 		{{ DBG_TRACE_GRAMMAR(path_id, | generic_function_id);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| table_set_function_call
 		{{ DBG_TRACE_GRAMMAR(path_id, | table_set_function_call);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 simple_path_id
@@ -20959,14 +20929,14 @@ simple_path_id
 			$$ = dot;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| identifier
 		{{ DBG_TRACE_GRAMMAR(simple_path_id, | identifier);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_in_out
@@ -20975,25 +20945,25 @@ opt_in_out
 
 			$$ = PT_NOPUT;
 
-		DBG_PRINT}}
+		}}
 	| IN_
 		{{
 
 			$$ = PT_INPUT;
 
-		DBG_PRINT}}
+		}}
 	| OUT_
 		{{
 
 			$$ = PT_OUTPUT;
 
-		DBG_PRINT}}
+		}}
 	| INOUT
 		{{
 
 			$$ = PT_INPUTOUTPUT;
 
-		DBG_PRINT}}
+		}}
 	;
 
 negative_prec_cast_type
@@ -21002,19 +20972,19 @@ negative_prec_cast_type
 
 			$$ = PT_TYPE_CHAR;
 
-		DBG_PRINT}}
+		}}
 	| NATIONAL CHAR_
 		{{ DBG_TRACE_GRAMMAR(negative_prec_cast_type, |  NATIONAL CHAR_);
 
 			$$ = PT_TYPE_NCHAR;
 
-		DBG_PRINT}}
+		}}
 	| NCHAR
 		{{ DBG_TRACE_GRAMMAR(negative_prec_cast_type, | NCHAR);
 
 			$$ = PT_TYPE_NCHAR;
 
-		DBG_PRINT}}
+		}}
 	;
 
 of_cast_data_type
@@ -21022,7 +20992,7 @@ of_cast_data_type
 		{{ DBG_TRACE_GRAMMAR(of_cast_data_type, : data_type);
 			$$ = $1;
 
-		DBG_PRINT}}
+		}}
 	| negative_prec_cast_type '(' '-' unsigned_integer ')' opt_charset opt_collation
 		{{ DBG_TRACE_GRAMMAR(of_cast_data_type, | negative_prec_cast_type '(' '-' unsigned_integer ')' opt_charset opt_collation);
 			container_2 ctn;
@@ -21088,7 +21058,7 @@ of_cast_data_type
 			    parser_free_node (this_parser, coll_node);
 			  }
 
-		DBG_PRINT}}
+		}}
 	;
 
 data_type
@@ -21116,7 +21086,7 @@ data_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (typ), dt);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| nested_set '(' data_type_list ')'
 		{{ DBG_TRACE_GRAMMAR(data_type, | nested_set '(' data_type_list ')');
 
@@ -21130,7 +21100,7 @@ data_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (typ), dt);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| nested_set '(' ')'
 		{{ DBG_TRACE_GRAMMAR(data_type, | nested_set '(' ')');
 
@@ -21141,7 +21111,7 @@ data_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (typ), NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| nested_set set_type
 		{{ DBG_TRACE_GRAMMAR(data_type, | nested_set set_type);
 
@@ -21160,7 +21130,7 @@ data_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (typ), dt);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| set_type
 		{{ DBG_TRACE_GRAMMAR(data_type, | set_type);
 
@@ -21170,13 +21140,13 @@ data_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (typ), NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| primitive_type
 		{{ DBG_TRACE_GRAMMAR(data_type, | primitive_type);
 
 			$$ = $1;
 
-		DBG_PRINT}}
+		}}
 	;
 
 nested_set
@@ -21185,13 +21155,13 @@ nested_set
 
 			$$ = $1;
 
-		DBG_PRINT}}
+		}}
 	| set_type
 		{{ DBG_TRACE_GRAMMAR(nested_set, | set_type);
 
 			$$ = $1;
 
-		DBG_PRINT}}
+		}}
 	;
 
 data_type_list
@@ -21227,7 +21197,7 @@ data_type_list
 			$$ = parser_make_link ($1, dt);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| data_type
 		{{ DBG_TRACE_GRAMMAR(data_type_list, | data_type);
 
@@ -21260,7 +21230,7 @@ data_type_list
 			$$ = dt;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 char_bit_type
@@ -21272,13 +21242,13 @@ char_bit_type
 			else
 			  $$ = PT_TYPE_CHAR;
 
-		DBG_PRINT}}
+		}}
 	| VARCHAR
 		{{ DBG_TRACE_GRAMMAR(char_bit_type, | VARCHAR);
 
 			$$ = PT_TYPE_VARCHAR;
 
-		DBG_PRINT}}
+		}}
 	| NATIONAL CHAR_ opt_varying
 		{{ DBG_TRACE_GRAMMAR(char_bit_type, | NATIONAL CHAR_ opt_varying);
 
@@ -21287,7 +21257,7 @@ char_bit_type
 			else
 			  $$ = PT_TYPE_NCHAR;
 
-		DBG_PRINT}}
+		}}
 	| NCHAR	opt_varying
 		{{ DBG_TRACE_GRAMMAR(char_bit_type, | NCHAR	opt_varying);
 
@@ -21296,7 +21266,7 @@ char_bit_type
 			else
 			  $$ = PT_TYPE_NCHAR;
 
-		DBG_PRINT}}
+		}}
 	| BIT opt_varying
 		{{ DBG_TRACE_GRAMMAR(char_bit_type, | BIT opt_varying);
 
@@ -21305,7 +21275,7 @@ char_bit_type
 			else
 			  $$ = PT_TYPE_BIT;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_varying
@@ -21314,13 +21284,13 @@ opt_varying
 
 			$$ = 0;
 
-		DBG_PRINT}}
+		}}
 	| VARYING
 		{{ DBG_TRACE_GRAMMAR(opt_varying, | VARYING);
 
 			$$ = 1;
 
-		DBG_PRINT}}
+		}}
 	;
 
 json_schema
@@ -21329,13 +21299,13 @@ json_schema
 
 				$$ = 0;
 
-			DBG_PRINT}}
+			}}
 		| '(' CHAR_STRING ')'
 			{{ DBG_TRACE_GRAMMAR(json_schema, | '(' CHAR_STRING ')' );
 
 				$$ = $2;
 
-			DBG_PRINT}}
+			}}
 		;
 
 primitive_type
@@ -21346,7 +21316,7 @@ primitive_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_INTEGER), NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| SmallInt
 		{{ DBG_TRACE_GRAMMAR(primitive_type, | SmallInt );
 
@@ -21354,7 +21324,7 @@ primitive_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_SMALLINT), NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| BIGINT
 		{{ DBG_TRACE_GRAMMAR(primitive_type, | BIGINT );
 
@@ -21362,7 +21332,7 @@ primitive_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_BIGINT), NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| Double PRECISION
 		{{ DBG_TRACE_GRAMMAR(primitive_type, | Double PRECISION );
 
@@ -21370,7 +21340,7 @@ primitive_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_DOUBLE), NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| Double
 		{{ DBG_TRACE_GRAMMAR(primitive_type, | Double );
 
@@ -21378,7 +21348,7 @@ primitive_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_DOUBLE), NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| Date
 		{{ DBG_TRACE_GRAMMAR(primitive_type, | Date );
 
@@ -21386,7 +21356,7 @@ primitive_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_DATE), NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| Time
 		{{ DBG_TRACE_GRAMMAR(primitive_type, | Time );
 
@@ -21394,7 +21364,7 @@ primitive_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_TIME), NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| Utime
 		{{ DBG_TRACE_GRAMMAR(primitive_type, | Utime );
 
@@ -21402,7 +21372,7 @@ primitive_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_TIMESTAMP), NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| TIMESTAMP
 		{{ DBG_TRACE_GRAMMAR(primitive_type, | TIMESTAMP );
 
@@ -21410,7 +21380,7 @@ primitive_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_TIMESTAMP), NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| TIMESTAMP WITH Time ZONE
 		{{ DBG_TRACE_GRAMMAR(primitive_type, | TIMESTAMP WITH Time ZONE );
 
@@ -21418,7 +21388,7 @@ primitive_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_TIMESTAMPTZ), NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| TIMESTAMPTZ
 		{{ DBG_TRACE_GRAMMAR(primitive_type, | TIMESTAMPTZ );
 
@@ -21426,7 +21396,7 @@ primitive_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_TIMESTAMPTZ), NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| TIMESTAMP WITH LOCAL Time ZONE
 		{{ DBG_TRACE_GRAMMAR(primitive_type, | TIMESTAMP WITH LOCAL Time ZONE );
 
@@ -21434,7 +21404,7 @@ primitive_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_TIMESTAMPLTZ), NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| TIMESTAMPLTZ
 		{{ DBG_TRACE_GRAMMAR(primitive_type, | TIMESTAMPLTZ );
 
@@ -21442,7 +21412,7 @@ primitive_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_TIMESTAMPLTZ), NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| DATETIME
 		{{ DBG_TRACE_GRAMMAR(primitive_type, | DATETIME );
 
@@ -21450,7 +21420,7 @@ primitive_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_DATETIME), NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| DATETIME WITH Time ZONE
 		{{ DBG_TRACE_GRAMMAR(primitive_type, | DATETIME WITH Time ZONE );
 
@@ -21458,7 +21428,7 @@ primitive_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_DATETIMETZ), NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| DATETIMETZ
 		{{ DBG_TRACE_GRAMMAR(primitive_type, | DATETIMETZ );
 
@@ -21466,7 +21436,7 @@ primitive_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_DATETIMETZ), NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| DATETIME WITH LOCAL Time ZONE
 		{{ DBG_TRACE_GRAMMAR(primitive_type, | DATETIME WITH LOCAL Time ZONE );
 
@@ -21474,7 +21444,7 @@ primitive_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_DATETIMELTZ), NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| DATETIMELTZ
 		{{ DBG_TRACE_GRAMMAR(primitive_type, | DATETIMELTZ );
 
@@ -21482,7 +21452,7 @@ primitive_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_DATETIMELTZ), NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| Monetary
 		{{ DBG_TRACE_GRAMMAR(primitive_type, | Monetary );
 
@@ -21490,7 +21460,7 @@ primitive_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_MONETARY), NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| JSON json_schema
 	    {{ DBG_TRACE_GRAMMAR(primitive_type, | JSON json_schema );
 			const char * json_schema_str = $2;
@@ -21513,14 +21483,14 @@ primitive_type
 				}
 
 			$$ = ctn;
-		DBG_PRINT}}
+		}}
 	| OBJECT
 		{{ DBG_TRACE_GRAMMAR(primitive_type, | OBJECT );
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_OBJECT), NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| String
 	  opt_charset
 	  opt_collation
@@ -21582,7 +21552,7 @@ primitive_type
 			    parser_free_node (this_parser, coll_node);
 			  }
 
-		DBG_PRINT}}
+		}}
 	| BLOB_ opt_internal_external
 		{{ DBG_TRACE_GRAMMAR(primitive_type, | BLOB_ opt_internal_external );
 
@@ -21590,7 +21560,7 @@ primitive_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_BLOB), NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| CLOB_ opt_internal_external
 		{{ DBG_TRACE_GRAMMAR(primitive_type, | CLOB_ opt_internal_external );
 
@@ -21598,7 +21568,7 @@ primitive_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_CLOB), NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| class_name opt_identity
 		{{ DBG_TRACE_GRAMMAR(primitive_type, | class_name opt_identity );
 
@@ -21618,7 +21588,7 @@ primitive_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (typ), dt);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| char_bit_type
 	  opt_prec_1
 	  opt_charset
@@ -21777,7 +21747,7 @@ primitive_type
 			    parser_free_node (this_parser, coll_node);
 			  }
 
-		DBG_PRINT}}
+		}}
 	| NUMERIC opt_prec_2
 		{{ DBG_TRACE_GRAMMAR(primitive_type, | NUMERIC opt_prec_2 );
 
@@ -21836,7 +21806,7 @@ primitive_type
 			if (scale)
 			  parser_free_node (this_parser, scale);
 
-		DBG_PRINT}}
+		}}
    	| FLOAT_ opt_prec_1
 		{{ DBG_TRACE_GRAMMAR(primitive_type, | FLOAT_ opt_prec_1);
 
@@ -21886,7 +21856,7 @@ primitive_type
 			if (prec)
 			  parser_free_node (this_parser, prec);
 
-		DBG_PRINT}}
+		}}
 	| ENUM '(' char_string_literal_list ')' opt_charset opt_collation
 	  {{ DBG_TRACE_GRAMMAR(primitive_type, | ENUM '(' char_string_literal_list ')' opt_charset opt_collation);
 			container_2 ctn;
@@ -21995,7 +21965,7 @@ primitive_type
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_ENUMERATION), dt);
 
 			$$ = ctn;
-	  DBG_PRINT}}
+	  }}
 	;
 
 opt_internal_external
@@ -22004,19 +21974,19 @@ opt_internal_external
 
 			$$ = 0;
 
-		DBG_PRINT}}
+		}}
 	| INTERNAL
 		{{ DBG_TRACE_GRAMMAR(opt_internal_external, | INTERNAL );
 
 			$$ = PT_LOB_INTERNAL;
 
-		DBG_PRINT}}
+		}}
 	| EXTERNAL
 		{{ DBG_TRACE_GRAMMAR(opt_internal_external, | EXTERNAL );
 
 			$$ = PT_LOB_EXTERNAL;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_identity
@@ -22025,13 +21995,13 @@ opt_identity
 
 			$$ = 0;
 
-		DBG_PRINT}}
+		}}
 	| IDENTITY
 		{{ DBG_TRACE_GRAMMAR(opt_identity, | IDENTITY );
 
 			$$ = 1;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_prec_1
@@ -22040,13 +22010,13 @@ opt_prec_1
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| '(' unsigned_integer ')'
 		{{ DBG_TRACE_GRAMMAR(opt_prec_1, | '(' unsigned_integer ')' );
 
 			$$ = $2;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_padding
@@ -22055,13 +22025,13 @@ opt_padding
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| '(' unsigned_integer ')'
 		{{ DBG_TRACE_GRAMMAR(opt_padding, | '(' unsigned_integer ')' );
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_prec_2
@@ -22072,7 +22042,7 @@ opt_prec_2
 			SET_CONTAINER_2 (ctn, NULL, NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| '(' unsigned_integer ')'
 		{{ DBG_TRACE_GRAMMAR(opt_prec_2, | '(' unsigned_integer ')' );
 
@@ -22080,7 +22050,7 @@ opt_prec_2
 			SET_CONTAINER_2 (ctn, $2, NULL);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| '(' unsigned_integer ',' unsigned_integer ')'
 		{{ DBG_TRACE_GRAMMAR(opt_prec_2, | '(' unsigned_integer ',' unsigned_integer ')' );
 
@@ -22088,7 +22058,7 @@ opt_prec_2
 			SET_CONTAINER_2 (ctn, $2, $4);
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	;
 
 of_charset
@@ -22102,13 +22072,13 @@ opt_collation
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| collation_spec
 		{{ DBG_TRACE_GRAMMAR(opt_collation, | collation_spec );
 
 			$$=$1;
 
-		DBG_PRINT}}
+		}}
 	;
 
 collation_spec
@@ -22117,7 +22087,7 @@ collation_spec
 
 			$$ = $2;
 
-		DBG_PRINT}}
+		}}
 	| COLLATE BINARY
 		{{ DBG_TRACE_GRAMMAR(collation_spec, | COLLATE BINARY);
 			PT_NODE *node;
@@ -22134,7 +22104,7 @@ collation_spec
 			  }
 
 			$$ = node;
-		DBG_PRINT}}
+		}}
 	| COLLATE IdName
 		{{ DBG_TRACE_GRAMMAR(collation_spec, | COLLATE IdName);
 			PT_NODE *node;
@@ -22151,7 +22121,7 @@ collation_spec
 			  }
 
 			$$ = node;
-		DBG_PRINT}}
+		}}
 	;
 
 class_encrypt_spec
@@ -22169,7 +22139,7 @@ class_encrypt_spec
 			  }
 
 			$$ = node;
-		DBG_PRINT}}
+		}}
 	;
 
 class_comment_spec
@@ -22192,7 +22162,7 @@ class_comment_spec
 			  }
 
 			$$ = node;
-		DBG_PRINT}}
+		}}
 	| COMMENT					/* 1 */
 	  ON_						/* 2 */
 	  opt_of_column_attribute			/* 3 */
@@ -22207,7 +22177,7 @@ class_comment_spec
 				alter_node->info.alter.code = PT_CHANGE_COLUMN_COMMENT;
 				alter_node->info.alter.alter_clause.attr_mthd.attr_def_list = $5;
 			  }
-		DBG_PRINT}}
+		}}
 	| COMMENT					/* 1 */
 	  ON_						/* 2 */
 	  CLASS ATTRIBUTE				/* 3, 4 */
@@ -22222,7 +22192,7 @@ class_comment_spec
 				alter_node->info.alter.code = PT_CHANGE_COLUMN_COMMENT;
 				alter_node->info.alter.alter_clause.attr_mthd.attr_def_list = $6;
 			  }
-		DBG_PRINT}}
+		}}
 	;
 
 opt_vclass_comment_spec
@@ -22269,7 +22239,7 @@ opt_index_with_clause
         | WITH index_with_item_list
           {  DBG_TRACE_GRAMMAR(opt_index_with_clause, | WITH index_with_item_list );
              $$ = $2;
-          DBG_PRINT}
+          }
         ;
 
 index_with_item_list  
@@ -22303,7 +22273,7 @@ online_parallel
 	: ONLINE
 	   {{ DBG_TRACE_GRAMMAR(online_parallel, : ONLINE);
                $$ = 1;  // thread count is 0
-           DBG_PRINT}}
+           }}
 	| ONLINE PARALLEL opt_equalsign unsigned_integer
 	   {{ DBG_TRACE_GRAMMAR(online_parallel, |  ONLINE PARALLEL opt_equalsign unsigned_integer);
                const int MIN_COUNT = 1;
@@ -22316,7 +22286,7 @@ online_parallel
                                   MSGCAT_SYNTAX_INVALID_PARALLEL_ARGUMENT, MIN_COUNT, MAX_COUNT);
                   }
 		$$ = thread_count + 1;
-	   DBG_PRINT}}
+	   }}
 	;
 
 deduplicate_key_mod_level
@@ -22330,7 +22300,7 @@ deduplicate_key_mod_level
                       }
 
                  $$ = int_val;
-               DBG_PRINT}
+               }
         ;
 
 opt_comment_spec
@@ -22362,7 +22332,7 @@ comment_value
 			  }
 
 			$$ = node;
-		DBG_PRINT}}
+		}}
 	;
 
 opt_charset
@@ -22371,13 +22341,13 @@ opt_charset
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| charset_spec
 		{{ DBG_TRACE_GRAMMAR(opt_charset, | charset_spec);
 
 			$$ = $1;
 
-		DBG_PRINT}}
+		}}
 	;
 
 charset_spec
@@ -22386,7 +22356,7 @@ charset_spec
 
 			$$ = $2;
 
-		DBG_PRINT}}
+		}}
 	| of_charset BINARY
 		{{ DBG_TRACE_GRAMMAR(charset_spec, | of_charset BINARY );
 			PT_NODE *node;
@@ -22403,7 +22373,7 @@ charset_spec
 			  }
 
 			$$ = node;
-		DBG_PRINT}}
+		}}
 	| of_charset IdName
 		{{ DBG_TRACE_GRAMMAR(charset_spec, | of_charset IdName );
 			PT_NODE *node;
@@ -22420,7 +22390,7 @@ charset_spec
 			  }
 
 			$$ = node;
-		DBG_PRINT}}
+		}}
 	;
 
 opt_using_charset
@@ -22440,7 +22410,7 @@ opt_using_charset
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| USING char_string_literal
 		{{ DBG_TRACE_GRAMMAR(opt_using_charset, | USING char_string_literal );
 
@@ -22467,7 +22437,7 @@ opt_using_charset
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| USING IdName
 		{{ DBG_TRACE_GRAMMAR(opt_using_charset, | USING IdName );
 
@@ -22506,7 +22476,7 @@ opt_using_charset
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| USING BINARY
 		{{ DBG_TRACE_GRAMMAR(opt_using_charset, | USING BINARY );
 
@@ -22522,7 +22492,7 @@ opt_using_charset
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 set_type
@@ -22531,25 +22501,25 @@ set_type
 
 			$$ = PT_TYPE_SET;
 
-		DBG_PRINT}}
+		}}
 	| MULTISET_OF
 		{{ DBG_TRACE_GRAMMAR(set_type, | MULTISET_OF );
 
 			$$ = PT_TYPE_MULTISET;
 
-		DBG_PRINT}}
+		}}
 	| SEQUENCE_OF
 		{{ DBG_TRACE_GRAMMAR(set_type, | SEQUENCE_OF );
 
 			$$ = PT_TYPE_SEQUENCE;
 
-		DBG_PRINT}}
+		}}
 	| of_container opt_of
 		{{ DBG_TRACE_GRAMMAR(set_type, | of_container opt_of );
 
 			$$ = $1;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_of
@@ -22564,7 +22534,7 @@ signed_literal_
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| '-' unsigned_integer
 		{{ DBG_TRACE_GRAMMAR(signed_literal_, | '-' unsigned_integer );
 
@@ -22611,7 +22581,7 @@ signed_literal_
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| '-' unsigned_real
 		{{ DBG_TRACE_GRAMMAR(signed_literal_,  | '-' unsigned_real);
 
@@ -22650,7 +22620,7 @@ signed_literal_
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| '-' monetary_literal
 		{{ DBG_TRACE_GRAMMAR(signed_literal_,  | '-' monetary_literal);
 
@@ -22671,7 +22641,7 @@ signed_literal_
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 literal_
@@ -22681,14 +22651,14 @@ literal_
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| param_
 		{{ DBG_TRACE_GRAMMAR(literal_,  | param_ );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 literal_w_o_param
@@ -22698,21 +22668,21 @@ literal_w_o_param
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| unsigned_real
 		{{ DBG_TRACE_GRAMMAR(literal_w_o_param,  | unsigned_real );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| monetary_literal
 		{{ DBG_TRACE_GRAMMAR(literal_w_o_param,  : unsigned_integer );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| char_string_literal
 		{{ DBG_TRACE_GRAMMAR(literal_w_o_param,  | char_string_literal);
 
@@ -22723,21 +22693,21 @@ literal_w_o_param
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| bit_string_literal
 		{{ DBG_TRACE_GRAMMAR(literal_w_o_param,  | bit_string_literal );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| host_param_input
 		{{ DBG_TRACE_GRAMMAR(literal_w_o_param,  | host_param_input );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| Null
 		{{ DBG_TRACE_GRAMMAR(literal_w_o_param,  | Null );
 
@@ -22747,14 +22717,14 @@ literal_w_o_param
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| constant_set
 		{{ DBG_TRACE_GRAMMAR(literal_w_o_param, | constant_set );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| NA
 		{{ DBG_TRACE_GRAMMAR(literal_w_o_param,  | NA );
 
@@ -22764,27 +22734,27 @@ literal_w_o_param
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| date_or_time_literal
 		{{ DBG_TRACE_GRAMMAR(literal_w_o_param, | date_or_time_literal );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| boolean
 		{{ DBG_TRACE_GRAMMAR(literal_w_o_param,  | boolean );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| json_literal
 		{{ DBG_TRACE_GRAMMAR(literal_w_o_param, | json_literal );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-		DBG_PRINT}}
+		}}
 	;
 
 boolean
@@ -22801,7 +22771,7 @@ boolean
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| False
 		{{ DBG_TRACE_GRAMMAR(boolean, | False );
 
@@ -22815,7 +22785,7 @@ boolean
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| UNKNOWN
 		{{ DBG_TRACE_GRAMMAR(boolean, | UNKNOWN );
 
@@ -22825,7 +22795,7 @@ boolean
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 constant_set
@@ -22856,7 +22826,7 @@ constant_set
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| opt_of_container '{' '}'
 		{{ DBG_TRACE_GRAMMAR(constant_set, | opt_of_container '{' '}' );
 
@@ -22871,7 +22841,7 @@ constant_set
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_of_container
@@ -22880,13 +22850,13 @@ opt_of_container
 
 			$$ = PT_TYPE_SEQUENCE;
 
-		DBG_PRINT}}
+		}}
 	| of_container
 		{{ DBG_TRACE_GRAMMAR(opt_of_container, | of_container );
 
 			$$ = $1;
 
-		DBG_PRINT}}
+		}}
 	;
 
 of_container
@@ -22895,25 +22865,25 @@ of_container
 
 			$$ = PT_TYPE_SET;
 
-		DBG_PRINT}}
+		}}
 	| MULTISET
 		{{ DBG_TRACE_GRAMMAR(of_container, | MULTISET );
 
 			$$ = PT_TYPE_MULTISET;
 
-		DBG_PRINT}}
+		}}
 	| SEQUENCE
 		{{ DBG_TRACE_GRAMMAR(of_container, | SEQUENCE );
 
 			$$ = PT_TYPE_SEQUENCE;
 
-		DBG_PRINT}}
+		}}
 	| LIST
 		{{ DBG_TRACE_GRAMMAR(of_container, | LIST );
 
 			$$ = PT_TYPE_SEQUENCE;
 
-		DBG_PRINT}}
+		}}
 	;
 
 identifier_list
@@ -22923,25 +22893,25 @@ identifier_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| identifier
 		{{ DBG_TRACE_GRAMMAR(identifier_list, | identifier );
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_bracketed_identifier_list
 	:	/* EMPTY */
 		{{ DBG_TRACE_GRAMMAR(opt_bracketed_identifier_list, : );
 			$$ = NULL;
-		DBG_PRINT}}
+		}}
 	| '(' identifier_list ')'
 		{{ DBG_TRACE_GRAMMAR(opt_bracketed_identifier_list, | '(' identifier_list ')' );
 			$$ = $2;
-		DBG_PRINT}}
+		}}
 	;
 
 simple_path_id_list
@@ -22951,14 +22921,14 @@ simple_path_id_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| simple_path_id
 		{{ DBG_TRACE_GRAMMAR(simple_path_id_list, | simple_path_id);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 identifier_without_dot
@@ -22984,7 +22954,7 @@ identifier_without_dot
 			$$ = p;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 identifier
@@ -23004,7 +22974,7 @@ identifier
 			    p->info.name.original = str_name;
 			  }
 			$$ = p;
-		DBG_PRINT}}
+		}}
 	| BracketDelimitedIdName
 		{{ DBG_TRACE_GRAMMAR(identifier, | BracketDelimitedIdName);
 			PT_NODE *p = parser_new_node (this_parser, PT_NAME);
@@ -23021,7 +22991,7 @@ identifier
 			    p->info.name.original = str_name;
 			  }
 			$$ = p;
-		DBG_PRINT}}
+		}}
 	| BacktickDelimitedIdName
 		{{ DBG_TRACE_GRAMMAR(identifier, | BacktickDelimitedIdName);
 			PT_NODE *p = parser_new_node (this_parser, PT_NAME);
@@ -23038,7 +23008,7 @@ identifier
 			    p->info.name.original = str_name;
 			  }
 			$$ = p;
-		DBG_PRINT}}
+		}}
 	| DelimitedIdName
 		{{ DBG_TRACE_GRAMMAR(identifier, | DelimitedIdName);
 			PT_NODE *p = parser_new_node (this_parser, PT_NAME);
@@ -23055,7 +23025,7 @@ identifier
 			    p->info.name.original = str_name;
 			  }
 			$$ = p;
-		DBG_PRINT}}
+		}}
 /*{{{*/
 	| ACTIVE                 {{ DBG_TRACE_GRAMMAR(identifier, | ACTIVE             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
 	| ADDDATE                {{ DBG_TRACE_GRAMMAR(identifier, | ADDDATE            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
@@ -23277,7 +23247,7 @@ escape_literal
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| Null
 		{{ DBG_TRACE_GRAMMAR(escape_literal, | Null);
 
@@ -23287,7 +23257,7 @@ escape_literal
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 string_literal_or_input_hv
@@ -23301,14 +23271,14 @@ string_literal_or_input_hv
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| host_param_input
 		{{ DBG_TRACE_GRAMMAR(string_literal_or_input_hv, | host_param_input);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
         ;
 
 
@@ -23329,13 +23299,13 @@ char_string_literal
 			$$ = str;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| char_string
 		{{ DBG_TRACE_GRAMMAR(char_string_literal, | char_string);
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 char_string
@@ -23344,7 +23314,7 @@ char_string
 			$$ = pt_create_string_literal_node_w_charset_coll($1, -1);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| NCHAR_STRING
 		{{ DBG_TRACE_GRAMMAR(char_string, | NCHAR_STRING);
 			PT_NODE *node = NULL;
@@ -23380,7 +23350,7 @@ char_string
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| BINARY_STRING
 		{{ DBG_TRACE_GRAMMAR(char_string, | BINARY_STRING);
 
@@ -23401,7 +23371,7 @@ char_string
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| EUCKR_STRING
 		{{ DBG_TRACE_GRAMMAR(char_string, | EUCKR_STRING);
 
@@ -23422,7 +23392,7 @@ char_string
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| ISO_STRING
 		{{ DBG_TRACE_GRAMMAR(char_string, | ISO_STRING);
 
@@ -23443,7 +23413,7 @@ char_string
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| UTF8_STRING
 		{{ DBG_TRACE_GRAMMAR(char_string, | UTF8_STRING);
 
@@ -23464,7 +23434,7 @@ char_string
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 
@@ -23485,14 +23455,14 @@ bit_string_literal
 			$$ = str;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| bit_string
 		{{ DBG_TRACE_GRAMMAR(bit_string_literal, | bit_string);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 bit_string
@@ -23513,7 +23483,7 @@ bit_string
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| HEX_STRING
 		{{ DBG_TRACE_GRAMMAR(bit_string, | HEX_STRING);
 
@@ -23531,7 +23501,7 @@ bit_string
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 unsigned_integer
@@ -23583,7 +23553,7 @@ unsigned_integer
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 unsigned_int32
@@ -23610,7 +23580,7 @@ unsigned_int32
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 unsigned_real
@@ -23665,7 +23635,7 @@ unsigned_real
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 monetary_literal
@@ -23686,7 +23656,7 @@ monetary_literal
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| DOLLAR_SIGN of_integer_real_literal
 		{{ DBG_TRACE_GRAMMAR(monetary_literal, | DOLLAR_SIGN of_integer_real_literal);
 
@@ -23704,7 +23674,7 @@ monetary_literal
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| WON_SIGN of_integer_real_literal
 		{{ DBG_TRACE_GRAMMAR(monetary_literal, | WON_SIGN of_integer_real_literal);
 
@@ -23722,7 +23692,7 @@ monetary_literal
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| TURKISH_LIRA_SIGN of_integer_real_literal
 		{{ DBG_TRACE_GRAMMAR(monetary_literal, | TURKISH_LIRA_SIGN of_integer_real_literal);
 
@@ -23740,7 +23710,7 @@ monetary_literal
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| BRITISH_POUND_SIGN of_integer_real_literal
 		{{ DBG_TRACE_GRAMMAR(monetary_literal, | BRITISH_POUND_SIGN of_integer_real_literal);
 
@@ -23757,7 +23727,7 @@ monetary_literal
 
 			$$ = val;
 
-		DBG_PRINT}}
+		}}
 	| CAMBODIAN_RIEL_SIGN of_integer_real_literal
 		{{ DBG_TRACE_GRAMMAR(monetary_literal, | CAMBODIAN_RIEL_SIGN of_integer_real_literal);
 
@@ -23774,7 +23744,7 @@ monetary_literal
 
 			$$ = val;
 
-		DBG_PRINT}}
+		}}
 	| CHINESE_RENMINBI_SIGN of_integer_real_literal
 		{{ DBG_TRACE_GRAMMAR(monetary_literal, | CHINESE_RENMINBI_SIGN of_integer_real_literal);
 
@@ -23791,7 +23761,7 @@ monetary_literal
 
 			$$ = val;
 
-		DBG_PRINT}}
+		}}
 	| INDIAN_RUPEE_SIGN of_integer_real_literal
 		{{ DBG_TRACE_GRAMMAR(monetary_literal, | INDIAN_RUPEE_SIGN of_integer_real_literal);
 
@@ -23808,7 +23778,7 @@ monetary_literal
 
 			$$ = val;
 
-		DBG_PRINT}}
+		}}
 	| RUSSIAN_RUBLE_SIGN of_integer_real_literal
 		{{ DBG_TRACE_GRAMMAR(monetary_literal, | RUSSIAN_RUBLE_SIGN of_integer_real_literal);
 
@@ -23825,7 +23795,7 @@ monetary_literal
 
 			$$ = val;
 
-		DBG_PRINT}}
+		}}
 	| AUSTRALIAN_DOLLAR_SIGN of_integer_real_literal
 		{{ DBG_TRACE_GRAMMAR(monetary_literal, | AUSTRALIAN_DOLLAR_SIGN of_integer_real_literal);
 
@@ -23842,7 +23812,7 @@ monetary_literal
 
 			$$ = val;
 
-		DBG_PRINT}}
+		}}
 	| CANADIAN_DOLLAR_SIGN of_integer_real_literal
 		{{ DBG_TRACE_GRAMMAR(monetary_literal, | CANADIAN_DOLLAR_SIGN of_integer_real_literal);
 
@@ -23859,7 +23829,7 @@ monetary_literal
 
 			$$ = val;
 
-		DBG_PRINT}}
+		}}
 	| BRASILIAN_REAL_SIGN of_integer_real_literal
 		{{ DBG_TRACE_GRAMMAR(monetary_literal, | BRASILIAN_REAL_SIGN of_integer_real_literal);
 
@@ -23876,7 +23846,7 @@ monetary_literal
 
 			$$ = val;
 
-		DBG_PRINT}}
+		}}
 	| ROMANIAN_LEU_SIGN of_integer_real_literal
 		{{ DBG_TRACE_GRAMMAR(monetary_literal, | ROMANIAN_LEU_SIGN of_integer_real_literal);
 
@@ -23893,7 +23863,7 @@ monetary_literal
 
 			$$ = val;
 
-		DBG_PRINT}}
+		}}
 	| EURO_SIGN of_integer_real_literal
 		{{ DBG_TRACE_GRAMMAR(monetary_literal, | EURO_SIGN of_integer_real_literal);
 
@@ -23910,7 +23880,7 @@ monetary_literal
 
 			$$ = val;
 
-		DBG_PRINT}}
+		}}
 	| SWISS_FRANC_SIGN of_integer_real_literal
 		{{ DBG_TRACE_GRAMMAR(monetary_literal, | SWISS_FRANC_SIGN of_integer_real_literal);
 
@@ -23927,7 +23897,7 @@ monetary_literal
 
 			$$ = val;
 
-		DBG_PRINT}}
+		}}
 	| DANISH_KRONE_SIGN of_integer_real_literal
 		{{ DBG_TRACE_GRAMMAR(monetary_literal, | DANISH_KRONE_SIGN of_integer_real_literal);
 
@@ -23944,7 +23914,7 @@ monetary_literal
 
 			$$ = val;
 
-		DBG_PRINT}}
+		}}
 	| NORWEGIAN_KRONE_SIGN of_integer_real_literal
 		{{ DBG_TRACE_GRAMMAR(monetary_literal, | NORWEGIAN_KRONE_SIGN of_integer_real_literal);
 
@@ -23961,7 +23931,7 @@ monetary_literal
 
 			$$ = val;
 
-		DBG_PRINT}}
+		}}
 	| BULGARIAN_LEV_SIGN of_integer_real_literal
 		{{ DBG_TRACE_GRAMMAR(monetary_literal, | BULGARIAN_LEV_SIGN of_integer_real_literal);
 
@@ -23978,7 +23948,7 @@ monetary_literal
 
 			$$ = val;
 
-		DBG_PRINT}}
+		}}
 	| VIETNAMESE_DONG_SIGN of_integer_real_literal
 		{{ DBG_TRACE_GRAMMAR(monetary_literal, | VIETNAMESE_DONG_SIGN of_integer_real_literal);
 
@@ -23995,7 +23965,7 @@ monetary_literal
 
 			$$ = val;
 
-		DBG_PRINT}}
+		}}
 	| CZECH_KORUNA_SIGN of_integer_real_literal
 		{{ DBG_TRACE_GRAMMAR(monetary_literal, | CZECH_KORUNA_SIGN of_integer_real_literal);
 
@@ -24012,7 +23982,7 @@ monetary_literal
 
 			$$ = val;
 
-		DBG_PRINT}}
+		}}
 	| POLISH_ZLOTY_SIGN of_integer_real_literal
 		{{ DBG_TRACE_GRAMMAR(monetary_literal, | POLISH_ZLOTY_SIGN of_integer_real_literal);
 
@@ -24029,7 +23999,7 @@ monetary_literal
 
 			$$ = val;
 
-		DBG_PRINT}}
+		}}
 	| SWEDISH_KRONA_SIGN of_integer_real_literal
 		{{ DBG_TRACE_GRAMMAR(monetary_literal, | SWEDISH_KRONA_SIGN of_integer_real_literal);
 
@@ -24046,7 +24016,7 @@ monetary_literal
 
 			$$ = val;
 
-		DBG_PRINT}}
+		}}
 	| CROATIAN_KUNA_SIGN of_integer_real_literal
 		{{ DBG_TRACE_GRAMMAR(monetary_literal, | CROATIAN_KUNA_SIGN of_integer_real_literal);
 
@@ -24063,7 +24033,7 @@ monetary_literal
 
 			$$ = val;
 
-		DBG_PRINT}}
+		}}
 	| SERBIAN_DINAR_SIGN of_integer_real_literal
 		{{ DBG_TRACE_GRAMMAR(monetary_literal, | SERBIAN_DINAR_SIGN of_integer_real_literal);
 
@@ -24080,7 +24050,7 @@ monetary_literal
 
 			$$ = val;
 
-		DBG_PRINT}}
+		}}
 	;
 
 of_integer_real_literal
@@ -24089,19 +24059,19 @@ of_integer_real_literal
 
 			$$ = $1;
 
-		DBG_PRINT}}
+		}}
 	| opt_plus UNSIGNED_REAL
 		{{ DBG_TRACE_GRAMMAR(of_integer_real_literal, | opt_plus UNSIGNED_REAL);
 
 			$$ = $2;
 
-		DBG_PRINT}}
+		}}
 	| '-' UNSIGNED_REAL
 		{{ DBG_TRACE_GRAMMAR(of_integer_real_literal, | '-' UNSIGNED_REAL);
 
 			$$ = pt_append_string (this_parser, (char *) "-", $2);
 
-		DBG_PRINT}}
+		}}
 	;
 
 date_or_time_literal
@@ -24113,7 +24083,7 @@ date_or_time_literal
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| Time CHAR_STRING
 		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | Time CHAR_STRING);
 
@@ -24122,7 +24092,7 @@ date_or_time_literal
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| TIMESTAMP CHAR_STRING
 		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | TIMESTAMP CHAR_STRING);
 
@@ -24131,7 +24101,7 @@ date_or_time_literal
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| TIMESTAMP WITH Time ZONE CHAR_STRING
 		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | TIMESTAMP WITH Time ZONE CHAR_STRING);
 
@@ -24140,7 +24110,7 @@ date_or_time_literal
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| TIMESTAMPTZ CHAR_STRING
 		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | TIMESTAMPTZ CHAR_STRING);
 
@@ -24149,7 +24119,7 @@ date_or_time_literal
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| TIMESTAMPLTZ CHAR_STRING
 		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | TIMESTAMPLTZ CHAR_STRING);
 
@@ -24158,7 +24128,7 @@ date_or_time_literal
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| TIMESTAMP WITH LOCAL Time ZONE CHAR_STRING
 		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | TIMESTAMP WITH LOCAL Time ZONE CHAR_STRING);
 
@@ -24167,7 +24137,7 @@ date_or_time_literal
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| DATETIME CHAR_STRING
 		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | DATETIME CHAR_STRING);
 
@@ -24176,7 +24146,7 @@ date_or_time_literal
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| DATETIME WITH Time ZONE CHAR_STRING
 		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | DATETIME WITH Time ZONE CHAR_STRING);
 
@@ -24185,7 +24155,7 @@ date_or_time_literal
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| DATETIMETZ CHAR_STRING
 		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | DATETIMETZ CHAR_STRING);
 
@@ -24194,7 +24164,7 @@ date_or_time_literal
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| DATETIMELTZ CHAR_STRING
 		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | DATETIMELTZ CHAR_STRING);
 
@@ -24203,7 +24173,7 @@ date_or_time_literal
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| DATETIME WITH LOCAL Time ZONE CHAR_STRING
 		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | DATETIME WITH LOCAL Time ZONE CHAR_STRING);
 
@@ -24212,7 +24182,7 @@ date_or_time_literal
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 json_literal
@@ -24223,7 +24193,7 @@ json_literal
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-                DBG_PRINT}}
+                }}
 
 create_as_clause
 	: opt_replace AS csql_query
@@ -24231,7 +24201,7 @@ create_as_clause
 			container_2 ctn;
 			SET_CONTAINER_2(ctn, FROM_NUMBER ($1), $3);
 			$$ = ctn;
-		DBG_PRINT}}
+		}}
 	;
 
 partition_clause
@@ -24248,7 +24218,7 @@ partition_clause
 
 			$$ = qc;
 
-		DBG_PRINT}}
+		}}
 	| PARTITION opt_by RANGE_ '(' expression_ ')' '(' partition_def_list ')'
 		{{ DBG_TRACE_GRAMMAR(partition_clause, | PARTITION opt_by RANGE_ '(' expression_ ')' '(' partition_def_list ')');
 
@@ -24264,7 +24234,7 @@ partition_clause
 			$$ = qc;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| PARTITION opt_by LIST '(' expression_ ')' '(' partition_def_list ')'
 		{{ DBG_TRACE_GRAMMAR(partition_clause, | PARTITION opt_by LIST '(' expression_ ')' '(' partition_def_list ')');
 
@@ -24280,7 +24250,7 @@ partition_clause
 			$$ = qc;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_by
@@ -24295,14 +24265,14 @@ partition_def_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| partition_def
 		{{ DBG_TRACE_GRAMMAR(partition_def_list, | partition_def);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 partition_def
@@ -24321,7 +24291,7 @@ partition_def
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| PARTITION identifier VALUES LESS THAN '(' signed_literal_ ')' opt_comment_spec
 		{{ DBG_TRACE_GRAMMAR(partition_def, | PARTITION identifier VALUES LESS THAN '(' signed_literal_ ')' opt_comment_spec);
 
@@ -24337,7 +24307,7 @@ partition_def
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| PARTITION identifier VALUES IN_ '(' signed_literal_list ')' opt_comment_spec
 		{{ DBG_TRACE_GRAMMAR(partition_def, | PARTITION identifier VALUES IN_ '(' signed_literal_list ')' opt_comment_spec);
 
@@ -24353,7 +24323,7 @@ partition_def
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 alter_partition_clause_for_alter_list
@@ -24368,7 +24338,7 @@ alter_partition_clause_for_alter_list
 			    alt->info.alter.alter_clause.partition.info = $1;
 			  }
 
-		DBG_PRINT}}
+		}}
 	| REMOVE PARTITIONING
 		{{ DBG_TRACE_GRAMMAR(alter_partition_clause_for_alter_list, | REMOVE PARTITIONING);
 
@@ -24377,7 +24347,7 @@ alter_partition_clause_for_alter_list
 			if (alt)
 			  alt->info.alter.code = PT_REMOVE_PARTITION;
 
-		DBG_PRINT}}
+		}}
 	| REORGANIZE PARTITION identifier_list INTO '(' partition_def_list ')'
 		{{ DBG_TRACE_GRAMMAR(alter_partition_clause_for_alter_list, | REORGANIZE PARTITION identifier_list INTO '(' partition_def_list ')');
 
@@ -24390,7 +24360,7 @@ alter_partition_clause_for_alter_list
 			    alt->info.alter.alter_clause.partition.parts = $6;
 			  }
 
-		DBG_PRINT}}
+		}}
 	| ANALYZE PARTITION opt_all
 		{{ DBG_TRACE_GRAMMAR(alter_partition_clause_for_alter_list, | ANALYZE PARTITION opt_all);
 
@@ -24402,7 +24372,7 @@ alter_partition_clause_for_alter_list
 			    alt->info.alter.alter_clause.partition.name_list = NULL;
 			  }
 
-		DBG_PRINT}}
+		}}
 	| ANALYZE PARTITION identifier_list
 		{{ DBG_TRACE_GRAMMAR(alter_partition_clause_for_alter_list, | ANALYZE PARTITION identifier_list);
 
@@ -24414,7 +24384,7 @@ alter_partition_clause_for_alter_list
 			    alt->info.alter.alter_clause.partition.name_list = $3;
 			  }
 
-		DBG_PRINT}}
+		}}
 	| COALESCE PARTITION literal_w_o_param
 		{{ DBG_TRACE_GRAMMAR(alter_partition_clause_for_alter_list, | COALESCE PARTITION literal_w_o_param);
 
@@ -24426,7 +24396,7 @@ alter_partition_clause_for_alter_list
 			    alt->info.alter.alter_clause.partition.size = $3;
 			  }
 
-		DBG_PRINT}}
+		}}
 	 | PROMOTE PARTITION identifier_list
 		{{ DBG_TRACE_GRAMMAR(alter_partition_clause_for_alter_list, | PROMOTE PARTITION identifier_list);
 
@@ -24438,7 +24408,7 @@ alter_partition_clause_for_alter_list
 			    alt->info.alter.alter_clause.partition.name_list = $3;
 			  }
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_all
@@ -24453,28 +24423,28 @@ execute_using_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| execute_using_list ',' signed_literal_
 		{{ DBG_TRACE_GRAMMAR(execute_using_list, | execute_using_list ',' signed_literal_);
 
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| session_variable_expression
 		{{ DBG_TRACE_GRAMMAR(execute_using_list, | session_variable_expression);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| signed_literal_
 		{{ DBG_TRACE_GRAMMAR(execute_using_list, | signed_literal_);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 signed_literal_list
@@ -24484,14 +24454,14 @@ signed_literal_list
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	| signed_literal_
 		{{ DBG_TRACE_GRAMMAR(signed_literal_list, | signed_literal_);
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-		DBG_PRINT}}
+		}}
 	;
 
 paren_plus
@@ -24514,7 +24484,7 @@ vacuum_stmt
 				    sizeof (PT_NODE));
 			  }
 			$$ = node;
-		DBG_PRINT}}
+		}}
 	;
 
 json_table_column_behavior_rule
@@ -24522,12 +24492,12 @@ json_table_column_behavior_rule
       {{ DBG_TRACE_GRAMMAR(json_table_column_behavior_rule, : Null);
         $$.m_behavior = JSON_TABLE_RETURN_NULL;
         $$.m_default_value = NULL;
-      DBG_PRINT}}
+      }}
     | ERROR_
       {{ DBG_TRACE_GRAMMAR(json_table_column_behavior_rule, | ERROR_);
         $$.m_behavior = JSON_TABLE_THROW_ERROR;
         $$.m_default_value = NULL;
-      DBG_PRINT}}
+      }}
     | DEFAULT expression_
       {{ DBG_TRACE_GRAMMAR(json_table_column_behavior_rule, | DEFAULT expression_);
         PT_NODE * default_value = $2;
@@ -24540,7 +24510,7 @@ json_table_column_behavior_rule
         $$.m_default_value = db_value_copy (temp);
 
         parser_free_node(this_parser, default_value);
-      DBG_PRINT}}
+      }}
     ;
 
 json_table_on_error_rule_optional
@@ -24548,11 +24518,11 @@ json_table_on_error_rule_optional
       {{ DBG_TRACE_GRAMMAR(json_table_on_error_rule_optional, : );
         $$.m_behavior = JSON_TABLE_RETURN_NULL;
         $$.m_default_value = NULL;
-      DBG_PRINT}}
+      }}
     | json_table_column_behavior_rule ON_ ERROR_
       {{ DBG_TRACE_GRAMMAR(json_table_on_error_rule_optional, | json_table_column_behavior_rule ON_ ERROR_);
         $$ = $1;
-      DBG_PRINT}}
+      }}
     ;
 
 json_table_on_empty_rule_optional
@@ -24560,11 +24530,11 @@ json_table_on_empty_rule_optional
       {{ DBG_TRACE_GRAMMAR(json_table_on_empty_rule_optional, : );
         $$.m_behavior = JSON_TABLE_RETURN_NULL;
         $$.m_default_value = NULL;
-      DBG_PRINT}}
+      }}
     | json_table_column_behavior_rule ON_ EMPTY
       {{ DBG_TRACE_GRAMMAR(json_table_on_empty_rule_optional, | json_table_column_behavior_rule ON_ EMPTY );
         $$ = $1;
-      DBG_PRINT}}
+      }}
     ;
 
 json_table_column_rule
@@ -24575,7 +24545,7 @@ json_table_column_rule
         pt_col->info.json_table_column_info.func = JSON_TABLE_ORDINALITY;
         pt_col->type_enum = PT_TYPE_INTEGER;
         $$ = pt_col;
-      DBG_PRINT}}
+      }}
     | identifier data_type PATH CHAR_STRING json_table_on_empty_rule_optional json_table_on_error_rule_optional
     //        $1        $2   $3          $4                                $5                                $6
       {{ DBG_TRACE_GRAMMAR(json_table_column_rule, | identifier data_type PATH CHAR_STRING json_table_on_empty_rule_optional json_table_on_error_rule_optional );
@@ -24588,7 +24558,7 @@ json_table_column_rule
         pt_col->info.json_table_column_info.on_empty = $5;
         pt_col->info.json_table_column_info.on_error = $6;
         $$ = pt_col;
-      DBG_PRINT}}
+      }}
     | identifier data_type EXISTS PATH CHAR_STRING
       {{ DBG_TRACE_GRAMMAR(json_table_column_rule, | identifier data_type EXISTS PATH CHAR_STRING );
         PT_NODE *pt_col = parser_new_node (this_parser, PT_JSON_TABLE_COLUMN);
@@ -24598,15 +24568,15 @@ json_table_column_rule
         pt_col->info.json_table_column_info.path=$5;
         pt_col->info.json_table_column_info.func = JSON_TABLE_EXISTS;
         $$ = pt_col;
-      DBG_PRINT}}
+      }}
     | NESTED json_table_node_rule
       {{ DBG_TRACE_GRAMMAR(json_table_column_rule, | NESTED json_table_node_rule );
         $$ = $2;
-      DBG_PRINT}}
+      }}
     | NESTED PATH json_table_node_rule
       {{ DBG_TRACE_GRAMMAR(json_table_column_rule, | NESTED PATH json_table_node_rule );
         $$ = $3;
-      DBG_PRINT}}
+      }}
     ;
 
 json_table_column_list_rule
@@ -24614,13 +24584,13 @@ json_table_column_list_rule
       {{ DBG_TRACE_GRAMMAR(json_table_column_list_rule,  : json_table_column_list_rule ',' json_table_column_rule );
         pt_jt_append_column_or_nested_node ($1, $3);
         $$ = $1;
-      DBG_PRINT}}
+      }}
     | json_table_column_rule
       {{ DBG_TRACE_GRAMMAR(json_table_column_list_rule, | json_table_column_rule );
         PT_NODE *pt_jt_node = parser_new_node (this_parser, PT_JSON_TABLE_NODE);
         pt_jt_append_column_or_nested_node (pt_jt_node, $1);
         $$ = pt_jt_node;
-      DBG_PRINT}}
+      }}
     ;
 
 json_table_node_rule
@@ -24633,13 +24603,13 @@ json_table_node_rule
         jt_node->info.json_table_node_info.path = $1;
 
         $$ = jt_node;
-      DBG_PRINT}}
+      }}
     ;
 
 json_table_rule
     : {{ DBG_TRACE_GRAMMAR(json_table_rule,  : );
             json_table_column_count = 0;
-      DBG_PRINT}}
+      }}
       '(' expression_ ',' json_table_node_rule ')'
       {{ DBG_TRACE_GRAMMAR(json_table_rule,  '(' expression_ ',' json_table_node_rule ')' );
         PT_NODE *jt = parser_new_node (this_parser, PT_JSON_TABLE);
@@ -24648,7 +24618,7 @@ json_table_rule
         json_table_column_count = 0;  // reset for next json table, if I am nested
 
         $$ = jt;
-      DBG_PRINT}}
+      }}
     ;
 
 connect_info
@@ -24658,7 +24628,7 @@ connect_info
 
                pt_fill_conn_info_container(this_parser, @$.buffer_pos, &ctn, $3);
 	        $$ = ctn;
-           DBG_PRINT }}
+           }}
         | connect_item
           {{ DBG_TRACE_GRAMMAR(connect_info, | connect_item );
                 container_10 ctn;
@@ -24666,7 +24636,7 @@ connect_info
 
                 pt_fill_conn_info_container(this_parser, @$.buffer_pos, &ctn, $1);    
 	        $$ = ctn;                
-           DBG_PRINT}}
+           }}
         ;
 
 connect_item    
@@ -24687,7 +24657,7 @@ connect_item
                   }
                 SET_CONTAINER_2(ctn, FROM_NUMBER(CONN_INFO_HOST), val);
                 $$ = ctn;
-            DBG_PRINT}}
+            }}
         | PORT '=' UNSIGNED_INTEGER 
           {{ DBG_TRACE_GRAMMAR(connect_item, | PORT '=' UNSIGNED_INTEGER );
                 container_2 ctn;
@@ -24705,7 +24675,7 @@ connect_item
 
                 SET_CONTAINER_2(ctn, FROM_NUMBER(CONN_INFO_PORT), val);
                 $$ = ctn;
-           DBG_PRINT}}
+           }}
          | DBNAME '=' char_string_literal 
           {{ DBG_TRACE_GRAMMAR(connect_item,  | DBNAME '=' char_string_literal  );
                container_2 ctn;
@@ -24718,13 +24688,13 @@ connect_item
 		 PT_NODE_PRINT_VALUE_TO_TEXT (this_parser, val);                
                 SET_CONTAINER_2(ctn, FROM_NUMBER(CONN_INFO_DBNAME), val);
                 $$ = ctn;
-           DBG_PRINT}}            
+           }}            
         | DBNAME '=' identifier 
           {{ DBG_TRACE_GRAMMAR(connect_item,  | DBNAME '=' identifier  );
                 container_2 ctn;
                 SET_CONTAINER_2(ctn, FROM_NUMBER(CONN_INFO_DBNAME), $3);
                 $$ = ctn;
-           DBG_PRINT}}
+           }}
         | USER '=' char_string_literal 
           {{ DBG_TRACE_GRAMMAR(connect_item,  | USER '=' char_string_literal);
                container_2 ctn;
@@ -24738,14 +24708,14 @@ connect_item
                SET_CONTAINER_2(ctn, FROM_NUMBER(CONN_INFO_USER), val);
                $$ = ctn;
                PARSER_SAVE_ERR_CONTEXT ($3, @$.buffer_pos)
-           DBG_PRINT}}            
+           }}            
         | USER '=' identifier
           {{ DBG_TRACE_GRAMMAR(connect_item, | USER '=' identifier);
                 container_2 ctn;
                 SET_CONTAINER_2(ctn, FROM_NUMBER(CONN_INFO_USER), $3);
                 $$ = ctn;
                 PARSER_SAVE_ERR_CONTEXT ($3, @$.buffer_pos)
-            DBG_PRINT}}
+            }}
         | PASSWORD '=' 
           {{ DBG_TRACE_GRAMMAR(connect_item,   | PASSWORD '='  );
                container_2 ctn;
@@ -24772,7 +24742,7 @@ connect_item
 
                 SET_CONTAINER_2(ctn, FROM_NUMBER(CONN_INFO_PASSWORD), val);
                  $$ = ctn;
-           DBG_PRINT}}
+           }}
         | PASSWORD '=' 
           {
                 pwd_info.pwd_start_offset = (@$.buffer_pos);
@@ -24801,13 +24771,13 @@ connect_item
 
                 SET_CONTAINER_2(ctn, FROM_NUMBER(CONN_INFO_PASSWORD), val);
                 $$ = ctn;
-           DBG_PRINT}}
+           }}
         | PROPERTIES '=' 
           {{ DBG_TRACE_GRAMMAR(connect_item, | PROPERTIES '=' );
                 container_2 ctn;
                 SET_CONTAINER_2(ctn, FROM_NUMBER(CONN_INFO_PROPERTIES), NULL);
                 $$ = ctn;
-           DBG_PRINT}}
+           }}
         | PROPERTIES '=' CHAR_STRING 
           {{ DBG_TRACE_GRAMMAR(connect_item,  | PROPERTIES '=' CHAR_STRING );
                 container_2 ctn;
@@ -24828,13 +24798,13 @@ connect_item
 
                 SET_CONTAINER_2(ctn, FROM_NUMBER(CONN_INFO_PROPERTIES), val);
                 $$ = ctn;
-           DBG_PRINT}}
+           }}
         | COMMENT '='
           {{ DBG_TRACE_GRAMMAR(connect_item,| COMMENT '=');
                 container_2 ctn;
                 SET_CONTAINER_2(ctn, FROM_NUMBER(CONN_INFO_COMMENT), NULL);
                 $$ = ctn;
-           DBG_PRINT }}
+           }}
         | COMMENT '=' char_string_literal
           {{ DBG_TRACE_GRAMMAR(connect_item, | COMMENT '=' char_string );
                 container_2 ctn;
@@ -24847,7 +24817,7 @@ connect_item
 	        PT_NODE_PRINT_VALUE_TO_TEXT (this_parser, val);                
                 SET_CONTAINER_2(ctn, FROM_NUMBER(CONN_INFO_COMMENT), val);
                 $$ = ctn;
-           DBG_PRINT}}
+           }}
         ;
 
 alter_server_list
@@ -24857,7 +24827,7 @@ alter_server_list
 
                pt_fill_conn_info_container(this_parser, @$.buffer_pos, &ctn, $3);
 	        $$ = ctn;
-           DBG_PRINT }}
+           }}
         | alter_server_item
           {{ DBG_TRACE_GRAMMAR(alter_server_list, | alter_server_item);
                 container_10 ctn;
@@ -24865,7 +24835,7 @@ alter_server_list
 
                 pt_fill_conn_info_container(this_parser, @$.buffer_pos, &ctn, $1);
 	        $$ = ctn;
-           DBG_PRINT}}
+           }}
         ;
 
 alter_server_item
@@ -24879,7 +24849,7 @@ alter_server_item
         | CHANGE connect_item
           {{ DBG_TRACE_GRAMMAR(alter_server_item, | CHANGE connect_item); 
 	        $$ = $2;
-           DBG_PRINT}}
+           }}
         ;
 
 dblink_server_name
@@ -24895,11 +24865,11 @@ dblink_server_name
                }  
               $$ = $3;
               PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-          DBG_PRINT}}
+          }}
         | server_identifier
           {{ DBG_TRACE_GRAMMAR(dblink_server_name, | server_identifier);
               $$ = $1;
-          DBG_PRINT}}
+          }}
         ;
 
 server_identifier
@@ -24914,7 +24884,7 @@ server_identifier
                   }
                 $$ = $1;
                 PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-                DBG_PRINT}}
+                }}
          ;
 dblink_expr
         :   dblink_conn  ',' 
@@ -24973,18 +24943,18 @@ dblink_expr
              }
 
              $$ = ct;   
-             DBG_PRINT}}    
+             }}    
         ;
 
 dblink_conn:
         dblink_server_name      
         {{ DBG_TRACE_GRAMMAR(dblink_conn, : dblink_server_name); 
                 $$ = $1;                
-                DBG_PRINT}}
+                }}
         | dblink_conn_str
         {{ DBG_TRACE_GRAMMAR(dblink_conn, | dblink_conn_str);
                 $$ = $1;
-		DBG_PRINT}}
+		}}
         ;   
 
 dblink_conn_str:
@@ -25044,7 +25014,7 @@ dblink_conn_str:
                  }
 
                 $$ = node_list;
-		DBG_PRINT}}
+		}}
         ;             
 
 dblink_identifier_col_attrs  
@@ -25054,7 +25024,7 @@ dblink_identifier_col_attrs
              
 	     SET_CONTAINER_2 (ctn, $2, $4);
              $$ = ctn;              
-             DBG_PRINT}}
+             }}
         ;
 
 dblink_column_definition_list
@@ -25062,12 +25032,12 @@ dblink_column_definition_list
            {{ DBG_TRACE_GRAMMAR(dblink_column_definition_list, :  dblink_column_definition_list ','  dblink_column_definition );  
                 $$ = parser_make_link($1, $3);
 	        PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos);
-                DBG_PRINT}}
+                }}
         | dblink_column_definition
            {{ DBG_TRACE_GRAMMAR(dblink_column_definition_list, | dblink_column_definition );
                $$ = $1;
                PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-             DBG_PRINT}}
+             }}
         ;
 
 dblink_column_definition
@@ -25101,7 +25071,7 @@ dblink_column_definition
                 $$ = node;
 		PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 
-        DBG_PRINT}}
+        }}
         ;
 
 opt_access_modifier
@@ -25110,19 +25080,19 @@ opt_access_modifier
 
 	$$ = PT_PRIVATE;
 
-      DBG_PRINT}}
+      }}
     | PRIVATE
       {{ DBG_TRACE_GRAMMAR(opt_access_modifier, | PRIVATE);
 
 	$$ = PT_PRIVATE;
 
-      DBG_PRINT}}
+      }}
     | PUBLIC
       {{ DBG_TRACE_GRAMMAR(opt_access_modifier, | PUBLIC);
 
 	$$ = PT_PUBLIC;
 
-      DBG_PRINT}}
+      }}
     ;
 
 /*
@@ -25142,7 +25112,7 @@ opt_create_synonym
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (0), FROM_NUMBER (PT_PRIVATE));
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| PRIVATE
 		{{ DBG_TRACE_GRAMMAR(opt_create_synonym, : PRIVATE);
 
@@ -25150,7 +25120,7 @@ opt_create_synonym
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (0), FROM_NUMBER (PT_PRIVATE));
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| PUBLIC
 		{{ DBG_TRACE_GRAMMAR(opt_create_synonym, : PUBLIC);
 
@@ -25158,7 +25128,7 @@ opt_create_synonym
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (0), FROM_NUMBER (PT_PUBLIC));
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| OR REPLACE
 		{{ DBG_TRACE_GRAMMAR(opt_create_synonym, : OR REPLACE);
 
@@ -25166,7 +25136,7 @@ opt_create_synonym
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (1), FROM_NUMBER (PT_PRIVATE));
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| OR REPLACE PRIVATE
 		{{ DBG_TRACE_GRAMMAR(opt_create_synonym, : OR REPLACE PRIVATE);
 
@@ -25174,7 +25144,7 @@ opt_create_synonym
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (1), FROM_NUMBER (PT_PRIVATE));
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	| OR REPLACE PUBLIC
 		{{ DBG_TRACE_GRAMMAR(opt_create_synonym, : OR REPLACE PUBLIC);
 
@@ -25182,7 +25152,7 @@ opt_create_synonym
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (1), FROM_NUMBER (PT_PUBLIC));
 			$$ = ctn;
 
-		DBG_PRINT}}
+		}}
 	;
 
 opt_alter_synonym
@@ -25191,13 +25161,13 @@ opt_alter_synonym
 
 			$$ = NULL;
 
-		DBG_PRINT}}
+		}}
 	| For class_name_for_synonym
 		{{ DBG_TRACE_GRAMMAR(opt_alter_syonnym, : For class_name_for_synonym);
 
 			$$ = $2;
 
-		DBG_PRINT}}
+		}}
 
 %%
 
@@ -25209,7 +25179,6 @@ extern FILE *yyin;
 void
 _push_msg (int code, int line)
 {
-  PRINT_2 ("push msg called: %d at line %d\n", code, line);
   g_msg[msg_ptr++] = code;
 }
 

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -113,36 +113,6 @@ extern int is_dblink_query_string;
 extern int expecting_pl_lang_spec;
 extern int yylex(void);
 
-#if defined(SA_MODE)
-     /*
-     ** DBG_TRACE_LEVEL is specified by referring to the following.
-     ** 0: No displayed on the screen
-     ** 1: Words extracted from csql_lexer are displayed on the screen
-     ** 2: Display the contents of application of grammar rules in csql_grammar on the screen
-     ** 3: Expression of both 1 and 2 above
-     */
-#    define DBG_TRACE_LEVEL      0
-#endif
-
-#if (DBG_TRACE_LEVEL == 1 || DBG_TRACE_LEVEL == 3) 
-#    define DBG_PRINT_TOKEN(token)            fprintf(stdout, " *** Token) [%s]\n", token);
-#    define DBG_PRINT_STRING(pre, str, post)  fprintf(stdout, " *** Token) [%s%s%s]\n", pre, str, post);
-#    define DBG_PRINT_TOKEN_END()             fprintf(stdout, "\n");
-#else
-#    define DBG_PRINT_TOKEN(token)
-#    define DBG_PRINT_STRING(pre, str, post)
-#    define DBG_PRINT_TOKEN_END()
-#endif
-
-#if (DBG_TRACE_LEVEL == 2 || DBG_TRACE_LEVEL == 3) 
-#    define DBG_TRACE_GRAMMAR(rule_head, rule_components) do {                            \
-                fprintf(stdout, " *** Rule) " #rule_head "::= "  #rule_components "\n");  \
-                fflush(stdout);                                                           \
-        } while(0)
-#else        
-#    define DBG_TRACE_GRAMMAR(rule_head, rule_components)
-#endif
-
 static void pt_fill_conn_info_container(PARSER_CONTEXT *parser, int buffer_pos, container_10 *ctn, container_2 info);
 /*%CODE_END%*/%}
 
@@ -1758,7 +1728,7 @@ BEGIN_SUPPRESS_WARNING_BISON_FLEX
 %%
 
 stmt_done
-	: stmt_list { DBG_PRINT_TOKEN_END();}
+	: stmt_list
 	| /* empty */
 	;
 
@@ -1767,7 +1737,6 @@ stmt_list
                 {{ /* empty line*/ }}
         | stmt_list SEMICOLON stmt %dprec 2
 		{{
-
 			if ($3 != NULL)
 			  {
 			    if (parser_statement_OK)
@@ -1781,11 +1750,9 @@ stmt_list
 
 			    pt_push (this_parser, $3);
 			  }
-
 		}}
 	| stmt %dprec 3
 		{{
-
 			if ($1 != NULL)
 			  {
 			    if (parser_statement_OK)
@@ -1799,7 +1766,6 @@ stmt_list
 
 			    pt_push (this_parser, $1);
 			  }
-
 		}}
         | SEMICOLON
                 {{ /* empty line*/ }}
@@ -1809,7 +1775,7 @@ stmt_list
 
 stmt
 	:
-		{{ DBG_TRACE_GRAMMAR(stmt, : );
+		{{
 			msg_ptr = 0;
 
                         pwd_info.pwd_start_offset = -1; 
@@ -1847,10 +1813,8 @@ stmt
 			        g_query_string++;
 			      }
 			  }
-
 		}}
 		{{
-
 			parser_initialize_parser_context ();
 
 			parser_statement_OK = 1;
@@ -1884,8 +1848,7 @@ stmt
                         assert(expecting_pl_lang_spec == 0); // initialized in parser_main() or parse_one_statement()
 		}}
 	stmt_
-		{{ DBG_TRACE_GRAMMAR(stmt, stmt_ );
-
+		{{
 			if (msg_ptr > 0)
 			  {
 			    csql_yyerror (NULL);
@@ -1922,10 +1885,8 @@ stmt
 				g_query_string_len = len;
 			      }
 			  }
-
 		}}
 		{{
-
 			PT_NODE *node = $3;
 
 			if (node)
@@ -1941,31 +1902,24 @@ stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 stmt_
 	: create_stmt
-		{ DBG_TRACE_GRAMMAR(stmt_, : create_stmt);
-                  $$ = $1; }
+		{ $$ = $1; }
 	| alter_stmt
-		{ DBG_TRACE_GRAMMAR(stmt_, | alter_stmt);
-                  $$ = $1; }
+		{ $$ = $1; }
 	| rename_stmt
-		{ DBG_TRACE_GRAMMAR(stmt_, | rename_stmt);
-                  $$ = $1; }
+		{ $$ = $1; }
 	| update_statistics_stmt
-		{ DBG_TRACE_GRAMMAR(stmt_, | update_statstics_stmt);
-                  $$ = $1; }
+		{ $$ = $1; }
 	| drop_stmt
-		{ DBG_TRACE_GRAMMAR(stmt_, | drop_stmt);
-                  $$ = $1; }
+		{ $$ = $1; }
 	| do_stmt
-		{ DBG_TRACE_GRAMMAR(stmt_, | do_stmt);
-                  $$ = $1; }
+		{ $$ = $1; }
 	| opt_with_clause
 	  esql_query_stmt
-		{{ DBG_TRACE_GRAMMAR(stmt_, | opt_with_clause esql_query_stmt);
+		{{
 			PT_NODE *with_clause = $1;
 			PT_NODE *stmt = $2;
 			if (stmt && with_clause)
@@ -1973,22 +1927,18 @@ stmt_
 			    stmt->info.query.with = with_clause;
 			  }
 			$$ = stmt;
-	  }}
+		}}
 	| evaluate_stmt
-		{ DBG_TRACE_GRAMMAR(stmt_, | evaluate_stmt);
-                  $$ = $1; }
+		{ $$ = $1; }
 	| prepare_stmt
-		{ DBG_TRACE_GRAMMAR(stmt_, | prepare_stmt);
-                  $$ = $1; }
+		{ $$ = $1; }
 	| execute_stmt
-		{ DBG_TRACE_GRAMMAR(stmt_, | execute_stmt);
-                  $$ = $1; }
+		{ $$ = $1; }
 	| insert_or_replace_stmt
-		{ DBG_TRACE_GRAMMAR(stmt_, | insert_or_replace_stmt);
-                  $$ = $1; }
+		{ $$ = $1; }
 	| opt_with_clause
 	  update_stmt
-		{{ DBG_TRACE_GRAMMAR(stmt_, | opt_with_clause update_stmt);
+		{{
 			PT_NODE *with_clause = $1;
 			PT_NODE *stmt = $2;
 			if (stmt && with_clause)
@@ -1996,10 +1946,10 @@ stmt_
 			    stmt->info.update.with = with_clause;
 			  }
 			$$ = stmt;
-	  }}
+		}}
 	| opt_with_clause
 	  delete_stmt
-		{{ DBG_TRACE_GRAMMAR(stmt_, | opt_with_clause delete_stmt);
+		{{
 			PT_NODE *with_clause = $1;
 			PT_NODE *stmt = $2;
 			if (stmt && with_clause)
@@ -2007,37 +1957,27 @@ stmt_
 			    stmt->info.delete_.with = with_clause;
 			  }
 			$$ = stmt;
-	  }}
+		}}
 	| show_stmt
-		{ DBG_TRACE_GRAMMAR(stmt_, | show_stmt);
-                  $$ = $1; }
+		{ $$ = $1; }
 	| call_stmt
-		{ DBG_TRACE_GRAMMAR(stmt_, | call_stmt);
-                  $$ = $1; }
+		{ $$ = $1; }
 	| auth_stmt
-		{ DBG_TRACE_GRAMMAR(stmt_, | auth_stmt);
-                  $$ = $1; }
+		{ $$ = $1; }
 	| transaction_stmt
-		{ DBG_TRACE_GRAMMAR(stmt_, | transaction_stmt);
-                  $$ = $1; }
+		{ $$ = $1; }
 	| truncate_stmt
-		{ DBG_TRACE_GRAMMAR(stmt_, | truncate_stmt);
-                  $$ = $1; }
+		{ $$ = $1; }
 	| merge_stmt
-		{ DBG_TRACE_GRAMMAR(stmt_, | merge_stmt);
-                  $$ = $1; }
+		{ $$ = $1; }
 	| set_stmt
-		{ DBG_TRACE_GRAMMAR(stmt_, | set_stmt);
-                  $$ = $1; }
+		{ $$ = $1; }
 	| get_stmt
-		{ DBG_TRACE_GRAMMAR(stmt_, | get_stmt);
-                  $$ = $1; }
+		{ $$ = $1; }
 	| kill_stmt
-		{ DBG_TRACE_GRAMMAR(stmt_, | kill_stmt);
-                  $$ = $1; }
+		{ $$ = $1; }
 	| DATA_TYPE___ data_type
-		{{ DBG_TRACE_GRAMMAR(stmt_, | DATA_TYPE___ data_type);
-
+		{{
 			PT_NODE *dt, *set_dt;
 			PT_TYPE_ENUM typ;
 
@@ -2076,14 +2016,12 @@ stmt_
 
 			$$ = dt;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| ATTACH
 		{ push_msg(MSGCAT_SYNTAX_INVALID_ATTACH); }
 	  unsigned_integer
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(stmt_, | ATTACH unsigned_integer);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_2PC_ATTACH);
 
 			if (node)
@@ -2093,14 +2031,12 @@ stmt_
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| PREPARE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_PREPARE); }
 	  opt_to COMMIT unsigned_integer
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(stmt_, | PREPARE opt_to COMMIT unsigned_integer);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_PREPARE_TO_COMMIT);
 
 			if (node)
@@ -2110,14 +2046,12 @@ stmt_
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| EXECUTE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_EXECUTE); }
 	  DEFERRED TRIGGER trigger_spec_list
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(stmt_, | EXECUTE DEFERRED TRIGGER trigger_spec_list);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_EXECUTE_TRIGGER);
 
 			if (node)
@@ -2127,14 +2061,12 @@ stmt_
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SCOPE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SCOPE); }
 	  trigger_action opt_from_table_spec_list
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(stmt_, | SCOPE trigger_action opt_from_table_spec_list);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_SCOPE);
 
 			if (node)
@@ -2145,18 +2077,15 @@ stmt_
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| vacuum_stmt
-		{ DBG_TRACE_GRAMMAR(stmt_, | vacuum_stmt);
-                  $$ = $1; }
+		{ $$ = $1; }
 
 	| SET TIMEZONE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SET_TIMEZONE); }
 	  char_string_literal
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(stmt_, | SET TIMEZONE char_string_literal);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_SET_TIMEZONE);
 			if (node)
 			  {
@@ -2165,13 +2094,12 @@ stmt_
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SET Time ZONE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SET_TIMEZONE); }
 	  char_string_literal
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(stmt_, | SET Time ZONE char_string_literal);
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_SET_TIMEZONE);
 			if (node)
 			  {
@@ -2180,18 +2108,15 @@ stmt_
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 
 opt_from_table_spec_list
 	: /* empty */
-		{ DBG_TRACE_GRAMMAR(opt_from_table_spec_list, : );
-                  $$ = NULL; }
+		{ $$ = NULL; }
 	| FROM ON_ table_spec_list
-		{ DBG_TRACE_GRAMMAR(opt_from_table_spec_list, | FROM ON_ table_spec_list);
-                  $$ = $3; }
+		{ $$ = $3; }
 	;
 
 
@@ -2200,7 +2125,7 @@ set_stmt
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SET_OPT_LEVEL); }
 	  LEVEL opt_of_to_eq opt_level_spec
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(set_stmt, : SET OPTIMIZATION LEVEL opt_of_to_eq opt_level_spec);
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_SET_OPT_LVL);
 			if (node)
 			  {
@@ -2210,14 +2135,12 @@ set_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SET OPTIMIZATION
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SET_OPT_COST); }
 	  COST opt_of char_string_literal opt_of_to_eq literal_
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(set_stmt, | SET OPTIMIZATION COST opt_of char_string_literal opt_of_to_eq literal_);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_SET_OPT_LVL);
 			if (node)
 			  {
@@ -2229,27 +2152,23 @@ set_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SET
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SET_SYS_PARAM); }
 	  SYSTEM PARAMETERS char_string_literal_list
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(set_stmt, | SET SYSTEM PARAMETERS char_string_literal_list);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_SET_SYS_PARAMS);
 			if (node)
 			  node->info.set_sys_params.val = $5;
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SET
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SET_TRAN); }
 	  TRANSACTION transaction_mode_list
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(set_stmt, | SET TRANSACTION transaction_mode_list);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_SET_XACTION);
 
 			if (node)
@@ -2259,14 +2178,12 @@ set_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SET TRIGGER
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SET_TRIGGER_TRACE); }
 	  TRACE trace_spec
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(set_stmt, | SET TRIGGER TRACE trace_spec);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_SET_TRIGGER);
 
 			if (node)
@@ -2277,14 +2194,12 @@ set_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SET TRIGGER
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SET_TRIGGER_DEPTH); }
 	  opt_maximum DEPTH depth_spec
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(set_stmt, | SET TRIGGER opt_maximum DEPTH depth_spec);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_SET_TRIGGER);
 
 			if (node)
@@ -2295,11 +2210,9 @@ set_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SET session_variable_assignment_list
-		{{ DBG_TRACE_GRAMMAR(set_stmt, | SET session_variable_assignment_list);
-
+		{{
 			PT_NODE *node =
 				parser_new_node (this_parser, PT_SET_SESSION_VARIABLES);
 			if (node)
@@ -2308,11 +2221,9 @@ set_stmt
 			  }
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SET NAMES BINARY
-		{{ DBG_TRACE_GRAMMAR(set_stmt, | SET NAMES BINARY);
-
+		{{
 			PT_NODE *node = NULL;
 			PT_NODE *charset_node = NULL;
 
@@ -2335,15 +2246,13 @@ set_stmt
 			  }
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SET
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SET_NAMES); }
 	  NAMES char_string_literal
 	  opt_collation
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(set_stmt, | SET NAMES char_string_literal opt_collation);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_SET_NAMES);
 			if (node)
 			  {
@@ -2353,15 +2262,13 @@ set_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SET
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SET_NAMES); }
 	  NAMES IdName
 	  opt_collation
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(set_stmt, | SET NAMES IdName opt_collation);
-
+		{{
 			PT_NODE *node = NULL;
 			PT_NODE *charset_node = NULL;
 
@@ -2384,11 +2291,9 @@ set_stmt
 			  }
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SET TRACE query_trace_spec opt_trace_output_format
-		{{ DBG_TRACE_GRAMMAR(set_stmt, | SET TRACE query_trace_spec opt_trace_output_format);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_QUERY_TRACE);
 
 			if (node)
@@ -2398,122 +2303,104 @@ set_stmt
 			  }
 
 			$$ = node;
-
 		}}
 	;
 
 query_trace_spec
 	: ON_
-		{{ DBG_TRACE_GRAMMAR(query_trace_spec, : ON_);
+		{{
 			$$ = PT_TRACE_ON;
 		}}
 	| OFF_
-		{{ DBG_TRACE_GRAMMAR(query_trace_spec, | OFF_);
+		{{
 			$$ = PT_TRACE_OFF;
 		}}
 	;
 
 opt_trace_output_format
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_trace_output_format, : );
+		{{
 			$$ = PT_TRACE_FORMAT_TEXT;
 		}}
 	| OUTPUT TEXT
-		{{ DBG_TRACE_GRAMMAR(opt_trace_output_format, | OUTPUT TEXT);
+		{{
 			$$ = PT_TRACE_FORMAT_TEXT;
 		}}
 	| OUTPUT JSON
-		{{ DBG_TRACE_GRAMMAR(opt_trace_output_format, | OUTPUT JSON);
+		{{
 			$$ = PT_TRACE_FORMAT_JSON;
 		}}
 	;
 
 session_variable_assignment_list
 	: session_variable_assignment_list ',' session_variable_assignment
-		{{ DBG_TRACE_GRAMMAR(session_variable_assignment_list, : session_variable_assignment_list ',' session_variable_assignment);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 
 	| session_variable_assignment
-		{{ DBG_TRACE_GRAMMAR(session_variable_assignment_list, | session_variable_assignment);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 session_variable_assignment
 	: session_variable '=' expression_
-		{{ DBG_TRACE_GRAMMAR(session_variable_assignment, : session_variable '=' expression_);
-
+		{{
 			PT_NODE* expr =
 				parser_make_expression (this_parser, PT_DEFINE_VARIABLE, $1, $3, NULL);
 			expr->flag.do_not_fold = 1;
 			$$ = expr;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| session_variable_definition
-		{{ DBG_TRACE_GRAMMAR(session_variable_assignment, | session_variable_definition);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 session_variable_definition
 	: session_variable VAR_ASSIGN expression_
-		{{ DBG_TRACE_GRAMMAR(session_variable_definition, : session_variable VAR_ASSIGN expression_);
-
+		{{
 			PT_NODE* expr =
 				parser_make_expression (this_parser, PT_DEFINE_VARIABLE, $1, $3, NULL);
 			expr->flag.do_not_fold = 1;
 			$$ = expr;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 session_variable_expression
 	: session_variable
-		{{ DBG_TRACE_GRAMMAR(session_variable_expression, : session_variable);
-
+		{{
 			PT_NODE *expr = NULL;
 			expr = parser_make_expression (this_parser, PT_EVALUATE_VARIABLE, $1, NULL,
 										   NULL);
 			expr->flag.do_not_fold = 1;
 			$$ = expr;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 session_variable_list
 	: session_variable_list ',' session_variable
-		{{ DBG_TRACE_GRAMMAR(session_variable_list, : session_variable_list ',' session_variable);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| session_variable
-		{{ DBG_TRACE_GRAMMAR(session_variable_list, | session_variable);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 session_variable
 	: '@' identifier
-		{{ DBG_TRACE_GRAMMAR(session_variable, : '@' identifier);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 			PT_NODE *id = $2;
 
@@ -2530,7 +2417,6 @@ session_variable
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
@@ -2539,8 +2425,7 @@ get_stmt
 		{ push_msg(MSGCAT_SYNTAX_INVALID_GET_STAT); }
 	  STATISTICS char_string_literal  OF class_name into_clause_opt
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(get_stmt, : GET STATISTICS char_string_literal  OF class_name into_clause_opt);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_GET_STATS);
 			if (node)
 			  {
@@ -2550,14 +2435,12 @@ get_stmt
 			  }
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| GET OPTIMIZATION
 		{ push_msg(MSGCAT_SYNTAX_INVALID_GET_OPT_LEVEL); }
 	  LEVEL into_clause_opt
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(get_stmt, | GET OPTIMIZATION LEVEL into_clause_opt);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_GET_OPT_LVL);
 			if (node)
 			  {
@@ -2567,14 +2450,12 @@ get_stmt
 			  }
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| GET OPTIMIZATION
 		{ push_msg(MSGCAT_SYNTAX_INVALID_GET_OPT_COST); }
 	  COST opt_of char_string_literal into_clause_opt
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(get_stmt, | GET OPTIMIZATION COST opt_of char_string_literal into_clause_opt);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_GET_OPT_LVL);
 			if (node)
 			  {
@@ -2584,14 +2465,12 @@ get_stmt
 			  }
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| GET TRANSACTION
 		{ push_msg(MSGCAT_SYNTAX_INVALID_GET_TRAN_ISOL); }
 	  ISOLATION LEVEL into_clause_opt
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(get_stmt, | GET TRANSACTION ISOLATION LEVEL into_clause_opt);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_GET_XACTION);
 
 			if (node)
@@ -2602,14 +2481,12 @@ get_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| GET TRANSACTION
 		{ push_msg(MSGCAT_SYNTAX_INVALID_GET_TRAN_LOCK); }
 	  LOCK_ TIMEOUT into_clause_opt
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(get_stmt, | GET TRANSACTION LOCK_ TIMEOUT into_clause_opt);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_GET_XACTION);
 
 			if (node)
@@ -2620,14 +2497,12 @@ get_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| GET TRIGGER
 		{ push_msg(MSGCAT_SYNTAX_INVALID_GET_TRIGGER_TRACE); }
 	  TRACE into_clause_opt
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(get_stmt, | GET TRIGGER TRACE into_clause_opt);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_GET_TRIGGER);
 
 			if (node)
@@ -2638,14 +2513,12 @@ get_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| GET TRIGGER
 		{ push_msg(MSGCAT_SYNTAX_INVALID_GET_TRIGGER_DEPTH); }
 	  opt_maximum DEPTH into_clause_opt
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(get_stmt, | GET TRIGGER opt_maximum DEPTH into_clause_opt);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_GET_TRIGGER);
 
 			if (node)
@@ -2656,7 +2529,6 @@ get_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
@@ -2665,7 +2537,7 @@ get_stmt
 
 create_stmt
 	: CREATE					/* 1 */
-		{ DBG_TRACE_GRAMMAR(create_stmt, : CREATE);	/* 2 */
+		{					/* 2 */
 			PT_NODE* qc = parser_new_node(this_parser, PT_CREATE_ENTITY);
 			parser_push_hint_node(qc);
 		}
@@ -2682,8 +2554,7 @@ create_stmt
 	  opt_inherit_resolution_list			/* 13 */
 	  opt_partition_clause 				/* 14 */
           opt_create_as_clause				/* 15 */
-		{{ DBG_TRACE_GRAMMAR(create_stmt, : CREATE ~ of_class_table_type ~ class_name_without_dot ~);
-
+		{{
 			PT_NODE *qc = parser_pop_hint_node ();
 			PARSER_SAVE_ERR_CONTEXT (qc, @$.buffer_pos)
 
@@ -2724,7 +2595,6 @@ create_stmt
 			  }
 
 			$$ = qc;
-
 		}}
 	| CREATE 					/* 1 */
 	  opt_or_replace				/* 2 */
@@ -2739,8 +2609,7 @@ create_stmt
 	  opt_as_query_list				/* 11 */
 	  opt_with_levels_clause			/* 12 */
 	  opt_vclass_comment_spec           		/* 13 */
-		{{ DBG_TRACE_GRAMMAR(create_stmt, | CREATE ~ of_view_vclass class_name_without_dot ~ );
-
+		{{
 			PT_NODE *qc = parser_new_node (this_parser, PT_CREATE_ENTITY);
 
 			if (qc)
@@ -2766,11 +2635,9 @@ create_stmt
 
 			$$ = qc;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| CREATE					/* 1 */
 		{					/* 2 */
-                        DBG_TRACE_GRAMMAR(create_stmt, | CREATE);
 			PT_NODE* node = parser_new_node (this_parser, PT_CREATE_INDEX);
 			parser_push_hint_node (node);
 			push_msg (MSGCAT_SYNTAX_INVALID_CREATE_INDEX);
@@ -2788,8 +2655,7 @@ create_stmt
           opt_index_with_clause                         /* 13 */
 	  opt_invisible					/* 14 */
 	  opt_comment_spec				/* 15 */          
-		{{ DBG_TRACE_GRAMMAR(create_stmt,  CREATE ~ INDEX identifier ON_ ~);
-
+		{{
 			PT_NODE *node = parser_pop_hint_node ();
 			PT_NODE *ocs = parser_new_node(this_parser, PT_SPEC);
 			PARSER_SAVE_ERR_CONTEXT (node, @$.buffer_pos)
@@ -2948,7 +2814,6 @@ create_stmt
                               }
 			  }
 		      $$ = node;
-
 		}}
 	| CREATE			/* 1 */
 	  USER				/* 2 */
@@ -2962,8 +2827,7 @@ create_stmt
 	  opt_members			/* 7 */
 	  opt_comment_spec		/* 8 */
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(create_stmt, | CREATE USER identifier ~);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_CREATE_USER);
 
 			if (node)
@@ -2977,7 +2841,6 @@ create_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| CREATE					/* 1 */
 		{ push_msg(MSGCAT_SYNTAX_INVALID_CREATE_TRIGGER); }	/* 2 */
@@ -2993,8 +2856,7 @@ create_stmt
 	  opt_trigger_action_time 			/* 12 */
 	  trigger_action				/* 13 */
 	  opt_comment_spec				/* 14 */
-		{{ DBG_TRACE_GRAMMAR(create_stmt, | CREATE TRIGGER trigger_name_without_dot ~);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_CREATE_TRIGGER);
 
 			if (node)
@@ -3013,7 +2875,6 @@ create_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| CREATE					/* 1 */
 		{ push_msg(MSGCAT_SYNTAX_INVALID_CREATE_SERIAL); }	/* 2 */
@@ -3022,8 +2883,7 @@ create_stmt
 	  serial_name_without_dot 			/* 5 */
 	  opt_serial_option_list			/* 6 */
 	  opt_comment_spec				/* 7 */
-		{{ DBG_TRACE_GRAMMAR(create_stmt, | CREATE SERIAL serial_name_without_dot ~);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_CREATE_SERIAL);
 
 			if (node)
@@ -3058,7 +2918,6 @@ create_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| CREATE					/* 1 */
 	  opt_or_replace               		        /* 2 */
@@ -3075,7 +2934,7 @@ create_stmt
 	  is_or_as pl_language_spec		        /* 8, 9 */
 	  opt_comment_spec				/* 10 */
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(create_stmt, | CREATE opt_or_replace PROCEDURE~);
+		{{
 			if (TO_NUMBER (CONTAINER_AT_1 ($7)) != 0)
                           {
                             push_msg(MSGCAT_SYNTAX_INVALID_CREATE_PROCEDURE);
@@ -3121,7 +2980,6 @@ create_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| CREATE                        		/* 1 */
 	  opt_or_replace                		/* 2 */
@@ -3139,7 +2997,7 @@ create_stmt
 	  is_or_as pl_language_spec		        /* 10, 11 */
 	  opt_comment_spec				/* 12 */
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(create_stmt, | CREATE opt_or_replace FUNCTION~);
+		{{
 			PT_NODE *node = parser_pop_hint_node ();
 			if (node)
 			  {
@@ -3185,14 +3043,11 @@ create_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| CREATE IdName
-		{{ DBG_TRACE_GRAMMAR(create_stmt, | CREATE IdName);
-
+		{{
 			push_msg (MSGCAT_SYNTAX_INVALID_CREATE);
 			csql_yyerror_explicit (@2.first_line, @2.first_column);
-
 		}}
 	| CREATE					/* 1 */
 		{					/* 2 */
@@ -3205,8 +3060,7 @@ create_stmt
 	  class_name_without_dot			/* 6 */
 	  LIKE						/* 7 */
 	  class_name					/* 8 */
-		{{ DBG_TRACE_GRAMMAR(create_stmt, | CREATE ~ class_name_without_dot LIKE class_name ~);
-
+		{{
 			PT_NODE *qc = parser_pop_hint_node ();
 
 			if (qc)
@@ -3219,7 +3073,6 @@ create_stmt
 
 			$$ = qc;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| CREATE					/* 1 */
 		{					/* 2 */
@@ -3234,8 +3087,7 @@ create_stmt
 	  LIKE						/* 8 */
 	  class_name					/* 9 */
 	  ')'						/* 10 */
-		{{ DBG_TRACE_GRAMMAR(create_stmt, | CREATE ~ class_name_without_dot '(' LIKE class_name ')' );
-
+		{{
 			PT_NODE *qc = parser_pop_hint_node ();
 
 			if (qc)
@@ -3248,10 +3100,9 @@ create_stmt
 
 			$$ = qc;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| CREATE SERVER dblink_server_name '(' connect_info ')'
-		{{ DBG_TRACE_GRAMMAR(create_stmt, | CREATE SERVER dblink_server_name '(' connect_info ')' );
+		{{
                         PT_NODE *node = parser_new_node (this_parser, PT_CREATE_SERVER);
 			if (node)
 			  {
@@ -3313,7 +3164,6 @@ create_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| CREATE			/* 1 */
 	  opt_create_synonym		/* 2 */
@@ -3324,8 +3174,7 @@ create_stmt
 	  class_name_for_synonym   	/* 7 */
 	  opt_comment_spec		/* 8 */
 	  	{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(create_stmt, | CREATE opt_or_replace opt_access_modifier SYNONYM synonym_name_without_dot For class_name opt_comment_spec);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_CREATE_SYNONYM);
 			PT_MISC_TYPE synonym_access_modifier;
 
@@ -3352,7 +3201,6 @@ create_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
@@ -3386,37 +3234,37 @@ class_name_for_synonym
 
 opt_serial_option_list
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_serial_option_list, : );
+		{{
 			container_11 ctn;
 			memset(&ctn, 0x00, sizeof(container_11));
 			$$ = ctn;
 		}}
 	| serial_option_list
-		{{ DBG_TRACE_GRAMMAR(opt_serial_option_list, | serial_option_list);
+		{{
 			$$ = $1;
 		}}
 	;
 
 opt_serial_option_list_or_owner_clause
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_serial_option_list_or_owner_clause, : );
+		{{
 			container_11 ctn;
 			memset(&ctn, 0x00, sizeof(container_11));
 			$$ = ctn;
 		}}
 	| serial_option_list
-		{{ DBG_TRACE_GRAMMAR(opt_serial_option_list_or_owner_clause, | serial_option_list);
+		{{
 			$$ = $1;
 		}}
 	| serial_owner_clause
-		{{ DBG_TRACE_GRAMMAR(opt_serial_option_list_or_owner_clause, | serial_owner_clause);
+		{{
 			$$ = $1;
 		}}
 	;
 
 serial_option_list
 	: serial_option_list of_serial_option
-		{{ DBG_TRACE_GRAMMAR(serial_option_list, : serial_option_list of_serial_option);
+		{{
 			/* container order
 			 * 1: start_val
 			 *
@@ -3508,10 +3356,9 @@ serial_option_list
 			  }
 
 			$$ = ctn;
-
 		}}
 	| of_serial_option
-		{{ DBG_TRACE_GRAMMAR(serial_option_list, | of_serial_option);
+		{{
 			/* container order
 			 * 1: start_val
 			 *
@@ -3565,43 +3412,42 @@ serial_option_list
 			  }
 
 			$$ = ctn;
-
 		}}
 	;
 
 of_serial_option
 	: serial_start
-		{{ DBG_TRACE_GRAMMAR(of_serial_option, : serial_start);
+		{{
 			container_3 ctn;
 			SET_CONTAINER_3(ctn, FROM_NUMBER(SERIAL_START), $1, NULL);
 			$$ = ctn;
 		}}
 	| serial_increment
-		{{ DBG_TRACE_GRAMMAR(of_serial_option, | serial_increment);
+		{{
 			container_3 ctn;
 			SET_CONTAINER_3(ctn, FROM_NUMBER(SERIAL_INC), $1, NULL);
 			$$ = ctn;
 		}}
 	| serial_min
-		{{ DBG_TRACE_GRAMMAR(of_serial_option, | serial_min);
+		{{
 			container_3 ctn;
 			SET_CONTAINER_3(ctn, FROM_NUMBER(SERIAL_MIN), CONTAINER_AT_0($1), CONTAINER_AT_1($1));
 			$$ = ctn;
 		}}
 	| serial_max
-		{{ DBG_TRACE_GRAMMAR(of_serial_option, | serial_max);
+		{{
 			container_3 ctn;
 			SET_CONTAINER_3(ctn, FROM_NUMBER(SERIAL_MAX), CONTAINER_AT_0($1), CONTAINER_AT_1($1));
 			$$ = ctn;
 		}}
 	| of_cycle_nocycle
-		{{ DBG_TRACE_GRAMMAR(of_serial_option, | of_cycle_nocycle);
+		{{
 			container_3 ctn;
 			SET_CONTAINER_3(ctn, FROM_NUMBER(SERIAL_CYCLE), CONTAINER_AT_0($1), CONTAINER_AT_1($1));
 			$$ = ctn;
 		}}
 	| of_cached_num
-		{{ DBG_TRACE_GRAMMAR(of_serial_option, | of_cached_num);
+		{{
 			container_3 ctn;
 			SET_CONTAINER_3(ctn, FROM_NUMBER(SERIAL_CACHE), CONTAINER_AT_0($1), CONTAINER_AT_1($1));
 			$$ = ctn;
@@ -3610,7 +3456,7 @@ of_serial_option
 
 serial_owner_clause
 	: of_serial_owner_clause
-		{{ DBG_TRACE_GRAMMAR(serial_owner_clause, : of_serial_owner_clause);
+		{{
 		        /* container order
 			 * 1: start_val
 			 *
@@ -3641,13 +3487,12 @@ serial_owner_clause
 			  }
 
 			$$ = ctn;
-
 		}}
 	;
 
 of_serial_owner_clause
         : OWNER TO identifier
-	        {{ DBG_TRACE_GRAMMAR(of_serial_owner_clause, : OWNER TO identifier);
+	        {{
 			container_3 ctn;
 			SET_CONTAINER_3(ctn, FROM_NUMBER(SERIAL_CHANGE_OWNER), $3, NULL);
 			$$ = ctn;
@@ -3656,16 +3501,12 @@ of_serial_owner_clause
 
 opt_replace
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_replace, : );
-
+		{{
 			$$ = PT_CREATE_SELECT_NO_ACTION;
-
 		}}
 	| REPLACE
-		{{ DBG_TRACE_GRAMMAR(opt_replace, | REPLACE);
-
+		{{
 			$$ = PT_CREATE_SELECT_REPLACE;
-
 		}}
 	;
 
@@ -3678,8 +3519,7 @@ alter_stmt
 	  opt_hint_list					/* 3 */
 	  opt_class_type				/* 4 */
 	  only_class_name				/* 5 */
-		{{ DBG_TRACE_GRAMMAR(alter_stmt, : ALTER opt_hint_list opt_class_type only_class_name);
-
+		{{
 			PT_NODE *node = parser_pop_hint_node ();
 			int entity_type = ($4 == PT_EMPTY ? PT_MISC_DUMMY : $4);
 
@@ -3690,11 +3530,9 @@ alter_stmt
 			  }
 
 			parser_save_alter_node (node);
-
 		}}
 	  alter_clause_cubrid_specific
-		{{ DBG_TRACE_GRAMMAR(alter_stmt,  ~ alter_clause_cubrid_specific);
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 
 			if (node)
@@ -3703,7 +3541,6 @@ alter_stmt
 			  }
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| ALTER						/* 1 */
 		{					/* 2 */
@@ -3714,8 +3551,7 @@ alter_stmt
 	  opt_class_type				/* 4 */
 	  only_class_name				/* 5 */
 	  alter_clause_list				/* 6 */		%dprec 2
-		{{ DBG_TRACE_GRAMMAR(alter_stmt, | ALTER opt_hint_list opt_class_type only_class_name alter_clause_list);
-
+		{{
 			PT_NODE *node = NULL;
 			int entity_type = ($4 == PT_EMPTY ? PT_MISC_DUMMY : $4);
 
@@ -3766,15 +3602,13 @@ alter_stmt
 
 			$$ = $6;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| ALTER				/* 1 */
 	  USER				/* 2 */
 	  identifier	        	/* 3 */
 	  opt_password  	        /* 4 */
 	  opt_comment_spec              /* 5 */
-		{{ DBG_TRACE_GRAMMAR(alter_stmt, | ALTER USER identifier opt_password opt_comment_spec);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_ALTER_USER);
 
 			if (node)
@@ -3792,7 +3626,6 @@ alter_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| ALTER				/* 1 */
 	  USER				/* 2 */
@@ -3803,8 +3636,7 @@ alter_stmt
 	  identifier_list		/* 7 */
 		{ pop_msg(); }
 	  opt_comment_spec              /* 9 */
-		{{ DBG_TRACE_GRAMMAR(alter_stmt, | ALTER USER identifier ADD MEMBERS identifier_list opt_comment_spec);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_ALTER_USER);
 
 			if (node)
@@ -3817,7 +3649,6 @@ alter_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| ALTER				/* 1 */
 	  USER				/* 2 */
@@ -3828,8 +3659,7 @@ alter_stmt
 	  identifier_list		/* 7 */
 		{ pop_msg(); }
 	  opt_comment_spec              /* 9 */
-		{{ DBG_TRACE_GRAMMAR(alter_stmt, | ALTER USER identifier DROP MEMBERS identifier_list opt_comment_spec);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_ALTER_USER);
 
 			if (node)
@@ -3842,15 +3672,13 @@ alter_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| ALTER						/* 1 */
 	  TRIGGER					/* 2 */
 	  trigger_name_list				/* 3 */
 	  trigger_status_or_priority_or_change_owner	/* 4 */
 	  opt_comment_spec				/* 5 */
-		{{ DBG_TRACE_GRAMMAR(alter_stmt, | ALTER TRIGGER trigger_name_list trigger_status_or_priority_or_change_owner opt_comment_spec);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_ALTER_TRIGGER);
 
 			PT_NODE *list = parser_new_node (this_parser, PT_TRIGGER_SPEC_LIST);
@@ -3870,14 +3698,12 @@ alter_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| ALTER				/* 1 */
 	  TRIGGER			/* 2 */
 	  trigger_name			/* 3 */
 	  COMMENT comment_value		/* 4, 5 */
-		{{ DBG_TRACE_GRAMMAR(alter_stmt, | ALTER TRIGGER identifier COMMENT comment_value);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_ALTER_TRIGGER);
 
 			PT_NODE *list = parser_new_node (this_parser, PT_TRIGGER_SPEC_LIST);
@@ -3894,14 +3720,13 @@ alter_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| ALTER						/* 1 */
 	  SERIAL					/* 2 */
 	  serial_name					/* 3 */
 	  opt_serial_option_list_or_owner_clause	/* 4 */
 	  opt_comment_spec				/* 5 */
-		{{ DBG_TRACE_GRAMMAR(alter_stmt, | ALTER SERIAL serial_name opt_serial_option_list_or_owner_clause opt_comment_spec);
+		{{
 			/* container order
 			 * 0: start_val
 			 * 1: increment_val,
@@ -3976,8 +3801,7 @@ alter_stmt
 	  only_class_name				/* 9 */	  
 	  opt_comment_spec				/* 10 */
 	  REBUILD					/* 11 */
-		{{ DBG_TRACE_GRAMMAR(alter_stmt, | ALTER ~ INDEX ~ REBUILD);
-
+		{{
 		  PT_NODE *node = parser_pop_hint_node ();
 		  
                   if (node)
@@ -4012,7 +3836,7 @@ alter_stmt
 	  ON_						/* 4 */
 	  class_name					/* 5 */
 	  COMMENT comment_value 			/* 6, 7 */
-		{{ DBG_TRACE_GRAMMAR(alter_stmt, | ALTER INDEX identifier ON_ class_name COMMENT comment_value);
+		{{
 			PT_NODE* node = parser_new_node(this_parser, PT_ALTER_INDEX);
 
 			if (node)
@@ -4039,7 +3863,6 @@ alter_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| ALTER				/* 1 */
 	  INDEX				/* 2 */
@@ -4047,7 +3870,7 @@ alter_stmt
 	  ON_				/* 4 */
 	  class_name			/* 5 */
 	  INVISIBLE			/* 6 */
-		{{ DBG_TRACE_GRAMMAR(alter_stmt, | ALTER INDEX identifier ON_ class_name INVISIBLE);
+		{{
 			PT_NODE* node = parser_new_node(this_parser, PT_ALTER_INDEX);
 
 			if (node)
@@ -4074,7 +3897,6 @@ alter_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| ALTER				/* 1 */
 	  INDEX				/* 2 */
@@ -4082,7 +3904,7 @@ alter_stmt
 	  ON_				/* 4 */
 	  class_name			/* 5 */
 	  VISIBLE			/* 6 */
-		{{ DBG_TRACE_GRAMMAR(alter_stmt, | ALTER INDEX identifier ON_ class_name VISIBLE);
+		{{
 			PT_NODE* node = parser_new_node(this_parser, PT_ALTER_INDEX);
 
 			if (node)
@@ -4109,7 +3931,6 @@ alter_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| ALTER						/* 1 */
 	  view_or_vclass				/* 2 */
@@ -4117,8 +3938,7 @@ alter_stmt
 	  AS						/* 4 */
 	  csql_query					/* 5 */
 	  opt_vclass_comment_spec			/* 6 */
-		{{ DBG_TRACE_GRAMMAR(alter_stmt, | ALTER view_or_vclass class_name AS csql_query opt_vclass_comment_spec);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_ALTER);
 			if (node)
 			  {
@@ -4134,14 +3954,12 @@ alter_stmt
 			  }
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| ALTER
 	  view_or_vclass
 	  class_name
 	  class_comment_spec		%dprec 1
-		{{ DBG_TRACE_GRAMMAR(alter_stmt, | ALTER view_or_vclass class_name class_comment_spec);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_ALTER);
 			if (node)
 			  {
@@ -4154,15 +3972,13 @@ alter_stmt
 			  }
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| ALTER				/* 1 */
 	  procedure_or_function		/* 2 */
 	  procedure_or_function_name    /* 3 */
 	  opt_owner_clause	        /* 4 */
 	  opt_comment_spec		/* 5 */
-		{{ DBG_TRACE_GRAMMAR(alter_stmt, | ALTER procedure_or_function procedure_or_function_name opt_owner_clause opt_comment_spec);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_ALTER_STORED_PROCEDURE);
 
 			if (node != NULL)
@@ -4183,14 +3999,12 @@ alter_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| ALTER				/* 1 */
 	  procedure_or_function		/* 2 */
 	  procedure_or_function_name    /* 3 */
 	  COMPILE	                /* 4 */
-		{{ DBG_TRACE_GRAMMAR(alter_stmt, | ALTER procedure_or_function procedure_or_function_name COMPILE);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_ALTER_STORED_PROCEDURE);
 
 			if (node != NULL)
@@ -4203,10 +4017,9 @@ alter_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| ALTER  SERVER  dblink_server_name alter_server_list
-                {{ DBG_TRACE_GRAMMAR(alter_stmt, | ALTER  SERVER  dblink_server_name alter_server_list);
+                {{
                         PT_NODE *node = parser_new_node (this_parser, PT_ALTER_SERVER);
 			if (node)
 			  {
@@ -4295,7 +4108,6 @@ alter_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| ALTER				/* 1 */
 	  opt_access_modifier		/* 2 */
@@ -4305,8 +4117,7 @@ alter_stmt
 	  opt_alter_synonym		/* 6 */
 	  opt_comment_spec		/* 7 */
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(alter_stmt, | ALTER opt_access_modifier SYNONYM synonym_name For class_name opt_comment_spec);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_ALTER_SYNONYM);
 			PT_MISC_TYPE synonym_access_modifier;
 
@@ -4339,64 +4150,52 @@ alter_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 view_or_vclass
-	: VIEW   { DBG_TRACE_GRAMMAR(view_or_vclass, : VIEW ); }
-	| VCLASS { DBG_TRACE_GRAMMAR(view_or_vclass, | VCLASS ); }
+	: VIEW   { }
+	| VCLASS { }
 	;
 
 alter_clause_list
 	: alter_clause_list ',' prepare_alter_node alter_clause_for_alter_list
-		{{ DBG_TRACE_GRAMMAR(alter_clause_list, : alter_clause_list ',' prepare_alter_node alter_clause_for_alter_list);
-
+		{{
 			$$ = parser_make_link ($1, parser_get_alter_node ());
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| /* The first node in the list is the one that was pushed for hints. */
 		{
-
 			PT_NODE *node = parser_pop_hint_node ();
 			parser_save_alter_node (node);
 		}
 	 alter_clause_for_alter_list
-		{{ DBG_TRACE_GRAMMAR(alter_clause_list, | alter_clause_for_alter_list);
-
+		{{
 			$$ = parser_get_alter_node ();
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 prepare_alter_node
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(prepare_alter_node, : );
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_ALTER);
 			parser_save_alter_node (node);
-
 		}}
 	;
 
 only_class_name
 	: ONLY user_specified_name
-		{ DBG_TRACE_GRAMMAR(only_class_name, : ONLY user_specified_name);
-                  $$ = $2; }
+		{ $$ = $2; }
 	| user_specified_name
-		{ DBG_TRACE_GRAMMAR(only_class_name, | user_specified_name);
-                  $$ = $1; }
+		{ $$ = $1; }
 	;
 
 only_class_name_or_with_server_name
         : only_class_name
-               { DBG_TRACE_GRAMMAR(only_class_name_or_with_server_name, : only_class_name);
-                  $$ = $1; }
+               { $$ = $1; }
         | class_name_with_server_name
-                {{ DBG_TRACE_GRAMMAR(only_class_name_or_with_server_name, | class_name_with_server_name);
-
+                {{
                         PT_NODE *scs = parser_new_node (this_parser, PT_SPEC);
 			if (scs)
 			  {
@@ -4411,13 +4210,11 @@ only_class_name_or_with_server_name
                         $$ = scs;                       
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
                 }}
-
 	;
 
 rename_stmt
 	: RENAME opt_class_type rename_class_list
-		{{ DBG_TRACE_GRAMMAR(rename_stmt, : RENAME opt_class_type rename_class_list);
-
+		{{
 			PT_NODE *node = NULL;
 			int entity_type = ($2 == PT_EMPTY ? PT_CLASS : $2);
 
@@ -4428,11 +4225,9 @@ rename_stmt
 
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| RENAME TRIGGER trigger_name as_or_to trigger_name
-		{{ DBG_TRACE_GRAMMAR(rename_stmt, | RENAME TRIGGER trigger_name as_or_to trigger_name);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_RENAME_TRIGGER);
 
 			if (node)
@@ -4443,10 +4238,9 @@ rename_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| RENAME SERVER dblink_server_name as_or_to identifier_without_dot
-		{{ DBG_TRACE_GRAMMAR(rename_stmt, | RENAME SERVER dblink_server_name as_or_to identifier_without_dot);
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_RENAME_SERVER);
 			if (node)
 			  {
@@ -4467,8 +4261,7 @@ rename_stmt
 	  as_or_to			/* 6 */
 	  synonym_name_without_dot	/* 7 */
 	  	{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(rename_stmt, | RENAME opt_access_modifier SYNONYM synonym_name as_or_to synonym_name_without_dot);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_RENAME_SYNONYM);
 			PT_MISC_TYPE synonym_access_modifier;
 
@@ -4492,25 +4285,20 @@ rename_stmt
 
 rename_class_list
 	: rename_class_list ',' rename_class_pair
-		{{ DBG_TRACE_GRAMMAR(rename_class_list, : rename_class_list ',' rename_class_pair);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| rename_class_pair
-		{{ DBG_TRACE_GRAMMAR(rename_class_list, | rename_class_pair);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 rename_class_pair
 	: only_class_name as_or_to only_class_name
-		{{ DBG_TRACE_GRAMMAR(rename_class_pair, : only_class_name as_or_to only_class_name);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_RENAME);
 			if (node)
 			  {
@@ -4521,32 +4309,25 @@ rename_class_pair
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 procedure_or_function
 	: PROCEDURE
-		{{ DBG_TRACE_GRAMMAR(procedure_or_function, : PROCEDURE);
-
+		{{
 			$$ = 1;
-
 		}}
 	| FUNCTION
-		{{ DBG_TRACE_GRAMMAR(procedure_or_function, | FUNCTION);
-
+		{{
 			$$ = 2;
-
 		}}
 	;
 
 opt_owner_clause
 	: /* empty */
-		{ DBG_TRACE_GRAMMAR(opt_owner_clause, : );
-                  $$ = NULL; }
+		{ $$ = NULL; }
 	| OWNER TO identifier
-		{ DBG_TRACE_GRAMMAR(opt_owner_clause, | OWNER TO identifier);
-                  $$ = $3; }
+		{ $$ = $3; }
 	;
 
 as_or_to
@@ -4556,8 +4337,7 @@ as_or_to
 
 truncate_stmt
 	: TRUNCATE opt_table_type class_spec_without_server_name opt_cascade
-		{{ DBG_TRACE_GRAMMAR(truncate_stmt, : TRUNCATE opt_table_type class_spec_without_server_name opt_cascade);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_TRUNCATE);
 			if (node)
 			  {
@@ -4567,14 +4347,12 @@ truncate_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 do_stmt
 	: DO expression_
-		{{ DBG_TRACE_GRAMMAR(do_stmt, :  DO expression_);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_DO);
 			if (node)
 			  {
@@ -4597,14 +4375,12 @@ do_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 drop_stmt
 	: DROP opt_class_type opt_if_exists class_spec_list opt_cascade_constraints
-		{{ DBG_TRACE_GRAMMAR(drop_stmt, : DROP opt_class_type opt_if_exists class_spec_list opt_cascade_constraints);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_DROP);
 			if (node)
 			  {
@@ -4620,7 +4396,6 @@ drop_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| DROP					/* 1 */
 		{				/* 2 */
@@ -4635,8 +4410,7 @@ drop_stmt
 	  ON_						/* 8 */
 	  only_class_name				/* 9 */
 	  opt_index_column_name_list			/* 10 */
-		{{ DBG_TRACE_GRAMMAR(drop_stmt, | DROP ~ INDEX ~);
-
+		{{
 			PT_NODE *node = parser_pop_hint_node ();
 			PT_NODE *ocs = parser_new_node(this_parser, PT_SPEC);
 
@@ -4685,11 +4459,9 @@ drop_stmt
 			    $$ = node;
 			    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 			  }
-
 		}}
 	| DROP USER identifier
-		{{ DBG_TRACE_GRAMMAR(drop_stmt, | DROP USER identifier);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_DROP_USER);
 
 			if (node)
@@ -4699,11 +4471,9 @@ drop_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| DROP TRIGGER trigger_name_list
-		{{ DBG_TRACE_GRAMMAR(drop_stmt, | DROP TRIGGER trigger_name_list);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_DROP_TRIGGER);
 
 			PT_NODE *list = parser_new_node (this_parser, PT_TRIGGER_SPEC_LIST);
@@ -4719,11 +4489,9 @@ drop_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| DROP DEFERRED TRIGGER trigger_spec_list
-		{{ DBG_TRACE_GRAMMAR(drop_stmt, | DROP DEFERRED TRIGGER trigger_spec_list);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_REMOVE_TRIGGER);
 
 			if (node)
@@ -4733,21 +4501,17 @@ drop_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| DROP VARIABLE_ identifier_list
-		{{ DBG_TRACE_GRAMMAR(drop_stmt, | DROP VARIABLE_ identifier_list);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_DROP_VARIABLE);
 			if (node)
 			  node->info.drop_variable.var_names = $3;
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| DROP SERIAL opt_if_exists serial_name
-		{{ DBG_TRACE_GRAMMAR(drop_stmt, | DROP SERIAL opt_if_exists serial_name);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_DROP_SERIAL);
 			if (node)
 			  {
@@ -4756,11 +4520,9 @@ drop_stmt
 			  }
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| DROP PROCEDURE procedure_or_function_name_list
-		{{ DBG_TRACE_GRAMMAR(drop_stmt, | DROP PROCEDURE procedure_or_function_name_list);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_DROP_STORED_PROCEDURE);
 
 			if (node)
@@ -4772,11 +4534,9 @@ drop_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| DROP FUNCTION procedure_or_function_name_list
-		{{ DBG_TRACE_GRAMMAR(drop_stmt, | DROP FUNCTION procedure_or_function_name_list);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_DROP_STORED_PROCEDURE);
 
 			if (node)
@@ -4788,10 +4548,9 @@ drop_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| DROP SERVER opt_if_exists dblink_server_name
-		{{ DBG_TRACE_GRAMMAR(drop_stmt, | DROP SERVER opt_if_exists dblink_server_name);
+		{{
                         PT_NODE *node = parser_new_node (this_parser, PT_DROP_SERVER);
 
 			if (node)
@@ -4807,7 +4566,6 @@ drop_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| DROP				/* 1 */
 	  opt_access_modifier		/* 2 */
@@ -4816,8 +4574,7 @@ drop_stmt
 	  opt_if_exists			/* 5 */
 	  synonym_name			/* 6 */
 	  	{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(drop_stmt, | DROP SERVER opt_access_modifier SYNONYM opt_if_exists synonym_name);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_DROP_SYNONYM);
 			PT_MISC_TYPE synonym_access_modifier;
 			const char *synonym_owner_name = NULL;
@@ -4837,11 +4594,9 @@ drop_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| deallocate_or_drop PREPARE identifier
-		{{ DBG_TRACE_GRAMMAR(drop_stmt, | deallocate_or_drop PREPARE identifier);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_DEALLOCATE_PREPARE);
 
 			if (node)
@@ -4852,11 +4607,9 @@ drop_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| deallocate_or_drop VARIABLE_ session_variable_list
-		{{ DBG_TRACE_GRAMMAR(drop_stmt, | deallocate_or_drop VARIABLE_ session_variable_list);
-
+		{{
 			PT_NODE *node =
 			  parser_new_node (this_parser, PT_DROP_SESSION_VARIABLES);
 			if (node)
@@ -4865,7 +4618,6 @@ drop_stmt
 			  }
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
@@ -4876,55 +4628,43 @@ deallocate_or_drop
 
 opt_reverse
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_reverse, : );
-
+		{{
 			parser_save_is_reverse (false);
 			$$ = false;
-
 		}}
 	| REVERSE
-		{{ DBG_TRACE_GRAMMAR(opt_reverse, | REVERSE);
-
+		{{
 			parser_save_is_reverse (true);
 			$$ = true;
-
 		}}
 	;
 
 opt_unique
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_unique, : );
-
+		{{
 			$$ = false;
-
 		}}
 	| UNIQUE
-		{{ DBG_TRACE_GRAMMAR(opt_unique, | UNIQUE);
-
+		{{
 			$$ = true;
-
 		}}
 	;
 
 opt_index_column_name_list
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_index_column_name_list, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| index_column_name_list
-		{{ DBG_TRACE_GRAMMAR(opt_index_column_name_list, | index_column_name_list);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 index_column_name_list
 	: '(' sort_spec_list ')'
-		{{ DBG_TRACE_GRAMMAR(index_column_name_list, '(' sort_spec_list ')');
+		{{
 			if (parser_get_is_reverse())
 			{
 			  PT_NODE *node;
@@ -4936,14 +4676,12 @@ index_column_name_list
 
 		      $$ = $2;
 		      PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 update_statistics_stmt
 	: UPDATE STATISTICS ON_ only_class_name_list opt_with_fullscan
-		{{ DBG_TRACE_GRAMMAR(update_statistics_stmt, : UPDATE STATISTICS ON_ only_class_name_list opt_with_fullscan);
-
+		{{
 			PT_NODE *ups = parser_new_node (this_parser, PT_UPDATE_STATS);
 			if (ups)
 			  {
@@ -4953,11 +4691,9 @@ update_statistics_stmt
 			  }
 			$$ = ups;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| UPDATE STATISTICS ON_ ALL CLASSES opt_with_fullscan
-		{{ DBG_TRACE_GRAMMAR(update_statistics_stmt, | UPDATE STATISTICS ON_ ALL CLASSES opt_with_fullscan);
-
+		{{
 			PT_NODE *ups = parser_new_node (this_parser, PT_UPDATE_STATS);
 			if (ups)
 			  {
@@ -4967,11 +4703,9 @@ update_statistics_stmt
 			  }
 			$$ = ups;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| UPDATE STATISTICS ON_ CATALOG CLASSES opt_with_fullscan
-		{{ DBG_TRACE_GRAMMAR(update_statistics_stmt, | UPDATE STATISTICS ON_ CATALOG CLASSES opt_with_fullscan);
-
+		{{
 			PT_NODE *ups = parser_new_node (this_parser, PT_UPDATE_STATS);
 			if (ups)
 			  {
@@ -4981,54 +4715,42 @@ update_statistics_stmt
 			  }
 			$$ = ups;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 only_class_name_list
 	: only_class_name_list ',' only_class_name
-		{{ DBG_TRACE_GRAMMAR(only_class_name_list, : only_class_name_list ',' only_class_name);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| only_class_name
-		{{ DBG_TRACE_GRAMMAR(only_class_name_list, | only_class_name);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_invisible
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_invisible, : );
+		{{
  			$$ = false;
-
 		}}
 	| INVISIBLE
-		{{ DBG_TRACE_GRAMMAR(opt_invisible, | INVISIBLE);
-
+		{{
 			$$ = true;
-
 		}}
 	;
 
 
 opt_with_fullscan
         : /* empty */
-                {{ DBG_TRACE_GRAMMAR(opt_with_fullscan, : );
-
+                {{
                         $$ = 0;
-
                 }}
         | WITH FULLSCAN
-                {{ DBG_TRACE_GRAMMAR(opt_with_fullscan, |  WITH FULLSCAN);
-
+                {{
                         $$ = 1;
-
                 }}
         ;
 
@@ -5040,138 +4762,109 @@ opt_of_to_eq
 
 opt_level_spec
 	: ON_
-		{{ DBG_TRACE_GRAMMAR(opt_level_spec, : ON_ );
-
+		{{
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 			if (val)
 			  val->info.value.data_value.i = -1;
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| OFF_
-		{{ DBG_TRACE_GRAMMAR(opt_level_spec, | OFF_ );
-
+		{{
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 			if (val)
 			  val->info.value.data_value.i = 0;
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| unsigned_integer
-		{{ DBG_TRACE_GRAMMAR(opt_level_spec, |  unsigned_integer);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| param_
-		{{ DBG_TRACE_GRAMMAR(opt_level_spec, |  param_ );
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| host_param_input
-		{{ DBG_TRACE_GRAMMAR(opt_level_spec, |  host_param_input);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 char_string_literal_list
 	: char_string_literal_list ',' char_string_literal
-		{{ DBG_TRACE_GRAMMAR(char_string_literal_list, : char_string_literal_list ',' char_string_literal );
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| char_string_literal
-		{{ DBG_TRACE_GRAMMAR(char_string_literal_list, | char_string_literal);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 table_spec_list
 	: table_spec_list  ',' table_spec
-		{{ DBG_TRACE_GRAMMAR(table_spec_list, : table_spec_list  ',' table_spec);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| table_spec
-		{{ DBG_TRACE_GRAMMAR(table_spec_list, |  table_spec);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 extended_table_spec_list
 	: extended_table_spec_list ',' table_spec
-		{{ DBG_TRACE_GRAMMAR(extended_table_spec_list, : extended_table_spec_list ',' table_spec);
-
+		{{
 			container_2 ctn;
 			PT_NODE *n1 = CONTAINER_AT_0 ($1);
 			PT_NODE *n2 = $3;
 			int number = (int) TO_NUMBER (CONTAINER_AT_1 ($1));
 			SET_CONTAINER_2 (ctn, parser_make_link (n1, n2), FROM_NUMBER (number));
 			$$ = ctn;
-
 		}}
 	| extended_table_spec_list join_table_spec
-		{{ DBG_TRACE_GRAMMAR(extended_table_spec_list, | extended_table_spec_list join_table_spec);
-
+		{{
 			container_2 ctn;
 			PT_NODE *n1 = CONTAINER_AT_0 ($1);
 			PT_NODE *n2 = $2;
 			SET_CONTAINER_2 (ctn, parser_make_link (n1, n2), FROM_NUMBER (1));
 			$$ = ctn;
-
 		}}
 	| '(' extended_table_spec_list join_table_spec ')'
-		{{ DBG_TRACE_GRAMMAR(extended_table_spec_list, | '(' extended_table_spec_list join_table_spec ')');
-
+		{{
 			container_2 ctn;
 			PT_NODE *n1 = CONTAINER_AT_0 ($2);
 			PT_NODE *n2 = $3;
 			SET_CONTAINER_2 (ctn, parser_make_link (n1, n2), FROM_NUMBER (1));
 			$$ = ctn;
-
 		}}
 	| table_spec
-		{{ DBG_TRACE_GRAMMAR(extended_table_spec_list, | table_spec);
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, $1, FROM_NUMBER (0));
 			$$ = ctn;
-
 		}}
 	;
 
 join_table_spec
 	: CROSS JOIN table_spec
-		{{ DBG_TRACE_GRAMMAR(join_table_spec, : CROSS JOIN table_spec);
-
+		{{
 			PT_NODE *sopt = $3;
 			if (sopt)
 			  sopt->info.spec.join_type = PT_JOIN_CROSS;
 			$$ = sopt;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| opt_of_inner_left_right JOIN table_spec join_condition
-		{{ DBG_TRACE_GRAMMAR(join_table_spec, | opt_of_inner_left_right JOIN table_spec join_condition);
-
+		{{
 			PT_NODE *sopt = $3;
 			bool natural = false;
 
@@ -5196,11 +4889,9 @@ join_table_spec
 			$$ = sopt;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 			parser_restore_pseudoc ();
-
 		}}
 	| NATURAL opt_of_inner_left_right JOIN table_spec
-		{{ DBG_TRACE_GRAMMAR(join_table_spec, | NATURAL opt_of_inner_left_right JOIN table_spec );
-
+		{{
 			PT_NODE *sopt = $4;
 			bool natural = true;
 
@@ -5217,7 +4908,7 @@ join_table_spec
 
 join_condition
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(join_condition, : );
+		{{
 			parser_save_and_set_pseudoc (0);
 			$$ = NULL;   /* just return NULL */
 		}}
@@ -5228,7 +4919,7 @@ join_condition
 			parser_save_and_set_ic (1);
 		}}
 	  search_condition
-		{{ DBG_TRACE_GRAMMAR(join_condition, | ON_ search_condition);
+		{{
 			PT_NODE *condition = $3;
 			bool instnum_flag = false;
 
@@ -5248,33 +4939,24 @@ join_condition
 			$$ = condition;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
-
-
 	;
 
 opt_of_inner_left_right
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_of_inner_left_right, : );
+		{{
 			$$ = PT_JOIN_INNER;
-
 		}}
 	| INNER opt_outer
-		{{ DBG_TRACE_GRAMMAR(opt_of_inner_left_right, | INNER opt_outer );
-
+		{{
 			$$ = PT_JOIN_INNER;
-
 		}}
 	| LEFT opt_outer
-		{{ DBG_TRACE_GRAMMAR(opt_of_inner_left_right, | LEFT opt_outer );
-
+		{{
 			$$ = PT_JOIN_LEFT_OUTER;
-
 		}}
 	| RIGHT opt_outer
-		{{ DBG_TRACE_GRAMMAR(opt_of_inner_left_right, |  RIGHT opt_outer );
-
+		{{
 			$$ = PT_JOIN_RIGHT_OUTER;
-
 		}}
 	;
 
@@ -5285,23 +4967,19 @@ opt_outer
 
 table_spec
 	: '(' table_spec ')' %dprec 1
-		{{ DBG_TRACE_GRAMMAR(table_spec, : '(' table_spec ')' );
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| original_table_spec %dprec 2
-		{{ DBG_TRACE_GRAMMAR(table_spec, | original_table_spec);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 
 original_table_spec
 	: class_spec opt_as_identifier_attr_name opt_table_spec_index_hint_list
-		{{ DBG_TRACE_GRAMMAR(original_table_spec, : class_spec opt_as_identifier_attr_name opt_table_spec_index_hint_list );
+		{{
 			PT_NODE *range_var = NULL;
 			PT_NODE *ent = $1;
 			if (ent)
@@ -5401,11 +5079,9 @@ original_table_spec
 
 			$$ = ent;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| meta_class_spec opt_as_identifier_attr_name
-		{{ DBG_TRACE_GRAMMAR(original_table_spec, | meta_class_spec opt_as_identifier_attr_name);
-
+		{{
 			PT_NODE *ent = $1;
 			if (ent)
 			  {
@@ -5428,11 +5104,9 @@ original_table_spec
 			  }
 			$$ = ent;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| subquery opt_as_identifier_attr_name
-		{{ DBG_TRACE_GRAMMAR(original_table_spec, | subquery opt_as_identifier_attr_name);
-
+		{{
 			PT_NODE *ent = parser_new_node (this_parser, PT_SPEC);
 			if (ent)
 			  {
@@ -5458,11 +5132,9 @@ original_table_spec
 			  }
 			$$ = ent;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| TABLE '(' expression_ ')' opt_as_identifier_attr_name
-		{{ DBG_TRACE_GRAMMAR(original_table_spec, | TABLE '(' expression_ ')' opt_as_identifier_attr_name);
-
+		{{
 			PT_NODE *ent = parser_new_node (this_parser, PT_SPEC);
 			if (ent)
 			  {
@@ -5476,10 +5148,9 @@ original_table_spec
 			  }
 			$$ = ent;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| JSON_TABLE json_table_rule opt_as identifier
-		{{ DBG_TRACE_GRAMMAR(original_table_spec, | JSON_TABLE json_table_rule opt_as identifier);
+		{{
 			PT_NODE *ent = parser_new_node (this_parser, PT_SPEC);
 			if (ent)
 			  {
@@ -5489,10 +5160,9 @@ original_table_spec
 			  }
 			$$ = ent;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
         | DBLINK  '('  dblink_expr ')'   dblink_identifier_col_attrs 
-                {{ DBG_TRACE_GRAMMAR(original_table_spec, | DBLINK  '('  dblink_expr ')' dblink_identifier_col_attrs );                       
+                {{
 			PT_NODE *ent = parser_new_node (this_parser, PT_SPEC);
 			if (ent)
 			  {
@@ -5508,8 +5178,7 @@ original_table_spec
 
 opt_table_spec_index_hint
 	: USE index_or_key '(' identifier_list ')'
-		{{ DBG_TRACE_GRAMMAR(opt_table_spec_index_hint, : USE index_or_key '(' identifier_list ')' );
-
+		{{
 			PT_NODE *list = $4;
 			while (list)
 			  {
@@ -5519,11 +5188,9 @@ opt_table_spec_index_hint
 
 			$$ = $4;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| FORCE index_or_key '(' identifier_list ')'
-		{{ DBG_TRACE_GRAMMAR(opt_table_spec_index_hint, | FORCE index_or_key '(' identifier_list ')' );
-
+		{{
 			PT_NODE *list = $4;
 			while (list)
 			  {
@@ -5534,11 +5201,9 @@ opt_table_spec_index_hint
 
 			$$ = $4;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| IGNORE_ index_or_key '(' identifier_list ')'
-		{{ DBG_TRACE_GRAMMAR(opt_table_spec_index_hint, | IGNORE_ index_or_key '(' identifier_list ')' );
-
+		{{
 			PT_NODE *list = $4;
 			while (list)
 			  {
@@ -5549,58 +5214,45 @@ opt_table_spec_index_hint
 
 			  $$ = $4;
 			  PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_table_spec_index_hint_list
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_table_spec_index_hint_list, :);
-
+		{{
 			$$ = 0;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| opt_table_spec_index_hint_list ',' opt_table_spec_index_hint
-		{{ DBG_TRACE_GRAMMAR(opt_table_spec_index_hint_list, | opt_table_spec_index_hint_list ',' opt_table_spec_index_hint );
-
+		{{
 			$$ = parser_make_link($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos);
-
 		}}
 	| opt_table_spec_index_hint
-		{{ DBG_TRACE_GRAMMAR(opt_table_spec_index_hint_list, | opt_table_spec_index_hint );
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos);
-
 		}}
 	;
 
 opt_as_identifier_attr_name
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_as_identifier_attr_name, : );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, NULL, NULL);
 			$$ = ctn;
-
 		}}
 	| opt_as identifier '(' identifier_list ')'
-		{{ DBG_TRACE_GRAMMAR(opt_as_identifier_attr_name, | opt_as identifier '(' identifier_list ')' );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, $2, $4);
 			$$ = ctn;
-
 		}}
 	| opt_as identifier
-		{{ DBG_TRACE_GRAMMAR(opt_as_identifier_attr_name, | opt_as identifier);
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, $2, NULL);
 			$$ = ctn;
-
 		}}
 	;
 
@@ -5611,87 +5263,68 @@ opt_as
 
 class_spec_list
 	: class_spec_list  ',' class_spec_without_server_name
-		{{ DBG_TRACE_GRAMMAR(class_spec_list, : class_spec_list  ',' class_spec );
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| class_spec_without_server_name
-		{{ DBG_TRACE_GRAMMAR(class_spec_list, | class_spec );
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 class_spec_without_server_name
         : only_all_class_spec
-		{{ DBG_TRACE_GRAMMAR(class_spec, : only_all_class_spec );
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| '(' only_all_class_spec_list ')'
-		{{ DBG_TRACE_GRAMMAR(class_spec, | '(' only_all_class_spec_list ')' );
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 class_spec
 	: only_all_class_spec
-		{{ DBG_TRACE_GRAMMAR(class_spec, : only_all_class_spec );
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| only_all_class_spec_with_server
-		{{ DBG_TRACE_GRAMMAR(class_spec, : only_all_class_spec_with_server );
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| '(' only_all_class_spec_list ')'
-		{{ DBG_TRACE_GRAMMAR(class_spec, | '(' only_all_class_spec_list ')' );
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 only_all_class_spec_list
 	: only_all_class_spec_list ',' only_all_class_spec
-		{{ DBG_TRACE_GRAMMAR(only_all_class_spec_list, : only_all_class_spec_list ',' only_all_class_spec );
-
+		{{
 			PT_NODE *result = parser_make_link ($1, $3);
 			PT_NODE *p = parser_new_node (this_parser, PT_SPEC);
 			if (p)
 			  p->info.spec.entity_name = result;
 			$$ = p;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| only_all_class_spec
-		{{ DBG_TRACE_GRAMMAR(only_all_class_spec_list, | only_all_class_spec );
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 meta_class_spec
 	: CLASS only_class_name
-		{{ DBG_TRACE_GRAMMAR(meta_class_spec, : CLASS only_class_name );
-
+		{{
 			PT_NODE *ocs = parser_new_node (this_parser, PT_SPEC);
 			if (ocs)
 			  {
@@ -5702,13 +5335,12 @@ meta_class_spec
 
 			$$ = ocs;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 only_all_class_spec_with_server
 	: class_name_with_server_name
-		{{ DBG_TRACE_GRAMMAR(only_all_class_spec_with_server, : class_name_with_server_name);
+		{{
                        PT_NODE *ocs = parser_new_node (this_parser, PT_SPEC);
 			if (ocs)
 			  {
@@ -5727,7 +5359,7 @@ only_all_class_spec_with_server
 
 only_all_class_spec
 	: only_class_name opt_partition_spec
-		{{ DBG_TRACE_GRAMMAR(only_all_class_spec, : only_class_name opt_partition_spec );
+		{{
                        PT_NODE *ocs = NULL;
 
                        ocs = parser_new_node (this_parser, PT_SPEC);
@@ -5744,11 +5376,9 @@ only_all_class_spec
 
 			$$ = ocs;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| ALL class_name '(' EXCEPT class_spec_list ')'
-		{{ DBG_TRACE_GRAMMAR(only_all_class_spec, | ALL class_name '(' EXCEPT class_spec_list ')' );
-
+		{{
 			PT_NODE *acs = parser_new_node (this_parser, PT_SPEC);
 			if (acs)
 			  {
@@ -5760,11 +5390,9 @@ only_all_class_spec
 			  }
 			$$ = acs;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| ALL class_name
-		{{ DBG_TRACE_GRAMMAR(only_all_class_spec, | class_name);
-
+		{{
 			PT_NODE *acs = parser_new_node (this_parser, PT_SPEC);
 			if (acs)
 			  {
@@ -5775,13 +5403,12 @@ only_all_class_spec
 
 			$$ = acs;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 class_name_with_server_name
         : class_name '@' dblink_server_name
-                {{DBG_TRACE_GRAMMAR(class_name_with_server_name, : class_name '@' dblink_server_name);
+                {{
                 assert($1 != NULL && $3 != NULL);
                 container_2 ctn;
                 // Do NOT automatically assign a user name. 
@@ -5793,8 +5420,7 @@ class_name_with_server_name
 
 object_name
 	: identifier DOT identifier
-		{{ DBG_TRACE_GRAMMAR(object_name, : identifier DOT identifier);
-
+		{{
 			PT_NODE *qualifier = $1;
 			PT_NODE *node = $3;
 
@@ -5806,21 +5432,17 @@ object_name
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| identifier
-		{{ DBG_TRACE_GRAMMAR(object_name, | identifier);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 user_specified_name_without_dot
 	: identifier_without_dot DOT identifier_without_dot
-		{{ DBG_TRACE_GRAMMAR(user_specified_name_without_dot, : identifier_without_dot DOT identifier_without_dot);
-
+		{{
 			PT_NODE *user = $1;
 			PT_NODE *name = $3;
 
@@ -5834,11 +5456,9 @@ user_specified_name_without_dot
 
 			$$ = name;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| identifier_without_dot
-		{{ DBG_TRACE_GRAMMAR(user_specified_name_without_dot, | identifier_without_dot);
-
+		{{
 			PT_NODE *name = $1;
 
 			if (name)
@@ -5848,14 +5468,12 @@ user_specified_name_without_dot
 
 			$$ = name;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 user_specified_name
 	: object_name
-		{{ DBG_TRACE_GRAMMAR(user_specified_name, : object_name);
- 
+		{{
 			PT_NODE *name = $1;
 
 			if (name)
@@ -5865,7 +5483,6 @@ user_specified_name
 
 			$$ = name;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
@@ -5881,25 +5498,20 @@ class_name
 
 class_name_list
 	: class_name_list ',' class_name
-		{{ DBG_TRACE_GRAMMAR(class_name_list, : class_name_list ',' class_name);
-
+		{{
 			$$ = parser_make_link($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| class_name
-		{{ DBG_TRACE_GRAMMAR(class_name_list, | class_name);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 index_name
 	: object_name
 		{{
-
 			PT_NODE *node = $1;
 
 			if (node)
@@ -5909,7 +5521,6 @@ index_name
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
@@ -5926,17 +5537,13 @@ trigger_name
 trigger_name_list
 	: trigger_name_list ',' trigger_name
 		{{
-
 			$$ = parser_make_link($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| trigger_name
 		{{
-
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
@@ -5952,56 +5559,52 @@ serial_name
 
 synonym_name_without_dot
 	: user_specified_name_without_dot
-		{ DBG_TRACE_GRAMMAR(synonym_name_without_dot, : user_specified_name_without_dot);
+		{
 			$$ = $1;
 		}
 	;
 
 synonym_name
 	: user_specified_name
-		{ DBG_TRACE_GRAMMAR(synonym_name, : user_specified_name);
+		{
 			$$ = $1;
 		}
 	;
 
 procedure_or_function_name_without_dot
 	: user_specified_name_without_dot
-		{ DBG_TRACE_GRAMMAR(procedure_or_function_name_without_dot, : user_specified_name_without_dot);
+		{
 			$$ = $1;
 		}
 	;
 	
 procedure_or_function_name
 	: user_specified_name
-		{ DBG_TRACE_GRAMMAR(procedure_or_function_name, : user_specified_name);
+		{
 			$$ = $1;
 		}
 	;
 
 procedure_or_function_name_list
 	: procedure_or_function_name_list ',' procedure_or_function_name
-		{{ DBG_TRACE_GRAMMAR(procedure_or_function_name_list, : procedure_or_function_name_list ',' procedure_or_function_name);
-
+		{{
 			$$ = parser_make_link($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| procedure_or_function_name
-		{{ DBG_TRACE_GRAMMAR(procedure_or_function_name_list, : procedure_or_function_name);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_partition_spec
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_partition_spec, : );
+		{{
 		    $$ = NULL;
 		}}
 	| PARTITION '(' identifier ')'
-		{{ DBG_TRACE_GRAMMAR(opt_partition_spec, | PARTITION '(' identifier ')' );
+		{{
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
@@ -6009,85 +5612,61 @@ opt_partition_spec
 
 opt_class_type
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_class_type, :);
-
+		{{
 			$$ = PT_EMPTY;
-
 		}}
 	| VCLASS
-		{{ DBG_TRACE_GRAMMAR(opt_class_type, | VCLASS);
-
+		{{
 			$$ = PT_VCLASS;
-
 		}}
 	| VIEW
-		{{ DBG_TRACE_GRAMMAR(opt_class_type, | VIEW );
-
+		{{
 			$$ = PT_VCLASS;
-
 		}}
 	| CLASS
-		{{ DBG_TRACE_GRAMMAR(opt_class_type, | CLASS );
-
+		{{
 			$$ = PT_CLASS;
-
 		}}
 	| TABLE
-		{{ DBG_TRACE_GRAMMAR(opt_class_type, | TABLE );
-
+		{{
 			$$ = PT_CLASS;
-
 		}}
 	;
 
 opt_table_type
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_table_type, : );
-
+		{{
 			$$ = PT_EMPTY;
-
 		}}
 	| CLASS
-		{{ DBG_TRACE_GRAMMAR(opt_table_type, | CLASS );
-
+		{{
 			$$ = PT_CLASS;
-
 		}}
 	| TABLE
-		{{ DBG_TRACE_GRAMMAR(opt_table_type, | TABLE );
-
+		{{
 			$$ = PT_CLASS;
-
 		}}
 	;
 
 opt_cascade
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_cascade, : );
-
+		{{
 			$$ = false;
-
 		}}
 	| CASCADE
-		{{ DBG_TRACE_GRAMMAR(opt_cascade, | CASCADE );
-
+		{{
 			$$ = true;
-
 		}}
 	;
 
 opt_cascade_constraints
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_cascade_constraints, : );
-
+		{{
 			$$ = false;
-
 		}}
 	| CASCADE CONSTRAINTS
-		{{ DBG_TRACE_GRAMMAR(opt_cascade_constraints, | CASCADE CONSTRAINTS );
-
+		{{
 			$$ = true;
-
 		}}
 	;
 
@@ -6103,7 +5682,7 @@ alter_clause_for_alter_list
 	| MODIFY alter_modify_clause_for_alter_list
 	| CHANGE alter_change_clause_for_alter_list
 	| OWNER TO identifier
-		{{ DBG_TRACE_GRAMMAR(alter_clause_for_alter_list, | OWNER TO identifier );
+		{{
 			PT_NODE *alt = parser_get_alter_node();
 
 			if (alt)
@@ -6113,7 +5692,7 @@ alter_clause_for_alter_list
 			  }
 		}}
 	| charset_spec opt_collation
-		{{ DBG_TRACE_GRAMMAR(alter_clause_for_alter_list, | charset_spec opt_collation );
+		{{
 			PT_NODE *node = parser_get_alter_node();
 			PT_NODE *cs_node, *coll_node;
 			int charset, coll_id;
@@ -6143,7 +5722,7 @@ alter_clause_for_alter_list
 			  }
 		}}
 	| collation_spec
-		{{ DBG_TRACE_GRAMMAR(alter_clause_for_alter_list, | collation_spec );
+		{{
 			PT_NODE *node = parser_get_alter_node();
 			PT_NODE *coll_node;
 			int charset, coll_id;
@@ -6167,7 +5746,7 @@ alter_clause_for_alter_list
 			  }
 		}}
 	| class_comment_spec
-		{{ DBG_TRACE_GRAMMAR(alter_clause_for_alter_list, | class_comment_spec );
+		{{
 			PT_NODE *alter_node = parser_get_alter_node();
 
 			if (alter_node != NULL && alter_node->info.alter.code != PT_CHANGE_COLUMN_COMMENT)
@@ -6186,8 +5765,7 @@ alter_clause_cubrid_specific
 	| ADD       alter_add_clause_for_alter_list      resolution_list_for_alter
 	| DROP     alter_drop_clause_for_alter_list      resolution_list_for_alter
 	| inherit_resolution_list
-		{{ DBG_TRACE_GRAMMAR(alter_clause_cubrid_specific, | inherit_resolution_list);
-
+		{{
 			PT_NODE *alt = parser_get_alter_node ();
 
 			if (alt)
@@ -6195,7 +5773,6 @@ alter_clause_cubrid_specific
 			    alt->info.alter.code = PT_RENAME_RESOLUTION;
 			    alt->info.alter.super.resolution_list = $1;
 			  }
-
 		}}
 	;
 
@@ -6206,22 +5783,19 @@ opt_resolution_list_for_alter
 
 resolution_list_for_alter
 	: inherit_resolution_list
-		{{ DBG_TRACE_GRAMMAR(resolution_list_for_alter, : inherit_resolution_list );
-
+		{{
 			PT_NODE *alt = parser_get_alter_node ();
 
 			if (alt)
 			  {
 			    alt->info.alter.super.resolution_list = $1;
 			  }
-
 		}}
 	;
 
 alter_rename_clause_mysql_specific
 	: opt_to only_class_name
-		{{ DBG_TRACE_GRAMMAR(alter_rename_clause_mysql_specific, : opt_to only_class_name );
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 
 			if (node)
@@ -6229,13 +5803,12 @@ alter_rename_clause_mysql_specific
 			    node->info.alter.code = PT_RENAME_ENTITY;
 			    node->info.alter.alter_clause.rename.new_name = $2;
 			  }
-
 		}}
 	;
 
 alter_auto_increment_mysql_specific
 	: AUTO_INCREMENT '=' UNSIGNED_INTEGER
-	      {{ DBG_TRACE_GRAMMAR(alter_auto_increment_mysql_specific, : AUTO_INCREMENT '=' UNSIGNED_INTEGER );
+	      {{
 			PT_NODE *node = parser_get_alter_node ();
     			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 
@@ -6253,14 +5826,12 @@ alter_auto_increment_mysql_specific
 			    node->info.alter.code = PT_CHANGE_AUTO_INCREMENT;
 			    node->info.alter.alter_clause.auto_increment.start_value = val;
 			  }
-
 	      }}
 	;
 
 alter_rename_clause_allow_multiple
 	: opt_of_attr_column_method opt_class identifier as_or_to identifier
-		{{ DBG_TRACE_GRAMMAR(alter_rename_clause_allow_multiple, : opt_of_attr_column_method opt_class identifier as_or_to identifier);
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 			PT_MISC_TYPE etyp = $1;
 
@@ -6280,14 +5851,12 @@ alter_rename_clause_allow_multiple
 			    node->info.alter.alter_clause.rename.new_name = $5;
 			    node->info.alter.alter_clause.rename.old_name = $3;
 			  }
-
 		}}
 	;
 
 alter_rename_clause_cubrid_specific
 	: FUNCTION opt_identifier OF opt_class identifier AS identifier
-		{{ DBG_TRACE_GRAMMAR(alter_rename_clause_cubrid_specific, : FUNCTION opt_identifier OF opt_class identifier AS identifier);
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 
 			if (node)
@@ -6303,11 +5872,9 @@ alter_rename_clause_cubrid_specific
 			    node->info.alter.alter_clause.rename.mthd_name = $5;
 			    node->info.alter.alter_clause.rename.old_name = $2;
 			  }
-
 		}}
 	| File file_path_name AS file_path_name
-		{{ DBG_TRACE_GRAMMAR(alter_rename_clause_cubrid_specific, | File file_path_name AS file_path_name);
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 
 			if (node)
@@ -6317,64 +5884,48 @@ alter_rename_clause_cubrid_specific
 			    node->info.alter.alter_clause.rename.new_name = $4;
 			    node->info.alter.alter_clause.rename.old_name = $2;
 			  }
-
 		}}
 	;
 
 opt_of_attr_column_method
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_of_attr_column_method,  : );
-
+		{{
 			$$ = PT_EMPTY;
-
 		}}
 	| ATTRIBUTE
-		{{ DBG_TRACE_GRAMMAR(opt_of_attr_column_method, | ATTRIBUTE );
-
+		{{
 			$$ = PT_ATTRIBUTE;
-
 		}}
 	| COLUMN
-		{{ DBG_TRACE_GRAMMAR(opt_of_attr_column_method, | COLUMN );
-
+		{{
 			$$ = PT_ATTRIBUTE;
-
 		}}
 	| METHOD
-		{{ DBG_TRACE_GRAMMAR(opt_of_attr_column_method, | METHOD );
-
+		{{
 			$$ = PT_METHOD;
 		}}
 	;
 
 opt_class
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_class, : );
-
+		{{
 			$$ = 0;
-
 		}}
 	| CLASS
-		{{ DBG_TRACE_GRAMMAR(opt_class, | CLASS );
-
+		{{
 			$$ = 1;
-
 		}}
 	;
 
 opt_identifier
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_identifier, :);
-
+		{{
 			$$ = NULL;
-
 		}}
 	| identifier
-		{{ DBG_TRACE_GRAMMAR(opt_identifier, | identifier );
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
@@ -6384,63 +5935,55 @@ alter_add_clause_for_alter_list
 		{ parser_attr_type = PT_META_ATTR; }
 	  '(' attr_def_list ')'
 		{ parser_attr_type = PT_NORMAL; }
-		{{ DBG_TRACE_GRAMMAR(alter_add_clause_for_alter_list, | CLASS ATTRIBUTE '(' attr_def_list ')' );
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 			if (node)
 			  {
 			    node->info.alter.code = PT_ADD_ATTR_MTHD;
 			    node->info.alter.alter_clause.attr_mthd.attr_def_list = $5;
 			  }
-
 		}}
 	| CLASS ATTRIBUTE
 		{ parser_attr_type = PT_META_ATTR; }
 	  attr_def
 		{ parser_attr_type = PT_NORMAL; }
-		{{ DBG_TRACE_GRAMMAR(alter_add_clause_for_alter_list, | CLASS ATTRIBUTE attr_def );
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 			if (node)
 			  {
 			    node->info.alter.code = PT_ADD_ATTR_MTHD;
 			    node->info.alter.alter_clause.attr_mthd.attr_def_list = $4;
 			  }
-
 		}}
 	| opt_of_column_attribute
 	  		{ allow_attribute_ordering = true; }
 	  '(' attr_def_list ')'
 	  		{ allow_attribute_ordering = false; }
-		{{ DBG_TRACE_GRAMMAR(alter_add_clause_for_alter_list, | opt_of_column_attribute  '(' attr_def_list ')' );
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 			if (node)
 			  {
 			    node->info.alter.code = PT_ADD_ATTR_MTHD;
 			    node->info.alter.alter_clause.attr_mthd.attr_def_list = $4;
 			  }
-
 		}}
 	| opt_of_column_attribute
 			{ allow_attribute_ordering = true; }
 	  attr_def
 	  		{ allow_attribute_ordering = false; }
-		{{ DBG_TRACE_GRAMMAR(alter_add_clause_for_alter_list, | opt_of_column_attribute attr_def );
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 			if (node)
 			  {
 			    node->info.alter.code = PT_ADD_ATTR_MTHD;
 			    node->info.alter.alter_clause.attr_mthd.attr_def_list = $3;
 			  }
-
 		}}
 	;
 
 alter_add_clause_cubrid_specific
 	: File method_file_list
-		{{ DBG_TRACE_GRAMMAR(alter_add_clause_cubrid_specific, : File method_file_list );
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 
 			if (node)
@@ -6448,22 +5991,18 @@ alter_add_clause_cubrid_specific
 			    node->info.alter.code = PT_ADD_ATTR_MTHD;
 			    node->info.alter.alter_clause.attr_mthd.mthd_file_list = $2;
 			  }
-
 		}}
 	| METHOD method_def_list
-		{{ DBG_TRACE_GRAMMAR(alter_add_clause_cubrid_specific, | METHOD method_def_list);
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 			if (node)
 			  {
 			    node->info.alter.code = PT_ADD_ATTR_MTHD;
 			    node->info.alter.alter_clause.attr_mthd.mthd_def_list = $2;
 			  }
-
 		}}
 	| METHOD method_def_list File method_file_list
-		{{ DBG_TRACE_GRAMMAR(alter_add_clause_cubrid_specific, | METHOD method_def_list File method_file_list);
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 
 			if (node)
@@ -6472,11 +6011,9 @@ alter_add_clause_cubrid_specific
 			    node->info.alter.alter_clause.attr_mthd.mthd_file_list = $4;
 			    node->info.alter.alter_clause.attr_mthd.mthd_def_list = $2;
 			  }
-
 		}}
 	| SUPERCLASS only_class_name_list
-		{{ DBG_TRACE_GRAMMAR(alter_add_clause_cubrid_specific, | SUPERCLASS only_class_name_list );
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 
 			if (node)
@@ -6484,11 +6021,9 @@ alter_add_clause_cubrid_specific
 			    node->info.alter.code = PT_ADD_SUPCLASS;
 			    node->info.alter.super.sup_class_list = $2;
 			  }
-
 		}}
 	| QUERY csql_query opt_vclass_comment_spec
-		{{ DBG_TRACE_GRAMMAR(alter_add_clause_cubrid_specific, | QUERY csql_query opt_vclass_comment_spec );
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 
 			if (node)
@@ -6497,32 +6032,27 @@ alter_add_clause_cubrid_specific
 			    node->info.alter.alter_clause.query.query = $2;
 			    node->info.alter.alter_clause.query.view_comment = $3;
 			  }
-
 		}}
 	| CLASS ATTRIBUTE
 		{ parser_attr_type = PT_META_ATTR; }
 	  attr_def_list_with_commas
 		{ parser_attr_type = PT_NORMAL; }
-		{{ DBG_TRACE_GRAMMAR(alter_add_clause_cubrid_specific, | CLASS ATTRIBUTE attr_def_list_with_commas );
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 			if (node)
 			  {
 			    node->info.alter.code = PT_ADD_ATTR_MTHD;
 			    node->info.alter.alter_clause.attr_mthd.attr_def_list = $4;
 			  }
-
 		}}
 	| opt_of_column_attribute attr_def_list_with_commas
-		{{ DBG_TRACE_GRAMMAR(alter_add_clause_cubrid_specific, | opt_of_column_attribute attr_def_list_with_commas );
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 			if (node)
 			  {
 			    node->info.alter.code = PT_ADD_ATTR_MTHD;
 			    node->info.alter.alter_clause.attr_mthd.attr_def_list = $2;
 			  }
-
 		}}
 	;
 
@@ -6534,27 +6064,22 @@ opt_of_column_attribute
 
 add_partition_clause
 	: PARTITIONS literal_w_o_param
-		{{ DBG_TRACE_GRAMMAR(add_partition_clause, : PARTITIONS literal_w_o_param );
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 			node->info.alter.code = PT_ADD_HASHPARTITION;
 			node->info.alter.alter_clause.partition.size = $2;
-
 		}}
 	| '(' partition_def_list ')'
-		{{ DBG_TRACE_GRAMMAR(add_partition_clause, | '(' partition_def_list ')' );
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 			node->info.alter.code = PT_ADD_PARTITION;
 			node->info.alter.alter_clause.partition.parts = $2;
-
 		}}
 	;
 
 alter_drop_clause_mysql_specific
 	: opt_reverse opt_unique index_or_key identifier
-		{{ DBG_TRACE_GRAMMAR(alter_drop_clause_mysql_specific, : opt_reverse opt_unique index_or_key identifier );
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 
 			if (node)
@@ -6564,22 +6089,18 @@ alter_drop_clause_mysql_specific
 			    node->info.alter.alter_clause.index.unique = $2;
 			    node->info.alter.constraint_list = $4;
 			  }
-
 		}}
 	| PRIMARY KEY
-		{{ DBG_TRACE_GRAMMAR(alter_drop_clause_mysql_specific, | PRIMARY KEY );
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 
 			if (node)
 			  {
 			    node->info.alter.code = PT_DROP_PRIMARY_CLAUSE;
 			  }
-
 		}}
 	| FOREIGN KEY identifier
-		{{ DBG_TRACE_GRAMMAR(alter_drop_clause_mysql_specific, | FOREIGN KEY identifier );
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 
 			if (node)
@@ -6587,14 +6108,12 @@ alter_drop_clause_mysql_specific
 			    node->info.alter.code = PT_DROP_FK_CLAUSE;
 			    node->info.alter.constraint_list = $3;
 			  }
-
 		}}
 	;
 
 alter_drop_clause_for_alter_list
 	: opt_of_attr_column_method normal_or_class_attr
-		{{ DBG_TRACE_GRAMMAR(alter_drop_clause_for_alter_list, : opt_of_attr_column_method normal_or_class_attr );
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 
 			if (node)
@@ -6602,11 +6121,9 @@ alter_drop_clause_for_alter_list
 			    node->info.alter.code = PT_DROP_ATTR_MTHD;
 			    node->info.alter.alter_clause.attr_mthd.attr_mthd_name_list = $2;
 			  }
-
 		}}
 	| CONSTRAINT identifier
-		{{ DBG_TRACE_GRAMMAR(alter_drop_clause_for_alter_list, | CONSTRAINT identifier );
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 
 			if (node)
@@ -6614,11 +6131,9 @@ alter_drop_clause_for_alter_list
 			    node->info.alter.code = PT_DROP_CONSTRAINT;
 			    node->info.alter.constraint_list = $2;
 			  }
-
 		}}
 	| PARTITION identifier_list
-		{{ DBG_TRACE_GRAMMAR(alter_drop_clause_for_alter_list, | PARTITION identifier_list );
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 
 			if (node)
@@ -6626,14 +6141,12 @@ alter_drop_clause_for_alter_list
 			    node->info.alter.code = PT_DROP_PARTITION;
 			    node->info.alter.alter_clause.partition.name_list = $2;
 			  }
-
 		}}
 	;
 
 alter_drop_clause_cubrid_specific
 	: opt_of_attr_column_method normal_or_class_attr_list_with_commas
-		{{ DBG_TRACE_GRAMMAR(alter_drop_clause_cubrid_specific, : opt_of_attr_column_method normal_or_class_attr_list_with_commas);
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 
 			if (node)
@@ -6641,11 +6154,9 @@ alter_drop_clause_cubrid_specific
 			    node->info.alter.code = PT_DROP_ATTR_MTHD;
 			    node->info.alter.alter_clause.attr_mthd.attr_mthd_name_list = $2;
 			  }
-
 		}}
 	| File method_file_list
-		{{ DBG_TRACE_GRAMMAR(alter_drop_clause_cubrid_specific, | File method_file_list);
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 
 			if (node)
@@ -6653,11 +6164,9 @@ alter_drop_clause_cubrid_specific
 			    node->info.alter.code = PT_DROP_ATTR_MTHD;
 			    node->info.alter.alter_clause.attr_mthd.mthd_file_list = $2;
 			  }
-
 		}}
 	| SUPERCLASS only_class_name_list
-		{{ DBG_TRACE_GRAMMAR(alter_drop_clause_cubrid_specific, | SUPERCLASS only_class_name_list);
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 
 			if (node)
@@ -6665,11 +6174,9 @@ alter_drop_clause_cubrid_specific
 			    node->info.alter.code = PT_DROP_SUPCLASS;
 			    node->info.alter.super.sup_class_list = $2;
 			  }
-
 		}}
 	| QUERY query_number_list
-		{{ DBG_TRACE_GRAMMAR(alter_drop_clause_cubrid_specific, | QUERY query_number_list);
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 
 			if (node)
@@ -6677,11 +6184,9 @@ alter_drop_clause_cubrid_specific
 			    node->info.alter.code = PT_DROP_QUERY;
 			    node->info.alter.alter_clause.query.query_no_list = $2;
 			  }
-
 		}}
 	| QUERY
-		{{ DBG_TRACE_GRAMMAR(alter_drop_clause_cubrid_specific, | QUERY );
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 
 			if (node)
@@ -6689,24 +6194,19 @@ alter_drop_clause_cubrid_specific
 			    node->info.alter.code = PT_DROP_QUERY;
 			    node->info.alter.alter_clause.query.query_no_list = NULL;
 			  }
-
 		}}
 	;
 
 normal_or_class_attr_list_with_commas
 	: normal_or_class_attr_list_with_commas ',' normal_or_class_attr
-		{{ DBG_TRACE_GRAMMAR(normal_or_class_attr_list_with_commas, : normal_or_class_attr_list_with_commas ',' normal_or_class_attr);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| normal_or_class_attr ',' normal_or_class_attr
-		{{ DBG_TRACE_GRAMMAR(normal_or_class_attr_list_with_commas, | normal_or_class_attr ',' normal_or_class_attr);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
@@ -6715,8 +6215,7 @@ alter_modify_clause_for_alter_list
 	  { allow_attribute_ordering = true; }
 	  attr_def_one
 	  { allow_attribute_ordering = false; }
-		{{ DBG_TRACE_GRAMMAR(alter_modify_clause_for_alter_list, : opt_of_column_attribute attr_def_one);
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 
 			if (node)
@@ -6725,14 +6224,12 @@ alter_modify_clause_for_alter_list
 			    node->info.alter.alter_clause.attr_mthd.attr_def_list = $3;
 			    /* no name change for MODIFY */
 			  }
-
 		}}
 	| CLASS ATTRIBUTE
 	  { allow_attribute_ordering = true; }
 	  attr_def_one
 	  { allow_attribute_ordering = false; }
-		{{ DBG_TRACE_GRAMMAR(alter_modify_clause_for_alter_list, | CLASS ATTRIBUTE attr_def_one);
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 
 			if (node)
@@ -6744,7 +6241,6 @@ alter_modify_clause_for_alter_list
 			    node->info.alter.alter_clause.attr_mthd.attr_def_list->
 				info.attr_def.attr_type = PT_META_ATTR;
 			  }
-
 		}}
 	;
 
@@ -6753,8 +6249,7 @@ alter_change_clause_for_alter_list
 	  { allow_attribute_ordering = true; }
 	  attr_def_one
 	  { allow_attribute_ordering = false; }
-		{{ DBG_TRACE_GRAMMAR(alter_change_clause_for_alter_list, : normal_column_or_class_attribute attr_def_one);
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 
 			if (node)
@@ -6769,14 +6264,12 @@ alter_change_clause_for_alter_list
 			    att->info.attr_def.attr_type =
 			      node->info.alter.alter_clause.attr_mthd.attr_old_name->info.name.meta_class;
 			  }
-
 		}}
 	;
 
 alter_change_clause_cubrid_specific
 	: METHOD method_def_list
-		{{ DBG_TRACE_GRAMMAR(alter_change_clause_cubrid_specific, : METHOD method_def_list);
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 
 			if (node)
@@ -6784,11 +6277,9 @@ alter_change_clause_cubrid_specific
 			    node->info.alter.code = PT_MODIFY_ATTR_MTHD;
 			    node->info.alter.alter_clause.attr_mthd.mthd_def_list = $2;
 			  }
-
 		}}
 	| QUERY unsigned_integer csql_query opt_vclass_comment_spec
-		{{ DBG_TRACE_GRAMMAR(alter_change_clause_cubrid_specific, | QUERY unsigned_integer csql_query opt_vclass_comment_spec);
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 
 			if (node)
@@ -6798,11 +6289,9 @@ alter_change_clause_cubrid_specific
 			    node->info.alter.alter_clause.query.query_no_list = $2;
 			    node->info.alter.alter_clause.query.view_comment = $4;
 			  }
-
 		}}
 	| QUERY csql_query opt_vclass_comment_spec
-		{{ DBG_TRACE_GRAMMAR(alter_change_clause_cubrid_specific, | QUERY csql_query opt_vclass_comment_spec);
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 
 			if (node)
@@ -6812,11 +6301,9 @@ alter_change_clause_cubrid_specific
 			    node->info.alter.alter_clause.query.query_no_list = NULL;
 			    node->info.alter.alter_clause.query.view_comment = $3;
 			  }
-
 		}}
 	| File file_path_name AS file_path_name
-		{{ DBG_TRACE_GRAMMAR(alter_change_clause_cubrid_specific, | File file_path_name AS file_path_name);
-
+		{{
 			PT_NODE *node = parser_get_alter_node ();
 
 			if (node)
@@ -6826,14 +6313,12 @@ alter_change_clause_cubrid_specific
 			    node->info.alter.alter_clause.rename.new_name = $4;
 			    node->info.alter.alter_clause.rename.old_name = $2;
 			  }
-
 		}}
 	;
 
 normal_or_class_attr
 	: opt_class identifier
-		{{ DBG_TRACE_GRAMMAR(normal_or_class_attr, : opt_class identifier);
-
+		{{
 			if ($1)
 			  $2->info.name.meta_class = PT_META_ATTR;
 			else
@@ -6841,31 +6326,25 @@ normal_or_class_attr
 
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 query_number_list
 	: query_number_list ',' unsigned_integer
-		{{ DBG_TRACE_GRAMMAR(query_number_list, : query_number_list ',' unsigned_integer);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| unsigned_integer
-		{{ DBG_TRACE_GRAMMAR(query_number_list, | unsigned_integer);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 alter_column_clause_mysql_specific
 	: normal_column_or_class_attribute SET DEFAULT expression_
-		{{ DBG_TRACE_GRAMMAR(alter_column_clause_mysql_specific, : normal_column_or_class_attribute SET DEFAULT expression_);
-
+		{{
 			PT_NODE *alter_node = parser_get_alter_node ();
 
 			if (alter_node)
@@ -6952,14 +6431,12 @@ alter_column_clause_mysql_specific
 			    alter_node->info.alter.alter_clause.ch_attr_def.attr_name_list = $1;
 			    alter_node->info.alter.alter_clause.ch_attr_def.data_default_list = node;
 			  }
-
 		}}
 	;
 
 normal_column_or_class_attribute
 	: opt_of_column_attribute identifier
-		{{ DBG_TRACE_GRAMMAR(normal_column_or_class_attribute, : opt_of_column_attribute identifier);
-
+		{{
 			PT_NODE * node = $2;
 			if (node)
 			  {
@@ -6967,11 +6444,9 @@ normal_column_or_class_attribute
 			  }
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| CLASS ATTRIBUTE identifier
-		{{ DBG_TRACE_GRAMMAR(normal_column_or_class_attribute, | CLASS ATTRIBUTE identifier);
-
+		{{
 			PT_NODE * node = $3;
 			if (node)
 			  {
@@ -6979,14 +6454,12 @@ normal_column_or_class_attribute
 			  }
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 insert_or_replace_stmt
 	: insert_name_clause insert_stmt_value_clause on_duplicate_key_update
-		{{ DBG_TRACE_GRAMMAR(insert_or_replace_stmt, : insert_name_clause insert_stmt_value_clause on_duplicate_key_update);
-
+		{{
 			PT_NODE *ins = $1;
 
 			if (ins)
@@ -6997,11 +6470,9 @@ insert_or_replace_stmt
 
 			$$ = ins;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| insert_name_clause insert_stmt_value_clause into_clause_opt
-		{{ DBG_TRACE_GRAMMAR(insert_or_replace_stmt, | insert_name_clause insert_stmt_value_clause into_clause_opt);
-
+		{{
 			PT_NODE *ins = $1;
 
 			if (ins)
@@ -7012,11 +6483,9 @@ insert_or_replace_stmt
 
 			$$ = ins;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| replace_name_clause insert_stmt_value_clause into_clause_opt
-		{{ DBG_TRACE_GRAMMAR(insert_or_replace_stmt, | replace_name_clause insert_stmt_value_clause into_clause_opt);
-
+		{{
 			PT_NODE *ins = $1;
 
 			if (ins)
@@ -7027,11 +6496,9 @@ insert_or_replace_stmt
 
 			$$ = ins;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| insert_set_stmt on_duplicate_key_update
-		{{ DBG_TRACE_GRAMMAR(insert_or_replace_stmt, | insert_set_stmt on_duplicate_key_update);
-
+		{{
 			PT_NODE *ins = $1;
 			if (ins)
 			  {
@@ -7040,11 +6507,9 @@ insert_or_replace_stmt
 
 			$$ = ins;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| insert_set_stmt into_clause_opt
-		{{ DBG_TRACE_GRAMMAR(insert_or_replace_stmt, | insert_set_stmt into_clause_opt);
-
+		{{
 			PT_NODE *ins = $1;
 
 			if (ins)
@@ -7054,11 +6519,9 @@ insert_or_replace_stmt
 
 			$$ = ins;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| replace_set_stmt into_clause_opt
-		{{ DBG_TRACE_GRAMMAR(insert_or_replace_stmt, | replace_set_stmt into_clause_opt);
-
+		{{
 			PT_NODE *ins = $1;
 
 			if (ins)
@@ -7068,14 +6531,13 @@ insert_or_replace_stmt
 
 			$$ = ins;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 insert_set_stmt
 	: insert_stmt_keyword
 	  insert_set_stmt_header
-		{{ DBG_TRACE_GRAMMAR(insert_set_stmt, : insert_stmt_keyword insert_set_stmt_header);
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
@@ -7084,7 +6546,7 @@ insert_set_stmt
 replace_set_stmt
 	: replace_stmt_keyword
 	  insert_set_stmt_header
-		{{ DBG_TRACE_GRAMMAR(replace_set_stmt, : replace_stmt_keyword insert_set_stmt_header);
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
@@ -7092,7 +6554,7 @@ replace_set_stmt
 
 insert_stmt_keyword
 	: INSERT
-		{ DBG_TRACE_GRAMMAR(insert_stmt_keyword, : INSERT);
+		{
 			PT_NODE* ins = parser_new_node (this_parser, PT_INSERT);
 			parser_push_hint_node (ins);
 		}
@@ -7100,7 +6562,7 @@ insert_stmt_keyword
 
 replace_stmt_keyword
 	: REPLACE
-		{ DBG_TRACE_GRAMMAR(replace_stmt_keyword, : REPLACE);
+		{
 			PT_NODE* ins = parser_new_node (this_parser, PT_INSERT);
 			if (ins)
 			  {
@@ -7116,8 +6578,7 @@ insert_set_stmt_header
 	  only_class_name_or_with_server_name
 	  SET
 	  insert_assignment_list
-		{{ DBG_TRACE_GRAMMAR(insert_set_stmt_header, : opt_hint_list opt_into only_class_name_or_with_server_name SET insert_assignment_list);
-
+		{{
 			PT_NODE *ins = parser_pop_hint_node ();
 			PT_NODE *ocs = NULL;
                         PT_NODE *nls = pt_node_list (this_parser, PT_IS_VALUE, CONTAINER_AT_1 ($5));
@@ -7147,22 +6608,19 @@ insert_set_stmt_header
 
 			$$ = ins;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 insert_assignment_list
 	: insert_assignment_list ',' identifier '=' expression_
-		{{ DBG_TRACE_GRAMMAR(insert_assignment_list, : insert_assignment_list ',' identifier '=' expression_);
-
+		{{
 			parser_make_link (CONTAINER_AT_0 ($1), $3);
 			parser_make_link (CONTAINER_AT_1 ($1), $5);
 
 			$$ = $1;
-
 		}}
 	| insert_assignment_list ',' identifier '=' DEFAULT
-		{{ DBG_TRACE_GRAMMAR(insert_assignment_list, | insert_assignment_list ',' identifier '=' DEFAULT );
+		{{
 			PT_NODE *arg = parser_copy_tree (this_parser, $3);
 
 			if (arg)
@@ -7174,20 +6632,16 @@ insert_assignment_list
 					  parser_make_expression (this_parser, PT_DEFAULTF, arg, NULL, NULL));
 
 			$$ = $1;
-
 		}}
 	| identifier '=' expression_
-		{{ DBG_TRACE_GRAMMAR(insert_assignment_list, | identifier '=' expression_ );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, $1, $3);
 
 			$$ = ctn;
-
 		}}
 	| identifier '=' DEFAULT
-		{{ DBG_TRACE_GRAMMAR(insert_assignment_list, | identifier '=' DEFAULT);
-
+		{{
 			container_2 ctn;
 			PT_NODE *arg = parser_copy_tree (this_parser, $1);
 
@@ -7199,25 +6653,21 @@ insert_assignment_list
 			  parser_make_expression (this_parser, PT_DEFAULTF, arg, NULL, NULL));
 
 			$$ = ctn;
-
 		}}
 	;
 
 on_duplicate_key_update
 	: ON_ DUPLICATE_ KEY UPDATE
 	  update_assignment_list
-		{{ DBG_TRACE_GRAMMAR(on_duplicate_key_update, : ON_ DUPLICATE_ KEY UPDATE update_assignment_list);
-
+		{{
 			$$ = $5;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 insert_expression
 	: insert_name_clause insert_expression_value_clause
-		{{ DBG_TRACE_GRAMMAR(insert_expression, : insert_name_clause insert_expression_value_clause);
-
+		{{
 			PT_NODE *ins = $1;
 
 			if (ins)
@@ -7227,11 +6677,9 @@ insert_expression
 
 			$$ = ins;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| '(' insert_name_clause insert_expression_value_clause into_clause_opt ')'
-		{{ DBG_TRACE_GRAMMAR(insert_expression, | '(' insert_name_clause insert_expression_value_clause into_clause_opt ')');
-
+		{{
 			PT_NODE *ins = $2;
 
 			if (ins)
@@ -7242,14 +6690,13 @@ insert_expression
 
 			$$ = ins;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 insert_name_clause
 	: insert_stmt_keyword
 	  insert_name_clause_header
-		{{ DBG_TRACE_GRAMMAR(insert_name_clause, : insert_stmt_keyword insert_name_clause_header);
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
@@ -7258,7 +6705,7 @@ insert_name_clause
 replace_name_clause
 	: replace_stmt_keyword
 	  insert_name_clause_header
-		{{ DBG_TRACE_GRAMMAR(replace_name_clause, : replace_stmt_keyword insert_name_clause_header);
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
@@ -7270,8 +6717,7 @@ insert_name_clause_header
 	  only_class_name_or_with_server_name
 	  opt_partition_spec
 	  opt_attr_list
-		{{ DBG_TRACE_GRAMMAR(insert_name_clause_header, : opt_hint_list opt_into only_class_name_or_with_server_name opt_partition_spec opt_attr_list);
-
+		{{
 			PT_NODE *ins = parser_pop_hint_node ();
 			PT_NODE *ocs = NULL;
 
@@ -7303,66 +6749,50 @@ insert_name_clause_header
 
 			$$ = ins;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_attr_list
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_attr_list, :);
-
+		{{
 			$$ = NULL;
-
 		}}
 	| '(' ')'
-		{{ DBG_TRACE_GRAMMAR(opt_attr_list, | '(' ')' );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| '(' identifier_list ')'
-		{{ DBG_TRACE_GRAMMAR(opt_attr_list, | '(' identifier_list ')' );
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_path_attr_list
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_path_attr_list, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| '(' ')'
-		{{ DBG_TRACE_GRAMMAR(opt_path_attr_list, |  '(' ')' );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| '(' simple_path_id_list ')'
-		{{ DBG_TRACE_GRAMMAR(opt_path_attr_list, | '(' simple_path_id_list ')' );
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 insert_stmt_value_clause
 	: insert_expression_value_clause
-		{{ DBG_TRACE_GRAMMAR(insert_stmt_value_clause, : insert_expression_value_clause );
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| opt_with_clause
 	  csql_query_without_values_and_single_subquery
-		{{ DBG_TRACE_GRAMMAR(insert_stmt_value_clause, |  opt_with_clause csql_query_without_values_and_single_subquery);
-
+		{{
 			PT_NODE *with_clause = $1;
 			PT_NODE *select_node = $2;
 			select_node->info.query.with = with_clause;
@@ -7370,11 +6800,10 @@ insert_stmt_value_clause
 
 			$$ = nls;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| '(' opt_with_clause
 	  csql_query_without_values_query_no_with_clause ')'
-		{{ DBG_TRACE_GRAMMAR(insert_stmt_value_clause, |  '(' opt_with_clause csql_query_without_values_query_no_with_clause ')');
+		{{
 			PT_NODE *with_clause = $2;
 			PT_NODE *select_node = $3;
 			select_node->info.query.with = with_clause;
@@ -7382,25 +6811,20 @@ insert_stmt_value_clause
 
 			$$ = nls;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 insert_expression_value_clause
 	: of_value_values insert_value_clause_list
-		{{ DBG_TRACE_GRAMMAR(insert_expression_value_clause, : of_value_values insert_value_clause_list);
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| DEFAULT opt_values
-		{{ DBG_TRACE_GRAMMAR(insert_expression_value_clause, | DEFAULT opt_values);
-
+		{{
 			PT_NODE *nls = pt_node_list (this_parser, PT_IS_DEFAULT_VALUE, NULL);
 			$$ = nls;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
@@ -7421,55 +6845,43 @@ opt_into
 
 into_clause_opt
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(into_clause_opt, : );
+		{{
 			$$ = NULL;
-
 		}}
 	| INTO to_param
-		{{ DBG_TRACE_GRAMMAR(into_clause_opt, | INTO to_param );
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| TO to_param
-		{{ DBG_TRACE_GRAMMAR(into_clause_opt, | TO to_param );
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 insert_value_clause_list
 	: insert_value_clause_list ',' insert_value_clause
-		{{ DBG_TRACE_GRAMMAR(insert_value_clause_list, : insert_value_clause_list ',' insert_value_clause);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| insert_value_clause
-		{{ DBG_TRACE_GRAMMAR(insert_value_clause_list, | insert_value_clause);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 insert_value_clause
 	: '(' insert_value_list ')'
-		{{ DBG_TRACE_GRAMMAR(insert_value_clause, : '(' insert_value_list ')' );
-
+		{{
 			PT_NODE *nls = pt_node_list (this_parser, PT_IS_VALUE, $2);
 			$$ = nls;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| '('')'
-		{{ DBG_TRACE_GRAMMAR(insert_value_clause, | '('')' );
-
+		{{
 			PT_NODE *nls = NULL;
 
 			if (prm_get_integer_value (PRM_ID_COMPAT_MODE) == COMPAT_MYSQL)
@@ -7483,59 +6895,46 @@ insert_value_clause
 
 			$$ = nls;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| DEFAULT opt_values
-		{{ DBG_TRACE_GRAMMAR(insert_value_clause, | DEFAULT opt_values);
-
+		{{
 			PT_NODE *nls = pt_node_list (this_parser, PT_IS_DEFAULT_VALUE, NULL);
 			$$ = nls;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 insert_value_list
 	: insert_value_list ',' insert_value
-		{{ DBG_TRACE_GRAMMAR(insert_value_list, : insert_value_list ',' insert_value);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| insert_value
-		{{ DBG_TRACE_GRAMMAR(insert_value_list, | insert_value);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 insert_value
 	: select_stmt
-		{{ DBG_TRACE_GRAMMAR(insert_value, : select_stmt);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| normal_expression
-		{{ DBG_TRACE_GRAMMAR(insert_value, | normal_expression);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| DEFAULT
-		{{ DBG_TRACE_GRAMMAR(insert_value, | DEFAULT);
-
+		{{
 			/* The argument will be filled in later, when the
 			   corresponding column name is known.
 			   See fill_in_insert_default_function_arguments(). */
 			$$ = parser_make_expression (this_parser, PT_DEFAULTF, NULL, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
@@ -7543,8 +6942,7 @@ show_stmt
 	: SHOW
 	  opt_full
 	  TABLES
-		{{ DBG_TRACE_GRAMMAR(show_stmt, : SHOW opt_full TABLES);
-
+		{{
 			const bool is_full_syntax = ($2 == 1);
 			const int like_where_syntax = 0;  /* neither LIKE nor WHERE */
 			PT_NODE *node = NULL;
@@ -7553,15 +6951,13 @@ show_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SHOW
 	  opt_full
 	  TABLES
 	  LIKE
 	  expression_
-		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW opt_full TABLES LIKE expression_);
-
+		{{
 			const bool is_full_syntax = ($2 == 1);
 			const int like_where_syntax = 1;  /* is LIKE */
 			PT_NODE *node = NULL;
@@ -7571,15 +6967,13 @@ show_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SHOW
 	  opt_full
 	  TABLES
 	  WHERE
 	  search_condition
-		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW opt_full TABLES WHERE search_condition);
-
+		{{
 			const bool is_full_syntax = ($2 == 1);
 			const int like_where_syntax = 2;  /* is WHERE */
 			PT_NODE *node = NULL;
@@ -7589,15 +6983,13 @@ show_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SHOW
 	  opt_full
 	  COLUMNS
 	  of_from_in
 	  class_name
-		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW opt_full COLUMNS of_from_in class_name);
-
+		{{
 			const bool is_full_syntax = ($2 == 1);
 			const int like_where_syntax = 0;  /* neither LIKE nor WHERE */
 			PT_NODE *node = NULL;
@@ -7608,7 +7000,6 @@ show_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SHOW
 	  opt_full
@@ -7617,8 +7008,7 @@ show_stmt
 	  class_name
 	  LIKE
 	  expression_
-		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW opt_full COLUMNS  of_from_in identifier LIKE expression_);
-
+		{{
 			const bool is_full_syntax = ($2 == 1);
 			const int like_where_syntax = 1;  /* is LIKE */
 			PT_NODE *node = NULL;
@@ -7630,7 +7020,6 @@ show_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SHOW
 	  opt_full
@@ -7639,8 +7028,7 @@ show_stmt
 	  class_name
 	  WHERE
 	  search_condition
-		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW opt_full COLUMNS of_from_in identifier WHERE search_condition);
-
+		{{
 			const bool is_full_syntax = ($2 == 1);
 			const int like_where_syntax = 2;  /* is WHERE */
 			PT_NODE *node = NULL;
@@ -7652,12 +7040,10 @@ show_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| of_describe_desc_explain
 	  class_name
-		{{ DBG_TRACE_GRAMMAR(show_stmt, | of_describe_desc_explain class_name);
-
+		{{
 			PT_NODE *node = NULL;
 			PT_NODE *original_cls_id = $2;
 
@@ -7666,13 +7052,11 @@ show_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| of_describe_desc_explain
 	  class_name
 	  identifier
-		{{ DBG_TRACE_GRAMMAR(show_stmt, | of_describe_desc_explain identifier identifier);
-
+		{{
 			PT_NODE *node = NULL;
 			PT_NODE *original_cls_id = $2;
 			PT_NODE *attr = $3;
@@ -7681,13 +7065,11 @@ show_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| of_describe_desc_explain
 	  class_name
 	  char_string_literal
-		{{ DBG_TRACE_GRAMMAR(show_stmt, | of_describe_desc_explain identifier char_string_literal);
-
+		{{
 			int like_where_syntax = 0;
 			PT_NODE *node = NULL;
 			PT_NODE *original_cls_id = $2;
@@ -7702,26 +7084,22 @@ show_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SHOW
 	  COLLATION
-		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW COLLATION);
-
+		{{
 			PT_NODE *node = NULL;
 
 			node = pt_make_query_show_collation (this_parser, 0, NULL);
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SHOW
 	  COLLATION
 	  LIKE
 	  expression_
-		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW COLLATION LIKE expression_);
-
+		{{
 			const int like_where_syntax = 1;  /* is LIKE */
 			PT_NODE *node = NULL;
 			PT_NODE *like_rhs = $4;
@@ -7732,13 +7110,12 @@ show_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SHOW
 	  COLLATION
 	  WHERE
 	  search_condition
-		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW COLLATION WHERE search_condition);
+		{{
 			const int like_where_syntax = 2;  /* is WHERE */
 			PT_NODE *node = NULL;
 			PT_NODE *where_cond = $4;
@@ -7749,27 +7126,23 @@ show_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SHOW
 	  CREATE
 	  TABLE
 	  class_name
-		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW CREATE TABLE class_name);
-
+		{{
 			PT_NODE *node = NULL;
 			node = pt_make_query_show_create_table (this_parser, $4);
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SHOW
 	  CREATE
 	  VIEW
 	  class_name
-		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW CREATE VIEW class_name);
-
+		{{
 			PT_NODE *node = NULL;
 			PT_NODE *view_id = $4;
 
@@ -7777,14 +7150,12 @@ show_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SHOW
 	  GRANTS
 	  For
 	  identifier
-		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW GRANTS For identifier);
-
+		{{
 			PT_NODE *node = NULL;
 			PT_NODE *user_id = $4;
 
@@ -7795,27 +7166,23 @@ show_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SHOW
 	  GRANTS
 	  opt_for_current_user
-		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW GRANTS opt_for_current_user);
-
+		{{
 			PT_NODE *node = NULL;
 
 			node = pt_make_query_show_grants_curr_usr (this_parser);
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SHOW
 	  of_index_indexes_keys
 	  of_from_in
 	  class_name
-		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW of_index_indexes_keys of_from_in class_name);
-
+		{{
 			PT_NODE *node = NULL;
 			PT_NODE *table_id = $4;
 
@@ -7825,46 +7192,41 @@ show_stmt
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
 	| SHOW EXEC STATISTICS ALL
-		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW EXEC STATISTICS ALL);
+		{{
 			PT_NODE *node = NULL;
 
 			node = pt_make_query_show_exec_stats_all (this_parser);
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SHOW EXEC STATISTICS
-		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW EXEC STATISTICS);
+		{{
 			PT_NODE *node = NULL;
 
 			node = pt_make_query_show_exec_stats (this_parser);
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SHOW TRACE
-		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW TRACE);
+		{{
 			PT_NODE *node = NULL;
 
 			node = pt_make_query_show_trace (this_parser);
 
 			$$ = node;
-
 		}}
 	| SHOW show_type
-		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW show_type);
+		{{
 			int type = $2;
 			PT_NODE *node = pt_make_query_showstmt (this_parser, type, NULL, 0, NULL);
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SHOW show_type_of_like LIKE expression_
-		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW show_type_of_like LIKE expression_);
-
+		{{
 			const int like_where_syntax = 1;  /* is LIKE */
 			int type = $2;
 			PT_NODE *like_rhs = $4;
@@ -7873,10 +7235,9 @@ show_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SHOW show_type_of_where WHERE search_condition
-		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW show_type_of_where WHERE search_condition);
+		{{
 			const int like_where_syntax = 2;  /* is WHERE */
 			int type = $2;
 			PT_NODE *where_cond = $4;
@@ -7885,20 +7246,18 @@ show_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SHOW show_type_arg1 OF arg_value
-		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW show_type_arg1 OF arg_value);
+		{{
 			int type = $2;
 			PT_NODE *args = $4;
 			PT_NODE *node = pt_make_query_showstmt (this_parser, type, args, 0, NULL);
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SHOW show_type_arg1_opt opt_arg_value
-		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW show_type_arg1_opt opt_arg_value);
+		{{
 			PT_NODE *node = NULL;
 			int type = $2;
 			PT_NODE *args = $3;
@@ -7907,10 +7266,9 @@ show_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SHOW show_type_arg_named of_or_where named_args
-		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW show_type_arg_named of_or_where named_args);
+		{{
 			PT_NODE *node = NULL;
 			int type = $2;
 			PT_NODE *args = $4;
@@ -7919,7 +7277,6 @@ show_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SHOW show_type_id OF class_name
 		{{
@@ -7930,10 +7287,9 @@ show_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SHOW show_type_id_dot_id OF class_name DOT identifier
-		{{ DBG_TRACE_GRAMMAR(show_stmt, | SHOW show_type_id_dot_id OF class_name DOT identifier);
+		{{
 			int type = $2;
 			PT_NODE *node, *args = $4;
 
@@ -7942,13 +7298,12 @@ show_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 kill_stmt
 	: KILL arg_value_list
-		{{ DBG_TRACE_GRAMMAR(kill_stmt, | KILL arg_value_list);
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_KILL_STMT);
 
 			if (node)
@@ -7958,10 +7313,9 @@ kill_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| KILL kill_type arg_value_list
-		{{ DBG_TRACE_GRAMMAR(kill_stmt, | KILL kill_type arg_value_list);
+		{{
 			int type = $2;
 			PT_NODE *node = parser_new_node (this_parser, PT_KILL_STMT);
 
@@ -7973,7 +7327,6 @@ kill_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
@@ -8138,29 +7491,29 @@ kill_type
 
 of_or_where
 	: OF
-		{{ DBG_TRACE_GRAMMAR(of_or_where, : OF );
+		{{
 			$$ = NULL;
 		}}
 	| WHERE
-		{{ DBG_TRACE_GRAMMAR(of_or_where, | WHERE);
+		{{
 			$$ = NULL;
 		}}
 	;
 
 named_args
 	: named_arg
-		{{ DBG_TRACE_GRAMMAR(named_args, | named_arg);
+		{{
 			$$ = $1;
 		}}
 	| named_args AND named_arg
-		{{ DBG_TRACE_GRAMMAR(named_args, | named_args AND named_arg);
+		{{
 			$$ = parser_make_link ($1, $3);
 		}}
 	;
 
 named_arg
 	: identifier '=' arg_value
-		{{ DBG_TRACE_GRAMMAR(named_arg, | identifier '=' arg_value);
+		{{
 			PT_NODE * node = parser_new_node (this_parser, PT_NAMED_ARG);
 			node->info.named_arg.name = $1;
 			node->info.named_arg.value = $3;
@@ -8170,7 +7523,7 @@ named_arg
 
 opt_arg_value
 	:
-		{{ DBG_TRACE_GRAMMAR(opt_arg_value, : );
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 			if (node)
 			  node->type_enum = PT_TYPE_NULL;
@@ -8178,55 +7531,47 @@ opt_arg_value
 			$$ = node;
 		}}
 	| OF arg_value
-		{{ DBG_TRACE_GRAMMAR(opt_arg_value, | OF arg_value);
+		{{
 			$$ = $2;
 		}}
 	;
 
 arg_value_list
 	: arg_value_list ','  arg_value
-		{{ DBG_TRACE_GRAMMAR(arg_value_list, : arg_value_list ','  arg_value);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| arg_value
-		{{ DBG_TRACE_GRAMMAR(arg_value_list, | arg_value);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 arg_value
 	: char_string_literal
-		{{ DBG_TRACE_GRAMMAR(arg_value, : char_string_literal);
+		{{
 			$$ = $1;
 		}}
 	| unsigned_integer
-		{{ DBG_TRACE_GRAMMAR(arg_value, | unsigned_integer);
+		{{
 			$$ = $1;
 		}}
 	| identifier
-		{{ DBG_TRACE_GRAMMAR(arg_value, | identifier);
+		{{
 			$$ = $1;
 		}}
 	;
 
 opt_full
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_full, : );
-
+		{{
 			$$ = 0;
-
 		}}
 	| FULL
-		{{ DBG_TRACE_GRAMMAR(arg_vopt_fullalue, | FULL);
-
+		{{
 			$$ = 1;
-
 		}}
 	;
 
@@ -8255,7 +7600,7 @@ of_index_indexes_keys
 
 update_head
 	: UPDATE
-		{ DBG_TRACE_GRAMMAR(update_head, : UPDATE);
+		{
 			PT_NODE* node = parser_new_node(this_parser, PT_UPDATE);
 			parser_push_hint_node(node);
 		}
@@ -8264,7 +7609,7 @@ update_head
 
 update_stmt
 	: update_head
-		{ DBG_TRACE_GRAMMAR(update_stmt, : update_head);
+		{
 			PT_NODE * node = parser_pop_hint_node();
 			parser_push_orderby_node (node);
 			parser_push_hint_node (node);
@@ -8276,8 +7621,7 @@ update_stmt
 	  opt_using_index_clause
 	  opt_update_orderby_clause
 	  opt_upd_del_limit_clause
-		{{ DBG_TRACE_GRAMMAR(update_stmt, extended_table_spec_list SET update_assignment_list ~ );
-
+		{{
 			PT_NODE *node = parser_pop_hint_node ();
 
 			node->info.update.spec = CONTAINER_AT_0 ($3);
@@ -8369,15 +7713,13 @@ update_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| update_head
 	  OBJECT
 	  from_param
 	  SET
 	  update_assignment_list
-		{{ DBG_TRACE_GRAMMAR(update_stmt, | update_head OBJECT from_param SET update_assignment_list);
-
+		{{
 			PT_NODE *node = parser_pop_hint_node ();
 			if (node)
 			  {
@@ -8387,95 +7729,75 @@ update_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 
 opt_of_where_cursor
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_of_where_cursor, : );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, 0, NULL);
 			$$ = ctn;
-
 		}}
 	| WHERE
-		{ DBG_TRACE_GRAMMAR(opt_of_where_cursor, | WHERE );
+		{
 			parser_save_and_set_ic(1);
-			}
+		}
 	  search_condition
 	  	{
 			parser_restore_ic();
-			}
-		{{ DBG_TRACE_GRAMMAR(opt_of_where_cursor, search_condition);
-
+		}
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (1), $3);
 			$$ = ctn;
-
 		}}
 	| WHERE CURRENT OF identifier
-		{{ DBG_TRACE_GRAMMAR(opt_of_where_cursor, | WHERE CURRENT OF identifier);
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (0), $4);
 			$$ = ctn;
-
 		}}
 	;
 
 opt_as_identifier
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_as_identifier, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| AS identifier
-		{{ DBG_TRACE_GRAMMAR(opt_as_identifier, | AS identifier);
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| identifier
-		{{ DBG_TRACE_GRAMMAR(opt_as_identifier, | identifier);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 update_assignment_list
 	: update_assignment_list ',' update_assignment
-		{{ DBG_TRACE_GRAMMAR(update_assignment_list, : update_assignment_list ',' update_assignment);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| update_assignment
-		{{ DBG_TRACE_GRAMMAR(update_assignment_list, | update_assignment);
-
+		{{
 			$$ = $1;
-
 		}}
 	;
 
 update_assignment
 	: path_expression '=' expression_
-		{{ DBG_TRACE_GRAMMAR(update_assignment, : path_expression '=' expression_);
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_ASSIGN, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| simple_path_id '=' DEFAULT
-		{{ DBG_TRACE_GRAMMAR("update_assignment", "| simple_path_id '=' DEFAULT ");
-
+		{{
 			PT_NODE *node, *node_df = NULL;
 			node = parser_copy_tree (this_parser, $1);
 			if (node)
@@ -8485,11 +7807,9 @@ update_assignment
 			  }
 			$$ = parser_make_expression (this_parser, PT_ASSIGN, $1, node_df, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| paren_path_expression_set '=' primary_w_collate
-		{{ DBG_TRACE_GRAMMAR(update_assignment, | paren_path_expression_set '=' primary_w_collate);
-
+		{{
 			PT_NODE *exp = parser_make_expression (this_parser, PT_ASSIGN, $1, NULL, NULL);
 			PT_NODE *arg1, *arg2, *list, *tmp;
 			PT_NODE *e1, *e2 = NULL, *e1_next, *e2_next;
@@ -8594,14 +7914,12 @@ update_assignment
 					   pt_show_binopcode (PT_ASSIGN));
 			      }
 			  }
-
 		}}
 	;
 
 paren_path_expression_set
 	: '(' path_expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(paren_path_expression_set, : '(' path_expression_list ')');
-
+		{{
 			PT_NODE *p = parser_new_node (this_parser, PT_EXPR);
 
 			if (p)
@@ -8613,21 +7931,17 @@ paren_path_expression_set
 
 			$$ = p;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 path_expression_list
 	: path_expression_list ',' path_expression
-		{{ DBG_TRACE_GRAMMAR(path_expression_list, : path_expression_list ',' path_expression);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| path_expression
-		{{ DBG_TRACE_GRAMMAR(path_expression_list, | path_expression);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
@@ -8635,82 +7949,66 @@ path_expression_list
 
 delete_name
 	: identifier
-		{{ DBG_TRACE_GRAMMAR(delete_name, : identifier);
-
+		{{
 			PT_NODE *node = $1;
 			node->info.name.meta_class = PT_CLASS;
 
 			$$ = node;
-
 		}}
 	| identifier DOT '*'
-		{{ DBG_TRACE_GRAMMAR(delete_name, | identifier DOT '*');
-
+		{{
 			PT_NODE *node = $1;
 			node->info.name.meta_class = PT_CLASS;
 
 			$$ = node;
-
 		}}
 	;
 
 delete_name_list
 	: delete_name_list ',' delete_name
-		{{ DBG_TRACE_GRAMMAR(delete_name_list, : delete_name_list ',' delete_name);
-
+		{{
 			$$ = parser_make_link ($1, $3);
-
 		}}
 	| delete_name
-		{{ DBG_TRACE_GRAMMAR(delete_name_list, | delete_name);
-
+		{{
 			$$ = $1;
-
 		}}
 	;
 
 delete_from_using
 	: delete_name_list FROM extended_table_spec_list
-		{{ DBG_TRACE_GRAMMAR(delete_from_using, : delete_name_list FROM extended_table_spec_list);
-
+		{{
 			container_3 ctn;
 			SET_CONTAINER_3(ctn, $1, CONTAINER_AT_0 ($3), CONTAINER_AT_1 ($3));
 
 			$$ = ctn;
-
 		}}
 	| FROM delete_name_list USING extended_table_spec_list
-		{{ DBG_TRACE_GRAMMAR(delete_from_using, | FROM delete_name_list USING extended_table_spec_list);
-
+		{{
 			container_3 ctn;
 			SET_CONTAINER_3(ctn, $2, CONTAINER_AT_0 ($4), CONTAINER_AT_1 ($4));
 
 			$$ = ctn;
-
 		}}
 	| FROM table_spec
-		{{ DBG_TRACE_GRAMMAR(delete_from_using, | FROM table_spec);
-
+		{{
 			container_3 ctn;
 			SET_CONTAINER_3(ctn, NULL, $2, FROM_NUMBER(0));
 
 			$$ = ctn;
-
 		}}
 	| table_spec
-		{{ DBG_TRACE_GRAMMAR(delete_from_using, | table_spec);
-
+		{{
 			container_3 ctn;
 			SET_CONTAINER_3(ctn, NULL, $1, FROM_NUMBER(0));
 
 			$$ = ctn;
-
 		}}
 	;
 
 delete_stmt
 	: DELETE_				/* $1 */
-		{ DBG_TRACE_GRAMMAR(delete_stmt, : DELETE_); /* $2 */
+		{ /* $2 */
 			PT_NODE* node = parser_new_node(this_parser, PT_DELETE);
 			parser_push_hint_node(node);
 		}
@@ -8719,8 +8017,7 @@ delete_stmt
 	  opt_of_where_cursor 			/* $5 */
 	  opt_using_index_clause 		/* $6 */
 	  opt_upd_del_limit_clause		/* $7 */
-		{{ DBG_TRACE_GRAMMAR(delete_stmt, opt_hint_list delete_from_using opt_of_where_cursor opt_using_index_clause  opt_upd_del_limit_clause);
-
+		{{
 			PT_NODE *del = parser_pop_hint_node ();
 
 			if (del)
@@ -8812,13 +8109,12 @@ delete_stmt
 			  }
 			$$ = del;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 merge_stmt
 	: MERGE					/* $1 */
-		{ DBG_TRACE_GRAMMAR(merge_stmt, : MERGE); /* $2 */
+		{				/* $2 */
 			PT_NODE *merge = parser_new_node (this_parser, PT_MERGE);
 			parser_push_hint_node (merge);
 		}
@@ -8830,8 +8126,7 @@ merge_stmt
 	  ON_					/* $8 */
 	  search_condition			/* $9 */
 	  merge_update_insert_clause		/* $10 */
-		{{ DBG_TRACE_GRAMMAR(merge_stmt, opt_hint_list INTO  table_spec USING table_spec ON_ search_condition merge_update_insert_clause);
-
+		{{
 			PT_NODE *merge = parser_pop_hint_node ();
 			if (merge)
 			  {
@@ -8842,24 +8137,23 @@ merge_stmt
 
 			$$ = merge;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 merge_update_insert_clause
 	: merge_update_clause
-		{{ DBG_TRACE_GRAMMAR(merge_update_insert_clause, : merge_update_clause);
+		{{
 		}}
 	| merge_insert_clause
-		{{ DBG_TRACE_GRAMMAR(merge_update_insert_clause, | merge_insert_clause);
+		{{
 		}}
 	| merge_update_clause
 	  merge_insert_clause
-		{{ DBG_TRACE_GRAMMAR(merge_update_insert_clause, | merge_update_clause merge_insert_clause);
+		{{
 		}}
 	| merge_insert_clause
 	  merge_update_clause
-		{{ DBG_TRACE_GRAMMAR(merge_update_insert_clause, | merge_insert_clause merge_update_clause);
+		{{
 		}}
 	;
 
@@ -8868,8 +8162,7 @@ merge_update_clause
 	  update_assignment_list		/* $6 */
 	  opt_where_clause			/* $7 */
 	  opt_merge_delete_clause		/* $8 */
-		{{ DBG_TRACE_GRAMMAR(merge_update_clause, : WHEN MATCHED THEN UPDATE SET update_assignment_list ~);
-
+		{{
 			PT_NODE *merge = parser_top_hint_node ();
 			if (merge)
 			  {
@@ -8881,7 +8174,6 @@ merge_update_clause
 				merge->info.merge.update.has_delete = true;
 			      }
 			  }
-
 		}}
 	;
 
@@ -8890,8 +8182,7 @@ merge_insert_clause
 	  opt_path_attr_list			/* $6 */
 	  insert_expression_value_clause	/* $7 */
 	  opt_where_clause			/* $8 */
-		{{ DBG_TRACE_GRAMMAR(merge_insert_clause, : WHEN NOT MATCHED THEN INSERT ~ insert_expression_value_clause ~);
-
+		{{
 			PT_NODE *merge = parser_top_hint_node ();
 			if (merge)
 			  {
@@ -8899,30 +8190,24 @@ merge_insert_clause
 			    merge->info.merge.insert.value_clauses = $7;
 			    merge->info.merge.insert.search_cond = $8;
 			  }
-
 		}}
 	;
 
 opt_merge_delete_clause
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_merge_delete_clause, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| DELETE_ WHERE search_condition
-		{{ DBG_TRACE_GRAMMAR(opt_merge_delete_clause, | DELETE_ WHERE search_condition);
-
+		{{
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 auth_stmt
 	 : grant_head opt_with_grant_option
-		{{ DBG_TRACE_GRAMMAR(auth_stmt, : grant_head opt_with_grant_option);
-
+		{{
 			PT_NODE *node = $1;
 			PT_MISC_TYPE w = PT_NO_GRANT_OPTION;
 			if ($2)
@@ -8935,11 +8220,9 @@ auth_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| revoke_cmd on_class_list from_id_list
-		{{ DBG_TRACE_GRAMMAR(auth_stmt, | revoke_cmd on_class_list from_id_list);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_REVOKE);
 
 			if (node)
@@ -8951,11 +8234,9 @@ auth_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| revoke_cmd from_id_list on_class_list
-		{{ DBG_TRACE_GRAMMAR(auth_stmt, | revoke_cmd from_id_list on_class_list);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_REVOKE);
 
 			if (node)
@@ -8967,11 +8248,9 @@ auth_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
         | revoke_proc_cmd procedure_or_function_name_list from_id_list
-		{{ DBG_TRACE_GRAMMAR(auth_stmt, | revoke_proc_cmd procedure_or_function_name_list from_id_list);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_REVOKE);
 
 			if (node)
@@ -8983,7 +8262,6 @@ auth_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
@@ -8992,8 +8270,7 @@ revoke_cmd
 		{ push_msg(MSGCAT_SYNTAX_MISSING_AUTH_COMMAND_LIST); }
 	  author_cmd_list
 		{ pop_msg(); }
-		{ DBG_TRACE_GRAMMAR(revoke_cmd, : REVOKE author_cmd_list);
-                  $$ = $3; }
+		{ $$ = $3; }
 	;
 
 grant_cmd
@@ -9001,16 +8278,14 @@ grant_cmd
 		{ push_msg(MSGCAT_SYNTAX_MISSING_AUTH_COMMAND_LIST); }
 	  author_cmd_list
 		{ pop_msg(); }
-		{ DBG_TRACE_GRAMMAR(grant_cmd, : GRANT author_cmd_list);
-                  $$ = $3; }
+		{ $$ = $3; }
 
 grant_proc_cmd
         : GRANT
 		{ push_msg(MSGCAT_SYNTAX_MISSING_AUTH_COMMAND_LIST); }
 	  authorized_execute_procedure_cmd
 		{ pop_msg(); }
-		{ DBG_TRACE_GRAMMAR(grant_proc_cmd, : GRANT authorized_execute_procedure_cmd);
-                  $$ = $3; }
+		{ $$ = $3; }
 	;
 
 revoke_proc_cmd
@@ -9018,14 +8293,12 @@ revoke_proc_cmd
 		{ push_msg(MSGCAT_SYNTAX_MISSING_AUTH_COMMAND_LIST); }
 	  authorized_execute_procedure_cmd
 		{ pop_msg(); }
-		{ DBG_TRACE_GRAMMAR(revoke_proc_cmd, : REVOKE authorized_execute_procedure_cmd);
-                  $$ = $3; }
+		{ $$ = $3; }
 	;
 
 grant_head
 	: grant_cmd on_class_list to_id_list
-		{{ DBG_TRACE_GRAMMAR(grant_head, : grant_cmd on_class_list to_id_list);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_GRANT);
 
 			if (node)
@@ -9037,11 +8310,9 @@ grant_head
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| grant_cmd to_id_list on_class_list
-		{{ DBG_TRACE_GRAMMAR(grant_head, | grant_cmd to_id_list on_class_list);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_GRANT);
 
 			if (node)
@@ -9053,11 +8324,9 @@ grant_head
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
         | grant_cmd to_id_list
-		{{ DBG_TRACE_GRAMMAR(grant_head, | grant_cmd to_id_list);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_GRANT);
 
 			if (node)
@@ -9069,11 +8338,9 @@ grant_head
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
         | grant_proc_cmd procedure_or_function_name_list to_id_list
-		{{ DBG_TRACE_GRAMMAR(grant_head, | grant_proc_cmd procedure_or_function_name_list to_id_list);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_GRANT);
 
 			if (node)
@@ -9085,22 +8352,17 @@ grant_head
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_with_grant_option
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_with_grant_option, : );
-
+		{{
 			$$ = 0;
-
 		}}
 	| WITH GRANT OPTION
-		{{ DBG_TRACE_GRAMMAR(opt_with_grant_option, | WITH GRANT OPTION);
-
+		{{
 			$$ = 1;
-
 		}}
 	;
 
@@ -9109,8 +8371,7 @@ on_class_list
 		{ push_msg(MSGCAT_SYNTAX_MISSING_CLASS_SPEC_LIST); }
 	  class_spec_list
 		{ pop_msg(); }
-		{ DBG_TRACE_GRAMMAR(on_class_list, : ON_ class_spec_list);
-                  $$ = $3; }
+		{ $$ = $3; }
 	;
 
 to_id_list
@@ -9118,8 +8379,7 @@ to_id_list
 		{ push_msg(MSGCAT_SYNTAX_MISSING_IDENTIFIER_LIST); }
 	  identifier_list
 		{ pop_msg(); }
-		{ DBG_TRACE_GRAMMAR(to_id_list, : TO identifier_list);
-                  $$ = $3; }
+		{ $$ = $3; }
 	;
 
 from_id_list
@@ -9127,24 +8387,19 @@ from_id_list
 		{ push_msg(MSGCAT_SYNTAX_MISSING_IDENTIFIER_LIST); }
 	  identifier_list
 		{ pop_msg(); }
-		{ DBG_TRACE_GRAMMAR(from_id_list, : FROM identifier_list);
-                  $$ = $3; }
+		{ $$ = $3; }
 	;
 
 author_cmd_list
 	: author_cmd_list ',' authorized_cmd
-		{{ DBG_TRACE_GRAMMAR(author_cmd_list, : author_cmd_list ',' authorized_cmd);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| authorized_cmd
-		{{ DBG_TRACE_GRAMMAR(author_cmd_list, | authorized_cmd);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
@@ -9164,18 +8419,15 @@ authorized_execute_procedure_cmd
 
 authorized_cmd
 	: SELECT
-		{{ DBG_TRACE_GRAMMAR(authorized_cmd, : SELECT);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_AUTH_CMD);
 			node->info.auth_cmd.auth_cmd = PT_SELECT_PRIV;
 			node->info.auth_cmd.attr_mthd_list = NULL;
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| INSERT
-		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | INSERT);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_AUTH_CMD);
 
 			if (node)
@@ -9186,11 +8438,9 @@ authorized_cmd
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| INDEX
-		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | INDEX);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_AUTH_CMD);
 
 			if (node)
@@ -9201,11 +8451,9 @@ authorized_cmd
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| DELETE_
-		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | DELETE_);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_AUTH_CMD);
 
 			if (node)
@@ -9216,12 +8464,10 @@ authorized_cmd
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 
 	| UPDATE '(' identifier_list ')'
-		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | UPDATE '(' identifier_list ')');
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_AUTH_CMD);
 			PARSER_SAVE_ERR_CONTEXT (node, @$.buffer_pos)
 			if (node)
@@ -9235,11 +8481,9 @@ authorized_cmd
 			  }
 
 			$$ = node;
-
 		}}
 	| UPDATE
-		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | UPDATE);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_AUTH_CMD);
 
 			if (node)
@@ -9250,11 +8494,9 @@ authorized_cmd
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| ALTER
-		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | ALTER);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_AUTH_CMD);
 
 			if (node)
@@ -9265,11 +8507,9 @@ authorized_cmd
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| ADD
-		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | ADD);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_AUTH_CMD);
 
 			if (node)
@@ -9280,11 +8520,9 @@ authorized_cmd
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| DROP
-		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | DROP);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_AUTH_CMD);
 
 			if (node)
@@ -9295,12 +8533,10 @@ authorized_cmd
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 
 	| EXECUTE
-		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | EXECUTE);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_AUTH_CMD);
 
 			if (node)
@@ -9311,11 +8547,9 @@ authorized_cmd
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| REFERENCES
-		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | REFERENCES);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_AUTH_CMD);
 
 			if (node)
@@ -9326,11 +8560,9 @@ authorized_cmd
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| ALL PRIVILEGES
-		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | ALL PRIVILEGES);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_AUTH_CMD);
 
 			if (node)
@@ -9341,11 +8573,9 @@ authorized_cmd
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| ALL
-		{{ DBG_TRACE_GRAMMAR(authorized_cmd, | ALL);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_AUTH_CMD);
 
 			if (node)
@@ -9356,14 +8586,12 @@ authorized_cmd
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_password
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_password, : );
-
+		{{
 			$$ = NULL;                        
                         if(pwd_info.parser_add_user_check)
                         {
@@ -9371,7 +8599,6 @@ opt_password
                            pwd_info.pwd_end_offset = (@$.buffer_pos);
                            pt_add_password_offset(pwd_info.pwd_start_offset, pwd_info.pwd_end_offset, false, en_user_password);
                         }
-
 		}}
 	| PASSWORD
 		{ push_msg(MSGCAT_SYNTAX_INVALID_PASSWORD);
@@ -9379,51 +8606,41 @@ opt_password
                 }
 	  char_string_literal
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(opt_password, | PASSWORD char_string_literal);
-
+		{{
                         pwd_info.pwd_end_offset = (@$.buffer_pos);
                         pt_add_password_offset(pwd_info.pwd_start_offset, pwd_info.pwd_end_offset, false, en_none_password);
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_groups
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_groups, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| GROUPS
 		{ push_msg(MSGCAT_SYNTAX_INVALID_GROUPS); }
 	  identifier_list
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(opt_groups, | GROUPS identifier_list);
-
+		{{
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_members
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_members, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| MEMBERS
 		{ push_msg(MSGCAT_SYNTAX_INVALID_MEMBERS); }
 	  identifier_list
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(opt_members, | MEMBERS identifier_list);
-
+		{{
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
@@ -9436,8 +8653,7 @@ call_stmt
                     pwd_info.method_password_arg_idx = -1;
                 }}
          generic_function_for_call into_clause_opt
-		{{ DBG_TRACE_GRAMMAR(call_stmt, : CALL generic_function_for_call into_clause_opt);
-			
+		{{
                         pwd_info.parser_call_check = false;
                         PT_NODE *node = $3;
 			if (node)
@@ -9462,137 +8678,102 @@ call_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_class_or_normal_attr_def_list
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_class_or_normal_attr_def_list, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| '(' class_or_normal_attr_def_list ')'
-		{{ DBG_TRACE_GRAMMAR(opt_class_or_normal_attr_def_list, | '(' class_or_normal_attr_def_list ')');
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_method_def_list
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_method_def_list, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| METHOD method_def_list
-		{{ DBG_TRACE_GRAMMAR(opt_method_def_list, | METHOD method_def_list);
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_method_files
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_method_files, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| File method_file_list
-		{{ DBG_TRACE_GRAMMAR(opt_method_files, | File method_file_list);
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_inherit_resolution_list
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_inherit_resolution_list, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| inherit_resolution_list
-		{{ DBG_TRACE_GRAMMAR(opt_inherit_resolution_list, | inherit_resolution_list);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_table_option_list
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_table_option_list, : );
-
-
+		{{
 			$$ = NULL;
-
 		}}
 	| table_option_list
-		{{ DBG_TRACE_GRAMMAR(opt_table_option_list, | table_option_list);
-
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_partition_clause
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_partition_clause, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| partition_clause
-		{{ DBG_TRACE_GRAMMAR(opt_partition_clause, | partition_clause);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_create_as_clause
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_create_as_clause, : );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2(ctn, NULL, NULL);
 			$$ = ctn;
-
 		}}
 	| create_as_clause
-		{{ DBG_TRACE_GRAMMAR(opt_create_as_clause, | create_as_clause);
-
+		{{
 			$$ = $1;
-
 		}}
 	;
 
 of_class_table_type
 	: CLASS
-		{{ DBG_TRACE_GRAMMAR(of_class_table_type, : CLASS);
-
+		{{
 			$$ = PT_CLASS;
-
 		}}
 	| TABLE
-		{{ DBG_TRACE_GRAMMAR(of_class_table_type, | TABLE);
-
+		{{
 			$$ = PT_CLASS;
-
 		}}
 	;
 
@@ -9603,146 +8784,109 @@ of_view_vclass
 
 opt_or_replace
 	: /*empty*/
-		{{ DBG_TRACE_GRAMMAR(opt_or_replace, : );
-
+		{{
 			$$ = 0;
-
 		}}
 	| OR REPLACE
-		{{ DBG_TRACE_GRAMMAR(opt_or_replace, | OR REPLACE);
-
+		{{
 			$$ = 1;
-
 		}}
 	;
 
 opt_if_not_exists
 	: /*empty*/
-		{{ DBG_TRACE_GRAMMAR(opt_if_not_exists, : );
-
+		{{
 			$$ = 0;
-
 		}}
 	| IF NOT EXISTS
-		{{ DBG_TRACE_GRAMMAR(opt_if_not_exists, |  IF NOT EXISTS);
-
+		{{
 			$$ = 1;
-
 		}}
 	;
 
 opt_if_exists
 	: /*empty*/
-		{{ DBG_TRACE_GRAMMAR(opt_if_exists, : );
-
+		{{
 			$$ = 0;
-
 		}}
 	| IF EXISTS
-		{{ DBG_TRACE_GRAMMAR(opt_if_exists, | IF EXISTS);
-
+		{{
 			$$ = 1;
-
 		}}
 	;
 
 opt_paren_view_attr_def_list
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_paren_view_attr_def_list, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| '(' view_attr_def_list ')'
-		{{ DBG_TRACE_GRAMMAR(opt_opt_paren_view_attr_def_listif_exists, | '(' view_attr_def_list ')');
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_as_query_list
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_as_query_list, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| AS query_list
-		{{ DBG_TRACE_GRAMMAR(opt_as_query_list, | AS query_list);
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_with_levels_clause
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_with_levels_clause, : );
-
+		{{
 			$$ = PT_EMPTY;
-
 		}}
 	| WITH LOCAL CHECK OPTION
-		{{ DBG_TRACE_GRAMMAR(opt_with_levels_clause, | WITH LOCAL CHECK OPTION);
-
+		{{
 			$$ = PT_LOCAL;
-
 		}}
 	| WITH CASCADED CHECK OPTION
-		{{ DBG_TRACE_GRAMMAR(opt_with_levels_clause, | WITH CASCADED CHECK OPTION);
-
+		{{
 			$$ = PT_CASCADED;
-
 		}}
 	| WITH CHECK OPTION
-		{{ DBG_TRACE_GRAMMAR(opt_with_levels_clause, | WITH CHECK OPTION);
-
+		{{
 			$$ = PT_CASCADED;
-
 		}}
 	;
 
 query_list
 	: query_list ',' csql_query
-		{{ DBG_TRACE_GRAMMAR(query_list, : query_list ',' csql_query);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| csql_query
-		{{ DBG_TRACE_GRAMMAR(query_list, | csql_query);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 inherit_resolution_list
 	: inherit_resolution_list  ',' inherit_resolution
-		{{ DBG_TRACE_GRAMMAR(inherit_resolution_list, : inherit_resolution_list  ',' inherit_resolution);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| INHERIT inherit_resolution
-		{{ DBG_TRACE_GRAMMAR(inherit_resolution_list, | INHERIT inherit_resolution);
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 inherit_resolution
 	: opt_class identifier OF class_name AS identifier
-		{{ DBG_TRACE_GRAMMAR(inherit_resolution, : opt_class identifier OF class_name AS identifier);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_RESOLUTION);
 
 			if (node)
@@ -9759,11 +8903,9 @@ inherit_resolution
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| opt_class identifier OF class_name
-		{{ DBG_TRACE_GRAMMAR(inherit_resolution, | opt_class identifier OF class_name);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_RESOLUTION);
 
 			if (node)
@@ -9779,52 +8921,40 @@ inherit_resolution
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 table_option_list
 	: table_option_list ',' table_option
-		{{ DBG_TRACE_GRAMMAR(table_option_list, : table_option_list ',' table_option);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| table_option_list table_option
-		{{ DBG_TRACE_GRAMMAR(table_option_list, | table_option_list table_option);
-
+		{{
 			$$ = parser_make_link ($1, $2);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| table_option
-		{{ DBG_TRACE_GRAMMAR(table_option_list, | table_option);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 table_option
 	: REUSE_OID
-		{{ DBG_TRACE_GRAMMAR(table_option, : REUSE_OID);
-
+		{{
 			$$ = pt_table_option (this_parser, PT_TABLE_OPTION_REUSE_OID, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| DONT_REUSE_OID
-		{{ DBG_TRACE_GRAMMAR(table_option, | DONT_REUSE_OID);
-
+		{{
 			$$ = pt_table_option (this_parser, PT_TABLE_OPTION_DONT_REUSE_OID, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| AUTO_INCREMENT '=' UNSIGNED_INTEGER
-		{{ DBG_TRACE_GRAMMAR(table_option, | AUTO_INCREMENT '=' UNSIGNED_INTEGER);
-
+		{{
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 			if (val)
 			{
@@ -9837,139 +8967,106 @@ table_option
 
 			$$ = pt_table_option (this_parser, PT_TABLE_OPTION_AUTO_INCREMENT, val);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		  }}
 	| class_encrypt_spec
-                {{ DBG_TRACE_GRAMMAR(table_option, | class_encrypt_spec);
+                {{
 	
                         $$ = pt_table_option (this_parser, PT_TABLE_OPTION_ENCRYPT, $1);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		  }}
 	| charset_spec
-		{{ DBG_TRACE_GRAMMAR(table_option, | charset_spec);
-
+		{{
 			$$ = pt_table_option (this_parser, PT_TABLE_OPTION_CHARSET, $1);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		  }}
 	| collation_spec
-		{{ DBG_TRACE_GRAMMAR(table_option, | collation_spec);
-
+		{{
 			$$ = pt_table_option (this_parser, PT_TABLE_OPTION_COLLATION, $1);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		  }}
 	| class_comment_spec
-		{{ DBG_TRACE_GRAMMAR(table_option, | class_comment_spec);
-
+		{{
 			$$ = pt_table_option (this_parser, PT_TABLE_OPTION_COMMENT, $1);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
-	      }}
+		}}
 	;
 
 opt_subtable_clause
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_subtable_clause, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| UNDER only_class_name_list
-		{{ DBG_TRACE_GRAMMAR(opt_subtable_clause, | UNDER only_class_name_list);
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| AS SUBCLASS OF only_class_name_list
-		{{ DBG_TRACE_GRAMMAR(opt_subtable_clause, | AS SUBCLASS OF only_class_name_list);
-
+		{{
 			$$ = $4;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_constraint_id
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_constraint_id, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| CONSTRAINT identifier
-		{{ DBG_TRACE_GRAMMAR(opt_constraint_id, | CONSTRAINT identifier);
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_constraint_opt_id
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_constraint_opt_id, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| CONSTRAINT opt_identifier
-		{{ DBG_TRACE_GRAMMAR(opt_constraint_opt_id, | CONSTRAINT opt_identifier);
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 of_unique_foreign_check
 	: unique_constraint
-		{{ DBG_TRACE_GRAMMAR(of_unique_foreign_check, : unique_constraint);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| foreign_key_constraint
-		{{ DBG_TRACE_GRAMMAR(of_unique_foreign_check, | foreign_key_constraint);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| check_constraint
-		{{ DBG_TRACE_GRAMMAR(of_unique_foreign_check, | check_constraint);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_constraint_attr_list
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_constraint_attr_list, : );
-
+		{{
 			container_4 ctn;
 			SET_CONTAINER_4 (ctn, FROM_NUMBER (0), FROM_NUMBER (0), FROM_NUMBER (0),
 					 FROM_NUMBER (0));
 			$$ = ctn;
-
 		}}
 	| constraint_attr_list
-		{{ DBG_TRACE_GRAMMAR(opt_constraint_attr_list, | constraint_attr_list);
-
+		{{
 			$$ = $1;
-
 		}}
 	;
 
 constraint_attr_list
 	: constraint_attr_list ',' constraint_attr
-		{{ DBG_TRACE_GRAMMAR(constraint_attr_list, : constraint_attr_list ',' constraint_attr);
-
+		{{
 			container_4 ctn = $1;
 			container_4 ctn_new = $3;
 
@@ -9986,20 +9083,16 @@ constraint_attr_list
 			  }
 
 			$$ = ctn;
-
 		}}
 	| constraint_attr
-		{{ DBG_TRACE_GRAMMAR(constraint_attr_list, | constraint_attr);
-
+		{{
 			$$ = $1;
-
 		}}
 	;
 
 unique_constraint
 	: PRIMARY KEY opt_identifier '(' index_column_identifier_list ')'
-		{{ DBG_TRACE_GRAMMAR(unique_constraint, : PRIMARY KEY opt_identifier '(' index_column_identifier_list ')');
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_CONSTRAINT);
 
 			if (node)
@@ -10011,11 +9104,9 @@ unique_constraint
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| UNIQUE opt_of_index_key opt_identifier index_column_name_list
-		{{ DBG_TRACE_GRAMMAR(unique_constraint, | UNIQUE opt_of_index_key opt_identifier index_column_name_list);
-
+		{{
 			PT_NODE *node = NULL;
 			PT_NODE *sort_spec_cols = $4, *name_cols = NULL, *temp;
 
@@ -10081,7 +9172,6 @@ unique_constraint
 			  }
 
 			$$ = node;
-
 		}}
 	;
 
@@ -10095,8 +9185,7 @@ foreign_key_constraint
 	  user_specified_name				/* 9 */
 	  opt_paren_attr_list				/* 10 */
 	  opt_ref_rule_list				/* 11 */
-		{{ DBG_TRACE_GRAMMAR(foreign_key_constraint, : FOREIGN KEY ~ '(' index_column_identifier_list ')' REFERENCES ~);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_CONSTRAINT);
 
 			if (node)
@@ -10116,105 +9205,83 @@ foreign_key_constraint
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 index_column_identifier_list
 	: index_column_identifier_list ',' index_column_identifier
-		{{ DBG_TRACE_GRAMMAR(index_column_identifier_list, : index_column_identifier_list ',' index_column_identifier);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| index_column_identifier
-		{{ DBG_TRACE_GRAMMAR(index_column_identifier_list, | index_column_identifier);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 index_column_identifier
 	: identifier opt_asc_or_desc
-		{{ DBG_TRACE_GRAMMAR(index_column_identifier, : identifier opt_asc_or_desc);
-
+		{{
 			if ($2)
 			  {
 			    PT_NAME_INFO_SET_FLAG ($1, PT_NAME_INFO_DESC);
 			  }
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_asc_or_desc
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_asc_or_desc, : );
-
+		{{
 			$$ = 0;
-
 		}}
 	| ASC
-		{{ DBG_TRACE_GRAMMAR(opt_asc_or_desc, | ASC);
-
+		{{
 			$$ = 0;
-
 		}}
 	| DESC
-		{{ DBG_TRACE_GRAMMAR(opt_asc_or_desc, | DESC);
-
+		{{
 			$$ = 1;
-
 		}}
 	;
 
 opt_paren_attr_list
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_paren_attr_list, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| '(' identifier_list ')'
-		{{ DBG_TRACE_GRAMMAR(opt_paren_attr_list, | '(' identifier_list ')');
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_ref_rule_list
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_ref_rule_list, : );
-
+		{{
 			container_3 ctn;
 			SET_CONTAINER_3 (ctn, FROM_NUMBER (PT_RULE_RESTRICT),
 					 FROM_NUMBER (PT_RULE_RESTRICT), NULL);
 			$$ = ctn;
-
 		}}
 	| ref_rule_list
-		{{ DBG_TRACE_GRAMMAR(opt_ref_rule_list, | ref_rule_list);
-
+		{{
 			container_3 ctn = $1;
 			if (ctn.c1 == NULL)
 			  ctn.c1 = FROM_NUMBER (PT_RULE_RESTRICT);
 			if (ctn.c2 == NULL)
 			  ctn.c2 = FROM_NUMBER (PT_RULE_RESTRICT);
 			$$ = ctn;
-
 		}}
 	;
 
 ref_rule_list
 	: ref_rule_list ON_ DELETE_ CASCADE
-		{{ DBG_TRACE_GRAMMAR(ref_rule_list, : ref_rule_list ON_ DELETE_ CASCADE);
-
+		{{
 			container_3 ctn = $1;
 			if (ctn.c1 != NULL)
 			  {
@@ -10224,11 +9291,9 @@ ref_rule_list
 
 			ctn.c1 = FROM_NUMBER (PT_RULE_CASCADE);
 			$$ = ctn;
-
 		}}
 	| ref_rule_list ON_ DELETE_ NO ACTION
-		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ref_rule_list ON_ DELETE_ NO ACTION);
-
+		{{
 			container_3 ctn = $1;
 			if (ctn.c1 != NULL)
 			  {
@@ -10238,11 +9303,9 @@ ref_rule_list
 
 			ctn.c1 = FROM_NUMBER (PT_RULE_NO_ACTION);
 			$$ = ctn;
-
 		}}
 	| ref_rule_list ON_ DELETE_ RESTRICT
-		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ref_rule_list ON_ DELETE_ RESTRICT);
-
+		{{
 			container_3 ctn = $1;
 			if (ctn.c1 != NULL)
 			  {
@@ -10252,11 +9315,9 @@ ref_rule_list
 
 			ctn.c1 = FROM_NUMBER (PT_RULE_RESTRICT);
 			$$ = ctn;
-
 		}}
 	| ref_rule_list ON_ DELETE_ SET Null
-		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ref_rule_list ON_ DELETE_ SET Null);
-
+		{{
 			container_3 ctn = $1;
 			if (ctn.c1 != NULL)
 			  {
@@ -10266,11 +9327,9 @@ ref_rule_list
 
 			ctn.c1 = FROM_NUMBER (PT_RULE_SET_NULL);
 			$$ = ctn;
-
 		}}
 	| ref_rule_list ON_ UPDATE NO ACTION
-		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ref_rule_list ON_ UPDATE NO ACTION);
-
+		{{
 			container_3 ctn = $1;
 			if (ctn.c2 != NULL)
 			  {
@@ -10280,11 +9339,9 @@ ref_rule_list
 
 			ctn.c2 = FROM_NUMBER (PT_RULE_NO_ACTION);
 			$$ = ctn;
-
 		}}
 	| ref_rule_list ON_ UPDATE RESTRICT
-		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ref_rule_list ON_ UPDATE RESTRICT);
-
+		{{
 			container_3 ctn = $1;
 			if (ctn.c2 != NULL)
 			  {
@@ -10294,11 +9351,9 @@ ref_rule_list
 
 			ctn.c2 = FROM_NUMBER (PT_RULE_RESTRICT);
 			$$ = ctn;
-
 		}}
 	| ref_rule_list ON_ UPDATE SET Null
-		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ref_rule_list ON_ UPDATE SET Null);
-
+		{{
 			container_3 ctn = $1;
 			if (ctn.c2 != NULL)
 			  {
@@ -10308,71 +9363,55 @@ ref_rule_list
 
 			ctn.c2 = FROM_NUMBER (PT_RULE_SET_NULL);
 			$$ = ctn;
-
 		}}
 	| ON_ DELETE_ CASCADE
-		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ON_ DELETE_ CASCADE);
-
+		{{
 			container_3 ctn;
 			SET_CONTAINER_3 (ctn, FROM_NUMBER (PT_RULE_CASCADE), NULL, NULL);
 			$$ = ctn;
-
 		}}
 	| ON_ DELETE_ NO ACTION
-		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ON_ DELETE_ NO ACTION);
-
+		{{
 			container_3 ctn;
 			SET_CONTAINER_3 (ctn, FROM_NUMBER (PT_RULE_NO_ACTION), NULL, NULL);
 			$$ = ctn;
-
 		}}
 	| ON_ DELETE_ RESTRICT
-		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ON_ DELETE_ RESTRICT);
-
+		{{
 			container_3 ctn;
 			SET_CONTAINER_3 (ctn, FROM_NUMBER (PT_RULE_RESTRICT), NULL, NULL);
 			$$ = ctn;
-
 		}}
 	| ON_ DELETE_ SET Null
-		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ON_ DELETE_ SET Null);
-
+		{{
 			container_3 ctn;
 			SET_CONTAINER_3 (ctn, FROM_NUMBER (PT_RULE_SET_NULL), NULL, NULL);
 			$$ = ctn;
-
 		}}
 	| ON_ UPDATE NO ACTION
-		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ON_ UPDATE NO ACTION);
-
+		{{
 			container_3 ctn;
 			SET_CONTAINER_3 (ctn, NULL, FROM_NUMBER (PT_RULE_NO_ACTION), NULL);
 			$$ = ctn;
-
 		}}
 	| ON_ UPDATE RESTRICT
-		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ON_ UPDATE RESTRICT);
-
+		{{
 			container_3 ctn;
 			SET_CONTAINER_3 (ctn, NULL, FROM_NUMBER (PT_RULE_RESTRICT), NULL);
 			$$ = ctn;
-
 		}}
 	| ON_ UPDATE SET Null
-		{{ DBG_TRACE_GRAMMAR(ref_rule_list, | ON_ UPDATE SET Null);
-
+		{{
 			container_3 ctn;
 			SET_CONTAINER_3 (ctn, NULL, FROM_NUMBER (PT_RULE_SET_NULL), NULL);
 			$$ = ctn;
-
 		}}
 	;
 
 
 check_constraint
 	: CHECK '(' search_condition ')'
-		{{ DBG_TRACE_GRAMMAR(check_constraint, : CHECK '(' search_condition ')');
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_CONSTRAINT);
 
 			if (node)
@@ -10383,7 +9422,6 @@ check_constraint
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
@@ -10391,65 +9429,53 @@ check_constraint
 /* bool_deferrable, deferrable value, bool_initially_deferred, initially_deferred value */
 constraint_attr
 	: NOT DEFERRABLE
-		{{ DBG_TRACE_GRAMMAR(constraint_attr, : NOT DEFERRABLE);
-
+		{{
 			container_4 ctn;
 			ctn.c1 = FROM_NUMBER (1);
 			ctn.c2 = FROM_NUMBER (0);
 			ctn.c3 = FROM_NUMBER (0);
 			ctn.c4 = FROM_NUMBER (0);
 			$$ = ctn;
-
 		}}
 	| DEFERRABLE
-		{{ DBG_TRACE_GRAMMAR(constraint_attr, | DEFERRABLE);
-
+		{{
 			container_4 ctn;
 			ctn.c1 = FROM_NUMBER (1);
 			ctn.c2 = FROM_NUMBER (1);
 			ctn.c3 = FROM_NUMBER (0);
 			ctn.c4 = FROM_NUMBER (0);
 			$$ = ctn;
-
 		}}
 	| INITIALLY DEFERRED
-		{{ DBG_TRACE_GRAMMAR(constraint_attr, | INITIALLY DEFERRED);
-
+		{{
 			container_4 ctn;
 			ctn.c1 = FROM_NUMBER (0);
 			ctn.c2 = FROM_NUMBER (0);
 			ctn.c3 = FROM_NUMBER (1);
 			ctn.c4 = FROM_NUMBER (1);
 			$$ = ctn;
-
 		}}
 	| INITIALLY IMMEDIATE
-		{{ DBG_TRACE_GRAMMAR(constraint_attr, | INITIALLY IMMEDIATE);
-
+		{{
 			container_4 ctn;
 			ctn.c1 = FROM_NUMBER (0);
 			ctn.c2 = FROM_NUMBER (0);
 			ctn.c3 = FROM_NUMBER (1);
 			ctn.c4 = FROM_NUMBER (0);
 			$$ = ctn;
-
 		}}
 	;
 
 method_def_list
 	: method_def_list ',' method_def
-		{{ DBG_TRACE_GRAMMAR(method_def_list, : method_def_list ',' method_def);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| method_def
-		{{ DBG_TRACE_GRAMMAR(method_def_list, | method_def);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
@@ -10459,8 +9485,7 @@ method_def
 	  opt_method_def_arg_list
 	  opt_data_type
 	  opt_function_identifier
-		{{ DBG_TRACE_GRAMMAR(method_def, : opt_class identifier opt_method_def_arg_list opt_data_type opt_function_identifier);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_METHOD_DEF);
 			PT_MISC_TYPE t = PT_NORMAL;
 			if ($1)
@@ -10477,53 +9502,41 @@ method_def
 			  }
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_method_def_arg_list
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_method_def_arg_list, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| '(' arg_type_list ')'
-		{{ DBG_TRACE_GRAMMAR(opt_method_def_arg_list, | '(' arg_type_list ')');
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| '(' ')'
-		{{ DBG_TRACE_GRAMMAR(opt_method_def_arg_list, | '(' ')');
-
+		{{
 			$$ = NULL;
-
 		}}
 	;
 
 arg_type_list
 	: arg_type_list ',' inout_data_type
-		{{ DBG_TRACE_GRAMMAR(arg_type_list, : arg_type_list ',' inout_data_type);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| inout_data_type
-		{{ DBG_TRACE_GRAMMAR(arg_type_list, | inout_data_type);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 inout_data_type
 	: opt_in_out data_type
-		{{ DBG_TRACE_GRAMMAR(inout_data_type, : opt_in_out data_type);
-
+		{{
 			PT_NODE *at = parser_new_node (this_parser, PT_DATA_TYPE);
 
 			if (at)
@@ -10535,155 +9548,121 @@ inout_data_type
 
 			$$ = at;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_data_type
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_data_type, : );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_NONE), NULL);
 			$$ = ctn;
-
 		}}
 	| data_type
-		{{ DBG_TRACE_GRAMMAR(opt_data_type, | data_type);
-
+		{{
 			$$ = $1;
-
 		}}
 	;
 
 opt_function_identifier
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_function_identifier, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| FUNCTION identifier
-		{{ DBG_TRACE_GRAMMAR(opt_function_identifier, | FUNCTION identifier);
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 method_file_list
 	: method_file_list ',' file_path_name
-		{{ DBG_TRACE_GRAMMAR(method_file_list, : method_file_list ',' file_path_name);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| file_path_name
-		{{ DBG_TRACE_GRAMMAR(method_file_list, | file_path_name);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 file_path_name
 	: char_string_literal
-		{{ DBG_TRACE_GRAMMAR(file_path_name, : char_string_literal);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_FILE_PATH);
 			if (node)
 			  node->info.file_path.string = $1;
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_class_attr_def_list
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_class_attr_def_list, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| CLASS
 	  ATTRIBUTE
 		{ parser_attr_type = PT_META_ATTR; }
 	 '(' attr_def_list ')'
 		{ parser_attr_type = PT_NORMAL; }
-		{{ DBG_TRACE_GRAMMAR(opt_class_attr_def_list, | CLASS ATTRIBUTE '(' attr_def_list ')');
-
+		{{
 			$$ = $5;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 class_or_normal_attr_def_list
 	: class_or_normal_attr_def_list  ',' class_or_normal_attr_def
-		{{ DBG_TRACE_GRAMMAR(class_or_normal_attr_def_list, : class_or_normal_attr_def_list  ',' class_or_normal_attr_def);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| class_or_normal_attr_def
-		{{ DBG_TRACE_GRAMMAR(class_or_normal_attr_def_list, | class_or_normal_attr_def);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 class_or_normal_attr_def
 	: CLASS { parser_attr_type = PT_META_ATTR; } attr_def { parser_attr_type = PT_NORMAL; }
-		{{ DBG_TRACE_GRAMMAR(class_or_normal_attr_def, : CLASS attr_def);
-
+		{{
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| attr_def
-		{{ DBG_TRACE_GRAMMAR(class_or_normal_attr_def, | attr_def);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 view_attr_def_list
 	: view_attr_def_list ',' view_attr_def
-		{{ DBG_TRACE_GRAMMAR(class_or_normal_attr_def, : view_attr_def_list ',' view_attr_def);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| view_attr_def
-		{{ DBG_TRACE_GRAMMAR(class_or_normal_attr_def, | view_attr_def);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 view_attr_def
 	: attr_def
-		{{ DBG_TRACE_GRAMMAR(view_attr_def, : attr_def);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| identifier opt_comment_spec
-		{{ DBG_TRACE_GRAMMAR(view_attr_def, | identifier opt_comment_spec);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_ATTR_DEF);
 
 			if (node)
@@ -10697,65 +9676,50 @@ view_attr_def
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 attr_def_list_with_commas
 	: attr_def_list_with_commas ','  attr_def
-		{{ DBG_TRACE_GRAMMAR(attr_def_list_with_commas, : attr_def_list_with_commas ','  attr_def);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| attr_def ','  attr_def
-		{{ DBG_TRACE_GRAMMAR(attr_def_list_with_commas, | attr_def ','  attr_def);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 attr_def_list
 	: attr_def_list ','  attr_def
-		{{ DBG_TRACE_GRAMMAR(attr_def_list, : attr_def_list ','  attr_def);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| attr_def
-		{{ DBG_TRACE_GRAMMAR(attr_def_list, | attr_def);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 attr_def
 	: attr_constraint_def
-		{{ DBG_TRACE_GRAMMAR(attr_def, : attr_constraint_def);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| attr_index_def
-		{{ DBG_TRACE_GRAMMAR(attr_def, | attr_index_def);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| attr_def_one
-		{{ DBG_TRACE_GRAMMAR(attr_def, | attr_def_one);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
@@ -10764,8 +9728,7 @@ attr_constraint_def
 	  of_unique_foreign_check
 	  opt_constraint_attr_list
 	  opt_comment_spec
-		{{ DBG_TRACE_GRAMMAR(attr_constraint_def, : opt_constraint_opt_id of_unique_foreign_check opt_constraint_attr_list opt_comment_spec);
-
+		{{
 			PT_NODE *name = $1;
 			PT_NODE *constraint = $2;
 
@@ -10818,7 +9781,6 @@ attr_constraint_def
 
 			$$ = constraint;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
@@ -10830,7 +9792,7 @@ attr_index_def
           opt_index_with_clause_no_online  /* 5 */
 	  opt_invisible             /* 6 */
           opt_comment_spec          /* 7 */
-		{{ DBG_TRACE_GRAMMAR(attr_index_def, : index_or_key identifier index_column_name_list opt_where_clause opt_comment_spec opt_invisible);
+		{{
 			int arg_count = 0, prefix_col_count = 0;
 			PT_NODE* node = parser_new_node(this_parser,
 							PT_CREATE_INDEX);
@@ -10892,15 +9854,13 @@ attr_index_def
 			       node->info.index.index_status = SM_INVISIBLE_INDEX;
 			  }
 			$$ = node;
-
 		}}
 	;
 
 attr_def_one
 	: identifier
 	  data_type
-		{{ DBG_TRACE_GRAMMAR(attr_def_one, : identifier data_type);
-
+		{{
 			PT_NODE *dt;
 			PT_TYPE_ENUM typ;
 			PT_NODE *node = parser_new_node (this_parser, PT_ATTR_DEF);
@@ -10922,12 +9882,10 @@ attr_def_one
 			  }
 
 			parser_save_attr_def_one (node);
-
 		}}
 	  opt_constraint_list_and_opt_column_comment
 	  opt_attr_ordering_info
-		{{ DBG_TRACE_GRAMMAR(attr_def_one, opt_constraint_list_and_opt_column_comment opt_attr_ordering_info);
-
+		{{
 			PT_NODE *node = parser_get_attr_def_one ();
 			if (node != NULL && node->info.attr_def.attr_type != PT_SHARED)
 			  {
@@ -10940,20 +9898,16 @@ attr_def_one
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_attr_ordering_info
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_attr_ordering_info, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| FIRST
-		{{ DBG_TRACE_GRAMMAR(opt_attr_ordering_info, | FIRST);
-
+		{{
 			PT_NODE *ord = parser_new_node (this_parser, PT_ATTR_ORDERING);
 			PARSER_SAVE_ERR_CONTEXT (ord, @$.buffer_pos)
 			if (ord)
@@ -10968,11 +9922,9 @@ opt_attr_ordering_info
 			  }
 
 			$$ = ord;
-
 		}}
 	| AFTER identifier
-		{{ DBG_TRACE_GRAMMAR(opt_attr_ordering_info, | AFTER identifier);
-
+		{{
 			PT_NODE *ord = parser_new_node (this_parser, PT_ATTR_ORDERING);
 			PARSER_SAVE_ERR_CONTEXT (ord, @$.buffer_pos)
 			if (ord)
@@ -10987,22 +9939,19 @@ opt_attr_ordering_info
 			  }
 
 			$$ = ord;
-
 		}}
 	;
 
 opt_constraint_list_and_opt_column_comment
 	: /* empty */
-		{ DBG_TRACE_GRAMMAR(opt_constraint_list_and_opt_column_comment, : );
-                   $$ = 0; }
+		{ $$ = 0; }
 	| constraint_list_and_column_comment
-		{ DBG_TRACE_GRAMMAR(opt_constraint_list_and_opt_column_comment, | constraint_list_and_column_comment);
-                   $$ = $1; }
+		{ $$ = $1; }
 	;
 
 constraint_list_and_column_comment
 	: constraint_list_and_column_comment column_constraint_and_comment_def
-		{{ DBG_TRACE_GRAMMAR(constraint_list_and_column_comment, : constraint_list_and_column_comment column_constraint_and_comment_def);
+		{{
 			unsigned int mask = $1;
 			unsigned int new_bit = $2;
 			unsigned int merged = mask | new_bit;
@@ -11036,54 +9985,53 @@ constraint_list_and_column_comment
 			$$ = merged;
 		}}
 	| column_constraint_and_comment_def
-		{{ DBG_TRACE_GRAMMAR(constraint_list_and_column_comment, | column_constraint_and_comment_def);
+		{{
 			$$ = $1;
 		}}
 	;
 
 column_constraint_and_comment_def
 	: column_unique_constraint_def
-		{{ DBG_TRACE_GRAMMAR(column_constraint_and_comment_def, : column_unique_constraint_def);
+		{{
 			$$ = COLUMN_CONSTRAINT_UNIQUE;
 		}}
 	| column_primary_constraint_def
-		{{ DBG_TRACE_GRAMMAR(column_constraint_and_comment_def, | column_primary_constraint_def);
+		{{
 			$$ = COLUMN_CONSTRAINT_PRIMARY_KEY;
 		}}
 	| column_null_constraint_def
-		{{ DBG_TRACE_GRAMMAR(column_constraint_and_comment_def, | column_null_constraint_def);
+		{{
 			$$ = COLUMN_CONSTRAINT_NULL;
 		}}
 	| column_other_constraint_def
-		{{ DBG_TRACE_GRAMMAR(column_constraint_and_comment_def, | column_other_constraint_def);
+		{{
 			$$ = COLUMN_CONSTRAINT_OTHERS;
 		}}
 	| column_shared_constraint_def
-		{{ DBG_TRACE_GRAMMAR(column_constraint_and_comment_def, | column_shared_constraint_def);
+		{{
 			$$ = COLUMN_CONSTRAINT_SHARED;
 		}}
 	| column_default_constraint_def
-		{{ DBG_TRACE_GRAMMAR(column_constraint_and_comment_def, | column_default_constraint_def);
+		{{
 			$$ = COLUMN_CONSTRAINT_DEFAULT;
 		}}
 	| column_ai_constraint_def
-		{{ DBG_TRACE_GRAMMAR(column_constraint_and_comment_def, | column_ai_constraint_def);
+		{{
 			$$ = COLUMN_CONSTRAINT_AUTO_INCREMENT;
 		}}
 	| column_comment_def
-		{{ DBG_TRACE_GRAMMAR(column_constraint_and_comment_def, | column_comment_def);
+		{{
 			$$ = COLUMN_CONSTRAINT_COMMENT;
 		}}
 	| column_on_update_def
-		{{ DBG_TRACE_GRAMMAR(column_constraint_and_comment_def, | column_on_update_def);
+		{{
 			$$ = COLUMN_CONSTRAINT_ON_UPDATE;
 		}}
 	;
 
 column_unique_constraint_def
 	: opt_constraint_id UNIQUE opt_key opt_constraint_attr_list
-		{{ DBG_TRACE_GRAMMAR(column_unique_constraint_def, : opt_constraint_id UNIQUE opt_key opt_constraint_attr_list);
-
+		{{
 			PT_NODE *node = parser_get_attr_def_one ();
 			PT_NODE *constrant_name = $1;
 			PT_NODE *constraint = parser_new_node (this_parser, PT_CONSTRAINT);
@@ -11118,14 +10066,12 @@ column_unique_constraint_def
 			  }
 
 			parser_make_link (node, constraint);
-
 		}}
 	;
 
 column_primary_constraint_def
 	: opt_constraint_id PRIMARY KEY opt_constraint_attr_list
-		{{ DBG_TRACE_GRAMMAR(column_primary_constraint_def, : opt_constraint_id PRIMARY KEY opt_constraint_attr_list);
-
+		{{
 			PT_NODE *node = parser_get_attr_def_one ();
 			PT_NODE *constrant_name = $1;
 			PT_NODE *constraint = parser_new_node (this_parser, PT_CONSTRAINT);
@@ -11152,14 +10098,12 @@ column_primary_constraint_def
 			  }
 
 			parser_make_link (node, constraint);
-
 		}}
 	;
 
 column_null_constraint_def
 	: opt_constraint_id Null opt_constraint_attr_list
-		{{ DBG_TRACE_GRAMMAR(column_null_constraint_def, : opt_constraint_id Null opt_constraint_attr_list);
-
+		{{
 			PT_NODE *node = parser_get_attr_def_one ();
 			PT_NODE *constrant_name = $1;
 			PT_NODE *constraint = parser_new_node (this_parser, PT_CONSTRAINT);
@@ -11184,11 +10128,9 @@ column_null_constraint_def
 			  }
 
 			parser_make_link (node, constraint);
-
 		}}
 	| opt_constraint_id NOT Null opt_constraint_attr_list
-		{{ DBG_TRACE_GRAMMAR(column_null_constraint_def, | opt_constraint_id NOT Null opt_constraint_attr_list);
-
+		{{
 			PT_NODE *node = parser_get_attr_def_one ();
 			PT_NODE *constrant_name = $1;
 			PT_NODE *constraint = parser_new_node (this_parser, PT_CONSTRAINT);
@@ -11221,14 +10163,12 @@ column_null_constraint_def
 			  }
 
 			parser_make_link (node, constraint);
-
 		}}
 	;
 
 column_other_constraint_def
 	: opt_constraint_id CHECK '(' search_condition ')' opt_constraint_attr_list
-		{{ DBG_TRACE_GRAMMAR(column_other_constraint_def, : opt_constraint_id CHECK '(' search_condition ')' opt_constraint_attr_list);
-
+		{{
 			PT_NODE *node = parser_get_attr_def_one ();
 			PT_NODE *constrant_name = $1;
 			PT_NODE *constraint = parser_new_node (this_parser, PT_CONSTRAINT);
@@ -11254,7 +10194,6 @@ column_other_constraint_def
 			  }
 
 			parser_make_link (node, constraint);
-
 		}}
 	| opt_constraint_id			/* 1 */
 	  opt_foreign_key			/* 2 */
@@ -11264,8 +10203,7 @@ column_other_constraint_def
 	  opt_paren_attr_list			/* 6 */
 	  opt_ref_rule_list			/* 7 */
 	  opt_constraint_attr_list		/* 8 */
-		{{ DBG_TRACE_GRAMMAR(column_other_constraint_def, | opt_constraint_id opt_foreign_key REFERENCES class_name ~);
-
+		{{
 			PT_NODE *node = parser_get_attr_def_one ();
 			PT_NODE *constrant_name = $1;
 			PT_NODE *constraint = parser_new_node (this_parser, PT_CONSTRAINT);
@@ -11297,7 +10235,6 @@ column_other_constraint_def
 			  }
 
 			parser_make_link (node, constraint);
-
 		}}
 	;
 
@@ -11324,8 +10261,7 @@ opt_foreign_key
 
 column_ai_constraint_def
 	: AUTO_INCREMENT '(' integer_text ',' integer_text ')'
-		{{ DBG_TRACE_GRAMMAR(column_ai_constraint_def, : AUTO_INCREMENT '(' integer_text ',' integer_text ')');
-
+		{{
 			PT_NODE *node = parser_get_attr_def_one ();
 			PT_NODE *start_val = parser_new_node (this_parser, PT_VALUE);
 			PT_NODE *increment_val = parser_new_node (this_parser, PT_VALUE);
@@ -11361,11 +10297,9 @@ column_ai_constraint_def
 			    PT_ERRORm (this_parser, node, MSGCAT_SET_PARSER_SEMANTIC,
 				       MSGCAT_SEMANTIC_CLASS_ATT_CANT_BE_AUTOINC);
 			  }
-
 		}}
 	| AUTO_INCREMENT
-		{{ DBG_TRACE_GRAMMAR(column_ai_constraint_def, | AUTO_INCREMENT);
-
+		{{
 			PT_NODE *node = parser_get_attr_def_one ();
 
 			PT_NODE *ai_node = parser_new_node (this_parser, PT_AUTO_INCREMENT);
@@ -11378,13 +10312,12 @@ column_ai_constraint_def
 			    PT_ERRORm (this_parser, node, MSGCAT_SET_PARSER_SEMANTIC,
 				       MSGCAT_SEMANTIC_CLASS_ATT_CANT_BE_AUTOINC);
 			  }
-
 		}}
 	;
 
 column_shared_constraint_def
 	: SHARED expression_
-		{{ DBG_TRACE_GRAMMAR(column_shared_constraint_def, : SHARED expression_);
+		{{
 			PT_NODE *attr_node;
 			PT_NODE *node = parser_new_node (this_parser, PT_DATA_DEFAULT);
 
@@ -11398,13 +10331,12 @@ column_shared_constraint_def
 			attr_node = parser_get_attr_def_one ();
 			attr_node->info.attr_def.data_default = node;
 			attr_node->info.attr_def.attr_type = PT_SHARED;
-
 		}}
 	;
 
 column_on_update_def
 	: ON_ UPDATE expression_
-		{{ DBG_TRACE_GRAMMAR(column_on_update_def, : ON_ UPDATE expression_);
+		{{
 			DB_DEFAULT_EXPR_TYPE default_expr_type = DB_DEFAULT_NONE;
 			PT_NODE *attr_node = parser_get_attr_def_one ();
 			PT_NODE *on_update_default_value = $3;
@@ -11449,14 +10381,12 @@ column_on_update_def
 			  }
 
 			attr_node->info.attr_def.on_update = default_expr_type;
-
 		}}
 	;
 
 column_default_constraint_def
 	: DEFAULT expression_
-		{{ DBG_TRACE_GRAMMAR(column_default_constraint_def, : DEFAULT expression_);
-
+		{{
 			PT_NODE *attr_node;
 			PT_NODE *node = parser_new_node (this_parser, PT_DATA_DEFAULT);
 
@@ -11539,31 +10469,25 @@ column_default_constraint_def
 
 			attr_node = parser_get_attr_def_one ();
 			attr_node->info.attr_def.data_default = node;
-
 		}}
 	;
 
 attr_def_comment_list
 	: attr_def_comment_list ',' attr_def_comment
-		{{ DBG_TRACE_GRAMMAR(attr_def_comment_list, : attr_def_comment_list ',' attr_def_comment);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos);
-
 		}}
 	| attr_def_comment
-		{{ DBG_TRACE_GRAMMAR(attr_def_comment_list, | attr_def_comment);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos);
-
 		}}
 	;
 
 attr_def_comment
 	: identifier opt_equalsign comment_value
-		{{ DBG_TRACE_GRAMMAR(attr_def_comment, : identifier opt_equalsign comment_value);
-
+		{{
 			PT_NODE *attr_node = parser_new_node (this_parser, PT_ATTR_DEF);
 
 			if (attr_node)
@@ -11576,42 +10500,34 @@ attr_def_comment
 
 			$$ = attr_node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos);
-
 		}}
 	;
 
 column_comment_def
 	: COMMENT comment_value
-		{{ DBG_TRACE_GRAMMAR(column_comment_def, : COMMENT comment_value);
-
+		{{
 			PT_NODE *attr_node;
 			attr_node = parser_get_attr_def_one ();
 			attr_node->info.attr_def.comment = $2;
-
 		}}
 	;
 
 transaction_mode_list
 	: transaction_mode_list ',' transaction_mode			%dprec 1
-		{{ DBG_TRACE_GRAMMAR(transaction_mode_list, : transaction_mode_list ',' transaction_mode);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| transaction_mode						%dprec 2
-		{{ DBG_TRACE_GRAMMAR(transaction_mode_list, | transaction_mode);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 transaction_mode
 	: ISOLATION LEVEL isolation_level_spec ',' isolation_level_spec		%dprec 1
-		{{ DBG_TRACE_GRAMMAR(transaction_mode, : ISOLATION LEVEL isolation_level_spec ',' isolation_level_spec);
-
+		{{
 			PT_NODE *tm = parser_new_node (this_parser, PT_ISOLATION_LVL);
 			PT_NODE *is = parser_new_node (this_parser, PT_ISOLATION_LVL);
 			int async_ws_or_error;
@@ -11687,11 +10603,9 @@ transaction_mode
 			  }
 
 			$$ = tm;
-
 		}}
 	| ISOLATION LEVEL isolation_level_spec			%dprec 2
-		{{ DBG_TRACE_GRAMMAR(transaction_mode, | ISOLATION LEVEL isolation_level_spec);
-
+		{{
 			PT_NODE *tm = parser_new_node (this_parser, PT_ISOLATION_LVL);
 			int async_ws_or_error = (int) TO_NUMBER (CONTAINER_AT_3 ($3));
 
@@ -11713,11 +10627,9 @@ transaction_mode
 			  }
 
 			$$ = tm;
-
 		}}
 	| LOCK_ TIMEOUT timeout_spec
-		{{ DBG_TRACE_GRAMMAR(transaction_mode, | LOCK_ TIMEOUT timeout_spec);
-
+		{{
 			PT_NODE *tm = parser_new_node (this_parser, PT_TIMEOUT);
 
 			if (tm)
@@ -11727,7 +10639,6 @@ transaction_mode
 
 			$$ = tm;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
@@ -11735,44 +10646,35 @@ transaction_mode
 /* container order : level, schema, instances, async_ws */
 isolation_level_spec
 	: expression_
-		{{ DBG_TRACE_GRAMMAR(isolation_level_spec, : expression_);
-
+		{{
 			container_4 ctn;
 			SET_CONTAINER_4 (ctn, $1, FROM_NUMBER (PT_NO_ISOLATION_LEVEL),
 					 FROM_NUMBER (PT_NO_ISOLATION_LEVEL), FROM_NUMBER (0));
 			$$ = ctn;
-
 		}}
 	| ASYNC WORKSPACE
-		{{ DBG_TRACE_GRAMMAR(isolation_level_spec, | ASYNC WORKSPACE);
-
+		{{
 			container_4 ctn;
 			SET_CONTAINER_4 (ctn, NULL, FROM_NUMBER (PT_NO_ISOLATION_LEVEL),
 					 FROM_NUMBER (PT_NO_ISOLATION_LEVEL), FROM_NUMBER (1));
 			$$ = ctn;
-
 		}}
 	| SERIALIZABLE
-		{{ DBG_TRACE_GRAMMAR(isolation_level_spec, | SERIALIZABLE);
-
+		{{
 			container_4 ctn;
 			SET_CONTAINER_4 (ctn, NULL, FROM_NUMBER (PT_SERIALIZABLE),
 					 FROM_NUMBER (PT_SERIALIZABLE), FROM_NUMBER (0));
 			$$ = ctn;
-
 		}}
 	| CURSOR STABILITY
-		{{ DBG_TRACE_GRAMMAR(isolation_level_spec, | CURSOR STABILITY);
-
+		{{
 			container_4 ctn;
 			SET_CONTAINER_4 (ctn, NULL, FROM_NUMBER (PT_NO_ISOLATION_LEVEL),
 					 FROM_NUMBER (PT_READ_COMMITTED), FROM_NUMBER (0));
 			$$ = ctn;
-
 		}}
 	| isolation_level_name								%dprec 1
-		{{ DBG_TRACE_GRAMMAR(isolation_level_spec, | isolation_level_name);
-
+		{{
 			container_4 ctn;
 			PT_MISC_TYPE schema = PT_REPEATABLE_READ;
 			PT_MISC_TYPE level = 0;
@@ -11781,11 +10683,9 @@ isolation_level_spec
 			SET_CONTAINER_4 (ctn, NULL, FROM_NUMBER (schema),
 					 FROM_NUMBER (level), FROM_NUMBER (0));
 			$$ = ctn;
-
 		}}
 	| isolation_level_name of_schema_class 						%dprec 1
-		{{ DBG_TRACE_GRAMMAR(isolation_level_spec, | isolation_level_name of_schema_class);
-
+		{{
 			container_4 ctn;
 			PT_MISC_TYPE schema = 0;
 			PT_MISC_TYPE level = 0;
@@ -11798,11 +10698,9 @@ isolation_level_spec
 			SET_CONTAINER_4 (ctn, NULL, FROM_NUMBER (schema), FROM_NUMBER (level),
 					 FROM_NUMBER (error));
 			$$ = ctn;
-
 		}}
 	| isolation_level_name INSTANCES						%dprec 1
-		{{ DBG_TRACE_GRAMMAR(isolation_level_spec, | isolation_level_name INSTANCES);
-
+		{{
 			container_4 ctn;
 			PT_MISC_TYPE schema = 0;
 			PT_MISC_TYPE level = 0;
@@ -11813,11 +10711,9 @@ isolation_level_spec
 			SET_CONTAINER_4 (ctn, NULL, FROM_NUMBER (schema), FROM_NUMBER (level),
 					 FROM_NUMBER (0));
 			$$ = ctn;
-
 		}}
 	| isolation_level_name of_schema_class ',' isolation_level_name INSTANCES	%dprec 10
-		{{ DBG_TRACE_GRAMMAR(isolation_level_spec, | isolation_level_name of_schema_class ',' isolation_level_name INSTANCES);
-
+		{{
 			container_4 ctn;
 			PT_MISC_TYPE schema = 0;
 			PT_MISC_TYPE level = 0;
@@ -11829,10 +10725,9 @@ isolation_level_spec
 			SET_CONTAINER_4 (ctn, NULL, FROM_NUMBER (schema), FROM_NUMBER (level),
 					 FROM_NUMBER (error));
 			$$ = ctn;
-
 		}}
 	| isolation_level_name INSTANCES ',' isolation_level_name of_schema_class	%dprec 10
-		{{ DBG_TRACE_GRAMMAR(isolation_level_spec, | isolation_level_name INSTANCES ',' isolation_level_name of_schema_class);
+		{{
 			container_4 ctn;
 			PT_MISC_TYPE schema = 0;
 			PT_MISC_TYPE level = 0;
@@ -11844,7 +10739,6 @@ isolation_level_spec
 			SET_CONTAINER_4 (ctn, NULL, FROM_NUMBER (schema), FROM_NUMBER (level),
 					 FROM_NUMBER (error));
 			$$ = ctn;
-
 		}}
 	;
 
@@ -11855,23 +10749,18 @@ of_schema_class
 
 isolation_level_name
 	: REPEATABLE READ
-		{{ DBG_TRACE_GRAMMAR(isolation_level_name, : REPEATABLE READ); 
-
+		{{
 			$$ = PT_REPEATABLE_READ;
-
 		}}
 	| READ COMMITTED
-		{{ DBG_TRACE_GRAMMAR(isolation_level_name, | READ COMMITTED); 
-
+		{{
 			$$ = PT_READ_COMMITTED;
-
 		}}
 	;
 
 timeout_spec
 	: INFINITE_
-		{{ DBG_TRACE_GRAMMAR(timeout_spec, : INFINITE_);
-
+		{{
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 
 			if (val)
@@ -11882,11 +10771,9 @@ timeout_spec
 
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| OFF_
-		{{ DBG_TRACE_GRAMMAR(timeout_spec, | OFF_);
-
+		{{
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 
 			if (val)
@@ -11897,43 +10784,33 @@ timeout_spec
 
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| unsigned_integer
-		{{ DBG_TRACE_GRAMMAR(timeout_spec, | unsigned_integer);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| unsigned_real
-		{{ DBG_TRACE_GRAMMAR(timeout_spec, | unsigned_real);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| param_
-		{{ DBG_TRACE_GRAMMAR(timeout_spec, | param_);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| host_param_input
-		{{ DBG_TRACE_GRAMMAR(timeout_spec, | host_param_input);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 
 transaction_stmt
 	: COMMIT opt_work RETAIN LOCK_
-		{{ DBG_TRACE_GRAMMAR(transaction_stmt, : COMMIT opt_work RETAIN LOCK_);
-
+		{{
 			PT_NODE *comm = parser_new_node (this_parser, PT_COMMIT_WORK);
 
 			if (comm)
@@ -11943,19 +10820,15 @@ transaction_stmt
 
 			$$ = comm;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| COMMIT opt_work
-		{{ DBG_TRACE_GRAMMAR(timeout_spec, | COMMIT opt_work);
-
+		{{
 			PT_NODE *comm = parser_new_node (this_parser, PT_COMMIT_WORK);
 			$$ = comm;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| ROLLBACK opt_work TO opt_savepoint expression_
-		{{ DBG_TRACE_GRAMMAR(timeout_spec, | ROLLBACK opt_work TO opt_savepoint expression_);
-
+		{{
 			PT_NODE *roll = parser_new_node (this_parser, PT_ROLLBACK_WORK);
 
 			if (roll)
@@ -11965,19 +10838,15 @@ transaction_stmt
 
 			$$ = roll;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| ROLLBACK opt_work
-		{{ DBG_TRACE_GRAMMAR(timeout_spec, | ROLLBACK opt_work);
-
+		{{
 			PT_NODE *roll = parser_new_node (this_parser, PT_ROLLBACK_WORK);
 			$$ = roll;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SAVEPOINT expression_
-		{{ DBG_TRACE_GRAMMAR(timeout_spec, | expression_);
-
+		{{
 			PT_NODE *svpt = parser_new_node (this_parser, PT_SAVEPOINT);
 
 			if (svpt)
@@ -11987,7 +10856,6 @@ transaction_stmt
 
 			$$ = svpt;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
@@ -12009,8 +10877,7 @@ opt_to
 
 evaluate_stmt
 	: EVALUATE expression_ into_clause_opt
-		{{ DBG_TRACE_GRAMMAR(evaluate_stmt, : EVALUATE expression_ into_clause_opt);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_EVALUATE);
 
 			if (node)
@@ -12021,14 +10888,12 @@ evaluate_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 prepare_stmt
 	: PREPARE identifier FROM char_string
-		{{ DBG_TRACE_GRAMMAR(prepare_stmt, : PREPARE identifier FROM char_string);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_PREPARE_STATEMENT);
 
 			if (node)
@@ -12039,14 +10904,12 @@ prepare_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 execute_stmt
 	: EXECUTE identifier opt_using
-		{{ DBG_TRACE_GRAMMAR(execute_stmt, : EXECUTE identifier opt_using);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_EXECUTE_PREPARE);
 
 			if (node)
@@ -12059,24 +10922,19 @@ execute_stmt
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_using
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_using, : );
-
-
+		{{
 			$$ = NULL;
-
 		}}
 	| USING
 		{ parser_save_and_set_hvar (0); }
 		execute_using_list
 		{ parser_restore_hvar (); }
-		{{ DBG_TRACE_GRAMMAR(opt_using, | USING execute_using_list);
-
+		{{
                         int arg[2];
                         arg[0] = PT_SELECT;
                         arg[1] = 0;
@@ -12093,128 +10951,96 @@ opt_using
 
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_status
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_status, : );
-
+		{{
 			$$ = PT_MISC_DUMMY;
-
 		}}
 	| trigger_status
-		{{ DBG_TRACE_GRAMMAR(opt_status, | trigger_status);
-
+		{{
 			$$ = $1;
-
 		}}
 	;
 
 trigger_status
 	: STATUS ACTIVE
-		{{ DBG_TRACE_GRAMMAR(trigger_status, : STATUS ACTIVE);
-
+		{{
 			$$ = PT_ACTIVE;
-
 		}}
 	| STATUS INACTIVE
-		{{ DBG_TRACE_GRAMMAR(trigger_status, | STATUS INACTIVE);
-
+		{{
 			$$ = PT_INACTIVE;
-
 		}}
 	;
 
 opt_priority
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_priority, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| trigger_priority
-		{{ DBG_TRACE_GRAMMAR(opt_priority, | trigger_priority);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 trigger_priority
 	: PRIORITY unsigned_real
-		{{ DBG_TRACE_GRAMMAR(trigger_priority, : PRIORITY unsigned_real);
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_if_trigger_condition
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_if_trigger_condition, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| IF trigger_condition
-		{{ DBG_TRACE_GRAMMAR(opt_if_trigger_condition, |   IF trigger_condition);
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 trigger_time
 	: BEFORE
-		{{ DBG_TRACE_GRAMMAR(trigger_time, : BEFORE);
-
+		{{
 			$$ = PT_BEFORE;
-
 		}}
 	| AFTER
-		{{ DBG_TRACE_GRAMMAR(trigger_time, | AFTER);
-
+		{{
 			$$ = PT_AFTER;
-
 		}}
 	| DEFERRED
-		{{ DBG_TRACE_GRAMMAR(trigger_time, | DEFERRED);
-
+		{{
 			$$ = PT_DEFERRED;
-
 		}}
 	;
 
 opt_trigger_action_time
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_trigger_action_time, : );
-
+		{{
 			$$ = PT_MISC_DUMMY;
-
 		}}
 	| AFTER
-		{{ DBG_TRACE_GRAMMAR(opt_trigger_action_time, | AFTER);
-
+		{{
 			$$ = PT_AFTER;
-
 		}}
 	| DEFERRED
-		{{ DBG_TRACE_GRAMMAR(opt_trigger_action_time, | DEFERRED);
-
+		{{
 			$$ = PT_DEFERRED;
-
 		}}
 	;
 
 event_spec
 	: event_type
-		{{ DBG_TRACE_GRAMMAR(event_spec, : event_type);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_EVENT_SPEC);
 
 			if (node)
@@ -12224,11 +11050,9 @@ event_spec
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| event_type event_target
-		{{ DBG_TRACE_GRAMMAR(opt_trigger_aevent_specction_time, | event_type event_target);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_EVENT_SPEC);
 
 			if (node)
@@ -12239,65 +11063,47 @@ event_spec
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 event_type
 	: INSERT
-		{{ DBG_TRACE_GRAMMAR(event_type, : INSERT);
-
+		{{
 			$$ = PT_EV_INSERT;
-
 		}}
 	| STATEMENT INSERT
-		{{ DBG_TRACE_GRAMMAR(event_type, | STATEMENT INSERT);
-
+		{{
 			$$ = PT_EV_STMT_INSERT;
-
 		}}
 	| DELETE_
-		{{ DBG_TRACE_GRAMMAR(event_type, | DELETE_);
-
+		{{
 			$$ = PT_EV_DELETE;
-
 		}}
 	| STATEMENT DELETE_
-		{{ DBG_TRACE_GRAMMAR(event_type, | STATEMENT DELETE_);
-
+		{{
 			$$ = PT_EV_STMT_DELETE;
-
 		}}
 	| UPDATE
-		{{ DBG_TRACE_GRAMMAR(event_type, | UPDATE);
-
+		{{
 			$$ = PT_EV_UPDATE;
-
 		}}
 	| STATEMENT UPDATE
-		{{ DBG_TRACE_GRAMMAR(event_type, | STATEMENT UPDATE);
-
+		{{
 			$$ = PT_EV_STMT_UPDATE;
-
 		}}
 	| COMMIT
-		{{ DBG_TRACE_GRAMMAR(event_type, | COMMIT);
-
+		{{
 			$$ = PT_EV_COMMIT;
-
 		}}
 	| ROLLBACK
-		{{ DBG_TRACE_GRAMMAR(event_type, | ROLLBACK);
-
+		{{
 			$$ = PT_EV_ROLLBACK;
-
 		}}
 	;
 
 event_target
 	: ON_ class_name '(' identifier ')'
-		{{ DBG_TRACE_GRAMMAR(event_target, : ON_ class_name '(' identifier ')');
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_EVENT_TARGET);
 
 			if (node)
@@ -12308,11 +11114,9 @@ event_target
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| ON_ class_name
-		{{ DBG_TRACE_GRAMMAR(event_target, | ON_ class_name);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_EVENT_TARGET);
 
 			if (node)
@@ -12322,31 +11126,25 @@ event_target
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 trigger_condition
 	: search_condition
-		{{ DBG_TRACE_GRAMMAR(trigger_condition, : search_condition);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| call_stmt
-		{{ DBG_TRACE_GRAMMAR(trigger_condition, | call_stmt);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 trigger_action_in
 	: REJECT_
-		{{ DBG_TRACE_GRAMMAR(trigger_action, : REJECT_);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_TRIGGER_ACTION);
 
 			if (node)
@@ -12356,11 +11154,9 @@ trigger_action_in
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| INVALIDATE TRANSACTION
-		{{ DBG_TRACE_GRAMMAR(trigger_action, | INVALIDATE TRANSACTION);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_TRIGGER_ACTION);
 
 			if (node)
@@ -12370,11 +11166,9 @@ trigger_action_in
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| PRINT char_string_literal
-		{{ DBG_TRACE_GRAMMAR(trigger_action, | PRINT char_string_literal);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_TRIGGER_ACTION);
 
 			if (node)
@@ -12385,11 +11179,9 @@ trigger_action_in
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| evaluate_stmt
-		{{ DBG_TRACE_GRAMMAR(trigger_action, | evaluate_stmt);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_TRIGGER_ACTION);
 
 			if (node)
@@ -12400,11 +11192,9 @@ trigger_action_in
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| insert_or_replace_stmt
-		{{ DBG_TRACE_GRAMMAR(trigger_action, | insert_or_replace_stmt);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_TRIGGER_ACTION);
 
 			if (node)
@@ -12415,11 +11205,9 @@ trigger_action_in
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| update_stmt
-		{{ DBG_TRACE_GRAMMAR(trigger_action, | update_stmt);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_TRIGGER_ACTION);
 
 			if (node)
@@ -12430,11 +11218,9 @@ trigger_action_in
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| delete_stmt
-		{{ DBG_TRACE_GRAMMAR(trigger_action, | delete_stmt);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_TRIGGER_ACTION);
 
 			if (node)
@@ -12445,11 +11231,9 @@ trigger_action_in
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| call_stmt
-		{{ DBG_TRACE_GRAMMAR(trigger_action, | call_stmt);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_TRIGGER_ACTION);
 
 			if (node)
@@ -12460,11 +11244,9 @@ trigger_action_in
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| merge_stmt
-		{{ DBG_TRACE_GRAMMAR(trigger_action, | merge_stmt);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_TRIGGER_ACTION);
 
 			if (node)
@@ -12475,13 +11257,12 @@ trigger_action_in
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 trigger_action
 	: trigger_action_in
-	    {{ DBG_TRACE_GRAMMAR(trigger_action, : trigger_action_in);
+	    {{
 		$$ = $1;
 		PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 	     }}
@@ -12489,9 +11270,7 @@ trigger_action
 
 trigger_spec_list
 	: trigger_name_list
-		{{ DBG_TRACE_GRAMMAR(trigger_spec_list, : trigger_name_list);
-
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_TRIGGER_SPEC_LIST);
 
 			if (node)
@@ -12501,11 +11280,9 @@ trigger_spec_list
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| ALL TRIGGERS
-		{{ DBG_TRACE_GRAMMAR(trigger_spec_list, | ALL TRIGGERS);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_TRIGGER_SPEC_LIST);
 
 			if (node)
@@ -12515,34 +11292,27 @@ trigger_spec_list
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 trigger_status_or_priority_or_change_owner
 	: trigger_status
-		{{ DBG_TRACE_GRAMMAR(trigger_status_or_priority_or_change_owner, : trigger_status);
-
+		{{
 			container_3 ctn;
 			SET_CONTAINER_3 (ctn, FROM_NUMBER ($1), NULL, NULL);
 			$$ = ctn;
-
 		}}
 	| trigger_priority
-		{{ DBG_TRACE_GRAMMAR(trigger_status_or_priority_or_change_owner, | trigger_priority);
-
+		{{
 			container_3 ctn;
 			SET_CONTAINER_3 (ctn, FROM_NUMBER (PT_MISC_DUMMY), $1, NULL);
 			$$ = ctn;
-
 		}}
 	| OWNER TO identifier
-		{{ DBG_TRACE_GRAMMAR(trigger_status_or_priority_or_change_owner, | OWNER TO identifier);
-
+		{{
 			container_3 ctn;
 			SET_CONTAINER_3 (ctn, FROM_NUMBER (PT_MISC_DUMMY), NULL, $3);
 			$$ = ctn;
-
 		}}
 	;
 
@@ -12553,8 +11323,7 @@ opt_maximum
 
 trace_spec
 	: ON_
-		{{ DBG_TRACE_GRAMMAR(trace_spec, : ON_);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 
 			if (node)
@@ -12565,11 +11334,9 @@ trace_spec
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| OFF_
-		{{ DBG_TRACE_GRAMMAR(trace_spec, | OFF_);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 
 			if (node)
@@ -12580,59 +11347,45 @@ trace_spec
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| unsigned_integer
-		{{ DBG_TRACE_GRAMMAR(trace_spec, | unsigned_integer);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| param_
-		{{ DBG_TRACE_GRAMMAR(trace_spec, | param_);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| host_param_input
-		{{ DBG_TRACE_GRAMMAR(trace_spec, | host_param_input);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 depth_spec
 	: unsigned_integer
-		{{ DBG_TRACE_GRAMMAR(depth_spec, : unsigned_integer);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| param_
-		{{ DBG_TRACE_GRAMMAR(depth_spec, | param_);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| host_param_input
-		{{ DBG_TRACE_GRAMMAR(depth_spec, | host_param_input);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 serial_start
 	: START_ WITH integer_text
-		{{ DBG_TRACE_GRAMMAR(serial_start, : START_ WITH integer_text);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 			if (node)
 			  {
@@ -12645,14 +11398,12 @@ serial_start
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 serial_increment
 	: INCREMENT BY integer_text
-		{{ DBG_TRACE_GRAMMAR(serial_increment, : INCREMENT BY integer_text);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 			if (node)
 			  {
@@ -12665,15 +11416,13 @@ serial_increment
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 
 serial_min
 	: MINVALUE integer_text
-		{{ DBG_TRACE_GRAMMAR(serial_min, : MINVALUE integer_text);
-
+		{{
 			container_2 ctn;
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 			if (node)
@@ -12687,22 +11436,18 @@ serial_min
 
 			SET_CONTAINER_2 (ctn, node, FROM_NUMBER (0));
 			$$ = ctn;
-
 		}}
 	| NOMINVALUE
-		{{ DBG_TRACE_GRAMMAR(serial_min, | NOMINVALUE);
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, NULL, FROM_NUMBER (1));
 			$$ = ctn;
-
 		}}
 	;
 
 serial_max
 	: MAXVALUE integer_text
-		{{ DBG_TRACE_GRAMMAR(serial_max, : MAXVALUE integer_text);
-
+		{{
 			container_2 ctn;
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 			if (node)
@@ -12716,76 +11461,60 @@ serial_max
 
 			SET_CONTAINER_2 (ctn, node, FROM_NUMBER (0));
 			$$ = ctn;
-
 		}}
 	| NOMAXVALUE
-		{{ DBG_TRACE_GRAMMAR(serial_max, | NOMAXVALUE);
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, NULL, FROM_NUMBER (1));
 			$$ = ctn;
-
 		}}
 	;
 
 of_cycle_nocycle
 	: CYCLE
-		{{ DBG_TRACE_GRAMMAR(of_cycle_nocycle, : CYCLE);
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (1), FROM_NUMBER (0));
 			$$ = ctn;
-
 		}}
 	| NOCYCLE
-		{{ DBG_TRACE_GRAMMAR(of_cycle_nocycle, | NOCYCLE);
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (0), FROM_NUMBER (1));
 			$$ = ctn;
-
 		}}
 	;
 
 of_cached_num
 	: CACHE unsigned_int32
-		{{ DBG_TRACE_GRAMMAR(of_cached_num, : CACHE unsigned_int32);
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, $2, FROM_NUMBER (0));
 			$$ = ctn;
-
 		}}
 	| NOCACHE
-		{{ DBG_TRACE_GRAMMAR(of_cached_num, | NOCACHE);
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, NULL, FROM_NUMBER (1));
 			$$ = ctn;
-
 		}}
 	;
 
 integer_text
 	: opt_plus UNSIGNED_INTEGER
-		{{ DBG_TRACE_GRAMMAR(integer_text, : opt_plus UNSIGNED_INTEGER);
-
+		{{
 			$$ = $2;
-
 		}}
 	| '-' UNSIGNED_INTEGER
-		{{ DBG_TRACE_GRAMMAR(integer_text, | '-' UNSIGNED_INTEGER);
-
+		{{
 			$$ = pt_append_string (this_parser, (char *) "-", $2);
-
 		}}
 	;
 
 uint_text
 	: UNSIGNED_INTEGER
-		{{ DBG_TRACE_GRAMMAR(uint_text, : UNSIGNED_INTEGER);
-
+		{{
 			$$ = $1;
-
 		}}
 	;
 
@@ -12800,23 +11529,18 @@ sp_return_type
                 is_in_sp_func_type = true;
            }
            data_type
-                {{ DBG_TRACE_GRAMMAR(sp_return_type, : data_type);
-
+                {{
                         is_in_sp_func_type = false;
 			$$ = $2;
-
                 }}
         | CURSOR
-                {{ DBG_TRACE_GRAMMAR(sp_return_type, | CURSOR);
-
+                {{
 			container_2 ctn;
 			SET_CONTAINER_2(ctn, FROM_NUMBER(PT_TYPE_RESULTSET), NULL);
 			$$ = ctn;
-
                 }}
         | table_column MOD TYPE
-		{{ DBG_TRACE_GRAMMAR(sp_return_type, | table_column MOD TYPE);
-
+		{{
 			container_2 ctn;
 
 			PT_NODE *dt = parser_new_node (this_parser, PT_DATA_TYPE);
@@ -12829,67 +11553,66 @@ sp_return_type
 
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_NONE), dt); // PT_TYPE_NONE: unknown yet
 			$$ = ctn;
-
 		}}
         ;
 
 opt_authid
         : AUTHID DEFINER
-                {{ DBG_TRACE_GRAMMAR(opt_authid, : AUTHID DEFINER);
+                {{
                         $$ = PT_AUTHID_OWNER; 
                 }}
         | AUTHID OWNER
-                {{ DBG_TRACE_GRAMMAR(opt_authid, : AUTHID OWNER);
+                {{
                         $$ = PT_AUTHID_OWNER; 
                 }}
         | AUTHID CALLER
-                {{ DBG_TRACE_GRAMMAR(opt_authid, : AUTHID CALLER);
+                {{
                         $$ = PT_AUTHID_CALLER; 
                 }}
         | AUTHID CURRENT_USER
-                {{ DBG_TRACE_GRAMMAR(opt_authid, : AUTHID CURRENT_USER);
+                {{
                         $$ = PT_AUTHID_CALLER; 
                 }}
         ;
 
 opt_deterministic
         : NOT DETERMINISTIC
-                {{ DBG_TRACE_GRAMMAR(opt_deterministic, : NOT DETERMINISTIC);
+                {{
                         $$ = PT_NOT_DETERMINISTIC; 
                 }}
         | DETERMINISTIC
-                {{ DBG_TRACE_GRAMMAR(opt_deterministic, : DETERMINISTIC);
+                {{
                         $$ = PT_DETERMINISTIC; 
                 }}
         ;
 
 opt_authid_and_deterministic
         : /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_authid_and_deterministic, : abcde);
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, NULL, NULL);
 			$$ = ctn;
 		}}
         | opt_authid opt_deterministic
-		{{ DBG_TRACE_GRAMMAR(opt_authid_and_deterministic, : opt_authid opt_deterministic);
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER($1), FROM_NUMBER($2));
 			$$ = ctn;
 		}}
         | opt_deterministic opt_authid
-		{{ DBG_TRACE_GRAMMAR(opt_authid_and_deterministic, : opt_deterministic opt_authid);
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER($2), FROM_NUMBER($1));
 			$$ = ctn;
 		}}
         | opt_authid
-		{{ DBG_TRACE_GRAMMAR(opt_authid_and_deterministic, : opt_authid);
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER($1), NULL);
 			$$ = ctn;
 		}}
         | opt_deterministic
-		{{ DBG_TRACE_GRAMMAR(opt_authid_and_deterministic, : opt_deterministic);
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, NULL, FROM_NUMBER($1));
 			$$ = ctn;
@@ -12898,22 +11621,21 @@ opt_authid_and_deterministic
 
 is_or_as
 	: IS          
-                { DBG_TRACE_GRAMMAR(is_or_as, : IS); }
+                { }
 	| AS          
-                { DBG_TRACE_GRAMMAR(is_or_as, : AS); }
+                { }
 	;
 
 opt_lang_plcsql
         : /* empty */          
-                { DBG_TRACE_GRAMMAR(opt_lang_plcsql, : ); }
+                { }
         | LANGUAGE PLCSQL
-                { DBG_TRACE_GRAMMAR(opt_lang_plcsql, : LANGUAGE PLCSQL); }
+                { }
         ;
 
 pl_language_spec
 	: opt_lang_plcsql plcsql_text
-		{{ DBG_TRACE_GRAMMAR(pl_language_spec, : opt_lang_plcsql plcsql_text);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_SP_BODY);
 
 			if (node)
@@ -12930,12 +11652,10 @@ pl_language_spec
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| LANGUAGE JAVA 		/* 1, 2 */
 	  NAME char_string_literal	/* 3, 4 */
-		{{ DBG_TRACE_GRAMMAR(pl_language_spec, : LANGAUGE JAVA );
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_SP_BODY);
 
 			if (node)
@@ -12947,55 +11667,50 @@ pl_language_spec
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 plcsql_text
         : plcsql_text plcsql_text_part
-		{{ DBG_TRACE_GRAMMAR(plcsql_text, : plcsql_text plcsql_text_part);
-
+		{{
                         $$ = $1 + strlen($2);
-
 		}}
         | plcsql_text_part
-		{{ DBG_TRACE_GRAMMAR(plcsql_text, | plcsql_text_part);
-
+		{{
                         assert(g_plcsql_text_pos == -1);
                         $$ = strlen($1);
                         g_plcsql_text_pos = @$.buffer_pos - $$;
-
 		}}
         ;
 
 plcsql_text_part
         : PLCSQL_TEXT_SOME
-		{{ DBG_TRACE_GRAMMAR(plcsql_text_part, : PLCSQL_TEXT_SOME);
+		{{
                     $$ = $1;
 		}}
         | CHAR_STRING
-		{{ DBG_TRACE_GRAMMAR(plcsql_text_part, | CHAR_STRING);
+		{{
                     char* val = pt_append_string(this_parser, NULL, "'");
                     val = pt_append_string(this_parser, val, $1);
                     val = pt_append_string(this_parser, val, "'");
                     $$ = val;
 		}}
         | DelimitedIdName
-		{{ DBG_TRACE_GRAMMAR(plcsql_text_part, | DelimitedIdName);
+		{{
                     char* val = pt_append_string(this_parser, NULL, "\"");
                     val = pt_append_string(this_parser, val, $1);
                     val = pt_append_string(this_parser, val, "\"");
                     $$ = val;
 		}}
         | BracketDelimitedIdName
-		{{ DBG_TRACE_GRAMMAR(plcsql_text_part, | BracketDelimitedIdName);
+		{{
                     char* val = pt_append_string(this_parser, NULL, "[");
                     val = pt_append_string(this_parser, val, $1);
                     val = pt_append_string(this_parser, val, "]");
                     $$ = val;
 		}}
         | BacktickDelimitedIdName
-		{{ DBG_TRACE_GRAMMAR(plcsql_text_part, | BacktickDelimitedIdName);
+		{{
                     char* val = pt_append_string(this_parser, NULL, "`");
                     val = pt_append_string(this_parser, val, $1);
                     val = pt_append_string(this_parser, val, "`");
@@ -13005,40 +11720,30 @@ plcsql_text_part
 
 opt_sp_param_list
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_sp_param_list, : );
-
+		{{
 			$$ = NULL;
-
 		}}
         | '(' ')'
-		{{ DBG_TRACE_GRAMMAR(opt_sp_param_list, | '(' ')' );
-
+		{{
 			$$ = NULL;  // same as the empty case
-
 		}}
 	| '(' sp_param_list ')'
-		{{ DBG_TRACE_GRAMMAR(opt_sp_param_list, | '(' sp_param_list ')' );
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 sp_param_list
 	: sp_param_list ',' sp_param_def
-		{{ DBG_TRACE_GRAMMAR(sp_param_list, : sp_param_list ',' sp_param_def); 
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| sp_param_def
-		{{ DBG_TRACE_GRAMMAR(sp_param_list, | sp_param_def); 
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
@@ -13048,8 +11753,7 @@ sp_param_def
 	  sp_param_type
           opt_sp_default_value
 	  opt_comment_spec
-		{{ DBG_TRACE_GRAMMAR(sp_param_def, : identifier opt_sp_in_out sp_param_type opt_comment_spec);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_SP_PARAMETERS);
 
 			if (node)
@@ -13064,7 +11768,6 @@ sp_param_def
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
@@ -13074,23 +11777,18 @@ sp_param_type
               is_in_sp_func_type = true;
           }
          data_type
-		{{ DBG_TRACE_GRAMMAR(sp_param_type, : data_type);
-
+		{{
                         is_in_sp_func_type = false;
                         $$ = $2;
-
 		}}
         | CURSOR
-		{{ DBG_TRACE_GRAMMAR(sp_param_type, | CURSOR);
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_RESULTSET), NULL);
 			$$ = ctn;
-
 		}}
         | table_column MOD TYPE
-		{{ DBG_TRACE_GRAMMAR(sp_param_type, | table_column MOD TYPE);
-
+		{{
 			container_2 ctn;
 
 			PT_NODE *dt = parser_new_node (this_parser, PT_DATA_TYPE);
@@ -13103,14 +11801,12 @@ sp_param_type
 
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_NONE), dt); // PT_TYPE_NONE: unknown yet
 			$$ = ctn;
-
 		}}
         ;
 
 table_column
         : class_name DOT identifier
-		{{ DBG_TRACE_GRAMMAR(table_column, : class_name DOT identifier);
-
+		{{
 			PT_NODE *dot = parser_new_node (this_parser, PT_DOT_);
 			if (dot)
 			  {
@@ -13120,22 +11816,17 @@ table_column
 
                         $$ = dot;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
         ;
 
 opt_sp_in_out
 	: opt_in_out
-		{{ DBG_TRACE_GRAMMAR(opt_sp_in_out, : opt_in_out); 
-
+		{{
 			$$ = $1;
-
 		}}
 	| IN_ OUT_
-		{{ DBG_TRACE_GRAMMAR(opt_sp_in_out, | IN_ OUT_); 
-
+		{{
 			$$ = PT_INPUTOUTPUT;
-
 		}}
 	;
 
@@ -13162,18 +11853,16 @@ opt_sp_default_value
 esql_query_stmt
 	: 	{ parser_select_level++; }
 	  csql_query_select_has_no_with_clause
-		{{ DBG_TRACE_GRAMMAR(esql_query_stmt, : csql_query_select_has_no_with_clause); 
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 			parser_select_level--;
-
 		}}
 	;
 
 csql_query
 	:
 		{{
-
 			parser_save_and_set_cannot_cache (false);
 			parser_save_and_set_ic (0);
 			parser_save_and_set_gc (0);
@@ -13185,18 +11874,14 @@ csql_query
 			parser_save_and_set_serc (1);
 			parser_save_and_set_sqc (1);
 			parser_save_and_set_pseudoc (1);
-
 		}}
 	  select_expression_opt_with
-		{{ DBG_TRACE_GRAMMAR(csql_query, : select_expression_opt_with);
-
+		{{
 			PT_NODE *node = $2;
 			parser_push_orderby_node (node);
-
 		}}
 	  opt_orderby_clause
-		{{ DBG_TRACE_GRAMMAR(csql_query, opt_orderby_clause);
-
+		{{
 			PT_NODE *node = parser_pop_orderby_node ();
 
 			if (node && parser_cannot_cache)
@@ -13245,23 +11930,19 @@ csql_query
 			  }
 
 			parser_push_orderby_node (node);
-
 		}}
 	opt_select_limit_clause
 	opt_for_update_clause
-		{{ DBG_TRACE_GRAMMAR(csql_query, opt_select_limit_clause opt_for_update_clause);
-
+		{{
 			PT_NODE *node = parser_pop_orderby_node ();
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 csql_query_select_has_no_with_clause
 	:
 		{{
-
 			parser_save_and_set_cannot_cache (false);
 			parser_save_and_set_ic (0);
 			parser_save_and_set_gc (0);
@@ -13273,18 +11954,14 @@ csql_query_select_has_no_with_clause
 			parser_save_and_set_serc (1);
 			parser_save_and_set_sqc (1);
 			parser_save_and_set_pseudoc (1);
-
 		}}
 	  select_expression
-		{{ DBG_TRACE_GRAMMAR(csql_query_select_has_no_with_clause, : select_expression);
-
+		{{
 			PT_NODE *node = $2;
 			parser_push_orderby_node (node);
-
 		}}
 	  opt_orderby_clause
-		{{ DBG_TRACE_GRAMMAR(csql_query_select_has_no_with_clause, opt_orderby_clause);
-
+		{{
 			PT_NODE *node = parser_pop_orderby_node ();
 
 			if (node && parser_cannot_cache)
@@ -13333,23 +12010,19 @@ csql_query_select_has_no_with_clause
 			  }
 
 			parser_push_orderby_node (node);
-
 		}}
 	opt_select_limit_clause
 	opt_for_update_clause
-		{{ DBG_TRACE_GRAMMAR(csql_query_select_has_no_with_clause, opt_select_limit_clause opt_for_update_clause);
-
+		{{
 			PT_NODE *node = parser_pop_orderby_node ();
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 csql_query_without_subquery_and_with_clause
 	:
 		{{
-
 			parser_save_and_set_cannot_cache (false);
 			parser_save_and_set_ic (0);
 			parser_save_and_set_gc (0);
@@ -13361,18 +12034,14 @@ csql_query_without_subquery_and_with_clause
 			parser_save_and_set_serc (1);
 			parser_save_and_set_sqc (1);
 			parser_save_and_set_pseudoc (1);
-
 		}}
 	  select_expression_without_subquery
-		{{ DBG_TRACE_GRAMMAR(csql_query_without_subquery_and_with_clause, : select_expression_without_subquery);
-
+		{{
 			PT_NODE *node = $2;
 			parser_push_orderby_node (node);
-
 		}}
 	  opt_orderby_clause
-		{{ DBG_TRACE_GRAMMAR(csql_query_without_subquery_and_with_clause, opt_orderby_clause);
-
+		{{
 			PT_NODE *node = parser_pop_orderby_node ();
 
 			if (node && parser_cannot_cache)
@@ -13421,23 +12090,19 @@ csql_query_without_subquery_and_with_clause
 			  }
 
 			parser_push_orderby_node (node);
-
 		}}
 	opt_select_limit_clause
 	opt_for_update_clause
-		{{ DBG_TRACE_GRAMMAR(csql_query_without_subquery_and_with_clause, opt_select_limit_clause opt_for_update_clause);
-
+		{{
 			PT_NODE *node = parser_pop_orderby_node ();
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 csql_query_without_values_query_no_with_clause
 	:
 		{{
-
 			parser_save_and_set_cannot_cache (false);
 			parser_save_and_set_ic (0);
 			parser_save_and_set_gc (0);
@@ -13449,18 +12114,14 @@ csql_query_without_values_query_no_with_clause
 			parser_save_and_set_serc (1);
 			parser_save_and_set_sqc (1);
 			parser_save_and_set_pseudoc (1);
-
 		}}
 	  select_expression_without_values_query_no_with_clause
-		{{ DBG_TRACE_GRAMMAR(csql_query_without_values_query_no_with_clause, : select_expression_without_values_query_no_with_clause);
-
+		{{
 			PT_NODE *node = $2;
 			parser_push_orderby_node (node);
-
 		}}
 	  opt_orderby_clause
-		{{ DBG_TRACE_GRAMMAR(csql_query_without_values_query_no_with_clause, opt_orderby_clause);
-
+		{{
 			PT_NODE *node = parser_pop_orderby_node ();
 
 			if (node && parser_cannot_cache)
@@ -13509,23 +12170,19 @@ csql_query_without_values_query_no_with_clause
 			  }
 
 			parser_push_orderby_node (node);
-
 		}}
 	  opt_select_limit_clause
 	  opt_for_update_clause
-		{{ DBG_TRACE_GRAMMAR(csql_query_without_values_query_no_with_clause, opt_select_limit_clause opt_for_update_clause);
-
+		{{
 			PT_NODE *node = parser_pop_orderby_node ();
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 csql_query_without_values_and_single_subquery
 	:
 		{{
-
 			parser_save_and_set_cannot_cache (false);
 			parser_save_and_set_ic (0);
 			parser_save_and_set_gc (0);
@@ -13537,18 +12194,14 @@ csql_query_without_values_and_single_subquery
 			parser_save_and_set_serc (1);
 			parser_save_and_set_sqc (1);
 			parser_save_and_set_pseudoc (1);
-
 		}}
 	  select_expression_without_values_and_single_subquery
-		{{ DBG_TRACE_GRAMMAR(csql_query_without_values_and_single_subquery, : select_expression_without_values_and_single_subquery);
-
+		{{
 			PT_NODE *node = $2;
 			parser_push_orderby_node (node);
-
 		}}
 	  opt_orderby_clause
-		{{ DBG_TRACE_GRAMMAR(csql_query_without_values_and_single_subquery,  opt_orderby_clause);
-
+		{{
 			PT_NODE *node = parser_pop_orderby_node ();
 
 			if (node && parser_cannot_cache)
@@ -13596,16 +12249,13 @@ csql_query_without_values_and_single_subquery
 			  }
 
 			parser_push_orderby_node (node);
-
 		}}
 	  opt_select_limit_clause
 	  opt_for_update_clause
-		{{ DBG_TRACE_GRAMMAR(csql_query_without_values_and_single_subquery,  opt_select_limit_clause opt_for_update_clause);
-
+		{{
 			PT_NODE *node = parser_pop_orderby_node ();
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
@@ -13613,8 +12263,7 @@ csql_query_without_values_and_single_subquery
 select_expression_opt_with
 	: opt_with_clause
 	  select_expression
-		{{ DBG_TRACE_GRAMMAR(select_expression_opt_with,  opt_with_clause select_expression);
-
+		{{
 			PT_NODE *with_clause = $1;
 			PT_NODE *stmt = $2;
 			if (stmt && with_clause)
@@ -13623,20 +12272,18 @@ select_expression_opt_with
 			  }
 
 			$$ = stmt;
-
 		}}
 	;
 
 select_expression_without_subquery
 	: select_expression_without_subquery
-		{{ DBG_TRACE_GRAMMAR(select_expression_without_subquery, : select_expression_without_subquery);
+		{{
         		PT_NODE *node = $1;
 			parser_push_orderby_node (node);
 	        }}
 
 	  opt_orderby_clause
-	        {{ DBG_TRACE_GRAMMAR(select_expression_without_subquery,  opt_orderby_clause);
-
+	        {{
 			PT_NODE *node = parser_pop_orderby_node ();
 
 			if (node && parser_cannot_cache)
@@ -13672,22 +12319,18 @@ select_expression_without_subquery
 			  }
 
 			parser_push_orderby_node (node);
-
 		}}
 
           opt_select_limit_clause
           opt_for_update_clause
-		{{ DBG_TRACE_GRAMMAR(select_expression_without_subquery,  opt_select_limit_clause opt_for_update_clause);
-
+		{{
 			PT_NODE *node = parser_pop_orderby_node ();
 			$<node>$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($<node>$, @$.buffer_pos)
-
                 }}
 
           table_op select_or_values_query
-                {{ DBG_TRACE_GRAMMAR(select_expression_without_subquery,  select_or_values_query);
-
+                {{
 			PT_NODE *stmt = $8;
 			PT_NODE *arg1 = $1;
 
@@ -13711,25 +12354,22 @@ select_expression_without_subquery
 
 			$$ = stmt;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| select_or_values_query
-		{{ DBG_TRACE_GRAMMAR(select_expression_without_subquery, | select_or_values_query);
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 select_expression
 	: select_expression
-		{{ DBG_TRACE_GRAMMAR(select_expression, : select_expression);
+		{{
 			PT_NODE *node = $1;
 			parser_push_orderby_node (node);
 		}}
 	  opt_orderby_clause
-		{{ DBG_TRACE_GRAMMAR(select_expression, opt_orderby_clause);
-
+		{{
 			PT_NODE *node = parser_pop_orderby_node ();
 
 			if (node && parser_cannot_cache)
@@ -13766,20 +12406,16 @@ select_expression
 			  }
 
 			parser_push_orderby_node (node);
-
 		}}
 	  opt_select_limit_clause
 	  opt_for_update_clause
-		{{ DBG_TRACE_GRAMMAR(select_expression, opt_select_limit_clause opt_for_update_clause);
-
+		{{
 			PT_NODE *node = parser_pop_orderby_node ();
 			$<node>$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($<node>$, @$.buffer_pos)
-
 		}}
 	  table_op select_or_subquery
-		{{ DBG_TRACE_GRAMMAR(select_expression, table_op select_or_subquery);
-
+		{{
 			PT_NODE *stmt = $8;
 			PT_NODE *arg1 = $1;
 
@@ -13802,26 +12438,22 @@ select_expression
 
 			$$ = stmt;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| select_or_subquery
-		{{ DBG_TRACE_GRAMMAR(select_expression, | select_or_subquery);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 select_expression_without_values_query_no_with_clause
 	: select_expression_without_values_query_no_with_clause
-		{{ DBG_TRACE_GRAMMAR(select_expression_without_values_query_no_with_clause, : select_expression_without_values_query_no_with_clause);
+		{{
 			PT_NODE *node = $1;
 			parser_push_orderby_node (node);
 		}}
 	  opt_orderby_clause
-		{{ DBG_TRACE_GRAMMAR(select_expression_without_values_query_no_with_clause, opt_orderby_clause);
-
+		{{
 			PT_NODE *node = parser_pop_orderby_node ();
 
 			if (node && parser_cannot_cache)
@@ -13857,20 +12489,16 @@ select_expression_without_values_query_no_with_clause
 			  }
 
 			parser_push_orderby_node (node);
-
 		}}
 	  opt_select_limit_clause
 	  opt_for_update_clause
-		{{ DBG_TRACE_GRAMMAR(select_expression_without_values_query_no_with_clause, opt_select_limit_clause opt_for_update_clause);
-
+		{{
 			PT_NODE *node = parser_pop_orderby_node ();
 			$<node>$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($<node>$, @$.buffer_pos)
-
 		}}
 	  table_op select_or_subquery_without_values_query_no_with_clause
-		{{ DBG_TRACE_GRAMMAR(select_expression_without_values_query_no_with_clause, table_op select_or_subquery_without_values_query_no_with_clause);
-
+		{{
 			PT_NODE *stmt = $8;
 			PT_NODE *arg1 = $1;
 
@@ -13893,26 +12521,22 @@ select_expression_without_values_query_no_with_clause
 
 			$$ = stmt;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| select_or_subquery_without_values_query_no_with_clause
-		{{ DBG_TRACE_GRAMMAR(select_expression_without_values_query_no_with_clause, | select_or_subquery_without_values_query_no_with_clause);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 select_expression_without_values_and_single_subquery
 	: select_expression_without_values_query_no_with_clause
-		{{ DBG_TRACE_GRAMMAR(select_expression_without_values_and_single_subquery, : select_expression_without_values_query_no_with_clause);
+		{{
 			PT_NODE *node = $1;
 			parser_push_orderby_node (node);
 		}}
 	  opt_orderby_clause
-		{{ DBG_TRACE_GRAMMAR(select_expression_without_values_and_single_subquery, opt_orderby_clause);
-
+		{{
 			PT_NODE *node = parser_pop_orderby_node ();
 
 			if (node && parser_cannot_cache)
@@ -13949,20 +12573,16 @@ select_expression_without_values_and_single_subquery
 			  }
 
 			parser_push_orderby_node (node);
-
 		}}
 	  opt_select_limit_clause
 	  opt_for_update_clause
-		{{ DBG_TRACE_GRAMMAR(select_expression_without_values_and_single_subquery, opt_select_limit_clause opt_for_update_clause);
-
+		{{
 			PT_NODE *node = parser_pop_orderby_node ();
 			$<node>$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($<node>$, @$.buffer_pos)
-
 		}}
 	  table_op select_or_subquery_without_values_query_no_with_clause
-		{{ DBG_TRACE_GRAMMAR(select_expression_without_values_and_single_subquery, table_op select_or_subquery_without_values_query_no_with_clause);
-
+		{{
 			PT_NODE *stmt = $8;
 			PT_NODE *arg1 = $1;
 
@@ -13985,20 +12605,17 @@ select_expression_without_values_and_single_subquery
 
 			$$ = stmt;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| select_or_nested_values_query
-		{{ DBG_TRACE_GRAMMAR(select_expression_without_values_and_single_subquery, | select_or_nested_values_query);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 table_op
 	: Union all_distinct
-		{{ DBG_TRACE_GRAMMAR(table_op, : Union all_distinct);
+		{{
 			PT_MISC_TYPE isAll = $2;
 			PT_NODE *node = parser_new_node (this_parser, PT_UNION);
 			if (node)
@@ -14010,11 +12627,9 @@ table_op
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| DIFFERENCE_ all_distinct
-		{{ DBG_TRACE_GRAMMAR(table_op, | DIFFERENCE_ all_distinct);
-
+		{{
 			PT_MISC_TYPE isAll = $2;
 			PT_NODE *node = parser_new_node (this_parser, PT_DIFFERENCE);
 			if (node)
@@ -14026,11 +12641,9 @@ table_op
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| EXCEPT all_distinct
-		{{ DBG_TRACE_GRAMMAR(table_op, | EXCEPT all_distinct);
-
+		{{
 			PT_MISC_TYPE isAll = $2;
 			PT_NODE *node = parser_new_node (this_parser, PT_DIFFERENCE);
 			if (node)
@@ -14042,11 +12655,9 @@ table_op
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| INTERSECTION all_distinct
-		{{ DBG_TRACE_GRAMMAR(table_op, | INTERSECTION all_distinct);
-
+		{{
 			PT_MISC_TYPE isAll = $2;
 			PT_NODE *node = parser_new_node (this_parser, PT_INTERSECTION);
 			if (node)
@@ -14058,11 +12669,9 @@ table_op
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| INTERSECT all_distinct
-		{{ DBG_TRACE_GRAMMAR(table_op, | INTERSECT all_distinct);
-
+		{{
 			PT_MISC_TYPE isAll = $2;
 			PT_NODE *node = parser_new_node (this_parser, PT_INTERSECTION);
 			if (node)
@@ -14074,27 +12683,22 @@ table_op
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 select_or_subquery
 	: select_stmt
-		{{ DBG_TRACE_GRAMMAR(select_or_subquery, : select_stmt);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| subquery
-		{{ DBG_TRACE_GRAMMAR(select_or_subquery, | subquery);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| values_query
-		{{ DBG_TRACE_GRAMMAR(select_or_subquery, | values_query);
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
@@ -14102,46 +12706,38 @@ select_or_subquery
 
 select_or_values_query
 	: values_query
-		{{ DBG_TRACE_GRAMMAR(select_or_values_query, : values_query);
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
 	| select_stmt
-		{{ DBG_TRACE_GRAMMAR(select_or_values_query, | select_stmt);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 select_or_subquery_without_values_query_no_with_clause
 	: select_stmt
-		{{ DBG_TRACE_GRAMMAR(select_or_subquery_without_values_query_no_with_clause, : select_stmt);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| subquery_without_subquery_and_with_clause
-		{{ DBG_TRACE_GRAMMAR(select_or_subquery_without_values_query_no_with_clause, | subquery_without_subquery_and_with_clause);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 select_or_nested_values_query
 	: select_stmt
-		{{ DBG_TRACE_GRAMMAR(select_or_nested_values_query, : select_stmt);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| '(' values_query ')'
-		{{ DBG_TRACE_GRAMMAR(select_or_nested_values_query, | '(' values_query ')');
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
@@ -14149,7 +12745,7 @@ select_or_nested_values_query
 
 values_query
 	: of_value_values
-		{{ DBG_TRACE_GRAMMAR(values_query, : of_value_values);
+		{{
 			PT_NODE *node;
 			parser_save_found_Oracle_outer ();
 			if (parser_select_level >= 0)
@@ -14169,7 +12765,7 @@ values_query
 			  parser_push_hint_node (node);
 		}}
 		values_expression
-			{{ DBG_TRACE_GRAMMAR(values_query, values_expression);
+			{{
 				/* $3 node of type PT_NODE_LIST */
 				PT_NODE *n;
 				PT_NODE *node = parser_pop_select_stmt_node ();
@@ -14216,7 +12812,7 @@ values_query
 
 values_expression
 	: values_expression ',' values_expr_item
-		{{ DBG_TRACE_GRAMMAR(values_expression, : values_expression ',' values_expr_item);
+		{{
 			PT_NODE *node1 = $1;
 			PT_NODE *node2 = $3;
 			parser_make_link (node1, node2);
@@ -14224,14 +12820,14 @@ values_expression
 			$$ = node1;
 		}}
 	| values_expr_item
-		{{ DBG_TRACE_GRAMMAR(values_expression, | values_expr_item);
+		{{
 			$$ = $1;
 		}}
 	;
 
 values_expr_item
 	: '(' alias_enabled_expression_list_top ')'
-		{{ DBG_TRACE_GRAMMAR(values_expr_item, : '(' alias_enabled_expression_list_top ')');
+		{{
 			PT_NODE *node_value = $2;
 			PT_NODE *node_tmp = $2;
 			PT_NODE *node = NULL;
@@ -14252,7 +12848,7 @@ values_expr_item
 select_stmt
 	:
 	SELECT			/* $1 */
-		{{ DBG_TRACE_GRAMMAR(select_stmt, : SELECT);
+		{{
 				/* $2 */
 			PT_NODE *node;
 			parser_save_found_Oracle_outer ();
@@ -14270,13 +12866,12 @@ select_stmt
 
 			parser_push_select_stmt_node (node);
 			parser_push_hint_node (node);
-
 		}}
 	opt_hint_list 		/* $3 */
 	all_distinct            /* $4 */
 	select_list 		/* $5 */
 	opt_select_param_list	/* $6 */
-		{{ DBG_TRACE_GRAMMAR(select_stmt, opt_hint_list all_distinct select_list opt_select_param_list);
+		{{
 				/* $7 */
 			PT_MISC_TYPE isAll = $4;
 			PT_NODE *node = parser_top_select_stmt_node ();
@@ -14294,26 +12889,22 @@ select_stmt
 				parser_hidden_incr_list = NULL;
 			      }
 			  }
-
 		}}
 	opt_from_clause  	/* $8 */
-		{{ DBG_TRACE_GRAMMAR(select_stmt, opt_from_clause);
+		{{
 			$$ = $8;
 		}}
 	;
 
 opt_with_clause
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_with_clause, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| WITH            /* $1 */
 	  opt_recursive   /* $2 */
 	  cte_definition_list   /* $3 */
-		{{ DBG_TRACE_GRAMMAR(opt_with_clause, | WITH opt_recursive cte_definition_list);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_WITH_CLAUSE);
 			if (node)
 			  {
@@ -14326,37 +12917,30 @@ opt_with_clause
 			  }
 
 			$$ = node;
-
 		}}
 	;
 
 opt_recursive
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_recursive, : );
+		{{
 			$$ = 0;
-
 		}}
 	| RECURSIVE
-		{{ DBG_TRACE_GRAMMAR(opt_recursive, | RECURSIVE);
+		{{
 			$$ = 1;
-
 		}}
 	;
 
 cte_definition_list
 	: cte_definition_list ',' cte_definition
-		{{ DBG_TRACE_GRAMMAR(cte_definition_list, : cte_definition_list ',' cte_definition);
-
+		{{
 			$$ = parser_make_link($1, $3);
 			PARSER_SAVE_ERR_CONTEXT($$, @$.buffer_pos)
-
 		}}
 	| cte_definition
-		{{ DBG_TRACE_GRAMMAR(cte_definition_list, | cte_definition);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT($$, @$.buffer_pos)
-
 		}}
   	;
 
@@ -14365,7 +12949,7 @@ cte_definition
 	opt_bracketed_identifier_list  /* $2 */
 	AS               /* $3 */
 	cte_query_list	/* $4 */
-		{{ DBG_TRACE_GRAMMAR(cte_definition, : identifier opt_bracketed_identifier_list AS cte_query_list);
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_CTE);
 			if (node)
 			  {
@@ -14380,7 +12964,6 @@ cte_definition
 			  }
 
 			$$ = node;
-
 		}}
   	;
 
@@ -14388,8 +12971,7 @@ cte_query_list
 	: cte_query_list
 	table_op
 	select_or_subquery
-		{{ DBG_TRACE_GRAMMAR(cte_query_list, : cte_query_list table_op select_or_subquery);
-
+		{{
 			PT_NODE *stmt = $2;
 			PT_NODE *arg1 = $1, *arg2 = $3;
 			if (stmt)
@@ -14402,21 +12984,17 @@ cte_query_list
 
 			$$ = stmt;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| select_or_subquery
-		{{ DBG_TRACE_GRAMMAR(cte_query_list, | select_or_subquery);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT($$, @$.buffer_pos);
-
 		}}
 	;
 
 opt_from_clause
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_from_clause, : );
-
+		{{
 			PT_NODE *n;
 			PT_NODE *node = parser_pop_select_stmt_node ();
 			parser_found_Oracle_outer = false;
@@ -14450,14 +13028,12 @@ opt_from_clause
 			  parser_select_level--;
 
 			$$ = node;
-
 		}}
 	| FROM				/* $1 */
 	  extended_table_spec_list	/* $2 */
 		{{			/* $3 */
-                    DBG_TRACE_GRAMMAR(opt_from_clause, | FROM extended_table_spec_list);
-			parser_found_Oracle_outer = false;
 
+			parser_found_Oracle_outer = false;
 		}}
 	  opt_where_clause		/* $4 */
 	  opt_startwith_connectby_clause/* $5 */
@@ -14466,8 +13042,7 @@ opt_from_clause
 	  opt_having_clause 		/* $8 */
 	  opt_using_index_clause	/* $9 */
 	  opt_with_increment_clause	/* $10 */
-		{{ DBG_TRACE_GRAMMAR(opt_from_clause, opt_where_clause opt_startwith_connectby_clause ~ opt_with_increment_clause);
-
+		{{
 			PT_NODE *n;
 			bool is_dummy_select;
 			PT_NODE *node = parser_pop_select_stmt_node ();
@@ -14578,144 +13153,113 @@ opt_from_clause
 			  parser_select_level--;
 
 			$$ = node;
-
 		}}
 	;
 
 opt_select_param_list
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_select_param_list, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| INTO to_param_list
-		{{ DBG_TRACE_GRAMMAR(opt_select_param_list, | INTO to_param_list);
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| TO to_param_list
-		{{ DBG_TRACE_GRAMMAR(opt_select_param_list, | TO to_param_list);
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_hint_list
 	: /* empty */
-		{ DBG_TRACE_GRAMMAR(opt_hint_list, : ); }
+		{ }
 	| hint_list
-		{ DBG_TRACE_GRAMMAR(opt_hint_list, : hint_list); }
+		{ }
 	;
 
 hint_list
 	: hint_list CPP_STYLE_HINT
-		{{ DBG_TRACE_GRAMMAR(hint_list, | hint_list CPP_STYLE_HINT);
-
+		{{
 			PT_NODE *node = parser_top_hint_node ();
 			char *hint_comment = $2;
 			(void) pt_get_hint (hint_comment, parser_hint_table, node);
-
 		}}
 	| hint_list SQL_STYLE_HINT
-		{{ DBG_TRACE_GRAMMAR(hint_list, | hint_list SQL_STYLE_HINT);
-
+		{{
 			PT_NODE *node = parser_top_hint_node ();
 			char *hint_comment = $2;
 			(void) pt_get_hint (hint_comment, parser_hint_table, node);
-
 		}}
 	| hint_list C_STYLE_HINT
-		{{ DBG_TRACE_GRAMMAR(hint_list, | hint_list C_STYLE_HINT);
-
+		{{
 			PT_NODE *node = parser_top_hint_node ();
 			char *hint_comment = $2;
 			(void) pt_get_hint (hint_comment, parser_hint_table, node);
-
 		}}
 	| CPP_STYLE_HINT
-		{{ DBG_TRACE_GRAMMAR(hint_list, | CPP_STYLE_HINT);
-
+		{{
 			PT_NODE *node = parser_top_hint_node ();
 			char *hint_comment = $1;
 			(void) pt_get_hint (hint_comment, parser_hint_table, node);
-
 		}}
 	| SQL_STYLE_HINT
-		{{ DBG_TRACE_GRAMMAR(hint_list, | SQL_STYLE_HINT);
-
+		{{
 			PT_NODE *node = parser_top_hint_node ();
 			char *hint_comment = $1;
 			(void) pt_get_hint (hint_comment, parser_hint_table, node);
-
 		}}
 	| C_STYLE_HINT
-		{{ DBG_TRACE_GRAMMAR(hint_list, | C_STYLE_HINT);
-
+		{{
 			PT_NODE *node = parser_top_hint_node ();
 			char *hint_comment = $1;
 			(void) pt_get_hint (hint_comment, parser_hint_table, node);
-
 		}}
 	;
 
 all_distinct
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(all_distinct, : );
-
+		{{
 			$$ = PT_EMPTY;
-
 		}}
 	| ALL
-		{{ DBG_TRACE_GRAMMAR(all_distinct, | ALL);
-
+		{{
 			$$ = PT_ALL;
-
 		}}
 	| DISTINCT
-		{{ DBG_TRACE_GRAMMAR(all_distinct, | DISTINCT);
-
+		{{
 			$$ = PT_DISTINCT;
-
 		}}
 	| UNIQUE
-		{{ DBG_TRACE_GRAMMAR(all_distinct, | UNIQUE);
-
+		{{
 			$$ = PT_DISTINCT;
-
 		}}
 	;
 
 select_list
 	: '*'
-		{{ DBG_TRACE_GRAMMAR(select_list,  : '*');
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 			if (node)
 			  node->type_enum = PT_TYPE_STAR;
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 
 	| '*' ',' alias_enabled_expression_list_top
-		{{ DBG_TRACE_GRAMMAR(select_list, | '*' ',' alias_enabled_expression_list_top);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 			if (node)
 			  node->type_enum = PT_TYPE_STAR;
 
 			$$ = parser_make_link (node, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 
 	| alias_enabled_expression_list_top
-		{{ DBG_TRACE_GRAMMAR(select_list, | alias_enabled_expression_list_top);
+		{{
 			 $$ = $1;
 			 PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
@@ -14723,19 +13267,16 @@ select_list
 
 alias_enabled_expression_list_top
 	:
-		{{ DBG_TRACE_GRAMMAR(alias_enabled_expression_list_top, : );
-
+		{{
 			parser_save_and_set_ic (2);
 			parser_save_and_set_gc (2);
 			parser_save_and_set_oc (2);
 			parser_save_and_set_sysc (1);
 			parser_save_and_set_prc (1);
 			parser_save_and_set_cbrc (1);
-
 		}}
 	  alias_enabled_expression_list
-		{{ DBG_TRACE_GRAMMAR(alias_enabled_expression_list_top, alias_enabled_expression_list);
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 			parser_restore_ic ();
@@ -14744,21 +13285,17 @@ alias_enabled_expression_list_top
 			parser_restore_sysc ();
 			parser_restore_prc ();
 			parser_restore_cbrc ();
-
 		}}
 	;
 
 alias_enabled_expression_list
 	: alias_enabled_expression_list  ',' alias_enabled_expression_
-		{{ DBG_TRACE_GRAMMAR(alias_enabled_expression_list, : alias_enabled_expression_list  ',' alias_enabled_expression_);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| alias_enabled_expression_
-		{{ DBG_TRACE_GRAMMAR(alias_enabled_expression_list, | alias_enabled_expression_);
-
+		{{
 			PT_NODE *node = $1;
 			if (node != NULL)
 			  {
@@ -14766,14 +13303,12 @@ alias_enabled_expression_list
 			  }
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 alias_enabled_expression_
 	: normal_expression opt_as_identifier %dprec 2
-		{{ DBG_TRACE_GRAMMAR(alias_enabled_expression_, : normal_expression opt_as_identifier);
-
+		{{
 			PT_NODE *subq, *id;
 			PT_NODE *node = $1;
 			if (node->node_type == PT_VALUE && node->type_enum == PT_TYPE_EXPR_SET)
@@ -14814,11 +13349,9 @@ alias_enabled_expression_
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| predicate_expression opt_as_identifier %dprec 1
-		{{ DBG_TRACE_GRAMMAR(alias_enabled_expression_, | predicate_expression opt_as_identifier);
-
+		{{
 			PT_NODE *id;
 			PT_NODE *node = $1;
 
@@ -14831,22 +13364,19 @@ alias_enabled_expression_
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 expression_list
 	: expression_queue
-		{{ DBG_TRACE_GRAMMAR(expression_list, : expression_queue);
-
+		{{
 			$$ = CONTAINER_AT_0($1);
-
 		}}
 	;
 
 expression_queue
 	: expression_queue  ',' expression_
-		{{ DBG_TRACE_GRAMMAR(expression_queue, : expression_queue  ',' expression_);
+		{{
 			container_2 new_q;
 
 			PT_NODE* q_head = CONTAINER_AT_0($1);
@@ -14856,25 +13386,21 @@ expression_queue
 			SET_CONTAINER_2(new_q, q_head, $3);
 			$$ = new_q;
 			PARSER_SAVE_ERR_CONTEXT (q_head, @$.buffer_pos)
-
 		}}
 	| expression_
-		{{ DBG_TRACE_GRAMMAR(expression_queue, | expression_);
+		{{
 			container_2 new_q;
 
 			SET_CONTAINER_2(new_q, $1, $1);
 			$$ = new_q;
 			PARSER_SAVE_ERR_CONTEXT ($1, @$.buffer_pos)
-
 		}}
 	;        
 
 expression_list_for_call
        	: expression_queue_for_call
-		{{ DBG_TRACE_GRAMMAR(expression_list_for_call, : expression_queue_for_call);
-
+		{{
 			$$ = CONTAINER_AT_0($1);
-
 		}}
 	;
 
@@ -14890,7 +13416,7 @@ expression_queue_for_call
                   }
             }}
           expression_
-		{{ DBG_TRACE_GRAMMAR(expression_queue_for_call, : expression_queue_for_call  ',' expression_);
+		{{
 			container_2 new_q;
 
                         if(pwd_info.parser_call_check && (pwd_info.method_arg_idx == pwd_info.method_password_arg_idx))
@@ -14905,7 +13431,6 @@ expression_queue_for_call
 			SET_CONTAINER_2(new_q, q_head, $4);
 			$$ = new_q;
 			PARSER_SAVE_ERR_CONTEXT (q_head, @$.buffer_pos)
-
 		}}
 	| 
            {{ 
@@ -14918,7 +13443,7 @@ expression_queue_for_call
                   }
            }}
            expression_
-		{{ DBG_TRACE_GRAMMAR(expression_queue_for_call, | expression_);
+		{{
 			container_2 new_q;
 
                         if(pwd_info.parser_call_check && (pwd_info.method_arg_idx == pwd_info.method_password_arg_idx))
@@ -14929,39 +13454,31 @@ expression_queue_for_call
 			SET_CONTAINER_2(new_q, $2, $2);
 			$$ = new_q;
 			PARSER_SAVE_ERR_CONTEXT ($2, @$.buffer_pos)
-
 		}}
 	;
 
 to_param_list
 	: to_param_list ',' to_param
-		{{ DBG_TRACE_GRAMMAR(to_param_list, : to_param_list ',' to_param);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| to_param
-		{{ DBG_TRACE_GRAMMAR(to_param_list, | to_param);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 to_param
 	: host_param_output
-		{{ DBG_TRACE_GRAMMAR(to_param, : host_param_output);
-
+		{{
 			$1->info.host_var.var_type = PT_HOST_OUT;
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| param_
-		{{ DBG_TRACE_GRAMMAR(to_param, | param_);
-
+		{{
 			PT_NODE *val = $1;
 
 			if (val)
@@ -14973,11 +13490,9 @@ to_param
 
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
         | identifier DOT identifier
-		{{ DBG_TRACE_GRAMMAR(to_param, | identifier DOT identifier);
-
+		{{
 			PT_NODE *val = $1;
                         
                          if (this_parser->flag.is_parsing_static_sql)
@@ -15005,12 +13520,10 @@ to_param
                                                  
                         $$ = val;  
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 
 	| identifier
-		{{ DBG_TRACE_GRAMMAR(to_param, | identifier);
-
+		{{
 			PT_NODE *val = $1;
 
 			if (val)
@@ -15022,14 +13535,12 @@ to_param
 
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 from_param
 	: host_param_input
-		{{ DBG_TRACE_GRAMMAR(from_param, : host_param_input);
-
+		{{
 			PT_NODE *val = $1;
 
 			if (val)
@@ -15040,11 +13551,9 @@ from_param
 
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| param_
-		{{ DBG_TRACE_GRAMMAR(from_param, | param_);
-
+		{{
 			PT_NODE *val = $1;
 
 			if (val)
@@ -15055,7 +13564,6 @@ from_param
 
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	/*
 	 * It must be changed to "CLASS class_name" by User Schema support.
@@ -15064,8 +13572,7 @@ from_param
 	 * Even on AS-IS, PT_INTERNAL_ERROR (parser, "resolution") occurs on pt_resolve_object.
 	 */
 	| CLASS identifier
-		{{ DBG_TRACE_GRAMMAR(from_param, | CLASS identifier);
-
+		{{
 			PT_NODE *val = $2;
 
 			if (val)
@@ -15076,11 +13583,9 @@ from_param
 
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| identifier
-		{{ DBG_TRACE_GRAMMAR(from_param, | identifier);
-
+		{{
 			PT_NODE *val = $1;
 
 			if (val)
@@ -15091,15 +13596,13 @@ from_param
 
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 
 host_param_input
 	: '?'
-		{{ DBG_TRACE_GRAMMAR(host_param_input, : '?');
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_HOST_VAR);
 
 			if (node)
@@ -15116,11 +13619,9 @@ host_param_input
 			  }
 
 			$$ = node;
-
 		}}
 	| PARAM_HEADER uint_text
-		{{ DBG_TRACE_GRAMMAR(host_param_input, | PARAM_HEADER uint_text);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_HOST_VAR);
 
 			if (node)
@@ -15141,14 +13642,12 @@ host_param_input
 			  }
 
 			$$ = node;
-
 		}}
 	;
 
 host_param_output
 	: '?'
-		{{ DBG_TRACE_GRAMMAR(host_param_output, : '?');
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_HOST_VAR);
 
 			if (node)
@@ -15160,11 +13659,9 @@ host_param_output
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| PARAM_HEADER uint_text
-		{{ DBG_TRACE_GRAMMAR(host_param_output, | PARAM_HEADER uint_text);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_HOST_VAR);
 
 			if (parent_parser == NULL)
@@ -15186,29 +13683,24 @@ host_param_output
 			  }
 
 			$$ = node;
-
 		}}
 	;
 
 param_
 	: ':' identifier
-		{{ DBG_TRACE_GRAMMAR(param_, : ':' identifier);
-
+		{{
 			$2->info.name.meta_class = PT_PARAMETER;
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_where_clause
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_where_clause, : );
-
+		{{
 			$$ = NULL;
-
 		}}
-	|	{ DBG_TRACE_GRAMMAR(opt_where_clause, | );
+	|	{
 			parser_save_and_set_ic (1);
 			assert (parser_prior_check == 0);
 			assert (parser_connectbyroot_check == 0);
@@ -15217,89 +13709,75 @@ opt_where_clause
 			parser_save_and_set_cbrc (1);
 		}
 	  WHERE search_condition
-		{{ DBG_TRACE_GRAMMAR(opt_where_clause, WHERE search_condition);
-
+		{{
 			parser_restore_ic ();
 			parser_restore_sysc ();
 			parser_restore_prc ();
 			parser_restore_cbrc ();
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_startwith_connectby_clause
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_startwith_connectby_clause, : );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, NULL, NULL);
 			$$ = ctn;
-
 		}}
 	| startwith_clause connectby_clause
-		{{ DBG_TRACE_GRAMMAR(opt_startwith_connectby_clause, |  startwith_clause connectby_clause);
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, $1, $2);
 			$$ = ctn;
-
 		}}
 	| connectby_clause startwith_clause
-		{{ DBG_TRACE_GRAMMAR(opt_startwith_connectby_clause, |  connectby_clause startwith_clause);
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, $2, $1);
 			$$ = ctn;
-
 		}}
 	| connectby_clause
-		{{ DBG_TRACE_GRAMMAR(opt_startwith_connectby_clause, |  connectby_clause);
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, NULL, $1);
 			$$ = ctn;
-
 		}}
 
 startwith_clause
-	:	{ DBG_TRACE_GRAMMAR(startwith_clause, : );
+	:	{
 			parser_save_and_set_pseudoc (0);
 		}
 	  START_ WITH search_condition
-		{{ DBG_TRACE_GRAMMAR(startwith_clause, START_ WITH search_condition);
-
+		{{
 			parser_restore_pseudoc ();
 			$$ = $4;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 connectby_clause
-	:	{ DBG_TRACE_GRAMMAR(connectby_clause, : );
+	:	{
 			parser_save_and_set_prc (1);
 			parser_save_and_set_serc (0);
 			parser_save_and_set_pseudoc (1);
 			parser_save_and_set_sqc (0);
 		}
 	  connectby_clause_with_option
-		{{ DBG_TRACE_GRAMMAR(connectby_clause, connectby_clause_with_option);
-
+		{{
 			parser_restore_prc ();
 			parser_restore_serc ();
 			parser_restore_pseudoc ();
 			parser_restore_sqc ();
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 connectby_clause_with_option
        : CONNECT BY NOCYCLE search_condition %dprec 2
-        {{ DBG_TRACE_GRAMMAR(connectby_clause_with_option, : CONNECT BY NOCYCLE search_condition);
+        {{
                 PT_NODE *node = parser_top_select_stmt_node ();
 		if (node)
 		  {
@@ -15311,56 +13789,44 @@ connectby_clause_with_option
 		}}
 
         | CONNECT BY search_condition %dprec 1
-        {{ DBG_TRACE_GRAMMAR(connectby_clause_with_option, | CONNECT BY search_condition);
+        {{
                 $$=$3;
 		}}
         ;
 
 opt_groupby_clause
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_groupby_clause, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| GROUP_ BY group_spec_list
-		{{ DBG_TRACE_GRAMMAR(opt_groupby_clause, |  GROUP_ BY group_spec_list);
-
+		{{
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_with_rollup
 	: /*empty*/
-		{{ DBG_TRACE_GRAMMAR(opt_with_rollup, : );
-
+		{{
 			$$ = 0;
-
 		}}
 	| WITH ROLLUP
-		{{ DBG_TRACE_GRAMMAR(opt_with_rollup, |  WITH ROLLUP);
-
+		{{
 			$$ = 1;
-
 		}}
 	;
 
 group_spec_list
 	: group_spec_list ',' group_spec
-		{{ DBG_TRACE_GRAMMAR(group_spec_list, : group_spec_list ',' group_spec);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| group_spec
-		{{ DBG_TRACE_GRAMMAR(group_spec_list, |  group_spec);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
@@ -15368,13 +13834,12 @@ group_spec_list
 // SR +3
 group_spec
 	:
-		{ DBG_TRACE_GRAMMAR(group_spec, : );
+		{
 			parser_groupby_exception = 0;
 		}
 	  expression_
 	  opt_asc_or_desc 	  /* $3 */
-		{{ DBG_TRACE_GRAMMAR(group_spec, expression_ opt_asc_or_desc);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_SORT_SPEC);
 
 			PARSER_SAVE_ERR_CONTEXT (node, @$.buffer_pos)
@@ -15417,46 +13882,36 @@ group_spec
 			  }
 
 			$$ = node;
-
 		}}
 	;
 
 
 opt_having_clause
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_having_clause, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	|	{ parser_save_and_set_gc(1); }
 	  HAVING search_condition
-		{{ DBG_TRACE_GRAMMAR(opt_having_clause, | HAVING search_condition);
-
+		{{
 			parser_restore_gc ();
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_using_index_clause
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_using_index_clause, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| USING INDEX index_hint_name_keylimit_list
-		{{ DBG_TRACE_GRAMMAR(opt_using_index_clause, | USING INDEX index_hint_name_keylimit_list);
-
+		{{
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| USING INDEX NONE
-		{{ DBG_TRACE_GRAMMAR(opt_using_index_clause, | USING INDEX NONE);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_NAME);
 
 			if (node)
@@ -15469,10 +13924,9 @@ opt_using_index_clause
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| USING INDEX ALL EXCEPT index_hint_name_list
-		{{ DBG_TRACE_GRAMMAR(opt_using_index_clause, | USING INDEX ALL EXCEPT index_hint_name_list);
+		{{
 			PT_NODE *curr;
 			PT_NODE *node = parser_new_node (this_parser, PT_NAME);
 
@@ -15505,48 +13959,38 @@ opt_using_index_clause
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 index_hint_name_keylimit_list
 	: index_hint_name_keylimit_list ',' index_hint_name_keylimit
-		{{ DBG_TRACE_GRAMMAR(index_hint_name_keylimit_list, : index_hint_name_keylimit_list ',' index_hint_name_keylimit);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| index_hint_name_keylimit
-		{{ DBG_TRACE_GRAMMAR(index_hint_name_keylimit_list, | index_hint_name_keylimit);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 index_hint_name_list
 	: index_hint_name_list ',' index_hint_name
-		{{ DBG_TRACE_GRAMMAR(index_name_list, : index_hint_name_list ',' index_hint_name);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| index_hint_name
-		{{ DBG_TRACE_GRAMMAR(index_hint_name_list, | index_hint_name);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 index_hint_name_keylimit
 	: index_hint_name KEYLIMIT limit_expr
-		{{ DBG_TRACE_GRAMMAR(index_hint_name_keylimit, : index_hint_name KEYLIMIT limit_expr);
-
+		{{
 			PT_NODE *node = $1;
 			PARSER_SAVE_ERR_CONTEXT (node, @$.buffer_pos)
 
@@ -15568,11 +14012,9 @@ index_hint_name_keylimit
 			      }
 			  }
 			$$ = node;
-
 		}}
 	| index_hint_name KEYLIMIT limit_expr ',' limit_expr
-		{{ DBG_TRACE_GRAMMAR(index_hint_name_keylimit, | index_hint_name KEYLIMIT limit_expr ',' limit_expr);
-
+		{{
 			PT_NODE *node = $1;
 			if (node)
 			  {
@@ -15593,48 +14035,38 @@ index_hint_name_keylimit
 			  }
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| index_hint_name
-		{{ DBG_TRACE_GRAMMAR(index_hint_name_keylimit, | index_hint_name);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 index_hint_name
 	: index_name paren_plus
-		{{ DBG_TRACE_GRAMMAR(index_hint_name, : index_name paren_plus);
-
+		{{
 			PT_NODE *node = $1;
 			node->etc = (void *) PT_IDX_HINT_FORCE;
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| index_name paren_minus
-		{{ DBG_TRACE_GRAMMAR(index_name, | index_name paren_minus);
-
+		{{
 			PT_NODE *node = $1;
 			node->etc = (void *) PT_IDX_HINT_IGNORE;
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| index_name
-		{{ DBG_TRACE_GRAMMAR(index_hint_name, | index_name);
-
+		{{
 			PT_NODE *node = $1;
 			node->etc = (void *) PT_IDX_HINT_USE;
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| identifier DOT NONE
-		{{ DBG_TRACE_GRAMMAR(index_name, | identifier DOT NONE);
-
+		{{
 			PT_NODE *node = $1;
 			node->info.name.meta_class = PT_INDEX_NAME;
 			node->info.name.resolved = node->info.name.original;
@@ -15642,38 +14074,30 @@ index_hint_name
 			node->etc = (void *) PT_IDX_HINT_CLASS_NONE;
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_with_increment_clause
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_with_increment_clause, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| WITH INCREMENT For incr_arg_name_list__inc
-		{{ DBG_TRACE_GRAMMAR(opt_with_increment_clause, | WITH INCREMENT For incr_arg_name_list__inc);
-
+		{{
 			$$ = $4;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| WITH DECREMENT For incr_arg_name_list__dec
-		{{ DBG_TRACE_GRAMMAR(opt_with_increment_clause, | WITH DECREMENT For incr_arg_name_list__dec);
-
+		{{
 			$$ = $4;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_for_update_clause
-	: /* empty */ { DBG_TRACE_GRAMMAR(opt_for_update_clause, : ); }
+	: /* empty */ { }
 	| For UPDATE
-		{{ DBG_TRACE_GRAMMAR(opt_for_update_clause, | For UPDATE);
-
+		{{
 			PT_NODE *node = parser_top_orderby_node ();
 
 			if (node != NULL && node->node_type == PT_SELECT)
@@ -15689,11 +14113,9 @@ opt_for_update_clause
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| For UPDATE OF class_name_list
-		{{ DBG_TRACE_GRAMMAR(opt_for_update_clause, | For UPDATE OF class_name_list);
-
+		{{
 			PT_NODE *node = parser_top_orderby_node ();
 			PT_NODE *names_list = $4;
 			PT_NODE *node1 = names_list, *node2 = NULL;
@@ -15730,30 +14152,25 @@ opt_for_update_clause
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 incr_arg_name_list__inc
 	: incr_arg_name_list__inc ',' incr_arg_name__inc
-		{{ DBG_TRACE_GRAMMAR(incr_arg_name_list__inc, : incr_arg_name_list__inc ',' incr_arg_name__inc);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| incr_arg_name__inc
-		{{ DBG_TRACE_GRAMMAR(incr_arg_name_list__inc, | incr_arg_name__inc);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 incr_arg_name__inc
 	: path_expression
-		{{ DBG_TRACE_GRAMMAR(incr_arg_name__inc, : path_expression);
+		{{
 			PT_NODE *node = $1;
 
 			if (node->node_type == PT_EXPR && node->info.expr.op == PT_INCR)
@@ -15778,24 +14195,20 @@ incr_arg_name__inc
 
 incr_arg_name_list__dec
 	: incr_arg_name_list__dec ',' incr_arg_name__dec
-		{{ DBG_TRACE_GRAMMAR(incr_arg_name_list__dec, : incr_arg_name_list__dec ',' incr_arg_name__dec);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| incr_arg_name__dec
-		{{ DBG_TRACE_GRAMMAR(incr_arg_name_list__dec, | incr_arg_name__dec);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 incr_arg_name__dec
 	: path_expression
-		{{ DBG_TRACE_GRAMMAR(incr_arg_name__dec, : path_expression);
+		{{
 			PT_NODE *node = $1;
 
 			if (node->node_type == PT_EXPR && node->info.expr.op == PT_INCR)
@@ -15820,13 +14233,13 @@ incr_arg_name__dec
 
 opt_update_orderby_clause
 	: /* empty */
-		{ DBG_TRACE_GRAMMAR(opt_update_orderby_clause, : );
+		{
                   $$ = NULL; }
 	| ORDER BY
 	  sort_spec_list
 		{  parser_save_and_set_oc (1); }
 	  opt_for_search_condition
-		{{ DBG_TRACE_GRAMMAR(opt_update_orderby_clause, | ORDER BY sort_spec_listopt_for_search_condition);
+		{{
 			PT_NODE *stmt = parser_pop_orderby_node ();
 
 			parser_restore_oc ();
@@ -15841,11 +14254,11 @@ opt_update_orderby_clause
 
 opt_orderby_clause
 	: /* empty */
-		{ DBG_TRACE_GRAMMAR(opt_orderby_clause, : );  $$ = NULL; }
+		{  $$ = NULL; }
 	| ORDER
 	  opt_siblings
 	  BY
-		{{ DBG_TRACE_GRAMMAR("opt_orderby_clause", "| ORDER opt_siblings BY");
+		{{
 			PT_NODE *stmt = parser_top_orderby_node ();
 
 			if (!stmt->info.query.flag.order_siblings)
@@ -15867,11 +14280,9 @@ opt_orderby_clause
 			    PT_ERRORmf(this_parser, pt_top(this_parser),
 				MSGCAT_SET_PARSER_SEMANTIC,
 				MSGCAT_SEMANTIC_NOT_ALLOWED_HERE, "ORDER BY");
-
 		}}
 	  sort_spec_list
-		{{ DBG_TRACE_GRAMMAR(opt_orderby_clause, sort_spec_list);
-
+		{{
 			PT_NODE *stmt = parser_top_orderby_node ();
 
 			parser_restore_sysc ();
@@ -15879,11 +14290,9 @@ opt_orderby_clause
 			parser_restore_cbrc ();
 			parser_restore_pseudoc ();
 			parser_save_and_set_oc (1);
-
 		}}
 	  opt_for_search_condition
-		{{ DBG_TRACE_GRAMMAR(opt_orderby_clause, opt_for_search_condition);
-
+		{{
 			PT_NODE *col, *order, *n, *temp, *list = NULL;
 			PT_NODE *stmt = parser_top_orderby_node ();
 			bool found_star;
@@ -16040,15 +14449,13 @@ opt_orderby_clause
 
 			$$ = stmt;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_siblings
 	: /* empty */
 	| SIBLINGS
-		{{ DBG_TRACE_GRAMMAR(opt_siblings, | SIBLINGS);
-
+		{{
 			PT_NODE *stmt = parser_top_orderby_node ();
 			stmt->info.query.flag.order_siblings = true;
 			if (stmt->info.query.q.select.connect_by == NULL)
@@ -16058,70 +14465,58 @@ opt_siblings
 				    MSGCAT_SEMANTIC_NOT_HIERACHICAL_QUERY,
 				    "SIBLINGS");
 			    }
-
 		}}
 	;
 
 limit_expr
         : limit_expr '+' limit_term
-                {{ DBG_TRACE_GRAMMAR(limit_expr, : limit_expr '+' limit_term);
+                {{
                         $$ = parser_make_expression (this_parser, PT_PLUS, $1, $3, NULL);
                         PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
                 }}
         | limit_expr '-' limit_term
-                {{ DBG_TRACE_GRAMMAR(limit_expr, | limit_expr '-' limit_term);
+                {{
                         $$ = parser_make_expression (this_parser, PT_MINUS, $1, $3, NULL);
                         PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
                 }}
         | limit_term
-                {{ DBG_TRACE_GRAMMAR(limit_expr, | limit_term);
+                {{
                         $$ = $1;
                         PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
                 }}
         ;
 
 limit_term
         : limit_term '*' limit_factor
-                {{ DBG_TRACE_GRAMMAR(limit_term, : limit_term '*' limit_factor);
+                {{
                         $$ = parser_make_expression (this_parser, PT_TIMES, $1, $3, NULL);
                         PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
                 }}
         | limit_term '/' limit_factor
-                {{ DBG_TRACE_GRAMMAR(limit_term, | limit_term '/' limit_factor);
+                {{
                         $$ = parser_make_expression (this_parser, PT_DIV, $1, $3, NULL);
                         PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
                 }}
         | limit_factor
-                {{ DBG_TRACE_GRAMMAR(limit_term, | limit_factor);
+                {{
                         $$ = $1;
                         PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
                 }}
           ;
 
 limit_factor
         : host_param_input
-                {{ DBG_TRACE_GRAMMAR(limit_factor, : host_param_input);
-
+                {{
                         $$ = $1;
                         PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
                 }}
         | unsigned_integer
-                {{ DBG_TRACE_GRAMMAR(limit_factor, | unsigned_integer);
-
+                {{
                         $$ = $1;
                         PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
                 }}
         | identifier_without_dot    /* for PL/CSQL Static SQL only */
-                {{ DBG_TRACE_GRAMMAR(limit_factor, | identifier_without_dot);
-
+                {{
                         if (this_parser->flag.is_parsing_static_sql) {
 
                             // interpret the identifier only as a PL/CSQL host variable
@@ -16146,10 +14541,9 @@ limit_factor
 			        MSGCAT_SEMANTIC_IDENTIFIER_IN_LIMIT_CLAUSE);
                             $$ = NULL;
                         }
-
                 }}
         | '(' limit_expr ')'
-                {{ DBG_TRACE_GRAMMAR(limit_factor, | '(' limit_expr ')');
+                {{
 			PT_NODE *exp = $2;
 
 			if (exp && exp->node_type == PT_EXPR)
@@ -16159,18 +14553,16 @@ limit_factor
 
                         $$ = exp;
                         PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
                 }}
         ;
 
 opt_select_limit_clause
 	: /* empty */
-           {{ DBG_TRACE_GRAMMAR(opt_select_limit_clause, : );
-                  $$ = NULL; 
-                  }}
+                {{
+                        $$ = NULL; 
+                }}
 	| LIMIT limit_options
-	        {{ DBG_TRACE_GRAMMAR(opt_select_limit_clause, | LIMIT limit_options);
-
+	        {{
 			PT_NODE *node = $2;
 			if (node)
 			  {
@@ -16233,14 +14625,12 @@ opt_select_limit_clause
 			  }
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 limit_options
 	: limit_expr
-		{{ DBG_TRACE_GRAMMAR(limit_options, : limit_expr);
-
+		{{
 			PT_NODE *node = parser_top_orderby_node ();
 			if (node)
 			  {
@@ -16249,11 +14639,9 @@ limit_options
 			  }
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| limit_expr ',' limit_expr
-		{{ DBG_TRACE_GRAMMAR(limit_options, | limit_expr ',' limit_expr);
-
+		{{
 			PT_NODE *node = parser_top_orderby_node ();
 			if (node)
 			  {
@@ -16268,11 +14656,9 @@ limit_options
 			  }
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| limit_expr OFFSET limit_expr
-		{{ DBG_TRACE_GRAMMAR(limit_options, | limit_expr OFFSET limit_expr);
-
+		{{
 			PT_NODE *node = parser_top_orderby_node ();
 			if (node)
 			  {
@@ -16287,29 +14673,24 @@ limit_options
 			  }
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_upd_del_limit_clause
 	: /* empty */
-		{ DBG_TRACE_GRAMMAR(opt_upd_del_limit_clause, : );
-                  $$ = NULL; }
+		{ $$ = NULL; }
 	| LIMIT limit_expr
-		{{ DBG_TRACE_GRAMMAR(opt_upd_del_limit_clause, | LIMIT limit_expr);
-
+		{{
 			  $$ = $2;
 			  PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_for_search_condition
 	: /* empty */
-		{ DBG_TRACE_GRAMMAR(opt_for_search_condition, : );
-                  $$ = NULL; }
+		{ $$ = NULL; }
 	| For search_condition
-		{{ DBG_TRACE_GRAMMAR(opt_for_search_condition, | For search_condition);
+		{{
 			PT_NODE *node = $2;
 			bool subquery_flag = false;
 			if (node)
@@ -16331,24 +14712,20 @@ opt_for_search_condition
 
 sort_spec_list
 	: sort_spec_list ',' sort_spec
-		{{ DBG_TRACE_GRAMMAR(sort_spec_list, : sort_spec_list ',' sort_spec);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| sort_spec
-		{{ DBG_TRACE_GRAMMAR(sort_spec_list, | sort_spec);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 sort_spec
 	: expression_ ASC opt_nulls_first_or_last
-		{{ DBG_TRACE_GRAMMAR(sort_spec, : expression_ ASC opt_nulls_first_or_last);
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_SORT_SPEC);
 
 			if (node)
@@ -16360,11 +14737,9 @@ sort_spec
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| expression_ DESC opt_nulls_first_or_last
-		{{ DBG_TRACE_GRAMMAR(sort_spec, | expression_ DESC opt_nulls_first_or_last);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_SORT_SPEC);
 
 			if (node)
@@ -16376,11 +14751,9 @@ sort_spec
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| expression_ opt_nulls_first_or_last
-		{{ DBG_TRACE_GRAMMAR(sort_spec, | expression_ opt_nulls_first_or_last);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_SORT_SPEC);
 
 			if (node)
@@ -16392,261 +14765,197 @@ sort_spec
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_nulls_first_or_last
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_nulls_first_or_last, : );
-
+		{{
 			$$ = PT_NULLS_DEFAULT;
-
 		}}
 	| NULLS FIRST
-		{{ DBG_TRACE_GRAMMAR(opt_nulls_first_or_last, | NULLS FIRST);
-
+		{{
 			$$ = PT_NULLS_FIRST;
-
 		}}
 	| NULLS LAST
-		{{ DBG_TRACE_GRAMMAR(opt_nulls_first_or_last, | NULLS LAST);
-
+		{{
 			$$ = PT_NULLS_LAST;
-
 		}}
 	;
 
 expression_
 	: normal_expression
-		{{DBG_TRACE_GRAMMAR(expression_, : normal_expression);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| predicate_expression
-		{{DBG_TRACE_GRAMMAR(expression_, | predicate_expression);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 
 normal_expression
 	: session_variable_definition
-		{{ DBG_TRACE_GRAMMAR(normal_expression, : session_variable_definition);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| expression_strcat
-		{{ DBG_TRACE_GRAMMAR(normal_expression, | expression_strcat);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 expression_strcat
 	: expression_strcat STRCAT expression_bitor
-		{{ DBG_TRACE_GRAMMAR(expression_strcat, : expression_strcat STRCAT expression_bitor);
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_STRCAT, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| expression_bitor
-		{{ DBG_TRACE_GRAMMAR(expression_strcat, | expression_bitor);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 expression_bitor
 	: expression_bitor '|' expression_bitand
-		{{ DBG_TRACE_GRAMMAR(expression_bitor, : expression_bitor '|' expression_bitand);
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_BIT_OR, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| expression_bitand
-		{{ DBG_TRACE_GRAMMAR(expression_bitor, | expression_bitand);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 expression_bitand
 	: expression_bitand '&' expression_bitshift
-		{{ DBG_TRACE_GRAMMAR(expression_bitand, : expression_bitand '&' expression_bitshift);
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_BIT_AND, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| expression_bitshift
-		{{ DBG_TRACE_GRAMMAR(expression_bitand, | expression_bitshift);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 expression_bitshift
 	: expression_bitshift BITSHIFT_LEFT expression_add_sub
-		{{ DBG_TRACE_GRAMMAR(expression_bitshift, : expression_bitshift BITSHIFT_LEFT expression_add_sub);
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_BITSHIFT_LEFT, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| expression_bitshift BITSHIFT_RIGHT expression_add_sub
-		{{ DBG_TRACE_GRAMMAR(expression_bitshift, | expression_bitshift BITSHIFT_RIGHT expression_add_sub);
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_BITSHIFT_RIGHT, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| expression_add_sub
-		{{ DBG_TRACE_GRAMMAR(expression_bitshift, | expression_add_sub);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 expression_add_sub
 	: expression_add_sub '+' term
-		{{ DBG_TRACE_GRAMMAR(expression_add_sub, : expression_add_sub '+' term);
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_PLUS, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| expression_add_sub '-' term
-		{{ DBG_TRACE_GRAMMAR(expression_add_sub, | expression_add_sub '-' term);
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_MINUS, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| term
-		{{ DBG_TRACE_GRAMMAR(expression_add_sub, | term);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 term
 	: term '*' factor
-		{{ DBG_TRACE_GRAMMAR(term, : term '*' factor);
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_TIMES, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| term '/' factor
-		{{ DBG_TRACE_GRAMMAR(term, | term '/' factor);
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_DIVIDE, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| term DIV factor
-		{{ DBG_TRACE_GRAMMAR(term, | term DIV factor);
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_DIV, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| term MOD factor
-		{{ DBG_TRACE_GRAMMAR(term, | term MOD factor);
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_MOD, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| factor
-		{{ DBG_TRACE_GRAMMAR(term, | factor);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 factor
 	: factor '^' factor_
-		{{ DBG_TRACE_GRAMMAR(factor, : factor '^' factor_);
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_BIT_XOR, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| factor_
-		{{ DBG_TRACE_GRAMMAR(factor, | factor_);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 factor_
 	: primary_w_collate
-		{{ DBG_TRACE_GRAMMAR(factor_, : primary_w_collate);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| '-' factor_
-		{{ DBG_TRACE_GRAMMAR(factor_, | '-' factor_);
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_UNARY_MINUS, $2, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| '+' factor_
-		{{ DBG_TRACE_GRAMMAR(factor_, | '+' factor_);
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| '~' primary
-		{{ DBG_TRACE_GRAMMAR(factor_, | '~' primary);
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_BIT_NOT, $2, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| PRIOR
-		{{ DBG_TRACE_GRAMMAR(factor_, | PRIOR);
-
+		{{
 			parser_save_and_set_sysc (0);
 			parser_save_and_set_prc (0);
 			parser_save_and_set_cbrc (0);
 			parser_save_and_set_pseudoc (0);
-
 		}}
 	  primary_w_collate
-		{{ DBG_TRACE_GRAMMAR(factor_, primary_w_collate);
-
+		{{
 			PT_NODE *node = parser_make_expression (this_parser, PT_PRIOR, $3, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT (node, @$.buffer_pos)
 
@@ -16662,20 +14971,16 @@ factor_
 			  }
 
 			$$ = node;
-
 		}}
 	| CONNECT_BY_ROOT
-		{{ DBG_TRACE_GRAMMAR(factor_, | CONNECT_BY_ROOT);
-
+		{{
 			parser_save_and_set_sysc (0);
 			parser_save_and_set_prc (0);
 			parser_save_and_set_cbrc (0);
 			parser_save_and_set_pseudoc (0);
-
 		}}
 	  primary_w_collate
-		{{ DBG_TRACE_GRAMMAR(factor_, primary_w_collate);
-
+		{{
 			PT_NODE *node = parser_make_expression (this_parser, PT_CONNECT_BY_ROOT, $3, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT (node, @$.buffer_pos)
 
@@ -16691,13 +14996,12 @@ factor_
 			  }
 
 			$$ = node;
-
 		}}
 	;
 
 primary_w_collate
 	: primary opt_collation
-		{{ DBG_TRACE_GRAMMAR(primary_w_collate, : primary opt_collation);
+		{{
 			PT_NODE *node = $1;
 			PT_NODE *coll_node = $2;
 
@@ -16713,84 +15017,66 @@ primary_w_collate
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 
 primary
 	: pseudo_column		%dprec 11
-		{{ DBG_TRACE_GRAMMAR(primary, : pseudo_column);
-
+		{{
 			if (parser_pseudocolumn_check == 0)
 			  PT_ERRORmf (this_parser, $1, MSGCAT_SET_PARSER_SEMANTIC,
 				MSGCAT_SEMANTIC_NOT_ALLOWED_HERE, "Pseudo-column");
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| reserved_func		%dprec 10
-		{{ DBG_TRACE_GRAMMAR(primary, | reserved_func);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| case_expr		%dprec 9
-		{{ DBG_TRACE_GRAMMAR(primary, | case_expr);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| extract_expr		%dprec 8
-		{{ DBG_TRACE_GRAMMAR(primary, | extract_expr);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| literal_w_o_param	%dprec 7
-		{{ DBG_TRACE_GRAMMAR(primary, | literal_w_o_param);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| insert_expression	%dprec 6
-		{{ DBG_TRACE_GRAMMAR(primary, | insert_expression);
-
+		{{
 			$1->info.insert.is_subinsert = PT_IS_SUBINSERT;
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 			parser_groupby_exception = PT_IS_SUBINSERT;
-
 		}}
 	| path_expression	%dprec 5
-		{{ DBG_TRACE_GRAMMAR(primary, | path_expression);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| '(' expression_list ')' %dprec 4
-		{{ DBG_TRACE_GRAMMAR(primary, | '(' expression_list ')');
+		{{
 			PT_NODE *exp = $2;
 			exp = pt_create_paren_expr_list (exp);
 			$$ = exp;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| ROW '(' expression_list ')' %dprec 4
-		{{ DBG_TRACE_GRAMMAR(primary, | ROW '(' expression_list ')');
+		{{
 			PT_NODE *exp = $3;
 			exp = pt_create_paren_expr_list (exp);
 			$$ = exp;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| '(' search_condition_query ')' %dprec 2
-		{{ DBG_TRACE_GRAMMAR(primary, | '(' search_condition_query ')');
-
+		{{
 			PT_NODE *exp = $2;
 
 			if (exp && exp->node_type == PT_EXPR)
@@ -16801,80 +15087,64 @@ primary
 			$$ = exp;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 			parser_groupby_exception = PT_EXPR;
-
 		}}
 	| subquery    %dprec 1
-		{{ DBG_TRACE_GRAMMAR(primary, | subquery);
+		{{
 			parser_groupby_exception = PT_IS_SUBQUERY;
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
 	| session_variable_expression
-		{{ DBG_TRACE_GRAMMAR(primary, | session_variable_expression);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 search_condition_query
 	: search_condition_expression
-		{{ DBG_TRACE_GRAMMAR(search_condition_query, : search_condition_expression);
-
+		{{
 			PT_NODE *node = $1;
 			parser_push_orderby_node (node);
-
 		}}
 	  opt_orderby_clause
-		{{ DBG_TRACE_GRAMMAR(search_condition_query, opt_orderby_clause);
-
+		{{
 			PT_NODE *node = parser_pop_orderby_node ();
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 search_condition_expression
 	: search_condition
-		{{ DBG_TRACE_GRAMMAR(search_condition_expression, : search_condition);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 pseudo_column
 	: CONNECT_BY_ISCYCLE
-		{{ DBG_TRACE_GRAMMAR(pseudo_column, : CONNECT_BY_ISCYCLE);
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_CONNECT_BY_ISCYCLE, NULL, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| CONNECT_BY_ISLEAF
-		{{ DBG_TRACE_GRAMMAR(pseudo_column, | CONNECT_BY_ISLEAF);
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_CONNECT_BY_ISLEAF, NULL, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| LEVEL
-		{{ DBG_TRACE_GRAMMAR(pseudo_column, | LEVEL);
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_LEVEL, NULL, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 
 reserved_func
         : COUNT '(' '*' ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, : COUNT '(' '*' ')');
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
 			if (node)
@@ -16887,11 +15157,9 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 			parser_groupby_exception = PT_COUNT;
-
 		}}
 	| COUNT '(' '*' ')' OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | COUNT '(' '*' ')' OVER '(' opt_analytic_partition_by opt_analytic_order_by ')');
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
 			if (node)
@@ -16906,11 +15174,9 @@ reserved_func
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| COUNT '(' of_distinct_unique expression_ ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | COUNT '(' of_distinct_unique expression_ ')');
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
 			if (node)
@@ -16923,11 +15189,9 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 			parser_groupby_exception = PT_COUNT;
-
 		}}
 	| COUNT '(' of_distinct_unique expression_ ')' OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | COUNT '(' of_distinct_unique expression_ ')' OVER '(' ~ ')');
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
 			if (node)
@@ -16942,11 +15206,9 @@ reserved_func
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| COUNT '(' opt_all expression_ ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | COUNT '(' opt_all expression_ ')');
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
 			if (node)
@@ -16959,11 +15221,9 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 			parser_groupby_exception = PT_COUNT;
-
 		}}
 	| COUNT '(' opt_all expression_ ')' OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | COUNT '(' opt_all expression_ ')' OVER '(' ~ ')');
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
 			if (node)
@@ -16978,11 +15238,9 @@ reserved_func
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| of_avg_max_etc '(' of_distinct_unique expression_ ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_avg_max_etc '(' of_distinct_unique expression_ ')');
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
 			if (node != NULL)
@@ -17000,11 +15258,9 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 			parser_groupby_exception = PT_COUNT;
-
 		}}
 	| of_avg_max_etc '(' opt_all expression_ ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_avg_max_etc '(' opt_all expression_ ')');
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
 			if (node != NULL)
@@ -17017,11 +15273,9 @@ reserved_func
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 			parser_groupby_exception = PT_COUNT;
-
 		}}
 	| of_analytic '(' of_distinct_unique expression_ ')' OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_analytic '(' of_distinct_unique expression_ ')' OVER '(' ~ ')');
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
 			if (node)
@@ -17039,11 +15293,9 @@ reserved_func
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| of_analytic '(' opt_all expression_ ')' OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_analytic '(' opt_all expression_ ')' OVER '(' ~ ')');
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
 			if (node)
@@ -17058,11 +15310,9 @@ reserved_func
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| of_analytic_first_last '(' expression_ ')' opt_analytic_ignore_nulls OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_analytic_first_last '(' expression_ ')' opt_analytic_ignore_nulls OVER '(' ~ ')');
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
 			if (node)
@@ -17080,11 +15330,9 @@ reserved_func
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| of_analytic_nth_value '(' expression_ ',' expression_ ')' opt_analytic_from_last opt_analytic_ignore_nulls OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_analytic_nth_value '(' expression_ ',' expression_ ')' opt_analytic_from_last opt_analytic_ignore_nulls OVER '(' ~ ')');
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
 			if (node)
@@ -17111,11 +15359,9 @@ reserved_func
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| of_analytic_lead_lag '(' expression_ ')' OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_analytic_lead_lag '(' expression_ ')' OVER '(' ~ ')');
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
 			if (node)
@@ -17144,11 +15390,9 @@ reserved_func
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| of_analytic_lead_lag '(' expression_ ',' expression_ ')' OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_analytic_lead_lag '(' expression_ ',' expression_ ')' OVER '(' ~ ')');
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
 			if (node)
@@ -17171,11 +15415,9 @@ reserved_func
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| of_analytic_lead_lag '(' expression_ ',' expression_ ',' expression_ ')' OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_analytic_lead_lag '(' expression_ ',' expression_ ',' expression_ ')' OVER '(' ~ ')');
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
 			if (node)
@@ -17192,11 +15434,9 @@ reserved_func
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| of_analytic_no_args '(' ')' OVER '(' opt_analytic_partition_by opt_analytic_order_by ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_analytic_no_args '(' ')' OVER '(' ~ ')');
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
 			if (node)
@@ -17221,14 +15461,12 @@ reserved_func
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| GROUP_CONCAT
 		{ push_msg(MSGCAT_SYNTAX_INVALID_GROUP_CONCAT); }
 		'(' of_distinct_unique expression_ opt_agg_order_by opt_group_concat_separator ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | GROUP_CONCAT '(' of_distinct_unique expression_ ~ ')' );
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
 			if (node)
@@ -17241,11 +15479,9 @@ reserved_func
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| GROUP_CONCAT '(' opt_all opt_expression_list opt_agg_order_by opt_group_concat_separator ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | GROUP_CONCAT '(' opt_all opt_expression_list opt_agg_order_by opt_group_concat_separator ')' );
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
 			PT_NODE *args_list = $4;
@@ -17266,11 +15502,9 @@ reserved_func
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| JSON_ARRAYAGG '(' expression_ ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_ARRAYAGG '(' expression_ ')' );
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
 			if (node)
@@ -17282,10 +15516,9 @@ reserved_func
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| JSON_OBJECTAGG '(' expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_OBJECTAGG '(' expression_list ')' );
+		{{
  			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 			PT_NODE *args_list = $3;
 
@@ -17306,8 +15539,7 @@ reserved_func
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
  		}}
 	| of_percentile '(' expression_ ')' WITHIN GROUP_ '(' ORDER BY sort_spec ')' opt_over_analytic_partition_by
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_percentile '(' expression_ ')' WITHIN GROUP_ '(' ORDER BY sort_spec ')' ~ );
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 
 			if (node != NULL)
@@ -17352,122 +15584,104 @@ reserved_func
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos);
-
 		}}
 	| INSERT
 	  { push_msg(MSGCAT_SYNTAX_INVALID_INSERT_SUBSTRING); }
 	  '(' expression_list ')'
 	  { pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | INSERT '(' expression_list ')' );
+		{{
                     $$ = parser_make_func_with_arg_count (this_parser, F_INSERT_SUBSTRING, $4, 4, 4);
                     PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
 	| ELT '(' opt_expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | ELT '(' opt_expression_list ')' );
+		{{
                     $$ = parser_make_func_with_arg_count (this_parser, F_ELT, $3, 1, 0);
                     PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
 	| POSITION '(' expression_ IN_ expression_ ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | POSITION '(' expression_ IN_ expression_ ')' );
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_POSITION, $3, $5, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SUBSTRING_
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SUBSTRING); }
 	  '(' expression_ FROM expression_ For expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | SUBSTRING_  '(' expression_ FROM expression_ For expression_ ')' );
-
+		{{
 			PT_NODE *node = parser_make_expression (this_parser, PT_SUBSTRING, $4, $6, $8);
 			node->info.expr.qualifier = PT_SUBSTR_ORG;
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SUBSTRING_
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SUBSTRING); }
 	  '(' expression_ FROM expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | SUBSTRING_  '(' expression_ FROM expression_ ')' );
-
+		{{
 			PT_NODE *node = parser_make_expression (this_parser, PT_SUBSTRING, $4, $6, NULL);
 			node->info.expr.qualifier = PT_SUBSTR_ORG;
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SUBSTRING_
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SUBSTRING); }
 	  '(' expression_ ',' expression_ ',' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | SUBSTRING_   '(' expression_ ',' expression_ ',' expression_ ')' );
-
+		{{
 			PT_NODE *node = parser_make_expression (this_parser, PT_SUBSTRING, $4, $6, $8);
 			node->info.expr.qualifier = PT_SUBSTR_ORG;
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SUBSTRING_
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SUBSTRING); }
 	  '(' expression_ ',' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | SUBSTRING_    '(' expression_ ',' expression_ ')' );
-
+		{{
 			PT_NODE *node = parser_make_expression (this_parser, PT_SUBSTRING, $4, $6, NULL);
 			node->info.expr.qualifier = PT_SUBSTR_ORG;
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| Date
 		{ push_msg(MSGCAT_SYNTAX_INVALID_DATE); }
 	  '(' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | Date  '(' expression_ ')' );
-
+		{{
 			PT_NODE *node = parser_make_expression (this_parser, PT_DATEF, $4, NULL, NULL);
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| Time
 		{ push_msg(MSGCAT_SYNTAX_INVALID_TIME); }
 	  '(' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | Time '(' expression_ ')' );
-
+		{{
 			PT_NODE *node = parser_make_expression (this_parser, PT_TIMEF, $4, NULL, NULL);
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| ADDDATE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_ADDDATE); }
 	  '(' expression_ ',' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | ADDDATE '(' expression_ ',' expression_ ')' );
-
+		{{
 			PT_NODE *node = parser_make_expression (this_parser, PT_ADDDATE, $4, $6, NULL);
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| adddate_name
 		{ push_msg(MSGCAT_SYNTAX_INVALID_DATE_ADD); }
 	  '(' expression_ ',' INTERVAL expression_ datetime_field ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | adddate_name '(' expression_ ',' INTERVAL expression_ datetime_field ')' );
-
+		{{
 			PT_NODE *node;
 			PT_NODE *node_unit = parser_new_node (this_parser, PT_VALUE);
 
@@ -17481,26 +15695,22 @@ reserved_func
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SUBDATE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SUBDATE); }
 	  '(' expression_ ',' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | SUBDATE '(' expression_ ',' expression_ ')' );
-
+		{{
 			PT_NODE *node = parser_make_expression (this_parser, PT_SUBDATE, $4, $6, NULL);
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| subdate_name
 		{ push_msg(MSGCAT_SYNTAX_INVALID_DATE_SUB); }
 	  '(' expression_ ',' INTERVAL expression_ datetime_field ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | subdate_name  '(' expression_ ',' INTERVAL expression_ datetime_field ')' );
-
+		{{
 			PT_NODE *node;
 			PT_NODE *node_unit = parser_new_node (this_parser, PT_VALUE);
 
@@ -17514,13 +15724,12 @@ reserved_func
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| TIMESTAMP
 		{ push_msg(MSGCAT_SYNTAX_INVALID_TIMESTAMP); }
 		'(' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | TIMESTAMP  '(' expression_ ')' );
+		{{
 			PT_NODE *arg2 = NULL;
 			PT_NODE *node = NULL;
 			arg2 = parser_new_node(this_parser, PT_VALUE);
@@ -17533,198 +15742,166 @@ reserved_func
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| TIMESTAMP
 		{ push_msg(MSGCAT_SYNTAX_INVALID_TIMESTAMP); }
 		'(' expression_ ',' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | TIMESTAMP  '(' expression_ ',' expression_ ')' );
-
+		{{
 			PT_NODE *node = parser_make_expression (this_parser, PT_TIMESTAMP, $4, $6, NULL); /* 2 parameters */
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| YEAR_
 		{ push_msg(MSGCAT_SYNTAX_INVALID_YEAR); }
 		'(' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | YEAR_  '(' expression_ ')' );
-
+		{{
 			PT_NODE *node = parser_make_expression (this_parser, PT_YEARF, $4, NULL, NULL); /* 1 parameter */
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| MONTH_
 		{ push_msg(MSGCAT_SYNTAX_INVALID_MONTH); }
 		'(' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | MONTH_  '(' expression_ ')' );
-
+		{{
 			PT_NODE *node = parser_make_expression (this_parser, PT_MONTHF, $4, NULL, NULL); /* 1 parameter */
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| DAY_
 		{ push_msg(MSGCAT_SYNTAX_INVALID_DAY); }
 		'(' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | DAY_  '(' expression_ ')' );
-
+		{{
 			PT_NODE *node = parser_make_expression (this_parser, PT_DAYF, $4, NULL, NULL); /* 1 parameter */
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| HOUR_
 		{ push_msg(MSGCAT_SYNTAX_INVALID_HOUR); }
 		'(' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | HOUR_  '(' expression_ ')' );
-
+		{{
 			PT_NODE *node = parser_make_expression (this_parser, PT_HOURF, $4, NULL, NULL); /* 1 parameter */
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| MINUTE_
 		{ push_msg(MSGCAT_SYNTAX_INVALID_MINUTE); }
 		'(' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | MINUTE_  '(' expression_ ')' );
-
+		{{
 			PT_NODE *node = parser_make_expression (this_parser, PT_MINUTEF, $4, NULL, NULL); /* 1 parameter */
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SECOND_
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SECOND); }
 		'(' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | SECOND_  '(' expression_ ')' );
-
+		{{
 			PT_NODE *node = parser_make_expression (this_parser, PT_SECONDF, $4, NULL, NULL); /* 1 parameter */
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| DATABASE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_DATABASE); }
 	  '(' ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | DATABASE  '(' ')' );
-
+		{{
 			PT_NODE *node = parser_make_expression (this_parser, PT_DATABASE, NULL, NULL, NULL);
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SCHEMA
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SCHEMA); }
 	  '(' ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | SCHEMA  '(' ')' );
-
+		{{
 			PT_NODE *node = parser_make_expression (this_parser, PT_SCHEMA, NULL, NULL, NULL);
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| TRIM
 		{ push_msg(MSGCAT_SYNTAX_INVALID_TRIM); }
 	  '(' of_leading_trailing_both expression_ FROM expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | TRIM  '(' of_leading_trailing_both expression_ FROM expression_ ')' );
-
+		{{
 			PT_NODE *node = parser_make_expression (this_parser, PT_TRIM, $7, $5, NULL);
 			node->info.expr.qualifier = $4;
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| TRIM
 		{ push_msg(MSGCAT_SYNTAX_INVALID_TRIM); }
 	  '(' of_leading_trailing_both FROM expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | TRIM  '(' of_leading_trailing_both FROM expression_ ')' );
-
+		{{
 			PT_NODE *node = parser_make_expression (this_parser, PT_TRIM, $6, NULL, NULL);
 			node->info.expr.qualifier = $4;
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| TRIM
 		{ push_msg(MSGCAT_SYNTAX_INVALID_TRIM); }
 	  '(' expression_ FROM  expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | TRIM '(' expression_ FROM  expression_ ')' );
-
+		{{
 			PT_NODE *node = parser_make_expression (this_parser, PT_TRIM, $6, $4, NULL);
 			node->info.expr.qualifier = PT_BOTH;
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| TRIM
 		{ push_msg(MSGCAT_SYNTAX_INVALID_TRIM); }
 	  '(' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | TRIM '(' expression_ ')' );
-
+		{{
 			PT_NODE *node = parser_make_expression (this_parser, PT_TRIM, $4, NULL, NULL);
 			node->info.expr.qualifier = PT_BOTH;
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| CHR
 		{ push_msg(MSGCAT_SYNTAX_INVALID_CHR); }
 	  '(' expression_ opt_using_charset ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | CHR '(' expression_ opt_using_charset ')' );
-
+		{{
 			PT_NODE *node = parser_make_expression (this_parser, PT_CHR, $4, $5, NULL);
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| CLOB_TO_CHAR
 		{ push_msg(MSGCAT_SYNTAX_INVALID_CLOB_TO_CHAR); }
 	  '(' expression_ opt_using_charset ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | CLOB_TO_CHAR '(' expression_ opt_using_charset ')' );
-
+		{{
 			PT_NODE *node = parser_make_expression (this_parser, PT_CLOB_TO_CHAR, $4, $5, NULL);
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| CAST
 		{ push_msg(MSGCAT_SYNTAX_INVALID_CAST); }
 	  '(' expression_ AS of_cast_data_type ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | CAST '(' expression_ AS of_cast_data_type ')' );
-
+		{{
 			PT_NODE *expr = parser_make_expression (this_parser, PT_CAST, $4, NULL, NULL);
 			PT_TYPE_ENUM typ = TO_NUMBER (CONTAINER_AT_0 ($6));
 			PT_NODE *dt = CONTAINER_AT_1 ($6);
@@ -17752,100 +15929,76 @@ reserved_func
 			expr->info.expr.cast_type = dt;
 			$$ = expr;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| CLASS '(' identifier ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | CLASS '(' identifier ')' );
-
+		{{
 			$3->info.name.meta_class = PT_OID_ATTR;
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 			parser_groupby_exception = PT_OID_ATTR;
-
 		}}
 	| SYS_DATE
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | SYS_DATE );
-
+		{{
 			PT_NODE *expr = parser_make_expression (this_parser, PT_SYS_DATE, NULL, NULL, NULL);
 			$$ = expr;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| of_current_date
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_current_date );
-
+		{{
 			PT_NODE *expr = parser_make_expression (this_parser, PT_CURRENT_DATE, NULL, NULL, NULL);
 			$$ = expr;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SYS_TIME_
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | SYS_TIME_ );
-
+		{{
 			PT_NODE *expr = parser_make_expression (this_parser, PT_SYS_TIME, NULL, NULL, NULL);
 			$$ = expr;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| of_current_time
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_current_time );
-
+		{{
 			PT_NODE *expr = parser_make_expression (this_parser, PT_CURRENT_TIME, NULL, NULL, NULL);
 			$$ = expr;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| of_db_timezone_
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_db_timezone_ );
-
+		{{
 			PT_NODE *expr = parser_make_expression (this_parser, PT_DBTIMEZONE, NULL, NULL, NULL);
 			$$ = expr;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| of_session_timezone_
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_session_timezone_ );
-
+		{{
 			PT_NODE *expr = parser_make_expression (this_parser, PT_SESSIONTIMEZONE, NULL, NULL, NULL);
 			$$ = expr;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SYS_TIMESTAMP
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | SYS_TIMESTAMP );
-
+		{{
 			PT_NODE *expr = parser_make_expression (this_parser, PT_SYS_TIMESTAMP, NULL, NULL, NULL);
 			$$ = expr;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| of_current_timestamps
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_current_timestamps );
-
+		{{
 			PT_NODE *expr = parser_make_expression (this_parser, PT_CURRENT_TIMESTAMP, NULL, NULL, NULL);
 			$$ = expr;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SYS_DATETIME
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | SYS_DATETIME );
-
+		{{
 			PT_NODE *expr = parser_make_expression (this_parser, PT_SYS_DATETIME, NULL, NULL, NULL);
 			$$ = expr;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| of_current_datetime
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_current_datetime );
-
+		{{
 			PT_NODE *expr = parser_make_expression (this_parser, PT_CURRENT_DATETIME, NULL, NULL, NULL);
 			$$ = expr;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| of_users
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_users );
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_EXPR);
 			if (node)
 			  node->info.expr.op = PT_CURRENT_USER;
@@ -17853,26 +16006,22 @@ reserved_func
 			parser_cannot_cache = true;
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| of_users
 		{ push_msg(MSGCAT_SYNTAX_INVALID_SYSTEM_USER); }
 	  '(' ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_users '(' ')' );
-
+		{{
 			PT_NODE *node = parser_make_expression (this_parser, PT_USER, NULL, NULL, NULL);
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| DEFAULT '('
 		{ push_msg(MSGCAT_SYNTAX_INVALID_DEFAULT); }
 	  simple_path_id ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | DEFAULT '(' simple_path_id ')');
-
+		{{
 			PT_NODE *node = NULL;
 			PT_NODE *path = $4;
 
@@ -17885,11 +16034,9 @@ reserved_func
 			  }
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| LOCAL_TRANSACTION_ID
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | LOCAL_TRANSACTION_ID);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_EXPR);
 			if (node)
 			  node->info.expr.op = PT_LOCAL_TRANSACTION_ID;
@@ -17898,11 +16045,9 @@ reserved_func
 			parser_cannot_cache = true;
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| ROWNUM
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | ROWNUM);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_EXPR);
 
 			if (node)
@@ -17919,93 +16064,75 @@ reserved_func
 			  PT_ERRORmf2 (this_parser, node, MSGCAT_SET_PARSER_SEMANTIC,
 				       MSGCAT_SEMANTIC_INSTNUM_COMPATIBILITY_ERR,
 				       "INST_NUM() or ROWNUM", "INST_NUM() or ROWNUM");
-
 		}}
 	| ADD_MONTHS
 		{ push_msg(MSGCAT_SYNTAX_INVALID_ADD_MONTHS); }
 	  '(' expression_ ',' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | ADD_MONTHS  '(' expression_ ',' expression_ ')');
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_ADD_MONTHS, $4, $6, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| OCTET_LENGTH
 		{ push_msg(MSGCAT_SYNTAX_INVALID_OCTET_LENGTH); }
 	  '(' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | OCTET_LENGTH  '(' expression_ ')');
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_OCTET_LENGTH, $4, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| BIT_LENGTH
 		{ push_msg(MSGCAT_SYNTAX_INVALID_BIT_LENGTH); }
 	  '(' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | BIT_LENGTH  '(' expression_ ')');
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_BIT_LENGTH, $4, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| LOWER
 		{ push_msg(MSGCAT_SYNTAX_INVALID_LOWER); }
 	  '(' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | BIT_LENGTH '(' expression_ ')' );
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_LOWER, $4, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| LCASE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_LOWER); }
 	  '(' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | LCASE '(' expression_ ')' );
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_LOWER, $4, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| UPPER
 		{ push_msg(MSGCAT_SYNTAX_INVALID_UPPER); }
 	  '(' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | UPPER '(' expression_ ')' );
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_UPPER, $4, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| UCASE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_UPPER); }
 	  '(' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | UCASE '(' expression_ ')' );
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_UPPER, $4, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SYS_CONNECT_BY_PATH
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | SYS_CONNECT_BY_PATH );
-
+		{{
 			push_msg(MSGCAT_SYNTAX_INVALID_SYS_CONNECT_BY_PATH);
 
 			parser_save_and_set_sysc (0);
 			parser_save_and_set_prc (0);
 			parser_save_and_set_cbrc (0);
 			parser_save_and_set_pseudoc (0);
-
 		}}
 	  '(' expression_ ',' char_string_literal ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func,  '(' expression_ ',' char_string_literal ')' );
-
+		{{
 			PT_NODE *node = parser_make_expression (this_parser, PT_SYS_CONNECT_BY_PATH, $4, $6, NULL);
 			PT_NODE *char_string_node = $6;
 
@@ -18023,129 +16150,109 @@ reserved_func
 				  MSGCAT_SEMANTIC_NOT_ALLOWED_HERE, "SYS_CONNECT_BY_PATH");
 			  }
 			$$ = node;
-
 		}}
 	| IF
 		{ push_msg (MSGCAT_SYNTAX_INVALID_IF); }
 	  '(' search_condition ',' expression_ ',' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func,  | IF '(' search_condition ',' expression_ ',' expression_ ')' );
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_IF, $4, $6, $8);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| IFNULL
 		{ push_msg (MSGCAT_SYNTAX_INVALID_IFNULL); }
 	  '(' expression_ ',' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func,  | IFNULL  '(' expression_ ',' expression_ ')' );
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_IFNULL, $4, $6, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| ISNULL
 		{ push_msg (MSGCAT_SYNTAX_INVALID_ISNULL); }
 	  '(' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func,  | ISNULL  '(' expression_ ')' );
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_ISNULL, $4, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| LEFT
 		{ push_msg(MSGCAT_SYNTAX_INVALID_LEFT); }
 	  '(' expression_ ',' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func,  | LEFT  '(' expression_ ',' expression_ ')' );
+		{{
 			PT_NODE *node =
 			  parser_make_expression (this_parser, PT_LEFT, $4, $6, NULL);
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| RIGHT
 		{ push_msg(MSGCAT_SYNTAX_INVALID_RIGHT); }
 	  '(' expression_ ',' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func,  | RIGHT  '(' expression_ ',' expression_ ')' );
+		{{
 			PT_NODE *node =
 			  parser_make_expression (this_parser, PT_RIGHT, $4, $6, NULL);
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| MOD
 		{ push_msg(MSGCAT_SYNTAX_INVALID_MODULUS); }
 	  '(' expression_ ',' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func,  | MOD  '(' expression_ ',' expression_ ')' );
+		{{
 			PT_NODE *node =
 			  parser_make_expression (this_parser, PT_MODULUS, $4, $6, NULL);
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| TRUNCATE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_TRUNCATE); }
 	  '(' expression_ ',' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func,  | TRUNCATE  '(' expression_ ',' expression_ ')' );
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_TRUNC, $4, $6, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| TRANSLATE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_TRANSLATE); }
 	  '(' expression_  ',' expression_ ',' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func,  | TRANSLATE  '(' expression_  ',' expression_ ',' expression_ ')' );
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_TRANSLATE, $4, $6, $8);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| REPLACE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_TRANSLATE); }
 	  '(' expression_  ',' expression_ ',' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func,  | REPLACE  '(' expression_  ',' expression_ ',' expression_ ')' );
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_REPLACE, $4, $6, $8);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| REPLACE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_REPLACE); }
 	  '(' expression_  ',' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func,  | REPLACE '(' expression_  ',' expression_ ')' );
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_REPLACE, $4, $6, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| STR_TO_DATE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_STRTODATE); }
 	  '(' expression_  ',' string_literal_or_input_hv ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func,  | STR_TO_DATE '(' expression_  ',' string_literal_or_input_hv ')' );
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_STR_TO_DATE, $4, $6, parser_make_date_lang (2, NULL));
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| STR_TO_DATE
 		{ push_msg(MSGCAT_SYNTAX_INVALID_STRTODATE); }
 	  '(' expression_  ',' Null ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func,  | STR_TO_DATE '(' expression_  ',' Null ')' );
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 			if (node)
 			  {
@@ -18155,35 +16262,31 @@ reserved_func
 
 			$$ = parser_make_expression (this_parser, PT_STR_TO_DATE, $4, node, parser_make_date_lang (2, NULL));
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| CHARSET
 		{ push_msg(MSGCAT_SYNTAX_INVALID_CHARSET); }
 	  '(' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func,  | CHARSET  '(' expression_ ')' );
+		{{
 			PT_NODE *node =
 			  parser_make_expression (this_parser, PT_CHARSET, $4, NULL, NULL);
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| COLLATION
 		{ push_msg(MSGCAT_SYNTAX_INVALID_COLLATION); }
 	  '(' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func,  | COLLATION  '(' expression_ ')' );
+		{{
 			PT_NODE *node =
 			  parser_make_expression (this_parser, PT_COLLATION, $4, NULL, NULL);
 			PICE (node);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| of_cume_dist_percent_rank_function '(' expression_list ')' WITHIN GROUP_ '('ORDER BY sort_spec_list')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | of_cume_dist_percent_rank_function '(' expression_list ')' WITHIN GROUP_ '('ORDER BY sort_spec_list')' );
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_FUNCTION);
 			if (node)
 			  {
@@ -18201,134 +16304,132 @@ reserved_func
 		{ push_msg(MSGCAT_SYNTAX_INVALID_INDEX_PREFIX); }
 	  '(' expression_  ',' expression_ ',' expression_ ')'
 		{ pop_msg(); }
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | INDEX_PREFIX  '(' expression_  ',' expression_ ',' expression_ ')' );
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_INDEX_PREFIX, $4, $6, $8);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
         | JSON_ARRAY_APPEND '(' expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_ARRAY_APPEND '(' expression_list ')' );
+		{{
                     $$ = parser_make_func_with_arg_count_mod2 (this_parser, F_JSON_ARRAY_APPEND, $3, 3, 0, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
         | JSON_ARRAY_INSERT '(' expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_ARRAY_INSERT '(' expression_list ')' );
+		{{
                     $$ = parser_make_func_with_arg_count_mod2 (this_parser, F_JSON_ARRAY_INSERT, $3, 3, 0, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
         | JSON_ARRAY_LEX '(' opt_expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_ARRAY_LEX '(' opt_expression_list ')' );
+		{{
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_ARRAY, $3, 0, 0);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
 	| JSON_CONTAINS '(' expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_CONTAINS '(' expression_list ')' );
+		{{
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_CONTAINS, $3, 2, 3);
                     PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 	      }}
 	| JSON_CONTAINS_PATH '(' expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_CONTAINS_PATH '(' expression_list ')' );
+		{{
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_CONTAINS_PATH, $3, 3, 0);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
         | JSON_DEPTH '(' expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_DEPTH '(' expression_list ')' );
+		{{
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_DEPTH, $3, 1, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
         | JSON_EXTRACT '(' expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_EXTRACT '(' expression_list ')' );
+		{{
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_EXTRACT, $3, 2, 0);
                     PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
         | JSON_GET_ALL_PATHS '(' expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_GET_ALL_PATHS '(' expression_list ')' );
+		{{
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_GET_ALL_PATHS, $3, 1, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
         | JSON_INSERT '(' expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_INSERT '(' expression_list ')' );
+		{{
                     $$ = parser_make_func_with_arg_count_mod2 (this_parser, F_JSON_INSERT, $3, 3, 0, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
         | JSON_KEYS '(' expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_KEYS '(' expression_list ')' );
+		{{
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_KEYS, $3, 0, 2);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
         | JSON_LENGTH '(' expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_LENGTH '(' expression_list ')' );
+		{{
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_LENGTH, $3, 1, 2);
                     PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
         | JSON_MERGE '(' expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_MERGE '(' expression_list ')' );
+		{{
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_MERGE, $3, 2, 0);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
         | JSON_MERGE_PATCH '(' expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_MERGE_PATCH '(' expression_list ')' );
+		{{
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_MERGE_PATCH, $3, 2, 0);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
         | JSON_MERGE_PRESERVE '(' expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_MERGE_PRESERVE '(' expression_list ')' );
+		{{
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_MERGE, $3, 2, 0);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
         | JSON_OBJECT_LEX '(' opt_expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_OBJECT_LEX '(' opt_expression_list ')');
+		{{
                     $$ = parser_make_func_with_arg_count_mod2 (this_parser, F_JSON_OBJECT, $3, 0, 0, 0);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
         | JSON_PRETTY '(' expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_PRETTY '(' expression_list ')');
+		{{
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_PRETTY, $3, 1, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
         | JSON_QUOTE '(' expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_QUOTE '(' expression_list ')');
+		{{
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_QUOTE, $3, 1, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
         | JSON_REMOVE '(' expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_REMOVE '(' expression_list ')');
+		{{
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_REMOVE, $3, 2, 0);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
         | JSON_REPLACE '(' expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_REPLACE '(' expression_list ')');
+		{{
                     $$ = parser_make_func_with_arg_count_mod2 (this_parser, F_JSON_REPLACE, $3, 3, 0, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
         | JSON_SET '(' expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_SET '(' expression_list ')');
+		{{
                     $$ = parser_make_func_with_arg_count_mod2 (this_parser, F_JSON_SET, $3, 3, 0, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
         | JSON_SEARCH '(' expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_SEARCH '(' expression_list ')');
+		{{
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_SEARCH, $3, 3, 0);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
         | JSON_TYPE '(' expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_TYPE '(' expression_list ')');
+		{{
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_TYPE, $3, 1, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
         | JSON_UNQUOTE '(' expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_UNQUOTE '(' expression_list ')' );
+		{{
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_UNQUOTE, $3, 1, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
         | JSON_VALID '(' expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | JSON_VALID '(' expression_list ')' );
+		{{
                     $$ = parser_make_func_with_arg_count (this_parser, F_JSON_VALID, $3, 1, 1);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
         | simple_path_id RIGHT_ARROW CHAR_STRING
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | simple_path_id RIGHT_ARROW CHAR_STRING);
+		{{
 		    PT_NODE *matcher = parser_new_node (this_parser, PT_VALUE);
                     if (matcher != NULL)
                       {
@@ -18343,7 +16444,7 @@ reserved_func
                     PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
                 }}
         | simple_path_id DOUBLE_RIGHT_ARROW CHAR_STRING
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | simple_path_id DOUBLE_RIGHT_ARROW CHAR_STRING);
+		{{
                     PT_NODE *matcher = parser_new_node (this_parser, PT_VALUE);
                     if (matcher != NULL)
                       {
@@ -18359,32 +16460,32 @@ reserved_func
                     PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
         | BENCHMARK '(' expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | BENCHMARK '(' expression_list ')');
+		{{
                     $$ = parser_make_func_with_arg_count (this_parser, F_BENCHMARK, $3, 2, 2);
 		    PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
 	| REGEXP_COUNT '(' expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | REGEXP_COUNT '(' expression_list ')');
+		{{
 			$$ = parser_make_func_with_arg_count (this_parser, F_REGEXP_COUNT, $3, 2, 4);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
 	| REGEXP_INSTR '(' expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | REGEXP_INSTR '(' expression_list ')');
+		{{
 			$$ = parser_make_func_with_arg_count (this_parser, F_REGEXP_INSTR, $3, 2, 6);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
 	| REGEXP_LIKE '(' expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | REGEXP_LIKE '(' expression_list ')');
+		{{
 			$$ = parser_make_func_with_arg_count (this_parser, F_REGEXP_LIKE, $3, 2, 3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
 	| REGEXP_REPLACE '(' expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | REGEXP_REPLACE '(' expression_list ')');
+		{{
 			$$ = parser_make_func_with_arg_count (this_parser, F_REGEXP_REPLACE, $3, 3, 6);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
 	| REGEXP_SUBSTR '(' expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(reserved_func, | REGEXP_SUBSTR '(' expression_list ')');
+		{{
 			$$ = parser_make_func_with_arg_count (this_parser, F_REGEXP_SUBSTR, $3, 2, 5);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
@@ -18392,12 +16493,12 @@ reserved_func
 
 of_cume_dist_percent_rank_function
 	: CUME_DIST
-		{{ DBG_TRACE_GRAMMAR(of_cume_dist_percent_rank_function, : CUME_DIST);
+		{{
 			$$ = PT_CUME_DIST;
 		}}
 
 	| PERCENT_RANK
-		{{ DBG_TRACE_GRAMMAR(of_cume_dist_percent_rank_function, | PERCENT_RANK);
+		{{
 			$$ = PT_PERCENT_RANK;
 		}}
     ;
@@ -18468,162 +16569,110 @@ of_users
 of_avg_max_etc
 	: AVG
 		{{
-
 			$$ = PT_AVG;
-
 		}}
 	| Max
 		{{
-
 			$$ = PT_MAX;
-
 		}}
 	| Min
 		{{
-
 			$$ = PT_MIN;
-
 		}}
 	| SUM
 		{{
-
 			$$ = PT_SUM;
-
 		}}
 	| STDDEV
 		{{
-
 			$$ = PT_STDDEV;
-
 		}}
 	| STDDEV_POP
 		{{
-
 			$$ = PT_STDDEV_POP;
-
 		}}
 	| STDDEV_SAMP
 		{{
-
 			$$ = PT_STDDEV_SAMP;
-
 		}}
 	| VAR_POP
 		{{
-
 			$$ = PT_VAR_POP;
-
 		}}
 	| VAR_SAMP
 		{{
-
 			$$ = PT_VAR_SAMP;
-
 		}}
 	| VARIANCE
 		{{
-
 			$$ = PT_VARIANCE;
-
 		}}
 	| BIT_AND
 		{{
-
 			$$ = PT_AGG_BIT_AND;
-
 		}}
 	| BIT_OR
 		{{
-
 			$$ = PT_AGG_BIT_OR;
-
 		}}
 	| BIT_XOR
 		{{
-
 			$$ = PT_AGG_BIT_XOR;
-
 		}}
 	| MEDIAN
 		{{
-
 			$$ = PT_MEDIAN;
-
 		}}
 	;
 
 of_analytic
 	: AVG
 		{{
-
 			$$ = PT_AVG;
-
 		}}
 	| Max
 		{{
-
 			$$ = PT_MAX;
-
 		}}
 	| Min
 		{{
-
 			$$ = PT_MIN;
-
 		}}
 	| SUM
 		{{
-
 			$$ = PT_SUM;
-
 		}}
 	| STDDEV
 		{{
-
 			$$ = PT_STDDEV;
-
 		}}
 	| STDDEV_POP
 		{{
-
 			$$ = PT_STDDEV_POP;
-
 		}}
 	| STDDEV_SAMP
 		{{
-
 			$$ = PT_STDDEV_SAMP;
-
 		}}
 	| VAR_POP
 		{{
-
 			$$ = PT_VAR_POP;
-
 		}}
 	| VAR_SAMP
 		{{
-
 			$$ = PT_VAR_SAMP;
-
 		}}
 	| VARIANCE
 		{{
-
 			$$ = PT_VARIANCE;
-
 		}}
 	| NTILE
 		{{
-
 			$$ = PT_NTILE;
-
 		}}
 	| MEDIAN
 		{{
-
 			$$ = PT_MEDIAN;
-
 		}}
 	/* add other analytic functions here */
 	;
@@ -18631,39 +16680,29 @@ of_analytic
 of_analytic_first_last
 	: FIRST_VALUE
 		{{
-
 			$$ = PT_FIRST_VALUE;
-
 		}}
 	| LAST_VALUE
 		{{
-
 			$$ = PT_LAST_VALUE;
-
 		}}
 	;
 
 of_analytic_nth_value
 	: NTH_VALUE
 		{{
-
 			$$ = PT_NTH_VALUE;
-
 		}}
 	;
 
 of_analytic_lead_lag
 	: LEAD
 		{{
-
 			$$ = PT_LEAD;
-
 		}}
 	| LAG
 		{{
-
 			$$ = PT_LAG;
-
 		}}
 	/* functions that use other row values */
 	;
@@ -18671,46 +16710,34 @@ of_analytic_lead_lag
 of_percentile
 	: PERCENTILE_CONT
 		{{
-
 			$$ = PT_PERCENTILE_CONT;
-
 		}}
 	| PERCENTILE_DISC
 		{{
-
 			$$ = PT_PERCENTILE_DISC;
-
 		}}
 	;
 
 of_analytic_no_args
 	: ROW_NUMBER
 		{{
-
 			$$ = PT_ROW_NUMBER;
-
 		}}
 	| RANK
 		{{
-
 			$$ = PT_RANK;
-
 		}}
 	| DENSE_RANK
 		{{
-
 			$$ = PT_DENSE_RANK;
-
 		}}
 	| CUME_DIST
 		{{
 			$$ = PT_CUME_DIST;
-
 		}}
 	| PERCENT_RANK
 		{{
 			$$ = PT_PERCENT_RANK;
-
 		}}
 	/* add other analytic functions here */
 	;
@@ -18722,95 +16749,70 @@ of_distinct_unique
 
 opt_group_concat_separator
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_group_concat_separator, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| SEPARATOR char_string
-		{{ DBG_TRACE_GRAMMAR(opt_group_concat_separator, | SEPARATOR char_string);
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SEPARATOR bit_string_literal
-		{{ DBG_TRACE_GRAMMAR(opt_group_concat_separator, | SEPARATOR bit_string_literal);
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_agg_order_by
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_agg_order_by, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| ORDER BY sort_spec
-		{{ DBG_TRACE_GRAMMAR(opt_agg_order_by, | ORDER BY sort_spec);
-
+		{{
 			$$ = $3;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_analytic_from_last
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_analytic_from_last, : );
-
+		{{
 			$$ = false;
-
 		}}
 	| FROM FIRST
-		{{ DBG_TRACE_GRAMMAR(opt_analytic_from_last, | FROM FIRST);
-
+		{{
 			$$ = false;
-
 		}}
 	| FROM LAST
-		{{ DBG_TRACE_GRAMMAR(opt_analytic_from_last, | FROM LAST);
-
+		{{
 			$$ = true;
-
 		}}
 	;
 
 opt_analytic_ignore_nulls
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_analytic_ignore_nulls, : );
-
+		{{
 			$$ = false;
-
 		}}
 	| RESPECT NULLS
-		{{ DBG_TRACE_GRAMMAR(opt_analytic_ignore_nulls, | RESPECT NULLS);
-
+		{{
 			$$ = false;
-
 		}}
 	| IGNORE_ NULLS
-		{{ DBG_TRACE_GRAMMAR(opt_analytic_ignore_nulls, | IGNORE_ NULLS);
-
+		{{
 			$$ = true;
-
 		}}
 	;
 
 opt_analytic_partition_by
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_analytic_partition_by, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| PARTITION BY sort_spec_list
-		{{ DBG_TRACE_GRAMMAR(opt_analytic_partition_by, | PARTITION BY sort_spec_list);
-
+		{{
 			PT_NODE *list;
 			$$ = $3;
 
@@ -18823,37 +16825,29 @@ opt_analytic_partition_by
 			  }
 
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_over_analytic_partition_by
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_over_analytic_partition_by, : );
-
+		{{
 			is_analytic_function = false;
 			$$ = NULL;
-
 		}}
 	| OVER '(' opt_analytic_partition_by ')'
-		{{ DBG_TRACE_GRAMMAR(opt_over_analytic_partition_by, | OVER '(' opt_analytic_partition_by ')' );
-
+		{{
 			is_analytic_function = true;
 			$$= $3;
-
 		}}
 	;
 
 opt_analytic_order_by
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_analytic_order_by, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| ORDER BY sort_spec_list
-		{{ DBG_TRACE_GRAMMAR(opt_analytic_order_by, | ORDER BY sort_spec_list );
-
+		{{
 			PT_NODE *list;
 			$$ = $3;
 
@@ -18865,39 +16859,32 @@ opt_analytic_order_by
 			      }
 			  }
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 of_leading_trailing_both
 	: LEADING_
-		{{ DBG_TRACE_GRAMMAR(of_leading_trailing_both, : LEADING_ );
-
+		{{
 			$$ = PT_LEADING;
-
 		}}
 	| TRAILING_
-		{{ DBG_TRACE_GRAMMAR(of_leading_trailing_both, | TRAILING_);
-
+		{{
 			$$ = PT_TRAILING;
-
 		}}
 	| BOTH_
-		{{ DBG_TRACE_GRAMMAR(of_leading_trailing_both, | BOTH_ );
-
+		{{
 			$$ = PT_BOTH;
-
 		}}
 	;
 
 case_expr
 	: NULLIF '(' expression_ ',' expression_ ')'
-		{{ DBG_TRACE_GRAMMAR(case_expr, : NULLIF '(' expression_ ',' expression_ ')' );
+		{{
 			$$ = parser_make_expression (this_parser, PT_NULLIF, $3, $5, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
 	| COALESCE '(' expression_list ')'
-		{{ DBG_TRACE_GRAMMAR(case_expr, | COALESCE '(' expression_list ')' );
+		{{
 			PT_NODE *prev, *expr, *arg, *tmp;
 			int count = parser_count_list ($3);
 			int i;
@@ -18960,11 +16947,9 @@ case_expr
 
 			$$ = expr;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| CASE expression_ simple_when_clause_list opt_else_expr END
-		{{ DBG_TRACE_GRAMMAR(case_expr, | CASE expression_ simple_when_clause_list opt_else_expr END );
-
+		{{
 			int i;
 			PT_NODE *case_oper = $2;
 			PT_NODE *node, *prev, *tmp, *curr, *p;
@@ -19018,11 +17003,9 @@ case_expr
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| CASE searched_when_clause_list opt_else_expr END
-		{{ DBG_TRACE_GRAMMAR(case_expr, | CASE searched_when_clause_list opt_else_expr END );
-
+		{{
 			int i;
 			PT_NODE *node, *prev, *curr, *p;
 
@@ -19063,47 +17046,37 @@ case_expr
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_else_expr
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_else_expr, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| ELSE expression_
-		{{ DBG_TRACE_GRAMMAR(opt_else_expr, | ELSE expression_);
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 simple_when_clause_list
 	: simple_when_clause_list simple_when_clause
-		{{ DBG_TRACE_GRAMMAR(simple_when_clause_list, : simple_when_clause_list simple_when_clause);
-
+		{{
 			$$ = parser_make_link ($1, $2);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| simple_when_clause
-		{{ DBG_TRACE_GRAMMAR(simple_when_clause_list, | simple_when_clause);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 simple_when_clause
 	: WHEN expression_ THEN expression_
-		{{ DBG_TRACE_GRAMMAR(simple_when_clause, : WHEN expression_ THEN expression_);
-
+		{{
 			PT_NODE *node, *p, *q;
 			p = $2;
 			node = parser_new_node (this_parser, PT_EXPR);
@@ -19128,31 +17101,25 @@ simple_when_clause
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 searched_when_clause_list
 	: searched_when_clause_list searched_when_clause
-		{{ DBG_TRACE_GRAMMAR(searched_when_clause_list, : searched_when_clause_list searched_when_clause);
-
+		{{
 			$$ = parser_make_link ($1, $2);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| searched_when_clause
-		{{ DBG_TRACE_GRAMMAR(searched_when_clause_list, | searched_when_clause);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 searched_when_clause
 	: WHEN search_condition THEN expression_
-		{{ DBG_TRACE_GRAMMAR(searched_when_clause, : WHEN search_condition THEN expression_);
-
+		{{
 			PT_NODE *node, *p;
 			node = parser_new_node (this_parser, PT_EXPR);
 			if (node)
@@ -19173,22 +17140,19 @@ searched_when_clause
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 
 extract_expr
 	: EXTRACT '(' datetime_field FROM expression_ ')'
-		{{ DBG_TRACE_GRAMMAR(extract_expr, : EXTRACT '(' datetime_field FROM expression_ ')');
-
+		{{
 			PT_NODE *tmp;
 			tmp = parser_make_expression (this_parser, PT_EXTRACT, $5, NULL, NULL);
 			if (tmp)
 			  tmp->info.expr.qualifier = $3;
 			$$ = tmp;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
@@ -19205,146 +17169,101 @@ subdate_name
 datetime_field
 	: YEAR_
 		{{
-
 			$$ = PT_YEAR;
-
 		}}
 	| MONTH_
 		{{
-
 			$$ = PT_MONTH;
-
 		}}
 	| DAY_
 		{{
-
 			$$ = PT_DAY;
-
 		}}
 	| HOUR_
 		{{
-
 			$$ = PT_HOUR;
-
 		}}
 	| MINUTE_
 		{{
-
 			$$ = PT_MINUTE;
-
 		}}
 	| SECOND_
 		{{
-
 			$$ = PT_SECOND;
-
 		}}
 	| MILLISECOND_
 		{{
-
 			$$ = PT_MILLISECOND;
-
 		}}
 	| WEEK
 		{{
-
 			$$ = PT_WEEK;
-
 		}}
 	| QUARTER
 		{{
-
 			$$ = PT_QUARTER;
-
     		}}
         | SECOND_MILLISECOND
 		{{
-
 			$$ = PT_SECOND_MILLISECOND;
-
     		}}
 	| MINUTE_MILLISECOND
 		{{
-
 			$$ = PT_MINUTE_MILLISECOND;
-
     		}}
 	| MINUTE_SECOND
 		{{
-
 			$$ = PT_MINUTE_SECOND;
-
     		}}
 	| HOUR_MILLISECOND
 		{{
-
 			$$ = PT_HOUR_MILLISECOND;
-
     		}}
 	| HOUR_SECOND
 		{{
-
 			$$ = PT_HOUR_SECOND;
-
     		}}
 	| HOUR_MINUTE
 		{{
-
 			$$ = PT_HOUR_MINUTE;
-
     		}}
 	| DAY_MILLISECOND
 		{{
-
 			$$ = PT_DAY_MILLISECOND;
-
     		}}
 	| DAY_SECOND
 		{{
-
 			$$ = PT_DAY_SECOND;
-
     		}}
 	| DAY_MINUTE
 		{{
-
 			$$ = PT_DAY_MINUTE;
-
     		}}
 	| DAY_HOUR
 		{{
-
 			$$ = PT_DAY_HOUR;
-
     		}}
 	| YEAR_MONTH
 		{{
-
 			$$ = PT_YEAR_MONTH;
-
     		}}
 	;
 
 opt_on_target
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_on_target, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| ON_ primary
-		{{ DBG_TRACE_GRAMMAR(opt_on_target, | ON_ primary);
-
+		{{
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 generic_function
 	: identifier '(' opt_expression_list ')' opt_on_target
-		{{ DBG_TRACE_GRAMMAR(generic_function, : identifier '(' opt_expression_list ')' opt_on_target );
-
+		{{
 			PT_NODE *node = NULL;
 
 			if ($5 == NULL)
@@ -19372,7 +17291,6 @@ generic_function
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
@@ -19392,7 +17310,7 @@ generic_function_for_call
             }
         }
         '(' opt_expression_list_for_call ')' opt_on_target
-		{{ DBG_TRACE_GRAMMAR(generic_function_for_call, : procedure_or_function_name '(' opt_expression_list_for_call ')' opt_on_target );
+		{{
 			PT_NODE *node = NULL;
 
 			if ($6 == NULL)
@@ -19431,14 +17349,12 @@ generic_function_for_call
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 generic_function_id
 	: generic_function
-		{{ DBG_TRACE_GRAMMAR(generic_function_id, : generic_function );
-
+		{{
 			PT_NODE *node = $1;
 
 			if (node && node->node_type == PT_METHOD_CALL)
@@ -19473,35 +17389,29 @@ generic_function_id
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_expression_list
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_expression_list, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| expression_list
-		{{ DBG_TRACE_GRAMMAR(opt_expression_list, | expression_list );
+		{{
                         
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_expression_list_for_call
        : /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_expression_list_for_call, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| expression_list_for_call
-		{{ DBG_TRACE_GRAMMAR(opt_expression_list_for_call, | expression_list );
+		{{
                         
                          if((pwd_info.method_password_arg_idx == 2) && (pwd_info.pwd_start_offset == -1 && pwd_info.pwd_end_offset == -1))
                          {
@@ -19512,14 +17422,12 @@ opt_expression_list_for_call
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 table_set_function_call
 	: SET subquery
-		{{ DBG_TRACE_GRAMMAR(table_set_function_call, : SET subquery );
-
+		{{
 			PT_NODE *func_node;
 			func_node = parser_new_node (this_parser, PT_FUNCTION);
 			if (func_node)
@@ -19529,11 +17437,9 @@ table_set_function_call
 			  }
 			$$ = func_node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| SEQUENCE subquery
-		{{ DBG_TRACE_GRAMMAR(table_set_function_call, | SEQUENCE subquery );
-
+		{{
 			PT_NODE *func_node;
 			func_node = parser_new_node (this_parser, PT_FUNCTION);
 			if (func_node)
@@ -19543,11 +17449,9 @@ table_set_function_call
 			  }
 			$$ = func_node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| LIST subquery
-		{{ DBG_TRACE_GRAMMAR(table_set_function_call, | LIST subquery );
-
+		{{
 			PT_NODE *func_node;
 			func_node = parser_new_node (this_parser, PT_FUNCTION);
 			if (func_node)
@@ -19557,11 +17461,9 @@ table_set_function_call
 			  }
 			$$ = func_node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| MULTISET subquery
-		{{ DBG_TRACE_GRAMMAR(table_set_function_call, | MULTISET subquery );
-
+		{{
 			PT_NODE *func_node;
 			func_node = parser_new_node (this_parser, PT_FUNCTION);
 			if (func_node)
@@ -19571,39 +17473,34 @@ table_set_function_call
 			  }
 			$$ = func_node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 search_condition
 	: search_condition OR boolean_term_xor
-		{{DBG_TRACE_GRAMMAR(search_condition, : search_condition OR boolean_term_xor);
+		{{
 			PT_NODE *arg1 = pt_check_non_logical_expr(this_parser, $1);
 			PT_NODE *arg2 = pt_check_non_logical_expr(this_parser, $3);
 			$$ = parser_make_expression (this_parser, PT_OR, arg1, arg2, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| boolean_term_xor
-		{{DBG_TRACE_GRAMMAR(search_condition, | boolean_term_xor);
+		{{
 			$$ = pt_check_non_logical_expr(this_parser, $1);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 boolean_term_xor
 	: boolean_term_xor XOR boolean_term_is
-		{{DBG_TRACE_GRAMMAR(boolean_term_xor, : boolean_term_xor XOR boolean_term_is);
+		{{
 			PT_NODE *arg1 = pt_check_non_logical_expr(this_parser, $1);
 			PT_NODE *arg2 = pt_check_non_logical_expr(this_parser, $3);
 			$$ = parser_make_expression (this_parser, PT_XOR, arg1, arg2, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| boolean_term_is
-		{{DBG_TRACE_GRAMMAR(boolean_term_xor, | boolean_term_is);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
@@ -19611,108 +17508,86 @@ boolean_term_xor
 
 boolean_term_is
 	: boolean_term_is is_op boolean
-		{{DBG_TRACE_GRAMMAR(boolean_term_xor, : boolean_term_is);
+		{{
 	                PT_NODE *arg = pt_check_non_logical_expr(this_parser, $1);
 			$$ = parser_make_expression (this_parser, $2, arg, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| boolean_term
-		{{DBG_TRACE_GRAMMAR(boolean_term_xor, | boolean_term_is);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 is_op
 	: IS NOT
-		{{ DBG_TRACE_GRAMMAR(is_op, : IS NOT);
-
+		{{
 			$$ = PT_IS_NOT;
-
 		}}
 	| IS
-		{{ DBG_TRACE_GRAMMAR(is_op, | IS);
-
+		{{
 			$$ = PT_IS;
-
 		}}
 	;
 
 boolean_term
 	: boolean_term AND boolean_factor
-		{{DBG_TRACE_GRAMMAR(boolean_term, : boolean_term AND boolean_factor);
+		{{
 			PT_NODE *arg1 = pt_check_non_logical_expr(this_parser, $1);
 			PT_NODE *arg2 = pt_check_non_logical_expr(this_parser, $3);
 			$$ = parser_make_expression (this_parser, PT_AND, arg1, arg2, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| boolean_factor
-		{{DBG_TRACE_GRAMMAR(boolean_term, | boolean_factor);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 boolean_factor
 	: NOT predicate
-		{{DBG_TRACE_GRAMMAR(boolean_factor, : NOT predicate);
-
+		{{
 			PT_NODE *arg = pt_check_non_logical_expr(this_parser, $2);
 			$$ = parser_make_expression (this_parser, PT_NOT, arg, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| '!' predicate
-		{{DBG_TRACE_GRAMMAR(boolean_factor, | '!' predicate);
-
+		{{
 			PT_NODE *arg = pt_check_non_logical_expr(this_parser, $2);
 			$$ = parser_make_expression (this_parser, PT_NOT, arg, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| predicate
-		{{DBG_TRACE_GRAMMAR(boolean_factor, | predicate);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 predicate
 	: EXISTS expression_
-		{{ DBG_TRACE_GRAMMAR(predicate, : EXISTS expression_);
+		{{
 			$$ = parser_make_expression (this_parser, PT_EXISTS, $2, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| expression_
-		{{ DBG_TRACE_GRAMMAR(predicate, | expression_);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 predicate_expression
 	: predicate_expr_sub
-		{{ DBG_TRACE_GRAMMAR(predicate_expression, : predicate_expr_sub);
-
+		{{
 			PT_JOIN_TYPE join_type = parser_top_join_type ();
 			if (join_type == PT_JOIN_RIGHT_OUTER)
 			  parser_restore_wjc ();
-
 		}}
 	  opt_paren_plus
-		{{ DBG_TRACE_GRAMMAR(predicate_expression, opt_paren_plus);
-
+		{{
 			PT_JOIN_TYPE join_type = parser_pop_join_type ();
 			PT_NODE *e, *attr;
 
@@ -19791,15 +17666,13 @@ predicate_expression
 
 			$$ = e;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 
 predicate_expr_sub
 	: pred_lhs comp_op normal_expression
-		{{ DBG_TRACE_GRAMMAR(predicate_expr_sub, : pred_lhs comp_op normal_expression);
-
+		{{
 			PT_NODE *e, *opd1, *opd2, *subq, *t;
 			PT_OP_TYPE op;
 			bool found_paren_set_expr = false;
@@ -19934,20 +17807,16 @@ predicate_expr_sub
 
 			$$ = e;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| pred_lhs like_op normal_expression ESCAPE escape_literal
-		{{ DBG_TRACE_GRAMMAR(predicate_expr_sub, | pred_lhs like_op normal_expression ESCAPE escape_literal);
-
+		{{
 			PT_NODE *esc = parser_make_expression (this_parser, PT_LIKE_ESCAPE, $3, $5, NULL);
 			PT_NODE *node = parser_make_expression (this_parser, $2, $1, esc, NULL);
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| pred_lhs like_op normal_expression
-		{{ DBG_TRACE_GRAMMAR(predicate_expr_sub, | pred_lhs like_op normal_expression);
-
+		{{
  			if (prm_get_bool_value (PRM_ID_REQUIRE_LIKE_ESCAPE_CHARACTER)
  			    && prm_get_bool_value (PRM_ID_NO_BACKSLASH_ESCAPES))
  			  {
@@ -19958,11 +17827,9 @@ predicate_expr_sub
  			  }
 			$$ = parser_make_expression (this_parser, $2, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| pred_lhs rlike_op normal_expression
-		{{ DBG_TRACE_GRAMMAR(predicate_expr_sub, | pred_lhs rlike_op normal_expression);
-
+		{{
 			/* case sensitivity flag */
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 			if (node)
@@ -19978,33 +17845,25 @@ predicate_expr_sub
 			    $$ = NULL;
 			  }
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| pred_lhs null_op
-		{{ DBG_TRACE_GRAMMAR(predicate_expr_sub, | pred_lhs null_op);
-
+		{{
 			$$ = parser_make_expression (this_parser, $2, $1, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| pred_lhs set_op normal_expression
-		{{ DBG_TRACE_GRAMMAR(predicate_expr_sub, | pred_lhs set_op normal_expression);
-
+		{{
 			$$ = parser_make_expression (this_parser, $2, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| pred_lhs between_op normal_expression AND normal_expression
-		{{ DBG_TRACE_GRAMMAR(predicate_expr_sub, | pred_lhs between_op normal_expression AND normal_expression);
-
+		{{
 			PT_NODE *node = parser_make_expression (this_parser, PT_BETWEEN_AND, $3, $5, NULL);
 			$$ = parser_make_expression (this_parser, $2, $1, node, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| pred_lhs in_op in_pred_operand
-		{{ DBG_TRACE_GRAMMAR(predicate_expr_sub, | pred_lhs in_op in_pred_operand);
-
+		{{
 			PT_NODE *node = parser_make_expression (this_parser, $2, $1, NULL, NULL);
 			PT_NODE *t = CONTAINER_AT_1 ($3);
 			bool is_paren = (bool)TO_NUMBER (CONTAINER_AT_0 ($3));
@@ -20195,28 +18054,23 @@ predicate_expr_sub
 			  }
 
 			$$ = node;
-
 		}}
 	;
 	| pred_lhs RANGE_ '(' range_list ')'
-		{{ DBG_TRACE_GRAMMAR(predicate_expr_sub, | pred_lhs RANGE_ '(' range_list ')');
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_RANGE, $1, $4, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| pred_lhs IdName
-		{{ DBG_TRACE_GRAMMAR(predicate_expr_sub, | pred_lhs IdName);
+		{{
 			PT_ERRORm (this_parser, $1, MSGCAT_SET_PARSER_SYNTAX,
 				    MSGCAT_SYNTAX_INVALID_RELATIONAL_OP);
-
 		}}
 	;
 
 pred_lhs
 	: normal_expression opt_paren_plus
-		{{ DBG_TRACE_GRAMMAR(pred_lhs, : normal_expression opt_paren_plus);
-
+		{{
 			PT_JOIN_TYPE join_type = PT_JOIN_NONE;
 
 			if ($2)
@@ -20228,29 +18082,23 @@ pred_lhs
 
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_paren_plus
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_paren_plus, : );
-
+		{{
 			$$ = 0;
-
 		}}
 	| paren_plus
-		{{ DBG_TRACE_GRAMMAR(opt_paren_plus, | paren_plus);
-
+		{{
 			$$ = 1;
-
 		}}
 	;
 
 comp_op
 	:  '=' opt_of_all_some_any
-		{{ DBG_TRACE_GRAMMAR(comp_op, :  '=' opt_of_all_some_any);
-
+		{{
 			switch ($2)
 			  {
 			  case 0:
@@ -20266,11 +18114,9 @@ comp_op
 			    $$ = PT_EQ_SOME;
 			    break;
 			  }
-
 		}}
 	| COMP_NOT_EQ opt_of_all_some_any
-		{{ DBG_TRACE_GRAMMAR(comp_op, | COMP_NOT_EQ opt_of_all_some_any);
-
+		{{
 			switch ($2)
 			  {
 			  case 0:
@@ -20286,11 +18132,9 @@ comp_op
 			    $$ = PT_NE_SOME;
 			    break;
 			  }
-
 		}}
 	| '>' opt_of_all_some_any
-		{{ DBG_TRACE_GRAMMAR(comp_op, | '>' opt_of_all_some_any);
-
+		{{
 			switch ($2)
 			  {
 			  case 0:
@@ -20306,11 +18150,9 @@ comp_op
 			    $$ = PT_GT_SOME;
 			    break;
 			  }
-
 		}}
 	| COMP_GE opt_of_all_some_any
-		{{ DBG_TRACE_GRAMMAR(comp_op, | COMP_GE opt_of_all_some_any);
-
+		{{
 			switch ($2)
 			  {
 			  case 0:
@@ -20326,11 +18168,9 @@ comp_op
 			    $$ = PT_GE_SOME;
 			    break;
 			  }
-
 		}}
 	| '<'  opt_of_all_some_any
-		{{ DBG_TRACE_GRAMMAR(comp_op, | '<'  opt_of_all_some_any);
-
+		{{
 			switch ($2)
 			  {
 			  case 0:
@@ -20346,11 +18186,9 @@ comp_op
 			    $$ = PT_LT_SOME;
 			    break;
 			  }
-
 		}}
 	| COMP_LE opt_of_all_some_any
-		{{ DBG_TRACE_GRAMMAR(comp_op, | COMP_LE opt_of_all_some_any);
-
+		{{
 			switch ($2)
 			  {
 			  case 0:
@@ -20366,96 +18204,69 @@ comp_op
 			    $$ = PT_LE_SOME;
 			    break;
 			  }
-
 		}}
 	| '=''=' opt_of_all_some_any
-		{{ DBG_TRACE_GRAMMAR(comp_op, | '=''=' opt_of_all_some_any);
-
+		{{
 			push_msg (MSGCAT_SYNTAX_INVALID_EQUAL_OP);
 			csql_yyerror_explicit (@1.first_line, @1.first_column);
-
 		}}
 	| '!''=' opt_of_all_some_any
-		{{ DBG_TRACE_GRAMMAR(comp_op, | '!''=' opt_of_all_some_any);
-
+		{{
 			push_msg (MSGCAT_SYNTAX_INVALID_NOT_EQUAL);
 			csql_yyerror_explicit (@1.first_line, @1.first_column);
-
 		}}
 	| COMP_NULLSAFE_EQ opt_of_all_some_any
-		{{ DBG_TRACE_GRAMMAR(comp_op, | COMP_NULLSAFE_EQ opt_of_all_some_any);
-
+		{{
 			$$ = PT_NULLSAFE_EQ;
-
 		}}
 	;
 
 opt_of_all_some_any
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_of_all_some_any, : );
-
+		{{
 			$$ = 0;
-
 		}}
 	| ALL
-		{{ DBG_TRACE_GRAMMAR(opt_of_all_some_any, | ALL );
-
+		{{
 			$$ = 1;
-
 		}}
 	| SOME
-		{{ DBG_TRACE_GRAMMAR(opt_of_all_some_any, | SOME );
-
+		{{
 			$$ = 2;
-
 		}}
 	| ANY
-		{{ DBG_TRACE_GRAMMAR(opt_of_all_some_any, | ANY );
-
+		{{
 			$$ = 3;
-
 		}}
 	;
 
 like_op
 	: NOT LIKE
-		{{ DBG_TRACE_GRAMMAR(like_op, : NOT LIKE );
-
+		{{
 			$$ = PT_NOT_LIKE;
-
 		}}
 	| LIKE
-		{{ DBG_TRACE_GRAMMAR(like_op, | LIKE );
-
+		{{
 			$$ = PT_LIKE;
-
 		}}
 	;
 
 rlike_op
 	: rlike_or_regexp
-		{{ DBG_TRACE_GRAMMAR(rlike_op, : rlike_or_regexp);
-
+		{{
 			$$ = PT_RLIKE;
-
 		}}
 	| NOT rlike_or_regexp
-		{{ DBG_TRACE_GRAMMAR(rlike_op, | NOT rlike_or_regexp);
-
+		{{
 			$$ = PT_NOT_RLIKE;
-
 		}}
 	| rlike_or_regexp BINARY
-		{{ DBG_TRACE_GRAMMAR(rlike_op, | rlike_or_regexp BINARY );
-
+		{{
 			$$ = PT_RLIKE_BINARY;
-
 		}}
 	| NOT rlike_or_regexp BINARY
-		{{ DBG_TRACE_GRAMMAR(rlike_op, | NOT rlike_or_regexp BINARY);
-
+		{{
 			$$ = PT_NOT_RLIKE_BINARY;
-
 		}}
 	;
 
@@ -20466,53 +18277,41 @@ rlike_or_regexp
 
 null_op
 	: IS NOT Null
-		{{ DBG_TRACE_GRAMMAR(null_op, : IS NOT Null);
-
+		{{
 			$$ = PT_IS_NOT_NULL;
-
 		}}
 	| IS Null
-		{{ DBG_TRACE_GRAMMAR(null_op, | IS Null);
-
+		{{
 			$$ = PT_IS_NULL;
-
 		}}
 	;
 
 
 between_op
 	: NOT BETWEEN
-		{{ DBG_TRACE_GRAMMAR(between_op, : NOT BETWEEN);
-
+		{{
 			$$ = PT_NOT_BETWEEN;
-
 		}}
 	| BETWEEN
-		{{ DBG_TRACE_GRAMMAR(between_op, | BETWEEN);
-
+		{{
 			$$ = PT_BETWEEN;
-
 		}}
 	;
 
 in_op
 	: IN_
-		{{ DBG_TRACE_GRAMMAR(in_op, : IN_);
-
+		{{
 			$$ = PT_IS_IN;
-
 		}}
 	| NOT IN_
-		{{ DBG_TRACE_GRAMMAR(in_op, | NOT IN_);
-
+		{{
 			$$ = PT_IS_NOT_IN;
-
 		}}
 	;
 
 in_pred_operand
 	: expression_
-		{{ DBG_TRACE_GRAMMAR(in_pred_operand, : expression_);
+		{{
 			container_2 ctn;
 			PT_NODE *exp = $1;
 			if (exp && exp->flag.is_paren == 0)
@@ -20530,130 +18329,95 @@ in_pred_operand
 
 range_list
 	: range_list OR range_
-		{{ DBG_TRACE_GRAMMAR(range_list, : range_list OR range_);
-
+		{{
 			$$ = parser_make_link_or ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| range_
-		{{ DBG_TRACE_GRAMMAR(range_list, | range_);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 range_
 	: expression_ GE_LE_ expression_
-		{{ DBG_TRACE_GRAMMAR(range_, : expression_ GE_LE_ expression_);
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_BETWEEN_GE_LE, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| expression_ GE_LT_ expression_
-		{{ DBG_TRACE_GRAMMAR(range_, | expression_ GE_LT_ expression_);
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_BETWEEN_GE_LT, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| expression_ GT_LE_ expression_
-		{{ DBG_TRACE_GRAMMAR(range_, | expression_ GT_LE_ expression_);
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_BETWEEN_GT_LE, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| expression_ GT_LT_ expression_
-		{{ DBG_TRACE_GRAMMAR(range_, | expression_ GT_LT_ expression_);
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_BETWEEN_GT_LT, $1, $3, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| expression_ '='
-		{{ DBG_TRACE_GRAMMAR(range_, | expression_ '=');
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_BETWEEN_EQ_NA, $1, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| expression_ GE_INF_ Max
-		{{ DBG_TRACE_GRAMMAR(range_, | expression_ GE_INF_ Max);
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_BETWEEN_GE_INF, $1, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| expression_ GT_INF_ Max
-		{{ DBG_TRACE_GRAMMAR(range_, | expression_ GT_INF_ Max);
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_BETWEEN_GT_INF, $1, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| Min INF_LE_ expression_
-		{{ DBG_TRACE_GRAMMAR(range_, | Min INF_LE_ expression_);
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_BETWEEN_INF_LE, $3, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| Min INF_LT_ expression_
-		{{ DBG_TRACE_GRAMMAR(range_, | Min INF_LT_ expression_);
-
+		{{
 			$$ = parser_make_expression (this_parser, PT_BETWEEN_INF_LT, $3, NULL, NULL);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 set_op
 	: SETEQ
 		{{
-
 			$$ = PT_SETEQ;
-
 		}}
 	| SETNEQ
 		{{
-
 			$$ = PT_SETNEQ;
-
 		}}
 	| SUBSET
 		{{
-
 			$$ = PT_SUBSET;
-
 		}}
 	| SUBSETEQ
 		{{
-
 			$$ = PT_SUBSETEQ;
-
 		}}
 	| SUPERSETEQ
 		{{
-
 			$$ = PT_SUPERSETEQ;
-
 		}}
 	| SUPERSET
 		{{
-
 			$$ = PT_SUPERSET;
-
 		}}
 	;
 
 subquery
 	: '(' csql_query ')'
-		{{ DBG_TRACE_GRAMMAR(subquery, : '(' csql_query ')');
-
+		{{
 			PT_NODE *stmt = $2;
 
 			if (parser_within_join_condition)
@@ -20666,14 +18430,12 @@ subquery
 			  stmt->info.query.is_subquery = PT_IS_SUBQUERY;
 			$$ = stmt;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 subquery_without_subquery_and_with_clause
 	: '(' csql_query_without_subquery_and_with_clause ')'
-		{{ DBG_TRACE_GRAMMAR(subquery_without_subquery_and_with_clause, : '(' csql_query_without_subquery_and_with_clause ')');
-
+		{{
 			PT_NODE *stmt = $2;
 
 			if (parser_within_join_condition)
@@ -20686,15 +18448,13 @@ subquery_without_subquery_and_with_clause
 			  stmt->info.query.is_subquery = PT_IS_SUBQUERY;
 			$$ = stmt;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 
 path_expression
 	: path_header path_dot NONE		%dprec 6
-		{{ DBG_TRACE_GRAMMAR(path_expression, : path_header path_dot NONE);
-
+		{{
 			PT_NODE *p = parser_new_node (this_parser, PT_NAME);
 			if (p)
 			  {
@@ -20702,18 +18462,14 @@ path_expression
 			  }
 			$$ = p;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| path_header path_dot IDENTITY		%dprec 5
-		{{ DBG_TRACE_GRAMMAR(path_expression, | path_header path_dot IDENTITY);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| path_header path_dot OBJECT		%dprec 4
-		{{ DBG_TRACE_GRAMMAR(path_expression, | path_header path_dot OBJECT);
-
+		{{
 			PT_NODE *node = $1;
 			if (node && node->node_type == PT_NAME)
 			  {
@@ -20722,11 +18478,9 @@ path_expression
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| path_header DOT '*'			%dprec 3
-		{{ DBG_TRACE_GRAMMAR(path_expression, | path_header DOT '*');
-
+		{{
 			PT_NODE *node = $1;
 			if (node && node->node_type == PT_NAME &&
 			    node->info.name.meta_class == PT_META_CLASS)
@@ -20742,10 +18496,9 @@ path_expression
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| path_id_list				%dprec 2
-		{{ DBG_TRACE_GRAMMAR(path_expression, | path_id_list);
+		{{
 			PT_NODE *dot;
 			PT_NODE *serial_value = NULL;
 
@@ -20817,14 +18570,12 @@ path_expression
 
 			$$ = dot;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 path_id_list
 	: path_id_list path_dot path_id			%dprec 1
-		{{ DBG_TRACE_GRAMMAR(path_id_list, : path_id_list path_dot path_id);
-
+		{{
 			PT_NODE *dot = parser_new_node (this_parser, PT_DOT_);
 			if (dot)
 			  {
@@ -20834,55 +18585,45 @@ path_id_list
 
 			$$ = dot;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| path_header					%dprec 2
-		{{ DBG_TRACE_GRAMMAR(path_id_list, | path_header);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 path_header
 	: param_
-		{{ DBG_TRACE_GRAMMAR(path_header, : param_);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| CLASS path_id
-		{{ DBG_TRACE_GRAMMAR(path_header, | CLASS path_id);
-
+		{{
 			PT_NODE *node = $2;
 			if (node && node->node_type == PT_NAME)
 			  node->info.name.meta_class = PT_META_CLASS;
 			$$ = node;
-
 		}}
 	| path_id
-		{{ DBG_TRACE_GRAMMAR(path_header, | path_id);
-
+		{{
 			PT_NODE *node = $1;
 			if (node && node->node_type == PT_NAME)
 			  node->info.name.meta_class = PT_NORMAL;
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 path_dot
-	: DOT          { DBG_TRACE_GRAMMAR(path_dot, : DOT); }
-	| RIGHT_ARROW  { DBG_TRACE_GRAMMAR(path_dot, | RIGHT_ARROW); }
+	: DOT          { }
+	| RIGHT_ARROW  { }
 	;
 
 path_id
 	: identifier '{' identifier '}'
-		{{ DBG_TRACE_GRAMMAR(path_id, : identifier '{' identifier '}');
-
+		{{
 			PT_NODE *corr = $3;
 			PT_NODE *name = $1;
 
@@ -20890,35 +18631,27 @@ path_id
 			  name->info.name.path_correlation = corr;
 			$$ = name;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| identifier
-		{{ DBG_TRACE_GRAMMAR(path_id, | identifier);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| generic_function_id
-		{{ DBG_TRACE_GRAMMAR(path_id, | generic_function_id);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| table_set_function_call
-		{{ DBG_TRACE_GRAMMAR(path_id, | table_set_function_call);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 simple_path_id
 	: identifier DOT identifier
-		{{ DBG_TRACE_GRAMMAR(simple_path_id, : identifier DOT identifier);
-
+		{{
 			PT_NODE *dot = parser_new_node (this_parser, PT_DOT_);
 			if (dot)
 			  {
@@ -20928,73 +18661,55 @@ simple_path_id
 
 			$$ = dot;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| identifier
-		{{ DBG_TRACE_GRAMMAR(simple_path_id, | identifier);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_in_out
 	: /* empty */
 		{{
-
 			$$ = PT_NOPUT;
-
 		}}
 	| IN_
 		{{
-
 			$$ = PT_INPUT;
-
 		}}
 	| OUT_
 		{{
-
 			$$ = PT_OUTPUT;
-
 		}}
 	| INOUT
 		{{
-
 			$$ = PT_INPUTOUTPUT;
-
 		}}
 	;
 
 negative_prec_cast_type
 	: CHAR_
-		{{ DBG_TRACE_GRAMMAR(negative_prec_cast_type, : CHAR_);
-
+		{{
 			$$ = PT_TYPE_CHAR;
-
 		}}
 	| NATIONAL CHAR_
-		{{ DBG_TRACE_GRAMMAR(negative_prec_cast_type, |  NATIONAL CHAR_);
-
+		{{
 			$$ = PT_TYPE_NCHAR;
-
 		}}
 	| NCHAR
-		{{ DBG_TRACE_GRAMMAR(negative_prec_cast_type, | NCHAR);
-
+		{{
 			$$ = PT_TYPE_NCHAR;
-
 		}}
 	;
 
 of_cast_data_type
 	: data_type
-		{{ DBG_TRACE_GRAMMAR(of_cast_data_type, : data_type);
+		{{
 			$$ = $1;
-
 		}}
 	| negative_prec_cast_type '(' '-' unsigned_integer ')' opt_charset opt_collation
-		{{ DBG_TRACE_GRAMMAR(of_cast_data_type, | negative_prec_cast_type '(' '-' unsigned_integer ')' opt_charset opt_collation);
+		{{
 			container_2 ctn;
 			PT_TYPE_ENUM typ = $1;
 			PT_NODE *len = NULL, *dt = NULL;
@@ -21057,14 +18772,12 @@ of_cast_data_type
 			  {
 			    parser_free_node (this_parser, coll_node);
 			  }
-
 		}}
 	;
 
 data_type
 	: nested_set primitive_type
-		{{ DBG_TRACE_GRAMMAR(data_type, : nested_set primitive_type);
-
+		{{
 			container_2 ctn;
 			PT_TYPE_ENUM typ, e;
 			PT_NODE *dt;
@@ -21085,11 +18798,9 @@ data_type
 
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (typ), dt);
 			$$ = ctn;
-
 		}}
 	| nested_set '(' data_type_list ')'
-		{{ DBG_TRACE_GRAMMAR(data_type, | nested_set '(' data_type_list ')');
-
+		{{
 			container_2 ctn;
 			PT_TYPE_ENUM typ;
 			PT_NODE *dt;
@@ -21099,22 +18810,18 @@ data_type
 
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (typ), dt);
 			$$ = ctn;
-
 		}}
 	| nested_set '(' ')'
-		{{ DBG_TRACE_GRAMMAR(data_type, | nested_set '(' ')');
-
+		{{
 			container_2 ctn;
 			PT_TYPE_ENUM typ;
 
 			typ = $1;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (typ), NULL);
 			$$ = ctn;
-
 		}}
 	| nested_set set_type
-		{{ DBG_TRACE_GRAMMAR(data_type, | nested_set set_type);
-
+		{{
 			container_2 ctn;
 			PT_TYPE_ENUM typ;
 			PT_NODE *dt;
@@ -21129,45 +18836,35 @@ data_type
 
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (typ), dt);
 			$$ = ctn;
-
 		}}
 	| set_type
-		{{ DBG_TRACE_GRAMMAR(data_type, | set_type);
-
+		{{
 			container_2 ctn;
 			PT_TYPE_ENUM typ;
 			typ = $1;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (typ), NULL);
 			$$ = ctn;
-
 		}}
 	| primitive_type
-		{{ DBG_TRACE_GRAMMAR(data_type, | primitive_type);
-
+		{{
 			$$ = $1;
-
 		}}
 	;
 
 nested_set
 	: nested_set set_type
-		{{ DBG_TRACE_GRAMMAR(nested_set, : nested_set set_type);
-
+		{{
 			$$ = $1;
-
 		}}
 	| set_type
-		{{ DBG_TRACE_GRAMMAR(nested_set, | set_type);
-
+		{{
 			$$ = $1;
-
 		}}
 	;
 
 data_type_list
 	: data_type_list ',' data_type
-		{{ DBG_TRACE_GRAMMAR(data_type_list, : data_type_list ',' data_type);
-
+		{{
 			PT_NODE *dt;
 			PT_TYPE_ENUM e;
 
@@ -21196,11 +18893,9 @@ data_type_list
 
 			$$ = parser_make_link ($1, dt);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| data_type
-		{{ DBG_TRACE_GRAMMAR(data_type_list, | data_type);
-
+		{{
 			PT_NODE *dt;
 			PT_TYPE_ENUM e;
 
@@ -21229,240 +18924,183 @@ data_type_list
 
 			$$ = dt;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 char_bit_type
 	: CHAR_ opt_varying
-		{{ DBG_TRACE_GRAMMAR(char_bit_type, : CHAR_ opt_varying);
-
+		{{
 			if ($2)
 			  $$ = PT_TYPE_VARCHAR;
 			else
 			  $$ = PT_TYPE_CHAR;
-
 		}}
 	| VARCHAR
-		{{ DBG_TRACE_GRAMMAR(char_bit_type, | VARCHAR);
-
+		{{
 			$$ = PT_TYPE_VARCHAR;
-
 		}}
 	| NATIONAL CHAR_ opt_varying
-		{{ DBG_TRACE_GRAMMAR(char_bit_type, | NATIONAL CHAR_ opt_varying);
-
+		{{
 			if ($3)
 			  $$ = PT_TYPE_VARNCHAR;
 			else
 			  $$ = PT_TYPE_NCHAR;
-
 		}}
 	| NCHAR	opt_varying
-		{{ DBG_TRACE_GRAMMAR(char_bit_type, | NCHAR	opt_varying);
-
+		{{
 			if ($2)
 			  $$ = PT_TYPE_VARNCHAR;
 			else
 			  $$ = PT_TYPE_NCHAR;
-
 		}}
 	| BIT opt_varying
-		{{ DBG_TRACE_GRAMMAR(char_bit_type, | BIT opt_varying);
-
+		{{
 			if ($2)
 			  $$ = PT_TYPE_VARBIT;
 			else
 			  $$ = PT_TYPE_BIT;
-
 		}}
 	;
 
 opt_varying
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_varying, : );
-
+		{{
 			$$ = 0;
-
 		}}
 	| VARYING
-		{{ DBG_TRACE_GRAMMAR(opt_varying, | VARYING);
-
+		{{
 			$$ = 1;
-
 		}}
 	;
 
 json_schema
 		: /* empty */
-			{{ DBG_TRACE_GRAMMAR(json_schema, : );
-
+			{{
 				$$ = 0;
-
 			}}
 		| '(' CHAR_STRING ')'
-			{{ DBG_TRACE_GRAMMAR(json_schema, | '(' CHAR_STRING ')' );
-
+			{{
 				$$ = $2;
-
 			}}
 		;
 
 primitive_type
 	: INTEGER opt_padding
-		{{ DBG_TRACE_GRAMMAR(primitive_type, : INTEGER opt_padding );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_INTEGER), NULL);
 			$$ = ctn;
-
 		}}
 	| SmallInt
-		{{ DBG_TRACE_GRAMMAR(primitive_type, | SmallInt );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_SMALLINT), NULL);
 			$$ = ctn;
-
 		}}
 	| BIGINT
-		{{ DBG_TRACE_GRAMMAR(primitive_type, | BIGINT );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_BIGINT), NULL);
 			$$ = ctn;
-
 		}}
 	| Double PRECISION
-		{{ DBG_TRACE_GRAMMAR(primitive_type, | Double PRECISION );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_DOUBLE), NULL);
 			$$ = ctn;
-
 		}}
 	| Double
-		{{ DBG_TRACE_GRAMMAR(primitive_type, | Double );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_DOUBLE), NULL);
 			$$ = ctn;
-
 		}}
 	| Date
-		{{ DBG_TRACE_GRAMMAR(primitive_type, | Date );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_DATE), NULL);
 			$$ = ctn;
-
 		}}
 	| Time
-		{{ DBG_TRACE_GRAMMAR(primitive_type, | Time );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_TIME), NULL);
 			$$ = ctn;
-
 		}}
 	| Utime
-		{{ DBG_TRACE_GRAMMAR(primitive_type, | Utime );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_TIMESTAMP), NULL);
 			$$ = ctn;
-
 		}}
 	| TIMESTAMP
-		{{ DBG_TRACE_GRAMMAR(primitive_type, | TIMESTAMP );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_TIMESTAMP), NULL);
 			$$ = ctn;
-
 		}}
 	| TIMESTAMP WITH Time ZONE
-		{{ DBG_TRACE_GRAMMAR(primitive_type, | TIMESTAMP WITH Time ZONE );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_TIMESTAMPTZ), NULL);
 			$$ = ctn;
-
 		}}
 	| TIMESTAMPTZ
-		{{ DBG_TRACE_GRAMMAR(primitive_type, | TIMESTAMPTZ );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_TIMESTAMPTZ), NULL);
 			$$ = ctn;
-
 		}}
 	| TIMESTAMP WITH LOCAL Time ZONE
-		{{ DBG_TRACE_GRAMMAR(primitive_type, | TIMESTAMP WITH LOCAL Time ZONE );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_TIMESTAMPLTZ), NULL);
 			$$ = ctn;
-
 		}}
 	| TIMESTAMPLTZ
-		{{ DBG_TRACE_GRAMMAR(primitive_type, | TIMESTAMPLTZ );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_TIMESTAMPLTZ), NULL);
 			$$ = ctn;
-
 		}}
 	| DATETIME
-		{{ DBG_TRACE_GRAMMAR(primitive_type, | DATETIME );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_DATETIME), NULL);
 			$$ = ctn;
-
 		}}
 	| DATETIME WITH Time ZONE
-		{{ DBG_TRACE_GRAMMAR(primitive_type, | DATETIME WITH Time ZONE );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_DATETIMETZ), NULL);
 			$$ = ctn;
-
 		}}
 	| DATETIMETZ
-		{{ DBG_TRACE_GRAMMAR(primitive_type, | DATETIMETZ );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_DATETIMETZ), NULL);
 			$$ = ctn;
-
 		}}
 	| DATETIME WITH LOCAL Time ZONE
-		{{ DBG_TRACE_GRAMMAR(primitive_type, | DATETIME WITH LOCAL Time ZONE );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_DATETIMELTZ), NULL);
 			$$ = ctn;
-
 		}}
 	| DATETIMELTZ
-		{{ DBG_TRACE_GRAMMAR(primitive_type, | DATETIMELTZ );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_DATETIMELTZ), NULL);
 			$$ = ctn;
-
 		}}
 	| Monetary
-		{{ DBG_TRACE_GRAMMAR(primitive_type, | Monetary );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_MONETARY), NULL);
 			$$ = ctn;
-
 		}}
 	| JSON json_schema
-	    {{ DBG_TRACE_GRAMMAR(primitive_type, | JSON json_schema );
+	    {{
 			const char * json_schema_str = $2;
 			container_2 ctn;
 			PT_TYPE_ENUM type = PT_TYPE_JSON;
@@ -21485,17 +19123,15 @@ primitive_type
 			$$ = ctn;
 		}}
 	| OBJECT
-		{{ DBG_TRACE_GRAMMAR(primitive_type, | OBJECT );
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_OBJECT), NULL);
 			$$ = ctn;
-
 		}}
 	| String
 	  opt_charset
 	  opt_collation
-		{{ DBG_TRACE_GRAMMAR(primitive_type, | String opt_charset opt_collation );
-
+		{{
 			container_2 ctn;
 			PT_TYPE_ENUM typ = PT_TYPE_VARCHAR;
 			PT_NODE *dt = parser_new_node (this_parser, PT_DATA_TYPE);
@@ -21551,27 +19187,21 @@ primitive_type
 			  {
 			    parser_free_node (this_parser, coll_node);
 			  }
-
 		}}
 	| BLOB_ opt_internal_external
-		{{ DBG_TRACE_GRAMMAR(primitive_type, | BLOB_ opt_internal_external );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_BLOB), NULL);
 			$$ = ctn;
-
 		}}
 	| CLOB_ opt_internal_external
-		{{ DBG_TRACE_GRAMMAR(primitive_type, | CLOB_ opt_internal_external );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_CLOB), NULL);
 			$$ = ctn;
-
 		}}
 	| class_name opt_identity
-		{{ DBG_TRACE_GRAMMAR(primitive_type, | class_name opt_identity );
-
+		{{
 			container_2 ctn;
 			PT_TYPE_ENUM typ = PT_TYPE_OBJECT;
 			PT_NODE *dt = parser_new_node (this_parser, PT_DATA_TYPE);
@@ -21587,14 +19217,12 @@ primitive_type
 
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (typ), dt);
 			$$ = ctn;
-
 		}}
 	| char_bit_type
 	  opt_prec_1
 	  opt_charset
 	  opt_collation
-		{{ DBG_TRACE_GRAMMAR(primitive_type, | char_bit_type opt_prec_1 opt_charset opt_collation );
-
+		{{
                         container_2 ctn;
                         PT_TYPE_ENUM typ = $1;
                         PT_NODE *len = NULL, *dt = NULL;
@@ -21746,11 +19374,9 @@ primitive_type
 			  {
 			    parser_free_node (this_parser, coll_node);
 			  }
-
 		}}
 	| NUMERIC opt_prec_2
-		{{ DBG_TRACE_GRAMMAR(primitive_type, | NUMERIC opt_prec_2 );
-
+		{{
 			container_2 ctn;
 			PT_TYPE_ENUM typ;
 			PT_NODE *prec, *scale, *dt;
@@ -21805,11 +19431,9 @@ primitive_type
 			  parser_free_node (this_parser, prec);
 			if (scale)
 			  parser_free_node (this_parser, scale);
-
 		}}
    	| FLOAT_ opt_prec_1
-		{{ DBG_TRACE_GRAMMAR(primitive_type, | FLOAT_ opt_prec_1);
-
+		{{
 			container_2 ctn;
 			PT_TYPE_ENUM typ = PT_TYPE_FLOAT;
 			PT_NODE *prec, *dt = NULL;
@@ -21855,10 +19479,9 @@ primitive_type
 
 			if (prec)
 			  parser_free_node (this_parser, prec);
-
 		}}
 	| ENUM '(' char_string_literal_list ')' opt_charset opt_collation
-	  {{ DBG_TRACE_GRAMMAR(primitive_type, | ENUM '(' char_string_literal_list ')' opt_charset opt_collation);
+	  {{
 			container_2 ctn;
 			int charset = -1;
 			int coll_id = -1;
@@ -21970,94 +19593,70 @@ primitive_type
 
 opt_internal_external
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_internal_external, : );
-
+		{{
 			$$ = 0;
-
 		}}
 	| INTERNAL
-		{{ DBG_TRACE_GRAMMAR(opt_internal_external, | INTERNAL );
-
+		{{
 			$$ = PT_LOB_INTERNAL;
-
 		}}
 	| EXTERNAL
-		{{ DBG_TRACE_GRAMMAR(opt_internal_external, | EXTERNAL );
-
+		{{
 			$$ = PT_LOB_EXTERNAL;
-
 		}}
 	;
 
 opt_identity
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_identity, : );
-
+		{{
 			$$ = 0;
-
 		}}
 	| IDENTITY
-		{{ DBG_TRACE_GRAMMAR(opt_identity, | IDENTITY );
-
+		{{
 			$$ = 1;
-
 		}}
 	;
 
 opt_prec_1
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_prec_1, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| '(' unsigned_integer ')'
-		{{ DBG_TRACE_GRAMMAR(opt_prec_1, | '(' unsigned_integer ')' );
-
+		{{
 			$$ = $2;
-
 		}}
 	;
 
 opt_padding
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_padding, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| '(' unsigned_integer ')'
-		{{ DBG_TRACE_GRAMMAR(opt_padding, | '(' unsigned_integer ')' );
-
+		{{
 			$$ = NULL;
-
 		}}
 	;
 
 opt_prec_2
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_prec_2, : );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, NULL, NULL);
 			$$ = ctn;
-
 		}}
 	| '(' unsigned_integer ')'
-		{{ DBG_TRACE_GRAMMAR(opt_prec_2, | '(' unsigned_integer ')' );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, $2, NULL);
 			$$ = ctn;
-
 		}}
 	| '(' unsigned_integer ',' unsigned_integer ')'
-		{{ DBG_TRACE_GRAMMAR(opt_prec_2, | '(' unsigned_integer ',' unsigned_integer ')' );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, $2, $4);
 			$$ = ctn;
-
 		}}
 	;
 
@@ -22068,28 +19667,22 @@ of_charset
 
 opt_collation
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_collation, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| collation_spec
-		{{ DBG_TRACE_GRAMMAR(opt_collation, | collation_spec );
-
+		{{
 			$$=$1;
-
 		}}
 	;
 
 collation_spec
 	: COLLATE char_string_literal
-		{{ DBG_TRACE_GRAMMAR(collation_spec, : );
-
+		{{
 			$$ = $2;
-
 		}}
 	| COLLATE BINARY
-		{{ DBG_TRACE_GRAMMAR(collation_spec, | COLLATE BINARY);
+		{{
 			PT_NODE *node;
 
 			node = parser_new_node (this_parser, PT_VALUE);
@@ -22106,7 +19699,7 @@ collation_spec
 			$$ = node;
 		}}
 	| COLLATE IdName
-		{{ DBG_TRACE_GRAMMAR(collation_spec, | COLLATE IdName);
+		{{
 			PT_NODE *node;
 
 			node = parser_new_node (this_parser, PT_VALUE);
@@ -22126,7 +19719,7 @@ collation_spec
 
 class_encrypt_spec
   : ENCRYPT opt_equalsign opt_encrypt_algorithm
-		{{ DBG_TRACE_GRAMMAR(class_encrypt_spec, : ENCRYPT opt_equalsign opt_encrypt_algorithm );
+		{{
 			PT_NODE *node = NULL;
 
       node = parser_new_node (this_parser, PT_VALUE);
@@ -22144,7 +19737,7 @@ class_encrypt_spec
 
 class_comment_spec
 	: COMMENT opt_equalsign char_string_literal
-		{{ DBG_TRACE_GRAMMAR(class_comment_spec, : COMMENT opt_equalsign char_string_literal);
+		{{
 			PT_NODE *node = $3;
 
 			if (node)
@@ -22166,10 +19759,10 @@ class_comment_spec
 	| COMMENT					/* 1 */
 	  ON_						/* 2 */
 	  opt_of_column_attribute			/* 3 */
-		{ DBG_TRACE_GRAMMAR(class_comment_spec, : COMMENT ON_ opt_of_column_attribute);
+		{
                   parser_attr_type = PT_NORMAL; }	/* 4 */
 	  attr_def_comment_list				/* 5 */
-		{{ DBG_TRACE_GRAMMAR(class_comment_spec, attr_def_comment_list);
+		{{
 			PT_NODE *alter_node = parser_get_alter_node();
 
 			if (alter_node != NULL)
@@ -22181,10 +19774,10 @@ class_comment_spec
 	| COMMENT					/* 1 */
 	  ON_						/* 2 */
 	  CLASS ATTRIBUTE				/* 3, 4 */
-		{ DBG_TRACE_GRAMMAR(class_comment_spec, : COMMENT ON_ CLASS ATTRIBUTE);
+		{
                    parser_attr_type = PT_META_ATTR; }	/* 5 */
 	  attr_def_comment_list 			/* 6 */
-		{{ DBG_TRACE_GRAMMAR(class_comment_spec, attr_def_comment_list);
+		{{
 			PT_NODE *alter_node = parser_get_alter_node();
 
 			if (alter_node != NULL)
@@ -22197,10 +19790,10 @@ class_comment_spec
 
 opt_vclass_comment_spec
 	: /* empty */
-		{ DBG_TRACE_GRAMMAR(opt_vclass_comment_spec, : );
+		{
                   $$ = NULL; }
 	| class_comment_spec
-		{ DBG_TRACE_GRAMMAR(opt_vclass_comment_spec, | class_comment_spec);
+		{
                   $$ = $1; }
 	;
 
@@ -22211,58 +19804,58 @@ opt_equalsign
 
 opt_encrypt_algorithm
   : /* empty */
-    { DBG_TRACE_GRAMMAR(opt_encrypt_algorithm, : );  
+    {
       $$ = -1; }  /* default algorithm from the system parameter */
   | AES
-    { DBG_TRACE_GRAMMAR(opt_encrypt_algorithm, | AES ); 
+    {
       $$ = 1; }   /* TDE_ALGORITHM_AES */ 
   | ARIA
-    { DBG_TRACE_GRAMMAR(opt_encrypt_algorithm, | ARIA ); 
+    {
       $$ = 2; }   /* TDE_ALGORITHM_ARIA */
   ;
 
 opt_index_with_clause_no_online
         : /* empty */
-          { DBG_TRACE_GRAMMAR(opt_index_with_clause_no_online, : );
+          {
             $$ = DEDUPLICATE_OPTION_AUTO; }
         | WITH deduplicate_key_mod_level
-           { DBG_TRACE_GRAMMAR(opt_index_with_clause_no_online, | WITH deduplicate_key_mod_level );
+           {
 	     $$ = $2; }
         ;
 
 opt_index_with_clause
         : /* empty */
-          { DBG_TRACE_GRAMMAR(opt_index_with_clause, : );
+          {
             container_2 ctn;
             SET_CONTAINER_2(ctn, FROM_NUMBER(0), FROM_NUMBER(DEDUPLICATE_OPTION_AUTO));
             $$ = ctn; }
         | WITH index_with_item_list
-          {  DBG_TRACE_GRAMMAR(opt_index_with_clause, | WITH index_with_item_list );
+          {
              $$ = $2;
           }
         ;
 
 index_with_item_list  
         : online_parallel
-          { DBG_TRACE_GRAMMAR(index_with_item_list, : online_parallel );
+          {
                 container_2 ctn;
                 SET_CONTAINER_2(ctn, FROM_NUMBER($1), FROM_NUMBER(DEDUPLICATE_OPTION_AUTO));
 		$$ = ctn;
           }
         | online_parallel ',' deduplicate_key_mod_level
-          { DBG_TRACE_GRAMMAR(index_with_item_list, | online_parallel ',' deduplicate_key_mod_level );
+          {
                 container_2 ctn;
 		SET_CONTAINER_2(ctn, FROM_NUMBER($1), FROM_NUMBER($3));
 		$$ = ctn;
           }
         | deduplicate_key_mod_level
-          { DBG_TRACE_GRAMMAR(index_with_item_list, | deduplicate_key_mod_level );
+          {
                 container_2 ctn;
 		SET_CONTAINER_2(ctn, FROM_NUMBER(0), FROM_NUMBER($1));
 		$$ = ctn;
           }
         | deduplicate_key_mod_level ',' online_parallel
-          { DBG_TRACE_GRAMMAR(index_with_item_list, | deduplicate_key_mod_level ',' online_parallel ); 
+          {
                 container_2 ctn;
 		SET_CONTAINER_2(ctn, FROM_NUMBER($3), FROM_NUMBER($1));
 		$$ = ctn;
@@ -22271,11 +19864,11 @@ index_with_item_list
 
 online_parallel
 	: ONLINE
-	   {{ DBG_TRACE_GRAMMAR(online_parallel, : ONLINE);
+	   {{
                $$ = 1;  // thread count is 0
            }}
 	| ONLINE PARALLEL opt_equalsign unsigned_integer
-	   {{ DBG_TRACE_GRAMMAR(online_parallel, |  ONLINE PARALLEL opt_equalsign unsigned_integer);
+	   {{
                const int MIN_COUNT = 1;
                const int MAX_COUNT = 16;
                int thread_count = $4->info.value.data_value.i;
@@ -22291,7 +19884,7 @@ online_parallel
 
 deduplicate_key_mod_level
         : DEDUPLICATE_ '=' unsigned_integer
-               { DBG_TRACE_GRAMMAR(deduplicate_key_mod_level,  | DEDUPLICATE_ = unsigned_integer); 
+               {
                   int int_val = $3->info.value.data_value.i;
                   if(int_val < DEDUPLICATE_KEY_LEVEL_OFF || int_val > DEDUPLICATE_KEY_LEVEL_MAX)
                       {                          
@@ -22305,16 +19898,16 @@ deduplicate_key_mod_level
 
 opt_comment_spec
 	: /* empty */
-		{ DBG_TRACE_GRAMMAR(opt_comment_spec, : );
+		{
                   $$ = NULL; }
 	| COMMENT comment_value
-		{ DBG_TRACE_GRAMMAR(opt_comment_spec, | COMMENT comment_value ); 
+		{
                   $$ = $2; }
 	;
 
 comment_value
 	: char_string_literal
-		{{ DBG_TRACE_GRAMMAR(comment_value, : char_string_literal );
+		{{
 			PT_NODE *node = $1;
 
 			if (node)
@@ -22337,28 +19930,22 @@ comment_value
 
 opt_charset
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_charset, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| charset_spec
-		{{ DBG_TRACE_GRAMMAR(opt_charset, | charset_spec);
-
+		{{
 			$$ = $1;
-
 		}}
 	;
 
 charset_spec
 	: of_charset char_string_literal
-		{{ DBG_TRACE_GRAMMAR(charset_spec, : of_charset char_string_literal );
-
+		{{
 			$$ = $2;
-
 		}}
 	| of_charset BINARY
-		{{ DBG_TRACE_GRAMMAR(charset_spec, | of_charset BINARY );
+		{{
 			PT_NODE *node;
 
 			node = parser_new_node (this_parser, PT_VALUE);
@@ -22375,7 +19962,7 @@ charset_spec
 			$$ = node;
 		}}
 	| of_charset IdName
-		{{ DBG_TRACE_GRAMMAR(charset_spec, | of_charset IdName );
+		{{
 			PT_NODE *node;
 
 			node = parser_new_node (this_parser, PT_VALUE);
@@ -22395,8 +19982,7 @@ charset_spec
 
 opt_using_charset
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_using_charset, : );
-
+		{{
 			int charset = lang_get_client_charset ();
 			PT_NODE *node;
 
@@ -22409,11 +19995,9 @@ opt_using_charset
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| USING char_string_literal
-		{{ DBG_TRACE_GRAMMAR(opt_using_charset, | USING char_string_literal );
-
+		{{
 			PT_NODE *charset_node = $2;
 			int dummy;
 			int charset = lang_get_client_charset ();
@@ -22436,11 +20020,9 @@ opt_using_charset
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| USING IdName
-		{{ DBG_TRACE_GRAMMAR(opt_using_charset, | USING IdName );
-
+		{{
 			PT_NODE *temp_node = NULL;
 			int dummy;
 			int charset = lang_charset ();
@@ -22475,11 +20057,9 @@ opt_using_charset
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| USING BINARY
-		{{ DBG_TRACE_GRAMMAR(opt_using_charset, | USING BINARY );
-
+		{{
 			PT_NODE *node;
 
 			node = parser_new_node (this_parser, PT_VALUE);
@@ -22491,34 +20071,25 @@ opt_using_charset
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 set_type
 	: SET_OF
-		{{ DBG_TRACE_GRAMMAR(set_type, : SET_OF );
-
+		{{
 			$$ = PT_TYPE_SET;
-
 		}}
 	| MULTISET_OF
-		{{ DBG_TRACE_GRAMMAR(set_type, | MULTISET_OF );
-
+		{{
 			$$ = PT_TYPE_MULTISET;
-
 		}}
 	| SEQUENCE_OF
-		{{ DBG_TRACE_GRAMMAR(set_type, | SEQUENCE_OF );
-
+		{{
 			$$ = PT_TYPE_SEQUENCE;
-
 		}}
 	| of_container opt_of
-		{{ DBG_TRACE_GRAMMAR(set_type, | of_container opt_of );
-
+		{{
 			$$ = $1;
-
 		}}
 	;
 
@@ -22529,15 +20100,12 @@ opt_of
 
 signed_literal_
 	: literal_
-		{{ DBG_TRACE_GRAMMAR(signed_literal_,  : literal_ );
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| '-' unsigned_integer
-		{{ DBG_TRACE_GRAMMAR(signed_literal_, | '-' unsigned_integer );
-
+		{{
 			PT_NODE *node = $2;
 			if (node != NULL)
 			{
@@ -22580,11 +20148,9 @@ signed_literal_
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| '-' unsigned_real
-		{{ DBG_TRACE_GRAMMAR(signed_literal_,  | '-' unsigned_real);
-
+		{{
 						/* not allowed partition type */
 						/* this will cause semantic error */
 			PT_NODE *node = $2;
@@ -22619,11 +20185,9 @@ signed_literal_
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| '-' monetary_literal
-		{{ DBG_TRACE_GRAMMAR(signed_literal_,  | '-' monetary_literal);
-
+		{{
 						/* not allowed partition type */
 						/* this will cause semantic error */
 
@@ -22640,118 +20204,90 @@ signed_literal_
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 literal_
 	: literal_w_o_param
-		{{ DBG_TRACE_GRAMMAR(literal_,  : literal_w_o_param);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| param_
-		{{ DBG_TRACE_GRAMMAR(literal_,  | param_ );
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 literal_w_o_param
 	: unsigned_integer
-		{{ DBG_TRACE_GRAMMAR(literal_w_o_param, : unsigned_integer );
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| unsigned_real
-		{{ DBG_TRACE_GRAMMAR(literal_w_o_param,  | unsigned_real );
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| monetary_literal
-		{{ DBG_TRACE_GRAMMAR(literal_w_o_param,  : unsigned_integer );
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| char_string_literal
-		{{ DBG_TRACE_GRAMMAR(literal_w_o_param,  | char_string_literal);
-
+		{{
 			PT_NODE *node = $1;
 
 			pt_value_set_collation_info (this_parser, node, NULL);
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| bit_string_literal
-		{{ DBG_TRACE_GRAMMAR(literal_w_o_param,  | bit_string_literal );
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| host_param_input
-		{{ DBG_TRACE_GRAMMAR(literal_w_o_param,  | host_param_input );
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| Null
-		{{ DBG_TRACE_GRAMMAR(literal_w_o_param,  | Null );
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 			if (node)
 			  node->type_enum = PT_TYPE_NULL;
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| constant_set
-		{{ DBG_TRACE_GRAMMAR(literal_w_o_param, | constant_set );
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| NA
-		{{ DBG_TRACE_GRAMMAR(literal_w_o_param,  | NA );
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 			if (node)
 			  node->type_enum = PT_TYPE_NA;
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| date_or_time_literal
-		{{ DBG_TRACE_GRAMMAR(literal_w_o_param, | date_or_time_literal );
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| boolean
-		{{ DBG_TRACE_GRAMMAR(literal_w_o_param,  | boolean );
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| json_literal
-		{{ DBG_TRACE_GRAMMAR(literal_w_o_param, | json_literal );
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
@@ -22759,8 +20295,7 @@ literal_w_o_param
 
 boolean
 	: True
-		{{ DBG_TRACE_GRAMMAR(boolean, : True );
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 			if (node)
 			  {
@@ -22770,11 +20305,9 @@ boolean
 			  }
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| False
-		{{ DBG_TRACE_GRAMMAR(boolean, | False );
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 			if (node)
 			  {
@@ -22784,24 +20317,20 @@ boolean
 			  }
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| UNKNOWN
-		{{ DBG_TRACE_GRAMMAR(boolean, | UNKNOWN );
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 			if (node)
 			  node->type_enum = PT_TYPE_NULL;
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 constant_set
 	: opt_of_container '{' expression_list '}'
-		{{ DBG_TRACE_GRAMMAR(constant_set, : opt_of_container '{' expression_list '}' );
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 			PT_NODE *e;
 
@@ -22825,11 +20354,9 @@ constant_set
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| opt_of_container '{' '}'
-		{{ DBG_TRACE_GRAMMAR(constant_set, | opt_of_container '{' '}' );
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 
 			if (node)
@@ -22840,101 +20367,79 @@ constant_set
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_of_container
 	: /* empty */
-		{{ DBG_TRACE_GRAMMAR(opt_of_container, : );
-
+		{{
 			$$ = PT_TYPE_SEQUENCE;
-
 		}}
 	| of_container
-		{{ DBG_TRACE_GRAMMAR(opt_of_container, | of_container );
-
+		{{
 			$$ = $1;
-
 		}}
 	;
 
 of_container
 	: SET
-		{{ DBG_TRACE_GRAMMAR(of_container, : SET );
-
+		{{
 			$$ = PT_TYPE_SET;
-
 		}}
 	| MULTISET
-		{{ DBG_TRACE_GRAMMAR(of_container, | MULTISET );
-
+		{{
 			$$ = PT_TYPE_MULTISET;
-
 		}}
 	| SEQUENCE
-		{{ DBG_TRACE_GRAMMAR(of_container, | SEQUENCE );
-
+		{{
 			$$ = PT_TYPE_SEQUENCE;
-
 		}}
 	| LIST
-		{{ DBG_TRACE_GRAMMAR(of_container, | LIST );
-
+		{{
 			$$ = PT_TYPE_SEQUENCE;
-
 		}}
 	;
 
 identifier_list
 	: identifier_list ',' identifier
-		{{ DBG_TRACE_GRAMMAR(identifier_list, : identifier_list ',' identifier );
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| identifier
-		{{ DBG_TRACE_GRAMMAR(identifier_list, | identifier );
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 opt_bracketed_identifier_list
 	:	/* EMPTY */
-		{{ DBG_TRACE_GRAMMAR(opt_bracketed_identifier_list, : );
+		{{
 			$$ = NULL;
 		}}
 	| '(' identifier_list ')'
-		{{ DBG_TRACE_GRAMMAR(opt_bracketed_identifier_list, | '(' identifier_list ')' );
+		{{
 			$$ = $2;
 		}}
 	;
 
 simple_path_id_list
 	: simple_path_id_list ',' simple_path_id
-		{{ DBG_TRACE_GRAMMAR(simple_path_id_list, : simple_path_id_list ',' simple_path_id);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| simple_path_id
-		{{ DBG_TRACE_GRAMMAR(simple_path_id_list, | simple_path_id);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 identifier_without_dot
 	: identifier
-		{{ DBG_TRACE_GRAMMAR(identifier_without_dot, : identifier);
-
+		{{
 			PT_NODE *p = $1;
 
 			if (p)
@@ -22953,13 +20458,12 @@ identifier_without_dot
 
 			$$ = p;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 identifier
 	: IdName
-		{{ DBG_TRACE_GRAMMAR(identifier, : IdName);
+		{{
 			PT_NODE *p = parser_new_node (this_parser, PT_NAME);
 			if (p)
 			  {
@@ -22976,7 +20480,7 @@ identifier
 			$$ = p;
 		}}
 	| BracketDelimitedIdName
-		{{ DBG_TRACE_GRAMMAR(identifier, | BracketDelimitedIdName);
+		{{
 			PT_NODE *p = parser_new_node (this_parser, PT_NAME);
 			if (p)
 			  {
@@ -22993,7 +20497,7 @@ identifier
 			$$ = p;
 		}}
 	| BacktickDelimitedIdName
-		{{ DBG_TRACE_GRAMMAR(identifier, | BacktickDelimitedIdName);
+		{{
 			PT_NODE *p = parser_new_node (this_parser, PT_NAME);
 			if (p)
 			  {
@@ -23010,7 +20514,7 @@ identifier
 			$$ = p;
 		}}
 	| DelimitedIdName
-		{{ DBG_TRACE_GRAMMAR(identifier, | DelimitedIdName);
+		{{
 			PT_NODE *p = parser_new_node (this_parser, PT_NAME);
 			if (p)
 			  {
@@ -23027,265 +20531,256 @@ identifier
 			$$ = p;
 		}}
 /*{{{*/
-	| ACTIVE                 {{ DBG_TRACE_GRAMMAR(identifier, | ACTIVE             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| ADDDATE                {{ DBG_TRACE_GRAMMAR(identifier, | ADDDATE            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| AES                    {{ DBG_TRACE_GRAMMAR(identifier, | AES                ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| ANALYZE                {{ DBG_TRACE_GRAMMAR(identifier, | ANALYZE            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| ARCHIVE                {{ DBG_TRACE_GRAMMAR(identifier, | ARCHIVE            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| ARIA                   {{ DBG_TRACE_GRAMMAR(identifier, | ARIA               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| AUTHID                 {{ DBG_TRACE_GRAMMAR(identifier, | AUTHID             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| AUTO_INCREMENT         {{ DBG_TRACE_GRAMMAR(identifier, | AUTO_INCREMENT     ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-        | BENCHMARK              {{ DBG_TRACE_GRAMMAR(identifier, | BENCHMARK          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| BIT_AND                {{ DBG_TRACE_GRAMMAR(identifier, | BIT_AND            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| BIT_OR                 {{ DBG_TRACE_GRAMMAR(identifier, | BIT_OR             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| BIT_XOR                {{ DBG_TRACE_GRAMMAR(identifier, | BIT_XOR            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| BUFFER                 {{ DBG_TRACE_GRAMMAR(identifier, | BUFFER             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| CALLER                 {{ DBG_TRACE_GRAMMAR(identifier, | CALLER             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| CACHE                  {{ DBG_TRACE_GRAMMAR(identifier, | CACHE              ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| CAPACITY               {{ DBG_TRACE_GRAMMAR(identifier, | CAPACITY           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| CHARACTER_SET_         {{ DBG_TRACE_GRAMMAR(identifier, | CHARACTER_SET_     ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| CHARSET                {{ DBG_TRACE_GRAMMAR(identifier, | CHARSET            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| CHR                    {{ DBG_TRACE_GRAMMAR(identifier, | CHR                ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| CLOB_TO_CHAR           {{ DBG_TRACE_GRAMMAR(identifier, | CLOB_TO_CHAR       ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| CLOSE                  {{ DBG_TRACE_GRAMMAR(identifier, | CLOSE              ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| COLLATION              {{ DBG_TRACE_GRAMMAR(identifier, | COLLATION          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| COLUMNS                {{ DBG_TRACE_GRAMMAR(identifier, | COLUMNS            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| COMMENT                {{ DBG_TRACE_GRAMMAR(identifier, | COMMENT            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| COMMITTED              {{ DBG_TRACE_GRAMMAR(identifier, | COMMITTED          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| COMPILE                {{ DBG_TRACE_GRAMMAR(identifier, | COMPILE            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| COST                   {{ DBG_TRACE_GRAMMAR(identifier, | COST               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| CRITICAL               {{ DBG_TRACE_GRAMMAR(identifier, | CRITICAL           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| CUME_DIST              {{ DBG_TRACE_GRAMMAR(identifier, | CUME_DIST          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| DATE_ADD               {{ DBG_TRACE_GRAMMAR(identifier, | DATE_ADD           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| DATE_SUB               {{ DBG_TRACE_GRAMMAR(identifier, | DATE_SUB           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| DB_TIMEZONE            {{ DBG_TRACE_GRAMMAR(identifier, | DB_TIMEZONE        ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| DBLINK                 {{ DBG_TRACE_GRAMMAR(identifier, | DBLINK             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| DBNAME                 {{ DBG_TRACE_GRAMMAR(identifier, | DBNAME             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| DECREMENT              {{ DBG_TRACE_GRAMMAR(identifier, | DECREMENT          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }} 
-	| DEFINER                {{ DBG_TRACE_GRAMMAR(identifier, | DEFINER            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }} 
-       	| DEDUPLICATE_           {{ DBG_TRACE_GRAMMAR(identifier, | DEDUPLICATE_       ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }} 	
-        | DENSE_RANK             {{ DBG_TRACE_GRAMMAR(identifier, | DENSE_RANK         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-        | DETERMINISTIC          {{ DBG_TRACE_GRAMMAR(identifier, | DETERMINISTIC      ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| DISK_SIZE              {{ DBG_TRACE_GRAMMAR(identifier, | DISK_SIZE          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| DONT_REUSE_OID         {{ DBG_TRACE_GRAMMAR(identifier, | DONT_REUSE_OID     ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| ELT                    {{ DBG_TRACE_GRAMMAR(identifier, | ELT                ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| EMPTY                  {{ DBG_TRACE_GRAMMAR(identifier, | EMPTY              ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| ENCRYPT                {{ DBG_TRACE_GRAMMAR(identifier, | ENCRYPT            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| ERROR_                 {{ DBG_TRACE_GRAMMAR(identifier, | ERROR_             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| EXPLAIN                {{ DBG_TRACE_GRAMMAR(identifier, | EXPLAIN            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| FIRST_VALUE            {{ DBG_TRACE_GRAMMAR(identifier, | FIRST_VALUE        ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| FULLSCAN               {{ DBG_TRACE_GRAMMAR(identifier, | FULLSCAN           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| GE_INF_                {{ DBG_TRACE_GRAMMAR(identifier, | GE_INF_            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| GE_LE_                 {{ DBG_TRACE_GRAMMAR(identifier, | GE_LE_             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| GE_LT_                 {{ DBG_TRACE_GRAMMAR(identifier, | GE_LT_             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| GRANTS                 {{ DBG_TRACE_GRAMMAR(identifier, | GRANTS             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| GROUPS                 {{ DBG_TRACE_GRAMMAR(identifier, | GROUPS             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| GROUP_CONCAT           {{ DBG_TRACE_GRAMMAR(identifier, | GROUP_CONCAT       ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| GT_INF_                {{ DBG_TRACE_GRAMMAR(identifier, | GT_INF_            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| GT_LE_                 {{ DBG_TRACE_GRAMMAR(identifier, | GT_LE_             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| GT_LT_                 {{ DBG_TRACE_GRAMMAR(identifier, | GT_LT_             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| HASH                   {{ DBG_TRACE_GRAMMAR(identifier, | HASH               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| HEADER                 {{ DBG_TRACE_GRAMMAR(identifier, | HEADER             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| HEAP                   {{ DBG_TRACE_GRAMMAR(identifier, | HEAP               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}        
-	| HOST                   {{ DBG_TRACE_GRAMMAR(identifier, | HOST               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| IFNULL                 {{ DBG_TRACE_GRAMMAR(identifier, | IFNULL             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| INACTIVE               {{ DBG_TRACE_GRAMMAR(identifier, | INACTIVE           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| INCREMENT              {{ DBG_TRACE_GRAMMAR(identifier, | INCREMENT          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| INDEXES                {{ DBG_TRACE_GRAMMAR(identifier, | INDEXES            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| INDEX_PREFIX           {{ DBG_TRACE_GRAMMAR(identifier, | INDEX_PREFIX       ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| INFINITE_              {{ DBG_TRACE_GRAMMAR(identifier, | INFINITE_          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| INF_LE_                {{ DBG_TRACE_GRAMMAR(identifier, | INF_LE_            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| INF_LT_                {{ DBG_TRACE_GRAMMAR(identifier, | INF_LT_            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| INSTANCES              {{ DBG_TRACE_GRAMMAR(identifier, | INSTANCES          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| INVALIDATE             {{ DBG_TRACE_GRAMMAR(identifier, | INVALIDATE         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| INVISIBLE              {{ DBG_TRACE_GRAMMAR(identifier, | INVISIBLE          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| ISNULL                 {{ DBG_TRACE_GRAMMAR(identifier, | ISNULL             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JAVA                   {{ DBG_TRACE_GRAMMAR(identifier, | JAVA               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JOB                    {{ DBG_TRACE_GRAMMAR(identifier, | JOB                ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_ARRAYAGG          {{ DBG_TRACE_GRAMMAR(identifier, | JSON_ARRAYAGG      ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_ARRAY_APPEND      {{ DBG_TRACE_GRAMMAR(identifier, | JSON_ARRAY_APPEND  ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_ARRAY_INSERT      {{ DBG_TRACE_GRAMMAR(identifier, | JSON_ARRAY_INSERT  ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_ARRAY_LEX         {{ DBG_TRACE_GRAMMAR(identifier, | JSON_ARRAY_LEX     ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_CONTAINS          {{ DBG_TRACE_GRAMMAR(identifier, | JSON_CONTAINS      ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_CONTAINS_PATH     {{ DBG_TRACE_GRAMMAR(identifier, | JSON_CONTAINS_PATH ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_DEPTH             {{ DBG_TRACE_GRAMMAR(identifier, | JSON_DEPTH         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_EXTRACT           {{ DBG_TRACE_GRAMMAR(identifier, | JSON_EXTRACT       ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_GET_ALL_PATHS     {{ DBG_TRACE_GRAMMAR(identifier, | JSON_GET_ALL_PATHS ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_INSERT            {{ DBG_TRACE_GRAMMAR(identifier, | JSON_INSERT        ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_KEYS              {{ DBG_TRACE_GRAMMAR(identifier, | JSON_KEYS          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_LENGTH            {{ DBG_TRACE_GRAMMAR(identifier, | JSON_LENGTH        ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_MERGE             {{ DBG_TRACE_GRAMMAR(identifier, | JSON_MERGE         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_MERGE_PATCH       {{ DBG_TRACE_GRAMMAR(identifier, | JSON_MERGE_PATCH   ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_MERGE_PRESERVE    {{ DBG_TRACE_GRAMMAR(identifier, | JSON_MERGE_PRESERVE); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_OBJECTAGG         {{ DBG_TRACE_GRAMMAR(identifier, | JSON_OBJECTAGG     ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_OBJECT_LEX        {{ DBG_TRACE_GRAMMAR(identifier, | JSON_OBJECT_LEX    ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_PRETTY            {{ DBG_TRACE_GRAMMAR(identifier, | JSON_PRETTY        ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_QUOTE             {{ DBG_TRACE_GRAMMAR(identifier, | JSON_QUOTE         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_REMOVE            {{ DBG_TRACE_GRAMMAR(identifier, | JSON_REMOVE        ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_REPLACE           {{ DBG_TRACE_GRAMMAR(identifier, | JSON_REPLACE       ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_SEARCH            {{ DBG_TRACE_GRAMMAR(identifier, | JSON_SEARCH        ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_SET               {{ DBG_TRACE_GRAMMAR(identifier, | JSON_SET           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_TABLE             {{ DBG_TRACE_GRAMMAR(identifier, | JSON_TABLE         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_TYPE              {{ DBG_TRACE_GRAMMAR(identifier, | JSON_TYPE          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_UNQUOTE           {{ DBG_TRACE_GRAMMAR(identifier, | JSON_UNQUOTE       ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| JSON_VALID             {{ DBG_TRACE_GRAMMAR(identifier, | JSON_VALID         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| KEYLIMIT               {{ DBG_TRACE_GRAMMAR(identifier, | KEYLIMIT           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| KEYS                   {{ DBG_TRACE_GRAMMAR(identifier, | KEYS               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| KILL                   {{ DBG_TRACE_GRAMMAR(identifier, | KILL               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| LAG                    {{ DBG_TRACE_GRAMMAR(identifier, | LAG                ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| LAST_VALUE             {{ DBG_TRACE_GRAMMAR(identifier, | LAST_VALUE         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| LCASE                  {{ DBG_TRACE_GRAMMAR(identifier, | LCASE              ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| LEAD                   {{ DBG_TRACE_GRAMMAR(identifier, | LEAD               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| LOCK_                  {{ DBG_TRACE_GRAMMAR(identifier, | LOCK_              ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| LOG                    {{ DBG_TRACE_GRAMMAR(identifier, | LOG                ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}        
-	| MATCHED                {{ DBG_TRACE_GRAMMAR(identifier, | MATCHED            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| MAXIMUM                {{ DBG_TRACE_GRAMMAR(identifier, | MAXIMUM            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| MAXVALUE               {{ DBG_TRACE_GRAMMAR(identifier, | MAXVALUE           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| MEDIAN                 {{ DBG_TRACE_GRAMMAR(identifier, | MEDIAN             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}	
-	| MEMBERS                {{ DBG_TRACE_GRAMMAR(identifier, | MEMBERS            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| MINVALUE               {{ DBG_TRACE_GRAMMAR(identifier, | MINVALUE           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| NAME                   {{ DBG_TRACE_GRAMMAR(identifier, | NAME               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| NESTED                 {{ DBG_TRACE_GRAMMAR(identifier, | NESTED             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| NOCACHE                {{ DBG_TRACE_GRAMMAR(identifier, | NOCACHE            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| NOCYCLE                {{ DBG_TRACE_GRAMMAR(identifier, | NOCYCLE            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| NOMAXVALUE             {{ DBG_TRACE_GRAMMAR(identifier, | NOMAXVALUE         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| NOMINVALUE             {{ DBG_TRACE_GRAMMAR(identifier, | NOMINVALUE         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| NTH_VALUE              {{ DBG_TRACE_GRAMMAR(identifier, | NTH_VALUE          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| NTILE                  {{ DBG_TRACE_GRAMMAR(identifier, | NTILE              ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| NULLS                  {{ DBG_TRACE_GRAMMAR(identifier, | NULLS              ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| OFFSET                 {{ DBG_TRACE_GRAMMAR(identifier, | OFFSET             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| ONLINE                 {{ DBG_TRACE_GRAMMAR(identifier, | ONLINE             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| OPEN                   {{ DBG_TRACE_GRAMMAR(identifier, | OPEN               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| ORDINALITY             {{ DBG_TRACE_GRAMMAR(identifier, | ORDINALITY         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| OVER                   {{ DBG_TRACE_GRAMMAR(identifier, | OVER               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| OWNER                  {{ DBG_TRACE_GRAMMAR(identifier, | OWNER              ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| PAGE                   {{ DBG_TRACE_GRAMMAR(identifier, | PAGE               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| PARALLEL               {{ DBG_TRACE_GRAMMAR(identifier, | PARALLEL           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| PARTITIONING           {{ DBG_TRACE_GRAMMAR(identifier, | PARTITIONING       ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| PARTITIONS             {{ DBG_TRACE_GRAMMAR(identifier, | PARTITIONS         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| PASSWORD               {{ DBG_TRACE_GRAMMAR(identifier, | PASSWORD           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| PATH                   {{ DBG_TRACE_GRAMMAR(identifier, | PATH               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| PERCENTILE_CONT        {{ DBG_TRACE_GRAMMAR(identifier, | PERCENTILE_CONT    ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| PERCENTILE_DISC        {{ DBG_TRACE_GRAMMAR(identifier, | PERCENTILE_DISC    ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| PERCENT_RANK           {{ DBG_TRACE_GRAMMAR(identifier, | PERCENT_RANK       ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| PLCSQL                 {{ DBG_TRACE_GRAMMAR(identifier, | PLCSQL             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| PORT                   {{ DBG_TRACE_GRAMMAR(identifier, | PORT               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| PRINT                  {{ DBG_TRACE_GRAMMAR(identifier, | PRINT              ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| PRIORITY               {{ DBG_TRACE_GRAMMAR(identifier, | PRIORITY           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| PRIVATE                {{ DBG_TRACE_GRAMMAR(identifier, | PRIVATE            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| PROMOTE                {{ DBG_TRACE_GRAMMAR(identifier, | PROMOTE            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| PROPERTIES             {{ DBG_TRACE_GRAMMAR(identifier, | PROPERTIES         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| PUBLIC                 {{ DBG_TRACE_GRAMMAR(identifier, | PUBLIC             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| QUARTER                {{ DBG_TRACE_GRAMMAR(identifier, | QUARTER            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| QUEUES                 {{ DBG_TRACE_GRAMMAR(identifier, | QUEUES             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| RANGE_                 {{ DBG_TRACE_GRAMMAR(identifier, | RANGE_             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| RANK                   {{ DBG_TRACE_GRAMMAR(identifier, | RANK               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| REBUILD                {{ DBG_TRACE_GRAMMAR(identifier, | REBUILD            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| REGEXP                 {{ DBG_TRACE_GRAMMAR(identifier, | REGEXP             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| REGEXP_COUNT           {{ DBG_TRACE_GRAMMAR(identifier, | REGEXP_COUNT       ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| REGEXP_INSTR           {{ DBG_TRACE_GRAMMAR(identifier, | REGEXP_INSTR       ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| REGEXP_LIKE            {{ DBG_TRACE_GRAMMAR(identifier, | REGEXP_LIKE        ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| REGEXP_REPLACE         {{ DBG_TRACE_GRAMMAR(identifier, | REGEXP_REPLACE     ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| REGEXP_SUBSTR          {{ DBG_TRACE_GRAMMAR(identifier, | REGEXP_SUBSTR      ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| REJECT_                {{ DBG_TRACE_GRAMMAR(identifier, | REJECT_            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| REMOVE                 {{ DBG_TRACE_GRAMMAR(identifier, | REMOVE             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| REORGANIZE             {{ DBG_TRACE_GRAMMAR(identifier, | REORGANIZE         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| REPEATABLE             {{ DBG_TRACE_GRAMMAR(identifier, | REPEATABLE         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| RESPECT                {{ DBG_TRACE_GRAMMAR(identifier, | RESPECT            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| RETAIN                 {{ DBG_TRACE_GRAMMAR(identifier, | RETAIN             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| REUSE_OID              {{ DBG_TRACE_GRAMMAR(identifier, | REUSE_OID          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| REVERSE                {{ DBG_TRACE_GRAMMAR(identifier, | REVERSE            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| ROW_NUMBER             {{ DBG_TRACE_GRAMMAR(identifier, | ROW_NUMBER         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| SECTIONS               {{ DBG_TRACE_GRAMMAR(identifier, | SECTIONS           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| SEPARATOR              {{ DBG_TRACE_GRAMMAR(identifier, | SEPARATOR          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| SERIAL                 {{ DBG_TRACE_GRAMMAR(identifier, | SERIAL             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| SERVER                 {{ DBG_TRACE_GRAMMAR(identifier, | SERVER             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| SESSION_TIMEZONE       {{ DBG_TRACE_GRAMMAR(identifier, | SESSION_TIMEZONE   ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| SHOW                   {{ DBG_TRACE_GRAMMAR(identifier, | SHOW               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-    | SLOTS                  {{ DBG_TRACE_GRAMMAR(identifier, | SLOTS              ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| SLOTTED                {{ DBG_TRACE_GRAMMAR(identifier, | SLOTTED            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| STABILITY              {{ DBG_TRACE_GRAMMAR(identifier, | STABILITY          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| START_                 {{ DBG_TRACE_GRAMMAR(identifier, | START_             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| STATEMENT              {{ DBG_TRACE_GRAMMAR(identifier, | STATEMENT          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| STATUS                 {{ DBG_TRACE_GRAMMAR(identifier, | STATUS             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| STDDEV                 {{ DBG_TRACE_GRAMMAR(identifier, | STDDEV             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| STDDEV_POP             {{ DBG_TRACE_GRAMMAR(identifier, | STDDEV_POP         ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| STDDEV_SAMP            {{ DBG_TRACE_GRAMMAR(identifier, | STDDEV_SAMP        ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| STR_TO_DATE            {{ DBG_TRACE_GRAMMAR(identifier, | STR_TO_DATE        ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| SUBDATE                {{ DBG_TRACE_GRAMMAR(identifier, | SUBDATE            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| SYNONYM                {{ DBG_TRACE_GRAMMAR(identifier, | SYNONYM            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| SYSTEM                 {{ DBG_TRACE_GRAMMAR(identifier, | SYSTEM             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| TABLES                 {{ DBG_TRACE_GRAMMAR(identifier, | TABLES             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| TEXT                   {{ DBG_TRACE_GRAMMAR(identifier, | TEXT               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| THAN                   {{ DBG_TRACE_GRAMMAR(identifier, | THAN               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| THREADS                {{ DBG_TRACE_GRAMMAR(identifier, | THREADS            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| TIMEOUT                {{ DBG_TRACE_GRAMMAR(identifier, | TIMEOUT            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| TIMEZONE               {{ DBG_TRACE_GRAMMAR(identifier, | TIMEZONE           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| TIMEZONES              {{ DBG_TRACE_GRAMMAR(identifier, | TIMEZONES          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| TRACE                  {{ DBG_TRACE_GRAMMAR(identifier, | TRACE              ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| TRAN                   {{ DBG_TRACE_GRAMMAR(identifier, | TRAN               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| TRIGGERS               {{ DBG_TRACE_GRAMMAR(identifier, | TRIGGERS           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| TYPE                   {{ DBG_TRACE_GRAMMAR(identifier, | TYPE               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| UCASE                  {{ DBG_TRACE_GRAMMAR(identifier, | UCASE              ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| UNCOMMITTED            {{ DBG_TRACE_GRAMMAR(identifier, | UNCOMMITTED        ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| VARIANCE               {{ DBG_TRACE_GRAMMAR(identifier, | VARIANCE           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| VAR_POP                {{ DBG_TRACE_GRAMMAR(identifier, | VAR_POP            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| VAR_SAMP               {{ DBG_TRACE_GRAMMAR(identifier, | VAR_SAMP           ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| VISIBLE                {{ DBG_TRACE_GRAMMAR(identifier, | VISIBLE            ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| VOLUME                 {{ DBG_TRACE_GRAMMAR(identifier, | VOLUME             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| WEEK                   {{ DBG_TRACE_GRAMMAR(identifier, | WEEK               ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| WITHIN                 {{ DBG_TRACE_GRAMMAR(identifier, | WITHIN             ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
-	| WORKSPACE              {{ DBG_TRACE_GRAMMAR(identifier, | WORKSPACE          ); SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }} 
+	| ACTIVE                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| ADDDATE                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| AES                    {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| ANALYZE                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| ARCHIVE                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| ARIA                   {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| AUTHID                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| AUTO_INCREMENT         {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+        | BENCHMARK              {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| BIT_AND                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| BIT_OR                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| BIT_XOR                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| BUFFER                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| CALLER                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| CACHE                  {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| CAPACITY               {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| CHARACTER_SET_         {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| CHARSET                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| CHR                    {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| CLOB_TO_CHAR           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| CLOSE                  {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| COLLATION              {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| COLUMNS                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| COMMENT                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| COMMITTED              {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| COMPILE                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| COST                   {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| CRITICAL               {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| CUME_DIST              {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| DATE_ADD               {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| DATE_SUB               {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| DB_TIMEZONE            {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| DBLINK                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| DBNAME                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| DECREMENT              {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }} 
+	| DEFINER                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }} 
+       	| DEDUPLICATE_           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }} 	
+        | DENSE_RANK             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+        | DETERMINISTIC          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| DISK_SIZE              {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| DONT_REUSE_OID         {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| ELT                    {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| EMPTY                  {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| ENCRYPT                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| ERROR_                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| EXPLAIN                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| FIRST_VALUE            {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| FULLSCAN               {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| GE_INF_                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| GE_LE_                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| GE_LT_                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| GRANTS                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| GROUPS                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| GROUP_CONCAT           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| GT_INF_                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| GT_LE_                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| GT_LT_                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| HASH                   {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| HEADER                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| HEAP                   {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}        
+	| HOST                   {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| IFNULL                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| INACTIVE               {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| INCREMENT              {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| INDEXES                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| INDEX_PREFIX           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| INFINITE_              {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| INF_LE_                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| INF_LT_                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| INSTANCES              {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| INVALIDATE             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| INVISIBLE              {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| ISNULL                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JAVA                   {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JOB                    {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_ARRAYAGG          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_ARRAY_APPEND      {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_ARRAY_INSERT      {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_ARRAY_LEX         {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_CONTAINS          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_CONTAINS_PATH     {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_DEPTH             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_EXTRACT           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_GET_ALL_PATHS     {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_INSERT            {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_KEYS              {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_LENGTH            {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_MERGE             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_MERGE_PATCH       {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_MERGE_PRESERVE    {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_OBJECTAGG         {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_OBJECT_LEX        {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_PRETTY            {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_QUOTE             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_REMOVE            {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_REPLACE           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_SEARCH            {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_SET               {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_TABLE             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_TYPE              {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_UNQUOTE           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| JSON_VALID             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| KEYLIMIT               {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| KEYS                   {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| KILL                   {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| LAG                    {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| LAST_VALUE             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| LCASE                  {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| LEAD                   {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| LOCK_                  {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| LOG                    {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}        
+	| MATCHED                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| MAXIMUM                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| MAXVALUE               {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| MEDIAN                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}	
+	| MEMBERS                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| MINVALUE               {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| NAME                   {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| NESTED                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| NOCACHE                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| NOCYCLE                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| NOMAXVALUE             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| NOMINVALUE             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| NTH_VALUE              {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| NTILE                  {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| NULLS                  {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| OFFSET                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| ONLINE                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| OPEN                   {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| ORDINALITY             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| OVER                   {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| OWNER                  {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| PAGE                   {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| PARALLEL               {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| PARTITIONING           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| PARTITIONS             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| PASSWORD               {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| PATH                   {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| PERCENTILE_CONT        {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| PERCENTILE_DISC        {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| PERCENT_RANK           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| PLCSQL                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| PORT                   {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| PRINT                  {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| PRIORITY               {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| PRIVATE                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| PROMOTE                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| PROPERTIES             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| PUBLIC                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| QUARTER                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| QUEUES                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| RANGE_                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| RANK                   {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| REBUILD                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| REGEXP                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| REGEXP_COUNT           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| REGEXP_INSTR           {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| REGEXP_LIKE            {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| REGEXP_REPLACE         {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| REGEXP_SUBSTR          {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| REJECT_                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| REMOVE                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| REORGANIZE             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| REPEATABLE             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| RESPECT                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| RETAIN                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| REUSE_OID              {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| REVERSE                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| ROW_NUMBER             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| SECTIONS               {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| SEPARATOR              {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| SERIAL                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| SERVER                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| SESSION_TIMEZONE       {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| SHOW                   {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| SLOTS                  {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| SLOTTED                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| STABILITY              {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| START_                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| STATEMENT              {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| STATUS                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| STDDEV                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| STDDEV_POP             {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| STDDEV_SAMP            {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| STR_TO_DATE            {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| SUBDATE                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| SYNONYM                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| SYSTEM                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| TABLES                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| TEXT                   {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| THAN                   {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| THREADS                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| TIMEOUT                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| TIMEZONE               {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| TIMEZONES              {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| TRACE                  {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| TRAN                   {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| TRIGGERS               {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| TYPE                   {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| UCASE                  {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| UNCOMMITTED            {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| VARIANCE               {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| VAR_POP                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| VAR_SAMP               {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| VISIBLE                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| VOLUME                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| WEEK                   {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| WITHIN                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| WORKSPACE              {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }} 
 /*}}}*/
 	;
 
 escape_literal
 	: string_literal_or_input_hv
-		{{ DBG_TRACE_GRAMMAR(escape_literal, : string_literal_or_input_hv);
-
+		{{
 			PT_NODE *node = $1;
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| Null
-		{{ DBG_TRACE_GRAMMAR(escape_literal, | Null);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 			if (node)
 			  node->type_enum = PT_TYPE_NULL;
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 string_literal_or_input_hv
 	: char_string_literal
-		{{ DBG_TRACE_GRAMMAR(string_literal_or_input_hv, : char_string_literal);
-
+		{{
 			PT_NODE *node = $1;
 
 			pt_value_set_collation_info (this_parser, node, NULL);
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| host_param_input
-		{{ DBG_TRACE_GRAMMAR(string_literal_or_input_hv, | host_param_input);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
         ;
 
 
 char_string_literal
 	: char_string_literal CHAR_STRING
-		{{ DBG_TRACE_GRAMMAR(char_string_literal, : char_string_literal CHAR_STRING);
-
+		{{
 			PT_NODE *str = $1;
 			if (str)
 			  {
@@ -23298,25 +20793,22 @@ char_string_literal
 
 			$$ = str;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| char_string
-		{{ DBG_TRACE_GRAMMAR(char_string_literal, | char_string);
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 char_string
 	: CHAR_STRING
-		{{ DBG_TRACE_GRAMMAR(char_string, : CHAR_STRING);
+		{{
 			$$ = pt_create_string_literal_node_w_charset_coll($1, -1);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| NCHAR_STRING
-		{{ DBG_TRACE_GRAMMAR(char_string, | NCHAR_STRING);
+		{{
 			PT_NODE *node = NULL;
 			INTL_CODESET charset;
 			int collation_id;
@@ -23349,11 +20841,9 @@ char_string
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| BINARY_STRING
-		{{ DBG_TRACE_GRAMMAR(char_string, | BINARY_STRING);
-
+		{{
 			PT_NODE *node = NULL;
 
 			node = pt_create_char_string_literal (this_parser, PT_TYPE_CHAR,
@@ -23370,11 +20860,9 @@ char_string
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| EUCKR_STRING
-		{{ DBG_TRACE_GRAMMAR(char_string, | EUCKR_STRING);
-
+		{{
 			PT_NODE *node = NULL;
 
 			node = pt_create_char_string_literal (this_parser, PT_TYPE_CHAR,
@@ -23391,11 +20879,9 @@ char_string
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| ISO_STRING
-		{{ DBG_TRACE_GRAMMAR(char_string, | ISO_STRING);
-
+		{{
 			PT_NODE *node = NULL;
 
 			node = pt_create_char_string_literal (this_parser, PT_TYPE_CHAR,
@@ -23412,11 +20898,9 @@ char_string
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| UTF8_STRING
-		{{ DBG_TRACE_GRAMMAR(char_string, | UTF8_STRING);
-
+		{{
 			PT_NODE *node = NULL;
 
 			node = pt_create_char_string_literal (this_parser, PT_TYPE_CHAR,
@@ -23433,15 +20917,13 @@ char_string
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 
 bit_string_literal
 	: bit_string_literal CHAR_STRING
-		{{ DBG_TRACE_GRAMMAR(bit_string_literal, : bit_string_literal CHAR_STRING);
-
+		{{
 			PT_NODE *str = $1;
 			if (str)
 			  {
@@ -23454,21 +20936,17 @@ bit_string_literal
 
 			$$ = str;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| bit_string
-		{{ DBG_TRACE_GRAMMAR(bit_string_literal, | bit_string);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 bit_string
 	: BIT_STRING
-		{{ DBG_TRACE_GRAMMAR(bit_string, : BIT_STRING);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 
 			if (node)
@@ -23482,11 +20960,9 @@ bit_string
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| HEX_STRING
-		{{ DBG_TRACE_GRAMMAR(bit_string, | HEX_STRING);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_VALUE);
 
 			if (node)
@@ -23500,14 +20976,12 @@ bit_string
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 unsigned_integer
 	: UNSIGNED_INTEGER
-		{{ DBG_TRACE_GRAMMAR(unsigned_integer, : UNSIGNED_INTEGER);
-
+		{{
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 			if (val)
 			  {
@@ -23552,14 +21026,12 @@ unsigned_integer
 
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 unsigned_int32
 	: UNSIGNED_INTEGER
-		{{ DBG_TRACE_GRAMMAR(unsigned_int32, : UNSIGNED_INTEGER);
-
+		{{
 			PT_NODE *val;
 			int result = 0;
 			int int_val;
@@ -23579,14 +21051,12 @@ unsigned_int32
 			  }
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 unsigned_real
 	: UNSIGNED_REAL
-		{{ DBG_TRACE_GRAMMAR(unsigned_real, : UNSIGNED_REAL);
-
+		{{
 			double dval;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 			if (val)
@@ -23634,14 +21104,12 @@ unsigned_real
 
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 monetary_literal
 	: YEN_SIGN of_integer_real_literal
-		{{ DBG_TRACE_GRAMMAR(monetary_literal, : YEN_SIGN of_integer_real_literal);
-
+		{{
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 
@@ -23655,11 +21123,9 @@ monetary_literal
 
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| DOLLAR_SIGN of_integer_real_literal
-		{{ DBG_TRACE_GRAMMAR(monetary_literal, | DOLLAR_SIGN of_integer_real_literal);
-
+		{{
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 
@@ -23673,11 +21139,9 @@ monetary_literal
 
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| WON_SIGN of_integer_real_literal
-		{{ DBG_TRACE_GRAMMAR(monetary_literal, | WON_SIGN of_integer_real_literal);
-
+		{{
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 
@@ -23691,11 +21155,9 @@ monetary_literal
 
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| TURKISH_LIRA_SIGN of_integer_real_literal
-		{{ DBG_TRACE_GRAMMAR(monetary_literal, | TURKISH_LIRA_SIGN of_integer_real_literal);
-
+		{{
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 
@@ -23709,11 +21171,9 @@ monetary_literal
 
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| BRITISH_POUND_SIGN of_integer_real_literal
-		{{ DBG_TRACE_GRAMMAR(monetary_literal, | BRITISH_POUND_SIGN of_integer_real_literal);
-
+		{{
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 
@@ -23726,11 +21186,9 @@ monetary_literal
 			  }
 
 			$$ = val;
-
 		}}
 	| CAMBODIAN_RIEL_SIGN of_integer_real_literal
-		{{ DBG_TRACE_GRAMMAR(monetary_literal, | CAMBODIAN_RIEL_SIGN of_integer_real_literal);
-
+		{{
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 
@@ -23743,11 +21201,9 @@ monetary_literal
 			  }
 
 			$$ = val;
-
 		}}
 	| CHINESE_RENMINBI_SIGN of_integer_real_literal
-		{{ DBG_TRACE_GRAMMAR(monetary_literal, | CHINESE_RENMINBI_SIGN of_integer_real_literal);
-
+		{{
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 
@@ -23760,11 +21216,9 @@ monetary_literal
 			  }
 
 			$$ = val;
-
 		}}
 	| INDIAN_RUPEE_SIGN of_integer_real_literal
-		{{ DBG_TRACE_GRAMMAR(monetary_literal, | INDIAN_RUPEE_SIGN of_integer_real_literal);
-
+		{{
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 
@@ -23777,11 +21231,9 @@ monetary_literal
 			  }
 
 			$$ = val;
-
 		}}
 	| RUSSIAN_RUBLE_SIGN of_integer_real_literal
-		{{ DBG_TRACE_GRAMMAR(monetary_literal, | RUSSIAN_RUBLE_SIGN of_integer_real_literal);
-
+		{{
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 
@@ -23794,11 +21246,9 @@ monetary_literal
 			  }
 
 			$$ = val;
-
 		}}
 	| AUSTRALIAN_DOLLAR_SIGN of_integer_real_literal
-		{{ DBG_TRACE_GRAMMAR(monetary_literal, | AUSTRALIAN_DOLLAR_SIGN of_integer_real_literal);
-
+		{{
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 
@@ -23811,11 +21261,9 @@ monetary_literal
 			  }
 
 			$$ = val;
-
 		}}
 	| CANADIAN_DOLLAR_SIGN of_integer_real_literal
-		{{ DBG_TRACE_GRAMMAR(monetary_literal, | CANADIAN_DOLLAR_SIGN of_integer_real_literal);
-
+		{{
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 
@@ -23828,11 +21276,9 @@ monetary_literal
 			  }
 
 			$$ = val;
-
 		}}
 	| BRASILIAN_REAL_SIGN of_integer_real_literal
-		{{ DBG_TRACE_GRAMMAR(monetary_literal, | BRASILIAN_REAL_SIGN of_integer_real_literal);
-
+		{{
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 
@@ -23845,11 +21291,9 @@ monetary_literal
 			  }
 
 			$$ = val;
-
 		}}
 	| ROMANIAN_LEU_SIGN of_integer_real_literal
-		{{ DBG_TRACE_GRAMMAR(monetary_literal, | ROMANIAN_LEU_SIGN of_integer_real_literal);
-
+		{{
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 
@@ -23862,11 +21306,9 @@ monetary_literal
 			  }
 
 			$$ = val;
-
 		}}
 	| EURO_SIGN of_integer_real_literal
-		{{ DBG_TRACE_GRAMMAR(monetary_literal, | EURO_SIGN of_integer_real_literal);
-
+		{{
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 
@@ -23879,11 +21321,9 @@ monetary_literal
 			  }
 
 			$$ = val;
-
 		}}
 	| SWISS_FRANC_SIGN of_integer_real_literal
-		{{ DBG_TRACE_GRAMMAR(monetary_literal, | SWISS_FRANC_SIGN of_integer_real_literal);
-
+		{{
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 
@@ -23896,11 +21336,9 @@ monetary_literal
 			  }
 
 			$$ = val;
-
 		}}
 	| DANISH_KRONE_SIGN of_integer_real_literal
-		{{ DBG_TRACE_GRAMMAR(monetary_literal, | DANISH_KRONE_SIGN of_integer_real_literal);
-
+		{{
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 
@@ -23913,11 +21351,9 @@ monetary_literal
 			  }
 
 			$$ = val;
-
 		}}
 	| NORWEGIAN_KRONE_SIGN of_integer_real_literal
-		{{ DBG_TRACE_GRAMMAR(monetary_literal, | NORWEGIAN_KRONE_SIGN of_integer_real_literal);
-
+		{{
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 
@@ -23930,11 +21366,9 @@ monetary_literal
 			  }
 
 			$$ = val;
-
 		}}
 	| BULGARIAN_LEV_SIGN of_integer_real_literal
-		{{ DBG_TRACE_GRAMMAR(monetary_literal, | BULGARIAN_LEV_SIGN of_integer_real_literal);
-
+		{{
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 
@@ -23947,11 +21381,9 @@ monetary_literal
 			  }
 
 			$$ = val;
-
 		}}
 	| VIETNAMESE_DONG_SIGN of_integer_real_literal
-		{{ DBG_TRACE_GRAMMAR(monetary_literal, | VIETNAMESE_DONG_SIGN of_integer_real_literal);
-
+		{{
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 
@@ -23964,11 +21396,9 @@ monetary_literal
 			  }
 
 			$$ = val;
-
 		}}
 	| CZECH_KORUNA_SIGN of_integer_real_literal
-		{{ DBG_TRACE_GRAMMAR(monetary_literal, | CZECH_KORUNA_SIGN of_integer_real_literal);
-
+		{{
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 
@@ -23981,11 +21411,9 @@ monetary_literal
 			  }
 
 			$$ = val;
-
 		}}
 	| POLISH_ZLOTY_SIGN of_integer_real_literal
-		{{ DBG_TRACE_GRAMMAR(monetary_literal, | POLISH_ZLOTY_SIGN of_integer_real_literal);
-
+		{{
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 
@@ -23998,11 +21426,9 @@ monetary_literal
 			  }
 
 			$$ = val;
-
 		}}
 	| SWEDISH_KRONA_SIGN of_integer_real_literal
-		{{ DBG_TRACE_GRAMMAR(monetary_literal, | SWEDISH_KRONA_SIGN of_integer_real_literal);
-
+		{{
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 
@@ -24015,11 +21441,9 @@ monetary_literal
 			  }
 
 			$$ = val;
-
 		}}
 	| CROATIAN_KUNA_SIGN of_integer_real_literal
-		{{ DBG_TRACE_GRAMMAR(monetary_literal, | CROATIAN_KUNA_SIGN of_integer_real_literal);
-
+		{{
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 
@@ -24032,11 +21456,9 @@ monetary_literal
 			  }
 
 			$$ = val;
-
 		}}
 	| SERBIAN_DINAR_SIGN of_integer_real_literal
-		{{ DBG_TRACE_GRAMMAR(monetary_literal, | SERBIAN_DINAR_SIGN of_integer_real_literal);
-
+		{{
 			char *str, *txt;
 			PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 
@@ -24049,155 +21471,123 @@ monetary_literal
 			  }
 
 			$$ = val;
-
 		}}
 	;
 
 of_integer_real_literal
 	: integer_text
-		{{ DBG_TRACE_GRAMMAR(of_integer_real_literal, : integer_text);
-
+		{{
 			$$ = $1;
-
 		}}
 	| opt_plus UNSIGNED_REAL
-		{{ DBG_TRACE_GRAMMAR(of_integer_real_literal, | opt_plus UNSIGNED_REAL);
-
+		{{
 			$$ = $2;
-
 		}}
 	| '-' UNSIGNED_REAL
-		{{ DBG_TRACE_GRAMMAR(of_integer_real_literal, | '-' UNSIGNED_REAL);
-
+		{{
 			$$ = pt_append_string (this_parser, (char *) "-", $2);
-
 		}}
 	;
 
 date_or_time_literal
 	: Date CHAR_STRING
-		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, : Date CHAR_STRING);
-
+		{{
 			PT_NODE *val;
 			val = pt_create_date_value (this_parser, PT_TYPE_DATE, $2);
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| Time CHAR_STRING
-		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | Time CHAR_STRING);
-
+		{{
 			PT_NODE *val;
 			val = pt_create_date_value (this_parser, PT_TYPE_TIME, $2);
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| TIMESTAMP CHAR_STRING
-		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | TIMESTAMP CHAR_STRING);
-
+		{{
 			PT_NODE *val;
 			val = pt_create_date_value (this_parser, PT_TYPE_TIMESTAMP, $2);
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| TIMESTAMP WITH Time ZONE CHAR_STRING
-		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | TIMESTAMP WITH Time ZONE CHAR_STRING);
-
+		{{
 			PT_NODE *val;
 			val = pt_create_date_value (this_parser, PT_TYPE_TIMESTAMPTZ, $5);
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| TIMESTAMPTZ CHAR_STRING
-		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | TIMESTAMPTZ CHAR_STRING);
-
+		{{
 			PT_NODE *val;
 			val = pt_create_date_value (this_parser, PT_TYPE_TIMESTAMPTZ, $2);
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| TIMESTAMPLTZ CHAR_STRING
-		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | TIMESTAMPLTZ CHAR_STRING);
-
+		{{
 			PT_NODE *val;
 			val = pt_create_date_value (this_parser, PT_TYPE_TIMESTAMPLTZ, $2);
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| TIMESTAMP WITH LOCAL Time ZONE CHAR_STRING
-		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | TIMESTAMP WITH LOCAL Time ZONE CHAR_STRING);
-
+		{{
 			PT_NODE *val;
 			val = pt_create_date_value (this_parser, PT_TYPE_TIMESTAMPLTZ, $6);
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| DATETIME CHAR_STRING
-		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | DATETIME CHAR_STRING);
-
+		{{
 			PT_NODE *val;
 			val = pt_create_date_value (this_parser, PT_TYPE_DATETIME, $2);
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| DATETIME WITH Time ZONE CHAR_STRING
-		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | DATETIME WITH Time ZONE CHAR_STRING);
-
+		{{
 			PT_NODE *val;
 			val = pt_create_date_value (this_parser, PT_TYPE_DATETIMETZ, $5);
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| DATETIMETZ CHAR_STRING
-		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | DATETIMETZ CHAR_STRING);
-
+		{{
 			PT_NODE *val;
 			val = pt_create_date_value (this_parser, PT_TYPE_DATETIMETZ, $2);
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| DATETIMELTZ CHAR_STRING
-		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | DATETIMELTZ CHAR_STRING);
-
+		{{
 			PT_NODE *val;
 			val = pt_create_date_value (this_parser, PT_TYPE_DATETIMELTZ, $2);
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| DATETIME WITH LOCAL Time ZONE CHAR_STRING
-		{{ DBG_TRACE_GRAMMAR(date_or_time_literal, | DATETIME WITH LOCAL Time ZONE CHAR_STRING);
-
+		{{
 			PT_NODE *val;
 			val = pt_create_date_value (this_parser, PT_TYPE_DATETIMELTZ, $6);
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 json_literal
         : JSON CHAR_STRING
-                {{ DBG_TRACE_GRAMMAR(json_literal,  : JSON CHAR_STRING);
+                {{
                 	PT_NODE *val;
 			val = pt_create_json_value (this_parser, $2);
 			$$ = val;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
                 }}
 
 create_as_clause
 	: opt_replace AS csql_query
-		{{ DBG_TRACE_GRAMMAR(create_as_clause, : opt_replace AS csql_query);
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2(ctn, FROM_NUMBER ($1), $3);
 			$$ = ctn;
@@ -24206,8 +21596,7 @@ create_as_clause
 
 partition_clause
 	: PARTITION opt_by HASH '(' expression_ ')' PARTITIONS literal_w_o_param
-		{{ DBG_TRACE_GRAMMAR(partition_clause, : PARTITION opt_by HASH '(' expression_ ')' PARTITIONS literal_w_o_param);
-
+		{{
 			PT_NODE *qc = parser_new_node (this_parser, PT_PARTITION);
 			if (qc)
 			  {
@@ -24217,11 +21606,9 @@ partition_clause
 			  }
 
 			$$ = qc;
-
 		}}
 	| PARTITION opt_by RANGE_ '(' expression_ ')' '(' partition_def_list ')'
-		{{ DBG_TRACE_GRAMMAR(partition_clause, | PARTITION opt_by RANGE_ '(' expression_ ')' '(' partition_def_list ')');
-
+		{{
 			PT_NODE *qc = parser_new_node (this_parser, PT_PARTITION);
 			if (qc)
 			  {
@@ -24233,11 +21620,9 @@ partition_clause
 
 			$$ = qc;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| PARTITION opt_by LIST '(' expression_ ')' '(' partition_def_list ')'
-		{{ DBG_TRACE_GRAMMAR(partition_clause, | PARTITION opt_by LIST '(' expression_ ')' '(' partition_def_list ')');
-
+		{{
 			PT_NODE *qc = parser_new_node (this_parser, PT_PARTITION);
 			if (qc)
 			  {
@@ -24249,7 +21634,6 @@ partition_clause
 
 			$$ = qc;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
@@ -24260,25 +21644,20 @@ opt_by
 
 partition_def_list
 	: partition_def_list ',' partition_def
-		{{ DBG_TRACE_GRAMMAR(partition_def_list, : partition_def_list ',' partition_def);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| partition_def
-		{{ DBG_TRACE_GRAMMAR(partition_def_list, | partition_def);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 partition_def
 	: PARTITION identifier VALUES LESS THAN MAXVALUE opt_comment_spec
-		{{ DBG_TRACE_GRAMMAR(partition_def, : PARTITION identifier VALUES LESS THAN MAXVALUE opt_comment_spec);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_PARTS);
 			if (node)
 			  {
@@ -24290,11 +21669,9 @@ partition_def
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| PARTITION identifier VALUES LESS THAN '(' signed_literal_ ')' opt_comment_spec
-		{{ DBG_TRACE_GRAMMAR(partition_def, | PARTITION identifier VALUES LESS THAN '(' signed_literal_ ')' opt_comment_spec);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_PARTS);
 			if (node)
 			  {
@@ -24306,11 +21683,9 @@ partition_def
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| PARTITION identifier VALUES IN_ '(' signed_literal_list ')' opt_comment_spec
-		{{ DBG_TRACE_GRAMMAR(partition_def, | PARTITION identifier VALUES IN_ '(' signed_literal_list ')' opt_comment_spec);
-
+		{{
 			PT_NODE *node = parser_new_node (this_parser, PT_PARTS);
 			if (node)
 			  {
@@ -24322,14 +21697,12 @@ partition_def
 
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 alter_partition_clause_for_alter_list
 	: partition_clause
-		{{ DBG_TRACE_GRAMMAR(alter_partition_clause_for_alter_list, : partition_clause);
-
+		{{
 			PT_NODE *alt = parser_get_alter_node ();
 
 			if (alt)
@@ -24337,20 +21710,16 @@ alter_partition_clause_for_alter_list
 			    alt->info.alter.code = PT_APPLY_PARTITION;
 			    alt->info.alter.alter_clause.partition.info = $1;
 			  }
-
 		}}
 	| REMOVE PARTITIONING
-		{{ DBG_TRACE_GRAMMAR(alter_partition_clause_for_alter_list, | REMOVE PARTITIONING);
-
+		{{
 			PT_NODE *alt = parser_get_alter_node ();
 
 			if (alt)
 			  alt->info.alter.code = PT_REMOVE_PARTITION;
-
 		}}
 	| REORGANIZE PARTITION identifier_list INTO '(' partition_def_list ')'
-		{{ DBG_TRACE_GRAMMAR(alter_partition_clause_for_alter_list, | REORGANIZE PARTITION identifier_list INTO '(' partition_def_list ')');
-
+		{{
 			PT_NODE *alt = parser_get_alter_node ();
 
 			if (alt)
@@ -24359,11 +21728,9 @@ alter_partition_clause_for_alter_list
 			    alt->info.alter.alter_clause.partition.name_list = $3;
 			    alt->info.alter.alter_clause.partition.parts = $6;
 			  }
-
 		}}
 	| ANALYZE PARTITION opt_all
-		{{ DBG_TRACE_GRAMMAR(alter_partition_clause_for_alter_list, | ANALYZE PARTITION opt_all);
-
+		{{
 			PT_NODE *alt = parser_get_alter_node ();
 
 			if (alt)
@@ -24371,11 +21738,9 @@ alter_partition_clause_for_alter_list
 			    alt->info.alter.code = PT_ANALYZE_PARTITION;
 			    alt->info.alter.alter_clause.partition.name_list = NULL;
 			  }
-
 		}}
 	| ANALYZE PARTITION identifier_list
-		{{ DBG_TRACE_GRAMMAR(alter_partition_clause_for_alter_list, | ANALYZE PARTITION identifier_list);
-
+		{{
 			PT_NODE *alt = parser_get_alter_node ();
 
 			if (alt)
@@ -24383,11 +21748,9 @@ alter_partition_clause_for_alter_list
 			    alt->info.alter.code = PT_ANALYZE_PARTITION;
 			    alt->info.alter.alter_clause.partition.name_list = $3;
 			  }
-
 		}}
 	| COALESCE PARTITION literal_w_o_param
-		{{ DBG_TRACE_GRAMMAR(alter_partition_clause_for_alter_list, | COALESCE PARTITION literal_w_o_param);
-
+		{{
 			PT_NODE *alt = parser_get_alter_node ();
 
 			if (alt)
@@ -24395,11 +21758,9 @@ alter_partition_clause_for_alter_list
 			    alt->info.alter.code = PT_COALESCE_PARTITION;
 			    alt->info.alter.alter_clause.partition.size = $3;
 			  }
-
 		}}
 	 | PROMOTE PARTITION identifier_list
-		{{ DBG_TRACE_GRAMMAR(alter_partition_clause_for_alter_list, | PROMOTE PARTITION identifier_list);
-
+		{{
 			PT_NODE *alt = parser_get_alter_node ();
 
 			if (alt)
@@ -24407,7 +21768,6 @@ alter_partition_clause_for_alter_list
 			    alt->info.alter.code = PT_PROMOTE_PARTITION;
 			    alt->info.alter.alter_clause.partition.name_list = $3;
 			  }
-
 		}}
 	;
 
@@ -24418,49 +21778,37 @@ opt_all
 
 execute_using_list
 	: execute_using_list ',' session_variable_expression
-		{{ DBG_TRACE_GRAMMAR(execute_using_list, : execute_using_list ',' session_variable_expression);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| execute_using_list ',' signed_literal_
-		{{ DBG_TRACE_GRAMMAR(execute_using_list, | execute_using_list ',' signed_literal_);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| session_variable_expression
-		{{ DBG_TRACE_GRAMMAR(execute_using_list, | session_variable_expression);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| signed_literal_
-		{{ DBG_TRACE_GRAMMAR(execute_using_list, | signed_literal_);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
 signed_literal_list
 	: signed_literal_list ',' signed_literal_
-		{{ DBG_TRACE_GRAMMAR(signed_literal_list, : signed_literal_list ',' signed_literal_);
-
+		{{
 			$$ = parser_make_link ($1, $3);
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	| signed_literal_
-		{{ DBG_TRACE_GRAMMAR(signed_literal_list, | signed_literal_);
-
+		{{
 			$$ = $1;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
 		}}
 	;
 
@@ -24474,7 +21822,7 @@ paren_minus
 
 vacuum_stmt
 	: VACUUM
-		{{ DBG_TRACE_GRAMMAR(vacuum_stmt, : VACUUM);
+		{{
 			PT_NODE *node =
 			  parser_new_node (this_parser, PT_VACUUM);
 			if (node == NULL)
@@ -24489,17 +21837,17 @@ vacuum_stmt
 
 json_table_column_behavior_rule
     : Null
-      {{ DBG_TRACE_GRAMMAR(json_table_column_behavior_rule, : Null);
+      {{
         $$.m_behavior = JSON_TABLE_RETURN_NULL;
         $$.m_default_value = NULL;
       }}
     | ERROR_
-      {{ DBG_TRACE_GRAMMAR(json_table_column_behavior_rule, | ERROR_);
+      {{
         $$.m_behavior = JSON_TABLE_THROW_ERROR;
         $$.m_default_value = NULL;
       }}
     | DEFAULT expression_
-      {{ DBG_TRACE_GRAMMAR(json_table_column_behavior_rule, | DEFAULT expression_);
+      {{
         PT_NODE * default_value = $2;
         if (default_value->node_type != PT_VALUE)
           {
@@ -24515,31 +21863,31 @@ json_table_column_behavior_rule
 
 json_table_on_error_rule_optional
     : /* empty */
-      {{ DBG_TRACE_GRAMMAR(json_table_on_error_rule_optional, : );
+      {{
         $$.m_behavior = JSON_TABLE_RETURN_NULL;
         $$.m_default_value = NULL;
       }}
     | json_table_column_behavior_rule ON_ ERROR_
-      {{ DBG_TRACE_GRAMMAR(json_table_on_error_rule_optional, | json_table_column_behavior_rule ON_ ERROR_);
+      {{
         $$ = $1;
       }}
     ;
 
 json_table_on_empty_rule_optional
     : /* empty */
-      {{ DBG_TRACE_GRAMMAR(json_table_on_empty_rule_optional, : );
+      {{
         $$.m_behavior = JSON_TABLE_RETURN_NULL;
         $$.m_default_value = NULL;
       }}
     | json_table_column_behavior_rule ON_ EMPTY
-      {{ DBG_TRACE_GRAMMAR(json_table_on_empty_rule_optional, | json_table_column_behavior_rule ON_ EMPTY );
+      {{
         $$ = $1;
       }}
     ;
 
 json_table_column_rule
     : identifier For ORDINALITY
-      {{ DBG_TRACE_GRAMMAR(json_table_column_rule, : identifier For ORDINALITY );
+      {{
         PT_NODE *pt_col = parser_new_node (this_parser, PT_JSON_TABLE_COLUMN);
         pt_col->info.json_table_column_info.name = $1;
         pt_col->info.json_table_column_info.func = JSON_TABLE_ORDINALITY;
@@ -24548,7 +21896,7 @@ json_table_column_rule
       }}
     | identifier data_type PATH CHAR_STRING json_table_on_empty_rule_optional json_table_on_error_rule_optional
     //        $1        $2   $3          $4                                $5                                $6
-      {{ DBG_TRACE_GRAMMAR(json_table_column_rule, | identifier data_type PATH CHAR_STRING json_table_on_empty_rule_optional json_table_on_error_rule_optional );
+      {{
         PT_NODE *pt_col = parser_new_node (this_parser, PT_JSON_TABLE_COLUMN);
         pt_col->info.json_table_column_info.name = $1;
         pt_col->type_enum = TO_NUMBER (CONTAINER_AT_0 ($2));
@@ -24560,7 +21908,7 @@ json_table_column_rule
         $$ = pt_col;
       }}
     | identifier data_type EXISTS PATH CHAR_STRING
-      {{ DBG_TRACE_GRAMMAR(json_table_column_rule, | identifier data_type EXISTS PATH CHAR_STRING );
+      {{
         PT_NODE *pt_col = parser_new_node (this_parser, PT_JSON_TABLE_COLUMN);
         pt_col->info.json_table_column_info.name = $1;
         pt_col->type_enum = TO_NUMBER (CONTAINER_AT_0 ($2));
@@ -24570,23 +21918,23 @@ json_table_column_rule
         $$ = pt_col;
       }}
     | NESTED json_table_node_rule
-      {{ DBG_TRACE_GRAMMAR(json_table_column_rule, | NESTED json_table_node_rule );
+      {{
         $$ = $2;
       }}
     | NESTED PATH json_table_node_rule
-      {{ DBG_TRACE_GRAMMAR(json_table_column_rule, | NESTED PATH json_table_node_rule );
+      {{
         $$ = $3;
       }}
     ;
 
 json_table_column_list_rule
     : json_table_column_list_rule ',' json_table_column_rule
-      {{ DBG_TRACE_GRAMMAR(json_table_column_list_rule,  : json_table_column_list_rule ',' json_table_column_rule );
+      {{
         pt_jt_append_column_or_nested_node ($1, $3);
         $$ = $1;
       }}
     | json_table_column_rule
-      {{ DBG_TRACE_GRAMMAR(json_table_column_list_rule, | json_table_column_rule );
+      {{
         PT_NODE *pt_jt_node = parser_new_node (this_parser, PT_JSON_TABLE_NODE);
         pt_jt_append_column_or_nested_node (pt_jt_node, $1);
         $$ = pt_jt_node;
@@ -24595,7 +21943,7 @@ json_table_column_list_rule
 
 json_table_node_rule
     : CHAR_STRING COLUMNS '(' json_table_column_list_rule ')'
-      {{ DBG_TRACE_GRAMMAR(json_table_node_rule,  : CHAR_STRING COLUMNS '(' json_table_column_list_rule ')' );
+      {{
         PT_NODE *jt_node = $4;
         assert (jt_node != NULL);
         assert (jt_node->node_type == PT_JSON_TABLE_NODE);
@@ -24607,11 +21955,11 @@ json_table_node_rule
     ;
 
 json_table_rule
-    : {{ DBG_TRACE_GRAMMAR(json_table_rule,  : );
+    : {{
             json_table_column_count = 0;
       }}
       '(' expression_ ',' json_table_node_rule ')'
-      {{ DBG_TRACE_GRAMMAR(json_table_rule,  '(' expression_ ',' json_table_node_rule ')' );
+      {{
         PT_NODE *jt = parser_new_node (this_parser, PT_JSON_TABLE);
         jt->info.json_table_info.expr = $3;
         jt->info.json_table_info.tree = $5;
@@ -24623,14 +21971,14 @@ json_table_rule
 
 connect_info
         : connect_info ',' connect_item
-          {{ DBG_TRACE_GRAMMAR(connect_info, : connect_info ',' connect_item );
+          {{
                container_10 ctn = $1;
 
                pt_fill_conn_info_container(this_parser, @$.buffer_pos, &ctn, $3);
 	        $$ = ctn;
            }}
         | connect_item
-          {{ DBG_TRACE_GRAMMAR(connect_info, | connect_item );
+          {{
                 container_10 ctn;
                 memset(&ctn, 0x00, sizeof(container_10));
 
@@ -24641,7 +21989,7 @@ connect_info
 
 connect_item    
         :  HOST '=' CHAR_STRING 
-          {{ DBG_TRACE_GRAMMAR(connect_item,  :  HOST '=' CHAR_STRING  );
+          {{
                 container_2 ctn;
                 PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
                 if (val)
@@ -24659,7 +22007,7 @@ connect_item
                 $$ = ctn;
             }}
         | PORT '=' UNSIGNED_INTEGER 
-          {{ DBG_TRACE_GRAMMAR(connect_item, | PORT '=' UNSIGNED_INTEGER );
+          {{
                 container_2 ctn;
                 PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
                 if (val)
@@ -24677,7 +22025,7 @@ connect_item
                 $$ = ctn;
            }}
          | DBNAME '=' char_string_literal 
-          {{ DBG_TRACE_GRAMMAR(connect_item,  | DBNAME '=' char_string_literal  );
+          {{
                container_2 ctn;
                PT_NODE *val = $3;
                val->type_enum = PT_TYPE_VARCHAR;
@@ -24690,13 +22038,13 @@ connect_item
                 $$ = ctn;
            }}            
         | DBNAME '=' identifier 
-          {{ DBG_TRACE_GRAMMAR(connect_item,  | DBNAME '=' identifier  );
+          {{
                 container_2 ctn;
                 SET_CONTAINER_2(ctn, FROM_NUMBER(CONN_INFO_DBNAME), $3);
                 $$ = ctn;
            }}
         | USER '=' char_string_literal 
-          {{ DBG_TRACE_GRAMMAR(connect_item,  | USER '=' char_string_literal);
+          {{
                container_2 ctn;
                PT_NODE *val = $3;
                val->type_enum = PT_TYPE_VARCHAR;
@@ -24710,14 +22058,14 @@ connect_item
                PARSER_SAVE_ERR_CONTEXT ($3, @$.buffer_pos)
            }}            
         | USER '=' identifier
-          {{ DBG_TRACE_GRAMMAR(connect_item, | USER '=' identifier);
+          {{
                 container_2 ctn;
                 SET_CONTAINER_2(ctn, FROM_NUMBER(CONN_INFO_USER), $3);
                 $$ = ctn;
                 PARSER_SAVE_ERR_CONTEXT ($3, @$.buffer_pos)
             }}
         | PASSWORD '=' 
-          {{ DBG_TRACE_GRAMMAR(connect_item,   | PASSWORD '='  );
+          {{
                container_2 ctn;
 
                pwd_info.pwd_start_offset = (@$.buffer_pos);
@@ -24748,7 +22096,7 @@ connect_item
                 pwd_info.pwd_start_offset = (@$.buffer_pos);
           }
           CHAR_STRING
-          {{ DBG_TRACE_GRAMMAR(connect_item, | PASSWORD '=' CHAR_STRING );
+          {{
                 container_2 ctn;
                 
                 pwd_info.pwd_end_offset = (@$.buffer_pos);
@@ -24773,13 +22121,13 @@ connect_item
                 $$ = ctn;
            }}
         | PROPERTIES '=' 
-          {{ DBG_TRACE_GRAMMAR(connect_item, | PROPERTIES '=' );
+          {{
                 container_2 ctn;
                 SET_CONTAINER_2(ctn, FROM_NUMBER(CONN_INFO_PROPERTIES), NULL);
                 $$ = ctn;
            }}
         | PROPERTIES '=' CHAR_STRING 
-          {{ DBG_TRACE_GRAMMAR(connect_item,  | PROPERTIES '=' CHAR_STRING );
+          {{
                 container_2 ctn;
                 PT_NODE *val = parser_new_node (this_parser, PT_VALUE);
 	        if (val)                    
@@ -24800,13 +22148,13 @@ connect_item
                 $$ = ctn;
            }}
         | COMMENT '='
-          {{ DBG_TRACE_GRAMMAR(connect_item,| COMMENT '=');
+          {{
                 container_2 ctn;
                 SET_CONTAINER_2(ctn, FROM_NUMBER(CONN_INFO_COMMENT), NULL);
                 $$ = ctn;
            }}
         | COMMENT '=' char_string_literal
-          {{ DBG_TRACE_GRAMMAR(connect_item, | COMMENT '=' char_string );
+          {{
                 container_2 ctn;
                 PT_NODE *val = $3;
                 $3->type_enum = PT_TYPE_VARCHAR;
@@ -24822,14 +22170,14 @@ connect_item
 
 alter_server_list
         : alter_server_list ',' alter_server_item
-          {{ DBG_TRACE_GRAMMAR(alter_server_list, : alter_server_list ',' alter_server_item);
+          {{
                container_10 ctn = $1;
 
                pt_fill_conn_info_container(this_parser, @$.buffer_pos, &ctn, $3);
 	        $$ = ctn;
            }}
         | alter_server_item
-          {{ DBG_TRACE_GRAMMAR(alter_server_list, | alter_server_item);
+          {{
                 container_10 ctn;
                 memset(&ctn, 0x00, sizeof(container_10));
 
@@ -24840,21 +22188,21 @@ alter_server_list
 
 alter_server_item
         : OWNER TO identifier
-          {{ DBG_TRACE_GRAMMAR(alter_server_item, : OWNER TO identifier);
+          {{
                 container_2 ctn;                 
 
                 SET_CONTAINER_2(ctn, FROM_NUMBER(CONN_INFO_OWNER), $3);
                 $$ = ctn;
           }}
         | CHANGE connect_item
-          {{ DBG_TRACE_GRAMMAR(alter_server_item, | CHANGE connect_item); 
+          {{
 	        $$ = $2;
            }}
         ;
 
 dblink_server_name
 	: identifier DOT server_identifier
-          {{ DBG_TRACE_GRAMMAR(dblink_server_name, : identifier DOT server_identifier);
+          {{
              if($3)
                {
                   $3->next = $1;                  
@@ -24867,14 +22215,14 @@ dblink_server_name
               PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
           }}
         | server_identifier
-          {{ DBG_TRACE_GRAMMAR(dblink_server_name, | server_identifier);
+          {{
               $$ = $1;
           }}
         ;
 
 server_identifier
         : identifier
-            {{ DBG_TRACE_GRAMMAR(server_identifier, : identifier);
+            {{
                 if ($1)
                   {                
                      if (strchr($1->info.name.original, '.')) 
@@ -24892,7 +22240,7 @@ dblink_expr
                 is_dblink_query_string = 1;
             }
          CHAR_STRING  
-            {{ DBG_TRACE_GRAMMAR(dblink_expr, : dblink_conn  ','  CHAR_STRING);
+            {{
              is_dblink_query_string = 0;
              PT_NODE *ct = parser_new_node(this_parser, PT_DBLINK_TABLE) ;           
              if(ct)
@@ -24948,18 +22296,18 @@ dblink_expr
 
 dblink_conn:
         dblink_server_name      
-        {{ DBG_TRACE_GRAMMAR(dblink_conn, : dblink_server_name); 
+        {{
                 $$ = $1;                
                 }}
         | dblink_conn_str
-        {{ DBG_TRACE_GRAMMAR(dblink_conn, | dblink_conn_str);
+        {{
                 $$ = $1;
 		}}
         ;   
 
 dblink_conn_str:
         CHAR_STRING
-        {{ DBG_TRACE_GRAMMAR(dblink_conn_str, : CHAR_STRING);
+        {{
                 char *zInfo[DBLINK_CONN_PARAM_CNT];     
                 char err_msg[512]; 
                 PT_NODE *node_list = NULL;
@@ -25019,7 +22367,7 @@ dblink_conn_str:
 
 dblink_identifier_col_attrs  
         :  opt_as identifier '('  dblink_column_definition_list ')' 
-        {{ DBG_TRACE_GRAMMAR(dblink_identifier_col_attrs,  :  opt_as identifier '('  dblink_column_definition_list ')' );
+        {{
              container_2 ctn;
              
 	     SET_CONTAINER_2 (ctn, $2, $4);
@@ -25029,12 +22377,12 @@ dblink_identifier_col_attrs
 
 dblink_column_definition_list
         :  dblink_column_definition_list ','  dblink_column_definition
-           {{ DBG_TRACE_GRAMMAR(dblink_column_definition_list, :  dblink_column_definition_list ','  dblink_column_definition );  
+           {{
                 $$ = parser_make_link($1, $3);
 	        PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos);
                 }}
         | dblink_column_definition
-           {{ DBG_TRACE_GRAMMAR(dblink_column_definition_list, | dblink_column_definition );
+           {{
                $$ = $1;
                PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
              }}
@@ -25042,7 +22390,7 @@ dblink_column_definition_list
 
 dblink_column_definition
         : identifier primitive_type
-        {{ DBG_TRACE_GRAMMAR(dblink_column_definition,  : identifier primitive_type );
+        {{
                 PT_NODE *node;              
 
                 node = parser_new_node (this_parser, PT_ATTR_DEF);
@@ -25070,28 +22418,21 @@ dblink_column_definition
 
                 $$ = node;
 		PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
-
         }}
         ;
 
 opt_access_modifier
     : /*empty*/
-      {{ DBG_TRACE_GRAMMAR(opt_access_modifier, : );
-
+      {{
 	$$ = PT_PRIVATE;
-
       }}
     | PRIVATE
-      {{ DBG_TRACE_GRAMMAR(opt_access_modifier, | PRIVATE);
-
+      {{
 	$$ = PT_PRIVATE;
-
       }}
     | PUBLIC
-      {{ DBG_TRACE_GRAMMAR(opt_access_modifier, | PUBLIC);
-
+      {{
 	$$ = PT_PUBLIC;
-
       }}
     ;
 
@@ -25106,67 +22447,51 @@ opt_access_modifier
  */
 opt_create_synonym
 	: /*empty*/
-		{{ DBG_TRACE_GRAMMAR(opt_create_synonym, : );
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (0), FROM_NUMBER (PT_PRIVATE));
 			$$ = ctn;
-
 		}}
 	| PRIVATE
-		{{ DBG_TRACE_GRAMMAR(opt_create_synonym, : PRIVATE);
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (0), FROM_NUMBER (PT_PRIVATE));
 			$$ = ctn;
-
 		}}
 	| PUBLIC
-		{{ DBG_TRACE_GRAMMAR(opt_create_synonym, : PUBLIC);
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (0), FROM_NUMBER (PT_PUBLIC));
 			$$ = ctn;
-
 		}}
 	| OR REPLACE
-		{{ DBG_TRACE_GRAMMAR(opt_create_synonym, : OR REPLACE);
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (1), FROM_NUMBER (PT_PRIVATE));
 			$$ = ctn;
-
 		}}
 	| OR REPLACE PRIVATE
-		{{ DBG_TRACE_GRAMMAR(opt_create_synonym, : OR REPLACE PRIVATE);
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (1), FROM_NUMBER (PT_PRIVATE));
 			$$ = ctn;
-
 		}}
 	| OR REPLACE PUBLIC
-		{{ DBG_TRACE_GRAMMAR(opt_create_synonym, : OR REPLACE PUBLIC);
-
+		{{
 			container_2 ctn;
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (1), FROM_NUMBER (PT_PUBLIC));
 			$$ = ctn;
-
 		}}
 	;
 
 opt_alter_synonym
 	: /*empty*/
-		{{ DBG_TRACE_GRAMMAR(opt_alter_synonym, : );
-
+		{{
 			$$ = NULL;
-
 		}}
 	| For class_name_for_synonym
-		{{ DBG_TRACE_GRAMMAR(opt_alter_syonnym, : For class_name_for_synonym);
-
+		{{
 			$$ = $2;
-
 		}}
 
 %%

--- a/src/parser/csql_lexer.l
+++ b/src/parser/csql_lexer.l
@@ -1262,7 +1262,6 @@ _[uU][tT][fF]8[']		{
 "."[ \t\r\n]*([a-zA-Z_#]|([\xc0-\xfe]))([a-zA-Z_#0-9]|([\x80-\xfe]))* {
 							    yybuffer_pos -= (csql_yyleng - 1);
 							    yyless(1);
-                                                            DBG_PRINT_TOKEN(yytext);
                                                             BEGIN(POST_DOT_OR_RIGHT_ARROW_STRING);
 							    return DOT;
 							}
@@ -1270,7 +1269,6 @@ _[uU][tT][fF]8[']		{
 "->"[ \t\r\n]*([a-zA-Z_#]|([\xc0-\xfe]))([a-zA-Z_#0-9]|([\x80-\xfe]))* {
                                                            yybuffer_pos -= (csql_yyleng - 2);
 							   yyless(2);
-                                                           DBG_PRINT_TOKEN(yytext);
                                                            BEGIN(POST_DOT_OR_RIGHT_ARROW_STRING);
 							   return RIGHT_ARROW;
 							}
@@ -1314,13 +1312,11 @@ _[uU][tT][fF]8[']		{
 
 0b[0-1]+			{
 					csql_yylval.cptr = pt_append_string(this_parser, NULL, yytext + 2);
-                                        DBG_PRINT_TOKEN(yytext);
 					return BIT_STRING;
 				}
 
 0x[0-9a-fA-F]+			{
 					csql_yylval.cptr = pt_append_string(this_parser, NULL, yytext + 2);                                        
-                                        DBG_PRINT_TOKEN(yytext);
 					return HEX_STRING;
 				}
 
@@ -1368,43 +1364,36 @@ _[uU][tT][fF]8[']		{
 
 <QUOTED_EUCKR_STRING>[']	{
 					BEGIN(INITIAL);
-                                        DBG_PRINT_STRING("_euckr'", csql_yylval.cptr, "'");
 					return EUCKR_STRING;
 				}
 
 <QUOTED_ISO_STRING>[']		{
 					BEGIN(INITIAL);
-                                        DBG_PRINT_STRING("_iso88591'", csql_yylval.cptr, "'");
 					return ISO_STRING;
 				}
 
 <QUOTED_BINARY_STRING>[']	{
 					BEGIN(INITIAL);
-                                        DBG_PRINT_STRING("_binary'", csql_yylval.cptr, "'");
 					return BINARY_STRING;
 				}
 
 <QUOTED_UTF8_STRING>[']		{
 					BEGIN(INITIAL);
-                                        DBG_PRINT_STRING("_utf8'", csql_yylval.cptr, "'");
 					return UTF8_STRING;
 				}
 
 <QUOTED_NCHAR_STRING>[']	{
 					BEGIN(INITIAL);
-                                        DBG_PRINT_STRING("n'", csql_yylval.cptr, "'");
 					return NCHAR_STRING;
 				}
 
 <QUOTED_BIT_STRING>[']		{
 					BEGIN(INITIAL);
-                                        DBG_PRINT_STRING("b'", csql_yylval.cptr, "'");
 					return BIT_STRING;
 				}
 
 <QUOTED_HEX_STRING>[']		{
 					BEGIN(INITIAL);
-                                        DBG_PRINT_STRING("x'", csql_yylval.cptr, "'");
 					return HEX_STRING;
 				}
 
@@ -1415,13 +1404,11 @@ _[uU][tT][fF]8[']		{
                                         } else {
                                                 BEGIN(INITIAL);
                                         }
-                                        DBG_PRINT_STRING("'", csql_yylval.cptr, "'");
 					return CHAR_STRING;
 				}
 
 <DOUBLY_QUOTED_CHAR_STRING>["]	{
 					BEGIN(INITIAL);
-                                        DBG_PRINT_STRING("\"", csql_yylval.cptr, "\"");
 					return CHAR_STRING;
 				}
 
@@ -1432,7 +1419,6 @@ _[uU][tT][fF]8[']		{
                                         } else {
                                                 BEGIN(INITIAL);
                                         }
-                                        DBG_PRINT_STRING("\"", csql_yylval.cptr, "\"");
 					if (strlen(csql_yylval.cptr) >= 254)
 					  {
 					    csql_yylval.cptr[254] = 0;
@@ -1447,7 +1433,6 @@ _[uU][tT][fF]8[']		{
                                         } else {
                                                 BEGIN(INITIAL);
                                         }
-                                        DBG_PRINT_STRING("[", csql_yylval.cptr, "]");
 					if (strlen(csql_yylval.cptr) >= 254)
 					  {
 					    csql_yylval.cptr[254] = 0;
@@ -1462,7 +1447,6 @@ _[uU][tT][fF]8[']		{
                                         } else {
                                                 BEGIN(INITIAL);
                                         }
-                                        DBG_PRINT_STRING("`", csql_yylval.cptr, "`");
 					if (strlen(csql_yylval.cptr) >= 254)
 					  {
 					    csql_yylval.cptr[254] = 0;
@@ -1479,7 +1463,6 @@ _[uU][tT][fF]8[']		{
 <QUOTED_NCHAR_STRING,QUOTED_BIT_STRING,QUOTED_HEX_STRING,QUOTED_CHAR_STRING,DOUBLY_QUOTED_CHAR_STRING,QUOTED_EUCKR_STRING,QUOTED_ISO_STRING,QUOTED_BINARY_STRING,QUOTED_UTF8_STRING><<EOF>>	{
                                         from_plcsql_text = 0;
 					BEGIN(INITIAL);
-                                        DBG_PRINT_STRING("?", csql_yylval.cptr, "<EOF>");
 					csql_yyerror("unterminated string");
 					return UNTERMINATED_STRING;
 				}
@@ -1487,7 +1470,6 @@ _[uU][tT][fF]8[']		{
 <DELIMITED_ID_NAME,BRACKET_ID_NAME,BACKTICK_ID_NAME><<EOF>>	{
                                         from_plcsql_text = 0;
 					BEGIN(INITIAL);
-                                        DBG_PRINT_STRING("?", csql_yylval.cptr, "<EOF>");
 					csql_yyerror("unterminated identifier");
 					return UNTERMINATED_IDENTIFIER;
 				}
@@ -2346,5 +2328,4 @@ begin_token (char *token)
   csql_yylloc.first_column = yycolumn;
   csql_yylloc.last_line = yylineno;
   csql_yylloc.last_column = yycolumn_end;
-  DBG_PRINT_TOKEN(token);
 }


### PR DESCRIPTION
[<http://jira.cubrid.org/browse/CBRD-26491>
](http://jira.cubrid.org/browse/CBRD-26491)

### Purpose
Bison의 공식 문서( https://www.gnu.org/software/bison/manual/html_node/Enabling-Traces.html) 에 debugging 할 수 있는 방법이 명시되어 있습니다. 기존에 있던 자체적인 debugging 코드를 제거(모든 rule마다 디버깅 코드가 추가되어있음)하고 이를 사용하도록 수정합니다.

기존에는 CUBRID에서 Bison을 debugging 하기 위해 두 가지 방법을 사용했습니다.

1. /* #define PARSER_DEBUG */ 주석 부분을 활성하여 재컴파일

 ```
// csql 수행 시, 아래와 같은 결과를 출력  
rule matched at line: 16060 
rule matched at line: 16099 
rule matched at line: 40274 
rule matched at line: 44056 
rule matched at line: 41191 
rule matched at line: 41598 
rule matched at line: 41257
rule matched at line: 40891 
rule matched at line: 40157 
rule matched at line: 16395 
Good!!!

//...
```

2. DBG_TRACE_LEVEL 레벨을 수정 후 재컴파일
``` 
// csql 수행 시, 아래와 같은 결과를 출력

*** Token) [DATA_TYPE___]
 *** Rule) stmt::= :
 *** Token) [ ]
 *** Token) [varchar]
 *** Rule) char_bit_type::= | VARCHAR
 *** Token) [(]
 *** Token) [20]
 *** Rule) unsigned_integer::= : UNSIGNED_INTEGER
 *** Token) [)]
 *** Rule) opt_prec_1::= | '(' unsigned_integer ')'
 *** Rule) opt_charset::= :
 *** Rule) opt_collation::= :
 *** Rule) primitive_type::= | char_bit_type opt_prec_1 opt_charset opt_collation
 *** Rule) data_type::= | primitive_type
 *** Rule) stmt_::= | DATA_TYPE___ data_type
 *** Rule) stmt::= stmt_

//...
 ```

두 방법은 모두 비표준이며 특히 첫 번째 방법은 두 번째에서 구현한 방법과 중복됩니다.
따라서 첫 번째 방법은 제거를 해야 하고, 두 번째 방법은 사용하는 사람이 없을 경우 제거하는 것이 좋다고 생각합니다.

### Implementation

Debug 모드로 빌드 후, CUBRID_PARSER_DEBUG 환경 변수 값에 따라 디버깅 모드를 동적으로 설정합니다.
```
// csql 수행 시, 아래와 같은 결과를 출력

Starting parse
Entering state 0
Reading a token: Next token is token DATA_TYPE___ (1.1-1.13: )
Reducing stack 0 by rule 7 (line 1835):
-> $$ = nterm $@1 (0.0-0.0: )
Entering state 5
Reducing stack 0 by rule 8 (line 1875):
-> $$ = nterm $@2 (0.0-0.0: )
Entering state 8
Next token is token DATA_TYPE___ (1.1-1.13: )
Shifting token DATA_TYPE___ (1.1-1.13: )
Entering state 15
Reading a token: Next token is token VARCHAR (1.14-1.21: )
Shifting token VARCHAR (1.14-1.21: )
Entering state 145
Reducing stack 0 by rule 1767 (line 21276):
   $1 = token VARCHAR (1.14-1.21: )
-> $$ = nterm char_bit_type (1.14-1.21: ) 

//...

```

### Remark
- 제거한 기존 디버깅 메크로
  - 47b94a3538f0e02c649f8020f04c066035df2503
    - `PARSER_DEBUG`,  `DBG_PRINT`,  `PRINT_`, `PRINT_1`, `PRINT_2` 제거
  - 38abd73d3a6f7d0d0194450b7b565efea3406568
    - `DBG_TRACE_LEVEL`, `DBG_PRINT_TOKEN`,  `DBG_PRINT_STRING`,  `DBG_PRINT_TOKEN_END`, `DBG_TRACE_GRAMMAR` 제거
#### 사용 방법
- csql parser
`CUBRID_PARSER_DEBUG` 환경 변수의 값을 설정
```
> CUBRID_PARSER_DEBUG=1 csql -u dba -S testdb
// or
> export CUBRID_PARSER_DEBUG=1
> csql -u dba -S testdb
```

- loaddb parser(object) - (schema는 csql parser를 사용함)
`CUBRID_LOADER_DEBUG` 환경 변수의 값을 설정
```
> CUBRID_LOADER_DEBUG=1 cubrid loaddb ...
// or
> export CUBRID_LOADER_DEBUG=1
> cubrid loaddb ...
```