### PR TITLE
[CBRD-26507] remove auto increment serial from db_serial view

### DIFF
--- a/src/object/schema_system_catalog_install_query_spec.cpp
+++ b/src/object/schema_system_catalog_install_query_spec.cpp
@@ -1406,8 +1406,7 @@ sm_define_view_serial_spec (void)
 	  /* CT_SERIAL_NAME */
           "[%s] AS [serial] "
         "WHERE "
-          "[serial].[class_name] IS NULL "
-          "AND [serial].[attr_name] IS NULL",
+          "[serial].[class_name] IS NULL",
         CT_SERIAL_NAME);
   // *INDENT-ON*
 

--- a/src/object/schema_system_catalog_install_query_spec.cpp
+++ b/src/object/schema_system_catalog_install_query_spec.cpp
@@ -1404,7 +1404,10 @@ sm_define_view_serial_spec (void)
           "[serial].[updated_time] AS [updated_time] "
         "FROM "
 	  /* CT_SERIAL_NAME */
-          "[%s] AS [serial] ",
+          "[%s] AS [serial] "
+        "WHERE "
+          "[serial].[class_name] IS NULL "
+          "AND [serial].[attr_name] IS NULL",
         CT_SERIAL_NAME);
   // *INDENT-ON*
 


### PR DESCRIPTION
[<http://jira.cubrid.org/browse/CBRD-26507>
](http://jira.cubrid.org/browse/CBRD-26507)

### Purpose
현재는 serial의 시스템 카탈로그 뷰인 db_serial에서 auto increment 인 serial도 같이 출력하는데, 이를 제외합니다.

### Implementation

**db_serial 뷰 쿼리 스펙을 _db_serial의 class_name이 존재하면 제외하도록 수정
