### PR TITLE
[CBRD-26506] (Phase-2-b) Handling Invisible Column in 'Dummy SELECT'

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -26254,6 +26254,7 @@ parser_remove_dummy_select (PT_NODE ** ent_inout)
               		    new_ent->info.spec.range_var = NULL;
               		    }
 
+                      new_ent->info.spec.flag = (PT_SPEC_FLAG) (new_ent->info.spec.flag | PT_SPEC_FLAG_DUMMY_REMOVED);
             	      new_ent->info.spec.range_var = ent->info.spec.range_var;
             	      ent->info.spec.range_var = NULL;
 

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -131,10 +131,9 @@ static PT_NODE *pt_clear_Oracle_outerjoin_spec_id (PARSER_CONTEXT * parser, PT_N
 						   int *continue_walk);
 static PT_NODE *pt_bind_names (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);
 static PT_NODE *pt_bind_value_to_hostvar_local (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);
-static int pt_find_attr_in_class_list (PARSER_CONTEXT * parser, DB_ATTRIBUTE ** ret_attribute, PT_NODE * flat,
-				       PT_NODE * attr);
+static int pt_find_attr_in_class_list (PARSER_CONTEXT * parser, PT_NODE * flat, PT_NODE * attr, bool is_spec_dummy);
 static int pt_find_class_attribute (PARSER_CONTEXT * parser, PT_NODE * cls, PT_NODE * attr);
-static int pt_is_name_in_spec (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * name);
+static int pt_find_name_in_spec (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * name);
 static int pt_check_unique_exposed (PARSER_CONTEXT * parser, const PT_NODE * p);
 static PT_NODE *pt_common_attribute (PARSER_CONTEXT * parser, PT_NODE * p, PT_NODE * q);
 static PT_NODE *pt_get_all_attributes_and_types (PARSER_CONTEXT * parser, PT_NODE * cls, PT_NODE * from);
@@ -1517,7 +1516,7 @@ pt_bind_names_post (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *con
 			/* must re-resolve the name */
 			lhs->info.name.original = lhs->info.name.resolved;
 			lhs->info.name.spec_id = 0;
-			if (!pt_is_name_in_spec (parser, spec, lhs))
+			if (!pt_find_name_in_spec (parser, spec, lhs))
 			  {
 			    error = MSGCAT_SEMANTIC_IS_NOT_DEFINED;
 			    PT_ERRORmf (parser, lhs, MSGCAT_SET_PARSER_SEMANTIC, error, pt_short_print (parser, lhs));
@@ -3931,12 +3930,12 @@ pt_resolve_default_value (PARSER_CONTEXT * parser, PT_NODE * name)
  * pt_find_attr_in_class_list () - trying to resolve X.attr
  *   return: 1 on success, 0 on failure
  *   parser(in): parser context
- *   ret_attribute(out): resolved attribute pointer
  *   flat(in): list of PT_NAME nodes (class names)
  *   attr(in): a PT_NAME (an attribute name)
+ *   is_spec_dummy(in): is PT_SPEC has flag PT_SPEC_FLAG_DUMMY_REMOVED?
  */
 static int
-pt_find_attr_in_class_list (PARSER_CONTEXT * parser, DB_ATTRIBUTE ** ret_attribute, PT_NODE * flat, PT_NODE * attr)
+pt_find_attr_in_class_list (PARSER_CONTEXT * parser, PT_NODE * flat, PT_NODE * attr, bool is_spec_dummy)
 {
   DB_ATTRIBUTE *att = 0;
   DB_OBJECT *db = 0;
@@ -3987,6 +3986,12 @@ pt_find_attr_in_class_list (PARSER_CONTEXT * parser, DB_ATTRIBUTE ** ret_attribu
 	  return 0;
 	}
 
+      if (is_spec_dummy && db_attribute_is_invisible_column (att))
+	{
+	  /* dummy spec from subquery cannot see invisible columns */
+	  return 0;
+	}
+
       /* set its type */
       pt_get_attr_data_type (parser, att, attr);
 
@@ -3995,10 +4000,6 @@ pt_find_attr_in_class_list (PARSER_CONTEXT * parser, DB_ATTRIBUTE ** ret_attribu
 	  if (attr->info.name.default_value != NULL)
 	    {
 	      /* default value was already set */
-	      if (ret_attribute != NULL)
-		{
-		  *ret_attribute = att;
-		}
 	      return 1;
 	    }
 	  if (att->default_value.default_expr.default_expr_type != DB_DEFAULT_NONE)
@@ -4071,10 +4072,6 @@ pt_find_attr_in_class_list (PARSER_CONTEXT * parser, DB_ATTRIBUTE ** ret_attribu
       cname = cname->next;
     }
   attr->info.name.spec_id = flat->info.name.spec_id;
-  if (ret_attribute != NULL)
-    {
-      *ret_attribute = att;
-    }
   return 1;
 }
 
@@ -4128,14 +4125,14 @@ pt_find_class_attribute (PARSER_CONTEXT * parser, PT_NODE * cls, PT_NODE * attr)
 }
 
 /*
- * pt_is_name_in_spec () - Given a spec, see if name can be resolved to this
+ * pt_find_name_in_spec () - Given a spec, see if name can be resolved to this
  *   return: 0 if name is NOT an attribute of spec
  *   parser(in):
  *   spec(in):
  *   name(in): a PT_NAME (an attribute name)
  */
 static int
-pt_is_name_in_spec (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * name)
+pt_find_name_in_spec (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * name)
 {
   int ok;
   PT_NODE *col;
@@ -4177,14 +4174,9 @@ pt_is_name_in_spec (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * name)
 	    {
 	      return 1;
 	    }
-	  DB_ATTRIBUTE *att = NULL;
-	  ok = pt_find_attr_in_class_list (parser, &att, spec->info.spec.flat_entity_list, name);
-
-	  exclude_invisible_column = (spec->info.spec.flag & PT_SPEC_FLAG_DUMMY_REMOVED);
-	  if (ok && exclude_invisible_column && db_attribute_is_invisible_column (att))
-	    {
-	      ok = 0;
-	    }
+	  ok =
+	    pt_find_attr_in_class_list (parser, spec->info.spec.flat_entity_list, name,
+					spec->info.spec.flag & PT_SPEC_FLAG_DUMMY_REMOVED);
 	}
     }
   else
@@ -5981,7 +5973,7 @@ pt_get_resolution (PARSER_CONTEXT * parser, PT_BIND_NAMES_ARG * bind_arg, PT_NOD
       /* Else, is this an attribute of a unique entity within scope? */
       for (savespec = NULL, spec = scope; spec; spec = spec->next)
 	{
-	  if (pt_is_name_in_spec (parser, spec, in_node))
+	  if (pt_find_name_in_spec (parser, spec, in_node))
 	    {
 	      if (spec->info.spec.remote_server_name)
 		{
@@ -6200,7 +6192,7 @@ pt_get_resolution (PARSER_CONTEXT * parser, PT_BIND_NAMES_ARG * bind_arg, PT_NOD
       if (arg1->node_type == PT_NAME && (arg1->info.name.meta_class == PT_OID_ATTR))
 	{
 	  /* Arg1 was an exposed name */
-	  if (pt_is_name_in_spec (parser, *p_entity, arg2))
+	  if (pt_find_name_in_spec (parser, *p_entity, arg2))
 	    {
 	      /* only mark it resolved if it was found! transfer the info from arg1 to arg2 */
 	      arg2->info.name.resolved = arg1->info.name.resolved;
@@ -6418,7 +6410,7 @@ pt_get_resolution (PARSER_CONTEXT * parser, PT_BIND_NAMES_ARG * bind_arg, PT_NOD
 	    {
 	      exposed_spec = NULL;
 	    }
-	  if (!pt_find_attr_in_class_list (parser, NULL, arg1->data_type->info.data_type.entity, arg2))
+	  if (!pt_find_attr_in_class_list (parser, arg1->data_type->info.data_type.entity, arg2, false))
 	    {
 	      temp = arg1->data_type;
 	      if (temp)
@@ -10748,7 +10740,7 @@ pt_function_name_is_spec_attr (PARSER_CONTEXT * parser, PT_NODE * node, PT_BIND_
       /* walk specs */
       for (spec = scope->specs; spec; spec = spec->next)
 	{
-	  if (pt_is_name_in_spec (parser, spec, attr) > 0)
+	  if (pt_find_name_in_spec (parser, spec, attr) > 0)
 	    {
 	      *is_spec_attr = 1;
 	      break;

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -131,9 +131,10 @@ static PT_NODE *pt_clear_Oracle_outerjoin_spec_id (PARSER_CONTEXT * parser, PT_N
 						   int *continue_walk);
 static PT_NODE *pt_bind_names (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);
 static PT_NODE *pt_bind_value_to_hostvar_local (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);
-static int pt_find_attr_in_class_list (PARSER_CONTEXT * parser, PT_NODE * flat, PT_NODE * attr);
+static int pt_find_attr_in_class_list (PARSER_CONTEXT * parser, DB_ATTRIBUTE ** ret_attribute, PT_NODE * flat,
+				       PT_NODE * attr);
 static int pt_find_class_attribute (PARSER_CONTEXT * parser, PT_NODE * cls, PT_NODE * attr);
-static int pt_find_name_in_spec (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * name);
+static int pt_is_name_in_spec (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * name);
 static int pt_check_unique_exposed (PARSER_CONTEXT * parser, const PT_NODE * p);
 static PT_NODE *pt_common_attribute (PARSER_CONTEXT * parser, PT_NODE * p, PT_NODE * q);
 static PT_NODE *pt_get_all_attributes_and_types (PARSER_CONTEXT * parser, PT_NODE * cls, PT_NODE * from);
@@ -216,7 +217,8 @@ static void free_natural_join_attrs (NATURAL_JOIN_ATTR_INFO * attrs);
 
 static int generate_natural_join_attrs_from_subquery (PT_NODE * subquery_attrs_list, NATURAL_JOIN_ATTR_INFO ** attrs_p);
 
-static int generate_natural_join_attrs_from_db_attrs (DB_ATTRIBUTE * db_attrs, NATURAL_JOIN_ATTR_INFO ** attrs_p);
+static int generate_natural_join_attrs_from_db_attrs (DB_ATTRIBUTE * db_attrs, NATURAL_JOIN_ATTR_INFO ** attrs_p,
+						      bool flag_star_all_col);
 
 static bool is_pt_name_in_group_having (PT_NODE * node);
 
@@ -1516,7 +1518,7 @@ pt_bind_names_post (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *con
 			/* must re-resolve the name */
 			lhs->info.name.original = lhs->info.name.resolved;
 			lhs->info.name.spec_id = 0;
-			if (!pt_find_name_in_spec (parser, spec, lhs))
+			if (!pt_is_name_in_spec (parser, spec, lhs))
 			  {
 			    error = MSGCAT_SEMANTIC_IS_NOT_DEFINED;
 			    PT_ERRORmf (parser, lhs, MSGCAT_SET_PARSER_SEMANTIC, error, pt_short_print (parser, lhs));
@@ -3930,11 +3932,12 @@ pt_resolve_default_value (PARSER_CONTEXT * parser, PT_NODE * name)
  * pt_find_attr_in_class_list () - trying to resolve X.attr
  *   return: returns a PT_NAME list or NULL
  *   parser(in):
+ *   ret_attribute(out): 
  *   flat(in): list of PT_NAME nodes (class names)
  *   attr(in): a PT_NAME (an attribute name)
  */
 static int
-pt_find_attr_in_class_list (PARSER_CONTEXT * parser, PT_NODE * flat, PT_NODE * attr)
+pt_find_attr_in_class_list (PARSER_CONTEXT * parser, DB_ATTRIBUTE ** ret_attribute, PT_NODE * flat, PT_NODE * attr)
 {
   DB_ATTRIBUTE *att = 0;
   DB_OBJECT *db = 0;
@@ -3993,6 +3996,10 @@ pt_find_attr_in_class_list (PARSER_CONTEXT * parser, PT_NODE * flat, PT_NODE * a
 	  if (attr->info.name.default_value != NULL)
 	    {
 	      /* default value was already set */
+	      if (ret_attribute != NULL)
+		{
+		  *ret_attribute = att;
+		}
 	      return 1;
 	    }
 	  if (att->default_value.default_expr.default_expr_type != DB_DEFAULT_NONE)
@@ -4065,7 +4072,10 @@ pt_find_attr_in_class_list (PARSER_CONTEXT * parser, PT_NODE * flat, PT_NODE * a
       cname = cname->next;
     }
   attr->info.name.spec_id = flat->info.name.spec_id;
-
+  if (ret_attribute != NULL)
+    {
+      *ret_attribute = att;
+    }
   return 1;
 }
 
@@ -4119,19 +4129,20 @@ pt_find_class_attribute (PARSER_CONTEXT * parser, PT_NODE * cls, PT_NODE * attr)
 }
 
 /*
- * pt_find_name_in_spec () - Given a spec, see if name can be resolved to this
+ * pt_is_name_in_spec () - Given a spec, see if name can be resolved to this
  *   return: 0 if name is NOT an attribute of spec
  *   parser(in):
  *   spec(in):
  *   name(in): a PT_NAME (an attribute name)
  */
 static int
-pt_find_name_in_spec (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * name)
+pt_is_name_in_spec (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * name)
 {
   int ok;
   PT_NODE *col;
   PT_NODE *range_var;
   const char *resolved_name;
+  bool exclude_invisible_column;
 
   if (spec == NULL)
     {
@@ -4167,7 +4178,14 @@ pt_find_name_in_spec (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * name)
 	    {
 	      return 1;
 	    }
-	  ok = pt_find_attr_in_class_list (parser, spec->info.spec.flat_entity_list, name);
+	  DB_ATTRIBUTE *att = NULL;
+	  ok = pt_find_attr_in_class_list (parser, &att, spec->info.spec.flat_entity_list, name);
+
+	  exclude_invisible_column = (spec->info.spec.flag & PT_SPEC_FLAG_DUMMY_REMOVED);
+	  if (ok && exclude_invisible_column && db_attribute_is_invisible_column (att))
+	    {
+	      ok = 0;
+	    }
 	}
     }
   else
@@ -5964,7 +5982,7 @@ pt_get_resolution (PARSER_CONTEXT * parser, PT_BIND_NAMES_ARG * bind_arg, PT_NOD
       /* Else, is this an attribute of a unique entity within scope? */
       for (savespec = NULL, spec = scope; spec; spec = spec->next)
 	{
-	  if (pt_find_name_in_spec (parser, spec, in_node))
+	  if (pt_is_name_in_spec (parser, spec, in_node))
 	    {
 	      if (spec->info.spec.remote_server_name)
 		{
@@ -6183,7 +6201,7 @@ pt_get_resolution (PARSER_CONTEXT * parser, PT_BIND_NAMES_ARG * bind_arg, PT_NOD
       if (arg1->node_type == PT_NAME && (arg1->info.name.meta_class == PT_OID_ATTR))
 	{
 	  /* Arg1 was an exposed name */
-	  if (pt_find_name_in_spec (parser, *p_entity, arg2))
+	  if (pt_is_name_in_spec (parser, *p_entity, arg2))
 	    {
 	      /* only mark it resolved if it was found! transfer the info from arg1 to arg2 */
 	      arg2->info.name.resolved = arg1->info.name.resolved;
@@ -6401,7 +6419,7 @@ pt_get_resolution (PARSER_CONTEXT * parser, PT_BIND_NAMES_ARG * bind_arg, PT_NOD
 	    {
 	      exposed_spec = NULL;
 	    }
-	  if (!pt_find_attr_in_class_list (parser, arg1->data_type->info.data_type.entity, arg2))
+	  if (!pt_find_attr_in_class_list (parser, NULL, arg1->data_type->info.data_type.entity, arg2))
 	    {
 	      temp = arg1->data_type;
 	      if (temp)
@@ -10731,7 +10749,7 @@ pt_function_name_is_spec_attr (PARSER_CONTEXT * parser, PT_NODE * node, PT_BIND_
       /* walk specs */
       for (spec = scope->specs; spec; spec = spec->next)
 	{
-	  if (pt_find_name_in_spec (parser, spec, attr) > 0)
+	  if (pt_is_name_in_spec (parser, spec, attr) > 0)
 	    {
 	      *is_spec_attr = 1;
 	      break;

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -217,8 +217,7 @@ static void free_natural_join_attrs (NATURAL_JOIN_ATTR_INFO * attrs);
 
 static int generate_natural_join_attrs_from_subquery (PT_NODE * subquery_attrs_list, NATURAL_JOIN_ATTR_INFO ** attrs_p);
 
-static int generate_natural_join_attrs_from_db_attrs (DB_ATTRIBUTE * db_attrs, NATURAL_JOIN_ATTR_INFO ** attrs_p,
-						      bool flag_star_all_col);
+static int generate_natural_join_attrs_from_db_attrs (DB_ATTRIBUTE * db_attrs, NATURAL_JOIN_ATTR_INFO ** attrs_p);
 
 static bool is_pt_name_in_group_having (PT_NODE * node);
 
@@ -3930,9 +3929,9 @@ pt_resolve_default_value (PARSER_CONTEXT * parser, PT_NODE * name)
 
 /*
  * pt_find_attr_in_class_list () - trying to resolve X.attr
- *   return: returns a PT_NAME list or NULL
- *   parser(in):
- *   ret_attribute(out): 
+ *   return: 1 on success, 0 on failure
+ *   parser(in): parser context
+ *   ret_attribute(out): resolved attribute pointer
  *   flat(in): list of PT_NAME nodes (class names)
  *   attr(in): a PT_NAME (an attribute name)
  */

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -4138,7 +4138,6 @@ pt_find_name_in_spec (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * name)
   PT_NODE *col;
   PT_NODE *range_var;
   const char *resolved_name;
-  bool exclude_invisible_column;
 
   if (spec == NULL)
     {

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -1573,7 +1573,8 @@ typedef enum
   PT_SPEC_FLAG_SAMPLING_SCAN = 0x2000,	/* spec for sampling scan */
   PT_SPEC_FLAG_REFERENCED_AT_ODKU = 0x4000,	/* spec for odku assignment */
   PT_SPEC_FLAG_NO_PARALLEL_HEAP_SCAN = 0x8000,	/* spec for not for parallel heap scan */
-  PT_SPEC_FLAG_PARALLEL_THREAD = 0x10000	/* spec for setted number of parallel query execution threads */
+  PT_SPEC_FLAG_PARALLEL_THREAD = 0x10000,	/* spec for setted number of parallel query execution threads */
+  PT_SPEC_FLAG_DUMMY_REMOVED = 0x20000	/* this spec was subquery, but resolved due to dummy handling. invisible column */
 } PT_SPEC_FLAG;
 
 typedef enum

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -1574,7 +1574,7 @@ typedef enum
   PT_SPEC_FLAG_REFERENCED_AT_ODKU = 0x4000,	/* spec for odku assignment */
   PT_SPEC_FLAG_NO_PARALLEL_HEAP_SCAN = 0x8000,	/* spec for not for parallel heap scan */
   PT_SPEC_FLAG_PARALLEL_THREAD = 0x10000,	/* spec for setted number of parallel query execution threads */
-  PT_SPEC_FLAG_DUMMY_REMOVED = 0x20000	/* this spec was subquery, but resolved due to dummy handling. invisible column */
+  PT_SPEC_FLAG_DUMMY_REMOVED = 0x20000	/* this spec was originally a subquery but was resolved to a table during dummy SELECT removal; invisible columns should be excluded from this spec */
 } PT_SPEC_FLAG;
 
 typedef enum


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26506

### Purpose

- subquery를 parser 단계에서 제거하는 로직에서 최대한 subquery를 제거하는 방식으로 유지하여 tmp volume을 사용할 가능성이 낮아지도록 유지
- (Phase-2)에서 변경한 Dummy SELECT 관련 로직을 롤백 (가능한 모든 dummy subquery를 제거)
- subquery가 table로 풀린 경우 flag로 관리

### Implementation

- ~함수명 변경 : `pt_find_name_in_spec` 은 반환을 기대하는 이름이므로 `pt_is_name_in_spec` 으로 변경~
- ~인자값 추가 : `pt_find_attr_in_class_list` 는 반환을 기대하는 이름이므로 반환용 인자 `DB_ATTRIBUTE ** ret_attribute`를 추가~
- 인자값 추가 : `pt_find_attr_in_class_list` 내부에서 spec이 볼 수 있는 컬럼인지 판단할 수 있도록 `is_spec_dummy` 를 추가
- `dummy` flag 추가 : subquery가 제거된 경우 invisible column을 spec에서 조회할 수 없도록 함

### Remarks
9fd4966 : `pt_find_attr_in_class_list`, `pt_find_class_attribute`, `pt_find_name_in_spec` 와 같은 함수들의 경우 find한 객체를 반환하지는 않으나 내부 로직이 검색에서 끝나지 않기 때문에 'is', 'has' 대신 'find'를 유지하는 방향으로 결정
