### PR TITLE
[CBRD-26520] restore next field of a SP call node in the XASL conversion function

### DIFF
--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -7689,7 +7689,6 @@ pt_to_regu_variable (PARSER_CONTEXT * parser, PT_NODE * node, UNBOX unbox)
 		    {
 		      PT_ERRORc (parser, node, er_msg ());
 		    }
-		  return regu;
 		}
 	      break;
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26520>

### Purpose

파스 트리를 XASL 로 변환하는 과정에서 
stored procedure 호출에 해당하는 PT_NODE의 next 필드를 복원하지 않고 그냥 리턴하는 버그를 수정합니다. 

