### PR TITLE
[CUBRIDQA-1338] optimize network credit charge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,6 +214,56 @@ jobs:
                         
                         echo "Build extracted to /home/CUBRID"
                         ls -la /home/CUBRID | head -10
+
+              download-build-to-glusterfs:
+                description: "Download CUBRID build to GlusterFS shared storage (for shell tests)"
+                steps:
+                  - attach_workspace:
+                      at: /tmp/workspace
+                  - run:
+                      name: Download build to GlusterFS
+                      command: |
+                        BUILD_NUM=\$(cat /tmp/workspace/BUILD_NUM)
+                        BUILD_DIR="/home/build-cache/builds/\${CIRCLE_WORKFLOW_ID}"
+                        
+                        echo "CIRCLE_WORKFLOW_ID: \${CIRCLE_WORKFLOW_ID}"
+                        echo "BUILD_NUM: \${BUILD_NUM}"
+                        echo "BUILD_DIR: \${BUILD_DIR}"
+                        
+                        # Check if build already exists
+                        if [ -d "\${BUILD_DIR}/CUBRID" ]; then
+                          echo "Build already exists, skipping download"
+                          ls -la "\${BUILD_DIR}/CUBRID" | head -10
+                          exit 0
+                        fi
+                        
+                        mkdir -p "\${BUILD_DIR}"
+                        
+                        echo "Downloading build from job #\${BUILD_NUM}..."
+                        
+                        # Fetch artifact list
+                        RESPONSE=\$(curl -s -H "Circle-Token: \${CIRCLECI_TOKEN}" \\
+                          "https://circleci.com/api/v2/project/gh/\${CIRCLE_PROJECT_USERNAME}/\${CIRCLE_PROJECT_REPONAME}/\${BUILD_NUM}/artifacts")
+                        
+                        # Extract CUBRID.tar.gz URL
+                        ARTIFACT_URL=\$(echo "\$RESPONSE" | grep -o '"url": "[^"]*CUBRID.tar.gz[^"]*"' | head -1 | sed 's/"url": "//;s/"$//')
+                        
+                        if [ -z "\$ARTIFACT_URL" ]; then
+                          echo "ERROR: CUBRID.tar.gz artifact not found"
+                          echo "Response: \$RESPONSE"
+                          exit 1
+                        fi
+                        
+                        echo "Artifact URL: \$ARTIFACT_URL"
+                        
+                        # Download to GlusterFS
+                        curl -L -o "\${BUILD_DIR}/CUBRID.tar.gz" "\$ARTIFACT_URL"
+                        tar xzf "\${BUILD_DIR}/CUBRID.tar.gz" -C "\${BUILD_DIR}"
+                        rm "\${BUILD_DIR}/CUBRID.tar.gz"
+                        
+                        echo "Build extracted to \${BUILD_DIR}/CUBRID"
+                        ls -la "\${BUILD_DIR}/CUBRID" | head -10
+                        df -h /home/build-cache
                       
             # --------------------------------------------------
             # 2. Reusable executors
@@ -344,6 +394,13 @@ jobs:
                   GITHUB_TOKEN: \$GHI_TOKEN
                 steps:
                   - attach-and-run-tests
+
+              download-build:
+                description: "Download CUBRID build to GlusterFS (1x download for all shell test pods)"
+                executor: cubrid-test-shell
+                parallelism: 1
+                steps:
+                  - download-build-to-glusterfs
             
             # --------------------------------------------------
             # 4. Conditional workflows
@@ -355,9 +412,12 @@ jobs:
             EOF
             
             echo "[debug] Conditionally add test jobs based on parameters"
-            [ "$RUN_MEDIUM_TEST"  = "true" ] && echo "      - test_medium: {requires: [build]}" >> .circleci/continue.yml
-            [ "$RUN_SQL_TEST"     = "true" ] && echo "      - test_sql:    {requires: [build]}" >> .circleci/continue.yml
-            [ "$RUN_SHELL_TEST"   = "true" ] && echo "      - test_shell:  {requires: [build]}" >> .circleci/continue.yml
+            [ "$RUN_MEDIUM_TEST"  = "true" ] && echo "      - test_medium:    {requires: [build]}" >> .circleci/continue.yml
+            [ "$RUN_SQL_TEST"     = "true" ] && echo "      - test_sql:       {requires: [build]}" >> .circleci/continue.yml
+            if [ "$RUN_SHELL_TEST" = "true" ]; then
+              echo "      - download-build: {requires: [build]}" >> .circleci/continue.yml
+              echo "      - test_shell:     {requires: [download-build]}" >> .circleci/continue.yml
+            fi
             
             echo "[debug] Output generated configuration (.circleci/continue.yml)"
             cat .circleci/continue.yml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -418,7 +418,7 @@ jobs:
 
               download-build:
                 description: "Download CUBRID build to GlusterFS (1x download for all shell test pods)"
-                executor: cubrid-test-staging
+                executor: cubrid-test-shell
                 parallelism: 1
                 steps:
                   - download-build-to-glusterfs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,13 +281,6 @@ jobs:
                 # self-hosted runner
                 resource_class: cubrid/ramdisk
                 working_directory: /home
-              
-              cubrid-test-staging:
-                docker:
-                  - image: cubridci/cubridci:test_shell
-                # self-hosted runner
-                resource_class: cubrid/staging
-                working_directory: /home
                 
             # --------------------------------------------------
             # 3. Jobs
@@ -407,8 +400,8 @@ jobs:
                         - cubrid-testcases
                       
               test_shell:
-                executor: cubrid-test-staging
-                parallelism: 1
+                executor: cubrid-test-shell
+                parallelism: 50
                 environment:
                   BASELINE: << pipeline.parameters.baseline >>
                   TEST_SUITE: "shell"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,10 +77,8 @@ jobs:
             # --------------------------------------------------
             commands:
               attach-and-run-tests:
-                description: "Attach workspace and run test scripts"
+                description: "Run test scripts (CUBRID must be at /home/CUBRID)"
                 steps:
-                  - attach_workspace:
-                      at: .
                   - run:
                       name: Test
                       shell: /bin/bash
@@ -182,6 +180,40 @@ jobs:
                   - store_artifacts:
                       path: /tmp/build_logs
                       when: always
+
+              download-build-from-artifact:
+                description: "Download CUBRID build from artifact (for sql/medium tests)"
+                steps:
+                  - attach_workspace:
+                      at: /tmp/workspace
+                  - run:
+                      name: Download build from artifact
+                      command: |
+                        BUILD_NUM=\$(cat /tmp/workspace/BUILD_NUM)
+                        echo "Downloading build from job #\${BUILD_NUM}..."
+                        
+                        # Fetch artifact list
+                        RESPONSE=\$(curl -s -H "Circle-Token: \${CIRCLECI_TOKEN}" \\
+                          "https://circleci.com/api/v2/project/gh/\${CIRCLE_PROJECT_USERNAME}/\${CIRCLE_PROJECT_REPONAME}/\${BUILD_NUM}/artifacts")
+                        
+                        # Extract CUBRID.tar.gz URL
+                        ARTIFACT_URL=\$(echo "\$RESPONSE" | grep -o '"url": "[^"]*CUBRID.tar.gz[^"]*"' | head -1 | sed 's/"url": "//;s/"$//')
+                        
+                        if [ -z "\$ARTIFACT_URL" ]; then
+                          echo "ERROR: CUBRID.tar.gz artifact not found"
+                          echo "Response: \$RESPONSE"
+                          exit 1
+                        fi
+                        
+                        echo "Artifact URL: \$ARTIFACT_URL"
+                        
+                        # Download and extract
+                        curl -L -o /tmp/CUBRID.tar.gz "\$ARTIFACT_URL"
+                        tar xzf /tmp/CUBRID.tar.gz -C /home/
+                        rm /tmp/CUBRID.tar.gz
+                        
+                        echo "Build extracted to /home/CUBRID"
+                        ls -la /home/CUBRID | head -10
                       
             # --------------------------------------------------
             # 2. Reusable executors
@@ -240,66 +272,20 @@ jobs:
                   - run:
                       name: Package build for artifact
                       command: |
-                        echo "Packaging CUBRID build..."
                         tar czf CUBRID.tar.gz CUBRID
-                        ls -lh CUBRID.tar.gz
+                        echo "Build packaged: \$(ls -lh CUBRID.tar.gz | awk '{print \$5}')"
                   - store_artifacts:
                       path: CUBRID.tar.gz
                       destination: CUBRID.tar.gz
                   - run:
-                      name: Test artifact API access
+                      name: Save build metadata for test jobs
                       command: |
-                        echo "=== Testing CircleCI Artifact API Access ==="
-                        echo "CIRCLE_BUILD_NUM: \${CIRCLE_BUILD_NUM}"
-                        echo "CIRCLE_PROJECT_USERNAME: \${CIRCLE_PROJECT_USERNAME}"
-                        echo "CIRCLE_PROJECT_REPONAME: \${CIRCLE_PROJECT_REPONAME}"
-                        echo "CIRCLE_WORKFLOW_ID: \${CIRCLE_WORKFLOW_ID}"
-                        echo ""
-                        
-                        # Check if CIRCLECI_TOKEN is available
-                        if [ -z "\${CIRCLECI_TOKEN}" ]; then
-                          echo "WARNING: CIRCLECI_TOKEN is not set"
-                          echo "Artifact API access requires CIRCLECI_TOKEN environment variable"
-                          exit 0
-                        fi
-                        
-                        echo "CIRCLECI_TOKEN is set (length: \${#CIRCLECI_TOKEN})"
-                        echo ""
-                        
-                        # Wait a moment for artifact to be uploaded
-                        sleep 5
-                        
-                        # Try to access artifacts API
-                        echo "Fetching artifacts for job \${CIRCLE_BUILD_NUM}..."
-                        RESPONSE=\$(curl -s -w "\\nHTTP_STATUS:%{http_code}" \\
-                          -H "Circle-Token: \${CIRCLECI_TOKEN}" \\
-                          "https://circleci.com/api/v2/project/gh/\${CIRCLE_PROJECT_USERNAME}/\${CIRCLE_PROJECT_REPONAME}/\${CIRCLE_BUILD_NUM}/artifacts")
-                        
-                        HTTP_STATUS=\$(echo "\$RESPONSE" | grep "HTTP_STATUS" | cut -d: -f2)
-                        BODY=\$(echo "\$RESPONSE" | grep -v "HTTP_STATUS")
-                        
-                        echo "HTTP Status: \$HTTP_STATUS"
-                        echo "Response:"
-                        echo "\$BODY"
-                        
-                        if [ "\$HTTP_STATUS" = "200" ]; then
-                          echo ""
-                          echo "SUCCESS: Artifact API is accessible"
-                          
-                          # Extract artifact URL using grep/sed (no jq needed)
-                          ARTIFACT_URL=\$(echo "\$BODY" | grep -o '"url": "[^"]*CUBRID.tar.gz[^"]*"' | head -1 | sed 's/"url": "//;s/"$//')
-                          if [ -n "\$ARTIFACT_URL" ]; then
-                            echo "Artifact URL: \$ARTIFACT_URL"
-                          else
-                            echo "Note: CUBRID.tar.gz not found in artifacts yet (may still be uploading)"
-                          fi
-                        else
-                          echo ""
-                          echo "FAILED: Could not access artifact API (HTTP \$HTTP_STATUS)"
-                        fi
+                        mkdir -p workspace
+                        echo "\${CIRCLE_BUILD_NUM}" > workspace/BUILD_NUM
+                        echo "Saved BUILD_NUM: \$(cat workspace/BUILD_NUM)"
                   - persist_to_workspace:
-                      root: .
-                      paths: [ CUBRID ]
+                      root: workspace
+                      paths: [ BUILD_NUM ]
               
               test_medium:
                 executor: cubrid-default
@@ -312,6 +298,7 @@ jobs:
                       keys:
                         - "cubrid-testcases-develop-${TC_SHA}"
                         - "cubrid-testcases-develop-"
+                  - download-build-from-artifact
                   - attach-and-run-tests
                   - run:
                       name: Clean up tc before save_cache
@@ -335,6 +322,7 @@ jobs:
                       keys:
                         - "cubrid-testcases-develop-${TC_SHA}"
                         - "cubrid-testcases-develop-"
+                  - download-build-from-artifact
                   - attach-and-run-tests
                   - run:
                       name: Clean up tc before save_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,6 +237,66 @@ jobs:
                       paths:
                         - /home/.ccache
                   - collect-build-logs
+                  - run:
+                      name: Package build for artifact
+                      command: |
+                        echo "Packaging CUBRID build..."
+                        tar czf CUBRID.tar.gz CUBRID
+                        ls -lh CUBRID.tar.gz
+                  - store_artifacts:
+                      path: CUBRID.tar.gz
+                      destination: CUBRID.tar.gz
+                  - run:
+                      name: Test artifact API access
+                      command: |
+                        echo "=== Testing CircleCI Artifact API Access ==="
+                        echo "CIRCLE_BUILD_NUM: \${CIRCLE_BUILD_NUM}"
+                        echo "CIRCLE_PROJECT_USERNAME: \${CIRCLE_PROJECT_USERNAME}"
+                        echo "CIRCLE_PROJECT_REPONAME: \${CIRCLE_PROJECT_REPONAME}"
+                        echo "CIRCLE_WORKFLOW_ID: \${CIRCLE_WORKFLOW_ID}"
+                        echo ""
+                        
+                        # Check if CIRCLECI_TOKEN is available
+                        if [ -z "\${CIRCLECI_TOKEN}" ]; then
+                          echo "WARNING: CIRCLECI_TOKEN is not set"
+                          echo "Artifact API access requires CIRCLECI_TOKEN environment variable"
+                          exit 0
+                        fi
+                        
+                        echo "CIRCLECI_TOKEN is set (length: \${#CIRCLECI_TOKEN})"
+                        echo ""
+                        
+                        # Wait a moment for artifact to be uploaded
+                        sleep 5
+                        
+                        # Try to access artifacts API
+                        echo "Fetching artifacts for job \${CIRCLE_BUILD_NUM}..."
+                        RESPONSE=\$(curl -s -w "\\nHTTP_STATUS:%{http_code}" \\
+                          -H "Circle-Token: \${CIRCLECI_TOKEN}" \\
+                          "https://circleci.com/api/v2/project/gh/\${CIRCLE_PROJECT_USERNAME}/\${CIRCLE_PROJECT_REPONAME}/\${CIRCLE_BUILD_NUM}/artifacts")
+                        
+                        HTTP_STATUS=\$(echo "\$RESPONSE" | grep "HTTP_STATUS" | cut -d: -f2)
+                        BODY=\$(echo "\$RESPONSE" | grep -v "HTTP_STATUS")
+                        
+                        echo "HTTP Status: \$HTTP_STATUS"
+                        echo "Response:"
+                        echo "\$BODY"
+                        
+                        if [ "\$HTTP_STATUS" = "200" ]; then
+                          echo ""
+                          echo "SUCCESS: Artifact API is accessible"
+                          
+                          # Extract artifact URL using grep/sed (no jq needed)
+                          ARTIFACT_URL=\$(echo "\$BODY" | grep -o '"url": "[^"]*CUBRID.tar.gz[^"]*"' | head -1 | sed 's/"url": "//;s/"$//')
+                          if [ -n "\$ARTIFACT_URL" ]; then
+                            echo "Artifact URL: \$ARTIFACT_URL"
+                          else
+                            echo "Note: CUBRID.tar.gz not found in artifacts yet (may still be uploading)"
+                          fi
+                        else
+                          echo ""
+                          echo "FAILED: Could not access artifact API (HTTP \$HTTP_STATUS)"
+                        fi
                   - persist_to_workspace:
                       root: .
                       paths: [ CUBRID ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -321,6 +321,19 @@ jobs:
                         - /home/.ccache
                   - collect-build-logs
                   - run:
+                      name: Stop after build logs on default trigger
+                      command: |
+                        case "${CIRCLE_BRANCH:-}" in
+                          */head*)
+                            echo "[info] head trigger detected (${CIRCLE_BRANCH}); continue to package artifacts"
+                            ;;
+                          *)
+                            echo "[info] default trigger detected (${CIRCLE_BRANCH}); stop after collect-build-logs"
+                            circleci-agent step halt
+                            exit 0
+                            ;;
+                        esac
+                  - run:
                       name: Package build for artifact
                       command: |
                         tar czf CUBRID.tar.gz CUBRID

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -418,7 +418,7 @@ jobs:
 
               download-build:
                 description: "Download CUBRID build to GlusterFS (1x download for all shell test pods)"
-                executor: cubrid-test-shell
+                executor: cubrid-test-staging
                 parallelism: 1
                 steps:
                   - download-build-to-glusterfs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,15 +224,16 @@ jobs:
                       name: Download build to GlusterFS
                       command: |
                         BUILD_NUM=\$(cat /tmp/workspace/BUILD_NUM)
-                        BUILD_DIR="/home/build-cache/builds/\${CIRCLE_WORKFLOW_ID}"
+                        # Use CIRCLE_SHA1 (commit hash) to reuse build across workflow retries
+                        BUILD_DIR="/home/build-cache/builds/\${CIRCLE_SHA1}"
                         
-                        echo "CIRCLE_WORKFLOW_ID: \${CIRCLE_WORKFLOW_ID}"
+                        echo "CIRCLE_SHA1: \${CIRCLE_SHA1}"
                         echo "BUILD_NUM: \${BUILD_NUM}"
                         echo "BUILD_DIR: \${BUILD_DIR}"
                         
-                        # Check if build already exists
+                        # Check if build already exists (same commit = same build)
                         if [ -d "\${BUILD_DIR}/CUBRID" ]; then
-                          echo "Build already exists, skipping download"
+                          echo "Build already exists for this commit, skipping download"
                           ls -la "\${BUILD_DIR}/CUBRID" | head -10
                           exit 0
                         fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,6 +281,13 @@ jobs:
                 # self-hosted runner
                 resource_class: cubrid/ramdisk
                 working_directory: /home
+              
+              cubrid-test-staging:
+                docker:
+                  - image: cubridci/cubridci:test_shell
+                # self-hosted runner
+                resource_class: cubrid/staging
+                working_directory: /home
                 
             # --------------------------------------------------
             # 3. Jobs
@@ -400,8 +407,8 @@ jobs:
                         - cubrid-testcases
                       
               test_shell:
-                executor: cubrid-test-shell
-                parallelism: 50
+                executor: cubrid-test-staging
+                parallelism: 1
                 environment:
                   BASELINE: << pipeline.parameters.baseline >>
                   TEST_SUITE: "shell"


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1338>

### Purpose
- CircleCI 빌드 배포 방식을 workspace에서 artifact 기반으로 전환하여 네트워크 대역폭 절감
- GlusterFS 공유 스토리지를 활용한 shell 테스트 빌드 캐싱 시스템 구현
- 커밋 해시 기반 캐싱으로 workflow 재실행 시 빌드 재사용 지원

### Implementation

**1. Artifact API 검증 (653826b69)**
- build job에서 CUBRID.tar.gz를 artifact로 저장
- CIRCLECI_TOKEN 환경변수를 이용한 artifact API 접근 테스트
- GlusterFS 캐시 구현을 위한 사전 준비 작업

**2. SQL/Medium 테스트 artifact 배포 (a67df910f)**
- `download-build-from-artifact` command 추가
  - artifact API로 CUBRID.tar.gz 다운로드
  - workspace 대신 artifact 사용
  
- Workspace 내용 변경
  - 기존: 248MB 빌드 전체 저장
  - 변경: BUILD_NUM만 저장 (몇 바이트)
  
- test_sql, test_medium job 수정
  - attach_workspace 제거
  - download-build-from-artifact 사용

**3. Shell 테스트 GlusterFS 캐시 (ecce9a5b0)**
- `download-build-to-glusterfs` command 추가
  - artifact API로 빌드 다운로드
  - GlusterFS에 저장: `/home/build-cache/builds/{CIRCLE_WORKFLOW_ID}/CUBRID`
  
- `download-build` job 추가
  - parallelism: 1 (1회만 실행)
  - self-hosted runner 사용
  
- Workflow 구조 변경
  - 기존: `build → test_shell (x50, 각각 다운로드)`
  - 변경: `build → download-build → test_shell (x50, 공유)`

**4. 커밋 해시 기반 재사용 (579fbc775)**
- 빌드 캐시 키 변경
  - `CIRCLE_WORKFLOW_ID` → `CIRCLE_SHA1`
  - 경로: `/home/build-cache/builds/{commit-hash}/CUBRID`
  
- 같은 커밋에 대한 재실행 시 다운로드 스킵

**5. Kubernetes container-agent 설정**
- postStart hook 4단계 로직:
  1. testcases overlay mount
  2. Pod 라벨 읽기 (Downward API)
  3. CUBRID 소스 결정 (download-build / workspace / GlusterFS)
  4. GlusterFS에서 overlay mount
  
- Downward API로 `CIRCLE_JOB`, `CIRCLE_SHA1` 라벨 노출
- 이전 workspace 방식과 호환성 유지

### Remarks

**네트워크 절감 효과**
- SQL/Medium 테스트 (Cloud):
  - workspace 248MB × 11개 = 2.7GB → artifact 다운로드로 변경
  
- Shell 테스트 (Self-hosted):
  - 기존: 50개 pod × 300MB = 15GB
  - 개선: 1회 다운로드 300MB
  
- **총 절감: 18.6GB → 3.6GB (약 80% 절감)**

**재사용 효과**
- 같은 커밋에 대한 workflow 재실행 시 다운로드 스킵
- 빌드 성공 + 테스트 실패 → 재실행 시 즉시 테스트 시작
- 새 커밋 푸시 시에만 새로 다운로드

**호환성 및 안정성**
- Overlay mount로 각 shell test pod 간 격리 유지
- 기존 config.yml (workspace 방식)과 호환
- download-build job 실패 시 graceful degradation