### PR TITLE
[CUBVEC-152][CUBVEC-154] Refactor HNSW parallel insertion to use a job queue based worker tasks

### DIFF
--- a/src/storage/index_hnsw/hnsw.cpp
+++ b/src/storage/index_hnsw/hnsw.cpp
@@ -766,14 +766,7 @@ hnsw_index_manager::create_btid (THREAD_ENTRY *thread_p, const hnsw_index_backen
 
 void hnsw_index_manager::finalize ()
 {
-  for (const auto &pair : m_index_map)
-    {
-      hnsw_index *index = pair.second.get();
-      if (index)
-	{
-	  delete index;
-	}
-    }
+  m_index_map.clear ();
 }
 
 void hnsw_index_manager::register_backend (std::unique_ptr<hnsw_index_backend> backend)

--- a/src/storage/index_hnsw/hnsw.cpp
+++ b/src/storage/index_hnsw/hnsw.cpp
@@ -97,6 +97,8 @@ class hnsw_index_manager
     int save_all_indices (THREAD_ENTRY *thread_p);
     int delete_index_on_disk (THREAD_ENTRY *thread_p, const std::string &prefix, const BTID *btid);
 
+    void finalize ();
+
     // backend management
     void register_backend (std::unique_ptr<hnsw_index_backend> backend);
     const hnsw_index_backend *get_backend () const;
@@ -151,6 +153,8 @@ xhnsw_finalize (THREAD_ENTRY *thread_p)
   assert (index_manager != nullptr);
 
   index_manager->save_all_indices (thread_p);
+
+  index_manager->finalize ();
   return NO_ERROR;
 }
 
@@ -758,6 +762,18 @@ hnsw_index_manager::create_btid (THREAD_ENTRY *thread_p, const hnsw_index_backen
     }
 
   return btid_out;
+}
+
+void hnsw_index_manager::finalize ()
+{
+  for (const auto &pair : m_index_map)
+  {
+    hnsw_index *index = pair.second.get();
+    if (index)
+    {
+      delete index;
+    }
+  }
 }
 
 void hnsw_index_manager::register_backend (std::unique_ptr<hnsw_index_backend> backend)

--- a/src/storage/index_hnsw/hnsw.cpp
+++ b/src/storage/index_hnsw/hnsw.cpp
@@ -767,13 +767,13 @@ hnsw_index_manager::create_btid (THREAD_ENTRY *thread_p, const hnsw_index_backen
 void hnsw_index_manager::finalize ()
 {
   for (const auto &pair : m_index_map)
-  {
-    hnsw_index *index = pair.second.get();
-    if (index)
     {
-      delete index;
+      hnsw_index *index = pair.second.get();
+      if (index)
+	{
+	  delete index;
+	}
     }
-  }
 }
 
 void hnsw_index_manager::register_backend (std::unique_ptr<hnsw_index_backend> backend)

--- a/src/storage/index_hnsw/hnsw_algo.hpp
+++ b/src/storage/index_hnsw/hnsw_algo.hpp
@@ -178,22 +178,6 @@ namespace cubhnsw
       using neighbors_ref_type = neighbors_ref_t<traits>;
 
       using pinned_t = pinned_block_t<Traits, std::function<void (pinned_block_data<Traits>&)>>;
-      struct context_t
-      {
-	top_candidates_t<Traits> m_top_candidates;
-	top_candidates_t<Traits> m_top_for_refine;
-	next_candidates_t<Traits> m_next_candidates;
-	visited_set_t<Traits> m_visits;
-	std::default_random_engine m_level_generator;
-
-	void clear_candidates ()
-	{
-	  m_top_candidates.clear ();
-	  m_top_for_refine.clear ();
-	  m_next_candidates.clear();
-	  m_visits.clear();
-	}
-      };
 
       algo (const hnsw_build_params &build_params);
 

--- a/src/storage/index_hnsw/hnsw_algo.hpp
+++ b/src/storage/index_hnsw/hnsw_algo.hpp
@@ -622,9 +622,9 @@ namespace cubhnsw
 	  }
 
 	neighbors_ref_type close_header;
+	pinned_t close_node_blk = m_storage->get_node_by_slot_id (thread_p, close_slot, lock_mode::exclusive);
 	{
 	  // TODO: exclusive??
-	  pinned_t close_node_blk = m_storage->get_node_by_slot_id (thread_p, close_slot, lock_mode::exclusive);
 	  close_header = get_neighbors (close_node_blk, level);
 	  if (close_header.size () < layer_connectivity)
 	    {

--- a/src/storage/index_hnsw/hnsw_usearch_ng.cpp
+++ b/src/storage/index_hnsw/hnsw_usearch_ng.cpp
@@ -124,6 +124,7 @@ class hnsw_usearch_ng final:public hnsw_index
       const float *m_vector;
     };
 
+    void init_worker_pool ();
     void add_internal (cubthread::entry &thread_ref, hnsw_build_worker_job &job);
 
     VPID m_root_vpid;
@@ -136,6 +137,14 @@ class hnsw_usearch_ng final:public hnsw_index
     cubthread::worker_pool_task_capper<cubthread::entry> *m_build_worker_task_capper;
     std::vector<cubthread::entry_callable_task> m_build_worker_tasks;
     std::size_t m_build_worker_size;
+
+    std::atomic<int> m_pending_jobs {0};
+    std::mutex m_worker_mtx;
+    std::condition_variable m_worker_cv;
+    std::atomic<bool> m_stop {false};
+
+    std::mutex m_single_thread_mtx;
+    bool m_force_single_thread {true};
 #endif
     lockfree::circular_queue<hnsw_build_worker_job> *m_build_worker_job_queue;
 };
@@ -233,25 +242,56 @@ hnsw_usearch_ng::init (cubthread::entry *thread_p, PAGE_PTR page_ptr, RECDES &re
 
   m_algo->set_storage (m_storage.get ());
 
+  init_worker_pool ();
+
+  return NO_ERROR;
+}
+
+void
+hnsw_usearch_ng::init_worker_pool ()
+{
 #if defined (SERVER_MODE)
   // TODO (CUBVEC): parameterize the worker size
   m_build_worker_size = std::min (static_cast<std::size_t> (std::thread::hardware_concurrency ()),
 				  static_cast<std::size_t> (16));
+
   if (m_build_worker_size > 1)
     {
       m_build_worker_pool = cubthread::get_manager ()->create_worker_pool (
-				    m_build_worker_size, m_build_worker_size * 2, "hnsw insertion worker pool", NULL, 1, false);
+				    m_build_worker_size, m_build_worker_size, "hnsw insertion worker pool", NULL, 1, false);
       m_build_worker_task_capper = new cubthread::worker_pool_task_capper<cubthread::entry> (m_build_worker_pool);
-      m_build_worker_job_queue = new lockfree::circular_queue<hnsw_build_worker_job> (m_build_worker_size);
+
+      const std::size_t queue_size = m_build_worker_size * 256;
+      m_build_worker_job_queue = new lockfree::circular_queue<hnsw_build_worker_job> (queue_size);
       m_build_worker_tasks.reserve (m_build_worker_size);
       for (std::size_t i = 0; i < m_build_worker_size; ++i)
 	{
 	  auto exec_func = [this] (cubthread::entry &entry)
 	  {
-	    hnsw_build_worker_job job;
-
-	    while (m_build_worker_job_queue->consume (job))
+	    while (true)
 	      {
+		std::unique_lock<std::mutex> lock (m_worker_mtx);
+		m_worker_cv.wait (lock, [&] { return m_pending_jobs.load () > 0 || m_stop.load (); });
+
+		if (m_stop.load (std::memory_order_acquire))
+		  {
+		    // exit
+		    return;
+		  }
+
+		if (m_pending_jobs.fetch_sub (1, std::memory_order_acq_rel) <= 0)
+		  {
+		    continue;
+		  }
+
+		hnsw_build_worker_job job;
+		if (!m_build_worker_job_queue->consume (job))
+		  {
+		    // should not happen
+		    assert (false);
+		    continue;
+		  }
+
 		this->add_internal (entry, job);
 	      }
 	  };
@@ -265,12 +305,15 @@ hnsw_usearch_ng::init (cubthread::entry *thread_p, PAGE_PTR page_ptr, RECDES &re
       m_build_worker_job_queue = nullptr;
     }
 #endif
-  return NO_ERROR;
 }
 
 hnsw_usearch_ng::~hnsw_usearch_ng ()
 {
 #if defined (SERVER_MODE)
+  m_stop.store (true, std::memory_order_release);
+
+  m_worker_cv.notify_all ();
+
   cubthread::get_manager()->destroy_worker_pool (m_build_worker_pool);
 
   if (m_build_worker_task_capper != nullptr)
@@ -299,6 +342,9 @@ hnsw_usearch_ng::add (cubthread::entry *thread_p, int n_vectors, const OID *oid,
   ctx.tran_index = thread_p->tran_index;
   // Push insert each vector insertion task to worker pool
 
+  std::vector<hnsw_build_worker_job> jobs;
+  jobs.reserve (n_vectors);
+
   for (int i = 0; i < n_vectors; ++i)
     {
       hnsw_build_worker_job job;
@@ -306,13 +352,35 @@ hnsw_usearch_ng::add (cubthread::entry *thread_p, int n_vectors, const OID *oid,
       job.m_oid = oid[i];
       job.m_vector = vector + i * m_build_params.dimension;
 
-      if (m_build_worker_job_queue != nullptr)
+      jobs.emplace_back (job);
+    }
+
+  for (auto &job : jobs)
+    {
+#if defined (SERVER_MODE)
+      if (m_stop.load (std::memory_order_acquire))
+	{
+	  // exit
+	  return ER_FAILED;
+	}
+
+      if (m_force_single_thread)
+	{
+	  std::lock_guard<std::mutex> lk (m_single_thread_mtx);
+	  job.m_ctx = nullptr;
+	  this->add_internal (*thread_p, job);
+	}
+      else if (m_build_worker_job_queue != nullptr && m_build_worker_job_queue->produce (std::move (job)))
 	{
 	  ctx.m_pushed_tasks++;
-	  m_build_worker_job_queue->produce (std::move (job));
 	}
       else
+#endif
 	{
+	  // SERVER_MODE: if worker pool is not available, perform the job on the current thread
+	  // SA_MODE : always reach here
+	  // fallback to single thread execution
+	  job.m_ctx = nullptr;
 	  this->add_internal (*thread_p, job);
 	}
     }
@@ -320,6 +388,11 @@ hnsw_usearch_ng::add (cubthread::entry *thread_p, int n_vectors, const OID *oid,
 #if defined (SERVER_MODE)
   if (ctx.m_pushed_tasks > 0)
     {
+      // notify the worker pool to start working
+      m_pending_jobs.fetch_add (ctx.m_pushed_tasks, std::memory_order_relaxed);
+      m_worker_cv.notify_all ();
+
+      // wait for all jobs to be completed
       std::unique_lock<std::mutex> lock (ctx.m_mutex);
       ctx.m_cv.wait (lock, [&ctx]
       {

--- a/src/storage/index_hnsw/hnsw_usearch_ng.cpp
+++ b/src/storage/index_hnsw/hnsw_usearch_ng.cpp
@@ -39,6 +39,8 @@
 #include "db_vector.hpp"	// db_vector_is_all_zeros
 #if defined (SERVER_MODE)
 #include "thread_worker_pool.hpp"
+#include "thread_worker_pool_taskcap.hpp"
+#include "lockfree_circular_queue.hpp"
 #endif
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
 #include "memory_wrapper.hpp"
@@ -102,7 +104,27 @@ class hnsw_usearch_ng final:public hnsw_index
 				 float *distances) override;
     virtual int dump (cubthread::entry *thread_p, FILE *fp) override;
 
-    int add_vector (cubthread::entry &thread_ref, const OID oid, const float *vector, const int tran_index);
+  protected:
+
+    struct hnsw_build_worker_context final
+    {
+      std::mutex m_mutex;
+      std::condition_variable m_cv;
+
+      std::atomic<int> m_active_tasks {0};
+      int m_pushed_tasks {0};
+
+      int tran_index {0};
+    };
+
+    struct hnsw_build_worker_job final
+    {
+      hnsw_build_worker_context *m_ctx;
+      OID m_oid;
+      const float *m_vector;
+    };
+
+    void add_internal (cubthread::entry &thread_ref, hnsw_build_worker_job &job);
 
     VPID m_root_vpid;
 
@@ -110,9 +132,12 @@ class hnsw_usearch_ng final:public hnsw_index
     std::unique_ptr < storage_type > m_storage;
 
 #if defined (SERVER_MODE)
-    cubthread::entry_workpool *m_worker_pool;
-    size_t m_worker_pool_size;
+    cubthread::entry_workpool *m_build_worker_pool;
+    cubthread::worker_pool_task_capper<cubthread::entry> *m_build_worker_task_capper;
+    std::vector<cubthread::entry_callable_task> m_build_worker_tasks;
+    std::size_t m_build_worker_size;
 #endif
+    lockfree::circular_queue<hnsw_build_worker_job> *m_build_worker_job_queue;
 };
 
 // =====================================================================
@@ -209,9 +234,36 @@ hnsw_usearch_ng::init (cubthread::entry *thread_p, PAGE_PTR page_ptr, RECDES &re
   m_algo->set_storage (m_storage.get ());
 
 #if defined (SERVER_MODE)
-  m_worker_pool_size = std::thread::hardware_concurrency ();
-  m_worker_pool = cubthread::get_manager ()->create_worker_pool (
-			  m_worker_pool_size, m_worker_pool_size, "hnsw insertion worker pool", NULL, 1, false);
+  // TODO (CUBVEC): parameterize the worker size
+  m_build_worker_size = std::min (static_cast<std::size_t> (std::thread::hardware_concurrency ()),
+				  static_cast<std::size_t> (16));
+  if (m_build_worker_size > 1)
+    {
+      m_build_worker_pool = cubthread::get_manager ()->create_worker_pool (
+				    m_build_worker_size, m_build_worker_size * 2, "hnsw insertion worker pool", NULL, 1, false);
+      m_build_worker_task_capper = new cubthread::worker_pool_task_capper<cubthread::entry> (m_build_worker_pool);
+      m_build_worker_job_queue = new lockfree::circular_queue<hnsw_build_worker_job> (m_build_worker_size);
+      m_build_worker_tasks.reserve (m_build_worker_size);
+      for (std::size_t i = 0; i < m_build_worker_size; ++i)
+	{
+	  auto exec_func = [this] (cubthread::entry &entry)
+	  {
+	    hnsw_build_worker_job job;
+
+	    while (m_build_worker_job_queue->consume (job))
+	      {
+		this->add_internal (entry, job);
+	      }
+	  };
+	  m_build_worker_task_capper->push_task (new cubthread::entry_callable_task (exec_func));
+	}
+    }
+  else
+    {
+      m_build_worker_pool = nullptr;
+      m_build_worker_task_capper = nullptr;
+      m_build_worker_job_queue = nullptr;
+    }
 #endif
   return NO_ERROR;
 }
@@ -219,7 +271,16 @@ hnsw_usearch_ng::init (cubthread::entry *thread_p, PAGE_PTR page_ptr, RECDES &re
 hnsw_usearch_ng::~hnsw_usearch_ng ()
 {
 #if defined (SERVER_MODE)
-  cubthread::get_manager()->destroy_worker_pool (m_worker_pool);
+  cubthread::get_manager()->destroy_worker_pool (m_build_worker_pool);
+
+  if (m_build_worker_task_capper != nullptr)
+    {
+      delete m_build_worker_task_capper;
+    }
+  if (m_build_worker_job_queue)
+    {
+      delete m_build_worker_job_queue;
+    }
 #endif
 }
 
@@ -234,43 +295,70 @@ hnsw_usearch_ng::prepare_to_add (cubthread::entry *thread_p, int n_vectors, cons
 int
 hnsw_usearch_ng::add (cubthread::entry *thread_p, int n_vectors, const OID *oid, const float *vector)
 {
-
+  hnsw_build_worker_context ctx;
+  ctx.tran_index = thread_p->tran_index;
   // Push insert each vector insertion task to worker pool
 
   for (int i = 0; i < n_vectors; ++i)
     {
-#if defined (SERVER_MODE)
-      auto exec_f = std::bind (&hnsw_usearch_ng::add_vector, std::ref (*this), std::placeholders::_1, oid[i],
-			       vector + i * m_build_params.dimension, thread_p->tran_index);
-      cubthread::entry_callable_task *task = new cubthread::entry_callable_task (exec_f);
-      cubthread::get_manager()->push_task (m_worker_pool, task);
-#else
-      if (m_build_params.metric == DB_VECTOR_DISTANCE_METRIC::METRIC_COSINE
-	  && db_vector_is_all_zeros (vector + i * m_build_params.dimension, m_build_params.dimension))
+      hnsw_build_worker_job job;
+      job.m_ctx = &ctx;
+      job.m_oid = oid[i];
+      job.m_vector = vector + i * m_build_params.dimension;
+
+      if (m_build_worker_job_queue != nullptr)
 	{
-	  er_log_debug (ARG_FILE_LINE, "Vector is all zeros, skipping add");
-	  continue;
+	  ctx.m_pushed_tasks++;
+	  m_build_worker_job_queue->produce (std::move (job));
 	}
-      m_algo->add (thread_p, oid[i], vector + i * m_build_params.dimension);
-#endif
+      else
+	{
+	  this->add_internal (*thread_p, job);
+	}
     }
+
+#if defined (SERVER_MODE)
+  if (ctx.m_pushed_tasks > 0)
+    {
+      std::unique_lock<std::mutex> lock (ctx.m_mutex);
+      ctx.m_cv.wait (lock, [&ctx]
+      {
+	return ctx.m_active_tasks.load (std::memory_order_acquire) == 0;
+      });
+    }
+#endif
+
   return NO_ERROR;
 }
 
-int
-hnsw_usearch_ng::add_vector (cubthread::entry &thread_ref, const OID oid, const float *vector, const int tran_index)
+void
+hnsw_usearch_ng::add_internal (cubthread::entry &thread_ref, hnsw_build_worker_job &job)
 {
-  thread_ref.tran_index = tran_index;
-
-  if (m_build_params.metric == DB_VECTOR_DISTANCE_METRIC::METRIC_COSINE
-      && db_vector_is_all_zeros (vector, m_build_params.dimension))
+  int error = NO_ERROR;
+  hnsw_build_worker_context *ctx = job.m_ctx;
+  if (ctx)
     {
-      er_log_debug (ARG_FILE_LINE, "Vector is all zeros, skipping search");
-      return NO_ERROR;
+      thread_ref.tran_index = ctx->tran_index;
+      ctx->m_active_tasks.fetch_add (1, std::memory_order_relaxed);
     }
 
-  m_algo->add (&thread_ref, oid, vector);
-  return NO_ERROR;
+  if (m_build_params.metric == DB_VECTOR_DISTANCE_METRIC::METRIC_COSINE
+      && db_vector_is_all_zeros (job.m_vector, m_build_params.dimension))
+    {
+      // Just skip if the vector is all zeros
+      error = NO_ERROR;
+    }
+  else
+    {
+      cubhnsw::add_result_t<traits> result = m_algo->add (&thread_ref, job.m_oid, job.m_vector);
+      error = result.error;
+    }
+
+  if (ctx && ctx->m_active_tasks.fetch_sub (1, std::memory_order_acq_rel) == 1)
+    {
+      std::lock_guard<std::mutex> lk (ctx->m_mutex);
+      ctx->m_cv.notify_all ();
+    }
 }
 
 int


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-152
http://jira.cubrid.org/browse/CUBVEC-154

### Purpose

This PR refactors HNSW parallel insertion to use a job queue based worker tasks. Instead of creating one task per vector insertion, the build process is restructured around a bounded, lock-free job queue with a fixed set of long-lived worker tasks.

### Implementation

- Introduced a job-queue–based worker model for HNSW build operations
- Added explicit build worker context to coordinate:
   - Transaction index propagation
   - Active task counting
   - Completion synchronization using condition variables
- Replaced per-insertion task allocation with pre-created reusable worker tasks, reducing task creation overhead
- Capped the build worker count (currently up to 16) to avoid excessive thread contention.
- Simplified insertion logic by consolidating shared logic into add_internal().

### Remarks

N/A
