### PR TITLE
[CBRD-26520] restore next field of a SP call node in the XASL conversion function (#6805)

### DIFF
--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -7606,7 +7606,6 @@ pt_to_regu_variable (PARSER_CONTEXT * parser, PT_NODE * node, UNBOX unbox)
 		    {
 		      PT_ERRORc (parser, node, er_msg ());
 		    }
-		  return regu;
 		}
 	      break;
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26520>

### Purpose

develop 브랜치에 적용했던 변경을 그대로 cherry-pick 했습니다. 