### PR TITLE
[CBRD-26534] trucate bug fix

### DIFF
--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -3970,6 +3970,27 @@ classobj_find_cons_primary_key (SM_CLASS_CONSTRAINT * cons_list)
 }
 
 /*
+ * classobj_find_cons_replication_key()
+ *   return: constraint
+ *   cons_list(in):
+ */
+SM_CLASS_CONSTRAINT *
+classobj_find_cons_replication_key (SM_CLASS_CONSTRAINT * cons_list)
+{
+  SM_CLASS_CONSTRAINT *cons = NULL;
+
+  for (cons = cons_list; cons; cons = cons->next)
+    {
+      if (IS_HA_REPLICATION_KEY_CONSTRAINT (cons))
+	{
+	  break;
+	}
+    }
+
+  return cons;
+}
+
+/*
  * classobj_find_class_primary_key()
  *   return: constraint
  *   class(in):

--- a/src/object/class_object.h
+++ b/src/object/class_object.h
@@ -1136,6 +1136,7 @@ extern int classobj_count_cons_attributes (SM_CLASS_CONSTRAINT * cons);
 #endif
 
 extern SM_CLASS_CONSTRAINT *classobj_find_cons_primary_key (SM_CLASS_CONSTRAINT * cons_list);
+extern SM_CLASS_CONSTRAINT *classobj_find_cons_replication_key (SM_CLASS_CONSTRAINT * cons_list);
 
 extern const char *classobj_map_constraint_to_property (SM_CONSTRAINT_TYPE constraint);
 extern char *classobj_describe_foreign_key_action (SM_FOREIGN_KEY_ACTION action);

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -371,7 +371,7 @@ truncate_need_repl_log (PT_NODE * statement)
 	  return false;
 	}
 
-      cons = classobj_find_cons_primary_key (class_->constraints);
+      cons = classobj_find_cons_replication_key (class_->constraints);
       if (cons != NULL)
 	{
 	  return true;


### PR DESCRIPTION

[<http://jira.cubrid.org/browse/CBRD-26534>](http://jira.cubrid.org/browse/CBRD-26534)

### Purpose

not null unique 를 이용한 복제 테이블에서 
truncate 가 슬레이브에 반영되지 않는 버그를 수정합니다.

### Implementation

DML은 do_execute_statement() 함수 내부에서 해당 DDL을 수행하고나서 
do_replicate_statement() 함수를 통해 복제 로그를 생성합니다.
이 함수 내부에서 PT_TRUNCATE의 경우 다시 truncate_need_repl_log() 함수를 호출해 
PK가 존재하는지 확인하고, PK가 존재한다면 복제 로그를 생성하는데, 
이 부분을 RK가 존재하면 복제로그를 생성하도록 변경하였습니다.

### Remarks
