### PR TITLE
[CBRD-26352] OOS bugfix - data_readval with COPY when oos column

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -10748,6 +10748,13 @@ heap_attrvalue_read (RECDES * recdes, HEAP_ATTRVALUE * value, HEAP_CACHE_ATTRINF
 
   /* the data pointer will point to either a current value in recdes or a default one in attrepr */
   error = heap_attrvalue_transform_to_dbvalue (value, attrepr, &raw, is_oos);
+  // TODO: heap_attrvalue_transform_to_dbvalue() used to PEEK &raw when creating value (dbvalue),
+  // but oos_insert() makes &raw point to newly allocated memory.
+  // Thus,
+  // 1) we need to free &raw only when is_oos is true.
+  // 2) we need to create dbvalue with mr_data_readval...(...COPY).
+  // This can be refactored later when dbvalue supports zero-copy to OOS data.
+  // oos_insert(OID) must be refactored to oos_read(PAGE_PTR, slotid, PEEK/COPY) and allow PEEK mode.
   if (is_oos)
     {
       recdes_free_data_area (&raw);

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -700,7 +700,8 @@ static void heap_attrvalue_point_fixed (RECDES * recdes, HEAP_CACHE_ATTRINFO * a
 					RECDES * raw);
 static void heap_attrvalue_point_variable (RECDES * recdes, HEAP_CACHE_ATTRINFO * attr_info, OR_ATTRIBUTE * attrepr,
 					   RECDES * raw, bool * is_oos);
-static int heap_attrvalue_transform_to_dbvalue (HEAP_ATTRVALUE * value, OR_ATTRIBUTE * attrepr, RECDES * raw);
+static int heap_attrvalue_transform_to_dbvalue (HEAP_ATTRVALUE * value, OR_ATTRIBUTE * attrepr, RECDES * raw,
+						bool is_oos);
 static int heap_attrvalue_read (RECDES * recdes, HEAP_ATTRVALUE * value, HEAP_CACHE_ATTRINFO * attr_info);
 
 static int heap_midxkey_get_value (RECDES * recdes, OR_ATTRIBUTE * att, DB_VALUE * value,
@@ -10643,7 +10644,7 @@ heap_attrvalue_point_variable (RECDES * recdes, HEAP_CACHE_ATTRINFO * attr_info,
  *
  */
 static int
-heap_attrvalue_transform_to_dbvalue (HEAP_ATTRVALUE * value, OR_ATTRIBUTE * attrepr, RECDES * raw)
+heap_attrvalue_transform_to_dbvalue (HEAP_ATTRVALUE * value, OR_ATTRIBUTE * attrepr, RECDES * raw, bool is_oos)
 {
   const PR_TYPE *pr_type;
   OR_BUF buf;
@@ -10676,7 +10677,7 @@ heap_attrvalue_transform_to_dbvalue (HEAP_ATTRVALUE * value, OR_ATTRIBUTE * attr
       pr_type = pr_type_from_id (attrepr->type);
       if (pr_type)
 	{
-	  rv = pr_type->data_readval (&buf, &value->dbvalue, attrepr->domain, raw->length, false, NULL, 0);
+	  rv = pr_type->data_readval (&buf, &value->dbvalue, attrepr->domain, raw->length, is_oos, NULL, 0);
 	}
       value->state = HEAP_READ_ATTRVALUE;
       if (rv != NO_ERROR)
@@ -10746,7 +10747,7 @@ heap_attrvalue_read (RECDES * recdes, HEAP_ATTRVALUE * value, HEAP_CACHE_ATTRINF
     }
 
   /* the data pointer will point to either a current value in recdes or a default one in attrepr */
-  error = heap_attrvalue_transform_to_dbvalue (value, attrepr, &raw);
+  error = heap_attrvalue_transform_to_dbvalue (value, attrepr, &raw, is_oos);
   if (is_oos)
     {
       recdes_free_data_area (&raw);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26352>

### Purpose

기존 transform_to_dbvalue 함수는 dbvalue 를 생성할 때,
COPY 인자가 false 이기 때문에 OR_BUF가 주어지면 이를 재활용하였다.

OOS 에서는 OOS recdes 가 따로 생성되고 이는 곧 해제되기 때문에,
dbvalue 를 생성할 때 이를 재활용해서는 안된다.

따라서 is_oos 일 경우에는 COPY를 true로 바꿔줘야 한다.

with help of @hgryoo, @hyahong 

### Implementation

<img width="1084" height="228" alt="image" src="https://github.com/user-attachments/assets/72f8e45e-c49a-4144-81fb-c3d7ff86f1c2" />

is_oos 일 경우 COPY = true

### Remarks

#### 테스트 SQL 
```sql
drop if exists tbl;

create table tbl (id int, vc varchar, vc2 varchar);

insert into tbl values (1, REPEAT('abcde', 200), REPEAT('12345', 200));

select * from tbl;

select vc2, vc from tbl;
```

#### 결과

결과 해석: before fix 에서는 select 결과가 잘못 출력된다.

##### before fix

<img width="1840" height="1568" alt="image" src="https://github.com/user-attachments/assets/20f0c202-49a7-4720-916d-bed752c94bef" />


##### after fix

<img width="1890" height="1778" alt="image" src="https://github.com/user-attachments/assets/f914b919-844c-434f-8040-7e045729792c" />
