### PR TITLE
[CUBVEC-163] Eliminate unnecessary disk space used by OpenSSL and HDF5 libraries

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -557,6 +557,7 @@ if(WITH_HDF STREQUAL "EXTERNAL")
   else()
     set(HDF_INCLUDES ${3RDPARTY_LIBS_DIR}/include)
     set(HDF_LIBS ${3RDPARTY_LIBS_DIR}/lib/libhdf5.a)
+    set(HDF_CONFIGURE_OPTS --enable-static --disable-shared --disable-tests --disable-tools --disable-hl --disable-cxx --disable-fortran --disable-parallel --without-zlib --without-szlib)
 
     ADD_BY_PRODUCTS_VARIABLE ("HDF" ${HDF_LIBS})
     externalproject_add(${HDF_TARGET}
@@ -564,9 +565,10 @@ if(WITH_HDF STREQUAL "EXTERNAL")
       TIMEOUT               600
       LOG_BUILD             TRUE
       DOWNLOAD_NO_PROGRESS  1
-      CONFIGURE_COMMAND     ${DEFAULT_CONFIGURE_OPTS}
-      BUILD_IN_SOURCE       true
+      CONFIGURE_COMMAND     <SOURCE_DIR>/configure --prefix=${3RDPARTY_LIBS_DIR} ${HDF_CONFIGURE_OPTS}
+      BUILD_IN_SOURCE       false
       BUILD_COMMAND         make CFLAGS=-fPIC CXXFLAGS=-fPIC # to allow static linking in shared library
+      INSTALL_COMMAND       make install && rm -rf <SOURCE_DIR>
       "${HDF_BYPRODUCTS}"
     )
 

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -384,6 +384,9 @@ if(WITH_LIBOPENSSL STREQUAL "EXTERNAL")
     #e.g. https://www.openssl.org/source/openssl-1.1.1f.tar.gz
     set(LIBOPENSSL_LIBS ${3RDPARTY_LIBS_DIR}/lib/libssl.a ${3RDPARTY_LIBS_DIR}/lib/libcrypto.a)
     set(LIBOPENSSL_INCLUDES ${3RDPARTY_LIBS_DIR}/include)
+
+    set(LIBOPENSSL_CONFIGURE_OPTS_PATENT_ALGOS no-idea no-md2 no-mdc2 no-rc5 no-rc4)
+    set(LIBOPENSSL_CONFIGURE_OPTS_REDUNDANTS no-tests no-ui-console no-comp no-ssl3 no-zlib no-engine no-dso no-async)
     ADD_BY_PRODUCTS_VARIABLE ("LIBOPENSSL" ${LIBOPENSSL_LIBS})
     externalproject_add(${LIBOPENSSL_TARGET}
       URL                  ${WITH_LIBOPENSSL_URL}
@@ -393,9 +396,9 @@ if(WITH_LIBOPENSSL STREQUAL "EXTERNAL")
       LOG_INSTALL          TRUE
       TIMEOUT              600
       DOWNLOAD_NO_PROGRESS 1
-      CONFIGURE_COMMAND    <SOURCE_DIR>/config --prefix=${3RDPARTY_LIBS_DIR} no-shared # ${DEFAULT_CONFIGURE_OPTS}
-      BUILD_COMMAND        make all AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
-      INSTALL_COMMAND      make install_sw AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
+      CONFIGURE_COMMAND    <SOURCE_DIR>/config no-shared ${LIBOPENSSL_CONFIGURE_OPTS_REDUNDANTS} ${LIBOPENSSL_CONFIGURE_OPTS_PATENT_ALGOS} --prefix=${3RDPARTY_LIBS_DIR} # ${DEFAULT_CONFIGURE_OPTS}
+      BUILD_COMMAND        make build_libs AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
+      INSTALL_COMMAND      make install_dev AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
       "${LIBOPENSSL_BYPRODUCTS}"
       )
     list(APPEND EP_TARGETS ${LIBOPENSSL_TARGET})


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-163

### Purpose

- OpenSSL의 빌드 폴더의 테스트 파일 등 필요없는 부분 제거
- HDF5의 테스트와 도구 제거

### Implementation

- OpenSSL과 HDF5의 configuration option 수정
- HDF5 빌드 후 소스 폴더 제거

### Remarks

OpenSSL
- AS-IS: 빌드 폴더 (412.5MB), 소스폴더 (49.8MB)
- TO-BE: 빌드 폴더 (21.5MB), 소스 폴더 (49.9MB)
약 391MB 제거

HDF5
- AS-IS: 빌드 폴더 (39.5MB), 소스폴더 (848.7MB)
- TO-BE: 빌드 폴더 (39.5MB), 소스 폴더 (0MB)
약 848 MB 제거