### PR TITLE
[CUBVEC-165] Replace unordered_set with ankerl::unordered_dense::set

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -35,7 +35,8 @@ set(WIN_FLEX_BISON_URL "https://github.com/CUBRID/3rdparty/raw/develop/win_flex_
 set(WITH_FAISS_URL "https://github.com/facebookresearch/faiss/archive/refs/tags/v1.8.0.tar.gz")               # Faiss
 set(WITH_OPENBLAS_URL "https://github.com/xianyi/OpenBLAS/archive/refs/tags/v0.3.24.tar.gz")                  # OpenBLAS
 set(WITH_LAPACK_URL "http://www.netlib.org/lapack/lapack-3.11.0.tar.gz")                                      # LAPACK
-set(WITH_USEARCH_URL "https://github.com/unum-cloud/usearch")                                                 # usearch
+set(WITH_USEARCH_URL "https://github.com/unum-cloud/usearch")                   
+set(WITH_ANKERL_URL "https://github.com/martinus/unordered_dense.git")                              # usearch
 
 # URL_HASH is a hash value used to verify the integrity of a file downloaded from a specified URL.
 # It is optional but highly recommended to set this value. If not set, the file will be downloaded
@@ -87,6 +88,7 @@ set(WITH_ZLIB         "${WITH_EXTERNAL_PREFIX}" CACHE STRING "Build with ZLIB li
 set(WITH_HIGHFIVE     "${WITH_EXTERNAL_PREFIX}" CACHE STRING "Build with HIGHFIVE library (default: EXTERNAL)")
 set(WITH_FAISS        "${WITH_EXTERNAL_PREFIX}" CACHE STRING "Build with Faiss library (default: EXTERNAL)")
 set(WITH_USEARCH      "${WITH_EXTERNAL_PREFIX}" CACHE STRING "Build with usearch library (default: EXTERNAL)")
+set(WITH_ANKERL       "${WITH_EXTERNAL_PREFIX}" CACHE STRING "Build with ankerl::unordered_dense (default: EXTERNAL)")
 
 message(STATUS "Build with flex and bison library: ${WITH_LIBFLEXBISON}")
 message(STATUS "Build with expat library: ${WITH_LIBEXPAT}")
@@ -102,6 +104,7 @@ message(STATUS "Build with ZLIB library: ${WITH_ZLIB}")
 message(STATUS "Build with HighFive library: ${WITH_HIGHFIVE}")
 message(STATUS "Build with Faiss library: ${WITH_FAISS}")
 message(STATUS "Build with usearch library: ${WITH_USEARCH}")
+message(STATUS "Build with ankerl::unordered_dense library: ${WITH_ANKERL}")
 
 macro(ADD_BY_PRODUCTS_VARIABLE prefix_dependee)
   if (CMAKE_GENERATOR MATCHES "Ninja")
@@ -716,6 +719,20 @@ set(USEARCH_USE_FP16LIB ON CACHE BOOL "" FORCE)
 FetchContent_Declare(usearch GIT_REPOSITORY https://github.com/unum-cloud/usearch.git GIT_TAG v2.17.8)
 FetchContent_MakeAvailable(usearch)
 
+# ankerl::unordered_dense (header-only)
+if(WITH_ANKERL STREQUAL "EXTERNAL")
+  FetchContent_Declare(
+    ankerl_unordered_dense
+    GIT_REPOSITORY ${WITH_ANKERL_URL}
+    GIT_TAG v4.8.1
+  )
+  FetchContent_MakeAvailable(ankerl_unordered_dense)
+
+  set(ANKERL_INCLUDES
+      ${ankerl_unordered_dense_SOURCE_DIR}/include)
+
+  list(APPEND EP_INCLUDES ${ANKERL_INCLUDES})
+endif()
 
 # [FIXME!] Expose variables for other CMakeLists
 set (EP_TARGETS ${EP_TARGETS} PARENT_SCOPE)

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -35,8 +35,8 @@ set(WIN_FLEX_BISON_URL "https://github.com/CUBRID/3rdparty/raw/develop/win_flex_
 set(WITH_FAISS_URL "https://github.com/facebookresearch/faiss/archive/refs/tags/v1.8.0.tar.gz")               # Faiss
 set(WITH_OPENBLAS_URL "https://github.com/xianyi/OpenBLAS/archive/refs/tags/v0.3.24.tar.gz")                  # OpenBLAS
 set(WITH_LAPACK_URL "http://www.netlib.org/lapack/lapack-3.11.0.tar.gz")                                      # LAPACK
-set(WITH_USEARCH_URL "https://github.com/unum-cloud/usearch")                   
-set(WITH_ANKERL_URL "https://github.com/martinus/unordered_dense.git")                              # usearch
+set(WITH_USEARCH_URL "https://github.com/unum-cloud/usearch")                                                # usearch
+set(WITH_ANKERL_URL "https://github.com/martinus/unordered_dense.git")                                 # ankerl
 
 # URL_HASH is a hash value used to verify the integrity of a file downloaded from a specified URL.
 # It is optional but highly recommended to set this value. If not set, the file will be downloaded

--- a/src/storage/index_hnsw/hnsw_algo.hpp
+++ b/src/storage/index_hnsw/hnsw_algo.hpp
@@ -194,6 +194,9 @@ namespace cubhnsw
     // pre-reserve top_for_refine
     context.m_top_for_refine.reserve (connectivity_max);
 
+    // pre-reserve for visits
+    context.m_visits.reserve (connectivity_max);
+
     top_candidates_t<Traits> &top = context.m_top_candidates;
     next_candidates_t<Traits> &next = context.m_next_candidates;
 
@@ -329,6 +332,11 @@ namespace cubhnsw
     next_candidates_t<Traits> &next = context.m_next_candidates;
 
     std::size_t expansion_size = std::max (k, expansion);
+
+    // pre-reserve for visits
+    context.m_visits.reserve (expansion_size);
+
+    // pre-reserve for top and next
     if (!top.reserve (expansion_size) || !next.reserve (expansion_size))
       {
 	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, expansion_size * sizeof (candidate_t<Traits>));
@@ -417,14 +425,10 @@ namespace cubhnsw
 	  {
 	    slot_id_t successor_slot = candidate_neighbors.at (i);
 
-	    bool already_visited = (visits.find (successor_slot) != visits.end());
-	    if (already_visited)
+	    auto [it, inserted] = visits.insert (successor_slot);
+	    if (!inserted)
 	      {
 		continue;
-	      }
-	    else
-	      {
-		visits.insert (successor_slot);
 	      }
 
 	    distance_t sucessor_dist = compute_distance_from_query_ (context, query, successor_slot);

--- a/src/storage/index_hnsw/hnsw_algo_common.hpp
+++ b/src/storage/index_hnsw/hnsw_algo_common.hpp
@@ -24,6 +24,7 @@
 #define _HNSW_ALGO_COMMON_HPP_
 
 #include <random>
+#include <ankerl/unordered_dense.h>
 
 #include "hnsw_api.hpp"
 #include "hnsw_graph_base.hpp"
@@ -59,45 +60,35 @@ namespace cubhnsw
     }
   };
 
-
   struct oid_hash
   {
-    std::size_t operator() (const OID &o) const noexcept
+    inline std::size_t operator()(const OID &o) const noexcept
     {
-      std::size_t h = 0;
-      auto mix = [&h] (auto v)
-      {
-	std::size_t x = std::hash<std::decay_t<decltype (v)>> {} (v);
-	h ^= x + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
-      };
-
-      mix (o.volid);
-      mix (o.pageid);
-      mix (o.slotid);
-      return h;
+      // bit packing of oid
+      return (uint64_t(uint32_t(o.pageid)) << 32)
+           | (uint64_t(uint16_t(o.slotid)) << 16)
+           |  uint64_t(uint16_t(o.volid));
     }
   };
 
   struct oid_equal
   {
-    bool operator() (const OID &a, const OID &b) const noexcept
+    inline bool operator() (const OID &a, const OID &b) const noexcept
     {
-      return a.pageid == b.pageid
-	     && a.slotid == b.slotid
-	     && a.volid == b.volid;
+      return memcmp (&a, &b, sizeof (OID)) == 0;
     }
   };
 
   template <typename T>
   struct visit_set_helper
   {
-    using type = std::unordered_set<T>;
+    using type = ankerl::unordered_dense::set<T>;
   };
 
   template <>
   struct visit_set_helper<OID>
   {
-    using type = std::unordered_set<OID, oid_hash, oid_equal>;
+    using type = ankerl::unordered_dense::set<OID, oid_hash, oid_equal>;
   };
 
   template <typename Traits>

--- a/src/storage/index_hnsw/hnsw_algo_common.hpp
+++ b/src/storage/index_hnsw/hnsw_algo_common.hpp
@@ -62,12 +62,12 @@ namespace cubhnsw
 
   struct oid_hash
   {
-    inline std::size_t operator()(const OID &o) const noexcept
+    inline std::size_t operator() (const OID &o) const noexcept
     {
       // bit packing of oid
-      return (uint64_t(uint32_t(o.pageid)) << 32)
-           | (uint64_t(uint16_t(o.slotid)) << 16)
-           |  uint64_t(uint16_t(o.volid));
+      return (uint64_t (uint32_t (o.pageid)) << 32)
+	     | (uint64_t (uint16_t (o.slotid)) << 16)
+	     |  uint64_t (uint16_t (o.volid));
     }
   };
 

--- a/src/storage/index_hnsw/hnsw_algo_common.hpp
+++ b/src/storage/index_hnsw/hnsw_algo_common.hpp
@@ -75,7 +75,7 @@ namespace cubhnsw
   {
     inline bool operator() (const OID &a, const OID &b) const noexcept
     {
-      return memcmp (&a, &b, sizeof (OID)) == 0;
+      return a.pageid == b.pageid && a.slotid == b.slotid && a.volid == b.volid;
     }
   };
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-165

### Purpose

During HNSW index construction on the nytimes-256-angular dataset, flamegraph analysis revealed a significant performance bottleneck in the std::unordered_set used to track visited nodes during neighbor traversal.
The overhead originates from frequent hash operations, poor cache locality, and allocator pressure in this hot path.

This PR aims to reduce the traversal overhead by replacing the STL hash set with a higher-performance alternative better library

### Implementation

- Added the ankerl hash container library to 3rdparty.
- Replaced the std::unordered_set used for visited_nodes in HNSW neighbor exploration with ankerl::unordered_dense::set.

### Remarks

N/A
