### PR TITLE
[CBRD-26544] Align enum and string pairs in the schema_type.

### DIFF
--- a/src/broker/cas_util.c
+++ b/src/broker/cas_util.c
@@ -151,7 +151,8 @@ static const char *schema_type_str[] = {
   "PRIMARY_KEY",
   "IMPORTED_KEYS",
   "EXPORTED_KEYS",
-  "CROSS_REFERENCE"
+  "CROSS_REFERENCE",
+  "ATTR_WITH_SYNONYM"
 };
 
 static const char *tran_type_str[] = { "COMMIT", "ROLLBACK" };


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26544>

### Purpose

CCI에서 schema 정보를 가져올 때 enum과 enum에 대한 string array가 일치하지 않아 에러가 발생합니다.

### Implementation

N/A

### Remarks

N/A
