### PR TITLE
[CBRD-26545] #2. copy all transaction logs from master 에서 copylogdb명령어 원복

### DIFF
--- a/contrib/scripts/ha/ha_make_slavedb.sh
+++ b/contrib/scripts/ha/ha_make_slavedb.sh
@@ -893,7 +893,7 @@ function copy_active_log_from_master()
 
 	# 2. copy all transaction logs from master.
 	echo -ne "\n - 2. copy all transaction logs from master.\n\n"
-	execute "cubrid copylogdb -L ${repl_log_path} -m async --start-page-id=-1 ${db_name}@${master_host}"
+	execute "cub_admin copylogdb -L ${repl_log_path} -m async --start-page-id=-1 ${db_name}@${master_host}"
 }
 
 function show_complete()


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26545>

### Purpose
copylogdb명령어를 cubrid 에서 cub_admin으로 원복합니다.

### Implementation

--2. copy all transaction logs from master.
echo -ne "\n - 2. copy all transaction logs from master.\n\n"
execute "cub_admin copylogdb -L ${repl_log_path} -m async --start-page-id=-1 ${db_name}@${master_host}"

### Remarks
명령어 일관성 때문에 cub_admin을 cubrid로 변경하려 했는데 오류가 있었습니다.
또한 명령어 에러 처리를 하지 않아 수행된 것으로 판명되었습니다.
