### PR TITLE
[CBRD-26547] Support OOS in Covered Index (midxkey)

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -10770,12 +10770,12 @@ heap_attrvalue_read (RECDES * recdes, HEAP_ATTRVALUE * value, HEAP_CACHE_ATTRINF
 static int
 heap_midxkey_get_value (RECDES * recdes, OR_ATTRIBUTE * att, DB_VALUE * value, HEAP_CACHE_ATTRINFO * attr_info)
 {
-  char *disk_data = NULL;
+  RECDES raw = { -1, -1, REC_UNKNOWN, NULL };
+  bool is_oos = false;
   bool found = true;		/* Does attribute(att) exist in this disk representation? */
   int i;
 
   /* Initialize disk value information */
-  disk_data = NULL;
   db_make_null (value);
 
   if (recdes != NULL && recdes->data != NULL && att != NULL)
@@ -10798,9 +10798,10 @@ heap_midxkey_get_value (RECDES * recdes, OR_ATTRIBUTE * att, DB_VALUE * value, H
 	{
 	  /* It means that the representation has an attribute which was created after insertion of the record. In this
 	   * case, return the default value of the attribute if it exists. */
-	  if (att->default_value.val_length > 0)
+	  raw.length = att->default_value.val_length;
+	  if (raw.length > 0)
 	    {
-	      disk_data = (char *) att->default_value.value;
+	      raw.data = (char *) att->default_value.value;
 	    }
 	}
       else
@@ -10808,23 +10809,11 @@ heap_midxkey_get_value (RECDES * recdes, OR_ATTRIBUTE * att, DB_VALUE * value, H
 	  /* Is it a fixed size attribute ? */
 	  if (att->is_fixed != 0)
 	    {			/* A fixed attribute.  */
-	      if (!OR_FIXED_ATT_IS_UNBOUND (recdes->data, attr_info->read_classrepr->n_variable,
-					    attr_info->read_classrepr->fixed_length, att->position))
-		{
-		  /* The fixed attribute is bound. Access its information */
-		  disk_data =
-		    ((char *) recdes->data +
-		     OR_FIXED_ATTRIBUTES_OFFSET_BY_OBJ (recdes->data,
-							attr_info->read_classrepr->n_variable) + att->location);
-		}
+	      heap_attrvalue_point_fixed (recdes, attr_info, att, &raw);
 	    }
 	  else
 	    {			/* A variable attribute */
-	      if (!OR_VAR_IS_NULL (recdes->data, att->location))
-		{
-		  /* The variable attribute is bound. Find its location through the variable offset attribute table. */
-		  disk_data = ((char *) recdes->data + OR_VAR_OFFSET (recdes->data, att->location));
-		}
+	      heap_attrvalue_point_variable (recdes, attr_info, att, &raw, &is_oos);
 	    }
 	}
     }
@@ -10834,12 +10823,17 @@ heap_midxkey_get_value (RECDES * recdes, OR_ATTRIBUTE * att, DB_VALUE * value, H
       return ER_FAILED;
     }
 
-  if (disk_data != NULL)
+  if (raw.data != NULL)
     {
       OR_BUF buf;
 
-      or_init (&buf, disk_data, -1);
-      att->domain->type->data_readval (&buf, value, att->domain, -1, false, NULL, 0);
+      or_init (&buf, raw.data, raw.length);
+      att->domain->type->data_readval (&buf, value, att->domain, raw.length, is_oos, NULL, 0);
+    }
+
+  if (is_oos)
+    {
+      recdes_free_data_area (&raw);
     }
 
   return NO_ERROR;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26547

### Purpose

현재 covered index (midxkey) 에서는 OOS 값을 읽어올 수 없다.
midxkey 생성 시 OOS OID 대신 OOS 값을 넣도록 개선한다.


### Implementation

heap_midxkey_get_value 함수는 현재 (예찬님이 리팩토링한) heap_attrvalue_point_variable() 함수로 되어 있지 않고 직접
OR_FIXED_ATTRIBUTES_OFFSET_BY_OBJ () 매크로를 통해 접근하는 방식으로 raw하게 구현되어 있다.

이를 heap_attrvalue_point_variable() 함수를 사용해 현대적인 방법으로 개선한다.

OOS에서는 heap_attrvalue_point_value() 함수 내부에서 IS_OOS를 값으로 바꿔주므로 이를 통해 midxkey 또한 OOS 값을 담도록 개선할 수 있다.

### Remarks

### How to Reproduce

disable string compression.

```sql
drop if exists tbl;
create table tbl (id int, vc varchar);
create index vc_idx on tbl (id, vc);
insert into tbl (id, vc) values (1, REPEAT('abcdeabcde', 200));

-- can read oos
select id, vc from tbl;

-- cannot read oos, empty result
select id, vc from tbl where id >= 0;
```

AS-IS

<img width="1894" height="813" alt="image" src="https://github.com/user-attachments/assets/044d4efd-7709-426c-ba5e-2eeb84d6239e" />

select id, vc from tbl where id > 0;
쿼리의 경우, vc 가 ''으로 빈 string 값이 나온다.

TO-BE

값이 정상적으로 잘 나온다.