### PR TITLE
[CBRD-26554] set correct language for built-in stored procedures

### DIFF
--- a/src/sp/sp_catalog.cpp
+++ b/src/sp/sp_catalog.cpp
@@ -98,7 +98,7 @@ static int sp_builtin_init ()
   db_sys_datetime (&current_datetime);
 
   // common
-  v.lang = SP_LANG_PLCSQL;
+  v.lang = SP_LANG_JAVA;
   v.is_system_generated = true;
   v.directive = SP_DIRECTIVE_RIGHTS_OWNER;
   v.owner = Au_public_user;


### PR DESCRIPTION
[<http://jira.cubrid.org/browse/CBRD-26554>
](http://jira.cubrid.org/browse/CBRD-26554)

### Purpose
dbms_output 패키지에 구현된 SP(stored procedure)는 현재 Java로 구현되어 있습니다.(DBMS_OUTPUT.java 참고)
따라서 _db_stored_procedure.lang 의 값은 1(JAVA) 가 나와야 하는데 0(PLCSQL)로 출력되고 있습니다.
따라서 이를 올바른 값으로 수정합니다.