### PR TITLE
[CBRD-26555] remove query entry in pl_executor when the result has no records

### DIFF
--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -6991,7 +6991,8 @@ qfile_update_qlist_count (THREAD_ENTRY * thread_p, const QFILE_LIST_ID * list_p,
 
   if (prm_get_bool_value (PRM_ID_LOG_QUERY_LISTS))
     {
-      er_print_callstack (ARG_FILE_LINE, "update qlist_count by %d to %d\n", inc, main_thread_p->m_qlist_count.load ());
+      er_print_callstack (ARG_FILE_LINE, "[thread %d with tran index %d] update qlist_count by %d to %d\n",
+			  main_thread->index, main_thread->tran_index, inc, main_thread_p->m_qlist_count.load ());
     }
 #endif // SERVER_MODE
 }

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -6992,7 +6992,7 @@ qfile_update_qlist_count (THREAD_ENTRY * thread_p, const QFILE_LIST_ID * list_p,
   if (prm_get_bool_value (PRM_ID_LOG_QUERY_LISTS))
     {
       er_print_callstack (ARG_FILE_LINE, "[thread %d with tran index %d] update qlist_count by %d to %d\n",
-			  main_thread->index, main_thread->tran_index, inc, main_thread_p->m_qlist_count.load ());
+			  main_thread_p->index, main_thread_p->tran_index, inc, main_thread_p->m_qlist_count.load ());
     }
 #endif // SERVER_MODE
 }

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -16188,7 +16188,9 @@ qexec_execute_query (THREAD_ENTRY * thread_p, xasl_node * xasl, int dbval_cnt, c
   qlist_enter_count = thread_p->m_qlist_count.load ();
   if (prm_get_bool_value (PRM_ID_LOG_QUERY_LISTS))
     {
-      er_print_callstack (ARG_FILE_LINE, "starting query execution with qlist_count = %d\n", qlist_enter_count);
+      er_print_callstack (ARG_FILE_LINE,
+			  "[thread %d with tran index %d] starting query execution with qlist_count = %d\n",
+			  thread_p->index, thread_p->tran_index, qlist_enter_count);
     }
 #endif // SERVER_MODE
 
@@ -16345,8 +16347,9 @@ end:
 #if defined (SERVER_MODE)
   if (prm_get_bool_value (PRM_ID_LOG_QUERY_LISTS))
     {
-      er_print_callstack (ARG_FILE_LINE, "ending query execution with qlist_count = %d\n",
-			  thread_p->m_qlist_count.load ());
+      er_print_callstack (ARG_FILE_LINE,
+			  "[thread %d with tran index %d] ending query execution with qlist_count = %d\n",
+			  thread_p->index, thread_p->tran_index, thread_p->m_qlist_count.load ());
     }
   if (list_id && list_id->type_list.type_cnt != 0)
     {

--- a/src/sp/pl_executor.cpp
+++ b/src/sp/pl_executor.cpp
@@ -34,6 +34,7 @@
 #include "pl_comm.h"
 #include "pl_query_cursor.hpp"
 #include "sp_code.hpp"
+#include "xserver_interface.h"
 
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
 #include "memory_wrapper.hpp"
@@ -706,10 +707,31 @@ exit:
 	  int stmt_type = current_result_info.stmt_type;
 	  if (stmt_type == CUBRID_STMT_SELECT)
 	    {
-	      int hid = info.handle_id;
 	      std::uint64_t qid = current_result_info.query_id;
-	      bool is_oid_included = current_result_info.include_oid;
-	      (void) m_stack->add_cursor (hid, qid, is_oid_included);
+	      if (current_result_info.tuple_count > 0)
+		{
+		  int hid = info.handle_id;
+		  bool is_oid_included = current_result_info.include_oid;
+		  (void) m_stack->add_cursor (hid, qid, is_oid_included);
+		}
+	      else
+		{
+		  QMGR_QUERY_ENTRY *query_entry = qmgr_get_query_entry (&thread_ref, qid, NULL_TRAN_INDEX);
+		  if (query_entry)
+		    {
+		      if (query_entry->list_id)
+			{
+			  qfile_update_qlist_count (&thread_ref, query_entry->list_id, 1);        // required?
+			  qfile_close_list (&thread_ref, query_entry->list_id);
+			}
+		      else
+			{
+			  ; // no data, no list?
+			}
+		    }
+
+		  xqmgr_end_query (&thread_ref, qid);
+		}
 	    }
 	}
 

--- a/src/sp/pl_executor.cpp
+++ b/src/sp/pl_executor.cpp
@@ -721,12 +721,8 @@ exit:
 		    {
 		      if (query_entry->list_id)
 			{
-			  qfile_update_qlist_count (&thread_ref, query_entry->list_id, 1);        // required?
+			  qfile_update_qlist_count (&thread_ref, query_entry->list_id, 1);
 			  qfile_close_list (&thread_ref, query_entry->list_id);
-			}
-		      else
-			{
-			  ; // no data, no list?
 			}
 		    }
 

--- a/src/sp/pl_executor.cpp
+++ b/src/sp/pl_executor.cpp
@@ -719,11 +719,11 @@ exit:
 		  QMGR_QUERY_ENTRY *query_entry = qmgr_get_query_entry (&thread_ref, qid, NULL_TRAN_INDEX);
 		  if (query_entry)
 		    {
-		      if (query_entry->list_id)
-			{
-			  qfile_update_qlist_count (&thread_ref, query_entry->list_id, 1);
-			  qfile_close_list (&thread_ref, query_entry->list_id);
-			}
+		      // Since the list was not created in this thread,
+		      // incrementing the count of the list (m_qlist_count) is required
+		      // to make the assertion on m_qlist_count in qexec_execute_query() hold
+		      qfile_update_qlist_count (&thread_ref, query_entry->list_id, 1);
+		      qfile_close_list (&thread_ref, query_entry->list_id);
 		    }
 
 		  xqmgr_end_query (&thread_ref, qid);

--- a/src/sp/pl_query_cursor.cpp
+++ b/src/sp/pl_query_cursor.cpp
@@ -96,10 +96,11 @@ namespace cubpl
 	    m_query_entry = qmgr_get_query_entry (m_thread, m_query_id, tran_index);
 	  }
 
-	if (m_query_entry && m_query_entry->list_id)
+	if (m_query_entry)
 	  {
 	    // Since the list was not created in this thread,
 	    // incrementing the count of the list (m_qlist_count) is required
+	    // to make the assertion on m_qlist_count in qexec_execute_query() hold
 	    qfile_update_qlist_count (m_thread, m_query_entry->list_id, 1);
 	    qfile_close_list (m_thread, m_query_entry->list_id);
 	  }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26555>

### Purpose

SP에서 SELECT 문의 실행 결과가 zero records 일 때, query entry 가 삭제되지 않고 남게되는 문제 해결.

### Implementation

SP의 SELECT 문 실행 결과가 zero records 일 때, execute 단계에서 미리 query entry 를 삭제.

### Remarks

