### PR TITLE
[CUBVEC-167] Cache vectors for caculating distances without unnecessary page fix.

### DIFF
--- a/src/storage/index_hnsw/hnsw_algo.hpp
+++ b/src/storage/index_hnsw/hnsw_algo.hpp
@@ -105,25 +105,33 @@ namespace cubhnsw
 	return metric_table[static_cast<size_t> (m_metric)] (v1, v2, m_dimension);
       }
 
+      // Returns pointer to vector for slot, using algo's cache to avoid repeated page fix/unfix.
+      inline const float *get_vector_cached_ (algo_context_t<Traits> &context, const slot_id_t &slot) const
+      {
+	auto it = m_vector_cache.find (slot);
+	if (it != m_vector_cache.end ())
+	  {
+	    return it->second.data ();
+	  }
+	pinned_t node_blk = m_storage->get_node_by_slot_id (context, slot, lock_mode::shared);
+	node_type node = node_type (node_blk->data);
+	const float *vec = node.get_vector ();
+	std::vector<float> &cached = m_vector_cache[slot];
+	cached.assign (vec, vec + m_dimension);
+	return cached.data ();
+      }
+
       inline distance_t compute_distance_from_query_ (algo_context_t<Traits> &context, const float *query,
 	  const slot_id_t &slot) const
       {
-	pinned_t vec_blk = m_storage->get_vector_by_slot_id (context, slot, lock_mode::shared);
-	node_type node = node_type (vec_blk->data);
-	return compute_distance_ (context, query, node.get_vector());
+	const float *vec = get_vector_cached_ (context, slot);
+	return compute_distance_ (context, query, vec);
       }
 
       inline distance_t compute_distance_between (algo_context_t<Traits> &context, const slot_id_t &a,
 	  const slot_id_t &b) const
       {
-	auto get_vec = [&] (const slot_id_t &slot) -> const float *
-	{
-	  pinned_t vec_blk = m_storage->get_vector_by_slot_id (context, slot, lock_mode::shared);
-	  node_type node = node_type (vec_blk->data);
-	  return node.get_vector();
-	};
-
-	return compute_distance_ (context, get_vec (a), get_vec (b));
+	return compute_distance_ (context, get_vector_cached_ (context, a), get_vector_cached_ (context, b));
       }
 
       inline neighbors_ref_type get_neighbors (const pinned_t &node_blk, const level_t level)
@@ -139,6 +147,7 @@ namespace cubhnsw
 
       // variables
       storage_t *m_storage {nullptr};
+      mutable vector_cache_t<Traits> m_vector_cache;  // (slot_id_t, vector) to avoid repeated page fix/unfix
 
       // from build_params
       vector_distance_metric_t m_metric;

--- a/src/storage/index_hnsw/hnsw_algo.hpp
+++ b/src/storage/index_hnsw/hnsw_algo.hpp
@@ -105,33 +105,19 @@ namespace cubhnsw
 	return metric_table[static_cast<size_t> (m_metric)] (v1, v2, m_dimension);
       }
 
-      // Returns pointer to vector for slot, using algo's cache to avoid repeated page fix/unfix.
-      inline const float *get_vector_cached_ (algo_context_t<Traits> &context, const slot_id_t &slot) const
-      {
-	auto it = m_vector_cache.find (slot);
-	if (it != m_vector_cache.end ())
-	  {
-	    return it->second.data ();
-	  }
-	pinned_t node_blk = m_storage->get_node_by_slot_id (context, slot, lock_mode::shared);
-	node_type node = node_type (node_blk->data);
-	const float *vec = node.get_vector ();
-	std::vector<float> &cached = m_vector_cache[slot];
-	cached.assign (vec, vec + m_dimension);
-	return cached.data ();
-      }
-
       inline distance_t compute_distance_from_query_ (algo_context_t<Traits> &context, const float *query,
 	  const slot_id_t &slot) const
       {
-	const float *vec = get_vector_cached_ (context, slot);
+	const float *vec = m_storage->get_vector_by_slot_id (context, slot, lock_mode::shared);
 	return compute_distance_ (context, query, vec);
       }
 
       inline distance_t compute_distance_between (algo_context_t<Traits> &context, const slot_id_t &a,
 	  const slot_id_t &b) const
       {
-	return compute_distance_ (context, get_vector_cached_ (context, a), get_vector_cached_ (context, b));
+	const float *avec = m_storage->get_vector_by_slot_id (context, a, lock_mode::shared);
+	const float *bvec = m_storage->get_vector_by_slot_id (context, b, lock_mode::shared);
+	return compute_distance_ (context, avec, bvec);
       }
 
       inline neighbors_ref_type get_neighbors (const pinned_t &node_blk, const level_t level)
@@ -147,7 +133,6 @@ namespace cubhnsw
 
       // variables
       storage_t *m_storage {nullptr};
-      mutable vector_cache_t<Traits> m_vector_cache;  // (slot_id_t, vector) to avoid repeated page fix/unfix
 
       // from build_params
       vector_distance_metric_t m_metric;

--- a/src/storage/index_hnsw/hnsw_algo_common.hpp
+++ b/src/storage/index_hnsw/hnsw_algo_common.hpp
@@ -103,7 +103,7 @@ namespace cubhnsw
   template <>
   struct vector_cache_helper<OID>
   {
-    using type = ankerl::unordered_dense::map<OID, float *, oid_hash, oid_equal>;
+    using type = ankerl::unordered_dense::map<OID, std::vector<float>, oid_hash, oid_equal>;
   };
 
   template <typename Traits>

--- a/src/storage/index_hnsw/hnsw_algo_common.hpp
+++ b/src/storage/index_hnsw/hnsw_algo_common.hpp
@@ -103,6 +103,21 @@ namespace cubhnsw
   template <typename Traits>
   using visited_set_t = typename visit_set_helper<typename Traits::slot_id_t>::type;
 
+  template <typename T>
+  struct vector_cache_helper
+  {
+    using type = std::unordered_map<T, std::vector<float>>;
+  };
+
+  template <>
+  struct vector_cache_helper<OID>
+  {
+    using type = std::unordered_map<OID, std::vector<float>, oid_hash, oid_equal>;
+  };
+
+  template <typename Traits>
+  using vector_cache_t = typename vector_cache_helper<typename Traits::slot_id_t>::type;
+
   template <typename Traits>
   using candidates_view_t = std::vector<candidate_t<Traits>>;
 

--- a/src/storage/index_hnsw/hnsw_algo_common.hpp
+++ b/src/storage/index_hnsw/hnsw_algo_common.hpp
@@ -106,13 +106,13 @@ namespace cubhnsw
   template <typename T>
   struct vector_cache_helper
   {
-    using type = std::unordered_map<T, std::vector<float>>;
+    using type = ankerl::unordered_dense::map<T, std::vector<float>>;
   };
 
   template <>
   struct vector_cache_helper<OID>
   {
-    using type = std::unordered_map<OID, std::vector<float>, oid_hash, oid_equal>;
+    using type = ankerl::unordered_dense::map<OID, float *, oid_hash, oid_equal>;
   };
 
   template <typename Traits>

--- a/src/storage/index_hnsw/hnsw_storage.hpp
+++ b/src/storage/index_hnsw/hnsw_storage.hpp
@@ -122,8 +122,8 @@ namespace cubhnsw
       virtual pinned_t get_root (algo_context_t<Traits> &context, lock_mode mode) = 0;
       virtual pinned_t get_node_by_slot_id (algo_context_t<Traits> &context, const slot_id_t &slot_id,
 					    const lock_mode &mode) = 0;
-      virtual pinned_t get_vector_by_slot_id (algo_context_t<Traits> &context, const slot_id_t &slot_id,
-					      const lock_mode &mode) = 0;
+      virtual const float *get_vector_by_slot_id (algo_context_t<Traits> &context, const slot_id_t &slot_id,
+	  const lock_mode &mode) = 0;
 
       // promote lockmode from shared to exclusive
       virtual void promote_root (pinned_t &root) = 0;

--- a/src/storage/index_hnsw/hnsw_storage_disk.cpp
+++ b/src/storage/index_hnsw/hnsw_storage_disk.cpp
@@ -246,11 +246,23 @@ namespace cubhnsw
 
   }
 
-  disk_storage::pinned_t
+  const float *
   disk_storage::get_vector_by_slot_id (algo_context_t<traits> &context, const slot_id_t &slot, const lock_mode &mode)
   {
-    // get node by slot id
-    return get_node_by_slot_id (context, slot, lock_mode::shared);
+    auto it = m_vector_cache.find (slot);
+    if (it != m_vector_cache.end ())
+      {
+	return it->second.data ();
+      }
+
+    pinned_t node_blk = get_node_by_slot_id (context, slot, mode);
+    node_t<disk_traits_t> node { reinterpret_cast<byte_t *> (node_blk->data) };
+    const float *vec = node.get_vector ();
+
+    std::vector<float> &cached = m_vector_cache[slot];
+    cached.assign (vec, vec + get_dimension ());
+
+    return cached.data ();
   }
 
   // promote lockmode from shared to exclusive

--- a/src/storage/index_hnsw/hnsw_storage_disk.hpp
+++ b/src/storage/index_hnsw/hnsw_storage_disk.hpp
@@ -92,8 +92,8 @@ namespace cubhnsw
       virtual pinned_t get_root (algo_context_t<traits> &context, lock_mode mode) override;
       virtual pinned_t get_node_by_slot_id (algo_context_t<traits> &context, const slot_id_t &slot_id,
 					    const lock_mode &mode) override;
-      virtual pinned_t get_vector_by_slot_id (algo_context_t<traits> &context, const slot_id_t &slot_id,
-					      const lock_mode &mode) override;
+      virtual const float *get_vector_by_slot_id (algo_context_t<traits> &context, const slot_id_t &slot_id,
+	  const lock_mode &mode) override;
 
       // promote lockmode from shared to exclusive
       // TODO: not implemented
@@ -118,6 +118,8 @@ namespace cubhnsw
 
       VFID m_vec_pool_vfid;
       VPID m_last_vec_vpid;
+
+      vector_cache_t<traits> m_vector_cache;  // (slot_id_t, vector) cache
 
       bool m_is_empty = true;
   };


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBVEC-167>

### Purpose

HNSW Index의 Node 탐색을 위해 neighbor node와의 거리 계산을 할 때, 불필요한 이웃 node page의 fix/unfix 작업을 단축시킨다.
### Implementation

- Unordered map을 사용하여 oid에 해당하는 float vector를 캐싱
- neighbor node와의 거리 계산 시, 이미 캐싱된 oid의 경우, caching된 float vector를 look-up

