### PR TITLE
[CBRD-26561] Fix incorrect casting of negative numeric values (zero integer part, non-zero scale) to bigint

### DIFF
--- a/src/query/numeric_opfunc.c
+++ b/src/query/numeric_opfunc.c
@@ -2371,29 +2371,34 @@ numeric_coerce_num_to_bigint (DB_C_NUMERIC arg, int scale, DB_BIGINT * answer)
   if (scale > 0)
     {
       numeric_div (arg, numeric_get_pow_of_10 (scale), zero_scale_arg, rem);
-      if (!numeric_is_negative (zero_scale_arg))
+      if (!numeric_is_zero (rem))
 	{
-	  numeric_negate (rem);
-	}
-
-      /* round */
-      numeric_add (numeric_get_pow_of_10 (scale), rem, tmp, DB_NUMERIC_BUF_SIZE);
-      numeric_add (tmp, rem, tmp, DB_NUMERIC_BUF_SIZE);
-      if (numeric_is_negative (tmp) || numeric_is_zero (tmp))
-	{
-	  if (numeric_is_negative (zero_scale_arg))
+	  /* The signs of the input, quotient, and remainder will be the same. 
+	     Here, we intend to make it negative */
+	  if (!numeric_is_negative (rem))
 	    {
-	      numeric_decrease (zero_scale_arg);
+	      numeric_negate (rem);
 	    }
-	  else
+
+	  /* round */
+	  numeric_add (numeric_get_pow_of_10 (scale), rem, tmp, DB_NUMERIC_BUF_SIZE);
+	  numeric_add (tmp, rem, tmp, DB_NUMERIC_BUF_SIZE);
+	  if (numeric_is_negative (tmp) || numeric_is_zero (tmp))
 	    {
-	      numeric_increase (zero_scale_arg);
+	      if (numeric_is_negative (arg))
+		{
+		  numeric_decrease (zero_scale_arg);
+		}
+	      else
+		{
+		  numeric_increase (zero_scale_arg);
+		}
 	    }
 	}
     }
   else
     {
-      numeric_copy (zero_scale_arg, arg);
+      zero_scale_arg = arg;
     }
 
   if (!numeric_is_bigint (zero_scale_arg))

--- a/src/query/numeric_opfunc.c
+++ b/src/query/numeric_opfunc.c
@@ -2373,14 +2373,19 @@ numeric_coerce_num_to_bigint (DB_C_NUMERIC arg, int scale, DB_BIGINT * answer)
       numeric_div (arg, numeric_get_pow_of_10 (scale), zero_scale_arg, rem);
       if (!numeric_is_zero (rem))
 	{
-	  /* The signs of the input, quotient, and remainder will be the same. 
-	     Here, we intend to make it negative */
+	  /* The signs of the input, quotient(except for zero), and remainder will be the same. 
+	     Here, we force 'rem' to be negative */
 	  if (!numeric_is_negative (rem))
 	    {
 	      numeric_negate (rem);
 	    }
 
 	  /* round */
+	  /* If (10^'scale' + 'rem' + 'rem') <= 0 (where 'rem' is a negative remainder), round up; otherwise, disregard. 
+	   * If adding the negative remainder twice to a power of 10 results in a negative value, the remainder is considered large enough to round up.
+	   * Otherwise, it is disregarded. 
+	   * Note: Since the remainder is expressed as a negative value, addition is used instead of subtraction.
+	   */
 	  numeric_add (numeric_get_pow_of_10 (scale), rem, tmp, DB_NUMERIC_BUF_SIZE);
 	  numeric_add (tmp, rem, tmp, DB_NUMERIC_BUF_SIZE);
 	  if (numeric_is_negative (tmp) || numeric_is_zero (tmp))


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26561>

### Purpose

* -0.xxx 처럼  정수부가 0인 음수 numeric을 bigint로 변경할 때의 오류 수정

### Implementation

N/A

### Remarks

* 코드 로직에서 (10의 scale 거듭제곱)으로 나누는데 이때 몫과 나머지의 부호는 원본과 같다.

*반올림 되어야 하는지 판단하는 방법은 
  (10의 scale 거듭제곱)에서 양수인 나머지를 두 번 빼 준 후  그 결과가 양수인지 음수인지 판단해 본다.(실제 코드에서는 뺄셈이 비싸기 때문에 나머지를 음수로 만든 후 두 번의 덧셈을 했다)
예)  scale이 1이고 나머지의 절대값이 각각 3, 7이라고 하면
      3인 경우 : 10 -3 -3 = 4 (양수) ==> 코드에서는 10 + (-3) + (-3) 방식 사용
      7인 경우 : 10 -7 -7 = -4(음수)
      결과가 양수라면 나머지는 본래 작은 숫자였다는 뜻이고(무시),
      음수라면 반올림 처리 해줘야 할 만큼 큰 숫자였다는 뜻이다.

