### PR TITLE
[CBRD-26178] qexec_clear_xasl 함수 수정

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -2828,9 +2828,7 @@ qexec_clear_xasl_for_parallel_aptr (THREAD_ENTRY * thread_p, XASL_NODE * xasl, b
   query_save_state = xasl->query_in_progress;
 
   xasl->query_in_progress = true;
-  status = xasl->status;
   qexec_clear_xasl_head (thread_p, xasl);
-  xasl->status = status;
 
 #if defined (ENABLE_COMPOSITE_LOCK)
   /* free alloced memory for composite locking */


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26178>

### Purpose
아래 두 쿼리의 결과가 다른 오류가 있어 해결합니다.
hash join을 감싸는 buildlist proc이 parallel aptr execution에 의해 실행되며, `(select c1 from tt4)` 는 실행되고 결과가 clear되지만 `xasl->status`는 cleared가 아닌 success로 남아 main query에서 재실행되지 않는 버그가 있습니다. 이를 수정합니다.

```sql
csql> select /*+ recompile use_hash */ *
csql> from tt1, tt2, tt3
csql> where (select c1 from tt4) > 0 and tt1.c1 = tt2.c1 and tt2.c1 = tt3.c1;

=== <Result of SELECT Command in Line 4> ===

There are no results.

csql> select /*+ recompile */ *
csql> from tt1, tt2, tt3
csql> where (select c1 from tt4) > 0 and tt1.c1 = tt2.c1 and tt2.c1 = tt3.c1;

=== <Result of SELECT Command in Line 3> ===

           c1           c1           c1
=======================================
            1            1            1
```
