### PR TITLE
[CUBVEC-159] Use PCA Reordering for inserting batch of vectors to HNSW Index

### DIFF
--- a/cubvec_examples/test.sh
+++ b/cubvec_examples/test.sh
@@ -30,9 +30,15 @@ valgrind --leak-check=full --track-origins=yes --trace-children=yes --log-file=v
 # ann benchmarks locally test
 wget http://ann-benchmarks.com/nytimes-256-angular.hdf5
 cubrid loaddb -h nytimes-256-angular.hdf5 -C -u dba demodb
-echo "CREATE VECTOR INDEX vidx_nytimes_train ON nytimes_256_angular_train (vec COSINE) WITH (M = 16, ef_construction = 200);" >> nytimes_256_angular_schema
 cubrid loaddb -s nytimes_256_angular_schema -d nytimes_256_angular_object -C -u dba demodb -v --no-statistics --no-user-specified-name
-;set print_object_as_oid=yes
+
+# test with debugging parameter
+csql -u dba demodb -c "
+  SET SYSTEM PARAMETERS 'hnsw_debug=1'; \
+  CREATE VECTOR INDEX vidx_nytimes_train ON nytimes_256_angular_train (vec COSINE) WITH (M = 64, ef_construction = 200);
+  "
+
+";set print_object_as_oid=yes
 prepare q1 from '
     SELECT tr, tr.id, tr.vec <c> ?:0 as dist
     FROM nytimes_256_angular_train tr

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -780,6 +780,8 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 #define PRM_NAME_MEMOIZE_MEMORY_LIMIT "memoize_memory_limit"
 
 #define PRM_NAME_VECTOR_INDEX_EF_SEARCH "hnsw_ef_search"
+#define PRM_NAME_VECTOR_INDEX_DEBUG "hnsw_debug"
+
 // #endregion 
 
 /*
@@ -5194,7 +5196,19 @@ SYSPRM_PARAM prm_Def[] = {
    {false, {.i = PRM_VECTOR_INDEX_EF_SEARCH}},
    {false, {.i = prm_vector_index_ef_search_upper}},
    {false, {.i = prm_vector_index_ef_search_lower}},
-      (char *) NULL,
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
+  {PRM_ID_VECTOR_INDEX_DEBUG,
+   PRM_NAME_VECTOR_INDEX_DEBUG,
+   (PRM_FOR_SESSION | PRM_USER_CHANGE | PRM_FOR_SERVER | PRM_FOR_CLIENT),
+   PRM_INTEGER,
+   PRM_CLEAR_DYNAMIC_FLAG,
+   {false, {.i = 0}},
+   {false, {.i = 0}},
+   {false, {.i = 1}},
+   {false, {.i = 0}},
+   (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL},
 };

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -513,8 +513,9 @@ enum param_id
   PRM_ID_HOSTVAR_PEEKING,
 
   PRM_ID_VECTOR_INDEX_EF_SEARCH,
+  PRM_ID_VECTOR_INDEX_DEBUG,
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_VECTOR_INDEX_EF_SEARCH
+  PRM_LAST_ID = PRM_ID_VECTOR_INDEX_DEBUG
 };
 typedef enum param_id PARAM_ID;
 

--- a/src/storage/index_hnsw/hnsw_algo.hpp
+++ b/src/storage/index_hnsw/hnsw_algo.hpp
@@ -32,6 +32,7 @@
 #include "hnsw_storage.hpp" // storage_t
 #include "vector_distance.hpp"
 #include "perf_monitor.h"
+#include "system_parameter.h"
 
 #define HNSW_ALGO_DEBUG 0
 #define HNSW_ALGO_PRINT(fmt, ...) do { if (HNSW_ALGO_DEBUG) { fprintf (stdout, fmt, ##__VA_ARGS__); fflush (stdout); } } while (0)
@@ -264,7 +265,7 @@ namespace cubhnsw
 	{
 	  for (const auto &node : context.m_accessed_nodes)
 	    {
-	      fprintf (stdout, "%s ->", node.c_str());
+	      fprintf (stdout, "%s ->", node.data());
 	    }
 	  fprintf (stdout, "\n");
 	  context.m_accessed_nodes.clear();
@@ -298,7 +299,7 @@ namespace cubhnsw
 	      fprintf (stdout, "level: %d\n", level);
 	      for (const auto &node : context.m_accessed_nodes)
 		{
-		  fprintf (stdout, "%s ->", node.c_str());
+		  fprintf (stdout, "%s ->", node.data ());
 		}
 	      fprintf (stdout, "\n");
 	      context.m_accessed_nodes.clear();

--- a/src/storage/index_hnsw/hnsw_algo.hpp
+++ b/src/storage/index_hnsw/hnsw_algo.hpp
@@ -105,25 +105,33 @@ namespace cubhnsw
 	return metric_table[static_cast<size_t> (m_metric)] (v1, v2, m_dimension);
       }
 
+      // Returns pointer to vector for slot, using algo's cache to avoid repeated page fix/unfix.
+      inline const float *get_vector_cached_ (algo_context_t<Traits> &context, const slot_id_t &slot) const
+      {
+	auto it = m_vector_cache.find (slot);
+	if (it != m_vector_cache.end ())
+	  {
+	    return it->second.data ();
+	  }
+	pinned_t node_blk = m_storage->get_node_by_slot_id (context, slot, lock_mode::shared);
+	node_type node = node_type (node_blk->data);
+	const float *vec = node.get_vector ();
+	std::vector<float> &cached = m_vector_cache[slot];
+	cached.assign (vec, vec + m_dimension);
+	return cached.data ();
+      }
+
       inline distance_t compute_distance_from_query_ (algo_context_t<Traits> &context, const float *query,
 	  const slot_id_t &slot) const
       {
-	pinned_t vec_blk = m_storage->get_vector_by_slot_id (context, slot, lock_mode::shared);
-	node_type node = node_type (vec_blk->data);
-	return compute_distance_ (context, query, node.get_vector());
+	const float *vec = get_vector_cached_ (context, slot);
+	return compute_distance_ (context, query, vec);
       }
 
       inline distance_t compute_distance_between (algo_context_t<Traits> &context, const slot_id_t &a,
 	  const slot_id_t &b) const
       {
-	auto get_vec = [&] (const slot_id_t &slot) -> const float *
-	{
-	  pinned_t vec_blk = m_storage->get_vector_by_slot_id (context, slot, lock_mode::shared);
-	  node_type node = node_type (vec_blk->data);
-	  return node.get_vector();
-	};
-
-	return compute_distance_ (context, get_vec (a), get_vec (b));
+	return compute_distance_ (context, get_vector_cached_ (context, a), get_vector_cached_ (context, b));
       }
 
       inline neighbors_ref_type get_neighbors (const pinned_t &node_blk, const level_t level)
@@ -139,6 +147,7 @@ namespace cubhnsw
 
       // variables
       storage_t *m_storage {nullptr};
+      mutable vector_cache_t<Traits> m_vector_cache;  // (slot_id_t, vector) to avoid repeated page fix/unfix
 
       // from build_params
       vector_distance_metric_t m_metric;

--- a/src/storage/index_hnsw/hnsw_algo.hpp
+++ b/src/storage/index_hnsw/hnsw_algo.hpp
@@ -105,22 +105,6 @@ namespace cubhnsw
 	return metric_table[static_cast<size_t> (m_metric)] (v1, v2, m_dimension);
       }
 
-      // Returns pointer to vector for slot, using algo's cache to avoid repeated page fix/unfix.
-      inline const float *get_vector_cached_ (algo_context_t<Traits> &context, const slot_id_t &slot) const
-      {
-	auto it = m_vector_cache.find (slot);
-	if (it != m_vector_cache.end ())
-	  {
-	    return it->second.data ();
-	  }
-	pinned_t node_blk = m_storage->get_node_by_slot_id (context, slot, lock_mode::shared);
-	node_type node = node_type (node_blk->data);
-	const float *vec = node.get_vector ();
-	std::vector<float> &cached = m_vector_cache[slot];
-	cached.assign (vec, vec + m_dimension);
-	return cached.data ();
-      }
-
       inline distance_t compute_distance_from_query_ (algo_context_t<Traits> &context, const float *query,
 	  const slot_id_t &slot) const
       {
@@ -149,7 +133,6 @@ namespace cubhnsw
 
       // variables
       storage_t *m_storage {nullptr};
-      mutable vector_cache_t<Traits> m_vector_cache;  // (slot_id_t, vector) to avoid repeated page fix/unfix
 
       // from build_params
       vector_distance_metric_t m_metric;

--- a/src/storage/index_hnsw/hnsw_algo.hpp
+++ b/src/storage/index_hnsw/hnsw_algo.hpp
@@ -181,6 +181,7 @@ namespace cubhnsw
     algo_context_t<Traits> context;
     context.m_thread_p = thread_p;
     context.m_is_perf_tracking = perfmon_is_perf_tracking ();
+    context.m_is_debugging = prm_get_integer_value (PRM_ID_VECTOR_INDEX_DEBUG) != 0;
     context.clear_candidates();
 
     std::size_t connectivity_max = m_connectivity * 2 + 1;
@@ -259,9 +260,24 @@ namespace cubhnsw
 	(void) seek_down_ (context, vector, entry_slot, curr_max_level, new_target_level, closest_slot);
       }
 
+      if (context.m_is_debugging)
+	{
+	  for (const auto &node : context.m_accessed_nodes)
+	    {
+	      fprintf (stdout, "%s ->", node.c_str());
+	    }
+	  fprintf (stdout, "\n");
+	  context.m_accessed_nodes.clear();
+	}
+
       level_t level = (std::min) (new_target_level, curr_max_level);
 
       pinned_t new_node_blk = m_storage->get_node_by_slot_id (context, new_slot, lock_mode::exclusive);
+
+      if (context.m_is_debugging)
+	{
+	  fprintf (stdout, "target level: %d\n", level);
+	}
 
       while (true)
 	{
@@ -276,6 +292,18 @@ namespace cubhnsw
 	    closest_slot = closest_view[0].slot;
 	  }
 	  form_reverse_links_ (context, new_node_blk, vector, closest_view, level);
+
+	  if (context.m_is_debugging)
+	    {
+	      fprintf (stdout, "level: %d\n", level);
+	      for (const auto &node : context.m_accessed_nodes)
+		{
+		  fprintf (stdout, "%s ->", node.c_str());
+		}
+	      fprintf (stdout, "\n");
+	      context.m_accessed_nodes.clear();
+	    }
+
 	  if (level == 0)
 	    {
 	      break;

--- a/src/storage/index_hnsw/hnsw_algo.hpp
+++ b/src/storage/index_hnsw/hnsw_algo.hpp
@@ -141,6 +141,11 @@ namespace cubhnsw
       std::size_t m_connectivity;
       std::size_t m_expansion;
 
+      std::default_random_engine m_level_generator;
+
+      std::size_t m_debug_group_start {0};
+      std::size_t m_debug_cnt {0};
+
       // precomputed
       double m_inverse_log_connectivity;
   };
@@ -183,6 +188,7 @@ namespace cubhnsw
     context.m_thread_p = thread_p;
     context.m_is_perf_tracking = perfmon_is_perf_tracking ();
     context.m_is_debugging = prm_get_integer_value (PRM_ID_VECTOR_INDEX_DEBUG) != 0;
+
     context.clear_candidates();
 
     std::size_t connectivity_max = m_connectivity * 2 + 1;
@@ -213,12 +219,21 @@ namespace cubhnsw
     root_type root_node = root_type (root_block->data);
     {
       curr_max_level = root_node.get_level(); // get max_level from root page
-      new_target_level = choose_random_level_ (context.m_level_generator, m_inverse_log_connectivity);
+      new_target_level = choose_random_level_ (m_level_generator, m_inverse_log_connectivity);
       entry_slot = root_node.get_entry();
       if (new_target_level > MAX_LEVELS)
 	{
 	  // TODO: for optimzation, if new_target_level is greater than max_level, we can just use max_level
 	  new_target_level = MAX_LEVELS;
+	}
+
+      if (context.m_is_debugging)
+	{
+	  if (new_target_level > curr_max_level)
+	    {
+	      m_debug_group_start = m_debug_cnt;
+	    }
+	  context.open_debug_file (m_debug_group_start, m_debug_cnt, std::max (curr_max_level, new_target_level));
 	}
 
       if (m_metric == vector_distance_metric_t::COSINE)
@@ -263,12 +278,16 @@ namespace cubhnsw
 
       if (context.m_is_debugging)
 	{
-	  for (const auto &node : context.m_accessed_nodes)
+	  fprintf (context.m_debug_fp, "===== node num: %zu, slot: %s =====\n", m_debug_cnt++, dump_oid (new_slot).c_str());
+	  if (!context.m_accessed_nodes.empty ())
 	    {
-	      fprintf (stdout, "%s ->", node.data());
+	      for (const auto &node : context.m_accessed_nodes)
+		{
+		  fprintf (context.m_debug_fp, "(%s) -> ", node.data());
+		}
+	      fprintf (context.m_debug_fp, "END \n");
+	      context.m_accessed_nodes.clear();
 	    }
-	  fprintf (stdout, "\n");
-	  context.m_accessed_nodes.clear();
 	}
 
       level_t level = (std::min) (new_target_level, curr_max_level);
@@ -277,7 +296,7 @@ namespace cubhnsw
 
       if (context.m_is_debugging)
 	{
-	  fprintf (stdout, "target level: %d\n", level);
+	  fprintf (context.m_debug_fp, "target level: %d\n", level);
 	}
 
       while (true)
@@ -296,13 +315,16 @@ namespace cubhnsw
 
 	  if (context.m_is_debugging)
 	    {
-	      fprintf (stdout, "level: %d\n", level);
-	      for (const auto &node : context.m_accessed_nodes)
+	      fprintf (context.m_debug_fp, "level: %d\n", level);
+	      if (!context.m_accessed_nodes.empty ())
 		{
-		  fprintf (stdout, "%s ->", node.data ());
+		  for (const auto &node : context.m_accessed_nodes)
+		    {
+		      fprintf (context.m_debug_fp, "(%s) -> ", node.data ());
+		    }
+		  fprintf (context.m_debug_fp, "END \n");
+		  context.m_accessed_nodes.clear();
 		}
-	      fprintf (stdout, "\n");
-	      context.m_accessed_nodes.clear();
 	    }
 
 	  if (level == 0)
@@ -320,6 +342,11 @@ namespace cubhnsw
 		      context.m_computed_distances_in_refines);
     perfmon_add_stat (context.m_thread_p, PSTAT_HNSW_NUM_COMPUTED_DISTANCES_IN_REVERSE_REFINES,
 		      context.m_computed_distances_in_reverse_refines);
+
+    if (context.m_is_debugging)
+      {
+	context.close_debug_file();
+      }
 
     if (new_target_level > curr_max_level)
       {

--- a/src/storage/index_hnsw/hnsw_algo_common.hpp
+++ b/src/storage/index_hnsw/hnsw_algo_common.hpp
@@ -32,6 +32,7 @@
 #include "hnsw_graph_base.hpp"
 #include "thread_entry.hpp"
 #include "vector_distance.hpp"
+#include "environment_variable.h"
 
 namespace cubhnsw
 {
@@ -147,7 +148,6 @@ namespace cubhnsw
     top_candidates_t<Traits> m_top_for_refine;
     next_candidates_t<Traits> m_next_candidates;
     visited_set_t<Traits> m_visits;
-    std::default_random_engine m_level_generator;
     cubthread::entry *m_thread_p {nullptr};
 
     // stats
@@ -158,7 +158,41 @@ namespace cubhnsw
     std::size_t m_computed_distances_in_reverse_refines{};
 
     bool m_is_debugging {false};
-    std::deque<std::string_view> m_accessed_nodes; // for debug
+    FILE *m_debug_fp {nullptr};
+    std::vector<std::string> m_accessed_nodes; // for debug
+
+    void open_debug_file (std::size_t level_start_debug_cnt, std::size_t debug_cnt, int level)
+    {
+      char path[PATH_MAX];
+      if (!m_is_debugging)
+	{
+	  return;
+	}
+
+      constexpr std::size_t GROUP_SIZE = 10000;
+      std::size_t group_start =
+	      level_start_debug_cnt +
+	      ((debug_cnt - level_start_debug_cnt) / GROUP_SIZE) * GROUP_SIZE;
+
+      std::string filename =
+	      "hnsw_debug_" +
+	      std::to_string (group_start) +
+	      "_L" + std::to_string (level) +
+	      ".log";
+
+      envvar_tmpdir_file (path, PATH_MAX, filename.c_str());
+
+      m_debug_fp = fopen (path, "a");
+    }
+
+    void close_debug_file()
+    {
+      if (m_debug_fp)
+	{
+	  fclose (m_debug_fp);
+	  m_debug_fp = nullptr;
+	}
+    }
 
     void clear_candidates ()
     {

--- a/src/storage/index_hnsw/hnsw_algo_common.hpp
+++ b/src/storage/index_hnsw/hnsw_algo_common.hpp
@@ -103,6 +103,21 @@ namespace cubhnsw
   template <typename Traits>
   using visited_set_t = typename visit_set_helper<typename Traits::slot_id_t>::type;
 
+  template <typename T>
+  struct vector_cache_helper
+  {
+    using type = std::unordered_map<T, std::vector<float>>;
+  };
+
+  template <>
+  struct vector_cache_helper<OID>
+  {
+    using type = std::unordered_map<OID, std::vector<float>, oid_hash, oid_equal>;
+  };
+
+  template <typename Traits>
+  using vector_cache_t = typename vector_cache_helper<typename Traits::slot_id_t>::type;
+
   template <typename Traits>
   using candidates_view_t = std::vector<candidate_t<Traits>>;
 

--- a/src/storage/index_hnsw/hnsw_algo_common.hpp
+++ b/src/storage/index_hnsw/hnsw_algo_common.hpp
@@ -24,6 +24,8 @@
 #define _HNSW_ALGO_COMMON_HPP_
 
 #include <random>
+#include <deque>
+#include <string_view>
 #include <ankerl/unordered_dense.h>
 
 #include "hnsw_api.hpp"
@@ -154,6 +156,9 @@ namespace cubhnsw
     std::size_t m_computed_distances{};
     std::size_t m_computed_distances_in_refines{};
     std::size_t m_computed_distances_in_reverse_refines{};
+
+    bool m_is_debugging {false};
+    std::deque<std::string_view> m_accessed_nodes; // for debug
 
     void clear_candidates ()
     {

--- a/src/storage/index_hnsw/hnsw_storage_disk.cpp
+++ b/src/storage/index_hnsw/hnsw_storage_disk.cpp
@@ -225,6 +225,10 @@ namespace cubhnsw
     if (context.m_is_perf_tracking)
       {
 	context.m_visited_nodes++;
+	if (context.m_is_debugging)
+	  {
+	    context.m_accessed_nodes.push_back (dump_oid (id));
+	  }
       }
 
     cubthread::entry *thread_p = context.m_thread_p;

--- a/src/storage/index_hnsw/hnsw_storage_disk.cpp
+++ b/src/storage/index_hnsw/hnsw_storage_disk.cpp
@@ -225,10 +225,11 @@ namespace cubhnsw
     if (context.m_is_perf_tracking)
       {
 	context.m_visited_nodes++;
-	if (context.m_is_debugging)
-	  {
-	    context.m_accessed_nodes.push_back (dump_oid (id));
-	  }
+      }
+
+    if (context.m_is_debugging)
+      {
+	context.m_accessed_nodes.push_back (dump_slot (id));
       }
 
     cubthread::entry *thread_p = context.m_thread_p;

--- a/src/storage/index_hnsw/hnsw_usearch_ng.cpp
+++ b/src/storage/index_hnsw/hnsw_usearch_ng.cpp
@@ -126,11 +126,19 @@ class hnsw_usearch_ng final:public hnsw_index
 
     void init_worker_pool ();
     void add_internal (cubthread::entry &thread_ref, hnsw_build_worker_job &job);
+    void update_pca_online (const float *vectors, int n_vectors, int dim,
+			    bool normalize_inputs);
 
     VPID m_root_vpid;
 
     std::unique_ptr < algo_type > m_algo;
     std::unique_ptr < storage_type > m_storage;
+
+    // For PCA Reordering
+    std::vector<float> m_pca_mean;  // running mean (dimension)
+    std::vector<float> m_pca_pc1;   // running PC1 (dimension)
+    uint64_t m_pca_seen {0};        // number of samples seen (for step schedule)
+    bool m_pca_inited {false};
 
 #if defined (SERVER_MODE)
     cubthread::entry_workpool *m_build_worker_pool;
@@ -148,6 +156,124 @@ class hnsw_usearch_ng final:public hnsw_index
 #endif
     lockfree::circular_queue<hnsw_build_worker_job> *m_build_worker_job_queue;
 };
+
+// Helper functions for vector preprocessing
+
+static inline float dot_f (const float *a, const float *b, int dim)
+{
+  float s = 0.0f;
+  for (int i = 0; i < dim; ++i)
+    {
+      s += a[i] * b[i];
+    }
+  return s;
+}
+
+static inline float l2norm_f (const float *a, int dim)
+{
+  return std::sqrt (dot_f (a, a, dim));
+}
+
+static inline void normalize_vec (std::vector<float> &v)
+{
+  float n = std::sqrt (dot_f (v.data (), v.data (), (int) v.size ()));
+  if (n > 0.0f)
+    {
+      for (auto &x : v)
+	{
+	  x /= n;
+	}
+    }
+}
+
+static inline bool is_all_zeros_f (const float *v, int dim)
+{
+  for (int i = 0; i < dim; ++i) if (v[i] != 0.0f)
+      {
+	return false;
+      }
+  return true;
+}
+
+void
+hnsw_usearch_ng::update_pca_online (const float *vectors, int n_vectors, int dim,
+				    bool normalize_inputs)
+{
+  if (m_pca_mean.empty ())
+    {
+      m_pca_mean.assign (dim, 0.0f);
+    }
+  if (m_pca_pc1.empty ())
+    {
+      m_pca_pc1.assign (dim, 0.0f);
+    }
+
+  std::vector<float> x (dim);
+  std::vector<float> centered (dim);
+
+  for (int i = 0; i < n_vectors; ++i)
+    {
+      const float *v = vectors + i * dim;
+
+      if (normalize_inputs && db_vector_is_all_zeros (v, dim))
+	{
+	  continue;
+	}
+
+      // x = v (or normalized v)
+      if (!normalize_inputs)
+	{
+	  for (int d = 0; d < dim; ++d)
+	    {
+	      x[d] = v[d];
+	    }
+	}
+      else
+	{
+	  float n = l2norm_f (v, dim);
+	  if (n <= 0.0f)
+	    {
+	      continue;
+	    }
+	  for (int d = 0; d < dim; ++d)
+	    {
+	      x[d] = v[d] / n;
+	    }
+	}
+
+      // centered = x - mean(prev)
+      for (int d = 0; d < dim; ++d)
+	{
+	  centered[d] = x[d] - m_pca_mean[d];
+	}
+
+      ++m_pca_seen;
+      const float inv = 1.0f / (float) m_pca_seen;
+      for (int d = 0; d < dim; ++d)
+	{
+	  m_pca_mean[d] += centered[d] * inv;
+	}
+
+      if (!m_pca_inited)
+	{
+	  m_pca_pc1 = centered;
+	  normalize_vec (m_pca_pc1);
+	  m_pca_inited = true;
+	  continue;
+	}
+
+      // Oja update: w <- w + eta * centered * (centered^T w)
+      const float eta0 = 0.2f;
+      const float eta = eta0 / std::sqrt ((float) m_pca_seen);
+
+      const float proj = dot_f (centered.data (), m_pca_pc1.data (), dim);
+      for (int d = 0; d < dim; ++d)
+	{
+	  m_pca_pc1[d] += eta * centered[d] * proj;
+	}
+      normalize_vec (m_pca_pc1);
+    }
+}
 
 // =====================================================================
 // hnsw_usearch_ng_backend
@@ -340,17 +466,79 @@ hnsw_usearch_ng::add (cubthread::entry *thread_p, int n_vectors, const OID *oid,
 {
   hnsw_build_worker_context ctx;
   ctx.tran_index = thread_p->tran_index;
-  // Push insert each vector insertion task to worker pool
 
-  std::vector<hnsw_build_worker_job> jobs;
-  jobs.reserve (n_vectors);
+  // PCA Reordering
+  const int dim = m_build_params.dimension;
+  const bool normalize_inputs =
+	  (m_build_params.metric == DB_VECTOR_DISTANCE_METRIC::METRIC_COSINE);
+
+  // 0) Update global PC1 using this batch
+  update_pca_online (vector, n_vectors, dim, normalize_inputs);
+
+  auto is_skippable = [&] (const float *v) -> bool
+  {
+    return (normalize_inputs && db_vector_is_all_zeros (v, dim));
+  };
+
+  // 1) score + ordering by projection onto (updated) PC1
+  std::vector<std::pair<float, int>> scored;
+  scored.reserve (n_vectors);
 
   for (int i = 0; i < n_vectors; ++i)
     {
+      const float *v = vector + i * dim;
+      if (is_skippable (v))
+	{
+	  er_log_debug (ARG_FILE_LINE, "Vector is all zeros, skipping add");
+	  continue;
+	}
+
+      float score = 0.0f;
+
+      // score = dot(pc1, (x - mean))
+      if (!normalize_inputs)
+	{
+	  for (int d = 0; d < dim; ++d)
+	    {
+	      score += m_pca_pc1[d] * (v[d] - m_pca_mean[d]);
+	    }
+	}
+      else
+	{
+	  float n = l2norm_f (v, dim);
+	  if (n <= 0.0f)
+	    {
+	      continue;
+	    }
+
+	  for (int d = 0; d < dim; ++d)
+	    {
+	      const float x = v[d] / n;
+	      score += m_pca_pc1[d] * (x - m_pca_mean[d]);
+	    }
+	}
+
+      scored.emplace_back (score, i);
+    }
+
+  std::sort (scored.begin (), scored.end (),
+	     [] (const auto &a, const auto &b)
+  {
+    return a.first < b.first;
+  });
+
+  // Build jobs in PCA order for worker pool / fallback (server mode and SA mode)
+  std::vector<hnsw_build_worker_job> jobs;
+  jobs.reserve (scored.size ());
+
+  for (const auto &kv : scored)
+    {
+      const int idx = kv.second;
+
       hnsw_build_worker_job job;
       job.m_ctx = &ctx;
-      job.m_oid = oid[i];
-      job.m_vector = vector + i * m_build_params.dimension;
+      job.m_oid = oid[idx];
+      job.m_vector = vector + idx * dim;
 
       jobs.emplace_back (job);
     }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBVEC-159>

### Purpose

Vector Index에 vector data를 batch로 로딩할 때, Insertion 순서를 조정하여 데이터 입력 후 인덱스 생성 시 진행되는 Vector Index Loading 작업의 성능 향상을 목표로 한다.

### Implementation

- PCA Reordering 구현
  -  Oja's rule을 활용한 online pca vector update
  - PCA vector를 통한 projection으로 batch로 삽입된 vector에 대해 reordering 진행
 