### PR TITLE
[CBRD-26563] NUM OVERFLOW error in round() for negative values with zero integer part

### DIFF
--- a/src/broker/cas_util.c
+++ b/src/broker/cas_util.c
@@ -151,7 +151,8 @@ static const char *schema_type_str[] = {
   "PRIMARY_KEY",
   "IMPORTED_KEYS",
   "EXPORTED_KEYS",
-  "CROSS_REFERENCE"
+  "CROSS_REFERENCE",
+  "ATTR_WITH_SYNONYM"
 };
 
 static const char *tran_type_str[] = { "COMMIT", "ROLLBACK" };

--- a/src/executables/csql_result_format.c
+++ b/src/executables/csql_result_format.c
@@ -347,15 +347,15 @@ add_commas (char *string)
   if (num_of_commas)
     {
       char *temp;
-      int l1, l2;
+      int src_idx, dest_idx;
 
-      l1 = string_len;
-      l2 = string_len + num_of_commas;
+      src_idx = string_len;
+      dest_idx = string_len + num_of_commas;
 
       temp = string;
 
-      temp[l2--] = '\0';
-      l1--;
+      temp[dest_idx--] = '\0';
+      src_idx--;
 
       /* Checks for a decimal point to avoid double-free core dumps in the scenarios described below
        *  select cast(23421.234 as numeric(7,0));  
@@ -364,22 +364,22 @@ add_commas (char *string)
 	{
 	  do
 	    {
-	      temp[l2--] = string[l1--];
+	      temp[dest_idx--] = string[src_idx--];
 	    }
-	  while (string[l1] != '.');
-	  temp[l2--] = string[l1--];
+	  while (string[src_idx] != '.');
+	  temp[dest_idx--] = string[src_idx--];
 	}
 
       for (i = 0; num_of_commas; i++)
 	{
 	  if (i && !(i % 3) && num_of_commas)
 	    {
-	      temp[l2--] = COMMA_CHAR;
+	      temp[dest_idx--] = COMMA_CHAR;
 	      --num_of_commas;
 	    }
-	  if (l1 && l2)
+	  if (src_idx && dest_idx)
 	    {
-	      temp[l2--] = string[l1--];
+	      temp[dest_idx--] = string[src_idx--];
 	    }
 	}
     }

--- a/src/executables/csql_result_format.c
+++ b/src/executables/csql_result_format.c
@@ -51,7 +51,7 @@
 #define FORMERBYTE(x)   ((UX_CHAR)(((unsigned)(x) & 0xff00) >> 8))
 #define LATTERBYTE(x)   ((UX_CHAR)((x) & 0xff))
 
-#define COMMAS_OFFSET(COND, N)   (COND == TRUE ? (N / 3) : 0)
+#define COMMAS_OFFSET(COND, N)   ((COND) == TRUE ? ((N) / 3) : 0)
 
 #define TIME_STRING_MAX         20
 
@@ -354,13 +354,18 @@ add_commas (char *string)
 
       temp = string;
 
-      do
+      /* Checks for a decimal point to avoid double-free core dumps in the scenarios described below
+       *  select cast(23421.234 as numeric(7,0));  
+       */
+      if (string[last_digit + 1] == '.')
 	{
+	  do
+	    {
+	      temp[l2--] = string[l1--];
+	    }
+	  while (string[l1] != '.');
 	  temp[l2--] = string[l1--];
 	}
-      while (string[l1] != '.');
-
-      temp[l2--] = string[l1--];
 
       for (i = 0; num_of_commas; i++)
 	{
@@ -905,47 +910,27 @@ numeric_to_string (DB_VALUE * value, bool commas)
 {
   char str_buf[NUMERIC_MAX_STRING_SIZE];
   char *return_string;
-  int prec;
-  int comma_length;
-  int max_length;
+  int comma_length = 0;
+  int str_length = 0;
 
-#if 0
-  /*
-   * Allocate string length based on precision plus the commas plus a
-   * character for each of the sign, decimal point, and NULL terminator.
-   */
-  prec = DB_VALUE_PRECISION (value);
-  comma_length = COMMAS_OFFSET (commas, prec);
-  max_length = prec + comma_length + 3;
-  return_string = (char *) malloc (max_length);
+  numeric_db_value_print (value, str_buf);
+
+  comma_length = COMMAS_OFFSET (commas, DB_VALUE_PRECISION (value));
+  str_length = strlen (str_buf) + 1;	// include '\0'
+
+
+  return_string = (char *) malloc (str_length + comma_length + 1);
   if (return_string == NULL)
     {
       return (NULL);
     }
 
-  numeric_db_value_print (value, str_buf);
-  if (strlen (str_buf) > max_length - 1)
-    {
-      free_and_init (return_string);
-      return (duplicate_string ("NUM OVERFLOW"));
-    }
-  strcpy (return_string, str_buf);
-#else
-  prec = DB_VALUE_PRECISION (value);
-  comma_length = COMMAS_OFFSET (commas, prec);
-
-  numeric_db_value_print (value, str_buf);
-
-  max_length = strlen (str_buf) + comma_length + 2;
-  return_string = (char *) malloc (max_length);
-
-  strcpy (return_string, str_buf);
+  memcpy (return_string, str_buf, str_length);
 
   if (commas == true)
     {
       add_commas (return_string);
     }
-#endif
   return return_string;
 }
 

--- a/src/executables/csql_result_format.c
+++ b/src/executables/csql_result_format.c
@@ -916,6 +916,15 @@ numeric_to_string (DB_VALUE * value, bool commas)
   int comma_length = 0;
   int str_length = 0;
 
+  do
+    {
+      /* Force-disable commas to preserve legacy behavior.
+       * TODO: Once the comma display requirement is finalized, update default_numeric_profile.commas and delete this block.
+       */
+      commas = false;
+    }
+  while (0);
+
   numeric_db_value_print (value, str_buf);
 
   comma_length = COMMAS_OFFSET (commas, DB_VALUE_PRECISION (value));
@@ -934,6 +943,7 @@ numeric_to_string (DB_VALUE * value, bool commas)
     {
       add_commas (return_string);
     }
+
   return return_string;
 }
 

--- a/src/executables/csql_result_format.c
+++ b/src/executables/csql_result_format.c
@@ -909,6 +909,7 @@ numeric_to_string (DB_VALUE * value, bool commas)
   int comma_length;
   int max_length;
 
+#if 0
   /*
    * Allocate string length based on precision plus the commas plus a
    * character for each of the sign, decimal point, and NULL terminator.
@@ -929,7 +930,22 @@ numeric_to_string (DB_VALUE * value, bool commas)
       return (duplicate_string ("NUM OVERFLOW"));
     }
   strcpy (return_string, str_buf);
+#else
+  prec = DB_VALUE_PRECISION (value);
+  comma_length = COMMAS_OFFSET (commas, prec);
 
+  numeric_db_value_print (value, str_buf);
+
+  max_length = strlen (str_buf) + comma_length + 2;
+  return_string = (char *) malloc (max_length);
+
+  strcpy (return_string, str_buf);
+
+  if (commas == true)
+    {
+      add_commas (return_string);
+    }
+#endif
   return return_string;
 }
 

--- a/src/executables/csql_result_format.c
+++ b/src/executables/csql_result_format.c
@@ -354,6 +354,9 @@ add_commas (char *string)
 
       temp = string;
 
+      temp[l2--] = '\0';
+      l1--;
+
       /* Checks for a decimal point to avoid double-free core dumps in the scenarios described below
        *  select cast(23421.234 as numeric(7,0));  
        */


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26563>

### Purpose

- csql에서 round()의 결과가 `NUM OVERFLOW`로 나오는 문제 해소

### Implementation

- `add_commas ()` 함수의 오류가 있어 수정 해 둡니다.(현재 이 함수를 호출하는 케이스는 없는 상태입니다.)
- `numeric_to_string ()`에서 `commas` 아규먼트에 따른 처리 로직이 빠져 있어 추가 둡니다.
   다만 기존과 동일한 결과를 유지 하기 위해 아규먼트를 강제로 false로 변경해 두고 있습니다.


### Remarks

select  round(-0.5);
select  round(-0.61);
