### PR TITLE
[CBRD-26523] Check for EOF before waiting in xlogwr_get_log_pages.

### DIFF
--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -645,6 +645,7 @@ logpb_initialize_pool (THREAD_ENTRY * thread_p)
   pthread_cond_init (&writer_info->flush_end_cond, NULL);
   pthread_mutex_init (&writer_info->flush_end_mutex, NULL);
 
+  writer_info->flush_completed = true;
   writer_info->is_init = true;
 
   return error_code;

--- a/src/transaction/log_writer.c
+++ b/src/transaction/log_writer.c
@@ -2631,6 +2631,45 @@ xlogwr_get_log_pages (THREAD_ENTRY * thread_p, LOG_PAGEID first_pageid, LOGWR_MO
 
       if (entry->status == LOGWR_STATUS_WAIT)
 	{
+	  LOG_LSA nxio_lsa = log_Gl.append.get_nxio_lsa ();
+
+	  /* Avoid sleeping if logs were flushed while sending previous pages.
+	   * Acquire wr_list_mutex to synchronize with LFT which may concurrently
+	   * change entry->status to LOGWR_STATUS_FETCH under the same mutex.
+	   */
+	  if (!LSA_ISNULL (&entry->last_sent_eof_lsa) && LSA_LT (&entry->last_sent_eof_lsa, &nxio_lsa))
+	    {
+	      rv = pthread_mutex_lock (&writer_info->wr_list_mutex);
+	      if (entry->status == LOGWR_STATUS_WAIT)
+		{
+		  entry->status = LOGWR_STATUS_DELAY;
+		}
+	      pthread_mutex_unlock (&writer_info->wr_list_mutex);
+	    }
+
+	  if (entry->status == LOGWR_STATUS_WAIT)
+	    {
+	      bool flush_in_progress;
+
+	      /* If a flush is already in progress, join it without sleeping. */
+	      rv = pthread_mutex_lock (&writer_info->flush_wait_mutex);
+	      flush_in_progress = (writer_info->flush_completed == false);
+	      pthread_mutex_unlock (&writer_info->flush_wait_mutex);
+
+	      if (flush_in_progress)
+		{
+		  rv = pthread_mutex_lock (&writer_info->wr_list_mutex);
+		  if (entry->status == LOGWR_STATUS_WAIT)
+		    {
+		      entry->status = LOGWR_STATUS_FETCH;
+		    }
+		  pthread_mutex_unlock (&writer_info->wr_list_mutex);
+		}
+	    }
+	}
+
+      if (entry->status == LOGWR_STATUS_WAIT)
+	{
 	  bool continue_checking = true;
 
 	  if (mode == LOGWR_MODE_ASYNC)
@@ -2703,10 +2742,14 @@ xlogwr_get_log_pages (THREAD_ENTRY * thread_p, LOG_PAGEID first_pageid, LOGWR_MO
 	}
       else
 	{
-	  assert (entry->status == LOGWR_STATUS_DELAY);
+	  assert (entry->status == LOGWR_STATUS_DELAY || entry->status == LOGWR_STATUS_FETCH);
 	  pthread_mutex_unlock (&writer_info->flush_start_mutex);
-	  LOG_CS_ENTER (thread_p);
-	  check_cs_own = true;
+
+	  if (entry->status == LOGWR_STATUS_DELAY)
+	    {
+	      LOG_CS_ENTER (thread_p);
+	      check_cs_own = true;
+	    }
 	}
 
       if (thread_p->resume_status == THREAD_RESUME_DUE_TO_INTERRUPT)

--- a/src/transaction/log_writer.h
+++ b/src/transaction/log_writer.h
@@ -184,7 +184,7 @@ struct logwr_info
     , flush_end_cond PTHREAD_COND_INITIALIZER
     , flush_end_mutex PTHREAD_MUTEX_INITIALIZER
     , skip_flush (false)
-    , flush_completed (false)
+    , flush_completed (true)
     , is_init (false)
     , trace_last_writer (false)
     , last_writer_client_info ()


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26523>

### Purpose

N/A

### Implementation

N/A

### Remarks

N/A
