### PR TITLE
[CUBVEC-170] [bugfix] Move m_level_generator to algo class

### DIFF
--- a/src/storage/index_hnsw/hnsw_algo.hpp
+++ b/src/storage/index_hnsw/hnsw_algo.hpp
@@ -146,6 +146,8 @@ namespace cubhnsw
       std::size_t m_connectivity;
       std::size_t m_expansion;
 
+      std::default_random_engine m_level_generator {std::random_device{}()};
+
       // precomputed
       double m_inverse_log_connectivity;
   };
@@ -214,7 +216,7 @@ namespace cubhnsw
     root_type root_node = root_type (root_block->data);
     {
       curr_max_level = root_node.get_level(); // get max_level from root page
-      new_target_level = choose_random_level_ (context.m_level_generator, m_inverse_log_connectivity);
+      new_target_level = choose_random_level_ (m_level_generator, m_inverse_log_connectivity);
       entry_slot = root_node.get_entry();
       if (new_target_level > MAX_LEVELS)
 	{

--- a/src/storage/index_hnsw/hnsw_algo_common.hpp
+++ b/src/storage/index_hnsw/hnsw_algo_common.hpp
@@ -139,7 +139,6 @@ namespace cubhnsw
     top_candidates_t<Traits> m_top_for_refine;
     next_candidates_t<Traits> m_next_candidates;
     visited_set_t<Traits> m_visits;
-    std::default_random_engine m_level_generator;
     cubthread::entry *m_thread_p {nullptr};
 
     // stats


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-170

### Purpose

HNSW에서 새로운 노드의 높이를 결정하기 위해서 random generator를 사용하는데, 매번 삽입될 때마다 새로 초기화되는 algo_context에 있어, 높은 level이 거의 만들어지지 않는 문제 수정

### Implementation

- std::default_random_engine m_level_generator를 algo 클래스로 옮기고 random seed를 부여하기 위해 random_device 설정

### Remarks

- HNSW의 높이값이 level generator에서 올바르게 반환되어 기존에 flat 한 구조를 가지는 문제점이 개선됨. 특히 인덱스 빌드 속도가 향상됨을 보임
