### PR TITLE
[CBRD-26578] use query start offset in the lexer buffer to set the start offset of SP body

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -454,6 +454,7 @@ void _push_msg (int code, int line);
 void pop_msg (void);
 
 char *g_query_string;
+int g_query_string_pos;
 int g_query_string_len;
 int g_original_buffer_len;
 
@@ -1807,10 +1808,12 @@ stmt
 			      }
 
 			    g_query_string = (char*) (this_parser->original_buffer + pos);
+                            g_query_string_pos = pos;
 
 			    while (char_isspace (*g_query_string))
 			      {
 			        g_query_string++;
+			        g_query_string_pos++;
 			      }
 			  }
 		}}
@@ -11677,7 +11680,7 @@ plcsql_text
 		{{
                         assert(g_plcsql_text_pos == -1);
                         $$ = strlen($1);
-                        g_plcsql_text_pos = @$.buffer_pos - $$;
+                        g_plcsql_text_pos = @$.buffer_pos - g_query_string_pos - $$;
 		}}
         ;
 
@@ -23700,6 +23703,7 @@ parser_main (PARSER_CONTEXT * parser)
   csql_yylloc.buffer_pos=0;
 
   g_query_string = NULL;
+  g_query_string_pos = 0;
   g_query_string_len = 0;
   g_original_buffer_len = 0;
 
@@ -23811,6 +23815,7 @@ parse_one_statement (int state)
   csql_yylloc.buffer_pos=0;
 
   g_query_string = NULL;
+  g_query_string_pos = 0;
   g_query_string_len = 0;
   g_original_buffer_len = 0;
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26578>

### Purpose

PL/CSQL SP 생성을 위한 CREATE PROCEDURE 문에서 body text (begin 이후) 가 잘못 인식되는 문제를 해결합니다. 
현재 구현은 CREATE 키워드 앞에 아무런 공란이 없을 때만 정상 동작합니다. 

### Implementation

Lexer buffer 상에서 query 의 시작 offset 을 기억하고 있다가 PL/CSQL SP body text 의 시작 offset 을 구할 때 반영합니다. 

