### PR TITLE
[CBRD-26591] Slave node core dump (leak) during Create Table as Select operation on CLOB tables in HA setup

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -12201,14 +12201,12 @@ heap_attrinfo_transform_variable_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_AT
 	  save_meta_data = elo_p->meta_data;
 	  elo_p->meta_data = new_meta_data;
 	  ret = db_elo_copy_with_prefix (db_get_elo (dbvalue), lob_path_prefix, &dest_elo);
-
 	  free_and_init (elo_p->meta_data);
+	  elo_p->meta_data = save_meta_data;
 	  if (ret != NO_ERROR)
 	    {
 	      return S_ERROR;
 	    }
-
-	  elo_p->meta_data = save_meta_data;
 
 	  /* The purpose of HEAP_WRITTEN_LOB_ATTRVALUE is to avoid reenter this branch. In the first pass,
 	   * this branch is entered and elo is copied. When BUFFER_OVERFLOW happens, we need avoid to copy


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26591>

### Purpose

* HA 구성된 상태에서 clob 타입을 갖은 테이블을 이용하여 create select 구문을 수행 할 때 slave에서 leak 발생하여
* resource tracker에 의해 코어 덤프 발생하는 문제  

### Implementation

N/A

### Remarks
- 이 문제는 아래가 적용되면서 발생한 문제임
  [CBRD-23700]  After executing the DROP table, LOB objects are not removed (#6833)
