### PR TITLE
[CBRD-26586] Prevent newly created threads from inheriting affinity settings.

### DIFF
--- a/src/base/resources.cpp
+++ b/src/base/resources.cpp
@@ -21,9 +21,9 @@
  */
 
 #include <cmath>
+#include <iterator>
 #include <thread>
 #include <fstream>
-#include <sched.h>
 #include <unistd.h>
 #include <net/if.h>
 #include <sys/socket.h>
@@ -41,6 +41,11 @@
 
 namespace os::resources
 {
+  void initialize ()
+  {
+    os::resources::cpu::effective ();
+  }
+
   std::optional<std::string> execute_command (const char *cmd)
   {
     std::string result;
@@ -65,7 +70,7 @@ namespace os::resources
 
   namespace cpu
   {
-    std::optional<std::set<std::size_t>> affinity_cpuset ()
+    std::tuple<std::optional<std::set<std::size_t>>, cpu_set_t *, std::size_t> affinity_cpuset ()
     {
       std::set<std::size_t> cpuset;
       cpu_set_t *bitmap;
@@ -80,7 +85,7 @@ namespace os::resources
 	  bitmap = CPU_ALLOC (size);
 	  if (!bitmap)
 	    {
-	      return std::nullopt;
+	      return { std::nullopt, nullptr, 0 };
 	    }
 
 	  CPU_ZERO_S (bytes, bitmap);
@@ -97,7 +102,7 @@ namespace os::resources
 	      /* _er_log_debug (ARG_FILE_LINE, "failed to sched_getaffinity: %s\n", strerror (errno)); */
 
 	      CPU_FREE (bitmap);
-	      return std::nullopt;
+	      return { std::nullopt, nullptr, 0 };
 	    }
 
 	  for (j = 0; j < size; j++)
@@ -108,12 +113,11 @@ namespace os::resources
 		}
 	    }
 
-	  CPU_FREE (bitmap);
-	  return cpuset;
+	  return { cpuset, bitmap, size };
 	}
 
       /* _er_log_debug (ARG_FILE_LINE, "failed to create cpuset: number of cores exceeds 2^18.\n"); */
-      return std::nullopt;
+      return { std::nullopt, nullptr, 0 };
     }
 
     std::optional<std::set<std::size_t>> online_cpuset ()
@@ -139,32 +143,78 @@ namespace os::resources
 
     void setaffinity (std::size_t core)
     {
-      cpu_set_t set;
+      cpu_set_t *bitmap;
+      std::size_t size;
       int status;
+      const auto &ctx = effective ();
+      if (!ctx.affinity.bitmap)
+	{
+	  return ;
+	}
 
-      CPU_ZERO (&set);
-      CPU_SET (core, &set);
-      status = pthread_setaffinity_np (pthread_self (), sizeof (set), &set);
+      size = CPU_ALLOC_SIZE (ctx.affinity.size);
+      bitmap = CPU_ALLOC (ctx.affinity.size);
+      if (!bitmap)
+	{
+	  return ;
+	}
+
+      CPU_ZERO_S (size, bitmap);
+      CPU_SET_S (core, size, bitmap);
+
+      status = pthread_setaffinity_np (pthread_self (), size, bitmap);
       if (status)
 	{
 	  _er_log_debug (__FILE__, __LINE__, "pthread_setaffinity_np failed for core %d: %s\n", core, strerror (status));
 	}
+
+      CPU_FREE (bitmap);
     }
 
-    context effective ()
+    void clearaffinity ()
     {
-      static const context ctx = []() -> context
+      int status;
+      const auto &ctx = effective ();
+      if (!ctx.affinity.bitmap)
+	{
+	  return ;
+	}
+
+      status = pthread_setaffinity_np (pthread_self (), CPU_ALLOC_SIZE (ctx.affinity.size), ctx.affinity.bitmap);
+      if (status)
+	{
+	  _er_log_debug (__FILE__, __LINE__, "pthread_setaffinity_np failed: %s\n", strerror (status));
+	}
+    }
+
+    /* This function must be called first in the main thread's entry point */
+    /* to initialize CPU and affinity information.			   */
+    context &effective ()
+    {
+      static context ctx = []() -> context
       {
 	std::optional<std::set<std::size_t>> affinity, online;
 	cgroup::cpu::context cgroup;
-	context ctx;
+	cpu_set_t *bitmap;
 	int nprocessors;
+	std::size_t size;
+	context ctx;
 
-	affinity = affinity_cpuset ();
+	std::tie (affinity, bitmap, size) = affinity_cpuset ();
 	if (affinity)
 	  {
+	    assert (bitmap);
+	    assert (size > 0);
+
 	    ctx.max = affinity->size ();
 	    ctx.effective = std::move (*affinity);
+
+	    if (ctx.affinity.bitmap)
+	      {
+		CPU_FREE (ctx.affinity.bitmap);
+	      }
+	    ctx.affinity.bitmap = bitmap;
+	    ctx.affinity.size = size;
 	  }
 
 	online = online_cpuset ();

--- a/src/base/resources.cpp
+++ b/src/base/resources.cpp
@@ -70,7 +70,7 @@ namespace os::resources
 
   namespace cpu
   {
-    std::tuple<std::optional<std::set<std::size_t>>, cpu_set_t *, std::size_t> affinity_cpuset ()
+    std::optional<std::tuple<std::set<std::size_t>, cpu_set_t *, std::size_t>> affinity_cpuset ()
     {
       std::set<std::size_t> cpuset;
       cpu_set_t *bitmap;
@@ -85,7 +85,7 @@ namespace os::resources
 	  bitmap = CPU_ALLOC (size);
 	  if (!bitmap)
 	    {
-	      return { std::nullopt, nullptr, 0 };
+	      return std::nullopt;
 	    }
 
 	  CPU_ZERO_S (bytes, bitmap);
@@ -102,7 +102,7 @@ namespace os::resources
 	      /* _er_log_debug (ARG_FILE_LINE, "failed to sched_getaffinity: %s\n", strerror (errno)); */
 
 	      CPU_FREE (bitmap);
-	      return { std::nullopt, nullptr, 0 };
+	      return std::nullopt;
 	    }
 
 	  for (j = 0; j < size; j++)
@@ -113,11 +113,11 @@ namespace os::resources
 		}
 	    }
 
-	  return { cpuset, bitmap, size };
+	  return std::tuple { cpuset, bitmap, size };
 	}
 
       /* _er_log_debug (ARG_FILE_LINE, "failed to create cpuset: number of cores exceeds 2^18.\n"); */
-      return { std::nullopt, nullptr, 0 };
+      return std::nullopt;
     }
 
     std::optional<std::set<std::size_t>> online_cpuset ()
@@ -193,21 +193,22 @@ namespace os::resources
     {
       static context ctx = []() -> context
       {
-	std::optional<std::set<std::size_t>> affinity, online;
+	std::optional<std::set<std::size_t>> online;
+	std::set<std::size_t> affinity;
 	cgroup::cpu::context cgroup;
 	cpu_set_t *bitmap;
 	int nprocessors;
 	std::size_t size;
 	context ctx;
 
-	std::tie (affinity, bitmap, size) = affinity_cpuset ();
-	if (affinity)
+	auto affinity_tuple = affinity_cpuset ();
+	if (affinity_tuple)
 	  {
-	    assert (bitmap);
-	    assert (size > 0);
+	    std::tie (affinity, bitmap, size) = *affinity_tuple;
+	    assert (bitmap && size > 0);
 
-	    ctx.max = affinity->size ();
-	    ctx.effective = std::move (*affinity);
+	    ctx.max = affinity.size ();
+	    ctx.effective = std::move (affinity);
 
 	    if (ctx.affinity.bitmap)
 	      {

--- a/src/base/resources.hpp
+++ b/src/base/resources.hpp
@@ -28,6 +28,7 @@
 #include <vector>
 #include <limits>
 #include <optional>
+#include <sched.h>
 
 namespace os::resources
 {
@@ -36,6 +37,7 @@ namespace os::resources
     inline constexpr const char *cpu_online = "/sys/devices/system/cpu/online";
   }
 
+  void initialize ();
   std::optional<std::string> execute_command (const char *cmd);
 
   namespace cpu
@@ -43,10 +45,63 @@ namespace os::resources
     struct context
     {
       context () :
+	affinity { nullptr, 0 },
 	max (std::numeric_limits<double>::max ()),
-	effective (std::nullopt)
+	effective (std::nullopt),
+	adjusted_max (0),
+	adjusted_effective (std::nullopt)
       {
       }
+
+      ~context ()
+      {
+	if (affinity.bitmap)
+	  {
+	    CPU_FREE (affinity.bitmap);
+	    affinity.bitmap = nullptr;
+	    affinity.size = 0;
+	  }
+      }
+
+      context (const context &) = delete;
+      context &operator= (const context &) = delete;
+
+      context (context &&other) :
+	affinity { other.affinity.bitmap, other.affinity.size },
+	max (other.max),
+	effective (std::move (other.effective)),
+	adjusted_max (other.adjusted_max),
+	adjusted_effective (std::move (other.adjusted_effective))
+      {
+	other.affinity.bitmap = nullptr;
+	other.affinity.size = 0;
+      }
+
+      context &operator= (context &&other)
+      {
+	if (this != &other)
+	  {
+	    if (affinity.bitmap)
+	      {
+		CPU_FREE (affinity.bitmap);
+	      }
+	    affinity = { other.affinity.bitmap, other.affinity.size };
+	    max = other.max;
+	    effective = std::move (other.effective);
+	    adjusted_max = other.adjusted_max;
+	    adjusted_effective = std::move (other.adjusted_effective);
+
+	    other.affinity.bitmap = nullptr;
+	    other.affinity.size = 0;
+	  }
+	return *this;
+      }
+
+      struct
+      {
+	cpu_set_t *bitmap;
+	std::size_t size;
+      } affinity;
 
       double max;
       std::optional<std::set<std::size_t>> effective;
@@ -55,12 +110,13 @@ namespace os::resources
       std::optional<std::vector<std::size_t>> adjusted_effective;
     };
 
-    std::optional<std::set<std::size_t>> affinity_cpuset ();
+    std::tuple<std::optional<std::set<std::size_t>>, cpu_set_t *, std::size_t> affinity_cpuset ();
     std::optional<std::set<std::size_t>> online_cpuset ();
 
     void setaffinity (std::size_t core);
+    void clearaffinity ();
 
-    context effective ();
+    context &effective ();
   }
 
   namespace net

--- a/src/base/resources.hpp
+++ b/src/base/resources.hpp
@@ -110,7 +110,7 @@ namespace os::resources
       std::optional<std::vector<std::size_t>> adjusted_effective;
     };
 
-    std::tuple<std::optional<std::set<std::size_t>>, cpu_set_t *, std::size_t> affinity_cpuset ();
+    std::optional<std::tuple<std::set<std::size_t>, cpu_set_t *, std::size_t>> affinity_cpuset ();
     std::optional<std::set<std::size_t>> online_cpuset ();
 
     void setaffinity (std::size_t core);

--- a/src/connection/connection_pool.cpp
+++ b/src/connection/connection_pool.cpp
@@ -248,7 +248,7 @@ namespace cubconn::connection
 
   std::uint32_t pool::initialize_topology (std::uint32_t max_connection_workers)
   {
-    auto ctx = os::resources::cpu::effective ();
+    const auto &ctx = os::resources::cpu::effective ();
 
     if (ctx.adjusted_effective && !ctx.adjusted_effective->empty ())
       {
@@ -270,7 +270,7 @@ namespace cubconn::connection
   {
     std::vector<std::size_t> cores;
     std::uint32_t i;
-    auto ctx = os::resources::cpu::effective ();
+    const auto &ctx = os::resources::cpu::effective ();
 
     assert (m_mutex_holder == std::this_thread::get_id ());
 
@@ -353,7 +353,7 @@ namespace cubconn::connection
   void pool::initialize_coordinator (std::uint32_t max_connection_workers, std::uint32_t min_connection_workers)
   {
     std::size_t core;
-    auto ctx = os::resources::cpu::effective ();
+    const auto &ctx = os::resources::cpu::effective ();
 
     if (ctx.adjusted_effective)
       {

--- a/src/thread/thread_manager.cpp
+++ b/src/thread/thread_manager.cpp
@@ -43,6 +43,7 @@
 #include "lockfree_transaction_system.hpp"
 #include "resource_shared_pool.hpp"
 #include "system_parameter.h"
+#include "resources.hpp"
 
 #include <cassert>
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
@@ -491,6 +492,8 @@ namespace cubthread
   initialize (entry *&my_entry)
   {
     // note - currently it is designed to be called only once. if we want repeatable calls, code must be updated.
+
+    os::resources::initialize ();
 
     assert (my_entry == NULL);
 

--- a/src/thread/thread_worker_pool.hpp
+++ b/src/thread/thread_worker_pool.hpp
@@ -30,6 +30,7 @@
 // cubrid includes
 #include "perf_def.hpp"
 #include "extensible_array.hpp"
+#include "resources.hpp"
 
 // system includes
 #include <atomic>
@@ -1580,6 +1581,7 @@ namespace cubthread
   {
     task_type *task_p = NULL;
 
+    os::resources::cpu::clearaffinity ();   // clear the affinity at start
     init_run ();    // do stuff at the beginning like creating context
 
     if (m_is_temp)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26586>

### Purpose

thread pool에서 새 thread를 생성할 때 기존 affinity로 되돌립니다.

### Implementation

N/A

### Remarks

N/A
