### PR TITLE
[CBRD-26555] remove query entry in pl_executor when the result has no records

### DIFF
--- a/src/method/method_invoke_java.cpp
+++ b/src/method/method_invoke_java.cpp
@@ -471,17 +471,20 @@ namespace cubmethod
 	  if (stmt_type == CUBRID_STMT_SELECT)
 	    {
 	      std::uint64_t qid = current_result_info.query_id;
-              if (current_result_info.tuple_count > 0) {
-                  bool is_oid_included = current_result_info.include_oid;
-                  (void) m_group->create_cursor (qid, is_oid_included);
-              } else {
-                  QMGR_QUERY_ENTRY *query_entry = qmgr_get_query_entry (&thread_ref, qid, NULL_TRAN_INDEX);
-                  if (query_entry)
-                    {
-                      qfile_close_list (&thread_ref, query_entry->list_id);
-                    }
-                  xqmgr_end_query (&thread_ref, qid);
-              }
+	      if (current_result_info.tuple_count > 0)
+		{
+		  bool is_oid_included = current_result_info.include_oid;
+		  (void) m_group->create_cursor (qid, is_oid_included);
+		}
+	      else
+		{
+		  QMGR_QUERY_ENTRY *query_entry = qmgr_get_query_entry (&thread_ref, qid, NULL_TRAN_INDEX);
+		  if (query_entry)
+		    {
+		      qfile_close_list (&thread_ref, query_entry->list_id);
+		    }
+		  xqmgr_end_query (&thread_ref, qid);
+		}
 	    }
 	}
 

--- a/src/method/method_invoke_java.cpp
+++ b/src/method/method_invoke_java.cpp
@@ -35,6 +35,7 @@
 #include "method_struct_query.hpp"
 #include "method_query_util.hpp"
 #include "method_runtime_context.hpp"
+#include "xserver_interface.h"
 
 #include "log_impl.h"
 
@@ -470,8 +471,17 @@ namespace cubmethod
 	  if (stmt_type == CUBRID_STMT_SELECT)
 	    {
 	      std::uint64_t qid = current_result_info.query_id;
-	      bool is_oid_included = current_result_info.include_oid;
-	      (void) m_group->create_cursor (qid, is_oid_included);
+              if (current_result_info.tuple_count > 0) {
+                  bool is_oid_included = current_result_info.include_oid;
+                  (void) m_group->create_cursor (qid, is_oid_included);
+              } else {
+                  QMGR_QUERY_ENTRY *query_entry = qmgr_get_query_entry (&thread_ref, qid, NULL_TRAN_INDEX);
+                  if (query_entry)
+                    {
+                      qfile_close_list (&thread_ref, query_entry->list_id);
+                    }
+                  xqmgr_end_query (&thread_ref, qid);
+              }
 	    }
 	}
 

--- a/src/method/method_query_cursor.cpp
+++ b/src/method/method_query_cursor.cpp
@@ -38,7 +38,7 @@ namespace cubmethod
 
   query_cursor::~query_cursor ()
   {
-      close();
+    close();
   }
 
   int
@@ -73,8 +73,8 @@ namespace cubmethod
       {
 	clear ();
 	qfile_close_scan (m_thread, &m_scan_id);
-        qfile_close_list (m_thread, m_list_id);
-        xqmgr_end_query (m_thread, m_query_id);
+	qfile_close_list (m_thread, m_list_id);
+	xqmgr_end_query (m_thread, m_query_id);
 	m_is_opened = false;
       }
   }
@@ -110,14 +110,14 @@ namespace cubmethod
 		TP_DOMAIN *domain = m_list_id->type_list.domp[i];
 		if (domain == NULL || domain->type == NULL)
 		  {
-                    scan_code = S_ERROR;
+		    scan_code = S_ERROR;
 		    break;
 		  }
 
 		PR_TYPE *pr_type = domain->type;
 		if (pr_type == NULL)
 		  {
-                    scan_code = S_ERROR;
+		    scan_code = S_ERROR;
 		    break;
 		  }
 
@@ -125,7 +125,7 @@ namespace cubmethod
 
 		if (pr_type->data_readval (&buf, value, domain, -1, true, NULL, 0) != NO_ERROR)
 		  {
-                    scan_code = S_ERROR;
+		    scan_code = S_ERROR;
 		    break;
 		  }
 	      }
@@ -133,9 +133,9 @@ namespace cubmethod
       }
 
     if (scan_code == S_END || scan_code == S_ERROR)
-    {
-      close ();
-    }
+      {
+	close ();
+      }
 
     return scan_code;
   }

--- a/src/method/method_query_cursor.cpp
+++ b/src/method/method_query_cursor.cpp
@@ -163,8 +163,6 @@ namespace cubmethod
     return m_current_tuple;
   }
 
-  void clear ();
-
   int
   query_cursor::get_current_index ()
   {

--- a/src/method/method_query_cursor.cpp
+++ b/src/method/method_query_cursor.cpp
@@ -23,6 +23,7 @@
 #include "list_file.h"
 #include "log_impl.h"
 #include "object_representation.h"
+#include "xserver_interface.h"
 
 namespace cubmethod
 {
@@ -33,6 +34,11 @@ namespace cubmethod
     , m_fetch_count (1000) // FIXME: change the fixed value, 1000
   {
     reset (query_entry_p);
+  }
+
+  query_cursor::~query_cursor ()
+  {
+      close();
   }
 
   int
@@ -67,6 +73,8 @@ namespace cubmethod
       {
 	clear ();
 	qfile_close_scan (m_thread, &m_scan_id);
+        qfile_close_list (m_thread, m_list_id);
+        xqmgr_end_query (m_thread, m_query_id);
 	m_is_opened = false;
       }
   }
@@ -76,53 +84,6 @@ namespace cubmethod
   {
     m_current_tuple.clear ();
     m_current_row_index = 0;
-  }
-
-  SCAN_CODE
-  query_cursor::prev_row ()
-  {
-    QFILE_TUPLE_RECORD tuple_record = { NULL, 0 };
-    SCAN_CODE scan_code = qfile_scan_list_prev (m_thread, &m_scan_id, &tuple_record, PEEK);
-    if (scan_code == S_SUCCESS)
-      {
-	m_current_row_index--;
-	char *ptr;
-	int length;
-	OR_BUF buf;
-
-	for (int i = 0; i < m_list_id->type_list.type_cnt; i++)
-	  {
-	    QFILE_TUPLE_VALUE_FLAG flag = (QFILE_TUPLE_VALUE_FLAG) qfile_locate_tuple_value_r (tuple_record.tpl, i, &ptr, &length);
-	    or_init (&buf, ptr, length);
-
-	    TP_DOMAIN *domain = m_list_id->type_list.domp[i];
-	    if (domain == NULL || domain->type == NULL)
-	      {
-		//TODO: error handling?
-		qfile_close_scan (m_thread, &m_scan_id);
-	      }
-
-	    DB_VALUE *value = &m_current_tuple[i];
-	    PR_TYPE *pr_type = domain->type;
-
-	    db_make_null (value);
-	    if (flag == V_BOUND)
-	      {
-		if (pr_type->data_readval (&buf, value, domain, -1, true, NULL, 0) != NO_ERROR)
-		  {
-		    scan_code = S_ERROR;
-		    break;
-		  }
-	      }
-	    else
-	      {
-		/* If value is NULL, properly initialize the result */
-		db_value_domain_init (value, pr_type->id, DB_DEFAULT_PRECISION, DB_DEFAULT_SCALE);
-	      }
-	  }
-      }
-
-    return scan_code;
   }
 
   SCAN_CODE
@@ -149,26 +110,32 @@ namespace cubmethod
 		TP_DOMAIN *domain = m_list_id->type_list.domp[i];
 		if (domain == NULL || domain->type == NULL)
 		  {
-		    //TODO: error handling?
-		    qfile_close_scan (m_thread, &m_scan_id);
-		    return S_ERROR;
+                    scan_code = S_ERROR;
+		    break;
 		  }
 
 		PR_TYPE *pr_type = domain->type;
 		if (pr_type == NULL)
 		  {
-		    return S_ERROR;
+                    scan_code = S_ERROR;
+		    break;
 		  }
 
 		or_init (&buf, ptr, length);
 
 		if (pr_type->data_readval (&buf, value, domain, -1, true, NULL, 0) != NO_ERROR)
 		  {
-		    return S_ERROR;
+                    scan_code = S_ERROR;
+		    break;
 		  }
 	      }
 	  }
       }
+
+    if (scan_code == S_END || scan_code == S_ERROR)
+    {
+      close ();
+    }
 
     return scan_code;
   }

--- a/src/method/method_query_cursor.hpp
+++ b/src/method/method_query_cursor.hpp
@@ -43,6 +43,7 @@ namespace cubmethod
   {
     public:
       query_cursor (cubthread::entry *thread_p, QMGR_QUERY_ENTRY *query_entry_p, bool is_oid_included = false);
+      ~query_cursor();
 
       int open ();
       void close ();
@@ -56,7 +57,6 @@ namespace cubmethod
 
       SCAN_CODE cursor (int peek);
 
-      SCAN_CODE prev_row ();
       SCAN_CODE next_row ();
 
       void clear ();

--- a/src/method/method_query_cursor.hpp
+++ b/src/method/method_query_cursor.hpp
@@ -46,26 +46,16 @@ namespace cubmethod
       ~query_cursor();
 
       int open ();
-      void close ();
-
-      int reset (QMGR_QUERY_ENTRY *query_entry_p);
 
       void change_owner (cubthread::entry *thread_p);
 
-      int first ();
-      int last ();
-
-      SCAN_CODE cursor (int peek);
-
       SCAN_CODE next_row ();
 
-      void clear ();
 
       QUERY_ID get_query_id ();
       int get_current_index ();
       std::vector<DB_VALUE> get_current_tuple ();
       OID *get_current_oid ();
-      int get_tuple_value (int index, DB_VALUE &result);
       bool get_is_oid_included ();
       bool get_is_opened ();
 
@@ -73,6 +63,11 @@ namespace cubmethod
       void set_fetch_count (int cnt);
 
     private:
+      int reset (QMGR_QUERY_ENTRY *query_entry_p);
+
+      void close ();
+      void clear ();
+
       cubthread::entry *m_thread; /* which thread owns this cursor */
 
       QUERY_ID m_query_id;		/* Query id for this cursor */

--- a/src/method/method_runtime_context.cpp
+++ b/src/method/method_runtime_context.cpp
@@ -393,11 +393,6 @@ namespace cubmethod
 	query_cursor *cursor = search->second;
 	if (cursor)
 	  {
-	    cursor->close ();
-	    if (query_id > 0)
-	      {
-		(void) xqmgr_end_query (thread_p, query_id);
-	      }
 	    delete cursor;
 	  }
 

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -6595,7 +6595,8 @@ qfile_update_qlist_count (THREAD_ENTRY * thread_p, const QFILE_LIST_ID * list_p,
       thread_p->m_qlist_count += inc;
       if (prm_get_bool_value (PRM_ID_LOG_QUERY_LISTS))
 	{
-	  er_print_callstack (ARG_FILE_LINE, "update qlist_count by %d to %d\n", inc, thread_p->m_qlist_count);
+	  er_print_callstack (ARG_FILE_LINE, "[thread %d with tran index %d] update qlist_count by %d to %d\n",
+                  thread_p->index, thread_p->tran_index, inc, thread_p->m_qlist_count);
 	}
     }
 #endif // SERVER_MODE

--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -6596,7 +6596,7 @@ qfile_update_qlist_count (THREAD_ENTRY * thread_p, const QFILE_LIST_ID * list_p,
       if (prm_get_bool_value (PRM_ID_LOG_QUERY_LISTS))
 	{
 	  er_print_callstack (ARG_FILE_LINE, "[thread %d with tran index %d] update qlist_count by %d to %d\n",
-                  thread_p->index, thread_p->tran_index, inc, thread_p->m_qlist_count);
+			      thread_p->index, thread_p->tran_index, inc, thread_p->m_qlist_count);
 	}
     }
 #endif // SERVER_MODE

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -14850,7 +14850,7 @@ qexec_execute_query (THREAD_ENTRY * thread_p, xasl_node * xasl, int dbval_cnt, c
   qlist_enter_count = thread_p->m_qlist_count;
   if (prm_get_bool_value (PRM_ID_LOG_QUERY_LISTS))
     {
-      er_print_callstack (ARG_FILE_LINE, "starting query execution with qlist_count = %d\n", qlist_enter_count);
+      er_print_callstack (ARG_FILE_LINE, "[thread %d with tran index %d] starting query execution with qlist_count = %d\n", thread_p->index, thread_p->tran_index, qlist_enter_count);
     }
 #endif // SERVER_MODE
 
@@ -15014,7 +15014,7 @@ end:
 #if defined (SERVER_MODE)
   if (prm_get_bool_value (PRM_ID_LOG_QUERY_LISTS))
     {
-      er_print_callstack (ARG_FILE_LINE, "ending query execution with qlist_count = %d\n", thread_p->m_qlist_count);
+      er_print_callstack (ARG_FILE_LINE, "[thread %d with tran index %d] ending query execution with qlist_count = %d\n", thread_p->index, thread_p->tran_index, thread_p->m_qlist_count);
     }
   if (list_id && list_id->type_list.type_cnt != 0)
     {

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -14850,7 +14850,9 @@ qexec_execute_query (THREAD_ENTRY * thread_p, xasl_node * xasl, int dbval_cnt, c
   qlist_enter_count = thread_p->m_qlist_count;
   if (prm_get_bool_value (PRM_ID_LOG_QUERY_LISTS))
     {
-      er_print_callstack (ARG_FILE_LINE, "[thread %d with tran index %d] starting query execution with qlist_count = %d\n", thread_p->index, thread_p->tran_index, qlist_enter_count);
+      er_print_callstack (ARG_FILE_LINE,
+			  "[thread %d with tran index %d] starting query execution with qlist_count = %d\n",
+			  thread_p->index, thread_p->tran_index, qlist_enter_count);
     }
 #endif // SERVER_MODE
 
@@ -15014,7 +15016,9 @@ end:
 #if defined (SERVER_MODE)
   if (prm_get_bool_value (PRM_ID_LOG_QUERY_LISTS))
     {
-      er_print_callstack (ARG_FILE_LINE, "[thread %d with tran index %d] ending query execution with qlist_count = %d\n", thread_p->index, thread_p->tran_index, thread_p->m_qlist_count);
+      er_print_callstack (ARG_FILE_LINE,
+			  "[thread %d with tran index %d] ending query execution with qlist_count = %d\n",
+			  thread_p->index, thread_p->tran_index, thread_p->m_qlist_count);
     }
   if (list_id && list_id->type_list.type_cnt != 0)
     {

--- a/src/query/query_manager.c
+++ b/src/query/query_manager.c
@@ -274,21 +274,21 @@ qmgr_allocate_query_entry (THREAD_ENTRY * thread_p, QMGR_TRAN_ENTRY * tran_entry
 
   static int qmgr_max_query_entry_per_tran = prm_get_integer_value (PRM_ID_QMGR_MAX_QUERY_PER_TRAN);
 
+  pthread_mutex_lock (&tran_entry_p->mutex);
   query_p = tran_entry_p->free_query_entry_list_p;
-
   if (query_p)
     {
-      pthread_mutex_lock (&tran_entry_p->mutex);
       tran_entry_p->free_query_entry_list_p = query_p->next;
       pthread_mutex_unlock (&tran_entry_p->mutex);
     }
   else if (qmgr_max_query_entry_per_tran < tran_entry_p->num_query_entries)
     {
-      assert (qmgr_max_query_entry_per_tran >= tran_entry_p->num_query_entries);
+      pthread_mutex_unlock (&tran_entry_p->mutex);
       return NULL;
     }
   else
     {
+      pthread_mutex_unlock (&tran_entry_p->mutex);
       query_p = (QMGR_QUERY_ENTRY *) malloc (sizeof (QMGR_QUERY_ENTRY));
       if (query_p == NULL)
 	{


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26555>

### Purpose

11.5 버전에 대해서 CBRD-26555 이슈에 관한 수정의 11.3으로의 backport 입니다. 
11.3에서 11.4로 넘어 가면서 JSP 실행 구조가 다소 바뀌어 cherry-pick 으로 반영할 수 없었습니다.
11.3에서는 없던 (11.4부터 적용된) fetch 중 record set 끝에 도달하면 query cursor 닫기 기능도 함께 추가합니다. 

### Implementation

11.5에서의 수정 내용 

- pl executor 단에서 SELECT 조회 결과가 empty 인 경우 query entry 를 제거 (xqmgr_end_query() 호출) 

해 주는 기존 수정이 11.3의 해당 모듈인 method_invoke_java 에 적용되었습니다. 

그 밖에도, 11.4 부터 적용되었던 내용

- query cursor의 next_row에서 result set 끝에 도달하였을 때 close() 를 호출
- query cursor 의 소멸자에서 close() 호출
- close() 에서 xqmgr_end_query() 호출 

도 함께 적용되었습니다.

안 쓰이는 코드도 일부 삭제 되었고, 디버깅 편의를 위해 THREAD_ENTRY의 m_qlist_count 관련 로그 메시지에 thread index와 transaction id도 추가하였습니다. 

### Remarks

N/A
