### PR TITLE
[CBRD-26596] [Regression] Core dumped in qexec_execute_query at src/query/query_executor.c:16449

### DIFF
--- a/src/query/parallel/px_heap_scan/px_heap_scan.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan.cpp
@@ -608,6 +608,7 @@ namespace parallel_heap_scan
       }
     if (m_result_handler != nullptr)
       {
+	m_result_handler->read_finalize (m_thread_p);
 	m_result_handler->~result_handler();
 	db_private_free (m_thread_p, m_result_handler);
 	m_result_handler = nullptr;
@@ -1086,7 +1087,6 @@ namespace parallel_heap_scan
   int manager<result_type>::close()
   {
     THREAD_ENTRY *thread_p = m_thread_p;
-    m_result_handler->read_finalize (thread_p);
     m_scan_id->s.phsid.manager = nullptr;
     this->~manager();
     db_private_free (thread_p, this);

--- a/src/query/parallel/px_heap_scan/px_heap_scan.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan.cpp
@@ -1086,6 +1086,7 @@ namespace parallel_heap_scan
   int manager<result_type>::close()
   {
     THREAD_ENTRY *thread_p = m_thread_p;
+    m_result_handler->read_finalize (thread_p);
     m_scan_id->s.phsid.manager = nullptr;
     this->~manager();
     db_private_free (thread_p, this);

--- a/src/query/parallel/px_heap_scan/px_heap_scan_checker.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_checker.cpp
@@ -22,6 +22,7 @@
 
 #include "px_heap_scan_checker.hpp"
 
+#include "dbtype_def.h"
 #include "regu_var.hpp"
 #include "storage_common.h"
 #include "xasl_predicate.hpp"
@@ -148,6 +149,10 @@ namespace parallel_heap_scan
       case TYPE_ATTR_ID:		/* fetch object attribute value */
       case TYPE_SHARED_ATTR_ID:
       case TYPE_CLASS_ATTR_ID:
+	if (arg->value.attr_descr.type == DB_TYPE_OBJECT || arg->value.attr_descr.type == DB_TYPE_OID)
+	  {
+	    set_flag (result, CANNOT_PARALLEL_HEAP_SCAN);
+	  }
 	break;
       case TYPE_CONSTANT:
       case TYPE_OID:


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26596>

### Purpose

qlist_count 관련 core dump가 발생해 이를 수정합니다.