### PR TITLE
[CBRD-26514] suppress user name and comment from SP creation statement texts

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -2849,13 +2849,12 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
                 // SP being defined
 
                 assert scopeLevel == SymbolStack.LEVEL_MAIN;
+                if (ctx.routine_uniq_name().owner != null) {
+                    String owner = Misc.getNormalizedText(ctx.routine_uniq_name().owner);
+                    assert owner.equals(spOwner);
+                }
                 spName = name;
                 isSpFunc = (ctx.PROCEDURE() == null);
-            }
-
-            if (ctx.routine_uniq_name().owner != null) {
-                String owner = Misc.getNormalizedText(ctx.routine_uniq_name().owner);
-                assert owner.equals(spOwner);
             }
 
             // push a temporary symbol table, in order not to corrupt the current symbol table with

--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -4738,7 +4738,7 @@ emit_stored_procedure_code (extract_context & ctxt, print_output & output_ctx, c
 		}
 	    }
 
-	  parser->flag.is_parsing_unload_schema = 1;
+	  parser->flag.is_unloading_schema = 1;
 	  scode_ptr_result = parser_print_tree_with_quotes (parser, *scode_ptr);
 	}
 

--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -4747,14 +4747,8 @@ emit_stored_procedure_code (extract_context & ctxt, print_output & output_ctx, c
 	  output_ctx ("\n%s", scode_ptr_result);
 	  if (!DB_IS_NULL (comment))
 	    {
-	      if ((*scode_ptr)->info.sp.comment == NULL)
-		{
-		  output_ctx ("\nCOMMENT ");
-		}
-	      else
-		{
-		  output_ctx (" COMMENT ");
-		}
+	      assert ((*scode_ptr)->info.sp.comment == NULL);	// CBRD-26513. scode cannot have the comment
+	      output_ctx ("COMMENT ");
 	      desc_value_print (output_ctx, comment);
 	    }
 	}

--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -4724,6 +4724,13 @@ emit_stored_procedure_code (extract_context & ctxt, print_output & output_ctx, c
       scode_ptr = parser_parse_string (parser, scode);
       if (scode_ptr != NULL)
 	{
+	  if ((*scode_ptr)->info.sp.comment)
+	    {
+	      // This can happen (scode has a comment) if the data was populated by a CUBRID version prior to 11.4.5,
+	      // in particular, prior to the patch for issue CBRD-26513
+	      (*scode_ptr)->info.sp.comment = NULL;
+	    }
+
 	  if (ctxt.is_dba_user == false && ctxt.is_dba_group_member == false)
 	    {
 	      parser->custom_print |= PT_PRINT_NO_CURRENT_USER_NAME;
@@ -4738,7 +4745,7 @@ emit_stored_procedure_code (extract_context & ctxt, print_output & output_ctx, c
 		}
 	    }
 
-	  parser->flag.is_unloading_schema = 1;
+	  parser->flag.is_unloading_plcsql_def = 1;
 	  scode_ptr_result = parser_print_tree_with_quotes (parser, *scode_ptr);
 	}
 
@@ -4747,7 +4754,6 @@ emit_stored_procedure_code (extract_context & ctxt, print_output & output_ctx, c
 	  output_ctx ("\n%s", scode_ptr_result);
 	  if (!DB_IS_NULL (comment))
 	    {
-	      assert ((*scode_ptr)->info.sp.comment == NULL);	// CBRD-26513. scode cannot have the comment
 	      output_ctx ("COMMENT ");
 	      desc_value_print (output_ctx, comment);
 	    }

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -12944,7 +12944,6 @@ pl_language_spec
                             } else {
                                 node->info.sp_body.impl = NULL; // set later
                             }
-			    node->info.sp_body.direct = 1;
 			  }
 
 			$$ = node;
@@ -12961,7 +12960,6 @@ pl_language_spec
 			  {
 			    node->info.sp_body.lang = SP_LANG_JAVA;
 			    node->info.sp_body.decl = $4;
-			    node->info.sp_body.direct = 0;
 			  }
 
 			$$ = node;

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -487,6 +487,7 @@ void _push_msg (int code, int line);
 void pop_msg (void);
 
 char *g_query_string;
+int g_query_string_pos;
 int g_query_string_len;
 int g_original_buffer_len;
 
@@ -1841,10 +1842,12 @@ stmt
 			      }
 
 			    g_query_string = (char*) (this_parser->original_buffer + pos);
+                            g_query_string_pos = pos;
 
 			    while (char_isspace (*g_query_string))
 			      {
 			        g_query_string++;
+			        g_query_string_pos++;
 			      }
 			  }
 
@@ -12980,8 +12983,7 @@ plcsql_text
 
                         assert(g_plcsql_text_pos == -1);
                         $$ = strlen($1);
-                        g_plcsql_text_pos = @$.buffer_pos - $$;
-
+                        g_plcsql_text_pos = @$.buffer_pos - g_query_string_pos - $$;
 		DBG_PRINT}}
         ;
 
@@ -26603,6 +26605,7 @@ parser_main (PARSER_CONTEXT * parser)
   csql_yylloc.buffer_pos=0;
 
   g_query_string = NULL;
+  g_query_string_pos = 0;
   g_query_string_len = 0;
   g_original_buffer_len = 0;
 
@@ -26711,6 +26714,7 @@ parse_one_statement (int state)
   csql_yylloc.buffer_pos=0;
 
   g_query_string = NULL;
+  g_query_string_pos = 0;
   g_query_string_len = 0;
   g_original_buffer_len = 0;
 

--- a/src/parser/parse_tree.c
+++ b/src/parser/parse_tree.c
@@ -1232,7 +1232,7 @@ parser_create_parser (void)
   parser->max_print_len = 0;
   parser->flag.is_auto_commit = 0;
   parser->flag.is_parsing_static_sql = 0;
-  parser->flag.is_unloading_schema = 0;
+  parser->flag.is_unloading_plcsql_def = 0;
   parser->flag.is_parsing_trigger = 0;
 
   parser->external_into_label = NULL;

--- a/src/parser/parse_tree.c
+++ b/src/parser/parse_tree.c
@@ -1232,7 +1232,7 @@ parser_create_parser (void)
   parser->max_print_len = 0;
   parser->flag.is_auto_commit = 0;
   parser->flag.is_parsing_static_sql = 0;
-  parser->flag.is_parsing_unload_schema = 0;
+  parser->flag.is_unloading_schema = 0;
   parser->flag.is_parsing_trigger = 0;
 
   parser->external_into_label = NULL;

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -3222,7 +3222,6 @@ struct pt_stored_proc_body_info
   int lang;
   PT_NODE *decl;		/* PT_VALUE */
   PT_NODE *impl;		/* PT_VALUE */
-  bool direct;			/* whether the body has implementation (direct) or points to a implementation file (indirect) */
 };
 
 struct pt_stored_proc_info
@@ -3853,7 +3852,7 @@ struct parser_context
     unsigned is_system_generated_stmt:1;
     unsigned is_auto_commit:1;	/* set to true, if auto commit. */
     unsigned is_parsing_static_sql:1;	/* For PL/CSQL's static SQL: parameterize PL/CSQL variable symbols (to host variable) */
-    unsigned is_parsing_unload_schema:1;	/* Parsing in unload: used to parse the scode (original query) of PL/CSQL to remove the owner. */
+    unsigned is_unloading_schema:1;
     unsigned is_parsing_trigger:1;
   } flag;
 };

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -3852,7 +3852,7 @@ struct parser_context
     unsigned is_system_generated_stmt:1;
     unsigned is_auto_commit:1;	/* set to true, if auto commit. */
     unsigned is_parsing_static_sql:1;	/* For PL/CSQL's static SQL: parameterize PL/CSQL variable symbols (to host variable) */
-    unsigned is_unloading_schema:1;
+    unsigned is_unloading_plcsql_def:1;
     unsigned is_parsing_trigger:1;
   } flag;
 };

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -7680,16 +7680,21 @@ pt_print_create_stored_procedure (PARSER_CONTEXT * parser, PT_NODE * p)
 
   r1 = pt_print_bytes (parser, p->info.sp.name);
 
-  q = pt_append_nulstring (parser, q, parser->flag.is_parsing_unload_schema ? "CREATE OR REPLACE " : "create ");
-  if (p->info.sp.or_replace && !parser->flag.is_parsing_unload_schema)
+  if (parser->flag.is_unloading_schema)
     {
-      q = pt_append_nulstring (parser, q, "or replace ");
+      q = pt_append_nulstring (parser, q, "CREATE OR REPLACE ");
+      q = pt_append_nulstring (parser, q, (p->info.sp.type == PT_SP_PROCEDURE) ? "PROCEDURE" : "FUNCTION");
     }
-  q =
-    pt_append_nulstring (parser, q,
-			 parser->flag.is_parsing_unload_schema ? strcmp (pt_show_misc_type (p->info.sp.type),
-									 "procedure") ==
-			 0 ? "PROCEDURE" : "FUNCTION" : pt_show_misc_type (p->info.sp.type));
+  else
+    {
+      q = pt_append_nulstring (parser, q, "create ");
+      if (p->info.sp.or_replace)
+	{
+	  q = pt_append_nulstring (parser, q, "or replace ");
+	}
+      q = pt_append_nulstring (parser, q, pt_show_misc_type (p->info.sp.type));
+    }
+
   q = pt_append_nulstring (parser, q, " ");
   if (parser->custom_print & (PT_PRINT_NO_SPECIFIED_USER_NAME | PT_PRINT_NO_CURRENT_USER_NAME))
     {
@@ -7707,7 +7712,7 @@ pt_print_create_stored_procedure (PARSER_CONTEXT * parser, PT_NODE * p)
 
   if (p->info.sp.type == PT_SP_FUNCTION)
     {
-      q = pt_append_nulstring (parser, q, parser->flag.is_parsing_unload_schema ? " RETURN " : " return ");
+      q = pt_append_nulstring (parser, q, parser->flag.is_unloading_schema ? " RETURN " : " return ");
       if (p->info.sp.ret_data_type)
 	{
 	  q = pt_append_varchar (parser, q, pt_print_bytes (parser, p->info.sp.ret_data_type));
@@ -7718,7 +7723,7 @@ pt_print_create_stored_procedure (PARSER_CONTEXT * parser, PT_NODE * p)
 	}
     }
 
-  if (parser->flag.is_parsing_unload_schema)
+  if (parser->flag.is_unloading_schema)
     {
       if (p->info.sp.auth_id == PT_AUTHID_OWNER)
 	{
@@ -7734,11 +7739,27 @@ pt_print_create_stored_procedure (PARSER_CONTEXT * parser, PT_NODE * p)
 	  q = pt_append_nulstring (parser, q, " DETERMINISTIC");
 	}
     }
+  else
+    {
+      if (p->info.sp.auth_id == PT_AUTHID_OWNER)
+	{
+	  q = pt_append_nulstring (parser, q, " authid owner");
+	}
+      else
+	{
+	  q = pt_append_nulstring (parser, q, " authid caller");
+	}
+
+      if (p->info.sp.dtrm_type == PT_DETERMINISTIC)
+	{
+	  q = pt_append_nulstring (parser, q, " deterministic");
+	}
+    }
 
   r3 = pt_print_bytes (parser, p->info.sp.body);
   q = pt_append_varchar (parser, q, r3);
 
-  if (p->info.sp.comment != NULL && !parser->flag.is_parsing_unload_schema)
+  if (p->info.sp.comment != NULL && !parser->flag.is_unloading_schema)
     {
       r1 = pt_print_bytes (parser, p->info.sp.comment);
       q = pt_append_nulstring (parser, q, " comment ");
@@ -7992,7 +8013,7 @@ pt_print_sp_parameter (PARSER_CONTEXT * parser, PT_NODE * p)
   r1 = pt_print_bytes (parser, p->info.sp_param.name);
   q = pt_append_varchar (parser, q, r1);
   q = pt_append_nulstring (parser, q, " ");
-  q = pt_append_nulstring (parser, q, parser->flag.is_parsing_unload_schema ?
+  q = pt_append_nulstring (parser, q, parser->flag.is_unloading_schema ?
 			   (p->info.sp_param.mode == PT_INPUT || p->info.sp_param.mode == PT_NOPUT) ?
 			   "IN" : p->info.sp_param.mode == PT_OUTPUT ?
 			   "OUT" : "INOUT" : pt_show_misc_type (p->info.sp_param.mode));
@@ -8046,43 +8067,16 @@ static PARSER_VARCHAR *
 pt_print_sp_body (PARSER_CONTEXT * parser, PT_NODE * p)
 {
   PARSER_VARCHAR *q = NULL, *r1 = NULL;
-  q = pt_append_nulstring (parser, q, parser->flag.is_parsing_unload_schema ? " AS\n" : " as ");
+  q = pt_append_nulstring (parser, q, parser->flag.is_unloading_schema ? " AS\n" : " as ");
   if (p->info.sp_body.lang == SP_LANG_PLCSQL)
     {
-      // TODO: PL/CSQL compiler should permit it.
-      // q = pt_append_nulstring (parser, q, "language plcsql ");
       r1 = pt_append_varchar (parser, r1, p->info.sp_body.impl->info.value.data_value.str);
     }
-  else				/* (p->info.sp_body.lang == SP_LANG_JAVA) */
+  else
+    /* (p->info.sp_body.lang == SP_LANG_JAVA) */
     {
-      q = pt_append_nulstring (parser, q, "language java ");
-
-      // TODO: CBRD-24641
-      /*
-         if (p->info.sp_body.direct)
-         {
-         q = pt_append_nulstring (parser, q, " begin ");
-         r1 = pt_print_bytes (parser, p->info.sp_body.impl);
-         }
-       */
-
-      if (p->info.sp_body.direct == false)
-	{
-	  q = pt_append_nulstring (parser, q, " name ");
-	  r1 = pt_print_bytes (parser, p->info.sp_body.decl);
-	}
-      else
-	{
-	  r1 = pt_append_varchar (parser, r1, p->info.sp_body.impl->info.value.data_value.str);
-	}
-
-      // TODO: CBRD-24641
-      /*
-         if (p->info.sp_body.direct)
-         {
-         q = pt_append_nulstring (parser, q, " end ");
-         }
-       */
+      q = pt_append_nulstring (parser, q, "language java name ");
+      r1 = pt_print_bytes (parser, p->info.sp_body.decl);
     }
 
   q = pt_append_varchar (parser, q, r1);
@@ -8683,7 +8677,7 @@ pt_print_datatype (PARSER_CONTEXT * parser, PT_NODE * p)
     case PT_TYPE_VARNCHAR:
     case PT_TYPE_CHAR:
     case PT_TYPE_VARCHAR:
-      if (parser->flag.is_parsing_unload_schema)
+      if (parser->flag.is_unloading_schema)
 	{
 	  switch (p->type_enum)
 	    {

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -7679,7 +7679,7 @@ pt_print_create_stored_procedure (PARSER_CONTEXT * parser, PT_NODE * p)
 {
   PARSER_VARCHAR *q = NULL, *r1, *r2, *r3;
 
-  if (parser->flag.is_unloading_schema)
+  if (parser->flag.is_unloading_plcsql_def)
     {
       q = pt_append_nulstring (parser, q, "CREATE OR REPLACE ");
       q = pt_append_nulstring (parser, q, (p->info.sp.type == PT_SP_PROCEDURE) ? "PROCEDURE" : "FUNCTION");
@@ -7705,7 +7705,7 @@ pt_print_create_stored_procedure (PARSER_CONTEXT * parser, PT_NODE * p)
 
   if (p->info.sp.type == PT_SP_FUNCTION)
     {
-      q = pt_append_nulstring (parser, q, parser->flag.is_unloading_schema ? " RETURN " : " return ");
+      q = pt_append_nulstring (parser, q, parser->flag.is_unloading_plcsql_def ? " RETURN " : " return ");
       if (p->info.sp.ret_data_type)
 	{
 	  q = pt_append_varchar (parser, q, pt_print_bytes (parser, p->info.sp.ret_data_type));
@@ -7716,7 +7716,7 @@ pt_print_create_stored_procedure (PARSER_CONTEXT * parser, PT_NODE * p)
 	}
     }
 
-  if (parser->flag.is_unloading_schema)
+  if (parser->flag.is_unloading_plcsql_def)
     {
       if (p->info.sp.auth_id == PT_AUTHID_OWNER)
 	{
@@ -7752,12 +7752,15 @@ pt_print_create_stored_procedure (PARSER_CONTEXT * parser, PT_NODE * p)
   r3 = pt_print_bytes (parser, p->info.sp.body);
   q = pt_append_varchar (parser, q, r3);
 
-  if (p->info.sp.comment != NULL)
+  if (!parser->flag.is_unloading_plcsql_def)
     {
-      assert (!parser->flag.is_unloading_schema);	// CBRD-26513
-      r1 = pt_print_bytes (parser, p->info.sp.comment);
-      q = pt_append_nulstring (parser, q, " comment ");
-      q = pt_append_varchar (parser, q, r1);
+      // CBRD-26513 : do not print comment when unloading plcsql definition
+      if (p->info.sp.comment != NULL)
+	{
+	  r1 = pt_print_bytes (parser, p->info.sp.comment);
+	  q = pt_append_nulstring (parser, q, " comment ");
+	  q = pt_append_varchar (parser, q, r1);
+	}
     }
 
   return q;
@@ -8007,7 +8010,7 @@ pt_print_sp_parameter (PARSER_CONTEXT * parser, PT_NODE * p)
   r1 = pt_print_bytes (parser, p->info.sp_param.name);
   q = pt_append_varchar (parser, q, r1);
   q = pt_append_nulstring (parser, q, " ");
-  q = pt_append_nulstring (parser, q, parser->flag.is_unloading_schema ?
+  q = pt_append_nulstring (parser, q, parser->flag.is_unloading_plcsql_def ?
 			   (p->info.sp_param.mode == PT_INPUT || p->info.sp_param.mode == PT_NOPUT) ?
 			   "IN" : p->info.sp_param.mode == PT_OUTPUT ?
 			   "OUT" : "INOUT" : pt_show_misc_type (p->info.sp_param.mode));
@@ -8061,7 +8064,7 @@ static PARSER_VARCHAR *
 pt_print_sp_body (PARSER_CONTEXT * parser, PT_NODE * p)
 {
   PARSER_VARCHAR *q = NULL, *r1 = NULL;
-  q = pt_append_nulstring (parser, q, parser->flag.is_unloading_schema ? " AS\n" : " as ");
+  q = pt_append_nulstring (parser, q, parser->flag.is_unloading_plcsql_def ? " AS\n" : " as ");
   if (p->info.sp_body.lang == SP_LANG_PLCSQL)
     {
       r1 = pt_append_varchar (parser, r1, p->info.sp_body.impl->info.value.data_value.str);
@@ -8671,7 +8674,7 @@ pt_print_datatype (PARSER_CONTEXT * parser, PT_NODE * p)
     case PT_TYPE_VARNCHAR:
     case PT_TYPE_CHAR:
     case PT_TYPE_VARCHAR:
-      if (parser->flag.is_unloading_schema)
+      if (parser->flag.is_unloading_plcsql_def)
 	{
 	  switch (p->type_enum)
 	    {

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -6743,6 +6743,7 @@ pt_print_attr_def (PARSER_CONTEXT * parser, PT_NODE * p)
 	      /* fixed data type: always show parameter */
 	      show_precision = true;
 	      break;
+
 	    default:
 	      /* variable data type: only show non-maximum(i.e., default) parameter */
 	      if (precision == TP_FLOATING_PRECISION_VALUE)
@@ -7678,8 +7679,6 @@ pt_print_create_stored_procedure (PARSER_CONTEXT * parser, PT_NODE * p)
 {
   PARSER_VARCHAR *q = NULL, *r1, *r2, *r3;
 
-  r1 = pt_print_bytes (parser, p->info.sp.name);
-
   if (parser->flag.is_unloading_schema)
     {
       q = pt_append_nulstring (parser, q, "CREATE OR REPLACE ");
@@ -7696,14 +7695,8 @@ pt_print_create_stored_procedure (PARSER_CONTEXT * parser, PT_NODE * p)
     }
 
   q = pt_append_nulstring (parser, q, " ");
-  if (parser->custom_print & (PT_PRINT_NO_SPECIFIED_USER_NAME | PT_PRINT_NO_CURRENT_USER_NAME))
-    {
-      q = pt_append_name (parser, q, p->info.sp.name->info.name.original);
-    }
-  else
-    {
-      q = pt_append_varchar (parser, q, r1);
-    }
+  r1 = pt_print_bytes (parser, p->info.sp.name);
+  q = pt_append_varchar (parser, q, r1);
 
   r2 = pt_print_bytes_l (parser, p->info.sp.param_list);
   q = pt_append_nulstring (parser, q, "(");
@@ -7759,8 +7752,9 @@ pt_print_create_stored_procedure (PARSER_CONTEXT * parser, PT_NODE * p)
   r3 = pt_print_bytes (parser, p->info.sp.body);
   q = pt_append_varchar (parser, q, r3);
 
-  if (p->info.sp.comment != NULL && !parser->flag.is_unloading_schema)
+  if (p->info.sp.comment != NULL)
     {
+      assert (!parser->flag.is_unloading_schema);	// CBRD-26513
       r1 = pt_print_bytes (parser, p->info.sp.comment);
       q = pt_append_nulstring (parser, q, " comment ");
       q = pt_append_varchar (parser, q, r1);
@@ -8719,6 +8713,7 @@ pt_print_datatype (PARSER_CONTEXT * parser, PT_NODE * p)
 	    /* fixed data type: always show parameter */
 	    show_precision = true;
 	    break;
+
 	  default:
 	    /* variable data type: only show non-maximum(i.e., default) parameter */
 	    if (precision == TP_FLOATING_PRECISION_VALUE)

--- a/src/sp/jsp_cl.cpp
+++ b/src/sp/jsp_cl.cpp
@@ -1193,6 +1193,7 @@ jsp_create_stored_procedure (PARSER_CONTEXT *parser, PT_NODE *statement)
 
   if (!compile_request.code.empty ())
     {
+      assert (sp_info.lang == SP_LANG_PLCSQL);
       SP_CODE_INFO code_info;
 
       auto now = std::chrono::system_clock::now();
@@ -1200,10 +1201,27 @@ jsp_create_stored_procedure (PARSER_CONTEXT *parser, PT_NODE *statement)
       std::stringstream stm;
       stm << std::put_time (localtime (&converted_timep), "%Y%m%d%H%M%S");
 
+
+      // CBRD-26513, CBRD-26514: rewrite the user code without the user name and the comment
+      const char *rewritten_code;
+      {
+	PT_NODE *comment_saved = statement->info.sp.comment;
+	int custom_print_saved = parser->custom_print;
+
+	statement->info.sp.comment = NULL;
+	parser->custom_print |= PT_PRINT_NO_SPECIFIED_USER_NAME;
+	parser->flag.is_unloading_schema = 1;
+	rewritten_code = parser_print_tree (parser, statement);
+	parser->flag.is_unloading_schema = 0;
+
+	parser->custom_print = custom_print_saved;
+	statement->info.sp.comment = comment_saved;
+      }
+
       code_info.name = sp_info.target_class;
       code_info.created_time = stm.str ();
-      code_info.stype = (sp_info.lang == SP_LANG_PLCSQL) ? SPSC_PLCSQL : SPSC_JAVA;
-      code_info.scode = compile_request.code;
+      code_info.stype = SPSC_PLCSQL;
+      code_info.scode.assign (rewritten_code, strlen (rewritten_code));
       code_info.otype = compile_response.compiled_type;
       code_info.ocode = compile_response.compiled_code;
       code_info.owner = sp_info.owner;

--- a/src/sp/jsp_cl.cpp
+++ b/src/sp/jsp_cl.cpp
@@ -1205,17 +1205,14 @@ jsp_create_stored_procedure (PARSER_CONTEXT *parser, PT_NODE *statement)
       // CBRD-26513, CBRD-26514: rewrite the user code without the user name and the comment
       const char *rewritten_code;
       {
-	PT_NODE *comment_saved = statement->info.sp.comment;
 	int custom_print_saved = parser->custom_print;
 
-	statement->info.sp.comment = NULL;
 	parser->custom_print |= PT_PRINT_NO_SPECIFIED_USER_NAME;
 	parser->flag.is_unloading_plcsql_def = 1;
 	rewritten_code = parser_print_tree (parser, statement);
 	parser->flag.is_unloading_plcsql_def = 0;
 
 	parser->custom_print = custom_print_saved;
-	statement->info.sp.comment = comment_saved;
       }
 
       if (rewritten_code == NULL)

--- a/src/sp/jsp_cl.cpp
+++ b/src/sp/jsp_cl.cpp
@@ -88,9 +88,6 @@
 #define PT_NODE_SP_ARGS(node) \
   ((node)->info.sp.param_list)
 
-#define PT_NODE_SP_DIRECT(node) \
-  ((node)->info.sp.body->info.sp_body.direct)
-
 #define PT_NODE_SP_IMPL(node) \
   ((node)->info.sp.body->info.sp_body.impl->info.value.data_value.str->bytes)
 
@@ -1146,16 +1143,7 @@ jsp_create_stored_procedure (PARSER_CONTEXT *parser, PT_NODE *statement)
     }
   else				/* SP_LANG_JAVA */
     {
-      bool is_direct = PT_NODE_SP_DIRECT (statement);
-      if (is_direct)
-	{
-	  // TODO: CBRD-24641
-	  assert (false);
-	}
-      else
-	{
-	  decl = (const char *) PT_NODE_SP_JAVA_METHOD (statement);
-	}
+      decl = (const char *) PT_NODE_SP_JAVA_METHOD (statement);
     }
 
   if (decl)

--- a/src/sp/jsp_cl.cpp
+++ b/src/sp/jsp_cl.cpp
@@ -1218,6 +1218,14 @@ jsp_create_stored_procedure (PARSER_CONTEXT *parser, PT_NODE *statement)
 	statement->info.sp.comment = comment_saved;
       }
 
+      if (rewritten_code == NULL)
+	{
+	  assert (false);
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_FAILED, 0);
+	  err = ER_FAILED;
+	  goto error_exit;
+	}
+
       code_info.name = sp_info.target_class;
       code_info.created_time = stm.str ();
       code_info.stype = SPSC_PLCSQL;

--- a/src/sp/jsp_cl.cpp
+++ b/src/sp/jsp_cl.cpp
@@ -1210,9 +1210,9 @@ jsp_create_stored_procedure (PARSER_CONTEXT *parser, PT_NODE *statement)
 
 	statement->info.sp.comment = NULL;
 	parser->custom_print |= PT_PRINT_NO_SPECIFIED_USER_NAME;
-	parser->flag.is_unloading_schema = 1;
+	parser->flag.is_unloading_plcsql_def = 1;
 	rewritten_code = parser_print_tree (parser, statement);
-	parser->flag.is_unloading_schema = 0;
+	parser->flag.is_unloading_plcsql_def = 0;
 
 	parser->custom_print = custom_print_saved;
 	statement->info.sp.comment = comment_saved;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26514
http://jira.cubrid.org/browse/CBRD-26513

### Purpose

ALTER 에 의해 변경될 수 있는 SP 의 owner와 comment 를 _db_stored_procedure_code.scode 에 포함되지 않도록 합니다.

### Implementation

develop 브랜치에 적용된 변경 commit 9e772d624, dc6d90dca (사전 코드 정리) 과 23343c008를 cherry-pick 했습니다. 

- 9e772d624 : [CBRD-26498] refine the code handling SP parse tree node (#6789) 
- dc6d90dca : [CBRD-26578] use query start offset in the lexer buffer to set the start offset of SP body (#6885)
- 23343c008 : [CBRD-26514] suppress user name and comment from SP creation statement texts (#6801)

