### PR TITLE
[CBRD-26610] broker_log_top 명령어 --all-broker-log 옵션 추가

### DIFF
--- a/src/broker/broker_log_top.c
+++ b/src/broker/broker_log_top.c
@@ -1117,219 +1117,20 @@ batch_run (void)
 	{
 	  if (batch_is_pattern (batch_broker_name))
 	    {
-	  nfiles = batch_gather_files_pattern_all (batch_broker_name, dirs[d], files, BROKER_LOG_TOP_MAX_FILES);
-	  if (nfiles == 0)
-	    {
-	      fprintf (stderr, "Info: [%s] no files matching pattern '%s', skipping.\n", dirs[d], batch_broker_name);
-	      goto next_dir;
-	    }
-	  batch_broker_to_safe (batch_broker_name, broker_safe, sizeof (broker_safe));
-	  snprintf (subdir, sizeof (subdir), "%.1023s/%.255s", parent_out_base, broker_safe);
-	  if (batch_mkdir_out (subdir) < 0 && errno != EEXIST)
-	    {
-	      fprintf (stderr, "Error: cannot create output directory: %s\n", subdir);
-	      error = -1;
-	      goto next_dir;
-	    }
-#if !defined(WINDOWS)
-	  if (chdir (subdir) < 0)
-#else
-	  if (_chdir (subdir) < 0)
-#endif
-	    {
-	      fprintf (stderr, "Error: cannot chdir to %s\n", subdir);
-	      error = -1;
-	      goto next_dir;
-	    }
-	  fprintf (stdout, "%s\n", batch_broker_name);
-	  query_info_reset ();
-#if !defined(WINDOWS)
-	  if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
-	    {
-	      broker_log_top_segfault_jmp_valid = 1;
-	      signal (SIGSEGV, broker_log_top_segfault_handler);
-	      if (mode_tran)
-		error = log_top_tran (nfiles, files, 0);
-	      else
-		error = log_top_query (nfiles, files, 0);
-	      chdir ((const char *) saved_cwd);
-	      for (i = 0; i < nfiles; i++)
-		FREE_MEM (files[i]);
-	      broker_log_top_segfault_jmp_valid = 0;
-	      signal (SIGSEGV, SIG_DFL);
-	    }
-	  else
-	    {
-	      broker_log_top_segfault_jmp_valid = 0;
-	      signal (SIGSEGV, SIG_DFL);
-	      fprintf (stderr, "Warning: segmentation fault during processing, skipping.\n");
-	      chdir ((const char *) saved_cwd);
-	    }
-#else
-	  if (mode_tran)
-	    error = log_top_tran (nfiles, files, 0);
-	  else
-	    error = log_top_query (nfiles, files, 0);
-	  chdir ((const char *) saved_cwd);
-	  for (i = 0; i < nfiles; i++)
-	    FREE_MEM (files[i]);
-#endif
-	    }
-	  else
-	    {
-	  nfiles = batch_gather_files_exact (batch_broker_name, dirs[d], files, BROKER_LOG_TOP_MAX_FILES);
-	  if (nfiles == 0)
-	    {
-	      fprintf (stderr, "Info: [%s] no files for broker '%s', skipping.\n", dirs[d], batch_broker_name);
-	      goto next_dir;
-	    }
-	  snprintf (subdir, sizeof (subdir), "%.1023s/%.255s", parent_out_base, batch_broker_name);
-	  if (batch_mkdir_out (subdir) < 0 && errno != EEXIST)
-	    {
-	      fprintf (stderr, "Error: cannot create output directory: %s\n", subdir);
-	      error = -1;
-	      goto next_dir;
-	    }
-#if !defined(WINDOWS)
-	  if (chdir (subdir) < 0)
-#else
-	  if (_chdir (subdir) < 0)
-#endif
-	    {
-	      fprintf (stderr, "Error: cannot chdir to %s\n", subdir);
-	      error = -1;
-	      goto next_dir;
-	    }
-	  fprintf (stdout, "%s\n", batch_broker_name);
-	  query_info_reset ();
-#if !defined(WINDOWS)
-	  if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
-	    {
-	      broker_log_top_segfault_jmp_valid = 1;
-	      signal (SIGSEGV, broker_log_top_segfault_handler);
-	      if (mode_tran)
-		error = log_top_tran (nfiles, files, 0);
-	      else
-		error = log_top_query (nfiles, files, 0);
-	      chdir ((const char *) saved_cwd);
-	      for (i = 0; i < nfiles; i++)
-		FREE_MEM (files[i]);
-	      broker_log_top_segfault_jmp_valid = 0;
-	      signal (SIGSEGV, SIG_DFL);
-	    }
-	  else
-	    {
-	      broker_log_top_segfault_jmp_valid = 0;
-	      signal (SIGSEGV, SIG_DFL);
-	      fprintf (stderr, "Warning: segmentation fault during processing, skipping.\n");
-	      chdir ((const char *) saved_cwd);
-	    }
-#else
-	  if (mode_tran)
-	    error = log_top_tran (nfiles, files, 0);
-	  else
-	    error = log_top_query (nfiles, files, 0);
-	  chdir ((const char *) saved_cwd);
-	  for (i = 0; i < nfiles; i++)
-	    FREE_MEM (files[i]);
-#endif
-	    }
-	next_dir:
-	  if (strcasecmp (batch_log_dir, "LOG_DIR") == 0)
-	    {
-	      FREE_MEM (dirs[d]);
-	      dirs[d] = NULL;
-	    }
-	}
-    }
-  else
-    {
-	  char *all_brokers[512];
-	  volatile int total_brokers = 0;
-	  int bi, dir_idx, k;
-
-	  memset (all_brokers, 0, sizeof (all_brokers));
-
-	  for (dir_idx = 0; dir_idx < ndirs && total_brokers < 512; dir_idx++)
-	    {
-	      char *dir_brokers[512];
-	      int dir_nb;
-
-	      memset (dir_brokers, 0, sizeof (dir_brokers));
-	      if (dirs[dir_idx] == NULL)
-		continue;
-	      dir_nb = batch_get_brokers_from_dir (dirs[dir_idx], dir_brokers, 512);
-
-	      for (bi = 0; bi < dir_nb && total_brokers < 512; bi++)
+	      nfiles = batch_gather_files_pattern_all (batch_broker_name, dirs[d], files, BROKER_LOG_TOP_MAX_FILES);
+	      if (nfiles == 0)
 		{
-		  int found = 0;
-		  if (dir_brokers[bi] == NULL)
-		    continue;
-		  for (k = 0; k < total_brokers; k++)
-		    {
-		      if (all_brokers[k] != NULL && strcmp (all_brokers[k], dir_brokers[bi]) == 0)
-			{
-			  found = 1;
-			  FREE_MEM (dir_brokers[bi]);
-			  dir_brokers[bi] = NULL;
-			  break;
-			}
-		    }
-		  if (!found)
-		    {
-		      all_brokers[total_brokers] = dir_brokers[bi];
-		      total_brokers++;
-		    }
+		  fprintf (stderr, "Info: [%s] no files matching pattern '%s', skipping.\n", dirs[d],
+			   batch_broker_name);
+		  goto next_dir;
 		}
-	    }
-
-	  if (total_brokers == 0)
-	    {
-	      fprintf (stderr, "Info: no brokers found in any directory.\n");
-	      /* LOG_DIR 모드인 경우, dirs[]는 아래 정리 루틴에서 한 번에 해제된다. */
-	      return 0;
-	    }
-
-	  for (i = 0; i < total_brokers && !error; i++)
-	    {
-	      volatile int total_files = 0;
-	      char *all_files[BROKER_LOG_TOP_MAX_FILES];
-	      int j, dir_idx;
-	      int num_files = 0;
-
-	      memset (all_files, 0, sizeof (all_files));
-
-	      if (all_brokers[i] == NULL)
-		continue;
-
-	      for (dir_idx = 0; dir_idx < ndirs && total_files < BROKER_LOG_TOP_MAX_FILES; dir_idx++)
-		{
-		  if (dirs[dir_idx] == NULL)
-		    continue;
-		  int dir_files = batch_gather_files_exact (all_brokers[i], dirs[dir_idx],
-							    all_files + total_files,
-							    BROKER_LOG_TOP_MAX_FILES - total_files);
-		  total_files += dir_files;
-		}
-	      num_files = total_files;
-
-	      if (total_files == 0)
-		{
-		  FREE_MEM (all_brokers[i]);
-		  all_brokers[i] = NULL;
-		  continue;
-		}
-
-	      snprintf (subdir, sizeof (subdir), "%.1023s/%.255s", parent_out_base, all_brokers[i]);
+	      batch_broker_to_safe (batch_broker_name, broker_safe, sizeof (broker_safe));
+	      snprintf (subdir, sizeof (subdir), "%.1023s/%.255s", parent_out_base, broker_safe);
 	      if (batch_mkdir_out (subdir) < 0 && errno != EEXIST)
 		{
 		  fprintf (stderr, "Error: cannot create output directory: %s\n", subdir);
-		  FREE_MEM (all_brokers[i]);
-		  all_brokers[i] = NULL;
-		  for (j = 0; j < num_files; j++)
-		    FREE_MEM (all_files[j]);
 		  error = -1;
-		  continue;
+		  goto next_dir;
 		}
 #if !defined(WINDOWS)
 	      if (chdir (subdir) < 0)
@@ -1338,14 +1139,10 @@ batch_run (void)
 #endif
 		{
 		  fprintf (stderr, "Error: cannot chdir to %s\n", subdir);
-		  FREE_MEM (all_brokers[i]);
-		  all_brokers[i] = NULL;
-		  for (j = 0; j < num_files; j++)
-		    FREE_MEM (all_files[j]);
 		  error = -1;
-		  continue;
+		  goto next_dir;
 		}
-	      fprintf (stdout, "%s\n", all_brokers[i]);
+	      fprintf (stdout, "%s\n", batch_broker_name);
 	      query_info_reset ();
 #if !defined(WINDOWS)
 	      if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
@@ -1353,14 +1150,12 @@ batch_run (void)
 		  broker_log_top_segfault_jmp_valid = 1;
 		  signal (SIGSEGV, broker_log_top_segfault_handler);
 		  if (mode_tran)
-		    error = log_top_tran (total_files, all_files, 0);
+		    error = log_top_tran (nfiles, files, 0);
 		  else
-		    error = log_top_query (total_files, all_files, 0);
+		    error = log_top_query (nfiles, files, 0);
 		  chdir ((const char *) saved_cwd);
-		  for (j = 0; j < num_files; j++)
-		    FREE_MEM (all_files[j]);
-		  FREE_MEM (all_brokers[i]);
-		  all_brokers[i] = NULL;
+		  for (i = 0; i < nfiles; i++)
+		    FREE_MEM (files[i]);
 		  broker_log_top_segfault_jmp_valid = 0;
 		  signal (SIGSEGV, SIG_DFL);
 		}
@@ -1373,6 +1168,192 @@ batch_run (void)
 		}
 #else
 	      if (mode_tran)
+		error = log_top_tran (nfiles, files, 0);
+	      else
+		error = log_top_query (nfiles, files, 0);
+	      chdir ((const char *) saved_cwd);
+	      for (i = 0; i < nfiles; i++)
+		FREE_MEM (files[i]);
+#endif
+	    }
+	  else
+	    {
+	      nfiles = batch_gather_files_exact (batch_broker_name, dirs[d], files, BROKER_LOG_TOP_MAX_FILES);
+	      if (nfiles == 0)
+		{
+		  fprintf (stderr, "Info: [%s] no files for broker '%s', skipping.\n", dirs[d], batch_broker_name);
+		  goto next_dir;
+		}
+	      snprintf (subdir, sizeof (subdir), "%.1023s/%.255s", parent_out_base, batch_broker_name);
+	      if (batch_mkdir_out (subdir) < 0 && errno != EEXIST)
+		{
+		  fprintf (stderr, "Error: cannot create output directory: %s\n", subdir);
+		  error = -1;
+		  goto next_dir;
+		}
+#if !defined(WINDOWS)
+	      if (chdir (subdir) < 0)
+#else
+	      if (_chdir (subdir) < 0)
+#endif
+		{
+		  fprintf (stderr, "Error: cannot chdir to %s\n", subdir);
+		  error = -1;
+		  goto next_dir;
+		}
+	      fprintf (stdout, "%s\n", batch_broker_name);
+	      query_info_reset ();
+#if !defined(WINDOWS)
+	      if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
+		{
+		  broker_log_top_segfault_jmp_valid = 1;
+		  signal (SIGSEGV, broker_log_top_segfault_handler);
+		  if (mode_tran)
+		    error = log_top_tran (nfiles, files, 0);
+		  else
+		    error = log_top_query (nfiles, files, 0);
+		  chdir ((const char *) saved_cwd);
+		  for (i = 0; i < nfiles; i++)
+		    FREE_MEM (files[i]);
+		  broker_log_top_segfault_jmp_valid = 0;
+		  signal (SIGSEGV, SIG_DFL);
+		}
+	      else
+		{
+		  broker_log_top_segfault_jmp_valid = 0;
+		  signal (SIGSEGV, SIG_DFL);
+		  fprintf (stderr, "Warning: segmentation fault during processing, skipping.\n");
+		  chdir ((const char *) saved_cwd);
+		}
+#else
+	      if (mode_tran)
+		error = log_top_tran (nfiles, files, 0);
+	      else
+		error = log_top_query (nfiles, files, 0);
+	      chdir ((const char *) saved_cwd);
+	      for (i = 0; i < nfiles; i++)
+		FREE_MEM (files[i]);
+#endif
+	    }
+	next_dir:
+	  if (strcasecmp (batch_log_dir, "LOG_DIR") == 0)
+	    {
+	      FREE_MEM (dirs[d]);
+	      dirs[d] = NULL;
+	    }
+	}
+    }
+  else
+    {
+      char *all_brokers[512];
+      volatile int total_brokers = 0;
+      int bi, dir_idx, k;
+
+      memset (all_brokers, 0, sizeof (all_brokers));
+
+      for (dir_idx = 0; dir_idx < ndirs && total_brokers < 512; dir_idx++)
+	{
+	  char *dir_brokers[512];
+	  int dir_nb;
+
+	  memset (dir_brokers, 0, sizeof (dir_brokers));
+	  if (dirs[dir_idx] == NULL)
+	    continue;
+	  dir_nb = batch_get_brokers_from_dir (dirs[dir_idx], dir_brokers, 512);
+
+	  for (bi = 0; bi < dir_nb && total_brokers < 512; bi++)
+	    {
+	      int found = 0;
+	      if (dir_brokers[bi] == NULL)
+		continue;
+	      for (k = 0; k < total_brokers; k++)
+		{
+		  if (all_brokers[k] != NULL && strcmp (all_brokers[k], dir_brokers[bi]) == 0)
+		    {
+		      found = 1;
+		      FREE_MEM (dir_brokers[bi]);
+		      dir_brokers[bi] = NULL;
+		      break;
+		    }
+		}
+	      if (!found)
+		{
+		  all_brokers[total_brokers] = dir_brokers[bi];
+		  total_brokers++;
+		}
+	    }
+	}
+
+      if (total_brokers == 0)
+	{
+	  fprintf (stderr, "Info: no brokers found in any directory.\n");
+	  /* LOG_DIR 모드인 경우, dirs[]는 아래 정리 루틴에서 한 번에 해제된다. */
+	  return 0;
+	}
+
+      for (i = 0; i < total_brokers && !error; i++)
+	{
+	  volatile int total_files = 0;
+	  char *all_files[BROKER_LOG_TOP_MAX_FILES];
+	  int j, dir_idx;
+	  int num_files = 0;
+
+	  memset (all_files, 0, sizeof (all_files));
+
+	  if (all_brokers[i] == NULL)
+	    continue;
+
+	  for (dir_idx = 0; dir_idx < ndirs && total_files < BROKER_LOG_TOP_MAX_FILES; dir_idx++)
+	    {
+	      if (dirs[dir_idx] == NULL)
+		continue;
+	      int dir_files = batch_gather_files_exact (all_brokers[i], dirs[dir_idx],
+							all_files + total_files,
+							BROKER_LOG_TOP_MAX_FILES - total_files);
+	      total_files += dir_files;
+	    }
+	  num_files = total_files;
+
+	  if (total_files == 0)
+	    {
+	      FREE_MEM (all_brokers[i]);
+	      all_brokers[i] = NULL;
+	      continue;
+	    }
+
+	  snprintf (subdir, sizeof (subdir), "%.1023s/%.255s", parent_out_base, all_brokers[i]);
+	  if (batch_mkdir_out (subdir) < 0 && errno != EEXIST)
+	    {
+	      fprintf (stderr, "Error: cannot create output directory: %s\n", subdir);
+	      FREE_MEM (all_brokers[i]);
+	      all_brokers[i] = NULL;
+	      for (j = 0; j < num_files; j++)
+		FREE_MEM (all_files[j]);
+	      error = -1;
+	      continue;
+	    }
+#if !defined(WINDOWS)
+	  if (chdir (subdir) < 0)
+#else
+	  if (_chdir (subdir) < 0)
+#endif
+	    {
+	      fprintf (stderr, "Error: cannot chdir to %s\n", subdir);
+	      FREE_MEM (all_brokers[i]);
+	      all_brokers[i] = NULL;
+	      for (j = 0; j < num_files; j++)
+		FREE_MEM (all_files[j]);
+	      error = -1;
+	      continue;
+	    }
+	  fprintf (stdout, "%s\n", all_brokers[i]);
+	  query_info_reset ();
+#if !defined(WINDOWS)
+	  if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
+	    {
+	      broker_log_top_segfault_jmp_valid = 1;
+	      signal (SIGSEGV, broker_log_top_segfault_handler);
+	      if (mode_tran)
 		error = log_top_tran (total_files, all_files, 0);
 	      else
 		error = log_top_query (total_files, all_files, 0);
@@ -1381,8 +1362,28 @@ batch_run (void)
 		FREE_MEM (all_files[j]);
 	      FREE_MEM (all_brokers[i]);
 	      all_brokers[i] = NULL;
-#endif
+	      broker_log_top_segfault_jmp_valid = 0;
+	      signal (SIGSEGV, SIG_DFL);
 	    }
+	  else
+	    {
+	      broker_log_top_segfault_jmp_valid = 0;
+	      signal (SIGSEGV, SIG_DFL);
+	      fprintf (stderr, "Warning: segmentation fault during processing, skipping.\n");
+	      chdir ((const char *) saved_cwd);
+	    }
+#else
+	  if (mode_tran)
+	    error = log_top_tran (total_files, all_files, 0);
+	  else
+	    error = log_top_query (total_files, all_files, 0);
+	  chdir ((const char *) saved_cwd);
+	  for (j = 0; j < num_files; j++)
+	    FREE_MEM (all_files[j]);
+	  FREE_MEM (all_brokers[i]);
+	  all_brokers[i] = NULL;
+#endif
+	}
     }
 
 #if !defined(WINDOWS)
@@ -1920,8 +1921,8 @@ get_args (int argc, char *argv[])
   int option_index = 0;
   /* pm_jmy */
   static struct option long_options[] = {
-    { "all-broker-log", optional_argument, 0, 'l' },
-    { 0, 0, 0, 0 }
+    {"all-broker-log", optional_argument, 0, 'l'},
+    {0, 0, 0, 0}
   };
 
   while ((c = getopt_long (argc, argv, "tq:h:F:T:", long_options, &option_index)) != EOF)

--- a/src/broker/broker_log_top.c
+++ b/src/broker/broker_log_top.c
@@ -28,8 +28,16 @@
 #include <string.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <sys/stat.h>
+#include <time.h>
 #if !defined(WINDOWS)
 #include <unistd.h>
+#include <dirent.h>
+#else
+#include <io.h>
+#include <windows.h>
 #endif
 
 #ifdef MT_MODE
@@ -82,6 +90,44 @@ static int read_bind_value (FILE * fp, T_STRING * t_str, char **linebuf, int *li
 static int search_offset (FILE * fp, char *string, long *offset, bool start);
 static char *organize_query_string (const char *sql);
 
+/* pm_jmy */
+static const char *batch_log_dir = NULL;
+static const char *batch_broker_name = NULL;
+#define BROKER_LOG_TOP_MAX_PATH 2048
+#define BROKER_LOG_TOP_MAX_FILES 4096
+#define BROKER_LOG_TOP_MAX_DIRS 128
+
+static int broker_log_top_force_single_thread = 0;
+
+#if !defined(WINDOWS)
+/* Segmentation fault 복구: 예외 시 longjmp로 복귀하여 무시하고 진행 */
+static sigjmp_buf broker_log_top_segfault_jmp;
+static volatile int broker_log_top_segfault_jmp_valid;
+
+static void
+broker_log_top_segfault_handler (int sig)
+{
+  if (sig == SIGSEGV && broker_log_top_segfault_jmp_valid)
+    {
+      broker_log_top_segfault_jmp_valid = 0;
+      siglongjmp (broker_log_top_segfault_jmp, 1);
+    }
+  /* 재진입 방지 실패 시 기본 동작 */
+  signal (SIGSEGV, SIG_DFL);
+  raise (sig);
+}
+#endif
+
+static int batch_discover_log_dirs (char *out_dirs[], int max_dirs);
+static void batch_normalize_path (const char *in, char *out, size_t out_len);
+static int batch_gather_files_exact (const char *broker, const char *dir, char *out_files[], int max_files);
+static int batch_gather_files_pattern (const char *pattern, const char *dir, char *out_files[], int max_files);
+static int batch_is_pattern (const char *s);
+static int batch_get_brokers_from_dir (const char *dir, char *out_brokers[], int max_brokers);
+static void batch_broker_to_safe (const char *name, char *out, size_t out_len);
+static int batch_mkdir_out (const char *path);
+static int batch_run (void);
+
 T_LOG_TOP_MODE log_top_mode = MODE_PROC_TIME;
 
 static char *sql_info_file = NULL;
@@ -113,6 +159,13 @@ main (int argc, char *argv[])
       return -1;
     }
 
+  /* pm_jmy */
+  if (batch_log_dir != NULL)
+    {
+      error = batch_run ();
+      return error;
+    }
+
 #if defined(WINDOWS)
   file_cnt = get_file_count (argc, argv, arg_start);
   if (file_cnt <= 0)
@@ -132,25 +185,59 @@ main (int argc, char *argv[])
       get_cnt = file_cnt;
     }
 
-  if (mode_tran)
+#if !defined(WINDOWS)
+  if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
     {
-      error = log_top_tran (get_cnt, file_list, 0);
+      broker_log_top_segfault_jmp_valid = 1;
+      signal (SIGSEGV, broker_log_top_segfault_handler);
+      if (mode_tran)
+	error = log_top_tran (get_cnt, file_list, 0);
+      else
+	error = log_top_query (get_cnt, file_list, 0);
+      broker_log_top_segfault_jmp_valid = 0;
+      signal (SIGSEGV, SIG_DFL);
     }
   else
     {
-      error = log_top_query (get_cnt, file_list, 0);
+      broker_log_top_segfault_jmp_valid = 0;
+      signal (SIGSEGV, SIG_DFL);
+      fprintf (stderr, "Warning: segmentation fault during processing.\n");
+      error = 0;
     }
+#else
+  if (mode_tran)
+    error = log_top_tran (get_cnt, file_list, 0);
+  else
+    error = log_top_query (get_cnt, file_list, 0);
+#endif
 
   free_file_list (file_list, file_cnt);
 #else
-  if (mode_tran)
+#if !defined(WINDOWS)
+  if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
     {
-      error = log_top_tran (argc, argv, arg_start);
+      broker_log_top_segfault_jmp_valid = 1;
+      signal (SIGSEGV, broker_log_top_segfault_handler);
+      if (mode_tran)
+	error = log_top_tran (argc, argv, arg_start);
+      else
+	error = log_top_query (argc, argv, arg_start);
+      broker_log_top_segfault_jmp_valid = 0;
+      signal (SIGSEGV, SIG_DFL);
     }
   else
     {
-      error = log_top_query (argc, argv, arg_start);
+      broker_log_top_segfault_jmp_valid = 0;
+      signal (SIGSEGV, SIG_DFL);
+      fprintf (stderr, "Warning: segmentation fault during processing.\n");
+      error = 0;
     }
+#else
+  if (mode_tran)
+    error = log_top_tran (argc, argv, arg_start);
+  else
+    error = log_top_query (argc, argv, arg_start);
+#endif
 #endif
 
   return error;
@@ -296,6 +383,1065 @@ free_file_list (char **list, int size)
 }
 #endif
 
+#if !defined(WINDOWS)
+static int
+batch_match_pattern (const char *broker_prefix, const char *pattern)
+{
+  size_t plen = strlen (pattern);
+  size_t blen = strlen (broker_prefix);
+  if (plen > 0 && pattern[plen - 1] == '*')
+    {
+      if (plen == 1)
+	return 1;
+      if (blen < plen - 1)
+	return 0;
+      return strncmp (broker_prefix, pattern, plen - 1) == 0 ? 1 : 0;
+    }
+  return (blen == plen && strncmp (broker_prefix, pattern, plen) == 0) ? 1 : 0;
+}
+#endif
+
+/* pm_jmy */
+static void
+batch_normalize_path (const char *in, char *out, size_t out_len)
+{
+  const char *cubrid;
+  char buf[BROKER_LOG_TOP_MAX_PATH];
+  size_t i, j;
+
+  if (out_len < 2)
+    return;
+  out[0] = '\0';
+
+  if (in[0] == '/' || (in[0] && in[1] == ':'))
+    {
+      snprintf (out, out_len, "%s", in);
+      for (i = 0; out[i]; i++)
+	if (out[i] == '\\')
+	  out[i] = '/';
+      j = strlen (out);
+      while (j > 1 && out[j - 1] == '/')
+	out[--j] = '\0';
+      return;
+    }
+
+  cubrid = getenv ("CUBRID");
+  if (!cubrid || !cubrid[0])
+    {
+      snprintf (out, out_len, "%s", in);
+      return;
+    }
+  snprintf (buf, sizeof (buf), "%s/%s", cubrid, in[0] == '.' && in[1] == '/' ? in + 2 : in);
+  for (i = 0; buf[i]; i++)
+    if (buf[i] == '\\')
+      buf[i] = '/';
+  while (i > 1 && buf[i - 1] == '/')
+    buf[--i] = '\0';
+  snprintf (out, out_len, "%s", buf);
+}
+
+/* pm_jmy */
+static int
+batch_discover_log_dirs (char *out_dirs[], int max_dirs)
+{
+  FILE *fp;
+  char conf_path[BROKER_LOG_TOP_MAX_PATH];
+  char line[512];
+  const char *env_conf;
+  const char *cubrid;
+  int count = 0;
+  char norm[BROKER_LOG_TOP_MAX_PATH];
+  char seen[BROKER_LOG_TOP_MAX_DIRS][BROKER_LOG_TOP_MAX_PATH];
+  int nseen = 0;
+  int i;
+
+  env_conf = getenv ("CUBRID_BROKER_CONF_FILE");
+  if (env_conf && env_conf[0])
+    snprintf (conf_path, sizeof (conf_path), "%s", env_conf);
+  else
+    {
+      cubrid = getenv ("CUBRID");
+      if (!cubrid || !cubrid[0])
+	{
+	  fprintf (stderr, "Error: CUBRID environment variable not set.\n");
+	  return -1;
+	}
+      snprintf (conf_path, sizeof (conf_path), "%s/conf/cubrid_broker.conf", cubrid);
+    }
+
+  fp = fopen (conf_path, "r");
+  if (!fp)
+    {
+      fprintf (stderr, "Error: cannot open broker config: %s\n", conf_path);
+      return -1;
+    }
+
+  while (fgets (line, sizeof (line), fp) && count < max_dirs)
+    {
+      char *eq, *val, *p;
+      for (p = line; *p && (*p == ' ' || *p == '\t'); p++)
+	;
+      if (strncasecmp (p, "LOG_DIR", 7) != 0)
+	continue;
+      p += 7;
+      while (*p == ' ' || *p == '\t')
+	p++;
+      if (*p != '=')
+	continue;
+      p++;
+      while (*p == ' ' || *p == '\t')
+	p++;
+      val = p;
+      while (*val && *val != '#' && *val != '\n' && *val != '\r')
+	val++;
+      while (val > p && (val[-1] == ' ' || val[-1] == '\t' || val[-1] == '\n' || val[-1] == '\r'))
+	val--;
+      *val = '\0';
+      if (p[0] == '\0')
+	continue;
+      batch_normalize_path (p, norm, sizeof (norm));
+      if (norm[0] == '\0')
+	continue;
+      /* pm_jmy */
+      for (i = 0; i < nseen; i++)
+	if (strcmp (seen[i], norm) == 0)
+	  break;
+      if (i < nseen)
+	continue;
+      if (nseen < BROKER_LOG_TOP_MAX_DIRS)
+	{
+	  snprintf (seen[nseen], sizeof (seen[0]), "%.2047s", norm);
+	  nseen++;
+	}
+      out_dirs[count] = (char *) MALLOC (strlen (norm) + 1);
+      if (out_dirs[count])
+	{
+	  strcpy (out_dirs[count], norm);
+	  count++;
+	}
+    }
+  fclose (fp);
+  return count;
+}
+
+/* pm_jmy */
+static int
+batch_is_pattern (const char *s)
+{
+  return strchr (s, '*') != NULL || strchr (s, '?') != NULL || strchr (s, '[') != NULL;
+}
+
+#if !defined(WINDOWS)
+/* pm_jmy */
+static int
+batch_gather_files_exact (const char *broker, const char *dir, char *out_files[], int max_files)
+{
+  DIR *d;
+  struct dirent *e;
+  char path[BROKER_LOG_TOP_MAX_PATH];
+  int n = 0;
+  size_t blen = strlen (broker);
+
+  d = opendir (dir);
+  if (!d)
+    return 0;
+
+  while ((e = readdir (d)) != NULL && n < max_files)
+    {
+      size_t elen = strlen (e->d_name);
+      if (elen < blen + 2)
+	continue;
+      if (strncmp (e->d_name, broker, blen) != 0 || e->d_name[blen] != '_')
+	continue;
+      if (elen >= 8 && strcmp (e->d_name + elen - 8, ".sql.log") == 0)
+	;
+      else if (elen >= 12 && strcmp (e->d_name + elen - 12, ".sql.log.bak") == 0)
+	;
+      else if (elen >= 9 && strcmp (e->d_name + elen - 9, ".slow.log") == 0)
+	;
+      else
+	continue;
+      snprintf (path, sizeof (path), "%s/%s", dir, e->d_name);
+      out_files[n] = (char *) MALLOC (strlen (path) + 1);
+      if (out_files[n])
+	{
+	  strcpy (out_files[n], path);
+	  n++;
+	}
+    }
+  closedir (d);
+  return n;
+}
+
+/* pm_jmy */
+static int
+batch_gather_files_pattern (const char *pattern, const char *dir, char *out_files[], int max_files)
+{
+  DIR *d;
+  struct dirent *e;
+  char path[BROKER_LOG_TOP_MAX_PATH];
+  char broker_prefix[256];
+  char *last_underscore;
+  int n = 0;
+  size_t elen;
+
+  d = opendir (dir);
+  if (!d)
+    return 0;
+
+  while ((e = readdir (d)) != NULL && n < max_files)
+    {
+      size_t copy_len;
+      elen = strlen (e->d_name);
+      if (elen < 9)
+	continue;
+      if (strcmp (e->d_name + elen - 8, ".sql.log") != 0)
+	continue;
+      copy_len = elen - 8;
+      if (copy_len >= sizeof (broker_prefix))
+	copy_len = sizeof (broker_prefix) - 1;
+      memcpy (broker_prefix, e->d_name, copy_len);
+      broker_prefix[copy_len] = '\0';
+      last_underscore = strrchr (broker_prefix, '_');
+      if (!last_underscore)
+	continue;
+      *last_underscore = '\0';
+      if (!batch_match_pattern (broker_prefix, pattern))
+	continue;
+      snprintf (path, sizeof (path), "%s/%s", dir, e->d_name);
+      out_files[n] = (char *) MALLOC (strlen (path) + 1);
+      if (out_files[n])
+	{
+	  strcpy (out_files[n], path);
+	  n++;
+	}
+    }
+  closedir (d);
+  return n;
+}
+
+static int
+batch_gather_files_pattern_suffix (const char *pattern, const char *dir, const char *suffix, size_t suffix_len,
+				   char *out_files[], int max_files)
+{
+  DIR *d;
+  struct dirent *e;
+  char path[BROKER_LOG_TOP_MAX_PATH];
+  char broker_prefix[256];
+  char *last_underscore;
+  int n = 0;
+  size_t elen;
+
+  d = opendir (dir);
+  if (!d)
+    return 0;
+
+  while ((e = readdir (d)) != NULL && n < max_files)
+    {
+      elen = strlen (e->d_name);
+      if (elen <= suffix_len)
+	continue;
+      if (strcmp (e->d_name + elen - suffix_len, suffix) != 0)
+	continue;
+      {
+	size_t copy_len = elen - suffix_len;
+	if (copy_len >= sizeof (broker_prefix))
+	  copy_len = sizeof (broker_prefix) - 1;
+	memcpy (broker_prefix, e->d_name, copy_len);
+	broker_prefix[copy_len] = '\0';
+      }
+      last_underscore = strrchr (broker_prefix, '_');
+      if (!last_underscore)
+	continue;
+      *last_underscore = '\0';
+      if (!batch_match_pattern (broker_prefix, pattern))
+	continue;
+      snprintf (path, sizeof (path), "%s/%s", dir, e->d_name);
+      out_files[n] = (char *) MALLOC (strlen (path) + 1);
+      if (out_files[n])
+	{
+	  strcpy (out_files[n], path);
+	  n++;
+	}
+    }
+  closedir (d);
+  return n;
+}
+
+static int
+batch_gather_files_pattern_all (const char *pattern, const char *dir, char *out_files[], int max_files)
+{
+  int n = 0;
+  n += batch_gather_files_pattern_suffix (pattern, dir, ".sql.log", 8, out_files, max_files);
+  n += batch_gather_files_pattern_suffix (pattern, dir, ".sql.log.bak", 12, out_files + n, max_files - n);
+  n += batch_gather_files_pattern_suffix (pattern, dir, ".slow.log", 9, out_files + n, max_files - n);
+  return n;
+}
+#else
+static int
+batch_gather_files_exact (const char *broker, const char *dir, char *out_files[], int max_files)
+{
+  HANDLE h;
+  WIN32_FIND_DATAA fd;
+  char pattern[BROKER_LOG_TOP_MAX_PATH];
+  char path[BROKER_LOG_TOP_MAX_PATH];
+  int n = 0;
+  const char *suffixes[] = { "*.sql.log", "*.sql.log.bak", "*.slow.log", NULL };
+
+  for (int i = 0; suffixes[i] && n < max_files; i++)
+    {
+      snprintf (pattern, sizeof (pattern), "%s\\%s_%s", dir, broker, suffixes[i]);
+      h = FindFirstFileA (pattern, &fd);
+      if (h == INVALID_HANDLE_VALUE)
+	continue;
+      do
+	{
+	  if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+	    continue;
+	  snprintf (path, sizeof (path), "%s\\%s", dir, fd.cFileName);
+	  out_files[n] = (char *) MALLOC (strlen (path) + 1);
+	  if (out_files[n])
+	    {
+	      strcpy (out_files[n], path);
+	      n++;
+	    }
+	}
+      while (FindNextFileA (h, &fd) && n < max_files);
+      FindClose (h);
+    }
+  return n;
+}
+
+/* pm_jmy */
+static int
+batch_gather_files_pattern (const char *pattern, const char *dir, char *out_files[], int max_files)
+{
+  HANDLE h;
+  WIN32_FIND_DATAA fd;
+  char search[BROKER_LOG_TOP_MAX_PATH];
+  char path[BROKER_LOG_TOP_MAX_PATH];
+  int n = 0;
+  size_t plen = strlen (pattern);
+
+  snprintf (search, sizeof (search), "%s\\%s_*.sql.log", dir, pattern);
+  h = FindFirstFileA (search, &fd);
+  if (h == INVALID_HANDLE_VALUE)
+    return 0;
+  do
+    {
+      if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+	continue;
+      snprintf (path, sizeof (path), "%s\\%s", dir, fd.cFileName);
+      out_files[n] = (char *) MALLOC (strlen (path) + 1);
+      if (out_files[n])
+	{
+	  strcpy (out_files[n], path);
+	  n++;
+	}
+    }
+  while (FindNextFileA (h, &fd) && n < max_files);
+  FindClose (h);
+  return n;
+}
+
+static int
+batch_gather_files_pattern_all (const char *pattern, const char *dir, char *out_files[], int max_files)
+{
+  int n = 0;
+  n += batch_gather_files_pattern (pattern, dir, out_files, max_files);
+  /* Windows: batch_gather_files_pattern only gets .sql.log; add .bak and .slow via FindFirstFile */
+  {
+    HANDLE h;
+    WIN32_FIND_DATAA fd;
+    char search[BROKER_LOG_TOP_MAX_PATH];
+    char path[BROKER_LOG_TOP_MAX_PATH];
+    snprintf (search, sizeof (search), "%s\\%s_*.sql.log.bak", dir, pattern);
+    h = FindFirstFileA (search, &fd);
+    if (h != INVALID_HANDLE_VALUE)
+      {
+	do
+	  {
+	    if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+	      continue;
+	    if (n >= max_files)
+	      break;
+	    snprintf (path, sizeof (path), "%s\\%s", dir, fd.cFileName);
+	    out_files[n] = (char *) MALLOC (strlen (path) + 1);
+	    if (out_files[n])
+	      strcpy (out_files[n], path), n++;
+	  }
+	while (FindNextFileA (h, &fd));
+	FindClose (h);
+      }
+    snprintf (search, sizeof (search), "%s\\%s_*.slow.log", dir, pattern);
+    h = FindFirstFileA (search, &fd);
+    if (h != INVALID_HANDLE_VALUE)
+      {
+	do
+	  {
+	    if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+	      continue;
+	    if (n >= max_files)
+	      break;
+	    snprintf (path, sizeof (path), "%s\\%s", dir, fd.cFileName);
+	    out_files[n] = (char *) MALLOC (strlen (path) + 1);
+	    if (out_files[n])
+	      strcpy (out_files[n], path), n++;
+	  }
+	while (FindNextFileA (h, &fd));
+	FindClose (h);
+      }
+  }
+  return n;
+}
+
+/* pm_jmy */
+static int
+batch_get_brokers_from_dir (const char *dir, char *out_brokers[], int max_brokers)
+{
+  HANDLE h;
+  WIN32_FIND_DATAA fd;
+  char pattern[BROKER_LOG_TOP_MAX_PATH];
+  char seen[256][128];
+  char broker[256];
+  char *last_underscore;
+  size_t elen, suffix_len;
+  int nseen = 0;
+  int n = 0;
+  int i;
+  const char *patterns[] = { "*_*.sql.log", "*_*.sql.log.bak", "*_*.slow.log", NULL };
+
+  for (i = 0; patterns[i] && n < max_brokers; i++)
+    {
+      snprintf (pattern, sizeof (pattern), "%s\\%s", dir, patterns[i]);
+      h = FindFirstFileA (pattern, &fd);
+      if (h == INVALID_HANDLE_VALUE)
+	continue;
+      do
+	{
+	  if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+	    continue;
+	  elen = strlen (fd.cFileName);
+	  if (strcmp (patterns[i], "*_*.sql.log") == 0)
+	    suffix_len = 8;
+	  else if (strcmp (patterns[i], "*_*.sql.log.bak") == 0)
+	    suffix_len = 12;
+	  else
+	    suffix_len = 9;
+	  if (elen <= suffix_len)
+	    continue;
+	  {
+	    size_t copy_len = elen - suffix_len;
+	    if (copy_len >= sizeof (broker))
+	      copy_len = sizeof (broker) - 1;
+	    memcpy (broker, fd.cFileName, copy_len);
+	    broker[copy_len] = '\0';
+	  }
+	  last_underscore = strrchr (broker, '_');
+	  if (!last_underscore || (size_t) (last_underscore - broker) >= sizeof (broker) - 1)
+	    continue;
+	  *last_underscore = '\0';
+	  {
+	    int j;
+	    for (j = 0; j < nseen; j++)
+	      if (strcmp (seen[j], broker) == 0)
+		break;
+	    if (j < nseen)
+	      continue;
+	  }
+	  if (nseen < 256)
+	    {
+	      snprintf (seen[nseen], sizeof (seen[0]), "%.127s", broker);
+	      nseen++;
+	    }
+	  if (n >= max_brokers)
+	    continue;
+	  out_brokers[n] = (char *) MALLOC (strlen (broker) + 1);
+	  if (out_brokers[n])
+	    {
+	      strcpy (out_brokers[n], broker);
+	      n++;
+	    }
+	}
+      while (FindNextFileA (h, &fd));
+      FindClose (h);
+    }
+  return n;
+}
+#endif
+
+/* pm_jmy */
+#if !defined(WINDOWS)
+static int
+batch_get_brokers_from_dir (const char *dir, char *out_brokers[], int max_brokers)
+{
+  DIR *d;
+  struct dirent *e;
+  char seen[256][128];
+  int nseen = 0;
+  int n = 0;
+  int i;
+  char broker[256];
+  char *last_underscore;
+  size_t suffix_len;
+
+  d = opendir (dir);
+  if (!d)
+    return 0;
+
+  while ((e = readdir (d)) != NULL)
+    {
+      size_t elen = strlen (e->d_name);
+      if (elen < 4)
+	continue;
+      if (elen >= 8 && strcmp (e->d_name + elen - 8, ".sql.log") == 0)
+	suffix_len = 8;
+      else if (elen >= 12 && strcmp (e->d_name + elen - 12, ".sql.log.bak") == 0)
+	suffix_len = 12;
+      else if (elen >= 9 && strcmp (e->d_name + elen - 9, ".slow.log") == 0)
+	suffix_len = 9;
+      else
+	continue;
+      {
+	size_t copy_len = elen - suffix_len;
+	if (copy_len >= sizeof (broker))
+	  copy_len = sizeof (broker) - 1;
+	memcpy (broker, e->d_name, copy_len);
+	broker[copy_len] = '\0';
+      }
+      last_underscore = strrchr (broker, '_');
+      if (!last_underscore || (size_t) (last_underscore - broker) >= sizeof (broker) - 1)
+	continue;
+      *last_underscore = '\0';
+      for (i = 0; i < nseen; i++)
+	if (strcmp (seen[i], broker) == 0)
+	  break;
+      if (i < nseen)
+	continue;
+      if (nseen < 256)
+	{
+	  snprintf (seen[nseen], sizeof (seen[0]), "%.127s", broker);
+	  nseen++;
+	}
+      if (n >= max_brokers)
+	continue;
+      out_brokers[n] = (char *) MALLOC (strlen (broker) + 1);
+      if (out_brokers[n])
+	{
+	  strcpy (out_brokers[n], broker);
+	  n++;
+	}
+    }
+  closedir (d);
+  return n;
+}
+#endif
+
+/* pm_jmy */
+static void
+batch_broker_to_safe (const char *name, char *out, size_t out_len)
+{
+  size_t i, j;
+  if (out_len < 2)
+    return;
+  for (i = 0, j = 0; name[i] && j < out_len - 1; i++)
+    {
+      if (name[i] == '*' || name[i] == '?' || name[i] == '[')
+	out[j++] = '_';
+      else
+	out[j++] = name[i];
+    }
+  out[j] = '\0';
+}
+
+/* pm_jmy */
+#if !defined(WINDOWS)
+static int
+batch_mkdir_out (const char *path)
+{
+  return mkdir (path, 0755);
+}
+#else
+static int
+batch_mkdir_out (const char *path)
+{
+  return _mkdir (path);
+}
+#endif
+
+/* pm_jmy */
+static int
+batch_run (void)
+{
+  char *dirs[BROKER_LOG_TOP_MAX_PATH];
+  char *files[BROKER_LOG_TOP_MAX_FILES];
+  char *brokers[512];
+  char norm[BROKER_LOG_TOP_MAX_PATH];
+  char parent_out_base[BROKER_LOG_TOP_MAX_PATH];
+  char subdir[BROKER_LOG_TOP_MAX_PATH];
+  char broker_safe[256];
+  char cwd_buf[BROKER_LOG_TOP_MAX_PATH];
+  volatile char *saved_cwd = NULL;
+  volatile int ndirs = 0;
+  volatile int d = 0, i = 0;
+  volatile int nfiles = 0;
+  int error = 0;
+  struct stat st;
+  time_t now;
+  struct tm tm_buf;
+  const char *env_out_base;
+
+  saved_cwd = getcwd (cwd_buf, sizeof (cwd_buf));
+  if (saved_cwd == NULL)
+    {
+      fprintf (stderr, "Error: cannot get current directory\n");
+      return -1;
+    }
+
+  /* 배치 모드는 안정성이 우선: MT_MODE 사용 시에도 단일 스레드로 실행 */
+  broker_log_top_force_single_thread = 1;
+
+  /* pm_jmy */
+  if (strcmp (batch_log_dir, ".") == 0 && batch_broker_name != NULL)
+    {
+      char *files[BROKER_LOG_TOP_MAX_FILES];
+      int nfiles;
+      int j;
+
+      nfiles = batch_is_pattern (batch_broker_name)
+	? batch_gather_files_pattern_all (batch_broker_name, cwd_buf, files, BROKER_LOG_TOP_MAX_FILES)
+	: batch_gather_files_exact (batch_broker_name, cwd_buf, files, BROKER_LOG_TOP_MAX_FILES);
+      if (nfiles == 0)
+	{
+	  fprintf (stderr, "Info: no files for broker '%s' in current directory.\n", batch_broker_name);
+	  return -1;
+	}
+      fprintf (stdout, "%s\n", batch_broker_name);
+      query_info_reset ();
+#if !defined(WINDOWS)
+      if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
+	{
+	  broker_log_top_segfault_jmp_valid = 1;
+	  signal (SIGSEGV, broker_log_top_segfault_handler);
+	  if (mode_tran)
+	    error = log_top_tran (nfiles, files, 0);
+	  else
+	    error = log_top_query (nfiles, files, 0);
+	  broker_log_top_segfault_jmp_valid = 0;
+	  signal (SIGSEGV, SIG_DFL);
+	}
+      else
+	{
+	  /* pm_jmy: batch_broker_name이 없는 경우(브로커 이름/패턴 미지정)는
+	   * 모든 디렉토리의 브로커 목록을 한 번에 모아서 처리한다.
+	   * 기존 코드에서는 for (d ...) 루프 안에서 매 디렉토리마다
+	   * 전체 브로커를 다시 처리하여, LOG_DIR가 여러 개일 때
+	   * 동일 브로커가 중복 처리되는 문제가 있었다.
+	   * d == 0에서만 전체 브로커 집계를 수행하고,
+	   * 이후 반복(d > 0)에서는 건너뛴다.
+	   */
+	  if (d > 0)
+	    {
+	      goto next_dir;
+	    }
+	  broker_log_top_segfault_jmp_valid = 0;
+	  signal (SIGSEGV, SIG_DFL);
+	  fprintf (stderr, "Warning: segmentation fault during processing, skipping.\n");
+	  error = 0;
+	}
+#else
+      if (mode_tran)
+	error = log_top_tran (nfiles, files, 0);
+      else
+	error = log_top_query (nfiles, files, 0);
+#endif
+      for (j = 0; j < nfiles; j++)
+	FREE_MEM (files[j]);
+      return error;
+    }
+
+  env_out_base = getenv ("OUT_BASE");
+  if (env_out_base && env_out_base[0])
+    {
+      snprintf (parent_out_base, sizeof (parent_out_base), "%s", env_out_base);
+    }
+  else
+    {
+      now = time (NULL);
+#if !defined(WINDOWS)
+      if (localtime_r (&now, &tm_buf) == NULL)
+#else
+      if (localtime_s (&tm_buf, &now) != 0)
+#endif
+	{
+	  fprintf (stderr, "Error: cannot get local time\n");
+	  return -1;
+	}
+      strftime (parent_out_base, sizeof (parent_out_base), "broker_log_top_%y%m%d_%H%M", &tm_buf);
+    }
+
+  if (batch_mkdir_out (parent_out_base) < 0 && errno != EEXIST)
+    {
+      fprintf (stderr, "Error: cannot create output directory: %s\n", parent_out_base);
+      return -1;
+    }
+
+  if (strcasecmp (batch_log_dir, "LOG_DIR") == 0)
+    {
+      ndirs = batch_discover_log_dirs (dirs, BROKER_LOG_TOP_MAX_DIRS);
+      if (ndirs <= 0)
+	{
+	  fprintf (stderr, "Error: no valid LOG_DIR found in cubrid_broker.conf\n");
+	  return -1;
+	}
+    }
+  else
+    {
+      batch_normalize_path (batch_log_dir, norm, sizeof (norm));
+      if (stat (norm, &st) < 0 || !S_ISDIR (st.st_mode))
+	{
+	  fprintf (stderr, "Error: directory does not exist: %s\n", norm);
+	  return -1;
+	}
+      dirs[0] = (char *) MALLOC (strlen (norm) + 1);
+      if (!dirs[0])
+	return -1;
+      strcpy (dirs[0], norm);
+      ndirs = 1;
+    }
+
+  if (batch_broker_name)
+    {
+      for (d = 0; d < ndirs && !error; d++)
+	{
+	  if (batch_is_pattern (batch_broker_name))
+	    {
+	  nfiles = batch_gather_files_pattern_all (batch_broker_name, dirs[d], files, BROKER_LOG_TOP_MAX_FILES);
+	  if (nfiles == 0)
+	    {
+	      fprintf (stderr, "Info: [%s] no files matching pattern '%s', skipping.\n", dirs[d], batch_broker_name);
+	      goto next_dir;
+	    }
+	  batch_broker_to_safe (batch_broker_name, broker_safe, sizeof (broker_safe));
+	  snprintf (subdir, sizeof (subdir), "%.1023s/%.255s", parent_out_base, broker_safe);
+	  if (batch_mkdir_out (subdir) < 0 && errno != EEXIST)
+	    {
+	      fprintf (stderr, "Error: cannot create output directory: %s\n", subdir);
+	      error = -1;
+	      goto next_dir;
+	    }
+#if !defined(WINDOWS)
+	  if (chdir (subdir) < 0)
+#else
+	  if (_chdir (subdir) < 0)
+#endif
+	    {
+	      fprintf (stderr, "Error: cannot chdir to %s\n", subdir);
+	      error = -1;
+	      goto next_dir;
+	    }
+	  fprintf (stdout, "%s\n", batch_broker_name);
+	  query_info_reset ();
+#if !defined(WINDOWS)
+	  if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
+	    {
+	      broker_log_top_segfault_jmp_valid = 1;
+	      signal (SIGSEGV, broker_log_top_segfault_handler);
+	      if (mode_tran)
+		error = log_top_tran (nfiles, files, 0);
+	      else
+		error = log_top_query (nfiles, files, 0);
+	      chdir ((const char *) saved_cwd);
+	      for (i = 0; i < nfiles; i++)
+		FREE_MEM (files[i]);
+	      broker_log_top_segfault_jmp_valid = 0;
+	      signal (SIGSEGV, SIG_DFL);
+	    }
+	  else
+	    {
+	      broker_log_top_segfault_jmp_valid = 0;
+	      signal (SIGSEGV, SIG_DFL);
+	      fprintf (stderr, "Warning: segmentation fault during processing, skipping.\n");
+	      chdir ((const char *) saved_cwd);
+	    }
+#else
+	  if (mode_tran)
+	    error = log_top_tran (nfiles, files, 0);
+	  else
+	    error = log_top_query (nfiles, files, 0);
+	  chdir ((const char *) saved_cwd);
+	  for (i = 0; i < nfiles; i++)
+	    FREE_MEM (files[i]);
+#endif
+	    }
+	  else
+	    {
+	  nfiles = batch_gather_files_exact (batch_broker_name, dirs[d], files, BROKER_LOG_TOP_MAX_FILES);
+	  if (nfiles == 0)
+	    {
+	      fprintf (stderr, "Info: [%s] no files for broker '%s', skipping.\n", dirs[d], batch_broker_name);
+	      goto next_dir;
+	    }
+	  snprintf (subdir, sizeof (subdir), "%.1023s/%.255s", parent_out_base, batch_broker_name);
+	  if (batch_mkdir_out (subdir) < 0 && errno != EEXIST)
+	    {
+	      fprintf (stderr, "Error: cannot create output directory: %s\n", subdir);
+	      error = -1;
+	      goto next_dir;
+	    }
+#if !defined(WINDOWS)
+	  if (chdir (subdir) < 0)
+#else
+	  if (_chdir (subdir) < 0)
+#endif
+	    {
+	      fprintf (stderr, "Error: cannot chdir to %s\n", subdir);
+	      error = -1;
+	      goto next_dir;
+	    }
+	  fprintf (stdout, "%s\n", batch_broker_name);
+	  query_info_reset ();
+#if !defined(WINDOWS)
+	  if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
+	    {
+	      broker_log_top_segfault_jmp_valid = 1;
+	      signal (SIGSEGV, broker_log_top_segfault_handler);
+	      if (mode_tran)
+		error = log_top_tran (nfiles, files, 0);
+	      else
+		error = log_top_query (nfiles, files, 0);
+	      chdir ((const char *) saved_cwd);
+	      for (i = 0; i < nfiles; i++)
+		FREE_MEM (files[i]);
+	      broker_log_top_segfault_jmp_valid = 0;
+	      signal (SIGSEGV, SIG_DFL);
+	    }
+	  else
+	    {
+	      broker_log_top_segfault_jmp_valid = 0;
+	      signal (SIGSEGV, SIG_DFL);
+	      fprintf (stderr, "Warning: segmentation fault during processing, skipping.\n");
+	      chdir ((const char *) saved_cwd);
+	    }
+#else
+	  if (mode_tran)
+	    error = log_top_tran (nfiles, files, 0);
+	  else
+	    error = log_top_query (nfiles, files, 0);
+	  chdir ((const char *) saved_cwd);
+	  for (i = 0; i < nfiles; i++)
+	    FREE_MEM (files[i]);
+#endif
+	    }
+	next_dir:
+	  if (strcasecmp (batch_log_dir, "LOG_DIR") == 0)
+	    {
+	      FREE_MEM (dirs[d]);
+	      dirs[d] = NULL;
+	    }
+	}
+    }
+  else
+    {
+	  char *all_brokers[512];
+	  volatile int total_brokers = 0;
+	  int bi, dir_idx, k;
+
+	  memset (all_brokers, 0, sizeof (all_brokers));
+
+	  for (dir_idx = 0; dir_idx < ndirs && total_brokers < 512; dir_idx++)
+	    {
+	      char *dir_brokers[512];
+	      int dir_nb;
+
+	      memset (dir_brokers, 0, sizeof (dir_brokers));
+	      if (dirs[dir_idx] == NULL)
+		continue;
+	      dir_nb = batch_get_brokers_from_dir (dirs[dir_idx], dir_brokers, 512);
+
+	      for (bi = 0; bi < dir_nb && total_brokers < 512; bi++)
+		{
+		  int found = 0;
+		  if (dir_brokers[bi] == NULL)
+		    continue;
+		  for (k = 0; k < total_brokers; k++)
+		    {
+		      if (all_brokers[k] != NULL && strcmp (all_brokers[k], dir_brokers[bi]) == 0)
+			{
+			  found = 1;
+			  FREE_MEM (dir_brokers[bi]);
+			  dir_brokers[bi] = NULL;
+			  break;
+			}
+		    }
+		  if (!found)
+		    {
+		      all_brokers[total_brokers] = dir_brokers[bi];
+		      total_brokers++;
+		    }
+		}
+	    }
+
+	  if (total_brokers == 0)
+	    {
+	      fprintf (stderr, "Info: no brokers found in any directory.\n");
+	      /* LOG_DIR 모드인 경우, dirs[]는 아래 정리 루틴에서 한 번에 해제된다. */
+	      return 0;
+	    }
+
+	  for (i = 0; i < total_brokers && !error; i++)
+	    {
+	      volatile int total_files = 0;
+	      char *all_files[BROKER_LOG_TOP_MAX_FILES];
+	      int j, dir_idx;
+	      int num_files = 0;
+
+	      memset (all_files, 0, sizeof (all_files));
+
+	      if (all_brokers[i] == NULL)
+		continue;
+
+	      for (dir_idx = 0; dir_idx < ndirs && total_files < BROKER_LOG_TOP_MAX_FILES; dir_idx++)
+		{
+		  if (dirs[dir_idx] == NULL)
+		    continue;
+		  int dir_files = batch_gather_files_exact (all_brokers[i], dirs[dir_idx],
+							    all_files + total_files,
+							    BROKER_LOG_TOP_MAX_FILES - total_files);
+		  total_files += dir_files;
+		}
+	      num_files = total_files;
+
+	      if (total_files == 0)
+		{
+		  FREE_MEM (all_brokers[i]);
+		  all_brokers[i] = NULL;
+		  continue;
+		}
+
+	      snprintf (subdir, sizeof (subdir), "%.1023s/%.255s", parent_out_base, all_brokers[i]);
+	      if (batch_mkdir_out (subdir) < 0 && errno != EEXIST)
+		{
+		  fprintf (stderr, "Error: cannot create output directory: %s\n", subdir);
+		  FREE_MEM (all_brokers[i]);
+		  all_brokers[i] = NULL;
+		  for (j = 0; j < num_files; j++)
+		    FREE_MEM (all_files[j]);
+		  error = -1;
+		  continue;
+		}
+#if !defined(WINDOWS)
+	      if (chdir (subdir) < 0)
+#else
+	      if (_chdir (subdir) < 0)
+#endif
+		{
+		  fprintf (stderr, "Error: cannot chdir to %s\n", subdir);
+		  FREE_MEM (all_brokers[i]);
+		  all_brokers[i] = NULL;
+		  for (j = 0; j < num_files; j++)
+		    FREE_MEM (all_files[j]);
+		  error = -1;
+		  continue;
+		}
+	      fprintf (stdout, "%s\n", all_brokers[i]);
+	      query_info_reset ();
+#if !defined(WINDOWS)
+	      if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
+		{
+		  broker_log_top_segfault_jmp_valid = 1;
+		  signal (SIGSEGV, broker_log_top_segfault_handler);
+		  if (mode_tran)
+		    error = log_top_tran (total_files, all_files, 0);
+		  else
+		    error = log_top_query (total_files, all_files, 0);
+		  chdir ((const char *) saved_cwd);
+		  for (j = 0; j < num_files; j++)
+		    FREE_MEM (all_files[j]);
+		  FREE_MEM (all_brokers[i]);
+		  all_brokers[i] = NULL;
+		  broker_log_top_segfault_jmp_valid = 0;
+		  signal (SIGSEGV, SIG_DFL);
+		}
+	      else
+		{
+		  broker_log_top_segfault_jmp_valid = 0;
+		  signal (SIGSEGV, SIG_DFL);
+		  fprintf (stderr, "Warning: segmentation fault during processing, skipping.\n");
+		  chdir ((const char *) saved_cwd);
+		}
+#else
+	      if (mode_tran)
+		error = log_top_tran (total_files, all_files, 0);
+	      else
+		error = log_top_query (total_files, all_files, 0);
+	      chdir ((const char *) saved_cwd);
+	      for (j = 0; j < num_files; j++)
+		FREE_MEM (all_files[j]);
+	      FREE_MEM (all_brokers[i]);
+	      all_brokers[i] = NULL;
+#endif
+	    }
+    }
+
+#if !defined(WINDOWS)
+  if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
+    {
+      broker_log_top_segfault_jmp_valid = 1;
+      signal (SIGSEGV, broker_log_top_segfault_handler);
+      if (strcasecmp (batch_log_dir, "LOG_DIR") == 0)
+	{
+	  for (d = 0; d < ndirs; d++)
+	    {
+	      if (dirs[d] != NULL)
+		{
+		  FREE_MEM (dirs[d]);
+		  dirs[d] = NULL;
+		}
+	    }
+	}
+      else
+	{
+	  if (dirs[0] != NULL)
+	    {
+	      FREE_MEM (dirs[0]);
+	      dirs[0] = NULL;
+	    }
+	}
+      broker_log_top_segfault_jmp_valid = 0;
+      signal (SIGSEGV, SIG_DFL);
+    }
+  else
+    {
+      broker_log_top_segfault_jmp_valid = 0;
+      signal (SIGSEGV, SIG_DFL);
+      fprintf (stderr, "Warning: segmentation fault during final cleanup, skipping.\n");
+    }
+#else
+  if (strcasecmp (batch_log_dir, "LOG_DIR") == 0)
+    {
+      for (d = 0; d < ndirs; d++)
+	{
+	  if (dirs[d] != NULL)
+	    {
+	      FREE_MEM (dirs[d]);
+	      dirs[d] = NULL;
+	    }
+	}
+    }
+  else
+    {
+      if (dirs[0] != NULL)
+	{
+	  FREE_MEM (dirs[0]);
+	  dirs[0] = NULL;
+	}
+    }
+#endif
+
+  return error;
+}
+
 int
 get_file_offset (char *filename, long *start_offset, long *end_offset)
 {
@@ -352,25 +1498,36 @@ log_top_query (int argc, char *argv[], int arg_start)
   int error = 0;
   long start_offset, end_offset;
 #ifdef MT_MODE
+  int use_mt = 0;
   T_THREAD thrid;
   int j;
 #endif
 
 #ifdef MT_MODE
-  query_info_mutex_init ();
+  if (!broker_log_top_force_single_thread && num_thread > 1)
+    {
+      use_mt = 1;
+    }
+  if (use_mt)
+    {
+      query_info_mutex_init ();
+    }
 #endif
 
 #ifdef MT_MODE
-  work_msg = MALLOC (sizeof (T_WORK_MSG) * num_thread);
-  if (work_msg == NULL)
+  if (use_mt)
     {
-      fprintf (stderr, "malloc error\n");
-      return -1;
-    }
-  memset (work_msg, 0, sizeof (T_WORK_MSG *) * num_thread);
+      work_msg = MALLOC (sizeof (T_WORK_MSG) * num_thread);
+      if (work_msg == NULL)
+	{
+	  fprintf (stderr, "malloc error\n");
+	  return -1;
+	}
+      memset (work_msg, 0, sizeof (T_WORK_MSG) * num_thread);
 
-  for (i = 0; i < num_thread; i++)
-    THREAD_BEGIN (thrid, thr_main, (void *) i);
+      for (i = 0; i < num_thread; i++)
+	THREAD_BEGIN (thrid, thr_main, (void *) i);
+    }
 #endif
 
   for (i = arg_start; i < argc; i++)
@@ -398,21 +1555,33 @@ log_top_query (int argc, char *argv[], int arg_start)
 	}
 
 #ifdef MT_MODE
-      while (1)
+      if (use_mt)
 	{
-	  for (j = 0; j < num_thread; j++)
+	  while (1)
 	    {
-	      if (work_msg[j].filename == NULL)
+	      for (j = 0; j < num_thread; j++)
 		{
-		  work_msg[j].fp = fp;
-		  work_msg[j].filename = filename;
-		  break;
+		  if (work_msg[j].filename == NULL)
+		    {
+		      work_msg[j].fp = fp;
+		      work_msg[j].filename = filename;
+		      break;
+		    }
 		}
+	      if (j == num_thread)
+		SLEEP_MILISEC (1, 0);
+	      else
+		break;
 	    }
-	  if (j == num_thread)
-	    SLEEP_MILISEC (1, 0);
-	  else
-	    break;
+	}
+      else
+	{
+	  error = log_top (fp, filename, start_offset, end_offset);
+	  fclose (fp);
+	  if (error == LT_INVAILD_VERSION)
+	    {
+	      return error;
+	    }
 	}
 #else
       error = log_top (fp, filename, start_offset, end_offset);
@@ -425,7 +1594,10 @@ log_top_query (int argc, char *argv[], int arg_start)
     }
 
 #ifdef MT_MODE
-  process_flag = 0;
+  if (use_mt)
+    {
+      process_flag = 0;
+    }
 #endif
 
   if (sql_info_file != NULL)
@@ -744,8 +1916,14 @@ static int
 get_args (int argc, char *argv[])
 {
   int c;
+  int option_index = 0;
+  /* pm_jmy */
+  static struct option long_options[] = {
+    { "all-broker-log", optional_argument, 0, 'l' },
+    { 0, 0, 0, 0 }
+  };
 
-  while ((c = getopt (argc, argv, "tq:h:F:T:")) != EOF)
+  while ((c = getopt_long (argc, argv, "tq:h:F:T:", long_options, &option_index)) != EOF)
     {
       switch (c)
 	{
@@ -770,6 +1948,18 @@ get_args (int argc, char *argv[])
 	      goto date_format_err;
 	    }
 	  break;
+	case 'l':
+	  /* pm_jmy */
+	  if (optarg && optarg[0])
+	    batch_log_dir = optarg;
+	  else if (optind < argc && strchr (argv[optind], '/') != NULL)
+	    {
+	      batch_log_dir = argv[optind];
+	      optind++;
+	    }
+	  else
+	    batch_log_dir = "LOG_DIR";
+	  break;
 	default:
 	  goto getargs_err;
 	}
@@ -778,11 +1968,33 @@ get_args (int argc, char *argv[])
   if (mode_max_handle_lower_bound > 0)
     log_top_mode = MODE_MAX_HANDLE;
 
+  /* pm_jmy */
+  if (optind < argc && optind + 1 == argc)
+    {
+      const char *arg = argv[optind];
+      size_t len = strlen (arg);
+      if (strchr (arg, '/') == NULL
+	  && !(len >= 8 && strcmp (arg + len - 8, ".sql.log") == 0)
+	  && !(len >= 12 && strcmp (arg + len - 12, ".sql.log.bak") == 0)
+	  && !(len >= 9 && strcmp (arg + len - 9, ".slow.log") == 0))
+	{
+	  batch_broker_name = arg;
+	  if (batch_log_dir == NULL)
+	    batch_log_dir = ".";
+	}
+    }
+
+  if (batch_log_dir != NULL)
+    return optind;
+
   if (optind < argc)
     return optind;
 
+  goto getargs_err;
+
 getargs_err:
-  fprintf (stderr, "%s [-t] [-F <from date>] [-T <to date>] <log_file> ...\n", argv[0]);
+  /* pm_jmy */
+  fprintf (stderr, "%s [-t] [-F <from date>] [-T <to date>] [--all-broker-log | <log_file> ...]\n", argv[0]);
   return -1;
 date_format_err:
   fprintf (stderr, "invalid date. valid date format is yy-mm-dd hh:mm:ss.\n");

--- a/src/broker/broker_log_top.c
+++ b/src/broker/broker_log_top.c
@@ -988,7 +988,12 @@ batch_run (void)
   int error = 0;
   struct stat st;
   time_t now;
+<<<<<<< HEAD
   struct tm tm_buf;
+=======
+  /* cppcheck: localtime_s() fills tm_buf, but analyzer requires initialization. */
+  struct tm tm_buf = { 0 };
+>>>>>>> 3991ee2f0 ([CBRD-26610] broker_log_top 명령어 --all-broker-log 옵션 추가)
   const char *env_out_base;
 
   saved_cwd = getcwd (cwd_buf, sizeof (cwd_buf));
@@ -1116,6 +1121,7 @@ batch_run (void)
 	{
 	  if (batch_is_pattern (batch_broker_name))
 	    {
+<<<<<<< HEAD
 	      nfiles = batch_gather_files_pattern_all (batch_broker_name, dirs[d], files, BROKER_LOG_TOP_MAX_FILES);
 	      if (nfiles == 0)
 		{
@@ -1330,6 +1336,21 @@ batch_run (void)
 		FREE_MEM (all_files[j]);
 	      error = -1;
 	      continue;
+=======
+	  nfiles = batch_gather_files_pattern_all (batch_broker_name, dirs[d], files, BROKER_LOG_TOP_MAX_FILES);
+	  if (nfiles == 0)
+	    {
+	      fprintf (stderr, "Info: [%s] no files matching pattern '%s', skipping.\n", dirs[d], batch_broker_name);
+	      goto next_dir;
+	    }
+	  batch_broker_to_safe (batch_broker_name, broker_safe, sizeof (broker_safe));
+	  snprintf (subdir, sizeof (subdir), "%.1023s/%.255s", parent_out_base, broker_safe);
+	  if (batch_mkdir_out (subdir) < 0 && errno != EEXIST)
+	    {
+	      fprintf (stderr, "Error: cannot create output directory: %s\n", subdir);
+	      error = -1;
+	      goto next_dir;
+>>>>>>> 3991ee2f0 ([CBRD-26610] broker_log_top 명령어 --all-broker-log 옵션 추가)
 	    }
 #if !defined(WINDOWS)
 	  if (chdir (subdir) < 0)
@@ -1338,6 +1359,7 @@ batch_run (void)
 #endif
 	    {
 	      fprintf (stderr, "Error: cannot chdir to %s\n", subdir);
+<<<<<<< HEAD
 	      FREE_MEM (all_brokers[i]);
 	      all_brokers[i] = NULL;
 	      for (j = 0; j < num_files; j++)
@@ -1346,6 +1368,12 @@ batch_run (void)
 	      continue;
 	    }
 	  fprintf (stdout, "%s\n", all_brokers[i]);
+=======
+	      error = -1;
+	      goto next_dir;
+	    }
+	  fprintf (stdout, "%s\n", batch_broker_name);
+>>>>>>> 3991ee2f0 ([CBRD-26610] broker_log_top 명령어 --all-broker-log 옵션 추가)
 	  query_info_reset ();
 #if !defined(WINDOWS)
 	  if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
@@ -1353,6 +1381,7 @@ batch_run (void)
 	      broker_log_top_segfault_jmp_valid = 1;
 	      signal (SIGSEGV, broker_log_top_segfault_handler);
 	      if (mode_tran)
+<<<<<<< HEAD
 		error = log_top_tran (total_files, all_files, 0);
 	      else
 		error = log_top_query (total_files, all_files, 0);
@@ -1361,6 +1390,14 @@ batch_run (void)
 		FREE_MEM (all_files[j]);
 	      FREE_MEM (all_brokers[i]);
 	      all_brokers[i] = NULL;
+=======
+		error = log_top_tran (nfiles, files, 0);
+	      else
+		error = log_top_query (nfiles, files, 0);
+	      chdir ((const char *) saved_cwd);
+	      for (i = 0; i < nfiles; i++)
+		FREE_MEM (files[i]);
+>>>>>>> 3991ee2f0 ([CBRD-26610] broker_log_top 명령어 --all-broker-log 옵션 추가)
 	      broker_log_top_segfault_jmp_valid = 0;
 	      signal (SIGSEGV, SIG_DFL);
 	    }
@@ -1373,6 +1410,7 @@ batch_run (void)
 	    }
 #else
 	  if (mode_tran)
+<<<<<<< HEAD
 	    error = log_top_tran (total_files, all_files, 0);
 	  else
 	    error = log_top_query (total_files, all_files, 0);
@@ -1384,6 +1422,225 @@ batch_run (void)
 #endif
 	}
     }
+=======
+	    error = log_top_tran (nfiles, files, 0);
+	  else
+	    error = log_top_query (nfiles, files, 0);
+	  chdir ((const char *) saved_cwd);
+	  for (i = 0; i < nfiles; i++)
+	    FREE_MEM (files[i]);
+#endif
+	    }
+	  else
+	    {
+	  nfiles = batch_gather_files_exact (batch_broker_name, dirs[d], files, BROKER_LOG_TOP_MAX_FILES);
+	  if (nfiles == 0)
+	    {
+	      fprintf (stderr, "Info: [%s] no files for broker '%s', skipping.\n", dirs[d], batch_broker_name);
+	      goto next_dir;
+	    }
+	  snprintf (subdir, sizeof (subdir), "%.1023s/%.255s", parent_out_base, batch_broker_name);
+	  if (batch_mkdir_out (subdir) < 0 && errno != EEXIST)
+	    {
+	      fprintf (stderr, "Error: cannot create output directory: %s\n", subdir);
+	      error = -1;
+	      goto next_dir;
+	    }
+#if !defined(WINDOWS)
+	  if (chdir (subdir) < 0)
+#else
+	  if (_chdir (subdir) < 0)
+#endif
+	    {
+	      fprintf (stderr, "Error: cannot chdir to %s\n", subdir);
+	      error = -1;
+	      goto next_dir;
+	    }
+	  fprintf (stdout, "%s\n", batch_broker_name);
+	  query_info_reset ();
+#if !defined(WINDOWS)
+	  if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
+	    {
+	      broker_log_top_segfault_jmp_valid = 1;
+	      signal (SIGSEGV, broker_log_top_segfault_handler);
+	      if (mode_tran)
+		error = log_top_tran (nfiles, files, 0);
+	      else
+		error = log_top_query (nfiles, files, 0);
+	      chdir ((const char *) saved_cwd);
+	      for (i = 0; i < nfiles; i++)
+		FREE_MEM (files[i]);
+	      broker_log_top_segfault_jmp_valid = 0;
+	      signal (SIGSEGV, SIG_DFL);
+	    }
+	  else
+	    {
+	      broker_log_top_segfault_jmp_valid = 0;
+	      signal (SIGSEGV, SIG_DFL);
+	      fprintf (stderr, "Warning: segmentation fault during processing, skipping.\n");
+	      chdir ((const char *) saved_cwd);
+	    }
+#else
+	  if (mode_tran)
+	    error = log_top_tran (nfiles, files, 0);
+	  else
+	    error = log_top_query (nfiles, files, 0);
+	  chdir ((const char *) saved_cwd);
+	  for (i = 0; i < nfiles; i++)
+	    FREE_MEM (files[i]);
+#endif
+	    }
+	next_dir:
+	  if (strcasecmp (batch_log_dir, "LOG_DIR") == 0)
+	    {
+	      FREE_MEM (dirs[d]);
+	      dirs[d] = NULL;
+	    }
+	}
+    }
+  else
+    {
+	  char *all_brokers[512];
+	  volatile int total_brokers = 0;
+	  int bi, dir_idx, k;
+
+	  memset (all_brokers, 0, sizeof (all_brokers));
+
+	  for (dir_idx = 0; dir_idx < ndirs && total_brokers < 512; dir_idx++)
+	    {
+	      char *dir_brokers[512];
+	      int dir_nb;
+
+	      memset (dir_brokers, 0, sizeof (dir_brokers));
+	      if (dirs[dir_idx] == NULL)
+		continue;
+	      dir_nb = batch_get_brokers_from_dir (dirs[dir_idx], dir_brokers, 512);
+
+	      for (bi = 0; bi < dir_nb && total_brokers < 512; bi++)
+		{
+		  int found = 0;
+		  if (dir_brokers[bi] == NULL)
+		    continue;
+		  for (k = 0; k < total_brokers; k++)
+		    {
+		      if (all_brokers[k] != NULL && strcmp (all_brokers[k], dir_brokers[bi]) == 0)
+			{
+			  found = 1;
+			  FREE_MEM (dir_brokers[bi]);
+			  dir_brokers[bi] = NULL;
+			  break;
+			}
+		    }
+		  if (!found)
+		    {
+		      all_brokers[total_brokers] = dir_brokers[bi];
+		      total_brokers++;
+		    }
+		}
+	    }
+
+	  if (total_brokers == 0)
+	    {
+	      fprintf (stderr, "Info: no brokers found in any directory.\n");
+	      /* LOG_DIR 모드인 경우, dirs[]는 아래 정리 루틴에서 한 번에 해제된다. */
+	      return 0;
+	    }
+
+	  for (i = 0; i < total_brokers && !error; i++)
+	    {
+	      volatile int total_files = 0;
+	      char *all_files[BROKER_LOG_TOP_MAX_FILES];
+	      int j, dir_idx;
+	      int num_files = 0;
+
+	      memset (all_files, 0, sizeof (all_files));
+
+	      if (all_brokers[i] == NULL)
+		continue;
+
+	      for (dir_idx = 0; dir_idx < ndirs && total_files < BROKER_LOG_TOP_MAX_FILES; dir_idx++)
+		{
+		  if (dirs[dir_idx] == NULL)
+		    continue;
+		  int dir_files = batch_gather_files_exact (all_brokers[i], dirs[dir_idx],
+							    all_files + total_files,
+							    BROKER_LOG_TOP_MAX_FILES - total_files);
+		  total_files += dir_files;
+		}
+	      num_files = total_files;
+
+	      if (total_files == 0)
+		{
+		  FREE_MEM (all_brokers[i]);
+		  all_brokers[i] = NULL;
+		  continue;
+		}
+
+	      snprintf (subdir, sizeof (subdir), "%.1023s/%.255s", parent_out_base, all_brokers[i]);
+	      if (batch_mkdir_out (subdir) < 0 && errno != EEXIST)
+		{
+		  fprintf (stderr, "Error: cannot create output directory: %s\n", subdir);
+		  FREE_MEM (all_brokers[i]);
+		  all_brokers[i] = NULL;
+		  for (j = 0; j < num_files; j++)
+		    FREE_MEM (all_files[j]);
+		  error = -1;
+		  continue;
+		}
+#if !defined(WINDOWS)
+	      if (chdir (subdir) < 0)
+#else
+	      if (_chdir (subdir) < 0)
+#endif
+		{
+		  fprintf (stderr, "Error: cannot chdir to %s\n", subdir);
+		  FREE_MEM (all_brokers[i]);
+		  all_brokers[i] = NULL;
+		  for (j = 0; j < num_files; j++)
+		    FREE_MEM (all_files[j]);
+		  error = -1;
+		  continue;
+		}
+	      fprintf (stdout, "%s\n", all_brokers[i]);
+	      query_info_reset ();
+#if !defined(WINDOWS)
+	      if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
+		{
+		  broker_log_top_segfault_jmp_valid = 1;
+		  signal (SIGSEGV, broker_log_top_segfault_handler);
+		  if (mode_tran)
+		    error = log_top_tran (total_files, all_files, 0);
+		  else
+		    error = log_top_query (total_files, all_files, 0);
+		  chdir ((const char *) saved_cwd);
+		  for (j = 0; j < num_files; j++)
+		    FREE_MEM (all_files[j]);
+		  FREE_MEM (all_brokers[i]);
+		  all_brokers[i] = NULL;
+		  broker_log_top_segfault_jmp_valid = 0;
+		  signal (SIGSEGV, SIG_DFL);
+		}
+	      else
+		{
+		  broker_log_top_segfault_jmp_valid = 0;
+		  signal (SIGSEGV, SIG_DFL);
+		  fprintf (stderr, "Warning: segmentation fault during processing, skipping.\n");
+		  chdir ((const char *) saved_cwd);
+		}
+#else
+	      if (mode_tran)
+		error = log_top_tran (total_files, all_files, 0);
+	      else
+		error = log_top_query (total_files, all_files, 0);
+	      chdir ((const char *) saved_cwd);
+	      for (j = 0; j < num_files; j++)
+		FREE_MEM (all_files[j]);
+	      FREE_MEM (all_brokers[i]);
+	      all_brokers[i] = NULL;
+#endif
+	    }
+    }
+>>>>>>> 3991ee2f0 ([CBRD-26610] broker_log_top 명령어 --all-broker-log 옵션 추가)
 
 #if !defined(WINDOWS)
   if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
@@ -1920,8 +2177,13 @@ get_args (int argc, char *argv[])
   int option_index = 0;
   /* pm_jmy */
   static struct option long_options[] = {
+<<<<<<< HEAD
     {"all-broker-log", optional_argument, 0, 'l'},
     {0, 0, 0, 0}
+=======
+    { "all-broker-log", optional_argument, 0, 'l' },
+    { 0, 0, 0, 0 }
+>>>>>>> 3991ee2f0 ([CBRD-26610] broker_log_top 명령어 --all-broker-log 옵션 추가)
   };
 
   while ((c = getopt_long (argc, argv, "tq:h:F:T:", long_options, &option_index)) != EOF)

--- a/src/broker/broker_log_top.c
+++ b/src/broker/broker_log_top.c
@@ -1116,219 +1116,20 @@ batch_run (void)
 	{
 	  if (batch_is_pattern (batch_broker_name))
 	    {
-	  nfiles = batch_gather_files_pattern_all (batch_broker_name, dirs[d], files, BROKER_LOG_TOP_MAX_FILES);
-	  if (nfiles == 0)
-	    {
-	      fprintf (stderr, "Info: [%s] no files matching pattern '%s', skipping.\n", dirs[d], batch_broker_name);
-	      goto next_dir;
-	    }
-	  batch_broker_to_safe (batch_broker_name, broker_safe, sizeof (broker_safe));
-	  snprintf (subdir, sizeof (subdir), "%.1023s/%.255s", parent_out_base, broker_safe);
-	  if (batch_mkdir_out (subdir) < 0 && errno != EEXIST)
-	    {
-	      fprintf (stderr, "Error: cannot create output directory: %s\n", subdir);
-	      error = -1;
-	      goto next_dir;
-	    }
-#if !defined(WINDOWS)
-	  if (chdir (subdir) < 0)
-#else
-	  if (_chdir (subdir) < 0)
-#endif
-	    {
-	      fprintf (stderr, "Error: cannot chdir to %s\n", subdir);
-	      error = -1;
-	      goto next_dir;
-	    }
-	  fprintf (stdout, "%s\n", batch_broker_name);
-	  query_info_reset ();
-#if !defined(WINDOWS)
-	  if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
-	    {
-	      broker_log_top_segfault_jmp_valid = 1;
-	      signal (SIGSEGV, broker_log_top_segfault_handler);
-	      if (mode_tran)
-		error = log_top_tran (nfiles, files, 0);
-	      else
-		error = log_top_query (nfiles, files, 0);
-	      chdir ((const char *) saved_cwd);
-	      for (i = 0; i < nfiles; i++)
-		FREE_MEM (files[i]);
-	      broker_log_top_segfault_jmp_valid = 0;
-	      signal (SIGSEGV, SIG_DFL);
-	    }
-	  else
-	    {
-	      broker_log_top_segfault_jmp_valid = 0;
-	      signal (SIGSEGV, SIG_DFL);
-	      fprintf (stderr, "Warning: segmentation fault during processing, skipping.\n");
-	      chdir ((const char *) saved_cwd);
-	    }
-#else
-	  if (mode_tran)
-	    error = log_top_tran (nfiles, files, 0);
-	  else
-	    error = log_top_query (nfiles, files, 0);
-	  chdir ((const char *) saved_cwd);
-	  for (i = 0; i < nfiles; i++)
-	    FREE_MEM (files[i]);
-#endif
-	    }
-	  else
-	    {
-	  nfiles = batch_gather_files_exact (batch_broker_name, dirs[d], files, BROKER_LOG_TOP_MAX_FILES);
-	  if (nfiles == 0)
-	    {
-	      fprintf (stderr, "Info: [%s] no files for broker '%s', skipping.\n", dirs[d], batch_broker_name);
-	      goto next_dir;
-	    }
-	  snprintf (subdir, sizeof (subdir), "%.1023s/%.255s", parent_out_base, batch_broker_name);
-	  if (batch_mkdir_out (subdir) < 0 && errno != EEXIST)
-	    {
-	      fprintf (stderr, "Error: cannot create output directory: %s\n", subdir);
-	      error = -1;
-	      goto next_dir;
-	    }
-#if !defined(WINDOWS)
-	  if (chdir (subdir) < 0)
-#else
-	  if (_chdir (subdir) < 0)
-#endif
-	    {
-	      fprintf (stderr, "Error: cannot chdir to %s\n", subdir);
-	      error = -1;
-	      goto next_dir;
-	    }
-	  fprintf (stdout, "%s\n", batch_broker_name);
-	  query_info_reset ();
-#if !defined(WINDOWS)
-	  if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
-	    {
-	      broker_log_top_segfault_jmp_valid = 1;
-	      signal (SIGSEGV, broker_log_top_segfault_handler);
-	      if (mode_tran)
-		error = log_top_tran (nfiles, files, 0);
-	      else
-		error = log_top_query (nfiles, files, 0);
-	      chdir ((const char *) saved_cwd);
-	      for (i = 0; i < nfiles; i++)
-		FREE_MEM (files[i]);
-	      broker_log_top_segfault_jmp_valid = 0;
-	      signal (SIGSEGV, SIG_DFL);
-	    }
-	  else
-	    {
-	      broker_log_top_segfault_jmp_valid = 0;
-	      signal (SIGSEGV, SIG_DFL);
-	      fprintf (stderr, "Warning: segmentation fault during processing, skipping.\n");
-	      chdir ((const char *) saved_cwd);
-	    }
-#else
-	  if (mode_tran)
-	    error = log_top_tran (nfiles, files, 0);
-	  else
-	    error = log_top_query (nfiles, files, 0);
-	  chdir ((const char *) saved_cwd);
-	  for (i = 0; i < nfiles; i++)
-	    FREE_MEM (files[i]);
-#endif
-	    }
-	next_dir:
-	  if (strcasecmp (batch_log_dir, "LOG_DIR") == 0)
-	    {
-	      FREE_MEM (dirs[d]);
-	      dirs[d] = NULL;
-	    }
-	}
-    }
-  else
-    {
-	  char *all_brokers[512];
-	  volatile int total_brokers = 0;
-	  int bi, dir_idx, k;
-
-	  memset (all_brokers, 0, sizeof (all_brokers));
-
-	  for (dir_idx = 0; dir_idx < ndirs && total_brokers < 512; dir_idx++)
-	    {
-	      char *dir_brokers[512];
-	      int dir_nb;
-
-	      memset (dir_brokers, 0, sizeof (dir_brokers));
-	      if (dirs[dir_idx] == NULL)
-		continue;
-	      dir_nb = batch_get_brokers_from_dir (dirs[dir_idx], dir_brokers, 512);
-
-	      for (bi = 0; bi < dir_nb && total_brokers < 512; bi++)
+	      nfiles = batch_gather_files_pattern_all (batch_broker_name, dirs[d], files, BROKER_LOG_TOP_MAX_FILES);
+	      if (nfiles == 0)
 		{
-		  int found = 0;
-		  if (dir_brokers[bi] == NULL)
-		    continue;
-		  for (k = 0; k < total_brokers; k++)
-		    {
-		      if (all_brokers[k] != NULL && strcmp (all_brokers[k], dir_brokers[bi]) == 0)
-			{
-			  found = 1;
-			  FREE_MEM (dir_brokers[bi]);
-			  dir_brokers[bi] = NULL;
-			  break;
-			}
-		    }
-		  if (!found)
-		    {
-		      all_brokers[total_brokers] = dir_brokers[bi];
-		      total_brokers++;
-		    }
+		  fprintf (stderr, "Info: [%s] no files matching pattern '%s', skipping.\n", dirs[d],
+			   batch_broker_name);
+		  goto next_dir;
 		}
-	    }
-
-	  if (total_brokers == 0)
-	    {
-	      fprintf (stderr, "Info: no brokers found in any directory.\n");
-	      /* LOG_DIR 모드인 경우, dirs[]는 아래 정리 루틴에서 한 번에 해제된다. */
-	      return 0;
-	    }
-
-	  for (i = 0; i < total_brokers && !error; i++)
-	    {
-	      volatile int total_files = 0;
-	      char *all_files[BROKER_LOG_TOP_MAX_FILES];
-	      int j, dir_idx;
-	      int num_files = 0;
-
-	      memset (all_files, 0, sizeof (all_files));
-
-	      if (all_brokers[i] == NULL)
-		continue;
-
-	      for (dir_idx = 0; dir_idx < ndirs && total_files < BROKER_LOG_TOP_MAX_FILES; dir_idx++)
-		{
-		  if (dirs[dir_idx] == NULL)
-		    continue;
-		  int dir_files = batch_gather_files_exact (all_brokers[i], dirs[dir_idx],
-							    all_files + total_files,
-							    BROKER_LOG_TOP_MAX_FILES - total_files);
-		  total_files += dir_files;
-		}
-	      num_files = total_files;
-
-	      if (total_files == 0)
-		{
-		  FREE_MEM (all_brokers[i]);
-		  all_brokers[i] = NULL;
-		  continue;
-		}
-
-	      snprintf (subdir, sizeof (subdir), "%.1023s/%.255s", parent_out_base, all_brokers[i]);
+	      batch_broker_to_safe (batch_broker_name, broker_safe, sizeof (broker_safe));
+	      snprintf (subdir, sizeof (subdir), "%.1023s/%.255s", parent_out_base, broker_safe);
 	      if (batch_mkdir_out (subdir) < 0 && errno != EEXIST)
 		{
 		  fprintf (stderr, "Error: cannot create output directory: %s\n", subdir);
-		  FREE_MEM (all_brokers[i]);
-		  all_brokers[i] = NULL;
-		  for (j = 0; j < num_files; j++)
-		    FREE_MEM (all_files[j]);
 		  error = -1;
-		  continue;
+		  goto next_dir;
 		}
 #if !defined(WINDOWS)
 	      if (chdir (subdir) < 0)
@@ -1337,14 +1138,10 @@ batch_run (void)
 #endif
 		{
 		  fprintf (stderr, "Error: cannot chdir to %s\n", subdir);
-		  FREE_MEM (all_brokers[i]);
-		  all_brokers[i] = NULL;
-		  for (j = 0; j < num_files; j++)
-		    FREE_MEM (all_files[j]);
 		  error = -1;
-		  continue;
+		  goto next_dir;
 		}
-	      fprintf (stdout, "%s\n", all_brokers[i]);
+	      fprintf (stdout, "%s\n", batch_broker_name);
 	      query_info_reset ();
 #if !defined(WINDOWS)
 	      if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
@@ -1352,14 +1149,12 @@ batch_run (void)
 		  broker_log_top_segfault_jmp_valid = 1;
 		  signal (SIGSEGV, broker_log_top_segfault_handler);
 		  if (mode_tran)
-		    error = log_top_tran (total_files, all_files, 0);
+		    error = log_top_tran (nfiles, files, 0);
 		  else
-		    error = log_top_query (total_files, all_files, 0);
+		    error = log_top_query (nfiles, files, 0);
 		  chdir ((const char *) saved_cwd);
-		  for (j = 0; j < num_files; j++)
-		    FREE_MEM (all_files[j]);
-		  FREE_MEM (all_brokers[i]);
-		  all_brokers[i] = NULL;
+		  for (i = 0; i < nfiles; i++)
+		    FREE_MEM (files[i]);
 		  broker_log_top_segfault_jmp_valid = 0;
 		  signal (SIGSEGV, SIG_DFL);
 		}
@@ -1372,6 +1167,192 @@ batch_run (void)
 		}
 #else
 	      if (mode_tran)
+		error = log_top_tran (nfiles, files, 0);
+	      else
+		error = log_top_query (nfiles, files, 0);
+	      chdir ((const char *) saved_cwd);
+	      for (i = 0; i < nfiles; i++)
+		FREE_MEM (files[i]);
+#endif
+	    }
+	  else
+	    {
+	      nfiles = batch_gather_files_exact (batch_broker_name, dirs[d], files, BROKER_LOG_TOP_MAX_FILES);
+	      if (nfiles == 0)
+		{
+		  fprintf (stderr, "Info: [%s] no files for broker '%s', skipping.\n", dirs[d], batch_broker_name);
+		  goto next_dir;
+		}
+	      snprintf (subdir, sizeof (subdir), "%.1023s/%.255s", parent_out_base, batch_broker_name);
+	      if (batch_mkdir_out (subdir) < 0 && errno != EEXIST)
+		{
+		  fprintf (stderr, "Error: cannot create output directory: %s\n", subdir);
+		  error = -1;
+		  goto next_dir;
+		}
+#if !defined(WINDOWS)
+	      if (chdir (subdir) < 0)
+#else
+	      if (_chdir (subdir) < 0)
+#endif
+		{
+		  fprintf (stderr, "Error: cannot chdir to %s\n", subdir);
+		  error = -1;
+		  goto next_dir;
+		}
+	      fprintf (stdout, "%s\n", batch_broker_name);
+	      query_info_reset ();
+#if !defined(WINDOWS)
+	      if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
+		{
+		  broker_log_top_segfault_jmp_valid = 1;
+		  signal (SIGSEGV, broker_log_top_segfault_handler);
+		  if (mode_tran)
+		    error = log_top_tran (nfiles, files, 0);
+		  else
+		    error = log_top_query (nfiles, files, 0);
+		  chdir ((const char *) saved_cwd);
+		  for (i = 0; i < nfiles; i++)
+		    FREE_MEM (files[i]);
+		  broker_log_top_segfault_jmp_valid = 0;
+		  signal (SIGSEGV, SIG_DFL);
+		}
+	      else
+		{
+		  broker_log_top_segfault_jmp_valid = 0;
+		  signal (SIGSEGV, SIG_DFL);
+		  fprintf (stderr, "Warning: segmentation fault during processing, skipping.\n");
+		  chdir ((const char *) saved_cwd);
+		}
+#else
+	      if (mode_tran)
+		error = log_top_tran (nfiles, files, 0);
+	      else
+		error = log_top_query (nfiles, files, 0);
+	      chdir ((const char *) saved_cwd);
+	      for (i = 0; i < nfiles; i++)
+		FREE_MEM (files[i]);
+#endif
+	    }
+	next_dir:
+	  if (strcasecmp (batch_log_dir, "LOG_DIR") == 0)
+	    {
+	      FREE_MEM (dirs[d]);
+	      dirs[d] = NULL;
+	    }
+	}
+    }
+  else
+    {
+      char *all_brokers[512];
+      volatile int total_brokers = 0;
+      int bi, dir_idx, k;
+
+      memset (all_brokers, 0, sizeof (all_brokers));
+
+      for (dir_idx = 0; dir_idx < ndirs && total_brokers < 512; dir_idx++)
+	{
+	  char *dir_brokers[512];
+	  int dir_nb;
+
+	  memset (dir_brokers, 0, sizeof (dir_brokers));
+	  if (dirs[dir_idx] == NULL)
+	    continue;
+	  dir_nb = batch_get_brokers_from_dir (dirs[dir_idx], dir_brokers, 512);
+
+	  for (bi = 0; bi < dir_nb && total_brokers < 512; bi++)
+	    {
+	      int found = 0;
+	      if (dir_brokers[bi] == NULL)
+		continue;
+	      for (k = 0; k < total_brokers; k++)
+		{
+		  if (all_brokers[k] != NULL && strcmp (all_brokers[k], dir_brokers[bi]) == 0)
+		    {
+		      found = 1;
+		      FREE_MEM (dir_brokers[bi]);
+		      dir_brokers[bi] = NULL;
+		      break;
+		    }
+		}
+	      if (!found)
+		{
+		  all_brokers[total_brokers] = dir_brokers[bi];
+		  total_brokers++;
+		}
+	    }
+	}
+
+      if (total_brokers == 0)
+	{
+	  fprintf (stderr, "Info: no brokers found in any directory.\n");
+	  /* LOG_DIR 모드인 경우, dirs[]는 아래 정리 루틴에서 한 번에 해제된다. */
+	  return 0;
+	}
+
+      for (i = 0; i < total_brokers && !error; i++)
+	{
+	  volatile int total_files = 0;
+	  char *all_files[BROKER_LOG_TOP_MAX_FILES];
+	  int j, dir_idx;
+	  int num_files = 0;
+
+	  memset (all_files, 0, sizeof (all_files));
+
+	  if (all_brokers[i] == NULL)
+	    continue;
+
+	  for (dir_idx = 0; dir_idx < ndirs && total_files < BROKER_LOG_TOP_MAX_FILES; dir_idx++)
+	    {
+	      if (dirs[dir_idx] == NULL)
+		continue;
+	      int dir_files = batch_gather_files_exact (all_brokers[i], dirs[dir_idx],
+							all_files + total_files,
+							BROKER_LOG_TOP_MAX_FILES - total_files);
+	      total_files += dir_files;
+	    }
+	  num_files = total_files;
+
+	  if (total_files == 0)
+	    {
+	      FREE_MEM (all_brokers[i]);
+	      all_brokers[i] = NULL;
+	      continue;
+	    }
+
+	  snprintf (subdir, sizeof (subdir), "%.1023s/%.255s", parent_out_base, all_brokers[i]);
+	  if (batch_mkdir_out (subdir) < 0 && errno != EEXIST)
+	    {
+	      fprintf (stderr, "Error: cannot create output directory: %s\n", subdir);
+	      FREE_MEM (all_brokers[i]);
+	      all_brokers[i] = NULL;
+	      for (j = 0; j < num_files; j++)
+		FREE_MEM (all_files[j]);
+	      error = -1;
+	      continue;
+	    }
+#if !defined(WINDOWS)
+	  if (chdir (subdir) < 0)
+#else
+	  if (_chdir (subdir) < 0)
+#endif
+	    {
+	      fprintf (stderr, "Error: cannot chdir to %s\n", subdir);
+	      FREE_MEM (all_brokers[i]);
+	      all_brokers[i] = NULL;
+	      for (j = 0; j < num_files; j++)
+		FREE_MEM (all_files[j]);
+	      error = -1;
+	      continue;
+	    }
+	  fprintf (stdout, "%s\n", all_brokers[i]);
+	  query_info_reset ();
+#if !defined(WINDOWS)
+	  if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
+	    {
+	      broker_log_top_segfault_jmp_valid = 1;
+	      signal (SIGSEGV, broker_log_top_segfault_handler);
+	      if (mode_tran)
 		error = log_top_tran (total_files, all_files, 0);
 	      else
 		error = log_top_query (total_files, all_files, 0);
@@ -1380,8 +1361,28 @@ batch_run (void)
 		FREE_MEM (all_files[j]);
 	      FREE_MEM (all_brokers[i]);
 	      all_brokers[i] = NULL;
-#endif
+	      broker_log_top_segfault_jmp_valid = 0;
+	      signal (SIGSEGV, SIG_DFL);
 	    }
+	  else
+	    {
+	      broker_log_top_segfault_jmp_valid = 0;
+	      signal (SIGSEGV, SIG_DFL);
+	      fprintf (stderr, "Warning: segmentation fault during processing, skipping.\n");
+	      chdir ((const char *) saved_cwd);
+	    }
+#else
+	  if (mode_tran)
+	    error = log_top_tran (total_files, all_files, 0);
+	  else
+	    error = log_top_query (total_files, all_files, 0);
+	  chdir ((const char *) saved_cwd);
+	  for (j = 0; j < num_files; j++)
+	    FREE_MEM (all_files[j]);
+	  FREE_MEM (all_brokers[i]);
+	  all_brokers[i] = NULL;
+#endif
+	}
     }
 
 #if !defined(WINDOWS)
@@ -1919,8 +1920,8 @@ get_args (int argc, char *argv[])
   int option_index = 0;
   /* pm_jmy */
   static struct option long_options[] = {
-    { "all-broker-log", optional_argument, 0, 'l' },
-    { 0, 0, 0, 0 }
+    {"all-broker-log", optional_argument, 0, 'l'},
+    {0, 0, 0, 0}
   };
 
   while ((c = getopt_long (argc, argv, "tq:h:F:T:", long_options, &option_index)) != EOF)

--- a/src/broker/broker_log_top.c
+++ b/src/broker/broker_log_top.c
@@ -988,12 +988,8 @@ batch_run (void)
   int error = 0;
   struct stat st;
   time_t now;
-<<<<<<< HEAD
-  struct tm tm_buf;
-=======
   /* cppcheck: localtime_s() fills tm_buf, but analyzer requires initialization. */
   struct tm tm_buf = { 0 };
->>>>>>> 3991ee2f0 ([CBRD-26610] broker_log_top 명령어 --all-broker-log 옵션 추가)
   const char *env_out_base;
 
   saved_cwd = getcwd (cwd_buf, sizeof (cwd_buf));
@@ -1121,222 +1117,6 @@ batch_run (void)
 	{
 	  if (batch_is_pattern (batch_broker_name))
 	    {
-<<<<<<< HEAD
-	      nfiles = batch_gather_files_pattern_all (batch_broker_name, dirs[d], files, BROKER_LOG_TOP_MAX_FILES);
-	      if (nfiles == 0)
-		{
-		  fprintf (stderr, "Info: [%s] no files matching pattern '%s', skipping.\n", dirs[d],
-			   batch_broker_name);
-		  goto next_dir;
-		}
-	      batch_broker_to_safe (batch_broker_name, broker_safe, sizeof (broker_safe));
-	      snprintf (subdir, sizeof (subdir), "%.1023s/%.255s", parent_out_base, broker_safe);
-	      if (batch_mkdir_out (subdir) < 0 && errno != EEXIST)
-		{
-		  fprintf (stderr, "Error: cannot create output directory: %s\n", subdir);
-		  error = -1;
-		  goto next_dir;
-		}
-#if !defined(WINDOWS)
-	      if (chdir (subdir) < 0)
-#else
-	      if (_chdir (subdir) < 0)
-#endif
-		{
-		  fprintf (stderr, "Error: cannot chdir to %s\n", subdir);
-		  error = -1;
-		  goto next_dir;
-		}
-	      fprintf (stdout, "%s\n", batch_broker_name);
-	      query_info_reset ();
-#if !defined(WINDOWS)
-	      if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
-		{
-		  broker_log_top_segfault_jmp_valid = 1;
-		  signal (SIGSEGV, broker_log_top_segfault_handler);
-		  if (mode_tran)
-		    error = log_top_tran (nfiles, files, 0);
-		  else
-		    error = log_top_query (nfiles, files, 0);
-		  chdir ((const char *) saved_cwd);
-		  for (i = 0; i < nfiles; i++)
-		    FREE_MEM (files[i]);
-		  broker_log_top_segfault_jmp_valid = 0;
-		  signal (SIGSEGV, SIG_DFL);
-		}
-	      else
-		{
-		  broker_log_top_segfault_jmp_valid = 0;
-		  signal (SIGSEGV, SIG_DFL);
-		  fprintf (stderr, "Warning: segmentation fault during processing, skipping.\n");
-		  chdir ((const char *) saved_cwd);
-		}
-#else
-	      if (mode_tran)
-		error = log_top_tran (nfiles, files, 0);
-	      else
-		error = log_top_query (nfiles, files, 0);
-	      chdir ((const char *) saved_cwd);
-	      for (i = 0; i < nfiles; i++)
-		FREE_MEM (files[i]);
-#endif
-	    }
-	  else
-	    {
-	      nfiles = batch_gather_files_exact (batch_broker_name, dirs[d], files, BROKER_LOG_TOP_MAX_FILES);
-	      if (nfiles == 0)
-		{
-		  fprintf (stderr, "Info: [%s] no files for broker '%s', skipping.\n", dirs[d], batch_broker_name);
-		  goto next_dir;
-		}
-	      snprintf (subdir, sizeof (subdir), "%.1023s/%.255s", parent_out_base, batch_broker_name);
-	      if (batch_mkdir_out (subdir) < 0 && errno != EEXIST)
-		{
-		  fprintf (stderr, "Error: cannot create output directory: %s\n", subdir);
-		  error = -1;
-		  goto next_dir;
-		}
-#if !defined(WINDOWS)
-	      if (chdir (subdir) < 0)
-#else
-	      if (_chdir (subdir) < 0)
-#endif
-		{
-		  fprintf (stderr, "Error: cannot chdir to %s\n", subdir);
-		  error = -1;
-		  goto next_dir;
-		}
-	      fprintf (stdout, "%s\n", batch_broker_name);
-	      query_info_reset ();
-#if !defined(WINDOWS)
-	      if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
-		{
-		  broker_log_top_segfault_jmp_valid = 1;
-		  signal (SIGSEGV, broker_log_top_segfault_handler);
-		  if (mode_tran)
-		    error = log_top_tran (nfiles, files, 0);
-		  else
-		    error = log_top_query (nfiles, files, 0);
-		  chdir ((const char *) saved_cwd);
-		  for (i = 0; i < nfiles; i++)
-		    FREE_MEM (files[i]);
-		  broker_log_top_segfault_jmp_valid = 0;
-		  signal (SIGSEGV, SIG_DFL);
-		}
-	      else
-		{
-		  broker_log_top_segfault_jmp_valid = 0;
-		  signal (SIGSEGV, SIG_DFL);
-		  fprintf (stderr, "Warning: segmentation fault during processing, skipping.\n");
-		  chdir ((const char *) saved_cwd);
-		}
-#else
-	      if (mode_tran)
-		error = log_top_tran (nfiles, files, 0);
-	      else
-		error = log_top_query (nfiles, files, 0);
-	      chdir ((const char *) saved_cwd);
-	      for (i = 0; i < nfiles; i++)
-		FREE_MEM (files[i]);
-#endif
-	    }
-	next_dir:
-	  if (strcasecmp (batch_log_dir, "LOG_DIR") == 0)
-	    {
-	      FREE_MEM (dirs[d]);
-	      dirs[d] = NULL;
-	    }
-	}
-    }
-  else
-    {
-      char *all_brokers[512];
-      volatile int total_brokers = 0;
-      int bi, dir_idx, k;
-
-      memset (all_brokers, 0, sizeof (all_brokers));
-
-      for (dir_idx = 0; dir_idx < ndirs && total_brokers < 512; dir_idx++)
-	{
-	  char *dir_brokers[512];
-	  int dir_nb;
-
-	  memset (dir_brokers, 0, sizeof (dir_brokers));
-	  if (dirs[dir_idx] == NULL)
-	    continue;
-	  dir_nb = batch_get_brokers_from_dir (dirs[dir_idx], dir_brokers, 512);
-
-	  for (bi = 0; bi < dir_nb && total_brokers < 512; bi++)
-	    {
-	      int found = 0;
-	      if (dir_brokers[bi] == NULL)
-		continue;
-	      for (k = 0; k < total_brokers; k++)
-		{
-		  if (all_brokers[k] != NULL && strcmp (all_brokers[k], dir_brokers[bi]) == 0)
-		    {
-		      found = 1;
-		      FREE_MEM (dir_brokers[bi]);
-		      dir_brokers[bi] = NULL;
-		      break;
-		    }
-		}
-	      if (!found)
-		{
-		  all_brokers[total_brokers] = dir_brokers[bi];
-		  total_brokers++;
-		}
-	    }
-	}
-
-      if (total_brokers == 0)
-	{
-	  fprintf (stderr, "Info: no brokers found in any directory.\n");
-	  /* LOG_DIR 모드인 경우, dirs[]는 아래 정리 루틴에서 한 번에 해제된다. */
-	  return 0;
-	}
-
-      for (i = 0; i < total_brokers && !error; i++)
-	{
-	  volatile int total_files = 0;
-	  char *all_files[BROKER_LOG_TOP_MAX_FILES];
-	  int j, dir_idx;
-	  int num_files = 0;
-
-	  memset (all_files, 0, sizeof (all_files));
-
-	  if (all_brokers[i] == NULL)
-	    continue;
-
-	  for (dir_idx = 0; dir_idx < ndirs && total_files < BROKER_LOG_TOP_MAX_FILES; dir_idx++)
-	    {
-	      if (dirs[dir_idx] == NULL)
-		continue;
-	      int dir_files = batch_gather_files_exact (all_brokers[i], dirs[dir_idx],
-							all_files + total_files,
-							BROKER_LOG_TOP_MAX_FILES - total_files);
-	      total_files += dir_files;
-	    }
-	  num_files = total_files;
-
-	  if (total_files == 0)
-	    {
-	      FREE_MEM (all_brokers[i]);
-	      all_brokers[i] = NULL;
-	      continue;
-	    }
-
-	  snprintf (subdir, sizeof (subdir), "%.1023s/%.255s", parent_out_base, all_brokers[i]);
-	  if (batch_mkdir_out (subdir) < 0 && errno != EEXIST)
-	    {
-	      fprintf (stderr, "Error: cannot create output directory: %s\n", subdir);
-	      FREE_MEM (all_brokers[i]);
-	      all_brokers[i] = NULL;
-	      for (j = 0; j < num_files; j++)
-		FREE_MEM (all_files[j]);
-	      error = -1;
-	      continue;
-=======
 	  nfiles = batch_gather_files_pattern_all (batch_broker_name, dirs[d], files, BROKER_LOG_TOP_MAX_FILES);
 	  if (nfiles == 0)
 	    {
@@ -1350,7 +1130,6 @@ batch_run (void)
 	      fprintf (stderr, "Error: cannot create output directory: %s\n", subdir);
 	      error = -1;
 	      goto next_dir;
->>>>>>> 3991ee2f0 ([CBRD-26610] broker_log_top 명령어 --all-broker-log 옵션 추가)
 	    }
 #if !defined(WINDOWS)
 	  if (chdir (subdir) < 0)
@@ -1359,21 +1138,10 @@ batch_run (void)
 #endif
 	    {
 	      fprintf (stderr, "Error: cannot chdir to %s\n", subdir);
-<<<<<<< HEAD
-	      FREE_MEM (all_brokers[i]);
-	      all_brokers[i] = NULL;
-	      for (j = 0; j < num_files; j++)
-		FREE_MEM (all_files[j]);
-	      error = -1;
-	      continue;
-	    }
-	  fprintf (stdout, "%s\n", all_brokers[i]);
-=======
 	      error = -1;
 	      goto next_dir;
 	    }
 	  fprintf (stdout, "%s\n", batch_broker_name);
->>>>>>> 3991ee2f0 ([CBRD-26610] broker_log_top 명령어 --all-broker-log 옵션 추가)
 	  query_info_reset ();
 #if !defined(WINDOWS)
 	  if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
@@ -1381,23 +1149,12 @@ batch_run (void)
 	      broker_log_top_segfault_jmp_valid = 1;
 	      signal (SIGSEGV, broker_log_top_segfault_handler);
 	      if (mode_tran)
-<<<<<<< HEAD
-		error = log_top_tran (total_files, all_files, 0);
-	      else
-		error = log_top_query (total_files, all_files, 0);
-	      chdir ((const char *) saved_cwd);
-	      for (j = 0; j < num_files; j++)
-		FREE_MEM (all_files[j]);
-	      FREE_MEM (all_brokers[i]);
-	      all_brokers[i] = NULL;
-=======
 		error = log_top_tran (nfiles, files, 0);
 	      else
 		error = log_top_query (nfiles, files, 0);
 	      chdir ((const char *) saved_cwd);
 	      for (i = 0; i < nfiles; i++)
 		FREE_MEM (files[i]);
->>>>>>> 3991ee2f0 ([CBRD-26610] broker_log_top 명령어 --all-broker-log 옵션 추가)
 	      broker_log_top_segfault_jmp_valid = 0;
 	      signal (SIGSEGV, SIG_DFL);
 	    }
@@ -1410,19 +1167,6 @@ batch_run (void)
 	    }
 #else
 	  if (mode_tran)
-<<<<<<< HEAD
-	    error = log_top_tran (total_files, all_files, 0);
-	  else
-	    error = log_top_query (total_files, all_files, 0);
-	  chdir ((const char *) saved_cwd);
-	  for (j = 0; j < num_files; j++)
-	    FREE_MEM (all_files[j]);
-	  FREE_MEM (all_brokers[i]);
-	  all_brokers[i] = NULL;
-#endif
-	}
-    }
-=======
 	    error = log_top_tran (nfiles, files, 0);
 	  else
 	    error = log_top_query (nfiles, files, 0);
@@ -1640,7 +1384,6 @@ batch_run (void)
 #endif
 	    }
     }
->>>>>>> 3991ee2f0 ([CBRD-26610] broker_log_top 명령어 --all-broker-log 옵션 추가)
 
 #if !defined(WINDOWS)
   if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
@@ -2177,13 +1920,8 @@ get_args (int argc, char *argv[])
   int option_index = 0;
   /* pm_jmy */
   static struct option long_options[] = {
-<<<<<<< HEAD
-    {"all-broker-log", optional_argument, 0, 'l'},
-    {0, 0, 0, 0}
-=======
     { "all-broker-log", optional_argument, 0, 'l' },
     { 0, 0, 0, 0 }
->>>>>>> 3991ee2f0 ([CBRD-26610] broker_log_top 명령어 --all-broker-log 옵션 추가)
   };
 
   while ((c = getopt_long (argc, argv, "tq:h:F:T:", long_options, &option_index)) != EOF)

--- a/src/broker/cas_query_info.c
+++ b/src/broker/cas_query_info.c
@@ -82,6 +82,44 @@ query_info_clear (T_QUERY_INFO * qi)
 }
 
 void
+query_info_reset (void)
+{
+  int i;
+
+#ifdef MT_MODE
+  MUTEX_LOCK (query_info_mutex);
+#endif
+
+  if (query_info_arr != NULL)
+    {
+      for (i = 0; i < num_query_info; i++)
+	{
+	  query_info_clear (&query_info_arr[i]);
+	}
+      FREE_MEM (query_info_arr);
+      query_info_arr = NULL;
+    }
+  num_query_info = 0;
+
+#ifdef TEST
+  if (query_info_arr_ne != NULL)
+    {
+      for (i = 0; i < num_query_info_ne; i++)
+	{
+	  query_info_clear (&query_info_arr_ne[i]);
+	}
+      FREE_MEM (query_info_arr_ne);
+      query_info_arr_ne = NULL;
+    }
+  num_query_info_ne = 0;
+#endif
+
+#ifdef MT_MODE
+  MUTEX_UNLOCK (query_info_mutex);
+#endif
+}
+
+void
 query_info_print (void)
 {
   int i;

--- a/src/broker/cas_query_info.h
+++ b/src/broker/cas_query_info.h
@@ -50,6 +50,7 @@ void query_info_mutex_init ();
 
 extern void query_info_init (T_QUERY_INFO * query_info);
 extern void query_info_clear (T_QUERY_INFO * qi);
+extern void query_info_reset (void);
 extern int query_info_add (T_QUERY_INFO * qi, int exec_time, int execute_res, char *filename, int lineno,
 			   char *end_date);
 extern int query_info_add_ne (T_QUERY_INFO * qi, char *end_date);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26610>

### Purpose
broker_log_top은 기본적으로 SQL 로그 파일 경로를 직접 인자로 넘기는 방식이 중심이며, cubrid_broker.conf에 정의된 여러 브로커 LOG_DIR에 흩어진 로그를 한 번에 분석하려면 브로커별 SQL LOG를 여러 번 수행해야 하고 동일 위치에서 수행할 경우 log_top.q, log_top.res, log_top.t 파일을 덮어 쓰는 문제가 있다.
이에 --all-broker-log 배치 모드를 추가하여, 설정 파일에서 LOG_DIR을 수집하거나 지정 디렉터리를 기준으로 브로커별 및 패턴별로 로그를 모아 분석하고, 결과를 타임스탬프 디렉터리 하위에 브로커(또는 패턴)별로 분리해 남기도록 한다.

### Specification Changes

1. broker_log_top 옵션들
- 전 : broker_log_top [-t] [-F <from date>] [-T <to date>] <log_file> ...
- 후 : broker_log_top [-t] [-F <from date>] [-T <to date>] [--all-broker-log | <log_file> ...]
2. 사용 예시:
2-1. cubrid_broker.conf의 모든 LOG_DIR에서 자동 수집
broker_log_top --all-broker-log
2-2.특정 디렉터리 기준
broker_log_top --all-broker-log $CUBRID/log/broker/sql_log
2-3. 기존 옵션과 같이 사용
broker_log_top -F "26-03-16 09:00" -T "26-03-16 09:30" --all-broker-log -t
2-4.--all-broker-log 사용하지 않고 지정 위치 디렉터리에서 지명 브로커명만 (단일 위치 인자)
broker_log_top $CUBRID/log/broker/sql_log/broker1*
3. broker_log_top 수행 결과
3-1. 명령어 수행 위치 : 타임스탬프 디렉터리 생성 후 하위 각 브로커명 디렉터리 생성하여 결과 파일 생성 됨
3-2. 수행 결과 파일
broker_log_top_260325_0949
 └── broker1
          └── log_top.q, log_top.res, log_top.t
 └── broker2
          └── log_top.q, log_top.res, log_top.t
 └── broker3
          └── log_top.q, log_top.res, log_top.t
 └── query_editor
          └── log_top.q, log_top.res, log_top.t

### Implementation
src/broker/broker_log_top.c : getopt_long 도입 및 long option all-broker-log 등록; batch_log_dir / batch_broker_name 및 배치용 상수, 헬퍼(batch_discover_log_dirs, batch_normalize_path, batch_gather_*, batch_run 등) 추가

### Remarks
1. 기존 동작 변경 없음: --all-broker-log 옵션 인자를 쓰지 않으면 기존처럼 동작한다.(참조: 타임스탬프 디렉토리 생성 동작은 동일 함)
2. 호환: 기존 -t, -F, -T, -q, -h 등 옵션과 조합 가능한 범위는 구현상 배치 경로에서 동일하게 호출되도록 맞춤.
3. 플랫폼: LOG_DIR 스캔·배치·SIGSEGV 복구 경로는 Unix 중심이며, Windows는 기존 단일 처리 경로 위주로 유지되는 형태다.
