### PR TITLE
[CBRD-26589] SBR 로그 복제 버그 수정 및 checksumdb 에서 checksum 수행 방식 수정

### DIFF
--- a/src/executables/checksumdb.c
+++ b/src/executables/checksumdb.c
@@ -1097,7 +1097,7 @@ chksum_print_checksum_query (PARSER_CONTEXT * parser, const char *table_name, DB
   escaped_lower_bound = chksum_get_quote_escaped_lower_bound (parser, lower_bound);
 
   /* query for calculating checksum */
-  buffer = pt_append_nulstring (parser, buffer, "REPLACE /*+ USE_SBR */ INTO ");
+  buffer = pt_append_nulstring (parser, buffer, "REPLACE INTO ");
   buffer = pt_append_nulstring (parser, buffer, chksum_result_Table_name);
   buffer =
     pt_append_nulstring (parser, buffer,
@@ -1123,7 +1123,7 @@ chksum_print_checksum_query (PARSER_CONTEXT * parser, const char *table_name, DB
   buffer = pt_append_nulstring (parser, buffer, ");");
 
   /* query for updating elapsed time */
-  buffer = pt_append_nulstring (parser, buffer, " UPDATE /*+ USE_SBR */ ");
+  buffer = pt_append_nulstring (parser, buffer, " UPDATE ");
   buffer = pt_append_nulstring (parser, buffer, chksum_result_Table_name);
   buffer = pt_append_nulstring (parser, buffer, " SET ");
   buffer =
@@ -1702,7 +1702,31 @@ chksum_calculate_checksum (PARSER_CONTEXT * parser, const OID * class_oidp, cons
 
   query = (const char *) pt_get_varchar_bytes (checksum_query);
 
+  /*
+   * write replication log first and release all locks
+   * to avoid long lock wait of other concurrent clients on active server
+   */
+  error = chksum_set_repl_info_and_demote_table_lock (table_name, query, class_oidp);
+  if (error != NO_ERROR)
+    {
+      snprintf (err_msg, LINE_MAX,
+		"Failed to write a checksum replication log." " (table name: %s, chunk id: %d, lower bound: %s)",
+		table_name, chunk_id, (char *) pt_get_varchar_bytes (lower_bound));
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CHKSUM_GENERIC_ERR, 2, err_msg, error);
+      return error;
+    }
+
+  /*
+   * The replication log written above is statement-based (SBR): the replica
+   * re-executes this query and recomputes the chunk checksum from its own data.
+   * Suppress row-based replication of the local execution below so the master's
+   * computed checksum row is not shipped as well - that would overwrite the
+   * replica's own recomputed value and hide real divergence. The flag lives on
+   * this transaction's descriptor (tdes) and is cleared right after execution.
+   */
+  db_set_suppress_repl_on_transaction (true);
   res = db_execute (query, &query_result, &query_error);
+  db_set_suppress_repl_on_transaction (false);
   if (res >= 0)
     {
       db_query_end (query_result);

--- a/src/executables/checksumdb.c
+++ b/src/executables/checksumdb.c
@@ -1724,9 +1724,22 @@ chksum_calculate_checksum (PARSER_CONTEXT * parser, const OID * class_oidp, cons
    * replica's own recomputed value and hide real divergence. The flag lives on
    * this transaction's descriptor (tdes) and is cleared right after execution.
    */
-  db_set_suppress_repl_on_transaction (true);
+  error = db_set_suppress_repl_on_transaction (true);
+  if (error != NO_ERROR)
+    {
+      snprintf (err_msg, LINE_MAX,
+		"Failed to suppress the row-based replication log." " (table name: %s, chunk id: %d)", table_name,
+		chunk_id);
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CHKSUM_GENERIC_ERR, 2, err_msg, error);
+      return error;
+    }
+
   res = db_execute (query, &query_result, &query_error);
-  db_set_suppress_repl_on_transaction (false);
+
+  /* resume row-based replication right after the local execution; keep its result as the error baseline,
+   * an actual execution failure below supersedes it */
+  error = db_set_suppress_repl_on_transaction (false);
+
   if (res >= 0)
     {
       db_query_end (query_result);

--- a/src/executables/checksumdb.c
+++ b/src/executables/checksumdb.c
@@ -697,8 +697,8 @@ chksum_drop_and_create_checksum_table (void)
 	    " %s INT,"		/* 7 */
 	    " %s DATETIME DEFAULT sys_datetime,"	/* 8 */
 	    " %s INT,"		/* 9 */
-	    " CONSTRAINT UNIQUE INDEX (%s, %s));"	/* 10, 11 */
-	    "DROP TABLE IF EXISTS %s;"	/* 12 */
+	    " CONSTRAINT UNIQUE INDEX (%s, %s))"	/* 10, 11 */
+	    " REPLICATION=OFF;" "DROP TABLE IF EXISTS %s;"	/* 12 */
 	    "CREATE TABLE %s"	/* 13 */
 	    "(%s VARCHAR (255) NOT NULL,"	/* 14 */
 	    " %s INT NOT NULL,"	/* 15 */

--- a/src/executables/checksumdb.c
+++ b/src/executables/checksumdb.c
@@ -697,8 +697,8 @@ chksum_drop_and_create_checksum_table (void)
 	    " %s INT,"		/* 7 */
 	    " %s DATETIME DEFAULT sys_datetime,"	/* 8 */
 	    " %s INT,"		/* 9 */
-	    " CONSTRAINT UNIQUE INDEX (%s, %s))"	/* 10, 11 */
-	    " REPLICATION=OFF;" "DROP TABLE IF EXISTS %s;"	/* 12 */
+	    " CONSTRAINT UNIQUE INDEX (%s, %s));"	/* 10, 11 */
+	    "DROP TABLE IF EXISTS %s;"	/* 12 */
 	    "CREATE TABLE %s"	/* 13 */
 	    "(%s VARCHAR (255) NOT NULL,"	/* 14 */
 	    " %s INT NOT NULL,"	/* 15 */
@@ -1097,7 +1097,7 @@ chksum_print_checksum_query (PARSER_CONTEXT * parser, const char *table_name, DB
   escaped_lower_bound = chksum_get_quote_escaped_lower_bound (parser, lower_bound);
 
   /* query for calculating checksum */
-  buffer = pt_append_nulstring (parser, buffer, "REPLACE INTO ");
+  buffer = pt_append_nulstring (parser, buffer, "REPLACE /*+ USE_SBR */ INTO ");
   buffer = pt_append_nulstring (parser, buffer, chksum_result_Table_name);
   buffer =
     pt_append_nulstring (parser, buffer,
@@ -1123,7 +1123,7 @@ chksum_print_checksum_query (PARSER_CONTEXT * parser, const char *table_name, DB
   buffer = pt_append_nulstring (parser, buffer, ");");
 
   /* query for updating elapsed time */
-  buffer = pt_append_nulstring (parser, buffer, " UPDATE ");
+  buffer = pt_append_nulstring (parser, buffer, " UPDATE /*+ USE_SBR */ ");
   buffer = pt_append_nulstring (parser, buffer, chksum_result_Table_name);
   buffer = pt_append_nulstring (parser, buffer, " SET ");
   buffer =
@@ -1701,20 +1701,6 @@ chksum_calculate_checksum (PARSER_CONTEXT * parser, const OID * class_oidp, cons
     }
 
   query = (const char *) pt_get_varchar_bytes (checksum_query);
-
-  /*
-   * write replication log first and release all locks
-   * to avoid long lock wait of other concurrent clients on active server
-   */
-  error = chksum_set_repl_info_and_demote_table_lock (table_name, query, class_oidp);
-  if (error != NO_ERROR)
-    {
-      snprintf (err_msg, LINE_MAX,
-		"Failed to write a checksum replication log." " (table name: %s, chunk id: %d, lower bound: %s)",
-		table_name, chunk_id, (char *) pt_get_varchar_bytes (lower_bound));
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CHKSUM_GENERIC_ERR, 2, err_msg, error);
-      return error;
-    }
 
   res = db_execute (query, &query_result, &query_error);
   if (res >= 0)

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -3119,14 +3119,14 @@ get_spec_classname (PT_NODE * spec)
   return spec->info.spec.entity_name->info.name.original;
 }
 
-int
+bool
 is_data_repl_log_enabled (PT_NODE * statement)
 {
   PT_NODE *spec;
 
   if (statement == NULL)
     {
-      return FALSE;
+      return false;
     }
 
   switch (statement->node_type)
@@ -3144,10 +3144,10 @@ is_data_repl_log_enabled (PT_NODE * statement)
 	{
 	  if ((spec->info.spec.flag & PT_SPEC_FLAG_UPDATE) && is_replication_class (get_spec_classname (spec)))
 	    {
-	      return TRUE;
+	      return true;
 	    }
 	}
-      return FALSE;
+      return false;
 
     case PT_DELETE:
       /* Only the specs actually deleted decide replication, not join-only specs. The deleted tables are
@@ -3156,13 +3156,13 @@ is_data_repl_log_enabled (PT_NODE * statement)
 	{
 	  if ((spec->info.spec.flag & PT_SPEC_FLAG_DELETE) && is_replication_class (get_spec_classname (spec)))
 	    {
-	      return TRUE;
+	      return true;
 	    }
 	}
-      return FALSE;
+      return false;
 
     default:
-      return TRUE;
+      return true;
     }
 }
 

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -3119,8 +3119,78 @@ get_spec_classname (PT_NODE * spec)
   return spec->info.spec.entity_name->info.name.original;
 }
 
+/* parser_walk_tree callback: set *found when a spec in the (derived) subtree
+ * resolves to a replication class. Used for updatable vclass targets that
+ * mq_rewrite_vclass_spec_as_derived pushed into a derived table (the outer
+ * spec's entity_name/flat_entity_list are cleared, so the real base classes
+ * live only inside the derived subtree). */
+static PT_NODE *
+pt_spec_repl_class_walk (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk)
+{
+  bool *found = (bool *) arg;
+  PT_NODE *cls;
+
+  if (*found)
+    {
+      *continue_walk = PT_STOP_WALK;
+      return node;
+    }
+
+  if (node != NULL && node->node_type == PT_SPEC)
+    {
+      for (cls = node->info.spec.flat_entity_list; cls != NULL; cls = cls->next)
+	{
+	  if (cls->info.name.db_object != NULL && sm_is_replication_class (cls->info.name.db_object))
+	    {
+	      *found = true;
+	      *continue_walk = PT_STOP_WALK;
+	      return node;
+	    }
+	}
+    }
+
+  return node;
+}
+
+/* A modify target may be named directly (entity_name / flat_entity_list) or,
+ * when an updatable vclass is rewritten into a derived table, have its real
+ * base classes only inside the derived subtree. Inspect both so SBR is not
+ * skipped for a derived vclass INSERT/UPDATE/DELETE target. */
+static bool
+spec_has_replication_class (PARSER_CONTEXT * parser, PT_NODE * spec)
+{
+  PT_NODE *cls;
+  bool found = false;
+
+  if (spec == NULL)
+    {
+      return false;
+    }
+
+  /* named / non-derived target: entity_name + resolved flat_entity_list */
+  if (is_replication_class (get_spec_classname (spec)))
+    {
+      return true;
+    }
+  for (cls = spec->info.spec.flat_entity_list; cls != NULL; cls = cls->next)
+    {
+      if (cls->info.name.db_object != NULL && sm_is_replication_class (cls->info.name.db_object))
+	{
+	  return true;
+	}
+    }
+
+  /* derived vclass target: the real base classes are inside the derived subtree */
+  if (spec->info.spec.derived_table != NULL)
+    {
+      parser_walk_tree (parser, spec->info.spec.derived_table, pt_spec_repl_class_walk, &found, NULL, NULL);
+    }
+
+  return found;
+}
+
 bool
-is_data_repl_log_enabled (PT_NODE * statement)
+is_data_repl_log_enabled (PARSER_CONTEXT * parser, PT_NODE * statement)
 {
   PT_NODE *spec;
 
@@ -3134,7 +3204,7 @@ is_data_repl_log_enabled (PT_NODE * statement)
     case PT_INSERT:
       /* INSERT has a single target spec. The INSERT...SELECT source tables are not modify targets and
        * are intentionally not inspected here. */
-      return is_replication_class (get_spec_classname (statement->info.insert.spec));
+      return spec_has_replication_class (parser, statement->info.insert.spec);
 
     case PT_UPDATE:
       /* Only the specs actually updated decide replication, not join-only specs. In a multi-table UPDATE
@@ -3142,7 +3212,7 @@ is_data_repl_log_enabled (PT_NODE * statement)
        * necessarily a target). Generate SBR when any updated target is a replication class. */
       for (spec = statement->info.update.spec; spec != NULL; spec = spec->next)
 	{
-	  if ((spec->info.spec.flag & PT_SPEC_FLAG_UPDATE) && is_replication_class (get_spec_classname (spec)))
+	  if ((spec->info.spec.flag & PT_SPEC_FLAG_UPDATE) && spec_has_replication_class (parser, spec))
 	    {
 	      return true;
 	    }
@@ -3154,7 +3224,7 @@ is_data_repl_log_enabled (PT_NODE * statement)
        * the ones flagged PT_SPEC_FLAG_DELETE. Generate SBR when any deleted target is a replication class. */
       for (spec = statement->info.delete_.spec; spec != NULL; spec = spec->next)
 	{
-	  if ((spec->info.spec.flag & PT_SPEC_FLAG_DELETE) && is_replication_class (get_spec_classname (spec)))
+	  if ((spec->info.spec.flag & PT_SPEC_FLAG_DELETE) && spec_has_replication_class (parser, spec))
 	    {
 	      return true;
 	    }
@@ -3221,7 +3291,7 @@ do_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
        * error. */
 
       /* disable data replication log for schema replication log types in HA mode */
-      if (!HA_DISABLED () && is_stmt_based_repl_type (statement) && is_data_repl_log_enabled (statement))
+      if (!HA_DISABLED () && is_stmt_based_repl_type (statement) && is_data_repl_log_enabled (parser, statement))
 	{
 	  need_stmt_replication = true;
 
@@ -3918,7 +3988,7 @@ do_execute_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
   /* for the subset of nodes which represent top level statements, process them; for any other node, return an error */
 
   /* disable data replication log for schema replication log types in HA mode */
-  if (!HA_DISABLED () && is_stmt_based_repl_type (statement) && is_data_repl_log_enabled (statement))
+  if (!HA_DISABLED () && is_stmt_based_repl_type (statement) && is_data_repl_log_enabled (parser, statement))
     {
       need_stmt_based_repl = true;
 

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -3099,17 +3099,30 @@ is_replication_class (const char *classname)
   class_obj = db_find_class (classname);
   if (class_obj == NULL)
     {
+      assert (false);
       return false;
     }
 
   return sm_is_replication_class (class_obj);
 }
 
+/* Safely extract the class name from a PT_SPEC; returns NULL when the spec has no entity name
+ * (e.g. a derived table). is_replication_class (NULL) is false, so callers stay null-safe. */
+static const char *
+get_spec_classname (PT_NODE * spec)
+{
+  if (spec == NULL || spec->info.spec.entity_name == NULL)
+    {
+      return NULL;
+    }
+
+  return spec->info.spec.entity_name->info.name.original;
+}
+
 int
 is_data_repl_log_enabled (PT_NODE * statement)
 {
   PT_NODE *spec;
-  const char *classname;
 
   if (statement == NULL)
     {
@@ -3119,19 +3132,29 @@ is_data_repl_log_enabled (PT_NODE * statement)
   switch (statement->node_type)
     {
     case PT_INSERT:
-      classname = statement->info.insert.spec->info.spec.entity_name->info.name.original;
-      return is_replication_class (classname);
+      /* INSERT has a single target spec. The INSERT...SELECT source tables are not modify targets and
+       * are intentionally not inspected here. */
+      return is_replication_class (get_spec_classname (statement->info.insert.spec));
 
     case PT_UPDATE:
-      classname = statement->info.update.spec->info.spec.entity_name->info.name.original;
-      return is_replication_class (classname);
+      /* Only the specs actually updated decide replication, not join-only specs. In a multi-table UPDATE
+       * the modified tables are the ones flagged PT_SPEC_FLAG_UPDATE (the first FROM spec is not
+       * necessarily a target). Generate SBR when any updated target is a replication class. */
+      for (spec = statement->info.update.spec; spec != NULL; spec = spec->next)
+	{
+	  if ((spec->info.spec.flag & PT_SPEC_FLAG_UPDATE) && is_replication_class (get_spec_classname (spec)))
+	    {
+	      return TRUE;
+	    }
+	}
+      return FALSE;
 
     case PT_DELETE:
+      /* Only the specs actually deleted decide replication, not join-only specs. The deleted tables are
+       * the ones flagged PT_SPEC_FLAG_DELETE. Generate SBR when any deleted target is a replication class. */
       for (spec = statement->info.delete_.spec; spec != NULL; spec = spec->next)
 	{
-	  classname = spec->info.spec.entity_name->info.name.original;
-
-	  if (is_replication_class (classname))
+	  if ((spec->info.spec.flag & PT_SPEC_FLAG_DELETE) && is_replication_class (get_spec_classname (spec)))
 	    {
 	      return TRUE;
 	    }

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -3720,6 +3720,63 @@ do_check_subquery_cache (PARSER_CONTEXT * parser, PT_NODE * statement)
   return err;
 }
 
+static bool
+is_replication_class_by_name (const char *classname)
+{
+  DB_OBJECT *class_obj;
+
+  if (classname == NULL)
+    {
+      return false;
+    }
+
+  class_obj = db_find_class (classname);
+  if (class_obj == NULL)
+    {
+      return false;
+    }
+
+  return sm_is_replication_class (class_obj);
+}
+
+int
+is_data_repl_log_enabled (PT_NODE * statement)
+{
+  PT_NODE *spec;
+  const char *classname;
+
+  if (statement == NULL)
+    {
+      return FALSE;
+    }
+
+  switch (statement->node_type)
+    {
+    case PT_INSERT:
+      classname = statement->info.insert.spec->info.spec.entity_name->info.name.original;
+      return is_replication_class_by_name (classname);
+
+    case PT_UPDATE:
+      classname = statement->info.update.spec->info.spec.entity_name->info.name.original;
+      return is_replication_class_by_name (classname);
+
+    case PT_DELETE:
+      for (spec = statement->info.delete_.spec; spec != NULL; spec = spec->next)
+	{
+	  classname = spec->info.spec.entity_name->info.name.original;
+
+	  if (is_replication_class_by_name (classname))
+	    {
+	      return TRUE;
+	    }
+	}
+      return FALSE;
+
+    default:
+      return TRUE;
+    }
+}
+
 /*
  * do_prepare_statement() - Prepare a given statement for execution
  *   return: Error code
@@ -3838,7 +3895,7 @@ do_execute_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
   /* for the subset of nodes which represent top level statements, process them; for any other node, return an error */
 
   /* disable data replication log for schema replication log types in HA mode */
-  if (!HA_DISABLED () && is_stmt_based_repl_type (statement))
+  if (!HA_DISABLED () && is_stmt_based_repl_type (statement) && is_data_repl_log_enabled (statement))
     {
       need_stmt_based_repl = true;
 

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -3086,6 +3086,63 @@ bool do_Trigger_involved;
  * Therefore, a separate global variable is set to distinguish whether the query is related to a trigger */
 bool cdc_Trigger_involved = false;
 
+static bool
+is_replication_class (const char *classname)
+{
+  DB_OBJECT *class_obj;
+
+  if (classname == NULL)
+    {
+      return false;
+    }
+
+  class_obj = db_find_class (classname);
+  if (class_obj == NULL)
+    {
+      return false;
+    }
+
+  return sm_is_replication_class (class_obj);
+}
+
+int
+is_data_repl_log_enabled (PT_NODE * statement)
+{
+  PT_NODE *spec;
+  const char *classname;
+
+  if (statement == NULL)
+    {
+      return FALSE;
+    }
+
+  switch (statement->node_type)
+    {
+    case PT_INSERT:
+      classname = statement->info.insert.spec->info.spec.entity_name->info.name.original;
+      return is_replication_class (classname);
+
+    case PT_UPDATE:
+      classname = statement->info.update.spec->info.spec.entity_name->info.name.original;
+      return is_replication_class (classname);
+
+    case PT_DELETE:
+      for (spec = statement->info.delete_.spec; spec != NULL; spec = spec->next)
+	{
+	  classname = spec->info.spec.entity_name->info.name.original;
+
+	  if (is_replication_class (classname))
+	    {
+	      return TRUE;
+	    }
+	}
+      return FALSE;
+
+    default:
+      return TRUE;
+    }
+}
+
 /*
  * do_statement() -
  *   return: Error code
@@ -3141,7 +3198,7 @@ do_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
        * error. */
 
       /* disable data replication log for schema replication log types in HA mode */
-      if (!HA_DISABLED () && is_stmt_based_repl_type (statement))
+      if (!HA_DISABLED () && is_stmt_based_repl_type (statement) && is_data_repl_log_enabled (statement))
 	{
 	  need_stmt_replication = true;
 
@@ -3718,63 +3775,6 @@ do_check_subquery_cache (PARSER_CONTEXT * parser, PT_NODE * statement)
     }
 
   return err;
-}
-
-static bool
-is_replication_class_by_name (const char *classname)
-{
-  DB_OBJECT *class_obj;
-
-  if (classname == NULL)
-    {
-      return false;
-    }
-
-  class_obj = db_find_class (classname);
-  if (class_obj == NULL)
-    {
-      return false;
-    }
-
-  return sm_is_replication_class (class_obj);
-}
-
-int
-is_data_repl_log_enabled (PT_NODE * statement)
-{
-  PT_NODE *spec;
-  const char *classname;
-
-  if (statement == NULL)
-    {
-      return FALSE;
-    }
-
-  switch (statement->node_type)
-    {
-    case PT_INSERT:
-      classname = statement->info.insert.spec->info.spec.entity_name->info.name.original;
-      return is_replication_class_by_name (classname);
-
-    case PT_UPDATE:
-      classname = statement->info.update.spec->info.spec.entity_name->info.name.original;
-      return is_replication_class_by_name (classname);
-
-    case PT_DELETE:
-      for (spec = statement->info.delete_.spec; spec != NULL; spec = spec->next)
-	{
-	  classname = spec->info.spec.entity_name->info.name.original;
-
-	  if (is_replication_class_by_name (classname))
-	    {
-	      return TRUE;
-	    }
-	}
-      return FALSE;
-
-    default:
-      return TRUE;
-    }
 }
 
 /*

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -8772,74 +8772,76 @@ locator_update_index (THREAD_ENTRY * thread_p, RECDES * new_recdes, RECDES * old
 	}
     }
 
-  if (rk_btid_index != -1)
+  if (heap_is_replication_class (thread_p, class_oid))
     {
-      assert (repl_info != NULL);
-
-      if (repl_old_key == NULL)
+      if (rk_btid_index != -1)
 	{
-	  key_domain = NULL;
-	  repl_old_key =
-	    heap_attrvalue_get_key (thread_p, rk_btid_index, old_attrinfo, old_recdes, &old_btid, &old_dbvalue,
-				    aligned_oldbuf, NULL, &key_domain, oid, false);
+	  assert (repl_info != NULL);
+
 	  if (repl_old_key == NULL)
 	    {
-	      error_code = ER_FAILED;
-	      goto error;
+	      key_domain = NULL;
+	      repl_old_key =
+		heap_attrvalue_get_key (thread_p, rk_btid_index, old_attrinfo, old_recdes, &old_btid, &old_dbvalue,
+					aligned_oldbuf, NULL, &key_domain, oid, false);
+	      if (repl_old_key == NULL)
+		{
+		  error_code = ER_FAILED;
+		  goto error;
+		}
+
+	      old_isnull = db_value_is_null (repl_old_key);
+	      pr_type = pr_type_from_id (DB_VALUE_DOMAIN_TYPE (repl_old_key));
+	      if (pr_type == NULL)
+		{
+		  error_code = ER_FAILED;
+		  goto error;
+		}
+
+	      if (pr_type->id == DB_TYPE_MIDXKEY)
+		{
+		  /*
+		   * The asc/desc properties in midxkey from log_applier may be
+		   * inaccurate. therefore, we should use btree header's domain
+		   * while processing btree search request from log_applier.
+		   */
+		  repl_old_key->data.midxkey.domain = key_domain;
+		}
+	      error_code =
+		repl_log_insert (thread_p, class_oid, oid, LOG_REPLICATION_DATA, RVREPL_DATA_UPDATE, repl_old_key,
+				 (REPL_INFO_TYPE) repl_info->repl_info_type);
+
+	      if (repl_old_key == &old_dbvalue)
+		{
+		  pr_clear_value (&old_dbvalue);
+		}
 	    }
-
-	  old_isnull = db_value_is_null (repl_old_key);
-	  pr_type = pr_type_from_id (DB_VALUE_DOMAIN_TYPE (repl_old_key));
-	  if (pr_type == NULL)
+	  else
 	    {
-	      error_code = ER_FAILED;
-	      goto error;
-	    }
+	      error_code =
+		repl_log_insert (thread_p, class_oid, oid, LOG_REPLICATION_DATA, RVREPL_DATA_UPDATE, repl_old_key,
+				 (REPL_INFO_TYPE) repl_info->repl_info_type);
 
-	  if (pr_type->id == DB_TYPE_MIDXKEY)
-	    {
-	      /*
-	       * The asc/desc properties in midxkey from log_applier may be
-	       * inaccurate. therefore, we should use btree header's domain
-	       * while processing btree search request from log_applier.
-	       */
-	      repl_old_key->data.midxkey.domain = key_domain;
-	    }
-
-	  error_code =
-	    repl_log_insert (thread_p, class_oid, oid, LOG_REPLICATION_DATA, RVREPL_DATA_UPDATE, repl_old_key,
-			     (REPL_INFO_TYPE) repl_info->repl_info_type);
-
-	  if (repl_old_key == &old_dbvalue)
-	    {
-	      pr_clear_value (&old_dbvalue);
+	      pr_free_ext_value (repl_old_key);
+	      repl_old_key = NULL;
 	    }
 	}
       else
 	{
-	  error_code =
-	    repl_log_insert (thread_p, class_oid, oid, LOG_REPLICATION_DATA, RVREPL_DATA_UPDATE, repl_old_key,
-			     (REPL_INFO_TYPE) repl_info->repl_info_type);
+	  /*
+	   * clear repl_insert_lsa to make sure that FK action
+	   * does not overwrite the original update's target lsa.
+	   */
+	  tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
+	  tdes = LOG_FIND_TDES (tran_index);
 
-	  pr_free_ext_value (repl_old_key);
-	  repl_old_key = NULL;
-	}
-    }
-  else
-    {
-      /*
-       * clear repl_insert_lsa to make sure that FK action
-       * does not overwrite the original update's target lsa.
-       */
-      tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
-      tdes = LOG_FIND_TDES (tran_index);
+	  LSA_SET_NULL (&tdes->repl_insert_lsa);
 
-      LSA_SET_NULL (&tdes->repl_insert_lsa);
-
-      /* No need to replicate this record since there is no primary key */
-      if (repl_info != NULL)
-	{
-	  repl_info->need_replication = false;
+	  /* No need to replicate this record since there is no primary key */
+	  if (repl_info != NULL)
+	    {
+	      repl_info->need_replication = false;
+	    }
 	}
     }
 

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -8420,7 +8420,7 @@ locator_update_index (THREAD_ENTRY * thread_p, RECDES * new_recdes, RECDES * old
       index = &(new_attrinfo->last_classrepr->indexes[i]);
       if (rk_btid_index == -1 && repl_info != NULL && repl_info->need_replication == true
 	  && !LOG_CHECK_LOG_APPLIER (thread_p) && or_is_replication_candidate_key (index)
-	  && log_does_allow_replication () == true)
+	  && heap_is_replication_class (thread_p, class_oid) && log_does_allow_replication () == true)
 	{
 	  rk_btid_index = i;
 	}
@@ -8772,76 +8772,73 @@ locator_update_index (THREAD_ENTRY * thread_p, RECDES * new_recdes, RECDES * old
 	}
     }
 
-  if (heap_is_replication_class (thread_p, class_oid))
+  if (rk_btid_index != -1)
     {
-      if (rk_btid_index != -1)
-	{
-	  assert (repl_info != NULL);
+      assert (repl_info != NULL);
 
+      if (repl_old_key == NULL)
+	{
+	  key_domain = NULL;
+	  repl_old_key =
+	    heap_attrvalue_get_key (thread_p, rk_btid_index, old_attrinfo, old_recdes, &old_btid, &old_dbvalue,
+				    aligned_oldbuf, NULL, &key_domain, oid, false);
 	  if (repl_old_key == NULL)
 	    {
-	      key_domain = NULL;
-	      repl_old_key =
-		heap_attrvalue_get_key (thread_p, rk_btid_index, old_attrinfo, old_recdes, &old_btid, &old_dbvalue,
-					aligned_oldbuf, NULL, &key_domain, oid, false);
-	      if (repl_old_key == NULL)
-		{
-		  error_code = ER_FAILED;
-		  goto error;
-		}
-
-	      old_isnull = db_value_is_null (repl_old_key);
-	      pr_type = pr_type_from_id (DB_VALUE_DOMAIN_TYPE (repl_old_key));
-	      if (pr_type == NULL)
-		{
-		  error_code = ER_FAILED;
-		  goto error;
-		}
-
-	      if (pr_type->id == DB_TYPE_MIDXKEY)
-		{
-		  /*
-		   * The asc/desc properties in midxkey from log_applier may be
-		   * inaccurate. therefore, we should use btree header's domain
-		   * while processing btree search request from log_applier.
-		   */
-		  repl_old_key->data.midxkey.domain = key_domain;
-		}
-	      error_code =
-		repl_log_insert (thread_p, class_oid, oid, LOG_REPLICATION_DATA, RVREPL_DATA_UPDATE, repl_old_key,
-				 (REPL_INFO_TYPE) repl_info->repl_info_type);
-
-	      if (repl_old_key == &old_dbvalue)
-		{
-		  pr_clear_value (&old_dbvalue);
-		}
+	      error_code = ER_FAILED;
+	      goto error;
 	    }
-	  else
-	    {
-	      error_code =
-		repl_log_insert (thread_p, class_oid, oid, LOG_REPLICATION_DATA, RVREPL_DATA_UPDATE, repl_old_key,
-				 (REPL_INFO_TYPE) repl_info->repl_info_type);
 
-	      pr_free_ext_value (repl_old_key);
-	      repl_old_key = NULL;
+	  old_isnull = db_value_is_null (repl_old_key);
+	  pr_type = pr_type_from_id (DB_VALUE_DOMAIN_TYPE (repl_old_key));
+	  if (pr_type == NULL)
+	    {
+	      error_code = ER_FAILED;
+	      goto error;
+	    }
+
+	  if (pr_type->id == DB_TYPE_MIDXKEY)
+	    {
+	      /*
+	       * The asc/desc properties in midxkey from log_applier may be
+	       * inaccurate. therefore, we should use btree header's domain
+	       * while processing btree search request from log_applier.
+	       */
+	      repl_old_key->data.midxkey.domain = key_domain;
+	    }
+	  error_code =
+	    repl_log_insert (thread_p, class_oid, oid, LOG_REPLICATION_DATA, RVREPL_DATA_UPDATE, repl_old_key,
+			     (REPL_INFO_TYPE) repl_info->repl_info_type);
+
+	  if (repl_old_key == &old_dbvalue)
+	    {
+	      pr_clear_value (&old_dbvalue);
 	    }
 	}
       else
 	{
-	  /*
-	   * clear repl_insert_lsa to make sure that FK action
-	   * does not overwrite the original update's target lsa.
-	   */
-	  tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
-	  tdes = LOG_FIND_TDES (tran_index);
+	  error_code =
+	    repl_log_insert (thread_p, class_oid, oid, LOG_REPLICATION_DATA, RVREPL_DATA_UPDATE, repl_old_key,
+			     (REPL_INFO_TYPE) repl_info->repl_info_type);
 
-	  LSA_SET_NULL (&tdes->repl_insert_lsa);
+	  pr_free_ext_value (repl_old_key);
+	  repl_old_key = NULL;
+	}
+    }
+  else
+    {
+      /*
+       * clear repl_insert_lsa to make sure that FK action
+       * does not overwrite the original update's target lsa.
+       */
+      tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
+      tdes = LOG_FIND_TDES (tran_index);
 
-	  /* No need to replicate this record since there is no primary key */
-	  if (repl_info != NULL)
-	    {
-	      repl_info->need_replication = false;
-	    }
+      LSA_SET_NULL (&tdes->repl_insert_lsa);
+
+      /* No need to replicate this record since there is no primary key */
+      if (repl_info != NULL)
+	{
+	  repl_info->need_replication = false;
 	}
     }
 


### PR DESCRIPTION
[<http://jira.cubrid.org/browse/CBRD-26589>](http://jira.cubrid.org/browse/CBRD-26589)

### Purpose

이 PR은 크게 다음 두가지 내용을 포함하고있습니다(코드가 길지 않고 연관된 이슈라 하나의 PR로 올립니다)

- REPLICATION = OFF 인 테이블에대해 SBR 을 모두 복제하던 버그 수정
기존 replication 옵션 적용 feature 에서는 일반 구문만 복제 여부를 판별, 수행하고, SBR에 대한 처리를 별도로 하지 않고 있어
replication off 인 테이블에서도 SBR을 통한 데이터 복제가 이뤄짐을 확인했습니다. 이에 따라 SBR 힌트가 있는 테이블의 DML은
슬레이브로 복제 로그를 남기지 않도록 처리했습니다.

- Checksumdb 유틸리티에서 마스터의 checksum 을 복제하던 버그 수정
checksumdb는 마스터와 슬레이브간의 데이터 무결성을 확인하기위한 유틸리티입니다.
마스터와 슬레이브의 데이터가 불일치 할 때, checksumdb 의 결과로는 다른 chunk의 목록을 결과로 출력해야하지만 replication 옵션을 추가하는 feature 에서 양측의 데이터가 다름에도 checksum 의 chunk 결과는 동일한 버그가 발견되어 이를 수정합니다.

원인은 2가지로
1. checksum 결과를 저장하는 db_ha_checksum 테이블이 복제 테이블로 슬레이브의 연산 결과와 상관 없이 마스터의 결과로 덮어 씌워집니다.
2. 마스터에서는 db_ha_checksum의 결과를 채우기위해 replace 연산을 수행하는데, checksum 을 계산하는 구문은 다음 절차로 이뤄지고 있습니다
2-1. checksum 연산 쿼리 생성(SBR 아님)
2-2. chksum_set_repl_info_and_demote_table_lock() 을 통한 복제 로그 생성
2-3. 마스터에서 수행
이때, 마스터에서 수행된 구문은 다시한번 복제 로그를 생성해 슬레이브로 마스터의 값을 덮어 씌우게 됩니다


### Implementation
기존 SBR로그를 복제하던 함수는
1. do_execute_statement 혹은 do_execute 함수에서 HA 가 실행 중이고, 복제가 필요한 구문이면 need_stmt_replication = true, db_set_suppress_repl_on_transaction (true) 로 설정합니다.
2. 로컬에서 구문이 실행 된 후 need_stmt_replication 가 ture이면 db_set_suppress_repl_on_transaction (false)를 호출하고, do_replicate_statement (parser, statement)를 통해 복제 로그를 생성합니다.


SBR 로그를 복제하던 문제를 해결하기위해 다음 내용을 구현합니다
1. do_execute_statement 혹은 do_execute 함수에서 클래스가 replication off일 경우 Insert, Update, Delete 는 복제 로그를 생성하지 않도록하는 함수 is_data_repl_log_enabled() 를 추가해 위에서 설명한 복제 로그 생성 절차 전체를 수행하지 않도록합니다
2. 이때, delete의 경우 join조건에 한해 여러 테이블을 나열할 수 있습니다. 이 경우 나열된 테이블이 하나라도 복제 테이블이면 복제 로그 생성, 모두 복제 테이블이 아닐경우 복제로그를 생성하지 않습니다

checksumdb 는 기존에 
1. checksum 연산 쿼리 생성(SBR 아님)
3. chksum_set_repl_info_and_demote_table_lock() 을 통한 복제 로그 생성
4. 마스터에서 수행
5. 복제 로그를 다시한번 생성
절차를 수행했는데 이 이 문제를 해결하기위해 
1. checkum 연산 및 해당 유틸에서 발생하는 모든 구문에 SBR 힌트 추가
2. chksum_set_repl_info_and_demote_table_lock() 호출 삭제

이전 리뷰에서는 lock을 demote시키는 코드를 제거했었지만
팀 공유회의에서 말씀드렸듯이 demote는 필요하며, repl log 생성 후 demote해야합니다.
그래서 맨 처음 컨셉과 동일하게 repl info생성하는 로직과 demote 로직을 모두 살렸습니다

그런데 이후 db_execute를 수행하면 로그가 다시한번 남으므로 중복 반영이고, 
사실상 처음 제기됐던 에러와 동일한 상황입니다 
이를 해결하기위해 db_execute 직전, 직후에 db_set_suppress_repl_on_transaction(true/false)를 추가했습니다

이 함수는 do_execute 함수에서 sbr 힌트를 만나면 설정되는 함수로써
repl_log_insert 내에서 복제 로그를 남기는것을 건너뛰도록합니다.

**즉, 복제 로그를 등록하고, 마스터에는 sbr힌트를 넣지 않은 쿼리를 수행하되
미리 db_set_suppress_repl_on_transaction를 호출함으로써 복제 로그 생성을 막아
슬레이브측의 중복 반영을 막습니다.**

### Remarks
다음은 SBR 복제 테스트 시나리오 및 결과이며, gdb를 통한 루틴 호출과 복제 여부, `db_ha_apply_info`의 `fail_count`로 확인하였습니다.

  **기본 INSERT, UPDATE, DELETE, 빈 테이블 DROP 테스트** (테이블 DROP 시에도 DELETE 수행)
  ```sql
  create table repl_on(a int primary key, b int);
  create table repl_off(a int primary key, b int) replication off;

  INSERT /*+ USE_SBR */ INTO repl_on  VALUES (1,1);
  INSERT /*+ USE_SBR */ INTO repl_off VALUES (1,1);

  UPDATE /*+ USE_SBR */ repl_on  SET b = 2 WHERE a = 1 AND b = 1;
  UPDATE /*+ USE_SBR */ repl_off SET b = 2 WHERE a = 1 AND b = 1;

  DELETE /*+ USE_SBR */ repl_on  WHERE a = 1;
  DELETE /*+ USE_SBR */ repl_off WHERE a = 1;

  DROP TABLE repl_on;
  DROP TABLE repl_off;
  ```
  테스트 결과 replication on 테이블만 슬레이브에 데이터가 복제됨을 확인했습니다.

  **데이터가 있는 테이블 DROP**
  ```sql
  CREATE TABLE repl_on(a int primary key, b int);
  INSERT INTO repl_on VALUES(1,1);
  DROP TABLE repl_on;

  CREATE TABLE repl_off(a int primary key, b int) REPLICATION OFF;
  INSERT INTO repl_off VALUES(1,1);
  DROP TABLE repl_off;
  ```
  확인 결과 에러 없이 테이블이 삭제됩니다.

  **DELETE 다중 테이블 (조인) — 나열 테이블에 ON/OFF 혼재**
  DELETE의 경우 조인에 한해 여러 테이블을 나열할 수 있습니다.
  ```sql
  CREATE TABLE t1 (id INT PRIMARY KEY, val VARCHAR(10));
  CREATE TABLE t2 (id INT, val VARCHAR(10)) REPLICATION OFF;
  INSERT INTO t1 VALUES (1, 'A'), (2, 'B');
  INSERT INTO t2 VALUES (1, 'X'), (3, 'Y');

  DELETE /*+ USE_SBR */ t1, t2 FROM t1 JOIN t2 ON t1.id = t2.id WHERE t1.id = 1;
  ```
  이 경우 정상 동작하지만 t1에 대해 데이터 불일치가 발생할 수 있습니다. 이는 SBR 스펙상 정상입니다.

  **DELETE 다중 테이블 — 나열 테이블이 모두 복제 OFF**
  ```sql
  CREATE TABLE t1 (id INT PRIMARY KEY, val VARCHAR(10)) REPLICATION OFF;
  CREATE TABLE t2 (id INT, val VARCHAR(10)) REPLICATION OFF;
  INSERT INTO t1 VALUES (1, 'A'), (2, 'B');
  INSERT INTO t2 VALUES (1, 'X'), (3, 'Y');

  DELETE /*+ USE_SBR */ t1, t2 FROM t1 JOIN t2 ON t1.id = t2.id WHERE t1.id = 1;
  ```
  역시 정상 동작합니다.

  **multi-table — 실제 수정 대상 테이블 기준으로 판정**
  multi-table에서는 FROM에 나열된 테이블이 아니라 **실제 수정 대상 테이블**(UPDATE는 SET 대상, DELETE는 삭제 대상)의 복제 옵션으로 복제 로그 생성 여부를 판정합니다. 조인 전용으로만 참조되는 테이블은 판정에서 제외됩니다.
  ```sql
  CREATE TABLE repl_on  (a INT PRIMARY KEY, b INT);
  CREATE TABLE repl_off (a INT PRIMARY KEY, b INT) REPLICATION OFF;
  INSERT INTO repl_on  VALUES (1,1);
  INSERT INTO repl_off VALUES (1,1);

  -- UPDATE: SET 대상이 b(repl_on, ON). 첫 나열 테이블이 repl_off여도 대상이 아니므로 무시 → 복제 로그 생성
  UPDATE /*+ USE_SBR */ repl_off a, repl_on b SET b.b = 9 WHERE a.a = b.a;

  -- UPDATE: SET 대상이 b(repl_off, OFF). 첫 나열 테이블 repl_on이 ON이어도 대상이 아니므로 무시 → 복제 로그 미생성
  UPDATE /*+ USE_SBR */ repl_on a, repl_off b SET b.b = 9 WHERE a.a = b.a;

  -- DELETE: 삭제 대상이 repl_off(OFF), repl_on은 조인 전용 → 복제 로그 미생성
  DELETE /*+ USE_SBR */ repl_off FROM repl_off JOIN repl_on ON repl_off.a = repl_on.a WHERE repl_off.a = 1;

  -- DELETE: 삭제 대상이 repl_on(ON), repl_off는 조인 전용 → 복제 로그 생성
  DELETE /*+ USE_SBR */ repl_on FROM repl_on JOIN repl_off ON repl_on.a = repl_off.a WHERE repl_on.a = 1;
  ```
  확인 결과, FROM에 나열된 전체 테이블이 아니라 실제 수정 대상 테이블(UPDATE의 SET 대상, DELETE의 삭제 대상)의 복제 옵션으로 복제 로그 생성 여부가 판정됨을 확인했습니다.

다음은 유틸리티 테스트 결과이며, ha 환경에서 테스트 용 데이터 베이스 testdb 를 생성하여 진행하였습니다

1. (마스터) 데이터 입력

```
csql> create table t1 (col1 int, col2 datetime, col3 varchar(10), primary key (col1));

csql> insert into t1 select rownum, sys_datetime, rand(rownum) from db_class a, db_class b limit 1000;
```

2. (마스터) checksum 생성
```
$ cubrid checksumdb -c 500 -s 0 testdb
```

3. checksumdb 보고서 확인
3-1. 직접 확인
(마스터) db_ha_checksum 조회
```
csql> select * from db_ha_checksum;

=== <Result of SELECT Command in Line 1> ===

  class_name               chunk_id  chunk_lower_bound     chunk_count  chunk_checksum  master_checksum  begins_at                      elapsed_time
====================================================================================================================================================
  'dba.t1'                        0  '(col1>=1)'                   500      -119905482       -119905482  09:07:33.465 AM 03/16/2026                8
  'dba.t1'                        1  '(col1>=500)'                 500      1059471926       1059471926  09:07:33.481 AM 03/16/2026                8
  'dba.t1'                        2  '(col1>=999)'                   2      1335483042       1335483042  09:07:33.498 AM 03/16/2026                1
```

(슬레이브) db_ha_checksum 조회
```
csql> select * from db_ha_checksum;

=== <Result of SELECT Command in Line 1> ===

  class_name               chunk_id  chunk_lower_bound     chunk_count  chunk_checksum  master_checksum  begins_at                      elapsed_time
====================================================================================================================================================
  'dba.t1'                        0  '(col1>=1)'                   500      -119905482       -119905482  09:07:33.497 AM 03/16/2026                9
  'dba.t1'                        1  '(col1>=500)'                 500      1059471926       1059471926  09:07:33.518 AM 03/16/2026                9
  'dba.t1'                        2  '(col1>=999)'                   2      1335483042       1335483042  09:07:33.532 AM 03/16/2026                1
```

3-2. (마스터) checksumdb -r 옵션으로 확인
```
[youngjun@youngjun3 ~]$ cubrid checksumdb -r testdb@youngjun4
================================================================
 target DB: testdb@youngjun4 (state: standby)
 report time: 2026-03-16 09:09:51
 checksum table name: dba.db_ha_checksum, dba.db_ha_checksum_schema
================================================================

------------------------
 different table schema
------------------------
NONE

----------------------------------------------------------------
table name	diff chunk id	chunk lower bound
----------------------------------------------------------------
NONE

--------------------------------------------------------------------------------------
table name	total # of chunks	# of diff chunks	total/avg/min/max time
--------------------------------------------------------------------------------------
dba.t1          3                       0                       19 / 6 / 1 / 9 (ms)
```

4.  슬레이브 데이터 삭제(삭제 후 checksumdb 재실행)
```
csql --sysadm -u dba --write-on-standby testdb@youngjun4 -c "delete from t1;"
```


5. 실행 결과 확인

5-1. 직접 확인
```
csql> select * from db_ha_checksum;

=== <Result of SELECT Command in Line 1> ===

  class_name               chunk_id  chunk_lower_bound     chunk_count  chunk_checksum  master_checksum  begins_at                      elapsed_time
====================================================================================================================================================
  'dba.t1'                        0  '(col1>=1)'                   500      -119905482       -119905482  09:11:31.678 AM 03/16/2026               11
  'dba.t1'                        1  '(col1>=500)'                 500      1059471926       1059471926  09:11:31.701 AM 03/16/2026               10
  'dba.t1'                        2  '(col1>=999)'                   2      1335483042       1335483042  09:11:31.723 AM 03/16/2026                1
```

```
csql> select * from db_ha_checksum;

=== <Result of SELECT Command in Line 1> ===

  class_name               chunk_id  chunk_lower_bound     chunk_count  chunk_checksum  master_checksum  begins_at                      elapsed_time
====================================================================================================================================================
  'dba.t1'                        0  '(col1>=1)'                     0            NULL       -119905482  09:11:31.780 AM 03/16/2026                2
  'dba.t1'                        1  '(col1>=500)'                   0            NULL       1059471926  09:11:31.787 AM 03/16/2026                1
  'dba.t1'                        2  '(col1>=999)'                   0            NULL       1335483042  09:11:31.793 AM 03/16/2026                1
```

5-2.
```
[youngjun@youngjun3 ~]$ cubrid checksumdb -r testdb@youngjun4
================================================================
 target DB: testdb@youngjun4 (state: standby)
 report time: 2026-03-16 09:12:40
 checksum table name: dba.db_ha_checksum, dba.db_ha_checksum_schema
================================================================

------------------------
 different table schema
------------------------
NONE

----------------------------------------------------------------
table name	diff chunk id	chunk lower bound
----------------------------------------------------------------
dba.t1          0               (col1>=1)
dba.t1          1               (col1>=500)
dba.t1          2               (col1>=999)

--------------------------------------------------------------------------------------
table name	total # of chunks	# of diff chunks	total/avg/min/max time
--------------------------------------------------------------------------------------
dba.t1          3                       3                       4 / 1 / 1 / 2 (ms)
```