### PR TITLE
[CBRD-26609] implement OOS delete API

### DIFF
--- a/src/storage/oos_file.cpp
+++ b/src/storage/oos_file.cpp
@@ -195,7 +195,7 @@ oos_insert (THREAD_ENTRY *thread_p, const VFID &oos_vfid, RECDES &recdes, OID &o
       err = oos_insert_across_pages (thread_p, oos_vfid, recdes, oid);
     }
 
-  oos_debug ("inserted to oid={vol=%d,page=%d,slot=%d}", oid.volid, oid.pageid, oid.slotid);
+  oos_debug ("inserted to oid={vol=%d,page=%d,slot=%d}", OID_AS_ARGS (&oid));
   return err;
 }
 
@@ -444,8 +444,7 @@ oos_read_within_page (THREAD_ENTRY *thread_p, const OID &oid, RECDES &recdes,
 int
 oos_read (THREAD_ENTRY *thread_p, const OID &oid, RECDES &recdes)
 {
-  oos_debug ("reading from oid={vol=%d,page=%d,slot=%d}",
-	     oid.volid, oid.pageid, oid.slotid);
+  oos_debug ("reading from oid={vol=%d,page=%d,slot=%d}", OID_AS_ARGS (&oid));
 
   int err = NO_ERROR;
 
@@ -679,7 +678,7 @@ oos_delete_chain (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const OID &oid)
       if (code != S_SUCCESS)
 	{
 	  oos_error ("spage_get_record failed for volid=%d, pageid=%d, slotid=%d",
-		     current_oid.volid, current_oid.pageid, current_oid.slotid);
+		     OID_AS_ARGS (&current_oid));
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
 	  return ER_FAILED;
 	}
@@ -696,7 +695,7 @@ oos_delete_chain (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const OID &oid)
       if (deleted_slotid == NULL_SLOTID)
 	{
 	  oos_error ("spage_delete failed for volid=%d, pageid=%d, slotid=%d",
-		     current_oid.volid, current_oid.pageid, current_oid.slotid);
+		     OID_AS_ARGS (&current_oid));
 	  assert (false);
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
 	  return ER_FAILED;
@@ -704,8 +703,7 @@ oos_delete_chain (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const OID &oid)
       pgbuf_set_dirty (thread_p, page_ptr, DONT_FREE);
 
       oos_debug ("deleted chunk at oid={vol=%d,page=%d,slot=%d}, next={vol=%d,page=%d,slot=%d}",
-		 current_oid.volid, current_oid.pageid, current_oid.slotid,
-		 next_chunk_oid.volid, next_chunk_oid.pageid, next_chunk_oid.slotid);
+		 OID_AS_ARGS (&current_oid), OID_AS_ARGS (&next_chunk_oid));
 
       current_oid = next_chunk_oid;
     }
@@ -746,7 +744,7 @@ oos_delete_chain (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const OID &oid)
 int
 oos_delete (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const OID &oid)
 {
-  oos_debug ("arguments: oid={vol=%d,page=%d,slot=%d}", oid.volid, oid.pageid, oid.slotid);
+  oos_debug ("arguments: oid={vol=%d,page=%d,slot=%d}", OID_AS_ARGS (&oid));
 
   return oos_delete_chain (thread_p, oos_vfid, oid);
 }

--- a/src/storage/oos_file.cpp
+++ b/src/storage/oos_file.cpp
@@ -56,7 +56,7 @@ oos_read_across_pages (THREAD_ENTRY *thread_p, const OID &oid, RECDES &recdes,
 static void
 oos_log_insert_physical (THREAD_ENTRY *thread_p, PAGE_PTR page_p, VFID *vfid_p, OID *oid_p, RECDES *recdes_p);
 static void
-oos_log_delete_physical (THREAD_ENTRY *thread_p, PAGE_PTR page_p, PGSLOTID slotid, RECDES *recdes_p);
+oos_log_delete_physical (THREAD_ENTRY *thread_p, PAGE_PTR page_p, VFID *vfid_p, PGSLOTID slotid, RECDES *recdes_p);
 
 STATIC_INLINE __attribute__ ((ALWAYS_INLINE))
 int oos_get_max_chunk_size_within_page ();
@@ -622,11 +622,11 @@ oos_log_insert_physical (THREAD_ENTRY *thread_p, PAGE_PTR page_p, VFID *vfid_p, 
  *   recdes_p(in): record descriptor of the record being deleted (undo data)
  */
 static void
-oos_log_delete_physical (THREAD_ENTRY *thread_p, PAGE_PTR page_p, PGSLOTID slotid, RECDES *recdes_p)
+oos_log_delete_physical (THREAD_ENTRY *thread_p, PAGE_PTR page_p, VFID *vfid_p, PGSLOTID slotid, RECDES *recdes_p)
 {
   LOG_DATA_ADDR log_addr;
 
-  log_addr.vfid = NULL;
+  log_addr.vfid = vfid_p;
   log_addr.offset = slotid;
   log_addr.pgptr = page_p;
 
@@ -669,7 +669,7 @@ oos_delete (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const OID &oid)
       std::memcpy (&header, recdes_with_header.data, sizeof (OOS_RECORD_HEADER));
       OID next_chunk_oid = header.next_chunk_oid;
 
-      oos_log_delete_physical (thread_p, page_ptr, slotid, &recdes_with_header);
+      oos_log_delete_physical (thread_p, page_ptr, const_cast<VFID *> (&oos_vfid), slotid, &recdes_with_header);
 
       (void) spage_delete (thread_p, page_ptr, slotid);
       pgbuf_set_dirty (thread_p, page_ptr, DONT_FREE);

--- a/src/storage/oos_file.cpp
+++ b/src/storage/oos_file.cpp
@@ -239,8 +239,9 @@ oos_insert_across_pages (THREAD_ENTRY *thread_p, const VFID &oos_vfid, RECDES &r
       if (err != NO_ERROR)
 	{
 	  oos_error ("could not insert chunk index=%d of length %d.", i, chunk_recdes.length);
-	  // TODO: free partially inserted chunks.
-	  // Currently, already inserted chunks to slotted pages will remain as garbage.
+	  // Partially inserted chunks are cleaned up when the caller aborts the transaction
+	  // (individual undo records replay in reverse). The caller MUST NOT continue
+	  // the transaction after this error.
 	  return err;
 	}
 

--- a/src/storage/oos_file.cpp
+++ b/src/storage/oos_file.cpp
@@ -649,9 +649,9 @@ oos_log_delete_physical (THREAD_ENTRY *thread_p, PAGE_PTR page_p, VFID *vfid_p, 
  *   oos_vfid(in): OOS file identifier
  *   oid(in): head OID of the OOS record chain
  *
- * NOTE: This is the inner workhorse called by oos_delete(). It must be called
- *       inside a system operation (log_sysop_start) so that on error the
- *       caller can abort the sysop and restore all partially deleted chunks.
+ * NOTE: This is the inner workhorse called by oos_delete(). Each chunk
+ *       deletion is logged individually with undo data, so transaction
+ *       abort restores all deleted chunks in reverse order.
  */
 static int
 oos_delete_chain (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const OID &oid)
@@ -721,58 +721,34 @@ oos_delete_chain (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const OID &oid)
  *   oos_vfid(in): OOS file identifier
  *   oid(in): head OID of the OOS record
  *
- * NOTE: Uses a system operation to guarantee atomicity for multi-chunk deletes.
- *       On success, the sysop is attached to the outer transaction so that the
- *       delete can be undone if the transaction aborts.
- *       On error mid-chain, the sysop is aborted, restoring all partially
- *       deleted chunks to a consistent state.
+ * NOTE: No sysop is used. Each chunk deletion is logged individually
+ *       (RVOOS_DELETE with full record as undo data).
  *
- *       Page deallocation is NOT done here. Empty pages will be reclaimed by
- *       vacuum after the transaction commits. file_dealloc() uses an internal
- *       committed sysop that would not be rolled back if the outer transaction
- *       aborts, which could leave pages deallocated while undo tries to
- *       re-insert records into them.
+ *       Why this is safe:
+ *       - Transaction abort: undo records are replayed in reverse order,
+ *         restoring all deleted chunks to their original slotids via
+ *         spage_insert_for_recovery. The chain is fully restored.
+ *       - Crash recovery: same mechanism — incomplete transaction's undo
+ *         records are replayed during recovery, restoring the chain.
+ *       - Error mid-chain: partial deletes have undo records in the
+ *         transaction log. The caller must abort the transaction to
+ *         restore consistency.
  *
- * TODO: chain marker dummy log (overflow file precedent)
+ *       Limitation: the caller MUST NOT continue the transaction after
+ *       this function returns an error. If the caller ignores the error
+ *       and commits, partially deleted chunks become permanent while
+ *       remaining chunks are orphaned. This is acceptable because storage
+ *       layer errors always propagate up and result in transaction abort.
  *
- *       The current implementation only uses a sysop for error atomicity
- *       (partial delete rollback). However, following the overflow file
- *       precedent (LOG_DUMMY_OVF_RECORD in overflow_file.c), we should also
- *       add dummy log records at the start/end of a multi-chunk chain delete.
- *
- *       Sysop and chain markers solve different problems:
- *       - sysop: rollback partial deletes on error (atomicity)
- *       - chain marker: let recovery/vacuum identify multi-page chains (identification)
- *
- *       Without chain markers, vacuum processing delete undo logs can only
- *       infer chain membership from OOS_RECORD_HEADER fields (next_chunk_oid,
- *       chunk_index) embedded in the undo data. Explicit dummy logs at chain
- *       boundaries would make recovery/vacuum logic simpler and more robust.
- *
- *       Implementation requires:
- *       1. New LOG_RECTYPE (e.g., LOG_DUMMY_OOS_CHAIN_DELETE)
- *       2. Recovery code to handle the new log type
- *       3. Vacuum integration to read chain markers and deallocate pages
+ *       Page deallocation is NOT done here. Empty pages will be reclaimed
+ *       by vacuum after the transaction commits.
  */
 int
 oos_delete (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const OID &oid)
 {
   oos_debug ("arguments: oid={vol=%d,page=%d,slot=%d}", oid.volid, oid.pageid, oid.slotid);
 
-  log_sysop_start (thread_p);
-
-  int error = oos_delete_chain (thread_p, oos_vfid, oid);
-  if (error != NO_ERROR)
-    {
-      log_sysop_abort (thread_p);
-      return error;
-    }
-
-  // Attach to outer transaction: if the outer transaction commits, the deletes persist.
-  // If the outer transaction aborts, the deletes are undone (chunks restored).
-  log_sysop_attach_to_outer (thread_p);
-
-  return NO_ERROR;
+  return oos_delete_chain (thread_p, oos_vfid, oid);
 }
 
 // TODO: since this value never changes, we can make it a constant or static variable,

--- a/src/storage/oos_file.cpp
+++ b/src/storage/oos_file.cpp
@@ -732,6 +732,27 @@ oos_delete_chain (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const OID &oid)
  *       committed sysop that would not be rolled back if the outer transaction
  *       aborts, which could leave pages deallocated while undo tries to
  *       re-insert records into them.
+ *
+ * TODO: chain marker dummy log (overflow file precedent)
+ *
+ *       The current implementation only uses a sysop for error atomicity
+ *       (partial delete rollback). However, following the overflow file
+ *       precedent (LOG_DUMMY_OVF_RECORD in overflow_file.c), we should also
+ *       add dummy log records at the start/end of a multi-chunk chain delete.
+ *
+ *       Sysop and chain markers solve different problems:
+ *       - sysop: rollback partial deletes on error (atomicity)
+ *       - chain marker: let recovery/vacuum identify multi-page chains (identification)
+ *
+ *       Without chain markers, vacuum processing delete undo logs can only
+ *       infer chain membership from OOS_RECORD_HEADER fields (next_chunk_oid,
+ *       chunk_index) embedded in the undo data. Explicit dummy logs at chain
+ *       boundaries would make recovery/vacuum logic simpler and more robust.
+ *
+ *       Implementation requires:
+ *       1. New LOG_RECTYPE (e.g., LOG_DUMMY_OOS_CHAIN_DELETE)
+ *       2. Recovery code to handle the new log type
+ *       3. Vacuum integration to read chain markers and deallocate pages
  */
 int
 oos_delete (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const OID &oid)

--- a/src/storage/oos_file.cpp
+++ b/src/storage/oos_file.cpp
@@ -633,6 +633,10 @@ oos_log_delete_physical (THREAD_ENTRY *thread_p, PAGE_PTR page_p, VFID *vfid_p, 
   log_append_undoredo_recdes (thread_p, RVOOS_DELETE, &log_addr, recdes_p, NULL);
 }
 
+// TODO: caller connection — heap_update → oos_delete, vacuum → oos_delete are not yet wired.
+//       These will be connected in the upper story.
+// TODO: concurrency — this function assumes the caller holds a row-level lock (e.g., X_LOCK from heap layer)
+//       to prevent concurrent deletion of the same OOS chain. Verify this assumption when wiring callers.
 int
 oos_delete (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const OID &oid)
 {

--- a/src/storage/oos_file.cpp
+++ b/src/storage/oos_file.cpp
@@ -55,6 +55,8 @@ oos_read_across_pages (THREAD_ENTRY *thread_p, const OID &oid, RECDES &recdes,
 		       OOS_RECORD_HEADER &out_header);
 static void
 oos_log_insert_physical (THREAD_ENTRY *thread_p, PAGE_PTR page_p, VFID *vfid_p, OID *oid_p, RECDES *recdes_p);
+static void
+oos_log_delete_physical (THREAD_ENTRY *thread_p, PAGE_PTR page_p, PGSLOTID slotid, RECDES *recdes_p);
 
 STATIC_INLINE __attribute__ ((ALWAYS_INLINE))
 int oos_get_max_chunk_size_within_page ();
@@ -610,6 +612,76 @@ oos_log_insert_physical (THREAD_ENTRY *thread_p, PAGE_PTR page_p, VFID *vfid_p, 
   log_addr.pgptr = page_p;
 
   log_append_undoredo_recdes (thread_p, RVOOS_INSERT, &log_addr, NULL, recdes_p);
+}
+
+/*
+ * oos_log_delete_physical () - add logging information for physical deletion
+ *   thread_p(in): thread entry
+ *   page_p(in): page where delete will be performed
+ *   slotid(in): slot id of the record to delete
+ *   recdes_p(in): record descriptor of the record being deleted (undo data)
+ */
+static void
+oos_log_delete_physical (THREAD_ENTRY *thread_p, PAGE_PTR page_p, PGSLOTID slotid, RECDES *recdes_p)
+{
+  LOG_DATA_ADDR log_addr;
+
+  log_addr.vfid = NULL;
+  log_addr.offset = slotid;
+  log_addr.pgptr = page_p;
+
+  log_append_undoredo_recdes (thread_p, RVOOS_DELETE, &log_addr, recdes_p, NULL);
+}
+
+int
+oos_delete (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const OID &oid)
+{
+  oos_debug ("arguments: oid={vol=%d,page=%d,slot=%d}", oid.volid, oid.pageid, oid.slotid);
+
+  OID current_oid = oid;
+  while (current_oid.pageid != NULL_PAGEID)
+    {
+      const auto [pageid, slotid, volid] = current_oid;
+      VPID vpid = {pageid, volid};
+
+      PAGE_PTR page_ptr = pgbuf_fix (thread_p, &vpid, OLD_PAGE, PGBUF_LATCH_WRITE, PGBUF_UNCONDITIONAL_LATCH);
+      if (page_ptr == nullptr)
+	{
+	  oos_error ("pgbuf_fix failed for volid=%d, pageid=%d", volid, pageid);
+	  return ER_FAILED;
+	}
+
+      scope_exit page_unfixer ([&] ()
+      {
+	pgbuf_unfix_and_init_after_check (thread_p, page_ptr);
+      });
+
+      RECDES recdes_with_header;
+      SCAN_CODE code = spage_get_record (thread_p, page_ptr, slotid, &recdes_with_header, PEEK);
+      if (code != S_SUCCESS)
+	{
+	  oos_error ("spage_get_record failed for volid=%d, pageid=%d, slotid=%d", volid, pageid, slotid);
+	  return ER_FAILED;
+	}
+
+      assert (recdes_with_header.length >= (int) sizeof (OOS_RECORD_HEADER));
+      OOS_RECORD_HEADER header;
+      std::memcpy (&header, recdes_with_header.data, sizeof (OOS_RECORD_HEADER));
+      OID next_chunk_oid = header.next_chunk_oid;
+
+      oos_log_delete_physical (thread_p, page_ptr, slotid, &recdes_with_header);
+
+      (void) spage_delete (thread_p, page_ptr, slotid);
+      pgbuf_set_dirty (thread_p, page_ptr, DONT_FREE);
+
+      oos_debug ("deleted chunk at oid={vol=%d,page=%d,slot=%d}, next={vol=%d,page=%d,slot=%d}",
+		 volid, pageid, slotid,
+		 next_chunk_oid.volid, next_chunk_oid.pageid, next_chunk_oid.slotid);
+
+      current_oid = next_chunk_oid;
+    }
+
+  return NO_ERROR;
 }
 
 // TODO: since this value never changes, we can make it a constant or static variable,

--- a/src/storage/oos_file.cpp
+++ b/src/storage/oos_file.cpp
@@ -58,6 +58,8 @@ static void
 oos_log_insert_physical (THREAD_ENTRY *thread_p, PAGE_PTR page_p, VFID *vfid_p, OID *oid_p, RECDES *recdes_p);
 static void
 oos_log_delete_physical (THREAD_ENTRY *thread_p, PAGE_PTR page_p, VFID *vfid_p, PGSLOTID slotid, RECDES *recdes_p);
+static int
+oos_delete_chain (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const OID &oid);
 
 STATIC_INLINE __attribute__ ((ALWAYS_INLINE))
 int oos_get_max_chunk_size_within_page ();
@@ -638,14 +640,22 @@ oos_log_delete_physical (THREAD_ENTRY *thread_p, PAGE_PTR page_p, VFID *vfid_p, 
 //       These will be connected in the upper story.
 // TODO: concurrency — this function assumes the caller holds a row-level lock (e.g., X_LOCK from heap layer)
 //       to prevent concurrent deletion of the same OOS chain. Verify this assumption when wiring callers.
-// TODO: multi-page atomicity — for multi-chunk OOS records, consider wrapping the entire delete in a
-//       log_sysop_start/commit pair or introducing chain marker dummy logs (like LOG_DUMMY_OVF_RECORD)
-//       so that recovery can detect and complete partial chain deletes after a crash.
-int
-oos_delete (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const OID &oid)
-{
-  oos_debug ("arguments: oid={vol=%d,page=%d,slot=%d}", oid.volid, oid.pageid, oid.slotid);
 
+/*
+ * oos_delete_chain () - delete all chunks in an OOS record chain (internal)
+ *
+ *   return: NO_ERROR or error code
+ *   thread_p(in): thread entry
+ *   oos_vfid(in): OOS file identifier
+ *   oid(in): head OID of the OOS record chain
+ *
+ * NOTE: This is the inner workhorse called by oos_delete(). It must be called
+ *       inside a system operation (log_sysop_start) so that on error the
+ *       caller can abort the sysop and restore all partially deleted chunks.
+ */
+static int
+oos_delete_chain (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const OID &oid)
+{
   OID current_oid = oid;
   while (!OID_ISNULL (&current_oid))
     {
@@ -693,28 +703,53 @@ oos_delete (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const OID &oid)
 	}
       pgbuf_set_dirty (thread_p, page_ptr, DONT_FREE);
 
-      // Deallocate page if it became empty after deleting the last record.
-      // OOS pages are shared (multiple records per slotted page), so only deallocate when truly empty.
-      if (spage_number_of_records (page_ptr) == 0)
-	{
-	  // Must unfix before file_dealloc
-	  pgbuf_unfix_and_init_after_check (thread_p, page_ptr);
-	  int dealloc_err = file_dealloc (thread_p, &oos_vfid, &vpid, FILE_OOS);
-	  if (dealloc_err != NO_ERROR)
-	    {
-	      // Page deallocation failure is not fatal — the page is just leaked.
-	      // Log and continue rather than aborting the entire chain delete.
-	      oos_error ("file_dealloc failed for volid=%d, pageid=%d (non-fatal, page leaked)",
-			 vpid.volid, vpid.pageid);
-	    }
-	}
-
       oos_debug ("deleted chunk at oid={vol=%d,page=%d,slot=%d}, next={vol=%d,page=%d,slot=%d}",
 		 current_oid.volid, current_oid.pageid, current_oid.slotid,
 		 next_chunk_oid.volid, next_chunk_oid.pageid, next_chunk_oid.slotid);
 
       current_oid = next_chunk_oid;
     }
+
+  return NO_ERROR;
+}
+
+/*
+ * oos_delete () - delete an OOS record (single-chunk or multi-chunk chain)
+ *
+ *   return: NO_ERROR or error code
+ *   thread_p(in): thread entry
+ *   oos_vfid(in): OOS file identifier
+ *   oid(in): head OID of the OOS record
+ *
+ * NOTE: Uses a system operation to guarantee atomicity for multi-chunk deletes.
+ *       On success, the sysop is attached to the outer transaction so that the
+ *       delete can be undone if the transaction aborts.
+ *       On error mid-chain, the sysop is aborted, restoring all partially
+ *       deleted chunks to a consistent state.
+ *
+ *       Page deallocation is NOT done here. Empty pages will be reclaimed by
+ *       vacuum after the transaction commits. file_dealloc() uses an internal
+ *       committed sysop that would not be rolled back if the outer transaction
+ *       aborts, which could leave pages deallocated while undo tries to
+ *       re-insert records into them.
+ */
+int
+oos_delete (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const OID &oid)
+{
+  oos_debug ("arguments: oid={vol=%d,page=%d,slot=%d}", oid.volid, oid.pageid, oid.slotid);
+
+  log_sysop_start (thread_p);
+
+  int error = oos_delete_chain (thread_p, oos_vfid, oid);
+  if (error != NO_ERROR)
+    {
+      log_sysop_abort (thread_p);
+      return error;
+    }
+
+  // Attach to outer transaction: if the outer transaction commits, the deletes persist.
+  // If the outer transaction aborts, the deletes are undone (chunks restored).
+  log_sysop_attach_to_outer (thread_p);
 
   return NO_ERROR;
 }

--- a/src/storage/oos_file.cpp
+++ b/src/storage/oos_file.cpp
@@ -18,6 +18,7 @@
 
 #include <cassert>
 #include "error_code.h"
+#include "error_manager.h"
 #include "file_manager.h"
 #include "memory_alloc.h"
 #include "page_buffer.h"
@@ -637,22 +638,25 @@ oos_log_delete_physical (THREAD_ENTRY *thread_p, PAGE_PTR page_p, VFID *vfid_p, 
 //       These will be connected in the upper story.
 // TODO: concurrency — this function assumes the caller holds a row-level lock (e.g., X_LOCK from heap layer)
 //       to prevent concurrent deletion of the same OOS chain. Verify this assumption when wiring callers.
+// TODO: multi-page atomicity — for multi-chunk OOS records, consider wrapping the entire delete in a
+//       log_sysop_start/commit pair or introducing chain marker dummy logs (like LOG_DUMMY_OVF_RECORD)
+//       so that recovery can detect and complete partial chain deletes after a crash.
 int
 oos_delete (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const OID &oid)
 {
   oos_debug ("arguments: oid={vol=%d,page=%d,slot=%d}", oid.volid, oid.pageid, oid.slotid);
 
   OID current_oid = oid;
-  while (current_oid.pageid != NULL_PAGEID)
+  while (!OID_ISNULL (&current_oid))
     {
-      const auto [pageid, slotid, volid] = current_oid;
-      VPID vpid = {pageid, volid};
+      VPID vpid = {current_oid.pageid, current_oid.volid};
 
       PAGE_PTR page_ptr = pgbuf_fix (thread_p, &vpid, OLD_PAGE, PGBUF_LATCH_WRITE, PGBUF_UNCONDITIONAL_LATCH);
       if (page_ptr == nullptr)
 	{
-	  oos_error ("pgbuf_fix failed for volid=%d, pageid=%d", volid, pageid);
-	  return ER_FAILED;
+	  oos_error ("pgbuf_fix failed for volid=%d, pageid=%d", current_oid.volid, current_oid.pageid);
+	  ASSERT_ERROR ();
+	  return er_errid ();
 	}
 
       scope_exit page_unfixer ([&] ()
@@ -660,11 +664,13 @@ oos_delete (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const OID &oid)
 	pgbuf_unfix_and_init_after_check (thread_p, page_ptr);
       });
 
-      RECDES recdes_with_header;
-      SCAN_CODE code = spage_get_record (thread_p, page_ptr, slotid, &recdes_with_header, PEEK);
+      RECDES recdes_with_header = RECDES_INITIALIZER;
+      SCAN_CODE code = spage_get_record (thread_p, page_ptr, current_oid.slotid, &recdes_with_header, PEEK);
       if (code != S_SUCCESS)
 	{
-	  oos_error ("spage_get_record failed for volid=%d, pageid=%d, slotid=%d", volid, pageid, slotid);
+	  oos_error ("spage_get_record failed for volid=%d, pageid=%d, slotid=%d",
+		     current_oid.volid, current_oid.pageid, current_oid.slotid);
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
 	  return ER_FAILED;
 	}
 
@@ -673,13 +679,38 @@ oos_delete (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const OID &oid)
       std::memcpy (&header, recdes_with_header.data, sizeof (OOS_RECORD_HEADER));
       OID next_chunk_oid = header.next_chunk_oid;
 
-      oos_log_delete_physical (thread_p, page_ptr, const_cast<VFID *> (&oos_vfid), slotid, &recdes_with_header);
+      oos_log_delete_physical (thread_p, page_ptr, const_cast<VFID *> (&oos_vfid), current_oid.slotid,
+			       &recdes_with_header);
 
-      (void) spage_delete (thread_p, page_ptr, slotid);
+      PGSLOTID deleted_slotid = spage_delete (thread_p, page_ptr, current_oid.slotid);
+      if (deleted_slotid == NULL_SLOTID)
+	{
+	  oos_error ("spage_delete failed for volid=%d, pageid=%d, slotid=%d",
+		     current_oid.volid, current_oid.pageid, current_oid.slotid);
+	  assert (false);
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
+	  return ER_FAILED;
+	}
       pgbuf_set_dirty (thread_p, page_ptr, DONT_FREE);
 
+      // Deallocate page if it became empty after deleting the last record.
+      // OOS pages are shared (multiple records per slotted page), so only deallocate when truly empty.
+      if (spage_number_of_records (page_ptr) == 0)
+	{
+	  // Must unfix before file_dealloc
+	  pgbuf_unfix_and_init_after_check (thread_p, page_ptr);
+	  int dealloc_err = file_dealloc (thread_p, &oos_vfid, &vpid, FILE_OOS);
+	  if (dealloc_err != NO_ERROR)
+	    {
+	      // Page deallocation failure is not fatal — the page is just leaked.
+	      // Log and continue rather than aborting the entire chain delete.
+	      oos_error ("file_dealloc failed for volid=%d, pageid=%d (non-fatal, page leaked)",
+			 vpid.volid, vpid.pageid);
+	    }
+	}
+
       oos_debug ("deleted chunk at oid={vol=%d,page=%d,slot=%d}, next={vol=%d,page=%d,slot=%d}",
-		 volid, pageid, slotid,
+		 current_oid.volid, current_oid.pageid, current_oid.slotid,
 		 next_chunk_oid.volid, next_chunk_oid.pageid, next_chunk_oid.slotid);
 
       current_oid = next_chunk_oid;
@@ -705,7 +736,13 @@ oos_rv_redo_delete (THREAD_ENTRY *thread_p, LOG_RCV *rcv)
   INT16 slotid;
 
   slotid = rcv->offset;
-  (void) spage_delete (thread_p, rcv->pgptr, slotid);
+  PGSLOTID deleted_slotid = spage_delete (thread_p, rcv->pgptr, slotid);
+  if (deleted_slotid == NULL_SLOTID)
+    {
+      assert (false);
+      er_set (ER_FATAL_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
+      return er_errid ();
+    }
   pgbuf_set_dirty (thread_p, rcv->pgptr, DONT_FREE);
 
   return NO_ERROR;

--- a/src/storage/oos_file.hpp
+++ b/src/storage/oos_file.hpp
@@ -35,6 +35,7 @@ extern int oos_file_create (THREAD_ENTRY *thread_p, VFID &oos_vfid);
 extern int oos_file_destroy (THREAD_ENTRY *thread_p, const VFID &oos_vfid);
 extern int oos_insert (THREAD_ENTRY *thread_p, const VFID &oos_vfid, RECDES &recdes, OID &oid);
 extern int oos_read (THREAD_ENTRY *thread_p, const OID &oid, RECDES &recdes);
+extern int oos_delete (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const OID &oid);
 
 extern int oos_rv_redo_delete (THREAD_ENTRY *thread_p, LOG_RCV *rcv);
 extern int oos_rv_redo_insert (THREAD_ENTRY *thread_p, LOG_RCV *rcv);

--- a/unit_tests/oos/CMakeLists.txt
+++ b/unit_tests/oos/CMakeLists.txt
@@ -49,6 +49,7 @@ endforeach()
 
 # Register individual tests one by one.
 add_test(NAME test_oos COMMAND test_oos)
+add_test(NAME test_oos_delete COMMAND test_oos_delete)
 # add_test(NAME test_oos_persist COMMAND test_oos_persist)
 # add_test(NAME test_oos_record_descriptor COMMAND test_oos_record_descriptor)
 

--- a/unit_tests/oos/test_oos_delete.cpp
+++ b/unit_tests/oos/test_oos_delete.cpp
@@ -392,6 +392,63 @@ TEST (OosDeleteTest, OosDeleteLarge160KBMultiChunk)
 }
 
 
+// ===========================================================================
+// TEST: OosDeleteSlotBecomesUnknown
+//
+// After oos_delete, the slot is internally marked REC_DELETED_WILL_REUSE by
+// spage_delete. The public API spage_get_record_type maps deleted slots to
+// REC_UNKNOWN. Verify this transition: valid type before, REC_UNKNOWN after.
+// ===========================================================================
+TEST (OosDeleteTest, OosDeleteSlotBecomesUnknown)
+{
+  int err;
+  VFID oos_vfid;
+
+  err = oos_file_create (thread_p, oos_vfid);
+  ASSERT_EQ (err, NO_ERROR);
+
+  RECDES rec_in{};
+  err = test_oos_utils::from_string_into_recdes ("slot state verification test", rec_in);
+  ASSERT_EQ (err, NO_ERROR);
+  test_oos_utils::auto_freed_recdes_ptr defer_free (&rec_in, recdes_free_data_area);
+
+  OID oid = OID_INITIALIZER;
+  err = oos_insert (thread_p, oos_vfid, rec_in, oid);
+  ASSERT_EQ (err, NO_ERROR);
+  ASSERT_NE (oid.pageid, NULL_PAGEID);
+
+  // Before deletion: slot must hold a valid record type (not unknown/deleted)
+  {
+    VPID vpid = {oid.pageid, oid.volid};
+    PAGE_PTR page_ptr = pgbuf_fix (thread_p, &vpid, OLD_PAGE_IF_IN_BUFFER,
+				   PGBUF_LATCH_READ, PGBUF_UNCONDITIONAL_LATCH);
+    ASSERT_NE (page_ptr, nullptr);
+    test_oos_utils::auto_unfixed_page_ptr auto_page { page_ptr, test_oos_utils::page_auto_unfix {thread_p} };
+
+    INT16 type_before = spage_get_record_type (page_ptr, oid.slotid);
+    ASSERT_NE (type_before, REC_UNKNOWN);
+    test_oos_debug ("type_before=%d", type_before);
+  }
+
+  err = oos_delete (thread_p, oos_vfid, oid);
+  ASSERT_EQ (err, NO_ERROR);
+
+  // After deletion: spage_get_record_type returns REC_UNKNOWN for deleted slots
+  // (internally the slot is REC_DELETED_WILL_REUSE, but the API maps it to REC_UNKNOWN)
+  {
+    VPID vpid = {oid.pageid, oid.volid};
+    PAGE_PTR page_ptr = pgbuf_fix (thread_p, &vpid, OLD_PAGE_IF_IN_BUFFER,
+				   PGBUF_LATCH_READ, PGBUF_UNCONDITIONAL_LATCH);
+    ASSERT_NE (page_ptr, nullptr);
+    test_oos_utils::auto_unfixed_page_ptr auto_page { page_ptr, test_oos_utils::page_auto_unfix {thread_p} };
+
+    INT16 type_after = spage_get_record_type (page_ptr, oid.slotid);
+    ASSERT_EQ (type_after, REC_UNKNOWN);
+    test_oos_debug ("type_after=%d (REC_UNKNOWN=%d)", type_after, REC_UNKNOWN);
+  }
+}
+
+
 int main (int argc, char **argv)
 {
   ::testing::InitGoogleTest (&argc, argv);

--- a/unit_tests/oos/test_oos_delete.cpp
+++ b/unit_tests/oos/test_oos_delete.cpp
@@ -449,6 +449,9 @@ TEST (OosDeleteTest, OosDeleteSlotBecomesUnknown)
 }
 
 
+// TODO: add recovery tests — verify undo (rollback restores deleted chunks) and redo (crash recovery re-deletes)
+//       for both single-chunk and multi-chunk records. Requires integration test infrastructure.
+
 int main (int argc, char **argv)
 {
   ::testing::InitGoogleTest (&argc, argv);

--- a/unit_tests/oos/test_oos_delete.cpp
+++ b/unit_tests/oos/test_oos_delete.cpp
@@ -1,0 +1,404 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#include "gtest/gtest.h"
+#include <cstdio>
+#include <cstring>
+
+#include "page_buffer.h"
+#include "slotted_page.h"
+#include "storage_common.h"
+#include "oos_file.hpp"
+#include "test_oos_common.hpp"
+#include "oos_log.hpp"
+#include "test_oos_log.hpp"
+
+using namespace test_oos_log;
+
+// bridge functions to access static functions in oos_file.cpp
+int bridge_oos_get_max_chunk_size_within_page ();
+int bridge_oos_get_recently_inserted_oos_vpid (const VFID &oos_vfid, VPID &vpid);
+
+// ---------------------------------------------------------------------------
+// helper: fix page from OID with READ latch, return free space, then unfix
+// ---------------------------------------------------------------------------
+static int
+get_free_space_of_oid_page (const OID &oid)
+{
+  VPID vpid = {oid.pageid, oid.volid};
+  PAGE_PTR page_ptr = pgbuf_fix (thread_p, &vpid, OLD_PAGE_IF_IN_BUFFER,
+				 PGBUF_LATCH_READ, PGBUF_UNCONDITIONAL_LATCH);
+  if (page_ptr == nullptr)
+    {
+      return -1;
+    }
+  test_oos_utils::auto_unfixed_page_ptr auto_page { page_ptr, test_oos_utils::page_auto_unfix {thread_p} };
+  return spage_get_free_space (thread_p, page_ptr);
+}
+
+// ---------------------------------------------------------------------------
+// helper: peek OOS_RECORD_HEADER from a slot (before deleting)
+// ---------------------------------------------------------------------------
+static int
+peek_oos_header (const OID &oid, OOS_RECORD_HEADER &header_out)
+{
+  VPID vpid = {oid.pageid, oid.volid};
+  PAGE_PTR page_ptr = pgbuf_fix (thread_p, &vpid, OLD_PAGE_IF_IN_BUFFER,
+				 PGBUF_LATCH_READ, PGBUF_UNCONDITIONAL_LATCH);
+  if (page_ptr == nullptr)
+    {
+      return ER_FAILED;
+    }
+  test_oos_utils::auto_unfixed_page_ptr auto_page { page_ptr, test_oos_utils::page_auto_unfix {thread_p} };
+
+  RECDES rec;
+  SCAN_CODE code = spage_get_record (thread_p, page_ptr, oid.slotid, &rec, PEEK);
+  if (code != S_SUCCESS)
+    {
+      return ER_FAILED;
+    }
+
+  if (rec.length < (int) sizeof (OOS_RECORD_HEADER))
+    {
+      return ER_FAILED;
+    }
+  std::memcpy (&header_out, rec.data, sizeof (OOS_RECORD_HEADER));
+  return NO_ERROR;
+}
+
+
+// ===========================================================================
+// TEST: OosDeleteBasic
+//
+// Insert a small record, then delete it.
+// Verify oos_delete returns NO_ERROR and the page gains free space.
+// ===========================================================================
+TEST (OosDeleteTest, OosDeleteBasic)
+{
+  int err;
+  VFID oos_vfid;
+
+  err = oos_file_create (thread_p, oos_vfid);
+  ASSERT_EQ (err, NO_ERROR);
+
+  RECDES rec_in{};
+  err = test_oos_utils::from_string_into_recdes ("Hello, OOS delete test!", rec_in);
+  ASSERT_EQ (err, NO_ERROR);
+  test_oos_utils::auto_freed_recdes_ptr defer_free_rec_in (&rec_in, recdes_free_data_area);
+
+  OID oid = OID_INITIALIZER;
+  err = oos_insert (thread_p, oos_vfid, rec_in, oid);
+  ASSERT_EQ (err, NO_ERROR);
+  ASSERT_NE (oid.pageid, NULL_PAGEID);
+  test_oos_debug ("Inserted oid={vol=%d,page=%d,slot=%d}", oid.volid, oid.pageid, oid.slotid);
+
+  int free_before = get_free_space_of_oid_page (oid);
+  ASSERT_GE (free_before, 0);
+  test_oos_debug ("free_before=%d", free_before);
+
+  err = oos_delete (thread_p, oos_vfid, oid);
+  ASSERT_EQ (err, NO_ERROR);
+
+  int free_after = get_free_space_of_oid_page (oid);
+  ASSERT_GE (free_after, 0);
+  test_oos_debug ("free_after=%d", free_after);
+
+  // free space must have grown by at least the record's user-data length
+  ASSERT_GT (free_after, free_before);
+}
+
+
+// ===========================================================================
+// TEST: OosDeleteThenReadFails
+//
+// After deletion the OID is invalid; oos_read must return an error.
+// ===========================================================================
+TEST (OosDeleteTest, OosDeleteThenReadFails)
+{
+  int err;
+  VFID oos_vfid;
+
+  err = oos_file_create (thread_p, oos_vfid);
+  ASSERT_EQ (err, NO_ERROR);
+
+  RECDES rec_in{};
+  err = test_oos_utils::from_string_into_recdes ("Record to be deleted", rec_in);
+  ASSERT_EQ (err, NO_ERROR);
+  test_oos_utils::auto_freed_recdes_ptr defer_free (&rec_in, recdes_free_data_area);
+
+  OID oid = OID_INITIALIZER;
+  err = oos_insert (thread_p, oos_vfid, rec_in, oid);
+  ASSERT_EQ (err, NO_ERROR);
+
+  err = oos_delete (thread_p, oos_vfid, oid);
+  ASSERT_EQ (err, NO_ERROR);
+
+  // Reading a deleted slot should fail
+  RECDES rec_out{};
+  int read_err = oos_read (thread_p, oid, rec_out);
+  ASSERT_NE (read_err, NO_ERROR);
+
+  // rec_out data area should not have been allocated if read failed
+  if (rec_out.data != nullptr)
+    {
+      recdes_free_data_area (&rec_out);
+    }
+}
+
+
+// ===========================================================================
+// TEST: OosDeleteMultiChunk
+//
+// Insert a record that spans two pages (> max_chunk_size).
+// Before deleting, save the free space of each chunk's page.
+// After deleting, verify both pages gained free space.
+// ===========================================================================
+TEST (OosDeleteTest, OosDeleteMultiChunk)
+{
+  int err;
+  VFID oos_vfid;
+
+  err = oos_file_create (thread_p, oos_vfid);
+  ASSERT_EQ (err, NO_ERROR);
+
+  const int max_chunk_size = bridge_oos_get_max_chunk_size_within_page ();
+  // 50 bytes past the single-chunk limit → guaranteed two chunks
+  const int large_size = max_chunk_size + 50;
+
+  auto large_data = test_oos_utils::make_repeated_pattern_string (large_size);
+
+  RECDES rec_in{};
+  err = test_oos_utils::from_string_into_recdes (large_data, rec_in);
+  ASSERT_EQ (err, NO_ERROR);
+  test_oos_utils::auto_freed_recdes_ptr defer_free (&rec_in, recdes_free_data_area);
+
+  OID head_oid = OID_INITIALIZER;
+  err = oos_insert (thread_p, oos_vfid, rec_in, head_oid);
+  ASSERT_EQ (err, NO_ERROR);
+  test_oos_debug ("head_oid={vol=%d,page=%d,slot=%d}", head_oid.volid, head_oid.pageid, head_oid.slotid);
+
+  // Peek the header of the first chunk to find the next chunk OID
+  OOS_RECORD_HEADER head_header{};
+  err = peek_oos_header (head_oid, head_header);
+  ASSERT_EQ (err, NO_ERROR);
+
+  OID next_oid = head_header.next_chunk_oid;
+  test_oos_debug ("next_oid={vol=%d,page=%d,slot=%d}", next_oid.volid, next_oid.pageid, next_oid.slotid);
+
+  // A two-chunk record must have a valid next chunk
+  ASSERT_NE (next_oid.pageid, NULL_PAGEID);
+
+  int head_free_before = get_free_space_of_oid_page (head_oid);
+  int next_free_before = get_free_space_of_oid_page (next_oid);
+  ASSERT_GE (head_free_before, 0);
+  ASSERT_GE (next_free_before, 0);
+  test_oos_debug ("head_free_before=%d, next_free_before=%d", head_free_before, next_free_before);
+
+  err = oos_delete (thread_p, oos_vfid, head_oid);
+  ASSERT_EQ (err, NO_ERROR);
+
+  int head_free_after = get_free_space_of_oid_page (head_oid);
+  int next_free_after = get_free_space_of_oid_page (next_oid);
+  test_oos_debug ("head_free_after=%d, next_free_after=%d", head_free_after, next_free_after);
+
+  // Both pages must have gained free space
+  ASSERT_GT (head_free_after, head_free_before);
+  ASSERT_GT (next_free_after, next_free_before);
+}
+
+
+// ===========================================================================
+// TEST: OosUpdatePattern
+//
+// Simulate UPDATE: insert old record, insert new record, delete old record.
+// Verify the new record is still readable and old OID is gone.
+// ===========================================================================
+TEST (OosDeleteTest, OosUpdatePattern)
+{
+  int err;
+  VFID oos_vfid;
+
+  err = oos_file_create (thread_p, oos_vfid);
+  ASSERT_EQ (err, NO_ERROR);
+
+  const std::string old_data = "old value before update";
+  const std::string new_data = "new value after update";
+
+  RECDES rec_old{};
+  RECDES rec_new{};
+  err = test_oos_utils::from_string_into_recdes (old_data, rec_old);
+  ASSERT_EQ (err, NO_ERROR);
+  err = test_oos_utils::from_string_into_recdes (new_data, rec_new);
+  ASSERT_EQ (err, NO_ERROR);
+  test_oos_utils::auto_freed_recdes_ptr defer_old (&rec_old, recdes_free_data_area);
+  test_oos_utils::auto_freed_recdes_ptr defer_new (&rec_new, recdes_free_data_area);
+
+  OID old_oid = OID_INITIALIZER;
+  err = oos_insert (thread_p, oos_vfid, rec_old, old_oid);
+  ASSERT_EQ (err, NO_ERROR);
+
+  OID new_oid = OID_INITIALIZER;
+  err = oos_insert (thread_p, oos_vfid, rec_new, new_oid);
+  ASSERT_EQ (err, NO_ERROR);
+
+  // Both OIDs should be different slots
+  ASSERT_NE (old_oid.slotid, new_oid.slotid);
+
+  // Delete the old record (UPDATE path: discard previous version)
+  err = oos_delete (thread_p, oos_vfid, old_oid);
+  ASSERT_EQ (err, NO_ERROR);
+
+  // New record must still be readable and unchanged
+  RECDES rec_out{};
+  err = oos_read (thread_p, new_oid, rec_out);
+  ASSERT_EQ (err, NO_ERROR);
+  ASSERT_EQ (rec_out.length, rec_new.length);
+  ASSERT_STREQ (rec_out.data, new_data.c_str());
+  recdes_free_data_area (&rec_out);
+
+  // Old OID must no longer be readable
+  RECDES stale_out{};
+  int stale_err = oos_read (thread_p, old_oid, stale_out);
+  ASSERT_NE (stale_err, NO_ERROR);
+  if (stale_out.data != nullptr)
+    {
+      recdes_free_data_area (&stale_out);
+    }
+}
+
+
+// ===========================================================================
+// TEST: OosDeleteRestoresFreeSpace
+//
+// Insert a record and then delete it.  The page's free space must return to
+// at least the value it had before the insert.
+// ===========================================================================
+TEST (OosDeleteTest, OosDeleteRestoresFreeSpace)
+{
+  int err;
+  VFID oos_vfid;
+
+  err = oos_file_create (thread_p, oos_vfid);
+  ASSERT_EQ (err, NO_ERROR);
+
+  const std::string data = "free space restore test data";
+  RECDES rec_in{};
+  err = test_oos_utils::from_string_into_recdes (data, rec_in);
+  ASSERT_EQ (err, NO_ERROR);
+  test_oos_utils::auto_freed_recdes_ptr defer_free (&rec_in, recdes_free_data_area);
+
+  // First insert establishes the page; record free space after it
+  OID first_oid = OID_INITIALIZER;
+  err = oos_insert (thread_p, oos_vfid, rec_in, first_oid);
+  ASSERT_EQ (err, NO_ERROR);
+
+  int free_after_first_insert = get_free_space_of_oid_page (first_oid);
+
+  // Insert the record we want to delete
+  RECDES rec_target{};
+  err = test_oos_utils::from_string_into_recdes (data, rec_target);
+  ASSERT_EQ (err, NO_ERROR);
+  test_oos_utils::auto_freed_recdes_ptr defer_target (&rec_target, recdes_free_data_area);
+
+  OID target_oid = OID_INITIALIZER;
+  err = oos_insert (thread_p, oos_vfid, rec_target, target_oid);
+  ASSERT_EQ (err, NO_ERROR);
+
+  // Both inserts should land on the same page (small data)
+  ASSERT_EQ (first_oid.pageid, target_oid.pageid);
+
+  int free_after_second_insert = get_free_space_of_oid_page (target_oid);
+  ASSERT_LT (free_after_second_insert, free_after_first_insert);
+
+  // Delete the second record
+  err = oos_delete (thread_p, oos_vfid, target_oid);
+  ASSERT_EQ (err, NO_ERROR);
+
+  int free_after_delete = get_free_space_of_oid_page (target_oid);
+  test_oos_debug ("free_after_first_insert=%d, free_after_second_insert=%d, free_after_delete=%d",
+		  free_after_first_insert, free_after_second_insert, free_after_delete);
+
+  // spage_delete reclaims record data but retains the slot entry as a reusable
+  // tombstone (sizeof SPAGE_SLOT = 4 bytes).  So the recovered space equals the
+  // record data size, not the full (data + slot) that was consumed on insert.
+  // Verify that at least the record data size was returned to the page.
+  const int recovered = free_after_delete - free_after_second_insert;
+  ASSERT_GE (recovered, rec_target.length);
+}
+
+
+// ===========================================================================
+// TEST: OosDeleteLarge160KBMultiChunk
+//
+// Insert a 160 KB record (many chunks across pages), delete it,
+// verify oos_read on the head OID fails afterward.
+// ===========================================================================
+TEST (OosDeleteTest, OosDeleteLarge160KBMultiChunk)
+{
+  int err;
+  VFID oos_vfid;
+
+  err = oos_file_create (thread_p, oos_vfid);
+  ASSERT_EQ (err, NO_ERROR);
+
+  const int large_size = 160 * 1024; // 160 KB
+  auto large_data = test_oos_utils::make_repeated_pattern_string (large_size);
+
+  RECDES rec_in{};
+  err = test_oos_utils::from_string_into_recdes (large_data, rec_in);
+  ASSERT_EQ (err, NO_ERROR);
+  test_oos_utils::auto_freed_recdes_ptr defer_free (&rec_in, recdes_free_data_area);
+
+  OID oid = OID_INITIALIZER;
+  err = oos_insert (thread_p, oos_vfid, rec_in, oid);
+  ASSERT_EQ (err, NO_ERROR);
+  test_oos_debug ("Inserted 160KB record at oid={vol=%d,page=%d,slot=%d}",
+		  oid.volid, oid.pageid, oid.slotid);
+
+  // Verify it can be read before deletion
+  RECDES rec_check{};
+  err = oos_read (thread_p, oid, rec_check);
+  ASSERT_EQ (err, NO_ERROR);
+  ASSERT_STREQ (rec_check.data, rec_in.data);
+  recdes_free_data_area (&rec_check);
+
+  // Delete the full chain
+  err = oos_delete (thread_p, oos_vfid, oid);
+  ASSERT_EQ (err, NO_ERROR);
+
+  // Reading any chunk from the head OID must now fail
+  RECDES rec_after{};
+  int read_err = oos_read (thread_p, oid, rec_after);
+  ASSERT_NE (read_err, NO_ERROR);
+  if (rec_after.data != nullptr)
+    {
+      recdes_free_data_area (&rec_after);
+    }
+}
+
+
+int main (int argc, char **argv)
+{
+  ::testing::InitGoogleTest (&argc, argv);
+  ::testing::AddGlobalTestEnvironment (new ServerEnv());
+  ::testing::GTEST_FLAG (break_on_failure) = true;
+
+  oos_log::oos_log_set_level (oos_log::OosLogLevel::INFO);
+  test_oos_log_set_level (test_oos_log::TestOosLogLevel::INFO);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26609>

### Description

Milestone 1에서 OOS insert/read는 구현되어 있으나, OOS 레코드를 물리적으로 삭제하는 `oos_delete` API가 없었다.

이로 인해 아래 두 경로에서 OOS 레코드가 영구히 잔존하는 문제가 있었다.

| 경로 | 문제 |
|---|---|
| `UPDATE` | 이전 버전 OOS 레코드가 삭제되지 않고 남음 |
| `DELETE` + vacuum | vacuum이 heap record를 정리하더라도 OOS 레코드가 orphan으로 잔존 |

`spage_delete`를 통해 OOS 페이지의 슬롯을 물리적으로 삭제하고, 페이지의 `total_free`를 회수하는 `oos_delete` API를 구현한다.

---

### Implementation

#### 신규 함수

| 함수 | 파일 | 설명 |
|---|---|---|
| `oos_delete` | `src/storage/oos_file.cpp` | OOS 레코드 물리 삭제 (public API) |
| `oos_log_delete_physical` | `src/storage/oos_file.cpp` | OOS 삭제 WAL 로깅 내부 헬퍼 (static) |

#### `oos_delete` 동작 흐름

Multi-chunk OOS 레코드(across-pages)를 지원하기 위해 `next_chunk_oid` 체인을 순회하며 모든 청크를 순서대로 삭제한다.

```
while (current_oid.pageid != NULL_PAGEID):
    pgbuf_fix (WRITE latch)
    spage_get_record (PEEK) → OOS_RECORD_HEADER에서 next_chunk_oid 확인
    oos_log_delete_physical 호출 (WAL 선행 기록)
    spage_delete → total_free 증가
    pgbuf_set_dirty + pgbuf_unfix
    current_oid = next_chunk_oid
```

#### WAL 로깅 설계

`RVOOS_DELETE` 로그 레코드는 이미 `recovery.h`에 정의되어 있으며, 핸들러도 등록되어 있다.

| 필드 | 내용 |
|---|---|
| `log_addr.pgptr` | 삭제 대상 OOS 페이지 |
| `log_addr.offset` | slotid (redo 시 `oos_rv_redo_delete`가 이 값 사용) |
| undo data | 원본 RECDES (rollback 시 `oos_rv_redo_insert`로 레코드 재삽입) |
| redo data | 없음 (slotid만으로 redo 가능) |

기존 recovery 테이블에 등록된 핸들러를 그대로 활용한다:
- undo: `oos_rv_redo_insert` (원본 레코드 재삽입)
- redo: `oos_rv_redo_delete` (슬롯 삭제)

#### 단위 테스트 (`unit_tests/oos/test_oos_delete.cpp`)

| 테스트 | 검증 내용 |
|---|---|
| `OosDeleteBasic` | `oos_delete` 성공, 삭제 후 페이지 free space 증가 확인 |
| `OosDeleteThenReadFails` | 삭제된 OID로 `oos_read` 시 에러 반환 확인 |
| `OosDeleteMultiChunk` | 2-chunk 레코드 삭제 시 양쪽 페이지 모두 free space 증가 확인 |
| `OosUpdatePattern` | UPDATE 패턴 시뮬레이션: 이전 레코드 삭제 후 새 레코드 정상 읽기, 이전 OID 읽기 실패 확인 |
| `OosDeleteRestoresFreeSpace` | 삭제 후 레코드 데이터 크기만큼 free space 회수 확인 |
| `OosDeleteLarge160KBMultiChunk` | 160KB multi-chunk 레코드 삭제 후 head OID 읽기 실패 확인 |

<img width="1518" height="861" alt="image" src="https://github.com/user-attachments/assets/83c91be5-603a-41c0-82bf-a7d76a2e091f" />

모두 통과한 모습

---

### Remarks

- `spage_delete`는 레코드 데이터는 해제하지만 슬롯 엔트리(`SPAGE_SLOT`, 4 bytes)는 `REC_DELETED_WILL_REUSE` 상태로 남긴다. 추후 `spage_compact`를 통한 in-page compaction에서 이 공간을 재활용할 수 있다.
- 호출 경로 연결(`heap_update` → `oos_delete`, `vacuum_heap` → `oos_delete`)은 이 PR 범위에 포함되지 않는다. 해당 연결은 상위 스토리에서 진행한다.
- 해당 PR 댓글로 남은 주요 분석 글들은 다음 링크에 문서화되었습니다.
  - https://vimkim.dev/cubrid-oos-vault/oos-delete-analysis