### PR TITLE
[CUBRIDQA-1320] fix branch separation logic.

### DIFF
--- a/.github/workflows/tc-branch-finalize.yml
+++ b/.github/workflows/tc-branch-finalize.yml
@@ -13,6 +13,9 @@ name: TC Branch Finalize
 on:
   pull_request_target:
     types: [closed]
+    branches:
+      - develop
+      - 'feature/**'
 
 permissions: {} # Least privilege — jobs opt-in below
 
@@ -143,7 +146,7 @@ jobs:
 
           **Cleanup Results:**${CLEANUP_ITEMS}
 
-          TC develop branch is ready for the next PR.
+          TC base branch is ready for the next PR.
           EOF
           )
 

--- a/.github/workflows/tc-branch-sync.yml
+++ b/.github/workflows/tc-branch-sync.yml
@@ -9,6 +9,9 @@ name: TC Branch Sync
 on:
   pull_request_target:
     types: [opened, reopened]
+    branches:
+      - develop
+      - 'feature/**'
 
 permissions: {} # Least privilege — jobs opt-in below
 
@@ -94,11 +97,13 @@ jobs:
         run: echo "::add-mask::${APP_TOKEN}"
 
       - name: Create TC branch from develop
+        id: create-tc-branch
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           TC_REPO: ${{ matrix.tc-repo }}
           OWNER: ${{ env.OWNER }}
+          ENGINE_BASE_REF: ${{ github.event.pull_request.base.ref }}
         shell: bash
         run: |
           set -euo pipefail
@@ -106,14 +111,28 @@ jobs:
 
           if gh api "repos/${OWNER}/${TC_REPO}/git/refs/heads/${BRANCH_NAME}" > /dev/null 2>&1; then
             echo "::notice::Branch '${BRANCH_NAME}' already exists in ${TC_REPO}. Skipping branch creation."
+            TC_BASE_REF="${ENGINE_BASE_REF}"
+            echo "tc_base_ref=${TC_BASE_REF}" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
 
-          DEVELOP_SHA=$(gh api "repos/${OWNER}/${TC_REPO}/git/refs/heads/develop" --jq '.object.sha')
+          TC_BASE_REF="${ENGINE_BASE_REF}"
+          API_RESPONSE=$(gh api "repos/${OWNER}/${TC_REPO}/git/refs/heads/${TC_BASE_REF}" 2>&1) || {
+            HTTP_STATUS=$?
+            if echo "${API_RESPONSE}" | grep -q "Not Found\|404"; then
+              echo "::notice::Branch '${TC_BASE_REF}' not found in ${TC_REPO}. Falling back to develop."
+              TC_BASE_REF="develop"
+            else
+              echo "::error::Failed to check branch '${TC_BASE_REF}' in ${TC_REPO}: ${API_RESPONSE}"
+              exit 1
+            fi
+          }
+
+          BASE_SHA=$(gh api "repos/${OWNER}/${TC_REPO}/git/refs/heads/${TC_BASE_REF}" --jq '.object.sha')
           gh api "repos/${OWNER}/${TC_REPO}/git/refs" \
             --method POST \
             --field ref="refs/heads/${BRANCH_NAME}" \
-            --field sha="${DEVELOP_SHA}"
+            --field sha="${BASE_SHA}"
 
           git clone --branch "${BRANCH_NAME}" --single-branch \
             "https://x-access-token:${GH_TOKEN}@github.com/${OWNER}/${TC_REPO}.git" \
@@ -126,6 +145,8 @@ jobs:
             git push origin "${BRANCH_NAME}" --force-with-lease
           fi
 
+          echo "tc_base_ref=${TC_BASE_REF}" >> "${GITHUB_OUTPUT}"
+
       - name: Create draft PR in TC repo
         id: create-draft-pr
         env:
@@ -135,6 +156,7 @@ jobs:
           TC_REPO: ${{ matrix.tc-repo }}
           ENGINE_REPO: ${{ github.repository }}
           OWNER: ${{ env.OWNER }}
+          TC_BASE_REF: ${{ steps.create-tc-branch.outputs.tc_base_ref }}
         shell: bash
         run: |
           set -euo pipefail
@@ -152,7 +174,7 @@ jobs:
           PR_URL=$(gh pr create \
             --repo "${OWNER}/${TC_REPO}" \
             --head "${BRANCH_NAME}" \
-            --base develop \
+            --base "${TC_BASE_REF}" \
             --title "${DRAFT_TITLE}" \
             --body "This is a draft PR for testing TC changes.
 
@@ -283,6 +305,7 @@ jobs:
           TC_REPO: ${{ matrix.tc-repo }}
           OWNER: ${{ env.OWNER }}
           ENGINE_REPO: ${{ github.repository }}
+          ENGINE_BASE_REF: ${{ github.event.pull_request.base.ref }}
         shell: bash
         run: |
           set -euo pipefail
@@ -302,14 +325,26 @@ jobs:
             exit 0
           fi
 
+          TC_BASE_REF="${ENGINE_BASE_REF}"
+          CHECK_OUTPUT=$(gh api "repos/${OWNER}/${TC_REPO}/git/refs/heads/${TC_BASE_REF}" 2>&1) || {
+            if echo "${CHECK_OUTPUT}" | grep -q "404\|Not Found"; then
+              echo "::notice::Branch '${TC_BASE_REF}' not found in ${TC_REPO}, falling back to develop"
+              TC_BASE_REF="develop"
+            else
+              echo "::error::Failed to check branch '${TC_BASE_REF}' in ${TC_REPO}: ${CHECK_OUTPUT}"
+              exit 1
+            fi
+          }
+          echo "tc_base_ref=${TC_BASE_REF}" >> "${GITHUB_OUTPUT}"
+
           TARGET_BRANCH="tc/pr-${PR_NUMBER}"
 
           git clone --filter=blob:none "https://x-access-token:${APP_TOKEN}@github.com/${OWNER}/${TC_REPO}.git" tc-repo
           cd tc-repo
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin develop
-          git checkout -B "${TARGET_BRANCH}" origin/develop
+          git fetch origin "${TC_BASE_REF}"
+          git checkout -B "${TARGET_BRANCH}" origin/"${TC_BASE_REF}"
 
           if ! git revert --no-edit "${MERGE_COMMIT}" 2>/dev/null; then
             git revert --abort 2>/dev/null || true
@@ -337,6 +372,7 @@ jobs:
           TC_REPO: ${{ matrix.tc-repo }}
           ENGINE_REPO: ${{ github.repository }}
           TARGET_BRANCH: ${{ steps.revert-tc-commit.outputs.tc_revert_branch }}
+          TC_BASE_REF: ${{ steps.revert-tc-commit.outputs.tc_base_ref }}
           OWNER: ${{ env.OWNER }}
         shell: bash
         run: |
@@ -357,7 +393,7 @@ jobs:
 
           **Please merge this PR FIRST, then merge the engine revert PR.**"
           
-          gh pr create --repo "${OWNER}/${TC_REPO}" --head "${TARGET_BRANCH}" --base develop --title "${PR_TITLE}" --body "${PR_BODY}"
+          gh pr create --repo "${OWNER}/${TC_REPO}" --head "${TARGET_BRANCH}" --base "${TC_BASE_REF}" --title "${PR_TITLE}" --body "${PR_BODY}"
 
   # Comment TC info on engine PR (revert PR)
   comment-on-engine-pr-revert:

--- a/.github/workflows/tc-branch-sync.yml
+++ b/.github/workflows/tc-branch-sync.yml
@@ -118,17 +118,17 @@ jobs:
 
           TC_BASE_REF="${ENGINE_BASE_REF}"
           API_RESPONSE=$(gh api "repos/${OWNER}/${TC_REPO}/git/refs/heads/${TC_BASE_REF}" 2>&1) || {
-            HTTP_STATUS=$?
             if echo "${API_RESPONSE}" | grep -q "Not Found\|404"; then
               echo "::notice::Branch '${TC_BASE_REF}' not found in ${TC_REPO}. Falling back to develop."
               TC_BASE_REF="develop"
+              API_RESPONSE=$(gh api "repos/${OWNER}/${TC_REPO}/git/refs/heads/${TC_BASE_REF}")
             else
               echo "::error::Failed to check branch '${TC_BASE_REF}' in ${TC_REPO}: ${API_RESPONSE}"
               exit 1
             fi
           }
 
-          BASE_SHA=$(gh api "repos/${OWNER}/${TC_REPO}/git/refs/heads/${TC_BASE_REF}" --jq '.object.sha')
+          BASE_SHA=$(echo "${API_RESPONSE}" | jq -r '.object.sha')
           gh api "repos/${OWNER}/${TC_REPO}/git/refs" \
             --method POST \
             --field ref="refs/heads/${BRANCH_NAME}" \


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1320>

## Purpose 
- `release/*` 하위 브랜치(예: `release/11.4`) PR에서 TC 브랜치 동기화 워크플로우가 실행되지 않도록 제한
- `develop` 및 `feature/*` 브랜치 PR에서는 엔진 PR의 base 브랜치를 기준으로 TC 브랜치를 생성하되, TC repo에 해당 feature 브랜치가 없을 경우 `develop`으로 자동 fallback

## Implementation 
- **트리거 제한**: `tc-branch-sync.yml`과 `tc-branch-finalize.yml`에 `pull_request_target.branches` allowlist 추가 (`develop`, `feature/**`)
- **동적 TC base ref**: 
  - `ENGINE_BASE_REF = github.event.pull_request.base.ref` 환경변수 추가
  - `gh api`로 TC repo에 해당 브랜치 존재 여부 확인 (404일 때만 `develop`로 fallback, 그 외 오류는 workflow 실패)
  - Normal flow와 Revert flow 모두 `--base "${TC_BASE_REF}"` 사용하도록 변경
- **하드코딩 제거**: `refs/heads/develop` SHA 조회, `--base develop`, `origin/develop` checkout 등을 `TC_BASE_REF` 기반으로 대체
- **Finalize 코멘트**: "TC develop branch" → "TC base branch" 문구 변경

## Remarks 
- **보안 유지**: `pull_request_target` 유지, PR 코드 checkout/실행 없음, 기존 secret 사용
- **Fallback 동작**: TC repo에 feature 브랜치가 없을 때 `::notice::Branch 'X' not found... Falling back to develop.` 로그 출력
- **변경 범위**: `.github/workflows/tc-branch-sync.yml`, `.github/workflows/tc-branch-finalize.yml` (최소 변경)
