### PR TITLE
[CBRD-26596] [Regression] Core dumped in qexec_execute_query at src/query/query_executor.c:16449

### DIFF
--- a/src/query/parallel/px_heap_scan/px_heap_scan.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan.cpp
@@ -825,6 +825,12 @@ namespace parallel_heap_scan
 	  }
       }
 
+    if (m_result_handler_read_initialized == false)
+      {
+	m_result_handler->read_initialize (m_thread_p);
+	m_result_handler_read_initialized = true;
+      }
+
     if (unlikely (!m_task_started))
       {
 	if constexpr (result_type == RESULT_TYPE::MERGEABLE_LIST || result_type == RESULT_TYPE::COUNT_DISTINCT)
@@ -832,6 +838,10 @@ namespace parallel_heap_scan
 	    if (m_xasl->scan_ptr)
 	      {
 		m_join_info.capture_join_info (m_xasl);
+		for (XASL_NODE *xptr = m_xasl->scan_ptr; xptr; xptr=xptr->scan_ptr)
+		  {
+		    scan_end_scan (m_thread_p, &xptr->spec_list->s_id);
+		  }
 	      }
 	  }
 	err_code = start_tasks();
@@ -839,11 +849,6 @@ namespace parallel_heap_scan
 	  {
 	    return S_ERROR;
 	  }
-      }
-    if (m_result_handler_read_initialized == false)
-      {
-	m_result_handler->read_initialize (m_thread_p);
-	m_result_handler_read_initialized = true;
       }
 
     if constexpr (result_type == RESULT_TYPE::MERGEABLE_LIST)

--- a/src/query/parallel/px_heap_scan/px_heap_scan.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan.cpp
@@ -834,7 +834,10 @@ namespace parallel_heap_scan
 		m_join_info.capture_join_info (m_xasl);
 		for (XASL_NODE *xptr = m_xasl->scan_ptr; xptr; xptr=xptr->scan_ptr)
 		  {
-		    scan_end_scan (m_thread_p, &xptr->spec_list->s_id);
+		    if (xptr->spec_list->type == TARGET_LIST)
+		      {
+			scan_end_scan (m_thread_p, &xptr->spec_list->s_id);
+		      }
 		  }
 	      }
 	  }

--- a/src/query/parallel/px_heap_scan/px_heap_scan.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan.cpp
@@ -825,12 +825,6 @@ namespace parallel_heap_scan
 	  }
       }
 
-    if (m_result_handler_read_initialized == false)
-      {
-	m_result_handler->read_initialize (m_thread_p);
-	m_result_handler_read_initialized = true;
-      }
-
     if (unlikely (!m_task_started))
       {
 	if constexpr (result_type == RESULT_TYPE::MERGEABLE_LIST || result_type == RESULT_TYPE::COUNT_DISTINCT)
@@ -849,6 +843,12 @@ namespace parallel_heap_scan
 	  {
 	    return S_ERROR;
 	  }
+      }
+
+    if (m_result_handler_read_initialized == false)
+      {
+	m_result_handler->read_initialize (m_thread_p);
+	m_result_handler_read_initialized = true;
       }
 
     if constexpr (result_type == RESULT_TYPE::MERGEABLE_LIST)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26596>

### Purpose

list_scan과 join할 시, main에서 open 된 list_scan이 apply join info 시에 list를 닫지 않고 상태만 S_ENDED로 바뀌어 qlist_count 관련 assertion이 실패하는 오류를 수정합니다.
