### PR TITLE
[CBRD-26629] code refinement after CBRD-26514

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -4733,6 +4733,7 @@ emit_stored_procedure_code (extract_context & ctxt, print_output & output_ctx, c
 	  if ((*scode_ptr)->info.sp.comment)
 	    {
 	      assert (false);	// scode does not have the comment: CBRD-26513
+	      er_log_debug (ARG_FILE_LINE, "emit_stored_procedure_code: unexpected comment node in scode\n");
 	      (*scode_ptr)->info.sp.comment = NULL;
 	    }
 

--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -4730,6 +4730,12 @@ emit_stored_procedure_code (extract_context & ctxt, print_output & output_ctx, c
       scode_ptr = parser_parse_string (parser, scode);
       if (scode_ptr != NULL)
 	{
+	  if ((*scode_ptr)->info.sp.comment)
+	    {
+	      assert (false);	// scode does not have the comment: CBRD-26513
+	      (*scode_ptr)->info.sp.comment = NULL;
+	    }
+
 	  if (ctxt.is_dba_user == false && ctxt.is_dba_group_member == false)
 	    {
 	      parser->custom_print |= PT_PRINT_NO_CURRENT_USER_NAME;
@@ -4744,7 +4750,7 @@ emit_stored_procedure_code (extract_context & ctxt, print_output & output_ctx, c
 		}
 	    }
 
-	  parser->flag.is_unloading_schema = 1;
+	  parser->flag.is_unloading_plcsql_def = 1;
 	  scode_ptr_result = parser_print_tree_with_quotes (parser, *scode_ptr);
 	}
 
@@ -4753,7 +4759,6 @@ emit_stored_procedure_code (extract_context & ctxt, print_output & output_ctx, c
 	  output_ctx ("\n%s", scode_ptr_result);
 	  if (!DB_IS_NULL (comment))
 	    {
-	      assert ((*scode_ptr)->info.sp.comment == NULL);	// CBRD-26513. scode cannot have the comment
 	      output_ctx ("COMMENT ");
 	      desc_value_print (output_ctx, comment);
 	    }

--- a/src/parser/parse_tree.c
+++ b/src/parser/parse_tree.c
@@ -1232,7 +1232,7 @@ parser_create_parser (void)
   parser->max_print_len = 0;
   parser->flag.is_auto_commit = 0;
   parser->flag.is_parsing_static_sql = 0;
-  parser->flag.is_unloading_schema = 0;
+  parser->flag.is_unloading_plcsql_def = 0;
   parser->flag.is_parsing_trigger = 0;
 
   parser->external_into_label = NULL;

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -3866,7 +3866,7 @@ struct parser_context
     unsigned is_system_generated_stmt:1;
     unsigned is_auto_commit:1;	/* set to true, if auto commit. */
     unsigned is_parsing_static_sql:1;	/* For PL/CSQL's static SQL: parameterize PL/CSQL variable symbols (to host variable) */
-    unsigned is_unloading_schema:1;
+    unsigned is_unloading_plcsql_def:1;
     unsigned is_parsing_trigger:1;
     unsigned is_skip_auto_parameterize:1;	/* set to 1 when skip auto parameterize, now only used for merge xasl generation */
   } flag;

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -7674,7 +7674,7 @@ pt_print_create_stored_procedure (PARSER_CONTEXT * parser, PT_NODE * p)
 {
   PARSER_VARCHAR *q = NULL, *r1, *r2, *r3;
 
-  if (parser->flag.is_unloading_schema)
+  if (parser->flag.is_unloading_plcsql_def)
     {
       q = pt_append_nulstring (parser, q, "CREATE OR REPLACE ");
       q = pt_append_nulstring (parser, q, (p->info.sp.type == PT_SP_PROCEDURE) ? "PROCEDURE" : "FUNCTION");
@@ -7700,7 +7700,7 @@ pt_print_create_stored_procedure (PARSER_CONTEXT * parser, PT_NODE * p)
 
   if (p->info.sp.type == PT_SP_FUNCTION)
     {
-      q = pt_append_nulstring (parser, q, parser->flag.is_unloading_schema ? " RETURN " : " return ");
+      q = pt_append_nulstring (parser, q, parser->flag.is_unloading_plcsql_def ? " RETURN " : " return ");
       if (p->info.sp.ret_data_type)
 	{
 	  q = pt_append_varchar (parser, q, pt_print_bytes (parser, p->info.sp.ret_data_type));
@@ -7711,7 +7711,7 @@ pt_print_create_stored_procedure (PARSER_CONTEXT * parser, PT_NODE * p)
 	}
     }
 
-  if (parser->flag.is_unloading_schema)
+  if (parser->flag.is_unloading_plcsql_def)
     {
       if (p->info.sp.auth_id == PT_AUTHID_OWNER)
 	{
@@ -7747,9 +7747,9 @@ pt_print_create_stored_procedure (PARSER_CONTEXT * parser, PT_NODE * p)
   r3 = pt_print_bytes (parser, p->info.sp.body);
   q = pt_append_varchar (parser, q, r3);
 
-  if (p->info.sp.comment != NULL)
+  // CBRD-26513 : do not print comment when unloading plcsql definition
+  if (p->info.sp.comment != NULL && !parser->flag.is_unloading_plcsql_def)
     {
-      assert (!parser->flag.is_unloading_schema);	// CBRD-26513
       r1 = pt_print_bytes (parser, p->info.sp.comment);
       q = pt_append_nulstring (parser, q, " comment ");
       q = pt_append_varchar (parser, q, r1);
@@ -8002,7 +8002,7 @@ pt_print_sp_parameter (PARSER_CONTEXT * parser, PT_NODE * p)
   r1 = pt_print_bytes (parser, p->info.sp_param.name);
   q = pt_append_varchar (parser, q, r1);
   q = pt_append_nulstring (parser, q, " ");
-  q = pt_append_nulstring (parser, q, parser->flag.is_unloading_schema ?
+  q = pt_append_nulstring (parser, q, parser->flag.is_unloading_plcsql_def ?
 			   (p->info.sp_param.mode == PT_INPUT || p->info.sp_param.mode == PT_NOPUT) ?
 			   "IN" : p->info.sp_param.mode == PT_OUTPUT ?
 			   "OUT" : "INOUT" : pt_show_misc_type (p->info.sp_param.mode));
@@ -8056,7 +8056,7 @@ static PARSER_VARCHAR *
 pt_print_sp_body (PARSER_CONTEXT * parser, PT_NODE * p)
 {
   PARSER_VARCHAR *q = NULL, *r1 = NULL;
-  q = pt_append_nulstring (parser, q, parser->flag.is_unloading_schema ? " AS\n" : " as ");
+  q = pt_append_nulstring (parser, q, parser->flag.is_unloading_plcsql_def ? " AS\n" : " as ");
   if (p->info.sp_body.lang == SP_LANG_PLCSQL)
     {
       r1 = pt_append_varchar (parser, r1, p->info.sp_body.impl->info.value.data_value.str);
@@ -8664,7 +8664,7 @@ pt_print_datatype (PARSER_CONTEXT * parser, PT_NODE * p)
 
     case PT_TYPE_CHAR:
     case PT_TYPE_VARCHAR:
-      if (parser->flag.is_unloading_schema)
+      if (parser->flag.is_unloading_plcsql_def)
 	{
 	  switch (p->type_enum)
 	    {

--- a/src/sp/jsp_cl.cpp
+++ b/src/sp/jsp_cl.cpp
@@ -1219,17 +1219,14 @@ jsp_create_stored_procedure (PARSER_CONTEXT *parser, PT_NODE *statement)
       // CBRD-26513, CBRD-26514: rewrite the user code without the user name and the comment
       const char *rewritten_code;
       {
-	PT_NODE *comment_saved = statement->info.sp.comment;
 	int custom_print_saved = parser->custom_print;
 
-	statement->info.sp.comment = NULL;
 	parser->custom_print |= PT_PRINT_NO_SPECIFIED_USER_NAME;
-	parser->flag.is_unloading_schema = 1;
+	parser->flag.is_unloading_plcsql_def = 1;
 	rewritten_code = parser_print_tree (parser, statement);
-	parser->flag.is_unloading_schema = 0;
+	parser->flag.is_unloading_plcsql_def = 0;
 
 	parser->custom_print = custom_print_saved;
-	statement->info.sp.comment = comment_saved;
       }
 
       code_info.name = sp_info.target_class;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26629>

### Purpose

CBRD-26514 변경을 11.4 에 backport 하면서 추가로 코드 정리할 만한 내용을 발견하여 수정합니다. 
동작에는 거의 영향이 없고 가독성을 높이기 위한 변경입니다. 

### Implementation
- add a defense code for an unlikely case when the scode has a comment clause
- rename a filed because it is too general: is_unloading_schema --> is_unloading_plcsql_def
- do not print comment when unloading plcsql definition
- do not erase and restore comment clause of create procedure comments before putting it into _db_stored_procedure_c
ode.scode
