### PR TITLE
[CBRD-26630] Heap Recdes contains OOS length info

### DIFF
--- a/src/base/object_representation.h
+++ b/src/base/object_representation.h
@@ -445,8 +445,8 @@ OR_PUT_DOUBLE (char *ptr, double val)
 
 #define OR_IS_OOS(length) (OR_GET_VAR_FLAG (length) & OR_VAR_BIT_OOS)
 
-/* OOS inline size: OOS OID (8 bytes) + OOS length (4 bytes) */
-#define OR_OOS_INLINE_SIZE (OR_OID_SIZE + OR_INT_SIZE)
+/* OOS inline size: OOS OID (8 bytes) + OOS length (8 bytes) */
+#define OR_OOS_INLINE_SIZE (OR_OID_SIZE + OR_BIGINT_SIZE)
 
 /* variable offset */
 

--- a/src/base/object_representation.h
+++ b/src/base/object_representation.h
@@ -445,6 +445,9 @@ OR_PUT_DOUBLE (char *ptr, double val)
 
 #define OR_IS_OOS(length) (OR_GET_VAR_FLAG (length) & OR_VAR_BIT_OOS)
 
+/* OOS inline size: OOS OID (8 bytes) + OOS length (4 bytes) */
+#define OR_OOS_INLINE_SIZE (OR_OID_SIZE + OR_INT_SIZE)
+
 /* variable offset */
 
 #define OR_VAR_TABLE_SIZE(vars) \

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -759,15 +759,16 @@ static SCAN_CODE heap_attrinfo_transform_fixed_to_disk (THREAD_ENTRY * thread_p,
 // *INDENT-ON*
 static SCAN_CODE heap_attrinfo_transform_variable_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * attr_info,
 							   OR_BUF * buf, char **ptr_varvals, bool is_oos, OID * oos_oid,
-							   int index, int offset_size, int header_size,
+							   int oos_length, int index, int offset_size, int header_size,
 							   int lob_create_flag);
 static SCAN_CODE heap_attrinfo_transform_header_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * attr_info,
 							 OR_BUF * buf, int offset_size, bool is_mvcc_class,
 							 bool is_update, bool has_oos);
 
 // *INDENT-OFF*
-static SCAN_CODE heap_attrinfo_transform_columns_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * attr_info, OR_BUF * buf, 
+static SCAN_CODE heap_attrinfo_transform_columns_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * attr_info, OR_BUF * buf,
 							  std::vector<bool> * oos_columns, std::vector<OID> * oos_oids,
+							  std::vector<int> * oos_lengths,
 							  std::set<int> * incremented_attrids, int offset_size, int header_size,
 							  size_t mvcc_extra, int lob_create_flag, size_t * record_size);
 // *INDENT-ON*
@@ -10889,18 +10890,19 @@ heap_midxkey_get_oos_extra_size (RECDES * recdes, OR_ATTRIBUTE * att)
       return 0;
     }
 
-  /* Extract OOS OID from inline data (no allocation needed) */
+  /* Extract OOS length from inline data: [OOS OID (8B) + length (4B)] */
   OR_BUF buf;
   OID oos_oid;
+  int rc = NO_ERROR;
 
   buf.ptr = (char *) recdes->data + OR_VAR_OFFSET (recdes->data, att->location);
   buf.endptr = recdes->data + recdes->length;
   or_get_oid (&buf, &oos_oid);
   assert (!OID_ISNULL (&oos_oid));
 
-  /* Query OOS length without reading/allocating the full data */
-  THREAD_ENTRY *thread_p = thread_get_thread_entry_info ();
-  int length = oos_get_length (thread_p, oos_oid);
+  /* Read OOS length directly from recdes inline data (no I/O needed) */
+  int length = or_get_int (&buf, &rc);
+  assert (rc == NO_ERROR);
 
   return length;
 }
@@ -12148,7 +12150,7 @@ heap_attrinfo_determine_disk_layout (HEAP_CACHE_ATTRINFO * attr_info, bool is_mv
 	  if ((*oos_columns)[i])
 	    {
 	      payload_size -= column_size[i];
-	      payload_size += OR_OID_SIZE;
+	      payload_size += OR_OOS_INLINE_SIZE;
 	      *has_oos = true;
 	    }
 	}
@@ -12319,7 +12321,7 @@ heap_attrinfo_dbvalue_to_recdes (THREAD_ENTRY * thread_p, HEAP_ATTRVALUE * value
 
 // *INDENT-OFF*
 static SCAN_CODE
-heap_attrinfo_insert_to_oos (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * attr_info, int lob_create_flag, std::vector<bool> * oos_columns, std::vector<OID> * oos_oids)
+heap_attrinfo_insert_to_oos (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * attr_info, int lob_create_flag, std::vector<bool> * oos_columns, std::vector<OID> * oos_oids, std::vector<int> * oos_lengths)
 // *INDENT-ON*
 
 {
@@ -12379,6 +12381,7 @@ heap_attrinfo_insert_to_oos (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * attr
 
 	  thread_p->oos_oids.push_back (oos_oid);	/* for replication log */
 	  (*oos_oids)[i] = oos_oid;
+	  (*oos_lengths)[i] = recdes.length;
 	  if (recdes.data != PTR_ALIGN (recbuf, MAX_ALIGNMENT))
 	    {
 	      free_and_init (recdes.data);
@@ -12634,8 +12637,8 @@ heap_attrinfo_transform_fixed_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRI
  */
 static SCAN_CODE
 heap_attrinfo_transform_variable_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * attr_info, OR_BUF * buf,
-					  char **ptr_varvals, bool is_oos, OID * oos_oid, int index, int offset_size,
-					  int header_size, int lob_create_flag)
+					  char **ptr_varvals, bool is_oos, OID * oos_oid, int oos_length, int index,
+					  int offset_size, int header_size, int lob_create_flag)
 {
   HEAP_ATTRVALUE *value;
   DB_VALUE *dbvalue;
@@ -12690,13 +12693,14 @@ heap_attrinfo_transform_variable_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_AT
 
   if (is_oos)
     {
-      if (buf->ptr + OR_OID_SIZE > buf->endptr)
+      if (buf->ptr + OR_OOS_INLINE_SIZE > buf->endptr)
 	{
 	  return S_DOESNT_FIT;
 	}
 
       buf->ptr = *ptr_varvals;
       or_put_oid (buf, oos_oid);
+      or_put_int (buf, oos_length);
       *ptr_varvals = buf->ptr;
     }
   else if (dbvalue != NULL && db_value_is_null (dbvalue) != true)
@@ -12781,6 +12785,7 @@ heap_attrinfo_transform_variable_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_AT
 static SCAN_CODE
 heap_attrinfo_transform_columns_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * attr_info, OR_BUF * buf,
 					 std::vector<bool> * oos_columns, std::vector<OID> * oos_oids,
+					 std::vector<int> * oos_lengths,
 					 std::set<int> * incremented_attrids, int offset_size, int header_size,
 					 size_t mvcc_extra, int lob_create_flag, size_t * record_size)
 // *INDENT-ON*
@@ -12808,7 +12813,8 @@ heap_attrinfo_transform_columns_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_ATT
 
 	  status =
 	    heap_attrinfo_transform_variable_to_disk (thread_p, attr_info, buf, &ptr_varvals, (*oos_columns)[i],
-						      &(*oos_oids)[i], i, offset_size, header_size, lob_create_flag);
+						      &(*oos_oids)[i], (*oos_lengths)[i], i, offset_size, header_size,
+						      lob_create_flag);
 	}
       if (status != S_SUCCESS)
 	{
@@ -12872,6 +12878,7 @@ heap_attrinfo_transform_to_disk_internal (THREAD_ENTRY * thread_p, HEAP_CACHE_AT
   // *INDENT-OFF*
   std::vector<bool> oos_columns (attr_info->num_values);
   std::vector<OID> oos_oids (attr_info->num_values);
+  std::vector<int> oos_lengths (attr_info->num_values, 0);
   std::set<int> incremented_attrids;
   // *INDENT-ON*
 
@@ -12916,7 +12923,8 @@ heap_attrinfo_transform_to_disk_internal (THREAD_ENTRY * thread_p, HEAP_CACHE_AT
   if (has_oos)
     {
       /* insert big columns to OOS */
-      status = heap_attrinfo_insert_to_oos (thread_p, attr_info, lob_create_flag, &oos_columns, &oos_oids);
+      status =
+	heap_attrinfo_insert_to_oos (thread_p, attr_info, lob_create_flag, &oos_columns, &oos_oids, &oos_lengths);
       if (status != S_SUCCESS)
 	{
 	  return S_ERROR;
@@ -12945,8 +12953,8 @@ heap_attrinfo_transform_to_disk_internal (THREAD_ENTRY * thread_p, HEAP_CACHE_AT
       /* build columns */
       status =
 	heap_attrinfo_transform_columns_to_disk (thread_p, attr_info, &buf, &oos_columns, &oos_oids,
-						 &incremented_attrids, offset_size, header_size, mvcc_extra,
-						 lob_create_flag, &record_size);
+						 &oos_lengths, &incremented_attrids, offset_size, header_size,
+						 mvcc_extra, lob_create_flag, &record_size);
       if (status == S_DOESNT_FIT)
 	{
 	  expected_size += DB_PAGESIZE;

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -759,8 +759,8 @@ static SCAN_CODE heap_attrinfo_transform_fixed_to_disk (THREAD_ENTRY * thread_p,
 // *INDENT-ON*
 static SCAN_CODE heap_attrinfo_transform_variable_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * attr_info,
 							   OR_BUF * buf, char **ptr_varvals, bool is_oos, OID * oos_oid,
-							   int oos_length, int index, int offset_size, int header_size,
-							   int lob_create_flag);
+							   DB_BIGINT oos_length, int index, int offset_size,
+							   int header_size, int lob_create_flag);
 static SCAN_CODE heap_attrinfo_transform_header_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * attr_info,
 							 OR_BUF * buf, int offset_size, bool is_mvcc_class,
 							 bool is_update, bool has_oos);
@@ -768,7 +768,7 @@ static SCAN_CODE heap_attrinfo_transform_header_to_disk (THREAD_ENTRY * thread_p
 // *INDENT-OFF*
 static SCAN_CODE heap_attrinfo_transform_columns_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * attr_info, OR_BUF * buf,
 							  std::vector<bool> * oos_columns, std::vector<OID> * oos_oids,
-							  std::vector<int> * oos_lengths,
+							  std::vector<DB_BIGINT> * oos_lengths,
 							  std::set<int> * incremented_attrids, int offset_size, int header_size,
 							  size_t mvcc_extra, int lob_create_flag, size_t * record_size);
 // *INDENT-ON*
@@ -10890,7 +10890,7 @@ heap_midxkey_get_oos_extra_size (RECDES * recdes, OR_ATTRIBUTE * att)
       return 0;
     }
 
-  /* Extract OOS length from inline data: [OOS OID (8B) + length (4B)] */
+  /* Extract OOS length from inline data: [OOS OID (8B) + length (8B)] */
   OR_BUF buf;
   OID oos_oid;
   int rc = NO_ERROR;
@@ -10901,10 +10901,10 @@ heap_midxkey_get_oos_extra_size (RECDES * recdes, OR_ATTRIBUTE * att)
   assert (!OID_ISNULL (&oos_oid));
 
   /* Read OOS length directly from recdes inline data (no I/O needed) */
-  int length = or_get_int (&buf, &rc);
+  DB_BIGINT length = or_get_bigint (&buf, &rc);
   assert (rc == NO_ERROR);
 
-  return length;
+  return (int) length;
 }
 
 /*
@@ -12321,7 +12321,7 @@ heap_attrinfo_dbvalue_to_recdes (THREAD_ENTRY * thread_p, HEAP_ATTRVALUE * value
 
 // *INDENT-OFF*
 static SCAN_CODE
-heap_attrinfo_insert_to_oos (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * attr_info, int lob_create_flag, std::vector<bool> * oos_columns, std::vector<OID> * oos_oids, std::vector<int> * oos_lengths)
+heap_attrinfo_insert_to_oos (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * attr_info, int lob_create_flag, std::vector<bool> * oos_columns, std::vector<OID> * oos_oids, std::vector<DB_BIGINT> * oos_lengths)
 // *INDENT-ON*
 
 {
@@ -12381,7 +12381,7 @@ heap_attrinfo_insert_to_oos (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * attr
 
 	  thread_p->oos_oids.push_back (oos_oid);	/* for replication log */
 	  (*oos_oids)[i] = oos_oid;
-	  (*oos_lengths)[i] = recdes.length;
+	  (*oos_lengths)[i] = (DB_BIGINT) recdes.length;
 	  if (recdes.data != PTR_ALIGN (recbuf, MAX_ALIGNMENT))
 	    {
 	      free_and_init (recdes.data);
@@ -12637,8 +12637,8 @@ heap_attrinfo_transform_fixed_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRI
  */
 static SCAN_CODE
 heap_attrinfo_transform_variable_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * attr_info, OR_BUF * buf,
-					  char **ptr_varvals, bool is_oos, OID * oos_oid, int oos_length, int index,
-					  int offset_size, int header_size, int lob_create_flag)
+					  char **ptr_varvals, bool is_oos, OID * oos_oid, DB_BIGINT oos_length,
+					  int index, int offset_size, int header_size, int lob_create_flag)
 {
   HEAP_ATTRVALUE *value;
   DB_VALUE *dbvalue;
@@ -12700,7 +12700,7 @@ heap_attrinfo_transform_variable_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_AT
 
       buf->ptr = *ptr_varvals;
       or_put_oid (buf, oos_oid);
-      or_put_int (buf, oos_length);
+      or_put_bigint (buf, oos_length);
       *ptr_varvals = buf->ptr;
     }
   else if (dbvalue != NULL && db_value_is_null (dbvalue) != true)
@@ -12785,7 +12785,7 @@ heap_attrinfo_transform_variable_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_AT
 static SCAN_CODE
 heap_attrinfo_transform_columns_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * attr_info, OR_BUF * buf,
 					 std::vector<bool> * oos_columns, std::vector<OID> * oos_oids,
-					 std::vector<int> * oos_lengths,
+					 std::vector<DB_BIGINT> * oos_lengths,
 					 std::set<int> * incremented_attrids, int offset_size, int header_size,
 					 size_t mvcc_extra, int lob_create_flag, size_t * record_size)
 // *INDENT-ON*
@@ -12878,7 +12878,7 @@ heap_attrinfo_transform_to_disk_internal (THREAD_ENTRY * thread_p, HEAP_CACHE_AT
   // *INDENT-OFF*
   std::vector<bool> oos_columns (attr_info->num_values);
   std::vector<OID> oos_oids (attr_info->num_values);
-  std::vector<int> oos_lengths (attr_info->num_values, 0);
+  std::vector<DB_BIGINT> oos_lengths (attr_info->num_values, 0);
   std::set<int> incremented_attrids;
   // *INDENT-ON*
 

--- a/unit_tests/oos/test_oos.cpp
+++ b/unit_tests/oos/test_oos.cpp
@@ -530,11 +530,11 @@ TEST (OosTest, ShouldInsertIntoDifferentPages)
 
 TEST (OosTest, OosInlineFormatWriteAndReadBack)
 {
-  /* Test that OR_OOS_INLINE_SIZE = OR_OID_SIZE + OR_INT_SIZE = 12 bytes */
-  ASSERT_EQ (OR_OOS_INLINE_SIZE, OR_OID_SIZE + OR_INT_SIZE);
-  ASSERT_EQ (OR_OOS_INLINE_SIZE, 12);
+  /* Test that OR_OOS_INLINE_SIZE = OR_OID_SIZE + OR_BIGINT_SIZE = 16 bytes */
+  ASSERT_EQ (OR_OOS_INLINE_SIZE, OR_OID_SIZE + OR_BIGINT_SIZE);
+  ASSERT_EQ (OR_OOS_INLINE_SIZE, 16);
 
-  /* Simulate writing OOS inline data: [OOS OID (8B) + length (4B)] */
+  /* Simulate writing OOS inline data: [OOS OID (8B) + length (8B)] */
   char buf_data[OR_OOS_INLINE_SIZE];
   OR_BUF write_buf;
   or_init (&write_buf, buf_data, OR_OOS_INLINE_SIZE);
@@ -543,10 +543,10 @@ TEST (OosTest, OosInlineFormatWriteAndReadBack)
   test_oid.pageid = 42;
   test_oid.slotid = 7;
   test_oid.volid = 3;
-  int test_length = 160 * 1024; /* 160 KB */
+  DB_BIGINT test_length = 160 * 1024; /* 160 KB */
 
   or_put_oid (&write_buf, &test_oid);
-  or_put_int (&write_buf, test_length);
+  or_put_bigint (&write_buf, test_length);
 
   /* Verify we wrote exactly OR_OOS_INLINE_SIZE bytes */
   ASSERT_EQ (write_buf.ptr - buf_data, OR_OOS_INLINE_SIZE);
@@ -562,7 +562,7 @@ TEST (OosTest, OosInlineFormatWriteAndReadBack)
   ASSERT_EQ (read_oid.volid, test_oid.volid);
 
   int rc = NO_ERROR;
-  int read_length = or_get_int (&read_buf, &rc);
+  DB_BIGINT read_length = or_get_bigint (&read_buf, &rc);
   ASSERT_EQ (rc, NO_ERROR);
   ASSERT_EQ (read_length, test_length);
 }
@@ -587,12 +587,12 @@ TEST (OosTest, OosInlineFormatWithRealOosInsert)
   err = oos_insert (thread_p, oos_vfid, rec_in, oos_oid);
   ASSERT_EQ (err, NO_ERROR);
 
-  /* Build inline OOS data: [OOS OID (8B) + length (4B)] */
+  /* Build inline OOS data: [OOS OID (8B) + length (8B)] */
   char inline_buf[OR_OOS_INLINE_SIZE];
   OR_BUF write_buf;
   or_init (&write_buf, inline_buf, OR_OOS_INLINE_SIZE);
   or_put_oid (&write_buf, &oos_oid);
-  or_put_int (&write_buf, rec_in.length);
+  or_put_bigint (&write_buf, (DB_BIGINT) rec_in.length);
 
   /* Read back OID and length from inline data */
   OR_BUF read_buf;
@@ -605,13 +605,13 @@ TEST (OosTest, OosInlineFormatWithRealOosInsert)
   ASSERT_EQ (read_oid.volid, oos_oid.volid);
 
   int rc = NO_ERROR;
-  int read_length = or_get_int (&read_buf, &rc);
+  DB_BIGINT read_length = or_get_bigint (&read_buf, &rc);
   ASSERT_EQ (rc, NO_ERROR);
-  ASSERT_EQ (read_length, rec_in.length);
+  ASSERT_EQ (read_length, (DB_BIGINT) rec_in.length);
 
   /* Verify that the inline length matches what oos_get_length returns (via I/O) */
   int oos_length = oos_get_length (thread_p, oos_oid);
-  ASSERT_EQ (read_length, oos_length);
+  ASSERT_EQ (read_length, (DB_BIGINT) oos_length);
 
   recdes_free_data_area (&rec_in);
 }
@@ -647,7 +647,7 @@ TEST (OosTest, OosInlineLengthMatchesAcrossPages)
       OR_BUF write_buf;
       or_init (&write_buf, inline_buf, OR_OOS_INLINE_SIZE);
       or_put_oid (&write_buf, &oos_oid);
-      or_put_int (&write_buf, rec_in.length);
+      or_put_bigint (&write_buf, (DB_BIGINT) rec_in.length);
 
       /* Read back length from inline data */
       OR_BUF read_buf;
@@ -656,15 +656,15 @@ TEST (OosTest, OosInlineLengthMatchesAcrossPages)
       or_get_oid (&read_buf, &read_oid);
 
       int rc = NO_ERROR;
-      int inline_length = or_get_int (&read_buf, &rc);
+      DB_BIGINT inline_length = or_get_bigint (&read_buf, &rc);
       ASSERT_EQ (rc, NO_ERROR);
 
       /* Inline length must equal original data length */
-      ASSERT_EQ (inline_length, rec_in.length) << "Failed for data_size=" << data_size;
+      ASSERT_EQ (inline_length, (DB_BIGINT) rec_in.length) << "Failed for data_size=" << data_size;
 
       /* Inline length must match oos_get_length (I/O-based) */
       int io_length = oos_get_length (thread_p, oos_oid);
-      ASSERT_EQ (inline_length, io_length) << "Failed for data_size=" << data_size;
+      ASSERT_EQ (inline_length, (DB_BIGINT) io_length) << "Failed for data_size=" << data_size;
 
       recdes_free_data_area (&rec_in);
     }

--- a/unit_tests/oos/test_oos.cpp
+++ b/unit_tests/oos/test_oos.cpp
@@ -22,6 +22,7 @@
 #include "page_buffer.h"
 #include "slotted_page.h"
 #include "storage_common.h"
+#include "object_representation.h"
 #include "oos_file.hpp"
 #include "test_oos_common.hpp"
 #include "page_buffer_util.hpp"
@@ -525,6 +526,148 @@ TEST (OosTest, ShouldInsertIntoDifferentPages)
   }
 
   // TODO
+}
+
+TEST (OosTest, OosInlineFormatWriteAndReadBack)
+{
+  /* Test that OR_OOS_INLINE_SIZE = OR_OID_SIZE + OR_INT_SIZE = 12 bytes */
+  ASSERT_EQ (OR_OOS_INLINE_SIZE, OR_OID_SIZE + OR_INT_SIZE);
+  ASSERT_EQ (OR_OOS_INLINE_SIZE, 12);
+
+  /* Simulate writing OOS inline data: [OOS OID (8B) + length (4B)] */
+  char buf_data[OR_OOS_INLINE_SIZE];
+  OR_BUF write_buf;
+  or_init (&write_buf, buf_data, OR_OOS_INLINE_SIZE);
+
+  OID test_oid;
+  test_oid.pageid = 42;
+  test_oid.slotid = 7;
+  test_oid.volid = 3;
+  int test_length = 160 * 1024; /* 160 KB */
+
+  or_put_oid (&write_buf, &test_oid);
+  or_put_int (&write_buf, test_length);
+
+  /* Verify we wrote exactly OR_OOS_INLINE_SIZE bytes */
+  ASSERT_EQ (write_buf.ptr - buf_data, OR_OOS_INLINE_SIZE);
+
+  /* Read back: simulate what heap_midxkey_get_oos_extra_size does */
+  OR_BUF read_buf;
+  or_init (&read_buf, buf_data, OR_OOS_INLINE_SIZE);
+
+  OID read_oid;
+  or_get_oid (&read_buf, &read_oid);
+  ASSERT_EQ (read_oid.pageid, test_oid.pageid);
+  ASSERT_EQ (read_oid.slotid, test_oid.slotid);
+  ASSERT_EQ (read_oid.volid, test_oid.volid);
+
+  int rc = NO_ERROR;
+  int read_length = or_get_int (&read_buf, &rc);
+  ASSERT_EQ (rc, NO_ERROR);
+  ASSERT_EQ (read_length, test_length);
+}
+
+TEST (OosTest, OosInlineFormatWithRealOosInsert)
+{
+  /* Insert data into OOS, then verify the inline format [OID + length] round-trips correctly */
+  int err;
+  VFID oos_vfid;
+
+  err = oos_file_create (thread_p, oos_vfid);
+  ASSERT_EQ (err, NO_ERROR);
+
+  const int data_size = 2048;
+  auto data = test_oos_utils::make_repeated_pattern_string (data_size);
+
+  RECDES rec_in{};
+  err = test_oos_utils::from_string_into_recdes (data, rec_in);
+  ASSERT_EQ (err, NO_ERROR);
+
+  OID oos_oid;
+  err = oos_insert (thread_p, oos_vfid, rec_in, oos_oid);
+  ASSERT_EQ (err, NO_ERROR);
+
+  /* Build inline OOS data: [OOS OID (8B) + length (4B)] */
+  char inline_buf[OR_OOS_INLINE_SIZE];
+  OR_BUF write_buf;
+  or_init (&write_buf, inline_buf, OR_OOS_INLINE_SIZE);
+  or_put_oid (&write_buf, &oos_oid);
+  or_put_int (&write_buf, rec_in.length);
+
+  /* Read back OID and length from inline data */
+  OR_BUF read_buf;
+  or_init (&read_buf, inline_buf, OR_OOS_INLINE_SIZE);
+
+  OID read_oid;
+  or_get_oid (&read_buf, &read_oid);
+  ASSERT_EQ (read_oid.pageid, oos_oid.pageid);
+  ASSERT_EQ (read_oid.slotid, oos_oid.slotid);
+  ASSERT_EQ (read_oid.volid, oos_oid.volid);
+
+  int rc = NO_ERROR;
+  int read_length = or_get_int (&read_buf, &rc);
+  ASSERT_EQ (rc, NO_ERROR);
+  ASSERT_EQ (read_length, rec_in.length);
+
+  /* Verify that the inline length matches what oos_get_length returns (via I/O) */
+  int oos_length = oos_get_length (thread_p, oos_oid);
+  ASSERT_EQ (read_length, oos_length);
+
+  recdes_free_data_area (&rec_in);
+}
+
+TEST (OosTest, OosInlineLengthMatchesAcrossPages)
+{
+  /* Test with data spanning multiple OOS pages to ensure inline length is correct */
+  int err;
+  VFID oos_vfid;
+
+  err = oos_file_create (thread_p, oos_vfid);
+  ASSERT_EQ (err, NO_ERROR);
+
+  const int max_chunk_size = bridge_oos_get_max_chunk_size_within_page ();
+
+  /* Test sizes: within page, at boundary, and across pages */
+  int test_sizes[] = { 512, max_chunk_size - 1, max_chunk_size, max_chunk_size + 1, 160 * 1024 };
+
+  for (int data_size : test_sizes)
+    {
+      auto data = test_oos_utils::make_repeated_pattern_string (data_size);
+
+      RECDES rec_in{};
+      err = test_oos_utils::from_string_into_recdes (data, rec_in);
+      ASSERT_EQ (err, NO_ERROR);
+
+      OID oos_oid;
+      err = oos_insert (thread_p, oos_vfid, rec_in, oos_oid);
+      ASSERT_EQ (err, NO_ERROR);
+
+      /* Write inline format */
+      char inline_buf[OR_OOS_INLINE_SIZE];
+      OR_BUF write_buf;
+      or_init (&write_buf, inline_buf, OR_OOS_INLINE_SIZE);
+      or_put_oid (&write_buf, &oos_oid);
+      or_put_int (&write_buf, rec_in.length);
+
+      /* Read back length from inline data */
+      OR_BUF read_buf;
+      or_init (&read_buf, inline_buf, OR_OOS_INLINE_SIZE);
+      OID read_oid;
+      or_get_oid (&read_buf, &read_oid);
+
+      int rc = NO_ERROR;
+      int inline_length = or_get_int (&read_buf, &rc);
+      ASSERT_EQ (rc, NO_ERROR);
+
+      /* Inline length must equal original data length */
+      ASSERT_EQ (inline_length, rec_in.length) << "Failed for data_size=" << data_size;
+
+      /* Inline length must match oos_get_length (I/O-based) */
+      int io_length = oos_get_length (thread_p, oos_oid);
+      ASSERT_EQ (inline_length, io_length) << "Failed for data_size=" << data_size;
+
+      recdes_free_data_area (&rec_in);
+    }
 }
 
 int main (int argc, char **argv)

--- a/unit_tests/oos/test_oos.cpp
+++ b/unit_tests/oos/test_oos.cpp
@@ -613,7 +613,14 @@ TEST (OosTest, OosInlineFormatWithRealOosInsert)
   int oos_length = oos_get_length (thread_p, oos_oid);
   ASSERT_EQ (read_length, (DB_BIGINT) oos_length);
 
+  /* Verify that oos_read returns a recdes whose length matches the inline length */
+  RECDES rec_out{};
+  err = oos_read (thread_p, oos_oid, rec_out);
+  ASSERT_EQ (err, NO_ERROR);
+  ASSERT_EQ (read_length, (DB_BIGINT) rec_out.length);
+
   recdes_free_data_area (&rec_in);
+  recdes_free_data_area (&rec_out);
 }
 
 TEST (OosTest, OosInlineLengthMatchesAcrossPages)
@@ -666,7 +673,14 @@ TEST (OosTest, OosInlineLengthMatchesAcrossPages)
       int io_length = oos_get_length (thread_p, oos_oid);
       ASSERT_EQ (inline_length, (DB_BIGINT) io_length) << "Failed for data_size=" << data_size;
 
+      /* Inline length must match oos_read recdes length */
+      RECDES rec_out{};
+      err = oos_read (thread_p, oos_oid, rec_out);
+      ASSERT_EQ (err, NO_ERROR);
+      ASSERT_EQ (inline_length, (DB_BIGINT) rec_out.length) << "Failed for data_size=" << data_size;
+
       recdes_free_data_area (&rec_in);
+      recdes_free_data_area (&rec_out);
     }
 }
 


### PR DESCRIPTION


<http://jira.cubrid.org/browse/CBRD-26630>

### Purpose / 목적

OOS 변수 속성이 저장될 때, heap recdes에 OOS OID(8바이트)와 OOS 데이터 길이(8바이트, `DB_BIGINT`)를 함께 인라인으로 저장하도록 변경합니다. 총 16바이트(`OR_OOS_INLINE_SIZE`)를 사용합니다.

이를 통해 OOS 데이터 크기를 파악할 때 `oos_get_length()`를 통한 추가 페이지 I/O가 불필요해집니다.

- 기존: OOS 변수 속성의 인라인 데이터에 OOS OID(8바이트)만 저장
- 문제: OOS 데이터의 실제 크기를 알기 위해 `oos_get_length()` 호출 시 OOS 페이지를 읽는 추가 I/O 발생
- 개선: OOS OID 옆에 길이 정보(8바이트)를 함께 저장하여 I/O 없이 크기 파악 가능



```txt
Heap Record (variable area)
┌─────────────────────────────────────────────────┐
│  ...  │  OOS column (inline)        │  ...      │
│       ├─────────────┬───────────────┤           │
│       │ OOS OID     │ OOS length    │           │
│       │ (8 bytes)   │ (8 bytes)     │           │
│       ├─────────────┼───────────────┤           │
│       │ volid  (2B) │               │           │
│       │ pageid (4B) │   DB_BIGINT   │           │
│       │ slotid (2B) │               │           │
│       ├─────────────┴───────┬───────┘           │
│       │  total: 16 bytes    │                   │
│       │  (OR_OOS_INLINE_SIZE)                   │
└─────────────────────────────────────────────────┘
         │                    │
         │  OOS OID points    │  length = size of
         │  to OOS pages      │  OOS data (no I/O
         ▼                    │  needed to read)
┌─────────────────┐           │
│  OOS Page(s)    │           │
│ ┌─────────────┐ │           │
│ │ chunk 1     │ │           │
│ │ (data...)   │ │           │
│ ├─────────────┤ │           │
│ │ chunk 2     │ │           │
│ │ (data...)   │ │           │
│ └─────────────┘ │           │
│  total = length ◄───────────┘
└─────────────────┘
```

Before (CBRD-26565): inline stored only OOS OID (8B), requiring `oos_get_length()` I/O to get size.
After (this PR): inline stores OOS OID + length (16B), eliminating I/O in `heap_midxkey_get_oos_extra_size()`.

### Implementation / 구현 내용

**`src/base/object_representation.h`**
- `OR_OOS_INLINE_SIZE` 매크로 추가 (`OR_OID_SIZE + OR_BIGINT_SIZE` = 16바이트)

**`src/storage/heap_file.c`**
- `heap_attrinfo_determine_disk_layout()`: OOS 컬럼 크기 계산 시 `OR_OID_SIZE` → `OR_OOS_INLINE_SIZE`로 변경
- `heap_attrinfo_insert_to_oos()`: OOS 삽입 후 길이 정보를 `oos_lengths` 벡터에 기록
- `heap_attrinfo_transform_variable_to_disk()`: OOS OID 기록 후 `or_put_bigint(buf, oos_length)`로 길이도 기록
- `heap_attrinfo_transform_columns_to_disk()`: `oos_lengths` 벡터 전달
- `heap_attrinfo_transform_to_disk_internal()`: `oos_lengths` 벡터 선언 및 파이프라인 전달
- `heap_midxkey_get_oos_extra_size()`: `oos_get_length()` I/O 호출 제거, recdes 인라인 데이터에서 `or_get_bigint()`로 직접 읽기

**변경 불필요한 부분**
- `heap_attrvalue_point_variable()`: `or_get_oid`가 8바이트만 읽으므로 영향 없음
- `locator_fixup_oos_oids_in_recdes()`: `or_put_oid`가 8바이트만 덮어쓰므로 길이 필드는 보존됨

**`unit_tests/oos/test_oos.cpp`**
- `OosInlineFormatWriteAndReadBack`: 순수 직렬화 라운드트립 테스트
- `OosInlineFormatWithRealOosInsert`: 실제 OOS 삽입 후 인라인 길이와 I/O 기반 길이 일치 검증
- `OosInlineLengthMatchesAcrossPages`: 다양한 크기(512B, 경계값, 160KB)에서 인라인 길이 정확성 검증

### Remarks / 비고

- 인라인 OOS 데이터 포맷: `[OOS OID (8B) | OOS length (8B)]` = 16바이트
- 레코드당 OOS 컬럼마다 8바이트 추가 사용 (기존 8B → 16B)
- OOS length를 `DB_BIGINT`(8바이트)로 저장하는 이유: 현재 `recdes.length`는 `int`(4B)이지만, 향후 대용량 OOS 데이터 지원을 위해 8바이트로 설계
- midxkey 버퍼 크기 추정 시 페이지 I/O 제거로 성능 향상