### PR TITLE
[CBRD-26621] [bug] drop trigger, ERROR: Object found in workspace without class.

### DIFF
--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -6367,7 +6367,7 @@ locator_delete_force_internal (THREAD_ENTRY * thread_p, HFID * hfid, OID * oid, 
 	}
 
       /* remove query result cache entries which are relevant with this class */
-      if (!QFILE_IS_LIST_CACHE_DISABLED)
+      if (!QFILE_IS_LIST_CACHE_DISABLED && !OID_ISNULL (&class_oid))
 	{
 	  OID superclass_oid;
 	  OID real_class_oid;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26621>

### Purpose

다음 쿼리 시나리오에서 에러가 발생하는 문제(버그) 패치
echo "max_query_cache_entries = 100" >> $CUBRID/conf/cubrid.conf
echo "query_cache_size_in_pages = 10" >> $CUBRID/conf/cubrid.conf

csql --no-auto-commit -S demodb

call login('dba') on class db_user;
create user test_user ;
call login('test_user') on class db_user;
create class test_class(col1 integer, col2 varchar(20));
create trigger test_trigger
after rollback
execute print 'rollback by test_user';
select * from db_user where name = 'TEST_USER';
drop trigger test_trigger;

ERROR: Object found in workspace without class

### Implementation

drop trigger에서 호출하는 locator_delete_force_internal 루티에서 partition_prune_update를 호출하기 전에 class_oid가 NULL인지를 체크하도록 수정

### Remarks

이전 버전 (11.4 이하, 10.2 이하) 확인 필요
