### PR TITLE
[CBRD-26631] add collection_to_string sql function for partition_description of information_schema.partitions

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/SymbolStack.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/SymbolStack.java
@@ -406,6 +406,7 @@ public class SymbolStack {
 
                         // data type casting
                         "CAST",
+                        "COLLECTION_TO_STRING",
                         "DATE_FORMAT",
                         "FORMAT",
                         "STR_TO_DATE",

--- a/src/base/object_representation.h
+++ b/src/base/object_representation.h
@@ -1052,6 +1052,7 @@ extern "C"
   extern int db_enum_put_cs_and_collation (DB_VALUE * value, const int codeset, const int collation_id);
 
   extern int valcnv_convert_value_to_string (DB_VALUE * value);
+  extern int valcnv_convert_collection_value_to_string_all_elements (DB_VALUE * value);
 
 #if defined __cplusplus
 }

--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -84,6 +84,7 @@ bool db_Keep_session = false;
 int db_Row_count = DB_ROW_COUNT_NOT_SET;
 
 static thread_local int valcnv_Max_set_elements = 10;
+static thread_local bool valcnv_Quote_strings = false;
 
 #if defined(SERVER_MODE)
 int db_Connect_status = DB_CONNECTION_STATUS_CONNECTED;
@@ -2714,6 +2715,30 @@ valcnv_convert_db_value_to_string (VALCNV_BUFFER * buffer_p, const DB_VALUE * va
 	  buffer_p = valcnv_append_string (buffer_p, "'");
 	  break;
 
+	case DB_TYPE_CHAR:
+	case DB_TYPE_VARCHAR:
+	  if (valcnv_Quote_strings)
+	    {
+	      buffer_p = valcnv_append_string (buffer_p, "'");
+	      if (buffer_p == NULL)
+		{
+		  return NULL;
+		}
+
+	      buffer_p = valcnv_convert_data_to_string (buffer_p, value_p);
+	      if (buffer_p == NULL)
+		{
+		  return NULL;
+		}
+
+	      buffer_p = valcnv_append_string (buffer_p, "'");
+	    }
+	  else
+	    {
+	      buffer_p = valcnv_convert_data_to_string (buffer_p, value_p);
+	    }
+	  break;
+
 	default:
 	  buffer_p = valcnv_convert_data_to_string (buffer_p, value_p);
 	  break;
@@ -2763,16 +2788,21 @@ valcnv_convert_value_to_string (DB_VALUE * value_p)
 int
 valcnv_convert_collection_value_to_string_all_elements (DB_VALUE * value_p)
 {
-  int save = valcnv_Max_set_elements;
-  int err;
+  int save_max = valcnv_Max_set_elements;
+  bool save_quote = valcnv_Quote_strings;
+  int error = NO_ERROR;
 
   assert (db_value_type_is_collection (value_p));
 
   valcnv_Max_set_elements = 0;
-  err = valcnv_convert_value_to_string (value_p);
-  valcnv_Max_set_elements = save;
+  valcnv_Quote_strings = true;
 
-  return err;
+  error = valcnv_convert_value_to_string (value_p);
+
+  valcnv_Max_set_elements = save_max;
+  valcnv_Quote_strings = save_quote;
+
+  return error;
 }
 
 int

--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -83,7 +83,7 @@ bool db_Keep_session = false;
 
 int db_Row_count = DB_ROW_COUNT_NOT_SET;
 
-static int valcnv_Max_set_elements = 10;
+static thread_local int valcnv_Max_set_elements = 10;
 
 #if defined(SERVER_MODE)
 int db_Connect_status = DB_CONNECTION_STATUS_CONNECTED;
@@ -2758,6 +2758,21 @@ valcnv_convert_value_to_string (DB_VALUE * value_p)
     }
 
   return NO_ERROR;
+}
+
+int
+valcnv_convert_collection_value_to_string_all_elements (DB_VALUE * value_p)
+{
+  int save = valcnv_Max_set_elements;
+  int err;
+
+  assert (db_value_type_is_collection (value_p));
+
+  valcnv_Max_set_elements = 0;
+  err = valcnv_convert_value_to_string (value_p);
+  valcnv_Max_set_elements = save;
+
+  return err;
 }
 
 int

--- a/src/object/schema_information_schema_install.cpp
+++ b/src/object/schema_information_schema_install.cpp
@@ -376,7 +376,7 @@ namespace cubschema
       {"partition_ordinal_position", "integer"},
       {"partition_method", format_varchar (5)},
       {"partition_expression", format_varchar (2048)},
-      {"partition_description", format_varchar (1024)},
+      {"partition_description", "string"},
       {"subpartition_name", format_varchar (255)},
       {"subpartition_ordinal_position", "integer"},
       {"subpartition_method", format_varchar (5)},

--- a/src/object/schema_information_schema_install.cpp
+++ b/src/object/schema_information_schema_install.cpp
@@ -376,8 +376,7 @@ namespace cubschema
       {"partition_ordinal_position", "integer"},
       {"partition_method", format_varchar (5)},
       {"partition_expression", format_varchar (2048)},
-      /* TODO: create a function for converting sequence to varchar */
-      {"partition_description", "sequence of"},
+      {"partition_description", format_varchar (1024)},
       {"subpartition_name", format_varchar (255)},
       {"subpartition_ordinal_position", "integer"},
       {"subpartition_method", format_varchar (5)},

--- a/src/object/schema_information_schema_install_query_spec.cpp
+++ b/src/object/schema_information_schema_install_query_spec.cpp
@@ -426,7 +426,7 @@ const char *sm_define_view_partitions_spec (void)
       "DECODE ([part].[ptype], %d, 'HASH', %d, 'RANGE', %d, 'LIST') AS [partition_method], "
       "[part_info].[pexpr] AS [partition_expression], "
       /* DB_PARTITION_RANGE, DB_PARTITION_LIST */
-      "IF ([part].[ptype] IN (%d, %d), [part].[pvalues], NULL) AS [partition_description], "
+      "IF ([part].[ptype] IN (%d, %d), COLLECTION_TO_STRING ([part].[pvalues]), NULL) AS [partition_description], "
       "NULL AS [subpartition_name], "
       "NULL AS [subpartition_ordinal_position], "
       "NULL AS [subpartition_method], "

--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -3372,6 +3372,7 @@ get_opcode_rank (PT_OP_TYPE opcode)
     case PT_TO_TIMESTAMP_TZ:
     case PT_CRC32:
     case PT_CONV_TZ:
+    case PT_COLLECTION_TO_STRING:
       return RANK_EXPR_MEDIUM;
 
       /* Group 3 -- heavy */

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -24030,6 +24030,7 @@ parser_keyword_func (const char *name, PT_NODE * args)
     case PT_CRC32:
     case PT_SCHEMA_DEF:
     case PT_DISK_SIZE:
+    case PT_COLLECTION_TO_STRING:
       {
 	PT_NODE *expr;
 	if (c != 1)

--- a/src/parser/keyword.c
+++ b/src/parser/keyword.c
@@ -771,6 +771,7 @@ static FUNCTION_MAP functions[] = {
   {0, "crc32", PT_CRC32},
   {0, "schema_def", PT_SCHEMA_DEF},
   {0, "conv_tz", PT_CONV_TZ},
+  {0, "collection_to_string", PT_COLLECTION_TO_STRING},
 };
 
 

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -1519,6 +1519,7 @@ typedef enum
   PT_CRC32,
   PT_SCHEMA_DEF,
   PT_CONV_TZ,
+  PT_COLLECTION_TO_STRING,
 
   /* This is the last entry. Please add a new one before it. */
   PT_LAST_OPCODE

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -4090,6 +4090,8 @@ pt_show_binopcode (PT_OP_TYPE n)
       return "schema_def";
     case PT_CONV_TZ:
       return "conv_tz";
+    case PT_COLLECTION_TO_STRING:
+      return "collection_to_string";
     default:
       assert (false);
       return "unknown opcode";
@@ -12369,6 +12371,12 @@ pt_print_expr (PARSER_CONTEXT * parser, PT_NODE * p)
     case PT_SCHEMA_DEF:
       r1 = pt_print_bytes (parser, p->info.expr.arg1);
       q = pt_append_nulstring (parser, q, " schema_def(");
+      q = pt_append_varchar (parser, q, r1);
+      q = pt_append_nulstring (parser, q, ")");
+      break;
+    case PT_COLLECTION_TO_STRING:
+      r1 = pt_print_bytes (parser, p->info.expr.arg1);
+      q = pt_append_nulstring (parser, q, " collection_to_string(");
       q = pt_append_varchar (parser, q, r1);
       q = pt_append_nulstring (parser, q, ")");
       break;

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -17535,16 +17535,12 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	}
 
     case PT_COLLECTION_TO_STRING:
-      db_value_clone (arg1, &tmp_val);
-      error = valcnv_convert_value_to_string (&tmp_val);
-      if (error != NO_ERROR)
+      error = db_collection_to_string_dbval (result, arg1);
+      if (error < 0)
 	{
-	  db_value_clear (&tmp_val);
 	  PT_ERRORc (parser, o1, er_msg ());
 	  return 0;
 	}
-      db_value_clone (&tmp_val, result);
-      db_value_clear (&tmp_val);
       return 1;
 
     default:

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -4449,6 +4449,23 @@ pt_get_expression_definition (const PT_OP_TYPE op, EXPRESSION_DEFINITION * def)
       def->overloads_count = num;
       break;
 
+    case PT_COLLECTION_TO_STRING:
+      num = 0;
+
+      /* one overload */
+
+      /* arg1 */
+      sig.arg1_type.type = pt_arg_type::GENERIC;
+      sig.arg1_type.val.generic_type = PT_GENERIC_TYPE_SEQUENCE;
+
+      /* return type */
+      sig.return_type.type = pt_arg_type::NORMAL;
+      sig.return_type.val.type = PT_TYPE_VARCHAR;
+      def->overloads[num++] = sig;
+
+      def->overloads_count = num;
+      break;
+
     default:
       return false;
     }
@@ -6335,6 +6352,7 @@ pt_is_symmetric_op (const PT_OP_TYPE op)
     case PT_CRC32:
     case PT_SCHEMA_DEF:
     case PT_CONV_TZ:
+    case PT_COLLECTION_TO_STRING:
       return false;
 
     default:
@@ -8626,6 +8644,7 @@ pt_is_able_to_determine_return_type (const PT_OP_TYPE op)
     case PT_CRC32:
     case PT_DISK_SIZE:
     case PT_SCHEMA_DEF:
+    case PT_COLLECTION_TO_STRING:
       return true;
 
     default:
@@ -9093,6 +9112,16 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
 	    goto error;
 	  }
       }
+      break;
+
+    case PT_COLLECTION_TO_STRING:
+      if (arg1_type != PT_TYPE_NULL && !PT_IS_COLLECTION_TYPE (arg1_type))
+	{
+	  PT_ERRORmf2 (parser, arg1, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_CANT_COERCE_TO,
+		       pt_short_print (parser, arg1), "collection type");
+	  node->type_enum = PT_TYPE_NONE;
+	  goto error;
+	}
       break;
 
     default:
@@ -11822,6 +11851,7 @@ pt_upd_domain_info (PARSER_CONTEXT * parser, PT_NODE * arg1, PT_NODE * arg2, PT_
     case PT_SUBSTRING:
     case PT_COERCIBILITY:
     case PT_INDEX_PREFIX:
+    case PT_COLLECTION_TO_STRING:
       assert (dt == NULL);
       dt = pt_make_prim_data_type (parser, node->type_enum);
       dt->info.data_type.precision = TP_FLOATING_PRECISION_VALUE;
@@ -17503,6 +17533,19 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 	{
 	  return 1;
 	}
+
+    case PT_COLLECTION_TO_STRING:
+      db_value_clone (arg1, &tmp_val);
+      error = valcnv_convert_value_to_string (&tmp_val);
+      if (error != NO_ERROR)
+	{
+	  db_value_clear (&tmp_val);
+	  PT_ERRORc (parser, o1, er_msg ());
+	  return 0;
+	}
+      db_value_clone (&tmp_val, result);
+      db_value_clear (&tmp_val);
+      return 1;
 
     default:
       break;

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -9115,7 +9115,7 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
       break;
 
     case PT_COLLECTION_TO_STRING:
-      if (arg1_type != PT_TYPE_NULL && !PT_IS_COLLECTION_TYPE (arg1_type))
+      if (arg1_type != PT_TYPE_NULL && arg1_type != PT_TYPE_MAYBE && !PT_IS_COLLECTION_TYPE (arg1_type))
 	{
 	  PT_ERRORmf2 (parser, arg1, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_CANT_COERCE_TO,
 		       pt_short_print (parser, arg1), "collection type");

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -7891,7 +7891,8 @@ pt_to_regu_variable (PARSER_CONTEXT * parser, PT_NODE * node, UNBOX unbox)
 		       || node->info.expr.op == PT_TO_BASE64 || node->info.expr.op == PT_FROM_BASE64
 		       || node->info.expr.op == PT_FROM_BASE64 || node->info.expr.op == PT_SLEEP
 		       || node->info.expr.op == PT_TZ_OFFSET || node->info.expr.op == PT_CRC32
-		       || node->info.expr.op == PT_DISK_SIZE || node->info.expr.op == PT_CONV_TZ)
+		       || node->info.expr.op == PT_DISK_SIZE || node->info.expr.op == PT_CONV_TZ
+		       || node->info.expr.op == PT_COLLECTION_TO_STRING)
 		{
 		  r1 = NULL;
 
@@ -9430,6 +9431,10 @@ pt_to_regu_variable (PARSER_CONTEXT * parser, PT_NODE * node, UNBOX unbox)
 
 		case PT_CRC32:
 		  regu = pt_make_regu_arith (r1, r2, NULL, T_CRC32, domain);
+		  break;
+
+		case PT_COLLECTION_TO_STRING:
+		  regu = pt_make_regu_arith (r1, r2, NULL, T_COLLECTION_TO_STRING, domain);
 		  break;
 
 		default:

--- a/src/query/arithmetic.c
+++ b/src/query/arithmetic.c
@@ -5062,7 +5062,7 @@ db_collection_to_string_dbval (DB_VALUE * result, DB_VALUE * value)
       return error;
     }
 
-  error = valcnv_convert_value_to_string (result);
+  error = valcnv_convert_collection_value_to_string_all_elements (result);
   if (error != NO_ERROR)
     {
       db_value_clear (result);

--- a/src/query/arithmetic.c
+++ b/src/query/arithmetic.c
@@ -5039,6 +5039,39 @@ error:
     }
 }
 
+/*
+ * db_collection_to_string_dbval()
+ *   return: error code
+ *   result(out):
+ *   value(in) : input db_value (collection type)
+ */
+int
+db_collection_to_string_dbval (DB_VALUE * result, DB_VALUE * value)
+{
+  int error = NO_ERROR;
+
+  if (DB_IS_NULL (value))
+    {
+      db_make_null (result);
+      return NO_ERROR;
+    }
+
+  error = db_value_clone (value, result);
+  if (error != NO_ERROR)
+    {
+      return error;
+    }
+
+  error = valcnv_convert_value_to_string (result);
+  if (error != NO_ERROR)
+    {
+      db_value_clear (result);
+      return error;
+    }
+
+  return error;
+}
+
 int
 db_evaluate_json_contains (DB_VALUE * result, DB_VALUE * const *arg, int const num_args)
 {

--- a/src/query/arithmetic.h
+++ b/src/query/arithmetic.h
@@ -66,6 +66,7 @@ extern int db_width_bucket (DB_VALUE * result, const DB_VALUE * value1, const DB
  */
 extern int db_sleep (DB_VALUE * result, DB_VALUE * value);
 extern int db_crc32_dbval (DB_VALUE * result, DB_VALUE * value);
+extern int db_collection_to_string_dbval (DB_VALUE * result, DB_VALUE * value);
 extern int db_least_or_greatest (DB_VALUE * arg1, DB_VALUE * arg2, DB_VALUE * result, bool least);
 
 // json functions

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -509,6 +509,7 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, val_descr *
     case T_SLEEP:
     case T_CRC32:
     case T_CONV_TZ:
+    case T_COLLECTION_TO_STRING:
       /* fetch rhs value */
       if (fetch_peek_dbval (thread_p, arithptr->rightptr, vd, NULL, obj_oid, tpl, &peek_right) != NO_ERROR)
 	{
@@ -3732,6 +3733,24 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, val_descr *
       else if (db_crc32_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
 	  goto error;
+	}
+      break;
+
+    case T_COLLECTION_TO_STRING:
+      if (DB_IS_NULL (peek_right))
+	{
+	  PRIM_SET_NULL (arithptr->value);
+	}
+      else
+	{
+	  if (db_value_clone (peek_right, arithptr->value) != NO_ERROR)
+	    {
+	      goto error;
+	    }
+	  if (valcnv_convert_value_to_string (arithptr->value) != NO_ERROR)
+	    {
+	      goto error;
+	    }
 	}
       break;
 

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -3737,20 +3737,9 @@ fetch_peek_arith (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, val_descr *
       break;
 
     case T_COLLECTION_TO_STRING:
-      if (DB_IS_NULL (peek_right))
+      if (db_collection_to_string_dbval (arithptr->value, peek_right) != NO_ERROR)
 	{
-	  PRIM_SET_NULL (arithptr->value);
-	}
-      else
-	{
-	  if (db_value_clone (peek_right, arithptr->value) != NO_ERROR)
-	    {
-	      goto error;
-	    }
-	  if (valcnv_convert_value_to_string (arithptr->value) != NO_ERROR)
-	    {
-	      goto error;
-	    }
+	  goto error;
 	}
       break;
 

--- a/src/storage/storage_common.h
+++ b/src/storage/storage_common.h
@@ -850,6 +850,7 @@ typedef enum
   T_CURRENT_DATE,
   T_CURRENT_TIME,
   T_CONV_TZ,
+  T_COLLECTION_TO_STRING,
 } OPERATOR_TYPE;		/* arithmetic operator types */
 
 /************************************************************************/


### PR DESCRIPTION
[<http://jira.cubrid.org/browse/CBRD-26631>](http://jira.cubrid.org/browse/CBRD-26631)

### Purpose
- `information_schema.partitions` 뷰의 `partition_description` 컬럼이 collection 타입을 그대로 노출하던 문제를 해결하기 위해, collection → VARCHAR 변환 내장 함수 `COLLECTION_TO_STRING`을 추가

### Implementation
- **SQL 내장 함수 `COLLECTION_TO_STRING` 신규 등록**
  - `PT_COLLECTION_TO_STRING` / `T_COLLECTION_TO_STRING` opcode 추가
  - keyword.c, csql_grammar.y에 1인자 함수로 등록
- **타입 체크 파이프라인 (type_checking.c)**
  - signature: `PT_GENERIC_TYPE_SEQUENCE` → `PT_TYPE_VARCHAR` (SET/MULTISET/SEQUENCE 모두 수용)
  - 클라이언트 측 상수 폴딩: `valcnv_convert_value_to_string`으로 리터럴 collection을 컴파일 타임에 변환
- **서버 측 실행 (fetch.c)**
  - `fetch_peek_arith`에 `T_COLLECTION_TO_STRING` case 추가, `valcnv_convert_value_to_string`으로 런타임 변환
- **XASL 생성 (xasl_generation.c)**
  - `pt_to_regu_variable`의 단항 연산자 분기와 arith 노드 생성에 등록
- **information_schema.partitions 뷰 적용**
  - `partition_description` 컬럼 타입을 `sequence of` → `VARCHAR(1024)`로 변경
  - 쿼리 스펙에서 `[part].[pvalues]`를 `COLLECTION_TO_STRING([part].[pvalues])`로 감싸 반환

### Remarks
- `PT_GENERIC_TYPE_SEQUENCE`는 명칭과 달리 SET, MULTISET, SEQUENCE 세 가지 collection 타입 모두를 매칭함 (func_type.cpp의 의도적 설계). 함수명을 `SEQUENCE_TO_STRING`이 아닌 `COLLECTION_TO_STRING`으로 정한 이유
~- 문자열 요소의 변환 결과에 개별 따옴표가 포함되지 않음 (`'{a, b, c}'`). 이는 `valcnv_convert_value_to_string`의 기존 동작을 그대로 따른 것~
