### PR TITLE
[CBRD-26613] log actual error line for ER_SP_NETWORK_ERROR error (#6910)

### DIFF
--- a/src/sp/pl_connection.cpp
+++ b/src/sp/pl_connection.cpp
@@ -313,13 +313,13 @@ namespace cubpl
     int nbytes = pl_writen (m_socket, request, OR_INT_SIZE);
     if (nbytes != OR_INT_SIZE)
       {
-	return do_handle_network_error (nbytes);
+	return do_handle_network_error (ARG_FILE_LINE, nbytes);
       }
 
     nbytes = pl_writen (m_socket, blk.ptr, blk.dim);
     if (nbytes != static_cast<int> (blk.dim))
       {
-	return do_handle_network_error (nbytes);
+	return do_handle_network_error (ARG_FILE_LINE, nbytes);
       }
 
     return NO_ERROR;
@@ -338,7 +338,7 @@ namespace cubpl
 
     if (!is_valid ())
       {
-	return do_handle_network_error (-1);
+	return do_handle_network_error (ARG_FILE_LINE, -1);
       }
 
     int res_size = 0;
@@ -360,11 +360,11 @@ namespace cubpl
 		  }
 		continue;
 	      }
-	    return do_handle_network_error (-1);
+	    return do_handle_network_error (ARG_FILE_LINE, -1);
 	  }
 	if (nbytes != sizeof (int))
 	  {
-	    return do_handle_network_error (nbytes);
+	    return do_handle_network_error (ARG_FILE_LINE, nbytes);
 	  }
 	else
 	  {
@@ -378,7 +378,7 @@ namespace cubpl
     constexpr int MAX_BUFFER_SIZE = 10 * 1024 * 1024; // 10MB max size
     if (res_size > MAX_BUFFER_SIZE || res_size < 0)
       {
-	return do_handle_network_error (nbytes);
+	return do_handle_network_error (ARG_FILE_LINE, res_size);
       }
 
     if (res_size == 0)
@@ -402,7 +402,7 @@ namespace cubpl
 	  }
 	if (nbytes < 0)
 	  {
-	    return do_handle_network_error (nbytes);
+	    return do_handle_network_error (ARG_FILE_LINE, nbytes);
 	  }
 
 	total_read += nbytes;
@@ -443,7 +443,7 @@ namespace cubpl
   }
 
   int
-  connection::do_handle_network_error (int nbytes)
+  connection::do_handle_network_error (const char *file_name, const int line_no, int nbytes)
   {
     (void) invalidate ();
 
@@ -455,7 +455,7 @@ namespace cubpl
       }
     else
       {
-	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_SP_NETWORK_ERROR, 1, nbytes);
+	er_set (ER_ERROR_SEVERITY, file_name, line_no, ER_SP_NETWORK_ERROR, 1, nbytes);
 	m_error = er_errid ();
       }
 

--- a/src/sp/pl_connection.hpp
+++ b/src/sp/pl_connection.hpp
@@ -154,7 +154,7 @@ namespace cubpl
       explicit connection (connection_pool *pool, int index);
 
       void do_reconnect ();
-      int do_handle_network_error (int nbytes);
+      int do_handle_network_error (const char *file_name, const int line_no, int nbytes);
 
       SOCKET get_socket () const;
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26613>

### Purpose

싸이트에서 발생한 ER_SP_NETWORK_ERROR 에러에 대해서 
발생 가능한 코드 상 위치 7가지 중 하나를 특정하기 위함.

### Implementation

실제 에러 발생 코드 위치를 출력하도록 수정
develop 브랜치에 적용한 수정을 cherry-pick
