### PR TITLE
[CBRD-26541] Target table dropped via synonym in DROP statement with unspecified object type

### DIFF
--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -9917,30 +9917,33 @@ pt_check_drop (PARSER_CONTEXT * parser, PT_NODE * node)
 	    }
 	}
     }
-
-  for (temp = node->info.drop.spec_list; temp && temp->node_type == PT_SPEC; temp = temp->next)
+  else
     {
-      if ((name = temp->info.spec.entity_name) != NULL && name->node_type == PT_NAME
-	  && (entity_name = name->info.name.original) != NULL)
+      for (temp = node->info.drop.spec_list; temp && temp->node_type == PT_SPEC; temp = temp->next)
 	{
-	  /* We cannot change the schema of a class by using synonym names. */
-	  if (db_find_synonym (entity_name) != NULL)
+	  if ((name = temp->info.spec.entity_name) != NULL && name->node_type == PT_NAME
+	      && (entity_name = name->info.name.original) != NULL)
 	    {
-	      PT_ERRORmf (parser, node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_CLASS_DOES_NOT_EXIST, entity_name);
-	      return;
-	    }
-	  else
-	    {
-	      /* db_find_synonym () == NULL */
-	      ASSERT_ERROR ();
-
-	      if (er_errid () == ER_SYNONYM_NOT_EXIST)
+	      /* We cannot change the schema of a class by using synonym names. */
+	      if (db_find_synonym (entity_name) != NULL)
 		{
-		  er_clear ();
+		  PT_ERRORmf (parser, node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_CLASS_DOES_NOT_EXIST,
+			      entity_name);
+		  return;
 		}
 	      else
 		{
-		  return;
+		  /* db_find_synonym () == NULL */
+		  ASSERT_ERROR ();
+
+		  if (er_errid () == ER_SYNONYM_NOT_EXIST)
+		    {
+		      er_clear ();
+		    }
+		  else
+		    {
+		      return;
+		    }
 		}
 	    }
 	}

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -9782,6 +9782,7 @@ pt_check_drop (PARSER_CONTEXT * parser, PT_NODE * node)
 {
   PT_NODE *temp;
   PT_NODE *name;
+  const char *entity_name;
   DB_OBJECT *db_obj;
   DB_ATTRIBUTE *attributes;
   PT_FLAT_SPEC_INFO info;
@@ -9797,13 +9798,12 @@ pt_check_drop (PARSER_CONTEXT * parser, PT_NODE * node)
 
       while ((free_node != NULL) && (free_node->node_type == PT_SPEC))
 	{
-	  const char *cls_name;
 	  /* check if class name exists. if not, we remove the corresponding node from spec_list. */
 	  if ((name = free_node->info.spec.entity_name) != NULL && name->node_type == PT_NAME
-	      && (cls_name = name->info.name.original) != NULL)
+	      && (entity_name = name->info.name.original) != NULL)
 	    {
 	      /* We cannot change the schema of a class by using synonym names. */
-	      if (db_find_synonym (cls_name) == NULL)
+	      if (db_find_synonym (entity_name) == NULL)
 		{
 		  ASSERT_ERROR ();
 
@@ -9816,7 +9816,7 @@ pt_check_drop (PARSER_CONTEXT * parser, PT_NODE * node)
 		      return;
 		    }
 
-		  if ((db_obj = db_find_class_with_purpose (cls_name, true)) != NULL)
+		  if ((db_obj = db_find_class_with_purpose (entity_name, true)) != NULL)
 		    {
 		      prev_node = free_node;
 		      free_node = free_node->next;
@@ -9894,7 +9894,6 @@ pt_check_drop (PARSER_CONTEXT * parser, PT_NODE * node)
 
       while ((free_node != NULL) && (free_node->node_type == PT_SPEC))
 	{
-
 	  if ((name = free_node->info.spec.entity_name) == NULL)
 	    {
 	      if (free_node == node->info.drop.spec_list)
@@ -9917,7 +9916,34 @@ pt_check_drop (PARSER_CONTEXT * parser, PT_NODE * node)
 	      free_node = free_node->next;
 	    }
 	}
+    }
 
+  for (temp = node->info.drop.spec_list; temp && temp->node_type == PT_SPEC; temp = temp->next)
+    {
+      if ((name = temp->info.spec.entity_name) != NULL && name->node_type == PT_NAME
+	  && (entity_name = name->info.name.original) != NULL)
+	{
+	  /* We cannot change the schema of a class by using synonym names. */
+	  if (db_find_synonym (entity_name) != NULL)
+	    {
+	      PT_ERRORmf (parser, node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_CLASS_DOES_NOT_EXIST, entity_name);
+	      return;
+	    }
+	  else
+	    {
+	      /* db_find_synonym () == NULL */
+	      ASSERT_ERROR ();
+
+	      if (er_errid () == ER_SYNONYM_NOT_EXIST)
+		{
+		  er_clear ();
+		}
+	      else
+		{
+		  return;
+		}
+	    }
+	}
     }
 
   info.spec_parent = NULL;
@@ -9927,55 +9953,30 @@ pt_check_drop (PARSER_CONTEXT * parser, PT_NODE * node)
 
   if (node->info.drop.entity_type != PT_MISC_DUMMY || node->info.drop.is_cascade_constraints)
     {
-      const char *cls_nam;
       PT_MISC_TYPE typ = node->info.drop.entity_type;
 
       /* verify declared class type is correct */
       for (temp = node->info.drop.spec_list; temp && temp->node_type == PT_SPEC; temp = temp->next)
 	{
 	  if ((name = temp->info.spec.entity_name) != NULL && name->node_type == PT_NAME
-	      && (cls_nam = name->info.name.original) != NULL)
+	      && (entity_name = name->info.name.original) != NULL && (db_obj = db_find_class (entity_name)) != NULL)
 	    {
-	      /* We cannot change the schema of a class by using synonym names. */
-	      if (db_find_synonym (cls_nam) != NULL)
+	      if (typ != PT_MISC_DUMMY)
 		{
-		  PT_ERRORmf (parser, node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_CLASS_DOES_NOT_EXIST, cls_nam);
-		  return;
-		}
-	      else
-		{
-		  /* db_find_synonym () == NULL */
-		  ASSERT_ERROR ();
-
-		  if (er_errid () == ER_SYNONYM_NOT_EXIST)
+		  name->info.name.db_object = db_obj;
+		  pt_check_user_owns_class (parser, name);
+		  if ((typ == PT_CLASS && db_is_class (db_obj) <= 0)
+		      || (typ == PT_VCLASS && db_is_vclass (db_obj) <= 0))
 		    {
-		      er_clear ();
-		    }
-		  else
-		    {
-		      return;
+		      PT_ERRORmf2 (parser, node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_IS_NOT_A, entity_name,
+				   pt_show_misc_type (typ));
 		    }
 		}
 
-	      if ((db_obj = db_find_class (cls_nam)) != NULL)
+	      if (node->info.drop.is_cascade_constraints && db_is_vclass (db_obj) > 0)
 		{
-		  if (typ != PT_MISC_DUMMY)
-		    {
-		      name->info.name.db_object = db_obj;
-		      pt_check_user_owns_class (parser, name);
-		      if ((typ == PT_CLASS && db_is_class (db_obj) <= 0)
-			  || (typ == PT_VCLASS && db_is_vclass (db_obj) <= 0))
-			{
-			  PT_ERRORmf2 (parser, node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_IS_NOT_A, cls_nam,
-				       pt_show_misc_type (typ));
-			}
-		    }
-
-		  if (node->info.drop.is_cascade_constraints && db_is_vclass (db_obj) > 0)
-		    {
-		      PT_ERRORmf (parser, node, MSGCAT_SET_PARSER_SEMANTIC,
-				  MSGCAT_SEMANTIC_VIEW_CASCADE_CONSTRAINTS_NOT_ALLOWED, cls_nam);
-		    }
+		  PT_ERRORmf (parser, node, MSGCAT_SET_PARSER_SEMANTIC,
+			      MSGCAT_SEMANTIC_VIEW_CASCADE_CONSTRAINTS_NOT_ALLOWED, entity_name);
 		}
 	    }
 	}
@@ -9985,10 +9986,8 @@ pt_check_drop (PARSER_CONTEXT * parser, PT_NODE * node)
    * for the attr */
   for (temp = node->info.drop.spec_list; temp && temp->node_type == PT_SPEC; temp = temp->next)
     {
-      const char *cls_nam;
-
       if ((name = temp->info.spec.entity_name) != NULL && name->node_type == PT_NAME
-	  && (cls_nam = name->info.name.original) != NULL && (db_obj = db_find_class (cls_nam)) != NULL)
+	  && (entity_name = name->info.name.original) != NULL && (db_obj = db_find_class (entity_name)) != NULL)
 	{
 	  attributes = db_get_attributes_force (db_obj);
 	  while (attributes)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26541

### Purpose

동의어(Synonym)는 대상 객체를 변경하는 **ALTER, DROP, RENAME** 문과 **TRUNCATE** 문에서는 동의어를 사용할 수 없습니다. ([매뉴얼](https://www.cubrid.org/manual/ko/11.4/sql/schema/synonym_stmt.html#id10))

하지만 타입을 지정하지 않는 **DROP** 문의 경우 **IF EXISTS**가 있는 경우에만 동의어 사용을 검사하고 있어서
그렇지 않은 경우에는 동의어를 통해서 대상 테이블이 삭제되는 문제가 발생합니다.

의도하지 않은 동작이므로 **IF EXISTS**가 없어도 동의어 사용을 검사해서 대상 테이블이 삭제되지 않도록 합니다.

### Implementation

`pt_check_drop`에서 `entity_type != PT_MISC_DUMMY`에 상관없이 동의어 사용을 검사합니다.

### Remarks

N/A

---

Prevent base table deletion via synonyms by enforcing synonym checks in all DROP statements regardless of the IF EXISTS clause.