### PR TITLE
[CBRD-26155] prohibit bind parameters in PL/CSQL Static SQL statements (#6686)

### DIFF
--- a/pl_engine/pl_server/src/main/antlr/PlcLexer.g4
+++ b/pl_engine/pl_server/src/main/antlr/PlcLexer.g4
@@ -203,7 +203,7 @@ FLOATING_POINT_NUM: FPNUM_W_POINT | FPNUM_WO_POINT;
 UNSIGNED_INTEGER:   BASIC_UINT;
 
 DELIMITED_ID: ('"' REGULAR_ID '"') | ('[' REGULAR_ID ']') | ('`' REGULAR_ID '`') ;
-CHAR_STRING: '\''  (~('\'' | '\r' | '\n') | '\'' '\'' | NEWLINE)* '\'';
+CHAR_STRING: '\''  ( ~('\'') | '\'\'')* '\'';
 
 NULL_SAFE_EQUALS_OP:          '<=>';
 
@@ -271,7 +271,7 @@ SS_SEMICOLON :  ';' {
         checkFirstLParen = false;
         mode(DEFAULT_MODE);
     };
-SS_STR :        '\''  (~('\'' | '\r' | '\n') | '\'' '\'' | NEWLINE)* '\'' {
+SS_STR :        '\''  (~('\'') | '\'\'')* '\'' {
         checkFirstLParen = false;
     };
 SS_WS :         [ \t\r\n]+ ;
@@ -296,7 +296,22 @@ SS_RPAREN :     ')' {
             setType(PlcParser.SS_NON_STR);
         }
     };
-SS_NON_STR:     ~( ';' | '\'' | ' ' | '\t' | '\r' | '\n' | '(' | ')' )+ {
+SS_BIND_PARAM:  '?' {
+        checkFirstLParen = false;
+    };
+SS_DELIMITED_ID: '"' (~('"') | '""')+ '"' {
+        checkFirstLParen = false;
+        setType(PlcParser.SS_NON_STR);
+    };
+SS_BRACKET_ID: '[' ~(']')+ ']' {
+        checkFirstLParen = false;
+        setType(PlcParser.SS_NON_STR);
+    };
+SS_BACKTICK_ID: '`' (~('`') | '``')+ '`' {
+        checkFirstLParen = false;
+        setType(PlcParser.SS_NON_STR);
+    };
+SS_NON_STR:     ~( ';' | '\'' | ' ' | '\t' | '\r' | '\n' | '(' | ')' | '?' | '"' | '[' | '`' )+ {
         checkFirstLParen = false;
     };
 

--- a/pl_engine/pl_server/src/main/antlr/PlcParser.g4
+++ b/pl_engine/pl_server/src/main/antlr/PlcParser.g4
@@ -251,7 +251,7 @@ sql_statement
     ;
 
 static_sql
-    : static_sql_begin (SS_STR | SS_WS | SS_NON_STR)+
+    : static_sql_begin (SS_STR | SS_WS | SS_NON_STR | SS_BIND_PARAM)+
     ;
 
 static_sql_begin

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -3340,6 +3340,15 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     }
 
     private SqlSemantics getSqlSemanticsFromServer(Static_sqlContext ctx) {
+
+        List<TerminalNode> bindParamTokens = ctx.SS_BIND_PARAM();
+        if (bindParamTokens != null && bindParamTokens.size() > 0) {
+            TerminalNode token = bindParamTokens.get(0);
+            throw new SemanticError(
+                    Misc.getLineColumnOf(token),
+                    "Static SQL statements cannot have a bind parameter");
+        }
+
         String text = expandRecordIfAny(ctx);
         return getSqlSemanticsFromServer(text, ctx);
     }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26155>

### Purpose

해당 이슈의 develop 브랜치에서의 변경을 11.4 로 backport 합니다. 
git cherry-pick 을 사용했습니다. 

