### PR TITLE
[CBRD-26617] Set thread name to match pool name.

### DIFF
--- a/src/connection/master_connector.cpp
+++ b/src/connection/master_connector.cpp
@@ -155,8 +155,6 @@ namespace cubconn::master
 
   bool connector::run (int port, std::string &server_name) noexcept
   {
-    pthread_setname_np (pthread_self (), "connector");
-
     m_master_port = port;
     m_server_name = server_name;
     if (!this->connect (port))

--- a/src/connection/master_connector.cpp
+++ b/src/connection/master_connector.cpp
@@ -155,6 +155,8 @@ namespace cubconn::master
 
   bool connector::run (int port, std::string &server_name) noexcept
   {
+    pthread_setname_np (pthread_self (), "connector");
+
     m_master_port = port;
     m_server_name = server_name;
     if (!this->connect (port))

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -574,7 +574,7 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
 
   // create request worker pool
   css_Server_request_worker_pool =
-    cubthread::get_manager ()->create_worker_pool (task_worker, MAX_TASK_COUNT, "transaction workers", NULL,
+    cubthread::get_manager ()->create_worker_pool (task_worker, MAX_TASK_COUNT, "transaction", NULL,
 						   task_group,
 						   cubthread::is_logging_configured
 						   (cubthread::LOG_WORKER_POOL_TRAN_WORKERS),

--- a/src/loaddb/load_worker_manager.cpp
+++ b/src/loaddb/load_worker_manager.cpp
@@ -116,7 +116,7 @@ namespace cubload
 	unsigned int pool_size = prm_get_integer_value (PRM_ID_LOADDB_WORKER_COUNT);
 
 	g_wp_context_manager = new worker_context_manager (pool_size);
-	g_worker_pool = cubthread::get_manager ()->create_worker_pool (pool_size, 2 * pool_size, "loaddb-workers",
+	g_worker_pool = cubthread::get_manager ()->create_worker_pool (pool_size, 2 * pool_size, "loaddb",
 			g_wp_context_manager, 1, false, true);
 
 	g_wp_task_capper = new cubthread::worker_pool_task_capper<cubthread::entry> (g_worker_pool);

--- a/src/query/parallel/px_worker_manager_global.cpp
+++ b/src/query/parallel/px_worker_manager_global.cpp
@@ -63,7 +63,7 @@ namespace parallel_query
       assert (m_worker_pool == nullptr);
       m_worker_pool = cubthread::get_manager()->create_worker_pool (
 			      pool_size, task_max_count,
-			      "parallel_query_worker_pool", NULL, 1, false);
+			      "parallel-query", NULL, 1, false);
       if (m_worker_pool == nullptr)
 	{
 	  return;

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1340,7 +1340,7 @@ vacuum_boot (THREAD_ENTRY * thread_p)
 
   // create vacuum master thread
   vacuum_Master_daemon =
-    thread_manager->create_daemon (looper, new vacuum_master_task (), "vacuum_master", vacuum_Master_context_manager);
+    thread_manager->create_daemon (looper, new vacuum_master_task (), "vacuum-master", vacuum_Master_context_manager);
 
   /* *INDENT-ON* */
 #endif /* SERVER_MODE */

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1331,7 +1331,7 @@ vacuum_boot (THREAD_ENTRY * thread_p)
   // create thread pool
   vacuum_Worker_threads =
     thread_manager->create_worker_pool (prm_get_integer_value (PRM_ID_VACUUM_WORKER_COUNT),
-					VACUUM_MAX_TASKS_IN_WORKER_POOL, "vacuum workers",
+					VACUUM_MAX_TASKS_IN_WORKER_POOL, "vacuum",
 					vacuum_Worker_context_manager, 1, log_vacuum_worker_pool);
   assert (vacuum_Worker_threads != NULL);
 

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -578,7 +578,7 @@ session_control_daemon_init ()
     new cubthread::entry_callable_task (std::bind (session_control_daemon_execute, std::placeholders::_1));
 
   // create session control daemon thread
-  session_Control_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "session_control");
+  session_Control_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "session-control");
 }
 
 /*

--- a/src/sp/pl_sr.cpp
+++ b/src/sp/pl_sr.cpp
@@ -261,7 +261,7 @@ namespace cubpl
   {
 #if defined (SERVER_MODE)
     cubthread::looper looper = cubthread::looper (std::chrono::milliseconds (1000));
-    m_monitor_helper_daemon = cubthread::get_manager ()->create_daemon (looper, m_server_monitor_task, "pl_monitor");
+    m_monitor_helper_daemon = cubthread::get_manager ()->create_daemon (looper, m_server_monitor_task, "pl-monitor");
 #else
     m_server_monitor_task->do_monitor ();
 #endif

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -4886,7 +4886,7 @@ online_index_builder (THREAD_ENTRY * thread_p, BTID_INT * btid_int, HFID * hfids
   // a worker pool is built only of loading is done in parallel
   cubthread::entry_workpool *ib_workpool =
     is_parallel ?
-    thread_get_manager()->create_worker_pool (ib_thread_count, 32, "Online index loader pool", &load_context, 1,
+    thread_get_manager()->create_worker_pool (ib_thread_count, 32, "online-index", &load_context, 1,
                                               btree_is_worker_pool_logging_true ())
     : NULL;
 

--- a/src/storage/double_write_buffer.cpp
+++ b/src/storage/double_write_buffer.cpp
@@ -4071,7 +4071,7 @@ dwb_flush_block_daemon_init ()
   cubthread::looper looper = cubthread::looper (std::chrono::milliseconds (1));
   dwb_flush_block_daemon_task *daemon_task = new dwb_flush_block_daemon_task ();
 
-  dwb_flush_block_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task);
+  dwb_flush_block_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "dwb-flush-block");
 }
 
 /*
@@ -4083,7 +4083,7 @@ dwb_file_sync_helper_daemon_init ()
   cubthread::looper looper = cubthread::looper (std::chrono::milliseconds (10));
   cubthread::entry_callable_task *daemon_task = new cubthread::entry_callable_task (dwb_file_sync_helper_execute);
 
-  dwb_file_sync_helper_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task);
+  dwb_file_sync_helper_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "dwb-file-sync-helper");
 }
 
 /*

--- a/src/storage/double_write_buffer.cpp
+++ b/src/storage/double_write_buffer.cpp
@@ -4083,7 +4083,7 @@ dwb_file_sync_helper_daemon_init ()
   cubthread::looper looper = cubthread::looper (std::chrono::milliseconds (10));
   cubthread::entry_callable_task *daemon_task = new cubthread::entry_callable_task (dwb_file_sync_helper_execute);
 
-  dwb_file_sync_helper_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "dwb-file-sync-helper");
+  dwb_file_sync_helper_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "dwb-file-sync");
 }
 
 /*

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -16512,8 +16512,7 @@ pgbuf_page_maintenance_daemon_init ()
   cubthread::looper looper = cubthread::looper (std::chrono::milliseconds (100));
   cubthread::entry_callable_task *daemon_task = new cubthread::entry_callable_task (pgbuf_page_maintenance_execute);
 
-  pgbuf_Page_maintenance_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task,
-                                                                            "pgbuf-page-maintenance");
+  pgbuf_Page_maintenance_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "pgbuf-maintain");
 }
 #endif /* SERVER_MODE */
 

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -16513,7 +16513,7 @@ pgbuf_page_maintenance_daemon_init ()
   cubthread::entry_callable_task *daemon_task = new cubthread::entry_callable_task (pgbuf_page_maintenance_execute);
 
   pgbuf_Page_maintenance_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task,
-                                                                            "pgbuf_page_maintenance");
+                                                                            "pgbuf-page-maintenance");
 }
 #endif /* SERVER_MODE */
 
@@ -16529,7 +16529,7 @@ pgbuf_page_flush_daemon_init ()
   cubthread::looper looper = cubthread::looper (pgbuf_get_page_flush_interval);
   pgbuf_page_flush_daemon_task *daemon_task = new pgbuf_page_flush_daemon_task ();
 
-  pgbuf_Page_flush_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "pgbuf_page_flush");
+  pgbuf_Page_flush_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "pgbuf-page-flush");
 }
 #endif /* SERVER_MODE */
 
@@ -16552,7 +16552,7 @@ pgbuf_page_post_flush_daemon_init ()
   cubthread::entry_callable_task *daemon_task = new cubthread::entry_callable_task (pgbuf_page_post_flush_execute);
 
   pgbuf_Page_post_flush_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task,
-                                                                           "pgbuf_page_post_flush");
+                                                                           "pgbuf-page-post-flush");
 }
 #endif /* SERVER_MODE */
 
@@ -16575,7 +16575,7 @@ pgbuf_flush_control_daemon_init ()
 
   cubthread::looper looper = cubthread::looper (std::chrono::milliseconds (50));
   pgbuf_Flush_control_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task,
-                                                                         "pgbuf_flush_control");
+                                                                         "pgbuf-flush-control");
 }
 #endif /* SERVER_MODE */
 

--- a/src/thread/internal_tasks_worker_pool.cpp
+++ b/src/thread/internal_tasks_worker_pool.cpp
@@ -44,7 +44,7 @@ namespace cubthread
 	}
 
       instance = cubthread::get_manager ()->create_worker_pool (WORKER_COUNT,
-		 TASK_COUNT, "internal_tasks_worker_pool", NULL, CORE_COUNT, ENABLE_LOGGING);
+		 TASK_COUNT, "internal", NULL, CORE_COUNT, ENABLE_LOGGING);
     }
 
     entry_workpool *get_instance ()

--- a/src/thread/thread_daemon.cpp
+++ b/src/thread/thread_daemon.cpp
@@ -199,7 +199,7 @@ namespace cubthread
     // its purpose is to help visualize daemon thread stacks
     if (!std::string (name).empty ())
       {
-	pthread_setname_np (pthread_self (), std::string (name).substr (0, 15).c_str ());
+	pthread_setname_np (pthread_self (), std::string (name).substr (0, TASK_COMM_LEN - 1).c_str ());
       }
     else
       {

--- a/src/thread/thread_daemon.cpp
+++ b/src/thread/thread_daemon.cpp
@@ -196,8 +196,15 @@ namespace cubthread
   void
   daemon::loop_without_context (daemon *daemon_arg, task_without_context *exec_arg, const char *name)
   {
-    (void) name;  // suppress unused parameter warning
     // its purpose is to help visualize daemon thread stacks
+    if (!std::string (name).empty ())
+      {
+	pthread_setname_np (pthread_self (), std::string (name).substr (0, 15).c_str ());
+      }
+    else
+      {
+	pthread_setname_np (pthread_self (), "unnamed-daemon");
+      }
 
     daemon_arg->register_stat_start ();
 

--- a/src/thread/thread_daemon.hpp
+++ b/src/thread/thread_daemon.hpp
@@ -35,6 +35,8 @@
 #include <cinttypes>
 #include <pthread.h>
 
+#define TASK_COMM_LEN 16
+
 // cubthread::daemon
 //
 //  description
@@ -167,7 +169,7 @@ namespace cubthread
     // its purpose is to help visualize daemon thread stacks
     if (!std::string (name).empty ())
       {
-	pthread_setname_np (pthread_self (), std::string (name).substr (0, 15).c_str ());
+	pthread_setname_np (pthread_self (), std::string (name).substr (0, TASK_COMM_LEN - 1).c_str ());
       }
     else
       {

--- a/src/thread/thread_daemon.hpp
+++ b/src/thread/thread_daemon.hpp
@@ -163,8 +163,15 @@ namespace cubthread
   daemon::loop_with_context (daemon *daemon_arg, context_manager<Context> *context_manager_arg,
 			     task<Context> *exec_arg, const char *name)
   {
-    (void) name;  // suppress unused parameter warning
     // its purpose is to help visualize daemon thread stacks
+    if (!std::string (name).empty ())
+      {
+	pthread_setname_np (pthread_self (), std::string (name).substr (0, 15).c_str ());
+      }
+    else
+      {
+	pthread_setname_np (pthread_self (), "unnamed-daemon");
+      }
 
     // create execution context
     Context &context = context_manager_arg->create_context ();

--- a/src/thread/thread_daemon.hpp
+++ b/src/thread/thread_daemon.hpp
@@ -33,6 +33,7 @@
 #include <thread>
 
 #include <cinttypes>
+#include <pthread.h>
 
 // cubthread::daemon
 //

--- a/src/thread/thread_daemon.hpp
+++ b/src/thread/thread_daemon.hpp
@@ -35,7 +35,9 @@
 #include <cinttypes>
 #include <pthread.h>
 
+#ifndef TASK_COMM_LEN
 #define TASK_COMM_LEN 16
+#endif
 
 // cubthread::daemon
 //

--- a/src/thread/thread_worker_pool.hpp
+++ b/src/thread/thread_worker_pool.hpp
@@ -50,6 +50,8 @@
 #include <cstring>
 #include <pthread.h>
 
+#define TASK_COMM_LEN 16
+
 namespace cubthread
 {
   // cubtread::worker_pool<Context>
@@ -579,7 +581,7 @@ namespace cubthread
     , m_log (debug_log)
     , m_pool_threads (pool_threads)
     , m_wait_for_task_time (wait_for_task_time)
-    , m_name (name == NULL ? "" : std::string (name, 0, 15))
+    , m_name (name == NULL ? "" : std::string (name, 0, TASK_COMM_LEN - 1))
   {
     // initialize cores; we'll try to distribute pool evenly to all cores. if core count is not fully contained in
     // pool size, some cores will have one additional worker
@@ -1593,7 +1595,7 @@ namespace cubthread
     task_type *task_p = NULL;
 
     os::resources::cpu::clearaffinity ();   // clear the affinity at start
-    pthread_setname_np (pthread_self (), m_parent_core->get_parent_pool ()->get_name ().c_str ());   // set name
+    pthread_setname_np (pthread_self (), m_parent_core->get_parent_pool ()->get_name ().c_str ());
 
     init_run ();    // do stuff at the beginning like creating context
 

--- a/src/thread/thread_worker_pool.hpp
+++ b/src/thread/thread_worker_pool.hpp
@@ -48,6 +48,7 @@
 
 #include <cassert>
 #include <cstring>
+#include <pthread.h>
 
 namespace cubthread
 {
@@ -170,6 +171,9 @@ namespace cubthread
       // is_running = is not stopped; when created, a worker pool starts running.
       // worker is stopped after stop_execution () is called
       bool is_running (void) const;
+
+      // get name
+      const std::string &get_name (void) const;
 
       // is_full = the maximum number of tasks is reached
       bool is_full (void) const;
@@ -575,7 +579,7 @@ namespace cubthread
     , m_log (debug_log)
     , m_pool_threads (pool_threads)
     , m_wait_for_task_time (wait_for_task_time)
-    , m_name (name == NULL ? "" : name)
+    , m_name (name == NULL ? "" : std::string (name, 0, 15))
   {
     // initialize cores; we'll try to distribute pool evenly to all cores. if core count is not fully contained in
     // pool size, some cores will have one additional worker
@@ -731,6 +735,13 @@ namespace cubthread
   worker_pool<Context>::is_running (void) const
   {
     return !m_stopped;
+  }
+
+  template<typename Context>
+  const std::string &
+  worker_pool<Context>::get_name (void) const
+  {
+    return m_name;
   }
 
   template<typename Context>
@@ -1582,6 +1593,8 @@ namespace cubthread
     task_type *task_p = NULL;
 
     os::resources::cpu::clearaffinity ();   // clear the affinity at start
+    pthread_setname_np (pthread_self (), m_parent_core->get_parent_pool ()->get_name ().c_str ());   // set name
+
     init_run ();    // do stuff at the beginning like creating context
 
     if (m_is_temp)

--- a/src/thread/thread_worker_pool.hpp
+++ b/src/thread/thread_worker_pool.hpp
@@ -50,7 +50,9 @@
 #include <cstring>
 #include <pthread.h>
 
+#ifndef TASK_COMM_LEN
 #define TASK_COMM_LEN 16
+#endif
 
 namespace cubthread
 {

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -5813,7 +5813,7 @@ lock_deadlock_detect_daemon_init ()
   cubthread::entry_callable_task *daemon_task = new cubthread::entry_callable_task (deadlock_detect_task_execute);
 
   // create deadlock detect daemon thread
-  lock_Deadlock_detect_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "lock_deadlock_detect");
+  lock_Deadlock_detect_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "lock-deadlock-detect");
 }
 #endif /* SERVER_MODE */
 

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -5813,7 +5813,7 @@ lock_deadlock_detect_daemon_init ()
   cubthread::entry_callable_task *daemon_task = new cubthread::entry_callable_task (deadlock_detect_task_execute);
 
   // create deadlock detect daemon thread
-  lock_Deadlock_detect_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "lock-deadlock-detect");
+  lock_Deadlock_detect_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "deadlock-detect");
 }
 #endif /* SERVER_MODE */
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -10430,8 +10430,7 @@ log_remove_log_archive_daemon_init ()
   cubthread::looper looper = cubthread::looper (setup_period_function);
 
   // create log archive remover daemon thread
-  log_Remove_log_archive_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task,
-                                                                            "log-remove-log-archive");
+  log_Remove_log_archive_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "log-rm-archive");
 }
 #endif /* SERVER_MODE */
 
@@ -10470,8 +10469,7 @@ log_check_ha_delay_info_daemon_init ()
   cubthread::looper looper = cubthread::looper (std::chrono::seconds (1));
   cubthread::entry_callable_task *daemon_task = new cubthread::entry_callable_task (log_check_ha_delay_info_execute);
 
-  log_Check_ha_delay_info_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task,
-                                                                             "log-check-ha-delay-info");
+  log_Check_ha_delay_info_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "ha-delay-check");
 }
 #endif /* SERVER_MODE */
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -10407,7 +10407,7 @@ log_checkpoint_daemon_init ()
   cubthread::entry_callable_task *daemon_task = new cubthread::entry_callable_task (log_checkpoint_execute);
 
   // create checkpoint daemon thread
-  log_Checkpoint_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "log_checkpoint");
+  log_Checkpoint_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "log-checkpoint");
 }
 #endif /* SERVER_MODE */
 
@@ -10431,7 +10431,7 @@ log_remove_log_archive_daemon_init ()
 
   // create log archive remover daemon thread
   log_Remove_log_archive_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task,
-                                                                            "log_remove_log_archive");
+                                                                            "log-remove-log-archive");
 }
 #endif /* SERVER_MODE */
 
@@ -10447,7 +10447,7 @@ log_clock_daemon_init ()
   cubthread::looper looper = cubthread::looper (std::chrono::milliseconds (200));
   log_Clock_daemon =
     cubthread::get_manager ()->create_daemon (looper, new cubthread::entry_callable_task (log_clock_execute),
-                                              "log_clock");
+                                              "log-clock");
 }
 #endif /* SERVER_MODE */
 
@@ -10471,7 +10471,7 @@ log_check_ha_delay_info_daemon_init ()
   cubthread::entry_callable_task *daemon_task = new cubthread::entry_callable_task (log_check_ha_delay_info_execute);
 
   log_Check_ha_delay_info_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task,
-                                                                             "log_check_ha_delay_info");
+                                                                             "log-check-ha-delay-info");
 }
 #endif /* SERVER_MODE */
 
@@ -10487,7 +10487,7 @@ log_flush_daemon_init ()
   cubthread::looper looper = cubthread::looper (log_get_log_group_commit_interval);
   cubthread::entry_callable_task *daemon_task = new cubthread::entry_callable_task (log_flush_execute);
 
-  log_Flush_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "log_flush");
+  log_Flush_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "log-flush");
 }
 #endif /* SERVER_MODE */
 
@@ -14031,7 +14031,7 @@ cdc_loginfo_producer_daemon_init ()
   cubthread::looper looper = cubthread::looper (std::chrono::milliseconds (10)); /* 주석 처리  */
   cubthread::entry_callable_task *daemon_task = new cubthread::entry_callable_task (cdc_loginfo_producer_execute);
 
-  cdc_Loginfo_producer_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "cdc_loginfo_producer"); 
+  cdc_Loginfo_producer_daemon = cubthread::get_manager ()->create_daemon (looper, daemon_task, "cdc-loginfo-producer"); 
   /* *INDENT-ON* */
 }
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -7530,7 +7530,7 @@ logpb_create_backup_read_worker_pool (size_t thread_count)
       thread_count = 1;
     }
   g_backup_read_worker_pool =
-    cubthread::get_manager ()->create_worker_pool (thread_count, thread_count, "backup read workers", NULL,
+    cubthread::get_manager ()->create_worker_pool (thread_count, thread_count, "backup-read", NULL,
 						   core_count, false, true);
 }
 

--- a/src/transaction/log_recovery_redo_parallel.cpp
+++ b/src/transaction/log_recovery_redo_parallel.cpp
@@ -662,7 +662,7 @@ namespace cublog
     // NOTE: already initialized globally (probably during boot)
     cubthread::manager *thread_manager = cubthread::get_manager ();
 
-    m_worker_pool = thread_manager->create_worker_pool (a_task_count, a_task_count, "log_recovery_redo_thread_pool",
+    m_worker_pool = thread_manager->create_worker_pool (a_task_count, a_task_count, "recovery-redo",
 		    m_pool_context_manager.get (),
 		    a_task_count, false /*debug_logging*/);
   }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26617>

### Purpose

각 Thread들이 자신이 속한 worker pool의 이름을 갖도록 합니다.
Daemon의 경우 각각의 이름을 출력합니다. 출력 예시는 아래와 같습니다.

Main thread는 이름을 변경할 경우 ps에서의 이름도 변경되어 제외합니다. 

```
  Id   Target Id                                            Frame
* 1    Thread 0x7eff441d1200 (LWP 572862) "cub_server"      0x00007eff40dce477 in epoll_wait () from /lib64/libc.so.6
  2    Thread 0x7eff3ff6f700 (LWP 572864) "pl-monitor"      0x00007eff423ee628 in pthread_cond_timedwait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  3    Thread 0x7eff3e9eb700 (LWP 572945) "pgbuf-maintain"  0x00007eff423ee628 in pthread_cond_timedwait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  4    Thread 0x7eff3e1ea700 (LWP 572946) "pgbuf-page-flus" 0x00007eff423ee628 in pthread_cond_timedwait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  5    Thread 0x7eff3d9e9700 (LWP 572947) "pgbuf-page-post" 0x00007eff423ee371 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  6    Thread 0x7eff3d1e8700 (LWP 572948) "pgbuf-flush-con" 0x00007eff423ee628 in pthread_cond_timedwait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  7    Thread 0x7eff3c9e7700 (LWP 572949) "dwb-flush-block" 0x00007eff423ee628 in pthread_cond_timedwait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  8    Thread 0x7eff061d3700 (LWP 572950) "dwb-file-sync"   0x00007eff423ee628 in pthread_cond_timedwait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  9    Thread 0x7eff3f76e700 (LWP 572953) "deadlock-detect" 0x00007eff423ee628 in pthread_cond_timedwait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  10   Thread 0x7eff07fbd700 (LWP 572954) "log-rm-archive"  0x00007eff423ee371 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  11   Thread 0x7eff077bc700 (LWP 572955) "log-checkpoint"  0x00007eff423ee628 in pthread_cond_timedwait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  12   Thread 0x7eff06fbb700 (LWP 572956) "log-clock"       0x00007eff423ee628 in pthread_cond_timedwait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  13   Thread 0x7eff059d2700 (LWP 572957) "log-flush"       0x00007eff423ee628 in pthread_cond_timedwait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  14   Thread 0x7eff051d1700 (LWP 572958) "vacuum-master"   0x00007eff423ee628 in pthread_cond_timedwait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  15   Thread 0x7eff049d0700 (LWP 572964) "session-control" 0x00007eff423ee628 in pthread_cond_timedwait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  16   Thread 0x7efee1a15700 (LWP 572965) "transaction"     0x00007eff423ee628 in pthread_cond_timedwait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  17   Thread 0x7efee1214700 (LWP 572966) "transaction"     0x00007eff423ee628 in pthread_cond_timedwait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
  18   Thread 0x7efee0a13700 (LWP 572967) "coordinator"     0x00007eff40dce477 in epoll_wait () from /lib64/libc.so.6
  19   Thread 0x7efedbfff700 (LWP 572968) "connections"     0x00007eff40dce477 in epoll_wait () from /lib64/libc.so.6
  20   Thread 0x7efedb7fe700 (LWP 572969) "connections"     0x00007eff40dce477 in epoll_wait () from /lib64/libc.so.6
```

### Implementation

N/A

### Remarks

worker pool 이름들은 최대 15자까지 설정될 수 있습니다.