### PR TITLE
[CBRD-26623] database.txt의 db-host에 여러 노드가 입력되어있을 시 rkcheck 유틸리티 실행 에러

### DIFF
--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -2921,6 +2921,7 @@ rkcheck (UTIL_FUNCTION_ARG * arg)
 
   if (strchr (database_name, '@') == NULL)
     {
+      /* TODO: Handle truncation explicitly here; keep this in sync with applyinfo() local_database_name build path. */
       snprintf (tmp_database_name, sizeof (tmp_database_name), "%s@localhost", database_name);
       database_name = tmp_database_name;
     }
@@ -2928,7 +2929,6 @@ rkcheck (UTIL_FUNCTION_ARG * arg)
   if (check_database_name (database_name))
     {
       err = ER_FAILED;
-      PRINT_AND_LOG_ERR_MSG ("%s: %s\n", arg->command_name, db_error_string (3));
       goto end2;
     }
 
@@ -3670,6 +3670,7 @@ applyinfo (UTIL_FUNCTION_ARG * arg)
   do
     {
       memset (local_database_name, 0x00, CUB_MAXHOSTNAMELEN);
+      /* TODO: Replace strcpy/strcat with bounded formatting and keep behavior aligned with rkcheck() tmp_database_name path. */
       strcpy (local_database_name, database_name);
       strcat (local_database_name, "@localhost");
 

--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -2895,6 +2895,7 @@ rkcheck (UTIL_FUNCTION_ARG * arg)
   DB_OBJLIST *classes = NULL;
   UTIL_ARG_MAP *arg_map = arg->arg_map;
   char *database_name = NULL;
+  char local_database_name[CUB_MAXHOSTNAMELEN];
   int rk_violation_count = 0, fk_violation_count = 0;
   char er_msg_file[PATH_MAX];
   char violation_list_file[PATH_MAX];
@@ -2918,7 +2919,18 @@ rkcheck (UTIL_FUNCTION_ARG * arg)
   db_set_client_type (DB_CLIENT_TYPE_ADMIN_UTILITY);
   db_login ("DBA", NULL);
 
-  if (db_restart (arg->command_name, TRUE, database_name))
+  memset (local_database_name, 0x00, CUB_MAXHOSTNAMELEN);
+  strcpy (local_database_name, database_name);
+  strcat (local_database_name, "@localhost");
+
+  if (check_database_name (local_database_name))
+    {
+      err = ER_FAILED;
+      PRINT_AND_LOG_ERR_MSG ("%s: %s\n", arg->command_name, db_error_string (3));
+      goto end2;
+    }
+
+  if (db_restart (arg->command_name, TRUE, local_database_name))
     {
       err = ER_FAILED;
       PRINT_AND_LOG_ERR_MSG ("%s: %s\n", arg->command_name, db_error_string (3));

--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -2895,7 +2895,7 @@ rkcheck (UTIL_FUNCTION_ARG * arg)
   DB_OBJLIST *classes = NULL;
   UTIL_ARG_MAP *arg_map = arg->arg_map;
   char *database_name = NULL;
-  char local_database_name[CUB_MAXHOSTNAMELEN];
+  char tmp_database_name[CUB_MAXHOSTNAMELEN];
   int rk_violation_count = 0, fk_violation_count = 0;
   char er_msg_file[PATH_MAX];
   char violation_list_file[PATH_MAX];
@@ -2919,18 +2919,20 @@ rkcheck (UTIL_FUNCTION_ARG * arg)
   db_set_client_type (DB_CLIENT_TYPE_ADMIN_UTILITY);
   db_login ("DBA", NULL);
 
-  memset (local_database_name, 0x00, CUB_MAXHOSTNAMELEN);
-  strcpy (local_database_name, database_name);
-  strcat (local_database_name, "@localhost");
+  if (strchr (database_name, '@') == NULL)
+    {
+      snprintf (tmp_database_name, sizeof (tmp_database_name), "%s@localhost", database_name);
+      database_name = tmp_database_name;
+    }
 
-  if (check_database_name (local_database_name))
+  if (check_database_name (database_name))
     {
       err = ER_FAILED;
       PRINT_AND_LOG_ERR_MSG ("%s: %s\n", arg->command_name, db_error_string (3));
       goto end2;
     }
 
-  if (db_restart (arg->command_name, TRUE, local_database_name))
+  if (db_restart (arg->command_name, TRUE, database_name))
     {
       err = ER_FAILED;
       PRINT_AND_LOG_ERR_MSG ("%s: %s\n", arg->command_name, db_error_string (3));


### PR DESCRIPTION
[<http://jira.cubrid.org/browse/CBRD-26623>](http://jira.cubrid.org/browse/CBRD-26623)

### Purpose

database.txt 의 db-host 에 여러 노드(ex. master:slave) 가 입력되어 있을 경우
(ha 실행 포함) rkcheck 수행 시 다음 에러가 발생합니다.

`
@ rkcheck start
rkcheck: The hostname on the database connection string should be specified when multihost is set in "databases.txt". ex) csql demodb@localhost
++ rkcheck start: fail
++ HA processes start: fail
++ cubrid heartbeat start: fail
`
이는 db_restart -> boot_restart_client 에서 데이터베이스 이름에 @가 포함되어있지 않고, 
여러 데이터베이스명이 입력되어있을 경우 에러가 발생합니다.

### Implementation

이를 해결하기위해 데이터베이스명에 '@localhost' 를 추가합니다.

### Remarks
1. rkcheck 로그 파일 명 변경 필요
확인 결과 다른 노드를 함께 입력할 경우, 해당 노드에 대한 rkcheck를 수행합니다. 
이 때 로그 파일에 해당 호스트 명을 함께 넘겨야 로그를 확인할 때 파일이 보다 명확하게 구분될 거라고 생각되어
rkcheck 결과 파일 명이 다음과 같이 변경되어야한다고 생각됩니다.

```
demodb@youngjun4_rkcheck_20260327_0224.list
```

3. 테스트
수정 후 database.txt 에 master:slave로 여러 노드를 입력해도 다음과같이 정상 동작함을 확인했습니다.
```
[youngjun@youngjun3 ~]$ cubrid hb start
@ cubrid heartbeat start
@ cubrid master start
++ cubrid master start: success
@ HA processes start
@ cubrid server start: demodb

This may take a long time depending on the amount of recovery works to do.

CUBRID 11.5.0 (11.5.0.2128) (64 debug build)

++ cubrid server start: success
@ rkcheck start

Constraint checks completed for all replication-enabled tables.

++ rkcheck start: success
@ copylogdb start
++ copylogdb start: success
@ applylogdb start
++ applylogdb start: success
```

