### PR TITLE
[CBRD-26598] [CMS] remove forcing insertion of 3 keys, _DBNAME/_DBID/_DBPASSWD

### DIFF
--- a/src/cm_common/cm_dep.h
+++ b/src/cm_common/cm_dep.h
@@ -269,6 +269,8 @@ extern "C"
   int make_temp_filename (char *tempfile, const char *prefix, int size);
   int make_temp_filepath (char *tempfile, char *tempdir, char *prefix, int task_code, int size);
 
+  bool key_not_exist (nvplist *req, const char *key);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/cm_common/cm_dep_tasks.c
+++ b/src/cm_common/cm_dep_tasks.c
@@ -252,9 +252,9 @@ _op_db_login (nvplist * out, nvplist * in, int ha_mode, char *_dbmt_error)
   char *id, *pwd, *db_name;
   char dbname_at_hostname[CUB_MAXHOSTNAMELEN + DB_NAME_LEN];
 
-  id = nv_get_val (in, "_DBID");
-  pwd = nv_get_val (in, "_DBPASSWD");
-  db_name = nv_get_val (in, "_DBNAME");
+  id = nv_get_val (in, "dbuser");
+  pwd = nv_get_val (in, "dbpasswd");
+  db_name = nv_get_val (in, "dbname");
 
   db_login (id, pwd);
 
@@ -597,7 +597,7 @@ cm_ts_class_info (nvplist * in, nvplist * out, char *_dbmt_error)
   int ha_mode = 0;
 
   dbstatus = nv_get_val (in, "dbstatus");
-  dbname = nv_get_val (in, "_DBNAME");
+  dbname = nv_get_val (in, "dbname");
   if (dbname == NULL)
     {
       return ERR_PARAM_MISSING;
@@ -612,8 +612,8 @@ cm_ts_class_info (nvplist * in, nvplist * out, char *_dbmt_error)
 
   if (db_mode == DB_SERVICE_MODE_NONE)
     {
-      char *uid = nv_get_val (in, "_DBID");
-      char *passwd = nv_get_val (in, "_DBPASSWD");
+      char *uid = nv_get_val (in, "dbuser");
+      char *passwd = nv_get_val (in, "dbpasswd");
       char *cli_ver_val = nv_get_val (in, "_CLIENT_VERSION");
       return (class_info_sa (dbname, uid, passwd, cli_ver_val, out, _dbmt_error));
     }
@@ -728,8 +728,9 @@ cm_ts_get_triggerinfo (nvplist * req, nvplist * res, char *_dbmt_error)
       /* use ts_get_triggerinfo_sa funtion */
       char *uid;
       char *password;
-      uid = nv_get_val (req, "_DBID");
-      password = nv_get_val (req, "_DBPASSWD");
+      uid = nv_get_val (req, "dbuser");
+      password = nv_get_val (req, "dbpasswd");
+
       return (trigger_info_sa (dbname, uid, password, res, _dbmt_error));
     }
 
@@ -1017,7 +1018,7 @@ cm_ts_update_user (nvplist * req, nvplist * res, char *_dbmt_error)
       const char *dbmt_db_id;
       const char *old_db_passwd;
 
-      dbmt_db_id = nv_get_val (req, "_DBID");
+      dbmt_db_id = nv_get_val (req, "dbuser");
       if (dbmt_db_id == NULL)
 	dbmt_db_id = "";
 
@@ -1211,7 +1212,7 @@ cm_ts_create_user (nvplist * req, nvplist * res, char *_dbmt_error)
   char *tval, *sval;
   int anum;
 
-  dbname = nv_get_val (req, "_DBNAME");
+  dbname = nv_get_val (req, "dbname");
   if (dbname == NULL)
     {
       return ERR_PARAM_MISSING;

--- a/src/cm_common/cm_dep_tasks.c
+++ b/src/cm_common/cm_dep_tasks.c
@@ -3101,9 +3101,9 @@ key_not_exist (nvplist *req, const char *key)
     {
       nv_lookup (req, i, &n, &v);
       if (n != NULL && strcasecmp (n, key) == 0)
-        {
-          return false;
-        }
+	{
+	  return false;
+	}
     }
 
   return true;

--- a/src/cm_common/cm_dep_tasks.c
+++ b/src/cm_common/cm_dep_tasks.c
@@ -610,11 +610,18 @@ cm_ts_class_info (nvplist * in, nvplist * out, char *_dbmt_error)
       return ERR_STANDALONE_MODE;
     }
 
+  if (key_not_exist (in, "dbuser") || key_not_exist (in, "dbpassword"))
+    {
+      sprintf (_dbmt_error, "%s", "key \'dbuser\' or \'dbpassword\' does not exist");
+      return ERR_WITH_MSG;
+    }
+
   if (db_mode == DB_SERVICE_MODE_NONE)
     {
       char *uid = nv_get_val (in, "dbuser");
-      char *passwd = nv_get_val (in, "dbpasswd");
+      char *passwd = nv_get_val (in, "dbpassword");
       char *cli_ver_val = nv_get_val (in, "_CLIENT_VERSION");
+
       return (class_info_sa (dbname, uid, passwd, cli_ver_val, out, _dbmt_error));
     }
   else
@@ -3082,4 +3089,22 @@ error_file_to_buf (const char *err_file, char *err_buf)
   unlink (err_file);
 
   return;
+}
+
+bool
+key_not_exist (nvplist *req, const char *key)
+{
+  int i;
+  char *n, *v;
+
+  for (i = 0; i < req->nvplist_leng; i++)
+    {
+      nv_lookup (req, i, &n, &v);
+      if (n != NULL && strcasecmp (n, key) == 0)
+        {
+          return false;
+        }
+    }
+
+  return true;
 }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26598>

### Purpose
* Removes the function to forcibly insert the three keys, **_DBNAME**/**_DBID**/**_DBPASSWD**.
* They will be changed to **dbname**, **dbuser**, and **dbpassword**, respectively.
for example, 
* currently, the **_classinfo_** CMS API requires only the following two keys, and replaces **_DBID** and **_DBPASSWD** with automatically inserted information for the user/password,
{dbname, dbstatus}
* afterwards, users must explicitly enter dbuser and dbpasswd as shown below:
{dbname, **dbuser**, **dbpassword**, dbstatus}

### Implementation

N/A

### Remarks
* check if the request has a key, dbuser, dbpassword, this is because we want distinguish 
 * dbpassword is present and value is null 
 * dbpassword is abesent
