### PR TITLE
[CBRD-26607] rkcheck 유틸리티에서 제약사항 확인할 때 view class 예외 처리

### DIFF
--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -170,7 +170,8 @@ static FILE *open_violation_list_file (const char *database_name, const char *ut
 static int get_print_flags (UTIL_ARG_MAP * arg_map);
 static int check_rk_constraint (MOP classop, FILE * fp);
 static int check_fk_constraint (MOP classop, FILE * fp);
-static int check_repl_constraint_violations (DB_OBJLIST * classes, FILE * fp, REPL_CONSTRAINT_CHECK_FUNC check_func);
+static int check_repl_constraint_violations (DB_OBJLIST * classes, FILE * fp, REPL_CONSTRAINT_CHECK_FUNC check_func,
+					     int *violation_count);
 
 /*
  * backupdb() - backupdb main routine
@@ -2859,26 +2860,33 @@ check_fk_constraint (MOP classop, FILE * fp)
  * check_repl_constraint_violations - Check replication constraint violations
  *                                   for replicated user classes.
  *
- * return: Number of detected constraint violations.
+ * return: NO_ERROR on success, error code otherwise.
  *
  * NOTE:
  *   - System classes are skipped.
  *   - Only replication-enabled classes are checked.
  */
 static int
-check_repl_constraint_violations (DB_OBJLIST * classes, FILE * fp, REPL_CONSTRAINT_CHECK_FUNC check_func)
+check_repl_constraint_violations (DB_OBJLIST * classes, FILE * fp, REPL_CONSTRAINT_CHECK_FUNC check_func,
+				  int *violation_count)
 {
   DB_OBJLIST *c;
-  int ret = 0;
+  int ret = NO_ERROR;
 
   for (c = classes; c != NULL; c = c->next)
     {
-      if (db_is_system_class (c->op) || db_is_vclass (c->op) || !sm_is_replication_class (c->op))
+      ret = db_is_vclass (c->op);
+      if (ret < 0)
+	{
+	  return ret;
+	}
+
+      if (db_is_system_class (c->op) || ret > 0 || !sm_is_replication_class (c->op))
 	{
 	  continue;
 	}
 
-      ret += check_func (c->op, fp);
+      *violation_count += check_func (c->op, fp);
     }
 
   return ret;
@@ -2941,7 +2949,12 @@ rkcheck (UTIL_FUNCTION_ARG * arg)
   if ((repl_check_flags & REPL_CHECK_RK) != 0)
     {
       PRINT_SECTION_TITLE (fp, RK_CONSTRAINT_VIOLATIONS_SECTION_TITLE);
-      rk_violation_count = check_repl_constraint_violations (classes, fp, check_rk_constraint);
+      err = check_repl_constraint_violations (classes, fp, check_rk_constraint, &rk_violation_count);
+      if (err != NO_ERROR)
+	{
+	  PRINT_AND_LOG_ERR_MSG ("%s: %s\n", arg->command_name, db_error_string (3));
+	  goto end1;
+	}
       if (rk_violation_count == 0)
 	{
 	  PRINT_MESSAGE (fp, RK_CONSTRAINT_COMPLIANCE_MESSAGE);
@@ -2952,7 +2965,12 @@ rkcheck (UTIL_FUNCTION_ARG * arg)
   if ((repl_check_flags & REPL_CHECK_FK) != 0)
     {
       PRINT_SECTION_TITLE (fp, FK_CONSTRAINT_VIOLATIONS_SECTION_TITLE);
-      fk_violation_count = check_repl_constraint_violations (classes, fp, check_fk_constraint);
+      err = check_repl_constraint_violations (classes, fp, check_fk_constraint, &fk_violation_count);
+      if (err != NO_ERROR)
+	{
+	  PRINT_AND_LOG_ERR_MSG ("%s: %s\n", arg->command_name, db_error_string (3));
+	  goto end1;
+	}
       if (fk_violation_count == 0)
 	{
 	  PRINT_MESSAGE (fp, FK_CONSTRAINT_COMPLIANCE_MESSAGE);

--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -2873,7 +2873,7 @@ check_repl_constraint_violations (DB_OBJLIST * classes, FILE * fp, REPL_CONSTRAI
 
   for (c = classes; c != NULL; c = c->next)
     {
-      if (db_is_system_class (c->op) || !sm_is_replication_class (c->op))
+      if (db_is_system_class (c->op) || db_is_vclass (c->op) || !sm_is_replication_class (c->op))
 	{
 	  continue;
 	}

--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -2871,17 +2871,17 @@ check_repl_constraint_violations (DB_OBJLIST * classes, FILE * fp, REPL_CONSTRAI
 				  int *violation_count)
 {
   DB_OBJLIST *c;
-  int ret = NO_ERROR;
+  int is_vclass;
 
   for (c = classes; c != NULL; c = c->next)
     {
-      ret = db_is_vclass (c->op);
-      if (ret < 0)
+      is_vclass = db_is_vclass (c->op);
+      if (is_vclass < 0)
 	{
-	  return ret;
+	  return is_vclass;
 	}
 
-      if (db_is_system_class (c->op) || ret > 0 || !sm_is_replication_class (c->op))
+      if (db_is_system_class (c->op) || is_vclass > 0 || !sm_is_replication_class (c->op))
 	{
 	  continue;
 	}
@@ -2889,7 +2889,7 @@ check_repl_constraint_violations (DB_OBJLIST * classes, FILE * fp, REPL_CONSTRAI
       *violation_count += check_func (c->op, fp);
     }
 
-  return ret;
+  return NO_ERROR;
 }
 
 /*
@@ -2952,7 +2952,7 @@ rkcheck (UTIL_FUNCTION_ARG * arg)
       err = check_repl_constraint_violations (classes, fp, check_rk_constraint, &rk_violation_count);
       if (err != NO_ERROR)
 	{
-	  PRINT_AND_LOG_ERR_MSG ("%s: %s\n", arg->command_name, db_error_string (3));
+	  PRINT_AND_LOG_ERR_MSG ("%s: RK constraint check failed (error=%d)\n", arg->command_name, err);
 	  goto end1;
 	}
       if (rk_violation_count == 0)
@@ -2968,7 +2968,7 @@ rkcheck (UTIL_FUNCTION_ARG * arg)
       err = check_repl_constraint_violations (classes, fp, check_fk_constraint, &fk_violation_count);
       if (err != NO_ERROR)
 	{
-	  PRINT_AND_LOG_ERR_MSG ("%s: %s\n", arg->command_name, db_error_string (3));
+	  PRINT_AND_LOG_ERR_MSG ("%s: FK constraint check failed (error=%d)\n", arg->command_name, err);
 	  goto end1;
 	}
       if (fk_violation_count == 0)

--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -2865,6 +2865,8 @@ check_fk_constraint (MOP classop, FILE * fp)
  * NOTE:
  *   - System classes are skipped.
  *   - Only replication-enabled classes are checked.
+ *   - Vclasses are skipped because they can be created with replication ON,
+ *     but do not have replication constraints to validate.
  */
 static int
 check_repl_constraint_violations (DB_OBJLIST * classes, FILE * fp, REPL_CONSTRAINT_CHECK_FUNC check_func,


### PR DESCRIPTION
[<http://jira.cubrid.org/browse/CBRD-26607>](http://jira.cubrid.org/browse/CBRD-26607)

### Purpose

현재 복제 옵션 추가 feature 에서 ha 를 실행할 때 rkcheck 유틸리티를 통해 복제 제약사항을 확인합니다.
이 때, view 클래스가 생성되어있다면, view 는 기본적으로 replication = on 옵션을 갖는 반면, constraints 나 attribute 가 없어 pk나 not null unique 속성을 확인 할 수 없습니다.

```
csql> create table tbl1 (i int primary key, j int, k int, d double, n numeric, s varchar(100)) dont_reuse_oid;

csql> create view  t1 as select * from tbl1 order by 1,2,3,4,5,6;

csql> ;sc tbl1

=== <Help: Schema of a Class> ===


 <Class Name>

     dba.tbl1

 <Attributes>

     i                    INTEGER NOT NULL
     j                    INTEGER
     k                    INTEGER
     d                    DOUBLE
     n                    NUMERIC(15,0)
     s                    CHARACTER VARYING(100)

 <Constraints>

     PRIMARY KEY pk_tbl1_i ON dba.tbl1 (i)

csql> ;sc t1

=== <Help: Schema of a Class> ===


 <VClass Name>

     dba.t1

 <Attributes>

     i                    INTEGER
     j                    INTEGER
     k                    INTEGER
     d                    DOUBLE
     n                    NUMERIC(15,0)
     s                    CHARACTER VARYING(100)

 <Query_specifications>

     select [dba.tbl1].[i], [dba.tbl1].[j], [dba.tbl1].[k], [dba.tbl1].[d], [dba.tbl1].[n], [dba.tbl1].[s] from [dba.tbl1] [dba.tbl1] order by 1, 2, 3, 4, 5,
 6
```
이로인해 rkcheck 시 실패가 발생해 ha모드를 실행할 수 없는 버그가 있습니다.

### Implementation

이를 해결하기위해 rkcheck에서 제약사항을 확인 할 때, VCLASS 에 대해서는 제약사항을 수행하지 않도록 변경하였습니다.

### Remarks

다음과 같이 테스트를 진행했습니다.

1. 클래스 및 뷰 생성
```
csql> create table tbl1 (i int primary key, j int, k int, d double, n numeric, s varchar(100)) dont_reuse_oid;

csql> create view  t1 as select * from tbl1 order by 1,2,3,4,5,6;

```

2. 슬래이브 재시작
```
[youngjun@youngjun4 ~]$ cubrid hb start
@ cubrid heartbeat start
@ cubrid master start
++ cubrid master start: success
@ HA processes start
@ cubrid server start: demodb

This may take a long time depending on the amount of recovery works to do.

CUBRID 11.5.0 (11.5.0.2128) (64 debug build)

++ cubrid server start: success
@ rkcheck start

Constraint checks completed for all replication-enabled tables.

++ rkcheck start: success
@ copylogdb start
++ copylogdb start: success
@ applylogdb start
++ applylogdb start: success
++ HA processes start: success
```

3. 실행 후 슬레이브 스키마 및 db_class 정보
```
csql> ;sc t1

=== <Help: Schema of a Class> ===


 <VClass Name>

     dba.t1

 <Attributes>

     i                    INTEGER
     j                    INTEGER
     k                    INTEGER
     d                    DOUBLE
     n                    NUMERIC(15,0)
     s                    CHARACTER VARYING(100)

 <Query_specifications>

     select [dba.tbl1].[i], [dba.tbl1].[j], [dba.tbl1].[k], [dba.tbl1].[d], [dba.tbl1].[n], [dba.tbl1].[s] from [dba.tbl1] [dba.tbl1] order by 1, 2, 3, 4, 5,
 6


Committed.

```

```
csql> select class_name, class_type, is_replication_class from db_class;

=== <Result of SELECT Command in Line 1> ===

  class_name            class_type            is_replication_class
==================================================================
....
  'tbl1'                'CLASS'               'YES'
  't1'                  'VCLASS'              'YES'
```

추가로 마스터에서 테이블과 뷰 삭제시에도 동일한 문제가 발생된다고 리포팅되어있는데, 
분석 결과 추가적으로 이상한 점은 없었고, 
슬레이브의 ha가 종료된 상태에서 마스터측에서 drop 을 수행했기때문에 
삭제 내용이 슬레이브에 반영되지 않은 상태로 추측됩니다
재현 시나리오는 없어 리포팅에 명시된 tc 를 로컬에서 수행했습니다.

```
============= TEST ==================
[ENV START] h1
STARTED
[TESTCASE] with_online/HA/shell/_27_features_920/bug_bts_16049_03/cases/bug_bts_16049_03.sh EnvId=h1 [OK]
[ENV STOP] h1
============= PRINT SUMMARY ==================
Test Category:shell
Total Case:1
Total Execution Case:1
Total Success Case:1
Total Fail Case:0
Total Skip Case:0

TEST COMPLETE
[SHELL] TEST END (Tue Mar 24 06:07:02 UTC 2026)
[SHELL] ELAPSE TIME: 294 seconds

```