### PR TITLE
[CBRD-26638] Add --echo CLI option to csql for persistent echo mode

### DIFF
--- a/msg/en_US.utf8/csql.msg
+++ b/msg/en_US.utf8/csql.msg
@@ -50,6 +50,7 @@ valid options:\n\
       --no-pager               do not use pager\n\
       --no-single-line         turn off single line oriented execution\n\
       --no-trigger-action      disable trigger action\n\
+      --echo                   print SQL statements before execution\n\
       --delimiter=ARG          delimiter between columns (only work with -q)\n\
       --enclosure=ARG          enclosure for result string (only work with -q)\n\
 \n\

--- a/msg/ko_KR.utf8/csql.msg
+++ b/msg/ko_KR.utf8/csql.msg
@@ -50,6 +50,7 @@ $set 1 MSGCAT_CSQL_SET_CSQL
       --no-pager               페이지 단위로 표시 안 함\n\
       --no-single-line         단일 라인 실행 안 함\n\
       --no-trigger-action      트리거 실행 안함\n\
+      --echo                   SQL 실행 전에 SQL 문장 출력\n\
       --delimiter=ARG          컬럼간 구분자 (-q에서만 사용 가능)\n\
       --enclosure=ARG          결과 문자열 엔클러저 (-q에서만 사용 가능)\n\
 \n\

--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -3393,6 +3393,11 @@ csql (const char *argv0, CSQL_ARGUMENT * csql_arg)
       csql_Pager_cmd[0] = '\0';
     }
 
+  if (csql_arg->echo_on)
+    {
+      csql_Is_echo_on = true;
+    }
+
   lang_init_console_txt_conv ();
 
   if (csql_Is_interactive)

--- a/src/executables/csql.h
+++ b/src/executables/csql.h
@@ -302,6 +302,7 @@ extern "C"
 #endif				/* CSQL_NO_LONGGING */
     bool midxkey_print;
     bool noprint_entrymsg;
+    bool echo_on;
   } CSQL_ARGUMENT;
 
   typedef struct

--- a/src/executables/csql_launcher.c
+++ b/src/executables/csql_launcher.c
@@ -149,6 +149,7 @@ main (int argc, char *argv[])
     {CSQL_QUERY_COLUMN_ENCLOSURE_L, 1, 0, CSQL_QUERY_COLUMN_ENCLOSURE_S},
     {CSQL_LOADDB_OUTPUT_L, 0, 0, CSQL_LOADDB_OUTPUT_S},
     {CSQL_NOPRINT_TITLE_L, 0, 0, CSQL_NOPRINT_TITLE_S},
+    {CSQL_ECHO_L, 0, 0, CSQL_ECHO_S},
     {VERSION_L, 0, 0, VERSION_S},
     {0, 0, 0, 0}
   };
@@ -350,6 +351,10 @@ main (int argc, char *argv[])
 
 	case CSQL_NOPRINT_TITLE_S:
 	  csql_arg.noprint_entrymsg = true;
+	  break;
+
+	case CSQL_ECHO_S:
+	  csql_arg.echo_on = true;
 	  break;
 
 	case VERSION_S:

--- a/src/executables/utility.h
+++ b/src/executables/utility.h
@@ -1492,6 +1492,8 @@ typedef struct _ha_config
 #define CSQL_SYSADM_REBUILD_CATALOG_L           "sysadm-rebuild-catalog"
 #define CSQL_NOPRINT_TITLE_S			12021
 #define CSQL_NOPRINT_TITLE_L			"skip-title"
+#define CSQL_ECHO_S				12022
+#define CSQL_ECHO_L				"echo"
 
 #define COMMDB_SERVER_LIST_S                    'P'
 #define COMMDB_SERVER_LIST_L                    "server-list"


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26638

## Description

`csql` 유틸리티에 `--echo` 커맨드라인 옵션을 추가하여, 시작 시 echo 모드를 활성화하고 각 SQL 문을 실행 전에 출력하도록 한다.

현재 `csql_Is_echo_on` 의 기본값은 `false` 이며, 이를 활성화하는 유일한 방법은 인터랙티브 세션 명령 `;echo on` 뿐이다. 셸에서 비대화식으로 설정할 수 없어 자동화 스크립트나 AI 에이전트 기반 디버깅에 불편함이 있다.

### 사용법

```bash
csql -udba testdb -S -i test.sql --echo
csql -udba testdb -S -c "SELECT 1; SELECT 2+2;" --echo
```

## Implementation

| 파일 | 변경 내용 |
|------|-----------|
| `src/executables/utility.h` | `CSQL_ECHO_S` (12022) 및 `CSQL_ECHO_L` ("echo") 옵션 상수 추가 |
| `src/executables/csql.h` | `CSQL_ARGUMENT` 구조체에 `bool echo_on` 필드 추가 |
| `src/executables/csql_launcher.c` | `csql_option[]` 배열에 옵션 등록; `CSQL_ECHO_S` 케이스 처리 |
| `src/executables/csql.c` | `csql()` 함수에서 `start_csql()` 호출 전에 `csql_arg->echo_on` 을 `csql_Is_echo_on` 에 적용 |
| `msg/en_US.utf8/csql.msg` | 사용법 메시지에 `--echo` 추가 |
| `msg/ko_KR.utf8/csql.msg` | 사용법 메시지에 `--echo` 한국어 번역 추가 |

## Remarks

- 기존 사용자의 동작 변경 없음 (echo는 여전히 기본 off)
- `--echo` 로 시작 후에도 `;echo off` 세션 명령으로 비활성화 가능
- 기존 `;echo on/off` 세션 명령어와 완전히 호환
- API 변경 없음; `CSQL_ARGUMENT` 는 csql 바이너리 내부 구조