### PR TITLE
[CBRD-26622] CREATE TABLE ... LIKE ... 복제 옵션 누락 수정

### DIFF
--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -9240,6 +9240,7 @@ do_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
   DB_QUERY_TYPE *query_columns = NULL;
   PT_NODE *tbl_opt = NULL;
   bool found_reuse_oid_option = false, reuse_oid = false;
+  bool is_replication_on = true;
   bool do_rollback_on_error = false;
   bool do_abort_class_on_error = false;
   bool do_flush_class_mop = false;
@@ -9587,7 +9588,16 @@ do_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
 	    }
 	}
 
-      if (IS_CREATE_STMT_SET_REPL_OPTION (tbl_opt_replication))
+      if (create_like)
+	{
+	  is_replication_on = !(source_class->flags & SM_CLASSFLAG_DATA_REPLICATION_OFF);
+	}
+      else
+	{
+	  is_replication_on = IS_CREATE_STMT_SET_REPL_OPTION (tbl_opt_replication);
+	}
+
+      if (is_replication_on)
 	{
 	  error = check_ha_repl_constraint (class_obj);
 	  if (error != NO_ERROR)


### PR DESCRIPTION
[<http://jira.cubrid.org/browse/CBRD-26622 >](http://jira.cubrid.org/browse/CBRD-26622)

### Purpose

CREATE TABLE ... LIKE ... 는 source 테이블의 스키마 정보와 동일한 새 테이블을 만드는 명령어입니다. 
복제 옵션을 추가하는 feature 에서 이에 대한 처리가 누락되어 해당 명령어를 이용해 새 테이블을 생성할 경우 
복제 옵션이 언제나 ON으로 생성되는 버그가 있어 수정합니다.
```
SELECT class_name, is_replication_class 
FROM db_class 
WHERE class_name IN ('repl_off_pk', 'repl_off_pk_like')
ORDER BY class_name;

=== <Result of SELECT Command in Line 4> ===

  class_name            is_replication_class
============================================
  'repl_off_pk'         'NO'                
  'repl_off_pk_like'    'YES'  
```
### Implementation

새로 생성되는 테이블의 복제 옵션 설정 전 어떤 복제 옵션을 설정할지 결정하게되는데, 
create_like 일 경우 원본이 되는 테이블로부터 복제 옵션을 확인하고, 
일반 생성일 경우 쿼리문에 명시된 복제 옵션(혹은 누락이라면 기본값) 으로 테이블의 옵션을 설정하도록 수정했습니다.

### Remarks

```
csql> create table repl_on (a int primary key);
Execute OK. (0.018001 sec) Committed. (0.034001 sec)

1 command(s) successfully processed.

csql> create table repl_off(a int primary key) replication off;
Execute OK. (0.016000 sec) Committed. (0.001000 sec)

1 command(s) successfully processed.

csql> create table repl_on_like like repl_on;
Execute OK. (0.014000 sec) Committed. (0.001000 sec)

1 command(s) successfully processed.

csql> create table repl_off_like like repl_off;
Execute OK. (0.014001 sec) Committed. (0.001000 sec)

1 command(s) successfully processed.
```
위와 같이 테이블을 생성했을 때, 

```
csql> select class_name, is_replication_class from db_class;

=== <Result of SELECT Command in Line 1> ===

  class_name            is_replication_class
============================================

  'repl_on'             'YES'
  'repl_off'            'NO'
  'repl_on_like'        'YES'
  'repl_off_like'       'NO'
```
와 같은 결과가 출력됩니다.


추가로 replication 옵션과 like를 함께 사용할 경우 에러입니다.