### PR TITLE
[CBRD-26570] Re-enable heap_recdes_contains_oos in heap_record_replace_oos_oids

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -7963,7 +7963,7 @@ heap_record_replace_oos_oids_with_values_if_exists (THREAD_ENTRY * thread_p, HEA
 
   // HOTFIX!
   // todo: this function is buggy. by doing this, we give up unloaddb.
-  return S_SUCCESS;
+  // return S_SUCCESS;
 
   if (!heap_recdes_contains_oos (context->recdes_p))
     {


### PR DESCRIPTION
## Description
`heap_record_replace_oos_oids_with_values_if_exists()` 함수에서 OOS OID를 실제 값으로 치환하는 로직이 HOTFIX로 비활성화되어 있었습니다. 이로 인해 unloaddb 등에서 OOS 데이터를 정상적으로 처리하지 못하는 문제가 있었습니다.

## Implementation
- `src/storage/heap_file.c`의 `heap_record_replace_oos_oids_with_values_if_exists()` 함수에서 early return (`return S_SUCCESS`)을 주석 처리하여 `heap_recdes_contains_oos()` 호출 경로를 다시 활성화했습니다.

## Remarks
- 해당 early return은 기존 버그로 인한 임시 HOTFIX였으며, 이번 변경으로 OOS OID 치환 로직이 다시 동작합니다.
- unloaddb에서 OOS 데이터가 정상적으로 export 되는지 검증이 필요합니다.