### PR TITLE
[CBRD-26646] Table alias issue when setting UPDATE DBLink query in trigger

### DIFF
--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -11785,7 +11785,7 @@ pt_convert_dblink_delete_query (PARSER_CONTEXT * parser, PT_NODE * node, SERVER_
 	{
 	  char *a_name = NULL, *t_name, *r_name;
 
-	  if (spec->info.spec.range_var)
+	  if (spec->info.spec.remote_server_name && spec->info.spec.range_var)
 	    {
 	      a_name = (char *) spec->info.spec.range_var->info.name.original;
 	      /* to skip aliased name at rewriting for mariadb and etc. */
@@ -11864,7 +11864,7 @@ pt_convert_dblink_update_query (PARSER_CONTEXT * parser, PT_NODE * node, SERVER_
 
   for (spec = node->info.update.spec; spec; spec = spec->next)
     {
-      if (spec->info.spec.range_var)
+      if (spec->info.spec.remote_server_name && spec->info.spec.range_var)
 	{
 	  char *a_name = (char *) spec->info.spec.range_var->info.name.original;
 

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -11789,7 +11789,7 @@ pt_convert_dblink_delete_query (PARSER_CONTEXT * parser, PT_NODE * node, SERVER_
 	    {
 	      a_name = (char *) spec->info.spec.range_var->info.name.original;
 	      /* to skip aliased name at rewriting for mariadb and etc. */
-	      if (spec->info.spec.entity_name
+	      if (a_name && spec->info.spec.entity_name
 		  && strcasecmp (a_name, spec->info.spec.entity_name->info.name.original) == 0)
 		{
 		  spec->info.spec.range_var = NULL;
@@ -11862,13 +11862,15 @@ pt_convert_dblink_update_query (PARSER_CONTEXT * parser, PT_NODE * node, SERVER_
       return;
     }
 
-  for (spec = node->info.delete_.spec; spec; spec = spec->next)
+  for (spec = node->info.update.spec; spec; spec = spec->next)
     {
       if (spec->info.spec.range_var)
 	{
 	  char *a_name = (char *) spec->info.spec.range_var->info.name.original;
+
 	  /* to skip aliased name at rewriting for mariadb and etc. */
-	  if (spec->info.spec.entity_name && strcasecmp (a_name, spec->info.spec.entity_name->info.name.original) == 0)
+	  if (a_name && spec->info.spec.entity_name
+	      && strcasecmp (a_name, spec->info.spec.entity_name->info.name.original) == 0)
 	    {
 	      spec->info.spec.range_var = NULL;
 	    }

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -11785,11 +11785,12 @@ pt_convert_dblink_delete_query (PARSER_CONTEXT * parser, PT_NODE * node, SERVER_
 	{
 	  char *a_name = NULL, *t_name, *r_name;
 
-	  if (spec->info.spec.remote_server_name && spec->info.spec.range_var)
+	  if (spec->info.spec.range_var)
 	    {
 	      a_name = (char *) spec->info.spec.range_var->info.name.original;
+
 	      /* to skip aliased name at rewriting for mariadb and etc. */
-	      if (a_name && spec->info.spec.entity_name
+	      if (a_name && spec->info.spec.remote_server_name && spec->info.spec.entity_name
 		  && strcasecmp (a_name, spec->info.spec.entity_name->info.name.original) == 0)
 		{
 		  spec->info.spec.range_var = NULL;
@@ -11864,12 +11865,12 @@ pt_convert_dblink_update_query (PARSER_CONTEXT * parser, PT_NODE * node, SERVER_
 
   for (spec = node->info.update.spec; spec; spec = spec->next)
     {
-      if (spec->info.spec.remote_server_name && spec->info.spec.range_var)
+      if (spec->info.spec.range_var)
 	{
 	  char *a_name = (char *) spec->info.spec.range_var->info.name.original;
 
 	  /* to skip aliased name at rewriting for mariadb and etc. */
-	  if (a_name && spec->info.spec.entity_name
+	  if (a_name && spec->info.spec.entity_name && spec->info.spec.remote_server_name
 	      && strcasecmp (a_name, spec->info.spec.entity_name->info.name.original) == 0)
 	    {
 	      spec->info.spec.range_var = NULL;

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -11854,11 +11854,25 @@ pt_convert_dblink_update_query (PARSER_CONTEXT * parser, PT_NODE * node, SERVER_
 {
   int local_upd = 0, remote_upd = 0;
   int error;
+  PT_NODE *spec;
 
   parser_walk_tree (parser, node, pt_convert_dblink_synonym, NULL, NULL, NULL);
   if (pt_has_error (parser))
     {
       return;
+    }
+
+  for (spec = node->info.delete_.spec; spec; spec = spec->next)
+    {
+      if (spec->info.spec.range_var)
+	{
+	  char *a_name = (char *) spec->info.spec.range_var->info.name.original;
+	  /* to skip aliased name at rewriting for mariadb and etc. */
+	  if (spec->info.spec.entity_name && strcasecmp (a_name, spec->info.spec.entity_name->info.name.original) == 0)
+	    {
+	      spec->info.spec.range_var = NULL;
+	    }
+	}
     }
 
   error = pt_check_update_set (parser, node, &local_upd, &remote_upd);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26646>

### Purpose

DBLink UPDATE 쿼리에 Table alias를 삭제하도록 조치해야 합니다. CUBRID에서는 alias가 설정되어도 동작에 문제가 없지만 오라클처럼 외부 DB에서는 오류가 발생합니다.

### Implementation

DELETE 쿼리의 경우 pt_convert_dblink_delete_query에서 이미 alias를 처리하고 있습니다. 이와 동일하게 pt_convert_dblink_update_query에도 적용.

### Remarks

N/A
