### PR TITLE
[CBRD-26648] Support partial aggregate with hash table

### DIFF
--- a/src/query/parallel/px_heap_scan/px_heap_scan.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan.cpp
@@ -907,7 +907,7 @@ namespace parallel_heap_scan
 	fetch_val_list (m_thread_p, m_xasl->outptr_list->valptrp, m_vd, nullptr, nullptr, NULL, true);
 	if (m_g_agg_domain_resolve_need)
 	  {
-	    qexec_resolve_domains_for_aggregation_for_parallel_heap_scan (m_thread_p, m_xasl, m_vd,
+	    qexec_resolve_domains_for_aggregation_for_parallel_heap_scan_g_agg (m_thread_p, m_xasl, m_vd,
 		&m_xasl->proc.buildlist.g_agg_domains_resolved);
 	  }
       }

--- a/src/query/parallel/px_heap_scan/px_heap_scan_checker.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_checker.cpp
@@ -484,10 +484,6 @@ namespace parallel_heap_scan
     switch (arg->type)
       {
       case BUILDLIST_PROC:
-	if (arg->proc.buildlist.g_hash_eligible)
-	  {
-	    set_flag (result, CANNOT_LIST_MERGE);
-	  }
 	break;
       case BUILDVALUE_PROC:
 	if (arg->proc.buildvalue.agg_list)

--- a/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
@@ -21,7 +21,6 @@
  */
 
 #include "px_heap_scan_result_handler.hpp"
-#include "db_function.hpp"
 #include "error_code.h"
 #include "error_manager.h"
 #include "memory_alloc.h"
@@ -29,19 +28,12 @@
 #include "porting.h"
 #include "query_opfunc.h"
 #include "list_file.h"
-#include "regu_var.hpp"
-#include "storage_common.h"
-#include "system.h"
 #include "dbtype_def.h"
-#include "query_list.h"
 #include "object_representation.h"
-#include <atomic>
 #include <chrono>
 #include "dbtype.h"
 #include "fetch.h"
 #include "query_aggregate.hpp"
-#include "thread_compat.hpp"
-#include "xasl.h"
 #include "xasl_aggregate.hpp"
 
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
@@ -163,6 +155,16 @@ namespace parallel_heap_scan
 	    if (list_id != nullptr && list_id->type_list.type_cnt > 0)
 	      {
 		qfile_destroy_list (thread_p, list_id);
+		QFILE_FREE_AND_INIT_LIST_ID (list_id);
+	      }
+	  }
+	m_.writer_results.clear();
+	for (QFILE_LIST_ID *list_id : m_.hgby_results)
+	  {
+	    if (list_id != nullptr && list_id->type_list.type_cnt > 0)
+	      {
+		qfile_destroy_list (thread_p, list_id);
+		QFILE_FREE_AND_INIT_LIST_ID (list_id);
 	      }
 	  }
 	m_.writer_results.clear();
@@ -529,7 +531,9 @@ namespace parallel_heap_scan
 	else
 	  {
 	    qfile_destroy_list (thread_p, list_id);
+	    QFILE_FREE_AND_INIT_LIST_ID (list_id);
 	  }
+	list_id = nullptr;
       }
     lists.clear();
     if (tmp_merged_list != nullptr)
@@ -573,6 +577,11 @@ namespace parallel_heap_scan
 		}
 	    }
 	}
+
+	if (m_interrupt_p->get_code() != parallel_query::interrupt::interrupt_code::NO_INTERRUPT)
+	  {
+	    return S_ERROR;
+	  }
 
 	merge_list_ids (thread_p, dest, m_.writer_results);
 

--- a/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
@@ -167,7 +167,7 @@ namespace parallel_heap_scan
 		QFILE_FREE_AND_INIT_LIST_ID (list_id);
 	      }
 	  }
-	m_.writer_results.clear();
+	m_.hgby_results.clear();
       }
     else if constexpr (result_type == RESULT_TYPE::XASL_SNAPSHOT)
       {

--- a/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
@@ -549,7 +549,7 @@ namespace parallel_heap_scan
 		qfile_destroy_list (thread_p, dest);
 	      }
 	    qfile_copy_list_id (dest, tmp_merged_list, true, QFILE_MOVE_DEPENDENT);
-	    qfile_clear_list_id (tmp_merged_list);
+	    QFILE_FREE_AND_INIT_LIST_ID (tmp_merged_list);
 	  }
       }
   }

--- a/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
@@ -22,9 +22,11 @@
 
 #include "px_heap_scan_result_handler.hpp"
 #include "db_function.hpp"
+#include "error_code.h"
 #include "error_manager.h"
 #include "memory_alloc.h"
 #include "object_primitive.h"
+#include "porting.h"
 #include "query_opfunc.h"
 #include "list_file.h"
 #include "regu_var.hpp"
@@ -38,6 +40,8 @@
 #include "dbtype.h"
 #include "fetch.h"
 #include "query_aggregate.hpp"
+#include "thread_compat.hpp"
+#include "xasl.h"
 #include "xasl_aggregate.hpp"
 
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
@@ -94,10 +98,10 @@ namespace parallel_heap_scan
     m_err_messages_p = err_messages_p;
     if constexpr (result_type == RESULT_TYPE::MERGEABLE_LIST)
       {
-	m_.result_p = nullptr;
-	m_.orig_xasl_tree_for_domain_resolve = orig_xasl_tree_for_domain_resolve;
+	m_.orig_xasl = orig_xasl_tree_for_domain_resolve;
 	m_.active_results = parallelism;
 	m_.is_list_id_domain_resolved = false;
+	m_.g_hash_eligible = (bool) orig_xasl_tree_for_domain_resolve->proc.buildlist.g_hash_eligible;
       }
     else if constexpr (result_type == RESULT_TYPE::XASL_SNAPSHOT)
       {
@@ -254,12 +258,11 @@ namespace parallel_heap_scan
 	  {
 	    m_err_messages_p->move_top_error_message_to_this();
 	    m_interrupt_p->set_code (parallel_query::interrupt::interrupt_code::ERROR_INTERRUPTED_FROM_WORKER_THREAD);
-	    /* error occurred, return false to stop the writer */
 	    return;
 	  }
 	tl.tpl_buf.size = DB_PAGESIZE;
 	int total_val_cnt = 0;
-	for (XASL_NODE *xasl = m_.orig_xasl_tree_for_domain_resolve; xasl != nullptr; xasl = xasl->scan_ptr)
+	for (XASL_NODE *xasl = m_.orig_xasl; xasl != nullptr; xasl = xasl->scan_ptr)
 	  {
 	    total_val_cnt += xasl->val_list->val_cnt;
 	  }
@@ -269,7 +272,20 @@ namespace parallel_heap_scan
 	    dbval.domain.general_info.is_null = 1;
 	  }
 	tl.val_list_domain_resolved = false;
-	tl.xasl_tree_for_domain_resolve = curr_xasl;
+	tl.xasl = curr_xasl;
+	tl.agg_hash_state = HS_NONE;
+	tl.g_agg_domains_resolved = true;
+	if (m_.g_hash_eligible)
+	  {
+	    if (qexec_alloc_agg_hash_context_buildlist_xasl (thread_p, curr_xasl, vd->xasl_state, true) != NO_ERROR)
+	      {
+		m_err_messages_p->move_top_error_message_to_this();
+		m_interrupt_p->set_code (parallel_query::interrupt::interrupt_code::ERROR_INTERRUPTED_FROM_WORKER_THREAD);
+		return;
+	      }
+	    tl.agg_hash_state = HS_ACCEPT_ALL;
+	    tl.g_agg_domains_resolved = false;
+	  }
       }
     else if constexpr (result_type == RESULT_TYPE::XASL_SNAPSHOT)
       {
@@ -296,6 +312,17 @@ namespace parallel_heap_scan
   {
     if constexpr (result_type == RESULT_TYPE::MERGEABLE_LIST)
       {
+	AGGREGATE_HASH_CONTEXT *context = tl.xasl->proc.buildlist.agg_hash_context;;
+	if (m_.g_hash_eligible)
+	  {
+	    if (qdata_save_agg_htable_to_list (thread_p, context->hash_table, tl.writer_result_p,
+					       context->part_list_id, context->temp_dbval_array) != NO_ERROR)
+	      {
+		m_err_messages_p->move_top_error_message_to_this();
+		m_interrupt_p->set_code (parallel_query::interrupt::interrupt_code::ERROR_INTERRUPTED_FROM_WORKER_THREAD);
+	      }
+	    qfile_close_list (thread_p, context->part_list_id);
+	  }
 	qfile_close_list (thread_p, tl.writer_result_p);
 
 	assert (tl.writer_result_p->last_pgptr == nullptr);
@@ -314,7 +341,7 @@ namespace parallel_heap_scan
 	  std::lock_guard<std::mutex> lock (m_result_mutex);
 
 	  HL_HEAPID heap_id = db_change_private_heap (thread_p, 0);
-	  XASL_NODE *xptr = m_.orig_xasl_tree_for_domain_resolve;
+	  XASL_NODE *xptr = m_.orig_xasl;
 	  int i = 0;
 	  for (; xptr != nullptr; xptr = xptr->scan_ptr)
 	    {
@@ -336,6 +363,12 @@ namespace parallel_heap_scan
 	      pr_clear_value (&dbval);
 	    }
 	  tl.dbvals_for_domain_resolve.clear();
+
+	  if (m_.g_hash_eligible)
+	    {
+	      m_.hgby_results.push_back (context->part_list_id);
+	      context->part_list_id = NULL;
+	    }
 
 	  m_.active_results--;
 	  if (m_.active_results == 0)
@@ -471,6 +504,52 @@ namespace parallel_heap_scan
       }
   }
 
+  void merge_list_ids (THREAD_ENTRY *thread_p, QFILE_LIST_ID *dest, std::vector<QFILE_LIST_ID *> &lists)
+  {
+    QFILE_LIST_ID *tmp_merged_list = nullptr;
+    for (QFILE_LIST_ID *list_id : lists)
+      {
+	assert (list_id != nullptr);
+	assert (list_id->last_pgptr == nullptr);
+	if (list_id->tuple_cnt > 0)
+	  {
+	    if (tmp_merged_list == nullptr)
+	      {
+		tmp_merged_list = list_id;
+	      }
+	    else
+	      {
+		qfile_connect_list (thread_p, tmp_merged_list, list_id);
+	      }
+	  }
+	else
+	  {
+	    qfile_destroy_list (thread_p, list_id);
+	  }
+      }
+    lists.clear();
+    if (tmp_merged_list != nullptr)
+      {
+	if (dest->tuple_cnt > 0)
+	  {
+	    if (dest->last_pgptr != nullptr)
+	      {
+		qfile_close_list (thread_p, dest);
+	      }
+	    qfile_connect_list (thread_p, dest, tmp_merged_list);
+	  }
+	else
+	  {
+	    if (dest->type_list.type_cnt > 0)
+	      {
+		qfile_destroy_list (thread_p, dest);
+	      }
+	    qfile_copy_list_id (dest, tmp_merged_list, true, QFILE_MOVE_DEPENDENT);
+	    qfile_clear_list_id (tmp_merged_list);
+	  }
+      }
+  }
+
   template <RESULT_TYPE result_type>
   SCAN_CODE result_handler<result_type>::read (THREAD_ENTRY *thread_p, read_dest_type *dest)
   {
@@ -490,49 +569,15 @@ namespace parallel_heap_scan
 		}
 	    }
 	}
-	for (QFILE_LIST_ID *list_id : m_.writer_results)
+
+	merge_list_ids (thread_p, dest, m_.writer_results);
+
+	if (m_.g_hash_eligible)
 	  {
-	    assert (list_id != nullptr);
-	    assert (list_id->last_pgptr == nullptr);
-	    if (list_id->tuple_cnt > 0)
-	      {
-		if (m_.result_p == nullptr)
-		  {
-		    m_.result_p = list_id;
-		  }
-		else
-		  {
-		    qfile_connect_list (thread_p, m_.result_p, list_id);
-		  }
-	      }
-	    else
-	      {
-		qfile_destroy_list (thread_p, list_id);
-	      }
+	    BUILDLIST_PROC_NODE *buildlist_proc = &m_.orig_xasl->proc.buildlist;
+	    merge_list_ids (thread_p, buildlist_proc->agg_hash_context->part_list_id, m_.hgby_results);
 	  }
-	m_.writer_results.clear();
-	if (m_.result_p != nullptr)
-	  {
-	    if (dest->tuple_cnt > 0)
-	      {
-		if (dest->last_pgptr != nullptr)
-		  {
-		    qfile_close_list (thread_p, dest);
-		  }
-		qfile_connect_list (thread_p, dest, m_.result_p);
-	      }
-	    else
-	      {
-		if (dest->type_list.type_cnt > 0)
-		  {
-		    qfile_destroy_list (thread_p, dest);
-		  }
-		qfile_copy_list_id (dest, m_.result_p, true, QFILE_MOVE_DEPENDENT);
-		qfile_clear_list_id (m_.result_p);
-	      }
-	  }
-	m_.result_p = nullptr;
-	/* immediately return false to stop the reader */
+
 	return S_END;
       }
     else if constexpr (result_type == RESULT_TYPE::XASL_SNAPSHOT)
@@ -676,7 +721,6 @@ namespace parallel_heap_scan
       {
 	int err_code = NO_ERROR;
 	QPROC_TPLDESCR_STATUS status;
-	QFILE_TUPLE_RECORD *tplrec;
 
 	OUTPTR_LIST *input = (OUTPTR_LIST *)src;
 
@@ -691,7 +735,7 @@ namespace parallel_heap_scan
 	  }
 	if (unlikely (!tl.val_list_domain_resolved))
 	  {
-	    XASL_NODE *xptr = tl.xasl_tree_for_domain_resolve;
+	    XASL_NODE *xptr = tl.xasl;
 	    int i = 0;
 	    tl.val_list_domain_resolved = true;
 
@@ -719,11 +763,36 @@ namespace parallel_heap_scan
 
 	if (likely (status == QPROC_TPLDESCR_SUCCESS))
 	  {
-	    if (unlikely (qfile_generate_tuple_into_list (thread_p, tl.writer_result_p, T_NORMAL) != NO_ERROR))
+	    bool output_tuple = true;
+	    if (tl.agg_hash_state == HS_ACCEPT_ALL)
 	      {
-		m_err_messages_p->move_top_error_message_to_this();
-		m_interrupt_p->set_code (parallel_query::interrupt::interrupt_code::ERROR_INTERRUPTED_FROM_WORKER_THREAD);
-		return false;
+		if (unlikely (!tl.g_agg_domains_resolved))
+		  {
+		    if (qexec_resolve_domains_for_aggregation_for_parallel_heap_scan_g_agg (thread_p, tl.xasl, tl.vd,
+			&tl.g_agg_domains_resolved) != NO_ERROR)
+		      {
+			m_err_messages_p->move_top_error_message_to_this();
+			m_interrupt_p->set_code (parallel_query::interrupt::interrupt_code::ERROR_INTERRUPTED_FROM_WORKER_THREAD);
+			return false;
+		      }
+		  }
+		if (qexec_hash_gby_agg_tuple_public (thread_p, tl.xasl, tl.vd->xasl_state, &tl.tpl_buf,
+						     & (tl.writer_result_p->tpl_descr), tl.writer_result_p, &output_tuple) != NO_ERROR)
+		  {
+		    m_err_messages_p->move_top_error_message_to_this();
+		    m_interrupt_p->set_code (parallel_query::interrupt::interrupt_code::ERROR_INTERRUPTED_FROM_WORKER_THREAD);
+		    return false;
+		  }
+		tl.agg_hash_state = tl.xasl->proc.buildlist.agg_hash_context->state;
+	      }
+	    if (output_tuple)
+	      {
+		if (unlikely (qfile_generate_tuple_into_list (thread_p, tl.writer_result_p, T_NORMAL) != NO_ERROR))
+		  {
+		    m_err_messages_p->move_top_error_message_to_this();
+		    m_interrupt_p->set_code (parallel_query::interrupt::interrupt_code::ERROR_INTERRUPTED_FROM_WORKER_THREAD);
+		    return false;
+		  }
 	      }
 	  }
 	else if (unlikely (status == QPROC_TPLDESCR_FAILURE))
@@ -952,7 +1021,7 @@ namespace parallel_heap_scan
     QFILE_TUPLE_RECORD tpl_buf;
     if (!tl_xasl_p->proc.buildvalue.agg_domains_resolved)
       {
-	if (qexec_resolve_domains_for_aggregation_for_parallel_heap_scan_aggregate (thread_p, tl_xasl_p, tl_vd,
+	if (qexec_resolve_domains_for_aggregation_for_parallel_heap_scan_buildvalue_proc (thread_p, tl_xasl_p, tl_vd,
 	    &tl_xasl_p->proc.buildvalue.agg_domains_resolved) != NO_ERROR)
 	  {
 	    return false;

--- a/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
@@ -576,6 +576,9 @@ namespace parallel_heap_scan
 	  {
 	    BUILDLIST_PROC_NODE *buildlist_proc = &m_.orig_xasl->proc.buildlist;
 	    merge_list_ids (thread_p, buildlist_proc->agg_hash_context->part_list_id, m_.hgby_results);
+	    /* Using HS_REJECT_ALL to force 'hash: partial' in trace during hash group by with part list IDs.
+	     * Refer to gstats in qdump_print_stats_text(). */
+	    m_.orig_xasl->groupby_stats.groupby_hash = HS_REJECT_ALL;
 	  }
 
 	return S_END;

--- a/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
@@ -327,7 +327,10 @@ namespace parallel_heap_scan
 		 * context->part_list_id will be destroyed in thread's qexec_clear_xasl */
 		hash_aggregate_append = false;
 	      }
-	    qfile_close_list (thread_p, context->part_list_id);
+	    if (context->part_list_id != NULL)
+	      {
+		qfile_close_list (thread_p, context->part_list_id);
+	      }
 	  }
 	qfile_close_list (thread_p, tl.writer_result_p);
 

--- a/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
@@ -313,7 +313,8 @@ namespace parallel_heap_scan
     if constexpr (result_type == RESULT_TYPE::MERGEABLE_LIST)
       {
 	AGGREGATE_HASH_CONTEXT *context = tl.xasl->proc.buildlist.agg_hash_context;
-	if (m_.g_hash_eligible)
+	bool hash_aggregate_append = m_.g_hash_eligible;
+	if (hash_aggregate_append)
 	  {
 	    if (qdata_save_agg_htable_to_list (thread_p, context->hash_table, tl.writer_result_p,
 					       context->part_list_id, context->temp_dbval_array) != NO_ERROR)
@@ -322,7 +323,7 @@ namespace parallel_heap_scan
 		m_interrupt_p->set_code (parallel_query::interrupt::interrupt_code::ERROR_INTERRUPTED_FROM_WORKER_THREAD);
 		/* for prevent data corruption at m_.hgby_results;
 		 * context->part_list_id will be destroyed in thread's qexec_clear_xasl */
-		m_.g_hash_eligible = false;
+		hash_aggregate_append = false;
 	      }
 	    qfile_close_list (thread_p, context->part_list_id);
 	  }
@@ -367,7 +368,7 @@ namespace parallel_heap_scan
 	    }
 	  tl.dbvals_for_domain_resolve.clear();
 
-	  if (m_.g_hash_eligible)
+	  if (hash_aggregate_append)
 	    {
 	      m_.hgby_results.push_back (context->part_list_id);
 	      context->part_list_id = NULL;

--- a/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
@@ -274,7 +274,7 @@ namespace parallel_heap_scan
 	tl.val_list_domain_resolved = false;
 	tl.xasl = curr_xasl;
 	tl.agg_hash_state = HS_NONE;
-	tl.g_agg_domains_resolved = true;
+	tl.g_agg_domains_resolved = TRUE;
 	if (m_.g_hash_eligible)
 	  {
 	    if (qexec_alloc_agg_hash_context_buildlist_xasl (thread_p, curr_xasl, vd->xasl_state, true) != NO_ERROR)
@@ -284,7 +284,7 @@ namespace parallel_heap_scan
 		return;
 	      }
 	    tl.agg_hash_state = HS_ACCEPT_ALL;
-	    tl.g_agg_domains_resolved = false;
+	    tl.g_agg_domains_resolved = FALSE;
 	  }
       }
     else if constexpr (result_type == RESULT_TYPE::XASL_SNAPSHOT)
@@ -312,7 +312,7 @@ namespace parallel_heap_scan
   {
     if constexpr (result_type == RESULT_TYPE::MERGEABLE_LIST)
       {
-	AGGREGATE_HASH_CONTEXT *context = tl.xasl->proc.buildlist.agg_hash_context;;
+	AGGREGATE_HASH_CONTEXT *context = tl.xasl->proc.buildlist.agg_hash_context;
 	if (m_.g_hash_eligible)
 	  {
 	    if (qdata_save_agg_htable_to_list (thread_p, context->hash_table, tl.writer_result_p,
@@ -320,6 +320,9 @@ namespace parallel_heap_scan
 	      {
 		m_err_messages_p->move_top_error_message_to_this();
 		m_interrupt_p->set_code (parallel_query::interrupt::interrupt_code::ERROR_INTERRUPTED_FROM_WORKER_THREAD);
+		/* for prevent data corruption at m_.hgby_results;
+		 * context->part_list_id will be destroyed in thread's qexec_clear_xasl */
+		m_.g_hash_eligible = false;
 	      }
 	    qfile_close_list (thread_p, context->part_list_id);
 	  }

--- a/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.hpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.hpp
@@ -29,6 +29,12 @@
 #include "px_interrupt.hpp"
 #include "xasl.h"
 #include "px_heap_scan_result_type.hpp"
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+#include <type_traits>
+#include <vector>
 
 namespace parallel_heap_scan
 {

--- a/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.hpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.hpp
@@ -78,17 +78,17 @@ namespace parallel_heap_scan
   {
     public:
       mergeable_list_variables()
-	: result_p (nullptr),
-	  orig_xasl_tree_for_domain_resolve (nullptr),
+	: orig_xasl (nullptr),
 	  active_results (0),
 	  is_list_id_domain_resolved (false) {}
       ~mergeable_list_variables() = default;
       std::vector<QFILE_LIST_ID *> writer_results;
       std::mutex writer_results_mutex;
-      QFILE_LIST_ID *result_p;
-      XASL_NODE *orig_xasl_tree_for_domain_resolve;
+      XASL_NODE *orig_xasl;
       int active_results;
       bool is_list_id_domain_resolved;
+      std::vector<QFILE_LIST_ID *> hgby_results;
+      bool g_hash_eligible;
   };
 
   class xasl_snapshot_variables
@@ -110,15 +110,17 @@ namespace parallel_heap_scan
       mergeable_list_tls()
 	: writer_result_p (nullptr),
 	  vd (nullptr),
-	  xasl_tree_for_domain_resolve (nullptr),
+	  xasl (nullptr),
 	  val_list_domain_resolved (false) {}
       ~mergeable_list_tls() = default;
       QFILE_LIST_ID *writer_result_p;
       QFILE_TUPLE_RECORD tpl_buf;
       VAL_DESCR *vd;
-      XASL_NODE *xasl_tree_for_domain_resolve;
+      XASL_NODE *xasl;
       std::vector<DB_VALUE> dbvals_for_domain_resolve;
       bool val_list_domain_resolved;
+      AGGREGATE_HASH_STATE agg_hash_state;
+      int g_agg_domains_resolved;
   };
 
   class xasl_snapshot_tls

--- a/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.hpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.hpp
@@ -111,7 +111,9 @@ namespace parallel_heap_scan
 	: writer_result_p (nullptr),
 	  vd (nullptr),
 	  xasl (nullptr),
-	  val_list_domain_resolved (false) {}
+	  val_list_domain_resolved (false),
+	  agg_hash_state (HS_NONE),
+	  g_agg_domains_resolved (TRUE) {}
       ~mergeable_list_tls() = default;
       QFILE_LIST_ID *writer_result_p;
       QFILE_TUPLE_RECORD tpl_buf;

--- a/src/query/parallel/px_heap_scan/px_heap_scan_task.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_task.cpp
@@ -490,6 +490,7 @@ namespace parallel_heap_scan
     m_xasl_state->query_id = m_orig_vd->xasl_state->query_id;
     m_vd = &m_xasl_state->vd;
     memcpy (m_vd, m_orig_vd, sizeof (val_descr));
+    m_vd->xasl_state = m_xasl_state;
     if (m_orig_vd->dbval_cnt > 0)
       {
 	m_vd->dbval_ptr = (DB_VALUE *) db_private_alloc (&thread_ref, sizeof (DB_VALUE) * m_orig_vd->dbval_cnt);

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -721,7 +721,8 @@ static void qexec_clear_pred_xasl (THREAD_ENTRY * thread_p, PRED_EXPR * pred);
 static void qexec_set_xasl_trace_to_session (THREAD_ENTRY * thread_p, XASL_NODE * xasl);
 #endif /* SERVER_MODE */
 
-static int qexec_alloc_agg_hash_context (THREAD_ENTRY * thread_p, BUILDLIST_PROC_NODE * proc, XASL_STATE * xasl_state);
+static int qexec_alloc_agg_hash_context (THREAD_ENTRY * thread_p, BUILDLIST_PROC_NODE * proc, XASL_STATE * xasl_state,
+					 bool not_use_membuf);
 static void qexec_free_agg_hash_context (THREAD_ENTRY * thread_p, BUILDLIST_PROC_NODE * proc);
 static int qexec_build_agg_hkey (THREAD_ENTRY * thread_p, XASL_STATE * xasl_state, REGU_VARIABLE_LIST regu_list,
 				 QFILE_TUPLE tpl, AGGREGATE_HASH_KEY * key);
@@ -4509,6 +4510,16 @@ exit_on_error:
   assert (er_errid () != NO_ERROR);
   gbstate->state = er_errid ();
   goto wrapup;
+}
+
+int
+qexec_hash_gby_agg_tuple_public (THREAD_ENTRY * thread_p, xasl_node * xasl, XASL_STATE * xasl_state,
+				 QFILE_TUPLE_RECORD * tplrec, QFILE_TUPLE_DESCRIPTOR * tpldesc,
+				 QFILE_LIST_ID * groupby_list, bool * output_tuple)
+{
+  assert (xasl->type == BUILDLIST_PROC);
+  return qexec_hash_gby_agg_tuple (thread_p, xasl, xasl_state, &xasl->proc.buildlist, tplrec, tpldesc, groupby_list,
+				   output_tuple);
 }
 
 /*
@@ -15287,7 +15298,7 @@ qexec_execute_mainblock_internal (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
 		  /* disable hash aggregate evaluation when group by skip is possible */
 		  xasl->proc.buildlist.g_hash_eligible = 0;
 		}
-	      else if (qexec_alloc_agg_hash_context (thread_p, &xasl->proc.buildlist, xasl_state) != NO_ERROR)
+	      else if (qexec_alloc_agg_hash_context (thread_p, &xasl->proc.buildlist, xasl_state, false) != NO_ERROR)
 		{
 		  GOTO_EXIT_ON_ERROR;
 		}
@@ -20155,8 +20166,8 @@ qexec_resolve_domains_for_group_by (BUILDLIST_PROC_NODE * buildlist, OUTPTR_LIST
 }
 
 int
-qexec_resolve_domains_for_aggregation_for_parallel_heap_scan (THREAD_ENTRY * thread_p, XASL_NODE * xasl, void *vd,
-							      int *resolved)
+qexec_resolve_domains_for_aggregation_for_parallel_heap_scan_g_agg (THREAD_ENTRY * thread_p, XASL_NODE * xasl, void *vd,
+								    int *resolved)
 {
   QFILE_TUPLE_RECORD tpl = { NULL, 0 };
   VAL_DESCR *vd_p = (VAL_DESCR *) vd;
@@ -20165,8 +20176,8 @@ qexec_resolve_domains_for_aggregation_for_parallel_heap_scan (THREAD_ENTRY * thr
 }
 
 int
-qexec_resolve_domains_for_aggregation_for_parallel_heap_scan_aggregate (THREAD_ENTRY * thread_p, XASL_NODE * xasl,
-									void *vd, int *resolved)
+qexec_resolve_domains_for_aggregation_for_parallel_heap_scan_buildvalue_proc (THREAD_ENTRY * thread_p, XASL_NODE * xasl,
+									      void *vd, int *resolved)
 {
   QFILE_TUPLE_RECORD tpl = { NULL, 0 };
   VAL_DESCR *vd_p = (VAL_DESCR *) vd;
@@ -26810,6 +26821,14 @@ qexec_clear_pred_xasl (THREAD_ENTRY * thread_p, PRED_EXPR * pred)
     }
 }
 
+int
+qexec_alloc_agg_hash_context_buildlist_xasl (THREAD_ENTRY * thread_p, xasl_node * xasl, XASL_STATE * xasl_state,
+					     bool not_use_membuf)
+{
+  assert (xasl->type == BUILDLIST_PROC);
+  return qexec_alloc_agg_hash_context (thread_p, &xasl->proc.buildlist, xasl_state, not_use_membuf);
+}
+
 /*
  * qexec_alloc_agg_hash_context () - allocate hash aggregate evaluation related
  *                                   structures used at runtime
@@ -26819,12 +26838,14 @@ qexec_clear_pred_xasl (THREAD_ENTRY * thread_p, PRED_EXPR * pred)
  *   xasl_state(in): XASL state
  */
 static int
-qexec_alloc_agg_hash_context (THREAD_ENTRY * thread_p, BUILDLIST_PROC_NODE * proc, XASL_STATE * xasl_state)
+qexec_alloc_agg_hash_context (THREAD_ENTRY * thread_p, BUILDLIST_PROC_NODE * proc, XASL_STATE * xasl_state,
+			      bool not_use_membuf)
 {
   QFILE_TUPLE_VALUE_TYPE_LIST type_list;
   REGU_VARIABLE_LIST regu_list;
   AGGREGATE_TYPE *agg_list;
   int value_count = 0, i = 0, error_code = NO_ERROR;
+  int open_list_flag = not_use_membuf ? QFILE_NOT_USE_MEMBUF : 0;
 
   if (!proc->g_hash_eligible)
     {
@@ -26945,7 +26966,8 @@ qexec_alloc_agg_hash_context (THREAD_ENTRY * thread_p, BUILDLIST_PROC_NODE * pro
   proc->agg_hash_context->sort_key.nkeys = 0;
 
   /* create list files */
-  proc->agg_hash_context->part_list_id = qfile_open_list (thread_p, &type_list, NULL, xasl_state->query_id, 0, NULL);
+  proc->agg_hash_context->part_list_id =
+    qfile_open_list (thread_p, &type_list, NULL, xasl_state->query_id, open_list_flag, NULL);
   proc->agg_hash_context->sorted_part_list_id =
     qfile_open_list (thread_p, &type_list, NULL, xasl_state->query_id, 0, NULL);
 

--- a/src/query/query_executor.h
+++ b/src/query/query_executor.h
@@ -93,11 +93,12 @@ extern int qexec_clear_pred_context (THREAD_ENTRY * thread_p, pred_expr_with_con
 				     bool dealloc_dbvalues);
 extern int qexec_clear_func_pred (THREAD_ENTRY * thread_p, func_pred * pred_filter);
 extern int qexec_clear_partition_expression (THREAD_ENTRY * thread_p, regu_variable_node * expr);
-extern int qexec_resolve_domains_for_aggregation_for_parallel_heap_scan (THREAD_ENTRY * thread_p, xasl_node * xasl,
-									 void *vd, int *resolved);
-extern int
-qexec_resolve_domains_for_aggregation_for_parallel_heap_scan_aggregate (THREAD_ENTRY * thread_p, xasl_node * xasl,
-									void *vd, int *resolved);
+extern int qexec_resolve_domains_for_aggregation_for_parallel_heap_scan_g_agg (THREAD_ENTRY * thread_p,
+									       xasl_node * xasl, void *vd,
+									       int *resolved);
+extern int qexec_resolve_domains_for_aggregation_for_parallel_heap_scan_buildvalue_proc (THREAD_ENTRY * thread_p,
+											 xasl_node * xasl, void *vd,
+											 int *resolved);
 extern int qexec_clear_xasl_for_parallel_aptr (THREAD_ENTRY * thread_p, xasl_node * xasl, bool is_final);
 extern qfile_list_id *qexec_get_xasl_list_id (xasl_node * xasl);
 extern xasl_state *qexec_deep_copy_xasl_state (THREAD_ENTRY * thread_p, xasl_state * xasl_state);
@@ -119,4 +120,9 @@ extern void qexec_replace_prior_regu_vars_prior_expr (THREAD_ENTRY * thread_p, r
 						      xasl_node * xasl, xasl_node * connect_by_ptr);
 extern SCAN_CODE qexec_execute_scan_ptr (THREAD_ENTRY * thread_p, xasl_node * xasl, XASL_STATE * xasl_state,
 					 void *scan_func_ptr);
+extern int qexec_alloc_agg_hash_context_buildlist_xasl (THREAD_ENTRY * thread_p, xasl_node * xasl,
+							XASL_STATE * xasl_state, bool not_use_membuf);
+extern int qexec_hash_gby_agg_tuple_public (THREAD_ENTRY * thread_p, xasl_node * xasl, XASL_STATE * xasl_state,
+					    QFILE_TUPLE_RECORD * tplrec, QFILE_TUPLE_DESCRIPTOR * tpldesc,
+					    QFILE_LIST_ID * groupby_list, bool * output_tuple);
 #endif /* _QUERY_EXECUTOR_H_ */


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26648>

### Purpose

CUBRID의 병렬 힙 스캔(parallel heap scan) 기능에서 GROUP BY와 집계 함수를 포함한 쿼리의 성능을 개선하기 위해, 해시 테이블을 활용한 부분 집계(partial aggregate)를 지원합니다.

기존 병렬 힙 스캔 구현에서는 각 워커 스레드의 결과를 단순히 병합하는 방식만 지원하여, 중복된 그룹 데이터 발생으로 인한 최종 집계 단계의 추가적인 처리 오버헤드가 있었습니다. 이를 해결하기 위해 각 워커 스레드가 독립적으로 해시 테이블을 생성하여 부분 집계를 수행하고, 최종 단계에서 이를 효율적으로 병합하는 방식을 도입하고자 합니다.

### Implementation

Result Handler 변수 구조 변경 (px_heap_scan_result_handler.cpp)

단일 result_p 및 orig_xasl_tree_for_domain_resolve 구조에서 아래와 같이 변수 구조를 변경하여 부분 집계를 지원합니다.

- XASL_NODE *orig_xasl;
- std::vector<QFILE_LIST_ID *> hgby_results; (해시 집계 결과)
- bool g_hash_eligible; (해시 집계 지원 여부)

스레드 로컬 저장소 상태 변수 추가

- 해시 집계 상태를 추적하는 AGGREGATE_HASH_STATE agg_hash_state; 변수를 추가합니다.
- 도메인 해석 완료 여부를 나타내는 int g_agg_domains_resolved; 변수를 추가합니다.

해시 테이블 결과 저장 및 최종 병합 로직 (px_heap_scan_result_handler.cpp)

- 결과 변환: 각 워커 스레드의 해시 테이블 결과를 qdata_save_agg_htable_to_list()를 통해 리스트 파일로 변환하여 part_list_id에 저장합니다.
- 병합 로직 추가: 여러 개의 QFILE_LIST_ID를 효율적으로 병합하는 merge_list_ids() 함수를 추가합니다. 일반 결과(writer_results)와 해시 집계 결과(hgby_results)를 별도로 관리하고 최종 병합 시 두 결과 세트를 통합합니다.

공개 API 추가 (query_executor.h)

- XASL 기반 해시 컨텍스트 할당을 위한 int qexec_alloc_agg_hash_context_buildlist_xasl(); 함수를 추가합니다.
- 공개 API로 튜플 해시 집계를 수행하는 int qexec_hash_gby_agg_tuple_public(); 함수를 추가합니다.

