### PR TITLE
[CBRD-26634] Fix incorrect parameter marker count when table names contain quotes

### DIFF
--- a/src/broker/cas_common_execute.c
+++ b/src/broker/cas_common_execute.c
@@ -249,6 +249,20 @@ consume_tokens (char *stmt, STATEMENT_STATUS stmt_status)
 	    }
 	}
     }
+  else if (stmt_status == BRACKETED_IDENTIFIER)
+    {
+      for (; *p; p++)
+	{
+	  if (*p == ']' && *(p + 1) == ']')
+	    {
+	      p++;
+	    }
+	  else if (*p == ']')
+	    {
+	      break;
+	    }
+	}
+    }
 
   return p;
 }
@@ -281,9 +295,13 @@ get_num_markers (char *stmt)
 	{
 	  p = consume_tokens (p + 1, SINGLE_QUOTED_STRING);
 	}
-      else if (cas_default_ansi_quotes == false && *p == '\"')
+      else if ( /* cas_default_ansi_quotes == false && */ *p == '\"')
 	{
 	  p = consume_tokens (p + 1, DOUBLE_QUOTED_STRING);
+	}
+      else if (*p == '[')
+	{
+	  p = consume_tokens (p + 1, BRACKETED_IDENTIFIER);
 	}
 
       if (*p == '\0')

--- a/src/broker/cas_common_execute.c
+++ b/src/broker/cas_common_execute.c
@@ -295,7 +295,7 @@ get_num_markers (char *stmt)
 	{
 	  p = consume_tokens (p + 1, SINGLE_QUOTED_STRING);
 	}
-      else if ( /* cas_default_ansi_quotes == false && */ *p == '\"')
+      else if (/* cas_default_ansi_quotes == false && */ *p == '\"')
 	{
 	  p = consume_tokens (p + 1, DOUBLE_QUOTED_STRING);
 	}

--- a/src/broker/cas_common_execute.c
+++ b/src/broker/cas_common_execute.c
@@ -295,7 +295,7 @@ get_num_markers (char *stmt)
 	{
 	  p = consume_tokens (p + 1, SINGLE_QUOTED_STRING);
 	}
-      else if (/* cas_default_ansi_quotes == false && */ *p == '\"')
+      else if ( /* cas_default_ansi_quotes == false && */ *p == '\"')
 	{
 	  p = consume_tokens (p + 1, DOUBLE_QUOTED_STRING);
 	}

--- a/src/broker/cas_util.h
+++ b/src/broker/cas_util.h
@@ -60,7 +60,8 @@ typedef enum
   C_STYLE_COMMENT,
   CPP_STYLE_COMMENT,
   SINGLE_QUOTED_STRING,
-  DOUBLE_QUOTED_STRING
+  DOUBLE_QUOTED_STRING,
+  BRACKETED_IDENTIFIER
 } STATEMENT_STATUS;
 
 extern const char *get_schema_type_str (int schema_type);

--- a/src/method/method_query_util.cpp
+++ b/src/method/method_query_util.cpp
@@ -563,10 +563,10 @@ namespace cubmethod
 	  {
 	    i = consume_tokens (sql, i + 1, DOUBLE_QUOTED_STRING);
 	  }
-        else if (sql[i] == '[')
-          {
-            i = consume_tokens (sql, i + 1, BRACKETED_IDENTIFIER);
-          }
+	else if (sql[i] == '[')
+	  {
+	    i = consume_tokens (sql, i + 1, BRACKETED_IDENTIFIER);
+	  }
       }
 
     num_markers += numbered_markers.size ();
@@ -635,20 +635,20 @@ namespace cubmethod
 	      }
 	  }
       }
-   else if (stmt_status == BRACKETED_IDENTIFIER)
-     {
-       for (; index < sql_len; index++)
-         {
-           if (sql[index] == ']' && sql[index + 1] == ']')
-             {
-               index++;
-             }
-           else if (sql[index] == ']')
-             {
-               break;
-             }
-         }
-     }
+    else if (stmt_status == BRACKETED_IDENTIFIER)
+      {
+	for (; index < sql_len; index++)
+	  {
+	    if (sql[index] == ']' && sql[index + 1] == ']')
+	      {
+		index++;
+	      }
+	    else if (sql[index] == ']')
+	      {
+		break;
+	      }
+	  }
+      }
 
     return index;
   }

--- a/src/method/method_query_util.cpp
+++ b/src/method/method_query_util.cpp
@@ -563,6 +563,10 @@ namespace cubmethod
 	  {
 	    i = consume_tokens (sql, i + 1, DOUBLE_QUOTED_STRING);
 	  }
+        else if (sql[i] == '[')
+          {
+            i = consume_tokens (sql, i + 1, BRACKETED_IDENTIFIER);
+          }
       }
 
     num_markers += numbered_markers.size ();
@@ -631,6 +635,20 @@ namespace cubmethod
 	      }
 	  }
       }
+   else if (stmt_status == BRACKETED_IDENTIFIER)
+     {
+       for (; index < sql_len; index++)
+         {
+           if (sql[index] == ']' && sql[index + 1] == ']')
+             {
+               index++;
+             }
+           else if (sql[index] == ']')
+             {
+               break;
+             }
+         }
+     }
 
     return index;
   }

--- a/src/method/method_query_util.hpp
+++ b/src/method/method_query_util.hpp
@@ -40,7 +40,8 @@ namespace cubmethod
     C_STYLE_COMMENT,
     CPP_STYLE_COMMENT,
     SINGLE_QUOTED_STRING,
-    DOUBLE_QUOTED_STRING
+    DOUBLE_QUOTED_STRING,
+    BRACKETED_IDENTIFIER
   } STATEMENT_STATUS;
 
   int get_stmt_type (std::string sql);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26634

This commit fixes an issue where get_num_markers() returns 0 if a table name (identifier) contains a single quote ('), even when valid parameter markers (?) exist in the query.
