### PR TITLE
[CBRD-26351] MERGE 조인 수행 시 statdump에서 Num_query_mjoins 통계가 증가하지 않음 (#6582)

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -16084,6 +16084,8 @@ qexec_end_mainblock_iterations (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_
 	{
 	  GOTO_EXIT_ON_ERROR;
 	}
+      /* monitor */
+      perfmon_inc_stat (thread_p, PSTAT_QM_NUM_MJOINS);
       break;
 
     case HASHJOIN_PROC:
@@ -17321,8 +17323,10 @@ qexec_execute_mainblock_internal (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
 	    }
 	}
 
-      /* monitor */
-      perfmon_inc_stat (thread_p, PSTAT_QM_NUM_SELECTS);
+      if (xasl->type == BUILDLIST_PROC || xasl->type == BUILDVALUE_PROC)
+	{
+	  perfmon_inc_stat (thread_p, PSTAT_QM_NUM_SELECTS);
+	}
       break;
     }
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26351>
backport #6582 