### PR TITLE
[CBRD-25471] fix varchar size of _db_user.name from string to 32

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,8 +47,8 @@ jobs:
             echo "RUN_ALL_TEST: $RUN_ALL_TEST"
             echo "BASELINE: $BASELINE"
                         
-            TC_SHA=$(git ls-remote https://x-access-token:${GHI_TOKEN}@github.com/CUBRID/cubrid-testcases.git feature/system-catalog-update | cut -f1)
-            echo "sha value from tc repository.(only from feature/system-catalog-update branch)"
+            TC_SHA=$(git ls-remote https://x-access-token:${GHI_TOKEN}@github.com/CUBRID/cubrid-testcases.git tc/pr-6956 | cut -f1)
+            echo "sha value from tc repository.(only from tc/pr-6956 branch)"
             echo "TC_SHA: $TC_SHA"
             echo "CACHE_KEY_BRANCH: $CACHE_KEY_BRANCH"
 
@@ -83,7 +83,7 @@ jobs:
                   - run:
                       name: Test
                       environment:
-                        BRANCH_TESTCASES: feature/system-catalog-update
+                        BRANCH_TESTCASES: tc/pr-6956
                       shell: /bin/bash
                       no_output_timeout: 45m
                       command: |

--- a/src/object/authenticate_context.cpp
+++ b/src/object/authenticate_context.cpp
@@ -359,7 +359,7 @@ authenticate_context::install (void)
   /* If the attribute configuration is changed, the CATCLS_USER_ATTR_IDX_NAME also be changed.
    *   - CATCLS_USER_ATTR_IDX_NAME is defined in the cubload::server_class_installer::locate_class () function.
    */
-  smt_add_attribute (def, "name", "varchar(32)", (DB_DOMAIN *) 0);
+  smt_add_attribute (def, "name", "varchar(32)", (DB_DOMAIN *) 0); /* DB_MAX_USER_LENGTH */
   smt_add_attribute (def, "id", "integer", (DB_DOMAIN *) 0);
   smt_add_attribute (def, "password", AU_PASSWORD_CLASS_NAME, (DB_DOMAIN *) 0);
   smt_add_attribute (def, "direct_groups", "set of (_db_user)", (DB_DOMAIN *) 0);

--- a/src/object/authenticate_context.cpp
+++ b/src/object/authenticate_context.cpp
@@ -359,7 +359,7 @@ authenticate_context::install (void)
   /* If the attribute configuration is changed, the CATCLS_USER_ATTR_IDX_NAME also be changed.
    *   - CATCLS_USER_ATTR_IDX_NAME is defined in the cubload::server_class_installer::locate_class () function.
    */
-  smt_add_attribute (def, "name", "string", (DB_DOMAIN *) 0);
+  smt_add_attribute (def, "name", "varchar(32)", (DB_DOMAIN *) 0);
   smt_add_attribute (def, "id", "integer", (DB_DOMAIN *) 0);
   smt_add_attribute (def, "password", AU_PASSWORD_CLASS_NAME, (DB_DOMAIN *) 0);
   smt_add_attribute (def, "direct_groups", "set of (_db_user)", (DB_DOMAIN *) 0);

--- a/src/object/schema_system_catalog_install.cpp
+++ b/src/object/schema_system_catalog_install.cpp
@@ -1240,6 +1240,7 @@ namespace cubschema
       {"host", format_varchar (255)},
       {"port", "integer"},
       {"db_name", format_varchar (255)},
+      /* dblink remote user_name; kept 255 for external DBMS compatibility */
       {"user_name", format_varchar (255)},
       {"password", "string"},
       {"properties", format_varchar (2048)},
@@ -1276,7 +1277,7 @@ namespace cubschema
 		   // columns
     {
       {"class_name", format_varchar (255)},
-      {"owner_name", format_varchar (255)},
+      {"owner_name", format_varchar (32)},
       {"class_type", format_varchar (6)},
       {"is_system_class", format_varchar (3)},
       {"tde_algorithm", format_varchar (32)},
@@ -1316,9 +1317,9 @@ namespace cubschema
 		   // columns
     {
       {"class_name", format_varchar (255)},
-      {"owner_name", format_varchar (255)},
+      {"owner_name", format_varchar (32)},
       {"super_class_name", format_varchar (255)},
-      {"super_owner_name", format_varchar (255)},
+      {"super_owner_name", format_varchar (32)},
       // query specs
       {attribute_kind::QUERY_SPEC, sm_define_view_direct_super_class_spec ()}
     },
@@ -1347,7 +1348,7 @@ namespace cubschema
 		   // columns
     {
       {"vclass_name", format_varchar (255)},
-      {"owner_name", format_varchar (255)},
+      {"owner_name", format_varchar (32)},
       {"vclass_def", format_varchar (1073741823)},
       {"comment", format_varchar (2048)},
       {"created_time", "datetime"},
@@ -1382,11 +1383,11 @@ namespace cubschema
     {
       {"attr_name", format_varchar (255)},
       {"class_name", format_varchar (255)},
-      {"owner_name", format_varchar (255)},
+      {"owner_name", format_varchar (32)},
       {"attr_type", format_varchar (8)},
       {"def_order", "integer"},
       {"from_class_name", format_varchar (255)},
-      {"from_owner_name", format_varchar (255)},
+      {"from_owner_name", format_varchar (32)},
       {"from_attr_name", format_varchar (255)},
       {"data_type", format_varchar (9)},
       {"prec", "integer"},
@@ -1394,7 +1395,7 @@ namespace cubschema
       {"charset", format_varchar (32)},
       {"collation", format_varchar (32)},
       {"domain_class_name", format_varchar (255)},
-      {"domain_owner_name", format_varchar (255)},
+      {"domain_owner_name", format_varchar (32)},
       {"default_value", format_varchar (255)},
       {"is_nullable", format_varchar (3)},
       {"comment", format_varchar (1024)},
@@ -1427,14 +1428,14 @@ namespace cubschema
     {
       {"attr_name", format_varchar (255)},
       {"class_name", format_varchar (255)},
-      {"owner_name", format_varchar (255)},
+      {"owner_name", format_varchar (32)},
       {"attr_type", format_varchar (8)},
       {"data_type", format_varchar (9)},
       {"prec", "integer"},
       {"scale", "integer"},
       {"code_set", "integer"},
       {"domain_class_name", format_varchar (255)},
-      {"domain_owner_name", format_varchar (255)},
+      {"domain_owner_name", format_varchar (32)},
       // query specs
       {attribute_kind::QUERY_SPEC, sm_define_view_attr_setdomain_elm_spec ()}
     },
@@ -1464,10 +1465,10 @@ namespace cubschema
     {
       {"meth_name", format_varchar (255)},
       {"class_name", format_varchar (255)},
-      {"owner_name", format_varchar (255)},
+      {"owner_name", format_varchar (32)},
       {"meth_type", format_varchar (8)},
       {"from_class_name", format_varchar (255)},
-      {"from_owner_name", format_varchar (255)},
+      {"from_owner_name", format_varchar (32)},
       {"from_meth_name", format_varchar (255)},
       {"func_name", format_varchar (255)},
       // query specs
@@ -1499,7 +1500,7 @@ namespace cubschema
     {
       {"meth_name", format_varchar (255)},
       {"class_name", format_varchar (255)},
-      {"owner_name", format_varchar (255)},
+      {"owner_name", format_varchar (32)},
       {"meth_type", format_varchar (8)},
       {"index_of", "integer"},
       {"data_type", format_varchar (9)},
@@ -1507,7 +1508,7 @@ namespace cubschema
       {"scale", "integer"},
       {"code_set", "integer"},
       {"domain_class_name", format_varchar (255)},
-      {"domain_owner_name", format_varchar (255)},
+      {"domain_owner_name", format_varchar (32)},
       // query specs
       {attribute_kind::QUERY_SPEC, sm_define_view_method_arg_spec ()}
     },
@@ -1537,7 +1538,7 @@ namespace cubschema
     {
       {"meth_name", format_varchar (255)},
       {"class_name", format_varchar (255)},
-      {"owner_name", format_varchar (255)},
+      {"owner_name", format_varchar (32)},
       {"meth_type", format_varchar (8)},
       {"index_of", "integer"},
       {"data_type", format_varchar (9)},
@@ -1545,7 +1546,7 @@ namespace cubschema
       {"scale", "integer"},
       {"code_set", "integer"},
       {"domain_class_name", format_varchar (255)},
-      {"domain_owner_name", format_varchar (255)},
+      {"domain_owner_name", format_varchar (32)},
       // query specs
       {attribute_kind::QUERY_SPEC, sm_define_view_meth_arg_setdomain_elm_spec ()}
     },
@@ -1574,10 +1575,10 @@ namespace cubschema
 		   // columns
     {
       {"class_name", format_varchar (255)},
-      {"owner_name", format_varchar (255)},
+      {"owner_name", format_varchar (32)},
       {"path_name", format_varchar (255)},
       {"from_class_name", format_varchar (255)},
-      {"from_owner_name", format_varchar (255)},
+      {"from_owner_name", format_varchar (32)},
       // query specs
       {attribute_kind::QUERY_SPEC, sm_define_view_meth_file_spec ()}
     },
@@ -1609,14 +1610,14 @@ namespace cubschema
       {"is_unique", format_varchar (3)},
       {"is_reverse", format_varchar (3)},
       {"class_name", format_varchar (255)},
-      {"owner_name", format_varchar (255)},
+      {"owner_name", format_varchar (32)},
       {"key_count", "integer"},
       {"is_primary_key", format_varchar (3)},
       {"is_foreign_key", format_varchar (3)},
       {"filter_expression", format_varchar (1073741823)},
       {"have_function", format_varchar (3)},
       {"status", format_varchar (255)},
-      {"referential_index_class_owner_name", format_varchar (255)},
+      {"referential_index_class_owner_name", format_varchar (32)},
       {"referential_index_class_name", format_varchar (255)},
       {"referential_index_name", format_varchar (255)},
       {"delete_rule", format_varchar (32)},
@@ -1656,7 +1657,7 @@ namespace cubschema
     {
       {"index_name", format_varchar (255)},
       {"class_name", format_varchar (255)},
-      {"owner_name", format_varchar (255)},
+      {"owner_name", format_varchar (32)},
       {"key_attr_name", format_varchar (255)},
       {"key_order", "integer"},
       {"asc_desc", format_varchar (4)},
@@ -1693,11 +1694,11 @@ namespace cubschema
 		   CTV_AUTH_NAME,
 		   // columns
     {
-      {"grantor_name", format_varchar (255)},
-      {"grantee_name", format_varchar (255)},
+      {"grantor_name", format_varchar (32)},
+      {"grantee_name", format_varchar (32)},
       {"object_type", format_varchar (16)},
       {"object_name", format_varchar (255)},
-      {"owner_name", format_varchar (255)},
+      {"owner_name", format_varchar (32)},
       {"auth_type", format_varchar (7)},
       {"is_grantable", format_varchar (3)},
       {"created_time", "datetime"},
@@ -1730,9 +1731,9 @@ namespace cubschema
 		   // columns
     {
       {"trigger_name", format_varchar (255)},
-      {"owner_name", format_varchar (255)},
+      {"owner_name", format_varchar (32)},
       {"target_class_name", format_varchar (255)},
-      {"target_owner_name", format_varchar (255)},
+      {"target_owner_name", format_varchar (32)},
       {"target_attr_name", format_varchar (255)},
       {"target_attr_type", format_varchar (8)},
       {"action_type", "integer"},
@@ -1768,7 +1769,7 @@ namespace cubschema
 		   // columns
     {
       {"class_name", format_varchar (255)},
-      {"owner_name", format_varchar (255)},
+      {"owner_name", format_varchar (32)},
       {"partition_name", format_varchar (255)},
       {"partition_class_name", format_varchar (255)},
       {"partition_type", format_varchar (32)},
@@ -1814,7 +1815,7 @@ namespace cubschema
       {"authid", format_varchar (16)},
       {"is_deterministic", format_varchar (3)},
       {"target", format_varchar (4096)},
-      {"owner", format_varchar (256)},
+      {"owner", format_varchar (32)},
       {"code", format_varchar (1073741823)},
 // TODO: implement sql_data_access
 //       {"sql_data_access", format_varchar (17)},
@@ -1849,7 +1850,7 @@ namespace cubschema
 		   // columns
     {
       {"sp_name", format_varchar (255)},
-      {"owner_name", format_varchar (255)},
+      {"owner_name", format_varchar (32)},
       {"pkg_name", format_varchar (255)},
       {"index_of", "integer"},
       {"arg_name", format_varchar (255)},
@@ -1888,7 +1889,7 @@ namespace cubschema
       /* kept for compatibility */
       {"unique_name", format_varchar (255)},
       {"name", format_varchar (255)},
-      {"owner", format_varchar (255)},
+      {"owner", format_varchar (32)},
       {"current_val", format_numeric (DB_MAX_NUMERIC_PRECISION, 0)},
       {"increment_val", format_numeric (DB_MAX_NUMERIC_PRECISION, 0)},
       {"max_val", format_numeric (DB_MAX_NUMERIC_PRECISION, 0)},
@@ -2014,12 +2015,12 @@ namespace cubschema
 		   CTV_USER_NAME,
 		   // columns
     {
-      {"name", format_varchar (255)},
+      {"name", format_varchar (32)},
       {"id", "integer"},
       /* kept for compatibility; always NULL in view */
       {"password", AU_PASSWORD_CLASS_NAME},
-      {"direct_groups", format_set (format_varchar (255))},
-      {"groups", format_set (format_varchar (255))},
+      {"direct_groups", format_set (format_varchar (32))},
+      {"groups", format_set (format_varchar (32))},
       /* kept for compatibility; always NULL in view */
       {"authorization", AU_AUTH_CLASS_NAME},
       {"triggers", format_sequence ("object")},
@@ -2059,7 +2060,7 @@ namespace cubschema
 		   // columns
     {
       /* "owner_name" by convention, but "owner" for compatibility */
-      {"owner", format_varchar (255)},
+      {"owner", format_varchar (32)},
       {"grants", "sequence of"},
       // query specs
       {attribute_kind::QUERY_SPEC, sm_define_view_authorization_spec ()}
@@ -2120,10 +2121,10 @@ namespace cubschema
 		   // columns
     {
       {"synonym_name", format_varchar (255)},
-      {"synonym_owner_name", format_varchar (255)},
+      {"synonym_owner_name", format_varchar (32)},
       {"is_public_synonym", format_varchar (3)},	/* access_modifier */
       {"target_name", format_varchar (255)},
-      {"target_owner_name", format_varchar (255)},
+      {"target_owner_name", format_varchar (32)},
       {"comment", format_varchar (2048)},
       {"created_time", "datetime"},
       {"updated_time", "datetime"},
@@ -2158,10 +2159,11 @@ namespace cubschema
       {"host", format_varchar (255)},
       {"port", "integer"},
       {"db_name", format_varchar (255)},
+      /* dblink remote user_name; kept 255 for external DBMS compatibility */
       {"user_name", format_varchar (255)},
       // {"password", format_varchar(256)}
       {"properties", format_varchar (2048)},
-      {"owner", format_varchar (255)},
+      {"owner", format_varchar (32)},
       {"comment", format_varchar (1024)},
       {"created_time", "datetime"},
       {"updated_time", "datetime"},

--- a/src/object/schema_system_catalog_install.cpp
+++ b/src/object/schema_system_catalog_install.cpp
@@ -1277,7 +1277,7 @@ namespace cubschema
 		   // columns
     {
       {"class_name", format_varchar (255)},
-      {"owner_name", format_varchar (32)},
+      {"owner_name", format_varchar (DB_MAX_USER_LENGTH)},
       {"class_type", format_varchar (6)},
       {"is_system_class", format_varchar (3)},
       {"tde_algorithm", format_varchar (32)},
@@ -1317,9 +1317,9 @@ namespace cubschema
 		   // columns
     {
       {"class_name", format_varchar (255)},
-      {"owner_name", format_varchar (32)},
+      {"owner_name", format_varchar (DB_MAX_USER_LENGTH)},
       {"super_class_name", format_varchar (255)},
-      {"super_owner_name", format_varchar (32)},
+      {"super_owner_name", format_varchar (DB_MAX_USER_LENGTH)},
       // query specs
       {attribute_kind::QUERY_SPEC, sm_define_view_direct_super_class_spec ()}
     },
@@ -1348,7 +1348,7 @@ namespace cubschema
 		   // columns
     {
       {"vclass_name", format_varchar (255)},
-      {"owner_name", format_varchar (32)},
+      {"owner_name", format_varchar (DB_MAX_USER_LENGTH)},
       {"vclass_def", format_varchar (1073741823)},
       {"comment", format_varchar (2048)},
       {"created_time", "datetime"},
@@ -1383,11 +1383,11 @@ namespace cubschema
     {
       {"attr_name", format_varchar (255)},
       {"class_name", format_varchar (255)},
-      {"owner_name", format_varchar (32)},
+      {"owner_name", format_varchar (DB_MAX_USER_LENGTH)},
       {"attr_type", format_varchar (8)},
       {"def_order", "integer"},
       {"from_class_name", format_varchar (255)},
-      {"from_owner_name", format_varchar (32)},
+      {"from_owner_name", format_varchar (DB_MAX_USER_LENGTH)},
       {"from_attr_name", format_varchar (255)},
       {"data_type", format_varchar (9)},
       {"prec", "integer"},
@@ -1395,7 +1395,7 @@ namespace cubschema
       {"charset", format_varchar (32)},
       {"collation", format_varchar (32)},
       {"domain_class_name", format_varchar (255)},
-      {"domain_owner_name", format_varchar (32)},
+      {"domain_owner_name", format_varchar (DB_MAX_USER_LENGTH)},
       {"default_value", format_varchar (255)},
       {"is_nullable", format_varchar (3)},
       {"comment", format_varchar (1024)},
@@ -1428,14 +1428,14 @@ namespace cubschema
     {
       {"attr_name", format_varchar (255)},
       {"class_name", format_varchar (255)},
-      {"owner_name", format_varchar (32)},
+      {"owner_name", format_varchar (DB_MAX_USER_LENGTH)},
       {"attr_type", format_varchar (8)},
       {"data_type", format_varchar (9)},
       {"prec", "integer"},
       {"scale", "integer"},
       {"code_set", "integer"},
       {"domain_class_name", format_varchar (255)},
-      {"domain_owner_name", format_varchar (32)},
+      {"domain_owner_name", format_varchar (DB_MAX_USER_LENGTH)},
       // query specs
       {attribute_kind::QUERY_SPEC, sm_define_view_attr_setdomain_elm_spec ()}
     },
@@ -1465,10 +1465,10 @@ namespace cubschema
     {
       {"meth_name", format_varchar (255)},
       {"class_name", format_varchar (255)},
-      {"owner_name", format_varchar (32)},
+      {"owner_name", format_varchar (DB_MAX_USER_LENGTH)},
       {"meth_type", format_varchar (8)},
       {"from_class_name", format_varchar (255)},
-      {"from_owner_name", format_varchar (32)},
+      {"from_owner_name", format_varchar (DB_MAX_USER_LENGTH)},
       {"from_meth_name", format_varchar (255)},
       {"func_name", format_varchar (255)},
       // query specs
@@ -1500,7 +1500,7 @@ namespace cubschema
     {
       {"meth_name", format_varchar (255)},
       {"class_name", format_varchar (255)},
-      {"owner_name", format_varchar (32)},
+      {"owner_name", format_varchar (DB_MAX_USER_LENGTH)},
       {"meth_type", format_varchar (8)},
       {"index_of", "integer"},
       {"data_type", format_varchar (9)},
@@ -1508,7 +1508,7 @@ namespace cubschema
       {"scale", "integer"},
       {"code_set", "integer"},
       {"domain_class_name", format_varchar (255)},
-      {"domain_owner_name", format_varchar (32)},
+      {"domain_owner_name", format_varchar (DB_MAX_USER_LENGTH)},
       // query specs
       {attribute_kind::QUERY_SPEC, sm_define_view_method_arg_spec ()}
     },
@@ -1538,7 +1538,7 @@ namespace cubschema
     {
       {"meth_name", format_varchar (255)},
       {"class_name", format_varchar (255)},
-      {"owner_name", format_varchar (32)},
+      {"owner_name", format_varchar (DB_MAX_USER_LENGTH)},
       {"meth_type", format_varchar (8)},
       {"index_of", "integer"},
       {"data_type", format_varchar (9)},
@@ -1546,7 +1546,7 @@ namespace cubschema
       {"scale", "integer"},
       {"code_set", "integer"},
       {"domain_class_name", format_varchar (255)},
-      {"domain_owner_name", format_varchar (32)},
+      {"domain_owner_name", format_varchar (DB_MAX_USER_LENGTH)},
       // query specs
       {attribute_kind::QUERY_SPEC, sm_define_view_meth_arg_setdomain_elm_spec ()}
     },
@@ -1575,10 +1575,10 @@ namespace cubschema
 		   // columns
     {
       {"class_name", format_varchar (255)},
-      {"owner_name", format_varchar (32)},
+      {"owner_name", format_varchar (DB_MAX_USER_LENGTH)},
       {"path_name", format_varchar (255)},
       {"from_class_name", format_varchar (255)},
-      {"from_owner_name", format_varchar (32)},
+      {"from_owner_name", format_varchar (DB_MAX_USER_LENGTH)},
       // query specs
       {attribute_kind::QUERY_SPEC, sm_define_view_meth_file_spec ()}
     },
@@ -1610,14 +1610,14 @@ namespace cubschema
       {"is_unique", format_varchar (3)},
       {"is_reverse", format_varchar (3)},
       {"class_name", format_varchar (255)},
-      {"owner_name", format_varchar (32)},
+      {"owner_name", format_varchar (DB_MAX_USER_LENGTH)},
       {"key_count", "integer"},
       {"is_primary_key", format_varchar (3)},
       {"is_foreign_key", format_varchar (3)},
       {"filter_expression", format_varchar (1073741823)},
       {"have_function", format_varchar (3)},
       {"status", format_varchar (255)},
-      {"referential_index_class_owner_name", format_varchar (32)},
+      {"referential_index_class_owner_name", format_varchar (DB_MAX_USER_LENGTH)},
       {"referential_index_class_name", format_varchar (255)},
       {"referential_index_name", format_varchar (255)},
       {"delete_rule", format_varchar (32)},
@@ -1657,7 +1657,7 @@ namespace cubschema
     {
       {"index_name", format_varchar (255)},
       {"class_name", format_varchar (255)},
-      {"owner_name", format_varchar (32)},
+      {"owner_name", format_varchar (DB_MAX_USER_LENGTH)},
       {"key_attr_name", format_varchar (255)},
       {"key_order", "integer"},
       {"asc_desc", format_varchar (4)},
@@ -1694,11 +1694,11 @@ namespace cubschema
 		   CTV_AUTH_NAME,
 		   // columns
     {
-      {"grantor_name", format_varchar (32)},
-      {"grantee_name", format_varchar (32)},
+      {"grantor_name", format_varchar (DB_MAX_USER_LENGTH)},
+      {"grantee_name", format_varchar (DB_MAX_USER_LENGTH)},
       {"object_type", format_varchar (16)},
       {"object_name", format_varchar (255)},
-      {"owner_name", format_varchar (32)},
+      {"owner_name", format_varchar (DB_MAX_USER_LENGTH)},
       {"auth_type", format_varchar (7)},
       {"is_grantable", format_varchar (3)},
       {"created_time", "datetime"},
@@ -1731,9 +1731,9 @@ namespace cubschema
 		   // columns
     {
       {"trigger_name", format_varchar (255)},
-      {"owner_name", format_varchar (32)},
+      {"owner_name", format_varchar (DB_MAX_USER_LENGTH)},
       {"target_class_name", format_varchar (255)},
-      {"target_owner_name", format_varchar (32)},
+      {"target_owner_name", format_varchar (DB_MAX_USER_LENGTH)},
       {"target_attr_name", format_varchar (255)},
       {"target_attr_type", format_varchar (8)},
       {"action_type", "integer"},
@@ -1769,7 +1769,7 @@ namespace cubschema
 		   // columns
     {
       {"class_name", format_varchar (255)},
-      {"owner_name", format_varchar (32)},
+      {"owner_name", format_varchar (DB_MAX_USER_LENGTH)},
       {"partition_name", format_varchar (255)},
       {"partition_class_name", format_varchar (255)},
       {"partition_type", format_varchar (32)},
@@ -1815,7 +1815,7 @@ namespace cubschema
       {"authid", format_varchar (16)},
       {"is_deterministic", format_varchar (3)},
       {"target", format_varchar (4096)},
-      {"owner", format_varchar (32)},
+      {"owner", format_varchar (DB_MAX_USER_LENGTH)},
       {"code", format_varchar (1073741823)},
 // TODO: implement sql_data_access
 //       {"sql_data_access", format_varchar (17)},
@@ -1850,7 +1850,7 @@ namespace cubschema
 		   // columns
     {
       {"sp_name", format_varchar (255)},
-      {"owner_name", format_varchar (32)},
+      {"owner_name", format_varchar (DB_MAX_USER_LENGTH)},
       {"pkg_name", format_varchar (255)},
       {"index_of", "integer"},
       {"arg_name", format_varchar (255)},
@@ -1889,7 +1889,7 @@ namespace cubschema
       /* kept for compatibility */
       {"unique_name", format_varchar (255)},
       {"name", format_varchar (255)},
-      {"owner", format_varchar (32)},
+      {"owner", format_varchar (DB_MAX_USER_LENGTH)},
       {"current_val", format_numeric (DB_MAX_NUMERIC_PRECISION, 0)},
       {"increment_val", format_numeric (DB_MAX_NUMERIC_PRECISION, 0)},
       {"max_val", format_numeric (DB_MAX_NUMERIC_PRECISION, 0)},
@@ -2015,12 +2015,12 @@ namespace cubschema
 		   CTV_USER_NAME,
 		   // columns
     {
-      {"name", format_varchar (32)},
+      {"name", format_varchar (DB_MAX_USER_LENGTH)},
       {"id", "integer"},
       /* kept for compatibility; always NULL in view */
       {"password", AU_PASSWORD_CLASS_NAME},
-      {"direct_groups", format_set (format_varchar (32))},
-      {"groups", format_set (format_varchar (32))},
+      {"direct_groups", format_set (format_varchar (DB_MAX_USER_LENGTH))},
+      {"groups", format_set (format_varchar (DB_MAX_USER_LENGTH))},
       /* kept for compatibility; always NULL in view */
       {"authorization", AU_AUTH_CLASS_NAME},
       {"triggers", format_sequence ("object")},
@@ -2060,7 +2060,7 @@ namespace cubschema
 		   // columns
     {
       /* "owner_name" by convention, but "owner" for compatibility */
-      {"owner", format_varchar (32)},
+      {"owner", format_varchar (DB_MAX_USER_LENGTH)},
       {"grants", "sequence of"},
       // query specs
       {attribute_kind::QUERY_SPEC, sm_define_view_authorization_spec ()}
@@ -2121,10 +2121,10 @@ namespace cubschema
 		   // columns
     {
       {"synonym_name", format_varchar (255)},
-      {"synonym_owner_name", format_varchar (32)},
+      {"synonym_owner_name", format_varchar (DB_MAX_USER_LENGTH)},
       {"is_public_synonym", format_varchar (3)},	/* access_modifier */
       {"target_name", format_varchar (255)},
-      {"target_owner_name", format_varchar (32)},
+      {"target_owner_name", format_varchar (DB_MAX_USER_LENGTH)},
       {"comment", format_varchar (2048)},
       {"created_time", "datetime"},
       {"updated_time", "datetime"},
@@ -2163,7 +2163,7 @@ namespace cubschema
       {"user_name", format_varchar (255)},
       // {"password", format_varchar(256)}
       {"properties", format_varchar (2048)},
-      {"owner", format_varchar (32)},
+      {"owner", format_varchar (DB_MAX_USER_LENGTH)},
       {"comment", format_varchar (1024)},
       {"created_time", "datetime"},
       {"updated_time", "datetime"},

--- a/src/object/schema_system_catalog_install_query_spec.cpp
+++ b/src/object/schema_system_catalog_install_query_spec.cpp
@@ -67,7 +67,7 @@ sm_define_view_class_spec (void)
   sprintf (stmt,
 	"SELECT "
 	  "[c].[class_name] AS [class_name], "
-	  "CAST ([c].[owner].[name] AS VARCHAR(255)) AS [owner_name], " /* string -> varchar(255) */
+	  "[c].[owner].[name] AS [owner_name], "
 	  "CASE [c].[class_type] WHEN 0 THEN 'CLASS' WHEN 1 THEN 'VCLASS' ELSE 'UNKNOWN' END AS [class_type], "
 	  "CASE WHEN [c].[is_system_class] = 1 THEN 'YES' ELSE 'NO' END AS [is_system_class], "
 	  "CASE [c].[tde_algorithm] WHEN 0 THEN 'NONE' WHEN 1 THEN 'AES' WHEN 2 THEN 'ARIA' END AS [tde_algorithm], "
@@ -155,9 +155,9 @@ sm_define_view_direct_super_class_spec (void)
   sprintf (stmt,
 	"SELECT "
 	  "[c].[class_name] AS [class_name], "
-	  "CAST ([c].[owner].[name] AS VARCHAR(255)) AS [owner_name], " /* string -> varchar(255) */
+	  "[c].[owner].[name] AS [owner_name], "
 	  "[s].[class_name] AS [super_class_name], "
-	  "CAST ([s].[owner].[name] AS VARCHAR(255)) AS [super_owner_name] " /* string -> varchar(255) */
+	  "[s].[owner].[name] AS [super_owner_name] "
 	"FROM "
 	  /* CT_CLASS_NAME */
 	  "[%s] AS [c], TABLE ([c].[super_classes]) AS [t] ([s]) "
@@ -217,7 +217,7 @@ sm_define_view_vclass_spec (void)
   sprintf (stmt,
 	"SELECT "
 	  "[q].[class_of].[class_name] AS [vclass_name], "
-	  "CAST ([q].[class_of].[owner].[name] AS VARCHAR(255)) AS [owner_name], " /* string -> varchar(255) */
+	  "[q].[class_of].[owner].[name] AS [owner_name], "
 	  "[q].[spec] AS [vclass_def], "
 	  "[c].[comment] AS [comment], "
 	  "[c].[created_time] AS [created_time], "
@@ -290,11 +290,11 @@ sm_define_view_attribute_spec (void)
 	"SELECT "
 	  "[a].[attr_name] AS [attr_name], "
 	  "[c].[class_name] AS [class_name], "
-	  "CAST ([c].[owner].[name] AS VARCHAR(255)) AS [owner_name], " /* string -> varchar(255) */
+	  "[c].[owner].[name] AS [owner_name], "
 	  "CASE [a].[attr_type] WHEN 0 THEN 'INSTANCE' WHEN 1 THEN 'CLASS' ELSE 'SHARED' END AS [attr_type], "
 	  "[a].[def_order] AS [def_order], "
 	  "[a].[from_class_of].[class_name] AS [from_class_name], "
-	  "CAST ([a].[from_class_of].[owner].[name] AS VARCHAR(255)) AS [from_owner_name], " /* string -> varchar(255) */
+	  "[a].[from_class_of].[owner].[name] AS [from_owner_name], "
 	  "[a].[from_attr_name] AS [from_attr_name], "
 	  "[t].[type_name] AS [data_type], "
 	  "[d].[prec] AS [prec], "
@@ -312,7 +312,7 @@ sm_define_view_attribute_spec (void)
 	      "'Not applicable'"
 	    ") AS [collation], "
 	  "[d].[class_of].[class_name] AS [domain_class_name], "
-	  "CAST ([d].[class_of].[owner].[name] AS VARCHAR(255)) AS [domain_owner_name], " /* string -> varchar(255) */
+	  "[d].[class_of].[owner].[name] AS [domain_owner_name], "
 	  "[a].[default_value] AS [default_value], "
 	  "CASE WHEN [a].[is_nullable] = 1 THEN 'YES' ELSE 'NO' END AS [is_nullable], "
 	  "[a].[comment] AS [comment] "
@@ -392,14 +392,14 @@ sm_define_view_attr_setdomain_elm_spec (void)
 	"SELECT "
 	  "[a].[attr_name] AS [attr_name], "
 	  "[c].[class_name] AS [class_name], "
-	  "CAST ([c].[owner].[name] AS VARCHAR(255)) AS [owner_name], " /* string -> varchar(255) */
+	  "[c].[owner].[name] AS [owner_name], "
 	  "CASE [a].[attr_type] WHEN 0 THEN 'INSTANCE' WHEN 1 THEN 'CLASS' ELSE 'SHARED' END AS [attr_type], "
 	  "[et].[type_name] AS [data_type], "
 	  "[e].[prec] AS [prec], "
 	  "[e].[scale] AS [scale], "
 	  "[e].[code_set] AS [code_set], "
 	  "[e].[class_of].[class_name] AS [domain_class_name], "
-	  "CAST ([e].[class_of].[owner].[name] AS VARCHAR(255)) AS [domain_owner_name] " /* string -> varchar(255) */
+	  "[e].[class_of].[owner].[name] AS [domain_owner_name] "
 	"FROM "
 	  /* CT_CLASS_NAME */
 	  "[%s] AS [c], "
@@ -474,10 +474,10 @@ sm_define_view_method_spec (void)
 	"SELECT "
 	  "[m].[meth_name] AS [meth_name], "
 	  "[m].[class_of].[class_name] AS [class_name], "
-	  "CAST ([m].[class_of].[owner].[name] AS VARCHAR(255)) AS [owner_name], " /* string -> varchar(255) */
+	  "[m].[class_of].[owner].[name] AS [owner_name], "
 	  "CASE [m].[meth_type] WHEN 0 THEN 'INSTANCE' ELSE 'CLASS' END AS [meth_type], "
 	  "[m].[from_class_of].[class_name] AS [from_class_name], "
-	  "CAST ([m].[from_class_of].[owner].[name] AS VARCHAR(255)) AS [from_owner_name], " /* string -> varchar(255) */
+	  "[m].[from_class_of].[owner].[name] AS [from_owner_name], "
 	  "[m].[from_meth_name] AS [from_meth_name], "
 	  "[s].[func_name] AS [func_name] "
 	"FROM "
@@ -546,7 +546,7 @@ sm_define_view_method_arg_spec (void)
 	"SELECT "
 	  "[s].[meth_of].[meth_name] AS [meth_name], "
 	  "[s].[meth_of].[class_of].[class_name] AS [class_name], "
-	  "CAST ([s].[meth_of].[class_of].[owner].[name] AS VARCHAR(255)) AS [owner_name], " /* string -> varchar(255) */
+	  "[s].[meth_of].[class_of].[owner].[name] AS [owner_name], "
 	  "CASE [s].[meth_of].[meth_type] WHEN 0 THEN 'INSTANCE' ELSE 'CLASS' END AS [meth_type], "
 	  "[a].[index_of] AS [index_of], "
 	  "[t].[type_name] AS [data_type], "
@@ -554,7 +554,7 @@ sm_define_view_method_arg_spec (void)
 	  "[d].[scale] AS [scale], "
 	  "[d].[code_set] AS [code_set], "
 	  "[d].[class_of].[class_name] AS [domain_class_name], "
-	  "CAST ([d].[class_of].[owner].[name] AS VARCHAR(255)) AS [domain_owner_name] " /* string -> varchar(255) */
+	  "[d].[class_of].[owner].[name] AS [domain_owner_name] "
 	"FROM "
 	  /* CT_METHSIG_NAME */
 	  "[%s] AS [s], "
@@ -629,7 +629,7 @@ sm_define_view_meth_arg_setdomain_elm_spec (void)
 	"SELECT "
 	  "[s].[meth_of].[meth_name] AS [meth_name], "
 	  "[s].[meth_of].[class_of].[class_name] AS [class_name], "
-	  "CAST ([s].[meth_of].[class_of].[owner].[name] AS VARCHAR(255)) AS [owner_name], " /* string -> varchar(255) */
+	  "[s].[meth_of].[class_of].[owner].[name] AS [owner_name], "
 	  "CASE [s].[meth_of].[meth_type] WHEN 0 THEN 'INSTANCE' ELSE 'CLASS' END AS [meth_type], "
 	  "[a].[index_of] AS [index_of], "
 	  "[et].[type_name] AS [data_type], "
@@ -637,7 +637,7 @@ sm_define_view_meth_arg_setdomain_elm_spec (void)
 	  "[e].[scale] AS [scale], "
 	  "[e].[code_set] AS [code_set], "
 	  "[e].[class_of].[class_name] AS [domain_class_name], "
-	  "CAST ([e].[class_of].[owner].[name] AS VARCHAR(255)) AS [domain_owner_name] " /* string -> varchar(255) */
+	  "[e].[class_of].[owner].[name] AS [domain_owner_name] "
 	"FROM "
 	  /* CT_METHSIG_NAME */
 	  "[%s] AS [s], "
@@ -711,10 +711,10 @@ sm_define_view_meth_file_spec (void)
   sprintf (stmt,
 	"SELECT "
 	  "[f].[class_of].[class_name] AS [class_name], "
-	  "CAST ([f].[class_of].[owner].[name] AS VARCHAR(255)) AS [owner_name], " /* string -> varchar(255) */
+	  "[f].[class_of].[owner].[name] AS [owner_name], "
 	  "[f].[path_name] AS [path_name], "
 	  "[f].[from_class_of].[class_name] AS [from_class_name], "
-	  "CAST ([f].[from_class_of].[owner].[name] AS VARCHAR(255)) AS [from_owner_name] " /* string -> varchar(255) */
+	  "[f].[from_class_of].[owner].[name] AS [from_owner_name] "
 	"FROM "
 	  /* CT_METHFILE_NAME */
 	  "[%s] AS [f] "
@@ -777,7 +777,7 @@ sm_define_view_index_spec (void)
 	  "CASE [i].[is_unique] WHEN 0 THEN 'NO' ELSE 'YES' END AS [is_unique], "
 	  "CASE [i].[is_reverse] WHEN 0 THEN 'NO' ELSE 'YES' END AS [is_reverse], "
 	  "[i].[class_of].[class_name] AS [class_name], "
-	  "CAST ([i].[class_of].[owner].[name] AS VARCHAR(255)) AS [owner_name], " /* string -> varchar(255) */
+	  "[i].[class_of].[owner].[name] AS [owner_name], "
 	  "NVL2 ("
 	      "("
 		"SELECT 1 "
@@ -905,7 +905,7 @@ sm_define_view_index_key_spec (void)
 	"SELECT "
 	  "[k].[index_of].[index_name] AS [index_name], "
 	  "[k].[index_of].[class_of].[class_name] AS [class_name], "
-	  "CAST ([k].[index_of].[class_of].[owner].[name] AS VARCHAR(255)) AS [owner_name], " /* string -> varchar(255) */
+	  "[k].[index_of].[class_of].[owner].[name] AS [owner_name], "
 	  "[k].[key_attr_name] AS [key_attr_name], "
 	  "[k].[key_order] AS [key_order], "
 	  "CASE [k].[asc_desc] WHEN 0 THEN 'ASC' WHEN 1 THEN 'DESC' ELSE 'UNKN' END AS [asc_desc], "
@@ -975,11 +975,11 @@ sm_define_view_auth_spec (void)
   // *INDENT-OFF*
   sprintf (stmt,
 	"SELECT "
-	  "CAST ([a].[grantor].[name] AS VARCHAR(255)) AS [grantor_name], " /* string -> varchar(255) */
-	  "CAST ([a].[grantee].[name] AS VARCHAR(255)) AS [grantee_name], " /* string -> varchar(255) */
+	  "[a].[grantor].[name] AS [grantor_name], "
+	  "[a].[grantee].[name] AS [grantee_name], "
           "CASE [c].[class_type] WHEN 0 THEN 'CLASS' WHEN 1 THEN 'VCLASS' ELSE 'UNKNOWN' END AS [object_type], "
 	  "[c].[class_name] AS [object_name], "
-	  "CAST ([c].[owner].[name] AS VARCHAR(255)) AS [owner_name], " /* string -> varchar(255) */
+	  "[c].[owner].[name] AS [owner_name], "
 	  "[a].[auth_type] AS [auth_type], "
 	  "CASE [a].[is_grantable] WHEN 0 THEN 'NO' ELSE 'YES' END AS [is_grantable], "
 	  "[a].[created_time] AS [created_time], "
@@ -1003,11 +1003,11 @@ sm_define_view_auth_spec (void)
 	  ") "
    "UNION ALL "
         "SELECT "
-	  "CAST ([a].[grantor].[name] AS VARCHAR(255)) AS [grantor_name], " /* string -> varchar(255) */
-	  "CAST ([a].[grantee].[name] AS VARCHAR(255)) AS [grantee_name], " /* string -> varchar(255) */
+	  "[a].[grantor].[name] AS [grantor_name], "
+	  "[a].[grantee].[name] AS [grantee_name], "
           "CASE [s].[sp_type] WHEN 1 THEN 'PROCEDURE' ELSE 'FUNCTION' END AS [object_type], "
           "[s].[sp_name] AS [object_name], "
-          "CAST ([s].[owner].[name] AS VARCHAR(255)) AS [owner_name], "
+          "[s].[owner].[name] AS [owner_name], "
           "[a].[auth_type] AS [auth_type], "
           "CASE [a].[is_grantable] WHEN 0 THEN 'NO' ELSE 'YES' END AS [is_grantable], "
           "[a].[created_time] AS [created_time], "
@@ -1051,9 +1051,9 @@ sm_define_view_trigger_spec (void)
   sprintf (stmt,
 	"SELECT "
 	  "CAST ([t].[name] AS VARCHAR (255)) AS [trigger_name], " /* string -> varchar(255) */
-	  "CAST ([t].[owner].[name] AS VARCHAR(255)) AS [owner_name], " /* string -> varchar(255) */
+	  "[t].[owner].[name] AS [owner_name], "
 	  "[c].[class_name] AS [target_class_name], "
-	  "CAST ([c].[owner].[name] AS VARCHAR(255)) AS [target_owner_name], " /* string -> varchar(255) */
+	  "[c].[owner].[name] AS [target_owner_name], "
 	  "CAST ([t].[target_attribute] AS VARCHAR (255)) AS [target_attr_name], " /* string -> varchar(255) */
 	  "CASE [t].[target_class_attribute] WHEN 0 THEN 'INSTANCE' ELSE 'CLASS' END AS [target_attr_type], "
 	  "[t].[action_type] AS [action_type], "
@@ -1123,7 +1123,7 @@ sm_define_view_partition_spec (void)
   sprintf (stmt,
 	"SELECT "
 	  "[s].[class_name] AS [class_name], "
-	  "CAST ([s].[owner].[name] AS VARCHAR(255)) AS [owner_name], " /* string -> varchar(255) */
+	  "[s].[owner].[name] AS [owner_name], "
 	  "[p].[pname] AS [partition_name], "
 	  "CONCAT ([s].[class_name], '__p__', [p].[pname]) AS [partition_class_name], " /* It can exceed varchar(255). */
 	  "CASE [p].[ptype] WHEN 0 THEN 'HASH' WHEN 1 THEN 'RANGE' ELSE 'LIST' END AS [partition_type], "
@@ -1218,7 +1218,7 @@ sm_define_view_stored_procedure_spec (void)
 	    "WHEN 0 THEN NULL "
 	    "ELSE CONCAT ([sp].[target_class], '.', [sp].[target_method]) "
 	    "END AS [target], "
-	  "CAST ([sp].[owner].[name] AS VARCHAR(255)) AS [owner], " /* string -> varchar(255) */
+	  "[sp].[owner].[name] AS [owner], "
           "CASE "
 	    "WHEN {'DBA'} SUBSETEQ ("
 	      "SELECT "
@@ -1319,7 +1319,7 @@ sm_define_view_stored_procedure_args_spec (void)
   sprintf (stmt,
 	"SELECT "
 	  "[sp].[sp_of].[sp_name] AS [sp_name], "
-	  "CAST ([sp].[sp_of].[owner].[name] AS VARCHAR(255)) AS [sp_owner_name], " /* string -> varchar(255) */
+	  "[sp].[sp_of].[owner].[name] AS [sp_owner_name], "
           "CAST ([sp].[sp_of].[pkg_name] AS VARCHAR(255)) AS [pkg_name], " /* string -> varchar(255) */
 	  "[sp].[index_of] AS [index_of], "
 	  "[sp].[arg_name] AS [arg_name], "
@@ -1399,7 +1399,7 @@ sm_define_view_serial_spec (void)
         "SELECT "
           "[serial].[unique_name] AS [unique_name], "
           "[serial].[name] AS [name], "
-          "CAST ([serial].[owner].[name] AS VARCHAR(255)) AS [owner], "
+          "[serial].[owner].[name] AS [owner], "
           "[serial].[current_val] AS [current_val], "
           "[serial].[increment_val] AS [increment_val], "
           "[serial].[max_val] AS [max_val], "
@@ -1554,7 +1554,7 @@ sm_define_view_authorization_spec (void)
   // *INDENT-OFF*
   sprintf (stmt,
 	"SELECT "
-	  "CAST ([a].[owner].[name] AS VARCHAR(255)) AS [owner], " /* string -> varchar(255) */
+	  "[a].[owner].[name] AS [owner], "
 	  "[a].[grants] AS [grants] "
 	"FROM "
 	  /* CT_AUTHORIZATION_NAME */
@@ -1613,10 +1613,10 @@ sm_define_view_synonym_spec (void)
   sprintf (stmt,
 	"SELECT "
 	  "[s].[name] AS [synonym_name], "
-	  "CAST ([s].[owner].[name] AS VARCHAR(255)) AS [synonym_owner_name], " /* string -> varchar(255) */
+	  "[s].[owner].[name] AS [synonym_owner_name], "
 	  "CASE [s].[is_public] WHEN 1 THEN 'YES' ELSE 'NO' END AS [is_public_synonym], "
 	  "[s].[target_name] AS [target_name], "
-	  "CAST ([s].[target_owner].[name] AS VARCHAR(255)) AS [target_owner_name], " /* string -> varchar(255) */
+	  "[s].[target_owner].[name] AS [target_owner_name], "
 	  "[s].[comment] AS [comment], "
           "[s].[created_time] AS [created_time], "
           "[s].[updated_time] AS [updated_time] "
@@ -1668,7 +1668,7 @@ sm_define_view_server_spec (void)
 	  "[ds].[db_name] AS [db_name], "
 	  "[ds].[user_name] AS [user_name], "
 	  "[ds].[properties] AS [properties], "
-	  "CAST ([ds].[owner].[name] AS VARCHAR(255)) AS [owner], " /* string -> varchar(255) */
+	  "[ds].[owner].[name] AS [owner], "
 	  "[ds].[comment] AS [comment], "
           "[ds].[created_time] AS [created_time], "
           "[ds].[updated_time] AS [updated_time], "


### PR DESCRIPTION
[<http://jira.cubrid.org/browse/CBRD-25471>](http://jira.cubrid.org/browse/CBRD-25471)

### Purpose
- `_db_user.name` 컬럼 타입을 `string`에서 `varchar(32)`로 변경하고, 시스템 뷰 전반의 owner 관련 컬럼 사이즈를 `varchar(255)`에서 `varchar(32)`로 통일

### Implementation
- `authenticate_context.cpp`: `_db_user` 테이블의 `name` 속성 도메인을 `"string"`에서 `"varchar(32)"`로 변경
- `schema_system_catalog_install.cpp`: 전체 시스템 뷰 정의에서 `owner_name`, `from_owner_name`, `domain_owner_name`, `grantor_name`, `grantee_name` 등 사용자명 참조 컬럼을 `varchar(255)` → `varchar(32)`로 일괄 변경
  - `db_user` 뷰의 `name`, `direct_groups`, `groups` 컬럼도 동일하게 `varchar(32)` 적용
  - `db_authorization` 뷰의 `owner` 컬럼도 `varchar(32)` 적용
  - `db_server` / `db_synonym` 뷰의 owner 컬럼도 동일 적용
  - `_db_server` 테이블의 `user_name`은 외부 DBMS 호환을 위해 `varchar(255)` 유지 (주석 추가)
- `schema_system_catalog_install_query_spec.cpp`: 뷰 쿼리 스펙에서 `CAST ([...].[owner].[name] AS VARCHAR(255))` 구문을 제거하고 `[...].[owner].[name]` 직접 참조로 변경 — `_db_user.name`이 `varchar(32)`로 정의되어 CAST 불필요

### Remarks
- `_db_user.name`의 최대 길이 32는 CUBRID의 `DB_MAX_USER_LENGTH` 상수와 일치하며, 기존 `string` 타입은 사실상 무제한이었으므로 스키마 수준에서 제약을 명시화한 것
- **[rollback 예정]** `.circleci/config.yml`: 테스트케이스 브랜치를 `feature/system-catalog-update`에서 `tc/pr-6956`으로 변경