### PR TITLE
[CBRD-26652] (Backport-11.4.5) Expand precision for auto-casting string literals and non-integers

### DIFF
--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -4815,7 +4815,7 @@ pt_coerce_expression_argument (PARSER_CONTEXT * parser, PT_NODE * expr, PT_NODE 
 	  break;
 
 	default:
-	  precision = DB_DEFAULT_NUMERIC_PRECISION;
+	  precision = DB_MAX_NUMERIC_PRECISION;
 	  scale = DB_DEFAULT_NUMERIC_DIVISION_SCALE;
 	  break;
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26652

### Purpose
- 문자 리터럴의 Numeric 자동 형변환 정밀도(Precision) 확장
  - semantic_check 단계에서 문자 리터럴을 NUMERIC으로 자동 형변환할 때 적용되는 기본 Precision을 15에서 38로 확장하여, Scale 보정 과정에서 발생하는 정밀도 초과 에러를 해결합니다.

### Implementation
- 수정 위치
  - pt_coerce_expression_argument 함수 내 타입 결정 로직.
- 변경 사항
  - 기존에 문자 리터럴 등 '기타 타입'에 일괄 적용되던 NUMERIC(15, 9) 도메인을 NUMERIC(38, 9)로 변경.
```sql
create table test(num_col NUMERIC(10,0));
insert into test values('1111111'); -- 7자리

-- 조회 시 에러 발생
select * from test where num_col='1111111';
In line 5, column 33,
ERROR: before ' ; '
Cannot coerce '1111111' to type numeric.

-- Update 시 에러 발생
update test set id=4 where num_col='1111111';
In line 5, column 35,
ERROR: before ' ; '
Cannot coerce '1111111' to type numeric.
```
- 유지 사항
  - smallint, integer, bigint 등 정수 계열 타입에 대한 고정 도메인 결정 로직은 기존과 동일하게 유지하여 하위 호환성 확보.

### Remarks
- 재현 케이스 확인
  - NUMERIC(10, 0) 컬럼과 7자리 이상의 숫자 형태 문자 리터럴('1111111') 비교 시 발생하는 Cannot coerce 에러 해결 확인.
- 영향 범위
  - 문자 리터럴 기반의 비교 연산(SELECT/UPDATE 등) 및 자동 형변환이 일어나는 모든 쿼리문에 적용됩니다.