### PR TITLE
[CBRD-26652] (Backport-11.3.5) Expand precision for auto-casting string literals and non-integers

### DIFF
--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -4839,7 +4839,7 @@ pt_coerce_expression_argument (PARSER_CONTEXT * parser, PT_NODE * expr, PT_NODE 
 	  break;
 
 	default:
-	  precision = DB_DEFAULT_NUMERIC_PRECISION;
+	  precision = DB_MAX_NUMERIC_PRECISION;
 	  scale = DB_DEFAULT_NUMERIC_DIVISION_SCALE;
 	  break;
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26652

### Purpose
- #6961 pr의 변경 사항을 11.3.5 패치 버전으로 백포트합니다.
- 상세 내용은 원본 PR(#6961)을 참조해 주세요.

- 주요 목적
  - 문자 리터럴을 NUMERIC으로 자동 형변환 시 발생하는 정밀도(Precision) 초과 에러 해결.

### Implementation
- 원본 PR과 동일한 로직을 적용하였습니다. (pt_coerce_expression_argument 내 기본 Precision을 15에서 38로 확장)

### Remarks
- 원본 PR에서 통과된 동일한 재현 케이스 확인 결과 정상 동작을 확인했습니다.
- 해당 패치 버전의 안정성을 위해 정수 계열(integer, bigint 등) 기존 로직은 유지되었습니다.
