### PR TITLE
[CBRD-26652] (Backport-10.2.18) Expand precision for auto-casting string literals and non-integers

### DIFF
--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -6553,7 +6553,8 @@ pt_print_attr_def (PARSER_CONTEXT * parser, PT_NODE * p)
       if (p->data_type)
 	{
 	  /* only show non-default parameter */
-	  if (p->data_type->info.data_type.precision != 15 || p->data_type->info.data_type.dec_precision != 0)
+	  if (p->data_type->info.data_type.precision != DB_DEFAULT_NUMERIC_PRECISION
+	      || p->data_type->info.data_type.dec_precision != DB_DEFAULT_NUMERIC_SCALE)
 	    {
 	      sprintf (s, "(%d,%d)", p->data_type->info.data_type.precision,
 		       p->data_type->info.data_type.dec_precision);
@@ -8489,7 +8490,8 @@ pt_print_datatype (PARSER_CONTEXT * parser, PT_NODE * p)
 
     case PT_TYPE_NUMERIC:
       q = pt_append_nulstring (parser, q, pt_show_type_enum (p->type_enum));
-      if (p->info.data_type.precision != 15 || p->info.data_type.dec_precision != 0)
+      if (p->info.data_type.precision != DB_DEFAULT_NUMERIC_PRECISION
+	  || p->info.data_type.dec_precision != DB_DEFAULT_NUMERIC_SCALE)
 	{
 	  sprintf (buf, "(%d,%d)", p->info.data_type.precision, p->info.data_type.dec_precision);
 	  q = pt_append_nulstring (parser, q, buf);

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -3858,7 +3858,7 @@ pt_limit_to_numbering_expr (PARSER_CONTEXT * parser, PT_NODE * limit, PT_OP_TYPE
 	}
 
       sum->data_type->type_enum = PT_TYPE_NUMERIC;
-      sum->data_type->info.data_type.precision = 38;
+      sum->data_type->info.data_type.precision = DB_MAX_NUMERIC_PRECISION;
       sum->data_type->info.data_type.dec_precision = 0;
 
       sum->info.expr.arg1 = parser_copy_tree (parser, limit);

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -4813,15 +4813,27 @@ pt_coerce_expression_argument (PARSER_CONTEXT * parser, PT_NODE * expr, PT_NODE 
       break;
 
     case PT_TYPE_NUMERIC:
-      if (PT_IS_DISCRETE_NUMBER_TYPE (node->type_enum))
+      switch (node->type_enum)
 	{
-	  precision = DB_DEFAULT_NUMERIC_PRECISION;
+	case PT_TYPE_SMALLINT:
+	  precision = DB_SMALLINT_PRECISION;
 	  scale = 0;
-	}
-      else
-	{
-	  precision = DB_DEFAULT_NUMERIC_PRECISION;
+	  break;
+
+	case PT_TYPE_INTEGER:
+	  precision = DB_INTEGER_PRECISION;
+	  scale = 0;
+	  break;
+
+	case PT_TYPE_BIGINT:
+	  precision = DB_BIGINT_PRECISION;
+	  scale = 0;
+	  break;
+
+	default:
+	  precision = DB_MAX_NUMERIC_PRECISION;
 	  scale = DB_DEFAULT_NUMERIC_DIVISION_SCALE;
+	  break;
 	}
       break;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26652

### Purpose
- PR [#6961](http://jira.cubrid.org/browse/CBRD-26652) 변경 사항을 10.2.18 패치 버전에 반영하기 위한 백포트입니다.
  - 본 PR은 의존성이 있는 PR #4375(CBRD-24815)의 변경 사항을 포함하고 있습니다. 
  - 최종적으로 PR #6961의 로직을 백포트합니다.

- 주요 목적
  - 문자 리터럴을 NUMERIC으로 자동 형변환 시 발생하는 정밀도(Precision) 초과 에러 해결.

### Implementation
- 원본 PR과 동일한 로직을 적용하였습니다. (pt_coerce_expression_argument 내 기본 Precision을 15에서 38로 확장)

### Remarks
- 원본 PR에서 통과된 동일한 재현 케이스 확인 결과 정상 동작을 확인했습니다.
- 해당 패치 버전의 안정성을 위해 정수 계열(integer, bigint 등) 기존 로직은 유지되었습니다.