### PR TITLE
[CBRD-26527] Prevent resetting the entire postpone cache inside nested loops.

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -793,6 +793,8 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 
 #define PRM_NAME_MEMOIZE_MEMORY_LIMIT "memoize_memory_limit"
 
+#define PRM_NAME_LOG_POSTPONE_CACHE_SIZE "postpone_cache_size"
+
 // #endregion 
 
 /*
@@ -5313,7 +5315,19 @@ SYSPRM_PARAM prm_Def[] = {
    NULL_SYSPRM_PARAM_VALUE,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
-   (DUP_PRM_FUNC) NULL}
+   (DUP_PRM_FUNC) NULL},
+  {PRM_ID_LOG_POSTPONE_CACHE_SIZE,
+   PRM_NAME_LOG_POSTPONE_CACHE_SIZE,
+   (PRM_FOR_SERVER | PRM_HIDDEN),
+   PRM_INTEGER,
+   PRM_CLEAR_DYNAMIC_FLAG,
+   {false, {.i = 512}},
+   {false, {.i = 512}},
+   {false, {.i = 4096}},
+   {false, {.i = 4}},
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
 };
 
 SYSPRM_INDIRECT_POS prm_Def_session_idx[DIM (prm_Def)];

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -526,8 +526,10 @@ enum param_id
 
   PRM_ID_HOSTVAR_PEEKING,
 
+  PRM_ID_LOG_POSTPONE_CACHE_SIZE,
+
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_HOSTVAR_PEEKING
+  PRM_LAST_ID = PRM_ID_LOG_POSTPONE_CACHE_SIZE
 };
 typedef enum param_id PARAM_ID;
 

--- a/src/transaction/log_postpone_cache.cpp
+++ b/src/transaction/log_postpone_cache.cpp
@@ -53,6 +53,29 @@ log_postpone_cache::reset ()
     }
 }
 
+void
+log_postpone_cache::reset_from (std::size_t cursor)
+{
+  if (cursor >= m_cursor)
+    {
+      // Cannot reset
+      assert (false);
+      return ;
+    }
+
+  if (cursor > 0)
+    {
+      m_cursor = cursor;
+      m_redo_data_offset = m_cache_entries[cursor].m_offset;
+      m_is_redo_data_buf_full = false;
+    }
+  else
+    {
+      assert (cursor == 0);
+      reset ();
+    }
+}
+
 /**
  * Cache redo data for log postpone
  *
@@ -150,13 +173,6 @@ log_postpone_cache::do_postpone (cubthread::entry &thread_ref, const log_lsa &st
 {
   assert (!start_postpone_lsa.is_null ());
 
-  if (is_full ())
-    {
-      // Cache is not usable
-      reset ();
-      return false;
-    }
-
   // First cached postpone entry at start_postpone_lsa
   int start_index = -1;
   for (std::size_t i = 0; i < m_cursor; ++i)
@@ -171,7 +187,16 @@ log_postpone_cache::do_postpone (cubthread::entry &thread_ref, const log_lsa &st
 
   if (start_index < 0)
     {
-      // Start LSA was not found. Unexpected situation
+      // Start LSA was not found.
+      // Should call log_do_postpone.
+      return false;
+    }
+
+  if (is_full ())
+    {
+      // Do not reset the entire cache; the postponed logs might be used by an outer loop.
+      // Since we cannot handle all of these postponed logs here, we must call log_do_postpone.
+      reset_from (static_cast<std::size_t> (start_index));
       return false;
     }
 
@@ -197,9 +222,9 @@ log_postpone_cache::do_postpone (cubthread::entry &thread_ref, const log_lsa &st
     }
 
   // Finished running postpones, update the number of entries which should be run on next commit
-  assert (!m_is_redo_data_buf_full);
   m_cursor = start_index;
   m_redo_data_offset = m_cache_entries[start_index].m_offset;
+  m_is_redo_data_buf_full = false;
   if (m_cursor == 0)
     {
       assert (m_redo_data_offset == 0); // should be 0 when cursor is back to 0

--- a/src/transaction/log_postpone_cache.cpp
+++ b/src/transaction/log_postpone_cache.cpp
@@ -37,6 +37,7 @@ log_postpone_cache::copy_to (log_postpone_cache &dest) const
   m_redo_data_buf.copy_to (dest.m_redo_data_buf);
   dest.m_redo_data_offset = m_redo_data_offset;
   dest.m_is_redo_data_buf_full = m_is_redo_data_buf_full;
+  dest.m_max_cache_entries = m_max_cache_entries;
   dest.m_cursor = m_cursor;
   dest.m_cache_entries = m_cache_entries;
 }
@@ -87,7 +88,7 @@ log_postpone_cache::add_redo_data (const log_prior_node &node)
 {
   assert (node.data_header != NULL);
   assert (node.rlength == 0 || node.rdata != NULL);
-  assert (m_cursor <= MAX_CACHE_ENTRIES);
+  assert (m_cursor <= m_max_cache_entries);
 
   if (is_full ())
     {
@@ -153,7 +154,7 @@ log_postpone_cache::add_lsa (const log_lsa &lsa)
       return;
     }
 
-  assert (m_cursor < MAX_CACHE_ENTRIES);
+  assert (m_cursor < m_max_cache_entries);
 
   m_cache_entries[m_cursor].m_lsa = lsa;
 
@@ -237,5 +238,5 @@ log_postpone_cache::do_postpone (cubthread::entry &thread_ref, const log_lsa &st
 bool
 log_postpone_cache::is_full () const
 {
-  return m_cursor == MAX_CACHE_ENTRIES || m_is_redo_data_buf_full;
+  return m_cursor == m_max_cache_entries || m_is_redo_data_buf_full;
 }

--- a/src/transaction/log_postpone_cache.hpp
+++ b/src/transaction/log_postpone_cache.hpp
@@ -65,6 +65,7 @@ class log_postpone_cache
 
     void copy_to (log_postpone_cache &dest) const;
     void reset ();
+    void reset_from (std::size_t cursor);
 
     void add_redo_data (const log_prior_node &node);
     void add_lsa (const log_lsa &lsa);

--- a/src/transaction/log_postpone_cache.hpp
+++ b/src/transaction/log_postpone_cache.hpp
@@ -27,8 +27,9 @@
 #include "log_record.hpp"
 #include "mem_block.hpp"
 #include "storage_common.h"
+#include "system_parameter.h"
 
-#include <array>
+#include <vector>
 
 // forward declarations
 struct log_tdes;
@@ -50,8 +51,9 @@ class log_postpone_cache
       : m_redo_data_buf ()
       , m_redo_data_offset (0)
       , m_is_redo_data_buf_full (false)
+      , m_max_cache_entries (static_cast<std::size_t> (prm_get_integer_value (PRM_ID_LOG_POSTPONE_CACHE_SIZE)))
       , m_cursor (0)
-      , m_cache_entries ()
+      , m_cache_entries (m_max_cache_entries)
     {
     }
 
@@ -72,7 +74,6 @@ class log_postpone_cache
     bool do_postpone (cubthread::entry &thread_ref, const log_lsa &start_postpone_lsa);
 
   private:
-    static const std::size_t MAX_CACHE_ENTRIES = 512;
     static const std::size_t REDO_DATA_MAX_SIZE = 100 * 1024;   // 100k
     static const std::size_t BUFFER_RESET_SIZE = 1024;
 
@@ -94,8 +95,9 @@ class log_postpone_cache
     std::size_t m_redo_data_offset;
     bool m_is_redo_data_buf_full;
 
+    std::size_t m_max_cache_entries;
     std::size_t m_cursor;
-    std::array<cache_entry, MAX_CACHE_ENTRIES> m_cache_entries;
+    std::vector<cache_entry> m_cache_entries;
 
     bool is_full () const;
 };


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26527>

### Purpose

log_postpone_cache는 postpone 로그에 접근하는 fast path로 사용되지만, nested loop에서 cache가 꽉 차는 경우 전체 cache를 초기화하고 있습니다. 이 동작은 postpone log가 누락되게 만들고 결과적으로 예상되지 않은 동작을 일으킵니다.

기존에 보고된 케이스의 경우 overflow file의 postpone log를 수행하는 도중 file 각각을 반납하는 sysop postpone으로 인해 cache가 꽉 차게 되고, do_postpone에서 reset이 일어나 외부 loop에서 등록된 postpone log가 모두 제거되어 발생합니다.

### Implementation

nested loop를 고려하여 full reset이 아닌 partial reset을 사용합니다. start_index 지점부터의 로그를 모두 제거하고 buffer offset을 재설정합니다.

### Remarks

전체 검증은 너무 오래 걸려 아래 파라미터들을 변경하여 빠르게 확인 할 수 있습니다. 기존 값은 각각 512, 100 * 1024이며 둘 중 하나의 값을 작게 바꿔 entry 개수가 부족하거나 buffer가 꽉 차는 경우를 재현할 수 있습니다.
```
static const std::size_t MAX_CACHE_ENTRIES = 512;
static const std::size_t REDO_DATA_MAX_SIZE = 100 * 1024;
```

아래와 같이 수행하여 확인하였습니다.
```
MAX_CACHE_ENTRIES를 8로 설정하거나 REDO_DATA_MAX_SIZE를 100으로 설정한 후 빌드.
```

```
cd ~/CUBRID/databases
cubrid createdb --db-volume-size=100M --log-volume-size=100M demodb en_US
cubrid server start demodb
csql -u dba demodb -c "create table tbl (a char (2048), b char (2048), c char (2048), d char (2048), e char (2048), f char (2048), g char (2048), h char (2048), i char (2048), j char (2048));"
csql -u dba demodb -c "INSERT INTO tbl select '1', '1', '1', '1', '1', '1', '1', '1', '1', '1' from table({0,1,2,3,4,5,6,7,8,9}) a, table({0,1,2,3,4,5,6,7,8,9}) b, table({0,1,2,3,4,5,6,7,8,9}) c, table({0,1,2,3,4,5,6,7,8,9}) d, table({0,1,2,3,4,5,6,7,8,9}) e, table({0,1,2,3,4,5,6,7,8,9}) f, table({0,1,2,3,4,5,6,7,8,9}) g, table({0,1,2,3,4,5,6,7,8,9}) h, table({0,1,2,3,4,5,6,7,8,9}) i, table({0,1,2,3,4,5,6,7,8,9}) j limit 10000;"
cubrid service stop
cubrid diagdb -d 2 demodb | tail -n 4
cubrid server start demodb
csql -u dba demodb -c "drop tbl;"
cubrid service stop
cubrid diagdb -d 2 demodb | tail -n 4
cd ~
cubrid deletedb demodb
```
