### PR TITLE
[CBRD-26657] [Regression] Core dumped in pgbuf_fix_debug at src/storage/page_buffer.c:2359

### DIFF
--- a/src/query/parallel/px_heap_scan/px_heap_scan_input_handler_ftabs.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_input_handler_ftabs.cpp
@@ -139,6 +139,10 @@ namespace parallel_heap_scan
 		    /* when bitmap is built, that page was valid.
 		     * but now, it's deallocated in some reasons.
 		     * this is not error, it can be ignored */
+		    if (m_tl_old_page_watcher.pgptr != NULL)
+		      {
+			pgbuf_ordered_unfix (thread_p, &m_tl_old_page_watcher);
+		      }
 		    er_clear ();
 		    found = false;
 		    continue;

--- a/src/query/parallel/px_heap_scan/px_heap_scan_input_handler_ftabs.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_input_handler_ftabs.cpp
@@ -124,8 +124,16 @@ namespace parallel_heap_scan
 		    pgbuf_replace_watcher (thread_p, &m_tl_scan_cache->page_watcher, &m_tl_old_page_watcher);
 		  }
 
-		error_code = pgbuf_ordered_fix (thread_p, &m_tl_vpid, OLD_PAGE_PREVENT_DEALLOC, PGBUF_LATCH_READ,
+		error_code = pgbuf_ordered_fix (thread_p, &m_tl_vpid, OLD_PAGE_MAYBE_DEALLOCATED, PGBUF_LATCH_READ,
 						&m_tl_scan_cache->page_watcher);
+
+		if (m_tl_scan_cache->page_watcher.pgptr == NULL)
+		  {
+		    /* when bitmap is built, that page was valid.
+		     * but now, it's deallocated in some reasons.
+		     * this is not error, it can be ignored */
+		    continue;
+		  }
 
 		if (m_tl_old_page_watcher.pgptr != NULL)
 		  {

--- a/src/query/parallel/px_heap_scan/px_heap_scan_input_handler_ftabs.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_input_handler_ftabs.cpp
@@ -132,6 +132,8 @@ namespace parallel_heap_scan
 		    /* when bitmap is built, that page was valid.
 		     * but now, it's deallocated in some reasons.
 		     * this is not error, it can be ignored */
+		    er_clear ();
+		    found = false;
 		    continue;
 		  }
 

--- a/src/query/parallel/px_heap_scan/px_heap_scan_input_handler_ftabs.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_input_handler_ftabs.cpp
@@ -129,6 +129,13 @@ namespace parallel_heap_scan
 
 		if (m_tl_scan_cache->page_watcher.pgptr == NULL)
 		  {
+		    if (error_code != NO_ERROR && error_code != ER_PB_BAD_PAGEID)
+		      {
+			/* non-dealloc error (e.g. ER_INTERRUPTED): propagate */
+			m_err_messages_p->move_top_error_message_to_this ();
+			m_interrupt_p->set_code (parallel_query::interrupt::interrupt_code::ERROR_INTERRUPTED_FROM_WORKER_THREAD);
+			return S_ERROR;
+		      }
 		    /* when bitmap is built, that page was valid.
 		     * but now, it's deallocated in some reasons.
 		     * this is not error, it can be ignored */

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -12121,6 +12121,13 @@ pgbuf_ordered_fix_release (THREAD_ENTRY * thread_p, const VPID * req_vpid, PAGE_
 	{
 	  goto exit;
 	}
+      /* OLD_PAGE_MAYBE_DEALLOCATED sets ER_WARNING_SEVERITY for ER_PB_BAD_PAGEID,
+       * which er_errid_if_has_error() does not catch; handle it explicitly here. */
+      if (fetch_mode == OLD_PAGE_MAYBE_DEALLOCATED && er_errid () == ER_PB_BAD_PAGEID)
+	{
+	  er_status = ER_PB_BAD_PAGEID;
+	  goto exit;
+	}
 
       wait_msecs = pgbuf_find_current_wait_msecs (thread_p);
       if (wait_msecs == LK_ZERO_WAIT || wait_msecs == LK_FORCE_ZERO_WAIT)
@@ -12567,10 +12574,21 @@ pgbuf_ordered_fix_release (THREAD_ENTRY * thread_p, const VPID * req_vpid, PAGE_
 	    }
 	  if (er_status == ER_PB_BAD_PAGEID)
 	    {
-	      /* page was probably deallocated? so has the impossible indeed happen?? */
-	      assert (false);
-	      er_log_debug (ARG_FILE_LINE, "pgbuf_ordered_fix: page %d|%d was deallocated an we told it not to!\n",
-			    VPID_AS_ARGS (&ordered_holders_info[i].vpid));
+	      if (VPID_EQ (req_vpid, &(ordered_holders_info[i].vpid)) && fetch_mode == OLD_PAGE_MAYBE_DEALLOCATED)
+		{
+		  /* page was deallocated between ftab snapshot and actual fix; this is expected with
+		   * OLD_PAGE_MAYBE_DEALLOCATED. */
+		  er_log_debug (ARG_FILE_LINE,
+				"pgbuf_ordered_fix: page %d|%d was deallocated (OLD_PAGE_MAYBE_DEALLOCATED mode).\n",
+				VPID_AS_ARGS (&ordered_holders_info[i].vpid));
+		}
+	      else
+		{
+		  /* page was probably deallocated? so has the impossible indeed happen?? */
+		  assert (false);
+		  er_log_debug (ARG_FILE_LINE, "pgbuf_ordered_fix: page %d|%d was deallocated an we told it not to!\n",
+				VPID_AS_ARGS (&ordered_holders_info[i].vpid));
+		}
 	    }
 	  if (!VPID_EQ (req_vpid, &(ordered_holders_info[i].vpid)))
 	    {


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26657>

### Purpose

비트맵 스냅샷을 찍은 이후 워커가 fix를 시도하기 이전에 이미 dealloc이 완료된 경우, `pgbuf_ordered_fix`를 `OLD_PAGE_PREVENT_DEALLOC`으로 요청하면 debug 모드에서는 assertion이, release 모드에서는 `page_watcher.pgptr`이 NULL인 채로 `pgbuf_get_page_ptype`이 호출되어 NULL dereference가 발생합니다. page fhead에 대한 latch를 길게 잡고 있도록 수정할 경우 db 전체의 성능이 저하될 수 있기 때문에, 비트맵을 찍은 시점의 heap data page가 dealloc 될 수 있음을 가정하고 코드를 수정하였습니다.

### Implementation

`px_heap_scan_input_handler_ftabs.cpp`

`pgbuf_ordered_fix` 호출 시 `fetch_mode`를 `OLD_PAGE_PREVENT_DEALLOC`에서 `OLD_PAGE_MAYBE_DEALLOCATED`로 변경
fix 완료 후 `page_watcher.pgptr`이 NULL인 경우(이미 dealloc된 페이지) 해당 페이지를 skip하도록 처리

`page_buffer.c (pgbuf_ordered_fix_debug)`

첫 번째 fix 실패 경로에서 `OLD_PAGE_MAYBE_DEALLOCATED`는 `ER_PB_BAD_PAGEID`를 `ER_WARNING_SEVERITY`로 설정하기 때문에 `er_errid_if_has_error()`가 이를 감지하지 못합니다. `er_errid()`를 통해 명시적으로 확인하여 early exit 처리하였습니다. 이를 처리하지 않으면 `PGBUF_CONDITIONAL_LATCH` 경로에서 dealloc된 페이지가 정상적인 latch 충돌로 오인되어 reorder 루프로 잘못 진입합니다.
re-fix 루프에서 요청 페이지(req_vpid)를 re-fix하는 도중 `ER_PB_BAD_PAGEID`가 반환된 경우, `OLD_PAGE_MAYBE_DEALLOCATED`가 사용된 경우에 한해 assert(false) 없이 디버그 로그만 남기고 exit 처리하였습니다.

### Remarks

기존 `pgbuf_ordered_fix_debug` re-fix 루프의 `assert(false)`는 `OLD_PAGE_PREVENT_DEALLOC`의 불변 조건(unfix 전 `pgbuf_bcb_register_avoid_deallocation`이 등록되어 dealloc이 불가능해야 함)을 보장하기 위한 것으로, 다른 페이지의 re-fix 또는 `OLD_PAGE_MAYBE_DEALLOCATED` 이외의 fetch_mode에 대해서는 그대로 유지됩니다.
