### PR TITLE
[CBRD-26649] Add PAGE_OOS to all page type switch/case statements

### DIFF
--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -2096,6 +2096,8 @@ perfmon_stat_page_type_name (const int page_type)
       return "PAGE_EHASH";
     case PERF_PAGE_OVERFLOW:
       return "PAGE_OVERFLOW";
+    case PERF_PAGE_OOS:
+      return "PAGE_OOS";
     case PERF_PAGE_AREA:
       return "PAGE_AREA";
     case PERF_PAGE_CATALOG:

--- a/src/base/perf_monitor.h
+++ b/src/base/perf_monitor.h
@@ -218,6 +218,7 @@ typedef enum
   PERF_PAGE_QRESULT,		/* query result page */
   PERF_PAGE_EHASH,		/* ehash bucket/dir page */
   PERF_PAGE_OVERFLOW,		/* overflow page (with ovf_keyval) */
+  PERF_PAGE_OOS,		/* oos page */
   PERF_PAGE_AREA,		/* area page */
   PERF_PAGE_CATALOG,		/* catalog page */
   PERF_PAGE_BTREE_GENERIC,	/* b+tree index (uninitialized) */

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -16728,6 +16728,7 @@ pgbuf_scan_bcb_table ()
 	      break;
 	    case PAGE_OVERFLOW:
 	    case PAGE_HEAP:
+	    case PAGE_OOS:
 	      show_status_snapshot->num_data_pages++;
 	      break;
 	    case PAGE_CATALOG:

--- a/src/storage/slotted_page.c
+++ b/src/storage/slotted_page.c
@@ -1152,6 +1152,7 @@ spage_is_slotted_page_type (PAGE_TYPE ptype)
   switch (ptype)
     {
     case PAGE_HEAP:
+    case PAGE_OOS:
     case PAGE_BTREE:
     case PAGE_EHASH:
     case PAGE_CATALOG:


### PR DESCRIPTION
https://jira.cubrid.org/browse/CBRD-26649

## Description

OOS 기능 구현 시 `PAGE_TYPE` enum에 `PAGE_OOS` 를 추가했으나, 코드베이스 전반의 page type switch/case 문에 반영하지 않았다. 이로 인해 replication 과정에서 `spage_is_slotted_page_type()` 이 OOS 페이지에 대해 `false` 를 반환하여 assert 실패 및 코어 덤프가 발생했다.

## Implementation

- `spage_is_slotted_page_type()` 에 `case PAGE_OOS:` 추가 → `true` 반환 (OOS는 slotted page 포맷 사용)
- `PERF_PAGE_TYPE` enum에 `PERF_PAGE_OOS` 추가 (`PERF_PAGE_OVERFLOW` 와 `PERF_PAGE_AREA` 사이) → `PAGE_TYPE` 과 값 일치 유지 (직접 cast 사용하므로 필수)
- `perfmon_stat_page_type_name()` 에 `case PERF_PAGE_OOS: return "PAGE_OOS"` 추가
- `pgbuf_scan_bcb_table()` 상태 스냅샷에서 `PAGE_OOS` 를 data pages로 카운팅 (`PAGE_HEAP`, `PAGE_OVERFLOW` 와 동일 카테고리)

## Remarks

- `PGBUF_IS_ORDERED_PAGETYPE` 매크로는 현재 수정 불필요 (OOS 페이지는 `pgbuf_fix` 만 사용, `pgbuf_ordered_fix` 미사용). Ordered fix 지원은 M4 과제로 예정.
- JIRA: http://jira.cubrid.org/browse/CBRD-26649