### PR TITLE
[CBRD-26061] Ignore #error directives during cppcheck in GitHub Actions

### DIFF
--- a/.github/workflows/cppcheck-spr-list
+++ b/.github/workflows/cppcheck-spr-list
@@ -2,3 +2,4 @@ syntaxError
 objectIndex
 unknownMacro
 internalAstError
+preprocessorErrorDirective


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26061

### Purpose
- develop 브랜치의 5defca1c8 커밋을 release/11.4에 backport
- cppcheck 실행 시 `#error` 지시어를 무시하도록 suppress 목록에 추가