### PR TITLE
[CBRD-26374] Fix loaddb compat client type handling and resource leaks

### DIFF
--- a/src/compat/db_client_type.hpp
+++ b/src/compat/db_client_type.hpp
@@ -52,6 +52,9 @@ enum db_client_type
    *   - default: DB_CLIENT_TYPE_ADMIN_LOADDB_COMPAT_UNDER_11_2
    *   - if source version >= 11.2: switch to DB_CLIENT_TYPE_ADMIN_LOADDB_COMPAT_UNDER_11_4
    *   - if source version >= 11.4: switch to DB_CLIENT_TYPE_LOADDB_UTILITY (compat off)
+   *
+   * NOTE: These three values must remain in ascending order.
+   *   ldr_server_load() uses MAX() to track the highest compat level.
    */
   DB_CLIENT_TYPE_ADMIN_LOADDB_COMPAT_UNDER_11_2 = 19,
   DB_CLIENT_TYPE_ADMIN_LOADDB_COMPAT_UNDER_11_4 = 20,

--- a/src/loaddb/load_db.c
+++ b/src/loaddb/load_db.c
@@ -1021,7 +1021,8 @@ ldr_exec_query_from_file (const char *file_name, FILE * input_stream, int *start
   int executed_cnt = 0;
   int last_statement_line_no = 0;	// tracks line no of the last successfully executed stmt. -1 for failed ones.
   int base_line = *start_line - 1;
-  int client_type = DB_CLIENT_TYPE_LOADDB_UTILITY;
+  int client_type;
+  int save_client_type = DB_CLIENT_TYPE_LOADDB_UTILITY;	/* prevents compat check in 'end' on early goto */
 
   if ((*start_line) > 1)
     {
@@ -1057,7 +1058,7 @@ ldr_exec_query_from_file (const char *file_name, FILE * input_stream, int *start
 
   util_arm_signal_handlers (&ldr_exec_query_interrupt_handler, &ldr_exec_query_interrupt_handler);
 
-  client_type = db_get_client_type ();
+  save_client_type = client_type = db_get_client_type ();
 
   while (true)
     {
@@ -1071,6 +1072,8 @@ ldr_exec_query_from_file (const char *file_name, FILE * input_stream, int *start
 	  db_close_session (session);
 	  goto end;
 	}
+
+      client_type = db_get_client_type ();
 
       stmt_cnt = db_parse_one_statement (session);
       if (stmt_cnt > 0)
@@ -1197,17 +1200,17 @@ end:
       db_commit_transaction ();
     }
 
-  if (client_type == DB_CLIENT_TYPE_ADMIN_LOADDB_COMPAT_UNDER_11_2
-      || client_type == DB_CLIENT_TYPE_ADMIN_LOADDB_COMPAT_UNDER_11_4)
+  if (save_client_type == DB_CLIENT_TYPE_ADMIN_LOADDB_COMPAT_UNDER_11_2
+      || save_client_type == DB_CLIENT_TYPE_ADMIN_LOADDB_COMPAT_UNDER_11_4)
     {
       /* For stored procedures, jsp_find_stored_procedure() is invoked from db_execute_statement()
        * and may change the client type.
        * Check whether the client type has changed after db_execute_statement(). */
 
-      int load_client_type = db_get_client_type ();
+      client_type = db_get_client_type ();
 
-      if (client_type == DB_CLIENT_TYPE_ADMIN_LOADDB_COMPAT_UNDER_11_2
-	  && load_client_type == DB_CLIENT_TYPE_ADMIN_LOADDB_COMPAT_UNDER_11_4)
+      if (save_client_type == DB_CLIENT_TYPE_ADMIN_LOADDB_COMPAT_UNDER_11_2
+	  && client_type == DB_CLIENT_TYPE_ADMIN_LOADDB_COMPAT_UNDER_11_4)
 	{
 	  if (args->verbose)
 	    {
@@ -1222,7 +1225,7 @@ end:
 	    }
 	}
 
-      if (load_client_type == DB_CLIENT_TYPE_LOADDB_UTILITY)
+      if (client_type == DB_CLIENT_TYPE_LOADDB_UTILITY)
 	{
 	  if (args->verbose)
 	    {

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -162,7 +162,7 @@ namespace cubload
 	  }
 
 	/* This is the case when the loaddb utility is executed with the --no-user-specified-name option as the dba user. */
-	if (thread_ref.conn_entry->client_type == DB_CLIENT_TYPE_ADMIN_LOADDB_COMPAT_UNDER_11_2)
+	if (m_session.get_client_type() == DB_CLIENT_TYPE_ADMIN_LOADDB_COMPAT_UNDER_11_2)
 	  {
 	    found_again = locate_class_for_all_users (class_name, class_oid);
 	    if (found_again == LC_CLASSNAME_EXIST)
@@ -219,7 +219,8 @@ namespace cubload
     mvcc_snapshot = logtb_get_mvcc_snapshot (&thread_ref);
     if (mvcc_snapshot == NULL)
       {
-	/* TODO: er_set() */
+	ASSERT_ERROR_AND_SET (error);
+	heap_attrinfo_end (&thread_ref, &attr_info);
 	return LC_CLASSNAME_ERROR;
       }
 
@@ -241,9 +242,16 @@ namespace cubload
 	if (scan_code == S_SUCCESS)
 	  {
 	    scan_code = heap_get_visible_version (&thread_ref, &inst_oid, oid_User_class_oid, &recdes, &scan_cache, PEEK, NULL_CHN);
-	    if (scan_code != S_SUCCESS)
+	    if (scan_code == S_SNAPSHOT_NOT_SATISFIED || scan_code == S_DOESNT_EXIST)
 	      {
 		continue;
+	      }
+	    else if (scan_code != S_SUCCESS)
+	      {
+		ASSERT_ERROR ();
+		heap_scancache_end (&thread_ref, &scan_cache);
+		heap_attrinfo_end (&thread_ref, &attr_info);
+		return LC_CLASSNAME_ERROR;
 	      }
 
 	    error = heap_attrinfo_read_dbvalues (&thread_ref, &inst_oid, &recdes, &attr_info);

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -219,7 +219,7 @@ namespace cubload
     mvcc_snapshot = logtb_get_mvcc_snapshot (&thread_ref);
     if (mvcc_snapshot == NULL)
       {
-	ASSERT_ERROR_AND_SET (error);
+	ASSERT_ERROR ();
 	heap_attrinfo_end (&thread_ref, &attr_info);
 	return LC_CLASSNAME_ERROR;
       }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26374

### Purpose

- loaddb의 호환성 옵션(`--no-user-specified-name`) 사용 시, `db_execute_statement ()` 내부에서 client_type이 변경될 수 있는 상황에 대한 안정성 개선
- `locate_class_for_all_users ()`에서 에러 경로의 리소스 누수 및 에러 미설정 문제 수정

### Implementation

- `ldr_exec_query_from_file ()`: save_client_type으로 원래 client_type을 보존하고, 루프 내에서 매 iteration 마다 최신 client_type을 반영
- `locate_class_for_all_users ()`:
   - MVCC snapshot NULL 시 리소스 누수 수정
   - `heap_get_visible_version ()` 에러와 MVCC invisible을 분리 처리
   - client type 접근을 세션 API로 변경
- `db_client_type.hpp`: compat enum 값의 오름차순 제약 주석 추가

### Remarks

N/A

---

Prevent unnecessary repeated changes to compatibility client_type and resolve associated resource leaks.