### PR TITLE
[CBRD-26670] 병렬 부질의 실행 시 세션변수를 분석함수 안에서 평가할 경우 crash

### DIFF
--- a/src/query/parallel/px_query_execute/px_query_checker.cpp
+++ b/src/query/parallel/px_query_execute/px_query_checker.cpp
@@ -316,7 +316,19 @@ namespace parallel_query_execute
     check_pred_expr (xasl->instnum_pred);
     check_regu_var (xasl->limit_offset);
     check_regu_var (xasl->limit_row_count);
-
+    if (xasl->type == BUILDLIST_PROC)
+      {
+	if (xasl->proc.buildlist.a_outptr_list)
+	  {
+	    check_regu_var_list (xasl->proc.buildlist.a_outptr_list->valptrp);
+	  }
+	if (xasl->proc.buildlist.g_outptr_list)
+	  {
+	    check_regu_var_list (xasl->proc.buildlist.g_outptr_list->valptrp);
+	  }
+	check_regu_var_list (xasl->proc.buildlist.a_regu_list);
+	check_regu_var_list (xasl->proc.buildlist.g_regu_list);
+      }
   }
 
   void xasl_checker::check_access_spec_type (ACCESS_SPEC_TYPE *access_spec_type)

--- a/src/query/parallel/px_query_execute/px_query_checker.cpp
+++ b/src/query/parallel/px_query_execute/px_query_checker.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "px_query_checker.hpp"
+#include "xasl_analytic.hpp"
 #include "xasl_predicate.hpp"
 #include <set>
 
@@ -47,6 +48,7 @@ namespace parallel_query_execute
       void check_like_eval_term (LIKE_EVAL_TERM *like_eval_term);
       void check_rlike_eval_term (RLIKE_EVAL_TERM *rlike_eval_term);
       void check_regu_var_list (REGU_VARIABLE_LIST regu_var_list);
+      void check_analytic_eval_list (ANALYTIC_EVAL_TYPE *a_eval_list);
       void check_xasl_node (XASL_NODE *xasl);
       void check_access_spec_type (ACCESS_SPEC_TYPE *access_spec_type);
       std::set<XASL_NODE *> get_child_xasl_set_recursive (XASL_NODE *xasl);
@@ -289,6 +291,21 @@ namespace parallel_query_execute
       }
   }
 
+  void xasl_checker::check_analytic_eval_list (ANALYTIC_EVAL_TYPE *a_eval_list)
+  {
+    for (ANALYTIC_EVAL_TYPE *eval = a_eval_list; eval != nullptr; eval = eval->next)
+      {
+	for (ANALYTIC_TYPE *node = eval->head; node != nullptr; node = node->next)
+	  {
+	    check_regu_var (&node->operand);
+	    if (node->function == PT_PERCENTILE_CONT || node->function == PT_PERCENTILE_DISC)
+	      {
+		check_regu_var (node->info.percentile.percentile_reguvar);
+	      }
+	  }
+      }
+  }
+
   void xasl_checker::check_xasl_node (XASL_NODE *xasl)
   {
     if (!xasl)
@@ -322,12 +339,27 @@ namespace parallel_query_execute
 	  {
 	    check_regu_var_list (xasl->proc.buildlist.a_outptr_list->valptrp);
 	  }
+	if (xasl->proc.buildlist.a_outptr_list_ex)
+	  {
+	    check_regu_var_list (xasl->proc.buildlist.a_outptr_list_ex->valptrp);
+	  }
+	if (xasl->proc.buildlist.a_outptr_list_interm)
+	  {
+	    check_regu_var_list (xasl->proc.buildlist.a_outptr_list_interm->valptrp);
+	  }
 	if (xasl->proc.buildlist.g_outptr_list)
 	  {
 	    check_regu_var_list (xasl->proc.buildlist.g_outptr_list->valptrp);
 	  }
 	check_regu_var_list (xasl->proc.buildlist.a_regu_list);
+	check_regu_var_list (xasl->proc.buildlist.a_scan_regu_list);
 	check_regu_var_list (xasl->proc.buildlist.g_regu_list);
+	check_regu_var_list (xasl->proc.buildlist.g_hk_scan_regu_list);
+	check_regu_var_list (xasl->proc.buildlist.g_hk_sort_regu_list);
+	check_regu_var_list (xasl->proc.buildlist.g_scan_regu_list);
+	check_pred_expr (xasl->proc.buildlist.g_having_pred);
+	check_pred_expr (xasl->proc.buildlist.g_grbynum_pred);
+	check_analytic_eval_list (xasl->proc.buildlist.a_eval_list);
       }
   }
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26670>

### Purpose

UNION 쿼리 내 SELECT 리스트에서 세션 변수(user-defined variable)가 analytic(window) 함수 내부에 포함된 경우, parallel uncorrelated subquery 실행 경로에서 세션 변수 평가 시 race-condition이 발생하여 segmentation fault가 발생합니다.

### Implementation

Parallel uncorrelated subquery 실행 시, SELECT 리스트 등에 세션 변수 평가가 포함된 경우 실행을 차단하는 guard 조건(if문)이 존재합니다.
그러나 해당 쿼리는 세션 변수(@v3)가 analytic함수의 인자 내부에 위치하기 때문에, 기존 guard 조건의 탐지 로직을 통과합니다.
이 상태에서 parallel 실행 경로로 진입하면, 세션 변수에 대한 thread-unsafe한 접근이 발생하여 segmentation fault로 이어집니다.
세션 변수 평가 여부를 탐지하는 로직을 보완하여, analytic 함수 내부에 세션 변수가 포함된 경우도 올바르게 감지하고 parallel 실행을 차단하거나 안전하게 처리하도록 수정이 필요합니다.
