### PR TITLE
[CBRD-non-unique-count-opt] non-unique btree count optimization

### DIFF
--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -5935,6 +5935,69 @@ sm_find_index (MOP classop, char **att_names, int num_atts, bool unique_index_on
 }
 
 /*
+ * sm_find_index_for_count_star_optimization () - MVCC COUNT(*) fast path: unique index if any, else non-unique index;
+ *						  skips partial/filter/function indexes.
+ *						  NULL rows are tracked in num_nulls so num_oids always equals
+ *						  the total row count, making the NOT NULL restriction unnecessary.
+ */
+BTID *
+sm_find_index_for_count_star_optimization (MOP classop, BTID * btid)
+{
+  int error = NO_ERROR;
+  SM_CLASS *class_ = NULL;
+  SM_CLASS_CONSTRAINT *con = NULL;
+  BTID *index = NULL;
+  bool force_local_index = false;
+  int is_global = 0;
+
+  if (sm_find_index (classop, NULL, 0, true, false, btid) != NULL)
+    {
+      return btid;
+    }
+
+  error = au_fetch_class (classop, &class_, AU_FETCH_READ, AU_SELECT);
+  if (error != NO_ERROR)
+    {
+      return NULL;
+    }
+
+  if (class_->partition != NULL && class_->users == NULL)
+    {
+      force_local_index = true;
+    }
+
+  for (con = class_->constraints; con != NULL; con = con->next)
+    {
+      if (!SM_IS_CONSTRAINT_INDEX_FAMILY (con->type))
+	{
+	  continue;
+	}
+      if (SM_IS_CONSTRAINT_UNIQUE_FAMILY (con->type))
+	{
+	  continue;
+	}
+      if (con->filter_predicate != NULL || con->func_index_info != NULL)
+	{
+	  continue;
+	}
+      if (sm_is_global_only_constraint (classop, con, &is_global, NULL) != NO_ERROR)
+	{
+	  return NULL;
+	}
+      if (force_local_index && is_global)
+	{
+	  continue;
+	}
+
+      BTID_COPY (btid, &con->index_btid);
+      index = btid;
+      break;
+    }
+
+  return index;
+}
+
+/*
  * sm_att_constrained() - Returns whether the attribute is auto_increment.
  *   classop(in): class object
  *   name(in): attribute

--- a/src/object/schema_manager.h
+++ b/src/object/schema_manager.h
@@ -239,6 +239,7 @@ extern int sm_att_default_value (MOP classop, const char *name, DB_VALUE * value
 extern int sm_class_check_uniques (MOP classop);
 extern BTID *sm_find_index (MOP classop, char **att_names, int num_atts, bool unique_index_only,
 			    bool skip_prefix_length_index, BTID * btid);
+extern BTID *sm_find_index_for_count_star_optimization (MOP classop, BTID * btid);
 
 
 /* Query processor support functions */

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -3985,22 +3985,14 @@ pt_to_aggregate_node (PARSER_CONTEXT * parser, PT_NODE * tree, void *arg, int *c
 	      || aggregate_list->function == PT_MAX || aggregate_list->function == PT_MIN))
 	{
 	  BTID *btid = NULL;
-	  bool need_unique_index;
+	  const bool need_unique_index = false;
 
 	  classop = sm_find_class (info->class_name);
-	  if (aggregate_list->function == PT_COUNT_STAR)
-	    {
-	      need_unique_index = true;
-	    }
-	  else
-	    {
-	      need_unique_index = false;
-	    }
 
-	  /* enable count optimization in MVCC if have unique index */
+	  /* enable count optimization in MVCC if a suitable index exists (unique or non-unique full-row coverage) */
 	  if (aggregate_list->function == PT_COUNT_STAR)
 	    {
-	      btid = sm_find_index (classop, NULL, 0, need_unique_index, false, &aggregate_list->btid);
+	      btid = sm_find_index_for_count_star_optimization (classop, &aggregate_list->btid);
 	      if (btid != NULL)
 		{
 		  /* If btree does not exist, optimize with heap in non-MVCC */

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -686,6 +686,8 @@ struct btree_insert_helper
 
   bool log_operations;		/* er_log. */
   bool is_null;			/* is key NULL. */
+  bool nonunique_oid_stats_valid;	/* true when the non-unique b-tree root header has valid (non-legacy) OID
+					 * statistics; set once in btree_fix_root_for_insert on first try. */
   char *printed_key;		/* Printed key. */
   SHA1Hash printed_key_sha1;	/* SHA1 of printed key - useful for very large keys */
 
@@ -731,6 +733,7 @@ btree_insert_helper::btree_insert_helper ()
   , is_ha_enabled (false)
   , log_operations (false)
   , is_null (false)
+  , nonunique_oid_stats_valid (false)
   , printed_key (NULL)
   , printed_key_sha1 (SHA1_HASH_INITIALIZER)
   , insert_list (NULL)
@@ -5819,9 +5822,10 @@ xbtree_add_index (THREAD_ENTRY * thread_p, BTID * btid, TP_DOMAIN * key_type, OI
     }
   else
     {
-      root_header->num_oids = -1;
-      root_header->num_nulls = -1;
-      root_header->num_keys = -1;
+      /* Maintain OID/key counters for COUNT(*) optimization on non-unique indexes. */
+      root_header->num_oids = 0;
+      root_header->num_nulls = 0;
+      root_header->num_keys = 0;
       root_header->unique_pk = 0;
     }
 
@@ -6607,6 +6611,10 @@ btree_get_unique_statistics_for_count (THREAD_ENTRY * thread_p, BTID * btid, lon
   *oid_cnt = unique_stats->tran_stats.num_oids + unique_stats->global_stats.num_oids;
   *key_cnt = unique_stats->tran_stats.num_keys + unique_stats->global_stats.num_keys;
   *null_cnt = unique_stats->tran_stats.num_nulls + unique_stats->global_stats.num_nulls;
+  if (*oid_cnt < 0 || *key_cnt < 0 || *null_cnt < 0)
+    {
+      return ER_FAILED;
+    }
 
   return NO_ERROR;
 }
@@ -6650,13 +6658,26 @@ btree_get_unique_statistics (THREAD_ENTRY * thread_p, BTID * btid, long long *oi
       return (((ret = er_errid ()) == NO_ERROR) ? ER_FAILED : ret);
     }
 
-  assert ((root_header->unique_pk & (BTREE_CONSTRAINT_UNIQUE | BTREE_CONSTRAINT_PRIMARY_KEY)) != 0);
+  if (BTREE_IS_UNIQUE (root_header->unique_pk))
+    {
+      assert ((root_header->unique_pk & (BTREE_CONSTRAINT_UNIQUE | BTREE_CONSTRAINT_PRIMARY_KEY)) != 0);
+    }
 
   *oid_cnt = root_header->num_oids;
   *null_cnt = root_header->num_nulls;
   *key_cnt = root_header->num_keys;
 
-  pgbuf_unfix_and_init (thread_p, root);
+  {
+    int r_unique_pk = root_header->unique_pk;
+
+    pgbuf_unfix_and_init (thread_p, root);
+
+    if (!BTREE_IS_UNIQUE (r_unique_pk) && (*oid_cnt < 0 || *null_cnt < 0 || *key_cnt < 0))
+      {
+	/* Legacy non-unique index created before per-index OID statistics. */
+	return ER_FAILED;
+      }
+  }
 
   return NO_ERROR;
 }
@@ -14814,8 +14835,6 @@ btree_reflect_global_unique_statistics (THREAD_ENTRY * thread_p, GLOBAL_UNIQUE_S
 
   if (root_header->num_nulls != -1)
     {
-      assert_release (BTREE_IS_UNIQUE (root_header->unique_pk));
-
       if (!only_active_tran || logtb_is_current_active (thread_p))
 	{
 	  int over = 0;
@@ -27212,6 +27231,13 @@ btree_fix_root_for_insert (THREAD_ENTRY * thread_p, BTID * btid, BTID_INT * btid
    * must not be executed again. Mark insert_helper to know to skip this part. */
   insert_helper->is_first_try = false;
 
+  /* Determine whether this non-unique b-tree has valid (non-legacy) OID statistics.
+   * Legacy btrees created before per-index OID tracking have num_oids == -1. */
+  if (!BTREE_IS_UNIQUE (btid_int->unique_pk))
+    {
+      insert_helper->nonunique_oid_stats_valid = (root_header->num_oids >= 0);
+    }
+
   /* Set complete domain for MIDXKEYS. */
   if (key != NULL && DB_VALUE_DOMAIN_TYPE (key) == DB_TYPE_MIDXKEY)
     {
@@ -27303,6 +27329,54 @@ btree_fix_root_for_insert (THREAD_ENTRY * thread_p, BTID * btid, BTID_INT * btid
 		  ASSERT_ERROR ();
 		  goto error;
 		}
+	    }
+	}
+    }
+  else if (insert_helper->nonunique_oid_stats_valid
+	   && !btree_is_online_index_loading (insert_helper->purpose)
+	   && (insert_helper->purpose == BTREE_OP_INSERT_MVCC_DELID
+	       || insert_helper->purpose == BTREE_OP_INSERT_MARK_DELETED
+	       || (btree_is_insert_object_purpose (insert_helper->purpose) && insert_helper->is_null)))
+    {
+      btree_unique_stats incr;
+
+      if (insert_helper->purpose == BTREE_OP_INSERT_MVCC_DELID
+	  || insert_helper->purpose == BTREE_OP_INSERT_MARK_DELETED)
+	{
+	  /* Non-unique indexes track one OID per visible row; logical delete removes a row, not always a key. */
+	  if (insert_helper->is_null)
+	    {
+	      incr.delete_null_and_row ();
+	    }
+	  else
+	    {
+	      incr.delete_row ();
+	    }
+	}
+      else
+	{
+	  /* NULL row being inserted: btree key will not be created (is_null early-exit below),
+	   * so track it here ??mirroring the unique-index path. */
+	  incr.insert_null_and_row ();
+	}
+
+      if (BTREE_IS_MULTI_ROW_OP (insert_helper->op_type))
+	{
+	  if (insert_helper->unique_stats_info == NULL)
+	    {
+	      assert_release (false);
+	      error_code = ER_FAILED;
+	      goto error;
+	    }
+	  (*insert_helper->unique_stats_info) += incr;
+	}
+      else
+	{
+	  error_code = logtb_tran_update_unique_stats (thread_p, *btid, incr, true);
+	  if (error_code != NO_ERROR)
+	    {
+	      ASSERT_ERROR ();
+	      goto error;
 	    }
 	}
     }
@@ -28505,6 +28579,17 @@ btree_key_insert_new_key (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB_VALUE
   (void) btree_verify_node (thread_p, btid_int, leaf_page);
 #endif
 
+  if (!BTREE_IS_UNIQUE (btid_int->unique_pk) && !btree_is_online_index_loading (insert_helper->purpose)
+      && insert_helper->nonunique_oid_stats_valid)
+    {
+      error_code = logtb_tran_update_unique_stats (thread_p, btid_int->sys_btid, 1LL, 1LL, 0LL, true);
+      if (error_code != NO_ERROR)
+	{
+	  ASSERT_ERROR ();
+	  return error_code;
+	}
+    }
+
   return NO_ERROR;
 
 error:
@@ -29001,6 +29086,17 @@ btree_key_append_object_non_unique (THREAD_ENTRY * thread_p, BTID_INT * btid_int
 			BTREE_INSERT_MODIFY_ARGS (thread_p, insert_helper, leaf, &prev_lsa, true, search_key->slotid,
 						  leaf_record->length, btid_int->sys_btid));
 
+      if (!BTREE_IS_UNIQUE (btid_int->unique_pk) && !btree_is_online_index_loading (insert_helper->purpose)
+	  && insert_helper->nonunique_oid_stats_valid)
+	{
+	  error_code = logtb_tran_update_unique_stats (thread_p, btid_int->sys_btid, 0LL, 1LL, 0LL, true);
+	  if (error_code != NO_ERROR)
+	    {
+	      ASSERT_ERROR ();
+	      return error_code;
+	    }
+	}
+
       return NO_ERROR;
     }
 
@@ -29015,6 +29111,17 @@ btree_key_append_object_non_unique (THREAD_ENTRY * thread_p, BTID_INT * btid_int
     {
       ASSERT_ERROR ();
       return error_code;
+    }
+
+  if (!BTREE_IS_UNIQUE (btid_int->unique_pk) && !btree_is_online_index_loading (insert_helper->purpose)
+      && insert_helper->nonunique_oid_stats_valid)
+    {
+      error_code = logtb_tran_update_unique_stats (thread_p, btid_int->sys_btid, 0LL, 1LL, 0LL, true);
+      if (error_code != NO_ERROR)
+	{
+	  ASSERT_ERROR ();
+	  return error_code;
+	}
     }
 
   /* Success. */
@@ -34756,7 +34863,7 @@ btree_key_online_index_IB_insert (THREAD_ENTRY * thread_p, BTID_INT * btid_int, 
     }
 
 end:
-  if (error_code == NO_ERROR && BTREE_IS_UNIQUE (btid_int->unique_pk))
+  if (error_code == NO_ERROR)
     {
       logtb_tran_update_unique_stats (thread_p, btid_int->sys_btid, n_keys, n_oids, 0, false);
     }
@@ -34964,7 +35071,7 @@ btree_key_online_index_tran_insert (THREAD_ENTRY * thread_p, BTID_INT * btid_int
 	    btree_key_append_object_non_unique (thread_p, btid_int, key, *leaf_page, search_key, &new_record,
 						offset_after_key, &leaf_info, &helper->insert_helper.obj_info,
 						&helper->insert_helper);
-	  if (error_code == NO_ERROR && BTREE_IS_UNIQUE (btid_int->unique_pk))
+	  if (error_code == NO_ERROR)
 	    {
 	      // Append a single object.
 	      logtb_tran_update_unique_stats (thread_p, btid_int->sys_btid, 0, 1, 0, false);
@@ -34977,7 +35084,7 @@ btree_key_online_index_tran_insert (THREAD_ENTRY * thread_p, BTID_INT * btid_int
     {
       /* Key was not found, we must insert it. */
       error_code = btree_key_insert_new_key (thread_p, btid_int, key, *leaf_page, &helper->insert_helper, search_key);
-      if (error_code == NO_ERROR && BTREE_IS_UNIQUE (btid_int->unique_pk))
+      if (error_code == NO_ERROR)
 	{
 	  /* Insert a key with an object. */
 	  logtb_tran_update_unique_stats (thread_p, btid_int->sys_btid, 1, 1, 0, false);
@@ -35206,7 +35313,7 @@ btree_key_online_index_tran_delete (THREAD_ENTRY * thread_p, BTID_INT * btid_int
 					 &leaf_info, offset_after_key, search_key, &page_found, prev_page, node_type,
 					 offset_to_object);
 
-	      if (error_code == NO_ERROR && BTREE_IS_UNIQUE (btid_int->unique_pk))
+	      if (error_code == NO_ERROR)
 		{
 		  logtb_tran_update_unique_stats (thread_p, btid_int->sys_btid, n_keys, n_oids, 0, false);
 		}
@@ -35269,7 +35376,7 @@ btree_key_online_index_tran_delete (THREAD_ENTRY * thread_p, BTID_INT * btid_int
 
       n_oids = 1;
 
-      if (error_code == NO_ERROR && BTREE_IS_UNIQUE (btid_int->unique_pk))
+      if (error_code == NO_ERROR)
 	{
 	  logtb_tran_update_unique_stats (thread_p, btid_int->sys_btid, n_keys, n_oids, 0, false);
 	}
@@ -35473,7 +35580,7 @@ btree_key_online_index_tran_insert_DF (THREAD_ENTRY * thread_p, BTID_INT * btid_
 					 &leaf_info, offset_after_key, search_key, &page_found, prev_page, node_type,
 					 offset_to_object);
 
-	      if (error_code == NO_ERROR && BTREE_IS_UNIQUE (btid_int->unique_pk))
+	      if (error_code == NO_ERROR)
 		{
 		  logtb_tran_update_unique_stats (thread_p, btid_int->sys_btid, n_keys, n_oids, 0, false);
 		}
@@ -35547,7 +35654,7 @@ btree_key_online_index_tran_insert_DF (THREAD_ENTRY * thread_p, BTID_INT * btid_
 						offset_after_key, &leaf_info, &helper->insert_helper.obj_info,
 						&helper->insert_helper);
 
-	  if (error_code == NO_ERROR && BTREE_IS_UNIQUE (btid_int->unique_pk))
+	  if (error_code == NO_ERROR)
 	    {
 	      logtb_tran_update_unique_stats (thread_p, btid_int->sys_btid, 0, 1, 0, false);
 	    }
@@ -35561,7 +35668,7 @@ btree_key_online_index_tran_insert_DF (THREAD_ENTRY * thread_p, BTID_INT * btid_
       btree_online_index_set_delete_flag_state (helper->insert_helper.obj_info.mvcc_info.insert_mvccid);
 
       error_code = btree_key_insert_new_key (thread_p, btid_int, key, *leaf_page, &helper->insert_helper, search_key);
-      if (error_code == NO_ERROR && BTREE_IS_UNIQUE (btid_int->unique_pk))
+      if (error_code == NO_ERROR)
 	{
 	  logtb_tran_update_unique_stats (thread_p, btid_int->sys_btid, 1, 1, 0, false);
 	}

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -5102,12 +5102,10 @@ index_builder_loader_task::add_key (const DB_VALUE *key, const OID &oid)
 {
   if (DB_IS_NULL (key) || btree_multicol_key_is_null (const_cast<DB_VALUE *>(key)))
     {
-      /* We do not store NULL keys, but we track them for unique indexes;
-       * for non-unique, just skip row */
-      if (BTREE_IS_UNIQUE (m_unique_pk))
-        {
-          ++m_insert_list.m_ignored_nulls_cnt;
-        }
+      /* We do not store NULL keys in the b-tree, but we track the count so that
+       * num_oids = num_keys + num_nulls = total rows, enabling COUNT(*) optimisation
+       * on both unique and non-unique indexes. */
+      ++m_insert_list.m_ignored_nulls_cnt;
       return BATCH_CONTINUE;
     }
 

--- a/src/storage/btree_unique.cpp
+++ b/src/storage/btree_unique.cpp
@@ -111,7 +111,10 @@ btree_unique_stats::delete_row ()
 bool
 btree_unique_stats::is_zero () const
 {
-  return m_keys == 0 && m_nulls == 0;
+  /* For unique indexes m_rows == m_keys + m_nulls, so checking keys/nulls was sufficient.
+   * Non-unique indexes may have row-only deltas (delete_row) where m_keys and m_nulls stay zero
+   * while m_rows changes; include m_rows in the check to handle that case. */
+  return m_keys == 0 && m_nulls == 0 && m_rows == 0;
 }
 
 bool

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -4417,6 +4417,30 @@ logtb_create_unique_stats_from_repr (THREAD_ENTRY * thread_p, OID * class_oid)
 	      goto exit_on_error;
 	    }
 	}
+      else
+	{
+	  long long g_oid = -1, g_null = -1, g_key = -1;
+
+	  /* Non-unique indexes that track OID statistics (new format); legacy headers skip. */
+	  if (btree_get_unique_statistics (thread_p, &classrepr->indexes[idx].btid, &g_oid, &g_null, &g_key) !=
+	      NO_ERROR)
+	    {
+	      continue;
+	    }
+	  unique_stats = logtb_tran_find_btid_stats (thread_p, &classrepr->indexes[idx].btid, true);
+	  if (unique_stats == NULL)
+	    {
+	      error_code = ER_FAILED;
+	      goto exit_on_error;
+	    }
+	  error_code =
+	    logtb_get_global_unique_stats (thread_p, &unique_stats->btid, &unique_stats->global_stats.num_oids,
+					   &unique_stats->global_stats.num_nulls, &unique_stats->global_stats.num_keys);
+	  if (error_code != NO_ERROR)
+	    {
+	      goto exit_on_error;
+	    }
+	}
     }
 
   /* free class representation */


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-XXXX>

### Purpose

non-unique B-tree 헤더의 통계 정보를 이용해서 조건이 없는 count(*) 쿼리의 최적화

### Implementation

non-unique B-tree 헤더에 통계 정보를 추가

### Remarks

N/A
