### PR TITLE
[CBRD-26650] Use CLOCK_MONOTONIC in tsc_getticks for consistent elapsed time measurement

### DIFF
--- a/src/base/perf_def.hpp
+++ b/src/base/perf_def.hpp
@@ -36,9 +36,10 @@
 namespace cubperf
 {
   // clocking
-  using clock = std::chrono::high_resolution_clock;   // default clock
+  using clock = std::chrono::steady_clock;            // monotonic clock for elapsed time measurement
   using time_point = clock::time_point;               // default time point
   using duration = clock::duration;                   // default duration
+  static_assert (clock::is_steady, "cubperf::clock must be steady (monotonic)");
 
   // statistics value types
   template <bool IsAtomic>

--- a/src/base/tsc_timer.c
+++ b/src/base/tsc_timer.c
@@ -93,7 +93,7 @@ tsc_getticks (TSC_TICKS * tck)
 #else
       struct timespec ts;
       /* replace gettimeofday with clock_gettime for performance */
-      clock_gettime (CLOCK_REALTIME_COARSE, &ts);
+      clock_gettime (CLOCK_MONOTONIC, &ts);
       tck->tv.tv_sec = ts.tv_sec;
       tck->tv.tv_usec = ts.tv_nsec / 1000;
 #endif

--- a/src/broker/broker.c
+++ b/src/broker/broker.c
@@ -1183,6 +1183,10 @@ dispatch_thr_f (void *arg)
 	  struct timeval tv;
 	  int r;
 
+	  /* NOTE: timeout is CLOCK_REALTIME-based (gettimeofday + 30ms). pthread_cond_timedwait uses
+	   * CLOCK_REALTIME by default, so NTP adjustments may affect the actual wait duration.
+	   * To use CLOCK_MONOTONIC, pthread_condattr_setclock(CLOCK_MONOTONIC) + clock_gettime(CLOCK_MONOTONIC)
+	   * would be needed. */
 	  gettimeofday (&tv, NULL);
 	  ts.tv_sec = tv.tv_sec;
 	  ts.tv_nsec = (tv.tv_usec + 30000) * 1000;

--- a/src/communication/network_histogram.cpp
+++ b/src/communication/network_histogram.cpp
@@ -137,10 +137,13 @@ net_histo_ctx::add_request (int request, int data_sent)
   entry.request_count++;
   entry.total_size_sent += data_sent;
 
-  if (gettimeofday (&tp, NULL) == 0)
-    {
-      last_call_time = tp.tv_sec * 1000000LL + tp.tv_usec;
-    }
+  {
+    struct timespec ts;
+    if (clock_gettime (CLOCK_MONOTONIC, &ts) == 0)
+      {
+	last_call_time = ts.tv_sec * 1000000LL + ts.tv_nsec / 1000;
+      }
+  }
 
   call_cnt++;
 }
@@ -151,7 +154,7 @@ net_histo_ctx::add_request (int request, int data_sent)
 void
 net_histo_ctx::finish_request (int request, int data_received)
 {
-  struct timeval tp;
+  struct timespec ts;
   INT64 current_time;
 
   if (request <= NET_SERVER_REQUEST_START || request >= NET_SERVER_REQUEST_END)
@@ -162,9 +165,9 @@ net_histo_ctx::finish_request (int request, int data_received)
   net_histogram_entry &entry = histogram_entries[request];
   entry.total_size_received += data_received;
 
-  if (gettimeofday (&tp, NULL) == 0)
+  if (clock_gettime (CLOCK_MONOTONIC, &ts) == 0)
     {
-      current_time = tp.tv_sec * 1000000LL + tp.tv_usec;
+      current_time = ts.tv_sec * 1000000LL + ts.tv_nsec / 1000;
       total_server_time = current_time - last_call_time;
       entry.elapsed_time += total_server_time;
     }

--- a/src/connection/connection_pool.cpp
+++ b/src/connection/connection_pool.cpp
@@ -313,7 +313,7 @@ namespace cubconn::connection
 
   void pool::finalize_workers ()
   {
-    std::chrono::system_clock::time_point deadline, now;
+    std::chrono::steady_clock::time_point deadline, now;
     std::chrono::microseconds wait_for (0);
     struct timeval *timeout;
     bool compelete;
@@ -331,10 +331,10 @@ namespace cubconn::connection
 
     /* shutdown timeout */
     timeout = css_get_shutdown_timeout ();
-    deadline = std::chrono::system_clock::time_point (
-		       std::chrono::seconds (timeout->tv_sec) +
-		       std::chrono::microseconds (timeout->tv_usec));
-    now = std::chrono::system_clock::now ();
+    now = std::chrono::steady_clock::now ();
+    deadline = now +
+	       std::chrono::seconds (timeout->tv_sec) +
+	       std::chrono::microseconds (timeout->tv_usec);
     if (deadline > now)
       {
 	wait_for = std::chrono::duration_cast<std::chrono::microseconds> (deadline - now);
@@ -387,7 +387,7 @@ namespace cubconn::connection
 
   void pool::finalize_coordinator ()
   {
-    std::chrono::system_clock::time_point deadline, now;
+    std::chrono::steady_clock::time_point deadline, now;
     std::chrono::microseconds wait_for (0);
     coordinator::message request;
     struct timeval *timeout;
@@ -402,10 +402,10 @@ namespace cubconn::connection
 
     /* shutdown timeout */
     timeout = css_get_shutdown_timeout ();
-    deadline = std::chrono::system_clock::time_point (
-		       std::chrono::seconds (timeout->tv_sec) +
-		       std::chrono::microseconds (timeout->tv_usec));
-    now = std::chrono::system_clock::now ();
+    now = std::chrono::steady_clock::now ();
+    deadline = now +
+	       std::chrono::seconds (timeout->tv_sec) +
+	       std::chrono::microseconds (timeout->tv_usec);
     if (deadline > now)
       {
 	wait_for = std::chrono::duration_cast<std::chrono::microseconds> (deadline - now);

--- a/src/connection/connection_pool.cpp
+++ b/src/connection/connection_pool.cpp
@@ -341,6 +341,9 @@ namespace cubconn::connection
       }
 
     std::unique_lock<std::mutex> lock (m_watcher->mtx);
+    /* NOTE: GCC 8 libstdc++ condition_variable::wait_for internally uses CLOCK_REALTIME. The deadline
+     * calculation above uses steady_clock (correct), but the pthread-level wait may be affected by NTP
+     * adjustments. After upgrading to GCC 11+ (glibc 2.30+), CLOCK_MONOTONIC will be used automatically. */
     compelete = m_watcher->cv.wait_for (lock, wait_for, [this] { return m_watcher->active == 1; /* coordinator */ });
     lock.unlock ();
     if (!compelete)
@@ -412,6 +415,9 @@ namespace cubconn::connection
       }
 
     std::unique_lock<std::mutex> lock (m_watcher->mtx);
+    /* NOTE: GCC 8 libstdc++ condition_variable::wait_for internally uses CLOCK_REALTIME. The deadline
+     * calculation above uses steady_clock (correct), but the pthread-level wait may be affected by NTP
+     * adjustments. After upgrading to GCC 11+ (glibc 2.30+), CLOCK_MONOTONIC will be used automatically. */
     compelete = m_watcher->cv.wait_for (lock, wait_for, [this] { return m_watcher->active == 0; });
     lock.unlock ();
     if (!compelete)

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -2597,8 +2597,8 @@ css_return_queued_data_timeout (CSS_CONN_ENTRY * conn, unsigned short rid,
 		  int r;
 		  struct timespec abstime;
 
-		  abstime.tv_sec = (int) time (NULL) + waitsec;
-		  abstime.tv_nsec = 0;
+		  clock_gettime (CLOCK_MONOTONIC, &abstime);
+		  abstime.tv_sec += waitsec;
 
 		  r = thread_suspend_timeout_wakeup_and_unlock_entry (thrd, &abstime, THREAD_CSS_QUEUE_SUSPENDED);
 

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -2892,7 +2892,7 @@ css_start_all_threads (void)
     }
 
   // start if pooling is configured
-  using clock_type = std::chrono::system_clock;
+  using clock_type = std::chrono::steady_clock;
   clock_type::time_point start_time = clock_type::now ();
 
   bool start_workers = css_get_server_request_thread_pooling_configuration ();

--- a/src/executables/unloaddb.c
+++ b/src/executables/unloaddb.c
@@ -461,11 +461,11 @@ unloaddb (UTIL_FUNCTION_ARG * arg)
       unload_context.login_user = user;
       unload_context.output_prefix = output_prefix;
 
-      struct timeval startTime, endTime;
+      struct timespec startTime, endTime;
       double diffTime;
       if (sampling_records >= 0)
 	{
-	  gettimeofday (&startTime, NULL);
+	  clock_gettime (CLOCK_MONOTONIC, &startTime);
 	}
 
       if (extract_objects (unload_context, output_dirname, thread_count, sampling_records, enhanced_estimates))
@@ -475,18 +475,18 @@ unloaddb (UTIL_FUNCTION_ARG * arg)
 
       if (sampling_records >= 0)
 	{
-	  gettimeofday (&endTime, NULL);
-	  int elapsed_sec = 0, elapsed_usec = 0;
+	  clock_gettime (CLOCK_MONOTONIC, &endTime);
+	  int elapsed_sec = 0, elapsed_nsec = 0;
 
 	  elapsed_sec = endTime.tv_sec - startTime.tv_sec;
-	  elapsed_usec = endTime.tv_usec - startTime.tv_usec;
-	  if (endTime.tv_usec < startTime.tv_usec)
+	  elapsed_nsec = endTime.tv_nsec - startTime.tv_nsec;
+	  if (endTime.tv_nsec < startTime.tv_nsec)
 	    {
-	      elapsed_usec += 1000000;
+	      elapsed_nsec += 1000000000;
 	      elapsed_sec--;
 	    }
 
-	  fprintf (stdout, "Elapsed= %.6f sec\n", elapsed_sec + ((double) elapsed_usec / 1000000));
+	  fprintf (stdout, "Elapsed= %.6f sec\n", elapsed_sec + ((double) elapsed_nsec / 1000000000));
 	}
     }
   AU_RESTORE (au_save);

--- a/src/monitor/monitor_definition.hpp
+++ b/src/monitor/monitor_definition.hpp
@@ -33,9 +33,10 @@ namespace cubmonitor
   using statistic_value = std::uint64_t;
 
   // clocking
-  using clock_type = std::chrono::high_resolution_clock;
+  using clock_type = std::chrono::steady_clock;       // monotonic clock for elapsed time measurement
   using time_point = clock_type::time_point;
   using duration = clock_type::duration;
+  static_assert (clock_type::is_steady, "cubmonitor::clock_type must be steady (monotonic)");
 
   // fetching global & transaction sheet
   using fetch_mode = bool;

--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -8587,7 +8587,7 @@ qdata_benchmark (THREAD_ENTRY * thread_p, FUNCTION_TYPE * function_p, VAL_DESCR 
       return ER_OBJ_INVALID_ARGUMENTS;
     }
 
-  using bench_clock = std::chrono::system_clock;
+  using bench_clock = std::chrono::steady_clock;
   bench_clock::time_point start_timept = bench_clock::now ();
 
   for (INT64 step = 0; step < count; step++)

--- a/src/storage/double_write_buffer.cpp
+++ b/src/storage/double_write_buffer.cpp
@@ -1596,9 +1596,13 @@ dwb_wait_for_block_completion (THREAD_ENTRY *thread_p, unsigned int block_no)
 
   save_check_interrupt = logtb_set_check_interrupt (thread_p, false);
   /* Waits for maximum 20 milliseconds. */
-  gettimeofday (&timeval_crt, NULL);
-  timeval_add_msec (&timeval_timeout, &timeval_crt, 20);
-  timeval_to_timespec (&to, &timeval_timeout);
+  clock_gettime (CLOCK_MONOTONIC, &to);
+  to.tv_nsec += 20 * 1000000L;
+  if (to.tv_nsec >= 1000000000L)
+    {
+      to.tv_sec++;
+      to.tv_nsec -= 1000000000L;
+    }
 
   r = thread_suspend_timeout_wakeup_and_unlock_entry (thread_p, &to, THREAD_DWB_QUEUE_SUSPENDED);
 
@@ -1737,9 +1741,13 @@ dwb_wait_for_strucure_modification (THREAD_ENTRY *thread_p)
 
   save_check_interrupt = logtb_set_check_interrupt (thread_p, false);
   /* Waits for maximum 10 milliseconds. */
-  gettimeofday (&timeval_crt, NULL);
-  timeval_add_msec (&timeval_timeout, &timeval_crt, 10);
-  timeval_to_timespec (&to, &timeval_timeout);
+  clock_gettime (CLOCK_MONOTONIC, &to);
+  to.tv_nsec += 10 * 1000000L;
+  if (to.tv_nsec >= 1000000000L)
+    {
+      to.tv_sec++;
+      to.tv_nsec -= 1000000000L;
+    }
 
   r = thread_suspend_timeout_wakeup_and_unlock_entry (thread_p, &to, THREAD_DWB_QUEUE_SUSPENDED);
 

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -7040,8 +7040,8 @@ pgbuf_timed_sleep (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr)
     }
 
 try_again:
-  to.tv_sec = (int) time (NULL) + wait_secs;
-  to.tv_nsec = 0;
+  clock_gettime (CLOCK_MONOTONIC, &to);
+  to.tv_sec += wait_secs;
 
   if (thread_p->type == TT_WORKER)
     {
@@ -7976,8 +7976,8 @@ pgbuf_allocate_bcb (THREAD_ENTRY * thread_p, const VPID * src_vpid)
       high_priority = high_priority || VACUUM_IS_THREAD_VACUUM (thread_p) || pgbuf_is_thread_high_priority (thread_p);
 
       /* add to waiters thread list to be assigned victim directly */
-      to.tv_sec = (int) time (NULL) + pgbuf_latch_timeout;
-      to.tv_nsec = 0;
+      clock_gettime (CLOCK_MONOTONIC, &to);
+      to.tv_sec += pgbuf_latch_timeout;
 
       thread_lock_entry (thread_p);
 

--- a/src/thread/critical_section.c
+++ b/src/thread/critical_section.c
@@ -167,7 +167,13 @@ csect_initialize_critical_section (SYNC_CRITICAL_SECTION * csect, const char *na
       return ER_CSS_PTHREAD_MUTEX_INIT;
     }
 
-  error_code = pthread_cond_init (&csect->readers_ok, NULL);
+  {
+    pthread_condattr_t cond_attr;
+    pthread_condattr_init (&cond_attr);
+    pthread_condattr_setclock (&cond_attr, CLOCK_MONOTONIC);
+    error_code = pthread_cond_init (&csect->readers_ok, &cond_attr);
+    pthread_condattr_destroy (&cond_attr);
+  }
   if (error_code != NO_ERROR)
     {
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_COND_INIT, 0);
@@ -781,8 +787,8 @@ csect_enter_critical_section_as_reader (THREAD_ENTRY * thread_p, SYNC_CRITICAL_S
 	  else if (wait_secs > 0)
 	    {
 	      struct timespec to;
-	      to.tv_sec = time (NULL) + wait_secs;
-	      to.tv_nsec = 0;
+	      clock_gettime (CLOCK_MONOTONIC, &to);
+	      to.tv_sec += wait_secs;
 
 	      csect->waiting_readers++;
 	      thread_p->resume_status = THREAD_CSECT_READER_SUSPENDED;
@@ -1024,8 +1030,8 @@ csect_demote_critical_section (THREAD_ENTRY * thread_p, SYNC_CRITICAL_SECTION * 
 	  else if (wait_secs > 0)
 	    {
 	      struct timespec to;
-	      to.tv_sec = time (NULL) + wait_secs;
-	      to.tv_nsec = 0;
+	      clock_gettime (CLOCK_MONOTONIC, &to);
+	      to.tv_sec += wait_secs;
 
 	      csect->waiting_readers++;
 	      thread_p->resume_status = THREAD_CSECT_READER_SUSPENDED;

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -163,11 +163,16 @@ namespace cubthread
 	// cannot recover from this
 	assert (false);
       }
-    if (pthread_cond_init (&wakeup_cond, NULL) != 0)
-      {
-	// cannot recover from this
-	assert (false);
-      }
+    {
+      pthread_condattr_t attr;
+      pthread_condattr_init (&attr);
+      pthread_condattr_setclock (&attr, CLOCK_MONOTONIC);
+      if (pthread_cond_init (&wakeup_cond, &attr) != 0)
+	{
+	  assert (false);
+	}
+      pthread_condattr_destroy (&attr);
+    }
     if (pthread_mutex_init (&m_px_lock_mutex, NULL) != 0)
       {
 	// cannot recover from this
@@ -563,6 +568,9 @@ thread_suspend_timeout_wakeup_and_unlock_entry (cubthread::entry *thread_p, stru
       start_time_pt = thread_clock_type::now ();
     }
 
+  /* NOTE: wakeup_cond is initialized with CLOCK_MONOTONIC (see entry::entry constructor).
+   * Callers must construct time_p using clock_gettime(CLOCK_MONOTONIC).
+   * thread_clock_type (steady_clock) above is used solely for elapsed-time statistics (latch_waits). */
   r = pthread_cond_timedwait (&thread_p->wakeup_cond, &thread_p->th_entry_lock, time_p);
 
   if (thread_p->event_stats.trace_slow_query == true && suspended_reason == THREAD_PGBUF_SUSPENDED)
@@ -708,6 +716,7 @@ thread_suspend_with_other_mutex (cubthread::entry *thread_p, pthread_mutex_t *mu
     }
   else
     {
+      /* NOTE: wakeup_cond uses CLOCK_MONOTONIC. Callers must construct 'to' via clock_gettime(CLOCK_MONOTONIC). */
       r = pthread_cond_timedwait (&thread_p->wakeup_cond, mutex_p, to);
     }
 

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -463,7 +463,7 @@ namespace cubthread
 // legacy C functions
 //////////////////////////////////////////////////////////////////////////
 
-using thread_clock_type = std::chrono::system_clock;
+using thread_clock_type = std::chrono::steady_clock;
 
 static void thread_wakeup_internal (cubthread::entry *thread_p, thread_resume_suspend_status resume_reason,
 				    bool had_mutex);

--- a/src/thread/thread_looper.cpp
+++ b/src/thread/thread_looper.cpp
@@ -149,6 +149,10 @@ namespace cubthread
 	    wait_time = period - execution_time;
 	  }
 
+	/* NOTE: waiter::wait_for uses condition_variable::wait_for internally. In GCC 8, this converts to
+	 * CLOCK_REALTIME-based absolute time at the pthread level, so NTP adjustments may affect the actual
+	 * wait duration. After upgrading to GCC 11+ (glibc 2.30+), CLOCK_MONOTONIC will be used
+	 * automatically via pthread_cond_clockwait(). */
 	m_was_woken_up = waiter_arg.wait_for (wait_time);
       }
     else

--- a/src/thread/thread_looper.cpp
+++ b/src/thread/thread_looper.cpp
@@ -138,9 +138,9 @@ namespace cubthread
 	delta_time wait_time = delta_time (0);
 	delta_time execution_time = delta_time (0);
 
-	if (m_start_execution_time != std::chrono::system_clock::time_point ())
+	if (m_start_execution_time != std::chrono::steady_clock::time_point ())
 	  {
-	    execution_time = std::chrono::system_clock::now () - m_start_execution_time;
+	    execution_time = std::chrono::steady_clock::now () - m_start_execution_time;
 	  }
 
 	// compute task execution time
@@ -158,7 +158,7 @@ namespace cubthread
       }
 
     // register start of the task execution time
-    m_start_execution_time = std::chrono::system_clock::now ();
+    m_start_execution_time = std::chrono::steady_clock::now ();
     Looper_statistics.time_and_increment (m_stats, STAT_LOOPER_SLEEP_COUNT_AND_TIME);
   }
 

--- a/src/thread/thread_looper.hpp
+++ b/src/thread/thread_looper.hpp
@@ -37,7 +37,7 @@
 namespace cubthread
 {
   // definitions
-  typedef std::chrono::system_clock::duration delta_time;
+  typedef std::chrono::steady_clock::duration delta_time;
   typedef std::function<void (bool &, delta_time &)> period_function;
 
   // for increasing period pattern
@@ -152,7 +152,7 @@ namespace cubthread
 
       // a time point that represents the start of task execution
       // used by put_to_sleep function in order to sleep for difference between period interval and task execution time
-      std::chrono::system_clock::time_point m_start_execution_time;
+      std::chrono::steady_clock::time_point m_start_execution_time;
 
       // statistics
       cubperf::statset &m_stats;

--- a/src/thread/thread_waiter.cpp
+++ b/src/thread/thread_waiter.cpp
@@ -198,7 +198,7 @@ namespace cubthread
   }
 
   bool
-  waiter::wait_for (const std::chrono::system_clock::duration &delta)
+  waiter::wait_for (const std::chrono::steady_clock::duration &delta)
   {
     if (delta == std::chrono::microseconds (0))
       {
@@ -224,7 +224,7 @@ namespace cubthread
   }
 
   bool
-  waiter::wait_until (const std::chrono::system_clock::time_point &timeout_time)
+  waiter::wait_until (const std::chrono::steady_clock::time_point &timeout_time)
   {
     std::unique_lock<std::mutex> lock (m_mutex);    // mutex is also locked
     goto_sleep ();

--- a/src/thread/thread_waiter.cpp
+++ b/src/thread/thread_waiter.cpp
@@ -211,6 +211,12 @@ namespace cubthread
     std::unique_lock<std::mutex> lock (m_mutex);    // mutex is also locked
     goto_sleep ();
 
+    /* NOTE: GCC 8 libstdc++ condition_variable internally uses CLOCK_REALTIME (system_clock) for all wait
+     * operations, regardless of the clock type used for the delta parameter. This means the pthread-level wait
+     * is still subject to NTP time adjustments (wall clock jumps).
+     * The steady_clock-based delta parameter ensures correct elapsed-time calculation in our code.
+     * After upgrading to GCC 11+ (glibc 2.30+), condition_variable will automatically use CLOCK_MONOTONIC
+     * for wait operations via pthread_cond_clockwait(), fully eliminating NTP influence. */
     ret = m_condvar.wait_for (lock, delta, [this] { return m_status == AWAKENING; });
     if (!ret)
       {
@@ -229,6 +235,9 @@ namespace cubthread
     std::unique_lock<std::mutex> lock (m_mutex);    // mutex is also locked
     goto_sleep ();
 
+    /* NOTE: GCC 8 libstdc++ condition_variable internally uses CLOCK_REALTIME for wait_until,
+     * regardless of the time_point clock type. The pthread-level wait is still subject to NTP adjustments.
+     * After upgrading to GCC 11+ (glibc 2.30+), this will automatically use CLOCK_MONOTONIC. */
     bool ret = m_condvar.wait_until (lock, timeout_time, [this] { return m_status == AWAKENING; });
     if (!ret)
       {

--- a/src/thread/thread_waiter.hpp
+++ b/src/thread/thread_waiter.hpp
@@ -62,9 +62,9 @@ namespace cubthread
       void wakeup (void);                                             // wakeup waiter thread
 
       void wait_inf (void);                                           // wait until wakeup
-      bool wait_for (const std::chrono::system_clock::duration &delta);   // wait for period of time or until wakeup
+      bool wait_for (const std::chrono::steady_clock::duration &delta);   // wait for period of time or until wakeup
       // returns true if woke up before timeout
-      bool wait_until (const std::chrono::system_clock::time_point &timeout_time);  // wait until time or until wakeup
+      bool wait_until (const std::chrono::steady_clock::time_point &timeout_time);  // wait until time or until wakeup
       // returns true if woke up before timeout
 
       // statistics

--- a/src/thread/thread_waiter.hpp
+++ b/src/thread/thread_waiter.hpp
@@ -155,6 +155,8 @@ namespace cubthread
       }
     else
       {
+	/* NOTE: GCC 8 libstdc++ condition_variable::wait_for internally converts to CLOCK_REALTIME-based
+	 * absolute time. The pthread-level wait is subject to NTP adjustments until GCC 11+ (glibc 2.30+). */
 	(void) condvar.wait_for (lock, duration.m_duration);
       }
   }
@@ -171,6 +173,8 @@ namespace cubthread
       }
     else
       {
+	/* NOTE: GCC 8 libstdc++ condition_variable::wait_for internally converts to CLOCK_REALTIME-based
+	 * absolute time. The pthread-level wait is subject to NTP adjustments until GCC 11+ (glibc 2.30+). */
 	return condvar.wait_for (lock, duration.m_duration, pred);
       }
   }

--- a/src/thread/thread_worker_pool.cpp
+++ b/src/thread/thread_worker_pool.cpp
@@ -154,7 +154,7 @@ namespace cubthread
     const std::chrono::milliseconds time_spin_sleep (10);       // sleep between spins for 10 milliseconds
 #endif
 
-    auto timeout = std::chrono::system_clock::now () + time_wait_to_thread_stop;
+    auto timeout = std::chrono::steady_clock::now () + time_wait_to_thread_stop;
 
     bool is_not_stopped;
     while (true)
@@ -173,7 +173,7 @@ namespace cubthread
 	    break;
 	  }
 
-	if (std::chrono::system_clock::now () > timeout)
+	if (std::chrono::steady_clock::now () > timeout)
 	  {
 	    // timed out
 	    assert (false);

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -371,7 +371,7 @@ struct lk_global_data
 
   /* deadlock detection related fields */
   pthread_mutex_t DL_detection_mutex;
-  struct timeval last_deadlock_run;	/* last deadlock detection time */
+  struct timespec last_deadlock_run;	/* last deadlock detection time */
   LK_WFG_NODE *TWFG_node;	/* transaction WFG node */
   LK_WFG_EDGE *TWFG_edge;	/* transaction WFG edge */
   int max_TWFG_edge;
@@ -1180,7 +1180,7 @@ lock_initialize_deadlock_detection (void)
   int i;
 
   pthread_mutex_init (&lk_Gl.DL_detection_mutex, NULL);
-  gettimeofday (&lk_Gl.last_deadlock_run, NULL);
+  clock_gettime (CLOCK_MONOTONIC, &lk_Gl.last_deadlock_run);
 
   /* allocate transaction WFG node table */
   lk_Gl.TWFG_node = (LK_WFG_NODE *) malloc (SIZEOF_LK_WFG_NODE * lk_Gl.num_trans);
@@ -2149,7 +2149,7 @@ static LOCK_WAIT_STATE
 lock_suspend (THREAD_ENTRY * thread_p, LK_ENTRY * entry_ptr, int wait_msecs)
 {
   THREAD_ENTRY *p;
-  struct timeval tv;
+  struct timespec ts;
   int client_id;
   LOG_TDES *tdes;
 
@@ -2177,8 +2177,8 @@ lock_suspend (THREAD_ENTRY * thread_p, LK_ENTRY * entry_ptr, int wait_msecs)
 
   /* register lock wait info. into the thread entry */
   entry_ptr->thrd_entry->lockwait = (void *) entry_ptr;
-  gettimeofday (&tv, NULL);
-  entry_ptr->thrd_entry->lockwait_stime = (tv.tv_sec * 1000000LL + tv.tv_usec) / 1000LL;
+  clock_gettime (CLOCK_MONOTONIC, &ts);
+  entry_ptr->thrd_entry->lockwait_stime = ts.tv_sec * 1000LL + ts.tv_nsec / 1000000LL;
   entry_ptr->thrd_entry->lockwait_msecs = wait_msecs;
   entry_ptr->thrd_entry->lockwait_state = (int) LOCK_SUSPENDED;
 
@@ -7459,11 +7459,11 @@ lock_force_timeout_expired_wait_transactions (void *thrd_entry)
 	}
       else if (LK_CAN_TIMEOUT (thrd->lockwait_msecs))
 	{
-	  struct timeval tv;
+	  struct timespec ts;
 	  INT64 etime;
 
-	  (void) gettimeofday (&tv, NULL);
-	  etime = (tv.tv_sec * 1000000LL + tv.tv_usec) / 1000LL;
+	  (void) clock_gettime (CLOCK_MONOTONIC, &ts);
+	  etime = ts.tv_sec * 1000LL + ts.tv_nsec / 1000000LL;
 	  if (etime - thrd->lockwait_stime > thrd->lockwait_msecs)
 	    {
 	      /* wake up the thread */
@@ -7618,13 +7618,13 @@ static bool
 lock_is_local_deadlock_detection_interval_up (void)
 {
 #if defined (SERVER_MODE)
-  struct timeval now, elapsed;
+  struct timespec now;
   double elapsed_sec;
 
   /* check deadlock detection interval */
-  gettimeofday (&now, NULL);
-  perfmon_diff_timeval (&elapsed, &lk_Gl.last_deadlock_run, &now);
-  elapsed_sec = elapsed.tv_sec + (elapsed.tv_usec / 1000000.0);
+  clock_gettime (CLOCK_MONOTONIC, &now);
+  elapsed_sec = (double) (now.tv_sec - lk_Gl.last_deadlock_run.tv_sec)
+		+ (double) (now.tv_nsec - lk_Gl.last_deadlock_run.tv_nsec) / 1000000000.0;
 
   if (elapsed_sec < prm_get_float_value (PRM_ID_LK_RUN_DEADLOCK_INTERVAL))
     {

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -535,7 +535,7 @@ static int la_change_state (void);
 static int la_log_commit (bool update_commit_time);
 static unsigned long la_get_mem_size (void);
 static int la_check_mem_size (void);
-static int la_check_time_commit (struct timeval *time, unsigned int threshold);
+static int la_check_time_commit (struct timespec *time, unsigned int threshold);
 
 static void la_init (const char *log_path, const int max_mem_size);
 
@@ -6704,10 +6704,10 @@ la_commit_transaction (void)
 }
 
 static int
-la_check_time_commit (struct timeval *time_commit, unsigned int threshold)
+la_check_time_commit (struct timespec *time_commit, unsigned int threshold)
 {
   int error = NO_ERROR;
-  struct timeval curtime;
+  struct timespec curtime;
   int diff_msec;
   bool need_commit = false;
 
@@ -6716,8 +6716,8 @@ la_check_time_commit (struct timeval *time_commit, unsigned int threshold)
   assert (time_commit);
 
   /* check interval time for commit */
-  gettimeofday (&curtime, NULL);
-  diff_msec = (curtime.tv_sec - time_commit->tv_sec) * 1000 + (curtime.tv_usec / 1000 - time_commit->tv_usec / 1000);
+  clock_gettime (CLOCK_MONOTONIC, &curtime);
+  diff_msec = (curtime.tv_sec - time_commit->tv_sec) * 1000 + (curtime.tv_nsec / 1000000 - time_commit->tv_nsec / 1000000);
   if (diff_msec < 0)
     {
       diff_msec = 0;
@@ -6725,7 +6725,7 @@ la_check_time_commit (struct timeval *time_commit, unsigned int threshold)
 
   if (threshold < (unsigned int) diff_msec)
     {
-      gettimeofday (time_commit, NULL);
+      clock_gettime (CLOCK_MONOTONIC, time_commit);
 
       /* check server is connected now */
       error = db_ping_server (0, NULL);
@@ -8081,7 +8081,7 @@ la_apply_log_file (const char *database_name, const char *log_path, const int ma
     -1, -1
   };
   LOG_LSA prev_final;
-  struct timeval time_commit;
+  struct timespec time_commit;
   int last_nxarv_num = 0;
   bool clear_owner;
   int now = 0, last_eof_time = 0;
@@ -8212,7 +8212,7 @@ la_apply_log_file (const char *database_name, const char *log_path, const int ma
   /* initialize final_lsa */
   LSA_COPY (&la_Info.committed_lsa, &la_Info.required_lsa);
 
-  gettimeofday (&time_commit, NULL);
+  clock_gettime (CLOCK_MONOTONIC, &time_commit);
   last_eof_time = time (NULL);
   LSA_SET_NULL (&last_eof_lsa);
 #ifdef UNSTABLE_TDE_FOR_REPLICATION_LOG

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -10182,7 +10182,7 @@ log_checkpoint_execute (cubthread::entry & thread_ref)
 class log_remove_log_archive_daemon_task : public cubthread::entry_task
 {
   private:
-    using clock = std::chrono::system_clock;
+    using clock = std::chrono::steady_clock;
 
     bool m_is_timed_wait;
     cubthread::delta_time m_period;
@@ -10280,10 +10280,10 @@ log_clock_execute (cubthread::entry & thread_ref)
       return;
     }
 
-  struct timeval now;
-  gettimeofday (&now, NULL);
+  struct timespec now;
+  clock_gettime (CLOCK_MONOTONIC, &now);
 
-  log_Clock_msec = (now.tv_sec * 1000LL) + (now.tv_usec / 1000LL);
+  log_Clock_msec = (now.tv_sec * 1000LL) + (now.tv_nsec / 1000000LL);
 }
 #endif /* SERVER_MODE */
 
@@ -10534,10 +10534,10 @@ log_get_clock_msec (void)
     }
 #endif /* SERVER_MODE */
 
-  struct timeval now;
-  gettimeofday (&now, NULL);
+  struct timespec now;
+  clock_gettime (CLOCK_MONOTONIC, &now);
 
-  return (now.tv_sec * 1000LL) + (now.tv_usec / 1000LL);
+  return (now.tv_sec * 1000LL) + (now.tv_nsec / 1000000LL);
 }
 
 // *INDENT-OFF*

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -631,7 +631,13 @@ logpb_initialize_pool (THREAD_ENTRY * thread_p)
   logpb_Initialized = true;
   pthread_mutex_init (&log_Gl.chkpt_lsa_lock, NULL);
 
-  pthread_cond_init (&group_commit_info->gc_cond, NULL);
+  {
+    pthread_condattr_t cond_attr;
+    pthread_condattr_init (&cond_attr);
+    pthread_condattr_setclock (&cond_attr, CLOCK_MONOTONIC);
+    pthread_cond_init (&group_commit_info->gc_cond, &cond_attr);
+    pthread_condattr_destroy (&cond_attr);
+  }
   pthread_mutex_init (&group_commit_info->gc_mutex, NULL);
 
   pthread_mutex_init (&writer_info->wr_list_mutex, NULL);
@@ -4062,9 +4068,10 @@ logpb_flush_pages (THREAD_ENTRY * thread_p, LOG_LSA * flush_lsa)
 
       while (LSA_LT (&nxio_lsa, flush_lsa))
 	{
-	  gettimeofday (&start_time, NULL);
-	  (void) timeval_add_msec (&tmp_timeval, &start_time, max_wait_time_in_msec);
-	  (void) timeval_to_timespec (&to, &tmp_timeval);
+	  clock_gettime (CLOCK_MONOTONIC, &to);
+	  to.tv_nsec += max_wait_time_in_msec * 1000000L;
+	  to.tv_sec += to.tv_nsec / 1000000000L;
+	  to.tv_nsec = to.tv_nsec % 1000000000L;
 
 	  rv = pthread_mutex_lock (&group_commit_info->gc_mutex);
 	  nxio_lsa = log_Gl.append.get_nxio_lsa ();

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -3258,7 +3258,7 @@ log_recovery_redo (THREAD_ENTRY * thread_p, const LOG_LSA * start_redolsa, const
   assert (end_redo_lsa != nullptr && !end_redo_lsa->is_null ());
 
   // *INDENT-OFF*
-  const auto time_start_setting_up = std::chrono::system_clock::now ();
+  const auto time_start_setting_up = std::chrono::steady_clock::now ();
   // *INDENT-ON*
 
   /* depending on compilation mode and on a system parameter, initialize the
@@ -3282,7 +3282,7 @@ log_recovery_redo (THREAD_ENTRY * thread_p, const LOG_LSA * start_redolsa, const
 #endif
 
   // *INDENT-OFF*
-  const auto time_start_main = std::chrono::system_clock::now ();
+  const auto time_start_main = std::chrono::steady_clock::now ();
   /* 'setting_up' measures the time taken to initialize parallel log recovery redo infrstructure */
   const auto duration_setting_up_ms
       = std::chrono::duration_cast <std::chrono::milliseconds>(time_start_main - time_start_setting_up);
@@ -3880,7 +3880,7 @@ log_recovery_redo (THREAD_ENTRY * thread_p, const LOG_LSA * start_redolsa, const
     // *INDENT-OFF*
     /* 'main' measures the time taken by the main thread to execute sync log records and dispatch async ones */
     const auto duration_main_ms = std::chrono::duration_cast <std::chrono::milliseconds> (
-          std::chrono::system_clock::now () - time_start_main);
+          std::chrono::steady_clock::now () - time_start_main);
     if (parallel_recovery_redo != nullptr)
       {
 	parallel_recovery_redo->wait_for_termination_and_stop_execution ();
@@ -3889,7 +3889,7 @@ log_recovery_redo (THREAD_ENTRY * thread_p, const LOG_LSA * start_redolsa, const
     /* 'async' measures the time taken by the main thread to execute sync log records, dispatch async ones
      * and wait for the async infrastructure to finish */
     const auto duration_async_ms = std::chrono::duration_cast <std::chrono::milliseconds> (
-          std::chrono::system_clock::now () - time_start_main);
+          std::chrono::steady_clock::now () - time_start_main);
     _er_log_debug (ARG_FILE_LINE,
 		   "log_recovery_redo_perf:  parallel_count=%2d  reusable_jobs_count=%6d  flush_back_count=%4d\n"
 		   "log_recovery_redo_perf:  setting_up=%6lld  main=%6lld  async=%6lld (ms)\n",

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -2891,8 +2891,11 @@ logtb_is_interrupted_tdes (THREAD_ENTRY * thread_p, LOG_TDES * tdes, bool clear,
 #if defined(SERVER_MODE)
       now = log_get_clock_msec ();
 #else /* SERVER_MODE */
-      gettimeofday (&tv, NULL);
-      now = (tv.tv_sec * 1000LL) + (tv.tv_usec / 1000LL);
+      {
+	struct timespec ts;
+	clock_gettime (CLOCK_MONOTONIC, &ts);
+	now = (ts.tv_sec * 1000LL) + (ts.tv_nsec / 1000000LL);
+      }
 #endif /* !SERVER_MODE */
       if (tdes->query_timeout < now)
 	{

--- a/src/transaction/log_writer.c
+++ b/src/transaction/log_writer.c
@@ -512,7 +512,7 @@ logwr_initialize (const char *db_name, const char *log_path, int mode, LOG_PAGEI
 
   logwr_Gl.force_flush = false;
   logwr_Gl.last_flush_time.tv_sec = 0;
-  logwr_Gl.last_flush_time.tv_usec = 0;
+  logwr_Gl.last_flush_time.tv_nsec = 0;
 
   logwr_Gl.ori_nxarv_pageid = NULL_PAGEID;
 
@@ -612,7 +612,7 @@ logwr_finalize (void)
 
   logwr_Gl.force_flush = false;
   logwr_Gl.last_flush_time.tv_sec = 0;
-  logwr_Gl.last_flush_time.tv_usec = 0;
+  logwr_Gl.last_flush_time.tv_nsec = 0;
 
   logwr_Gl.ori_nxarv_pageid = NULL_PAGEID;
   logwr_Gl.start_pageid = -2;
@@ -1512,7 +1512,7 @@ int
 logwr_write_log_pages (void)
 {
   int error;
-  struct timeval curtime;
+  struct timespec curtime;
   int diff_msec;
 
   if (logwr_Gl.num_toflush <= 0)
@@ -1520,10 +1520,10 @@ logwr_write_log_pages (void)
 
   if (logwr_Gl.mode == LOGWR_MODE_SEMISYNC)
     {
-      gettimeofday (&curtime, NULL);
+      clock_gettime (CLOCK_MONOTONIC, &curtime);
       diff_msec =
 	(((curtime.tv_sec - logwr_Gl.last_flush_time.tv_sec) * 1000) +
-	 ((curtime.tv_usec - logwr_Gl.last_flush_time.tv_usec) / 1000));
+	 ((curtime.tv_nsec - logwr_Gl.last_flush_time.tv_nsec) / 1000000));
 
       if (logwr_Gl.force_flush == false && !LOGWR_AT_SERVER_ARCHIVING ()
 	  && (logwr_Gl.hdr.eof_lsa.pageid <= logwr_Gl.toflush[0]->hdr.logical_pageid) && (diff_msec < 1000))
@@ -1569,7 +1569,7 @@ logwr_write_log_pages (void)
 
   logwr_flush_header_page ();
 
-  gettimeofday (&logwr_Gl.last_flush_time, NULL);
+  clock_gettime (CLOCK_MONOTONIC, &logwr_Gl.last_flush_time);
 
   return NO_ERROR;
 }

--- a/src/transaction/log_writer.h
+++ b/src/transaction/log_writer.h
@@ -96,7 +96,7 @@ struct logwr_global
   int last_arv_num;
 
   bool force_flush;
-  struct timeval last_flush_time;
+  struct timespec last_flush_time;
   /* background log archiving info */
   BACKGROUND_ARCHIVING_INFO bg_archive_info;
   char bg_archive_name[PATH_MAX];


### PR DESCRIPTION
 http://jira.cubrid.org/browse/CBRD-26650

### Purpose

경과 시간(elapsed time)을 측정하는 코드가 non-monotonic clock(`CLOCK_REALTIME_COARSE`, `system_clock`, `high_resolution_clock`)을 사용하고 있어, NTP 동기화·수동 시계 변경·VM 마이그레이션 등 외부 요인으로 시간이 앞/뒤로 점프하면 경과 시간이 음수이거나 비정상적으로 큰 값이 될 수 있는 문제를 해결합니다.

### Implementation

경과 시간 측정에 사용되는 clock을 monotonic clock으로 통일합니다.

- **Tier 0 — tsc_timer (1파일, 1곳)**
  - `src/base/tsc_timer.c:96` — `CLOCK_REALTIME_COARSE` → `CLOCK_MONOTONIC`

- **Tier 1 — 성능 통계 clock 정의 (2파일, 2곳)**
  - `src/base/perf_def.hpp:39` — `high_resolution_clock` → `steady_clock`
  - `src/monitor/monitor_definition.hpp:36` — `high_resolution_clock` → `steady_clock`
  - `static_assert`로 `is_steady == true` 보장 추가

- **Tier 2 — 스레드 인프라 및 커넥션 풀 (6파일, 18곳)**
  - `thread_waiter.hpp/cpp` — `system_clock` → `steady_clock`
  - `thread_looper.hpp/cpp` — `system_clock` → `steady_clock`
  - `thread_entry.cpp` — typedef 변경으로 7곳 자동 적용
  - `thread_worker_pool.cpp` — `system_clock` → `steady_clock`
  - `connection_pool.cpp` — `system_clock` → `steady_clock`

### Remarks

- Broker/CAS의 `gettimeofday` (14+ 파일, 50+ 곳)는 자료형 전환 등 추가 작업이 필요하여 별도 이슈로 분리합니다.
- GCC 8의 `std::condition_variable`은 내부적으로 `system_clock`(`CLOCK_REALTIME`)을 사용하므로, `wait_for`/`wait_until`의 pthread 레벨 대기는 변경 후에도 NTP 영향을 받을 수 있습니다. 향후 GCC 11+ / glibc 2.30+ 전환 시 자동으로 monotonic 대기가 활성화됩니다. (`gcc --version`, `ldd --version`)
- `steady_clock::duration`과 `system_clock::duration`은 동일 타입(`nanoseconds`)이므로 API/ABI 호환성이 유지됩니다.
