### PR TITLE
[CBRD-26671] Incorrect OOS Detection and Core Dump Caused by Missing LAST_ELEMENT in the VOT

### DIFF
--- a/src/base/object_representation.h
+++ b/src/base/object_representation.h
@@ -400,6 +400,9 @@ OR_PUT_DOUBLE (char *ptr, double val)
 #define OR_PUT_OFFSET(ptr, val) \
   OR_PUT_BIG_VAR_OFFSET ((ptr), (val))
 
+#define OR_PUT_LAST_VAR_OFFSET(ptr, val) \
+  OR_PUT_OFFSET ((ptr), OR_SET_VAR_LAST_ELEMENT (val))
+
 #define OR_GET_OFFSET(ptr) \
   OR_GET_BIG_VAR_OFFSET ((ptr))
 
@@ -447,6 +450,22 @@ OR_PUT_DOUBLE (char *ptr, double val)
 
 #define OR_IS_OOS(length) (OR_GET_VAR_FLAG (length) & OR_VAR_BIT_OOS)
 #define OR_IS_LAST_ELEMENT(length) (OR_GET_VAR_FLAG (length) & OR_VAR_BIT_LAST_ELEMENT)
+
+STATIC_INLINE int
+or_var_offset_apply_flags (int offset, bool is_oos, bool is_last_element)
+{
+  if (is_oos)
+    {
+      offset = OR_SET_VAR_OOS (offset);
+    }
+
+  if (is_last_element)
+    {
+      offset = OR_SET_VAR_LAST_ELEMENT (offset);
+    }
+
+  return offset;
+}
 
 /* OOS inline size: OOS OID (8 bytes) + OOS length (8 bytes) */
 #define OR_OOS_INLINE_SIZE (OR_OID_SIZE + OR_BIGINT_SIZE)
@@ -2552,6 +2571,12 @@ STATIC_INLINE int
 or_put_offset (OR_BUF * buf, int num)
 {
   return or_put_big_var_offset (buf, num);
+}
+
+STATIC_INLINE int
+or_put_last_var_offset (OR_BUF * buf, int num)
+{
+  return or_put_offset (buf, OR_SET_VAR_LAST_ELEMENT (num));
 }
 
 STATIC_INLINE int

--- a/src/base/object_representation.h
+++ b/src/base/object_representation.h
@@ -451,22 +451,6 @@ OR_PUT_DOUBLE (char *ptr, double val)
 #define OR_IS_OOS(length) (OR_GET_VAR_FLAG (length) & OR_VAR_BIT_OOS)
 #define OR_IS_LAST_ELEMENT(length) (OR_GET_VAR_FLAG (length) & OR_VAR_BIT_LAST_ELEMENT)
 
-STATIC_INLINE int
-or_var_offset_apply_flags (int offset, bool is_oos, bool is_last_element)
-{
-  if (is_oos)
-    {
-      offset = OR_SET_VAR_OOS (offset);
-    }
-
-  if (is_last_element)
-    {
-      offset = OR_SET_VAR_LAST_ELEMENT (offset);
-    }
-
-  return offset;
-}
-
 /* OOS inline size: OOS OID (8 bytes) + OOS length (8 bytes) */
 #define OR_OOS_INLINE_SIZE (OR_OID_SIZE + OR_BIGINT_SIZE)
 

--- a/src/loaddb/load_object.c
+++ b/src/loaddb/load_object.c
@@ -342,7 +342,7 @@ put_varinfo (OR_BUF * buf, DESC_OBJ * obj, int offset_size)
 	  or_put_offset_internal (buf, offset, offset_size);
 	  offset += len;
 	}
-      or_put_offset_internal (buf, offset, offset_size);
+      or_put_offset_internal (buf, OR_SET_VAR_LAST_ELEMENT (offset), offset_size);
       buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
     }
 }

--- a/src/object/transform_cl.c
+++ b/src/object/transform_cl.c
@@ -131,6 +131,7 @@ static void tf_free_fixup (OR_FIXUP * fix);
 static void fixup_callback (LC_OIDMAP * oidmap);
 static int tf_do_fixup (OR_FIXUP * fix);
 static int put_varinfo (OR_BUF * buf, char *obj, SM_CLASS * class_, int offset_size);
+static void tf_put_last_var_offset (OR_BUF * buf, int offset);
 static int object_size (SM_CLASS * class_, MOBJ obj, int *offset_size_ptr);
 static int put_attributes (OR_BUF * buf, char *obj, SM_CLASS * class_);
 static char *get_current (OR_BUF * buf, SM_CLASS * class_, MOBJ * obj_ptr, int bound_bit_flag, int offset_size);
@@ -640,10 +641,16 @@ put_varinfo (OR_BUF * buf, char *obj, SM_CLASS * class_, int offset_size)
 	  offset += len;
 	}
 
-      or_put_offset_internal (buf, offset, offset_size);
+      or_put_offset_internal (buf, OR_SET_VAR_LAST_ELEMENT (offset), offset_size);
       buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
     }
   return rc;
+}
+
+static void
+tf_put_last_var_offset (OR_BUF * buf, int offset)
+{
+  or_put_offset (buf, OR_SET_VAR_LAST_ELEMENT (offset));
 }
 
 
@@ -2071,7 +2078,7 @@ domain_to_disk (OR_BUF * buf, TP_DOMAIN * domain)
   offset += (domain->json_validator == NULL
 	     ? 0 : string_disk_size (db_json_get_schema_raw_from_validator (domain->json_validator)));
 
-  or_put_offset (buf, offset);
+  tf_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
   /* ATTRIBUTES */
@@ -2263,7 +2270,7 @@ metharg_to_disk (OR_BUF * buf, SM_METHOD_ARGUMENT * arg)
   offset = tf_Metaclass_metharg.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_metharg.mc_n_variable);
   or_put_offset (buf, offset);
   offset += substructure_set_size ((DB_LIST *) arg->domain, (LSIZER) domain_size);
-  or_put_offset (buf, offset);
+  tf_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
   /* ATTRIBUTES */
@@ -2384,7 +2391,7 @@ methsig_to_disk (OR_BUF * buf, SM_METHOD_SIGNATURE * sig)
   or_put_offset (buf, offset);
   offset += substructure_set_size ((DB_LIST *) sig->args, (LSIZER) metharg_size);
 
-  or_put_offset (buf, offset);
+  tf_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
 
@@ -2537,7 +2544,7 @@ method_to_disk (OR_BUF * buf, SM_METHOD * method)
   offset += property_list_size (method->properties);
 
   /* end of variables */
-  or_put_offset (buf, offset);
+  tf_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
   /* ATTRIBUTES */
@@ -2664,7 +2671,7 @@ methfile_to_disk (OR_BUF * buf, SM_METHOD_FILE * file)
   offset += property_list_size (NULL);
 
   /* end of object */
-  or_put_offset (buf, offset);
+  tf_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
   /* ATTRIBUTES */
@@ -2786,7 +2793,7 @@ query_spec_to_disk (OR_BUF * buf, SM_QUERY_SPEC * query_spec)
   or_put_offset (buf, offset);
   offset += string_disk_size (query_spec->specification);
 
-  or_put_offset (buf, offset);
+  tf_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
   /* ATTRIBUTES */
@@ -2909,7 +2916,7 @@ attribute_to_disk (OR_BUF * buf, SM_ATTRIBUTE * att)
   offset += string_disk_size (att->comment);
 
   /* end of object */
-  or_put_offset (buf, offset);
+  tf_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
   /* ATTRIBUTES */
@@ -3200,7 +3207,7 @@ resolution_to_disk (OR_BUF * buf, SM_RESOLUTION * res)
   offset += string_disk_size (res->alias);
 
   /* end of object */
-  or_put_offset (buf, offset);
+  tf_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
   /* ATTRIBUTES */
@@ -3336,7 +3343,7 @@ repattribute_to_disk (OR_BUF * buf, SM_REPR_ATTRIBUTE * rat)
   offset += substructure_set_size ((DB_LIST *) rat->domain, (LSIZER) domain_size);
 
   /* end of object */
-  or_put_offset (buf, offset);
+  tf_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
   /* fixed width attributes */
   or_put_int (buf, rat->attid);
@@ -3461,7 +3468,7 @@ representation_to_disk (OR_BUF * buf, SM_REPRESENTATION * rep)
   or_put_offset (buf, offset);
   offset += property_list_size (NULL);
   /* end of object */
-  or_put_offset (buf, offset);
+  tf_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
   or_put_int (buf, rep->id);
@@ -3661,7 +3668,7 @@ put_class_varinfo (OR_BUF * buf, SM_CLASS * class_)
   offset += substructure_set_size ((DB_LIST *) class_->partition, (LSIZER) partition_info_size);
 
   /* end of object */
-  or_put_offset (buf, offset);
+  tf_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
   return (offset);
@@ -4254,7 +4261,7 @@ root_to_disk (OR_BUF * buf, ROOT_CLASS * root)
   offset += string_disk_size (sm_ch_name ((MOBJ) root));
 
   /* end of object */
-  or_put_offset (buf, offset);
+  tf_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
   assert (OID_ISNULL (sm_ch_rep_dir ((MOBJ) root)));	/* is dummy */
@@ -4892,7 +4899,7 @@ partition_info_to_disk (OR_BUF * buf, SM_PARTITION * partition_info)
   or_put_offset (buf, offset);
   offset += string_disk_size (partition_info->comment);
 
-  or_put_offset (buf, offset);
+  tf_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
   /* ATTRIBUTES */

--- a/src/object/transform_cl.c
+++ b/src/object/transform_cl.c
@@ -131,7 +131,6 @@ static void tf_free_fixup (OR_FIXUP * fix);
 static void fixup_callback (LC_OIDMAP * oidmap);
 static int tf_do_fixup (OR_FIXUP * fix);
 static int put_varinfo (OR_BUF * buf, char *obj, SM_CLASS * class_, int offset_size);
-static void tf_put_last_var_offset (OR_BUF * buf, int offset);
 static int object_size (SM_CLASS * class_, MOBJ obj, int *offset_size_ptr);
 static int put_attributes (OR_BUF * buf, char *obj, SM_CLASS * class_);
 static char *get_current (OR_BUF * buf, SM_CLASS * class_, MOBJ * obj_ptr, int bound_bit_flag, int offset_size);
@@ -646,13 +645,6 @@ put_varinfo (OR_BUF * buf, char *obj, SM_CLASS * class_, int offset_size)
     }
   return rc;
 }
-
-static void
-tf_put_last_var_offset (OR_BUF * buf, int offset)
-{
-  or_put_offset (buf, OR_SET_VAR_LAST_ELEMENT (offset));
-}
-
 
 /*
  * object_size - Calculates the amount of disk storage required for an instance.
@@ -2078,7 +2070,7 @@ domain_to_disk (OR_BUF * buf, TP_DOMAIN * domain)
   offset += (domain->json_validator == NULL
 	     ? 0 : string_disk_size (db_json_get_schema_raw_from_validator (domain->json_validator)));
 
-  tf_put_last_var_offset (buf, offset);
+  or_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
   /* ATTRIBUTES */
@@ -2270,7 +2262,7 @@ metharg_to_disk (OR_BUF * buf, SM_METHOD_ARGUMENT * arg)
   offset = tf_Metaclass_metharg.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_metharg.mc_n_variable);
   or_put_offset (buf, offset);
   offset += substructure_set_size ((DB_LIST *) arg->domain, (LSIZER) domain_size);
-  tf_put_last_var_offset (buf, offset);
+  or_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
   /* ATTRIBUTES */
@@ -2391,7 +2383,7 @@ methsig_to_disk (OR_BUF * buf, SM_METHOD_SIGNATURE * sig)
   or_put_offset (buf, offset);
   offset += substructure_set_size ((DB_LIST *) sig->args, (LSIZER) metharg_size);
 
-  tf_put_last_var_offset (buf, offset);
+  or_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
 
@@ -2544,7 +2536,7 @@ method_to_disk (OR_BUF * buf, SM_METHOD * method)
   offset += property_list_size (method->properties);
 
   /* end of variables */
-  tf_put_last_var_offset (buf, offset);
+  or_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
   /* ATTRIBUTES */
@@ -2671,7 +2663,7 @@ methfile_to_disk (OR_BUF * buf, SM_METHOD_FILE * file)
   offset += property_list_size (NULL);
 
   /* end of object */
-  tf_put_last_var_offset (buf, offset);
+  or_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
   /* ATTRIBUTES */
@@ -2793,7 +2785,7 @@ query_spec_to_disk (OR_BUF * buf, SM_QUERY_SPEC * query_spec)
   or_put_offset (buf, offset);
   offset += string_disk_size (query_spec->specification);
 
-  tf_put_last_var_offset (buf, offset);
+  or_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
   /* ATTRIBUTES */
@@ -2916,7 +2908,7 @@ attribute_to_disk (OR_BUF * buf, SM_ATTRIBUTE * att)
   offset += string_disk_size (att->comment);
 
   /* end of object */
-  tf_put_last_var_offset (buf, offset);
+  or_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
   /* ATTRIBUTES */
@@ -3207,7 +3199,7 @@ resolution_to_disk (OR_BUF * buf, SM_RESOLUTION * res)
   offset += string_disk_size (res->alias);
 
   /* end of object */
-  tf_put_last_var_offset (buf, offset);
+  or_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
   /* ATTRIBUTES */
@@ -3343,7 +3335,7 @@ repattribute_to_disk (OR_BUF * buf, SM_REPR_ATTRIBUTE * rat)
   offset += substructure_set_size ((DB_LIST *) rat->domain, (LSIZER) domain_size);
 
   /* end of object */
-  tf_put_last_var_offset (buf, offset);
+  or_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
   /* fixed width attributes */
   or_put_int (buf, rat->attid);
@@ -3468,7 +3460,7 @@ representation_to_disk (OR_BUF * buf, SM_REPRESENTATION * rep)
   or_put_offset (buf, offset);
   offset += property_list_size (NULL);
   /* end of object */
-  tf_put_last_var_offset (buf, offset);
+  or_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
   or_put_int (buf, rep->id);
@@ -3668,7 +3660,7 @@ put_class_varinfo (OR_BUF * buf, SM_CLASS * class_)
   offset += substructure_set_size ((DB_LIST *) class_->partition, (LSIZER) partition_info_size);
 
   /* end of object */
-  tf_put_last_var_offset (buf, offset);
+  or_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
   return (offset);
@@ -4261,7 +4253,7 @@ root_to_disk (OR_BUF * buf, ROOT_CLASS * root)
   offset += string_disk_size (sm_ch_name ((MOBJ) root));
 
   /* end of object */
-  tf_put_last_var_offset (buf, offset);
+  or_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
   assert (OID_ISNULL (sm_ch_rep_dir ((MOBJ) root)));	/* is dummy */
@@ -4899,7 +4891,7 @@ partition_info_to_disk (OR_BUF * buf, SM_PARTITION * partition_info)
   or_put_offset (buf, offset);
   offset += string_disk_size (partition_info->comment);
 
-  tf_put_last_var_offset (buf, offset);
+  or_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
   /* ATTRIBUTES */

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -137,6 +137,7 @@ static int catcls_get_or_value_from_buffer (THREAD_ENTRY * thread_p, OR_BUF * bu
 					    DISK_REPR * rep);
 static int catcls_put_or_value_into_buffer (OR_VALUE * value_p, int chn, OR_BUF * buf_p, OID * class_oid,
 					    DISK_REPR * rep);
+static void catcls_put_last_var_offset (char *offset_p, int offset);
 
 static OR_VALUE *catcls_get_or_value_from_class_record (THREAD_ENTRY * thread_p, RECDES * record);
 static OR_VALUE *catcls_get_or_value_from_record (THREAD_ENTRY * thread_p, RECDES * record, OID * class_oid);
@@ -3307,7 +3308,7 @@ catcls_put_or_value_into_buffer (OR_VALUE * value_p, int chn, OR_BUF * buf_p, OI
 
   /* put last offset */
   offset = (int) (buf_p->ptr - buf_p->buffer - header_size);
-  OR_PUT_OFFSET (offset_p, offset);
+  catcls_put_last_var_offset (offset_p, offset);
 
   if (bound_bits)
     {
@@ -3324,6 +3325,12 @@ error:
     }
 
   return error;
+}
+
+static void
+catcls_put_last_var_offset (char *offset_p, int offset)
+{
+  OR_PUT_OFFSET (offset_p, OR_SET_VAR_LAST_ELEMENT (offset));
 }
 
 /*

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -137,7 +137,6 @@ static int catcls_get_or_value_from_buffer (THREAD_ENTRY * thread_p, OR_BUF * bu
 					    DISK_REPR * rep);
 static int catcls_put_or_value_into_buffer (OR_VALUE * value_p, int chn, OR_BUF * buf_p, OID * class_oid,
 					    DISK_REPR * rep);
-static void catcls_put_last_var_offset (char *offset_p, int offset);
 
 static OR_VALUE *catcls_get_or_value_from_class_record (THREAD_ENTRY * thread_p, RECDES * record);
 static OR_VALUE *catcls_get_or_value_from_record (THREAD_ENTRY * thread_p, RECDES * record, OID * class_oid);
@@ -3308,7 +3307,7 @@ catcls_put_or_value_into_buffer (OR_VALUE * value_p, int chn, OR_BUF * buf_p, OI
 
   /* put last offset */
   offset = (int) (buf_p->ptr - buf_p->buffer - header_size);
-  catcls_put_last_var_offset (offset_p, offset);
+  OR_PUT_LAST_VAR_OFFSET (offset_p, offset);
 
   if (bound_bits)
     {
@@ -3325,12 +3324,6 @@ error:
     }
 
   return error;
-}
-
-static void
-catcls_put_last_var_offset (char *offset_p, int offset)
-{
-  OR_PUT_OFFSET (offset_p, OR_SET_VAR_LAST_ELEMENT (offset));
 }
 
 /*

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -27925,6 +27925,7 @@ heap_recdes_check_has_oos (const RECDES * recdes)
 	  offset = OR_GET_INT (OR_VAR_TABLE_ELEMENT_PTR (var_table, index, offset_size));
 	  break;
 	default:
+	  assert (false && "unexpected variable offset size");
 	  return false;
 	}
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -13141,7 +13141,8 @@ heap_attrinfo_transform_columns_to_disk_develop_ver (THREAD_ENTRY * thread_p, HE
 	}
       else
 	{
-	  or_put_offset_internal (buf, CAST_BUFLEN (ptr_varvals - buf->buffer - header_size), offset_size);
+	  const int end_of_vot_offset = CAST_BUFLEN (ptr_varvals - buf->buffer - header_size);
+	  or_put_offset_internal (buf, OR_SET_VAR_LAST_ELEMENT (end_of_vot_offset), offset_size);
 	}
       buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
     }

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -21698,24 +21698,19 @@ heap_update_adjust_recdes_header (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEX
   update_mvcc_flags = OR_MVCC_FLAG_VALID_INSID | OR_MVCC_FLAG_VALID_PREV_VERSION;
 
   bool has_oos = heap_recdes_check_has_oos (update_context->recdes_p);
-  /* old_has_oos is the current HAS_OOS bit already stored in the recdes header before resynchronization. */
-  bool old_has_oos = (mvcc_flags & OR_MVCC_FLAG_HAS_OOS) != 0;
 
-  if (has_oos != old_has_oos)
+  if (has_oos)
     {
-      if (has_oos)
-	{
-	  mvcc_flags |= OR_MVCC_FLAG_HAS_OOS;
-	  repid_and_flag_bits |= (OR_MVCC_FLAG_HAS_OOS << OR_MVCC_FLAG_SHIFT_BITS);
-	}
-      else
-	{
-	  mvcc_flags &= ~OR_MVCC_FLAG_HAS_OOS;
-	  repid_and_flag_bits &= ~(OR_MVCC_FLAG_HAS_OOS << OR_MVCC_FLAG_SHIFT_BITS);
-	}
-
-      OR_PUT_INT (update_context->recdes_p->data, repid_and_flag_bits);
+      mvcc_flags |= OR_MVCC_FLAG_HAS_OOS;
+      repid_and_flag_bits |= (OR_MVCC_FLAG_HAS_OOS << OR_MVCC_FLAG_SHIFT_BITS);
     }
+  else
+    {
+      mvcc_flags &= ~OR_MVCC_FLAG_HAS_OOS;
+      repid_and_flag_bits &= ~(OR_MVCC_FLAG_HAS_OOS << OR_MVCC_FLAG_SHIFT_BITS);
+    }
+
+  OR_PUT_INT (update_context->recdes_p->data, repid_and_flag_bits);
   is_mvcc_op = HEAP_UPDATE_IS_MVCC_OP (is_mvcc_class, update_context->update_in_place);
 #if defined (SERVER_MODE)
   use_optimization = (is_mvcc_op && !heap_is_big_length (record_size + OR_MVCCID_SIZE + OR_MVCC_PREV_VERSION_LSA_SIZE));
@@ -27907,7 +27902,7 @@ heap_recdes_check_has_oos (const RECDES * recdes)
   void *var_table = OR_GET_OBJECT_VAR_TABLE (recdes->data);
   const int max_var_count = (recdes->length - OR_HEADER_SIZE (recdes->data)) / offset_size;
 
-  for (int index = 0; index <= max_var_count; ++index)
+  for (int index = 0;; ++index)
     {
       if (index == max_var_count)
 	{

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -21703,16 +21703,15 @@ heap_update_adjust_recdes_header (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEX
 
   if (has_oos)
     {
-      mvcc_flags |= OR_MVCC_FLAG_HAS_OOS;
       repid_and_flag_bits |= (OR_MVCC_FLAG_HAS_OOS << OR_MVCC_FLAG_SHIFT_BITS);
     }
   else
     {
-      mvcc_flags &= ~OR_MVCC_FLAG_HAS_OOS;
       repid_and_flag_bits &= ~(OR_MVCC_FLAG_HAS_OOS << OR_MVCC_FLAG_SHIFT_BITS);
     }
 
   OR_PUT_INT (update_context->recdes_p->data, repid_and_flag_bits);
+
   is_mvcc_op = HEAP_UPDATE_IS_MVCC_OP (is_mvcc_class, update_context->update_in_place);
 #if defined (SERVER_MODE)
   use_optimization = (is_mvcc_op && !heap_is_big_length (record_size + OR_MVCCID_SIZE + OR_MVCC_PREV_VERSION_LSA_SIZE));
@@ -21826,6 +21825,15 @@ heap_update_adjust_recdes_header (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEX
 #endif /* SERVER_MODE */
     {
       MVCC_CLEAR_FLAG_BITS (&mvcc_rec_header, OR_MVCC_FLAG_VALID_PREV_VERSION);
+    }
+
+  if (has_oos)
+    {
+      mvcc_rec_header.mvcc_flag |= OR_MVCC_FLAG_HAS_OOS;
+    }
+  else
+    {
+      mvcc_rec_header.mvcc_flag &= ~OR_MVCC_FLAG_HAS_OOS;
     }
 
   if (is_mvcc_class && heap_is_big_length (record_size))

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -12840,9 +12840,10 @@ heap_attrinfo_transform_columns_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_ATT
 	}
       else
 	{
-	  or_put_offset_internal (buf, OR_SET_VAR_LAST_ELEMENT (CAST_BUFLEN (ptr_varvals - buf->buffer - header_size)),
-				  offset_size);
+	  const int end_of_vot_offset = CAST_BUFLEN (ptr_varvals - buf->buffer - header_size);
+	  or_put_offset_internal (buf, OR_SET_VAR_LAST_ELEMENT (end_of_vot_offset), offset_size);
 	}
+
       buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
     }
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -21690,15 +21690,14 @@ heap_update_adjust_recdes_header (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEX
   assert (update_context != NULL);
   assert (update_context->type == HEAP_OPERATION_UPDATE);
   assert (update_context->recdes_p != NULL);
+  /* Root-class records do not use the generic object header layout handled here. */
+  assert (!OID_IS_ROOTOID (&update_context->class_oid));
 
   record_size = update_context->recdes_p->length;
 
   repid_and_flag_bits = OR_GET_MVCC_REPID_AND_FLAG (update_context->recdes_p->data);
   mvcc_flags = (repid_and_flag_bits >> OR_MVCC_FLAG_SHIFT_BITS) & OR_MVCC_FLAG_MASK;
   update_mvcc_flags = OR_MVCC_FLAG_VALID_INSID | OR_MVCC_FLAG_VALID_PREV_VERSION;
-
-  /* Root-class records do not use the generic object header layout handled here. */
-  assert (!OID_IS_ROOTOID (&update_context->class_oid));
 
   bool has_oos = heap_recdes_check_has_oos (update_context->recdes_p);
   bool old_has_oos = (mvcc_flags & OR_MVCC_FLAG_HAS_OOS) != 0;

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -12691,14 +12691,8 @@ heap_attrinfo_transform_variable_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_AT
 	  length = OR_SET_VAR_OOS (length);
 	}
 
-      /* Mark the last variable attribute so readers can determine the variable offset table boundary
-       * without needing attrinfo->num_values (e.g., in logging and replication paths). */
-      if (value->last_attrepr->location == attr_info->last_classrepr->n_variable - 1)
-	{
-	  oos_trace ("Setting LAST_ELEMENT flag for variable attribute at location %d (n_variable=%d)",
-		     value->last_attrepr->location, attr_info->last_classrepr->n_variable);
-	  length = OR_SET_VAR_LAST_ELEMENT (length);
-	}
+      /* VOT low 2 bits are reserved for storage flags. Keep all writes centralized. */
+      length = heap_vot_apply_flags (length, is_oos, false);
       or_put_offset_internal (buf, length, offset_size);
     }
 
@@ -12847,7 +12841,9 @@ heap_attrinfo_transform_columns_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_ATT
 	}
       else
 	{
-	  or_put_offset_internal (buf, CAST_BUFLEN (ptr_varvals - buf->buffer - header_size), offset_size);
+	  or_put_offset_internal (buf,
+				  heap_vot_apply_flags (CAST_BUFLEN (ptr_varvals - buf->buffer - header_size), false,
+							true), offset_size);
 	}
       buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
     }
@@ -21701,6 +21697,27 @@ heap_update_adjust_recdes_header (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEX
   mvcc_flags = (repid_and_flag_bits >> OR_MVCC_FLAG_SHIFT_BITS) & OR_MVCC_FLAG_MASK;
   update_mvcc_flags = OR_MVCC_FLAG_VALID_INSID | OR_MVCC_FLAG_VALID_PREV_VERSION;
 
+  /* Root-class records do not use the generic object header layout handled here. */
+  assert (!OID_IS_ROOTOID (&update_context->class_oid));
+
+  bool has_oos = heap_recdes_check_has_oos (update_context->recdes_p);
+  bool old_has_oos = (mvcc_flags & OR_MVCC_FLAG_HAS_OOS) != 0;
+
+  if (has_oos != old_has_oos)
+    {
+      if (has_oos)
+	{
+	  mvcc_flags |= OR_MVCC_FLAG_HAS_OOS;
+	  repid_and_flag_bits |= (OR_MVCC_FLAG_HAS_OOS << OR_MVCC_FLAG_SHIFT_BITS);
+	}
+      else
+	{
+	  mvcc_flags &= ~OR_MVCC_FLAG_HAS_OOS;
+	  repid_and_flag_bits &= ~(OR_MVCC_FLAG_HAS_OOS << OR_MVCC_FLAG_SHIFT_BITS);
+	}
+
+      OR_PUT_INT (update_context->recdes_p->data, repid_and_flag_bits);
+    }
   is_mvcc_op = HEAP_UPDATE_IS_MVCC_OP (is_mvcc_class, update_context->update_in_place);
 #if defined (SERVER_MODE)
   use_optimization = (is_mvcc_op && !heap_is_big_length (record_size + OR_MVCCID_SIZE + OR_MVCC_PREV_VERSION_LSA_SIZE));
@@ -27878,4 +27895,52 @@ heap_recdes_get_oos_oids (const RECDES * recdes, OID_VECTOR & oos_oids)
 
   assert (false && "unreachable: there must be last element");
   return ER_FAILED;
+}
+bool
+heap_recdes_check_has_oos (const RECDES * recdes)
+{
+  if (recdes == NULL || recdes->data == NULL)
+    {
+      return false;
+    }
+
+  const int offset_size = OR_GET_OFFSET_SIZE (recdes->data);
+  void *var_table = OR_GET_OBJECT_VAR_TABLE (recdes->data);
+  const int max_var_count = (recdes->length - OR_HEADER_SIZE (recdes->data)) / offset_size;
+
+  for (int index = 0; index <= max_var_count; ++index)
+    {
+      if (index == max_var_count)
+	{
+	  return false;
+	}
+
+      int offset;
+      switch (offset_size)
+	{
+	case OR_BYTE_SIZE:
+	  offset = OR_GET_BYTE (OR_VAR_TABLE_ELEMENT_PTR (var_table, index, offset_size));
+	  break;
+	case OR_SHORT_SIZE:
+	  offset = OR_GET_SHORT (OR_VAR_TABLE_ELEMENT_PTR (var_table, index, offset_size));
+	  break;
+	case OR_INT_SIZE:
+	  offset = OR_GET_INT (OR_VAR_TABLE_ELEMENT_PTR (var_table, index, offset_size));
+	  break;
+	default:
+	  return false;
+	}
+
+      if (OR_IS_OOS (offset))
+	{
+	  return true;
+	}
+
+      if (OR_IS_LAST_ELEMENT (offset))
+	{
+	  return false;
+	}
+    }
+
+  return false;
 }

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -27895,6 +27895,7 @@ heap_recdes_get_oos_oids (const RECDES * recdes, OID_VECTOR & oos_oids)
   assert (false && "unreachable: there must be last element");
   return ER_FAILED;
 }
+
 bool
 heap_recdes_check_has_oos (const RECDES * recdes)
 {

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -12692,8 +12692,6 @@ heap_attrinfo_transform_variable_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_AT
 	  length = OR_SET_VAR_OOS (length);
 	}
 
-      /* VOT low 2 bits are reserved for storage flags. Keep all writes centralized. */
-      length = or_var_offset_apply_flags (length, is_oos, false);
       or_put_offset_internal (buf, length, offset_size);
     }
 
@@ -12842,9 +12840,8 @@ heap_attrinfo_transform_columns_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_ATT
 	}
       else
 	{
-	  or_put_offset_internal (buf,
-				  or_var_offset_apply_flags (CAST_BUFLEN (ptr_varvals - buf->buffer - header_size),
-							     false, true), offset_size);
+	  or_put_offset_internal (buf, OR_SET_VAR_LAST_ELEMENT (CAST_BUFLEN (ptr_varvals - buf->buffer - header_size)),
+				  offset_size);
 	}
       buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
     }
@@ -21701,6 +21698,7 @@ heap_update_adjust_recdes_header (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEX
   update_mvcc_flags = OR_MVCC_FLAG_VALID_INSID | OR_MVCC_FLAG_VALID_PREV_VERSION;
 
   bool has_oos = heap_recdes_check_has_oos (update_context->recdes_p);
+  /* old_has_oos is the current HAS_OOS bit already stored in the recdes header before resynchronization. */
   bool old_has_oos = (mvcc_flags & OR_MVCC_FLAG_HAS_OOS) != 0;
 
   if (has_oos != old_has_oos)
@@ -27913,6 +27911,7 @@ heap_recdes_check_has_oos (const RECDES * recdes)
     {
       if (index == max_var_count)
 	{
+	  assert (false && "LAST_ELEMENT flag not found within record bounds");
 	  return false;
 	}
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -855,6 +855,8 @@ static int heap_insert_adjust_recdes_header (THREAD_ENTRY * thread_p, HEAP_OPERA
 					     bool is_mvcc_class);
 static int heap_update_adjust_recdes_header (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * update_context,
 					     bool is_mvcc_class);
+static int heap_vot_apply_flags (int offset, bool is_oos, bool is_last_element);
+static bool heap_recdes_check_has_oos (const RECDES * recdes);
 static int heap_insert_handle_multipage_record (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context);
 static int heap_get_insert_location_with_lock (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context,
 					       PGBUF_WATCHER * home_hint_p);
@@ -12768,6 +12770,22 @@ heap_attrinfo_transform_variable_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_AT
   assert (!(((uint64_t) * ptr_varvals) & 0x3));
 
   return S_SUCCESS;
+}
+
+static int
+heap_vot_apply_flags (int offset, bool is_oos, bool is_last_element)
+{
+  if (is_oos)
+    {
+      offset = OR_SET_VAR_OOS (offset);
+    }
+
+  if (is_last_element)
+    {
+      offset = OR_SET_VAR_LAST_ELEMENT (offset);
+    }
+
+  return offset;
 }
 
 /*
@@ -27896,7 +27914,7 @@ heap_recdes_get_oos_oids (const RECDES * recdes, OID_VECTOR & oos_oids)
   return ER_FAILED;
 }
 
-bool
+static bool
 heap_recdes_check_has_oos (const RECDES * recdes)
 {
   if (recdes == NULL || recdes->data == NULL)

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -855,7 +855,6 @@ static int heap_insert_adjust_recdes_header (THREAD_ENTRY * thread_p, HEAP_OPERA
 					     bool is_mvcc_class);
 static int heap_update_adjust_recdes_header (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * update_context,
 					     bool is_mvcc_class);
-static int heap_vot_apply_flags (int offset, bool is_oos, bool is_last_element);
 static bool heap_recdes_check_has_oos (const RECDES * recdes);
 static int heap_insert_handle_multipage_record (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context);
 static int heap_get_insert_location_with_lock (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context,
@@ -12694,7 +12693,7 @@ heap_attrinfo_transform_variable_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_AT
 	}
 
       /* VOT low 2 bits are reserved for storage flags. Keep all writes centralized. */
-      length = heap_vot_apply_flags (length, is_oos, false);
+      length = or_var_offset_apply_flags (length, is_oos, false);
       or_put_offset_internal (buf, length, offset_size);
     }
 
@@ -12772,22 +12771,6 @@ heap_attrinfo_transform_variable_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_AT
   return S_SUCCESS;
 }
 
-static int
-heap_vot_apply_flags (int offset, bool is_oos, bool is_last_element)
-{
-  if (is_oos)
-    {
-      offset = OR_SET_VAR_OOS (offset);
-    }
-
-  if (is_last_element)
-    {
-      offset = OR_SET_VAR_LAST_ELEMENT (offset);
-    }
-
-  return offset;
-}
-
 /*
  * heap_attrinfo_transform_columns_to_disk ()
  *   return: SCAN_CODE
@@ -12860,8 +12843,8 @@ heap_attrinfo_transform_columns_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_ATT
       else
 	{
 	  or_put_offset_internal (buf,
-				  heap_vot_apply_flags (CAST_BUFLEN (ptr_varvals - buf->buffer - header_size), false,
-							true), offset_size);
+				  or_var_offset_apply_flags (CAST_BUFLEN (ptr_varvals - buf->buffer - header_size),
+							     false, true), offset_size);
 	}
       buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
     }


### PR DESCRIPTION
  <http://jira.cubrid.org/browse/CBRD-26671>

  ### Purpose

  VOT 마지막 sentinel entry에 `OR_VAR_BIT_LAST_ELEMENT`가 기록되지 않아 발생하던
  잘못된 OOS 판정과 core dump를 수정한다.

  일부 recdes 생성 경로에서는 마지막 VOT entry를 plain offset으로만 기록하고 있었고,
  이 경우 `heap_recdes_check_has_oos()`가 VOT 경계를 찾지 못한 채 payload 영역까지
  계속 읽을 수 있었다.

  그 결과 payload의 임의 값이 `OR_VAR_BIT_OOS`로 해석되어 false positive OOS 판정이 발생하고,
  관련 assert 및 `createdb testdb en_US` 수행 중 core dump로 이어질 수 있었다.

  이번 변경은 마지막 VOT sentinel entry에만 `LAST_ELEMENT`를 기록하도록 규약을 통일하고,
  관련 helper도 공용 object representation helper로 정리해
  향후 동일한 규약을 재사용할 수 있도록 한다.

  ### Implementation

  영향받는 recdes 생성 경로 전반에서 마지막 VOT sentinel entry에
  `OR_VAR_BIT_LAST_ELEMENT`를 일관되게 기록하도록 수정했다.

  - `src/base/object_representation.h`
    VOT offset flag 처리를 공용으로 사용할 수 있도록
    `or_var_offset_apply_flags()`,
    `or_put_last_var_offset()`,
    `OR_PUT_LAST_VAR_OFFSET`를 추가
  - `src/object/transform_cl.c`
    generic instance recdes와 meta-class/schema object serializer가
    마지막 sentinel offset에 `LAST_ELEMENT`를 기록하도록 정리하고,
    기존 local helper 대신 공용 `or_put_last_var_offset()`을 사용하도록 변경
  - `src/storage/catalog_class.c`
    catalog class recdes의 마지막 offset entry를 plain offset 대신
    `LAST_ELEMENT`가 포함된 값으로 기록하도록 수정하고,
    기존 local helper 대신 공용 `OR_PUT_LAST_VAR_OFFSET`을 사용하도록 변경
  - `src/storage/heap_file.c`
    server-side heap recdes transform에서 일반 variable entry에는
    `LAST_ELEMENT`를 기록하지 않고,
    마지막 sentinel entry에만 기록하도록 정리
  - `src/storage/heap_file.c`
    heap 전용 local helper였던 `heap_vot_apply_flags()`를 제거하고,
    공용 `or_var_offset_apply_flags()`를 사용하도록 정리
  - `src/storage/heap_file.c`
    `heap_update_adjust_recdes_header()`에
    root-class record는 generic object header layout 대상이 아님을 나타내는
    assert와 주석 추가

  ### Remarks

  이번 수정의 핵심은 특정 한 종류의 special record를 예외 처리하는 것이 아니라,
  VOT termination 규약을 사용하는 주요 경로 전반에 동일한 기록 규칙을 적용하고,
  그 규칙을 공용 helper로 정리한 것이다.

  기대 효과는 다음과 같다.

  - `heap_recdes_check_has_oos()`가 VOT boundary 밖을 읽지 않음
  - false positive OOS 판정 방지
  - `heap_recdes_get_oos_oids()`와 raw VOT scan 결과 불일치 방지
  - `createdb testdb en_US` 수행 중 관련 assert/core dump 방지
  - 이후 유사한 serializer 경로에서도 공용 helper를 통해 같은 규약을 재사용 가능