### PR TITLE
[CBRD-26410] rev2: Improve performance for SQL_TRACE_EXECUTION_PLAN

### DIFF
--- a/src/base/trace_event_log.c
+++ b/src/base/trace_event_log.c
@@ -219,13 +219,16 @@ trace_event_file_open (const char *path, char log_type)
     }
 
 #if !defined (WINDOWS) && defined (SERVER_MODE)
-  if (fp != NULL && log_type == 'E' /* event log */ )
+  if (fp != NULL)
     {
-      er_file_create_link_to_current_log_file (path, EVENT_LOG_FILE_SUFFIX);
-    }
-  else
-    {
-      er_file_create_link_to_current_log_file (path, LATEST_SQL_TRACE_FILE);
+      if (log_type == 'E' /* event log */ )
+	{
+	  er_file_create_link_to_current_log_file (path, EVENT_LOG_FILE_SUFFIX);
+	}
+      else
+	{
+	  er_file_create_link_to_current_log_file (path, LATEST_SQL_TRACE_FILE);
+	}
     }
 #endif /* !WINDOWS && SERVER_MODE */
 
@@ -321,18 +324,17 @@ trace_event_log_start (THREAD_ENTRY * thread_p, const char *log_name, const char
 
   if (log_type == 'E')
     {
-      csect = CSECT_EVENT_LOG_FILE;
+      csect_enter (thread_p, csect = CSECT_EVENT_LOG_FILE, INF_WAIT);
       log_Fp = event_Fp;
       log_file_name = event_log_file_path;
     }
   else
     {
-      csect = CSECT_TRACE_LOG_FILE;
+      csect_enter (thread_p, csect = CSECT_TRACE_LOG_FILE, INF_WAIT);
       log_Fp = trace_Fp;
       log_file_name = trace_log_file_path;
     }
 
-  csect_enter (thread_p, csect, INF_WAIT);
   /* If file is not exist, it will recreate *log_fh file. */
   if (log_Fp == NULL || access (log_file_name, F_OK) == -1)
     {
@@ -405,6 +407,7 @@ trace_log_end (THREAD_ENTRY * thread_p)
 
   if (trace_Fp == NULL)
     {
+      csect_exit (thread_p, CSECT_TRACE_LOG_FILE);
       return;
     }
 
@@ -423,6 +426,7 @@ event_log_end (THREAD_ENTRY * thread_p)
 
   if (event_Fp == NULL)
     {
+      csect_exit (thread_p, CSECT_EVENT_LOG_FILE);
       return;
     }
 

--- a/src/base/trace_log.h
+++ b/src/base/trace_log.h
@@ -47,4 +47,4 @@ extern void trace_log_bind_values (THREAD_ENTRY * thread_p, FILE * log_fp, int t
 #define TRACE_LOG_LEVEL_SIMPLE  1
 #define TRACE_LOG_LEVEL_DETAIL  2
 
-#endif /* _EVENT_LOG_H_ */
+#endif /* _TRACE_LOG_H_ */


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26410>

### Purpose

SQL_TRACE_EXECUTION_PLAN 시스템 파라미터가 설정되어 있을 경우, 쿼리 실행의 성능 저하가 발생하고 있습니다. 성능 저하는 최소 3배에서 최대 5배 이상으로 성능을 높일 필요가 있습니다.

### Implementation

sqmgr_execute_query에서 perfmon_calc_diff_stats => perfmon_server_calc_stats를 호출할 때 response_time >= trace_slow_msec인 경우만으로 한정

### Remarks
11.3, 11.4에 backport 중, greptile의 comment 내용을 반영
* trace_log.h 헤더 파일에 커멘트 오류가 있어 수정
* trace_event_log_start 에서 critical section 위치 조정
* trace_event_file_open에서 link 전에 fp가 NULL인지 체크
* trace_log_end, event_log_end에서 critical section 위치 조정 (NULL일 때 체크)


