### PR TITLE
[CBRD-26497] slip: missing blank

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -4760,7 +4760,7 @@ emit_stored_procedure_code (extract_context & ctxt, print_output & output_ctx, c
 	  output_ctx ("\n%s", scode_ptr_result);
 	  if (!DB_IS_NULL (comment))
 	    {
-	      output_ctx ("COMMENT ");
+	      output_ctx (" COMMENT ");
 	      desc_value_print (output_ctx, comment);
 	    }
 	}


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26497>

### Purpose

과거 수정된 부분을 다른 이슈를 처리하면서 실수로 원복해서 다시 적용합니다. 
COMMENT 키워드 앞에 공란 하나를 추가하는 변경입니다. 

### Implementation

N/A

### Remarks

N/A
