### PR TITLE
[CBRD-26681] Memoize 미사용 시 trace 결과 조회되지 않도록 변경

### DIFF
--- a/src/query/query_dump.c
+++ b/src/query/query_dump.c
@@ -3257,7 +3257,7 @@ qdump_print_stats_json (xasl_node * xasl_p, json_t * parent)
       scan = qdump_print_access_spec_stats_json (xasl_p->merge_spec);
     }
 
-  if (xasl_p->memoize_storage)
+  if (xasl_p->memoize_storage && xasl_p->memoize_storage->hit > 0)
     {
       memoize = json_object ();
       json_object_set_new (memoize, "time", json_integer (TO_MSEC (xasl_p->memoize_storage->m_elapsed_time)));
@@ -3780,7 +3780,7 @@ qdump_print_stats_text (FILE * fp, xasl_node * xasl_p, int indent)
       qdump_print_access_spec_stats_text (fp, xasl_p->merge_spec, indent);
     }
 
-  if (xasl_p->memoize_storage)
+  if (xasl_p->memoize_storage && xasl_p->memoize_storage->hit > 0)
     {
       fprintf (fp, "%*c", indent, ' ');
       fprintf (fp, "MEMOIZE (time: %d, hit: %lu, miss: %lu, size: %luKB, enabled: %s)\n",


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26681>

### Purpose

Memoize 기능이 실제로 사용되지 않은 경우(hit == 0)에도 trace 결과에 MEMOIZE 항목이 출력되는 문제가 있습니다.
memoize_storage가 할당되어 있더라도 실제 hit이 없는 경우 trace 출력에서 제외하도록 변경합니다.

### Implementation
주요 변경 파일

src/query/query_dump.c
qdump_print_stats_json: memoize_storage 출력 조건에 hit > 0 추가
