### PR TITLE
[CUBRIDQA-1320] Add TC merge gate workflow to block engine PR merge until TC PRs are merged or closed

### DIFF
--- a/.github/workflows/tc-merge-gate.yml
+++ b/.github/workflows/tc-merge-gate.yml
@@ -22,7 +22,7 @@ name: TC Merge Gate
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, labeled, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - develop
       - 'feature/**'

--- a/.github/workflows/tc-merge-gate.yml
+++ b/.github/workflows/tc-merge-gate.yml
@@ -87,7 +87,7 @@ jobs:
               --state open \
               --limit 1 \
               --json url,isDraft \
-              --jq '.[0] // empty' 2>/dev/null || echo "")
+              --jq '.[0] // empty')
 
             if [ -z "${OPEN_PR}" ]; then
               echo "::notice::${TC_REPO}: No open TC PR for '${BRANCH_NAME}' — pass"

--- a/.github/workflows/tc-merge-gate.yml
+++ b/.github/workflows/tc-merge-gate.yml
@@ -59,12 +59,6 @@ jobs:
           repositories: cubrid-testcases,cubrid-testcases-private-ex
           owner: ${{ env.OWNER }}
 
-      - name: Mask token
-        env:
-          APP_TOKEN: ${{ steps.app-token.outputs.token }}
-        shell: bash
-        run: echo "::add-mask::${APP_TOKEN}"
-
       - name: Check TC PRs
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -86,14 +80,12 @@ jobs:
           OVERALL_PASS=true
           TC_TEXT_BLOCK=""
 
-          echo "Checking TC PR status for branch '${BRANCH_NAME}' in ${#TC_REPOS[@]} repos..."
-          echo ""
-
           for TC_REPO in "${TC_REPOS[@]}"; do
             OPEN_PR=$(gh pr list \
               --repo "${OWNER}/${TC_REPO}" \
               --head "${BRANCH_NAME}" \
               --state open \
+              --limit 1 \
               --json url,isDraft \
               --jq '.[0] // empty' 2>/dev/null || echo "")
 
@@ -103,20 +95,13 @@ jobs:
             else
               IS_DRAFT=$(echo "${OPEN_PR}" | jq -r '.isDraft')
               URL=$(echo "${OPEN_PR}" | jq -r '.url')
-
-              if [ "${IS_DRAFT}" == "true" ]; then
-                STATE_DISPLAY="open (draft)"
-              else
-                STATE_DISPLAY="open"
-              fi
+              STATE_DISPLAY=$( [ "${IS_DRAFT}" == "true" ] && echo "open (draft)" || echo "open" )
 
               echo "::error::${TC_REPO}: TC PR is ${STATE_DISPLAY}: ${URL}"
               TC_TEXT_BLOCK+="- ❌ **${TC_REPO}**: TC PR [\`${BRANCH_NAME}\`](${URL}) is ${STATE_DISPLAY} — must be merged or closed first"$'\n'
               OVERALL_PASS=false
             fi
           done
-
-          echo ""
 
           if [ "${OVERALL_PASS}" == "false" ]; then
             COMMENT_BODY=$(cat <<EOF
@@ -130,7 +115,7 @@ jobs:
           1. Merge or close all TC PRs listed above.
           2. Re-run this check: **Actions tab → TC Merge Gate → Re-run failed jobs**
           EOF
-            )
+          )
           else
             COMMENT_BODY=$(cat <<EOF
           ## ✅ TC Merge Gate — Merge Allowed
@@ -140,19 +125,22 @@ jobs:
           **TC Repositories & Branches:**
           ${TC_TEXT_BLOCK}
           EOF
-            )
+          )
           fi
 
-          COMMENT_ID=$(GH_TOKEN="${GITHUB_TOKEN}" gh api "repos/${ENGINE_REPO}/issues/${PR_NUMBER}/comments" \
-            --jq '.[] | select(.user.login=="github-actions[bot]" and (.body | contains("TC Merge Gate"))) | .id' \
-            | tail -n 1 || echo "")
+          # Post or update comment on engine PR (best-effort — does not affect check result)
+          {
+            COMMENT_ID=$(GH_TOKEN="${GITHUB_TOKEN}" gh api "repos/${ENGINE_REPO}/issues/${PR_NUMBER}/comments" \
+              --jq '.[] | select(.user.login=="github-actions[bot]" and (.body | contains("TC Merge Gate"))) | .id' \
+              | tail -n 1)
 
-          if [ -n "${COMMENT_ID}" ]; then
-            GH_TOKEN="${GITHUB_TOKEN}" gh api -X PATCH "repos/${ENGINE_REPO}/issues/comments/${COMMENT_ID}" \
-              -f body="${COMMENT_BODY}" > /dev/null
-          else
-            GH_TOKEN="${GITHUB_TOKEN}" gh pr comment "${PR_NUMBER}" --repo "${ENGINE_REPO}" --body "${COMMENT_BODY}"
-          fi
+            if [ -n "${COMMENT_ID}" ]; then
+              GH_TOKEN="${GITHUB_TOKEN}" gh api -X PATCH "repos/${ENGINE_REPO}/issues/comments/${COMMENT_ID}" \
+                -f body="${COMMENT_BODY}" > /dev/null
+            else
+              GH_TOKEN="${GITHUB_TOKEN}" gh pr comment "${PR_NUMBER}" --repo "${ENGINE_REPO}" --body "${COMMENT_BODY}"
+            fi
+          } || echo "::warning::Failed to post PR comment — check result is unaffected"
 
           if [ "${OVERALL_PASS}" == "false" ]; then
             echo "TC Merge Gate FAILED: One or more TC PRs are still open."

--- a/.github/workflows/tc-merge-gate.yml
+++ b/.github/workflows/tc-merge-gate.yml
@@ -1,0 +1,162 @@
+#
+# TC Merge Gate — Block engine PR merge until TC PRs are merged or closed
+#
+# Trigger: pull_request_target (opened, synchronize, reopened, labeled, ready_for_review)
+#          workflow_dispatch (manual re-run after TC PRs are handled)
+#
+# Register as Required Status Check in Branch Protection Rules:
+#   Settings → Branches → develop → Require status checks → "TC Merge Gate / Check TC PRs"
+#
+# Pass conditions (per TC repo):
+#   - No open TC PR found for tc/pr-<N>  →  pass  (TC creation was skipped or TC PR was merged/closed)
+#   - TC PR state is MERGED or CLOSED    →  pass
+#
+# Fail condition:
+#   - TC PR is OPEN (including draft)    →  fail  (merge blocked)
+#
+# After TC PRs are merged/closed, re-run this check via:
+#   GitHub Actions UI → "Re-run failed jobs"
+#
+
+name: TC Merge Gate
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled, ready_for_review]
+    branches:
+      - develop
+      - 'feature/**'
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Engine PR number to check (required for workflow_dispatch)'
+        required: true
+        type: string
+
+permissions: {} # Least privilege — job opts in below
+
+concurrency:
+  group: tc-merge-gate-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+env:
+  OWNER: CUBRID
+
+jobs:
+  check-tc-prs:
+    name: Check TC PRs
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.TC_APP_ID }}
+          private-key: ${{ secrets.TC_APP_PRIVATE_KEY }}
+          repositories: cubrid-testcases,cubrid-testcases-private-ex
+          owner: ${{ env.OWNER }}
+
+      - name: Mask token
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+        shell: bash
+        run: echo "::add-mask::${APP_TOKEN}"
+
+      - name: Check TC PRs
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+          ENGINE_REPO: ${{ github.repository }}
+          OWNER: ${{ env.OWNER }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -z "${PR_NUMBER}" ] || ! [[ "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
+            echo "::error::PR_NUMBER is empty or not a valid number: '${PR_NUMBER}'"
+            exit 1
+          fi
+
+          TC_REPOS=("cubrid-testcases" "cubrid-testcases-private-ex")
+          BRANCH_NAME="tc/pr-${PR_NUMBER}"
+          OVERALL_PASS=true
+          TC_TEXT_BLOCK=""
+
+          echo "Checking TC PR status for branch '${BRANCH_NAME}' in ${#TC_REPOS[@]} repos..."
+          echo ""
+
+          for TC_REPO in "${TC_REPOS[@]}"; do
+            OPEN_PR=$(gh pr list \
+              --repo "${OWNER}/${TC_REPO}" \
+              --head "${BRANCH_NAME}" \
+              --state open \
+              --json url,isDraft \
+              --jq '.[0] // empty' 2>/dev/null || echo "")
+
+            if [ -z "${OPEN_PR}" ]; then
+              echo "::notice::${TC_REPO}: No open TC PR for '${BRANCH_NAME}' — pass"
+              TC_TEXT_BLOCK+="- ✅ **${TC_REPO}**: No open TC PR (merged, closed, or not created)"$'\n'
+            else
+              IS_DRAFT=$(echo "${OPEN_PR}" | jq -r '.isDraft')
+              URL=$(echo "${OPEN_PR}" | jq -r '.url')
+
+              if [ "${IS_DRAFT}" == "true" ]; then
+                STATE_DISPLAY="open (draft)"
+              else
+                STATE_DISPLAY="open"
+              fi
+
+              echo "::error::${TC_REPO}: TC PR is ${STATE_DISPLAY}: ${URL}"
+              TC_TEXT_BLOCK+="- ❌ **${TC_REPO}**: TC PR [\`${BRANCH_NAME}\`](${URL}) is ${STATE_DISPLAY} — must be merged or closed first"$'\n'
+              OVERALL_PASS=false
+            fi
+          done
+
+          echo ""
+
+          if [ "${OVERALL_PASS}" == "false" ]; then
+            COMMENT_BODY=$(cat <<EOF
+          ## ❌ TC Merge Gate — Merge Blocked
+
+          One or more TC PRs are still open. Please merge or close them before merging this PR.
+
+          **TC Repositories & Branches:**
+          ${TC_TEXT_BLOCK}
+          **Steps to unblock:**
+          1. Merge or close all TC PRs listed above.
+          2. Re-run this check: **Actions tab → TC Merge Gate → Re-run failed jobs**
+          EOF
+            )
+          else
+            COMMENT_BODY=$(cat <<EOF
+          ## ✅ TC Merge Gate — Merge Allowed
+
+          All TC PRs are merged, closed, or not present.
+
+          **TC Repositories & Branches:**
+          ${TC_TEXT_BLOCK}
+          EOF
+            )
+          fi
+
+          COMMENT_ID=$(GH_TOKEN="${GITHUB_TOKEN}" gh api "repos/${ENGINE_REPO}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.user.login=="github-actions[bot]" and (.body | contains("TC Merge Gate"))) | .id' \
+            | tail -n 1 || echo "")
+
+          if [ -n "${COMMENT_ID}" ]; then
+            GH_TOKEN="${GITHUB_TOKEN}" gh api -X PATCH "repos/${ENGINE_REPO}/issues/comments/${COMMENT_ID}" \
+              -f body="${COMMENT_BODY}" > /dev/null
+          else
+            GH_TOKEN="${GITHUB_TOKEN}" gh pr comment "${PR_NUMBER}" --repo "${ENGINE_REPO}" --body "${COMMENT_BODY}"
+          fi
+
+          if [ "${OVERALL_PASS}" == "false" ]; then
+            echo "TC Merge Gate FAILED: One or more TC PRs are still open."
+            exit 1
+          fi
+
+          echo "TC Merge Gate PASSED: All TC PRs are merged, closed, or not present."


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1320?focusedCommentId=4774122&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-4774122

### Purpose

engine PR이 머지될 때 작업 중이던 TC 브랜치(`tc/pr-<N>`)와 TC PR이 자동으로 삭제·close되는 문제를 방지한다.
TC PR이 먼저 처리(merged 또는 closed)되어야만 engine PR을 머지할 수 있도록 Required Status Check를 추가한다.

### Implementation

`.github/workflows/tc-merge-gate.yml` 워크플로우를 새로 추가한다.

**동작 방식**

engine PR이 열리거나 업데이트될 때마다 두 TC 레포(`cubrid-testcases`, `cubrid-testcases-private-ex`)의 `tc/pr-<N>` 브랜치에 대한 오픈 PR 여부를 확인한다.

| TC PR 상태 | 결과 |
|---|---|
| TC PR 없음 (생성 스킵 또는 미생성) | ✅ 통과 |
| TC PR merged 또는 closed | ✅ 통과 |
| TC PR open (draft 포함) | ❌ 실패 — 머지 차단 |

두 레포 모두 통과해야 최종 통과 (AND 조건).

**트리거**
- `pull_request_target`: opened, synchronize, reopened, labeled, ready_for_review (develop, feature/**)
- `workflow_dispatch`: TC PR 처리 후 수동 재실행용 (pr_number 입력)

**PR 코멘트**

체크 결과를 engine PR에 자동 코멘트로 남긴다. 동일 PR에 기존 코멘트가 있으면 업데이트한다.
- ❌ 실패 시: 차단된 TC PR 링크 + 해제 방법 안내
- ✅ 통과 시: 전체 TC PR 상태 요약

### Remarks

이 체크가 실제로 머지를 차단하려면 **Branch Protection Rule** 설정이 필요하다.

```
GitHub → CUBRID/cubrid → Settings → Branches → Branch protection rules
  → develop 규칙 편집 → Require status checks to pass before merging
  → Status check 추가: "TC Merge Gate / Check TC PRs"
```

> **주의**: 워크플로우가 최소 1회 실행된 이후에야 검색창에 나타난다.

TC PR 머지/close 후 재실행: **Actions 탭 → TC Merge Gate → Re-run failed jobs**