### PR TITLE
[CBRD-26695] Fix NUMERIC overflow beyond BIGINT range in ROWNUM key limit optimization

### DIFF
--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -5163,18 +5163,11 @@ fetch_and_coerce_key_limit_lower (THREAD_ENTRY * thread_p, REGU_VARIABLE * key_l
 	    }
 
 	  /* NUMERIC -> BIGINT overflow during arithmetic: find the NUMERIC operand and check its sign */
-	  {
-	    int saved_err = er_errid ();
-	    tmp_dbvalp = fetch_peek_leftmost_numeric_regu (thread_p, key_limit_l, vd);
-	    if (tmp_dbvalp == NULL)
-	      {
-		if (er_errid () != saved_err)
-		  {
-		    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, saved_err, 0);
-		  }
-		return ER_FAILED;
-	      }
-	  }
+	  tmp_dbvalp = fetch_peek_leftmost_numeric_regu (thread_p, key_limit_l, vd);
+	  if (tmp_dbvalp == NULL)
+	    {
+	      return ER_FAILED;
+	    }
 
 	  /* positive overflow: no rows match (DB_BIGINT_MAX); negative overflow: all rows match (0) */
 #if 1				/* phase-3: raw sign-bit check; replaced by DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE in phase-4 */

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -5085,3 +5085,42 @@ fetch_force_not_const_recursive (REGU_VARIABLE & reguvar)
   reguvar.map_regu (map_func);
 }
 // *INDENT-ON*
+
+/*
+ * fetch_find_numeric_leaf () - Recursively search leftptr of an arith tree for the first NUMERIC-typed leaf.
+ *
+ *   return       : peeked DB_VALUE of the NUMERIC leaf, or NULL if not found
+ *   thread_p(in) : thread entry
+ *   regu_var(in) : root of the regu variable arith tree to search
+ *   vd(in)       : value descriptor
+ */
+DB_VALUE *
+fetch_find_numeric_leaf (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR * vd)
+{
+  ARITH_TYPE *arithptr;
+  DB_VALUE *dbvalp;
+
+  if (regu_var == NULL)
+    {
+      return NULL;
+    }
+
+  if (TP_DOMAIN_TYPE (regu_var->domain) == DB_TYPE_NUMERIC)
+    {
+      dbvalp = NULL;
+      if (fetch_peek_dbval (thread_p, regu_var, vd, NULL, NULL, NULL, &dbvalp) == NO_ERROR
+	  && dbvalp != NULL && DB_VALUE_DOMAIN_TYPE (dbvalp) == DB_TYPE_NUMERIC)
+	{
+	  return dbvalp;
+	}
+      return NULL;
+    }
+
+  if (regu_var->type == TYPE_INARITH || regu_var->type == TYPE_OUTARITH)
+    {
+      arithptr = regu_var->value.arithptr;
+      return fetch_find_numeric_leaf (thread_p, arithptr->leftptr, vd);
+    }
+
+  return NULL;
+}

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -55,6 +55,9 @@
 #include "thread_entry.hpp"
 #include "subquery_cache.h"
 #include "pl_executor.hpp"
+#if 1				/* This is a temporary measure to allow the use of the NUMERIC_VALUE_SIGN_BIT_MASK macro in Phase-3. */
+#include "numeric_opfunc.h"
+#endif
 
 #include "dbtype.h"
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
@@ -5087,7 +5090,7 @@ fetch_force_not_const_recursive (REGU_VARIABLE & reguvar)
 // *INDENT-ON*
 
 /*
- * fetch_find_numeric_leaf () - Recursively search leftptr of an arith tree for the first NUMERIC-typed leaf.
+ * fetch_peek_leftmost_numeric_regu () - Recursively search leftptr of an arith tree for the first NUMERIC-typed leaf.
  *
  *   return       : peeked DB_VALUE of the NUMERIC leaf, or NULL if not found
  *   thread_p(in) : thread entry
@@ -5095,7 +5098,7 @@ fetch_force_not_const_recursive (REGU_VARIABLE & reguvar)
  *   vd(in)       : value descriptor
  */
 DB_VALUE *
-fetch_find_numeric_leaf (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR * vd)
+fetch_peek_leftmost_numeric_regu (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR * vd)
 {
   ARITH_TYPE *arithptr;
   DB_VALUE *dbvalp;
@@ -5119,8 +5122,95 @@ fetch_find_numeric_leaf (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_
   if (regu_var->type == TYPE_INARITH || regu_var->type == TYPE_OUTARITH)
     {
       arithptr = regu_var->value.arithptr;
-      return fetch_find_numeric_leaf (thread_p, arithptr->leftptr, vd);
+      return fetch_peek_leftmost_numeric_regu (thread_p, arithptr->leftptr, vd);
     }
 
   return NULL;
+}
+
+/*
+ * fetch_and_coerce_key_limit_lower () - fetch regu variable and coerce to BIGINT,
+ *                                       handling NUMERIC-to-BIGINT overflow for a lower key limit.
+ *
+ *   return          : NO_ERROR or error code
+ *   thread_p (in)   : thread entry
+ *   key_limit_l(in) : regu variable for lower key limit
+ *   vd (in)         : value descriptor
+ *   out_val (out)   : always set to a valid BIGINT on success;
+ *                     DB_BIGINT_MAX on positive overflow (no rows), 0 on negative overflow (all rows)
+ */
+int
+fetch_and_coerce_key_limit_lower (THREAD_ENTRY * thread_p, REGU_VARIABLE * key_limit_l,
+				  VAL_DESCR * vd, DB_VALUE * out_val)
+{
+  TP_DOMAIN *domainp = tp_domain_resolve_default (DB_TYPE_BIGINT);
+  TP_DOMAIN_STATUS dom_status;
+  DB_VALUE *tmp_dbvalp;
+  int error_code;
+
+  assert (key_limit_l != NULL);
+  assert (vd != NULL);
+  assert (out_val != NULL);
+
+  if (key_limit_l->type == TYPE_INARITH)
+    {
+      error_code = fetch_peek_dbval (thread_p, key_limit_l, vd, NULL, NULL, NULL, &tmp_dbvalp);
+      if (error_code != NO_ERROR)
+	{
+	  if (er_errid () != ER_IT_DATA_OVERFLOW && er_errid () != ER_QPROC_OVERFLOW_SUBTRACTION)
+	    {
+	      return ER_FAILED;
+	    }
+
+	  /* NUMERIC -> BIGINT overflow during arithmetic: find the NUMERIC operand and check its sign */
+	  tmp_dbvalp = fetch_peek_leftmost_numeric_regu (thread_p, key_limit_l, vd);
+	  if (tmp_dbvalp == NULL)
+	    {
+	      return ER_FAILED;
+	    }
+
+	  /* positive overflow: no rows match (DB_BIGINT_MAX); negative overflow: all rows match (0) */
+#if 1				/* phase-3: raw sign-bit check; replaced by DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE in phase-4 */
+	  db_make_bigint (out_val, (tmp_dbvalp->data.num.d.buf[0] & NUMERIC_VALUE_SIGN_BIT_MASK) ? 0 : DB_BIGINT_MAX);
+#else
+	  db_make_bigint (out_val, DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE (tmp_dbvalp) ? 0 : DB_BIGINT_MAX);
+#endif
+	  er_clear ();
+	  return NO_ERROR;
+	}
+    }
+  else
+    {
+      if (fetch_peek_dbval (thread_p, key_limit_l, vd, NULL, NULL, NULL, &tmp_dbvalp) != NO_ERROR)
+	{
+	  return ER_FAILED;
+	}
+    }
+
+  /* coerce fetched value to BIGINT */
+  dom_status = tp_value_coerce (tmp_dbvalp, out_val, domainp);
+  if (dom_status != DOMAIN_COMPATIBLE)
+    {
+      if (dom_status == DOMAIN_OVERFLOW && DB_VALUE_DOMAIN_TYPE (tmp_dbvalp) == DB_TYPE_NUMERIC)
+	{
+	  /* positive overflow: no rows match (DB_BIGINT_MAX); negative overflow: all rows match (0) */
+#if 1				/* phase-3: raw sign-bit check; replaced by DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE in phase-4 */
+	  db_make_bigint (out_val, (tmp_dbvalp->data.num.d.buf[0] & NUMERIC_VALUE_SIGN_BIT_MASK) ? 0 : DB_BIGINT_MAX);
+#else
+	  db_make_bigint (out_val, DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE (tmp_dbvalp) ? 0 : DB_BIGINT_MAX);
+#endif
+	  er_clear ();
+	  return NO_ERROR;
+	}
+      (void) tp_domain_status_er_set (dom_status, ARG_FILE_LINE, tmp_dbvalp, domainp);
+      return ER_FAILED;
+    }
+
+  if (DB_VALUE_DOMAIN_TYPE (out_val) != DB_TYPE_BIGINT)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_DATATYPE, 0);
+      return ER_FAILED;
+    }
+
+  return NO_ERROR;
 }

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -5090,9 +5090,9 @@ fetch_force_not_const_recursive (REGU_VARIABLE & reguvar)
 // *INDENT-ON*
 
 /*
- * fetch_peek_leftmost_numeric_regu () - Recursively search leftptr of an arith tree for the first NUMERIC-typed leaf.
+ * fetch_peek_leftmost_numeric_regu () - Recursively search leftptr of an arith tree for the first NUMERIC-typed node.
  *
- *   return       : peeked DB_VALUE of the NUMERIC leaf, or NULL if not found
+ *   return       : peeked DB_VALUE of the NUMERIC node, or NULL if not found
  *   thread_p(in) : thread entry
  *   regu_var(in) : root of the regu variable arith tree to search
  *   vd(in)       : value descriptor
@@ -5163,11 +5163,18 @@ fetch_and_coerce_key_limit_lower (THREAD_ENTRY * thread_p, REGU_VARIABLE * key_l
 	    }
 
 	  /* NUMERIC -> BIGINT overflow during arithmetic: find the NUMERIC operand and check its sign */
-	  tmp_dbvalp = fetch_peek_leftmost_numeric_regu (thread_p, key_limit_l, vd);
-	  if (tmp_dbvalp == NULL)
-	    {
-	      return ER_FAILED;
-	    }
+	  {
+	    int saved_err = er_errid ();
+	    tmp_dbvalp = fetch_peek_leftmost_numeric_regu (thread_p, key_limit_l, vd);
+	    if (tmp_dbvalp == NULL)
+	      {
+		if (er_errid () != saved_err)
+		  {
+		    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, saved_err, 0);
+		  }
+		return ER_FAILED;
+	      }
+	  }
 
 	  /* positive overflow: no rows match (DB_BIGINT_MAX); negative overflow: all rows match (0) */
 #if 1				/* phase-3: raw sign-bit check; replaced by DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE in phase-4 */

--- a/src/query/fetch.h
+++ b/src/query/fetch.h
@@ -46,6 +46,9 @@ extern void fetch_init_val_list (regu_variable_list_node * regu_list);
 
 extern void fetch_force_not_const_recursive (regu_variable_node & reguvar);
 
-extern DB_VALUE *fetch_find_numeric_leaf (THREAD_ENTRY * thread_p, regu_variable_node * regu_var, val_descr * vd);
+extern DB_VALUE *fetch_peek_leftmost_numeric_regu (THREAD_ENTRY * thread_p, regu_variable_node * regu_var,
+						   val_descr * vd);
+extern int fetch_and_coerce_key_limit_lower (THREAD_ENTRY * thread_p, regu_variable_node * key_limit_l, val_descr * vd,
+					     DB_VALUE * out_val);
 
 #endif /* _FETCH_H_ */

--- a/src/query/fetch.h
+++ b/src/query/fetch.h
@@ -46,4 +46,6 @@ extern void fetch_init_val_list (regu_variable_list_node * regu_list);
 
 extern void fetch_force_not_const_recursive (regu_variable_node & reguvar);
 
+extern DB_VALUE *fetch_find_numeric_leaf (THREAD_ENTRY * thread_p, regu_variable_node * regu_var, val_descr * vd);
+
 #endif /* _FETCH_H_ */

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -666,10 +666,8 @@ static int qexec_resolve_domains_for_aggregation (THREAD_ENTRY * thread_p, AGGRE
 						  REGU_VARIABLE_LIST regu_list, int *resolved);
 static int query_multi_range_opt_check_set_sort_col (THREAD_ENTRY * thread_p, XASL_NODE * xasl);
 static ACCESS_SPEC_TYPE *query_multi_range_opt_check_specs (THREAD_ENTRY * thread_p, XASL_NODE * xasl);
-static DB_VALUE *qexec_find_numeric_leaf (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR * vd);
-static int qexec_fetch_and_coerce_instnum_lower (THREAD_ENTRY * thread_p, XASL_NODE * xasl,
-						 XASL_STATE * xasl_state, REGU_VARIABLE * key_limit_l,
-						 DB_VALUE ** out_dbvalp);
+static int qexec_fetch_and_coerce_instnum_lower (THREAD_ENTRY * thread_p, XASL_STATE * xasl_state,
+						 REGU_VARIABLE * key_limit_l, DB_VALUE * out_val);
 static int qexec_init_instnum_val (XASL_NODE * xasl, THREAD_ENTRY * thread_p, XASL_STATE * xasl_state);
 static int qexec_set_class_locks (THREAD_ENTRY * thread_p, XASL_NODE * aptr_list, UPDDEL_CLASS_INFO * query_classes,
 				  int query_classes_count, UPDDEL_CLASS_INFO_INTERNAL * internal_classes);
@@ -14157,44 +14155,6 @@ exit_on_error:
   goto exit;
 }
 
-/*
- * qexec_find_numeric_leaf () - Recursively search leftptr of an arith tree for the first NUMERIC-typed leaf.
- *
- *   return       : peeked DB_VALUE of the NUMERIC leaf, or NULL if not found
- *   thread_p(in) : thread entry
- *   regu_var(in) : root of the regu variable arith tree to search
- *   vd(in)       : value descriptor
- */
-static DB_VALUE *
-qexec_find_numeric_leaf (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR * vd)
-{
-  ARITH_TYPE *arithptr;
-  DB_VALUE *dbvalp;
-
-  if (regu_var == NULL)
-    {
-      return NULL;
-    }
-
-  if (TP_DOMAIN_TYPE (regu_var->domain) == DB_TYPE_NUMERIC)
-    {
-      dbvalp = NULL;
-      if (fetch_peek_dbval (thread_p, regu_var, vd, NULL, NULL, NULL, &dbvalp) == NO_ERROR
-	  && dbvalp != NULL && DB_VALUE_DOMAIN_TYPE (dbvalp) == DB_TYPE_NUMERIC)
-	{
-	  return dbvalp;
-	}
-      return NULL;
-    }
-
-  if (regu_var->type == TYPE_INARITH || regu_var->type == TYPE_OUTARITH)
-    {
-      arithptr = regu_var->value.arithptr;
-      return qexec_find_numeric_leaf (thread_p, arithptr->leftptr, vd);
-    }
-
-  return NULL;
-}
 
 /*
  * qexec_fetch_and_coerce_instnum_lower () - fetch and coerce lower key limit to BIGINT for instnum
@@ -14202,35 +14162,28 @@ qexec_find_numeric_leaf (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_
  *
  *   return          : NO_ERROR or error code
  *   thread_p (in)   : thread entry
- *   xasl (in/out)   : XASL node — instnum_val is set directly on positive overflow (DB_BIGINT_MAX)
  *   xasl_state (in) : XASL state (provides value descriptor)
  *   key_limit_l (in): regu variable for lower key limit
- *   out_dbvalp (out): set to NULL when overflow is handled (instnum_val already set);
- *                     set to the coerced BIGINT DB_VALUE otherwise (caller clones the value)
- *
- * Note: negative overflow means all rows match — instnum_val stays at its initial 0.
- *       positive overflow means no rows match — instnum_val is set to DB_BIGINT_MAX.
+ *   out_val (out)   : always set to a valid BIGINT DB_VALUE on success;
+ *                     DB_BIGINT_MAX on positive overflow (no rows), 0 on negative overflow (all rows)
  */
 static int
-qexec_fetch_and_coerce_instnum_lower (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_state,
-				      REGU_VARIABLE * key_limit_l, DB_VALUE ** out_dbvalp)
+qexec_fetch_and_coerce_instnum_lower (THREAD_ENTRY * thread_p, XASL_STATE * xasl_state,
+				      REGU_VARIABLE * key_limit_l, DB_VALUE * out_val)
 {
   TP_DOMAIN *domainp = tp_domain_resolve_default (DB_TYPE_BIGINT);
   TP_DOMAIN_STATUS dom_status;
   DB_VALUE *tmp_dbvalp;
   int error_code;
 
-  assert (xasl != NULL && xasl->instnum_val != NULL);
   assert (key_limit_l != NULL);
   assert (xasl_state != NULL);
-  assert (out_dbvalp != NULL);
-
-  *out_dbvalp = NULL;
+  assert (out_val != NULL);
 
   if (key_limit_l->type == TYPE_INARITH)
     {
       /* rownum >= N or BETWEEN: arithmetic may overflow when N exceeds BIGINT range */
-      error_code = fetch_peek_dbval (thread_p, key_limit_l, &xasl_state->vd, NULL, NULL, NULL, out_dbvalp);
+      error_code = fetch_peek_dbval (thread_p, key_limit_l, &xasl_state->vd, NULL, NULL, NULL, &tmp_dbvalp);
       if (error_code != NO_ERROR)
 	{
 	  if (er_errid () != ER_IT_DATA_OVERFLOW && er_errid () != ER_QPROC_OVERFLOW_SUBTRACTION)
@@ -14239,56 +14192,44 @@ qexec_fetch_and_coerce_instnum_lower (THREAD_ENTRY * thread_p, XASL_NODE * xasl,
 	    }
 
 	  /* NUMERIC -> BIGINT overflow during arithmetic: find the NUMERIC operand and check its sign */
-	  tmp_dbvalp = qexec_find_numeric_leaf (thread_p, key_limit_l, &xasl_state->vd);
+	  tmp_dbvalp = fetch_find_numeric_leaf (thread_p, key_limit_l, &xasl_state->vd);
 	  if (tmp_dbvalp == NULL)
 	    {
 	      return ER_FAILED;
 	    }
 
-	  /* if positive, returns 0 rows (DB_BIGINT_MAX) 
-	   * if negative, all rows are included (instnum_val is already initialized to 0). 
-	   */
-	  if (!(tmp_dbvalp->data.num.d.buf[0] & NUMERIC_VALUE_SIGN_BIT_MASK))
-	    {
-	      db_make_bigint (xasl->instnum_val, DB_BIGINT_MAX);
-	    }
+	  /* positive overflow: no rows match (DB_BIGINT_MAX); negative overflow: all rows match (0) */
+	  db_make_bigint (out_val, (tmp_dbvalp->data.num.d.buf[0] & NUMERIC_VALUE_SIGN_BIT_MASK) ? 0 : DB_BIGINT_MAX);
 	  er_clear ();
-	  /* overflow handled: *out_dbvalp stays NULL */
 	  return NO_ERROR;
 	}
     }
   else
     {
-      if (fetch_peek_dbval (thread_p, key_limit_l, &xasl_state->vd, NULL, NULL, NULL, out_dbvalp) != NO_ERROR)
+      if (fetch_peek_dbval (thread_p, key_limit_l, &xasl_state->vd, NULL, NULL, NULL, &tmp_dbvalp) != NO_ERROR)
 	{
 	  return ER_FAILED;
 	}
     }
 
   /* coerce fetched value to BIGINT */
-  dom_status = tp_value_coerce (*out_dbvalp, *out_dbvalp, domainp);
+  dom_status = tp_value_coerce (tmp_dbvalp, out_val, domainp);
   if (dom_status != DOMAIN_COMPATIBLE)
     {
-      if (dom_status == DOMAIN_OVERFLOW && DB_VALUE_DOMAIN_TYPE (*out_dbvalp) == DB_TYPE_NUMERIC)
+      if (dom_status == DOMAIN_OVERFLOW && DB_VALUE_DOMAIN_TYPE (tmp_dbvalp) == DB_TYPE_NUMERIC)
 	{
 	  /* NUMERIC -> BIGINT coercion overflow: handle by sign
-	   * if positive, returns 0 rows (DB_BIGINT_MAX) 
-	   * if negative, all rows are included (instnum_val is already initialized to 0)
+	   * positive overflow: no rows match (DB_BIGINT_MAX); negative overflow: all rows match (0)
 	   */
-	  if (!((*out_dbvalp)->data.num.d.buf[0] & NUMERIC_VALUE_SIGN_BIT_MASK))
-	    {
-	      db_make_bigint (xasl->instnum_val, DB_BIGINT_MAX);
-	    }
+	  db_make_bigint (out_val, (tmp_dbvalp->data.num.d.buf[0] & NUMERIC_VALUE_SIGN_BIT_MASK) ? 0 : DB_BIGINT_MAX);
 	  er_clear ();
-	  /* overflow handled: *out_dbvalp stays NULL */
-	  *out_dbvalp = NULL;
 	  return NO_ERROR;
 	}
-      (void) tp_domain_status_er_set (dom_status, ARG_FILE_LINE, *out_dbvalp, domainp);
+      (void) tp_domain_status_er_set (dom_status, ARG_FILE_LINE, tmp_dbvalp, domainp);
       return ER_FAILED;
     }
 
-  if (DB_VALUE_DOMAIN_TYPE (*out_dbvalp) != DB_TYPE_BIGINT)
+  if (DB_VALUE_DOMAIN_TYPE (out_val) != DB_TYPE_BIGINT)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_DATATYPE, 0);
       return ER_FAILED;
@@ -14316,7 +14257,7 @@ static int
 qexec_init_instnum_val (XASL_NODE * xasl, THREAD_ENTRY * thread_p, XASL_STATE * xasl_state)
 {
   REGU_VARIABLE *key_limit_l;
-  DB_VALUE *dbvalp;
+  DB_VALUE dbval;
   int error = NO_ERROR;
 
   assert (xasl && xasl->instnum_val);
@@ -14334,23 +14275,20 @@ qexec_init_instnum_val (XASL_NODE * xasl, THREAD_ENTRY * thread_p, XASL_STATE * 
     {
       key_limit_l = xasl->spec_list->indexptr->key_info.key_limit_l;
 
-      error = qexec_fetch_and_coerce_instnum_lower (thread_p, xasl, xasl_state, key_limit_l, &dbvalp);
+      error = qexec_fetch_and_coerce_instnum_lower (thread_p, xasl_state, key_limit_l, &dbval);
       if (error != NO_ERROR)
 	{
 	  goto exit_on_error;
 	}
 
-      if (dbvalp != NULL)
+      if (pr_clone_value (&dbval, xasl->instnum_val) != NO_ERROR)
 	{
-	  if (pr_clone_value (dbvalp, xasl->instnum_val) != NO_ERROR)
-	    {
-	      goto exit_on_error;
-	    }
+	  goto exit_on_error;
+	}
 
-	  if (xasl->save_instnum_val && pr_clone_value (dbvalp, xasl->save_instnum_val) != NO_ERROR)
-	    {
-	      goto exit_on_error;
-	    }
+      if (xasl->save_instnum_val && pr_clone_value (&dbval, xasl->save_instnum_val) != NO_ERROR)
+	{
+	  goto exit_on_error;
 	}
     }
 

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -14171,71 +14171,7 @@ static int
 qexec_fetch_and_coerce_instnum_lower (THREAD_ENTRY * thread_p, XASL_STATE * xasl_state,
 				      REGU_VARIABLE * key_limit_l, DB_VALUE * out_val)
 {
-  TP_DOMAIN *domainp = tp_domain_resolve_default (DB_TYPE_BIGINT);
-  TP_DOMAIN_STATUS dom_status;
-  DB_VALUE *tmp_dbvalp;
-  int error_code;
-
-  assert (key_limit_l != NULL);
-  assert (xasl_state != NULL);
-  assert (out_val != NULL);
-
-  if (key_limit_l->type == TYPE_INARITH)
-    {
-      /* rownum >= N or BETWEEN: arithmetic may overflow when N exceeds BIGINT range */
-      error_code = fetch_peek_dbval (thread_p, key_limit_l, &xasl_state->vd, NULL, NULL, NULL, &tmp_dbvalp);
-      if (error_code != NO_ERROR)
-	{
-	  if (er_errid () != ER_IT_DATA_OVERFLOW && er_errid () != ER_QPROC_OVERFLOW_SUBTRACTION)
-	    {
-	      return ER_FAILED;
-	    }
-
-	  /* NUMERIC -> BIGINT overflow during arithmetic: find the NUMERIC operand and check its sign */
-	  tmp_dbvalp = fetch_find_numeric_leaf (thread_p, key_limit_l, &xasl_state->vd);
-	  if (tmp_dbvalp == NULL)
-	    {
-	      return ER_FAILED;
-	    }
-
-	  /* positive overflow: no rows match (DB_BIGINT_MAX); negative overflow: all rows match (0) */
-	  db_make_bigint (out_val, (tmp_dbvalp->data.num.d.buf[0] & NUMERIC_VALUE_SIGN_BIT_MASK) ? 0 : DB_BIGINT_MAX);
-	  er_clear ();
-	  return NO_ERROR;
-	}
-    }
-  else
-    {
-      if (fetch_peek_dbval (thread_p, key_limit_l, &xasl_state->vd, NULL, NULL, NULL, &tmp_dbvalp) != NO_ERROR)
-	{
-	  return ER_FAILED;
-	}
-    }
-
-  /* coerce fetched value to BIGINT */
-  dom_status = tp_value_coerce (tmp_dbvalp, out_val, domainp);
-  if (dom_status != DOMAIN_COMPATIBLE)
-    {
-      if (dom_status == DOMAIN_OVERFLOW && DB_VALUE_DOMAIN_TYPE (tmp_dbvalp) == DB_TYPE_NUMERIC)
-	{
-	  /* NUMERIC -> BIGINT coercion overflow: handle by sign
-	   * positive overflow: no rows match (DB_BIGINT_MAX); negative overflow: all rows match (0)
-	   */
-	  db_make_bigint (out_val, (tmp_dbvalp->data.num.d.buf[0] & NUMERIC_VALUE_SIGN_BIT_MASK) ? 0 : DB_BIGINT_MAX);
-	  er_clear ();
-	  return NO_ERROR;
-	}
-      (void) tp_domain_status_er_set (dom_status, ARG_FILE_LINE, tmp_dbvalp, domainp);
-      return ER_FAILED;
-    }
-
-  if (DB_VALUE_DOMAIN_TYPE (out_val) != DB_TYPE_BIGINT)
-    {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_DATATYPE, 0);
-      return ER_FAILED;
-    }
-
-  return NO_ERROR;
+  return fetch_and_coerce_key_limit_lower (thread_p, key_limit_l, &xasl_state->vd, out_val);
 }
 
 /*

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -666,8 +666,6 @@ static int qexec_resolve_domains_for_aggregation (THREAD_ENTRY * thread_p, AGGRE
 						  REGU_VARIABLE_LIST regu_list, int *resolved);
 static int query_multi_range_opt_check_set_sort_col (THREAD_ENTRY * thread_p, XASL_NODE * xasl);
 static ACCESS_SPEC_TYPE *query_multi_range_opt_check_specs (THREAD_ENTRY * thread_p, XASL_NODE * xasl);
-static int qexec_fetch_and_coerce_instnum_lower (THREAD_ENTRY * thread_p, XASL_STATE * xasl_state,
-						 REGU_VARIABLE * key_limit_l, DB_VALUE * out_val);
 static int qexec_init_instnum_val (XASL_NODE * xasl, THREAD_ENTRY * thread_p, XASL_STATE * xasl_state);
 static int qexec_set_class_locks (THREAD_ENTRY * thread_p, XASL_NODE * aptr_list, UPDDEL_CLASS_INFO * query_classes,
 				  int query_classes_count, UPDDEL_CLASS_INFO_INTERNAL * internal_classes);
@@ -14157,24 +14155,6 @@ exit_on_error:
 
 
 /*
- * qexec_fetch_and_coerce_instnum_lower () - fetch and coerce lower key limit to BIGINT for instnum
- *                                           initialization, handling NUMERIC-to-BIGINT overflow.
- *
- *   return          : NO_ERROR or error code
- *   thread_p (in)   : thread entry
- *   xasl_state (in) : XASL state (provides value descriptor)
- *   key_limit_l (in): regu variable for lower key limit
- *   out_val (out)   : always set to a valid BIGINT DB_VALUE on success;
- *                     DB_BIGINT_MAX on positive overflow (no rows), 0 on negative overflow (all rows)
- */
-static int
-qexec_fetch_and_coerce_instnum_lower (THREAD_ENTRY * thread_p, XASL_STATE * xasl_state,
-				      REGU_VARIABLE * key_limit_l, DB_VALUE * out_val)
-{
-  return fetch_and_coerce_key_limit_lower (thread_p, key_limit_l, &xasl_state->vd, out_val);
-}
-
-/*
  * qexec_init_instnum_val () -
  *   return: NO_ERROR, or ER_code
  *   xasl(in)   : XASL Tree pointer
@@ -14211,7 +14191,7 @@ qexec_init_instnum_val (XASL_NODE * xasl, THREAD_ENTRY * thread_p, XASL_STATE * 
     {
       key_limit_l = xasl->spec_list->indexptr->key_info.key_limit_l;
 
-      error = qexec_fetch_and_coerce_instnum_lower (thread_p, xasl_state, key_limit_l, &dbval);
+      error = fetch_and_coerce_key_limit_lower (thread_p, key_limit_l, &xasl_state->vd, &dbval);
       if (error != NO_ERROR)
 	{
 	  goto exit_on_error;

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -666,6 +666,10 @@ static int qexec_resolve_domains_for_aggregation (THREAD_ENTRY * thread_p, AGGRE
 						  REGU_VARIABLE_LIST regu_list, int *resolved);
 static int query_multi_range_opt_check_set_sort_col (THREAD_ENTRY * thread_p, XASL_NODE * xasl);
 static ACCESS_SPEC_TYPE *query_multi_range_opt_check_specs (THREAD_ENTRY * thread_p, XASL_NODE * xasl);
+static DB_VALUE *qexec_find_numeric_leaf (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR * vd);
+static int qexec_fetch_and_coerce_instnum_lower (THREAD_ENTRY * thread_p, XASL_NODE * xasl,
+						 XASL_STATE * xasl_state, REGU_VARIABLE * key_limit_l,
+						 DB_VALUE ** out_dbvalp);
 static int qexec_init_instnum_val (XASL_NODE * xasl, THREAD_ENTRY * thread_p, XASL_STATE * xasl_state);
 static int qexec_set_class_locks (THREAD_ENTRY * thread_p, XASL_NODE * aptr_list, UPDDEL_CLASS_INFO * query_classes,
 				  int query_classes_count, UPDDEL_CLASS_INFO_INTERNAL * internal_classes);
@@ -14154,6 +14158,146 @@ exit_on_error:
 }
 
 /*
+ * qexec_find_numeric_leaf () - Recursively search leftptr of an arith tree for the first NUMERIC-typed leaf.
+ *
+ *   return       : peeked DB_VALUE of the NUMERIC leaf, or NULL if not found
+ *   thread_p(in) : thread entry
+ *   regu_var(in) : root of the regu variable arith tree to search
+ *   vd(in)       : value descriptor
+ */
+static DB_VALUE *
+qexec_find_numeric_leaf (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR * vd)
+{
+  ARITH_TYPE *arithptr;
+  DB_VALUE *dbvalp;
+
+  if (regu_var == NULL)
+    {
+      return NULL;
+    }
+
+  if (TP_DOMAIN_TYPE (regu_var->domain) == DB_TYPE_NUMERIC)
+    {
+      dbvalp = NULL;
+      if (fetch_peek_dbval (thread_p, regu_var, vd, NULL, NULL, NULL, &dbvalp) == NO_ERROR
+	  && dbvalp != NULL && DB_VALUE_DOMAIN_TYPE (dbvalp) == DB_TYPE_NUMERIC)
+	{
+	  return dbvalp;
+	}
+      return NULL;
+    }
+
+  if (regu_var->type == TYPE_INARITH || regu_var->type == TYPE_OUTARITH)
+    {
+      arithptr = regu_var->value.arithptr;
+      return qexec_find_numeric_leaf (thread_p, arithptr->leftptr, vd);
+    }
+
+  return NULL;
+}
+
+/*
+ * qexec_fetch_and_coerce_instnum_lower () - fetch and coerce lower key limit to BIGINT for instnum
+ *                                           initialization, handling NUMERIC-to-BIGINT overflow.
+ *
+ *   return          : NO_ERROR or error code
+ *   thread_p (in)   : thread entry
+ *   xasl (in/out)   : XASL node — instnum_val is set directly on positive overflow (DB_BIGINT_MAX)
+ *   xasl_state (in) : XASL state (provides value descriptor)
+ *   key_limit_l (in): regu variable for lower key limit
+ *   out_dbvalp (out): set to NULL when overflow is handled (instnum_val already set);
+ *                     set to the coerced BIGINT DB_VALUE otherwise (caller clones the value)
+ *
+ * Note: negative overflow means all rows match — instnum_val stays at its initial 0.
+ *       positive overflow means no rows match — instnum_val is set to DB_BIGINT_MAX.
+ */
+static int
+qexec_fetch_and_coerce_instnum_lower (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_state,
+				      REGU_VARIABLE * key_limit_l, DB_VALUE ** out_dbvalp)
+{
+  TP_DOMAIN *domainp = tp_domain_resolve_default (DB_TYPE_BIGINT);
+  TP_DOMAIN_STATUS dom_status;
+  DB_VALUE *tmp_dbvalp;
+  int error_code;
+
+  assert (xasl != NULL && xasl->instnum_val != NULL);
+  assert (key_limit_l != NULL);
+  assert (xasl_state != NULL);
+  assert (out_dbvalp != NULL);
+
+  *out_dbvalp = NULL;
+
+  if (key_limit_l->type == TYPE_INARITH)
+    {
+      /* rownum >= N or BETWEEN: arithmetic may overflow when N exceeds BIGINT range */
+      error_code = fetch_peek_dbval (thread_p, key_limit_l, &xasl_state->vd, NULL, NULL, NULL, out_dbvalp);
+      if (error_code != NO_ERROR)
+	{
+	  if (er_errid () != ER_IT_DATA_OVERFLOW && er_errid () != ER_QPROC_OVERFLOW_SUBTRACTION)
+	    {
+	      return ER_FAILED;
+	    }
+
+	  /* NUMERIC -> BIGINT overflow during arithmetic: find the NUMERIC operand and check its sign */
+	  tmp_dbvalp = qexec_find_numeric_leaf (thread_p, key_limit_l, &xasl_state->vd);
+	  if (tmp_dbvalp == NULL)
+	    {
+	      return ER_FAILED;
+	    }
+
+	  /* if positive, returns 0 rows (DB_BIGINT_MAX) 
+	   * if negative, all rows are included (instnum_val is already initialized to 0). 
+	   */
+	  if (!(tmp_dbvalp->data.num.d.buf[0] & NUMERIC_VALUE_SIGN_BIT_MASK))
+	    {
+	      db_make_bigint (xasl->instnum_val, DB_BIGINT_MAX);
+	    }
+	  er_clear ();
+	  /* overflow handled: *out_dbvalp stays NULL */
+	  return NO_ERROR;
+	}
+    }
+  else
+    {
+      if (fetch_peek_dbval (thread_p, key_limit_l, &xasl_state->vd, NULL, NULL, NULL, out_dbvalp) != NO_ERROR)
+	{
+	  return ER_FAILED;
+	}
+    }
+
+  /* coerce fetched value to BIGINT */
+  dom_status = tp_value_coerce (*out_dbvalp, *out_dbvalp, domainp);
+  if (dom_status != DOMAIN_COMPATIBLE)
+    {
+      if (dom_status == DOMAIN_OVERFLOW && DB_VALUE_DOMAIN_TYPE (*out_dbvalp) == DB_TYPE_NUMERIC)
+	{
+	  /* NUMERIC -> BIGINT coercion overflow: handle by sign
+	   * if positive, returns 0 rows (DB_BIGINT_MAX) 
+	   * if negative, all rows are included (instnum_val is already initialized to 0)
+	   */
+	  if (!((*out_dbvalp)->data.num.d.buf[0] & NUMERIC_VALUE_SIGN_BIT_MASK))
+	    {
+	      db_make_bigint (xasl->instnum_val, DB_BIGINT_MAX);
+	    }
+	  er_clear ();
+	  /* overflow handled: *out_dbvalp stays NULL */
+	  *out_dbvalp = NULL;
+	  return NO_ERROR;
+	}
+      (void) tp_domain_status_er_set (dom_status, ARG_FILE_LINE, *out_dbvalp, domainp);
+      return ER_FAILED;
+    }
+
+  if (DB_VALUE_DOMAIN_TYPE (*out_dbvalp) != DB_TYPE_BIGINT)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_DATATYPE, 0);
+      return ER_FAILED;
+    }
+
+  return NO_ERROR;
+}
+
+/*
  * qexec_init_instnum_val () -
  *   return: NO_ERROR, or ER_code
  *   xasl(in)   : XASL Tree pointer
@@ -14171,12 +14315,9 @@ exit_on_error:
 static int
 qexec_init_instnum_val (XASL_NODE * xasl, THREAD_ENTRY * thread_p, XASL_STATE * xasl_state)
 {
-  TP_DOMAIN *domainp = tp_domain_resolve_default (DB_TYPE_BIGINT);
-  DB_TYPE orig_type;
   REGU_VARIABLE *key_limit_l;
   DB_VALUE *dbvalp;
   int error = NO_ERROR;
-  TP_DOMAIN_STATUS dom_status;
 
   assert (xasl && xasl->instnum_val);
   db_make_bigint (xasl->instnum_val, 0);
@@ -14192,38 +14333,24 @@ qexec_init_instnum_val (XASL_NODE * xasl, THREAD_ENTRY * thread_p, XASL_STATE * 
       && xasl->spec_list->indexptr->key_info.key_limit_l)
     {
       key_limit_l = xasl->spec_list->indexptr->key_info.key_limit_l;
-      if (fetch_peek_dbval (thread_p, key_limit_l, &xasl_state->vd, NULL, NULL, NULL, &dbvalp) != NO_ERROR)
+
+      error = qexec_fetch_and_coerce_instnum_lower (thread_p, xasl, xasl_state, key_limit_l, &dbvalp);
+      if (error != NO_ERROR)
 	{
 	  goto exit_on_error;
 	}
 
-      orig_type = DB_VALUE_DOMAIN_TYPE (dbvalp);
-      if (orig_type != DB_TYPE_BIGINT)
+      if (dbvalp != NULL)
 	{
-	  dom_status = tp_value_coerce (dbvalp, dbvalp, domainp);
-	  if (dom_status != DOMAIN_COMPATIBLE)
+	  if (pr_clone_value (dbvalp, xasl->instnum_val) != NO_ERROR)
 	    {
-	      error = tp_domain_status_er_set (dom_status, ARG_FILE_LINE, dbvalp, domainp);
-	      assert_release (error != NO_ERROR);
-
 	      goto exit_on_error;
 	    }
 
-	  if (DB_VALUE_DOMAIN_TYPE (dbvalp) != DB_TYPE_BIGINT)
+	  if (xasl->save_instnum_val && pr_clone_value (dbvalp, xasl->save_instnum_val) != NO_ERROR)
 	    {
-	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_DATATYPE, 0);
 	      goto exit_on_error;
 	    }
-	}
-
-      if (pr_clone_value (dbvalp, xasl->instnum_val) != NO_ERROR)
-	{
-	  goto exit_on_error;
-	}
-
-      if (xasl->save_instnum_val && pr_clone_value (dbvalp, xasl->save_instnum_val) != NO_ERROR)
-	{
-	  goto exit_on_error;
 	}
     }
 

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -876,16 +876,21 @@ scan_fetch_and_coerce_key_limit_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * i
       error_code = fetch_peek_dbval (thread_p, key_limit_u, vd, NULL, NULL, NULL, out_dbvalp);
       if (error_code != NO_ERROR)
 	{
-	  if (er_errid () == ER_IT_DATA_OVERFLOW)
+	  int saved_err = er_errid ();
+	  if (saved_err == ER_IT_DATA_OVERFLOW)
 	    {
 	      /* ER_IT_DATA_OVERFLOW: NUMERIC value itself exceeds BIGINT range (e.g. BIGINT < rownum < HUGE).
 	       * find the NUMERIC leaf and check sign:
-	       *   positive NUMERIC -> no upper bound (-1), 
-	       *   negative NUMERIC -> no rows match (0). 
+	       *   positive NUMERIC -> no upper bound (-1),
+	       *   negative NUMERIC -> no rows match (0).
 	       */
 	      tmp_dbvalp = fetch_peek_leftmost_numeric_regu (thread_p, key_limit_u, vd);
 	      if (tmp_dbvalp == NULL)
 		{
+		  if (er_errid () != saved_err)
+		    {
+		      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, saved_err, 0);
+		    }
 		  return ER_FAILED;
 		}
 #if 1				/* phase-3: raw sign-bit check; replaced by DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE in phase-4 */
@@ -894,7 +899,7 @@ scan_fetch_and_coerce_key_limit_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * i
 	      isidp->key_limit_upper = DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE (tmp_dbvalp) ? 0 : -1;
 #endif
 	    }
-	  else if (er_errid () == ER_QPROC_OVERFLOW_SUBTRACTION)
+	  else if (saved_err == ER_QPROC_OVERFLOW_SUBTRACTION)
 	    {
 	      /* T_SUB(upper_expr, lower_expr) overflows because a bound contains a huge NUMERIC.
 	       * branch on top-level left/right structure:
@@ -969,6 +974,10 @@ scan_fetch_and_coerce_key_limit_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * i
 		  tmp_dbvalp = fetch_peek_leftmost_numeric_regu (thread_p, left, vd);
 		  if (tmp_dbvalp == NULL)
 		    {
+		      if (er_errid () != saved_err)
+			{
+			  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, saved_err, 0);
+			}
 		      return ER_FAILED;
 		    }
 #if 1				/* phase-3: raw sign-bit check; replaced by DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE in phase-4 */

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -876,8 +876,7 @@ scan_fetch_and_coerce_key_limit_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * i
       error_code = fetch_peek_dbval (thread_p, key_limit_u, vd, NULL, NULL, NULL, out_dbvalp);
       if (error_code != NO_ERROR)
 	{
-	  int saved_err = er_errid ();
-	  if (saved_err == ER_IT_DATA_OVERFLOW)
+	  if (er_errid () == ER_IT_DATA_OVERFLOW)
 	    {
 	      /* ER_IT_DATA_OVERFLOW: NUMERIC value itself exceeds BIGINT range (e.g. BIGINT < rownum < HUGE).
 	       * find the NUMERIC leaf and check sign:
@@ -887,10 +886,6 @@ scan_fetch_and_coerce_key_limit_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * i
 	      tmp_dbvalp = fetch_peek_leftmost_numeric_regu (thread_p, key_limit_u, vd);
 	      if (tmp_dbvalp == NULL)
 		{
-		  if (er_errid () != saved_err)
-		    {
-		      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, saved_err, 0);
-		    }
 		  return ER_FAILED;
 		}
 #if 1				/* phase-3: raw sign-bit check; replaced by DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE in phase-4 */
@@ -899,7 +894,7 @@ scan_fetch_and_coerce_key_limit_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * i
 	      isidp->key_limit_upper = DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE (tmp_dbvalp) ? 0 : -1;
 #endif
 	    }
-	  else if (saved_err == ER_QPROC_OVERFLOW_SUBTRACTION)
+	  else if (er_errid () == ER_QPROC_OVERFLOW_SUBTRACTION)
 	    {
 	      /* T_SUB(upper_expr, lower_expr) overflows because a bound contains a huge NUMERIC.
 	       * branch on top-level left/right structure:
@@ -974,10 +969,6 @@ scan_fetch_and_coerce_key_limit_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * i
 		  tmp_dbvalp = fetch_peek_leftmost_numeric_regu (thread_p, left, vd);
 		  if (tmp_dbvalp == NULL)
 		    {
-		      if (er_errid () != saved_err)
-			{
-			  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, saved_err, 0);
-			}
 		      return ER_FAILED;
 		    }
 #if 1				/* phase-3: raw sign-bit check; replaced by DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE in phase-4 */

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -172,7 +172,6 @@ static int scan_get_index_oidset (THREAD_ENTRY * thread_p, SCAN_ID * s_id, DB_BI
 static void scan_init_scan_id (SCAN_ID * scan_id, bool force_select_lock, SCAN_OPERATION_TYPE scan_op_type, int fixed,
 			       int grouped, QPROC_SINGLE_FETCH single_fetch, DB_VALUE * join_dbval,
 			       val_list_node * val_list, VAL_DESCR * vd);
-static DB_VALUE *scan_find_numeric_leaf (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR * vd);
 static int scan_fetch_and_coerce_key_limit_lower (THREAD_ENTRY * thread_p, INDX_SCAN_ID * isidp,
 						  REGU_VARIABLE * key_limit_l, VAL_DESCR * vd, DB_VALUE ** out_dbvalp);
 static int scan_fetch_and_coerce_key_limit_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * isidp,
@@ -809,44 +808,6 @@ exit_on_error:
   return err;
 }
 
-/*
- * scan_find_numeric_leaf () - Recursively search leftptr of an arith tree for the first NUMERIC-typed leaf.
- *
- *   return       : peeked DB_VALUE of the NUMERIC leaf, or NULL if not found
- *   thread_p(in) : thread entry
- *   regu_var(in) : root of the regu variable arith tree to search
- *   vd(in)       : value descriptor
- */
-static DB_VALUE *
-scan_find_numeric_leaf (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR * vd)
-{
-  ARITH_TYPE *arithptr;
-  DB_VALUE *dbvalp;
-
-  if (regu_var == NULL)
-    {
-      return NULL;
-    }
-
-  if (TP_DOMAIN_TYPE (regu_var->domain) == DB_TYPE_NUMERIC)
-    {
-      dbvalp = NULL;
-      if (fetch_peek_dbval (thread_p, regu_var, vd, NULL, NULL, NULL, &dbvalp) == NO_ERROR
-	  && dbvalp != NULL && DB_VALUE_DOMAIN_TYPE (dbvalp) == DB_TYPE_NUMERIC)
-	{
-	  return dbvalp;
-	}
-      return NULL;
-    }
-
-  if (regu_var->type == TYPE_INARITH || regu_var->type == TYPE_OUTARITH)
-    {
-      arithptr = regu_var->value.arithptr;
-      return scan_find_numeric_leaf (thread_p, arithptr->leftptr, vd);
-    }
-
-  return NULL;
-}
 
 /*
  * scan_fetch_and_coerce_key_limit_lower () - fetch and coerce lower key limit to BIGINT,
@@ -891,7 +852,7 @@ scan_fetch_and_coerce_key_limit_lower (THREAD_ENTRY * thread_p, INDX_SCAN_ID * i
 	    }
 
 	  /* NUMERIC -> BIGINT overflow during arithmetic: find the NUMERIC operand and check its sign */
-	  tmp_dbvalp = scan_find_numeric_leaf (thread_p, key_limit_l, vd);
+	  tmp_dbvalp = fetch_find_numeric_leaf (thread_p, key_limit_l, vd);
 	  if (tmp_dbvalp == NULL)
 	    {
 	      return ER_FAILED;
@@ -989,7 +950,7 @@ scan_fetch_and_coerce_key_limit_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * i
 	       *   positive NUMERIC -> no upper bound (-1), 
 	       *   negative NUMERIC -> no rows match (0). 
 	       */
-	      tmp_dbvalp = scan_find_numeric_leaf (thread_p, key_limit_u, vd);
+	      tmp_dbvalp = fetch_find_numeric_leaf (thread_p, key_limit_u, vd);
 	      if (tmp_dbvalp == NULL)
 		{
 		  return ER_FAILED;
@@ -1016,6 +977,8 @@ scan_fetch_and_coerce_key_limit_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * i
 	      ARITH_TYPE *arithptr = key_limit_u->value.arithptr;
 	      REGU_VARIABLE *left = arithptr->leftptr;
 	      REGU_VARIABLE *right = arithptr->rightptr;
+	      assert (left && right);
+
 	      bool left_is_inarith = (left->type == TYPE_INARITH || left->type == TYPE_OUTARITH);
 	      bool left_is_numeric = (TP_DOMAIN_TYPE (left->domain) == DB_TYPE_NUMERIC);
 
@@ -1029,22 +992,26 @@ scan_fetch_and_coerce_key_limit_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * i
 		      /* case1 */
 		      isidp->key_limit_upper = db_get_bigint (tmp_dbvalp);
 		    }
-		  else
+		  else if (er_errid () == ER_IT_DATA_OVERFLOW || er_errid () == ER_QPROC_OVERFLOW_SUBTRACTION)
 		    {
 		      /* case3 */
 		      er_clear ();
-		      tmp_dbvalp = scan_find_numeric_leaf (thread_p, left, vd);
+		      tmp_dbvalp = fetch_find_numeric_leaf (thread_p, left, vd);
 		      if (tmp_dbvalp == NULL)
 			{
 			  return ER_FAILED;
 			}
 		      isidp->key_limit_upper = (tmp_dbvalp->data.num.d.buf[0] & NUMERIC_VALUE_SIGN_BIT_MASK) ? 0 : -1;
 		    }
+		  else
+		    {
+		      return ER_FAILED;
+		    }
 		}
 	      else if (left_is_numeric)
 		{
 		  /* case4 */
-		  tmp_dbvalp = scan_find_numeric_leaf (thread_p, left, vd);
+		  tmp_dbvalp = fetch_find_numeric_leaf (thread_p, left, vd);
 		  if (tmp_dbvalp == NULL)
 		    {
 		      return ER_FAILED;

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -927,7 +927,21 @@ scan_fetch_and_coerce_key_limit_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * i
 		      && tmp_dbvalp != NULL)
 		    {
 		      /* case1 */
-		      isidp->key_limit_upper = db_get_bigint (tmp_dbvalp);
+		      switch (DB_VALUE_DOMAIN_TYPE (tmp_dbvalp))
+			{
+			case DB_TYPE_BIGINT:
+			  isidp->key_limit_upper = db_get_bigint (tmp_dbvalp);
+			  break;
+			case DB_TYPE_INTEGER:
+			  isidp->key_limit_upper = db_get_int (tmp_dbvalp);
+			  break;
+			case DB_TYPE_SHORT:
+			  isidp->key_limit_upper = db_get_short (tmp_dbvalp);
+			  break;
+			default:
+			  assert (false);
+			  return ER_FAILED;
+			}
 		    }
 		  else if (er_errid () == ER_IT_DATA_OVERFLOW || er_errid () == ER_QPROC_OVERFLOW_SUBTRACTION)
 		    {
@@ -973,9 +987,22 @@ scan_fetch_and_coerce_key_limit_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * i
 		    {
 		      return ER_FAILED;
 		    }
-		  isidp->key_limit_upper =
-		    (DB_VALUE_DOMAIN_TYPE (tmp_dbvalp) ==
-		     DB_TYPE_BIGINT) ? db_get_bigint (tmp_dbvalp) : db_get_int (tmp_dbvalp);
+
+		  switch (DB_VALUE_DOMAIN_TYPE (tmp_dbvalp))
+		    {
+		    case DB_TYPE_BIGINT:
+		      isidp->key_limit_upper = db_get_bigint (tmp_dbvalp);
+		      break;
+		    case DB_TYPE_INTEGER:
+		      isidp->key_limit_upper = db_get_int (tmp_dbvalp);
+		      break;
+		    case DB_TYPE_SHORT:
+		      isidp->key_limit_upper = db_get_short (tmp_dbvalp);
+		      break;
+		    default:
+		      assert (false);
+		      return ER_FAILED;
+		    }
 		}
 	    }
 	  else

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -881,6 +881,7 @@ scan_check_user_given_keylimit_overflow (THREAD_ENTRY * thread_p, REGU_VARIABLE 
 {
   DB_VALUE *dbvalp = NULL;
 
+  assert (numeric_operand != NULL);
   assert (TP_DOMAIN_TYPE (numeric_operand->domain) == DB_TYPE_NUMERIC);
 
   if (fetch_peek_dbval (thread_p, numeric_operand, vd, NULL, NULL, NULL, &dbvalp) != NO_ERROR || dbvalp == NULL)
@@ -923,9 +924,13 @@ scan_handle_it_data_overflow_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * isid
 {
   DB_VALUE *tmp_dbvalp;
 
+  assert (key_limit_u != NULL);
+  assert (key_limit_u->value.arithptr != NULL);
+
   if (is_user_given_keylimit)
     {
       /* rownum <= -HUGE USING INDEX .. KEYLIMIT BIGINT or HUGE */
+      assert (key_limit_u->value.arithptr->rightptr != NULL);
       int error_code = scan_check_user_given_keylimit_overflow (thread_p,
 								key_limit_u->value.arithptr->rightptr, vd);
       if (error_code != NO_ERROR)
@@ -978,14 +983,20 @@ static int
 scan_handle_overflow_subtraction_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * isidp, REGU_VARIABLE * key_limit_u,
 					VAL_DESCR * vd, bool is_user_given_keylimit)
 {
-  ARITH_TYPE *arithptr = key_limit_u->value.arithptr;
-  REGU_VARIABLE *left = arithptr->leftptr;
-  REGU_VARIABLE *right = arithptr->rightptr;
+  ARITH_TYPE *arithptr;
+  REGU_VARIABLE *left;
+  REGU_VARIABLE *right;
   DB_VALUE *tmp_dbvalp;
   int error_code;
   bool left_is_inarith;
   bool left_is_numeric;
 
+  assert (key_limit_u != NULL);
+  assert (key_limit_u->value.arithptr != NULL);
+
+  arithptr = key_limit_u->value.arithptr;
+  left = arithptr->leftptr;
+  right = arithptr->rightptr;
   assert (left && right);
 
   left_is_inarith = (left->type == TYPE_INARITH || left->type == TYPE_OUTARITH);

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -173,7 +173,7 @@ static void scan_init_scan_id (SCAN_ID * scan_id, bool force_select_lock, SCAN_O
 			       int grouped, QPROC_SINGLE_FETCH single_fetch, DB_VALUE * join_dbval,
 			       val_list_node * val_list, VAL_DESCR * vd);
 static int scan_fetch_and_coerce_key_limit_lower (THREAD_ENTRY * thread_p, INDX_SCAN_ID * isidp,
-						  REGU_VARIABLE * key_limit_l, VAL_DESCR * vd, DB_VALUE ** out_dbvalp);
+						  REGU_VARIABLE * key_limit_l, VAL_DESCR * vd);
 static int scan_fetch_and_coerce_key_limit_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * isidp,
 						  REGU_VARIABLE * key_limit_u, VAL_DESCR * vd, DB_VALUE ** out_dbvalp);
 static int scan_init_index_key_limit (THREAD_ENTRY * thread_p, INDX_SCAN_ID * isidp, KEY_INFO * key_infop,
@@ -815,91 +815,24 @@ exit_on_error:
  *
  *   return         : NO_ERROR or error code
  *   thread_p (in)  : thread entry
- *   isidp (out)    : index scan id — key_limit_lower is set directly on overflow
+ *   isidp (out)    : index scan id — key_limit_lower is set on success
  *   key_limit_l(in): regu variable for lower key limit
  *   vd (in)        : value descriptor
- *   out_dbvalp(out): set to NULL when overflow is handled (key_limit_lower already set);
- *                    set to the coerced BIGINT DB_VALUE otherwise (caller reads the value)
- *
- * Note: overflow sign semantics for lower limit are the opposite of upper:
- *   positive overflow → no rows match (DB_BIGINT_MAX), negative overflow → all rows match (0).
  */
 static int
 scan_fetch_and_coerce_key_limit_lower (THREAD_ENTRY * thread_p, INDX_SCAN_ID * isidp, REGU_VARIABLE * key_limit_l,
-				       VAL_DESCR * vd, DB_VALUE ** out_dbvalp)
+				       VAL_DESCR * vd)
 {
-  TP_DOMAIN *domainp = tp_domain_resolve_default (DB_TYPE_BIGINT);
-  TP_DOMAIN_STATUS dom_status;
-  DB_VALUE *tmp_dbvalp;
+  DB_VALUE out_val;
   int error_code;
 
-  assert (isidp != NULL);
-  assert (key_limit_l != NULL);
-  assert (vd != NULL);
-  assert (out_dbvalp != NULL);
-
-  *out_dbvalp = NULL;
-
-  if (key_limit_l->type == TYPE_INARITH)
+  error_code = fetch_and_coerce_key_limit_lower (thread_p, key_limit_l, vd, &out_val);
+  if (error_code != NO_ERROR)
     {
-      /* rownum > N or rownum >= N or BETWEEN */
-      error_code = fetch_peek_dbval (thread_p, key_limit_l, vd, NULL, NULL, NULL, out_dbvalp);
-      if (error_code != NO_ERROR)
-	{
-	  if (er_errid () != ER_IT_DATA_OVERFLOW && er_errid () != ER_QPROC_OVERFLOW_SUBTRACTION)
-	    {
-	      return ER_FAILED;
-	    }
-
-	  /* NUMERIC -> BIGINT overflow during arithmetic: find the NUMERIC operand and check its sign */
-	  tmp_dbvalp = fetch_find_numeric_leaf (thread_p, key_limit_l, vd);
-	  if (tmp_dbvalp == NULL)
-	    {
-	      return ER_FAILED;
-	    }
-
-	  /* if negative, all rows are returned (full scan from the beginning) 
-	   * if positive, returns 0 rows. */
-	  isidp->key_limit_lower = (tmp_dbvalp->data.num.d.buf[0] & NUMERIC_VALUE_SIGN_BIT_MASK) ? 0 : DB_BIGINT_MAX;
-	  er_clear ();
-	  /* overflow handled: *out_dbvalp stays NULL */
-	  return NO_ERROR;
-	}
-    }
-  else
-    {
-      if (fetch_peek_dbval (thread_p, key_limit_l, vd, NULL, NULL, NULL, out_dbvalp) != NO_ERROR)
-	{
-	  return ER_FAILED;
-	}
+      return error_code;
     }
 
-  /* coerce fetched value to BIGINT */
-  dom_status = tp_value_coerce (*out_dbvalp, *out_dbvalp, domainp);
-  if (dom_status != DOMAIN_COMPATIBLE)
-    {
-      if (dom_status == DOMAIN_OVERFLOW && DB_VALUE_DOMAIN_TYPE (*out_dbvalp) == DB_TYPE_NUMERIC)
-	{
-	  /* NUMERIC → BIGINT coercion overflow: handle by sign
-	   * if negative, all rows are returned (full scan from the beginning) 
-	   * if positive, returns 0 rows. 
-	   */
-	  isidp->key_limit_lower = ((*out_dbvalp)->data.num.d.buf[0] & NUMERIC_VALUE_SIGN_BIT_MASK) ? 0 : DB_BIGINT_MAX;
-	  er_clear ();
-	  /* overflow handled: *out_dbvalp stays NULL */
-	  *out_dbvalp = NULL;
-	  return NO_ERROR;
-	}
-      (void) tp_domain_status_er_set (dom_status, ARG_FILE_LINE, *out_dbvalp, domainp);
-      return ER_FAILED;
-    }
-
-  if (DB_VALUE_DOMAIN_TYPE (*out_dbvalp) != DB_TYPE_BIGINT)
-    {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_DATATYPE, 0);
-      return ER_QPROC_INVALID_DATATYPE;
-    }
-
+  isidp->key_limit_lower = db_get_bigint (&out_val);
   return NO_ERROR;
 }
 
@@ -950,12 +883,16 @@ scan_fetch_and_coerce_key_limit_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * i
 	       *   positive NUMERIC -> no upper bound (-1), 
 	       *   negative NUMERIC -> no rows match (0). 
 	       */
-	      tmp_dbvalp = fetch_find_numeric_leaf (thread_p, key_limit_u, vd);
+	      tmp_dbvalp = fetch_peek_leftmost_numeric_regu (thread_p, key_limit_u, vd);
 	      if (tmp_dbvalp == NULL)
 		{
 		  return ER_FAILED;
 		}
+#if 1				/* phase-3: raw sign-bit check; replaced by DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE in phase-4 */
 	      isidp->key_limit_upper = (tmp_dbvalp->data.num.d.buf[0] & NUMERIC_VALUE_SIGN_BIT_MASK) ? 0 : -1;
+#else
+	      isidp->key_limit_upper = DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE (tmp_dbvalp) ? 0 : -1;
+#endif
 	    }
 	  else if (er_errid () == ER_QPROC_OVERFLOW_SUBTRACTION)
 	    {
@@ -996,12 +933,16 @@ scan_fetch_and_coerce_key_limit_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * i
 		    {
 		      /* case3 */
 		      er_clear ();
-		      tmp_dbvalp = fetch_find_numeric_leaf (thread_p, left, vd);
+		      tmp_dbvalp = fetch_peek_leftmost_numeric_regu (thread_p, left, vd);
 		      if (tmp_dbvalp == NULL)
 			{
 			  return ER_FAILED;
 			}
+#if 1				/* phase-3: raw sign-bit check; replaced by DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE in phase-4 */
 		      isidp->key_limit_upper = (tmp_dbvalp->data.num.d.buf[0] & NUMERIC_VALUE_SIGN_BIT_MASK) ? 0 : -1;
+#else
+		      isidp->key_limit_upper = DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE (tmp_dbvalp) ? 0 : -1;
+#endif
 		    }
 		  else
 		    {
@@ -1011,12 +952,16 @@ scan_fetch_and_coerce_key_limit_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * i
 	      else if (left_is_numeric)
 		{
 		  /* case4 */
-		  tmp_dbvalp = fetch_find_numeric_leaf (thread_p, left, vd);
+		  tmp_dbvalp = fetch_peek_leftmost_numeric_regu (thread_p, left, vd);
 		  if (tmp_dbvalp == NULL)
 		    {
 		      return ER_FAILED;
 		    }
+#if 1				/* phase-3: raw sign-bit check; replaced by DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE in phase-4 */
 		  isidp->key_limit_upper = (tmp_dbvalp->data.num.d.buf[0] & NUMERIC_VALUE_SIGN_BIT_MASK) ? 0 : -1;
+#else
+		  isidp->key_limit_upper = DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE (tmp_dbvalp) ? 0 : -1;
+#endif
 		}
 	      else
 		{
@@ -1060,7 +1005,11 @@ scan_fetch_and_coerce_key_limit_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * i
 	   * if negative, all rows are returned (full scan from the beginning) 
 	   * if positive, returns 0 rows. 
 	   */
+#if 1				/* phase-3: raw sign-bit check; replaced by DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE in phase-4 */
 	  isidp->key_limit_upper = ((*out_dbvalp)->data.num.d.buf[0] & NUMERIC_VALUE_SIGN_BIT_MASK) ? 0 : -1;
+#else
+	  isidp->key_limit_upper = DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE ((*out_dbvalp)) ? 0 : -1;
+#endif
 	  er_clear ();
 	  /* overflow handled: *out_dbvalp stays NULL */
 	  *out_dbvalp = NULL;
@@ -1086,40 +1035,34 @@ scan_fetch_and_coerce_key_limit_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * i
 static int
 scan_init_index_key_limit (THREAD_ENTRY * thread_p, INDX_SCAN_ID * isidp, KEY_INFO * key_infop, VAL_DESCR * vd)
 {
-  DB_VALUE *dbvalp;
   bool is_lower_limit_negative = false;
   int error_code;
 
   if (key_infop->key_limit_l != NULL)
     {
-      error_code = scan_fetch_and_coerce_key_limit_lower (thread_p, isidp, key_infop->key_limit_l, vd, &dbvalp);
+      error_code = scan_fetch_and_coerce_key_limit_lower (thread_p, isidp, key_infop->key_limit_l, vd);
       if (error_code != NO_ERROR)
 	{
 	  return error_code;
 	}
 
-      if (dbvalp != NULL)
+      if (isidp->key_limit_lower < 0)
 	{
-	  isidp->key_limit_lower = db_get_bigint (dbvalp);
-
-	  if (isidp->key_limit_lower < 0)
+	  if (key_infop->is_user_given_keylimit == true)
 	    {
-	      if (key_infop->is_user_given_keylimit == true)
-		{
-		  /* We don't allow users to give us a bad keylimit bound */
-		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_PARAMETER, 0);
-		  return ER_QPROC_INVALID_PARAMETER;
-		}
-
-	      /* SELECT * from t where ROWNUM = 0 order by a: this would sometimes get optimized using keylimit, if the
-	       * circumstances are right. in this case, the lower limit would be "0-1", effectiveley -1. We cannot allow
-	       * that to happen, since -1 is a special value meaning "there is no lower limit", and certain critical
-	       * decisions (such as resetting the key limit for multiple ranges) depend on knowing whether or not there is
-	       * a lower key limit. We set a flag to remember, later on, to "adjust" the key limits such that, if the lower
-	       * limit is negative, to return no results.
-	       */
-	      is_lower_limit_negative = true;
+	      /* We don't allow users to give us a bad keylimit bound */
+	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_PARAMETER, 0);
+	      return ER_QPROC_INVALID_PARAMETER;
 	    }
+
+	  /* SELECT * from t where ROWNUM = 0 order by a: this would sometimes get optimized using keylimit, if the
+	   * circumstances are right. in this case, the lower limit would be "0-1", effectiveley -1. We cannot allow
+	   * that to happen, since -1 is a special value meaning "there is no lower limit", and certain critical
+	   * decisions (such as resetting the key limit for multiple ranges) depend on knowing whether or not there is
+	   * a lower key limit. We set a flag to remember, later on, to "adjust" the key limits such that, if the lower
+	   * limit is negative, to return no results.
+	   */
+	  is_lower_limit_negative = true;
 	}
     }
   else
@@ -1129,6 +1072,7 @@ scan_init_index_key_limit (THREAD_ENTRY * thread_p, INDX_SCAN_ID * isidp, KEY_IN
 
   if (key_infop->key_limit_u != NULL)
     {
+      DB_VALUE *dbvalp;
       error_code = scan_fetch_and_coerce_key_limit_upper (thread_p, isidp, key_infop->key_limit_u, vd, &dbvalp);
       if (error_code != NO_ERROR)
 	{

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -1048,9 +1048,11 @@ scan_handle_overflow_subtraction_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * 
   else if (left_is_numeric)
     {
       /* case4 */
+      assert (right->type == TYPE_INARITH || right->type == TYPE_OUTARITH);
       if (is_user_given_keylimit)
 	{
 	  /* rownum < -HUGE USING INDEX .. KEYLIMIT HUGE */
+	  assert (right->value.arithptr != NULL && right->value.arithptr->leftptr != NULL);
 	  error_code = scan_check_user_given_keylimit_overflow (thread_p, right->value.arithptr->leftptr, vd);
 	  if (error_code != NO_ERROR)
 	    {
@@ -1077,6 +1079,7 @@ scan_handle_overflow_subtraction_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * 
       if (is_user_given_keylimit)
 	{
 	  /* rownum < -HUGE USING INDEX .. KEYLIMIT BIGINT */
+	  assert (right->value.arithptr != NULL && right->value.arithptr->leftptr != NULL);
 	  error_code = scan_check_user_given_keylimit_overflow (thread_p, right->value.arithptr->leftptr, vd);
 	  if (error_code != NO_ERROR)
 	    {

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -174,8 +174,17 @@ static void scan_init_scan_id (SCAN_ID * scan_id, bool force_select_lock, SCAN_O
 			       val_list_node * val_list, VAL_DESCR * vd);
 static int scan_fetch_and_coerce_key_limit_lower (THREAD_ENTRY * thread_p, INDX_SCAN_ID * isidp,
 						  REGU_VARIABLE * key_limit_l, VAL_DESCR * vd);
+static int scan_check_user_given_keylimit_overflow (THREAD_ENTRY * thread_p, REGU_VARIABLE * numeric_operand,
+						    VAL_DESCR * vd);
+static int scan_handle_it_data_overflow_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * isidp,
+					       REGU_VARIABLE * key_limit_u, VAL_DESCR * vd,
+					       bool is_user_given_keylimit);
+static int scan_handle_overflow_subtraction_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * isidp,
+						   REGU_VARIABLE * key_limit_u, VAL_DESCR * vd,
+						   bool is_user_given_keylimit);
 static int scan_fetch_and_coerce_key_limit_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * isidp,
-						  REGU_VARIABLE * key_limit_u, VAL_DESCR * vd, DB_VALUE ** out_dbvalp);
+						  REGU_VARIABLE * key_limit_u, VAL_DESCR * vd, DB_VALUE ** out_dbvalp,
+						  bool is_user_given_keylimit);
 static int scan_init_index_key_limit (THREAD_ENTRY * thread_p, INDX_SCAN_ID * isidp, KEY_INFO * key_infop,
 				      VAL_DESCR * vd);
 static SCAN_CODE scan_next_scan_local (THREAD_ENTRY * thread_p, SCAN_ID * scan_id);
@@ -808,7 +817,6 @@ exit_on_error:
   return err;
 }
 
-
 /*
  * scan_fetch_and_coerce_key_limit_lower () - fetch and coerce lower key limit to BIGINT,
  *                                            handling NUMERIC-to-BIGINT overflow.
@@ -837,6 +845,259 @@ scan_fetch_and_coerce_key_limit_lower (THREAD_ENTRY * thread_p, INDX_SCAN_ID * i
 }
 
 /*
+ * scan_check_user_given_keylimit_overflow () - reject a merged user-given KEYLIMIT
+ *   when the rownum-derived NUMERIC bound is negative.
+ *
+ *   return               : NO_ERROR if the NUMERIC operand is non-negative;
+ *                          ER_QPROC_INVALID_PARAMETER if negative;
+ *                          ER_FAILED on fetch failure or non-NUMERIC value
+ *   thread_p (in)        : thread entry
+ *   numeric_operand (in) : NUMERIC regu variable inside the merged T_LEAST tree —
+ *                          the rownum-derived bound paired with the user KEYLIMIT
+ *   vd (in)              : value descriptor
+ *
+ * Rationale:
+ *   A BIGINT-range negative rownum bound combined with a user KEYLIMIT, e.g.
+ *       SELECT ... USING INDEX i KEYLIMIT <bigint>
+ *       WHERE  ... rownum <  -<bigint>          -- or rownum <= -<bigint>
+ *   is already rejected with ER_QPROC_INVALID_PARAMETER at
+ *   scan_init_index_key_limit:1175-1188, because the merged upper bound resolves
+ *   to a negative BIGINT and is treated as a bad keylimit bound.
+ *
+ *   The NUMERIC-overflow form, e.g.
+ *       SELECT ... USING INDEX i KEYLIMIT <bigint or numeric>
+ *       WHERE  ... rownum <  -<huge NUMERIC>    -- or rownum <= -<huge NUMERIC>
+ *   carries the same user intent (an unsatisfiable upper bound), but the merged
+ *   T_LEAST overflows during BIGINT coercion before reaching that check. Without
+ *   this helper, the upper-bound resolver in case2 / case4 / the R_LE branch would
+ *   adopt the user KEYLIMIT and silently return rows. To keep both paths
+ *   consistent, we apply the same negative-bound rejection policy here.
+ *
+ *   Positive NUMERIC overflows fall through (return NO_ERROR); the caller then
+ *   handles the positive case (adopt left, leftmost sign-clamp, etc.).
+ */
+static int
+scan_check_user_given_keylimit_overflow (THREAD_ENTRY * thread_p, REGU_VARIABLE * numeric_operand, VAL_DESCR * vd)
+{
+  DB_VALUE *dbvalp = NULL;
+
+  assert (TP_DOMAIN_TYPE (numeric_operand->domain) == DB_TYPE_NUMERIC);
+
+  if (fetch_peek_dbval (thread_p, numeric_operand, vd, NULL, NULL, NULL, &dbvalp) != NO_ERROR || dbvalp == NULL)
+    {
+      return ER_FAILED;
+    }
+#if 1				/* phase-3: raw sign-bit check; replaced by DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE in phase-4 */
+  if (dbvalp->data.num.d.buf[0] & NUMERIC_VALUE_SIGN_BIT_MASK)
+#else
+  if (DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE (dbvalp))
+#endif
+    {
+      /* We don't allow users to give us a bad keylimit bound */
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_PARAMETER, 0);
+      return ER_QPROC_INVALID_PARAMETER;
+    }
+  return NO_ERROR;
+}
+
+/*
+ * scan_handle_it_data_overflow_upper () - handle ER_IT_DATA_OVERFLOW for the upper key limit.
+ *
+ *   return                       : NO_ERROR or error code; on success isidp->key_limit_upper is set.
+ *   thread_p (in)                : thread entry
+ *   isidp (out)                  : index scan id — key_limit_upper set on success
+ *   key_limit_u (in)             : regu variable for upper key limit (TYPE_INARITH)
+ *   vd (in)                      : value descriptor
+ *   is_user_given_keylimit (in)  : true if a user KEYLIMIT hint was merged in
+ *
+ * Note: ER_IT_DATA_OVERFLOW means a NUMERIC value itself exceeds BIGINT range
+ *   (e.g. BIGINT < rownum < HUGE). The leftmost NUMERIC leaf's sign decides the bound:
+ *     positive NUMERIC -> no upper bound (-1; full scan),
+ *     negative NUMERIC -> no rows match (0).
+ *   When merged with a user-given KEYLIMIT, a negative NUMERIC is rejected
+ *   (see scan_check_user_given_keylimit_overflow ()).
+ */
+static int
+scan_handle_it_data_overflow_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * isidp, REGU_VARIABLE * key_limit_u,
+				    VAL_DESCR * vd, bool is_user_given_keylimit)
+{
+  DB_VALUE *tmp_dbvalp;
+
+  if (is_user_given_keylimit)
+    {
+      /* rownum <= -HUGE USING INDEX .. KEYLIMIT BIGINT or HUGE */
+      int error_code = scan_check_user_given_keylimit_overflow (thread_p,
+								key_limit_u->value.arithptr->rightptr, vd);
+      if (error_code != NO_ERROR)
+	{
+	  return error_code;
+	}
+    }
+
+  tmp_dbvalp = fetch_peek_leftmost_numeric_regu (thread_p, key_limit_u, vd);
+  if (tmp_dbvalp == NULL)
+    {
+      return ER_FAILED;
+    }
+#if 1				/* phase-3: raw sign-bit check; replaced by DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE in phase-4 */
+  isidp->key_limit_upper = (tmp_dbvalp->data.num.d.buf[0] & NUMERIC_VALUE_SIGN_BIT_MASK) ? 0 : -1;
+#else
+  isidp->key_limit_upper = DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE (tmp_dbvalp) ? 0 : -1;
+#endif
+  return NO_ERROR;
+}
+
+/*
+ * scan_handle_overflow_subtraction_upper () - handle ER_QPROC_OVERFLOW_SUBTRACTION for the upper key limit.
+ *
+ *   return                       : NO_ERROR or error code; on success isidp->key_limit_upper is set.
+ *   thread_p (in)                : thread entry
+ *   isidp (out)                  : index scan id — key_limit_upper set on success
+ *   key_limit_u (in)             : regu variable for upper key limit (TYPE_INARITH, T_SUB or merged T_LEAST)
+ *   vd (in)                      : value descriptor
+ *   is_user_given_keylimit (in)  : true if a user KEYLIMIT hint was merged in
+ *
+ * Note: T_SUB(upper_expr, lower_expr) overflows because a bound contains a huge NUMERIC.
+ *   Branch on the top-level left/right structure:
+ *     case1: -HUGE < rownum < 5 -> fetch left (BIGINT upper bound)
+ *            - left=INARITH[bigint](int,int)
+ *            - right=POS_VALUE[numeric]
+ *     case2: rownum BETWEEN -HUGE AND 5 -> fetch left (INT/BIGINT upper bound)
+ *            - left=POS_VALUE[int|bigint]
+ *            - right=INARITH[bigint]
+ *     case3: BIGINT or -HUGE < rownum < HUGE -> fetch left (NUMERIC sign check)
+ *            - left=INARITH[bigint](numeric,int)
+ *            - right=POS_VALUE[numeric]
+ *     case4: rownum BETWEEN BIGINT or -HUGE AND HUGE -> fetch left (NUMERIC sign check)
+ *            - left=POS_VALUE[numeric]
+ *            - right=INARITH[bigint]
+ *   When merged with a user-given KEYLIMIT, case2 / case4 reject a negative NUMERIC
+ *   on the right side (see scan_check_user_given_keylimit_overflow ()).
+ */
+static int
+scan_handle_overflow_subtraction_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * isidp, REGU_VARIABLE * key_limit_u,
+					VAL_DESCR * vd, bool is_user_given_keylimit)
+{
+  ARITH_TYPE *arithptr = key_limit_u->value.arithptr;
+  REGU_VARIABLE *left = arithptr->leftptr;
+  REGU_VARIABLE *right = arithptr->rightptr;
+  DB_VALUE *tmp_dbvalp;
+  int error_code;
+  bool left_is_inarith;
+  bool left_is_numeric;
+
+  assert (left && right);
+
+  left_is_inarith = (left->type == TYPE_INARITH || left->type == TYPE_OUTARITH);
+  left_is_numeric = (TP_DOMAIN_TYPE (left->domain) == DB_TYPE_NUMERIC);
+
+  if (left_is_inarith)
+    {
+      /* case1 or case3 */
+      tmp_dbvalp = NULL;
+      if (fetch_peek_dbval (thread_p, left, vd, NULL, NULL, NULL, &tmp_dbvalp) == NO_ERROR && tmp_dbvalp != NULL)
+	{
+	  /* case1 */
+	  switch (DB_VALUE_DOMAIN_TYPE (tmp_dbvalp))
+	    {
+	    case DB_TYPE_BIGINT:
+	      isidp->key_limit_upper = db_get_bigint (tmp_dbvalp);
+	      break;
+	    case DB_TYPE_INTEGER:
+	      isidp->key_limit_upper = db_get_int (tmp_dbvalp);
+	      break;
+	    case DB_TYPE_SHORT:
+	      isidp->key_limit_upper = db_get_short (tmp_dbvalp);
+	      break;
+	    default:
+	      assert (false);
+	      return ER_FAILED;
+	    }
+	}
+      else if (er_errid () == ER_IT_DATA_OVERFLOW || er_errid () == ER_QPROC_OVERFLOW_SUBTRACTION)
+	{
+	  /* case3 */
+	  er_clear ();
+	  tmp_dbvalp = fetch_peek_leftmost_numeric_regu (thread_p, left, vd);
+	  if (tmp_dbvalp == NULL)
+	    {
+	      return ER_FAILED;
+	    }
+#if 1				/* phase-3: raw sign-bit check; replaced by DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE in phase-4 */
+	  isidp->key_limit_upper = (tmp_dbvalp->data.num.d.buf[0] & NUMERIC_VALUE_SIGN_BIT_MASK) ? 0 : -1;
+#else
+	  isidp->key_limit_upper = DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE (tmp_dbvalp) ? 0 : -1;
+#endif
+	}
+      else
+	{
+	  return ER_FAILED;
+	}
+    }
+  else if (left_is_numeric)
+    {
+      /* case4 */
+      if (is_user_given_keylimit)
+	{
+	  /* rownum < -HUGE USING INDEX .. KEYLIMIT HUGE */
+	  error_code = scan_check_user_given_keylimit_overflow (thread_p, right->value.arithptr->leftptr, vd);
+	  if (error_code != NO_ERROR)
+	    {
+	      return error_code;
+	    }
+	}
+
+      tmp_dbvalp = fetch_peek_leftmost_numeric_regu (thread_p, left, vd);
+      if (tmp_dbvalp == NULL)
+	{
+	  return ER_FAILED;
+	}
+#if 1				/* phase-3: raw sign-bit check; replaced by DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE in phase-4 */
+      isidp->key_limit_upper = (tmp_dbvalp->data.num.d.buf[0] & NUMERIC_VALUE_SIGN_BIT_MASK) ? 0 : -1;
+#else
+      isidp->key_limit_upper = DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE (tmp_dbvalp) ? 0 : -1;
+#endif
+    }
+  else
+    {
+      /* case2 */
+      assert (right->type == TYPE_INARITH || right->type == TYPE_OUTARITH);
+      tmp_dbvalp = NULL;
+      if (is_user_given_keylimit)
+	{
+	  /* rownum < -HUGE USING INDEX .. KEYLIMIT BIGINT */
+	  error_code = scan_check_user_given_keylimit_overflow (thread_p, right->value.arithptr->leftptr, vd);
+	  if (error_code != NO_ERROR)
+	    {
+	      return error_code;
+	    }
+	}
+
+      if (fetch_peek_dbval (thread_p, left, vd, NULL, NULL, NULL, &tmp_dbvalp) != NO_ERROR || tmp_dbvalp == NULL)
+	{
+	  return ER_FAILED;
+	}
+
+      switch (DB_VALUE_DOMAIN_TYPE (tmp_dbvalp))
+	{
+	case DB_TYPE_BIGINT:
+	  isidp->key_limit_upper = db_get_bigint (tmp_dbvalp);
+	  break;
+	case DB_TYPE_INTEGER:
+	  isidp->key_limit_upper = db_get_int (tmp_dbvalp);
+	  break;
+	case DB_TYPE_SHORT:
+	  isidp->key_limit_upper = db_get_short (tmp_dbvalp);
+	  break;
+	default:
+	  assert (false);
+	  return ER_FAILED;
+	}
+    }
+  return NO_ERROR;
+}
+
+/*
  * scan_fetch_and_coerce_key_limit_upper () - fetch and coerce upper key limit to BIGINT,
  *                                            handling NUMERIC-to-BIGINT overflow.
  *
@@ -856,11 +1117,10 @@ scan_fetch_and_coerce_key_limit_lower (THREAD_ENTRY * thread_p, INDX_SCAN_ID * i
  */
 static int
 scan_fetch_and_coerce_key_limit_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * isidp, REGU_VARIABLE * key_limit_u,
-				       VAL_DESCR * vd, DB_VALUE ** out_dbvalp)
+				       VAL_DESCR * vd, DB_VALUE ** out_dbvalp, bool is_user_given_keylimit)
 {
   TP_DOMAIN *domainp = tp_domain_resolve_default (DB_TYPE_BIGINT);
   TP_DOMAIN_STATUS dom_status;
-  DB_VALUE *tmp_dbvalp;
   int error_code;
 
   assert (isidp != NULL);
@@ -878,131 +1138,20 @@ scan_fetch_and_coerce_key_limit_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * i
 	{
 	  if (er_errid () == ER_IT_DATA_OVERFLOW)
 	    {
-	      /* ER_IT_DATA_OVERFLOW: NUMERIC value itself exceeds BIGINT range (e.g. BIGINT < rownum < HUGE).
-	       * find the NUMERIC leaf and check sign:
-	       *   positive NUMERIC -> no upper bound (-1),
-	       *   negative NUMERIC -> no rows match (0).
-	       */
-	      tmp_dbvalp = fetch_peek_leftmost_numeric_regu (thread_p, key_limit_u, vd);
-	      if (tmp_dbvalp == NULL)
+	      error_code =
+		scan_handle_it_data_overflow_upper (thread_p, isidp, key_limit_u, vd, is_user_given_keylimit);
+	      if (error_code != NO_ERROR)
 		{
-		  return ER_FAILED;
+		  return error_code;
 		}
-#if 1				/* phase-3: raw sign-bit check; replaced by DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE in phase-4 */
-	      isidp->key_limit_upper = (tmp_dbvalp->data.num.d.buf[0] & NUMERIC_VALUE_SIGN_BIT_MASK) ? 0 : -1;
-#else
-	      isidp->key_limit_upper = DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE (tmp_dbvalp) ? 0 : -1;
-#endif
 	    }
 	  else if (er_errid () == ER_QPROC_OVERFLOW_SUBTRACTION)
 	    {
-	      /* T_SUB(upper_expr, lower_expr) overflows because a bound contains a huge NUMERIC.
-	       * branch on top-level left/right structure:
-	       *   case1: -HUGE < rownum < 5 -> fetch left (BIGINT upper bound)
-	       *          - left=INARITH[bigint](int,int)
-	       *          - right=POS_VALUE[numeric]
-	       *   case2: rownum BETWEEN -HUGE AND 5 -> fetch left (INT/BIGINT upper bound)
-	       *          - left=POS_VALUE[int|bigint]
-	       *          - right=INARITH[bigint]
-	       *   case3: BIGINT or -HUGE < rownum < HUGE -> fetch left (NUMERIC sign check)
-	       *          - left=INARITH[bigint](numeric,int)
-	       *          - right=POS_VALUE[numeric]
-	       *   case4: rownum BETWEEN BIGINT or -HUGE AND HUGE -> fetch left (NUMERIC sign check)
-	       *          - left=POS_VALUE[numeric]
-	       *          - right=INARITH[bigint]
-	       */
-	      ARITH_TYPE *arithptr = key_limit_u->value.arithptr;
-	      REGU_VARIABLE *left = arithptr->leftptr;
-	      REGU_VARIABLE *right = arithptr->rightptr;
-	      assert (left && right);
-
-	      bool left_is_inarith = (left->type == TYPE_INARITH || left->type == TYPE_OUTARITH);
-	      bool left_is_numeric = (TP_DOMAIN_TYPE (left->domain) == DB_TYPE_NUMERIC);
-
-	      if (left_is_inarith)
+	      error_code = scan_handle_overflow_subtraction_upper (thread_p, isidp, key_limit_u, vd,
+								   is_user_given_keylimit);
+	      if (error_code != NO_ERROR)
 		{
-		  /* case1 or case3 */
-		  tmp_dbvalp = NULL;
-		  if (fetch_peek_dbval (thread_p, left, vd, NULL, NULL, NULL, &tmp_dbvalp) == NO_ERROR
-		      && tmp_dbvalp != NULL)
-		    {
-		      /* case1 */
-		      switch (DB_VALUE_DOMAIN_TYPE (tmp_dbvalp))
-			{
-			case DB_TYPE_BIGINT:
-			  isidp->key_limit_upper = db_get_bigint (tmp_dbvalp);
-			  break;
-			case DB_TYPE_INTEGER:
-			  isidp->key_limit_upper = db_get_int (tmp_dbvalp);
-			  break;
-			case DB_TYPE_SHORT:
-			  isidp->key_limit_upper = db_get_short (tmp_dbvalp);
-			  break;
-			default:
-			  assert (false);
-			  return ER_FAILED;
-			}
-		    }
-		  else if (er_errid () == ER_IT_DATA_OVERFLOW || er_errid () == ER_QPROC_OVERFLOW_SUBTRACTION)
-		    {
-		      /* case3 */
-		      er_clear ();
-		      tmp_dbvalp = fetch_peek_leftmost_numeric_regu (thread_p, left, vd);
-		      if (tmp_dbvalp == NULL)
-			{
-			  return ER_FAILED;
-			}
-#if 1				/* phase-3: raw sign-bit check; replaced by DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE in phase-4 */
-		      isidp->key_limit_upper = (tmp_dbvalp->data.num.d.buf[0] & NUMERIC_VALUE_SIGN_BIT_MASK) ? 0 : -1;
-#else
-		      isidp->key_limit_upper = DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE (tmp_dbvalp) ? 0 : -1;
-#endif
-		    }
-		  else
-		    {
-		      return ER_FAILED;
-		    }
-		}
-	      else if (left_is_numeric)
-		{
-		  /* case4 */
-		  tmp_dbvalp = fetch_peek_leftmost_numeric_regu (thread_p, left, vd);
-		  if (tmp_dbvalp == NULL)
-		    {
-		      return ER_FAILED;
-		    }
-#if 1				/* phase-3: raw sign-bit check; replaced by DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE in phase-4 */
-		  isidp->key_limit_upper = (tmp_dbvalp->data.num.d.buf[0] & NUMERIC_VALUE_SIGN_BIT_MASK) ? 0 : -1;
-#else
-		  isidp->key_limit_upper = DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE (tmp_dbvalp) ? 0 : -1;
-#endif
-		}
-	      else
-		{
-		  /* case2 */
-		  assert (right->type == TYPE_INARITH || right->type == TYPE_OUTARITH);
-		  tmp_dbvalp = NULL;
-		  if (fetch_peek_dbval (thread_p, left, vd, NULL, NULL, NULL, &tmp_dbvalp) != NO_ERROR
-		      || tmp_dbvalp == NULL)
-		    {
-		      return ER_FAILED;
-		    }
-
-		  switch (DB_VALUE_DOMAIN_TYPE (tmp_dbvalp))
-		    {
-		    case DB_TYPE_BIGINT:
-		      isidp->key_limit_upper = db_get_bigint (tmp_dbvalp);
-		      break;
-		    case DB_TYPE_INTEGER:
-		      isidp->key_limit_upper = db_get_int (tmp_dbvalp);
-		      break;
-		    case DB_TYPE_SHORT:
-		      isidp->key_limit_upper = db_get_short (tmp_dbvalp);
-		      break;
-		    default:
-		      assert (false);
-		      return ER_FAILED;
-		    }
+		  return error_code;
 		}
 	    }
 	  else
@@ -1100,7 +1249,9 @@ scan_init_index_key_limit (THREAD_ENTRY * thread_p, INDX_SCAN_ID * isidp, KEY_IN
   if (key_infop->key_limit_u != NULL)
     {
       DB_VALUE *dbvalp;
-      error_code = scan_fetch_and_coerce_key_limit_upper (thread_p, isidp, key_infop->key_limit_u, vd, &dbvalp);
+      error_code =
+	scan_fetch_and_coerce_key_limit_upper (thread_p, isidp, key_infop->key_limit_u, vd, &dbvalp,
+					       key_infop->is_user_given_keylimit);
       if (error_code != NO_ERROR)
 	{
 	  return error_code;

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -1178,8 +1178,8 @@ scan_fetch_and_coerce_key_limit_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * i
       if (dom_status == DOMAIN_OVERFLOW && DB_VALUE_DOMAIN_TYPE (*out_dbvalp) == DB_TYPE_NUMERIC)
 	{
 	  /* NUMERIC -> BIGINT coercion overflow: handle by sign
-	   * if negative, all rows are returned (full scan from the beginning) 
-	   * if positive, returns 0 rows. 
+	   * if positive, no upper bound applies (-1; full scan, all rows)
+	   * if negative, no rows match (0; upper bound is unreachable)
 	   */
 #if 1				/* phase-3: raw sign-bit check; replaced by DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE in phase-4 */
 	  isidp->key_limit_upper = ((*out_dbvalp)->data.num.d.buf[0] & NUMERIC_VALUE_SIGN_BIT_MASK) ? 0 : -1;

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -172,6 +172,11 @@ static int scan_get_index_oidset (THREAD_ENTRY * thread_p, SCAN_ID * s_id, DB_BI
 static void scan_init_scan_id (SCAN_ID * scan_id, bool force_select_lock, SCAN_OPERATION_TYPE scan_op_type, int fixed,
 			       int grouped, QPROC_SINGLE_FETCH single_fetch, DB_VALUE * join_dbval,
 			       val_list_node * val_list, VAL_DESCR * vd);
+static DB_VALUE *scan_find_numeric_leaf (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR * vd);
+static int scan_fetch_and_coerce_key_limit_lower (THREAD_ENTRY * thread_p, INDX_SCAN_ID * isidp,
+						  REGU_VARIABLE * key_limit_l, VAL_DESCR * vd, DB_VALUE ** out_dbvalp);
+static int scan_fetch_and_coerce_key_limit_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * isidp,
+						  REGU_VARIABLE * key_limit_u, VAL_DESCR * vd, DB_VALUE ** out_dbvalp);
 static int scan_init_index_key_limit (THREAD_ENTRY * thread_p, INDX_SCAN_ID * isidp, KEY_INFO * key_infop,
 				      VAL_DESCR * vd);
 static SCAN_CODE scan_next_scan_local (THREAD_ENTRY * thread_p, SCAN_ID * scan_id);
@@ -805,6 +810,309 @@ exit_on_error:
 }
 
 /*
+ * scan_find_numeric_leaf () - Recursively search leftptr of an arith tree for the first NUMERIC-typed leaf.
+ *
+ *   return       : peeked DB_VALUE of the NUMERIC leaf, or NULL if not found
+ *   thread_p(in) : thread entry
+ *   regu_var(in) : root of the regu variable arith tree to search
+ *   vd(in)       : value descriptor
+ */
+static DB_VALUE *
+scan_find_numeric_leaf (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, VAL_DESCR * vd)
+{
+  ARITH_TYPE *arithptr;
+  DB_VALUE *dbvalp;
+
+  if (regu_var == NULL)
+    {
+      return NULL;
+    }
+
+  if (TP_DOMAIN_TYPE (regu_var->domain) == DB_TYPE_NUMERIC)
+    {
+      dbvalp = NULL;
+      if (fetch_peek_dbval (thread_p, regu_var, vd, NULL, NULL, NULL, &dbvalp) == NO_ERROR
+	  && dbvalp != NULL && DB_VALUE_DOMAIN_TYPE (dbvalp) == DB_TYPE_NUMERIC)
+	{
+	  return dbvalp;
+	}
+      return NULL;
+    }
+
+  if (regu_var->type == TYPE_INARITH || regu_var->type == TYPE_OUTARITH)
+    {
+      arithptr = regu_var->value.arithptr;
+      return scan_find_numeric_leaf (thread_p, arithptr->leftptr, vd);
+    }
+
+  return NULL;
+}
+
+/*
+ * scan_fetch_and_coerce_key_limit_lower () - fetch and coerce lower key limit to BIGINT,
+ *                                            handling NUMERIC-to-BIGINT overflow.
+ *
+ *   return         : NO_ERROR or error code
+ *   thread_p (in)  : thread entry
+ *   isidp (out)    : index scan id — key_limit_lower is set directly on overflow
+ *   key_limit_l(in): regu variable for lower key limit
+ *   vd (in)        : value descriptor
+ *   out_dbvalp(out): set to NULL when overflow is handled (key_limit_lower already set);
+ *                    set to the coerced BIGINT DB_VALUE otherwise (caller reads the value)
+ *
+ * Note: overflow sign semantics for lower limit are the opposite of upper:
+ *   positive overflow → no rows match (DB_BIGINT_MAX), negative overflow → all rows match (0).
+ */
+static int
+scan_fetch_and_coerce_key_limit_lower (THREAD_ENTRY * thread_p, INDX_SCAN_ID * isidp, REGU_VARIABLE * key_limit_l,
+				       VAL_DESCR * vd, DB_VALUE ** out_dbvalp)
+{
+  TP_DOMAIN *domainp = tp_domain_resolve_default (DB_TYPE_BIGINT);
+  TP_DOMAIN_STATUS dom_status;
+  DB_VALUE *tmp_dbvalp;
+  int error_code;
+
+  assert (isidp != NULL);
+  assert (key_limit_l != NULL);
+  assert (vd != NULL);
+  assert (out_dbvalp != NULL);
+
+  *out_dbvalp = NULL;
+
+  if (key_limit_l->type == TYPE_INARITH)
+    {
+      /* rownum > N or rownum >= N or BETWEEN */
+      error_code = fetch_peek_dbval (thread_p, key_limit_l, vd, NULL, NULL, NULL, out_dbvalp);
+      if (error_code != NO_ERROR)
+	{
+	  if (er_errid () != ER_IT_DATA_OVERFLOW && er_errid () != ER_QPROC_OVERFLOW_SUBTRACTION)
+	    {
+	      return ER_FAILED;
+	    }
+
+	  /* NUMERIC -> BIGINT overflow during arithmetic: find the NUMERIC operand and check its sign */
+	  tmp_dbvalp = scan_find_numeric_leaf (thread_p, key_limit_l, vd);
+	  if (tmp_dbvalp == NULL)
+	    {
+	      return ER_FAILED;
+	    }
+
+	  /* if negative, all rows are returned (full scan from the beginning) 
+	   * if positive, returns 0 rows. */
+	  isidp->key_limit_lower = (tmp_dbvalp->data.num.d.buf[0] & NUMERIC_VALUE_SIGN_BIT_MASK) ? 0 : DB_BIGINT_MAX;
+	  er_clear ();
+	  /* overflow handled: *out_dbvalp stays NULL */
+	  return NO_ERROR;
+	}
+    }
+  else
+    {
+      if (fetch_peek_dbval (thread_p, key_limit_l, vd, NULL, NULL, NULL, out_dbvalp) != NO_ERROR)
+	{
+	  return ER_FAILED;
+	}
+    }
+
+  /* coerce fetched value to BIGINT */
+  dom_status = tp_value_coerce (*out_dbvalp, *out_dbvalp, domainp);
+  if (dom_status != DOMAIN_COMPATIBLE)
+    {
+      if (dom_status == DOMAIN_OVERFLOW && DB_VALUE_DOMAIN_TYPE (*out_dbvalp) == DB_TYPE_NUMERIC)
+	{
+	  /* NUMERIC → BIGINT coercion overflow: handle by sign
+	   * if negative, all rows are returned (full scan from the beginning) 
+	   * if positive, returns 0 rows. 
+	   */
+	  isidp->key_limit_lower = ((*out_dbvalp)->data.num.d.buf[0] & NUMERIC_VALUE_SIGN_BIT_MASK) ? 0 : DB_BIGINT_MAX;
+	  er_clear ();
+	  /* overflow handled: *out_dbvalp stays NULL */
+	  *out_dbvalp = NULL;
+	  return NO_ERROR;
+	}
+      (void) tp_domain_status_er_set (dom_status, ARG_FILE_LINE, *out_dbvalp, domainp);
+      return ER_FAILED;
+    }
+
+  if (DB_VALUE_DOMAIN_TYPE (*out_dbvalp) != DB_TYPE_BIGINT)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_DATATYPE, 0);
+      return ER_QPROC_INVALID_DATATYPE;
+    }
+
+  return NO_ERROR;
+}
+
+/*
+ * scan_fetch_and_coerce_key_limit_upper () - fetch and coerce upper key limit to BIGINT,
+ *                                            handling NUMERIC-to-BIGINT overflow.
+ *
+ *   return         : NO_ERROR or error code
+ *   thread_p (in)  : thread entry
+ *   isidp (out)    : index scan id — key_limit_upper is set directly on overflow
+ *   key_limit_u(in): regu variable for upper key limit
+ *   vd (in)        : value descriptor
+ *   out_dbvalp(out): set to NULL when overflow is handled (key_limit_upper already set);
+ *                    set to the coerced BIGINT DB_VALUE otherwise (caller reads the value)
+ *
+ * Note: BIGINT overflow can only occur when the bound value is NUMERIC. Two cases arise:
+ *   - TYPE_INARITH  : arithmetic expression overflows during fetch (e.g. rownum < 10^100 - 1)
+ *   - other types   : coercion to BIGINT overflows (e.g. LIMIT 10^100 stored as NUMERIC)
+ * In both cases the sign of the NUMERIC value determines the result:
+ *   positive overflow → no upper bound (-1), negative overflow → no rows match (0).
+ */
+static int
+scan_fetch_and_coerce_key_limit_upper (THREAD_ENTRY * thread_p, INDX_SCAN_ID * isidp, REGU_VARIABLE * key_limit_u,
+				       VAL_DESCR * vd, DB_VALUE ** out_dbvalp)
+{
+  TP_DOMAIN *domainp = tp_domain_resolve_default (DB_TYPE_BIGINT);
+  TP_DOMAIN_STATUS dom_status;
+  DB_VALUE *tmp_dbvalp;
+  int error_code;
+
+  assert (isidp != NULL);
+  assert (key_limit_u != NULL);
+  assert (vd != NULL);
+  assert (out_dbvalp != NULL);
+
+  *out_dbvalp = NULL;
+
+  if (key_limit_u->type == TYPE_INARITH)
+    {
+      /* rownum < N or rownum <= N: arithmetic may overflow when N exceeds BIGINT range */
+      error_code = fetch_peek_dbval (thread_p, key_limit_u, vd, NULL, NULL, NULL, out_dbvalp);
+      if (error_code != NO_ERROR)
+	{
+	  if (er_errid () == ER_IT_DATA_OVERFLOW)
+	    {
+	      /* ER_IT_DATA_OVERFLOW: NUMERIC value itself exceeds BIGINT range (e.g. BIGINT < rownum < HUGE).
+	       * find the NUMERIC leaf and check sign:
+	       *   positive NUMERIC -> no upper bound (-1), 
+	       *   negative NUMERIC -> no rows match (0). 
+	       */
+	      tmp_dbvalp = scan_find_numeric_leaf (thread_p, key_limit_u, vd);
+	      if (tmp_dbvalp == NULL)
+		{
+		  return ER_FAILED;
+		}
+	      isidp->key_limit_upper = (tmp_dbvalp->data.num.d.buf[0] & NUMERIC_VALUE_SIGN_BIT_MASK) ? 0 : -1;
+	    }
+	  else if (er_errid () == ER_QPROC_OVERFLOW_SUBTRACTION)
+	    {
+	      /* T_SUB(upper_expr, lower_expr) overflows because a bound contains a huge NUMERIC.
+	       * branch on top-level left/right structure:
+	       *   case1: -HUGE < rownum < 5 -> fetch left (BIGINT upper bound)
+	       *          - left=INARITH[bigint](int,int)
+	       *          - right=POS_VALUE[numeric]
+	       *   case2: rownum BETWEEN -HUGE AND 5 -> fetch left (INT/BIGINT upper bound)
+	       *          - left=POS_VALUE[int|bigint]
+	       *          - right=INARITH[bigint]
+	       *   case3: BIGINT or -HUGE < rownum < HUGE -> fetch left (NUMERIC sign check)
+	       *          - left=INARITH[bigint](numeric,int)
+	       *          - right=POS_VALUE[numeric]
+	       *   case4: rownum BETWEEN BIGINT or -HUGE AND HUGE -> fetch left (NUMERIC sign check)
+	       *          - left=POS_VALUE[numeric]
+	       *          - right=INARITH[bigint]
+	       */
+	      ARITH_TYPE *arithptr = key_limit_u->value.arithptr;
+	      REGU_VARIABLE *left = arithptr->leftptr;
+	      REGU_VARIABLE *right = arithptr->rightptr;
+	      bool left_is_inarith = (left->type == TYPE_INARITH || left->type == TYPE_OUTARITH);
+	      bool left_is_numeric = (TP_DOMAIN_TYPE (left->domain) == DB_TYPE_NUMERIC);
+
+	      if (left_is_inarith)
+		{
+		  /* case1 or case3 */
+		  tmp_dbvalp = NULL;
+		  if (fetch_peek_dbval (thread_p, left, vd, NULL, NULL, NULL, &tmp_dbvalp) == NO_ERROR
+		      && tmp_dbvalp != NULL)
+		    {
+		      /* case1 */
+		      isidp->key_limit_upper = db_get_bigint (tmp_dbvalp);
+		    }
+		  else
+		    {
+		      /* case3 */
+		      er_clear ();
+		      tmp_dbvalp = scan_find_numeric_leaf (thread_p, left, vd);
+		      if (tmp_dbvalp == NULL)
+			{
+			  return ER_FAILED;
+			}
+		      isidp->key_limit_upper = (tmp_dbvalp->data.num.d.buf[0] & NUMERIC_VALUE_SIGN_BIT_MASK) ? 0 : -1;
+		    }
+		}
+	      else if (left_is_numeric)
+		{
+		  /* case4 */
+		  tmp_dbvalp = scan_find_numeric_leaf (thread_p, left, vd);
+		  if (tmp_dbvalp == NULL)
+		    {
+		      return ER_FAILED;
+		    }
+		  isidp->key_limit_upper = (tmp_dbvalp->data.num.d.buf[0] & NUMERIC_VALUE_SIGN_BIT_MASK) ? 0 : -1;
+		}
+	      else
+		{
+		  /* case2 */
+		  assert (right->type == TYPE_INARITH || right->type == TYPE_OUTARITH);
+		  tmp_dbvalp = NULL;
+		  if (fetch_peek_dbval (thread_p, left, vd, NULL, NULL, NULL, &tmp_dbvalp) != NO_ERROR
+		      || tmp_dbvalp == NULL)
+		    {
+		      return ER_FAILED;
+		    }
+		  isidp->key_limit_upper =
+		    (DB_VALUE_DOMAIN_TYPE (tmp_dbvalp) ==
+		     DB_TYPE_BIGINT) ? db_get_bigint (tmp_dbvalp) : db_get_int (tmp_dbvalp);
+		}
+	    }
+	  else
+	    {
+	      return ER_FAILED;
+	    }
+	  er_clear ();
+	  /* overflow handled: *out_dbvalp stays NULL */
+	  return NO_ERROR;
+	}
+    }
+  else
+    {
+      if (fetch_peek_dbval (thread_p, key_limit_u, vd, NULL, NULL, NULL, out_dbvalp) != NO_ERROR)
+	{
+	  return ER_FAILED;
+	}
+    }
+
+  /* coerce fetched value to BIGINT */
+  dom_status = tp_value_coerce (*out_dbvalp, *out_dbvalp, domainp);
+  if (dom_status != DOMAIN_COMPATIBLE)
+    {
+      if (dom_status == DOMAIN_OVERFLOW && DB_VALUE_DOMAIN_TYPE (*out_dbvalp) == DB_TYPE_NUMERIC)
+	{
+	  /* NUMERIC -> BIGINT coercion overflow: handle by sign
+	   * if negative, all rows are returned (full scan from the beginning) 
+	   * if positive, returns 0 rows. 
+	   */
+	  isidp->key_limit_upper = ((*out_dbvalp)->data.num.d.buf[0] & NUMERIC_VALUE_SIGN_BIT_MASK) ? 0 : -1;
+	  er_clear ();
+	  /* overflow handled: *out_dbvalp stays NULL */
+	  *out_dbvalp = NULL;
+	  return NO_ERROR;
+	}
+      (void) tp_domain_status_er_set (dom_status, ARG_FILE_LINE, *out_dbvalp, domainp);
+      return ER_FAILED;
+    }
+
+  if (DB_VALUE_DOMAIN_TYPE (*out_dbvalp) != DB_TYPE_BIGINT)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_DATATYPE, 0);
+      return ER_QPROC_INVALID_DATATYPE;
+    }
+
+  return NO_ERROR;
+}
+
+/*
  * scan_init_index_key_limit () - initialize/reset index key limits
  *   return: error code
  */
@@ -812,55 +1120,39 @@ static int
 scan_init_index_key_limit (THREAD_ENTRY * thread_p, INDX_SCAN_ID * isidp, KEY_INFO * key_infop, VAL_DESCR * vd)
 {
   DB_VALUE *dbvalp;
-  TP_DOMAIN *domainp = tp_domain_resolve_default (DB_TYPE_BIGINT);
   bool is_lower_limit_negative = false;
-  TP_DOMAIN_STATUS dom_status;
+  int error_code;
 
   if (key_infop->key_limit_l != NULL)
     {
-      if (fetch_peek_dbval (thread_p, key_infop->key_limit_l, vd, NULL, NULL, NULL, &dbvalp) != NO_ERROR)
+      error_code = scan_fetch_and_coerce_key_limit_lower (thread_p, isidp, key_infop->key_limit_l, vd, &dbvalp);
+      if (error_code != NO_ERROR)
 	{
-	  return ER_FAILED;
-	}
-      dom_status = tp_value_coerce (dbvalp, dbvalp, domainp);
-      if (dom_status != DOMAIN_COMPATIBLE)
-	{
-	  (void) tp_domain_status_er_set (dom_status, ARG_FILE_LINE, dbvalp, domainp);
-
-	  return ER_FAILED;
+	  return error_code;
 	}
 
-      if (DB_VALUE_DOMAIN_TYPE (dbvalp) != DB_TYPE_BIGINT)
-	{
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_DATATYPE, 0);
-	  return ER_QPROC_INVALID_DATATYPE;
-	}
-      else
+      if (dbvalp != NULL)
 	{
 	  isidp->key_limit_lower = db_get_bigint (dbvalp);
-	}
 
-      if (isidp->key_limit_lower < 0)
-	{
-	  if (key_infop->is_user_given_keylimit == true)
+	  if (isidp->key_limit_lower < 0)
 	    {
-	      /* We don't allow users to give us a bad keylimit bound */
+	      if (key_infop->is_user_given_keylimit == true)
+		{
+		  /* We don't allow users to give us a bad keylimit bound */
+		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_PARAMETER, 0);
+		  return ER_QPROC_INVALID_PARAMETER;
+		}
 
-	      /* still want to have better error code */
-	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_PARAMETER, 0);
-	      return ER_QPROC_INVALID_PARAMETER;
+	      /* SELECT * from t where ROWNUM = 0 order by a: this would sometimes get optimized using keylimit, if the
+	       * circumstances are right. in this case, the lower limit would be "0-1", effectiveley -1. We cannot allow
+	       * that to happen, since -1 is a special value meaning "there is no lower limit", and certain critical
+	       * decisions (such as resetting the key limit for multiple ranges) depend on knowing whether or not there is
+	       * a lower key limit. We set a flag to remember, later on, to "adjust" the key limits such that, if the lower
+	       * limit is negative, to return no results.
+	       */
+	      is_lower_limit_negative = true;
 	    }
-
-	  /* Optimizer adopts keylimit optimization */
-
-	  /* SELECT * from t where ROWNUM = 0 order by a: this would sometimes get optimized using keylimit, if the
-	   * circumstances are right. in this case, the lower limit would be "0-1", effectiveley -1. We cannot allow
-	   * that to happen, since -1 is a special value meaning "there is no lower limit", and certain critical
-	   * decisions (such as resetting the key limit for multiple ranges) depend on knowing whether or not there is
-	   * a lower key limit. We set a flag to remember, later on, to "adjust" the key limits such that, if the lower
-	   * limit is negative, to return no results.
-	   */
-	  is_lower_limit_negative = true;
 	}
     }
   else
@@ -870,44 +1162,31 @@ scan_init_index_key_limit (THREAD_ENTRY * thread_p, INDX_SCAN_ID * isidp, KEY_IN
 
   if (key_infop->key_limit_u != NULL)
     {
-      if (fetch_peek_dbval (thread_p, key_infop->key_limit_u, vd, NULL, NULL, NULL, &dbvalp) != NO_ERROR)
+      error_code = scan_fetch_and_coerce_key_limit_upper (thread_p, isidp, key_infop->key_limit_u, vd, &dbvalp);
+      if (error_code != NO_ERROR)
 	{
-	  return ER_FAILED;
+	  return error_code;
 	}
-      dom_status = tp_value_coerce (dbvalp, dbvalp, domainp);
-      if (dom_status != DOMAIN_COMPATIBLE)
-	{
-	  (void) tp_domain_status_er_set (dom_status, ARG_FILE_LINE, dbvalp, domainp);
 
-	  return ER_FAILED;
-	}
-      if (DB_VALUE_DOMAIN_TYPE (dbvalp) != DB_TYPE_BIGINT)
-	{
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_DATATYPE, 0);
-	  return ER_QPROC_INVALID_DATATYPE;
-	}
-      else
+      if (dbvalp != NULL)
 	{
 	  isidp->key_limit_upper = db_get_bigint (dbvalp);
-	}
 
-      if (isidp->key_limit_upper < 0)
-	{
-	  if (key_infop->is_user_given_keylimit == true)
+	  if (isidp->key_limit_upper < 0)
 	    {
-	      /* We don't allow users to give us a bad keylimit bound */
+	      if (key_infop->is_user_given_keylimit == true)
+		{
+		  /* We don't allow users to give us a bad keylimit bound */
+		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_PARAMETER, 0);
+		  return ER_QPROC_INVALID_PARAMETER;
+		}
 
-	      /* still want to have better error code */
-	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_INVALID_PARAMETER, 0);
-	      return ER_QPROC_INVALID_PARAMETER;
+	      /* Optimizer adopts keylimit optimization.
+	       * Try to sanitize the upper value — it might have been computed from operations on host variables,
+	       * which are unpredictable.
+	       */
+	      isidp->key_limit_upper = 0;
 	    }
-
-	  /* Optimizer adopts keylimit optimization */
-
-	  /* Try to sanitize the upper value. It might have been computed from operations on host variables, which are
-	   * unpredictable.
-	   */
-	  isidp->key_limit_upper = 0;
 	}
     }
   else


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26695

### Purpose
- 실제 필드에서 테이블의 row 수는 BIGINT 범위(2^63-1)를 초과하지 않는다는 전제를 둔다.
- rownum 기반 key limit 최적화 과정에서 HUGE NUMERIC 값 사용 시 발생하는 overflow(ER_IT_DATA_OVERFLOW, ER_QPROC_OVERFLOW_SUBTRACTION)를 처리하여, 에러 대신 정의된 기준에 따라 결과를 반환하도록 개선한다.
    - lower/upper bound 계산 시 NUMERIC → BIGINT 변환 과정에서 ER_IT_DATA_OVERFLOW 발생
    - scan count 계산 시 NUMERIC 연산 과정에서 ER_QPROC_OVERFLOW_SUBTRACTION 발생

### Implementation
- key limit(lower/upper) 및 instnum 초기화 과정에서 NUMERIC → BIGINT 변환 시 발생하는 overflow를 런타임에 감지하여 처리하도록 수정함.

#### lower overflow
- 음수: 0 (전체 대상)
- 양수: DB_BIGINT_MAX (도달 불가 → 0건)
#### upper overflow
- 양수: -1 (제한 없음 → 전체 대상)
- 음수: 0 (도달 불가 → 0건)

#### 주요 변경 사항
- scan_manager.c
    - 수정
        - scan_init_index_key_limit()
            - 기존 로직을 아래 함수로 위임
    - 추가
        - scan_fetch_and_coerce_key_limit_lower()
            - lower 처리
        - scan_fetch_and_coerce_key_limit_upper()
            - upper 처리
            - ovf인 경우, `scan_handle_it_data_overflow_upper()` 및 `scan_handle_overflow_subtraction_upper()` 호출
        - scan_handle_it_data_overflow_upper()
            -  upper 처리 중 ER_IT_DATA_OVERFLOW 분기 처리
        - scan_handle_overflow_subtraction_upper()
            - upper 처리 중 ER_QPROC_OVERFLOW_SUBTRACTION 분기 처리 
        - scan_check_user_given_keylimit_overflow()
            -  `scan_handle_it_data_overflow_upper()` 및 `scan_handle_overflow_subtraction_upper()` 처리 진행 중
            - 사용자 KEYLIMIT 힌트 머지 시 NUMERIC bound가 음수면, `ER_QPROC_INVALID_PARAMETER` 에러 출력 헬퍼 (BIGINT-negative 에러 정책과 동일함)

- query_executor.c
    - 수정
        - qexec_init_instnum_val()
            - 기존 로직을 fetch_and_coerce_key_limit_lower()로 위임
            - key limit 최적화 적용 불가 (upper 없음) 시 기존대로 full index scan 수행하며, 이 경우 overflow 없이 정상 동작함

- fetch.c
    - 추가
        - fetch_peek_leftmost_numeric_regu()
            - 공통 로직 헬퍼 함수로 `scan_fetch_and_coerce_key_limit_upper()` 및 `fetch_and_coerce_key_limit_lower()` 사용
            - NUMERIC leaf 재귀 탐색
        - fetch_and_coerce_key_limit_lower()
            -  lower 처리의 공통 로직 헬퍼 함수.

### Remarks
#### 사용자 혼란을 줄이기 위한 개선:
- AS-IS(DEV)에서는 HUGE NUMERIC 범위의 값을 처리하지 못해 모든 케이스에서 overflow 에러가 발생한다.
- TO-BE(Phase-3)에서는 NUMERIC 범위 확장으로 HUGE NUMERIC 값을 처리할 수 있게 되지만,
  일부 케이스는 key limit 최적화가 적용되지 않거나(NUMERIC → BIGINT 변환이 발생하지 않음),
  일부는 변환 과정에서 overflow가 발생하여 동일 조건임에도 결과가 상이하게 나타나는 문제가 있다.
- 이러한 비일관성을 제거하고, overflow 상황에서도 일관된 기준으로 결과를 반환하도록 수정한다.
- 관련 TC
    - _18_index_enhancement_qa/_02_full_test/_06_optimizing_limit/_07_rewrite_rownum_illegal.sql

#### 런타임(실행 시점)에서 처리하는 이유:
- 리터럴 상수뿐 아니라 host variable 및 컬럼 참조의 경우, 실제 값은 실행 시점에 확정됨
- plan 생성 시점(qo_get_key_limit_from_instnum)에서는 host variable 값을 알 수 없음
