### PR TITLE
[CBRD-26682] Separate base class from concrete class.

### DIFF
--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -2657,7 +2657,7 @@ css_get_task_stats (UINT64 *stats_out)
 size_t
 css_get_num_request_workers (void)
 {
-  return css_Server_request_worker_pool->get_max_count ();
+  return css_Server_request_worker_pool->get_worker_count ();
 }
 
 //
@@ -2712,7 +2712,7 @@ css_wp_core_job_scan_mapper (const cubthread::worker_pool::core & wp_core, bool 
   (void) db_make_int (&vals[val_index++], (int) core_index);
 
   // add max worker count; it used to be max thread workers per job queue
-  (void) db_make_int (&vals[val_index++], (int) wp_core.get_max_worker_count ());
+  (void) db_make_int (&vals[val_index++], (int) wp_core.get_worker_count ());
 
   // number of busy workers; core does not keep it, we need to count them manually
   int busy_count = 0;
@@ -2767,7 +2767,7 @@ css_are_all_request_handlers_suspended (void)
       return false;
     }
 
-  if (checked_threads_count == css_Server_request_worker_pool->get_max_count ())
+  if (checked_threads_count == css_Server_request_worker_pool->get_worker_count ())
     {
       // all threads are suspended
       return true;

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -3078,7 +3078,7 @@ vacuum_master_task::check_shutdown() const
 bool
 vacuum_master_task::is_task_queue_full() const
 {
-  if (cubthread::get_manager ()->is_pool_full (vacuum_Worker_threads))
+  if (vacuum_Worker_threads->is_full ())
     {
       // stop if worker pool is full
       vacuum_er_log (VACUUM_ER_LOG_MASTER, "%s", "Interrupt iteration: full worker pool");

--- a/src/thread/thread_manager.cpp
+++ b/src/thread/thread_manager.cpp
@@ -122,69 +122,6 @@ namespace cubthread
 #endif // !SERVER_MODE = SA_MODE
   }
 
-  template<typename Res>
-  void manager::destroy_and_untrack_all_resources (std::vector<Res *> &tracker)
-  {
-    assert (tracker.empty ());
-
-#if defined (SERVER_MODE)
-    for (; !tracker.empty ();)
-      {
-	const auto iter = tracker.begin ();
-	(*iter)->stop_execution ();
-	delete *iter;
-	tracker.erase (iter);
-      }
-#endif // SERVER_MODE
-  }
-
-  template<typename Res, typename ... CtArgs>
-  inline Res *manager::create_and_track_resource (std::vector<Res *> &tracker, size_t entries_count, CtArgs &&... args)
-  {
-    check_not_single_thread ();
-
-    std::unique_lock<std::mutex> lock (m_entries_mutex);  // safe-guard
-
-    if (m_available_entries_count < entries_count)
-      {
-	return NULL;
-      }
-    m_available_entries_count -= entries_count;
-
-    Res *new_res = new Res (std::forward<CtArgs> (args)...);
-
-    tracker.push_back (new_res);
-
-    return new_res;
-  }
-
-  worker_pool *
-  manager::create_worker_pool (size_t pool_size, size_t task_max_count, const char *name,
-			       entry_manager *entry_mgr, std::size_t core_count, bool debug_logging,
-			       bool pool_threads, wait_seconds wait_for_task_time)
-  {
-#if defined (SERVER_MODE)
-    if (is_single_thread ())
-      {
-	return NULL;
-      }
-    else
-      {
-	assert (m_worker_pools.size () <= workerpool_registry_t::count ());
-
-	if (entry_mgr == NULL)
-	  {
-	    entry_mgr = &m_entry_manager;
-	  }
-	// reserve pool_size entries and add to m_worker_pools
-	return create_and_track_resource (m_worker_pools, pool_size, pool_size, task_max_count, *entry_mgr,
-					  name, core_count, debug_logging, pool_threads, wait_for_task_time);
-      }
-#else // not SERVER_MODE = SA_MODE
-    return NULL;
-#endif // not SERVER_MODE = SA_MODE
-  }
-
   daemon *
   manager::create_daemon (const looper &looper_arg, entry_task *exec_p,
 			  const char *daemon_name /* = "" */, entry_manager *entry_mgr /* = NULL */)
@@ -232,35 +169,6 @@ namespace cubthread
 #endif // not SERVER_MODE = SA_MODE
   }
 
-  template<typename Res>
-  inline void
-  manager::destroy_and_untrack_resource (std::vector<Res *> &tracker, Res *&res, std::size_t entries_count)
-  {
-    std::unique_lock<std::mutex> lock (m_entries_mutex);    // safe-guard
-    check_not_single_thread ();
-
-    for (auto iter = tracker.begin (); iter != tracker.end (); ++iter)
-      {
-	if (res == *iter)
-	  {
-	    // remove resource from tracker
-	    (void) tracker.erase (iter);
-
-	    // stop resource and delete
-	    res->stop_execution ();
-	    delete res;
-	    res = NULL;
-
-	    // update available entries
-	    m_available_entries_count += entries_count;
-
-	    return;
-	  }
-      }
-    // resource not found
-    assert (false);
-  }
-
   void
   manager::destroy_worker_pool (worker_pool *&worker_pool_arg)
   {
@@ -269,8 +177,8 @@ namespace cubthread
       {
 	return;
       }
-    // remove from m_worker_pools and free worker_pool_arg->get_max_count thread entries
-    return destroy_and_untrack_resource (m_worker_pools, worker_pool_arg, worker_pool_arg->get_max_count ());
+    // remove from m_worker_pools and free worker_pool_arg->get_worker_count thread entries
+    return destroy_and_untrack_resource (m_worker_pools, worker_pool_arg, worker_pool_arg->get_worker_count ());
 #else // not SERVER_MODE = SA_MODE
     assert (worker_pool_arg == NULL);
 #endif // not SERVER_MODE = SA_MODE
@@ -321,39 +229,6 @@ namespace cubthread
 	exec_p->retire ();
 #endif // not SERVER_MODE = SA_MODE
       }
-  }
-
-  bool
-  manager::try_task (entry &thread_p, worker_pool *worker_pool_arg, entry_task *exec_p)
-  {
-    if (worker_pool_arg == NULL)
-      {
-	// execute on this thread
-	exec_p->execute (thread_p);
-	exec_p->retire ();
-	return true;
-      }
-    else
-      {
-#if defined (SERVER_MODE)
-	check_not_single_thread ();
-	return worker_pool_arg->try_execute (exec_p);
-#else // not SERVER_MODE = SA_MODE
-	assert (false);
-	return false;
-#endif // not SERVER_MODE = SA_MODE
-      }
-  }
-
-  bool
-  manager::is_pool_full (worker_pool *worker_pool_arg)
-  {
-#if defined (SERVER_MODE)
-    return worker_pool_arg == NULL || worker_pool_arg->is_full ();
-#else // not SERVER_MODE = SA_MODE
-    // on SA_MODE can always push more tasks
-    return false;
-#endif // not SERVER_MODE = SA_MODE
   }
 
   void

--- a/src/thread/thread_manager.cpp
+++ b/src/thread/thread_manager.cpp
@@ -127,22 +127,14 @@ namespace cubthread
 			  const char *daemon_name /* = "" */, entry_manager *entry_mgr /* = NULL */)
   {
 #if defined (SERVER_MODE)
-    if (is_single_thread ())
-      {
-	assert (false);
-	return NULL;
-      }
-    else
-      {
-	assert (m_daemons.size () <= daemon_registry_t::count ());
+    assert (m_daemons.size () <= daemon_registry_t::count ());
 
-	if (entry_mgr == NULL)
-	  {
-	    entry_mgr = &m_daemon_entry_manager;
-	  }
-	// reserve 1 entry and add to m_daemons
-	return create_and_track_resource (m_daemons, 1, looper_arg, entry_mgr, exec_p, daemon_name);
+    if (entry_mgr == NULL)
+      {
+	entry_mgr = &m_daemon_entry_manager;
       }
+    // reserve 1 entry and add to m_daemons
+    return create_and_track_resource (m_daemons, 1, looper_arg, entry_mgr, exec_p, daemon_name);
 #else // not SERVER_MODE = SA_MODE
     assert (false);
     return NULL;
@@ -153,16 +145,8 @@ namespace cubthread
   manager::create_daemon_without_entry (const looper &looper_arg, task_without_context *exec_p, const char *daemon_name)
   {
 #if defined (SERVER_MODE)
-    if (is_single_thread ())
-      {
-	assert (false);
-	return NULL;
-      }
-    else
-      {
-	// reserve no entry and add to m_daemons_without_entries
-	return create_and_track_resource (m_daemons_without_entries, 0, looper_arg, exec_p, daemon_name);
-      }
+    // reserve no entry and add to m_daemons_without_entries
+    return create_and_track_resource (m_daemons_without_entries, 0, looper_arg, exec_p, daemon_name);
 #else // not SERVER_MODE = SA_MODE
     assert (false);
     return NULL;

--- a/src/thread/thread_manager.hpp
+++ b/src/thread/thread_manager.hpp
@@ -357,23 +357,16 @@ namespace cubthread
 #if defined (SERVER_MODE)
     Res *workerpool;
 
-    if (is_single_thread ())
-      {
-	return NULL;
-      }
-    else
-      {
-	assert (m_worker_pools.size () <= workerpool_registry_t::count ());
+    assert (m_worker_pools.size () <= workerpool_registry_t::count ());
 
-	// reserve pool_size entries and add to m_worker_pools
-	workerpool = create_and_track_resource (m_worker_pools, pool_size,
-						pool_size, core_count, std::forward<CtArgs> (args)...);
-	if (workerpool)
-	  {
-	    workerpool->initialize (pool_size, core_count);
-	  }
-	return workerpool;
+    // reserve pool_size entries and add to m_worker_pools
+    workerpool = create_and_track_resource (m_worker_pools, pool_size,
+					    pool_size, core_count, std::forward<CtArgs> (args)...);
+    if (workerpool)
+      {
+	workerpool->initialize (pool_size, core_count);
       }
+    return workerpool;
 #else // not SERVER_MODE = SA_MODE
     return NULL;
 #endif // not SERVER_MODE = SA_MODE
@@ -400,7 +393,7 @@ namespace cubthread
   {
     check_not_single_thread ();
 
-    std::unique_lock<std::mutex> lock (m_entries_mutex);  // safe-guard
+    std::lock_guard<std::mutex> lock (m_entries_mutex);
 
     if (m_available_entries_count < entries_count)
       {
@@ -419,8 +412,9 @@ namespace cubthread
   void
   manager::destroy_and_untrack_resource (std::vector<Res *> &tracker, Res *&res, std::size_t entries_count)
   {
-    std::unique_lock<std::mutex> lock (m_entries_mutex);    // safe-guard
     check_not_single_thread ();
+
+    std::lock_guard<std::mutex> lock (m_entries_mutex);
 
     for (auto iter = tracker.begin (); iter != tracker.end (); ++iter)
       {

--- a/src/thread/thread_manager.hpp
+++ b/src/thread/thread_manager.hpp
@@ -130,10 +130,8 @@ namespace cubthread
       // create a worker pool with pool_size number of threads
       // notes: if there are not pool_size number of entries available, worker pool is not created and NULL is returned
       //        signature emulates worker_pool constructor signature
-      worker_pool *create_worker_pool (std::size_t pool_size, std::size_t task_max_count, const char *name,
-				       entry_manager *entry_mgr, std::size_t core_count,
-				       bool debug_logging, bool pool_threads = false,
-				       wait_seconds wait_for_task_time = std::chrono::seconds (5));
+      template<typename Res, typename ... CtArgs>
+      Res *create_worker_pool (std::size_t pool_size, std::size_t core_count, CtArgs &&... args);
 
       // destroy worker pool
       void destroy_worker_pool (worker_pool *&worker_pool_arg);
@@ -144,15 +142,6 @@ namespace cubthread
       // push task on the given core of entry worker pool.
       // read cubthread::worker_pool::execute_on_core for details.
       void push_task_on_core (worker_pool *worker_pool_arg, entry_task *exec_p, std::size_t core_hash, bool method_mode);
-
-      // try to execute task if there are available thread in worker pool
-      // if worker_pool_arg is NULL, the task is executed immediately
-      bool try_task (entry &thread_p, worker_pool *worker_pool_arg, entry_task *exec_p);
-
-      // return if pool is full
-      // for SERVER_MODE see worker_pool::is_full
-      // for SA_MODE it is always false
-      bool is_pool_full (worker_pool *worker_pool_arg);
 
       //////////////////////////////////////////////////////////////////////////
       // daemon management
@@ -204,6 +193,11 @@ namespace cubthread
 	return m_all_entries;
       }
 
+      entry_manager &get_entry_manager (void)
+      {
+	return m_entry_manager;
+      }
+
       lockfree::tran::system &get_lockfree_transys ()
       {
 	return *m_lf_tran_sys;
@@ -246,8 +240,8 @@ namespace cubthread
       using entry_dispatcher = resource_shared_pool<entry>;
 
       // generic implementation to create and destroy resources (specialize through daemon and worker pool)
-      template <typename Res, typename ... CtArgs>
-      Res *create_and_track_resource (std::vector<Res *> &tracker, size_t entries_count, CtArgs &&... args);
+      template <typename Res, typename Base, typename ... CtArgs>
+      Res *create_and_track_resource (std::vector<Base *> &tracker, size_t entries_count, CtArgs &&... args);
       template <typename Res>
       void destroy_and_untrack_resource (std::vector<Res *> &tracker, Res *&res, std::size_t entries_count);
       template <typename Res>
@@ -354,6 +348,37 @@ namespace cubthread
   // template / inline functions
   //////////////////////////////////////////////////////////////////////////
 
+  template<typename Res, typename ... CtArgs>
+  Res *
+  manager::create_worker_pool (std::size_t pool_size, std::size_t core_count, CtArgs &&... args)
+  {
+    static_assert (std::is_base_of_v<worker_pool, Res>);
+
+#if defined (SERVER_MODE)
+    Res *workerpool;
+
+    if (is_single_thread ())
+      {
+	return NULL;
+      }
+    else
+      {
+	assert (m_worker_pools.size () <= workerpool_registry_t::count ());
+
+	// reserve pool_size entries and add to m_worker_pools
+	workerpool = create_and_track_resource (m_worker_pools, pool_size,
+						pool_size, core_count, std::forward<CtArgs> (args)...);
+	if (workerpool)
+	  {
+	    workerpool->initialize (pool_size, core_count);
+	  }
+	return workerpool;
+      }
+#else // not SERVER_MODE = SA_MODE
+    return NULL;
+#endif // not SERVER_MODE = SA_MODE
+  }
+
   template <typename Func, typename ... Args>
   void
   manager::map_entries (Func &&func, Args &&... args)
@@ -367,6 +392,73 @@ namespace cubthread
 	    break;
 	  }
       }
+  }
+
+  template <typename Res, typename Base, typename ... CtArgs>
+  Res *
+  manager::create_and_track_resource (std::vector<Base *> &tracker, size_t entries_count, CtArgs &&... args)
+  {
+    check_not_single_thread ();
+
+    std::unique_lock<std::mutex> lock (m_entries_mutex);  // safe-guard
+
+    if (m_available_entries_count < entries_count)
+      {
+	return NULL;
+      }
+    m_available_entries_count -= entries_count;
+
+    Res *new_res = new Res (std::forward<CtArgs> (args)...);
+
+    tracker.push_back (new_res);
+
+    return new_res;
+  }
+
+  template<typename Res>
+  void
+  manager::destroy_and_untrack_resource (std::vector<Res *> &tracker, Res *&res, std::size_t entries_count)
+  {
+    std::unique_lock<std::mutex> lock (m_entries_mutex);    // safe-guard
+    check_not_single_thread ();
+
+    for (auto iter = tracker.begin (); iter != tracker.end (); ++iter)
+      {
+	if (res == *iter)
+	  {
+	    // remove resource from tracker
+	    (void) tracker.erase (iter);
+
+	    // stop resource and delete
+	    res->stop_execution ();
+	    delete res;
+	    res = NULL;
+
+	    // update available entries
+	    m_available_entries_count += entries_count;
+
+	    return;
+	  }
+      }
+    // resource not found
+    assert (false);
+  }
+
+  template<typename Res>
+  void
+  manager::destroy_and_untrack_all_resources (std::vector<Res *> &tracker)
+  {
+    assert (tracker.empty ());
+
+#if defined (SERVER_MODE)
+    for (; !tracker.empty ();)
+      {
+	const auto iter = tracker.begin ();
+	(*iter)->stop_execution ();
+	delete *iter;
+	tracker.erase (iter);
+      }
+#endif // SERVER_MODE
   }
 
 } // namespace cubthread
@@ -389,6 +481,19 @@ inline cubthread::manager *
 thread_get_manager (void)
 {
   return cubthread::get_manager ();
+}
+
+inline cubthread::entry_manager &
+thread_get_entry_manager (void)
+{
+  return cubthread::get_manager ()->get_entry_manager ();
+}
+
+inline cubthread::worker_pool *
+thread_create_worker_pool_base (std::size_t pool_size, std::size_t core_count, const char *name,
+				cubthread::entry_manager &entry_mgr)
+{
+  return cubthread::get_manager ()->create_worker_pool<cubthread::worker_pool> (pool_size, core_count, name, entry_mgr);
 }
 
 inline std::size_t

--- a/src/thread/thread_manager.hpp
+++ b/src/thread/thread_manager.hpp
@@ -491,9 +491,10 @@ thread_get_entry_manager (void)
 
 inline cubthread::worker_pool *
 thread_create_worker_pool_base (std::size_t pool_size, std::size_t core_count, const char *name,
-				cubthread::entry_manager &entry_mgr)
+				cubthread::entry_manager &entry_mgr, bool pool_threads = false)
 {
-  return cubthread::get_manager ()->create_worker_pool<cubthread::worker_pool> (pool_size, core_count, name, entry_mgr);
+  return cubthread::get_manager ()->create_worker_pool<cubthread::worker_pool> (pool_size, core_count, name, entry_mgr,
+	 pool_threads);
 }
 
 inline std::size_t

--- a/src/thread/thread_worker_pool.cpp
+++ b/src/thread/thread_worker_pool.cpp
@@ -65,7 +65,7 @@ namespace cubthread
   worker_pool::initialize (std::size_t worker_count, std::size_t core_count)
   {
     allocate_cores (core_count);
-    assign_workers_to_cores (core_count, worker_count);
+    assign_workers_to_cores (worker_count);
 
     // [optional] this option must be useful using perf
     if (wp_is_thread_always_alive_forced ())
@@ -186,7 +186,7 @@ namespace cubthread
   }
 
   void
-  worker_pool::assign_workers_to_cores (std::size_t core_count, std::size_t worker_count)
+  worker_pool::assign_workers_to_cores (std::size_t worker_count)
   {
     std::size_t quotient, remainder;
     std::size_t it;

--- a/src/thread/thread_worker_pool.cpp
+++ b/src/thread/thread_worker_pool.cpp
@@ -170,7 +170,7 @@ namespace cubthread
   std::unique_ptr<worker_pool::core>
   worker_pool::allocate_core (void)
   {
-    return std::make_unique<worker_pool::core> ();
+    return std::unique_ptr<core> (new core ());
   }
 
   void
@@ -197,13 +197,13 @@ namespace cubthread
     for (it = 0; it < remainder; it++)
       {
 	m_cores[it]->set_worker_pool (*this);
-	// worker pool is referenced in worker to get m_pool_threads when initialing core
+	// worker pool is referenced in worker to get m_pool_threads when initializing core
 	m_cores[it]->initialize (quotient + 1);
       }
     for (; it < m_cores.size (); it++)
       {
 	m_cores[it]->set_worker_pool (*this);
-	// worker pool is referenced in worker to get m_pool_threads when initialing core
+	// worker pool is referenced in worker to get m_pool_threads when initializing core
 	m_cores[it]->initialize (quotient);
       }
   }
@@ -267,56 +267,17 @@ namespace cubthread
   {
   }
 
-  std::unique_ptr<worker_pool::core::worker>
-  worker_pool::core::allocate_worker (bool is_temp)
-  {
-    return std::make_unique<worker_pool::core::worker> (is_temp);
-  }
-
-  void
-  worker_pool::core::allocate_workers (std::size_t worker_count)
-  {
-    std::size_t it;
-
-    m_workers.reserve (worker_count);
-    for (it = 0; it < worker_count; it++)
-      {
-	m_workers.push_back (allocate_worker ());
-      }
-  }
-
-  void
-  worker_pool::core::initialize_workers ()
-  {
-    for (auto it = m_workers.begin (); it != m_workers.end (); it++)
-      {
-	(*it)->set_core (*this);
-
-	if (m_parent_pool->get_pool_threads ())
-	  {
-	    // assign task / start thread
-	    // it will add itself to available workers
-	    (*it)->assign_task (NULL);
-	  }
-	else
-	  {
-	    // add to available workers
-	    m_available_workers.push_back (it->get ());
-	  }
-      }
-  }
-
   void
   worker_pool::core::initialize (std::size_t worker_count)
   {
     assert (worker_count > 0);
 
+    // resources reserve
+    m_available_workers.reserve (worker_count);
+
     // workers
     allocate_workers (worker_count);
     initialize_workers ();
-
-    // resources reserve
-    m_available_workers.reserve (worker_count);
   }
 
   void
@@ -384,7 +345,7 @@ namespace cubthread
       }
     temp_guard.unlock ();
 
-    // stop all workers to stop
+    // tell all workers to stop
     std::unique_lock<std::mutex> worker_guard (m_workers_mutex);
 
     for (auto it = m_workers.begin (); it != m_workers.end (); it++)
@@ -482,6 +443,45 @@ namespace cubthread
     std::unique_lock<std::mutex> ulock (m_temp_workers_mutex);
 
     m_free_temp_workers.clear ();
+  }
+
+  std::unique_ptr<worker_pool::core::worker>
+  worker_pool::core::allocate_worker (bool is_temp)
+  {
+    return std::unique_ptr<worker> (new worker (is_temp));
+  }
+
+  void
+  worker_pool::core::allocate_workers (std::size_t worker_count)
+  {
+    std::size_t it;
+
+    m_workers.reserve (worker_count);
+    for (it = 0; it < worker_count; it++)
+      {
+	m_workers.push_back (allocate_worker ());
+      }
+  }
+
+  void
+  worker_pool::core::initialize_workers ()
+  {
+    for (auto it = m_workers.begin (); it != m_workers.end (); it++)
+      {
+	(*it)->set_core (*this);
+
+	if (m_parent_pool->get_pool_threads ())
+	  {
+	    // assign task / start thread
+	    // it will add itself to available workers
+	    (*it)->assign_task (NULL);
+	  }
+	else
+	  {
+	    // add to available workers
+	    m_available_workers.push_back (it->get ());
+	  }
+      }
   }
 
   void
@@ -807,7 +807,7 @@ namespace cubthread
   }
 
   //////////////////////////////////////////////////////////////////////////
-  // [optional] userful when using perf
+  // [optional] useful when using perf
   //////////////////////////////////////////////////////////////////////////
 
   static bool FORCE_THREAD_ALWAYS_ALIVE = false;

--- a/src/thread/thread_worker_pool.cpp
+++ b/src/thread/thread_worker_pool.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008 Search Solution Corporation
+ *
  * Copyright 2016 CUBRID Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,70 +24,50 @@
 
 #include "resources.hpp"
 #include "error_manager.h"
-#include "perf.hpp"
 
-#include <sstream>
 #include <cstring>
-#include <cmath>
 
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
 #include "memory_wrapper.hpp"
 
 namespace cubthread
 {
-  /************************************************************************/
-  /* inline implementation						  */
-  /************************************************************************/
-
   //////////////////////////////////////////////////////////////////////////
   // worker_pool implementation
   //////////////////////////////////////////////////////////////////////////
 
-  worker_pool::worker_pool (std::size_t pool_size, std::size_t task_max_count,
-			    entry_manager &entry_mgr, const char *name, std::size_t core_count,
-			    bool debug_log, bool pool_threads, wait_seconds wait_for_task_time)
-    : m_max_workers (pool_size)
-    , m_task_max_count (task_max_count)
-    , m_task_count (0)
+  worker_pool::worker_pool (std::size_t pool_size, std::size_t core_count, const char *name, entry_manager &entry_mgr,
+			    bool pool_threads, wait_seconds wait_for_task_time)
+    : m_name (name == NULL ? "" : name)
     , m_entry_manager (entry_mgr)
-    , m_core_array (NULL)
-    , m_core_count (core_count)
+    , m_max_workers (pool_size)
     , m_round_robin_counter (0)
     , m_stopped (false)
-    , m_log (debug_log)
     , m_pool_threads (pool_threads)
     , m_wait_for_task_time (wait_for_task_time)
-    , m_name (name == NULL ? "" : name)
   {
-    // initialize cores; we'll try to distribute pool evenly to all cores. if core count is not fully contained in
-    // pool size, some cores will have one additional worker
+    assert (core_count > 0 && core_count <= pool_size);
+  }
 
-    if (m_core_count == 0)
-      {
-	assert (false);
-	m_core_count = 1;
-      }
+  worker_pool::~worker_pool ()
+  {
+    // not safe to destroy running pools
+    assert (m_stopped);
+  }
 
-    if (m_core_count > pool_size)
-      {
-	m_core_count = pool_size;
-      }
+  const std::string &
+  worker_pool::get_name (void) const
+  {
+    return m_name;
+  }
 
-    m_core_array = new core[m_core_count];
+  void
+  worker_pool::initialize (std::size_t worker_count, std::size_t core_count)
+  {
+    allocate_cores (core_count);
+    assign_workers_to_cores (core_count, worker_count);
 
-    std::size_t quotient = m_max_workers / m_core_count;
-    std::size_t remainder = m_max_workers % m_core_count;
-    std::size_t it = 0;
-
-    for (; it < remainder; it++)
-      {
-	m_core_array[it].init_pool_and_workers (*this, quotient + 1);
-      }
-    for (; it < m_core_count; it++)
-      {
-	m_core_array[it].init_pool_and_workers (*this, quotient);
-      }
-
+    // [optional] this option must be useful using perf
     if (wp_is_thread_always_alive_forced ())
       {
 	// override pooling/wait time options to keep threads always alive
@@ -96,41 +76,25 @@ namespace cubthread
       }
   }
 
-  worker_pool::~worker_pool ()
-  {
-    // not safe to destroy running pools
-    assert (m_stopped);
-
-    delete [] m_core_array;
-    m_core_array = NULL;
-  }
-
-  bool
-  worker_pool::try_execute (task_type *work_arg)
-  {
-    if (is_full ())
-      {
-	return false;
-      }
-
-    execute (work_arg);
-    return true;
-  }
-
   void
   worker_pool::execute (task_type *work_arg)
   {
-    execute_on_core (work_arg, get_round_robin_core_hash ());
+    execute_on_core (work_arg, get_next_core ());
   }
 
   void
-  worker_pool::execute_on_core (task_type *work_arg, std::size_t core_hash, bool for_method)
+  worker_pool::execute_on_core (task_type *work_arg, std::size_t core_hash, bool is_temp)
   {
-    // increment task count
-    ++m_task_count;
+    std::size_t core_index;
 
-    std::size_t core_index = core_hash % m_core_count;
-    m_core_array[core_index].execute_task (work_arg, for_method);
+    core_index = core_hash % m_cores.size ();
+    m_cores[core_index]->execute_task (work_arg, is_temp);
+  }
+
+  bool
+  worker_pool::is_running (void) const
+  {
+    return !m_stopped;
   }
 
   void
@@ -161,10 +125,10 @@ namespace cubthread
       {
 	// notify all cores to stop
 	is_not_stopped = false;     // assume all are stopped
-	for (std::size_t it = 0; it < m_core_count; it++)
+	for (std::size_t it = 0; it < m_cores.size (); it++)
 	  {
 	    // notify all workers to stop. if any worker is still running, is_not_stopped = true is output
-	    m_core_array[it].notify_stop (is_not_stopped);
+	    m_cores[it]->notify_stop (is_not_stopped);
 	  }
 
 	if (!is_not_stopped)
@@ -185,41 +149,14 @@ namespace cubthread
       }
 
     // retire all tasks that have not been executed; at this point, no new tasks are produced
-    for (std::size_t it = 0; it < m_core_count; it++)
+    for (std::size_t it = 0; it < m_cores.size (); it++)
       {
-	m_core_array[it].retire_queued_tasks ();
+	m_cores[it]->retire_queued_tasks ();
       }
-  }
-
-  void
-  worker_pool::start_all_workers (void)
-  {
-    for (std::size_t it = 0; it < m_core_count; it++)
-      {
-	m_core_array[it].start_all_workers ();
-      }
-  }
-
-  bool
-  worker_pool::is_running (void) const
-  {
-    return !m_stopped;
-  }
-
-  const std::string &
-  worker_pool::get_name (void) const
-  {
-    return m_name;
-  }
-
-  bool
-  worker_pool::is_full (void) const
-  {
-    return m_task_count >= m_task_max_count;
   }
 
   std::size_t
-  worker_pool::get_max_count (void) const
+  worker_pool::get_worker_count (void) const
   {
     return m_max_workers;
   }
@@ -227,42 +164,54 @@ namespace cubthread
   std::size_t
   worker_pool::get_core_count (void) const
   {
-    return m_core_count;
+    return m_cores.size ();
+  }
+
+  std::unique_ptr<worker_pool::core>
+  worker_pool::allocate_core (void)
+  {
+    return std::make_unique<worker_pool::core> ();
   }
 
   void
-  worker_pool::get_stats (cubperf::stat_value *stats_out) const
+  worker_pool::allocate_cores (std::size_t core_count)
   {
-    for (std::size_t it = 0; it < m_core_count; it++)
-      {
-	m_core_array[it].get_stats (stats_out);
-      }
-  }
+    std::size_t it;
 
-  void worker_pool::get_task_stats (uint64_t *stats_out) noexcept
-  {
-    for (std::size_t it = 0; it < m_core_count; it++)
+    m_cores.reserve (core_count);
+    for (it = 0; it < core_count; it++)
       {
-	auto [requested, started, completed] = m_core_array[it].get_task_stats ();
-	stats_out[0] += requested;
-	stats_out[1] += started;
-	stats_out[2] += completed;
+	m_cores.push_back (allocate_core ());
       }
   }
 
   void
-  worker_pool::er_log_stats (void) const
+  worker_pool::assign_workers_to_cores (std::size_t core_count, std::size_t worker_count)
   {
-    if (!m_log)
-      {
-	return;
-      }
+    std::size_t quotient, remainder;
+    std::size_t it;
 
-    const std::size_t MAX_SIZE = 32;
-    cubperf::stat_value stats[MAX_SIZE];
-    std::memset (stats, 0, sizeof (stats));
-    get_stats (stats);
-    wp_er_log_stats (m_name.c_str (), stats);
+    quotient = worker_count / m_cores.size ();
+    remainder = worker_count % m_cores.size ();
+
+    for (it = 0; it < remainder; it++)
+      {
+	m_cores[it]->set_worker_pool (*this);
+	// worker pool is referenced in worker to get m_pool_threads when initialing core
+	m_cores[it]->initialize (quotient + 1);
+      }
+    for (; it < m_cores.size (); it++)
+      {
+	m_cores[it]->set_worker_pool (*this);
+	// worker pool is referenced in worker to get m_pool_threads when initialing core
+	m_cores[it]->initialize (quotient);
+      }
+  }
+
+  std::size_t
+  worker_pool::get_next_core (void)
+  {
+    return get_round_robin_core_hash ();
   }
 
   std::size_t
@@ -311,94 +260,81 @@ namespace cubthread
 
   worker_pool::core::core ()
     : m_parent_pool (NULL)
-    , m_max_workers (0)
-    , m_worker_array (NULL)
-    , m_available_workers (NULL)
-    , m_available_count (0)
-    , m_task_queue ()
-    , m_workers_mutex ()
-    , m_temp_workers ()
-    , m_temp_free_workers ()
-    , m_temp_workers_mutex ()
   {
-    m_task_metrics.requested.store (0, std::memory_order_relaxed);
-    m_task_metrics.started.store (0, std::memory_order_relaxed);
-    m_task_metrics.completed.store (0, std::memory_order_relaxed);
   }
 
   worker_pool::core::~core ()
   {
-    delete [] m_worker_array;
-    m_worker_array = NULL;
+  }
 
-    delete [] m_available_workers;
-    m_available_workers = NULL;
-
-    std::lock_guard<std::mutex> ulock (m_temp_workers_mutex);
-
-    for (worker *w : m_temp_workers)
-      {
-	if (w)
-	  {
-	    delete w;
-	  }
-      }
-    m_temp_workers.clear ();
-
-    for (worker *w : m_temp_free_workers)
-      {
-	delete w;
-      }
-    m_temp_free_workers.clear ();
+  std::unique_ptr<worker_pool::core::worker>
+  worker_pool::core::allocate_worker (bool is_temp)
+  {
+    return std::make_unique<worker_pool::core::worker> (is_temp);
   }
 
   void
-  worker_pool::core::init_pool_and_workers (worker_pool &parent, std::size_t worker_count)
+  worker_pool::core::allocate_workers (std::size_t worker_count)
   {
-    assert (worker_count > 0);
+    std::size_t it;
 
-    m_parent_pool = &parent;
-    m_max_workers = worker_count;
-
-    // allocate workers array
-    m_worker_array = new worker[m_max_workers];
-    m_available_workers = new worker*[m_max_workers];
-
-    for (std::size_t it = 0; it < m_max_workers; it++)
+    m_workers.reserve (worker_count);
+    for (it = 0; it < worker_count; it++)
       {
-	m_worker_array[it].init_core (*this);
-	if (m_parent_pool->m_pool_threads)
+	m_workers.push_back (allocate_worker ());
+      }
+  }
+
+  void
+  worker_pool::core::initialize_workers ()
+  {
+    for (auto it = m_workers.begin (); it != m_workers.end (); it++)
+      {
+	(*it)->set_core (*this);
+
+	if (m_parent_pool->get_pool_threads ())
 	  {
 	    // assign task / start thread
 	    // it will add itself to available workers
-	    m_worker_array[it].assign_task (NULL, cubperf::clock::now ());
+	    (*it)->assign_task (NULL);
 	  }
 	else
 	  {
 	    // add to available workers
-	    m_available_workers[m_available_count++] = &m_worker_array[it];
+	    m_available_workers.push_back (it->get ());
 	  }
       }
   }
 
   void
-  worker_pool::core::finished_task_notification (void)
+  worker_pool::core::initialize (std::size_t worker_count)
   {
-    // decrement task count
-    -- (m_parent_pool->m_task_count);
+    assert (worker_count > 0);
+
+    // workers
+    allocate_workers (worker_count);
+    initialize_workers ();
+
+    // resources reserve
+    m_available_workers.reserve (worker_count);
   }
 
   void
-  worker_pool::core::execute_task (task_type *task_p, bool for_method)
+  worker_pool::core::set_worker_pool (worker_pool &parent)
   {
-    assert (task_p != NULL);
+    m_parent_pool = &parent;
+  }
 
+  void
+  worker_pool::core::execute_task (task_type *task_p, bool is_temp)
+  {
     // find an available worker
     // 1. one already active is preferable
     // 2. inactive will do too
-    // 3. if no workers, reject task (returns false)
+    // 3. if no workers, enqueue the task
 
-    cubperf::time_point push_time = cubperf::clock::now ();
+    assert (task_p != NULL);
+
     worker *refp = NULL;
 
     if (m_parent_pool->m_stopped)
@@ -408,23 +344,25 @@ namespace cubthread
 	return;
       }
 
-    on_task_requested ();
-
     std::unique_lock<std::mutex> ulock (m_workers_mutex);
 
-    if (m_available_count > 0)
+    if (!m_available_workers.empty ())
       {
-	refp = m_available_workers[--m_available_count];
+	refp = m_available_workers.back ();
+	m_available_workers.pop_back ();
 	ulock.unlock ();
 
 	assert (refp != NULL);
-	refp->assign_task (task_p, push_time);
+	refp->assign_task (task_p);
       }
     else
       {
-	if (for_method)
+	if (is_temp)
 	  {
-	    execute_temp_task (task_p, push_time);
+	    // no need to hold the mutex (prevent deadlock)
+	    ulock.unlock ();
+
+	    execute_task_as_temp (task_p);
 	  }
 	else
 	  {
@@ -435,155 +373,25 @@ namespace cubthread
   }
 
   void
-  worker_pool::core::execute_temp_task (task_type *task_p, const cubperf::time_point &push_time)
-  {
-    worker *w = new worker (true);
-    w->init_core (*this);
-
-    std::lock_guard<std::mutex> ulock (m_temp_workers_mutex);
-    m_temp_workers.insert (w);
-    w->assign_task (task_p, push_time);
-  }
-
-  worker_pool::task_type *
-  worker_pool::core::get_task_or_become_available (worker &worker_arg)
-  {
-    std::unique_lock<std::mutex> ulock (m_workers_mutex);
-
-    if (!m_task_queue.empty ())
-      {
-	task_type *task_p = m_task_queue.front ();
-	assert (task_p != NULL);
-	m_task_queue.pop ();
-	return task_p;
-      }
-
-    m_available_workers[m_available_count++] = &worker_arg;
-    assert (m_available_count <= m_max_workers);
-    return NULL;
-  }
-
-  void
-  worker_pool::core::become_available (worker &worker_arg)
-  {
-    std::unique_lock<std::mutex> ulock (m_workers_mutex);
-    m_available_workers[m_available_count++] = &worker_arg;
-    assert (m_available_count <= m_max_workers);
-  }
-
-  void
-  worker_pool::core::check_worker_not_available (const worker &worker_arg)
-  {
-#if !defined (NDEBUG)
-    std::unique_lock<std::mutex> ulock (m_workers_mutex);
-
-    for (std::size_t idx = 0; idx < m_available_count; idx++)
-      {
-	assert (m_available_workers[idx] != &worker_arg);
-      }
-#endif // DEBUG
-  }
-
-  entry_manager &
-  worker_pool::core::get_entry_manager (void)
-  {
-    return m_parent_pool->m_entry_manager;
-  }
-
-  std::size_t
-  worker_pool::core::get_max_worker_count (void) const
-  {
-    return m_max_workers;
-  }
-
-  void
   worker_pool::core::notify_stop (bool &is_not_stopped)
   {
     // stop all temp workers first
-    std::unique_lock<std::mutex> ulock (m_temp_workers_mutex);
-    for (worker *w : m_temp_workers)
+    std::unique_lock<std::mutex> temp_guard (m_temp_workers_mutex);
+
+    for (auto it = m_temp_workers.begin (); it != m_temp_workers.end (); it++)
       {
-	w->stop_execution (is_not_stopped);
+	(*it)->stop_execution (is_not_stopped);
       }
-    ulock.unlock ();
+    temp_guard.unlock ();
 
-    // tell all workers to stop
-    for (std::size_t it = 0; it < m_max_workers; it++)
+    // stop all workers to stop
+    std::unique_lock<std::mutex> worker_guard (m_workers_mutex);
+
+    for (auto it = m_workers.begin (); it != m_workers.end (); it++)
       {
-	m_worker_array[it].stop_execution (is_not_stopped);
+	(*it)->stop_execution (is_not_stopped);
       }
-  }
-
-  void
-  worker_pool::core::start_all_workers (void)
-  {
-    worker *refp = NULL;
-    const std::size_t AVAILABLE_STACK_DEFAULT_SIZE = 1024;
-    cubmem::appendable_array<worker *, AVAILABLE_STACK_DEFAULT_SIZE> available_stack;
-
-    // how this works:
-    //
-    // we need to start all workers, but we need to consider the fact that some may be already running. what we need
-    // to do is process the available workers and start threads for all those that don't have a thread started.
-    //
-    // workers that already have threads are saved and added back after processing all available workers.
-    //
-    // NOTE: this function does not guarantee that at the end all workers have threads. workers that stop their threads
-    //       during processing available workers are not restarted. however, we end up starting all or almost all
-    //       threads, which is good enough.
-    //
-
-    while (true)
-      {
-	// processing is done in two steps:
-	//
-	//    1. retrieve worker from available workers holding workers mutex
-	//    2. verify if worker has a thread started
-	//        2.1. if it doesn't have a thread, start one
-	//        2.2. if it does have thread, save it to available_stack.
-	//
-
-	std::unique_lock<std::mutex> core_lock (m_workers_mutex);
-	if (m_available_count == 0)
-	  {
-	    break;
-	  }
-	refp = m_available_workers[--m_available_count];
-	core_lock.unlock ();
-
-	if (refp->has_thread ())
-	  {
-	    // stack to make available at the end
-	    available_stack.append (&refp, 1);
-
-	    // note: this worker's thread may stop soon or may have stopped already. this case is accepted.
-	  }
-	else
-	  {
-	    // this thread is already stopped and we can start its thread
-	    refp->set_push_time_now ();
-	    refp->set_has_thread ();
-	    refp->start_thread ();
-	  }
-      }
-
-    // copy all workers having threads back to available array.
-    if (available_stack.get_size () > 0)
-      {
-	std::unique_lock<std::mutex> core_lock (m_workers_mutex);
-	if (m_available_count > 0)
-	  {
-	    // move current available to make room for older ones
-	    std::memmove (m_available_workers + available_stack.get_size (), m_available_workers,
-			  m_available_count * sizeof (worker *));
-	  }
-
-	// copy from stack at the beginning of m_available_workers
-	std::memcpy (m_available_workers, available_stack.get_array (), available_stack.get_memsize ());
-
-	// update available count
-	m_available_count += available_stack.get_size ();
-      }
+    worker_guard.unlock ();
   }
 
   void
@@ -598,19 +406,58 @@ namespace cubthread
       }
   }
 
-  void
-  worker_pool::core::get_stats (cubperf::stat_value *stats_out) const
+  worker_pool::task_type *
+  worker_pool::core::get_task_or_become_available (worker &worker_arg)
   {
-    for (std::size_t it = 0; it < m_max_workers; it++)
+    std::unique_lock<std::mutex> ulock (m_workers_mutex);
+
+    if (!m_task_queue.empty ())
       {
-	m_worker_array[it].get_stats (stats_out);
+	task_type *task_p = m_task_queue.front ();
+	assert (task_p != NULL);
+	m_task_queue.pop ();
+
+	return task_p;
       }
 
-    std::unique_lock<std::mutex> ulock (m_temp_workers_mutex);
-    for (worker *w: m_temp_workers)
+    m_available_workers.push_back (&worker_arg);
+    assert (m_available_workers.size () <= m_workers.size ());
+
+    return NULL;
+  }
+
+  void
+  worker_pool::core::become_available (worker &worker_arg)
+  {
+    std::unique_lock<std::mutex> ulock (m_workers_mutex);
+
+    m_available_workers.push_back (&worker_arg);
+    assert (m_available_workers.size () <= m_workers.size ());
+  }
+
+  void
+  worker_pool::core::check_worker_not_available (const worker &worker_arg)
+  {
+#if !defined (NDEBUG)
+    std::unique_lock<std::mutex> ulock (m_workers_mutex);
+
+    for (auto it = m_available_workers.begin (); it != m_available_workers.end (); it++)
       {
-	w->get_stats (stats_out);
+	assert (*it != &worker_arg);
       }
+#endif // DEBUG
+  }
+
+  entry_manager &
+  worker_pool::core::get_entry_manager (void)
+  {
+    return m_parent_pool->m_entry_manager;
+  }
+
+  std::size_t
+  worker_pool::core::get_worker_count (void) const
+  {
+    return m_workers.size ();
   }
 
   void
@@ -618,8 +465,15 @@ namespace cubthread
   {
     std::unique_lock<std::mutex> ulock (m_temp_workers_mutex);
 
-    m_temp_workers.erase (w);
-    m_temp_free_workers.push_back (w);
+    auto it = std::find_if (m_temp_workers.begin (), m_temp_workers.end (), [w] (const std::unique_ptr<worker> &p)
+    {
+      return p.get () == w;
+    });
+
+    assert (it != m_temp_workers.end ());
+
+    m_free_temp_workers.push_back (std::move (*it));
+    m_temp_workers.erase (it);
   }
 
   void
@@ -627,34 +481,19 @@ namespace cubthread
   {
     std::unique_lock<std::mutex> ulock (m_temp_workers_mutex);
 
-    for (worker *w: m_temp_free_workers)
-      {
-	delete w;
-      }
-    m_temp_free_workers.clear ();
+    m_free_temp_workers.clear ();
   }
 
-  inline uint64_t worker_pool::core::on_task_requested () noexcept
+  void
+  worker_pool::core::execute_task_as_temp (task_type *task_p)
   {
-    return m_task_metrics.requested.fetch_add (1, std::memory_order_relaxed);
-  }
+    auto w = allocate_worker (true);
+    w->set_core (*this);
 
-  inline uint64_t worker_pool::core::on_task_started () noexcept
-  {
-    return m_task_metrics.started.fetch_add (1, std::memory_order_relaxed);
-  }
+    std::lock_guard<std::mutex> ulock (m_temp_workers_mutex);
 
-  inline uint64_t worker_pool::core::on_task_completed () noexcept
-  {
-    return m_task_metrics.completed.fetch_add (1, std::memory_order_relaxed);
-  }
-
-  std::tuple<uint64_t, uint64_t, uint64_t> worker_pool::core::get_task_stats () noexcept
-  {
-    uint64_t completed = m_task_metrics.completed.load (std::memory_order_relaxed);
-    uint64_t started = m_task_metrics.started.load (std::memory_order_relaxed);
-    uint64_t requested = m_task_metrics.requested.load (std::memory_order_relaxed);
-    return { requested, started, completed };
+    m_temp_workers.push_back (std::move (w));
+    m_temp_workers.back ()->assign_task (task_p);
   }
 
   //////////////////////////////////////////////////////////////////////////
@@ -665,33 +504,47 @@ namespace cubthread
     : m_parent_core (NULL)
     , m_context_p (NULL)
     , m_task_p (NULL)
-    , m_task_cv ()
-    , m_task_mutex ()
     , m_stop (false)
     , m_has_thread (false)
     , m_is_temp (is_temp)
-    , m_statistics (wp_worker_statset_create ())
-    , m_push_time ()
   {
   }
 
   worker_pool::core::worker::~worker (void)
   {
-    wp_worker_statset_destroy (m_statistics);
   }
 
   void
-  worker_pool::core::worker::init_core (core &parent)
+  worker_pool::core::worker::set_core (core &parent)
   {
     m_parent_core = &parent;
   }
 
   void
-  worker_pool::core::worker::assign_task (task_type *work_p, cubperf::time_point push_time)
+  worker_pool::core::worker::start_thread (void)
   {
-    // save push time
-    m_push_time = push_time;
+    assert (m_has_thread);
 
+    //
+    // the next code tries to help visualizing any system errors that can occur during create or detach in debug
+    // mode
+    //
+    // release will basically be reduced to:
+    // std::thread (&worker::run, this).detach ();
+    //
+
+    std::thread t;
+
+    auto lambda_create = [&] (void) -> void { t = std::thread (&worker::run, this); };
+    auto lambda_detach = [&] (void) -> void { t.detach (); };
+
+    wp_call_func_throwing_system_error ("starting thread", lambda_create);
+    wp_call_func_throwing_system_error ("detaching thread", lambda_detach);
+  }
+
+  void
+  worker_pool::core::worker::assign_task (task_type *work_p)
+  {
     std::unique_lock<std::mutex> ulock (m_task_mutex);
 
     // save task
@@ -722,39 +575,12 @@ namespace cubthread
   }
 
   void
-  worker_pool::core::worker::start_thread (void)
+  worker_pool::core::worker::push_task_on_running_thread (task_type *work_p)
   {
-    assert (m_has_thread);
-
-    //
-    // the next code tries to help visualizing any system errors that can occur during create or detach in debug
-    // mode
-    //
-    // release will basically be reduced to:
-    // std::thread (&worker::run, this).detach ();
-    //
-
-    std::thread t;
-
-    auto lambda_create = [&] (void) -> void { t = std::thread (&worker::run, this); };
-    auto lambda_detach = [&] (void) -> void { t.detach (); };
-
-    wp_call_func_throwing_system_error ("starting thread", lambda_create);
-    wp_call_func_throwing_system_error ("detaching thread", lambda_detach);
-  }
-
-  void
-  worker_pool::core::worker::push_task_on_running_thread (task_type *work_p,
-      cubperf::time_point push_time)
-  {
-    // run on current thread
-    assert (work_p != NULL);
-
-    m_push_time = push_time;
-
     // must lock task mutex
     std::unique_lock<std::mutex> ulock (m_task_mutex);
 
+    assert (work_p != NULL);
     // make sure worker is in a valid state
     assert (m_task_p == NULL);
     assert (m_context_p != NULL);
@@ -762,8 +588,9 @@ namespace cubthread
     // set task
     m_task_p = work_p;
 
+    // mutex is not needed for notify
+    ulock.unlock ();
     // notify waiting thread
-    ulock.unlock (); // mutex is not needed for notify
     m_task_cv.notify_one ();
   }
 
@@ -783,12 +610,14 @@ namespace cubthread
 
     if (m_has_thread)
       {
-	/// this thread is still running
+	// this thread is still running
 	is_not_stopped = true;
       }
 
-    m_stop = true;    // stop worker
-    ulock.unlock ();    // mutex is not needed for notify
+    // stop worker
+    m_stop = true;
+    // mutex is not needed for notify
+    ulock.unlock ();
 
     if (m_is_temp)
       {
@@ -799,165 +628,16 @@ namespace cubthread
   }
 
   void
-  worker_pool::core::worker::init_run (void)
-  {
-    // safe-guard - we have a thread
-    assert (m_has_thread);
-
-    // safe-guard - threads should [no longer] be available
-    if (m_is_temp == false)
-      {
-	m_parent_core->check_worker_not_available (*this);
-      }
-
-    // thread was started
-    m_statistics.m_timept = m_push_time;
-    wp_worker_statset_time_and_increment (m_statistics, Wpstat_start_thread);
-
-    // a context is required
-    m_context_p = &m_parent_core->get_entry_manager ().create_context ();
-    wp_worker_statset_time_and_increment (m_statistics, Wpstat_create_context);
-  }
-
-  void
-  worker_pool::core::worker::finish_run (void)
-  {
-    assert (m_task_p == NULL);
-    assert (m_context_p != NULL);
-
-    // retire context
-    m_parent_core->get_entry_manager ().retire_context (*m_context_p);
-    m_context_p = NULL;
-    wp_worker_statset_time_and_increment (m_statistics, Wpstat_retire_context);
-
-    if (m_is_temp)
-      {
-	m_parent_core->register_free_temp_list (this);
-      }
-  }
-
-  void
-  worker_pool::core::worker::retire_current_task (void)
-  {
-    assert (m_task_p != NULL);
-
-    // retire task
-    m_task_p->retire ();
-    m_task_p = NULL;
-    wp_worker_statset_time_and_increment (m_statistics, Wpstat_retire_task);
-  }
-
-  void
-  worker_pool::core::worker::execute_current_task (void)
-  {
-    assert (m_task_p != NULL);
-
-    m_parent_core->on_task_started ();
-
-    // execute task
-    m_task_p->execute (*m_context_p);
-
-    m_parent_core->on_task_completed ();
-    wp_worker_statset_time_and_increment (m_statistics, Wpstat_execute_task);
-
-    // and retire task
-    retire_current_task ();
-
-    // and recycle context before getting another task
-    m_parent_core->get_entry_manager ().recycle_context (*m_context_p);
-    wp_worker_statset_time_and_increment (m_statistics, Wpstat_recycle_context);
-
-    // notify core one task was finished
-    if (m_is_temp == false)
-      {
-	m_parent_core->finished_task_notification ();
-	m_parent_core->free_all_temp_list ();
-      }
-  }
-
-  bool
-  worker_pool::core::worker::get_new_task (void)
-  {
-    assert (m_task_p == NULL);
-
-    std::unique_lock<std::mutex> ulock (m_task_mutex, std::defer_lock);
-
-    // check stop condition
-    if (!m_stop)
-      {
-	// get a queued task or wait for one to come
-
-	// either get a queued task or add to free active list
-	// note: returned task cannot be saved directly to m_task_p. if worker is added to wait queue and NULL is returned,
-	//       current thread may be preempted. worker is then claimed from free active list and worker is assigned
-	//       a task. this changes expected behavior and can have unwanted consequences.
-	task_type *task_p = m_parent_core->get_task_or_become_available (*this);
-	if (task_p != NULL)
-	  {
-	    wp_worker_statset_time_and_increment (m_statistics, Wpstat_found_in_queue);
-
-	    // it is safe to set here
-	    m_task_p = task_p;
-	    return true;
-	  }
-
-	// wait for task
-	ulock.lock ();
-	if (m_task_p == NULL && !m_stop)
-	  {
-	    // wait until a task is received or stopped ...
-	    // ... or time out
-	    condvar_wait (m_task_cv, ulock, m_parent_core->get_parent_pool ()->get_wait_for_task_time (),
-			  [this] () -> bool { return m_task_p != NULL || m_stop; });
-	  }
-	else
-	  {
-	    // no need to wait
-	  }
-      }
-    else
-      {
-	// we need to add to available list
-	m_parent_core->become_available (*this);
-
-	ulock.lock ();
-      }
-
-    // did I get a task?
-    if (m_task_p == NULL)
-      {
-	// no; this thread will stop. from this point forward, if a new task is assigned, a new thread must be spawned
-	m_has_thread = false;
-
-	// finish_run; we neet to retire context before another thread uses this worker
-	m_statistics.m_timept = cubperf::clock::now ();
-	finish_run ();
-
-	return false;
-      }
-    else
-      {
-	// unlock mutex
-	ulock.unlock ();
-
-	// safe-guard - threads should no longer be available
-	m_parent_core->check_worker_not_available (*this);
-
-	// found task
-	m_statistics.m_timept = m_push_time;
-	wp_worker_statset_time_and_increment (m_statistics, Wpstat_wakeup_with_task);
-	return true;
-      }
-  }
-
-  void
   worker_pool::core::worker::run (void)
   {
-    os::resources::cpu::clearaffinity ();   // clear the affinity at start
+    // clear the affinity at start
+    os::resources::cpu::clearaffinity ();
     pthread_setname_np (pthread_self (), m_parent_core->get_parent_pool ()->get_name ().c_str ());
 
-    init_run ();    // do stuff at the beginning like creating context
+    // do stuff at the beginning like creating context
+    init_run ();
 
+    // do task and terminate if this is temp worker
     if (m_is_temp)
       {
 	execute_current_task ();
@@ -992,13 +672,142 @@ namespace cubthread
   }
 
   void
-  worker_pool::core::worker::get_stats (cubperf::stat_value *sum_inout) const
+  worker_pool::core::worker::init_run (void)
   {
-    wp_worker_statset_accumulate (m_statistics, sum_inout);
+    // safe-guard - we have a thread
+    assert (m_has_thread);
+
+#if !defined (NDEBUG)
+    // safe-guard - threads should [no longer] be available
+    if (!m_is_temp)
+      {
+	m_parent_core->check_worker_not_available (*this);
+      }
+#endif
+
+    // a context is required
+    m_context_p = &m_parent_core->get_entry_manager ().create_context ();
+  }
+
+  void
+  worker_pool::core::worker::finish_run (void)
+  {
+    assert (m_task_p == NULL);
+    assert (m_context_p != NULL);
+
+    // retire context
+    m_parent_core->get_entry_manager ().retire_context (*m_context_p);
+    m_context_p = NULL;
+
+    if (m_is_temp)
+      {
+	m_parent_core->register_free_temp_list (this);
+      }
+  }
+
+  void
+  worker_pool::core::worker::execute_current_task (void)
+  {
+    assert (m_task_p != NULL);
+
+    // execute task
+    m_task_p->execute (*m_context_p);
+
+    // and retire task
+    retire_current_task ();
+
+    // and recycle context before getting another task
+    m_parent_core->get_entry_manager ().recycle_context (*m_context_p);
+
+    // notify core one task was finished
+    if (m_is_temp == false)
+      {
+	m_parent_core->free_all_temp_list ();
+      }
+  }
+
+  void
+  worker_pool::core::worker::retire_current_task (void)
+  {
+    assert (m_task_p != NULL);
+
+    // retire task
+    m_task_p->retire ();
+    m_task_p = NULL;
+  }
+
+  bool
+  worker_pool::core::worker::get_new_task (void)
+  {
+    assert (m_task_p == NULL);
+
+    std::unique_lock<std::mutex> ulock (m_task_mutex, std::defer_lock);
+
+    // check stop condition
+    if (!m_stop)
+      {
+	// get a queued task or wait for one to come
+
+	// either get a queued task or add to free active list
+	// note: returned task cannot be saved directly to m_task_p. if worker is added to wait queue and NULL is returned,
+	//       current thread may be preempted. worker is then claimed from free active list and worker is assigned
+	//       a task. this changes expected behavior and can have unwanted consequences.
+	task_type *task_p = m_parent_core->get_task_or_become_available (*this);
+	if (task_p != NULL)
+	  {
+	    // it is safe to set here
+	    m_task_p = task_p;
+	    return true;
+	  }
+
+	// wait for task
+	ulock.lock ();
+	if (m_task_p == NULL && !m_stop)
+	  {
+	    // wait until a task is received or stopped ...
+	    // ... or time out
+	    condvar_wait (m_task_cv, ulock, m_parent_core->get_parent_pool ()->get_wait_for_task_time (),
+			  [this] () -> bool { return m_task_p != NULL || m_stop; });
+	  }
+	else
+	  {
+	    // no need to wait
+	  }
+      }
+    else
+      {
+	// we need to add to available list
+	m_parent_core->become_available (*this);
+
+	ulock.lock ();
+      }
+
+    // did I get a task?
+    if (m_task_p == NULL)
+      {
+	// no; this thread will stop. from this point forward, if a new task is assigned, a new thread must be spawned
+	m_has_thread = false;
+
+	// finish_run; we neet to retire context before another thread uses this worker
+	finish_run ();
+
+	return false;
+      }
+    else
+      {
+	// unlock mutex
+	ulock.unlock ();
+
+	// safe-guard - threads should no longer be available
+	m_parent_core->check_worker_not_available (*this);
+
+	// found task
+	return true;
+      }
   }
 
   //////////////////////////////////////////////////////////////////////////
-  // checker
+  // [optional] userful when using perf
   //////////////////////////////////////////////////////////////////////////
 
   static bool FORCE_THREAD_ALWAYS_ALIVE = false;
@@ -1013,66 +822,6 @@ namespace cubthread
   wp_set_force_thread_always_alive ()
   {
     FORCE_THREAD_ALWAYS_ALIVE = true;
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // statistics
-  //////////////////////////////////////////////////////////////////////////
-
-  static const cubperf::statset_definition Worker_pool_statdef =
-  {
-    cubperf::stat_definition (Wpstat_start_thread, cubperf::stat_definition::COUNTER_AND_TIMER,
-			      "Counter_start_thread", "Timer_start_thread"),
-    cubperf::stat_definition (Wpstat_create_context, cubperf::stat_definition::COUNTER_AND_TIMER,
-			      "Counter_create_context", "Timer_create_context"),
-    cubperf::stat_definition (Wpstat_execute_task, cubperf::stat_definition::COUNTER_AND_TIMER,
-			      "Counter_execute_task", "Timer_execute_task"),
-    cubperf::stat_definition (Wpstat_retire_task, cubperf::stat_definition::COUNTER_AND_TIMER,
-			      "Counter_retire_task", "Timer_retire_task"),
-    cubperf::stat_definition (Wpstat_found_in_queue, cubperf::stat_definition::COUNTER_AND_TIMER,
-			      "Counter_found_task_in_queue", "Timer_found_task_in_queue"),
-    cubperf::stat_definition (Wpstat_wakeup_with_task, cubperf::stat_definition::COUNTER_AND_TIMER,
-			      "Counter_wakeup_with_task", "Timer_wakeup_with_task"),
-    cubperf::stat_definition (Wpstat_recycle_context, cubperf::stat_definition::COUNTER_AND_TIMER,
-			      "Counter_recycle_context", "Timer_recycle_context"),
-    cubperf::stat_definition (Wpstat_retire_context, cubperf::stat_definition::COUNTER_AND_TIMER,
-			      "Counter_retire_context", "Timer_retire_context")
-  };
-
-  cubperf::statset &
-  wp_worker_statset_create (void)
-  {
-    return *Worker_pool_statdef.create_statset ();
-  }
-
-  void
-  wp_worker_statset_destroy (cubperf::statset &stats)
-  {
-    delete &stats;
-  }
-
-  void
-  wp_worker_statset_time_and_increment (cubperf::statset &stats, cubperf::stat_id id)
-  {
-    Worker_pool_statdef.time_and_increment (stats, id);
-  }
-
-  void
-  wp_worker_statset_accumulate (const cubperf::statset &what, cubperf::stat_value *where)
-  {
-    Worker_pool_statdef.add_stat_values_with_converted_timers<std::chrono::microseconds> (what, where);
-  }
-
-  std::size_t
-  wp_worker_statset_get_count (void)
-  {
-    return Worker_pool_statdef.get_value_count ();
-  }
-
-  const char *
-  wp_worker_statset_get_name (std::size_t stat_index)
-  {
-    return Worker_pool_statdef.get_value_name (stat_index);
   }
 
   //////////////////////////////////////////////////////////////////////////
@@ -1091,23 +840,6 @@ namespace cubthread
     er_print_callstack (ARG_FILE_LINE, "%s - throws err = %d: %s\n", message, e.code().value(), e.what ());
     assert (false);
     throw e;
-  }
-
-  void
-  wp_er_log_stats (const char *header, cubperf::stat_value *statsp)
-  {
-    std::stringstream ss;
-
-    ss << "Worker pool statistics: " << header << std::endl;
-
-    for (std::size_t index = 0; index < Worker_pool_statdef.get_value_count (); index++)
-      {
-	ss << "\t" << Worker_pool_statdef.get_value_name (index) << ": ";
-	ss << statsp[index] << std::endl;
-      }
-
-    std::string str = ss.str ();
-    _er_log_debug (ARG_FILE_LINE, str.c_str ());
   }
 
 } // namespace cubthread

--- a/src/thread/thread_worker_pool.hpp
+++ b/src/thread/thread_worker_pool.hpp
@@ -184,7 +184,7 @@ namespace cubthread
       virtual std::unique_ptr<core> allocate_core ();
 
       virtual void allocate_cores (std::size_t core_count);
-      virtual void assign_workers_to_cores (std::size_t core_count, std::size_t worker_count);
+      virtual void assign_workers_to_cores (std::size_t worker_count);
 
       // get next core by policy
       virtual std::size_t get_next_core (void);

--- a/src/thread/thread_worker_pool.hpp
+++ b/src/thread/thread_worker_pool.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008 Search Solution Corporation
+ *
  * Copyright 2016 CUBRID Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -42,15 +42,14 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
-#include <forward_list>
-#include <list>
+#include <algorithm>
+#include <vector>
 #include <memory>
 #include <mutex>
 #include <queue>
 #include <string>
 #include <system_error>
 #include <thread>
-#include <set>
 
 #include <cassert>
 #include <cstring>
@@ -62,10 +61,7 @@
 
 namespace cubthread
 {
-  // cubtread::worker_pool<Context>
-  //
-  //  templates
-  //    Context - thread context; a class to cache helpful information for task execution
+  // cubtread::worker_pool
   //
   //  description
   //    a pool of threads to execute tasks in parallel
@@ -75,12 +71,8 @@ namespace cubthread
   //    in high-loads, thread context is shared between task
   //
   // how to use
-  //    // note that worker_pool must be specialized with a thread context
   //
-  //    // define the thread context; for CUBRID, that is usually cubthread::entry
-  //    class custom_context { ... };
-  //
-  //    // then define the task
+  //    // define the task
   //    class custom_task : public task<custom_context>
   //    {
   //      void execute (Context &) override { ... }
@@ -89,7 +81,7 @@ namespace cubthread
   //    };
   //
   //    // create worker pool
-  //    cubthread::worker_pool<custom_context> thread_pool (THREAD_COUNT, MAX_TASKS);
+  //    cubthread::worker_pool thread_pool (THREAD_COUNT, MAX_TASKS);
   //
   //    // push tasks
   //    for (std::size_t i = 0; i < task_count; i++)
@@ -101,47 +93,13 @@ namespace cubthread
   //
   //    // on destroy, worker pools stops execution (jobs in queue are not executed) and joins any running threads
   //
-  //
-  // implementation
+  // interface
   //
   //    the worker pool can be partitioned into cores - a middle layer above a group of workers. this is an
   //    optimization for high-contention systems and only one core can be set if that's not the case.
   //
   //    core manages a number of workers, tracks available resource - free active workers and inactive workers and
   //    queues tasks that could not be executed immediately.
-  //
-  //    a worker starts by being inactive (does not have a thread running). it spawns a thread on its first task,
-  //    becoming active, and stays active as long as it finds more tasks to execute.
-  //
-  //    This is how a new task is processed:
-  //
-  //      1. Worker pool assigns the task to a core via round robin method*. The core can then accept the task (if an
-  //         available worker is found) or reject it. If task is rejected, then it is stored in a queue to be processed
-  //         later.
-  //         *round robin scheduling behavior may be overwritten by using execute_on_core instead of execute. it is
-  //         recommended to understand how cores and workers work before trying it.
-  //         sometimes however, if current tasks may be blocked until other incoming tasks are finished, a more careful
-  //         core management is required.
-  //
-  //      2. Core checks if a thread is available
-  //          - first checks free active list
-  //          - if no free active worker is found, it checks inactive list
-  //          - if a worker is found, then it is assigned the task
-  //          - if no worker is found, task is saved in queue
-  //
-  //      3. Task is executed by worker in one of three ways:
-  //          3.1. worker was inactive and starts a new thread to execute the task
-  //               after it finishes its first task, it tries to find new ones:
-  //          3.2. gets a queued task on its parent core
-  //          3.3. if there is no queue task, notifies core of its status (free and active) and waits for new task.
-  //          note: 3.2. and 3.3. together is an atomic operation (protected by mutex)
-  //          Worker stops if waiting for new task times out (and becomes inactive).
-  //
-  //    NOTE: core class is private nested to worker pool and cannot be instantiated outside it.
-  //          worker class is private nested to core class.
-  //
-  //  todo:
-  //    [Optional] Define a way to stop worker pool, but to finish executing everything it has in queue.
   //
   class worker_pool
   {
@@ -152,55 +110,35 @@ namespace cubthread
       // forward definition
       class core;
 
-      worker_pool (std::size_t pool_size, std::size_t task_max_count, entry_manager &entry_mgr,
-		   const char *name, std::size_t core_count = 1, bool debug_logging = false, bool pool_threads = false,
-		   wait_seconds wait_for_task_time = std::chrono::seconds (5));
-      ~worker_pool ();
+      worker_pool (std::size_t pool_size, std::size_t core_count, const char *name, entry_manager &entry_mgr,
+		   bool pool_threads = false, wait_seconds wait_for_task_time = std::chrono::seconds (5));
+      virtual ~worker_pool ();
 
-      // try to execute task; executes only if the maximum number of tasks is not reached.
-      // it return true when task is executed, false otherwise
-      bool try_execute (task_type *work_arg);
+      // get name
+      const std::string &get_name (void) const;
+
+      // init
+      virtual void initialize (std::size_t worker_count, std::size_t core_count);
 
       // execute task; execution is guaranteed, even if maximum number of tasks is reached.
-      // read implementation in class comment for details
       void execute (task_type *work_arg);
 
-      // execute on give core. real core index is core_hash module core count.
-      // note: regular execute chooses a core through round robin scheduling. this may not be a good fit for all
-      //       execution patterns.
-      //       execute_on_core provides control on core scheduling.
-      void execute_on_core (task_type *work_arg, std::size_t core_hash, bool method_mode = false);
-
-      // stop worker pool; stop all running threads; discard any tasks in queue
-      void stop_execution (void);
-
-      // start all worker threads to be ready for future tasks
-      void start_all_workers (void);
+      // execute on give core.
+      virtual void execute_on_core (task_type *work_arg, std::size_t core_hash, bool is_temp = false);
 
       // is_running = is not stopped; when created, a worker pool starts running.
       // worker is stopped after stop_execution () is called
       bool is_running (void) const;
 
-      // get name
-      const std::string &get_name (void) const;
-
-      // is_full = the maximum number of tasks is reached
-      bool is_full (void) const;
+      // stop worker pool; stop all running threads; discard any tasks in queue
+      void stop_execution (void);
 
       // get maximum number of threads that can run concurrently in this worker pool
-      std::size_t get_max_count (void) const;
+      std::size_t get_worker_count (void) const;
       // get the number of cores
       std::size_t get_core_count (void) const;
 
-      // get worker pool statistics
-      // note: the statistics are collected from all cores and all their workers adding up all local statistics
-      void get_stats (cubperf::stat_value *stats_out) const;
-      void get_task_stats (uint64_t *stats_out) noexcept;
-
-      // log stats to error log file
-      void er_log_stats (void) const;
-
-      inline bool is_pooling_threads () const
+      bool get_pool_threads () const
       {
 	return m_pool_threads;
       }
@@ -239,41 +177,44 @@ namespace cubthread
       template <typename Func, typename ... Args>
       void map_cores (Func &&func, Args &&... args);
 
-    private:
+    protected:
       // forward definition for nested core class; he's a friend
       friend class core;
 
-      // get next core by round robin scheduling
+      // override this if want to change core type
+      virtual std::unique_ptr<core> allocate_core ();
+
+      virtual void allocate_cores (std::size_t core_count);
+      virtual void assign_workers_to_cores (std::size_t core_count, std::size_t worker_count);
+
+      // get next core by policy
+      virtual std::size_t get_next_core (void);
+      // get next core by round robin scheduling (default policy)
       std::size_t get_round_robin_core_hash (void);
 
-      // maximum number of concurrent workers
-      std::size_t m_max_workers;
-
-      // work queue to store tasks that cannot be immediately executed
-      std::size_t m_task_max_count;
-      std::atomic<std::size_t> m_task_count;
+      // worker pool name
+      std::string m_name;
 
       // thread entry manager
       entry_manager &m_entry_manager;
 
+      // maximum number of concurrent workers
+      std::size_t m_max_workers;
+
       // core variables
-      core *m_core_array;                                   // all cores
-      std::size_t m_core_count;                             // core count
-      std::atomic<std::size_t> m_round_robin_counter;       // round robin counter used to dispatch tasks on cores
+      std::vector<std::unique_ptr<core>> m_cores;
+
+      // [optional] round robin counter used to dispatch tasks on cores
+      std::atomic<std::size_t> m_round_robin_counter;
 
       // set to true when stopped
       std::atomic<bool> m_stopped;
 
-      // true to do debug logging
-      bool m_log;
-
-      // true to start threads at init
+      // true to keep all threads alive
       bool m_pool_threads;
 
       // transition time period between active and inactive
       wait_seconds m_wait_for_task_time;
-
-      std::string m_name;
   };
 
   // worker_pool<Context>::core
@@ -288,42 +229,39 @@ namespace cubthread
       // forward definition of nested class worker
       class worker;
 
-      // init function
-      void init_pool_and_workers (worker_pool &parent, std::size_t worker_count);
+      core ();
+      virtual ~core (void);
 
-      // interface for worker pool
+      // override this if want to change worker type
+      virtual std::unique_ptr<worker> allocate_worker (bool is_temp = false);
+
+      virtual void allocate_workers (std::size_t worker_count);
+      virtual void initialize_workers ();
+      virtual void initialize (std::size_t worker_count);
+
+      void set_worker_pool (worker_pool &parent);
+
       // task management
-      // execute task; returns true if task is accepted, false if it is rejected (no available workers)
-      void execute_task (task_type *task_p, bool method_mode);
+      // execute task
+      virtual void execute_task (task_type *task_p, bool is_temp);
 
-      // context management
-      // map function to all workers (and their contexts)
-      template <typename Func, typename ... Args>
-      void map_running_contexts (bool &stop, Func &&func, Args &&... args) const;
       // worker management
       // notify workers to stop; if any of core's workers are still running, outputs is_not_stopped = true
       void notify_stop (bool &is_not_stopped);
       void retire_queued_tasks (void);
 
-      void start_all_workers (void);
-
-      // statistics
-      void get_stats (cubperf::stat_value *sum_inout) const;
-
-      // interface for workers
-      // task management
-      void finished_task_notification (void);
       // worker management
       // get a task or add worker to free active list (still running, but ready to execute another task)
-      task_type *get_task_or_become_available (worker &worker_arg);
-      void become_available (worker &worker_arg);
+      virtual task_type *get_task_or_become_available (worker &worker_arg);
+      virtual void become_available (worker &worker_arg);
       // is worker available?
       void check_worker_not_available (const worker &worker_arg);
+
       // context management
       entry_manager &get_entry_manager (void);
 
       // getters
-      std::size_t get_max_worker_count (void) const;
+      std::size_t get_worker_count (void) const;
       inline worker_pool *get_parent_pool (void) const
       {
 	return m_parent_pool;
@@ -333,40 +271,27 @@ namespace cubthread
       void register_free_temp_list (worker *w);
       void free_all_temp_list ();
 
-      inline uint64_t on_task_requested () noexcept;
-      inline uint64_t on_task_started () noexcept;
-      inline uint64_t on_task_completed () noexcept;
+      // context management
+      // map function to all workers (and their contexts)
+      template <typename Func, typename ... Args>
+      void map_running_contexts (bool &stop, Func &&func, Args &&... args) const;
 
-      std::tuple<uint64_t, uint64_t, uint64_t> get_task_stats () noexcept;
-
-    private:
+    protected:
       // execute task for method/stored procedure by recursive call; This task is not pooled and executes in a temporary created thread.
-      void execute_temp_task (task_type *task_p, const cubperf::time_point &push_time);
+      virtual void execute_task_as_temp (task_type *task_p);
 
       friend worker_pool;
 
-      // ctor/dtor
-      core ();
-      ~core (void);
-
       worker_pool *m_parent_pool;		      // pointer to parent pool
-      std::size_t m_max_workers;                      // maximum number of workers running at once
-      worker *m_worker_array;                         // all core workers
-      worker **m_available_workers;
-      std::size_t m_available_count;
+
+      std::vector<std::unique_ptr<worker>> m_workers;
+      std::vector<worker *> m_available_workers;
       std::queue<task_type *> m_task_queue;           // list of tasks pushed while all workers were occupied
       mutable std::mutex m_workers_mutex;             // mutex to synchronize activity on worker lists
 
-      std::set<worker *> m_temp_workers;              // temporary executed workers for method/stored procedure
-      std::vector<worker *> m_temp_free_workers;      //
+      std::vector<std::unique_ptr<worker>> m_temp_workers;	      // temporary executed workers for method/stored procedure
+      std::vector<std::unique_ptr<worker>> m_free_temp_workers;
       mutable std::mutex m_temp_workers_mutex;        // mutex to synchronize temp worker lists
-
-      struct
-      {
-	std::atomic<uint64_t> requested;
-	std::atomic<uint64_t> started;
-	std::atomic<uint64_t> completed;
-      } m_task_metrics;
   };
 
   // worker_pool<Context>::worker
@@ -375,93 +300,25 @@ namespace cubthread
   //    the worker is a worker pool nested class and represents one instance of execution. its purpose is to store the
   //    context, manage multiple task executions of a single thread and collect statistics.
   //
-  // how it works
-  //    the worker is assigned a task and a new thread is started. when task is finished, the worker tries to execute
-  //    more tasks, either by consuming one from task queue or by waiting for one. if it waits too long and it is given
-  //    no task, the thread stops
-  //
-  //    there are two types of workers in regard with the thread status:
-  //
-  //      1. inactive worker (initial state), thread is not running and must be started before executing task
-  //      2. active worker, either executing task or waiting for a new task.
-  //
-  //    there are three ways task is executed:
-  //
-  //      1. by an inactive worker; it goes through next phases:
-  //          - claiming from inactive list of workers
-  //          - starting thread
-  //          - claiming context
-  //          - executing task
-  //
-  //      2. by an active worker (thread is running); it goes through next phases:
-  //          - claiming from active list of workers
-  //          - notifying and waking thread
-  //          - executing task
-  //
-  //      3. by being claimed from task queue; if no worker (active or inactive) is available, task is queued on core
-  //         to be executed when a worker finishes its current task; it goes through next phases
-  //          - adding task to queue
-  //          - claiming task from queue
-  //          - executing task
-  //
-  //    a more sensible part of task execution is pushing task to running thread, due to limit cases. there are up to
-  //    three threads implicated into this process:
-  //
-  //      1. task pusher
-  //          - whenever worker is claimed from free active list, the task is directly assigned (m_task_p is set)!
-  //            (as a consequence, waiting thread cannot reject the task)
-  //
-  //      2. worker pool stopper
-  //          - thread requests worker pool to stop. the signal is passed to all cores and workers; including workers
-  //            that are waiting for tasks. that is signaled using m_stop field
-  //
-  //      3. task waiter
-  //         the thread "lingers" waiting for new arriving tasks. the worker first adds itself to core's free active
-  //         list and then waits until one of next conditions happen
-  //          - task is assigned (m_task_p is not nil). it executes the task (regardless of m_stop).
-  //          - thread is stopped (m_stop is true).
-  //          - wait times out
-  //         after waking up, if no task was assigned up to this point, the thread will attempt to remove its worker
-  //         from free active list. a task may yet be assigned until the worker is removed from this list; if worker is
-  //         not found to be removed, it means the worker was claimed and a task was pushed or is being pushed. thread
-  //         is forced to wait for assigned task.
-  //         if worker is removed successfully from free active list, its thread will stop and it will be added to
-  //         inactive list.
-  //         note that after wake up, m_stop does not affect the course of action in any way, only m_task_p. In most
-  //         cases, m_stop being true will be equivalent to m_task_p being nil. in the very limited case when m_stop is
-  //         true and a task is also assigned, we let the worker execute the task.
-  //
-  // note
-  //    class is nested to worker pool and cannot be used outside it
-  //
   class worker_pool::core::worker
   {
     public:
       worker (bool is_temp = false);
-      ~worker (void);
+      virtual ~worker (void);
 
       // init
-      void init_core (core &parent);
+      void set_core (core &parent);
+
+      // start thread for current worker
+      virtual void start_thread (void);
 
       // assign task (can be NULL) to running thread or start thread
-      void assign_task (task_type *work_p, cubperf::time_point push_time);
-      // start thread for current worker
-      void start_thread (void);
+      virtual void assign_task (task_type *work_p);
       // run task on current thread (push_time is provided by core)
-      void push_task_on_running_thread (task_type *work_p, cubperf::time_point push_time);
+      virtual void push_task_on_running_thread (task_type *work_p);
+
       // stop execution; if worker has a thread running, it outputs is_not_stopped = true
       void stop_execution (bool &is_not_stopped);
-
-      // map function to context (if a task is running and if context is available)
-      //
-      // note - sometimes a thread has a context assigned, but it is waiting for tasks. if that's the case, the
-      //        function will not be applied, since it is not considered a "running" context.
-      //
-      template <typename Func, typename ... Args>
-      void map_context_if_running (bool &stop, Func &&func, Args &&... args);
-
-      // add own stats to given argument
-      void get_stats (cubperf::stat_value *sum_inout) const;
 
       std::mutex &get_mutex (void)
       {
@@ -475,64 +332,47 @@ namespace cubthread
       {
 	m_has_thread = true;
       }
-      void set_push_time_now (void)
-      {
-	m_push_time = cubperf::clock::now ();
-      }
 
-    private:
+      // map function to context (if a task is running and if context is available)
+      //
+      // note - sometimes a thread has a context assigned, but it is waiting for tasks. if that's the case, the
+      //        function will not be applied, since it is not considered a "running" context.
+      //
+      template <typename Func, typename ... Args>
+      void map_context_if_running (bool &stop, Func &&func, Args &&... args);
+
+    protected:
 
       // run function invoked by spawned thread
-      void run (void);
+      virtual void run (void);
+
       // run initialization (creating execution context)
-      void init_run (void);
+      virtual void init_run (void);
       // finishing initialization (retiring execution context, worker becomes inactive)
-      void finish_run (void);
+      virtual void finish_run (void);
+
       // execute m_task_p
-      void execute_current_task (void);
+      virtual void execute_current_task (void);
       // retire m_task_p
-      void retire_current_task (void);
+      virtual void retire_current_task (void);
       // get new task from 1. worker pool task queue or 2. wait for incoming tasks
-      bool get_new_task (void);
+      virtual bool get_new_task (void);
 
       core *m_parent_core;		      // parent core
-      context_type *m_context_p;              // execution context (same lifetime as spawned thread)
 
+      context_type *m_context_p;              // execution context (same lifetime as spawned thread)
       task_type *m_task_p;                    // current task
 
       // synchronization on task wait
       std::condition_variable m_task_cv;      // condition variable used to notify when a task is assigned or when
       // worker is stopped
       std::mutex m_task_mutex;                // mutex to protect waiting task condition
+
       bool m_stop;                            // stop execution (set to true when worker pool is stopped)
       bool m_has_thread;                      // true if worker has a thread running
+
       bool m_is_temp;                         // true if worker is for temp task
-
-      // statistics
-      cubperf::statset &m_statistics;                                          // statistic collector
-      cubperf::time_point m_push_time;                          // push time point (provided by core)
   };
-
-  //////////////////////////////////////////////////////////////////////////
-  // statistics
-  //////////////////////////////////////////////////////////////////////////
-
-  // collected workers
-  static const cubperf::stat_id Wpstat_start_thread = 0;
-  static const cubperf::stat_id Wpstat_create_context = 1;
-  static const cubperf::stat_id Wpstat_execute_task = 2;
-  static const cubperf::stat_id Wpstat_retire_task = 3;
-  static const cubperf::stat_id Wpstat_found_in_queue = 4;
-  static const cubperf::stat_id Wpstat_wakeup_with_task = 5;
-  static const cubperf::stat_id Wpstat_recycle_context = 6;
-  static const cubperf::stat_id Wpstat_retire_context = 7;
-
-  cubperf::statset &wp_worker_statset_create (void);
-  void wp_worker_statset_destroy (cubperf::statset &stats);
-  void wp_worker_statset_time_and_increment (cubperf::statset &stats, cubperf::stat_id id);
-  void wp_worker_statset_accumulate (const cubperf::statset &what, cubperf::stat_value *where);
-  std::size_t wp_worker_statset_get_count (void);
-  const char *wp_worker_statset_get_name (std::size_t stat_index);
 
   //////////////////////////////////////////////////////////////////////////
   // other functions
@@ -548,9 +388,6 @@ namespace cubthread
   void wp_handle_system_error (const char *message, const std::system_error &e);
   template <typename Func>
   void wp_call_func_throwing_system_error (const char *message, Func &func);
-
-  // dump worker pool statistics to error log
-  void wp_er_log_stats (const char *header, cubperf::stat_value *statsp);
 
   bool wp_is_thread_always_alive_forced ();
   void wp_set_force_thread_always_alive ();
@@ -568,9 +405,9 @@ namespace cubthread
   worker_pool::map_running_contexts (Func &&func, Args &&... args)
   {
     bool stop = false;
-    for (std::size_t it = 0; it < m_core_count && !stop; it++)
+    for (auto it = m_cores.begin (); it != m_cores.end (); it++)
       {
-	m_core_array[it].map_running_contexts (stop, func, args...);
+	(*it)->map_running_contexts (stop, func, args...);
 	if (stop)
 	  {
 	    // mapping is stopped
@@ -585,9 +422,9 @@ namespace cubthread
   {
     bool stop = false;
     const core *core_p;
-    for (std::size_t it = 0; it < m_core_count && !stop; it++)
+    for (auto it = m_cores.begin (); it != m_cores.end (); it++)
       {
-	core_p = &m_core_array[it];
+	core_p = it->get ();
 	func (*core_p, stop, args...);
 	if (stop)
 	  {
@@ -601,26 +438,31 @@ namespace cubthread
   void
   worker_pool::core::map_running_contexts (bool &stop, Func &&func, Args &&... args) const
   {
-    for (std::size_t it = 0; it < m_max_workers && !stop; it++)
-      {
-	m_worker_array[it].map_context_if_running (stop, func, args...);
-	if (stop)
-	  {
-	    // stop mapping
-	    return;
-	  }
-      }
+    std::unique_lock<std::mutex> worker_guard (m_workers_mutex);
 
-    std::unique_lock<std::mutex> ulock (m_temp_workers_mutex);
-    for (worker *w : m_temp_workers)
+    for (auto it = m_workers.begin (); it != m_workers.end (); it++)
       {
-	w->map_context_if_running (stop, func, args...);
+	(*it)->map_context_if_running (stop, func, args...);
 	if (stop)
 	  {
 	    // stop mapping
 	    return;
 	  }
       }
+    worker_guard.unlock ();
+
+    std::unique_lock<std::mutex> temp_guard (m_temp_workers_mutex);
+
+    for (auto it = m_temp_workers.begin (); it != m_temp_workers.end (); it++)
+      {
+	(*it)->map_context_if_running (stop, func, args...);
+	if (stop)
+	  {
+	    // stop mapping
+	    return;
+	  }
+      }
+    temp_guard.unlock ();
   }
 
   template <typename Func, typename ... Args>

--- a/src/thread/thread_worker_pool.hpp
+++ b/src/thread/thread_worker_pool.hpp
@@ -104,14 +104,13 @@ namespace cubthread
   class worker_pool
   {
     public:
+      // forward definition for nested core class
+      friend class thread_manager;
+      class core;
+
       using context_type = entry;
       using task_type = task<context_type>;
 
-      // forward definition
-      class core;
-
-      worker_pool (std::size_t pool_size, std::size_t core_count, const char *name, entry_manager &entry_mgr,
-		   bool pool_threads = false, wait_seconds wait_for_task_time = std::chrono::seconds (5));
       virtual ~worker_pool ();
 
       // get name
@@ -178,8 +177,8 @@ namespace cubthread
       void map_cores (Func &&func, Args &&... args);
 
     protected:
-      // forward definition for nested core class; he's a friend
-      friend class core;
+      worker_pool (std::size_t pool_size, std::size_t core_count, const char *name, entry_manager &entry_mgr,
+		   bool pool_threads = false, wait_seconds wait_for_task_time = std::chrono::seconds (5));
 
       // override this if want to change core type
       virtual std::unique_ptr<core> allocate_core ();
@@ -227,23 +226,18 @@ namespace cubthread
   {
     public:
       // forward definition of nested class worker
+      friend class worker_pool;
       class worker;
 
-      core ();
       virtual ~core (void);
 
-      // override this if want to change worker type
-      virtual std::unique_ptr<worker> allocate_worker (bool is_temp = false);
-
-      virtual void allocate_workers (std::size_t worker_count);
-      virtual void initialize_workers ();
       virtual void initialize (std::size_t worker_count);
 
       void set_worker_pool (worker_pool &parent);
 
       // task management
       // execute task
-      virtual void execute_task (task_type *task_p, bool is_temp);
+      void execute_task (task_type *task_p, bool is_temp);
 
       // worker management
       // notify workers to stop; if any of core's workers are still running, outputs is_not_stopped = true
@@ -252,8 +246,8 @@ namespace cubthread
 
       // worker management
       // get a task or add worker to free active list (still running, but ready to execute another task)
-      virtual task_type *get_task_or_become_available (worker &worker_arg);
-      virtual void become_available (worker &worker_arg);
+      task_type *get_task_or_become_available (worker &worker_arg);
+      void become_available (worker &worker_arg);
       // is worker available?
       void check_worker_not_available (const worker &worker_arg);
 
@@ -277,10 +271,16 @@ namespace cubthread
       void map_running_contexts (bool &stop, Func &&func, Args &&... args) const;
 
     protected:
+      core ();
+
+      // override this if want to change worker type
+      virtual std::unique_ptr<worker> allocate_worker (bool is_temp = false);
+
+      virtual void allocate_workers (std::size_t worker_count);
+      virtual void initialize_workers ();
+
       // execute task for method/stored procedure by recursive call; This task is not pooled and executes in a temporary created thread.
       virtual void execute_task_as_temp (task_type *task_p);
-
-      friend worker_pool;
 
       worker_pool *m_parent_pool;		      // pointer to parent pool
 
@@ -303,19 +303,20 @@ namespace cubthread
   class worker_pool::core::worker
   {
     public:
-      worker (bool is_temp = false);
+      friend class core;
+
       virtual ~worker (void);
 
       // init
       void set_core (core &parent);
 
       // start thread for current worker
-      virtual void start_thread (void);
+      void start_thread (void);
 
       // assign task (can be NULL) to running thread or start thread
-      virtual void assign_task (task_type *work_p);
+      void assign_task (task_type *work_p);
       // run task on current thread (push_time is provided by core)
-      virtual void push_task_on_running_thread (task_type *work_p);
+      void push_task_on_running_thread (task_type *work_p);
 
       // stop execution; if worker has a thread running, it outputs is_not_stopped = true
       void stop_execution (bool &is_not_stopped);
@@ -342,21 +343,22 @@ namespace cubthread
       void map_context_if_running (bool &stop, Func &&func, Args &&... args);
 
     protected:
+      worker (bool is_temp = false);
 
       // run function invoked by spawned thread
-      virtual void run (void);
+      void run (void);
 
       // run initialization (creating execution context)
-      virtual void init_run (void);
+      void init_run (void);
       // finishing initialization (retiring execution context, worker becomes inactive)
-      virtual void finish_run (void);
+      void finish_run (void);
 
       // execute m_task_p
-      virtual void execute_current_task (void);
+      void execute_current_task (void);
       // retire m_task_p
-      virtual void retire_current_task (void);
+      void retire_current_task (void);
       // get new task from 1. worker pool task queue or 2. wait for incoming tasks
-      virtual bool get_new_task (void);
+      bool get_new_task (void);
 
       core *m_parent_core;		      // parent core
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -7540,7 +7540,7 @@ logpb_create_backup_read_worker_pool (size_t thread_count)
     }
 
   g_backup_read_worker_pool =
-    thread_create_worker_pool_base (thread_count, core_count, "backup-read", thread_get_entry_manager ());
+    thread_create_worker_pool_base (thread_count, core_count, "backup-read", thread_get_entry_manager (), true);
 }
 
 void

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -7538,9 +7538,9 @@ logpb_create_backup_read_worker_pool (size_t thread_count)
     {
       thread_count = 1;
     }
+
   g_backup_read_worker_pool =
-    cubthread::get_manager ()->create_worker_pool (thread_count, thread_count, "backup-read", NULL,
-						   core_count, false, true);
+    thread_create_worker_pool_base (thread_count, core_count, "backup-read", thread_get_entry_manager ());
 }
 
 void

--- a/unit_tests/thread/test_manager.cpp
+++ b/unit_tests/thread/test_manager.cpp
@@ -79,7 +79,7 @@ namespace test_thread
 
     thread_mgr.init_entries (max_threads);
 
-    auto *dummy_pool = thread_mgr.create_worker_pool (1, 1, NULL, NULL, 1, false);
+    auto *dummy_pool = thread_mgr.create_worker_pool (1, 1, NULL, thread_mgr.get_entry_manager ());
     thread_mgr.destroy_worker_pool (dummy_pool);
 
     auto *daemon = thread_mgr.create_daemon (cubthread::looper (), new dummy_exec ());


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26682>

### Purpose

Worker pool을 확장 가능하게 하려는 변경 중 하나입니다. 빌드는 되지 않습니다.
주요 변경점은 아래와 같습니다.
1. class worker_pool, class core, class worker의 최소 base만 남기고 코드를 제거했습니다.
2. 자유로운 구조가 가능하도록 상속에 용이한 구조로 변경하고, derived class들이 사용될 수 있게 모든 구조를 base 포인터 기반으로 변경하였습니다. 상속 후 간단한 수정으로 아래와 같은 구조가 가능해집니다.
```
worker pool > core > worker
worker pool > custom core > worker
custom worker pool > core > custom worker
```
3. thread manager를 거치지 않고 외부에서 임의적으로 worker pool, core, worker를 생성하지 못하도록 하였습니다.

### Implementation

구조는 거의 유사하나 unique_ptr로 교체된 부분들이 있고, 단순 배열의 경우 확장 가능성을 위해 컨테이너로 교체되었습니다.
unique_ptr 사용의 주 목적은 base (worker_pool, core, worker)를 상속하는 custom들의 현재 구조에서 자유롭게 교체될 수 있도록 하기 위함입니다.

```
allocate_core
allocate_worker
```
위 함수를 override하여 하위 component만 교체할 수 있습니다.

### Remarks

함수의 가장 기초적인 부분만 남겨놓았습니다.
다음 변경에서는 stats을 붙이고, 그 다음 변경에서는 worker pool 사용 목적을 단일화 할 계획입니다.

현 시점에서는 외부의 호출과 Worker pool에서 제공하는 인터페이스가 상이할 수 있습니다.