### PR TITLE
[CBRD-26693] Determine stats path at compile time.

### DIFF
--- a/src/thread/thread_worker_pool.hpp
+++ b/src/thread/thread_worker_pool.hpp
@@ -131,6 +131,9 @@ namespace cubthread
       // execution
       virtual void execute_task (task_type *task_p, bool is_temp) = 0;
 
+      // termination
+      virtual bool stop_execution (void) = 0;
+
       // information
       entry_manager &get_entry_manager (void) const
       {
@@ -173,6 +176,9 @@ namespace cubthread
 
       // init
       virtual void initialize () = 0;
+
+      // termination
+      virtual bool stop_execution (void) = 0;
 
       // information
       void set_parent_core (core &parent)

--- a/src/thread/thread_worker_pool_impl.cpp
+++ b/src/thread/thread_worker_pool_impl.cpp
@@ -22,7 +22,6 @@
 
 #include "thread_worker_pool_impl.hpp"
 
-#include "perf.hpp"
 #include "resources.hpp"
 #include "error_manager.h"
 
@@ -33,73 +32,6 @@
 
 namespace cubthread
 {
-  //////////////////////////////////////////////////////////////////////////
-  // statistics
-  //////////////////////////////////////////////////////////////////////////
-
-  static constexpr cubperf::stat_definition
-  stat_definition (stats::id id, cubperf::stat_definition::type stat_type, const char *first_name,
-		   const char *second_name)
-  {
-    return cubperf::stat_definition (static_cast<cubperf::stat_id> (id), stat_type, first_name, second_name);
-  }
-
-  static const cubperf::statset_definition statdef =
-  {
-    stat_definition (stats::id::start_thread, cubperf::stat_definition::COUNTER_AND_TIMER,
-		     "Counter_start_thread", "Timer_start_thread"),
-    stat_definition (stats::id::create_context, cubperf::stat_definition::COUNTER_AND_TIMER,
-		     "Counter_create_context", "Timer_create_context"),
-    stat_definition (stats::id::execute_task, cubperf::stat_definition::COUNTER_AND_TIMER,
-		     "Counter_execute_task", "Timer_execute_task"),
-    stat_definition (stats::id::retire_task, cubperf::stat_definition::COUNTER_AND_TIMER,
-		     "Counter_retire_task", "Timer_retire_task"),
-    stat_definition (stats::id::found_in_queue, cubperf::stat_definition::COUNTER_AND_TIMER,
-		     "Counter_found_task_in_queue", "Timer_found_task_in_queue"),
-    stat_definition (stats::id::wakeup_with_task, cubperf::stat_definition::COUNTER_AND_TIMER,
-		     "Counter_wakeup_with_task", "Timer_wakeup_with_task"),
-    stat_definition (stats::id::recycle_context, cubperf::stat_definition::COUNTER_AND_TIMER,
-		     "Counter_recycle_context", "Timer_recycle_context"),
-    stat_definition (stats::id::retire_context, cubperf::stat_definition::COUNTER_AND_TIMER,
-		     "Counter_retire_context", "Timer_retire_context")
-  };
-
-  cubperf::statset &
-  stats::create (void)
-  {
-    return *statdef.create_statset ();
-  }
-
-  void
-  stats::destroy (cubperf::statset &stats)
-  {
-    delete &stats;
-  }
-
-  void
-  stats::time_and_increment (cubperf::statset &stats, cubperf::stat_id id)
-  {
-    statdef.time_and_increment (stats, id);
-  }
-
-  void
-  stats::accumulate (const cubperf::statset &what, cubperf::stat_value *where)
-  {
-    statdef.add_stat_values_with_converted_timers<std::chrono::microseconds> (what, where);
-  }
-
-  std::size_t
-  stats::get_count (void)
-  {
-    return statdef.get_value_count ();
-  }
-
-  const char *
-  stats::get_name (std::size_t stat_index)
-  {
-    return statdef.get_value_name (stat_index);
-  }
-
   //////////////////////////////////////////////////////////////////////////
   // functions
   //////////////////////////////////////////////////////////////////////////
@@ -116,25 +48,6 @@ namespace cubthread
     er_print_callstack (ARG_FILE_LINE, "%s - throws err = %d: %s\n", message, e.code().value(), e.what ());
     assert (false);
     throw e;
-  }
-
-  void
-  wp_er_log_stats (const char *header, cubperf::stat_value *statsp)
-  {
-    /*
-    std::stringstream ss;
-
-    ss << "Worker pool statistics: " << header << std::endl;
-
-    for (std::size_t index = 0; index < Worker_pool_statdef.get_value_count (); index++)
-      {
-    ss << "\t" << Worker_pool_statdef.get_value_name (index) << ": ";
-    ss << statsp[index] << std::endl;
-      }
-
-    std::string str = ss.str ();
-    _er_log_debug (ARG_FILE_LINE, str.c_str ());
-    */
   }
 
   //////////////////////////////////////////////////////////////////////////

--- a/src/thread/thread_worker_pool_impl.cpp
+++ b/src/thread/thread_worker_pool_impl.cpp
@@ -22,6 +22,7 @@
 
 #include "thread_worker_pool_impl.hpp"
 
+#include "perf.hpp"
 #include "resources.hpp"
 #include "error_manager.h"
 
@@ -32,6 +33,73 @@
 
 namespace cubthread
 {
+  //////////////////////////////////////////////////////////////////////////
+  // statistics
+  //////////////////////////////////////////////////////////////////////////
+
+  static constexpr cubperf::stat_definition
+  stat_definition (stats::id id, cubperf::stat_definition::type stat_type, const char *first_name,
+		   const char *second_name)
+  {
+    return cubperf::stat_definition (static_cast<cubperf::stat_id> (id), stat_type, first_name, second_name);
+  }
+
+  static const cubperf::statset_definition statdef =
+  {
+    stat_definition (stats::id::start_thread, cubperf::stat_definition::COUNTER_AND_TIMER,
+		     "Counter_start_thread", "Timer_start_thread"),
+    stat_definition (stats::id::create_context, cubperf::stat_definition::COUNTER_AND_TIMER,
+		     "Counter_create_context", "Timer_create_context"),
+    stat_definition (stats::id::execute_task, cubperf::stat_definition::COUNTER_AND_TIMER,
+		     "Counter_execute_task", "Timer_execute_task"),
+    stat_definition (stats::id::retire_task, cubperf::stat_definition::COUNTER_AND_TIMER,
+		     "Counter_retire_task", "Timer_retire_task"),
+    stat_definition (stats::id::found_in_queue, cubperf::stat_definition::COUNTER_AND_TIMER,
+		     "Counter_found_task_in_queue", "Timer_found_task_in_queue"),
+    stat_definition (stats::id::wakeup_with_task, cubperf::stat_definition::COUNTER_AND_TIMER,
+		     "Counter_wakeup_with_task", "Timer_wakeup_with_task"),
+    stat_definition (stats::id::recycle_context, cubperf::stat_definition::COUNTER_AND_TIMER,
+		     "Counter_recycle_context", "Timer_recycle_context"),
+    stat_definition (stats::id::retire_context, cubperf::stat_definition::COUNTER_AND_TIMER,
+		     "Counter_retire_context", "Timer_retire_context")
+  };
+
+  cubperf::statset &
+  stats::create (void)
+  {
+    return *statdef.create_statset ();
+  }
+
+  void
+  stats::destroy (cubperf::statset &stats)
+  {
+    delete &stats;
+  }
+
+  void
+  stats::time_and_increment (cubperf::statset &stats, cubperf::stat_id id)
+  {
+    statdef.time_and_increment (stats, id);
+  }
+
+  void
+  stats::accumulate (const cubperf::statset &what, cubperf::stat_value *where)
+  {
+    statdef.add_stat_values_with_converted_timers<std::chrono::microseconds> (what, where);
+  }
+
+  std::size_t
+  stats::get_count (void)
+  {
+    return statdef.get_value_count ();
+  }
+
+  const char *
+  stats::get_name (std::size_t stat_index)
+  {
+    return statdef.get_value_name (stat_index);
+  }
+
   //////////////////////////////////////////////////////////////////////////
   // functions
   //////////////////////////////////////////////////////////////////////////

--- a/src/thread/thread_worker_pool_impl.hpp
+++ b/src/thread/thread_worker_pool_impl.hpp
@@ -297,7 +297,7 @@ namespace cubthread
       void start_thread (void);
 
       // assign task to worker; wake a running thread or start a new one.
-      // NULL is used only to prestart pooled threads.
+      // nullptr is used only to prestart pooled threads.
       void assign_task (task_type *work_p);
 
       // stop execution; if worker has a thread running, returns true
@@ -792,9 +792,9 @@ namespace cubthread
     // 2. inactive will do too
     // 3. if no workers, enqueue the task
 
-    assert (task_p != NULL);
+    assert (task_p != nullptr);
 
-    worker_impl *refp = NULL;
+    worker_impl *refp = nullptr;
 
     if (!m_parent_pool->is_running ())
       {
@@ -811,7 +811,7 @@ namespace cubthread
 	m_available_workers.pop_back ();
 	ulock.unlock ();
 
-	assert (refp != NULL);
+	assert (refp != nullptr);
 	refp->assign_task (task_p);
       }
     else
@@ -884,7 +884,7 @@ namespace cubthread
       {
 	wrapped_task &queued_task = m_task_queue.front ();
 	task_type *task_p = queued_task.get_task ();
-	assert (task_p != NULL);
+	assert (task_p != nullptr);
 	m_task_queue.pop ();
 
 	return task_p;
@@ -893,7 +893,7 @@ namespace cubthread
     m_available_workers.push_back (&worker_arg);
     assert (m_available_workers.size () <= m_workers.size ());
 
-    return NULL;
+    return nullptr;
   }
 
   template <bool Stats>
@@ -1048,7 +1048,7 @@ namespace cubthread
 
 	    // assign task / start thread
 	    // it will add itself to available workers
-	    static_cast<worker_impl *> (worker.get ())->assign_task (NULL);
+	    static_cast<worker_impl *> (worker.get ())->assign_task (nullptr);
 	  }
 	else
 	  {
@@ -1078,8 +1078,8 @@ namespace cubthread
   template <bool Stats>
   worker_pool_impl<Stats>::core_impl::worker_impl::worker_impl (bool is_temp)
     : worker_pool::core::worker ()
-    , m_context_p (NULL)
-    , m_task_p (NULL)
+    , m_context_p (nullptr)
+    , m_task_p (nullptr)
     , m_stop (false)
     , m_has_thread (false)
     , m_is_temp (is_temp)
@@ -1129,7 +1129,7 @@ namespace cubthread
   {
     std::unique_lock<std::mutex> ulock (m_task_mutex);
 
-    assert (m_task_p == NULL);
+    assert (m_task_p == nullptr);
 
     // save task
     m_task_p = work_p;
@@ -1137,7 +1137,7 @@ namespace cubthread
     if (m_is_temp)
       {
 	m_has_thread = true;
-	assert (m_context_p == NULL);
+	assert (m_context_p == nullptr);
 	start_thread ();
       }
 
@@ -1152,7 +1152,7 @@ namespace cubthread
 	m_has_thread = true;
 	ulock.unlock ();
 
-	assert (m_context_p == NULL);
+	assert (m_context_p == nullptr);
 
 	start_thread ();
       }
@@ -1165,7 +1165,7 @@ namespace cubthread
     context_type *context_p = m_context_p;
     bool has_thread = false;
 
-    if (context_p != NULL)
+    if (context_p != nullptr)
       {
 	// notify context to stop
 	m_parent_core->get_entry_manager ().stop_execution (*context_p);
@@ -1204,7 +1204,7 @@ namespace cubthread
   void
   worker_pool_impl<Stats>::core_impl::worker_impl::map_context_if_running (bool &stop, Func &&func, Args &&... args)
   {
-    if (m_task_p == NULL)
+    if (m_task_p == nullptr)
       {
 	// not running
 	return;
@@ -1212,7 +1212,7 @@ namespace cubthread
 
     context_type *ctxp = m_context_p;
 
-    if (ctxp != NULL)
+    if (ctxp != nullptr)
       {
 	func (*ctxp, stop, args...);
       }
@@ -1237,16 +1237,16 @@ namespace cubthread
 	return;
       }
 
-    if (m_task_p == NULL)
+    if (m_task_p == nullptr)
       {
 	// started without task; get one
 	if (get_new_task ())
 	  {
-	    assert (m_task_p != NULL);
+	    assert (m_task_p != nullptr);
 	  }
       }
 
-    if (m_task_p != NULL)
+    if (m_task_p != nullptr)
       {
 	// loop and execute as many tasks as possible
 	do
@@ -1288,12 +1288,12 @@ namespace cubthread
   void
   worker_pool_impl<Stats>::core_impl::worker_impl::finish_run (void)
   {
-    assert (m_task_p == NULL);
-    assert (m_context_p != NULL);
+    assert (m_task_p == nullptr);
+    assert (m_context_p != nullptr);
 
     // retire context
     m_parent_core->get_entry_manager ().retire_context (*m_context_p);
-    m_context_p = NULL;
+    m_context_p = nullptr;
 
     if (m_is_temp)
       {
@@ -1307,7 +1307,7 @@ namespace cubthread
   void
   worker_pool_impl<Stats>::core_impl::worker_impl::execute_current_task (void)
   {
-    assert (m_task_p != NULL);
+    assert (m_task_p != nullptr);
 
     // execute task
     m_task_p->execute (*m_context_p);
@@ -1331,18 +1331,18 @@ namespace cubthread
   void
   worker_pool_impl<Stats>::core_impl::worker_impl::retire_current_task (void)
   {
-    assert (m_task_p != NULL);
+    assert (m_task_p != nullptr);
 
     // retire task
     m_task_p->retire ();
-    m_task_p = NULL;
+    m_task_p = nullptr;
   }
 
   template <bool Stats>
   bool
   worker_pool_impl<Stats>::core_impl::worker_impl::get_new_task (void)
   {
-    assert (m_task_p == NULL);
+    assert (m_task_p == nullptr);
     assert (dynamic_cast<core_impl *> (m_parent_core));
 
     std::unique_lock<std::mutex> ulock (m_task_mutex, std::defer_lock);
@@ -1353,12 +1353,12 @@ namespace cubthread
 	// get a queued task or wait for one to come
 
 	// either get a queued task or add to free active list
-	// note: returned task cannot be saved directly to m_task_p. if worker is added to wait queue and NULL is returned,
+	// note: returned task cannot be saved directly to m_task_p. if worker is added to wait queue and nullptr is returned,
 	//       current thread may be preempted. worker is then claimed from free active list and worker is assigned
 	//       a task. this changes expected behavior and can have unwanted consequences.
 
 	task_type *task_p = static_cast<core_impl *> (m_parent_core)->get_task_or_become_available (*this);
-	if (task_p != NULL)
+	if (task_p != nullptr)
 	  {
 	    // it is safe to set here
 	    m_task_p = task_p;
@@ -1367,12 +1367,12 @@ namespace cubthread
 
 	// wait for task
 	ulock.lock ();
-	if (m_task_p == NULL && !m_stop)
+	if (m_task_p == nullptr && !m_stop)
 	  {
 	    // wait until a task is received or stopped ...
 	    // ... or time out
 	    condvar_wait (m_task_cv, ulock, m_parent_core->get_parent_pool ()->get_idle_timeout (),
-			  [this] () -> bool { return m_task_p != NULL || m_stop; });
+			  [this] () -> bool { return m_task_p != nullptr || m_stop; });
 	  }
 	else
 	  {
@@ -1388,7 +1388,7 @@ namespace cubthread
       }
 
     // did I get a task?
-    if (m_task_p == NULL)
+    if (m_task_p == nullptr)
       {
 	// no; this thread will stop. from this point forward, if a new task is assigned, a new thread must be spawned
 	m_has_thread = false;

--- a/src/thread/thread_worker_pool_impl.hpp
+++ b/src/thread/thread_worker_pool_impl.hpp
@@ -110,34 +110,34 @@ namespace cubthread
 
     public:
       // forward definition
-      class stats;
       class core_impl;
+      class wrapped_task;
+      class stats;
 
       virtual ~worker_pool_impl ();
 
       // init
-      virtual void initialize (std::size_t worker_count, std::size_t core_count);
+      virtual void initialize (std::size_t worker_count, std::size_t core_count) override;
 
       // execute task; execution is guaranteed, even if maximum number of tasks is reached.
-      void execute (task_type *work_arg);
+      void execute (task_type *work_arg) override;
 
       // execute on give core.
-      virtual void execute_on_core (task_type *work_arg, std::size_t core_hash, bool is_temp = false);
+      virtual void execute_on_core (task_type *work_arg, std::size_t core_hash, bool is_temp = false) override;
 
       // stop worker pool; stop all running threads; discard any tasks in queue
-      void stop_execution (void);
+      void stop_execution (void) override;
 
-      // is_running = is not stopped; when created, a worker pool starts running.
       // worker is stopped after stop_execution () is called
-      bool is_running (void) const;
+      bool is_running (void) const override;
 
       // get maximum number of threads that can run concurrently in this worker pool
-      std::size_t get_worker_count (void) const;
+      std::size_t get_worker_count (void) const override;
       // get the number of cores
-      std::size_t get_core_count (void) const;
+      std::size_t get_core_count (void) const override;
 
       // get worker pool statistics
-      void get_stats (cubperf::stat_value *stats_out) const;
+      void get_stats (cubperf::stat_value *stats_out) const override;
       // log stats to error log file
 
       void er_log_stats (void) const;
@@ -227,7 +227,7 @@ namespace cubthread
       void execute_task (task_type *task_p, bool is_temp) override;
 
       // notify workers to stop; if any of core's workers are still running, outputs is_not_stopped = true
-      void notify_stop (bool &is_not_stopped);
+      bool stop_execution (void) override;
       void retire_queued_tasks (void);
 
       // get a task or add worker to free active list (still running, but ready to execute another task)
@@ -265,12 +265,15 @@ namespace cubthread
 
       std::vector<std::unique_ptr<worker>> m_workers;
       std::vector<worker *> m_available_workers;
-      std::queue<task_type *> m_task_queue;           // list of tasks pushed while all workers were occupied
-      mutable std::mutex m_workers_mutex;             // mutex to synchronize activity on worker lists
+      std::queue<wrapped_task> m_task_queue;
+      // mutex to synchronize activity on worker lists
+      mutable std::mutex m_workers_mutex;
 
-      std::vector<std::unique_ptr<worker>> m_temp_workers;	      // temporary executed workers for method/stored procedure
+      // temporary executed workers for method/stored procedure
+      std::vector<std::unique_ptr<worker>> m_temp_workers;
       std::vector<std::unique_ptr<worker>> m_free_temp_workers;
-      mutable std::mutex m_temp_workers_mutex;        // mutex to synchronize temp worker lists
+      // mutex to synchronize temp worker lists
+      mutable std::mutex m_temp_workers_mutex;
   };
 
   // worker_pool_impl<Stats>::core_impl::worker_impl
@@ -284,6 +287,8 @@ namespace cubthread
   {
     public:
       friend class core_impl;
+
+      using stats_type = std::conditional_t<Stats, cubperf::statset, bool /* dummy */>;
 
       virtual ~worker_impl (void);
 
@@ -299,7 +304,7 @@ namespace cubthread
       void push_task_on_running_thread (task_type *work_p);
 
       // stop execution; if worker has a thread running, it outputs is_not_stopped = true
-      void stop_execution (bool &is_not_stopped);
+      bool stop_execution (void) override;
 
       std::mutex &get_mutex (void)
       {
@@ -347,6 +352,41 @@ namespace cubthread
       bool m_has_thread;                      // true if worker has a thread running
 
       bool m_is_temp;                         // true if worker is for temp task
+
+      stats_type *m_statistics;
+  };
+
+  // worker_pool_impl<Stats>::wrapped_task
+  //
+  // description
+  //    wrapper task for timing.
+  //
+  template <bool Stats>
+  class worker_pool_impl<Stats>::wrapped_task
+  {
+    private:
+      struct task_only
+      {
+	task_type *task;
+      };
+
+      struct task_with_stats
+      {
+	task_type *task;
+	cubperf::time_point at_created;
+      };
+
+      using inner_type = typename std::conditional_t<Stats, task_with_stats, task_only>;
+
+    public:
+      explicit wrapped_task (task_type *task_p);
+      ~wrapped_task ();
+
+      task_type *get_task (void);
+      cubperf::time_point &get_created (void);
+
+    private:
+      inner_type m_inner;
   };
 
   //////////////////////////////////////////////////////////////////////////
@@ -494,21 +534,20 @@ namespace cubthread
 #endif
 
     auto timeout = std::chrono::system_clock::now () + time_wait_to_thread_stop;
+    bool has_running_workers;
 
-    bool is_not_stopped;
     while (true)
       {
 	// notify all cores to stop
-	is_not_stopped = false;     // assume all are stopped
+	has_running_workers = false;
+
 	for (const auto &it : m_cores)
 	  {
-	    assert (dynamic_cast<core_impl *> (it.get ()));
-
 	    // notify all workers to stop. if any worker is still running, is_not_stopped = true is output
-	    static_cast<core_impl *> (it.get ())->notify_stop (is_not_stopped);
+	    has_running_workers |= it->stop_execution ();
 	  }
 
-	if (!is_not_stopped)
+	if (!has_running_workers)
 	  {
 	    // all stopped
 	    break;
@@ -786,22 +825,24 @@ namespace cubthread
 	else
 	  {
 	    // save to queue
-	    m_task_queue.push (task_p);
+	    m_task_queue.emplace (task_p);
 	  }
       }
   }
 
   template <bool Stats>
-  void
-  worker_pool_impl<Stats>::core_impl::notify_stop (bool &is_not_stopped)
+  bool
+  worker_pool_impl<Stats>::core_impl::stop_execution (void)
   {
+    bool has_running_workers = false;
+
     // stop all temp workers first
     {
       std::unique_lock<std::mutex> ulock (m_temp_workers_mutex);
 
       for (const auto &it : m_temp_workers)
 	{
-	  static_cast<worker_impl *> (it.get ())->stop_execution (is_not_stopped);
+	  has_running_workers |= it->stop_execution ();
 	}
     }
 
@@ -811,9 +852,11 @@ namespace cubthread
 
       for (const auto &it : m_workers)
 	{
-	  static_cast<worker_impl *> (it.get ())->stop_execution (is_not_stopped);
+	  has_running_workers |= it->stop_execution ();
 	}
     }
+
+    return has_running_workers;
   }
 
   template <bool Stats>
@@ -824,7 +867,8 @@ namespace cubthread
 
     while (!m_task_queue.empty ())
       {
-	m_task_queue.front ()->retire ();
+	wrapped_task &queued_task = m_task_queue.front ();
+	queued_task.get_task ()->retire ();
 	m_task_queue.pop ();
       }
   }
@@ -837,7 +881,8 @@ namespace cubthread
 
     if (!m_task_queue.empty ())
       {
-	task_type *task_p = m_task_queue.front ();
+	wrapped_task &queued_task = m_task_queue.front ();
+	task_type *task_p = queued_task.get_task ();
 	assert (task_p != NULL);
 	m_task_queue.pop ();
 
@@ -1129,10 +1174,11 @@ namespace cubthread
   }
 
   template <bool Stats>
-  void
-  worker_pool_impl<Stats>::core_impl::worker_impl::stop_execution (bool &is_not_stopped)
+  bool
+  worker_pool_impl<Stats>::core_impl::worker_impl::stop_execution (void)
   {
     context_type *context_p = m_context_p;
+    bool has_thread = false;
 
     if (context_p != NULL)
       {
@@ -1146,7 +1192,7 @@ namespace cubthread
     if (m_has_thread)
       {
 	// this thread is still running
-	is_not_stopped = true;
+	has_thread = true;
       }
 
     // stop worker
@@ -1154,12 +1200,12 @@ namespace cubthread
     // mutex is not needed for notify
     ulock.unlock ();
 
-    if (m_is_temp)
+    // The temp worker doesn't wait on task_cv; it executes the task immediately and terminates.
+    if (!m_is_temp)
       {
-	// not to notify one if it is for temp
-	return;
+	m_task_cv.notify_one ();
       }
-    m_task_cv.notify_one ();
+    return has_thread;
   }
 
   template <bool Stats>
@@ -1378,6 +1424,37 @@ namespace cubthread
 	// found task
 	return true;
       }
+  }
+
+  template <bool Stats>
+  worker_pool_impl<Stats>::wrapped_task::wrapped_task (task_type *task_p)
+  {
+    m_inner.task = task_p;
+    if constexpr (Stats)
+      {
+	m_inner.at_created = cubperf::clock::now ();
+      }
+  }
+
+  template <bool Stats>
+  worker_pool_impl<Stats>::wrapped_task::~wrapped_task (void)
+  {
+  }
+
+  template <bool Stats>
+  typename worker_pool_impl<Stats>::task_type *
+  worker_pool_impl<Stats>::wrapped_task::get_task (void)
+  {
+    return m_inner.task;
+  }
+
+  template <bool Stats>
+  cubperf::time_point &
+  worker_pool_impl<Stats>::wrapped_task::get_created (void)
+  {
+    static_assert (Stats, "get_time() requires Stats == true");
+
+    return m_inner.at_created;
   }
 
   //////////////////////////////////////////////////////////////////////////

--- a/src/thread/thread_worker_pool_impl.hpp
+++ b/src/thread/thread_worker_pool_impl.hpp
@@ -288,8 +288,6 @@ namespace cubthread
     public:
       friend class core_impl;
 
-      using stats_type = std::conditional_t<Stats, cubperf::statset, bool /* dummy */>;
-
       virtual ~worker_impl (void);
 
       // init
@@ -352,7 +350,7 @@ namespace cubthread
 
       bool m_is_temp;                         // true if worker is for temp task
 
-      stats_type *m_statistics;
+      cubperf::statset *m_statistics;	      // stats
   };
 
   // worker_pool_impl<Stats>::wrapped_task
@@ -373,7 +371,7 @@ namespace cubthread
       {
 	task_type *task;
 
-	cubperf::time_point at_created;
+	cubperf::time_point time;
 
 	// Other stats might be added here
       };
@@ -385,7 +383,7 @@ namespace cubthread
       ~wrapped_task ();
 
       task_type *get_task (void);
-      cubperf::time_point &get_created (void);
+      cubperf::time_point &get_time (void);
 
     private:
       inner_type m_inner;
@@ -1084,12 +1082,15 @@ namespace cubthread
     , m_stop (false)
     , m_has_thread (false)
     , m_is_temp (is_temp)
+    , m_statistics (stats::create ())
   {
+    assert (Stats ? m_statistics != nullptr : m_statistics == nullptr);
   }
 
   template <bool Stats>
   worker_pool_impl<Stats>::core_impl::worker_impl::~worker_impl (void)
   {
+    stats::destroy (m_statistics);
   }
 
   template <bool Stats>
@@ -1433,11 +1434,11 @@ namespace cubthread
 
   template <bool Stats>
   cubperf::time_point &
-  worker_pool_impl<Stats>::wrapped_task::get_created (void)
+  worker_pool_impl<Stats>::wrapped_task::get_time (void)
   {
     static_assert (Stats, "get_time() requires Stats == true");
 
-    return m_inner.at_created;
+    return m_inner.time;
   }
 
   //////////////////////////////////////////////////////////////////////////

--- a/src/thread/thread_worker_pool_impl.hpp
+++ b/src/thread/thread_worker_pool_impl.hpp
@@ -41,6 +41,7 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <optional>
 #include <algorithm>
 #include <vector>
 #include <memory>
@@ -211,6 +212,9 @@ namespace cubthread
   //    a worker pool core execution. manages a sub-group of workers.
   //    acts as middleman between worker pool and workers
   //
+  //    task in: execute_task
+  //    task out: execute_task (immediately execute) or get_task_or_become_available (queued task)
+  //
   template <bool Stats>
   class worker_pool_impl<Stats>::core_impl : public worker_pool::core
   {
@@ -231,7 +235,7 @@ namespace cubthread
       void retire_queued_tasks (void);
 
       // get a task or add worker to free active list (still running, but ready to execute another task)
-      task_type *get_task_or_become_available (worker &worker_arg);
+      std::optional<wrapped_task> get_task_or_become_available (worker &worker_arg);
       void become_available (worker &worker_arg);
 
       // is worker available?
@@ -261,7 +265,7 @@ namespace cubthread
       virtual void initialize_workers ();
 
       // execute task for method/stored procedure by recursive call; This task is not pooled and executes in a temporary created thread.
-      virtual void execute_task_as_temp (task_type *task_p);
+      virtual void execute_task_as_temp (wrapped_task &task_ref);
 
       std::vector<std::unique_ptr<worker>> m_workers;
       std::vector<worker *> m_available_workers;
@@ -297,8 +301,9 @@ namespace cubthread
       void start_thread (void);
 
       // assign task to worker; wake a running thread or start a new one.
-      // nullptr is used only to prestart pooled threads.
-      void assign_task (task_type *work_p);
+      void assign_task (wrapped_task &task_ref);
+      // [optional] used only to prestart pooled threads.
+      void assign_task (void);
 
       // stop execution; if worker has a thread running, returns true
       bool stop_execution (void) override;
@@ -330,27 +335,27 @@ namespace cubthread
       // finishing initialization (retiring execution context, worker becomes inactive)
       void finish_run (void);
 
-      // execute m_task_p
+      // execute m_wrapped_task
       void execute_current_task (void);
-      // retire m_task_p
+      // retire m_wrapped_task
       void retire_current_task (void);
       // get new task from 1. worker pool task queue or 2. wait for incoming tasks
       bool get_new_task (void);
 
-      context_type *m_context_p;              // execution context (same lifetime as spawned thread)
-      task_type *m_task_p;                    // current task
+      context_type *m_context_p;		    // execution context (same lifetime as spawned thread)
+      std::optional<wrapped_task> m_wrapped_task;   // current task and metadata
 
       // synchronization on task wait
-      std::condition_variable m_task_cv;      // condition variable used to notify when a task is assigned or when
+      std::condition_variable m_task_cv;	    // condition variable used to notify when a task is assigned or when
       // worker is stopped
-      std::mutex m_task_mutex;                // mutex to protect waiting task condition
+      std::mutex m_task_mutex;			    // mutex to protect waiting task condition
 
-      bool m_stop;                            // stop execution (set to true when worker pool is stopped)
-      bool m_has_thread;                      // true if worker has a thread running
+      bool m_stop;				    // stop execution (set to true when worker pool is stopped)
+      bool m_has_thread;			    // true if worker has a thread running
 
-      bool m_is_temp;                         // true if worker is for temp task
+      bool m_is_temp;				    // true if worker is for temp task
 
-      cubperf::statset *m_statistics;	      // stats
+      cubperf::statset *m_statistics;		    // stats
   };
 
   // worker_pool_impl<Stats>::wrapped_task
@@ -384,6 +389,10 @@ namespace cubthread
 
       task_type *get_task (void);
       cubperf::time_point &get_time (void);
+
+      // helper
+      void execute (context_type &thread_ref);
+      void retire (void);
 
     private:
       inner_type m_inner;
@@ -803,6 +812,7 @@ namespace cubthread
 	return;
       }
 
+    wrapped_task task_ref (task_p);
     std::unique_lock<std::mutex> ulock (m_workers_mutex);
 
     if (!m_available_workers.empty ())
@@ -812,7 +822,8 @@ namespace cubthread
 	ulock.unlock ();
 
 	assert (refp != nullptr);
-	refp->assign_task (task_p);
+
+	refp->assign_task (task_ref);
       }
     else
       {
@@ -821,12 +832,12 @@ namespace cubthread
 	    // no need to hold the mutex (prevent deadlock)
 	    ulock.unlock ();
 
-	    execute_task_as_temp (task_p);
+	    execute_task_as_temp (task_ref);
 	  }
 	else
 	  {
 	    // save to queue
-	    m_task_queue.emplace (task_p);
+	    m_task_queue.push (task_ref);
 	  }
       }
   }
@@ -875,25 +886,25 @@ namespace cubthread
   }
 
   template <bool Stats>
-  typename worker_pool_impl<Stats>::task_type *
+  std::optional<typename worker_pool_impl<Stats>::wrapped_task>
   worker_pool_impl<Stats>::core_impl::get_task_or_become_available (worker &worker_arg)
   {
     std::unique_lock<std::mutex> ulock (m_workers_mutex);
 
     if (!m_task_queue.empty ())
       {
-	wrapped_task &queued_task = m_task_queue.front ();
-	task_type *task_p = queued_task.get_task ();
-	assert (task_p != nullptr);
+	wrapped_task queued_task = m_task_queue.front ();
 	m_task_queue.pop ();
 
-	return task_p;
+	assert (queued_task.get_task ());
+
+	return queued_task;
       }
 
     m_available_workers.push_back (&worker_arg);
     assert (m_available_workers.size () <= m_workers.size ());
 
-    return nullptr;
+    return std::nullopt;
   }
 
   template <bool Stats>
@@ -1048,7 +1059,7 @@ namespace cubthread
 
 	    // assign task / start thread
 	    // it will add itself to available workers
-	    static_cast<worker_impl *> (worker.get ())->assign_task (nullptr);
+	    static_cast<worker_impl *> (worker.get ())->assign_task ();
 	  }
 	else
 	  {
@@ -1060,7 +1071,7 @@ namespace cubthread
 
   template <bool Stats>
   void
-  worker_pool_impl<Stats>::core_impl::execute_task_as_temp (task_type *task_p)
+  worker_pool_impl<Stats>::core_impl::execute_task_as_temp (wrapped_task &task_ref)
   {
     auto w = allocate_worker (true);
     w->set_parent_core (*this);
@@ -1068,7 +1079,7 @@ namespace cubthread
     std::lock_guard<std::mutex> ulock (m_temp_workers_mutex);
 
     m_temp_workers.push_back (std::move (w));
-    static_cast<worker_impl *> (m_temp_workers.back ())->assign_task (task_p);
+    static_cast<worker_impl *> (m_temp_workers.back ())->assign_task (task_ref);
   }
 
   //////////////////////////////////////////////////////////////////////////
@@ -1079,7 +1090,7 @@ namespace cubthread
   worker_pool_impl<Stats>::core_impl::worker_impl::worker_impl (bool is_temp)
     : worker_pool::core::worker ()
     , m_context_p (nullptr)
-    , m_task_p (nullptr)
+    , m_wrapped_task (std::nullopt)
     , m_stop (false)
     , m_has_thread (false)
     , m_is_temp (is_temp)
@@ -1125,14 +1136,14 @@ namespace cubthread
 
   template <bool Stats>
   void
-  worker_pool_impl<Stats>::core_impl::worker_impl::assign_task (task_type *work_p)
+  worker_pool_impl<Stats>::core_impl::worker_impl::assign_task (wrapped_task &task_ref)
   {
     std::unique_lock<std::mutex> ulock (m_task_mutex);
 
-    assert (m_task_p == nullptr);
+    assert (!m_wrapped_task.has_value ());
 
     // save task
-    m_task_p = work_p;
+    m_wrapped_task = task_ref;
 
     if (m_is_temp)
       {
@@ -1146,6 +1157,30 @@ namespace cubthread
 	// notify waiting thread
 	ulock.unlock (); // mutex is not needed for notify
 	m_task_cv.notify_one ();
+      }
+    else
+      {
+	m_has_thread = true;
+	ulock.unlock ();
+
+	assert (m_context_p == nullptr);
+
+	start_thread ();
+      }
+  }
+
+  template <bool Stats>
+  void
+  worker_pool_impl<Stats>::core_impl::worker_impl::assign_task (void)
+  {
+    std::unique_lock<std::mutex> ulock (m_task_mutex);
+
+    assert (!m_wrapped_task.has_value ());
+    assert (!m_is_temp);
+
+    if (m_has_thread)
+      {
+	ulock.unlock ();
       }
     else
       {
@@ -1204,7 +1239,7 @@ namespace cubthread
   void
   worker_pool_impl<Stats>::core_impl::worker_impl::map_context_if_running (bool &stop, Func &&func, Args &&... args)
   {
-    if (m_task_p == nullptr)
+    if (!m_wrapped_task.has_value ())
       {
 	// not running
 	return;
@@ -1237,16 +1272,16 @@ namespace cubthread
 	return;
       }
 
-    if (m_task_p == nullptr)
+    if (!m_wrapped_task.has_value ())
       {
 	// started without task; get one
 	if (get_new_task ())
 	  {
-	    assert (m_task_p != nullptr);
+	    assert (m_wrapped_task.has_value ());
 	  }
       }
 
-    if (m_task_p != nullptr)
+    if (m_wrapped_task.has_value ())
       {
 	// loop and execute as many tasks as possible
 	do
@@ -1259,8 +1294,6 @@ namespace cubthread
       {
 	// never got a task
       }
-
-    // finish_run ();    // do stuff on end like retiring context
   }
 
   template <bool Stats>
@@ -1288,7 +1321,7 @@ namespace cubthread
   void
   worker_pool_impl<Stats>::core_impl::worker_impl::finish_run (void)
   {
-    assert (m_task_p == nullptr);
+    assert (!m_wrapped_task.has_value ());
     assert (m_context_p != nullptr);
 
     // retire context
@@ -1307,10 +1340,10 @@ namespace cubthread
   void
   worker_pool_impl<Stats>::core_impl::worker_impl::execute_current_task (void)
   {
-    assert (m_task_p != nullptr);
+    assert (m_wrapped_task.has_value ());
 
     // execute task
-    m_task_p->execute (*m_context_p);
+    m_wrapped_task->execute (*m_context_p);
 
     // and retire task
     retire_current_task ();
@@ -1331,18 +1364,18 @@ namespace cubthread
   void
   worker_pool_impl<Stats>::core_impl::worker_impl::retire_current_task (void)
   {
-    assert (m_task_p != nullptr);
+    assert (m_wrapped_task.has_value ());
 
     // retire task
-    m_task_p->retire ();
-    m_task_p = nullptr;
+    m_wrapped_task->retire ();
+    m_wrapped_task = std::nullopt;
   }
 
   template <bool Stats>
   bool
   worker_pool_impl<Stats>::core_impl::worker_impl::get_new_task (void)
   {
-    assert (m_task_p == nullptr);
+    assert (!m_wrapped_task.has_value ());
     assert (dynamic_cast<core_impl *> (m_parent_core));
 
     std::unique_lock<std::mutex> ulock (m_task_mutex, std::defer_lock);
@@ -1357,22 +1390,23 @@ namespace cubthread
 	//       current thread may be preempted. worker is then claimed from free active list and worker is assigned
 	//       a task. this changes expected behavior and can have unwanted consequences.
 
-	task_type *task_p = static_cast<core_impl *> (m_parent_core)->get_task_or_become_available (*this);
-	if (task_p != nullptr)
+	std::optional<wrapped_task> queued_task =
+		static_cast<core_impl *> (m_parent_core)->get_task_or_become_available (*this);
+	if (queued_task.has_value ())
 	  {
 	    // it is safe to set here
-	    m_task_p = task_p;
+	    m_wrapped_task = std::move (queued_task);
 	    return true;
 	  }
 
 	// wait for task
 	ulock.lock ();
-	if (m_task_p == nullptr && !m_stop)
+	if (!m_wrapped_task.has_value () && !m_stop)
 	  {
 	    // wait until a task is received or stopped ...
 	    // ... or time out
 	    condvar_wait (m_task_cv, ulock, m_parent_core->get_parent_pool ()->get_idle_timeout (),
-			  [this] () -> bool { return m_task_p != nullptr || m_stop; });
+			  [this] () -> bool { return m_wrapped_task.has_value () || m_stop; });
 	  }
 	else
 	  {
@@ -1388,7 +1422,7 @@ namespace cubthread
       }
 
     // did I get a task?
-    if (m_task_p == nullptr)
+    if (!m_wrapped_task.has_value ())
       {
 	// no; this thread will stop. from this point forward, if a new task is assigned, a new thread must be spawned
 	m_has_thread = false;
@@ -1418,6 +1452,8 @@ namespace cubthread
   template <bool Stats>
   worker_pool_impl<Stats>::wrapped_task::wrapped_task (task_type *task_p)
   {
+    assert (task_p != nullptr);
+
     m_inner.task = task_p;
     if constexpr (Stats)
       {
@@ -1444,6 +1480,25 @@ namespace cubthread
     static_assert (Stats, "get_time() requires Stats == true");
 
     return m_inner.time;
+  }
+
+  template <bool Stats>
+  void
+  worker_pool_impl<Stats>::wrapped_task::execute (context_type &thread_ref)
+  {
+    assert (m_inner.task != nullptr);
+
+    m_inner.task->execute (thread_ref);
+  }
+
+  template <bool Stats>
+  void
+  worker_pool_impl<Stats>::wrapped_task::retire (void)
+  {
+    assert (m_inner.task != nullptr);
+
+    m_inner.task->retire ();
+    m_inner.task = nullptr;
   }
 
   //////////////////////////////////////////////////////////////////////////

--- a/src/thread/thread_worker_pool_impl.hpp
+++ b/src/thread/thread_worker_pool_impl.hpp
@@ -434,7 +434,6 @@ namespace cubthread
       wrapped_task (wrapped_task &&other);
       wrapped_task &operator= (wrapped_task &&other) = delete;
 
-      task_type *get_task (void);
       cubperf::time_point &get_time (void);
 
       // helper
@@ -960,9 +959,9 @@ namespace cubthread
 
     while (!m_task_queue.empty ())
       {
-	wrapped_task &queued_task = m_task_queue.front ();
-	queued_task.get_task ()->retire ();
+	wrapped_task queued_task = std::move (m_task_queue.front ());
 	m_task_queue.pop ();
+	queued_task.retire ();
       }
   }
 
@@ -976,8 +975,6 @@ namespace cubthread
       {
 	wrapped_task queued_task = std::move (m_task_queue.front ());
 	m_task_queue.pop ();
-
-	assert (queued_task.get_task ());
 
 	return std::optional<wrapped_task> (std::in_place, std::move (queued_task));
       }
@@ -1567,6 +1564,7 @@ namespace cubthread
   template <bool Stats>
   worker_pool_impl<Stats>::wrapped_task::~wrapped_task (void)
   {
+    assert (m_inner.task == nullptr);
   }
 
   template <bool Stats>
@@ -1579,13 +1577,6 @@ namespace cubthread
       {
 	m_inner.time = other.m_inner.time;
       }
-  }
-
-  template <bool Stats>
-  typename worker_pool_impl<Stats>::task_type *
-  worker_pool_impl<Stats>::wrapped_task::get_task (void)
-  {
-    return m_inner.task;
   }
 
   template <bool Stats>

--- a/src/thread/thread_worker_pool_impl.hpp
+++ b/src/thread/thread_worker_pool_impl.hpp
@@ -298,10 +298,9 @@ namespace cubthread
       // start thread for current worker
       void start_thread (void);
 
-      // assign task (can be NULL) to running thread or start thread
+      // assign task to worker; wake a running thread or start a new one.
+      // NULL is used only to prestart pooled threads.
       void assign_task (task_type *work_p);
-      // run task on current thread (push_time is provided by core)
-      void push_task_on_running_thread (task_type *work_p);
 
       // stop execution; if worker has a thread running, returns true
       bool stop_execution (void) override;
@@ -1128,6 +1127,8 @@ namespace cubthread
   {
     std::unique_lock<std::mutex> ulock (m_task_mutex);
 
+    assert (m_task_p == NULL);
+
     // save task
     m_task_p = work_p;
 
@@ -1153,27 +1154,6 @@ namespace cubthread
 
 	start_thread ();
       }
-  }
-
-  template <bool Stats>
-  void
-  worker_pool_impl<Stats>::core_impl::worker_impl::push_task_on_running_thread (task_type *work_p)
-  {
-    // must lock task mutex
-    std::unique_lock<std::mutex> ulock (m_task_mutex);
-
-    assert (work_p != NULL);
-    // make sure worker is in a valid state
-    assert (m_task_p == NULL);
-    assert (m_context_p != NULL);
-
-    // set task
-    m_task_p = work_p;
-
-    // mutex is not needed for notify
-    ulock.unlock ();
-    // notify waiting thread
-    m_task_cv.notify_one ();
   }
 
   template <bool Stats>
@@ -1589,4 +1569,3 @@ namespace cubthread
 } // namespace cubthread
 
 #endif // _THREAD_WORKER_POOL_IMPL_HPP_
-

--- a/src/thread/thread_worker_pool_impl.hpp
+++ b/src/thread/thread_worker_pool_impl.hpp
@@ -306,7 +306,7 @@ namespace cubthread
       virtual void initialize_workers ();
 
       // execute task for method/stored procedure by recursive call; This task is not pooled and executes in a temporary created thread.
-      virtual void execute_task_as_temp (wrapped_task &task_ref);
+      virtual void execute_task_as_temp (wrapped_task &&task_ref);
 
       std::vector<std::unique_ptr<worker>> m_workers;
       std::vector<worker *> m_available_workers;
@@ -342,7 +342,7 @@ namespace cubthread
       void start_thread (void);
 
       // assign task to worker; wake a running thread or start a new one.
-      void assign_task (wrapped_task &task_ref);
+      void assign_task (wrapped_task &&task_ref);
       // [optional] used only to prestart pooled threads.
       void assign_task (void);
 
@@ -427,6 +427,12 @@ namespace cubthread
     public:
       explicit wrapped_task (task_type *task_p);
       ~wrapped_task ();
+
+      wrapped_task (const wrapped_task &) = delete;
+      wrapped_task &operator= (const wrapped_task &) = delete;
+
+      wrapped_task (wrapped_task &&other);
+      wrapped_task &operator= (wrapped_task &&other) = delete;
 
       task_type *get_task (void);
       cubperf::time_point &get_time (void);
@@ -896,7 +902,7 @@ namespace cubthread
 
 	assert (refp != nullptr);
 
-	refp->assign_task (task_ref);
+	refp->assign_task (std::move (task_ref));
       }
     else
       {
@@ -905,12 +911,12 @@ namespace cubthread
 	    // no need to hold the mutex (prevent deadlock)
 	    ulock.unlock ();
 
-	    execute_task_as_temp (task_ref);
+	    execute_task_as_temp (std::move (task_ref));
 	  }
 	else
 	  {
 	    // save to queue
-	    m_task_queue.push (task_ref);
+	    m_task_queue.push (std::move (task_ref));
 	  }
       }
   }
@@ -966,12 +972,12 @@ namespace cubthread
 
     if (!m_task_queue.empty ())
       {
-	wrapped_task queued_task = m_task_queue.front ();
+	wrapped_task queued_task = std::move (m_task_queue.front ());
 	m_task_queue.pop ();
 
 	assert (queued_task.get_task ());
 
-	return queued_task;
+	return std::optional<wrapped_task> (std::in_place, std::move (queued_task));
       }
 
     m_available_workers.push_back (&worker_arg);
@@ -1144,7 +1150,7 @@ namespace cubthread
 
   template <bool Stats>
   void
-  worker_pool_impl<Stats>::core_impl::execute_task_as_temp (wrapped_task &task_ref)
+  worker_pool_impl<Stats>::core_impl::execute_task_as_temp (wrapped_task &&task_ref)
   {
     auto w = allocate_worker (true);
     w->set_parent_core (*this);
@@ -1152,7 +1158,7 @@ namespace cubthread
     std::lock_guard<std::mutex> ulock (m_temp_workers_mutex);
 
     m_temp_workers.push_back (std::move (w));
-    static_cast<worker_impl *> (m_temp_workers.back ())->assign_task (task_ref);
+    static_cast<worker_impl *> (m_temp_workers.back ())->assign_task (std::move (task_ref));
   }
 
   //////////////////////////////////////////////////////////////////////////
@@ -1208,14 +1214,14 @@ namespace cubthread
 
   template <bool Stats>
   void
-  worker_pool_impl<Stats>::core_impl::worker_impl::assign_task (wrapped_task &task_ref)
+  worker_pool_impl<Stats>::core_impl::worker_impl::assign_task (wrapped_task &&task_ref)
   {
     std::unique_lock<std::mutex> ulock (m_task_mutex);
 
     assert (!m_wrapped_task.has_value ());
 
     // save task
-    m_wrapped_task = task_ref;
+    m_wrapped_task.emplace (std::move (task_ref));
 
     if (m_is_temp)
       {
@@ -1487,7 +1493,7 @@ namespace cubthread
 	    stats::time_and_increment (m_stats, stats::id::found_in_queue);
 
 	    // it is safe to set here
-	    m_wrapped_task = std::move (queued_task);
+	    m_wrapped_task.emplace (std::move (*queued_task));
 	    return true;
 	  }
 
@@ -1559,6 +1565,18 @@ namespace cubthread
   template <bool Stats>
   worker_pool_impl<Stats>::wrapped_task::~wrapped_task (void)
   {
+  }
+
+  template <bool Stats>
+  worker_pool_impl<Stats>::wrapped_task::wrapped_task (wrapped_task &&other)
+  {
+    m_inner.task = other.m_inner.task;
+    other.m_inner.task = nullptr;
+
+    if constexpr (Stats)
+      {
+	m_inner.time = other.m_inner.time;
+      }
   }
 
   template <bool Stats>

--- a/src/thread/thread_worker_pool_impl.hpp
+++ b/src/thread/thread_worker_pool_impl.hpp
@@ -226,7 +226,7 @@ namespace cubthread
       // execute task
       void execute_task (task_type *task_p, bool is_temp) override;
 
-      // notify workers to stop; if any of core's workers are still running, outputs is_not_stopped = true
+      // notify workers to stop; if any of core's workers are still running, returns true
       bool stop_execution (void) override;
       void retire_queued_tasks (void);
 
@@ -303,7 +303,7 @@ namespace cubthread
       // run task on current thread (push_time is provided by core)
       void push_task_on_running_thread (task_type *work_p);
 
-      // stop execution; if worker has a thread running, it outputs is_not_stopped = true
+      // stop execution; if worker has a thread running, returns true
       bool stop_execution (void) override;
 
       std::mutex &get_mutex (void)
@@ -373,7 +373,10 @@ namespace cubthread
       struct task_with_stats
       {
 	task_type *task;
+
 	cubperf::time_point at_created;
+
+	// Other stats might be added here
       };
 
       using inner_type = typename std::conditional_t<Stats, task_with_stats, task_only>;

--- a/src/thread/thread_worker_pool_impl.hpp
+++ b/src/thread/thread_worker_pool_impl.hpp
@@ -418,6 +418,7 @@ namespace cubthread
       static void destroy (cubperf::statset *stats);
 
       static void time_and_increment (cubperf::statset &stats, cubperf::stat_id id);
+      static void time_and_increment (cubperf::statset &stats, cubperf::stat_id id, cubperf::duration d);
       static void accumulate (const cubperf::statset &what, cubperf::stat_value *where);
 
       static std::size_t get_count (void);
@@ -1410,13 +1411,17 @@ namespace cubthread
       }
   }
 
+  //////////////////////////////////////////////////////////////////////////
+  // worker_pool_impl<Stats>::wrapped_task
+  //////////////////////////////////////////////////////////////////////////
+
   template <bool Stats>
   worker_pool_impl<Stats>::wrapped_task::wrapped_task (task_type *task_p)
   {
     m_inner.task = task_p;
     if constexpr (Stats)
       {
-	m_inner.at_created = cubperf::clock::now ();
+	m_inner.time = cubperf::clock::now ();
       }
   }
 
@@ -1504,6 +1509,16 @@ namespace cubthread
     if constexpr (Stats)
       {
 	statdef.time_and_increment (stats, id);
+      }
+  }
+
+  template <bool Stats>
+  void
+  worker_pool_impl<Stats>::stats::time_and_increment (cubperf::statset &stats, cubperf::stat_id id, cubperf::duration d)
+  {
+    if constexpr (Stats)
+      {
+	statdef.time_and_increment (stats, id, d);
       }
   }
 

--- a/src/thread/thread_worker_pool_impl.hpp
+++ b/src/thread/thread_worker_pool_impl.hpp
@@ -346,6 +346,34 @@ namespace cubthread
   };
 
   //////////////////////////////////////////////////////////////////////////
+  // statistics
+  //////////////////////////////////////////////////////////////////////////
+
+  struct stats
+  {
+    enum class id : cubperf::stat_id
+    {
+      start_thread = 0,
+      create_context = 1,
+      execute_task = 2,
+      retire_task = 3,
+      found_in_queue = 4,
+      wakeup_with_task = 5,
+      recycle_context = 6,
+      retire_context = 7
+    };
+
+    static cubperf::statset &create (void);
+    static void destroy (cubperf::statset &stats);
+
+    static void time_and_increment (cubperf::statset &stats, cubperf::stat_id id);
+    static void accumulate (const cubperf::statset &what, cubperf::stat_value *where);
+
+    static std::size_t get_count (void);
+    static const char *get_name (std::size_t stat_index);
+  };
+
+  //////////////////////////////////////////////////////////////////////////
   // base functions
   //////////////////////////////////////////////////////////////////////////
 

--- a/src/thread/thread_worker_pool_impl.hpp
+++ b/src/thread/thread_worker_pool_impl.hpp
@@ -663,11 +663,11 @@ namespace cubthread
   {
     if constexpr (Stats)
       {
-	cubperf::stat_value statset[static_cast<std::size_t> (stats::id::type_count)];
+	std::vector<cubperf::stat_value> statset (stats::get_count (), 0);
 	std::stringstream ss;
 
-	std::memset (statset, 0, sizeof (stats));
-	get_stats (statset);
+	std::memset (statset.data (), 0, stats::get_count () * sizeof (cubperf::stat_value));
+	get_stats (statset.data ());
 
 	ss << "Worker pool statistics: " << m_name << std::endl;
 

--- a/src/thread/thread_worker_pool_impl.hpp
+++ b/src/thread/thread_worker_pool_impl.hpp
@@ -215,11 +215,14 @@ namespace cubthread
   template <bool Stats>
   class worker_pool_impl<Stats>::stats_base
   {
-      friend class worker;
-
     public:
-      explicit stats_base ();
-      ~stats_base ();
+      stats_base () = default;
+      ~stats_base () = default;
+
+      stats_base (const stats_base &) = delete;
+      stats_base &operator= (const stats_base &) = delete;
+      stats_base (stats_base &&) = default;
+      stats_base &operator= (stats_base &&) = default;
 
       // empty base
   };
@@ -227,13 +230,16 @@ namespace cubthread
   template <>
   class worker_pool_impl<true>::stats_base
   {
-      friend class worker;
-
     public:
-      explicit stats_base ();
+      stats_base ();
       ~stats_base ();
 
-    private:
+      stats_base (const stats_base &) = delete;
+      stats_base &operator= (const stats_base &) = delete;
+
+      stats_base (stats_base &&other);
+      stats_base &operator= (stats_base &&other);
+
       // stats
       cubperf::statset *statset;
       // timing
@@ -450,7 +456,7 @@ namespace cubthread
 	found_in_queue = 4,
 	wakeup_with_task = 5,
 	recycle_context = 6,
-	retire_context = 7,
+	retire_context = 7
       };
 
       static const cubperf::statset_definition statdef;
@@ -463,7 +469,7 @@ namespace cubthread
 
       static void time_and_increment (stats_base &base, id stat_id);
       static void time_and_increment (stats_base &base, id stat_id, cubperf::duration d);
-      static void accumulate (stats_base &base, cubperf::stat_value *where);
+      static void accumulate (const stats_base &base, cubperf::stat_value *where);
 
       static std::size_t get_count (void);
       static const char *get_name (std::size_t stat_index);
@@ -797,26 +803,37 @@ namespace cubthread
   // worker_pool_impl<Stats>::stats_base
   //////////////////////////////////////////////////////////////////////////
 
-  template <bool Stats>
-  worker_pool_impl<Stats>::stats_base::stats_base ()
-  {
-  }
-
-  template <bool Stats>
-  worker_pool_impl<Stats>::stats_base::~stats_base ()
-  {
-  }
-
   inline
   worker_pool_impl<true>::stats_base::stats_base ()
     : statset (nullptr)
-    , at_started ()
+    , time ()
   {
   }
 
   inline
   worker_pool_impl<true>::stats_base::~stats_base ()
   {
+  }
+
+  inline
+  worker_pool_impl<true>::stats_base::stats_base (stats_base &&other)
+    : statset (other.statset)
+    , time (other.time)
+  {
+    other.statset = nullptr;
+  }
+
+  inline worker_pool_impl<true>::stats_base &
+  worker_pool_impl<true>::stats_base::operator= (stats_base &&other)
+  {
+    if (this != &other)
+      {
+	delete statset;
+	statset = other.statset;
+	time = other.time;
+	other.statset = nullptr;
+      }
+    return *this;
   }
 
   //////////////////////////////////////////////////////////////////////////
@@ -1642,8 +1659,8 @@ namespace cubthread
   {
     if constexpr (Stats)
       {
-	base.statset.m_timept = base.time;
-	statdef.time_and_increment (base.statset, static_cast<cubperf::stat_id> (stat_id));
+	base.statset->m_timept = base.time;
+	statdef.time_and_increment (*base.statset, static_cast<cubperf::stat_id> (stat_id));
       }
   }
 
@@ -1653,18 +1670,18 @@ namespace cubthread
   {
     if constexpr (Stats)
       {
-	base.statset.m_timept = base.time;
-	statdef.time_and_increment (base.statset, static_cast<cubperf::stat_id> (stat_id), d);
+	base.statset->m_timept = base.time;
+	statdef.time_and_increment (*base.statset, static_cast<cubperf::stat_id> (stat_id), d);
       }
   }
 
   template <bool Stats>
   void
-  worker_pool_impl<Stats>::stats::accumulate (stats_base &base, cubperf::stat_value *where)
+  worker_pool_impl<Stats>::stats::accumulate (const stats_base &base, cubperf::stat_value *where)
   {
     if constexpr (Stats)
       {
-	statdef.add_stat_values_with_converted_timers<std::chrono::microseconds> (base.statset, where);
+	statdef.add_stat_values_with_converted_timers<std::chrono::microseconds> (*base.statset, where);
       }
   }
 

--- a/src/thread/thread_worker_pool_impl.hpp
+++ b/src/thread/thread_worker_pool_impl.hpp
@@ -462,7 +462,10 @@ namespace cubthread
 	found_in_queue = 4,
 	wakeup_with_task = 5,
 	recycle_context = 6,
-	retire_context = 7
+	retire_context = 7,
+
+	// must be last
+	type_count
       };
 
       static const cubperf::statset_definition statdef;
@@ -660,19 +663,18 @@ namespace cubthread
   {
     if constexpr (Stats)
       {
-	const std::size_t MAX_SIZE = 32;
-	cubperf::stat_value stats[MAX_SIZE];
+	cubperf::stat_value statset[static_cast<std::size_t> (stats::id::type_count)];
 	std::stringstream ss;
 
-	std::memset (stats, 0, sizeof (stats));
-	get_stats (stats);
+	std::memset (statset, 0, sizeof (stats));
+	get_stats (statset);
 
 	ss << "Worker pool statistics: " << m_name << std::endl;
 
 	for (std::size_t index = 0; index < stats::get_count (); index++)
 	  {
 	    ss << "\t" << stats::get_name (index) << ": ";
-	    ss << stats[index] << std::endl;
+	    ss << statset[index] << std::endl;
 	  }
 
 	_er_log_debug (ARG_FILE_LINE, ss.str ().c_str ());

--- a/src/thread/thread_worker_pool_impl.hpp
+++ b/src/thread/thread_worker_pool_impl.hpp
@@ -113,6 +113,7 @@ namespace cubthread
       // forward definition
       class core_impl;
       class wrapped_task;
+      class stats_base;
       class stats;
 
       virtual ~worker_pool_impl ();
@@ -206,6 +207,39 @@ namespace cubthread
       std::atomic<std::size_t> m_round_robin_counter;
   };
 
+  // worker_pool_impl<Stats>::stats_base
+  //
+  // description
+  //    empty if Stats is false
+  //
+  template <bool Stats>
+  class worker_pool_impl<Stats>::stats_base
+  {
+      friend class worker;
+
+    public:
+      explicit stats_base ();
+      ~stats_base ();
+
+      // empty base
+  };
+
+  template <>
+  class worker_pool_impl<true>::stats_base
+  {
+      friend class worker;
+
+    public:
+      explicit stats_base ();
+      ~stats_base ();
+
+    private:
+      // stats
+      cubperf::statset *statset;
+      // timing
+      cubperf::time_point time;
+  };
+
   // worker_pool_impl<Stats>::core
   //
   // description
@@ -218,9 +252,10 @@ namespace cubthread
   template <bool Stats>
   class worker_pool_impl<Stats>::core_impl : public worker_pool::core
   {
+      friend class worker_pool_impl;
+
     public:
       // forward definition of nested class worker
-      friend class worker_pool_impl;
       class worker_impl;
 
       virtual ~core_impl (void);
@@ -289,9 +324,9 @@ namespace cubthread
   template <bool Stats>
   class worker_pool_impl<Stats>::core_impl::worker_impl : public worker_pool::core::worker
   {
-    public:
       friend class core_impl;
 
+    public:
       virtual ~worker_impl (void);
 
       // init
@@ -355,7 +390,7 @@ namespace cubthread
 
       bool m_is_temp;				    // true if worker is for temp task
 
-      cubperf::statset *m_statistics;		    // stats
+      stats_base m_stats;			    // bool if Stats is false
   };
 
   // worker_pool_impl<Stats>::wrapped_task
@@ -415,7 +450,7 @@ namespace cubthread
 	found_in_queue = 4,
 	wakeup_with_task = 5,
 	recycle_context = 6,
-	retire_context = 7
+	retire_context = 7,
       };
 
       static const cubperf::statset_definition statdef;
@@ -423,12 +458,12 @@ namespace cubthread
       static constexpr cubperf::stat_definition make_def (id stat_id, cubperf::stat_definition::type stat_type,
 	  const char *first_name, const char *second_name);
 
-      static cubperf::statset *create (void);
-      static void destroy (cubperf::statset *stats);
+      static stats_base create (void);
+      static void destroy (stats_base &base);
 
-      static void time_and_increment (cubperf::statset &stats, cubperf::stat_id id);
-      static void time_and_increment (cubperf::statset &stats, cubperf::stat_id id, cubperf::duration d);
-      static void accumulate (const cubperf::statset &what, cubperf::stat_value *where);
+      static void time_and_increment (stats_base &base, id stat_id);
+      static void time_and_increment (stats_base &base, id stat_id, cubperf::duration d);
+      static void accumulate (stats_base &base, cubperf::stat_value *where);
 
       static std::size_t get_count (void);
       static const char *get_name (std::size_t stat_index);
@@ -617,11 +652,6 @@ namespace cubthread
 	cubperf::stat_value stats[MAX_SIZE];
 	std::stringstream ss;
 
-	if (!m_log)
-	  {
-	    return;
-	  }
-
 	std::memset (stats, 0, sizeof (stats));
 	get_stats (stats);
 
@@ -761,6 +791,32 @@ namespace cubthread
       }
 
     return index;
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // worker_pool_impl<Stats>::stats_base
+  //////////////////////////////////////////////////////////////////////////
+
+  template <bool Stats>
+  worker_pool_impl<Stats>::stats_base::stats_base ()
+  {
+  }
+
+  template <bool Stats>
+  worker_pool_impl<Stats>::stats_base::~stats_base ()
+  {
+  }
+
+  inline
+  worker_pool_impl<true>::stats_base::stats_base ()
+    : statset (nullptr)
+    , at_started ()
+  {
+  }
+
+  inline
+  worker_pool_impl<true>::stats_base::~stats_base ()
+  {
   }
 
   //////////////////////////////////////////////////////////////////////////
@@ -1094,15 +1150,14 @@ namespace cubthread
     , m_stop (false)
     , m_has_thread (false)
     , m_is_temp (is_temp)
-    , m_statistics (stats::create ())
+    , m_stats (stats::create ())
   {
-    assert (Stats ? m_statistics != nullptr : m_statistics == nullptr);
   }
 
   template <bool Stats>
   worker_pool_impl<Stats>::core_impl::worker_impl::~worker_impl (void)
   {
-    stats::destroy (m_statistics);
+    stats::destroy (m_stats);
   }
 
   template <bool Stats>
@@ -1232,6 +1287,7 @@ namespace cubthread
   void
   worker_pool_impl<Stats>::core_impl::worker_impl::get_stats (cubperf::stat_value *stats_out) const
   {
+    stats::accumulate (m_stats, stats_out);
   }
 
   template <bool Stats>
@@ -1313,8 +1369,14 @@ namespace cubthread
       }
 #endif
 
+    // stats: start thread
+    stats::time_and_increment (m_stats, stats::id::start_thread);
+
     // a context is required
     m_context_p = &m_parent_core->get_entry_manager ().create_context ();
+
+    // stats: context create
+    stats::time_and_increment (m_stats, stats::id::create_context);
   }
 
   template <bool Stats>
@@ -1327,6 +1389,9 @@ namespace cubthread
     // retire context
     m_parent_core->get_entry_manager ().retire_context (*m_context_p);
     m_context_p = nullptr;
+
+    // stats: context retire
+    stats::time_and_increment (m_stats, stats::id::retire_context);
 
     if (m_is_temp)
       {
@@ -1344,12 +1409,16 @@ namespace cubthread
 
     // execute task
     m_wrapped_task->execute (*m_context_p);
+    // stats: execute task
+    stats::time_and_increment (m_stats, stats::id::execute_task);
 
     // and retire task
     retire_current_task ();
 
     // and recycle context before getting another task
     m_parent_core->get_entry_manager ().recycle_context (*m_context_p);
+    // stats: context recycle
+    stats::time_and_increment (m_stats, stats::id::recycle_context);
 
     // notify core one task was finished
     if (m_is_temp == false)
@@ -1369,6 +1438,9 @@ namespace cubthread
     // retire task
     m_wrapped_task->retire ();
     m_wrapped_task = std::nullopt;
+
+    // stats: retire task
+    stats::time_and_increment (m_stats, stats::id::retire_task);
   }
 
   template <bool Stats>
@@ -1394,6 +1466,9 @@ namespace cubthread
 		static_cast<core_impl *> (m_parent_core)->get_task_or_become_available (*this);
 	if (queued_task.has_value ())
 	  {
+	    // stats: found in queue
+	    stats::time_and_increment (m_stats, stats::id::found_in_queue);
+
 	    // it is safe to set here
 	    m_wrapped_task = std::move (queued_task);
 	    return true;
@@ -1439,6 +1514,9 @@ namespace cubthread
 
 	// safe-guard - threads should no longer be available
 	static_cast<core_impl *> (m_parent_core)->check_worker_not_available (*this);
+
+	// stats: wake up with task
+	stats::time_and_increment (m_stats, stats::id::wakeup_with_task);
 
 	// found task
 	return true;
@@ -1534,56 +1612,59 @@ namespace cubthread
   };
 
   template <bool Stats>
-  cubperf::statset *
+  typename worker_pool_impl<Stats>::stats_base
   worker_pool_impl<Stats>::stats::create (void)
   {
+    stats_base base;
+
     if constexpr (Stats)
       {
-	return statdef.create_statset ();
+	base.statset = statdef.create_statset ();
+	base.time = cubperf::clock::now ();
       }
-    else
+    return base;
+  }
+
+  template <bool Stats>
+  void
+  worker_pool_impl<Stats>::stats::destroy (stats_base &base)
+  {
+    if constexpr (Stats)
       {
-	return nullptr;
+	delete base.statset;
+	base.statset = nullptr;
       }
   }
 
   template <bool Stats>
   void
-  worker_pool_impl<Stats>::stats::destroy (cubperf::statset *stats)
+  worker_pool_impl<Stats>::stats::time_and_increment (stats_base &base, id stat_id)
   {
     if constexpr (Stats)
       {
-	delete stats;
+	base.statset.m_timept = base.time;
+	statdef.time_and_increment (base.statset, static_cast<cubperf::stat_id> (stat_id));
       }
   }
 
   template <bool Stats>
   void
-  worker_pool_impl<Stats>::stats::time_and_increment (cubperf::statset &stats, cubperf::stat_id id)
+  worker_pool_impl<Stats>::stats::time_and_increment (stats_base &base, id stat_id, cubperf::duration d)
   {
     if constexpr (Stats)
       {
-	statdef.time_and_increment (stats, id);
+	base.statset.m_timept = base.time;
+	statdef.time_and_increment (base.statset, static_cast<cubperf::stat_id> (stat_id), d);
       }
   }
 
   template <bool Stats>
   void
-  worker_pool_impl<Stats>::stats::time_and_increment (cubperf::statset &stats, cubperf::stat_id id, cubperf::duration d)
+  worker_pool_impl<Stats>::stats::accumulate (stats_base &base, cubperf::stat_value *where)
   {
     if constexpr (Stats)
       {
-	statdef.time_and_increment (stats, id, d);
-      }
-  }
-
-  template <bool Stats>
-  void
-  worker_pool_impl<Stats>::stats::accumulate (const cubperf::statset &what, cubperf::stat_value *where)
-  {
-    if constexpr (Stats)
-      {
-	statdef.add_stat_values_with_converted_timers<std::chrono::microseconds> (what, where);
+	statdef.add_stat_values_with_converted_timers<std::chrono::microseconds> (base.statset, where);
       }
   }
 

--- a/src/thread/thread_worker_pool_impl.hpp
+++ b/src/thread/thread_worker_pool_impl.hpp
@@ -33,7 +33,7 @@
 #include "thread_worker_pool.hpp"
 
 // cubrid includes
-#include "perf_def.hpp"
+#include "perf.hpp"
 #include "resources.hpp"
 #include "error_manager.h"
 
@@ -49,7 +49,7 @@
 #include <string>
 #include <system_error>
 #include <thread>
-
+#include <sstream>
 #include <cassert>
 #include <cstring>
 #include <pthread.h>
@@ -107,6 +107,10 @@ namespace cubthread
     public:
       // forward definition for nested core class
       friend class manager;
+
+    public:
+      // forward definition
+      class stats;
       class core_impl;
 
       virtual ~worker_pool_impl ();
@@ -349,28 +353,38 @@ namespace cubthread
   // statistics
   //////////////////////////////////////////////////////////////////////////
 
-  struct stats
+  template <bool Stats>
+  class worker_pool_impl<Stats>::stats
   {
-    enum class id : cubperf::stat_id
-    {
-      start_thread = 0,
-      create_context = 1,
-      execute_task = 2,
-      retire_task = 3,
-      found_in_queue = 4,
-      wakeup_with_task = 5,
-      recycle_context = 6,
-      retire_context = 7
-    };
+    public:
+      enum class id : cubperf::stat_id
+      {
+	start_thread = 0,
+	create_context = 1,
+	execute_task = 2,
+	retire_task = 3,
+	found_in_queue = 4,
+	wakeup_with_task = 5,
+	recycle_context = 6,
+	retire_context = 7
+      };
 
-    static cubperf::statset &create (void);
-    static void destroy (cubperf::statset &stats);
+      static const cubperf::statset_definition statdef;
 
-    static void time_and_increment (cubperf::statset &stats, cubperf::stat_id id);
-    static void accumulate (const cubperf::statset &what, cubperf::stat_value *where);
+      static constexpr cubperf::stat_definition make_def (id stat_id, cubperf::stat_definition::type stat_type,
+	  const char *first_name, const char *second_name);
 
-    static std::size_t get_count (void);
-    static const char *get_name (std::size_t stat_index);
+      static cubperf::statset *create (void);
+      static void destroy (cubperf::statset *stats);
+
+      static void time_and_increment (cubperf::statset &stats, cubperf::stat_id id);
+      static void accumulate (const cubperf::statset &what, cubperf::stat_value *where);
+
+      static std::size_t get_count (void);
+      static const char *get_name (std::size_t stat_index);
+
+    private:
+      stats () = delete;
   };
 
   //////////////////////////////////////////////////////////////////////////
@@ -387,8 +401,6 @@ namespace cubthread
   void wp_handle_system_error (const char *message, const std::system_error &e);
   template <typename Func>
   void wp_call_func_throwing_system_error (const char *message, Func &func);
-
-  void wp_er_log_stats (const char *header, cubperf::stat_value *statsp);
 
   bool wp_is_thread_always_alive_forced ();
   void wp_set_force_thread_always_alive ();
@@ -550,18 +562,30 @@ namespace cubthread
   void
   worker_pool_impl<Stats>::er_log_stats (void) const
   {
-    /*
-    if (!m_log)
+    if constexpr (Stats)
       {
-    return;
-      }
+	const std::size_t MAX_SIZE = 32;
+	cubperf::stat_value stats[MAX_SIZE];
+	std::stringstream ss;
 
-    const std::size_t MAX_SIZE = 32;
-    cubperf::stat_value stats[MAX_SIZE];
-    std::memset (stats, 0, sizeof (stats));
-    get_stats (stats);
-    wp_er_log_stats (m_name.c_str (), stats);
-    */
+	if (!m_log)
+	  {
+	    return;
+	  }
+
+	std::memset (stats, 0, sizeof (stats));
+	get_stats (stats);
+
+	ss << "Worker pool statistics: " << m_name << std::endl;
+
+	for (std::size_t index = 0; index < stats::get_count (); index++)
+	  {
+	    ss << "\t" << stats::get_name (index) << ": ";
+	    ss << stats[index] << std::endl;
+	  }
+
+	_er_log_debug (ARG_FILE_LINE, ss.str ().c_str ());
+      }
   }
 
   template <bool Stats>
@@ -1353,6 +1377,110 @@ namespace cubthread
 
 	// found task
 	return true;
+      }
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // statistics
+  //////////////////////////////////////////////////////////////////////////
+
+  template <bool Stats>
+  constexpr cubperf::stat_definition worker_pool_impl<Stats>::stats::make_def (id stat_id,
+      cubperf::stat_definition::type stat_type, const char *first_name, const char *second_name)
+  {
+    return cubperf::stat_definition (static_cast<cubperf::stat_id> (stat_id), stat_type, first_name, second_name);
+  }
+
+  template <bool Stats>
+  inline const cubperf::statset_definition worker_pool_impl<Stats>::stats::statdef =
+  {
+    make_def (id::start_thread, cubperf::stat_definition::COUNTER_AND_TIMER,
+	      "Counter_start_thread", "Timer_start_thread"),
+    make_def (id::create_context, cubperf::stat_definition::COUNTER_AND_TIMER,
+	      "Counter_create_context", "Timer_create_context"),
+    make_def (id::execute_task, cubperf::stat_definition::COUNTER_AND_TIMER,
+	      "Counter_execute_task", "Timer_execute_task"),
+    make_def (id::retire_task, cubperf::stat_definition::COUNTER_AND_TIMER,
+	      "Counter_retire_task", "Timer_retire_task"),
+    make_def (id::found_in_queue, cubperf::stat_definition::COUNTER_AND_TIMER,
+	      "Counter_found_task_in_queue", "Timer_found_task_in_queue"),
+    make_def (id::wakeup_with_task, cubperf::stat_definition::COUNTER_AND_TIMER,
+	      "Counter_wakeup_with_task", "Timer_wakeup_with_task"),
+    make_def (id::recycle_context, cubperf::stat_definition::COUNTER_AND_TIMER,
+	      "Counter_recycle_context", "Timer_recycle_context"),
+    make_def (id::retire_context, cubperf::stat_definition::COUNTER_AND_TIMER,
+	      "Counter_retire_context", "Timer_retire_context")
+  };
+
+  template <bool Stats>
+  cubperf::statset *
+  worker_pool_impl<Stats>::stats::create (void)
+  {
+    if constexpr (Stats)
+      {
+	return statdef.create_statset ();
+      }
+    else
+      {
+	return nullptr;
+      }
+  }
+
+  template <bool Stats>
+  void
+  worker_pool_impl<Stats>::stats::destroy (cubperf::statset *stats)
+  {
+    if constexpr (Stats)
+      {
+	delete stats;
+      }
+  }
+
+  template <bool Stats>
+  void
+  worker_pool_impl<Stats>::stats::time_and_increment (cubperf::statset &stats, cubperf::stat_id id)
+  {
+    if constexpr (Stats)
+      {
+	statdef.time_and_increment (stats, id);
+      }
+  }
+
+  template <bool Stats>
+  void
+  worker_pool_impl<Stats>::stats::accumulate (const cubperf::statset &what, cubperf::stat_value *where)
+  {
+    if constexpr (Stats)
+      {
+	statdef.add_stat_values_with_converted_timers<std::chrono::microseconds> (what, where);
+      }
+  }
+
+  template <bool Stats>
+  std::size_t
+  worker_pool_impl<Stats>::stats::get_count (void)
+  {
+    if constexpr (Stats)
+      {
+	return statdef.get_value_count ();
+      }
+    else
+      {
+	return 0;
+      }
+  }
+
+  template <bool Stats>
+  const char *
+  worker_pool_impl<Stats>::stats::get_name (std::size_t stat_index)
+  {
+    if constexpr (Stats)
+      {
+	return statdef.get_value_name (stat_index);
+      }
+    else
+      {
+	return nullptr;
       }
   }
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26693>

아직 빌드가 되지 않습니다.

### Purpose

template Stats가 true인 경우에만 stats 관련 구조체를 포함하고, stats 관련 코드를 수행합니다.
Worker impl 각각이 stats 구조체를 가지며, Worker impl들 > Core impl들 > Worker pool 구조로 stats을 모아 하나로 합칩니다.

기존 stats의 경우 task가 queue에 들어가는 경우 시간 정보가 소실되었습니다. 또, 여러 종류의 stats을 측정하며 하나의 time만 사용하여 시간 측정 코드의 혼잡도가 높고, 실행 순서에 따라 시간 정보가 꼬이게 됩니다.
따라서 기존에 존재하는 count stats 코드에 대해서만 일관성을 맞추고, 시간 정보의 경우 실제로 어떤 정보가 사용될 지 모르므로 추후 Monitor 이슈에서 처리합니다.

### Implementation

1. wrapped_task
Stats가 true인 경우 stats을 포함합니다. Core -> Worker 수준에서 사용되며 task_type의 specialization wrapper입니다.

2. stats_base
Stats가 true인 경우 stats을 포함합니다.

3. stats
Stats가 true인 경우에만 stats 관련 코드를 수행합니다. Stats가 false인 경우에도 인터페이스 일관성을 맞춰, 외부에서 신경쓰지 않도록 하였습니다.

### Remarks

#7028 이 섞여 보이고 있습니다. #7028 병합 이후 이 PR의 변경점만 표시됩니다
 현재는 제대로 표시되고 있습니다.