### PR TITLE
[CBRD-26610] broker_log_top 다중 브로커 SQL 로그 일괄 분석 및 운영 편의 개선

### DIFF
--- a/src/broker/broker_log_sql_list.c
+++ b/src/broker/broker_log_sql_list.c
@@ -132,6 +132,29 @@ error:
   return -1;
 }
 
+void
+sql_list_reset (void)
+{
+  int i, j;
+
+  if (sql_list == NULL)
+    {
+      return;
+    }
+
+  for (i = 0; i < num_sql_list; i++)
+    {
+      FREE_MEM (sql_list[i].sql);
+      for (j = 0; j < sql_list[i].num_file; j++)
+	{
+	  FREE_MEM (sql_list[i].filename[j]);
+	}
+      FREE_MEM (sql_list[i].filename);
+    }
+  FREE_MEM (sql_list);
+  num_sql_list = 0;
+}
+
 int
 sql_info_write (char *src_sql, char *q_name, FILE * fp)
 {

--- a/src/broker/broker_log_sql_list.h
+++ b/src/broker/broker_log_sql_list.h
@@ -26,6 +26,8 @@
 
 #ident "$Id$"
 
+#include <stdio.h>
+
 typedef struct t_sql_info T_SQL_INFO;
 struct t_sql_info
 {
@@ -35,6 +37,7 @@ struct t_sql_info
 };
 
 extern int sql_list_make (char *list_file);
+extern void sql_list_reset (void);
 extern int sql_info_write (char *sql_org, char *q_name, FILE * fp);
 
 #endif /* _BROKER_LOG_SQL_LIST_H_ */

--- a/src/broker/broker_log_top.c
+++ b/src/broker/broker_log_top.c
@@ -276,7 +276,6 @@ get_file_list (char *list[], int size, int argc, char *argv[], int arg_start)
 
       do
 	{
-	  /* skip directory */
 	  if (index < size && !(find_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY))
 	    {
 	      assert (list[index] != NULL);
@@ -384,7 +383,6 @@ log_top_free_heap_files (char **tab, int n)
     }
 }
 
-/* Restore working directory after chdir into a broker output subdirectory. */
 static int
 log_top_restore_cwd (const char *saved_cwd)
 {
@@ -401,10 +399,6 @@ log_top_restore_cwd (const char *saved_cwd)
   return 0;
 }
 
-/*
- * log_top_multi_run 내 dirs[] 배열 해제 — 4곳에서 반복되던 패턴을 통합.
- * is_conf_multi 일 때는 전체 배열, 아니면 dirs[0]만 해제.
- */
 static void
 log_top_free_dirs (char **dirs, int ndirs, int is_conf_multi)
 {
@@ -544,34 +538,38 @@ log_top_is_pattern (const char *s)
   return strchr (s, '*') != NULL || strchr (s, '?') != NULL || strchr (s, '[') != NULL;
 }
 
-/* Returns 0 if basename is not a CAS sql/slow log filename; else suffix length (8, 9, 12, or 13). */
 static size_t
 log_top_cas_log_suffix_len (const char *basename)
 {
+  const char *p;
+  const char *best = NULL;
   size_t elen;
 
   if (basename == NULL)
     {
       return 0;
     }
+
   elen = strlen (basename);
-  if (elen >= 13 && strcmp (basename + elen - 13, ".slow.log.bak") == 0)
+
+  p = strstr (basename, ".sql.log");
+  if (p != NULL && (best == NULL || p < best))
     {
-      return 13;
+      best = p;
     }
-  if (elen >= 12 && strcmp (basename + elen - 12, ".sql.log.bak") == 0)
+
+  p = strstr (basename, ".slow.log");
+  if (p != NULL && (best == NULL || p < best))
     {
-      return 12;
+      best = p;
     }
-  if (elen >= 9 && strcmp (basename + elen - 9, ".slow.log") == 0)
+
+  if (best == NULL)
     {
-      return 9;
+      return 0;
     }
-  if (elen >= 8 && strcmp (basename + elen - 8, ".sql.log") == 0)
-    {
-      return 8;
-    }
-  return 0;
+
+  return elen - (size_t) (best - basename);
 }
 
 #if !defined(WINDOWS)
@@ -614,8 +612,7 @@ log_top_gather_files_exact (const char *broker, const char *dir, char *out_files
 }
 
 static int
-log_top_gather_files_pattern_suffix (const char *pattern, const char *dir, const char *suffix, size_t suffix_len,
-				     char *out_files[], int max_files)
+log_top_gather_files_pattern_all (const char *pattern, const char *dir, char *out_files[], int max_files)
 {
   DIR *d;
   struct dirent *e;
@@ -623,7 +620,7 @@ log_top_gather_files_pattern_suffix (const char *pattern, const char *dir, const
   char broker_prefix[256];
   char *last_underscore;
   int n = 0;
-  size_t elen;
+  size_t elen, suffix_len, copy_len;
 
   d = opendir (dir);
   if (!d)
@@ -632,23 +629,24 @@ log_top_gather_files_pattern_suffix (const char *pattern, const char *dir, const
   while ((e = readdir (d)) != NULL && n < max_files)
     {
       elen = strlen (e->d_name);
-      if (elen <= suffix_len)
+      suffix_len = log_top_cas_log_suffix_len (e->d_name);
+      if (suffix_len == 0)
 	continue;
-      if (strcmp (e->d_name + elen - suffix_len, suffix) != 0)
-	continue;
-      {
-	size_t copy_len = elen - suffix_len;
-	if (copy_len >= sizeof (broker_prefix))
-	  copy_len = sizeof (broker_prefix) - 1;
-	memcpy (broker_prefix, e->d_name, copy_len);
-	broker_prefix[copy_len] = '\0';
-      }
+
+      copy_len = elen - suffix_len;
+      if (copy_len >= sizeof (broker_prefix))
+	copy_len = sizeof (broker_prefix) - 1;
+      memcpy (broker_prefix, e->d_name, copy_len);
+      broker_prefix[copy_len] = '\0';
+
       last_underscore = strrchr (broker_prefix, '_');
       if (!last_underscore)
 	continue;
       *last_underscore = '\0';
+
       if (!log_top_match_pattern (broker_prefix, pattern))
 	continue;
+
       snprintf (path, sizeof (path), "%s/%s", dir, e->d_name);
       out_files[n] = (char *) MALLOC (strlen (path) + 1);
       if (out_files[n] == NULL)
@@ -664,42 +662,6 @@ log_top_gather_files_pattern_suffix (const char *pattern, const char *dir, const
   closedir (d);
   return n;
 }
-
-static int
-log_top_gather_files_pattern_all (const char *pattern, const char *dir, char *out_files[], int max_files)
-{
-  int n = 0;
-  int r;
-
-  r = log_top_gather_files_pattern_suffix (pattern, dir, ".sql.log", 8, out_files, max_files);
-  if (r < 0)
-    {
-      return -1;
-    }
-  n = r;
-  r = log_top_gather_files_pattern_suffix (pattern, dir, ".sql.log.bak", 12, out_files + n, max_files - n);
-  if (r < 0)
-    {
-      log_top_free_heap_files (out_files, n);
-      return -1;
-    }
-  n += r;
-  r = log_top_gather_files_pattern_suffix (pattern, dir, ".slow.log", 9, out_files + n, max_files - n);
-  if (r < 0)
-    {
-      log_top_free_heap_files (out_files, n);
-      return -1;
-    }
-  n += r;
-  r = log_top_gather_files_pattern_suffix (pattern, dir, ".slow.log.bak", 13, out_files + n, max_files - n);
-  if (r < 0)
-    {
-      log_top_free_heap_files (out_files, n);
-      return -1;
-    }
-  n += r;
-  return n;
-}
 #else
 static int
 log_top_gather_files_exact (const char *broker, const char *dir, char *out_files[], int max_files)
@@ -709,7 +671,7 @@ log_top_gather_files_exact (const char *broker, const char *dir, char *out_files
   char pattern[BROKER_LOG_TOP_MAX_PATH];
   char path[BROKER_LOG_TOP_MAX_PATH];
   int n = 0;
-  const char *suffixes[] = { "*.sql.log", "*.sql.log.bak", "*.slow.log", "*.slow.log.bak", NULL };
+  const char *suffixes[] = { "*.sql.log*", "*.slow.log*", NULL };
 
   for (int i = 0; suffixes[i] && n < max_files; i++)
     {
@@ -747,7 +709,7 @@ log_top_gather_files_pattern_all (const char *pattern, const char *dir, char *ou
   char path[BROKER_LOG_TOP_MAX_PATH];
   int n = 0;
   int si;
-  const char *suffixes[] = { "*.sql.log", "*.sql.log.bak", "*.slow.log", "*.slow.log.bak", NULL };
+  const char *suffixes[] = { "*.sql.log*", "*.slow.log*", NULL };
 
   for (si = 0; suffixes[si] && n < max_files; si++)
     {
@@ -789,7 +751,7 @@ log_top_get_brokers_from_dir (const char *dir, char *out_brokers[], int max_brok
   int nseen = 0;
   int n = 0;
   int i;
-  const char *patterns[] = { "*_*.sql.log", "*_*.sql.log.bak", "*_*.slow.log", "*_*.slow.log.bak", NULL };
+  const char *patterns[] = { "*_*.sql.log*", "*_*.slow.log*", NULL };
 
   for (i = 0; patterns[i] && n < max_brokers; i++)
     {
@@ -944,11 +906,6 @@ log_top_fill_parent_out_base (char *parent_out_base, size_t parent_sz)
   return 0;
 }
 
-/*
- * Unix: log_top_tran / log_top_query를 자식 프로세스에서 실행해 SIGSEGV 등으로 힙이 손상된 채
- * 복귀하는 것을 피한다. 반환값: 0 = 정상 완료, 1 = 자식이 시그널로 종료(건너뜀).
- * Windows: 동일 프로세스에서 직접 호출.
- */
 static int
 log_top_fork_tran_query (int argc, char **argv, int arg_start, volatile int *qerr)
 {
@@ -1117,7 +1074,6 @@ log_top_multi_run_one_broker (const char *parent_out_base, const char *subdir_fo
     }
 }
 
-/* log_top_multi_run / log_top_query_split_paths 종료 시 MT 억제 플래그 복원 */
 static int
 log_top_finish_force_single_thread (int val)
 {
@@ -1140,14 +1096,13 @@ log_top_multi_run (void)
   int error = 0;
   struct stat st;
 
-  saved_cwd = getcwd (cwd_buf, sizeof (cwd_buf));
+  saved_cwd = (volatile char *) getcwd (cwd_buf, sizeof (cwd_buf));
   if (saved_cwd == NULL)
     {
       fprintf (stderr, "Error: cannot get current directory\n");
       return -1;
     }
 
-  /* 배치 모드는 안정성이 우선: MT_MODE 사용 시에도 단일 스레드로 실행 */
   broker_log_top_force_single_thread = 1;
 
   if (strcmp (log_top_multi_log_dir, ".") == 0 && log_top_multi_broker_name != NULL)
@@ -1633,6 +1588,7 @@ log_top_query (int argc, char *argv[], int arg_start)
 	      return error;
 	    }
 	}
+	}
 #else
       error = log_top (fp, filename, start_offset, end_offset);
       fclose (fp);
@@ -1684,10 +1640,6 @@ log_top_basename_is_cas_sql_slow_log (const char *basename)
   return log_top_cas_log_suffix_len (basename) != 0;
 }
 
-/*
- * log_top_path_to_basename — 경로에서 basename 부분의 포인터를 반환.
- * '/'(및 Windows '\\'）이후 부분. 구분자가 없으면 path 자체.
- */
 static const char *
 log_top_path_to_basename (const char *path)
 {
@@ -1822,7 +1774,6 @@ log_top_query_split_paths (int nfiles, char **paths)
       return -1;
     }
 
-  /* 배치 split 경로와 동일하게 MT_MODE에서도 단일 스레드로 실행 */
   broker_log_top_force_single_thread = 1;
 
   g_start = 0;
@@ -1917,7 +1868,7 @@ thr_main (void *arg)
 	}
       else
 	{
-	  log_top (work_msg[self_index].fp, work_msg[self_index].filename);
+	  log_top (work_msg[self_index].fp, work_msg[self_index].filename, -1, -1);
 	  fclose (work_msg[self_index].fp);
 	  work_msg[self_index].fp = NULL;
 	  work_msg[self_index].filename = NULL;
@@ -2207,18 +2158,16 @@ get_args (int argc, char *argv[])
 {
   int c;
   int option_index = 0;
-  int from_conf_mode = 0;
 
   log_top_multi_explicit_dirs_flag = 0;
   log_top_out_merge = 1;
 
   static struct option long_options[] = {
-    {"all-broker-log", optional_argument, 0, 'l'},
     {"from-conf", no_argument, 0, 'C'},
     {0, 0, 0, 0}
   };
 
-  while ((c = getopt_long (argc, argv, "tq:h:F:T:O:Cl::", long_options, &option_index)) != EOF)
+  while ((c = getopt_long (argc, argv, "tq:h:F:T:O:C", long_options, &option_index)) != EOF)
     {
       switch (c)
 	{
@@ -2243,31 +2192,7 @@ get_args (int argc, char *argv[])
 	      goto date_format_err;
 	    }
 	  break;
-	case 'l':
-	  if (from_conf_mode)
-	    {
-	      goto getargs_err;
-	    }
-	  if (optarg && optarg[0])
-	    {
-	      log_top_multi_log_dir = optarg;
-	    }
-	  else if (optind < argc && strchr (argv[optind], '/') != NULL)
-	    {
-	      log_top_multi_log_dir = argv[optind];
-	      optind++;
-	    }
-	  else
-	    {
-	      log_top_multi_log_dir = "LOG_DIR";
-	    }
-	  break;
 	case 'C':
-	  if (log_top_multi_log_dir != NULL)
-	    {
-	      goto getargs_err;
-	    }
-	  from_conf_mode = 1;
 	  log_top_multi_log_dir = "LOG_DIR";
 	  break;
 	case 'O':
@@ -2292,7 +2217,6 @@ get_args (int argc, char *argv[])
       log_top_mode = MODE_MAX_HANDLE;
     }
 
-  /* -O split + only directory path(s): same batch layout as --from-conf / --all-broker-log */
   if (!log_top_out_merge && log_top_multi_log_dir == NULL && optind < argc)
     {
       struct stat st;
@@ -2350,7 +2274,7 @@ get_args (int argc, char *argv[])
 	}
     }
 
-  if (from_conf_mode && optind < argc)
+  if (log_top_multi_log_dir != NULL && optind < argc)
     {
       goto getargs_err;
     }
@@ -2370,7 +2294,8 @@ get_args (int argc, char *argv[])
 getargs_err:
   fprintf (stderr,
 	   "%s [-t] [-F <from date>] [-T <to date>] [-O <merge | split>] <log_file> ...\n"
-	   "or\n" "%s [-t] [-F <from date>] [-T <to date>] <--from-conf>\n", argv[0], argv[0]);
+	   "or\n"
+	   "%s [-t] [-F <from date>] [-T <to date>] --from-conf\n", argv[0], argv[0]);
   return -1;
 date_format_err:
   fprintf (stderr, "invalid date. valid date format is yy-mm-dd hh:mm:ss.\n");

--- a/src/broker/broker_log_top.c
+++ b/src/broker/broker_log_top.c
@@ -615,7 +615,7 @@ log_top_gather_files_exact (const char *broker, const char *dir, char *out_files
 
 static int
 log_top_gather_files_pattern_suffix (const char *pattern, const char *dir, const char *suffix, size_t suffix_len,
-				   char *out_files[], int max_files)
+				     char *out_files[], int max_files)
 {
   DIR *d;
   struct dirent *e;
@@ -789,8 +789,7 @@ log_top_get_brokers_from_dir (const char *dir, char *out_brokers[], int max_brok
   int nseen = 0;
   int n = 0;
   int i;
-  const char *patterns[] =
-    { "*_*.sql.log", "*_*.sql.log.bak", "*_*.slow.log", "*_*.slow.log.bak", NULL };
+  const char *patterns[] = { "*_*.sql.log", "*_*.sql.log.bak", "*_*.slow.log", "*_*.slow.log.bak", NULL };
 
   for (i = 0; patterns[i] && n < max_brokers; i++)
     {
@@ -914,8 +913,7 @@ log_top_mkdir_out (const char *path)
 static int
 log_top_multi_dir_is_conf_multi (void)
 {
-  return log_top_multi_explicit_dirs_flag != 0
-    || strcasecmp (log_top_multi_log_dir, "LOG_DIR") == 0;
+  return log_top_multi_explicit_dirs_flag != 0 || strcasecmp (log_top_multi_log_dir, "LOG_DIR") == 0;
 }
 
 static int
@@ -1167,8 +1165,7 @@ log_top_multi_run (void)
       dot_file_count = log_top_is_pattern (log_top_multi_broker_name)
 	? log_top_gather_files_pattern_all (log_top_multi_broker_name, cwd_buf, (char **) files,
 					    BROKER_LOG_TOP_MAX_FILES)
-	: log_top_gather_files_exact (log_top_multi_broker_name, cwd_buf, (char **) files,
-				      BROKER_LOG_TOP_MAX_FILES);
+	: log_top_gather_files_exact (log_top_multi_broker_name, cwd_buf, (char **) files, BROKER_LOG_TOP_MAX_FILES);
       if (dot_file_count < 0)
 	{
 	  fprintf (stderr, "Error: failed to gather log files for broker '%s'.\n", log_top_multi_broker_name);
@@ -1289,8 +1286,8 @@ log_top_multi_run (void)
 		  goto next_dir;
 		}
 	      log_top_multi_run_one_broker (parent_out_base, log_top_multi_broker_name, 1,
-					   log_top_multi_broker_name, (char **) files, nfiles, (char *) saved_cwd,
-					   &error);
+					    log_top_multi_broker_name, (char **) files, nfiles, (char *) saved_cwd,
+					    &error);
 	      nfiles = 0;
 	    }
 	  else
@@ -1306,12 +1303,13 @@ log_top_multi_run (void)
 		}
 	      if (nfiles == 0)
 		{
-		  fprintf (stderr, "Info: [%s] no files for broker '%s', skipping.\n", dirs[d], log_top_multi_broker_name);
+		  fprintf (stderr, "Info: [%s] no files for broker '%s', skipping.\n", dirs[d],
+			   log_top_multi_broker_name);
 		  goto next_dir;
 		}
 	      log_top_multi_run_one_broker (parent_out_base, log_top_multi_broker_name, 0,
-					   log_top_multi_broker_name, (char **) files, nfiles, (char *) saved_cwd,
-					   &error);
+					    log_top_multi_broker_name, (char **) files, nfiles, (char *) saved_cwd,
+					    &error);
 	      nfiles = 0;
 	    }
 	next_dir:
@@ -1444,8 +1442,7 @@ log_top_multi_run (void)
 	      if (dirs[dir_idx] == NULL)
 		continue;
 	      dir_files = log_top_gather_files_exact (all_brokers[i], dirs[dir_idx],
-							all_files + total_files,
-							BROKER_LOG_TOP_MAX_FILES - total_files);
+						      all_files + total_files, BROKER_LOG_TOP_MAX_FILES - total_files);
 	      if (dir_files < 0)
 		{
 		  fprintf (stderr, "Error: failed to gather log files for broker '%s' under [%s].\n",
@@ -1465,7 +1462,7 @@ log_top_multi_run (void)
 	    }
 
 	  log_top_multi_run_one_broker (parent_out_base, all_brokers[i], 0, all_brokers[i], all_files, num_files,
-				       (char *) saved_cwd, &error);
+					(char *) saved_cwd, &error);
 	  memset (all_files, 0, sizeof (char *) * BROKER_LOG_TOP_MAX_FILES);
 	  FREE_MEM (all_brokers[i]);
 	  all_brokers[i] = NULL;
@@ -2373,8 +2370,7 @@ get_args (int argc, char *argv[])
 getargs_err:
   fprintf (stderr,
 	   "%s [-t] [-F <from date>] [-T <to date>] [-O <merge | split>] <log_file> ...\n"
-	   "or\n"
-	   "%s [-t] [-F <from date>] [-T <to date>] <--from-conf>\n", argv[0], argv[0]);
+	   "or\n" "%s [-t] [-F <from date>] [-T <to date>] <--from-conf>\n", argv[0], argv[0]);
   return -1;
 date_format_err:
   fprintf (stderr, "invalid date. valid date format is yy-mm-dd hh:mm:ss.\n");

--- a/src/broker/broker_log_top.c
+++ b/src/broker/broker_log_top.c
@@ -1588,7 +1588,7 @@ log_top_query (int argc, char *argv[], int arg_start)
 	      return error;
 	    }
 	}
-	}
+    }
 #else
       error = log_top (fp, filename, start_offset, end_offset);
       fclose (fp);
@@ -2294,8 +2294,7 @@ get_args (int argc, char *argv[])
 getargs_err:
   fprintf (stderr,
 	   "%s [-t] [-F <from date>] [-T <to date>] [-O <merge | split>] <log_file> ...\n"
-	   "or\n"
-	   "%s [-t] [-F <from date>] [-T <to date>] --from-conf\n", argv[0], argv[0]);
+	   "or\n" "%s [-t] [-F <from date>] [-T <to date>] --from-conf\n", argv[0], argv[0]);
   return -1;
 date_format_err:
   fprintf (stderr, "invalid date. valid date format is yy-mm-dd hh:mm:ss.\n");

--- a/src/broker/broker_log_top.c
+++ b/src/broker/broker_log_top.c
@@ -28,13 +28,13 @@
 #include <string.h>
 #include <stdlib.h>
 #include <assert.h>
-#include <setjmp.h>
 #include <signal.h>
 #include <sys/stat.h>
 #include <time.h>
 #if !defined(WINDOWS)
 #include <unistd.h>
 #include <dirent.h>
+#include <sys/wait.h>
 #else
 #include <direct.h>
 #include <io.h>
@@ -58,6 +58,7 @@
 #include "log_top_string.h"
 #include "broker_log_top.h"
 #include "broker_log_util.h"
+#include "broker_config.h"
 
 #if defined (SUPPRESS_STRLEN_WARNING)
 #define strlen(s1)  ((int) strlen(s1))
@@ -78,7 +79,7 @@ struct t_work_msg
 
 static int log_top_query (int argc, char *argv[], int arg_start);
 static int log_top_query_split_paths (int nfiles, char **paths);
-static int log_top_sigjmp_tran_query (int argc, char **argv, int arg_start, volatile int *qerr);
+static int log_top_fork_tran_query (int argc, char **argv, int arg_start, volatile int *qerr);
 static int log_top (FILE * fp, char *filename, long start_offset, long end_offset);
 static int log_execute (T_QUERY_INFO * qi, char *linebuf, char **query_p);
 static int get_args (int argc, char *argv[]);
@@ -106,29 +107,13 @@ static const char *log_top_multi_broker_name = NULL;
 
 static int broker_log_top_force_single_thread = 0;
 
-#if !defined(WINDOWS)
-/* Segmentation fault 복구: 예외 시 longjmp로 복귀하여 무시하고 진행 */
-static sigjmp_buf broker_log_top_segfault_jmp;
-static volatile int broker_log_top_segfault_jmp_valid;
-
-static void
-broker_log_top_segfault_handler (int sig)
-{
-  if (sig == SIGSEGV && broker_log_top_segfault_jmp_valid)
-    {
-      broker_log_top_segfault_jmp_valid = 0;
-      siglongjmp (broker_log_top_segfault_jmp, 1);
-    }
-  /* 재진입 방지 실패 시 기본 동작 */
-  signal (SIGSEGV, SIG_DFL);
-  raise (sig);
-}
-#endif
-
 static void log_top_free_heap_files (char **tab, int n);
+static int log_top_restore_cwd (const char *saved_cwd);
 static int log_top_discover_log_dirs (char *out_dirs[], int max_dirs);
 static void log_top_normalize_path (const char *in, char *out, size_t out_len);
 static size_t log_top_cas_log_suffix_len (const char *basename);
+static const char *log_top_path_to_basename (const char *path);
+static int log_top_broker_key_from_basename (const char *basename, char *out, size_t outlen);
 static int log_top_gather_files_exact (const char *broker, const char *dir, char *out_files[], int max_files);
 static int log_top_is_pattern (const char *s);
 static int log_top_get_brokers_from_dir (const char *dir, char *out_brokers[], int max_brokers);
@@ -203,7 +188,7 @@ main (int argc, char *argv[])
   else
     {
       volatile int mqerr = 0;
-      if (log_top_sigjmp_tran_query (get_cnt, file_list, 0, &mqerr) == 0)
+      if (log_top_fork_tran_query (get_cnt, file_list, 0, &mqerr) == 0)
 	error = (int) mqerr;
       else
 	error = 0;
@@ -216,7 +201,7 @@ main (int argc, char *argv[])
   else
     {
       volatile int mqerr = 0;
-      if (log_top_sigjmp_tran_query (argc, argv, arg_start, &mqerr) == 0)
+      if (log_top_fork_tran_query (argc, argv, arg_start, &mqerr) == 0)
 	error = (int) mqerr;
       else
 	error = 0;
@@ -399,6 +384,23 @@ log_top_free_heap_files (char **tab, int n)
     }
 }
 
+/* Restore working directory after chdir into a broker output subdirectory. */
+static int
+log_top_restore_cwd (const char *saved_cwd)
+{
+  if (saved_cwd == NULL)
+    {
+      fprintf (stderr, "Error: cannot restore working directory (invalid path).\n");
+      return -1;
+    }
+  if (LOG_TOP_CHDIR ((char *) saved_cwd) < 0)
+    {
+      fprintf (stderr, "Error: cannot restore working directory to %s: %s\n", saved_cwd, strerror (errno));
+      return -1;
+    }
+  return 0;
+}
+
 /*
  * log_top_multi_run 내 dirs[] 배열 해제 — 4곳에서 반복되던 패턴을 통합.
  * is_conf_multi 일 때는 전체 배열, 아니면 dirs[0]만 해제.
@@ -470,89 +472,69 @@ log_top_normalize_path (const char *in, char *out, size_t out_len)
 static int
 log_top_discover_log_dirs (char *out_dirs[], int max_dirs)
 {
-  FILE *fp;
-  char conf_path[BROKER_LOG_TOP_MAX_PATH];
-  char line[BROKER_LOG_TOP_MAX_PATH + 64];
-  const char *env_conf;
-  const char *cubrid;
+  T_BROKER_INFO br_info[MAX_BROKER_NUM];
+  int num_broker = 0;
+  int master_shm_id = 0;
   int count = 0;
+  int i, k;
   char norm[BROKER_LOG_TOP_MAX_PATH];
-  int i;
+  const char *env_conf;
+  const char *conf_file = NULL;
+
+  memset (br_info, 0, sizeof (br_info));
 
   env_conf = getenv ("CUBRID_BROKER_CONF_FILE");
   if (env_conf && env_conf[0])
-    snprintf (conf_path, sizeof (conf_path), "%s", env_conf);
-  else
     {
-      cubrid = getenv ("CUBRID");
-      if (!cubrid || !cubrid[0])
-	{
-	  fprintf (stderr, "Error: CUBRID environment variable not set.\n");
-	  return -1;
-	}
-      snprintf (conf_path, sizeof (conf_path), "%s/conf/cubrid_broker.conf", cubrid);
+      conf_file = env_conf;
     }
 
-  fp = fopen (conf_path, "r");
-  if (!fp)
+  if (broker_config_read (conf_file, br_info, &num_broker, &master_shm_id, NULL, 0, NULL, NULL, NULL, NULL) < 0)
     {
-      fprintf (stderr, "Error: cannot open broker config: %s\n", conf_path);
+      fprintf (stderr, "Error: failed to read broker configuration via broker_config_read().\n");
       return -1;
     }
 
-  while (fgets (line, sizeof (line), fp) && count < max_dirs)
+  for (k = 0; k < num_broker && count < max_dirs; k++)
     {
-      char *val, *p;
-      for (p = line; *p && (*p == ' ' || *p == '\t'); p++)
-	;
-      if (strncasecmp (p, "SLOW_LOG_DIR", 12) == 0 && (p[12] == '=' || p[12] == ' ' || p[12] == '\t'))
+      const char *dirs_to_add[2] = { br_info[k].log_dir, br_info[k].slow_log_dir };
+      int di;
+
+      for (di = 0; di < 2 && count < max_dirs; di++)
 	{
-	  p += 12;
-	}
-      else if (strncasecmp (p, "LOG_DIR", 7) == 0 && (p[7] == '=' || p[7] == ' ' || p[7] == '\t'))
-	{
-	  p += 7;
-	}
-      else
-	{
-	  continue;
-	}
-      while (*p == ' ' || *p == '\t')
-	p++;
-      if (*p != '=')
-	continue;
-      p++;
-      while (*p == ' ' || *p == '\t')
-	p++;
-      val = p;
-      while (*val && *val != '#' && *val != '\n' && *val != '\r')
-	val++;
-      while (val > p && (val[-1] == ' ' || val[-1] == '\t' || val[-1] == '\n' || val[-1] == '\r'))
-	val--;
-      *val = '\0';
-      if (p[0] == '\0')
-	continue;
-      log_top_normalize_path (p, norm, sizeof (norm));
-      if (norm[0] == '\0')
-	continue;
-      for (i = 0; i < count; i++)
-	{
-	  if (strcmp (out_dirs[i], norm) == 0)
+	  const char *p = dirs_to_add[di];
+	  if (p == NULL || p[0] == '\0')
+	    continue;
+
+	  log_top_normalize_path (p, norm, sizeof (norm));
+	  if (norm[0] == '\0')
+	    continue;
+
+	  for (i = 0; i < count; i++)
 	    {
-	      break;
+	      if (strcmp (out_dirs[i], norm) == 0)
+		{
+		  break;
+		}
 	    }
+	  if (i < count)
+	    continue;
+
+	  out_dirs[count] = (char *) MALLOC (strlen (norm) + 1);
+	  if (out_dirs[count] == NULL)
+	    {
+	      fprintf (stderr, "Error: out of memory while collecting broker log directories.\n");
+	      for (i = 0; i < count; i++)
+		{
+		  FREE_MEM (out_dirs[i]);
+		}
+	      return -1;
+	    }
+	  strcpy (out_dirs[count], norm);
+	  count++;
 	}
-      if (i < count)
-	continue;
-      out_dirs[count] = (char *) MALLOC (strlen (norm) + 1);
-      if (out_dirs[count] == NULL)
-	{
-	  continue;
-	}
-      strcpy (out_dirs[count], norm);
-      count++;
     }
-  fclose (fp);
+
   return count;
 }
 
@@ -617,11 +599,15 @@ log_top_gather_files_exact (const char *broker, const char *dir, char *out_files
 	continue;
       snprintf (path, sizeof (path), "%s/%s", dir, e->d_name);
       out_files[n] = (char *) MALLOC (strlen (path) + 1);
-      if (out_files[n])
+      if (out_files[n] == NULL)
 	{
-	  strcpy (out_files[n], path);
-	  n++;
+	  fprintf (stderr, "Error: out of memory while collecting log file path under %s.\n", dir);
+	  log_top_free_heap_files (out_files, n);
+	  closedir (d);
+	  return -1;
 	}
+      strcpy (out_files[n], path);
+      n++;
     }
   closedir (d);
   return n;
@@ -629,7 +615,7 @@ log_top_gather_files_exact (const char *broker, const char *dir, char *out_files
 
 static int
 log_top_gather_files_pattern_suffix (const char *pattern, const char *dir, const char *suffix, size_t suffix_len,
-				     char *out_files[], int max_files)
+				   char *out_files[], int max_files)
 {
   DIR *d;
   struct dirent *e;
@@ -665,11 +651,15 @@ log_top_gather_files_pattern_suffix (const char *pattern, const char *dir, const
 	continue;
       snprintf (path, sizeof (path), "%s/%s", dir, e->d_name);
       out_files[n] = (char *) MALLOC (strlen (path) + 1);
-      if (out_files[n])
+      if (out_files[n] == NULL)
 	{
-	  strcpy (out_files[n], path);
-	  n++;
+	  fprintf (stderr, "Error: out of memory while collecting log file path under %s.\n", dir);
+	  log_top_free_heap_files (out_files, n);
+	  closedir (d);
+	  return -1;
 	}
+      strcpy (out_files[n], path);
+      n++;
     }
   closedir (d);
   return n;
@@ -679,10 +669,35 @@ static int
 log_top_gather_files_pattern_all (const char *pattern, const char *dir, char *out_files[], int max_files)
 {
   int n = 0;
-  n += log_top_gather_files_pattern_suffix (pattern, dir, ".sql.log", 8, out_files, max_files);
-  n += log_top_gather_files_pattern_suffix (pattern, dir, ".sql.log.bak", 12, out_files + n, max_files - n);
-  n += log_top_gather_files_pattern_suffix (pattern, dir, ".slow.log", 9, out_files + n, max_files - n);
-  n += log_top_gather_files_pattern_suffix (pattern, dir, ".slow.log.bak", 13, out_files + n, max_files - n);
+  int r;
+
+  r = log_top_gather_files_pattern_suffix (pattern, dir, ".sql.log", 8, out_files, max_files);
+  if (r < 0)
+    {
+      return -1;
+    }
+  n = r;
+  r = log_top_gather_files_pattern_suffix (pattern, dir, ".sql.log.bak", 12, out_files + n, max_files - n);
+  if (r < 0)
+    {
+      log_top_free_heap_files (out_files, n);
+      return -1;
+    }
+  n += r;
+  r = log_top_gather_files_pattern_suffix (pattern, dir, ".slow.log", 9, out_files + n, max_files - n);
+  if (r < 0)
+    {
+      log_top_free_heap_files (out_files, n);
+      return -1;
+    }
+  n += r;
+  r = log_top_gather_files_pattern_suffix (pattern, dir, ".slow.log.bak", 13, out_files + n, max_files - n);
+  if (r < 0)
+    {
+      log_top_free_heap_files (out_files, n);
+      return -1;
+    }
+  n += r;
   return n;
 }
 #else
@@ -708,11 +723,14 @@ log_top_gather_files_exact (const char *broker, const char *dir, char *out_files
 	    continue;
 	  snprintf (path, sizeof (path), "%s\\%s", dir, fd.cFileName);
 	  out_files[n] = (char *) MALLOC (strlen (path) + 1);
-	  if (out_files[n])
+	  if (out_files[n] == NULL)
 	    {
-	      strcpy (out_files[n], path);
-	      n++;
+	      fprintf (stderr, "Error: out of memory while collecting log file path under %s.\n", dir);
+	      FindClose (h);
+	      return -1;
 	    }
+	  strcpy (out_files[n], path);
+	  n++;
 	}
       while (FindNextFileA (h, &fd) && n < max_files);
       FindClose (h);
@@ -745,11 +763,14 @@ log_top_gather_files_pattern_all (const char *pattern, const char *dir, char *ou
 	    break;
 	  snprintf (path, sizeof (path), "%s\\%s", dir, fd.cFileName);
 	  out_files[n] = (char *) MALLOC (strlen (path) + 1);
-	  if (out_files[n])
+	  if (out_files[n] == NULL)
 	    {
-	      strcpy (out_files[n], path);
-	      n++;
+	      fprintf (stderr, "Error: out of memory while collecting log file path under %s.\n", dir);
+	      FindClose (h);
+	      return -1;
 	    }
+	  strcpy (out_files[n], path);
+	  n++;
 	}
       while (FindNextFileA (h, &fd));
       FindClose (h);
@@ -765,12 +786,11 @@ log_top_get_brokers_from_dir (const char *dir, char *out_brokers[], int max_brok
   char pattern[BROKER_LOG_TOP_MAX_PATH];
   char seen[256][256];
   char broker[256];
-  char *last_underscore;
-  size_t elen, suffix_len;
   int nseen = 0;
   int n = 0;
   int i;
-  const char *patterns[] = { "*_*.sql.log", "*_*.sql.log.bak", "*_*.slow.log", "*_*.slow.log.bak", NULL };
+  const char *patterns[] =
+    { "*_*.sql.log", "*_*.sql.log.bak", "*_*.slow.log", "*_*.slow.log.bak", NULL };
 
   for (i = 0; patterns[i] && n < max_brokers; i++)
     {
@@ -780,33 +800,16 @@ log_top_get_brokers_from_dir (const char *dir, char *out_brokers[], int max_brok
 	continue;
       do
 	{
+	  int j;
 	  if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
 	    continue;
-	  elen = strlen (fd.cFileName);
-	  suffix_len = log_top_cas_log_suffix_len (fd.cFileName);
-	  if (suffix_len == 0)
+	  if (log_top_broker_key_from_basename (fd.cFileName, broker, sizeof (broker)) != 0)
 	    continue;
-	  if (elen <= suffix_len)
+	  for (j = 0; j < nseen; j++)
+	    if (strcmp (seen[j], broker) == 0)
+	      break;
+	  if (j < nseen)
 	    continue;
-	  {
-	    size_t copy_len = elen - suffix_len;
-	    if (copy_len >= sizeof (broker))
-	      copy_len = sizeof (broker) - 1;
-	    memcpy (broker, fd.cFileName, copy_len);
-	    broker[copy_len] = '\0';
-	  }
-	  last_underscore = strrchr (broker, '_');
-	  if (!last_underscore || (size_t) (last_underscore - broker) >= sizeof (broker) - 1)
-	    continue;
-	  *last_underscore = '\0';
-	  {
-	    int j;
-	    for (j = 0; j < nseen; j++)
-	      if (strcmp (seen[j], broker) == 0)
-		break;
-	    if (j < nseen)
-	      continue;
-	  }
 	  if (nseen < 256)
 	    {
 	      snprintf (seen[nseen], sizeof (seen[0]), "%.255s", broker);
@@ -815,11 +818,14 @@ log_top_get_brokers_from_dir (const char *dir, char *out_brokers[], int max_brok
 	  if (n >= max_brokers)
 	    continue;
 	  out_brokers[n] = (char *) MALLOC (strlen (broker) + 1);
-	  if (out_brokers[n])
+	  if (out_brokers[n] == NULL)
 	    {
-	      strcpy (out_brokers[n], broker);
-	      n++;
+	      fprintf (stderr, "Error: out of memory while collecting broker names under %s.\n", dir);
+	      FindClose (h);
+	      return -1;
 	    }
+	  strcpy (out_brokers[n], broker);
+	  n++;
 	}
       while (FindNextFileA (h, &fd));
       FindClose (h);
@@ -839,8 +845,6 @@ log_top_get_brokers_from_dir (const char *dir, char *out_brokers[], int max_brok
   int n = 0;
   int i;
   char broker[256];
-  char *last_underscore;
-  size_t suffix_len;
 
   d = opendir (dir);
   if (!d)
@@ -848,23 +852,8 @@ log_top_get_brokers_from_dir (const char *dir, char *out_brokers[], int max_brok
 
   while ((e = readdir (d)) != NULL && n < max_brokers)
     {
-      size_t elen = strlen (e->d_name);
-      if (elen < 4)
+      if (log_top_broker_key_from_basename (e->d_name, broker, sizeof (broker)) != 0)
 	continue;
-      suffix_len = log_top_cas_log_suffix_len (e->d_name);
-      if (suffix_len == 0)
-	continue;
-      {
-	size_t copy_len = elen - suffix_len;
-	if (copy_len >= sizeof (broker))
-	  copy_len = sizeof (broker) - 1;
-	memcpy (broker, e->d_name, copy_len);
-	broker[copy_len] = '\0';
-      }
-      last_underscore = strrchr (broker, '_');
-      if (!last_underscore || (size_t) (last_underscore - broker) >= sizeof (broker) - 1)
-	continue;
-      *last_underscore = '\0';
       for (i = 0; i < nseen; i++)
 	if (strcmp (seen[i], broker) == 0)
 	  break;
@@ -878,11 +867,14 @@ log_top_get_brokers_from_dir (const char *dir, char *out_brokers[], int max_brok
       if (n >= max_brokers)
 	continue;
       out_brokers[n] = (char *) MALLOC (strlen (broker) + 1);
-      if (out_brokers[n])
+      if (out_brokers[n] == NULL)
 	{
-	  strcpy (out_brokers[n], broker);
-	  n++;
+	  fprintf (stderr, "Error: out of memory while collecting broker names under %s.\n", dir);
+	  closedir (d);
+	  return -1;
 	}
+      strcpy (out_brokers[n], broker);
+      n++;
     }
   closedir (d);
   return n;
@@ -922,7 +914,8 @@ log_top_mkdir_out (const char *path)
 static int
 log_top_multi_dir_is_conf_multi (void)
 {
-  return log_top_multi_explicit_dirs_flag != 0 || strcasecmp (log_top_multi_log_dir, "LOG_DIR") == 0;
+  return log_top_multi_explicit_dirs_flag != 0
+    || strcasecmp (log_top_multi_log_dir, "LOG_DIR") == 0;
 }
 
 static int
@@ -954,36 +947,116 @@ log_top_fill_parent_out_base (char *parent_out_base, size_t parent_sz)
 }
 
 /*
- * sigsetjmp로 감싼 log_top_tran / log_top_query 통합 래퍼.
- * 기존 _inner(nfiles, files)는 arg_start=0으로, _argv(argc, argv, arg_start)는 그대로 호출.
- * 반환값: 0 = 정상 완료, 1 = SIGSEGV로 건너뜀.
+ * Unix: log_top_tran / log_top_query를 자식 프로세스에서 실행해 SIGSEGV 등으로 힙이 손상된 채
+ * 복귀하는 것을 피한다. 반환값: 0 = 정상 완료, 1 = 자식이 시그널로 종료(건너뜀).
+ * Windows: 동일 프로세스에서 직접 호출.
  */
 static int
-log_top_sigjmp_tran_query (int argc, char **argv, int arg_start, volatile int *qerr)
+log_top_fork_tran_query (int argc, char **argv, int arg_start, volatile int *qerr)
 {
 #if !defined(WINDOWS)
-  if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
+  int pipefd[2];
+  pid_t pid;
+  int status;
+  ssize_t rw;
+  int err_buf;
+
+  if (pipe (pipefd) < 0)
     {
-      broker_log_top_segfault_jmp_valid = 1;
-      signal (SIGSEGV, broker_log_top_segfault_handler);
-      if (mode_tran)
-	*qerr = log_top_tran (argc, argv, arg_start);
-      else
-	*qerr = log_top_query (argc, argv, arg_start);
-      broker_log_top_segfault_jmp_valid = 0;
-      signal (SIGSEGV, SIG_DFL);
+      fprintf (stderr, "Error: pipe failed: %s\n", strerror (errno));
+      *qerr = -1;
       return 0;
     }
-  broker_log_top_segfault_jmp_valid = 0;
-  signal (SIGSEGV, SIG_DFL);
-  fprintf (stderr, "Warning: segmentation fault during processing, skipping.\n");
-  *qerr = 0;
-  return 1;
+
+  pid = fork ();
+  if (pid < 0)
+    {
+      fprintf (stderr, "Error: fork failed: %s\n", strerror (errno));
+      close (pipefd[0]);
+      close (pipefd[1]);
+      *qerr = -1;
+      return 0;
+    }
+
+  if (pid == 0)
+    {
+      int err_run;
+
+      close (pipefd[0]);
+      if (mode_tran)
+	{
+	  err_run = log_top_tran (argc, argv, arg_start);
+	}
+      else
+	{
+	  err_run = log_top_query (argc, argv, arg_start);
+	}
+      rw = write (pipefd[1], &err_run, sizeof (err_run));
+      if (rw != (ssize_t) sizeof (err_run))
+	{
+	  close (pipefd[1]);
+	  _exit (124);
+	}
+      close (pipefd[1]);
+      _exit (0);
+    }
+
+  close (pipefd[1]);
+  if (waitpid (pid, &status, 0) < 0)
+    {
+      fprintf (stderr, "Error: waitpid failed: %s\n", strerror (errno));
+      close (pipefd[0]);
+      *qerr = -1;
+      return 0;
+    }
+
+  if (WIFSIGNALED (status))
+    {
+      if (WTERMSIG (status) == SIGSEGV)
+	{
+	  fprintf (stderr, "Warning: segmentation fault during processing, skipping.\n");
+	}
+      else
+	{
+	  fprintf (stderr, "Warning: child terminated by signal %d.\n", WTERMSIG (status));
+	}
+      close (pipefd[0]);
+      *qerr = 0;
+      return 1;
+    }
+
+  if (!WIFEXITED (status))
+    {
+      close (pipefd[0]);
+      *qerr = -1;
+      return 0;
+    }
+
+  if (WEXITSTATUS (status) != 0)
+    {
+      close (pipefd[0]);
+      *qerr = -1;
+      return 0;
+    }
+
+  rw = read (pipefd[0], &err_buf, sizeof (err_buf));
+  close (pipefd[0]);
+  if (rw != (ssize_t) sizeof (err_buf))
+    {
+      *qerr = -1;
+      return 0;
+    }
+  *qerr = err_buf;
+  return 0;
 #else
   if (mode_tran)
-    *qerr = log_top_tran (argc, argv, arg_start);
+    {
+      *qerr = log_top_tran (argc, argv, arg_start);
+    }
   else
-    *qerr = log_top_query (argc, argv, arg_start);
+    {
+      *qerr = log_top_query (argc, argv, arg_start);
+    }
   return 0;
 #endif
 }
@@ -1021,19 +1094,37 @@ log_top_multi_run_one_broker (const char *parent_out_base, const char *subdir_fo
     }
   fprintf (stdout, "%s\n", stdout_label);
   query_info_reset ();
-  if (log_top_sigjmp_tran_query (nfiles, files, 0, &qerr) == 0)
+  if (log_top_fork_tran_query (nfiles, files, 0, &qerr) == 0)
     {
-      LOG_TOP_CHDIR ((char *) saved_cwd);
+      if (log_top_restore_cwd (saved_cwd) < 0)
+	{
+	  *error_io = -1;
+	}
+      else if (qerr != 0)
+	{
+	  *error_io = qerr;
+	}
       for (i = 0; i < nfiles; i++)
-	FREE_MEM (files[i]);
-      if (qerr != 0)
-	*error_io = qerr;
+	{
+	  FREE_MEM (files[i]);
+	}
     }
   else
     {
-      LOG_TOP_CHDIR ((char *) saved_cwd);
+      if (log_top_restore_cwd (saved_cwd) < 0)
+	{
+	  *error_io = -1;
+	}
       log_top_free_heap_files (files, nfiles);
     }
+}
+
+/* log_top_multi_run / log_top_query_split_paths 종료 시 MT 억제 플래그 복원 */
+static int
+log_top_finish_force_single_thread (int val)
+{
+  broker_log_top_force_single_thread = 0;
+  return val;
 }
 
 static int
@@ -1063,52 +1154,69 @@ log_top_multi_run (void)
 
   if (strcmp (log_top_multi_log_dir, ".") == 0 && log_top_multi_broker_name != NULL)
     {
-      int nfiles;
-      int j;
+      int dot_file_count;
       volatile int qerr_dot = 0;
 
-      files = (volatile char **) calloc (BROKER_LOG_TOP_MAX_FILES, sizeof (char *));
+      files = (volatile char **) MALLOC (sizeof (char *) * BROKER_LOG_TOP_MAX_FILES);
       if (files == NULL)
 	{
 	  fprintf (stderr, "Error: memory allocation failed\n");
-	  return -1;
+	  return log_top_finish_force_single_thread (-1);
 	}
-      nfiles = log_top_is_pattern (log_top_multi_broker_name)
+      memset ((void *) files, 0, sizeof (char *) * BROKER_LOG_TOP_MAX_FILES);
+      dot_file_count = log_top_is_pattern (log_top_multi_broker_name)
 	? log_top_gather_files_pattern_all (log_top_multi_broker_name, cwd_buf, (char **) files,
 					    BROKER_LOG_TOP_MAX_FILES)
-	: log_top_gather_files_exact (log_top_multi_broker_name, cwd_buf, (char **) files, BROKER_LOG_TOP_MAX_FILES);
-      if (nfiles == 0)
+	: log_top_gather_files_exact (log_top_multi_broker_name, cwd_buf, (char **) files,
+				      BROKER_LOG_TOP_MAX_FILES);
+      if (dot_file_count < 0)
+	{
+	  fprintf (stderr, "Error: failed to gather log files for broker '%s'.\n", log_top_multi_broker_name);
+	  {
+	    char **fp = (char **) files;
+	    FREE_MEM (fp);
+	    files = (volatile char **) fp;
+	  }
+	  return log_top_finish_force_single_thread (-1);
+	}
+      if (dot_file_count == 0)
 	{
 	  fprintf (stderr, "Info: no files for broker '%s' in current directory.\n", log_top_multi_broker_name);
-	  free ((void *) files);
-	  return -1;
+	  {
+	    char **fp = (char **) files;
+	    FREE_MEM (fp);
+	    files = (volatile char **) fp;
+	  }
+	  return log_top_finish_force_single_thread (-1);
 	}
       fprintf (stdout, "%s\n", log_top_multi_broker_name);
       query_info_reset ();
-      if (log_top_sigjmp_tran_query (nfiles, (char **) files, 0, &qerr_dot) == 0)
-	error = (int) qerr_dot;
-      else
-	error = 0;
-      for (j = 0; j < nfiles; j++)
+      if (log_top_fork_tran_query (dot_file_count, (char **) files, 0, &qerr_dot) == 0)
 	{
-	  char *fj = (char *) files[j];
-
-	  FREE_MEM (fj);
-	  files[j] = fj;
+	  error = (int) qerr_dot;
 	}
-      free ((void *) files);
-      return error;
+      else
+	{
+	  error = 0;
+	}
+      log_top_free_heap_files ((char **) files, dot_file_count);
+      {
+	char **fp = (char **) files;
+	FREE_MEM (fp);
+	files = (volatile char **) fp;
+      }
+      return log_top_finish_force_single_thread (error);
     }
 
   if (log_top_fill_parent_out_base (parent_out_base, sizeof (parent_out_base)) < 0)
     {
-      return -1;
+      return log_top_finish_force_single_thread (-1);
     }
 
   if (log_top_mkdir_out (parent_out_base) < 0 && errno != EEXIST)
     {
       fprintf (stderr, "Error: cannot create output directory: %s\n", parent_out_base);
-      return -1;
+      return log_top_finish_force_single_thread (-1);
     }
 
   if (log_top_multi_explicit_dirs_flag)
@@ -1122,10 +1230,15 @@ log_top_multi_run (void)
   else if (strcasecmp (log_top_multi_log_dir, "LOG_DIR") == 0)
     {
       ndirs = log_top_discover_log_dirs (dirs, BROKER_LOG_TOP_MAX_DIRS);
-      if (ndirs <= 0)
+      if (ndirs < 0)
+	{
+	  fprintf (stderr, "Error: failed to read LOG_DIR / SLOW_LOG_DIR entries from broker configuration.\n");
+	  return log_top_finish_force_single_thread (-1);
+	}
+      if (ndirs == 0)
 	{
 	  fprintf (stderr, "Error: no valid LOG_DIR or SLOW_LOG_DIR found in cubrid_broker.conf\n");
-	  return -1;
+	  return log_top_finish_force_single_thread (-1);
 	}
     }
   else
@@ -1134,22 +1247,25 @@ log_top_multi_run (void)
       if (stat (norm, &st) < 0 || !S_ISDIR (st.st_mode))
 	{
 	  fprintf (stderr, "Error: directory does not exist: %s\n", norm);
-	  return -1;
+	  return log_top_finish_force_single_thread (-1);
 	}
       dirs[0] = (char *) MALLOC (strlen (norm) + 1);
       if (!dirs[0])
-	return -1;
+	{
+	  return log_top_finish_force_single_thread (-1);
+	}
       strcpy (dirs[0], norm);
       ndirs = 1;
     }
 
-  files = (volatile char **) calloc (BROKER_LOG_TOP_MAX_FILES, sizeof (char *));
+  files = (volatile char **) MALLOC (sizeof (char *) * BROKER_LOG_TOP_MAX_FILES);
   if (files == NULL)
     {
       fprintf (stderr, "Error: memory allocation failed\n");
       log_top_free_dirs (dirs, ndirs, log_top_multi_dir_is_conf_multi ());
-      return -1;
+      return log_top_finish_force_single_thread (-1);
     }
+  memset ((void *) files, 0, sizeof (char *) * BROKER_LOG_TOP_MAX_FILES);
 
   if (log_top_multi_broker_name)
     {
@@ -1159,6 +1275,13 @@ log_top_multi_run (void)
 	    {
 	      nfiles = log_top_gather_files_pattern_all (log_top_multi_broker_name, dirs[d], (char **) files,
 							 BROKER_LOG_TOP_MAX_FILES);
+	      if (nfiles < 0)
+		{
+		  fprintf (stderr, "Error: failed to gather log files matching '%s' under [%s].\n",
+			   log_top_multi_broker_name, dirs[d]);
+		  error = -1;
+		  break;
+		}
 	      if (nfiles == 0)
 		{
 		  fprintf (stderr, "Info: [%s] no files matching pattern '%s', skipping.\n", dirs[d],
@@ -1166,23 +1289,29 @@ log_top_multi_run (void)
 		  goto next_dir;
 		}
 	      log_top_multi_run_one_broker (parent_out_base, log_top_multi_broker_name, 1,
-					    log_top_multi_broker_name, (char **) files, nfiles, (char *) saved_cwd,
-					    &error);
+					   log_top_multi_broker_name, (char **) files, nfiles, (char *) saved_cwd,
+					   &error);
 	      nfiles = 0;
 	    }
 	  else
 	    {
 	      nfiles = log_top_gather_files_exact (log_top_multi_broker_name, dirs[d], (char **) files,
 						   BROKER_LOG_TOP_MAX_FILES);
+	      if (nfiles < 0)
+		{
+		  fprintf (stderr, "Error: failed to gather log files for broker '%s' under [%s].\n",
+			   log_top_multi_broker_name, dirs[d]);
+		  error = -1;
+		  break;
+		}
 	      if (nfiles == 0)
 		{
-		  fprintf (stderr, "Info: [%s] no files for broker '%s', skipping.\n", dirs[d],
-			   log_top_multi_broker_name);
+		  fprintf (stderr, "Info: [%s] no files for broker '%s', skipping.\n", dirs[d], log_top_multi_broker_name);
 		  goto next_dir;
 		}
 	      log_top_multi_run_one_broker (parent_out_base, log_top_multi_broker_name, 0,
-					    log_top_multi_broker_name, (char **) files, nfiles, (char *) saved_cwd,
-					    &error);
+					   log_top_multi_broker_name, (char **) files, nfiles, (char *) saved_cwd,
+					   &error);
 	      nfiles = 0;
 	    }
 	next_dir:
@@ -1202,16 +1331,21 @@ log_top_multi_run (void)
 
       memset (all_brokers, 0, sizeof (all_brokers));
 
-      all_files = (char **) calloc (BROKER_LOG_TOP_MAX_FILES, sizeof (char *));
+      all_files = (char **) MALLOC (sizeof (char *) * BROKER_LOG_TOP_MAX_FILES);
       if (all_files == NULL)
 	{
 	  fprintf (stderr, "Error: memory allocation failed\n");
 	  log_top_free_dirs (dirs, ndirs, log_top_multi_dir_is_conf_multi ());
-	  free ((void *) files);
-	  return -1;
+	  {
+	    char **fp = (char **) files;
+	    FREE_MEM (fp);
+	    files = (volatile char **) fp;
+	  }
+	  return log_top_finish_force_single_thread (-1);
 	}
+      memset (all_files, 0, sizeof (char *) * BROKER_LOG_TOP_MAX_FILES);
 
-      for (dir_idx = 0; dir_idx < ndirs && total_brokers < 512; dir_idx++)
+      for (dir_idx = 0; dir_idx < ndirs && total_brokers < 512 && error == 0; dir_idx++)
 	{
 	  char *dir_brokers[512];
 	  int dir_nb;
@@ -1220,6 +1354,12 @@ log_top_multi_run (void)
 	  if (dirs[dir_idx] == NULL)
 	    continue;
 	  dir_nb = log_top_get_brokers_from_dir (dirs[dir_idx], dir_brokers, 512);
+	  if (dir_nb < 0)
+	    {
+	      fprintf (stderr, "Error: failed to list brokers under [%s].\n", dirs[dir_idx]);
+	      error = -1;
+	      break;
+	    }
 
 	  for (bi = 0; bi < dir_nb && total_brokers < 512; bi++)
 	    {
@@ -1252,13 +1392,38 @@ log_top_multi_run (void)
 	    }
 	}
 
+      if (error != 0)
+	{
+	  int zb;
+	  for (zb = 0; zb < total_brokers && zb < 512; zb++)
+	    {
+	      if (all_brokers[zb] != NULL)
+		{
+		  FREE_MEM (all_brokers[zb]);
+		  all_brokers[zb] = NULL;
+		}
+	    }
+	  log_top_free_dirs (dirs, ndirs, log_top_multi_dir_is_conf_multi ());
+	  FREE_MEM (all_files);
+	  {
+	    char **fp = (char **) files;
+	    FREE_MEM (fp);
+	    files = (volatile char **) fp;
+	  }
+	  return log_top_finish_force_single_thread (-1);
+	}
+
       if (total_brokers == 0)
 	{
 	  fprintf (stderr, "Info: no brokers found in any directory.\n");
 	  log_top_free_dirs (dirs, ndirs, log_top_multi_dir_is_conf_multi ());
-	  free (all_files);
-	  free ((void *) files);
-	  return 0;
+	  FREE_MEM (all_files);
+	  {
+	    char **fp = (char **) files;
+	    FREE_MEM (fp);
+	    files = (volatile char **) fp;
+	  }
+	  return log_top_finish_force_single_thread (0);
 	}
 
       for (i = 0; i < total_brokers && !error; i++)
@@ -1272,13 +1437,22 @@ log_top_multi_run (void)
 	  if (all_brokers[i] == NULL)
 	    continue;
 
-	  for (dir_idx = 0; dir_idx < ndirs && total_files < BROKER_LOG_TOP_MAX_FILES; dir_idx++)
+	  for (dir_idx = 0; dir_idx < ndirs && total_files < BROKER_LOG_TOP_MAX_FILES && error == 0; dir_idx++)
 	    {
+	      int dir_files;
+
 	      if (dirs[dir_idx] == NULL)
 		continue;
-	      int dir_files = log_top_gather_files_exact (all_brokers[i], dirs[dir_idx],
-							  all_files + total_files,
-							  BROKER_LOG_TOP_MAX_FILES - total_files);
+	      dir_files = log_top_gather_files_exact (all_brokers[i], dirs[dir_idx],
+							all_files + total_files,
+							BROKER_LOG_TOP_MAX_FILES - total_files);
+	      if (dir_files < 0)
+		{
+		  fprintf (stderr, "Error: failed to gather log files for broker '%s' under [%s].\n",
+			   all_brokers[i], dirs[dir_idx]);
+		  error = -1;
+		  break;
+		}
 	      total_files += dir_files;
 	    }
 	  num_files = total_files;
@@ -1291,7 +1465,7 @@ log_top_multi_run (void)
 	    }
 
 	  log_top_multi_run_one_broker (parent_out_base, all_brokers[i], 0, all_brokers[i], all_files, num_files,
-					(char *) saved_cwd, &error);
+				       (char *) saved_cwd, &error);
 	  memset (all_files, 0, sizeof (char *) * BROKER_LOG_TOP_MAX_FILES);
 	  FREE_MEM (all_brokers[i]);
 	  all_brokers[i] = NULL;
@@ -1305,18 +1479,19 @@ log_top_multi_run (void)
 	      all_brokers[k] = NULL;
 	    }
 	}
-      free (all_files);
+      FREE_MEM (all_files);
     }
 
   if (files != NULL)
     {
-      free ((void *) files);
-      files = NULL;
+      char **fp = (char **) files;
+      FREE_MEM (fp);
+      files = (volatile char **) fp;
     }
 
   log_top_free_dirs (dirs, ndirs, log_top_multi_dir_is_conf_multi ());
 
-  return error;
+  return log_top_finish_force_single_thread (error);
 }
 
 int
@@ -1512,10 +1687,13 @@ log_top_basename_is_cas_sql_slow_log (const char *basename)
   return log_top_cas_log_suffix_len (basename) != 0;
 }
 
-static int
-log_top_path_is_cas_sql_slow_log (const char *path)
+/*
+ * log_top_path_to_basename — 경로에서 basename 부분의 포인터를 반환.
+ * '/'(및 Windows '\\'）이후 부분. 구분자가 없으면 path 자체.
+ */
+static const char *
+log_top_path_to_basename (const char *path)
 {
-  const char *base = path;
   const char *p;
 
   p = strrchr (path, '/');
@@ -1526,9 +1704,13 @@ log_top_path_is_cas_sql_slow_log (const char *path)
       p = p2;
   }
 #endif
-  if (p != NULL)
-    base = p + 1;
-  return log_top_basename_is_cas_sql_slow_log (base);
+  return (p != NULL) ? p + 1 : path;
+}
+
+static int
+log_top_path_is_cas_sql_slow_log (const char *path)
+{
+  return log_top_basename_is_cas_sql_slow_log (log_top_path_to_basename (path));
 }
 
 static int
@@ -1571,20 +1753,7 @@ log_top_broker_key_from_basename (const char *basename, char *out, size_t outlen
 static void
 log_top_broker_key_from_path (const char *path, char *out, size_t outlen)
 {
-  const char *base = path;
-  const char *p;
-
-  p = strrchr (path, '/');
-#if defined(WINDOWS)
-  {
-    const char *p2 = strrchr (path, '\\');
-    if (p2 != NULL && (p == NULL || p2 > p))
-      p = p2;
-  }
-#endif
-  if (p != NULL)
-    base = p + 1;
-  (void) log_top_broker_key_from_basename (base, out, outlen);
+  (void) log_top_broker_key_from_basename (log_top_path_to_basename (path), out, outlen);
 }
 
 static int
@@ -1620,7 +1789,7 @@ log_top_query_split_paths (int nfiles, char **paths)
       return -1;
     }
 
-  tab = (lt_split_sort *) calloc ((size_t) nvalid, sizeof (lt_split_sort));
+  tab = (lt_split_sort *) MALLOC ((size_t) nvalid * sizeof (lt_split_sort));
   if (tab == NULL)
     {
       fprintf (stderr, "Error: memory allocation failed\n");
@@ -1640,23 +1809,24 @@ log_top_query_split_paths (int nfiles, char **paths)
   if (saved_cwd == NULL)
     {
       fprintf (stderr, "Error: cannot get current directory\n");
-      free (tab);
+      FREE_MEM (tab);
       return -1;
     }
 
-  broker_log_top_force_single_thread = 1;
-
   if (log_top_fill_parent_out_base (parent_out_base, sizeof (parent_out_base)) < 0)
     {
-      free (tab);
+      FREE_MEM (tab);
       return -1;
     }
   if (log_top_mkdir_out (parent_out_base) < 0 && errno != EEXIST)
     {
       fprintf (stderr, "Error: cannot create output directory: %s\n", parent_out_base);
-      free (tab);
+      FREE_MEM (tab);
       return -1;
     }
+
+  /* 배치 split 경로와 동일하게 MT_MODE에서도 단일 스레드로 실행 */
+  broker_log_top_force_single_thread = 1;
 
   g_start = 0;
   while (g_start < nvalid)
@@ -1667,13 +1837,14 @@ log_top_query_split_paths (int nfiles, char **paths)
       while (g_end < nvalid && strcmp (tab[g_end].key, tab[g_start].key) == 0)
 	g_end++;
 
-      argv_small = (volatile char **) calloc ((size_t) (g_end - g_start), sizeof (char *));
+      argv_small = (volatile char **) MALLOC ((size_t) (g_end - g_start) * sizeof (char *));
       if (argv_small == NULL)
 	{
 	  fprintf (stderr, "Error: memory allocation failed\n");
 	  error = -1;
 	  break;
 	}
+      memset ((void *) argv_small, 0, (size_t) (g_end - g_start) * sizeof (char *));
       for (k = 0; k < g_end - g_start; k++)
 	argv_small[k] = tab[g_start + k].path;
 
@@ -1684,34 +1855,55 @@ log_top_query_split_paths (int nfiles, char **paths)
 	{
 	  fprintf (stderr, "Error: cannot create output directory: %s\n", subdir);
 	  error = -1;
-	  free ((void *) argv_small);
+	  {
+	    char **fp = (char **) argv_small;
+	    FREE_MEM (fp);
+	    argv_small = (volatile char **) fp;
+	  }
 	  break;
 	}
       if (LOG_TOP_CHDIR (subdir) < 0)
 	{
 	  fprintf (stderr, "Error: cannot chdir to %s\n", subdir);
 	  error = -1;
-	  free ((void *) argv_small);
+	  {
+	    char **fp = (char **) argv_small;
+	    FREE_MEM (fp);
+	    argv_small = (volatile char **) fp;
+	  }
 	  break;
 	}
 
       fprintf (stdout, "%s\n", tab[g_start].key);
       query_info_reset ();
-      if (log_top_sigjmp_tran_query (g_end - g_start, (char **) argv_small, 0, &qerr) == 0)
+      if (log_top_fork_tran_query (g_end - g_start, (char **) argv_small, 0, &qerr) == 0)
 	{
-	  LOG_TOP_CHDIR ((char *) saved_cwd);
-	  if (qerr != 0)
-	    error = qerr;
+	  if (log_top_restore_cwd (saved_cwd) < 0)
+	    {
+	      error = -1;
+	    }
+	  else if (qerr != 0)
+	    {
+	      error = qerr;
+	    }
 	}
       else
-	LOG_TOP_CHDIR ((char *) saved_cwd);
-      free ((void *) argv_small);
-      argv_small = NULL;
+	{
+	  if (log_top_restore_cwd (saved_cwd) < 0)
+	    {
+	      error = -1;
+	    }
+	}
+      {
+	char **fp = (char **) argv_small;
+	FREE_MEM (fp);
+	argv_small = (volatile char **) fp;
+      }
       g_start = g_end;
     }
 
-  free (tab);
-  return (int) error;
+  FREE_MEM (tab);
+  return log_top_finish_force_single_thread ((int) error);
 }
 
 #ifdef MT_MODE
@@ -2181,7 +2373,8 @@ get_args (int argc, char *argv[])
 getargs_err:
   fprintf (stderr,
 	   "%s [-t] [-F <from date>] [-T <to date>] [-O <merge | split>] <log_file> ...\n"
-	   "or\n" "%s [-t] [-F <from date>] [-T <to date>] <--from-conf>\n", argv[0], argv[0]);
+	   "or\n"
+	   "%s [-t] [-F <from date>] [-T <to date>] <--from-conf>\n", argv[0], argv[0]);
   return -1;
 date_format_err:
   fprintf (stderr, "invalid date. valid date format is yy-mm-dd hh:mm:ss.\n");

--- a/src/broker/broker_log_top.c
+++ b/src/broker/broker_log_top.c
@@ -78,8 +78,7 @@ struct t_work_msg
 
 static int log_top_query (int argc, char *argv[], int arg_start);
 static int log_top_query_split_paths (int nfiles, char **paths);
-static int log_top_sigjmp_tran_query_inner (int nfiles, char **files, volatile int *qerr);
-static int log_top_sigjmp_tran_query_argv (int argc, char **argv, int arg_start, volatile int *qerr);
+static int log_top_sigjmp_tran_query (int argc, char **argv, int arg_start, volatile int *qerr);
 static int log_top (FILE * fp, char *filename, long start_offset, long end_offset);
 static int log_execute (T_QUERY_INFO * qi, char *linebuf, char **query_p);
 static int get_args (int argc, char *argv[]);
@@ -131,7 +130,6 @@ static int log_top_discover_log_dirs (char *out_dirs[], int max_dirs);
 static void log_top_normalize_path (const char *in, char *out, size_t out_len);
 static size_t log_top_cas_log_suffix_len (const char *basename);
 static int log_top_gather_files_exact (const char *broker, const char *dir, char *out_files[], int max_files);
-static int log_top_gather_files_pattern (const char *pattern, const char *dir, char *out_files[], int max_files);
 static int log_top_is_pattern (const char *s);
 static int log_top_get_brokers_from_dir (const char *dir, char *out_brokers[], int max_brokers);
 static void log_top_broker_to_safe (const char *name, char *out, size_t out_len);
@@ -203,53 +201,26 @@ main (int argc, char *argv[])
   if (!log_top_out_merge && get_cnt > 0)
     error = log_top_query_split_paths (get_cnt, file_list);
   else
-#if !defined(WINDOWS)
-  if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
     {
-      broker_log_top_segfault_jmp_valid = 1;
-      signal (SIGSEGV, broker_log_top_segfault_handler);
-      if (mode_tran)
-	error = log_top_tran (get_cnt, file_list, 0);
+      volatile int mqerr = 0;
+      if (log_top_sigjmp_tran_query (get_cnt, file_list, 0, &mqerr) == 0)
+	error = (int) mqerr;
       else
-	error = log_top_query (get_cnt, file_list, 0);
-      broker_log_top_segfault_jmp_valid = 0;
-      signal (SIGSEGV, SIG_DFL);
+	error = 0;
     }
-  else
-    {
-      broker_log_top_segfault_jmp_valid = 0;
-      signal (SIGSEGV, SIG_DFL);
-      fprintf (stderr, "Warning: segmentation fault during processing.\n");
-      error = 0;
-    }
-#else
-  if (mode_tran)
-    error = log_top_tran (get_cnt, file_list, 0);
-  else
-    error = log_top_query (get_cnt, file_list, 0);
-#endif
 
   free_file_list (file_list, file_cnt);
 #else
-#if !defined(WINDOWS)
   if (!log_top_out_merge && arg_start < argc)
     error = log_top_query_split_paths (argc - arg_start, argv + arg_start);
   else
     {
       volatile int mqerr = 0;
-      if (log_top_sigjmp_tran_query_argv (argc, argv, arg_start, &mqerr) == 0)
+      if (log_top_sigjmp_tran_query (argc, argv, arg_start, &mqerr) == 0)
 	error = (int) mqerr;
       else
 	error = 0;
     }
-#else
-  if (!log_top_out_merge && arg_start < argc)
-    error = log_top_query_split_paths (argc - arg_start, argv + arg_start);
-  else if (mode_tran)
-    error = log_top_tran (argc, argv, arg_start);
-  else
-    error = log_top_query (argc, argv, arg_start);
-#endif
 #endif
 
   return error;
@@ -425,6 +396,36 @@ log_top_free_heap_files (char **tab, int n)
   for (j = 0; j < n; j++)
     {
       FREE_MEM (tab[j]);
+    }
+}
+
+/*
+ * log_top_multi_run 내 dirs[] 배열 해제 — 4곳에서 반복되던 패턴을 통합.
+ * is_conf_multi 일 때는 전체 배열, 아니면 dirs[0]만 해제.
+ */
+static void
+log_top_free_dirs (char **dirs, int ndirs, int is_conf_multi)
+{
+  int d;
+
+  if (is_conf_multi)
+    {
+      for (d = 0; d < ndirs; d++)
+	{
+	  if (dirs[d] != NULL)
+	    {
+	      FREE_MEM (dirs[d]);
+	      dirs[d] = NULL;
+	    }
+	}
+    }
+  else
+    {
+      if (dirs[0] != NULL)
+	{
+	  FREE_MEM (dirs[0]);
+	  dirs[0] = NULL;
+	}
     }
 }
 
@@ -629,50 +630,6 @@ log_top_gather_files_exact (const char *broker, const char *dir, char *out_files
 }
 
 static int
-log_top_gather_files_pattern (const char *pattern, const char *dir, char *out_files[], int max_files)
-{
-  DIR *d;
-  struct dirent *e;
-  char path[BROKER_LOG_TOP_MAX_PATH];
-  char broker_prefix[256];
-  char *last_underscore;
-  int n = 0;
-  size_t elen;
-
-  d = opendir (dir);
-  if (!d)
-    return 0;
-
-  while ((e = readdir (d)) != NULL && n < max_files)
-    {
-      size_t copy_len;
-      elen = strlen (e->d_name);
-      if (log_top_cas_log_suffix_len (e->d_name) != 8)
-	continue;
-      copy_len = elen - 8;
-      if (copy_len >= sizeof (broker_prefix))
-	copy_len = sizeof (broker_prefix) - 1;
-      memcpy (broker_prefix, e->d_name, copy_len);
-      broker_prefix[copy_len] = '\0';
-      last_underscore = strrchr (broker_prefix, '_');
-      if (!last_underscore)
-	continue;
-      *last_underscore = '\0';
-      if (!log_top_match_pattern (broker_prefix, pattern))
-	continue;
-      snprintf (path, sizeof (path), "%s/%s", dir, e->d_name);
-      out_files[n] = (char *) MALLOC (strlen (path) + 1);
-      if (out_files[n])
-	{
-	  strcpy (out_files[n], path);
-	  n++;
-	}
-    }
-  closedir (d);
-  return n;
-}
-
-static int
 log_top_gather_files_pattern_suffix (const char *pattern, const char *dir, const char *suffix, size_t suffix_len,
 				   char *out_files[], int max_files)
 {
@@ -766,102 +723,39 @@ log_top_gather_files_exact (const char *broker, const char *dir, char *out_files
 }
 
 static int
-log_top_gather_files_pattern (const char *pattern, const char *dir, char *out_files[], int max_files)
+log_top_gather_files_pattern_all (const char *pattern, const char *dir, char *out_files[], int max_files)
 {
   HANDLE h;
   WIN32_FIND_DATAA fd;
   char search[BROKER_LOG_TOP_MAX_PATH];
   char path[BROKER_LOG_TOP_MAX_PATH];
   int n = 0;
-  size_t plen = strlen (pattern);
+  int si;
+  const char *suffixes[] = { "*.sql.log", "*.sql.log.bak", "*.slow.log", "*.slow.log.bak", NULL };
 
-  snprintf (search, sizeof (search), "%s\\%s_*.sql.log", dir, pattern);
-  h = FindFirstFileA (search, &fd);
-  if (h == INVALID_HANDLE_VALUE)
-    return 0;
-  do
+  for (si = 0; suffixes[si] && n < max_files; si++)
     {
-      if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+      snprintf (search, sizeof (search), "%s\\%s_%s", dir, pattern, suffixes[si]);
+      h = FindFirstFileA (search, &fd);
+      if (h == INVALID_HANDLE_VALUE)
 	continue;
-      snprintf (path, sizeof (path), "%s\\%s", dir, fd.cFileName);
-      out_files[n] = (char *) MALLOC (strlen (path) + 1);
-      if (out_files[n])
+      do
 	{
-	  strcpy (out_files[n], path);
-	  n++;
+	  if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+	    continue;
+	  if (n >= max_files)
+	    break;
+	  snprintf (path, sizeof (path), "%s\\%s", dir, fd.cFileName);
+	  out_files[n] = (char *) MALLOC (strlen (path) + 1);
+	  if (out_files[n])
+	    {
+	      strcpy (out_files[n], path);
+	      n++;
+	    }
 	}
+      while (FindNextFileA (h, &fd));
+      FindClose (h);
     }
-  while (FindNextFileA (h, &fd) && n < max_files);
-  FindClose (h);
-  return n;
-}
-
-static int
-log_top_gather_files_pattern_all (const char *pattern, const char *dir, char *out_files[], int max_files)
-{
-  int n = 0;
-  n += log_top_gather_files_pattern (pattern, dir, out_files, max_files);
-  /* Windows: log_top_gather_files_pattern only gets .sql.log; add other suffixes via FindFirstFile */
-  {
-    HANDLE h;
-    WIN32_FIND_DATAA fd;
-    char search[BROKER_LOG_TOP_MAX_PATH];
-    char path[BROKER_LOG_TOP_MAX_PATH];
-    snprintf (search, sizeof (search), "%s\\%s_*.sql.log.bak", dir, pattern);
-    h = FindFirstFileA (search, &fd);
-    if (h != INVALID_HANDLE_VALUE)
-      {
-	do
-	  {
-	    if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
-	      continue;
-	    if (n >= max_files)
-	      break;
-	    snprintf (path, sizeof (path), "%s\\%s", dir, fd.cFileName);
-	    out_files[n] = (char *) MALLOC (strlen (path) + 1);
-	    if (out_files[n])
-	      strcpy (out_files[n], path), n++;
-	  }
-	while (FindNextFileA (h, &fd));
-	FindClose (h);
-      }
-    snprintf (search, sizeof (search), "%s\\%s_*.slow.log", dir, pattern);
-    h = FindFirstFileA (search, &fd);
-    if (h != INVALID_HANDLE_VALUE)
-      {
-	do
-	  {
-	    if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
-	      continue;
-	    if (n >= max_files)
-	      break;
-	    snprintf (path, sizeof (path), "%s\\%s", dir, fd.cFileName);
-	    out_files[n] = (char *) MALLOC (strlen (path) + 1);
-	    if (out_files[n])
-	      strcpy (out_files[n], path), n++;
-	  }
-	while (FindNextFileA (h, &fd));
-	FindClose (h);
-      }
-    snprintf (search, sizeof (search), "%s\\%s_*.slow.log.bak", dir, pattern);
-    h = FindFirstFileA (search, &fd);
-    if (h != INVALID_HANDLE_VALUE)
-      {
-	do
-	  {
-	    if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
-	      continue;
-	    if (n >= max_files)
-	      break;
-	    snprintf (path, sizeof (path), "%s\\%s", dir, fd.cFileName);
-	    out_files[n] = (char *) MALLOC (strlen (path) + 1);
-	    if (out_files[n])
-	      strcpy (out_files[n], path), n++;
-	  }
-	while (FindNextFileA (h, &fd));
-	FindClose (h);
-      }
-  }
   return n;
 }
 
@@ -1063,40 +957,13 @@ log_top_fill_parent_out_base (char *parent_out_base, size_t parent_sz)
   return 0;
 }
 
-/* sigsetjmp로 감싼 log_top_tran / log_top_query — 원본 main(Unix)과 동일한 호출, 복구만 추가 */
+/*
+ * sigsetjmp로 감싼 log_top_tran / log_top_query 통합 래퍼.
+ * 기존 _inner(nfiles, files)는 arg_start=0으로, _argv(argc, argv, arg_start)는 그대로 호출.
+ * 반환값: 0 = 정상 완료, 1 = SIGSEGV로 건너뜀.
+ */
 static int
-log_top_sigjmp_tran_query_inner (int nfiles, char **files, volatile int *qerr)
-{
-#if !defined(WINDOWS)
-  if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
-    {
-      broker_log_top_segfault_jmp_valid = 1;
-      signal (SIGSEGV, broker_log_top_segfault_handler);
-      if (mode_tran)
-	*qerr = log_top_tran (nfiles, files, 0);
-      else
-	*qerr = log_top_query (nfiles, files, 0);
-      broker_log_top_segfault_jmp_valid = 0;
-      signal (SIGSEGV, SIG_DFL);
-      return 0;
-    }
-  broker_log_top_segfault_jmp_valid = 0;
-  signal (SIGSEGV, SIG_DFL);
-  fprintf (stderr, "Warning: segmentation fault during processing, skipping.\n");
-  *qerr = 0;
-  return 1;
-#else
-  if (mode_tran)
-    *qerr = log_top_tran (nfiles, files, 0);
-  else
-    *qerr = log_top_query (nfiles, files, 0);
-  return 0;
-#endif
-}
-
-/* broker_log_top.c_old 의 Unix main 과 동일하게 (argc,argv,arg_start) 로 tran/query 호출 */
-static int
-log_top_sigjmp_tran_query_argv (int argc, char **argv, int arg_start, volatile int *qerr)
+log_top_sigjmp_tran_query (int argc, char **argv, int arg_start, volatile int *qerr)
 {
 #if !defined(WINDOWS)
   if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
@@ -1113,7 +980,7 @@ log_top_sigjmp_tran_query_argv (int argc, char **argv, int arg_start, volatile i
     }
   broker_log_top_segfault_jmp_valid = 0;
   signal (SIGSEGV, SIG_DFL);
-  fprintf (stderr, "Warning: segmentation fault during processing.\n");
+  fprintf (stderr, "Warning: segmentation fault during processing, skipping.\n");
   *qerr = 0;
   return 1;
 #else
@@ -1158,7 +1025,7 @@ log_top_multi_run_one_broker (const char *parent_out_base, const char *subdir_fo
     }
   fprintf (stdout, "%s\n", stdout_label);
   query_info_reset ();
-  if (log_top_sigjmp_tran_query_inner (nfiles, files, &qerr) == 0)
+  if (log_top_sigjmp_tran_query (nfiles, files, 0, &qerr) == 0)
     {
       LOG_TOP_CHDIR ((char *) saved_cwd);
       for (i = 0; i < nfiles; i++)
@@ -1223,7 +1090,7 @@ log_top_multi_run (void)
 	}
       fprintf (stdout, "%s\n", log_top_multi_broker_name);
       query_info_reset ();
-      if (log_top_sigjmp_tran_query_inner (nfiles, (char **) files, &qerr_dot) == 0)
+      if (log_top_sigjmp_tran_query (nfiles, (char **) files, 0, &qerr_dot) == 0)
 	error = (int) qerr_dot;
       else
 	error = 0;
@@ -1285,17 +1152,7 @@ log_top_multi_run (void)
   if (files == NULL)
     {
       fprintf (stderr, "Error: memory allocation failed\n");
-      if (log_top_multi_dir_is_conf_multi ())
-	{
-	  for (d = 0; d < ndirs; d++)
-	    {
-	      FREE_MEM (dirs[d]);
-	    }
-	}
-      else if (dirs[0] != NULL)
-	{
-	  FREE_MEM (dirs[0]);
-	}
+      log_top_free_dirs (dirs, ndirs, log_top_multi_dir_is_conf_multi ());
       return -1;
     }
 
@@ -1353,17 +1210,7 @@ log_top_multi_run (void)
       if (all_files == NULL)
 	{
 	  fprintf (stderr, "Error: memory allocation failed\n");
-	  if (log_top_multi_dir_is_conf_multi ())
-	    {
-	      for (d = 0; d < ndirs; d++)
-		{
-		  FREE_MEM (dirs[d]);
-		}
-	    }
-	  else if (dirs[0] != NULL)
-	    {
-	      FREE_MEM (dirs[0]);
-	    }
+	  log_top_free_dirs (dirs, ndirs, log_top_multi_dir_is_conf_multi ());
 	  free ((void *) files);
 	  return -1;
 	}
@@ -1412,19 +1259,7 @@ log_top_multi_run (void)
       if (total_brokers == 0)
 	{
 	  fprintf (stderr, "Info: no brokers found in any directory.\n");
-	  if (log_top_multi_dir_is_conf_multi ())
-	    {
-	      for (d = 0; d < ndirs; d++)
-		{
-		  FREE_MEM (dirs[d]);
-		  dirs[d] = NULL;
-		}
-	    }
-	  else if (dirs[0] != NULL)
-	    {
-	      FREE_MEM (dirs[0]);
-	      dirs[0] = NULL;
-	    }
+	  log_top_free_dirs (dirs, ndirs, log_top_multi_dir_is_conf_multi ());
 	  free (all_files);
 	  free ((void *) files);
 	  return 0;
@@ -1483,60 +1318,7 @@ log_top_multi_run (void)
       files = NULL;
     }
 
-#if !defined(WINDOWS)
-  if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
-    {
-      broker_log_top_segfault_jmp_valid = 1;
-      signal (SIGSEGV, broker_log_top_segfault_handler);
-      if (log_top_multi_dir_is_conf_multi ())
-	{
-	  for (d = 0; d < ndirs; d++)
-	    {
-	      if (dirs[d] != NULL)
-		{
-		  FREE_MEM (dirs[d]);
-		  dirs[d] = NULL;
-		}
-	    }
-	}
-      else
-	{
-	  if (dirs[0] != NULL)
-	    {
-	      FREE_MEM (dirs[0]);
-	      dirs[0] = NULL;
-	    }
-	}
-      broker_log_top_segfault_jmp_valid = 0;
-      signal (SIGSEGV, SIG_DFL);
-    }
-  else
-    {
-      broker_log_top_segfault_jmp_valid = 0;
-      signal (SIGSEGV, SIG_DFL);
-      fprintf (stderr, "Warning: segmentation fault during final cleanup, skipping.\n");
-    }
-#else
-  if (log_top_multi_dir_is_conf_multi ())
-    {
-      for (d = 0; d < ndirs; d++)
-	{
-	  if (dirs[d] != NULL)
-	    {
-	      FREE_MEM (dirs[d]);
-	      dirs[d] = NULL;
-	    }
-	}
-    }
-  else
-    {
-      if (dirs[0] != NULL)
-	{
-	  FREE_MEM (dirs[0]);
-	  dirs[0] = NULL;
-	}
-    }
-#endif
+  log_top_free_dirs (dirs, ndirs, log_top_multi_dir_is_conf_multi ());
 
   return error;
 }
@@ -1919,7 +1701,7 @@ log_top_query_split_paths (int nfiles, char **paths)
 
       fprintf (stdout, "%s\n", tab[g_start].key);
       query_info_reset ();
-      if (log_top_sigjmp_tran_query_inner (g_end - g_start, (char **) argv_small, &qerr) == 0)
+      if (log_top_sigjmp_tran_query (g_end - g_start, (char **) argv_small, 0, &qerr) == 0)
 	{
 	  LOG_TOP_CHDIR ((char *) saved_cwd);
 	  if (qerr != 0)

--- a/src/broker/broker_log_top.c
+++ b/src/broker/broker_log_top.c
@@ -28,8 +28,23 @@
 #include <string.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <sys/stat.h>
+#include <time.h>
 #if !defined(WINDOWS)
 #include <unistd.h>
+#include <dirent.h>
+#else
+#include <direct.h>
+#include <io.h>
+#include <windows.h>
+#endif
+
+#if !defined(WINDOWS)
+#define LOG_TOP_CHDIR(D)  chdir (D)
+#else
+#define LOG_TOP_CHDIR(D)  _chdir (D)
 #endif
 
 #ifdef MT_MODE
@@ -40,7 +55,6 @@
 #include "cas_common.h"
 #include "cas_query_info.h"
 #include "broker_log_time.h"
-#include "broker_log_sql_list.h"
 #include "log_top_string.h"
 #include "broker_log_top.h"
 #include "broker_log_util.h"
@@ -63,6 +77,9 @@ struct t_work_msg
 #endif
 
 static int log_top_query (int argc, char *argv[], int arg_start);
+static int log_top_query_split_paths (int nfiles, char **paths);
+static int log_top_sigjmp_tran_query_inner (int nfiles, char **files, volatile int *qerr);
+static int log_top_sigjmp_tran_query_argv (int argc, char **argv, int arg_start, volatile int *qerr);
 static int log_top (FILE * fp, char *filename, long start_offset, long end_offset);
 static int log_execute (T_QUERY_INFO * qi, char *linebuf, char **query_p);
 static int get_args (int argc, char *argv[]);
@@ -81,6 +98,51 @@ static int read_execute_end_msg (char *msg_p, int *res_code, int *runtime_msec);
 static int read_bind_value (FILE * fp, T_STRING * t_str, char **linebuf, int *lineno, T_STRING * cas_log_buf);
 static int search_offset (FILE * fp, char *string, long *offset, bool start);
 static char *organize_query_string (const char *sql);
+
+static const char *log_top_multi_log_dir = NULL;
+static const char *log_top_multi_broker_name = NULL;
+#define BROKER_LOG_TOP_MAX_PATH 2048
+#define BROKER_LOG_TOP_MAX_FILES 4096
+#define BROKER_LOG_TOP_MAX_DIRS 128
+
+static int broker_log_top_force_single_thread = 0;
+
+#if !defined(WINDOWS)
+/* Segmentation fault 복구: 예외 시 longjmp로 복귀하여 무시하고 진행 */
+static sigjmp_buf broker_log_top_segfault_jmp;
+static volatile int broker_log_top_segfault_jmp_valid;
+
+static void
+broker_log_top_segfault_handler (int sig)
+{
+  if (sig == SIGSEGV && broker_log_top_segfault_jmp_valid)
+    {
+      broker_log_top_segfault_jmp_valid = 0;
+      siglongjmp (broker_log_top_segfault_jmp, 1);
+    }
+  /* 재진입 방지 실패 시 기본 동작 */
+  signal (SIGSEGV, SIG_DFL);
+  raise (sig);
+}
+#endif
+
+static void log_top_free_heap_files (char **tab, int n);
+static int log_top_discover_log_dirs (char *out_dirs[], int max_dirs);
+static void log_top_normalize_path (const char *in, char *out, size_t out_len);
+static size_t log_top_cas_log_suffix_len (const char *basename);
+static int log_top_gather_files_exact (const char *broker, const char *dir, char *out_files[], int max_files);
+static int log_top_gather_files_pattern (const char *pattern, const char *dir, char *out_files[], int max_files);
+static int log_top_is_pattern (const char *s);
+static int log_top_get_brokers_from_dir (const char *dir, char *out_brokers[], int max_brokers);
+static void log_top_broker_to_safe (const char *name, char *out, size_t out_len);
+static int log_top_mkdir_out (const char *path);
+static int log_top_multi_run (void);
+
+static int log_top_out_merge = 1;
+static int log_top_multi_explicit_dirs_flag = 0;
+static int log_top_multi_explicit_ndirs = 0;
+static char *log_top_multi_explicit_dirs_buf[BROKER_LOG_TOP_MAX_DIRS];
+static const char log_top_multi_explicit_sentinel[] = "__EXPLICIT__";
 
 T_LOG_TOP_MODE log_top_mode = MODE_PROC_TIME;
 
@@ -113,6 +175,12 @@ main (int argc, char *argv[])
       return -1;
     }
 
+  if (log_top_multi_log_dir != NULL)
+    {
+      error = log_top_multi_run ();
+      return error;
+    }
+
 #if defined(WINDOWS)
   file_cnt = get_file_count (argc, argv, arg_start);
   if (file_cnt <= 0)
@@ -132,25 +200,56 @@ main (int argc, char *argv[])
       get_cnt = file_cnt;
     }
 
-  if (mode_tran)
+  if (!log_top_out_merge && get_cnt > 0)
+    error = log_top_query_split_paths (get_cnt, file_list);
+  else
+#if !defined(WINDOWS)
+  if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
     {
-      error = log_top_tran (get_cnt, file_list, 0);
+      broker_log_top_segfault_jmp_valid = 1;
+      signal (SIGSEGV, broker_log_top_segfault_handler);
+      if (mode_tran)
+	error = log_top_tran (get_cnt, file_list, 0);
+      else
+	error = log_top_query (get_cnt, file_list, 0);
+      broker_log_top_segfault_jmp_valid = 0;
+      signal (SIGSEGV, SIG_DFL);
     }
   else
     {
-      error = log_top_query (get_cnt, file_list, 0);
+      broker_log_top_segfault_jmp_valid = 0;
+      signal (SIGSEGV, SIG_DFL);
+      fprintf (stderr, "Warning: segmentation fault during processing.\n");
+      error = 0;
     }
+#else
+  if (mode_tran)
+    error = log_top_tran (get_cnt, file_list, 0);
+  else
+    error = log_top_query (get_cnt, file_list, 0);
+#endif
 
   free_file_list (file_list, file_cnt);
 #else
-  if (mode_tran)
-    {
-      error = log_top_tran (argc, argv, arg_start);
-    }
+#if !defined(WINDOWS)
+  if (!log_top_out_merge && arg_start < argc)
+    error = log_top_query_split_paths (argc - arg_start, argv + arg_start);
   else
     {
-      error = log_top_query (argc, argv, arg_start);
+      volatile int mqerr = 0;
+      if (log_top_sigjmp_tran_query_argv (argc, argv, arg_start, &mqerr) == 0)
+	error = (int) mqerr;
+      else
+	error = 0;
     }
+#else
+  if (!log_top_out_merge && arg_start < argc)
+    error = log_top_query_split_paths (argc - arg_start, argv + arg_start);
+  else if (mode_tran)
+    error = log_top_tran (argc, argv, arg_start);
+  else
+    error = log_top_query (argc, argv, arg_start);
+#endif
 #endif
 
   return error;
@@ -296,6 +395,1152 @@ free_file_list (char **list, int size)
 }
 #endif
 
+#if !defined(WINDOWS)
+static int
+log_top_match_pattern (const char *broker_prefix, const char *pattern)
+{
+  size_t plen = strlen (pattern);
+  size_t blen = strlen (broker_prefix);
+  if (plen > 0 && pattern[plen - 1] == '*')
+    {
+      if (plen == 1)
+	return 1;
+      if (blen < plen - 1)
+	return 0;
+      return strncmp (broker_prefix, pattern, plen - 1) == 0 ? 1 : 0;
+    }
+  return (blen == plen && strncmp (broker_prefix, pattern, plen) == 0) ? 1 : 0;
+}
+#endif
+
+static void
+log_top_free_heap_files (char **tab, int n)
+{
+  int j;
+
+  if (tab == NULL || n <= 0)
+    {
+      return;
+    }
+  for (j = 0; j < n; j++)
+    {
+      FREE_MEM (tab[j]);
+    }
+}
+
+static void
+log_top_normalize_path (const char *in, char *out, size_t out_len)
+{
+  const char *cubrid;
+  char buf[BROKER_LOG_TOP_MAX_PATH];
+  size_t i, j;
+
+  if (out_len < 2)
+    return;
+  out[0] = '\0';
+
+  if (in[0] == '/' || (in[0] && in[1] == ':'))
+    {
+      snprintf (out, out_len, "%s", in);
+      for (i = 0; out[i]; i++)
+	if (out[i] == '\\')
+	  out[i] = '/';
+      j = strlen (out);
+      while (j > 1 && out[j - 1] == '/')
+	out[--j] = '\0';
+      return;
+    }
+
+  cubrid = getenv ("CUBRID");
+  if (!cubrid || !cubrid[0])
+    {
+      snprintf (out, out_len, "%s", in);
+      return;
+    }
+  snprintf (buf, sizeof (buf), "%s/%s", cubrid, in[0] == '.' && in[1] == '/' ? in + 2 : in);
+  for (i = 0; buf[i]; i++)
+    if (buf[i] == '\\')
+      buf[i] = '/';
+  while (i > 1 && buf[i - 1] == '/')
+    buf[--i] = '\0';
+  snprintf (out, out_len, "%s", buf);
+}
+
+static int
+log_top_discover_log_dirs (char *out_dirs[], int max_dirs)
+{
+  FILE *fp;
+  char conf_path[BROKER_LOG_TOP_MAX_PATH];
+  char line[BROKER_LOG_TOP_MAX_PATH + 64];
+  const char *env_conf;
+  const char *cubrid;
+  int count = 0;
+  char norm[BROKER_LOG_TOP_MAX_PATH];
+  int i;
+
+  env_conf = getenv ("CUBRID_BROKER_CONF_FILE");
+  if (env_conf && env_conf[0])
+    snprintf (conf_path, sizeof (conf_path), "%s", env_conf);
+  else
+    {
+      cubrid = getenv ("CUBRID");
+      if (!cubrid || !cubrid[0])
+	{
+	  fprintf (stderr, "Error: CUBRID environment variable not set.\n");
+	  return -1;
+	}
+      snprintf (conf_path, sizeof (conf_path), "%s/conf/cubrid_broker.conf", cubrid);
+    }
+
+  fp = fopen (conf_path, "r");
+  if (!fp)
+    {
+      fprintf (stderr, "Error: cannot open broker config: %s\n", conf_path);
+      return -1;
+    }
+
+  while (fgets (line, sizeof (line), fp) && count < max_dirs)
+    {
+      char *val, *p;
+      for (p = line; *p && (*p == ' ' || *p == '\t'); p++)
+	;
+      if (strncasecmp (p, "SLOW_LOG_DIR", 12) == 0
+	  && (p[12] == '=' || p[12] == ' ' || p[12] == '\t'))
+	{
+	  p += 12;
+	}
+      else if (strncasecmp (p, "LOG_DIR", 7) == 0
+	       && (p[7] == '=' || p[7] == ' ' || p[7] == '\t'))
+	{
+	  p += 7;
+	}
+      else
+	{
+	  continue;
+	}
+      while (*p == ' ' || *p == '\t')
+	p++;
+      if (*p != '=')
+	continue;
+      p++;
+      while (*p == ' ' || *p == '\t')
+	p++;
+      val = p;
+      while (*val && *val != '#' && *val != '\n' && *val != '\r')
+	val++;
+      while (val > p && (val[-1] == ' ' || val[-1] == '\t' || val[-1] == '\n' || val[-1] == '\r'))
+	val--;
+      *val = '\0';
+      if (p[0] == '\0')
+	continue;
+      log_top_normalize_path (p, norm, sizeof (norm));
+      if (norm[0] == '\0')
+	continue;
+      for (i = 0; i < count; i++)
+	{
+	  if (strcmp (out_dirs[i], norm) == 0)
+	    {
+	      break;
+	    }
+	}
+      if (i < count)
+	continue;
+      out_dirs[count] = (char *) MALLOC (strlen (norm) + 1);
+      if (out_dirs[count] == NULL)
+	{
+	  continue;
+	}
+      strcpy (out_dirs[count], norm);
+      count++;
+    }
+  fclose (fp);
+  return count;
+}
+
+static int
+log_top_is_pattern (const char *s)
+{
+  return strchr (s, '*') != NULL || strchr (s, '?') != NULL || strchr (s, '[') != NULL;
+}
+
+/* Returns 0 if basename is not a CAS sql/slow log filename; else suffix length (8, 9, 12, or 13). */
+static size_t
+log_top_cas_log_suffix_len (const char *basename)
+{
+  size_t elen;
+
+  if (basename == NULL)
+    {
+      return 0;
+    }
+  elen = strlen (basename);
+  if (elen >= 13 && strcmp (basename + elen - 13, ".slow.log.bak") == 0)
+    {
+      return 13;
+    }
+  if (elen >= 12 && strcmp (basename + elen - 12, ".sql.log.bak") == 0)
+    {
+      return 12;
+    }
+  if (elen >= 9 && strcmp (basename + elen - 9, ".slow.log") == 0)
+    {
+      return 9;
+    }
+  if (elen >= 8 && strcmp (basename + elen - 8, ".sql.log") == 0)
+    {
+      return 8;
+    }
+  return 0;
+}
+
+#if !defined(WINDOWS)
+static int
+log_top_gather_files_exact (const char *broker, const char *dir, char *out_files[], int max_files)
+{
+  DIR *d;
+  struct dirent *e;
+  char path[BROKER_LOG_TOP_MAX_PATH];
+  int n = 0;
+  size_t blen = strlen (broker);
+
+  d = opendir (dir);
+  if (!d)
+    return 0;
+
+  while ((e = readdir (d)) != NULL && n < max_files)
+    {
+      size_t elen = strlen (e->d_name);
+      if (elen < blen + 2)
+	continue;
+      if (strncmp (e->d_name, broker, blen) != 0 || e->d_name[blen] != '_')
+	continue;
+      if (log_top_cas_log_suffix_len (e->d_name) == 0)
+	continue;
+      snprintf (path, sizeof (path), "%s/%s", dir, e->d_name);
+      out_files[n] = (char *) MALLOC (strlen (path) + 1);
+      if (out_files[n])
+	{
+	  strcpy (out_files[n], path);
+	  n++;
+	}
+    }
+  closedir (d);
+  return n;
+}
+
+static int
+log_top_gather_files_pattern (const char *pattern, const char *dir, char *out_files[], int max_files)
+{
+  DIR *d;
+  struct dirent *e;
+  char path[BROKER_LOG_TOP_MAX_PATH];
+  char broker_prefix[256];
+  char *last_underscore;
+  int n = 0;
+  size_t elen;
+
+  d = opendir (dir);
+  if (!d)
+    return 0;
+
+  while ((e = readdir (d)) != NULL && n < max_files)
+    {
+      size_t copy_len;
+      elen = strlen (e->d_name);
+      if (log_top_cas_log_suffix_len (e->d_name) != 8)
+	continue;
+      copy_len = elen - 8;
+      if (copy_len >= sizeof (broker_prefix))
+	copy_len = sizeof (broker_prefix) - 1;
+      memcpy (broker_prefix, e->d_name, copy_len);
+      broker_prefix[copy_len] = '\0';
+      last_underscore = strrchr (broker_prefix, '_');
+      if (!last_underscore)
+	continue;
+      *last_underscore = '\0';
+      if (!log_top_match_pattern (broker_prefix, pattern))
+	continue;
+      snprintf (path, sizeof (path), "%s/%s", dir, e->d_name);
+      out_files[n] = (char *) MALLOC (strlen (path) + 1);
+      if (out_files[n])
+	{
+	  strcpy (out_files[n], path);
+	  n++;
+	}
+    }
+  closedir (d);
+  return n;
+}
+
+static int
+log_top_gather_files_pattern_suffix (const char *pattern, const char *dir, const char *suffix, size_t suffix_len,
+				   char *out_files[], int max_files)
+{
+  DIR *d;
+  struct dirent *e;
+  char path[BROKER_LOG_TOP_MAX_PATH];
+  char broker_prefix[256];
+  char *last_underscore;
+  int n = 0;
+  size_t elen;
+
+  d = opendir (dir);
+  if (!d)
+    return 0;
+
+  while ((e = readdir (d)) != NULL && n < max_files)
+    {
+      elen = strlen (e->d_name);
+      if (elen <= suffix_len)
+	continue;
+      if (strcmp (e->d_name + elen - suffix_len, suffix) != 0)
+	continue;
+      {
+	size_t copy_len = elen - suffix_len;
+	if (copy_len >= sizeof (broker_prefix))
+	  copy_len = sizeof (broker_prefix) - 1;
+	memcpy (broker_prefix, e->d_name, copy_len);
+	broker_prefix[copy_len] = '\0';
+      }
+      last_underscore = strrchr (broker_prefix, '_');
+      if (!last_underscore)
+	continue;
+      *last_underscore = '\0';
+      if (!log_top_match_pattern (broker_prefix, pattern))
+	continue;
+      snprintf (path, sizeof (path), "%s/%s", dir, e->d_name);
+      out_files[n] = (char *) MALLOC (strlen (path) + 1);
+      if (out_files[n])
+	{
+	  strcpy (out_files[n], path);
+	  n++;
+	}
+    }
+  closedir (d);
+  return n;
+}
+
+static int
+log_top_gather_files_pattern_all (const char *pattern, const char *dir, char *out_files[], int max_files)
+{
+  int n = 0;
+  n += log_top_gather_files_pattern_suffix (pattern, dir, ".sql.log", 8, out_files, max_files);
+  n += log_top_gather_files_pattern_suffix (pattern, dir, ".sql.log.bak", 12, out_files + n, max_files - n);
+  n += log_top_gather_files_pattern_suffix (pattern, dir, ".slow.log", 9, out_files + n, max_files - n);
+  n += log_top_gather_files_pattern_suffix (pattern, dir, ".slow.log.bak", 13, out_files + n, max_files - n);
+  return n;
+}
+#else
+static int
+log_top_gather_files_exact (const char *broker, const char *dir, char *out_files[], int max_files)
+{
+  HANDLE h;
+  WIN32_FIND_DATAA fd;
+  char pattern[BROKER_LOG_TOP_MAX_PATH];
+  char path[BROKER_LOG_TOP_MAX_PATH];
+  int n = 0;
+  const char *suffixes[] = { "*.sql.log", "*.sql.log.bak", "*.slow.log", "*.slow.log.bak", NULL };
+
+  for (int i = 0; suffixes[i] && n < max_files; i++)
+    {
+      snprintf (pattern, sizeof (pattern), "%s\\%s_%s", dir, broker, suffixes[i]);
+      h = FindFirstFileA (pattern, &fd);
+      if (h == INVALID_HANDLE_VALUE)
+	continue;
+      do
+	{
+	  if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+	    continue;
+	  snprintf (path, sizeof (path), "%s\\%s", dir, fd.cFileName);
+	  out_files[n] = (char *) MALLOC (strlen (path) + 1);
+	  if (out_files[n])
+	    {
+	      strcpy (out_files[n], path);
+	      n++;
+	    }
+	}
+      while (FindNextFileA (h, &fd) && n < max_files);
+      FindClose (h);
+    }
+  return n;
+}
+
+static int
+log_top_gather_files_pattern (const char *pattern, const char *dir, char *out_files[], int max_files)
+{
+  HANDLE h;
+  WIN32_FIND_DATAA fd;
+  char search[BROKER_LOG_TOP_MAX_PATH];
+  char path[BROKER_LOG_TOP_MAX_PATH];
+  int n = 0;
+  size_t plen = strlen (pattern);
+
+  snprintf (search, sizeof (search), "%s\\%s_*.sql.log", dir, pattern);
+  h = FindFirstFileA (search, &fd);
+  if (h == INVALID_HANDLE_VALUE)
+    return 0;
+  do
+    {
+      if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+	continue;
+      snprintf (path, sizeof (path), "%s\\%s", dir, fd.cFileName);
+      out_files[n] = (char *) MALLOC (strlen (path) + 1);
+      if (out_files[n])
+	{
+	  strcpy (out_files[n], path);
+	  n++;
+	}
+    }
+  while (FindNextFileA (h, &fd) && n < max_files);
+  FindClose (h);
+  return n;
+}
+
+static int
+log_top_gather_files_pattern_all (const char *pattern, const char *dir, char *out_files[], int max_files)
+{
+  int n = 0;
+  n += log_top_gather_files_pattern (pattern, dir, out_files, max_files);
+  /* Windows: log_top_gather_files_pattern only gets .sql.log; add other suffixes via FindFirstFile */
+  {
+    HANDLE h;
+    WIN32_FIND_DATAA fd;
+    char search[BROKER_LOG_TOP_MAX_PATH];
+    char path[BROKER_LOG_TOP_MAX_PATH];
+    snprintf (search, sizeof (search), "%s\\%s_*.sql.log.bak", dir, pattern);
+    h = FindFirstFileA (search, &fd);
+    if (h != INVALID_HANDLE_VALUE)
+      {
+	do
+	  {
+	    if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+	      continue;
+	    if (n >= max_files)
+	      break;
+	    snprintf (path, sizeof (path), "%s\\%s", dir, fd.cFileName);
+	    out_files[n] = (char *) MALLOC (strlen (path) + 1);
+	    if (out_files[n])
+	      strcpy (out_files[n], path), n++;
+	  }
+	while (FindNextFileA (h, &fd));
+	FindClose (h);
+      }
+    snprintf (search, sizeof (search), "%s\\%s_*.slow.log", dir, pattern);
+    h = FindFirstFileA (search, &fd);
+    if (h != INVALID_HANDLE_VALUE)
+      {
+	do
+	  {
+	    if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+	      continue;
+	    if (n >= max_files)
+	      break;
+	    snprintf (path, sizeof (path), "%s\\%s", dir, fd.cFileName);
+	    out_files[n] = (char *) MALLOC (strlen (path) + 1);
+	    if (out_files[n])
+	      strcpy (out_files[n], path), n++;
+	  }
+	while (FindNextFileA (h, &fd));
+	FindClose (h);
+      }
+    snprintf (search, sizeof (search), "%s\\%s_*.slow.log.bak", dir, pattern);
+    h = FindFirstFileA (search, &fd);
+    if (h != INVALID_HANDLE_VALUE)
+      {
+	do
+	  {
+	    if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+	      continue;
+	    if (n >= max_files)
+	      break;
+	    snprintf (path, sizeof (path), "%s\\%s", dir, fd.cFileName);
+	    out_files[n] = (char *) MALLOC (strlen (path) + 1);
+	    if (out_files[n])
+	      strcpy (out_files[n], path), n++;
+	  }
+	while (FindNextFileA (h, &fd));
+	FindClose (h);
+      }
+  }
+  return n;
+}
+
+static int
+log_top_get_brokers_from_dir (const char *dir, char *out_brokers[], int max_brokers)
+{
+  HANDLE h;
+  WIN32_FIND_DATAA fd;
+  char pattern[BROKER_LOG_TOP_MAX_PATH];
+  char seen[256][256];
+  char broker[256];
+  char *last_underscore;
+  size_t elen, suffix_len;
+  int nseen = 0;
+  int n = 0;
+  int i;
+  const char *patterns[] =
+    { "*_*.sql.log", "*_*.sql.log.bak", "*_*.slow.log", "*_*.slow.log.bak", NULL };
+
+  for (i = 0; patterns[i] && n < max_brokers; i++)
+    {
+      snprintf (pattern, sizeof (pattern), "%s\\%s", dir, patterns[i]);
+      h = FindFirstFileA (pattern, &fd);
+      if (h == INVALID_HANDLE_VALUE)
+	continue;
+      do
+	{
+	  if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+	    continue;
+	  elen = strlen (fd.cFileName);
+	  suffix_len = log_top_cas_log_suffix_len (fd.cFileName);
+	  if (suffix_len == 0)
+	    continue;
+	  if (elen <= suffix_len)
+	    continue;
+	  {
+	    size_t copy_len = elen - suffix_len;
+	    if (copy_len >= sizeof (broker))
+	      copy_len = sizeof (broker) - 1;
+	    memcpy (broker, fd.cFileName, copy_len);
+	    broker[copy_len] = '\0';
+	  }
+	  last_underscore = strrchr (broker, '_');
+	  if (!last_underscore || (size_t) (last_underscore - broker) >= sizeof (broker) - 1)
+	    continue;
+	  *last_underscore = '\0';
+	  {
+	    int j;
+	    for (j = 0; j < nseen; j++)
+	      if (strcmp (seen[j], broker) == 0)
+		break;
+	    if (j < nseen)
+	      continue;
+	  }
+	  if (nseen < 256)
+	    {
+	      snprintf (seen[nseen], sizeof (seen[0]), "%.255s", broker);
+	      nseen++;
+	    }
+	  if (n >= max_brokers)
+	    continue;
+	  out_brokers[n] = (char *) MALLOC (strlen (broker) + 1);
+	  if (out_brokers[n])
+	    {
+	      strcpy (out_brokers[n], broker);
+	      n++;
+	    }
+	}
+      while (FindNextFileA (h, &fd));
+      FindClose (h);
+    }
+  return n;
+}
+#endif
+
+#if !defined(WINDOWS)
+static int
+log_top_get_brokers_from_dir (const char *dir, char *out_brokers[], int max_brokers)
+{
+  DIR *d;
+  struct dirent *e;
+  char seen[256][256];
+  int nseen = 0;
+  int n = 0;
+  int i;
+  char broker[256];
+  char *last_underscore;
+  size_t suffix_len;
+
+  d = opendir (dir);
+  if (!d)
+    return 0;
+
+  while ((e = readdir (d)) != NULL && n < max_brokers)
+    {
+      size_t elen = strlen (e->d_name);
+      if (elen < 4)
+	continue;
+      suffix_len = log_top_cas_log_suffix_len (e->d_name);
+      if (suffix_len == 0)
+	continue;
+      {
+	size_t copy_len = elen - suffix_len;
+	if (copy_len >= sizeof (broker))
+	  copy_len = sizeof (broker) - 1;
+	memcpy (broker, e->d_name, copy_len);
+	broker[copy_len] = '\0';
+      }
+      last_underscore = strrchr (broker, '_');
+      if (!last_underscore || (size_t) (last_underscore - broker) >= sizeof (broker) - 1)
+	continue;
+      *last_underscore = '\0';
+      for (i = 0; i < nseen; i++)
+	if (strcmp (seen[i], broker) == 0)
+	  break;
+      if (i < nseen)
+	continue;
+      if (nseen < 256)
+	{
+	  snprintf (seen[nseen], sizeof (seen[0]), "%.255s", broker);
+	  nseen++;
+	}
+      if (n >= max_brokers)
+	continue;
+      out_brokers[n] = (char *) MALLOC (strlen (broker) + 1);
+      if (out_brokers[n])
+	{
+	  strcpy (out_brokers[n], broker);
+	  n++;
+	}
+    }
+  closedir (d);
+  return n;
+}
+#endif
+
+static void
+log_top_broker_to_safe (const char *name, char *out, size_t out_len)
+{
+  size_t i, j;
+  if (out_len < 2)
+    return;
+  for (i = 0, j = 0; name[i] && j < out_len - 1; i++)
+    {
+      if (name[i] == '*' || name[i] == '?' || name[i] == '[')
+	out[j++] = '_';
+      else
+	out[j++] = name[i];
+    }
+  out[j] = '\0';
+}
+
+#if !defined(WINDOWS)
+static int
+log_top_mkdir_out (const char *path)
+{
+  return mkdir (path, 0755);
+}
+#else
+static int
+log_top_mkdir_out (const char *path)
+{
+  return _mkdir (path);
+}
+#endif
+
+static int
+log_top_multi_dir_is_conf_multi (void)
+{
+  return log_top_multi_explicit_dirs_flag != 0
+    || strcasecmp (log_top_multi_log_dir, "LOG_DIR") == 0;
+}
+
+static int
+log_top_fill_parent_out_base (char *parent_out_base, size_t parent_sz)
+{
+  time_t now;
+  struct tm tm_buf;
+
+  memset (&tm_buf, 0, sizeof (tm_buf));
+  const char *env_out_base = getenv ("OUT_BASE");
+
+  if (env_out_base && env_out_base[0])
+    {
+      snprintf (parent_out_base, parent_sz, "%s", env_out_base);
+      return 0;
+    }
+  now = time (NULL);
+#if !defined(WINDOWS)
+  if (localtime_r (&now, &tm_buf) == NULL)
+#else
+  if (localtime_s (&tm_buf, &now) != 0)
+#endif
+    {
+      fprintf (stderr, "Error: cannot get local time\n");
+      return -1;
+    }
+  strftime (parent_out_base, parent_sz, "broker_log_top_%y%m%d_%H%M", &tm_buf);
+  return 0;
+}
+
+/* sigsetjmp로 감싼 log_top_tran / log_top_query — 원본 main(Unix)과 동일한 호출, 복구만 추가 */
+static int
+log_top_sigjmp_tran_query_inner (int nfiles, char **files, volatile int *qerr)
+{
+#if !defined(WINDOWS)
+  if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
+    {
+      broker_log_top_segfault_jmp_valid = 1;
+      signal (SIGSEGV, broker_log_top_segfault_handler);
+      if (mode_tran)
+	*qerr = log_top_tran (nfiles, files, 0);
+      else
+	*qerr = log_top_query (nfiles, files, 0);
+      broker_log_top_segfault_jmp_valid = 0;
+      signal (SIGSEGV, SIG_DFL);
+      return 0;
+    }
+  broker_log_top_segfault_jmp_valid = 0;
+  signal (SIGSEGV, SIG_DFL);
+  fprintf (stderr, "Warning: segmentation fault during processing, skipping.\n");
+  *qerr = 0;
+  return 1;
+#else
+  if (mode_tran)
+    *qerr = log_top_tran (nfiles, files, 0);
+  else
+    *qerr = log_top_query (nfiles, files, 0);
+  return 0;
+#endif
+}
+
+/* broker_log_top.c_old 의 Unix main 과 동일하게 (argc,argv,arg_start) 로 tran/query 호출 */
+static int
+log_top_sigjmp_tran_query_argv (int argc, char **argv, int arg_start, volatile int *qerr)
+{
+#if !defined(WINDOWS)
+  if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
+    {
+      broker_log_top_segfault_jmp_valid = 1;
+      signal (SIGSEGV, broker_log_top_segfault_handler);
+      if (mode_tran)
+	*qerr = log_top_tran (argc, argv, arg_start);
+      else
+	*qerr = log_top_query (argc, argv, arg_start);
+      broker_log_top_segfault_jmp_valid = 0;
+      signal (SIGSEGV, SIG_DFL);
+      return 0;
+    }
+  broker_log_top_segfault_jmp_valid = 0;
+  signal (SIGSEGV, SIG_DFL);
+  fprintf (stderr, "Warning: segmentation fault during processing.\n");
+  *qerr = 0;
+  return 1;
+#else
+  if (mode_tran)
+    *qerr = log_top_tran (argc, argv, arg_start);
+  else
+    *qerr = log_top_query (argc, argv, arg_start);
+  return 0;
+#endif
+}
+
+static void
+log_top_multi_run_one_broker (const char *parent_out_base, const char *subdir_for_mkdir,
+			      int use_safe_mkdir, const char *stdout_label, char **files, int nfiles, char *saved_cwd,
+			      volatile int *error_io)
+{
+  char subdir[BROKER_LOG_TOP_MAX_PATH];
+  char broker_safe[256];
+  const char *mkcomp = subdir_for_mkdir;
+  volatile int i;
+  volatile int qerr = 0;
+
+  if (use_safe_mkdir)
+    {
+      log_top_broker_to_safe (subdir_for_mkdir, broker_safe, sizeof (broker_safe));
+      mkcomp = broker_safe;
+    }
+  snprintf (subdir, sizeof (subdir), "%.1023s/%.255s", parent_out_base, mkcomp);
+  if (log_top_mkdir_out (subdir) < 0 && errno != EEXIST)
+    {
+      fprintf (stderr, "Error: cannot create output directory: %s\n", subdir);
+      log_top_free_heap_files (files, nfiles);
+      *error_io = -1;
+      return;
+    }
+  if (LOG_TOP_CHDIR (subdir) < 0)
+    {
+      fprintf (stderr, "Error: cannot chdir to %s\n", subdir);
+      log_top_free_heap_files (files, nfiles);
+      *error_io = -1;
+      return;
+    }
+  fprintf (stdout, "%s\n", stdout_label);
+  query_info_reset ();
+  if (log_top_sigjmp_tran_query_inner (nfiles, files, &qerr) == 0)
+    {
+      LOG_TOP_CHDIR ((char *) saved_cwd);
+      for (i = 0; i < nfiles; i++)
+	FREE_MEM (files[i]);
+      if (qerr != 0)
+	*error_io = qerr;
+    }
+  else
+    {
+      LOG_TOP_CHDIR ((char *) saved_cwd);
+      log_top_free_heap_files (files, nfiles);
+    }
+}
+
+static int
+log_top_multi_run (void)
+{
+  char *dirs[BROKER_LOG_TOP_MAX_DIRS];
+  volatile char **files = NULL;
+  char norm[BROKER_LOG_TOP_MAX_PATH];
+  char parent_out_base[BROKER_LOG_TOP_MAX_PATH];
+  char cwd_buf[BROKER_LOG_TOP_MAX_PATH];
+  volatile char *saved_cwd = NULL;
+  volatile int ndirs = 0;
+  volatile int d = 0, i = 0;
+  volatile int nfiles = 0;
+  int error = 0;
+  struct stat st;
+
+  saved_cwd = getcwd (cwd_buf, sizeof (cwd_buf));
+  if (saved_cwd == NULL)
+    {
+      fprintf (stderr, "Error: cannot get current directory\n");
+      return -1;
+    }
+
+  /* 배치 모드는 안정성이 우선: MT_MODE 사용 시에도 단일 스레드로 실행 */
+  broker_log_top_force_single_thread = 1;
+
+  if (strcmp (log_top_multi_log_dir, ".") == 0 && log_top_multi_broker_name != NULL)
+    {
+      int nfiles;
+      int j;
+      volatile int qerr_dot = 0;
+
+      files = (volatile char **) calloc (BROKER_LOG_TOP_MAX_FILES, sizeof (char *));
+      if (files == NULL)
+	{
+	  fprintf (stderr, "Error: memory allocation failed\n");
+	  return -1;
+	}
+      nfiles = log_top_is_pattern (log_top_multi_broker_name)
+	? log_top_gather_files_pattern_all (log_top_multi_broker_name, cwd_buf, (char **) files,
+					    BROKER_LOG_TOP_MAX_FILES)
+	: log_top_gather_files_exact (log_top_multi_broker_name, cwd_buf, (char **) files,
+				      BROKER_LOG_TOP_MAX_FILES);
+      if (nfiles == 0)
+	{
+	  fprintf (stderr, "Info: no files for broker '%s' in current directory.\n", log_top_multi_broker_name);
+	  free ((void *) files);
+	  return -1;
+	}
+      fprintf (stdout, "%s\n", log_top_multi_broker_name);
+      query_info_reset ();
+      if (log_top_sigjmp_tran_query_inner (nfiles, (char **) files, &qerr_dot) == 0)
+	error = (int) qerr_dot;
+      else
+	error = 0;
+      for (j = 0; j < nfiles; j++)
+	{
+	  char *fj = (char *) files[j];
+
+	  FREE_MEM (fj);
+	  files[j] = fj;
+	}
+      free ((void *) files);
+      return error;
+    }
+
+  if (log_top_fill_parent_out_base (parent_out_base, sizeof (parent_out_base)) < 0)
+    {
+      return -1;
+    }
+
+  if (log_top_mkdir_out (parent_out_base) < 0 && errno != EEXIST)
+    {
+      fprintf (stderr, "Error: cannot create output directory: %s\n", parent_out_base);
+      return -1;
+    }
+
+  if (log_top_multi_explicit_dirs_flag)
+    {
+      ndirs = log_top_multi_explicit_ndirs;
+      for (d = 0; d < ndirs; d++)
+	{
+	  dirs[d] = log_top_multi_explicit_dirs_buf[d];
+	}
+    }
+  else if (strcasecmp (log_top_multi_log_dir, "LOG_DIR") == 0)
+    {
+      ndirs = log_top_discover_log_dirs (dirs, BROKER_LOG_TOP_MAX_DIRS);
+      if (ndirs <= 0)
+	{
+	  fprintf (stderr, "Error: no valid LOG_DIR or SLOW_LOG_DIR found in cubrid_broker.conf\n");
+	  return -1;
+	}
+    }
+  else
+    {
+      log_top_normalize_path (log_top_multi_log_dir, norm, sizeof (norm));
+      if (stat (norm, &st) < 0 || !S_ISDIR (st.st_mode))
+	{
+	  fprintf (stderr, "Error: directory does not exist: %s\n", norm);
+	  return -1;
+	}
+      dirs[0] = (char *) MALLOC (strlen (norm) + 1);
+      if (!dirs[0])
+	return -1;
+      strcpy (dirs[0], norm);
+      ndirs = 1;
+    }
+
+  files = (volatile char **) calloc (BROKER_LOG_TOP_MAX_FILES, sizeof (char *));
+  if (files == NULL)
+    {
+      fprintf (stderr, "Error: memory allocation failed\n");
+      if (log_top_multi_dir_is_conf_multi ())
+	{
+	  for (d = 0; d < ndirs; d++)
+	    {
+	      FREE_MEM (dirs[d]);
+	    }
+	}
+      else if (dirs[0] != NULL)
+	{
+	  FREE_MEM (dirs[0]);
+	}
+      return -1;
+    }
+
+  if (log_top_multi_broker_name)
+    {
+      for (d = 0; d < ndirs && !error; d++)
+	{
+	  if (log_top_is_pattern (log_top_multi_broker_name))
+	    {
+	      nfiles = log_top_gather_files_pattern_all (log_top_multi_broker_name, dirs[d], (char **) files,
+							 BROKER_LOG_TOP_MAX_FILES);
+	      if (nfiles == 0)
+		{
+		  fprintf (stderr, "Info: [%s] no files matching pattern '%s', skipping.\n", dirs[d],
+			   log_top_multi_broker_name);
+		  goto next_dir;
+		}
+	      log_top_multi_run_one_broker (parent_out_base, log_top_multi_broker_name, 1,
+					   log_top_multi_broker_name, (char **) files, nfiles, (char *) saved_cwd,
+					   &error);
+	      nfiles = 0;
+	    }
+	  else
+	    {
+	      nfiles = log_top_gather_files_exact (log_top_multi_broker_name, dirs[d], (char **) files,
+						   BROKER_LOG_TOP_MAX_FILES);
+	      if (nfiles == 0)
+		{
+		  fprintf (stderr, "Info: [%s] no files for broker '%s', skipping.\n", dirs[d], log_top_multi_broker_name);
+		  goto next_dir;
+		}
+	      log_top_multi_run_one_broker (parent_out_base, log_top_multi_broker_name, 0,
+					   log_top_multi_broker_name, (char **) files, nfiles, (char *) saved_cwd,
+					   &error);
+	      nfiles = 0;
+	    }
+	next_dir:
+	  if (log_top_multi_dir_is_conf_multi ())
+	    {
+	      FREE_MEM (dirs[d]);
+	      dirs[d] = NULL;
+	    }
+	}
+    }
+  else
+    {
+      char *all_brokers[512];
+      char **all_files;
+      volatile int total_brokers = 0;
+      int bi, dir_idx, k;
+
+      memset (all_brokers, 0, sizeof (all_brokers));
+
+      all_files = (char **) calloc (BROKER_LOG_TOP_MAX_FILES, sizeof (char *));
+      if (all_files == NULL)
+	{
+	  fprintf (stderr, "Error: memory allocation failed\n");
+	  if (log_top_multi_dir_is_conf_multi ())
+	    {
+	      for (d = 0; d < ndirs; d++)
+		{
+		  FREE_MEM (dirs[d]);
+		}
+	    }
+	  else if (dirs[0] != NULL)
+	    {
+	      FREE_MEM (dirs[0]);
+	    }
+	  free ((void *) files);
+	  return -1;
+	}
+
+      for (dir_idx = 0; dir_idx < ndirs && total_brokers < 512; dir_idx++)
+	{
+	  char *dir_brokers[512];
+	  int dir_nb;
+
+	  memset (dir_brokers, 0, sizeof (dir_brokers));
+	  if (dirs[dir_idx] == NULL)
+	    continue;
+	  dir_nb = log_top_get_brokers_from_dir (dirs[dir_idx], dir_brokers, 512);
+
+	  for (bi = 0; bi < dir_nb && total_brokers < 512; bi++)
+	    {
+	      int found = 0;
+	      if (dir_brokers[bi] == NULL)
+		continue;
+	      for (k = 0; k < total_brokers; k++)
+		{
+		  if (all_brokers[k] != NULL && strcmp (all_brokers[k], dir_brokers[bi]) == 0)
+		    {
+		      found = 1;
+		      FREE_MEM (dir_brokers[bi]);
+		      dir_brokers[bi] = NULL;
+		      break;
+		    }
+		}
+	      if (!found)
+		{
+		  all_brokers[total_brokers] = dir_brokers[bi];
+		  total_brokers++;
+		}
+	    }
+	  for (; bi < dir_nb; bi++)
+	    {
+	      if (dir_brokers[bi] != NULL)
+		{
+		  FREE_MEM (dir_brokers[bi]);
+		  dir_brokers[bi] = NULL;
+		}
+	    }
+	}
+
+      if (total_brokers == 0)
+	{
+	  fprintf (stderr, "Info: no brokers found in any directory.\n");
+	  if (log_top_multi_dir_is_conf_multi ())
+	    {
+	      for (d = 0; d < ndirs; d++)
+		{
+		  FREE_MEM (dirs[d]);
+		  dirs[d] = NULL;
+		}
+	    }
+	  else if (dirs[0] != NULL)
+	    {
+	      FREE_MEM (dirs[0]);
+	      dirs[0] = NULL;
+	    }
+	  free (all_files);
+	  free ((void *) files);
+	  return 0;
+	}
+
+      for (i = 0; i < total_brokers && !error; i++)
+	{
+	  volatile int total_files = 0;
+	  int dir_idx;
+	  int num_files = 0;
+
+	  memset (all_files, 0, sizeof (char *) * BROKER_LOG_TOP_MAX_FILES);
+
+	  if (all_brokers[i] == NULL)
+	    continue;
+
+	  for (dir_idx = 0; dir_idx < ndirs && total_files < BROKER_LOG_TOP_MAX_FILES; dir_idx++)
+	    {
+	      if (dirs[dir_idx] == NULL)
+		continue;
+	      int dir_files = log_top_gather_files_exact (all_brokers[i], dirs[dir_idx],
+							all_files + total_files,
+							BROKER_LOG_TOP_MAX_FILES - total_files);
+	      total_files += dir_files;
+	    }
+	  num_files = total_files;
+
+	  if (total_files == 0)
+	    {
+	      FREE_MEM (all_brokers[i]);
+	      all_brokers[i] = NULL;
+	      continue;
+	    }
+
+	  log_top_multi_run_one_broker (parent_out_base, all_brokers[i], 0, all_brokers[i], all_files, num_files,
+				       (char *) saved_cwd, &error);
+	  memset (all_files, 0, sizeof (char *) * BROKER_LOG_TOP_MAX_FILES);
+	  FREE_MEM (all_brokers[i]);
+	  all_brokers[i] = NULL;
+	}
+
+      for (k = 0; k < total_brokers; k++)
+	{
+	  if (all_brokers[k] != NULL)
+	    {
+	      FREE_MEM (all_brokers[k]);
+	      all_brokers[k] = NULL;
+	    }
+	}
+      free (all_files);
+    }
+
+  if (files != NULL)
+    {
+      free ((void *) files);
+      files = NULL;
+    }
+
+#if !defined(WINDOWS)
+  if (sigsetjmp (broker_log_top_segfault_jmp, 1) == 0)
+    {
+      broker_log_top_segfault_jmp_valid = 1;
+      signal (SIGSEGV, broker_log_top_segfault_handler);
+      if (log_top_multi_dir_is_conf_multi ())
+	{
+	  for (d = 0; d < ndirs; d++)
+	    {
+	      if (dirs[d] != NULL)
+		{
+		  FREE_MEM (dirs[d]);
+		  dirs[d] = NULL;
+		}
+	    }
+	}
+      else
+	{
+	  if (dirs[0] != NULL)
+	    {
+	      FREE_MEM (dirs[0]);
+	      dirs[0] = NULL;
+	    }
+	}
+      broker_log_top_segfault_jmp_valid = 0;
+      signal (SIGSEGV, SIG_DFL);
+    }
+  else
+    {
+      broker_log_top_segfault_jmp_valid = 0;
+      signal (SIGSEGV, SIG_DFL);
+      fprintf (stderr, "Warning: segmentation fault during final cleanup, skipping.\n");
+    }
+#else
+  if (log_top_multi_dir_is_conf_multi ())
+    {
+      for (d = 0; d < ndirs; d++)
+	{
+	  if (dirs[d] != NULL)
+	    {
+	      FREE_MEM (dirs[d]);
+	      dirs[d] = NULL;
+	    }
+	}
+    }
+  else
+    {
+      if (dirs[0] != NULL)
+	{
+	  FREE_MEM (dirs[0]);
+	  dirs[0] = NULL;
+	}
+    }
+#endif
+
+  return error;
+}
+
 int
 get_file_offset (char *filename, long *start_offset, long *end_offset)
 {
@@ -352,25 +1597,37 @@ log_top_query (int argc, char *argv[], int arg_start)
   int error = 0;
   long start_offset, end_offset;
 #ifdef MT_MODE
+  int use_mt = 0;
   T_THREAD thrid;
   int j;
 #endif
 
 #ifdef MT_MODE
-  query_info_mutex_init ();
+  if (!broker_log_top_force_single_thread && num_thread > 1)
+    {
+      use_mt = 1;
+    }
+  if (use_mt)
+    {
+      query_info_mutex_init ();
+    }
 #endif
 
 #ifdef MT_MODE
-  work_msg = MALLOC (sizeof (T_WORK_MSG) * num_thread);
-  if (work_msg == NULL)
+  if (use_mt)
     {
-      fprintf (stderr, "malloc error\n");
-      return -1;
-    }
-  memset (work_msg, 0, sizeof (T_WORK_MSG *) * num_thread);
+      process_flag = 1;
+      work_msg = MALLOC (sizeof (T_WORK_MSG) * num_thread);
+      if (work_msg == NULL)
+	{
+	  fprintf (stderr, "malloc error\n");
+	  return -1;
+	}
+      memset (work_msg, 0, sizeof (T_WORK_MSG) * num_thread);
 
-  for (i = 0; i < num_thread; i++)
-    THREAD_BEGIN (thrid, thr_main, (void *) i);
+      for (i = 0; i < num_thread; i++)
+	THREAD_BEGIN (thrid, thr_main, (void *) i);
+    }
 #endif
 
   for (i = arg_start; i < argc; i++)
@@ -398,21 +1655,33 @@ log_top_query (int argc, char *argv[], int arg_start)
 	}
 
 #ifdef MT_MODE
-      while (1)
+      if (use_mt)
 	{
-	  for (j = 0; j < num_thread; j++)
+	  while (1)
 	    {
-	      if (work_msg[j].filename == NULL)
+	      for (j = 0; j < num_thread; j++)
 		{
-		  work_msg[j].fp = fp;
-		  work_msg[j].filename = filename;
-		  break;
+		  if (work_msg[j].filename == NULL)
+		    {
+		      work_msg[j].fp = fp;
+		      work_msg[j].filename = filename;
+		      break;
+		    }
 		}
+	      if (j == num_thread)
+		SLEEP_MILISEC (1, 0);
+	      else
+		break;
 	    }
-	  if (j == num_thread)
-	    SLEEP_MILISEC (1, 0);
-	  else
-	    break;
+	}
+      else
+	{
+	  error = log_top (fp, filename, start_offset, end_offset);
+	  fclose (fp);
+	  if (error == LT_INVAILD_VERSION)
+	    {
+	      return error;
+	    }
 	}
 #else
       error = log_top (fp, filename, start_offset, end_offset);
@@ -425,7 +1694,10 @@ log_top_query (int argc, char *argv[], int arg_start)
     }
 
 #ifdef MT_MODE
-  process_flag = 0;
+  if (use_mt)
+    {
+      process_flag = 0;
+    }
 #endif
 
   if (sql_info_file != NULL)
@@ -441,6 +1713,227 @@ log_top_query (int argc, char *argv[], int arg_start)
   query_info_print ();
 
   return 0;
+}
+
+typedef struct lt_split_sort lt_split_sort;
+struct lt_split_sort
+{
+  char *path;
+  char key[256];
+};
+
+static int
+lt_split_sort_cmp (const void *a, const void *b)
+{
+  return strcmp (((const lt_split_sort *) a)->key, ((const lt_split_sort *) b)->key);
+}
+
+static int
+log_top_basename_is_cas_sql_slow_log (const char *basename)
+{
+  return log_top_cas_log_suffix_len (basename) != 0;
+}
+
+static int
+log_top_path_is_cas_sql_slow_log (const char *path)
+{
+  const char *base = path;
+  const char *p;
+
+  p = strrchr (path, '/');
+#if defined(WINDOWS)
+  {
+    const char *p2 = strrchr (path, '\\');
+    if (p2 != NULL && (p == NULL || p2 > p))
+      p = p2;
+  }
+#endif
+  if (p != NULL)
+    base = p + 1;
+  return log_top_basename_is_cas_sql_slow_log (base);
+}
+
+static int
+log_top_broker_key_from_basename (const char *basename, char *out, size_t outlen)
+{
+  size_t elen = strlen (basename);
+  size_t suffix_len;
+  char tmp[512];
+  char *lastu;
+
+  suffix_len = log_top_cas_log_suffix_len (basename);
+  if (suffix_len == 0)
+    {
+      snprintf (out, outlen, "%s", basename);
+      return -1;
+    }
+  if (elen <= suffix_len)
+    {
+      snprintf (out, outlen, "%s", basename);
+      return -1;
+    }
+  if (elen - suffix_len >= sizeof (tmp))
+    {
+      snprintf (out, outlen, "%s", basename);
+      return -1;
+    }
+  memcpy (tmp, basename, elen - suffix_len);
+  tmp[elen - suffix_len] = '\0';
+  lastu = strrchr (tmp, '_');
+  if (lastu == NULL || lastu == tmp)
+    {
+      snprintf (out, outlen, "%s", basename);
+      return -1;
+    }
+  *lastu = '\0';
+  snprintf (out, outlen, "%.255s", tmp);
+  return 0;
+}
+
+static void
+log_top_broker_key_from_path (const char *path, char *out, size_t outlen)
+{
+  const char *base = path;
+  const char *p;
+
+  p = strrchr (path, '/');
+#if defined(WINDOWS)
+  {
+    const char *p2 = strrchr (path, '\\');
+    if (p2 != NULL && (p == NULL || p2 > p))
+      p = p2;
+  }
+#endif
+  if (p != NULL)
+    base = p + 1;
+  (void) log_top_broker_key_from_basename (base, out, outlen);
+}
+
+static int
+log_top_query_split_paths (int nfiles, char **paths)
+{
+  lt_split_sort *tab = NULL;
+  char parent_out_base[BROKER_LOG_TOP_MAX_PATH];
+  char cwd_buf[BROKER_LOG_TOP_MAX_PATH];
+  char *saved_cwd;
+  char subdir[BROKER_LOG_TOP_MAX_PATH];
+  char broker_safe[256];
+  int i, k;
+  int nvalid;
+  volatile int error = 0;
+  int g_start, g_end;
+  volatile char **argv_small = NULL;
+
+  if (nfiles <= 0 || paths == NULL)
+    return -1;
+
+  nvalid = 0;
+  for (i = 0; i < nfiles; i++)
+    {
+      if (log_top_path_is_cas_sql_slow_log (paths[i]))
+	nvalid++;
+      else
+	fprintf (stderr, "Info: skipping (not a CAS sql/slow log): %s\n", paths[i]);
+    }
+  if (nvalid == 0)
+    {
+      fprintf (stderr,
+	       "Error: no CAS sql/slow log files (.sql.log, .sql.log.bak, .slow.log, .slow.log.bak) in arguments.\n");
+      return -1;
+    }
+
+  tab = (lt_split_sort *) calloc ((size_t) nvalid, sizeof (lt_split_sort));
+  if (tab == NULL)
+    {
+      fprintf (stderr, "Error: memory allocation failed\n");
+      return -1;
+    }
+  for (i = 0, k = 0; i < nfiles; i++)
+    {
+      if (!log_top_path_is_cas_sql_slow_log (paths[i]))
+	continue;
+      tab[k].path = paths[i];
+      log_top_broker_key_from_path (paths[i], tab[k].key, sizeof (tab[k].key));
+      k++;
+    }
+  qsort (tab, (size_t) nvalid, sizeof (tab[0]), lt_split_sort_cmp);
+
+  saved_cwd = getcwd (cwd_buf, sizeof (cwd_buf));
+  if (saved_cwd == NULL)
+    {
+      fprintf (stderr, "Error: cannot get current directory\n");
+      free (tab);
+      return -1;
+    }
+
+  broker_log_top_force_single_thread = 1;
+
+  if (log_top_fill_parent_out_base (parent_out_base, sizeof (parent_out_base)) < 0)
+    {
+      free (tab);
+      return -1;
+    }
+  if (log_top_mkdir_out (parent_out_base) < 0 && errno != EEXIST)
+    {
+      fprintf (stderr, "Error: cannot create output directory: %s\n", parent_out_base);
+      free (tab);
+      return -1;
+    }
+
+  g_start = 0;
+  while (g_start < nvalid)
+    {
+      volatile int qerr = 0;
+
+      g_end = g_start + 1;
+      while (g_end < nvalid && strcmp (tab[g_end].key, tab[g_start].key) == 0)
+	g_end++;
+
+      argv_small = (volatile char **) calloc ((size_t) (g_end - g_start), sizeof (char *));
+      if (argv_small == NULL)
+	{
+	  fprintf (stderr, "Error: memory allocation failed\n");
+	  error = -1;
+	  break;
+	}
+      for (k = 0; k < g_end - g_start; k++)
+	argv_small[k] = tab[g_start + k].path;
+
+      log_top_broker_to_safe (tab[g_start].key, broker_safe, sizeof (broker_safe));
+      snprintf (subdir, sizeof (subdir), "%.1023s/%.255s", parent_out_base, broker_safe);
+
+      if (log_top_mkdir_out (subdir) < 0 && errno != EEXIST)
+	{
+	  fprintf (stderr, "Error: cannot create output directory: %s\n", subdir);
+	  error = -1;
+	  free ((void *) argv_small);
+	  break;
+	}
+      if (LOG_TOP_CHDIR (subdir) < 0)
+	{
+	  fprintf (stderr, "Error: cannot chdir to %s\n", subdir);
+	  error = -1;
+	  free ((void *) argv_small);
+	  break;
+	}
+
+      fprintf (stdout, "%s\n", tab[g_start].key);
+      query_info_reset ();
+      if (log_top_sigjmp_tran_query_inner (g_end - g_start, (char **) argv_small, &qerr) == 0)
+	{
+	  LOG_TOP_CHDIR ((char *) saved_cwd);
+	  if (qerr != 0)
+	    error = qerr;
+	}
+      else
+	LOG_TOP_CHDIR ((char *) saved_cwd);
+      free ((void *) argv_small);
+      argv_small = NULL;
+      g_start = g_end;
+    }
+
+  free (tab);
+  return (int) error;
 }
 
 #ifdef MT_MODE
@@ -728,7 +2221,9 @@ log_execute (T_QUERY_INFO * qi, char *linebuf, char **query_p)
   exec_h_id = atoi (p + 9);
   *query_p = strchr (p + 9, ' ');
   if (*query_p)
-    *query_p = *query_p + 1;
+    {
+      *query_p = *query_p + 1;
+    }
 
   if (exec_h_id <= 0 || exec_h_id > MAX_SRV_HANDLE)
     {
@@ -744,8 +2239,19 @@ static int
 get_args (int argc, char *argv[])
 {
   int c;
+  int option_index = 0;
+  int from_conf_mode = 0;
 
-  while ((c = getopt (argc, argv, "tq:h:F:T:")) != EOF)
+  log_top_multi_explicit_dirs_flag = 0;
+  log_top_out_merge = 1;
+
+  static struct option long_options[] = {
+    {"all-broker-log", optional_argument, 0, 'l'},
+    {"from-conf", no_argument, 0, 'C'},
+    {0, 0, 0, 0}
+  };
+
+  while ((c = getopt_long (argc, argv, "tq:h:F:T:O:Cl::", long_options, &option_index)) != EOF)
     {
       switch (c)
 	{
@@ -770,19 +2276,135 @@ get_args (int argc, char *argv[])
 	      goto date_format_err;
 	    }
 	  break;
+	case 'l':
+	  if (from_conf_mode)
+	    {
+	      goto getargs_err;
+	    }
+	  if (optarg && optarg[0])
+	    {
+	      log_top_multi_log_dir = optarg;
+	    }
+	  else if (optind < argc && strchr (argv[optind], '/') != NULL)
+	    {
+	      log_top_multi_log_dir = argv[optind];
+	      optind++;
+	    }
+	  else
+	    {
+	      log_top_multi_log_dir = "LOG_DIR";
+	    }
+	  break;
+	case 'C':
+	  if (log_top_multi_log_dir != NULL)
+	    {
+	      goto getargs_err;
+	    }
+	  from_conf_mode = 1;
+	  log_top_multi_log_dir = "LOG_DIR";
+	  break;
+	case 'O':
+	  if (optarg == NULL)
+	    {
+	      goto getargs_err;
+	    }
+	  if (strcmp (optarg, "merge") != 0 && strcmp (optarg, "split") != 0)
+	    {
+	      fprintf (stderr, "Error: invalid -O value: %s (allowed: merge|split)\n", optarg);
+	      goto getargs_err;
+	    }
+	  log_top_out_merge = (strcmp (optarg, "merge") == 0);
+	  break;
 	default:
 	  goto getargs_err;
 	}
     }
 
   if (mode_max_handle_lower_bound > 0)
-    log_top_mode = MODE_MAX_HANDLE;
+    {
+      log_top_mode = MODE_MAX_HANDLE;
+    }
+
+  /* -O split + only directory path(s): same batch layout as --from-conf / --all-broker-log */
+  if (!log_top_out_merge && log_top_multi_log_dir == NULL && optind < argc)
+    {
+      struct stat st;
+      char norm[BROKER_LOG_TOP_MAX_PATH];
+      int dir_idx;
+      int n_remain = argc - optind;
+      int all_dir = 1;
+
+      for (dir_idx = 0; dir_idx < n_remain; dir_idx++)
+	{
+	  log_top_normalize_path (argv[optind + dir_idx], norm, sizeof (norm));
+	  if (stat (norm, &st) != 0 || !S_ISDIR (st.st_mode))
+	    {
+	      all_dir = 0;
+	      break;
+	    }
+	}
+      if (all_dir && n_remain >= 1 && n_remain <= BROKER_LOG_TOP_MAX_DIRS)
+	{
+	  for (dir_idx = 0; dir_idx < n_remain; dir_idx++)
+	    {
+	      log_top_normalize_path (argv[optind + dir_idx], norm, sizeof (norm));
+	      log_top_multi_explicit_dirs_buf[dir_idx] = (char *) MALLOC (strlen (norm) + 1);
+	      if (log_top_multi_explicit_dirs_buf[dir_idx] == NULL)
+		{
+		  while (dir_idx > 0)
+		    {
+		      dir_idx--;
+		      FREE_MEM (log_top_multi_explicit_dirs_buf[dir_idx]);
+		      log_top_multi_explicit_dirs_buf[dir_idx] = NULL;
+		    }
+		  goto getargs_err;
+		}
+	      strcpy (log_top_multi_explicit_dirs_buf[dir_idx], norm);
+	    }
+	  log_top_multi_explicit_dirs_flag = 1;
+	  log_top_multi_explicit_ndirs = n_remain;
+	  optind += n_remain;
+	  log_top_multi_log_dir = log_top_multi_explicit_sentinel;
+	  log_top_multi_broker_name = NULL;
+	  return optind;
+	}
+    }
+
+  if (optind < argc && optind + 1 == argc)
+    {
+      const char *arg = argv[optind];
+      if (strchr (arg, '/') == NULL && log_top_cas_log_suffix_len (arg) == 0)
+	{
+	  log_top_multi_broker_name = arg;
+	  if (log_top_multi_log_dir == NULL)
+	    {
+	      log_top_multi_log_dir = ".";
+	    }
+	}
+    }
+
+  if (from_conf_mode && optind < argc)
+    {
+      goto getargs_err;
+    }
+
+  if (log_top_multi_log_dir != NULL)
+    {
+      return optind;
+    }
 
   if (optind < argc)
-    return optind;
+    {
+      return optind;
+    }
+
+  goto getargs_err;
 
 getargs_err:
-  fprintf (stderr, "%s [-t] [-F <from date>] [-T <to date>] <log_file> ...\n", argv[0]);
+  fprintf (stderr,
+	   "%s [-t] [-F <from date>] [-T <to date>] [-O <merge | split>] <log_file> ...\n"
+	   "or\n"
+	   "%s [-t] [-F <from date>] [-T <to date>] <--from-conf>\n", argv[0], argv[0]);
   return -1;
 date_format_err:
   fprintf (stderr, "invalid date. valid date format is yy-mm-dd hh:mm:ss.\n");

--- a/src/broker/broker_log_top.c
+++ b/src/broker/broker_log_top.c
@@ -505,13 +505,11 @@ log_top_discover_log_dirs (char *out_dirs[], int max_dirs)
       char *val, *p;
       for (p = line; *p && (*p == ' ' || *p == '\t'); p++)
 	;
-      if (strncasecmp (p, "SLOW_LOG_DIR", 12) == 0
-	  && (p[12] == '=' || p[12] == ' ' || p[12] == '\t'))
+      if (strncasecmp (p, "SLOW_LOG_DIR", 12) == 0 && (p[12] == '=' || p[12] == ' ' || p[12] == '\t'))
 	{
 	  p += 12;
 	}
-      else if (strncasecmp (p, "LOG_DIR", 7) == 0
-	       && (p[7] == '=' || p[7] == ' ' || p[7] == '\t'))
+      else if (strncasecmp (p, "LOG_DIR", 7) == 0 && (p[7] == '=' || p[7] == ' ' || p[7] == '\t'))
 	{
 	  p += 7;
 	}
@@ -631,7 +629,7 @@ log_top_gather_files_exact (const char *broker, const char *dir, char *out_files
 
 static int
 log_top_gather_files_pattern_suffix (const char *pattern, const char *dir, const char *suffix, size_t suffix_len,
-				   char *out_files[], int max_files)
+				     char *out_files[], int max_files)
 {
   DIR *d;
   struct dirent *e;
@@ -772,8 +770,7 @@ log_top_get_brokers_from_dir (const char *dir, char *out_brokers[], int max_brok
   int nseen = 0;
   int n = 0;
   int i;
-  const char *patterns[] =
-    { "*_*.sql.log", "*_*.sql.log.bak", "*_*.slow.log", "*_*.slow.log.bak", NULL };
+  const char *patterns[] = { "*_*.sql.log", "*_*.sql.log.bak", "*_*.slow.log", "*_*.slow.log.bak", NULL };
 
   for (i = 0; patterns[i] && n < max_brokers; i++)
     {
@@ -925,8 +922,7 @@ log_top_mkdir_out (const char *path)
 static int
 log_top_multi_dir_is_conf_multi (void)
 {
-  return log_top_multi_explicit_dirs_flag != 0
-    || strcasecmp (log_top_multi_log_dir, "LOG_DIR") == 0;
+  return log_top_multi_explicit_dirs_flag != 0 || strcasecmp (log_top_multi_log_dir, "LOG_DIR") == 0;
 }
 
 static int
@@ -1080,8 +1076,7 @@ log_top_multi_run (void)
       nfiles = log_top_is_pattern (log_top_multi_broker_name)
 	? log_top_gather_files_pattern_all (log_top_multi_broker_name, cwd_buf, (char **) files,
 					    BROKER_LOG_TOP_MAX_FILES)
-	: log_top_gather_files_exact (log_top_multi_broker_name, cwd_buf, (char **) files,
-				      BROKER_LOG_TOP_MAX_FILES);
+	: log_top_gather_files_exact (log_top_multi_broker_name, cwd_buf, (char **) files, BROKER_LOG_TOP_MAX_FILES);
       if (nfiles == 0)
 	{
 	  fprintf (stderr, "Info: no files for broker '%s' in current directory.\n", log_top_multi_broker_name);
@@ -1171,8 +1166,8 @@ log_top_multi_run (void)
 		  goto next_dir;
 		}
 	      log_top_multi_run_one_broker (parent_out_base, log_top_multi_broker_name, 1,
-					   log_top_multi_broker_name, (char **) files, nfiles, (char *) saved_cwd,
-					   &error);
+					    log_top_multi_broker_name, (char **) files, nfiles, (char *) saved_cwd,
+					    &error);
 	      nfiles = 0;
 	    }
 	  else
@@ -1181,12 +1176,13 @@ log_top_multi_run (void)
 						   BROKER_LOG_TOP_MAX_FILES);
 	      if (nfiles == 0)
 		{
-		  fprintf (stderr, "Info: [%s] no files for broker '%s', skipping.\n", dirs[d], log_top_multi_broker_name);
+		  fprintf (stderr, "Info: [%s] no files for broker '%s', skipping.\n", dirs[d],
+			   log_top_multi_broker_name);
 		  goto next_dir;
 		}
 	      log_top_multi_run_one_broker (parent_out_base, log_top_multi_broker_name, 0,
-					   log_top_multi_broker_name, (char **) files, nfiles, (char *) saved_cwd,
-					   &error);
+					    log_top_multi_broker_name, (char **) files, nfiles, (char *) saved_cwd,
+					    &error);
 	      nfiles = 0;
 	    }
 	next_dir:
@@ -1281,8 +1277,8 @@ log_top_multi_run (void)
 	      if (dirs[dir_idx] == NULL)
 		continue;
 	      int dir_files = log_top_gather_files_exact (all_brokers[i], dirs[dir_idx],
-							all_files + total_files,
-							BROKER_LOG_TOP_MAX_FILES - total_files);
+							  all_files + total_files,
+							  BROKER_LOG_TOP_MAX_FILES - total_files);
 	      total_files += dir_files;
 	    }
 	  num_files = total_files;
@@ -1295,7 +1291,7 @@ log_top_multi_run (void)
 	    }
 
 	  log_top_multi_run_one_broker (parent_out_base, all_brokers[i], 0, all_brokers[i], all_files, num_files,
-				       (char *) saved_cwd, &error);
+					(char *) saved_cwd, &error);
 	  memset (all_files, 0, sizeof (char *) * BROKER_LOG_TOP_MAX_FILES);
 	  FREE_MEM (all_brokers[i]);
 	  all_brokers[i] = NULL;
@@ -2185,8 +2181,7 @@ get_args (int argc, char *argv[])
 getargs_err:
   fprintf (stderr,
 	   "%s [-t] [-F <from date>] [-T <to date>] [-O <merge | split>] <log_file> ...\n"
-	   "or\n"
-	   "%s [-t] [-F <from date>] [-T <to date>] <--from-conf>\n", argv[0], argv[0]);
+	   "or\n" "%s [-t] [-F <from date>] [-T <to date>] <--from-conf>\n", argv[0], argv[0]);
   return -1;
 date_format_err:
   fprintf (stderr, "invalid date. valid date format is yy-mm-dd hh:mm:ss.\n");

--- a/src/broker/cas_query_info.c
+++ b/src/broker/cas_query_info.c
@@ -27,6 +27,9 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <string.h>
+#ifdef MT_MODE
+#include <pthread.h>
+#endif
 
 #include "cas_common.h"
 #include "cas_query_info.h"
@@ -49,7 +52,6 @@ static int num_query_info_ne = 0;
 #endif
 
 #ifdef MT_MODE
-/* Statically initialized so query_info_reset() is safe before query_info_mutex_init(). */
 static pthread_mutex_t query_info_mutex = PTHREAD_MUTEX_INITIALIZER;
 #endif
 
@@ -57,8 +59,6 @@ static pthread_mutex_t query_info_mutex = PTHREAD_MUTEX_INITIALIZER;
 void
 query_info_mutex_init ()
 {
-  /* Mutex uses PTHREAD_MUTEX_INITIALIZER; kept for API compatibility. */
-}
 #endif
 
 void

--- a/src/broker/cas_query_info.c
+++ b/src/broker/cas_query_info.c
@@ -59,6 +59,7 @@ static pthread_mutex_t query_info_mutex = PTHREAD_MUTEX_INITIALIZER;
 void
 query_info_mutex_init ()
 {
+}
 #endif
 
 void

--- a/src/broker/cas_query_info.c
+++ b/src/broker/cas_query_info.c
@@ -27,13 +27,9 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <string.h>
-#ifdef MT_MODE
-#include <pthread.h>
-#endif
 
 #include "cas_common.h"
 #include "cas_query_info.h"
-#include "broker_log_sql_list.h"
 #include "broker_log_top.h"
 
 #define LOG_TOP_RES_FILE	"log_top.res"
@@ -53,14 +49,15 @@ static int num_query_info_ne = 0;
 #endif
 
 #ifdef MT_MODE
-static T_MUTEX query_info_mutex;
+/* Statically initialized so query_info_reset() is safe before query_info_mutex_init(). */
+static pthread_mutex_t query_info_mutex = PTHREAD_MUTEX_INITIALIZER;
 #endif
 
 #ifdef MT_MODE
 void
 query_info_mutex_init ()
 {
-  MUTEX_INIT (query_info_mutex);
+  /* Mutex uses PTHREAD_MUTEX_INITIALIZER; kept for API compatibility. */
 }
 #endif
 
@@ -82,6 +79,43 @@ query_info_clear (T_QUERY_INFO * qi)
 }
 
 void
+query_info_reset (void)
+{
+  int i;
+#ifdef MT_MODE
+  pthread_mutex_lock (&query_info_mutex);
+#endif
+
+  if (query_info_arr != NULL)
+    {
+      for (i = 0; i < num_query_info; i++)
+	{
+	  query_info_clear (&query_info_arr[i]);
+	}
+      FREE_MEM (query_info_arr);
+      num_query_info = 0;
+    }
+
+#ifdef TEST
+  if (query_info_arr_ne != NULL)
+    {
+      for (i = 0; i < num_query_info_ne; i++)
+	{
+	  query_info_clear (&query_info_arr_ne[i]);
+	}
+      FREE_MEM (query_info_arr_ne);
+      num_query_info_ne = 0;
+    }
+#endif
+
+  sql_list_reset ();
+
+#ifdef MT_MODE
+  pthread_mutex_unlock (&query_info_mutex);
+#endif
+}
+
+void
 query_info_print (void)
 {
   int i;
@@ -94,7 +128,7 @@ query_info_print (void)
   int xml_found;
 
 #ifdef MT_MODE
-  MUTEX_LOCK (query_info_mutex);
+  pthread_mutex_lock (&query_info_mutex);
 #endif
 
   fp_res = fopen (LOG_TOP_RES_FILE, "w");
@@ -184,7 +218,7 @@ query_info_print (void)
 
 query_info_print_end:
 #ifdef MT_MODE
-  MUTEX_UNLOCK (query_info_mutex);
+  pthread_mutex_unlock (&query_info_mutex);
 #endif
   return;
 }
@@ -200,7 +234,7 @@ query_info_add (T_QUERY_INFO * qi, int exec_time, int execute_res, char *filenam
     return 0;
 
 #ifdef MT_MODE
-  MUTEX_LOCK (query_info_mutex);
+  pthread_mutex_lock (&query_info_mutex);
 #endif
 
 #if 0
@@ -264,7 +298,7 @@ query_info_add (T_QUERY_INFO * qi, int exec_time, int execute_res, char *filenam
 query_info_add_end:
 
 #ifdef MT_MODE
-  MUTEX_UNLOCK (query_info_mutex);
+  pthread_mutex_unlock (&query_info_mutex);
 #endif
   return retval;
 }
@@ -286,7 +320,7 @@ query_info_add_ne (T_QUERY_INFO * qi, char *end_date)
     }
 
 #ifdef MT_MODE
-  MUTEX_LOCK (query_info_mutex);
+  pthread_mutex_lock (&query_info_mutex);
 #endif
 
   for (i = 0; i < num_query_info; i++)
@@ -336,7 +370,7 @@ query_info_add_ne (T_QUERY_INFO * qi, char *end_date)
 
 query_info_add_ne_end:
 #ifdef MT_MODE
-  MUTEX_UNLOCK (query_info_mutex);
+  pthread_mutex_unlock (&query_info_mutex);
 #endif
   return retval;
 #endif /* define TEST */

--- a/src/broker/cas_query_info.h
+++ b/src/broker/cas_query_info.h
@@ -28,6 +28,7 @@
 
 #include "broker_log_top.h"
 #include "broker_log_util.h"
+#include "broker_log_sql_list.h"
 
 typedef struct t_query_info T_QUERY_INFO;
 struct t_query_info
@@ -50,6 +51,7 @@ void query_info_mutex_init ();
 
 extern void query_info_init (T_QUERY_INFO * query_info);
 extern void query_info_clear (T_QUERY_INFO * qi);
+extern void query_info_reset (void);
 extern int query_info_add (T_QUERY_INFO * qi, int exec_time, int execute_res, char *filename, int lineno,
 			   char *end_date);
 extern int query_info_add_ne (T_QUERY_INFO * qi, char *end_date);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26610

### Purpose
브로커 SQL 로그 상위 분석(broker_log_top)은 로그 파일 경로를 직접 나열하거나 브로커별로 반복 실행해야 하는 경우가 많아 운영 부담이 있다. cubrid_broker.conf에 정의된 여러 LOG_DIR(및 SLOW_LOG_DIR)에 분산된 로그를 한 번에 다루고, 결과를 한 세트로 볼지(merge) 브로커별로 나눌지(split) 선택할 수 있도록 옵션을 추가/개선한다.

### Specification Changes
1.broker_log_top 옵션들
전 : broker_log_top [-t] [-F ] [-T ] <log_file> ...
**후 : broker_log_top [-t] [-F ] [-T ] [-O <merge | split>] <log_file> ...
or
broker_log_top [-t] [-F ] [-T ] <--from-conf>**

사용 예시:
2-1. -O split 옵션 브로커별 log_top.* 수집
broker_log_top -O split $CUBRID/log/broker/sql_log/*
broker_log_top -t -F "26-03-16 09:00" -T "26-03-16 09:30" -O split $CUBRID/log/broker/sql_log/*
2-2. --from-con 옵션 cubrid_broker.conf 브로커별 log_top.* 수집
broker_log_top --from-conf
broker_log_top -t -F "26-03-16 09:00" -T "26-03-16 09:30"--from-conf
2-3, 상세 테스트 정보: http://jira.cubrid.org/browse/CBRD-26610

3. broker_log_top 수행 결과
3-1. 명령어 수행 위치 : 타임스탬프 디렉터리 생성 후 하위 각 브로커명 디렉터리 생성하여 결과 파일 생성 됨
3-2. 수행 결과 파일
broker_log_top_260325_0949
└── broker1
└── log_top.q, log_top.res, log_top.t
└── broker2
└── log_top.q, log_top.res, log_top.t
└── broker3
└── log_top.q, log_top.res, log_top.t
└── query_editor
└── log_top.q, log_top.res, log_top.t

### Implementation
1. src/broker/broker_log_sql_list.c : 전역 sql_list·파일명 배열을 비우는 sql_list_reset() 추가(반복 실행 시 메모리/상태 초기화).
2. src/broker/broker_log_sql_list.h : stdio.h 포함, sql_list_reset 선언 추가.
3. src/broker/broker_log_top.c : --from-conf(conf 기반 배치 실행), -O merge|split(출력 모드 선택), 멀티 로그 디렉터리 자동 수집, 브로커별 파일 수집, -O split 경로별 분리 처리, 비윈도우 SEGV 복구(sigsetjmp/siglongjmp) 추가.
4. src/broker/cas_query_info.c : query_info_reset() 추가(쿼리 정보 배열 해제 후 sql_list_reset() 호출), MT 뮤텍스를 정적 초기화·pthread_mutex_*로 통일, broker_log_sql_list.h 직접 include 제거.
5. src/broker/cas_query_info.h : broker_log_sql_list.h include 및 query_info_reset() 선언 추가.

### Remarks
* 기존 동작 변경 없음: [-O <merge | split>] <--from-conf> 옵션 인자를 쓰지 않으면 기존처럼 동작.(참조: 타임스탬프 디렉토리 생성 동작은 동일 함)
