### PR TITLE
[CUBVEC-177] Aligned allocation for vector data to improve SIMD performance

### DIFF
--- a/src/base/memory_alloc.c
+++ b/src/base/memory_alloc.c
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#include <stdint.h>
 
 #include "set_object.h"
 #include "misc_string.h"
@@ -60,6 +61,12 @@ HL_HEAPID private_heap_id = 0;
 #if defined (SERVER_MODE)
 static HL_HEAPID db_private_get_heapid_from_thread (REFPTR (THREAD_ENTRY, thread_p));
 #endif // SERVER_MODE
+
+typedef struct db_private_aligned_header DB_PRIVATE_ALIGNED_HEADER;
+struct db_private_aligned_header
+{
+  void *raw_ptr;
+};
 
 /*
  * ansisql_strcmp - String comparison according to ANSI SQL
@@ -747,6 +754,58 @@ db_private_strndup (THREAD_ENTRY * thrd, const char *s, size_t size)
     }
 
   return cp;
+}
+
+void *
+db_private_aligned_alloc (THREAD_ENTRY * thrd, size_t alignment, size_t size)
+{
+  char *raw_ptr = NULL;
+  uintptr_t aligned_addr;
+  size_t total_size;
+  DB_PRIVATE_ALIGNED_HEADER *header = NULL;
+
+  if (size == 0)
+    {
+      return NULL;
+    }
+
+  if (alignment < sizeof (void *))
+    {
+      alignment = sizeof (void *);
+    }
+
+  if ((alignment & (alignment - 1)) != 0)
+    {
+      return NULL;
+    }
+
+  total_size = size + alignment - 1 + sizeof (DB_PRIVATE_ALIGNED_HEADER);
+  raw_ptr = (char *) db_private_alloc (thrd, total_size);
+  if (raw_ptr == NULL)
+    {
+      return NULL;
+    }
+
+  aligned_addr =
+    ((uintptr_t) (raw_ptr + sizeof (DB_PRIVATE_ALIGNED_HEADER)) + alignment - 1) & ~((uintptr_t) alignment - 1);
+  header = (DB_PRIVATE_ALIGNED_HEADER *) ((char *) aligned_addr - sizeof (DB_PRIVATE_ALIGNED_HEADER));
+  header->raw_ptr = raw_ptr;
+
+  return (void *) aligned_addr;
+}
+
+void
+db_private_aligned_free (THREAD_ENTRY * thrd, void *ptr)
+{
+  DB_PRIVATE_ALIGNED_HEADER *header = NULL;
+
+  if (ptr == NULL)
+    {
+      return;
+    }
+
+  header = (DB_PRIVATE_ALIGNED_HEADER *) ((char *) ptr - sizeof (DB_PRIVATE_ALIGNED_HEADER));
+  db_private_free (thrd, header->raw_ptr);
 }
 
 /*

--- a/src/base/memory_alloc.h
+++ b/src/base/memory_alloc.h
@@ -279,6 +279,8 @@ extern "C"
 #endif
   extern char *db_private_strdup (THREAD_ENTRY * thrd, const char *s);
   extern char *db_private_strndup (THREAD_ENTRY * thrd, const char *s, size_t size);
+  extern void *db_private_aligned_alloc (THREAD_ENTRY * thrd, size_t alignment, size_t size);
+  extern void db_private_aligned_free (THREAD_ENTRY * thrd, void *ptr);
 #ifdef __cplusplus
 }
 #endif

--- a/src/compat/db_vector.cpp
+++ b/src/compat/db_vector.cpp
@@ -22,22 +22,51 @@
  */
 
 #include "cubvec_assert.h"
+#include "db_vector.hpp"
 #include "error_code.h"
 
-#include <algorithm>
+#include <cstdint>
 #include <cmath>
 #include <limits>
 #include <sstream>
 #include <iomanip>
 #include <string>
 #include "rapidjson/document.h"
-
-#include "dbtype_def.h"
+#include "memory_alloc.h"
 
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
 #include "memory_wrapper.hpp"
 
 #define VECTOR_DIM_MAX 2000
+
+float *
+db_vector_allocate_float_array (int dim)
+{
+  if (dim <= 0)
+    {
+      return nullptr;
+    }
+
+  const std::size_t bytes = static_cast<std::size_t> (dim) * sizeof (float);
+  return static_cast<float *> (db_private_aligned_alloc (NULL, DB_VECTOR_ALIGNMENT, bytes));
+}
+
+void
+db_vector_free_float_array (float *vf)
+{
+  if (vf == nullptr)
+    {
+      return;
+    }
+
+  db_private_aligned_free (NULL, vf);
+}
+
+bool
+db_vector_is_aligned (const float *vf)
+{
+  return vf != nullptr && (reinterpret_cast<std::uintptr_t> (vf) % DB_VECTOR_ALIGNMENT) == 0;
+}
 
 int db_string_to_vector (
 	const char *p,

--- a/src/compat/db_vector.hpp
+++ b/src/compat/db_vector.hpp
@@ -23,12 +23,19 @@
 #ifndef _DB_VECTOR_HPP_
 #define _DB_VECTOR_HPP_
 
+#include <cstddef>
 #include <string>
 #include "dbtype_def.h"
 
 #ident "$Id$"
 
 extern int db_string_to_vector (const char *p, int str_len, float *vector, int *count);
+
+constexpr std::size_t DB_VECTOR_ALIGNMENT = 64;
+
+float *db_vector_allocate_float_array (int dim);
+void db_vector_free_float_array (float *vf);
+bool db_vector_is_aligned (const float *vf);
 
 std::string db_vector_float_to_string (const DB_VECTOR_FLOAT &vf);
 

--- a/src/loaddb/load_db_value_converter.cpp
+++ b/src/loaddb/load_db_value_converter.cpp
@@ -590,7 +590,7 @@ namespace cubload
   {
     int count = 0;
     const int max_vector_size = 2000;
-    float *float_array = (float *) db_private_alloc (NULL, max_vector_size * sizeof (float));
+    float *float_array = db_vector_allocate_float_array (max_vector_size);
     vimkim_log ("db_private_alloc: %p, size = %zu\n", float_array, max_vector_size * sizeof (float));
     if (float_array == NULL)
       {

--- a/src/loaddb/load_sa_loader.cpp
+++ b/src/loaddb/load_sa_loader.cpp
@@ -22,6 +22,7 @@
 
 #include "config.h"
 #include "cubvec_assert.h"
+#include "db_vector.hpp"
 #include "dbtype_def.h"
 
 #include <assert.h>
@@ -6823,7 +6824,7 @@ ldr_vector_elem (LDR_CONTEXT *context, const char *str, size_t len, DB_VALUE *va
 {
   int count = 0;
   const int max_vector_size = 2000;
-  float *float_array = (float *) db_private_alloc (NULL, sizeof (float) * max_vector_size);
+  float *float_array = db_vector_allocate_float_array (max_vector_size);
   vimkim_log ("db_private_alloc: %p, size = %zu\n", float_array, sizeof (float) * max_vector_size);
   ASSERT_CUBVEC (float_array != NULL);
   if (float_array == NULL)

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -4948,7 +4948,7 @@ tp_atovector (const DB_VALUE * src, DB_VALUE * result)
 
   DB_VECTOR_FLOAT vector_float;
   vector_float.dim = 0;
-  vector_float.float_array = (float *) db_private_alloc (nullptr, max_vector_size * sizeof (float));
+  vector_float.float_array = db_vector_allocate_float_array (max_vector_size);
 
   vimkim_log ("db_private_alloc: %p of size %zu\n", vector_float.float_array, max_vector_size * sizeof (float));
 
@@ -4961,7 +4961,7 @@ tp_atovector (const DB_VALUE * src, DB_VALUE * result)
   int error = db_string_to_vector (p, db_get_string_size (src), vector_float.float_array, &vector_float.dim);
   if (error != NO_ERROR)
     {
-      db_private_free (nullptr, vector_float.float_array);
+      db_vector_free_float_array (vector_float.float_array);
       vimkim_log ("db_string_to_vector failed: %d\n", error);
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
       return ER_FAILED;
@@ -4973,7 +4973,7 @@ tp_atovector (const DB_VALUE * src, DB_VALUE * result)
   if (vector_float.dim == 0)
     {
       vimkim_log ("TODO: dim should not be zero yet.\n");
-      db_private_free (nullptr, vector_float.float_array);
+      db_vector_free_float_array (vector_float.float_array);
       return ER_FAILED;
     }
 

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -1989,7 +1989,7 @@ pr_clear_value (DB_VALUE * value)
 	  {
 	    vimkim_log ("freeing addr: %p, vf: %s\n", value,
 			db_vector_float_to_string (value->data.vector_float).c_str ());
-	    db_private_free (NULL, value->data.vector_float.float_array);
+	    db_vector_free_float_array (value->data.vector_float.float_array);
 	  }
 	else
 	  {
@@ -7709,7 +7709,7 @@ mr_setval_vector_float (DB_VALUE * dest, const DB_VALUE * src, bool copy)
 
 	  DB_VECTOR_FLOAT dest_vf;
 	  dest_vf.dim = src_vf->dim;
-	  dest_vf.float_array = (float *) db_private_alloc (NULL, dim * sizeof (float));
+	  dest_vf.float_array = db_vector_allocate_float_array (dim);
 	  assert (dest_vf.float_array != NULL);
 	  if (dest_vf.float_array == NULL)
 	    {
@@ -7800,7 +7800,7 @@ mr_data_readval_vector_float (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain
   if (copy)
     {
 
-      vector_float.float_array = (float *) db_private_alloc (NULL, vector_float.dim * sizeof (float));
+      vector_float.float_array = db_vector_allocate_float_array (vector_float.dim);
       vimkim_log ("db_private_alloc: %p, size = %lu\n", vector_float.float_array, vector_float.dim * sizeof (float));
       ASSERT_CUBVEC (vector_float.float_array != NULL);
       if (vector_float.float_array == NULL)

--- a/src/parser/parse_dbi.c
+++ b/src/parser/parse_dbi.c
@@ -38,6 +38,7 @@
 #include "memory_alloc.h"
 #include "language_support.h"
 #include "db.h"
+#include "db_vector.hpp"
 #include "schema_manager.h"
 #include "cnv.h"
 #include "string_opfunc.h"
@@ -626,7 +627,7 @@ pt_dbval_to_value (PARSER_CONTEXT * parser, const DB_VALUE * val)
 	vimkim_log ("TRACE: pt_dbval_to_value not analyzed.\n");
 	DB_VECTOR_FLOAT dest_vector_float;
 	dest_vector_float.dim = dim;
-	dest_vector_float.float_array = (float *) malloc (dim * sizeof (float));
+	dest_vector_float.float_array = db_vector_allocate_float_array (dim);
 	if (dest_vector_float.float_array == NULL)
 	  {
 	    PT_INTERNAL_ERROR (parser, "Cannot allocate float_array for vector");

--- a/src/storage/index_hnsw/hnsw_impl.cpp
+++ b/src/storage/index_hnsw/hnsw_impl.cpp
@@ -22,6 +22,8 @@
 
 #include "hnsw_api.hpp"
 
+#include <cstring>
+
 #include "page_buffer.h"
 #include "storage_common.h"
 #include "thread_compat.hpp"
@@ -43,6 +45,45 @@
 #endif
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
 #include "memory_wrapper.hpp"
+
+namespace
+{
+  class aligned_vector_buffer final
+  {
+    public:
+      explicit aligned_vector_buffer (std::size_t dimension)
+      {
+	m_data = db_vector_allocate_float_array (static_cast<int> (dimension));
+	assert (m_data != nullptr);
+      }
+
+      ~aligned_vector_buffer ()
+      {
+	db_vector_free_float_array (m_data);
+      }
+
+      aligned_vector_buffer (const aligned_vector_buffer &) = delete;
+      aligned_vector_buffer &operator= (const aligned_vector_buffer &) = delete;
+
+      float *data () noexcept
+      {
+	return m_data;
+      }
+
+      const float *data () const noexcept
+      {
+	return m_data;
+      }
+
+      void copy_from (const float *source, std::size_t dimension) noexcept
+      {
+	std::memcpy (m_data, source, dimension * sizeof (float));
+      }
+
+    private:
+      float *m_data {nullptr};
+  };
+}
 
 class hnsw_impl_backend final:public hnsw_index_backend
 {
@@ -564,7 +605,21 @@ hnsw_impl::add_internal (cubthread::entry &thread_ref, hnsw_build_worker_job &jo
     }
   else
     {
-      auto result = m_algo->add (&thread_ref, job.m_oid, job.m_vector);
+      const bool needs_vector_copy =
+	      m_build_params.metric == DB_VECTOR_DISTANCE_METRIC::METRIC_COSINE
+	      || !db_vector_is_aligned (job.m_vector);
+
+      std::unique_ptr<aligned_vector_buffer> aligned_vector;
+      const float *vector_ptr = job.m_vector;
+
+      if (needs_vector_copy)
+	{
+	  aligned_vector = std::make_unique<aligned_vector_buffer> (m_build_params.dimension);
+	  aligned_vector->copy_from (job.m_vector, m_build_params.dimension);
+	  vector_ptr = aligned_vector->data ();
+	}
+
+      auto result = m_algo->add (&thread_ref, job.m_oid, vector_ptr);
       error = result.error;
     }
 
@@ -579,14 +634,28 @@ int
 hnsw_impl::search (cubthread::entry *thread_p, const float *query, const int k, const int ef_search,
 		   OID *rec_oids, float *distances)
 {
+  const bool needs_query_copy =
+	  m_build_params.metric == DB_VECTOR_DISTANCE_METRIC::METRIC_COSINE
+	  || !db_vector_is_aligned (query);
+
+  std::unique_ptr<aligned_vector_buffer> aligned_query;
+  const float *query_ptr = query;
+
+  if (needs_query_copy)
+    {
+      aligned_query = std::make_unique<aligned_vector_buffer> (m_build_params.dimension);
+      aligned_query->copy_from (query, m_build_params.dimension);
+      query_ptr = aligned_query->data ();
+    }
+
   if (m_build_params.metric == DB_VECTOR_DISTANCE_METRIC::METRIC_COSINE
-      && db_vector_is_all_zeros (query, m_build_params.dimension))
+      && db_vector_is_all_zeros (query_ptr, m_build_params.dimension))
     {
       er_log_debug (ARG_FILE_LINE, "Vector is all zeros, skipping search");
       return NO_ERROR;
     }
 
-  auto results = m_algo->search (thread_p, query, k, ef_search);
+  auto results = m_algo->search (thread_p, query_ptr, k, ef_search);
   if (results.error != NO_ERROR)
     {
       er_log_debug (ARG_FILE_LINE, "Error during search: %s", results.error);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-177

### Purpose

Improve SIMD execution efficiency by ensuring vector data is properly aligned in memory.
- Eliminates unaligned SIMD loads (e.g., split loads, extra uops).
- Improves cache-line utilization and memory access efficiency.
- Guarantees consistent SIMD-friendly layout across all vector entry points.
- Introduces minimal overhead via conditional copy only when alignment is not satisfied.
- No functional changes; performance-focused refactor.

### Implementation

- Added `db_private_aligned_alloc` / `db_private_aligned_free` with header-based raw pointer tracking for safe deallocation. :contentReference[oaicite:0]{index=0}
- Introduced `DB_VECTOR_ALIGNMENT` (64B) to match AVX-512 requirements.
- Implemented vector helpers:
  - `db_vector_allocate_float_array`
  - `db_vector_free_float_array`
  - `db_vector_is_aligned`
- Replaced all vector-related allocations (`db_private_alloc`, `malloc`) with aligned allocation across:
  - vector parsing / conversion
  - loader paths
  - object/domain handling
  - DB_VALUE lifecycle
- Added RAII-style `aligned_vector_buffer` in HNSW implementation to ensure safe temporary aligned copies.
- Ensured alignment at runtime:
  - fallback copy when input vector is unaligned
  - mandatory copy for cosine metric (normalization path)
- Updated HNSW build/search paths to operate on aligned buffers when required.

### Remarks

N/A
