### PR TITLE
[CBRD-26698] (backport to 11.4) bug-fix: correct length when handling shard keys (#7030)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,7 +216,7 @@ if(UNIX)
     endif(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.4.7)
 
     # C flags for both debug and release build
-    set(CMAKE_C_COMMON_FLAGS "-ggdb -fno-omit-frame-pointer")
+    set(CMAKE_C_COMMON_FLAGS "-ggdb -fno-omit-frame-pointer -fstack-protector-strong")
     # C++ flags for both debug and release build
     set(CMAKE_CXX_COMMON_FLAGS "${CMAKE_C_COMMON_FLAGS} -std=c++17")
 

--- a/src/broker/shard_parser.c
+++ b/src/broker/shard_parser.c
@@ -315,17 +315,18 @@ static int
 sp_make_int_sp_value_from_string (SP_VALUE * value_p, char *pos, int length)
 {
   int result = 0;
-  const int KEY_LENGTH = 128;
-  char shard_key[KEY_LENGTH];
+  char shard_key[SHARD_KEY_LENGTH + 1];
+  int key_len = (length > SHARD_KEY_LENGTH) ? SHARD_KEY_LENGTH : length;
   char *p;
 
-  snprintf (shard_key, KEY_LENGTH, "%s", pos);
+  memcpy (shard_key, pos, key_len);
+  shard_key[key_len] = '\0';
+
   p = strchr (shard_key, ';');
   if (p)
     {
       *p = '\0';
     }
-  shard_key[length] = '\0';
 
   result = parse_bigint (&value_p->integer, shard_key, 10);
   if (result != 0)

--- a/src/broker/shard_parser.h
+++ b/src/broker/shard_parser.h
@@ -35,7 +35,7 @@
 #include "error_code.h"
 
 #define SP_VALUE_INIT_SIZE 50
-
+#define SHARD_KEY_LENGTH 128
 
 enum sp_error_code
 {


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26698>

### Purpose

sp_make_int_sp_value_from_string 루틴에서 shard key MAX인 128이 아닌 128을 오버하는 스트링 버퍼에 '\0'을 쓰고 있는 버그를 패치(shard_key[length] = '\0')

### Implementation

backport from 11.5

### Remarks

N/A
