### PR TITLE
[CBRD-26707] Allow parallel heap scan::mergeable list when 'not exists' clause and filter subquery

### DIFF
--- a/src/query/parallel/px_heap_scan/px_heap_scan_checker.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_checker.cpp
@@ -431,8 +431,8 @@ namespace parallel_heap_scan
 
     if (sibling->if_pred)
       {
-	result |= check<is_outptr_list> (sibling->if_pred);
-	if (is_flag_set (result, CANNOT_PARALLEL_HEAP_SCAN))
+	temp = check<is_outptr_list> (sibling->if_pred);
+	if (is_flag_set (temp, CANNOT_PARALLEL_HEAP_SCAN))
 	  {
 	    set_flag (result, CANNOT_PARALLEL_HEAP_SCAN);
 	  }

--- a/src/query/parallel/px_heap_scan/px_heap_scan_checker.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_checker.cpp
@@ -116,16 +116,6 @@ namespace parallel_heap_scan
   void process_xasl_node_recursive (XASL_NODE *arg);
   void process_xasl_node_recursive_force_cannot_parallel (XASL_NODE *arg);
 
-  inline bool is_pred_exists (PRED_EXPR *pred_expr)
-  {
-    if (!pred_expr || pred_expr->type != T_EVAL_TERM || pred_expr->pe.m_eval_term.et_type != T_COMP_EVAL_TERM
-	|| pred_expr->pe.m_eval_term.et.et_comp.rel_op != R_EXISTS)
-      {
-	return false;
-      }
-    return true;
-  }
-
   template <bool is_outptr_list>
   possible_flags check (REGU_VARIABLE *arg)
   {
@@ -441,9 +431,10 @@ namespace parallel_heap_scan
 
     if (sibling->if_pred)
       {
-	if (!is_pred_exists (sibling->if_pred))
+	result |= check<is_outptr_list> (sibling->if_pred);
+	if (is_flag_set (result, CANNOT_PARALLEL_HEAP_SCAN))
 	  {
-	    set_flag (result, CANNOT_LIST_MERGE);
+	    set_flag (result, CANNOT_PARALLEL_HEAP_SCAN);
 	  }
       }
 
@@ -549,7 +540,19 @@ namespace parallel_heap_scan
       }
     for (XASL_NODE *xaslp = arg->aptr_list; xaslp; xaslp = xaslp->next)
       {
-	result |= check<is_outptr_list> (xaslp);
+	if (XASL_IS_FLAGED (xaslp, XASL_LINK_TO_REGU_VARIABLE))
+	  {
+	    temp = sibling_check<false> (xaslp);
+	    if (is_flag_set (temp, CANNOT_PARALLEL_HEAP_SCAN))
+	      {
+		set_flag (result, CANNOT_PARALLEL_HEAP_SCAN);
+	      }
+	  }
+	else
+	  {
+	    result |= check<is_outptr_list> (xaslp);
+	  }
+
       }
 
     if (arg->bptr_list || arg->fptr_list || arg->connect_by_ptr)
@@ -582,7 +585,8 @@ namespace parallel_heap_scan
 
     if (arg->if_pred)
       {
-	if (!is_pred_exists (arg->if_pred))
+	temp = check<is_outptr_list> (arg->if_pred);
+	if (is_flag_set (temp, CANNOT_PARALLEL_HEAP_SCAN))
 	  {
 	    set_flag (result, CANNOT_PARALLEL_HEAP_SCAN);
 	  }

--- a/src/query/parallel/px_heap_scan/px_heap_scan_slot_iterator.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_slot_iterator.cpp
@@ -70,7 +70,7 @@ namespace parallel_heap_scan
     m_cur_oid.pageid = NULL_PAGEID;
     m_class_oid = hsidp->cls_oid;
     m_next_oid.pageid = NULL_PAGEID;
-    m_is_peeking = scan_id->fixed;
+    m_is_peeking = (scan_id->fixed != 0);
     m_rest_regu_list = hsidp->rest_regu_list;
     m_val_list = scan_id->val_list;
     m_scan_cache = &hsidp->scan_cache;

--- a/src/query/parallel/px_heap_scan/px_heap_scan_slot_iterator.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_slot_iterator.cpp
@@ -70,7 +70,7 @@ namespace parallel_heap_scan
     m_cur_oid.pageid = NULL_PAGEID;
     m_class_oid = hsidp->cls_oid;
     m_next_oid.pageid = NULL_PAGEID;
-    m_is_peeking = PEEK;
+    m_is_peeking = scan_id->fixed;
     m_rest_regu_list = hsidp->rest_regu_list;
     m_val_list = scan_id->val_list;
     m_scan_cache = &hsidp->scan_cache;

--- a/src/query/parallel/px_heap_scan/px_heap_scan_task.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_task.cpp
@@ -577,7 +577,7 @@ namespace parallel_heap_scan
 		if (ev_res != V_TRUE)
 		  {
 		    clear_xasl_dptr_list (&thread_ref, m_xasl, uses_clones);
-		    if (ev_res == V_FALSE)
+		    if (ev_res == V_FALSE || ev_res == V_UNKNOWN)
 		      {
 			continue;
 		      }

--- a/src/query/parallel/px_heap_scan/px_heap_scan_trace_handler.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_trace_handler.cpp
@@ -196,6 +196,14 @@ namespace parallel_heap_scan
 	xasl_merge_stats (xptr1, m_main_xasl_tree);
       }
 
+    for (xptr1 = xasl_tree->aptr_list; xptr1 != nullptr; xptr1 = xptr1->next)
+      {
+	if (XASL_IS_FLAGED (xptr1, XASL_LINK_TO_REGU_VARIABLE))
+	  {
+	    xasl_merge_stats (xptr1, m_main_xasl_tree);
+	  }
+      }
+
     dst_node = m_main_xasl_tree;
     src_node = xasl_tree;
     if (dst_node->sq_cache != nullptr && src_node->sq_cache != nullptr)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26707>

### Purpose

parallel heap scan의 mergeable list 모드에서, if_pred와 XASL_LINK_TO_REGU_VARIABLE 플래그가 설정된 aptr_list(regu-linked 서브쿼리)가 존재하는 경우 불필요하게 병렬화가 차단되는 문제를 수정합니다. 기존에는 if_pred가 EXISTS 조건이 아니면 무조건 CANNOT_LIST_MERGE 또는 CANNOT_PARALLEL_HEAP_SCAN으로 처리했으나, if_pred와 aptr_list의 내부 구조를 재귀적으로 검사하여 실제 병렬화가 불가능한 요소가 없으면 mergeable list 최적화를 허용하도록 개선합니다.

### Implementation

px_heap_scan_checker.cpp — if_pred 검사 로직 변경

- is_pred_exists() 인라인 함수 제거
- sibling_check와 check 양쪽에서 if_pred에 대해 check<is_outptr_list>()를 호출하여 predicate 내부의 regu variable을 재귀적으로 검사
- 검사 결과 CANNOT_PARALLEL_HEAP_SCAN이 발견된 경우에만 해당 플래그 설정

px_heap_scan_checker.cpp — aptr_list 검사 로직 변경

- check<is_outptr_list>(XASL_NODE *arg)에서 aptr_list 순회 시 XASL_LINK_TO_REGU_VARIABLE 플래그 여부를 분기
- XASL_LINK_TO_REGU_VARIABLE인 경우: sibling_check<false>()로 검사하여 CANNOT_PARALLEL_HEAP_SCAN만 전파 (일반 executor에서도 dptr과 유사하게 skip 후 별도 실행하는 패턴이므로, regu-linked 서브쿼리의 내부 구조만 검사)
- XASL_LINK_TO_REGU_VARIABLE이 아닌 경우: 기존과 동일하게 check<is_outptr_list>()로 전체 검사

px_heap_scan_slot_iterator.cpp — peeking 모드 수정

- slot_iterator 초기화 시 m_is_peeking을 PEEK 상수가 아닌 scan_id->fixed 값으로 설정하여, scan의 실제 fixed/unfixed 설정을 반영
- px_heap_scan_trace_handler.cpp — regu-linked aptr trace 통계 병합

merge_xasl_tree()에서 aptr_list 중 XASL_LINK_TO_REGU_VARIABLE인 항목의 실행 통계도 main xasl tree로 병합하도록 추가

**주요 변경 파일**

- px_heap_scan_checker.cpp — if_pred 재귀 검사, aptr_list LINK_TO_REGU_VARIABLE 분기 처리
- px_heap_scan_slot_iterator.cpp — peeking 모드를 scan 설정에 맞게 수정
- px_heap_scan_trace_handler.cpp — regu-linked aptr의 trace 통계 병합 추가
