### PR TITLE
[CBRD-26703] Fix use-after-unfix in fhs_find_bucket_vpid_with_hash (#7034)

### DIFF
--- a/src/query/query_hash_scan.c
+++ b/src/query/query_hash_scan.c
@@ -1709,9 +1709,8 @@ fhs_find_bucket_vpid_with_hash (THREAD_ENTRY * thread_p, FHSID * fhsid_p, void *
       return ER_FAILED;
     }
   dir_record_p = (FHS_DIR_RECORD *) ((char *) dir_page_p + location);
-  pgbuf_unfix_and_init (thread_p, dir_page_p);
-
   *out_vpid_p = dir_record_p->bucket_vpid;
+  pgbuf_unfix_and_init (thread_p, dir_page_p);
 
   return NO_ERROR;
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26703

backport #7034