### PR TITLE
[CBRD-26704] Correlated subquery cache 미사용 시 trace 결과 조회되지 않도록 변경

### DIFF
--- a/src/query/query_dump.c
+++ b/src/query/query_dump.c
@@ -3280,7 +3280,7 @@ qdump_print_stats_json (xasl_node * xasl_p, json_t * parent)
 
   qdump_print_stats_json (xasl_p->connect_by_ptr, proc);
 
-  if (xasl_p->sq_cache && XASL_IS_FLAGED (xasl_p, XASL_USES_SQ_CACHE))
+  if (xasl_p->sq_cache && XASL_IS_FLAGED (xasl_p, XASL_USES_SQ_CACHE) && SQ_CACHE_HIT (xasl_p) > 0)
     {
       sq_cache = json_object ();
       json_object_set_new (sq_cache, "hit", json_integer (SQ_CACHE_HIT (xasl_p)));
@@ -3792,7 +3792,7 @@ qdump_print_stats_text (FILE * fp, xasl_node * xasl_p, int indent)
   qdump_print_stats_text (fp, xasl_p->scan_ptr, indent);
   qdump_print_stats_text (fp, xasl_p->connect_by_ptr, indent);
 
-  if (xasl_p->sq_cache && XASL_IS_FLAGED (xasl_p, XASL_USES_SQ_CACHE))
+  if (xasl_p->sq_cache && XASL_IS_FLAGED (xasl_p, XASL_USES_SQ_CACHE) && SQ_CACHE_HIT (xasl_p) > 0)
     {
       fprintf (fp, "%*c", indent, ' ');
       if (SQ_CACHE_ENABLED (xasl_p))


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26704>

### Purpose

Correlated Subquery Cache 기능이 실제로 사용되지 않은 경우(hit == 0)에도 trace 결과에 SUBQUERY_CACHE 항목이 출력되는 문제가 있습니다.
sq_cache가 할당되어 있고 XASL_USES_SQ_CACHE 플래그가 설정되어 있더라도, 실제 cache hit이 없는 경우 trace 출력에서 제외하도록 변경합니다.

### Implementation

주요 변경 파일

src/query/query_dump.c

qdump_print_stats_json: SUBQUERY_CACHE 출력 조건에 SQ_CACHE_HIT (xasl_p) > 0 추가
qdump_print_stats_text: 동일