### PR TITLE
[CBRD-26710] Fix CAS coredump in authenticate_context and reset cache depth

### DIFF
--- a/src/object/authenticate_cache.cpp
+++ b/src/object/authenticate_cache.cpp
@@ -826,7 +826,6 @@ authenticate_cache::reset_user_cache (void)
       u = nextu;
     }
   user_cache = NULL;
-  cache_depth = 0;
 }
 
 /*

--- a/src/object/authenticate_cache.cpp
+++ b/src/object/authenticate_cache.cpp
@@ -826,6 +826,7 @@ authenticate_cache::reset_user_cache (void)
       u = nextu;
     }
   user_cache = NULL;
+  cache_depth = 0;
 }
 
 /*

--- a/src/object/authenticate_context.cpp
+++ b/src/object/authenticate_context.cpp
@@ -700,11 +700,11 @@ authenticate_context::set_user (MOP newuser)
 	  if (user_name == nullptr)
 	    {
 	      error = ER_AU_INVALID_USER_NAME;
-              er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_AU_INVALID_USER_NAME, 1, "");
+	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_AU_INVALID_USER_NAME, 1, "");
 	      return (error);
 	    }
 	  user_cache = caches.make_user_cache (user_name, newuser, false);
-          ws_free_string (user_name);
+	  ws_free_string (user_name);
 	}
 
       if (user_cache)

--- a/src/object/authenticate_context.cpp
+++ b/src/object/authenticate_context.cpp
@@ -697,6 +697,11 @@ authenticate_context::set_user (MOP newuser)
       if (!user_cache)
 	{
 	  const char *user_name = au_get_user_name (newuser);
+	  if (user_name == nullptr)
+	    {
+	      error = ER_AU_INVALID_USER_NAME;
+	      return (error);
+	    }
 	  user_cache = caches.make_user_cache (user_name, newuser, false);
 	}
 

--- a/src/object/authenticate_context.cpp
+++ b/src/object/authenticate_context.cpp
@@ -700,9 +700,11 @@ authenticate_context::set_user (MOP newuser)
 	  if (user_name == nullptr)
 	    {
 	      error = ER_AU_INVALID_USER_NAME;
+              er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_AU_INVALID_USER_NAME, 1, "");
 	      return (error);
 	    }
 	  user_cache = caches.make_user_cache (user_name, newuser, false);
+          ws_free_string (user_name);
 	}
 
       if (user_cache)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26710

- Prevent a coredump in authenticate_context::set_user() by adding a null check for the value returned by au_get_user_name(). (Fixes crash when passing nullptr to std::string in make_user_cache)
- Fix a potential memory (class_cache->data) growth issue where cache_depth was not reset in reset_user_cache()