### PR TITLE
[CBRD-26711] Support avg,sum function on parallel heap scan

### DIFF
--- a/src/query/parallel/px_heap_scan/px_heap_scan.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan.cpp
@@ -59,9 +59,9 @@ extern "C"
 	return manager_p->next();
       }
 
-      case parallel_heap_scan::RESULT_TYPE::COUNT_DISTINCT:
+      case parallel_heap_scan::RESULT_TYPE::BUILDVALUE_OPT:
       {
-	using manager_type = parallel_heap_scan::manager < parallel_heap_scan::RESULT_TYPE::COUNT_DISTINCT >;
+	using manager_type = parallel_heap_scan::manager < parallel_heap_scan::RESULT_TYPE::BUILDVALUE_OPT >;
 	manager_type *manager_p = (manager_type *) scan_id->s.phsid.manager;
 	return manager_p->next();
       }
@@ -153,9 +153,9 @@ extern "C"
 	return manager_p->reset ();
       }
 
-      case parallel_heap_scan::RESULT_TYPE::COUNT_DISTINCT:
+      case parallel_heap_scan::RESULT_TYPE::BUILDVALUE_OPT:
       {
-	using manager_type = parallel_heap_scan::manager < parallel_heap_scan::RESULT_TYPE::COUNT_DISTINCT >;
+	using manager_type = parallel_heap_scan::manager < parallel_heap_scan::RESULT_TYPE::BUILDVALUE_OPT >;
 	manager_type *manager_p = (manager_type *) scan_id->s.phsid.manager;
 
 	manager_p->merge_stats();
@@ -223,9 +223,9 @@ extern "C"
 	break;
       }
 
-      case parallel_heap_scan::RESULT_TYPE::COUNT_DISTINCT:
+      case parallel_heap_scan::RESULT_TYPE::BUILDVALUE_OPT:
       {
-	using manager_type = parallel_heap_scan::manager < parallel_heap_scan::RESULT_TYPE::COUNT_DISTINCT >;
+	using manager_type = parallel_heap_scan::manager < parallel_heap_scan::RESULT_TYPE::BUILDVALUE_OPT >;
 	manager_type *manager_p = (manager_type *) scan_id->s.phsid.manager;
 	manager_p->end();
 	break;
@@ -307,9 +307,9 @@ extern "C"
 	break;
       }
 
-      case parallel_heap_scan::RESULT_TYPE::COUNT_DISTINCT:
+      case parallel_heap_scan::RESULT_TYPE::BUILDVALUE_OPT:
       {
-	using manager_type = parallel_heap_scan::manager < parallel_heap_scan::RESULT_TYPE::COUNT_DISTINCT >;
+	using manager_type = parallel_heap_scan::manager < parallel_heap_scan::RESULT_TYPE::BUILDVALUE_OPT >;
 
 	manager_type *manager_p = (manager_type *) scan_id->s.phsid.manager;
 
@@ -438,9 +438,9 @@ extern "C"
       {
 	scan_id->s.phsid.result_type = parallel_heap_scan::RESULT_TYPE::MERGEABLE_LIST;
       }
-    else if (ACCESS_SPEC_IS_FLAGED (spec, ACCESS_SPEC_FLAG_COUNT_DISTINCT))
+    else if (ACCESS_SPEC_IS_FLAGED (spec, ACCESS_SPEC_FLAG_BUILDVALUE_OPT))
       {
-	scan_id->s.phsid.result_type = parallel_heap_scan::RESULT_TYPE::COUNT_DISTINCT;
+	scan_id->s.phsid.result_type = parallel_heap_scan::RESULT_TYPE::BUILDVALUE_OPT;
       }
     else
       {
@@ -515,10 +515,10 @@ extern "C"
 	break;
       }
 
-      case parallel_heap_scan::RESULT_TYPE::COUNT_DISTINCT:
+      case parallel_heap_scan::RESULT_TYPE::BUILDVALUE_OPT:
       {
 	using manager_type =
-		parallel_heap_scan::manager < parallel_heap_scan::RESULT_TYPE::COUNT_DISTINCT >;
+		parallel_heap_scan::manager < parallel_heap_scan::RESULT_TYPE::BUILDVALUE_OPT >;
 
 	scan_id->s.phsid.manager = (void *) db_private_alloc (thread_p, sizeof (manager_type));
 	if (scan_id->s.phsid.manager == nullptr)
@@ -725,16 +725,16 @@ namespace parallel_heap_scan
 	m_result_handler = placement_new ((result_handler<RESULT_TYPE::XASL_SNAPSHOT> *) m_result_handler, m_query_id,
 					  &m_interrupt, &m_err_messages, m_parallelism, m_g_agg_domain_resolve_need, m_xasl);
       }
-    else if constexpr (result_type == RESULT_TYPE::COUNT_DISTINCT)
+    else if constexpr (result_type == RESULT_TYPE::BUILDVALUE_OPT)
       {
-	m_result_handler = (result_handler<RESULT_TYPE::COUNT_DISTINCT> *) db_private_alloc (m_thread_p,
-			   sizeof (result_handler<RESULT_TYPE::COUNT_DISTINCT>));
+	m_result_handler = (result_handler<RESULT_TYPE::BUILDVALUE_OPT> *) db_private_alloc (m_thread_p,
+			   sizeof (result_handler<RESULT_TYPE::BUILDVALUE_OPT>));
 	if (m_result_handler == nullptr)
 	  {
 	    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 0);
 	    return ER_FAILED;
 	  }
-	m_result_handler = placement_new ((result_handler<RESULT_TYPE::COUNT_DISTINCT> *) m_result_handler, m_query_id,
+	m_result_handler = placement_new ((result_handler<RESULT_TYPE::BUILDVALUE_OPT> *) m_result_handler, m_query_id,
 					  &m_interrupt, &m_err_messages, m_parallelism, m_xasl->proc.buildvalue.agg_list);
       }
     else
@@ -835,7 +835,7 @@ namespace parallel_heap_scan
 
     if (unlikely (!m_task_started))
       {
-	if constexpr (result_type == RESULT_TYPE::MERGEABLE_LIST || result_type == RESULT_TYPE::COUNT_DISTINCT)
+	if constexpr (result_type == RESULT_TYPE::MERGEABLE_LIST || result_type == RESULT_TYPE::BUILDVALUE_OPT)
 	  {
 	    if (m_xasl->scan_ptr)
 	      {
@@ -923,7 +923,7 @@ namespace parallel_heap_scan
       {
 	scan_code = m_result_handler->read (m_thread_p, m_xasl->val_list);
       }
-    else if constexpr (result_type == RESULT_TYPE::COUNT_DISTINCT)
+    else if constexpr (result_type == RESULT_TYPE::BUILDVALUE_OPT)
       {
 	scan_code = m_result_handler->read (m_thread_p, m_xasl->proc.buildvalue.agg_list);
 	if (m_xasl->scan_ptr)
@@ -1112,5 +1112,5 @@ namespace parallel_heap_scan
   // Explicit template instantiations
   template class manager<RESULT_TYPE::MERGEABLE_LIST>;
   template class manager<RESULT_TYPE::XASL_SNAPSHOT>;
-  template class manager<RESULT_TYPE::COUNT_DISTINCT>;
+  template class manager<RESULT_TYPE::BUILDVALUE_OPT>;
 }

--- a/src/query/parallel/px_heap_scan/px_heap_scan_checker.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_checker.cpp
@@ -75,9 +75,9 @@ namespace parallel_heap_scan
       case PT_VARIANCE:
       case PT_VAR_POP:
       case PT_VAR_SAMP:
-        return true;
+	return true;
       default:
-        return false;
+	return false;
       }
   }
 

--- a/src/query/parallel/px_heap_scan/px_heap_scan_checker.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_checker.cpp
@@ -43,20 +43,43 @@ namespace parallel_heap_scan
    *
    * When list_merge is not possible, row_by_row is always available as a fallback.
    *
-   * Count optimization (count_opt) can be applied when:
-   *   - The select list contains only count() aggregate functions
-   *   - list_merge mode: count_opt is always possible
-   *   - row_by_row mode: count_opt may not be possible due to constraints like ROWNUM
+   * Buildvalue optimization (buildvalue_opt) can be applied when:
+   *   - The select list contains only aggregate functions suitable for buildvalue optimization
+   *   - list_merge mode: buildvalue_opt is always possible
+   *   - row_by_row mode: buildvalue_opt may not be possible due to constraints like ROWNUM
    *
-   * The COUNT_OPT_POSSIBLE flag specifically checks:
-   *   1. Whether the select list consists solely of count() functions
-   *   2. Whether row_by_row constraints (e.g., ROWNUM usage) prevent count optimization
+   * The BUILDVALUE_OPT_POSSIBLE flag specifically checks:
+   *   1. Whether the select list consists solely of suitable aggregate functions
+   *   2. Whether row_by_row constraints (e.g., ROWNUM usage) prevent buildvalue optimization
    */
 
   using possible_flags = uint32_t;
   const possible_flags CANNOT_PARALLEL_HEAP_SCAN = 0x1 << 0;
   const possible_flags CANNOT_LIST_MERGE = 0x1 << 1;
-  const possible_flags CANNOT_COUNT_OPT = 0x1 << 2;
+  const possible_flags CANNOT_BUILDVALUE_OPT = 0x1 << 2;
+
+  static bool
+  is_buildvalue_opt_supported_function (FUNC_CODE function)
+  {
+    switch (function)
+      {
+      case PT_COUNT_STAR:
+      case PT_COUNT:
+      case PT_MIN:
+      case PT_MAX:
+      case PT_SUM:
+      case PT_AVG:
+      case PT_STDDEV:
+      case PT_STDDEV_POP:
+      case PT_STDDEV_SAMP:
+      case PT_VARIANCE:
+      case PT_VAR_POP:
+      case PT_VAR_SAMP:
+        return true;
+      default:
+        return false;
+      }
+  }
 
   // Thread-local map to cache check results for XASL_NODE and prevent infinite recursion
   // This is used to detect circular references in XASL structures and reuse computed results
@@ -480,7 +503,7 @@ namespace parallel_heap_scan
     xasl_check_cache[arg] = 0;
 
     possible_flags result = 0, temp = 0;
-    bool count_opt = false;
+    bool buildvalue_opt = false;
     switch (arg->type)
       {
       case BUILDLIST_PROC:
@@ -489,28 +512,28 @@ namespace parallel_heap_scan
 	if (arg->proc.buildvalue.agg_list)
 	  {
 	    set_flag (result, CANNOT_LIST_MERGE);
-	    count_opt = true;
+	    buildvalue_opt = true;
 	    AGGREGATE_TYPE *agg_it = arg->proc.buildvalue.agg_list;
 	    int agg_cnt = 0;
 	    temp = 0;
 	    for (; agg_it; agg_it = agg_it->next)
 	      {
 		agg_cnt++;
-		if (agg_it->function != PT_COUNT_STAR && agg_it->function != PT_COUNT)
+		if (!is_buildvalue_opt_supported_function (agg_it->function))
 		  {
-		    count_opt = false;
+		    buildvalue_opt = false;
 		    break;
 		  }
 		temp |= check<false> (agg_it->operands);
 		if (is_flag_set (temp, CANNOT_PARALLEL_HEAP_SCAN))
 		  {
-		    count_opt = false;
+		    buildvalue_opt = false;
 		    break;
 		  }
 	      }
 	    if (agg_cnt != arg->outptr_list->valptr_cnt)
 	      {
-		count_opt = false;
+		buildvalue_opt = false;
 	      }
 	  }
 	break;
@@ -577,7 +600,7 @@ namespace parallel_heap_scan
     if (arg->connect_by_ptr)
       {
 	set_flag (result, CANNOT_LIST_MERGE);
-	count_opt = false;
+	buildvalue_opt = false;
       }
 
     if (arg->if_pred)
@@ -591,7 +614,7 @@ namespace parallel_heap_scan
     if (arg->instnum_pred || arg->instnum_val)
       {
 	set_flag (result, CANNOT_LIST_MERGE);
-	count_opt = false;
+	buildvalue_opt = false;
       }
 
     if (arg->outptr_list)
@@ -608,9 +631,9 @@ namespace parallel_heap_scan
 	result |= check<false> (specp);
       }
 
-    if (!count_opt)
+    if (!buildvalue_opt)
       {
-	set_flag (result, CANNOT_COUNT_OPT);
+	set_flag (result, CANNOT_BUILDVALUE_OPT);
       }
 
     // Update cache with computed result
@@ -716,12 +739,12 @@ namespace parallel_heap_scan
     else
       {
 	/* parallel heap scan is possible */
-	if (!is_flag_set (result, CANNOT_COUNT_OPT))
+	if (!is_flag_set (result, CANNOT_BUILDVALUE_OPT))
 	  {
-	    /* count optimization is possible */
+	    /* buildvalue optimization is possible */
 	    for (ACCESS_SPEC_TYPE *specp = arg->spec_list; specp; specp = specp->next)
 	      {
-		ACCESS_SPEC_SET_FLAG (specp, ACCESS_SPEC_FLAG_COUNT_DISTINCT);
+		ACCESS_SPEC_SET_FLAG (specp, ACCESS_SPEC_FLAG_BUILDVALUE_OPT);
 	      }
 	  }
 	else

--- a/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
@@ -1056,7 +1056,6 @@ namespace parallel_heap_scan
 
   bool result_handler<RESULT_TYPE::BUILDVALUE_OPT>::write (THREAD_ENTRY *thread_p)
   {
-    QFILE_TUPLE_RECORD tpl_buf;
     if (!tl_xasl_p->proc.buildvalue.agg_domains_resolved)
       {
 	if (qexec_resolve_domains_for_aggregation_for_parallel_heap_scan_buildvalue_proc (thread_p, tl_xasl_p, tl_vd,
@@ -1232,6 +1231,7 @@ namespace parallel_heap_scan
 
 		if (tp_value_coerce (db_value_p, &coerced, acc_dom->value_dom) != DOMAIN_COMPATIBLE)
 		  {
+		    pr_clear_value (&coerced);
 		    return false;
 		  }
 
@@ -1306,7 +1306,13 @@ namespace parallel_heap_scan
 
 	      if (orig_agg_p->list_id->tuple_cnt > 0)
 		{
-		  QFILE_LIST_ID *list_id_p = (QFILE_LIST_ID *) malloc (sizeof (QFILE_LIST_ID));
+		  QFILE_LIST_ID *list_id_p = (QFILE_LIST_ID *) db_private_alloc (thread_p, sizeof (QFILE_LIST_ID));
+		  if (list_id_p == nullptr)
+		    {
+		      qfile_clear_list_id (cur_agg_p->list_id);
+		      cur_agg_p = cur_agg_p->next;
+		      continue;
+		    }
 		  qfile_copy_list_id (list_id_p, cur_agg_p->list_id, false, QFILE_PROHIBIT_DEPENDENT);
 		  qfile_connect_list (thread_p, orig_agg_p->list_id, list_id_p);
 		  qfile_clear_list_id (cur_agg_p->list_id);

--- a/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
@@ -44,12 +44,12 @@ namespace parallel_heap_scan
   template <RESULT_TYPE result_type>
   thread_local typename result_handler<result_type>::tls result_handler<result_type>::tl;
 
-  thread_local AGGREGATE_TYPE *result_handler<RESULT_TYPE::COUNT_DISTINCT>::tl_agg_p;
-  thread_local OUTPTR_LIST *result_handler<RESULT_TYPE::COUNT_DISTINCT>::tl_outptr_list_p;
-  thread_local VAL_DESCR *result_handler<RESULT_TYPE::COUNT_DISTINCT>::tl_vd;
-  thread_local xasl_node *result_handler<RESULT_TYPE::COUNT_DISTINCT>::tl_xasl_p;
-  thread_local QFILE_TUPLE_RECORD result_handler<RESULT_TYPE::COUNT_DISTINCT>::tl_tpl_buf;
-  thread_local OR_BUF result_handler<RESULT_TYPE::COUNT_DISTINCT>::tl_or_buf;
+  thread_local AGGREGATE_TYPE *result_handler<RESULT_TYPE::BUILDVALUE_OPT>::tl_agg_p;
+  thread_local OUTPTR_LIST *result_handler<RESULT_TYPE::BUILDVALUE_OPT>::tl_outptr_list_p;
+  thread_local VAL_DESCR *result_handler<RESULT_TYPE::BUILDVALUE_OPT>::tl_vd;
+  thread_local xasl_node *result_handler<RESULT_TYPE::BUILDVALUE_OPT>::tl_xasl_p;
+  thread_local QFILE_TUPLE_RECORD result_handler<RESULT_TYPE::BUILDVALUE_OPT>::tl_tpl_buf;
+  thread_local OR_BUF result_handler<RESULT_TYPE::BUILDVALUE_OPT>::tl_or_buf;
 
   int update_domains_on_type_list_by_val_list (THREAD_ENTRY *thread_p, QFILE_LIST_ID *list_id_p, VAL_LIST *val_list_p)
   {
@@ -929,7 +929,7 @@ namespace parallel_heap_scan
       }
   }
 
-  result_handler<RESULT_TYPE::COUNT_DISTINCT>::result_handler (QUERY_ID query_id, interrupt *interrupt_p,
+  result_handler<RESULT_TYPE::BUILDVALUE_OPT>::result_handler (QUERY_ID query_id, interrupt *interrupt_p,
       err_messages_with_lock *err_messages_p, int parallelism, AGGREGATE_TYPE *orig_agg_list)
   {
     m_parallelism = parallelism;
@@ -940,12 +940,15 @@ namespace parallel_heap_scan
     m_orig_agg_list = orig_agg_list;
   }
 
-  void result_handler<RESULT_TYPE::COUNT_DISTINCT>::read_initialize (THREAD_ENTRY *thread_p)
+  void result_handler<RESULT_TYPE::BUILDVALUE_OPT>::read_initialize (THREAD_ENTRY *thread_p)
   {
     for (AGGREGATE_TYPE *orig_agg_p = m_orig_agg_list; orig_agg_p != NULL; orig_agg_p = orig_agg_p->next)
       {
-	orig_agg_p->accumulator_domain.value_dom = &tp_Bigint_domain;
-	orig_agg_p->accumulator_domain.value2_dom = &tp_Null_domain;
+	if (orig_agg_p->function == PT_COUNT_STAR || orig_agg_p->function == PT_COUNT)
+	  {
+	    orig_agg_p->accumulator_domain.value_dom = &tp_Bigint_domain;
+	    orig_agg_p->accumulator_domain.value2_dom = &tp_Null_domain;
+	  }
 	if (orig_agg_p->list_id != nullptr)
 	  {
 	    qfile_close_list (thread_p, orig_agg_p->list_id);
@@ -953,7 +956,7 @@ namespace parallel_heap_scan
       }
   }
 
-  SCAN_CODE result_handler<RESULT_TYPE::COUNT_DISTINCT>::read (THREAD_ENTRY *thread_p, AGGREGATE_TYPE *dest)
+  SCAN_CODE result_handler<RESULT_TYPE::BUILDVALUE_OPT>::read (THREAD_ENTRY *thread_p, AGGREGATE_TYPE *dest)
   {
     std::unique_lock<std::mutex> lock (m_result_mutex);
     while (m_result_completed < m_parallelism)
@@ -968,29 +971,46 @@ namespace parallel_heap_scan
       {
 	if (orig_agg_p->function == PT_COUNT_STAR)
 	  {
-	    ;
+	  }
+	else if (orig_agg_p->option == Q_DISTINCT)
+	  {
 	  }
 	else if (orig_agg_p->function == PT_COUNT)
 	  {
-	    if (orig_agg_p->option == Q_DISTINCT)
+	    db_make_bigint (orig_agg_p->accumulator.value, (INT64) orig_agg_p->accumulator.curr_cnt);
+	  }
+	else
+	  {
+	    DB_VALUE tmp;
+	    if (!DB_IS_NULL (orig_agg_p->accumulator.value))
 	      {
-		;
+		db_make_null (&tmp);
+		pr_clone_value (orig_agg_p->accumulator.value, &tmp);
+		HL_HEAPID save_heap = db_change_private_heap (thread_p, 0);
+		pr_clear_value (orig_agg_p->accumulator.value);
+		db_change_private_heap (thread_p, save_heap);
+		*(orig_agg_p->accumulator.value) = tmp;
 	      }
-	    else
+	    if (orig_agg_p->accumulator.value2 != NULL && !DB_IS_NULL (orig_agg_p->accumulator.value2))
 	      {
-		db_make_bigint (orig_agg_p->accumulator.value, (INT64) orig_agg_p->accumulator.curr_cnt);
+		db_make_null (&tmp);
+		pr_clone_value (orig_agg_p->accumulator.value2, &tmp);
+		HL_HEAPID save_heap = db_change_private_heap (thread_p, 0);
+		pr_clear_value (orig_agg_p->accumulator.value2);
+		db_change_private_heap (thread_p, save_heap);
+		*(orig_agg_p->accumulator.value2) = tmp;
 	      }
 	  }
       }
     return S_END;
   }
 
-  void result_handler<RESULT_TYPE::COUNT_DISTINCT>::read_finalize (THREAD_ENTRY *thread_p)
+  void result_handler<RESULT_TYPE::BUILDVALUE_OPT>::read_finalize (THREAD_ENTRY *thread_p)
   {
 
   }
 
-  void result_handler<RESULT_TYPE::COUNT_DISTINCT>::write_initialize (THREAD_ENTRY *thread_p, OUTPTR_LIST *outptr_list,
+  void result_handler<RESULT_TYPE::BUILDVALUE_OPT>::write_initialize (THREAD_ENTRY *thread_p, OUTPTR_LIST *outptr_list,
       write_dest_type *agg_p, VAL_DESCR *vd, xasl_node *xasl_p)
   {
     tl_outptr_list_p = outptr_list;
@@ -1005,37 +1025,35 @@ namespace parallel_heap_scan
 	  {
 	    agg_node->accumulator.curr_cnt = 0;
 	  }
+	else if (agg_node->option == Q_DISTINCT)
+	  {
+	    int ls_flag = QFILE_FLAG_DISTINCT | QFILE_NOT_USE_MEMBUF;
+	    QFILE_TUPLE_VALUE_TYPE_LIST type_list;
+	    type_list.type_cnt = 1;
+	    type_list.domp = (TP_DOMAIN **) db_private_alloc (thread_p, sizeof (TP_DOMAIN *));
+	    if (type_list.domp == NULL)
+	      {
+		return;
+	      }
+	    type_list.domp[0] = agg_node->operands->value.domain;
+	    agg_node->list_id = qfile_open_list (thread_p, &type_list, NULL, m_query_id, ls_flag, agg_node->list_id);
+	    db_private_free_and_init (thread_p, type_list.domp);
+	    if (agg_node->list_id == nullptr)
+	      {
+		return;
+	      }
+	  }
 	else
 	  {
-	    assert (agg_node->function == PT_COUNT);
-	    if (agg_node->option == Q_DISTINCT)
-	      {
-		int ls_flag = QFILE_FLAG_DISTINCT|QFILE_NOT_USE_MEMBUF;
-		QFILE_TUPLE_VALUE_TYPE_LIST type_list;
-		type_list.type_cnt = 1;
-		type_list.domp = (TP_DOMAIN **) db_private_alloc (thread_p, sizeof (TP_DOMAIN *));
-		if (type_list.domp == NULL)
-		  {
-		    return;
-		  }
-		type_list.domp[0] = agg_node->operands->value.domain;
-		agg_node->list_id = qfile_open_list (thread_p, &type_list, NULL, m_query_id, ls_flag, agg_node->list_id);
-		db_private_free_and_init (thread_p, type_list.domp);
-		if (agg_node->list_id == nullptr)
-		  {
-		    return;
-		  }
-	      }
-	    else
-	      {
-		agg_node->accumulator.curr_cnt = 0;
-	      }
+	    /* Non-DISTINCT: init curr_cnt for all types.
+	     * value/value2 initialization happens on first row in write() via curr_cnt < 1 check. */
+	    agg_node->accumulator.curr_cnt = 0;
 	  }
       }
 
   }
 
-  bool result_handler<RESULT_TYPE::COUNT_DISTINCT>::write (THREAD_ENTRY *thread_p)
+  bool result_handler<RESULT_TYPE::BUILDVALUE_OPT>::write (THREAD_ENTRY *thread_p)
   {
     QFILE_TUPLE_RECORD tpl_buf;
     if (!tl_xasl_p->proc.buildvalue.agg_domains_resolved)
@@ -1048,78 +1066,217 @@ namespace parallel_heap_scan
       }
     for (AGGREGATE_TYPE *agg_node = tl_xasl_p->proc.buildvalue.agg_list; agg_node != NULL; agg_node = agg_node->next)
       {
+	AGGREGATE_ACCUMULATOR *acc = &agg_node->accumulator;
+	AGGREGATE_ACCUMULATOR_DOMAIN *acc_dom = &agg_node->accumulator_domain;
+
 	if (agg_node->function == PT_COUNT_STAR)
 	  {
-	    agg_node->accumulator.curr_cnt ++;
+	    acc->curr_cnt++;
 	    continue;
+	  }
+
+	DB_VALUE *db_value_p;
+	if (agg_node->operands->value.type == TYPE_CONSTANT)
+	  {
+	    db_value_p = agg_node->operands->value.value.dbvalptr;
 	  }
 	else
 	  {
-	    assert (agg_node->function == PT_COUNT);
-	    if (agg_node->option == Q_DISTINCT)
+	    int err_code = fetch_peek_dbval (thread_p, &agg_node->operands->value, tl_vd, NULL, NULL,
+					     tl_tpl_buf.tpl, &db_value_p);
+	    if (err_code != NO_ERROR)
 	      {
-		for (REGU_VARIABLE_LIST operand = agg_node->operands; operand != NULL; operand = operand->next)
-		  {
-		    DB_VALUE *db_value_p;
-		    if (operand->value.type == TYPE_CONSTANT)
-		      {
-			db_value_p = operand->value.value.dbvalptr;
-		      }
-		    else
-		      {
-			int err_code = fetch_peek_dbval (thread_p, &operand->value, tl_vd, NULL, NULL, tl_tpl_buf.tpl, &db_value_p);
-			if (err_code != NO_ERROR)
-			  {
-			    return false;
-			  }
-		      }
-		    if (DB_IS_NULL (db_value_p))
-		      {
-			continue;
-		      }
-		    DB_TYPE dbval_type = DB_VALUE_DOMAIN_TYPE (db_value_p);
-		    const PR_TYPE *pr_type_p = pr_type_from_id (dbval_type);
-		    int dbval_size = pr_data_writeval_disk_size (db_value_p);
-		    if (dbval_size > tl_tpl_buf.size)
-		      {
-			tl_tpl_buf.tpl = (char *)db_private_realloc (thread_p, tl_tpl_buf.tpl, dbval_size);
-			tl_tpl_buf.size = dbval_size;
-		      }
-		    or_init (&tl_or_buf, tl_tpl_buf.tpl, dbval_size);
-		    pr_type_p->data_writeval (&tl_or_buf, db_value_p);
-		    if (qfile_add_item_to_list (thread_p, tl_tpl_buf.tpl, dbval_size, agg_node->list_id) != NO_ERROR)
-		      {
-			return false;
-		      }
-		  }
+		return false;
 	      }
-	    else
+	  }
+
+	if (DB_IS_NULL (db_value_p))
+	  {
+	    continue;
+	  }
+
+	if (agg_node->option == Q_DISTINCT)
+	  {
+	    for (REGU_VARIABLE_LIST operand = agg_node->operands; operand != NULL; operand = operand->next)
 	      {
-		DB_VALUE *db_value_p;
-		if (agg_node->operands->value.type == TYPE_CONSTANT)
+		DB_VALUE *op_val_p;
+		if (operand->value.type == TYPE_CONSTANT)
 		  {
-		    db_value_p = agg_node->operands->value.value.dbvalptr;
+		    op_val_p = operand->value.value.dbvalptr;
 		  }
 		else
 		  {
-		    int err_code = fetch_peek_dbval (thread_p, &agg_node->operands->value, tl_vd, NULL, NULL, tl_tpl_buf.tpl, &db_value_p);
+		    int err_code = fetch_peek_dbval (thread_p, &operand->value, tl_vd, NULL, NULL,
+						     tl_tpl_buf.tpl, &op_val_p);
 		    if (err_code != NO_ERROR)
 		      {
 			return false;
 		      }
 		  }
-
-		if (DB_IS_NULL (db_value_p))
+		if (DB_IS_NULL (op_val_p))
 		  {
 		    continue;
 		  }
-		agg_node->accumulator.curr_cnt ++;
+		DB_TYPE dbval_type = DB_VALUE_DOMAIN_TYPE (op_val_p);
+		const PR_TYPE *pr_type_p = pr_type_from_id (dbval_type);
+		int dbval_size = pr_data_writeval_disk_size (op_val_p);
+		if (dbval_size > tl_tpl_buf.size)
+		  {
+		    tl_tpl_buf.tpl = (char *) db_private_realloc (thread_p, tl_tpl_buf.tpl, dbval_size);
+		    tl_tpl_buf.size = dbval_size;
+		  }
+		or_init (&tl_or_buf, tl_tpl_buf.tpl, dbval_size);
+		pr_type_p->data_writeval (&tl_or_buf, op_val_p);
+		if (qfile_add_item_to_list (thread_p, tl_tpl_buf.tpl, dbval_size, agg_node->list_id) != NO_ERROR)
+		  {
+		    return false;
+		  }
+	      }
+	  }
+	else
+	  {
+	    switch (agg_node->function)
+	      {
+	      case PT_COUNT:
+		acc->curr_cnt++;
+		break;
+
+	      case PT_MIN:
+		{
+		  int coll_id = acc_dom->value_dom->collation_id;
+		  if (acc->curr_cnt < 1
+		      || acc_dom->value_dom->type->cmpval (acc->value, db_value_p, 1, 1, NULL, coll_id) > 0)
+		    {
+		      DB_TYPE type = DB_VALUE_DOMAIN_TYPE (db_value_p);
+		      pr_clear_value (acc->value);
+		      if (TP_DOMAIN_TYPE (acc_dom->value_dom) != type)
+			{
+			  if (db_value_coerce (db_value_p, acc->value, acc_dom->value_dom) != NO_ERROR)
+			    {
+			      return false;
+			    }
+			}
+		      else
+			{
+			  pr_clone_value (db_value_p, acc->value);
+			}
+		    }
+		  acc->curr_cnt++;
+		}
+		break;
+
+	      case PT_MAX:
+		{
+		  int coll_id = acc_dom->value_dom->collation_id;
+		  if (acc->curr_cnt < 1
+		      || acc_dom->value_dom->type->cmpval (acc->value, db_value_p, 1, 1, NULL, coll_id) < 0)
+		    {
+		      DB_TYPE type = DB_VALUE_DOMAIN_TYPE (db_value_p);
+		      pr_clear_value (acc->value);
+		      if (TP_DOMAIN_TYPE (acc_dom->value_dom) != type)
+			{
+			  if (db_value_coerce (db_value_p, acc->value, acc_dom->value_dom) != NO_ERROR)
+			    {
+			      return false;
+			    }
+			}
+		      else
+			{
+			  pr_clone_value (db_value_p, acc->value);
+			}
+		    }
+		  acc->curr_cnt++;
+		}
+		break;
+
+	      case PT_SUM:
+	      case PT_AVG:
+		if (acc->curr_cnt < 1)
+		  {
+		    DB_TYPE type = DB_VALUE_DOMAIN_TYPE (db_value_p);
+		    pr_clear_value (acc->value);
+		    if (TP_DOMAIN_TYPE (acc_dom->value_dom) != type)
+		      {
+			if (db_value_coerce (db_value_p, acc->value, acc_dom->value_dom) != NO_ERROR)
+			  {
+			    return false;
+			  }
+		      }
+		    else
+		      {
+			pr_clone_value (db_value_p, acc->value);
+		      }
+		  }
+		else
+		  {
+		    if (qdata_add_dbval (acc->value, db_value_p, acc->value, acc_dom->value_dom) != NO_ERROR)
+		      {
+			return false;
+		      }
+		  }
+		acc->curr_cnt++;
+		break;
+
+	      case PT_STDDEV:
+	      case PT_STDDEV_POP:
+	      case PT_STDDEV_SAMP:
+	      case PT_VARIANCE:
+	      case PT_VAR_POP:
+	      case PT_VAR_SAMP:
+		{
+		  DB_VALUE coerced, squared;
+		  db_make_null (&coerced);
+		  db_make_null (&squared);
+
+		  if (tp_value_coerce (db_value_p, &coerced, acc_dom->value_dom) != DOMAIN_COMPATIBLE)
+		    {
+		      return false;
+		    }
+
+		  if (qdata_multiply_dbval (&coerced, &coerced, &squared, acc_dom->value2_dom) != NO_ERROR)
+		    {
+		      pr_clear_value (&coerced);
+		      return false;
+		    }
+
+		  if (acc->curr_cnt < 1)
+		    {
+		      pr_clear_value (acc->value);
+		      pr_clear_value (acc->value2);
+		      acc_dom->value_dom->type->setval (acc->value, &coerced, true);
+		      acc_dom->value2_dom->type->setval (acc->value2, &squared, true);
+		    }
+		  else
+		    {
+		      if (qdata_add_dbval (acc->value, &coerced, acc->value, acc_dom->value_dom) != NO_ERROR)
+			{
+			  pr_clear_value (&coerced);
+			  pr_clear_value (&squared);
+			  return false;
+			}
+		      if (qdata_add_dbval (acc->value2, &squared, acc->value2, acc_dom->value2_dom) != NO_ERROR)
+			{
+			  pr_clear_value (&coerced);
+			  pr_clear_value (&squared);
+			  return false;
+			}
+		    }
+
+		  pr_clear_value (&coerced);
+		  pr_clear_value (&squared);
+		  acc->curr_cnt++;
+		}
+		break;
+
+	      default:
+		assert (false);
+		return false;
 	      }
 	  }
       }
     return true;
   }
-  void result_handler<RESULT_TYPE::COUNT_DISTINCT>::write_finalize (THREAD_ENTRY *thread_p)
+  void result_handler<RESULT_TYPE::BUILDVALUE_OPT>::write_finalize (THREAD_ENTRY *thread_p)
   {
     {
       std::lock_guard<std::mutex> lock (writer_results_mutex);
@@ -1133,47 +1290,65 @@ namespace parallel_heap_scan
 	      cur_agg_p = cur_agg_p->next;
 	      continue;
 	    }
-	  else
+
+	  if (orig_agg_p->option == Q_DISTINCT)
 	    {
-	      assert (orig_agg_p->function == PT_COUNT);
-	      if (orig_agg_p->option == Q_DISTINCT)
+	      qfile_close_list (thread_p, cur_agg_p->list_id);
+	      if (cur_agg_p->list_id->tuple_cnt == 0)
 		{
-		  qfile_close_list (thread_p, cur_agg_p->list_id);
-		  if (cur_agg_p->list_id->tuple_cnt == 0)
-		    {
-		      qfile_destroy_list (thread_p, cur_agg_p->list_id);
-		      cur_agg_p = cur_agg_p->next;
-		      continue;
-		    }
+		  qfile_destroy_list (thread_p, cur_agg_p->list_id);
+		  cur_agg_p = cur_agg_p->next;
+		  continue;
+		}
 
-		  if (orig_agg_p->list_id->tuple_cnt > 0)
-		    {
-		      QFILE_LIST_ID *list_id_p = (QFILE_LIST_ID *)malloc (sizeof (QFILE_LIST_ID));
-		      qfile_copy_list_id (list_id_p, cur_agg_p->list_id, false, QFILE_PROHIBIT_DEPENDENT);
-		      qfile_connect_list (thread_p, orig_agg_p->list_id, list_id_p);
-		      qfile_clear_list_id (cur_agg_p->list_id);
-		      cur_agg_p = cur_agg_p->next;
-		      continue;
-		    }
-		  else if (orig_agg_p->list_id->type_list.type_cnt > 0)
-		    {
-		      qfile_clear_list_id (orig_agg_p->list_id);
-		    }
-		  else
-		    {
-		      QFILE_CLEAR_LIST_ID (orig_agg_p->list_id);
-		    }
-
-		  qfile_copy_list_id (orig_agg_p->list_id, cur_agg_p->list_id, false, QFILE_PROHIBIT_DEPENDENT);
+	      if (orig_agg_p->list_id->tuple_cnt > 0)
+		{
+		  QFILE_LIST_ID *list_id_p = (QFILE_LIST_ID *) malloc (sizeof (QFILE_LIST_ID));
+		  qfile_copy_list_id (list_id_p, cur_agg_p->list_id, false, QFILE_PROHIBIT_DEPENDENT);
+		  qfile_connect_list (thread_p, orig_agg_p->list_id, list_id_p);
 		  qfile_clear_list_id (cur_agg_p->list_id);
+		  cur_agg_p = cur_agg_p->next;
+		  continue;
+		}
+	      else if (orig_agg_p->list_id->type_list.type_cnt > 0)
+		{
+		  qfile_clear_list_id (orig_agg_p->list_id);
 		}
 	      else
 		{
-		  orig_agg_p->accumulator.curr_cnt += cur_agg_p->accumulator.curr_cnt;
-		  cur_agg_p->accumulator.curr_cnt = 0;
+		  QFILE_CLEAR_LIST_ID (orig_agg_p->list_id);
 		}
-	      cur_agg_p = cur_agg_p->next;
+
+	      qfile_copy_list_id (orig_agg_p->list_id, cur_agg_p->list_id, false, QFILE_PROHIBIT_DEPENDENT);
+	      qfile_clear_list_id (cur_agg_p->list_id);
 	    }
+	  else if (orig_agg_p->function == PT_COUNT)
+	    {
+	      orig_agg_p->accumulator.curr_cnt += cur_agg_p->accumulator.curr_cnt;
+	      cur_agg_p->accumulator.curr_cnt = 0;
+	    }
+	  else
+	    {
+	      if (orig_agg_p->accumulator_domain.value_dom == NULL && cur_agg_p->accumulator_domain.value_dom != NULL)
+		{
+		  orig_agg_p->accumulator_domain.value_dom = cur_agg_p->accumulator_domain.value_dom;
+		  orig_agg_p->accumulator_domain.value2_dom = cur_agg_p->accumulator_domain.value2_dom;
+		}
+
+	      HL_HEAPID prev_heap_id = db_change_private_heap (thread_p, 0);
+	      (void) qdata_aggregate_accumulator_to_accumulator (thread_p, &orig_agg_p->accumulator,
+		  &orig_agg_p->accumulator_domain, orig_agg_p->function,
+		  orig_agg_p->domain, &cur_agg_p->accumulator);
+	      db_change_private_heap (thread_p, prev_heap_id);
+
+	      pr_clear_value (cur_agg_p->accumulator.value);
+	      if (cur_agg_p->accumulator.value2 != NULL && !DB_IS_NULL (cur_agg_p->accumulator.value2))
+		{
+		  pr_clear_value (cur_agg_p->accumulator.value2);
+		}
+	      cur_agg_p->accumulator.curr_cnt = 0;
+	    }
+	  cur_agg_p = cur_agg_p->next;
 	}
     }
 
@@ -1198,5 +1373,5 @@ namespace parallel_heap_scan
 // Explicit template instantiations
   template class result_handler<RESULT_TYPE::MERGEABLE_LIST>;
   template class result_handler<RESULT_TYPE::XASL_SNAPSHOT>;
-  template class result_handler<RESULT_TYPE::COUNT_DISTINCT>;
+  template class result_handler<RESULT_TYPE::BUILDVALUE_OPT>;
 }

--- a/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
@@ -1026,6 +1026,7 @@ namespace parallel_heap_scan
     tl_xasl_p = xasl_p;
     tl_tpl_buf.tpl = (char *)db_private_alloc (thread_p, DB_PAGESIZE);
     tl_tpl_buf.size = DB_PAGESIZE;
+    tl_xasl_p->proc.buildvalue.agg_domains_resolved = 0;
     for (AGGREGATE_TYPE *agg_node = tl_xasl_p->proc.buildvalue.agg_list; agg_node != NULL; agg_node = agg_node->next)
       {
 	if (agg_node->function == PT_COUNT_STAR)

--- a/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
@@ -1354,9 +1354,11 @@ namespace parallel_heap_scan
 
 	      if (orig_agg_p->list_id->tuple_cnt > 0)
 		{
-		  QFILE_LIST_ID *list_id_p = (QFILE_LIST_ID *) db_private_alloc (thread_p, sizeof (QFILE_LIST_ID));
+		  QFILE_LIST_ID *list_id_p = (QFILE_LIST_ID *) malloc (sizeof (QFILE_LIST_ID));
 		  if (list_id_p == nullptr)
 		    {
+		      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1,
+			      (size_t) sizeof (QFILE_LIST_ID));
 		      m_err_messages_p->move_top_error_message_to_this ();
 		      m_interrupt_p->set_code (parallel_query::interrupt::interrupt_code::ERROR_INTERRUPTED_FROM_WORKER_THREAD);
 		      qfile_destroy_list (thread_p, cur_agg_p->list_id);

--- a/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
@@ -1340,8 +1340,8 @@ namespace parallel_heap_scan
 
 	      HL_HEAPID prev_heap_id = db_change_private_heap (thread_p, 0);
 	      int err = qdata_aggregate_accumulator_to_accumulator (thread_p, &orig_agg_p->accumulator,
-			    &orig_agg_p->accumulator_domain, orig_agg_p->function,
-			    orig_agg_p->domain, &cur_agg_p->accumulator);
+			&orig_agg_p->accumulator_domain, orig_agg_p->function,
+			orig_agg_p->domain, &cur_agg_p->accumulator);
 	      db_change_private_heap (thread_p, prev_heap_id);
 	      if (err != NO_ERROR)
 		{

--- a/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
@@ -989,7 +989,7 @@ namespace parallel_heap_scan
 		HL_HEAPID save_heap = db_change_private_heap (thread_p, 0);
 		pr_clear_value (orig_agg_p->accumulator.value);
 		db_change_private_heap (thread_p, save_heap);
-		*(orig_agg_p->accumulator.value) = tmp;
+		* (orig_agg_p->accumulator.value) = tmp;
 	      }
 	    if (orig_agg_p->accumulator.value2 != NULL && !DB_IS_NULL (orig_agg_p->accumulator.value2))
 	      {
@@ -998,7 +998,7 @@ namespace parallel_heap_scan
 		HL_HEAPID save_heap = db_change_private_heap (thread_p, 0);
 		pr_clear_value (orig_agg_p->accumulator.value2);
 		db_change_private_heap (thread_p, save_heap);
-		*(orig_agg_p->accumulator.value2) = tmp;
+		* (orig_agg_p->accumulator.value2) = tmp;
 	      }
 	  }
       }
@@ -1142,52 +1142,52 @@ namespace parallel_heap_scan
 		break;
 
 	      case PT_MIN:
-		{
-		  int coll_id = acc_dom->value_dom->collation_id;
-		  if (acc->curr_cnt < 1
-		      || acc_dom->value_dom->type->cmpval (acc->value, db_value_p, 1, 1, NULL, coll_id) > 0)
-		    {
-		      DB_TYPE type = DB_VALUE_DOMAIN_TYPE (db_value_p);
-		      pr_clear_value (acc->value);
-		      if (TP_DOMAIN_TYPE (acc_dom->value_dom) != type)
-			{
-			  if (db_value_coerce (db_value_p, acc->value, acc_dom->value_dom) != NO_ERROR)
-			    {
-			      return false;
-			    }
-			}
-		      else
-			{
-			  pr_clone_value (db_value_p, acc->value);
-			}
-		    }
-		  acc->curr_cnt++;
-		}
-		break;
+	      {
+		int coll_id = acc_dom->value_dom->collation_id;
+		if (acc->curr_cnt < 1
+		    || acc_dom->value_dom->type->cmpval (acc->value, db_value_p, 1, 1, NULL, coll_id) > 0)
+		  {
+		    DB_TYPE type = DB_VALUE_DOMAIN_TYPE (db_value_p);
+		    pr_clear_value (acc->value);
+		    if (TP_DOMAIN_TYPE (acc_dom->value_dom) != type)
+		      {
+			if (db_value_coerce (db_value_p, acc->value, acc_dom->value_dom) != NO_ERROR)
+			  {
+			    return false;
+			  }
+		      }
+		    else
+		      {
+			pr_clone_value (db_value_p, acc->value);
+		      }
+		  }
+		acc->curr_cnt++;
+	      }
+	      break;
 
 	      case PT_MAX:
-		{
-		  int coll_id = acc_dom->value_dom->collation_id;
-		  if (acc->curr_cnt < 1
-		      || acc_dom->value_dom->type->cmpval (acc->value, db_value_p, 1, 1, NULL, coll_id) < 0)
-		    {
-		      DB_TYPE type = DB_VALUE_DOMAIN_TYPE (db_value_p);
-		      pr_clear_value (acc->value);
-		      if (TP_DOMAIN_TYPE (acc_dom->value_dom) != type)
-			{
-			  if (db_value_coerce (db_value_p, acc->value, acc_dom->value_dom) != NO_ERROR)
-			    {
-			      return false;
-			    }
-			}
-		      else
-			{
-			  pr_clone_value (db_value_p, acc->value);
-			}
-		    }
-		  acc->curr_cnt++;
-		}
-		break;
+	      {
+		int coll_id = acc_dom->value_dom->collation_id;
+		if (acc->curr_cnt < 1
+		    || acc_dom->value_dom->type->cmpval (acc->value, db_value_p, 1, 1, NULL, coll_id) < 0)
+		  {
+		    DB_TYPE type = DB_VALUE_DOMAIN_TYPE (db_value_p);
+		    pr_clear_value (acc->value);
+		    if (TP_DOMAIN_TYPE (acc_dom->value_dom) != type)
+		      {
+			if (db_value_coerce (db_value_p, acc->value, acc_dom->value_dom) != NO_ERROR)
+			  {
+			    return false;
+			  }
+		      }
+		    else
+		      {
+			pr_clone_value (db_value_p, acc->value);
+		      }
+		  }
+		acc->curr_cnt++;
+	      }
+	      break;
 
 	      case PT_SUM:
 	      case PT_AVG:
@@ -1223,50 +1223,50 @@ namespace parallel_heap_scan
 	      case PT_VARIANCE:
 	      case PT_VAR_POP:
 	      case PT_VAR_SAMP:
-		{
-		  DB_VALUE coerced, squared;
-		  db_make_null (&coerced);
-		  db_make_null (&squared);
+	      {
+		DB_VALUE coerced, squared;
+		db_make_null (&coerced);
+		db_make_null (&squared);
 
-		  if (tp_value_coerce (db_value_p, &coerced, acc_dom->value_dom) != DOMAIN_COMPATIBLE)
-		    {
-		      return false;
-		    }
+		if (tp_value_coerce (db_value_p, &coerced, acc_dom->value_dom) != DOMAIN_COMPATIBLE)
+		  {
+		    return false;
+		  }
 
-		  if (qdata_multiply_dbval (&coerced, &coerced, &squared, acc_dom->value2_dom) != NO_ERROR)
-		    {
-		      pr_clear_value (&coerced);
-		      return false;
-		    }
+		if (qdata_multiply_dbval (&coerced, &coerced, &squared, acc_dom->value2_dom) != NO_ERROR)
+		  {
+		    pr_clear_value (&coerced);
+		    return false;
+		  }
 
-		  if (acc->curr_cnt < 1)
-		    {
-		      pr_clear_value (acc->value);
-		      pr_clear_value (acc->value2);
-		      acc_dom->value_dom->type->setval (acc->value, &coerced, true);
-		      acc_dom->value2_dom->type->setval (acc->value2, &squared, true);
-		    }
-		  else
-		    {
-		      if (qdata_add_dbval (acc->value, &coerced, acc->value, acc_dom->value_dom) != NO_ERROR)
-			{
-			  pr_clear_value (&coerced);
-			  pr_clear_value (&squared);
-			  return false;
-			}
-		      if (qdata_add_dbval (acc->value2, &squared, acc->value2, acc_dom->value2_dom) != NO_ERROR)
-			{
-			  pr_clear_value (&coerced);
-			  pr_clear_value (&squared);
-			  return false;
-			}
-		    }
+		if (acc->curr_cnt < 1)
+		  {
+		    pr_clear_value (acc->value);
+		    pr_clear_value (acc->value2);
+		    acc_dom->value_dom->type->setval (acc->value, &coerced, true);
+		    acc_dom->value2_dom->type->setval (acc->value2, &squared, true);
+		  }
+		else
+		  {
+		    if (qdata_add_dbval (acc->value, &coerced, acc->value, acc_dom->value_dom) != NO_ERROR)
+		      {
+			pr_clear_value (&coerced);
+			pr_clear_value (&squared);
+			return false;
+		      }
+		    if (qdata_add_dbval (acc->value2, &squared, acc->value2, acc_dom->value2_dom) != NO_ERROR)
+		      {
+			pr_clear_value (&coerced);
+			pr_clear_value (&squared);
+			return false;
+		      }
+		  }
 
-		  pr_clear_value (&coerced);
-		  pr_clear_value (&squared);
-		  acc->curr_cnt++;
-		}
-		break;
+		pr_clear_value (&coerced);
+		pr_clear_value (&squared);
+		acc->curr_cnt++;
+	      }
+	      break;
 
 	      default:
 		assert (false);

--- a/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
@@ -1403,13 +1403,7 @@ namespace parallel_heap_scan
 		  m_err_messages_p->move_top_error_message_to_this ();
 		  m_interrupt_p->set_code (parallel_query::interrupt::interrupt_code::ERROR_INTERRUPTED_FROM_WORKER_THREAD);
 		}
-
-	      pr_clear_value (cur_agg_p->accumulator.value);
-	      if (cur_agg_p->accumulator.value2 != NULL && !DB_IS_NULL (cur_agg_p->accumulator.value2))
-		{
-		  pr_clear_value (cur_agg_p->accumulator.value2);
-		}
-	      cur_agg_p->accumulator.curr_cnt = 0;
+	      /* cur_agg_p accumulator cleanup is handled by qexec_clear_xasl on the cloned XASL. */
 	    }
 	  cur_agg_p = cur_agg_p->next;
 	}

--- a/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
@@ -1026,7 +1026,8 @@ namespace parallel_heap_scan
 	  {
 	    agg_node->accumulator.curr_cnt = 0;
 	  }
-	else if (agg_node->option == Q_DISTINCT)
+	else if (agg_node->option == Q_DISTINCT
+		 && agg_node->function != PT_MIN && agg_node->function != PT_MAX)
 	  {
 	    int ls_flag = QFILE_FLAG_DISTINCT | QFILE_NOT_USE_MEMBUF;
 	    QFILE_TUPLE_VALUE_TYPE_LIST type_list;
@@ -1123,7 +1124,12 @@ namespace parallel_heap_scan
 		int dbval_size = pr_data_writeval_disk_size (op_val_p);
 		if (dbval_size > tl_tpl_buf.size)
 		  {
-		    tl_tpl_buf.tpl = (char *) db_private_realloc (thread_p, tl_tpl_buf.tpl, dbval_size);
+		    char *new_tpl = (char *) db_private_realloc (thread_p, tl_tpl_buf.tpl, dbval_size);
+		    if (new_tpl == nullptr)
+		      {
+			return false;
+		      }
+		    tl_tpl_buf.tpl = new_tpl;
 		    tl_tpl_buf.size = dbval_size;
 		  }
 		or_init (&tl_or_buf, tl_tpl_buf.tpl, dbval_size);

--- a/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
@@ -1306,6 +1306,21 @@ namespace parallel_heap_scan
       AGGREGATE_TYPE *orig_agg_p, *cur_agg_p = tl_xasl_p->proc.buildvalue.agg_list;
       for (orig_agg_p = m_orig_agg_list; orig_agg_p != NULL; orig_agg_p = orig_agg_p->next)
 	{
+	  if (m_interrupt_p->get_code () != parallel_query::interrupt::interrupt_code::NO_INTERRUPT)
+	    {
+	      for (; cur_agg_p != NULL; cur_agg_p = cur_agg_p->next)
+		{
+		  if (cur_agg_p->accumulator.value != NULL)
+		    {
+		      pr_clear_value (cur_agg_p->accumulator.value);
+		    }
+		  if (cur_agg_p->accumulator.value2 != NULL)
+		    {
+		      pr_clear_value (cur_agg_p->accumulator.value2);
+		    }
+		}
+	      break;
+	    }
 	  if (orig_agg_p->function == PT_COUNT_STAR)
 	    {
 	      orig_agg_p->accumulator.curr_cnt += cur_agg_p->accumulator.curr_cnt;
@@ -1330,7 +1345,9 @@ namespace parallel_heap_scan
 		  QFILE_LIST_ID *list_id_p = (QFILE_LIST_ID *) db_private_alloc (thread_p, sizeof (QFILE_LIST_ID));
 		  if (list_id_p == nullptr)
 		    {
-		      qfile_clear_list_id (cur_agg_p->list_id);
+		      m_err_messages_p->move_top_error_message_to_this ();
+		      m_interrupt_p->set_code (parallel_query::interrupt::interrupt_code::ERROR_INTERRUPTED_FROM_WORKER_THREAD);
+		      qfile_destroy_list (thread_p, cur_agg_p->list_id);
 		      cur_agg_p = cur_agg_p->next;
 		      continue;
 		    }

--- a/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
@@ -986,7 +986,10 @@ namespace parallel_heap_scan
 	    if (!DB_IS_NULL (orig_agg_p->accumulator.value))
 	      {
 		db_make_null (&tmp);
-		pr_clone_value (orig_agg_p->accumulator.value, &tmp);
+		if (pr_clone_value (orig_agg_p->accumulator.value, &tmp) != NO_ERROR)
+		  {
+		    return S_ERROR;
+		  }
 		HL_HEAPID save_heap = db_change_private_heap (thread_p, 0);
 		pr_clear_value (orig_agg_p->accumulator.value);
 		db_change_private_heap (thread_p, save_heap);
@@ -995,7 +998,10 @@ namespace parallel_heap_scan
 	    if (orig_agg_p->accumulator.value2 != NULL && !DB_IS_NULL (orig_agg_p->accumulator.value2))
 	      {
 		db_make_null (&tmp);
-		pr_clone_value (orig_agg_p->accumulator.value2, &tmp);
+		if (pr_clone_value (orig_agg_p->accumulator.value2, &tmp) != NO_ERROR)
+		  {
+		    return S_ERROR;
+		  }
 		HL_HEAPID save_heap = db_change_private_heap (thread_p, 0);
 		pr_clear_value (orig_agg_p->accumulator.value2);
 		db_change_private_heap (thread_p, save_heap);
@@ -1165,7 +1171,10 @@ namespace parallel_heap_scan
 		      }
 		    else
 		      {
-			pr_clone_value (db_value_p, acc->value);
+			if (pr_clone_value (db_value_p, acc->value) != NO_ERROR)
+			  {
+			    return false;
+			  }
 		      }
 		  }
 		acc->curr_cnt++;
@@ -1189,7 +1198,10 @@ namespace parallel_heap_scan
 		      }
 		    else
 		      {
-			pr_clone_value (db_value_p, acc->value);
+			if (pr_clone_value (db_value_p, acc->value) != NO_ERROR)
+			  {
+			    return false;
+			  }
 		      }
 		  }
 		acc->curr_cnt++;
@@ -1211,7 +1223,10 @@ namespace parallel_heap_scan
 		      }
 		    else
 		      {
-			pr_clone_value (db_value_p, acc->value);
+			if (pr_clone_value (db_value_p, acc->value) != NO_ERROR)
+			  {
+			    return false;
+			  }
 		      }
 		  }
 		else

--- a/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
@@ -972,7 +972,8 @@ namespace parallel_heap_scan
 	if (orig_agg_p->function == PT_COUNT_STAR)
 	  {
 	  }
-	else if (orig_agg_p->option == Q_DISTINCT)
+	else if (orig_agg_p->option == Q_DISTINCT
+		 && orig_agg_p->function != PT_MIN && orig_agg_p->function != PT_MAX)
 	  {
 	  }
 	else if (orig_agg_p->function == PT_COUNT)
@@ -1095,7 +1096,8 @@ namespace parallel_heap_scan
 	    continue;
 	  }
 
-	if (agg_node->option == Q_DISTINCT)
+	if (agg_node->option == Q_DISTINCT
+	    && agg_node->function != PT_MIN && agg_node->function != PT_MAX)
 	  {
 	    for (REGU_VARIABLE_LIST operand = agg_node->operands; operand != NULL; operand = operand->next)
 	      {
@@ -1291,7 +1293,8 @@ namespace parallel_heap_scan
 	      continue;
 	    }
 
-	  if (orig_agg_p->option == Q_DISTINCT)
+	  if (orig_agg_p->option == Q_DISTINCT
+	      && orig_agg_p->function != PT_MIN && orig_agg_p->function != PT_MAX)
 	    {
 	      qfile_close_list (thread_p, cur_agg_p->list_id);
 	      if (cur_agg_p->list_id->tuple_cnt == 0)
@@ -1336,10 +1339,15 @@ namespace parallel_heap_scan
 		}
 
 	      HL_HEAPID prev_heap_id = db_change_private_heap (thread_p, 0);
-	      (void) qdata_aggregate_accumulator_to_accumulator (thread_p, &orig_agg_p->accumulator,
-		  &orig_agg_p->accumulator_domain, orig_agg_p->function,
-		  orig_agg_p->domain, &cur_agg_p->accumulator);
+	      int err = qdata_aggregate_accumulator_to_accumulator (thread_p, &orig_agg_p->accumulator,
+			    &orig_agg_p->accumulator_domain, orig_agg_p->function,
+			    orig_agg_p->domain, &cur_agg_p->accumulator);
 	      db_change_private_heap (thread_p, prev_heap_id);
+	      if (err != NO_ERROR)
+		{
+		  m_err_messages_p->move_top_error_message_to_this ();
+		  m_interrupt_p->set_code (parallel_query::interrupt::interrupt_code::ERROR_INTERRUPTED_FROM_WORKER_THREAD);
+		}
 
 	      pr_clear_value (cur_agg_p->accumulator.value);
 	      if (cur_agg_p->accumulator.value2 != NULL && !DB_IS_NULL (cur_agg_p->accumulator.value2))

--- a/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
@@ -1041,6 +1041,8 @@ namespace parallel_heap_scan
 	    type_list.domp = (TP_DOMAIN **) db_private_alloc (thread_p, sizeof (TP_DOMAIN *));
 	    if (type_list.domp == NULL)
 	      {
+		m_err_messages_p->move_top_error_message_to_this ();
+		m_interrupt_p->set_code (parallel_query::interrupt::interrupt_code::ERROR_INTERRUPTED_FROM_WORKER_THREAD);
 		return;
 	      }
 	    type_list.domp[0] = agg_node->operands->value.domain;
@@ -1048,6 +1050,8 @@ namespace parallel_heap_scan
 	    db_private_free_and_init (thread_p, type_list.domp);
 	    if (agg_node->list_id == nullptr)
 	      {
+		m_err_messages_p->move_top_error_message_to_this ();
+		m_interrupt_p->set_code (parallel_query::interrupt::interrupt_code::ERROR_INTERRUPTED_FROM_WORKER_THREAD);
 		return;
 	      }
 	  }
@@ -1310,6 +1314,13 @@ namespace parallel_heap_scan
 	    {
 	      for (; cur_agg_p != NULL; cur_agg_p = cur_agg_p->next)
 		{
+		  if (cur_agg_p->option == Q_DISTINCT
+		      && cur_agg_p->function != PT_MIN && cur_agg_p->function != PT_MAX
+		      && cur_agg_p->list_id != nullptr)
+		    {
+		      qfile_close_list (thread_p, cur_agg_p->list_id);
+		      qfile_destroy_list (thread_p, cur_agg_p->list_id);
+		    }
 		  if (cur_agg_p->accumulator.value != NULL)
 		    {
 		      pr_clear_value (cur_agg_p->accumulator.value);

--- a/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.cpp
@@ -1113,7 +1113,11 @@ namespace parallel_heap_scan
 	    for (REGU_VARIABLE_LIST operand = agg_node->operands; operand != NULL; operand = operand->next)
 	      {
 		DB_VALUE *op_val_p;
-		if (operand->value.type == TYPE_CONSTANT)
+		if (operand == agg_node->operands)
+		  {
+		    op_val_p = db_value_p;
+		  }
+		else if (operand->value.type == TYPE_CONSTANT)
 		  {
 		    op_val_p = operand->value.value.dbvalptr;
 		  }

--- a/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.hpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_result_handler.hpp
@@ -225,7 +225,7 @@ namespace parallel_heap_scan
   };
 
   template <>
-  class result_handler <RESULT_TYPE::COUNT_DISTINCT>
+  class result_handler <RESULT_TYPE::BUILDVALUE_OPT>
   {
       using interrupt = parallel_query::interrupt;
       using err_messages_with_lock = parallel_query::err_messages_with_lock;

--- a/src/query/parallel/px_heap_scan/px_heap_scan_result_type.hpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_result_type.hpp
@@ -30,7 +30,7 @@ namespace parallel_heap_scan
     NONE = 0x0,
     MERGEABLE_LIST = 0x1, /* (fast) list-per-thread return, and merge (set dependent) it. */
     XASL_SNAPSHOT = 0x2, /* (slow) xasl snapshot return (row-by-row) */
-    COUNT_DISTINCT = 0x3, /* (fast) for update statistics */
+    BUILDVALUE_OPT = 0x3, /* (fast) buildvalue proc aggregate optimization */
 
   };
 }

--- a/src/query/parallel/px_heap_scan/px_heap_scan_task.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_task.cpp
@@ -296,6 +296,10 @@ namespace parallel_heap_scan
       {
 	m_result_handler->write_initialize (&thread_ref, m_xasl->outptr_list, m_xasl, m_vd);
       }
+    if (er_errid () != NO_ERROR)
+      {
+	return er_errid ();
+      }
     return NO_ERROR;
   }
 

--- a/src/query/parallel/px_heap_scan/px_heap_scan_task.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_task.cpp
@@ -118,7 +118,7 @@ namespace parallel_heap_scan
 	  }
 	else
 	  {
-	    if constexpr (result_type == RESULT_TYPE::MERGEABLE_LIST || result_type == RESULT_TYPE::COUNT_DISTINCT)
+	    if constexpr (result_type == RESULT_TYPE::MERGEABLE_LIST || result_type == RESULT_TYPE::BUILDVALUE_OPT)
 	      {
 		scan_info scan_info = m_join_info->get_scan_info (xptr->header.id);
 		ACCESS_SPEC_TYPE *specp = xptr->curr_spec? xptr->curr_spec : xptr->spec_list;
@@ -288,7 +288,7 @@ namespace parallel_heap_scan
       }
     m_slot_iterator.initialize (&thread_ref, m_scan_id, m_vd);
     m_input_handler->initialize (&thread_ref, &hsidp->hfid, m_scan_id);
-    if constexpr (result_type == RESULT_TYPE::COUNT_DISTINCT)
+    if constexpr (result_type == RESULT_TYPE::BUILDVALUE_OPT)
       {
 	m_result_handler->write_initialize (&thread_ref, m_xasl->outptr_list, m_xasl->proc.buildvalue.agg_list, m_vd, m_xasl);
       }
@@ -304,7 +304,7 @@ namespace parallel_heap_scan
   {
     THREAD_ENTRY *main_thread_p = thread_get_main_thread (m_parent_thread_p);
     xasl_node *xptr;
-    if constexpr (result_type == RESULT_TYPE::MERGEABLE_LIST || result_type == RESULT_TYPE::COUNT_DISTINCT)
+    if constexpr (result_type == RESULT_TYPE::MERGEABLE_LIST || result_type == RESULT_TYPE::BUILDVALUE_OPT)
       {
 	if (m_scan_func_ptr != nullptr)
 	  {
@@ -320,7 +320,7 @@ namespace parallel_heap_scan
 	tsc_getticks (&end_tick);
 	tsc_elapsed_time_usec (&tv_diff, end_tick, m_start_tick);
 	TSC_ADD_TIMEVAL (elapsed_time, tv_diff);
-	if constexpr (result_type == RESULT_TYPE::MERGEABLE_LIST || result_type == RESULT_TYPE::COUNT_DISTINCT)
+	if constexpr (result_type == RESULT_TYPE::MERGEABLE_LIST || result_type == RESULT_TYPE::BUILDVALUE_OPT)
 	  {
 	    m_trace_handler->m_trace_storage_for_sibling_xasl.merge_xasl_tree (m_xasl);
 	  }
@@ -336,7 +336,7 @@ namespace parallel_heap_scan
     m_input_handler->finalize (&thread_ref);
     m_slot_iterator.finalize (&thread_ref);
 
-    if constexpr (result_type == RESULT_TYPE::MERGEABLE_LIST || result_type == RESULT_TYPE::COUNT_DISTINCT)
+    if constexpr (result_type == RESULT_TYPE::MERGEABLE_LIST || result_type == RESULT_TYPE::BUILDVALUE_OPT)
       {
 	for (xptr = m_xasl; xptr != NULL; xptr = xptr->scan_ptr)
 	  {
@@ -590,7 +590,7 @@ namespace parallel_heap_scan
 		      }
 		  }
 	      }
-	    if constexpr (result_type == RESULT_TYPE::MERGEABLE_LIST || result_type == RESULT_TYPE::COUNT_DISTINCT)
+	    if constexpr (result_type == RESULT_TYPE::MERGEABLE_LIST || result_type == RESULT_TYPE::BUILDVALUE_OPT)
 	      {
 		if (m_xasl->scan_ptr)
 		  {
@@ -617,7 +617,7 @@ namespace parallel_heap_scan
 			  {
 			    result_handler_p->write (&thread_ref, m_xasl->outptr_list);
 			  }
-			else if constexpr (result_type == RESULT_TYPE::COUNT_DISTINCT)
+			else if constexpr (result_type == RESULT_TYPE::BUILDVALUE_OPT)
 			  {
 			    result_handler_p->write (&thread_ref);
 			  }
@@ -637,7 +637,7 @@ namespace parallel_heap_scan
 		      {
 			result_handler_p->write (&thread_ref, m_xasl->outptr_list);
 		      }
-		    else if constexpr (result_type == RESULT_TYPE::COUNT_DISTINCT)
+		    else if constexpr (result_type == RESULT_TYPE::BUILDVALUE_OPT)
 		      {
 			result_handler_p->write (&thread_ref);
 		      }
@@ -667,5 +667,5 @@ namespace parallel_heap_scan
   // Explicit template instantiations
   template class task<RESULT_TYPE::MERGEABLE_LIST>;
   template class task<RESULT_TYPE::XASL_SNAPSHOT>;
-  template class task<RESULT_TYPE::COUNT_DISTINCT>;
+  template class task<RESULT_TYPE::BUILDVALUE_OPT>;
 }

--- a/src/query/parallel/px_heap_scan/px_heap_scan_trace_handler.cpp
+++ b/src/query/parallel/px_heap_scan/px_heap_scan_trace_handler.cpp
@@ -126,7 +126,7 @@ namespace parallel_heap_scan
     int parallel_workers = m_stats.size();
     const char *result_type_str = m_result_type == RESULT_TYPE::MERGEABLE_LIST ? "mergeable list" :
 				  m_result_type == RESULT_TYPE::XASL_SNAPSHOT ? "row by row" :
-				  m_result_type == RESULT_TYPE::COUNT_DISTINCT ? "count" : "unknown";
+				  m_result_type == RESULT_TYPE::BUILDVALUE_OPT ? "buildvalue" : "unknown";
     for (size_t i = 0; i < m_stats.size(); i++)
       {
 	min_elapsed_scan = std::min (min_elapsed_scan, (UINT64) (TO_MSEC (m_stats[i].elapsed_time)));
@@ -155,7 +155,7 @@ namespace parallel_heap_scan
     int parallel_workers = m_stats.size();
     const char *result_type_str = m_result_type == RESULT_TYPE::MERGEABLE_LIST ? "mergeable list" :
 				  m_result_type == RESULT_TYPE::XASL_SNAPSHOT ? "row by row" :
-				  m_result_type == RESULT_TYPE::COUNT_DISTINCT ? "count" : "unknown";
+				  m_result_type == RESULT_TYPE::BUILDVALUE_OPT ? "buildvalue" : "unknown";
     for (size_t i = 0; i < m_stats.size(); i++)
       {
 	min_elapsed_scan = std::min (min_elapsed_scan, (UINT64) (TO_MSEC (m_stats[i].elapsed_time)));

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -1957,8 +1957,8 @@ qexec_clear_access_spec_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl_p, ACCES
 		      ((parallel_heap_scan::manager < parallel_heap_scan::RESULT_TYPE::XASL_SNAPSHOT >
 			*)p->s_id.s.phsid.manager)->close ();
 		      break;
-		    case parallel_heap_scan::RESULT_TYPE::COUNT_DISTINCT:
-		      ((parallel_heap_scan::manager < parallel_heap_scan::RESULT_TYPE::COUNT_DISTINCT >
+		    case parallel_heap_scan::RESULT_TYPE::BUILDVALUE_OPT:
+		      ((parallel_heap_scan::manager < parallel_heap_scan::RESULT_TYPE::BUILDVALUE_OPT >
 			*)p->s_id.s.phsid.manager)->close ();
 		      break;
 		    default:

--- a/src/query/xasl.h
+++ b/src/query/xasl.h
@@ -768,7 +768,7 @@ typedef enum
   ACCESS_SPEC_FLAG_NO_PARALLEL_HEAP_SCAN = 0x1 << 1,	/* used with parallel heap scan. */
   ACCESS_SPEC_FLAG_NUM_PARALLEL_THREADS = 0x1 << 2,	/* used with parallel heap scan. */
   ACCESS_SPEC_FLAG_MERGEABLE_LIST = 0x1 << 3,	/* used with parallel heap scan. */
-  ACCESS_SPEC_FLAG_COUNT_DISTINCT = 0x1 << 4,	/* used with parallel heap scan count distinct aggregate. */
+  ACCESS_SPEC_FLAG_BUILDVALUE_OPT = 0x1 << 4,	/* used with parallel heap scan buildvalue aggregate optimization. */
   ACCESS_SPEC_FLAG_ONLY_MIN_MAX_SCAN = 0x1 << 5,	/* used with min/max aggregate. */
   ACCESS_SPEC_FLAG_FORCE_FIXED_SCAN = 0x1 << 6	/* used with keep page hint. */
 } ACCESS_SPEC_FLAG;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26711>

### Purpose

CUBRID의 병렬 힙 스캔(parallel heap scan) 기능에서 BUILDVALUE_PROC(GROUP BY 없는 단일 튜플 집계) 쿼리의 성능을 개선하기 위해, 지원 가능한 집계 함수를 확장합니다.

기존 병렬 힙 스캔 구현에서는 BUILDVALUE_PROC에 대해 COUNT(*), COUNT(col), COUNT(DISTINCT col)만 최적화(COUNT_DISTINCT)를 지원하여, MIN/MAX/SUM/AVG/STDDEV/VARIANCE 등의 집계 함수가 포함된 쿼리는 직렬 실행되거나 MERGEABLE_LIST 또는 XASL_SNAPSHOT 방식으로 처리되어 불필요한 오버헤드가 있었습니다. 이를 해결하기 위해 COUNT_DISTINCT 최적화를 BUILDVALUE_OPT로 확장하여, 각 워커 스레드가 독립적으로 부분 집계를 수행하고 최종 단계에서 효율적으로 병합하는 방식을 도입합니다.

### Implementation

집계 함수 지원 확장 (px_heap_scan_checker.cpp)

- is_buildvalue_opt_supported_function() 헬퍼 함수를 추가하여 지원 가능한 집계 함수(COUNT_STAR, COUNT, MIN, MAX, SUM, AVG, STDDEV, STDDEV_POP, STDDEV_SAMP, VARIANCE, VAR_POP, VAR_SAMP)를 판별합니다.
- 기존 agg_it->function != PT_COUNT_STAR && agg_it->function != PT_COUNT 조건을  !is_buildvalue_opt_supported_function(agg_it->function)으로 변경합니다.
- 워커 스레드 초기화 확장 (px_heap_scan_result_handler.cpp - write_initialize)
- COUNT_STAR: curr_cnt=0 초기화
- DISTINCT (모든 타입): 스레드별 독립 리스트 오픈
- Non-DISTINCT (MIN/MAX/SUM/AVG/STDDEV*/VAR*): curr_cnt=0 초기화

행 단위 누적 로직 추가 (px_heap_scan_result_handler.cpp - write)

- PT_COUNT: curr_cnt++
- PT_MIN: cmpval > 0이면 도메인 변환 후 복사
- PT_MAX: cmpval < 0이면 도메인 변환 후 복사
- PT_SUM/PT_AVG: 첫 행은 복사+변환, 이후 qdata_add_dbval로 누적, curr_cnt++
- PT_STDDEV*/PT_VAR*: double 변환, X^2 계산, value와 value2 누적, curr_cnt++
- DISTINCT: 스레드별 리스트에 삽입 (기존 패턴 동일)

병합 로직 확장 (px_heap_scan_result_handler.cpp - write_finalize)

- COUNT_STAR: orig.curr_cnt += worker.curr_cnt
- DISTINCT: {{qfile_connect_list}}로 리스트 병합
- Non-DISTINCT COUNT: orig.curr_cnt += worker.curr_cnt
- Non-DISTINCT MIN/MAX/SUM/AVG/STDDEV*/VAR*: db_change_private_heap(thread_p, 0)으로 heap 0 전환 후 qdata_aggregate_accumulator_to_accumulator() 호출, 이후 원래 heap 복원. accumulator_domain이 미해석 상태이면 워커의 해석된 도메인을 복사합니다.

메인 스레드 값 재할당 (px_heap_scan_result_handler.cpp - read)

- 워커 완료 대기 후, Non-DISTINCT/Non-COUNT 집계의 accumulator 값을 메인 스레드의 private heap으로 재할당합니다.
- heap 0에서 할당된 값을 pr_clone_value로 private heap에 복사한 뒤, heap 0 전환 후 원본을 pr_clear_value로 해제합니다.
- 이를 통해 qexec_end_buildvalueblock_iterations에서의 pr_clear_value 호출 시 올바른 heap에서 해제가 이루어집니다.
