### PR TITLE
[CBRD-26712] Change the minimum join selectivity to 1 / (the product of the row counts of each table).

### DIFF
--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -7858,7 +7858,7 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 	      else
 		{
 		  selectivity *= QO_TERM_SELECTIVITY (term);
-		  selectivity = MAX (1.0 / cardinality, selectivity);
+		  selectivity = MAX (1.0 / MAX (cardinality, 1.0), selectivity);
 
 		  double head_factor, tail_factor;
 		  qo_get_term_hit_prob (term, head_info, tail_info, planner->env, &head_factor, &tail_factor);

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -7858,7 +7858,7 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 	      else
 		{
 		  selectivity *= QO_TERM_SELECTIVITY (term);
-		  selectivity = MAX (1.0 / MAX (head_info->cardinality, tail_info->cardinality), selectivity);
+		  selectivity = MAX (1.0 / cardinality, selectivity);
 
 		  double head_factor, tail_factor;
 		  qo_get_term_hit_prob (term, head_info, tail_info, planner->env, &head_factor, &tail_factor);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26712>

### Purpose
[CBRD-26309](http://jira.cubrid.org/browse/CBRD-26309)에서 적용했던 변경 사항을 이전 상태로 원복합니다. 다중 컬럼 인덱스에서 선택도가 과소평가되는 문제를 해결하기 위해 최소값을 낮게 측정하도록 수정했으나, 해당 방식은 실제 선택도 감소를 정확히 반영하지 못하는 한계가 있습니다. 따라서 최소값 설정은 기존 방식으로 되돌립니다.

### Implementation
AS-is : sel = max(sel, 1 / max(t1 card, t2 card))
TO-be : sel = max(sel, 1 / (t1 card * t2 card))

### Remarks
N/A
