### PR TITLE
[CBRD-26698] apply --fstack-proctector-strong to debug mode only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,12 +199,12 @@ if(UNIX)
     endif(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.4.7)
 
     # C flags for both debug and release build
-    set(CMAKE_C_COMMON_FLAGS "-ggdb -fno-omit-frame-pointer -fstack-protector-strong")
+    set(CMAKE_C_COMMON_FLAGS "-ggdb -fno-omit-frame-pointer")
     # C++ flags for both debug and release build
     set(CMAKE_CXX_COMMON_FLAGS "${CMAKE_C_COMMON_FLAGS} -std=c++17")
 
     # C flags for debug build
-    set(CMAKE_C_DEBUG_FLAGS "-Wall -fno-inline ${CMAKE_C_COMMON_FLAGS}")
+    set(CMAKE_C_DEBUG_FLAGS "-Wall -fno-inline ${CMAKE_C_COMMON_FLAGS} -fstack-protector-strong")
     # C++ flags for debug build
     set(CMAKE_CXX_DEBUG_FLAGS "-Wall -fno-inline ${CMAKE_CXX_COMMON_FLAGS}")
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26698

restrict this flag to debug builds as it causes malfunctions during testing when compiled in release mode.

