### PR TITLE
[CBRD-26710] Fix CAS coredump in authenticate_context

### DIFF
--- a/src/object/authenticate_context.cpp
+++ b/src/object/authenticate_context.cpp
@@ -731,7 +731,14 @@ authenticate_context::set_user (MOP newuser)
       if (!user_cache)
 	{
 	  const char *user_name = au_get_user_name (newuser);
+	  if (user_name == nullptr)
+	    {
+	      error = ER_AU_INVALID_USER_NAME;
+	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_AU_INVALID_USER_NAME, 1, "");
+	      return (error);
+	    }
 	  user_cache = caches.make_user_cache (user_name, newuser, false);
+	  ws_free_string (user_name);
 	}
 
       if (user_cache)
@@ -1019,4 +1026,3 @@ exit_on_error:
   AU_ENABLE (save);
   return ER_FAILED;
 }
-


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26710

- Prevent a coredump in authenticate_context::set_user() by adding a null check for the value returned by au_get_user_name(). (Fixes crash when passing nullptr to std::string in make_user_cache)

