### PR TITLE
[CBRD-26701] Fix the worker pool to work properly.

### DIFF
--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -4170,7 +4170,7 @@ static size_t
 thread_stats_count (void)
 {
 #if defined (SERVER_MODE)
-  assert (PERFMON_PORTABLE_WORKER_STAT_COUNT == static_cast<size_t> (cubthread::stats_worker_pool_type::stats::id::type_count));
+  assert (PERFMON_PORTABLE_WORKER_STAT_COUNT == cubthread::stats_worker_pool_type::stats::get_count ());
   static bool check_names = true;
   if (check_names)
     {

--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -42,7 +42,6 @@
 #include "server_interface.h"
 #endif /* !SERVER_MODE */
 #if defined (SERVER_MODE)
-#include "thread_worker_pool.hpp"
 #include "thread_daemon.hpp"
 #endif // SERVER_MODE
 #if defined (SERVER_MODE) || defined (SA_MODE)
@@ -4171,19 +4170,19 @@ static size_t
 thread_stats_count (void)
 {
 #if defined (SERVER_MODE)
-  assert (PERFMON_PORTABLE_WORKER_STAT_COUNT == cubthread::wp_worker_statset_get_count ());
+  assert (PERFMON_PORTABLE_WORKER_STAT_COUNT == static_cast<size_t> (cubthread::stats_worker_pool_type::stats::id::type_count));
   static bool check_names = true;
   if (check_names)
     {
       for (size_t index = 0; index < PERFMON_PORTABLE_WORKER_STAT_COUNT; index++)
         {
-          if (std::strcmp (perfmon_Portable_worker_stat_names[index], cubthread::wp_worker_statset_get_name (index)) != 0)
+          if (std::strcmp (perfmon_Portable_worker_stat_names[index], cubthread::stats_worker_pool_type::stats::get_name (index)) != 0)
             {
               assert (false);
               _er_log_debug (ARG_FILE_LINE,
                              "Warning - Monitoring thread worker statistics; statistics name not matching for %zu\n"
                              "\t\tperfmon name = %s\n" "\t\tdaemon name = %s\n", index,
-                             perfmon_Portable_worker_stat_names[index], cubthread::wp_worker_statset_get_name (index));
+                             perfmon_Portable_worker_stat_names[index], cubthread::stats_worker_pool_type::stats::get_name (index));
             }
         }
       check_names = false;

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -140,7 +140,7 @@ static HA_LOG_APPLIER_STATE_TABLE ha_Log_applier_state[HA_LOG_APPLIER_STATE_TABL
 static int ha_Log_applier_state_num = 0;
 
 // *INDENT-OFF*
-static cubthread::worker_pool *css_Server_request_worker_pool = NULL;
+static cubthread::worker_pool_impl<true> *css_Server_request_worker_pool = NULL;
 
 class css_server_task : public cubthread::entry_task
 {
@@ -579,12 +579,11 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
 
   // create request worker pool
   css_Server_request_worker_pool =
-    cubthread::get_manager ()->create_worker_pool (task_worker, MAX_TASK_COUNT, "transaction", NULL,
-						   task_group,
-						   cubthread::is_logging_configured
-						   (cubthread::LOG_WORKER_POOL_TRAN_WORKERS),
-						   css_get_server_request_thread_pooling_configuration (),
-						   css_get_server_request_thread_timeout_configuration ());
+    thread_create_stats_worker_pool (task_worker, task_group, "transaction", thread_get_entry_manager (),
+				     css_get_server_request_thread_pooling_configuration (),
+				     css_get_server_request_thread_timeout_configuration ());
+  // m_log = cubthread::is_logging_configured (cubthread::LOG_WORKER_POOL_TRAN_WORKERS)
+
   if (css_Server_request_worker_pool == NULL)
     {
       assert (false);

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -31,7 +31,6 @@
 #include "thread_entry_task.hpp"
 #include "thread_entry.hpp"
 #include "thread_manager.hpp"
-#include "thread_worker_pool.hpp"
 #include "master_connector.hpp"
 #include "connection_pool.hpp"
 
@@ -140,7 +139,7 @@ static HA_LOG_APPLIER_STATE_TABLE ha_Log_applier_state[HA_LOG_APPLIER_STATE_TABL
 static int ha_Log_applier_state_num = 0;
 
 // *INDENT-OFF*
-static cubthread::worker_pool_impl<true> *css_Server_request_worker_pool = NULL;
+static cubthread::stats_worker_pool_type *css_Server_request_worker_pool = NULL;
 
 class css_server_task : public cubthread::entry_task
 {
@@ -212,8 +211,8 @@ static bool css_is_log_writer (const THREAD_ENTRY & thread_arg);
 static void css_stop_all_workers (THREAD_ENTRY & thread_ref, css_thread_stop_type stop_phase);
 static void css_wp_worker_get_busy_count_mapper (THREAD_ENTRY & thread_ref, bool & stop_mapper, int &busy_count);
 
-// cubthread::worker_pool::core confuses indent
-static void css_wp_core_job_scan_mapper (const cubthread::worker_pool::core & wp_core, bool & stop_mapper,
+// cubthread::stats_worker_pool_type::core_impl confuses indent
+static void css_wp_core_job_scan_mapper (const cubthread::stats_worker_pool_type::core_impl & wp_core, bool & stop_mapper,
                                          THREAD_ENTRY * thread_p, SHOWSTMT_ARRAY_CONTEXT * ctx, size_t & core_index,
                                          int & error_code);
 static void
@@ -2647,7 +2646,7 @@ css_get_thread_stats (UINT64 *stats_out)
 void
 css_get_task_stats (UINT64 *stats_out)
 {
-  css_Server_request_worker_pool->get_task_stats (stats_out);
+//  css_Server_request_worker_pool->get_task_stats (stats_out);
 }
 
 //
@@ -2693,7 +2692,7 @@ css_wp_worker_get_busy_count_mapper (THREAD_ENTRY & thread_ref, bool & stop_mapp
 // error_code (out)     : output error_code if any errors occur
 //
 static void
-css_wp_core_job_scan_mapper (const cubthread::worker_pool::core & wp_core, bool & stop_mapper,
+css_wp_core_job_scan_mapper (const cubthread::stats_worker_pool_type::core_impl & wp_core, bool & stop_mapper,
                              THREAD_ENTRY * thread_p, SHOWSTMT_ARRAY_CONTEXT * ctx, size_t & core_index,
                              int & error_code)
 {
@@ -2902,7 +2901,7 @@ css_start_all_threads (void)
 
   if (start_workers)
     {
-      css_Server_request_worker_pool->start_all_workers ();
+      //css_Server_request_worker_pool->start_all_workers ();
     }
 
   clock_type::time_point end_time = clock_type::now ();

--- a/src/loaddb/load_worker_manager.cpp
+++ b/src/loaddb/load_worker_manager.cpp
@@ -63,7 +63,7 @@ namespace cubload
   static std::mutex g_wp_mutex;
   static std::condition_variable g_wp_condvar;
   std::set<session *> g_active_sessions;
-  static cubthread::worker_pool *g_worker_pool;
+  static cubthread::worker_pool_impl<true> *g_worker_pool;
   static worker_entry_manager *g_wp_entry_manager;
   static cubthread::worker_pool_task_capper *g_wp_task_capper;
 
@@ -121,8 +121,8 @@ namespace cubload
 	unsigned int pool_size = prm_get_integer_value (PRM_ID_LOADDB_WORKER_COUNT);
 
 	g_wp_entry_manager = new worker_entry_manager (pool_size);
-	g_worker_pool = cubthread::get_manager ()->create_worker_pool (pool_size, 2 * pool_size, "loaddb",
-			g_wp_entry_manager, 1, false, true);
+	g_worker_pool = thread_create_worker_pool (pool_size, 1, "loaddb", *g_wp_entry_manager, true);
+	// m_log = false
 
 	g_wp_task_capper = new cubthread::worker_pool_task_capper (g_worker_pool);
       }

--- a/src/loaddb/load_worker_manager.cpp
+++ b/src/loaddb/load_worker_manager.cpp
@@ -25,7 +25,7 @@
 #include "load_driver.hpp"
 #include "load_session.hpp"
 #include "resource_shared_pool.hpp"
-#include "thread_worker_pool.hpp"
+#include "thread_manager.hpp"
 #include "thread_worker_pool_taskcap.hpp"
 #include "xserver_interface.h"
 
@@ -63,7 +63,7 @@ namespace cubload
   static std::mutex g_wp_mutex;
   static std::condition_variable g_wp_condvar;
   std::set<session *> g_active_sessions;
-  static cubthread::worker_pool_impl<true> *g_worker_pool;
+  static cubthread::stats_worker_pool_type *g_worker_pool;
   static worker_entry_manager *g_wp_entry_manager;
   static cubthread::worker_pool_task_capper *g_wp_task_capper;
 
@@ -121,7 +121,7 @@ namespace cubload
 	unsigned int pool_size = prm_get_integer_value (PRM_ID_LOADDB_WORKER_COUNT);
 
 	g_wp_entry_manager = new worker_entry_manager (pool_size);
-	g_worker_pool = thread_create_worker_pool (pool_size, 1, "loaddb", *g_wp_entry_manager, true);
+	g_worker_pool = thread_create_stats_worker_pool (pool_size, 1, "loaddb", *g_wp_entry_manager, true);
 	// m_log = false
 
 	g_wp_task_capper = new cubthread::worker_pool_task_capper (g_worker_pool);

--- a/src/loaddb/load_worker_manager.hpp
+++ b/src/loaddb/load_worker_manager.hpp
@@ -29,7 +29,6 @@
 
 #include "system.h"
 #include "thread_manager.hpp"
-#include "thread_worker_pool.hpp"
 
 namespace cubload
 {

--- a/src/query/parallel/px_parallel.cpp
+++ b/src/query/parallel/px_parallel.cpp
@@ -26,7 +26,7 @@
 
 #include "system.h"		/* UINT32, UINT64 */
 #include "system_parameter.h"	/* sysprm_get_range, PRM_ID_PARALLELISM */
-#include "thread_worker_pool.hpp"	/* cubthread::system_core_count */
+#include "thread_manager.hpp"	/* cubthread::system_core_count */
 
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
 #include "memory_wrapper.hpp"

--- a/src/query/parallel/px_worker_manager_global.cpp
+++ b/src/query/parallel/px_worker_manager_global.cpp
@@ -63,12 +63,12 @@ namespace parallel_query
 	}
 
       int pool_size = max_parallel_workers;
-      int task_max_count = max_parallel_workers * TASK_QUEUE_SIZE_PER_CORE;
 
       assert (m_worker_pool == nullptr);
-      m_worker_pool = cubthread::get_manager()->create_worker_pool (
-			      pool_size, task_max_count,
-			      "parallel-query", NULL, 1, false);
+
+      m_worker_pool = thread_create_worker_pool (pool_size, 1, "parallel-query", thread_get_entry_manager ());
+      // m_log = false
+
       if (m_worker_pool == nullptr)
 	{
 	  return;

--- a/src/query/parallel/px_worker_manager_global.hpp
+++ b/src/query/parallel/px_worker_manager_global.hpp
@@ -54,7 +54,7 @@ namespace parallel_query
       friend class worker_manager;
 
       /* member variables (ordered by size for alignment) */
-      cubthread::worker_pool *m_worker_pool;
+      cubthread::worker_pool_type *m_worker_pool;
       std::once_flag m_init_flag;
       std::atomic<int> m_available;
       int m_capacity;

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -54,7 +54,7 @@
 #include "thread_looper.hpp"
 #include "thread_manager.hpp"
 #if defined (SERVER_MODE)
-#include "thread_worker_pool.hpp"
+#include "thread_worker_pool_impl.hpp"
 #include "monitor_vacuum_ovfp_threshold.hpp"
 #endif // SERVER_MODE
 #include "util_func.h"
@@ -934,8 +934,8 @@ static cubthread::daemon *vacuum_Master_daemon = NULL;                       // 
 static vacuum_master_entry_manager *vacuum_Master_entry_manager = NULL;  // entry manager
 
 // vacuum worker globals
-static cubthread::worker_pool *vacuum_Worker_threads = NULL;              // thread pool
-static vacuum_worker_entry_manager *vacuum_Worker_entry_manager = NULL;  // entry manager
+static cubthread::stats_worker_pool_type *vacuum_Worker_threads = NULL;   // thread pool
+static vacuum_worker_entry_manager *vacuum_Worker_entry_manager = NULL;	  // entry manager
 
 /* *INDENT-ON* */
 

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1334,7 +1334,7 @@ vacuum_boot (THREAD_ENTRY * thread_p)
     || flag<int>::is_flag_set (prm_get_integer_value (PRM_ID_ER_LOG_VACUUM), VACUUM_ER_LOG_WORKER);
 
   // create thread pool
-  vacuum_Worker_threads = thread_create_worker_pool (prm_get_integer_value (PRM_ID_VACUUM_WORKER_COUNT), 1, "vacuum", *vacuum_Worker_entry_manager);
+  vacuum_Worker_threads = thread_create_stats_worker_pool (prm_get_integer_value (PRM_ID_VACUUM_WORKER_COUNT), 1, "vacuum", *vacuum_Worker_entry_manager);
   // m_log = log_vacuum_worker_pool
 
   assert (vacuum_Worker_threads != NULL);

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1334,10 +1334,9 @@ vacuum_boot (THREAD_ENTRY * thread_p)
     || flag<int>::is_flag_set (prm_get_integer_value (PRM_ID_ER_LOG_VACUUM), VACUUM_ER_LOG_WORKER);
 
   // create thread pool
-  vacuum_Worker_threads =
-    thread_manager->create_worker_pool (prm_get_integer_value (PRM_ID_VACUUM_WORKER_COUNT),
-					VACUUM_MAX_TASKS_IN_WORKER_POOL, "vacuum",
-					vacuum_Worker_entry_manager, 1, log_vacuum_worker_pool);
+  vacuum_Worker_threads = thread_create_worker_pool (prm_get_integer_value (PRM_ID_VACUUM_WORKER_COUNT), 1, "vacuum", *vacuum_Worker_entry_manager);
+  // m_log = log_vacuum_worker_pool
+
   assert (vacuum_Worker_threads != NULL);
 
   int vacuum_master_wakeup_interval_msec = prm_get_integer_value (PRM_ID_VACUUM_MASTER_WAKEUP_INTERVAL);

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -3077,12 +3077,14 @@ vacuum_master_task::check_shutdown() const
 bool
 vacuum_master_task::is_task_queue_full() const
 {
+  /*
   if (vacuum_Worker_threads->is_full ())
     {
       // stop if worker pool is full
       vacuum_er_log (VACUUM_ER_LOG_MASTER, "%s", "Interrupt iteration: full worker pool");
       return true;
     }
+    */
   return false;
 }
 

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -4889,7 +4889,7 @@ online_index_builder (THREAD_ENTRY * thread_p, BTID_INT * btid_int, HFID * hfids
   assert (ib_thread_count <= 16);
 
   // a worker pool is built only of loading is done in parallel
-  cubthread::worker_pool *ib_workpool =
+  cubthread::worker_pool_type *ib_workpool =
     is_parallel ? thread_create_worker_pool (ib_thread_count, 1, "online-index", load_context) : NULL;
   // m_log = btree_is_worker_pool_logging_true ()
 

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -4890,10 +4890,8 @@ online_index_builder (THREAD_ENTRY * thread_p, BTID_INT * btid_int, HFID * hfids
 
   // a worker pool is built only of loading is done in parallel
   cubthread::worker_pool *ib_workpool =
-    is_parallel ?
-    thread_get_manager()->create_worker_pool (ib_thread_count, 32, "online-index", &load_context, 1,
-                                              btree_is_worker_pool_logging_true ())
-    : NULL;
+    is_parallel ? thread_create_worker_pool (ib_thread_count, 1, "online-index", load_context) : NULL;
+  // m_log = btree_is_worker_pool_logging_true ()
 
   aligned_midxkey_buf = PTR_ALIGN (midxkey_buf, MAX_ALIGNMENT);
   p_func_idx_info = func_idx_info.expr ? &func_idx_info : NULL;

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -116,7 +116,7 @@
 #include "tsc_timer.h"
 
 #if defined (SERVER_MODE)
-#include "thread_worker_pool.hpp"	// for system_core_count
+#include "thread_worker_pool_impl.hpp"	// for system_core_count
 #include "server_support.h"
 #endif // SERVER_MODE
 #if defined (SERVER_MODE)

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -48,6 +48,7 @@
 #include "perf_monitor.h"
 #include "porting_inline.hpp"
 #include "environment_variable.h"
+#include "thread_looper.hpp"
 #if defined (SERVER_MODE)
 #include "thread_daemon.hpp"
 #endif

--- a/src/thread/thread_manager.cpp
+++ b/src/thread/thread_manager.cpp
@@ -134,7 +134,7 @@ namespace cubthread
 	entry_mgr = &m_daemon_entry_manager;
       }
     // reserve 1 entry and add to m_daemons
-    return create_and_track_resource (m_daemons, 1, looper_arg, entry_mgr, exec_p, daemon_name);
+    return create_and_track_resource<daemon> (m_daemons, 1, looper_arg, entry_mgr, exec_p, daemon_name);
 #else // not SERVER_MODE = SA_MODE
     assert (false);
     return NULL;
@@ -146,25 +146,10 @@ namespace cubthread
   {
 #if defined (SERVER_MODE)
     // reserve no entry and add to m_daemons_without_entries
-    return create_and_track_resource (m_daemons_without_entries, 0, looper_arg, exec_p, daemon_name);
+    return create_and_track_resource<daemon> (m_daemons_without_entries, 0, looper_arg, exec_p, daemon_name);
 #else // not SERVER_MODE = SA_MODE
     assert (false);
     return NULL;
-#endif // not SERVER_MODE = SA_MODE
-  }
-
-  void
-  manager::destroy_worker_pool (worker_pool *&worker_pool_arg)
-  {
-#if defined (SERVER_MODE)
-    if (worker_pool_arg == NULL)
-      {
-	return;
-      }
-    // remove from m_worker_pools and free worker_pool_arg->get_worker_count thread entries
-    return destroy_and_untrack_resource (m_worker_pools, worker_pool_arg, worker_pool_arg->get_worker_count ());
-#else // not SERVER_MODE = SA_MODE
-    assert (worker_pool_arg == NULL);
 #endif // not SERVER_MODE = SA_MODE
   }
 

--- a/src/thread/thread_manager.hpp
+++ b/src/thread/thread_manager.hpp
@@ -278,6 +278,17 @@ namespace cubthread
   };
 
   //////////////////////////////////////////////////////////////////////////
+  // alias
+  //////////////////////////////////////////////////////////////////////////
+#if defined (SERVER_MODE)
+  using worker_pool_type = cubthread::worker_pool_impl<false>;
+  using stats_worker_pool_type = cubthread::worker_pool_impl<true>;
+#else
+  using worker_pool_type = cubthread::worker_pool;
+  using stats_worker_pool_type = cubthread::worker_pool;
+#endif
+
+  //////////////////////////////////////////////////////////////////////////
   // thread logging flags
   //
   // TODO: complete thread logging for all modules
@@ -486,20 +497,20 @@ thread_get_entry_manager (void)
   return cubthread::get_manager ()->get_entry_manager ();
 }
 
-inline cubthread::worker_pool_impl<false> *
+inline cubthread::worker_pool_type *
 thread_create_worker_pool (std::size_t pool_size, std::size_t core_count, const char *name,
 			   cubthread::entry_manager &entry_mgr, bool pool_threads = false)
 {
-  return cubthread::get_manager ()->create_worker_pool<cubthread::worker_pool_impl<false>> (pool_size, core_count, name,
+  return cubthread::get_manager ()->create_worker_pool<cubthread::worker_pool_type> (pool_size, core_count, name,
 	 entry_mgr, pool_threads);
 }
 
-inline cubthread::worker_pool_impl<true> *
+inline cubthread::stats_worker_pool_type *
 thread_create_stats_worker_pool (std::size_t pool_size, std::size_t core_count, const char *name,
 				 cubthread::entry_manager &entry_mgr, bool pool_threads = false,
 				 cubthread::wait_seconds idle_timeout = std::chrono::seconds (5))
 {
-  return cubthread::get_manager ()->create_worker_pool<cubthread::worker_pool_impl<true>> (pool_size, core_count, name,
+  return cubthread::get_manager ()->create_worker_pool<cubthread::stats_worker_pool_type> (pool_size, core_count, name,
 	 entry_mgr, pool_threads, idle_timeout);
 }
 

--- a/src/thread/thread_manager.hpp
+++ b/src/thread/thread_manager.hpp
@@ -136,8 +136,8 @@ namespace cubthread
       template<typename Res, typename ... CtArgs>
       Res *create_worker_pool (std::size_t pool_size, std::size_t core_count, CtArgs &&... args);
 
-      // destroy worker pool
-      void destroy_worker_pool (worker_pool *&worker_pool_arg);
+      template <typename Res>
+      void destroy_worker_pool (Res *&worker_pool_arg);
 
       // push task to worker pool created with this manager
       // if worker_pool_arg is NULL, the task is executed immediately
@@ -383,6 +383,24 @@ namespace cubthread
     return workerpool;
 #else // not SERVER_MODE = SA_MODE
     return NULL;
+#endif // not SERVER_MODE = SA_MODE
+  }
+
+  template <typename Res>
+  void
+  manager::destroy_worker_pool (Res *&worker_pool_arg)
+  {
+#if defined (SERVER_MODE)
+    if (worker_pool_arg == NULL)
+      {
+	return;
+      }
+    // remove from m_worker_pools and free worker_pool_arg->get_worker_count thread entries
+    worker_pool *base_arg = worker_pool_arg;
+    destroy_and_untrack_resource (m_worker_pools, base_arg, worker_pool_arg->get_worker_count ());
+    worker_pool_arg = NULL;
+#else // not SERVER_MODE = SA_MODE
+    assert (worker_pool_arg == NULL);
 #endif // not SERVER_MODE = SA_MODE
   }
 

--- a/src/thread/thread_manager.hpp
+++ b/src/thread/thread_manager.hpp
@@ -32,6 +32,9 @@
 #include "thread_entry_task.hpp"
 #include "thread_task.hpp"
 #include "thread_waiter.hpp"
+#if defined (SERVER_MODE)
+#include "thread_worker_pool_impl.hpp"
+#endif
 
 // other module includes
 #include "count_registry.hpp"
@@ -101,7 +104,7 @@ namespace cubthread
   //
   //     2. worker_pool -
   //	      REGISTER_WORKERPOOL (name, getter);
-  //          worker_pool *my_workpool = cubthread::get_manager ()->create_worker_pool (MAX_THREADS, MAX_JOBS);
+  //          worker_pool *my_workpool = cubthread::get_manager ()->create_worker_pool<pool_type> (MAX_THREADS, MAX_JOBS);
   //          cubthread::get_manager ()->push_task (my_workpool, entry_task_p);
   //          cubthread::get_manager ()->destroy_worker_pool (my_workpool);
   //
@@ -360,8 +363,8 @@ namespace cubthread
     assert (m_worker_pools.size () <= workerpool_registry_t::count ());
 
     // reserve pool_size entries and add to m_worker_pools
-    workerpool = create_and_track_resource (m_worker_pools, pool_size,
-					    pool_size, core_count, std::forward<CtArgs> (args)...);
+    workerpool = create_and_track_resource<Res> (m_worker_pools, pool_size,
+		 pool_size, core_count, std::forward<CtArgs> (args)...);
     if (workerpool)
       {
 	workerpool->initialize (pool_size, core_count);
@@ -483,12 +486,21 @@ thread_get_entry_manager (void)
   return cubthread::get_manager ()->get_entry_manager ();
 }
 
-inline cubthread::worker_pool *
-thread_create_worker_pool_base (std::size_t pool_size, std::size_t core_count, const char *name,
-				cubthread::entry_manager &entry_mgr, bool pool_threads = false)
+inline cubthread::worker_pool_impl<false> *
+thread_create_worker_pool (std::size_t pool_size, std::size_t core_count, const char *name,
+			   cubthread::entry_manager &entry_mgr, bool pool_threads = false)
 {
-  return cubthread::get_manager ()->create_worker_pool<cubthread::worker_pool> (pool_size, core_count, name, entry_mgr,
-	 pool_threads);
+  return cubthread::get_manager ()->create_worker_pool<cubthread::worker_pool_impl<false>> (pool_size, core_count, name,
+	 entry_mgr, pool_threads);
+}
+
+inline cubthread::worker_pool_impl<true> *
+thread_create_stats_worker_pool (std::size_t pool_size, std::size_t core_count, const char *name,
+				 cubthread::entry_manager &entry_mgr, bool pool_threads = false,
+				 cubthread::wait_seconds idle_timeout = std::chrono::seconds (5))
+{
+  return cubthread::get_manager ()->create_worker_pool<cubthread::worker_pool_impl<true>> (pool_size, core_count, name,
+	 entry_mgr, pool_threads, idle_timeout);
 }
 
 inline std::size_t

--- a/src/thread/thread_worker_pool_impl.hpp
+++ b/src/thread/thread_worker_pool_impl.hpp
@@ -1157,7 +1157,7 @@ namespace cubthread
     std::lock_guard<std::mutex> ulock (m_temp_workers_mutex);
 
     m_temp_workers.push_back (std::move (w));
-    static_cast<worker_impl *> (m_temp_workers.back ())->assign_task (std::move (task_ref));
+    static_cast<worker_impl *> (m_temp_workers.back ().get ())->assign_task (std::move (task_ref));
   }
 
   //////////////////////////////////////////////////////////////////////////

--- a/src/thread/thread_worker_pool_taskcap.cpp
+++ b/src/thread/thread_worker_pool_taskcap.cpp
@@ -38,7 +38,7 @@ namespace cubthread
     , m_mutex ()
     , m_cond_var ()
   {
-    m_tasks_available = m_max_tasks = worker_pool->get_max_count ();
+    m_tasks_available = m_max_tasks = worker_pool->get_worker_count ();
   }
 
   bool

--- a/src/thread/thread_worker_pool_taskcap.hpp
+++ b/src/thread/thread_worker_pool_taskcap.hpp
@@ -23,7 +23,7 @@
 #ifndef _THREAD_WORKER_POOL_TASKCAP_HPP_
 #define _THREAD_WORKER_POOL_TASKCAP_HPP_
 
-#include "thread_worker_pool.hpp"
+#include "thread_manager.hpp"
 
 namespace cubthread
 {

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -954,7 +954,7 @@ extern bool cdc_Logging;
 
 #if defined (SERVER_MODE)
 // *INDENT-OFF*
-extern cubthread::worker_pool *g_backup_read_worker_pool;
+extern cubthread::worker_pool_type *g_backup_read_worker_pool;
 // *INDENT-ON*
 #endif
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -90,6 +90,7 @@
 #endif
 #include "thread_entry.hpp"
 #include "thread_entry_task.hpp"
+#include "thread_looper.hpp"
 #include "thread_manager.hpp"
 #include "transaction_transient.hpp"
 #include "vacuum.h"

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -71,7 +71,6 @@
 #else /* !SERVER_MODE */
 #include "connection_defs.h"
 #include "connection_sr.h"
-#include "thread_worker_pool.hpp"
 #endif
 #include "critical_section.h"
 #include "page_buffer.h"
@@ -7521,7 +7520,7 @@ logpb_backup_for_volume (THREAD_ENTRY * thread_p, VOLID volid, LOG_LSA * chkpt_l
 }
 
 // *INDENT-OFF*
-cubthread::worker_pool * g_backup_read_worker_pool = NULL;
+cubthread::worker_pool_type * g_backup_read_worker_pool = NULL;
 
 REGISTER_WORKERPOOL (backup_read, []() {
 #if defined (SERVER_MODE)

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -7544,7 +7544,8 @@ logpb_create_backup_read_worker_pool (size_t thread_count)
     }
 
   g_backup_read_worker_pool =
-    thread_create_worker_pool_base (thread_count, core_count, "backup-read", thread_get_entry_manager (), true);
+    thread_create_worker_pool (thread_count, core_count, "backup-read", thread_get_entry_manager (), true);
+  // m_log = false
 }
 
 void

--- a/src/transaction/log_recovery_redo_parallel.cpp
+++ b/src/transaction/log_recovery_redo_parallel.cpp
@@ -659,12 +659,9 @@ namespace cublog
     assert (a_task_count > 0);
     assert (m_worker_pool == nullptr);
 
-    // NOTE: already initialized globally (probably during boot)
-    cubthread::manager *thread_manager = cubthread::get_manager ();
-
-    m_worker_pool = thread_manager->create_worker_pool (a_task_count, a_task_count, "recovery-redo",
-		    m_pool_entry_manager.get (),
-		    a_task_count, false /*debug_logging*/);
+    m_worker_pool = thread_create_worker_pool (a_task_count, a_task_count, "recovery-redo",
+		    *m_pool_entry_manager.get ());
+    // m_log = false
   }
 
   void

--- a/src/transaction/log_recovery_redo_parallel.hpp
+++ b/src/transaction/log_recovery_redo_parallel.hpp
@@ -25,7 +25,6 @@
 
 #if defined (SERVER_MODE)
 #include "thread_manager.hpp"
-#include "thread_worker_pool.hpp"
 #include "vpid_utilities.hpp"
 
 #include <atomic>
@@ -194,7 +193,7 @@ namespace cublog
        */
       task_active_state_bookkeeping m_task_state_bookkeeping;
 
-      cubthread::worker_pool *m_worker_pool;
+      cubthread::worker_pool_type *m_worker_pool;
       /* tasks have owner-controlled life-time in order to be able to
        * collect post-execution perf stats from them
        */

--- a/unit_tests/thread/test_manager.cpp
+++ b/unit_tests/thread/test_manager.cpp
@@ -79,7 +79,7 @@ namespace test_thread
 
     thread_mgr.init_entries (max_threads);
 
-    auto *dummy_pool = thread_mgr.create_worker_pool (1, 1, NULL, thread_mgr.get_entry_manager ());
+    auto *dummy_pool = thread_create_worker_pool (1, 1, NULL, thread_mgr.get_entry_manager ());
     thread_mgr.destroy_worker_pool (dummy_pool);
 
     auto *daemon = thread_mgr.create_daemon (cubthread::looper (), new dummy_exec ());

--- a/unit_tests/thread/test_worker_pool.cpp
+++ b/unit_tests/thread/test_worker_pool.cpp
@@ -28,7 +28,7 @@
 #define SERVER_MODE
 #include "thread_entry_task.hpp"
 #include "thread_task.hpp"
-#include "thread_worker_pool.hpp"
+#include "thread_manager.hpp"
 
 #include <atomic>
 #include <chrono>
@@ -107,7 +107,7 @@ namespace test_thread
   test_one_thread_pool (void)
   {
     test_entry_manager ctx_mgr;
-    cubthread::worker_pool pool (1, 1, ctx_mgr, NULL, 1, false);
+    cubthread::worker_pool_type pool (1, 1, ctx_mgr, NULL, 1, false);
     pool.execute (new test_task ());
     pool.execute (new test_task ());
 
@@ -123,7 +123,7 @@ namespace test_thread
   test_two_threads_pool (void)
   {
     test_entry_manager ctx_mgr;
-    cubthread::worker_pool pool (2, 16, ctx_mgr, NULL, 1, false);
+    cubthread::worker_pool_type pool (2, 16, ctx_mgr, NULL, 1, false);
 
     pool.execute (new start_end_task ());
     pool.execute (new start_end_task ());
@@ -142,7 +142,7 @@ namespace test_thread
 
     nthreads *= 4;
 
-    cubthread::worker_pool workpool (nthreads, nthreads * 16, ctx_mgr, NULL, 1, false);
+    cubthread::worker_pool_type workpool (nthreads, nthreads * 16, ctx_mgr, NULL, 1, false);
 
     auto start_time = std::chrono::high_resolution_clock::now ();
     for (int i = 0; i < 10000; i++)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26701>

### Purpose

Worker pool의 구조 변경, 수정에 맞게 호출자를 수정합니다. 아래와 같은 alias를 제공합니다.

```
cubthread::worker_pool_type -> cubthread::worker_pool_impl<false>
cubthread::stats_worker_pool_type -> cubthread::worker_pool_impl<true>
```

SERVER_MODE가 아닐 시에는 cubthread::worker_pool입니다.

### Implementation

새 구조 및 함수에 맞게 호출자를 수정합니다. 대부분이 생성자와 선언부를 맞춰주는 내용입니다.
특별한 구현은 없습니다.

### Remarks

Vacuum의 is_full은 다음 이슈이므로 주석처리하였습니다.
get_task_stats은 모니터링 이슈에서 처리합니다. m_log (debug_logging)에 대한 구현은 고려 중입니다. 깨지는 케이스가 없다면 하지 않을 가능성이 더 높습니다.

Unit test의 test_worker_pool.cpp에서는 worker_pool 생성자를 직접 호출하고 있기 때문에 깨지게 됩니다.
테스트의 의도 자체가 thread manager를 거치지 않고 단독으로 하는 테스트입니다.
하지만, 구조를 변경하여 thread manager를 거치지 않은 worker pool의 생성을 막았기 때문에 고려가 필요합니다. (생성자만 사용되는 경우 올바른 초기화 경로를 거치지 못합니다)