### PR TITLE
[CUBVEC-178] Optimize HNSW Key Structures by Replacing OID with uint64_t Encoding

### DIFF
--- a/src/storage/index_hnsw/hnsw_algo.hpp
+++ b/src/storage/index_hnsw/hnsw_algo.hpp
@@ -68,6 +68,10 @@ namespace cubhnsw
       }
 
     protected:
+      inline uint64_t encode_slot_id_ (const slot_id_t &slot) const noexcept
+      {
+	return encode_oid_key (slot);
+      }
 
       // horizontal seeking
       int seek_on_layer_ (algo_context_t &context, const float *query, const slot_id_t &start_slot,
@@ -460,7 +464,7 @@ namespace cubhnsw
 
     next.insert_reserved (candidate_t (-radius, start_slot));
     top.insert_reserved (candidate_t (radius, start_slot));
-    visits.insert (start_slot);
+    visits.insert (encode_slot_id_ (start_slot));
     stats.on_start_node ();
 
     while (!next.empty ())
@@ -485,7 +489,7 @@ namespace cubhnsw
 	    context.m_stats.on_neighbors_cache_hit (context.m_is_perf_tracking, level);
 	    for (slot_id_t successor_slot : *cached_neighbors)
 	      {
-		auto [it, inserted] = visits.insert (successor_slot);
+		auto [it, inserted] = visits.insert (encode_slot_id_ (successor_slot));
 		if (!inserted)
 		  {
 		    continue;
@@ -520,7 +524,7 @@ namespace cubhnsw
 	    neigh.push_back (successor_slot);
 	    stats.on_neighbor_scan ();
 
-	    auto [it, inserted] = visits.insert (successor_slot);
+	    auto [it, inserted] = visits.insert (encode_slot_id_ (successor_slot));
 	    if (!inserted)
 	      {
 		continue;
@@ -545,7 +549,7 @@ namespace cubhnsw
 		stats.on_candidate_prune ();
 	      }
 	  }
-	m_storage->set_neighbors_cached_ids (context, candidate_slot, level, neigh);
+	m_storage->set_neighbors_cached_ids (context, candidate_slot, level, std::move (neigh));
       }
 
     stats.commit (context.m_stats, context.m_is_perf_tracking, context.m_level);
@@ -614,7 +618,7 @@ namespace cubhnsw
 			changed = true;
 		      }
 		  }
-		m_storage->set_neighbors_cached_ids (context, original_closest_slot, level, neigh);
+		m_storage->set_neighbors_cached_ids (context, original_closest_slot, level, std::move (neigh));
 	      }
 	    stats.on_visit ();
 	  }
@@ -653,7 +657,7 @@ namespace cubhnsw
       {
 	neigh.push_back (new_neighbors.at (i));
       }
-    m_storage->set_neighbors_cached_ids (context, new_node_blk->id, level, neigh);
+    m_storage->set_neighbors_cached_ids (context, new_node_blk->id, level, std::move (neigh));
     m_graph_structure_profile.on_edges_added (level, top_view.size ());
   }
 
@@ -690,7 +694,7 @@ namespace cubhnsw
 		{
 		  neigh.push_back (close_header.at (i));
 		}
-	      m_storage->set_neighbors_cached_ids (context, close_slot, level, neigh);
+	      m_storage->set_neighbors_cached_ids (context, close_slot, level, std::move (neigh));
 	      m_graph_structure_profile.on_edges_added (level, 1);
 	      continue;
 	    }
@@ -731,7 +735,7 @@ namespace cubhnsw
 	  {
 	    neigh.push_back (close_header.at (i));
 	  }
-	m_storage->set_neighbors_cached_ids (context, close_slot, level, neigh);
+	m_storage->set_neighbors_cached_ids (context, close_slot, level, std::move (neigh));
 	m_graph_structure_profile.on_edges_added (level, top_view.size ());
       }
 

--- a/src/storage/index_hnsw/hnsw_algo_common.hpp
+++ b/src/storage/index_hnsw/hnsw_algo_common.hpp
@@ -23,6 +23,7 @@
 #ifndef _HNSW_ALGO_COMMON_HPP_
 #define _HNSW_ALGO_COMMON_HPP_
 
+#include <array>
 #include <random>
 #include <ankerl/unordered_dense.h>
 
@@ -78,22 +79,6 @@ namespace cubhnsw
 	   | uint64_t (uint16_t (o.volid));
   }
 
-  struct oid_hash
-  {
-    inline std::size_t operator() (const OID &o) const noexcept
-    {
-      return encode_oid_key (o);
-    }
-  };
-
-  struct oid_equal
-  {
-    inline bool operator() (const OID &a, const OID &b) const noexcept
-    {
-      return a.pageid == b.pageid && a.slotid == b.slotid && a.volid == b.volid;
-    }
-  };
-
   struct visit_set_helper
   {
     using type = ankerl::unordered_dense::set<uint64_t>;
@@ -103,36 +88,17 @@ namespace cubhnsw
 
   struct vector_cache_helper
   {
-    using type = ankerl::unordered_dense::map<OID, std::vector<float>, oid_hash, oid_equal>;
+    using type = ankerl::unordered_dense::map<uint64_t, std::vector<float>>;
   };
 
   using vector_cache_t = vector_cache_helper::type;
 
-  struct neighbors_key
-  {
-    slot_id_t slot;
-    level_t level;
+  using neighbors_cache_per_level_t =
+	  ankerl::unordered_dense::map<uint64_t, std::vector<slot_id_t>>;
 
-    bool operator== (const neighbors_key &o) const noexcept
-    {
-      static constexpr oid_equal eq {};
-      return level == o.level && eq (slot, o.slot);
-    }
-  };
-
-  struct neighbors_key_hash
-  {
-    std::size_t operator() (neighbors_key const &k) const noexcept
-    {
-      std::size_t h = encode_oid_key (k.slot);
-      std::size_t x = std::hash<level_t> {} (k.level);
-      h ^= x + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
-      return h;
-    }
-  };
-
-  using neighbors_cache_t =
-	  ankerl::unordered_dense::map<neighbors_key, std::vector<slot_id_t>, neighbors_key_hash>;
+  // One map per level; level is the array index, so the in-map key is just the
+  // encoded slot (uint64_t). Avoids a composite key struct/hash on the hot path.
+  using neighbors_cache_t = std::array<neighbors_cache_per_level_t, MAX_LEVELS>;
 
   using candidates_view_t = std::vector<candidate_t>;
 

--- a/src/storage/index_hnsw/hnsw_algo_common.hpp
+++ b/src/storage/index_hnsw/hnsw_algo_common.hpp
@@ -71,14 +71,18 @@ namespace cubhnsw
     }
   };
 
+  inline uint64_t encode_oid_key (const OID &o) noexcept
+  {
+    return (uint64_t (uint32_t (o.pageid)) << 32)
+	   | (uint64_t (uint16_t (o.slotid)) << 16)
+	   | uint64_t (uint16_t (o.volid));
+  }
+
   struct oid_hash
   {
     inline std::size_t operator() (const OID &o) const noexcept
     {
-      // bit packing of oid
-      return (uint64_t (uint32_t (o.pageid)) << 32)
-	     | (uint64_t (uint16_t (o.slotid)) << 16)
-	     |  uint64_t (uint16_t (o.volid));
+      return encode_oid_key (o);
     }
   };
 
@@ -92,7 +96,7 @@ namespace cubhnsw
 
   struct visit_set_helper
   {
-    using type = ankerl::unordered_dense::set<OID, oid_hash, oid_equal>;
+    using type = ankerl::unordered_dense::set<uint64_t>;
   };
 
   using visited_set_t = visit_set_helper::type;
@@ -120,7 +124,7 @@ namespace cubhnsw
   {
     std::size_t operator() (neighbors_key const &k) const noexcept
     {
-      std::size_t h = oid_hash {} (k.slot);
+      std::size_t h = encode_oid_key (k.slot);
       std::size_t x = std::hash<level_t> {} (k.level);
       h ^= x + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
       return h;

--- a/src/storage/index_hnsw/hnsw_storage.cpp
+++ b/src/storage/index_hnsw/hnsw_storage.cpp
@@ -204,10 +204,10 @@ namespace cubhnsw
   storage::set_neighbors_cached_ids (algo_context_t &context,
 				     const slot_id_t &slot,
 				     level_t level,
-				     const std::vector<slot_id_t> &neighbors)
+				     std::vector<slot_id_t> neighbors)
   {
     neighbors_key key { slot, level };
-    m_neighbors_cache[key] = neighbors;
+    m_neighbors_cache.insert_or_assign (key, std::move (neighbors));
   }
 
   const float *

--- a/src/storage/index_hnsw/hnsw_storage.cpp
+++ b/src/storage/index_hnsw/hnsw_storage.cpp
@@ -189,7 +189,11 @@ namespace cubhnsw
   const std::vector<slot_id_t> *
   storage::get_neighbors_cached_ids (algo_context_t &context, const slot_id_t &slot, level_t level)
   {
-    assert (level >= 0 && level < MAX_LEVELS);
+    if (level < 0 || level >= MAX_LEVELS)
+      {
+	assert (false);
+	return nullptr;
+      }
     auto &per_level = m_neighbors_cache[level];
     auto it = per_level.find (encode_oid_key (slot));
     if (it != per_level.end ())

--- a/src/storage/index_hnsw/hnsw_storage.cpp
+++ b/src/storage/index_hnsw/hnsw_storage.cpp
@@ -189,9 +189,10 @@ namespace cubhnsw
   const std::vector<slot_id_t> *
   storage::get_neighbors_cached_ids (algo_context_t &context, const slot_id_t &slot, level_t level)
   {
-    neighbors_key key { slot, level };
-    auto it = m_neighbors_cache.find (key);
-    if (it != m_neighbors_cache.end ())
+    assert (level >= 0 && level < MAX_LEVELS);
+    auto &per_level = m_neighbors_cache[level];
+    auto it = per_level.find (encode_oid_key (slot));
+    if (it != per_level.end ())
       {
 	return &it->second;
       }
@@ -206,8 +207,8 @@ namespace cubhnsw
 				     level_t level,
 				     std::vector<slot_id_t> neighbors)
   {
-    neighbors_key key { slot, level };
-    m_neighbors_cache.insert_or_assign (key, std::move (neighbors));
+    assert (level >= 0 && level < MAX_LEVELS);
+    m_neighbors_cache[level].insert_or_assign (encode_oid_key (slot), std::move (neighbors));
   }
 
   const float *
@@ -215,7 +216,7 @@ namespace cubhnsw
   {
     context.m_stats.on_vector_access (context.m_is_perf_tracking, context.m_level);
 
-    auto it = m_vector_cache.find (slot);
+    auto it = m_vector_cache.find (encode_oid_key (slot));
     if (it != m_vector_cache.end ())
       {
 	context.m_stats.on_vector_cache_hit (context.m_is_perf_tracking, context.m_level);
@@ -228,7 +229,7 @@ namespace cubhnsw
     node_t node { reinterpret_cast<byte_t *> (node_blk->data) };
     const float *vec = node.get_vector ();
 
-    std::vector<float> &cached = m_vector_cache[slot];
+    std::vector<float> &cached = m_vector_cache[encode_oid_key (slot)];
     cached.assign (vec, vec + get_dimension ());
 
     return cached.data ();

--- a/src/storage/index_hnsw/hnsw_storage.hpp
+++ b/src/storage/index_hnsw/hnsw_storage.hpp
@@ -253,7 +253,7 @@ namespace cubhnsw
       void set_neighbors_cached_ids (algo_context_t &context,
 				     const slot_id_t &slot_id,
 				     level_t level,
-				     const std::vector<slot_id_t> &neighbors);
+				     std::vector<slot_id_t> neighbors);
 
       void promote_root (pinned_t &root);
 

--- a/src/storage/index_hnsw/hnsw_storage.hpp
+++ b/src/storage/index_hnsw/hnsw_storage.hpp
@@ -316,6 +316,6 @@ namespace cubhnsw
       vector_cache_t m_vector_cache;  // (slot_id_t, vector) cache
 
       /* TODO: This is not thread-safe. Currently, we are assuming single-threaded access, but we need to make it thread-safe. */
-      neighbors_cache_t m_neighbors_cache;    // (slot_id_t, level) -> neighbors
+      neighbors_cache_t m_neighbors_cache;    // per-level: encoded slot -> neighbors
   };
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-178

### Purpose

Improve performance of frequently accessed data structures in HNSW by reducing overhead from OID hashing and comparison.

### Implementation

- Introduced conversion utilities between OID and uint64_t
- Replaced OID-based keys with uint64_t in core HNSW data structures:
  - visited set
  - vector cache
  - neighbor cache
- Eliminated repeated OID hashing and comparison during intensive operations such as:
   - graph traversal
   - distance evaluation
   - neighbor expansion

### Remarks

N/A
