### PR TITLE
[CBRD-26698] (backport to 11.0) bug-fix: correct length when handling shard keys (#7030)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,7 +262,7 @@ if(UNIX)
     endif(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.4.7)
 
     # C flags for both debug and release build
-    set(CMAKE_C_COMMON_FLAGS "-ggdb -fno-omit-frame-pointer")
+    set(CMAKE_C_COMMON_FLAGS "-ggdb -fno-omit-frame-pointer -fstack-protector-strong")
     # C++ flags for both debug and release build
     set(CMAKE_CXX_COMMON_FLAGS "${CMAKE_C_COMMON_FLAGS} -std=c++0x")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,12 +262,12 @@ if(UNIX)
     endif(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.4.7)
 
     # C flags for both debug and release build
-    set(CMAKE_C_COMMON_FLAGS "-ggdb -fno-omit-frame-pointer -fstack-protector-strong")
+    set(CMAKE_C_COMMON_FLAGS "-ggdb -fno-omit-frame-pointer")
     # C++ flags for both debug and release build
     set(CMAKE_CXX_COMMON_FLAGS "${CMAKE_C_COMMON_FLAGS} -std=c++0x")
 
     # C flags for debug build
-    set(CMAKE_C_DEBUG_FLAGS "-Wall -fno-inline ${CMAKE_C_COMMON_FLAGS}")
+    set(CMAKE_C_DEBUG_FLAGS "-Wall -fno-inline ${CMAKE_C_COMMON_FLAGS} -fstack-protector-strong")
     # C++ flags for debug build
     set(CMAKE_CXX_DEBUG_FLAGS "-Wall -fno-inline ${CMAKE_CXX_COMMON_FLAGS}")
 

--- a/src/broker/shard_parser.c
+++ b/src/broker/shard_parser.c
@@ -316,10 +316,20 @@ static int
 sp_make_int_sp_value_from_string (SP_VALUE * value_p, char *pos, int length)
 {
   int result = 0;
-  char tmp = pos[length];
+  char shard_key[SHARD_KEY_LENGTH + 1];
+  int key_len = (length > SHARD_KEY_LENGTH) ? SHARD_KEY_LENGTH : length;
+  char *p;
 
-  pos[length] = '\0';
-  result = parse_bigint (&value_p->integer, pos, 10);
+  memcpy (shard_key, pos, key_len);
+  shard_key[key_len] = '\0';
+
+  p = strchr (shard_key, ';');
+  if (p)
+    {
+      *p = '\0';
+    }
+
+  result = parse_bigint (&value_p->integer, shard_key, 10);
   if (result != 0)
     {
       return ER_SP_INVALID_HINT;

--- a/src/broker/shard_parser.c
+++ b/src/broker/shard_parser.c
@@ -334,7 +334,7 @@ sp_make_int_sp_value_from_string (SP_VALUE * value_p, char *pos, int length)
     {
       return ER_SP_INVALID_HINT;
     }
-  pos[length] = tmp;
+
   value_p->type = VT_INTEGER;
   return NO_ERROR;
 }

--- a/src/broker/shard_parser.h
+++ b/src/broker/shard_parser.h
@@ -35,7 +35,7 @@
 #include "error_code.h"
 
 #define SP_VALUE_INIT_SIZE 50
-
+#define SHARD_KEY_LENGTH 128
 
 enum sp_error_code
 {


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26698>

### Purpose

sp_make_int_sp_value_from_string 루틴에서 shard key MAX인 128이 아닌 128을 오버하는 스트링 버퍼에 '\0'을 쓰고 있는 버그를 패치(shard_key[length] = '\0')

### Implementation

backport from 11.5

### Remarks

N/A
