### PR TITLE
[CBRD-26716] Incorrect assignment used in assert in logwr_read_bgarv_log_header()

### DIFF
--- a/src/transaction/log_writer.c
+++ b/src/transaction/log_writer.c
@@ -373,7 +373,7 @@ logwr_read_bgarv_log_header (void)
     }
 
   assert (log_pgptr->hdr.logical_pageid == LOGPB_HEADER_PAGE_ID);
-  assert (log_pgptr->hdr.offset = NULL_OFFSET);
+  assert (log_pgptr->hdr.offset == NULL_OFFSET);
 
   bgarv_header = (LOG_BGARV_HEADER *) log_pgptr->area;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26716

### Purpose

logwr_read_bgarv_log_header() 함수 내에 잘못된 assert문을 수정합니다.

### Implementation

logwr_read_bgarv_log_header() 함수의 assert 구문 변경
assert (log_pgptr->hdr.offset = NULL_OFFSET); -> assert (log_pgptr->hdr.offset == NULL_OFFSET);

### Remarks

N/A
