### PR TITLE
[CBRD-26410] revert sys-param: (backport to 11.4) Improve performance for SQL_TRACE_EXECUTION_PLAN

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -1853,10 +1853,8 @@ static int prm_sql_trace_slow_msecs_lower = -1;
 static int prm_sql_trace_slow_msecs_upper = 1000 * 60 * 60 * 24;	/* 24 hours */
 static unsigned int prm_sql_trace_slow_msecs_flag = 0;
 
-int PRM_SQL_TRACE_EXECUTION_PLAN = 0;
-static int prm_sql_trace_execution_plan_default = 0;
-static int prm_sql_trace_execution_plan_lower = 0;
-static int prm_sql_trace_execution_plan_upper = 2;
+bool PRM_SQL_TRACE_EXECUTION_PLAN = false;
+static bool prm_sql_trace_execution_plan_default = false;
 static unsigned int prm_sql_trace_execution_plan_flag = 0;
 
 int PRM_LOG_TRACE_FLUSH_TIME_MSECS = 0;
@@ -4854,12 +4852,12 @@ SYSPRM_PARAM prm_Def[] = {
   {PRM_ID_SQL_TRACE_EXECUTION_PLAN,
    PRM_NAME_SQL_TRACE_EXECUTION_PLAN,
    (PRM_USER_CHANGE | PRM_FOR_SERVER),
-   PRM_INTEGER,
+   PRM_BOOLEAN,
    &prm_sql_trace_execution_plan_flag,
-   &prm_sql_trace_execution_plan_default,
-   &PRM_SQL_TRACE_EXECUTION_PLAN,
-   (void *) &prm_sql_trace_execution_plan_upper,
-   (void *) &prm_sql_trace_execution_plan_lower,
+   (void *) &prm_sql_trace_execution_plan_default,
+   (void *) &PRM_SQL_TRACE_EXECUTION_PLAN,
+   (void *) NULL,
+   (char *) NULL,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL},

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -5225,8 +5225,7 @@ sqmgr_execute_query (THREAD_ENTRY * thread_p, unsigned int rid, char *request, i
   TRAN_STATE tran_state;
   bool is_tran_auto_commit;
 
-  trace_level =
-    prm_get_bool_value (PRM_ID_SQL_TRACE_EXECUTION_PLAN) ? TRACE_LOG_LEVEL_DETAIL : TRACE_LOG_LEVEL_OFF;
+  trace_level = prm_get_bool_value (PRM_ID_SQL_TRACE_EXECUTION_PLAN) ? TRACE_LOG_LEVEL_DETAIL : TRACE_LOG_LEVEL_OFF;
   trace_slow_msec = prm_get_integer_value (PRM_ID_SQL_TRACE_SLOW_MSECS);
   trace_ioreads = prm_get_integer_value (PRM_ID_SQL_TRACE_IOREADS);
 

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -5225,7 +5225,8 @@ sqmgr_execute_query (THREAD_ENTRY * thread_p, unsigned int rid, char *request, i
   TRAN_STATE tran_state;
   bool is_tran_auto_commit;
 
-  trace_level = prm_get_integer_value (PRM_ID_SQL_TRACE_EXECUTION_PLAN);
+  trace_level =
+    (prm_get_integer_value (PRM_ID_SQL_TRACE_EXECUTION_PLAN)) ? TRACE_LOG_LEVEL_DETAIL : TRACE_LOG_LEVEL_OFF;
   trace_slow_msec = prm_get_integer_value (PRM_ID_SQL_TRACE_SLOW_MSECS);
   trace_ioreads = prm_get_integer_value (PRM_ID_SQL_TRACE_IOREADS);
 

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -5226,7 +5226,7 @@ sqmgr_execute_query (THREAD_ENTRY * thread_p, unsigned int rid, char *request, i
   bool is_tran_auto_commit;
 
   trace_level =
-    (prm_get_integer_value (PRM_ID_SQL_TRACE_EXECUTION_PLAN)) ? TRACE_LOG_LEVEL_DETAIL : TRACE_LOG_LEVEL_OFF;
+    prm_get_bool_value (PRM_ID_SQL_TRACE_EXECUTION_PLAN) ? TRACE_LOG_LEVEL_DETAIL : TRACE_LOG_LEVEL_OFF;
   trace_slow_msec = prm_get_integer_value (PRM_ID_SQL_TRACE_SLOW_MSECS);
   trace_ioreads = prm_get_integer_value (PRM_ID_SQL_TRACE_IOREADS);
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26410>

### Purpose

11.4 conf 호환성 유지를 위해 system parameter PRM_ID_SQL_TRACE_EXECUTION_PLAN을 bool 타입으로 되돌림

### Implementation

system_parameter.c modify &
trace_level =
    (prm_get_bool_value (PRM_ID_SQL_TRACE_EXECUTION_PLAN)) ? TRACE_LOG_LEVEL_DETAIL : TRACE_LOG_LEVEL_OFF;

### Remarks