### PR TITLE
[CBRD-26410] revert sys-param: (backport to 11.3) Improve performance for SQL_TRACE_EXECUTION_PLAN (#7072)

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -1807,10 +1807,8 @@ static int prm_sql_trace_slow_msecs_lower = -1;
 static int prm_sql_trace_slow_msecs_upper = 1000 * 60 * 60 * 24;	/* 24 hours */
 static unsigned int prm_sql_trace_slow_msecs_flag = 0;
 
-int PRM_SQL_TRACE_EXECUTION_PLAN = 0;
-static int prm_sql_trace_execution_plan_default = 0;
-static int prm_sql_trace_execution_plan_lower = 0;
-static int prm_sql_trace_execution_plan_upper = 2;
+bool PRM_SQL_TRACE_EXECUTION_PLAN = false;
+static bool prm_sql_trace_execution_plan_default = false;
 static unsigned int prm_sql_trace_execution_plan_flag = 0;
 
 int PRM_LOG_TRACE_FLUSH_TIME_MSECS = 0;
@@ -4768,12 +4766,12 @@ SYSPRM_PARAM prm_Def[] = {
   {PRM_ID_SQL_TRACE_EXECUTION_PLAN,
    PRM_NAME_SQL_TRACE_EXECUTION_PLAN,
    (PRM_USER_CHANGE | PRM_FOR_SERVER),
-   PRM_INTEGER,
+   PRM_BOOLEAN,
    &prm_sql_trace_execution_plan_flag,
    (void *) &prm_sql_trace_execution_plan_default,
    (void *) &PRM_SQL_TRACE_EXECUTION_PLAN,
-   (void *) &prm_sql_trace_execution_plan_upper,
-   (void *) &prm_sql_trace_execution_plan_lower,
+   (void *) NULL,
+   (void *) NULL,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL},

--- a/src/base/trace_event_log.c
+++ b/src/base/trace_event_log.c
@@ -339,8 +339,7 @@ trace_event_log_start (THREAD_ENTRY * thread_p, const char *log_name, const char
       if (log_Fp == NULL)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
-	  csect_exit (thread_p, csect);
-	  return NULL;
+	  goto clear_and_exit;
 	}
     }
   else if (ftell (log_Fp) > prm_get_integer_value (PRM_ID_ER_LOG_SIZE))
@@ -351,8 +350,7 @@ trace_event_log_start (THREAD_ENTRY * thread_p, const char *log_name, const char
       if (log_Fp == NULL)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
-	  csect_exit (thread_p, csect);
-	  return NULL;
+	  goto clear_and_exit;
 	}
     }
 
@@ -376,6 +374,7 @@ trace_event_log_start (THREAD_ENTRY * thread_p, const char *log_name, const char
 
   fprintf (log_Fp, "%s - %s\n", time_array, log_name);
 
+clear_and_exit:
   if (log_type == 'E')
     {
       event_Fp = log_Fp;
@@ -383,6 +382,11 @@ trace_event_log_start (THREAD_ENTRY * thread_p, const char *log_name, const char
   else
     {
       trace_Fp = log_Fp;
+    }
+
+  if (log_Fp == NULL)
+    {
+      csect_exit (thread_p, csect);
     }
 
   return log_Fp;

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -5195,7 +5195,7 @@ sqmgr_execute_query (THREAD_ENTRY * thread_p, unsigned int rid, char *request, i
   TRAN_STATE tran_state;
   bool is_tran_auto_commit;
 
-  trace_level = prm_get_integer_value (PRM_ID_SQL_TRACE_EXECUTION_PLAN);
+  trace_level = prm_get_bool_value (PRM_ID_SQL_TRACE_EXECUTION_PLAN) ? TRACE_LOG_LEVEL_DETAIL : TRACE_LOG_LEVEL_OFF;
   trace_slow_msec = prm_get_integer_value (PRM_ID_SQL_TRACE_SLOW_MSECS);
   trace_ioreads = prm_get_integer_value (PRM_ID_SQL_TRACE_IOREADS);
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26410>

### Purpose

11.3 conf 호환성 유지를 위해 system parameter PRM_ID_SQL_TRACE_EXECUTION_PLAN을 bool 타입으로 되돌림

### Implementation

system_parameter.c modify &
trace_level =
(prm_get_bool_value (PRM_ID_SQL_TRACE_EXECUTION_PLAN)) ? TRACE_LOG_LEVEL_DETAIL : TRACE_LOG_LEVEL_OFF;

### Remarks

N/A
