### PR TITLE
[CBRD-26410] revision: Improve performance for SQL_TRACE_EXECUTION_PLAN

### DIFF
--- a/src/base/trace_event_log.c
+++ b/src/base/trace_event_log.c
@@ -347,7 +347,6 @@ trace_event_log_start (THREAD_ENTRY * thread_p, const char *log_name, const char
       if (log_Fp == NULL)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
-	  csect_exit (thread_p, csect);
 	  goto clear_and_exit;
 	}
     }
@@ -359,7 +358,6 @@ trace_event_log_start (THREAD_ENTRY * thread_p, const char *log_name, const char
       if (log_Fp == NULL)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
-	  csect_exit (thread_p, csect);
 	  goto clear_and_exit;
 	}
     }
@@ -385,6 +383,11 @@ trace_event_log_start (THREAD_ENTRY * thread_p, const char *log_name, const char
   fprintf (log_Fp, "%s - %s\n", time_array, log_name);
 
 clear_and_exit:
+  if (log_Fp == NULL)
+    {
+      csect_exit (thread_p, csect);
+    }
+
   if (log_type == 'E')
     {
       event_Fp = log_Fp;

--- a/src/base/trace_event_log.c
+++ b/src/base/trace_event_log.c
@@ -383,11 +383,6 @@ trace_event_log_start (THREAD_ENTRY * thread_p, const char *log_name, const char
   fprintf (log_Fp, "%s - %s\n", time_array, log_name);
 
 clear_and_exit:
-  if (log_Fp == NULL)
-    {
-      csect_exit (thread_p, csect);
-    }
-
   if (log_type == 'E')
     {
       event_Fp = log_Fp;
@@ -395,6 +390,11 @@ clear_and_exit:
   else
     {
       trace_Fp = log_Fp;
+    }
+
+  if (log_Fp == NULL)
+    {
+      csect_exit (thread_p, csect);
     }
 
   return log_Fp;

--- a/src/base/trace_event_log.c
+++ b/src/base/trace_event_log.c
@@ -348,7 +348,7 @@ trace_event_log_start (THREAD_ENTRY * thread_p, const char *log_name, const char
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
 	  csect_exit (thread_p, csect);
-	  return NULL;
+	  goto clear_and_exit;
 	}
     }
   else if (ftell (log_Fp) > prm_get_integer_value (PRM_ID_ER_LOG_SIZE))
@@ -360,7 +360,7 @@ trace_event_log_start (THREAD_ENTRY * thread_p, const char *log_name, const char
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
 	  csect_exit (thread_p, csect);
-	  return NULL;
+	  goto clear_and_exit;
 	}
     }
 
@@ -384,6 +384,7 @@ trace_event_log_start (THREAD_ENTRY * thread_p, const char *log_name, const char
 
   fprintf (log_Fp, "%s - %s\n", time_array, log_name);
 
+clear_and_exit:
   if (log_type == 'E')
     {
       event_Fp = log_Fp;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-XXXX>

### Purpose

trace_event_log_start에서 file open 중 error 발생 시  event_Fp 혹은 trace_Fp가 잘못된 파일 포인터를 가질 수 있음. 이를 수정해야 함.

### Implementation

file open에서 에러 발생 시 event_Fp, trace_Fp에 NULL을 assign하고 return

### Remarks

11.4 이전 버전에도 백포트해야 함.
