### PR TITLE
[CBRD-26410] revision: backport to 11.4, Improve performance for SQL_TRACE_EXECUTION_PLAN

### DIFF
--- a/src/base/trace_event_log.c
+++ b/src/base/trace_event_log.c
@@ -341,8 +341,7 @@ trace_event_log_start (THREAD_ENTRY * thread_p, const char *log_name, const char
       if (log_Fp == NULL)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
-	  csect_exit (thread_p, csect);
-	  return NULL;
+	  goto clear_and_exit;
 	}
     }
   else if (ftell (log_Fp) > prm_get_integer_value (PRM_ID_ER_LOG_SIZE))
@@ -353,8 +352,7 @@ trace_event_log_start (THREAD_ENTRY * thread_p, const char *log_name, const char
       if (log_Fp == NULL)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
-	  csect_exit (thread_p, csect);
-	  return NULL;
+	  goto clear_and_exit;
 	}
     }
 
@@ -378,6 +376,7 @@ trace_event_log_start (THREAD_ENTRY * thread_p, const char *log_name, const char
 
   fprintf (log_Fp, "%s - %s\n", time_array, log_name);
 
+clear_and_exit:
   if (log_type == 'E')
     {
       event_Fp = log_Fp;
@@ -385,6 +384,11 @@ trace_event_log_start (THREAD_ENTRY * thread_p, const char *log_name, const char
   else
     {
       trace_Fp = log_Fp;
+    }
+
+  if (log_Fp == NULL)
+    {
+      csect_exit (thread_p, csect);
     }
 
   return log_Fp;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26410>

### Purpose

trace_event_log_start에서 file open 중 error 발생 시 event_Fp 혹은 trace_Fp가 잘못된 파일 포인터를 가질 수 있음. 이를 수정해야 함.

### Implementation

backport from 11.5 (develop)

### Remarks

N/A
