### PR TITLE
[CBRD-26718] fix assertion failure in perfmon_add_at_offset()

### DIFF
--- a/src/base/perf_monitor.h
+++ b/src/base/perf_monitor.h
@@ -990,8 +990,7 @@ perfmon_add_at_offset (THREAD_ENTRY * thread_p, int offset, UINT64 amount)
 #if defined (SERVER_MODE) || defined (SA_MODE)
   /* Update local statistic */
   tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
-  assert (tran_index >= 0 && tran_index < pstat_Global.n_trans);
-  if (pstat_Global.is_watching[tran_index])
+  if ((tran_index >= 0 && tran_index < pstat_Global.n_trans) && pstat_Global.is_watching[tran_index])
     {
       if (thread_p != NULL && thread_p->m_uses_px_stats)
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26718

 - prevent assertion in perfmon_add_at_offset() by checking for valid transaction indices.
 - This addresses a race condition where a transaction ends before its interrupted state is processed.
