### PR TITLE
[CBRD-26723] Gate OOS debug logger stderr output behind env var

### DIFF
--- a/src/storage/oos_log.hpp
+++ b/src/storage/oos_log.hpp
@@ -127,16 +127,31 @@ namespace oos_log
     // so stderr is opt-in via the CUBRID_OOS_LOG_STDERR environment variable
     // (intended for local development, not for daemonized cub_server).
     FILE *logfp = oos_log_get_file();
+    bool file_written = false;
     if (logfp != nullptr)
       {
 	std::fputs (header, logfp);
 	std::fputs (body, logfp);
 	std::fputc ('\n', logfp);
 	std::fflush (logfp);
+	file_written = true;
       }
 
+    // Presence-only check: any value including "0"/"false"/"" enables stderr.
+    // To disable, the variable must be unset.  This matches the documented
+    // opt-in contract (PR description) and avoids bike-shedding over truthy
+    // string parsing.
     static const bool stderr_enabled = (std::getenv ("CUBRID_OOS_LOG_STDERR") != nullptr);
-    if (stderr_enabled)
+
+    // Fallback: if the file sink is unavailable (e.g. $CUBRID unset, log dir
+    // unwritable, fopen failed) AND the message is ERROR/WARN, force stderr
+    // so that release-build diagnostics are never silently dropped — this
+    // preserves the contract documented at the bottom of this header
+    // ("oos_error and oos_warn are always active").
+    const bool force_stderr_fallback =
+	    !file_written && static_cast<int> (level) >= static_cast<int> (OosLogLevel::WARN);
+
+    if (stderr_enabled || force_stderr_fallback)
       {
 	std::fputs (header, stderr);
 	std::fputs (body, stderr);

--- a/src/storage/oos_log.hpp
+++ b/src/storage/oos_log.hpp
@@ -25,6 +25,7 @@
 
 #include <cstdio>
 #include <cstdarg>
+#include <cstdlib>
 #include <ctime>
 #include <cstring>
 #include <atomic>
@@ -120,13 +121,11 @@ namespace oos_log
     std::vsnprintf (body, sizeof (body), fmt, args);
     va_end (args);
 
-    // stderr
-    std::fputs (header, stderr);
-    std::fputs (body, stderr);
-    std::fputc ('\n', stderr);
-    std::fflush (stderr);
-
-    // file: $CUBRID/log/oos.log
+    // file: $CUBRID/log/oos.log is always the primary sink.  Writing to an
+    // inherited stderr tty corrupts the controlling terminal (cgdb UI, or a
+    // foreground csql/readline session that has switched the tty to raw mode),
+    // so stderr is opt-in via the CUBRID_OOS_LOG_STDERR environment variable
+    // (intended for local development, not for daemonized cub_server).
     FILE *logfp = oos_log_get_file();
     if (logfp != nullptr)
       {
@@ -134,6 +133,15 @@ namespace oos_log
 	std::fputs (body, logfp);
 	std::fputc ('\n', logfp);
 	std::fflush (logfp);
+      }
+
+    static const bool stderr_enabled = (std::getenv ("CUBRID_OOS_LOG_STDERR") != nullptr);
+    if (stderr_enabled)
+      {
+	std::fputs (header, stderr);
+	std::fputs (body, stderr);
+	std::fputc ('\n', stderr);
+	std::fflush (stderr);
       }
   }
 


### PR DESCRIPTION
https://jira.cubrid.org/browse/CBRD-26723

## Description

`src/storage/oos_log.hpp` 의 `oos_log_internal()` 은 모든 OOS 디버그 로그 라인(`oos_debug` / `oos_trace` / `oos_info` / `oos_warn` / `oos_error`)을 항상 stderr 에 추가로 출력하고 있었다. `$CUBRID/log/oos.log` 파일 싱크와는 별개로 매 라인을 `fputs(..., stderr); fputc('\n', stderr); fflush(stderr);` 로 흘려보냈다.

이로 인해 다음과 같은 상황에서 제어 터미널이 손상되었다.

1. **cgdb 아래에서 cub_server / csql 실행** — ncurses UI 가 stderr OOS 출력으로 덮어쓰여 프레임이 깨졌다.
2. **foreground csql 이 readline/linenoise 로 tty 를 raw 모드로 전환한 같은 세션에서 백그라운드 cub_server 가 OOS 로그를 낼 때** — raw 모드에는 `ONLCR` 변환이 없어 `\n` 이 CR 없이 LF 로만 전송되어 아래처럼 계단식(staircase) 출력이 발생했다.

   ```
   [06:09:04] OOS [DEBUG](oos_insert:1074): arguments: oos_vfid={fileid=576, volid=1}, recdes.length=608
                                                                                                               [06:09:04] OOS [DEBUG](oos_insert:1095): inserted to oid={vol=1,page=578,slot=0}
   ```

3. **Daemonize 된 cub_server** — 상속된 stderr 가 의미 있는 소비자 없이 I/O 만 소모한다.

## Implementation

- `oos_log.hpp` 의 `oos_log_internal()` 을 수정:
  - `$CUBRID/log/oos.log` 파일 싱크는 기존대로 항상 수행 (Single Source of Truth).
  - stderr 싱크는 `CUBRID_OOS_LOG_STDERR` 환경 변수가 set 되어 있을 때만 수행. 값 자체는 검사하지 않고 존재 여부(`std::getenv(...) != nullptr`)만 확인.
  - `stderr_enabled` 는 함수 로컬 static 으로 캐싱되어 `getenv` 가 프로세스 lifetime 동안 한 번만 호출된다 (C++11 magic static — thread-safe).
- `<cstdlib>` 헤더 추가 (`std::getenv` 를 위해).

## Test Plan

OOS 가 트리거되는 DML (record > 2KB AND column > 512B on 16KB pages) 을 `csql -udba -S` 로 실행하며 stderr 출력과 `$CUBRID/log/oos.log` 라인 증가를 두 가지 케이스에서 확인한다.

재현 SQL:

```sql
DROP TABLE IF EXISTS t_oos_stderr;
CREATE TABLE t_oos_stderr (id INT PRIMARY KEY, payload BIT VARYING);
INSERT INTO t_oos_stderr VALUES (1, CAST(REPEAT('AA', 2500) AS BIT VARYING));
INSERT INTO t_oos_stderr VALUES (2, CAST(REPEAT('BB', 2500) AS BIT VARYING));
```

### Reproducer script

리뷰어도 동일하게 검증할 수 있도록 전체 하네스를 첨부한다. `$CUBRID` 가 설정되어 있고 `testdb` 가 존재하며 본 PR 반영된 바이너리가 설치된 상태에서 실행한다 (예: `./test_oos_log_stderr.sh`).

<details>
<summary><code>test_oos_log_stderr.sh</code> (click to expand)</summary>

```bash
#!/usr/bin/env bash
# Verify oos_log stderr gating:
#   - default: no OOS lines on stderr, entries still land in $CUBRID/log/oos.log
#   - CUBRID_OOS_LOG_STDERR=1: OOS lines appear on stderr AND in oos.log
#
# Assumes: testdb already created, $CUBRID env set, csql on PATH, built binaries
# include the updated oos_log.hpp.

set -u

DB=${DB:-testdb}
LOG_FILE="${CUBRID:?CUBRID env var not set}/log/oos.log"

SQL=$(cat <<'EOSQL'
-- OOS triggers when record > DB_PAGESIZE/8 (2KB on 16KB pages) AND column > 512B.
-- REPEAT('AA', N) emits N bytes on disk when cast to BIT VARYING (non-compressed).
DROP TABLE IF EXISTS t_oos_stderr;
CREATE TABLE t_oos_stderr (id INT PRIMARY KEY, payload BIT VARYING);
INSERT INTO t_oos_stderr VALUES (1, CAST(REPEAT('AA', 2500) AS BIT VARYING));
INSERT INTO t_oos_stderr VALUES (2, CAST(REPEAT('BB', 2500) AS BIT VARYING));
SELECT COUNT(*) FROM t_oos_stderr;
EOSQL
)

run_case () {
  local label="$1" expect_stderr="$2"
  local tmp_stderr; tmp_stderr=$(mktemp)
  local log_before=0
  [[ -f "$LOG_FILE" ]] && log_before=$(wc -l < "$LOG_FILE")

  echo "=== $label ==="
  # shellcheck disable=SC2086
  csql -udba -S -c "$SQL" "$DB" 1>/dev/null 2>"$tmp_stderr"
  local rc=$?

  local log_after=0
  [[ -f "$LOG_FILE" ]] && log_after=$(wc -l < "$LOG_FILE")
  local log_delta=$((log_after - log_before))
  local stderr_hits
  stderr_hits=$(grep -c 'OOS \[' "$tmp_stderr" || true)

  echo "  csql exit    : $rc"
  echo "  oos.log new  : $log_delta lines"
  echo "  stderr hits  : $stderr_hits lines"

  local fail=0
  if (( log_delta == 0 )); then
    echo "  FAIL: expected new entries in $LOG_FILE"
    fail=1
  fi
  if [[ "$expect_stderr" == "yes" ]] && (( stderr_hits == 0 )); then
    echo "  FAIL: expected OOS lines on stderr"
    fail=1
  fi
  if [[ "$expect_stderr" == "no" ]] && (( stderr_hits != 0 )); then
    echo "  FAIL: expected clean stderr, got $stderr_hits OOS lines"
    echo "  --- stderr sample ---"
    sed -n '1,5p' "$tmp_stderr"
    fail=1
  fi

  rm -f "$tmp_stderr"
  return $fail
}

overall=0

unset CUBRID_OOS_LOG_STDERR
run_case "default (CUBRID_OOS_LOG_STDERR unset) -> stderr must be clean" no || overall=1

export CUBRID_OOS_LOG_STDERR=1
run_case "opt-in  (CUBRID_OOS_LOG_STDERR=1)    -> stderr must receive OOS" yes || overall=1
unset CUBRID_OOS_LOG_STDERR

if (( overall == 0 )); then
  echo "ALL OK"
else
  echo "FAILED"
fi
exit $overall
```

</details>

### Observed result

로컬 재빌드된 `oos-minor-stderr-fix` install 에 대해 위 스크립트를 실행한 결과:

```
=== default (CUBRID_OOS_LOG_STDERR unset) -> stderr must be clean ===
  csql exit    : 0
  oos.log new  : 4 lines
  stderr hits  : 0 lines
=== opt-in  (CUBRID_OOS_LOG_STDERR=1)    -> stderr must receive OOS ===
  csql exit    : 0
  oos.log new  : 4 lines
  stderr hits  : 4 lines
ALL OK
```

| 케이스 | oos.log 신규 라인 | stderr OOS 라인 | 결과 |
|---|---|---|---|
| 기본 (`CUBRID_OOS_LOG_STDERR` unset) | 4 | **0** | PASS — terminal clean |
| opt-in (`CUBRID_OOS_LOG_STDERR=1`) | 4 | 4 | PASS — stderr 활성 |

## Remarks

- `oos_log.hpp` 는 header-only 라 이 변경으로 `oos_file.cpp` / `heap_file.c` 가 재컴파일된다.
- 기존 stderr 출력을 기대했던 개발자는 `export CUBRID_OOS_LOG_STDERR=1` 로 동일한 동작을 얻을 수 있다.
- 단위 테스트(`unit_tests/oos/`) 는 `test_oos_log.hpp` 기반 자체 logger fixture 를 사용하므로 영향받지 않는다.
- 검토 과정에서 고려했으나 채택하지 않은 대안: stderr 에 `\r\n` 사용(workaround, cgdb 문제 미해결) / `isatty`+`tcgetpgrp` 기반 감지(fragile) / syslog 전환(의존성 부담) / stderr 브랜치 완전 제거(로컬 개발 편의 저하).
