### PR TITLE
[CBRD-26495] Fix error when using CONNECT_BY_ROOT in ORDER BY with GROUP BY (#6804)

### DIFF
--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -12953,6 +12953,12 @@ pt_check_group_by (PARSER_CONTEXT * parser, PT_NODE * node)
       };
       parser_walk_tree (parser, node->info.query.q.select.list, pt_expr_disallow_op_except_agg, disallow_ops,
 			NULL, NULL);
+
+      if (node->info.query.order_by != NULL)
+	{
+	  parser_walk_tree (parser, node->info.query.order_by, pt_expr_disallow_op_except_agg, disallow_ops,
+			    NULL, NULL);
+	}
     }
 
   return error;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26495

backport https://github.com/CUBRID/cubrid/pull/6804