### PR TITLE
[CBRD-26555] [slip] increase qlist_count before closing a list file

### DIFF
--- a/src/method/method_invoke_java.cpp
+++ b/src/method/method_invoke_java.cpp
@@ -481,6 +481,7 @@ namespace cubmethod
 		  QMGR_QUERY_ENTRY *query_entry = qmgr_get_query_entry (&thread_ref, qid, NULL_TRAN_INDEX);
 		  if (query_entry)
 		    {
+		      qfile_update_qlist_count (&thread_ref, query_entry->list_id, 1);
 		      qfile_close_list (&thread_ref, query_entry->list_id);
 		    }
 		  xqmgr_end_query (&thread_ref, qid);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26555>

### Purpose

원 PR (https://github.com/CUBRID/cubrid/pull/6898) 에서 누락된 한줄을 추가합니다. 
누락된 한 줄 때문에 Debug build 에서 assertion fail 이 발생했습니다. 
(query_executor.c, qexec_execute_query(), assert (thread_p->m_qlist_count == qlist_enter_count + 1)
 query execute 후에 qlist_count 가 하나 증가해야 한다는 assertion)

