### PR TITLE
[CBRD-26726] Fix clang build warnings

### DIFF
--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -4516,7 +4516,7 @@ perfmon_er_log_current_stats (THREAD_ENTRY * thread_p)
 
   _er_log_debug (ARG_FILE_LINE, "%s\n", strbuf);
 
-  delete strbuf;
+  delete[] strbuf;
 }
 #endif // SERVER_MODE || SA_MODE
 // *INDENT-ON*

--- a/src/base/tz_compile.c
+++ b/src/base/tz_compile.c
@@ -293,7 +293,7 @@ static const char *tzc_Err_messages[] = {
   /* TZC_ERR_INVALID_PACKAGE */
   "Invalid timezone package! File %s not found in folder %s.",
   /* TZC_ERR_BAD_TZ_LINK */
-  "Invalid link definition (s1: %s, s2: %s). " "Format error or invalid data encountered.",
+  "Invalid link definition (s1: %s, s2: %s). Format error or invalid data encountered.",
   /* TZC_ERR_OUT_OF_MEMORY */
   "Memory exhausted when allocating %d items of type '%s'.",
   /* TZC_ERR_INVALID_VALUE */
@@ -4904,7 +4904,7 @@ tzc_summary (TZ_RAW_DATA * tzd_raw, TZ_DATA * tzd)
 	{
 	  max_len = temp_len;
 	}
-      if (tzd_raw->zones[i].comments != NULL)
+      if (tzd_raw->zones[i].comments[0] != '\0')
 	{
 	  temp_len = strlen (tzd_raw->zones[i].comments);
 	  if (temp_len > max_len2)
@@ -4912,7 +4912,7 @@ tzc_summary (TZ_RAW_DATA * tzd_raw, TZ_DATA * tzd)
 	      max_len2 = temp_len;
 	    }
 	}
-      if (tzd_raw->zones[i].coordinates != NULL)
+      if (tzd_raw->zones[i].coordinates[0] != '\0')
 	{
 	  temp_len = strlen (tzd_raw->zones[i].coordinates);
 	  if (temp_len > max_len3)

--- a/src/base/unicode_support.c
+++ b/src/base/unicode_support.c
@@ -520,11 +520,8 @@ load_unicode_data (const LOCALE_DATA * ld)
 		      break;
 		    }
 
-		  if (str_p != NULL)
-		    {
-		      uc->unicode_mapping_cp_count =
-			string_to_int_array (str_p, uc->unicode_mapping, UNICODE_DECOMP_MAP_CP_COUNT, " ");
-		    }
+		  uc->unicode_mapping_cp_count =
+		    string_to_int_array (str_p, uc->unicode_mapping, UNICODE_DECOMP_MAP_CP_COUNT, " ");
 		  break;
 		}
 	      while (0);

--- a/src/broker/cas_network.c
+++ b/src/broker/cas_network.c
@@ -222,10 +222,6 @@ net_connect_proxy (void)
 
   ut_get_proxy_port_name (port_name, shm_appl->broker_name, as_info->proxy_id, BROKER_PATH_MAX);
 
-  if (port_name == NULL)
-    {
-      return (INVALID_SOCKET);
-    }
   /* FOR DEBUG */
   SHARD_ERR ("<CAS> connect to unixdoamin:[%s].\n", port_name);
 

--- a/src/broker/cas_sql_log2.c
+++ b/src/broker/cas_sql_log2.c
@@ -80,7 +80,7 @@ sql_log2_get_filename ()
 #if defined(WINDOWS)
   return "";
 #else
-  return (sql_log2_file == NULL) ? (char *) "" : (char *) sql_log2_file;
+  return (sql_log2_file[0] == '\0') ? (char *) "" : (char *) sql_log2_file;
 #endif
 }
 

--- a/src/broker/shard_shm.c
+++ b/src/broker/shard_shm.c
@@ -733,7 +733,7 @@ shard_shm_set_as_client_info_with_db_param (T_PROXY_INFO * proxy_info_p, T_SHM_A
     }
 
   memcpy (&as_info_p->cas_clt_ip[0], &client_info_p->client_ip, sizeof (as_info_p->cas_clt_ip));
-  if (client_info_p->driver_info)
+  if (client_info_p->driver_info[0] != '\0')
     {
       as_info_p->clt_version = CAS_MAKE_PROTO_VER (client_info_p->driver_info);
       memcpy (as_info_p->driver_info, client_info_p->driver_info, SRV_CON_CLIENT_INFO_SIZE);

--- a/src/compat/db_json.cpp
+++ b/src/compat/db_json.cpp
@@ -1233,7 +1233,7 @@ db_json_extract_document_from_path (const JSON_DOC *document, const std::vector<
   std::vector<std::vector<const JSON_VALUE *>> produced_array (json_paths.size ());
   for (size_t i = 0; i < json_paths.size (); ++i)
     {
-      produced_array[i] = std::move (json_paths[i].extract (*document));
+      produced_array[i] = json_paths[i].extract (*document);
     }
 
   if (array_result)

--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -6290,7 +6290,7 @@ filter_user_classes (DB_OBJLIST ** class_list, const char *user)
       name = db_get_class_name (cl->op);
       sm_qualifier_name (name, owner_name, DB_MAX_IDENTIFIER_LENGTH);
 
-      if (owner_name != NULL && strcmp (owner_name, user) == 0)
+      if (strcmp (owner_name, user) == 0)
 	{
 	  prev = cl;
 	}

--- a/src/executables/util_cs.c
+++ b/src/executables/util_cs.c
@@ -614,7 +614,7 @@ util_get_class_oids_and_index_btid (dynamic_array * darray, const char *index_na
 	}
 
       OID_SET_NULL (&oids[i]);
-      if (table == NULL || table[0] == '\0')
+      if (table[0] == '\0')
 	{
 	  continue;
 	}

--- a/src/loaddb/load_scanner.hpp
+++ b/src/loaddb/load_scanner.hpp
@@ -58,6 +58,7 @@ namespace cubload
        * The main scanner function.
        * See load_lexer.l file for method declaration
        */
+      using yyFlexLexer::yylex;
       virtual int yylex (parser::semantic_type *yylval, parser::location_type *yylloc);
 
       /*

--- a/src/method/method_callback.cpp
+++ b/src/method/method_callback.cpp
@@ -917,7 +917,7 @@ exit:
 	const char *c_attr_name = db_attribute_name (attr);
 
 	std::string attr_name_string (c_attr_name? c_attr_name : "");
-	std::string class_name_string (realname? realname : "");
+	std::string class_name_string (realname);
 
 	std::string default_value_string = get_column_default_as_string (attr);
 

--- a/src/optimizer/plan_generation.c
+++ b/src/optimizer/plan_generation.c
@@ -4408,7 +4408,7 @@ qo_check_terms_for_multiple_range_opt (QO_PLAN * plan, int first_sort_col_idx, b
 	{
 	  for (j = 0; j < index_entryp->nsegs; j++)
 	    {
-	      if ((index_entryp->seg_idxs[j] == QO_SEG_IDX (termp->index_seg[i])))
+	      if (index_entryp->seg_idxs[j] == QO_SEG_IDX (termp->index_seg[i]))
 		{
 		  pos = j;
 		  break;
@@ -4474,7 +4474,7 @@ qo_check_terms_for_multiple_range_opt (QO_PLAN * plan, int first_sort_col_idx, b
 	{
 	  for (j = 0; j < index_entryp->nsegs; j++)
 	    {
-	      if ((index_entryp->seg_idxs[j] == QO_SEG_IDX (termp->index_seg[i])))
+	      if (index_entryp->seg_idxs[j] == QO_SEG_IDX (termp->index_seg[i]))
 		{
 		  pos = j;
 		  break;

--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -1698,7 +1698,7 @@ qo_add_final_segment (PARSER_CONTEXT * parser, PT_NODE * tree, void *arg, int *c
       (void) set_seg_node (tree, env, &env->final_segs);
       *continue_walk = PT_LIST_WALK;
     }
-  else if ((tree->node_type == PT_DOT_))
+  else if (tree->node_type == PT_DOT_)
     {
       (void) set_seg_node (tree->info.dot.arg2, env, &env->final_segs);
       *continue_walk = PT_LIST_WALK;

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -426,7 +426,7 @@ static void pt_value_set_collation_info (PARSER_CONTEXT *parser,
 					 PT_NODE *node,
 					 PT_NODE *coll_node);
 static void pt_value_set_monetary (PARSER_CONTEXT *parser, PT_NODE *node,
-                   const char *str, const char *txt, DB_CURRENCY type);
+                   const char *str, const char *txt, PT_CURRENCY type);
 static PT_NODE * pt_create_paren_expr_list (PT_NODE * exp);
 static PT_MISC_TYPE parser_attr_type;
 
@@ -25365,7 +25365,7 @@ pt_value_set_collation_info (PARSER_CONTEXT *parser, PT_NODE *node,
 
 static void
 pt_value_set_monetary (PARSER_CONTEXT *parser, PT_NODE *node,
-                   const char *currency_str, const char *value, DB_CURRENCY type)
+                   const char *currency_str, const char *value, PT_CURRENCY type)
 {
   double dval;
 

--- a/src/parser/parse_dbi.c
+++ b/src/parser/parse_dbi.c
@@ -519,7 +519,7 @@ pt_sm_attribute_default_value_to_node (PARSER_CONTEXT * parser, const SM_ATTRIBU
   const SM_DEFAULT_VALUE *default_value;
   PT_NODE *data_type;
 
-  if (sm_attr == NULL || &sm_attr->default_value == NULL)
+  if (sm_attr == NULL)
     {
       return NULL;
     }

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -14453,7 +14453,7 @@ pt_print_select (PARSER_CONTEXT * parser, PT_NODE * p)
       parser->custom_print |= PT_PRINT_ALIAS;
 
       is_first_list = true;
-      for (temp = temp; temp; temp = temp->next)
+      for (; temp; temp = temp->next)
 	{
 	  if (!is_first_list)
 	    {

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -6590,7 +6590,6 @@ mq_push_paths (PARSER_CONTEXT * parser, PT_NODE * statement, void *void_arg, int
       break;
 
     default:
-      statement = statement;
       break;
     }
 
@@ -6801,7 +6800,6 @@ mq_translate_local (PARSER_CONTEXT * parser, PT_NODE * statement, void *void_arg
       break;
 
     default:
-      statement = statement;
       break;
     }
 

--- a/src/sp/pl_executor.cpp
+++ b/src/sp/pl_executor.cpp
@@ -630,12 +630,12 @@ exit:
     cubmem::block blk;
     if (parameter_info)
       {
-	blk = std::move (pack_data_block (METHOD_RESPONSE_SUCCESS, *parameter_info));
+	blk = pack_data_block (METHOD_RESPONSE_SUCCESS, *parameter_info);
       }
     else
       {
-	blk = std::move (pack_data_block (METHOD_RESPONSE_ERROR, ER_FAILED, std::string ("unknown error"),
-					  ARG_FILE_LINE));
+	blk = pack_data_block (METHOD_RESPONSE_ERROR, ER_FAILED, std::string ("unknown error"),
+			       ARG_FILE_LINE);
       }
 
     if (blk.is_valid ())
@@ -757,8 +757,8 @@ exit:
     query_cursor *cursor = m_stack->get_cursor (qid);
     if (cursor == nullptr)
       {
-	cubmem::block b = std::move (pack_data_block (METHOD_RESPONSE_ERROR, ER_SP_INVALID_CURSOR,
-				     std::string ("cursor closed"), ARG_FILE_LINE));
+	cubmem::block b = pack_data_block (METHOD_RESPONSE_ERROR, ER_SP_INVALID_CURSOR,
+					   std::string ("cursor closed"), ARG_FILE_LINE);
 	error = m_stack->send_data_to_java (b);
 	return error;
       }
@@ -813,12 +813,12 @@ exit:
     cubmem::block blk;
     if (s_code != S_ERROR)
       {
-	blk = std::move (pack_data_block (METHOD_RESPONSE_SUCCESS, info));
+	blk = pack_data_block (METHOD_RESPONSE_SUCCESS, info);
       }
     else
       {
-	blk = std::move (pack_data_block (METHOD_RESPONSE_ERROR, ER_SP_INVALID_CURSOR,
-					  std::string ("cursor closed"), ARG_FILE_LINE));
+	blk = pack_data_block (METHOD_RESPONSE_ERROR, ER_SP_INVALID_CURSOR,
+			       std::string ("cursor closed"), ARG_FILE_LINE);
       }
 
     error = m_stack->send_data_to_java (blk);
@@ -1022,11 +1022,11 @@ exit:
 	dbvalue_java java_packer;
 	java_packer.value = &res;
 
-	blk = std::move (pack_data_block (error, java_packer));
+	blk = pack_data_block (error, java_packer);
       }
     else
       {
-	blk = std::move (pack_data_block (error));
+	blk = pack_data_block (error);
       }
 
     db_value_clear (&res);
@@ -1065,7 +1065,7 @@ exit:
 	  }
       }
 
-    cubmem::block blk = std::move (pack_data_block (METHOD_RESPONSE_SUCCESS));
+    cubmem::block blk = pack_data_block (METHOD_RESPONSE_SUCCESS);
     if (blk.is_valid ())
       {
 	m_stack->send_data_to_java (blk);

--- a/src/sp/pl_session.cpp
+++ b/src/sp/pl_session.cpp
@@ -226,7 +226,7 @@ namespace cubpl
 	connection_pool *pool = get_connection_pool ();
 	if (pool)
 	  {
-	    m_session_connections.emplace_back (std::move (pool->claim ()));
+	    m_session_connections.emplace_back (pool->claim ());
 	  }
       }
 

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -8644,7 +8644,7 @@ locator_update_index (THREAD_ENTRY * thread_p, RECDES * new_recdes, RECDES * old
 	      else
 		{
 		  /* in MVCC - update index key means insert index key */
-		  if ((do_insert_only == true))
+		  if (do_insert_only == true)
 		    {
 		      if (index->type == BTREE_FOREIGN_KEY)
 			{

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -7434,7 +7434,7 @@ check_copied_log_volume_info_end:
 	    {
 	      lrec = LOG_GET_LOG_RECORD_HEADER (logpage, &lsa);
 
-	      printf ("offset:%04ld (tid:%d bck p:%lld,o:%ld frw p:%lld,o:%ld type:%d)\n", lsa.offset, lrec->trid,
+	      printf ("offset:%04d (tid:%d bck p:%lld,o:%d frw p:%lld,o:%d type:%d)\n", lsa.offset, lrec->trid,
 		      (long long int) lrec->back_lsa.pageid, lrec->back_lsa.offset,
 		      (long long int) lrec->forw_lsa.pageid, lrec->forw_lsa.offset, lrec->type);
 	      LSA_COPY (&lsa, &lrec->forw_lsa);


### PR DESCRIPTION
https://jira.cubrid.org/browse/CBRD-26726

## Description

`debug_clang` 프리셋으로 빌드 시 출력되는 **1,590 건의 clang 경고** 중 실제 버그/UB 후보에 해당하는 카테고리를 **코드 직접 수정으로 제거**한다. `-Wno-*` 억제 플래그는 사용하지 않는다.

`-Wunknown-warning-option` (GCC 전용 `-Wclobbered` 등으로 인한 경고) 은 비교적 최근에 추가된 경고로, **본 PR 의 범위가 아니며 [CBRD-26725](http://jira.cubrid.org/browse/CBRD-26725) 에서 선행 처리**될 예정이다.

3rd-party 파일 (`src/heaplayers/malloc_2_8_3.c`, `src/base/mprec.c`) 및 생성 파일 (`csql_grammar.c`, `csql_lexer.c`) 은 수정 대상에서 제외한다 (원본 `.y` 는 수정).

## Implementation

**경고 감소 결과: 1,590 → 1,462 (128 건 제거, 빌드 성공)**

아래 카테고리를 **완전히 제거 (0 건)** 했다:

| 카테고리 | 제거 수 | 수정 방식 |
|---------|:------:|-----------|
| `-Wmismatched-new-delete` | 2 | `delete` → `delete[]` (`perf_monitor.c`) — UB 수정 |
| `-Wself-assign` | 6 | `x = x;` no-op 제거 (`view_transform.c`, `parse_tree_cl.c`) |
| `-Wpointer-bool-conversion` | 13 | `if (arr)` → `arr[0] != '\0'` 또는 죽은 체크 제거 |
| `-Wtautological-pointer-compare` | 12 | 배열 vs `NULL` 비교 제거 또는 `[0]` 검사로 교체 |
| `-Wenum-conversion` | 50 | `pt_value_set_monetary` 파라미터를 `DB_CURRENCY` → `PT_CURRENCY` 로 변경 (`csql_grammar.y`) |
| `-Wpessimizing-move` | 21 | rvalue 에 적용된 불필요한 `std::move` 제거 (`pl_executor.cpp`, `pl_session.cpp`, `db_json.cpp`) |
| `-Wparentheses-equality` | 8 | `if ((x == y))` → `if (x == y)` |
| `-Woverloaded-virtual` | 12 | `using yyFlexLexer::yylex;` 추가 (`load_scanner.hpp`) |
| `-Wformat` | 3 | `%ld` → `%d` (`PGLENGTH` 는 `INT16`, `log_applier.c`) |
| `-Wstring-concatenation` | 1 | 인접 string literal 병합 (`tz_compile.c`) |

### 주요 수정 파일 (21 개)

- `src/base/` — `perf_monitor.c`, `tz_compile.c`, `unicode_support.c`
- `src/broker/` — `cas_network.c`, `cas_sql_log2.c`, `shard_shm.c`
- `src/compat/` — `db_json.cpp`
- `src/executables/` — `unload_schema.c`, `util_cs.c`
- `src/loaddb/` — `load_scanner.hpp`
- `src/method/` — `method_callback.cpp`
- `src/optimizer/` — `plan_generation.c`, `query_graph.c`
- `src/parser/` — `csql_grammar.y`, `parse_dbi.c`, `parse_tree_cl.c`, `view_transform.c`
- `src/sp/` — `pl_executor.cpp`, `pl_session.cpp`
- `src/transaction/` — `locator_sr.c`, `log_applier.c`

## Test Plan

- [x] `cmake --build --preset debug_clang --clean-first` 빌드 성공
- [x] 코드 스타일 체크 통과 (pre-commit hook)
- [ ] CI 통과 (Jenkins, CircleCI SQL/shell tests)

## Remarks

### 남은 경고 (follow-up 후보)

본 PR 이후에도 1,462 건의 경고가 남아 있다. 주요 항목:

| 카테고리 | Count | 비고 |
|----------|:-----:|------|
| `-Wgnu-null-pointer-arithmetic` | 120 | 3rd-party `malloc_2_8_3.c` 전용 |
| `-Wmissing-field-initializers` | 45 | cosmetic 대량 |
| `-Wimplicit-const-int-float-conversion` | 42 | 정밀도 손실 — 개별 검토 필요 |
| `-Wsign-compare` | 24 | `size_t` vs `int` |
| `-Wtautological-constant-out-of-range-compare` | 23 | enum vs `-1` 비교 |
| `-Wtautological-bitwise-compare` | 8 | `(x \| NONZERO)` 류 — 의심 버그 |
| `-Wvarargs` | 4 | `QO_PARAM` (enum) → `va_start`. UB 이나 signature 변경 필요 (callers 광범위) |
| `-Wvla-cxx-extension` | 3 | C VLA 를 C++ 로 빌드 |
| `-Wlogical-not-parentheses` | 3 | 3rd-party `mprec.c` 전용 |
| 기타 | ~10 | `-Wdeprecated-copy-with-user-provided-copy`, `-Wconstant-conversion`, `-Wmismatched-tags` 등 |

### 관련 이슈
- [CBRD-26725](http://jira.cubrid.org/browse/CBRD-26725) — `-Wunknown-warning-option` 선행 처리 (GCC 전용 `-Wclobbered` 등)