### PR TITLE
[CBRD-26721] Show error message when thread creation fails in worker pool.

### DIFF
--- a/src/communication/network_cl.c
+++ b/src/communication/network_cl.c
@@ -152,7 +152,6 @@ set_server_error (int error)
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, server_error, 1, "");
 	  return server_error;
 	case ER_THREAD_STACK:
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, server_error, 1, 0);
 	  return server_error;
 	}
       /* FALLTHRU */

--- a/src/communication/network_cl.c
+++ b/src/communication/network_cl.c
@@ -151,6 +151,9 @@ set_server_error (int error)
 	case ER_AU_DBA_ONLY:
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, server_error, 1, "");
 	  return server_error;
+	case ER_THREAD_STACK:
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, server_error, 1, 0);
+	  return server_error;
 	}
       /* FALLTHRU */
     default:

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1349,7 +1349,7 @@ tran_compensation (cubthread::task<cubthread::entry> *ptr)
     }
   else
     {
-      css_send_request_error_and_abort (conn, rid, ER_THREAD_STACK);
+      (void) css_send_request_error_and_abort (conn, rid, ER_THREAD_STACK);
     }
 
   ptr->retire ();
@@ -1362,7 +1362,8 @@ css_compensation (cubthread::task<cubthread::entry> *ptr)
 
   er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_THREAD_STACK, 1, prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS));
 
-  (*css_Connection_error_handler) (&cubthread::get_entry (), &task_p->get_conn ());
+  css_end_server_request (&task_p->get_conn ());
+  css_free_conn (&task_p->get_conn ());
 
   task_p->retire ();
 }
@@ -1780,16 +1781,22 @@ css_send_request_error_and_abort (CSS_CONN_ENTRY * conn, unsigned short rid, int
 {
   OR_ALIGNED_BUF (1024) a_buffer;
   char *buffer = OR_ALIGNED_BUF_START (a_buffer);
+  unsigned int eid;
+  char *area;
   int length = 1024;
+  int err;
 
-  char *area = er_get_area_error (buffer, &length);
-  unsigned int eid = css_return_eid_from_conn (conn, rid);
-
+  area = er_get_area_error (buffer, &length);
+  eid = css_return_eid_from_conn (conn, rid);
   if (area != NULL)
     {
-      conn.db_error = errid;
-      (void) css_send_error_to_client (conn, eid, area, length);
-      conn.db_error = 0;
+      conn->db_error = errid;
+      err = css_send_error_to_client (conn, eid, area, length);
+      if (err != NO_ERRORS)
+	{
+	  return err;
+	}
+      conn->db_error = 0;
     }
 
   return css_send_abort_to_client (conn, eid);

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1374,8 +1374,9 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_THREAD_STACK, 1, prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS));
 
       task_p->get_conn ().start_request ();
-      css_send_request_error_and_abort (task_p->get_conn (), 0, ER_THREAD_STACK);
-      css_shutdown_conn (&task_p->get_conn ());
+      css_send_request_error_and_abort (task_p->get_conn (), 1, ER_THREAD_STACK);
+
+      css_end_server_request (&task_p->get_conn ());
 
       task_p->retire ();
   };
@@ -1387,7 +1388,7 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
 
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_THREAD_STACK, 1, prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS));
 
-      css_shutdown_conn (&task_p->get_conn ());
+      (*css_Connection_error_handler)(&cubthread::get_entry (), &task_p->get_conn ());
 
       task_p->retire ();
   };

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -32,6 +32,7 @@
 #include "thread_entry.hpp"
 #include "thread_manager.hpp"
 #include "thread_worker_pool.hpp"
+#include "network_interface_sr.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -149,6 +150,11 @@ public:
 
   void execute (context_type &thread_ref) override final;
 
+  CSS_CONN_ENTRY &get_conn ()
+    {
+      return m_conn;
+    }
+
   // retire not overwritten; task is automatically deleted
 
 private:
@@ -197,6 +203,11 @@ public:
   }
 
   void execute (context_type & thread_ref) override final;
+
+  CSS_CONN_ENTRY &get_conn ()
+    {
+      return m_conn;
+    }
 
   // retire not overwritten; task is automatically deleted
 
@@ -1297,6 +1308,26 @@ css_start_shutdown_server ()
   css_Server_shutdown_inited = true;
 }
 
+static void
+css_send_request_error_and_abort (CSS_CONN_ENTRY & conn, unsigned short rid, int errid)
+{
+  OR_ALIGNED_BUF (1024) a_buffer;
+  char *buffer = OR_ALIGNED_BUF_START (a_buffer);
+  int length = 1024;
+
+  char *area = er_get_area_error (buffer, &length);
+  unsigned int eid = css_return_eid_from_conn (&conn, rid);
+
+  if (area != NULL)
+    {
+      conn.db_error = errid;
+      (void) css_send_error_to_client (&conn, eid, area, length);
+      conn.db_error = 0;
+    }
+
+  (void) css_send_abort_to_client (&conn, eid);
+}
+
 /*
  * css_init() -
  *   return:
@@ -1334,6 +1365,30 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
 #define MAX_TASK_COUNT css_get_max_task_count ()
 #define MAX_CONNECTIONS css_get_max_connections ()
 
+  // *INDENT-OFF*
+  auto tran_compensation = [](cubthread::task<cubthread::entry> *ptr) {
+      css_server_task *task_p = static_cast<css_server_task *> (ptr);
+
+      printf ("css_server_task: fd: %d, client_id: %d\n", task_p->get_conn ().fd, task_p->get_conn ().client_id);
+
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_CLIENTS_EXCEEDED, 1, NUM_NORMAL_TRANS);
+      css_send_request_error_and_abort (task_p->get_conn (), task_p->get_conn ().request_id, ER_CSS_CLIENTS_EXCEEDED);
+
+      task_p->retire ();
+  };
+
+  auto css_compensation = [](cubthread::task<cubthread::entry> *ptr) {
+      css_connection_task *task_p = static_cast<css_connection_task *> (ptr);
+
+      printf ("css_connection_task: fd: %d, client_id: %d\n", task_p->get_conn ().fd, task_p->get_conn ().client_id);
+
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_CLIENTS_EXCEEDED, 1, NUM_NORMAL_TRANS);
+      css_send_request_error_and_abort (task_p->get_conn (), task_p->get_conn ().request_id, ER_CSS_CLIENTS_EXCEEDED);
+
+      task_p->retire ();
+  };
+  // *INDENT-ON*
+
   // create request worker pool
   css_Server_request_worker_pool =
     cubthread::get_manager ()->create_worker_pool (MAX_WORKERS, MAX_TASK_COUNT, "transaction workers", NULL,
@@ -1341,7 +1396,8 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
 						   cubthread::is_logging_configured
 						   (cubthread::LOG_WORKER_POOL_TRAN_WORKERS),
 						   css_get_server_request_thread_pooling_configuration (),
-						   css_get_server_request_thread_timeout_configuration ());
+						   css_get_server_request_thread_timeout_configuration (),
+						   tran_compensation);
   if (css_Server_request_worker_pool == NULL)
     {
       assert (false);
@@ -1356,7 +1412,8 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
 						   cubthread::is_logging_configured
 						   (cubthread::LOG_WORKER_POOL_CONNECTIONS),
 						   css_get_connection_thread_pooling_configuration (),
-						   css_get_connection_thread_timeout_configuration ());
+						   css_get_connection_thread_timeout_configuration (),
+						   css_compensation);
   if (css_Connection_worker_pool == NULL)
     {
       assert (false);

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1322,6 +1322,8 @@ tran_compensation (cubthread::task<cubthread::entry> *ptr)
   int request, size;
   int rc;
 
+  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_THREAD_STACK, 1, prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS));
+
   if (dynamic_cast<css_server_task *> (ptr))
     {
       css_server_task *task_p = static_cast<css_server_task *> (ptr);
@@ -1329,30 +1331,33 @@ tran_compensation (cubthread::task<cubthread::entry> *ptr)
 
       /* pending_request_count was increased at push_task. offset that. */
       task_p->get_conn ().start_request ();
+
+      if (conn)
+	{
+	  rc = css_receive_request (conn, &rid, &request, &size);
+	  if (rc != NO_ERRORS)
+	    {
+	      /* something was wrong */
+	      assert (false);
+	      /* shutdown immediately */
+	      css_end_server_request (conn);
+	    }
+	  else
+	    {
+	      /* this can block the request for new connection to be connected */
+	      css_send_request_error_and_abort (conn, rid, ER_THREAD_STACK);
+	    }
+	}
     }
   else
     {
       assert (dynamic_cast<css_server_external_task *> (ptr));
       css_server_external_task *task_p = static_cast<css_server_external_task *> (ptr);
       conn = task_p->get_conn ();
-    }
 
-  if (conn)
-    {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_THREAD_STACK, 1, prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS));
-
-      rc = css_receive_request (conn, &rid, &request, &size);
-      if (rc != NO_ERRORS)
+      if (conn)
 	{
-	  /* something was wrong */
-	  assert (false);
-	  /* shutdown immediately */
 	  css_end_server_request (conn);
-	}
-      else
-	{
-	  /* this can block the request for new connection to be connected */
-	  css_send_request_error_and_abort (conn, rid, ER_THREAD_STACK);
 	}
     }
 

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -183,6 +183,11 @@ public:
 
   void execute (context_type &thread_ref) override final;
 
+  CSS_CONN_ENTRY *get_conn ()
+    {
+      return m_conn;
+    }
+
   // retire not overwritten; task is automatically deleted
 
 private:
@@ -1328,6 +1333,58 @@ css_send_request_error_and_abort (CSS_CONN_ENTRY & conn, unsigned short rid, int
   (void) css_send_abort_to_client (&conn, eid);
 }
 
+// *INDENT-OFF*
+static void
+tran_compensation (cubthread::task<cubthread::entry> *ptr)
+{
+  if (dynamic_cast<css_server_task *> (ptr))
+    {
+      css_server_task *task_p = static_cast<css_server_task *> (ptr);
+
+      printf ("css_server_task: fd: %d, client_id: %d\n", task_p->get_conn ().fd, task_p->get_conn ().client_id);
+
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_THREAD_STACK, 1, prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS));
+
+      task_p->get_conn ().start_request ();
+      css_send_request_error_and_abort (task_p->get_conn (), 1, ER_THREAD_STACK);
+
+      css_end_server_request (&task_p->get_conn ());
+
+      task_p->retire ();
+    }
+  else
+    {
+      assert (dynamic_cast<css_server_external_task *> (ptr));
+
+      css_server_external_task *task_p = static_cast<css_server_external_task *> (ptr);
+
+      printf ("css_server_task: fd: %d, client_id: %d\n", task_p->get_conn ()->fd, task_p->get_conn ()->client_id);
+
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_THREAD_STACK, 1, prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS));
+
+      css_send_request_error_and_abort (*task_p->get_conn (), 1, ER_THREAD_STACK);
+
+      css_end_server_request (task_p->get_conn ());
+
+      task_p->retire ();
+    }
+}
+
+static void
+css_compensation (cubthread::task<cubthread::entry> *ptr)
+{
+  css_connection_task *task_p = static_cast<css_connection_task *> (ptr);
+
+  printf ("css_connection_task: fd: %d, client_id: %d\n", task_p->get_conn ().fd, task_p->get_conn ().client_id);
+
+  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_THREAD_STACK, 1, prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS));
+
+  (*css_Connection_error_handler)(&cubthread::get_entry (), &task_p->get_conn ());
+
+  task_p->retire ();
+}
+// *INDENT-ON*
+
 /*
  * css_init() -
  *   return:
@@ -1364,35 +1421,6 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
 #define MAX_WORKERS css_get_max_workers ()
 #define MAX_TASK_COUNT css_get_max_task_count ()
 #define MAX_CONNECTIONS css_get_max_connections ()
-
-  // *INDENT-OFF*
-  auto tran_compensation = [](cubthread::task<cubthread::entry> *ptr) {
-      css_server_task *task_p = static_cast<css_server_task *> (ptr);
-
-      printf ("css_server_task: fd: %d, client_id: %d\n", task_p->get_conn ().fd, task_p->get_conn ().client_id);
-
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_THREAD_STACK, 1, prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS));
-
-      task_p->get_conn ().start_request ();
-      css_send_request_error_and_abort (task_p->get_conn (), 1, ER_THREAD_STACK);
-
-      css_end_server_request (&task_p->get_conn ());
-
-      task_p->retire ();
-  };
-
-  auto css_compensation = [](cubthread::task<cubthread::entry> *ptr) {
-      css_connection_task *task_p = static_cast<css_connection_task *> (ptr);
-
-      printf ("css_connection_task: fd: %d, client_id: %d\n", task_p->get_conn ().fd, task_p->get_conn ().client_id);
-
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_THREAD_STACK, 1, prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS));
-
-      (*css_Connection_error_handler)(&cubthread::get_entry (), &task_p->get_conn ());
-
-      task_p->retire ();
-  };
-  // *INDENT-ON*
 
   // create request worker pool
   css_Server_request_worker_pool =
@@ -3341,7 +3369,7 @@ css_get_connection_thread_timeout_configuration (void)
 //  return
 //    cubthread::wait_seconds (std::chrono::seconds (prm_get_integer_value (PRM_ID_THREAD_CONNECTION_TIMEOUT_SECONDS)));
   return
-    cubthread::wait_seconds (std::chrono::seconds (2000));
+    cubthread::wait_seconds (std::chrono::seconds (20));
 }
 
 static bool
@@ -3361,7 +3389,7 @@ css_get_server_request_thread_timeout_configuration (void)
 {
   // todo: need infinite timeout
   //return cubthread::wait_seconds (std::chrono::seconds (prm_get_integer_value (PRM_ID_THREAD_WORKER_TIMEOUT_SECONDS)));
-  return cubthread::wait_seconds (std::chrono::seconds (20));
+  return cubthread::wait_seconds (std::chrono::seconds (2000));
 }
 
 static void

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1337,19 +1337,23 @@ tran_compensation (cubthread::task<cubthread::entry> *ptr)
       conn = task_p->get_conn ();
     }
 
-  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_THREAD_STACK, 1, prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS));
+  if (conn)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_THREAD_STACK, 1, prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS));
 
-  rc = css_receive_request (conn, &rid, &request, &size);
-  if (rc != NO_ERRORS)
-    {
-      /* something was wrong */
-      assert (false);
-      /* shutdown immediately */
-      css_end_server_request (conn);
-    }
-  else
-    {
-      (void) css_send_request_error_and_abort (conn, rid, ER_THREAD_STACK);
+      rc = css_receive_request (conn, &rid, &request, &size);
+      if (rc != NO_ERRORS)
+	{
+	  /* something was wrong */
+	  assert (false);
+	  /* shutdown immediately */
+	  css_end_server_request (conn);
+	}
+      else
+	{
+	  /* this can block the request for new connection to be connected */
+	  css_send_request_error_and_abort (conn, rid, ER_THREAD_STACK);
+	}
     }
 
   ptr->retire ();
@@ -1776,7 +1780,7 @@ css_send_abort_to_client (CSS_CONN_ENTRY * conn, unsigned int eid)
  *   rid(in): request id
  *   errid(in): error code
  */
-unsigned int
+void
 css_send_request_error_and_abort (CSS_CONN_ENTRY * conn, unsigned short rid, int errid)
 {
   OR_ALIGNED_BUF (1024) a_buffer;
@@ -1784,22 +1788,17 @@ css_send_request_error_and_abort (CSS_CONN_ENTRY * conn, unsigned short rid, int
   unsigned int eid;
   char *area;
   int length = 1024;
-  int err;
 
   area = er_get_area_error (buffer, &length);
   eid = css_return_eid_from_conn (conn, rid);
   if (area != NULL)
     {
       conn->db_error = errid;
-      err = css_send_error_to_client (conn, eid, area, length);
-      if (err != NO_ERRORS)
-	{
-	  return err;
-	}
+      (void) css_send_error_to_client (conn, eid, area, length);
       conn->db_error = 0;
     }
 
-  return css_send_abort_to_client (conn, eid);
+  (void) css_send_abort_to_client (conn, eid);
 }
 
 /*
@@ -3383,10 +3382,8 @@ static cubthread::wait_seconds
 css_get_connection_thread_timeout_configuration (void)
 {
   // todo: need infinite timeout
-//  return
-//    cubthread::wait_seconds (std::chrono::seconds (prm_get_integer_value (PRM_ID_THREAD_CONNECTION_TIMEOUT_SECONDS)));
   return
-    cubthread::wait_seconds (std::chrono::seconds (20));
+    cubthread::wait_seconds (std::chrono::seconds (prm_get_integer_value (PRM_ID_THREAD_CONNECTION_TIMEOUT_SECONDS)));
 }
 
 static bool
@@ -3405,8 +3402,7 @@ static cubthread::wait_seconds
 css_get_server_request_thread_timeout_configuration (void)
 {
   // todo: need infinite timeout
-  //return cubthread::wait_seconds (std::chrono::seconds (prm_get_integer_value (PRM_ID_THREAD_WORKER_TIMEOUT_SECONDS)));
-  return cubthread::wait_seconds (std::chrono::seconds (2000));
+  return cubthread::wait_seconds (std::chrono::seconds (prm_get_integer_value (PRM_ID_THREAD_WORKER_TIMEOUT_SECONDS)));
 }
 
 static void

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1313,61 +1313,46 @@ css_start_shutdown_server ()
   css_Server_shutdown_inited = true;
 }
 
-static void
-css_send_request_error_and_abort (CSS_CONN_ENTRY & conn, unsigned short rid, int errid)
-{
-  OR_ALIGNED_BUF (1024) a_buffer;
-  char *buffer = OR_ALIGNED_BUF_START (a_buffer);
-  int length = 1024;
-
-  char *area = er_get_area_error (buffer, &length);
-  unsigned int eid = css_return_eid_from_conn (&conn, rid);
-
-  if (area != NULL)
-    {
-      conn.db_error = errid;
-      (void) css_send_error_to_client (&conn, eid, area, length);
-      conn.db_error = 0;
-    }
-
-  (void) css_send_abort_to_client (&conn, eid);
-}
-
 // *INDENT-OFF*
 static void
 tran_compensation (cubthread::task<cubthread::entry> *ptr)
 {
+  CSS_CONN_ENTRY *conn;
+  unsigned short rid;
+  int request, size;
+  int rc;
+
   if (dynamic_cast<css_server_task *> (ptr))
     {
       css_server_task *task_p = static_cast<css_server_task *> (ptr);
+      conn = &task_p->get_conn ();
 
-      printf ("css_server_task: fd: %d, client_id: %d\n", task_p->get_conn ().fd, task_p->get_conn ().client_id);
-
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_THREAD_STACK, 1, prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS));
-
+      /* pending_request_count was increased at push_task. offset that. */
       task_p->get_conn ().start_request ();
-      css_send_request_error_and_abort (task_p->get_conn (), 1, ER_THREAD_STACK);
-
-      css_end_server_request (&task_p->get_conn ());
-
-      task_p->retire ();
     }
   else
     {
       assert (dynamic_cast<css_server_external_task *> (ptr));
-
       css_server_external_task *task_p = static_cast<css_server_external_task *> (ptr);
-
-      printf ("css_server_task: fd: %d, client_id: %d\n", task_p->get_conn ()->fd, task_p->get_conn ()->client_id);
-
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_THREAD_STACK, 1, prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS));
-
-      css_send_request_error_and_abort (*task_p->get_conn (), 1, ER_THREAD_STACK);
-
-      css_end_server_request (task_p->get_conn ());
-
-      task_p->retire ();
+      conn = task_p->get_conn ();
     }
+
+  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_THREAD_STACK, 1, prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS));
+
+  rc = css_receive_request (conn, &rid, &request, &size);
+  if (rc != NO_ERRORS)
+    {
+      /* something was wrong */
+      assert (false);
+      /* shutdown immediately */
+      css_end_server_request (conn);
+    }
+  else
+    {
+      css_send_request_error_and_abort (conn, rid, ER_THREAD_STACK);
+    }
+
+  ptr->retire ();
 }
 
 static void
@@ -1375,14 +1360,13 @@ css_compensation (cubthread::task<cubthread::entry> *ptr)
 {
   css_connection_task *task_p = static_cast<css_connection_task *> (ptr);
 
-  printf ("css_connection_task: fd: %d, client_id: %d\n", task_p->get_conn ().fd, task_p->get_conn ().client_id);
-
   er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_THREAD_STACK, 1, prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS));
 
-  (*css_Connection_error_handler)(&cubthread::get_entry (), &task_p->get_conn ());
+  (*css_Connection_error_handler) (&cubthread::get_entry (), &task_p->get_conn ());
 
   task_p->retire ();
 }
+
 // *INDENT-ON*
 
 /*
@@ -1783,6 +1767,32 @@ css_send_abort_to_client (CSS_CONN_ENTRY * conn, unsigned int eid)
   rc = css_send_abort_request (conn, CSS_RID_FROM_EID (eid));
 
   return (rc == NO_ERRORS) ? 0 : rc;
+}
+
+/*
+ * css_send_request_error_and_abort () - send an error message and abort message to the client
+ *   return:
+ *   rid(in): request id
+ *   errid(in): error code
+ */
+unsigned int
+css_send_request_error_and_abort (CSS_CONN_ENTRY * conn, unsigned short rid, int errid)
+{
+  OR_ALIGNED_BUF (1024) a_buffer;
+  char *buffer = OR_ALIGNED_BUF_START (a_buffer);
+  int length = 1024;
+
+  char *area = er_get_area_error (buffer, &length);
+  unsigned int eid = css_return_eid_from_conn (conn, rid);
+
+  if (area != NULL)
+    {
+      conn.db_error = errid;
+      (void) css_send_error_to_client (conn, eid, area, length);
+      conn.db_error = 0;
+    }
+
+  return css_send_abort_to_client (conn, eid);
 }
 
 /*

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1371,8 +1371,11 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
 
       printf ("css_server_task: fd: %d, client_id: %d\n", task_p->get_conn ().fd, task_p->get_conn ().client_id);
 
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_CLIENTS_EXCEEDED, 1, NUM_NORMAL_TRANS);
-      css_send_request_error_and_abort (task_p->get_conn (), task_p->get_conn ().request_id, ER_CSS_CLIENTS_EXCEEDED);
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_THREAD_STACK, 1, prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS));
+
+      task_p->get_conn ().start_request ();
+      css_send_request_error_and_abort (task_p->get_conn (), 0, ER_THREAD_STACK);
+      css_shutdown_conn (&task_p->get_conn ());
 
       task_p->retire ();
   };
@@ -1382,8 +1385,9 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
 
       printf ("css_connection_task: fd: %d, client_id: %d\n", task_p->get_conn ().fd, task_p->get_conn ().client_id);
 
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_CLIENTS_EXCEEDED, 1, NUM_NORMAL_TRANS);
-      css_send_request_error_and_abort (task_p->get_conn (), task_p->get_conn ().request_id, ER_CSS_CLIENTS_EXCEEDED);
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_THREAD_STACK, 1, prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS));
+
+      css_shutdown_conn (&task_p->get_conn ());
 
       task_p->retire ();
   };
@@ -3333,8 +3337,10 @@ static cubthread::wait_seconds
 css_get_connection_thread_timeout_configuration (void)
 {
   // todo: need infinite timeout
+//  return
+//    cubthread::wait_seconds (std::chrono::seconds (prm_get_integer_value (PRM_ID_THREAD_CONNECTION_TIMEOUT_SECONDS)));
   return
-    cubthread::wait_seconds (std::chrono::seconds (prm_get_integer_value (PRM_ID_THREAD_CONNECTION_TIMEOUT_SECONDS)));
+    cubthread::wait_seconds (std::chrono::seconds (2000));
 }
 
 static bool
@@ -3353,7 +3359,8 @@ static cubthread::wait_seconds
 css_get_server_request_thread_timeout_configuration (void)
 {
   // todo: need infinite timeout
-  return cubthread::wait_seconds (std::chrono::seconds (prm_get_integer_value (PRM_ID_THREAD_WORKER_TIMEOUT_SECONDS)));
+  //return cubthread::wait_seconds (std::chrono::seconds (prm_get_integer_value (PRM_ID_THREAD_WORKER_TIMEOUT_SECONDS)));
+  return cubthread::wait_seconds (std::chrono::seconds (20));
 }
 
 static void

--- a/src/connection/server_support.h
+++ b/src/connection/server_support.h
@@ -61,6 +61,8 @@ extern unsigned int css_receive_data_from_client (CSS_CONN_ENTRY * conn, unsigne
 extern unsigned int css_receive_data_from_client_with_timeout (CSS_CONN_ENTRY * conn, unsigned int eid, char **buffer,
 							       int *size, int timeout);
 extern unsigned int css_send_abort_to_client (CSS_CONN_ENTRY * conn, unsigned int eid);
+extern unsigned int css_send_request_error_and_abort (CSS_CONN_ENTRY * conn, unsigned short rid, int errid);
+
 extern void
 css_initialize_server_interfaces (int (*request_handler)
 				  (THREAD_ENTRY * thrd, unsigned int eid, int request, int size, char *buffer),

--- a/src/connection/server_support.h
+++ b/src/connection/server_support.h
@@ -61,7 +61,7 @@ extern unsigned int css_receive_data_from_client (CSS_CONN_ENTRY * conn, unsigne
 extern unsigned int css_receive_data_from_client_with_timeout (CSS_CONN_ENTRY * conn, unsigned int eid, char **buffer,
 							       int *size, int timeout);
 extern unsigned int css_send_abort_to_client (CSS_CONN_ENTRY * conn, unsigned int eid);
-extern unsigned int css_send_request_error_and_abort (CSS_CONN_ENTRY * conn, unsigned short rid, int errid);
+extern void css_send_request_error_and_abort (CSS_CONN_ENTRY * conn, unsigned short rid, int errid);
 
 extern void
 css_initialize_server_interfaces (int (*request_handler)

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -237,20 +237,16 @@ namespace cubthread
 	    adj_ar_free (cnv_adj_buffer[i]);
 	  }
       }
-    int rc;
-    if ((rc = pthread_mutex_destroy (&tran_index_lock)) != 0)
+    if (pthread_mutex_destroy (&tran_index_lock) != 0)
       {
-	printf ("pthread_mutex_destroy failed: %s\n", strerror (rc));
 	assert (false);
       }
-    if ((rc = pthread_mutex_destroy (&th_entry_lock)) != 0)
+    if (pthread_mutex_destroy (&th_entry_lock) != 0)
       {
-	printf ("pthread_mutex_destroy failed: %s\n", strerror (rc));
 	assert (false);
       }
-    if ((rc = pthread_cond_destroy (&wakeup_cond)) != 0)
+    if (pthread_cond_destroy (&wakeup_cond) != 0)
       {
-	printf ("pthread_cond_destroy failed: %s\n", strerror (rc));
 	assert (false);
       }
 

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -237,16 +237,20 @@ namespace cubthread
 	    adj_ar_free (cnv_adj_buffer[i]);
 	  }
       }
-    if (pthread_mutex_destroy (&tran_index_lock) != 0)
+    int rc;
+    if ((rc = pthread_mutex_destroy (&tran_index_lock)) != 0)
       {
+	printf ("pthread_mutex_destroy failed: %s\n", strerror (rc));
 	assert (false);
       }
-    if (pthread_mutex_destroy (&th_entry_lock) != 0)
+    if ((rc = pthread_mutex_destroy (&th_entry_lock)) != 0)
       {
+	printf ("pthread_mutex_destroy failed: %s\n", strerror (rc));
 	assert (false);
       }
-    if (pthread_cond_destroy (&wakeup_cond) != 0)
+    if ((rc = pthread_cond_destroy (&wakeup_cond)) != 0)
       {
+	printf ("pthread_cond_destroy failed: %s\n", strerror (rc));
 	assert (false);
       }
 

--- a/src/thread/thread_manager.cpp
+++ b/src/thread/thread_manager.cpp
@@ -162,7 +162,7 @@ namespace cubthread
   entry_workpool *
   manager::create_worker_pool (size_t pool_size, size_t task_max_count, const char *name,
 			       entry_manager *context_manager, std::size_t core_count, bool debug_logging,
-			       bool pool_threads, wait_seconds wait_for_task_time)
+			       bool pool_threads, wait_seconds wait_for_task_time, std::function<void (task<entry> *)> compensate_func)
   {
 #if defined (SERVER_MODE)
     if (is_single_thread ())
@@ -177,7 +177,7 @@ namespace cubthread
 	  }
 	// reserve pool_size entries and add to m_worker_pools
 	return create_and_track_resource (m_worker_pools, pool_size, pool_size, task_max_count, *context_manager,
-					  name, core_count, debug_logging, pool_threads, wait_for_task_time);
+					  name, core_count, debug_logging, pool_threads, wait_for_task_time, compensate_func);
       }
 #else // not SERVER_MODE = SA_MODE
     return NULL;

--- a/src/thread/thread_manager.hpp
+++ b/src/thread/thread_manager.hpp
@@ -129,7 +129,8 @@ namespace cubthread
       entry_workpool *create_worker_pool (std::size_t pool_size, std::size_t task_max_count, const char *name,
 					  entry_manager *context_manager, std::size_t core_count,
 					  bool debug_logging, bool pool_threads = false,
-					  wait_seconds wait_for_task_time = std::chrono::seconds (5));
+					  wait_seconds wait_for_task_time = std::chrono::seconds (5),
+					  std::function<void (task<entry> *)> compensate_func = nullptr);
 
       // destroy worker pool
       void destroy_worker_pool (entry_workpool *&worker_pool_arg);

--- a/src/thread/thread_worker_pool.cpp
+++ b/src/thread/thread_worker_pool.cpp
@@ -125,14 +125,6 @@ namespace cubthread
   }
 
   void
-  wp_handle_system_error (const char *message, const std::system_error &e)
-  {
-    er_print_callstack (ARG_FILE_LINE, "%s - throws err = %d: %s\n", message, e.code (), e.what ());
-    assert (false);
-    throw e;
-  }
-
-  void
   wp_er_log_stats (const char *header, cubperf::stat_value *statsp)
   {
     std::stringstream ss;

--- a/src/thread/thread_worker_pool.hpp
+++ b/src/thread/thread_worker_pool.hpp
@@ -536,11 +536,6 @@ namespace cubthread
   // does not return 0
   std::size_t system_core_count (void);
 
-  // custom worker pool exception handler
-  void wp_handle_system_error (const char *message, const std::system_error &e);
-  template <typename Func>
-  void wp_call_func_throwing_system_error (const char *message, Func &func);
-
   // dump worker pool statistics to error log
   void wp_er_log_stats (const char *header, cubperf::stat_value *statsp);
 
@@ -1338,7 +1333,6 @@ namespace cubthread
       }
     catch (const std::exception &e)
       {
-	//e.code (), e.what ();
 	er_log_debug (ARG_FILE_LINE, "%s\n", e.what ());
 	success = false;
       }
@@ -1619,24 +1613,6 @@ namespace cubthread
     if (ctxp != NULL)
       {
 	func (*ctxp, stop, args...);
-      }
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // other functions
-  //////////////////////////////////////////////////////////////////////////
-
-  template <typename Func>
-  void
-  wp_call_func_throwing_system_error (const char *message, Func &func)
-  {
-    try
-      {
-	func ();  // no exception catching on release
-      }
-    catch (const std::system_error &e)
-      {
-	wp_handle_system_error (message, e);
       }
   }
 

--- a/src/thread/thread_worker_pool.hpp
+++ b/src/thread/thread_worker_pool.hpp
@@ -968,9 +968,10 @@ namespace cubthread
 	if (!refp->assign_task (task_p, push_time))
 	  {
 	    // failed to start new thread
-	    if (m_parent_pool->get_compensate_func ())
+	    auto func = m_parent_pool->get_compensate_func ();
+	    if (func)
 	      {
-		m_parent_pool->get_compensate_func () (task_p);
+		func (task_p);
 		finished_task_notification ();
 	      }
 	    else
@@ -1325,7 +1326,6 @@ namespace cubthread
   worker_pool<Context>::core::worker::start_thread (void)
   {
     bool success = true;
-    int max_clients;
     std::thread t;
 
     assert (m_has_thread);
@@ -1335,12 +1335,10 @@ namespace cubthread
 	t = std::thread (&worker::run, this);
 	t.detach ();
       }
-    catch (const std::system_error &e)
+    catch (const std::exception &e)
       {
 	//e.code (), e.what ();
-	max_clients = prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS);
-	er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_THREAD_STACK, 1, max_clients);
-
+	er_log_debug (ARG_FILE_LINE, "%s\n", e.what ());
 	success = false;
       }
     return success;

--- a/src/thread/thread_worker_pool.hpp
+++ b/src/thread/thread_worker_pool.hpp
@@ -1307,6 +1307,7 @@ namespace cubthread
 	      {
 		return true;
 	      }
+	    // TODO: need to thread_sleep (100) but this makes the master thread blocked
 	  }
 	// failed to start thread
 	m_has_thread = false;

--- a/src/thread/thread_worker_pool.hpp
+++ b/src/thread/thread_worker_pool.hpp
@@ -30,6 +30,8 @@
 // cubrid includes
 #include "perf_def.hpp"
 #include "extensible_array.hpp"
+#include "system_parameter.h"
+#include "error_manager.h"
 
 // system includes
 #include <atomic>
@@ -144,7 +146,8 @@ namespace cubthread
 
       worker_pool (std::size_t pool_size, std::size_t task_max_count, context_manager_type &context_mgr,
 		   const char *name, std::size_t core_count = 1, bool debug_logging = false, bool pool_threads = false,
-		   wait_seconds wait_for_task_time = std::chrono::seconds (5));
+		   wait_seconds wait_for_task_time = std::chrono::seconds (5),
+		   std::function<void (task_type *)> compensate_func = nullptr);
       ~worker_pool ();
 
       // try to execute task; executes only if the maximum number of tasks is not reached.
@@ -177,6 +180,8 @@ namespace cubthread
       std::size_t get_max_count (void) const;
       // get the number of cores
       std::size_t get_core_count (void) const;
+      // get compensate function
+      std::function<void (task_type *)> &get_compensate_func (void);
 
       // get worker pool statistics
       // note: the statistics are collected from all cores and all their workers adding up all local statistics
@@ -261,6 +266,8 @@ namespace cubthread
       wait_seconds m_wait_for_task_time;
 
       std::string m_name;
+
+      std::function<void (task_type *)> m_compensate_func;
   };
 
   // worker_pool<Context>::core
@@ -425,9 +432,9 @@ namespace cubthread
       void init_core (core_type &parent);
 
       // assign task (can be NULL) to running thread or start thread
-      void assign_task (task<Context> *work_p, cubperf::time_point push_time);
+      bool assign_task (task<Context> *work_p, cubperf::time_point push_time);
       // start thread for current worker
-      void start_thread (void);
+      bool start_thread (void);
       // run task on current thread (push_time is provided by core)
       void push_task_on_running_thread (task<Context> *work_p, cubperf::time_point push_time);
       // stop execution; if worker has a thread running, it outputs is_not_stopped = true
@@ -455,6 +462,10 @@ namespace cubthread
       void set_has_thread (void)
       {
 	m_has_thread = true;
+      }
+      void set_has_no_thread (void)
+      {
+	m_has_thread = false;
       }
       void set_push_time_now (void)
       {
@@ -547,7 +558,7 @@ namespace cubthread
   template <typename Context>
   worker_pool<Context>::worker_pool (std::size_t pool_size, std::size_t task_max_count,
 				     context_manager_type &context_mgr, const char *name, std::size_t core_count,
-				     bool debug_log, bool pool_threads, wait_seconds wait_for_task_time)
+				     bool debug_log, bool pool_threads, wait_seconds wait_for_task_time, std::function<void (task_type *)> compensate_func)
     : m_max_workers (pool_size)
     , m_task_max_count (task_max_count)
     , m_task_count (0)
@@ -560,6 +571,7 @@ namespace cubthread
     , m_pool_threads (pool_threads)
     , m_wait_for_task_time (wait_for_task_time)
     , m_name (name == NULL ? "" : name)
+    , m_compensate_func (compensate_func)
   {
     // initialize cores; we'll try to distribute pool evenly to all cores. if core count is not fully contained in
     // pool size, some cores will have one additional worker
@@ -736,6 +748,13 @@ namespace cubthread
   worker_pool<Context>::get_core_count (void) const
   {
     return m_core_count;
+  }
+
+  template<typename Context>
+  std::function<void (typename worker_pool<Context>::task_type *)> &
+  worker_pool<Context>::get_compensate_func (void)
+  {
+    return m_compensate_func;
   }
 
   template<typename Context>
@@ -945,7 +964,18 @@ namespace cubthread
 	ulock.unlock ();
 
 	assert (refp != NULL);
-	refp->assign_task (task_p, push_time);
+	if (!refp->assign_task (task_p, push_time))
+	  {
+	    // failed to start new thread
+	    if (m_parent_pool->get_compensate_func ())
+	      {
+		m_parent_pool->get_compensate_func () (task_p);
+	      }
+	    else
+	      {
+		m_task_queue.push (task_p);
+	      }
+	  }
       }
     else
       {
@@ -1120,7 +1150,11 @@ namespace cubthread
 	    // this thread is already stopped and we can start its thread
 	    refp->set_push_time_now ();
 	    refp->set_has_thread ();
-	    refp->start_thread ();
+	    if (!refp->start_thread ())
+	      {
+		refp->set_has_no_thread ();
+		available_stack.append (&refp, 1);
+	      }
 	  }
       }
 
@@ -1228,9 +1262,11 @@ namespace cubthread
   }
 
   template <typename Context>
-  void
+  bool
   worker_pool<Context>::core::worker::assign_task (task<Context> *work_p, cubperf::time_point push_time)
   {
+    int i = 0;
+
     // save push time
     m_push_time = push_time;
 
@@ -1243,6 +1279,7 @@ namespace cubthread
       {
 	m_has_thread = true;
 	assert (m_context_p == NULL);
+	// this must be success
 	start_thread ();
       }
 
@@ -1259,31 +1296,51 @@ namespace cubthread
 
 	assert (m_context_p == NULL);
 
-	start_thread ();
+	// try to start new thread
+	for (i = 0; i < 2; i++)
+	  {
+	    if (start_thread ())
+	      {
+		return true;
+	      }
+	  }
+	// failed to start thread
+	m_has_thread = false;
+	if (m_task_p)
+	  {
+	    m_task_p = NULL;
+	  }
+
+	return false;
       }
+
+    return true;
   }
 
   template <typename Context>
-  void
+  bool
   worker_pool<Context>::core::worker::start_thread (void)
   {
-    assert (m_has_thread);
-
-    //
-    // the next code tries to help visualizing any system errors that can occur during create or detach in debug
-    // mode
-    //
-    // release will basically be reduced to:
-    // std::thread (&worker::run, this).detach ();
-    //
-
+    bool success = true;
+    int max_clients;
     std::thread t;
 
-    auto lambda_create = [&] (void) -> void { t = std::thread (&worker::run, this); };
-    auto lambda_detach = [&] (void) -> void { t.detach (); };
+    assert (m_has_thread);
 
-    wp_call_func_throwing_system_error ("starting thread", lambda_create);
-    wp_call_func_throwing_system_error ("detaching thread", lambda_detach);
+    try
+      {
+	t = std::thread (&worker::run, this);
+	t.detach ();
+      }
+    catch (const std::system_error &e)
+      {
+	//e.code (), e.what ();
+	max_clients = prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS);
+	er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_THREAD_STACK, 1, max_clients);
+
+	success = false;
+      }
+    return success;
   }
 
   template <typename Context>
@@ -1571,25 +1628,16 @@ namespace cubthread
   void
   wp_call_func_throwing_system_error (const char *message, Func &func)
   {
-#if !defined (NDEBUG)
     try
       {
-#endif // DEBUG
-
 	func ();  // no exception catching on release
-
-#if !defined (NDEBUG)
       }
     catch (const std::system_error &e)
       {
 	wp_handle_system_error (message, e);
       }
-#endif // DEBUG
   }
 
 } // namespace cubthread
-
-
-
 
 #endif // _THREAD_WORKER_POOL_HPP_

--- a/src/thread/thread_worker_pool.hpp
+++ b/src/thread/thread_worker_pool.hpp
@@ -955,6 +955,7 @@ namespace cubthread
       {
 	// reject task
 	task_p->retire ();
+	finished_task_notification ();
 	return;
       }
 
@@ -970,11 +971,13 @@ namespace cubthread
 	    if (m_parent_pool->get_compensate_func ())
 	      {
 		m_parent_pool->get_compensate_func () (task_p);
+		finished_task_notification ();
 	      }
 	    else
 	      {
 		m_task_queue.push (task_p);
 	      }
+	    become_available (*refp);
 	  }
       }
     else


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26721>

### Purpose

Thread 생성에 실패할 경우 현재는 core가 발생하며 서버가 종료되므로 아래처럼 변경합니다.
1. Thread 생성 루틴을 2회 수행
2. Thread 생성에 실패한 경우 worker pool이 compensation function을 가지고 있다면, 함수 실행
3. compensation function이 없다면 task queue에 task 삽입

Connection worker pool과 transaction worker pool만 compensation function을 가집니다.

### Implementation

- css compensation
연결을 종료하고 conn을 반환합니다.

- tran compensation
client에게 에러를 출력합니다. 이 경우 해당 task만 실패처리되고 현재 session, transaction은 유지됩니다. 추후 thread 생성에 성공해 task가 수행되면 작업이 이어 수행됩니다.

### Remarks

테스트 방법

connection worker pool
`cubrid.conf` 설정
```
thread_connection_timeout_seconds=10
```

```
cubrid server start demodb
20초 대기
prlimit --pid $(pidof cub_server) --nproc=120: < cub_server의 최대 process/thread 제한
csql -u dba demodb < 실패 - cub_server 에러 로그 출력
```

transaction worker pool
`cubrid.conf` 설정
```
thread_worker_timeout_seconds=10
```

```
cubrid server start demodb
csql -u dba demodb
csql> create table tbl (a int);
csql> ;autocommit off
csql> insert into tbl values (10), (12);
csql> select * from tbl;
20초 대기
prlimit --pid $(pidof cub_server) --nproc=120:
csql> select * from tbl; < 실패
prlimit --pid $(pidof cub_server) --nproc=900:
csql> select * from tbl; < 정상 출력
csql> ;commit < 세션, 트랜잭션 유지
```