### PR TITLE
[CBRD-26740] fix memory leak in method scanner by clearing vectors with swap

### DIFF
--- a/src/method/method_scan.cpp
+++ b/src/method/method_scan.cpp
@@ -106,28 +106,25 @@ namespace cubscan
       close_value_array ();
       pr_clear_value_vector (m_arg_vector);
 
-      m_arg_vector.clear ();
-      m_arg_use_vector.clear ();
-      m_arg_dom_vector.clear ();
-
-      if (is_final)
+      if (is_final && m_method_group)
 	{
+	  m_method_group->reset (true);
+	  m_method_group->end ();
+
+	  cubmethod::runtime_context *rctx = cubmethod::get_rctx (m_thread_p);
+	  if (rctx)
+	    {
+	      rctx->pop_stack (m_thread_p, m_method_group);
+	    }
+	  m_method_group = nullptr; // will be destroyed by cubmethod::runtime_context
+
+	  m_arg_vector.clear ();
+	  m_arg_use_vector.clear ();
+	  m_arg_dom_vector.clear ();
+
 	  std::vector<TP_DOMAIN *>().swap (m_arg_dom_vector);
 	  std::vector<DB_VALUE>().swap (m_arg_vector);
 	  std::vector<bool>().swap (m_arg_use_vector);
-
-	  if (m_method_group)
-	    {
-	      m_method_group->reset (true);
-	      m_method_group->end ();
-
-	      cubmethod::runtime_context *rctx = cubmethod::get_rctx (m_thread_p);
-	      if (rctx)
-		{
-		  rctx->pop_stack (m_thread_p, m_method_group);
-		}
-	      m_method_group = nullptr; // will be destroyed by cubmethod::runtime_context
-	    }
 	}
     }
 

--- a/src/method/method_scan.cpp
+++ b/src/method/method_scan.cpp
@@ -118,13 +118,11 @@ namespace cubscan
 	    }
 	  m_method_group = nullptr; // will be destroyed by cubmethod::runtime_context
 
-	  m_arg_vector.clear ();
-	  m_arg_use_vector.clear ();
-	  m_arg_dom_vector.clear ();
-
 	  std::vector<TP_DOMAIN *>().swap (m_arg_dom_vector);
 	  std::vector<DB_VALUE>().swap (m_arg_vector);
 	  std::vector<bool>().swap (m_arg_use_vector);
+
+          m_list_id = nullptr;
 	}
     }
 

--- a/src/method/method_scan.cpp
+++ b/src/method/method_scan.cpp
@@ -122,7 +122,7 @@ namespace cubscan
 	  std::vector<DB_VALUE>().swap (m_arg_vector);
 	  std::vector<bool>().swap (m_arg_use_vector);
 
-          m_list_id = nullptr;
+	  m_list_id = nullptr;
 	}
     }
 

--- a/src/method/method_scan.cpp
+++ b/src/method/method_scan.cpp
@@ -105,6 +105,16 @@ namespace cubscan
     {
       close_value_array ();
       pr_clear_value_vector (m_arg_vector);
+      m_arg_vector.clear ();
+      m_arg_use_vector.clear ();
+      m_arg_dom_vector.clear ();
+
+      if (is_final)
+        {
+          std::vector<TP_DOMAIN *>().swap(m_arg_dom_vector);
+          std::vector<DB_VALUE>().swap(m_arg_vector);
+          std::vector<bool>().swap(m_arg_use_vector);
+        }
 
       if (is_final && m_method_group)
 	{

--- a/src/method/method_scan.cpp
+++ b/src/method/method_scan.cpp
@@ -105,28 +105,29 @@ namespace cubscan
     {
       close_value_array ();
       pr_clear_value_vector (m_arg_vector);
+
       m_arg_vector.clear ();
       m_arg_use_vector.clear ();
       m_arg_dom_vector.clear ();
 
       if (is_final)
-        {
-          std::vector<TP_DOMAIN *>().swap(m_arg_dom_vector);
-          std::vector<DB_VALUE>().swap(m_arg_vector);
-          std::vector<bool>().swap(m_arg_use_vector);
-        }
-
-      if (is_final && m_method_group)
 	{
-	  m_method_group->reset (true);
-	  m_method_group->end ();
+	  std::vector<TP_DOMAIN *>().swap (m_arg_dom_vector);
+	  std::vector<DB_VALUE>().swap (m_arg_vector);
+	  std::vector<bool>().swap (m_arg_use_vector);
 
-	  cubmethod::runtime_context *rctx = cubmethod::get_rctx (m_thread_p);
-	  if (rctx)
+	  if (m_method_group)
 	    {
-	      rctx->pop_stack (m_thread_p, m_method_group);
+	      m_method_group->reset (true);
+	      m_method_group->end ();
+
+	      cubmethod::runtime_context *rctx = cubmethod::get_rctx (m_thread_p);
+	      if (rctx)
+		{
+		  rctx->pop_stack (m_thread_p, m_method_group);
+		}
+	      m_method_group = nullptr; // will be destroyed by cubmethod::runtime_context
 	    }
-	  m_method_group = nullptr; // will be destroyed by cubmethod::runtime_context
 	}
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26740

- Applied the swap-to-empty idiom in `scanner::clear` to ensure  member vectors release their underlying memory capacity, preventing memory bloat in static scanner instances.