### PR TITLE
[CBRD-26741] Refactor oos_read / oos_insert to take oos_buffer (caller-owned span)

### DIFF
--- a/cs/CMakeLists.txt
+++ b/cs/CMakeLists.txt
@@ -170,6 +170,7 @@ set(BASE_HEADERS
   ${BASE_DIR}/string_buffer.hpp
   ${BASE_DIR}/resource_tracker.hpp
   ${BASE_DIR}/ddl_log.h
+  ${BASE_DIR}/byte_span_writer.hpp
   ${BASE_DIR}/ifsys.hpp
   ${BASE_DIR}/filesys_parser.hpp
   ${BASE_DIR}/cgroup.hpp

--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -181,6 +181,7 @@ set (BASE_HEADERS
   ${BASE_DIR}/string_buffer.hpp
   ${BASE_DIR}/fixed_size_allocator.hpp
   ${BASE_DIR}/span.hpp
+  ${BASE_DIR}/byte_span_writer.hpp
   ${BASE_DIR}/ifsys.hpp
   ${BASE_DIR}/packet_buffer.hpp
   ${BASE_DIR}/DMRB.hpp

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -169,6 +169,7 @@ set(BASE_HEADERS
   ${BASE_DIR}/resource_tracker.hpp
   ${BASE_DIR}/scope_exit.hpp
   ${BASE_DIR}/fixed_size_allocator.hpp
+  ${BASE_DIR}/byte_span_writer.hpp
   ${BASE_DIR}/ifsys.hpp
   ${BASE_DIR}/filesys_parser.hpp
   ${BASE_DIR}/cgroup.hpp

--- a/src/base/byte_span_writer.hpp
+++ b/src/base/byte_span_writer.hpp
@@ -17,17 +17,9 @@
  */
 
 /*
- * byte_span_writer.hpp - bounded append-only cursor over a cubbase::span
- *
- * Invariant: 0 <= written() <= capacity(). append() is the only mutator;
- * it bounds-checks before memcpy and refuses to write past the end. There
- * is no way to advance the cursor without copying, and no way to copy
- * without also advancing the cursor — so "wrote past the end" is
- * unrepresentable.
- *
- * Error reporting: append() returns bool. Callers emit context-rich
- * errors (er_set / oos_error / etc.) — the writer stays free of any
- * specific error vocabulary.
+ * byte_span_writer.hpp - bounded append-only cursor over a cubbase::span.
+ * append() is the only mutator; it bounds-checks before memcpy, returns
+ * false on overflow, and never advances the cursor without copying.
  */
 
 #ifndef _BYTE_SPAN_WRITER_HPP_
@@ -71,9 +63,7 @@ namespace cubbase
 	return _written == _dest.size ();
       }
 
-      /* Append n bytes from src. Returns false if the write would overrun
-       * capacity; cursor is unchanged and no bytes are written in that case.
-       * n == 0 is always legal (no-op success), even when the writer is full. */
+      /* Returns false on capacity overrun; cursor unchanged. n == 0 is a no-op success. */
       bool append (const char *src, std::size_t n) noexcept
       {
 	assert (n == 0 || src != nullptr);

--- a/src/base/byte_span_writer.hpp
+++ b/src/base/byte_span_writer.hpp
@@ -1,0 +1,98 @@
+/*
+ *
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+/*
+ * byte_span_writer.hpp - bounded append-only cursor over a cubbase::span
+ *
+ * Invariant: 0 <= written() <= capacity(). append() is the only mutator;
+ * it bounds-checks before memcpy and refuses to write past the end. There
+ * is no way to advance the cursor without copying, and no way to copy
+ * without also advancing the cursor — so "wrote past the end" is
+ * unrepresentable.
+ *
+ * Error reporting: append() returns bool. Callers emit context-rich
+ * errors (er_set / oos_error / etc.) — the writer stays free of any
+ * specific error vocabulary.
+ */
+
+#ifndef _BYTE_SPAN_WRITER_HPP_
+#define _BYTE_SPAN_WRITER_HPP_
+
+#ident "$Id$"
+
+#include "span.hpp"
+
+#include <cassert>
+#include <cstddef>
+#include <cstring>
+
+namespace cubbase
+{
+  class byte_span_writer
+  {
+    public:
+      explicit byte_span_writer (span<char> dest) noexcept
+	: _dest (dest), _written (0)
+      {
+      }
+
+      std::size_t written () const noexcept
+      {
+	return _written;
+      }
+
+      std::size_t capacity () const noexcept
+      {
+	return _dest.size ();
+      }
+
+      std::size_t remaining () const noexcept
+      {
+	return _dest.size () - _written;
+      }
+
+      bool full () const noexcept
+      {
+	return _written == _dest.size ();
+      }
+
+      /* Append n bytes from src. Returns false if the write would overrun
+       * capacity; cursor is unchanged and no bytes are written in that case.
+       * n == 0 is always legal (no-op success), even when the writer is full. */
+      bool append (const char *src, std::size_t n) noexcept
+      {
+	assert (n == 0 || src != nullptr);
+	if (n > remaining ())
+	  {
+	    return false;
+	  }
+	if (n > 0)
+	  {
+	    std::memcpy (_dest.data () + _written, src, n);
+	    _written += n;
+	  }
+	return true;
+      }
+
+    private:
+      span<char> _dest;
+      std::size_t _written;
+  };
+}
+
+#endif /* _BYTE_SPAN_WRITER_HPP_ */

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -10638,35 +10638,63 @@ heap_attrvalue_point_variable (RECDES * recdes, HEAP_CACHE_ATTRINFO * attr_info,
   raw->data = ((char *) recdes->data + OR_VAR_OFFSET (recdes->data, attrepr->location));
   if (OR_IS_OOS (offset))
     {
+      /* OOS branch contract.
+       *
+       * Heap-record inline OOS layout (since M2): [OID (8B) | full_length (8B bigint)].
+       * On success: raw->data points to a freshly allocated buffer (owned by raw)
+       *             holding the full reassembled OOS value of length oos_len.
+       * On failure: raw->data is NULL so consumers of (raw, *is_oos) observe
+       *             absence of data even if assert_release is compiled out.
+       */
       OR_BUF buf;
       OID oos_oid;
       DB_BIGINT oos_len;
       int rc = NO_ERROR;
 
-      /* Inline OOS layout in the heap record (since M2): [OID (8B) | full_length (8B bigint)].
-       * Validate the buffer holds both fields before reading either of them. */
       buf.ptr = raw->data;
       buf.endptr = recdes->data + recdes->length;
-      assert (buf.endptr - buf.ptr >= OR_OID_SIZE + OR_BIGINT_SIZE);
+      if (buf.endptr - buf.ptr < OR_OID_SIZE + OR_BIGINT_SIZE)
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
+	  raw->data = NULL;
+	  assert_release_error (er_errid () != NO_ERROR);
+	  *is_oos = true;
+	  return;
+	}
 
       or_get_oid (&buf, &oos_oid);
       oos_len = or_get_bigint (&buf, &rc);
 
-      assert (!OID_ISNULL (&oos_oid));
-      assert (rc == NO_ERROR);
-      /* recdes/oos_read APIs use int for sizes, so clamp the bigint to int range. */
-      assert (oos_len > 0 && oos_len <= (DB_BIGINT) INT_MAX);
+      if (rc != NO_ERROR || OID_ISNULL (&oos_oid))
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
+	  raw->data = NULL;
+	  assert_release_error (er_errid () != NO_ERROR);
+	  *is_oos = true;
+	  return;
+	}
+      /* recdes/oos_read APIs use int for sizes; the inline length must fit. An
+       * out-of-range bigint here is on-disk corruption, not a programmer bug. */
+      if (oos_len <= 0 || oos_len > (DB_BIGINT) INT_MAX)
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
+	  raw->data = NULL;
+	  assert_release_error (er_errid () != NO_ERROR);
+	  *is_oos = true;
+	  return;
+	}
 
       THREAD_ENTRY *thread_p = thread_get_thread_entry_info ();
       assert (thread_p);
 
-      /* Preallocate the buffer using the inline length so oos_read only has to copy.
-       * oos_read uses raw->area_size as the authoritative expected length and validates
-       * the OOS header's total_data_length against it. On failure, null raw->data so
-       * any downstream consumer of (raw, is_oos) sees absence of data even if
-       * assert_release is compiled out. */
-      if (recdes_allocate_data_area (raw, (int) oos_len) != NO_ERROR || oos_read (thread_p, oos_oid, *raw) != NO_ERROR)
+      if (recdes_allocate_data_area (raw, (int) oos_len) != NO_ERROR)
 	{
+	  raw->data = NULL;
+	  assert_release (false);
+	}
+      else if (oos_read (thread_p, oos_oid, *raw) != NO_ERROR)
+	{
+	  recdes_free_data_area (raw);
 	  raw->data = NULL;
 	  assert_release (false);
 	}

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -698,10 +698,11 @@ static size_t heap_attrinfo_determine_disk_layout (HEAP_CACHE_ATTRINFO * attr_in
 
 static void heap_attrvalue_point_fixed (RECDES * recdes, HEAP_CACHE_ATTRINFO * attr_info, OR_ATTRIBUTE * attrepr,
 					RECDES * raw);
+static void heap_attrvalue_read_oos_inline (RECDES * recdes, RECDES * raw);
 static void heap_attrvalue_point_variable (RECDES * recdes, HEAP_CACHE_ATTRINFO * attr_info, OR_ATTRIBUTE * attrepr,
-					   RECDES * raw, bool * is_oos);
+					   RECDES * raw, bool * oos_owned_buffer);
 static int heap_attrvalue_transform_to_dbvalue (HEAP_ATTRVALUE * value, OR_ATTRIBUTE * attrepr, RECDES * raw,
-						bool is_oos);
+						bool oos_owned_buffer);
 static int heap_attrvalue_read (RECDES * recdes, HEAP_ATTRVALUE * value, HEAP_CACHE_ATTRINFO * attr_info);
 
 static int heap_midxkey_get_value (RECDES * recdes, OR_ATTRIBUTE * att, DB_VALUE * value,
@@ -10589,19 +10590,91 @@ heap_attrvalue_point_fixed (RECDES * recdes, HEAP_CACHE_ATTRINFO * attr_info, OR
 }
 
 /*
+ * heap_attrvalue_read_oos_inline () - Resolve an inline-OOS variable attribute.
+ *
+ *   recdes(in): heap record holding the inline OOS header
+ *   raw(in/out): on entry, raw->data points at the inline [OID (8B) | full_length (8B)]
+ *                inside recdes; on success, raw->data is replaced with a freshly
+ *                allocated buffer holding the full reassembled OOS value of
+ *                length oos_len, and raw owns that buffer (caller must free).
+ *                On failure, raw->data is set to NULL so consumers observe
+ *                absence of data even if assert_release is compiled out.
+ *
+ * Inline OOS layout (since M2): [OID (8B) | full_length (8B bigint)].
+ */
+static void
+heap_attrvalue_read_oos_inline (RECDES * recdes, RECDES * raw)
+{
+  OR_BUF buf;
+  OID oos_oid;
+  DB_BIGINT oos_len;
+  int rc = NO_ERROR;
+  THREAD_ENTRY *thread_p;
+
+  buf.ptr = raw->data;
+  buf.endptr = recdes->data + recdes->length;
+  if (buf.endptr - buf.ptr < OR_OID_SIZE + OR_BIGINT_SIZE)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
+      raw->data = NULL;
+      assert_release_error (er_errid () != NO_ERROR);
+      return;
+    }
+
+  or_get_oid (&buf, &oos_oid);
+  oos_len = or_get_bigint (&buf, &rc);
+
+  if (rc != NO_ERROR || OID_ISNULL (&oos_oid))
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
+      raw->data = NULL;
+      assert_release_error (er_errid () != NO_ERROR);
+      return;
+    }
+  /* recdes/oos_read APIs use int for sizes; the inline length must fit. An
+   * out-of-range bigint here is on-disk corruption, not a programmer bug. */
+  if (oos_len <= 0 || oos_len > (DB_BIGINT) INT_MAX)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
+      raw->data = NULL;
+      assert_release_error (er_errid () != NO_ERROR);
+      return;
+    }
+
+  thread_p = thread_get_thread_entry_info ();
+  assert (thread_p);
+
+  if (recdes_allocate_data_area (raw, (int) oos_len) != NO_ERROR)
+    {
+      raw->data = NULL;
+      assert_release (false);
+      return;
+    }
+  if (oos_read (thread_p, oos_oid, *raw) != NO_ERROR)
+    {
+      recdes_free_data_area (raw);
+      raw->data = NULL;
+      assert_release (false);
+      return;
+    }
+}
+
+/*
  * heap_attrvalue_point_variable () -
  *
  *   return: NO_ERROR
  *   recdes(in): Record
  *   attr_info(in): The attribute information structure
  *   attrepr(in): The attribute structure
- *   data(out): Disk value pointer
- *   length(out): Disk value length
- *
+ *   raw(out): Disk value pointer + length
+ *   oos_owned_buffer(out): set to true iff this attribute is stored OOS. The
+ *                          caller then (a) owns raw->data and must call
+ *                          recdes_free_data_area, and (b) must request COPY
+ *                          mode in data_readval (PEEK would dangle).
  */
 static void
 heap_attrvalue_point_variable (RECDES * recdes, HEAP_CACHE_ATTRINFO * attr_info, OR_ATTRIBUTE * attrepr, RECDES * raw,
-			       bool * is_oos)
+			       bool * oos_owned_buffer)
 {
   int offset;
   int offset_size;
@@ -10638,67 +10711,10 @@ heap_attrvalue_point_variable (RECDES * recdes, HEAP_CACHE_ATTRINFO * attr_info,
   raw->data = ((char *) recdes->data + OR_VAR_OFFSET (recdes->data, attrepr->location));
   if (OR_IS_OOS (offset))
     {
-      /* OOS branch contract.
-       *
-       * Heap-record inline OOS layout (since M2): [OID (8B) | full_length (8B bigint)].
-       * On success: raw->data points to a freshly allocated buffer (owned by raw)
-       *             holding the full reassembled OOS value of length oos_len.
-       * On failure: raw->data is NULL so consumers of (raw, *is_oos) observe
-       *             absence of data even if assert_release is compiled out.
-       */
-      OR_BUF buf;
-      OID oos_oid;
-      DB_BIGINT oos_len;
-      int rc = NO_ERROR;
-
-      buf.ptr = raw->data;
-      buf.endptr = recdes->data + recdes->length;
-      if (buf.endptr - buf.ptr < OR_OID_SIZE + OR_BIGINT_SIZE)
-	{
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
-	  raw->data = NULL;
-	  assert_release_error (er_errid () != NO_ERROR);
-	  *is_oos = true;
-	  return;
-	}
-
-      or_get_oid (&buf, &oos_oid);
-      oos_len = or_get_bigint (&buf, &rc);
-
-      if (rc != NO_ERROR || OID_ISNULL (&oos_oid))
-	{
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
-	  raw->data = NULL;
-	  assert_release_error (er_errid () != NO_ERROR);
-	  *is_oos = true;
-	  return;
-	}
-      /* recdes/oos_read APIs use int for sizes; the inline length must fit. An
-       * out-of-range bigint here is on-disk corruption, not a programmer bug. */
-      if (oos_len <= 0 || oos_len > (DB_BIGINT) INT_MAX)
-	{
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
-	  raw->data = NULL;
-	  assert_release_error (er_errid () != NO_ERROR);
-	  *is_oos = true;
-	  return;
-	}
-
-      THREAD_ENTRY *thread_p = thread_get_thread_entry_info ();
-      assert (thread_p);
-
-      if (recdes_allocate_data_area (raw, (int) oos_len) != NO_ERROR)
-	{
-	  raw->data = NULL;
-	  assert_release (false);
-	}
-      else if (oos_read (thread_p, oos_oid, *raw) != NO_ERROR)
-	{
-	  recdes_free_data_area (raw);
-	  raw->data = NULL;
-	  assert_release (false);
-	}
-      *is_oos = true;
+      /* Set the contract flag up-front so every helper exit (success or
+       * failure) uniformly leaves the caller in the OOS-owned-buffer state. */
+      *oos_owned_buffer = true;
+      heap_attrvalue_read_oos_inline (recdes, raw);
     }
   else
     {
@@ -10728,7 +10744,8 @@ heap_attrvalue_point_variable (RECDES * recdes, HEAP_CACHE_ATTRINFO * attr_info,
  *
  */
 static int
-heap_attrvalue_transform_to_dbvalue (HEAP_ATTRVALUE * value, OR_ATTRIBUTE * attrepr, RECDES * raw, bool is_oos)
+heap_attrvalue_transform_to_dbvalue (HEAP_ATTRVALUE * value, OR_ATTRIBUTE * attrepr, RECDES * raw,
+				     bool oos_owned_buffer)
 {
   const PR_TYPE *pr_type;
   OR_BUF buf;
@@ -10761,7 +10778,8 @@ heap_attrvalue_transform_to_dbvalue (HEAP_ATTRVALUE * value, OR_ATTRIBUTE * attr
       pr_type = pr_type_from_id (attrepr->type);
       if (pr_type)
 	{
-	  rv = pr_type->data_readval (&buf, &value->dbvalue, attrepr->domain, raw->length, is_oos, NULL, 0);
+	  /* OOS-owned buffer ⇒ COPY (PEEK would dangle once the caller frees it). */
+	  rv = pr_type->data_readval (&buf, &value->dbvalue, attrepr->domain, raw->length, oos_owned_buffer, NULL, 0);
 	}
       value->state = HEAP_READ_ATTRVALUE;
       if (rv != NO_ERROR)
@@ -10791,7 +10809,7 @@ heap_attrvalue_read (RECDES * recdes, HEAP_ATTRVALUE * value, HEAP_CACHE_ATTRINF
 {
   OR_ATTRIBUTE *attrepr;
   RECDES raw = { -1, -1, REC_UNKNOWN, NULL };
-  bool is_oos = false;
+  bool oos_owned_buffer = false;
   int error;
 
   if (unlikely (IS_DEDUPLICATE_KEY_ATTR_ID (value->attrid)))
@@ -10826,20 +10844,18 @@ heap_attrvalue_read (RECDES * recdes, HEAP_ATTRVALUE * value, HEAP_CACHE_ATTRINF
 	}
       else
 	{
-	  heap_attrvalue_point_variable (recdes, attr_info, attrepr, &raw, &is_oos);
+	  heap_attrvalue_point_variable (recdes, attr_info, attrepr, &raw, &oos_owned_buffer);
 	}
     }
 
   /* the data pointer will point to either a current value in recdes or a default one in attrepr */
-  error = heap_attrvalue_transform_to_dbvalue (value, attrepr, &raw, is_oos);
+  error = heap_attrvalue_transform_to_dbvalue (value, attrepr, &raw, oos_owned_buffer);
   // TODO: heap_attrvalue_transform_to_dbvalue() used to PEEK &raw when creating value (dbvalue),
-  // but oos_insert() makes &raw point to newly allocated memory.
-  // Thus,
-  // 1) we need to free &raw only when is_oos is true.
-  // 2) we need to create dbvalue with mr_data_readval...(...COPY).
-  // This can be refactored later when dbvalue supports zero-copy to OOS data.
-  // oos_insert(OID) must be refactored to oos_read(PAGE_PTR, slotid, PEEK/COPY) and allow PEEK mode.
-  if (is_oos)
+  // but oos_insert() makes &raw point to newly allocated memory. Thus we must free
+  // &raw and request COPY in data_readval. Both decisions are gated by oos_owned_buffer.
+  // Revisit once dbvalue supports zero-copy to OOS data and oos_insert(OID) is refactored
+  // to oos_read(PAGE_PTR, slotid, PEEK/COPY) so PEEK mode becomes available.
+  if (oos_owned_buffer)
     {
       recdes_free_data_area (&raw);
     }
@@ -10859,7 +10875,7 @@ static int
 heap_midxkey_get_value (RECDES * recdes, OR_ATTRIBUTE * att, DB_VALUE * value, HEAP_CACHE_ATTRINFO * attr_info)
 {
   RECDES raw = { -1, -1, REC_UNKNOWN, NULL };
-  bool is_oos = false;
+  bool oos_owned_buffer = false;
   bool found = true;		/* Does attribute(att) exist in this disk representation? */
   int i;
 
@@ -10901,7 +10917,7 @@ heap_midxkey_get_value (RECDES * recdes, OR_ATTRIBUTE * att, DB_VALUE * value, H
 	    }
 	  else
 	    {			/* A variable attribute */
-	      heap_attrvalue_point_variable (recdes, attr_info, att, &raw, &is_oos);
+	      heap_attrvalue_point_variable (recdes, attr_info, att, &raw, &oos_owned_buffer);
 	    }
 	}
     }
@@ -10916,10 +10932,11 @@ heap_midxkey_get_value (RECDES * recdes, OR_ATTRIBUTE * att, DB_VALUE * value, H
       OR_BUF buf;
 
       or_init (&buf, raw.data, raw.length);
-      att->domain->type->data_readval (&buf, value, att->domain, raw.length, is_oos, NULL, 0);
+      /* OOS-owned buffer ⇒ COPY (PEEK would dangle once we free it below). */
+      att->domain->type->data_readval (&buf, value, att->domain, raw.length, oos_owned_buffer, NULL, 0);
     }
 
-  if (is_oos)
+  if (oos_owned_buffer)
     {
       recdes_free_data_area (&raw);
     }

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -10603,8 +10603,6 @@ static void
 heap_attrvalue_point_variable (RECDES * recdes, HEAP_CACHE_ATTRINFO * attr_info, OR_ATTRIBUTE * attrepr, RECDES * raw,
 			       bool * is_oos)
 {
-  OR_BUF buf;
-  OID oos_oid;
   int offset;
   int offset_size;
 
@@ -10640,16 +10638,32 @@ heap_attrvalue_point_variable (RECDES * recdes, HEAP_CACHE_ATTRINFO * attr_info,
   raw->data = ((char *) recdes->data + OR_VAR_OFFSET (recdes->data, attrepr->location));
   if (OR_IS_OOS (offset))
     {
+      OR_BUF buf;
+      OID oos_oid;
+      DB_BIGINT oos_len;
+      int rc = NO_ERROR;
+
+      /* Inline OOS layout in the heap record (since M2): [OID (8B) | full_length (8B bigint)]. */
       buf.ptr = raw->data;
       buf.endptr = recdes->data + recdes->length;
       or_get_oid (&buf, &oos_oid);
+      oos_len = or_get_bigint (&buf, &rc);
 
       assert (!OID_ISNULL (&oos_oid));
+      assert (rc == NO_ERROR);
+      assert (oos_len > 0 && oos_len <= INT_MAX);
 
       THREAD_ENTRY *thread_p = thread_get_thread_entry_info ();
       assert (thread_p);
-      if (oos_read (thread_p, oos_oid, *raw) != NO_ERROR)
+
+      /* Preallocate the buffer using the inline length so oos_read only has to copy.
+       * oos_read uses raw->area_size as the authoritative expected length and validates
+       * the OOS header's total_data_length against it. On failure, null raw->data so
+       * any downstream consumer of (raw, is_oos) sees absence of data even if
+       * assert_release is compiled out. */
+      if (recdes_allocate_data_area (raw, (int) oos_len) != NO_ERROR || oos_read (thread_p, oos_oid, *raw) != NO_ERROR)
 	{
+	  raw->data = NULL;
 	  assert_release (false);
 	}
       *is_oos = true;

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -698,9 +698,10 @@ static size_t heap_attrinfo_determine_disk_layout (HEAP_CACHE_ATTRINFO * attr_in
 
 static void heap_attrvalue_point_fixed (RECDES * recdes, HEAP_CACHE_ATTRINFO * attr_info, OR_ATTRIBUTE * attrepr,
 					RECDES * raw);
-static void heap_attrvalue_read_oos_inline (RECDES * recdes, RECDES * raw);
+static void heap_attrvalue_read_oos_inline (RECDES * recdes, RECDES * raw, char *oos_scratch, int oos_scratch_size);
 static void heap_attrvalue_point_variable (RECDES * recdes, HEAP_CACHE_ATTRINFO * attr_info, OR_ATTRIBUTE * attrepr,
-					   RECDES * raw, bool * oos_owned_buffer);
+					   RECDES * raw, bool * oos_owned_buffer, char *oos_scratch,
+					   int oos_scratch_size);
 static int heap_attrvalue_transform_to_dbvalue (HEAP_ATTRVALUE * value, OR_ATTRIBUTE * attrepr, RECDES * raw,
 						bool oos_owned_buffer);
 static int heap_attrvalue_read (RECDES * recdes, HEAP_ATTRVALUE * value, HEAP_CACHE_ATTRINFO * attr_info);
@@ -10594,16 +10595,21 @@ heap_attrvalue_point_fixed (RECDES * recdes, HEAP_CACHE_ATTRINFO * attr_info, OR
  *
  *   recdes(in): heap record holding the inline OOS header
  *   raw(in/out): on entry, raw->data points at the inline [OID (8B) | full_length (8B)]
- *                inside recdes; on success, raw->data is replaced with a freshly
- *                allocated buffer holding the full reassembled OOS value of
- *                length oos_len, and raw owns that buffer (caller must free).
+ *                inside recdes; on success, raw->data is replaced with a buffer
+ *                holding the full reassembled OOS value of length oos_len.
+ *                The buffer is the caller-supplied scratch when oos_len fits
+ *                (no heap alloc), otherwise a freshly allocated heap buffer
+ *                that the caller owns and must free via recdes_free_data_area.
  *                On failure, raw->data is set to NULL so consumers observe
  *                absence of data even if assert_release is compiled out.
+ *   oos_scratch(in): caller-provided buffer used as a fast path; may be NULL
+ *                    to force heap allocation.
+ *   oos_scratch_size(in): usable size of oos_scratch in bytes.
  *
  * Inline OOS layout (since M2): [OID (8B) | full_length (8B bigint)].
  */
 static void
-heap_attrvalue_read_oos_inline (RECDES * recdes, RECDES * raw)
+heap_attrvalue_read_oos_inline (RECDES * recdes, RECDES * raw, char *oos_scratch, int oos_scratch_size)
 {
   OR_BUF buf;
   OID oos_oid;
@@ -10644,7 +10650,17 @@ heap_attrvalue_read_oos_inline (RECDES * recdes, RECDES * raw)
   thread_p = thread_get_thread_entry_info ();
   assert (thread_p);
 
-  if (recdes_allocate_data_area (raw, (int) oos_len) != NO_ERROR)
+  /* Fast path: when the inline length fits the caller-provided scratch, skip
+   * the per-row heap allocation. Caller must avoid freeing scratch-backed
+   * buffers; it discriminates by comparing raw->data against its scratch ptr.
+   * NB: oos_read derives expected_length from raw->area_size, so set area_size
+   * to oos_len (not the scratch capacity) even though the buffer is larger. */
+  if (oos_scratch != NULL && oos_len <= (DB_BIGINT) oos_scratch_size)
+    {
+      raw->data = oos_scratch;
+      raw->area_size = (int) oos_len;
+    }
+  else if (recdes_allocate_data_area (raw, (int) oos_len) != NO_ERROR)
     {
       raw->data = NULL;
       assert_release (false);
@@ -10652,7 +10668,10 @@ heap_attrvalue_read_oos_inline (RECDES * recdes, RECDES * raw)
     }
   if (oos_read (thread_p, oos_oid, *raw) != NO_ERROR)
     {
-      recdes_free_data_area (raw);
+      if (raw->data != oos_scratch)
+	{
+	  recdes_free_data_area (raw);
+	}
       raw->data = NULL;
       assert_release (false);
       return;
@@ -10668,13 +10687,21 @@ heap_attrvalue_read_oos_inline (RECDES * recdes, RECDES * raw)
  *   attrepr(in): The attribute structure
  *   raw(out): Disk value pointer + length
  *   oos_owned_buffer(out): set to true iff this attribute is stored OOS. The
- *                          caller then (a) owns raw->data and must call
- *                          recdes_free_data_area, and (b) must request COPY
- *                          mode in data_readval (PEEK would dangle).
+ *                          caller then (a) owns raw->data and must request
+ *                          COPY mode in data_readval (PEEK would dangle), and
+ *                          (b) must call recdes_free_data_area only when
+ *                          raw->data is not the caller-provided oos_scratch
+ *                          (heap allocations happen only when oos_len exceeds
+ *                          the scratch buffer).
+ *   oos_scratch(in): optional caller-owned buffer for inline-OOS fast path;
+ *                    when set, OOS payloads up to oos_scratch_size bytes are
+ *                    materialised here without a heap allocation. May be NULL
+ *                    to force heap allocation.
+ *   oos_scratch_size(in): usable size of oos_scratch.
  */
 static void
 heap_attrvalue_point_variable (RECDES * recdes, HEAP_CACHE_ATTRINFO * attr_info, OR_ATTRIBUTE * attrepr, RECDES * raw,
-			       bool * oos_owned_buffer)
+			       bool * oos_owned_buffer, char *oos_scratch, int oos_scratch_size)
 {
   int offset;
   int offset_size;
@@ -10714,7 +10741,7 @@ heap_attrvalue_point_variable (RECDES * recdes, HEAP_CACHE_ATTRINFO * attr_info,
       /* Set the contract flag up-front so every helper exit (success or
        * failure) uniformly leaves the caller in the OOS-owned-buffer state. */
       *oos_owned_buffer = true;
-      heap_attrvalue_read_oos_inline (recdes, raw);
+      heap_attrvalue_read_oos_inline (recdes, raw, oos_scratch, oos_scratch_size);
     }
   else
     {
@@ -10810,6 +10837,11 @@ heap_attrvalue_read (RECDES * recdes, HEAP_ATTRVALUE * value, HEAP_CACHE_ATTRINF
   OR_ATTRIBUTE *attrepr;
   RECDES raw = { -1, -1, REC_UNKNOWN, NULL };
   bool oos_owned_buffer = false;
+  /* Stack scratch for inline-OOS reads: most OOS payloads fit one I/O page,
+   * so this fast path avoids a per-row db_private_alloc/free. Larger payloads
+   * still fall through to heap allocation inside the helper. */
+  char oos_scratch_buf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
+  char *oos_scratch = PTR_ALIGN (oos_scratch_buf, MAX_ALIGNMENT);
   int error;
 
   if (unlikely (IS_DEDUPLICATE_KEY_ATTR_ID (value->attrid)))
@@ -10844,7 +10876,8 @@ heap_attrvalue_read (RECDES * recdes, HEAP_ATTRVALUE * value, HEAP_CACHE_ATTRINF
 	}
       else
 	{
-	  heap_attrvalue_point_variable (recdes, attr_info, attrepr, &raw, &oos_owned_buffer);
+	  heap_attrvalue_point_variable (recdes, attr_info, attrepr, &raw, &oos_owned_buffer, oos_scratch,
+					 IO_MAX_PAGE_SIZE);
 	}
     }
 
@@ -10855,7 +10888,7 @@ heap_attrvalue_read (RECDES * recdes, HEAP_ATTRVALUE * value, HEAP_CACHE_ATTRINF
   // &raw and request COPY in data_readval. Both decisions are gated by oos_owned_buffer.
   // Revisit once dbvalue supports zero-copy to OOS data and oos_insert(OID) is refactored
   // to oos_read(PAGE_PTR, slotid, PEEK/COPY) so PEEK mode becomes available.
-  if (oos_owned_buffer)
+  if (oos_owned_buffer && raw.data != oos_scratch)
     {
       recdes_free_data_area (&raw);
     }
@@ -10877,6 +10910,10 @@ heap_midxkey_get_value (RECDES * recdes, OR_ATTRIBUTE * att, DB_VALUE * value, H
   RECDES raw = { -1, -1, REC_UNKNOWN, NULL };
   bool oos_owned_buffer = false;
   bool found = true;		/* Does attribute(att) exist in this disk representation? */
+  /* Stack scratch for inline-OOS reads: avoids per-row alloc on the hot
+   * index-key materialisation path when the OOS payload fits one I/O page. */
+  char oos_scratch_buf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
+  char *oos_scratch = PTR_ALIGN (oos_scratch_buf, MAX_ALIGNMENT);
   int i;
 
   /* Initialize disk value information */
@@ -10917,7 +10954,8 @@ heap_midxkey_get_value (RECDES * recdes, OR_ATTRIBUTE * att, DB_VALUE * value, H
 	    }
 	  else
 	    {			/* A variable attribute */
-	      heap_attrvalue_point_variable (recdes, attr_info, att, &raw, &oos_owned_buffer);
+	      heap_attrvalue_point_variable (recdes, attr_info, att, &raw, &oos_owned_buffer, oos_scratch,
+					     IO_MAX_PAGE_SIZE);
 	    }
 	}
     }
@@ -10936,7 +10974,7 @@ heap_midxkey_get_value (RECDES * recdes, OR_ATTRIBUTE * att, DB_VALUE * value, H
       att->domain->type->data_readval (&buf, value, att->domain, raw.length, oos_owned_buffer, NULL, 0);
     }
 
-  if (oos_owned_buffer)
+  if (oos_owned_buffer && raw.data != oos_scratch)
     {
       recdes_free_data_area (&raw);
     }

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -10659,7 +10659,7 @@ heap_attrvalue_read_oos_inline (RECDES * recdes, RECDES * raw, char *oos_scratch
       return;
     }
 
-  if (oos_read (thread_p, oos_oid, cubbase::span < char >(raw->data, (std::size_t) oos_len)) != NO_ERROR)
+  if (oos_read (thread_p, oos_oid, oos_buffer (raw->data, (std::size_t) oos_len)) != NO_ERROR)
     {
       if (raw->data != oos_scratch)
 	{

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -10592,21 +10592,10 @@ heap_attrvalue_point_fixed (RECDES * recdes, HEAP_CACHE_ATTRINFO * attr_info, OR
 
 /*
  * heap_attrvalue_read_oos_inline () - Resolve an inline-OOS variable attribute.
- *
- *   recdes(in): heap record holding the inline OOS header
- *   raw(in/out): on entry, raw->data points at the inline [OID (8B) | full_length (8B)]
- *                inside recdes; on success, raw->data is replaced with a buffer
- *                holding the full reassembled OOS value of length oos_len.
- *                The buffer is the caller-supplied scratch when oos_len fits
- *                (no heap alloc), otherwise a freshly allocated heap buffer
- *                that the caller owns and must free via recdes_free_data_area.
- *                On failure, raw->data is set to NULL so consumers observe
- *                absence of data even if assert_release is compiled out.
- *   oos_scratch(in): caller-provided buffer used as a fast path; may be NULL
- *                    to force heap allocation.
- *   oos_scratch_size(in): usable size of oos_scratch in bytes.
- *
- * Inline OOS layout (since M2): [OID (8B) | full_length (8B bigint)].
+ *   Inline layout (M2+): [OID (8B) | full_length (8B bigint)].
+ *   On success raw->data is either the caller scratch (when oos_len fits) or a
+ *   heap-allocated buffer the caller must free via recdes_free_data_area.
+ *   On failure raw->data is set to NULL.
  */
 static void
 heap_attrvalue_read_oos_inline (RECDES * recdes, RECDES * raw, char *oos_scratch, int oos_scratch_size)
@@ -10619,9 +10608,7 @@ heap_attrvalue_read_oos_inline (RECDES * recdes, RECDES * raw, char *oos_scratch
 
   buf.ptr = raw->data;
   buf.endptr = recdes->data + recdes->length;
-  /* OOS attribute layout is a writer-side invariant: the raw region always
-   * begins with [OID | bigint]. A shorter region indicates a programmer bug,
-   * not on-disk corruption. */
+  /* Writer invariant: the OOS-marked variable region always starts with [OID | bigint]. */
   assert (buf.endptr - buf.ptr >= OR_OID_SIZE + OR_BIGINT_SIZE);
 
   or_get_oid (&buf, &oos_oid);
@@ -10635,18 +10622,14 @@ heap_attrvalue_read_oos_inline (RECDES * recdes, RECDES * raw, char *oos_scratch
       return;
     }
 
-  /* OOS writer invariants: never emits a NULL OID for the inline marker and
-   * always writes a length that fits int (recdes/oos_read sizes are int). */
+  /* Writer invariants: non-null OID, length fits int. */
   assert (!OID_ISNULL (&oos_oid));
   assert (oos_len > 0 && oos_len <= (DB_BIGINT) INT_MAX);
 
   thread_p = thread_get_thread_entry_info ();
 
-  /* Fast path: when the inline length fits the caller-provided scratch, skip
-   * the per-row heap allocation. Caller must avoid freeing scratch-backed
-   * buffers; it discriminates by comparing raw->data against its scratch ptr.
-   * oos_read now takes a cubbase::span sized to oos_len, so raw->area_size is
-   * free to truthfully reflect the underlying buffer's capacity. */
+  /* Fast path: payload fits scratch, no per-row heap alloc. The caller
+   * distinguishes scratch- vs heap-backed buffers by pointer comparison. */
   if (oos_scratch != NULL && oos_len <= (DB_BIGINT) oos_scratch_size)
     {
       raw->data = oos_scratch;
@@ -10680,18 +10663,10 @@ heap_attrvalue_read_oos_inline (RECDES * recdes, RECDES * raw, char *oos_scratch
  *   attr_info(in): The attribute information structure
  *   attrepr(in): The attribute structure
  *   raw(out): Disk value pointer + length
- *   oos_owned_buffer(out): set to true iff this attribute is stored OOS. The
- *                          caller then (a) owns raw->data and must request
- *                          COPY mode in data_readval (PEEK would dangle), and
- *                          (b) must call recdes_free_data_area only when
- *                          raw->data is not the caller-provided oos_scratch
- *                          (heap allocations happen only when oos_len exceeds
- *                          the scratch buffer).
- *   oos_scratch(in): optional caller-owned buffer for inline-OOS fast path;
- *                    when set, OOS payloads up to oos_scratch_size bytes are
- *                    materialised here without a heap allocation. May be NULL
- *                    to force heap allocation.
- *   oos_scratch_size(in): usable size of oos_scratch.
+ *   oos_owned_buffer(out): true iff this attribute is OOS. Caller then owns
+ *                          raw->data, must use COPY in data_readval, and must
+ *                          recdes_free_data_area unless raw->data == oos_scratch.
+ *   oos_scratch / oos_scratch_size(in): optional fast-path buffer; NULL forces heap alloc.
  */
 static void
 heap_attrvalue_point_variable (RECDES * recdes, HEAP_CACHE_ATTRINFO * attr_info, OR_ATTRIBUTE * attrepr, RECDES * raw,
@@ -10732,8 +10707,7 @@ heap_attrvalue_point_variable (RECDES * recdes, HEAP_CACHE_ATTRINFO * attr_info,
   raw->data = ((char *) recdes->data + OR_VAR_OFFSET (recdes->data, attrepr->location));
   if (OR_IS_OOS (offset))
     {
-      /* Set the contract flag up-front so every helper exit (success or
-       * failure) uniformly leaves the caller in the OOS-owned-buffer state. */
+      /* Flag set before the call so every helper exit leaves caller in OOS-owned state. */
       *oos_owned_buffer = true;
       heap_attrvalue_read_oos_inline (recdes, raw, oos_scratch, oos_scratch_size);
     }
@@ -10799,7 +10773,7 @@ heap_attrvalue_transform_to_dbvalue (HEAP_ATTRVALUE * value, OR_ATTRIBUTE * attr
       pr_type = pr_type_from_id (attrepr->type);
       if (pr_type)
 	{
-	  /* OOS-owned buffer ⇒ COPY (PEEK would dangle once the caller frees it). */
+	  /* OOS-owned buffer => COPY (PEEK dangles once caller frees raw). */
 	  rv = pr_type->data_readval (&buf, &value->dbvalue, attrepr->domain, raw->length, oos_owned_buffer, NULL, 0);
 	}
       value->state = HEAP_READ_ATTRVALUE;
@@ -10831,9 +10805,7 @@ heap_attrvalue_read (RECDES * recdes, HEAP_ATTRVALUE * value, HEAP_CACHE_ATTRINF
   OR_ATTRIBUTE *attrepr;
   RECDES raw = { -1, -1, REC_UNKNOWN, NULL };
   bool oos_owned_buffer = false;
-  /* Stack scratch for inline-OOS reads: most OOS payloads fit one I/O page,
-   * so this fast path avoids a per-row db_private_alloc/free. Larger payloads
-   * still fall through to heap allocation inside the helper. */
+  /* Stack scratch for inline-OOS reads up to one I/O page; larger payloads heap-alloc. */
   char oos_scratch_buf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
   char *oos_scratch = PTR_ALIGN (oos_scratch_buf, MAX_ALIGNMENT);
   int error;
@@ -10877,11 +10849,7 @@ heap_attrvalue_read (RECDES * recdes, HEAP_ATTRVALUE * value, HEAP_CACHE_ATTRINF
 
   /* the data pointer will point to either a current value in recdes or a default one in attrepr */
   error = heap_attrvalue_transform_to_dbvalue (value, attrepr, &raw, oos_owned_buffer);
-  // TODO: heap_attrvalue_transform_to_dbvalue() used to PEEK &raw when creating value (dbvalue),
-  // but oos_insert() makes &raw point to newly allocated memory. Thus we must free
-  // &raw and request COPY in data_readval. Both decisions are gated by oos_owned_buffer.
-  // Revisit once dbvalue supports zero-copy to OOS data and oos_insert(OID) is refactored
-  // to oos_read(PAGE_PTR, slotid, PEEK/COPY) so PEEK mode becomes available.
+  /* TODO: revisit when dbvalue supports zero-copy to OOS and a PEEK mode lands. */
   if (oos_owned_buffer && raw.data != oos_scratch)
     {
       recdes_free_data_area (&raw);
@@ -10904,8 +10872,7 @@ heap_midxkey_get_value (RECDES * recdes, OR_ATTRIBUTE * att, DB_VALUE * value, H
   RECDES raw = { -1, -1, REC_UNKNOWN, NULL };
   bool oos_owned_buffer = false;
   bool found = true;		/* Does attribute(att) exist in this disk representation? */
-  /* Stack scratch for inline-OOS reads: avoids per-row alloc on the hot
-   * index-key materialisation path when the OOS payload fits one I/O page. */
+  /* Stack scratch for inline-OOS reads up to one I/O page on the hot index-key path. */
   char oos_scratch_buf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
   char *oos_scratch = PTR_ALIGN (oos_scratch_buf, MAX_ALIGNMENT);
   int i;
@@ -10964,7 +10931,7 @@ heap_midxkey_get_value (RECDES * recdes, OR_ATTRIBUTE * att, DB_VALUE * value, H
       OR_BUF buf;
 
       or_init (&buf, raw.data, raw.length);
-      /* OOS-owned buffer ⇒ COPY (PEEK would dangle once we free it below). */
+      /* OOS-owned buffer => COPY (PEEK would dangle once we free it below). */
       att->domain->type->data_readval (&buf, value, att->domain, raw.length, oos_owned_buffer, NULL, 0);
     }
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -10645,12 +10645,12 @@ heap_attrvalue_read_oos_inline (RECDES * recdes, RECDES * raw, char *oos_scratch
   /* Fast path: when the inline length fits the caller-provided scratch, skip
    * the per-row heap allocation. Caller must avoid freeing scratch-backed
    * buffers; it discriminates by comparing raw->data against its scratch ptr.
-   * NB: oos_read derives expected_length from raw->area_size, so set area_size
-   * to oos_len (not the scratch capacity) even though the buffer is larger. */
+   * oos_read now takes a cubbase::span sized to oos_len, so raw->area_size is
+   * free to truthfully reflect the underlying buffer's capacity. */
   if (oos_scratch != NULL && oos_len <= (DB_BIGINT) oos_scratch_size)
     {
       raw->data = oos_scratch;
-      raw->area_size = (int) oos_len;
+      raw->area_size = oos_scratch_size;
     }
   else if (recdes_allocate_data_area (raw, (int) oos_len) != NO_ERROR)
     {
@@ -10659,7 +10659,7 @@ heap_attrvalue_read_oos_inline (RECDES * recdes, RECDES * raw, char *oos_scratch
       return;
     }
 
-  if (oos_read (thread_p, oos_oid, *raw) != NO_ERROR)
+  if (oos_read (thread_p, oos_oid, cubbase::span < char >(raw->data, (std::size_t) oos_len)) != NO_ERROR)
     {
       if (raw->data != oos_scratch)
 	{
@@ -10669,6 +10669,7 @@ heap_attrvalue_read_oos_inline (RECDES * recdes, RECDES * raw, char *oos_scratch
       assert_release (false);
       return;
     }
+  raw->length = (int) oos_len;
 }
 
 /*

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -10619,27 +10619,15 @@ heap_attrvalue_read_oos_inline (RECDES * recdes, RECDES * raw, char *oos_scratch
 
   buf.ptr = raw->data;
   buf.endptr = recdes->data + recdes->length;
-  if (buf.endptr - buf.ptr < OR_OID_SIZE + OR_BIGINT_SIZE)
-    {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
-      raw->data = NULL;
-      assert_release_error (er_errid () != NO_ERROR);
-      return;
-    }
+  /* OOS attribute layout is a writer-side invariant: the raw region always
+   * begins with [OID | bigint]. A shorter region indicates a programmer bug,
+   * not on-disk corruption. */
+  assert (buf.endptr - buf.ptr >= OR_OID_SIZE + OR_BIGINT_SIZE);
 
   or_get_oid (&buf, &oos_oid);
   oos_len = or_get_bigint (&buf, &rc);
 
-  if (rc != NO_ERROR || OID_ISNULL (&oos_oid))
-    {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
-      raw->data = NULL;
-      assert_release_error (er_errid () != NO_ERROR);
-      return;
-    }
-  /* recdes/oos_read APIs use int for sizes; the inline length must fit. An
-   * out-of-range bigint here is on-disk corruption, not a programmer bug. */
-  if (oos_len <= 0 || oos_len > (DB_BIGINT) INT_MAX)
+  if (rc != NO_ERROR)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
       raw->data = NULL;
@@ -10647,8 +10635,12 @@ heap_attrvalue_read_oos_inline (RECDES * recdes, RECDES * raw, char *oos_scratch
       return;
     }
 
+  /* OOS writer invariants: never emits a NULL OID for the inline marker and
+   * always writes a length that fits int (recdes/oos_read sizes are int). */
+  assert (!OID_ISNULL (&oos_oid));
+  assert (oos_len > 0 && oos_len <= (DB_BIGINT) INT_MAX);
+
   thread_p = thread_get_thread_entry_info ();
-  assert (thread_p);
 
   /* Fast path: when the inline length fits the caller-provided scratch, skip
    * the per-row heap allocation. Caller must avoid freeing scratch-backed
@@ -10666,6 +10658,7 @@ heap_attrvalue_read_oos_inline (RECDES * recdes, RECDES * raw, char *oos_scratch
       assert_release (false);
       return;
     }
+
   if (oos_read (thread_p, oos_oid, *raw) != NO_ERROR)
     {
       if (raw->data != oos_scratch)

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -12512,7 +12512,7 @@ heap_attrinfo_insert_to_oos (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * attr
 	    {
 	      return S_ERROR;
 	    }
-	  if (oos_insert (thread_p, oos_vfid, recdes, oos_oid) != NO_ERROR)
+	  if (oos_insert (thread_p, oos_vfid, oos_buffer (recdes.data, (size_t) recdes.length), oos_oid) != NO_ERROR)
 	    {
 	      return S_ERROR;
 	    }

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -10643,15 +10643,19 @@ heap_attrvalue_point_variable (RECDES * recdes, HEAP_CACHE_ATTRINFO * attr_info,
       DB_BIGINT oos_len;
       int rc = NO_ERROR;
 
-      /* Inline OOS layout in the heap record (since M2): [OID (8B) | full_length (8B bigint)]. */
+      /* Inline OOS layout in the heap record (since M2): [OID (8B) | full_length (8B bigint)].
+       * Validate the buffer holds both fields before reading either of them. */
       buf.ptr = raw->data;
       buf.endptr = recdes->data + recdes->length;
+      assert (buf.endptr - buf.ptr >= OR_OID_SIZE + OR_BIGINT_SIZE);
+
       or_get_oid (&buf, &oos_oid);
       oos_len = or_get_bigint (&buf, &rc);
 
       assert (!OID_ISNULL (&oos_oid));
       assert (rc == NO_ERROR);
-      assert (oos_len > 0 && oos_len <= INT_MAX);
+      /* recdes/oos_read APIs use int for sizes, so clamp the bigint to int range. */
+      assert (oos_len > 0 && oos_len <= (DB_BIGINT) INT_MAX);
 
       THREAD_ENTRY *thread_p = thread_get_thread_entry_info ();
       assert (thread_p);

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -12474,14 +12474,17 @@ heap_attrinfo_insert_to_oos (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * attr
 	  assert (attr_info->values != NULL && !db_value_is_null (&attr_info->values[i].dbvalue));
 	  assert (!attr_info->values[i].last_attrepr->is_fixed);
 
+	  /* heap_attrinfo_dbvalue_to_recdes may replace recdes.data with a malloc'd
+	   * buffer when the dbvalue doesn't fit the stack scratch. Both failure
+	   * branches below must reach the cleanup at error_oos. */
 	  if (heap_attrinfo_dbvalue_to_recdes (thread_p, &attr_info->values[i], attr_info->class_oid, lob_create_flag,
 					       &recdes) != S_SUCCESS)
 	    {
-	      return S_ERROR;
+	      goto error_oos;
 	    }
 	  if (oos_insert (thread_p, oos_vfid, oos_buffer (recdes.data, (size_t) recdes.length), oos_oid) != NO_ERROR)
 	    {
-	      return S_ERROR;
+	      goto error_oos;
 	    }
 
 	  thread_p->oos_oids.push_back (oos_oid);	/* for replication log */
@@ -12499,6 +12502,13 @@ heap_attrinfo_insert_to_oos (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * attr
   /* here: or vectorize the DB_VALUEs and insert at once */
 
   return S_SUCCESS;
+
+error_oos:
+  if (recdes.data != PTR_ALIGN (recbuf, MAX_ALIGNMENT))
+    {
+      free_and_init (recdes.data);
+    }
+  return S_ERROR;
 }
 
 /*

--- a/src/storage/oos_file.cpp
+++ b/src/storage/oos_file.cpp
@@ -47,10 +47,10 @@ static int
 oos_vpid_init_new (THREAD_ENTRY *thread_p, PAGE_PTR page, void *args);
 
 static int
-oos_insert_within_page (THREAD_ENTRY *thread_p, const VFID &oos_vfid, RECDES &recdes,
+oos_insert_within_page (THREAD_ENTRY *thread_p, const VFID &oos_vfid, oos_buffer src,
 			const OOS_RECORD_HEADER &header, OID &oid);
 static int
-oos_insert_across_pages (THREAD_ENTRY *thread_p, const VFID &oos_vfid, RECDES &recdes,
+oos_insert_across_pages (THREAD_ENTRY *thread_p, const VFID &oos_vfid, oos_buffer src,
 			 OID &oid);
 static int
 oos_read_within_page (THREAD_ENTRY *thread_p, const OID &oid,
@@ -1019,13 +1019,14 @@ oos_remove_page (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const VPID &vpid)
 
 
 static int
-oos_prepend_header (const RECDES &recdes, const OOS_RECORD_HEADER &oos_header, OOS_RECDES &oos_recdes)
+oos_prepend_header (oos_buffer src, const OOS_RECORD_HEADER &oos_header, OOS_RECDES &oos_recdes)
 {
   // Prepends the OOS header to user data, producing the on-page record.
   // Allocates a new data area for oos_recdes; caller must free it.
 
+  const int src_len = static_cast<int> (src.size ());
   int err;
-  err = recdes_allocate_data_area (&oos_recdes, recdes.length + (int)sizeof (OOS_RECORD_HEADER));
+  err = recdes_allocate_data_area (&oos_recdes, src_len + OOS_RECORD_HEADER_SIZE);
   if (err != NO_ERROR)
     {
       oos_error ("recdes_allocate_data_area failed in oos_prepend_header");
@@ -1035,37 +1036,38 @@ oos_prepend_header (const RECDES &recdes, const OOS_RECORD_HEADER &oos_header, O
     }
 
   oos_recdes.type = REC_HOME;
-  oos_recdes.length = recdes.length + (int)sizeof (OOS_RECORD_HEADER);
-  std::memcpy (oos_recdes.data, &oos_header, (int)sizeof (OOS_RECORD_HEADER));
-  std::memcpy (oos_recdes.data + (int)sizeof (OOS_RECORD_HEADER), recdes.data, recdes.length);
+  oos_recdes.length = src_len + OOS_RECORD_HEADER_SIZE;
+  std::memcpy (oos_recdes.data, &oos_header, OOS_RECORD_HEADER_SIZE);
+  std::memcpy (oos_recdes.data + OOS_RECORD_HEADER_SIZE, src.data (), src.size ());
 
   return NO_ERROR;
 }
 
 
 int
-oos_insert (THREAD_ENTRY *thread_p, const VFID &oos_vfid, RECDES &recdes, OID &oid)
+oos_insert (THREAD_ENTRY *thread_p, const VFID &oos_vfid, oos_buffer src, OID &oid)
 {
-  oos_debug ("arguments: oos_vfid={fileid=%d, volid=%d}, recdes.length=%d",
-	     oos_vfid.fileid, oos_vfid.volid, recdes.length);
+  oos_debug ("arguments: oos_vfid={fileid=%d, volid=%d}, src.size=%zu",
+	     oos_vfid.fileid, oos_vfid.volid, src.size ());
   int err = NO_ERROR;
 
-  // TODO: otherwise spage assert type <= REC_UNKNOWN fails
-  assert (recdes.type == REC_HOME);
-  assert (recdes.length > 0);
+  assert (src.data () != nullptr);
+  assert (src.size () > 0);
+
+  const int src_len = static_cast<int> (src.size ());
 
   // TODO: Once the OOS_RECORD_HEADER spec is finalized (first segment header and rest segment header),
   // review whether it is possible to generate the segment headers inside the oos_insert_within_page() and
   // oos_insert_across_pages() functions.
 
-  if (recdes.length <= oos_get_max_chunk_size_within_page ())
+  if (src_len <= oos_get_max_chunk_size_within_page ())
     {
-      const OOS_RECORD_HEADER header{recdes.length, 0, OID_INITIALIZER};
-      err = oos_insert_within_page (thread_p, oos_vfid, recdes, header, oid);
+      const OOS_RECORD_HEADER header{src_len, 0, OID_INITIALIZER};
+      err = oos_insert_within_page (thread_p, oos_vfid, src, header, oid);
     }
   else
     {
-      err = oos_insert_across_pages (thread_p, oos_vfid, recdes, oid);
+      err = oos_insert_across_pages (thread_p, oos_vfid, src, oid);
     }
 
   oos_debug ("inserted to oid={vol=%d,page=%d,slot=%d}", OID_AS_ARGS (&oid));
@@ -1096,7 +1098,7 @@ oos_insert (THREAD_ENTRY *thread_p, const VFID &oos_vfid, RECDES &recdes, OID &o
 //   auto-push in log_append_{undo,}redo_crumbs while this function runs.
 //
 static int
-oos_insert_across_pages (THREAD_ENTRY *thread_p, const VFID &oos_vfid, RECDES &recdes, OID &oid)
+oos_insert_across_pages (THREAD_ENTRY *thread_p, const VFID &oos_vfid, oos_buffer src, OID &oid)
 {
   int error_code = NO_ERROR;
   LOG_TDES *tdes = NULL;
@@ -1104,14 +1106,13 @@ oos_insert_across_pages (THREAD_ENTRY *thread_p, const VFID &oos_vfid, RECDES &r
   LOG_LSA tail_chunk_lsa = NULL_LSA;
   bool track_repl = false;
 
-  // split the recdes to multiple chunks and insert them one by one
+  // split the payload to multiple chunks and insert them one by one
   const int max_chunk_size = oos_get_max_chunk_size_within_page ();
-  assert (recdes.length + (int)sizeof (OOS_RECORD_HEADER) > max_chunk_size);
+  const int total_data_length = static_cast<int> (src.size ());
+  assert (total_data_length + OOS_RECORD_HEADER_SIZE > max_chunk_size);
 
-  int required_page_nums = (recdes.length + max_chunk_size - 1) / max_chunk_size;
+  int required_page_nums = (total_data_length + max_chunk_size - 1) / max_chunk_size;
   assert (required_page_nums > 1);
-
-  const int total_data_length = recdes.length;
 
   int total_inserted_length = 0;
   OID next_chunk_oid = OID_INITIALIZER; // the last chunk has null OID as next_chunk_oid
@@ -1144,20 +1145,18 @@ oos_insert_across_pages (THREAD_ENTRY *thread_p, const VFID &oos_vfid, RECDES &r
   // this loop inserts chunks in reverse order so that next_chunk_oid is always known
   for (int i = required_page_nums - 1; i >= 0; --i)
     {
-      RECDES chunk_recdes{};
-      chunk_recdes.type = REC_HOME;
-      chunk_recdes.length = std::min (max_chunk_size, total_data_length - i * max_chunk_size);
-      total_inserted_length += chunk_recdes.length;
-      chunk_recdes.data = recdes.data + i * max_chunk_size;
+      const int chunk_len = std::min (max_chunk_size, total_data_length - i * max_chunk_size);
+      oos_buffer chunk (src.data () + i * max_chunk_size, static_cast<std::size_t> (chunk_len));
+      total_inserted_length += chunk_len;
 
       // Keep total_data_length in each chunk so the log applier can validate all pieces before reassembly.
       OOS_RECORD_HEADER header{total_data_length, i, next_chunk_oid};
 
       OID current_chunk_oid;
-      error_code = oos_insert_within_page (thread_p, oos_vfid, chunk_recdes, header, current_chunk_oid);
+      error_code = oos_insert_within_page (thread_p, oos_vfid, chunk, header, current_chunk_oid);
       if (error_code != NO_ERROR)
 	{
-	  oos_error ("could not insert chunk index=%d of length %d.", i, chunk_recdes.length);
+	  oos_error ("could not insert chunk index=%d of length %d.", i, chunk_len);
 	  assert_release_error (er_errid () != NO_ERROR);
 	  // Partially inserted chunks are cleaned up when the caller aborts the transaction
 	  // (individual undo records replay in reverse). The caller MUST NOT continue
@@ -1172,7 +1171,7 @@ oos_insert_across_pages (THREAD_ENTRY *thread_p, const VFID &oos_vfid, RECDES &r
 
       next_chunk_oid = current_chunk_oid;
     }
-  assert (total_inserted_length == recdes.length);
+  assert (total_inserted_length == total_data_length);
 
   if (track_repl)
     {
@@ -1188,16 +1187,17 @@ oos_insert_across_pages (THREAD_ENTRY *thread_p, const VFID &oos_vfid, RECDES &r
 
 
 static int
-oos_insert_within_page (THREAD_ENTRY *thread_p, const VFID &oos_vfid, RECDES &recdes,
+oos_insert_within_page (THREAD_ENTRY *thread_p, const VFID &oos_vfid, oos_buffer src,
 			const OOS_RECORD_HEADER &header,
 			OID &oid)
 {
   int err = NO_ERROR;
   VPID vpid;
 
-  assert (recdes.length <= oos_get_max_chunk_size_within_page ());
+  const int src_len = static_cast<int> (src.size ());
+  assert (src_len <= oos_get_max_chunk_size_within_page ());
 
-  int required_length = recdes.length + (int)sizeof (OOS_RECORD_HEADER);
+  int required_length = src_len + OOS_RECORD_HEADER_SIZE;
 
   assert (required_length <= DB_ALIGN_BELOW (spage_max_record_size (), OOS_ALIGNMENT));
 
@@ -1205,7 +1205,7 @@ oos_insert_within_page (THREAD_ENTRY *thread_p, const VFID &oos_vfid, RECDES &re
 
   OOS_RECDES oos_recdes{};
   {
-    err = oos_prepend_header (recdes, header, oos_recdes);
+    err = oos_prepend_header (src, header, oos_recdes);
     if (err != NO_ERROR)
       {
 	oos_error ("oos_prepend_header failed");

--- a/src/storage/oos_file.cpp
+++ b/src/storage/oos_file.cpp
@@ -1054,6 +1054,17 @@ oos_insert (THREAD_ENTRY *thread_p, const VFID &oos_vfid, oos_buffer src, OID &o
   assert (src.data () != nullptr);
   assert (src.size () > 0);
 
+  /* Runtime guard for the narrowing cast below. Asserts above catch programmer
+   * bugs in dev; this check catches corrupt callers (e.g. a truncated
+   * replication log record producing a wrap-around size_t in locator_sr.c)
+   * before they reach chunk-count math or oos_prepend_header. */
+  if (src.data () == nullptr || src.size () == 0 || src.size () > (std::size_t) INT_MAX)
+    {
+      oos_error ("oos_insert rejected invalid src (data=%p, size=%zu)", src.data (), src.size ());
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
+      return ER_GENERIC_ERROR;
+    }
+
   const int src_len = static_cast<int> (src.size ());
 
   // TODO: Once the OOS_RECORD_HEADER spec is finalized (first segment header and rest segment header),
@@ -1327,8 +1338,22 @@ oos_read_across_pages (THREAD_ENTRY *thread_p, const OID &next_oid,
 	{
 	  return err;
 	}
-      assert (idx == header.chunk_index);
-      assert (header.total_data_length == total_data_length);
+
+      /* Chain invariants: chunk_index must increment monotonically from 1, and
+       * every chunk's total_data_length must agree with the head. A mismatch
+       * means next_chunk_oid points outside the chain (corruption) or chunks
+       * are reordered. Asserts catch writer bugs in dev; the runtime check
+       * prevents release builds from silently returning a misassembled value. */
+      if (idx != header.chunk_index || header.total_data_length != total_data_length)
+	{
+	  oos_error ("OOS chain inconsistency at idx=%d: header.chunk_index=%d, header.total_data_length=%d,"
+		     " expected_total=%d at oid={vol=%d,page=%d,slot=%d}",
+		     idx, header.chunk_index, header.total_data_length, total_data_length, OID_AS_ARGS (&current));
+	  assert (idx == header.chunk_index);
+	  assert (header.total_data_length == total_data_length);
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
+	  return ER_GENERIC_ERROR;
+	}
 
       /* Empty-chunk guard: a 0-byte chunk does not advance the writer, so a
        * corrupt cyclic next_chunk_oid would loop forever. Production never
@@ -1374,7 +1399,18 @@ oos_read (THREAD_ENTRY *thread_p, const OID &oid, oos_buffer dest)
       return err;
     }
 
-  assert (first_header.chunk_index == 0);
+  /* The caller's OID must point at the chain head (chunk_index == 0). If a
+   * corrupted heap inline OID points at a mid-chain chunk, that chunk's own
+   * total_data_length / next_chunk_oid would otherwise be accepted as a valid
+   * (but wrong) value. Runtime check so release builds reject corruption. */
+  if (first_header.chunk_index != 0)
+    {
+      oos_error ("OOS read at non-head chunk: chunk_index=%d at oid={vol=%d,page=%d,slot=%d}",
+		 first_header.chunk_index, OID_AS_ARGS (&oid));
+      assert (first_header.chunk_index == 0);
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
+      return ER_GENERIC_ERROR;
+    }
 
   /* Validate the on-disk OOS header length against the caller-provided length.
    * Disagreement means the inline length and the OOS chain disagree, which is

--- a/src/storage/oos_file.cpp
+++ b/src/storage/oos_file.cpp
@@ -1145,9 +1145,12 @@ oos_insert_across_pages (THREAD_ENTRY *thread_p, const VFID &oos_vfid, oos_buffe
   // this loop inserts chunks in reverse order so that next_chunk_oid is always known
   for (int i = required_page_nums - 1; i >= 0; --i)
     {
-      const int chunk_len = std::min (max_chunk_size, total_data_length - i * max_chunk_size);
-      oos_buffer chunk (src.data () + i * max_chunk_size, static_cast<std::size_t> (chunk_len));
-      total_inserted_length += chunk_len;
+      // subspan handles both bounds checking (assert offset <= size) and tail
+      // clamping (count > remaining clamps to remaining), so the final chunk's
+      // shorter length falls out for free.
+      oos_buffer chunk = src.subspan (static_cast<std::size_t> (i * max_chunk_size),
+				      static_cast<std::size_t> (max_chunk_size));
+      total_inserted_length += static_cast<int> (chunk.size ());
 
       // Keep total_data_length in each chunk so the log applier can validate all pieces before reassembly.
       OOS_RECORD_HEADER header{total_data_length, i, next_chunk_oid};
@@ -1156,7 +1159,7 @@ oos_insert_across_pages (THREAD_ENTRY *thread_p, const VFID &oos_vfid, oos_buffe
       error_code = oos_insert_within_page (thread_p, oos_vfid, chunk, header, current_chunk_oid);
       if (error_code != NO_ERROR)
 	{
-	  oos_error ("could not insert chunk index=%d of length %d.", i, chunk_len);
+	  oos_error ("could not insert chunk index=%d of length %zu.", i, chunk.size ());
 	  assert_release_error (er_errid () != NO_ERROR);
 	  // Partially inserted chunks are cleaned up when the caller aborts the transaction
 	  // (individual undo records replay in reverse). The caller MUST NOT continue

--- a/src/storage/oos_file.cpp
+++ b/src/storage/oos_file.cpp
@@ -1120,9 +1120,20 @@ oos_insert_across_pages (THREAD_ENTRY *thread_p, const VFID &oos_vfid, oos_buffe
   // split the payload to multiple chunks and insert them one by one
   const int max_chunk_size = oos_get_max_chunk_size_within_page ();
   const int total_data_length = static_cast<int> (src.size ());
-  assert (total_data_length + OOS_RECORD_HEADER_SIZE > max_chunk_size);
+  /* Equivalent to total_data_length + OOS_RECORD_HEADER_SIZE > max_chunk_size
+   * but rewritten without addition on total_data_length: with the INT_MAX
+   * upper bound at oos_insert's entry guard, the addition form would overflow
+   * for payloads near INT_MAX (signed overflow is UB). */
+  assert (total_data_length > max_chunk_size - OOS_RECORD_HEADER_SIZE);
 
-  int required_page_nums = (total_data_length + max_chunk_size - 1) / max_chunk_size;
+  /* Ceil division without `(total + max - 1) / max`, which overflows int when
+   * total_data_length is close to INT_MAX. The split-form below uses only one
+   * division and one modulo on values already bounded by total_data_length. */
+  int required_page_nums = total_data_length / max_chunk_size;
+  if (total_data_length % max_chunk_size != 0)
+    {
+      ++required_page_nums;
+    }
   assert (required_page_nums > 1);
 
   int total_inserted_length = 0;

--- a/src/storage/oos_file.cpp
+++ b/src/storage/oos_file.cpp
@@ -1259,6 +1259,7 @@ oos_read_within_page (THREAD_ENTRY *thread_p, const OID &oid, char *buf_out, int
   PAGE_PTR page_ptr = pgbuf_fix (thread_p, &vpid, OLD_PAGE, PGBUF_LATCH_READ, PGBUF_UNCONDITIONAL_LATCH);
   if (page_ptr == nullptr)
     {
+      oos_error ("pgbuf_fix failed at oid={vol=%d,page=%d,slot=%d}", OID_AS_ARGS (&oid));
       assert_release_error (er_errid () != NO_ERROR);
       return er_errid ();
     }
@@ -1271,7 +1272,7 @@ oos_read_within_page (THREAD_ENTRY *thread_p, const OID &oid, char *buf_out, int
   SCAN_CODE code = spage_get_record (thread_p, page_ptr, slotid, &oos_recdes, PEEK);
   if (code != S_SUCCESS)
     {
-      oos_error ("spage_get_record failed (code=%d) at oid={%d,%d,%d}", (int) code, OID_AS_ARGS (&oid));
+      oos_error ("spage_get_record failed (code=%d) at oid={vol=%d,page=%d,slot=%d}", (int) code, OID_AS_ARGS (&oid));
       /* Some SCAN_CODE failures leave er_errid()==NO_ERROR; ensure caller observes an error. */
       if (er_errid () == NO_ERROR)
 	{
@@ -1282,7 +1283,8 @@ oos_read_within_page (THREAD_ENTRY *thread_p, const OID &oid, char *buf_out, int
 
   if (oos_recdes.length < OOS_RECORD_HEADER_SIZE)
     {
-      oos_error ("OOS slot smaller than header (len=%d) at oid={%d,%d,%d}", oos_recdes.length, OID_AS_ARGS (&oid));
+      oos_error ("OOS slot smaller than header (len=%d) at oid={vol=%d,page=%d,slot=%d}",
+		 oos_recdes.length, OID_AS_ARGS (&oid));
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
       return ER_GENERIC_ERROR;
     }
@@ -1292,7 +1294,7 @@ oos_read_within_page (THREAD_ENTRY *thread_p, const OID &oid, char *buf_out, int
   const int payload_len = oos_recdes.length - OOS_RECORD_HEADER_SIZE;
   if (payload_len > buf_cap)
     {
-      oos_error ("OOS chunk overflows caller buffer (payload=%d, cap=%d) at oid={%d,%d,%d}",
+      oos_error ("OOS chunk overflows caller buffer (payload=%d, cap=%d) at oid={vol=%d,page=%d,slot=%d}",
 		 payload_len, buf_cap, OID_AS_ARGS (&oid));
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
       return ER_GENERIC_ERROR;
@@ -1327,12 +1329,12 @@ oos_read_across_pages (THREAD_ENTRY *thread_p, const OID &next_oid,
       assert (idx == header.chunk_index);
       assert (header.total_data_length == total_data_length);
 
-      /* A 0-byte chunk would not advance bytes_written; combined with a corrupt
-       * cyclic next_chunk_oid it would loop forever. Production never produces
-       * empty chunks, so an empty chunk implies on-disk corruption. */
+      /* Empty-chunk guard: a 0-byte chunk does not advance bytes_written, so a
+       * corrupt cyclic next_chunk_oid would loop forever. Production never
+       * emits empty chunks; treat as on-disk corruption. */
       if (chunk_bytes == 0)
 	{
-	  oos_error ("OOS empty chunk at idx=%d", idx);
+	  oos_error ("OOS empty chunk at idx=%d, oid={vol=%d,page=%d,slot=%d}", idx, OID_AS_ARGS (&current));
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
 	  return ER_GENERIC_ERROR;
 	}
@@ -1352,20 +1354,12 @@ oos_read_across_pages (THREAD_ENTRY *thread_p, const OID &next_oid,
 }
 
 
-/* oos_read -
+/* oos_read - Read an OOS value into a caller-preallocated buffer.
  *
- * Read an OOS value into a caller-preallocated buffer.
- *
- *   oid(in):        first-chunk OOS OID
- *   recdes(in/out): caller owns recdes.data and sets recdes.area_size to the
- *                   expected full length (from the inline 8B length stored in
- *                   the heap record since M2). On success, recdes.length is set
- *                   to that same value.
- *
- * The caller-provided length (recdes.area_size) is the source of truth. The
- * on-disk OOS header's total_data_length is checked against it only as a
- * cross-validation; a mismatch indicates corruption and is reported as an
- * error.
+ * Caller owns recdes.data; recdes.area_size is the authoritative expected
+ * length (sourced from the inline length in the heap record since M2). On
+ * success, recdes.length is set to that same value. The on-disk OOS header's
+ * total_data_length is cross-validated; disagreement is treated as corruption.
  */
 int
 oos_read (THREAD_ENTRY *thread_p, const OID &oid, RECDES &recdes)
@@ -1391,7 +1385,7 @@ oos_read (THREAD_ENTRY *thread_p, const OID &oid, RECDES &recdes)
    * on-disk corruption. */
   if (first_header.total_data_length != expected_length)
     {
-      oos_error ("OOS length mismatch: caller=%d header=%d at oid={%d,%d,%d}",
+      oos_error ("OOS length mismatch: caller=%d header=%d at oid={vol=%d,page=%d,slot=%d}",
 		 expected_length, first_header.total_data_length, OID_AS_ARGS (&oid));
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
       return ER_GENERIC_ERROR;
@@ -1407,7 +1401,13 @@ oos_read (THREAD_ENTRY *thread_p, const OID &oid, RECDES &recdes)
 	}
     }
 
-  assert (bytes_written == expected_length);
+  if (bytes_written != expected_length)
+    {
+      oos_error ("OOS final length mismatch: written=%d expected=%d at oid={vol=%d,page=%d,slot=%d}",
+		 bytes_written, expected_length, OID_AS_ARGS (&oid));
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
+      return ER_GENERIC_ERROR;
+    }
   recdes.length = expected_length;
   return NO_ERROR;
 }

--- a/src/storage/oos_file.cpp
+++ b/src/storage/oos_file.cpp
@@ -1308,7 +1308,8 @@ oos_read_within_page (THREAD_ENTRY *thread_p, const OID &oid, char *buf_out, int
 
 static int
 oos_read_across_pages (THREAD_ENTRY *thread_p, const OID &next_oid,
-		       int total_data_length, RECDES &recdes, int &bytes_written)
+		       int total_data_length, RECDES &recdes,
+		       int &remaining, int &bytes_written)
 {
   assert (recdes.data != nullptr && recdes.area_size >= total_data_length);
 
@@ -1319,7 +1320,6 @@ oos_read_across_pages (THREAD_ENTRY *thread_p, const OID &next_oid,
       OOS_RECORD_HEADER header;
       int chunk_bytes = 0;
       char *dest = recdes.data + bytes_written;
-      int remaining = total_data_length - bytes_written;
 
       int err = oos_read_within_page (thread_p, current, dest, remaining, header, chunk_bytes);
       if (err != NO_ERROR)
@@ -1340,6 +1340,7 @@ oos_read_across_pages (THREAD_ENTRY *thread_p, const OID &next_oid,
 	}
 
       bytes_written += chunk_bytes;
+      remaining -= chunk_bytes;
       current = header.next_chunk_oid;
       idx++;
     }
@@ -1370,13 +1371,18 @@ oos_read (THREAD_ENTRY *thread_p, const OID &oid, RECDES &recdes)
 
   OOS_RECORD_HEADER first_header;
   int bytes_written = 0;
+  /* buf_cap semantics = remaining buffer capacity at the write offset; track
+   * it explicitly so first-chunk and subsequent-chunk reads use the same
+   * "remaining" contract. */
+  int remaining = expected_length;
 
-  int err = oos_read_within_page (thread_p, oid, recdes.data, expected_length,
+  int err = oos_read_within_page (thread_p, oid, recdes.data, remaining,
 				  first_header, bytes_written);
   if (err != NO_ERROR)
     {
       return err;
     }
+  remaining -= bytes_written;
 
   assert (first_header.chunk_index == 0);
 
@@ -1394,7 +1400,7 @@ oos_read (THREAD_ENTRY *thread_p, const OID &oid, RECDES &recdes)
   if (!OID_ISNULL (&first_header.next_chunk_oid))
     {
       err = oos_read_across_pages (thread_p, first_header.next_chunk_oid,
-				   expected_length, recdes, bytes_written);
+				   expected_length, recdes, remaining, bytes_written);
       if (err != NO_ERROR)
 	{
 	  return err;

--- a/src/storage/oos_file.cpp
+++ b/src/storage/oos_file.cpp
@@ -1054,10 +1054,7 @@ oos_insert (THREAD_ENTRY *thread_p, const VFID &oos_vfid, oos_buffer src, OID &o
   assert (src.data () != nullptr);
   assert (src.size () > 0);
 
-  /* Runtime guard for the narrowing cast below. Asserts above catch programmer
-   * bugs in dev; this check catches corrupt callers (e.g. a truncated
-   * replication log record producing a wrap-around size_t in locator_sr.c)
-   * before they reach chunk-count math or oos_prepend_header. */
+  /* Guards the narrowing cast below against wrap-around from a corrupt caller. */
   if (src.data () == nullptr || src.size () == 0 || src.size () > (std::size_t) INT_MAX)
     {
       oos_error ("oos_insert rejected invalid src (data=%p, size=%zu)", src.data (), src.size ());
@@ -1120,15 +1117,10 @@ oos_insert_across_pages (THREAD_ENTRY *thread_p, const VFID &oos_vfid, oos_buffe
   // split the payload to multiple chunks and insert them one by one
   const int max_chunk_size = oos_get_max_chunk_size_within_page ();
   const int total_data_length = static_cast<int> (src.size ());
-  /* Equivalent to total_data_length + OOS_RECORD_HEADER_SIZE > max_chunk_size
-   * but rewritten without addition on total_data_length: with the INT_MAX
-   * upper bound at oos_insert's entry guard, the addition form would overflow
-   * for payloads near INT_MAX (signed overflow is UB). */
+  /* Both expressions below are rewritten to avoid adding to total_data_length,
+   * which can be near INT_MAX (entry-guard bound) and would signed-overflow. */
   assert (total_data_length > max_chunk_size - OOS_RECORD_HEADER_SIZE);
 
-  /* Ceil division without `(total + max - 1) / max`, which overflows int when
-   * total_data_length is close to INT_MAX. The split-form below uses only one
-   * division and one modulo on values already bounded by total_data_length. */
   int required_page_nums = total_data_length / max_chunk_size;
   if (total_data_length % max_chunk_size != 0)
     {
@@ -1167,9 +1159,7 @@ oos_insert_across_pages (THREAD_ENTRY *thread_p, const VFID &oos_vfid, oos_buffe
   // this loop inserts chunks in reverse order so that next_chunk_oid is always known
   for (int i = required_page_nums - 1; i >= 0; --i)
     {
-      // subspan handles both bounds checking (assert offset <= size) and tail
-      // clamping (count > remaining clamps to remaining), so the final chunk's
-      // shorter length falls out for free.
+      // subspan clamps count to the remaining size, so the tail chunk's shorter length is automatic.
       oos_buffer chunk = src.subspan (static_cast<std::size_t> (i * max_chunk_size),
 				      static_cast<std::size_t> (max_chunk_size));
       total_inserted_length += static_cast<int> (chunk.size ());
@@ -1307,9 +1297,7 @@ oos_read_within_page (THREAD_ENTRY *thread_p, const OID &oid,
       return er_errid ();
     }
 
-  /* Writer-side invariant: every OOS slot carries at least the chain header.
-   * A shorter slot indicates a writer bug; keep the runtime guard for release
-   * builds to catch genuine on-disk corruption safely. */
+  /* Every OOS slot carries at least the chain header; shorter is on-disk corruption. */
   assert (oos_recdes.length >= OOS_RECORD_HEADER_SIZE);
   if (oos_recdes.length < OOS_RECORD_HEADER_SIZE)
     {
@@ -1350,25 +1338,19 @@ oos_read_across_pages (THREAD_ENTRY *thread_p, const OID &next_oid,
 	  return err;
 	}
 
-      /* Chain invariants: chunk_index must increment monotonically from 1, and
-       * every chunk's total_data_length must agree with the head. A mismatch
-       * means next_chunk_oid points outside the chain (corruption) or chunks
-       * are reordered. Asserts catch writer bugs in dev; the runtime check
-       * prevents release builds from silently returning a misassembled value. */
+      /* chunk_index must increment from 1 and total_data_length must match the head. */
+      assert (idx == header.chunk_index);
+      assert (header.total_data_length == total_data_length);
       if (idx != header.chunk_index || header.total_data_length != total_data_length)
 	{
 	  oos_error ("OOS chain inconsistency at idx=%d: header.chunk_index=%d, header.total_data_length=%d,"
 		     " expected_total=%d at oid={vol=%d,page=%d,slot=%d}",
 		     idx, header.chunk_index, header.total_data_length, total_data_length, OID_AS_ARGS (&current));
-	  assert (idx == header.chunk_index);
-	  assert (header.total_data_length == total_data_length);
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
 	  return ER_GENERIC_ERROR;
 	}
 
-      /* Empty-chunk guard: a 0-byte chunk does not advance the writer, so a
-       * corrupt cyclic next_chunk_oid would loop forever. Production never
-       * emits empty chunks; treat as on-disk corruption. */
+      /* A 0-byte chunk would let a cyclic next_chunk_oid loop forever. */
       if (writer.written () == before)
 	{
 	  oos_error ("OOS empty chunk at idx=%d, oid={vol=%d,page=%d,slot=%d}", idx, OID_AS_ARGS (&current));
@@ -1383,17 +1365,9 @@ oos_read_across_pages (THREAD_ENTRY *thread_p, const OID &next_oid,
 }
 
 
-/* oos_read - Read an OOS value into a caller-owned span.
- *
- * dest.size() is the authoritative expected payload length. The caller has
- * already obtained it (typically from the inline 8B length in the heap record
- * or from oos_get_length in test contexts) and sized the span accordingly.
- * The on-disk OOS header's total_data_length is cross-validated against
- * dest.size(); disagreement is treated as on-disk corruption.
- *
- * The writer's bounds check is the last line of defense against an inflated
- * payload_len on disk: see byte_span_writer.hpp.
- */
+/* Cross-validates dest.size() against the chain header's total_data_length;
+ * mismatch (corruption) is rejected. byte_span_writer guards each chunk
+ * against payload_len overflow inside the loop. */
 int
 oos_read (THREAD_ENTRY *thread_p, const OID &oid, oos_buffer dest)
 {
@@ -1410,22 +1384,17 @@ oos_read (THREAD_ENTRY *thread_p, const OID &oid, oos_buffer dest)
       return err;
     }
 
-  /* The caller's OID must point at the chain head (chunk_index == 0). If a
-   * corrupted heap inline OID points at a mid-chain chunk, that chunk's own
-   * total_data_length / next_chunk_oid would otherwise be accepted as a valid
-   * (but wrong) value. Runtime check so release builds reject corruption. */
+  /* Caller's OID must be the chain head; mid-chain target = corrupted inline OID. */
+  assert (first_header.chunk_index == 0);
   if (first_header.chunk_index != 0)
     {
       oos_error ("OOS read at non-head chunk: chunk_index=%d at oid={vol=%d,page=%d,slot=%d}",
 		 first_header.chunk_index, OID_AS_ARGS (&oid));
-      assert (first_header.chunk_index == 0);
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
       return ER_GENERIC_ERROR;
     }
 
-  /* Validate the on-disk OOS header length against the caller-provided length.
-   * Disagreement means the inline length and the OOS chain disagree, which is
-   * on-disk corruption. */
+  /* Inline length (dest.size()) and chain header must agree. */
   if (first_header.total_data_length != expected_length)
     {
       oos_error ("OOS length mismatch: caller=%d header=%d at oid={vol=%d,page=%d,slot=%d}",

--- a/src/storage/oos_file.cpp
+++ b/src/storage/oos_file.cpp
@@ -1282,6 +1282,10 @@ oos_read_within_page (THREAD_ENTRY *thread_p, const OID &oid, char *buf_out, int
       return er_errid ();
     }
 
+  /* Writer-side invariant: every OOS slot carries at least the chain header.
+   * A shorter slot indicates a writer bug; keep the runtime guard for release
+   * builds to catch genuine on-disk corruption safely. */
+  assert (oos_recdes.length >= OOS_RECORD_HEADER_SIZE);
   if (oos_recdes.length < OOS_RECORD_HEADER_SIZE)
     {
       oos_error ("OOS slot smaller than header (len=%d) at oid={vol=%d,page=%d,slot=%d}",

--- a/src/storage/oos_file.cpp
+++ b/src/storage/oos_file.cpp
@@ -52,11 +52,11 @@ static int
 oos_insert_across_pages (THREAD_ENTRY *thread_p, const VFID &oos_vfid, RECDES &recdes,
 			 OID &oid);
 static int
-oos_read_within_page (THREAD_ENTRY *thread_p, const OID &oid, RECDES &recdes,
-		      OOS_RECORD_HEADER &out_header);
+oos_read_within_page (THREAD_ENTRY *thread_p, const OID &oid, char *buf_out, int buf_cap,
+		      OOS_RECORD_HEADER &header_out, int &chunk_bytes_out);
 static int
-oos_read_across_pages (THREAD_ENTRY *thread_p, const OID &oid, RECDES &recdes,
-		       OOS_RECORD_HEADER &out_header);
+oos_read_across_pages (THREAD_ENTRY *thread_p, const OID &next_oid,
+		       int total_data_length, RECDES &recdes, int &bytes_written);
 static void
 oos_log_insert_physical (THREAD_ENTRY *thread_p, PAGE_PTR page_p, VFID *vfid_p, OID *oid_p, RECDES *recdes_p);
 static void
@@ -1042,32 +1042,6 @@ oos_prepend_header (const RECDES &recdes, const OOS_RECORD_HEADER &oos_header, O
 }
 
 
-static int
-oos_strip_header (const OOS_RECDES &oos_recdes, OOS_RECORD_HEADER &header_out, RECDES &recdes)
-{
-  assert (oos_recdes.length >= (int)sizeof (OOS_RECORD_HEADER));
-  assert (&oos_recdes != &recdes);
-
-  int err;
-
-  err = recdes_allocate_data_area (&recdes, oos_recdes.length - (int)sizeof (OOS_RECORD_HEADER));
-  if (err != NO_ERROR)
-    {
-      oos_error ("recdes_allocate_data_area failed");
-      assert_release_error (er_errid () != NO_ERROR);
-      assert (false);
-      return err;
-    }
-
-  recdes.type = REC_HOME;
-  recdes.length = oos_recdes.length - (int)sizeof (OOS_RECORD_HEADER);
-  std::memcpy (&header_out, oos_recdes.data, (int)sizeof (OOS_RECORD_HEADER));
-  std::memcpy (recdes.data, oos_recdes.data + (int)sizeof (OOS_RECORD_HEADER), recdes.length);
-
-  return NO_ERROR;
-}
-
-
 int
 oos_insert (THREAD_ENTRY *thread_p, const VFID &oos_vfid, RECDES &recdes, OID &oid)
 {
@@ -1276,90 +1250,18 @@ oos_insert_within_page (THREAD_ENTRY *thread_p, const VFID &oos_vfid, RECDES &re
 
 
 static int
-oos_read_across_pages (THREAD_ENTRY *thread_p, const OID &oid,
-		       const OOS_RECORD_HEADER &first_chunk_header, RECDES &recdes)
+oos_read_within_page (THREAD_ENTRY *thread_p, const OID &oid, char *buf_out, int buf_cap,
+		      OOS_RECORD_HEADER &header_out, int &chunk_bytes_out)
 {
-  int err = NO_ERROR;
-  const int total_data_length = first_chunk_header.total_data_length;
-  assert (first_chunk_header.chunk_index == 0);
-
-  assert (total_data_length > oos_get_max_chunk_size_within_page ());
-  oos_trace ("total_data_length=%d", total_data_length);
-
-  err = recdes_allocate_data_area (&recdes, total_data_length);
-  if (err != NO_ERROR)
-    {
-      oos_error ("recdes_allocate_data_area failed in oos_read_across_pages, total_data_length=%d", total_data_length);
-      assert_release_error (er_errid () != NO_ERROR);
-      assert (false);
-      return err;
-    }
-
-  recdes.type = REC_HOME;
-  recdes.length = total_data_length;
-
-  int idx = 0;
-  OID current_chunk_oid = oid;
-  char *buf = recdes.data;
-  int total_read_length = 0;
-  while (current_chunk_oid.pageid != NULL_PAGEID)
-    {
-      OOS_RECORD_HEADER header;
-      RECDES chunk_recdes;
-      {
-	int err = oos_read_within_page (thread_p, current_chunk_oid, chunk_recdes, header);
-	if (err != NO_ERROR)
-	  {
-	    oos_error ("oos_read_within_page failed for chunk index=%d", idx);
-	    assert_release_error (er_errid () != NO_ERROR);
-	    assert (false);
-	    recdes_free_data_area (&recdes);
-	    return err;
-	  }
-
-	scope_exit defer_free_chunk_recdes ([&]()
-	{
-	  recdes_free_data_area (&chunk_recdes);
-	});
-
-	assert (idx == header.chunk_index);
-	assert (total_data_length == header.total_data_length);
-
-	total_read_length += chunk_recdes.length;
-	std::memcpy (buf, chunk_recdes.data, chunk_recdes.length);
-	buf += chunk_recdes.length;
-
-	current_chunk_oid = header.next_chunk_oid;
-      }
-      assert (chunk_recdes.data == nullptr); // should be freed by scope_exit
-
-      idx++;
-    }
-
-  assert (total_read_length == total_data_length);
-  assert (buf == total_data_length + recdes.data);
-
-  return NO_ERROR;
-}
-
-
-static int
-oos_read_within_page (THREAD_ENTRY *thread_p, const OID &oid, RECDES &recdes,
-		      OOS_RECORD_HEADER &header_out)
-{
-  int err = NO_ERROR;
   const auto [pageid, slotid, volid] = oid;
   auto vpid = VPID{pageid, volid};
 
   PAGE_PTR page_ptr = pgbuf_fix (thread_p, &vpid, OLD_PAGE, PGBUF_LATCH_READ, PGBUF_UNCONDITIONAL_LATCH);
   if (page_ptr == nullptr)
     {
-      oos_error ("oos_read_within_page: pgbuf_fix failed for volid=%d, pageid=%d", volid, pageid);
       assert_release_error (er_errid () != NO_ERROR);
-      assert (false);
       return er_errid ();
     }
-
   scope_exit page_unfixer ([&]()
   {
     pgbuf_unfix_and_init_after_check (thread_p, page_ptr);
@@ -1369,78 +1271,144 @@ oos_read_within_page (THREAD_ENTRY *thread_p, const OID &oid, RECDES &recdes,
   SCAN_CODE code = spage_get_record (thread_p, page_ptr, slotid, &oos_recdes, PEEK);
   if (code != S_SUCCESS)
     {
-      oos_error ("oos_read_within_page: spage_get_record failed for volid=%d, pageid=%d, slotid=%d",
-		 volid, pageid, slotid);
+      oos_error ("spage_get_record failed (code=%d) at oid={%d,%d,%d}", (int) code, OID_AS_ARGS (&oid));
+      /* Some SCAN_CODE failures leave er_errid()==NO_ERROR; ensure caller observes an error. */
+      if (er_errid () == NO_ERROR)
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
+	}
+      return er_errid ();
+    }
+
+  if (oos_recdes.length < OOS_RECORD_HEADER_SIZE)
+    {
+      oos_error ("OOS slot smaller than header (len=%d) at oid={%d,%d,%d}", oos_recdes.length, OID_AS_ARGS (&oid));
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
       return ER_GENERIC_ERROR;
     }
 
-  // TODO: Ensure OOS_RECORD_HEADER always fits within a single page
+  std::memcpy (&header_out, oos_recdes.data, OOS_RECORD_HEADER_SIZE);
 
-  err = oos_strip_header (oos_recdes, header_out, recdes);
-  if (err != NO_ERROR)
+  const int payload_len = oos_recdes.length - OOS_RECORD_HEADER_SIZE;
+  if (payload_len > buf_cap)
     {
-      oos_error ("oos_strip_header failed for volid=%d, pageid=%d, slotid=%d",
-		 volid, pageid, slotid);
-      assert_release_error (er_errid () != NO_ERROR);
-      assert (false);
-      return err;
+      oos_error ("OOS chunk overflows caller buffer (payload=%d, cap=%d) at oid={%d,%d,%d}",
+		 payload_len, buf_cap, OID_AS_ARGS (&oid));
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
+      return ER_GENERIC_ERROR;
     }
 
+  std::memcpy (buf_out, oos_recdes.data + OOS_RECORD_HEADER_SIZE, payload_len);
+  chunk_bytes_out = payload_len;
+  return NO_ERROR;
+}
+
+
+static int
+oos_read_across_pages (THREAD_ENTRY *thread_p, const OID &next_oid,
+		       int total_data_length, RECDES &recdes, int &bytes_written)
+{
+  assert (recdes.data != nullptr && recdes.area_size >= total_data_length);
+
+  int idx = 1;
+  OID current = next_oid;
+  while (!OID_ISNULL (&current))
+    {
+      OOS_RECORD_HEADER header;
+      int chunk_bytes = 0;
+      char *dest = recdes.data + bytes_written;
+      int remaining = total_data_length - bytes_written;
+
+      int err = oos_read_within_page (thread_p, current, dest, remaining, header, chunk_bytes);
+      if (err != NO_ERROR)
+	{
+	  return err;
+	}
+      assert (idx == header.chunk_index);
+      assert (header.total_data_length == total_data_length);
+
+      /* A 0-byte chunk would not advance bytes_written; combined with a corrupt
+       * cyclic next_chunk_oid it would loop forever. Production never produces
+       * empty chunks, so an empty chunk implies on-disk corruption. */
+      if (chunk_bytes == 0)
+	{
+	  oos_error ("OOS empty chunk at idx=%d", idx);
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
+	  return ER_GENERIC_ERROR;
+	}
+
+      bytes_written += chunk_bytes;
+      current = header.next_chunk_oid;
+      idx++;
+    }
+
+  if (bytes_written != total_data_length)
+    {
+      oos_error ("OOS short read: written=%d expected=%d", bytes_written, total_data_length);
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
+      return ER_GENERIC_ERROR;
+    }
   return NO_ERROR;
 }
 
 
 /* oos_read -
  *
- * return:
+ * Read an OOS value into a caller-preallocated buffer.
  *
- *   oos_vfid(in):
- *   oid(in):
- *   recdes(out):
+ *   oid(in):        first-chunk OOS OID
+ *   recdes(in/out): caller owns recdes.data and sets recdes.area_size to the
+ *                   expected full length (from the inline 8B length stored in
+ *                   the heap record since M2). On success, recdes.length is set
+ *                   to that same value.
  *
- *   important notes: recdes.data is allocated inside this function.
- *   It sholud be freed by the caller using recdes_free_data_area().
+ * The caller-provided length (recdes.area_size) is the source of truth. The
+ * on-disk OOS header's total_data_length is checked against it only as a
+ * cross-validation; a mismatch indicates corruption and is reported as an
+ * error.
  */
 int
 oos_read (THREAD_ENTRY *thread_p, const OID &oid, RECDES &recdes)
 {
-  oos_debug ("reading from oid={vol=%d,page=%d,slot=%d}", OID_AS_ARGS (&oid));
+  assert (recdes.data != nullptr && recdes.area_size > 0);
 
-  int err = NO_ERROR;
+  const int expected_length = recdes.area_size;
 
-  // try reading just one slot
-  OOS_RECORD_HEADER first_chunk_header;
-  RECDES first_chunk_recdes;
+  OOS_RECORD_HEADER first_header;
+  int bytes_written = 0;
 
-  err = oos_read_within_page (thread_p, oid, first_chunk_recdes, first_chunk_header);
+  int err = oos_read_within_page (thread_p, oid, recdes.data, expected_length,
+				  first_header, bytes_written);
   if (err != NO_ERROR)
     {
-      oos_error ("oos_read_within_page failed");
       return err;
     }
 
-  // check if we need to read all the chunks
-  if (first_chunk_header.next_chunk_oid.slotid != NULL_SLOTID)
+  assert (first_header.chunk_index == 0);
+
+  /* Validate the on-disk OOS header length against the caller-provided length.
+   * Disagreement means the inline length and the OOS chain disagree, which is
+   * on-disk corruption. */
+  if (first_header.total_data_length != expected_length)
     {
-      err = oos_read_across_pages (thread_p, oid, first_chunk_header, recdes);
-      // CASE 1: we do not need first_chunk_recdes anymore
-      recdes_free_data_area (&first_chunk_recdes);
+      oos_error ("OOS length mismatch: caller=%d header=%d at oid={%d,%d,%d}",
+		 expected_length, first_header.total_data_length, OID_AS_ARGS (&oid));
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
+      return ER_GENERIC_ERROR;
+    }
+
+  if (!OID_ISNULL (&first_header.next_chunk_oid))
+    {
+      err = oos_read_across_pages (thread_p, first_header.next_chunk_oid,
+				   expected_length, recdes, bytes_written);
       if (err != NO_ERROR)
 	{
-	  oos_error ("oos_read_across_pages failed");
-	  assert_release_error (er_errid () != NO_ERROR);
-	  assert (false);
 	  return err;
 	}
     }
-  else
-    {
-      // CASE 2: we use first_chunk_recdes as the final output
-      recdes = std::move (first_chunk_recdes);
-    }
-  oos_trace ("read completed, total_data_length=%d", first_chunk_header.total_data_length);
 
+  assert (bytes_written == expected_length);
+  recdes.length = expected_length;
   return NO_ERROR;
 }
 

--- a/src/storage/oos_file.cpp
+++ b/src/storage/oos_file.cpp
@@ -18,6 +18,7 @@
 
 #include <cassert>
 #include <cstring>
+#include "byte_span_writer.hpp"
 #include "error_code.h"
 #include "error_manager.h"
 #include "file_manager.h"
@@ -52,12 +53,11 @@ static int
 oos_insert_across_pages (THREAD_ENTRY *thread_p, const VFID &oos_vfid, RECDES &recdes,
 			 OID &oid);
 static int
-oos_read_within_page (THREAD_ENTRY *thread_p, const OID &oid, char *buf_out, int buf_cap,
-		      OOS_RECORD_HEADER &header_out, int &chunk_bytes_out);
+oos_read_within_page (THREAD_ENTRY *thread_p, const OID &oid,
+		      cubbase::byte_span_writer &writer, OOS_RECORD_HEADER &header_out);
 static int
 oos_read_across_pages (THREAD_ENTRY *thread_p, const OID &next_oid,
-		       int total_data_length, RECDES &recdes,
-		       int &remaining, int &bytes_written);
+		       int total_data_length, cubbase::byte_span_writer &writer);
 static void
 oos_log_insert_physical (THREAD_ENTRY *thread_p, PAGE_PTR page_p, VFID *vfid_p, OID *oid_p, RECDES *recdes_p);
 static void
@@ -1251,8 +1251,8 @@ oos_insert_within_page (THREAD_ENTRY *thread_p, const VFID &oos_vfid, RECDES &re
 
 
 static int
-oos_read_within_page (THREAD_ENTRY *thread_p, const OID &oid, char *buf_out, int buf_cap,
-		      OOS_RECORD_HEADER &header_out, int &chunk_bytes_out)
+oos_read_within_page (THREAD_ENTRY *thread_p, const OID &oid,
+		      cubbase::byte_span_writer &writer, OOS_RECORD_HEADER &header_out)
 {
   const auto [pageid, slotid, volid] = oid;
   auto vpid = VPID{pageid, volid};
@@ -1297,36 +1297,29 @@ oos_read_within_page (THREAD_ENTRY *thread_p, const OID &oid, char *buf_out, int
   std::memcpy (&header_out, oos_recdes.data, OOS_RECORD_HEADER_SIZE);
 
   const int payload_len = oos_recdes.length - OOS_RECORD_HEADER_SIZE;
-  if (payload_len > buf_cap)
+  if (!writer.append (oos_recdes.data + OOS_RECORD_HEADER_SIZE, static_cast<std::size_t> (payload_len)))
     {
-      oos_error ("OOS chunk overflows caller buffer (payload=%d, cap=%d) at oid={vol=%d,page=%d,slot=%d}",
-		 payload_len, buf_cap, OID_AS_ARGS (&oid));
+      oos_error ("OOS chunk overflows caller buffer (payload=%d, remaining=%zu) at oid={vol=%d,page=%d,slot=%d}",
+		 payload_len, writer.remaining (), OID_AS_ARGS (&oid));
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
       return ER_GENERIC_ERROR;
     }
-
-  std::memcpy (buf_out, oos_recdes.data + OOS_RECORD_HEADER_SIZE, payload_len);
-  chunk_bytes_out = payload_len;
   return NO_ERROR;
 }
 
 
 static int
 oos_read_across_pages (THREAD_ENTRY *thread_p, const OID &next_oid,
-		       int total_data_length, RECDES &recdes,
-		       int &remaining, int &bytes_written)
+		       int total_data_length, cubbase::byte_span_writer &writer)
 {
-  assert (recdes.data != nullptr && recdes.area_size >= total_data_length);
-
   int idx = 1;
   OID current = next_oid;
   while (!OID_ISNULL (&current))
     {
       OOS_RECORD_HEADER header;
-      int chunk_bytes = 0;
-      char *dest = recdes.data + bytes_written;
+      const std::size_t before = writer.written ();
 
-      int err = oos_read_within_page (thread_p, current, dest, remaining, header, chunk_bytes);
+      int err = oos_read_within_page (thread_p, current, writer, header);
       if (err != NO_ERROR)
 	{
 	  return err;
@@ -1334,60 +1327,49 @@ oos_read_across_pages (THREAD_ENTRY *thread_p, const OID &next_oid,
       assert (idx == header.chunk_index);
       assert (header.total_data_length == total_data_length);
 
-      /* Empty-chunk guard: a 0-byte chunk does not advance bytes_written, so a
+      /* Empty-chunk guard: a 0-byte chunk does not advance the writer, so a
        * corrupt cyclic next_chunk_oid would loop forever. Production never
        * emits empty chunks; treat as on-disk corruption. */
-      if (chunk_bytes == 0)
+      if (writer.written () == before)
 	{
 	  oos_error ("OOS empty chunk at idx=%d, oid={vol=%d,page=%d,slot=%d}", idx, OID_AS_ARGS (&current));
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
 	  return ER_GENERIC_ERROR;
 	}
 
-      bytes_written += chunk_bytes;
-      remaining -= chunk_bytes;
       current = header.next_chunk_oid;
       idx++;
-    }
-
-  if (bytes_written != total_data_length)
-    {
-      oos_error ("OOS short read: written=%d expected=%d", bytes_written, total_data_length);
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
-      return ER_GENERIC_ERROR;
     }
   return NO_ERROR;
 }
 
 
-/* oos_read - Read an OOS value into a caller-preallocated buffer.
+/* oos_read - Read an OOS value into a caller-owned span.
  *
- * Caller owns recdes.data; recdes.area_size is the authoritative expected
- * length (sourced from the inline length in the heap record since M2). On
- * success, recdes.length is set to that same value. The on-disk OOS header's
- * total_data_length is cross-validated; disagreement is treated as corruption.
+ * dest.size() is the authoritative expected payload length. The caller has
+ * already obtained it (typically from the inline 8B length in the heap record
+ * or from oos_get_length in test contexts) and sized the span accordingly.
+ * The on-disk OOS header's total_data_length is cross-validated against
+ * dest.size(); disagreement is treated as on-disk corruption.
+ *
+ * The writer's bounds check is the last line of defense against an inflated
+ * payload_len on disk: see byte_span_writer.hpp.
  */
 int
-oos_read (THREAD_ENTRY *thread_p, const OID &oid, RECDES &recdes)
+oos_read (THREAD_ENTRY *thread_p, const OID &oid, cubbase::span<char> dest)
 {
-  assert (recdes.data != nullptr && recdes.area_size > 0);
+  assert (dest.data () != nullptr && dest.size () > 0);
 
-  const int expected_length = recdes.area_size;
+  const int expected_length = static_cast<int> (dest.size ());
 
+  cubbase::byte_span_writer writer (dest);
   OOS_RECORD_HEADER first_header;
-  int bytes_written = 0;
-  /* buf_cap semantics = remaining buffer capacity at the write offset; track
-   * it explicitly so first-chunk and subsequent-chunk reads use the same
-   * "remaining" contract. */
-  int remaining = expected_length;
 
-  int err = oos_read_within_page (thread_p, oid, recdes.data, remaining,
-				  first_header, bytes_written);
+  int err = oos_read_within_page (thread_p, oid, writer, first_header);
   if (err != NO_ERROR)
     {
       return err;
     }
-  remaining -= bytes_written;
 
   assert (first_header.chunk_index == 0);
 
@@ -1405,21 +1387,20 @@ oos_read (THREAD_ENTRY *thread_p, const OID &oid, RECDES &recdes)
   if (!OID_ISNULL (&first_header.next_chunk_oid))
     {
       err = oos_read_across_pages (thread_p, first_header.next_chunk_oid,
-				   expected_length, recdes, remaining, bytes_written);
+				   expected_length, writer);
       if (err != NO_ERROR)
 	{
 	  return err;
 	}
     }
 
-  if (bytes_written != expected_length)
+  if (!writer.full ())
     {
-      oos_error ("OOS final length mismatch: written=%d expected=%d at oid={vol=%d,page=%d,slot=%d}",
-		 bytes_written, expected_length, OID_AS_ARGS (&oid));
+      oos_error ("OOS final length mismatch: written=%zu expected=%d at oid={vol=%d,page=%d,slot=%d}",
+		 writer.written (), expected_length, OID_AS_ARGS (&oid));
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
       return ER_GENERIC_ERROR;
     }
-  recdes.length = expected_length;
   return NO_ERROR;
 }
 

--- a/src/storage/oos_file.cpp
+++ b/src/storage/oos_file.cpp
@@ -56,7 +56,8 @@ oos_read_within_page (THREAD_ENTRY *thread_p, const OID &oid, char *buf_out, int
 		      OOS_RECORD_HEADER &header_out, int &chunk_bytes_out);
 static int
 oos_read_across_pages (THREAD_ENTRY *thread_p, const OID &next_oid,
-		       int total_data_length, RECDES &recdes, int &bytes_written);
+		       int total_data_length, RECDES &recdes,
+		       int &remaining, int &bytes_written);
 static void
 oos_log_insert_physical (THREAD_ENTRY *thread_p, PAGE_PTR page_p, VFID *vfid_p, OID *oid_p, RECDES *recdes_p);
 static void

--- a/src/storage/oos_file.cpp
+++ b/src/storage/oos_file.cpp
@@ -1356,7 +1356,7 @@ oos_read_across_pages (THREAD_ENTRY *thread_p, const OID &next_oid,
  * payload_len on disk: see byte_span_writer.hpp.
  */
 int
-oos_read (THREAD_ENTRY *thread_p, const OID &oid, cubbase::span<char> dest)
+oos_read (THREAD_ENTRY *thread_p, const OID &oid, oos_buffer dest)
 {
   assert (dest.data () != nullptr && dest.size () > 0);
 

--- a/src/storage/oos_file.hpp
+++ b/src/storage/oos_file.hpp
@@ -37,10 +37,15 @@ using OOS_RECORD_HEADER = struct oos_record_header;
  * Documentation only — no compile-time distinction from RECDES. */
 using OOS_RECDES = RECDES;
 
-/* Mutable byte-span destination for oos_read.
+/* Byte-span for OOS payload exchange (oos_insert source / oos_read destination).
  *
- * dest.size() carries the authoritative expected payload length, decoupled
- * from any RECDES.area_size bookkeeping the caller may keep separately.
+ * span.size() is the authoritative payload length in both directions, decoupled
+ * from any RECDES.area_size bookkeeping the caller may keep separately. The
+ * caller may back the span with a scratch buffer larger than the payload
+ * without lying about RECDES.area_size.
+ *
+ * Mutable element type (`char`, not `const char`) so a single alias serves both
+ * directions; oos_insert only reads from its argument.
  *
  * Exists as a named alias so .c call sites (compiled as C++17) can construct
  * it as `oos_buffer (data, len)` instead of `cubbase::span<char> (data, len)`;
@@ -90,7 +95,14 @@ struct oos_hdr_stats
 extern int oos_create_file (THREAD_ENTRY *thread_p, VFID &oos_vfid);
 extern int oos_remove_file (THREAD_ENTRY *thread_p, const VFID &oos_vfid);
 extern int oos_remove_page (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const VPID &vpid);
-extern int oos_insert (THREAD_ENTRY *thread_p, const VFID &oos_vfid, RECDES &recdes, OID &oid);
+/* Insert an OOS value held in a caller-owned span.
+ *
+ * src.size() is the authoritative payload length to store; oos_insert only
+ * reads from the span and never mutates the underlying bytes. If the payload
+ * exceeds one OOS page, the value is split into a chunk chain and `oid` is
+ * set to the head-chunk OID.
+ */
+extern int oos_insert (THREAD_ENTRY *thread_p, const VFID &oos_vfid, oos_buffer src, OID &oid);
 /* Read an OOS value into a caller-owned span.
  *
  * dest.size() is the authoritative expected payload length: the caller has

--- a/src/storage/oos_file.hpp
+++ b/src/storage/oos_file.hpp
@@ -37,20 +37,9 @@ using OOS_RECORD_HEADER = struct oos_record_header;
  * Documentation only — no compile-time distinction from RECDES. */
 using OOS_RECDES = RECDES;
 
-/* Byte-span for OOS payload exchange (oos_insert source / oos_read destination).
- *
- * span.size() is the authoritative payload length in both directions, decoupled
- * from any RECDES.area_size bookkeeping the caller may keep separately. The
- * caller may back the span with a scratch buffer larger than the payload
- * without lying about RECDES.area_size.
- *
- * Mutable element type (`char`, not `const char`) so a single alias serves both
- * directions; oos_insert only reads from its argument.
- *
- * Exists as a named alias so .c call sites (compiled as C++17) can construct
- * it as `oos_buffer (data, len)` instead of `cubbase::span<char> (data, len)`;
- * the C-file formatter (indent) mangles the template angle brackets, the
- * alias sidesteps that. */
+/* Caller-owned byte span for OOS payloads. size() is the authoritative length;
+ * oos_insert only reads from it, oos_read only writes. Named alias because the
+ * .c-file formatter mangles `cubbase::span<char>(...)`'s angle brackets. */
 using oos_buffer = cubbase::span<char>;
 
 #define OOS_NUM_BEST_SPACESTATS 10
@@ -95,26 +84,10 @@ struct oos_hdr_stats
 extern int oos_create_file (THREAD_ENTRY *thread_p, VFID &oos_vfid);
 extern int oos_remove_file (THREAD_ENTRY *thread_p, const VFID &oos_vfid);
 extern int oos_remove_page (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const VPID &vpid);
-/* Insert an OOS value held in a caller-owned span.
- *
- * src.size() is the authoritative payload length to store; oos_insert only
- * reads from the span and never mutates the underlying bytes. If the payload
- * exceeds one OOS page, the value is split into a chunk chain and `oid` is
- * set to the head-chunk OID.
- */
+/* Inserts src.size() bytes; on multi-page payloads, oid is the head-chunk OID. */
 extern int oos_insert (THREAD_ENTRY *thread_p, const VFID &oos_vfid, oos_buffer src, OID &oid);
-/* Read an OOS value into a caller-owned span.
- *
- * dest.size() is the authoritative expected payload length: the caller has
- * already obtained it (typically from the inline 8B length in the heap record
- * or from oos_get_length in test contexts) and sized the span accordingly.
- * The OOS chain header's total_data_length is cross-validated against
- * dest.size(); disagreement is treated as on-disk corruption.
- *
- * Span semantics decouple "expected payload length" from "underlying buffer
- * capacity", so the caller may back the span with a scratch buffer larger
- * than the payload without having to coerce a RECDES.area_size into a lie.
- */
+/* Reads exactly dest.size() bytes; the caller obtains the length from the
+ * heap record's inline 8B field (or oos_get_length in tests) and sizes dest. */
 extern int oos_read (THREAD_ENTRY *thread_p, const OID &oid, oos_buffer dest);
 extern int oos_delete (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const OID &oid);
 extern int oos_get_length (THREAD_ENTRY *thread_p, const OID &oid);

--- a/src/storage/oos_file.hpp
+++ b/src/storage/oos_file.hpp
@@ -37,6 +37,17 @@ using OOS_RECORD_HEADER = struct oos_record_header;
  * Documentation only — no compile-time distinction from RECDES. */
 using OOS_RECDES = RECDES;
 
+/* Mutable byte-span destination for oos_read.
+ *
+ * dest.size() carries the authoritative expected payload length, decoupled
+ * from any RECDES.area_size bookkeeping the caller may keep separately.
+ *
+ * Exists as a named alias so .c call sites (compiled as C++17) can construct
+ * it as `oos_buffer (data, len)` instead of `cubbase::span<char> (data, len)`;
+ * the C-file formatter (indent) mangles the template angle brackets, the
+ * alias sidesteps that. */
+using oos_buffer = cubbase::span<char>;
+
 #define OOS_NUM_BEST_SPACESTATS 10
 
 #define OOS_STATS_NEXT_BEST_INDEX(i) \
@@ -92,7 +103,7 @@ extern int oos_insert (THREAD_ENTRY *thread_p, const VFID &oos_vfid, RECDES &rec
  * capacity", so the caller may back the span with a scratch buffer larger
  * than the payload without having to coerce a RECDES.area_size into a lie.
  */
-extern int oos_read (THREAD_ENTRY *thread_p, const OID &oid, cubbase::span<char> dest);
+extern int oos_read (THREAD_ENTRY *thread_p, const OID &oid, oos_buffer dest);
 extern int oos_delete (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const OID &oid);
 extern int oos_get_length (THREAD_ENTRY *thread_p, const OID &oid);
 

--- a/src/storage/oos_file.hpp
+++ b/src/storage/oos_file.hpp
@@ -19,6 +19,7 @@
 #ifndef _OOS_FILE_HPP_
 #define _OOS_FILE_HPP_
 
+#include "span.hpp"
 #include "storage_common.h"
 #include "thread_compat.hpp"
 
@@ -79,7 +80,19 @@ extern int oos_create_file (THREAD_ENTRY *thread_p, VFID &oos_vfid);
 extern int oos_remove_file (THREAD_ENTRY *thread_p, const VFID &oos_vfid);
 extern int oos_remove_page (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const VPID &vpid);
 extern int oos_insert (THREAD_ENTRY *thread_p, const VFID &oos_vfid, RECDES &recdes, OID &oid);
-extern int oos_read (THREAD_ENTRY *thread_p, const OID &oid, RECDES &recdes);
+/* Read an OOS value into a caller-owned span.
+ *
+ * dest.size() is the authoritative expected payload length: the caller has
+ * already obtained it (typically from the inline 8B length in the heap record
+ * or from oos_get_length in test contexts) and sized the span accordingly.
+ * The OOS chain header's total_data_length is cross-validated against
+ * dest.size(); disagreement is treated as on-disk corruption.
+ *
+ * Span semantics decouple "expected payload length" from "underlying buffer
+ * capacity", so the caller may back the span with a scratch buffer larger
+ * than the payload without having to coerce a RECDES.area_size into a lie.
+ */
+extern int oos_read (THREAD_ENTRY *thread_p, const OID &oid, cubbase::span<char> dest);
 extern int oos_delete (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const OID &oid);
 extern int oos_get_length (THREAD_ENTRY *thread_p, const OID &oid);
 

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -5319,7 +5319,15 @@ locator_oos_insert_force (THREAD_ENTRY * thread_p, OID * class_oid, RECDES * rec
   thread_p->oos_oids.clear ();
 
   /* The recdes data from the log includes the OOS record header. Since oos_insert adds its own header,
-   * we project a span over the payload (skipping the on-log header) instead of mutating the caller's recdes. */
+   * we project a span over the payload (skipping the on-log header) instead of mutating the caller's recdes.
+   * Guard the subtraction against a corrupt replication record: an int underflow here would cast to a huge
+   * size_t span and propagate as either a wrap-around int or a huge memcpy inside oos_insert. */
+  if (recdes->length <= OOS_RECORD_HEADER_SIZE)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HA_GENERIC_ERROR, 1,
+	      "OOS replication log record shorter than header");
+      return ER_HA_GENERIC_ERROR;
+    }
   oos_buffer payload (recdes->data + OOS_RECORD_HEADER_SIZE, (size_t) (recdes->length - OOS_RECORD_HEADER_SIZE));
   error_code = oos_insert (thread_p, oos_vfid, payload, oos_oid);
   if (error_code != NO_ERROR)

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -5318,10 +5318,8 @@ locator_oos_insert_force (THREAD_ENTRY * thread_p, OID * class_oid, RECDES * rec
   tdes->oos_insert_lsa_queue.clear ();
   thread_p->oos_oids.clear ();
 
-  /* The recdes data from the log includes the OOS record header. Since oos_insert adds its own header,
-   * we project a span over the payload (skipping the on-log header) instead of mutating the caller's recdes.
-   * Guard the subtraction against a corrupt replication record: an int underflow here would cast to a huge
-   * size_t span and propagate as either a wrap-around int or a huge memcpy inside oos_insert. */
+  /* Skip the on-log OOS header (oos_insert prepends its own). Reject corrupt
+   * records that would underflow the subtraction below. */
   if (recdes->length <= OOS_RECORD_HEADER_SIZE)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HA_GENERIC_ERROR, 1,

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -5319,12 +5319,9 @@ locator_oos_insert_force (THREAD_ENTRY * thread_p, OID * class_oid, RECDES * rec
   thread_p->oos_oids.clear ();
 
   /* The recdes data from the log includes the OOS record header. Since oos_insert adds its own header,
-   * we must skip the existing header to avoid duplication. */
-  recdes->data = recdes->data + OOS_RECORD_HEADER_SIZE;
-  recdes->length = recdes->length - OOS_RECORD_HEADER_SIZE;
-
-  recdes->type = REC_HOME;
-  error_code = oos_insert (thread_p, oos_vfid, *recdes, oos_oid);
+   * we project a span over the payload (skipping the on-log header) instead of mutating the caller's recdes. */
+  oos_buffer payload (recdes->data + OOS_RECORD_HEADER_SIZE, (size_t) (recdes->length - OOS_RECORD_HEADER_SIZE));
+  error_code = oos_insert (thread_p, oos_vfid, payload, oos_oid);
   if (error_code != NO_ERROR)
     {
       if (er_errid () == NO_ERROR)

--- a/unit_tests/oos/CMakeLists.txt
+++ b/unit_tests/oos/CMakeLists.txt
@@ -83,6 +83,8 @@ add_test(NAME test_oos COMMAND test_oos)
 add_test(NAME test_oos_delete COMMAND test_oos_delete)
 add_test(NAME test_oos_remove_file COMMAND test_oos_remove_file)
 add_test(NAME test_oos_bestspace COMMAND test_oos_bestspace)
+# pure-logic test for the bounded writer used by oos_read; no DB fixture.
+add_test(NAME test_byte_span_writer COMMAND test_byte_span_writer)
 # add_test(NAME test_oos_persist COMMAND test_oos_persist)
 # add_test(NAME test_oos_record_descriptor COMMAND test_oos_record_descriptor)
 

--- a/unit_tests/oos/test_byte_span_writer.cpp
+++ b/unit_tests/oos/test_byte_span_writer.cpp
@@ -1,0 +1,183 @@
+/*
+ *
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+/*
+ * test_byte_span_writer.cpp - pure unit tests for cubbase::byte_span_writer.
+ *
+ * Pure logic: no server, no page buffer, no fixtures. Validates the
+ * bounds-check invariant that the OOS read path relies on for corruption
+ * defense.
+ */
+
+#include "gtest/gtest.h"
+#include "byte_span_writer.hpp"
+
+#include <cstddef>
+#include <cstring>
+
+namespace
+{
+  /* Fill buf with a sentinel byte we can later check for untouched-ness. */
+  void
+  fill_sentinel (char *buf, std::size_t n, unsigned char sentinel = 0x7f)
+  {
+    std::memset (buf, sentinel, n);
+  }
+}
+
+TEST (ByteSpanWriter, EmptyState)
+{
+  char buf[16];
+  fill_sentinel (buf, sizeof (buf));
+
+  cubbase::byte_span_writer w (cubbase::span<char> (buf, sizeof (buf)));
+  EXPECT_EQ (w.written (), 0u);
+  EXPECT_EQ (w.capacity (), 16u);
+  EXPECT_EQ (w.remaining (), 16u);
+  EXPECT_FALSE (w.full ());
+}
+
+TEST (ByteSpanWriter, AppendWithinCapacityAdvancesCursorAndCopies)
+{
+  char buf[16];
+  fill_sentinel (buf, sizeof (buf));
+
+  cubbase::byte_span_writer w (cubbase::span<char> (buf, sizeof (buf)));
+
+  ASSERT_TRUE (w.append ("hello", 5));
+  EXPECT_EQ (w.written (), 5u);
+  EXPECT_EQ (w.remaining (), 11u);
+  EXPECT_EQ (std::memcmp (buf, "hello", 5), 0);
+  /* bytes beyond the cursor untouched */
+  EXPECT_EQ (static_cast<unsigned char> (buf[5]), 0x7fu);
+}
+
+TEST (ByteSpanWriter, AppendOverflowFailsAndDoesNotWrite)
+{
+  /* The headline safety property: when the requested append would overrun
+   * capacity, the call must (a) return false, (b) leave the cursor unchanged,
+   * (c) write zero bytes. This is the invariant that converts a corrupt OOS
+   * payload_len from a buffer overrun into a clean error return. */
+  char buf[8];
+  fill_sentinel (buf, sizeof (buf));
+
+  cubbase::byte_span_writer w (cubbase::span<char> (buf, sizeof (buf)));
+
+  /* fill 5 of 8 */
+  ASSERT_TRUE (w.append ("abcde", 5));
+  ASSERT_EQ (w.written (), 5u);
+
+  /* overflow attempt: want 4 more, only 3 left */
+  EXPECT_FALSE (w.append ("WXYZ", 4));
+
+  /* cursor unchanged */
+  EXPECT_EQ (w.written (), 5u);
+  EXPECT_EQ (w.remaining (), 3u);
+
+  /* prior bytes intact */
+  EXPECT_EQ (std::memcmp (buf, "abcde", 5), 0);
+  /* bytes beyond cursor untouched (still sentinel) */
+  EXPECT_EQ (static_cast<unsigned char> (buf[5]), 0x7fu);
+  EXPECT_EQ (static_cast<unsigned char> (buf[6]), 0x7fu);
+  EXPECT_EQ (static_cast<unsigned char> (buf[7]), 0x7fu);
+}
+
+TEST (ByteSpanWriter, RecoveryAfterFailedAppend)
+{
+  /* A failed overflow must not poison the writer: a subsequent fitting
+   * append must still succeed. */
+  char buf[8];
+  fill_sentinel (buf, sizeof (buf));
+
+  cubbase::byte_span_writer w (cubbase::span<char> (buf, sizeof (buf)));
+
+  ASSERT_TRUE (w.append ("abcde", 5));
+  EXPECT_FALSE (w.append ("WXYZ", 4));   /* overflow, no-op */
+
+  /* still 3 bytes of room, a 2-byte fit must succeed */
+  ASSERT_TRUE (w.append ("xy", 2));
+  EXPECT_EQ (w.written (), 7u);
+
+  /* exact-fit fills to capacity */
+  ASSERT_TRUE (w.append ("Z", 1));
+  EXPECT_EQ (w.written (), 8u);
+  EXPECT_TRUE (w.full ());
+  EXPECT_EQ (std::memcmp (buf, "abcdexyZ", 8), 0);
+}
+
+TEST (ByteSpanWriter, FullWriterRejectsNonZeroAppendButAcceptsZero)
+{
+  char buf[4];
+  fill_sentinel (buf, sizeof (buf));
+
+  cubbase::byte_span_writer w (cubbase::span<char> (buf, sizeof (buf)));
+  ASSERT_TRUE (w.append ("1234", 4));
+  ASSERT_TRUE (w.full ());
+
+  /* zero-byte append at full is a legal no-op */
+  EXPECT_TRUE (w.append ("", 0));
+  EXPECT_TRUE (w.append (nullptr, 0));
+  EXPECT_EQ (w.written (), 4u);
+
+  /* any non-zero append at full must fail */
+  EXPECT_FALSE (w.append ("!", 1));
+  EXPECT_EQ (w.written (), 4u);
+  EXPECT_EQ (std::memcmp (buf, "1234", 4), 0);
+}
+
+TEST (ByteSpanWriter, ZeroCapacitySpanIsImmediatelyFull)
+{
+  char sentinel = static_cast<char> (0x7f);
+  cubbase::byte_span_writer w (cubbase::span<char> (&sentinel, 0));
+
+  EXPECT_EQ (w.capacity (), 0u);
+  EXPECT_EQ (w.remaining (), 0u);
+  EXPECT_TRUE (w.full ());
+
+  /* any non-zero append fails and leaves memory beyond the span untouched */
+  EXPECT_FALSE (w.append ("X", 1));
+  EXPECT_EQ (static_cast<unsigned char> (sentinel), 0x7fu);
+
+  /* zero-byte append is still legal */
+  EXPECT_TRUE (w.append ("", 0));
+}
+
+TEST (ByteSpanWriter, OverflowByExactlyOneByteIsCaught)
+{
+  /* Adversarial corruption pattern: the inline length and the chain
+   * total_data_length agree, but a single chunk on disk claims one extra
+   * byte. The bounds check must catch the off-by-one. */
+  char buf[10];
+  fill_sentinel (buf, sizeof (buf));
+
+  cubbase::byte_span_writer w (cubbase::span<char> (buf, sizeof (buf)));
+  ASSERT_TRUE (w.append ("123456789", 9));
+  EXPECT_EQ (w.remaining (), 1u);
+
+  /* claim 2 bytes for the final chunk — exactly one byte over */
+  EXPECT_FALSE (w.append ("AB", 2));
+  EXPECT_EQ (w.written (), 9u);
+  EXPECT_EQ (static_cast<unsigned char> (buf[9]), 0x7fu);
+}
+
+int
+main (int argc, char **argv)
+{
+  ::testing::InitGoogleTest (&argc, argv);
+  return RUN_ALL_TESTS ();
+}

--- a/unit_tests/oos/test_oos.cpp
+++ b/unit_tests/oos/test_oos.cpp
@@ -717,7 +717,7 @@ TEST (OosTest, OosReadRejectsCallerLengthDisagreeingWithHeader)
 
       er_clear ();
       int read_err = oos_read (thread_p, oos_oid,
-			       cubbase::span<char> (rec_out.data, static_cast<std::size_t> (claimed_len)));
+			       oos_buffer (rec_out.data, static_cast<std::size_t> (claimed_len)));
       EXPECT_NE (read_err, NO_ERROR) << "actual_size=" << actual_size;
       EXPECT_NE (er_errid (), NO_ERROR) << "actual_size=" << actual_size;
 

--- a/unit_tests/oos/test_oos.cpp
+++ b/unit_tests/oos/test_oos.cpp
@@ -712,10 +712,12 @@ TEST (OosTest, OosReadRejectsCallerLengthDisagreeingWithHeader)
       ASSERT_EQ (err, NO_ERROR);
 
       RECDES rec_out{};
-      ASSERT_EQ (recdes_allocate_data_area (&rec_out, actual_size - 16), NO_ERROR);
+      const int claimed_len = actual_size - 16;
+      ASSERT_EQ (recdes_allocate_data_area (&rec_out, claimed_len), NO_ERROR);
 
       er_clear ();
-      int read_err = oos_read (thread_p, oos_oid, rec_out);
+      int read_err = oos_read (thread_p, oos_oid,
+			       cubbase::span<char> (rec_out.data, static_cast<std::size_t> (claimed_len)));
       EXPECT_NE (read_err, NO_ERROR) << "actual_size=" << actual_size;
       EXPECT_NE (er_errid (), NO_ERROR) << "actual_size=" << actual_size;
 

--- a/unit_tests/oos/test_oos.cpp
+++ b/unit_tests/oos/test_oos.cpp
@@ -98,7 +98,7 @@ TEST (OosTest, OosInsertAndRead)
   test_oos_utils::from_string_into_recdes ("This is a test OOS data.", rec);
 
   OID oid = OID_INITIALIZER;
-  err = oos_insert (thread_p, oos_vfid, rec, oid);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec, oid);
   ASSERT_EQ (err, NO_ERROR);
   ASSERT_NE (oid.pageid, NULL_PAGEID);
   ASSERT_NE (oid.volid, NULL_VOLID);
@@ -131,7 +131,7 @@ TEST (OosTest, OosInsertLargerThanPageSize)
   ASSERT_EQ (err, NO_ERROR);
 
   OID oid;
-  err = oos_insert (thread_p, oos_vfid, rec_in, oid);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_in, oid);
   ASSERT_EQ (err, NO_ERROR);
 
   RECDES rec_out{};
@@ -163,7 +163,7 @@ TEST (OosTest, OosInsertLarge160KBString)
   ASSERT_EQ (err, NO_ERROR);
 
   OID oid;
-  err = oos_insert (thread_p, oos_vfid, rec_in, oid);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_in, oid);
   ASSERT_EQ (err, NO_ERROR);
 
   RECDES rec_out{};
@@ -198,7 +198,7 @@ TEST (OosTest, OosInsertAndRead100LargeStringsAroundMaxOosChunkSize)
       ASSERT_EQ (err, NO_ERROR);
 
       OID oid;
-      err = oos_insert (thread_p, oos_vfid, rec_in, oid);
+      err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_in, oid);
       ASSERT_EQ (err, NO_ERROR);
 
       RECDES rec_out{};
@@ -367,11 +367,11 @@ TEST (OosTest, ShouldInsertIntoSamePage)
     ASSERT_EQ (err, NO_ERROR);
 
     OID oid1;
-    err = oos_insert (thread_p, oos_vfid, rec_in1, oid1);
+    err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_in1, oid1);
     ASSERT_EQ (err, NO_ERROR);
 
     OID oid2;
-    err = oos_insert (thread_p, oos_vfid, rec_in2, oid2);
+    err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_in2, oid2);
     ASSERT_EQ (err, NO_ERROR);
 
     err = test_oos_utils::oos_read_with_alloc (thread_p, oid1, rec_out1);
@@ -411,7 +411,7 @@ TEST (OosTest, OosGetLengthWithinPage)
   ASSERT_EQ (err, NO_ERROR);
 
   OID oid;
-  err = oos_insert (thread_p, oos_vfid, rec_in, oid);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_in, oid);
   ASSERT_EQ (err, NO_ERROR);
 
   int length = oos_get_length (thread_p, oid);
@@ -436,7 +436,7 @@ TEST (OosTest, OosGetLengthAcrossPages)
   ASSERT_EQ (err, NO_ERROR);
 
   OID oid;
-  err = oos_insert (thread_p, oos_vfid, rec_in, oid);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_in, oid);
   ASSERT_EQ (err, NO_ERROR);
 
   /* oos_get_length reads only the first chunk header, which stores the total size */
@@ -466,7 +466,7 @@ TEST (OosTest, OosGetLengthAroundMaxChunkSize)
       ASSERT_EQ (err, NO_ERROR);
 
       OID oid;
-      err = oos_insert (thread_p, oos_vfid, rec_in, oid);
+      err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_in, oid);
       ASSERT_EQ (err, NO_ERROR);
 
       int length = oos_get_length (thread_p, oid);
@@ -503,7 +503,7 @@ TEST (OosTest, ShouldInsertIntoDifferentPages)
    */
 
   OID oid1;
-  err = oos_insert (thread_p, oos_vfid, rec_in1, oid1);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_in1, oid1);
   ASSERT_EQ (err, NO_ERROR);
   test_oos_debug ("Inserted record oid1: volid=%d, pageid=%d, slotid=%d", oid1.volid, oid1.pageid, oid1.slotid);
 
@@ -583,7 +583,7 @@ TEST (OosTest, OosInlineFormatWithRealOosInsert)
   ASSERT_EQ (err, NO_ERROR);
 
   OID oos_oid;
-  err = oos_insert (thread_p, oos_vfid, rec_in, oos_oid);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_in, oos_oid);
   ASSERT_EQ (err, NO_ERROR);
 
   /* Build inline OOS data: [OOS OID (8B) + length (8B)] */
@@ -645,7 +645,7 @@ TEST (OosTest, OosInlineLengthMatchesAcrossPages)
       ASSERT_EQ (err, NO_ERROR);
 
       OID oos_oid;
-      err = oos_insert (thread_p, oos_vfid, rec_in, oos_oid);
+      err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_in, oos_oid);
       ASSERT_EQ (err, NO_ERROR);
 
       /* Write inline format */
@@ -708,7 +708,7 @@ TEST (OosTest, OosReadRejectsCallerLengthDisagreeingWithHeader)
       ASSERT_EQ (err, NO_ERROR);
 
       OID oos_oid;
-      err = oos_insert (thread_p, oos_vfid, rec_in, oos_oid);
+      err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_in, oos_oid);
       ASSERT_EQ (err, NO_ERROR);
 
       RECDES rec_out{};

--- a/unit_tests/oos/test_oos.cpp
+++ b/unit_tests/oos/test_oos.cpp
@@ -106,7 +106,7 @@ TEST (OosTest, OosInsertAndRead)
   test_oos_debug ("OID: volid=%d, pageid=%d, slotid=%d", oid.volid, oid.pageid, oid.slotid);
 
   RECDES rec_out{};
-  err = oos_read (thread_p, oid, rec_out);
+  err = test_oos_utils::oos_read_with_alloc (thread_p, oid, rec_out);
   ASSERT_EQ (err, NO_ERROR);
 
   ASSERT_EQ (rec_out.length, rec.length);
@@ -135,7 +135,7 @@ TEST (OosTest, OosInsertLargerThanPageSize)
   ASSERT_EQ (err, NO_ERROR);
 
   RECDES rec_out{};
-  err = oos_read (thread_p, oid, rec_out);
+  err = test_oos_utils::oos_read_with_alloc (thread_p, oid, rec_out);
   ASSERT_EQ (err, NO_ERROR);
   ASSERT_STREQ (rec_out.data, rec_in.data);
   ASSERT_EQ (strlen (rec_out.data),strlen (large_data.c_str()));
@@ -167,7 +167,7 @@ TEST (OosTest, OosInsertLarge160KBString)
   ASSERT_EQ (err, NO_ERROR);
 
   RECDES rec_out{};
-  err = oos_read (thread_p, oid, rec_out);
+  err = test_oos_utils::oos_read_with_alloc (thread_p, oid, rec_out);
   ASSERT_EQ (err, NO_ERROR);
   ASSERT_STREQ (rec_out.data, rec_in.data);
   ASSERT_EQ (strlen (rec_out.data),strlen (large_data.c_str()));
@@ -202,7 +202,7 @@ TEST (OosTest, OosInsertAndRead100LargeStringsAroundMaxOosChunkSize)
       ASSERT_EQ (err, NO_ERROR);
 
       RECDES rec_out{};
-      err = oos_read (thread_p, oid, rec_out);
+      err = test_oos_utils::oos_read_with_alloc (thread_p, oid, rec_out);
       ASSERT_EQ (err, NO_ERROR);
       ASSERT_EQ (strlen (rec_out.data),strlen (large_data.c_str()));
       ASSERT_STREQ (rec_out.data, rec_in.data);
@@ -374,12 +374,12 @@ TEST (OosTest, ShouldInsertIntoSamePage)
     err = oos_insert (thread_p, oos_vfid, rec_in2, oid2);
     ASSERT_EQ (err, NO_ERROR);
 
-    err = oos_read (thread_p, oid1, rec_out1);
+    err = test_oos_utils::oos_read_with_alloc (thread_p, oid1, rec_out1);
     ASSERT_EQ (err, NO_ERROR);
     ASSERT_STREQ (rec_out1.data, rec_in1.data);
     ASSERT_EQ (strlen (rec_out1.data),strlen ("first string"));
 
-    err = oos_read (thread_p, oid2, rec_out2);
+    err = test_oos_utils::oos_read_with_alloc (thread_p, oid2, rec_out2);
     ASSERT_EQ (err, NO_ERROR);
     ASSERT_STREQ (rec_out2.data, rec_in2.data);
     ASSERT_EQ (strlen (rec_out2.data),strlen ("second string again"));
@@ -614,7 +614,7 @@ TEST (OosTest, OosInlineFormatWithRealOosInsert)
 
   /* Verify that oos_read returns a recdes whose length matches the inline length */
   RECDES rec_out{};
-  err = oos_read (thread_p, oos_oid, rec_out);
+  err = test_oos_utils::oos_read_with_alloc (thread_p, oos_oid, rec_out);
   ASSERT_EQ (err, NO_ERROR);
   ASSERT_EQ (read_length, (DB_BIGINT) rec_out.length);
 
@@ -674,12 +674,53 @@ TEST (OosTest, OosInlineLengthMatchesAcrossPages)
 
       /* Inline length must match oos_read recdes length */
       RECDES rec_out{};
-      err = oos_read (thread_p, oos_oid, rec_out);
+      err = test_oos_utils::oos_read_with_alloc (thread_p, oos_oid, rec_out);
       ASSERT_EQ (err, NO_ERROR);
       ASSERT_EQ (inline_length, (DB_BIGINT) rec_out.length) << "Failed for data_size=" << data_size;
 
       recdes_free_data_area (&rec_in);
       recdes_free_data_area (&rec_out);
+    }
+}
+
+TEST (OosTest, OosReadRejectsCallerLengthDisagreeingWithHeader)
+{
+  /* Caller passes oos_read a buffer sized from an (assumed) inline length that
+   * disagrees with the OOS header's total_data_length. oos_read must surface a
+   * clean error rather than truncate silently. Covers within-page and
+   * multi-chunk cases. The within-page path fails in oos_read_within_page via
+   * payload_len > buf_cap; the multi-chunk path fails in oos_read on the
+   * length-vs-header cross-check. */
+  int err;
+  VFID oos_vfid;
+
+  err = oos_create_file (thread_p, oos_vfid);
+  ASSERT_EQ (err, NO_ERROR);
+
+  const int max_chunk_size = bridge_oos_get_max_chunk_size_within_page ();
+  int actual_sizes[] = { 4096, max_chunk_size + 4096 };
+
+  for (int actual_size : actual_sizes)
+    {
+      auto data = test_oos_utils::make_repeated_pattern_string (actual_size);
+      RECDES rec_in{};
+      err = test_oos_utils::from_string_into_recdes (data, rec_in);
+      ASSERT_EQ (err, NO_ERROR);
+
+      OID oos_oid;
+      err = oos_insert (thread_p, oos_vfid, rec_in, oos_oid);
+      ASSERT_EQ (err, NO_ERROR);
+
+      RECDES rec_out{};
+      ASSERT_EQ (recdes_allocate_data_area (&rec_out, actual_size - 16), NO_ERROR);
+
+      er_clear ();
+      int read_err = oos_read (thread_p, oos_oid, rec_out);
+      EXPECT_NE (read_err, NO_ERROR) << "actual_size=" << actual_size;
+      EXPECT_NE (er_errid (), NO_ERROR) << "actual_size=" << actual_size;
+
+      recdes_free_data_area (&rec_out);
+      recdes_free_data_area (&rec_in);
     }
 }
 

--- a/unit_tests/oos/test_oos_bestspace.cpp
+++ b/unit_tests/oos/test_oos_bestspace.cpp
@@ -98,7 +98,7 @@ TEST (OosBestspaceTest, BestspaceReuseAfterDelete)
 
   // First insert — establishes a page
   OID oid1 = OID_INITIALIZER;
-  err = oos_insert (thread_p, oos_vfid, rec_in, oid1);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_in, oid1);
   ASSERT_EQ (err, NO_ERROR);
   test_oos_debug ("oid1={vol=%d,page=%d,slot=%d}", oid1.volid, oid1.pageid, oid1.slotid);
 
@@ -115,7 +115,7 @@ TEST (OosBestspaceTest, BestspaceReuseAfterDelete)
   test_oos_utils::auto_freed_recdes_ptr defer_free_in2 (&rec_in2, recdes_free_data_area);
 
   OID oid2 = OID_INITIALIZER;
-  err = oos_insert (thread_p, oos_vfid, rec_in2, oid2);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_in2, oid2);
   ASSERT_EQ (err, NO_ERROR);
   test_oos_debug ("oid2={vol=%d,page=%d,slot=%d}", oid2.volid, oid2.pageid, oid2.slotid);
 
@@ -161,7 +161,7 @@ TEST (OosBestspaceTest, BestspaceFullPageAllocsNew)
   test_oos_utils::auto_freed_recdes_ptr defer_large (&rec_large, recdes_free_data_area);
 
   OID oid_large = OID_INITIALIZER;
-  err = oos_insert (thread_p, oos_vfid, rec_large, oid_large);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_large, oid_large);
   ASSERT_EQ (err, NO_ERROR);
   test_oos_debug ("large oid={vol=%d,page=%d,slot=%d}", oid_large.volid, oid_large.pageid, oid_large.slotid);
 
@@ -176,7 +176,7 @@ TEST (OosBestspaceTest, BestspaceFullPageAllocsNew)
   test_oos_utils::auto_freed_recdes_ptr defer_large2 (&rec_large2, recdes_free_data_area);
 
   OID oid_large2 = OID_INITIALIZER;
-  err = oos_insert (thread_p, oos_vfid, rec_large2, oid_large2);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_large2, oid_large2);
   ASSERT_EQ (err, NO_ERROR);
   test_oos_debug ("large2 oid={vol=%d,page=%d,slot=%d}", oid_large2.volid, oid_large2.pageid, oid_large2.slotid);
 
@@ -214,7 +214,7 @@ TEST (OosBestspaceTest, BestspaceMultipleFilesIsolation)
   test_oos_utils::auto_freed_recdes_ptr defer1 (&rec1, recdes_free_data_area);
 
   OID oid1 = OID_INITIALIZER;
-  err = oos_insert (thread_p, vfid1, rec1, oid1);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, vfid1, rec1, oid1);
   ASSERT_EQ (err, NO_ERROR);
 
   // Insert into file 2
@@ -224,7 +224,7 @@ TEST (OosBestspaceTest, BestspaceMultipleFilesIsolation)
   test_oos_utils::auto_freed_recdes_ptr defer2 (&rec2, recdes_free_data_area);
 
   OID oid2 = OID_INITIALIZER;
-  err = oos_insert (thread_p, vfid2, rec2, oid2);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, vfid2, rec2, oid2);
   ASSERT_EQ (err, NO_ERROR);
 
   // Delete from file 1 — frees space in file 1 only
@@ -238,7 +238,7 @@ TEST (OosBestspaceTest, BestspaceMultipleFilesIsolation)
   test_oos_utils::auto_freed_recdes_ptr defer2b (&rec2b, recdes_free_data_area);
 
   OID oid2b = OID_INITIALIZER;
-  err = oos_insert (thread_p, vfid2, rec2b, oid2b);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, vfid2, rec2b, oid2b);
   ASSERT_EQ (err, NO_ERROR);
 
   // oid2b must be on the same volume/page as oid2 (file 2's page), not file 1's
@@ -290,7 +290,7 @@ TEST (OosBestspaceTest, BestspaceManySmallInsertsConsolidate)
       ASSERT_EQ (err, NO_ERROR);
 
       OID oid = OID_INITIALIZER;
-      err = oos_insert (thread_p, oos_vfid, rec, oid);
+      err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec, oid);
       ASSERT_EQ (err, NO_ERROR);
 
       pages_used.insert (oid.pageid);
@@ -352,7 +352,7 @@ TEST (OosBestspaceTest, BestspaceInsertDeleteCycle)
       test_oos_utils::auto_freed_recdes_ptr defer_rec (&rec, recdes_free_data_area);
 
       OID oid = OID_INITIALIZER;
-      err = oos_insert (thread_p, oos_vfid, rec, oid);
+      err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec, oid);
       ASSERT_EQ (err, NO_ERROR);
 
       all_pages.insert (oid.pageid);
@@ -441,7 +441,7 @@ TEST (OosBestspaceTest, BestspaceFindBestPageConsecutiveCalls)
   test_oos_utils::auto_freed_recdes_ptr defer_rec (&rec, recdes_free_data_area);
 
   OID oid = OID_INITIALIZER;
-  err = oos_insert (thread_p, oos_vfid, rec, oid);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec, oid);
   ASSERT_EQ (err, NO_ERROR);
 
   // Release page1 before second find
@@ -487,7 +487,7 @@ TEST (OosBestspaceTest, BestspaceDeleteThenFindReclaimsPage)
       ASSERT_EQ (err, NO_ERROR);
 
       OID oid = OID_INITIALIZER;
-      err = oos_insert (thread_p, oos_vfid, rec, oid);
+      err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec, oid);
       ASSERT_EQ (err, NO_ERROR);
       oids.push_back (oid);
       recdes_free_data_area (&rec);
@@ -545,7 +545,7 @@ TEST (OosBestspaceTest, BestspaceMultiChunkDeleteReuse)
   test_oos_utils::auto_freed_recdes_ptr defer_large (&rec_large, recdes_free_data_area);
 
   OID oid_large = OID_INITIALIZER;
-  err = oos_insert (thread_p, oos_vfid, rec_large, oid_large);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_large, oid_large);
   ASSERT_EQ (err, NO_ERROR);
   test_oos_debug ("large oid={vol=%d,page=%d,slot=%d}", oid_large.volid, oid_large.pageid, oid_large.slotid);
 
@@ -563,7 +563,7 @@ TEST (OosBestspaceTest, BestspaceMultiChunkDeleteReuse)
   test_oos_utils::auto_freed_recdes_ptr defer_small (&rec_small, recdes_free_data_area);
 
   OID oid_small = OID_INITIALIZER;
-  err = oos_insert (thread_p, oos_vfid, rec_small, oid_small);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_small, oid_small);
   ASSERT_EQ (err, NO_ERROR);
   test_oos_debug ("small oid={vol=%d,page=%d,slot=%d}", oid_small.volid, oid_small.pageid, oid_small.slotid);
 
@@ -616,7 +616,7 @@ TEST (OosBestspaceTest, BestspaceCacheCleanedOnFileRemove)
       ASSERT_EQ (err, NO_ERROR);
 
       OID oid = OID_INITIALIZER;
-      err = oos_insert (thread_p, vfid1, rec, oid);
+      err = test_oos_utils::oos_insert_from_recdes (thread_p, vfid1, rec, oid);
       ASSERT_EQ (err, NO_ERROR);
       recdes_free_data_area (&rec);
     }
@@ -636,7 +636,7 @@ TEST (OosBestspaceTest, BestspaceCacheCleanedOnFileRemove)
   test_oos_utils::auto_freed_recdes_ptr defer_rec (&rec, recdes_free_data_area);
 
   OID oid = OID_INITIALIZER;
-  err = oos_insert (thread_p, vfid2, rec, oid);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, vfid2, rec, oid);
   ASSERT_EQ (err, NO_ERROR);
 
   RECDES rec_out{};
@@ -680,7 +680,7 @@ TEST (OosBestspaceTest, BestspaceBulkInsertDeleteReinsert)
       ASSERT_EQ (err, NO_ERROR);
 
       OID oid = OID_INITIALIZER;
-      err = oos_insert (thread_p, oos_vfid, rec, oid);
+      err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec, oid);
       ASSERT_EQ (err, NO_ERROR);
 
       oids.push_back (oid);
@@ -708,7 +708,7 @@ TEST (OosBestspaceTest, BestspaceBulkInsertDeleteReinsert)
       ASSERT_EQ (err, NO_ERROR);
 
       OID oid = OID_INITIALIZER;
-      err = oos_insert (thread_p, oos_vfid, rec, oid);
+      err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec, oid);
       ASSERT_EQ (err, NO_ERROR);
 
       oids.push_back (oid);
@@ -776,7 +776,7 @@ TEST (OosBestspaceTest, BestspaceArrayOverflowEviction)
       ASSERT_EQ (err, NO_ERROR);
 
       OID oid = OID_INITIALIZER;
-      err = oos_insert (thread_p, oos_vfid, rec, oid);
+      err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec, oid);
       ASSERT_EQ (err, NO_ERROR);
 
       oids.push_back (oid);
@@ -806,7 +806,7 @@ TEST (OosBestspaceTest, BestspaceArrayOverflowEviction)
       ASSERT_EQ (err, NO_ERROR);
 
       OID oid = OID_INITIALIZER;
-      err = oos_insert (thread_p, oos_vfid, rec, oid);
+      err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec, oid);
       ASSERT_EQ (err, NO_ERROR);
 
       pages_round2.insert (oid.pageid);
@@ -869,7 +869,7 @@ TEST (OosBestspaceTest, BestspaceStaleCacheEviction)
   test_oos_utils::auto_freed_recdes_ptr defer_small (&rec_small, recdes_free_data_area);
 
   OID oid_seed = OID_INITIALIZER;
-  err = oos_insert (thread_p, oos_vfid, rec_small, oid_seed);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_small, oid_seed);
   ASSERT_EQ (err, NO_ERROR);
   PAGEID seed_page = oid_seed.pageid;
 
@@ -881,7 +881,7 @@ TEST (OosBestspaceTest, BestspaceStaleCacheEviction)
   test_oos_utils::auto_freed_recdes_ptr defer_large (&rec_large, recdes_free_data_area);
 
   OID oid_large = OID_INITIALIZER;
-  err = oos_insert (thread_p, oos_vfid, rec_large, oid_large);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_large, oid_large);
   ASSERT_EQ (err, NO_ERROR);
 
   // The page should now be (nearly) full — verify the large record landed there
@@ -896,7 +896,7 @@ TEST (OosBestspaceTest, BestspaceStaleCacheEviction)
   test_oos_utils::auto_freed_recdes_ptr defer_large2 (&rec_large2, recdes_free_data_area);
 
   OID oid_large2 = OID_INITIALIZER;
-  err = oos_insert (thread_p, oos_vfid, rec_large2, oid_large2);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_large2, oid_large2);
   ASSERT_EQ (err, NO_ERROR);
 
   // Must go to a different page since seed_page is full
@@ -942,7 +942,7 @@ TEST (OosBestspaceTest, BestspaceHeaderPageNeverReturned)
       ASSERT_EQ (err, NO_ERROR);
 
       OID oid = OID_INITIALIZER;
-      err = oos_insert (thread_p, oos_vfid, rec, oid);
+      err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec, oid);
       ASSERT_EQ (err, NO_ERROR);
       ASSERT_NE (oid.pageid, hdr_vpid.pageid);
       recdes_free_data_area (&rec);
@@ -982,7 +982,7 @@ TEST (OosBestspaceTest, BestspaceSyncRefillsCache)
       ASSERT_EQ (err, NO_ERROR);
 
       OID oid = OID_INITIALIZER;
-      err = oos_insert (thread_p, oos_vfid, rec, oid);
+      err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec, oid);
       ASSERT_EQ (err, NO_ERROR);
       oids.push_back (oid);
       original_pages.insert (oid.pageid);
@@ -1196,7 +1196,7 @@ TEST (OosBestspaceTest, BestspaceExactMaxChunkBoundary)
   test_oos_utils::auto_freed_recdes_ptr defer_exact (&rec_exact, recdes_free_data_area);
 
   OID oid_exact = OID_INITIALIZER;
-  err = oos_insert (thread_p, oos_vfid, rec_exact, oid_exact);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_exact, oid_exact);
   ASSERT_EQ (err, NO_ERROR);
 
   PAGEID exact_page = oid_exact.pageid;
@@ -1213,7 +1213,7 @@ TEST (OosBestspaceTest, BestspaceExactMaxChunkBoundary)
   test_oos_utils::auto_freed_recdes_ptr defer_exact2 (&rec_exact2, recdes_free_data_area);
 
   OID oid_exact2 = OID_INITIALIZER;
-  err = oos_insert (thread_p, oos_vfid, rec_exact2, oid_exact2);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_exact2, oid_exact2);
   ASSERT_EQ (err, NO_ERROR);
 
   ASSERT_NE (oid_exact2.pageid, exact_page);
@@ -1270,7 +1270,7 @@ TEST (OosBestspaceTest, DeleteUpdatesBestspaceCacheDirectly)
   test_oos_utils::auto_freed_recdes_ptr defer_large (&rec_large, recdes_free_data_area);
 
   OID oid_large = OID_INITIALIZER;
-  err = oos_insert (thread_p, oos_vfid, rec_large, oid_large);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_large, oid_large);
   ASSERT_EQ (err, NO_ERROR);
 
   PAGEID target_page = oid_large.pageid;
@@ -1293,7 +1293,7 @@ TEST (OosBestspaceTest, DeleteUpdatesBestspaceCacheDirectly)
   test_oos_utils::auto_freed_recdes_ptr defer_medium (&rec_medium, recdes_free_data_area);
 
   OID oid_medium = OID_INITIALIZER;
-  err = oos_insert (thread_p, oos_vfid, rec_medium, oid_medium);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_medium, oid_medium);
   ASSERT_EQ (err, NO_ERROR);
   test_oos_debug ("medium oid={vol=%d,page=%d,slot=%d}", oid_medium.volid, oid_medium.pageid, oid_medium.slotid);
 
@@ -1344,7 +1344,7 @@ TEST (OosBestspaceTest, DeleteMultipleRecordsUpdatesAllPages)
       ASSERT_EQ (err, NO_ERROR);
 
       OID oid = OID_INITIALIZER;
-      err = oos_insert (thread_p, oos_vfid, rec, oid);
+      err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec, oid);
       ASSERT_EQ (err, NO_ERROR);
 
       oids.push_back (oid);
@@ -1372,7 +1372,7 @@ TEST (OosBestspaceTest, DeleteMultipleRecordsUpdatesAllPages)
       ASSERT_EQ (err, NO_ERROR);
 
       OID oid = OID_INITIALIZER;
-      err = oos_insert (thread_p, oos_vfid, rec, oid);
+      err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec, oid);
       ASSERT_EQ (err, NO_ERROR);
 
       reinsert_pages.insert (oid.pageid);
@@ -1418,7 +1418,7 @@ TEST (OosBestspaceTest, DeletePartialChainUpdatesBestspace)
   test_oos_utils::auto_freed_recdes_ptr defer_large (&rec_large, recdes_free_data_area);
 
   OID oid_large = OID_INITIALIZER;
-  err = oos_insert (thread_p, oos_vfid, rec_large, oid_large);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_large, oid_large);
   ASSERT_EQ (err, NO_ERROR);
 
   // Delete the multi-chunk record — all 3 pages should have freed space in cache
@@ -1437,7 +1437,7 @@ TEST (OosBestspaceTest, DeletePartialChainUpdatesBestspace)
       ASSERT_EQ (err, NO_ERROR);
 
       OID oid = OID_INITIALIZER;
-      err = oos_insert (thread_p, oos_vfid, rec, oid);
+      err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec, oid);
       ASSERT_EQ (err, NO_ERROR);
 
       reuse_pages.insert (oid.pageid);

--- a/unit_tests/oos/test_oos_bestspace.cpp
+++ b/unit_tests/oos/test_oos_bestspace.cpp
@@ -124,7 +124,7 @@ TEST (OosBestspaceTest, BestspaceReuseAfterDelete)
 
   // Verify the data is correct
   RECDES rec_out{};
-  err = oos_read (thread_p, oid2, rec_out);
+  err = test_oos_utils::oos_read_with_alloc (thread_p, oid2, rec_out);
   ASSERT_EQ (err, NO_ERROR);
   ASSERT_STREQ (rec_out.data, data.c_str());
   recdes_free_data_area (&rec_out);
@@ -251,7 +251,7 @@ TEST (OosBestspaceTest, BestspaceMultipleFilesIsolation)
 
   // Verify file 2 data is correct
   RECDES rec_out{};
-  err = oos_read (thread_p, oid2b, rec_out);
+  err = test_oos_utils::oos_read_with_alloc (thread_p, oid2b, rec_out);
   ASSERT_EQ (err, NO_ERROR);
   ASSERT_STREQ (rec_out.data, data.c_str());
   recdes_free_data_area (&rec_out);
@@ -311,7 +311,7 @@ TEST (OosBestspaceTest, BestspaceManySmallInsertsConsolidate)
   for (int i = 0; i < num_inserts; i++)
     {
       RECDES rec_out{};
-      err = oos_read (thread_p, oids[i], rec_out);
+      err = test_oos_utils::oos_read_with_alloc (thread_p, oids[i], rec_out);
       ASSERT_EQ (err, NO_ERROR);
 
       std::string expected = "small record #" + std::to_string (i);
@@ -359,7 +359,7 @@ TEST (OosBestspaceTest, BestspaceInsertDeleteCycle)
 
       // Verify readable
       RECDES rec_out{};
-      err = oos_read (thread_p, oid, rec_out);
+      err = test_oos_utils::oos_read_with_alloc (thread_p, oid, rec_out);
       ASSERT_EQ (err, NO_ERROR);
       ASSERT_STREQ (rec_out.data, data.c_str ());
       recdes_free_data_area (&rec_out);
@@ -582,7 +582,7 @@ TEST (OosBestspaceTest, BestspaceMultiChunkDeleteReuse)
 
   // Verify data
   RECDES rec_out{};
-  err = oos_read (thread_p, oid_small, rec_out);
+  err = test_oos_utils::oos_read_with_alloc (thread_p, oid_small, rec_out);
   ASSERT_EQ (err, NO_ERROR);
   ASSERT_STREQ (rec_out.data, "small after multi-chunk delete");
   recdes_free_data_area (&rec_out);
@@ -640,7 +640,7 @@ TEST (OosBestspaceTest, BestspaceCacheCleanedOnFileRemove)
   ASSERT_EQ (err, NO_ERROR);
 
   RECDES rec_out{};
-  err = oos_read (thread_p, oid, rec_out);
+  err = test_oos_utils::oos_read_with_alloc (thread_p, oid, rec_out);
   ASSERT_EQ (err, NO_ERROR);
   ASSERT_STREQ (rec_out.data, "after cleanup insert");
   recdes_free_data_area (&rec_out);
@@ -732,7 +732,7 @@ TEST (OosBestspaceTest, BestspaceBulkInsertDeleteReinsert)
   for (int i = 0; i < num_records; i++)
     {
       RECDES rec_out{};
-      err = oos_read (thread_p, oids[i], rec_out);
+      err = test_oos_utils::oos_read_with_alloc (thread_p, oids[i], rec_out);
       ASSERT_EQ (err, NO_ERROR);
       ASSERT_EQ ((int) strlen (rec_out.data), record_size);
       recdes_free_data_area (&rec_out);
@@ -1220,13 +1220,13 @@ TEST (OosBestspaceTest, BestspaceExactMaxChunkBoundary)
 
   // Verify both records are readable
   RECDES rec_out{};
-  err = oos_read (thread_p, oid_exact, rec_out);
+  err = test_oos_utils::oos_read_with_alloc (thread_p, oid_exact, rec_out);
   ASSERT_EQ (err, NO_ERROR);
   ASSERT_EQ ((int) strlen (rec_out.data), max_chunk);
   recdes_free_data_area (&rec_out);
 
   RECDES rec_out2{};
-  err = oos_read (thread_p, oid_exact2, rec_out2);
+  err = test_oos_utils::oos_read_with_alloc (thread_p, oid_exact2, rec_out2);
   ASSERT_EQ (err, NO_ERROR);
   ASSERT_EQ ((int) strlen (rec_out2.data), max_chunk);
   recdes_free_data_area (&rec_out2);
@@ -1304,7 +1304,7 @@ TEST (OosBestspaceTest, DeleteUpdatesBestspaceCacheDirectly)
 
   // Verify data
   RECDES rec_out{};
-  err = oos_read (thread_p, oid_medium, rec_out);
+  err = test_oos_utils::oos_read_with_alloc (thread_p, oid_medium, rec_out);
   ASSERT_EQ (err, NO_ERROR);
   ASSERT_EQ ((int) strlen (rec_out.data), 2000);
   recdes_free_data_area (&rec_out);

--- a/unit_tests/oos/test_oos_common.hpp
+++ b/unit_tests/oos/test_oos_common.hpp
@@ -97,22 +97,13 @@ namespace test_oos_utils
     return large_data;
   }
 
-  /* Test-side wrapper for the span-based oos_insert API. Tests construct
-   * payloads as RECDES via from_string_into_recdes; this helper bridges
-   * that to oos_insert's oos_buffer parameter without leaking span-
-   * construction boilerplate into every call site. Mirrors the production
-   * pattern in heap_file.c, which wraps recdes.data/length in an oos_buffer
-   * at the boundary. */
+  /* Wraps a test RECDES as the oos_buffer src that oos_insert expects. */
   inline int oos_insert_from_recdes (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const RECDES &recdes, OID &oid)
   {
     return oos_insert (thread_p, oos_vfid, oos_buffer (recdes.data, static_cast<std::size_t> (recdes.length)), oid);
   }
 
-  /* Test-side wrapper for the span-based oos_read API. Production callers know
-   * the OOS length from the inline 8B field in the heap record; tests don't
-   * have that record, so we read the length via oos_get_length and hand
-   * oos_read a span sized to exactly that length. The RECDES wrapping is for
-   * the test's downstream convenience only — oos_read no longer touches it. */
+  /* Reads OID into a fresh RECDES, sized via oos_get_length (tests have no heap-inline length). */
   inline int oos_read_with_alloc (THREAD_ENTRY *thread_p, const OID &oid, RECDES &recdes)
   {
     recdes = RECDES{};

--- a/unit_tests/oos/test_oos_common.hpp
+++ b/unit_tests/oos/test_oos_common.hpp
@@ -97,6 +97,17 @@ namespace test_oos_utils
     return large_data;
   }
 
+  /* Test-side wrapper for the span-based oos_insert API. Tests construct
+   * payloads as RECDES via from_string_into_recdes; this helper bridges
+   * that to oos_insert's oos_buffer parameter without leaking span-
+   * construction boilerplate into every call site. Mirrors the production
+   * pattern in heap_file.c, which wraps recdes.data/length in an oos_buffer
+   * at the boundary. */
+  inline int oos_insert_from_recdes (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const RECDES &recdes, OID &oid)
+  {
+    return oos_insert (thread_p, oos_vfid, oos_buffer (recdes.data, static_cast<std::size_t> (recdes.length)), oid);
+  }
+
   /* Test-side wrapper for the span-based oos_read API. Production callers know
    * the OOS length from the inline 8B field in the heap record; tests don't
    * have that record, so we read the length via oos_get_length and hand

--- a/unit_tests/oos/test_oos_common.hpp
+++ b/unit_tests/oos/test_oos_common.hpp
@@ -97,9 +97,11 @@ namespace test_oos_utils
     return large_data;
   }
 
-  /* Test-side wrapper for the caller-preallocated oos_read API. Production
-   * callers know the OOS length from the inline 8B field in the heap record;
-   * tests don't have that record, so we read the length via oos_get_length. */
+  /* Test-side wrapper for the span-based oos_read API. Production callers know
+   * the OOS length from the inline 8B field in the heap record; tests don't
+   * have that record, so we read the length via oos_get_length and hand
+   * oos_read a span sized to exactly that length. The RECDES wrapping is for
+   * the test's downstream convenience only — oos_read no longer touches it. */
   inline int oos_read_with_alloc (THREAD_ENTRY *thread_p, const OID &oid, RECDES &recdes)
   {
     recdes = RECDES{};
@@ -113,12 +115,14 @@ namespace test_oos_utils
       {
 	return err;
       }
-    err = oos_read (thread_p, oid, recdes);
+    err = oos_read (thread_p, oid, cubbase::span<char> (recdes.data, static_cast<std::size_t> (len)));
     if (err != NO_ERROR)
       {
 	recdes_free_data_area (&recdes);
+	return err;
       }
-    return err;
+    recdes.length = len;
+    return NO_ERROR;
   }
 
   inline int from_string_into_recdes (const std::string &large_data, RECDES &rec)

--- a/unit_tests/oos/test_oos_common.hpp
+++ b/unit_tests/oos/test_oos_common.hpp
@@ -24,8 +24,10 @@
 #include "dbi.h"
 #include "error_manager.h"
 #include "record_descriptor.hpp"
+#include "storage_common.h"
 #include "thread_manager.hpp"
 #include "page_buffer.h"
+#include "oos_file.hpp"
 
 static cubthread::entry *thread_p;
 
@@ -93,6 +95,30 @@ namespace test_oos_utils
       }
 
     return large_data;
+  }
+
+  /* Test-side wrapper for the caller-preallocated oos_read API. Production
+   * callers know the OOS length from the inline 8B field in the heap record;
+   * tests don't have that record, so we read the length via oos_get_length. */
+  inline int oos_read_with_alloc (THREAD_ENTRY *thread_p, const OID &oid, RECDES &recdes)
+  {
+    recdes = RECDES{};
+    int len = oos_get_length (thread_p, oid);
+    if (len < 0)
+      {
+	return er_errid ();
+      }
+    int err = recdes_allocate_data_area (&recdes, len);
+    if (err != NO_ERROR)
+      {
+	return err;
+      }
+    err = oos_read (thread_p, oid, recdes);
+    if (err != NO_ERROR)
+      {
+	recdes_free_data_area (&recdes);
+      }
+    return err;
   }
 
   inline int from_string_into_recdes (const std::string &large_data, RECDES &rec)

--- a/unit_tests/oos/test_oos_common.hpp
+++ b/unit_tests/oos/test_oos_common.hpp
@@ -115,7 +115,7 @@ namespace test_oos_utils
       {
 	return err;
       }
-    err = oos_read (thread_p, oid, cubbase::span<char> (recdes.data, static_cast<std::size_t> (len)));
+    err = oos_read (thread_p, oid, oos_buffer (recdes.data, static_cast<std::size_t> (len)));
     if (err != NO_ERROR)
       {
 	recdes_free_data_area (&recdes);

--- a/unit_tests/oos/test_oos_delete.cpp
+++ b/unit_tests/oos/test_oos_delete.cpp
@@ -149,7 +149,7 @@ TEST (OosDeleteTest, OosDeleteThenReadFails)
 
   // Reading a deleted slot should fail
   RECDES rec_out{};
-  int read_err = oos_read (thread_p, oid, rec_out);
+  int read_err = test_oos_utils::oos_read_with_alloc (thread_p, oid, rec_out);
   ASSERT_NE (read_err, NO_ERROR);
 
   // rec_out data area should not have been allocated if read failed
@@ -264,7 +264,7 @@ TEST (OosDeleteTest, OosUpdatePattern)
 
   // New record must still be readable and unchanged
   RECDES rec_out{};
-  err = oos_read (thread_p, new_oid, rec_out);
+  err = test_oos_utils::oos_read_with_alloc (thread_p, new_oid, rec_out);
   ASSERT_EQ (err, NO_ERROR);
   ASSERT_EQ (rec_out.length, rec_new.length);
   ASSERT_STREQ (rec_out.data, new_data.c_str());
@@ -272,7 +272,7 @@ TEST (OosDeleteTest, OosUpdatePattern)
 
   // Old OID must no longer be readable
   RECDES stale_out{};
-  int stale_err = oos_read (thread_p, old_oid, stale_out);
+  int stale_err = test_oos_utils::oos_read_with_alloc (thread_p, old_oid, stale_out);
   ASSERT_NE (stale_err, NO_ERROR);
   if (stale_out.data != nullptr)
     {
@@ -371,7 +371,7 @@ TEST (OosDeleteTest, OosDeleteLarge160KBMultiChunk)
 
   // Verify it can be read before deletion
   RECDES rec_check{};
-  err = oos_read (thread_p, oid, rec_check);
+  err = test_oos_utils::oos_read_with_alloc (thread_p, oid, rec_check);
   ASSERT_EQ (err, NO_ERROR);
   ASSERT_STREQ (rec_check.data, rec_in.data);
   recdes_free_data_area (&rec_check);
@@ -382,7 +382,7 @@ TEST (OosDeleteTest, OosDeleteLarge160KBMultiChunk)
 
   // Reading any chunk from the head OID must now fail
   RECDES rec_after{};
-  int read_err = oos_read (thread_p, oid, rec_after);
+  int read_err = test_oos_utils::oos_read_with_alloc (thread_p, oid, rec_after);
   ASSERT_NE (read_err, NO_ERROR);
   if (rec_after.data != nullptr)
     {

--- a/unit_tests/oos/test_oos_delete.cpp
+++ b/unit_tests/oos/test_oos_delete.cpp
@@ -101,7 +101,7 @@ TEST (OosDeleteTest, OosDeleteBasic)
   test_oos_utils::auto_freed_recdes_ptr defer_free_rec_in (&rec_in, recdes_free_data_area);
 
   OID oid = OID_INITIALIZER;
-  err = oos_insert (thread_p, oos_vfid, rec_in, oid);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_in, oid);
   ASSERT_EQ (err, NO_ERROR);
   ASSERT_NE (oid.pageid, NULL_PAGEID);
   test_oos_debug ("Inserted oid={vol=%d,page=%d,slot=%d}", oid.volid, oid.pageid, oid.slotid);
@@ -141,7 +141,7 @@ TEST (OosDeleteTest, OosDeleteThenReadFails)
   test_oos_utils::auto_freed_recdes_ptr defer_free (&rec_in, recdes_free_data_area);
 
   OID oid = OID_INITIALIZER;
-  err = oos_insert (thread_p, oos_vfid, rec_in, oid);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_in, oid);
   ASSERT_EQ (err, NO_ERROR);
 
   err = oos_delete (thread_p, oos_vfid, oid);
@@ -187,7 +187,7 @@ TEST (OosDeleteTest, OosDeleteMultiChunk)
   test_oos_utils::auto_freed_recdes_ptr defer_free (&rec_in, recdes_free_data_area);
 
   OID head_oid = OID_INITIALIZER;
-  err = oos_insert (thread_p, oos_vfid, rec_in, head_oid);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_in, head_oid);
   ASSERT_EQ (err, NO_ERROR);
   test_oos_debug ("head_oid={vol=%d,page=%d,slot=%d}", head_oid.volid, head_oid.pageid, head_oid.slotid);
 
@@ -248,11 +248,11 @@ TEST (OosDeleteTest, OosUpdatePattern)
   test_oos_utils::auto_freed_recdes_ptr defer_new (&rec_new, recdes_free_data_area);
 
   OID old_oid = OID_INITIALIZER;
-  err = oos_insert (thread_p, oos_vfid, rec_old, old_oid);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_old, old_oid);
   ASSERT_EQ (err, NO_ERROR);
 
   OID new_oid = OID_INITIALIZER;
-  err = oos_insert (thread_p, oos_vfid, rec_new, new_oid);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_new, new_oid);
   ASSERT_EQ (err, NO_ERROR);
 
   // Both OIDs should be different slots
@@ -303,7 +303,7 @@ TEST (OosDeleteTest, OosDeleteRestoresFreeSpace)
 
   // First insert establishes the page; record free space after it
   OID first_oid = OID_INITIALIZER;
-  err = oos_insert (thread_p, oos_vfid, rec_in, first_oid);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_in, first_oid);
   ASSERT_EQ (err, NO_ERROR);
 
   int free_after_first_insert = get_free_space_of_oid_page (first_oid);
@@ -315,7 +315,7 @@ TEST (OosDeleteTest, OosDeleteRestoresFreeSpace)
   test_oos_utils::auto_freed_recdes_ptr defer_target (&rec_target, recdes_free_data_area);
 
   OID target_oid = OID_INITIALIZER;
-  err = oos_insert (thread_p, oos_vfid, rec_target, target_oid);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_target, target_oid);
   ASSERT_EQ (err, NO_ERROR);
 
   // Both inserts should land on the same page (small data)
@@ -364,7 +364,7 @@ TEST (OosDeleteTest, OosDeleteLarge160KBMultiChunk)
   test_oos_utils::auto_freed_recdes_ptr defer_free (&rec_in, recdes_free_data_area);
 
   OID oid = OID_INITIALIZER;
-  err = oos_insert (thread_p, oos_vfid, rec_in, oid);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_in, oid);
   ASSERT_EQ (err, NO_ERROR);
   test_oos_debug ("Inserted 160KB record at oid={vol=%d,page=%d,slot=%d}",
 		  oid.volid, oid.pageid, oid.slotid);
@@ -412,7 +412,7 @@ TEST (OosDeleteTest, OosDeleteSlotBecomesUnknown)
   test_oos_utils::auto_freed_recdes_ptr defer_free (&rec_in, recdes_free_data_area);
 
   OID oid = OID_INITIALIZER;
-  err = oos_insert (thread_p, oos_vfid, rec_in, oid);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_in, oid);
   ASSERT_EQ (err, NO_ERROR);
   ASSERT_NE (oid.pageid, NULL_PAGEID);
 

--- a/unit_tests/oos/test_oos_remove_file.cpp
+++ b/unit_tests/oos/test_oos_remove_file.cpp
@@ -217,7 +217,7 @@ TEST (OosFileDestroyTest, OosFileDestroyMultipleFiles)
 
   // File 2 should still be readable
   RECDES rec_out{};
-  err = oos_read (thread_p, oid2, rec_out);
+  err = test_oos_utils::oos_read_with_alloc (thread_p, oid2, rec_out);
   ASSERT_EQ (err, NO_ERROR);
   ASSERT_STREQ (rec_out.data, "File 2 data");
   recdes_free_data_area (&rec_out);

--- a/unit_tests/oos/test_oos_remove_file.cpp
+++ b/unit_tests/oos/test_oos_remove_file.cpp
@@ -71,7 +71,7 @@ TEST (OosFileDestroyTest, OosFileDestroyWithData)
   test_oos_utils::auto_freed_recdes_ptr defer_free (&rec_in, recdes_free_data_area);
 
   OID oid = OID_INITIALIZER;
-  err = oos_insert (thread_p, oos_vfid, rec_in, oid);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_in, oid);
   ASSERT_EQ (err, NO_ERROR);
   ASSERT_NE (oid.pageid, NULL_PAGEID);
   test_oos_debug ("Inserted oid={vol=%d,page=%d,slot=%d}", oid.volid, oid.pageid, oid.slotid);
@@ -105,7 +105,7 @@ TEST (OosFileDestroyTest, OosFileDestroyWithMultiChunkData)
   test_oos_utils::auto_freed_recdes_ptr defer_free (&rec_in, recdes_free_data_area);
 
   OID oid = OID_INITIALIZER;
-  err = oos_insert (thread_p, oos_vfid, rec_in, oid);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_in, oid);
   ASSERT_EQ (err, NO_ERROR);
   test_oos_debug ("Inserted multi-chunk oid={vol=%d,page=%d,slot=%d}", oid.volid, oid.pageid, oid.slotid);
 
@@ -134,7 +134,7 @@ TEST (OosFileDestroyTest, OosFileDestroyCacheCleared)
   test_oos_utils::auto_freed_recdes_ptr defer_free (&rec_in, recdes_free_data_area);
 
   OID oid = OID_INITIALIZER;
-  err = oos_insert (thread_p, oos_vfid, rec_in, oid);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_in, oid);
   ASSERT_EQ (err, NO_ERROR);
 
   err = oos_remove_file (thread_p, oos_vfid);
@@ -162,7 +162,7 @@ TEST (OosFileDestroyTest, OosPageDestroyBasic)
   test_oos_utils::auto_freed_recdes_ptr defer_free (&rec_in, recdes_free_data_area);
 
   OID oid = OID_INITIALIZER;
-  err = oos_insert (thread_p, oos_vfid, rec_in, oid);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec_in, oid);
   ASSERT_EQ (err, NO_ERROR);
 
   // Get the VPID of the page where the record was inserted
@@ -204,11 +204,11 @@ TEST (OosFileDestroyTest, OosFileDestroyMultipleFiles)
   test_oos_utils::auto_freed_recdes_ptr defer_free2 (&rec2, recdes_free_data_area);
 
   OID oid1 = OID_INITIALIZER;
-  err = oos_insert (thread_p, oos_vfid1, rec1, oid1);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid1, rec1, oid1);
   ASSERT_EQ (err, NO_ERROR);
 
   OID oid2 = OID_INITIALIZER;
-  err = oos_insert (thread_p, oos_vfid2, rec2, oid2);
+  err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid2, rec2, oid2);
   ASSERT_EQ (err, NO_ERROR);
 
   // Destroy file 1


### PR DESCRIPTION
https://jira.cubrid.org/browse/CBRD-26741

> **TL;DR**: M2 부터 heap recdes 에 OOS 전체 길이가 8B 인라인으로 저장되므로 호출자가 버퍼 크기를 미리 알 수 있다. 이를 활용해 `oos_read` 가 더 이상 내부에서 버퍼를 할당하지 않도록 바꾸고, `oos_buffer` (= `cubbase::span<char>` 알리어스) 라는 caller-owned span 을 받아 직접 복사하도록 단순화했다. 같은 모양으로 `oos_insert` 도 `oos_buffer` 를 받도록 미러 리팩터링했다.

## Summary

- **변경 1 (read 측)**: `oos_read` 가 caller-owned `oos_buffer` (`cubbase::span<char>` 알리어스) 에 직접 쓰도록 변경. 멀티 청크 경로에서 첫 청크를 두 번 읽던 부분을 정리.
- **변경 2 (insert 측, oos_read 와 미러)**: `oos_insert` 도 `RECDES &` → `oos_buffer src` 로 통일. RECDES 의 `.type`/`.area_size` 책임이 사라지고, `oos_insert_across_pages` 의 청크 분할은 매 iteration `RECDES chunk_recdes{}` boilerplate → `src.subspan (offset, max)` 한 줄로 단순화 (`subspan` 이 offset bounds assert 와 tail clamping 을 모두 책임짐).
- **부수효과 (`locator_sr.c`)**: replication apply 경로가 caller 의 `*recdes` 를 mutate 해서 헤더를 스킵하던 코드 → span 오프셋 한 줄로 변경. caller 데이터 무손상.
- **신규 인프라**: `oos_buffer = cubbase::span<char>` 알리어스 (read dest / insert src 양방향용, C-file indent 포매터의 angle-bracket 망가짐 회피), `cubbase::byte_span_writer` (멀티 청크 read 의 overflow 가드를 단일 cursor invariant 로 통일).
- **이유**: 호출자가 이미 길이를 아는 상황이므로 내부 자체 할당과 첫 청크 중복 PEEK 는 불필요. RECDES 가 끼면 `.area_size` 책임이 모호해지지만 span 은 `size()` 가 길이 진실원으로 일의적.

## Description

CBRD-26630 으로 heap recdes 안에 `[OOS OID (8B) | OOS 전체 길이 (8B bigint)]` 가 인라인으로 들어오게 되면서, OOS 본문을 읽기 전에 이미 길이를 알 수 있게 되었다. 그런데 `oos_read` 는 여전히 내부에서 출력 버퍼를 할당하고, 멀티 청크일 때는 첫 청크를 한 번 더 PEEK 하던 구조였다.

`oos_insert` 쪽도 `RECDES &recdes` 를 받았는데, 실제로 사용하는 필드는 `.data`/`.length` 두 개뿐이고 `.type`/`.area_size` 는 무시되거나 caller 가 어쩔 수 없이 채워야 했다 (특히 read 쪽 scratch fast path 에서 `area_size` 를 거짓말로 채워야 했음). 두 API 모두 사실상 **"가변 바이트 영역"** 만 필요한데 RECDES 가 끼어들면서 길이의 진실원이 흐려졌다.

본 PR 은 두 API 모두 `oos_buffer` (caller-owned span) 로 통일하고, 멀티 청크 read 의 overflow 가드는 별도 `byte_span_writer` 로 모은다.

## Implementation

- **`src/storage/oos_file.hpp`** —
  - `oos_buffer = cubbase::span<char>` 알리어스 추가. `.c` 파일에서 GNU `indent` 의 `< char >` 공백 삽입 망가짐을 피하면서 의도("OOS 페이로드 교환용 byte span") 를 시그니처에서 바로 읽히게 한다. mutable `<char>` 인 이유는 단일 알리어스로 read dest / insert src 양방향을 커버하기 위함이며, `oos_insert` 는 본문에서 절대 mutate 하지 않는다 (시그니처 주석에 명시).
  - `oos_read` / `oos_insert` 모두 `oos_buffer` 를 받도록 시그니처 변경.
- **`src/storage/oos_file.cpp`** —
  - `oos_read` 와 내부 헬퍼(`oos_read_within_page`, `oos_read_across_pages`) 가 `byte_span_writer` 를 통해 caller span 에 바로 쓰도록 변경. `oos_pop_record_header` 등 더 이상 호출되지 않는 임시 버퍼 헬퍼 제거.
  - `oos_insert` / `oos_insert_within_page` / `oos_insert_across_pages` / `oos_prepend_header` 가 모두 `oos_buffer` 를 받도록 변경. across-pages 청크 분할은 `src.subspan (i * max, max)` 한 줄로 단순화 (`subspan` 이 offset 의 bounds assert 와 마지막 청크 tail clamping 을 모두 책임지므로 `std::min` 으로 손-계산하던 chunk_len 자체가 사라짐).
- **`src/base/byte_span_writer.hpp` (신규)** — `cubbase::span<char>` 위의 append-only 커서. 유일한 mutator `append(src, len)` 이 bounds check 후 memcpy. invariant `0 <= written <= capacity` 하나로 기존 손-동기화 카운터 (`expected_length` / `remaining` / `bytes_written`) 를 대체. 7개 단위 테스트 (overflow / 0-cap / 회복 / off-by-one) 포함.
- **`src/storage/heap_file.c`** —
  - `heap_attrvalue_point_variable` 의 read 경로: `or_get_oid` → `or_get_bigint` 으로 인라인 8B 길이를 읽어 scratch 또는 `recdes_allocate_data_area` 로 preallocate 후 `oos_read (thread_p, oid, oos_buffer (raw->data, oos_len))` 호출. scratch fast path 에서 더 이상 `raw->area_size` 를 거짓말로 채우지 않는다.
  - insert 경로: `heap_attrinfo_dbvalue_to_recdes` 의 RECDES 출력을 API 경계에서 `oos_buffer (recdes.data, recdes.length)` 로 좁혀 호출.
- **`src/transaction/locator_sr.c`** — `locator_oos_insert_force` 가 caller `*recdes` 를 mutate (data/length/type) 해서 OOS 헤더를 스킵하던 코드를 span 오프셋 한 줄로 교체. caller 데이터 무손상.
- **`unit_tests/oos/`** — 4개 테스트 파일 전체에서:
  - `test_oos_common.hpp` 에 `oos_read_with_alloc` (`oos_get_length → alloc → oos_read(span)`) 와 `oos_insert_from_recdes` (`oos_insert(span(recdes.data, recdes.length))`) 헬퍼 2개 추가.
  - read 호출 24개와 insert 호출 60여 개를 각각 위 헬퍼로 마이그레이션.

## Test Plan

- 로컬 `just build-test` 결과 13/13 통과:
  - OOS 코어 단위 테스트 (`test_oos`, `test_oos_delete`, `test_oos_remove_file`, `test_oos_bestspace`).
  - `byte_span_writer` 단위 테스트 7개 (overflow / cursor 불변 / 0-cap / 회복 / 정확히 off-by-one).
  - OOS SQL 회귀 6개 (`test_oos_sql_crud/ddl/delete/boundary/update_delete/txn`). SQL 회귀가 production 의 `heap_attrvalue_point_variable` → `or_get_bigint` → preallocate → `oos_read(oos_buffer)` 경로와 `oos_insert(oos_buffer)` 경로를 실제로 통과시킨다.
- `tc_CBRD26565_midxkey_oos_overflow.sql` 회귀도 통과.

## Remarks

- 선행 조건은 CBRD-26630 (인라인 OOS 길이 8B) 이다. 인라인 길이가 없으면 caller 가 preallocate 할 크기를 알 수 없으니 본 PR 은 그 위에서만 성립한다.
- M1 한계로 적어두었던 "OOS read 시 항상 COPY, 추가 memcpy" 중 "추가 memcpy" 한 단계를 줄이는 작업. 본격적인 PEEK/COPY 모드 분리와 DB_VALUE zero-copy 는 후속.
- `oos_buffer` 를 mutable `cubbase::span<char>` 로 둔 이유는 단일 알리어스로 양방향을 커버하기 위함. `oos_view = span<const char>` 별도 알리어스를 두는 안은 C-file indent 포매터의 angle-bracket 망가짐을 두 번 처리해야 해서 보류 (`oos_insert` 본문에서 mutate 하지 않음을 주석으로 명시).
