### PR TITLE
[CBRD-26684] Implement skeleton class for elastic worker pool.

### DIFF
--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -67,6 +67,7 @@ set(THREAD_HEADERS
   ${THREAD_DIR}/thread_waiter.hpp
   ${THREAD_DIR}/thread_worker_pool.hpp
   ${THREAD_DIR}/thread_worker_pool_impl.hpp
+  ${THREAD_DIR}/thread_worker_pool_elastic.hpp
   ${THREAD_DIR}/thread_worker_pool_taskcap.hpp
   )
 

--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -4170,19 +4170,19 @@ static size_t
 thread_stats_count (void)
 {
 #if defined (SERVER_MODE)
-  assert (PERFMON_PORTABLE_WORKER_STAT_COUNT == cubthread::stats_worker_pool_type::stats::get_count ());
+  assert (PERFMON_PORTABLE_WORKER_STAT_COUNT == worker_pool_type<stats_t::on>::stats::get_count ());
   static bool check_names = true;
   if (check_names)
     {
       for (size_t index = 0; index < PERFMON_PORTABLE_WORKER_STAT_COUNT; index++)
         {
-          if (std::strcmp (perfmon_Portable_worker_stat_names[index], cubthread::stats_worker_pool_type::stats::get_name (index)) != 0)
+          if (std::strcmp (perfmon_Portable_worker_stat_names[index], worker_pool_type<stats_t::on>::stats::get_name (index)) != 0)
             {
               assert (false);
               _er_log_debug (ARG_FILE_LINE,
                              "Warning - Monitoring thread worker statistics; statistics name not matching for %zu\n"
                              "\t\tperfmon name = %s\n" "\t\tdaemon name = %s\n", index,
-                             perfmon_Portable_worker_stat_names[index], cubthread::stats_worker_pool_type::stats::get_name (index));
+                             perfmon_Portable_worker_stat_names[index], worker_pool_type<stats_t::on>::stats::get_name (index));
             }
         }
       check_names = false;

--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -4170,19 +4170,19 @@ static size_t
 thread_stats_count (void)
 {
 #if defined (SERVER_MODE)
-  assert (PERFMON_PORTABLE_WORKER_STAT_COUNT == worker_pool_type<stats_t::on>::stats::get_count ());
+  assert (PERFMON_PORTABLE_WORKER_STAT_COUNT == worker_pool_type<cubthread::stats_t::on>::stats::get_count ());
   static bool check_names = true;
   if (check_names)
     {
       for (size_t index = 0; index < PERFMON_PORTABLE_WORKER_STAT_COUNT; index++)
         {
-          if (std::strcmp (perfmon_Portable_worker_stat_names[index], worker_pool_type<stats_t::on>::stats::get_name (index)) != 0)
+          if (std::strcmp (perfmon_Portable_worker_stat_names[index], worker_pool_type<cubthread::stats_t::on>::stats::get_name (index)) != 0)
             {
               assert (false);
               _er_log_debug (ARG_FILE_LINE,
                              "Warning - Monitoring thread worker statistics; statistics name not matching for %zu\n"
                              "\t\tperfmon name = %s\n" "\t\tdaemon name = %s\n", index,
-                             perfmon_Portable_worker_stat_names[index], worker_pool_type<stats_t::on>::stats::get_name (index));
+                             perfmon_Portable_worker_stat_names[index], worker_pool_type<cubthread::stats_t::on>::stats::get_name (index));
             }
         }
       check_names = false;

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -139,7 +139,7 @@ static HA_LOG_APPLIER_STATE_TABLE ha_Log_applier_state[HA_LOG_APPLIER_STATE_TABL
 static int ha_Log_applier_state_num = 0;
 
 // *INDENT-OFF*
-static cubthread::stats_worker_pool_type *css_Server_request_worker_pool = NULL;
+static worker_pool_type<stats_t::on> *css_Server_request_worker_pool = NULL;
 
 class css_server_task : public cubthread::entry_task
 {
@@ -212,7 +212,7 @@ static void css_stop_all_workers (THREAD_ENTRY & thread_ref, css_thread_stop_typ
 static void css_wp_worker_get_busy_count_mapper (THREAD_ENTRY & thread_ref, bool & stop_mapper, int &busy_count);
 
 // cubthread::stats_worker_pool_type::core_impl confuses indent
-static void css_wp_core_job_scan_mapper (const cubthread::stats_worker_pool_type::core_impl & wp_core, bool & stop_mapper,
+static void css_wp_core_job_scan_mapper (const worker_pool_type<stats_t::on>::core_impl & wp_core, bool & stop_mapper,
                                          THREAD_ENTRY * thread_p, SHOWSTMT_ARRAY_CONTEXT * ctx, size_t & core_index,
                                          int & error_code);
 static void
@@ -577,10 +577,12 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
   min_connection_workers = (int) prm_get_integer_value (PRM_ID_CSS_MIN_CONNECTION_WORKER);
 
   // create request worker pool
+  //*INDENT-OFF*
   css_Server_request_worker_pool =
-    thread_create_stats_worker_pool (task_worker, task_group, "transaction", thread_get_entry_manager (),
-				     css_get_server_request_thread_pooling_configuration (),
-				     css_get_server_request_thread_timeout_configuration ());
+    thread_create_worker_pool<stats_t::on> (task_worker, task_group, "transaction", thread_get_entry_manager (),
+					    css_get_server_request_thread_pooling_configuration (),
+					    css_get_server_request_thread_timeout_configuration ());
+  //*INDENT-ON*
   // m_log = cubthread::is_logging_configured (cubthread::LOG_WORKER_POOL_TRAN_WORKERS)
 
   if (css_Server_request_worker_pool == NULL)
@@ -2692,7 +2694,7 @@ css_wp_worker_get_busy_count_mapper (THREAD_ENTRY & thread_ref, bool & stop_mapp
 // error_code (out)     : output error_code if any errors occur
 //
 static void
-css_wp_core_job_scan_mapper (const cubthread::stats_worker_pool_type::core_impl & wp_core, bool & stop_mapper,
+css_wp_core_job_scan_mapper (const worker_pool_type<stats_t::on>::core_impl & wp_core, bool & stop_mapper,
                              THREAD_ENTRY * thread_p, SHOWSTMT_ARRAY_CONTEXT * ctx, size_t & core_index,
                              int & error_code)
 {

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -139,7 +139,7 @@ static HA_LOG_APPLIER_STATE_TABLE ha_Log_applier_state[HA_LOG_APPLIER_STATE_TABL
 static int ha_Log_applier_state_num = 0;
 
 // *INDENT-OFF*
-static worker_pool_type<stats_t::on> *css_Server_request_worker_pool = NULL;
+static worker_pool_type<cubthread::stats_t::on, cubthread::pool_t::elastic> *css_Server_request_worker_pool = NULL;
 
 class css_server_task : public cubthread::entry_task
 {
@@ -212,9 +212,11 @@ static void css_stop_all_workers (THREAD_ENTRY & thread_ref, css_thread_stop_typ
 static void css_wp_worker_get_busy_count_mapper (THREAD_ENTRY & thread_ref, bool & stop_mapper, int &busy_count);
 
 // cubthread::stats_worker_pool_type::core_impl confuses indent
-static void css_wp_core_job_scan_mapper (const worker_pool_type<stats_t::on>::core_impl & wp_core, bool & stop_mapper,
+template <typename WorkerPoolCore>
+static void css_wp_core_job_scan_mapper (const WorkerPoolCore & wp_core, bool & stop_mapper,
                                          THREAD_ENTRY * thread_p, SHOWSTMT_ARRAY_CONTEXT * ctx, size_t & core_index,
                                          int & error_code);
+
 static void
 css_is_any_thread_not_suspended_mapfunc (THREAD_ENTRY & thread_ref, bool & stop_mapper, size_t & count, bool & found);
 static void
@@ -264,7 +266,10 @@ css_job_queues_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VALUE ** a
     }
 
   size_t core_index = 0;	// core index starts with 0
-  css_Server_request_worker_pool->map_cores (css_wp_core_job_scan_mapper, thread_p, ctx, core_index, error);
+  //*INDENT-OFF*
+  using request_pool_core_t = worker_pool_type<cubthread::stats_t::on, cubthread::pool_t::elastic>::core_impl;
+  css_Server_request_worker_pool->map_cores (&css_wp_core_job_scan_mapper<request_pool_core_t>, thread_p, ctx, core_index, error);
+  //*INDENT-ON*
   if (error != NO_ERROR)
     {
       ASSERT_ERROR ();
@@ -579,9 +584,10 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
   // create request worker pool
   //*INDENT-OFF*
   css_Server_request_worker_pool =
-    thread_create_worker_pool<stats_t::on> (task_worker, task_group, "transaction", thread_get_entry_manager (),
-					    css_get_server_request_thread_pooling_configuration (),
-					    css_get_server_request_thread_timeout_configuration ());
+    thread_create_worker_pool<cubthread::stats_t::on, cubthread::pool_t::elastic> (task_worker, task_group, "transaction",
+							     thread_get_entry_manager (),
+							     css_get_server_request_thread_pooling_configuration (),
+							     css_get_server_request_thread_timeout_configuration ());
   //*INDENT-ON*
   // m_log = cubthread::is_logging_configured (cubthread::LOG_WORKER_POOL_TRAN_WORKERS)
 
@@ -2693,8 +2699,9 @@ css_wp_worker_get_busy_count_mapper (THREAD_ENTRY & thread_ref, bool & stop_mapp
 // core_index (in/out)  : current core index; is incremented on each call
 // error_code (out)     : output error_code if any errors occur
 //
+template <typename WorkerPoolCore>
 static void
-css_wp_core_job_scan_mapper (const worker_pool_type<stats_t::on>::core_impl & wp_core, bool & stop_mapper,
+css_wp_core_job_scan_mapper (const WorkerPoolCore & wp_core, bool & stop_mapper,
                              THREAD_ENTRY * thread_p, SHOWSTMT_ARRAY_CONTEXT * ctx, size_t & core_index,
                              int & error_code)
 {

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -211,7 +211,7 @@ static bool css_is_log_writer (const THREAD_ENTRY & thread_arg);
 static void css_stop_all_workers (THREAD_ENTRY & thread_ref, css_thread_stop_type stop_phase);
 static void css_wp_worker_get_busy_count_mapper (THREAD_ENTRY & thread_ref, bool & stop_mapper, int &busy_count);
 
-// cubthread::stats_worker_pool_type::core_impl confuses indent
+// WorkerPoolCore template parameter confuses indent
 template <typename WorkerPoolCore>
 static void css_wp_core_job_scan_mapper (const WorkerPoolCore & wp_core, bool & stop_mapper,
                                          THREAD_ENTRY * thread_p, SHOWSTMT_ARRAY_CONTEXT * ctx, size_t & core_index,

--- a/src/loaddb/load_worker_manager.cpp
+++ b/src/loaddb/load_worker_manager.cpp
@@ -63,7 +63,7 @@ namespace cubload
   static std::mutex g_wp_mutex;
   static std::condition_variable g_wp_condvar;
   std::set<session *> g_active_sessions;
-  static worker_pool_type<stats_t::on> *g_worker_pool;
+  static worker_pool_type<cubthread::stats_t::on> *g_worker_pool;
   static worker_entry_manager *g_wp_entry_manager;
   static cubthread::worker_pool_task_capper *g_wp_task_capper;
 
@@ -121,7 +121,7 @@ namespace cubload
 	unsigned int pool_size = prm_get_integer_value (PRM_ID_LOADDB_WORKER_COUNT);
 
 	g_wp_entry_manager = new worker_entry_manager (pool_size);
-	g_worker_pool = thread_create_worker_pool<stats_t::on> (pool_size, 1, "loaddb", *g_wp_entry_manager, true);
+	g_worker_pool = thread_create_worker_pool<cubthread::stats_t::on> (pool_size, 1, "loaddb", *g_wp_entry_manager, true);
 	// m_log = false
 
 	g_wp_task_capper = new cubthread::worker_pool_task_capper (g_worker_pool);

--- a/src/loaddb/load_worker_manager.cpp
+++ b/src/loaddb/load_worker_manager.cpp
@@ -63,7 +63,7 @@ namespace cubload
   static std::mutex g_wp_mutex;
   static std::condition_variable g_wp_condvar;
   std::set<session *> g_active_sessions;
-  static cubthread::stats_worker_pool_type *g_worker_pool;
+  static worker_pool_type<stats_t::on> *g_worker_pool;
   static worker_entry_manager *g_wp_entry_manager;
   static cubthread::worker_pool_task_capper *g_wp_task_capper;
 
@@ -121,7 +121,7 @@ namespace cubload
 	unsigned int pool_size = prm_get_integer_value (PRM_ID_LOADDB_WORKER_COUNT);
 
 	g_wp_entry_manager = new worker_entry_manager (pool_size);
-	g_worker_pool = thread_create_stats_worker_pool (pool_size, 1, "loaddb", *g_wp_entry_manager, true);
+	g_worker_pool = thread_create_worker_pool<stats_t::on> (pool_size, 1, "loaddb", *g_wp_entry_manager, true);
 	// m_log = false
 
 	g_wp_task_capper = new cubthread::worker_pool_task_capper (g_worker_pool);

--- a/src/query/parallel/px_worker_manager_global.hpp
+++ b/src/query/parallel/px_worker_manager_global.hpp
@@ -54,7 +54,7 @@ namespace parallel_query
       friend class worker_manager;
 
       /* member variables (ordered by size for alignment) */
-      cubthread::worker_pool_type *m_worker_pool;
+      worker_pool_type<> *m_worker_pool;
       std::once_flag m_init_flag;
       std::atomic<int> m_available;
       int m_capacity;

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -939,7 +939,7 @@ static cubthread::daemon *vacuum_Master_daemon = NULL;                       // 
 static vacuum_master_entry_manager *vacuum_Master_entry_manager = NULL;  // entry manager
 
 // vacuum worker globals
-static worker_pool_type<stats_t::on> *vacuum_Worker_threads = NULL;   // thread pool
+static worker_pool_type<cubthread::stats_t::on> *vacuum_Worker_threads = NULL;   // thread pool
 static vacuum_worker_entry_manager *vacuum_Worker_entry_manager = NULL;	  // entry manager
 
 /* *INDENT-ON* */
@@ -1339,7 +1339,7 @@ vacuum_boot (THREAD_ENTRY * thread_p)
     || flag<int>::is_flag_set (prm_get_integer_value (PRM_ID_ER_LOG_VACUUM), VACUUM_ER_LOG_WORKER);
 
   // create thread pool
-  vacuum_Worker_threads = thread_create_worker_pool<stats_t::on> (prm_get_integer_value (PRM_ID_VACUUM_WORKER_COUNT), 1, "vacuum", *vacuum_Worker_entry_manager);
+  vacuum_Worker_threads = thread_create_worker_pool<cubthread::stats_t::on> (prm_get_integer_value (PRM_ID_VACUUM_WORKER_COUNT), 1, "vacuum", *vacuum_Worker_entry_manager);
   // m_log = log_vacuum_worker_pool
 
   assert (vacuum_Worker_threads != NULL);

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -939,7 +939,7 @@ static cubthread::daemon *vacuum_Master_daemon = NULL;                       // 
 static vacuum_master_entry_manager *vacuum_Master_entry_manager = NULL;  // entry manager
 
 // vacuum worker globals
-static cubthread::stats_worker_pool_type *vacuum_Worker_threads = NULL;   // thread pool
+static worker_pool_type<stats_t::on> *vacuum_Worker_threads = NULL;   // thread pool
 static vacuum_worker_entry_manager *vacuum_Worker_entry_manager = NULL;	  // entry manager
 
 /* *INDENT-ON* */
@@ -1339,7 +1339,7 @@ vacuum_boot (THREAD_ENTRY * thread_p)
     || flag<int>::is_flag_set (prm_get_integer_value (PRM_ID_ER_LOG_VACUUM), VACUUM_ER_LOG_WORKER);
 
   // create thread pool
-  vacuum_Worker_threads = thread_create_stats_worker_pool (prm_get_integer_value (PRM_ID_VACUUM_WORKER_COUNT), 1, "vacuum", *vacuum_Worker_entry_manager);
+  vacuum_Worker_threads = thread_create_worker_pool<stats_t::on> (prm_get_integer_value (PRM_ID_VACUUM_WORKER_COUNT), 1, "vacuum", *vacuum_Worker_entry_manager);
   // m_log = log_vacuum_worker_pool
 
   assert (vacuum_Worker_threads != NULL);

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -4889,7 +4889,7 @@ online_index_builder (THREAD_ENTRY * thread_p, BTID_INT * btid_int, HFID * hfids
   assert (ib_thread_count <= 16);
 
   // a worker pool is built only of loading is done in parallel
-  cubthread::worker_pool_type *ib_workpool =
+  worker_pool_type<> *ib_workpool =
     is_parallel ? thread_create_worker_pool (ib_thread_count, 1, "online-index", load_context) : NULL;
   // m_log = btree_is_worker_pool_logging_true ()
 

--- a/src/thread/thread_compat.hpp
+++ b/src/thread/thread_compat.hpp
@@ -29,11 +29,26 @@
 // forward definition for THREAD_ENTRY
 #if defined (SERVER_MODE) || (defined (SA_MODE) && defined (__cplusplus))
 #include <thread>
-#ifndef _THREAD_ENTRY_HPP_
 namespace cubthread
 {
   class entry;
+
+  enum class stats : bool
+  {
+    on = true,
+    off = false
+  };
+
+  enum class pool_type
+  {
+    basic,
+    elastic
+  };
+
 } // namespace cubthread
+typedef cubthread::stats stats_t;
+typedef cubthread::pool_type pool_t;
+#ifndef _THREAD_ENTRY_HPP_
 typedef cubthread::entry THREAD_ENTRY;
 typedef std::thread::id thread_id_t;
 #endif // _THREAD_ENTRY_HPP_
@@ -41,6 +56,8 @@ typedef std::thread::id thread_id_t;
 #else // not SERVER_MODE and not SA_MODE-C++
 // client or SA_MODE annoying grammars
 typedef void THREAD_ENTRY;
+typedef bool stats_t;
+typedef unsigned int pool_t;
 typedef unsigned long int thread_id_t;
 #endif // not SERVER_MODE and not SA_MODE
 

--- a/src/thread/thread_compat.hpp
+++ b/src/thread/thread_compat.hpp
@@ -33,21 +33,19 @@ namespace cubthread
 {
   class entry;
 
-  enum class stats : bool
+  enum class stats_t : bool
   {
     on = true,
     off = false
   };
 
-  enum class pool_type
+  enum class pool_t : std::uint8_t
   {
     basic,
     elastic
   };
 
 } // namespace cubthread
-typedef cubthread::stats stats_t;
-typedef cubthread::pool_type pool_t;
 #ifndef _THREAD_ENTRY_HPP_
 typedef cubthread::entry THREAD_ENTRY;
 typedef std::thread::id thread_id_t;
@@ -56,8 +54,6 @@ typedef std::thread::id thread_id_t;
 #else // not SERVER_MODE and not SA_MODE-C++
 // client or SA_MODE annoying grammars
 typedef void THREAD_ENTRY;
-typedef bool stats_t;
-typedef unsigned int pool_t;
 typedef unsigned long int thread_id_t;
 #endif // not SERVER_MODE and not SA_MODE
 

--- a/src/thread/thread_manager.hpp
+++ b/src/thread/thread_manager.hpp
@@ -28,18 +28,21 @@
 #endif // not SERVER_MODE and not SA_MODE
 
 // same module includes
+#include "thread_compat.hpp"
 #include "thread_entry.hpp"
 #include "thread_entry_task.hpp"
 #include "thread_task.hpp"
 #include "thread_waiter.hpp"
 #if defined (SERVER_MODE)
 #include "thread_worker_pool_impl.hpp"
+#include "thread_worker_pool_elastic.hpp"
 #endif
 
 // other module includes
 #include "count_registry.hpp"
 #include "base_flag.hpp"
 
+#include <type_traits>
 #include <mutex>
 #include <vector>
 
@@ -278,17 +281,6 @@ namespace cubthread
   };
 
   //////////////////////////////////////////////////////////////////////////
-  // alias
-  //////////////////////////////////////////////////////////////////////////
-#if defined (SERVER_MODE)
-  using worker_pool_type = cubthread::worker_pool_impl<false>;
-  using stats_worker_pool_type = cubthread::worker_pool_impl<true>;
-#else
-  using worker_pool_type = cubthread::worker_pool;
-  using stats_worker_pool_type = cubthread::worker_pool;
-#endif
-
-  //////////////////////////////////////////////////////////////////////////
   // thread logging flags
   //
   // TODO: complete thread logging for all modules
@@ -498,6 +490,31 @@ namespace cubthread
 #define REGISTER_DAEMON(name) static cubthread::manager::daemon_registry_t _gl_reg_daemon_##name (#name, 1)
 
 //////////////////////////////////////////////////////////////////////////
+// alias
+//////////////////////////////////////////////////////////////////////////
+
+#if defined (SERVER_MODE)
+template <
+	stats_t Stats = stats_t::off,
+	pool_t Type = pool_t::basic
+	>
+using worker_pool_type =
+	std::conditional_t<Type == pool_t::basic, cubthread::worker_pool_impl<Stats>,
+	std::conditional_t<Type == pool_t::elastic, cubthread::worker_pool_elastic<Stats>,
+	cubthread::worker_pool>>;
+#else
+template <stats_t Stats = stats_t::off, pool_t Type = pool_t::basic>
+using worker_pool_type = cubthread::worker_pool;
+#endif
+
+template <stats_t Stats = stats_t::off, pool_t Type = pool_t::basic, typename ... Args>
+worker_pool_type<Stats, Type> *
+thread_create_worker_pool (Args &&... args)
+{
+  return cubthread::get_manager ()->create_worker_pool<worker_pool_type<Stats, Type>> (std::forward<Args> (args)...);
+}
+
+//////////////////////////////////////////////////////////////////////////
 // alias functions to be used in C legacy code
 //
 // use inline functions instead of definitions
@@ -513,23 +530,6 @@ inline cubthread::entry_manager &
 thread_get_entry_manager (void)
 {
   return cubthread::get_manager ()->get_entry_manager ();
-}
-
-inline cubthread::worker_pool_type *
-thread_create_worker_pool (std::size_t pool_size, std::size_t core_count, const char *name,
-			   cubthread::entry_manager &entry_mgr, bool pool_threads = false)
-{
-  return cubthread::get_manager ()->create_worker_pool<cubthread::worker_pool_type> (pool_size, core_count, name,
-	 entry_mgr, pool_threads);
-}
-
-inline cubthread::stats_worker_pool_type *
-thread_create_stats_worker_pool (std::size_t pool_size, std::size_t core_count, const char *name,
-				 cubthread::entry_manager &entry_mgr, bool pool_threads = false,
-				 cubthread::wait_seconds idle_timeout = std::chrono::seconds (5))
-{
-  return cubthread::get_manager ()->create_worker_pool<cubthread::stats_worker_pool_type> (pool_size, core_count, name,
-	 entry_mgr, pool_threads, idle_timeout);
 }
 
 inline std::size_t

--- a/src/thread/thread_manager.hpp
+++ b/src/thread/thread_manager.hpp
@@ -495,19 +495,20 @@ namespace cubthread
 
 #if defined (SERVER_MODE)
 template <
-	stats_t Stats = stats_t::off,
-	pool_t Type = pool_t::basic
+	cubthread::stats_t Stats = cubthread::stats_t::off,
+	cubthread::pool_t Type = cubthread::pool_t::basic
 	>
 using worker_pool_type =
-	std::conditional_t<Type == pool_t::basic, cubthread::worker_pool_impl<Stats>,
-	std::conditional_t<Type == pool_t::elastic, cubthread::worker_pool_elastic<Stats>,
+	std::conditional_t<Type == cubthread::pool_t::basic, cubthread::worker_pool_impl<Stats>,
+	std::conditional_t<Type == cubthread::pool_t::elastic, cubthread::worker_pool_elastic<Stats>,
 	cubthread::worker_pool>>;
 #else
-template <stats_t Stats = stats_t::off, pool_t Type = pool_t::basic>
+template <cubthread::stats_t Stats = cubthread::stats_t::off, cubthread::pool_t Type = cubthread::pool_t::basic>
 using worker_pool_type = cubthread::worker_pool;
 #endif
 
-template <stats_t Stats = stats_t::off, pool_t Type = pool_t::basic, typename ... Args>
+template <cubthread::stats_t Stats = cubthread::stats_t::off, cubthread::pool_t Type = cubthread::pool_t::basic,
+	  typename ... Args>
 worker_pool_type<Stats, Type> *
 thread_create_worker_pool (Args &&... args)
 {

--- a/src/thread/thread_worker_pool_elastic.hpp
+++ b/src/thread/thread_worker_pool_elastic.hpp
@@ -123,6 +123,6 @@ namespace cubthread
   {
   }
 
-}
+} // namespace cubthread
 
 #endif // _THREAD_WORKER_POOL_ELASTIC_HPP_

--- a/src/thread/thread_worker_pool_elastic.hpp
+++ b/src/thread/thread_worker_pool_elastic.hpp
@@ -38,35 +38,35 @@
 
 namespace cubthread
 {
-  // elastic_worker_pool<Stats>
+  // worker_pool_elastic<Stats>
   //
   // description
   //    worker pool that maintains target concurrency by spawning
   //    additional workers when existing workers enter a known wait
   //    (e.g., blocked on a transaction lock).
-  template <bool Stats>
-  class elastic_worker_pool : public worker_pool_impl<Stats>
+  template <stats_t Stats>
+  class worker_pool_elastic : public worker_pool_impl<Stats>
   {
     public:
       // forward definition
       class core_elastic;
 
-      ~elastic_worker_pool ();
+      ~worker_pool_elastic ();
 
     protected:
-      elastic_worker_pool (std::size_t pool_size, std::size_t core_count, const char *name, entry_manager &entry_mgr,
+      worker_pool_elastic (std::size_t pool_size, std::size_t core_count, const char *name, entry_manager &entry_mgr,
 			   bool pool_threads = false, wait_seconds idle_timeout = std::chrono::seconds (5));
 
       std::unique_ptr<worker_pool::core> allocate_core (bool pool_threads) override;
   };
 
-  // elastic_worker_pool<Stats>::core_elastic
+  // worker_pool_elastic<Stats>::core_elastic
   //
   // description
   //    TODO: add description
   //
-  template <bool Stats>
-  class elastic_worker_pool<Stats>::core_elastic : public worker_pool_impl<Stats>::core_impl
+  template <stats_t Stats>
+  class worker_pool_elastic<Stats>::core_elastic : public worker_pool_impl<Stats>::core_impl
   {
     public:
       ~core_elastic ();
@@ -80,40 +80,40 @@ namespace cubthread
 namespace cubthread
 {
   //////////////////////////////////////////////////////////////////////////
-  // elastic_worker_pool<Stats>
+  // worker_pool_elastic<Stats>
   //////////////////////////////////////////////////////////////////////////
 
-  template <bool Stats>
-  elastic_worker_pool<Stats>::elastic_worker_pool (std::size_t pool_size, std::size_t core_count, const char *name,
+  template <stats_t Stats>
+  worker_pool_elastic<Stats>::worker_pool_elastic (std::size_t pool_size, std::size_t core_count, const char *name,
       entry_manager &entry_mgr, bool pool_threads, wait_seconds idle_timeout)
     : worker_pool_impl<Stats> (pool_size, core_count, name, entry_mgr, pool_threads, idle_timeout)
   {
   }
 
-  template <bool Stats>
-  elastic_worker_pool<Stats>::~elastic_worker_pool ()
+  template <stats_t Stats>
+  worker_pool_elastic<Stats>::~worker_pool_elastic ()
   {
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   std::unique_ptr<typename worker_pool::core>
-  elastic_worker_pool<Stats>::allocate_core (bool pool_threads)
+  worker_pool_elastic<Stats>::allocate_core (bool pool_threads)
   {
     return std::unique_ptr<worker_pool::core> (new core_elastic (pool_threads));
   }
 
   //////////////////////////////////////////////////////////////////////////
-  // elastic_worker_pool<Stats>::core_elastic
+  // worker_pool_elastic<Stats>::core_elastic
   //////////////////////////////////////////////////////////////////////////
 
-  template <bool Stats>
-  elastic_worker_pool<Stats>::core_elastic::core_elastic (bool pool_threads)
+  template <stats_t Stats>
+  worker_pool_elastic<Stats>::core_elastic::core_elastic (bool pool_threads)
     : worker_pool_impl<Stats>::core_impl (pool_threads)
   {
   }
 
-  template <bool Stats>
-  elastic_worker_pool<Stats>::core_elastic::~core_elastic ()
+  template <stats_t Stats>
+  worker_pool_elastic<Stats>::core_elastic::~core_elastic ()
   {
   }
 

--- a/src/thread/thread_worker_pool_elastic.hpp
+++ b/src/thread/thread_worker_pool_elastic.hpp
@@ -1,0 +1,122 @@
+/*
+ *
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+/*
+ * thread_worker_pool_elastic.hpp
+ */
+
+#ifndef _THREAD_WORKER_POOL_ELASTIC_HPP_
+#define _THREAD_WORKER_POOL_ELASTIC_HPP_
+
+#if !defined (SERVER_MODE)
+#error Wrong module
+#endif // not SERVER_MODE
+
+// same module include
+#include "thread_worker_pool_impl.hpp"
+
+// cubrid includes
+#include "error_manager.h"
+
+// system includes
+#include <chrono>
+
+namespace cubthread
+{
+  // elastic_worker_pool<Stats>
+  //
+  // description
+  //    worker pool that maintains target concurrency by spawning
+  //    additional workers when existing workers enter a known wait
+  //    (e.g., blocked on a transaction lock).
+  template <bool Stats>
+  class elastic_worker_pool : public worker_pool_impl<Stats>
+  {
+    public:
+      // forward definition
+      class core_elastic;
+
+      ~elastic_worker_pool ();
+
+    protected:
+      elastic_worker_pool (std::size_t pool_size, std::size_t core_count, const char *name, entry_manager &entry_mgr,
+			   bool pool_threads = false, wait_seconds idle_timeout = std::chrono::seconds (5));
+
+      std::unique_ptr<worker_pool::core> allocate_core (bool pool_threads) override;
+  };
+
+  // elastic_worker_pool<Stats>::core_elastic
+  //
+  // description
+  //    TODO: add description
+  //
+  template <bool Stats>
+  class elastic_worker_pool<Stats>::core_elastic : public worker_pool_impl<Stats>::core_impl
+  {
+    public:
+      ~core_elastic ();
+
+    protected:
+      core_elastic (bool pool_threads);
+  };
+
+} // namespace cubthread
+
+namespace cubthread
+{
+  //////////////////////////////////////////////////////////////////////////
+  // elastic_worker_pool<Stats>
+  //////////////////////////////////////////////////////////////////////////
+
+  template <bool Stats>
+  elastic_worker_pool<Stats>::elastic_worker_pool (std::size_t pool_size, std::size_t core_count, const char *name,
+      entry_manager &entry_mgr, bool pool_threads, wait_seconds idle_timeout)
+    : worker_pool_impl<Stats> (pool_size, core_count, name, entry_mgr, pool_threads, idle_timeout)
+  {
+  }
+
+  template <bool Stats>
+  elastic_worker_pool<Stats>::~elastic_worker_pool ()
+  {
+  }
+
+  template <bool Stats>
+  std::unique_ptr<typename worker_pool::core>
+  elastic_worker_pool<Stats>::allocate_core (bool pool_threads)
+  {
+    return std::unique_ptr<worker_pool::core> (new core_elastic (pool_threads));
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // elastic_worker_pool<Stats>::core_elastic
+  //////////////////////////////////////////////////////////////////////////
+
+  template <bool Stats>
+  elastic_worker_pool<Stats>::core_elastic::core_elastic (bool pool_threads)
+    : worker_pool_impl<Stats>::core_impl (pool_threads)
+  {
+  }
+
+  template <bool Stats>
+  elastic_worker_pool<Stats>::core_elastic::~core_elastic ()
+  {
+  }
+
+}
+
+#endif

--- a/src/thread/thread_worker_pool_elastic.hpp
+++ b/src/thread/thread_worker_pool_elastic.hpp
@@ -44,9 +44,13 @@ namespace cubthread
   //    worker pool that maintains target concurrency by spawning
   //    additional workers when existing workers enter a known wait
   //    (e.g., blocked on a transaction lock).
+  //
   template <stats_t Stats>
   class worker_pool_elastic : public worker_pool_impl<Stats>
   {
+      // forward definition for nested core class
+      friend class manager;
+
     public:
       // forward definition
       class core_elastic;
@@ -68,6 +72,8 @@ namespace cubthread
   template <stats_t Stats>
   class worker_pool_elastic<Stats>::core_elastic : public worker_pool_impl<Stats>::core_impl
   {
+      friend class worker_pool_elastic;
+
     public:
       ~core_elastic ();
 
@@ -119,4 +125,4 @@ namespace cubthread
 
 }
 
-#endif
+#endif // _THREAD_WORKER_POOL_ELASTIC_HPP_

--- a/src/thread/thread_worker_pool_impl.hpp
+++ b/src/thread/thread_worker_pool_impl.hpp
@@ -106,7 +106,6 @@ namespace cubthread
   template <stats_t Stats>
   class worker_pool_impl : public worker_pool
   {
-    public:
       // forward definition for nested core class
       friend class manager;
 

--- a/src/thread/thread_worker_pool_impl.hpp
+++ b/src/thread/thread_worker_pool_impl.hpp
@@ -28,6 +28,7 @@
 #endif // not SERVER_MODE
 
 // same module include
+#include "thread_compat.hpp"
 #include "thread_task.hpp"
 #include "thread_entry.hpp"
 #include "thread_worker_pool.hpp"
@@ -102,7 +103,7 @@ namespace cubthread
   //    core manages a number of workers, tracks available resource - free active workers and inactive workers and
   //    queues tasks that could not be executed immediately.
   //
-  template <bool Stats>
+  template <stats_t Stats>
   class worker_pool_impl : public worker_pool
   {
     public:
@@ -216,7 +217,7 @@ namespace cubthread
   // description
   //    empty if Stats is false
   //
-  template <bool Stats>
+  template <stats_t Stats>
   class worker_pool_impl<Stats>::stats_base
   {
     public:
@@ -232,7 +233,7 @@ namespace cubthread
   };
 
   template <>
-  class worker_pool_impl<true>::stats_base
+  class worker_pool_impl<stats_t::on>::stats_base
   {
     public:
       stats_base ();
@@ -259,7 +260,7 @@ namespace cubthread
   //    task in: execute_task
   //    task out: execute_task (immediately execute) or get_task_or_become_available (queued task)
   //
-  template <bool Stats>
+  template <stats_t Stats>
   class worker_pool_impl<Stats>::core_impl : public worker_pool::core
   {
       friend class worker_pool_impl;
@@ -335,7 +336,7 @@ namespace cubthread
   //    the worker is a worker pool nested class and represents one instance of execution. its purpose is to store the
   //    context, manage multiple task executions of a single thread and collect statistics.
   //
-  template <bool Stats>
+  template <stats_t Stats>
   class worker_pool_impl<Stats>::core_impl::worker_impl : public worker_pool::core::worker
   {
       friend class core_impl;
@@ -413,7 +414,7 @@ namespace cubthread
   // description
   //    wrapper task for timing.
   //
-  template <bool Stats>
+  template <stats_t Stats>
   class worker_pool_impl<Stats>::wrapped_task
   {
     private:
@@ -431,7 +432,7 @@ namespace cubthread
 	// Other stats might be added here
       };
 
-      using inner_type = typename std::conditional_t<Stats, task_with_stats, task_only>;
+      using inner_type = typename std::conditional_t<Stats == stats_t::on, task_with_stats, task_only>;
 
     public:
       explicit wrapped_task (task_type *task_p);
@@ -457,7 +458,7 @@ namespace cubthread
   // statistics
   //////////////////////////////////////////////////////////////////////////
 
-  template <bool Stats>
+  template <stats_t Stats>
   class worker_pool_impl<Stats>::stats
   {
     public:
@@ -521,7 +522,7 @@ namespace cubthread
   // worker_pool_impl<Stats>
   //////////////////////////////////////////////////////////////////////////
 
-  template <bool Stats>
+  template <stats_t Stats>
   worker_pool_impl<Stats>::worker_pool_impl (std::size_t pool_size, std::size_t core_count, const char *name,
       entry_manager &entry_mgr, bool pool_threads, wait_seconds idle_timeout)
     : worker_pool (name, entry_mgr, pool_threads, idle_timeout)
@@ -540,14 +541,14 @@ namespace cubthread
       }
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   worker_pool_impl<Stats>::~worker_pool_impl ()
   {
     // not safe to destroy running pools
     assert (m_stopped);
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::initialize (std::size_t worker_count, std::size_t core_count)
   {
@@ -555,14 +556,14 @@ namespace cubthread
     assign_workers_to_cores (worker_count);
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::execute (task_type *work_arg)
   {
     execute_on_core (work_arg, get_next_core ());
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::execute_on_core (task_type *work_arg, std::size_t core_hash, bool is_temp)
   {
@@ -572,14 +573,14 @@ namespace cubthread
     m_cores[core_index]->execute_task (work_arg, is_temp);
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   bool
   worker_pool_impl<Stats>::is_running (void) const
   {
     return !m_stopped;
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::warmup (void)
   {
@@ -589,7 +590,7 @@ namespace cubthread
       }
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::stop_execution (void)
   {
@@ -651,21 +652,21 @@ namespace cubthread
       }
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   std::size_t
   worker_pool_impl<Stats>::get_worker_count (void) const
   {
     return m_max_workers;
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   std::size_t
   worker_pool_impl<Stats>::get_core_count (void) const
   {
     return m_cores.size ();
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::get_stats (cubperf::stat_value *stats_out) const
   {
@@ -675,11 +676,11 @@ namespace cubthread
       }
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::er_log_stats (void) const
   {
-    if constexpr (Stats)
+    if constexpr (Stats == stats_t::on)
       {
 	std::vector<cubperf::stat_value> statset (stats::get_count (), 0);
 	std::stringstream ss;
@@ -699,7 +700,7 @@ namespace cubthread
       }
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   template <typename Func, typename ... Args>
   void
   worker_pool_impl<Stats>::map_running_contexts (Func &&func, Args &&... args)
@@ -718,7 +719,7 @@ namespace cubthread
       }
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   template <typename Func, typename ... Args>
   void
   worker_pool_impl<Stats>::map_cores (Func &&func, Args &&... args)
@@ -735,14 +736,14 @@ namespace cubthread
       }
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   std::unique_ptr<typename worker_pool::core>
   worker_pool_impl<Stats>::allocate_core (bool pool_threads)
   {
     return std::unique_ptr<core> (new core_impl (pool_threads));
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::allocate_cores (std::size_t core_count)
   {
@@ -755,7 +756,7 @@ namespace cubthread
       }
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::assign_workers_to_cores (std::size_t worker_count)
   {
@@ -777,14 +778,14 @@ namespace cubthread
       }
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   std::size_t
   worker_pool_impl<Stats>::get_next_core (void)
   {
     return get_round_robin_core_hash ();
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   std::size_t
   worker_pool_impl<Stats>::get_round_robin_core_hash (void)
   {
@@ -830,27 +831,27 @@ namespace cubthread
   //////////////////////////////////////////////////////////////////////////
 
   inline
-  worker_pool_impl<true>::stats_base::stats_base ()
+  worker_pool_impl<stats_t::on>::stats_base::stats_base ()
     : statset (nullptr)
     , time ()
   {
   }
 
   inline
-  worker_pool_impl<true>::stats_base::~stats_base ()
+  worker_pool_impl<stats_t::on>::stats_base::~stats_base ()
   {
   }
 
   inline
-  worker_pool_impl<true>::stats_base::stats_base (stats_base &&other)
+  worker_pool_impl<stats_t::on>::stats_base::stats_base (stats_base &&other)
     : statset (other.statset)
     , time (other.time)
   {
     other.statset = nullptr;
   }
 
-  inline worker_pool_impl<true>::stats_base &
-  worker_pool_impl<true>::stats_base::operator= (stats_base &&other)
+  inline worker_pool_impl<stats_t::on>::stats_base &
+  worker_pool_impl<stats_t::on>::stats_base::operator= (stats_base &&other)
   {
     if (this != &other)
       {
@@ -866,18 +867,18 @@ namespace cubthread
   // worker_pool_impl<Stats>::core_impl
   //////////////////////////////////////////////////////////////////////////
 
-  template <bool Stats>
+  template <stats_t Stats>
   worker_pool_impl<Stats>::core_impl::core_impl (bool pool_threads)
     : worker_pool::core (pool_threads)
   {
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   worker_pool_impl<Stats>::core_impl::~core_impl ()
   {
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::core_impl::initialize (std::size_t worker_count)
   {
@@ -891,7 +892,7 @@ namespace cubthread
     initialize_workers ();
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::core_impl::execute_task (task_type *task_p, bool is_temp)
   {
@@ -941,7 +942,7 @@ namespace cubthread
       }
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::core_impl::warmup (void)
   {
@@ -964,7 +965,7 @@ namespace cubthread
       }
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   bool
   worker_pool_impl<Stats>::core_impl::stop_execution (void)
   {
@@ -993,7 +994,7 @@ namespace cubthread
     return has_running_workers;
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::core_impl::retire_queued_tasks (void)
   {
@@ -1007,7 +1008,7 @@ namespace cubthread
       }
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   std::optional<typename worker_pool_impl<Stats>::wrapped_task>
   worker_pool_impl<Stats>::core_impl::get_task_or_become_available (worker &worker_arg)
   {
@@ -1027,7 +1028,7 @@ namespace cubthread
     return std::nullopt;
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::core_impl::become_available (worker &worker_arg)
   {
@@ -1037,7 +1038,7 @@ namespace cubthread
     assert (m_available_workers.size () <= m_workers.size ());
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::core_impl::check_worker_not_available (const worker &worker_arg)
   {
@@ -1051,14 +1052,14 @@ namespace cubthread
 #endif // DEBUG
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   std::size_t
   worker_pool_impl<Stats>::core_impl::get_worker_count (void) const
   {
     return m_workers.size ();
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::core_impl::register_free_temp_list (worker *w)
   {
@@ -1075,7 +1076,7 @@ namespace cubthread
     m_temp_workers.erase (it);
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::core_impl::free_all_temp_list ()
   {
@@ -1084,7 +1085,7 @@ namespace cubthread
     m_free_temp_workers.clear ();
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::core_impl::get_stats (cubperf::stat_value *stats_out) const
   {
@@ -1107,7 +1108,7 @@ namespace cubthread
     }
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   template <typename Func, typename ... Args>
   void
   worker_pool_impl<Stats>::core_impl::map_running_contexts (bool &stop, Func &&func, Args &&... args) const
@@ -1145,14 +1146,14 @@ namespace cubthread
     }
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   std::unique_ptr<typename worker_pool::core::worker>
   worker_pool_impl<Stats>::core_impl::allocate_worker (bool is_temp)
   {
     return std::unique_ptr<worker> (new worker_impl (is_temp));
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::core_impl::allocate_workers (std::size_t worker_count)
   {
@@ -1165,7 +1166,7 @@ namespace cubthread
       }
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::core_impl::initialize_workers ()
   {
@@ -1189,7 +1190,7 @@ namespace cubthread
       }
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::core_impl::execute_task_as_temp (wrapped_task &&task_ref)
   {
@@ -1206,7 +1207,7 @@ namespace cubthread
   // worker_pool_impl<Stats>::core_impl::worker_impl
   //////////////////////////////////////////////////////////////////////////
 
-  template <bool Stats>
+  template <stats_t Stats>
   worker_pool_impl<Stats>::core_impl::worker_impl::worker_impl (bool is_temp)
     : worker_pool::core::worker ()
     , m_context_p (nullptr)
@@ -1218,19 +1219,19 @@ namespace cubthread
   {
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   worker_pool_impl<Stats>::core_impl::worker_impl::~worker_impl (void)
   {
     stats::destroy (m_stats);
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::core_impl::worker_impl::initialize (void)
   {
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::core_impl::worker_impl::start_thread (void)
   {
@@ -1253,7 +1254,7 @@ namespace cubthread
     wp_call_func_throwing_system_error ("detaching thread", lambda_detach);
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   bool
   worker_pool_impl<Stats>::core_impl::worker_impl::has_thread (void)
   {
@@ -1262,7 +1263,7 @@ namespace cubthread
     return m_has_thread;
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::core_impl::worker_impl::assign_task (wrapped_task &&task_ref)
   {
@@ -1297,7 +1298,7 @@ namespace cubthread
       }
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::core_impl::worker_impl::assign_task (void)
   {
@@ -1321,7 +1322,7 @@ namespace cubthread
       }
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   bool
   worker_pool_impl<Stats>::core_impl::worker_impl::stop_execution (void)
   {
@@ -1356,14 +1357,14 @@ namespace cubthread
     return has_thread;
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::core_impl::worker_impl::get_stats (cubperf::stat_value *stats_out) const
   {
     stats::accumulate (m_stats, stats_out);
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   template <typename Func, typename ... Args>
   void
   worker_pool_impl<Stats>::core_impl::worker_impl::map_context_if_running (bool &stop, Func &&func, Args &&... args)
@@ -1382,7 +1383,7 @@ namespace cubthread
       }
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::core_impl::worker_impl::run (void)
   {
@@ -1425,7 +1426,7 @@ namespace cubthread
       }
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::core_impl::worker_impl::init_run (void)
   {
@@ -1452,7 +1453,7 @@ namespace cubthread
     stats::time_and_increment (m_stats, stats::id::create_context);
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::core_impl::worker_impl::finish_run (void)
   {
@@ -1474,7 +1475,7 @@ namespace cubthread
       }
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::core_impl::worker_impl::execute_current_task (void)
   {
@@ -1502,7 +1503,7 @@ namespace cubthread
       }
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::core_impl::worker_impl::retire_current_task (void)
   {
@@ -1516,7 +1517,7 @@ namespace cubthread
     stats::time_and_increment (m_stats, stats::id::retire_task);
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   bool
   worker_pool_impl<Stats>::core_impl::worker_impl::get_new_task (void)
   {
@@ -1600,46 +1601,46 @@ namespace cubthread
   // worker_pool_impl<Stats>::wrapped_task
   //////////////////////////////////////////////////////////////////////////
 
-  template <bool Stats>
+  template <stats_t Stats>
   worker_pool_impl<Stats>::wrapped_task::wrapped_task (task_type *task_p)
   {
     assert (task_p != nullptr);
 
     m_inner.task = task_p;
-    if constexpr (Stats)
+    if constexpr (Stats == stats_t::on)
       {
 	m_inner.time = cubperf::clock::now ();
       }
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   worker_pool_impl<Stats>::wrapped_task::~wrapped_task (void)
   {
     assert (m_inner.task == nullptr);
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   worker_pool_impl<Stats>::wrapped_task::wrapped_task (wrapped_task &&other)
   {
     m_inner.task = other.m_inner.task;
     other.m_inner.task = nullptr;
 
-    if constexpr (Stats)
+    if constexpr (Stats == stats_t::on)
       {
 	m_inner.time = other.m_inner.time;
       }
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   cubperf::time_point &
   worker_pool_impl<Stats>::wrapped_task::get_time (void)
   {
-    static_assert (Stats, "get_time() requires Stats == true");
+    static_assert (Stats == stats_t::on, "get_time() requires Stats == stats_t::on");
 
     return m_inner.time;
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::wrapped_task::execute (context_type &thread_ref)
   {
@@ -1648,7 +1649,7 @@ namespace cubthread
     m_inner.task->execute (thread_ref);
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::wrapped_task::retire (void)
   {
@@ -1662,14 +1663,14 @@ namespace cubthread
   // statistics
   //////////////////////////////////////////////////////////////////////////
 
-  template <bool Stats>
+  template <stats_t Stats>
   constexpr cubperf::stat_definition worker_pool_impl<Stats>::stats::make_def (id stat_id,
       cubperf::stat_definition::type stat_type, const char *first_name, const char *second_name)
   {
     return cubperf::stat_definition (static_cast<cubperf::stat_id> (stat_id), stat_type, first_name, second_name);
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   inline const cubperf::statset_definition worker_pool_impl<Stats>::stats::statdef =
   {
     make_def (id::start_thread, cubperf::stat_definition::COUNTER_AND_TIMER,
@@ -1690,13 +1691,13 @@ namespace cubthread
 	      "Counter_retire_context", "Timer_retire_context")
   };
 
-  template <bool Stats>
+  template <stats_t Stats>
   typename worker_pool_impl<Stats>::stats_base
   worker_pool_impl<Stats>::stats::create (void)
   {
     stats_base base;
 
-    if constexpr (Stats)
+    if constexpr (Stats == stats_t::on)
       {
 	base.statset = statdef.create_statset ();
 	base.time = cubperf::clock::now ();
@@ -1704,54 +1705,54 @@ namespace cubthread
     return base;
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::stats::destroy (stats_base &base)
   {
-    if constexpr (Stats)
+    if constexpr (Stats == stats_t::on)
       {
 	delete base.statset;
 	base.statset = nullptr;
       }
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::stats::time_and_increment (stats_base &base, id stat_id)
   {
-    if constexpr (Stats)
+    if constexpr (Stats == stats_t::on)
       {
 	base.statset->m_timept = base.time;
 	statdef.time_and_increment (*base.statset, static_cast<cubperf::stat_id> (stat_id));
       }
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::stats::time_and_increment (stats_base &base, id stat_id, cubperf::duration d)
   {
-    if constexpr (Stats)
+    if constexpr (Stats == stats_t::on)
       {
 	base.statset->m_timept = base.time;
 	statdef.time_and_increment (*base.statset, static_cast<cubperf::stat_id> (stat_id), d);
       }
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   void
   worker_pool_impl<Stats>::stats::accumulate (const stats_base &base, cubperf::stat_value *where)
   {
-    if constexpr (Stats)
+    if constexpr (Stats == stats_t::on)
       {
 	statdef.add_stat_values_with_converted_timers<std::chrono::microseconds> (*base.statset, where);
       }
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   std::size_t
   worker_pool_impl<Stats>::stats::get_count (void)
   {
-    if constexpr (Stats)
+    if constexpr (Stats == stats_t::on)
       {
 	return statdef.get_value_count ();
       }
@@ -1761,11 +1762,11 @@ namespace cubthread
       }
   }
 
-  template <bool Stats>
+  template <stats_t Stats>
   const char *
   worker_pool_impl<Stats>::stats::get_name (std::size_t stat_index)
   {
-    if constexpr (Stats)
+    if constexpr (Stats == stats_t::on)
       {
 	return statdef.get_value_name (stat_index);
       }

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -954,7 +954,7 @@ extern bool cdc_Logging;
 
 #if defined (SERVER_MODE)
 // *INDENT-OFF*
-extern cubthread::worker_pool_type *g_backup_read_worker_pool;
+extern worker_pool_type<> *g_backup_read_worker_pool;
 // *INDENT-ON*
 #endif
 

--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -7520,7 +7520,7 @@ logpb_backup_for_volume (THREAD_ENTRY * thread_p, VOLID volid, LOG_LSA * chkpt_l
 }
 
 // *INDENT-OFF*
-cubthread::worker_pool_type * g_backup_read_worker_pool = NULL;
+worker_pool_type<> *g_backup_read_worker_pool = NULL;
 
 REGISTER_WORKERPOOL (backup_read, []() {
 #if defined (SERVER_MODE)

--- a/src/transaction/log_recovery_redo_parallel.hpp
+++ b/src/transaction/log_recovery_redo_parallel.hpp
@@ -193,7 +193,7 @@ namespace cublog
        */
       task_active_state_bookkeeping m_task_state_bookkeeping;
 
-      cubthread::worker_pool_type *m_worker_pool;
+      worker_pool_type<> *m_worker_pool;
       /* tasks have owner-controlled life-time in order to be able to
        * collect post-execution perf stats from them
        */


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26684>

### Purpose

class worker_pool_impl을 상속받아 worker_pool_elastic을 구현하였습니다.
단순한 상속 수준이므로 내부 동작은 바뀌지 않았습니다.

Worker pool 종류가 추가됨에 따라 stats 여부와 worker pool 선택을 명시적으로 하도록 하였습니다. 형태는 아래와 같습니다.

```
enum class stats_t { on, off };
enum class pool_t { basic, elastic };

template <
	cubthread::stats_t Stats = cubthread::stats_t::off,
	cubthread::pool_t Type = cubthread::pool_t::basic
	>
worker_pool_type
```

### Implementation

N/A

### Remarks

N/A
