### PR TITLE
[CBRD-25073] fix core dump that occurs when user information is omitted in create server statement (#4791)

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -3170,7 +3170,10 @@ create_stmt
                                      }
                                      si->pwd = val;
                                       
-                                    pt_add_password_offset(si->user->buffer_pos, si->user->buffer_pos, true, en_server_password);
+                                     if (si->user)
+                                     {
+                                        pt_add_password_offset(si->user->buffer_pos, si->user->buffer_pos, true, en_server_password);
+                                     }
                                 }
 
                                 if( !si->host || !si->port || !si->dbname || !si->user || !si->pwd)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25073

* fix core dump that occurs when user information is omitted in create server statement
* backport #4791
