### PR TITLE
[CBRD-26640] Reuse correlated DBLink result set via CCI cursor rewind

### DIFF
--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -18131,11 +18131,10 @@ parser_generate_xasl_proc (PARSER_CONTEXT * parser, PT_NODE * node, PT_NODE * qu
 	  XASL_SET_FLAG (xasl, XASL_ZERO_CORR_LEVEL);
 	}
 
-      /* correlated subquery with DBLink: rewind CCI cursor instead of re-issuing cci_execute per outer row
-       * (CBRD-26640).
+      /* correlated subquery with DBLink: rewind CCI cursor instead of re-issuing cci_execute per outer row.
        * Assumption: conn_sql is invariant across outer rows — mq_copypush never modifies conn_sql for
        * correlated terms (they are always pushed to access_pred only).
-       * NOTE: if a future optimization (e.g. CBRD-26601 join push-down) places per-row host variables into
+       * NOTE: if a future optimization (e.g. join push-down) places per-row host variables into
        * conn_sql, this flag must NOT be set for that case; re-bind + re-execute would be required instead. */
       if (PT_IS_QUERY (node) && node->info.query.correlation_level != 0 && pt_xasl_spec_has_dblink (xasl))
 	{

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -18136,7 +18136,7 @@ parser_generate_xasl_proc (PARSER_CONTEXT * parser, PT_NODE * node, PT_NODE * qu
        * correlated terms (they are always pushed to access_pred only).
        * NOTE: if a future optimization (e.g. join push-down) places per-row host variables into
        * conn_sql, this flag must NOT be set for that case; re-bind + re-execute would be required instead. */
-      if (PT_IS_QUERY (node) && node->info.query.correlation_level != 0 && pt_xasl_spec_has_dblink (xasl))
+      if (PT_IS_QUERY (node) && node->info.query.correlation_level > 0 && pt_xasl_spec_has_dblink (xasl))
 	{
 	  XASL_SET_FLAG (xasl, XASL_DBLINK_CURSOR_REWIND);
 	}

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -18131,10 +18131,15 @@ parser_generate_xasl_proc (PARSER_CONTEXT * parser, PT_NODE * node, PT_NODE * qu
 	  XASL_SET_FLAG (xasl, XASL_ZERO_CORR_LEVEL);
 	}
 
-      /* correlated subquery with DBLink: reuse materialized list across outer rows (CBRD-26640) */
+      /* correlated subquery with DBLink: rewind CCI cursor instead of re-issuing cci_execute per outer row
+       * (CBRD-26640).
+       * Assumption: conn_sql is invariant across outer rows — mq_copypush never modifies conn_sql for
+       * correlated terms (they are always pushed to access_pred only).
+       * NOTE: if a future optimization (e.g. CBRD-26601 join push-down) places per-row host variables into
+       * conn_sql, this flag must NOT be set for that case; re-bind + re-execute would be required instead. */
       if (PT_IS_QUERY (node) && node->info.query.correlation_level != 0 && pt_xasl_spec_has_dblink (xasl))
 	{
-	  XASL_SET_FLAG (xasl, XASL_REUSE_DBLINK);
+	  XASL_SET_FLAG (xasl, XASL_DBLINK_CURSOR_REWIND);
 	}
 
 /* BUG FIX - COMMENT OUT: DO NOT REMOVE ME FOR USE IN THE FUTURE */

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -452,6 +452,7 @@ static XASL_NODE *pt_plan_set_query (PARSER_CONTEXT * parser, PT_NODE * node, PR
 static XASL_NODE *pt_plan_query (PARSER_CONTEXT * parser, PT_NODE * select_node);
 static XASL_NODE *pt_plan_schema (PARSER_CONTEXT * parser, PT_NODE * select_node);
 static XASL_NODE *parser_generate_xasl_proc (PARSER_CONTEXT * parser, PT_NODE * node, PT_NODE * query_list);
+static bool pt_xasl_spec_has_dblink (XASL_NODE * xasl);
 static PT_NODE *parser_generate_xasl_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);
 static int pt_spec_to_xasl_class_oid_list (PARSER_CONTEXT * parser, const PT_NODE * spec, OID ** oid_listp,
 					   int **lock_listp, int **tcard_listp, int *nump, int *sizep,
@@ -17941,6 +17942,32 @@ exit:
   return xasl;
 }
 
+/*
+ * pt_xasl_spec_has_dblink () - true if any scan in the xasl chain has a TARGET_DBLINK access spec
+ */
+static bool
+pt_xasl_spec_has_dblink (XASL_NODE * xasl)
+{
+  XASL_NODE *scan;
+  ACCESS_SPEC_TYPE *spec;
+
+  if (xasl == NULL)
+    {
+      return false;
+    }
+
+  for (scan = xasl; scan != NULL; scan = scan->scan_ptr)
+    {
+      for (spec = scan->spec_list; spec != NULL; spec = spec->next)
+	{
+	  if (spec->type == TARGET_DBLINK)
+	    {
+	      return true;
+	    }
+	}
+    }
+  return false;
+}
 
 /*
  * parser_generate_xasl_proc () - Creates xasl proc for parse tree.
@@ -18102,6 +18129,12 @@ parser_generate_xasl_proc (PARSER_CONTEXT * parser, PT_NODE * node, PT_NODE * qu
       if ((PT_IS_QUERY (node) && node->info.query.correlation_level == 0) || node->node_type == PT_CTE)
 	{
 	  XASL_SET_FLAG (xasl, XASL_ZERO_CORR_LEVEL);
+	}
+
+      /* correlated subquery with DBLink: reuse materialized list across outer rows (CBRD-26640) */
+      if (PT_IS_QUERY (node) && node->info.query.correlation_level != 0 && pt_xasl_spec_has_dblink (xasl))
+	{
+	  XASL_SET_FLAG (xasl, XASL_REUSE_DBLINK);
 	}
 
 /* BUG FIX - COMMENT OUT: DO NOT REMOVE ME FOR USE IN THE FUTURE */

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -736,6 +736,7 @@ dblink_open_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_INFO * scan_info, struct 
       ret = cci_cursor (scan_info->stmt_handle, 1, CCI_CURSOR_FIRST, &err_buf);
       if (ret < 0)
 	{
+	  /* 0-row remote result: cci_cursor (FIRST) returns CCI_ER_NO_MORE_DATA (expected, not a link error). */
 	  if (ret == CCI_ER_NO_MORE_DATA)
 	    {
 	      scan_info->cursor = CCI_CURSOR_FIRST;

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -769,8 +769,9 @@ dblink_open_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_INFO * scan_info, struct 
 
   /* Force autocommit OFF for the duration of this scan.
    * cursor_rewind requires the CCI cursor to stay alive across outer rows;
-   * this is only necessary when auto_commit is true (false connections are already OFF). */
-  if (auto_commit)
+   * this is only necessary when cursor_rewind is set and auto_commit is true
+   * (false connections are already OFF). */
+  if (scan_info->cursor_rewind && auto_commit)
     {
       ret = cci_set_autocommit (scan_info->conn_handle, CCI_AUTOCOMMIT_FALSE);
       if (ret < 0)
@@ -867,7 +868,7 @@ dblink_close_scan (DBLINK_SCAN_INFO * scan_info, bool is_final)
     }
 
   /* sentinel: already closed (set below on success) */
-  if (scan_info->stmt_handle < 0)
+  if (scan_info->stmt_handle <= 0)
     {
       return NO_ERROR;
     }

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -748,6 +748,8 @@ dblink_open_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_INFO * scan_info, struct 
       if (ret < 0)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, "set autocommit mode");
+	  (void) cci_disconnect (scan_info->conn_handle, &err_buf);
+	  scan_info->conn_handle = -1;
 	  return ER_DBLINK;
 	}
 
@@ -758,6 +760,8 @@ dblink_open_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_INFO * scan_info, struct 
 					 password, false);
 	  if (ret < 0)
 	    {
+	      (void) cci_disconnect (scan_info->conn_handle, &err_buf);
+	      scan_info->conn_handle = -1;
 	      return ER_DBLINK;
 	    }
 	}
@@ -773,6 +777,8 @@ dblink_open_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_INFO * scan_info, struct 
 	{
 	  cci_get_err_msg (ret, err_buf.err_msg, sizeof (err_buf.err_msg));
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, err_buf.err_msg);
+	  (void) cci_disconnect (scan_info->conn_handle, &err_buf);
+	  scan_info->conn_handle = -1;
 	  return ER_DBLINK;
 	}
     }
@@ -814,6 +820,11 @@ dblink_open_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_INFO * scan_info, struct 
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, "unknown error");
 	  (void) cci_close_req_handle (scan_info->stmt_handle);
 	  scan_info->stmt_handle = -1;
+	  if (auto_commit && scan_info->conn_handle >= 0)
+	    {
+	      (void) cci_disconnect (scan_info->conn_handle, &err_buf);
+	      scan_info->conn_handle = -1;
+	    }
 	  return ER_DBLINK;
 	}
       scan_info->cursor = CCI_CURSOR_FIRST;

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -673,29 +673,6 @@ error_exit:
   return ER_DBLINK;
 }
 
-/*
- * dblink_restore_cci_autocommit_if_saved () - restore CCI autocommit after dblink_open_scan forced false
- */
-static int
-dblink_restore_cci_autocommit_if_saved (DBLINK_SCAN_INFO * scan_info)
-{
-  int ret;
-  T_CCI_ERROR err_buf;
-
-  if (scan_info->conn_handle < 0 || !scan_info->cci_autocommit_saved)
-    {
-      return NO_ERROR;
-    }
-  scan_info->cci_autocommit_saved = 0;
-  ret = cci_set_autocommit (scan_info->conn_handle, (CCI_AUTOCOMMIT_MODE) scan_info->cci_autocommit_before);
-  if (ret < 0)
-    {
-      cci_get_err_msg (ret, err_buf.err_msg, sizeof (err_buf.err_msg));
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, err_buf.err_msg);
-      return ER_DBLINK;
-    }
-  return NO_ERROR;
-}
 
 /*
  * dblink_open_scan () - open the scan for dblink
@@ -787,31 +764,29 @@ dblink_open_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_INFO * scan_info, struct 
 	}
     }
 
-  /* During this dblink scan use manual commit; restore previous mode in dblink_close_scan. */
-  ret = cci_get_autocommit (scan_info->conn_handle);
-  if (ret < 0)
+  /* Force autocommit OFF for the duration of this scan.
+   * cursor_rewind (CBRD-26640) requires the CCI cursor to stay alive across outer rows;
+   * this is only necessary when auto_commit is true (false connections are already OFF). */
+  if (auto_commit)
     {
-      cci_get_err_msg (ret, err_buf.err_msg, sizeof (err_buf.err_msg));
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, err_buf.err_msg);
-      return ER_DBLINK;
-    }
-  scan_info->cci_autocommit_before = (char) ret;
-  scan_info->cci_autocommit_saved = 1;
-
-  ret = cci_set_autocommit (scan_info->conn_handle, CCI_AUTOCOMMIT_FALSE);
-  if (ret < 0)
-    {
-      cci_get_err_msg (ret, err_buf.err_msg, sizeof (err_buf.err_msg));
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, err_buf.err_msg);
-      scan_info->cci_autocommit_saved = 0;
-      return ER_DBLINK;
+      ret = cci_set_autocommit (scan_info->conn_handle, CCI_AUTOCOMMIT_FALSE);
+      if (ret < 0)
+	{
+	  cci_get_err_msg (ret, err_buf.err_msg, sizeof (err_buf.err_msg));
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, err_buf.err_msg);
+	  return ER_DBLINK;
+	}
     }
 
   scan_info->stmt_handle = cci_prepare (scan_info->conn_handle, sql_text, 0, &err_buf);
   if (scan_info->stmt_handle < 0)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, err_buf.err_msg);
-      (void) dblink_restore_cci_autocommit_if_saved (scan_info);
+      if (auto_commit && scan_info->conn_handle >= 0)
+	{
+	  (void) cci_disconnect (scan_info->conn_handle, &err_buf);
+	  scan_info->conn_handle = -1;
+	}
       return ER_DBLINK;
     }
 
@@ -819,7 +794,6 @@ dblink_open_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_INFO * scan_info, struct 
     {
       if ((ret = dblink_bind_param (scan_info->stmt_handle, vd, host_vars)) < 0)
 	{
-	  (void) dblink_restore_cci_autocommit_if_saved (scan_info);
 	  return ER_DBLINK;
 	}
     }
@@ -828,7 +802,6 @@ dblink_open_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_INFO * scan_info, struct 
   if (ret < 0)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, err_buf.err_msg);
-      (void) dblink_restore_cci_autocommit_if_saved (scan_info);
       return ER_DBLINK;
     }
   else
@@ -840,7 +813,8 @@ dblink_open_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_INFO * scan_info, struct 
 	{
 	  /* this can not be reached, something wrong */
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, "unknown error");
-	  (void) dblink_restore_cci_autocommit_if_saved (scan_info);
+	  (void) cci_close_req_handle (scan_info->stmt_handle);
+	  scan_info->stmt_handle = -1;
 	  return ER_DBLINK;
 	}
       scan_info->cursor = CCI_CURSOR_FIRST;
@@ -892,7 +866,6 @@ dblink_close_scan (DBLINK_SCAN_INFO * scan_info, bool is_final)
     {
       cci_get_err_msg (error, err_buf.err_msg, sizeof (err_buf.err_msg));
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, err_buf.err_msg);
-      (void) dblink_restore_cci_autocommit_if_saved (scan_info);
       if (auto_commit)
 	{
 	  (void) cci_disconnect (scan_info->conn_handle, &err_buf);
@@ -901,16 +874,6 @@ dblink_close_scan (DBLINK_SCAN_INFO * scan_info, bool is_final)
       return S_ERROR;
     }
   scan_info->stmt_handle = -1;
-
-  if (dblink_restore_cci_autocommit_if_saved (scan_info) != NO_ERROR)
-    {
-      if (auto_commit && scan_info->conn_handle >= 0)
-	{
-	  (void) cci_disconnect (scan_info->conn_handle, &err_buf);
-	  scan_info->conn_handle = -1;
-	}
-      return S_ERROR;
-    }
 
   if (scan_info->conn_handle >= 0 && auto_commit)
     {

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -673,7 +673,6 @@ error_exit:
   return ER_DBLINK;
 }
 
-
 /*
  * dblink_open_scan () - open the scan for dblink
  *   return: int

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -705,8 +705,9 @@ dblink_open_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_INFO * scan_info, struct 
       snprintf (conn_url, MAX_LEN_CONNECTION_URL, "%s%s", spec->s.dblink_node.conn_url, "?__gateway=true");
     }
 
-  /* correlated reuse mode: CCI connection/stmt already open, just rewind cursor */
-  if (scan_info->cursor_rewind && scan_info->conn_handle >= 0 && scan_info->stmt_handle >= 0)
+  /* correlated reuse mode: CCI connection/stmt already open, just rewind cursor.
+   * Check > 0: CCI handles are positive integers; 0 is the uninitialized/zero-init value. */
+  if (scan_info->cursor_rewind && scan_info->conn_handle > 0 && scan_info->stmt_handle > 0)
     {
       scan_info->cursor = CCI_CURSOR_FIRST;
       return NO_ERROR;

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -892,6 +892,7 @@ dblink_close_scan (DBLINK_SCAN_INFO * scan_info, bool is_final)
       if ((error = cci_disconnect (scan_info->conn_handle, &err_buf)) < 0)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, err_buf.err_msg);
+	  scan_info->conn_handle = -1;
 	  return S_ERROR;
 	}
       scan_info->conn_handle = -1;

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -674,6 +674,30 @@ error_exit:
 }
 
 /*
+ * dblink_restore_cci_autocommit_if_saved () - restore CCI autocommit after dblink_open_scan forced false
+ */
+static int
+dblink_restore_cci_autocommit_if_saved (DBLINK_SCAN_INFO * scan_info)
+{
+  int ret;
+  T_CCI_ERROR err_buf;
+
+  if (scan_info->conn_handle < 0 || !scan_info->cci_autocommit_saved)
+    {
+      return NO_ERROR;
+    }
+  scan_info->cci_autocommit_saved = 0;
+  ret = cci_set_autocommit (scan_info->conn_handle, (CCI_AUTOCOMMIT_MODE) scan_info->cci_autocommit_before);
+  if (ret < 0)
+    {
+      cci_get_err_msg (ret, err_buf.err_msg, sizeof (err_buf.err_msg));
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, err_buf.err_msg);
+      return ER_DBLINK;
+    }
+  return NO_ERROR;
+}
+
+/*
  * dblink_open_scan () - open the scan for dblink
  *   return: int
  *   scan_info(out)      : dblink information
@@ -705,10 +729,21 @@ dblink_open_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_INFO * scan_info, struct 
       snprintf (conn_url, MAX_LEN_CONNECTION_URL, "%s%s", spec->s.dblink_node.conn_url, "?__gateway=true");
     }
 
-  /* correlated reuse mode: CCI connection/stmt already open, just rewind cursor.
+  /* correlated reuse mode: CCI connection/stmt already open; reposition remote cursor to first row.
    * Check > 0: CCI handles are positive integers; 0 is the uninitialized/zero-init value. */
   if (scan_info->cursor_rewind && scan_info->conn_handle > 0 && scan_info->stmt_handle > 0)
     {
+      ret = cci_cursor (scan_info->stmt_handle, 1, CCI_CURSOR_FIRST, &err_buf);
+      if (ret < 0)
+	{
+	  if (ret == CCI_ER_NO_MORE_DATA)
+	    {
+	      scan_info->cursor = CCI_CURSOR_FIRST;
+	      return NO_ERROR;
+	    }
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, err_buf.err_msg);
+	  return ER_DBLINK;
+	}
       scan_info->cursor = CCI_CURSOR_FIRST;
       return NO_ERROR;
     }
@@ -749,10 +784,31 @@ dblink_open_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_INFO * scan_info, struct 
 	}
     }
 
+  /* During this dblink scan use manual commit; restore previous mode in dblink_close_scan. */
+  ret = cci_get_autocommit (scan_info->conn_handle);
+  if (ret < 0)
+    {
+      cci_get_err_msg (ret, err_buf.err_msg, sizeof (err_buf.err_msg));
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, err_buf.err_msg);
+      return ER_DBLINK;
+    }
+  scan_info->cci_autocommit_before = (char) ret;
+  scan_info->cci_autocommit_saved = 1;
+
+  ret = cci_set_autocommit (scan_info->conn_handle, CCI_AUTOCOMMIT_FALSE);
+  if (ret < 0)
+    {
+      cci_get_err_msg (ret, err_buf.err_msg, sizeof (err_buf.err_msg));
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, err_buf.err_msg);
+      scan_info->cci_autocommit_saved = 0;
+      return ER_DBLINK;
+    }
+
   scan_info->stmt_handle = cci_prepare (scan_info->conn_handle, sql_text, 0, &err_buf);
   if (scan_info->stmt_handle < 0)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, err_buf.err_msg);
+      (void) dblink_restore_cci_autocommit_if_saved (scan_info);
       return ER_DBLINK;
     }
 
@@ -760,6 +816,7 @@ dblink_open_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_INFO * scan_info, struct 
     {
       if ((ret = dblink_bind_param (scan_info->stmt_handle, vd, host_vars)) < 0)
 	{
+	  (void) dblink_restore_cci_autocommit_if_saved (scan_info);
 	  return ER_DBLINK;
 	}
     }
@@ -768,6 +825,7 @@ dblink_open_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_INFO * scan_info, struct 
   if (ret < 0)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, err_buf.err_msg);
+      (void) dblink_restore_cci_autocommit_if_saved (scan_info);
       return ER_DBLINK;
     }
   else
@@ -779,6 +837,7 @@ dblink_open_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_INFO * scan_info, struct 
 	{
 	  /* this can not be reached, something wrong */
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, "unknown error");
+	  (void) dblink_restore_cci_autocommit_if_saved (scan_info);
 	  return ER_DBLINK;
 	}
       scan_info->cursor = CCI_CURSOR_FIRST;
@@ -817,12 +876,22 @@ dblink_close_scan (DBLINK_SCAN_INFO * scan_info)
 	{
 	  cci_get_err_msg (error, err_buf.err_msg, sizeof (err_buf.err_msg));
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, err_buf.err_msg);
+	  (void) dblink_restore_cci_autocommit_if_saved (scan_info);
 	  if (auto_commit)
 	    {
 	      (void) cci_disconnect (scan_info->conn_handle, &err_buf);
 	    }
 	  return S_ERROR;
 	}
+    }
+
+  if (dblink_restore_cci_autocommit_if_saved (scan_info) != NO_ERROR)
+    {
+      if (auto_commit && scan_info->conn_handle >= 0)
+	{
+	  (void) cci_disconnect (scan_info->conn_handle, &err_buf);
+	}
+      return S_ERROR;
     }
 
   if (scan_info->conn_handle >= 0 && auto_commit)

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -734,19 +734,14 @@ dblink_open_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_INFO * scan_info, struct 
   if (scan_info->cursor_rewind && scan_info->conn_handle > 0 && scan_info->stmt_handle > 0)
     {
       ret = cci_cursor (scan_info->stmt_handle, 1, CCI_CURSOR_FIRST, &err_buf);
-      if (ret < 0)
+      /* Success (CCI_ER_NO_ERROR) or 0-row remote result (CCI_ER_NO_MORE_DATA, expected). */
+      if (ret == CCI_ER_NO_ERROR || ret == CCI_ER_NO_MORE_DATA)
 	{
-	  /* 0-row remote result: cci_cursor (FIRST) returns CCI_ER_NO_MORE_DATA (expected, not a link error). */
-	  if (ret == CCI_ER_NO_MORE_DATA)
-	    {
-	      scan_info->cursor = CCI_CURSOR_FIRST;
-	      return NO_ERROR;
-	    }
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, err_buf.err_msg);
-	  return ER_DBLINK;
+	  scan_info->cursor = CCI_CURSOR_FIRST;
+	  return NO_ERROR;
 	}
-      scan_info->cursor = CCI_CURSOR_FIRST;
-      return NO_ERROR;
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, err_buf.err_msg);
+      return ER_DBLINK;
     }
 
   scan_info->conn_handle = -1;

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -877,6 +877,7 @@ dblink_close_scan (DBLINK_SCAN_INFO * scan_info, bool is_final)
     {
       cci_get_err_msg (error, err_buf.err_msg, sizeof (err_buf.err_msg));
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, err_buf.err_msg);
+      scan_info->stmt_handle = -1;
       if (auto_commit)
 	{
 	  (void) cci_disconnect (scan_info->conn_handle, &err_buf);

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -679,7 +679,7 @@ error_exit:
  *   scan_info(out)      : dblink information
  *   conn_url(in)        : connection URL for dblink
  *   user_name(in)	 : user name for dblink
- *   passowrd(in)	 : password for dblink
+ *   password(in)	 : password for dblink
  *   sql_text(in)	 : SQL text for dblink
  */
 int
@@ -703,6 +703,13 @@ dblink_open_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_INFO * scan_info, struct 
   else
     {
       snprintf (conn_url, MAX_LEN_CONNECTION_URL, "%s%s", spec->s.dblink_node.conn_url, "?__gateway=true");
+    }
+
+  /* correlated reuse mode: CCI connection/stmt already open, just rewind cursor */
+  if (scan_info->cursor_rewind && scan_info->conn_handle >= 0 && scan_info->stmt_handle >= 0)
+    {
+      scan_info->cursor = CCI_CURSOR_FIRST;
+      return NO_ERROR;
     }
 
   scan_info->conn_handle = -1;
@@ -793,6 +800,15 @@ dblink_close_scan (DBLINK_SCAN_INFO * scan_info)
   static bool auto_commit = prm_get_bool_value (PRM_ID_DBLINK_AUTO_COMMIT);
 
   /*  note: return NO_ERROR even though the connection or stmt handle is not valid */
+
+  /* correlated reuse mode: keep CCI resources open for next outer-row iteration.
+   * Actual close is deferred to qexec_clear_xasl (BUILDLIST_PROC, is_final=true),
+   * which clears cursor_rewind and calls dblink_close_scan directly before
+   * scan_close_scan (which would otherwise see S_CLOSED and return early). */
+  if (scan_info->cursor_rewind)
+    {
+      return NO_ERROR;
+    }
 
   if (scan_info->stmt_handle >= 0)
     {

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -702,18 +702,8 @@ dblink_open_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_INFO * scan_info, struct 
    * pool-managed (qmgr_dblink_*) and conn_handle legitimately remains >= 0 after close. */
   assert (scan_info->cursor_rewind || scan_info->stmt_handle <= 0);
 
-  char *find = strstr (spec->s.dblink_node.conn_url, ":?");
-  if (find)
-    {
-      snprintf (conn_url, MAX_LEN_CONNECTION_URL, "%s%s", spec->s.dblink_node.conn_url, "&__gateway=true");
-    }
-  else
-    {
-      snprintf (conn_url, MAX_LEN_CONNECTION_URL, "%s%s", spec->s.dblink_node.conn_url, "?__gateway=true");
-    }
-
   /* correlated reuse mode: CCI connection/stmt already open; reposition remote cursor to first row.
-   * Check > 0: CCI handles are positive integers; 0 is the uninitialized/zero-init value. */
+   * conn/stmt handles are valid only from the second outer row onwards; first call falls through to open. */
   if (scan_info->cursor_rewind && scan_info->conn_handle > 0 && scan_info->stmt_handle > 0)
     {
       ret = cci_cursor (scan_info->stmt_handle, 1, CCI_CURSOR_FIRST, &err_buf);
@@ -725,6 +715,16 @@ dblink_open_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_INFO * scan_info, struct 
 	}
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, err_buf.err_msg);
       return ER_DBLINK;
+    }
+
+  char *find = strstr (spec->s.dblink_node.conn_url, ":?");
+  if (find)
+    {
+      snprintf (conn_url, MAX_LEN_CONNECTION_URL, "%s%s", spec->s.dblink_node.conn_url, "&__gateway=true");
+    }
+  else
+    {
+      snprintf (conn_url, MAX_LEN_CONNECTION_URL, "%s%s", spec->s.dblink_node.conn_url, "?__gateway=true");
     }
 
   scan_info->conn_handle = -1;

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -696,7 +696,7 @@ dblink_open_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_INFO * scan_info, struct 
   char *password = spec->s.dblink_node.conn_password;
   char *sql_text = spec->s.dblink_node.conn_sql;
 
-  /* CBRD-26640 invariant: a non-reuse open must arrive without an active stmt_handle.
+  /* Invariant: a non-reuse open must arrive without an active stmt_handle.
    * CCI handles are positive integers; 0 = zero-initialized (never opened), -1 = sentinel
    * set by dblink_close_scan after successful close.  Both mean "no active statement".
    * conn_handle is intentionally excluded: when auto_commit=false the connection is
@@ -765,7 +765,7 @@ dblink_open_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_INFO * scan_info, struct 
     }
 
   /* Force autocommit OFF for the duration of this scan.
-   * cursor_rewind (CBRD-26640) requires the CCI cursor to stay alive across outer rows;
+   * cursor_rewind requires the CCI cursor to stay alive across outer rows;
    * this is only necessary when auto_commit is true (false connections are already OFF). */
   if (auto_commit)
     {

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -719,6 +719,13 @@ dblink_open_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_INFO * scan_info, struct 
   char *password = spec->s.dblink_node.conn_password;
   char *sql_text = spec->s.dblink_node.conn_sql;
 
+  /* CBRD-26640 invariant: a non-reuse open must arrive without an active stmt_handle.
+   * CCI handles are positive integers; 0 = zero-initialized (never opened), -1 = sentinel
+   * set by dblink_close_scan after successful close.  Both mean "no active statement".
+   * conn_handle is intentionally excluded: when auto_commit=false the connection is
+   * pool-managed (qmgr_dblink_*) and conn_handle legitimately remains >= 0 after close. */
+  assert (scan_info->cursor_rewind || scan_info->stmt_handle <= 0);
+
   char *find = strstr (spec->s.dblink_node.conn_url, ":?");
   if (find)
     {
@@ -846,9 +853,15 @@ dblink_open_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_INFO * scan_info, struct 
  * dblink_close_scan () -
  *   return: int
  *   scan_info(in)       : information for dblink
+ *   is_final(in)        : true  = final teardown (XASL clear path); always close CCI handles.
+ *                         false = per-iteration close; skip if cursor_rewind is set so that
+ *                                 the next outer row can rewind the CCI cursor without re-executing.
+ *
+ * Note: stmt_handle and conn_handle are set to -1 after successful close so that repeated calls
+ * (e.g. via scan_close_scan after an explicit is_final=true call) are safe no-ops.
  */
 int
-dblink_close_scan (DBLINK_SCAN_INFO * scan_info)
+dblink_close_scan (DBLINK_SCAN_INFO * scan_info, bool is_final)
 {
   int error;
   T_CCI_ERROR err_buf;
@@ -857,35 +870,44 @@ dblink_close_scan (DBLINK_SCAN_INFO * scan_info)
 
   /*  note: return NO_ERROR even though the connection or stmt handle is not valid */
 
-  /* correlated reuse mode: keep CCI resources open for next outer-row iteration.
-   * Actual close is deferred to qexec_clear_xasl (BUILDLIST_PROC, is_final=true),
-   * which clears cursor_rewind and calls dblink_close_scan directly before
-   * scan_close_scan (which would otherwise see S_CLOSED and return early). */
+  /* correlated reuse mode: keep CCI resources open for the next outer-row cursor rewind.
+   * On is_final=true (called from qexec_clear_xasl spec-list walk) clear the flag and
+   * fall through to the real teardown below. */
   if (scan_info->cursor_rewind)
+    {
+      if (!is_final)
+	{
+	  return NO_ERROR;
+	}
+      scan_info->cursor_rewind = 0;
+    }
+
+  /* sentinel: already closed (set below on success) */
+  if (scan_info->stmt_handle < 0)
     {
       return NO_ERROR;
     }
 
-  if (scan_info->stmt_handle >= 0)
+  if ((error = cci_close_req_handle (scan_info->stmt_handle)) < 0)
     {
-      if ((error = cci_close_req_handle (scan_info->stmt_handle)) < 0)
+      cci_get_err_msg (error, err_buf.err_msg, sizeof (err_buf.err_msg));
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, err_buf.err_msg);
+      (void) dblink_restore_cci_autocommit_if_saved (scan_info);
+      if (auto_commit)
 	{
-	  cci_get_err_msg (error, err_buf.err_msg, sizeof (err_buf.err_msg));
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, err_buf.err_msg);
-	  (void) dblink_restore_cci_autocommit_if_saved (scan_info);
-	  if (auto_commit)
-	    {
-	      (void) cci_disconnect (scan_info->conn_handle, &err_buf);
-	    }
-	  return S_ERROR;
+	  (void) cci_disconnect (scan_info->conn_handle, &err_buf);
+	  scan_info->conn_handle = -1;
 	}
+      return S_ERROR;
     }
+  scan_info->stmt_handle = -1;
 
   if (dblink_restore_cci_autocommit_if_saved (scan_info) != NO_ERROR)
     {
       if (auto_commit && scan_info->conn_handle >= 0)
 	{
 	  (void) cci_disconnect (scan_info->conn_handle, &err_buf);
+	  scan_info->conn_handle = -1;
 	}
       return S_ERROR;
     }
@@ -897,6 +919,7 @@ dblink_close_scan (DBLINK_SCAN_INFO * scan_info)
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK, 1, err_buf.err_msg);
 	  return S_ERROR;
 	}
+      scan_info->conn_handle = -1;
     }
 
   return NO_ERROR;

--- a/src/query/dblink_scan.h
+++ b/src/query/dblink_scan.h
@@ -58,7 +58,7 @@ struct dblink_scan_info
   int col_cnt;			/* column count of dblink query result */
   char cursor;			/* cursor position T_CCI_CURSOR_POS */
   void *col_info;		/* column information T_CCI_COL_INFO */
-  int cursor_rewind;		/* set from XASL_DBLINK_CURSOR_REWIND flag (CBRD-26640):
+  int cursor_rewind;		/* set from XASL_DBLINK_CURSOR_REWIND flag:
 				 * on each outer-row open, rewind CCI cursor to FIRST
 				 * instead of re-issuing cci_execute;
 				 * dblink_close_scan is skipped per iteration and

--- a/src/query/dblink_scan.h
+++ b/src/query/dblink_scan.h
@@ -98,7 +98,7 @@ extern int dblink_execute_query (THREAD_ENTRY * thread_p, struct access_spec_nod
 				 DBLINK_HOST_VARS * host_vars);
 extern int dblink_open_scan (THREAD_ENTRY * thread_p, DBLINK_SCAN_INFO * scan_info, struct access_spec_node *spec,
 			     VAL_DESCR * vd, DBLINK_HOST_VARS * host_vars);
-extern int dblink_close_scan (DBLINK_SCAN_INFO * scan_info);
+extern int dblink_close_scan (DBLINK_SCAN_INFO * scan_info, bool is_final);
 extern SCAN_CODE dblink_scan_next (DBLINK_SCAN_INFO * scan_info, val_list_node * val_list);
 extern SCAN_CODE dblink_scan_reset (DBLINK_SCAN_INFO * scan_info);
 

--- a/src/query/dblink_scan.h
+++ b/src/query/dblink_scan.h
@@ -63,8 +63,6 @@ struct dblink_scan_info
 				 * instead of re-issuing cci_execute;
 				 * dblink_close_scan is skipped per iteration and
 				 * deferred to query teardown (qexec_clear_xasl) */
-  int cci_autocommit_saved;	/* non-zero: cci_autocommit_before is valid; restored in dblink_close_scan */
-  char cci_autocommit_before;	/* CCI autocommit mode before open_scan forced CCI_AUTOCOMMIT_FALSE */
 };
 
 #define MAX_LEN_CONNECTION_URL 512

--- a/src/query/dblink_scan.h
+++ b/src/query/dblink_scan.h
@@ -58,6 +58,11 @@ struct dblink_scan_info
   int col_cnt;			/* column count of dblink query result */
   char cursor;			/* cursor position T_CCI_CURSOR_POS */
   void *col_info;		/* column information T_CCI_COL_INFO */
+  int cursor_rewind;		/* set from XASL_DBLINK_CURSOR_REWIND flag (CBRD-26640):
+				 * on each outer-row open, rewind CCI cursor to FIRST
+				 * instead of re-issuing cci_execute;
+				 * dblink_close_scan is skipped per iteration and
+				 * deferred to query teardown (qexec_clear_xasl) */
 };
 
 #define MAX_LEN_CONNECTION_URL 512

--- a/src/query/dblink_scan.h
+++ b/src/query/dblink_scan.h
@@ -63,6 +63,8 @@ struct dblink_scan_info
 				 * instead of re-issuing cci_execute;
 				 * dblink_close_scan is skipped per iteration and
 				 * deferred to query teardown (qexec_clear_xasl) */
+  int cci_autocommit_saved;	/* non-zero: cci_autocommit_before is valid; restored in dblink_close_scan */
+  char cci_autocommit_before;	/* CCI autocommit mode before open_scan forced CCI_AUTOCOMMIT_FALSE */
 };
 
 #define MAX_LEN_CONNECTION_URL 512

--- a/src/query/query_dump.c
+++ b/src/query/query_dump.c
@@ -2407,10 +2407,10 @@ qdump_print_xasl (xasl_node * xasl_p)
 	  nflag++;
 	}
 
-      if (XASL_IS_FLAGED (xasl_p, XASL_REUSE_DBLINK))
+      if (XASL_IS_FLAGED (xasl_p, XASL_DBLINK_CURSOR_REWIND))
 	{
-	  XASL_CLEAR_FLAG (xasl_p, XASL_REUSE_DBLINK);
-	  fprintf (foutput, "%sXASL_REUSE_DBLINK", (nflag ? "|" : ""));
+	  XASL_CLEAR_FLAG (xasl_p, XASL_DBLINK_CURSOR_REWIND);
+	  fprintf (foutput, "%sXASL_DBLINK_CURSOR_REWIND", (nflag ? "|" : ""));
 	  nflag++;
 	}
 

--- a/src/query/query_dump.c
+++ b/src/query/query_dump.c
@@ -2407,7 +2407,7 @@ qdump_print_xasl (xasl_node * xasl_p)
 	  nflag++;
 	}
 
-      if (XASL_IS_FLAGED (xasl_p, XASL_DBLINK_CURSOR_REWIND))
+      if (IS_DBLINK_CURSOR_REWIND_XASL (xasl_p))
 	{
 	  XASL_CLEAR_FLAG (xasl_p, XASL_DBLINK_CURSOR_REWIND);
 	  fprintf (foutput, "%sXASL_DBLINK_CURSOR_REWIND", (nflag ? "|" : ""));

--- a/src/query/query_dump.c
+++ b/src/query/query_dump.c
@@ -2407,6 +2407,13 @@ qdump_print_xasl (xasl_node * xasl_p)
 	  nflag++;
 	}
 
+      if (XASL_IS_FLAGED (xasl_p, XASL_REUSE_DBLINK))
+	{
+	  XASL_CLEAR_FLAG (xasl_p, XASL_REUSE_DBLINK);
+	  fprintf (foutput, "%sXASL_REUSE_DBLINK", (nflag ? "|" : ""));
+	  nflag++;
+	}
+
       if (XASL_IS_FLAGED (xasl_p, XASL_TOP_MOST_XASL))
 	{
 	  XASL_CLEAR_FLAG (xasl_p, XASL_TOP_MOST_XASL);

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -3313,6 +3313,11 @@ qexec_clear_head_lists_with_truncate (THREAD_ENTRY * thread_p, XASL_NODE * xasl_
 	  /* skip out zero correlation-level uncorrelated subquery */
 	  continue;
 	}
+      if (IS_REUSE_DBLINK_XASL (xasl))
+	{
+	  /* correlated DBLink: keep materialized list for outer-row reuse (CBRD-26640) */
+	  continue;
+	}
 
 
       if (xasl->list_id && !xasl->list_id->is_result_cached)
@@ -3354,6 +3359,7 @@ qexec_clear_head_lists_with_truncate (THREAD_ENTRY * thread_p, XASL_NODE * xasl_
     }
 }
 
+
 /*
  * qexec_clear_head_lists () -
  *   return:
@@ -3373,6 +3379,11 @@ qexec_clear_head_lists (THREAD_ENTRY * thread_p, XASL_NODE * xasl_list)
       if (XASL_IS_FLAGED (xasl, XASL_ZERO_CORR_LEVEL))
 	{
 	  /* skip out zero correlation-level uncorrelated subquery */
+	  continue;
+	}
+      if (IS_REUSE_DBLINK_XASL (xasl))
+	{
+	  /* correlated DBLink: keep materialized list for outer-row reuse (CBRD-26640) */
 	  continue;
 	}
       /* clear XASL head node */

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -2407,9 +2407,14 @@ qexec_clear_xasl (THREAD_ENTRY * thread_p, xasl_node * xasl, bool is_final, bool
     }
 
 
+  /* Final teardown of correlated DBLink CCI handles — runs for all proc types so that inner
+   * DBLink XASLs (BUILDVALUE_PROC wrappers included) are covered regardless of which branch follows. */
   qexec_final_close_dblink_specs (xasl);
 
 #if !defined(NDEBUG)
+  /* Invariant: after final teardown every DBLink spec must have released its handles.
+   * If either assertion fires here, qexec_final_close_dblink_specs did not reach this spec —
+   * i.e., the setter (cursor_rewind=1) was applied but the unsetter (is_final close) was not. */
   {
     ACCESS_SPEC_TYPE *dbg_spec;
     for (dbg_spec = xasl->spec_list; dbg_spec != NULL; dbg_spec = dbg_spec->next)
@@ -2892,7 +2897,7 @@ qexec_clear_xasl_for_parallel_aptr (THREAD_ENTRY * thread_p, XASL_NODE * xasl, b
       qfile_clear_list_id (xasl->list_id);
     }
 
-  /* CBRD-26640: final teardown of correlated DBLink CCI handles (parallel aptr path). */
+  /* Final teardown of correlated DBLink CCI handles (parallel aptr path). */
   qexec_final_close_dblink_specs (xasl);
 
   /* clear the body node */
@@ -3482,7 +3487,7 @@ qexec_clear_all_lists (THREAD_ENTRY * thread_p, XASL_NODE * xasl_list)
 }
 
 /*
- * qexec_final_close_dblink_specs () - CBRD-26640: Walk spec_list and merge_spec of one XASL node and call
+ * qexec_final_close_dblink_specs () - Walk spec_list and merge_spec of one XASL node and call
  * dblink_close_scan(is_final=true) for every TARGET_DBLINK spec whose CCI handles are still open.
  *
  * Called from qexec_clear_xasl / qexec_clear_xasl_for_parallel_aptr before the proc-type switch so that

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -438,6 +438,7 @@ static void qexec_clear_head_lists (THREAD_ENTRY * thread_p, XASL_NODE * xasl_li
 static void qexec_clear_head_lists_with_truncate (THREAD_ENTRY * thread_p, XASL_NODE * xasl_list);
 static void qexec_clear_scan_all_lists (THREAD_ENTRY * thread_p, XASL_NODE * xasl_list);
 static void qexec_clear_all_lists (THREAD_ENTRY * thread_p, XASL_NODE * xasl_list);
+static void qexec_final_close_dblink_specs (XASL_NODE * xasl);
 static int qexec_clear_update_assignment (THREAD_ENTRY * thread_p, XASL_NODE * xasl_p, UPDATE_ASSIGNMENT * assignment,
 					  bool is_final);
 static DB_LOGICAL qexec_eval_ordbynum_pred (THREAD_ENTRY * thread_p, ORDBYNUM_INFO * ordby_info);
@@ -1558,6 +1559,13 @@ qexec_clear_regu_var (THREAD_ENTRY * thread_p, XASL_NODE * xasl_p, REGU_VARIABLE
 		  /* regu_var->xasl not cleared yet. Clear the values allocated during execution. */
 		  pg_cnt += qexec_clear_xasl (thread_p, regu_var->xasl, is_final, for_parallel_aptr);
 		}
+	      else
+		{
+		  /* xcache clone reuse: XASL already cleared this run (status reset to XASL_INITIALIZED),
+		   * so skip full qexec_clear_xasl. But CCI handles must still be released — safe no-op if
+		   * qexec_clear_xasl already ran qexec_final_close_dblink_specs (stmt_handle = -1 sentinel). */
+		  qexec_final_close_dblink_specs (regu_var->xasl);
+		}
 	    }
 	  else if (regu_var->xasl->status != XASL_CLEARED)
 	    {
@@ -2399,6 +2407,30 @@ qexec_clear_xasl (THREAD_ENTRY * thread_p, xasl_node * xasl, bool is_final, bool
     }
 
 
+  qexec_final_close_dblink_specs (xasl);
+
+#if !defined(NDEBUG)
+  {
+    ACCESS_SPEC_TYPE *dbg_spec;
+    for (dbg_spec = xasl->spec_list; dbg_spec != NULL; dbg_spec = dbg_spec->next)
+      {
+	if (dbg_spec->type == TARGET_DBLINK)
+	  {
+	    assert (dbg_spec->s_id.s.dblid.scan_info.stmt_handle <= 0);
+	    assert (dbg_spec->s_id.s.dblid.scan_info.cursor_rewind == 0);
+	  }
+      }
+    for (dbg_spec = xasl->merge_spec; dbg_spec != NULL; dbg_spec = dbg_spec->next)
+      {
+	if (dbg_spec->type == TARGET_DBLINK)
+	  {
+	    assert (dbg_spec->s_id.s.dblid.scan_info.stmt_handle <= 0);
+	    assert (dbg_spec->s_id.s.dblid.scan_info.cursor_rewind == 0);
+	  }
+      }
+  }
+#endif /* !defined(NDEBUG) */
+
   switch (xasl->type)
     {
     case CONNECTBY_PROC:
@@ -2449,14 +2481,6 @@ qexec_clear_xasl (THREAD_ENTRY * thread_p, xasl_node * xasl, bool is_final, bool
 	if (xasl->curr_spec)
 	  {
 	    SCAN_ID *s_id = &xasl->curr_spec->s_id;
-
-	    /* Force-close reuse-mode DBLink: scan_close_scan would see S_CLOSED (set during the
-	     * last iteration's skipped dblink_close_scan) and return early, leaking CCI handles. */
-	    if (s_id->type == S_DBLINK_SCAN && s_id->s.dblid.scan_info.cursor_rewind)
-	      {
-		s_id->s.dblid.scan_info.cursor_rewind = 0;
-		dblink_close_scan (&s_id->s.dblid.scan_info);
-	      }
 
 	    scan_end_scan (thread_p, s_id);
 	    scan_close_scan (thread_p, s_id);
@@ -2867,6 +2891,9 @@ qexec_clear_xasl_for_parallel_aptr (THREAD_ENTRY * thread_p, XASL_NODE * xasl, b
     {
       qfile_clear_list_id (xasl->list_id);
     }
+
+  /* CBRD-26640: final teardown of correlated DBLink CCI handles (parallel aptr path). */
+  qexec_final_close_dblink_specs (xasl);
 
   /* clear the body node */
   /* not clear aptr nodes has px_executor; it will be cleared by other threads. */
@@ -3450,6 +3477,41 @@ qexec_clear_all_lists (THREAD_ENTRY * thread_p, XASL_NODE * xasl_list)
       if (xasl->scan_ptr)
 	{
 	  qexec_clear_scan_all_lists (thread_p, xasl->scan_ptr);
+	}
+    }
+}
+
+/*
+ * qexec_final_close_dblink_specs () - CBRD-26640: Walk spec_list and merge_spec of one XASL node and call
+ * dblink_close_scan(is_final=true) for every TARGET_DBLINK spec whose CCI handles are still open.
+ *
+ * Called from qexec_clear_xasl / qexec_clear_xasl_for_parallel_aptr before the proc-type switch so that
+ * the teardown runs regardless of XASL proc type (BUILDLIST, BUILDVALUE, etc.).
+ *
+ * Safe to call multiple times: dblink_close_scan sets stmt_handle = -1 on success, so subsequent calls
+ * return immediately via the stmt_handle < 0 sentinel.
+ */
+static void
+qexec_final_close_dblink_specs (XASL_NODE * xasl)
+{
+  ACCESS_SPEC_TYPE *spec;
+
+  if (xasl == NULL)
+    {
+      return;
+    }
+  for (spec = xasl->spec_list; spec != NULL; spec = spec->next)
+    {
+      if (spec->type == TARGET_DBLINK)
+	{
+	  (void) dblink_close_scan (&spec->s_id.s.dblid.scan_info, true);
+	}
+    }
+  for (spec = xasl->merge_spec; spec != NULL; spec = spec->next)
+    {
+      if (spec->type == TARGET_DBLINK)
+	{
+	  (void) dblink_close_scan (&spec->s_id.s.dblid.scan_info, true);
 	}
     }
 }

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -2485,10 +2485,8 @@ qexec_clear_xasl (THREAD_ENTRY * thread_p, xasl_node * xasl, bool is_final, bool
 
 	if (xasl->curr_spec)
 	  {
-	    SCAN_ID *s_id = &xasl->curr_spec->s_id;
-
-	    scan_end_scan (thread_p, s_id);
-	    scan_close_scan (thread_p, s_id);
+	    scan_end_scan (thread_p, &xasl->curr_spec->s_id);
+	    scan_close_scan (thread_p, &xasl->curr_spec->s_id);
 	  }
 	if (xasl->merge_spec)
 	  {

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -2448,8 +2448,18 @@ qexec_clear_xasl (THREAD_ENTRY * thread_p, xasl_node * xasl, bool is_final, bool
 
 	if (xasl->curr_spec)
 	  {
-	    scan_end_scan (thread_p, &xasl->curr_spec->s_id);
-	    scan_close_scan (thread_p, &xasl->curr_spec->s_id);
+	    SCAN_ID *s_id = &xasl->curr_spec->s_id;
+
+	    /* Force-close reuse-mode DBLink: scan_close_scan would see S_CLOSED (set during the
+	     * last iteration's skipped dblink_close_scan) and return early, leaking CCI handles. */
+	    if (s_id->type == S_DBLINK_SCAN && s_id->s.dblid.scan_info.cursor_rewind)
+	      {
+		s_id->s.dblid.scan_info.cursor_rewind = 0;
+		dblink_close_scan (&s_id->s.dblid.scan_info);
+	      }
+
+	    scan_end_scan (thread_p, s_id);
+	    scan_close_scan (thread_p, s_id);
 	  }
 	if (xasl->merge_spec)
 	  {
@@ -3313,13 +3323,6 @@ qexec_clear_head_lists_with_truncate (THREAD_ENTRY * thread_p, XASL_NODE * xasl_
 	  /* skip out zero correlation-level uncorrelated subquery */
 	  continue;
 	}
-      if (IS_REUSE_DBLINK_XASL (xasl))
-	{
-	  /* correlated DBLink: keep materialized list for outer-row reuse (CBRD-26640) */
-	  continue;
-	}
-
-
       if (xasl->list_id && !xasl->list_id->is_result_cached)
 	{
 	  qfile_truncate_list (thread_p, xasl->list_id);
@@ -3379,11 +3382,6 @@ qexec_clear_head_lists (THREAD_ENTRY * thread_p, XASL_NODE * xasl_list)
       if (XASL_IS_FLAGED (xasl, XASL_ZERO_CORR_LEVEL))
 	{
 	  /* skip out zero correlation-level uncorrelated subquery */
-	  continue;
-	}
-      if (IS_REUSE_DBLINK_XASL (xasl))
-	{
-	  /* correlated DBLink: keep materialized list for outer-row reuse (CBRD-26640) */
 	  continue;
 	}
       /* clear XASL head node */
@@ -7628,6 +7626,10 @@ qexec_open_scan (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * curr_spec, VAL_LIST
 
 	host_vars.count = curr_spec->s.dblink_node.host_var_count;
 	host_vars.index = curr_spec->s.dblink_node.host_var_index;
+
+	/* inject reuse flag before open: scan_init_scan_id does not touch s.dblid.scan_info,
+	 * so the flag survives across open/close cycles. */
+	s_id->s.dblid.scan_info.cursor_rewind = IS_DBLINK_CURSOR_REWIND_XASL (xasl) ? 1 : 0;
 
 	error_code = scan_open_dblink_scan (thread_p, s_id, curr_spec, vd, val_list, &host_vars);
 	if (error_code != NO_ERROR)

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -3394,7 +3394,6 @@ qexec_clear_head_lists_with_truncate (THREAD_ENTRY * thread_p, XASL_NODE * xasl_
     }
 }
 
-
 /*
  * qexec_clear_head_lists () -
  *   return:

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -5073,7 +5073,7 @@ scan_close_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
       break;
 
     case S_DBLINK_SCAN:
-      dblink_close_scan (&scan_id->s.dblid.scan_info);
+      dblink_close_scan (&scan_id->s.dblid.scan_info, false);
       break;
 
     case S_JSON_TABLE_SCAN:

--- a/src/query/xasl.h
+++ b/src/query/xasl.h
@@ -519,10 +519,10 @@ struct cte_proc_node
 #define XASL_NO_PARALLEL_SUBQUERY       (0x1 << 19)	/* disable parallel subquery */
 #define XASL_ANALYTIC_USES_LIMIT_OPT (0x1 << 20)	/* analytic uses limit optimization */
 #define XASL_ANALYTIC_SKIP_SORT (0x1 << 21)	/* analytic skip sort optimization */
-#define XASL_REUSE_DBLINK	(0x1 << 22)	/* correlated DBLink subquery: reuse list file (result set) across outer rows */
+#define XASL_DBLINK_CURSOR_REWIND	(0x1 << 22)	/* correlated DBLink subquery: rewind CCI cursor instead of re-issuing cci_execute per outer row */
 
 #define XASL_IS_FLAGED(x, f)        (((x)->flag & (int) (f)) != 0)
-#define IS_REUSE_DBLINK_XASL(x)     XASL_IS_FLAGED ((x), XASL_REUSE_DBLINK)
+#define IS_DBLINK_CURSOR_REWIND_XASL(x)     XASL_IS_FLAGED ((x), XASL_DBLINK_CURSOR_REWIND)
 #define XASL_SET_FLAG(x, f)         (x)->flag |= (int) (f)
 #define XASL_CLEAR_FLAG(x, f)       (x)->flag &= (int) ~(f)
 

--- a/src/query/xasl.h
+++ b/src/query/xasl.h
@@ -519,8 +519,10 @@ struct cte_proc_node
 #define XASL_NO_PARALLEL_SUBQUERY       (0x1 << 19)	/* disable parallel subquery */
 #define XASL_ANALYTIC_USES_LIMIT_OPT (0x1 << 20)	/* analytic uses limit optimization */
 #define XASL_ANALYTIC_SKIP_SORT (0x1 << 21)	/* analytic skip sort optimization */
+#define XASL_REUSE_DBLINK	(0x1 << 22)	/* correlated DBLink subquery: reuse list file (result set) across outer rows */
 
 #define XASL_IS_FLAGED(x, f)        (((x)->flag & (int) (f)) != 0)
+#define IS_REUSE_DBLINK_XASL(x)     XASL_IS_FLAGED ((x), XASL_REUSE_DBLINK)
 #define XASL_SET_FLAG(x, f)         (x)->flag |= (int) (f)
 #define XASL_CLEAR_FLAG(x, f)       (x)->flag &= (int) ~(f)
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26640

### Purpose

상관 DBLink 스칼라 서브쿼리(`SELECT r.col FROM remote_t@conn r WHERE r.id = l.id`)에서
outer 행마다 `cci_execute`가 재실행되어 원격 전체 행이 반복 전송되는 문제를 수정한다.

**근본 원인**: `mq_copypush_sargable_terms_helper`가 DBLink SELECT 노드의 `correlation_level`을 0→2로
변경하기 때문에 `parser_generate_xasl_proc`에서 `XASL_ZERO_CORR_LEVEL`이 설정되지 않는다.
결과적으로 런타임에 `qexec_clear_head_lists`가 매 outer 행마다 DBLink XASL을 CLEAR하고
`cci_execute`가 재발행된다.

**수정**: `XASL_DBLINK_CURSOR_REWIND` 플래그를 추가하고, 첫 outer 행에서 `cci_execute`를 1회
실행한 뒤 이후 outer 행에서는 `cci_cursor(CCI_CURSOR_FIRST)`로 커서를 되감아 재스캔한다.
원격 SQL 실행 및 네트워크 전송이 1회로 줄어든다.

| | AS-IS | TO-BE (이 PR) |
|---|---|---|
| `cci_execute` 호출 횟수 | outer 행 수(M)회 | 1회 |
| 원격 전송 행 수 | N행 × M회 | N행 × 1회 |
| CCI 핸들 생명주기 | 매 outer 행마다 open/close | query 종료 시 최종 close |

### Implementation

- `src/query/xasl.h`
  - `XASL_DBLINK_CURSOR_REWIND` (bit 22), `IS_DBLINK_CURSOR_REWIND_XASL` 추가

- `src/parser/xasl_generation.c`
  - `pt_xasl_spec_has_dblink()` 신규: XASL spec_list에 `TARGET_DBLINK` spec 존재 여부 검사
  - `parser_generate_xasl_proc()`: `correlation_level != 0` 이고 DBLink spec이 있으면
    `XASL_DBLINK_CURSOR_REWIND` 설정

- `src/query/dblink_scan.h`
  - `DBLINK_SCAN_INFO.cursor_rewind` 필드 추가
  - `dblink_close_scan(is_final)` 시그니처 변경 (`bool is_final` 파라미터 추가)

- `src/query/dblink_scan.c`
  - `dblink_open_scan()`: `cursor_rewind=1`이고 CCI 핸들이 살아 있으면
    `cci_cursor(1, CCI_CURSOR_FIRST)`로 되감기, `cci_execute` 생략
  - `dblink_close_scan(is_final)`:
    - `is_final=false` (per-iteration): `cursor_rewind=1`이면 close 생략, CCI 핸들 유지
    - `is_final=true` (최종 teardown): `cursor_rewind` 해제 + CCI stmt/conn 핸들 해제
  - `stmt_handle=-1` / `conn_handle=-1` sentinel 도입 (이중 해제 방지)
  - autocommit 처리 단순화: `auto_commit` 파라미터가 true인 경우에만 `cci_set_autocommit(FALSE)`
    호출 (save/restore 방식 제거)

- `src/query/scan_manager.c`
  - `scan_close_scan()`: `dblink_close_scan(is_final=false)` 호출로 변경

- `src/query/query_executor.c`
  - `qexec_final_close_dblink_specs()` 신규: XASL의 `spec_list`/`merge_spec`를 순회하며
    모든 `TARGET_DBLINK` spec에 `dblink_close_scan(is_final=true)` 호출
  - `qexec_clear_xasl()` / `qexec_clear_xasl_for_parallel_aptr()` 진입부에서
    `qexec_final_close_dblink_specs()` 호출 — proc type switch 이전에 실행하여
    BUILDVALUE_PROC 래퍼 포함 모든 XASL node type을 커버
  - `scan_open_scan()` 직전: `cursor_rewind = IS_DBLINK_CURSOR_REWIND_XASL(xasl) ? 1 : 0` 주입
  - xcache clone 재사용 경로(`qexec_clear_regu_var`, `XASL_INITIALIZED`): `regu_var->xasl`에도
    `qexec_final_close_dblink_specs()` 호출 추가

- `src/query/query_dump.c`
  - `XASL_DBLINK_CURSOR_REWIND` 플래그 이름 등록

### Remarks

#### debug 빌드 assert

setter/unsetter 쌍 누락을 즉시 검출할 수 있도록 debug 빌드에 assert 2개를 추가했다.

```c
/* dblink_open_scan() 진입부 — 이전 teardown에서 핸들이 누수됐으면 발화 */
assert (cursor_rewind || stmt_handle <= 0);

/* qexec_clear_xasl() 의 qexec_final_close_dblink_specs() 호출 직후 — unsetter 미도달 시 발화 */
assert (stmt_handle <= 0 && cursor_rewind == 0);
```

