### PR TITLE
[CBRD-26685] Implement skeleton class for slot pool.

### DIFF
--- a/src/thread/thread_worker_pool_elastic.hpp
+++ b/src/thread/thread_worker_pool_elastic.hpp
@@ -35,6 +35,8 @@
 
 // system includes
 #include <chrono>
+#include <memory>
+#include <queue>
 
 namespace cubthread
 {
@@ -46,7 +48,7 @@ namespace cubthread
   //    (e.g., blocked on a transaction lock).
   //
   template <stats_t Stats>
-  class worker_pool_elastic : public worker_pool_impl<Stats>
+  class worker_pool_elastic final : public worker_pool_impl<Stats>
   {
       // forward definition for nested core class
       friend class manager;
@@ -55,9 +57,12 @@ namespace cubthread
       // forward definition
       class core_elastic;
 
+      class slot;
+      class slot_pool;
+
       ~worker_pool_elastic ();
 
-    protected:
+    private:
       worker_pool_elastic (std::size_t pool_size, std::size_t core_count, const char *name, entry_manager &entry_mgr,
 			   bool pool_threads = false, wait_seconds idle_timeout = std::chrono::seconds (5));
 
@@ -67,18 +72,85 @@ namespace cubthread
   // worker_pool_elastic<Stats>::core_elastic
   //
   // description
-  //    TODO: add description
+  //    elastic worker-pool core with a per-core slot pool that limits runnable concurrency.
   //
   template <stats_t Stats>
-  class worker_pool_elastic<Stats>::core_elastic : public worker_pool_impl<Stats>::core_impl
+  class worker_pool_elastic<Stats>::core_elastic final : public worker_pool_impl<Stats>::core_impl
   {
       friend class worker_pool_elastic;
 
     public:
       ~core_elastic ();
 
-    protected:
+      void initialize (std::size_t concurrency) override;
+
+    private:
       core_elastic (bool pool_threads);
+
+      slot_pool m_slot_pool;
+  };
+
+  // worker_pool_elastic<Stats>::slot
+  //
+  // description
+  //	slot required by a worker before it can run a task.
+  //
+  template <stats_t Stats>
+  class worker_pool_elastic<Stats>::slot
+  {
+      friend class slot_pool;
+
+    public:
+      ~slot ();
+
+      void set_owner_pool (slot_pool *owner_pool);
+
+    private:
+      slot ();
+
+      slot_pool *m_owner_pool;
+  };
+
+  // worker_pool_elastic<Stats>::slot_pool
+  //
+  // description
+  //    manages available concurrency slots
+  //
+  template <stats_t Stats>
+  class worker_pool_elastic<Stats>::slot_pool
+  {
+      friend class core_elastic;
+
+    public:
+      ~slot_pool ();
+
+      void initialize (std::size_t slot_count);
+
+      // for worker
+      std::unique_ptr<slot> try_acquire_slot ();
+      std::unique_ptr<slot> acquire_slot ();
+
+      void release_slot (std::unique_ptr<slot> uslot);
+
+      // called by the daemon to borrow surplus slots in batches of SLOT_SURPLUS_THRESHOLD.
+      bool borrow_surplus_slots ();
+
+      // information
+      void set_parent_core (core_elastic *parent_core);
+
+    private:
+      slot_pool ();
+
+      static constexpr std::size_t SLOT_SURPLUS_THRESHOLD = 2;
+
+      core_elastic *m_parent_core;
+
+      std::queue<std::unique_ptr<slot>> m_available_slots;
+      std::chrono::time_point<std::chrono::steady_clock> m_surplus_since;
+
+      std::queue<entry *> m_wait_queue; // wait entry list to acquire a slot
+
+      std::mutex m_mutex; // guard for m_available_slots, m_surplus_since and m_wait_queue
   };
 
 } // namespace cubthread
@@ -121,6 +193,109 @@ namespace cubthread
   template <stats_t Stats>
   worker_pool_elastic<Stats>::core_elastic::~core_elastic ()
   {
+  }
+
+  template <stats_t Stats>
+  void
+  worker_pool_elastic<Stats>::core_elastic::initialize (std::size_t concurrency)
+  {
+    assert (concurrency > 0);
+
+    // resources reserve
+    this->m_available_workers.reserve (concurrency);
+
+    // workers
+    this->allocate_workers (concurrency);
+    this->initialize_workers ();
+
+    // slot
+    m_slot_pool.set_parent_core (this);
+    m_slot_pool.initialize (concurrency);
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // worker_pool_elastic<Stats>::slot
+  //////////////////////////////////////////////////////////////////////////
+
+  template <stats_t Stats>
+  worker_pool_elastic<Stats>::slot::slot ()
+    : m_owner_pool (nullptr)
+  {
+  }
+
+  template <stats_t Stats>
+  worker_pool_elastic<Stats>::slot::~slot ()
+  {
+  }
+
+  template <stats_t Stats>
+  void
+  worker_pool_elastic<Stats>::slot::set_owner_pool (slot_pool *owner_pool)
+  {
+    m_owner_pool = owner_pool;
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // worker_pool_elastic<Stats>::slot_pool
+  //////////////////////////////////////////////////////////////////////////
+
+  template <stats_t Stats>
+  worker_pool_elastic<Stats>::slot_pool::slot_pool ()
+    : m_parent_core (nullptr)
+  {
+  }
+
+  template <stats_t Stats>
+  worker_pool_elastic<Stats>::slot_pool::~slot_pool ()
+  {
+  }
+
+  template <stats_t Stats>
+  void
+  worker_pool_elastic<Stats>::slot_pool::initialize (std::size_t slot_count)
+  {
+    std::lock_guard<std::mutex> lock (m_mutex);
+    std::size_t i;
+
+    for (i = 0; i < slot_count; i++)
+      {
+	m_available_slots.emplace (std::unique_ptr<slot> (new slot ()));
+	m_available_slots.back ()->set_owner_pool (this);
+      }
+  }
+
+  template <stats_t Stats>
+  std::unique_ptr<typename worker_pool_elastic<Stats>::slot>
+  worker_pool_elastic<Stats>::slot_pool::try_acquire_slot ()
+  {
+    return nullptr;
+  }
+
+  template <stats_t Stats>
+  std::unique_ptr<typename worker_pool_elastic<Stats>::slot>
+  worker_pool_elastic<Stats>::slot_pool::acquire_slot ()
+  {
+    return nullptr;
+  }
+
+  template <stats_t Stats>
+  void
+  worker_pool_elastic<Stats>::slot_pool::release_slot (std::unique_ptr<slot> uslot)
+  {
+  }
+
+  template <stats_t Stats>
+  bool
+  worker_pool_elastic<Stats>::slot_pool::borrow_surplus_slots ()
+  {
+    return true;
+  }
+
+  template <stats_t Stats>
+  void
+  worker_pool_elastic<Stats>::slot_pool::set_parent_core (core_elastic *parent_core)
+  {
+    m_parent_core = parent_core;
   }
 
 } // namespace cubthread


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26685>

### Purpose

Slot 관리를 위한 slot pool을 구현합니다. 이 이슈에서는 인터페이스 수준으로만 구현합니다.

Slot pool은 아래와 같은 기능들을 가질 것이고, 이에 따라 몇 가지 멤버들을 가지게 되었습니다.
1. Slot 관리
2. Slot 대관 - Slot이 일정 개수 이상인 경우 그 시점을 시간을 기록합니다. 추후 daemon이 확인했을 때 일정 개수 이상 유지된 시간이 일정 시간 이상이라면 slot을 다른 core (slot pool)로 잠시 이동합니다.
3. 대기자 - Slot을 얻기 위해 Thread가 요청한 경우 내부적으로 순서를 관리합니다. 현재는 단순한 queue 하나만 존재합니다.

### Implementation

N/A

### Remarks

in-progress PR이므로 CI는 제외합니다.