### PR TITLE
[CBRD-26747] Enable fixed scan for outer heap scans in NLJ by default

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -795,6 +795,8 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 
 #define PRM_NAME_LOG_POSTPONE_CACHE_SIZE "postpone_cache_size"
 
+#define PRM_NAME_ENABLE_HEAP_FIXED_SCAN "enable_heap_fixed_scan"
+
 // #endregion 
 
 /*
@@ -5325,6 +5327,17 @@ SYSPRM_PARAM prm_Def[] = {
    {false, {.i = 512}},
    {false, {.i = 4096}},
    {false, {.i = 4}},
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
+  {PRM_ID_ENABLE_HEAP_FIXED_SCAN,
+   PRM_NAME_ENABLE_HEAP_FIXED_SCAN,
+   (PRM_FOR_CLIENT | PRM_USER_CHANGE | PRM_FOR_SESSION | PRM_FOR_QRY_STRING),
+   PRM_BOOLEAN,
+   PRM_CLEAR_DYNAMIC_FLAG,
+   {false, {.b = true}},
+   {false, {.b = true}},
+   NULL_SYSPRM_PARAM_VALUE, NULL_SYSPRM_PARAM_VALUE,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL},

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -528,8 +528,10 @@ enum param_id
 
   PRM_ID_LOG_POSTPONE_CACHE_SIZE,
 
+  PRM_ID_ENABLE_HEAP_FIXED_SCAN,
+
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_LOG_POSTPONE_CACHE_SIZE
+  PRM_LAST_ID = PRM_ID_ENABLE_HEAP_FIXED_SCAN
 };
 typedef enum param_id PARAM_ID;
 

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -430,6 +430,7 @@ static OUTPTR_LIST *pt_to_outlist (PARSER_CONTEXT * parser, PT_NODE * node_list,
 static void pt_to_fetch_proc_list_recurse (PARSER_CONTEXT * parser, PT_NODE * spec, XASL_NODE * root);
 static void pt_to_fetch_proc_list (PARSER_CONTEXT * parser, PT_NODE * spec, XASL_NODE * root);
 static XASL_NODE *pt_to_scan_proc_list (PARSER_CONTEXT * parser, PT_NODE * node, XASL_NODE * root);
+static void pt_apply_heap_fixed_scan_flag (XASL_NODE * xasl);
 static XASL_NODE *pt_gen_optimized_plan (PARSER_CONTEXT * parser, PT_NODE * select_node, QO_PLAN * plan,
 					 XASL_NODE * xasl);
 static XASL_NODE *pt_gen_simple_plan (PARSER_CONTEXT * parser, PT_NODE * select_node, QO_PLAN * plan, XASL_NODE * xasl);
@@ -14703,6 +14704,34 @@ pt_to_scan_proc_list (PARSER_CONTEXT * parser, PT_NODE * node, XASL_NODE * root)
 }
 
 /*
+ * pt_apply_heap_fixed_scan_flag () - Set ACCESS_SPEC_FLAG_FORCE_FIXED_SCAN on all TARGET_CLASS sequential scan specs
+ *   in the XASL scan chain when the enable_heap_fixed_scan system parameter is true.
+ *   xasl(in): top-level XASL node
+ */
+static void
+pt_apply_heap_fixed_scan_flag (XASL_NODE * xasl)
+{
+  XASL_NODE *xptr;
+  ACCESS_SPEC_TYPE *specp;
+
+  if (!prm_get_bool_value (PRM_ID_ENABLE_HEAP_FIXED_SCAN))
+    {
+      return;
+    }
+
+  for (xptr = xasl; xptr; xptr = xptr->scan_ptr)
+    {
+      for (specp = xptr->spec_list; specp; specp = specp->next)
+	{
+	  if (specp->type == TARGET_CLASS)
+	    {
+	      ACCESS_SPEC_SET_FLAG (specp, ACCESS_SPEC_FLAG_FORCE_FIXED_SCAN);
+	    }
+	}
+    }
+}
+
+/*
  * pt_gen_optimized_plan () - Translate a PT_SELECT node to a XASL plan
  *   return:
  *   parser(in):
@@ -16962,6 +16991,8 @@ pt_to_buildlist_proc (PARSER_CONTEXT * parser, PT_NODE * select_node, QO_PLAN * 
       qo_plan = NULL;
     }
 
+  pt_apply_heap_fixed_scan_flag (xasl);
+
   if (xasl->outptr_list)
     {
       if (qo_plan)
@@ -17328,6 +17359,8 @@ pt_to_buildvalue_proc (PARSER_CONTEXT * parser, PT_NODE * select_node, QO_PLAN *
 	}
       buildvalue = &xasl->proc.buildvalue;
     }
+
+  pt_apply_heap_fixed_scan_flag (xasl);
 
   /* set access spec for aggregation */
   if (xasl->spec_list)

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -430,7 +430,6 @@ static OUTPTR_LIST *pt_to_outlist (PARSER_CONTEXT * parser, PT_NODE * node_list,
 static void pt_to_fetch_proc_list_recurse (PARSER_CONTEXT * parser, PT_NODE * spec, XASL_NODE * root);
 static void pt_to_fetch_proc_list (PARSER_CONTEXT * parser, PT_NODE * spec, XASL_NODE * root);
 static XASL_NODE *pt_to_scan_proc_list (PARSER_CONTEXT * parser, PT_NODE * node, XASL_NODE * root);
-static void pt_apply_heap_fixed_scan_flag (XASL_NODE * xasl);
 static XASL_NODE *pt_gen_optimized_plan (PARSER_CONTEXT * parser, PT_NODE * select_node, QO_PLAN * plan,
 					 XASL_NODE * xasl);
 static XASL_NODE *pt_gen_simple_plan (PARSER_CONTEXT * parser, PT_NODE * select_node, QO_PLAN * plan, XASL_NODE * xasl);
@@ -12465,6 +12464,11 @@ pt_to_class_spec_list (PARSER_CONTEXT * parser, PT_NODE * spec, PT_NODE * where_
 		  assert (access->num_parallel_threads == -1 /* auto-compute */ );
 		}
 
+	      if (scan_type == TARGET_CLASS && prm_get_bool_value (PRM_ID_ENABLE_HEAP_FIXED_SCAN))
+		{
+		  ACCESS_SPEC_SET_FLAG (access, ACCESS_SPEC_FLAG_FORCE_FIXED_SCAN);
+		}
+
 	    }
 	  else if (PT_SPEC_SPECIAL_INDEX_SCAN (spec))
 	    {
@@ -14701,34 +14705,6 @@ pt_to_scan_proc_list (PARSER_CONTEXT * parser, PT_NODE * node, XASL_NODE * root)
     }
 
   return list;
-}
-
-/*
- * pt_apply_heap_fixed_scan_flag () - Set ACCESS_SPEC_FLAG_FORCE_FIXED_SCAN on all TARGET_CLASS sequential scan specs
- *   in the XASL scan chain when the enable_heap_fixed_scan system parameter is true.
- *   xasl(in): top-level XASL node
- */
-static void
-pt_apply_heap_fixed_scan_flag (XASL_NODE * xasl)
-{
-  XASL_NODE *xptr;
-  ACCESS_SPEC_TYPE *specp;
-
-  if (!prm_get_bool_value (PRM_ID_ENABLE_HEAP_FIXED_SCAN))
-    {
-      return;
-    }
-
-  for (xptr = xasl; xptr; xptr = xptr->scan_ptr)
-    {
-      for (specp = xptr->spec_list; specp; specp = specp->next)
-	{
-	  if (specp->type == TARGET_CLASS)
-	    {
-	      ACCESS_SPEC_SET_FLAG (specp, ACCESS_SPEC_FLAG_FORCE_FIXED_SCAN);
-	    }
-	}
-    }
 }
 
 /*
@@ -16991,8 +16967,6 @@ pt_to_buildlist_proc (PARSER_CONTEXT * parser, PT_NODE * select_node, QO_PLAN * 
       qo_plan = NULL;
     }
 
-  pt_apply_heap_fixed_scan_flag (xasl);
-
   if (xasl->outptr_list)
     {
       if (qo_plan)
@@ -17359,8 +17333,6 @@ pt_to_buildvalue_proc (PARSER_CONTEXT * parser, PT_NODE * select_node, QO_PLAN *
 	}
       buildvalue = &xasl->proc.buildvalue;
     }
-
-  pt_apply_heap_fixed_scan_flag (xasl);
 
   /* set access spec for aggregation */
   if (xasl->spec_list)

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -603,6 +603,7 @@ static SCAN_CODE qexec_init_next_partition (THREAD_ENTRY * thread_p, ACCESS_SPEC
 
 static int qexec_check_limit_clause (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_state,
 				     bool * empty_result);
+static XASL_NODE *qexec_determine_fixed_scan_xasl (XASL_NODE * xasl);
 static int qexec_execute_mainblock_internal (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xasl_state,
 					     UPDDEL_CLASS_INSTANCE_LOCK_INFO * p_class_instance_lock_info);
 static DEL_LOB_INFO *qexec_create_delete_lob_info (THREAD_ENTRY * thread_p, XASL_STATE * xasl_state,
@@ -15047,6 +15048,78 @@ qexec_execute_dblink_query (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STAT
 }
 
 /*
+ * qexec_determine_fixed_scan_xasl () - Determine which XASL node is eligible for fixed heap scan.
+ *   return: the innermost TARGET_CLASS XASL node that should use fixed scan, or NULL if fixed scan is not allowed.
+ *   xasl(in): top-level XASL node
+ *
+ * Fixed scan keeps the last fetched heap page latched between rows (PEEK mode), avoiding repeated fix/unfix overhead.
+ * It is disabled when: composite locking is required, any index scan is present, a correlated subquery exists,
+ * a HAVING subquery exists, an uncorrelated subquery linked to a regu variable exists, or the XASL_NO_FIXED_SCAN
+ * flag was set at compile time.
+ */
+static XASL_NODE *
+qexec_determine_fixed_scan_xasl (XASL_NODE * xasl)
+{
+  XASL_NODE *xptr;
+  ACCESS_SPEC_TYPE *specp;
+  XASL_NODE *fixed_scan_xasl = NULL;
+  bool has_index_scan = false;
+
+  if (COMPOSITE_LOCK (xasl->scan_op_type))
+    {
+      return NULL;
+    }
+
+  for (xptr = xasl; xptr; xptr = xptr->scan_ptr)
+    {
+      for (specp = xptr->spec_list; specp; specp = specp->next)
+	{
+	  if (specp->type == TARGET_CLASS)
+	    {
+	      fixed_scan_xasl = xptr;
+	      if (IS_ANY_INDEX_ACCESS (specp->access))
+		{
+		  has_index_scan = true;
+		  break;
+		}
+	    }
+	}
+      if (has_index_scan)
+	{
+	  break;
+	}
+      specp = xptr->merge_spec;
+      if (specp && specp->type == TARGET_CLASS)
+	{
+	  fixed_scan_xasl = xptr;
+	  if (IS_ANY_INDEX_ACCESS (specp->access))
+	    {
+	      has_index_scan = true;
+	      break;
+	    }
+	}
+    }
+
+  if (has_index_scan || XASL_IS_FLAGED (xasl, XASL_NO_FIXED_SCAN) || xasl->dptr_list != NULL)
+    {
+      return NULL;
+    }
+  if (xasl->type == BUILDLIST_PROC && xasl->proc.buildlist.eptr_list != NULL)
+    {
+      return NULL;
+    }
+  for (xptr = xasl->aptr_list; xptr != NULL; xptr = xptr->next)
+    {
+      if (XASL_IS_FLAGED (xptr, XASL_LINK_TO_REGU_VARIABLE))
+	{
+	  return NULL;
+	}
+    }
+
+  return fixed_scan_xasl;
+}
+
+/*
  * qexec_execute_mainblock_internal () -
  *   return: NO_ERROR, or ER_code
  *   xasl(in)   : XASL Tree pointer
@@ -15071,7 +15144,6 @@ qexec_execute_mainblock_internal (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
   XASL_NODE *outer_xasl = NULL, *inner_xasl = NULL;
   XASL_NODE *fixed_scan_xasl = NULL;
   bool iscan_oid_order, force_select_lock = false;
-  bool has_index_scan = false;
   int old_wait_msecs, wait_msecs;
   int error;
   bool empty_result = false;
@@ -15590,84 +15662,7 @@ qexec_execute_mainblock_internal (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
       /* iterative processing is done only for XASL blocks that has access specification list blocks. */
       if (xasl->spec_list)
 	{
-	  /* Decide which scan will use fixed flags and which won't. There are several cases here: 1. Do not use fixed
-	   * scans if locks on objects are required. 2. Disable all fixed scans if any index scan is used (this is
-	   * legacy and should be reconsidered). 3. Disable fixed scan for outer scans. Fixed cannot be allowed while
-	   * new scans start which also need to fix pages. This may lead to page deadlocks. NOTE: Only the innermost
-	   * scans are allowed fixed scans. */
-	  if (COMPOSITE_LOCK (xasl->scan_op_type))
-	    {
-	      /* Do locking on each instance instead of composite locking */
-	      /* Fall through */
-	    }
-	  else
-	    {
-	      for (xptr = xasl; xptr; xptr = xptr->scan_ptr)
-		{
-		  specp = xptr->spec_list;
-		  for (; specp; specp = specp->next)
-		    {
-		      if (specp->type == TARGET_CLASS)
-			{
-			  /* Update fixed scan XASL */
-			  fixed_scan_xasl = xptr;
-			  if (IS_ANY_INDEX_ACCESS (specp->access))
-			    {
-			      has_index_scan = true;
-			      break;
-			    }
-			}
-		    }
-		  if (has_index_scan)
-		    {
-		      /* Stop search */
-		      break;
-		    }
-		  specp = xptr->merge_spec;
-		  if (specp)
-		    {
-		      if (specp->type == TARGET_CLASS)
-			{
-			  /* Update fixed scan XASL */
-			  fixed_scan_xasl = xptr;
-			  if (IS_ANY_INDEX_ACCESS (specp->access))
-			    {
-			      has_index_scan = true;
-			      break;
-			    }
-			}
-		    }
-		}
-	    }
-	  if (has_index_scan)
-	    {
-	      /* Index found, no fixed is allowed */
-	      fixed_scan_xasl = NULL;
-	    }
-	  if (XASL_IS_FLAGED (xasl, XASL_NO_FIXED_SCAN))
-	    {
-	      /* no fixed scan if it was decided so during compilation */
-	      fixed_scan_xasl = NULL;
-	    }
-	  if (xasl->dptr_list != NULL)
-	    {
-	      /* correlated subquery found, no fixed is allowed */
-	      fixed_scan_xasl = NULL;
-	    }
-	  if (xasl->type == BUILDLIST_PROC && xasl->proc.buildlist.eptr_list != NULL)
-	    {
-	      /* subquery in HAVING clause, can't have fixed scan */
-	      fixed_scan_xasl = NULL;
-	    }
-	  for (xptr = xasl->aptr_list; xptr != NULL; xptr = xptr->next)
-	    {
-	      if (XASL_IS_FLAGED (xptr, XASL_LINK_TO_REGU_VARIABLE))
-		{
-		  /* uncorrelated query that is not pre-executed, but evaluated in a reguvar; no fixed scan in this
-		   * case */
-		  fixed_scan_xasl = NULL;
-		}
-	    }
+	  fixed_scan_xasl = qexec_determine_fixed_scan_xasl (xasl);
 
 	  /* open all the scans that are involved within the query, for SCAN blocks */
 	  for (xptr = xasl, level = 0; xptr; xptr = xptr->scan_ptr, level++)
@@ -15680,7 +15675,8 @@ qexec_execute_mainblock_internal (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
 		  for (specp = spec_ptr[spec_level]; specp; specp = specp->next)
 		    {
 		      specp->fixed_scan = (xptr == fixed_scan_xasl)
-			|| ACCESS_SPEC_IS_FLAGED (specp, ACCESS_SPEC_FLAG_FORCE_FIXED_SCAN);
+			|| (ACCESS_SPEC_IS_FLAGED (specp, ACCESS_SPEC_FLAG_FORCE_FIXED_SCAN)
+			    && !COMPOSITE_LOCK (xasl->scan_op_type));
 
 		      /* set if the scan will be done in a grouped manner */
 		      if ((level == 0 && xptr->scan_ptr == NULL) && (QPROC_MAX_GROUPED_SCAN_CNT > 0))


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26747>

### Purpose
힙 스캔이 NLJ(Nested Loop Join) 포함 질의에서 최대 10배 느려지는 현상이 확인됨. 원인은 qexec_execute_mainblock_internal의 fixed scan 결정 로직에 존재하는 보수적 제약들로, inner scan에 인덱스 스캔이 하나라도 있으면 outer 힙 스캔을 포함한 전체 scan chain의 fixed scan을 무조건 비활성화하는 구조였음.

fixed_scan = true이면 heap page를 row 반환 후에도 buffer pool에 S-latch로 유지(PEEK 모드)하여, 동일 page의 다음 row 접근 시 fix/unfix 비용을 생략한다. NLJ에서 outer table 한 페이지당 수십~수백 번의 inner scan이 수행되므로 효과가 극대화된다.

기존 제약들의 추가 시점을 분석한 결과:

인덱스 스캔 있으면 전체 비활성화 (pre-2015): pgbuf_ordered_fix 도입 이전, 인덱스 스캔이 heap page를 랜덤 순서로 접근하면 circular latch wait 발생 위험이 있었음
MVCC 시대 추가 제약 (dptr_list, eptr_list, XASL_LINK_TO_REGU_VARIABLE, outer scan 제한): 구체적인 deadlock 시나리오 없이 방어적으로 추가됨
2015년 도입된 pgbuf_ordered_fix는 thread-global하게 PAGE_HEAP 간 latch 순서를 강제하므로, 위 제약들이 막으려 했던 heap-heap circular latch 문제는 이미 해소된 상태이다.

### Implementation
enable_heap_fixed_scan = true (기본)
→ pt_to_class_spec_list에서 ACCESS_SPEC_FLAG_FORCE_FIXED_SCAN 세팅
→ qexec_execute_mainblock_internal에서 specp->fixed_scan = true
→ heap_scancache_start(cache_last_fix_page=true)
→ heap_next() 반환 후 page S-latch 유지 (PEEK 모드)

enable_heap_fixed_scan = false
→ 플래그 미세팅 → 기존 동작 (innermost 단일 힙 스캔에만 제한)

### Remarks
안전성 분석
heap-heap latch deadlock: pgbuf_ordered_fix가 PAGE_HEAP 간 순서를 thread-global로 강제 → 제거됨
서브쿼리/inner scan deadlock: 동일 스레드에서 실행, S-latch 호환 → 문제 없음
VACUUM X-latch와의 경합: S-latch 보유 시간 증가로 VACUUM wait 시간이 늘어날 수 있음. Deadlock이 아닌 latch contention(처리량 트레이드오프)
