### PR TITLE
[CBRD-26745] Flush deferred query handlers on net callback error path and cas finalize

### DIFF
--- a/src/communication/network_cl.c
+++ b/src/communication/network_cl.c
@@ -80,9 +80,12 @@ namespace
   {
     ~deferred_flush_guard ()
     {
-      if (!tran_is_in_libcas ())
+      cubmethod::callback_handler *h = cubmethod::get_callback_handler ();
+      /* fast path: skip the libcas-depth check and the flush call entirely
+         when no PL callback pushed anything to the queue. */
+      if (h->has_deferred_query_handler () && !tran_is_in_libcas ())
         {
-          cubmethod::get_callback_handler ()->free_deferred_query_handler ();
+          h->free_deferred_query_handler ();
         }
     }
   };

--- a/src/communication/network_cl.c
+++ b/src/communication/network_cl.c
@@ -85,7 +85,17 @@ namespace
          when no PL callback pushed anything to the queue. */
       if (h->has_deferred_query_handler () && !tran_is_in_libcas ())
 	{
+	  /* CBRD-26745: free_deferred_query_handler() walks query_handler dtors
+	     that may invoke db_query_end_internal()/db_close_session_local(),
+	     which call er_set() (e.g. ER_OBJ_NO_CONNECT when disconnected).
+	     Without isolation, that would clobber the caller's error (typically
+	     ER_NET_SERVER_CRASHED set by set_server_error() right before this
+	     destructor runs), so csql would lose the "Server no longer
+	     responding" message on disconnect paths. Wrap the flush with
+	     er_stack_push/pop to restore the outer error on exit. */
+	  er_stack_push ();
 	  h->free_deferred_query_handler ();
+	  er_stack_pop ();
 	}
     }
   };

--- a/src/communication/network_cl.c
+++ b/src/communication/network_cl.c
@@ -66,14 +66,10 @@
 #error Does not belong to cs module
 #endif /* !defined (CS_MODE) */
 
-/*
- * CBRD-26745: RAII guard that flushes callback_handler's deferred
- * query_handler list whenever the enclosing RPC helper exits, covering
- * every early return path (socket errors, allocation failures, etc).
- * Without this guard, stale query_handler* entries persisted in the
- * process-wide singleton queue across client sessions and were deleted
- * later by an unrelated client's RPC, double-freeing host_variables.
- */
+/* RAII guard: flush callback_handler's deferred query_handler queue on every return
+   path of method callback helpers. PL/SP execution pushes handlers into the process-wide
+   singleton; early-return paths would otherwise leak stale handlers that a later client
+   request frees. er_stack_push/pop keeps handler dtor er_set()s from clobbering the outer error. */
 namespace
 {
   struct deferred_flush_guard
@@ -81,18 +77,8 @@ namespace
     ~deferred_flush_guard ()
     {
       cubmethod::callback_handler * h = cubmethod::get_callback_handler ();
-      /* fast path: skip the libcas-depth check and the flush call entirely
-         when no PL callback pushed anything to the queue. */
       if (h->has_deferred_query_handler () && !tran_is_in_libcas ())
 	{
-	  /* CBRD-26745: free_deferred_query_handler() walks query_handler dtors
-	     that may invoke db_query_end_internal()/db_close_session_local(),
-	     which call er_set() (e.g. ER_OBJ_NO_CONNECT when disconnected).
-	     Without isolation, that would clobber the caller's error (typically
-	     ER_NET_SERVER_CRASHED set by set_server_error() right before this
-	     destructor runs), so csql would lose the "Server no longer
-	     responding" message on disconnect paths. Wrap the flush with
-	     er_stack_push/pop to restore the outer error on exit. */
 	  er_stack_push ();
 	  h->free_deferred_query_handler ();
 	  er_stack_pop ();
@@ -1169,7 +1155,6 @@ net_client_request_with_callback (int request, char *argbuf, int argsize, char *
 				  char **replydata_listid, int *replydatasize_listid, char **replydata_page,
 				  int *replydatasize_page, char **replydata_plan, int *replydatasize_plan)
 {
-  /* CBRD-26745: flush deferred query_handler queue on every return path */
   deferred_flush_guard _flush_guard;
 
   unsigned int rc;
@@ -1764,7 +1749,6 @@ int
 net_client_request_method_callback (int request, char *argbuf, int argsize, char *replybuf, int replysize,
 				    char **replydata_ptr, int *replydatasize_ptr)
 {
-  /* CBRD-26745: flush deferred query_handler queue on every return path */
   deferred_flush_guard _flush_guard;
 
   unsigned int rc;
@@ -1913,25 +1897,6 @@ net_client_request_method_callback (int request, char *argbuf, int argsize, char
 
 		__gv_cvar.css_queue_receive_data_buffer (rc, replydata, replydata_size);
 		error = __gv_cvar.css_receive_data_from_server (rc, &reply, &size);
-
-		/* (WILL REMOVE) CBRD-26745 fault injection: every Nth pl_call force the early
-		   return path so a stale query_handler is left in the deferred
-		   queue. Set env CBRD26745_INJECT_EVERY=N to enable. */
-		{
-		  const char *_inj_env = getenv ("CBRD26745_INJECT_EVERY");
-		  if (_inj_env != NULL)
-		    {
-		      static int _inj_count = 0;
-		      int _inj_n = atoi (_inj_env);
-		      if (_inj_n > 0 && (++_inj_count % _inj_n) == 0)
-			{
-			  fprintf (stderr, "[CBRD26745 inject] early-return @ call #%d\n", _inj_count);
-			  error = ER_NET_SERVER_DATA_RECEIVE;
-			  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 0);
-			}
-		    }
-		}
-
 		if (error != NO_ERROR)
 		  {
 		    COMPARE_AND_FREE_BUFFER (replydata, reply);

--- a/src/communication/network_cl.c
+++ b/src/communication/network_cl.c
@@ -1881,10 +1881,38 @@ net_client_request_method_callback (int request, char *argbuf, int argsize, char
 
 		__gv_cvar.css_queue_receive_data_buffer (rc, replydata, replydata_size);
 		error = __gv_cvar.css_receive_data_from_server (rc, &reply, &size);
+
+		/* (WILL REMOVE) CBRD-26745 fault injection: every Nth pl_call force the early
+		   return path so a stale query_handler is left in the deferred
+		   queue. Set env CBRD26745_INJECT_EVERY=N to enable. */
+		{
+		  const char *_inj_env = getenv ("CBRD26745_INJECT_EVERY");
+		  if (_inj_env != NULL)
+		    {
+		      static int _inj_count = 0;
+		      int _inj_n = atoi (_inj_env);
+		      if (_inj_n > 0 && (++_inj_count % _inj_n) == 0)
+		        {
+		          fprintf (stderr, "[CBRD26745 inject] early-return @ call #%d\n", _inj_count);
+		          error = ER_NET_SERVER_DATA_RECEIVE;
+		          er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 0);
+		        }
+		    }
+		}
+
 		if (error != NO_ERROR)
 		  {
 		    COMPARE_AND_FREE_BUFFER (replydata, reply);
 		    free_and_init (replydata);
+		    /* CBRD-26745: flush the deferred query_handler queue on the
+		       error path too, otherwise stale handlers persist in the
+		       callback_handler singleton across sessions and the next
+		       client's execute crashes in mspace_free via
+		       pr_clear_value on a freed host_variables buffer. */
+		    if (!tran_is_in_libcas ())
+		      {
+		        cubmethod::get_callback_handler ()->free_deferred_query_handler ();
+		      }
 		    return set_server_error (error);
 		  }
 		else

--- a/src/communication/network_cl.c
+++ b/src/communication/network_cl.c
@@ -67,6 +67,28 @@
 #endif /* !defined (CS_MODE) */
 
 /*
+ * CBRD-26745: RAII guard that flushes callback_handler's deferred
+ * query_handler list whenever the enclosing RPC helper exits, covering
+ * every early return path (socket errors, allocation failures, etc).
+ * Without this guard, stale query_handler* entries persisted in the
+ * process-wide singleton queue across client sessions and were deleted
+ * later by an unrelated client's RPC, double-freeing host_variables.
+ */
+namespace
+{
+  struct deferred_flush_guard
+  {
+    ~deferred_flush_guard ()
+    {
+      if (!tran_is_in_libcas ())
+        {
+          cubmethod::get_callback_handler ()->free_deferred_query_handler ();
+        }
+    }
+  };
+}
+
+/*
  * To check for errors from the comm system. Note that if we get any error
  * other than RECORD_TRUNCATED or CANT_ALLOC_BUFFER, we will call it a
  * SERVER_CRASHED error.  Also note that CANT_ALLOC_BUFFER allows the
@@ -1134,6 +1156,9 @@ net_client_request_with_callback (int request, char *argbuf, int argsize, char *
 				  char **replydata_listid, int *replydatasize_listid, char **replydata_page,
 				  int *replydatasize_page, char **replydata_plan, int *replydatasize_plan)
 {
+  /* CBRD-26745: flush deferred query_handler queue on every return path */
+  deferred_flush_guard _flush_guard;
+
   unsigned int rc;
   int size, error;
   int reply_datasize_listid, reply_datasize_page, reply_datasize_plan, remaining_size;
@@ -1710,15 +1735,6 @@ net_client_request_with_callback (int request, char *argbuf, int argsize, char *
 	}
       while (server_request != END_CALLBACK && server_request != QUERY_END);
 
-      /*
-       * delete deferred query handlers during PL execution
-       * TODO: move it to proper place
-       */
-      if (!tran_is_in_libcas ())
-	{
-	  cubmethod::get_callback_handler ()->free_deferred_query_handler ();
-	}
-
       if (histo_is_collecting ())
 	{
 	  int recevied = replysize
@@ -1735,6 +1751,9 @@ int
 net_client_request_method_callback (int request, char *argbuf, int argsize, char *replybuf, int replysize,
 				    char **replydata_ptr, int *replydatasize_ptr)
 {
+  /* CBRD-26745: flush deferred query_handler queue on every return path */
+  deferred_flush_guard _flush_guard;
+
   unsigned int rc;
   int error;
   QUERY_SERVER_REQUEST server_request;
@@ -1904,15 +1923,6 @@ net_client_request_method_callback (int request, char *argbuf, int argsize, char
 		  {
 		    COMPARE_AND_FREE_BUFFER (replydata, reply);
 		    free_and_init (replydata);
-		    /* CBRD-26745: flush the deferred query_handler queue on the
-		       error path too, otherwise stale handlers persist in the
-		       callback_handler singleton across sessions and the next
-		       client's execute crashes in mspace_free via
-		       pr_clear_value on a freed host_variables buffer. */
-		    if (!tran_is_in_libcas ())
-		      {
-		        cubmethod::get_callback_handler ()->free_deferred_query_handler ();
-		      }
 		    return set_server_error (error);
 		  }
 		else
@@ -1939,15 +1949,6 @@ net_client_request_method_callback (int request, char *argbuf, int argsize, char
 	}
     }
   while (server_request != END_CALLBACK);
-
-  /*
-   * delete deferred query handlers during PL execution
-   * TODO: move it to proper place
-   */
-  if (!tran_is_in_libcas ())
-    {
-      cubmethod::get_callback_handler ()->free_deferred_query_handler ();
-    }
 
   if (histo_is_collecting ())
     {

--- a/src/communication/network_cl.c
+++ b/src/communication/network_cl.c
@@ -80,13 +80,13 @@ namespace
   {
     ~deferred_flush_guard ()
     {
-      cubmethod::callback_handler *h = cubmethod::get_callback_handler ();
+      cubmethod::callback_handler * h = cubmethod::get_callback_handler ();
       /* fast path: skip the libcas-depth check and the flush call entirely
          when no PL callback pushed anything to the queue. */
       if (h->has_deferred_query_handler () && !tran_is_in_libcas ())
-        {
-          h->free_deferred_query_handler ();
-        }
+	{
+	  h->free_deferred_query_handler ();
+	}
     }
   };
 }
@@ -1914,11 +1914,11 @@ net_client_request_method_callback (int request, char *argbuf, int argsize, char
 		      static int _inj_count = 0;
 		      int _inj_n = atoi (_inj_env);
 		      if (_inj_n > 0 && (++_inj_count % _inj_n) == 0)
-		        {
-		          fprintf (stderr, "[CBRD26745 inject] early-return @ call #%d\n", _inj_count);
-		          error = ER_NET_SERVER_DATA_RECEIVE;
-		          er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 0);
-		        }
+			{
+			  fprintf (stderr, "[CBRD26745 inject] early-return @ call #%d\n", _inj_count);
+			  error = ER_NET_SERVER_DATA_RECEIVE;
+			  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error, 0);
+			}
 		    }
 		}
 

--- a/src/method/method_callback.cpp
+++ b/src/method/method_callback.cpp
@@ -1132,21 +1132,13 @@ exit:
   void
   callback_handler::clear_all_query_handlers ()
   {
-    /* CBRD-26745: drain every query_handler before ws_final() destroys the
-       workspace heap. Each query_handler owns a DB_SESSION whose parser and
-       host_variables[] are allocated from ws_heap; if a handler outlives
-       ws_final(), its dtor's db_close_session_local() walks freed mspace
-       memory and aborts. Called via method_callback_final() from
-       boot_client_all_finalize() right before ws_final(). */
-
-    /* drain deferred queue */
+    /* must run before ws_final(); query_handler dtor walks ws_heap-allocated host_variables */
     for (auto it = m_deferred_query_free_handler.begin (); it != m_deferred_query_free_handler.end (); it++)
       {
 	delete *it;
       }
     m_deferred_query_free_handler.clear ();
 
-    /* free live cached handlers */
     for (size_t i = 0; i < m_query_handlers.size (); i++)
       {
 	if (m_query_handlers[i] != nullptr)
@@ -1157,7 +1149,6 @@ exit:
       }
     m_query_handlers.clear ();
 
-    /* clear lookup maps that referenced the handler ids above */
     m_sql_handler_map.clear ();
     m_qid_handler_map.clear ();
   }
@@ -1210,11 +1201,7 @@ exit:
   }
 }
 
-/*
- * CBRD-26745: Invoked from boot_client_all_finalize() in
- * boot_cl.c (before ws_final()). Drains the singleton callback_handler so
- * no query_handler outlives the workspace heap.
- */
+/* called from boot_client_all_finalize() before ws_final() */
 void
 method_callback_final (void)
 {

--- a/src/method/method_callback.cpp
+++ b/src/method/method_callback.cpp
@@ -1129,6 +1129,39 @@ exit:
     m_deferred_query_free_handler.clear();
   }
 
+  void
+  callback_handler::clear_all_query_handlers ()
+  {
+    /* CBRD-26745: drain every query_handler before ws_final() destroys the
+       workspace heap. Each query_handler owns a DB_SESSION whose parser and
+       host_variables[] are allocated from ws_heap; if a handler outlives
+       ws_final(), its dtor's db_close_session_local() walks freed mspace
+       memory and aborts. Called via method_callback_final() from
+       boot_client_all_finalize() right before ws_final(). */
+
+    /* drain deferred queue */
+    for (auto it = m_deferred_query_free_handler.begin (); it != m_deferred_query_free_handler.end (); it++)
+      {
+	delete *it;
+      }
+    m_deferred_query_free_handler.clear ();
+
+    /* free live cached handlers */
+    for (size_t i = 0; i < m_query_handlers.size (); i++)
+      {
+	if (m_query_handlers[i] != nullptr)
+	  {
+	    delete m_query_handlers[i];
+	    m_query_handlers[i] = nullptr;
+	  }
+      }
+    m_query_handlers.clear ();
+
+    /* clear lookup maps that referenced the handler ids above */
+    m_sql_handler_map.clear ();
+    m_qid_handler_map.clear ();
+  }
+
   query_handler *
   callback_handler::get_query_handler_by_query_id (const uint64_t qid)
   {
@@ -1175,4 +1208,19 @@ exit:
   {
     return &handler;
   }
+}
+
+/*
+ * CBRD-26745: Invoked from boot_client_all_finalize() in
+ * boot_cl.c (before ws_final()). Drains the singleton callback_handler so
+ * no query_handler outlives the workspace heap.
+ */
+void
+method_callback_final (void)
+{
+  cubmethod::callback_handler *h = cubmethod::get_callback_handler ();
+  if (h != NULL)
+    {
+      h->clear_all_query_handlers ();
+    }
 }

--- a/src/method/method_callback.hpp
+++ b/src/method/method_callback.hpp
@@ -78,9 +78,6 @@ namespace cubmethod
 	return !m_deferred_query_free_handler.empty ();
       }
 
-      /* CBRD-26745: drop every query_handler and its DB_SESSION before the
-         workspace heap is torn down. Called from method_callback_final(),
-         which boot_client_all_finalize() invokes prior to ws_final(). */
       void clear_all_query_handlers ();
 
       /* find query handler */

--- a/src/method/method_callback.hpp
+++ b/src/method/method_callback.hpp
@@ -73,6 +73,15 @@ namespace cubmethod
       void free_query_handle (int id, bool is_free);
       void free_query_handle_all (bool is_free);
       void free_deferred_query_handler ();
+      bool has_deferred_query_handler () const
+      {
+	return !m_deferred_query_free_handler.empty ();
+      }
+
+      /* CBRD-26745: drop every query_handler and its DB_SESSION before the
+         workspace heap is torn down. Called from method_callback_final(),
+         which boot_client_all_finalize() invokes prior to ws_final(). */
+      void clear_all_query_handlers ();
 
       /* find query handler */
       query_handler *get_query_handler_by_id (const int id);
@@ -131,5 +140,8 @@ namespace cubmethod
   EXPORT_IMPORT callback_handler *get_callback_handler (void);
 
 } // namespace cubmethod
+
+// C declarations
+extern void method_callback_final (void);
 
 #endif // _METHOD_CALLBACK_HPP_

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -84,6 +84,7 @@
 #include "show_meta.h"
 #include "tz_support.h"
 #include "dbtype.h"
+#include "method_callback.hpp"
 #include "object_primitive.h"
 #include "connection_globals.h"
 #include "host_lookup.h"
@@ -1530,6 +1531,7 @@ boot_client_all_finalize (int final_level)
 	  tr_final ();
 	  au_final ();
 	  sm_final ();
+	  method_callback_final ();
 	  ws_final ();
 	  es_final ();
 	  tp_final ();


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26745

### Purpose

CAS crashes with mspace_free abort in db_close_session_local while walking parser->host_variables. Stack always ends at callback_handler::free_deferred_query_handler → ~query_handler → close_and_free_session.                                                           
                                                                                                                                                                                                                                                                             
net_client_request_method_callback (and _with_callback) only flush the process-wide callback_handler::m_deferred_query_free_handler on the normal loop exit path. The return set_server_error(...) early-returns on socket receive errors skip the flush, leaving a query_handler * with a freed DB_SESSION in the singleton queue. The next client request on the same CAS (even a plain SELECT 1) reaches the flush at end-of-RPC and deletes the stale handler → double free on host_variables payload → heaplayers abort.                  
                                                                                                                                                                                                                                                                             
 A second variant of the same root cause shows up at CAS shutdown: query_handler entries cached in m_query_handlers (and the deferred queue) outlive ws_final(), so their dtor's db_close_session_local() walks an already-destroyed workspace heap.

Triggers in the wild: cub_pl_server / cub_server restart or crash, HA failover, JDBC queryTimeout, Statement.cancel, TCP idle timeout on LB/NAT, container overlay flap, etc.    

### Implementation

RPC early-return path (src/communication/network_cl.c)
- Replace the single end-of-function flush in net_client_request_with_callback / net_client_request_method_callback with an RAII deferred_flush_guard declared at function entry. Its dtor runs callback_handler::free_deferred_query_handler() on every return path (socket  errors, allocation failures, normal exit) when !tran_is_in_libcas().

Fast-path guard (src/method/method_callback.{hpp,cpp})
- Add callback_handler::has_deferred_query_handler() so the RAII guard skips the libcas-depth check and the flush call when the deferred queue is empty (the common case).

CAS shutdown drain (src/method/method_callback.{hpp,cpp}, src/transaction/boot_cl.c)
- Add callback_handler::clear_all_query_handlers() which drains both m_deferred_query_free_handler and the live m_query_handlers cache (and clears m_sql_handler_map / m_qid_handler_map). Expose it via C wrapper method_callback_final() and call it from boot_client_all_finalize() immediately before ws_final(), so no query_handler outlives the workspace heap.                                                                                                                                                                 


### Remarks

A fault injection via env `CBRD26745_INJECT_EVERY=N` (not in this PR) forces the early-return path every N-th `pl_call`.:
  - Before fix: 8/8 CAS coredump, stack matches the ticket                                                                 
  - After fix: 0 coredump on the same workload