### PR TITLE
[CBRD-26686] Implement interface class for slot daemon.

### DIFF
--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -42,6 +42,7 @@ set (COMPAT_HEADERS
   )
 
 set(THREAD_SOURCES
+  ${THREAD_DIR}/concurrency_slot.cpp
   ${THREAD_DIR}/critical_section.c
   ${THREAD_DIR}/critical_section_tracker.cpp
   ${THREAD_DIR}/thread_daemon.cpp
@@ -55,6 +56,7 @@ set(THREAD_SOURCES
   ${THREAD_DIR}/thread_worker_pool_taskcap.cpp
   )
 set(THREAD_HEADERS
+  ${THREAD_DIR}/concurrency_slot.hpp
   ${THREAD_DIR}/critical_section_tracker.hpp
   ${THREAD_DIR}/thread_compat.hpp
   ${THREAD_DIR}/thread_daemon.hpp

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -562,6 +562,7 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
   cubconn::connection::pool connections;
   std::size_t task_group, task_worker;
   std::size_t max_connection_workers, min_connection_workers;
+  std::size_t max_connections;
   std::string name;
   int status = NO_ERROR;
 
@@ -571,15 +572,16 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
     }
   name = std::string (server_name, name_length);
 
-  // initialize worker pool for server requests
-#define MAX_WORKERS css_get_max_workers ()
-#define MAX_TASK_COUNT css_get_max_task_count ()
-#define MAX_CONNECTIONS css_get_max_connections ()
-
   task_group = (int) prm_get_integer_value (PRM_ID_TASK_GROUP);
   task_worker = (int) prm_get_integer_value (PRM_ID_TASK_WORKER);
+
   max_connection_workers = (int) prm_get_integer_value (PRM_ID_CSS_MAX_CONNECTION_WORKER);
   min_connection_workers = (int) prm_get_integer_value (PRM_ID_CSS_MIN_CONNECTION_WORKER);
+
+  max_connections = css_get_max_connections ();
+
+  // initialize the concurrency slot daemon
+  cubthread::concurrency_slot_daemon::initialize ();
 
   // create request worker pool
   //*INDENT-OFF*
@@ -603,7 +605,7 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
     }
 
   /* initialize epoll worker pool */
-  connections.initialize (MAX_CONNECTIONS, max_connection_workers, min_connection_workers);
+  connections.initialize (max_connections, max_connection_workers, min_connection_workers);
 
   /* attach thread entry */
   connector.attach (*thread_p);
@@ -624,6 +626,9 @@ shutdown:
   // stop threads; in first phase we need to stop active workers, but keep log writers for a while longer to make sure
   // all log is transfered
   css_stop_all_workers (*thread_p, THREAD_STOP_WORKERS_EXCEPT_LOGWR);
+
+  // finalize the concurrency slot daemon
+  cubthread::concurrency_slot_daemon::finalize ();
 
   /* stop vacuum threads. */
   vacuum_stop_workers (thread_p);

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -583,11 +583,14 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
 
   // create request worker pool
   //*INDENT-OFF*
-  css_Server_request_worker_pool =
-    thread_create_worker_pool<cubthread::stats_t::on, cubthread::pool_t::elastic> (task_worker, task_group, "transaction",
-							     thread_get_entry_manager (),
-							     css_get_server_request_thread_pooling_configuration (),
-							     css_get_server_request_thread_timeout_configuration ());
+  css_Server_request_worker_pool = thread_create_worker_pool<cubthread::stats_t::on, cubthread::pool_t::elastic> (
+      task_worker,
+      task_group,
+      "transaction",
+      thread_get_entry_manager (),
+      css_get_server_request_thread_pooling_configuration (),
+      css_get_server_request_thread_timeout_configuration ()
+      );
   //*INDENT-ON*
   // m_log = cubthread::is_logging_configured (cubthread::LOG_WORKER_POOL_TRAN_WORKERS)
 

--- a/src/thread/concurrency_slot.cpp
+++ b/src/thread/concurrency_slot.cpp
@@ -88,10 +88,6 @@ namespace cubthread
       {
 	assert_release (false);
       }
-
-    assert (!m_subscribers.empty ());
-
-    trigger (false);
   }
 
   void
@@ -111,8 +107,6 @@ namespace cubthread
 	      {
 		m_subscribers.erase (identifier);
 	      }
-
-	    trigger (m_subscribers.empty ());
 	    return;
 	  }
       }
@@ -240,11 +234,22 @@ namespace cubthread
   concurrency_slot_daemon::concurrency_slot_daemon ()
     : m_daemon (nullptr)
   {
-
   }
 
   concurrency_slot_daemon::~concurrency_slot_daemon ()
   {
+  }
+
+  void
+  concurrency_slot_daemon::initialize ()
+  {
+    get_instance ().create_daemon ();
+  }
+
+  void
+  concurrency_slot_daemon::finalize ()
+  {
+    get_instance ().destroy_daemon ();
   }
 
   concurrency_slot_publisher *
@@ -262,22 +267,12 @@ namespace cubthread
   }
 
   void
-  concurrency_slot_daemon::trigger (bool empty)
-  {
-    if (!empty && !m_daemon)
-      {
-	create_daemon ();
-      }
-    else if (empty && m_daemon)
-      {
-	destroy_daemon ();
-      }
-  }
-
-  void
   concurrency_slot_daemon::create_daemon ()
   {
-    assert (!m_daemon);
+    if (m_daemon)
+      {
+	return;
+      }
 
     looper loop = looper (std::chrono::milliseconds (1000));
     concurrency_slot_daemon_task *daemon_task = new concurrency_slot_daemon_task ();
@@ -288,7 +283,10 @@ namespace cubthread
   void
   concurrency_slot_daemon::destroy_daemon ()
   {
-    assert (m_daemon);
+    if (!m_daemon)
+      {
+	return;
+      }
 
     cubthread::get_manager ()->destroy_daemon (m_daemon);
   }

--- a/src/thread/concurrency_slot.cpp
+++ b/src/thread/concurrency_slot.cpp
@@ -1,0 +1,296 @@
+/*
+ *
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+/*
+ * concurrency_slot.cpp
+ */
+
+#include "concurrency_slot.hpp"
+#include "thread_manager.hpp"
+#include "boot_sr.h"
+#include "error_manager.h"
+
+// XXX: SHOULD BE THE LAST INCLUDE HEADER
+#include "memory_wrapper.hpp"
+
+namespace cubthread
+{
+  //////////////////////////////////////////////////////////////////////////
+  // concurrency_slot_subscriber
+  //////////////////////////////////////////////////////////////////////////
+
+  concurrency_slot_subscriber::concurrency_slot_subscriber (concurrency_slot_publisher *pub)
+    : m_publisher (pub)
+    , m_identifier (nullptr)
+  {
+  }
+
+  concurrency_slot_subscriber::~concurrency_slot_subscriber ()
+  {
+    deactivate ();
+  }
+
+  void
+  concurrency_slot_subscriber::activate (void *identifier)
+  {
+    m_identifier = identifier;
+    m_publisher->subscribe (identifier, this);
+  }
+
+  void
+  concurrency_slot_subscriber::deactivate ()
+  {
+    if (m_identifier)
+      {
+	m_publisher->unsubscribe (m_identifier, this);
+	m_identifier = nullptr;
+      }
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // concurrency_slot_publisher
+  //////////////////////////////////////////////////////////////////////////
+
+  concurrency_slot_publisher::concurrency_slot_publisher ()
+  {
+  }
+
+  concurrency_slot_publisher::~concurrency_slot_publisher ()
+  {
+  }
+
+  void
+  concurrency_slot_publisher::subscribe (void *identifier, concurrency_slot_subscriber *sub)
+  {
+    std::lock_guard<std::mutex> lock (m_mutex);
+
+    auto &subs = m_subscribers.emplace (identifier, std::vector<concurrency_slot_subscriber *> ()).first->second;
+    if (std::find (subs.begin (), subs.end (), sub) == subs.end ())
+      {
+	subs.push_back (sub);
+      }
+    else
+      {
+	assert_release (false);
+      }
+
+    assert (!m_subscribers.empty ());
+
+    trigger (false);
+  }
+
+  void
+  concurrency_slot_publisher::unsubscribe (void *identifier, concurrency_slot_subscriber *sub)
+  {
+    std::lock_guard<std::mutex> lock (m_mutex);
+
+    auto map_it = m_subscribers.find (identifier);
+    if (map_it != m_subscribers.end ())
+      {
+	auto &subs = map_it->second;
+	auto it = std::find (subs.begin (), subs.end (), sub);
+	if (it != subs.end ())
+	  {
+	    subs.erase (it);
+	    if (subs.empty ())
+	      {
+		m_subscribers.erase (identifier);
+	      }
+
+	    trigger (m_subscribers.empty ());
+	    return;
+	  }
+      }
+
+    assert_release (false);
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // concurrency_slot
+  //////////////////////////////////////////////////////////////////////////
+
+  concurrency_slot::concurrency_slot (concurrency_slot_pool *owner_pool)
+    : m_owner_pool (owner_pool)
+    , m_wait (false)
+    , m_wait_since ()
+  {
+  }
+
+  concurrency_slot::~concurrency_slot ()
+  {
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // concurrency_slot_pool
+  //////////////////////////////////////////////////////////////////////////
+
+  concurrency_slot_pool::concurrency_slot_pool ()
+    : concurrency_slot_subscriber (concurrency_slot_daemon::get_publisher ())
+    , m_available_slots ()
+    , m_surplus_since ()
+    , m_wait_queue ()
+    , m_mutex ()
+  {
+  }
+
+  concurrency_slot_pool::~concurrency_slot_pool ()
+  {
+  }
+
+  void
+  concurrency_slot_pool::initialize (void *identifier, std::size_t slot_count)
+  {
+    std::unique_lock<std::mutex> ulock (m_mutex);
+    std::size_t i;
+
+    for (i = 0; i < slot_count; i++)
+      {
+	m_available_slots.emplace (std::unique_ptr<concurrency_slot> (new concurrency_slot (this)));
+      }
+
+    ulock.unlock ();
+
+    // attach to the daemon
+    concurrency_slot_subscriber::activate (identifier);
+  }
+
+  std::unique_ptr<concurrency_slot>
+  concurrency_slot_pool::try_acquire_slot ()
+  {
+    std::lock_guard<std::mutex> lock (m_mutex);
+
+    if (m_available_slots.empty ())
+      {
+	return nullptr;
+      }
+
+    std::unique_ptr<concurrency_slot> slot = std::move (m_available_slots.front ());
+    m_available_slots.pop ();
+
+    return slot;
+  }
+
+  std::unique_ptr<concurrency_slot>
+  concurrency_slot_pool::acquire_slot ()
+  {
+    return nullptr;
+  }
+
+  void
+  concurrency_slot_pool::release_slot (std::unique_ptr<concurrency_slot> slot)
+  {
+    if (slot == nullptr)
+      {
+	return;
+      }
+
+    std::lock_guard<std::mutex> lock (m_mutex);
+
+    m_available_slots.emplace (std::move (slot));
+  }
+
+  bool
+  concurrency_slot_pool::borrow_surplus_slots ()
+  {
+    return false;
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  // concurrency_slot_daemon task
+  //////////////////////////////////////////////////////////////////////////
+
+  class concurrency_slot_daemon_task : public entry_task
+  {
+    public:
+      concurrency_slot_daemon_task () = default;
+      ~concurrency_slot_daemon_task () = default;
+
+      void execute (entry &thread_ref) override
+      {
+	// 1. traverse all entries and steal the concurrency slot from any entry
+	//    whose wait time exceeds the threshold. (identifier = worker pool pointer)
+	// 2. rebalance slots across cores.
+	// 3. apply concurrency parameter changes at runtime.
+
+	// add here
+      }
+  };
+
+  //////////////////////////////////////////////////////////////////////////
+  // concurrency_slot_daemon
+  //////////////////////////////////////////////////////////////////////////
+
+  REGISTER_DAEMON (concurrency_slot_daemon);
+
+  concurrency_slot_daemon::concurrency_slot_daemon ()
+    : m_daemon (nullptr)
+  {
+
+  }
+
+  concurrency_slot_daemon::~concurrency_slot_daemon ()
+  {
+  }
+
+  concurrency_slot_publisher *
+  concurrency_slot_daemon::get_publisher ()
+  {
+    return &get_instance ();
+  }
+
+  concurrency_slot_daemon &
+  concurrency_slot_daemon::get_instance ()
+  {
+    static concurrency_slot_daemon daemon;
+
+    return daemon;
+  }
+
+  void
+  concurrency_slot_daemon::trigger (bool empty)
+  {
+    if (!empty && !m_daemon)
+      {
+	create_daemon ();
+      }
+    else if (empty && m_daemon)
+      {
+	destroy_daemon ();
+      }
+  }
+
+  void
+  concurrency_slot_daemon::create_daemon ()
+  {
+    assert (!m_daemon);
+
+    looper loop = looper (std::chrono::milliseconds (1000));
+    concurrency_slot_daemon_task *daemon_task = new concurrency_slot_daemon_task ();
+
+    m_daemon = cubthread::get_manager ()->create_daemon (loop, daemon_task, "concurrency");
+  }
+
+  void
+  concurrency_slot_daemon::destroy_daemon ()
+  {
+    assert (m_daemon);
+
+    cubthread::get_manager ()->destroy_daemon (m_daemon);
+  }
+
+} // namespace cubthread

--- a/src/thread/concurrency_slot.hpp
+++ b/src/thread/concurrency_slot.hpp
@@ -1,0 +1,156 @@
+/*
+ *
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+/*
+ * concurrency_slot.hpp
+ */
+
+#ifndef _CONCURRENCY_SLOT_HPP_
+#define _CONCURRENCY_SLOT_HPP_
+
+#include "thread_entry.hpp"
+#include "thread_daemon.hpp"
+
+#include <map>
+#include <chrono>
+#include <vector>
+#include <list>
+#include <queue>
+#include <memory>
+#include <mutex>
+
+namespace cubthread
+{
+  // concurrency_slot_subscriber, concurrency_slot_publisher
+  //
+  // description
+  //    a subscriber automatically registers itself with the publisher's
+  //    subscriber list when activated, so that the publisher can iterate
+  //    over all active subscribers.
+  //
+  class concurrency_slot_publisher;
+
+  class concurrency_slot_subscriber
+  {
+    public:
+      concurrency_slot_subscriber (concurrency_slot_publisher *pub);
+      ~concurrency_slot_subscriber ();
+
+      void activate (void *identifier);
+      void deactivate ();
+
+    private:
+      concurrency_slot_publisher *m_publisher;
+      void *m_identifier;
+  };
+
+  class concurrency_slot_publisher
+  {
+      friend class concurrency_slot_subscriber;
+
+    protected:
+      concurrency_slot_publisher ();
+      ~concurrency_slot_publisher ();
+
+      virtual void trigger (bool empty) = 0;
+
+    private:
+      void subscribe (void *identifier, concurrency_slot_subscriber *sub);
+      void unsubscribe (void *identifier, concurrency_slot_subscriber *sub);
+
+      std::map<void *, std::vector<concurrency_slot_subscriber *>> m_subscribers;
+      std::mutex m_mutex;
+  };
+
+  // concurrency_slot, concurrency_slot_pool
+  //
+  // description
+  //    manages concurrency slots.
+  //
+  class concurrency_slot_pool;
+
+  class concurrency_slot
+  {
+      friend class concurrency_slot_pool;
+
+    public:
+      ~concurrency_slot ();
+
+    private:
+      concurrency_slot (concurrency_slot_pool *owner_pool);
+
+      concurrency_slot_pool *const m_owner_pool;
+
+      bool m_wait; // soft wait
+      std::chrono::time_point<std::chrono::steady_clock> m_wait_since;
+  };
+
+  class concurrency_slot_pool : public concurrency_slot_subscriber
+  {
+    public:
+      concurrency_slot_pool ();
+      ~concurrency_slot_pool ();
+
+      virtual void initialize (void *identifier, std::size_t concurrency);
+
+      // for worker
+      std::unique_ptr<concurrency_slot> try_acquire_slot ();
+      std::unique_ptr<concurrency_slot> acquire_slot ();
+
+      void release_slot (std::unique_ptr<concurrency_slot> slot);
+
+      // called by the daemon to borrow surplus slots in batches of SLOT_SURPLUS_THRESHOLD.
+      bool borrow_surplus_slots ();
+
+    private:
+      static constexpr std::size_t SLOT_SURPLUS_THRESHOLD = 2;
+
+      std::queue<std::unique_ptr<concurrency_slot>> m_available_slots;
+      std::chrono::time_point<std::chrono::steady_clock> m_surplus_since;
+
+      std::list<entry *> m_wait_queue; // list of entries waiting to acquire a slot
+
+      std::mutex m_mutex; // guard for m_available_slots, m_surplus_since and m_wait_queue
+  };
+
+  // concurrency_slot_daemon
+  //
+  // description
+  //    rebalances concurrency slots across pools
+  //
+  class concurrency_slot_daemon : public concurrency_slot_publisher
+  {
+    public:
+      static concurrency_slot_publisher *get_publisher ();
+
+    private:
+      concurrency_slot_daemon ();
+      ~concurrency_slot_daemon ();
+
+      static concurrency_slot_daemon &get_instance ();
+
+      void trigger (bool empty) override;
+
+      void create_daemon ();
+      void destroy_daemon ();
+
+      daemon *m_daemon;
+  };
+}
+
+#endif

--- a/src/thread/concurrency_slot.hpp
+++ b/src/thread/concurrency_slot.hpp
@@ -67,8 +67,6 @@ namespace cubthread
       concurrency_slot_publisher ();
       ~concurrency_slot_publisher ();
 
-      virtual void trigger (bool empty) = 0;
-
     private:
       void subscribe (void *identifier, concurrency_slot_subscriber *sub);
       void unsubscribe (void *identifier, concurrency_slot_subscriber *sub);
@@ -136,6 +134,9 @@ namespace cubthread
   class concurrency_slot_daemon : public concurrency_slot_publisher
   {
     public:
+      static void initialize ();
+      static void finalize ();
+
       static concurrency_slot_publisher *get_publisher ();
 
     private:
@@ -143,8 +144,6 @@ namespace cubthread
       ~concurrency_slot_daemon ();
 
       static concurrency_slot_daemon &get_instance ();
-
-      void trigger (bool empty) override;
 
       void create_daemon ();
       void destroy_daemon ();

--- a/src/thread/concurrency_slot.hpp
+++ b/src/thread/concurrency_slot.hpp
@@ -56,7 +56,7 @@ namespace cubthread
 
     private:
       concurrency_slot_publisher *m_publisher;
-      void *m_identifier;
+      void *m_identifier; // currently used only as a worker_pool type
   };
 
   class concurrency_slot_publisher

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -90,6 +90,9 @@ namespace cubthread
     , wakeup_cond ()
     , private_heap_id (0)
     , conn_entry (NULL)
+#if defined (SERVER_MODE)
+    , slot (nullptr)
+#endif
     , xasl_unpack_info_ptr (NULL)
     , xasl_errcode (0)
     , xasl_recursion_depth (0)

--- a/src/thread/thread_entry.hpp
+++ b/src/thread/thread_entry.hpp
@@ -32,6 +32,7 @@
 #include "porting.h"        // for pthread_mutex_t, drand48_data
 #include "system.h"         // for UINTPTR, INT64, HL_HEAPID
 
+#include <memory>
 #include <atomic>
 #include <thread>
 
@@ -39,6 +40,11 @@
 
 // forward definitions
 
+// from concurrency_slot.hpp
+namespace cubthread
+{
+  class concurrency_slot;
+};
 // from connection_defs.h
 struct css_conn_entry;
 // from connection_defs.h
@@ -230,6 +236,11 @@ namespace cubthread
       HL_HEAPID private_heap_id;	/* id of thread private memory allocator */
 
       css_conn_entry *conn_entry;	/* conn entry ptr */
+
+#if defined (SERVER_MODE)
+      /* concurrency slot held by this entry; only set for workers from an elastic worker pool */
+      std::unique_ptr<cubthread::concurrency_slot> slot;
+#endif
 
       xasl_unpack_info *xasl_unpack_info_ptr;     /* XASL_UNPACK_INFO * */
       int xasl_errcode;		/* xasl errorcode */

--- a/src/thread/thread_manager.hpp
+++ b/src/thread/thread_manager.hpp
@@ -417,7 +417,7 @@ namespace cubthread
   {
     check_not_single_thread ();
 
-    std::lock_guard<std::mutex> lock (m_entries_mutex);
+    std::unique_lock<std::mutex> ulock (m_entries_mutex);
 
     if (m_available_entries_count < entries_count)
       {
@@ -425,7 +425,12 @@ namespace cubthread
       }
     m_available_entries_count -= entries_count;
 
+    ulock.unlock ();
+
+    // this doesn't need to hold the lock
     Res *new_res = new Res (std::forward<CtArgs> (args)...);
+
+    ulock.lock ();
 
     tracker.push_back (new_res);
 
@@ -438,7 +443,7 @@ namespace cubthread
   {
     check_not_single_thread ();
 
-    std::lock_guard<std::mutex> lock (m_entries_mutex);
+    std::unique_lock<std::mutex> ulock (m_entries_mutex);
 
     for (auto iter = tracker.begin (); iter != tracker.end (); ++iter)
       {
@@ -447,10 +452,14 @@ namespace cubthread
 	    // remove resource from tracker
 	    (void) tracker.erase (iter);
 
+	    ulock.unlock ();
+
 	    // stop resource and delete
 	    res->stop_execution ();
 	    delete res;
 	    res = NULL;
+
+	    ulock.lock ();
 
 	    // update available entries
 	    m_available_entries_count += entries_count;
@@ -507,8 +516,11 @@ template <cubthread::stats_t Stats = cubthread::stats_t::off, cubthread::pool_t 
 using worker_pool_type = cubthread::worker_pool;
 #endif
 
-template <cubthread::stats_t Stats = cubthread::stats_t::off, cubthread::pool_t Type = cubthread::pool_t::basic,
-	  typename ... Args>
+template <
+	cubthread::stats_t Stats = cubthread::stats_t::off,
+	cubthread::pool_t Type = cubthread::pool_t::basic,
+	typename ... Args
+	>
 worker_pool_type<Stats, Type> *
 thread_create_worker_pool (Args &&... args)
 {

--- a/src/thread/thread_worker_pool_elastic.hpp
+++ b/src/thread/thread_worker_pool_elastic.hpp
@@ -28,6 +28,8 @@
 #endif // not SERVER_MODE
 
 // same module include
+#include "concurrency_slot.hpp"
+#include "thread_daemon.hpp"
 #include "thread_worker_pool_impl.hpp"
 
 // cubrid includes
@@ -36,7 +38,7 @@
 // system includes
 #include <chrono>
 #include <memory>
-#include <queue>
+#include <algorithm>
 
 namespace cubthread
 {
@@ -56,9 +58,6 @@ namespace cubthread
     public:
       // forward definition
       class core_elastic;
-
-      class slot;
-      class slot_pool;
 
       ~worker_pool_elastic ();
 
@@ -87,70 +86,7 @@ namespace cubthread
     private:
       core_elastic (bool pool_threads);
 
-      slot_pool m_slot_pool;
-  };
-
-  // worker_pool_elastic<Stats>::slot
-  //
-  // description
-  //	slot required by a worker before it can run a task.
-  //
-  template <stats_t Stats>
-  class worker_pool_elastic<Stats>::slot
-  {
-      friend class slot_pool;
-
-    public:
-      ~slot ();
-
-      void set_owner_pool (slot_pool *owner_pool);
-
-    private:
-      slot ();
-
-      slot_pool *m_owner_pool;
-  };
-
-  // worker_pool_elastic<Stats>::slot_pool
-  //
-  // description
-  //    manages available concurrency slots
-  //
-  template <stats_t Stats>
-  class worker_pool_elastic<Stats>::slot_pool
-  {
-      friend class core_elastic;
-
-    public:
-      ~slot_pool ();
-
-      void initialize (std::size_t slot_count);
-
-      // for worker
-      std::unique_ptr<slot> try_acquire_slot ();
-      std::unique_ptr<slot> acquire_slot ();
-
-      void release_slot (std::unique_ptr<slot> uslot);
-
-      // called by the daemon to borrow surplus slots in batches of SLOT_SURPLUS_THRESHOLD.
-      bool borrow_surplus_slots ();
-
-      // information
-      void set_parent_core (core_elastic *parent_core);
-
-    private:
-      slot_pool ();
-
-      static constexpr std::size_t SLOT_SURPLUS_THRESHOLD = 2;
-
-      core_elastic *m_parent_core;
-
-      std::queue<std::unique_ptr<slot>> m_available_slots;
-      std::chrono::time_point<std::chrono::steady_clock> m_surplus_since;
-
-      std::queue<entry *> m_wait_queue; // wait entry list to acquire a slot
-
-      std::mutex m_mutex; // guard for m_available_slots, m_surplus_since and m_wait_queue
+      concurrency_slot_pool m_slots;
   };
 
 } // namespace cubthread
@@ -199,103 +135,9 @@ namespace cubthread
   void
   worker_pool_elastic<Stats>::core_elastic::initialize (std::size_t concurrency)
   {
-    assert (concurrency > 0);
+    worker_pool_impl<Stats>::core_impl::initialize (concurrency);
 
-    // resources reserve
-    this->m_available_workers.reserve (concurrency);
-
-    // workers
-    this->allocate_workers (concurrency);
-    this->initialize_workers ();
-
-    // slot
-    m_slot_pool.set_parent_core (this);
-    m_slot_pool.initialize (concurrency);
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // worker_pool_elastic<Stats>::slot
-  //////////////////////////////////////////////////////////////////////////
-
-  template <stats_t Stats>
-  worker_pool_elastic<Stats>::slot::slot ()
-    : m_owner_pool (nullptr)
-  {
-  }
-
-  template <stats_t Stats>
-  worker_pool_elastic<Stats>::slot::~slot ()
-  {
-  }
-
-  template <stats_t Stats>
-  void
-  worker_pool_elastic<Stats>::slot::set_owner_pool (slot_pool *owner_pool)
-  {
-    m_owner_pool = owner_pool;
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // worker_pool_elastic<Stats>::slot_pool
-  //////////////////////////////////////////////////////////////////////////
-
-  template <stats_t Stats>
-  worker_pool_elastic<Stats>::slot_pool::slot_pool ()
-    : m_parent_core (nullptr)
-  {
-  }
-
-  template <stats_t Stats>
-  worker_pool_elastic<Stats>::slot_pool::~slot_pool ()
-  {
-  }
-
-  template <stats_t Stats>
-  void
-  worker_pool_elastic<Stats>::slot_pool::initialize (std::size_t slot_count)
-  {
-    std::lock_guard<std::mutex> lock (m_mutex);
-    std::size_t i;
-
-    for (i = 0; i < slot_count; i++)
-      {
-	m_available_slots.emplace (std::unique_ptr<slot> (new slot ()));
-	m_available_slots.back ()->set_owner_pool (this);
-      }
-  }
-
-  template <stats_t Stats>
-  std::unique_ptr<typename worker_pool_elastic<Stats>::slot>
-  worker_pool_elastic<Stats>::slot_pool::try_acquire_slot ()
-  {
-    return nullptr;
-  }
-
-  template <stats_t Stats>
-  std::unique_ptr<typename worker_pool_elastic<Stats>::slot>
-  worker_pool_elastic<Stats>::slot_pool::acquire_slot ()
-  {
-    return nullptr;
-  }
-
-  template <stats_t Stats>
-  void
-  worker_pool_elastic<Stats>::slot_pool::release_slot (std::unique_ptr<slot> uslot)
-  {
-  }
-
-  template <stats_t Stats>
-  bool
-  worker_pool_elastic<Stats>::slot_pool::borrow_surplus_slots ()
-  {
-    return true;
-  }
-
-  template <stats_t Stats>
-  void
-  worker_pool_elastic<Stats>::slot_pool::set_parent_core (core_elastic *parent_core)
-  {
-    m_parent_core = parent_core;
+    m_slots.initialize (static_cast<void *> (this->m_parent_pool), concurrency);
   }
 
 } // namespace cubthread


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26686>

### Purpose

동시성을 조율하는 concurrency slot daemon을 인터페이스 수준으로 구현합니다.

base가 되는 concurrency_slot_subscriber와 concurrency_slot_publisher로 구성되어 있으며 아래처럼 상속됩니다.
pool이 여러 개인 상황을 고려하여 작성되었습니다.

```
concurrency_slot_pool : concurrency_slot_subscriber
concurrency_slot_daemon : concurrency_slot_publisher
```

### Implementation

인터페이스 수준이므로 base class에 대한 구현과 class 간 연결 수준만 존재합니다.

### Remarks

아직 기존 transaction worker pool과 동작 자체는 다르지 않습니다.
Thread 개수가 바뀌어 CI가 실패합니다.
