### PR TITLE
[CBRD-26698] (change build option) bug-fix: correct length when handling shard keys

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,12 +215,12 @@ if(UNIX)
     endif(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.4.7)
 
     # C flags for both debug and release build
-    set(CMAKE_C_COMMON_FLAGS "-ggdb -fno-omit-frame-pointer -fstack-protector-strong")
+    set(CMAKE_C_COMMON_FLAGS "-ggdb -fno-omit-frame-pointer")
     # C++ flags for both debug and release build
     set(CMAKE_CXX_COMMON_FLAGS "${CMAKE_C_COMMON_FLAGS} -std=c++17")
 
     # C flags for debug build
-    set(CMAKE_C_DEBUG_FLAGS "-ggdb3 -Wall -fno-inline ${CMAKE_C_COMMON_FLAGS}")
+    set(CMAKE_C_DEBUG_FLAGS "-ggdb3 -Wall -fno-inline -fstack-protector-strong ${CMAKE_C_COMMON_FLAGS}")
     # C++ flags for debug build
     set(CMAKE_CXX_DEBUG_FLAGS "-ggdb3 -Wall -fno-inline ${CMAKE_CXX_COMMON_FLAGS}")
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26698>

### Purpose

빌드 옵션 -fstack-protector-strong을 debug 모드에만 적용

### Implementation

CMakeLists.txt 파일에  -fstack-protector-strong을 반영

### Remarks

-fstack-protector-strong 옵션이 성능에 영향이 거의 없으나 매우 짧은 함수가 엄청 자주 호출되는 경우 (hot path) 성능 저하가 미세하게 발생할 가능성이 있어, 옵션을 디버그 모드에만 한정함.
