### PR TITLE
[CBRD-26749] (11.0 Patch 16) NUMERIC coercion 시 invalid format 문자열 리터럴이 에러 없이 잘못된 값으로 저장되는 문제

### DIFF
--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -12989,7 +12989,7 @@ pt_check_group_by (PARSER_CONTEXT * parser, PT_NODE * node)
     }
 
   /* do not allow GROUP BY ... WITH ROLLUP and GROUPBY_NUM () */
-  if (node->info.query.q.select.group_by != NULL && node->info.query.q.select.group_by->flag.with_rollup)
+  if (node->info.query.q.select.group_by != NULL && node->info.query.q.select.group_by->with_rollup)
     {
       bool has_gbynum = false;
       (void) parser_walk_tree (parser, node->info.query.q.select.having, pt_check_groupbynum_pre, NULL,

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -20098,7 +20098,7 @@ pt_fold_const_function (PARSER_CONTEXT * parser, PT_NODE * func)
 	  func_arg = func->info.function.arg_list;
 	  memset (&(func->info), 0, sizeof (func->info));
 	  func->info.value.data_value.set = func_arg;
-	  func->type_enum == PT_TYPE_SEQUENCE;
+	  func->type_enum = PT_TYPE_SEQUENCE;
 	}
     }
 

--- a/src/query/numeric_opfunc.c
+++ b/src/query/numeric_opfunc.c
@@ -3088,9 +3088,9 @@ numeric_coerce_string_to_num (const char *astring, int astring_length, INTL_CODE
       skip_size = 1;
       if (astring[i] == '.')
 	{
-	  if (decimal_part)
+	  if (decimal_part || trailing_spaces)
 	    {
-	      /* reject strings with more than one decimal point */
+	      /* reject duplicate decimal points and decimal points after trailing spaces (e.g. '1   .') */
 	      ret = DOMAIN_INCOMPATIBLE;
 	      break;
 	    }
@@ -3111,17 +3111,18 @@ numeric_coerce_string_to_num (const char *astring, int astring_length, INTL_CODE
 	    }
 	  else if (astring[i] == '+' || astring[i] == '-')
 	    {			/* sign found */
-	      if (!sign_found)
+	      /* Sign is only allowed before any digit (rejects duplicates and signs after a leading zero, e.g. '0-1') */
+	      if (sign_found || pad_character_zero)
+		{
+		  ret = DOMAIN_INCOMPATIBLE;
+		}
+	      else
 		{
 		  sign_found = true;
 		  if (astring[i] == '-')
 		    {
 		      negate_value = true;
 		    }
-		}
-	      else
-		{		/* Duplicate sign characters */
-		  ret = DOMAIN_INCOMPATIBLE;
 		}
 	    }
 	  else if (astring[i] == '0')
@@ -3131,8 +3132,18 @@ numeric_coerce_string_to_num (const char *astring, int astring_length, INTL_CODE
 	    }
 	  else if (intl_is_space (astring + i, NULL, codeset, &skip_size))
 	    {
-	      /* Just skip this.  OK to have leading spaces */
-	      ;
+	      /* A space after a sign without any digit is invalid (e.g. '-   1'). */
+	      if (sign_found && !pad_character_zero)
+		{
+		  ret = DOMAIN_INCOMPATIBLE;
+		  break;
+		}
+	      /* A space after a leading zero ends the leading phase (e.g. '0   1' is invalid). */
+	      if (pad_character_zero)
+		{
+		  leading_zeroes = false;
+		  trailing_spaces = true;
+		}
 	    }
 	  else
 	    {

--- a/src/query/numeric_opfunc.c
+++ b/src/query/numeric_opfunc.c
@@ -3088,6 +3088,12 @@ numeric_coerce_string_to_num (const char *astring, int astring_length, INTL_CODE
       skip_size = 1;
       if (astring[i] == '.')
 	{
+	  if (decimal_part)
+	    {
+	      /* reject strings with more than one decimal point */
+	      ret = DOMAIN_INCOMPATIBLE;
+	      break;
+	    }
 	  leading_zeroes = false;
 	  decimal_part = true;
 	  scale = astring_length - (i + 1);
@@ -3193,12 +3199,30 @@ numeric_coerce_string_to_num (const char *astring, int astring_length, INTL_CODE
       goto exit_on_error;
     }
 
-  if (prec == 0 && pad_character_zero)
+  if (prec == 0)
     {
-      prec = 1;
-      num_string[0] = '0';
-      num_string[prec] = '\0';
-      numeric_coerce_dec_str_to_num (num_string, num);
+      if (pad_character_zero)
+	{
+	  prec = 1;
+	  num_string[0] = '0';
+	  num_string[prec] = '\0';
+	  numeric_coerce_dec_str_to_num (num_string, num);
+	}
+      else
+	{
+	  /*
+	   * no valid digit was found in input.
+	   * reject strings that do not contain any numeric digit.
+	   *
+	   * examples:
+	   *   '+', '-'                  (sign only)
+	   *   '.', ' . ', '   .   '     (decimal point only)
+	   *   ' ', '    '               (whitespace only)
+	   *   '+.', '-.', ' + . '       (sign + non-digit combinations)
+	   */
+	  ret = DOMAIN_INCOMPATIBLE;
+	  goto exit_on_error;
+	}
     }
   else
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26749

### Purpose
- NUMERIC 타입으로 변환(coercion) 시, 잘못된 형식의 문자열 리터럴에 대해 에러가 발생하지 않고 의도하지 않은 값으로 변환되어 저장되는 문제가 있음.
- 특히 다음과 같은 케이스에서 validation이 일관되게 적용되지 않음:
    - 소수점이 2개 이상 포함된 경우 (예: `'1.2.3'`, `'1....'`)
    - 숫자 digit이 없는 경우 (예: `'+'`, `'-'`, `'.'`, `' '`, `''`)
    - 숫자 이후 공백 뒤에 다시 숫자/소수점이 오는 경우 (예: `'1  2'`, `'1  .2'`, `'1   .'`)
    - sign 뒤에 공백이 오는 경우 (예: `'-     1'`, `'+          1'`)
    - leading zero 뒤에 공백/sign이 오고 다시 digit이 오는 경우 (예: `'0  1'`, `'0 0 0 1'`, `'0-1'`, `'0+1'`)
- NUMERIC 변환 시 invalid format은 반드시 에러를 반환해야 하며, 상수 리터럴과 문자열 리터럴 간의 동작은 일관되어야 한다.
- 본 PR은 invalid numeric format에 대한 validation 누락을 보완하는 것을 목적으로 한다.

### Implementation
- `numeric_coerce_string_to_num()` 함수의 numeric parsing validation을 다음과 같이 강화했습니다.
    -  **소수점 중복 검사 보완** 
        - `.`이 두 번 이상 등장하면 `DOMAIN_INCOMPATIBLE` 반환
        - trailing 공백 이후 등장하는 `.`도 거부 (예: `'1   .'`, `'1.5  .'`)
    - **digit 존재 여부 검증 추가**
        - 숫자 digit이 하나도 없으면 에러 처리 (단, 연속된 zero-padding은 예외)
    - **sign 위치 검증 강화**
        - sign 뒤에 공백이 곧바로 오는 경우 거부 (예: `'-     1'`)
        - 단, sign 뒤 leading zero가 먼저 등장한 경우의 공백은 trailing 공백으로 간주 (예: `'-0   '` → 정상)
        - leading zero 이후 등장하는 sign 거부 (예: `'0-1'`, `'0+1'`)
    - **leading zero를 digit으로 취급**
        - leading zero 뒤 공백이 오면 leading 단계를 종료하고 trailing 상태로 전환
        - 따라서 `'0  1'`, `'0 0 0 1'`처럼 zero 이후 공백+digit은 거부됨
        - 기존의 trailing space 이후 문자 제한 로직은 유지됨

### Remarks
- 숫자 리터럴(예: `1.2.3`)은 파서 단계에서 syntax error로 처리되지만, 문자열 리터럴(예: `'1.2.3'`)은 coercion 단계에서 처리되므로 별도의 validation이 필요함.
- 다음 케이스는 기존 동작을 유지함
```
case1) `'1.'`, `'123.'`, `'1.   '`, `'   1.'` → 유효한 numeric으로 처리 (digit 직후 `.`은 허용)
case2) `'   -123'`, `'-1       '`, `'        +1'` → leading/trailing 공백 허용
case3) `'0001'`, `'-0001'` → 연속된 zero-padding 허용
```
- `''`(empty string)과 공백스트링(`'   '`)은 기본적으로 에러 처리되며, `''`의 경우 `oracle_style_empty_string = yes` 설정 시 NULL로 처리됨.