### PR TITLE
[CBRD-26109] fix coredump that could occur when cas receives sigterm and clears.

### DIFF
--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -1486,6 +1486,15 @@ boot_server_die_or_changed (void)
 void
 boot_client_all_finalize (int final_level)
 {
+  void (*sigterm_handler) (int);
+  void (*sigabrt_handler) (int);
+  void (*sigint_handler) (int);
+
+  /* to prevent duplicate calls by signal handlers during execution of the function. */
+  sigterm_handler = signal (SIGTERM, SIG_IGN);
+  sigabrt_handler = signal (SIGABRT, SIG_IGN);
+  sigint_handler = signal (SIGINT, SIG_IGN);
+
   if (BOOT_IS_CLIENT_RESTARTED () || boot_Is_client_all_final == false)
     {
       if (boot_Server_credential.db_full_name)
@@ -1554,6 +1563,11 @@ boot_client_all_finalize (int final_level)
 
       boot_client (NULL_TRAN_INDEX, TRAN_LOCK_INFINITE_WAIT, TRAN_DEFAULT_ISOLATION_LEVEL ());
       boot_Is_client_all_final = true;
+
+      /* restore the signals that was blocked, when the function started. */
+      signal (SIGTERM, sigterm_handler);
+      signal (SIGABRT, sigabrt_handler);
+      signal (SIGINT, sigint_handler);
     }
 }
 

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -92,6 +92,8 @@
 
 #include "authenticate_context.hpp"
 
+#include <signal.h>
+
 #if defined(CS_MODE)
 #include "network.h"
 #include "connection_cl.h"

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -1566,11 +1566,12 @@ boot_client_all_finalize (int final_level)
       boot_client (NULL_TRAN_INDEX, TRAN_LOCK_INFINITE_WAIT, TRAN_DEFAULT_ISOLATION_LEVEL ());
       boot_Is_client_all_final = true;
 
-      /* restore the signals that was blocked, when the function started. */
-      signal (SIGTERM, sigterm_handler);
-      signal (SIGABRT, sigabrt_handler);
-      signal (SIGINT, sigint_handler);
     }
+
+    /* restore the signals that was blocked, when the function started. */
+    signal (SIGTERM, sigterm_handler);
+    signal (SIGABRT, sigabrt_handler);
+    signal (SIGINT, sigint_handler);
 }
 
 #if defined(CS_MODE)

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -1568,10 +1568,10 @@ boot_client_all_finalize (int final_level)
 
     }
 
-    /* restore the signals that was blocked, when the function started. */
-    signal (SIGTERM, sigterm_handler);
-    signal (SIGABRT, sigabrt_handler);
-    signal (SIGINT, sigint_handler);
+  /* restore the signals that was blocked, when the function started. */
+  signal (SIGTERM, sigterm_handler);
+  signal (SIGABRT, sigabrt_handler);
+  signal (SIGINT, sigint_handler);
 }
 
 #if defined(CS_MODE)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26109

backport from #6246 #6255 
