### PR TITLE
[CBRD-26618] Reconstruct OOS column values for HA sql.log

### DIFF
--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -450,10 +450,32 @@ static LA_OOS_SQL_LOG_CACHE_ENTRY *la_Oos_sql_log_cache_tail = NULL;
  * remains the canonical owner of entries (used for ordered teardown in
  * la_clear_oos_sql_log_cache()).  The hash maps chunk_oid -> latest cached
  * entry, turning chain reassembly from O(N^2) to O(N) for OOS columns whose
- * value spans many physical chunks (e.g. several MB strings).  Lazily
- * allocated on first cache insert; freed/recreated on cache clear. */
-#define LA_OOS_SQL_LOG_CACHE_HASH_SIZE 257
+ * value spans many physical chunks (e.g. several MB strings).
+ *
+ * Lazily allocated on first cache insert; cleared (not destroyed) on
+ * transaction boundaries so the bucket array survives across transactions.
+ *
+ * Bucket count: ~1024.  Sized to keep the chain length below ~8 even for
+ * heavy workloads in the order of ~8K chunks (e.g. ~32MB OOS column with the
+ * smallest legal chunk payload).  Smaller workloads pay only the bucket
+ * array cost (one MHT_TABLE allocation, ~8KB on a 64-bit platform). */
+#define LA_OOS_SQL_LOG_CACHE_HASH_SIZE 1024
 static MHT_TABLE *la_Oos_sql_log_cache_hash = NULL;
+
+/* Lower bound on a single OOS chunk's payload size.  Used purely as a
+ * defensive divisor when bounding the iteration count of the chunk-chain
+ * walker — real chunks are page-size (KB) based, so 256 bytes is a
+ * conservative pathological floor. */
+#define LA_OOS_MIN_CHUNK_PAYLOAD       256
+/* Slack on top of (total_data_length / LA_OOS_MIN_CHUNK_PAYLOAD) to absorb
+ * head/tail rounding and never trip on a legitimate chain. */
+#define LA_OOS_RESOLVE_ITERATION_SLACK 16
+
+/* Sentinel embedded at the head of synthetic placeholders so an operator
+ * inspecting sql.log can immediately tell that the value was synthesized
+ * (cache miss) rather than the master's real payload.  Contains no SQL meta
+ * characters so it is safe inside a quoted varchar literal. */
+#define LA_OOS_MISSING_MARKER          "<<OOS_CHUNK_MISSING>>"
 
 /* Tranid currently being processed by la_apply_repl_log; scopes OOS sql.log
  * cache lookups to the current transaction so that a stale entry surviving
@@ -540,6 +562,7 @@ static int la_set_repl_log (LOG_PAGE * log_pgptr, int log_type, int tranid, LOG_
 static int la_add_node_into_la_commit_list (int tranid, LOG_LSA * lsa, int type, time_t eot_time);
 static time_t la_retrieve_eot_time (LOG_PAGE * pgptr, LOG_LSA * lsa);
 static int la_get_raw_offset_internal (OR_BUF * buf, int *error, int offset_size);
+static int la_register_new_oos_sql_log_cache_entry (LA_OOS_SQL_LOG_CACHE_ENTRY * entry);
 static int la_cache_oos_sql_log_recdes (LA_ITEM * item, LOG_PAGE * pgptr, RECDES * recdes);
 static int la_resolve_oos_sql_log_recdes (const OID * head_oid, int total_data_length, RECDES * recdes);
 static void la_clear_oos_sql_log_cache (void);
@@ -3723,55 +3746,58 @@ la_get_oos_sql_log_chunk_oid (LA_ITEM * item, LOG_PAGE * pgptr, OID * chunk_oid)
       return NO_ERROR;
     }
 
+  /* Two-pass over lrec->type: first pick the on-disk record size so we can
+   * advance/spill a single page boundary, then re-cast and grab the embedded
+   * LOG_DATA pointer.  Splitting the switch keeps the fit-check and error
+   * handling unduplicated. */
   switch (lrec->type)
     {
     case LOG_UNDOREDO_DATA:
     case LOG_DIFF_UNDOREDO_DATA:
       log_size = DB_SIZEOF (LOG_REC_UNDOREDO);
-      LA_LOG_READ_ADVANCE_WHEN_DOESNT_FIT (error, log_size, offset, pageid, pg);
-      if (error != NO_ERROR)
-	{
-	  return NO_ERROR;
-	}
-      logdata = &((LOG_REC_UNDOREDO *) ((char *) pg->area + offset))->data;
       break;
-
     case LOG_MVCC_UNDOREDO_DATA:
     case LOG_MVCC_DIFF_UNDOREDO_DATA:
       log_size = DB_SIZEOF (LOG_REC_MVCC_UNDOREDO);
-      LA_LOG_READ_ADVANCE_WHEN_DOESNT_FIT (error, log_size, offset, pageid, pg);
-      if (error != NO_ERROR)
-	{
-	  return NO_ERROR;
-	}
-      logdata = &((LOG_REC_MVCC_UNDOREDO *) ((char *) pg->area + offset))->undoredo.data;
       break;
-
     case LOG_REDO_DATA:
       log_size = DB_SIZEOF (LOG_REC_REDO);
-      LA_LOG_READ_ADVANCE_WHEN_DOESNT_FIT (error, log_size, offset, pageid, pg);
-      if (error != NO_ERROR)
-	{
-	  return NO_ERROR;
-	}
-      logdata = &((LOG_REC_REDO *) ((char *) pg->area + offset))->data;
       break;
-
     case LOG_MVCC_REDO_DATA:
       log_size = DB_SIZEOF (LOG_REC_MVCC_REDO);
-      LA_LOG_READ_ADVANCE_WHEN_DOESNT_FIT (error, log_size, offset, pageid, pg);
-      if (error != NO_ERROR)
-	{
-	  return NO_ERROR;
-	}
-      logdata = &((LOG_REC_MVCC_REDO *) ((char *) pg->area + offset))->redo.data;
       break;
-
     default:
       return NO_ERROR;
     }
 
-  if (logdata == NULL || logdata->rcvindex != RVOOS_INSERT)
+  LA_LOG_READ_ADVANCE_WHEN_DOESNT_FIT (error, log_size, offset, pageid, pg);
+  if (error != NO_ERROR)
+    {
+      return NO_ERROR;
+    }
+
+  switch (lrec->type)
+    {
+    case LOG_UNDOREDO_DATA:
+    case LOG_DIFF_UNDOREDO_DATA:
+      logdata = &((LOG_REC_UNDOREDO *) ((char *) pg->area + offset))->data;
+      break;
+    case LOG_MVCC_UNDOREDO_DATA:
+    case LOG_MVCC_DIFF_UNDOREDO_DATA:
+      logdata = &((LOG_REC_MVCC_UNDOREDO *) ((char *) pg->area + offset))->undoredo.data;
+      break;
+    case LOG_REDO_DATA:
+      logdata = &((LOG_REC_REDO *) ((char *) pg->area + offset))->data;
+      break;
+    case LOG_MVCC_REDO_DATA:
+      logdata = &((LOG_REC_MVCC_REDO *) ((char *) pg->area + offset))->redo.data;
+      break;
+    default:
+      /* unreachable — first switch already handled this. */
+      return NO_ERROR;
+    }
+
+  if (logdata->rcvindex != RVOOS_INSERT)
     {
       return NO_ERROR;
     }
@@ -3779,6 +3805,37 @@ la_get_oos_sql_log_chunk_oid (LA_ITEM * item, LOG_PAGE * pgptr, OID * chunk_oid)
   chunk_oid->volid = logdata->volid;
   chunk_oid->pageid = logdata->pageid;
   chunk_oid->slotid = logdata->offset;
+  return NO_ERROR;
+}
+
+/*
+ * la_register_new_oos_sql_log_cache_entry () - Publish a freshly allocated
+ *   cache entry: insert into the OID -> entry hash accelerator, then append
+ *   to the linked list owner.  Hash key is &entry->chunk_oid (entry-owned,
+ *   stable for entry lifetime).  mht_put overwrites any prior hash mapping
+ *   for the same OID, which is the desired behavior for cross-transaction
+ *   OID reuse: the previous owner's entry remains in the linked list (until
+ *   next cache clear) but is no longer reachable via lookup.  Returns
+ *   ER_OUT_OF_VIRTUAL_MEMORY on hash insert failure.
+ */
+static int
+la_register_new_oos_sql_log_cache_entry (LA_OOS_SQL_LOG_CACHE_ENTRY * entry)
+{
+  if (mht_put (la_Oos_sql_log_cache_hash, &entry->chunk_oid, entry) == NULL)
+    {
+      return ER_OUT_OF_VIRTUAL_MEMORY;
+    }
+
+  if (la_Oos_sql_log_cache_tail == NULL)
+    {
+      la_Oos_sql_log_cache_head = entry;
+      la_Oos_sql_log_cache_tail = entry;
+    }
+  else
+    {
+      la_Oos_sql_log_cache_tail->next = entry;
+      la_Oos_sql_log_cache_tail = entry;
+    }
   return NO_ERROR;
 }
 
@@ -3836,21 +3893,19 @@ la_cache_oos_sql_log_recdes (LA_ITEM * item, LOG_PAGE * pgptr, RECDES * recdes)
   if (entry == NULL)
     {
       entry = (LA_OOS_SQL_LOG_CACHE_ENTRY *) malloc (sizeof (LA_OOS_SQL_LOG_CACHE_ENTRY));
-      is_new_entry = true;
-      if (entry != NULL)
+      if (entry == NULL)
 	{
-	  memset (entry, 0, sizeof (LA_OOS_SQL_LOG_CACHE_ENTRY));
+	  db_private_free_and_init (NULL, payload_data);
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (LA_OOS_SQL_LOG_CACHE_ENTRY));
+	  return ER_OUT_OF_VIRTUAL_MEMORY;
 	}
+      memset (entry, 0, sizeof (LA_OOS_SQL_LOG_CACHE_ENTRY));
+      is_new_entry = true;
     }
-  if (entry == NULL)
+  else if (entry->data != NULL)
     {
-      db_private_free_and_init (NULL, payload_data);
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (LA_OOS_SQL_LOG_CACHE_ENTRY));
-      return ER_OUT_OF_VIRTUAL_MEMORY;
-    }
-
-  if (entry->data != NULL)
-    {
+      /* Existing entry — drop stale payload before overwriting (same chunk
+       * resent / replay scenarios). */
       db_private_free_and_init (NULL, entry->data);
     }
 
@@ -3864,29 +3919,14 @@ la_cache_oos_sql_log_recdes (LA_ITEM * item, LOG_PAGE * pgptr, RECDES * recdes)
 
   if (is_new_entry)
     {
-      /* Hash key is &entry->chunk_oid (entry-owned, stable for entry lifetime).
-       * mht_put overwrites any prior hash mapping for the same OID, which is the
-       * desired behavior for cross-transaction OID reuse: the previous owner's
-       * entry remains in the linked list (until next cache clear) but is no
-       * longer reachable via lookup.  mht_put failure is treated as an alloc
-       * failure since lookups would silently miss otherwise. */
-      if (mht_put (la_Oos_sql_log_cache_hash, &entry->chunk_oid, entry) == NULL)
+      error = la_register_new_oos_sql_log_cache_entry (entry);
+      if (error != NO_ERROR)
 	{
-	  free_and_init (entry);
-	  db_private_free_and_init (NULL, payload_data);
+	  /* hash insert failed.  entry->data points at payload_data — let the
+	   * canonical entry destructor free both at once. */
+	  la_free_oos_sql_log_cache_entry (entry);
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (LA_OOS_SQL_LOG_CACHE_ENTRY));
-	  return ER_OUT_OF_VIRTUAL_MEMORY;
-	}
-
-      if (la_Oos_sql_log_cache_tail == NULL)
-	{
-	  la_Oos_sql_log_cache_head = entry;
-	  la_Oos_sql_log_cache_tail = entry;
-	}
-      else
-	{
-	  la_Oos_sql_log_cache_tail->next = entry;
-	  la_Oos_sql_log_cache_tail = entry;
+	  return error;
 	}
     }
 
@@ -3916,7 +3956,16 @@ la_resolve_oos_sql_log_recdes (const OID * head_oid, int total_data_length, RECD
     }
 
   current_oid = *head_oid;
-  max_iterations = total_data_length > INT_MAX - 16 ? INT_MAX : total_data_length + 16;
+  /* Bound the chain walk by the worst-case chunk count: total length divided
+   * by the smallest legal chunk payload, plus a small slack.  Real chunks are
+   * page-size based (KB), so this is a defensive ceiling rather than a tight
+   * bound.  Saturate to INT_MAX on multiplicative overflow. */
+  {
+    int max_chunks = total_data_length / LA_OOS_MIN_CHUNK_PAYLOAD;
+
+    max_iterations =
+      (max_chunks > INT_MAX - LA_OOS_RESOLVE_ITERATION_SLACK) ? INT_MAX : max_chunks + LA_OOS_RESOLVE_ITERATION_SLACK;
+  }
 
   while (!OID_ISNULL (&current_oid) && copied_size < total_data_length && iterations++ < max_iterations)
     {
@@ -3956,6 +4005,7 @@ la_make_synthetic_oos_sql_log_value (DB_VALUE * value, SM_ATTRIBUTE * att, DB_BI
   DB_TYPE type;
   int string_length;
   int precision;
+  int marker_len;
   char *string = NULL;
 
   assert (value != NULL && att != NULL);
@@ -3988,24 +4038,19 @@ la_make_synthetic_oos_sql_log_value (DB_VALUE * value, SM_ATTRIBUTE * att, DB_BI
       return ER_OUT_OF_VIRTUAL_MEMORY;
     }
 
-  /* Embed an explicit sentinel at the value head so an operator who later inspects
-   * the sql.log can tell that the column body was synthesized (cache miss) rather
-   * than the actual OOS payload from the master.  Marker contains no SQL meta
-   * characters (quotes/backslash) so it remains safe inside a quoted varchar
-   * literal.  Remaining bytes are filled with spaces to keep the inline OOS length
-   * intact for sql.log size accounting / rotation. */
-  {
-    static const char OOS_MISSING_MARKER[] = "<<OOS_CHUNK_MISSING>>";
-    int marker_len = (int) (sizeof (OOS_MISSING_MARKER) - 1);
-
-    if (marker_len > string_length)
-      {
-	marker_len = string_length;
-      }
-    memcpy (string, OOS_MISSING_MARKER, marker_len);
-    memset (string + marker_len, ' ', string_length - marker_len);
-    string[string_length] = '\0';
-  }
+  /* Embed the file-level sentinel at the value head so an operator inspecting
+   * the sql.log can tell that the column body was synthesized (cache miss)
+   * rather than the actual OOS payload from the master.  Remaining bytes are
+   * spaces to keep the inline OOS length intact for sql.log size accounting
+   * / rotation. */
+  marker_len = (int) (sizeof (LA_OOS_MISSING_MARKER) - 1);
+  if (marker_len > string_length)
+    {
+      marker_len = string_length;
+    }
+  memcpy (string, LA_OOS_MISSING_MARKER, marker_len);
+  memset (string + marker_len, ' ', string_length - marker_len);
+  string[string_length] = '\0';
 
   er_log_debug (ARG_FILE_LINE,
 		"la_make_synthetic_oos_sql_log_value: OOS chunk(s) missing from SQL log cache; "

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -258,17 +258,10 @@ typedef struct la_oos_cache_entry LA_OOS_CACHE_ENTRY;
 struct la_oos_cache_entry
 {
   LA_OOS_CACHE_ENTRY *next;
-
-  /* Owning transaction id.  Resolves cross-transaction OID collisions when the
-   * master rapidly reuses the same OOS slot inside a SYSOP_END boundary that
-   * keeps the cache alive across mini-batches. */
-  int tranid;
-  OID chunk_oid;
-  OID next_chunk_oid;
-  int length;
-  char *data;
-  int total_data_length;
-  int chunk_index;
+  TRANID tranid;		/* tx scope guard against cross-tx OID reuse across SYSOP_END */
+  OID head_oid;			/* hash key: master's chunk_index=0 OID */
+  int length;			/* payload bytes (no OOS header prefix) */
+  char data[1];			/* flexible array — entry + payload share one alloc */
 };
 
 typedef struct la_apply LA_APPLY;
@@ -442,45 +435,23 @@ LA_INFO la_Info;
 
 LA_RECDES_POOL la_recdes_pool;
 
+/* OOS sql.log value cache: one entry per OOS column value, keyed by master's
+ * head OID (chunk_index=0).  Linked list owns memory; hash gives O(1) lookup.
+ * Lazily allocated; cleared (not destroyed) on tx boundaries so the bucket
+ * array survives.  Single-threaded — see CBRD-26618 TODO below for parallel
+ * applylogdb migration plan. */
+#define LA_OOS_CACHE_HASH_SIZE  1024
+#define LA_OOS_MISSING_MARKER   "<<OOS_CHUNK_MISSING>>"
+
+/* TODO(CBRD-26618): when parallel applylogdb is introduced, migrate these
+ * globals to per-LA_APPLY (or per-worker) state.  The tranid filter alone is
+ * NOT sufficient under concurrency — two workers processing different
+ * transactions can interleave la_cache_oos_value / la_lookup_oos_value /
+ * la_clear_oos_cache and race on the linked list and MHT_TABLE. */
 static LA_OOS_CACHE_ENTRY *la_oos_cache_head = NULL;
 static LA_OOS_CACHE_ENTRY *la_oos_cache_tail = NULL;
-
-/* Hash accelerator for la_find_oos_cache_entry().  The linked list
- * remains the canonical owner of entries (used for ordered teardown in
- * la_clear_oos_cache()).  The hash maps chunk_oid -> latest cached
- * entry, turning chain reassembly from O(N^2) to O(N) for OOS columns whose
- * value spans many physical chunks (e.g. several MB strings).
- *
- * Lazily allocated on first cache insert; cleared (not destroyed) on
- * transaction boundaries so the bucket array survives across transactions.
- *
- * Bucket count: ~1024.  Sized to keep the chain length below ~8 even for
- * heavy workloads in the order of ~8K chunks (e.g. ~32MB OOS column with the
- * smallest legal chunk payload).  Smaller workloads pay only the bucket
- * array cost (one MHT_TABLE allocation, ~8KB on a 64-bit platform). */
-#define LA_OOS_CACHE_HASH_SIZE 1024
 static MHT_TABLE *la_oos_cache_hash = NULL;
-
-/* Lower bound on a single OOS chunk's payload size.  Used purely as a
- * defensive divisor when bounding the iteration count of the chunk-chain
- * walker — real chunks are page-size (KB) based, so 256 bytes is a
- * conservative pathological floor. */
-#define LA_OOS_MIN_CHUNK_PAYLOAD       256
-/* Slack on top of (total_data_length / LA_OOS_MIN_CHUNK_PAYLOAD) to absorb
- * head/tail rounding and never trip on a legitimate chain. */
-#define LA_OOS_RESOLVE_ITERATION_SLACK 16
-
-/* Sentinel embedded at the head of synthetic placeholders so an operator
- * inspecting sql.log can immediately tell that the value was synthesized
- * (cache miss) rather than the master's real payload.  Contains no SQL meta
- * characters so it is safe inside a quoted varchar literal. */
-#define LA_OOS_MISSING_MARKER          "<<OOS_CHUNK_MISSING>>"
-
-/* Tranid currently being processed by la_apply_repl_log; scopes OOS sql.log
- * cache lookups to the current transaction so that a stale entry surviving
- * across LOG_SYSOP_END boundaries cannot be matched by a different transaction
- * that happens to land on the same chunk OID. */
-static int la_oos_current_tranid = NULL_TRAN_INDEX;
+static TRANID la_oos_current_tranid = NULL_TRANID;
 
 static bool la_applier_need_shutdown = false;
 static bool la_applier_shutdown_by_signal = false;
@@ -561,11 +532,12 @@ static int la_set_repl_log (LOG_PAGE * log_pgptr, int log_type, int tranid, LOG_
 static int la_add_node_into_la_commit_list (int tranid, LOG_LSA * lsa, int type, time_t eot_time);
 static time_t la_retrieve_eot_time (LOG_PAGE * pgptr, LOG_LSA * lsa);
 static int la_get_raw_offset_internal (OR_BUF * buf, int *error, int offset_size);
-static int la_register_oos_cache_entry (LA_OOS_CACHE_ENTRY * entry);
-static int la_cache_oos_chunk (LA_ITEM * item, LOG_PAGE * pgptr, RECDES * recdes);
-static int la_resolve_oos_recdes (const OID * head_oid, int total_data_length, RECDES * recdes);
+static int la_cache_oos_value (const OID * head_oid, const char *payload, int payload_length);
+static LA_OOS_CACHE_ENTRY *la_lookup_oos_value (const OID * head_oid);
 static void la_clear_oos_cache (void);
 static int la_make_oos_placeholder (DB_VALUE * value, SM_ATTRIBUTE * att, DB_BIGINT oos_length);
+static int la_resolve_oos_value_for_sql_log (const OID * head_oid, DB_BIGINT oos_length, SM_ATTRIBUTE * att,
+					     DB_VALUE * value);
 static int la_get_current (OR_BUF * buf, SM_CLASS * sm_class, int bound_bit_flag, DB_OTMPL * def, DB_VALUE * key,
 			   int offset_size);
 static void la_make_room_for_mvcc_insid (RECDES * recdes);
@@ -582,7 +554,7 @@ static int la_get_next_update_log (LOG_RECORD_HEADER * prev_lrec, LOG_PAGE * pgp
 				   char **data, int *d_length);
 static int la_get_relocation_recdes (LOG_RECORD_HEADER * lrec, LOG_PAGE * pgptr, unsigned int match_rcvindex,
 				     void **logs, char **rec_type, RECDES * recdes);
-static int la_rebuild_oos_recdes (LOG_LSA * lsa, RECDES * recdes);
+static int la_rebuild_oos_recdes (LOG_LSA * lsa, RECDES * recdes, OID * head_oid_out);
 static int la_get_recdes (LOG_LSA * lsa, LOG_PAGE * pgptr, RECDES * recdes, unsigned int *rcvindex, char *rec_type,
 			  bool is_mvcc_class);
 static void la_log_apply_error (const char *op_name, int err_id, LA_ITEM * item, int error);
@@ -3634,59 +3606,37 @@ la_get_raw_offset_internal (OR_BUF * buf, int *error, int offset_size)
 }
 
 /*
- * la_find_oos_cache_entry () - Look up a cached OOS chunk by
- *   (current tranid, OID).  Uses la_oos_cache_hash for O(1) probe;
- *   the tranid match prevents a stale entry surviving across LOG_SYSOP_END
- *   mini-batches from being matched by a different transaction that lands on
- *   the same recycled OOS slot OID.  Returns NULL when the hash is not yet
- *   allocated, the OID is null/invalid, the entry is missing, or the entry's
- *   tranid does not match the current transaction.
+ * la_lookup_oos_value () - O(1) cache lookup by master's head OID.
+ *   Tranid filter rejects stale entries surviving across LOG_SYSOP_END
+ *   mini-batches that happen to land on a recycled OOS slot OID.
  */
 static LA_OOS_CACHE_ENTRY *
-la_find_oos_cache_entry (const OID * chunk_oid)
+la_lookup_oos_value (const OID * head_oid)
 {
   LA_OOS_CACHE_ENTRY *entry;
 
-  if (chunk_oid == NULL || OID_ISNULL (chunk_oid) || la_oos_cache_hash == NULL)
+  if (head_oid == NULL || OID_ISNULL (head_oid) || la_oos_cache_hash == NULL)
     {
       return NULL;
     }
 
-  entry = (LA_OOS_CACHE_ENTRY *) mht_get (la_oos_cache_hash, chunk_oid);
+  entry = (LA_OOS_CACHE_ENTRY *) mht_get (la_oos_cache_hash, head_oid);
   if (entry == NULL || entry->tranid != la_oos_current_tranid)
     {
       return NULL;
     }
-
   return entry;
-}
-
-static void
-la_free_oos_cache_entry (LA_OOS_CACHE_ENTRY * entry)
-{
-  if (entry == NULL)
-    {
-      return;
-    }
-
-  if (entry->data != NULL)
-    {
-      db_private_free_and_init (NULL, entry->data);
-    }
-
-  free_and_init (entry);
 }
 
 static void
 la_clear_oos_cache (void)
 {
   LA_OOS_CACHE_ENTRY *entry = la_oos_cache_head;
-  LA_OOS_CACHE_ENTRY *next_entry = NULL;
+  LA_OOS_CACHE_ENTRY *next_entry;
 
-  /* Drop the hash bucket entries (rem_func == NULL — entries are not owned
-   * by the hash, the linked list below frees them).  Keep the MHT_TABLE
-   * itself alive so successive transactions reuse the same bucket array
-   * instead of paying mht_destroy + mht_create on every commit/abort. */
+  /* mht_clear (no rem_func) drops bucket entries; linked list owns memory.
+   * MHT_TABLE itself is kept alive across transactions to amortize bucket
+   * array alloc — see TODO at globals for parallel-applier migration. */
   if (la_oos_cache_hash != NULL)
     {
       (void) mht_clear (la_oos_cache_hash, NULL, NULL);
@@ -3695,7 +3645,7 @@ la_clear_oos_cache (void)
   while (entry != NULL)
     {
       next_entry = entry->next;
-      la_free_oos_cache_entry (entry);
+      free_and_init (entry);
       entry = next_entry;
     }
 
@@ -3704,13 +3654,15 @@ la_clear_oos_cache (void)
 }
 
 /*
- * la_get_oos_chunk_oid () - Peek the LOG_DATA at item->target_lsa
- *   directly from the in-memory page and extract the OID where the OOS chunk
- *   was inserted on the master.  Unlike la_get_log_data(), this does not
- *   allocate/decompress the redo body — only the small fixed-size log record
- *   header struct is read.  The chunk_oid is filled only when the recovery
- *   index is RVOOS_INSERT; otherwise it stays OID_NULL and NO_ERROR is
- *   returned, leaving the caller to fall back gracefully.
+ * la_get_oos_chunk_oid () - Peek the LOG_DATA at item->target_lsa and extract
+ *   the OID where the OOS chunk was inserted on the master.  Reads only the
+ *   fixed-size LOG_REC header — no redo body alloc/decompress.  Fills
+ *   chunk_oid only for RVOOS_INSERT records; otherwise leaves OID_NULL and
+ *   returns NO_ERROR so the caller can fall back gracefully.
+ *
+ *   For single-chunk OOS, target_lsa points at the only chunk = head chunk;
+ *   thus the result is master's head OID.  Multi-chunk uses
+ *   la_rebuild_oos_recdes() to capture head OID instead.
  */
 static int
 la_get_oos_chunk_oid (LA_ITEM * item, LOG_PAGE * pgptr, OID * chunk_oid)
@@ -3746,10 +3698,9 @@ la_get_oos_chunk_oid (LA_ITEM * item, LOG_PAGE * pgptr, OID * chunk_oid)
       return NO_ERROR;
     }
 
-  /* Two-pass over lrec->type: first pick the on-disk record size so we can
-   * advance/spill a single page boundary, then re-cast and grab the embedded
-   * LOG_DATA pointer.  Splitting the switch keeps the fit-check and error
-   * handling unduplicated. */
+  /* First switch picks record size for the page-boundary fit check; second
+   * switch (after the advance) casts to the type-specific struct.  Cannot
+   * be merged because LA_LOG_READ_ADVANCE_WHEN_DOESNT_FIT may shift pg. */
   switch (lrec->type)
     {
     case LOG_UNDOREDO_DATA:
@@ -3793,8 +3744,7 @@ la_get_oos_chunk_oid (LA_ITEM * item, LOG_PAGE * pgptr, OID * chunk_oid)
       logdata = &((LOG_REC_MVCC_REDO *) ((char *) pg->area + offset))->redo.data;
       break;
     default:
-      /* unreachable — first switch already handled this. */
-      return NO_ERROR;
+      return NO_ERROR;		/* unreachable — handled above */
     }
 
   if (logdata->rcvindex != RVOOS_INSERT)
@@ -3802,6 +3752,7 @@ la_get_oos_chunk_oid (LA_ITEM * item, LOG_PAGE * pgptr, OID * chunk_oid)
       return NO_ERROR;
     }
 
+  /* OOS abuses LOG_DATA.offset as slotid (see oos_log_insert_physical). */
   chunk_oid->volid = logdata->volid;
   chunk_oid->pageid = logdata->pageid;
   chunk_oid->slotid = logdata->offset;
@@ -3809,62 +3760,20 @@ la_get_oos_chunk_oid (LA_ITEM * item, LOG_PAGE * pgptr, OID * chunk_oid)
 }
 
 /*
- * la_register_oos_cache_entry () - Publish a freshly allocated
- *   cache entry: insert into the OID -> entry hash accelerator, then append
- *   to the linked list owner.  Hash key is &entry->chunk_oid (entry-owned,
- *   stable for entry lifetime).  mht_put overwrites any prior hash mapping
- *   for the same OID, which is the desired behavior for cross-transaction
- *   OID reuse: the previous owner's entry remains in the linked list (until
- *   next cache clear) but is no longer reachable via lookup.  Returns
- *   ER_OUT_OF_VIRTUAL_MEMORY on hash insert failure.
+ * la_cache_oos_value () - Stash one OOS column value (already assembled
+ *   into a contiguous payload) keyed by master's head OID.  Single allocation
+ *   for entry + payload via flexible array member.
  */
 static int
-la_register_oos_cache_entry (LA_OOS_CACHE_ENTRY * entry)
+la_cache_oos_value (const OID * head_oid, const char *payload, int payload_length)
 {
-  if (mht_put (la_oos_cache_hash, &entry->chunk_oid, entry) == NULL)
-    {
-      return ER_OUT_OF_VIRTUAL_MEMORY;
-    }
+  LA_OOS_CACHE_ENTRY *entry;
+  size_t alloc_size;
 
-  if (la_oos_cache_tail == NULL)
+  if (head_oid == NULL || OID_ISNULL (head_oid) || payload == NULL || payload_length <= 0)
     {
-      la_oos_cache_head = entry;
-      la_oos_cache_tail = entry;
-    }
-  else
-    {
-      la_oos_cache_tail->next = entry;
-      la_oos_cache_tail = entry;
-    }
-  return NO_ERROR;
-}
-
-static int
-la_cache_oos_chunk (LA_ITEM * item, LOG_PAGE * pgptr, RECDES * recdes)
-{
-  LA_OOS_CACHE_ENTRY *entry = NULL;
-  OOS_RECORD_HEADER oos_header;
-  OID chunk_oid = OID_INITIALIZER;
-  char *payload_data = NULL;
-  int payload_length;
-  int error = NO_ERROR;
-  bool is_new_entry = false;
-
-  if (recdes == NULL || recdes->data == NULL || recdes->length <= OOS_RECORD_HEADER_SIZE)
-    {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HA_GENERIC_ERROR, 1, "invalid OOS record for SQL log");
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HA_GENERIC_ERROR, 1, "invalid OOS value for SQL log cache");
       return ER_FAILED;
-    }
-
-  error = la_get_oos_chunk_oid (item, pgptr, &chunk_oid);
-  if (error != NO_ERROR)
-    {
-      return error;
-    }
-
-  if (OID_ISNULL (&chunk_oid))
-    {
-      return NO_ERROR;
     }
 
   if (la_oos_cache_hash == NULL)
@@ -3872,176 +3781,58 @@ la_cache_oos_chunk (LA_ITEM * item, LOG_PAGE * pgptr, RECDES * recdes)
       la_oos_cache_hash = mht_create ("OOS cache", LA_OOS_CACHE_HASH_SIZE, oid_hash, oid_compare_equals);
       if (la_oos_cache_hash == NULL)
 	{
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (MHT_TABLE));
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1,
+		  (size_t) LA_OOS_CACHE_HASH_SIZE * sizeof (void *));
 	  return ER_OUT_OF_VIRTUAL_MEMORY;
 	}
     }
 
-  memcpy (&oos_header, recdes->data, OOS_RECORD_HEADER_SIZE);
-  payload_length = recdes->length - OOS_RECORD_HEADER_SIZE;
-
-  payload_data = (char *) db_private_alloc (NULL, payload_length);
-  if (payload_data == NULL)
-    {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, payload_length);
-      return ER_OUT_OF_VIRTUAL_MEMORY;
-    }
-  memcpy (payload_data, recdes->data + OOS_RECORD_HEADER_SIZE, payload_length);
-
-  entry = la_find_oos_cache_entry (&chunk_oid);
+  alloc_size = offsetof (LA_OOS_CACHE_ENTRY, data) + (size_t) payload_length;
+  entry = (LA_OOS_CACHE_ENTRY *) malloc (alloc_size);
   if (entry == NULL)
     {
-      entry = (LA_OOS_CACHE_ENTRY *) malloc (sizeof (LA_OOS_CACHE_ENTRY));
-      if (entry == NULL)
-	{
-	  db_private_free_and_init (NULL, payload_data);
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (LA_OOS_CACHE_ENTRY));
-	  return ER_OUT_OF_VIRTUAL_MEMORY;
-	}
-      memset (entry, 0, sizeof (LA_OOS_CACHE_ENTRY));
-      is_new_entry = true;
-    }
-  else if (entry->data != NULL)
-    {
-      /* Existing entry — drop stale payload before overwriting (same chunk
-       * resent / replay scenarios). */
-      db_private_free_and_init (NULL, entry->data);
-    }
-
-  entry->tranid = la_oos_current_tranid;
-  entry->chunk_oid = chunk_oid;
-  entry->next_chunk_oid = oos_header.next_chunk_oid;
-  entry->length = payload_length;
-  entry->data = payload_data;
-  entry->total_data_length = oos_header.total_data_length;
-  entry->chunk_index = oos_header.chunk_index;
-
-  if (is_new_entry)
-    {
-      error = la_register_oos_cache_entry (entry);
-      if (error != NO_ERROR)
-	{
-	  /* hash insert failed.  entry->data points at payload_data — let the
-	   * canonical entry destructor free both at once. */
-	  la_free_oos_cache_entry (entry);
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (LA_OOS_CACHE_ENTRY));
-	  return error;
-	}
-    }
-
-  return NO_ERROR;
-}
-
-/*
- * la_resolve_oos_recdes () - Reassemble a single OOS column value from
- *   the per-transaction chunk cache and return it as a contiguous RECDES.
- *
- *   Note on ordering: the master logs OOS chunks in *reverse* order
- *   (last-chunk-first) so each chunk record can carry the next chunk's OID
- *   in its OOS_RECORD_HEADER.  As a result la_cache_oos_chunk()
- *   populates this cache tail-first.  The hash accelerator however gives
- *   random access by OID, so this resolver walks *forward* from the head OID
- *   passed in (taken from the heap recdes inline OOS metadata) by following
- *   entry->next_chunk_oid until total_data_length bytes are reassembled or
- *   the chain terminates with a NULL OID.  Arrival order is therefore
- *   irrelevant at resolution time.
- *
- *   Validation (any failure returns ER_FAILED, leaving the caller to fall
- *   back to la_make_oos_placeholder()):
- *     - chunk_index strictly monotone increasing from 0
- *     - total_data_length identical on every chunk in the chain
- *     - each chunk's body fits the remaining buffer
- *     - the chain terminates exactly at total_data_length and a NULL OID
- *     - max_iterations guard against pathological / self-referential chains
- *
- *   On success, recdes->data is owned by the caller and must be freed with
- *   db_private_free_and_init() / recdes_free_data_area().
- */
-static int
-la_resolve_oos_recdes (const OID * head_oid, int total_data_length, RECDES * recdes)
-{
-  OID current_oid;
-  char *data = NULL;
-  int copied_size = 0;
-  int expected_chunk_index = 0;
-  int max_iterations;
-  int iterations = 0;
-
-  if (head_oid == NULL || OID_ISNULL (head_oid) || total_data_length <= 0 || recdes == NULL)
-    {
-      return ER_FAILED;
-    }
-
-  data = (char *) db_private_alloc (NULL, total_data_length);
-  if (data == NULL)
-    {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, total_data_length);
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, alloc_size);
       return ER_OUT_OF_VIRTUAL_MEMORY;
     }
 
-  current_oid = *head_oid;
-  /* Bound the chain walk by the worst-case chunk count: total length divided
-   * by the smallest legal chunk payload, plus a small slack.  Real chunks are
-   * page-size based (KB), so this is a defensive ceiling rather than a tight
-   * bound.  Saturate to INT_MAX on multiplicative overflow. */
-  {
-    int max_chunks = total_data_length / LA_OOS_MIN_CHUNK_PAYLOAD;
+  entry->next = NULL;
+  entry->tranid = la_oos_current_tranid;
+  entry->head_oid = *head_oid;
+  entry->length = payload_length;
+  memcpy (entry->data, payload, payload_length);
 
-    max_iterations =
-      (max_chunks > INT_MAX - LA_OOS_RESOLVE_ITERATION_SLACK) ? INT_MAX : max_chunks + LA_OOS_RESOLVE_ITERATION_SLACK;
-  }
-
-  while (!OID_ISNULL (&current_oid) && copied_size < total_data_length && iterations++ < max_iterations)
+  /* mht_put overwrites a stale mapping for the same OID (cross-tx OID reuse).
+   * The previous owner's entry stays in the linked list until next clear,
+   * but is no longer reachable via lookup. */
+  if (mht_put (la_oos_cache_hash, &entry->head_oid, entry) == NULL)
     {
-      LA_OOS_CACHE_ENTRY *entry = la_find_oos_cache_entry (&current_oid);
-
-      if (entry == NULL || entry->chunk_index != expected_chunk_index
-	  || entry->total_data_length != total_data_length
-	  || entry->length < 0 || entry->length > total_data_length - copied_size)
-	{
-	  db_private_free_and_init (NULL, data);
-	  return ER_FAILED;
-	}
-
-      memcpy (data + copied_size, entry->data, entry->length);
-      copied_size += entry->length;
-      expected_chunk_index++;
-      current_oid = entry->next_chunk_oid;
+      free_and_init (entry);
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, alloc_size);
+      return ER_OUT_OF_VIRTUAL_MEMORY;
     }
 
-  if (copied_size != total_data_length || !OID_ISNULL (&current_oid))
+  if (la_oos_cache_tail == NULL)
     {
-      db_private_free_and_init (NULL, data);
-      return ER_FAILED;
+      la_oos_cache_head = entry;
     }
-
-  recdes->area_size = total_data_length;
-  recdes->length = total_data_length;
-  recdes->type = REC_HOME;
-  recdes->data = data;
+  else
+    {
+      la_oos_cache_tail->next = entry;
+    }
+  la_oos_cache_tail = entry;
 
   return NO_ERROR;
 }
 
 /*
- * la_make_oos_placeholder () - Last-resort fallback when the
- *   chunk chain cannot be reassembled (cache miss, integrity check failure,
- *   etc.).  Produces a varchar of the inline OOS length filled with spaces
- *   except for the LA_OOS_MISSING_MARKER sentinel at the head, so:
- *     - the sql.log line still has the correct length for size accounting /
- *       rotation,
- *     - an operator running grep on sql.log can immediately spot which rows
- *       were synthesized rather than reproduced from the master,
- *     - the marker contains no SQL meta characters (quotes, backslash) so
- *       it is safe inside a quoted varchar literal.
+ * la_make_oos_placeholder () - Last-resort fallback when the OOS value is
+ *   missing from the cache.  Produces a varchar of the inline OOS length
+ *   prefixed with LA_OOS_MISSING_MARKER (visible in operator grep) and
+ *   space-padded so sql.log size accounting / rotation stays correct.
  *
- *   Currently OOS columns are only used for variable-length string types
- *   (VARCHAR/VARNCHAR).  Non-string types fall through to ER_FAILED
- *   (loud failure, no synthesis) which propagates and aborts sql.log
- *   writing for that row — a clear signal in the error log.
- *
- *   Also emits er_log_debug() so the operator can find every fallback
- *   occurrence in the applylogdb error log alongside the source location.
+ *   Refuses (ER_FAILED) when (a) attribute is non-string — OOS is currently
+ *   string-only, so non-string here means corruption — or (b) length is
+ *   shorter than the marker (a partial marker defeats grep visibility).
  */
 static int
 la_make_oos_placeholder (DB_VALUE * value, SM_ATTRIBUTE * att, DB_BIGINT oos_length)
@@ -4049,8 +3840,8 @@ la_make_oos_placeholder (DB_VALUE * value, SM_ATTRIBUTE * att, DB_BIGINT oos_len
   DB_TYPE type;
   int string_length;
   int precision;
-  int marker_len;
-  char *string = NULL;
+  int marker_len = (int) (sizeof (LA_OOS_MISSING_MARKER) - 1);
+  char *string;
 
   assert (value != NULL && att != NULL);
 
@@ -4069,10 +3860,17 @@ la_make_oos_placeholder (DB_VALUE * value, SM_ATTRIBUTE * att, DB_BIGINT oos_len
     }
 
   string_length = (int) oos_length;
-  precision = att->domain != NULL ? att->domain->precision : DB_MAX_VARCHAR_PRECISION;
+  precision = (att->domain != NULL) ? att->domain->precision : DB_MAX_VARCHAR_PRECISION;
   if (precision > 0 && precision < string_length)
     {
       string_length = precision;
+    }
+
+  if (string_length < marker_len)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HA_GENERIC_ERROR, 1,
+	      "OOS placeholder shorter than missing-marker sentinel");
+      return ER_FAILED;
     }
 
   string = (char *) db_private_alloc (NULL, string_length + 1);
@@ -4082,29 +3880,39 @@ la_make_oos_placeholder (DB_VALUE * value, SM_ATTRIBUTE * att, DB_BIGINT oos_len
       return ER_OUT_OF_VIRTUAL_MEMORY;
     }
 
-  /* Embed the file-level sentinel at the value head so an operator inspecting
-   * the sql.log can tell that the column body was synthesized (cache miss)
-   * rather than the actual OOS payload from the master.  Remaining bytes are
-   * spaces to keep the inline OOS length intact for sql.log size accounting
-   * / rotation. */
-  marker_len = (int) (sizeof (LA_OOS_MISSING_MARKER) - 1);
-  if (marker_len > string_length)
-    {
-      marker_len = string_length;
-    }
   memcpy (string, LA_OOS_MISSING_MARKER, marker_len);
   memset (string + marker_len, ' ', string_length - marker_len);
   string[string_length] = '\0';
 
   er_log_debug (ARG_FILE_LINE,
-		"la_make_oos_placeholder: OOS chunk(s) missing from SQL log cache; "
-		"synthesizing %d-byte placeholder for column", string_length);
+		"la_make_oos_placeholder: OOS value missing from SQL log cache; "
+		"synthesized %d-byte placeholder", string_length);
 
   db_make_varchar (value, precision, string, string_length, TP_DOMAIN_CODESET (att->domain),
 		   TP_DOMAIN_COLLATION (att->domain));
   value->need_clear = true;
-
   return NO_ERROR;
+}
+
+/*
+ * la_resolve_oos_value_for_sql_log () - Cache lookup → readval, with
+ *   placeholder synthesis on miss.  Used by la_get_current() for each OOS
+ *   column when emitting INSERT/UPDATE sql.log lines.
+ */
+static int
+la_resolve_oos_value_for_sql_log (const OID * head_oid, DB_BIGINT oos_length, SM_ATTRIBUTE * att, DB_VALUE * value)
+{
+  LA_OOS_CACHE_ENTRY *entry;
+  OR_BUF buf;
+
+  entry = la_lookup_oos_value (head_oid);
+  if (entry != NULL)
+    {
+      or_init (&buf, entry->data, entry->length);
+      return att->type->data_readval (&buf, value, att->domain, entry->length, true, NULL, 0);
+    }
+
+  return la_make_oos_placeholder (value, att, oos_length);
 }
 
 /*
@@ -4223,8 +4031,6 @@ la_get_current (OR_BUF * buf, SM_CLASS * sm_class, int bound_bit_flag, DB_OTMPL 
     {
       if (vars_oos[j])
 	{
-	  RECDES oos_recdes = { -1, -1, REC_HOME, NULL };
-	  OR_BUF oos_buf;
 	  OR_BUF inline_buf;
 	  OID oos_oid = OID_INITIALIZER;
 	  DB_BIGINT oos_length = 0;
@@ -4242,31 +4048,7 @@ la_get_current (OR_BUF * buf, SM_CLASS * sm_class, int bound_bit_flag, DB_OTMPL 
 		}
 	    }
 
-	  if (!OID_ISNULL (&oos_oid) && oos_length > 0 && oos_length <= (DB_BIGINT) INT_MAX)
-	    {
-	      error = la_resolve_oos_recdes (&oos_oid, (int) oos_length, &oos_recdes);
-	    }
-
-	  if (error == NO_ERROR && oos_recdes.data != NULL)
-	    {
-	      or_init (&oos_buf, oos_recdes.data, oos_recdes.length);
-	      error = att->type->data_readval (&oos_buf, &value, att->domain, oos_recdes.length, true, NULL, 0);
-	      recdes_free_data_area (&oos_recdes);
-	    }
-	  else
-	    {
-	      if (error == ER_OUT_OF_VIRTUAL_MEMORY)
-		{
-		  free_and_init (vars);
-		  free_and_init (vars_oos);
-		  return error;
-		}
-
-	      /* Prefer exact OID-chain reconstruction.  If any chunk is missing from the replication
-	       * cache, preserve sql.log sizing/rotation for large strings using the inline OOS length. */
-	      error = la_make_oos_placeholder (&value, att, oos_length);
-	    }
-
+	  error = la_resolve_oos_value_for_sql_log (&oos_oid, oos_length, att, &value);
 	  if (error != NO_ERROR)
 	    {
 	      free_and_init (vars);
@@ -5132,8 +4914,10 @@ la_append_oos_chunk (LA_OOS_CHUNK ** chunks, int *chunk_count, int *chunk_capaci
 /*
  * la_rebuild_oos_recdes() - rebuild a multi-chunk OOS record from log records
  *   return: NO_ERROR or error code
- *   lsa(in): LSA of the first logged OOS chunk
+ *   lsa(in): LSA of the first logged OOS chunk (master's tail chunk)
  *   recdes(out): merged OOS record description
+ *   head_oid_out(out): master's chunk_index=0 OID — used as sql.log cache key.
+ *                     May be NULL if the caller does not need it.
  *
  * Note:
  *   Multi-chunk OOS chunks are logged from tail to head. This function follows
@@ -5143,7 +4927,7 @@ la_append_oos_chunk (LA_OOS_CHUNK ** chunks, int *chunk_count, int *chunk_capaci
  *   the caller.
  */
 static int
-la_rebuild_oos_recdes (LOG_LSA * lsa, RECDES * recdes)
+la_rebuild_oos_recdes (LOG_LSA * lsa, RECDES * recdes, OID * head_oid_out)
 {
   LOG_LSA current_lsa;
   TRANID trid = NULL_TRANID;
@@ -5157,6 +4941,11 @@ la_rebuild_oos_recdes (LOG_LSA * lsa, RECDES * recdes)
 
   assert (lsa != NULL);
   assert (recdes != NULL);
+
+  if (head_oid_out != NULL)
+    {
+      OID_SET_NULL (head_oid_out);
+    }
 
   LSA_COPY (&current_lsa, lsa);
 
@@ -5256,6 +5045,39 @@ la_rebuild_oos_recdes (LOG_LSA * lsa, RECDES * recdes)
 	      if (oos_header.chunk_index == 0)
 		{
 		  found_head_chunk = true;
+
+		  /* Capture master's head OID for the sql.log cache key.
+		   * OOS log records stuff slotid into LOG_DATA.offset
+		   * (oos_log_insert_physical), so unpack the same way. */
+		  if (head_oid_out != NULL && log_info != NULL)
+		    {
+		      LOG_DATA *logdata = NULL;
+		      switch (current_log_record->type)
+			{
+			case LOG_UNDOREDO_DATA:
+			case LOG_DIFF_UNDOREDO_DATA:
+			  logdata = &((LOG_REC_UNDOREDO *) log_info)->data;
+			  break;
+			case LOG_MVCC_UNDOREDO_DATA:
+			case LOG_MVCC_DIFF_UNDOREDO_DATA:
+			  logdata = &((LOG_REC_MVCC_UNDOREDO *) log_info)->undoredo.data;
+			  break;
+			case LOG_REDO_DATA:
+			  logdata = &((LOG_REC_REDO *) log_info)->data;
+			  break;
+			case LOG_MVCC_REDO_DATA:
+			  logdata = &((LOG_REC_MVCC_REDO *) log_info)->redo.data;
+			  break;
+			default:
+			  break;
+			}
+		      if (logdata != NULL && logdata->rcvindex == RVOOS_INSERT)
+			{
+			  head_oid_out->volid = logdata->volid;
+			  head_oid_out->pageid = logdata->pageid;
+			  head_oid_out->slotid = logdata->offset;
+			}
+		    }
 		}
 	    }
 	}
@@ -6287,6 +6109,7 @@ la_apply_insert_log (LA_APPLY * apply, LA_ITEM * item)
   LOG_PAGEID old_pageid = NULL_PAGEID;
   bool is_mvcc_class;
   bool rebuild_oos = item->item_type == RVREPL_OOS_INSERT && apply->need_oos_rebuild;
+  OID oos_head_oid = OID_INITIALIZER;	/* master's chunk_index=0 OID — sql.log cache key */
 
   error = la_flush_repl_items (false);
   if (error != NO_ERROR)
@@ -6311,7 +6134,8 @@ la_apply_insert_log (LA_APPLY * apply, LA_ITEM * item)
 
   if (rebuild_oos)
     {
-      error = la_rebuild_oos_recdes (&item->target_lsa, recdes);
+      /* Multi-chunk: walk WAL and concatenate; capture chunk_index=0 OID. */
+      error = la_rebuild_oos_recdes (&item->target_lsa, recdes, &oos_head_oid);
       if (error != NO_ERROR)
 	{
 	  goto end;
@@ -6342,6 +6166,12 @@ la_apply_insert_log (LA_APPLY * apply, LA_ITEM * item)
 	{
 	  goto end;
 	}
+
+      /* Single-chunk: target_lsa already points at the only/head chunk. */
+      if (item->item_type == RVREPL_OOS_INSERT && la_enable_sql_logging)
+	{
+	  (void) la_get_oos_chunk_oid (item, pgptr, &oos_head_oid);
+	}
     }
 
   if (recdes->type == REC_ASSIGN_ADDRESS || recdes->type == REC_RELOCATION)
@@ -6362,19 +6192,22 @@ la_apply_insert_log (LA_APPLY * apply, LA_ITEM * item)
 
   if (la_enable_sql_logging)
     {
-      int ret;
+      int ret = NO_ERROR;
 
-      /* sql.log is an audit/debug artifact; an error here (cache OOM, mht_put
-       * failure, etc.) must not abort replication of the row itself.  Stash
-       * the current error stack across the call so any failure is recorded
-       * via la_set_error_sql_log() instead of bubbling up. */
+      /* sql.log is an audit artifact; cache OOM / mht_put failure here must
+       * not abort row replication.  er_stack_push/pop isolates the error so
+       * la_set_error_sql_log records it without propagation. */
       er_stack_push ();
       if (item->item_type == RVREPL_OOS_INSERT)
 	{
-	  /* OOS chunk record — body is not a user INSERT, just stash it in the
-	   * per-transaction cache for la_resolve_oos_recdes() to pick
-	   * up when the heap INSERT arrives.  No sql.log line is emitted. */
-	  ret = la_cache_oos_chunk (item, pgptr, recdes);
+	  /* OOS chunk: stash the assembled value keyed by master's head OID;
+	   * la_get_current() will pick it up at heap-row sql.log time.
+	   * No sql.log line is emitted for the chunk record itself. */
+	  if (!OID_ISNULL (&oos_head_oid) && recdes->length > OOS_RECORD_HEADER_SIZE)
+	    {
+	      ret = la_cache_oos_value (&oos_head_oid,
+					recdes->data + OOS_RECORD_HEADER_SIZE, recdes->length - OOS_RECORD_HEADER_SIZE);
+	    }
 	}
       else
 	{

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -3934,6 +3934,31 @@ la_cache_oos_sql_log_recdes (LA_ITEM * item, LOG_PAGE * pgptr, RECDES * recdes)
   return NO_ERROR;
 }
 
+/*
+ * la_resolve_oos_sql_log_recdes () - Reassemble a single OOS column value from
+ *   the per-transaction chunk cache and return it as a contiguous RECDES.
+ *
+ *   Note on ordering: the master logs OOS chunks in *reverse* order
+ *   (last-chunk-first) so each chunk record can carry the next chunk's OID
+ *   in its OOS_RECORD_HEADER.  As a result la_cache_oos_sql_log_recdes()
+ *   populates this cache tail-first.  The hash accelerator however gives
+ *   random access by OID, so this resolver walks *forward* from the head OID
+ *   passed in (taken from the heap recdes inline OOS metadata) by following
+ *   entry->next_chunk_oid until total_data_length bytes are reassembled or
+ *   the chain terminates with a NULL OID.  Arrival order is therefore
+ *   irrelevant at resolution time.
+ *
+ *   Validation (any failure returns ER_FAILED, leaving the caller to fall
+ *   back to la_make_synthetic_oos_sql_log_value()):
+ *     - chunk_index strictly monotone increasing from 0
+ *     - total_data_length identical on every chunk in the chain
+ *     - each chunk's body fits the remaining buffer
+ *     - the chain terminates exactly at total_data_length and a NULL OID
+ *     - max_iterations guard against pathological / self-referential chains
+ *
+ *   On success, recdes->data is owned by the caller and must be freed with
+ *   db_private_free_and_init() / recdes_free_data_area().
+ */
 static int
 la_resolve_oos_sql_log_recdes (const OID * head_oid, int total_data_length, RECDES * recdes)
 {
@@ -4000,6 +4025,26 @@ la_resolve_oos_sql_log_recdes (const OID * head_oid, int total_data_length, RECD
   return NO_ERROR;
 }
 
+/*
+ * la_make_synthetic_oos_sql_log_value () - Last-resort fallback when the
+ *   chunk chain cannot be reassembled (cache miss, integrity check failure,
+ *   etc.).  Produces a varchar of the inline OOS length filled with spaces
+ *   except for the LA_OOS_MISSING_MARKER sentinel at the head, so:
+ *     - the sql.log line still has the correct length for size accounting /
+ *       rotation,
+ *     - an operator running grep on sql.log can immediately spot which rows
+ *       were synthesized rather than reproduced from the master,
+ *     - the marker contains no SQL meta characters (quotes, backslash) so
+ *       it is safe inside a quoted varchar literal.
+ *
+ *   Currently OOS columns are only used for variable-length string types
+ *   (VARCHAR/VARNCHAR).  Non-string types fall through to ER_FAILED
+ *   (loud failure, no synthesis) which propagates and aborts sql.log
+ *   writing for that row — a clear signal in the error log.
+ *
+ *   Also emits er_log_debug() so the operator can find every fallback
+ *   occurrence in the applylogdb error log alongside the source location.
+ */
 static int
 la_make_synthetic_oos_sql_log_value (DB_VALUE * value, SM_ATTRIBUTE * att, DB_BIGINT oos_length)
 {
@@ -6321,9 +6366,16 @@ la_apply_insert_log (LA_APPLY * apply, LA_ITEM * item)
     {
       int ret;
 
+      /* sql.log is an audit/debug artifact; an error here (cache OOM, mht_put
+       * failure, etc.) must not abort replication of the row itself.  Stash
+       * the current error stack across the call so any failure is recorded
+       * via la_set_error_sql_log() instead of bubbling up. */
       er_stack_push ();
       if (item->item_type == RVREPL_OOS_INSERT)
 	{
+	  /* OOS chunk record — body is not a user INSERT, just stash it in the
+	   * per-transaction cache for la_resolve_oos_sql_log_recdes() to pick
+	   * up when the heap INSERT arrives.  No sql.log line is emitted. */
 	  ret = la_cache_oos_sql_log_recdes (item, pgptr, recdes);
 	}
       else

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -3684,12 +3684,13 @@ la_clear_oos_sql_log_cache (void)
   LA_OOS_SQL_LOG_CACHE_ENTRY *entry = la_Oos_sql_log_cache_head;
   LA_OOS_SQL_LOG_CACHE_ENTRY *next_entry = NULL;
 
-  /* Tear down the hash first; entries themselves are owned by the linked list
-   * walked just below, so the hash teardown only releases the bucket array. */
+  /* Drop the hash bucket entries (rem_func == NULL — entries are not owned
+   * by the hash, the linked list below frees them).  Keep the MHT_TABLE
+   * itself alive so successive transactions reuse the same bucket array
+   * instead of paying mht_destroy + mht_create on every commit/abort. */
   if (la_Oos_sql_log_cache_hash != NULL)
     {
-      mht_destroy (la_Oos_sql_log_cache_hash);
-      la_Oos_sql_log_cache_hash = NULL;
+      (void) mht_clear (la_Oos_sql_log_cache_hash, NULL, NULL);
     }
 
   while (entry != NULL)

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -565,7 +565,8 @@ static int la_write_insert_sql_log (LA_ITEM * item, DB_OBJECT * class_obj, RECDE
 static int la_apply_dummy_oos_log (LA_APPLY * apply, LA_ITEM * item);
 static int la_apply_delete_log (LA_ITEM * item);
 static int la_apply_update_log (LA_ITEM * item);
-static int la_apply_insert_log (LA_APPLY * apply, LA_ITEM * item);
+static int la_apply_insert_log (LA_ITEM * item);
+static int la_apply_oos_insert_log (LA_APPLY * apply, LA_ITEM * item);
 static int la_update_query_execute (const char *sql, bool au_disable);
 static int la_update_query_execute_with_values (const char *sql, int arg_count, DB_VALUE * vals, bool au_disable);
 static int la_apply_statement_log (LA_ITEM * item);
@@ -3668,7 +3669,6 @@ static int
 la_get_oos_chunk_oid (LA_ITEM * item, LOG_PAGE * pgptr, OID * chunk_oid)
 {
   LOG_RECORD_HEADER *lrec;
-  LOG_PAGE *pg;
   PGLENGTH offset;
   LOG_PAGEID pageid;
   LOG_DATA *logdata = NULL;
@@ -3687,12 +3687,11 @@ la_get_oos_chunk_oid (LA_ITEM * item, LOG_PAGE * pgptr, OID * chunk_oid)
       return NO_ERROR;
     }
 
-  pg = pgptr;
-  lrec = LOG_GET_LOG_RECORD_HEADER (pg, &item->target_lsa);
+  lrec = LOG_GET_LOG_RECORD_HEADER (pgptr, &item->target_lsa);
   offset = DB_SIZEOF (LOG_RECORD_HEADER) + item->target_lsa.offset;
   pageid = item->target_lsa.pageid;
 
-  LA_LOG_READ_ALIGN (error, offset, pageid, pg);
+  LA_LOG_READ_ALIGN (error, offset, pageid, pgptr);
   if (error != NO_ERROR)
     {
       return NO_ERROR;
@@ -3700,7 +3699,7 @@ la_get_oos_chunk_oid (LA_ITEM * item, LOG_PAGE * pgptr, OID * chunk_oid)
 
   /* First switch picks record size for the page-boundary fit check; second
    * switch (after the advance) casts to the type-specific struct.  Cannot
-   * be merged because LA_LOG_READ_ADVANCE_WHEN_DOESNT_FIT may shift pg. */
+   * be merged because LA_LOG_READ_ADVANCE_WHEN_DOESNT_FIT may shift pgptr. */
   switch (lrec->type)
     {
     case LOG_UNDOREDO_DATA:
@@ -3721,7 +3720,7 @@ la_get_oos_chunk_oid (LA_ITEM * item, LOG_PAGE * pgptr, OID * chunk_oid)
       return NO_ERROR;
     }
 
-  LA_LOG_READ_ADVANCE_WHEN_DOESNT_FIT (error, log_size, offset, pageid, pg);
+  LA_LOG_READ_ADVANCE_WHEN_DOESNT_FIT (error, log_size, offset, pageid, pgptr);
   if (error != NO_ERROR)
     {
       return NO_ERROR;
@@ -3731,17 +3730,17 @@ la_get_oos_chunk_oid (LA_ITEM * item, LOG_PAGE * pgptr, OID * chunk_oid)
     {
     case LOG_UNDOREDO_DATA:
     case LOG_DIFF_UNDOREDO_DATA:
-      logdata = &((LOG_REC_UNDOREDO *) ((char *) pg->area + offset))->data;
+      logdata = &((LOG_REC_UNDOREDO *) ((char *) pgptr->area + offset))->data;
       break;
     case LOG_MVCC_UNDOREDO_DATA:
     case LOG_MVCC_DIFF_UNDOREDO_DATA:
-      logdata = &((LOG_REC_MVCC_UNDOREDO *) ((char *) pg->area + offset))->undoredo.data;
+      logdata = &((LOG_REC_MVCC_UNDOREDO *) ((char *) pgptr->area + offset))->undoredo.data;
       break;
     case LOG_REDO_DATA:
-      logdata = &((LOG_REC_REDO *) ((char *) pg->area + offset))->data;
+      logdata = &((LOG_REC_REDO *) ((char *) pgptr->area + offset))->data;
       break;
     case LOG_MVCC_REDO_DATA:
-      logdata = &((LOG_REC_MVCC_REDO *) ((char *) pg->area + offset))->redo.data;
+      logdata = &((LOG_REC_MVCC_REDO *) ((char *) pgptr->area + offset))->redo.data;
       break;
     default:
       return NO_ERROR;		/* unreachable — handled above */
@@ -3830,8 +3829,8 @@ la_cache_oos_value (const OID * head_oid, const char *payload, int payload_lengt
  *   lines.  A miss is treated as an invariant violation (eager assembly +
  *   tranid scope make a hit guaranteed in normal operation) and surfaces as
  *   ER_FAILED so an operator sees a loud signal in the error log instead of
- *   silently synthesized data.  The caller (la_apply_insert_log) already
- *   isolates this error from row replication via er_stack_push / pop +
+ *   silently synthesized data.  The heap-row sql.log callers already isolate
+ *   this error from row replication via er_stack_push / pop +
  *   la_set_error_sql_log.
  */
 static int
@@ -6028,30 +6027,27 @@ la_apply_dummy_oos_log (LA_APPLY * apply, LA_ITEM * item)
 }
 
 /*
- * la_apply_insert_log() - apply the insert log to the target slave
+ * la_apply_oos_insert_log() - apply an OOS insert log to the target slave
  *   return: NO_ERROR or error code
  *   apply(in/out): apply list state
- *   item(in): replication item
+ *   item(in): OOS replication item
  *
  * Note:
- *      Apply the insert log to the target slave.
- *      . get the target log page
- *      . get the record description
- *      . fetch the class info
- *      . create a replication object to be flushed and add it to a link
- *      . If la_enable_sql_logging(config param is ha_enable_sql_logging) is enabled, the query is written to a file.
+ *      OOS INSERT and UPDATE both emit RVREPL_OOS_INSERT items before the
+ *      heap row item.  This function applies the OOS chunk record and, when
+ *      sql logging is enabled, caches the assembled OOS value so the later
+ *      heap INSERT/UPDATE sql.log path can reconstruct the column value.
  */
 static int
-la_apply_insert_log (LA_APPLY * apply, LA_ITEM * item)
+la_apply_oos_insert_log (LA_APPLY * apply, LA_ITEM * item)
 {
   int error = NO_ERROR;
   DB_OBJECT *class_obj;
   LOG_PAGE *pgptr = NULL;
-  unsigned int rcvindex;
+  unsigned int rcvindex = 0;
   RECDES *recdes;
   LOG_PAGEID old_pageid = NULL_PAGEID;
-  bool is_mvcc_class;
-  bool rebuild_oos = item->item_type == RVREPL_OOS_INSERT && apply->need_oos_rebuild;
+  bool rebuild_oos = apply->need_oos_rebuild;
   OID oos_head_oid = OID_INITIALIZER;	/* master's chunk_index=0 OID — sql.log cache key */
 
   error = la_flush_repl_items (false);
@@ -6073,7 +6069,6 @@ la_apply_insert_log (LA_APPLY * apply, LA_ITEM * item)
     }
 
   recdes = la_assign_recdes_from_pool ();
-  is_mvcc_class = la_is_mvcc_class (ws_oid (class_obj));
 
   if (rebuild_oos)
     {
@@ -6103,15 +6098,15 @@ la_apply_insert_log (LA_APPLY * apply, LA_ITEM * item)
 	  goto end;
 	}
 
-      /* retrieve the target record description */
-      error = la_get_recdes (&item->target_lsa, pgptr, recdes, &rcvindex, la_Info.rec_type, is_mvcc_class);
+      /* retrieve the target OOS record description */
+      error = la_get_recdes (&item->target_lsa, pgptr, recdes, &rcvindex, la_Info.rec_type, false);
       if (error != NO_ERROR)
 	{
 	  goto end;
 	}
 
       /* Single-chunk: target_lsa already points at the only/head chunk. */
-      if (item->item_type == RVREPL_OOS_INSERT && la_enable_sql_logging)
+      if (la_enable_sql_logging)
 	{
 	  (void) la_get_oos_chunk_oid (item, pgptr, &oos_head_oid);
 	}
@@ -6125,7 +6120,7 @@ la_apply_insert_log (LA_APPLY * apply, LA_ITEM * item)
       goto end;
     }
 
-  if (rcvindex != RVHF_INSERT && rcvindex != RVHF_MVCC_INSERT && rcvindex != RVOOS_INSERT)
+  if (rcvindex != RVOOS_INSERT)
     {
       er_log_debug (ARG_FILE_LINE, "apply_insert : rcvindex = %d\n", rcvindex);
       error = ER_FAILED;
@@ -6141,21 +6136,16 @@ la_apply_insert_log (LA_APPLY * apply, LA_ITEM * item)
        * not abort row replication.  er_stack_push/pop isolates the error so
        * la_set_error_sql_log records it without propagation. */
       er_stack_push ();
-      if (item->item_type == RVREPL_OOS_INSERT)
+
+      /* OOS chunk: stash the assembled value keyed by master's head OID;
+       * la_get_current() will pick it up at heap-row sql.log time.
+       * No sql.log line is emitted for the chunk record itself. */
+      if (!OID_ISNULL (&oos_head_oid) && recdes->length > OOS_RECORD_HEADER_SIZE)
 	{
-	  /* OOS chunk: stash the assembled value keyed by master's head OID;
-	   * la_get_current() will pick it up at heap-row sql.log time.
-	   * No sql.log line is emitted for the chunk record itself. */
-	  if (!OID_ISNULL (&oos_head_oid) && recdes->length > OOS_RECORD_HEADER_SIZE)
-	    {
-	      ret = la_cache_oos_value (&oos_head_oid,
-					recdes->data + OOS_RECORD_HEADER_SIZE, recdes->length - OOS_RECORD_HEADER_SIZE);
-	    }
+	  ret = la_cache_oos_value (&oos_head_oid, recdes->data + OOS_RECORD_HEADER_SIZE,
+				    recdes->length - OOS_RECORD_HEADER_SIZE);
 	}
-      else
-	{
-	  ret = la_write_insert_sql_log (item, class_obj, recdes);
-	}
+
       er_stack_pop ();
       if (ret != NO_ERROR)
 	{
@@ -6180,8 +6170,126 @@ end:
     {
       la_Info.insert_counter++;
       la_Info.num_unflushed++;
-      /* RVREPL_DUMMY_OOS_RECORD is handled by la_apply_dummy_oos_log; only inserts reach here. */
-      la_Info.pending_oos_flush = (item->item_type == RVREPL_OOS_INSERT);
+      la_Info.pending_oos_flush = true;
+    }
+
+  if (old_pageid != NULL_PAGEID)
+    {
+      la_release_page_buffer (old_pageid);
+    }
+
+  return error;
+}
+
+/*
+ * la_apply_insert_log() - apply the insert log to the target slave
+ *   return: NO_ERROR or error code
+ *   item(in): replication item
+ *
+ * Note:
+ *      Apply the insert log to the target slave.
+ *      . get the target log page
+ *      . get the record description
+ *      . fetch the class info
+ *      . create a replication object to be flushed and add it to a link
+ *      . If la_enable_sql_logging(config param is ha_enable_sql_logging) is enabled, the query is written to a file.
+ */
+static int
+la_apply_insert_log (LA_ITEM * item)
+{
+  int error = NO_ERROR;
+  DB_OBJECT *class_obj;
+  LOG_PAGE *pgptr = NULL;
+  unsigned int rcvindex;
+  RECDES *recdes;
+  LOG_PAGEID old_pageid = NULL_PAGEID;
+  bool is_mvcc_class;
+
+  error = la_flush_repl_items (false);
+  if (error != NO_ERROR)
+    {
+      return error;
+    }
+
+  class_obj = db_find_class (item->class_name);
+  if (class_obj == NULL)
+    {
+      assert (er_errid () != NO_ERROR);
+      if (er_errid () == NO_ERROR)
+	{
+	  error = ER_FAILED;
+	}
+
+      goto end;
+    }
+
+  recdes = la_assign_recdes_from_pool ();
+  is_mvcc_class = la_is_mvcc_class (ws_oid (class_obj));
+
+  /* get the target log page */
+  old_pageid = item->target_lsa.pageid;
+  pgptr = la_get_page (old_pageid);
+  if (pgptr == NULL)
+    {
+      assert (er_errid () != NO_ERROR);
+      error = er_errid ();
+      if (error == NO_ERROR)
+	{
+	  error = ER_FAILED;
+	}
+      old_pageid = NULL_PAGEID;
+      goto end;
+    }
+
+  /* retrieve the target record description */
+  error = la_get_recdes (&item->target_lsa, pgptr, recdes, &rcvindex, la_Info.rec_type, is_mvcc_class);
+  if (error != NO_ERROR)
+    {
+      goto end;
+    }
+
+  if (recdes->type == REC_ASSIGN_ADDRESS || recdes->type == REC_RELOCATION)
+    {
+      er_log_debug (ARG_FILE_LINE, "apply_insert : rectype.type = %d\n", recdes->type);
+      error = ER_FAILED;
+
+      goto end;
+    }
+
+  if (rcvindex != RVHF_INSERT && rcvindex != RVHF_MVCC_INSERT)
+    {
+      er_log_debug (ARG_FILE_LINE, "apply_insert : rcvindex = %d\n", rcvindex);
+      error = ER_FAILED;
+
+      goto end;
+    }
+
+  if (la_enable_sql_logging)
+    {
+      int ret;
+
+      er_stack_push ();
+      ret = la_write_insert_sql_log (item, class_obj, recdes);
+      er_stack_pop ();
+      if (ret != NO_ERROR)
+	{
+	  la_set_error_sql_log (item->class_name, la_get_item_pk_value (item));
+	}
+    }
+
+  error = la_repl_add_object (class_obj, item, recdes);
+
+end:
+  if (error != NO_ERROR)
+    {
+      la_Info.pending_oos_flush = false;
+      la_log_apply_error ("apply_insert", ER_HA_LA_FAILED_TO_APPLY_INSERT, item, error);
+    }
+  else
+    {
+      la_Info.insert_counter++;
+      la_Info.num_unflushed++;
+      la_Info.pending_oos_flush = false;
     }
 
   if (old_pageid != NULL_PAGEID)
@@ -6605,8 +6713,11 @@ la_apply_repl_log (int tranid, int rectype, LOG_LSA * commit_lsa, int *total_row
 		  break;
 
 		case RVREPL_DATA_INSERT:
+		  error = la_apply_insert_log (item);
+		  break;
+
 		case RVREPL_OOS_INSERT:
-		  error = la_apply_insert_log (apply, item);
+		  error = la_apply_oos_insert_log (apply, item);
 		  break;
 
 		case RVREPL_DUMMY_OOS_RECORD:

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -268,7 +268,7 @@ struct la_oos_sql_log_cache_entry
   OID next_chunk_oid;
   int length;
   char *data;
-  int total_size;
+  int total_data_length;
   int chunk_index;
 };
 
@@ -541,7 +541,7 @@ static int la_add_node_into_la_commit_list (int tranid, LOG_LSA * lsa, int type,
 static time_t la_retrieve_eot_time (LOG_PAGE * pgptr, LOG_LSA * lsa);
 static int la_get_raw_offset_internal (OR_BUF * buf, int *error, int offset_size);
 static int la_cache_oos_sql_log_recdes (LA_ITEM * item, LOG_PAGE * pgptr, RECDES * recdes);
-static int la_resolve_oos_sql_log_recdes (const OID * head_oid, int total_size, RECDES * recdes);
+static int la_resolve_oos_sql_log_recdes (const OID * head_oid, int total_data_length, RECDES * recdes);
 static void la_clear_oos_sql_log_cache (void);
 static int la_make_synthetic_oos_sql_log_value (DB_VALUE * value, SM_ATTRIBUTE * att, DB_BIGINT oos_length);
 static int la_get_current (OR_BUF * buf, SM_CLASS * sm_class, int bound_bit_flag, DB_OTMPL * def, DB_VALUE * key,
@@ -3859,7 +3859,7 @@ la_cache_oos_sql_log_recdes (LA_ITEM * item, LOG_PAGE * pgptr, RECDES * recdes)
   entry->next_chunk_oid = oos_header.next_chunk_oid;
   entry->length = payload_length;
   entry->data = payload_data;
-  entry->total_size = oos_header.total_size;
+  entry->total_data_length = oos_header.total_data_length;
   entry->chunk_index = oos_header.chunk_index;
 
   if (is_new_entry)
@@ -3894,7 +3894,7 @@ la_cache_oos_sql_log_recdes (LA_ITEM * item, LOG_PAGE * pgptr, RECDES * recdes)
 }
 
 static int
-la_resolve_oos_sql_log_recdes (const OID * head_oid, int total_size, RECDES * recdes)
+la_resolve_oos_sql_log_recdes (const OID * head_oid, int total_data_length, RECDES * recdes)
 {
   OID current_oid;
   char *data = NULL;
@@ -3903,27 +3903,28 @@ la_resolve_oos_sql_log_recdes (const OID * head_oid, int total_size, RECDES * re
   int max_iterations;
   int iterations = 0;
 
-  if (head_oid == NULL || OID_ISNULL (head_oid) || total_size <= 0 || recdes == NULL)
+  if (head_oid == NULL || OID_ISNULL (head_oid) || total_data_length <= 0 || recdes == NULL)
     {
       return ER_FAILED;
     }
 
-  data = (char *) db_private_alloc (NULL, total_size);
+  data = (char *) db_private_alloc (NULL, total_data_length);
   if (data == NULL)
     {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, total_size);
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, total_data_length);
       return ER_OUT_OF_VIRTUAL_MEMORY;
     }
 
   current_oid = *head_oid;
-  max_iterations = total_size > INT_MAX - 16 ? INT_MAX : total_size + 16;
+  max_iterations = total_data_length > INT_MAX - 16 ? INT_MAX : total_data_length + 16;
 
-  while (!OID_ISNULL (&current_oid) && copied_size < total_size && iterations++ < max_iterations)
+  while (!OID_ISNULL (&current_oid) && copied_size < total_data_length && iterations++ < max_iterations)
     {
       LA_OOS_SQL_LOG_CACHE_ENTRY *entry = la_find_oos_sql_log_cache_entry (&current_oid);
 
-      if (entry == NULL || entry->chunk_index != expected_chunk_index || entry->total_size != total_size
-	  || entry->length < 0 || entry->length > total_size - copied_size)
+      if (entry == NULL || entry->chunk_index != expected_chunk_index
+	  || entry->total_data_length != total_data_length
+	  || entry->length < 0 || entry->length > total_data_length - copied_size)
 	{
 	  db_private_free_and_init (NULL, data);
 	  return ER_FAILED;
@@ -3935,14 +3936,14 @@ la_resolve_oos_sql_log_recdes (const OID * head_oid, int total_size, RECDES * re
       current_oid = entry->next_chunk_oid;
     }
 
-  if (copied_size != total_size || !OID_ISNULL (&current_oid))
+  if (copied_size != total_data_length || !OID_ISNULL (&current_oid))
     {
       db_private_free_and_init (NULL, data);
       return ER_FAILED;
     }
 
-  recdes->area_size = total_size;
-  recdes->length = total_size;
+  recdes->area_size = total_data_length;
+  recdes->length = total_data_length;
   recdes->type = REC_HOME;
   recdes->data = data;
 

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -263,7 +263,6 @@ struct la_oos_cache_entry
    * master rapidly reuses the same OOS slot inside a SYSOP_END boundary that
    * keeps the cache alive across mini-batches. */
   int tranid;
-
   OID chunk_oid;
   OID next_chunk_oid;
   int length;

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -3927,8 +3927,28 @@ la_make_synthetic_oos_sql_log_value (DB_VALUE * value, SM_ATTRIBUTE * att, DB_BI
       return ER_OUT_OF_VIRTUAL_MEMORY;
     }
 
-  memset (string, ' ', string_length);
-  string[string_length] = '\0';
+  /* Embed an explicit sentinel at the value head so an operator who later inspects
+   * the sql.log can tell that the column body was synthesized (cache miss) rather
+   * than the actual OOS payload from the master.  Marker contains no SQL meta
+   * characters (quotes/backslash) so it remains safe inside a quoted varchar
+   * literal.  Remaining bytes are filled with spaces to keep the inline OOS length
+   * intact for sql.log size accounting / rotation. */
+  {
+    static const char OOS_MISSING_MARKER[] = "<<OOS_CHUNK_MISSING>>";
+    int marker_len = (int) (sizeof (OOS_MISSING_MARKER) - 1);
+
+    if (marker_len > string_length)
+      {
+	marker_len = string_length;
+      }
+    memcpy (string, OOS_MISSING_MARKER, marker_len);
+    memset (string + marker_len, ' ', string_length - marker_len);
+    string[string_length] = '\0';
+  }
+
+  er_log_debug (ARG_FILE_LINE,
+		"la_make_synthetic_oos_sql_log_value: OOS chunk(s) missing from SQL log cache; "
+		"synthesizing %d-byte placeholder for column", string_length);
 
   db_make_varchar (value, precision, string, string_length, TP_DOMAIN_CODESET (att->domain),
 		   TP_DOMAIN_COLLATION (att->domain));

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -523,11 +523,11 @@ static int la_cache_oos_sql_log_recdes (LA_ITEM * item, LOG_PAGE * pgptr, RECDES
 static int la_resolve_oos_sql_log_recdes (const OID * head_oid, int total_size, RECDES * recdes);
 static void la_clear_oos_sql_log_cache (void);
 static int la_make_synthetic_oos_sql_log_value (DB_VALUE * value, SM_ATTRIBUTE * att, DB_BIGINT oos_length);
-static int la_get_current (OR_BUF * buf, SM_CLASS * sm_class, int bound_bit_flag, DB_OTMPL * def, LA_ITEM * item,
+static int la_get_current (OR_BUF * buf, SM_CLASS * sm_class, int bound_bit_flag, DB_OTMPL * def, DB_VALUE * key,
 			   int offset_size);
 static void la_make_room_for_mvcc_insid (RECDES * recdes);
 static void la_make_room_for_mvcc_delid_and_prev_ver (RECDES * recdes);
-static int la_disk_to_obj (MOBJ classobj, RECDES * record, DB_OTMPL * def, LA_ITEM * item);
+static int la_disk_to_obj (MOBJ classobj, RECDES * record, DB_OTMPL * def, DB_VALUE * key);
 static char *la_get_zipped_data (char *undo_data, int undo_length, bool is_diff, bool is_undo_zip, bool is_overflow,
 				 char **rec_type, char **data, int *length);
 static int la_get_undoredo_diff (LOG_PAGE ** pgptr, LOG_PAGEID * pageid, PGLENGTH * offset, bool * is_undo_zip,
@@ -3917,8 +3917,7 @@ la_make_synthetic_oos_sql_log_value (DB_VALUE * value, SM_ATTRIBUTE * att, DB_BI
  *     call dbt_put_internal() for update...
  */
 static int
-la_get_current (OR_BUF * buf, SM_CLASS * sm_class, int bound_bit_flag, DB_OTMPL * def, LA_ITEM * item,
-		int offset_size)
+la_get_current (OR_BUF * buf, SM_CLASS * sm_class, int bound_bit_flag, DB_OTMPL * def, DB_VALUE * key, int offset_size)
 {
   SM_ATTRIBUTE *att;
   int *vars = NULL;
@@ -3929,8 +3928,6 @@ la_get_current (OR_BUF * buf, SM_CLASS * sm_class, int bound_bit_flag, DB_OTMPL 
   int rc = NO_ERROR;
   DB_VALUE value;
   int error = NO_ERROR;
-
-  (void) item;
 
   if (sm_class->variable_count)
     {
@@ -4184,7 +4181,7 @@ la_make_room_for_mvcc_delid_and_prev_ver (RECDES * recdes)
  *     call dbt_put_internal() for update...
  */
 static int
-la_disk_to_obj (MOBJ classobj, RECDES * record, DB_OTMPL * def, LA_ITEM * item)
+la_disk_to_obj (MOBJ classobj, RECDES * record, DB_OTMPL * def, DB_VALUE * key)
 {
   OR_BUF orep, *buf;
   SM_CLASS *sm_class;
@@ -4240,7 +4237,7 @@ la_disk_to_obj (MOBJ classobj, RECDES * record, DB_OTMPL * def, LA_ITEM * item)
 
   bound_bit_flag = repid_bits & OR_BOUND_BIT_FLAG;
 
-  error = la_get_current (buf, sm_class, bound_bit_flag, def, item, offset_size);
+  error = la_get_current (buf, sm_class, bound_bit_flag, def, key, offset_size);
 
   if (error == NO_ERROR && buf->ptr > buf->endptr)
     {
@@ -5814,7 +5811,7 @@ la_write_update_sql_log (LA_ITEM * item, DB_OBJECT * class_obj, RECDES * recdes)
 
   key = la_get_item_pk_value (item);
 
-  if (la_disk_to_obj (mclass, recdes, inst_tp, item) != NO_ERROR)
+  if (la_disk_to_obj (mclass, recdes, inst_tp, key) != NO_ERROR)
     {
       ret = ER_FAILED;
       goto end;
@@ -6016,7 +6013,7 @@ la_write_insert_sql_log (LA_ITEM * item, DB_OBJECT * class_obj, RECDES * recdes)
   key = la_get_item_pk_value (item);
 
   /* make object using the record description */
-  if (la_disk_to_obj (mclass, recdes, inst_tp, item) != NO_ERROR)
+  if (la_disk_to_obj (mclass, recdes, inst_tp, key) != NO_ERROR)
     {
       ret = ER_FAILED;
       goto end;

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -7920,6 +7920,17 @@ la_shutdown (void)
       free_and_init (la_Info.cache_pb);
     }
 
+  /* OOS sql.log cache: drop entries via la_clear_oos_cache (mht_clear keeps
+   * the bucket array alive across transactions) and then release the table
+   * itself.  Without this destroy path, the bucket array would leak ~8KB on
+   * applier shutdown / HA failover. */
+  la_clear_oos_cache ();
+  if (la_oos_cache_hash != NULL)
+    {
+      mht_destroy (la_oos_cache_hash);
+      la_oos_cache_hash = NULL;
+    }
+
   if (la_Info.repl_lists)
     {
       for (i = 0; i < la_Info.repl_cnt; i++)

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -51,6 +51,7 @@
 #include "log_lsa.hpp"
 #include "object_primitive.h"
 #include "object_representation.h"
+#include "oid.h"
 #include "oos_file.hpp"
 #include "db_value_printer.hpp"
 #include "db.h"
@@ -444,6 +445,15 @@ LA_RECDES_POOL la_recdes_pool;
 
 static LA_OOS_SQL_LOG_CACHE_ENTRY *la_Oos_sql_log_cache_head = NULL;
 static LA_OOS_SQL_LOG_CACHE_ENTRY *la_Oos_sql_log_cache_tail = NULL;
+
+/* Hash accelerator for la_find_oos_sql_log_cache_entry().  The linked list
+ * remains the canonical owner of entries (used for ordered teardown in
+ * la_clear_oos_sql_log_cache()).  The hash maps chunk_oid -> latest cached
+ * entry, turning chain reassembly from O(N^2) to O(N) for OOS columns whose
+ * value spans many physical chunks (e.g. several MB strings).  Lazily
+ * allocated on first cache insert; freed/recreated on cache clear. */
+#define LA_OOS_SQL_LOG_CACHE_HASH_SIZE 257
+static MHT_TABLE *la_Oos_sql_log_cache_hash = NULL;
 
 /* Tranid currently being processed by la_apply_repl_log; scopes OOS sql.log
  * cache lookups to the current transaction so that a stale entry surviving
@@ -3603,31 +3613,30 @@ la_get_raw_offset_internal (OR_BUF * buf, int *error, int offset_size)
 
 /*
  * la_find_oos_sql_log_cache_entry () - Look up a cached OOS chunk by
- *   (current tranid, OID).  Filtering on tranid prevents a stale entry from a
- *   previous transaction (which can survive across LOG_SYSOP_END mini-batches
- *   that intentionally keep the cache alive) from masquerading as the current
- *   transaction's chunk when the master rapidly recycles the same OOS slot OID.
+ *   (current tranid, OID).  Uses la_Oos_sql_log_cache_hash for O(1) probe;
+ *   the tranid match prevents a stale entry surviving across LOG_SYSOP_END
+ *   mini-batches from being matched by a different transaction that lands on
+ *   the same recycled OOS slot OID.  Returns NULL when the hash is not yet
+ *   allocated, the OID is null/invalid, the entry is missing, or the entry's
+ *   tranid does not match the current transaction.
  */
 static LA_OOS_SQL_LOG_CACHE_ENTRY *
 la_find_oos_sql_log_cache_entry (const OID * chunk_oid)
 {
-  LA_OOS_SQL_LOG_CACHE_ENTRY *entry = la_Oos_sql_log_cache_head;
+  LA_OOS_SQL_LOG_CACHE_ENTRY *entry;
 
-  if (chunk_oid == NULL || OID_ISNULL (chunk_oid))
+  if (chunk_oid == NULL || OID_ISNULL (chunk_oid) || la_Oos_sql_log_cache_hash == NULL)
     {
       return NULL;
     }
 
-  while (entry != NULL)
+  entry = (LA_OOS_SQL_LOG_CACHE_ENTRY *) mht_get (la_Oos_sql_log_cache_hash, chunk_oid);
+  if (entry == NULL || entry->tranid != la_Oos_sql_log_current_tranid)
     {
-      if (entry->tranid == la_Oos_sql_log_current_tranid && OID_EQ (&entry->chunk_oid, chunk_oid))
-	{
-	  return entry;
-	}
-      entry = entry->next;
+      return NULL;
     }
 
-  return NULL;
+  return entry;
 }
 
 static void
@@ -3651,6 +3660,14 @@ la_clear_oos_sql_log_cache (void)
 {
   LA_OOS_SQL_LOG_CACHE_ENTRY *entry = la_Oos_sql_log_cache_head;
   LA_OOS_SQL_LOG_CACHE_ENTRY *next_entry = NULL;
+
+  /* Tear down the hash first; entries themselves are owned by the linked list
+   * walked just below, so the hash teardown only releases the bucket array. */
+  if (la_Oos_sql_log_cache_hash != NULL)
+    {
+      mht_destroy (la_Oos_sql_log_cache_hash);
+      la_Oos_sql_log_cache_hash = NULL;
+    }
 
   while (entry != NULL)
     {
@@ -3793,6 +3810,17 @@ la_cache_oos_sql_log_recdes (LA_ITEM * item, LOG_PAGE * pgptr, RECDES * recdes)
       return NO_ERROR;
     }
 
+  if (la_Oos_sql_log_cache_hash == NULL)
+    {
+      la_Oos_sql_log_cache_hash =
+	mht_create ("OOS sql.log cache", LA_OOS_SQL_LOG_CACHE_HASH_SIZE, oid_hash, oid_compare_equals);
+      if (la_Oos_sql_log_cache_hash == NULL)
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (MHT_TABLE));
+	  return ER_OUT_OF_VIRTUAL_MEMORY;
+	}
+    }
+
   memcpy (&oos_header, recdes->data, OOS_RECORD_HEADER_SIZE);
   payload_length = recdes->length - OOS_RECORD_HEADER_SIZE;
 
@@ -3836,6 +3864,20 @@ la_cache_oos_sql_log_recdes (LA_ITEM * item, LOG_PAGE * pgptr, RECDES * recdes)
 
   if (is_new_entry)
     {
+      /* Hash key is &entry->chunk_oid (entry-owned, stable for entry lifetime).
+       * mht_put overwrites any prior hash mapping for the same OID, which is the
+       * desired behavior for cross-transaction OID reuse: the previous owner's
+       * entry remains in the linked list (until next cache clear) but is no
+       * longer reachable via lookup.  mht_put failure is treated as an alloc
+       * failure since lookups would silently miss otherwise. */
+      if (mht_put (la_Oos_sql_log_cache_hash, &entry->chunk_oid, entry) == NULL)
+	{
+	  free_and_init (entry);
+	  db_private_free_and_init (NULL, payload_data);
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (LA_OOS_SQL_LOG_CACHE_ENTRY));
+	  return ER_OUT_OF_VIRTUAL_MEMORY;
+	}
+
       if (la_Oos_sql_log_cache_tail == NULL)
 	{
 	  la_Oos_sql_log_cache_head = entry;

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -520,13 +520,16 @@ static void la_clear_all_repl_and_commit_list (void);
 static int la_set_repl_log (LOG_PAGE * log_pgptr, int log_type, int tranid, LOG_LSA * lsa);
 static int la_add_node_into_la_commit_list (int tranid, LOG_LSA * lsa, int type, time_t eot_time);
 static time_t la_retrieve_eot_time (LOG_PAGE * pgptr, LOG_LSA * lsa);
+static int la_get_raw_offset_internal (OR_BUF * buf, int *error, int offset_size);
 static int la_cache_oos_sql_log_recdes (LA_ITEM * item, RECDES * recdes);
+static int la_consume_oos_sql_log_recdes (LA_ITEM * item, RECDES * recdes, int *total_size, int *chunk_index);
 static void la_clear_oos_sql_log_cache (void);
-static int la_get_current (OR_BUF * buf, SM_CLASS * sm_class, int bound_bit_flag, DB_OTMPL * def, DB_VALUE * key,
+static int la_make_synthetic_oos_sql_log_value (DB_VALUE * value, SM_ATTRIBUTE * att, DB_BIGINT oos_length);
+static int la_get_current (OR_BUF * buf, SM_CLASS * sm_class, int bound_bit_flag, DB_OTMPL * def, LA_ITEM * item,
 			   int offset_size);
 static void la_make_room_for_mvcc_insid (RECDES * recdes);
 static void la_make_room_for_mvcc_delid_and_prev_ver (RECDES * recdes);
-static int la_disk_to_obj (MOBJ classobj, RECDES * record, DB_OTMPL * def, DB_VALUE * key);
+static int la_disk_to_obj (MOBJ classobj, RECDES * record, DB_OTMPL * def, LA_ITEM * item);
 static char *la_get_zipped_data (char *undo_data, int undo_length, bool is_diff, bool is_undo_zip, bool is_overflow,
 				 char **rec_type, char **data, int *length);
 static int la_get_undoredo_diff (LOG_PAGE ** pgptr, LOG_PAGEID * pageid, PGLENGTH * offset, bool * is_undo_zip,
@@ -3571,6 +3574,39 @@ la_retrieve_eot_time (LOG_PAGE * pgptr, LOG_LSA * lsa)
   return donetime->at_time;
 }
 
+static int
+la_get_raw_offset_internal (OR_BUF * buf, int *error, int offset_size)
+{
+  if (offset_size == OR_BYTE_SIZE)
+    {
+      return or_get_byte (buf, error);
+    }
+  else if (offset_size == OR_SHORT_SIZE)
+    {
+      return or_get_short (buf, error);
+    }
+  else
+    {
+      assert (offset_size == OR_INT_SIZE);
+      return or_get_int (buf, error);
+    }
+}
+
+static bool
+la_oos_sql_log_cache_entry_matches (LA_OOS_SQL_LOG_CACHE_ENTRY * entry, LA_ITEM * item)
+{
+  assert (entry != NULL);
+
+  if (item == NULL || item->class_name == NULL || item->packed_key_value == NULL)
+    {
+      return false;
+    }
+
+  return entry->packed_key_value_length == item->packed_key_value_length
+    && strcmp (entry->class_name, item->class_name) == 0
+    && memcmp (entry->packed_key_value, item->packed_key_value, item->packed_key_value_length) == 0;
+}
+
 static void
 la_free_oos_sql_log_cache_entry (LA_OOS_SQL_LOG_CACHE_ENTRY * entry)
 {
@@ -3674,6 +3710,104 @@ la_cache_oos_sql_log_recdes (LA_ITEM * item, RECDES * recdes)
   return NO_ERROR;
 }
 
+static int
+la_consume_oos_sql_log_recdes (LA_ITEM * item, RECDES * recdes, int *total_size, int *chunk_index)
+{
+  LA_OOS_SQL_LOG_CACHE_ENTRY *entry = la_Oos_sql_log_cache_head;
+  LA_OOS_SQL_LOG_CACHE_ENTRY *prev_entry = NULL;
+
+  while (entry != NULL && !la_oos_sql_log_cache_entry_matches (entry, item))
+    {
+      prev_entry = entry;
+      entry = entry->next;
+    }
+
+  if (entry == NULL)
+    {
+      entry = la_Oos_sql_log_cache_head;
+      prev_entry = NULL;
+    }
+
+  if (entry == NULL)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HA_GENERIC_ERROR, 1, "cannot find OOS data for SQL log");
+      return ER_FAILED;
+    }
+
+  if (prev_entry == NULL)
+    {
+      la_Oos_sql_log_cache_head = entry->next;
+    }
+  else
+    {
+      prev_entry->next = entry->next;
+    }
+
+  if (la_Oos_sql_log_cache_tail == entry)
+    {
+      la_Oos_sql_log_cache_tail = prev_entry;
+    }
+
+  recdes->area_size = entry->length;
+  recdes->length = entry->length;
+  recdes->type = REC_HOME;
+  recdes->data = entry->data;
+  *total_size = entry->total_size;
+  *chunk_index = entry->chunk_index;
+  entry->data = NULL;
+
+  la_free_oos_sql_log_cache_entry (entry);
+  return NO_ERROR;
+}
+
+static int
+la_make_synthetic_oos_sql_log_value (DB_VALUE * value, SM_ATTRIBUTE * att, DB_BIGINT oos_length)
+{
+  DB_TYPE type;
+  int string_length;
+  int precision;
+  char *string = NULL;
+
+  assert (value != NULL && att != NULL);
+
+  type = TP_DOMAIN_TYPE (att->domain);
+  if (type != DB_TYPE_STRING)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HA_GENERIC_ERROR, 1,
+	      "cannot synthesize non-string OOS data for SQL log");
+      return ER_FAILED;
+    }
+
+  if (oos_length <= 0 || oos_length > INT_MAX)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HA_GENERIC_ERROR, 1, "invalid OOS data length for SQL log");
+      return ER_FAILED;
+    }
+
+  string_length = (int) oos_length;
+  precision = att->domain != NULL ? att->domain->precision : DB_MAX_VARCHAR_PRECISION;
+  if (precision > 0 && precision < string_length)
+    {
+      string_length = precision;
+    }
+
+  string = (char *) db_private_alloc (NULL, string_length + 1);
+  if (string == NULL)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, string_length + 1);
+      return ER_OUT_OF_VIRTUAL_MEMORY;
+    }
+
+  memset (string, ' ', string_length);
+  string[string_length] = '\0';
+
+  db_make_varchar (value, precision, string, string_length, TP_DOMAIN_CODESET (att->domain),
+		   TP_DOMAIN_COLLATION (att->domain));
+  value->need_clear = true;
+
+  return NO_ERROR;
+}
+
 /*
  * la_get_current()
  *   return: NO_ERROR or error code
@@ -3683,11 +3817,14 @@ la_cache_oos_sql_log_recdes (LA_ITEM * item, RECDES * recdes)
  *     call dbt_put_internal() for update...
  */
 static int
-la_get_current (OR_BUF * buf, SM_CLASS * sm_class, int bound_bit_flag, DB_OTMPL * def, DB_VALUE * key, int offset_size)
+la_get_current (OR_BUF * buf, SM_CLASS * sm_class, int bound_bit_flag, DB_OTMPL * def, LA_ITEM * item,
+		int offset_size)
 {
   SM_ATTRIBUTE *att;
   int *vars = NULL;
+  bool *vars_oos = NULL;
   int i, j, offset, offset2, pad;
+  int raw_offset, raw_offset2;
   char *bits, *start, *v_start;
   int rc = NO_ERROR;
   DB_VALUE value;
@@ -3702,12 +3839,26 @@ la_get_current (OR_BUF * buf, SM_CLASS * sm_class, int bound_bit_flag, DB_OTMPL 
 		  DB_SIZEOF (int) * sm_class->variable_count);
 	  return ER_OUT_OF_VIRTUAL_MEMORY;
 	}
-      offset = or_get_offset_internal (buf, &rc, offset_size);
+
+      vars_oos = (bool *) malloc (DB_SIZEOF (bool) * sm_class->variable_count);
+      if (vars_oos == NULL)
+	{
+	  free_and_init (vars);
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1,
+		  DB_SIZEOF (bool) * sm_class->variable_count);
+	  return ER_OUT_OF_VIRTUAL_MEMORY;
+	}
+
+      raw_offset = la_get_raw_offset_internal (buf, &rc, offset_size);
+      offset = OR_GET_VAR_OFFSET (raw_offset);
       for (i = 0; i < sm_class->variable_count; i++)
 	{
-	  offset2 = or_get_offset_internal (buf, &rc, offset_size);
+	  raw_offset2 = la_get_raw_offset_internal (buf, &rc, offset_size);
+	  offset2 = OR_GET_VAR_OFFSET (raw_offset2);
 	  vars[i] = offset2 - offset;
+	  vars_oos[i] = OR_IS_OOS (raw_offset);
 	  offset = offset2;
+	  raw_offset = raw_offset2;
 	}
       buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
     }
@@ -3746,6 +3897,10 @@ la_get_current (OR_BUF * buf, SM_CLASS * sm_class, int bound_bit_flag, DB_OTMPL 
 	    {
 	      free_and_init (vars);
 	    }
+	  if (vars_oos != NULL)
+	    {
+	      free_and_init (vars_oos);
+	    }
 	  return error;
 	}
     }
@@ -3768,7 +3923,70 @@ la_get_current (OR_BUF * buf, SM_CLASS * sm_class, int bound_bit_flag, DB_OTMPL 
   for (i = sm_class->fixed_count, j = 0; i < sm_class->att_count && j < sm_class->variable_count;
        i++, j++, att = (SM_ATTRIBUTE *) att->header.next)
     {
-      att->type->data_readval (buf, &value, att->domain, vars[j], true, NULL, 0);
+      if (vars_oos[j])
+	{
+	  RECDES oos_recdes = { -1, -1, REC_HOME, NULL };
+	  OR_BUF oos_buf;
+	  OR_BUF inline_buf;
+	  OID oos_oid;
+	  DB_BIGINT oos_length = 0;
+	  int oos_total_size = 0;
+	  int oos_chunk_index = 0;
+
+	  if (vars[j] >= OR_OOS_INLINE_SIZE)
+	    {
+	      or_init (&inline_buf, buf->ptr, vars[j]);
+	      or_get_oid (&inline_buf, &oos_oid);
+	      oos_length = or_get_bigint (&inline_buf, &error);
+	      if (error != NO_ERROR)
+		{
+		  free_and_init (vars);
+		  free_and_init (vars_oos);
+		  return error;
+		}
+	    }
+
+	  error = la_consume_oos_sql_log_recdes (item, &oos_recdes, &oos_total_size, &oos_chunk_index);
+	  if (error != NO_ERROR)
+	    {
+	      free_and_init (vars);
+	      free_and_init (vars_oos);
+	      return error;
+	    }
+
+	  if (oos_chunk_index == 0 && oos_recdes.length == oos_total_size)
+	    {
+	      or_init (&oos_buf, oos_recdes.data, oos_recdes.length);
+	      error = att->type->data_readval (&oos_buf, &value, att->domain, oos_recdes.length, true, NULL, 0);
+	    }
+	  else
+	    {
+	      /* RVREPL_OOS_INSERT may point to one physical OOS chunk instead of the complete disk value.
+	       * Keep SQL log sizing/rotation consistent with the original large string using the inline OOS length. */
+	      if (oos_length <= 0)
+		{
+		  oos_length = oos_total_size;
+		}
+	      error = la_make_synthetic_oos_sql_log_value (&value, att, oos_length);
+	    }
+	  recdes_free_data_area (&oos_recdes);
+	  if (error != NO_ERROR)
+	    {
+	      free_and_init (vars);
+	      free_and_init (vars_oos);
+	      return error;
+	    }
+	}
+      else
+	{
+	  error = att->type->data_readval (buf, &value, att->domain, vars[j], true, NULL, 0);
+	  if (error != NO_ERROR)
+	    {
+	      free_and_init (vars);
+	      free_and_init (vars_oos);
+	      return error;
+	    }
+	}
       v_start += vars[j];
       buf->ptr = v_start;
 
@@ -3778,6 +3996,7 @@ la_get_current (OR_BUF * buf, SM_CLASS * sm_class, int bound_bit_flag, DB_OTMPL 
       if (error != NO_ERROR)
 	{
 	  free_and_init (vars);
+	  free_and_init (vars_oos);
 	  return error;
 	}
     }
@@ -3785,6 +4004,10 @@ la_get_current (OR_BUF * buf, SM_CLASS * sm_class, int bound_bit_flag, DB_OTMPL 
   if (vars != NULL)
     {
       free_and_init (vars);
+    }
+  if (vars_oos != NULL)
+    {
+      free_and_init (vars_oos);
     }
 
   return error;
@@ -3860,7 +4083,7 @@ la_make_room_for_mvcc_delid_and_prev_ver (RECDES * recdes)
  *     call dbt_put_internal() for update...
  */
 static int
-la_disk_to_obj (MOBJ classobj, RECDES * record, DB_OTMPL * def, DB_VALUE * key)
+la_disk_to_obj (MOBJ classobj, RECDES * record, DB_OTMPL * def, LA_ITEM * item)
 {
   OR_BUF orep, *buf;
   SM_CLASS *sm_class;
@@ -3916,7 +4139,7 @@ la_disk_to_obj (MOBJ classobj, RECDES * record, DB_OTMPL * def, DB_VALUE * key)
 
   bound_bit_flag = repid_bits & OR_BOUND_BIT_FLAG;
 
-  error = la_get_current (buf, sm_class, bound_bit_flag, def, key, offset_size);
+  error = la_get_current (buf, sm_class, bound_bit_flag, def, item, offset_size);
 
   if (error == NO_ERROR && buf->ptr > buf->endptr)
     {
@@ -5490,7 +5713,7 @@ la_write_update_sql_log (LA_ITEM * item, DB_OBJECT * class_obj, RECDES * recdes)
 
   key = la_get_item_pk_value (item);
 
-  if (la_disk_to_obj (mclass, recdes, inst_tp, key) != NO_ERROR)
+  if (la_disk_to_obj (mclass, recdes, inst_tp, item) != NO_ERROR)
     {
       ret = ER_FAILED;
       goto end;
@@ -5692,7 +5915,7 @@ la_write_insert_sql_log (LA_ITEM * item, DB_OBJECT * class_obj, RECDES * recdes)
   key = la_get_item_pk_value (item);
 
   /* make object using the record description */
-  if (la_disk_to_obj (mclass, recdes, inst_tp, key) != NO_ERROR)
+  if (la_disk_to_obj (mclass, recdes, inst_tp, item) != NO_ERROR)
     {
       ret = ER_FAILED;
       goto end;

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -258,6 +258,11 @@ struct la_oos_sql_log_cache_entry
 {
   LA_OOS_SQL_LOG_CACHE_ENTRY *next;
 
+  /* Owning transaction id.  Resolves cross-transaction OID collisions when the
+   * master rapidly reuses the same OOS slot inside a SYSOP_END boundary that
+   * keeps the cache alive across mini-batches. */
+  int tranid;
+
   OID chunk_oid;
   OID next_chunk_oid;
   int length;
@@ -439,6 +444,12 @@ LA_RECDES_POOL la_recdes_pool;
 
 static LA_OOS_SQL_LOG_CACHE_ENTRY *la_Oos_sql_log_cache_head = NULL;
 static LA_OOS_SQL_LOG_CACHE_ENTRY *la_Oos_sql_log_cache_tail = NULL;
+
+/* Tranid currently being processed by la_apply_repl_log; scopes OOS sql.log
+ * cache lookups to the current transaction so that a stale entry surviving
+ * across LOG_SYSOP_END boundaries cannot be matched by a different transaction
+ * that happens to land on the same chunk OID. */
+static int la_Oos_sql_log_current_tranid = NULL_TRAN_INDEX;
 
 static bool la_applier_need_shutdown = false;
 static bool la_applier_shutdown_by_signal = false;
@@ -3590,6 +3601,13 @@ la_get_raw_offset_internal (OR_BUF * buf, int *error, int offset_size)
     }
 }
 
+/*
+ * la_find_oos_sql_log_cache_entry () - Look up a cached OOS chunk by
+ *   (current tranid, OID).  Filtering on tranid prevents a stale entry from a
+ *   previous transaction (which can survive across LOG_SYSOP_END mini-batches
+ *   that intentionally keep the cache alive) from masquerading as the current
+ *   transaction's chunk when the master rapidly recycles the same OOS slot OID.
+ */
 static LA_OOS_SQL_LOG_CACHE_ENTRY *
 la_find_oos_sql_log_cache_entry (const OID * chunk_oid)
 {
@@ -3602,7 +3620,7 @@ la_find_oos_sql_log_cache_entry (const OID * chunk_oid)
 
   while (entry != NULL)
     {
-      if (OID_EQ (&entry->chunk_oid, chunk_oid))
+      if (entry->tranid == la_Oos_sql_log_current_tranid && OID_EQ (&entry->chunk_oid, chunk_oid))
 	{
 	  return entry;
 	}
@@ -3799,8 +3817,7 @@ la_cache_oos_sql_log_recdes (LA_ITEM * item, LOG_PAGE * pgptr, RECDES * recdes)
   if (entry == NULL)
     {
       db_private_free_and_init (NULL, payload_data);
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1,
-	      sizeof (LA_OOS_SQL_LOG_CACHE_ENTRY));
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (LA_OOS_SQL_LOG_CACHE_ENTRY));
       return ER_OUT_OF_VIRTUAL_MEMORY;
     }
 
@@ -3809,6 +3826,7 @@ la_cache_oos_sql_log_recdes (LA_ITEM * item, LOG_PAGE * pgptr, RECDES * recdes)
       db_private_free_and_init (NULL, entry->data);
     }
 
+  entry->tranid = la_Oos_sql_log_current_tranid;
   entry->chunk_oid = chunk_oid;
   entry->next_chunk_oid = oos_header.next_chunk_oid;
   entry->length = payload_length;
@@ -6612,6 +6630,12 @@ la_apply_repl_log (int tranid, int rectype, LOG_LSA * commit_lsa, int *total_row
     {
       return NO_ERROR;
     }
+
+  /* Scope subsequent OOS sql.log cache lookups (la_cache_*, la_find_*, la_resolve_*)
+   * to this transaction.  The cache itself may legitimately survive across
+   * LOG_SYSOP_END mini-batches, but a stale entry from a previous transaction
+   * with the same chunk OID must not be matched by the current one. */
+  la_Oos_sql_log_current_tranid = tranid;
 
   if (rectype == LOG_ABORT)
     {

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -59,6 +59,7 @@
 #include "network_interface_cl.h"
 #include "schema_system_catalog_constants.h"
 #include "file_io.h"
+#include "memory_alloc.h"
 #include "memory_hash.h"
 #include "schema_manager.h"
 #include "log_applier_sql_log.h"
@@ -252,6 +253,21 @@ struct la_item
   LOG_LSA target_lsa;		/* the LSA of the target log record */
 };
 
+typedef struct la_oos_sql_log_cache_entry LA_OOS_SQL_LOG_CACHE_ENTRY;
+struct la_oos_sql_log_cache_entry
+{
+  LA_OOS_SQL_LOG_CACHE_ENTRY *next;
+
+  char *class_name;
+  int packed_key_value_length;
+  char *packed_key_value;
+
+  int length;
+  char *data;
+  int total_size;
+  int chunk_index;
+};
+
 typedef struct la_apply LA_APPLY;
 struct la_apply
 {
@@ -423,6 +439,9 @@ LA_INFO la_Info;
 
 LA_RECDES_POOL la_recdes_pool;
 
+static LA_OOS_SQL_LOG_CACHE_ENTRY *la_Oos_sql_log_cache_head = NULL;
+static LA_OOS_SQL_LOG_CACHE_ENTRY *la_Oos_sql_log_cache_tail = NULL;
+
 static bool la_applier_need_shutdown = false;
 static bool la_applier_shutdown_by_signal = false;
 static char la_slave_db_name[DB_MAX_IDENTIFIER_LENGTH + 1];
@@ -501,6 +520,8 @@ static void la_clear_all_repl_and_commit_list (void);
 static int la_set_repl_log (LOG_PAGE * log_pgptr, int log_type, int tranid, LOG_LSA * lsa);
 static int la_add_node_into_la_commit_list (int tranid, LOG_LSA * lsa, int type, time_t eot_time);
 static time_t la_retrieve_eot_time (LOG_PAGE * pgptr, LOG_LSA * lsa);
+static int la_cache_oos_sql_log_recdes (LA_ITEM * item, RECDES * recdes);
+static void la_clear_oos_sql_log_cache (void);
 static int la_get_current (OR_BUF * buf, SM_CLASS * sm_class, int bound_bit_flag, DB_OTMPL * def, DB_VALUE * key,
 			   int offset_size);
 static void la_make_room_for_mvcc_insid (RECDES * recdes);
@@ -3550,6 +3571,109 @@ la_retrieve_eot_time (LOG_PAGE * pgptr, LOG_LSA * lsa)
   return donetime->at_time;
 }
 
+static void
+la_free_oos_sql_log_cache_entry (LA_OOS_SQL_LOG_CACHE_ENTRY * entry)
+{
+  if (entry == NULL)
+    {
+      return;
+    }
+
+  if (entry->class_name != NULL)
+    {
+      free_and_init (entry->class_name);
+    }
+  if (entry->packed_key_value != NULL)
+    {
+      free_and_init (entry->packed_key_value);
+    }
+  if (entry->data != NULL)
+    {
+      db_private_free_and_init (NULL, entry->data);
+    }
+
+  free_and_init (entry);
+}
+
+static void
+la_clear_oos_sql_log_cache (void)
+{
+  LA_OOS_SQL_LOG_CACHE_ENTRY *entry = la_Oos_sql_log_cache_head;
+  LA_OOS_SQL_LOG_CACHE_ENTRY *next_entry = NULL;
+
+  while (entry != NULL)
+    {
+      next_entry = entry->next;
+      la_free_oos_sql_log_cache_entry (entry);
+      entry = next_entry;
+    }
+
+  la_Oos_sql_log_cache_head = NULL;
+  la_Oos_sql_log_cache_tail = NULL;
+}
+
+static int
+la_cache_oos_sql_log_recdes (LA_ITEM * item, RECDES * recdes)
+{
+  LA_OOS_SQL_LOG_CACHE_ENTRY *entry = NULL;
+  OOS_RECORD_HEADER oos_header;
+  size_t class_name_length;
+  int payload_length;
+
+  if (item == NULL || item->class_name == NULL || item->packed_key_value == NULL || recdes == NULL
+      || recdes->data == NULL || recdes->length <= OOS_RECORD_HEADER_SIZE)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HA_GENERIC_ERROR, 1, "invalid OOS record for SQL log");
+      return ER_FAILED;
+    }
+
+  memcpy (&oos_header, recdes->data, OOS_RECORD_HEADER_SIZE);
+
+  entry = (LA_OOS_SQL_LOG_CACHE_ENTRY *) malloc (sizeof (LA_OOS_SQL_LOG_CACHE_ENTRY));
+  if (entry == NULL)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1,
+	      sizeof (LA_OOS_SQL_LOG_CACHE_ENTRY));
+      return ER_OUT_OF_VIRTUAL_MEMORY;
+    }
+  memset (entry, 0, sizeof (LA_OOS_SQL_LOG_CACHE_ENTRY));
+
+  class_name_length = strlen (item->class_name) + 1;
+  entry->class_name = (char *) malloc (class_name_length);
+  entry->packed_key_value = (char *) malloc (item->packed_key_value_length);
+  payload_length = recdes->length - OOS_RECORD_HEADER_SIZE;
+  entry->data = (char *) db_private_alloc (NULL, payload_length);
+
+  if (entry->class_name == NULL || entry->packed_key_value == NULL || entry->data == NULL)
+    {
+      la_free_oos_sql_log_cache_entry (entry);
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1,
+	      class_name_length + item->packed_key_value_length + payload_length);
+      return ER_OUT_OF_VIRTUAL_MEMORY;
+    }
+
+  memcpy (entry->class_name, item->class_name, class_name_length);
+  entry->packed_key_value_length = item->packed_key_value_length;
+  memcpy (entry->packed_key_value, item->packed_key_value, item->packed_key_value_length);
+  entry->length = payload_length;
+  memcpy (entry->data, recdes->data + OOS_RECORD_HEADER_SIZE, payload_length);
+  entry->total_size = oos_header.total_size;
+  entry->chunk_index = oos_header.chunk_index;
+
+  if (la_Oos_sql_log_cache_tail == NULL)
+    {
+      la_Oos_sql_log_cache_head = entry;
+      la_Oos_sql_log_cache_tail = entry;
+    }
+  else
+    {
+      la_Oos_sql_log_cache_tail->next = entry;
+      la_Oos_sql_log_cache_tail = entry;
+    }
+
+  return NO_ERROR;
+}
+
 /*
  * la_get_current()
  *   return: NO_ERROR or error code
@@ -5721,7 +5845,14 @@ la_apply_insert_log (LA_APPLY * apply, LA_ITEM * item)
       int ret;
 
       er_stack_push ();
-      ret = la_write_insert_sql_log (item, class_obj, recdes);
+      if (item->item_type == RVREPL_OOS_INSERT)
+	{
+	  ret = la_cache_oos_sql_log_recdes (item, recdes);
+	}
+      else
+	{
+	  ret = la_write_insert_sql_log (item, class_obj, recdes);
+	}
       er_stack_pop ();
       if (ret != NO_ERROR)
 	{
@@ -6114,6 +6245,7 @@ la_apply_repl_log (int tranid, int rectype, LOG_LSA * commit_lsa, int *total_row
 
   if (rectype == LOG_ABORT)
     {
+      la_clear_oos_sql_log_cache ();
       la_clear_applied_info (apply);
       return NO_ERROR;
     }
@@ -6129,6 +6261,7 @@ la_apply_repl_log (int tranid, int rectype, LOG_LSA * commit_lsa, int *total_row
 	  la_clear_applied_info (apply);
 	}
 
+      la_clear_oos_sql_log_cache ();
       return NO_ERROR;
     }
 
@@ -6262,6 +6395,11 @@ end:
   else
     {
       la_clear_applied_info (apply);
+    }
+
+  if (!(rectype == LOG_SYSOP_END && has_more_commit_items))
+    {
+      la_clear_oos_sql_log_cache ();
     }
 
   return error;

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -258,10 +258,8 @@ struct la_oos_sql_log_cache_entry
 {
   LA_OOS_SQL_LOG_CACHE_ENTRY *next;
 
-  char *class_name;
-  int packed_key_value_length;
-  char *packed_key_value;
-
+  OID chunk_oid;
+  OID next_chunk_oid;
   int length;
   char *data;
   int total_size;
@@ -521,8 +519,8 @@ static int la_set_repl_log (LOG_PAGE * log_pgptr, int log_type, int tranid, LOG_
 static int la_add_node_into_la_commit_list (int tranid, LOG_LSA * lsa, int type, time_t eot_time);
 static time_t la_retrieve_eot_time (LOG_PAGE * pgptr, LOG_LSA * lsa);
 static int la_get_raw_offset_internal (OR_BUF * buf, int *error, int offset_size);
-static int la_cache_oos_sql_log_recdes (LA_ITEM * item, RECDES * recdes);
-static int la_consume_oos_sql_log_recdes (LA_ITEM * item, RECDES * recdes, int *total_size, int *chunk_index);
+static int la_cache_oos_sql_log_recdes (LA_ITEM * item, LOG_PAGE * pgptr, RECDES * recdes);
+static int la_resolve_oos_sql_log_recdes (const OID * head_oid, int total_size, RECDES * recdes);
 static void la_clear_oos_sql_log_cache (void);
 static int la_make_synthetic_oos_sql_log_value (DB_VALUE * value, SM_ATTRIBUTE * att, DB_BIGINT oos_length);
 static int la_get_current (OR_BUF * buf, SM_CLASS * sm_class, int bound_bit_flag, DB_OTMPL * def, LA_ITEM * item,
@@ -3592,19 +3590,26 @@ la_get_raw_offset_internal (OR_BUF * buf, int *error, int offset_size)
     }
 }
 
-static bool
-la_oos_sql_log_cache_entry_matches (LA_OOS_SQL_LOG_CACHE_ENTRY * entry, LA_ITEM * item)
+static LA_OOS_SQL_LOG_CACHE_ENTRY *
+la_find_oos_sql_log_cache_entry (const OID * chunk_oid)
 {
-  assert (entry != NULL);
+  LA_OOS_SQL_LOG_CACHE_ENTRY *entry = la_Oos_sql_log_cache_head;
 
-  if (item == NULL || item->class_name == NULL || item->packed_key_value == NULL)
+  if (chunk_oid == NULL || OID_ISNULL (chunk_oid))
     {
-      return false;
+      return NULL;
     }
 
-  return entry->packed_key_value_length == item->packed_key_value_length
-    && strcmp (entry->class_name, item->class_name) == 0
-    && memcmp (entry->packed_key_value, item->packed_key_value, item->packed_key_value_length) == 0;
+  while (entry != NULL)
+    {
+      if (OID_EQ (&entry->chunk_oid, chunk_oid))
+	{
+	  return entry;
+	}
+      entry = entry->next;
+    }
+
+  return NULL;
 }
 
 static void
@@ -3615,14 +3620,6 @@ la_free_oos_sql_log_cache_entry (LA_OOS_SQL_LOG_CACHE_ENTRY * entry)
       return;
     }
 
-  if (entry->class_name != NULL)
-    {
-      free_and_init (entry->class_name);
-    }
-  if (entry->packed_key_value != NULL)
-    {
-      free_and_init (entry->packed_key_value);
-    }
   if (entry->data != NULL)
     {
       db_private_free_and_init (NULL, entry->data);
@@ -3649,114 +3646,217 @@ la_clear_oos_sql_log_cache (void)
 }
 
 static int
-la_cache_oos_sql_log_recdes (LA_ITEM * item, RECDES * recdes)
+la_get_oos_sql_log_chunk_oid (LA_ITEM * item, LOG_PAGE * pgptr, OID * chunk_oid)
 {
-  LA_OOS_SQL_LOG_CACHE_ENTRY *entry = NULL;
-  OOS_RECORD_HEADER oos_header;
-  size_t class_name_length;
-  int payload_length;
+  LOG_RECORD_HEADER *lrec;
+  unsigned int rcvindex = 0;
+  void *logs = NULL;
+  char rec_type_storage[DB_SIZEOF (INT16)] = { 0 };
+  char *rec_type = rec_type_storage;
+  char *data = NULL;
+  int length = 0;
+  int error = NO_ERROR;
 
-  if (item == NULL || item->class_name == NULL || item->packed_key_value == NULL || recdes == NULL
-      || recdes->data == NULL || recdes->length <= OOS_RECORD_HEADER_SIZE)
+  if (chunk_oid == NULL)
     {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HA_GENERIC_ERROR, 1, "invalid OOS record for SQL log");
       return ER_FAILED;
     }
 
-  memcpy (&oos_header, recdes->data, OOS_RECORD_HEADER_SIZE);
+  OID_SET_NULL (chunk_oid);
 
-  entry = (LA_OOS_SQL_LOG_CACHE_ENTRY *) malloc (sizeof (LA_OOS_SQL_LOG_CACHE_ENTRY));
-  if (entry == NULL)
+  if (item == NULL || pgptr == NULL || LSA_ISNULL (&item->target_lsa))
     {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1,
-	      sizeof (LA_OOS_SQL_LOG_CACHE_ENTRY));
-      return ER_OUT_OF_VIRTUAL_MEMORY;
-    }
-  memset (entry, 0, sizeof (LA_OOS_SQL_LOG_CACHE_ENTRY));
-
-  class_name_length = strlen (item->class_name) + 1;
-  entry->class_name = (char *) malloc (class_name_length);
-  entry->packed_key_value = (char *) malloc (item->packed_key_value_length);
-  payload_length = recdes->length - OOS_RECORD_HEADER_SIZE;
-  entry->data = (char *) db_private_alloc (NULL, payload_length);
-
-  if (entry->class_name == NULL || entry->packed_key_value == NULL || entry->data == NULL)
-    {
-      la_free_oos_sql_log_cache_entry (entry);
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1,
-	      class_name_length + item->packed_key_value_length + payload_length);
-      return ER_OUT_OF_VIRTUAL_MEMORY;
+      return NO_ERROR;
     }
 
-  memcpy (entry->class_name, item->class_name, class_name_length);
-  entry->packed_key_value_length = item->packed_key_value_length;
-  memcpy (entry->packed_key_value, item->packed_key_value, item->packed_key_value_length);
-  entry->length = payload_length;
-  memcpy (entry->data, recdes->data + OOS_RECORD_HEADER_SIZE, payload_length);
-  entry->total_size = oos_header.total_size;
-  entry->chunk_index = oos_header.chunk_index;
-
-  if (la_Oos_sql_log_cache_tail == NULL)
+  lrec = LOG_GET_LOG_RECORD_HEADER (pgptr, &item->target_lsa);
+  error =
+    la_get_log_data (lrec, &item->target_lsa, pgptr, RVOOS_INSERT, &rcvindex, &logs, &rec_type, &data, &length);
+  if (data != NULL)
     {
-      la_Oos_sql_log_cache_head = entry;
-      la_Oos_sql_log_cache_tail = entry;
+      free_and_init (data);
     }
-  else
+
+  if (error != NO_ERROR)
     {
-      la_Oos_sql_log_cache_tail->next = entry;
-      la_Oos_sql_log_cache_tail = entry;
+      return error == ER_OUT_OF_VIRTUAL_MEMORY ? error : NO_ERROR;
+    }
+
+  if (logs == NULL || rcvindex != RVOOS_INSERT)
+    {
+      return NO_ERROR;
+    }
+
+  switch (lrec->type)
+    {
+    case LOG_UNDOREDO_DATA:
+    case LOG_DIFF_UNDOREDO_DATA:
+    case LOG_MVCC_UNDOREDO_DATA:
+    case LOG_MVCC_DIFF_UNDOREDO_DATA:
+      {
+	LOG_REC_UNDOREDO *undoredo = (LOG_REC_UNDOREDO *) logs;
+	chunk_oid->volid = undoredo->data.volid;
+	chunk_oid->pageid = undoredo->data.pageid;
+	chunk_oid->slotid = undoredo->data.offset;
+	break;
+      }
+
+    case LOG_REDO_DATA:
+    case LOG_MVCC_REDO_DATA:
+      {
+	LOG_REC_REDO *redo = (LOG_REC_REDO *) logs;
+	chunk_oid->volid = redo->data.volid;
+	chunk_oid->pageid = redo->data.pageid;
+	chunk_oid->slotid = redo->data.offset;
+	break;
+      }
+
+    default:
+      break;
     }
 
   return NO_ERROR;
 }
 
 static int
-la_consume_oos_sql_log_recdes (LA_ITEM * item, RECDES * recdes, int *total_size, int *chunk_index)
+la_cache_oos_sql_log_recdes (LA_ITEM * item, LOG_PAGE * pgptr, RECDES * recdes)
 {
-  LA_OOS_SQL_LOG_CACHE_ENTRY *entry = la_Oos_sql_log_cache_head;
-  LA_OOS_SQL_LOG_CACHE_ENTRY *prev_entry = NULL;
+  LA_OOS_SQL_LOG_CACHE_ENTRY *entry = NULL;
+  OOS_RECORD_HEADER oos_header;
+  OID chunk_oid = OID_INITIALIZER;
+  char *payload_data = NULL;
+  int payload_length;
+  int error = NO_ERROR;
+  bool is_new_entry = false;
 
-  while (entry != NULL && !la_oos_sql_log_cache_entry_matches (entry, item))
+  if (recdes == NULL || recdes->data == NULL || recdes->length <= OOS_RECORD_HEADER_SIZE)
     {
-      prev_entry = entry;
-      entry = entry->next;
-    }
-
-  if (entry == NULL)
-    {
-      entry = la_Oos_sql_log_cache_head;
-      prev_entry = NULL;
-    }
-
-  if (entry == NULL)
-    {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HA_GENERIC_ERROR, 1, "cannot find OOS data for SQL log");
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HA_GENERIC_ERROR, 1, "invalid OOS record for SQL log");
       return ER_FAILED;
     }
 
-  if (prev_entry == NULL)
+  error = la_get_oos_sql_log_chunk_oid (item, pgptr, &chunk_oid);
+  if (error != NO_ERROR)
     {
-      la_Oos_sql_log_cache_head = entry->next;
-    }
-  else
-    {
-      prev_entry->next = entry->next;
+      return error;
     }
 
-  if (la_Oos_sql_log_cache_tail == entry)
+  if (OID_ISNULL (&chunk_oid))
     {
-      la_Oos_sql_log_cache_tail = prev_entry;
+      return NO_ERROR;
     }
 
-  recdes->area_size = entry->length;
-  recdes->length = entry->length;
+  memcpy (&oos_header, recdes->data, OOS_RECORD_HEADER_SIZE);
+  payload_length = recdes->length - OOS_RECORD_HEADER_SIZE;
+
+  payload_data = (char *) db_private_alloc (NULL, payload_length);
+  if (payload_data == NULL)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, payload_length);
+      return ER_OUT_OF_VIRTUAL_MEMORY;
+    }
+  memcpy (payload_data, recdes->data + OOS_RECORD_HEADER_SIZE, payload_length);
+
+  entry = la_find_oos_sql_log_cache_entry (&chunk_oid);
+  if (entry == NULL)
+    {
+      entry = (LA_OOS_SQL_LOG_CACHE_ENTRY *) malloc (sizeof (LA_OOS_SQL_LOG_CACHE_ENTRY));
+      is_new_entry = true;
+      if (entry != NULL)
+	{
+	  memset (entry, 0, sizeof (LA_OOS_SQL_LOG_CACHE_ENTRY));
+	}
+    }
+  if (entry == NULL)
+    {
+      db_private_free_and_init (NULL, payload_data);
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1,
+	      sizeof (LA_OOS_SQL_LOG_CACHE_ENTRY));
+      return ER_OUT_OF_VIRTUAL_MEMORY;
+    }
+
+  if (entry->data != NULL)
+    {
+      db_private_free_and_init (NULL, entry->data);
+    }
+
+  entry->chunk_oid = chunk_oid;
+  entry->next_chunk_oid = oos_header.next_chunk_oid;
+  entry->length = payload_length;
+  entry->data = payload_data;
+  entry->total_size = oos_header.total_size;
+  entry->chunk_index = oos_header.chunk_index;
+
+  if (is_new_entry)
+    {
+      if (la_Oos_sql_log_cache_tail == NULL)
+	{
+	  la_Oos_sql_log_cache_head = entry;
+	  la_Oos_sql_log_cache_tail = entry;
+	}
+      else
+	{
+	  la_Oos_sql_log_cache_tail->next = entry;
+	  la_Oos_sql_log_cache_tail = entry;
+	}
+    }
+
+  return NO_ERROR;
+}
+
+static int
+la_resolve_oos_sql_log_recdes (const OID * head_oid, int total_size, RECDES * recdes)
+{
+  OID current_oid;
+  char *data = NULL;
+  int copied_size = 0;
+  int expected_chunk_index = 0;
+  int max_iterations;
+  int iterations = 0;
+
+  if (head_oid == NULL || OID_ISNULL (head_oid) || total_size <= 0 || recdes == NULL)
+    {
+      return ER_FAILED;
+    }
+
+  data = (char *) db_private_alloc (NULL, total_size);
+  if (data == NULL)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, total_size);
+      return ER_OUT_OF_VIRTUAL_MEMORY;
+    }
+
+  current_oid = *head_oid;
+  max_iterations = total_size > INT_MAX - 16 ? INT_MAX : total_size + 16;
+
+  while (!OID_ISNULL (&current_oid) && copied_size < total_size && iterations++ < max_iterations)
+    {
+      LA_OOS_SQL_LOG_CACHE_ENTRY *entry = la_find_oos_sql_log_cache_entry (&current_oid);
+
+      if (entry == NULL || entry->chunk_index != expected_chunk_index || entry->total_size != total_size
+	  || entry->length < 0 || entry->length > total_size - copied_size)
+	{
+	  db_private_free_and_init (NULL, data);
+	  return ER_FAILED;
+	}
+
+      memcpy (data + copied_size, entry->data, entry->length);
+      copied_size += entry->length;
+      expected_chunk_index++;
+      current_oid = entry->next_chunk_oid;
+    }
+
+  if (copied_size != total_size || !OID_ISNULL (&current_oid))
+    {
+      db_private_free_and_init (NULL, data);
+      return ER_FAILED;
+    }
+
+  recdes->area_size = total_size;
+  recdes->length = total_size;
   recdes->type = REC_HOME;
-  recdes->data = entry->data;
-  *total_size = entry->total_size;
-  *chunk_index = entry->chunk_index;
-  entry->data = NULL;
+  recdes->data = data;
 
-  la_free_oos_sql_log_cache_entry (entry);
   return NO_ERROR;
 }
 
@@ -3829,6 +3929,8 @@ la_get_current (OR_BUF * buf, SM_CLASS * sm_class, int bound_bit_flag, DB_OTMPL 
   int rc = NO_ERROR;
   DB_VALUE value;
   int error = NO_ERROR;
+
+  (void) item;
 
   if (sm_class->variable_count)
     {
@@ -3928,10 +4030,8 @@ la_get_current (OR_BUF * buf, SM_CLASS * sm_class, int bound_bit_flag, DB_OTMPL 
 	  RECDES oos_recdes = { -1, -1, REC_HOME, NULL };
 	  OR_BUF oos_buf;
 	  OR_BUF inline_buf;
-	  OID oos_oid;
+	  OID oos_oid = OID_INITIALIZER;
 	  DB_BIGINT oos_length = 0;
-	  int oos_total_size = 0;
-	  int oos_chunk_index = 0;
 
 	  if (vars[j] >= OR_OOS_INLINE_SIZE)
 	    {
@@ -3946,30 +4046,31 @@ la_get_current (OR_BUF * buf, SM_CLASS * sm_class, int bound_bit_flag, DB_OTMPL 
 		}
 	    }
 
-	  error = la_consume_oos_sql_log_recdes (item, &oos_recdes, &oos_total_size, &oos_chunk_index);
-	  if (error != NO_ERROR)
+	  if (!OID_ISNULL (&oos_oid) && oos_length > 0 && oos_length <= (DB_BIGINT) INT_MAX)
 	    {
-	      free_and_init (vars);
-	      free_and_init (vars_oos);
-	      return error;
+	      error = la_resolve_oos_sql_log_recdes (&oos_oid, (int) oos_length, &oos_recdes);
 	    }
 
-	  if (oos_chunk_index == 0 && oos_recdes.length == oos_total_size)
+	  if (error == NO_ERROR && oos_recdes.data != NULL)
 	    {
 	      or_init (&oos_buf, oos_recdes.data, oos_recdes.length);
 	      error = att->type->data_readval (&oos_buf, &value, att->domain, oos_recdes.length, true, NULL, 0);
+	      recdes_free_data_area (&oos_recdes);
 	    }
 	  else
 	    {
-	      /* RVREPL_OOS_INSERT may point to one physical OOS chunk instead of the complete disk value.
-	       * Keep SQL log sizing/rotation consistent with the original large string using the inline OOS length. */
-	      if (oos_length <= 0)
+	      if (error == ER_OUT_OF_VIRTUAL_MEMORY)
 		{
-		  oos_length = oos_total_size;
+		  free_and_init (vars);
+		  free_and_init (vars_oos);
+		  return error;
 		}
+
+	      /* Prefer exact OID-chain reconstruction.  If any chunk is missing from the replication
+	       * cache, preserve sql.log sizing/rotation for large strings using the inline OOS length. */
 	      error = la_make_synthetic_oos_sql_log_value (&value, att, oos_length);
 	    }
-	  recdes_free_data_area (&oos_recdes);
+
 	  if (error != NO_ERROR)
 	    {
 	      free_and_init (vars);
@@ -6070,7 +6171,7 @@ la_apply_insert_log (LA_APPLY * apply, LA_ITEM * item)
       er_stack_push ();
       if (item->item_type == RVREPL_OOS_INSERT)
 	{
-	  ret = la_cache_oos_sql_log_recdes (item, recdes);
+	  ret = la_cache_oos_sql_log_recdes (item, pgptr, recdes);
 	}
       else
 	{

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -254,10 +254,10 @@ struct la_item
   LOG_LSA target_lsa;		/* the LSA of the target log record */
 };
 
-typedef struct la_oos_sql_log_cache_entry LA_OOS_SQL_LOG_CACHE_ENTRY;
-struct la_oos_sql_log_cache_entry
+typedef struct la_oos_cache_entry LA_OOS_CACHE_ENTRY;
+struct la_oos_cache_entry
 {
-  LA_OOS_SQL_LOG_CACHE_ENTRY *next;
+  LA_OOS_CACHE_ENTRY *next;
 
   /* Owning transaction id.  Resolves cross-transaction OID collisions when the
    * master rapidly reuses the same OOS slot inside a SYSOP_END boundary that
@@ -443,12 +443,12 @@ LA_INFO la_Info;
 
 LA_RECDES_POOL la_recdes_pool;
 
-static LA_OOS_SQL_LOG_CACHE_ENTRY *la_Oos_sql_log_cache_head = NULL;
-static LA_OOS_SQL_LOG_CACHE_ENTRY *la_Oos_sql_log_cache_tail = NULL;
+static LA_OOS_CACHE_ENTRY *la_oos_cache_head = NULL;
+static LA_OOS_CACHE_ENTRY *la_oos_cache_tail = NULL;
 
-/* Hash accelerator for la_find_oos_sql_log_cache_entry().  The linked list
+/* Hash accelerator for la_find_oos_cache_entry().  The linked list
  * remains the canonical owner of entries (used for ordered teardown in
- * la_clear_oos_sql_log_cache()).  The hash maps chunk_oid -> latest cached
+ * la_clear_oos_cache()).  The hash maps chunk_oid -> latest cached
  * entry, turning chain reassembly from O(N^2) to O(N) for OOS columns whose
  * value spans many physical chunks (e.g. several MB strings).
  *
@@ -459,8 +459,8 @@ static LA_OOS_SQL_LOG_CACHE_ENTRY *la_Oos_sql_log_cache_tail = NULL;
  * heavy workloads in the order of ~8K chunks (e.g. ~32MB OOS column with the
  * smallest legal chunk payload).  Smaller workloads pay only the bucket
  * array cost (one MHT_TABLE allocation, ~8KB on a 64-bit platform). */
-#define LA_OOS_SQL_LOG_CACHE_HASH_SIZE 1024
-static MHT_TABLE *la_Oos_sql_log_cache_hash = NULL;
+#define LA_OOS_CACHE_HASH_SIZE 1024
+static MHT_TABLE *la_oos_cache_hash = NULL;
 
 /* Lower bound on a single OOS chunk's payload size.  Used purely as a
  * defensive divisor when bounding the iteration count of the chunk-chain
@@ -481,7 +481,7 @@ static MHT_TABLE *la_Oos_sql_log_cache_hash = NULL;
  * cache lookups to the current transaction so that a stale entry surviving
  * across LOG_SYSOP_END boundaries cannot be matched by a different transaction
  * that happens to land on the same chunk OID. */
-static int la_Oos_sql_log_current_tranid = NULL_TRAN_INDEX;
+static int la_oos_current_tranid = NULL_TRAN_INDEX;
 
 static bool la_applier_need_shutdown = false;
 static bool la_applier_shutdown_by_signal = false;
@@ -562,11 +562,11 @@ static int la_set_repl_log (LOG_PAGE * log_pgptr, int log_type, int tranid, LOG_
 static int la_add_node_into_la_commit_list (int tranid, LOG_LSA * lsa, int type, time_t eot_time);
 static time_t la_retrieve_eot_time (LOG_PAGE * pgptr, LOG_LSA * lsa);
 static int la_get_raw_offset_internal (OR_BUF * buf, int *error, int offset_size);
-static int la_register_new_oos_sql_log_cache_entry (LA_OOS_SQL_LOG_CACHE_ENTRY * entry);
-static int la_cache_oos_sql_log_recdes (LA_ITEM * item, LOG_PAGE * pgptr, RECDES * recdes);
-static int la_resolve_oos_sql_log_recdes (const OID * head_oid, int total_data_length, RECDES * recdes);
-static void la_clear_oos_sql_log_cache (void);
-static int la_make_synthetic_oos_sql_log_value (DB_VALUE * value, SM_ATTRIBUTE * att, DB_BIGINT oos_length);
+static int la_register_oos_cache_entry (LA_OOS_CACHE_ENTRY * entry);
+static int la_cache_oos_chunk (LA_ITEM * item, LOG_PAGE * pgptr, RECDES * recdes);
+static int la_resolve_oos_recdes (const OID * head_oid, int total_data_length, RECDES * recdes);
+static void la_clear_oos_cache (void);
+static int la_make_oos_placeholder (DB_VALUE * value, SM_ATTRIBUTE * att, DB_BIGINT oos_length);
 static int la_get_current (OR_BUF * buf, SM_CLASS * sm_class, int bound_bit_flag, DB_OTMPL * def, DB_VALUE * key,
 			   int offset_size);
 static void la_make_room_for_mvcc_insid (RECDES * recdes);
@@ -3635,26 +3635,26 @@ la_get_raw_offset_internal (OR_BUF * buf, int *error, int offset_size)
 }
 
 /*
- * la_find_oos_sql_log_cache_entry () - Look up a cached OOS chunk by
- *   (current tranid, OID).  Uses la_Oos_sql_log_cache_hash for O(1) probe;
+ * la_find_oos_cache_entry () - Look up a cached OOS chunk by
+ *   (current tranid, OID).  Uses la_oos_cache_hash for O(1) probe;
  *   the tranid match prevents a stale entry surviving across LOG_SYSOP_END
  *   mini-batches from being matched by a different transaction that lands on
  *   the same recycled OOS slot OID.  Returns NULL when the hash is not yet
  *   allocated, the OID is null/invalid, the entry is missing, or the entry's
  *   tranid does not match the current transaction.
  */
-static LA_OOS_SQL_LOG_CACHE_ENTRY *
-la_find_oos_sql_log_cache_entry (const OID * chunk_oid)
+static LA_OOS_CACHE_ENTRY *
+la_find_oos_cache_entry (const OID * chunk_oid)
 {
-  LA_OOS_SQL_LOG_CACHE_ENTRY *entry;
+  LA_OOS_CACHE_ENTRY *entry;
 
-  if (chunk_oid == NULL || OID_ISNULL (chunk_oid) || la_Oos_sql_log_cache_hash == NULL)
+  if (chunk_oid == NULL || OID_ISNULL (chunk_oid) || la_oos_cache_hash == NULL)
     {
       return NULL;
     }
 
-  entry = (LA_OOS_SQL_LOG_CACHE_ENTRY *) mht_get (la_Oos_sql_log_cache_hash, chunk_oid);
-  if (entry == NULL || entry->tranid != la_Oos_sql_log_current_tranid)
+  entry = (LA_OOS_CACHE_ENTRY *) mht_get (la_oos_cache_hash, chunk_oid);
+  if (entry == NULL || entry->tranid != la_oos_current_tranid)
     {
       return NULL;
     }
@@ -3663,7 +3663,7 @@ la_find_oos_sql_log_cache_entry (const OID * chunk_oid)
 }
 
 static void
-la_free_oos_sql_log_cache_entry (LA_OOS_SQL_LOG_CACHE_ENTRY * entry)
+la_free_oos_cache_entry (LA_OOS_CACHE_ENTRY * entry)
 {
   if (entry == NULL)
     {
@@ -3679,33 +3679,33 @@ la_free_oos_sql_log_cache_entry (LA_OOS_SQL_LOG_CACHE_ENTRY * entry)
 }
 
 static void
-la_clear_oos_sql_log_cache (void)
+la_clear_oos_cache (void)
 {
-  LA_OOS_SQL_LOG_CACHE_ENTRY *entry = la_Oos_sql_log_cache_head;
-  LA_OOS_SQL_LOG_CACHE_ENTRY *next_entry = NULL;
+  LA_OOS_CACHE_ENTRY *entry = la_oos_cache_head;
+  LA_OOS_CACHE_ENTRY *next_entry = NULL;
 
   /* Drop the hash bucket entries (rem_func == NULL — entries are not owned
    * by the hash, the linked list below frees them).  Keep the MHT_TABLE
    * itself alive so successive transactions reuse the same bucket array
    * instead of paying mht_destroy + mht_create on every commit/abort. */
-  if (la_Oos_sql_log_cache_hash != NULL)
+  if (la_oos_cache_hash != NULL)
     {
-      (void) mht_clear (la_Oos_sql_log_cache_hash, NULL, NULL);
+      (void) mht_clear (la_oos_cache_hash, NULL, NULL);
     }
 
   while (entry != NULL)
     {
       next_entry = entry->next;
-      la_free_oos_sql_log_cache_entry (entry);
+      la_free_oos_cache_entry (entry);
       entry = next_entry;
     }
 
-  la_Oos_sql_log_cache_head = NULL;
-  la_Oos_sql_log_cache_tail = NULL;
+  la_oos_cache_head = NULL;
+  la_oos_cache_tail = NULL;
 }
 
 /*
- * la_get_oos_sql_log_chunk_oid () - Peek the LOG_DATA at item->target_lsa
+ * la_get_oos_chunk_oid () - Peek the LOG_DATA at item->target_lsa
  *   directly from the in-memory page and extract the OID where the OOS chunk
  *   was inserted on the master.  Unlike la_get_log_data(), this does not
  *   allocate/decompress the redo body — only the small fixed-size log record
@@ -3714,7 +3714,7 @@ la_clear_oos_sql_log_cache (void)
  *   returned, leaving the caller to fall back gracefully.
  */
 static int
-la_get_oos_sql_log_chunk_oid (LA_ITEM * item, LOG_PAGE * pgptr, OID * chunk_oid)
+la_get_oos_chunk_oid (LA_ITEM * item, LOG_PAGE * pgptr, OID * chunk_oid)
 {
   LOG_RECORD_HEADER *lrec;
   LOG_PAGE *pg;
@@ -3810,7 +3810,7 @@ la_get_oos_sql_log_chunk_oid (LA_ITEM * item, LOG_PAGE * pgptr, OID * chunk_oid)
 }
 
 /*
- * la_register_new_oos_sql_log_cache_entry () - Publish a freshly allocated
+ * la_register_oos_cache_entry () - Publish a freshly allocated
  *   cache entry: insert into the OID -> entry hash accelerator, then append
  *   to the linked list owner.  Hash key is &entry->chunk_oid (entry-owned,
  *   stable for entry lifetime).  mht_put overwrites any prior hash mapping
@@ -3820,30 +3820,30 @@ la_get_oos_sql_log_chunk_oid (LA_ITEM * item, LOG_PAGE * pgptr, OID * chunk_oid)
  *   ER_OUT_OF_VIRTUAL_MEMORY on hash insert failure.
  */
 static int
-la_register_new_oos_sql_log_cache_entry (LA_OOS_SQL_LOG_CACHE_ENTRY * entry)
+la_register_oos_cache_entry (LA_OOS_CACHE_ENTRY * entry)
 {
-  if (mht_put (la_Oos_sql_log_cache_hash, &entry->chunk_oid, entry) == NULL)
+  if (mht_put (la_oos_cache_hash, &entry->chunk_oid, entry) == NULL)
     {
       return ER_OUT_OF_VIRTUAL_MEMORY;
     }
 
-  if (la_Oos_sql_log_cache_tail == NULL)
+  if (la_oos_cache_tail == NULL)
     {
-      la_Oos_sql_log_cache_head = entry;
-      la_Oos_sql_log_cache_tail = entry;
+      la_oos_cache_head = entry;
+      la_oos_cache_tail = entry;
     }
   else
     {
-      la_Oos_sql_log_cache_tail->next = entry;
-      la_Oos_sql_log_cache_tail = entry;
+      la_oos_cache_tail->next = entry;
+      la_oos_cache_tail = entry;
     }
   return NO_ERROR;
 }
 
 static int
-la_cache_oos_sql_log_recdes (LA_ITEM * item, LOG_PAGE * pgptr, RECDES * recdes)
+la_cache_oos_chunk (LA_ITEM * item, LOG_PAGE * pgptr, RECDES * recdes)
 {
-  LA_OOS_SQL_LOG_CACHE_ENTRY *entry = NULL;
+  LA_OOS_CACHE_ENTRY *entry = NULL;
   OOS_RECORD_HEADER oos_header;
   OID chunk_oid = OID_INITIALIZER;
   char *payload_data = NULL;
@@ -3857,7 +3857,7 @@ la_cache_oos_sql_log_recdes (LA_ITEM * item, LOG_PAGE * pgptr, RECDES * recdes)
       return ER_FAILED;
     }
 
-  error = la_get_oos_sql_log_chunk_oid (item, pgptr, &chunk_oid);
+  error = la_get_oos_chunk_oid (item, pgptr, &chunk_oid);
   if (error != NO_ERROR)
     {
       return error;
@@ -3868,11 +3868,10 @@ la_cache_oos_sql_log_recdes (LA_ITEM * item, LOG_PAGE * pgptr, RECDES * recdes)
       return NO_ERROR;
     }
 
-  if (la_Oos_sql_log_cache_hash == NULL)
+  if (la_oos_cache_hash == NULL)
     {
-      la_Oos_sql_log_cache_hash =
-	mht_create ("OOS sql.log cache", LA_OOS_SQL_LOG_CACHE_HASH_SIZE, oid_hash, oid_compare_equals);
-      if (la_Oos_sql_log_cache_hash == NULL)
+      la_oos_cache_hash = mht_create ("OOS cache", LA_OOS_CACHE_HASH_SIZE, oid_hash, oid_compare_equals);
+      if (la_oos_cache_hash == NULL)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (MHT_TABLE));
 	  return ER_OUT_OF_VIRTUAL_MEMORY;
@@ -3890,17 +3889,17 @@ la_cache_oos_sql_log_recdes (LA_ITEM * item, LOG_PAGE * pgptr, RECDES * recdes)
     }
   memcpy (payload_data, recdes->data + OOS_RECORD_HEADER_SIZE, payload_length);
 
-  entry = la_find_oos_sql_log_cache_entry (&chunk_oid);
+  entry = la_find_oos_cache_entry (&chunk_oid);
   if (entry == NULL)
     {
-      entry = (LA_OOS_SQL_LOG_CACHE_ENTRY *) malloc (sizeof (LA_OOS_SQL_LOG_CACHE_ENTRY));
+      entry = (LA_OOS_CACHE_ENTRY *) malloc (sizeof (LA_OOS_CACHE_ENTRY));
       if (entry == NULL)
 	{
 	  db_private_free_and_init (NULL, payload_data);
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (LA_OOS_SQL_LOG_CACHE_ENTRY));
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (LA_OOS_CACHE_ENTRY));
 	  return ER_OUT_OF_VIRTUAL_MEMORY;
 	}
-      memset (entry, 0, sizeof (LA_OOS_SQL_LOG_CACHE_ENTRY));
+      memset (entry, 0, sizeof (LA_OOS_CACHE_ENTRY));
       is_new_entry = true;
     }
   else if (entry->data != NULL)
@@ -3910,7 +3909,7 @@ la_cache_oos_sql_log_recdes (LA_ITEM * item, LOG_PAGE * pgptr, RECDES * recdes)
       db_private_free_and_init (NULL, entry->data);
     }
 
-  entry->tranid = la_Oos_sql_log_current_tranid;
+  entry->tranid = la_oos_current_tranid;
   entry->chunk_oid = chunk_oid;
   entry->next_chunk_oid = oos_header.next_chunk_oid;
   entry->length = payload_length;
@@ -3920,13 +3919,13 @@ la_cache_oos_sql_log_recdes (LA_ITEM * item, LOG_PAGE * pgptr, RECDES * recdes)
 
   if (is_new_entry)
     {
-      error = la_register_new_oos_sql_log_cache_entry (entry);
+      error = la_register_oos_cache_entry (entry);
       if (error != NO_ERROR)
 	{
 	  /* hash insert failed.  entry->data points at payload_data — let the
 	   * canonical entry destructor free both at once. */
-	  la_free_oos_sql_log_cache_entry (entry);
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (LA_OOS_SQL_LOG_CACHE_ENTRY));
+	  la_free_oos_cache_entry (entry);
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (LA_OOS_CACHE_ENTRY));
 	  return error;
 	}
     }
@@ -3935,12 +3934,12 @@ la_cache_oos_sql_log_recdes (LA_ITEM * item, LOG_PAGE * pgptr, RECDES * recdes)
 }
 
 /*
- * la_resolve_oos_sql_log_recdes () - Reassemble a single OOS column value from
+ * la_resolve_oos_recdes () - Reassemble a single OOS column value from
  *   the per-transaction chunk cache and return it as a contiguous RECDES.
  *
  *   Note on ordering: the master logs OOS chunks in *reverse* order
  *   (last-chunk-first) so each chunk record can carry the next chunk's OID
- *   in its OOS_RECORD_HEADER.  As a result la_cache_oos_sql_log_recdes()
+ *   in its OOS_RECORD_HEADER.  As a result la_cache_oos_chunk()
  *   populates this cache tail-first.  The hash accelerator however gives
  *   random access by OID, so this resolver walks *forward* from the head OID
  *   passed in (taken from the heap recdes inline OOS metadata) by following
@@ -3949,7 +3948,7 @@ la_cache_oos_sql_log_recdes (LA_ITEM * item, LOG_PAGE * pgptr, RECDES * recdes)
  *   irrelevant at resolution time.
  *
  *   Validation (any failure returns ER_FAILED, leaving the caller to fall
- *   back to la_make_synthetic_oos_sql_log_value()):
+ *   back to la_make_oos_placeholder()):
  *     - chunk_index strictly monotone increasing from 0
  *     - total_data_length identical on every chunk in the chain
  *     - each chunk's body fits the remaining buffer
@@ -3960,7 +3959,7 @@ la_cache_oos_sql_log_recdes (LA_ITEM * item, LOG_PAGE * pgptr, RECDES * recdes)
  *   db_private_free_and_init() / recdes_free_data_area().
  */
 static int
-la_resolve_oos_sql_log_recdes (const OID * head_oid, int total_data_length, RECDES * recdes)
+la_resolve_oos_recdes (const OID * head_oid, int total_data_length, RECDES * recdes)
 {
   OID current_oid;
   char *data = NULL;
@@ -3995,7 +3994,7 @@ la_resolve_oos_sql_log_recdes (const OID * head_oid, int total_data_length, RECD
 
   while (!OID_ISNULL (&current_oid) && copied_size < total_data_length && iterations++ < max_iterations)
     {
-      LA_OOS_SQL_LOG_CACHE_ENTRY *entry = la_find_oos_sql_log_cache_entry (&current_oid);
+      LA_OOS_CACHE_ENTRY *entry = la_find_oos_cache_entry (&current_oid);
 
       if (entry == NULL || entry->chunk_index != expected_chunk_index
 	  || entry->total_data_length != total_data_length
@@ -4026,7 +4025,7 @@ la_resolve_oos_sql_log_recdes (const OID * head_oid, int total_data_length, RECD
 }
 
 /*
- * la_make_synthetic_oos_sql_log_value () - Last-resort fallback when the
+ * la_make_oos_placeholder () - Last-resort fallback when the
  *   chunk chain cannot be reassembled (cache miss, integrity check failure,
  *   etc.).  Produces a varchar of the inline OOS length filled with spaces
  *   except for the LA_OOS_MISSING_MARKER sentinel at the head, so:
@@ -4046,7 +4045,7 @@ la_resolve_oos_sql_log_recdes (const OID * head_oid, int total_data_length, RECD
  *   occurrence in the applylogdb error log alongside the source location.
  */
 static int
-la_make_synthetic_oos_sql_log_value (DB_VALUE * value, SM_ATTRIBUTE * att, DB_BIGINT oos_length)
+la_make_oos_placeholder (DB_VALUE * value, SM_ATTRIBUTE * att, DB_BIGINT oos_length)
 {
   DB_TYPE type;
   int string_length;
@@ -4099,7 +4098,7 @@ la_make_synthetic_oos_sql_log_value (DB_VALUE * value, SM_ATTRIBUTE * att, DB_BI
   string[string_length] = '\0';
 
   er_log_debug (ARG_FILE_LINE,
-		"la_make_synthetic_oos_sql_log_value: OOS chunk(s) missing from SQL log cache; "
+		"la_make_oos_placeholder: OOS chunk(s) missing from SQL log cache; "
 		"synthesizing %d-byte placeholder for column", string_length);
 
   db_make_varchar (value, precision, string, string_length, TP_DOMAIN_CODESET (att->domain),
@@ -4246,7 +4245,7 @@ la_get_current (OR_BUF * buf, SM_CLASS * sm_class, int bound_bit_flag, DB_OTMPL 
 
 	  if (!OID_ISNULL (&oos_oid) && oos_length > 0 && oos_length <= (DB_BIGINT) INT_MAX)
 	    {
-	      error = la_resolve_oos_sql_log_recdes (&oos_oid, (int) oos_length, &oos_recdes);
+	      error = la_resolve_oos_recdes (&oos_oid, (int) oos_length, &oos_recdes);
 	    }
 
 	  if (error == NO_ERROR && oos_recdes.data != NULL)
@@ -4266,7 +4265,7 @@ la_get_current (OR_BUF * buf, SM_CLASS * sm_class, int bound_bit_flag, DB_OTMPL 
 
 	      /* Prefer exact OID-chain reconstruction.  If any chunk is missing from the replication
 	       * cache, preserve sql.log sizing/rotation for large strings using the inline OOS length. */
-	      error = la_make_synthetic_oos_sql_log_value (&value, att, oos_length);
+	      error = la_make_oos_placeholder (&value, att, oos_length);
 	    }
 
 	  if (error != NO_ERROR)
@@ -6374,9 +6373,9 @@ la_apply_insert_log (LA_APPLY * apply, LA_ITEM * item)
       if (item->item_type == RVREPL_OOS_INSERT)
 	{
 	  /* OOS chunk record — body is not a user INSERT, just stash it in the
-	   * per-transaction cache for la_resolve_oos_sql_log_recdes() to pick
+	   * per-transaction cache for la_resolve_oos_recdes() to pick
 	   * up when the heap INSERT arrives.  No sql.log line is emitted. */
-	  ret = la_cache_oos_sql_log_recdes (item, pgptr, recdes);
+	  ret = la_cache_oos_chunk (item, pgptr, recdes);
 	}
       else
 	{
@@ -6776,11 +6775,11 @@ la_apply_repl_log (int tranid, int rectype, LOG_LSA * commit_lsa, int *total_row
    * to this transaction.  The cache itself may legitimately survive across
    * LOG_SYSOP_END mini-batches, but a stale entry from a previous transaction
    * with the same chunk OID must not be matched by the current one. */
-  la_Oos_sql_log_current_tranid = tranid;
+  la_oos_current_tranid = tranid;
 
   if (rectype == LOG_ABORT)
     {
-      la_clear_oos_sql_log_cache ();
+      la_clear_oos_cache ();
       la_clear_applied_info (apply);
       return NO_ERROR;
     }
@@ -6796,7 +6795,7 @@ la_apply_repl_log (int tranid, int rectype, LOG_LSA * commit_lsa, int *total_row
 	  la_clear_applied_info (apply);
 	}
 
-      la_clear_oos_sql_log_cache ();
+      la_clear_oos_cache ();
       return NO_ERROR;
     }
 
@@ -6934,7 +6933,7 @@ end:
 
   if (!(rectype == LOG_SYSOP_END && has_more_commit_items))
     {
-      la_clear_oos_sql_log_cache ();
+      la_clear_oos_cache ();
     }
 
   return error;

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -3645,16 +3645,24 @@ la_clear_oos_sql_log_cache (void)
   la_Oos_sql_log_cache_tail = NULL;
 }
 
+/*
+ * la_get_oos_sql_log_chunk_oid () - Peek the LOG_DATA at item->target_lsa
+ *   directly from the in-memory page and extract the OID where the OOS chunk
+ *   was inserted on the master.  Unlike la_get_log_data(), this does not
+ *   allocate/decompress the redo body — only the small fixed-size log record
+ *   header struct is read.  The chunk_oid is filled only when the recovery
+ *   index is RVOOS_INSERT; otherwise it stays OID_NULL and NO_ERROR is
+ *   returned, leaving the caller to fall back gracefully.
+ */
 static int
 la_get_oos_sql_log_chunk_oid (LA_ITEM * item, LOG_PAGE * pgptr, OID * chunk_oid)
 {
   LOG_RECORD_HEADER *lrec;
-  unsigned int rcvindex = 0;
-  void *logs = NULL;
-  char rec_type_storage[DB_SIZEOF (INT16)] = { 0 };
-  char *rec_type = rec_type_storage;
-  char *data = NULL;
-  int length = 0;
+  LOG_PAGE *pg;
+  PGLENGTH offset;
+  LOG_PAGEID pageid;
+  LOG_DATA *logdata = NULL;
+  int log_size = 0;
   int error = NO_ERROR;
 
   if (chunk_oid == NULL)
@@ -3669,20 +3677,13 @@ la_get_oos_sql_log_chunk_oid (LA_ITEM * item, LOG_PAGE * pgptr, OID * chunk_oid)
       return NO_ERROR;
     }
 
-  lrec = LOG_GET_LOG_RECORD_HEADER (pgptr, &item->target_lsa);
-  error =
-    la_get_log_data (lrec, &item->target_lsa, pgptr, RVOOS_INSERT, &rcvindex, &logs, &rec_type, &data, &length);
-  if (data != NULL)
-    {
-      free_and_init (data);
-    }
+  pg = pgptr;
+  lrec = LOG_GET_LOG_RECORD_HEADER (pg, &item->target_lsa);
+  offset = DB_SIZEOF (LOG_RECORD_HEADER) + item->target_lsa.offset;
+  pageid = item->target_lsa.pageid;
 
+  LA_LOG_READ_ALIGN (error, offset, pageid, pg);
   if (error != NO_ERROR)
-    {
-      return error == ER_OUT_OF_VIRTUAL_MEMORY ? error : NO_ERROR;
-    }
-
-  if (logs == NULL || rcvindex != RVOOS_INSERT)
     {
       return NO_ERROR;
     }
@@ -3691,30 +3692,58 @@ la_get_oos_sql_log_chunk_oid (LA_ITEM * item, LOG_PAGE * pgptr, OID * chunk_oid)
     {
     case LOG_UNDOREDO_DATA:
     case LOG_DIFF_UNDOREDO_DATA:
+      log_size = DB_SIZEOF (LOG_REC_UNDOREDO);
+      LA_LOG_READ_ADVANCE_WHEN_DOESNT_FIT (error, log_size, offset, pageid, pg);
+      if (error != NO_ERROR)
+	{
+	  return NO_ERROR;
+	}
+      logdata = &((LOG_REC_UNDOREDO *) ((char *) pg->area + offset))->data;
+      break;
+
     case LOG_MVCC_UNDOREDO_DATA:
     case LOG_MVCC_DIFF_UNDOREDO_DATA:
-      {
-	LOG_REC_UNDOREDO *undoredo = (LOG_REC_UNDOREDO *) logs;
-	chunk_oid->volid = undoredo->data.volid;
-	chunk_oid->pageid = undoredo->data.pageid;
-	chunk_oid->slotid = undoredo->data.offset;
-	break;
-      }
+      log_size = DB_SIZEOF (LOG_REC_MVCC_UNDOREDO);
+      LA_LOG_READ_ADVANCE_WHEN_DOESNT_FIT (error, log_size, offset, pageid, pg);
+      if (error != NO_ERROR)
+	{
+	  return NO_ERROR;
+	}
+      logdata = &((LOG_REC_MVCC_UNDOREDO *) ((char *) pg->area + offset))->undoredo.data;
+      break;
 
     case LOG_REDO_DATA:
+      log_size = DB_SIZEOF (LOG_REC_REDO);
+      LA_LOG_READ_ADVANCE_WHEN_DOESNT_FIT (error, log_size, offset, pageid, pg);
+      if (error != NO_ERROR)
+	{
+	  return NO_ERROR;
+	}
+      logdata = &((LOG_REC_REDO *) ((char *) pg->area + offset))->data;
+      break;
+
     case LOG_MVCC_REDO_DATA:
-      {
-	LOG_REC_REDO *redo = (LOG_REC_REDO *) logs;
-	chunk_oid->volid = redo->data.volid;
-	chunk_oid->pageid = redo->data.pageid;
-	chunk_oid->slotid = redo->data.offset;
-	break;
-      }
+      log_size = DB_SIZEOF (LOG_REC_MVCC_REDO);
+      LA_LOG_READ_ADVANCE_WHEN_DOESNT_FIT (error, log_size, offset, pageid, pg);
+      if (error != NO_ERROR)
+	{
+	  return NO_ERROR;
+	}
+      logdata = &((LOG_REC_MVCC_REDO *) ((char *) pg->area + offset))->redo.data;
+      break;
 
     default:
-      break;
+      return NO_ERROR;
     }
 
+  if (logdata == NULL || logdata->rcvindex != RVOOS_INSERT)
+    {
+      return NO_ERROR;
+    }
+
+  chunk_oid->volid = logdata->volid;
+  chunk_oid->pageid = logdata->pageid;
+  chunk_oid->slotid = logdata->offset;
   return NO_ERROR;
 }
 

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -439,9 +439,10 @@ LA_RECDES_POOL la_recdes_pool;
  * head OID (chunk_index=0).  Linked list owns memory; hash gives O(1) lookup.
  * Lazily allocated; cleared (not destroyed) on tx boundaries so the bucket
  * array survives.  Single-threaded — see CBRD-26618 TODO below for parallel
- * applylogdb migration plan. */
+ * applylogdb migration plan.  Cache miss is treated as an invariant
+ * violation: la_resolve_oos_value_for_sql_log returns ER_FAILED so the
+ * operator sees a loud error rather than a silently synthesized placeholder. */
 #define LA_OOS_CACHE_HASH_SIZE  1024
-#define LA_OOS_MISSING_MARKER   "<<OOS_CHUNK_MISSING>>"
 
 /* TODO(CBRD-26618): when parallel applylogdb is introduced, migrate these
  * globals to per-LA_APPLY (or per-worker) state.  The tranid filter alone is
@@ -535,7 +536,6 @@ static int la_get_raw_offset_internal (OR_BUF * buf, int *error, int offset_size
 static int la_cache_oos_value (const OID * head_oid, const char *payload, int payload_length);
 static LA_OOS_CACHE_ENTRY *la_lookup_oos_value (const OID * head_oid);
 static void la_clear_oos_cache (void);
-static int la_make_oos_placeholder (DB_VALUE * value, SM_ATTRIBUTE * att, DB_BIGINT oos_length);
 static int la_resolve_oos_value_for_sql_log (const OID * head_oid, DB_BIGINT oos_length, SM_ATTRIBUTE * att,
 					     DB_VALUE * value);
 static int la_get_current (OR_BUF * buf, SM_CLASS * sm_class, int bound_bit_flag, DB_OTMPL * def, DB_VALUE * key,
@@ -3825,79 +3825,14 @@ la_cache_oos_value (const OID * head_oid, const char *payload, int payload_lengt
 }
 
 /*
- * la_make_oos_placeholder () - Last-resort fallback when the OOS value is
- *   missing from the cache.  Produces a varchar of the inline OOS length
- *   prefixed with LA_OOS_MISSING_MARKER (visible in operator grep) and
- *   space-padded so sql.log size accounting / rotation stays correct.
- *
- *   Refuses (ER_FAILED) when (a) attribute is non-string — OOS is currently
- *   string-only, so non-string here means corruption — or (b) length is
- *   shorter than the marker (a partial marker defeats grep visibility).
- */
-static int
-la_make_oos_placeholder (DB_VALUE * value, SM_ATTRIBUTE * att, DB_BIGINT oos_length)
-{
-  DB_TYPE type;
-  int string_length;
-  int precision;
-  int marker_len = (int) (sizeof (LA_OOS_MISSING_MARKER) - 1);
-  char *string;
-
-  assert (value != NULL && att != NULL);
-
-  type = TP_DOMAIN_TYPE (att->domain);
-  if (type != DB_TYPE_STRING)
-    {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HA_GENERIC_ERROR, 1,
-	      "cannot synthesize non-string OOS data for SQL log");
-      return ER_FAILED;
-    }
-
-  if (oos_length <= 0 || oos_length > INT_MAX)
-    {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HA_GENERIC_ERROR, 1, "invalid OOS data length for SQL log");
-      return ER_FAILED;
-    }
-
-  string_length = (int) oos_length;
-  precision = (att->domain != NULL) ? att->domain->precision : DB_MAX_VARCHAR_PRECISION;
-  if (precision > 0 && precision < string_length)
-    {
-      string_length = precision;
-    }
-
-  if (string_length < marker_len)
-    {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HA_GENERIC_ERROR, 1,
-	      "OOS placeholder shorter than missing-marker sentinel");
-      return ER_FAILED;
-    }
-
-  string = (char *) db_private_alloc (NULL, string_length + 1);
-  if (string == NULL)
-    {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, string_length + 1);
-      return ER_OUT_OF_VIRTUAL_MEMORY;
-    }
-
-  memcpy (string, LA_OOS_MISSING_MARKER, marker_len);
-  memset (string + marker_len, ' ', string_length - marker_len);
-  string[string_length] = '\0';
-
-  er_log_debug (ARG_FILE_LINE,
-		"la_make_oos_placeholder: OOS value missing from SQL log cache; "
-		"synthesized %d-byte placeholder", string_length);
-
-  db_make_varchar (value, precision, string, string_length, TP_DOMAIN_CODESET (att->domain),
-		   TP_DOMAIN_COLLATION (att->domain));
-  value->need_clear = true;
-  return NO_ERROR;
-}
-
-/*
- * la_resolve_oos_value_for_sql_log () - Cache lookup → readval, with
- *   placeholder synthesis on miss.  Used by la_get_current() for each OOS
- *   column when emitting INSERT/UPDATE sql.log lines.
+ * la_resolve_oos_value_for_sql_log () - Cache lookup → readval.  Used by
+ *   la_get_current() for each OOS column when emitting INSERT/UPDATE sql.log
+ *   lines.  A miss is treated as an invariant violation (eager assembly +
+ *   tranid scope make a hit guaranteed in normal operation) and surfaces as
+ *   ER_FAILED so an operator sees a loud signal in the error log instead of
+ *   silently synthesized data.  The caller (la_apply_insert_log) already
+ *   isolates this error from row replication via er_stack_push / pop +
+ *   la_set_error_sql_log.
  */
 static int
 la_resolve_oos_value_for_sql_log (const OID * head_oid, DB_BIGINT oos_length, SM_ATTRIBUTE * att, DB_VALUE * value)
@@ -3906,13 +3841,21 @@ la_resolve_oos_value_for_sql_log (const OID * head_oid, DB_BIGINT oos_length, SM
   OR_BUF buf;
 
   entry = la_lookup_oos_value (head_oid);
-  if (entry != NULL)
+  if (entry == NULL)
     {
-      or_init (&buf, entry->data, entry->length);
-      return att->type->data_readval (&buf, value, att->domain, entry->length, true, NULL, 0);
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HA_GENERIC_ERROR, 1, "OOS value missing from SQL log cache");
+      return ER_FAILED;
     }
 
-  return la_make_oos_placeholder (value, att, oos_length);
+  if ((DB_BIGINT) entry->length != oos_length)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HA_GENERIC_ERROR, 1,
+	      "OOS cached value length mismatches inline length");
+      return ER_FAILED;
+    }
+
+  or_init (&buf, entry->data, entry->length);
+  return att->type->data_readval (&buf, value, att->domain, entry->length, true, NULL, 0);
 }
 
 /*


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26618


## Description

HA 슬레이브 `applylogdb` 가 OOS 컬럼 INSERT/UPDATE 를 sql.log 에 기록할 때,
실제 문자열 대신 inline 메타의 첫 4바이트 (`538976288`) 또는 빈 문자열이 출력되는 회귀.

이로 인해 sql.log 가 1MB 크기에 도달하지 못하고,
`ha_sql_log_max_count` 정리 실패까지 연쇄되던 문제를 수정한다.
(1MB가 넘어가면 새 sql log 파일이 생성되어 sql log 자동 삭제 테스트를 수행하였으나, 생성되지 않아 테스트 실패)

## Implementation

OOS 청크를 받자마자 컬럼 값 1개로 미리 합쳐 트랜잭션 단위 캐시에 보관한다.

heap INSERT sql.log 작성 시점에는 inline head OID 로 단일 hash 조회 →
`data_readval` 로 디코딩 → sql.log 한 줄 작성.

조회 실패는 정상 운영에서 발생하지 않아야 하는 invariant 위반으로 간주하여
즉시 `ER_FAILED` 로 처리한다 (호출자가 row replication 흐름과 격리하므로
sql.log 한 줄만 누락되고 슬레이브 적용은 정상 진행).

## Test Plan

| 케이스 | 결과 |
|---|---|
| 기존: `cbrd_25497`, `cbrd_24721_2` | 3/3 + 6/6 OK |
| 신규: `cbrd_26618` (단일 청크 8KB + 다중 청크 100KB byte-for-byte) | 2/2 OK |
| 신규: `cbrd_26618_mixed` (8 컬럼 혼합 INSERT/UPDATE×4/DELETE) | 6/6 OK |

## Remarks

자료구조 · 처리 흐름 · 함수별 설계 의도 · Edge case 정리는
JIRA 이슈 페이지의 첨부 파일 `cbrd-26618_review_20260429.html` 참조:

http://jira.cubrid.org/browse/CBRD-26618
