### PR TITLE
[CBRD-26754] An error occurs when executing an update statement containing a db_link.

### DIFF
--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -11748,9 +11748,6 @@ pt_convert_dblink_insert_query (PARSER_CONTEXT * parser, PT_NODE * node, SERVER_
   if (spec->info.spec.remote_server_name)
     {
       remote_ins = 1;
-
-      /* alias is not needed for remote table */
-      spec->info.spec.range_var = NULL;
     }
 
   pt_convert_dblink_dml_query (parser, node, (remote_ins == 0), remote_ins, snl);
@@ -11780,13 +11777,6 @@ pt_convert_dblink_delete_query (PARSER_CONTEXT * parser, PT_NODE * node, SERVER_
 	  if (spec->info.spec.range_var)
 	    {
 	      a_name = (char *) spec->info.spec.range_var->info.name.original;
-
-	      /* to skip aliased name at rewriting for mariadb and etc. */
-	      if (a_name && spec->info.spec.remote_server_name && spec->info.spec.entity_name
-		  && strcasecmp (a_name, spec->info.spec.entity_name->info.name.original) == 0)
-		{
-		  spec->info.spec.range_var = NULL;
-		}
 	    }
 
 	  t_name = (char *) target->info.name.original;
@@ -11847,27 +11837,11 @@ pt_convert_dblink_update_query (PARSER_CONTEXT * parser, PT_NODE * node, SERVER_
 {
   int local_upd = 0, remote_upd = 0;
   int error;
-  PT_NODE *spec;
 
   parser_walk_tree (parser, node, pt_convert_dblink_synonym, NULL, NULL, NULL);
   if (pt_has_error (parser))
     {
       return;
-    }
-
-  for (spec = node->info.update.spec; spec; spec = spec->next)
-    {
-      if (spec->info.spec.range_var)
-	{
-	  char *a_name = (char *) spec->info.spec.range_var->info.name.original;
-
-	  /* to skip aliased name at rewriting for mariadb and etc. */
-	  if (a_name && spec->info.spec.entity_name && spec->info.spec.remote_server_name
-	      && strcasecmp (a_name, spec->info.spec.entity_name->info.name.original) == 0)
-	    {
-	      spec->info.spec.range_var = NULL;
-	    }
-	}
     }
 
   error = pt_check_update_set (parser, node, &local_upd, &remote_upd);
@@ -12086,6 +12060,24 @@ pt_convert_dblink_dml_query (PARSER_CONTEXT * parser, PT_NODE * node,
   parser->custom_print |=
     PT_PRINT_SUPPRESS_SERVER_NAME | PT_PRINT_SUPPRESS_SERIAL_CONV | PT_PRINT_NO_HOST_VAR_INDEX |
     PT_PRINT_SUPPRESS_FOR_DBLINK;
+
+  /* strip redundant aliases (alias == entity_name) from remote specs before printing;
+   * without this, "t1@srv1 t1" would be printed as "t1 t1" after server name suppression */
+  {
+    PT_NODE *s;
+    PT_NODE *spec_list = upd_spec ? upd_spec : into_spec;
+    for (s = spec_list; s; s = s->next)
+      {
+	if (s->info.spec.range_var && s->info.spec.entity_name && s->info.spec.remote_server_name)
+	  {
+	    const char *a_name = s->info.spec.range_var->info.name.original;
+	    if (a_name && strcasecmp (a_name, s->info.spec.entity_name->info.name.original) == 0)
+	      {
+		s->info.spec.range_var = NULL;
+	      }
+	  }
+      }
+  }
 
   dml = pt_print_bytes (parser, node);
 

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -12065,13 +12065,33 @@ pt_convert_dblink_dml_query (PARSER_CONTEXT * parser, PT_NODE * node,
    * without this, "t1@srv1 t1" would be printed as "t1 t1" after server name suppression */
   {
     PT_NODE *s;
-    PT_NODE *spec_list = upd_spec ? upd_spec : into_spec;
+    PT_NODE *spec_list;
+    const char *a_name, *e_name;
+
+    /* for update incuding merge node */
+    spec_list = upd_spec;
     for (s = spec_list; s; s = s->next)
       {
 	if (s->info.spec.range_var && s->info.spec.entity_name && s->info.spec.remote_server_name)
 	  {
-	    const char *a_name = s->info.spec.range_var->info.name.original;
-	    if (a_name && strcasecmp (a_name, s->info.spec.entity_name->info.name.original) == 0)
+	    a_name = s->info.spec.range_var->info.name.original;
+	    e_name = s->info.spec.entity_name->info.name.original;
+	    if (a_name && e_name && strcasecmp (a_name, e_name) == 0)
+	      {
+		s->info.spec.range_var = NULL;
+	      }
+	  }
+      }
+
+    /* for insert incuding merge node */
+    spec_list = into_spec;
+    for (s = spec_list; s; s = s->next)
+      {
+	if (s->info.spec.range_var && s->info.spec.entity_name && s->info.spec.remote_server_name)
+	  {
+	    a_name = s->info.spec.range_var->info.name.original;
+	    e_name = s->info.spec.entity_name->info.name.original;
+	    if (a_name && e_name && strcasecmp (a_name, e_name) == 0)
 	      {
 		s->info.spec.range_var = NULL;
 	      }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26754>

### Purpose

UPDATE 쿼리에 remote table join이 포함된 경우 remote table에 대한 alias가 null 처리되면서 semantic 에러 발생하는 문제를 수정

### Implementation

pt_convert_dblink_update_query, pt_convert_dblink_delete_query, pt_convert_dblink_insert_query 쿼리에서 alias를 처리하는 것을 pt_convert_dblink_dml_query 에서 일괄 처리

### Remarks

N/A
