### PR TITLE
[CBRD-26757] Fix runtime_context hang causes by invalid draining logic

### DIFF
--- a/src/jsp/jsp_comm.c
+++ b/src/jsp/jsp_comm.c
@@ -110,9 +110,18 @@ jsp_disconnect_server (SOCKET & sockfd)
       linger_buffer.l_onoff = 1;
       linger_buffer.l_linger = 0;
       setsockopt (sockfd, SOL_SOCKET, SO_LINGER, (char *) &linger_buffer, sizeof (linger_buffer));
+
+      // Force the peer (javasp ExecuteThread) to wake from blocking recv/poll
+      // immediately. SO_LINGER {1,0} alone relies on the kernel sending RST,
+      // which can be suppressed by send-buffer state, firewalls, or socket
+      // options. shutdown(SHUT_RDWR) guarantees the peer observes EOF on the
+      // read side regardless, so server-side interrupt does not depend on
+      // RST delivery to free javasp threads.
 #if defined(WINDOWS)
+      shutdown (sockfd, SD_BOTH);
       closesocket (sockfd);
 #else /* not WINDOWS */
+      shutdown (sockfd, SHUT_RDWR);
       close (sockfd);
 #endif /* not WINDOWS */
       sockfd = INVALID_SOCKET;

--- a/src/method/method_connection_pool.cpp
+++ b/src/method/method_connection_pool.cpp
@@ -82,30 +82,20 @@ namespace cubmethod
 	return;
       }
 
-    // test connection
-    if (kill == false && claimed->is_valid () == true)
+    // Push back to pool only if reusable: caller did not request kill,
+    // socket is still valid, and pool has room.
+    if (!kill && claimed->is_valid () && (int) m_queue.size () < m_pool_size)
       {
-	if ((int) m_queue.size () < m_pool_size)
-	  {
-	    m_queue.push (claimed);
-	    return;
-	  }
-	else
-	  {
-	    // overflow
-	    kill = true;
-	  }
+	m_queue.push (claimed);
+	return;
       }
 
-    if (kill)
-      {
-	assert (claimed != nullptr);
-	if (claimed)
-	  {
-	    delete claimed;
-	    claimed = nullptr;
-	  }
-      }
+    // Otherwise destroy. Covers kill=true, an already-invalidated
+    // connection (e.g. concurrent set_interrupt closed it), and pool
+    // overflow. The previous shape fell through silently when
+    // kill=false && !is_valid(), leaking the connection object.
+    delete claimed;
+    claimed = nullptr;
   }
 
   void

--- a/src/method/method_connection_pool.cpp
+++ b/src/method/method_connection_pool.cpp
@@ -108,6 +108,33 @@ namespace cubmethod
       }
   }
 
+  void
+  connection_pool::invalidate_idle ()
+  {
+    // Drain the queue under the pool mutex, then close+delete outside.
+    // Under interrupt the rctx is being torn down, so we do not return
+    // these connections to the pool -- closing them now ensures javasp
+    // ExecuteThreads on the peer side terminate (RST via SO_LINGER {1,0})
+    // instead of waiting for ~runtime_context, which may be pinned by a
+    // stuck wait_for_interrupt() drain.
+    std::queue<connection *> drained;
+    {
+      std::unique_lock<std::mutex> ulock (m_mutex);
+      std::swap (drained, m_queue);
+    }
+
+    while (!drained.empty ())
+      {
+	connection *conn = drained.front ();
+	drained.pop ();
+	if (conn != nullptr)
+	  {
+	    conn->invalidate ();
+	    delete conn;
+	  }
+      }
+  }
+
   int
   connection_pool::max_size () const
   {

--- a/src/method/method_connection_pool.hpp
+++ b/src/method/method_connection_pool.hpp
@@ -54,6 +54,11 @@ namespace cubmethod
       connection *claim ();
       void retire (connection *&claimed, bool kill);
 
+      // Tear down every idle (retired) connection in the queue.
+      // Caller must guarantee no claim()/retire() races (e.g., invoked under
+      // the owning rctx's interrupt path before the rctx is destroyed).
+      void invalidate_idle ();
+
       int max_size () const;
 
     private:

--- a/src/method/method_runtime_context.cpp
+++ b/src/method/method_runtime_context.cpp
@@ -388,8 +388,10 @@ namespace cubmethod
     // stuck one, and destroying group memory while a worker is still unwinding
     // would be a use-after-free. If the drain never completes, the session
     // owning this rctx remains pinned -- prefer that to a crash.
+#if !defined(NDEBUG)
     auto wait_started = steady_clock::now ();
     auto last_log = wait_started;
+#endif
 
     while (!pred ())
       {
@@ -398,19 +400,19 @@ namespace cubmethod
 	  {
 	    m_cond_var.notify_all ();
 
+#if !defined(NDEBUG)
 	    auto now = steady_clock::now ();
 	    if (now - last_log >= seconds (10))
 	      {
 		auto elapsed = duration_cast<seconds> (now - wait_started).count ();
-		char msg[256];
-		snprintf (msg, sizeof (msg),
-			  "method runtime_context: drain pending for %llds "
-			  "(group_stack=%zu, deferred=%zu, interrupt_id=%d)",
-			  (long long) elapsed, m_group_stack.size (),
-			  m_deferred_free_stack.size (), m_interrupt_id);
-		er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, ER_SP_EXECUTE_ERROR, 1, msg);
+		er_log_debug (ARG_FILE_LINE,
+			      "method runtime_context: drain pending for %llds "
+			      "(group_stack=%zu, deferred=%zu, interrupt_id=%d)\n",
+			      (long long) elapsed, m_group_stack.size (),
+			      m_deferred_free_stack.size (), m_interrupt_id);
 		last_log = now;
 	      }
+#endif
 	  }
       }
   }

--- a/src/method/method_runtime_context.cpp
+++ b/src/method/method_runtime_context.cpp
@@ -211,7 +211,7 @@ namespace cubmethod
       // condition to check
       // Wake on interrupt so we can drain even if XASL ordering never makes
       // claimed reach the top of m_group_stack.
-      return m_group_stack.empty () || m_group_stack.back() == claimed->get_id () || m_is_interrupted;
+      return m_group_stack.back() == claimed->get_id () || m_is_interrupted;
     };
 
     // Guaranteed to be removed from the topmost element

--- a/src/method/method_runtime_context.cpp
+++ b/src/method/method_runtime_context.cpp
@@ -402,11 +402,13 @@ namespace cubmethod
 	    if (now - last_log >= seconds (10))
 	      {
 		auto elapsed = duration_cast<seconds> (now - wait_started).count ();
-		er_log_debug (ARG_FILE_LINE,
-			      "method runtime_context: drain pending for %llds "
-			      "(group_stack=%zu, deferred=%zu, interrupt_id=%d)\n",
-			      (long long) elapsed, m_group_stack.size (),
-			      m_deferred_free_stack.size (), m_interrupt_id);
+		char msg[256];
+		snprintf (msg, sizeof (msg),
+			  "method runtime_context: drain pending for %llds "
+			  "(group_stack=%zu, deferred=%zu, interrupt_id=%d)",
+			  (long long) elapsed, m_group_stack.size (),
+			  m_deferred_free_stack.size (), m_interrupt_id);
+		er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, ER_SP_EXECUTE_ERROR, 1, msg);
 		last_log = now;
 	      }
 	  }

--- a/src/method/method_runtime_context.cpp
+++ b/src/method/method_runtime_context.cpp
@@ -18,6 +18,8 @@
 
 #include "method_runtime_context.hpp"
 
+#include <algorithm>
+
 #include "method_query_cursor.hpp"
 #include "query_manager.h"
 #include "session.h"
@@ -132,41 +134,106 @@ namespace cubmethod
   {
     std::unique_lock<std::mutex> ulock (m_mutex);
 
-    if (claimed->is_for_scan () && m_group_stack.back() != claimed->get_id ())
+    // Drain any deferred id matching the current group stack top.
+    // Back-only match can stall when nested method_scan leaves the orders mismatched.
+    auto drain_deferred = [&] ()
+    {
+      bool changed = true;
+      while (changed && !m_group_stack.empty () && !m_deferred_free_stack.empty ())
+	{
+	  changed = false;
+	  METHOD_GROUP_ID top = m_group_stack.back ();
+	  for (auto it = m_deferred_free_stack.begin (); it != m_deferred_free_stack.end (); ++it)
+	    {
+	      if (*it == top)
+		{
+		  destroy_group (top);
+		  m_group_stack.pop_back ();
+		  m_deferred_free_stack.erase (it);
+		  changed = true;
+		  break;
+		}
+	    }
+	}
+    };
+
+    // Interrupt drain path. Under interrupt no other worker will satisfy the
+    // normal "back == claimed" predicate (XASL clear ordering is abandoned),
+    // so we cannot block on m_cond_var or we deadlock wait_for_interrupt().
+    // The connection that backed claimed was already retired by
+    // method_invoke_group::end() before we got here, and method_scan's caller
+    // nulls its pointer right after pop_stack -- so it is safe to remove
+    // claimed's id from both stacks and destroy it now.
+    auto handle_interrupt_pop = [&] ()
+    {
+      METHOD_GROUP_ID id = claimed->get_id ();
+      auto stack_end = std::remove (m_group_stack.begin (), m_group_stack.end (), id);
+      m_group_stack.erase (stack_end, m_group_stack.end ());
+      auto def_end = std::remove (m_deferred_free_stack.begin (), m_deferred_free_stack.end (), id);
+      m_deferred_free_stack.erase (def_end, m_deferred_free_stack.end ());
+
+      destroy_group (id);
+
+      if (m_group_stack.empty ())
+	{
+	  m_is_running = false;
+	}
+      m_cond_var.notify_all ();
+    };
+
+    if (m_is_interrupted)
+      {
+	handle_interrupt_pop ();
+	return;
+      }
+
+    if (claimed->is_for_scan () && m_group_stack.back () != claimed->get_id ())
       {
 	// push deferred
 	// When beginning method_invoke_group with method scan, method_invoke_group belonging to child node in XASL is pushed first (postorder)
 	// When method_invoke_group is ended while clearing XASL by qexec_clear_xasl(), method_invoke_group belonging to the parent node in XASL is poped first (preorder)
 	// Because of these differences, I've introduced the m_deferred_free_stack structure to follow the order of clearing according to the XASL structure when clearing method_invoke_groups from the m_group_stack.
 	m_deferred_free_stack.push_back (claimed->get_id ());
+
+	// drain in case the new top is already deferred.
+	drain_deferred ();
+	if (m_group_stack.empty ())
+	  {
+	    m_is_running = false;
+	    clear_interrupt ();
+	  }
+	m_cond_var.notify_all ();
 	return;
       }
 
     auto pred = [&] () -> bool
     {
       // condition to check
-      return m_group_stack.empty () || m_group_stack.back() == claimed->get_id ();
+      // Wake on interrupt so we can drain even if XASL ordering never makes
+      // claimed reach the top of m_group_stack.
+      return m_group_stack.empty () || m_group_stack.back() == claimed->get_id () || m_is_interrupted;
     };
 
     // Guaranteed to be removed from the topmost element
     m_cond_var.wait (ulock, pred);
 
-    if (pred ())
+    // If we woke because of interrupt, take the same drain path as on entry.
+    if (m_is_interrupted)
       {
-	if (!m_group_stack.empty())
-	  {
-	    destroy_group (m_group_stack.back ());
-	    m_group_stack.pop_back ();
-	  }
+	handle_interrupt_pop ();
+	return;
       }
 
-    // should be freed for all XASL structure
-    while (m_deferred_free_stack.empty () == false && m_deferred_free_stack.back () == m_group_stack.back())
+    // m_cond_var.wait(lock, pred) only returns when pred() is true, so the
+    // outer pred() guard would always be true here -- drop it.
+    if (!m_group_stack.empty ())
       {
 	destroy_group (m_group_stack.back ());
 	m_group_stack.pop_back ();
-	m_deferred_free_stack.pop_back ();
       }
+
+    // should be freed for all XASL structure
+    drain_deferred ();
 
     if (m_group_stack.empty())
       {
@@ -218,6 +285,12 @@ namespace cubmethod
   void
   runtime_context::set_interrupt (int reason, std::string msg)
   {
+    // Hold m_mutex for the whole operation so the flag set, the connection
+    // teardown and the notify_all all observe the same state. Otherwise a
+    // pop_stack worker can call clear_interrupt() between our flag write and
+    // our re-read of m_is_interrupted, silently losing the interrupt.
+    std::unique_lock<std::mutex> ulock (m_mutex);
+
     if (m_is_interrupted)
       {
 	// do not overwrite interrupt
@@ -252,7 +325,6 @@ namespace cubmethod
 
     if (m_is_interrupted)
       {
-	std::unique_lock<std::mutex> ulock (m_mutex);
 	for (auto &it : m_group_map)
 	  {
 	    connection *conn = it.second->get_connection ();
@@ -261,6 +333,17 @@ namespace cubmethod
 		conn->invalidate ();
 	      }
 	  }
+	// Also tear down idle connections that were retired back to the pool
+	// before the interrupt fired. Without this, sockets to javasp leak
+	// until ~runtime_context runs -- which may never happen if a worker
+	// is stuck in pop_stack's wait. (Lock order: rctx mutex -> pool mutex.)
+	m_conn_pool.invalidate_idle ();
+
+	// Wake any worker parked in pop_stack's m_cond_var.wait so it can
+	// take the interrupt drain path. set_interrupt without notify_all
+	// would leave wait_for_interrupt() blocked forever even after the
+	// sockets are closed, because cond_var has no fd-close coupling.
+	m_cond_var.notify_all ();
       }
   }
 
@@ -298,9 +381,35 @@ namespace cubmethod
     };
 
     std::unique_lock<std::mutex> ulock (m_mutex);
-    while (m_cond_var.wait_for (ulock, std::chrono::milliseconds (100), pred) == false)
+
+    using namespace std::chrono;
+    // Wait until the runtime drains. We intentionally do NOT impose a deadline:
+    // a time-based force-drain cannot tell "slow but live" worker from a truly
+    // stuck one, and destroying group memory while a worker is still unwinding
+    // would be a use-after-free. If the drain never completes, the session
+    // owning this rctx remains pinned -- prefer that to a crash.
+    auto wait_started = steady_clock::now ();
+    auto last_log = wait_started;
+
+    while (!pred ())
       {
-	m_cond_var.notify_all ();
+	m_cond_var.wait_for (ulock, milliseconds (100), pred);
+	if (!pred ())
+	  {
+	    m_cond_var.notify_all ();
+
+	    auto now = steady_clock::now ();
+	    if (now - last_log >= seconds (10))
+	      {
+		auto elapsed = duration_cast<seconds> (now - wait_started).count ();
+		er_log_debug (ARG_FILE_LINE,
+			      "method runtime_context: drain pending for %llds "
+			      "(group_stack=%zu, deferred=%zu, interrupt_id=%d)\n",
+			      (long long) elapsed, m_group_stack.size (),
+			      m_deferred_free_stack.size (), m_interrupt_id);
+		last_log = now;
+	      }
+	  }
       }
   }
 

--- a/src/method/method_runtime_context.cpp
+++ b/src/method/method_runtime_context.cpp
@@ -94,7 +94,7 @@ namespace cubmethod
       }
     else
       {
-	set_interrupt (er_errid ());
+	set_interrupt (ulock, er_errid ());
       }
     return group;
   }
@@ -290,6 +290,14 @@ namespace cubmethod
     // pop_stack worker can call clear_interrupt() between our flag write and
     // our re-read of m_is_interrupted, silently losing the interrupt.
     std::unique_lock<std::mutex> ulock (m_mutex);
+    set_interrupt (ulock, reason, msg);
+  }
+
+  void
+  runtime_context::set_interrupt (std::unique_lock<std::mutex> &lock, int reason, std::string msg)
+  {
+    assert (lock.owns_lock () && lock.mutex () == &m_mutex);
+    (void) lock;
 
     if (m_is_interrupted)
       {

--- a/src/method/method_runtime_context.hpp
+++ b/src/method/method_runtime_context.hpp
@@ -31,6 +31,7 @@
 #include <unordered_set>
 #include <deque>
 #include <condition_variable>
+#include <mutex>
 #include <string>
 
 #include "method_connection_pool.hpp"
@@ -82,6 +83,8 @@ namespace cubmethod
       method_invoke_group *top_stack ();
 
       void set_interrupt (int reason, std::string msg = "");
+      // Locked overload: caller must already own m_mutex.
+      void set_interrupt (std::unique_lock<std::mutex> &lock, int reason, std::string msg = "");
       bool is_interrupted ();
       int get_interrupt_id ();
       std::string get_interrupt_msg ();


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26757

### Purpose

  `cubmethod::runtime_context::pop_stack`의 deferred-free 드레인은 nested method_scan에서
  `m_group_stack=[A,B]`, `m_deferred_free_stack=[B,A]` 같은 상태로 빠질 수 있고, 기존 루프
  `deferred.back() == stack.back()`는 이를 영원히 드레인하지 못한다. 세션 종료 시
  `wait_for_interrupt`가 무한 spin → END_SESSION RPC가 반환되지 않아 csql `;ex`가 hang.
  11.4는 `m_deferred_free_stack` 자체를 제거하여 구조적으로 회피하지만 11.3은 미해결.

  같은 경로에서 두 가지 부수 결함도 같이 드러남:
  - `set_interrupt`가 `notify_all` 없이 플래그만 set → parked worker가 못 깨어남.
  - 그 결과 `~runtime_context`에 도달 못해 idle javasp 연결이 누수.

### Implementation

 **src/method/method_runtime_context.cpp**
  - **fixed-point drain** — back-only 매칭을 폐기하고 `m_group_stack` top과 매칭되는
    deferred id를 모두 끌어내려 destroy (note: multiset 끼리의 매칭 비교라 보면 됨). nested 시퀀스에서도 invariant가 유지됨.
  - **interrupt drain path** — `m_is_interrupted` 진입 시 `claimed`의 id를 양 stack에서
    제거하고 즉시 destroy. 다른 worker가 술어를 만족시켜 줄 수 없으므로 `m_cond_var`에
    block하지 않는다. wait 도중 인터럽트로 깨어난 경우에도 같은 경로 재사용.
  - **set_interrupt**: idle pool invalidate + `m_cond_var.notify_all` (lock order: rctx → pool).
  - **wait_for_interrupt**: deadline 제거, drain 정체 10 s마다 heartbeat
    `er_log_debug` (`group_stack`, `deferred`, `interrupt_id`).

  **src/method/method_connection_pool.{hpp,cpp}**
  - `invalidate_idle()` 추가 — 풀에 반납된 socket을 일괄 close.

  **src/method/method_invoke_group.cpp, src/method/method_scan.cpp, src/jsp/jsp_comm.c**
  - interrupt 하에서도 동일 idle 반납 경로로 통일하여 재누수 방지.