### PR TITLE
[CBRD-26643] Replace std::string copy in lowercase_hash with FNV-1a

### DIFF
--- a/src/base/string_utility.hpp
+++ b/src/base/string_utility.hpp
@@ -24,7 +24,6 @@
 #define _STRING_UTILITY_HPP_
 
 #include <algorithm>
-#include <string>
 #include <string_view>
 #include <unordered_set>
 #include <cctype>
@@ -38,12 +37,19 @@ namespace cubbase
   struct lowercase_hash
   {
     // for case-insensitive comparision
+    // FNV-1a 64-bit: single pass, no allocation; consistent with lowercase_compare
+    static constexpr size_t FNV_OFFSET_BASIS = 14695981039346656037ULL;
+    static constexpr size_t FNV_PRIME        = 1099511628211ULL;
+
     size_t operator() (const std::string_view str) const
     {
-      std::string lower (str);
-      std::transform (str.begin(), str.end(), lower.begin(),
-		      [] (char c) -> char { return std::tolower (c); });
-      return std::hash<std::string> {} (lower);
+      size_t hash = FNV_OFFSET_BASIS;
+      for (unsigned char c : str)
+	{
+	  hash ^= static_cast<size_t> (std::tolower (c));
+	  hash *= FNV_PRIME;
+	}
+      return hash;
     }
   };
 


### PR DESCRIPTION
[<http://jira.cubrid.org/browse/CBRD-26643>
](http://jira.cubrid.org/browse/CBRD-26643)

### Purpose
- lowercase_hash::operator()의 std::string 복사 + 2-pass 해시 비용 제거.
- 단일 패스 FNV-1a 64-bit 으로 교체해 매 호출 힙 할당과 transform 패스를 제거한다.

### Implementation
- src/base/string_utility.hpp::lowercase_hash 본체 교체
  - std::string_view 를 unsigned char 단위로 순회, std::tolower fold-in
  - 한 step = (hash XOR byte) * prime, 단일 루프
- FNV 상수는 struct 내부 static constexpr 로 격리 (헤더 매크로 누출 방지)
- <string> include 제거 (직접 의존 사라짐, identifier_store.hpp 는 transitive 로 충당)

### Remarks
- lowercase_compare 와의 case-insensitive 일관성은 동일 std::tolower fold-in 으로 보장.

