### PR TITLE
[CBRD-26739] snapshot cubrid.conf to prevent runtime failures from cubrid.config edits

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -6027,9 +6027,6 @@ sysprm_load_and_init_internal (const char *db_name, const char *conf_file, bool 
   int num_session_prms;
 #endif
 
-  /* TODO: conf_file is always NULL. Therefore, you need to decide whether to keep this argument. */
-  assert (conf_file == NULL);
-
 #ifndef NDEBUG
   sysprm_check_id_order ();
 #endif

--- a/src/broker/broker_admin_pub.c
+++ b/src/broker/broker_admin_pub.c
@@ -360,6 +360,8 @@ admin_start_cmd (T_BROKER_INFO * br_info, int br_num, int master_shm_id, bool ac
       return -1;
     }
 
+  COPY_CUBRID_CONF;
+
   for (i = 0; i < br_num; i++)
     {
       if (br_info[i].shard_flag == OFF)
@@ -569,6 +571,8 @@ admin_stop_cmd (int master_shm_id)
   uw_shm_detach (shm_br);
 #endif /* WINDOWS */
   uw_shm_destroy (master_shm_id);
+
+  REMOVE_CUBRID_CONF;
 
   return 0;
 }
@@ -961,6 +965,8 @@ admin_on_cmd (int master_shm_id, const char *broker_name)
       putenv (shard_db_password_env_str[i]);
     }
 
+  ENABLE_CUBRID_CONF_ENV;
+
   for (i = 0; i < shm_br->num_broker; i++)
     {
       shm_proxy_p = NULL;
@@ -1103,6 +1109,8 @@ admin_off_cmd (int master_shm_id, const char *broker_name)
       return -1;
     }
 #endif /* !WINDOWS */
+
+  DISABLE_CUBRID_CONF_ENV;
 
   for (i = 0; i < shm_br->num_broker; i++)
     {

--- a/src/broker/broker_env_def.h
+++ b/src/broker/broker_env_def.h
@@ -49,4 +49,6 @@
 #define PROXY_ID_ENV_STR            "PROXY_ID"
 #define AS_ID_ENV_STR               "AS_ID"
 
+#define CUBRID_CONF_FOR_BROKER      "CUBRID_CONF_FOR_BROKER"
+
 #endif /* _BROKER_ENV_DEF_H_ */

--- a/src/broker/broker_filename.c
+++ b/src/broker/broker_filename.c
@@ -442,8 +442,7 @@ copy_cubrid_conf (const char *dest)
       goto error;
     }
 
-  unlink (dest);
-  dest_fd = open (dest, O_WRONLY | O_CREAT | O_TRUNC, 0400);
+  dest_fd = open (dest, O_WRONLY | O_CREAT | O_TRUNC, 0600);
   if (dest_fd < 0)
     {
       error_code = -3;
@@ -453,6 +452,12 @@ copy_cubrid_conf (const char *dest)
   if (sendfile (dest_fd, src_fd, NULL, stat_buf.st_size) != (ssize_t) stat_buf.st_size)
     {
       error_code = -4;
+      goto error;
+    }
+
+  if (fchmod (dest_fd, 0400) < 0)
+    {
+      error_code = -5;
       goto error;
     }
 

--- a/src/broker/broker_filename.c
+++ b/src/broker/broker_filename.c
@@ -450,7 +450,7 @@ copy_cubrid_conf (const char *dest)
       goto error;
     }
 
-  if (sendfile (dest_fd, src_fd, NULL, stat_buf.st_size) == -1)
+  if (sendfile (dest_fd, src_fd, NULL, stat_buf.st_size) != (ssize_t) stat_buf.st_size)
     {
       error_code = -4;
       goto error;

--- a/src/broker/broker_filename.c
+++ b/src/broker/broker_filename.c
@@ -435,18 +435,24 @@ copy_cubrid_conf (const char *dest)
       error_code = -1;
       goto error;
     }
-  fstat (src_fd, &stat_buf);
 
-  dest_fd = open (dest, O_WRONLY | O_CREAT | O_TRUNC, 0400);
-  if (dest_fd < 0)
+  if (fstat (src_fd, &stat_buf) < 0)
     {
       error_code = -2;
       goto error;
     }
 
-  if (sendfile (dest_fd, src_fd, NULL, stat_buf.st_size) == -1)
+  unlink (dest);
+  dest_fd = open (dest, O_WRONLY | O_CREAT | O_TRUNC, 0400);
+  if (dest_fd < 0)
     {
       error_code = -3;
+      goto error;
+    }
+
+  if (sendfile (dest_fd, src_fd, NULL, stat_buf.st_size) == -1)
+    {
+      error_code = -4;
       goto error;
     }
 
@@ -474,15 +480,20 @@ void
 manage_cubrid_conf (T_CMD_CUBRID_CONF command)
 {
   char cubrid_conf[BROKER_PATH_MAX];
+  int error_code = 0;
 
   get_cubrid_file (FID_COPIED_CUBRID_CONF, cubrid_conf, BROKER_PATH_MAX);
 
   switch (command)
     {
     case CMD_START:
-      if (copy_cubrid_conf (cubrid_conf) == 0)
+      if ((error_code = copy_cubrid_conf (cubrid_conf)) == 0)
 	{
 	  setenv (CUBRID_CONF_FOR_BROKER, cubrid_conf, 1);
+	}
+      else
+	{
+	  _er_log_debug (ARG_FILE_LINE, "fail of copy_cubrid_conf : %d\n", error_code);
 	}
       break;
     case CMD_STOP:

--- a/src/broker/broker_filename.c
+++ b/src/broker/broker_filename.c
@@ -32,6 +32,11 @@
 #if defined(WINDOWS)
 #include <direct.h>
 #else
+#include <fcntl.h>
+#include <sys/sendfile.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <linux/fs.h>
 #include <unistd.h>
 #endif
 
@@ -64,7 +69,8 @@ static T_CUBRID_FILE_INFO cubrid_file[NUM_CUBRID_FILE] = {
   {FID_SLOW_LOG_DIR, ""},
   {FID_SHARD_DBINFO, ""},
   {FID_SHARD_PROXY_LOG_DIR, ""},
-  {FID_CUBRID_GATEWAY_CONF, ""}
+  {FID_CUBRID_GATEWAY_CONF, ""},
+  {FID_COPIED_CUBRID_CONF, ""}
 };
 
 void
@@ -310,6 +316,9 @@ get_cubrid_file (T_CUBRID_FILE_ID fid, char *buf, size_t len)
 	  buf[0] = '\0';
 	}
       break;
+    case FID_COPIED_CUBRID_CONF:
+      envvar_vardir_file (buf, len, "as_pid/.cubrid.conf");
+      break;
     default:
       break;
     }
@@ -392,3 +401,108 @@ make_abs_path (char *dest, const char *subdir, const char *path, size_t dest_len
 
   return ret;
 }
+
+#if !defined(WINDOWS)
+int
+copy_cubrid_conf (const char *dest)
+{
+  const char *conf_file = NULL;
+  const char *file_path_ptr = NULL;
+  char file_being_dealt_with[PATH_MAX];
+  int src_fd = -1, dest_fd = -1;
+  struct stat stat_buf;
+  int error_code = 0;
+
+  conf_file = envvar_get ("CONF_FILE");
+  if (conf_file != NULL && *conf_file == '\0')
+    {
+      conf_file = NULL;
+    }
+
+  if (conf_file != NULL)
+    {
+      file_path_ptr = conf_file;
+    }
+  else
+    {
+      envvar_confdir_file (file_being_dealt_with, PATH_MAX, "cubrid.conf");
+      file_path_ptr = file_being_dealt_with;
+    }
+
+  src_fd = open (file_path_ptr, O_RDONLY);
+  if (src_fd < 0)
+    {
+      error_code = -1;
+      goto error;
+    }
+  fstat (src_fd, &stat_buf);
+
+  dest_fd = open (dest, O_WRONLY | O_CREAT | O_TRUNC, 0400);
+  if (dest_fd < 0)
+    {
+      error_code = -2;
+      goto error;
+    }
+
+  if (sendfile (dest_fd, src_fd, NULL, stat_buf.st_size) == -1)
+    {
+      error_code = -3;
+      goto error;
+    }
+
+  close (src_fd);
+  close (dest_fd);
+
+  return 0;
+
+error:
+  if (src_fd >= 0)
+    {
+      close (src_fd);
+    }
+
+  if (dest_fd >= 0)
+    {
+      close (dest_fd);
+      unlink (dest);
+    }
+
+  return error_code;
+}
+
+void
+manage_cubrid_conf (T_CMD_CUBRID_CONF command)
+{
+  char cubrid_conf[BROKER_PATH_MAX];
+
+  get_cubrid_file (FID_COPIED_CUBRID_CONF, cubrid_conf, BROKER_PATH_MAX);
+
+  switch (command)
+    {
+    case CMD_START:
+      if (copy_cubrid_conf (cubrid_conf) == 0)
+	{
+	  setenv (CUBRID_CONF_FOR_BROKER, cubrid_conf, 1);
+	}
+      break;
+    case CMD_STOP:
+      if (access (cubrid_conf, F_OK) == 0)
+	{
+	  unlink (cubrid_conf);
+	}
+      unsetenv (CUBRID_CONF_FOR_BROKER);
+      break;
+    case CMD_ON:
+      if (access (cubrid_conf, F_OK) == 0)
+	{
+	  setenv (CUBRID_CONF_FOR_BROKER, cubrid_conf, 1);
+	}
+      break;
+    case CMD_OFF:
+      unsetenv (CUBRID_CONF_FOR_BROKER);
+      break;
+    default:
+      break;
+    }
+}
+#endif

--- a/src/broker/broker_filename.h
+++ b/src/broker/broker_filename.h
@@ -90,6 +90,7 @@ enum t_cubrid_file_id
   FID_SHARD_DBINFO,
   FID_SHARD_PROXY_LOG_DIR,
   FID_CUBRID_GATEWAY_CONF,
+  FID_COPIED_CUBRID_CONF,
   MAX_CUBRID_FILE
 };
 typedef enum t_cubrid_file_id T_CUBRID_FILE_ID;
@@ -101,6 +102,17 @@ struct t_cubrid_file_info
   char file_name[BROKER_PATH_MAX];
 };
 
+#if !defined (WINDOWS)
+enum t_cmd_cubrid_conf
+{
+  CMD_START,
+  CMD_STOP,
+  CMD_ON,
+  CMD_OFF
+};
+typedef enum t_cmd_cubrid_conf T_CMD_CUBRID_CONF;
+#endif
+
 extern void set_cubrid_home (void);
 extern void set_cubrid_file (T_CUBRID_FILE_ID fid, char *value);
 extern char *get_cubrid_file (T_CUBRID_FILE_ID fid, char *buf, size_t len);
@@ -108,5 +120,14 @@ extern char *get_cubrid_file_ptr (T_CUBRID_FILE_ID fid);
 extern char *get_cubrid_home (void);
 extern const char *getenv_cubrid_broker (void);
 extern int make_abs_path (char *dst, const char *subdir, const char *path, size_t dest_len);
+#if !defined(WINDOWS)
+extern int copy_cubrid_conf (const char *dest);
+extern void manage_cubrid_conf (T_CMD_CUBRID_CONF command);
+
+#define COPY_CUBRID_CONF 	manage_cubrid_conf (CMD_START)
+#define REMOVE_CUBRID_CONF 	manage_cubrid_conf (CMD_STOP)
+#define ENABLE_CUBRID_CONF_ENV	manage_cubrid_conf (CMD_ON)
+#define DISABLE_CUBRID_CONF_ENV	manage_cubrid_conf (CMD_OFF)
+#endif
 
 #endif /* _BROKER_FILENAME_H_ */

--- a/src/broker/broker_filename.h
+++ b/src/broker/broker_filename.h
@@ -128,6 +128,11 @@ extern void manage_cubrid_conf (T_CMD_CUBRID_CONF command);
 #define REMOVE_CUBRID_CONF 	manage_cubrid_conf (CMD_STOP)
 #define ENABLE_CUBRID_CONF_ENV	manage_cubrid_conf (CMD_ON)
 #define DISABLE_CUBRID_CONF_ENV	manage_cubrid_conf (CMD_OFF)
+#else
+#define COPY_CUBRID_CONF	((void)0)
+#define REMOVE_CUBRID_CONF	((void)0)
+#define ENABLE_CUBRID_CONF_ENV	((void)0)
+#define DISABLE_CUBRID_CONF_ENV	((void)0)
 #endif
 
 #endif /* _BROKER_FILENAME_H_ */

--- a/src/transaction/boot.h
+++ b/src/transaction/boot.h
@@ -101,6 +101,12 @@
         || (client_type) == DB_CLIENT_TYPE_ADMIN_CSQL_WOS \
         || (client_type) == DB_CLIENT_TYPE_ADMIN_COMPACTDB_WOS)
 
+#define BOOT_BROKER_CLIENT_TYPE(client_type) \
+        ((client_type) == DB_CLIENT_TYPE_BROKER \
+         || (client_type) == DB_CLIENT_TYPE_READ_ONLY_BROKER \
+         || (client_type) == DB_CLIENT_TYPE_SLAVE_ONLY_BROKER \
+         || BOOT_REPLICA_ONLY_BROKER_CLIENT_TYPE (client_type)) 
+
 /*
  * BOOT_IS_ALLOWED_CLIENT_TYPE_IN_MT_MODE()
  * ((broker_default type || (remote && csql or broker_default type)) ? 0 : 1)

--- a/src/transaction/boot.h
+++ b/src/transaction/boot.h
@@ -105,7 +105,7 @@
         ((client_type) == DB_CLIENT_TYPE_BROKER \
          || (client_type) == DB_CLIENT_TYPE_READ_ONLY_BROKER \
          || (client_type) == DB_CLIENT_TYPE_SLAVE_ONLY_BROKER \
-         || BOOT_REPLICA_ONLY_BROKER_CLIENT_TYPE (client_type)) 
+         || BOOT_REPLICA_ONLY_BROKER_CLIENT_TYPE (client_type))
 
 /*
  * BOOT_IS_ALLOWED_CLIENT_TYPE_IN_MT_MODE()

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -775,7 +775,9 @@ boot_restart_client (BOOT_CLIENT_CREDENTIAL * client_credential)
 	{
 	  conf_file = NULL;
 	}
+#if !defined (NDEBUG)
       _er_log_debug (ARG_FILE_LINE, "conf_for_broker = %s\n", conf_file ? conf_file : "unknown");
+#endif
     }
 #endif
 

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -708,8 +708,8 @@ boot_restart_client (BOOT_CLIENT_CREDENTIAL * client_credential)
   bool check_capabilities;
   bool skip_preferred_hosts = false;
   bool skip_db_info = false;
-  const char *conf_file = NULL;
 #endif /* CS_MODE */
+  const char *conf_file = NULL;
 
   assert (client_credential != NULL);
 
@@ -777,11 +777,9 @@ boot_restart_client (BOOT_CLIENT_CREDENTIAL * client_credential)
 	}
       _er_log_debug (ARG_FILE_LINE, "conf_for_broker = %s\n", conf_file ? conf_file : "unknown");
     }
+#endif
 
   if (sysprm_load_and_init_client (client_credential->get_db_name (), conf_file) != NO_ERROR)
-#else
-  if (sysprm_load_and_init_client (client_credential->get_db_name (), NULL) != NO_ERROR)
-#endif
     {
       error_code = ER_BO_CANT_LOAD_SYSPRM;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_code, 0);

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -708,6 +708,7 @@ boot_restart_client (BOOT_CLIENT_CREDENTIAL * client_credential)
   bool check_capabilities;
   bool skip_preferred_hosts = false;
   bool skip_db_info = false;
+  const char *conf_file = NULL;
 #endif /* CS_MODE */
 
   assert (client_credential != NULL);
@@ -766,7 +767,21 @@ boot_restart_client (BOOT_CLIENT_CREDENTIAL * client_credential)
     }
 
   /* initialize system parameters */
+#if defined (CS_MODE)
+  if (BOOT_BROKER_CLIENT_TYPE (client_credential->client_type))
+    {
+      conf_file = envvar_get ("CONF_FOR_BROKER");
+      if (conf_file && access (conf_file, R_OK | F_OK) != 0)
+	{
+	  conf_file = NULL;
+	}
+      _er_log_debug (ARG_FILE_LINE, "conf_for_broker = %s\n", conf_file ? conf_file : "unknown");
+    }
+
+  if (sysprm_load_and_init_client (client_credential->get_db_name (), conf_file) != NO_ERROR)
+#else
   if (sysprm_load_and_init_client (client_credential->get_db_name (), NULL) != NO_ERROR)
+#endif
     {
       error_code = ER_BO_CANT_LOAD_SYSPRM;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_code, 0);

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -770,7 +770,7 @@ boot_restart_client (BOOT_CLIENT_CREDENTIAL * client_credential)
 #if defined (CS_MODE)
   if (BOOT_BROKER_CLIENT_TYPE (client_credential->client_type))
     {
-      conf_file = envvar_get ("CONF_FOR_BROKER");
+      conf_file = getenv ("CUBRID_CONF_FOR_BROKER");
       if (conf_file && access (conf_file, R_OK | F_OK) != 0)
 	{
 	  conf_file = NULL;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26739

### Purpose
Currently, the Broker and CAS refer directly to '$CUBRID/conf/cubrid.conf' during runtime. This poses a risk where accidental user edits to the configuration file can cause service failures when a CAS restarts.

To isolate the running service from manual configuration changes, this commit implements a snapshot mechanism that clones the configuration at startup.

### Implementation
- Broker Startup: Copies 'cubrid.conf' to '$CUBRID/var/as_pid/.cubrid.conf' and registers the 'CUBRID_CONF_FOR_BROKER' environment variable.
- Broker Shutdown: Automatically removes the cloned '.cubrid.conf' file.
- Client/CAS Logic: Updated 'boot_restart_client()' to prioritize the snapped config via 'CUBRID_CONF_FOR_BROKER'. Falls back to the original 'cubrid.conf' if the variable is missing or the file is unreadable.