### PR TITLE
[CBRD-26687] Add calls to thread suspension routine and slot-related functions in Lock manager and CSS path.

### DIFF
--- a/src/thread/concurrency_slot.cpp
+++ b/src/thread/concurrency_slot.cpp
@@ -120,6 +120,7 @@ namespace cubthread
 
   concurrency_slot::concurrency_slot (concurrency_slot_pool *owner_pool)
     : m_owner_pool (owner_pool)
+    , m_holder_pool (nullptr)
     , m_wait (false)
     , m_wait_since ()
   {
@@ -129,16 +130,47 @@ namespace cubthread
   {
   }
 
+  concurrency_slot_pool *
+  concurrency_slot::get_owner_pool ()
+  {
+    return m_owner_pool;
+  }
+
+  void
+  concurrency_slot::set_holder_pool (concurrency_slot_pool *holder_pool)
+  {
+    m_holder_pool = holder_pool;
+  }
+
+  concurrency_slot_pool *
+  concurrency_slot::get_holder_pool ()
+  {
+    return m_holder_pool;
+  }
+
+  void
+  concurrency_slot::start_waiting ()
+  {
+    m_wait = true;
+    m_wait_since = std::chrono::steady_clock::now ();
+  }
+
+  void
+  concurrency_slot::stop_waiting ()
+  {
+    m_wait = false;
+  }
+
   //////////////////////////////////////////////////////////////////////////
   // concurrency_slot_pool
   //////////////////////////////////////////////////////////////////////////
 
-  concurrency_slot_pool::concurrency_slot_pool ()
+  concurrency_slot_pool::concurrency_slot_pool (std::mutex &mtx)
     : concurrency_slot_subscriber (concurrency_slot_daemon::get_publisher ())
     , m_available_slots ()
     , m_surplus_since ()
     , m_wait_queue ()
-    , m_mutex ()
+    , m_mutex (&mtx)
   {
   }
 
@@ -149,7 +181,6 @@ namespace cubthread
   void
   concurrency_slot_pool::initialize (void *identifier, std::size_t slot_count)
   {
-    std::unique_lock<std::mutex> ulock (m_mutex);
     std::size_t i;
 
     for (i = 0; i < slot_count; i++)
@@ -157,16 +188,19 @@ namespace cubthread
 	m_available_slots.emplace (std::unique_ptr<concurrency_slot> (new concurrency_slot (this)));
       }
 
-    ulock.unlock ();
-
     // attach to the daemon
     concurrency_slot_subscriber::activate (identifier);
   }
 
   std::unique_ptr<concurrency_slot>
-  concurrency_slot_pool::try_acquire_slot ()
+  concurrency_slot_pool::try_acquire_slot (bool has_mutex)
   {
-    std::lock_guard<std::mutex> lock (m_mutex);
+    std::unique_lock<std::mutex> ulock (*m_mutex, std::defer_lock);
+
+    if (!has_mutex)
+      {
+	ulock.lock ();
+      }
 
     if (m_available_slots.empty ())
       {
@@ -180,20 +214,32 @@ namespace cubthread
   }
 
   std::unique_ptr<concurrency_slot>
-  concurrency_slot_pool::acquire_slot ()
+  concurrency_slot_pool::acquire_slot (bool has_mutex)
   {
+    std::unique_lock<std::mutex> ulock (*m_mutex, std::defer_lock);
+
+    if (!has_mutex)
+      {
+	ulock.lock ();
+      }
+
     return nullptr;
   }
 
   void
-  concurrency_slot_pool::release_slot (std::unique_ptr<concurrency_slot> slot)
+  concurrency_slot_pool::release_slot (std::unique_ptr<concurrency_slot> slot, bool has_mutex)
   {
+    std::unique_lock<std::mutex> ulock (*m_mutex, std::defer_lock);
+
     if (slot == nullptr)
       {
 	return;
       }
 
-    std::lock_guard<std::mutex> lock (m_mutex);
+    if (!has_mutex)
+      {
+	ulock.lock ();
+      }
 
     m_available_slots.emplace (std::move (slot));
   }

--- a/src/thread/concurrency_slot.hpp
+++ b/src/thread/concurrency_slot.hpp
@@ -23,6 +23,10 @@
 #ifndef _CONCURRENCY_SLOT_HPP_
 #define _CONCURRENCY_SLOT_HPP_
 
+#if !defined (SERVER_MODE)
+#error Wrong module
+#endif // not SERVER_MODE
+
 #include "thread_entry.hpp"
 #include "thread_daemon.hpp"
 
@@ -89,28 +93,39 @@ namespace cubthread
     public:
       ~concurrency_slot ();
 
+      concurrency_slot_pool *get_owner_pool ();
+
+      void set_holder_pool (concurrency_slot_pool *holder_pool);
+      concurrency_slot_pool *get_holder_pool ();
+
+      void start_waiting ();
+      void stop_waiting ();
+
     private:
       concurrency_slot (concurrency_slot_pool *owner_pool);
 
       concurrency_slot_pool *const m_owner_pool;
+      concurrency_slot_pool *m_holder_pool;
 
       bool m_wait; // soft wait
       std::chrono::time_point<std::chrono::steady_clock> m_wait_since;
+
+      // guarded by the holder pool mutex (core mutex)
   };
 
   class concurrency_slot_pool : public concurrency_slot_subscriber
   {
     public:
-      concurrency_slot_pool ();
+      concurrency_slot_pool (std::mutex &mtx);
       ~concurrency_slot_pool ();
 
       virtual void initialize (void *identifier, std::size_t concurrency);
 
       // for worker
-      std::unique_ptr<concurrency_slot> try_acquire_slot ();
-      std::unique_ptr<concurrency_slot> acquire_slot ();
+      std::unique_ptr<concurrency_slot> try_acquire_slot (bool has_mutex = true);
+      std::unique_ptr<concurrency_slot> acquire_slot (bool has_mutex = true);
 
-      void release_slot (std::unique_ptr<concurrency_slot> slot);
+      void release_slot (std::unique_ptr<concurrency_slot> slot, bool has_mutex = true);
 
       // called by the daemon to borrow surplus slots in batches of SLOT_SURPLUS_THRESHOLD.
       bool borrow_surplus_slots ();
@@ -123,7 +138,8 @@ namespace cubthread
 
       std::list<entry *> m_wait_queue; // list of entries waiting to acquire a slot
 
-      std::mutex m_mutex; // guard for m_available_slots, m_surplus_since and m_wait_queue
+      // slot pool state is guarded by the owning core mutex
+      std::mutex *m_mutex;
   };
 
   // concurrency_slot_daemon

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -34,6 +34,9 @@
 #include "memory_alloc.h"
 #include "page_buffer.h"
 #include "resource_tracker.hpp"
+#if defined (SERVER_MODE)
+#include "concurrency_slot.hpp"
+#endif
 
 #include <cstring>
 #include <sstream>
@@ -90,9 +93,6 @@ namespace cubthread
     , wakeup_cond ()
     , private_heap_id (0)
     , conn_entry (NULL)
-#if defined (SERVER_MODE)
-    , slot (nullptr)
-#endif
     , xasl_unpack_info_ptr (NULL)
     , xasl_errcode (0)
     , xasl_recursion_depth (0)
@@ -144,6 +144,9 @@ namespace cubthread
     , m_uses_px_stats (false)
     , m_is_private_lru_enabled (false)
     , m_holder_anchor (NULL)
+#if defined (SERVER_MODE)
+    , m_slot (nullptr)
+#endif
       // private:
     , m_id ()
     , m_error ()
@@ -460,6 +463,20 @@ namespace cubthread
     return m_lf_tran_index;
   }
 
+#if defined (SERVER_MODE)
+  void
+  entry::start_waiting ()
+  {
+    m_slot->start_waiting ();
+  }
+
+  void
+  entry::stop_waiting ()
+  {
+    m_slot->stop_waiting ();
+  }
+#endif
+
 } // namespace cubthread
 
 //////////////////////////////////////////////////////////////////////////
@@ -468,6 +485,10 @@ namespace cubthread
 
 using thread_clock_type = std::chrono::system_clock;
 
+static void thread_prepare_suspension (cubthread::entry *thread_p, cubthread::entry::status &status,
+				       thread_resume_suspend_status suspended_reason, thread_clock_type::time_point &start_time, void *&holder);
+static void thread_prepare_resumption (cubthread::entry *thread_p, cubthread::entry::status status,
+				       thread_resume_suspend_status suspended_reason, thread_clock_type::time_point start_time, void *holder);
 static void thread_wakeup_internal (cubthread::entry *thread_p, thread_resume_suspend_status resume_reason,
 				    bool had_mutex);
 static void thread_check_suspend_reason_and_wakeup_internal (cubthread::entry *thread_p,
@@ -489,51 +510,31 @@ thread_timeval_add_usec (const std::chrono::microseconds &usec, struct timeval &
 }
 
 /*
- * thread_suspend_wakeup_and_unlock_entry() -
+ * thread_suspend_wakeup_and_unlock_entry ()
  *   return:
  *   thread_p(in):
  *   suspended_reason(in):
  *
- * Note: this function must be called by current thread also, the lock must have already been acquired.
+ * Note: this function must be called by the current thread with th_entry_lock already acquired.
  */
 void
 thread_suspend_wakeup_and_unlock_entry (cubthread::entry *thread_p, thread_resume_suspend_status suspended_reason)
 {
-  cubthread::entry::status old_status;
+  thread_clock_type::time_point start_time;
+  cubthread::entry::status status;
+  void *holder = nullptr;
 
-  thread_clock_type::time_point start_time_pt;
-  std::chrono::microseconds usecs;
+  thread_prepare_suspension (thread_p, status, suspended_reason, start_time, holder);
 
-  assert (thread_p->m_status == cubthread::entry::status::TS_RUN
-	  || thread_p->m_status == cubthread::entry::status::TS_CHECK);
-  old_status = thread_p->m_status;
-  thread_p->m_status = cubthread::entry::status::TS_WAIT;
-
-  thread_p->resume_status = suspended_reason;
-
-  if (thread_p->event_stats.trace_slow_query == true)
+  // wait until the wakeup predicate is true
+  while (thread_p->resume_status == suspended_reason)
     {
-      start_time_pt = thread_clock_type::now ();
+      pthread_cond_wait (&thread_p->wakeup_cond, &thread_p->th_entry_lock);
     }
 
-  pthread_cond_wait (&thread_p->wakeup_cond, &thread_p->th_entry_lock);
+  thread_prepare_resumption (thread_p, status, suspended_reason, start_time, holder);
 
-  if (thread_p->event_stats.trace_slow_query == true)
-    {
-      usecs = std::chrono::duration_cast<std::chrono::microseconds> (thread_clock_type::now () - start_time_pt);
-
-      if (suspended_reason == THREAD_LOCK_SUSPENDED)
-	{
-	  thread_timeval_add_usec (usecs, thread_p->event_stats.lock_waits);
-	}
-      else if (suspended_reason == THREAD_PGBUF_SUSPENDED)
-	{
-	  thread_timeval_add_usec (usecs, thread_p->event_stats.latch_waits);
-	}
-    }
-
-  thread_p->m_status = old_status;
-
+  // unlock the th_entry_lock
   pthread_mutex_unlock (&thread_p->th_entry_lock);
 }
 
@@ -548,49 +549,171 @@ int
 thread_suspend_timeout_wakeup_and_unlock_entry (cubthread::entry *thread_p, struct timespec *time_p,
     thread_resume_suspend_status suspended_reason)
 {
-  int r;
-  cubthread::entry::status old_status;
-  thread_clock_type::time_point start_time_pt;
-  std::chrono::microseconds usecs;
+  thread_clock_type::time_point start_time;
+  cubthread::entry::status status;
+  void *holder = nullptr;
   int error = NO_ERROR;
+  int r;
 
-  assert (thread_p->m_status == cubthread::entry::status::TS_RUN
-	  || thread_p->m_status == cubthread::entry::status::TS_CHECK);
-  old_status = thread_p->m_status;
-  thread_p->m_status = cubthread::entry::status::TS_WAIT;
+  // TODO: there may be no need to call the start_waiting when the steal threshold is shorter than time_p
+  thread_prepare_suspension (thread_p, status, suspended_reason, start_time, holder);
 
-  thread_p->resume_status = suspended_reason;
-
-  if (thread_p->event_stats.trace_slow_query == true && suspended_reason == THREAD_PGBUF_SUSPENDED)
+  // wait until timeout or the wakeup predicate changes
+  while (thread_p->resume_status == suspended_reason)
     {
-      start_time_pt = thread_clock_type::now ();
+      r = pthread_cond_timedwait (&thread_p->wakeup_cond, &thread_p->th_entry_lock, time_p);
+      if (r != 0 && r != ETIMEDOUT)
+	{
+	  // preserve existing behavior: leave th_entry_lock held on pthread error
+	  er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_COND_TIMEDWAIT, 0);
+	  return ER_CSS_PTHREAD_COND_TIMEDWAIT;
+	}
+      if (r == ETIMEDOUT)
+	{
+	  error = ER_CSS_PTHREAD_COND_TIMEDOUT;
+	  break;
+	}
     }
 
-  r = pthread_cond_timedwait (&thread_p->wakeup_cond, &thread_p->th_entry_lock, time_p);
+  thread_prepare_resumption (thread_p, status, suspended_reason, start_time, holder);
 
-  if (thread_p->event_stats.trace_slow_query == true && suspended_reason == THREAD_PGBUF_SUSPENDED)
-    {
-      usecs = std::chrono::duration_cast < std::chrono::microseconds > (thread_clock_type::now () - start_time_pt);
-
-      thread_timeval_add_usec (usecs, thread_p->event_stats.latch_waits);
-    }
-
-  if (r != 0 && r != ETIMEDOUT)
-    {
-      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_PTHREAD_COND_TIMEDWAIT, 0);
-      return ER_CSS_PTHREAD_COND_TIMEDWAIT;
-    }
-
-  if (r == ETIMEDOUT)
-    {
-      error = ER_CSS_PTHREAD_COND_TIMEDOUT;
-    }
-
-  thread_p->m_status = old_status;
-
+  // unlock the th_entry_lock
   pthread_mutex_unlock (&thread_p->th_entry_lock);
 
   return error;
+}
+
+/*
+ * thread_prepare_suspension ()
+ *   return:
+ *   thread_p(in):
+ *   suspended_reason(in):
+ */
+static void
+thread_prepare_suspension (cubthread::entry *thread_p, cubthread::entry::status &status,
+			   thread_resume_suspend_status suspended_reason, thread_clock_type::time_point &start_time, void *&holder)
+{
+  assert (thread_p->m_status == cubthread::entry::status::TS_RUN
+	  || thread_p->m_status == cubthread::entry::status::TS_CHECK);
+  status = thread_p->m_status;
+  thread_p->m_status = cubthread::entry::status::TS_WAIT;
+  thread_p->resume_status = suspended_reason;
+
+#if defined (SERVER_MODE)
+  // concurrency control
+  if (thread_p->m_slot)
+    {
+      switch (suspended_reason)
+	{
+	case THREAD_CSS_QUEUE_SUSPENDED:
+	case THREAD_LOCK_SUSPENDED:
+	  // this entry belongs to an elastic worker pool
+	  holder = static_cast<void *> (thread_p->m_slot->get_holder_pool ());
+	  assert (holder);
+	  thread_p->start_waiting ();
+	  break;
+
+	default:
+	  break;
+	}
+    }
+#endif
+
+  // trace
+  if (thread_p->event_stats.trace_slow_query == true)
+    {
+      switch (suspended_reason)
+	{
+	case THREAD_LOCK_SUSPENDED:
+	case THREAD_PGBUF_SUSPENDED:
+	  start_time = thread_clock_type::now ();
+	  break;
+
+	default:
+	  break;
+	}
+    }
+}
+
+/*
+ * thread_prepare_resumption ()
+ *   return:
+ *   thread_p(in):
+ *   suspended_reason(in):
+ */
+static void
+thread_prepare_resumption (cubthread::entry *thread_p, cubthread::entry::status status,
+			   thread_resume_suspend_status suspended_reason, thread_clock_type::time_point start_time, void *holder)
+{
+#if defined (SERVER_MODE)
+  std::unique_ptr<cubthread::concurrency_slot> slot;
+#endif
+  std::chrono::microseconds usecs;
+
+  // trace
+  if (thread_p->event_stats.trace_slow_query == true)
+    {
+      usecs = std::chrono::duration_cast<std::chrono::microseconds> (thread_clock_type::now () - start_time);
+      switch (suspended_reason)
+	{
+	case THREAD_LOCK_SUSPENDED:
+	  thread_timeval_add_usec (usecs, thread_p->event_stats.lock_waits);
+	  break;
+
+	case THREAD_PGBUF_SUSPENDED:
+	  thread_timeval_add_usec (usecs, thread_p->event_stats.latch_waits);
+	  break;
+
+	default:
+	  break;
+	}
+    }
+
+#if defined (SERVER_MODE)
+  // concurrency control
+  if (holder)
+    {
+      switch (suspended_reason)
+	{
+	case THREAD_CSS_QUEUE_SUSPENDED:
+	case THREAD_LOCK_SUSPENDED:
+	  // this thread is managed by concurrency-slot control
+	  if (thread_p->m_slot)
+	    {
+	      // 1. the entry still holds its slot (wait time < threshold)
+	      thread_p->stop_waiting ();
+	    }
+	  else
+	    {
+	      // 2. wait until the slot is acquired (wait time >= threshold)
+	      pthread_mutex_unlock (&thread_p->th_entry_lock);
+
+	      if (thread_p->event_stats.trace_slow_query == true)
+		{
+		  start_time = thread_clock_type::now ();
+		}
+
+	      slot = static_cast<cubthread::concurrency_slot_pool *> (holder)->acquire_slot (false);
+
+	      pthread_mutex_lock (&thread_p->th_entry_lock);
+
+	      if (thread_p->event_stats.trace_slow_query == true)
+		{
+		  usecs = std::chrono::duration_cast<std::chrono::microseconds> (thread_clock_type::now () - start_time);
+		  thread_timeval_add_usec (usecs, thread_p->event_stats.slot_waits);
+		}
+
+	      thread_p->m_slot = std::move (slot);
+	    }
+	  break;
+
+	default:
+	  break;
+	}
+    }
+#endif
+
+  thread_p->m_status = status;
 }
 
 /*

--- a/src/thread/thread_entry.hpp
+++ b/src/thread/thread_entry.hpp
@@ -112,6 +112,7 @@ struct event_stat
   struct timeval cs_waits;
   struct timeval lock_waits;
   struct timeval latch_waits;
+  struct timeval slot_waits;
 
   /* volume expand stats */
   struct timeval extend_time;
@@ -237,11 +238,6 @@ namespace cubthread
 
       css_conn_entry *conn_entry;	/* conn entry ptr */
 
-#if defined (SERVER_MODE)
-      /* concurrency slot held by this entry; only set for workers from an elastic worker pool */
-      std::unique_ptr<cubthread::concurrency_slot> slot;
-#endif
-
       xasl_unpack_info *xasl_unpack_info_ptr;     /* XASL_UNPACK_INFO * */
       int xasl_errcode;		/* xasl errorcode */
       int xasl_recursion_depth;
@@ -322,6 +318,11 @@ namespace cubthread
       bool m_is_private_lru_enabled;
       struct pgbuf_holder_anchor *m_holder_anchor;
 
+#if defined (SERVER_MODE)
+      /* concurrency slot held by the entry; only set for workers from an elastic worker pool */
+      std::unique_ptr<cubthread::concurrency_slot> m_slot;
+#endif
+
       thread_id_t get_id ();
       pthread_t get_posix_id ();
       void register_id ();
@@ -375,6 +376,11 @@ namespace cubthread
       void assign_lf_tran_index (lockfree::tran::index idx);
       lockfree::tran::index pull_lf_tran_index ();
       lockfree::tran::index get_lf_tran_index ();
+
+#if defined (SERVER_MODE)
+      void start_waiting ();
+      void stop_waiting ();
+#endif
 
     private:
       void clear_resources (void);

--- a/src/thread/thread_worker_pool_elastic.hpp
+++ b/src/thread/thread_worker_pool_elastic.hpp
@@ -56,6 +56,14 @@ namespace cubthread
       friend class manager;
 
     public:
+      using worker = worker_pool::core::worker;
+
+      using task_type = worker_pool::task_type;
+      using wrapped_task = typename worker_pool_impl<Stats>::wrapped_task;
+
+      using unique_slot = std::unique_ptr<concurrency_slot>;
+      using stats = typename worker_pool_impl<Stats>::stats;
+
       // forward definition
       class core_elastic;
 
@@ -79,14 +87,62 @@ namespace cubthread
       friend class worker_pool_elastic;
 
     public:
+      // forward definition
+      class worker_elastic;
+
       ~core_elastic ();
 
       void initialize (std::size_t concurrency) override;
 
+      // execute task
+      void execute_task (task_type *task_p) override;
+
+      // concurrency slot management
+      unique_slot try_acquire_slot ();
+      unique_slot acquire_slot ();
+
+      void release_slot (unique_slot slot);
+
+      std::optional<std::pair<wrapped_task, unique_slot>> get_task_and_slot_or_become_available (worker &worker_arg);
+
     private:
       core_elastic (bool pool_threads);
 
+      std::unique_ptr<worker> allocate_worker () override;
+
+      worker *get_or_make_available_worker ();
+
       concurrency_slot_pool m_slots;
+  };
+
+  // worker_pool_elastic<Stats>::core_elastic::worker_elastic
+  //
+  // description
+  //    elastic worker-pool core with a per-core slot pool that limits runnable concurrency.
+  //
+  template <stats_t Stats>
+  class worker_pool_elastic<Stats>::core_elastic::worker_elastic final
+    : public worker_pool_impl<Stats>::core_impl::worker_impl
+  {
+      friend class core_elastic;
+
+    public:
+      ~worker_elastic ();
+
+      // assign task to worker; wake a running thread or start a new one.
+      std::optional<std::pair<wrapped_task, unique_slot>> assign_task (wrapped_task &&task_ref, unique_slot slot);
+
+    private:
+      worker_elastic ();
+
+      // execute m_wrapped_task
+      void execute_current_task (void) override;
+
+      // get new task with slot
+      bool get_new_task (void) override;
+
+      // guarded by m_task_mutex
+      unique_slot m_slot;
   };
 
 } // namespace cubthread
@@ -138,6 +194,313 @@ namespace cubthread
     worker_pool_impl<Stats>::core_impl::initialize (concurrency);
 
     m_slots.initialize (static_cast<void *> (this->m_parent_pool), concurrency);
+  }
+
+  template <stats_t Stats>
+  void
+  worker_pool_elastic<Stats>::core_elastic::execute_task (task_type *task_p)
+  {
+    // find an available worker
+    // 1. one already active is preferable
+    // 2. inactive will do too
+    // 3. if no workers, enqueue the task
+
+    assert (task_p != nullptr);
+
+    std::unique_lock<std::mutex> ulock (this->m_workers_mutex, std::defer_lock);
+    worker_elastic *worker_p = nullptr;
+
+    if (!this->m_parent_pool->is_running ())
+      {
+	// reject task
+	task_p->retire ();
+	return;
+      }
+
+    wrapped_task task_ref (task_p);
+
+    unique_slot slot = try_acquire_slot ();
+    // hold the mutex here
+    ulock.lock ();
+    if (slot)
+      {
+	worker_p = static_cast<worker_elastic *> (get_or_make_available_worker ());
+	assert (worker_p);
+
+	ulock.unlock ();
+
+	std::optional<std::pair<wrapped_task, unique_slot>> unexecuted =
+		    worker_p->assign_task (std::move (task_ref), std::move (slot));
+	if (!unexecuted.has_value ())
+	  {
+	    /* successfully assign the task */
+	    return;
+	  }
+
+	// failed to start new thread
+	// return the slot to the pool
+	m_slots.release_slot (std::move (unexecuted->second));
+
+	ulock.lock ();
+
+	// save to queue
+	this->m_task_queue.push (std::move (unexecuted->first));
+	// return the worker
+	this->m_available_workers.push_back (worker_p);
+      }
+    else
+      {
+	// save to queue
+	this->m_task_queue.push (std::move (task_ref));
+      }
+  }
+
+  template <stats_t Stats>
+  typename worker_pool_elastic<Stats>::unique_slot
+  worker_pool_elastic<Stats>::core_elastic::try_acquire_slot ()
+  {
+    return m_slots.try_acquire_slot ();
+  }
+
+  template <stats_t Stats>
+  typename worker_pool_elastic<Stats>::unique_slot
+  worker_pool_elastic<Stats>::core_elastic::acquire_slot ()
+  {
+    return m_slots.acquire_slot ();
+  }
+
+  template <stats_t Stats>
+  void
+  worker_pool_elastic<Stats>::core_elastic::release_slot (unique_slot slot)
+  {
+    m_slots.release_slot (std::move (slot));
+  }
+
+  template <stats_t Stats>
+  std::optional<std::pair<typename worker_pool_elastic<Stats>::wrapped_task, typename worker_pool_elastic<Stats>::unique_slot>>
+      worker_pool_elastic<Stats>::core_elastic::get_task_and_slot_or_become_available (worker &worker_arg)
+  {
+    std::unique_lock<std::mutex> ulock (this->m_workers_mutex, std::defer_lock);
+
+    unique_slot slot = try_acquire_slot ();
+    ulock.lock ();
+    if (slot)
+      {
+	if (!this->m_task_queue.empty ())
+	  {
+	    wrapped_task queued_task = std::move (this->m_task_queue.front ());
+	    this->m_task_queue.pop ();
+
+	    return std::optional<std::pair<wrapped_task, unique_slot>> (std::in_place, std::move (queued_task), std::move (slot));
+	  }
+
+	// insert this worker into available list
+	this->m_available_workers.push_back (&worker_arg);
+	assert (this->m_available_workers.size () <= this->m_workers.size ());
+
+	ulock.unlock ();
+
+	// return the slot
+	release_slot (std::move (slot));
+
+	return std::nullopt;
+      }
+
+    // insert this worker into available list
+    this->m_available_workers.push_back (&worker_arg);
+    assert (this->m_available_workers.size () <= this->m_workers.size ());
+
+    return std::nullopt;
+  }
+
+  template <stats_t Stats>
+  std::unique_ptr<typename worker_pool::core::worker>
+  worker_pool_elastic<Stats>::core_elastic::allocate_worker ()
+  {
+    return std::unique_ptr<worker> (new worker_elastic ());
+  }
+
+  template <stats_t Stats>
+  typename worker_pool_elastic<Stats>::worker *
+  worker_pool_elastic<Stats>::core_elastic::get_or_make_available_worker ()
+  {
+    worker *worker_p;
+
+    worker_p = this->get_available_worker ();
+    if (!worker_p)
+      {
+	// make a new worker
+	std::unique_ptr<worker> w = this->allocate_worker ();
+	w->set_parent_core (*this);
+	worker_p = w.get ();
+	this->m_workers.push_back (std::move (w));
+      }
+    return worker_p;
+  }
+
+  template <stats_t Stats>
+  worker_pool_elastic<Stats>::core_elastic::worker_elastic::worker_elastic ()
+    : m_slot (nullptr)
+  {
+  }
+
+  template <stats_t Stats>
+  worker_pool_elastic<Stats>::core_elastic::worker_elastic::~worker_elastic ()
+  {
+  }
+
+  template <stats_t Stats>
+  std::optional<std::pair<typename worker_pool_elastic<Stats>::wrapped_task, typename worker_pool_elastic<Stats>::unique_slot>>
+      worker_pool_elastic<Stats>::core_elastic::worker_elastic::assign_task (wrapped_task &&task_ref, unique_slot slot)
+  {
+    std::unique_lock<std::mutex> ulock (this->m_task_mutex);
+
+    assert (!this->m_wrapped_task.has_value ());
+
+    // give the task
+    this->m_wrapped_task.emplace (std::move (task_ref));
+    // give the slot
+    m_slot = std::move (slot);
+
+    if (this->m_has_thread)
+      {
+	ulock.unlock ();
+
+	// notify waiting thread
+	this->m_task_cv.notify_one ();
+
+	return std::nullopt;
+      }
+
+    assert (!this->m_has_thread);
+
+    this->m_has_thread = true;
+
+    ulock.unlock ();
+
+    assert (this->m_context_p == nullptr);
+
+    if (!this->start_thread ())
+      {
+	ulock.lock ();
+
+	std::pair<wrapped_task, unique_slot> unexecuted (std::move (*this->m_wrapped_task), std::move (m_slot));
+	this->m_wrapped_task = std::nullopt;
+	m_slot = nullptr;
+
+	this->m_has_thread = false;
+
+	return unexecuted;
+      }
+    return std::nullopt;
+  }
+
+  template <stats_t Stats>
+  bool
+  worker_pool_elastic<Stats>::core_elastic::worker_elastic::get_new_task (void)
+  {
+    assert (!this->m_wrapped_task.has_value ());
+    assert (dynamic_cast<core_elastic *> (this->m_parent_core));
+
+    std::unique_lock<std::mutex> ulock (this->m_task_mutex, std::defer_lock);
+
+    if (!this->m_stop)
+      {
+	std::optional<std::pair<wrapped_task, unique_slot>> queued =
+		    static_cast<core_elastic *> (this->m_parent_core)->get_task_and_slot_or_become_available (*this);
+	if (queued.has_value ())
+	  {
+	    // stats: found in queue
+	    stats::time_and_increment (this->m_stats, stats::id::found_in_queue);
+
+	    // it is safe to set here
+	    this->m_wrapped_task.emplace (std::move (queued->first));
+	    m_slot = std::move (queued->second);
+
+	    return true;
+	  }
+
+	// wait for task
+	ulock.lock ();
+
+	assert ((!this->m_wrapped_task.has_value () && !m_slot) || (this->m_wrapped_task.has_value () && m_slot));
+
+	if ((!this->m_wrapped_task.has_value () && !m_slot) && !this->m_stop)
+	  {
+	    // wait until a task is received or stopped ...
+	    // ... or time out
+	    condvar_wait (this->m_task_cv, ulock, this->m_parent_core->get_parent_pool ()->get_idle_timeout (),
+			  [this] () -> bool { return (this->m_wrapped_task.has_value () && m_slot) || this->m_stop; });
+	  }
+	else
+	  {
+	    // no need to wait
+	  }
+      }
+    else
+      {
+	// we need to add to available list
+	static_cast<core_elastic *> (this->m_parent_core)->become_available (*this);
+
+	ulock.lock ();
+      }
+
+    assert ((!this->m_wrapped_task.has_value () && !m_slot) || (this->m_wrapped_task.has_value () && m_slot));
+
+    // does this worker have a task with slot ?
+    if (!this->m_wrapped_task.has_value () && !m_slot)
+      {
+	// no; this thread will stop. from this point forward, if a new task is assigned, a new thread must be spawned
+	this->m_has_thread = false;
+
+	// we need to retire context before another thread uses this worker
+	this->finish_run ();
+
+	return false;
+      }
+    else
+      {
+	// unlock mutex
+	ulock.unlock ();
+
+	// safe-guard - threads should no longer be available
+	static_cast<core_elastic *> (this->m_parent_core)->check_worker_not_available (*this);
+
+	// stats: wake up with task
+	stats::time_and_increment (this->m_stats, stats::id::wakeup_with_task);
+
+	// found task
+	return true;
+      }
+  }
+
+  template <stats_t Stats>
+  void
+  worker_pool_elastic<Stats>::core_elastic::worker_elastic::execute_current_task (void)
+  {
+    assert (dynamic_cast<core_elastic *> (this->m_parent_core));
+    assert (this->m_wrapped_task.has_value () && m_slot);
+    assert (!this->m_context_p->slot);
+
+    // give the slot to the entry
+    this->m_context_p->slot = std::move (m_slot);
+    // execute task
+    this->m_wrapped_task->execute (*this->m_context_p);
+
+    // return the slot to the pool
+    static_cast<core_elastic *> (this->m_parent_core)->release_slot (std::move (this->m_context_p->slot));
+    this->m_context_p->slot = nullptr;
+
+    // stats: execute task
+    stats::time_and_increment (this->m_stats, stats::id::execute_task);
+
+    // and retire task
+    this->retire_current_task ();
+
+    // and recycle context before getting another task
+    this->m_parent_core->get_entry_manager ().recycle_context (*this->m_context_p);
+    // stats: context recycle
+    stats::time_and_increment (this->m_stats, stats::id::recycle_context);
   }
 
 } // namespace cubthread

--- a/src/thread/thread_worker_pool_elastic.hpp
+++ b/src/thread/thread_worker_pool_elastic.hpp
@@ -64,7 +64,7 @@ namespace cubthread
       using unique_slot = std::unique_ptr<concurrency_slot>;
       using stats = typename worker_pool_impl<Stats>::stats;
 
-      // forward definition
+      // forward declaration
       class core_elastic;
 
       ~worker_pool_elastic ();
@@ -87,7 +87,7 @@ namespace cubthread
       friend class worker_pool_elastic;
 
     public:
-      // forward definition
+      // forward declaration
       class worker_elastic;
 
       ~core_elastic ();
@@ -98,10 +98,10 @@ namespace cubthread
       void execute_task (task_type *task_p) override;
 
       // concurrency slot management
-      unique_slot try_acquire_slot ();
-      unique_slot acquire_slot ();
+      unique_slot try_acquire_slot (bool has_mutex = true);
+      unique_slot acquire_slot (bool has_mutex = true);
 
-      void release_slot (unique_slot slot);
+      void release_slot (unique_slot slot, bool has_mutex = true);
 
       std::optional<std::pair<wrapped_task, unique_slot>> get_task_and_slot_or_become_available (worker &worker_arg);
 
@@ -112,13 +112,15 @@ namespace cubthread
 
       worker *get_or_make_available_worker ();
 
+      void execute_task_with_slot (worker_elastic *worker_p, wrapped_task &&task_ref, unique_slot slot);
+
       concurrency_slot_pool m_slots;
   };
 
   // worker_pool_elastic<Stats>::core_elastic::worker_elastic
   //
   // description
-  //    elastic worker-pool core with a per-core slot pool that limits runnable concurrency.
+  //    worker implementation that carries a task together with a concurrency slot.
   //
   template <stats_t Stats>
   class worker_pool_elastic<Stats>::core_elastic::worker_elastic final
@@ -129,7 +131,7 @@ namespace cubthread
     public:
       ~worker_elastic ();
 
-      // assign task to worker; wake a running thread or start a new one.
+      // assign a task to the worker; wake a running thread or start a new one
       std::optional<std::pair<wrapped_task, unique_slot>> assign_task (wrapped_task &&task_ref, unique_slot slot);
 
     private:
@@ -138,7 +140,7 @@ namespace cubthread
       // execute m_wrapped_task
       void execute_current_task (void) override;
 
-      // get new task with slot
+      // get a new task and slot
       bool get_new_task (void) override;
 
       // guarded by m_task_mutex
@@ -179,6 +181,7 @@ namespace cubthread
   template <stats_t Stats>
   worker_pool_elastic<Stats>::core_elastic::core_elastic (bool pool_threads)
     : worker_pool_impl<Stats>::core_impl (pool_threads)
+    , m_slots (this->m_core_mutex)
   {
   }
 
@@ -200,14 +203,8 @@ namespace cubthread
   void
   worker_pool_elastic<Stats>::core_elastic::execute_task (task_type *task_p)
   {
-    // find an available worker
-    // 1. one already active is preferable
-    // 2. inactive will do too
-    // 3. if no workers, enqueue the task
-
     assert (task_p != nullptr);
 
-    std::unique_lock<std::mutex> ulock (this->m_workers_mutex, std::defer_lock);
     worker_elastic *worker_p = nullptr;
 
     if (!this->m_parent_pool->is_running ())
@@ -218,95 +215,88 @@ namespace cubthread
       }
 
     wrapped_task task_ref (task_p);
+    std::unique_lock<std::mutex> ulock (this->m_core_mutex);
 
     unique_slot slot = try_acquire_slot ();
-    // hold the mutex here
-    ulock.lock ();
     if (slot)
       {
 	worker_p = static_cast<worker_elastic *> (get_or_make_available_worker ());
 	assert (worker_p);
 
-	ulock.unlock ();
-
-	std::optional<std::pair<wrapped_task, unique_slot>> unexecuted =
-		    worker_p->assign_task (std::move (task_ref), std::move (slot));
-	if (!unexecuted.has_value ())
+	// preserve FIFO order when queued tasks already exist
+	if (!this->m_task_queue.empty ())
 	  {
-	    /* successfully assign the task */
-	    return;
+	    // enqueue the new task behind existing work
+	    this->m_task_queue.push_back (std::move (task_ref));
+
+	    // dispatch the oldest queued task first
+	    wrapped_task queued_task = std::move (this->m_task_queue.front ());
+	    this->m_task_queue.pop_front ();
+
+	    ulock.unlock ();
+
+	    execute_task_with_slot (worker_p, std::move (queued_task), std::move (slot));
 	  }
+	else
+	  {
+	    ulock.unlock ();
 
-	// failed to start new thread
-	// return the slot to the pool
-	m_slots.release_slot (std::move (unexecuted->second));
-
-	ulock.lock ();
-
-	// save to queue
-	this->m_task_queue.push (std::move (unexecuted->first));
-	// return the worker
-	this->m_available_workers.push_back (worker_p);
+	    execute_task_with_slot (worker_p, std::move (task_ref), std::move (slot));
+	  }
       }
     else
       {
-	// save to queue
-	this->m_task_queue.push (std::move (task_ref));
+	// enqueue the task until a slot is available
+	this->m_task_queue.push_back (std::move (task_ref));
       }
   }
 
   template <stats_t Stats>
   typename worker_pool_elastic<Stats>::unique_slot
-  worker_pool_elastic<Stats>::core_elastic::try_acquire_slot ()
+  worker_pool_elastic<Stats>::core_elastic::try_acquire_slot (bool has_mutex)
   {
-    return m_slots.try_acquire_slot ();
+    auto slot = m_slots.try_acquire_slot (has_mutex);
+    assert (!slot || (slot->get_owner_pool () && slot->get_holder_pool ()));
+
+    return slot;
   }
 
   template <stats_t Stats>
   typename worker_pool_elastic<Stats>::unique_slot
-  worker_pool_elastic<Stats>::core_elastic::acquire_slot ()
+  worker_pool_elastic<Stats>::core_elastic::acquire_slot (bool has_mutex)
   {
-    return m_slots.acquire_slot ();
+    auto slot = m_slots.acquire_slot (has_mutex);
+    assert (slot->get_owner_pool () && slot->get_holder_pool ());
+
+    return slot;
   }
 
   template <stats_t Stats>
   void
-  worker_pool_elastic<Stats>::core_elastic::release_slot (unique_slot slot)
+  worker_pool_elastic<Stats>::core_elastic::release_slot (unique_slot slot, bool has_mutex)
   {
-    m_slots.release_slot (std::move (slot));
+    m_slots.release_slot (std::move (slot), has_mutex);
   }
 
   template <stats_t Stats>
   std::optional<std::pair<typename worker_pool_elastic<Stats>::wrapped_task, typename worker_pool_elastic<Stats>::unique_slot>>
       worker_pool_elastic<Stats>::core_elastic::get_task_and_slot_or_become_available (worker &worker_arg)
   {
-    std::unique_lock<std::mutex> ulock (this->m_workers_mutex, std::defer_lock);
+    std::lock_guard<std::mutex> lock (this->m_core_mutex);
 
-    unique_slot slot = try_acquire_slot ();
-    ulock.lock ();
-    if (slot)
+    if (!this->m_task_queue.empty ())
       {
-	if (!this->m_task_queue.empty ())
+	unique_slot slot = try_acquire_slot ();
+	if (slot)
 	  {
 	    wrapped_task queued_task = std::move (this->m_task_queue.front ());
-	    this->m_task_queue.pop ();
+	    this->m_task_queue.pop_front ();
 
 	    return std::optional<std::pair<wrapped_task, unique_slot>> (std::in_place, std::move (queued_task), std::move (slot));
 	  }
-
-	// insert this worker into available list
-	this->m_available_workers.push_back (&worker_arg);
-	assert (this->m_available_workers.size () <= this->m_workers.size ());
-
-	ulock.unlock ();
-
-	// return the slot
-	release_slot (std::move (slot));
-
-	return std::nullopt;
       }
 
-    // insert this worker into available list
+    // add this worker to the available list
     this->m_available_workers.push_back (&worker_arg);
     assert (this->m_available_workers.size () <= this->m_workers.size ());
 
@@ -329,13 +319,32 @@ namespace cubthread
     worker_p = this->get_available_worker ();
     if (!worker_p)
       {
-	// make a new worker
+	// create a worker when none is available
 	std::unique_ptr<worker> w = this->allocate_worker ();
 	w->set_parent_core (*this);
 	worker_p = w.get ();
 	this->m_workers.push_back (std::move (w));
       }
     return worker_p;
+  }
+
+  template <stats_t Stats>
+  void
+  worker_pool_elastic<Stats>::core_elastic::execute_task_with_slot (worker_elastic *worker_p, wrapped_task &&task_ref,
+      unique_slot slot)
+  {
+    auto unexecuted = worker_p->assign_task (std::move (task_ref), std::move (slot));
+    if (unexecuted.has_value ())
+      {
+	// could not start a new thread; put the task and slot back
+	std::lock_guard<std::mutex> lock (this->m_core_mutex);
+	// requeue the task at the front to preserve FIFO order
+	this->m_task_queue.push_front (std::move (unexecuted->first));
+	// release the slot
+	release_slot (std::move (unexecuted->second));
+	// return the worker to the available list
+	this->m_available_workers.push_back (worker_p);
+      }
   }
 
   template <stats_t Stats>
@@ -357,9 +366,9 @@ namespace cubthread
 
     assert (!this->m_wrapped_task.has_value ());
 
-    // give the task
+    // assign the task
     this->m_wrapped_task.emplace (std::move (task_ref));
-    // give the slot
+    // assign the slot
     m_slot = std::move (slot);
 
     if (this->m_has_thread)
@@ -420,15 +429,14 @@ namespace cubthread
 	    return true;
 	  }
 
-	// wait for task
+	// wait for a task
 	ulock.lock ();
 
 	assert ((!this->m_wrapped_task.has_value () && !m_slot) || (this->m_wrapped_task.has_value () && m_slot));
 
 	if ((!this->m_wrapped_task.has_value () && !m_slot) && !this->m_stop)
 	  {
-	    // wait until a task is received or stopped ...
-	    // ... or time out
+	    // wait for a task, a stop request, or idle timeout
 	    condvar_wait (this->m_task_cv, ulock, this->m_parent_core->get_parent_pool ()->get_idle_timeout (),
 			  [this] () -> bool { return (this->m_wrapped_task.has_value () && m_slot) || this->m_stop; });
 	  }
@@ -439,7 +447,7 @@ namespace cubthread
       }
     else
       {
-	// we need to add to available list
+	// keep this worker visible to the core while it is stopping
 	static_cast<core_elastic *> (this->m_parent_core)->become_available (*this);
 
 	ulock.lock ();
@@ -447,29 +455,29 @@ namespace cubthread
 
     assert ((!this->m_wrapped_task.has_value () && !m_slot) || (this->m_wrapped_task.has_value () && m_slot));
 
-    // does this worker have a task with slot ?
+    // does this worker have both a task and a slot ?
     if (!this->m_wrapped_task.has_value () && !m_slot)
       {
-	// no; this thread will stop. from this point forward, if a new task is assigned, a new thread must be spawned
+	// no task is available; future assignments must start a new thread
 	this->m_has_thread = false;
 
-	// we need to retire context before another thread uses this worker
+	// retire the context before another thread reuses this worker
 	this->finish_run ();
 
 	return false;
       }
     else
       {
-	// unlock mutex
+	// unlock the worker mutex
 	ulock.unlock ();
 
-	// safe-guard - threads should no longer be available
+	// sanity check: this worker should no longer be available
 	static_cast<core_elastic *> (this->m_parent_core)->check_worker_not_available (*this);
 
 	// stats: wake up with task
 	stats::time_and_increment (this->m_stats, stats::id::wakeup_with_task);
 
-	// found task
+	// found a task
 	return true;
       }
   }
@@ -480,16 +488,16 @@ namespace cubthread
   {
     assert (dynamic_cast<core_elastic *> (this->m_parent_core));
     assert (this->m_wrapped_task.has_value () && m_slot);
-    assert (!this->m_context_p->slot);
+    assert (!this->m_context_p->m_slot);
 
-    // give the slot to the entry
-    this->m_context_p->slot = std::move (m_slot);
-    // execute task
+    // move the slot to the thread entry for task execution
+    this->m_context_p->m_slot = std::move (m_slot);
+    // execute the task
     this->m_wrapped_task->execute (*this->m_context_p);
 
     // return the slot to the pool
-    static_cast<core_elastic *> (this->m_parent_core)->release_slot (std::move (this->m_context_p->slot));
-    this->m_context_p->slot = nullptr;
+    static_cast<core_elastic *> (this->m_parent_core)->release_slot (std::move (this->m_context_p->m_slot), false);
+    this->m_context_p->m_slot = nullptr;
 
     // stats: execute task
     stats::time_and_increment (this->m_stats, stats::id::execute_task);

--- a/src/thread/thread_worker_pool_impl.cpp
+++ b/src/thread/thread_worker_pool_impl.cpp
@@ -42,14 +42,6 @@ namespace cubthread
     return os::resources::cpu::effective ().adjusted_max;
   }
 
-  void
-  wp_handle_system_error (const char *message, const std::system_error &e)
-  {
-    er_print_callstack (ARG_FILE_LINE, "%s - throws err = %d: %s\n", message, e.code().value(), e.what ());
-    assert (false);
-    throw e;
-  }
-
   //////////////////////////////////////////////////////////////////////////
   // [optional] useful when using perf
   //////////////////////////////////////////////////////////////////////////

--- a/src/thread/thread_worker_pool_impl.hpp
+++ b/src/thread/thread_worker_pool_impl.hpp
@@ -36,6 +36,7 @@
 // cubrid includes
 #include "perf.hpp"
 #include "resources.hpp"
+#include "system_parameter.h"
 #include "error_manager.h"
 
 // system includes
@@ -309,6 +310,8 @@ namespace cubthread
       virtual void allocate_workers (std::size_t worker_count);
       virtual void initialize_workers ();
 
+      virtual worker *get_available_worker ();
+
       std::vector<std::unique_ptr<worker>> m_workers;
       std::vector<worker *> m_available_workers;
       std::queue<wrapped_task> m_task_queue;
@@ -334,13 +337,13 @@ namespace cubthread
       void initialize () override;
 
       // start thread for current worker
-      void start_thread (void);
+      bool start_thread (void);
       bool has_thread (void);
 
       // assign task to worker; wake a running thread or start a new one.
-      void assign_task (wrapped_task &&task_ref);
+      std::optional<wrapped_task> assign_task (wrapped_task &&task_ref);
       // [optional] used only to prestart pooled threads.
-      void assign_task (void);
+      bool assign_task (void);
 
       // stop execution; if worker has a thread running, returns true
       bool stop_execution (void) override;
@@ -489,11 +492,6 @@ namespace cubthread
   // use it as core count if the task execution must be highly tuned.
   // does not return 0
   std::size_t system_core_count (void);
-
-  // custom worker pool exception handler
-  void wp_handle_system_error (const char *message, const std::system_error &e);
-  template <typename Func>
-  void wp_call_func_throwing_system_error (const char *message, Func &func);
 
   bool wp_is_thread_always_alive_forced ();
   void wp_set_force_thread_always_alive ();
@@ -887,7 +885,7 @@ namespace cubthread
 
     assert (task_p != nullptr);
 
-    worker_impl *refp = nullptr;
+    worker_impl *worker_p = nullptr;
 
     if (!m_parent_pool->is_running ())
       {
@@ -899,15 +897,23 @@ namespace cubthread
     wrapped_task task_ref (task_p);
     std::unique_lock<std::mutex> ulock (m_workers_mutex);
 
-    if (!m_available_workers.empty ())
+    worker_p = static_cast<worker_impl *> (get_available_worker ());
+    if (worker_p)
       {
-	refp = static_cast<worker_impl *> (m_available_workers.back ());
-	m_available_workers.pop_back ();
 	ulock.unlock ();
 
-	assert (refp != nullptr);
+	std::optional<wrapped_task> unexecuted_task = worker_p->assign_task (std::move (task_ref));
+	if (unexecuted_task.has_value ())
+	  {
+	    // failed to start new thread
+	    ulock.lock ();
 
-	refp->assign_task (std::move (task_ref));
+	    // save to queue
+	    m_task_queue.push (std::move (*unexecuted_task));
+
+	    // return the worker back
+	    m_available_workers.push_back (worker_p);
+	  }
       }
     else
       {
@@ -929,8 +935,14 @@ namespace cubthread
 	w = static_cast<worker_impl *> (*it);
 	if (!w->has_thread ())
 	  {
-	    w->assign_task ();
-	    it = m_available_workers.erase (it);
+	    if (w->assign_task ())
+	      {
+		it = m_available_workers.erase (it);
+	      }
+	    else
+	      {
+		++it;
+	      }
 	  }
 	else
 	  {
@@ -1087,7 +1099,11 @@ namespace cubthread
 
 	    // assign task / start thread
 	    // it will add itself to available workers
-	    static_cast<worker_impl *> (worker.get ())->assign_task ();
+	    if (!static_cast<worker_impl *> (worker.get ())->assign_task ())
+	      {
+		// add to available workers
+		m_available_workers.push_back (worker.get ());
+	      }
 	  }
 	else
 	  {
@@ -1095,6 +1111,37 @@ namespace cubthread
 	    m_available_workers.push_back (worker.get ());
 	  }
       }
+  }
+
+  template <stats_t Stats>
+  typename worker_pool::core::worker *
+  worker_pool_impl<Stats>::core_impl::get_available_worker ()
+  {
+    // must be called holding m_workers_mutex.
+    // internally acquires m_task_mutex via has_thread () — caller must NOT hold m_task_mutex.
+
+    worker *worker_p;
+
+    if (m_available_workers.empty ())
+      {
+	return nullptr;
+      }
+
+    for (auto it = m_available_workers.begin (); it != m_available_workers.end (); it++)
+      {
+	if (static_cast<worker_impl *> (*it)->has_thread ())
+	  {
+	    worker_p = *it;
+	    m_available_workers.erase (it);
+
+	    return worker_p;
+	  }
+      }
+
+    worker_p = m_available_workers.back ();
+    m_available_workers.pop_back ();
+
+    return worker_p;
   }
 
   //////////////////////////////////////////////////////////////////////////
@@ -1125,26 +1172,25 @@ namespace cubthread
   }
 
   template <stats_t Stats>
-  void
+  bool
   worker_pool_impl<Stats>::core_impl::worker_impl::start_thread (void)
   {
+    std::thread thread;
+
     assert (m_has_thread);
 
-    //
-    // the next code tries to help visualizing any system errors that can occur during create or detach in debug
-    // mode
-    //
-    // release will basically be reduced to:
-    // std::thread (&worker::run, this).detach ();
-    //
-
-    std::thread t;
-
-    auto lambda_create = [&] (void) -> void { t = std::thread (&worker_impl::run, this); };
-    auto lambda_detach = [&] (void) -> void { t.detach (); };
-
-    wp_call_func_throwing_system_error ("starting thread", lambda_create);
-    wp_call_func_throwing_system_error ("detaching thread", lambda_detach);
+    try
+      {
+	thread = std::thread (&worker_impl::run, this);
+	thread.detach ();
+      }
+    catch (const std::system_error &e)
+      {
+	// er_set ( ... )
+	er_log_debug (ARG_FILE_LINE, "failed to start the thread: %s\n", e.what ());
+	return false;
+      }
+    return true;
   }
 
   template <stats_t Stats>
@@ -1157,7 +1203,7 @@ namespace cubthread
   }
 
   template <stats_t Stats>
-  void
+  std::optional<typename worker_pool_impl<Stats>::wrapped_task>
   worker_pool_impl<Stats>::core_impl::worker_impl::assign_task (wrapped_task &&task_ref)
   {
     std::unique_lock<std::mutex> ulock (m_task_mutex);
@@ -1169,42 +1215,63 @@ namespace cubthread
 
     if (m_has_thread)
       {
-	// notify waiting thread
-	ulock.unlock (); // mutex is not needed for notify
-	m_task_cv.notify_one ();
-      }
-    else
-      {
-	m_has_thread = true;
 	ulock.unlock ();
 
-	assert (m_context_p == nullptr);
+	// notify waiting thread
+	m_task_cv.notify_one ();
 
-	start_thread ();
+	return std::nullopt;
       }
+
+    assert (!m_has_thread);
+
+    m_has_thread = true;
+
+    ulock.unlock ();
+
+    assert (m_context_p == nullptr);
+
+    if (!start_thread ())
+      {
+	ulock.lock ();
+
+	std::optional<wrapped_task> unexecuted_task (std::in_place, std::move (*m_wrapped_task));
+	m_wrapped_task = std::nullopt;
+
+	m_has_thread = false;
+
+	return unexecuted_task;
+      }
+    return std::nullopt;
   }
 
   template <stats_t Stats>
-  void
+  bool
   worker_pool_impl<Stats>::core_impl::worker_impl::assign_task (void)
   {
     std::unique_lock<std::mutex> ulock (m_task_mutex);
 
     assert (!m_wrapped_task.has_value ());
 
-    if (m_has_thread)
-      {
-	ulock.unlock ();
-      }
-    else
+    if (!m_has_thread)
       {
 	m_has_thread = true;
+
 	ulock.unlock ();
 
 	assert (m_context_p == nullptr);
 
-	start_thread ();
+	if (!start_thread ())
+	  {
+	    ulock.lock ();
+
+	    m_has_thread = false;
+
+	    return false;
+	  }
       }
+
+    return true;
   }
 
   template <stats_t Stats>
@@ -1629,28 +1696,6 @@ namespace cubthread
       {
 	return nullptr;
       }
-  }
-
-  //////////////////////////////////////////////////////////////////////////
-  // base functions
-  //////////////////////////////////////////////////////////////////////////
-
-  template <typename Func>
-  void
-  wp_call_func_throwing_system_error (const char *message, Func &func)
-  {
-#if !defined (NDEBUG)
-    try
-      {
-#endif
-	func ();  // no exception catching on release
-#if !defined (NDEBUG)
-      }
-    catch (const std::system_error &e)
-      {
-	wp_handle_system_error (message, e);
-      }
-#endif
   }
 
 } // namespace cubthread

--- a/src/thread/thread_worker_pool_impl.hpp
+++ b/src/thread/thread_worker_pool_impl.hpp
@@ -48,7 +48,7 @@
 #include <vector>
 #include <memory>
 #include <mutex>
-#include <queue>
+#include <deque>
 #include <string>
 #include <system_error>
 #include <thread>
@@ -314,9 +314,10 @@ namespace cubthread
 
       std::vector<std::unique_ptr<worker>> m_workers;
       std::vector<worker *> m_available_workers;
-      std::queue<wrapped_task> m_task_queue;
-      // mutex to synchronize activity on worker lists
-      mutable std::mutex m_workers_mutex;
+      std::deque<wrapped_task> m_task_queue;
+
+      // guards the members in core
+      mutable std::mutex m_core_mutex;
   };
 
   // worker_pool_impl<Stats>::core_impl::worker_impl
@@ -895,7 +896,7 @@ namespace cubthread
       }
 
     wrapped_task task_ref (task_p);
-    std::unique_lock<std::mutex> ulock (m_workers_mutex);
+    std::unique_lock<std::mutex> ulock (m_core_mutex);
 
     worker_p = static_cast<worker_impl *> (get_available_worker ());
     if (worker_p)
@@ -909,7 +910,7 @@ namespace cubthread
 	    ulock.lock ();
 
 	    // save to queue
-	    m_task_queue.push (std::move (*unexecuted_task));
+	    m_task_queue.push_back (std::move (*unexecuted_task));
 
 	    // return the worker back
 	    m_available_workers.push_back (worker_p);
@@ -918,7 +919,7 @@ namespace cubthread
     else
       {
 	// save to queue
-	m_task_queue.push (std::move (task_ref));
+	m_task_queue.push_back (std::move (task_ref));
       }
   }
 
@@ -926,7 +927,7 @@ namespace cubthread
   void
   worker_pool_impl<Stats>::core_impl::warmup (void)
   {
-    std::lock_guard<std::mutex> lock (m_workers_mutex);
+    std::lock_guard<std::mutex> lock (m_core_mutex);
     worker_impl *w;
 
     for (auto it = m_available_workers.begin (); it != m_available_workers.end (); )
@@ -958,7 +959,7 @@ namespace cubthread
     bool has_running_workers = false;
 
     // tell all workers to stop
-    std::unique_lock<std::mutex> ulock (m_workers_mutex);
+    std::unique_lock<std::mutex> ulock (m_core_mutex);
 
     for (const auto &it : m_workers)
       {
@@ -972,12 +973,12 @@ namespace cubthread
   void
   worker_pool_impl<Stats>::core_impl::retire_queued_tasks (void)
   {
-    std::unique_lock<std::mutex> ulock (m_workers_mutex);
+    std::unique_lock<std::mutex> ulock (m_core_mutex);
 
     while (!m_task_queue.empty ())
       {
 	wrapped_task queued_task = std::move (m_task_queue.front ());
-	m_task_queue.pop ();
+	m_task_queue.pop_front ();
 	queued_task.retire ();
       }
   }
@@ -986,12 +987,12 @@ namespace cubthread
   std::optional<typename worker_pool_impl<Stats>::wrapped_task>
   worker_pool_impl<Stats>::core_impl::get_task_or_become_available (worker &worker_arg)
   {
-    std::unique_lock<std::mutex> ulock (m_workers_mutex);
+    std::unique_lock<std::mutex> ulock (m_core_mutex);
 
     if (!m_task_queue.empty ())
       {
 	wrapped_task queued_task = std::move (m_task_queue.front ());
-	m_task_queue.pop ();
+	m_task_queue.pop_front ();
 
 	return std::optional<wrapped_task> (std::in_place, std::move (queued_task));
       }
@@ -1006,7 +1007,7 @@ namespace cubthread
   void
   worker_pool_impl<Stats>::core_impl::become_available (worker &worker_arg)
   {
-    std::unique_lock<std::mutex> ulock (m_workers_mutex);
+    std::unique_lock<std::mutex> ulock (m_core_mutex);
 
     m_available_workers.push_back (&worker_arg);
     assert (m_available_workers.size () <= m_workers.size ());
@@ -1017,7 +1018,7 @@ namespace cubthread
   worker_pool_impl<Stats>::core_impl::check_worker_not_available (const worker &worker_arg)
   {
 #if !defined (NDEBUG)
-    std::unique_lock<std::mutex> ulock (m_workers_mutex);
+    std::unique_lock<std::mutex> ulock (m_core_mutex);
 
     for (const auto it : m_available_workers)
       {
@@ -1037,7 +1038,7 @@ namespace cubthread
   void
   worker_pool_impl<Stats>::core_impl::get_stats (cubperf::stat_value *stats_out) const
   {
-    std::unique_lock<std::mutex> ulock (m_workers_mutex);
+    std::unique_lock<std::mutex> ulock (m_core_mutex);
 
     for (const auto &it : m_workers)
       {
@@ -1050,7 +1051,7 @@ namespace cubthread
   void
   worker_pool_impl<Stats>::core_impl::map_running_contexts (bool &stop, Func &&func, Args &&... args) const
   {
-    std::unique_lock<std::mutex> ulock (m_workers_mutex);
+    std::unique_lock<std::mutex> ulock (m_core_mutex);
 
     for (const auto &worker : m_workers)
       {
@@ -1117,8 +1118,8 @@ namespace cubthread
   typename worker_pool::core::worker *
   worker_pool_impl<Stats>::core_impl::get_available_worker ()
   {
-    // must be called holding m_workers_mutex.
-    // internally acquires m_task_mutex via has_thread () — caller must NOT hold m_task_mutex.
+    // must be called holding m_core_mutex.
+    // it calls has_thread (), which locks m_task_mutex; caller must not hold m_task_mutex
 
     worker *worker_p;
 

--- a/src/thread/thread_worker_pool_impl.hpp
+++ b/src/thread/thread_worker_pool_impl.hpp
@@ -120,13 +120,13 @@ namespace cubthread
       virtual ~worker_pool_impl ();
 
       // init
-      virtual void initialize (std::size_t worker_count, std::size_t core_count) override;
+      void initialize (std::size_t worker_count, std::size_t core_count) override;
 
       // execute task; execution is guaranteed, even if maximum number of tasks is reached.
       void execute (task_type *work_arg) override;
 
       // execute on give core.
-      virtual void execute_on_core (task_type *work_arg, std::size_t core_hash) override;
+      void execute_on_core (task_type *work_arg, std::size_t core_hash) override;
 
       // ensure every available worker has a live thread waiting for tasks.
       // workers currently executing a task are skipped — they already have a thread.
@@ -271,7 +271,7 @@ namespace cubthread
 
       virtual ~core_impl (void);
 
-      virtual void initialize (std::size_t worker_count) override;
+      void initialize (std::size_t worker_count) override;
 
       // execute task
       void execute_task (task_type *task_p) override;
@@ -376,11 +376,11 @@ namespace cubthread
       void finish_run (void);
 
       // execute m_wrapped_task
-      void execute_current_task (void);
+      virtual void execute_current_task (void);
       // retire m_wrapped_task
-      void retire_current_task (void);
+      virtual void retire_current_task (void);
       // get new task from 1. worker pool task queue or 2. wait for incoming tasks
-      bool get_new_task (void);
+      virtual bool get_new_task (void);
 
       context_type *m_context_p;		    // execution context (same lifetime as spawned thread)
       std::optional<wrapped_task> m_wrapped_task;   // current task and metadata


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26687>

### Purpose

동시성 기준으로 작업이 수행되게 하도록 Slot의 반납 - 획득 함수를 호출하는 처리입니다.
이 구조에서는 트랜잭션 Task를 수행하기 위해서는 Slot이 있어야만 합니다. 따라서 아래와 같은 정책을 사용합니다.
CSS, LOCK 대기에 들어가야 하는 경우 Worker는 현재 시간을 기록합니다. (이 지점까지가 PR 범위)
이후 daemon이 순회하며 일정 시간 이상 지난 Worker의 Slot을 빼앗아 core에 반납합니다. (추후 처리할 이슈)

CSS - 클라이언트로부터 데이터를 받을 때까지 대기
LOCK - 잠금을 얻기위한 대기

이 이슈는 3개의 커밋으로 구성되어 있습니다. 완벽하게 쪼개진 못했습니다..

- **Push the task into the task queue if failed to start the new thread.**
Worker pool의 available worker 목록에 있는 worker는 thread를 가지고 있지 않을 수 있습니다. 따라서 작업이 할당되는 순간에 thread를 생성하는데, 이 thread 생성이 실패할 경우 상황을 되돌리고 Task를 queue에 넣도록 합니다.
문제점으로는 thread가 하나도 없는 경우 무한 대기가 일어나게 됩니다. 추후 처리 예정입니다.

- **Add elastic worker and inherit the functions getting the new task**
Worker impl을 상속받아 Slot 기반의 처리를 하도록 일부 함수를 재작성합니다.
주요 변경점은 Task와 Slot이 함께 처리되도록 하는 것입니다. 또, 기존에는 사용 가능한 worker가 없다면 queue에 task를 넣고 대기했습니다.
하지만 Slot이 실행의 기준점이 되므로 slot이 있는데 worker가 없다면 새 worker를 생성합니다. 동일하게 시작에 실패하면 slot을 반납하고 task를 작업에 넣습니다.
또, Task가 FIFO로 수행되도록 하기 위해 queue에 있는 작업 먼저 수행하도록 하였습니다.

-  **Add call in thread suspension routine and call the slot releated functions in lock manager and PL path**
Worker가 잠금 대기나 클라이언트로부터 데이터를 받기 위해 대기하는 경로에 Slot 관련 함수들을 추가하였습니다. 구성은 아래와 같습니다.

```cpp
lock_mutex (thread_lock);
old_status = thread_p->status;
thread_p->status = TS_WAIT;     <---- 이 스레드가 대기 상태임을 명시
thread_p->resume_status = LOCK_SUSPENDED;
start_waiting ()    <---   이 지점에서 Slot에 시간을 기록합니다.

while (thread_p->resume_status == LOCK_SUSPENDED)
     cond_wait (cv, thread_lock);     <---    실직적 대기

if (thread_p->has_slot () == false)   // 대기가 길어져 daemon에 의해 Slot을 빼앗긴 경우
    unlock_mutex (thread_lock);
    acquire_slot ()    <---   이 지점에서 Slot을 얻기 위해 대기합니다.
    lock_mutex (thread_lock);

thread_p->status = old_status;
unlock_mutex (thread_lock);
```

### Implementation

위 내용을 전체적으로 구현했습니다. 이 이슈의 문제점은 아니나 아래와 같은 구현 문제가 있습니다.
acquire_slot ( .. )는 무한 대기가 가능한 함수인데, interrupt를 받아 깨어나려면 동일하게 cv를 사용하고 status를 predicate로 가져야 합니다.
추후 구현하겠지만 이 처리에 따라 설계가 변경될 수도 있습니다.

### Remarks

concurrency pool이 미구현이므로, build에는 성공하지만 CI에는 실패합니다. (아마 core 발생)
