### PR TITLE
[CBRD-26768] Fix stack-use-after-scope in do_prepare_select()

### DIFF
--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -14566,7 +14566,7 @@ do_prepare_select (PARSER_CONTEXT * parser, PT_NODE * statement)
 
   COMPILE_CONTEXT *contextp;
   XASL_STREAM stream;
-  XASL_NODE_HEADER xasl_header;
+  XASL_NODE_HEADER xasl_header = { 0, 0 };
 
   contextp = &parser->context;
 

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -14566,6 +14566,7 @@ do_prepare_select (PARSER_CONTEXT * parser, PT_NODE * statement)
 
   COMPILE_CONTEXT *contextp;
   XASL_STREAM stream;
+  XASL_NODE_HEADER xasl_header;
 
   contextp = &parser->context;
 
@@ -14628,7 +14629,6 @@ do_prepare_select (PARSER_CONTEXT * parser, PT_NODE * statement)
   contextp->recompile_xasl = statement->flag.recompile;
   if (statement->flag.recompile == 0)
     {
-      XASL_NODE_HEADER xasl_header;
       stream.xasl_header = &xasl_header;
 
       err = prepare_query (contextp, &stream);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26768>

### Purpose

* Fix stack-use-after-scope in do_prepare_select() function.

### Implementation

N/A

### Remarks

아래처럼 함수 내에서 특정 조건의 if()문 블럭 내에서 선언된 변수로 포인터를 연결하고
```
XASL_NODE_HEADER xasl_header;
stream.xasl_header = &xasl_header;
```
해당 블럭을 벗어난 다른 곳에서 아래와 같은 매크로를 이용해서 memset을 시도하는 문제입니다.
`INIT_XASL_NODE_HEADER (stream->xasl_header);`
