### PR TITLE
[CBRD-26771] Fix stack-buffer-overflow in file_create()

### DIFF
--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -3261,17 +3261,21 @@ int
 file_create_ehash (THREAD_ENTRY * thread_p, int npages, bool is_tmp, FILE_EHASH_DES * des_ehash, VFID * vfid)
 {
   FILE_TABLESPACE tablespace;
-  FILE_DESCRIPTORS des;
+  FILE_DESCRIPTORS des, *des_p = NULL;
 
-  memset (&des, 0, sizeof (FILE_DESCRIPTORS));
-  des.ehash = *des_ehash;
+  if (des_ehash)
+    {
+      memset (&des, 0, sizeof (FILE_DESCRIPTORS));
+      des.ehash = *des_ehash;
+      des_p = &des;
+    }
 
   assert (npages > 0);
 
   /* todo: use temporary file cache? */
 
   FILE_TABLESPACE_FOR_TEMP_NPAGES (&tablespace, npages);
-  return file_create (thread_p, FILE_EXTENDIBLE_HASH, &tablespace, &des, is_tmp, true, vfid);
+  return file_create (thread_p, FILE_EXTENDIBLE_HASH, &tablespace, des_p, is_tmp, true, vfid);
 }
 
 /*
@@ -3289,17 +3293,21 @@ int
 file_create_ehash_dir (THREAD_ENTRY * thread_p, int npages, bool is_tmp, FILE_EHASH_DES * des_ehash, VFID * vfid)
 {
   FILE_TABLESPACE tablespace;
-  FILE_DESCRIPTORS des;
+  FILE_DESCRIPTORS des, *des_p = NULL;
 
-  memset (&des, 0, sizeof (FILE_DESCRIPTORS));
-  des.ehash = *des_ehash;
+  if (des_ehash)
+    {
+      memset (&des, 0, sizeof (FILE_DESCRIPTORS));
+      des.ehash = *des_ehash;
+      des_p = &des;
+    }
 
   assert (npages > 0);
 
   /* todo: use temporary file cache? */
 
   FILE_TABLESPACE_FOR_TEMP_NPAGES (&tablespace, npages);
-  return file_create (thread_p, FILE_EXTENDIBLE_HASH_DIRECTORY, &tablespace, &des, is_tmp, true, vfid);
+  return file_create (thread_p, FILE_EXTENDIBLE_HASH_DIRECTORY, &tablespace, des_p, is_tmp, true, vfid);
 }
 
 /*

--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -3261,13 +3261,17 @@ int
 file_create_ehash (THREAD_ENTRY * thread_p, int npages, bool is_tmp, FILE_EHASH_DES * des_ehash, VFID * vfid)
 {
   FILE_TABLESPACE tablespace;
+  FILE_DESCRIPTORS des;
+
+  memset (&des, 0, sizeof (FILE_DESCRIPTORS));
+  des.ehash = *des_ehash;
 
   assert (npages > 0);
 
   /* todo: use temporary file cache? */
 
   FILE_TABLESPACE_FOR_TEMP_NPAGES (&tablespace, npages);
-  return file_create (thread_p, FILE_EXTENDIBLE_HASH, &tablespace, (FILE_DESCRIPTORS *) des_ehash, is_tmp, true, vfid);
+  return file_create (thread_p, FILE_EXTENDIBLE_HASH, &tablespace, &des, is_tmp, true, vfid);
 }
 
 /*
@@ -3285,14 +3289,17 @@ int
 file_create_ehash_dir (THREAD_ENTRY * thread_p, int npages, bool is_tmp, FILE_EHASH_DES * des_ehash, VFID * vfid)
 {
   FILE_TABLESPACE tablespace;
+  FILE_DESCRIPTORS des;
+
+  memset (&des, 0, sizeof (FILE_DESCRIPTORS));
+  des.ehash = *des_ehash;
 
   assert (npages > 0);
 
   /* todo: use temporary file cache? */
 
   FILE_TABLESPACE_FOR_TEMP_NPAGES (&tablespace, npages);
-  return file_create (thread_p, FILE_EXTENDIBLE_HASH_DIRECTORY, &tablespace, (FILE_DESCRIPTORS *) des_ehash, is_tmp,
-		      true, vfid);
+  return file_create (thread_p, FILE_EXTENDIBLE_HASH_DIRECTORY, &tablespace, &des, is_tmp, true, vfid);
 }
 
 /*


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26771>

### Purpose

* Fix stack-buffer-overflow in file_create()

### Implementation

N/A

### Remarks

ASan 라이브러리 연결해서 수행시 즉시 검출됩니다만,
그렇지 않을 경우 발견되지 않고,  실제 문제가 될 가능성도 낮을 것으로 판단 됩니다.
