### PR TITLE
[CBRD-26772] Remove db_password member from BOOT_CLIENT_CREDENTIAL struct

### DIFF
--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -1129,10 +1129,9 @@ boot_restart_client (BOOT_CLIENT_CREDENTIAL * client_credential)
   tran_lock_wait_msecs = TRAN_LOCK_INFINITE_WAIT;
 
   er_log_debug (ARG_FILE_LINE,
-		"boot_restart_client: register client { type %d db %s user %s password %s "
+		"boot_restart_client: register client { type %d db %s user %s password **** "
 		"program %s login %s host %s pid %d }\n", client_credential->client_type,
 		client_credential->get_db_name (), client_credential->get_db_user (),
-		client_credential->db_password.empty ()? "(null)" : client_credential->get_db_password (),
 		client_credential->get_program_name (),
 		client_credential->get_login_name (), client_credential->get_host_name (),
 		client_credential->process_id);

--- a/src/transaction/client_credentials.cpp
+++ b/src/transaction/client_credentials.cpp
@@ -223,7 +223,6 @@ clientids::unpack (cubpacking::unpacker &deserializator)
 boot_client_credential::boot_client_credential ()
   : clientids ()
   , db_name {}
-  , db_password {}
   , preferred_hosts (NULL)
   , connect_order (0)
 {
@@ -239,18 +238,12 @@ boot_client_credential::get_db_name () const
   return db_name.c_str ();
 }
 
-const char *
-boot_client_credential::get_db_password () const
-{
-  return db_password.c_str ();
-}
-
 //
 // packing of boot_client_credential
 //
 
 #define BOOTCLCRED_PACKER_ARGS \
-  db_name, db_password
+  db_name
 
 size_t
 boot_client_credential::get_packed_size (cubpacking::packer &serializator, std::size_t start_offset) const

--- a/src/transaction/client_credentials.cpp
+++ b/src/transaction/client_credentials.cpp
@@ -245,7 +245,6 @@ boot_client_credential::get_db_name () const
 #define BOOTCLCRED_PACKER_ARGS \
   db_name
 
-#if !defined(SERVER_MODE)
 size_t
 boot_client_credential::get_packed_size (cubpacking::packer &serializator, std::size_t start_offset) const
 {
@@ -259,11 +258,9 @@ boot_client_credential::pack (cubpacking::packer &serializator) const
   clientids::pack (serializator);
   serializator.pack_all (BOOTCLCRED_PACKER_ARGS);
 }
-#else
 void
 boot_client_credential::unpack (cubpacking::unpacker &deserializator)
 {
   clientids::unpack (deserializator);
   deserializator.unpack_all (BOOTCLCRED_PACKER_ARGS);
 }
-#endif

--- a/src/transaction/client_credentials.cpp
+++ b/src/transaction/client_credentials.cpp
@@ -223,7 +223,6 @@ clientids::unpack (cubpacking::unpacker &deserializator)
 boot_client_credential::boot_client_credential ()
   : clientids ()
   , db_name {}
-  , db_password {}
   , preferred_hosts (NULL)
   , connect_order (0)
 {

--- a/src/transaction/client_credentials.cpp
+++ b/src/transaction/client_credentials.cpp
@@ -244,8 +244,9 @@ boot_client_credential::get_db_name () const
 //
 
 #define BOOTCLCRED_PACKER_ARGS \
-  db_name, db_password
+  db_name
 
+#if !defined(SERVER_MODE)
 size_t
 boot_client_credential::get_packed_size (cubpacking::packer &serializator, std::size_t start_offset) const
 {
@@ -259,10 +260,11 @@ boot_client_credential::pack (cubpacking::packer &serializator) const
   clientids::pack (serializator);
   serializator.pack_all (BOOTCLCRED_PACKER_ARGS);
 }
-
+#else
 void
 boot_client_credential::unpack (cubpacking::unpacker &deserializator)
 {
   clientids::unpack (deserializator);
   deserializator.unpack_all (BOOTCLCRED_PACKER_ARGS);
 }
+#endif

--- a/src/transaction/client_credentials.cpp
+++ b/src/transaction/client_credentials.cpp
@@ -223,6 +223,7 @@ clientids::unpack (cubpacking::unpacker &deserializator)
 boot_client_credential::boot_client_credential ()
   : clientids ()
   , db_name {}
+  , db_password {}
   , preferred_hosts (NULL)
   , connect_order (0)
 {
@@ -243,7 +244,7 @@ boot_client_credential::get_db_name () const
 //
 
 #define BOOTCLCRED_PACKER_ARGS \
-  db_name
+  db_name, db_password
 
 size_t
 boot_client_credential::get_packed_size (cubpacking::packer &serializator, std::size_t start_offset) const

--- a/src/transaction/client_credentials.hpp
+++ b/src/transaction/client_credentials.hpp
@@ -85,7 +85,6 @@ typedef struct boot_client_credential BOOT_CLIENT_CREDENTIAL;
 struct boot_client_credential : public clientids
 {
   std::string db_name;		/* DB_MAX_IDENTIFIER_LENGTH */
-  std::string db_password;		/* DB_MAX_PASSWORD_LENGTH */
   char *preferred_hosts;	/* LINE_MAX */
   int connect_order;
 
@@ -93,7 +92,6 @@ struct boot_client_credential : public clientids
   ~boot_client_credential () override;
 
   const char *get_db_name () const;
-  const char *get_db_password () const;
 
   // packable_object
   virtual size_t get_packed_size (cubpacking::packer &serializator, std::size_t start_offset = 0) const override;

--- a/src/transaction/client_credentials.hpp
+++ b/src/transaction/client_credentials.hpp
@@ -94,12 +94,9 @@ struct boot_client_credential : public clientids
   const char *get_db_name () const;
 
   // packable_object
-#if !defined(SERVER_MODE)
   virtual size_t get_packed_size (cubpacking::packer &serializator, std::size_t start_offset = 0) const override;
   virtual void pack (cubpacking::packer &serializator) const override;
-#else
   virtual void unpack (cubpacking::unpacker &deserializator) override;
-#endif
 };
 
 #endif // !_CLIENT_CREDENTIALS_HPP_

--- a/src/transaction/client_credentials.hpp
+++ b/src/transaction/client_credentials.hpp
@@ -86,9 +86,8 @@ struct boot_client_credential : public clientids
 {
   std::string db_name;		/* DB_MAX_IDENTIFIER_LENGTH */
   /*
-   * FIX-ME: Since db_password is always an empty string and never used, it’s a dead variable.
-   * But because removing it might trigger runtime issues during Rolling Upgrades,
-   * we’ll keep it in the structure for now to ensure backward compatibility
+   * FIXME: The db_password remains an empty string after initialization; it is never assigned a functional value.
+   * But, We are preserving it in the schema to avoid potential runtime failures during rolling upgrades and to maintain backward compatibility
   */
   std::string db_password;	/* DB_MAX_PASSWORD_LENGTH */
   char *preferred_hosts;	/* LINE_MAX */

--- a/src/transaction/client_credentials.hpp
+++ b/src/transaction/client_credentials.hpp
@@ -85,6 +85,12 @@ typedef struct boot_client_credential BOOT_CLIENT_CREDENTIAL;
 struct boot_client_credential : public clientids
 {
   std::string db_name;		/* DB_MAX_IDENTIFIER_LENGTH */
+  /*
+   * FIX-ME: Since db_password is always an empty string and never used, it’s a dead variable.
+   * But because removing it might trigger runtime issues during Rolling Upgrades,
+   * we’ll keep it in the structure for now to ensure backward compatibility
+  */
+  std::string db_password;	/* DB_MAX_PASSWORD_LENGTH */
   char *preferred_hosts;	/* LINE_MAX */
   int connect_order;
 

--- a/src/transaction/client_credentials.hpp
+++ b/src/transaction/client_credentials.hpp
@@ -85,11 +85,6 @@ typedef struct boot_client_credential BOOT_CLIENT_CREDENTIAL;
 struct boot_client_credential : public clientids
 {
   std::string db_name;		/* DB_MAX_IDENTIFIER_LENGTH */
-  /*
-   * FIXME: The db_password remains an empty string after initialization; it is never assigned a functional value.
-   * But, We are preserving it in the schema to avoid potential runtime failures during rolling upgrades and to maintain backward compatibility
-  */
-  std::string db_password;	/* DB_MAX_PASSWORD_LENGTH */
   char *preferred_hosts;	/* LINE_MAX */
   int connect_order;
 
@@ -99,9 +94,12 @@ struct boot_client_credential : public clientids
   const char *get_db_name () const;
 
   // packable_object
+#if !defined(SERVER_MODE)
   virtual size_t get_packed_size (cubpacking::packer &serializator, std::size_t start_offset = 0) const override;
   virtual void pack (cubpacking::packer &serializator) const override;
+#else
   virtual void unpack (cubpacking::unpacker &deserializator) override;
+#endif
 };
 
 #endif // !_CLIENT_CREDENTIALS_HPP_


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26772>

### Purpose

* [refactoring] 접속 과정에서 레벨에 따라서 남겨지는 로그에 패스워드가 남겨지는 형태를 조정합니다.
   기존 password '(null)'   ==> password **** 

### Implementation

N/A

### Remarks

N/A
