### PR TITLE
[CBRD-26785] (feat/oos <-) Align VOT offsets to INT_ALIGNMENT in metaclass and catalog serializers

### DIFF
--- a/src/object/transform_cl.c
+++ b/src/object/transform_cl.c
@@ -673,11 +673,9 @@ re_check:
     {
       size += OR_VAR_TABLE_SIZE_INTERNAL (class_->variable_count, *offset_size_ptr);
 
-      /* Align the variable data area start to 4 bytes (relative to end of header).
-       * OR_GET_VAR_OFFSET() masks off the low 2 bits, so VOT offsets must be multiples of 4. */
-      int var_start = OR_VAR_TABLE_SIZE_INTERNAL (class_->variable_count, *offset_size_ptr)
-	+ class_->fixed_size + OR_BOUND_BIT_BYTES (class_->fixed_count);
-      size += DB_ALIGN (var_start, INT_ALIGNMENT) - var_start;
+      /* Pad the variable data area start to 4 bytes; the MVCC header is already
+       * 4-byte aligned so aligning the running total is equivalent. */
+      size = DB_ALIGN (size, INT_ALIGNMENT);
 
       for (a = class_->fixed_count; a < class_->att_count; a++)
 	{
@@ -746,28 +744,16 @@ put_attributes (OR_BUF * buf, char *obj, SM_CLASS * class_)
     {
       or_put_data (buf, obj + OBJ_HEADER_BOUND_BITS_OFFSET, OR_BOUND_BIT_BYTES (class_->fixed_count));
     }
-  /* write the variable attributes — pad to 4-byte alignment between each,
-   * matching the aligned offsets written by put_varinfo(). */
+  /* write the variable attributes, padding to 4 bytes between each so the
+   * VOT offsets emitted by put_varinfo () remain aligned (see put_varinfo). */
   if (att != NULL)
     {
-      /* align start of variable data area to 4 bytes */
-      int written = (int) (buf->ptr - start);
-      int aligned = DB_ALIGN (written, INT_ALIGNMENT);
-      if (aligned > written)
-	{
-	  or_pad (buf, aligned - written);
-	}
+      or_put_align32 (buf);
     }
   for (; att != NULL; att = (SM_ATTRIBUTE *) att->header.next)
     {
       att->type->data_writemem (buf, obj + att->offset, att->domain);
-      /* align after each variable for the next one */
-      int written = (int) (buf->ptr - start);
-      int aligned = DB_ALIGN (written, INT_ALIGNMENT);
-      if (aligned > written)
-	{
-	  or_pad (buf, aligned - written);
-	}
+      or_put_align32 (buf);
     }
   return NO_ERROR;
 }
@@ -3508,7 +3494,7 @@ representation_size (SM_REPRESENTATION * rep)
 
   size =
     DB_ALIGN (tf_Metaclass_representation.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_representation.mc_n_variable),
-	      4);
+	      INT_ALIGNMENT);
 
   size += DB_ALIGN (substructure_set_size ((DB_LIST *) rep->attributes, (LSIZER) repattribute_size), INT_ALIGNMENT);
 

--- a/src/object/transform_cl.c
+++ b/src/object/transform_cl.c
@@ -624,10 +624,13 @@ put_varinfo (OR_BUF * buf, char *obj, SM_CLASS * class_, int offset_size)
 
   if (class_->variable_count)
     {
-      /* compute the variable offsets relative to the end of the header (beginning of variable table) */
+      /* compute the variable offsets relative to the end of the header (beginning of variable table).
+       * Align each offset to 4 bytes — OR_GET_VAR_OFFSET() masks off the low 2 bits,
+       * so unaligned offsets would cause read errors and OR_IS_OOS false positives. */
       offset =
-	OR_VAR_TABLE_SIZE_INTERNAL (class_->variable_count,
-				    offset_size) + class_->fixed_size + OR_BOUND_BIT_BYTES (class_->fixed_count);
+	DB_ALIGN (OR_VAR_TABLE_SIZE_INTERNAL (class_->variable_count,
+					      offset_size) + class_->fixed_size
+		  + OR_BOUND_BIT_BYTES (class_->fixed_count), INT_ALIGNMENT);
 
       for (a = class_->fixed_count; a < class_->att_count; a++)
 	{
@@ -638,6 +641,7 @@ put_varinfo (OR_BUF * buf, char *obj, SM_CLASS * class_, int offset_size)
 
 	  or_put_offset_internal (buf, offset, offset_size);
 	  offset += len;
+	  offset = DB_ALIGN (offset, INT_ALIGNMENT);
 	}
 
       or_put_offset_internal (buf, OR_SET_VAR_LAST_ELEMENT (offset), offset_size);
@@ -668,12 +672,19 @@ re_check:
   if (class_->variable_count)
     {
       size += OR_VAR_TABLE_SIZE_INTERNAL (class_->variable_count, *offset_size_ptr);
+
+      /* Align the variable data area start to 4 bytes (relative to end of header).
+       * OR_GET_VAR_OFFSET() masks off the low 2 bits, so VOT offsets must be multiples of 4. */
+      int var_start = OR_VAR_TABLE_SIZE_INTERNAL (class_->variable_count, *offset_size_ptr)
+	+ class_->fixed_size + OR_BOUND_BIT_BYTES (class_->fixed_count);
+      size += DB_ALIGN (var_start, INT_ALIGNMENT) - var_start;
+
       for (a = class_->fixed_count; a < class_->att_count; a++)
 	{
 	  att = &class_->attributes[a];
 	  mem = obj + att->offset;
 
-	  size += att->domain->type->get_disk_size_of_mem (mem, att->domain);
+	  size += DB_ALIGN (att->domain->type->get_disk_size_of_mem (mem, att->domain), INT_ALIGNMENT);
 	}
     }
 
@@ -735,11 +746,28 @@ put_attributes (OR_BUF * buf, char *obj, SM_CLASS * class_)
     {
       or_put_data (buf, obj + OBJ_HEADER_BOUND_BITS_OFFSET, OR_BOUND_BIT_BYTES (class_->fixed_count));
     }
-  /* write the variable attributes */
-
+  /* write the variable attributes — pad to 4-byte alignment between each,
+   * matching the aligned offsets written by put_varinfo(). */
+  if (att != NULL)
+    {
+      /* align start of variable data area to 4 bytes */
+      int written = (int) (buf->ptr - start);
+      int aligned = DB_ALIGN (written, INT_ALIGNMENT);
+      if (aligned > written)
+	{
+	  or_pad (buf, aligned - written);
+	}
+    }
   for (; att != NULL; att = (SM_ATTRIBUTE *) att->header.next)
     {
       att->type->data_writemem (buf, obj + att->offset, att->domain);
+      /* align after each variable for the next one */
+      int written = (int) (buf->ptr - start);
+      int aligned = DB_ALIGN (written, INT_ALIGNMENT);
+      if (aligned > written)
+	{
+	  or_pad (buf, aligned - written);
+	}
     }
   return NO_ERROR;
 }
@@ -2021,14 +2049,16 @@ domain_size (TP_DOMAIN * domain)
 {
   int size;
 
-  size = tf_Metaclass_domain.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_domain.mc_n_variable);
+  size =
+    DB_ALIGN (tf_Metaclass_domain.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_domain.mc_n_variable), INT_ALIGNMENT);
 
-  size += enumeration_size (&DOM_GET_ENUMERATION (domain));
+  size += DB_ALIGN (enumeration_size (&DOM_GET_ENUMERATION (domain)), INT_ALIGNMENT);
 
-  size += substructure_set_size ((DB_LIST *) domain->setdomain, (LSIZER) domain_size);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) domain->setdomain, (LSIZER) domain_size), INT_ALIGNMENT);
 
-  size += (domain->json_validator == NULL
-	   ? 0 : string_disk_size (db_json_get_schema_raw_from_validator (domain->json_validator)));
+  size += DB_ALIGN ((domain->json_validator == NULL
+		     ? 0 : string_disk_size (db_json_get_schema_raw_from_validator (domain->json_validator))),
+		    INT_ALIGNMENT);
 
   return (size);
 }
@@ -2060,16 +2090,20 @@ domain_to_disk (OR_BUF * buf, TP_DOMAIN * domain)
   start = buf->ptr;
   offset = tf_Metaclass_domain.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_domain.mc_n_variable);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += substructure_set_size ((DB_LIST *) domain->setdomain, (LSIZER) domain_size);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += enumeration_size (&DOM_GET_ENUMERATION (domain));
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += (domain->json_validator == NULL
 	     ? 0 : string_disk_size (db_json_get_schema_raw_from_validator (domain->json_validator)));
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
@@ -2260,8 +2294,10 @@ metharg_to_disk (OR_BUF * buf, SM_METHOD_ARGUMENT * arg)
   /* VARIABLE OFFSET TABLE */
   start = buf->ptr;
   offset = tf_Metaclass_metharg.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_metharg.mc_n_variable);
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += substructure_set_size ((DB_LIST *) arg->domain, (LSIZER) domain_size);
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
@@ -2298,8 +2334,10 @@ metharg_size (SM_METHOD_ARGUMENT * arg)
 {
   int size;
 
-  size = tf_Metaclass_metharg.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_metharg.mc_n_variable);
-  size += substructure_set_size ((DB_LIST *) arg->domain, (LSIZER) domain_size);
+  size =
+    DB_ALIGN (tf_Metaclass_metharg.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_metharg.mc_n_variable),
+	      INT_ALIGNMENT);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) arg->domain, (LSIZER) domain_size), INT_ALIGNMENT);
 
   return (size);
 }
@@ -2371,18 +2409,23 @@ methsig_to_disk (OR_BUF * buf, SM_METHOD_SIGNATURE * sig)
   /* VARIABLE OFFSET TABLE */
   offset = tf_Metaclass_methsig.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_methsig.mc_n_variable);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += string_disk_size (sig->function_name);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += string_disk_size (sig->sql_definition);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += substructure_set_size ((DB_LIST *) sig->value, (LSIZER) metharg_size);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += substructure_set_size ((DB_LIST *) sig->args, (LSIZER) metharg_size);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
@@ -2422,11 +2465,13 @@ methsig_size (SM_METHOD_SIGNATURE * sig)
 {
   int size;
 
-  size = tf_Metaclass_methsig.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_methsig.mc_n_variable);
-  size += string_disk_size (sig->function_name);
-  size += string_disk_size (sig->sql_definition);
-  size += substructure_set_size ((DB_LIST *) sig->value, (LSIZER) metharg_size);
-  size += substructure_set_size ((DB_LIST *) sig->args, (LSIZER) metharg_size);
+  size =
+    DB_ALIGN (tf_Metaclass_methsig.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_methsig.mc_n_variable),
+	      INT_ALIGNMENT);
+  size += DB_ALIGN (string_disk_size (sig->function_name), INT_ALIGNMENT);
+  size += DB_ALIGN (string_disk_size (sig->sql_definition), INT_ALIGNMENT);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) sig->value, (LSIZER) metharg_size), INT_ALIGNMENT);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) sig->args, (LSIZER) metharg_size), INT_ALIGNMENT);
 
   return (size);
 }
@@ -2523,19 +2568,23 @@ method_to_disk (OR_BUF * buf, SM_METHOD * method)
   /* name */
   offset = tf_Metaclass_method.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_method.mc_n_variable);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += string_disk_size (method->header.name);
 
   /* signature set */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += substructure_set_size ((DB_LIST *) method->signatures, (LSIZER) methsig_size);
 
   /* property list */
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += property_list_size (method->properties);
 
   /* end of variables */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
@@ -2577,10 +2626,11 @@ method_size (SM_METHOD * method)
 {
   int size;
 
-  size = tf_Metaclass_method.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_method.mc_n_variable);
-  size += string_disk_size (method->header.name);
-  size += substructure_set_size ((DB_LIST *) method->signatures, (LSIZER) methsig_size);
-  size += property_list_size (method->properties);
+  size =
+    DB_ALIGN (tf_Metaclass_method.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_method.mc_n_variable), INT_ALIGNMENT);
+  size += DB_ALIGN (string_disk_size (method->header.name), INT_ALIGNMENT);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) method->signatures, (LSIZER) methsig_size), INT_ALIGNMENT);
+  size += DB_ALIGN (property_list_size (method->properties), INT_ALIGNMENT);
 
   return (size);
 }
@@ -2654,15 +2704,18 @@ methfile_to_disk (OR_BUF * buf, SM_METHOD_FILE * file)
   offset = tf_Metaclass_methfile.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_methfile.mc_n_variable);
 
   /* name */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += string_disk_size (file->name);
 
   /* property list */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   /* currently no properties */
   offset += property_list_size (NULL);
 
   /* end of object */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
@@ -2701,9 +2754,11 @@ methfile_size (SM_METHOD_FILE * file)
 {
   int size;
 
-  size = tf_Metaclass_methfile.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_methfile.mc_n_variable);
-  size += string_disk_size (file->name);
-  size += property_list_size (NULL);
+  size =
+    DB_ALIGN (tf_Metaclass_methfile.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_methfile.mc_n_variable),
+	      INT_ALIGNMENT);
+  size += DB_ALIGN (string_disk_size (file->name), INT_ALIGNMENT);
+  size += DB_ALIGN (property_list_size (NULL), INT_ALIGNMENT);
 
   return (size);
 }
@@ -2782,9 +2837,11 @@ query_spec_to_disk (OR_BUF * buf, SM_QUERY_SPEC * query_spec)
   /* VARIABLE OFFSET TABLE */
   offset = tf_Metaclass_query_spec.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_query_spec.mc_n_variable);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += string_disk_size (query_spec->specification);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
@@ -2815,8 +2872,10 @@ query_spec_size (SM_QUERY_SPEC * statement)
 {
   int size;
 
-  size = tf_Metaclass_query_spec.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_query_spec.mc_n_variable);
-  size += string_disk_size (statement->specification);
+  size =
+    DB_ALIGN (tf_Metaclass_query_spec.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_query_spec.mc_n_variable),
+	      INT_ALIGNMENT);
+  size += DB_ALIGN (string_disk_size (statement->specification), INT_ALIGNMENT);
 
   return (size);
 }
@@ -2876,38 +2935,46 @@ attribute_to_disk (OR_BUF * buf, SM_ATTRIBUTE * att)
   /* VARIABLE OFFSET TABLE */
   /* name */
   offset = tf_Metaclass_attribute.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_attribute.mc_n_variable);
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += string_disk_size (att->header.name);
 
   /* initial value variable */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   /* could avoid domain tag here ? */
   offset += or_packed_value_size (&att->default_value.value, 1, 1, 0);
 
   /* original value */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   /* could avoid domain tag here ? */
   offset += or_packed_value_size (&att->default_value.original_value, 1, 1, 0);
 
   /* domain list */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += substructure_set_size ((DB_LIST *) att->domain, (LSIZER) domain_size);
 
   /* trigger list */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   (void) tr_get_cache_objects (att->triggers, &triggers);
   offset += object_set_size (triggers);
 
   /* property list */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += property_list_size (att->properties);
 
   /* comment */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += string_disk_size (att->comment);
 
   /* end of object */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
@@ -2975,20 +3042,22 @@ attribute_size (SM_ATTRIBUTE * att)
   DB_OBJLIST *triggers;
   int size;
 
-  size = tf_Metaclass_attribute.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_attribute.mc_n_variable);
+  size =
+    DB_ALIGN (tf_Metaclass_attribute.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_attribute.mc_n_variable),
+	      INT_ALIGNMENT);
 
-  size += string_disk_size (att->header.name);
-  size += or_packed_value_size (&att->default_value.value, 1, 1, 0);
-  size += or_packed_value_size (&att->default_value.original_value, 1, 1, 0);
-  size += substructure_set_size ((DB_LIST *) att->domain, (LSIZER) domain_size);
+  size += DB_ALIGN (string_disk_size (att->header.name), INT_ALIGNMENT);
+  size += DB_ALIGN (or_packed_value_size (&att->default_value.value, 1, 1, 0), INT_ALIGNMENT);
+  size += DB_ALIGN (or_packed_value_size (&att->default_value.original_value, 1, 1, 0), INT_ALIGNMENT);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) att->domain, (LSIZER) domain_size), INT_ALIGNMENT);
 
   (void) tr_get_cache_objects (att->triggers, &triggers);
-  size += object_set_size (triggers);
+  size += DB_ALIGN (object_set_size (triggers), INT_ALIGNMENT);
 
   /* size += att_extension_size(att); */
-  size += property_list_size (att->properties);
+  size += DB_ALIGN (property_list_size (att->properties), INT_ALIGNMENT);
 
-  size += string_disk_size (att->comment);
+  size += DB_ALIGN (string_disk_size (att->comment), INT_ALIGNMENT);
 
   return (size);
 }
@@ -3191,14 +3260,17 @@ resolution_to_disk (OR_BUF * buf, SM_RESOLUTION * res)
   /* VARIABLE OFFSET TABLE */
   /* name */
   offset = tf_Metaclass_resolution.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_resolution.mc_n_variable);
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += string_disk_size (res->name);
 
   /* new name */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += string_disk_size (res->alias);
 
   /* end of object */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
@@ -3233,9 +3305,11 @@ resolution_size (SM_RESOLUTION * res)
 {
   int size;
 
-  size = tf_Metaclass_resolution.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_resolution.mc_n_variable);
-  size += string_disk_size (res->name);
-  size += string_disk_size (res->alias);
+  size =
+    DB_ALIGN (tf_Metaclass_resolution.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_resolution.mc_n_variable),
+	      INT_ALIGNMENT);
+  size += DB_ALIGN (string_disk_size (res->name), INT_ALIGNMENT);
+  size += DB_ALIGN (string_disk_size (res->alias), INT_ALIGNMENT);
 
   return (size);
 }
@@ -3331,10 +3405,12 @@ repattribute_to_disk (OR_BUF * buf, SM_REPR_ATTRIBUTE * rat)
   offset = tf_Metaclass_repattribute.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_repattribute.mc_n_variable);
 
   /* domain list */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += substructure_set_size ((DB_LIST *) rat->domain, (LSIZER) domain_size);
 
   /* end of object */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
   /* fixed width attributes */
@@ -3369,9 +3445,11 @@ repattribute_size (SM_REPR_ATTRIBUTE * rat)
 {
   int size;
 
-  size = tf_Metaclass_repattribute.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_repattribute.mc_n_variable);
+  size =
+    DB_ALIGN (tf_Metaclass_repattribute.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_repattribute.mc_n_variable),
+	      INT_ALIGNMENT);
 
-  size += substructure_set_size ((DB_LIST *) rat->domain, (LSIZER) domain_size);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) rat->domain, (LSIZER) domain_size), INT_ALIGNMENT);
 
   return (size);
 }
@@ -3428,11 +3506,13 @@ representation_size (SM_REPRESENTATION * rep)
 {
   int size;
 
-  size = tf_Metaclass_representation.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_representation.mc_n_variable);
+  size =
+    DB_ALIGN (tf_Metaclass_representation.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_representation.mc_n_variable),
+	      4);
 
-  size += substructure_set_size ((DB_LIST *) rep->attributes, (LSIZER) repattribute_size);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) rep->attributes, (LSIZER) repattribute_size), INT_ALIGNMENT);
 
-  size += property_list_size (NULL);
+  size += DB_ALIGN (property_list_size (NULL), INT_ALIGNMENT);
 
   return (size);
 }
@@ -3454,12 +3534,15 @@ representation_to_disk (OR_BUF * buf, SM_REPRESENTATION * rep)
   start = buf->ptr;
   offset = tf_Metaclass_representation.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_representation.mc_n_variable);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += substructure_set_size ((DB_LIST *) rep->attributes, (LSIZER) repattribute_size);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += property_list_size (NULL);
   /* end of object */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
@@ -3593,73 +3676,91 @@ put_class_varinfo (OR_BUF * buf, SM_CLASS * class_)
   offset = tf_Metaclass_class.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_class.mc_n_variable);
 
   /* name */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += string_disk_size (sm_ch_name ((MOBJ) class_));
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += string_disk_size (class_->loader_commands);
 
   /* representation set */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += substructure_set_size ((DB_LIST *) class_->representations, (LSIZER) representation_size);
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += object_set_size (class_->users);
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += object_set_size (class_->inheritance);
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += substructure_set_size ((DB_LIST *) class_->attributes, (LSIZER) attribute_size);
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += substructure_set_size ((DB_LIST *) class_->shared, (LSIZER) attribute_size);
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += substructure_set_size ((DB_LIST *) class_->class_attributes, (LSIZER) attribute_size);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += substructure_set_size ((DB_LIST *) class_->methods, (LSIZER) method_size);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += substructure_set_size ((DB_LIST *) class_->class_methods, (LSIZER) method_size);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += substructure_set_size ((DB_LIST *) class_->method_files, (LSIZER) methfile_size);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += substructure_set_size ((DB_LIST *) class_->resolutions, (LSIZER) resolution_size);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += substructure_set_size ((DB_LIST *) class_->query_spec, (LSIZER) query_spec_size);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   (void) tr_get_cache_objects (class_->triggers, &triggers);
   offset += object_set_size (triggers);
 
   /* property list */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += property_list_size (class_->properties);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += string_disk_size (class_->comment);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += substructure_set_size ((DB_LIST *) class_->partition, (LSIZER) partition_info_size);
 
   /* end of object */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
@@ -3833,37 +3934,40 @@ tf_class_size (MOBJ classobj)
 
   size = OR_NON_MVCC_HEADER_SIZE;
 
-  size += tf_Metaclass_class.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_class.mc_n_variable);
+  size +=
+    DB_ALIGN (tf_Metaclass_class.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_class.mc_n_variable), INT_ALIGNMENT);
 
-  size += string_disk_size (sm_ch_name ((MOBJ) class_));
-  size += string_disk_size (class_->loader_commands);
+  size += DB_ALIGN (string_disk_size (sm_ch_name ((MOBJ) class_)), INT_ALIGNMENT);
+  size += DB_ALIGN (string_disk_size (class_->loader_commands), INT_ALIGNMENT);
 
-  size += substructure_set_size ((DB_LIST *) class_->representations, (LSIZER) representation_size);
+  size +=
+    DB_ALIGN (substructure_set_size ((DB_LIST *) class_->representations, (LSIZER) representation_size), INT_ALIGNMENT);
 
-  size += object_set_size (class_->users);
-  size += object_set_size (class_->inheritance);
+  size += DB_ALIGN (object_set_size (class_->users), INT_ALIGNMENT);
+  size += DB_ALIGN (object_set_size (class_->inheritance), INT_ALIGNMENT);
 
-  size += substructure_set_size ((DB_LIST *) class_->attributes, (LSIZER) attribute_size);
-  size += substructure_set_size ((DB_LIST *) class_->shared, (LSIZER) attribute_size);
-  size += substructure_set_size ((DB_LIST *) class_->class_attributes, (LSIZER) attribute_size);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) class_->attributes, (LSIZER) attribute_size), INT_ALIGNMENT);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) class_->shared, (LSIZER) attribute_size), INT_ALIGNMENT);
+  size +=
+    DB_ALIGN (substructure_set_size ((DB_LIST *) class_->class_attributes, (LSIZER) attribute_size), INT_ALIGNMENT);
 
-  size += substructure_set_size ((DB_LIST *) class_->methods, (LSIZER) method_size);
-  size += substructure_set_size ((DB_LIST *) class_->class_methods, (LSIZER) method_size);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) class_->methods, (LSIZER) method_size), INT_ALIGNMENT);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) class_->class_methods, (LSIZER) method_size), INT_ALIGNMENT);
 
-  size += substructure_set_size ((DB_LIST *) class_->method_files, (LSIZER) methfile_size);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) class_->method_files, (LSIZER) methfile_size), INT_ALIGNMENT);
 
-  size += substructure_set_size ((DB_LIST *) class_->resolutions, (LSIZER) resolution_size);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) class_->resolutions, (LSIZER) resolution_size), INT_ALIGNMENT);
 
-  size += substructure_set_size ((DB_LIST *) class_->query_spec, (LSIZER) query_spec_size);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) class_->query_spec, (LSIZER) query_spec_size), INT_ALIGNMENT);
 
   (void) tr_get_cache_objects (class_->triggers, &triggers);
-  size += object_set_size (triggers);
+  size += DB_ALIGN (object_set_size (triggers), INT_ALIGNMENT);
 
-  size += property_list_size (class_->properties);
+  size += DB_ALIGN (property_list_size (class_->properties), INT_ALIGNMENT);
 
-  size += string_disk_size (class_->comment);
+  size += DB_ALIGN (string_disk_size (class_->comment), INT_ALIGNMENT);
 
-  size += substructure_set_size ((DB_LIST *) class_->partition, (LSIZER) partition_info_size);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) class_->partition, (LSIZER) partition_info_size), INT_ALIGNMENT);
 
   return (size);
 }
@@ -4249,10 +4353,12 @@ root_to_disk (OR_BUF * buf, ROOT_CLASS * root)
   offset = tf_Metaclass_root.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_root.mc_n_variable);
 
   /* name */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += string_disk_size (sm_ch_name ((MOBJ) root));
 
   /* end of object */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
@@ -4289,10 +4395,11 @@ root_size (MOBJ rootobj)
   root = (ROOT_CLASS *) rootobj;
 
   size = OR_NON_MVCC_HEADER_SIZE;
-  size += tf_Metaclass_root.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_root.mc_n_variable);
+  size +=
+    DB_ALIGN (tf_Metaclass_root.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_root.mc_n_variable), INT_ALIGNMENT);
 
   /* name */
-  size += string_disk_size (sm_ch_name ((MOBJ) root));
+  size += DB_ALIGN (string_disk_size (sm_ch_name ((MOBJ) root)), INT_ALIGNMENT);
 
   return (size);
 }
@@ -4879,18 +4986,23 @@ partition_info_to_disk (OR_BUF * buf, SM_PARTITION * partition_info)
 
   db_make_sequence (&val, partition_info->values);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += string_disk_size (partition_info->pname);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += string_disk_size (partition_info->expr);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += or_packed_value_size (&val, 1, 1, 0);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += string_disk_size (partition_info->comment);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_last_var_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
@@ -4930,13 +5042,15 @@ partition_info_size (SM_PARTITION * partition_info)
   int size;
   DB_VALUE val;
 
-  size = tf_Metaclass_partition.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_partition.mc_n_variable);
-  size += string_disk_size (partition_info->pname);
-  size += string_disk_size (partition_info->expr);
-  size += string_disk_size (partition_info->comment);
+  size =
+    DB_ALIGN (tf_Metaclass_partition.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_partition.mc_n_variable),
+	      INT_ALIGNMENT);
+  size += DB_ALIGN (string_disk_size (partition_info->pname), INT_ALIGNMENT);
+  size += DB_ALIGN (string_disk_size (partition_info->expr), INT_ALIGNMENT);
+  size += DB_ALIGN (string_disk_size (partition_info->comment), INT_ALIGNMENT);
 
   db_make_sequence (&val, partition_info->values);
-  size += or_packed_value_size (&val, 1, 1, 0);
+  size += DB_ALIGN (or_packed_value_size (&val, 1, 1, 0), INT_ALIGNMENT);
 
   return (size);
 }

--- a/src/object/transform_cl.c
+++ b/src/object/transform_cl.c
@@ -624,9 +624,9 @@ put_varinfo (OR_BUF * buf, char *obj, SM_CLASS * class_, int offset_size)
 
   if (class_->variable_count)
     {
-      /* compute the variable offsets relative to the end of the header (beginning of variable table).
-       * Align each offset to 4 bytes — OR_GET_VAR_OFFSET() masks off the low 2 bits,
-       * so unaligned offsets would cause read errors and OR_IS_OOS false positives. */
+      /* VOT offsets must be 4-byte aligned: the low 2 bits are reserved for flags
+       * (one of them is the OOS flag, read by OR_IS_OOS / masked off by OR_GET_VAR_OFFSET).
+       * Align the first offset, then re-align after adding each attribute length. */
       offset =
 	DB_ALIGN (OR_VAR_TABLE_SIZE_INTERNAL (class_->variable_count,
 					      offset_size) + class_->fixed_size
@@ -673,8 +673,9 @@ re_check:
     {
       size += OR_VAR_TABLE_SIZE_INTERNAL (class_->variable_count, *offset_size_ptr);
 
-      /* Pad the variable data area start to 4 bytes; the MVCC header is already
-       * 4-byte aligned so aligning the running total is equivalent. */
+      /* The variable data area starts on a 4-byte boundary, and each variable
+       * attribute is padded to 4 bytes. Sizes here must agree with the offsets
+       * emitted by put_varinfo () and the bytes written by put_attributes (). */
       size = DB_ALIGN (size, INT_ALIGNMENT);
 
       for (a = class_->fixed_count; a < class_->att_count; a++)
@@ -744,8 +745,10 @@ put_attributes (OR_BUF * buf, char *obj, SM_CLASS * class_)
     {
       or_put_data (buf, obj + OBJ_HEADER_BOUND_BITS_OFFSET, OR_BOUND_BIT_BYTES (class_->fixed_count));
     }
-  /* write the variable attributes, padding to 4 bytes between each so the
-   * VOT offsets emitted by put_varinfo () remain aligned (see put_varinfo). */
+  /* Write the variable attributes. The VOT offsets emitted by put_varinfo ()
+   * are 4-byte aligned, so we pad up to a 4-byte boundary at the start of the
+   * variable data area and after every attribute — that way the write cursor
+   * always lands on the offset the VOT advertises. */
   if (att != NULL)
     {
       or_put_align32 (buf);

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -583,6 +583,13 @@ catcls_guess_record_length (OR_VALUE * value_p)
       length += map_p->get_disk_size_of_value (&attrs_p[i].value);
     }
 
+  /* catcls_put_or_value_into_buffer () calls or_put_align32 () once per
+   * variable column and once before the last offset; each can add up to
+   * INT_ALIGNMENT - 1 zero pad bytes to keep VOT offsets 4-byte aligned.
+   * Reserve INT_ALIGNMENT per attribute as a conservative upper bound so the
+   * caller's malloc is large enough to hold the padded record. */
+  length += INT_ALIGNMENT * (n_attrs + 1);
+
   return (length);
 }
 

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -3291,20 +3291,12 @@ catcls_put_or_value_into_buffer (OR_VALUE * value_p, int chn, OR_BUF * buf_p, OI
       or_put_data (buf_p, bound_bits, bound_size);
     }
 
-  /* variable */
+  /* variable — VOT offsets must be 4-byte aligned because OR_GET_VAR_OFFSET ()
+   * masks the low 2 bits (flag bits OR_VAR_BIT_OOS, OR_VAR_BIT_LAST_ELEMENT). */
   var_attrs = &attrs[n_fixed];
   for (i = 0; i < n_variable; i++)
     {
-      /* Align variable data position to 4 bytes — OR_GET_VAR_OFFSET() masks off
-       * the low 2 bits, so unaligned offsets would lose precision. */
-      {
-	int current = (int) (buf_p->ptr - buf_p->buffer - header_size);
-	int aligned = DB_ALIGN (current, INT_ALIGNMENT);
-	if (aligned > current)
-	  {
-	    or_pad (buf_p, aligned - current);
-	  }
-      }
+      or_put_align32 (buf_p);
 
       /* the variable offsets are relative to end of the class record header */
       offset = (int) (buf_p->ptr - buf_p->buffer - header_size);
@@ -3317,14 +3309,7 @@ catcls_put_or_value_into_buffer (OR_VALUE * value_p, int chn, OR_BUF * buf_p, OI
     }
 
   /* put last offset */
-  {
-    int current = (int) (buf_p->ptr - buf_p->buffer - header_size);
-    int aligned = DB_ALIGN (current, INT_ALIGNMENT);
-    if (aligned > current)
-      {
-	or_pad (buf_p, aligned - current);
-      }
-  }
+  or_put_align32 (buf_p);
   offset = (int) (buf_p->ptr - buf_p->buffer - header_size);
   OR_PUT_LAST_VAR_OFFSET (offset_p, offset);
 

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -3295,6 +3295,17 @@ catcls_put_or_value_into_buffer (OR_VALUE * value_p, int chn, OR_BUF * buf_p, OI
   var_attrs = &attrs[n_fixed];
   for (i = 0; i < n_variable; i++)
     {
+      /* Align variable data position to 4 bytes — OR_GET_VAR_OFFSET() masks off
+       * the low 2 bits, so unaligned offsets would lose precision. */
+      {
+	int current = (int) (buf_p->ptr - buf_p->buffer - header_size);
+	int aligned = DB_ALIGN (current, INT_ALIGNMENT);
+	if (aligned > current)
+	  {
+	    or_pad (buf_p, aligned - current);
+	  }
+      }
+
       /* the variable offsets are relative to end of the class record header */
       offset = (int) (buf_p->ptr - buf_p->buffer - header_size);
 
@@ -3306,6 +3317,14 @@ catcls_put_or_value_into_buffer (OR_VALUE * value_p, int chn, OR_BUF * buf_p, OI
     }
 
   /* put last offset */
+  {
+    int current = (int) (buf_p->ptr - buf_p->buffer - header_size);
+    int aligned = DB_ALIGN (current, INT_ALIGNMENT);
+    if (aligned > current)
+      {
+	or_pad (buf_p, aligned - current);
+      }
+  }
   offset = (int) (buf_p->ptr - buf_p->buffer - header_size);
   OR_PUT_LAST_VAR_OFFSET (offset_p, offset);
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -27952,7 +27952,27 @@ heap_recdes_check_has_oos (const RECDES * recdes)
 
   const int offset_size = OR_GET_OFFSET_SIZE (recdes->data);
   void *var_table = OR_GET_OBJECT_VAR_TABLE (recdes->data);
-  const int max_var_count = (recdes->length - OR_HEADER_SIZE (recdes->data)) / offset_size;
+  const int header_size = OR_HEADER_SIZE (recdes->data);
+  const int max_var_count = (recdes->length - header_size) / offset_size;
+
+  /* Sanity check: validate the first VOT entry is a reasonable offset.
+   * Class/root records have different internal formats — their data area
+   * looks like garbage when interpreted as a VOT. */
+  if (max_var_count > 0)
+    {
+      int first;
+      if (offset_size == OR_BYTE_SIZE)
+	first = OR_GET_BYTE (OR_VAR_TABLE_ELEMENT_PTR (var_table, 0, offset_size));
+      else if (offset_size == OR_SHORT_SIZE)
+	first = (unsigned short) OR_GET_SHORT (OR_VAR_TABLE_ELEMENT_PTR (var_table, 0, offset_size));
+      else
+	first = OR_GET_INT (OR_VAR_TABLE_ELEMENT_PTR (var_table, 0, offset_size));
+      int clean = first & ~OR_VAR_FLAG_MASK;
+      if (clean < 0 || clean > recdes->length)
+	{
+	  return false;
+	}
+    }
 
   for (int index = 0;; ++index)
     {

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -855,7 +855,7 @@ static int heap_insert_adjust_recdes_header (THREAD_ENTRY * thread_p, HEAP_OPERA
 					     bool is_mvcc_class);
 static int heap_update_adjust_recdes_header (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * update_context,
 					     bool is_mvcc_class);
-static bool heap_recdes_check_has_oos (const RECDES * recdes);
+static bool heap_recdes_compute_oos_flag (const RECDES * recdes);
 static int heap_insert_handle_multipage_record (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context);
 static int heap_get_insert_location_with_lock (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context,
 					       PGBUF_WATCHER * home_hint_p);
@@ -21741,7 +21741,7 @@ heap_update_adjust_recdes_header (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEX
   mvcc_flags = (repid_and_flag_bits >> OR_MVCC_FLAG_SHIFT_BITS) & OR_MVCC_FLAG_MASK;
   update_mvcc_flags = OR_MVCC_FLAG_VALID_INSID | OR_MVCC_FLAG_VALID_PREV_VERSION;
 
-  bool has_oos = heap_recdes_check_has_oos (update_context->recdes_p);
+  bool has_oos = heap_recdes_compute_oos_flag (update_context->recdes_p);
 
   if (has_oos)
     {
@@ -27942,8 +27942,43 @@ heap_recdes_get_oos_oids (const RECDES * recdes, OID_VECTOR & oos_oids)
   return ER_FAILED;
 }
 
+/*
+ * heap_recdes_compute_oos_flag - decide whether OR_MVCC_FLAG_HAS_OOS should be
+ *                                set on this record's MVCC header
+ *    return: true if the VOT contains any OOS-flagged entry, false otherwise
+ *    recdes(in): heap record being written
+ *
+ * Note:
+ *    Counterpart of heap_recdes_contains_oos (). The two functions look alike
+ *    but serve opposite ends of the OOS-flag lifecycle:
+ *
+ *      compute  (this fn):  scan the VOT once at update time, derive the flag,
+ *                           and store it in the MVCC header. Called by
+ *                           heap_update_adjust_recdes_header ().
+ *      contains:            on read, do an O(1) bit test on the cached header
+ *                           flag. Hot path; called from locator_sr.c and from
+ *                           heap_recdes_get_oos_oids ().
+ *
+ *    "compute" is the source of truth that produces the value "contains"
+ *    later reads back.
+ *
+ *    Defense against non-object-instance records: the heap can hold records
+ *    with layouts other than the object-instance VOT format (class records,
+ *    root records, etc.). For those, the bytes read as a VOT offset are
+ *    arbitrary and could spuriously satisfy OR_IS_OOS.
+ *
+ *    The caller of this function asserts !OID_IS_ROOTOID() upstream, but we
+ *    still validate the first VOT entry as a cheap belt-and-suspenders check:
+ *    a real first offset must fall inside [0, recdes->length] (after masking
+ *    the two flag bits). Anything outside that range means we are not looking
+ *    at a real VOT, and we return false rather than walking arbitrary bytes.
+ *
+ *    Only index 0 needs the bound check — once the first entry validates,
+ *    the loop is self-terminating via OR_IS_OOS or OR_IS_LAST_ELEMENT, and
+ *    max_var_count is a backstop against malformed data.
+ */
 static bool
-heap_recdes_check_has_oos (const RECDES * recdes)
+heap_recdes_compute_oos_flag (const RECDES * recdes)
 {
   if (recdes == NULL || recdes->data == NULL)
     {
@@ -27979,9 +28014,7 @@ heap_recdes_check_has_oos (const RECDES * recdes)
 	  return false;
 	}
 
-      /* Sanity check on the first entry: class/root records use a different
-       * internal layout and their data area looks like garbage when read as a
-       * VOT. A grossly out-of-range first offset means this is not a VOT. */
+      /* First-entry bound check — see the function header for the rationale. */
       if (index == 0)
 	{
 	  const int clean = offset & ~OR_VAR_FLAG_MASK;

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -27952,27 +27952,7 @@ heap_recdes_check_has_oos (const RECDES * recdes)
 
   const int offset_size = OR_GET_OFFSET_SIZE (recdes->data);
   void *var_table = OR_GET_OBJECT_VAR_TABLE (recdes->data);
-  const int header_size = OR_HEADER_SIZE (recdes->data);
-  const int max_var_count = (recdes->length - header_size) / offset_size;
-
-  /* Sanity check: validate the first VOT entry is a reasonable offset.
-   * Class/root records have different internal formats — their data area
-   * looks like garbage when interpreted as a VOT. */
-  if (max_var_count > 0)
-    {
-      int first;
-      if (offset_size == OR_BYTE_SIZE)
-	first = OR_GET_BYTE (OR_VAR_TABLE_ELEMENT_PTR (var_table, 0, offset_size));
-      else if (offset_size == OR_SHORT_SIZE)
-	first = (unsigned short) OR_GET_SHORT (OR_VAR_TABLE_ELEMENT_PTR (var_table, 0, offset_size));
-      else
-	first = OR_GET_INT (OR_VAR_TABLE_ELEMENT_PTR (var_table, 0, offset_size));
-      int clean = first & ~OR_VAR_FLAG_MASK;
-      if (clean < 0 || clean > recdes->length)
-	{
-	  return false;
-	}
-    }
+  const int max_var_count = (recdes->length - OR_HEADER_SIZE (recdes->data)) / offset_size;
 
   for (int index = 0;; ++index)
     {
@@ -27997,6 +27977,18 @@ heap_recdes_check_has_oos (const RECDES * recdes)
 	default:
 	  assert (false && "unexpected variable offset size");
 	  return false;
+	}
+
+      /* Sanity check on the first entry: class/root records use a different
+       * internal layout and their data area looks like garbage when read as a
+       * VOT. A grossly out-of-range first offset means this is not a VOT. */
+      if (index == 0)
+	{
+	  const int clean = offset & ~OR_VAR_FLAG_MASK;
+	  if (clean < 0 || clean > recdes->length)
+	    {
+	      return false;
+	    }
 	}
 
       if (OR_IS_OOS (offset))


### PR DESCRIPTION
https://jira.cubrid.org/browse/CBRD-26785

## Description

`transform_cl.c` (클라이언트 측 recdes 생성 경로) 의 VOT(Variable Offset Table) 오프셋을 항상 4-byte 정렬하도록 보정한다.

VOT 엔트리 하위 2비트는 `OR_VAR_BIT_OOS` / `OR_VAR_BIT_LAST_ELEMENT` flag 로 reserved 되어 있으므로 오프셋 자체는 4의 배수여야 한다. 사용자 데이터 레코드는 정렬을 보장하지만, `transform_cl.c` 의 카탈로그/메타클래스 직렬화기는 그렇지 않아 홀수 오프셋이 발생할 수 있었다.

## Implementation

DB_ALIGN, or_put_offset 을 이용한 recdes VOT 4byte align

## Test Plan

- [x] debug 빌드 성공
- [x] `createdb demodb en_US` 후 `[OOS-CONSISTENCY] MISMATCH` 0건 (이전 6건)
- [ ] CI (SQL / medium)

## Remarks

- `heap_recdes_check_has_oos()` 의 이름이 모호해서 `heap_recdes_compute_oos_flag()` 로 rename. 같은 파일의 `heap_recdes_contains_oos()` (헤더 flag 비트를 읽는 hot-path 함수) 와 한 글자 차이라 역할 구분이 안 됐는데, 이 함수는 update 시점에 VOT 를 스캔해서 그 flag 값을 *결정* 하는 함수다.