### PR TITLE
[CBRD-26785] (develop <-) Align VOT offsets to INT_ALIGNMENT in metaclass and catalog serializers

### DIFF
--- a/src/object/transform_cl.c
+++ b/src/object/transform_cl.c
@@ -624,10 +624,13 @@ put_varinfo (OR_BUF * buf, char *obj, SM_CLASS * class_, int offset_size)
 
   if (class_->variable_count)
     {
-      /* compute the variable offsets relative to the end of the header (beginning of variable table) */
+      /* compute the variable offsets relative to the end of the header (beginning of variable table).
+       * Align each offset to 4 bytes — OR_GET_VAR_OFFSET() masks off the low 2 bits,
+       * so unaligned offsets would cause read errors and OR_IS_OOS false positives. */
       offset =
-	OR_VAR_TABLE_SIZE_INTERNAL (class_->variable_count,
-				    offset_size) + class_->fixed_size + OR_BOUND_BIT_BYTES (class_->fixed_count);
+	DB_ALIGN (OR_VAR_TABLE_SIZE_INTERNAL (class_->variable_count,
+					      offset_size) + class_->fixed_size
+		  + OR_BOUND_BIT_BYTES (class_->fixed_count), INT_ALIGNMENT);
 
       for (a = class_->fixed_count; a < class_->att_count; a++)
 	{
@@ -638,6 +641,7 @@ put_varinfo (OR_BUF * buf, char *obj, SM_CLASS * class_, int offset_size)
 
 	  or_put_offset_internal (buf, offset, offset_size);
 	  offset += len;
+	  offset = DB_ALIGN (offset, INT_ALIGNMENT);
 	}
 
       or_put_offset_internal (buf, offset, offset_size);
@@ -669,12 +673,19 @@ re_check:
   if (class_->variable_count)
     {
       size += OR_VAR_TABLE_SIZE_INTERNAL (class_->variable_count, *offset_size_ptr);
+
+      /* Align the variable data area start to 4 bytes (relative to end of header).
+       * OR_GET_VAR_OFFSET() masks off the low 2 bits, so VOT offsets must be multiples of 4. */
+      int var_start = OR_VAR_TABLE_SIZE_INTERNAL (class_->variable_count, *offset_size_ptr)
+	+ class_->fixed_size + OR_BOUND_BIT_BYTES (class_->fixed_count);
+      size += DB_ALIGN (var_start, INT_ALIGNMENT) - var_start;
+
       for (a = class_->fixed_count; a < class_->att_count; a++)
 	{
 	  att = &class_->attributes[a];
 	  mem = obj + att->offset;
 
-	  size += att->domain->type->get_disk_size_of_mem (mem, att->domain);
+	  size += DB_ALIGN (att->domain->type->get_disk_size_of_mem (mem, att->domain), INT_ALIGNMENT);
 	}
     }
 
@@ -736,11 +747,28 @@ put_attributes (OR_BUF * buf, char *obj, SM_CLASS * class_)
     {
       or_put_data (buf, obj + OBJ_HEADER_BOUND_BITS_OFFSET, OR_BOUND_BIT_BYTES (class_->fixed_count));
     }
-  /* write the variable attributes */
-
+  /* write the variable attributes — pad to 4-byte alignment between each,
+   * matching the aligned offsets written by put_varinfo(). */
+  if (att != NULL)
+    {
+      /* align start of variable data area to 4 bytes */
+      int written = (int) (buf->ptr - start);
+      int aligned = DB_ALIGN (written, INT_ALIGNMENT);
+      if (aligned > written)
+	{
+	  or_pad (buf, aligned - written);
+	}
+    }
   for (; att != NULL; att = (SM_ATTRIBUTE *) att->header.next)
     {
       att->type->data_writemem (buf, obj + att->offset, att->domain);
+      /* align after each variable for the next one */
+      int written = (int) (buf->ptr - start);
+      int aligned = DB_ALIGN (written, INT_ALIGNMENT);
+      if (aligned > written)
+	{
+	  or_pad (buf, aligned - written);
+	}
     }
   return NO_ERROR;
 }
@@ -2022,14 +2050,16 @@ domain_size (TP_DOMAIN * domain)
 {
   int size;
 
-  size = tf_Metaclass_domain.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_domain.mc_n_variable);
+  size =
+    DB_ALIGN (tf_Metaclass_domain.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_domain.mc_n_variable), INT_ALIGNMENT);
 
-  size += enumeration_size (&DOM_GET_ENUMERATION (domain));
+  size += DB_ALIGN (enumeration_size (&DOM_GET_ENUMERATION (domain)), INT_ALIGNMENT);
 
-  size += substructure_set_size ((DB_LIST *) domain->setdomain, (LSIZER) domain_size);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) domain->setdomain, (LSIZER) domain_size), INT_ALIGNMENT);
 
-  size += (domain->json_validator == NULL
-	   ? 0 : string_disk_size (db_json_get_schema_raw_from_validator (domain->json_validator)));
+  size += DB_ALIGN ((domain->json_validator == NULL
+		     ? 0 : string_disk_size (db_json_get_schema_raw_from_validator (domain->json_validator))),
+		    INT_ALIGNMENT);
 
   return (size);
 }
@@ -2061,16 +2091,20 @@ domain_to_disk (OR_BUF * buf, TP_DOMAIN * domain)
   start = buf->ptr;
   offset = tf_Metaclass_domain.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_domain.mc_n_variable);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += substructure_set_size ((DB_LIST *) domain->setdomain, (LSIZER) domain_size);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += enumeration_size (&DOM_GET_ENUMERATION (domain));
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += (domain->json_validator == NULL
 	     ? 0 : string_disk_size (db_json_get_schema_raw_from_validator (domain->json_validator)));
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
@@ -2261,8 +2295,10 @@ metharg_to_disk (OR_BUF * buf, SM_METHOD_ARGUMENT * arg)
   /* VARIABLE OFFSET TABLE */
   start = buf->ptr;
   offset = tf_Metaclass_metharg.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_metharg.mc_n_variable);
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += substructure_set_size ((DB_LIST *) arg->domain, (LSIZER) domain_size);
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
@@ -2299,8 +2335,10 @@ metharg_size (SM_METHOD_ARGUMENT * arg)
 {
   int size;
 
-  size = tf_Metaclass_metharg.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_metharg.mc_n_variable);
-  size += substructure_set_size ((DB_LIST *) arg->domain, (LSIZER) domain_size);
+  size =
+    DB_ALIGN (tf_Metaclass_metharg.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_metharg.mc_n_variable),
+	      INT_ALIGNMENT);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) arg->domain, (LSIZER) domain_size), INT_ALIGNMENT);
 
   return (size);
 }
@@ -2372,18 +2410,23 @@ methsig_to_disk (OR_BUF * buf, SM_METHOD_SIGNATURE * sig)
   /* VARIABLE OFFSET TABLE */
   offset = tf_Metaclass_methsig.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_methsig.mc_n_variable);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += string_disk_size (sig->function_name);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += string_disk_size (sig->sql_definition);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += substructure_set_size ((DB_LIST *) sig->value, (LSIZER) metharg_size);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += substructure_set_size ((DB_LIST *) sig->args, (LSIZER) metharg_size);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
@@ -2423,11 +2466,13 @@ methsig_size (SM_METHOD_SIGNATURE * sig)
 {
   int size;
 
-  size = tf_Metaclass_methsig.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_methsig.mc_n_variable);
-  size += string_disk_size (sig->function_name);
-  size += string_disk_size (sig->sql_definition);
-  size += substructure_set_size ((DB_LIST *) sig->value, (LSIZER) metharg_size);
-  size += substructure_set_size ((DB_LIST *) sig->args, (LSIZER) metharg_size);
+  size =
+    DB_ALIGN (tf_Metaclass_methsig.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_methsig.mc_n_variable),
+	      INT_ALIGNMENT);
+  size += DB_ALIGN (string_disk_size (sig->function_name), INT_ALIGNMENT);
+  size += DB_ALIGN (string_disk_size (sig->sql_definition), INT_ALIGNMENT);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) sig->value, (LSIZER) metharg_size), INT_ALIGNMENT);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) sig->args, (LSIZER) metharg_size), INT_ALIGNMENT);
 
   return (size);
 }
@@ -2524,19 +2569,23 @@ method_to_disk (OR_BUF * buf, SM_METHOD * method)
   /* name */
   offset = tf_Metaclass_method.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_method.mc_n_variable);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += string_disk_size (method->header.name);
 
   /* signature set */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += substructure_set_size ((DB_LIST *) method->signatures, (LSIZER) methsig_size);
 
   /* property list */
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += property_list_size (method->properties);
 
   /* end of variables */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
@@ -2578,10 +2627,11 @@ method_size (SM_METHOD * method)
 {
   int size;
 
-  size = tf_Metaclass_method.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_method.mc_n_variable);
-  size += string_disk_size (method->header.name);
-  size += substructure_set_size ((DB_LIST *) method->signatures, (LSIZER) methsig_size);
-  size += property_list_size (method->properties);
+  size =
+    DB_ALIGN (tf_Metaclass_method.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_method.mc_n_variable), INT_ALIGNMENT);
+  size += DB_ALIGN (string_disk_size (method->header.name), INT_ALIGNMENT);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) method->signatures, (LSIZER) methsig_size), INT_ALIGNMENT);
+  size += DB_ALIGN (property_list_size (method->properties), INT_ALIGNMENT);
 
   return (size);
 }
@@ -2655,15 +2705,18 @@ methfile_to_disk (OR_BUF * buf, SM_METHOD_FILE * file)
   offset = tf_Metaclass_methfile.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_methfile.mc_n_variable);
 
   /* name */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += string_disk_size (file->name);
 
   /* property list */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   /* currently no properties */
   offset += property_list_size (NULL);
 
   /* end of object */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
@@ -2702,9 +2755,11 @@ methfile_size (SM_METHOD_FILE * file)
 {
   int size;
 
-  size = tf_Metaclass_methfile.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_methfile.mc_n_variable);
-  size += string_disk_size (file->name);
-  size += property_list_size (NULL);
+  size =
+    DB_ALIGN (tf_Metaclass_methfile.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_methfile.mc_n_variable),
+	      INT_ALIGNMENT);
+  size += DB_ALIGN (string_disk_size (file->name), INT_ALIGNMENT);
+  size += DB_ALIGN (property_list_size (NULL), INT_ALIGNMENT);
 
   return (size);
 }
@@ -2783,9 +2838,11 @@ query_spec_to_disk (OR_BUF * buf, SM_QUERY_SPEC * query_spec)
   /* VARIABLE OFFSET TABLE */
   offset = tf_Metaclass_query_spec.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_query_spec.mc_n_variable);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += string_disk_size (query_spec->specification);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
@@ -2816,8 +2873,10 @@ query_spec_size (SM_QUERY_SPEC * statement)
 {
   int size;
 
-  size = tf_Metaclass_query_spec.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_query_spec.mc_n_variable);
-  size += string_disk_size (statement->specification);
+  size =
+    DB_ALIGN (tf_Metaclass_query_spec.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_query_spec.mc_n_variable),
+	      INT_ALIGNMENT);
+  size += DB_ALIGN (string_disk_size (statement->specification), INT_ALIGNMENT);
 
   return (size);
 }
@@ -2877,38 +2936,46 @@ attribute_to_disk (OR_BUF * buf, SM_ATTRIBUTE * att)
   /* VARIABLE OFFSET TABLE */
   /* name */
   offset = tf_Metaclass_attribute.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_attribute.mc_n_variable);
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += string_disk_size (att->header.name);
 
   /* initial value variable */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   /* could avoid domain tag here ? */
   offset += or_packed_value_size (&att->default_value.value, 1, 1, 0);
 
   /* original value */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   /* could avoid domain tag here ? */
   offset += or_packed_value_size (&att->default_value.original_value, 1, 1, 0);
 
   /* domain list */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += substructure_set_size ((DB_LIST *) att->domain, (LSIZER) domain_size);
 
   /* trigger list */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   (void) tr_get_cache_objects (att->triggers, &triggers);
   offset += object_set_size (triggers);
 
   /* property list */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += property_list_size (att->properties);
 
   /* comment */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += string_disk_size (att->comment);
 
   /* end of object */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
@@ -2976,20 +3043,22 @@ attribute_size (SM_ATTRIBUTE * att)
   DB_OBJLIST *triggers;
   int size;
 
-  size = tf_Metaclass_attribute.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_attribute.mc_n_variable);
+  size =
+    DB_ALIGN (tf_Metaclass_attribute.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_attribute.mc_n_variable),
+	      INT_ALIGNMENT);
 
-  size += string_disk_size (att->header.name);
-  size += or_packed_value_size (&att->default_value.value, 1, 1, 0);
-  size += or_packed_value_size (&att->default_value.original_value, 1, 1, 0);
-  size += substructure_set_size ((DB_LIST *) att->domain, (LSIZER) domain_size);
+  size += DB_ALIGN (string_disk_size (att->header.name), INT_ALIGNMENT);
+  size += DB_ALIGN (or_packed_value_size (&att->default_value.value, 1, 1, 0), INT_ALIGNMENT);
+  size += DB_ALIGN (or_packed_value_size (&att->default_value.original_value, 1, 1, 0), INT_ALIGNMENT);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) att->domain, (LSIZER) domain_size), INT_ALIGNMENT);
 
   (void) tr_get_cache_objects (att->triggers, &triggers);
-  size += object_set_size (triggers);
+  size += DB_ALIGN (object_set_size (triggers), INT_ALIGNMENT);
 
   /* size += att_extension_size(att); */
-  size += property_list_size (att->properties);
+  size += DB_ALIGN (property_list_size (att->properties), INT_ALIGNMENT);
 
-  size += string_disk_size (att->comment);
+  size += DB_ALIGN (string_disk_size (att->comment), INT_ALIGNMENT);
 
   return (size);
 }
@@ -3192,14 +3261,17 @@ resolution_to_disk (OR_BUF * buf, SM_RESOLUTION * res)
   /* VARIABLE OFFSET TABLE */
   /* name */
   offset = tf_Metaclass_resolution.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_resolution.mc_n_variable);
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += string_disk_size (res->name);
 
   /* new name */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += string_disk_size (res->alias);
 
   /* end of object */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
@@ -3234,9 +3306,11 @@ resolution_size (SM_RESOLUTION * res)
 {
   int size;
 
-  size = tf_Metaclass_resolution.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_resolution.mc_n_variable);
-  size += string_disk_size (res->name);
-  size += string_disk_size (res->alias);
+  size =
+    DB_ALIGN (tf_Metaclass_resolution.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_resolution.mc_n_variable),
+	      INT_ALIGNMENT);
+  size += DB_ALIGN (string_disk_size (res->name), INT_ALIGNMENT);
+  size += DB_ALIGN (string_disk_size (res->alias), INT_ALIGNMENT);
 
   return (size);
 }
@@ -3332,10 +3406,12 @@ repattribute_to_disk (OR_BUF * buf, SM_REPR_ATTRIBUTE * rat)
   offset = tf_Metaclass_repattribute.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_repattribute.mc_n_variable);
 
   /* domain list */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += substructure_set_size ((DB_LIST *) rat->domain, (LSIZER) domain_size);
 
   /* end of object */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
   /* fixed width attributes */
@@ -3370,9 +3446,11 @@ repattribute_size (SM_REPR_ATTRIBUTE * rat)
 {
   int size;
 
-  size = tf_Metaclass_repattribute.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_repattribute.mc_n_variable);
+  size =
+    DB_ALIGN (tf_Metaclass_repattribute.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_repattribute.mc_n_variable),
+	      INT_ALIGNMENT);
 
-  size += substructure_set_size ((DB_LIST *) rat->domain, (LSIZER) domain_size);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) rat->domain, (LSIZER) domain_size), INT_ALIGNMENT);
 
   return (size);
 }
@@ -3429,11 +3507,13 @@ representation_size (SM_REPRESENTATION * rep)
 {
   int size;
 
-  size = tf_Metaclass_representation.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_representation.mc_n_variable);
+  size =
+    DB_ALIGN (tf_Metaclass_representation.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_representation.mc_n_variable),
+	      4);
 
-  size += substructure_set_size ((DB_LIST *) rep->attributes, (LSIZER) repattribute_size);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) rep->attributes, (LSIZER) repattribute_size), INT_ALIGNMENT);
 
-  size += property_list_size (NULL);
+  size += DB_ALIGN (property_list_size (NULL), INT_ALIGNMENT);
 
   return (size);
 }
@@ -3455,12 +3535,15 @@ representation_to_disk (OR_BUF * buf, SM_REPRESENTATION * rep)
   start = buf->ptr;
   offset = tf_Metaclass_representation.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_representation.mc_n_variable);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += substructure_set_size ((DB_LIST *) rep->attributes, (LSIZER) repattribute_size);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += property_list_size (NULL);
   /* end of object */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
@@ -3594,73 +3677,91 @@ put_class_varinfo (OR_BUF * buf, SM_CLASS * class_)
   offset = tf_Metaclass_class.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_class.mc_n_variable);
 
   /* name */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += string_disk_size (sm_ch_name ((MOBJ) class_));
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += string_disk_size (class_->loader_commands);
 
   /* representation set */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += substructure_set_size ((DB_LIST *) class_->representations, (LSIZER) representation_size);
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += object_set_size (class_->users);
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += object_set_size (class_->inheritance);
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += substructure_set_size ((DB_LIST *) class_->attributes, (LSIZER) attribute_size);
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += substructure_set_size ((DB_LIST *) class_->shared, (LSIZER) attribute_size);
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += substructure_set_size ((DB_LIST *) class_->class_attributes, (LSIZER) attribute_size);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += substructure_set_size ((DB_LIST *) class_->methods, (LSIZER) method_size);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += substructure_set_size ((DB_LIST *) class_->class_methods, (LSIZER) method_size);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += substructure_set_size ((DB_LIST *) class_->method_files, (LSIZER) methfile_size);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += substructure_set_size ((DB_LIST *) class_->resolutions, (LSIZER) resolution_size);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += substructure_set_size ((DB_LIST *) class_->query_spec, (LSIZER) query_spec_size);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   (void) tr_get_cache_objects (class_->triggers, &triggers);
   offset += object_set_size (triggers);
 
   /* property list */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += property_list_size (class_->properties);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += string_disk_size (class_->comment);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
 
   offset += substructure_set_size ((DB_LIST *) class_->partition, (LSIZER) partition_info_size);
 
   /* end of object */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
@@ -3834,37 +3935,40 @@ tf_class_size (MOBJ classobj)
 
   size = OR_NON_MVCC_HEADER_SIZE;
 
-  size += tf_Metaclass_class.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_class.mc_n_variable);
+  size +=
+    DB_ALIGN (tf_Metaclass_class.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_class.mc_n_variable), INT_ALIGNMENT);
 
-  size += string_disk_size (sm_ch_name ((MOBJ) class_));
-  size += string_disk_size (class_->loader_commands);
+  size += DB_ALIGN (string_disk_size (sm_ch_name ((MOBJ) class_)), INT_ALIGNMENT);
+  size += DB_ALIGN (string_disk_size (class_->loader_commands), INT_ALIGNMENT);
 
-  size += substructure_set_size ((DB_LIST *) class_->representations, (LSIZER) representation_size);
+  size +=
+    DB_ALIGN (substructure_set_size ((DB_LIST *) class_->representations, (LSIZER) representation_size), INT_ALIGNMENT);
 
-  size += object_set_size (class_->users);
-  size += object_set_size (class_->inheritance);
+  size += DB_ALIGN (object_set_size (class_->users), INT_ALIGNMENT);
+  size += DB_ALIGN (object_set_size (class_->inheritance), INT_ALIGNMENT);
 
-  size += substructure_set_size ((DB_LIST *) class_->attributes, (LSIZER) attribute_size);
-  size += substructure_set_size ((DB_LIST *) class_->shared, (LSIZER) attribute_size);
-  size += substructure_set_size ((DB_LIST *) class_->class_attributes, (LSIZER) attribute_size);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) class_->attributes, (LSIZER) attribute_size), INT_ALIGNMENT);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) class_->shared, (LSIZER) attribute_size), INT_ALIGNMENT);
+  size +=
+    DB_ALIGN (substructure_set_size ((DB_LIST *) class_->class_attributes, (LSIZER) attribute_size), INT_ALIGNMENT);
 
-  size += substructure_set_size ((DB_LIST *) class_->methods, (LSIZER) method_size);
-  size += substructure_set_size ((DB_LIST *) class_->class_methods, (LSIZER) method_size);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) class_->methods, (LSIZER) method_size), INT_ALIGNMENT);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) class_->class_methods, (LSIZER) method_size), INT_ALIGNMENT);
 
-  size += substructure_set_size ((DB_LIST *) class_->method_files, (LSIZER) methfile_size);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) class_->method_files, (LSIZER) methfile_size), INT_ALIGNMENT);
 
-  size += substructure_set_size ((DB_LIST *) class_->resolutions, (LSIZER) resolution_size);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) class_->resolutions, (LSIZER) resolution_size), INT_ALIGNMENT);
 
-  size += substructure_set_size ((DB_LIST *) class_->query_spec, (LSIZER) query_spec_size);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) class_->query_spec, (LSIZER) query_spec_size), INT_ALIGNMENT);
 
   (void) tr_get_cache_objects (class_->triggers, &triggers);
-  size += object_set_size (triggers);
+  size += DB_ALIGN (object_set_size (triggers), INT_ALIGNMENT);
 
-  size += property_list_size (class_->properties);
+  size += DB_ALIGN (property_list_size (class_->properties), INT_ALIGNMENT);
 
-  size += string_disk_size (class_->comment);
+  size += DB_ALIGN (string_disk_size (class_->comment), INT_ALIGNMENT);
 
-  size += substructure_set_size ((DB_LIST *) class_->partition, (LSIZER) partition_info_size);
+  size += DB_ALIGN (substructure_set_size ((DB_LIST *) class_->partition, (LSIZER) partition_info_size), INT_ALIGNMENT);
 
   return (size);
 }
@@ -4250,10 +4354,12 @@ root_to_disk (OR_BUF * buf, ROOT_CLASS * root)
   offset = tf_Metaclass_root.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_root.mc_n_variable);
 
   /* name */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += string_disk_size (sm_ch_name ((MOBJ) root));
 
   /* end of object */
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
@@ -4290,10 +4396,11 @@ root_size (MOBJ rootobj)
   root = (ROOT_CLASS *) rootobj;
 
   size = OR_NON_MVCC_HEADER_SIZE;
-  size += tf_Metaclass_root.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_root.mc_n_variable);
+  size +=
+    DB_ALIGN (tf_Metaclass_root.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_root.mc_n_variable), INT_ALIGNMENT);
 
   /* name */
-  size += string_disk_size (sm_ch_name ((MOBJ) root));
+  size += DB_ALIGN (string_disk_size (sm_ch_name ((MOBJ) root)), INT_ALIGNMENT);
 
   return (size);
 }
@@ -4880,18 +4987,23 @@ partition_info_to_disk (OR_BUF * buf, SM_PARTITION * partition_info)
 
   db_make_sequence (&val, partition_info->values);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += string_disk_size (partition_info->pname);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += string_disk_size (partition_info->expr);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += or_packed_value_size (&val, 1, 1, 0);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   offset += string_disk_size (partition_info->comment);
 
+  offset = DB_ALIGN (offset, INT_ALIGNMENT);
   or_put_offset (buf, offset);
   buf->ptr = PTR_ALIGN (buf->ptr, INT_ALIGNMENT);
 
@@ -4931,13 +5043,15 @@ partition_info_size (SM_PARTITION * partition_info)
   int size;
   DB_VALUE val;
 
-  size = tf_Metaclass_partition.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_partition.mc_n_variable);
-  size += string_disk_size (partition_info->pname);
-  size += string_disk_size (partition_info->expr);
-  size += string_disk_size (partition_info->comment);
+  size =
+    DB_ALIGN (tf_Metaclass_partition.mc_fixed_size + OR_VAR_TABLE_SIZE (tf_Metaclass_partition.mc_n_variable),
+	      INT_ALIGNMENT);
+  size += DB_ALIGN (string_disk_size (partition_info->pname), INT_ALIGNMENT);
+  size += DB_ALIGN (string_disk_size (partition_info->expr), INT_ALIGNMENT);
+  size += DB_ALIGN (string_disk_size (partition_info->comment), INT_ALIGNMENT);
 
   db_make_sequence (&val, partition_info->values);
-  size += or_packed_value_size (&val, 1, 1, 0);
+  size += DB_ALIGN (or_packed_value_size (&val, 1, 1, 0), INT_ALIGNMENT);
 
   return (size);
 }

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -3295,6 +3295,17 @@ catcls_put_or_value_into_buffer (OR_VALUE * value_p, int chn, OR_BUF * buf_p, OI
   var_attrs = &attrs[n_fixed];
   for (i = 0; i < n_variable; i++)
     {
+      /* Align variable data position to 4 bytes — OR_GET_VAR_OFFSET() masks off
+       * the low 2 bits, so unaligned offsets would lose precision. */
+      {
+	int current = (int) (buf_p->ptr - buf_p->buffer - header_size);
+	int aligned = DB_ALIGN (current, INT_ALIGNMENT);
+	if (aligned > current)
+	  {
+	    or_pad (buf_p, aligned - current);
+	  }
+      }
+
       /* the variable offsets are relative to end of the class record header */
       offset = (int) (buf_p->ptr - buf_p->buffer - header_size);
 
@@ -3306,6 +3317,14 @@ catcls_put_or_value_into_buffer (OR_VALUE * value_p, int chn, OR_BUF * buf_p, OI
     }
 
   /* put last offset */
+  {
+    int current = (int) (buf_p->ptr - buf_p->buffer - header_size);
+    int aligned = DB_ALIGN (current, INT_ALIGNMENT);
+    if (aligned > current)
+      {
+	or_pad (buf_p, aligned - current);
+      }
+  }
   offset = (int) (buf_p->ptr - buf_p->buffer - header_size);
   OR_PUT_OFFSET (offset_p, offset);
 


### PR DESCRIPTION
https://jira.cubrid.org/browse/CBRD-26785

> **TL;DR**: feat/oos 의 alignment 수정(#7162)을 develop 에도 적용했을 때 CI 가 깨지지 않는지 검증하기 위한 PR. develop 은 VOT 의 bit-flag 스킴이 없어 alignment 가 *기능적 필요*는 아니지만, 정렬 자체는 무해하고 disk 포맷 invariant 차원에서 미리 맞춰두는 의미가 있다.

## Summary

- **변경**: `transform_cl.c` 의 13개 메타클래스 `*_to_disk()` / `*_size()` 와 `catalog_class.c::catcls_put_or_value_into_buffer()` 의 VOT 오프셋을 `INT_ALIGNMENT` 경계로 정렬. feat/oos 용 PR #7162 의 develop-port 버전.
- **이유**: feat/oos 의 alignment 수정이 develop 에 머지될 때 회귀가 없는지 사전 확인. OOS 머지 시 충돌·재작업 최소화.
- **영향**: `src/object/transform_cl.c`, `src/storage/catalog_class.c`. develop 의 카탈로그 disk 포맷은 신규 레코드의 padding 만 0-3 byte 늘어남. 기존 카탈로그를 읽을 때는 `OR_VAR_OFFSET()` 가 알아서 읽으므로 호환성 무해.
- **리뷰 포인트**: (1) 본 PR 은 검증용이며 develop 단독 머지 대상이 아닐 수 있음 — 머지 결정은 OOS 머지 시점과 동조 검토. (2) CI(SQL/shell/medium) 가 깨지지 않는지가 본 PR 의 핵심 검증 목적.

---

## Description

feat/oos 브랜치의 alignment 수정 PR (#7162) 을 develop base 로 cherry-pick 해서 CI 만 돌려 보는 용도의 PR 이다. OOS 머지 시점에 alignment 수정이 develop CI 를 깨지 않는지 사전에 확인한다.

### feat/oos 의 alignment 수정 vs develop port 차이

| 항목 | feat/oos (PR #7162) | develop port (this PR) |
|---|---|---|
| `transform_cl.c` DB_ALIGN 삽입 | O | O (동일) |
| `catalog_class.c` `or_pad` 삽입 | O | O (동일) |
| `heap_file.c` `heap_recdes_check_has_oos` sanity check | O | X (함수 자체가 develop 에 없음) |
| `or_put_last_var_offset` / `OR_SET_VAR_LAST_ELEMENT` | feat/oos 의 OOS 마지막-엔트리 sentinel API 사용 | develop 의 기존 `or_put_offset` 사용 |

`OR_VAR_BIT_OOS` / `OR_VAR_BIT_LAST_ELEMENT` flag 스킴은 OOS 기능이라 develop 에 없다. 그러므로 develop 에서는 holiday-precision-loss 또는 OOS 오탐 문제 자체가 없고, 본 PR 의 변경은 *예방적 정렬* 의 성격을 띤다.

## Implementation

### `src/object/transform_cl.c`

- `put_varinfo()` / `put_attributes()`: 가변 컬럼 사이 `DB_ALIGN` / `or_pad` 적용.
- 13개 메타클래스 `*_to_disk()` (`domain`, `metharg`, `methsig`, `method`, `methfile`, `query_spec`, `attribute`, `resolution`, `repattribute`, `representation`, `class`, `root`, `partition`): 매 `or_put_offset()` 직전 `offset = DB_ALIGN (offset, INT_ALIGNMENT);` 삽입.
- 대응되는 `*_size()` 함수: 각 가변 컬럼 size 가산을 `DB_ALIGN(그 size, INT_ALIGNMENT)` 로 감싸기.

### `src/storage/catalog_class.c`

- `catcls_put_or_value_into_buffer()`: variable column 루프 진입 직전과 last-offset 기록 직전에 `or_pad()` 로 `INT_ALIGNMENT` 경계까지 padding.

## Test Plan

- [ ] CI 통과 (SQL/shell/medium) 확인이 본 PR 의 주된 목적.
- [ ] 기존 카탈로그 호환성 회귀 없음.

## Remarks

- 본 PR 은 CI 검증용이며 머지 가부는 OOS 머지 일정과 함께 검토.
- 자매 PR: #7162 (feat/oos base).
- 부모 epic: CBRD-26583 (OOS M2).