### PR TITLE
[CBRD-26789] fix a wrong null termination of an error message

### DIFF
--- a/src/broker/cas_error.c
+++ b/src/broker/cas_error.c
@@ -121,7 +121,7 @@ error_info_set_with_msg (int err_number, int err_indicator, const char *err_msg,
 
   err_info.err_indicator = err_indicator;
   strncpy (err_info.err_file, file, ERR_FILE_LENGTH - 1);
-  err_info.err_string[ERR_FILE_LENGTH - 1] = 0;
+  err_info.err_file[ERR_FILE_LENGTH - 1] = 0;
   err_info.err_line = line;
 
   if (err_indicator == CAS_ERROR_INDICATOR)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26789>

### Purpose

CAS 의 전역 구조체인 err_info 의 err_string 필드에 잘못된 '\0' 를 대입하는 한 줄을 수정합니다. 

### Remarks

문제 현상 없이 코드 수정 중에 발견한 버그 입니다. 
