### PR TITLE
[CBRD-26799] Fix row loss in parallel index build dual-cursor desync

### DIFF
--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -3343,6 +3343,9 @@ btree_sort_get_next_parallel (THREAD_ENTRY * thread_p, RECDES * temp_recdes, voi
   HFID hfid;
   VPID vpid = vpid_Null_vpid;
 
+  /* CBRD-26678: cur_oid snapshot to re-sync the slot cursor with the page cursor at nofit */
+  OID slot_resume_oid;
+
   db_make_null (&dbvalue);
 
   aligned_midxkey_buf = PTR_ALIGN (midxkey_buf, MAX_ALIGNMENT);
@@ -3355,6 +3358,8 @@ btree_sort_get_next_parallel (THREAD_ENTRY * thread_p, RECDES * temp_recdes, voi
   VPID_SET_NULL (&vpid);
   hfid = sort_args->hfids[0];
   PGBUF_INIT_WATCHER (&old_pgwatcher, PGBUF_ORDERED_HEAP_NORMAL, &hfid);
+
+  OID_SET_NULL (&slot_resume_oid);
 
   if (OID_ISNULL (&sort_args->cur_oid))
     {
@@ -3408,6 +3413,8 @@ btree_sort_get_next_parallel (THREAD_ENTRY * thread_p, RECDES * temp_recdes, voi
 	}
       else
 	{
+	  /* snapshot resume slot before heap_next_1page advances cur_oid (CBRD-26678 nofit) */
+	  slot_resume_oid = sort_args->cur_oid;
 	  slot_iter_scan_result =
 	    heap_next_1page (thread_p, &sort_args->hfids[cur_class], &vpid, &sort_args->class_ids[cur_class],
 			     &sort_args->cur_oid, &sort_args->in_recdes, &sort_args->hfscan_cache,
@@ -3633,6 +3640,19 @@ btree_sort_get_next_parallel (THREAD_ENTRY * thread_p, RECDES * temp_recdes, voi
   while (true);
 
 nofit:
+
+  /* CBRD-26678: re-anchor cur_oid onto vpid's page so the page cursor can't desync and skip a page */
+  assert (!VPID_ISNULL (&vpid));
+  if (!OID_ISNULL (&slot_resume_oid))
+    {
+      sort_args->cur_oid = slot_resume_oid;
+    }
+  else
+    {
+      sort_args->cur_oid.volid = vpid.volid;
+      sort_args->cur_oid.pageid = vpid.pageid;
+      sort_args->cur_oid.slotid = 0;
+    }
 
   if (dbvalue_ptr == &dbvalue || dbvalue_ptr->need_clear == true)
     {

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -3343,7 +3343,6 @@ btree_sort_get_next_parallel (THREAD_ENTRY * thread_p, RECDES * temp_recdes, voi
   HFID hfid;
   VPID vpid = vpid_Null_vpid;
 
-  /* CBRD-26678: cur_oid snapshot to re-sync the slot cursor with the page cursor at nofit */
   OID slot_resume_oid;
 
   db_make_null (&dbvalue);
@@ -3413,7 +3412,6 @@ btree_sort_get_next_parallel (THREAD_ENTRY * thread_p, RECDES * temp_recdes, voi
 	}
       else
 	{
-	  /* snapshot resume slot before heap_next_1page advances cur_oid (CBRD-26678 nofit) */
 	  slot_resume_oid = sort_args->cur_oid;
 	  slot_iter_scan_result =
 	    heap_next_1page (thread_p, &sort_args->hfids[cur_class], &vpid, &sort_args->class_ids[cur_class],
@@ -3641,7 +3639,6 @@ btree_sort_get_next_parallel (THREAD_ENTRY * thread_p, RECDES * temp_recdes, voi
 
 nofit:
 
-  /* CBRD-26678: re-anchor cur_oid onto vpid's page so the page cursor can't desync and skip a page */
   assert (!VPID_ISNULL (&vpid));
   if (!OID_ISNULL (&slot_resume_oid))
     {


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26799>

## 개요

`btree_sort_get_next_parallel` (CBRD-26678 / PR #7011 에서 추가된 parallel index build 경로) 은 스캔 커서를 **두 개** 유지합니다:

- 슬롯 커서 `sort_args->cur_oid` — `heap_next_1page` 가 전진시킴
- 페이지 커서 `sort_args->curr_sec` / `curr_pgoffset` — `get_next_vpid` 가 전진시킴

`SORT_REC_DOESNT_FIT` (nofit) 시 `bt_load_put_buf_to_record` 가 `cur_oid` 를 함수 진입 시점의 `prev_oid` 로 되감습니다. 그런데 같은 invocation 안에서 heap page 전환이 일어났던 경우, 슬롯 커서는 이전 페이지로 되돌아가는 반면 페이지 커서는 이미 다음 페이지를 가리키고 있습니다. 이어지는 invocation 에서 `get_next_vpid` 의 무조건적인 `(*offset)++` 가 그 다음 페이지를 통째로 건너뛰어, 약 1 heap page 분량의 row 가 빌드된 B-tree 에 들어가지 못합니다.

결과적으로 parallel 경로로 수행한 `CREATE INDEX` 가 간헐적으로(약 6/100) 약 180~250건의 entry 가 누락된 인덱스를 만듭니다. 일반 `count(*)` heap scan 은 정상이며, index scan(예: `INDEX_SS`)으로만 유실이 드러납니다. serial 경로인 `btree_sort_get_next` 는 커서가 하나라 영향이 없습니다.

## 구현

- 각 `heap_next_1page` 호출 직전에 `cur_oid` 를 지역 변수 `slot_resume_oid` 로 스냅샷합니다.
- `nofit` 레이블에서 `cur_oid` 를 `vpid` 의 페이지로 재정렬합니다 (`slot_resume_oid` 사용, null 인 경우 `vpid` 의 slot 0). 이로써 슬롯 커서와 페이지 커서가 더 이상 어긋나지 않습니다.

`src/storage/btree_load.c` 만 수정했으며 serial 경로는 그대로 둡니다.

## 테스트

- [x] release 빌드, `failure.sql` 재현 스크립트 **562/562 회 정상** (수정 전 약 6/100 실패)
- [x] 모든 실행에서 `select count(*) from t` (heap scan) 은 정상 — 수정 전에도 heap 은 무결, 빌드된 인덱스만 부족했음
