### PR TITLE
[CBRD-26690] Adjust the concurrency parameters in runtime.

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -5203,7 +5203,7 @@ SYSPRM_PARAM prm_Def[] = {
 #else
    {false, {.i = 1}},
    {false, {.i = 1}},
-   {false, {.i = 1}},
+   NULL_SYSPRM_PARAM_VALUE,
    {false, {.i = 1}},
 #endif
    (char *) NULL,
@@ -5223,7 +5223,7 @@ SYSPRM_PARAM prm_Def[] = {
 #else
    {false, {.i = 1}},
    {false, {.i = 1}},
-   {false, {.i = 1}},
+   NULL_SYSPRM_PARAM_VALUE,
    {false, {.i = 1}},
 #endif
    (char *) NULL,

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -2880,6 +2880,18 @@ css_count_transaction_worker_threads (THREAD_ENTRY * thread_p, int tran_index, i
   return count;
 }
 
+void
+css_set_max_concurrency_and_workers (std::size_t max_concurrency, std::size_t max_worker)
+{
+  if (css_Server_request_worker_pool)
+    {
+      assert (max_concurrency > 0);
+      assert (max_worker >= max_concurrency);
+
+      css_Server_request_worker_pool->adjust_runtime_parameter (max_concurrency, max_worker);
+    }
+}
+
 size_t css_get_max_connections ()
 {
   return css_get_max_conn () + 1;

--- a/src/connection/server_support.h
+++ b/src/connection/server_support.h
@@ -110,6 +110,7 @@ extern void css_get_task_stats (UINT64 * stats_out);
 extern size_t css_get_num_request_workers (void);
 extern bool css_are_all_request_handlers_suspended (void);
 extern size_t css_count_transaction_worker_threads (THREAD_ENTRY * thread_p, int tran_index, int client_id);
+extern void css_set_max_concurrency_and_workers (std::size_t max_concurrency, std::size_t max_worker);
 
 extern void css_set_thread_info (THREAD_ENTRY * thread_p, int client_id, int rid, int tran_index,
 				 int net_request_index);

--- a/src/thread/concurrency_slot.cpp
+++ b/src/thread/concurrency_slot.cpp
@@ -22,7 +22,8 @@
 
 #include "concurrency_slot.hpp"
 #include "thread_manager.hpp"
-#include "boot_sr.h"
+#include "server_support.h"
+#include "system_parameter.h"
 #include "error_manager.h"
 
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
@@ -175,6 +176,8 @@ namespace cubthread
     : concurrency_slot_subscriber (concurrency_slot_daemon::get_publisher ())
     , m_available_slots ()
     , m_surplus_since ()
+    , m_slot_count (0)
+    , m_target_count (0)
     , m_wait_queue ()
     , m_mutex (&mtx)
   {
@@ -193,9 +196,48 @@ namespace cubthread
       {
 	m_available_slots.emplace (std::unique_ptr<concurrency_slot> (new concurrency_slot (this)));
       }
+    m_slot_count = concurrency;
+    m_target_count = concurrency;
 
     // attach to the daemon
     concurrency_slot_subscriber::activate (identifier);
+  }
+
+  void
+  concurrency_slot_pool::adjust_concurrency (std::size_t concurrency)
+  {
+    std::unique_lock<std::mutex> ulock (*m_mutex);
+
+    adjust_concurrency (concurrency, ulock);
+  }
+
+  void
+  concurrency_slot_pool::adjust_concurrency (std::size_t concurrency, std::unique_lock<std::mutex> &ulock)
+  {
+    std::size_t i;
+
+    m_target_count = concurrency;
+
+    if (m_slot_count < concurrency)
+      {
+	i = m_slot_count;
+	m_slot_count = concurrency;
+	for (; i < concurrency; i++)
+	  {
+	    release_slot (std::unique_ptr<concurrency_slot> (new concurrency_slot (this)), ulock);
+	  }
+      }
+    else if (m_slot_count > concurrency)
+      {
+	while (m_slot_count > concurrency && !m_available_slots.empty ())
+	  {
+	    auto slot = std::move (m_available_slots.front ());
+	    m_available_slots.pop ();
+	    slot.reset ();
+
+	    m_slot_count--;
+	  }
+      }
   }
 
   std::unique_ptr<concurrency_slot>
@@ -336,6 +378,14 @@ namespace cubthread
     // reset
     slot->reset ();
 
+    if (m_target_count < m_slot_count)
+      {
+	slot.reset ();
+
+	m_slot_count--;
+	return;
+      }
+
     // store or wake up
     while (true)
       {
@@ -378,6 +428,12 @@ namespace cubthread
     return false;
   }
 
+  std::size_t
+  concurrency_slot_pool::available_slots ()
+  {
+    return m_available_slots.size ();
+  }
+
   //////////////////////////////////////////////////////////////////////////
   // concurrency_slot_daemon task
   //////////////////////////////////////////////////////////////////////////
@@ -385,19 +441,89 @@ namespace cubthread
   class concurrency_slot_daemon_task : public entry_task
   {
     public:
-      concurrency_slot_daemon_task () = default;
+      concurrency_slot_daemon_task ();
       ~concurrency_slot_daemon_task () = default;
 
-      void execute (entry &thread_ref) override
-      {
-	// 1. traverse all entries and steal the concurrency slot from any entry
-	//    whose wait time exceeds the threshold. (identifier = worker pool pointer)
-	// 2. rebalance slots across cores.
-	// 3. apply concurrency parameter changes at runtime.
+      void execute (entry &thread_ref) override;
 
-	// add here
-      }
+    private:
+      void tune_parameters (std::size_t &max_transaction_concurrency, std::size_t &max_transaction_worker);
+      void check_and_propagate_parameters ();
+
+      std::size_t m_max_transaction_concurrency;
+      std::size_t m_max_transaction_worker;
   };
+
+  //////////////////////////////////////////////////////////////////////////
+  // concurrency_slot_daemon task definition
+  //////////////////////////////////////////////////////////////////////////
+
+  concurrency_slot_daemon_task::concurrency_slot_daemon_task ()
+    : m_max_transaction_concurrency (static_cast<std::size_t> (prm_get_integer_value (PRM_ID_MAX_TRANSACTION_CONCURRENCY)))
+    , m_max_transaction_worker (static_cast<std::size_t> (prm_get_integer_value (PRM_ID_MAX_TRANSACTION_WORKER)))
+  {
+  }
+
+  void
+  concurrency_slot_daemon_task::execute (entry &thread_ref)
+  {
+    // 1. traverse all entries and steal the concurrency slot from any entry
+    //    whose wait time exceeds the threshold. (identifier = worker pool pointer)
+    // 2. rebalance slots across cores.
+    // 3. apply concurrency parameter changes at runtime.
+
+    check_and_propagate_parameters ();
+  }
+
+  void
+  concurrency_slot_daemon_task::tune_parameters (std::size_t &max_transaction_concurrency,
+      std::size_t &max_transaction_worker)
+  {
+    std::size_t core_count = system_core_count ();
+    std::size_t max_clients = prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS);
+    std::size_t clamp_min = max_clients < core_count ? core_count : max_clients;
+
+    if (max_transaction_concurrency > max_clients)
+      {
+	max_transaction_concurrency = clamp_min;
+      }
+    if (max_transaction_concurrency < core_count)
+      {
+	max_transaction_concurrency = core_count;
+      }
+
+    if (max_transaction_worker > max_clients)
+      {
+	max_transaction_worker = clamp_min;
+      }
+    if (max_transaction_worker < max_transaction_concurrency)
+      {
+	max_transaction_worker = max_transaction_concurrency;
+      }
+  }
+
+  void
+  concurrency_slot_daemon_task::check_and_propagate_parameters ()
+  {
+    std::size_t max_transaction_concurrency = prm_get_integer_value (PRM_ID_MAX_TRANSACTION_CONCURRENCY);
+    std::size_t max_transaction_worker = prm_get_integer_value (PRM_ID_MAX_TRANSACTION_WORKER);
+
+    if (max_transaction_concurrency != m_max_transaction_concurrency ||
+	max_transaction_worker != m_max_transaction_worker)
+      {
+	tune_parameters (max_transaction_concurrency, max_transaction_worker);
+
+	// propagate
+	css_set_max_concurrency_and_workers (max_transaction_concurrency, max_transaction_worker);
+
+	// set
+	prm_set_integer_value (PRM_ID_MAX_TRANSACTION_CONCURRENCY, max_transaction_concurrency);
+	prm_set_integer_value (PRM_ID_MAX_TRANSACTION_WORKER, max_transaction_worker);
+
+	m_max_transaction_concurrency = max_transaction_concurrency;
+	m_max_transaction_worker = max_transaction_worker;
+      }
+  }
 
   //////////////////////////////////////////////////////////////////////////
   // concurrency_slot_daemon

--- a/src/thread/concurrency_slot.hpp
+++ b/src/thread/concurrency_slot.hpp
@@ -123,6 +123,9 @@ namespace cubthread
 
       virtual void initialize (void *identifier, std::size_t concurrency);
 
+      void adjust_concurrency (std::size_t concurrency);
+      void adjust_concurrency (std::size_t concurrency, std::unique_lock<std::mutex> &ulock);
+
       // for worker
       std::unique_ptr<concurrency_slot> try_acquire_slot ();
       std::unique_ptr<concurrency_slot> try_acquire_slot (std::unique_lock<std::mutex> &ulock);
@@ -137,11 +140,16 @@ namespace cubthread
       // called by the daemon to borrow surplus slots in batches of SLOT_SURPLUS_THRESHOLD.
       bool borrow_surplus_slots ();
 
+      std::size_t available_slots ();
+
     private:
       static constexpr std::size_t SLOT_SURPLUS_THRESHOLD = 2;
 
       std::queue<std::unique_ptr<concurrency_slot>> m_available_slots;
       std::chrono::time_point<std::chrono::steady_clock> m_surplus_since;
+
+      std::size_t m_slot_count;
+      std::size_t m_target_count;
 
       std::list<entry *> m_wait_queue; // list of entries waiting to acquire a slot
 

--- a/src/thread/thread_worker_pool_elastic.hpp
+++ b/src/thread/thread_worker_pool_elastic.hpp
@@ -115,6 +115,7 @@ namespace cubthread
 
       // runtime variable parameter
       void adjust_runtime_parameter (std::size_t max_concurrency, std::size_t max_worker);
+      void adjust_workers (std::unique_lock<std::mutex> &ulock);
 
       // execute task
       void execute_task (task_type *task_p) override;
@@ -137,9 +138,9 @@ namespace cubthread
 
       std::unique_ptr<worker> allocate_worker () override;
 
-      worker *get_or_make_available_worker ();
+      worker_elastic *get_or_make_available_worker ();
 
-      void try_execute_task_with_slot (worker_elastic *worker_p, wrapped_task &&task_ref, unique_slot slot);
+      bool try_execute_task_with_slot (worker_elastic *worker_p, wrapped_task &&task_ref, unique_slot slot);
 
       concurrency_slot_pool m_slots;
 
@@ -317,11 +318,46 @@ namespace cubthread
     assert (max_concurrency > 0);
     assert (max_worker >= max_concurrency);
 
-    std::lock_guard<std::mutex> lock (this->m_core_mutex);
+    std::unique_lock<std::mutex> ulock (this->m_core_mutex);
 
     m_max_concurrency = max_concurrency;
     m_max_worker = max_worker;
     m_retire_threshold = std::max ((max_concurrency + max_worker) / 2, max_concurrency);
+
+    m_slots.adjust_concurrency (m_max_concurrency, ulock);
+    adjust_workers (ulock);
+  }
+
+  template <stats_t Stats>
+  void
+  worker_pool_elastic<Stats>::core_elastic::adjust_workers (std::unique_lock<std::mutex> &ulock)
+  {
+    while (!this->m_task_queue.empty () && // the tasks exist in queue
+	   m_slots.available_slots () > 0)
+      {
+	worker_elastic *worker_p = get_or_make_available_worker ();
+	if (!worker_p)
+	  {
+	    ulock.unlock ();
+	    break;
+	  }
+
+	// has valid worker, concurrency slot and task
+	auto slot = m_slots.try_acquire_slot (ulock);
+	assert (slot);
+
+	wrapped_task queued_task = std::move (this->m_task_queue.front ());
+	this->m_task_queue.pop_front ();
+
+	ulock.unlock ();
+
+	if (!try_execute_task_with_slot (worker_p, std::move (queued_task), std::move (slot)))
+	  {
+	    break;
+	  }
+
+	ulock.lock ();
+      }
   }
 
   template <stats_t Stats>
@@ -345,7 +381,7 @@ namespace cubthread
     unique_slot slot = m_slots.try_acquire_slot (ulock);
     if (slot)
       {
-	worker_p = static_cast<worker_elastic *> (get_or_make_available_worker ());
+	worker_p = get_or_make_available_worker ();
 
 	if (worker_p)
 	  {
@@ -476,7 +512,7 @@ namespace cubthread
   }
 
   template <stats_t Stats>
-  typename worker_pool_elastic<Stats>::worker *
+  typename worker_pool_elastic<Stats>::core_elastic::worker_elastic *
   worker_pool_elastic<Stats>::core_elastic::get_or_make_available_worker ()
   {
     worker *worker_p;
@@ -489,11 +525,11 @@ namespace cubthread
 	worker_p = this->m_workers.back ().get ();
 	worker_p->set_parent_core (*this);
       }
-    return worker_p;
+    return static_cast<worker_elastic *> (worker_p);
   }
 
   template <stats_t Stats>
-  void
+  bool
   worker_pool_elastic<Stats>::core_elastic::try_execute_task_with_slot (worker_elastic *worker_p, wrapped_task &&task_ref,
       unique_slot slot)
   {
@@ -508,7 +544,10 @@ namespace cubthread
 	release_slot (std::move (unexecuted->second), ulock);
 	// return the worker to the available list
 	this->m_available_workers.push_back (worker_p);
+
+	return false;
       }
+    return true;
   }
 
   template <stats_t Stats>


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26690>

### Purpose

max_transaction_worker, max_transaction_concurrency가 실시간으로 반영되도록 합니다.
```
csql> set system parameters 'max_transaction_worker=?';
csql> set system parameters 'max_transaction_concurrency=?'; 

csql> ;set max_transaction_worker=?
csql> ;set max_transaction_concurrency=?
```

위처럼 변경 가능합니다. concurrency나 worker가 늘어나는 변경은 즉각적이지만, 줄어드는 변경은 매우 lazy하게 적용됩니다.

### Implementation

1. 파라미터 실시간 반영
concurrency daemon이 파라미터를 비교하고 변경되었을 경우 전파합니다

2.1 concurrency 증가
slot을 추가로 만들고 대기 중인 thread가 있다면 할당합니다
2.2 concurrency 감소
slot이 반납될 때 목표치보다 많다면 제거합니다

3.1 worker 증가
worker 상한을 늘리고 slot과 대기 중인 작업이 있는 경우 새 worker를 만들어 수행합니다
3.2 worker 감소
바로 적용되지 않으며 worker들이 작업을 끝내고 pooling 대기 시간이 지났을 때 worker 상한보다 많다면 제거합니다.

### Remarks

N/A
