### PR TITLE
[CBRD-26801] Fix CLOB compressed_buf double-free and DB_MAKE_CLOB macro

### DIFF
--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -5079,7 +5079,7 @@ stran_can_end_after_query_execution (THREAD_ENTRY * thread_p, int query_flag, QF
       pr_type = domains[i]->type;
       assert (pr_type != NULL);
 
-      if (pr_type->id == DB_TYPE_VARCHAR || pr_type->id == DB_TYPE_VARNCHAR)
+      if (pr_type->id == DB_TYPE_VARCHAR || pr_type->id == DB_TYPE_VARNCHAR || pr_type->id == DB_TYPE_CLOB)
 	{
 	  found_compressible_string_domain = true;
 	  break;
@@ -5119,7 +5119,8 @@ stran_can_end_after_query_execution (THREAD_ENTRY * thread_p, int query_flag, QF
 	  tuple_p += QFILE_TUPLE_VALUE_HEADER_SIZE;
 
 	  pr_type = domains[i]->type;
-	  if (flag != V_UNBOUND && (pr_type->id == DB_TYPE_VARCHAR || pr_type->id == DB_TYPE_VARNCHAR))
+	  if (flag != V_UNBOUND
+	      && (pr_type->id == DB_TYPE_VARCHAR || pr_type->id == DB_TYPE_VARNCHAR || pr_type->id == DB_TYPE_CLOB))
 	    {
 	      buf.ptr = tuple_p;
 	      or_get_varchar_compression_lengths (&buf, &compressed_size, &decompressed_size);

--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -5079,7 +5079,7 @@ stran_can_end_after_query_execution (THREAD_ENTRY * thread_p, int query_flag, QF
       pr_type = domains[i]->type;
       assert (pr_type != NULL);
 
-      if (pr_type->id == DB_TYPE_VARCHAR || pr_type->id == DB_TYPE_VARNCHAR || pr_type->id == DB_TYPE_CLOB)
+      if (TP_IS_VAR_LEN_CHAR_TYPE (pr_type->id))
 	{
 	  found_compressible_string_domain = true;
 	  break;
@@ -5119,8 +5119,7 @@ stran_can_end_after_query_execution (THREAD_ENTRY * thread_p, int query_flag, QF
 	  tuple_p += QFILE_TUPLE_VALUE_HEADER_SIZE;
 
 	  pr_type = domains[i]->type;
-	  if (flag != V_UNBOUND
-	      && (pr_type->id == DB_TYPE_VARCHAR || pr_type->id == DB_TYPE_VARNCHAR || pr_type->id == DB_TYPE_CLOB))
+	  if (flag != V_UNBOUND && TP_IS_VAR_LEN_CHAR_TYPE (pr_type->id))
 	    {
 	      buf.ptr = tuple_p;
 	      or_get_varchar_compression_lengths (&buf, &compressed_size, &decompressed_size);

--- a/src/compat/dbtype.h
+++ b/src/compat/dbtype.h
@@ -239,7 +239,7 @@ extern "C"
       }
 
     DB_TYPE type = db_value_domain_type (src);
-    if (type == DB_TYPE_STRING || type == DB_TYPE_VARNCHAR || type == DB_TYPE_CLOB)
+    if (TP_IS_VAR_LEN_CHAR_TYPE (type))
       {
 	dst->data.ch.info.compressed_need_clear = false;
       }

--- a/src/compat/dbtype.h
+++ b/src/compat/dbtype.h
@@ -239,7 +239,7 @@ extern "C"
       }
 
     DB_TYPE type = db_value_domain_type (src);
-    if (type == DB_TYPE_STRING || type == DB_TYPE_VARNCHAR)
+    if (type == DB_TYPE_STRING || type == DB_TYPE_VARNCHAR || type == DB_TYPE_CLOB)
       {
 	dst->data.ch.info.compressed_need_clear = false;
       }

--- a/src/compat/dbtype_function.h
+++ b/src/compat/dbtype_function.h
@@ -170,7 +170,7 @@
 #define DB_MAKE_ENUMERATION(value, index, str, size, codeset, collation) \
 	db_make_enumeration(value, index, str, size, codeset, collation)
 
-#define DB_MAKE_CLOB (value, max_char_length, str, char_str_byte_size, codeset, collation_id) \
+#define DB_MAKE_CLOB(value, max_char_length, str, char_str_byte_size, codeset, collation_id) \
         db_make_clob (value, max_char_length, str, char_str_byte_size, codeset, collation_id)
 
 #define DB_MAKE_BLOB(value, max_byte_length, str, byte_str_size) \

--- a/src/object/object_domain.h
+++ b/src/object/object_domain.h
@@ -258,7 +258,7 @@ typedef enum tp_match
   (((typeid) == DB_TYPE_CHAR) || ((typeid) == DB_TYPE_NCHAR))
 
 #define TP_IS_VAR_LEN_CHAR_TYPE(typeid) \
-    (((typeid) == DB_TYPE_VARCHAR) || ((typeid) == DB_TYPE_VARNCHAR))
+    (((typeid) == DB_TYPE_VARCHAR) || ((typeid) == DB_TYPE_VARNCHAR) || ((typeid) == DB_TYPE_CLOB))
 
 /*
  * TP_IS_CHAR_BIT_TYPE

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -16573,8 +16573,8 @@ pr_clear_compressed_string (DB_VALUE * value)
 
   db_type = DB_VALUE_DOMAIN_TYPE (value);
 
-  /* Make sure we clear only for VARCHAR and VARNCHAR types. */
-  if (db_type != DB_TYPE_VARCHAR && db_type != DB_TYPE_VARNCHAR)
+  /* Make sure we clear only for VARCHAR, VARNCHAR and CLOB types. */
+  if (db_type != DB_TYPE_VARCHAR && db_type != DB_TYPE_VARNCHAR && db_type != DB_TYPE_CLOB)
     {
       return NO_ERROR;		/* do nothing */
     }

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -16573,8 +16573,8 @@ pr_clear_compressed_string (DB_VALUE * value)
 
   db_type = DB_VALUE_DOMAIN_TYPE (value);
 
-  /* Make sure we clear only for VARCHAR, VARNCHAR and CLOB types. */
-  if (db_type != DB_TYPE_VARCHAR && db_type != DB_TYPE_VARNCHAR && db_type != DB_TYPE_CLOB)
+  /* Make sure we clear only for variable length character types. */
+  if (!TP_IS_VAR_LEN_CHAR_TYPE (db_type))
     {
       return NO_ERROR;		/* do nothing */
     }

--- a/src/query/query_aggregate.cpp
+++ b/src/query/query_aggregate.cpp
@@ -2446,14 +2446,14 @@ qdata_load_agg_hvalue_in_agg_list (aggregate_hash_value *value, cubxasl::aggrega
 	      /* reset accumulator values. */
 	      value->accumulators[i].value->need_clear = false;
 	      db_type = DB_VALUE_DOMAIN_TYPE (value->accumulators[i].value);
-	      if (db_type == DB_TYPE_VARCHAR || db_type == DB_TYPE_VARNCHAR)
+	      if (db_type == DB_TYPE_VARCHAR || db_type == DB_TYPE_VARNCHAR || db_type == DB_TYPE_CLOB)
 		{
 		  value->accumulators[i].value->data.ch.info.compressed_need_clear = false;
 		}
 
 	      value->accumulators[i].value2->need_clear = false;
 	      db_type = DB_VALUE_DOMAIN_TYPE (value->accumulators[i].value2);
-	      if (db_type == DB_TYPE_VARCHAR || db_type == DB_TYPE_VARNCHAR)
+	      if (db_type == DB_TYPE_VARCHAR || db_type == DB_TYPE_VARNCHAR || db_type == DB_TYPE_CLOB)
 		{
 		  value->accumulators[i].value2->data.ch.info.compressed_need_clear = false;
 		}

--- a/src/query/query_aggregate.cpp
+++ b/src/query/query_aggregate.cpp
@@ -2446,14 +2446,14 @@ qdata_load_agg_hvalue_in_agg_list (aggregate_hash_value *value, cubxasl::aggrega
 	      /* reset accumulator values. */
 	      value->accumulators[i].value->need_clear = false;
 	      db_type = DB_VALUE_DOMAIN_TYPE (value->accumulators[i].value);
-	      if (db_type == DB_TYPE_VARCHAR || db_type == DB_TYPE_VARNCHAR || db_type == DB_TYPE_CLOB)
+	      if (TP_IS_VAR_LEN_CHAR_TYPE (db_type))
 		{
 		  value->accumulators[i].value->data.ch.info.compressed_need_clear = false;
 		}
 
 	      value->accumulators[i].value2->need_clear = false;
 	      db_type = DB_VALUE_DOMAIN_TYPE (value->accumulators[i].value2);
-	      if (db_type == DB_TYPE_VARCHAR || db_type == DB_TYPE_VARNCHAR || db_type == DB_TYPE_CLOB)
+	      if (TP_IS_VAR_LEN_CHAR_TYPE (db_type))
 		{
 		  value->accumulators[i].value2->data.ch.info.compressed_need_clear = false;
 		}

--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -393,7 +393,7 @@ qdata_copy_db_value_to_tuple_value (DB_VALUE * dbval_p, bool clear_compressed_st
       /* Good moment to clear the compressed_string that might have been stored in the DB_VALUE */
       if (clear_compressed_string)
 	{
-	  if (dbval_type == DB_TYPE_VARCHAR || dbval_type == DB_TYPE_VARNCHAR)
+	  if (dbval_type == DB_TYPE_VARCHAR || dbval_type == DB_TYPE_VARNCHAR || dbval_type == DB_TYPE_CLOB)
 	    {
 	      rc = pr_clear_compressed_string (dbval_p);
 	      if (rc != NO_ERROR)

--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -393,7 +393,7 @@ qdata_copy_db_value_to_tuple_value (DB_VALUE * dbval_p, bool clear_compressed_st
       /* Good moment to clear the compressed_string that might have been stored in the DB_VALUE */
       if (clear_compressed_string)
 	{
-	  if (dbval_type == DB_TYPE_VARCHAR || dbval_type == DB_TYPE_VARNCHAR || dbval_type == DB_TYPE_CLOB)
+	  if (TP_IS_VAR_LEN_CHAR_TYPE (dbval_type))
 	    {
 	      rc = pr_clear_compressed_string (dbval_p);
 	      if (rc != NO_ERROR)


### PR DESCRIPTION
  http://jira.cubrid.org/browse/CBRD-26801

  ## Purpose

  CBRD-26224 에서 internal CLOB 을 VARCHAR 와 같은 모양(압축 가능한 inline 문자열)으로
  추가하면서 빠뜨린 두 곳을 보완한다.

  1. `pr_share_value` 는 DB_VALUE 를 `memcpy` 로 통째 복사하므로 `compressed_buf`
     포인터와 소유권 플래그(`compressed_need_clear`) 까지 같이 복사된다.
     이 함수는 복사 직후 해당 플래그를 `false` 로 되돌려서 복사된 값이
     `compressed_buf` 의 소유권을 가지지 않도록 정리하는데, VARCHAR / VARNCHAR 만
     처리하고 CLOB 을 빠뜨렸다.
     그래서 256바이트 이상 압축된 CLOB 을 공유하면 원본과 복사된 값이 같은 포인터를
     동시에 소유한 것처럼 보이고, 둘 다 정리될 때 같은 포인터가 두 번 해제되어
     서버가 abort 된다.
  2. `DB_MAKE_CLOB` 매크로 이름과 `(` 사이에 공백이 있어 function-like 매크로로
     확장되지 않는다. 공개 헤더라 외부 코드에도 영향을 준다.

  ## Changes

  **`src/compat/dbtype.h` — `pr_share_value`**

  ```diff
  -    if (type == DB_TYPE_STRING || type == DB_TYPE_VARNCHAR)
  +    if (type == DB_TYPE_STRING || type == DB_TYPE_VARNCHAR || type == DB_TYPE_CLOB)
  ```

  **`src/compat/dbtype_function.h` — `DB_MAKE_CLOB`**

  ```diff
  -#define DB_MAKE_CLOB (value, max_char_length, str, char_str_byte_size, codeset, collation_id) \
  +#define DB_MAKE_CLOB(value, max_char_length, str, char_str_byte_size, codeset, collation_id) \
  ```

  BLOB 은 bit 데이터로 저장되어 `compressed_buf` 경로를 타지 않으니 해당 사항 없다.

  ## Test

 아래 시나리오는 모두 CLOB 컬럼을 SELECT 리스트에만
  노출하고, 조인 · 정렬 · 서브쿼리 술어는 비-LOB 컬럼(`id`, `sz`)으로만 구성하여
  명세에 어긋나지 않는 범위에서 `pr_share_value` 호출만 유도한다.

  | 케이스 | 결과 |
  |---|---|
  | 256B 초과 CLOB 32행을 다양한 plan 에서 SELECT 리스트로 노출, share/cleanup 20회 반복 | 8/8 OK, 서버 abort 없음 |
  | 9개 길이(200/255/256/257/511/512/1023/1024/4096B) × 4 세션 동시 share | 17/17 OK, 모든 세션 정상 종료 |
  | `dbi.h` 외부 C 컴파일 + `gcc -E` 전처리 확장 결과 확인 | `db_make_clob(...)` 함수 호출로 정상 확장 |

  기존 BLOB / VARCHAR / VARNCHAR 공유 경로는 손대지 않아 영향 없다.

## Remarks
N/A