### PR TITLE
[CBRD-26691] Implement the slot daemon.

### DIFF
--- a/src/thread/concurrency_slot.cpp
+++ b/src/thread/concurrency_slot.cpp
@@ -26,6 +26,9 @@
 #include "system_parameter.h"
 #include "error_manager.h"
 
+#include <algorithm>
+#include <utility>
+
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
 #include "memory_wrapper.hpp"
 
@@ -156,6 +159,23 @@ namespace cubthread
   }
 
   void
+  concurrency_slot::return_to_pool (std::unique_ptr<concurrency_slot> slot)
+  {
+    assert (m_owner_pool && m_holder_pool);
+    assert (slot.get () == this);
+
+    auto returned_from_owner = m_owner_pool->return_slot (std::move (slot), false);
+    if (returned_from_owner)
+      {
+	auto returned_from_holder = m_holder_pool->return_slot (std::move (returned_from_owner), false);
+	if (returned_from_holder)
+	  {
+	    m_owner_pool->return_slot (std::move (returned_from_holder), true);
+	  }
+      }
+  }
+
+  void
   concurrency_slot::start_waiting ()
   {
     m_wait = true;
@@ -168,13 +188,23 @@ namespace cubthread
     m_wait = false;
   }
 
+  bool
+  concurrency_slot::has_wait_expired (const std::chrono::time_point<std::chrono::steady_clock> &now)
+  {
+    constexpr auto threshold = std::chrono::milliseconds (50);
+
+    return m_wait && (now - m_wait_since >= threshold);
+  }
+
   //////////////////////////////////////////////////////////////////////////
   // concurrency_slot_pool
   //////////////////////////////////////////////////////////////////////////
 
-  concurrency_slot_pool::concurrency_slot_pool (std::mutex &mtx)
+  concurrency_slot_pool::concurrency_slot_pool (void *parent, std::mutex &mtx)
     : concurrency_slot_subscriber (concurrency_slot_daemon::get_publisher ())
+    , m_parent (parent)
     , m_available_slots ()
+    , m_surplus (false)
     , m_surplus_since ()
     , m_slot_count (0)
     , m_target_count (0)
@@ -199,6 +229,8 @@ namespace cubthread
     m_slot_count = concurrency;
     m_target_count = concurrency;
 
+    check_surplus_slots ();
+
     // attach to the daemon
     concurrency_slot_subscriber::activate (identifier);
   }
@@ -214,6 +246,7 @@ namespace cubthread
   void
   concurrency_slot_pool::adjust_concurrency (std::size_t concurrency, std::unique_lock<std::mutex> &ulock)
   {
+    std::vector<std::unique_ptr<concurrency_slot>> bucket;
     std::size_t i;
 
     m_target_count = concurrency;
@@ -233,10 +266,23 @@ namespace cubthread
 	  {
 	    auto slot = std::move (m_available_slots.front ());
 	    m_available_slots.pop ();
-	    slot.reset ();
+	    if (slot->m_owner_pool == this)
+	      {
+		slot.reset ();
 
-	    m_slot_count--;
+		m_slot_count--;
+	      }
+	    else
+	      {
+		bucket.emplace_back (std::move (slot));
+	      }
 	  }
+	for (auto &slot : bucket)
+	  {
+	    m_available_slots.push (std::move (slot));
+	  }
+
+	check_surplus_slots ();
       }
   }
 
@@ -264,6 +310,8 @@ namespace cubthread
     assert (slot);
     slot->set_holder_pool (this);
     assert (slot->get_owner_pool () && slot->get_holder_pool ());
+
+    check_surplus_slots ();
 
     return slot;
   }
@@ -294,6 +342,7 @@ namespace cubthread
 	thread_p->m_slot->set_holder_pool (this);
 	assert (thread_p->m_slot->get_owner_pool () && thread_p->m_slot->get_holder_pool ());
 
+	check_surplus_slots ();
 	return true;
       }
 
@@ -378,11 +427,13 @@ namespace cubthread
     // reset
     slot->reset ();
 
-    if (m_target_count < m_slot_count)
+    if (slot->m_owner_pool == this && m_target_count < m_slot_count)
       {
 	slot.reset ();
 
 	m_slot_count--;
+
+	check_surplus_slots ();
 	return;
       }
 
@@ -420,18 +471,87 @@ namespace cubthread
 	waiter->unlock ();
 	ulock.lock ();
       }
+
+    check_surplus_slots ();
   }
 
-  bool
-  concurrency_slot_pool::borrow_surplus_slots ()
+  std::unique_ptr<concurrency_slot>
+  concurrency_slot_pool::return_slot (std::unique_ptr<concurrency_slot> slot, bool force)
   {
-    return false;
+    assert (slot);
+
+    std::unique_lock<std::mutex> ulock (*m_mutex);
+
+    if ((m_available_slots.empty () && !m_wait_queue.empty ()) ||
+	(slot->m_owner_pool == this && m_slot_count > m_target_count) ||
+	force)
+      {
+	release_slot (std::move (slot), ulock);
+
+	return nullptr;
+      }
+    return slot;
+  }
+
+  std::vector<std::unique_ptr<concurrency_slot>>
+      concurrency_slot_pool::borrow_surplus_slots (const std::chrono::time_point<std::chrono::steady_clock> &now)
+  {
+    constexpr auto threshold = std::chrono::milliseconds (2000);
+    std::vector<std::unique_ptr<concurrency_slot>> slots;
+
+    std::unique_lock<std::mutex> ulock (*m_mutex);
+
+    if (m_surplus &&
+	now - m_surplus_since > threshold &&
+	m_available_slots.size () >= SLOT_SURPLUS_THRESHOLD)
+      {
+	while (m_available_slots.size () >= SLOT_SURPLUS_THRESHOLD)
+	  {
+	    slots.emplace_back (std::move (m_available_slots.front ()));
+	    m_available_slots.pop ();
+	  }
+
+	check_surplus_slots ();
+      }
+
+    return slots;
   }
 
   std::size_t
   concurrency_slot_pool::available_slots ()
   {
     return m_available_slots.size ();
+  }
+
+  const void *
+  concurrency_slot_pool::get_parent ()
+  {
+    return m_parent;
+  }
+
+  float
+  concurrency_slot_pool::get_score ()
+  {
+    std::lock_guard<std::mutex> lock (*m_mutex);
+
+    return -static_cast<float> (m_available_slots.size ()) + m_wait_queue.size () * 2.0f;
+  }
+
+  void
+  concurrency_slot_pool::check_surplus_slots ()
+  {
+    if (m_available_slots.size () >= SLOT_SURPLUS_THRESHOLD)
+      {
+	if (!m_surplus)
+	  {
+	    m_surplus_since = std::chrono::steady_clock::now ();
+	    m_surplus = true;
+	  }
+      }
+    else
+      {
+	m_surplus = false;
+      }
   }
 
   //////////////////////////////////////////////////////////////////////////
@@ -441,14 +561,25 @@ namespace cubthread
   class concurrency_slot_daemon_task : public entry_task
   {
     public:
-      concurrency_slot_daemon_task ();
+      concurrency_slot_daemon_task (concurrency_slot_publisher *publisher);
       ~concurrency_slot_daemon_task () = default;
 
       void execute (entry &thread_ref) override;
 
     private:
+      void steal_from_entries_if_excess (std::vector<std::unique_ptr<concurrency_slot>> &slots, void *identifier);
+      void steal_from_cores_if_excess (std::vector<std::unique_ptr<concurrency_slot>> &slots, void *identifier,
+				       std::vector<concurrency_slot_subscriber *> &subs);
+
+      void distribute_slots (std::vector<std::unique_ptr<concurrency_slot>> &slots,
+			     std::vector<concurrency_slot_subscriber *> &subs);
+
+      void wakeup_workers (void *identifier, std::vector<concurrency_slot_subscriber *> &subs);
+
       void tune_parameters (std::size_t &max_transaction_concurrency, std::size_t &max_transaction_worker);
       void check_and_propagate_parameters ();
+
+      concurrency_slot_publisher *m_publisher;
 
       std::size_t m_max_transaction_concurrency;
       std::size_t m_max_transaction_worker;
@@ -458,8 +589,9 @@ namespace cubthread
   // concurrency_slot_daemon task definition
   //////////////////////////////////////////////////////////////////////////
 
-  concurrency_slot_daemon_task::concurrency_slot_daemon_task ()
-    : m_max_transaction_concurrency (static_cast<std::size_t> (prm_get_integer_value (PRM_ID_MAX_TRANSACTION_CONCURRENCY)))
+  concurrency_slot_daemon_task::concurrency_slot_daemon_task (concurrency_slot_publisher *publisher)
+    : m_publisher (publisher)
+    , m_max_transaction_concurrency (static_cast<std::size_t> (prm_get_integer_value (PRM_ID_MAX_TRANSACTION_CONCURRENCY)))
     , m_max_transaction_worker (static_cast<std::size_t> (prm_get_integer_value (PRM_ID_MAX_TRANSACTION_WORKER)))
   {
   }
@@ -467,12 +599,145 @@ namespace cubthread
   void
   concurrency_slot_daemon_task::execute (entry &thread_ref)
   {
-    // 1. traverse all entries and steal the concurrency slot from any entry
+    // 1. apply concurrency parameter changes at runtime.
+    // 2. traverse all entries and steal the concurrency slot from any entry
     //    whose wait time exceeds the threshold. (identifier = worker pool pointer)
-    // 2. rebalance slots across cores.
-    // 3. apply concurrency parameter changes at runtime.
+    // 3. take the slots from cores which has them over threshold time.
+    // 4. rebalance slots across cores.
+    // 5. wake the workers in each core if there are the tasks in wait queue
 
+    // 1.
     check_and_propagate_parameters ();
+
+    static_cast<concurrency_slot_daemon *> (m_publisher)->traverse_subscribers ([this] (void *identifier, auto subs)
+    {
+      std::vector<std::unique_ptr<concurrency_slot>> slots;
+
+      assert (!subs.empty ());
+
+      // 2.
+      steal_from_entries_if_excess (slots, identifier);
+
+      // 3.
+      steal_from_cores_if_excess (slots, identifier, subs);
+
+      // 4.
+      distribute_slots (slots, subs);
+      assert (slots.empty ());
+
+      // 5.
+      wakeup_workers (identifier, subs);
+    });
+  }
+
+  void
+  concurrency_slot_daemon_task::steal_from_entries_if_excess (std::vector<std::unique_ptr<concurrency_slot>> &slots,
+      void *identifier)
+  {
+    std::chrono::time_point<std::chrono::steady_clock> now = std::chrono::steady_clock::now ();
+    auto func = [&slots, &now] (entry &thread_ref, bool &stop)
+    {
+      thread_ref.lock ();
+
+      if (thread_ref.m_status == cubthread::entry::status::TS_WAIT &&
+	  thread_ref.m_slot && thread_ref.m_slot->has_wait_expired (now))
+	{
+	  slots.emplace_back (std::move (thread_ref.m_slot));
+	  thread_ref.m_slot = nullptr;
+
+	  thread_ref.unlock ();
+	}
+      else
+	{
+	  thread_ref.unlock ();
+	}
+    };
+
+    auto *base = static_cast<worker_pool *> (identifier);
+    if (auto *pool = dynamic_cast<worker_pool_elastic<stats_t::on> *> (base))
+      {
+	pool->map_running_contexts (func);
+      }
+    else if (auto *pool = dynamic_cast<worker_pool_elastic<stats_t::off> *> (base))
+      {
+	pool->map_running_contexts (func);
+      }
+  }
+
+  void
+  concurrency_slot_daemon_task::steal_from_cores_if_excess (std::vector<std::unique_ptr<concurrency_slot>> &slots,
+      void *identifier, std::vector<concurrency_slot_subscriber *> &subs)
+  {
+    std::chrono::time_point<std::chrono::steady_clock> now = std::chrono::steady_clock::now ();
+
+    for (auto &sub : subs)
+      {
+	auto surplus_slots = static_cast<concurrency_slot_pool *> (sub)->borrow_surplus_slots (now);
+	slots.insert (
+		slots.end (),
+		std::make_move_iterator (surplus_slots.begin ()),
+		std::make_move_iterator (surplus_slots.end ())
+	);
+      }
+  }
+
+  void
+  concurrency_slot_daemon_task::distribute_slots (std::vector<std::unique_ptr<concurrency_slot>> &slots,
+      std::vector<concurrency_slot_subscriber *> &subs)
+  {
+    std::vector<std::pair<concurrency_slot_pool *, float>> scores;
+    std::size_t i = 0;
+
+    for (auto &sub : subs)
+      {
+	auto pool = static_cast<concurrency_slot_pool *> (sub);
+	scores.emplace_back (pool, pool->get_score ());
+      }
+    subs.clear ();
+
+    std::sort (scores.begin (), scores.end (), [] (const auto &a, const auto &b)
+    {
+      return a.second > b.second;
+    });
+
+    while (!slots.empty ())
+      {
+	auto slot = std::move (slots.back ());
+	slots.pop_back ();
+
+	auto pool = static_cast<concurrency_slot_pool *> (scores[i++ % scores.size ()].first);
+	pool->release_slot (std::move (slot));
+	if (std::find (subs.begin (), subs.end (), static_cast<concurrency_slot_subscriber *> (pool)) == subs.end ())
+	  {
+	    subs.push_back (pool);
+	  }
+      }
+  }
+
+  void
+  concurrency_slot_daemon_task::wakeup_workers (void *identifier, std::vector<concurrency_slot_subscriber *> &subs)
+  {
+    auto *base = static_cast<worker_pool *> (identifier);
+    if (dynamic_cast<worker_pool_elastic<stats_t::on> *> (base))
+      {
+	for (concurrency_slot_subscriber *it : subs)
+	  {
+	    auto parent = static_cast<concurrency_slot_pool *> (it)->get_parent ();
+	    assert (parent);
+
+	    static_cast<worker_pool_elastic<stats_t::on>::core_elastic *> (const_cast<void *> (parent))->adjust_workers ();
+	  }
+      }
+    else if (dynamic_cast<worker_pool_elastic<stats_t::off> *> (base))
+      {
+	for (concurrency_slot_subscriber *it : subs)
+	  {
+	    auto parent = static_cast<concurrency_slot_pool *> (it)->get_parent ();
+	    assert (parent);
+
+	    static_cast<worker_pool_elastic<stats_t::off>::core_elastic *> (const_cast<void *> (parent))->adjust_workers ();
+	  }
+      }
   }
 
   void
@@ -574,8 +839,8 @@ namespace cubthread
 	return;
       }
 
-    looper loop = looper (std::chrono::milliseconds (1000));
-    concurrency_slot_daemon_task *daemon_task = new concurrency_slot_daemon_task ();
+    looper loop = looper (std::chrono::milliseconds (50));
+    concurrency_slot_daemon_task *daemon_task = new concurrency_slot_daemon_task (this);
 
     m_daemon = cubthread::get_manager ()->create_daemon (loop, daemon_task, "concurrency");
   }

--- a/src/thread/concurrency_slot.cpp
+++ b/src/thread/concurrency_slot.cpp
@@ -568,7 +568,7 @@ namespace cubthread
 
     private:
       void steal_from_entries_if_excess (std::vector<std::unique_ptr<concurrency_slot>> &slots, void *identifier);
-      void steal_from_cores_if_excess (std::vector<std::unique_ptr<concurrency_slot>> &slots, void *identifier,
+      void steal_from_cores_if_excess (std::vector<std::unique_ptr<concurrency_slot>> &slots,
 				       std::vector<concurrency_slot_subscriber *> &subs);
 
       void distribute_slots (std::vector<std::unique_ptr<concurrency_slot>> &slots,
@@ -619,7 +619,7 @@ namespace cubthread
       steal_from_entries_if_excess (slots, identifier);
 
       // 3.
-      steal_from_cores_if_excess (slots, identifier, subs);
+      steal_from_cores_if_excess (slots, subs);
 
       // 4.
       distribute_slots (slots, subs);
@@ -666,7 +666,7 @@ namespace cubthread
 
   void
   concurrency_slot_daemon_task::steal_from_cores_if_excess (std::vector<std::unique_ptr<concurrency_slot>> &slots,
-      void *identifier, std::vector<concurrency_slot_subscriber *> &subs)
+      std::vector<concurrency_slot_subscriber *> &subs)
   {
     std::chrono::time_point<std::chrono::steady_clock> now = std::chrono::steady_clock::now ();
 

--- a/src/thread/concurrency_slot.hpp
+++ b/src/thread/concurrency_slot.hpp
@@ -145,7 +145,7 @@ namespace cubthread
       void release_slot (std::unique_ptr<concurrency_slot> slot, std::unique_lock<std::mutex> &ulock);
 
       std::unique_ptr<concurrency_slot> return_slot (std::unique_ptr<concurrency_slot> slot, bool force);
-      // called by the daemon to borrow surplus slots in batches of SLOT_SURPLUS_THRESHOLD.
+
       std::vector<std::unique_ptr<concurrency_slot>>
 	  borrow_surplus_slots (const std::chrono::time_point<std::chrono::steady_clock> &now);
 

--- a/src/thread/concurrency_slot.hpp
+++ b/src/thread/concurrency_slot.hpp
@@ -71,6 +71,9 @@ namespace cubthread
       concurrency_slot_publisher ();
       ~concurrency_slot_publisher ();
 
+      template <typename Func>
+      void traverse (Func &&func);
+
     private:
       void subscribe (void *identifier, concurrency_slot_subscriber *sub);
       void unsubscribe (void *identifier, concurrency_slot_subscriber *sub);
@@ -100,8 +103,12 @@ namespace cubthread
       void set_holder_pool (concurrency_slot_pool *holder_pool);
       concurrency_slot_pool *get_holder_pool ();
 
+      void return_to_pool (std::unique_ptr<concurrency_slot> slot);
+
       void start_waiting ();
       void stop_waiting ();
+
+      bool has_wait_expired (const std::chrono::time_point<std::chrono::steady_clock> &now);
 
     private:
       concurrency_slot (concurrency_slot_pool *owner_pool);
@@ -118,7 +125,7 @@ namespace cubthread
   class concurrency_slot_pool : public concurrency_slot_subscriber
   {
     public:
-      concurrency_slot_pool (std::mutex &mtx);
+      concurrency_slot_pool (void *parent, std::mutex &mtx);
       ~concurrency_slot_pool ();
 
       virtual void initialize (void *identifier, std::size_t concurrency);
@@ -137,15 +144,25 @@ namespace cubthread
       void release_slot (std::unique_ptr<concurrency_slot> slot);
       void release_slot (std::unique_ptr<concurrency_slot> slot, std::unique_lock<std::mutex> &ulock);
 
+      std::unique_ptr<concurrency_slot> return_slot (std::unique_ptr<concurrency_slot> slot, bool force);
       // called by the daemon to borrow surplus slots in batches of SLOT_SURPLUS_THRESHOLD.
-      bool borrow_surplus_slots ();
+      std::vector<std::unique_ptr<concurrency_slot>>
+	  borrow_surplus_slots (const std::chrono::time_point<std::chrono::steady_clock> &now);
 
       std::size_t available_slots ();
 
+      const void *get_parent ();
+      float get_score ();
+
     private:
+      // must be greater than 1
       static constexpr std::size_t SLOT_SURPLUS_THRESHOLD = 2;
 
+      const void *m_parent;
+
       std::queue<std::unique_ptr<concurrency_slot>> m_available_slots;
+
+      bool m_surplus;
       std::chrono::time_point<std::chrono::steady_clock> m_surplus_since;
 
       std::size_t m_slot_count;
@@ -155,6 +172,8 @@ namespace cubthread
 
       // slot pool state is guarded by the owning core mutex
       std::mutex *m_mutex;
+
+      void check_surplus_slots ();
   };
 
   // concurrency_slot_daemon
@@ -170,6 +189,9 @@ namespace cubthread
 
       static concurrency_slot_publisher *get_publisher ();
 
+      template <typename Func>
+      void traverse_subscribers (Func &&func);
+
     private:
       concurrency_slot_daemon ();
       ~concurrency_slot_daemon ();
@@ -181,6 +203,27 @@ namespace cubthread
 
       daemon *m_daemon;
   };
+}
+
+namespace cubthread
+{
+  template <typename Func>
+  void
+  concurrency_slot_publisher::traverse (Func &&func)
+  {
+    std::lock_guard<std::mutex> lock (m_mutex);
+
+    for (auto &subset : m_subscribers)
+      {
+	func (subset.first, subset.second);
+      }
+  }
+
+  template <typename Func>
+  void concurrency_slot_daemon::traverse_subscribers (Func &&func)
+  {
+    concurrency_slot_publisher::traverse (func);
+  }
 }
 
 #endif

--- a/src/thread/thread_worker_pool_elastic.hpp
+++ b/src/thread/thread_worker_pool_elastic.hpp
@@ -115,6 +115,7 @@ namespace cubthread
 
       // runtime variable parameter
       void adjust_runtime_parameter (std::size_t max_concurrency, std::size_t max_worker);
+      void adjust_workers ();
       void adjust_workers (std::unique_lock<std::mutex> &ulock);
 
       // execute task
@@ -287,7 +288,7 @@ namespace cubthread
   template <stats_t Stats>
   worker_pool_elastic<Stats>::core_elastic::core_elastic (bool pool_threads)
     : worker_pool_impl<Stats>::core_impl (pool_threads)
-    , m_slots (this->m_core_mutex)
+    , m_slots (this, this->m_core_mutex)
     , m_max_concurrency (0)
     , m_max_worker (0)
     , m_retire_threshold (0)
@@ -325,6 +326,16 @@ namespace cubthread
     m_retire_threshold = std::max ((max_concurrency + max_worker) / 2, max_concurrency);
 
     m_slots.adjust_concurrency (m_max_concurrency, ulock);
+    adjust_workers (ulock);
+  }
+
+
+  template <stats_t Stats>
+  void
+  worker_pool_elastic<Stats>::core_elastic::adjust_workers ()
+  {
+    std::unique_lock<std::mutex> ulock (this->m_core_mutex);
+
     adjust_workers (ulock);
   }
 
@@ -719,7 +730,7 @@ namespace cubthread
     // return the slot to the pool
     if (this->m_context_p->m_slot)
       {
-	static_cast<core_elastic *> (this->m_parent_core)->release_slot (std::move (this->m_context_p->m_slot));
+	this->m_context_p->m_slot->return_to_pool (std::move (this->m_context_p->m_slot));
 	this->m_context_p->m_slot = nullptr;
       }
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26691>

### Purpose

Concurrency slot daemon을 구현하는 PR입니다. 구현 목록은 아래와 같습니다.
1. 모든 entry를 순회하며 대기 상태이고 충분한 대기 시간이 지났다면 slot을 뺏어옵니다.
2. core들을 순회하며 slot을 2초 이상 2개 이상 들고 있었으면 slot을 1개 남기고 뺏어옵니다.
3. core 간에 slot을 적절히 분배합니다. 우선순위 score는 (-현재 가지고 있는 slot + 대기 entry 개수 * 2)입니다.
4. slot을 분배한 후 worker들을 깨웁니다. (새 작업이 시작 가능하다면 시작)

### Implementation

이전 PR들이 병합되지 않아 섞여보입니다. 리뷰는 
[Implement the slot daemon](https://github.com/CUBRID/cubrid/pull/7182/commits/d88a04165dc4d50e94437a68a067d74b8a80a50f) 커밋만 확인해주시면 됩니다.

### Remarks

slot을 뺏기까지의 기준 시간과 daemon의 interval, core에서 slot을 가져오는 기준 시간 모두 적당히 임의적으로 정했습니다.
근거가 없는 임의적 지정이고 실험을 통해 정해야 할 부분들입니다. 실험 후 변경하겠지만, 의견 있으시면 부탁드립니다.