### PR TITLE
[CBRD-26809] Include <string> in identifier_store.hpp for modern toolchains

### DIFF
--- a/src/object/identifier_store.hpp
+++ b/src/object/identifier_store.hpp
@@ -24,7 +24,7 @@
 #define _IDENTIFIER_STORE_HPP_
 
 #include <vector>
-#include <string_view>
+#include <string>
 
 #include "porting.h"
 #include "string_utility.hpp"

--- a/src/object/identifier_store.hpp
+++ b/src/object/identifier_store.hpp
@@ -25,6 +25,7 @@
 
 #include <vector>
 #include <string>
+#include <string_view>
 
 #include "porting.h"
 #include "string_utility.hpp"


### PR DESCRIPTION
https://jira.cubrid.org/browse/CBRD-26809

> **TL;DR**: `identifier_store.hpp` 가 `std::string` 을 쓰면서 `<string>` 을 직접 include 하지 않아 모던 툴체인(GCC 13+, Clang 17+, clangd 등)에서 빌드가 실패한다. `<string_view>` -> `<string>` 한 줄 교체로 해결.

## Summary

- **변경**: `src/object/identifier_store.hpp:27` 의 `#include <string_view>` 를 `#include <string>` 로 교체.
- **이유**: 헤더가 line 35 에서 `const std::string SYSTEM_CLASS_PREFIX` 를 선언하지만 `<string>` 을 직접 include 하지 않아, `string_utility.hpp` 의 전이 경로에만 의존하는 자기-모순 상태.
- **영향**: Rocky 8 + GCC 8 공식 CI 는 통과해 왔지만, 모던 stdlib 에서는 전이 경로가 끊겨 `error: 'string' in namespace 'std' does not name a type` 발생. 이 PR 로 양쪽 모두 통과. ABI / 동작 변경 없음.
- **리뷰 포인트**: libstdc++ 의 `<string>` 이 `string_view` 변환 생성자를 위해 `<string_view>` 를 전이 제공하므로 기존 `std::string_view` 시그니처가 그대로 컴파일된다는 점만 확인.