### PR TITLE
[CBRD-26764] Remove the controller entry point to prevent permission issues.

### DIFF
--- a/src/connection/coordinator.cpp
+++ b/src/connection/coordinator.cpp
@@ -44,8 +44,6 @@
 #define EVAL_WORKER(mq, rmutex) (VAL_TO_SCORE (25, 3.5, (mq)) + VAL_TO_SCORE (500, 1, (rmutex)))
 #define EVAL_CONTEXT(bytes, budget) (VAL_TO_SCORE (50, 1000, (bytes)) + VAL_TO_SCORE (10, 1, (budget)))
 
-//#define ENABLE_CONTROLLER
-
 #if 0
 #define er_log_conn(...) er_log_debug (__VA_ARGS__)
 #else
@@ -70,8 +68,8 @@ namespace cubconn::connection
   {
     std::size_t i;
 
-    /* external controller */
 #if defined (ENABLE_CONTROLLER)
+    /* external controller */
     if (!m_controller.open ("/tmp/cub_server_" + std::to_string (getpid ()) + "_coordinator.sock",
 			    SOCK_NONBLOCK | SOCK_CLOEXEC))
       {
@@ -79,8 +77,6 @@ namespace cubconn::connection
 	assert_release (false);
       }
     m_ctrlfd = m_controller.get_fd ();
-#else
-    m_ctrlfd = -1;
 #endif
 
     /* notifier */
@@ -93,16 +89,19 @@ namespace cubconn::connection
       }
 
     if (!this->eventfd_register (m_eventfd) ||
-	!this->eventfd_register (m_timerfd) ||
-#if defined (ENABLE_CONTROLLER)
-	!this->eventfd_register (m_ctrlfd))
-#else
-	0)
-#endif
+	!this->eventfd_register (m_timerfd))
       {
 	er_log_conn (__FILE__, __LINE__, "connection::coordinator: failed to register fd\n");
 	assert_release (false);
       }
+
+#if defined (ENABLE_CONTROLLER)
+    if (!this->eventfd_register (m_ctrlfd))
+      {
+	er_log_conn (__FILE__, __LINE__, "connection::coordinator: failed to register fd\n");
+	assert_release (false);
+      }
+#endif
 
     /* timer */
     for (i = 0; i < static_cast<std::size_t> (timer_type::TYPE_COUNT); i++)
@@ -1118,6 +1117,7 @@ not_transferred:
     return true;
   }
 
+#if defined (ENABLE_CONTROLLER)
   bool coordinator::handle_controller_request (control_recv &rx, control_send &tx)
   {
     const char *name_table[] =
@@ -1199,6 +1199,7 @@ not_transferred:
 
     return true;
   }
+#endif
 
   void coordinator::initialize ()
   {

--- a/src/connection/coordinator.cpp
+++ b/src/connection/coordinator.cpp
@@ -44,6 +44,8 @@
 #define EVAL_WORKER(mq, rmutex) (VAL_TO_SCORE (25, 3.5, (mq)) + VAL_TO_SCORE (500, 1, (rmutex)))
 #define EVAL_CONTEXT(bytes, budget) (VAL_TO_SCORE (50, 1000, (bytes)) + VAL_TO_SCORE (10, 1, (budget)))
 
+//#define ENABLE_CONTROLLER
+
 #if 0
 #define er_log_conn(...) er_log_debug (__VA_ARGS__)
 #else
@@ -69,6 +71,7 @@ namespace cubconn::connection
     std::size_t i;
 
     /* external controller */
+#if defined (ENABLE_CONTROLLER)
     if (!m_controller.open ("/tmp/cub_server_" + std::to_string (getpid ()) + "_coordinator.sock",
 			    SOCK_NONBLOCK | SOCK_CLOEXEC))
       {
@@ -76,6 +79,10 @@ namespace cubconn::connection
 	assert_release (false);
       }
     m_ctrlfd = m_controller.get_fd ();
+#else
+    m_ctrlfd = -1;
+#endif
+
     /* notifier */
     m_eventfd = eventfd (0, EFD_NONBLOCK | EFD_CLOEXEC);
     m_timerfd = timerfd_create (CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC);
@@ -87,7 +94,11 @@ namespace cubconn::connection
 
     if (!this->eventfd_register (m_eventfd) ||
 	!this->eventfd_register (m_timerfd) ||
+#if defined (ENABLE_CONTROLLER)
 	!this->eventfd_register (m_ctrlfd))
+#else
+	0)
+#endif
       {
 	er_log_conn (__FILE__, __LINE__, "connection::coordinator: failed to register fd\n");
 	assert_release (false);
@@ -1300,10 +1311,12 @@ not_transferred:
 			return false;
 		      }
 		  }
+#if defined (ENABLE_CONTROLLER)
 		else if (events[i].data.fd == m_ctrlfd)
 		  {
 		    this->handle_controller ();
 		  }
+#endif
 	      }
 	  }
       }

--- a/src/connection/coordinator.hpp
+++ b/src/connection/coordinator.hpp
@@ -116,6 +116,7 @@ namespace cubconn::connection
 	uint64_t last_time;
       };
 
+#if defined (ENABLE_CONTROLLER)
       /* utils */
       enum class control_type : uint32_t
       {
@@ -146,6 +147,7 @@ namespace cubconn::connection
       {
 	control_type type;
       };
+#endif
 
     public:
       enum class message_type
@@ -236,9 +238,12 @@ namespace cubconn::connection
       int m_timerfd;
       uint64_t m_timens;
       std::array<timer_handle, static_cast<std::size_t> (timer_type::TYPE_COUNT)> m_timer_handler;
+
+#if defined (ENABLE_CONTROLLER)
       /* controller */
       controller<control_recv, control_send> m_controller;
       int m_ctrlfd;
+#endif
 
       /* this is a multi-producer single-consumer queue, so */
       /* data can be put into the queue from anywhere, but  */
@@ -363,11 +368,13 @@ namespace cubconn::connection
 
       bool handle_message_queue ();
 
+#if defined (ENABLE_CONTROLLER)
       /* --------------------------------------------------------------------------- */
       /* controller								     */
       /* --------------------------------------------------------------------------- */
       bool handle_controller_request (control_recv &rx, control_send &tx);
       bool handle_controller ();
+#endif
   };
 
   template <typename T>

--- a/src/connection/coordinator.hpp
+++ b/src/connection/coordinator.hpp
@@ -32,7 +32,9 @@
 #include "tbb/concurrent_queue.h"
 #include "epoll.hpp"
 #include "connection_context.hpp"
+#if defined (ENABLE_CONTROLLER)
 #include "controller.hpp"
+#endif
 
 namespace cubconn::connection
 {


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26764>

### Purpose

Connection pool 구현에서 변경된 내용입니다.
추후 통계값을 가져오거나 임의적 scale up/down, rebalancing를 지원하는 경우가 있을 것 같아 coordinator에 controller를 붙을 수 있게 구성하였습니다.
이 controller는 event 기반으로 동작하고 /tmp/cub_server_{pid}_coordinator.sock 파일을 생성합니다.
이때 site에서 /tmp/ 경로에 권한이 없을 수 있고, 이 케이스에서는 서버가 시작하지 못하고 깨지므로 controller 경로를 비활성화합니다.

### Implementation

매크로로 감쌉니다.

### Remarks

N/A
