### PR TITLE
[CBRD-26812] Handle resource allocation failure during connection pool initialization.

### DIFF
--- a/src/base/DMRB.hpp
+++ b/src/base/DMRB.hpp
@@ -93,6 +93,8 @@ namespace cubbase
       DMRB (DMRB &&other) = delete;
       DMRB &operator= (DMRB &&other) = delete;
 
+      bool prepare ();
+
       std::size_t capacity () const noexcept;
       std::size_t available () const noexcept;
       std::size_t readable () const noexcept;
@@ -123,61 +125,12 @@ namespace cubbase
 
   template <bool T>
   DMRB<T>::DMRB (std::size_t capacity) :
+    m_base (nullptr),
+    m_fd (-1),
     m_size (capacity),
     m_mask (capacity - 1)
   {
-    std::string name;
-    long page;
-
     assert (capacity > 0);
-
-    page = sysconf (_SC_PAGESIZE);
-    if (m_size % page != 0)
-      {
-	assert_release (false);
-      }
-
-    /* make virtual descriptor */
-    name = generate_unique_name ();
-    m_fd = ::shm_open (name.c_str (), O_RDWR | O_CREAT | O_EXCL, 0600);
-    if (m_fd < 0)
-      {
-	_er_log_debug (ARG_FILE_LINE, "shm_open failed: %s.\n", strerror (errno));
-	assert_release (false);
-      }
-    if (::shm_unlink (name.c_str ()) < 0)
-      {
-	_er_log_debug (ARG_FILE_LINE, "shm_unlink failed: %s.\n", strerror (errno));
-	assert_release (false);
-      }
-    if (::ftruncate (m_fd, m_size))
-      {
-	_er_log_debug (ARG_FILE_LINE, "ftruncate failed: %s.\n", strerror (errno));
-	assert_release (false);
-      }
-
-    /* reserve address space */
-    /* TODO: change this to NUMA or MUST make first touch on epoll group core */
-    m_base = ::mmap (nullptr, m_size * 2, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-    if (m_base == MAP_FAILED)
-      {
-	_er_log_debug (ARG_FILE_LINE, "mmap failed: %s.\n", strerror (errno));
-	assert_release (false);
-      }
-    /* map virtual address to physical memory */
-    if (::mmap (m_base, m_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED, m_fd, 0) == MAP_FAILED ||
-	::mmap (static_cast<char *> (m_base) + m_size, m_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED, m_fd,
-		0) == MAP_FAILED)
-      {
-	_er_log_debug (ARG_FILE_LINE, "mmap failed: %s.\n", strerror (errno));
-	assert_release (false);
-      }
-
-    if (::madvise (m_base, m_size * 2, MADV_DONTFORK) < 0)
-      {
-	_er_log_debug (ARG_FILE_LINE, "madvise failed: %s.\n", strerror (errno));
-	assert_release (false);
-      }
   }
 
   template <bool T>
@@ -200,6 +153,68 @@ namespace cubbase
       {
 	::close (m_fd);
       }
+  }
+
+  template <bool T>
+  bool DMRB<T>::prepare ()
+  {
+    std::string name;
+    long page;
+
+    assert (m_fd < 0 && m_base == nullptr);
+    assert (m_size != 0 && m_mask != 0);
+
+    page = sysconf (_SC_PAGESIZE);
+    if (m_size % page != 0)
+      {
+	return false;
+      }
+
+    /* make virtual descriptor */
+    name = generate_unique_name ();
+    m_fd = ::shm_open (name.c_str (), O_RDWR | O_CREAT | O_EXCL, 0600);
+    if (m_fd < 0)
+      {
+	_er_log_debug (ARG_FILE_LINE, "shm_open failed: %s.\n", strerror (errno));
+	return false;
+      }
+    if (::shm_unlink (name.c_str ()) < 0)
+      {
+	_er_log_debug (ARG_FILE_LINE, "shm_unlink failed: %s.\n", strerror (errno));
+	return false;
+      }
+    if (::ftruncate (m_fd, m_size))
+      {
+	_er_log_debug (ARG_FILE_LINE, "ftruncate failed: %s.\n", strerror (errno));
+	return false;
+      }
+
+    /* reserve address space */
+    /* TODO: change this to NUMA or MUST make first touch on epoll group core */
+    m_base = ::mmap (nullptr, m_size * 2, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (m_base == MAP_FAILED)
+      {
+	_er_log_debug (ARG_FILE_LINE, "mmap failed: %s.\n", strerror (errno));
+
+	m_base = nullptr;
+	return false;
+      }
+    /* map virtual address to physical memory */
+    if (::mmap (m_base, m_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED, m_fd, 0) == MAP_FAILED ||
+	::mmap (static_cast<char *> (m_base) + m_size, m_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED, m_fd,
+		0) == MAP_FAILED)
+      {
+	_er_log_debug (ARG_FILE_LINE, "mmap failed: %s.\n", strerror (errno));
+	return false;
+      }
+
+    if (::madvise (m_base, m_size * 2, MADV_DONTFORK) < 0)
+      {
+	_er_log_debug (ARG_FILE_LINE, "madvise failed: %s.\n", strerror (errno));
+	return false;
+      }
+
+    return true;
   }
 
   template <bool T>

--- a/src/connection/connection_context.cpp
+++ b/src/connection/connection_context.cpp
@@ -116,6 +116,11 @@ namespace cubconn::connection
   {
   }
 
+  bool context::prepare ()
+  {
+    return m_recv.m_receiver.prepare ();
+  }
+
   void context::reset ()
   {
     m_conn = nullptr;

--- a/src/connection/connection_context.hpp
+++ b/src/connection/connection_context.hpp
@@ -198,6 +198,7 @@ namespace cubconn::connection
     context (context &&) noexcept = delete;
     context &operator= (context &&) noexcept = delete;
 
+    bool prepare ();
     void reset ();
   };
 }

--- a/src/connection/connection_pool.cpp
+++ b/src/connection/connection_pool.cpp
@@ -49,7 +49,8 @@ namespace cubconn::connection
   pool::pool () :
     m_max_connections (-1),
     m_max_connection_workers (-1),
-    m_min_connection_workers (-1)
+    m_min_connection_workers (-1),
+    m_freelist { nullptr, 0, 0 }
   {
     m_watcher = std::make_shared<thread_watcher> ();
     m_watcher->active = 0;
@@ -59,7 +60,7 @@ namespace cubconn::connection
   {
   }
 
-  void pool::initialize (std::uint32_t max_connections, int max_connection_workers, int min_connection_workers)
+  bool pool::initialize (std::uint32_t max_connections, int max_connection_workers, int min_connection_workers)
   {
     (void) os_set_signal_handler (SIGPIPE, SIG_IGN);
     (void) os_set_signal_handler (SIGFPE, SIG_IGN);
@@ -72,7 +73,12 @@ namespace cubconn::connection
 
     this->lock_resource ();
 
-    this->initialize_freelist (max_connections);
+    if (!this->initialize_freelist (max_connections))
+      {
+	this->release_resource ();
+
+	return false;
+      }
     this->initialize_coordinator (max_connection_workers, min_connection_workers);
     this->initialize_workers (max_connection_workers, min_connection_workers);
 
@@ -84,6 +90,8 @@ namespace cubconn::connection
     m_max_connections = max_connections;
     m_max_connection_workers = max_connection_workers;
     m_min_connection_workers = min_connection_workers;
+
+    return true;
   }
 
   void pool::finalize ()
@@ -151,6 +159,12 @@ namespace cubconn::connection
     else
       {
 	head = new freelist (32 * 1024);
+	if (!head->prepare ())
+	  {
+	    delete head;
+
+	    return nullptr;
+	  }
       }
     m_freelist.m_claim++;
 
@@ -210,9 +224,9 @@ namespace cubconn::connection
 #endif
   }
 
-  void pool::initialize_freelist (std::uint32_t max_connections)
+  bool pool::initialize_freelist (std::uint32_t max_connections)
   {
-    freelist *head;
+    freelist *node;
     std::size_t i;
 
     assert (m_mutex_holder == std::this_thread::get_id ());
@@ -222,10 +236,18 @@ namespace cubconn::connection
     m_freelist.m_max = static_cast<std::size_t> (static_cast<float> (max_connections) * /* margin */ 1.1);
     for (i = 0; i < m_freelist.m_max; i++)
       {
-	head = m_freelist.m_head;
-	m_freelist.m_head = new freelist (32 * 1024);
-	m_freelist.m_head->m_next = head;
+	node = new freelist (32 * 1024);
+	if (!node->prepare ())
+	  {
+	    delete node;
+
+	    return false;
+	  }
+	node->m_next = m_freelist.m_head;
+	m_freelist.m_head = node;
       }
+
+    return true;
   }
 
   void pool::finalize_freelist ()
@@ -318,6 +340,12 @@ namespace cubconn::connection
     struct timeval *timeout;
     bool compelete;
 
+    if (m_workers.empty ())
+      {
+	/* not initialized */
+	return;
+      }
+
     for (auto &worker : m_workers)
       {
 	worker::message request;
@@ -392,6 +420,12 @@ namespace cubconn::connection
     coordinator::message request;
     struct timeval *timeout;
     bool compelete;
+
+    if (!m_coordinator)
+      {
+	/* not initialized */
+	return;
+      }
 
     request.type = coordinator::message_type::SHUTDOWN;
     m_coordinator->enqueue (std::move (request));

--- a/src/connection/connection_pool.hpp
+++ b/src/connection/connection_pool.hpp
@@ -53,13 +53,18 @@ namespace cubconn::connection
 	}
 
 	~freelist () = default;
+
+	bool prepare ()
+	{
+	  return m_context.prepare ();
+	}
       };
 
     public:
       pool ();
       ~pool ();
 
-      void initialize (std::uint32_t max_connections, int max_connection_workers, int min_connection_workers);
+      bool initialize (std::uint32_t max_connections, int max_connection_workers, int min_connection_workers);
       void finalize ();
 
       void dispatch (css_conn_entry *conn);
@@ -102,7 +107,7 @@ namespace cubconn::connection
 
       void try_to_lock_resource ();
 
-      void initialize_freelist (std::uint32_t max_connections);
+      bool initialize_freelist (std::uint32_t max_connections);
       void finalize_freelist ();
 
       std::uint32_t initialize_topology (std::uint32_t max_connection_workers);

--- a/src/connection/coordinator.cpp
+++ b/src/connection/coordinator.cpp
@@ -948,6 +948,17 @@ namespace cubconn::connection
     std::vector<std::unique_ptr<worker>> &workers = m_parent->get_workers ();
     connection::worker::message request;
     std::size_t worker;
+    context *ctx;
+
+    ctx = m_parent->claim_context ();
+    if (!ctx)
+      {
+	/* failed to allocate the resources */
+	css_free_conn (item.conn);
+
+	/* just ignore */
+	return true;
+      }
 
     std::tie (worker, std::ignore) = statistics_find_score_extremes ();
 
@@ -960,7 +971,7 @@ namespace cubconn::connection
     m_statistics[worker].m_client_num++;
 
     request.type = connection::worker::message_type::NEW_CLIENT;
-    request.ctx = m_parent->claim_context ();
+    request.ctx = ctx;
     request.ctx->m_worker = worker;
     request.ctx->m_id = id++;
     request.conn = item.conn;

--- a/src/connection/receiver.cpp
+++ b/src/connection/receiver.cpp
@@ -56,8 +56,6 @@ namespace cubconn
     m_stats (stats),
     m_buf (capacity)
   {
-    m_result.reserve (8);
-    this->reset ();
   }
 
   receiver::receiver () :
@@ -74,6 +72,18 @@ namespace cubconn
 	assert (false);
       }
 #endif
+  }
+
+  bool receiver::prepare ()
+  {
+    if (!m_buf.prepare ())
+      {
+	return false;
+      }
+
+    m_result.reserve (8);
+    this->reset ();
+    return true;
   }
 
   void receiver::reset ()

--- a/src/connection/receiver.hpp
+++ b/src/connection/receiver.hpp
@@ -53,6 +53,7 @@ namespace cubconn
       receiver ();
       ~receiver ();
 
+      bool prepare ();
       void reset ();
 
       result drain (int fd, size_t limit = 0);

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -585,14 +585,18 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
 
   if (css_Server_request_worker_pool == NULL)
     {
-      assert (false);
       er_set (ER_FATAL_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
       status = ER_FAILED;
       goto shutdown;
     }
 
   /* initialize epoll worker pool */
-  connections.initialize (MAX_CONNECTIONS, max_connection_workers, min_connection_workers);
+  if (!connections.initialize (MAX_CONNECTIONS, max_connection_workers, min_connection_workers))
+    {
+      er_set (ER_FATAL_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
+      status = ER_FAILED;
+      goto shutdown;
+    }
 
   /* attach thread entry */
   connector.attach (*thread_p);

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -593,7 +593,8 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
   /* initialize epoll worker pool */
   if (!connections.initialize (MAX_CONNECTIONS, max_connection_workers, min_connection_workers))
     {
-      er_set (ER_FATAL_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
+      _er_log_debug (ARG_FILE_LINE, "connection::pool failed to prepare DMRB for connection contexts.\n");
+      er_set (ER_FATAL_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, 32 * 1024);
       status = ER_FAILED;
       goto shutdown;
     }
@@ -627,7 +628,7 @@ shutdown:
   /* we should flush all append pages before stop log writer */
   logpb_force_flush_pages (thread_p);
 
-#if !defined(NDEBUG)
+#if !defined (NDEBUG)
   /* All active transaction and vacuum workers should have been stopped. Only system transactions are still running. */
   assert (!log_prior_has_worker_log_records (thread_p));
 #endif
@@ -639,7 +640,9 @@ shutdown:
     {
       perfmon_er_log_current_stats (thread_p);
     }
+#if !defined (NDEBUG)
   css_Server_request_worker_pool->er_log_stats ();
+#endif
 
   // destroy thread worker pools
   thread_get_manager ()->destroy_worker_pool (css_Server_request_worker_pool);

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -641,7 +641,10 @@ shutdown:
       perfmon_er_log_current_stats (thread_p);
     }
 #if !defined (NDEBUG)
-  css_Server_request_worker_pool->er_log_stats ();
+  if (css_Server_request_worker_pool)
+    {
+      css_Server_request_worker_pool->er_log_stats ();
+    }
 #endif
 
   // destroy thread worker pools

--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1375,7 +1375,9 @@ vacuum_stop_workers (THREAD_ENTRY * thread_p)
   if (vacuum_Worker_threads != NULL)
     {
 #if defined (SERVER_MODE)
+#if !defined (NDEBUG)
       vacuum_Worker_threads->er_log_stats ();
+#endif
       vacuum_Worker_threads->stop_execution ();
 #endif // SERVER_MODE
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26812>

### Purpose

Connection pool에서 사용하는 context는 초기화 및 새 연결에서 사용됩니다. 이때 생성자에서 메모리와 file descriptor 자원을 요구하는데 부족한 경우 실패할 수 있습니다.

### Implementation

생성자에서의 자원 실패를 인지할 수 없기 때문에 prepare ()를 만들어 별도로 초기화합니다.

### Remarks

container 내부와 new 실패도 잡고 싶었으나 std::nothrow가 cubmem wrapper로 인해 정상 사용되지 않고, container의 경우 exception으로 처리되는 것을 기대합니다.