### PR TITLE
[CBRD-25561] Make sure the active log backup includes all records.

### DIFF
--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -8077,6 +8077,9 @@ loop:
 
   LOG_CS_ENTER (thread_p);
 
+  /* Flush before selecting archive logs. This may create a new archive and advance nxarv_num. */
+  logpb_flush_pages_direct (thread_p);
+
 #if defined(SERVER_MODE)
   /*
    * Determine the first log archive that will be needed to insure


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-25561>

### Purpose

backup 시 header를 flush하기 전에 현재 로그를 flush하지 않아 최신 로그가 누락되는 케이스입니다. 시나리오는 아래와 같습니다.

1. lock LOG_CS
1. log flush
2. unlock LOG_CS
3. backup을 위한 작업 수행
4. 이 짧은 윈도우에 새 로그가 작성됨
5. lock LOG_CS
6. flush log header (실제 로그는 flush되지 않았지만 log header에는 최신 로그가 반영된 것으로 flush 됨)
7. unlock LOG_CS

따라서 log header flush 전에 log flush를 추가합니다. 또, log flush 시 새 archive log가 발생할 수 있어 위치를 위로 하였습니다.

### Implementation

logpb_flush_header 전에 logpb_flush_pages_direct를 호출하여 최신 로그들이 반영되도록 합니다.

### Remarks

N/A