### PR TITLE
[CBRD-26802] Reject internal LOB host vars in dblink with actual type name

### DIFF
--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -114,11 +114,11 @@ static int type_map[] = {
   CCI_A_TYPE_BIGINT,		/* CCI_U_TYPE_BIGINT */
   CCI_A_TYPE_DATE,		/* CCI_U_TYPE_DATETIME */
 
-  /* not support for BFILE, CFILE, and ENUM */
+  /* not support for BFILE, CFILE, BLOB, CLOB, and ENUM */
   0,				/* CCI_U_TYPE_BFILE */
   0,				/* CCI_U_TYPE_CFILE */
-  CCI_A_TYPE_BIT,		/* CCI_U_TYPE_BLOB */
-  CCI_A_TYPE_STR,		/* CCI_U_TYPE_CLOB */
+  0,				/* CCI_U_TYPE_BLOB */
+  0,				/* CCI_U_TYPE_CLOB */
   0,				/* CCI_U_TYPE_ENUM */
 
   CCI_A_TYPE_UINT,		/* CCI_U_TYPE_USHORT */
@@ -535,6 +535,12 @@ dblink_bind_param (int stmt_handle, VAL_DESCR * vd, DBLINK_HOST_VARS * host_vars
 	  value = NULL;
 	  u_type = CCI_U_TYPE_NULL;
 	  break;
+	case DB_TYPE_BFILE:
+	case DB_TYPE_CFILE:
+	case DB_TYPE_BLOB:
+	case DB_TYPE_CLOB:
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK_UNSUPPORTED_TYPE, 1, pr_type_name ((DB_TYPE) type));
+	  return ER_DBLINK_UNSUPPORTED_TYPE;
 	default:
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK_UNSUPPORTED_TYPE, 1, "unknown");
 	  return ER_DBLINK_UNSUPPORTED_TYPE;


### PR DESCRIPTION
  http://jira.cubrid.org/browse/CBRD-26802

  ### Purpose

  `dblink_bind_param` 은 BFILE / CFILE / BLOB / CLOB 4종 LOB 타입에 대한 명시 분기 없이
  `default` 로 흘려서 `"unknown"` 이라는 모호한 에러 메시지를 반환하고 있었다.

  CBRD-26224 에서 INTERNAL BLOB / CLOB 이 inline 타입으로 도입된 이후,
  다음과 같이 `@srv` 원격 컬럼과 host 변수를 비교하는 패턴이 가능해졌고
  파서가 host 변수를 컬럼 도메인(BLOB/CLOB)으로 implicit-coerce 하면서
  `DB_TYPE_BLOB` / `DB_TYPE_CLOB` 호스트 변수가 `dblink_bind_param` 까지 흘러 들어간다.

  ```sql
  prepare s from 'select id from lob_src@srv_self where cb = ?';
  execute s using X'68656c6c6f';
  -- 수정 전: ERROR: dblink - not supported type unknown.
  -- 수정 후: ERROR: dblink - not supported type blob.
  ```

  또한 `type_map` 의 `CCI_U_TYPE_BLOB` / `CCI_U_TYPE_CLOB` 항목은
  결과 처리 switch (`dblink_scan.c:909-1010`) 에 매칭 case 가 없어 `default`
  분기로 떨어지므로 실제로는 도달하지 않는 dead value 로 남아 있다.

  ### Implementation

  **`src/query/dblink_scan.c`**

  ```diff
     /* not support for BFILE, CFILE, and ENUM */
     0,                         /* CCI_U_TYPE_BFILE */
     0,                         /* CCI_U_TYPE_CFILE */
  -  CCI_A_TYPE_BIT,            /* CCI_U_TYPE_BLOB */
  -  CCI_A_TYPE_STR,            /* CCI_U_TYPE_CLOB */
  +  0,                         /* CCI_U_TYPE_BLOB */
  +  0,                         /* CCI_U_TYPE_CLOB */
     0,                         /* CCI_U_TYPE_ENUM */
  ```

  ```diff
        case DB_TYPE_NULL:
          ...
          break;
  +     case DB_TYPE_BFILE:
  +     case DB_TYPE_CFILE:
  +     case DB_TYPE_BLOB:
  +     case DB_TYPE_CLOB:
  +       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK_UNSUPPORTED_TYPE,
  +               1, pr_type_name ((DB_TYPE) type));
  +       return ER_DBLINK_UNSUPPORTED_TYPE;
        default:
          er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_DBLINK_UNSUPPORTED_TYPE,
                  1, "unknown");
  ```

  BFILE / CFILE 은 일반적으로 semantic-check 단계에서 먼저 거부되어
  `dblink_bind_param` 까지 도달하지 않지만, defense-in-depth 와 4종 일관성을 위해
  함께 처리한다.

  ### Test

  `dblink_scan.c` 만 `HEAD~1` 로 revert 후 재빌드하여 before/after 빌드를 비교 검증.

  | 케이스 (`@srv` WHERE col = ?) | Before-fix | After-fix |
  |---|---|---|
  | BLOB 컬럼 + `X'..'` host var | `not supported type unknown` | `not supported type blob` |
  | CLOB 컬럼 + STRING host var | `not supported type unknown` | `not supported type clob` |
  | BFILE 컬럼 + `X'..'` host var | `Semantic: not supported type bfile` | 동일 (semantic 단계 거부) |
  | CFILE 컬럼 + STRING host var | `Semantic: not supported type cfile` | 동일 (semantic 단계 거부) |
  | INT 컬럼 + INT host var (회귀) | 정상 | 정상 |

  신규 회귀 TC `dblink_lob_bind_unknown_0001` (8 assertion):

  | 빌드 | 결과 |
  |---|---|
  | Before-fix | 4 OK / 4 NOK (`blob`/`clob` 누락 + `unknown` placeholder 검출) |
  | After-fix | 8 OK / 0 NOK |

  기존 회귀 (`cubrid_typesupport`, `cbrd_24501_dblink_dml`) 에 영향 없음 확인.

  ### Remarks

  - INTERNAL BLOB / CLOB 호스트 변수의 dblink 경로 거부 메시지를 BFILE / CFILE 과
    동일한 형태(`dblink - not supported type <type>`)로 정렬하여 사용자에게 일관된 진단을 제공한다.
  - 선행: CBRD-26223, CBRD-26224 / EPIC: CBRD-26197
