### PR TITLE
[CBRD-26820] Fix Au_disable leak from parser->au_save overwrite in do_select_internal

### DIFF
--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -14360,6 +14360,7 @@ do_select_internal (PARSER_CONTEXT * parser, PT_NODE * statement, bool for_ins_u
   const char *into_label;
   DB_VALUE *vals, *v;
   int save;
+  int prev_parser_au_save;
   QUERY_FLAG query_flag;
   XASL_STREAM stream;
   bool query_trace = false;
@@ -14377,6 +14378,7 @@ do_select_internal (PARSER_CONTEXT * parser, PT_NODE * statement, bool for_ins_u
     }
 
   AU_DISABLE (save);
+  prev_parser_au_save = parser->au_save;
   parser->au_save = save;
 
   /* mark the beginning of another level of xasl packing */
@@ -14516,6 +14518,7 @@ do_select_internal (PARSER_CONTEXT * parser, PT_NODE * statement, bool for_ins_u
   /* mark the end of another level of xasl packing */
   pt_exit_packing_buf ();
 
+  parser->au_save = prev_parser_au_save;
   AU_ENABLE (save);
   return error;
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26821

### Purpose
- do_select_internal()이 caller(do_update)의 parser->au_save를 덮어써 발생하는 stale Au_disable 잔존을 차단하고, JDBC 세션에서 system class 권한 검사가 bypass되던 회귀를 수정한다.

### Implementation
- do_select_internal() 진입 시 parser->au_save를 local 변수에 백업하고, 함수 종료 시 복원.

### Remarks
- 동일 패턴이 insert_local, do_execute_do에도 있으나 이번 회귀와 직접 무관하여 별도 sub-task로 분리.
- 재현 trigger는 medium/_01_fixed/cases/3992.sql의 multi-assignment UPDATE with subquery. CBRD-25862 이후 노출.
- 검증: full medium suite 970 cases 모두 통과.
