### PR TITLE
[CBRD-26803] Support internal LOB (BLOB/CLOB) in CDC log info

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -12724,8 +12724,16 @@ cdc_get_attribute_size (DB_VALUE * value)
 	size = ((db_get_string_length (value) + 3) / 4) + 3;
 	break;
       }
+    case DB_TYPE_BLOB:
+      /* internal BLOB is stored inline like a bit string; see cdc_put_bit_string_to_loginfo */
+      size = ((db_get_string_length (value) + 3) / 4) + 3;
+      break;
     case DB_TYPE_CHAR:
     case DB_TYPE_VARCHAR:
+      size = db_get_string_size (value);
+      break;
+    case DB_TYPE_CLOB:
+      /* internal CLOB is stored inline like a character string; see cdc_put_value_to_loginfo */
       size = db_get_string_size (value);
       break;
     case DB_TYPE_NCHAR:
@@ -13627,6 +13635,69 @@ cdc_compare_undoredo_dbvalue (const db_value * new_value, const db_value * old_v
     }
 }
 
+/*
+ * cdc_put_bit_string_to_loginfo - pack a bit-string DB_VALUE into CDC log info
+ *    return: NO_ERROR if successful, error code otherwise
+ *    new_value(in): DB_VALUE of type BIT/VARBIT/BLOB
+ *    data_ptr(in/out): CDC log info write pointer, advanced on success
+ * Note:
+ *    Internal BLOB is stored inline like a bit string and shares this packing
+ *    routine. It is invoked from dedicated BIT/VARBIT and BLOB switch cases so
+ *    that BLOB-specific handling can diverge without touching the BIT path.
+ */
+static int
+cdc_put_bit_string_to_loginfo (db_value * new_value, char **data_ptr)
+{
+  char temp[1024];
+  char *result = NULL;
+  int length;
+  int func_type = 7;
+  char *ptr = *data_ptr;
+
+  length = ((db_get_string_length (new_value) + 3) / 4) + 4;
+
+  if (length <= 1024)
+    {
+      result = temp;
+    }
+  else
+    {
+      result = (char *) malloc (length);
+      if (result == NULL)
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, length);
+	  return ER_OUT_OF_VIRTUAL_MEMORY;
+	}
+    }
+
+  snprintf (result, 3, "X'");
+
+  if (db_bit_string (new_value, "%X", result + 2, length - 2) != NO_ERROR)
+    {
+      if (result != temp)
+	{
+	  free_and_init (result);
+	}
+
+      return ER_FAILED;
+    }
+
+  snprintf (result + length - 2, 2, "'");
+
+  assert ((int) strlen (result) == (length - 1));
+
+  ptr = or_pack_int (ptr, func_type);
+  ptr = or_pack_string (ptr, result);
+
+  if (result != temp)
+    {
+      free_and_init (result);
+    }
+
+  *data_ptr = ptr;
+  return NO_ERROR;
+}
+
 static int
 cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
 {
@@ -13706,55 +13777,20 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
       break;
     case DB_TYPE_BIT:
     case DB_TYPE_VARBIT:
-      {
-	char temp[1024];
-	char *result = NULL;
-	int length, n, count;
-	char *bitstring = NULL;
-	func_type = 7;
-
-	length = ((db_get_string_length (new_value) + 3) / 4) + 4;
-
-	if (length <= 1024)
-	  {
-	    result = temp;
-	  }
-	else
-	  {
-	    result = (char *) malloc (length);
-	    if (result == NULL)
-	      {
-		er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, length);
-		return ER_OUT_OF_VIRTUAL_MEMORY;
-	      }
-	  }
-
-	snprintf (result, 3, "X'");
-
-	if (db_bit_string (new_value, "%X", result + 2, length - 2) != NO_ERROR)
-	  {
-	    if (result != temp)
-	      {
-		free_and_init (result);
-	      }
-
-	    return ER_FAILED;
-	  }
-
-	snprintf (result + length - 2, 2, "'");
-
-	assert ((int) strlen (result) == (length - 1));
-
-	ptr = or_pack_int (ptr, func_type);
-	ptr = or_pack_string (ptr, result);
-
-	if (result != temp)
-	  {
-	    free_and_init (result);
-	  }
-
-	break;
-      }
+      error_status = cdc_put_bit_string_to_loginfo (new_value, &ptr);
+      if (error_status != NO_ERROR)
+	{
+	  return error_status;
+	}
+      break;
+    case DB_TYPE_BLOB:
+      /* internal BLOB is stored inline like a bit string */
+      error_status = cdc_put_bit_string_to_loginfo (new_value, &ptr);
+      if (error_status != NO_ERROR)
+	{
+	  return error_status;
+	}
+      break;
     case DB_TYPE_CHAR:
       func_type = 7;
 
@@ -13762,6 +13798,12 @@ cdc_put_value_to_loginfo (db_value * new_value, char **data_ptr)
       ptr = or_pack_string_with_length (ptr, db_get_string (new_value), db_get_string_size (new_value) - 1);
       break;
     case DB_TYPE_VARCHAR:
+      func_type = 7;
+      ptr = or_pack_int (ptr, func_type);
+      ptr = or_pack_string (ptr, db_get_string (new_value));
+      break;
+    case DB_TYPE_CLOB:
+      /* internal CLOB is stored inline like a character string */
       func_type = 7;
       ptr = or_pack_int (ptr, func_type);
       ptr = or_pack_string (ptr, db_get_string (new_value));


### PR DESCRIPTION
  http://jira.cubrid.org/browse/CBRD-26803

  ### Purpose

  CBRD-26224 에서 INTERNAL BLOB / CLOB 을 inline 타입으로 추가했으나,
  서버측 CDC 로그 정보 생성 경로 (`src/transaction/log_manager.c` 의 `cdc_*`)
  에는 두 타입에 대한 분기가 없어 CDC 대상 테이블에 BLOB / CLOB 컬럼이 있으면
  변경 데이터가 로그 정보에 직렬화되지 않는다.

  INTERNAL BLOB 은 VARBIT, INTERNAL CLOB 은 VARCHAR 와 동일한 inline 데이터이므로
  같은 직렬화 규칙을 적용한다. BIT / VARBIT 비트 문자열 패킹 로직은 BLOB case 와
  공유하기 위해 정적 헬퍼로 추출한다.

  ### Implementation

  **`src/transaction/log_manager.c` — `cdc_get_attribute_size`**

  ```diff
  +    case DB_TYPE_BLOB:
  +      /* internal BLOB is stored inline like a bit string */
  +      size = ((db_get_string_length (value) + 3) / 4) + 3;
  +      break;
       case DB_TYPE_CHAR:
       case DB_TYPE_VARCHAR:
         size = db_get_string_size (value);
         break;
  +    case DB_TYPE_CLOB:
  +      /* internal CLOB is stored inline like a character string */
  +      size = db_get_string_size (value);
  +      break;
  ```

  **`src/transaction/log_manager.c` — `cdc_put_value_to_loginfo`**

  BIT / VARBIT 의 인라인 패킹 블록을 `cdc_put_bit_string_to_loginfo` 정적 헬퍼로
  추출하여 BLOB case 와 공유. CLOB case 는 CHAR / VARCHAR 와 동일하게 `func_type=7`
  + `or_pack_string` 으로 직렬화.

  ```diff
       case DB_TYPE_BIT:
       case DB_TYPE_VARBIT:
  -      { /* inline 비트 문자열 패킹 ~50줄 */ }
  +      error_status = cdc_put_bit_string_to_loginfo (new_value, &ptr);
  +      if (error_status != NO_ERROR) return error_status;
  +      break;
  +    case DB_TYPE_BLOB:
  +      /* internal BLOB is stored inline like a bit string */
  +      error_status = cdc_put_bit_string_to_loginfo (new_value, &ptr);
  +      if (error_status != NO_ERROR) return error_status;
  +      break;
       ...
  +    case DB_TYPE_CLOB:
  +      /* internal CLOB is stored inline like a character string */
  +      func_type = 7;
  +      ptr = or_pack_int (ptr, func_type);
  +      ptr = or_pack_string (ptr, db_get_string (new_value));
  +      break;
  ```

  추출 과정에서 미사용 지역 변수(`n`, `count`, `bitstring`) 도 함께 정리.
  추후 LOB 처리가 분기될 때 BLOB 전용 case 만 수정하면 되도록 설계.

  ### Test

  BLOB / CLOB 컬럼을 가진 테이블에 INSERT / UPDATE / DELETE 를 수행하고,
  CDC consumer 가 받은 로그에 값이 그대로 나오는지 회귀 테스트로 검증.

  | 테스트 | 내용 | 결과 |
  |---|---|---|
  | 기본 직렬화 | BLOB 값 `B'1010111'` → CDC 로그에 `X'57'`, CLOB 값 `'hello'` → `hello` 로 그대로 출력 | PASS |
  | INSERT / UPDATE / DELETE | DML 종류별로 BLOB / CLOB 컬럼 값이 정상 직렬화되고 변경 컬럼만 기록 | PASS |
  | 크기 경계 | 8 byte 부터 1 MB 까지 값 손실 없이 직렬화 | PASS |
  | 특수 데이터 | UTF-8 한글 CLOB, 임베디드 NUL(`0x00`) 바이트 BLOB 그대로 보존 | PASS |
  | 트랜잭션 | 커밋 / 롤백 모두 CDC 로그에 정상 기록 | PASS |
  | 에러 경로 | 잘못된 host · 미래 시각으로 호출 시 crash 없이 정상 종료 | PASS |

  기존 BIT / VARBIT / CHAR / VARCHAR 직렬화는 동작 변화 없음.

  ### Remarks

  - BFILE / CFILE 은 EPIC 범위 밖이며 CDC 대상으로 도달하지 않는다.

