### PR TITLE
[CBRD-26827] Fix SIGSEGV in pt_print_dblink_table when server name is quoted

### DIFF
--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -19419,12 +19419,19 @@ pt_print_dblink_table (PARSER_CONTEXT * parser, PT_NODE * p)
       else
 	{
 	  /* For Query-cache:
-	   * Separate comments have been added 
+	   * Separate comments have been added
 	   * for cases where there is no change in the query but information on the server has changed. */
 	}
     }
+  else
+    {
+      if (!pt->url || !pt->user || !pt->pwd)
+	{
+	  print_detail = false;
+	}
+    }
 
-  if (print_detail && pt->url && pt->user && pt->pwd)
+  if (print_detail)
     {
       var = pt_print_remote_info (parser, pt, false);
     }

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -19424,7 +19424,7 @@ pt_print_dblink_table (PARSER_CONTEXT * parser, PT_NODE * p)
 	}
     }
 
-  if (print_detail)
+  if (print_detail && pt->url && pt->user && pt->pwd)
     {
       var = pt_print_remote_info (parser, pt, false);
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26827

### Purpose

`dblink('server', ...)` 형태(홑따옴표 서버 이름)를 사용하면 correlated subquery에서 SIGSEGV가 발생하는 버그를 수정한다.

홑따옴표로 감싼 서버 이름(`'cubrid_conn'`)은 `CHAR_STRING` 토큰으로 인식되어 `dblink_conn_str` 규칙으로 파싱된다. 연결 문자열 형식(`host=..., port=...`)이 아니므로 파싱이 실패하고 `url/user/pwd`가 NULL인 상태로 노드가 생성된다.

Correlated subquery에서 GLR 파서 에러 처리 경로가 `pt_print_dblink_table()`을 호출하면서 NULL인 `pt->url`을 역참조하여 crash 발생.

| 표기 | 토큰 | 현상 |
|------|------|------|
| `cubrid_conn` | `IdName` | 정상 |
| `'cubrid_conn'` | `CHAR_STRING` | **CRASH** |

### Implementation

`src/parser/parse_tree_cl.c`의 `pt_print_dblink_table()` 함수에서 `pt_print_remote_info()` 호출 전 NULL 체크 추가.

```c
// Before
if (print_detail)

// After
if (print_detail && pt->url && pt->user && pt->pwd)
```

### Remarks

- 파서 에러 처리 경로에서 NULL 체크 누락으로 crash 발생.