### PR TITLE
[CBRD-26713] Resolve DMRB corruption by fixing race condition during context migration.

### DIFF
--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -2983,6 +2983,7 @@ void
 css_request_shutdown_conn (css_conn_entry * conn, uint8_t ignore, bool retry, int wait_time)
 {
   cubconn::connection::worker::message request;
+  cubconn::connection::context * ctx;
   int r;
 
   assert (conn);
@@ -3009,6 +3010,10 @@ css_request_shutdown_conn (css_conn_entry * conn, uint8_t ignore, bool retry, in
       return;
     }
 
+  ctx = static_cast < cubconn::connection::context * >(conn->context);
+  request.ctx = ctx;
+  request.id = ctx->m_id;
+
   auto func =[conn] ()noexcept {
     /* unlock */
     rmutex_unlock (NULL, &conn->cmutex);
@@ -3025,6 +3030,7 @@ void
 css_request_release_packet (css_conn_entry * conn, void *buffer)
 {
   cubconn::connection::worker::message request;
+  cubconn::connection::context * ctx;
   int r;
 
   assert (conn && buffer);
@@ -3049,6 +3055,10 @@ css_request_release_packet (css_conn_entry * conn, void *buffer)
 
       return;
     }
+
+  ctx = static_cast < cubconn::connection::context * >(conn->context);
+  request.ctx = ctx;
+  request.id = ctx->m_id;
 
   conn->worker->enqueue (cubconn::connection::worker::queue_type::IMMEDIATE, std::move (request));
 

--- a/src/connection/connection_worker.cpp
+++ b/src/connection/connection_worker.cpp
@@ -500,8 +500,6 @@ namespace cubconn::connection
 
     /* clear resource */
 
-    ctx->m_send.m_transmitter.clear ();
-
     start = std::chrono::steady_clock::now ();
 
     rmutex_lock (m_entry, &ctx->m_conn->cmutex);
@@ -514,6 +512,8 @@ namespace cubconn::connection
     end = std::chrono::steady_clock::now ();
     m_stats.add (statistics::worker::BLOCKED_RMUTEX,
 		 std::chrono::duration_cast<std::chrono::microseconds> (end - start).count ());
+
+    ctx->m_send.m_transmitter.clear ();
 
     /* close the socket */
     css_shutdown_socket (ctx->m_conn->fd);
@@ -542,6 +542,8 @@ retry:
 
     request.type = message_type::SHUTDOWN_CLIENT;
     request.conn = ctx->m_conn;
+    request.ctx = ctx;
+    request.id = ctx->m_id;
     request.ignore = ctx->m_ignore;
     request.retry = true;
     request.waiter_handle = handle;
@@ -877,9 +879,41 @@ retry:
     return true;
   }
 
+  bool worker::validate_message_generation (const message &item, context *ctx) const
+  {
+    return ctx != nullptr && item.ctx == ctx && item.id == ctx->m_id && ctx->m_conn == item.conn;
+  }
+
+  bool worker::forward_message_to_successor (queue_type type, message &item, context *ctx)
+  {
+    worker *successor;
+
+    if (item.conn->worker == this && m_context.find (ctx) != m_context.end ())
+      {
+	return false;
+      }
+
+    successor = item.conn->worker;
+    if (successor != nullptr)
+      {
+	successor->enqueue (type, std::move (item));
+	if (!successor->notify ())
+	  {
+	    assert_release (false);
+	  }
+      }
+    else
+      {
+	this->wakeup_blocked_worker (item.waiter_handle);
+      }
+
+    return true;
+  }
+
   bool worker::handle_message_queue_send_packet (message &item)
   {
     context *ctx;
+    css_conn_entry *conn;
     result status;
     int r;
 
@@ -891,13 +925,13 @@ retry:
     ctx = reinterpret_cast<context *> (item.conn->context);
     if (ctx == nullptr)
       {
-	r = rmutex_unlock (m_entry, &item.conn->cmutex);
-	assert (r == NO_ERROR);
-
 	if (item.deleter)
 	  {
 	    item.deleter ();
 	  }
+
+	r = rmutex_unlock (m_entry, &item.conn->cmutex);
+	assert (r == NO_ERROR);
 
 #if !defined (NDEBUG)
 	er_log_conn (__FILE__, __LINE__,
@@ -905,6 +939,24 @@ retry:
 		     item.message_id, static_cast<void *> (item.conn));
 #endif
 	this->wakeup_blocked_worker (item.waiter_handle);
+
+	return true;
+      }
+
+    conn = item.conn;
+    if (!this->validate_message_generation (item, ctx))
+      {
+	r = rmutex_unlock (m_entry, &conn->cmutex);
+	assert (r == NO_ERROR);
+
+	this->wakeup_blocked_worker (item.waiter_handle);
+
+	return true;
+      }
+    if (this->forward_message_to_successor (queue_type::IMMEDIATE, item, ctx))
+      {
+	r = rmutex_unlock (m_entry, &conn->cmutex);
+	assert (r == NO_ERROR);
 
 	return true;
       }
@@ -980,6 +1032,7 @@ retry:
   bool worker::handle_message_queue_release_packet (message &item)
   {
     context *ctx;
+    css_conn_entry *conn;
     int r;
 
     assert (item.conn);
@@ -997,6 +1050,22 @@ retry:
 	er_log_conn (__FILE__, __LINE__,
 		     "connection::worker->handle_message_queue_release_packet: context is already cleared for conn = %p\n",
 		     static_cast<void *> (item.conn));
+	return true;
+      }
+
+    conn = item.conn;
+    if (!this->validate_message_generation (item, ctx))
+      {
+	r = rmutex_unlock (m_entry, &conn->cmutex);
+	assert (r == NO_ERROR);
+
+	return true;
+      }
+    if (this->forward_message_to_successor (queue_type::IMMEDIATE, item, ctx))
+      {
+	r = rmutex_unlock (m_entry, &conn->cmutex);
+	assert (r == NO_ERROR);
+
 	return true;
       }
 
@@ -1227,6 +1296,7 @@ respond:
   bool worker::handle_message_queue_shutdown_client (message &item)
   {
     context *ctx;
+    css_conn_entry *conn;
     int r;
 
     assert (item.conn);
@@ -1243,6 +1313,26 @@ respond:
 	er_log_conn (__FILE__, __LINE__,
 		     "connection::worker->handle_message_queue_shutdown_client: context is already cleared for conn = %p\n",
 		     static_cast<void *> (item.conn));
+
+	this->wakeup_blocked_worker (item.waiter_handle);
+	return true;
+      }
+
+    conn = item.conn;
+    if (!this->validate_message_generation (item, ctx))
+      {
+	r = rmutex_unlock (m_entry, &conn->cmutex);
+	assert (r == NO_ERROR);
+
+	this->wakeup_blocked_worker (item.waiter_handle);
+
+	return true;
+      }
+    if (this->forward_message_to_successor (queue_type::LAZY, item, ctx))
+      {
+	r = rmutex_unlock (m_entry, &conn->cmutex);
+	assert (r == NO_ERROR);
+
 	return true;
       }
 

--- a/src/connection/connection_worker.hpp
+++ b/src/connection/connection_worker.hpp
@@ -301,6 +301,9 @@ namespace cubconn::connection
       /* --------------------------------------------------------------------------- */
       /* message queue based interface						     */
       /* --------------------------------------------------------------------------- */
+      bool validate_message_generation (const message &item, context *ctx) const;
+      bool forward_message_to_successor (queue_type type, message &item, context *ctx);
+
       bool handle_message_queue_send_packet (message &item);
       bool handle_message_queue_release_packet (message &item);
 

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -658,6 +658,7 @@ css_enqueue_and_notify (cubconn::connection::worker::queue_type type, cubconn::c
 			int wait_time)
 {
   CSS_CONN_ENTRY * conn;
+  cubconn::connection::context *ctx;
   int r;
 
   assert (item.conn);
@@ -680,6 +681,10 @@ css_enqueue_and_notify (cubconn::connection::worker::queue_type type, cubconn::c
 
       return 0;
     }
+
+  ctx = static_cast<cubconn::connection::context *> (conn->context);
+  item.ctx = ctx;
+  item.id = ctx->m_id;
 
   auto func =[conn] ()noexcept {
     /* unlock */


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26713>

### Purpose

두 개의 Connection worker가 동시에 하나의 context에 접근하게 되는 문제를 제거합니다. 시나리오는 아래와 같습니다.

T0 (Coordinator)
1. Connection worker A의 CTX 1을 rebalancing 대상으로 지정. Connection worker A에 CTX 1을 Connection worker B로 이관하는 요청을 보냄.

T1 (Worker 0)
2. 작업을 수행하며 사용한 DMRB packet 영역에 대한 release를 요청. Connection worker A에 CTX 1의 DMRB 요청을 보냄.

T2 (Connection worker A)
3. 요청을 받고 CTX 1을 Connection worker B로 이관하기 위해 준비.
4. 이때 MQ에 있는 잔여 작업들을 비우려고 하지만, 이전 trigger에서 atomic exchange를 통해 MQ에 있는 작업 개수가 0이 되었음으로 작업이 비워지지 않음.
5. Connection worker B에 CTX 1 이관.

T1 (Worker 0)
2. 작업을 수행하며 사용한 DMRB packet 영역에 대한 release를 요청. Connection worker B에 CTX 1의 DMRB 요청을 보냄.

T3 (Connection worker B)
6. CTX 1을 Connection worker A로부터 받음.
7. DMRB packet release 요청을 보고 처리하려고 함.

T2 (Connection worker A)
8. 앞서 받았던 DMRB packet release 요청을 처리하려고 함. << RACE 발생

두 스레드가 동시에 std::map에 접근하려고 하며 std::map tree가 깨짐.

### Implementation

packet release, send, shutdown을 수행하기 전에 context의 소유 Connection worker가 자기 자신이 맞는 지 확인하도록 합니다.
자기 자신이 아니라면 이관한 Worker에 요청을 forwarding

### Remarks

N/A
