### PR TITLE
[CBRD-26838] Remove repetitive re-allocation for char * in a same scope

### DIFF
--- a/src/base/error_manager.c
+++ b/src/base/error_manager.c
@@ -1489,8 +1489,8 @@ er_set_internal (int severity, const char *file_name, const int line_no, int err
     }
   if (os_error != NULL)
     {
-      strcat (crt_error.msg_area, "... ");
-      strcat (crt_error.msg_area, os_error);
+      size_t len = strlen (crt_error.msg_area);
+      snprintf (crt_error.msg_area + len, crt_error.msg_area_size - len, "... %s", os_error);
     }
 
   /* Call the logging function if any */

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -3547,17 +3547,16 @@ get_column_default_as_string (DB_ATTRIBUTE * attr, bool * alloc)
 
       if (default_value_expr_op_string != NULL)
 	{
-	  strcpy (default_value_string, default_value_expr_op_string);
-	  strcat (default_value_string, "(");
-	  strcat (default_value_string, default_value_expr_type_string);
 	  if (default_expr_format)
 	    {
-	      strcat (default_value_string, ", \'");
-	      strcat (default_value_string, default_expr_format);
-	      strcat (default_value_string, "\'");
+	      snprintf (default_value_string, len + 1, "%s(%s, \'%s\')",
+			default_value_expr_op_string, default_value_expr_type_string, default_expr_format);
 	    }
-
-	  strcat (default_value_string, ")");
+	  else
+	    {
+	      snprintf (default_value_string, len + 1, "%s(%s)",
+			default_value_expr_op_string, default_value_expr_type_string);
+	    }
 	}
       else
 	{

--- a/src/executables/master_request.c
+++ b/src/executables/master_request.c
@@ -288,6 +288,7 @@ css_process_server_list_info (CSS_CONN_ENTRY * conn, unsigned short request_id)
   int bufsize = 0, required_size;
   char *buffer = NULL;
   SOCKET_QUEUE_ENTRY *temp;
+  size_t offset = 0;
 
   for (temp = css_Master_socket_anchor; temp; temp = temp->next)
     {
@@ -338,14 +339,13 @@ css_process_server_list_info (CSS_CONN_ENTRY * conn, unsigned short request_id)
 	  /* if HA mode server */
 	  if (IS_MASTER_CONN_NAME_HA_SERVER (temp->name))
 	    {
-	      snprintf (buffer + strlen (buffer), required_size, HA_SERVER_FORMAT_STRING, temp->name + 1,
-			(temp->version_string == NULL ? "?" : temp->version_string), temp->pid);
+	      offset += snprintf (buffer + offset, bufsize - offset, HA_SERVER_FORMAT_STRING, temp->name + 1,
+				  (temp->version_string == NULL ? "?" : temp->version_string), temp->pid);
 	    }
 	  else
 	    {
-	      snprintf (buffer + strlen (buffer), required_size, SERVER_FORMAT_STRING, temp->name,
-			(temp->version_string == NULL ? "?" : temp->version_string), temp->pid);
-
+	      offset += snprintf (buffer + offset, bufsize - offset, SERVER_FORMAT_STRING, temp->name,
+				  (temp->version_string == NULL ? "?" : temp->version_string), temp->pid);
 	    }
 	}
     }
@@ -389,6 +389,11 @@ css_process_all_list_info (CSS_CONN_ENTRY * conn, unsigned short request_id)
   char *buffer = NULL;
   SOCKET_QUEUE_ENTRY *temp;
 
+  size_t ha_srv_fmt_len = strlen (HA_SERVER_FORMAT_STRING);
+  size_t ha_cp_log_db_fmt_len = strlen (HA_COPYLOGDB_FORMAT_STRING);
+  size_t ha_appl_log_db_fmt_len = strlen (HA_APPLYLOGDB_FORMAT_STRING);
+  size_t srv_fmt_len = strlen (SERVER_FORMAT_STRING);
+
   for (temp = css_Master_socket_anchor; temp; temp = temp->next)
     {
       if (!IS_INVALID_SOCKET (temp->fd) && !IS_MASTER_SOCKET_FD (temp->fd) && temp->name != NULL)
@@ -398,16 +403,16 @@ css_process_all_list_info (CSS_CONN_ENTRY * conn, unsigned short request_id)
 	  switch (temp->name[0])
 	    {
 	    case '#':
-	      required_size += strlen (HA_SERVER_FORMAT_STRING);
+	      required_size += ha_srv_fmt_len;
 	      break;
 	    case '$':
-	      required_size += strlen (HA_COPYLOGDB_FORMAT_STRING);
+	      required_size += ha_cp_log_db_fmt_len;
 	      break;
 	    case '%':
-	      required_size += strlen (HA_APPLYLOGDB_FORMAT_STRING);
+	      required_size += ha_appl_log_db_fmt_len;
 	      break;
 	    default:
-	      required_size += strlen (SERVER_FORMAT_STRING);
+	      required_size += srv_fmt_len;
 	      break;
 	    }
 	  required_size += strlen (temp->name);
@@ -624,7 +629,7 @@ css_process_start_shutdown_by_name (char *server_name)
     {
       if ((temp->name != NULL) && (strcmp (temp->name, server_name) == 0))
 	{
-	  /* Send a shutdown request to the specified cub_server with a timeout of 0. 
+	  /* Send a shutdown request to the specified cub_server with a timeout of 0.
 	   * Buffer will be unused in the receiving function (css_process_shutdown_request). */
 	  css_process_start_shutdown (temp, 0, buffer);
 	}

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -645,7 +645,7 @@ createdb (UTIL_FUNCTION_ARG * arg)
 	  if (snprintf (abs_lob_path, PATH_MAX, "%s/%s", cwd, lob_path) >= PATH_MAX)
 	    {
 	      /* TODO:  Temporarily processed to clean up "-Wformat-truncation=" warning.
-	       * Additional review will be required.        
+	       * Additional review will be required.
 	       */
 	      goto error_exit;
 	    }
@@ -2614,14 +2614,13 @@ dumplocale (UTIL_FUNCTION_ARG * arg)
 			    err_status, true);
 	  goto error;
 	}
-      lf->locale_name = (char *) malloc (strlen (locale_str) + 1);
+      lf->locale_name = strdup (locale_str);
       if (lf->locale_name == NULL)
 	{
 	  err_status = ER_LOC_INIT;
 	  LOG_LOCALE_ERROR ("memory allocation failed", err_status, true);
 	  goto error;
 	}
-      strcpy (lf->locale_name, locale_str);
       err_status = locale_check_and_set_default_files (lf, true);
     }
   else
@@ -2924,9 +2923,7 @@ synccoll_check (const char *db_name, int *db_obs_coll_cnt, int *new_sys_coll_cnt
 
   assert (db_collations != NULL);
 
-  strcpy (f_stmt_name, FILE_STMT_NAME);
-  strcat (f_stmt_name, db_name);
-  strcat (f_stmt_name, ".sql");
+  snprintf (f_stmt_name, PATH_MAX, FILE_STMT_NAME "%s.sql", db_name);
 
   f_stmt = fopen (f_stmt_name, "wt");
   if (f_stmt == NULL)

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -1498,16 +1498,15 @@ catcls_get_or_value_from_attribute (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
 		  goto error;
 		}
 
-	      strcpy (default_str_val_tmp, default_expr_op_string);
-	      strcat (default_str_val_tmp, "(");
-	      strcat (default_str_val_tmp, default_expr_type_string);
 	      if (def_expr_format_string)
 		{
-		  strcat (default_str_val_tmp, ", \'");
-		  strcat (default_str_val_tmp, def_expr_format_string);
-		  strcat (default_str_val_tmp, "\'");
+		  snprintf (default_str_val_tmp, len + 1, "%s(%s, \'%s\')", default_expr_op_string,
+			    default_expr_type_string, def_expr_format_string);
 		}
-	      strcat (default_str_val_tmp, ")");
+	      else
+		{
+		  snprintf (default_str_val_tmp, len + 1, "%s(%s)", default_expr_op_string, default_expr_type_string);
+		}
 	    }
 	  else
 	    {
@@ -1559,10 +1558,9 @@ catcls_get_or_value_from_attribute (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
 	  len = strlen (default_expr_type_string);
 
 	  /* add whitespace character if default_str_val is not an empty string */
-	  str_val =
-	    (char *) db_private_alloc (thread_p,
-				       (default_value_len + (default_value_len ? 1 : 0) + len + strlen ("ON UPDATE ")
-					+ 1));
+	  size_t str_val_size = default_value_len + 1 + len + strlen ("ON UPDATE ") + 1;
+
+	  str_val = (char *) db_private_alloc (thread_p, str_val_size);
 	  if (str_val == NULL)
 	    {
 	      pr_clear_value (&default_expr);
@@ -1572,14 +1570,11 @@ catcls_get_or_value_from_attribute (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
 	    }
 	  if (default_str_val != NULL)
 	    {
-	      strcpy (str_val, default_str_val);
-	      strcat (str_val, " ON UPDATE ");
-	      strcat (str_val, default_expr_type_string);
+	      snprintf (str_val, str_val_size, "%s ON UPDATE %s", default_str_val, default_expr_type_string);
 	    }
 	  else
 	    {
-	      strcpy (str_val, "ON UPDATE ");
-	      strcat (str_val, default_expr_type_string);
+	      snprintf (str_val, str_val_size, "ON UPDATE %s", default_expr_type_string);
 	    }
 
 	  pr_clear_value (attr_val_p);	/* clean old default value */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26838

### Purpose

This pull request aims for micro optimization when repetitive `strlen`/`strcat`/`strcpy` call happens.

### Implementation

O(N^2) `strlen` => O(N) `strlen`, temporary variable
`strcpy`->`strcat`->`strcat` => `strcpy`->`snprinf` or `snprintf`, temporary len variable
extraneous `malloc` => strdup