### PR TITLE
[CBRD-25862] Switch contrib/scripts to _db_user after db_user view split

### DIFF
--- a/contrib/scripts/check_index_ovfps.sh
+++ b/contrib/scripts/check_index_ovfps.sh
@@ -191,7 +191,7 @@ function verify_user_pass ()
 	local USERNAME
 	local dbuser
 	local passwd
-	local qry_dba_grp="SELECT u.name FROM db_user AS u, TABLE(u.groups) AS g(x) where x.name = 'DBA'"
+	local qry_dba_grp="SELECT u.name FROM _db_user AS u, TABLE(u.groups) AS g(x) where x.name = 'DBA'"
 
 	dbuser=$(echo ${user} | cut -d' ' -f2-2)
 	USERNAME=$(echo ${dbuser} | tr [:lower:] [:upper:])
@@ -277,7 +277,7 @@ function do_get_index_name_list()
 	local i_qry=""
 	local csql_qry=""
 
-	i_qry="${i_qry} SELECT CAST (c.owner.name AS VARCHAR(255)) AS owner_name,"
+	i_qry="${i_qry} SELECT c.owner.name AS owner_name,"
 	i_qry="${i_qry}         c.class_name AS class_name,"
 	i_qry="${i_qry}         i.index_name AS index_name,"
 	i_qry="${i_qry}         NVL( (SELECT CASE WHEN pname IS NULL THEN 'P' ELSE 'S' END"

--- a/contrib/scripts/check_reserved.sql
+++ b/contrib/scripts/check_reserved.sql
@@ -35,7 +35,7 @@ SELECT 'stored_proc_arg', arg_name, '', sp_of.sp_name
 FROM   _db_stored_procedure_args WHERE arg_name IN :reserved
 UNION ALL
 SELECT 'user', name, '', ''
-FROM   db_user WHERE LOWER(name) IN :reserved
+FROM   _db_user WHERE LOWER(name) IN :reserved
 UNION ALL
 SELECT 'trigger', name, '', ''
 FROM   _db_trigger WHERE name IN :reserved


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25862

### Purpose
- PR #6903의 db_user 수정 이후 contrib/scripts가 view 대신 base table에 직접 의존하도록 수정

### Implementation
- DBA 그룹 멤버십 probe와 예약어 충돌 검사를 db_user view에서 _db_user table로 전환.
- _db_user.name이 varchar(32)로 좁혀진 의도에 맞춰 owner_name 컬럼의 CAST AS VARCHAR(255) 제거.

### Remarks

