### PR TITLE
[CBRD-26804] Raise pgbuf tracker max re-fix from 16 to 400

### DIFF
--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -69,7 +69,10 @@ namespace cubthread
   const char *PGBUF_TRACK_NAME = "Page Buffer";
   const char *PGBUF_TRACK_RES_NAME = "pgptr";
   const std::size_t PGBUF_TRACK_MAX_ITEMS = 1024;
-  const unsigned PGBUF_TRACK_MAX_AMOUNT = 16;       // re-fix is possible... how many to accept is debatable
+  // this is only a debug check to find page fix leaks.
+  // one query can fix the same page many times. for example, nested subqueries with fixed scan fix the same page
+  // one time for each level. SQL nesting can go up to max_recursion_sql_depth (default 400), so we allow 400.
+  const unsigned PGBUF_TRACK_MAX_AMOUNT = 400;
 
   //////////////////////////////////////////////////////////////////////////
   // entry implementation


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26804>

### Purpose
현상
debug 서버 빌드에서 깊게 중첩된 correlated subquery 실행 시 assert로 core 발생. ({{enable_heap_fixed_scan=no}}로 회피 가능, release 빌드는 영향 없음)

원인
페이지 버퍼 resource tracker는 한 스레드가 같은 페이지를 재fix하는 누적 횟수를 추적하고, PGBUF_TRACK_MAX_AMOUNT(=16)를 넘으면 assert로 죽습니다. heap fixed scan은 페이지를 잡은 채 다음 단계로 진입하므로, 중첩 subquery가 nesting 단계마다 같은 페이지를 한 번씩 더 fix → 17단째에 16을 초과해 assert.
이 16은 하드 제약이 아니라 fix leak 조기 탐지용 debug 전용 임계값입니다(release는 tracker 자체 비활성). 문제는 엔진이 공식 허용하는 SQL 중첩 한도(max_recursion_sql_depth, 기본 400)와 어긋난다는 점으로, 합법적인 쿼리도 16을 넘길 수 있습니다.

### Implementation
한도를 16 → 400으로 상향하여 max_recursion_sql_depth 기본값과 정합. 자원 측면 부작용 없음(같은 페이지 재fix는 프레임 1개를 여러 번 pin할 뿐). debug 빌드 + 동일 TC로 core 미발생 확인.

### Remarks
N/A
