### PR TITLE
[CBRD-26851] Fix DBLink parser bypass for UPDATE/DELETE with local subquery

### DIFF
--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -11962,6 +11962,10 @@ pt_convert_dblink_dml_query (PARSER_CONTEXT * parser, PT_NODE * node,
     {
       parser_walk_tree (parser, node, pt_check_sub_query_spec, snl, NULL, NULL);
     }
+  else if (remote_upd > 0 && upd_spec)
+    {
+      parser_walk_tree (parser, node, pt_get_server_name_list, snl, NULL, NULL);
+    }
 
   if (into_spec)
     {

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -11958,15 +11958,6 @@ pt_convert_dblink_dml_query (PARSER_CONTEXT * parser, PT_NODE * node,
       assert (false);
     }
 
-  if (local_upd > 0 && upd_spec)
-    {
-      parser_walk_tree (parser, node, pt_check_sub_query_spec, snl, NULL, NULL);
-    }
-  else if (remote_upd > 0 && upd_spec)
-    {
-      parser_walk_tree (parser, node, pt_get_server_name_list, snl, NULL, NULL);
-    }
-
   if (into_spec)
     {
       parser_walk_tree (parser, into_spec, pt_get_server_name_list, snl, NULL, NULL);
@@ -11974,6 +11965,15 @@ pt_convert_dblink_dml_query (PARSER_CONTEXT * parser, PT_NODE * node,
 
   if (upd_spec)
     {
+      if (local_upd > 0)
+	{
+	  parser_walk_tree (parser, node, pt_check_sub_query_spec, snl, NULL, NULL);
+	}
+      else if (remote_upd > 0)
+	{
+	  parser_walk_tree (parser, node, pt_get_server_name_list, snl, NULL, NULL);
+	}
+
       parser_walk_tree (parser, upd_spec, pt_get_server_name_list, snl, NULL, NULL);
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26851

### Purpose

원격 DBLink 테이블에 대한 UPDATE/DELETE 문에서 로컬 서브쿼리를 포함할 때, 파서 검증이 우회되어 쿼리가 원격 서버로 전송되는 버그 수정.

**버그 재현:**
```sql
-- 원격 테이블 UPDATE + 로컬 서브쿼리 → 에러가 나야 하지만 우회됨
UPDATE remote_t@cubrid_conn
SET name = (SELECT name FROM local_t WHERE id = 1)
WHERE id = 1;
```

**문제점:**
- 로컬과 원격에 동일 이름 테이블이 있을 경우, 의도치 않은 데이터 무결성 침해 발생 가능
- INSERT SELECT는 정상 차단되지만, UPDATE/DELETE는 검증 누락

### Implementation

**변경 파일:** `src/parser/parser_support.c`

**수정 내용:**
1. `pt_convert_dblink_dml_query()` 함수에서 `remote_upd > 0`인 경우에도 서브쿼리 내 로컬 테이블을 카운트하도록 `else if` 브랜치 추가
2. 기존 INSERT SELECT 로직(`pt_get_server_name_list`)을 미러링하여 일관성 유지

**코드 변경:**
```c
if (upd_spec)
  {
    if (local_upd > 0)
      {
        parser_walk_tree (parser, node, pt_check_sub_query_spec, snl, NULL, NULL);
      }
    else if (remote_upd > 0)
      {
        parser_walk_tree (parser, node, pt_get_server_name_list, snl, NULL, NULL);
      }

    parser_walk_tree (parser, upd_spec, pt_get_server_name_list, snl, NULL, NULL);
  }
```

**왜 `else if`인가:**
- 로컬+원격 혼합 DML은 상위에서 이미 `"dblink: local mixed remote DML is not allowed"` 에러로 차단됨
- 따라서 이 코드에 도달 시 `local_upd > 0`이면 `remote_upd == 0`이고, 그 반대도 마찬가지
- `else if`는 이 상호 배타성을 명시적으로 표현

### Remarks

- 리팩토링 커밋 포함: upd_spec 검증 로직을 단일 블록으로 통합 (기능 변경 없음)