### PR TITLE
[CBRD-26855] Document pinned formatter versions and safe re-apply workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,40 +1,183 @@
-First off, thank you for considering contributing to CUBRID. 
+# Contributing to CUBRID
 
-There are many ways to contribute, from submitting a bug report and a feature request, improving the documentation, sharing sample codes, writing a blog or issuing a patch.
+First off, thank you for considering contributing to CUBRID.
 
-## How to file a bug report and suggest a new feature
+There are many ways to contribute, from submitting a bug report and a feature
+request, improving the documentation, sharing sample codes, writing a blog or
+issuing a patch.
 
-  Please [our issue tracker](http://jira.cubrid.org/browse/CBRD) to [create an issue](http://jira.cubrid.org/secure/CreateIssue!default.jspa). 
-  
-  ### For a bug report
-  
-  * Please select a proper "Project". Typical choice is "CUBRID (CBRD)". 
-  * Please specify "Issue Type" as "Correct Error" and describe your issues with details, especially a reproduction scenario.
-  * It would be great if you also show us your expected results as well as the current results.
-    
-  ### For a feature suggestion
-  
-  * Please select a proper "Project". Typical choice is "CUBRID (CBRD)". 
-  * Please "Issue Type" as "Improve Function/Performance" and let us hear your suggestion.
-     
+- [How to file a bug report or feature request](#how-to-file-a-bug-report-or-feature-request)
+- [How to submit a pull request](#how-to-submit-a-pull-request)
+- [PR requirements](#pr-requirements)
+- [Code style](#code-style)
+- [Memory header rule](#memory-header-rule-server-side-files)
+- [Build & test](#build--test)
+- [Getting help](#getting-help)
+
+## How to file a bug report or feature request
+
+Please use [our issue tracker](http://jira.cubrid.org/browse/CBRD) to
+[create an issue](http://jira.cubrid.org/secure/CreateIssue!default.jspa).
+
+### For a bug report
+
+* Please select a proper "Project". Typical choice is "CUBRID (CBRD)".
+* Please specify "Issue Type" as "Correct Error" and describe your issue with
+  details, especially a reproduction scenario.
+* It would be great if you also show us your expected results as well as the
+  current results.
+
+### For a feature suggestion
+
+* Please select a proper "Project". Typical choice is "CUBRID (CBRD)".
+* Please specify "Issue Type" as "Improve Function/Performance" and let us
+  hear your suggestion.
+
 ## How to submit a pull request
 
-  We are using [the standard GitHub fork and pull requests workflow](https://gist.github.com/Chaser324/ce0505fbed06b947d962).
+We use [the standard GitHub fork-and-pull-request workflow](https://gist.github.com/Chaser324/ce0505fbed06b947d962).
 
-  If you want to submit your work to CUBRID, first please make sure that you have signed and submitted [the contributors license agreement (CLA)](https://github.com/CUBRID/cubrid/wiki/CUBRID-Contributor's-Agreement). 
+Before submitting, please make sure you have signed and submitted
+[the contributors license agreement (CLA)](https://github.com/CUBRID/cubrid/wiki/CUBRID-Contributor's-Agreement).
 
-  The workflow is essentially as follows:
+The workflow is essentially:
 
-  * Fork CUBRID project.
-  * Make a topic branch. Make your changes to this branch.
-  * Issue a pull request on CUBRID repository. Base branch for a pull request would be develop.
+1. Fork the CUBRID project.
+2. Make a topic branch off `develop`. Make your changes to that branch.
+3. Open a pull request against the CUBRID repository. The base branch is
+   `develop`.
 
-  You are kindly requested to keep your work mergeable. 
+Useful references:
 
-You can also refer to
+* [Forking a repository](https://help.github.com/articles/fork-a-repo)
+* [Using pull requests](https://help.github.com/articles/using-pull-requests/)
+* [How to Contribute to an Open Source Project on GitHub](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github)
 
-  * [Forking a repository](https://help.github.com/articles/fork-a-repo).
-  * [Using pull requests](https://help.github.com/articles/using-pull-requests/).
-  * [How to Contribute to an Open Source Project on GitHub](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github).
-  
-You can also send us an email to contact at cubrid.org.
+You can also email us at contact at cubrid.org.
+
+## PR requirements
+
+| Check | Requirement |
+|---|---|
+| **Title** | Must match `^\[[A-Z]+-\d+\]\s.+` — e.g. `[CBRD-12345] Fix btree overflow` |
+| **License header** | New `.c/.h/.cpp/.hpp/.C/.H/.CPP/.HPP/.ipp/.sh/.bat/.y/.l/.msg` files need the Apache 2.0 header (copy from any existing file) |
+| **Code style** | Each changed file must be a fixed point under the project formatters (see [Code style](#code-style)) |
+| **memory_wrapper.hpp** | In `.c`/`.cpp` files compiled into the server, must be the **last** `#include`, immediately preceded by the marker comment (see [Memory header rule](#memory-header-rule-server-side-files)) |
+| **cppcheck** | No new `error:` findings (warnings are allowed) |
+| **CLA** | Required before merge |
+
+The corresponding CI jobs live in [`.github/workflows/check.yml`](.github/workflows/check.yml).
+
+## Code style
+
+CUBRID dispatches **three formatters by file extension** via a single script,
+[`.github/workflows/codestyle.sh`](.github/workflows/codestyle.sh). Always go
+through that script — the option flags are not the tool defaults, and the
+extension dispatch matters (a `.c` file is formatted with `indent` even though
+the build compiles it as C++17).
+
+| Extension | Formatter | Pinned version |
+|---|---|---|
+| `.c`, `.h`, `.i` | GNU indent | **2.2.11** (build from source — distro is 2.2.12+) |
+| `.cpp`, `.hpp`, `.ipp` | astyle | Ubuntu 24.04 package |
+| `.java` | google-java-format | **1.7** |
+
+Install: see [docs/install_build_requirements.md#code-formatters](docs/install_build_requirements.md#code-formatters).
+
+Format one file:
+
+```sh
+.github/workflows/codestyle.sh path/to/file.c
+```
+
+Reproduce the exact CI gate locally (run from the repo root):
+
+```sh
+# 1. List files you've changed. Default: unstaged + staged vs. HEAD.
+#    For a feature branch, you may instead want everything since the base:
+#    files=$(git diff --name-only cub/develop...HEAD)
+files=$(git diff --name-only HEAD)
+
+# 2. Format each one (skip deleted / non-existent paths).
+echo "$files" | while read -r f; do
+  [ -n "$f" ] && [ -f "$f" ] && .github/workflows/codestyle.sh "$f"
+done
+
+# 3. Assert the formatter was a no-op on those files specifically.
+#    Scoping the final diff to $files avoids tripping on unrelated unstaged
+#    edits elsewhere in your working tree.
+echo "$files" | xargs -r git diff -- | tee /tmp/gitdiff
+test ! -s /tmp/gitdiff   # exit 0 = CI will pass
+```
+
+### Why CI sometimes flags lines you didn't touch
+
+GNU indent is **context-sensitive and not strictly idempotent**. Its output
+for your hunk can depend on whitespace and comment alignment elsewhere in the
+same file. If a file's existing formatting predates `indent 2.2.11`, running
+the formatter on it can rewrite regions far from your change — and those
+rewrites land in your PR diff.
+
+**Safe workflow for `.c`/`.h`/`.i` edits** (skip for `.cpp`/`.hpp` — astyle
+is much closer to idempotent in practice):
+
+```sh
+# 1. Save your logical change as a patch.
+git diff -- path/to/file.c > /tmp/my-change.patch
+
+# 2. Revert the file to its committed state.
+git checkout HEAD -- path/to/file.c
+
+# 3. Format the baseline. Any diff here is pre-existing drift, NOT yours —
+#    decide separately whether to commit it (often: not in this PR).
+.github/workflows/codestyle.sh path/to/file.c
+git diff path/to/file.c
+
+# 4. Re-apply only your logical change on top of the formatted baseline.
+git apply /tmp/my-change.patch
+# Alternative: have an AI agent re-introduce just the logical edits hunk by hunk.
+
+# 5. Format once more. Drift is now confined to your touched lines.
+.github/workflows/codestyle.sh path/to/file.c
+```
+
+**Shortcut for tiny edits**: run the formatter, then `git add -p` and stage
+only the hunks that match your intent. The cosmetic drift stays unstaged and
+never reaches CI.
+
+> Do **not** use `clang-format` — there is no `.clang-format` in this repo,
+> and clang-format output will fail CI.
+
+## Memory header rule (server-side files)
+
+For any `.c`/`.cpp` file listed in `cubrid/CMakeLists.txt`,
+`memory_wrapper.hpp` must be the **last** `#include`, immediately preceded by
+the marker comment:
+
+```cpp
+// XXX: SHOULD BE THE LAST INCLUDE HEADER
+#include "memory_wrapper.hpp"
+```
+
+Exceptions:
+
+* `strict_warnings_on.hpp` / `strict_warnings_off.hpp` may appear after
+  `memory_wrapper.hpp` (see CBRD-25966).
+* `src/heaplayers/lea_heap.c` is third-party and exempt.
+* `src/base/memory_monitor_sr.cpp` and `src/base/memory_monitor_api.cpp` are
+  the implementation of the memory monitoring module itself and are exempt.
+
+Enforced by the `memory-monitor-check` job in
+[`.github/workflows/check.yml`](.github/workflows/check.yml).
+
+## Build & test
+
+* Build: see [README.md](README.md#build-from-source)
+  (`./build.sh -m debug` is the most common invocation).
+* Unit tests: see [unit_tests/AGENTS.md](unit_tests/AGENTS.md).
+
+## Getting help
+
+* JIRA: <http://jira.cubrid.org/browse/CBRD>
+* Wiki: <https://github.com/CUBRID/cubrid/wiki>
+* Subreddit: <https://www.reddit.com/r/CUBRID/>

--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ To see usage, run `.\win\build.bat /h`
 - CUBRID Issue Tracker: http://jira.cubrid.org/browse/CBRD
 - CUBRID Manuals: http://cubrid.org/manuals
 
+## Contributing
+
+Before opening a PR, please read [CONTRIBUTING.md](CONTRIBUTING.md). It covers
+the PR title format, the pinned formatter versions CI enforces, and the safe
+workflow for keeping formatter drift out of your diff.
+
+Formatter installation lives in
+[docs/install_build_requirements.md#code-formatters](docs/install_build_requirements.md#code-formatters).
+
 ## License
 
 CUBRID is distributed under two licenses according to its component:

--- a/docs/install_build_requirements.md
+++ b/docs/install_build_requirements.md
@@ -98,3 +98,46 @@ Start-Process -FilePath $VS_INSTALL_PATH -Argument (
 
 Copy-Item "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Redist\MSVC\14.16.27012\MergeModules\*" -Destination "C:\Program Files (x86)\Common Files\Merge Modules"
 ```
+
+## Code Formatters
+
+CI rejects PRs whose changed files are not a fixed point under the project
+formatters. **Versions are pinned** — the distro `indent` package (2.2.12+)
+produces output that differs from CI and will cause failures. Do not use
+`clang-format`; there is no `.clang-format` in this repository.
+
+The CI invocation lives in [`.github/workflows/check.yml`](../.github/workflows/check.yml)
+(the `code-style` job); these commands mirror it exactly.
+
+### Linux
+
+```sh
+# GNU indent 2.2.11 — MUST be built from source.
+# Distro 'indent' is 2.2.12+ and produces different output, breaking CI.
+sudo apt-get install -y build-essential texi2html wget
+wget https://github.com/CUBRID/3rdparty/raw/develop/indent/indent-2.2.11.tar.gz
+tar xf indent-2.2.11.tar.gz
+cd indent-2.2.11 && ./configure && sudo make -j install && cd ..
+
+# astyle — system package is fine on Ubuntu 24.04
+sudo apt-get install -y astyle
+
+# google-java-format 1.7 — codestyle.sh expects the jar at the path
+# .github/workflows/google-java-format-1.7-all-deps.jar relative to the repo
+# root. Place it there directly (run from the repo root).
+wget -O .github/workflows/google-java-format-1.7-all-deps.jar \
+    https://github.com/CUBRID/3rdparty/raw/develop/google-java-format/google-java-format-1.7-all-deps.jar
+```
+
+### Verify
+
+```sh
+indent --version   # must print: GNU indent 2.2.11
+astyle --version   # Artistic Style 3.x
+java -jar .github/workflows/google-java-format-1.7-all-deps.jar --version
+# expected: google-java-format: Version 1.7
+```
+
+For the format-on-save workflow and how to avoid spurious "you touched lines
+you didn't touch" CI failures, see
+[CONTRIBUTING.md](../CONTRIBUTING.md#code-style).


### PR DESCRIPTION
https://jira.cubrid.org/browse/CBRD-26855

> **TL;DR**: 새 컨트리뷰터가 `.github/workflows/check.yml` 의 `code-style` 잡(변경 파일에 포맷터를 한 번 더 돌렸을 때 워킹 트리에 diff 가 남지 않아야 통과하는 잡)을 첫 push 에 통과시킬 수 있도록, 핀 박힌 포맷터 버전과 GNU indent 의 context-sensitive 한 재포맷이 무관한 라인까지 건드리는 문제를 피하는 절차를 `CONTRIBUTING.md` 에 정리한다. 설치 명령은 `docs/install_build_requirements.md` 에, 진입점 포인터는 `README.md` 에 둔다.

## Summary

- **변경**: `CONTRIBUTING.md` 에 PR Requirements / Code Style / Memory Header Rule 섹션을 추가하고, `docs/install_build_requirements.md` 에 Code Formatters 설치·검증 섹션을 추가, `README.md` 에 `CONTRIBUTING.md` 로 가는 6줄짜리 Contributing 포인터를 추가한다.
- **이유**: 기존 `README.md` / `docs/` 어디에도 포맷터 정보가 없어 새 컨트리뷰터가 `code-style` 잡 실패로만 핀 버전을 학습하게 된다. 특히 GNU indent 는 배포판 패키지(2.2.12+)와 CI 가 쓰는 2.2.11 의 출력이 달라 "로컬은 깨끗한데 CI 만 실패"가 반복된다.
- **영향**: 문서 3개 파일 수정. 코드·빌드·CI 잡 추가 없음. 기존 `CONTRIBUTING.md` 의 bug-report·fork-workflow 안내 내용은 보존하되 ToC 와 numbered list 형태로 재구성.
- **리뷰 포인트**:
  1. `CONTRIBUTING.md` `## Code style` 안 "Why CI sometimes flags lines you didn't touch" 절의 5단계 revert-and-replay 절차. 특히 step 3 (`git checkout HEAD -- <file>` 직후 baseline 포맷)이 무관한 드리프트를 본 PR 에 끌어들이지 않는 안전한 권고인지.
  2. `docs/install_build_requirements.md` 의 `wget -O .github/workflows/google-java-format-1.7-all-deps.jar ...` 명령이 `.github/workflows/codestyle.sh:32` (`java -jar .github/workflows/google-java-format-1.7-all-deps.jar ...`)가 기대하는 경로와 맞는지.
  3. `CONTRIBUTING.md` `## Code style` 의 CI 게이트 재현 스니펫이 워킹 트리에 무관한 unstaged 변경이 있을 때도 false-positive 없이 동작하는지 (스니펫 step 3 의 `xargs -r git diff -- $files` 부분).

---

## Description

CUBRID 의 `code-style` 잡(`.github/workflows/check.yml:86-131`)은 PR 의 변경 파일에 대해 `.github/workflows/codestyle.sh`(확장자별로 `indent` / `astyle` / `google-java-format` 을 호출하는 디스패처)를 실행한 뒤 `git diff` 가 비어 있는지로 통과 여부를 결정한다. 이 게이트를 첫 push 에 통과시키려면 두 가지 invariant 를 정확히 맞춰야 한다: (1) 변경 파일에 포맷터를 한 번 더 돌려도 워킹 트리에 변화가 없어야 한다 (fixed-point — 한 번 더 돌려도 출력이 같은 상태), (2) 그 포맷터들의 버전이 CI 가 쓰는 것과 같아야 한다 (version pin — 특히 GNU indent 2.2.11; 배포판 2.2.12+ 는 출력이 달라 fixed-point 가 깨진다).

현재 리포에는 이 두 가지가 어디에도 명문화되어 있지 않아, 컨트리뷰터는 CI 가 빨갛게 뜬 뒤에야 핀 버전과 디스패처 위치를 학습한다. 본 PR 은 이 정보를 명시적인 문서로 만든다.

## Implementation

* **`CONTRIBUTING.md`**
  * 기존 bug-report / feature-request / fork-workflow 안내는 의미 단위 그대로 보존하되, ToC 와 numbered-list 구조로 재구성. 그 과정에서 "kindly requested to keep your work mergeable" 문장은 삭제, fork 워크플로우의 base branch 를 `develop` 로 명시 (기존에는 base 명시 없이 "topic branch" 만 언급).
  * 신규 `## PR requirements` 표: 제목 정규식, license header, code style, `memory_wrapper.hpp` 위치, `cppcheck`(정적 분석기) `error:` 0개, CLA. 각 항목은 `.github/workflows/check.yml` 의 잡 이름으로 역참조.
  * 신규 `## Code style` 절: 확장자→도구 매핑과 핀 버전 표, `codestyle.sh` 한 줄 호출법, **CI 게이트 재현 스니펫**. 스니펫은 `git diff --name-only HEAD` 로 변경 파일 목록을 얻은 뒤 `echo "$files" | xargs -r git diff --` 로 그 파일들에 대해서만 최종 diff 를 검사하도록 작성해, 워킹 트리의 무관한 unstaged 변경이 있어도 false-positive 가 나지 않게 한다.
  * 신규 하위 절 "Why CI sometimes flags lines you didn't touch": GNU indent 가 context-sensitive 하고 strictly idempotent 하지 않아 무관한 라인까지 재포맷되는 메커니즘을 한 단락으로 설명한 뒤, 5단계 revert-and-replay 절차(patch 저장 → `git checkout HEAD` → baseline 포맷 → patch 재적용 → 다시 포맷)와 `git add -p` shortcut 을 제시. `.cpp`/`.hpp` (astyle) 는 사실상 idempotent 라 이 절차가 불필요함을 명시.
  * 신규 `## Memory header rule (server-side files)` 절: `cubrid/CMakeLists.txt` 에 basename 이 나타나는 `.c`/`.cpp` 파일 한정으로 `memory_wrapper.hpp` 가 마지막 `#include` + 바로 위 `// XXX: SHOULD BE THE LAST INCLUDE HEADER` 코멘트 필요. 스코프 정의는 `check.yml` 의 `memory-monitor-check` 잡이 실제로 사용하는 `grep -E "/$filename\$" cubrid/CMakeLists.txt` 와 일치. 예외(`strict_warnings_on.hpp` / `strict_warnings_off.hpp` 두 파일에 한정, `src/heaplayers/lea_heap.c`, `src/base/memory_monitor_sr.cpp` / `src/base/memory_monitor_api.cpp`)도 정리.

* **`docs/install_build_requirements.md`**
  * Windows 섹션 뒤에 `## Code Formatters` 절 추가. 본 PR 범위는 **Linux 만** (Windows·macOS 의 핀 빌드는 별도 PR 또는 의도적으로 unscoped).
  * Linux 설치 명령은 `check.yml` 의 `code-style` 잡 install 단계와 같은 결과를 만들도록 작성. CI 의 install 단계는 `working-directory: .github/workflows` 가 적용된 상태에서 `wget` 을 실행하므로 jar 가 `.github/workflows/google-java-format-1.7-all-deps.jar` 에 떨어지고, 이후 "Check code style" 단계는 repo 루트에서 `codestyle.sh` 를 호출한다 — `codestyle.sh:32` 는 `.github/workflows/google-java-format-1.7-all-deps.jar` 를 repo 루트 상대 경로로 하드코딩하므로 두 경로가 정확히 맞물린다. 사용자는 보통 repo 루트에서 모든 명령을 실행하므로, 본 PR 은 `wget -O .github/workflows/google-java-format-1.7-all-deps.jar ...` 로 같은 결과를 한 줄로 강제한다.
  * `### Verify` 절에서 `indent --version` 이 정확히 `GNU indent 2.2.11` 을 찍어야 함을 명시. `clang-format` 사용 금지를 별도 노트로.

* **`README.md`**
  * 기존 `## License` 앞에 `## Contributing` 섹션 추가 (약 6줄). `CONTRIBUTING.md` 와 `docs/install_build_requirements.md#code-formatters` 로 가는 링크 두 개. 버전 문자열은 README 에 인라인하지 않아 핀 버전 변경 시 갱신해야 할 파일을 `CONTRIBUTING.md` + `docs/install_build_requirements.md` + `check.yml` 3곳으로 한정한다 (README 가 4번째 갱신 지점이 되는 것을 피함).

## Verification

* `bash -n` 으로 `CONTRIBUTING.md` 의 CI 게이트 재현 스니펫이 syntactically 유효함을 확인.
* `docs/install_build_requirements.md` 의 jar URL (`https://github.com/CUBRID/3rdparty/raw/develop/google-java-format/google-java-format-1.7-all-deps.jar`) 이 HTTP 200 으로 fetch 됨을 확인 (현재 시점 기준).
* **검증되지 않음**: clean Ubuntu 24.04 컨테이너에서 install 섹션 전체를 처음부터 끝까지 실행해 `indent --version` 이 `GNU indent 2.2.11` 을 찍는 단계는 본 PR 에서 수행하지 않음. 대신 `docs/install_build_requirements.md` 의 명령 각 줄은 `.github/workflows/check.yml` 의 `code-style` 잡 install 블록(라인 ~96-110)과 1:1로 대응하도록 작성되어, 향후 CI install 단계가 바뀌면 grep diff 로 동기화 결렬을 발견할 수 있다.

## Remarks

* "Why CI sometimes flags lines you didn't touch" 절은 onboarding 사례에서 가장 자주 막히는 지점을 직접 다룬다. 5단계 절차가 무겁다고 판단되면 `git add -p` shortcut 을 더 윗쪽으로 올리도록 순서 조정 가능.
* GNU indent 의 context-sensitivity 는 도구 자체의 한계라 upstream 이 동작을 바꾸지 않는 한 본 절차는 유지된다. CUBRID 가 `clang-format` 같은 AST-driven 포맷터로 옮기는 큰 정책 변경을 한다면 그때 deprecate.