### PR TITLE
[CBRD-26782] Block unsupported operations and syntax on internal BLOB/CLOB

### DIFF
--- a/src/compat/dbtype_function.h
+++ b/src/compat/dbtype_function.h
@@ -170,8 +170,8 @@
 #define DB_MAKE_ENUMERATION(value, index, str, size, codeset, collation) \
 	db_make_enumeration(value, index, str, size, codeset, collation)
 
-#define DB_MAKE_CLOB(value, max_char_length, str, char_str_byte_size, codeset, collation_id) \
-        db_make_clob (value, max_char_length, str, char_str_byte_size, codeset, collation_id)
+#define DB_MAKE_CLOB(value, max_char_length, str, char_str_byte_size) \
+        db_make_clob (value, max_char_length, str, char_str_byte_size)
 
 #define DB_MAKE_BLOB(value, max_byte_length, str, byte_str_size) \
         db_make_blob(value, max_byte_length, str, byte_str_size)
@@ -393,7 +393,7 @@ extern "C"
   extern int db_make_time (DB_VALUE * value, const int hour, const int minute, const int second);
   extern int db_make_date (DB_VALUE * value, const int month, const int day, const int year);
   extern int db_make_clob (DB_VALUE * value, const int max_char_length, DB_CONST_C_CHAR str,
-			   const int char_str_byte_size, const int codeset, const int collation_id);
+			   const int char_str_byte_size);
   extern int db_make_blob (DB_VALUE * value, const int max_bit_length, DB_CONST_C_BIT bit_str,
 			   const int bit_str_bit_size);
   extern int db_get_compressed_size (DB_VALUE * value);

--- a/src/compat/dbtype_function.i
+++ b/src/compat/dbtype_function.i
@@ -133,7 +133,7 @@ STATIC_INLINE int db_make_json (DB_VALUE * value, JSON_DOC * json_document, bool
   __attribute__ ((ALWAYS_INLINE));
 
 STATIC_INLINE int db_make_clob (DB_VALUE * value, const int max_char_length, DB_CONST_C_CHAR str,
-				const int char_str_byte_size, const int codeset, const int collation_id)
+				const int char_str_byte_size)
   __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int db_make_blob (DB_VALUE * value, const int max_bit_length, DB_CONST_C_BIT bit_str,
 				const int bit_str_bit_size) __attribute__ ((ALWAYS_INLINE));
@@ -2147,8 +2147,7 @@ db_make_json (DB_VALUE * value, JSON_DOC * json_document, bool need_clear)
  * char_str_byte_size(in):
  */
 int
-db_make_clob (DB_VALUE * value, const int max_char_length, DB_CONST_C_CHAR str, const int char_str_byte_size,
-	      const int codeset, const int collation_id)
+db_make_clob (DB_VALUE * value, const int max_char_length, DB_CONST_C_CHAR str, const int char_str_byte_size)
 {
   int error;
 
@@ -2159,8 +2158,9 @@ db_make_clob (DB_VALUE * value, const int max_char_length, DB_CONST_C_CHAR str, 
   error = db_value_domain_init (value, DB_TYPE_CLOB, max_char_length, 0);
   if (error == NO_ERROR)
     {
-      assert (codeset >= INTL_CODESET_RAW_BYTES && codeset <= INTL_CODESET_UTF8);
-      error = db_make_db_char (value, (INTL_CODESET) codeset, collation_id, str, char_str_byte_size);
+      /* CLOB has no per-value codeset/collation — server uses LANG_SYS_CODESET
+       * (createdb codeset). Mirrors BFILE/CFILE which carry no codeset slot. */
+      error = db_make_db_char (value, (INTL_CODESET) LANG_SYS_CODESET, 0, str, char_str_byte_size);
     }
 
   return error;

--- a/src/compat/dbtype_function.i
+++ b/src/compat/dbtype_function.i
@@ -133,8 +133,7 @@ STATIC_INLINE int db_make_json (DB_VALUE * value, JSON_DOC * json_document, bool
   __attribute__ ((ALWAYS_INLINE));
 
 STATIC_INLINE int db_make_clob (DB_VALUE * value, const int max_char_length, DB_CONST_C_CHAR str,
-				const int char_str_byte_size)
-  __attribute__ ((ALWAYS_INLINE));
+				const int char_str_byte_size) __attribute__ ((ALWAYS_INLINE));
 STATIC_INLINE int db_make_blob (DB_VALUE * value, const int max_bit_length, DB_CONST_C_BIT bit_str,
 				const int bit_str_bit_size) __attribute__ ((ALWAYS_INLINE));
 

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -273,15 +273,12 @@ TP_DOMAIN tp_Elo_domain = { NULL, NULL, &tp_Elo, DOMAIN_INIT };	/* todo: remove 
 TP_DOMAIN tp_Bfile_domain = { NULL, NULL, &tp_Bfile, DOMAIN_INIT };
 TP_DOMAIN tp_Cfile_domain = { NULL, NULL, &tp_Cfile, DOMAIN_INIT };
 
-// TODO: Uses VARCHAR/VARBIT code, update when storage structure is improved.
-TP_DOMAIN tp_Blob_domain = { NULL, NULL, &tp_Blob, DB_MAX_LOB_PRECISION, 0,
-  DOMAIN_INIT2 (INTL_CODESET_RAW_BITS, 0)
-};
-
-// TODO: Uses VARCHAR/VARBIT code, update when storage structure is improved.
-TP_DOMAIN tp_Clob_domain = { NULL, NULL, &tp_Clob, DB_MAX_LOB_PRECISION, 0,
-  DOMAIN_INIT2 (INTL_CODESET_ISO88591, LANG_COLL_ISO_BINARY)
-};
+/* BLOB / CLOB are inline storage capped at DB_MAX_LOB_PRECISION (1 GiB).
+ * codeset / collation slots stay 0 — mirrors BFILE / CFILE (no user-facing
+ * codeset or collation); server uses LANG_SYS_CODESET (createdb codeset)
+ * for any byte→char view at runtime. */
+TP_DOMAIN tp_Blob_domain = { NULL, NULL, &tp_Blob, DOMAIN_INIT4 (DB_MAX_LOB_PRECISION, 0) };
+TP_DOMAIN tp_Clob_domain = { NULL, NULL, &tp_Clob, DOMAIN_INIT4 (DB_MAX_LOB_PRECISION, 0) };
 
 TP_DOMAIN tp_Time_domain = { NULL, NULL, &tp_Time, DOMAIN_INIT4 (DB_TIME_PRECISION, 0) };
 TP_DOMAIN tp_Utime_domain = { NULL, NULL, &tp_Utime, DOMAIN_INIT4 (DB_TIMESTAMP_PRECISION, 0) };
@@ -717,14 +714,14 @@ tp_apply_sys_charset (void)
   tp_NChar_domain.codeset = LANG_SYS_CODESET;
   tp_VarNChar_domain.codeset = LANG_SYS_CODESET;
   tp_Enumeration_domain.codeset = LANG_SYS_CODESET;
-  tp_Clob_domain.codeset = LANG_SYS_CODESET;
+  /* tp_Clob_domain / tp_Blob_domain carry no codeset/collation slot — mirrors BFILE/CFILE.
+   * Server uses LANG_SYS_CODESET (createdb codeset) for byte->char views at runtime. */
 
   tp_String_domain.collation_id = LANG_SYS_COLLATION;
   tp_Char_domain.collation_id = LANG_SYS_COLLATION;
   tp_NChar_domain.collation_id = LANG_SYS_COLLATION;
   tp_VarNChar_domain.collation_id = LANG_SYS_COLLATION;
   tp_Enumeration_domain.collation_id = LANG_SYS_COLLATION;
-  tp_Clob_domain.collation_id = LANG_SYS_COLLATION;
 }
 
 /*
@@ -2852,7 +2849,7 @@ tp_domain_find_charbit (DB_TYPE type, int codeset, int collation_id, unsigned ch
 	  /* we MUST perform exact matches here */
 	  if (dom->precision == precision && dom->is_desc == is_desc)
 	    {
-	      if (type == DB_TYPE_VARBIT || type == DB_TYPE_BLOB)
+	      if (type == DB_TYPE_VARBIT || type == DB_TYPE_BLOB || type == DB_TYPE_CLOB)
 		{
 		  break;	/* found */
 		}
@@ -3523,7 +3520,8 @@ tp_domain_resolve_value (const DB_VALUE * val, TP_DOMAIN * dbuf)
 
 	case DB_TYPE_BLOB:
 	case DB_TYPE_CLOB:
-	  // TODO: Uses VARCHAR/VARBIT code, update when storage structure is improved.
+	  /* BLOB / CLOB carry no codeset/collation slot — mirrors BFILE/CFILE.
+	   * Server uses LANG_SYS_CODESET (createdb codeset) for byte->char views. */
 	  if (dbuf == NULL)
 	    {
 	      domain = tp_domain_new (value_type);
@@ -3537,25 +3535,11 @@ tp_domain_resolve_value (const DB_VALUE * val, TP_DOMAIN * dbuf)
 	      domain = dbuf;
 	      tp_domain_init (domain, value_type);
 	    }
-	  domain->codeset = db_get_string_codeset (val);
-	  domain->collation_id = db_get_string_collation (val);
 	  domain->precision = db_value_precision (val);
-
-	  if (TP_DOMAIN_TYPE (domain) == DB_TYPE_CLOB)
+	  if (domain->precision == 0 || domain->precision == TP_FLOATING_PRECISION_VALUE
+	      || domain->precision > DB_MAX_LOB_PRECISION)
 	    {
-	      if (domain->precision == 0 || domain->precision == TP_FLOATING_PRECISION_VALUE
-		  || domain->precision > DB_MAX_LOB_PRECISION)
-		{
-		  domain->precision = DB_MAX_LOB_PRECISION;
-		}
-	    }
-	  else if (TP_DOMAIN_TYPE (domain) == DB_TYPE_BLOB)
-	    {
-	      if (domain->precision == 0 || domain->precision == TP_FLOATING_PRECISION_VALUE
-		  || domain->precision > DB_MAX_LOB_PRECISION)
-		{
-		  domain->precision = DB_MAX_LOB_PRECISION;
-		}
+	      domain->precision = DB_MAX_LOB_PRECISION;
 	    }
 
 	  if (dbuf == NULL)
@@ -5787,8 +5771,7 @@ tp_dtoa (DB_VALUE const *src, DB_VALUE * result)
       break;
 
     case DB_TYPE_CLOB:
-      db_make_clob (result, DB_VALUE_PRECISION (result), str_double, strlen (str_double),
-		    db_get_string_codeset (result), db_get_string_collation (result));
+      db_make_clob (result, DB_VALUE_PRECISION (result), str_double, strlen (str_double));
       result->need_clear = true;
       break;
 
@@ -5987,8 +5970,7 @@ make_desired_string_db_value (DB_TYPE desired_type, const TP_DOMAIN * desired_do
 			TP_DOMAIN_CODESET (desired_domain), TP_DOMAIN_COLLATION (desired_domain));
       break;
     case DB_TYPE_CLOB:
-      db_make_clob (&temp, desired_domain->precision, new_string, strlen (new_string),
-		    TP_DOMAIN_CODESET (desired_domain), TP_DOMAIN_COLLATION (desired_domain));
+      db_make_clob (&temp, desired_domain->precision, new_string, strlen (new_string));
       break;
     default:			/* Can't get here.  This just quiets the compiler */
       break;

--- a/src/object/object_domain.c
+++ b/src/object/object_domain.c
@@ -9424,16 +9424,9 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_VARBIT:
 	  err = db_bit_to_blob (src, target);
 	  break;
-	case DB_TYPE_CHAR:
-	case DB_TYPE_VARCHAR:
-	case DB_TYPE_NCHAR:
-	case DB_TYPE_VARNCHAR:
-	  err = db_char_to_blob (src, target);
-	  break;
-	case DB_TYPE_CLOB:
-	  // TODO: update when storage structure is improved.
-	  err = db_char_to_blob (src, target);
-	  break;
+	  /* CHAR / VARCHAR / NCHAR / VARNCHAR / CLOB → BLOB implicit cast is
+	   * intentionally not supported.  Use CHAR_TO_BLOB / BIT_TO_BLOB /
+	   * BLOB_FROM_FILE etc. explicitly. */
 	case DB_TYPE_ENUMERATION:
 	  {
 	    DB_VALUE varchar_val;
@@ -9485,7 +9478,8 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
     case DB_TYPE_VARBIT:
       switch (original_type)
 	{
-	case DB_TYPE_CLOB:
+	  /* CLOB → BIT/VARBIT implicit cast is intentionally not supported.
+	   * Use CLOB_TO_CHAR (or similar) then string → bit explicitly. */
 	case DB_TYPE_VARCHAR:
 	case DB_TYPE_CHAR:
 	case DB_TYPE_NCHAR:
@@ -9562,20 +9556,8 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  }
 	  break;
 
-	case DB_TYPE_BFILE:
-	  {
-	    DB_VALUE tmpval;
-
-	    db_make_null (&tmpval);
-
-	    err = db_bfile_to_bit (src, NULL, &tmpval);
-	    if (err == NO_ERROR)
-	      {
-		err = tp_value_cast_internal (&tmpval, target, desired_domain, coercion_mode, do_domain_select, false);
-	      }
-	    (void) pr_clear_value (&tmpval);
-	  }
-	  break;
+	  /* BFILE → BIT/VARBIT implicit cast is intentionally not supported.
+	   * Use BFILE_TO_BIT explicitly. */
 
 	default:
 	  if (src == dest && tp_can_steal_string (src, desired_domain))
@@ -9904,10 +9886,10 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  }
 	  break;
 
+	  /* BLOB → CHAR/VARCHAR/NCHAR/VARNCHAR implicit cast is intentionally
+	   * not supported.  Use BLOB_TO_CHAR / BLOB_TO_BIT explicitly. */
 	case DB_TYPE_BIT:
 	case DB_TYPE_VARBIT:
-	case DB_TYPE_BLOB:
-	  // TODO: Uses VARCHAR/VARBIT code, update when storage structure is improved.
 	  {
 	    int max_size;
 	    char *new_string;
@@ -9951,33 +9933,8 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	  }
 	  break;
 
-	case DB_TYPE_CFILE:
-	  switch (desired_type)
-	    {
-	    case DB_TYPE_NCHAR:
-	    case DB_TYPE_VARNCHAR:
-	      status = DOMAIN_INCOMPATIBLE;
-	      break;
-	    default:
-	      {
-		DB_VALUE tmpval;
-		DB_VALUE cs;
-
-		db_make_null (&tmpval);
-		/* convert directly from CFILE into charset of desired domain string */
-		db_make_int (&cs, desired_domain->codeset);
-		err = db_cfile_to_char (src, &cs, &tmpval);
-		if (err == NO_ERROR)
-		  {
-		    err =
-		      tp_value_cast_internal (&tmpval, dest, desired_domain, coercion_mode, do_domain_select, false);
-		  }
-
-		pr_clear_value (&tmpval);
-	      }
-	      break;
-	    }
-	  break;
+	  /* CFILE → CHAR/VARCHAR/NCHAR/VARNCHAR implicit cast is intentionally
+	   * not supported.  Use CFILE_TO_CHAR explicitly. */
 	case DB_TYPE_CLOB:
 	  switch (desired_type)
 	    {
@@ -10035,24 +9992,9 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_BFILE:
 	  err = db_value_clone ((DB_VALUE *) src, target);
 	  break;
-	case DB_TYPE_BIT:
-	case DB_TYPE_VARBIT:
-	  err = db_bit_to_bfile (src, target);
-	  break;
-	case DB_TYPE_CHAR:
-	case DB_TYPE_VARCHAR:
-	case DB_TYPE_NCHAR:
-	case DB_TYPE_VARNCHAR:
-	  err = db_char_to_bfile (src, target);
-	  break;
-	case DB_TYPE_BLOB:
-	  // TODO: Uses VARCHAR/VARBIT code, update when storage structure is improved.
-	  err = db_bit_to_bfile (src, target);
-	  break;
-	case DB_TYPE_CLOB:
-	  // TODO: Uses VARCHAR/VARBIT code, update when storage structure is improved.
-	  err = db_char_to_bfile (src, target);
-	  break;
+	  /* No implicit cast into BFILE.  BFILE represents an external file and
+	   * any conversion must be explicit (BFILE_FROM_FILE / CHAR_TO_BFILE /
+	   * BIT_TO_BFILE / BLOB_TO_BFILE). */
 	case DB_TYPE_ENUMERATION:
 	  {
 	    DB_VALUE varchar_val;
@@ -10078,14 +10020,9 @@ tp_value_cast_internal (const DB_VALUE * src, DB_VALUE * dest, const TP_DOMAIN *
 	case DB_TYPE_CFILE:
 	  err = db_value_clone ((DB_VALUE *) src, target);
 	  break;
-	case DB_TYPE_CHAR:
-	case DB_TYPE_VARCHAR:
-	  err = db_char_to_cfile (src, target);
-	  break;
-	case DB_TYPE_CLOB:
-	  // TODO: Uses VARCHAR/VARBIT code, update when storage structure is improved.
-	  err = db_char_to_cfile (src, target);
-	  break;
+	  /* No implicit cast into CFILE.  CFILE represents an external file and
+	   * any conversion must be explicit (CFILE_FROM_FILE / CHAR_TO_CFILE /
+	   * CLOB_TO_CFILE). */
 	case DB_TYPE_ENUMERATION:
 	  {
 	    DB_VALUE varchar_val;

--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -17272,8 +17272,7 @@ mr_getmem_clob (void *memptr, TP_DOMAIN * domain, DB_VALUE * value, bool copy)
 
       if (!copy)
 	{
-	  db_make_clob (value, domain->precision, cur, mem_length, TP_DOMAIN_CODESET (domain),
-			TP_DOMAIN_COLLATION (domain));
+	  db_make_clob (value, domain->precision, cur, mem_length);
 	  value->need_clear = false;
 	}
       else
@@ -17289,8 +17288,7 @@ mr_getmem_clob (void *memptr, TP_DOMAIN * domain, DB_VALUE * value, bool copy)
 	    {
 	      memcpy (new_, cur, mem_length);
 	      new_[mem_length] = '\0';
-	      db_make_clob (value, domain->precision, new_, mem_length, TP_DOMAIN_CODESET (domain),
-			    TP_DOMAIN_COLLATION (domain));
+	      db_make_clob (value, domain->precision, new_, mem_length);
 	      value->need_clear = true;
 	    }
 	}
@@ -17469,7 +17467,8 @@ mr_freemem_clob (void *memptr)
 static void
 mr_initval_clob (DB_VALUE * value, int precision, int scale)
 {
-  db_make_clob (value, precision, NULL, 0, LANG_SYS_CODESET, LANG_SYS_COLLATION);
+  /* CLOB has no per-value codeset/collation — server uses LANG_SYS_CODESET. */
+  db_make_clob (value, precision, NULL, 0);
   value->need_clear = false;
 }
 
@@ -17515,8 +17514,7 @@ mr_setval_clob (DB_VALUE * dest, const DB_VALUE * src, bool copy)
       /* should we be paying attention to this? it is extremely dangerous */
       if (!copy)
 	{
-	  error = db_make_clob (dest, src_precision, src_str, src_length, db_get_string_codeset (src),
-				db_get_string_collation (src));
+	  error = db_make_clob (dest, src_precision, src_str, src_length);
 	  dest->data.ch.medium.compressed_buf = src->data.ch.medium.compressed_buf;
 	  dest->data.ch.info.compressed_need_clear = false;
 	}
@@ -17533,8 +17531,7 @@ mr_setval_clob (DB_VALUE * dest, const DB_VALUE * src, bool copy)
 	    {
 	      memcpy (new_, src_str, src_length);
 	      new_[src_length] = '\0';
-	      db_make_clob (dest, src_precision, new_, src_length, db_get_string_codeset (src),
-			    db_get_string_collation (src));
+	      db_make_clob (dest, src_precision, new_, src_length);
 	      dest->need_clear = true;
 	    }
 
@@ -17808,8 +17805,7 @@ mr_readval_clob_internal (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain, in
 		  goto cleanup;
 		}
 	      string[expected_decompressed_size] = '\0';
-	      db_make_clob (value, precision, string, expected_decompressed_size, TP_DOMAIN_CODESET (domain),
-			    TP_DOMAIN_COLLATION (domain));
+	      db_make_clob (value, precision, string, expected_decompressed_size);
 	      value->need_clear = true;
 
 	      compressed_string = (char *) db_private_alloc (NULL, compressed_size + 1);
@@ -17829,8 +17825,7 @@ mr_readval_clob_internal (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain, in
 	      assert (compressed_size == 0);
 
 	      str_length = expected_decompressed_size;
-	      db_make_clob (value, precision, buf->ptr, expected_decompressed_size, TP_DOMAIN_CODESET (domain),
-			    TP_DOMAIN_COLLATION (domain));
+	      db_make_clob (value, precision, buf->ptr, expected_decompressed_size);
 	      value->need_clear = false;
 	      db_set_compressed_string (value, NULL, DB_UNCOMPRESSABLE, false);
 	    }
@@ -17974,8 +17969,7 @@ mr_readval_clob_internal (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain, in
 		  goto cleanup;
 		}
 
-	      db_make_clob (value, precision, new_, str_length, TP_DOMAIN_CODESET (domain),
-			    TP_DOMAIN_COLLATION (domain));
+	      db_make_clob (value, precision, new_, str_length);
 	      value->need_clear = (new_ != copy_buf) ? true : false;
 
 	      if (compressed_string == NULL)
@@ -18104,8 +18098,7 @@ data_readval_clob (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain, int size,
 	      goto cleanup;
 	    }
 
-	  db_make_clob (value, precision, decompressed_string, expected_decompressed_size,
-			TP_DOMAIN_CODESET (domain), TP_DOMAIN_COLLATION (domain));
+	  db_make_clob (value, precision, decompressed_string, expected_decompressed_size);
 	  value->need_clear = (decompressed_string != copy_buf) ? true : false;
 	  db_set_compressed_string (value, NULL, DB_NOT_YET_COMPRESSED, false);
 	}
@@ -18113,8 +18106,7 @@ data_readval_clob (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain, int size,
 	{
 	  assert (compressed_size == 0);
 
-	  db_make_clob (value, precision, buf->ptr, expected_decompressed_size, TP_DOMAIN_CODESET (domain),
-			TP_DOMAIN_COLLATION (domain));
+	  db_make_clob (value, precision, buf->ptr, expected_decompressed_size);
 	  value->need_clear = false;
 	  db_set_compressed_string (value, NULL, DB_UNCOMPRESSABLE, false);
 	}
@@ -18149,8 +18141,7 @@ data_readval_clob (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain, int size,
 	      goto cleanup;
 	    }
 
-	  db_make_clob (value, precision, decompressed_string, expected_decompressed_size,
-			TP_DOMAIN_CODESET (domain), TP_DOMAIN_COLLATION (domain));
+	  db_make_clob (value, precision, decompressed_string, expected_decompressed_size);
 	  value->need_clear = (decompressed_string != copy_buf) ? true : false;
 	  db_set_compressed_string (value, NULL, DB_NOT_YET_COMPRESSED, false);
 	}
@@ -18161,8 +18152,7 @@ data_readval_clob (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain, int size,
 	  memcpy (decompressed_string, buf->ptr, expected_decompressed_size);
 	  decompressed_string[expected_decompressed_size] = '\0';
 
-	  db_make_clob (value, precision, decompressed_string, expected_decompressed_size,
-			TP_DOMAIN_CODESET (domain), TP_DOMAIN_COLLATION (domain));
+	  db_make_clob (value, precision, decompressed_string, expected_decompressed_size);
 	  value->need_clear = (decompressed_string != copy_buf) ? true : false;
 	  db_set_compressed_string (value, NULL, DB_UNCOMPRESSABLE, false);
 	}
@@ -18569,7 +18559,7 @@ mr_data_lengthmem_blob (void *memptr, TP_DOMAIN * domain, int disk)
   len = 0;
   if (!disk)
     {
-      len = tp_VarBit.size;
+      len = tp_Blob.size;
     }
   else if (memptr != NULL)
     {

--- a/src/object/schema_template.c
+++ b/src/object/schema_template.c
@@ -1333,8 +1333,7 @@ smt_set_attribute_default (SM_TEMPLATE * template_, const char *name, int class_
   error = smt_find_attribute (template_, name, class_attribute, &att);
   if (error == NO_ERROR)
     {
-      if ((att->type->id == DB_TYPE_BFILE || att->type->id == DB_TYPE_CFILE) && proposed_value
-	  && !DB_IS_NULL (proposed_value))
+      if (TP_IS_LOB_FAMILY_TYPE (att->type->id) && proposed_value && !DB_IS_NULL (proposed_value))
 	{
 	  ERROR1 (error, ER_SM_DEFAULT_NOT_ALLOWED, att->type->name);
 	  return error;

--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -21610,60 +21610,37 @@ primitive_type
 	| BLOB_
 		{{ DBG_TRACE_GRAMMAR(primitive_type, | BLOB_);
 
+			/* BLOB: inline storage capped at DB_MAX_LOB_PRECISION (1 GiB).
+			 * codeset / collation slots are not used — mirrors BFILE/CFILE.
+			 * Server uses LANG_SYS_CODESET (createdb codeset) at runtime. */
 			container_2 ctn;
 			PT_NODE *dt = parser_new_node (this_parser, PT_DATA_TYPE);
 			if (dt)
 			  {
 			    dt->type_enum = PT_TYPE_BLOB;
-
 			    dt->info.data_type.precision = DB_MAX_LOB_PRECISION;
-
-			    dt->info.data_type.units = -1;          /* character set is not allowed */
-			    dt->info.data_type.collation_id = LANG_COLL_DEFAULT;   /* collation is not supported */
-			    dt->info.data_type.has_cs_spec = false;
-			    dt->info.data_type.has_coll_spec = false;
 			  }
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_BLOB), dt);
 			$$ = ctn;
 
 		DBG_PRINT}}
-	| CLOB_ opt_charset
-		{{
+	| CLOB_
+		{{ DBG_TRACE_GRAMMAR(primitive_type, | CLOB_);
+
+			/* CLOB: inline storage capped at DB_MAX_LOB_PRECISION (1 GiB).
+			 * codeset / collation slots are not used — mirrors BFILE/CFILE.
+			 * Server uses LANG_SYS_CODESET (createdb codeset) at runtime. */
 			container_2 ctn;
 			PT_NODE *dt = parser_new_node (this_parser, PT_DATA_TYPE);
-			PT_NODE *charset_node = $2;
 			if (dt)
 			  {
-			    int charset, coll_id;
-
 			    dt->type_enum = PT_TYPE_CLOB;
-
 			    dt->info.data_type.precision = DB_MAX_LOB_PRECISION;
-
-			    /* CLOB allows only CHARACTER SET, collation is not supported */
-			    if (pt_check_grammar_charset_collation
-				  (this_parser, charset_node, NULL, &charset, &coll_id) == NO_ERROR)
-			      {
-				dt->info.data_type.units = charset;     /* storage character set */
-			      }
-			    else
-			      {
-				dt->info.data_type.units = -1;         /* no charset specified */
-			      }
-
-			    dt->info.data_type.collation_id = LANG_COLL_DEFAULT;     /* collation is not supported */
-			    dt->info.data_type.has_cs_spec = (charset_node != NULL);
-			    dt->info.data_type.has_coll_spec = false;
 			  }
 			SET_CONTAINER_2 (ctn, FROM_NUMBER (PT_TYPE_CLOB), dt);
 			$$ = ctn;
 
-			if (charset_node)
-			  {
-			    parser_free_node (this_parser, charset_node);
-			  }
-
-		}}
+		DBG_PRINT}}
 	| class_name opt_identity
 		{{ DBG_TRACE_GRAMMAR(primitive_type, | class_name opt_identity );
 
@@ -25155,7 +25132,9 @@ dblink_column_definition
                         node->data_type = dt = CONTAINER_AT_1 ($2);
                         node->info.attr_def.attr_name = $1;
 
-                        if(typ == PT_TYPE_BFILE || typ == PT_TYPE_CFILE || typ == PT_TYPE_OBJECT || typ == PT_TYPE_ENUMERATION)
+                        if (typ == PT_TYPE_BFILE || typ == PT_TYPE_CFILE
+                            || typ == PT_TYPE_BLOB || typ == PT_TYPE_CLOB
+                            || typ == PT_TYPE_OBJECT || typ == PT_TYPE_ENUMERATION)
                           {
                                 PT_ERRORmf (this_parser, node, MSGCAT_SET_PARSER_SEMANTIC,
 					     MSGCAT_SEMANTIC_DBLINK_NOT_SUPPORTED_TYPE, pt_show_type_enum (typ));

--- a/src/parser/func_type.cpp
+++ b/src/parser/func_type.cpp
@@ -870,7 +870,7 @@ namespace func_type
 	      {
 		if ((PT_IS_SIMPLE_CHAR_STRING_TYPE (arg1->type_enum) && PT_IS_NATIONAL_CHAR_STRING_TYPE (arg2->type_enum)) ||
 		    (PT_IS_SIMPLE_CHAR_STRING_TYPE (arg2->type_enum) && PT_IS_NATIONAL_CHAR_STRING_TYPE (arg1->type_enum)) ||
-		    (PT_IS_LOB_TYPE (arg1->type_enum) || PT_IS_LOB_TYPE (arg2->type_enum)))
+		    (PT_IS_LOB_FAMILY_TYPE (arg1->type_enum) || PT_IS_LOB_FAMILY_TYPE (arg2->type_enum)))
 		  {
 		    pt_cat_error (m_parser, m_node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OP_NOT_DEFINED_ON,
 				  fcode_get_lowercase_name (PT_GROUP_CONCAT), pt_show_type_enum (arg1->type_enum),
@@ -1653,7 +1653,7 @@ pt_eval_function_type_aggregate (PARSER_CONTEXT *parser, PT_NODE *node)
 	  break;
 	}
 
-      if (PT_IS_LOB_TYPE (arg_type) || PT_IS_LOB_TYPE (sep_type))
+      if (PT_IS_LOB_FAMILY_TYPE (arg_type) || PT_IS_LOB_FAMILY_TYPE (sep_type))
 	{
 	  PT_ERRORmf3 (parser, node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OP_NOT_DEFINED_ON,
 		       fcode_get_lowercase_name (fcode), pt_show_type_enum (arg_type), pt_show_type_enum (sep_type));

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -5104,14 +5104,14 @@ pt_dblink_table_fill_attr_def (PARSER_CONTEXT * parser, PT_NODE * attr_def_node,
     case PT_TYPE_NCHAR:
     case PT_TYPE_BIT:
     case PT_TYPE_VARBIT:
-    case PT_TYPE_BLOB:
-    case PT_TYPE_CLOB:
     case PT_TYPE_NUMERIC:
     case PT_TYPE_MONETARY:
       break;
 
     case PT_TYPE_BFILE:
     case PT_TYPE_CFILE:
+    case PT_TYPE_BLOB:
+    case PT_TYPE_CLOB:
     case PT_TYPE_OBJECT:
     case PT_TYPE_ENUMERATION:
     case PT_TYPE_SET:

--- a/src/parser/parse_dbi.c
+++ b/src/parser/parse_dbi.c
@@ -3800,7 +3800,7 @@ pt_db_value_initialize (PARSER_CONTEXT * parser, PT_NODE * value, DB_VALUE * db_
 	  }
 	buf[len] = '\0';
 
-	db_make_clob (db_value, DB_MAX_LOB_PRECISION, buf, len, codeset, collation_id);
+	db_make_clob (db_value, DB_MAX_LOB_PRECISION, buf, len);
 
 	db_value->need_clear = true;
 	value->info.value.db_value_is_in_workspace = true;

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -2746,6 +2746,30 @@ pt_check_union_compatibility (PARSER_CONTEXT * parser, PT_NODE * node)
       return NULL;
     }
 
+  /* CBRD-26782: LOB family (BFILE / CFILE / BLOB / CLOB) columns are not
+   * allowed in UNION / INTERSECT / DIFFERENCE select lists. */
+  {
+    PT_NODE *lob_iter;
+    for (lob_iter = attrs1; lob_iter != NULL; lob_iter = lob_iter->next)
+      {
+	if (PT_IS_LOB_FAMILY_TYPE (lob_iter->type_enum))
+	  {
+	    PT_ERRORmf2 (parser, lob_iter, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_UNION_INCOMPATIBLE,
+			 pt_short_print (parser, lob_iter), pt_show_type_enum (lob_iter->type_enum));
+	    return NULL;
+	  }
+      }
+    for (lob_iter = attrs2; lob_iter != NULL; lob_iter = lob_iter->next)
+      {
+	if (PT_IS_LOB_FAMILY_TYPE (lob_iter->type_enum))
+	  {
+	    PT_ERRORmf2 (parser, lob_iter, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_UNION_INCOMPATIBLE,
+			 pt_short_print (parser, lob_iter), pt_show_type_enum (lob_iter->type_enum));
+	    return NULL;
+	  }
+      }
+  }
+
   cnt1 = pt_length_of_select_list (attrs1, EXCLUDE_HIDDEN_COLUMNS);
   cnt2 = pt_length_of_select_list (attrs2, EXCLUDE_HIDDEN_COLUMNS);
 
@@ -11215,6 +11239,21 @@ pt_semantic_check_local (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int
 
       pt_check_into_clause (parser, node);
 
+      /* CBRD-26782: SELECT DISTINCT on LOB family column is not allowed. */
+      if (node->info.query.all_distinct == PT_DISTINCT)
+	{
+	  PT_NODE *sel_col;
+	  for (sel_col = node->info.query.q.select.list; sel_col != NULL; sel_col = sel_col->next)
+	    {
+	      if (PT_IS_LOB_FAMILY_TYPE (sel_col->type_enum))
+		{
+		  PT_ERRORmf2 (parser, sel_col, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OP_NOT_DEFINED_ON_1,
+			       "DISTINCT", pt_show_type_enum (sel_col->type_enum));
+		  break;
+		}
+	    }
+	}
+
       if (node->info.query.q.select.with_increment)
 	{
 	  PT_NODE *select_list = node->info.query.q.select.list;
@@ -14501,6 +14540,16 @@ pt_check_group_by (PARSER_CONTEXT * parser, PT_NODE * node)
 	    {
 	      continue;
 	    }
+
+	  /* CBRD-26782: GROUP BY on LOB family (BFILE / CFILE / BLOB / CLOB) is not allowed.
+	   * Mirror the top-level ORDER BY gate at semantic_check.c:15729. */
+	  if (PT_IS_LOB_FAMILY_TYPE (r->type_enum))
+	    {
+	      PT_ERRORmf (parser, r, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_NO_GROUPBY_ALLOWED,
+			  pt_short_print (parser, r));
+	      continue;
+	    }
+
 	  /*
 	   * If a position is specified on group by clause,
 	   * we should check its range.

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -11255,6 +11255,10 @@ pt_semantic_check_local (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int
 	  PT_NODE *sel_col;
 	  for (sel_col = node->info.query.q.select.list; sel_col != NULL; sel_col = sel_col->next)
 	    {
+	      if (sel_col->flag.is_hidden_column)
+		{
+		  continue;
+		}
 	      if (PT_IS_LOB_FAMILY_TYPE (sel_col->type_enum))
 		{
 		  PT_ERRORmf2 (parser, sel_col, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OP_NOT_DEFINED_ON_1,

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -2747,11 +2747,17 @@ pt_check_union_compatibility (PARSER_CONTEXT * parser, PT_NODE * node)
     }
 
   /* CBRD-26782: LOB family (BFILE / CFILE / BLOB / CLOB) columns are not
-   * allowed in UNION / INTERSECT / DIFFERENCE select lists. */
+   * allowed in UNION / INTERSECT / DIFFERENCE select lists. Only the visible
+   * select-list columns participate in the set operation (arity/compat below
+   * use EXCLUDE_HIDDEN_COLUMNS), so skip system-added hidden columns here. */
   {
     PT_NODE *lob_iter;
     for (lob_iter = attrs1; lob_iter != NULL; lob_iter = lob_iter->next)
       {
+	if (lob_iter->flag.is_hidden_column)
+	  {
+	    continue;
+	  }
 	if (PT_IS_LOB_FAMILY_TYPE (lob_iter->type_enum))
 	  {
 	    PT_ERRORmf2 (parser, lob_iter, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_UNION_INCOMPATIBLE,
@@ -2761,6 +2767,10 @@ pt_check_union_compatibility (PARSER_CONTEXT * parser, PT_NODE * node)
       }
     for (lob_iter = attrs2; lob_iter != NULL; lob_iter = lob_iter->next)
       {
+	if (lob_iter->flag.is_hidden_column)
+	  {
+	    continue;
+	  }
 	if (PT_IS_LOB_FAMILY_TYPE (lob_iter->type_enum))
 	  {
 	    PT_ERRORmf2 (parser, lob_iter, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_UNION_INCOMPATIBLE,

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -15950,7 +15950,7 @@ pt_check_cume_dist_percent_rank_order_by (PARSER_CONTEXT * parser, PT_NODE * fun
       /* check order by */
       order_expr = order->info.sort_spec.expr;
       if (order->node_type != PT_SORT_SPEC || (order_expr->node_type != PT_NAME && order_expr->node_type != PT_VALUE)
-	  || PT_IS_LOBFILE_TYPE (order_expr->type_enum))
+	  || PT_IS_LOB_FAMILY_TYPE (order_expr->type_enum))
 	{
 	  PT_ERRORmf (parser, func, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_INVALID_FUNCTION_ORDERBY, func_name);
 	  goto error_exit;

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -14591,6 +14591,17 @@ pt_check_group_by (PARSER_CONTEXT * parser, PT_NODE * node)
 	    {
 	      t_node->info.sort_spec.expr = parser_copy_tree (parser, referred_node);
 	      parser_free_node (parser, r);
+
+	      /* CBRD-26782: a positional group key (e.g. GROUP BY 1) is resolved
+	       * to a select-list column only here, after the type_enum check
+	       * above. Re-check the resolved column so an ordinal cannot bypass
+	       * the LOB family (BFILE / CFILE / BLOB / CLOB) gate. */
+	      if (PT_IS_LOB_FAMILY_TYPE (referred_node->type_enum))
+		{
+		  PT_ERRORmf (parser, t_node->info.sort_spec.expr, MSGCAT_SET_PARSER_SEMANTIC,
+			      MSGCAT_SEMANTIC_NO_GROUPBY_ALLOWED, pt_short_print (parser, t_node->info.sort_spec.expr));
+		  continue;
+		}
 	    }
 	}
 

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -9175,6 +9175,44 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
 	}
     }
 
+  /* CBRD-26782: comparison / relational / range / set-compare / LIKE operators
+   * are not defined on LOB family (BFILE / CFILE / BLOB / CLOB).
+   * IS NULL / IS NOT NULL are different ops (PT_IS_NULL / PT_IS_NOT_NULL) and
+   * bypass this gate, which matches the spec's "IS NULL is allowed" exception. */
+  if (pt_is_range_or_comp (op) || pt_is_range_expression (op)
+      || op == PT_LIKE || op == PT_NOT_LIKE
+      || op == PT_RLIKE || op == PT_NOT_RLIKE
+      || op == PT_RLIKE_BINARY || op == PT_NOT_RLIKE_BINARY
+      || op == PT_NOT_BETWEEN
+      || op == PT_SETEQ || op == PT_SETNEQ
+      || op == PT_SUPERSET || op == PT_SUPERSETEQ
+      || op == PT_SUBSET || op == PT_SUBSETEQ)
+    {
+      if (PT_IS_LOB_FAMILY_TYPE (arg1_type) || PT_IS_LOB_FAMILY_TYPE (arg2_type)
+	  || PT_IS_LOB_FAMILY_TYPE (arg3_type))
+	{
+	  if (arg2 && arg3)
+	    {
+	      PT_ERRORmf4 (parser, node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OP_NOT_DEFINED_ON_3,
+			   pt_show_binopcode (op), pt_show_type_enum (arg1_type),
+			   pt_show_type_enum (arg2_type), pt_show_type_enum (arg3_type));
+	    }
+	  else if (arg2)
+	    {
+	      PT_ERRORmf3 (parser, node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OP_NOT_DEFINED_ON,
+			   pt_show_binopcode (op), pt_show_type_enum (arg1_type),
+			   pt_show_type_enum (arg2_type));
+	    }
+	  else
+	    {
+	      PT_ERRORmf2 (parser, node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OP_NOT_DEFINED_ON_1,
+			   pt_show_binopcode (op), pt_show_type_enum (arg1_type));
+	    }
+	  node->type_enum = PT_TYPE_NONE;
+	  return node;
+	}
+    }
+
   /*
    * At this point, arg1_hv is non-NULL (and equal to arg1) if it represents
    * a dynamic host variable, i.e., a host var parameter that hasn't had

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -9185,11 +9185,9 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
       || op == PT_RLIKE_BINARY || op == PT_NOT_RLIKE_BINARY
       || op == PT_NOT_BETWEEN
       || op == PT_SETEQ || op == PT_SETNEQ
-      || op == PT_SUPERSET || op == PT_SUPERSETEQ
-      || op == PT_SUBSET || op == PT_SUBSETEQ)
+      || op == PT_SUPERSET || op == PT_SUPERSETEQ || op == PT_SUBSET || op == PT_SUBSETEQ)
     {
-      if (PT_IS_LOB_FAMILY_TYPE (arg1_type) || PT_IS_LOB_FAMILY_TYPE (arg2_type)
-	  || PT_IS_LOB_FAMILY_TYPE (arg3_type))
+      if (PT_IS_LOB_FAMILY_TYPE (arg1_type) || PT_IS_LOB_FAMILY_TYPE (arg2_type) || PT_IS_LOB_FAMILY_TYPE (arg3_type))
 	{
 	  if (arg2 && arg3)
 	    {
@@ -9200,8 +9198,7 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
 	  else if (arg2)
 	    {
 	      PT_ERRORmf3 (parser, node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OP_NOT_DEFINED_ON,
-			   pt_show_binopcode (op), pt_show_type_enum (arg1_type),
-			   pt_show_type_enum (arg2_type));
+			   pt_show_binopcode (op), pt_show_type_enum (arg1_type), pt_show_type_enum (arg2_type));
 	    }
 	  else
 	    {

--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -786,7 +786,7 @@ do_alter_one_clause_with_template (PARSER_CONTEXT * parser, PT_NODE * alter)
 	    {
 	      pt_desired_type = p->type_enum;
 
-	      if (pt_desired_type == PT_TYPE_BFILE || pt_desired_type == PT_TYPE_CFILE)
+	      if (PT_IS_LOB_FAMILY_TYPE (pt_desired_type))
 		{
 		  error = ER_INTERFACE_NOT_SUPPORTED_OPERATION;
 		  er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, error, 0);
@@ -12679,7 +12679,7 @@ check_att_chg_allowed (const char *att_name, const PT_TYPE_ENUM t, const SM_ATTR
   /* NOT NULL : gaining is not always allowed */
   if (is_att_prop_set (attr_chg_prop->p[P_NOT_NULL], ATT_CHG_PROPERTY_GAINED))
     {
-      if (t == PT_TYPE_BFILE || t == PT_TYPE_CFILE)
+      if (PT_IS_LOB_FAMILY_TYPE (t))
 	{
 	  error = ER_SM_NOT_NULL_NOT_ALLOWED;
 	  *new_attempt = false;

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -8158,7 +8158,7 @@ qstr_make_typed_string (const DB_TYPE db_type, DB_VALUE * value, const int preci
       break;
 
     case DB_TYPE_CLOB:
-      error = db_make_clob (value, precision, src, s_unit, codeset, collation_id);
+      error = db_make_clob (value, precision, src, s_unit);
       break;
 
     case DB_TYPE_BLOB:
@@ -25560,7 +25560,7 @@ db_char_to_clob (const DB_VALUE * src_value, DB_VALUE * result_value)
       memcpy (buf, char_data, length);
     }
 
-  error_status = db_make_clob (result_value, DB_MAX_LOB_PRECISION, (DB_CONST_C_CHAR) buf, length, codeset, collation);
+  error_status = db_make_clob (result_value, DB_MAX_LOB_PRECISION, (DB_CONST_C_CHAR) buf, length);
   if (error_status != NO_ERROR)
     {
       goto error;

--- a/src/storage/statistics_cl.c
+++ b/src/storage/statistics_cl.c
@@ -590,7 +590,7 @@ stats_make_select_list_for_ndv (const MOP class_mop, ATTR_NDV ** attr_ndv)
     {
       /* check if type is varchar or lobfile or json. */
       dom = db_attribute_domain (att);
-      if (TP_IS_LOBFILE_TYPE (TP_DOMAIN_TYPE (dom)) || TP_DOMAIN_TYPE (dom) == DB_TYPE_JSON ||
+      if (TP_IS_LOB_FAMILY_TYPE (TP_DOMAIN_TYPE (dom)) || TP_DOMAIN_TYPE (dom) == DB_TYPE_JSON ||
 	  (TP_IS_CHAR_TYPE (TP_DOMAIN_TYPE (dom)) && dom->precision > STATS_MAX_PRECISION))
 	{
 	  /* These types are not gathered for statistics. */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26782

### Purpose

internal BLOB / CLOB 에 대해 비교 / 정렬 / 그룹 / 집합 / 인덱스 등 지원하지 않는 연산과 구문을 차단한다. 차단 정책은 기존 external LOB(BFILE / CFILE)과 동일하게 맞춘다.

차단 술어를 `PT_IS_LOBFILE_TYPE` / `TP_IS_LOBFILE_TYPE`(BFILE/CFILE 한정)에서 LOB family 술어(`PT_IS_LOB_FAMILY_TYPE` / `TP_IS_LOB_FAMILY_TYPE`, 4종 전체)로 교체하는 것이 핵심이다.

### Implementation
---
**1. DDL parity — `src/query/execute_schema.c`, `src/parser/semantic_check.c`, `src/object/schema_template.c`**

BFILE/CFILE 만 거부하던 좁은 게이트를 LOB family 로 확장한다.

```diff
-  if (PT_IS_LOBFILE_TYPE (...))   /* BFILE / CFILE only */
+  if (PT_IS_LOB_FAMILY_TYPE (...))  /* BFILE / CFILE / BLOB / CLOB */
```

- `execute_schema.c:789` CREATE TABLE DEFAULT, `:12682` ALTER CHANGE NOT NULL
- `semantic_check.c:15953` aggregate-internal ORDER BY(LIST_AGG 등)
- `schema_template.c:1336` `smt_set_attribute_default`
- → DEFAULT 는 NULL 만 허용, PK / UNIQUE / FK / INDEX / PARTITION 정의 시 4종 모두 거부.

---
**2. 비교 / 부분비교 — `src/parser/type_checking.c` (`pt_eval_expr_type`)**

arg 타입 추출 직후 명시적 LOB family 게이트를 추가한다. 기존 런타임 게이트 `tp_implicit_coercion_not_allowed` 는 implicit coercion 이 필요할 때만 발동하므로 same-type LOB 비교(`bf = bf`)가 빠져나갔다.

- 차단 목록
  - 등가/비등가/널세이프(`PT_EQ/NE/NULLSAFE_EQ`)
  - 관계(`PT_LT/LE/GT/GE/...`)
  - 범위/BETWEEN(`pt_is_range_or_comp`)
  - 한정 비교/IN(`pt_is_range_expression`, `PT_IS_IN/IS_NOT_IN`)
  - LIKE 계열(`PT_LIKE/RLIKE/...`)
  - 집합 비교(`PT_SETEQ/SUBSET/...`)

- `IS NULL` / `IS NOT NULL`(`PT_IS_NULL`/`PT_IS_NOT_NULL`)은 게이트 비대상 → 스펙 예외대로 허용.
- 에러는 `MSGCAT_SEMANTIC_OP_NOT_DEFINED_ON_{1,3,4}` 재사용으로 기존 per-type 거부 메시지와 일관.
---
**3. GROUP BY / DISTINCT / UNION / GROUP_CONCAT — `src/parser/semantic_check.c`, `src/parser/func_type.cpp`, `src/storage/statistics_cl.c`**

- `pt_check_group_by` GROUP BY 컬럼 루프에 LOB family reject 추가(BLOB/CLOB 은 cmpval 이 wired 되어 통과하던 문제).
- `pt_check_union_compatibility` UNION/INTERSECT/DIFFERENCE 양쪽 select list 를 순회하며 type-cast 전에 LOB family 거부.
- `PT_SELECT` DISTINCT-on-LOB 거부(`MSGCAT_SEMANTIC_OP_NOT_DEFINED_ON_1`).
- `func_type.cpp` GROUP_CONCAT / LIST_AGG 인자 호환성에서 `PT_IS_LOB_TYPE`(BLOB/CLOB) → `PT_IS_LOB_FAMILY_TYPE`.
- `statistics_cl.c:593` `TP_IS_LOBFILE_TYPE` → `TP_IS_LOB_FAMILY_TYPE`(통계 수집 시 internal LOB 도 skip).
---
**4. 도메인 정렬 — `src/object/object_domain.c`, `src/object/object_primitive.c`**

internal BLOB/CLOB 도메인 속성을 BFILE/CFILE 과 일관되게 정렬: codeset/collation(`LANG_SYS_CODESET` + binary collation), precision(`DB_MAX_LOB_PRECISION` 명시), primitive type case split(`mr_*_clob`).

---
**5. implicit cast 매트릭스 — `src/object/object_domain.c` (`tp_value_cast_internal`)**

양방향에서 LOB family implicit cast 차단. 유지되는 implicit pair 는 자연스러운 inline 쌍뿐:

```
CHAR / VARCHAR  <->  CLOB
BIT  / VARBIT   <->  BLOB
```
---
### Test

| 항목 (Verification) | 기대 결과 | 테스트 결과 |
|---|---|---|
| DDL 차단: PK/UK/FK/INDEX/PARTITION/non-NULL DEFAULT on BLOB/CLOB | 에러(정상) | OK |
| 비교 차단: `=, <>, <, <=, >, >=, IN, NOT IN, BETWEEN, LIKE` | 에러(정상) | OK |
| 정렬/그룹 차단: ORDER BY / GROUP BY / HAVING 그룹키 / DISTINCT | 에러(정상) | OK |
| 집합 차단: UNION / INTERSECT / MINUS(EXCEPT) 에 BLOB/CLOB 포함 | 에러(정상) | OK |
| 컬렉션 차단: SET OF / LIST OF / MULTISET OF BLOB/CLOB | 에러(정상) | OK |
| 허용 경로: `IS NULL` / `IS NOT NULL` | 에러(정상) | OK |

> 차단 시 에러 코드/메시지가 BFILE/CFILE 차단과 일관됨을 함께 확인한다.
---
### Remarks

- N/A