### PR TITLE
[CBRD-26863] Fix parallel index scan overflow-chain deadlock vs concurrent DML/DDL

### DIFF
--- a/src/query/parallel/px_scan/index/px_scan_index_overflow_chain_pool.cpp
+++ b/src/query/parallel/px_scan/index/px_scan_index_overflow_chain_pool.cpp
@@ -16,7 +16,7 @@
  *
  */
 
-/* px_scan_index_overflow_chain_pool.cpp — multi-chain shared overflow pool v3: key-publish (Option B), fix-outside-mutex (T2). */
+/* multi-chain shared overflow pool v3: key-publish (Option B), fix-outside-mutex. */
 
 #include "px_scan_index_overflow_chain_pool.hpp"
 
@@ -34,7 +34,7 @@
 
 namespace parallel_index_scan
 {
-  /* Requires m_overflow_mutex held; clears slot key and resets all fields. */
+  /* m_overflow_mutex held; clears key, resets all slot fields. */
   void
   overflow_chain_pool::close_slot_locked (overflow_slot &slot)
   {
@@ -50,10 +50,7 @@ namespace parallel_index_scan
     m_overflow_cv.notify_all ();
   }
 
-  /* Requires m_overflow_mutex held; see header. Asserts the failing thread is still counted —
-     this function MUST NOT decrement helpers (the failing thread decrements exactly once later
-     via its own exit_help). Adding a decrement here causes a double-decrement → helpers underflow
-     → permanent slot leak or premature close that re-introduces the ABA. */
+  /* m_overflow_mutex held; never decrement helpers — exit_help owns the one decrement (else underflow → leak/ABA). */
   void
   overflow_chain_pool::mark_chain_dead_locked (overflow_slot &slot)
   {
@@ -65,7 +62,7 @@ namespace parallel_index_scan
     m_overflow_cv.notify_all ();
   }
 
-  /* cap == parallelism + producer/late-joiner time-disjoint per worker => -1 unreachable; -1 path is defense-in-depth. */
+  /* cap==parallelism + producer/late-joiner time-disjoint => -1 unreachable; -1 is defense-in-depth. */
   int
   overflow_chain_pool::try_publish (THREAD_ENTRY *thread_p, VPID first_ovf_vpid,
 				    const DB_VALUE *key, int range_idx)
@@ -84,11 +81,11 @@ namespace parallel_index_scan
 	    slot.chain_walked = false;
 	    slot.claim_in_flight = false;
 	    slot.active = true;
-	    /* MANDATORY: ensure null before clone (belt-and-suspenders for slot reuse). */
+	    /* null before clone (slot-reuse safety). */
 	    db_make_null (&slot.key);
 	    if (pr_clone_value (key, &slot.key) != NO_ERROR)
 	      {
-		/* clone failed; roll back via close_slot_locked (clears partial key state). */
+		/* clone failed; roll back partial key. */
 		close_slot_locked (slot);
 		er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_FAILED, 0);
 		return -1;
@@ -116,8 +113,7 @@ namespace parallel_index_scan
 	return S_END;
       }
 
-    /* Predicate-loop: wait for any in-flight claim to finish before taking the cursor.
-     * Shared CV may fire spuriously or for unrelated slots — recheck predicate every wakeup. */
+    /* predicate-loop: shared CV wakes spuriously / for other slots — recheck before taking cursor. */
     while (slot.claim_in_flight)
       {
 	m_overflow_cv.wait (lock);
@@ -131,21 +127,13 @@ namespace parallel_index_scan
     slot.claim_in_flight = true;
     lock.unlock ();
 
-    /* Fix happens AFTER unlocking m_overflow_mutex — that is what removes the lock-order inversion:
-     * no page latch is taken while the mutex is held, so the mutex can never sit inside a
-     * leaf<->overflow latch cycle. Correctness rests on this alone. (Secondary, and only while the
-     * producer still holds its leaf-S in OVERFLOW_SHARED: a writer needs leaf-X before overflow-X
-     * (btree.c:9818/31524), so it cannot hold overflow-X against this UNCONDITIONAL fix.) */
+    /* fix outside m_overflow_mutex: no latch held under the mutex → can't form a leaf<->overflow latch cycle. */
     PAGE_PTR page = pgbuf_fix (thread_p, &claim_vpid, OLD_PAGE, PGBUF_LATCH_READ, PGBUF_UNCONDITIONAL_LATCH);
     if (page == NULL)
       {
 	ASSERT_ERROR ();
 	lock.lock ();
-	/* Option B: mark the chain dead but keep the slot occupied. This failing thread is itself
-	   a counted helper; it decrements once via its caller's exit_help. Each other straggler
-	   also drains via its own exit_help; the last out (helpers==0) runs close_slot_locked.
-	   Because try_publish only reuses !active slots and the slot stays active until fully
-	   drained, the slot index cannot be recycled under a straggler (ABA prevented). */
+	/* Option B: dead-mark; slot stays active till last-out exit_help closes it — no straggler recycle (ABA guard). */
 	mark_chain_dead_locked (slot);
 	return S_ERROR;
       }
@@ -158,7 +146,7 @@ namespace parallel_index_scan
 	ASSERT_ERROR ();
 	pgbuf_unfix (thread_p, page);
 	lock.lock ();
-	/* Option B (see pgbuf_fix-failure path above): dead-mark, defer close to last-out exit_help. */
+	/* Option B (see pgbuf_fix path): dead-mark, defer close to last-out exit_help. */
 	mark_chain_dead_locked (slot);
 	return S_ERROR;
       }
@@ -196,13 +184,10 @@ namespace parallel_index_scan
 
     if (!slot.active)
       {
-	/* Under Option B an error-dead chain stays active until the last helper drains it, so this
-	   no longer fires for error paths. Its remaining role: guard a redundant exit_help after a
-	   legitimate last-out close. Do NOT remove — a stray double-exit would trip the assert below
-	   or underflow helpers. */
+	/* guards a redundant exit_help after last-out close; do NOT remove — stray double-exit underflows helpers. */
 	return;
       }
-    assert (slot.helpers > 0);   /* holds under Option B: the failing thread stays counted (>=1). */
+    assert (slot.helpers > 0);   /* holds: failing thread stays counted (>=1). */
     --slot.helpers;
     if (slot.helpers == 0)
       {
@@ -269,8 +254,7 @@ namespace parallel_index_scan
 	    if (pr_clone_value (&ps.key, out_local_key) != NO_ERROR)
 	      {
 		ASSERT_ERROR ();
-		/* clone may have left a partial value; release it here — the caller will not
-		   (out_local_clear_key is still false on this path). */
+		/* clone may leave a partial value; release here — caller won't (out_local_clear_key still false). */
 		pr_clear_value (out_local_key);
 		db_make_null (out_local_key);
 		/* undo the helpers++ */

--- a/src/query/parallel/px_scan/index/px_scan_index_overflow_chain_pool.cpp
+++ b/src/query/parallel/px_scan/index/px_scan_index_overflow_chain_pool.cpp
@@ -25,6 +25,7 @@
 #include "dbtype.h"
 #include "error_code.h"
 #include "error_manager.h"
+#include "memory_alloc.h"
 #include "object_primitive.h"
 #include "page_buffer.h"
 #include "storage_common.h"
@@ -34,11 +35,38 @@
 
 namespace parallel_index_scan
 {
+  /* clone slot.key on the common heap (heap_id 0) so any worker thread can later free it; see clear_key_common_heap. */
+  int
+  overflow_chain_pool::clone_key_common_heap (DB_VALUE *dest, const DB_VALUE *src)
+  {
+#if defined (SERVER_MODE)
+    HL_HEAPID old_heap = db_private_set_heapid_to_thread (NULL, 0);
+#endif
+    int rc = pr_clone_value (src, dest);
+#if defined (SERVER_MODE)
+    (void) db_private_set_heapid_to_thread (NULL, old_heap);
+#endif
+    return rc;
+  }
+
+  /* free slot.key on common heap: last-out helper differs from producer; cross-thread private-heap free aborts. */
+  void
+  overflow_chain_pool::clear_key_common_heap (DB_VALUE *val)
+  {
+#if defined (SERVER_MODE)
+    HL_HEAPID old_heap = db_private_set_heapid_to_thread (NULL, 0);
+#endif
+    pr_clear_value (val);
+#if defined (SERVER_MODE)
+    (void) db_private_set_heapid_to_thread (NULL, old_heap);
+#endif
+  }
+
   /* m_overflow_mutex held; clears key, resets all slot fields. */
   void
   overflow_chain_pool::close_slot_locked (overflow_slot &slot)
   {
-    pr_clear_value (&slot.key);
+    clear_key_common_heap (&slot.key);
     db_make_null (&slot.key);
     slot.clear_key = false;
     slot.active = false;
@@ -83,7 +111,7 @@ namespace parallel_index_scan
 	    slot.active = true;
 	    /* null before clone (slot-reuse safety). */
 	    db_make_null (&slot.key);
-	    if (pr_clone_value (key, &slot.key) != NO_ERROR)
+	    if (clone_key_common_heap (&slot.key, key) != NO_ERROR)
 	      {
 		/* clone failed; roll back partial key. */
 		close_slot_locked (slot);

--- a/src/query/parallel/px_scan/index/px_scan_index_overflow_chain_pool.cpp
+++ b/src/query/parallel/px_scan/index/px_scan_index_overflow_chain_pool.cpp
@@ -16,7 +16,7 @@
  *
  */
 
-/* px_scan_index_overflow_chain_pool.cpp — multi-chain shared overflow share v2: per-slot active-chains, leaf re-read, round-robin. */
+/* px_scan_index_overflow_chain_pool.cpp — multi-chain shared overflow pool v3: key-publish (Option B), fix-outside-mutex (T2). */
 
 #include "px_scan_index_overflow_chain_pool.hpp"
 
@@ -27,7 +27,6 @@
 #include "error_manager.h"
 #include "object_primitive.h"
 #include "page_buffer.h"
-#include "slotted_page.h"
 #include "storage_common.h"
 
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
@@ -35,27 +34,51 @@
 
 namespace parallel_index_scan
 {
-  /* cap == parallelism + producer/late-joiner time-disjoint per worker => -1 unreachable; -1 path is defense-in-depth (er_set + assert) feeding the sole caller's S_ERROR. */
+  /* Requires m_overflow_mutex held; clears slot key and resets all fields. */
+  void
+  overflow_chain_pool::close_slot_locked (overflow_slot &slot)
+  {
+    pr_clear_value (&slot.key);
+    db_make_null (&slot.key);
+    slot.clear_key = false;
+    slot.active = false;
+    VPID_SET_NULL (&slot.cur_vpid);
+    slot.chain_walked = true;
+    slot.range_idx = -1;
+    slot.helpers = 0;
+    slot.claim_in_flight = false;
+    m_overflow_cv.notify_all ();
+  }
+
+  /* cap == parallelism + producer/late-joiner time-disjoint per worker => -1 unreachable; -1 path is defense-in-depth. */
   int
   overflow_chain_pool::try_publish (THREAD_ENTRY *thread_p, VPID first_ovf_vpid,
-				    VPID leaf_vpid, PGSLOTID leaf_slot_id, int range_idx)
+				    const DB_VALUE *key, int range_idx)
   {
     std::unique_lock<std::mutex> lock (m_overflow_mutex);
-    /* producer-mode precondition: inside enter_worker, before signal_no_more_leaves. */
-    assert (m_active_workers > 0 && !m_no_more_leaves);
-    /* find free slot — O(parallelism), small N. */
+    /* producer still owns an active worker slot; another worker may have already called signal_no_more_leaves. */
+    assert (m_active_workers > 0);
     for (int i = 0; i < static_cast<int> (m_overflow_slots.size ()); i++)
       {
 	if (!m_overflow_slots[i].active)
 	  {
 	    overflow_slot &slot = m_overflow_slots[i];
-	    slot.cur_vpid       = first_ovf_vpid;
-	    slot.leaf_vpid      = leaf_vpid;
-	    slot.leaf_slot_id   = leaf_slot_id;
-	    slot.range_idx      = range_idx;
-	    slot.helpers        = 1;        /* producer counts itself */
-	    slot.chain_walked   = false;
-	    slot.active         = true;
+	    slot.cur_vpid = first_ovf_vpid;
+	    slot.range_idx = range_idx;
+	    slot.helpers = 1;              /* producer counts itself */
+	    slot.chain_walked = false;
+	    slot.claim_in_flight = false;
+	    slot.active = true;
+	    /* MANDATORY: ensure null before clone (belt-and-suspenders for slot reuse). */
+	    db_make_null (&slot.key);
+	    if (pr_clone_value (key, &slot.key) != NO_ERROR)
+	      {
+		/* clone failed; roll back via close_slot_locked (clears partial key state). */
+		close_slot_locked (slot);
+		er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_FAILED, 0);
+		return -1;
+	      }
+	    slot.clear_key = true;
 	    m_overflow_cv.notify_all ();
 	    return i;
 	  }
@@ -72,37 +95,60 @@ namespace parallel_index_scan
     std::unique_lock<std::mutex> lock (m_overflow_mutex);
     assert (slot_idx >= 0 && slot_idx < static_cast<int> (m_overflow_slots.size ()));
     overflow_slot &slot = m_overflow_slots[slot_idx];
+
     if (!slot.active || VPID_ISNULL (&slot.cur_vpid))
       {
 	return S_END;
       }
+
+    /* Predicate-loop: wait for any in-flight claim to finish before taking the cursor.
+     * Shared CV may fire spuriously or for unrelated slots — recheck predicate every wakeup. */
+    while (slot.claim_in_flight)
+      {
+	m_overflow_cv.wait (lock);
+	if (!slot.active || VPID_ISNULL (&slot.cur_vpid))
+	  {
+	    return S_END;
+	  }
+      }
+
     VPID claim_vpid = slot.cur_vpid;
+    slot.claim_in_flight = true;
+    lock.unlock ();
+
+    /* Fix outside mutex — UNCONDITIONAL. Deadlock-free: writer requires leaf-X before overflow-X
+     * (btree.c:9818/31524), and producer holds leaf-S blocking that leaf-X. So no writer can hold
+     * overflow-X while we wait here. */
     PAGE_PTR page = pgbuf_fix (thread_p, &claim_vpid, OLD_PAGE, PGBUF_LATCH_READ, PGBUF_UNCONDITIONAL_LATCH);
     if (page == NULL)
       {
 	ASSERT_ERROR ();
-	slot.chain_walked = true;
-	VPID_SET_NULL (&slot.cur_vpid);
-	m_overflow_cv.notify_all ();
+	lock.lock ();
+	close_slot_locked (slot);
 	return S_ERROR;
       }
+
     (void) pgbuf_check_page_ptype (thread_p, page, PAGE_BTREE);
+
     VPID next_vpid;
     if (btree_get_next_overflow_vpid (thread_p, page, &next_vpid) != NO_ERROR)
       {
 	ASSERT_ERROR ();
 	pgbuf_unfix (thread_p, page);
-	slot.chain_walked = true;
-	VPID_SET_NULL (&slot.cur_vpid);
-	m_overflow_cv.notify_all ();
+	lock.lock ();
+	close_slot_locked (slot);
 	return S_ERROR;
       }
+
+    lock.lock ();
     slot.cur_vpid = next_vpid;
+    slot.claim_in_flight = false;
     if (VPID_ISNULL (&next_vpid))
       {
 	slot.chain_walked = true;
-	m_overflow_cv.notify_all ();
       }
+    m_overflow_cv.notify_all ();
+
     out_page = page;
     out_range_idx = slot.range_idx;
     return S_SUCCESS;
@@ -117,23 +163,24 @@ namespace parallel_index_scan
       }
   }
 
-  /* per-slot helpers decrement; last out closes chain unconditionally. */
+  /* per-slot helpers decrement; last out closes chain via close_slot_locked. */
   void
   overflow_chain_pool::exit_help (THREAD_ENTRY *thread_p, int slot_idx)
   {
     std::unique_lock<std::mutex> lock (m_overflow_mutex);
     assert (slot_idx >= 0 && slot_idx < static_cast<int> (m_overflow_slots.size ()));
     overflow_slot &slot = m_overflow_slots[slot_idx];
-    assert (slot.active && slot.helpers > 0);
+
+    if (!slot.active)
+      {
+	/* Already force-closed by claim_next error path; helpers counter is stale. */
+	return;
+      }
+    assert (slot.helpers > 0);
     --slot.helpers;
     if (slot.helpers == 0)
       {
-	/* helpers==0 closes the chain unconditionally (mirrors v1 error/interrupt clean-close). */
-	slot.active = false;
-	VPID_SET_NULL (&slot.cur_vpid);
-	slot.chain_walked = true;
-	slot.range_idx = -1;
-	m_overflow_cv.notify_all ();
+	close_slot_locked (slot);
       }
   }
 
@@ -146,7 +193,7 @@ namespace parallel_index_scan
     db_make_null (out_local_key);
     *out_local_clear_key = false;
     out_slot_idx = -1;
-    BTID_INT *btid_int = m_ranges->get_btid_int ();
+
     std::unique_lock<std::mutex> lock (m_overflow_mutex);
     for (;;)
       {
@@ -164,15 +211,13 @@ namespace parallel_index_scan
 	  {
 	    return S_END;
 	  }
+
 	if (any_active)
 	  {
 	    /* round-robin pick; relaxed counter is best-effort; under-lock slot-scan provides actual synchronization. */
 	    int cap = static_cast<int> (m_overflow_slots.size ());
 	    int base = m_next_chain_to_help.fetch_add (1, std::memory_order_relaxed) % cap;
 	    int picked = -1;
-	    VPID re_leaf_vpid;
-	    PGSLOTID re_slot_id = NULL_SLOTID;
-	    VPID_SET_NULL (&re_leaf_vpid);
 	    for (int i = 0; i < cap; i++)
 	      {
 		int idx = (base + i) % cap;
@@ -180,67 +225,36 @@ namespace parallel_index_scan
 		if (s.active && !s.chain_walked)
 		  {
 		    picked = idx;
-		    /* helpers++ under mutex pins slot active across the unlocked leaf re-read window. */
+		    /* helpers++ under mutex pins slot across the unlock window. */
 		    s.helpers++;
-		    re_leaf_vpid = s.leaf_vpid;
-		    re_slot_id = s.leaf_slot_id;
 		    break;
 		  }
 	      }
+
 	    if (picked < 0)
 	      {
-		m_overflow_cv.wait (lock);   /* every slot active && chain_walked; wait for last-out to close. */
+		/* All active slots are chain_walked; wait for last-out to close them. */
+		m_overflow_cv.wait (lock);
 		continue;
 	      }
-	    /* AS1 race-window close: pin leaf S-latch INSIDE m_overflow_mutex while producer's S-hold still covers it; helper's own S then keeps any X-acquirer (split/compactify/vacuum) out. Never S_PROMOTE (C7). */
-	    PAGE_PTR leaf_page = pgbuf_fix (thread_p, &re_leaf_vpid, OLD_PAGE, PGBUF_LATCH_READ,
-					    PGBUF_UNCONDITIONAL_LATCH);
-	    if (leaf_page == NULL)
+
+	    /* Option B: clone key from slot while still under mutex (helpers++ pins slot lifetime). */
+	    overflow_slot &ps = m_overflow_slots[picked];
+	    if (pr_clone_value (&ps.key, out_local_key) != NO_ERROR)
 	      {
 		ASSERT_ERROR ();
-		overflow_slot &s = m_overflow_slots[picked];
-		--s.helpers;
-		if (s.helpers == 0)
+		/* undo the helpers++ */
+		--ps.helpers;
+		if (ps.helpers == 0)
 		  {
-		    s.active = false;
-		    VPID_SET_NULL (&s.cur_vpid);
-		    s.chain_walked = true;
-		    s.range_idx = -1;
-		    m_overflow_cv.notify_all ();
+		    close_slot_locked (ps);
 		  }
 		return S_ERROR;
 	      }
+	    *out_local_clear_key = true;
 	    lock.unlock ();
-	    (void) pgbuf_check_page_ptype (thread_p, leaf_page, PAGE_BTREE);
-	    RECDES leaf_rec;
-	    leaf_rec.data = nullptr;
-	    leaf_rec.area_size = -1;
-	    if (spage_get_record (thread_p, leaf_page, re_slot_id, &leaf_rec, PEEK) != S_SUCCESS)
-	      {
-		ASSERT_ERROR ();
-		pgbuf_unfix (thread_p, leaf_page);
-		exit_help (thread_p, picked);
-		return S_ERROR;
-	      }
-	    LEAF_REC leaf_rec_info_unused;
-	    int after_key_offset_unused = 0;
-	    bool local_clear_key = false;
-	    int rerr = btree_read_record (thread_p, btid_int, leaf_page, &leaf_rec, out_local_key,
-					  &leaf_rec_info_unused, BTREE_LEAF_NODE,
-					  &local_clear_key, &after_key_offset_unused, COPY, nullptr);
-	    pgbuf_unfix (thread_p, leaf_page);
-	    if (rerr != NO_ERROR)
-	      {
-		ASSERT_ERROR ();
-		if (local_clear_key)
-		  {
-		    pr_clear_value (out_local_key);
-		  }
-		exit_help (thread_p, picked);
-		return S_ERROR;
-	      }
-	    *out_local_clear_key = local_clear_key;
-	    /* claim drives chain cursor; key already owned by caller. */
+
+	    /* claim_next manages its own mutex; fix happens outside m_overflow_mutex (no inversion). */
 	    SCAN_CODE sc = claim_next (thread_p, picked, out_page, out_range_idx);
 	    if (sc == S_SUCCESS)
 	      {
@@ -249,25 +263,21 @@ namespace parallel_index_scan
 	      }
 	    if (sc == S_ERROR)
 	      {
-		if (local_clear_key)
-		  {
-		    pr_clear_value (out_local_key);
-		  }
+		pr_clear_value (out_local_key);
+		db_make_null (out_local_key);
 		*out_local_clear_key = false;
 		exit_help (thread_p, picked);
 		return S_ERROR;
 	      }
-	    /* sc == S_END — chain exhausted between pick and claim; clear owned key, release helper, retry. */
-	    if (local_clear_key)
-	      {
-		pr_clear_value (out_local_key);
-	      }
-	    *out_local_clear_key = false;
+	    /* S_END: chain exhausted between pick and claim; clear owned key, release helper, retry. */
+	    pr_clear_value (out_local_key);
 	    db_make_null (out_local_key);
+	    *out_local_clear_key = false;
 	    exit_help (thread_p, picked);
 	    lock.lock ();
 	    continue;
 	  }
+
 	/* no active slots but workers still running; wait. */
 	m_overflow_cv.wait (lock);
       }

--- a/src/query/parallel/px_scan/index/px_scan_index_overflow_chain_pool.cpp
+++ b/src/query/parallel/px_scan/index/px_scan_index_overflow_chain_pool.cpp
@@ -50,6 +50,21 @@ namespace parallel_index_scan
     m_overflow_cv.notify_all ();
   }
 
+  /* Requires m_overflow_mutex held; see header. Asserts the failing thread is still counted —
+     this function MUST NOT decrement helpers (the failing thread decrements exactly once later
+     via its own exit_help). Adding a decrement here causes a double-decrement → helpers underflow
+     → permanent slot leak or premature close that re-introduces the ABA. */
+  void
+  overflow_chain_pool::mark_chain_dead_locked (overflow_slot &slot)
+  {
+    assert (slot.active);
+    assert (slot.helpers > 0);
+    VPID_SET_NULL (&slot.cur_vpid);
+    slot.chain_walked = true;
+    slot.claim_in_flight = false;
+    m_overflow_cv.notify_all ();
+  }
+
   /* cap == parallelism + producer/late-joiner time-disjoint per worker => -1 unreachable; -1 path is defense-in-depth. */
   int
   overflow_chain_pool::try_publish (THREAD_ENTRY *thread_p, VPID first_ovf_vpid,
@@ -116,15 +131,22 @@ namespace parallel_index_scan
     slot.claim_in_flight = true;
     lock.unlock ();
 
-    /* Fix outside mutex — UNCONDITIONAL. Deadlock-free: writer requires leaf-X before overflow-X
-     * (btree.c:9818/31524), and producer holds leaf-S blocking that leaf-X. So no writer can hold
-     * overflow-X while we wait here. */
+    /* Fix happens AFTER unlocking m_overflow_mutex — that is what removes the lock-order inversion:
+     * no page latch is taken while the mutex is held, so the mutex can never sit inside a
+     * leaf<->overflow latch cycle. Correctness rests on this alone. (Secondary, and only while the
+     * producer still holds its leaf-S in OVERFLOW_SHARED: a writer needs leaf-X before overflow-X
+     * (btree.c:9818/31524), so it cannot hold overflow-X against this UNCONDITIONAL fix.) */
     PAGE_PTR page = pgbuf_fix (thread_p, &claim_vpid, OLD_PAGE, PGBUF_LATCH_READ, PGBUF_UNCONDITIONAL_LATCH);
     if (page == NULL)
       {
 	ASSERT_ERROR ();
 	lock.lock ();
-	close_slot_locked (slot);
+	/* Option B: mark the chain dead but keep the slot occupied. This failing thread is itself
+	   a counted helper; it decrements once via its caller's exit_help. Each other straggler
+	   also drains via its own exit_help; the last out (helpers==0) runs close_slot_locked.
+	   Because try_publish only reuses !active slots and the slot stays active until fully
+	   drained, the slot index cannot be recycled under a straggler (ABA prevented). */
+	mark_chain_dead_locked (slot);
 	return S_ERROR;
       }
 
@@ -136,7 +158,8 @@ namespace parallel_index_scan
 	ASSERT_ERROR ();
 	pgbuf_unfix (thread_p, page);
 	lock.lock ();
-	close_slot_locked (slot);
+	/* Option B (see pgbuf_fix-failure path above): dead-mark, defer close to last-out exit_help. */
+	mark_chain_dead_locked (slot);
 	return S_ERROR;
       }
 
@@ -173,10 +196,13 @@ namespace parallel_index_scan
 
     if (!slot.active)
       {
-	/* Already force-closed by claim_next error path; helpers counter is stale. */
+	/* Under Option B an error-dead chain stays active until the last helper drains it, so this
+	   no longer fires for error paths. Its remaining role: guard a redundant exit_help after a
+	   legitimate last-out close. Do NOT remove — a stray double-exit would trip the assert below
+	   or underflow helpers. */
 	return;
       }
-    assert (slot.helpers > 0);
+    assert (slot.helpers > 0);   /* holds under Option B: the failing thread stays counted (>=1). */
     --slot.helpers;
     if (slot.helpers == 0)
       {
@@ -243,6 +269,10 @@ namespace parallel_index_scan
 	    if (pr_clone_value (&ps.key, out_local_key) != NO_ERROR)
 	      {
 		ASSERT_ERROR ();
+		/* clone may have left a partial value; release it here — the caller will not
+		   (out_local_clear_key is still false on this path). */
+		pr_clear_value (out_local_key);
+		db_make_null (out_local_key);
 		/* undo the helpers++ */
 		--ps.helpers;
 		if (ps.helpers == 0)

--- a/src/query/parallel/px_scan/index/px_scan_index_overflow_chain_pool.cpp
+++ b/src/query/parallel/px_scan/index/px_scan_index_overflow_chain_pool.cpp
@@ -35,7 +35,7 @@
 
 namespace parallel_index_scan
 {
-  /* clone slot.key on the common heap (heap_id 0) so any worker thread can later free it; see clear_key_common_heap. */
+  /* clone slot.key on common heap (id 0) so any worker thread can free it. */
   int
   overflow_chain_pool::clone_key_common_heap (DB_VALUE *dest, const DB_VALUE *src)
   {
@@ -49,7 +49,7 @@ namespace parallel_index_scan
     return rc;
   }
 
-  /* free slot.key on common heap: last-out helper differs from producer; cross-thread private-heap free aborts. */
+  /* free slot.key on common heap; cross-thread private-heap free (last-out helper != producer) aborts. */
   void
   overflow_chain_pool::clear_key_common_heap (DB_VALUE *val)
   {

--- a/src/query/parallel/px_scan/index/px_scan_index_overflow_chain_pool.hpp
+++ b/src/query/parallel/px_scan/index/px_scan_index_overflow_chain_pool.hpp
@@ -45,7 +45,9 @@ namespace parallel_index_scan
     bool     active;            /* slot in use; gates round-robin pick + termination predicate. */
     bool     claim_in_flight;   /* one in-flight claim at a time; predicate-loop in claim_next. */
     DB_VALUE key;               /* deep-copied from producer's m_slot_key at publish; slot-owned. */
-    bool     clear_key;         /* needs pr_clear_value on close. */
+    bool     clear_key;         /* slot.key currently owns variable-length storage. close_slot_locked
+				   clears unconditionally (pr_clear_value on a NULL value is a safe
+				   no-op); init() uses this flag to release pre-existing slots on reinit. */
   };
 
   /* (A) Multi-chain shared overflow pool (v2): cap = parallelism slots, helper supply matches chain demand. */
@@ -107,6 +109,12 @@ namespace parallel_index_scan
     private:
       /* Requires m_overflow_mutex held; clears key, resets all slot fields, notifies waiters. */
       void close_slot_locked (overflow_slot &slot);
+
+      /* Requires m_overflow_mutex held. Marks the chain DEAD (cursor exhausted) but does NOT
+         end slot occupancy: leaves active/helpers/key/clear_key untouched so the slot index
+         cannot be recycled by try_publish while a straggler helper still holds it (ABA guard).
+         The last exit_help to bring helpers to 0 runs close_slot_locked. */
+      void mark_chain_dead_locked (overflow_slot &slot);
 
       std::mutex                  m_overflow_mutex;
       std::condition_variable     m_overflow_cv;

--- a/src/query/parallel/px_scan/index/px_scan_index_overflow_chain_pool.hpp
+++ b/src/query/parallel/px_scan/index/px_scan_index_overflow_chain_pool.hpp
@@ -45,9 +45,7 @@ namespace parallel_index_scan
     bool     active;            /* slot in use; gates round-robin pick + termination predicate. */
     bool     claim_in_flight;   /* one in-flight claim at a time; predicate-loop in claim_next. */
     DB_VALUE key;               /* deep-copied from producer's m_slot_key at publish; slot-owned. */
-    bool     clear_key;         /* slot.key currently owns variable-length storage. close_slot_locked
-				   clears unconditionally (pr_clear_value on a NULL value is a safe
-				   no-op); init() uses this flag to release pre-existing slots on reinit. */
+    bool     clear_key;         /* slot.key owns var-length storage; init() frees pre-existing slots on reinit. */
   };
 
   /* (A) Multi-chain shared overflow pool (v2): cap = parallelism slots, helper supply matches chain demand. */
@@ -90,7 +88,7 @@ namespace parallel_index_scan
 	m_no_more_leaves = false;
       }
 
-      /* returns slot_idx >= 0; -1 only on broken cap==parallelism invariant (er_set+assert inside); key deep-copied from producer's m_slot_key. */
+      /* returns slot_idx>=0; -1 only on broken cap==parallelism invariant; key deep-copied from producer. */
       int try_publish (THREAD_ENTRY *thread_p, VPID first_ovf_vpid,
 		       const DB_VALUE *key, int range_idx);
       /* slot_idx mandatory: identifies which chain to advance. */
@@ -98,7 +96,7 @@ namespace parallel_index_scan
       void release_page (THREAD_ENTRY *thread_p, PAGE_PTR page);
       /* slot_idx mandatory: decrements helpers on the specific slot. */
       void exit_help (THREAD_ENTRY *thread_p, int slot_idx);
-      /* wait_or_help: round-robin pick; out_local_key owned by caller on S_SUCCESS (pr_clear_value if out_local_clear_key); cleared on S_END/S_ERROR. */
+      /* caller owns out_local_key on S_SUCCESS (per out_local_clear_key); cleared on S_END/S_ERROR. */
       SCAN_CODE wait_or_help (THREAD_ENTRY *thread_p, PAGE_PTR &out_page,
 			      DB_VALUE *out_local_key, bool *out_local_clear_key,
 			      int &out_range_idx, int &out_slot_idx);
@@ -107,13 +105,10 @@ namespace parallel_index_scan
       void signal_no_more_leaves ();
 
     private:
-      /* Requires m_overflow_mutex held; clears key, resets all slot fields, notifies waiters. */
+      /* m_overflow_mutex held; clears key, resets slot fields, notifies waiters. */
       void close_slot_locked (overflow_slot &slot);
 
-      /* Requires m_overflow_mutex held. Marks the chain DEAD (cursor exhausted) but does NOT
-         end slot occupancy: leaves active/helpers/key/clear_key untouched so the slot index
-         cannot be recycled by try_publish while a straggler helper still holds it (ABA guard).
-         The last exit_help to bring helpers to 0 runs close_slot_locked. */
+      /* m_overflow_mutex held; marks chain dead, slot stays occupied (ABA guard) — last-out exit_help closes it. */
       void mark_chain_dead_locked (overflow_slot &slot);
 
       std::mutex                  m_overflow_mutex;

--- a/src/query/parallel/px_scan/index/px_scan_index_overflow_chain_pool.hpp
+++ b/src/query/parallel/px_scan/index/px_scan_index_overflow_chain_pool.hpp
@@ -25,7 +25,6 @@
 
 #include "btree.h"
 #include "dbtype.h"
-#include "px_scan_index_key_range_list.hpp"
 #include "scan_manager.h"
 #include "storage_common.h"
 
@@ -40,12 +39,13 @@ namespace parallel_index_scan
   struct overflow_slot
   {
     VPID     cur_vpid;          /* chain cursor; VPID_ISNULL after chain_walked. */
-    VPID     leaf_vpid;         /* producer's leaf page locator (P2 leaf re-read source). */
-    PGSLOTID leaf_slot_id;      /* producer's leaf-slot id; record locator inside leaf_vpid. */
     int      range_idx;         /* owning range. */
     int      helpers;           /* drainers; producer counts itself. helpers==0 + chain_walked => releasable. */
     bool     chain_walked;      /* cur_vpid hit VPID_ISNULL. */
     bool     active;            /* slot in use; gates round-robin pick + termination predicate. */
+    bool     claim_in_flight;   /* one in-flight claim at a time; predicate-loop in claim_next. */
+    DB_VALUE key;               /* deep-copied from producer's m_slot_key at publish; slot-owned. */
+    bool     clear_key;         /* needs pr_clear_value on close. */
   };
 
   /* (A) Multi-chain shared overflow pool (v2): cap = parallelism slots, helper supply matches chain demand. */
@@ -56,34 +56,41 @@ namespace parallel_index_scan
 	: m_overflow_slots (),
 	  m_next_chain_to_help (0),
 	  m_active_workers (0),
-	  m_no_more_leaves (false),
-	  m_ranges (nullptr)
+	  m_no_more_leaves (false)
       {
       }
 
-      /* main-thread: rebind backing range view + reset slot vector to cap. */
-      void init (int parallelism, key_range_list *ranges)
+      /* main-thread: reset slot vector to cap. */
+      void init (int parallelism)
       {
-	m_ranges = ranges;
+	/* Clear variable-length key storage before overwriting slots (reinit / abort-cleanup safety). */
+	for (auto &slot : m_overflow_slots)
+	  {
+	    if (slot.clear_key)
+	      {
+		pr_clear_value (&slot.key);
+	      }
+	  }
 	m_overflow_slots.assign (parallelism, overflow_slot {});
 	for (auto &slot : m_overflow_slots)
 	  {
 	    VPID_SET_NULL (&slot.cur_vpid);
-	    VPID_SET_NULL (&slot.leaf_vpid);
-	    slot.leaf_slot_id = NULL_SLOTID;
 	    slot.range_idx = -1;
 	    slot.helpers = 0;
 	    slot.chain_walked = false;
 	    slot.active = false;
+	    slot.claim_in_flight = false;
+	    db_make_null (&slot.key);
+	    slot.clear_key = false;
 	  }
 	m_next_chain_to_help.store (0, std::memory_order_relaxed);
 	m_active_workers = 0;
 	m_no_more_leaves = false;
       }
 
-      /* returns slot_idx >= 0; -1 only on broken cap==parallelism invariant (er_set+assert inside); leaf_vpid/slot_id stored for helper re-read. */
+      /* returns slot_idx >= 0; -1 only on broken cap==parallelism invariant (er_set+assert inside); key deep-copied from producer's m_slot_key. */
       int try_publish (THREAD_ENTRY *thread_p, VPID first_ovf_vpid,
-		       VPID leaf_vpid, PGSLOTID leaf_slot_id, int range_idx);
+		       const DB_VALUE *key, int range_idx);
       /* slot_idx mandatory: identifies which chain to advance. */
       SCAN_CODE claim_next (THREAD_ENTRY *thread_p, int slot_idx, PAGE_PTR &out_page, int &out_range_idx);
       void release_page (THREAD_ENTRY *thread_p, PAGE_PTR page);
@@ -98,6 +105,9 @@ namespace parallel_index_scan
       void signal_no_more_leaves ();
 
     private:
+      /* Requires m_overflow_mutex held; clears key, resets all slot fields, notifies waiters. */
+      void close_slot_locked (overflow_slot &slot);
+
       std::mutex                  m_overflow_mutex;
       std::condition_variable     m_overflow_cv;
       std::vector<overflow_slot>  m_overflow_slots;       /* size == parallelism; cap = helper supply. */
@@ -105,8 +115,6 @@ namespace parallel_index_scan
       /* Late-joiner termination tracking (under m_overflow_mutex) */
       int                       m_active_workers;         /* workers currently inside loop body */
       bool                      m_no_more_leaves;         /* set when last get_next_page_with_fix returned S_END */
-
-      key_range_list *m_ranges;   /* borrowed; needed for BTID_INT inside wait_or_help leaf re-read. */
   };
 }
 

--- a/src/query/parallel/px_scan/index/px_scan_index_overflow_chain_pool.hpp
+++ b/src/query/parallel/px_scan/index/px_scan_index_overflow_chain_pool.hpp
@@ -111,7 +111,7 @@ namespace parallel_index_scan
       /* m_overflow_mutex held; marks chain dead, slot stays occupied (ABA guard) — last-out exit_help closes it. */
       void mark_chain_dead_locked (overflow_slot &slot);
 
-      /* slot.key published by producer, freed by last-out helper (other thread); clone/clear on common heap (id 0). */
+      /* slot.key cloned by producer, freed by another (last-out) thread; use common heap (id 0). */
       static int clone_key_common_heap (DB_VALUE *dest, const DB_VALUE *src);
       static void clear_key_common_heap (DB_VALUE *val);
 

--- a/src/query/parallel/px_scan/index/px_scan_index_overflow_chain_pool.hpp
+++ b/src/query/parallel/px_scan/index/px_scan_index_overflow_chain_pool.hpp
@@ -68,7 +68,7 @@ namespace parallel_index_scan
 	  {
 	    if (slot.clear_key)
 	      {
-		pr_clear_value (&slot.key);
+		clear_key_common_heap (&slot.key);
 	      }
 	  }
 	m_overflow_slots.assign (parallelism, overflow_slot {});
@@ -110,6 +110,10 @@ namespace parallel_index_scan
 
       /* m_overflow_mutex held; marks chain dead, slot stays occupied (ABA guard) — last-out exit_help closes it. */
       void mark_chain_dead_locked (overflow_slot &slot);
+
+      /* slot.key published by producer, freed by last-out helper (other thread); clone/clear on common heap (id 0). */
+      static int clone_key_common_heap (DB_VALUE *dest, const DB_VALUE *src);
+      static void clear_key_common_heap (DB_VALUE *val);
 
       std::mutex                  m_overflow_mutex;
       std::condition_variable     m_overflow_cv;

--- a/src/query/parallel/px_scan/index/px_scan_index_overflow_drain_fsm.cpp
+++ b/src/query/parallel/px_scan/index/px_scan_index_overflow_drain_fsm.cpp
@@ -138,15 +138,10 @@ namespace parallel_index_scan
 		m_drain_state = drain_state::IDLE;
 		return S_END;
 	      }
-	    /* leaf_slot_for_publish recovers producer's read slot: m_current_slot was inc/dec'd past it, so reverse by one. */
-	    VPID leaf_vpid_for_publish;
-	    pgbuf_get_vpid (walker->m_page, &leaf_vpid_for_publish);
-	    PGSLOTID leaf_slot_for_publish = (PGSLOTID) (walker->m_use_desc_index ? (walker->m_current_slot + 1) :
-					     (walker->m_current_slot - 1));
+	    /* m_slot_key is valid here: walker.cpp sets it before begin_leaf_drain, and key is immutable (MVCC: no in-place mutation). */
 	    int published_idx = handler->try_publish_overflow (thread_p,
 				m_pending_ovf_vpid,
-				leaf_vpid_for_publish,
-				leaf_slot_for_publish,
+				&walker->m_slot_key,
 				walker->m_current_range_idx);
 	    /* cap == parallelism invariant: try_publish_overflow cannot legitimately return -1; if-branch defends release builds (try_publish already er_set). */
 	    assert (published_idx >= 0 && "try_publish must succeed under cap == parallelism invariant");

--- a/src/query/parallel/px_scan/index/px_scan_index_overflow_drain_fsm.cpp
+++ b/src/query/parallel/px_scan/index/px_scan_index_overflow_drain_fsm.cpp
@@ -138,7 +138,7 @@ namespace parallel_index_scan
 		m_drain_state = drain_state::IDLE;
 		return S_END;
 	      }
-	    /* m_slot_key is valid here: walker.cpp sets it before begin_leaf_drain, and key is immutable (MVCC: no in-place mutation). */
+	    /* m_slot_key valid here: walker.cpp sets it before begin_leaf_drain; key immutable (MVCC). */
 	    int published_idx = handler->try_publish_overflow (thread_p,
 				m_pending_ovf_vpid,
 				&walker->m_slot_key,

--- a/src/query/parallel/px_scan/px_scan_input_handler_index.cpp
+++ b/src/query/parallel/px_scan/px_scan_input_handler_index.cpp
@@ -38,7 +38,7 @@ namespace parallel_scan
 	return err;
       }
     m_leaf.init (&m_ranges);
-    m_ovf.init (parallelism, &m_ranges);
+    m_ovf.init (parallelism);
     return NO_ERROR;
   }
 

--- a/src/query/parallel/px_scan/px_scan_input_handler_index.hpp
+++ b/src/query/parallel/px_scan/px_scan_input_handler_index.hpp
@@ -87,11 +87,11 @@ namespace parallel_scan
 	return m_ranges.get_num_key_ranges ();
       }
 
-      /* --- Shared overflow API (v2 / multi-chain): delegate to m_ovf. --- */
+      /* --- Shared overflow API (v3 / key-publish): delegate to m_ovf. --- */
       int try_publish_overflow (THREAD_ENTRY *thread_p, VPID first_ovf_vpid,
-				VPID leaf_vpid, PGSLOTID leaf_slot_id, int range_idx)
+				const DB_VALUE *key, int range_idx)
       {
-	return m_ovf.try_publish (thread_p, first_ovf_vpid, leaf_vpid, leaf_slot_id, range_idx);
+	return m_ovf.try_publish (thread_p, first_ovf_vpid, key, range_idx);
       }
       SCAN_CODE claim_next_overflow_page (THREAD_ENTRY *thread_p, int slot_idx, PAGE_PTR &out_page,
 					  int &out_range_idx)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26863>

### Purpose

병렬 인덱스 스캔이 같은 인덱스에서 동시에 DML/DDL(DELETE split, DROP dealloc, vacuum 등)이 돌 때 deadlock으로 hang 걸리는 문제를 수정합니다.

원인은 overflow chain pool이 `m_overflow_mutex`(C++ `std::mutex`)를 잡은 채로 `pgbuf_fix`를 호출하는 데 있습니다. leaf latch → overflow latch 순서가 정상인데, mutex 안에서 leaf를 다시 fix하면 순서가 뒤집힙니다. 이 mutex는 pgbuf 교착 탐지 그래프에 안 잡히기 때문에 자동 해소 없이 영구 hang으로 굳습니다.

### Implementation

**key-publish 방식으로 변경**

producer가 leaf S-latch를 쥔 시점에 키를 `overflow_slot`으로 deep-copy해 둡니다. helper는 슬롯에서 키를 복제만 하고 leaf 페이지를 다시 fix하지 않습니다. 기존에 helper가 하던 `spage_get_record` + `btree_read_record` 경로를 제거해서, `m_overflow_mutex` 보유 중 leaf fix가 일어나던 역전을 원천 차단합니다. `overflow_slot`에서 `leaf_vpid`/`leaf_slot_id`를 빼고 키(`DB_VALUE`) + `clear_key` 플래그를 추가했습니다.

**page fix를 mutex 밖으로 이동**

`claim_next`는 mutex 안에서 커서만 스냅샷하고, mutex를 풀고 난 뒤 overflow 페이지를 `PGBUF_UNCONDITIONAL_LATCH`로 fix합니다. writer/vacuum 모두 leaf→overflow(top-down) 순서로 latch를 잡으므로 mutex 밖에서 fix해도 사이클이 생기지 않고, 병렬 스캔은 latch-coupling을 안 쓰므로 CONDITIONAL latch가 필요 없습니다.

**동시성 보조**

- `close_slot_locked` 함수로 슬롯 정리(키 해제 + 필드 리셋 + 통지)를 한 곳으로 모아서 키 lifetime 누수/이중 해제 방지.
- per-slot `claim_in_flight` 플래그로 두 helper가 같은 overflow 페이지를 중복 처리하는 것을 방지. 커서 전진은 fix 성공 후 1회만.
- `signal_no_more_leaves` 이후에도 다른 producer가 늦게 publish하는 건 정상이므로, `try_publish`의 assert를 `m_active_workers > 0` 조건으로 완화.

수정 범위는 `src/query/parallel/px_scan`에 한정하며 btree core 동시성 프로토콜은 건드리지 않았습니다.

### Remarks

- debug 빌드 무경고, `m_overflow_mutex`·`m_leaf_mutex` 보유 중 `pgbuf_fix` 호출 0건 확인.
- 병렬==직렬 정합성 확인: overflow 중복키 케이스, `COUNT` 2000 / `GROUP BY` 400×5 일치.
- 실제 동시부하 long-run hang/core 측정, ASAN/valgrind 메모리 누수 검증은 환경 제약으로 미수행 — 머지 전 별도 확인이 필요합니다.