### PR TITLE
[CBRD-26635] Retry disconnection later if client is still registering.

### DIFF
--- a/src/connection/connection_defs.h
+++ b/src/connection/connection_defs.h
@@ -504,6 +504,7 @@ struct css_conn_entry
   // working task count manipulation
   void add_working_task ();
   size_t end_working_task ();
+  bool has_working_task () const;
   void init_working_task ();
 
   void release_packet (void *buffer);

--- a/src/connection/connection_support.cpp
+++ b/src/connection/connection_support.cpp
@@ -2835,6 +2835,12 @@ css_send_req_with_large_buffer (CSS_CONN_ENTRY *conn, int request, unsigned shor
    return --working_task_count;
  }
 
+ bool
+ css_conn_entry::has_working_task () const
+ {
+   return working_task_count > 0;
+ }
+
  void
  css_conn_entry::init_working_task ()
  {

--- a/src/connection/connection_worker.cpp
+++ b/src/connection/connection_worker.cpp
@@ -337,6 +337,11 @@ namespace cubconn::connection
     return true;
   }
 
+  bool worker::is_registering_client (context *ctx)
+  {
+    return ctx->m_conn->has_pending_request () || ctx->m_conn->has_working_task ();
+  }
+
   bool worker::has_remaining_tasks (context *ctx)
   {
     /* handle the entries in the message queue as there may be a queued request to release the memory in ctx */
@@ -383,10 +388,35 @@ namespace cubconn::connection
     pthread_mutex_unlock (&m_entry->tran_index_lock);
   }
 
-  bool worker::handle_connection_close (context *ctx, bool retry, std::shared_ptr<message_blocker> handle)
+  bool worker::retry_connection_close (context *ctx, bool retry, std::shared_ptr<message_blocker> handle)
+  {
+    message request;
+
+    er_log_conn (__FILE__, __LINE__, "connection::worker->handle_connection_close: retry fd = %d, ignore = %d, conn = %p\n",
+		 ctx->m_conn ? ctx->m_conn->fd : -1, ctx->m_ignore, ctx->m_conn);
+
+    request.type = message_type::SHUTDOWN_CLIENT;
+    request.conn = ctx->m_conn;
+    request.ignore = ctx->m_ignore;
+    request.retry = retry;
+    request.waiter_handle = handle;
+
+    /* this request must be handled as lazily */
+    this->enqueue (queue_type::LAZY, std::move (request));
+
+    /* lazily notified */
+    m_has_retry = true;
+
+    return this->eventfd_addtimer (
+		   timer_type::QUEUE,
+		   timer_latency::LOW_LATENCY,
+		   std::bind (&worker::handle_message_queue, this)
+	   );
+  }
+
+  bool worker::handle_connection_close (context *ctx, bool is_retry, std::shared_ptr<message_blocker> handle)
   {
     std::chrono::time_point<std::chrono::steady_clock> start, end;
-    message request;
     int tran_index, client_id;
     int status;
 
@@ -401,6 +431,16 @@ namespace cubconn::connection
       }
 
     assert_release (ctx->m_conn);
+
+    if (this->is_wait_required (ctx) && ctx->m_conn->get_tran_index () == NULL_TRAN_INDEX
+	&& this->is_registering_client (ctx))
+      {
+	er_log_conn (__FILE__, __LINE__,
+		     "connection::worker->handle_connection_close: retry for transaction index. conn = %p, fd = %d\n",
+		     ctx->m_conn, ctx->m_conn->fd);
+
+	return this->retry_connection_close (ctx, is_retry, handle);
+      }
 
     /* change status */
 
@@ -424,20 +464,7 @@ namespace cubconn::connection
       {
 	if (this->is_wait_required (ctx))
 	  {
-	    pthread_mutex_unlock (&m_entry->tran_index_lock);
-
-	    er_log_conn (__FILE__, __LINE__,
-			 "connection::worker->handle_connection_close: wait for transaction index. conn = %p, fd = %d\n", ctx->m_conn,
-			 ctx->m_conn->fd);
-
-	    /* the connected client does not yet finished boot_client_register */
-	    /* this case is unusual */
-	    /* DO NOT RETRY. retrying may result in duplicate shutdown client requests */
-	    thread_sleep (50);
-
-	    pthread_mutex_lock (&m_entry->tran_index_lock);
-
-	    tran_index = ctx->m_conn->get_tran_index ();
+	    /* boot_client_register cannot make progress anymore. close the connection without fixed wait. */
 	    client_id = ctx->m_conn->client_id;
 	  }
       }
@@ -454,7 +481,7 @@ namespace cubconn::connection
 	ssession_stop_attached_threads (m_entry, ctx->m_conn->session_p);
       }
 
-    if (!retry)
+    if (!is_retry)
       {
 	/* interrupt and wake up */
 
@@ -535,30 +562,9 @@ namespace cubconn::connection
     return true;
 
 retry:
-    er_log_conn (__FILE__, __LINE__, "connection::worker->handle_connection_close: retry fd = %d, ignore = %d, conn = %p\n",
-		 ctx->m_conn ? ctx->m_conn->fd : -1, ctx->m_ignore, ctx->m_conn);
-
     this->end_connection_close ();
 
-    request.type = message_type::SHUTDOWN_CLIENT;
-    request.conn = ctx->m_conn;
-    request.ctx = ctx;
-    request.id = ctx->m_id;
-    request.ignore = ctx->m_ignore;
-    request.retry = true;
-    request.waiter_handle = handle;
-
-    /* this request must be handled as razily */
-    this->enqueue (queue_type::LAZY, std::move (request));
-
-    /* rezily notified */
-    m_has_retry = true;
-
-    return this->eventfd_addtimer (
-		   timer_type::QUEUE,
-		   timer_latency::LOW_LATENCY,
-		   std::bind (&worker::handle_message_queue, this)
-	   );
+    return this->retry_connection_close (ctx, true, handle);
   }
 
   bool worker::statistics_metrics_to_coordinator ()

--- a/src/connection/connection_worker.cpp
+++ b/src/connection/connection_worker.cpp
@@ -388,7 +388,7 @@ namespace cubconn::connection
     pthread_mutex_unlock (&m_entry->tran_index_lock);
   }
 
-  bool worker::retry_connection_close (context *ctx, bool retry, std::shared_ptr<message_blocker> handle)
+  bool worker::retry_connection_close (context *ctx, bool is_retry, std::shared_ptr<message_blocker> handle)
   {
     message request;
 
@@ -398,7 +398,7 @@ namespace cubconn::connection
     request.type = message_type::SHUTDOWN_CLIENT;
     request.conn = ctx->m_conn;
     request.ignore = ctx->m_ignore;
-    request.retry = retry;
+    request.retry = is_retry;
     request.waiter_handle = handle;
 
     /* this request must be handled as lazily */

--- a/src/connection/connection_worker.cpp
+++ b/src/connection/connection_worker.cpp
@@ -327,7 +327,7 @@ namespace cubconn::connection
       }
   }
 
-  bool worker::is_wait_required (context *ctx)
+  bool worker::requires_client_info (context *ctx)
   {
     if (ctx->m_conn->fd == cdc_Gl.conn.fd)
       {
@@ -434,7 +434,7 @@ namespace cubconn::connection
 
     /* during shutdown, boot_client_register cannot be expected to finish */
     if (m_status != status::TERMINATING && !css_is_shutdowning_server ()
-	&& this->is_wait_required (ctx)
+	&& this->requires_client_info (ctx)
 	&& ctx->m_conn->get_tran_index () == NULL_TRAN_INDEX
 	&& this->is_registering_client (ctx))
       {
@@ -465,9 +465,10 @@ namespace cubconn::connection
     std::tie (tran_index, client_id) = this->start_connection_close (ctx);
     if (tran_index < 0 && client_id < 0)
       {
-	if (this->is_wait_required (ctx))
+	if (this->requires_client_info (ctx))
 	  {
-	    /* boot_client_register cannot make progress anymore. close the connection without fixed wait. */
+	    /* retry was skipped, so boot_client_register is not expected to publish a transaction index. */
+	    /* close without retry. */
 	    client_id = ctx->m_conn->client_id;
 	  }
       }

--- a/src/connection/connection_worker.cpp
+++ b/src/connection/connection_worker.cpp
@@ -432,7 +432,10 @@ namespace cubconn::connection
 
     assert_release (ctx->m_conn);
 
-    if (this->is_wait_required (ctx) && ctx->m_conn->get_tran_index () == NULL_TRAN_INDEX
+    /* during shutdown, boot_client_register cannot be expected to finish */
+    if (m_status != status::TERMINATING && !css_is_shutdowning_server ()
+	&& this->is_wait_required (ctx)
+	&& ctx->m_conn->get_tran_index () == NULL_TRAN_INDEX
 	&& this->is_registering_client (ctx))
       {
 	er_log_conn (__FILE__, __LINE__,

--- a/src/connection/connection_worker.cpp
+++ b/src/connection/connection_worker.cpp
@@ -397,6 +397,8 @@ namespace cubconn::connection
 
     request.type = message_type::SHUTDOWN_CLIENT;
     request.conn = ctx->m_conn;
+    request.ctx = ctx;
+    request.id = ctx->m_id;
     request.ignore = ctx->m_ignore;
     request.retry = is_retry;
     request.waiter_handle = handle;

--- a/src/connection/connection_worker.hpp
+++ b/src/connection/connection_worker.hpp
@@ -269,7 +269,7 @@ namespace cubconn::connection
 
       std::pair<int, int> start_connection_close (context *ctx);
       void end_connection_close ();
-      bool retry_connection_close (context *ctx, bool retry, std::shared_ptr<message_blocker> handle);
+      bool retry_connection_close (context *ctx, bool is_retry, std::shared_ptr<message_blocker> handle);
 
       bool handle_connection_close (context *ctx, bool is_retry = false, std::shared_ptr<message_blocker> handle = nullptr);
 

--- a/src/connection/connection_worker.hpp
+++ b/src/connection/connection_worker.hpp
@@ -263,12 +263,15 @@ namespace cubconn::connection
       /* close connection							     */
       /* --------------------------------------------------------------------------- */
       bool is_wait_required (context *ctx);
+      bool is_registering_client (context *ctx);
+
       bool has_remaining_tasks (context *ctx);
 
       std::pair<int, int> start_connection_close (context *ctx);
       void end_connection_close ();
+      bool retry_connection_close (context *ctx, bool retry, std::shared_ptr<message_blocker> handle);
 
-      bool handle_connection_close (context *ctx, bool retry = false, std::shared_ptr<message_blocker> handle = nullptr);
+      bool handle_connection_close (context *ctx, bool is_retry = false, std::shared_ptr<message_blocker> handle = nullptr);
 
       /* --------------------------------------------------------------------------- */
       /* statistics and hibernation						     */

--- a/src/connection/connection_worker.hpp
+++ b/src/connection/connection_worker.hpp
@@ -262,7 +262,7 @@ namespace cubconn::connection
       /* --------------------------------------------------------------------------- */
       /* close connection							     */
       /* --------------------------------------------------------------------------- */
-      bool is_wait_required (context *ctx);
+      bool requires_client_info (context *ctx);
       bool is_registering_client (context *ctx);
 
       bool has_remaining_tasks (context *ctx);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-XXXX>

### Purpose

#7192 에서 리뷰 완료하였습니다. 테스트케이스 최신화 과정에서 PR이 닫히고 force push되어 새로 열었습니다.

### Implementation

N/A

### Remarks

N/A
