### PR TITLE
[CBRD-23839] Fix race condition in unloaddb.sh schema unload

### DIFF
--- a/contrib/scripts/unloaddb.sh
+++ b/contrib/scripts/unloaddb.sh
@@ -243,6 +243,7 @@ function do_unloaddb ()
 	local opts="$user $pass -s "
 	local do_schema_unload=0
 	local do_data_unload=0
+	local schema_pid=
 
 	for ((i = 0; i < $num_tables; i++))
 	do
@@ -278,10 +279,17 @@ function do_unloaddb ()
 		if [ $from_file -eq 1 ];then
 			opts=$opts" --input-class-only --input-class-file $filename"
 		fi
+		# Run the schema unload concurrently with the data, but capture its PID and
+		# wait on it below so it is not orphaned -- otherwise the schema files could
+		# still be incomplete when "Completed." is printed.
 		(silent_cd $target_dir;cubrid unloaddb $opts $database) &
+		schema_pid=$!
 	fi
 
 	if [ $do_data_unload -eq 0 ];then
+		if [ -n "$schema_pid" ];then
+			wait $schema_pid
+		fi
 		return
 	fi
 
@@ -297,6 +305,10 @@ function do_unloaddb ()
 		echo "process $slot_num: failed" > $log_prefix.status
 	else
 		echo "process $slot_num: success" > $log_prefix.status
+	fi
+
+	if [ -n "$schema_pid" ];then
+		wait $schema_pid
 	fi
 
 	# move unloaddb logfile to $logdir


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-23839>

### Purpose

do_unloaddb()가 스키마 언로드를 백그라운드('&')로 실행하면서 wait하지 않아 고아 프로세스로 남았습니다. 최종 wait는 슬롯별 워커 서브셸만 기다리고 각 워커는 데이터 PID만 wait하므로, "Completed." 출력 시점에 *_schema가 미완성일 수 있었습니다(부하 시 간헐적 CI 실패).

### Implementation

스키마 언로드 PID를 포착해, 워커가 반환하기 전(-s 경로와 schema+data 경로 양쪽)에서 wait합니다. 스키마는 데이터와 동시 실행되어 병렬 설계를 유지하며, 스키마 파일은 "Completed." 전에 완성이 보장됩니다.

### Remarks

N/A
