### PR TITLE
[CBRD-26784] Support internal LOB (BLOB/CLOB) in utilities

### DIFF
--- a/src/executables/csql_result.c
+++ b/src/executables/csql_result.c
@@ -565,13 +565,6 @@ get_current_result (int **lengths, const CUR_RESULT_INFO * result_info, const CS
 	      || (TP_IS_CHAR_TYPE (value_type) && (result_info->attr_types[i] == DB_TYPE_CLOB))
 	      || (TP_IS_BIT_TYPE (value_type) && (result_info->attr_types[i] == DB_TYPE_BLOB)));
 
-      //TODO : develop에 merge하기 전에 지우기
-      if ((TP_IS_CHAR_TYPE (value_type) && (result_info->attr_types[i] == DB_TYPE_CLOB))
-	  || (TP_IS_BIT_TYPE (value_type) && (result_info->attr_types[i] == DB_TYPE_BLOB)))
-	{
-	  assert_release (false);
-	}
-
       switch (value_type)
 	{
 	case DB_TYPE_NULL:	/* null value */

--- a/src/executables/unload_object_file.c
+++ b/src/executables/unload_object_file.c
@@ -75,6 +75,8 @@ static void print_set (print_output & output_ctx, DB_SET * set);
 static int fprint_special_set (TEXT_OUTPUT * tout, DB_SET * set);
 static int bfmt_print (int bfmt, const DB_VALUE * the_db_bit, char *string, int max_size);
 static int print_quoted_str (TEXT_OUTPUT * tout, const char *str, int len, int max_token_len);
+static int fprint_clob_value (TEXT_OUTPUT * tout, DB_VALUE * value);
+static int fprint_blob_value (TEXT_OUTPUT * tout, DB_VALUE * value);
 static int fprint_special_strings (TEXT_OUTPUT * tout, DB_VALUE * value);
 
 static int write_object_file (TEXT_BUFFER_BLK * head);
@@ -670,6 +672,82 @@ exit_on_error:
 #define INTERNAL_BUFFER_SIZE (400)	/* bigger than DBL_MAX_DIGITS */
 
 /*
+ * fprint_clob_value - print an internal CLOB DB_VALUE to TEXT_OUTPUT
+ *    return: NO_ERROR if successful, error code otherwise
+ *    tout(out): output
+ *    value(in): DB_VALUE of type DB_TYPE_CLOB
+ * Note:
+ *    Internal CLOB is stored inline like a character string, so it is printed
+ *    as a quoted string. Kept separate from the CHAR/VARCHAR case so that
+ *    CLOB-specific formatting can diverge without touching that path.
+ */
+static int
+fprint_clob_value (TEXT_OUTPUT * tout, DB_VALUE * value)
+{
+  int error = NO_ERROR;
+  const char *str_ptr;
+  int len;
+
+  str_ptr = db_get_string (value);
+  len = db_get_string_size (value);
+  if (len < 0)
+    {
+      len = (int) strlen (str_ptr);
+    }
+
+  CHECK_PRINT_ERROR (print_quoted_str (tout, str_ptr, len, MAX_DISPLAY_COLUMN));
+
+exit_on_error:
+  return error;
+}
+
+/*
+ * fprint_blob_value - print an internal BLOB DB_VALUE to TEXT_OUTPUT
+ *    return: NO_ERROR if successful, error code otherwise
+ *    tout(out): output
+ *    value(in): DB_VALUE of type DB_TYPE_BLOB
+ * Note:
+ *    Internal BLOB is stored inline like a bit string, so it is printed as a
+ *    hex string. Kept separate from the BIT/VARBIT case so that BLOB-specific
+ *    formatting can diverge without touching that path.
+ */
+static int
+fprint_blob_value (TEXT_OUTPUT * tout, DB_VALUE * value)
+{
+  int error = NO_ERROR;
+  char buf[INTERNAL_BUFFER_SIZE];
+  char *ptr = NULL;
+  int max_size = ((db_get_string_length (value) + 3) / 4) + 1;
+
+  if (max_size > INTERNAL_BUFFER_SIZE)
+    {
+      ptr = (char *) malloc (max_size);
+      if (ptr == NULL)
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, (size_t) max_size);
+	  return error;		/* FIXME */
+	}
+    }
+  else
+    {
+      ptr = buf;
+    }
+
+  if (bfmt_print (1 /* BIT_STRING_HEX */ , value, ptr, max_size) == NO_ERROR)
+    {
+      CHECK_PRINT_ERROR (text_print (tout, "X", 1, NULL));
+      CHECK_PRINT_ERROR (print_quoted_str (tout, ptr, max_size - 1, MAX_DISPLAY_COLUMN));
+    }
+
+exit_on_error:
+  if (ptr != buf)
+    {
+      free_and_init (ptr);
+    }
+  return error;
+}
+
+/*
  * fprint_special_strings - print special DB_VALUE to TEXT_OUTPUT
  *    return: NO_ERROR if successful, error code otherwise
  *    tout(out): output
@@ -785,6 +863,9 @@ fprint_special_strings (TEXT_OUTPUT * tout, DB_VALUE * value)
 
       CHECK_PRINT_ERROR (print_quoted_str (tout, str_ptr, len, MAX_DISPLAY_COLUMN));
       break;
+    case DB_TYPE_CLOB:
+      CHECK_PRINT_ERROR (fprint_clob_value (tout, value));
+      break;
     case DB_TYPE_NUMERIC:
       ptr = numeric_db_value_print (value, buf);
       CHECK_PRINT_ERROR (text_print (tout, NULL, 0, !strchr (ptr, '.') ? "%s." : "%s", ptr));
@@ -820,6 +901,9 @@ fprint_special_strings (TEXT_OUTPUT * tout, DB_VALUE * value)
 	  }
 	break;
       }
+    case DB_TYPE_BLOB:
+      CHECK_PRINT_ERROR (fprint_blob_value (tout, value));
+      break;
 
       /* other stubs */
     case DB_TYPE_ERROR:

--- a/src/executables/unload_object_file.c
+++ b/src/executables/unload_object_file.c
@@ -672,7 +672,7 @@ exit_on_error:
 #define INTERNAL_BUFFER_SIZE (400)	/* bigger than DBL_MAX_DIGITS */
 
 /*
- * fprint_clob_value - print an internal CLOB DB_VALUE to TEXT_OUTPUT
+ * fprint_clob_value - print a CLOB DB_VALUE to TEXT_OUTPUT
  *    return: NO_ERROR if successful, error code otherwise
  *    tout(out): output
  *    value(in): DB_VALUE of type DB_TYPE_CLOB

--- a/src/loaddb/load_db_value_converter.cpp
+++ b/src/loaddb/load_db_value_converter.cpp
@@ -59,6 +59,7 @@ namespace cubload
   int to_db_varchar (const char *str, const size_t str_size, const attribute *attr, db_value *val);
   int to_db_make_nchar (const char *str, const size_t str_size, const attribute *attr, db_value *val);
   int to_db_make_varnchar (const char *str, const size_t str_size, const attribute *attr, db_value *val);
+  int to_db_clob (const char *str, const size_t str_size, const attribute *attr, db_value *val);
   int to_db_string (const char *str, const size_t str_size, const attribute *attr, db_value *val);
   int to_db_float (const char *str, const size_t str_size, const attribute *attr, db_value *val);
   int to_db_double (const char *str, const size_t str_size, const attribute *attr, db_value *val);
@@ -75,6 +76,8 @@ namespace cubload
   int to_db_monetary (const char *str, const size_t str_size, const attribute *attr, db_value *val);
   int to_db_varbit_from_bin_str (const char *str, const size_t str_size, const attribute *attr, db_value *val);
   int to_db_varbit_from_hex_str (const char *str, const size_t str_size, const attribute *attr, db_value *val);
+  int to_db_blob_from_bin_str (const char *str, const size_t str_size, const attribute *attr, db_value *val);
+  int to_db_blob_from_hex_str (const char *str, const size_t str_size, const attribute *attr, db_value *val);
   int to_db_elo_ext (const char *str, const size_t str_size, const attribute *attr, db_value *val);
   int to_db_elo_int (const char *str, const size_t str_size, const attribute *attr, db_value *val);
   int to_int_generic (const char *str, const size_t str_size, const attribute *attr, db_value *val);
@@ -157,6 +160,10 @@ namespace cubload
     setters_[DB_TYPE_BIT][LDR_XSTR] = &to_db_varbit_from_hex_str;
     setters_[DB_TYPE_VARBIT][LDR_BSTR] = &to_db_varbit_from_bin_str;
     setters_[DB_TYPE_VARBIT][LDR_XSTR] = &to_db_varbit_from_hex_str;
+    setters_[DB_TYPE_BLOB][LDR_BSTR] = &to_db_blob_from_bin_str;
+    setters_[DB_TYPE_BLOB][LDR_XSTR] = &to_db_blob_from_hex_str;
+
+    setters_[DB_TYPE_CLOB][LDR_STR] = &to_db_clob;
 
     setters_[DB_TYPE_BFILE][LDR_ELO_EXT] = &to_db_elo_ext;
     setters_[DB_TYPE_BFILE][LDR_ELO_INT] = &to_db_elo_int;
@@ -423,6 +430,30 @@ namespace cubload
   int to_db_make_varnchar (const char *str, const size_t str_size, const attribute *attr, db_value *val)
   {
     return to_db_generic_char (DB_TYPE_VARNCHAR, str, str_size, attr, val);
+  }
+
+  int
+  to_db_clob (const char *str, const size_t str_size, const attribute *attr, db_value *val)
+  {
+    /*
+     * Internal CLOB is stored inline like a character string, but it is not a
+     * fixed-precision type: the trailing-pad truncation that to_db_generic_char
+     * performs for CHAR/VARCHAR is meaningless here. A CLOB only has the single
+     * absolute LOB size limit (DB_MAX_LOB_PRECISION), so apply a plain bound check.
+     */
+    int char_count = 0;
+    const tp_domain &domain = attr->get_domain ();
+    INTL_CODESET codeset = (INTL_CODESET) domain.codeset;
+
+    intl_char_count ((unsigned char *) str, (int) str_size, codeset, &char_count);
+
+    if (char_count > domain.precision)
+      {
+	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_IT_DATA_OVERFLOW, 1, pr_type_name (DB_TYPE_CLOB));
+	return ER_IT_DATA_OVERFLOW;
+      }
+
+    return db_make_clob (val, domain.precision, str, (int) str_size, codeset, domain.collation_id);
   }
 
   int
@@ -758,6 +789,24 @@ namespace cubload
     db_value_clear (&temp);
 
     return error_code;
+  }
+
+  /*
+   * Internal BLOB is stored inline like a bit string and currently shares the
+   * VARBIT conversion path (the target domain is resolved from the attribute,
+   * so the cast already lands on DB_TYPE_BLOB). Keep dedicated entry points so
+   * BLOB-specific handling can diverge here without touching the VARBIT path.
+   */
+  int
+  to_db_blob_from_bin_str (const char *str, const size_t str_size, const attribute *attr, db_value *val)
+  {
+    return to_db_varbit_from_bin_str (str, str_size, attr, val);
+  }
+
+  int
+  to_db_blob_from_hex_str (const char *str, const size_t str_size, const attribute *attr, db_value *val)
+  {
+    return to_db_varbit_from_hex_str (str, str_size, attr, val);
   }
 
   int

--- a/src/loaddb/load_db_value_converter.cpp
+++ b/src/loaddb/load_db_value_converter.cpp
@@ -792,21 +792,93 @@ namespace cubload
   }
 
   /*
-   * Internal BLOB is stored inline like a bit string and currently shares the
-   * VARBIT conversion path (the target domain is resolved from the attribute,
-   * so the cast already lands on DB_TYPE_BLOB). Keep dedicated entry points so
-   * BLOB-specific handling can diverge here without touching the VARBIT path.
+   * Internal BLOB is stored inline like a bit string, but it must be built with
+   * the BLOB primitive (db_make_blob), not by borrowing the VARBIT conversion
+   * path. The on-disk layout being identical today is incidental; routing BLOB
+   * through VARBIT functions couples the two types and would break if the BLOB
+   * storage diverges later. The literal is parsed into a raw bit buffer here and
+   * handed directly to db_make_blob.
    */
   int
   to_db_blob_from_bin_str (const char *str, const size_t str_size, const attribute *attr, db_value *val)
   {
-    return to_db_varbit_from_bin_str (str, str_size, attr, val);
+    int error_code = NO_ERROR;
+    char *bstring = NULL;
+    std::size_t dest_size;
+
+    dest_size = (str_size + 7) / 8;
+
+    bstring = (char *) db_private_alloc (NULL, dest_size + 1);
+    if (bstring == NULL)
+      {
+	error_code = er_errid ();
+	assert (error_code != NO_ERROR);
+
+	return error_code;
+      }
+
+    if (qstr_bit_to_bin (bstring, (int) dest_size, const_cast<char *> (str), (int) str_size) != (int) str_size)
+      {
+	db_private_free_and_init (NULL, bstring);
+
+	error_code = ER_OBJ_DOMAIN_CONFLICT;
+	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_code, 1, attr->get_name ());
+
+	return error_code;
+      }
+
+    error_code = db_make_blob (val, DB_MAX_LOB_PRECISION, bstring, (int) str_size);
+    if (error_code != NO_ERROR)
+      {
+	db_private_free_and_init (NULL, bstring);
+	return error_code;
+      }
+
+    /* val takes ownership of bstring */
+    val->need_clear = true;
+
+    return error_code;
   }
 
   int
   to_db_blob_from_hex_str (const char *str, const size_t str_size, const attribute *attr, db_value *val)
   {
-    return to_db_varbit_from_hex_str (str, str_size, attr, val);
+    int error_code = NO_ERROR;
+    char *bstring = NULL;
+    std::size_t dest_size;
+
+    dest_size = (str_size + 1) / 2;
+
+    bstring = (char *) db_private_alloc (NULL, dest_size + 1);
+    if (bstring == NULL)
+      {
+	error_code = er_errid ();
+	assert (error_code != NO_ERROR);
+
+	return error_code;
+      }
+
+    if (qstr_hex_to_bin (bstring, (int) dest_size, const_cast<char *> (str), (int) str_size) != (int) str_size)
+      {
+	db_private_free_and_init (NULL, bstring);
+
+	error_code = ER_OBJ_DOMAIN_CONFLICT;
+	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_code, 1, attr->get_name ());
+
+	return error_code;
+      }
+
+    error_code = db_make_blob (val, DB_MAX_LOB_PRECISION, bstring, ((int) str_size) * 4);
+    if (error_code != NO_ERROR)
+      {
+	db_private_free_and_init (NULL, bstring);
+	return error_code;
+      }
+
+    /* val takes ownership of bstring */
+    val->need_clear = true;
+
+    return error_code;
   }
 
   int

--- a/src/loaddb/load_sa_loader.cpp
+++ b/src/loaddb/load_sa_loader.cpp
@@ -562,11 +562,14 @@ static int ldr_int_db_short (LDR_CONTEXT *context, const char *str, size_t len, 
 static int ldr_str_elem (LDR_CONTEXT *context, const char *str, size_t len, DB_VALUE *val);
 static int ldr_str_db_char (LDR_CONTEXT *context, const char *str, size_t len, SM_ATTRIBUTE *att);
 static int ldr_str_db_varchar (LDR_CONTEXT *context, const char *str, size_t len, SM_ATTRIBUTE *att);
+static int ldr_str_db_clob (LDR_CONTEXT *context, const char *str, size_t len, SM_ATTRIBUTE *att);
 static int ldr_str_db_generic (LDR_CONTEXT *context, const char *str, size_t len, SM_ATTRIBUTE *att);
 static int ldr_bstr_elem (LDR_CONTEXT *context, const char *str, size_t len, DB_VALUE *val);
 static int ldr_bstr_db_varbit (LDR_CONTEXT *context, const char *str, size_t len, SM_ATTRIBUTE *att);
+static int ldr_bstr_db_blob (LDR_CONTEXT *context, const char *str, size_t len, SM_ATTRIBUTE *att);
 static int ldr_xstr_elem (LDR_CONTEXT *context, const char *str, size_t len, DB_VALUE *val);
 static int ldr_xstr_db_varbit (LDR_CONTEXT *context, const char *str, size_t len, SM_ATTRIBUTE *att);
+static int ldr_xstr_db_blob (LDR_CONTEXT *context, const char *str, size_t len, SM_ATTRIBUTE *att);
 static int ldr_nstr_elem (LDR_CONTEXT *context, const char *str, size_t len, DB_VALUE *val);
 static int ldr_nstr_db_varnchar (LDR_CONTEXT *context, const char *str, size_t len, SM_ATTRIBUTE *att);
 static int ldr_numeric_elem (LDR_CONTEXT *context, const char *str, size_t len, DB_VALUE *val);
@@ -2843,6 +2846,46 @@ ldr_str_db_generic (LDR_CONTEXT *context, const char *str, size_t len, SM_ATTRIB
 }
 
 /*
+ * ldr_str_db_clob -
+ *    return:
+ *    context():
+ *    str():
+ *    len():
+ *    att():
+ */
+static int
+ldr_str_db_clob (LDR_CONTEXT *context, const char *str, size_t len, SM_ATTRIBUTE *att)
+{
+  int err = NO_ERROR;
+  int char_count = 0;
+  DB_VALUE val;
+
+  db_make_null (&val);
+
+  /*
+   * Internal CLOB is stored inline like a character string, but it is not a
+   * fixed-precision type: the trailing-pad truncation that ldr_str_db_varchar
+   * performs for CHAR/VARCHAR is meaningless here. A CLOB only has the single
+   * absolute LOB size limit (att->domain->precision == DB_MAX_LOB_PRECISION),
+   * so apply a plain bound check.
+   */
+  intl_char_count ((unsigned char *) str, (int) len, (INTL_CODESET) att->domain->codeset, &char_count);
+  if (char_count > att->domain->precision)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_IT_DATA_OVERFLOW, 1, db_get_type_name (DB_TYPE_CLOB));
+      CHECK_PARSE_ERR (err, ER_IT_DATA_OVERFLOW, context, DB_TYPE_CLOB, str);
+    }
+
+  CHECK_ERR (err, db_make_clob (&val, att->domain->precision, str, (int) len, att->domain->codeset,
+				att->domain->collation_id));
+  CHECK_ERR (err, ldr_generic (context, &val));
+
+error_exit:
+  db_value_clear (&val);
+  return err;
+}
+
+/*
  * ldr_bstr_elem -
  *    return:
  *    context():
@@ -2920,6 +2963,25 @@ ldr_bstr_db_varbit (LDR_CONTEXT *context, const char *str, size_t len, SM_ATTRIB
 error_exit:
   db_value_clear (&val);
   return err;
+}
+
+/*
+ * ldr_bstr_db_blob -
+ *    return:
+ *    context():
+ *    str():
+ *    len():
+ *    att():
+ * Note:
+ *    Internal BLOB is stored inline like a bit string and currently shares the
+ *    VARBIT loader path (ldr_bstr_elem resolves the target domain from context,
+ *    so the cast already lands on DB_TYPE_BLOB). Keep a dedicated entry point so
+ *    BLOB-specific handling can diverge here without touching the VARBIT path.
+ */
+static int
+ldr_bstr_db_blob (LDR_CONTEXT *context, const char *str, size_t len, SM_ATTRIBUTE *att)
+{
+  return ldr_bstr_db_varbit (context, str, len, att);
 }
 
 /*
@@ -3008,6 +3070,25 @@ ldr_xstr_db_varbit (LDR_CONTEXT *context, const char *str, size_t len, SM_ATTRIB
 error_exit:
   db_value_clear (&val);
   return err;
+}
+
+/*
+ * ldr_xstr_db_blob -
+ *    return:
+ *    context():
+ *    str():
+ *    len():
+ *    att():
+ * Note:
+ *    Internal BLOB is stored inline like a bit string and currently shares the
+ *    VARBIT loader path (ldr_xstr_elem resolves the target domain from context,
+ *    so the cast already lands on DB_TYPE_BLOB). Keep a dedicated entry point so
+ *    BLOB-specific handling can diverge here without touching the VARBIT path.
+ */
+static int
+ldr_xstr_db_blob (LDR_CONTEXT *context, const char *str, size_t len, SM_ATTRIBUTE *att)
+{
+  return ldr_xstr_db_varbit (context, str, len, att);
 }
 
 /*
@@ -5382,6 +5463,15 @@ ldr_act_add_attr (LDR_CONTEXT *context, const char *attr_name, size_t len)
     case DB_TYPE_VARBIT:
       attdesc->setter[LDR_BSTR] = &ldr_bstr_db_varbit;
       attdesc->setter[LDR_XSTR] = &ldr_xstr_db_varbit;
+      break;
+
+    case DB_TYPE_BLOB:
+      attdesc->setter[LDR_BSTR] = &ldr_bstr_db_blob;
+      attdesc->setter[LDR_XSTR] = &ldr_xstr_db_blob;
+      break;
+
+    case DB_TYPE_CLOB:
+      attdesc->setter[LDR_STR] = &ldr_str_db_clob;
       break;
 
     case DB_TYPE_NCHAR:

--- a/src/loaddb/load_sa_loader.cpp
+++ b/src/loaddb/load_sa_loader.cpp
@@ -2973,15 +2973,47 @@ error_exit:
  *    len():
  *    att():
  * Note:
- *    Internal BLOB is stored inline like a bit string and currently shares the
- *    VARBIT loader path (ldr_bstr_elem resolves the target domain from context,
- *    so the cast already lands on DB_TYPE_BLOB). Keep a dedicated entry point so
- *    BLOB-specific handling can diverge here without touching the VARBIT path.
+ *    Internal BLOB is stored inline like a bit string, but it must be built with
+ *    the BLOB primitive (db_make_blob), not by borrowing the VARBIT loader path.
+ *    The identical on-disk layout today is incidental; routing BLOB through the
+ *    VARBIT functions couples the two types and would break if the BLOB storage
+ *    diverges later. The bit literal is parsed into a raw buffer and handed to
+ *    db_make_blob directly.
  */
 static int
 ldr_bstr_db_blob (LDR_CONTEXT *context, const char *str, size_t len, SM_ATTRIBUTE *att)
 {
-  return ldr_bstr_db_varbit (context, str, len, att);
+  int err = NO_ERROR;
+  size_t dest_size;
+  char *bstring = NULL;
+  DB_VALUE val;
+
+  db_make_null (&val);
+
+  dest_size = (len + 7) / 8;
+  CHECK_PTR (err, bstring = (char *) db_private_alloc (NULL, dest_size + 1));
+
+  if (qstr_bit_to_bin (bstring, (int) dest_size, (char *) str, (int) len) != (int) len)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OBJ_DOMAIN_CONFLICT, 1, ldr_attr_name (context));
+      CHECK_PARSE_ERR (err, ER_OBJ_DOMAIN_CONFLICT, context, DB_TYPE_BLOB, str);
+    }
+
+  CHECK_ERR (err, db_make_blob (&val, DB_MAX_LOB_PRECISION, bstring, (int) len));
+
+  /* val takes ownership of this piece of memory */
+  val.need_clear = true;
+  bstring = NULL;
+
+  CHECK_ERR (err, ldr_generic (context, &val));
+
+error_exit:
+  if (bstring != NULL)
+    {
+      db_private_free_and_init (NULL, bstring);
+    }
+  db_value_clear (&val);
+  return err;
 }
 
 /*
@@ -3080,15 +3112,47 @@ error_exit:
  *    len():
  *    att():
  * Note:
- *    Internal BLOB is stored inline like a bit string and currently shares the
- *    VARBIT loader path (ldr_xstr_elem resolves the target domain from context,
- *    so the cast already lands on DB_TYPE_BLOB). Keep a dedicated entry point so
- *    BLOB-specific handling can diverge here without touching the VARBIT path.
+ *    Internal BLOB is stored inline like a bit string, but it must be built with
+ *    the BLOB primitive (db_make_blob), not by borrowing the VARBIT loader path.
+ *    The identical on-disk layout today is incidental; routing BLOB through the
+ *    VARBIT functions couples the two types and would break if the BLOB storage
+ *    diverges later. The hex literal is parsed into a raw buffer and handed to
+ *    db_make_blob directly.
  */
 static int
 ldr_xstr_db_blob (LDR_CONTEXT *context, const char *str, size_t len, SM_ATTRIBUTE *att)
 {
-  return ldr_xstr_db_varbit (context, str, len, att);
+  int err = NO_ERROR;
+  size_t dest_size;
+  char *bstring = NULL;
+  DB_VALUE val;
+
+  db_make_null (&val);
+
+  dest_size = (len + 1) / 2;
+  CHECK_PTR (err, bstring = (char *) db_private_alloc (NULL, dest_size + 1));
+
+  if (qstr_hex_to_bin (bstring, (int) dest_size, (char *) str, (int) len) != (int) len)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OBJ_DOMAIN_CONFLICT, 1, ldr_attr_name (context));
+      CHECK_PARSE_ERR (err, ER_OBJ_DOMAIN_CONFLICT, context, DB_TYPE_BLOB, str);
+    }
+
+  CHECK_ERR (err, db_make_blob (&val, DB_MAX_LOB_PRECISION, bstring, (int) len * 4));
+
+  /* val takes ownership of this piece of memory */
+  val.need_clear = true;
+  bstring = NULL;
+
+  CHECK_ERR (err, ldr_generic (context, &val));
+
+error_exit:
+  if (bstring != NULL)
+    {
+      db_private_free_and_init (NULL, bstring);
+    }
+  db_value_clear (&val);
+  return err;
 }
 
 /*


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26784

### Purpose

CBRD-26224 에서 INTERNAL BLOB / CLOB 을 inline 타입으로 추가하면서, 
유틸리티 경로에 남아 있던 develop 머지 차단 항목과 누락된 BLOB / CLOB 분기를 정합화한다.

1. `src/executables/csql_result.c` 의 임시 `assert_release (false)` (TODO: develop 머지 전 제거) 를 제거한다.
   legitimate CLOB-as-char / BLOB-as-bit 결과를 SELECT 할 때 csql 이 abort 되던 문제를 해소한다.
2. `unloaddb` / `loaddb` 에 INTERNAL BLOB / CLOB 명시 분기를 추가하여 export -> import 라운드트립을 보장한다.
   (기존에는 BFILE / CFILE 분기만 있고 BLOB / CLOB 은 일반 string / bit 경로에 묻혀 라운드트립이 검증되지 않았다.)

INTERNAL CLOB 은 문자열, INTERNAL BLOB 은 hex 비트 문자열로 직렬화하며, 기존 string / hex 리터럴 토큰을
재사용하므로 load grammar 변경은 없다.

.
### Implementation

**`src/executables/csql_result.c` — `get_current_result`**

디버깅용 임시 assert를 제거한다. 코드 생성 후 실수로 지우지 못한 부분이다.
잔존하는 정식 assert 가 이미 CLOB->char / BLOB->bit 케이스를 허용하고,
결과값 type 기준의 기존 switch 가 CLOB 은 문자열로, BLOB 은 bit 로 정상 출력한다.

```diff
-      //TODO : develop에 merge하기 전에 지우기
-      if ((TP_IS_CHAR_TYPE (value_type) && (result_info->attr_types[i] == DB_TYPE_CLOB))
-	  || (TP_IS_BIT_TYPE (value_type) && (result_info->attr_types[i] == DB_TYPE_BLOB)))
-	{
-	  assert_release (false);
-	}
```

---
**`src/executables/unload_object_file.c` — `fprint_clob_value` / `fprint_blob_value`**

`fprint_special_strings` 의 DB_TYPE_CLOB / DB_TYPE_BLOB case 에서 호출한다. CLOB 은 quoted string,
BLOB 은 `X'..'` hex 로 출력하며, 기존 BIT / VARBIT 출력 규칙과 동일하다.

```diff
+    case DB_TYPE_CLOB:
+      CHECK_PRINT_ERROR (fprint_clob_value (tout, value));
+      break;
...
+    case DB_TYPE_BLOB:
+      CHECK_PRINT_ERROR (fprint_blob_value (tout, value));
+      break;
```

---
**`src/loaddb/load_db_value_converter.cpp` (server) / `src/loaddb/load_sa_loader.cpp` (SA)**

- CLOB: `LDR_STR` -> `to_db_clob` / `ldr_str_db_clob`. precision bound check 후 `db_make_clob`.
- BLOB: `LDR_BSTR` / `LDR_XSTR` -> VARBIT 변환 경로 재사용 후 도메인 캐스트로 DB_TYPE_BLOB 에 착지.

```diff
+    setters_[DB_TYPE_BLOB][LDR_BSTR] = &to_db_blob_from_bin_str;
+    setters_[DB_TYPE_BLOB][LDR_XSTR] = &to_db_blob_from_hex_str;
+    setters_[DB_TYPE_CLOB][LDR_STR]  = &to_db_clob;
```

unload (`X'..'` / quoted string) 와 load (`LDR_XSTR` / `LDR_STR`) 의 포맷이 대칭이라 라운드트립이 무손실로 닫힌다.

.

### Test

| 케이스 | 결과 |
|---|---|
| csql: BLOB / CLOB 컬럼 SELECT (NULL / empty / 한글 / 바이너리 / 0~16KB) | OK, abort 없음. CLOB=문자열, BLOB=`X'..'` |
| unloaddb -> loaddb 라운드트립 (src / dst 결과 지문 byte 비교) | OK, 무손실 |
| backup -> restore 라운드트립 | OK, 무손실 |

자체 회귀 스위트 3/3 PASS (26 assertion). debug 빌드 (4파일 재컴파일 exit 0) / codestyle 통과.

.

### Remarks
- cubrid_log / CDC 디코딩은 CBRD-26803, dblink 미지원 정렬은 CBRD-26802 에서 각각 처리되었다.
- PL / method 의 BLOB / CLOB 미지원 표기는 CBRD-26224 에서 BFILE / CFILE 와 동일 case 로 이미 정렬되어 있다.


.
  ## CUBRID 유틸리티 × INTERNAL LOB(BLOB/CLOB) 지원/검증 결과

  ### 1. 데이터를 다루는 유틸 — LOB 정상 지원해야 함

  | 유틸 | LOB 지원 | 검증 |
  |---|---|---|
  | `csql` | 정상 지원 | OK |
  | `unloaddb` | 정상 지원 | OK |
  | `loaddb` | 정상 지원 | OK |
  | `backupdb` | 정상 지원 | OK |
  | `restoredb` | 정상 지원 | OK |
  | `compactdb` | 정상 지원 | OK |
  | `checkdb` | 정상 지원 | OK |
  | `diagdb` | 정상 지원 | OK |
  | `copydb` | 정상 지원 | OK |
  | `vacuumdb` | 정상 지원 | OK |
  | `optimizedb` | 정상 지원 | OK |

  ### 2. LOB을 지원하지 않아야 하는 경로 — 차단되어야 함

  | 경로 | LOB 지원 | 검증 |
  |---|---|---|
  | `dblink` | 미지원 (차단) | OK |
  | 저장 프로시저(PL) | 미지원 (차단) | OK |
  | 메서드(method) | 미지원 (차단) | OK |

  ### 3. 컬럼 값을 다루지 않는 유틸 — LOB과 무관

  | 유틸 | LOB 지원 | 검증 |
  |---|---|---|
  | `createdb` `deletedb` `renamedb` `installdb` `alterdbhost` | 해당 없음 | - |
  | `spacedb` `statdump` `plandump` `paramdump` | 해당 없음 | - |
  | `tranlist` `killtran` `lockdb` | 해당 없음 | - |
  | `changemode` `applyinfo` `synccolldb` | 해당 없음 | - |


