### PR TITLE
[CBRD-00000] POC: shell test baseline (release build) - do not merge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,6 +327,7 @@ jobs:
                         mkdir -p \$CCACHE_DIR
                         ccache --max-size=5G
                         ccache -z
+                        # POC: shell debug-build measurement (throwaway, do not merge)
                         scl enable devtoolset-8 -- /entrypoint.sh build
                         ccache -s
                   - save_cache:


### PR DESCRIPTION
**Throwaway POC PR — DO NOT MERGE / DO NOT REVIEW.**

Release-build shell test **baseline** for a debug-build comparison POC.
Sibling of #poc/shell-debug; both branched from the same develop HEAD (\`8a64a3a1\`).

- Only change: a no-op comment in \`.circleci/config.yml\` (so a PR diff exists to enable the comment trigger). Build stays release (RelWithDebInfo).
- Trigger: comment \`shell\` on this PR (off-peak), **release ×1**.
- Will be closed and branch deleted after the POC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)