### PR TITLE
[CBRD-26864] Prevent owner change when renaming a table via ALTER TABLE by adding the missing owner-change check

### DIFF
--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -1588,6 +1588,15 @@ do_alter_clause_rename_entity (PARSER_CONTEXT * const parser, PT_NODE * const al
   assert (alter_code == PT_RENAME_ENTITY);
   assert (alter->info.alter.super.resolution_list == NULL);
 
+  const char *old_qualifier_name = pt_get_qualifier_name (parser, alter->info.alter.entity_name);
+  const char *new_qualifier_name = pt_get_qualifier_name (parser, alter->info.alter.alter_clause.rename.new_name);
+
+  if (old_qualifier_name && new_qualifier_name && intl_identifier_casecmp (old_qualifier_name, new_qualifier_name) != 0)
+    {
+      ERROR_SET_ERROR (error_code, ER_SM_RENAME_CANT_ALTER_OWNER);
+      goto error_exit;
+    }
+
   error_code = do_rename_internal (old_name, new_name);
   if (error_code != NO_ERROR)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26864

### Purpose

**RENAME TABLE** 경로에는 있던 소유자 변경 차단 가드가 **ALTER TABLE \<old\> RENAME {AS|TO} \<new\>** 경로에는 누락되어 있었다. 그 결과 다른 소유자로 해석되는 rename 시 테이블의 소유자 오브젝트는 그대로인 채 `unique_name`만 변경되어 카탈로그 불일치가 발생했다. 이 PR은 누락된 가드를 추가해 의도치 않은 소유자 변경을 묵시적으로 적용하지 않고 에러를 발생시킨다.

### Implementation

- `do_alter_clause_rename_entity()`에 소유자 한정자 검사를 추가: old/new 이름의 `pt_get_qualifier_name()`을 `intl_identifier_casecmp()`로 비교한다.
- 한정자가 다르면 `ER_SM_RENAME_CANT_ALTER_OWNER`를 발생시켜 **RENAME TABLE**(`do_rename()`) 경로와 동일하게 동작하도록 맞춘다.

### Remarks

- `sm_rename_class()`는 의도적으로 변경하지 않았다. 이 함수는 `do_rename_partition()`을 통해 파티션 서브클래스마다 재귀 호출되므로, 정책은 statement 계층에 두어 중복 검사를 피한다.

---

Add the owner-qualifier check to `do_alter_clause_rename_entity()` that the **RENAME TABLE** path already had, raising `ER_SM_RENAME_CANT_ALTER_OWNER` when the old and new owners differ.