### PR TITLE
[CBRD-26612] Resolve estimated_*/INDEX_CARDINALITY class name by current schema

### DIFF
--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -9162,7 +9162,7 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
 	      /* text and db_value still hold the old name; clear so both are refreshed from the qualified one */
 	      arg1->info.value.text = NULL;
 	      arg1->info.value.db_value_is_initialized = false;
-	      pt_value_to_db (parser, arg1);
+	      (void) pt_value_to_db (parser, arg1);
 	    }
 	}
       break;

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -9145,6 +9145,35 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
 	}
       break;
 
+    case PT_INDEX_CARDINALITY:
+    case PT_ESTIMATED_TABLE_ROWS:
+    case PT_ESTIMATED_AVG_ROW_LENGTH:
+    case PT_ESTIMATED_DATA_LENGTH:
+    case PT_ESTIMATED_DATA_FREE:
+      /* qualify a constant class name with the current schema; the server resolves it by the 'owner.name' form */
+      if (PT_IS_VALUE_NODE (arg1) && PT_IS_CHAR_STRING_TYPE (arg1->type_enum)
+	  && arg1->info.value.data_value.str != NULL)
+	{
+	  char realname[DB_MAX_IDENTIFIER_LENGTH];
+
+	  if (sm_user_specified_name ((const char *) PT_VALUE_GET_BYTES (arg1), realname,
+				      DB_MAX_IDENTIFIER_LENGTH) != NULL)
+	    {
+	      arg1->info.value.data_value.str = pt_append_bytes (parser, NULL, realname, strlen (realname));
+	      arg1->info.value.text = NULL;
+	      if (arg1->info.value.db_value.need_clear)
+		{
+		  pr_clear_value (&arg1->info.value.db_value);
+		}
+	      if (arg1->info.value.db_value_is_initialized)
+		{
+		  arg1->info.value.db_value_is_initialized = false;
+		  pt_value_to_db (parser, arg1);
+		}
+	    }
+	}
+      break;
+
     default:
       break;
     }

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -9150,9 +9150,16 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
     case PT_ESTIMATED_AVG_ROW_LENGTH:
     case PT_ESTIMATED_DATA_LENGTH:
     case PT_ESTIMATED_DATA_FREE:
-      /* qualify a constant class name with the current schema; the server resolves it by the 'owner.name' form */
+      /* Qualify a bare constant class-name literal with the current schema (e.g. 't1' -> 'user1.t1'),
+       * the same way a normal table reference is resolved.  Only a dot-less literal shorter than the
+       * identifier limit is handled here: sm_user_specified_name () assumes a validated identifier and
+       * would trip its length/format asserts -- or overrun its fixed buffer in a release build -- on an
+       * arbitrary value.  An already-qualified ('owner.name'), malformed, or over-length value is left
+       * unchanged for the server, which lower-cases and resolves it (or returns NULL) on its own. */
       if (PT_IS_VALUE_NODE (arg1) && PT_IS_CHAR_STRING_TYPE (arg1->type_enum)
-	  && arg1->info.value.data_value.str != NULL)
+	  && arg1->info.value.data_value.str != NULL
+	  && arg1->info.value.data_value.str->length < DB_MAX_IDENTIFIER_LENGTH
+	  && memchr (PT_VALUE_GET_BYTES (arg1), '.', arg1->info.value.data_value.str->length) == NULL)
 	{
 	  char realname[DB_MAX_IDENTIFIER_LENGTH];
 

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -9150,33 +9150,19 @@ pt_eval_expr_type (PARSER_CONTEXT * parser, PT_NODE * node)
     case PT_ESTIMATED_AVG_ROW_LENGTH:
     case PT_ESTIMATED_DATA_LENGTH:
     case PT_ESTIMATED_DATA_FREE:
-      /* Qualify a bare constant class-name literal with the current schema (e.g. 't1' -> 'user1.t1'),
-       * the same way a normal table reference is resolved.  Only a dot-less literal shorter than the
-       * identifier limit is handled here: sm_user_specified_name () assumes a validated identifier and
-       * would trip its length/format asserts -- or overrun its fixed buffer in a release build -- on an
-       * arbitrary value.  An already-qualified ('owner.name'), malformed, or over-length value is left
-       * unchanged for the server, which lower-cases and resolves it (or returns NULL) on its own. */
       if (PT_IS_VALUE_NODE (arg1) && PT_IS_CHAR_STRING_TYPE (arg1->type_enum)
-	  && arg1->info.value.data_value.str != NULL
-	  && arg1->info.value.data_value.str->length < DB_MAX_IDENTIFIER_LENGTH
-	  && memchr (PT_VALUE_GET_BYTES (arg1), '.', arg1->info.value.data_value.str->length) == NULL)
+	  && arg1->info.value.data_value.str != NULL && arg1->info.value.data_value.str->length < DB_MAX_CLASS_LENGTH)
 	{
+	  const char *name = (const char *) PT_VALUE_GET_BYTES (arg1);
 	  char realname[DB_MAX_IDENTIFIER_LENGTH];
 
-	  if (sm_user_specified_name ((const char *) PT_VALUE_GET_BYTES (arg1), realname,
-				      DB_MAX_IDENTIFIER_LENGTH) != NULL)
+	  if (strchr (name, '.') == NULL && sm_user_specified_name (name, realname, DB_MAX_IDENTIFIER_LENGTH) != NULL)
 	    {
 	      arg1->info.value.data_value.str = pt_append_bytes (parser, NULL, realname, strlen (realname));
+	      /* text and db_value still hold the old name; clear so both are refreshed from the qualified one */
 	      arg1->info.value.text = NULL;
-	      if (arg1->info.value.db_value.need_clear)
-		{
-		  pr_clear_value (&arg1->info.value.db_value);
-		}
-	      if (arg1->info.value.db_value_is_initialized)
-		{
-		  arg1->info.value.db_value_is_initialized = false;
-		  pt_value_to_db (parser, arg1);
-		}
+	      arg1->info.value.db_value_is_initialized = false;
+	      pt_value_to_db (parser, arg1);
 	    }
 	}
       break;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26612

### Purpose
- `estimated_table_rows` / `estimated_avg_row_length` / `estimated_data_length` / `estimated_data_free` 와 `INDEX_CARDINALITY` 에 owner 없이 테이블 이름만 넘겨도 현재 스키마 기준으로 해석되도록 한다.
- 서버는 `unique_name`(`owner.name`)을 정확히 일치시켜 조회하므로, 사용자가 `estimated_table_rows('t1')` 처럼 호출하면 조회 실패로 `NULL` 이 반환되던 동작을 바로잡는다.

### Implementation
- 상수 문자열 리터럴인 클래스명 인자를 타입 검사 단계에서 현재 스키마 이름으로 qualify 한다 (예: `'t1'` → `'user1.t1'`). 일반 테이블 참조와 동일한 규칙을 따른다.
- 이미 `owner.name` 형태이거나 시스템 클래스명인 인자는 그대로 둔다.
- 컬럼 인자(`INFORMATION_SCHEMA` 뷰가 넘기는 `unique_name`)는 변경하지 않는다.
- 서버 측 평가 로직은 변경 없음 — 클라이언트 측 이름 qualify 만 추가.

### Remarks