### PR TITLE
[CBRD-26870] Set DBLink remote column collation to match its codeset

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -38,6 +38,7 @@
 #include "object_primitive.h"
 #include "memory_alloc.h"
 #include "intl_support.h"
+#include "language_support.h"
 #include "memory_hash.h"
 #include "system_parameter.h"
 #include "object_print.h"
@@ -5187,6 +5188,13 @@ pt_dblink_table_fill_attr_def (PARSER_CONTEXT * parser, PT_NODE * attr_def_node,
       dt->info.data_type.dec_precision = attr->dec_precision;
       dt->info.data_type.precision = attr->precision;
       dt->info.data_type.units = attr->charset;
+      /* The remote column metadata from CCI carries a codeset (units) but no collation.
+       * Leaving collation_id at its default (0 == LANG_COLL_ISO_BINARY) breaks the
+       * invariant in pt_check_expr_collation that an equal collation id implies an equal
+       * codeset: a remote UTF8 column would keep an ISO88591 collation, which asserts in
+       * debug builds and silently yields wrong results in release. Assign the binary
+       * collation that matches the codeset so the id and codeset stay consistent. */
+      dt->info.data_type.collation_id = LANG_GET_BINARY_COLLATION (attr->charset);
     }
 
   attr_def_node->data_type = dt;

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -5188,12 +5188,10 @@ pt_dblink_table_fill_attr_def (PARSER_CONTEXT * parser, PT_NODE * attr_def_node,
       dt->info.data_type.dec_precision = attr->dec_precision;
       dt->info.data_type.precision = attr->precision;
       dt->info.data_type.units = attr->charset;
-      /* The remote column metadata from CCI carries a codeset (units) but no collation.
-       * Leaving collation_id at its default (0 == LANG_COLL_ISO_BINARY) breaks the
-       * invariant in pt_check_expr_collation that an equal collation id implies an equal
-       * codeset: a remote UTF8 column would keep an ISO88591 collation, which asserts in
-       * debug builds and silently yields wrong results in release. Assign the binary
-       * collation that matches the codeset so the id and codeset stay consistent. */
+      /* CCI remote-column metadata carries a codeset (units) but no collation;
+       * collation_id then defaults to 0 (LANG_COLL_ISO_BINARY), violating the
+       * pt_check_expr_collation invariant that equal collation_id implies equal
+       * codeset. Assign the codeset's binary collation to keep them consistent. */
       dt->info.data_type.collation_id = LANG_GET_BINARY_COLLATION (attr->charset);
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26870

### Purpose

DBLink 원격 문자열 컬럼의 codeset이 로컬 DB와 다를 때(예: 로컬 ISO88591, 원격 UTF8),
collation-민감 연산(`||`, `=`, `LIKE`)에서 로컬 피연산자와 함께 쓰면 올바르게 처리되지 않는
버그를 수정한다.

**근본 원인**: 원격 컬럼의 data type을 만들 때 codeset(`units`)은 CCI 결과셋 메타데이터에서
채우지만, `collation_id`는 기본값 `0`(`LANG_COLL_ISO_BINARY`)으로 남는다. CCI가 컬럼의 charset은
노출하지만 collation은 노출하지 않기 때문이다. 이로 인해 `pt_check_expr_collation()`의 불변식
(collation id가 같으면 codeset도 같다)이 깨진다 — 원격 UTF8 컬럼이 ISO88591 collation을 유지해,
로컬 피연산자와의 codeset 불일치가 감지되지 않는다.

**증상**:
- **debug**: `pt_check_expr_collation()`의 codeset assertion에서 SIGABRT
  (`type_checking.c`, `arg1_coll_inf.codeset == arg2_coll_inf.codeset`).
- **release**: coercion이 조용히 생략되어 서로 다른 codeset의 raw 바이트가 비교/연결됨 —
  ASCII 데이터에서만 맞고, 비-ASCII에서는 silent wrong.

원격 codeset 수집·data type 빌드 경로가 공통이므로 원격 벤더(CUBRID / MySQL / Oracle)와
무관하게 발생한다.

### Implementation

`src/parser/name_resolution.c` · `pt_dblink_table_fill_attr_def()`:

- collation id와 codeset이 일관되도록, 컬럼 codeset에 대응하는 binary collation을 부여한다:
  ```c
  dt->info.data_type.collation_id = LANG_GET_BINARY_COLLATION (attr->charset);
  ```
- `LANG_GET_BINARY_COLLATION`을 위해 `#include "language_support.h"` 추가.

원격 컬럼이 `(coll_id = <codeset>_BINARY, codeset = <codeset>)`로 정규화되면 "동일 coll_id"
분기로 잘못 빠지지 않고, type checking이 정상적인 `pt_common_collation` 경로를 타므로 assertion이
안전해진다.

### Remarks

- 수정 후 연산자 동작 (cross-codeset, 원격 UTF8 × 로컬 ISO 리터럴):
  - `=`, `||`, `>=` (coercible): 로컬 리터럴이 원격 codeset으로 coerce되어 정상 수행
    (이전: debug crash / release silent wrong).
  - `LIKE` (cross-codeset 비강제): `ERROR: Context requires compatible collations.`로 올바르게
    거부됨. 이는 as-is 대비 **동작 변경**이다(이전엔 cross-codeset `LIKE`가 조용히 행을 반환).
    리터럴을 매치해야 하면 우회: `LIKE _utf8'a%'` 또는 `LIKE 'a%' COLLATE utf8_bin`.
- 한계: 원격 컬럼에는 codeset에 대응하는 **binary** collation만 부여되며, 원격의 실제 정렬 규칙
  (대소문자 무시 / locale)은 여전히 반영되지 않는다. CCI 메타데이터(`T_CCI_COL_INFO`)가 charset만
  노출하고 collation은 노출하지 않는 데서 기인하는 기존 한계.