### PR TITLE
[CBRD-26838] Replace malloc+strcpy with strdup where safe

### DIFF
--- a/src/base/error_manager.c
+++ b/src/base/error_manager.c
@@ -948,10 +948,9 @@ er_init (const char *msglog_filename, int exit_ask)
 	  msg = msgcat_message (MSGCAT_CATALOG_CUBRID, MSGCAT_SET_INTERNAL, i);
 	  if (msg && *msg)
 	    {
-	      tmp = (char *) malloc (std::strlen (msg) + 1);
+	      tmp = strdup (msg);
 	      if (tmp)
 		{
-		  strcpy (tmp, msg);
 		  er_Cached_msg[i] = tmp;
 		}
 	    }

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -529,11 +529,7 @@ connect_error:
 
   if (db_err_msg)
     {
-      *db_err_msg = (char *) malloc (strlen (p) + 1);
-      if (*db_err_msg)
-	{
-	  strcpy (*db_err_msg, p);
-	}
+      *db_err_msg = strdup (p);
     }
 
   return ERROR_INFO_SET_WITH_MSG (err_code, DBMS_ERROR_INDICATOR, p);

--- a/src/connection/connection_less.cpp
+++ b/src/connection/connection_less.cpp
@@ -133,12 +133,8 @@ connection_less::css_queue_connection (CSS_CONN_ENTRY *conn, const char *host)
   map_entry_p = (CSS_MAP_ENTRY *) malloc (sizeof (CSS_MAP_ENTRY));
   if (map_entry_p != NULL)
     {
-      map_entry_p->key = (char *) malloc (strlen (host) + 1);
-      if (map_entry_p->key != NULL)
-	{
-	  strcpy (map_entry_p->key, host);
-	}
-      else
+      map_entry_p->key = strdup (host);
+      if (map_entry_p->key == NULL)
 	{
 	  free (map_entry_p);
 	  return (NULL);

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -1529,10 +1529,9 @@ css_add_client_version_string (THREAD_ENTRY * thread_p, const char *version_stri
     {
       if (conn->version_string == NULL)
 	{
-	  ver_str = (char *) malloc (strlen (version_string) + 1);
+	  ver_str = strdup (version_string);
 	  if (ver_str != NULL)
 	    {
-	      strcpy (ver_str, version_string);
 	      conn->version_string = ver_str;
 	    }
 	  else

--- a/src/executables/compactdb_cl.c
+++ b/src/executables/compactdb_cl.c
@@ -228,13 +228,11 @@ get_name_from_class_oid (OID * class_oid)
       return NULL;
     }
 
-  result = (char *) malloc (sizeof (char) * (strlen (temp_class_name) + 1));
+  result = strdup (temp_class_name);
   if (result == NULL)
     {
       return NULL;
     }
-
-  strcpy (result, temp_class_name);
 
   return result;
 }

--- a/src/executables/csql_result_format.c
+++ b/src/executables/csql_result_format.c
@@ -1137,11 +1137,7 @@ duplicate_string (const char *string)
       return NULL;
     }
 
-  new_string = (char *) malloc (strlen (string) + 1);
-  if (new_string)
-    {
-      strcpy (new_string, string);
-    }
+  new_string = strdup (string);
 
   return (new_string);
 

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -412,10 +412,6 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer,
 		      server_name += strlen (entry->version_string) + 1;
 
 		      entry->env_var = strdup (server_name);
-		      if (entry->env_var != NULL)
-			{
-			  /* empty */
-			}
 
 		      server_name += strlen (server_name) + 1;
 
@@ -629,10 +625,6 @@ css_register_new_server2 (CSS_CONN_ENTRY * conn, unsigned short rid)
 			    {
 			      recv_data += strlen (entry->version_string) + 1;
 			      entry->env_var = strdup (recv_data);
-			      if (entry->env_var != NULL)
-				{
-				  /* empty */
-				}
 			      recv_data += strlen (recv_data) + 1;
 			      entry->pid = atoi (recv_data);
 			    }

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -406,16 +406,15 @@ css_accept_new_request (CSS_CONN_ENTRY * conn, unsigned short rid, char *buffer,
 	      if (entry != NULL)
 		{
 		  server_name += length;
-		  entry->version_string = (char *) malloc (strlen (server_name) + 1);
+		  entry->version_string = strdup (server_name);
 		  if (entry->version_string != NULL)
 		    {
-		      strcpy (entry->version_string, server_name);
 		      server_name += strlen (entry->version_string) + 1;
 
-		      entry->env_var = (char *) malloc (strlen (server_name) + 1);
+		      entry->env_var = strdup (server_name);
 		      if (entry->env_var != NULL)
 			{
-			  strcpy (entry->env_var, server_name);
+			  /* empty */
 			}
 
 		      server_name += strlen (server_name) + 1;
@@ -484,10 +483,7 @@ css_accept_old_request (CSS_CONN_ENTRY * conn, unsigned short rid, SOCKET_QUEUE_
 	  if (length < server_name_length)
 	    {
 	      server_name += length;
-	      if ((entry->version_string = (char *) malloc (strlen (server_name) + 1)) != NULL)
-		{
-		  strcpy (entry->version_string, server_name);
-		}
+	      entry->version_string = strdup (server_name);
 	    }
 	}
     }
@@ -628,15 +624,14 @@ css_register_new_server2 (CSS_CONN_ENTRY * conn, unsigned short rid)
 			  char *recv_data;
 
 			  recv_data = server_name + length;
-			  entry->version_string = (char *) malloc (strlen (recv_data) + 1);
+			  entry->version_string = strdup (recv_data);
 			  if (entry->version_string != NULL)
 			    {
-			      strcpy (entry->version_string, recv_data);
 			      recv_data += strlen (entry->version_string) + 1;
-			      entry->env_var = (char *) malloc (strlen (recv_data) + 1);
+			      entry->env_var = strdup (recv_data);
 			      if (entry->env_var != NULL)
 				{
-				  strcpy (entry->env_var, recv_data);
+				  /* empty */
 				}
 			      recv_data += strlen (recv_data) + 1;
 			      entry->pid = atoi (recv_data);
@@ -1443,10 +1438,9 @@ css_add_request_to_socket_queue (CSS_CONN_ENTRY * conn_p, int info_p, char *name
 
   if (name_p)
     {
-      p->name = (char *) malloc (strlen (name_p) + 1);
+      p->name = strdup (name_p);
       if (p->name)
 	{
-	  strcpy (p->name, name_p);
 #if !defined(WINDOWS)
 	  if (IS_MASTER_CONN_NAME_HA_SERVER (p->name) || IS_MASTER_CONN_NAME_HA_COPYLOG (p->name)
 	      || IS_MASTER_CONN_NAME_HA_APPLYLOG (p->name))

--- a/src/executables/util_sa.c
+++ b/src/executables/util_sa.c
@@ -4970,14 +4970,13 @@ gen_tz (UTIL_FUNCTION_ARG * arg)
 	      exit_status = EXIT_FAILURE;
 	      goto exit;
 	    }
-	  dir->name = (char *) calloc (strlen (db_name) + 1, sizeof (char));
+	  dir->name = strdup (db_name);
 	  if (dir->name == NULL)
 	    {
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, strlen (db_name) + 1);
 	      exit_status = EXIT_FAILURE;
 	      goto exit;
 	    }
-	  strcpy (dir->name, db_name);
 	  dir->next = NULL;
 	}
       else if (cfg_read_directory (&dir, false) != NO_ERROR)

--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -8108,13 +8108,12 @@ classobj_make_descriptor (MOP class_mop, SM_CLASS * classobj, SM_COMPONENT * com
   if (comp != NULL)
     {
       /* save the component name so we can rebuild the map cache after schema/transaction changes */
-      desc->name = (char *) malloc (strlen (comp->name) + 1);
+      desc->name = strdup (comp->name);
       if (desc->name == NULL)
 	{
 	  free_and_init (desc);
 	  return NULL;
 	}
-      strcpy (desc->name, comp->name);
       desc->name_space = comp->name_space;
     }
 

--- a/src/object/object_print_util.cpp
+++ b/src/object/object_print_util.cpp
@@ -64,11 +64,7 @@ char *object_print::copy_string (const char *source)
 
   if (source != NULL)
     {
-      new_str = (char *) malloc (strlen (source) + 1);
-      if (new_str != NULL)
-	{
-	  strcpy (new_str, source);
-	}
+      new_str = strdup (source);
     }
 
   return new_str;

--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -11688,15 +11688,13 @@ drop_foreign_key_ref (MOP classop, SM_CLASS * class_, SM_CLASS_CONSTRAINT * flat
   assert (class_ != NULL && class_->constraints != NULL && *cons != NULL);
 
   name_length = strlen ((*cons)->name) + 1;
-  saved_name = (char *) malloc (name_length);
+  saved_name = strdup ((*cons)->name);
   if (saved_name == NULL)
     {
       error = ER_OUT_OF_VIRTUAL_MEMORY;
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, (size_t) name_length);
       goto end;
     }
-
-  strcpy (saved_name, (*cons)->name);
 
   /* Since the constraints may be reallocated during the following process, we have to mark a special status flag to be
    * used for identifying whether the instance will have been reallocated. */

--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -7588,8 +7588,7 @@ qo_find_node_indexes (QO_ENV * env, QO_NODE * nodep)
 		      temp_name = consp->attributes[0]->header.name;
 		      if (temp_name)
 			{
-			  size_t len = strlen (temp_name) + 1;
-			  index_entryp->statistics_attribute_name = (char *) malloc (sizeof (char) * len);
+			  index_entryp->statistics_attribute_name = strdup (temp_name);
 			  if (index_entryp->statistics_attribute_name == NULL)
 			    {
 			      if (seg_idx != seg_idx_arr)
@@ -7597,10 +7596,9 @@ qo_find_node_indexes (QO_ENV * env, QO_NODE * nodep)
 				  free_and_init (seg_idx);
 				}
 			      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1,
-				      sizeof (char) * len);
+				      sizeof (char) * (strlen (temp_name) + 1));
 			      return;
 			    }
-			  strcpy (index_entryp->statistics_attribute_name, temp_name);
 			}
 		    }
 		}

--- a/src/parser/query_result.c
+++ b/src/parser/query_result.c
@@ -1043,20 +1043,20 @@ pt_fillin_type_size (PARSER_CONTEXT * parser, PT_NODE * query, DB_QUERY_TYPE * l
 	    {
 	      /* there is only one class spec */
 	      original_name = pt_append_string (parser, NULL, t->name);
-	      t->original_name = (char *) malloc (strlen (original_name) + 1);
+	      t->original_name = strdup (original_name);
 	    }
 	  else
 	    {
 	      /* there are plural class specs */
 	      original_name = pt_append_string (parser, pt_append_string (parser, (char *) t->spec_name, "."), t->name);
-	      t->original_name = (char *) malloc (strlen (original_name) + 1);
+	      t->original_name = strdup (original_name);
 	    }
 	  if (!t->original_name)
 	    {
 	      PT_INTERNAL_ERROR (parser, "insufficient memory");
 	      return list;
 	    }
-	  strcpy ((char *) t->original_name, original_name);
+
 	}
     }
 
@@ -1274,12 +1274,8 @@ db_object_describe (DB_OBJECT * obj_mop, int num_attrs, const char **attrs, DB_Q
     {
       t->db_type = sm_att_type_id (class_mop, *name);
       t->size = pt_find_size_from_dbtype (t->db_type);
-      t->name = (char *) malloc (1 + strlen (*name));
-      if (t->name)
-	{
-	  strcpy ((char *) t->name, *name);
-	}
-      else
+      t->name = strdup (*name);
+      if (t->name == NULL)
 	{
 	  db_free_query_format (*col_spec);
 	  *col_spec = NULL;
@@ -1365,12 +1361,8 @@ db_object_fetch (DB_OBJECT * obj_mop, int num_attrs, const char **attrs, DB_QUER
     {
       t->db_type = sm_att_type_id (class_mop, *name);
       t->size = pt_find_size_from_dbtype (t->db_type);
-      t->name = (char *) malloc (1 + strlen (*name));
-      if (t->name)
-	{
-	  strcpy ((char *) t->name, *name);
-	}
-      else
+      t->name = strdup (*name);
+      if (t->name == NULL)
 	{
 	  goto err_end;
 	}

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -7576,10 +7576,9 @@ pt_to_regu_variable (PARSER_CONTEXT * parser, PT_NODE * node, UNBOX unbox)
 			  || (parser->symbols->query_node->info.query.q.select.connect_by == NULL))
 			{
 			  const char *opcode = pt_show_binopcode (node->info.expr.op);
-			  char *temp_buffer = (char *) malloc (strlen (opcode) + 1);
+			  char *temp_buffer = strdup (opcode);
 			  if (temp_buffer)
 			    {
-			      strcpy (temp_buffer, opcode);
 			      ustr_upper (temp_buffer);
 			    }
 			  PT_ERRORmf (parser, node, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_NOT_HIERACHICAL_QUERY,

--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -5867,11 +5867,7 @@ xdisk_get_remarks (THREAD_ENTRY * thread_p, INT16 volid)
       return NULL;
     }
 
-  remarks = (char *) malloc ((int) strlen (disk_vhdr_get_vol_remarks (vhdr)) + 1);
-  if (remarks != NULL)
-    {
-      strcpy (remarks, disk_vhdr_get_vol_remarks (vhdr));
-    }
+  remarks = strdup (disk_vhdr_get_vol_remarks (vhdr));
 
   pgbuf_unfix_and_init (thread_p, hdr_pgptr);
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26838>

### Purpose

지난번 26838번 이슈에서 추후 작업으로 언급한 malloc+strcpy+free 패턴의 strdup 단순화입니다.

### Implementation

아래와 같은 단순화가 진행됩니다.

```c
char *a = malloc(size);
strcpy(a, b);
free(b);
```
와 같은 패턴이
```c
char *a = strdup(b);
```

로 안전하게 해제됩니다. <- (안전하게 정리됩니다. 완전히 오기입임)

### Remarks

strdup 이후 두 포인터가 같은 방향을 보고 있는 것이 괜찮은지, b = nullptr; 내지는 b = NULL; 처리를 더 해야 할지 논의가 필요합니다.