### PR TITLE
[CBRD-26880] Fix DBLink remote bind for FLOAT, DATETIME, and typed NULL values

### DIFF
--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -409,10 +409,13 @@ dblink_bind_param (int stmt_handle, VAL_DESCR * vd, DBLINK_HOST_VARS * host_vars
       value = &vd->dbval_ptr[i].data;
       /* A typed NULL (e.g. NUMERIC/DATE domain with the null flag set) must be bound as NULL,
        * not decoded through its type branch; otherwise it yields a precision-0 error or a zero date. */
-      type = vd->dbval_ptr[i].domain.general_info.type;
       if (DB_IS_NULL (&vd->dbval_ptr[i]))
 	{
 	  type = DB_TYPE_NULL;
+	}
+      else
+	{
+	  type = vd->dbval_ptr[i].domain.general_info.type;
 	}
       switch (type)
 	{

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -54,7 +54,7 @@
 #define  DATETIME_DECODE(date, dt, m, d, y, hour, min, sec, msec) \
   do \
     {  \
-      db_datetime_decode (&(dt), &d, &y, &m, &hour, &min, &sec, &msec); \
+      db_datetime_decode (&(dt), &m, &d, &y, &hour, &min, &sec, &msec); \
       date.hh = hour; \
       date.mm = min;  \
       date.ss = sec; \
@@ -407,7 +407,13 @@ dblink_bind_param (int stmt_handle, VAL_DESCR * vd, DBLINK_HOST_VARS * host_vars
     {
       i = host_vars->index[n];
       value = &vd->dbval_ptr[i].data;
+      /* A typed NULL (e.g. NUMERIC/DATE domain with the null flag set) must be bound as NULL,
+       * not decoded through its type branch; otherwise it yields a precision-0 error or a zero date. */
       type = vd->dbval_ptr[i].domain.general_info.type;
+      if (DB_IS_NULL (&vd->dbval_ptr[i]))
+	{
+	  type = DB_TYPE_NULL;
+	}
       switch (type)
 	{
 	case DB_TYPE_BIT:
@@ -440,8 +446,11 @@ dblink_bind_param (int stmt_handle, VAL_DESCR * vd, DBLINK_HOST_VARS * host_vars
 	  u_type = CCI_U_TYPE_NUMERIC;
 	  value = (void *) numeric_db_value_print (&vd->dbval_ptr[i], num_str);
 	  break;
-	case DB_TYPE_DOUBLE:
 	case DB_TYPE_FLOAT:
+	  a_type = CCI_A_TYPE_FLOAT;
+	  u_type = CCI_U_TYPE_FLOAT;
+	  break;
+	case DB_TYPE_DOUBLE:
 	  a_type = CCI_A_TYPE_DOUBLE;
 	  u_type = CCI_U_TYPE_DOUBLE;
 	  break;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26880

### Purpose

DBLink로 원격 서버에 host 변수(`?`)를 바인딩하는 공통 경로 `dblink_bind_param`
(`src/query/dblink_scan.c`)에서 일부 타입이 잘못 처리되어, 원격 SELECT/DML의
`?` 바인딩에서 다음이 발생한다. 

- **FLOAT**: 실제 값이 아니라 ≈0 으로 바인딩됨 (silent 데이터 손상). DOUBLE은 정상.
- **DATETIME**: `Conversion error in date format` 로 실패. DATE/TIME/TIMESTAMP는 정상.
- **타입 있는 NULL**(NUMERIC/DATE 도메인 + null 플래그): `Given precision of 0 is
  invalid` 에러 또는 `00/00/0000` 제로데이트로 둔갑 (NULL 미보존).

### Implementation

`src/query/dblink_scan.c` `dblink_bind_param` 의 타입 분기 한 곳을 수정.

- **FLOAT** — `DB_TYPE_FLOAT`를 `DB_TYPE_DOUBLE` 분기에서 분리해
  `CCI_A_TYPE_FLOAT`/`CCI_U_TYPE_FLOAT`로 바인딩. 기존에는 4바이트 `data.f`를
  `CCI_A_TYPE_DOUBLE`로 넘겨 CCI가 8바이트 double로 역참조 → subnormal(≈0).
- **DATETIME** — `DATETIME_DECODE` 매크로가 `db_datetime_decode(datetime, *month,
  *day, *year, …)` 에 인자를 `&d, &y, &m`(day, year, month) 순으로 잘못 넘겨
  month/day/year가 뒤섞였다(예: `2026-06-04` → month=2026 → 유효범위 초과 →
  Conversion error). 호출을 `&m, &d, &y`로 교정. DATE/TIME/TIMESTAMP는 올바른
  순서의 `TIMESTAMP_DECODE`를 쓰므로 정상이었음 → DATETIME/DATETIMETZ/LTZ만 영향.
- **typed-NULL** — switch 진입 직전 `if (DB_IS_NULL(...)) type = DB_TYPE_NULL;`로
  null인 dbval을 도메인 타입과 무관하게 기존 `DB_TYPE_NULL`(`CCI_U_TYPE_NULL`)
  분기로 라우팅.

### Remarks

이 결함은 타입이 지정된 host 변수(`?`) 바인딩 경로(`dblink_bind_param`)에서 발현된다.
csql도 `PREPARE/EXECUTE USING ?`로 이 경로를 타며, 그중 **DATETIME은 csql로도 재현된다**
(`EXECUTE s USING DATETIME'...'` → develop(pre-fix)에서 `Conversion error in date format`,
26880 fix 빌드에서 정상 저장 확인). 다만 **FLOAT·typed-NULL은 csql로 재현할 수 없어** JDBC
`PreparedStatement`로 검증했다 — csql `EXECUTE USING`은 리터럴만 받아 FLOAT 타입 host 변수를
강제할 수 없고(숫자 리터럴은 NUMERIC/DOUBLE로 바인딩), typed-NULL도 만들 수 없다
(`USING NULL`은 untyped `DB_TYPE_NULL`, `CAST(NULL AS ...)`는 `EXECUTE USING`이 거부).

- DATETIME: JDBC `setTimestamp` **및 csql `DATETIME'...'` 리터럴** 둘 다로 재현·수정 확인.
  `DATETIME_DECODE` 매크로의 month/day/year 인자 순서 오류가 원인.
- FLOAT: JDBC `setFloat`로 재현·수정 확인(csql은 FLOAT host 변수 강제 불가).
- typed-NULL: 타입 setter에 null을 전달하면(`setDate(1, null)`) JDBC 드라이버가
  `U_TYPE_DATE` + null로 바인딩하여 서버에 **도메인 타입을 가진 NULL(typed-NULL)**
  로 도착한다. `DB_IS_NULL` 체크가 없으면 해당 도메인 분기(DATE/NUMERIC)로 들어가
  `Conversion error in date format`(DATE) 또는 precision-0 에러(NUMERIC)가 난다.
  반면 `setNull(...)`은 `U_TYPE_NULL`(→ `DB_TYPE_NULL`)로 도착해 정상이므로 영향이
  없다 — 이 차이 때문에 흔한 "타입 setter + null" 패턴에서만 드러난다.
  csql `USING NULL`도 untyped라 정상(재현 안 됨).
