### PR TITLE
[CBRD-26805] Fix the HY010 Error During DBLink Operation

### DIFF
--- a/src/broker/cas_cgw_execute.c
+++ b/src/broker/cas_cgw_execute.c
@@ -115,6 +115,7 @@ ux_cgw_prepare (char *sql_stmt, int flag, char auto_commit_mode, T_NET_BUF * net
   int num_markers;
   T_BROKER_VERSION client_version = req_info->client_version;
   int result_cache_lifetime;
+  T_CGW_HANDLE *cgw_handle = NULL;
 
   if ((flag & CCI_PREPARE_UPDATABLE) && (flag & CCI_PREPARE_HOLDABLE))
     {
@@ -131,7 +132,7 @@ ux_cgw_prepare (char *sql_stmt, int flag, char auto_commit_mode, T_NET_BUF * net
       goto prepare_error;
     }
 
-  err_code = cgw_get_handle (&srv_handle->cgw_handle);
+  err_code = cgw_get_handle (&cgw_handle);
   if (err_code < 0)
     {
       err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
@@ -172,7 +173,7 @@ ux_cgw_prepare (char *sql_stmt, int flag, char auto_commit_mode, T_NET_BUF * net
   srv_handle->num_markers = num_markers;
   srv_handle->prepare_flag = flag;
 
-  err_code = cgw_sql_prepare ((SQLCHAR *) sql_stmt);
+  err_code = cgw_sql_prepare (cgw_handle->hdbc, srv_handle, (SQLCHAR *) sql_stmt);
   if (err_code < 0)
     {
       err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
@@ -196,8 +197,7 @@ ux_cgw_prepare (char *sql_stmt, int flag, char auto_commit_mode, T_NET_BUF * net
   net_buf_cp_int (net_buf, num_markers, NULL);
 
   err_code =
-    cgw_prepare_column_list_info_set (srv_handle->cgw_handle->hstmt, flag, srv_handle->stmt_type, client_version,
-				      net_buf);
+    cgw_prepare_column_list_info_set (srv_handle->cgw_hstmt, flag, srv_handle->stmt_type, client_version, net_buf);
 
   if (err_code < 0)
     {
@@ -334,10 +334,18 @@ ux_cgw_execute (T_SRV_HANDLE * srv_handle, char flag, int max_col_size, int max_
   SQLLEN row_count = 0;
   T_BROKER_VERSION client_version = req_info->client_version;
   ODBC_BIND_INFO *bind_data_list = NULL;
+  T_CGW_HANDLE *cgw_handle = NULL;
+
+  err_code = cgw_get_handle (&cgw_handle);
+  if (err_code < 0)
+    {
+      err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
+      goto execute_error;
+    }
 
   if (srv_handle->is_prepared == FALSE)
     {
-      err_code = cgw_sql_prepare ((SQLCHAR *) srv_handle->sql_stmt);
+      err_code = cgw_sql_prepare (cgw_handle->hdbc, srv_handle, (SQLCHAR *) srv_handle->sql_stmt);
 
       if (err_code < 0)
 	{
@@ -350,7 +358,7 @@ ux_cgw_execute (T_SRV_HANDLE * srv_handle, char flag, int max_col_size, int max_
 
   if (num_bind > 0)
     {
-      err_code = cgw_make_bind_value (srv_handle->cgw_handle, num_bind, argc, argv, &bind_data_list);
+      err_code = cgw_make_bind_value (cgw_handle->hdbc, srv_handle, num_bind, argc, argv, &bind_data_list);
       if (err_code < 0)
 	{
 	  err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
@@ -358,33 +366,16 @@ ux_cgw_execute (T_SRV_HANDLE * srv_handle, char flag, int max_col_size, int max_
 	}
     }
 
-  if (srv_handle->is_prepared == FALSE)
-    {
-      err_code = cgw_sql_prepare ((SQLCHAR *) srv_handle->sql_stmt);
-
-      if (err_code != SQL_SUCCESS && err_code != SQL_SUCCESS_WITH_INFO)
-	{
-	  err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
-	  goto execute_error;
-	}
-
-      err_code = cgw_set_commit_mode (srv_handle->cgw_handle->hdbc, srv_handle->auto_commit_mode);
-      if (err_code != NO_ERROR)
-	{
-	  err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
-	  goto execute_error;
-	}
-    }
   srv_handle->is_from_current_transaction = true;
 
-  err_code = cgw_set_commit_mode (srv_handle->cgw_handle->hdbc, srv_handle->auto_commit_mode);
+  err_code = cgw_set_commit_mode (cgw_handle->hdbc, srv_handle->auto_commit_mode);
   if (err_code != NO_ERROR)
     {
       err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
       goto execute_error;
     }
 
-  err_code = cgw_execute (srv_handle, &row_count);
+  err_code = cgw_execute (cgw_handle->hdbc, srv_handle, &row_count);
   if (err_code < 0)
     {
       err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
@@ -461,7 +452,7 @@ ux_cgw_execute (T_SRV_HANDLE * srv_handle, char flag, int max_col_size, int max_
 	  net_buf_cp_int (net_buf, srv_handle->num_markers, NULL);
 
 	  err_code =
-	    cgw_prepare_column_list_info_set (srv_handle->cgw_handle->hstmt, flag, srv_handle->stmt_type,
+	    cgw_prepare_column_list_info_set (srv_handle->cgw_hstmt, flag, srv_handle->stmt_type,
 					      client_version, net_buf);
 	  if (err_code != NO_ERROR)
 	    {
@@ -570,16 +561,23 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
   SQLSMALLINT num_cols;
   SQLLEN total_row_count = 0;
   T_BROKER_VERSION client_version = req_info->client_version;
+  T_CGW_HANDLE *cgw_handle = NULL;
 
   if (result_set_idx < 0 || result_set_idx > 1)
     {
       return ERROR_INFO_SET (CAS_ER_NO_MORE_RESULT_SET, CAS_ERROR_INDICATOR);
     }
 
+  err_code = cgw_get_handle (&cgw_handle);
+  if (err_code < 0)
+    {
+      err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
+      goto fetch_error;
+    }
 
   if (srv_handle->is_cursor_open == false)
     {
-      err_code = cgw_execute (srv_handle, &row_count);
+      err_code = cgw_execute (cgw_handle->hdbc, srv_handle, &row_count);
       if (err_code < 0)
 	{
 	  err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
@@ -595,7 +593,7 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
 	  goto fetch_error;
 	}
 
-      err_code = cgw_execute (srv_handle, &row_count);
+      err_code = cgw_execute (cgw_handle->hdbc, srv_handle, &row_count);
       if (err_code < 0)
 	{
 	  err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
@@ -605,7 +603,7 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
 
   net_buf_cp_int (net_buf, (int) total_row_count, &num_tuple_msg_offset);
 
-  err_code = cgw_get_num_cols (srv_handle->cgw_handle->hstmt, &num_cols);
+  err_code = cgw_get_num_cols (srv_handle->cgw_hstmt, &num_cols);
 
   if (err_code < 0)
     {
@@ -621,7 +619,7 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
 	  col_binding_buff = NULL;
 	}
 
-      err_code = cgw_col_bindings (srv_handle->cgw_handle->hstmt, num_cols, &col_binding, &col_binding_buff);
+      err_code = cgw_col_bindings (srv_handle->cgw_hstmt, num_cols, &col_binding, &col_binding_buff);
       if (err_code < 0)
 	{
 	  err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
@@ -655,7 +653,7 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
 	}
       else
 	{
-	  err_code = cgw_row_data (srv_handle->cgw_handle->hstmt);
+	  err_code = cgw_row_data (srv_handle->cgw_hstmt);
 	  if (err_code < 0)
 	    {
 	      err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
@@ -717,7 +715,7 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
 	  break;
 	}
 
-      err_code = cgw_row_data (srv_handle->cgw_handle->hstmt);
+      err_code = cgw_row_data (srv_handle->cgw_hstmt);
       if (err_code < 0)
 	{
 	  err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);

--- a/src/broker/cas_cgw_execute.c
+++ b/src/broker/cas_cgw_execute.c
@@ -49,12 +49,6 @@
 #define DBLINK_HINT                     "DBLINK"
 
 /* ========================================================================
- * Global Variable Definitions
- * ======================================================================== */
-T_COL_BINDER *col_binding = NULL;
-T_COL_BINDER *col_binding_buff = NULL;
-
-/* ========================================================================
  * Type Definitions
  * ======================================================================== */
 typedef int (*T_FETCH_FUNC) (T_SRV_HANDLE *, int, int, char, int, T_NET_BUF *, T_REQ_INFO *);
@@ -69,6 +63,7 @@ static char ux_cgw_get_stmt_type (char *stmt);
 static int fetch_not_supported (T_SRV_HANDLE *, int, int, char, int, T_NET_BUF *, T_REQ_INFO *);
 static int fetch_call (T_SRV_HANDLE * srv_handle, T_NET_BUF * net_buf, T_REQ_INFO * req_info);
 static bool do_commit_after_execute (const t_srv_handle & server_handle);
+static void cgw_cleanup_col_bindings (T_SRV_HANDLE * srv_handle);
 
 /* ========================================================================
  * Static Variable Definitions
@@ -547,6 +542,33 @@ fetch_error:
   return err_code;
 }
 
+static void
+cgw_cleanup_col_bindings (T_SRV_HANDLE * srv_handle)
+{
+  T_COL_BINDER *col_binding;
+  T_COL_BINDER *col_binding_buff;
+
+  if (srv_handle == NULL)
+    {
+      return;
+    }
+
+  col_binding = (T_COL_BINDER *) srv_handle->cgw_col_binding;
+  col_binding_buff = (T_COL_BINDER *) srv_handle->cgw_col_binding_buff;
+
+  if (col_binding != NULL)
+    {
+      cgw_cleanup_binder (col_binding);
+      srv_handle->cgw_col_binding = NULL;
+    }
+
+  if (col_binding_buff != NULL)
+    {
+      cgw_cleanup_binder (col_binding_buff);
+      srv_handle->cgw_col_binding_buff = NULL;
+    }
+}
+
 static int
 cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, char fetch_flag, int result_set_idx,
 		  T_NET_BUF * net_buf, T_REQ_INFO * req_info)
@@ -562,6 +584,8 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
   SQLLEN total_row_count = 0;
   T_BROKER_VERSION client_version = req_info->client_version;
   T_CGW_HANDLE *cgw_handle = NULL;
+  T_COL_BINDER *col_binding;
+  T_COL_BINDER *col_binding_buff;
 
   if (result_set_idx < 0 || result_set_idx > 1)
     {
@@ -577,6 +601,8 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
 
   if (srv_handle->is_cursor_open == false)
     {
+      cgw_cleanup_col_bindings (srv_handle);
+
       err_code = cgw_execute (cgw_handle->hdbc, srv_handle, &row_count);
       if (err_code < 0)
 	{
@@ -592,6 +618,8 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
 	  err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
 	  goto fetch_error;
 	}
+
+      cgw_cleanup_col_bindings (srv_handle);
 
       err_code = cgw_execute (cgw_handle->hdbc, srv_handle, &row_count);
       if (err_code < 0)
@@ -611,20 +639,22 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
       goto fetch_error;
     }
 
+  col_binding = (T_COL_BINDER *) srv_handle->cgw_col_binding;
+  col_binding_buff = (T_COL_BINDER *) srv_handle->cgw_col_binding_buff;
+
   if (col_binding == NULL)
     {
-      if (col_binding_buff)
-	{
-	  cgw_cleanup_binder (col_binding_buff);
-	  col_binding_buff = NULL;
-	}
-
-      err_code = cgw_col_bindings (srv_handle->cgw_hstmt, num_cols, &col_binding, &col_binding_buff);
+      err_code = cgw_col_bindings (srv_handle->cgw_hstmt, num_cols,
+				   (T_COL_BINDER **) & srv_handle->cgw_col_binding,
+				   (T_COL_BINDER **) & srv_handle->cgw_col_binding_buff);
       if (err_code < 0)
 	{
 	  err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
 	  goto fetch_error;
 	}
+
+      col_binding = (T_COL_BINDER *) srv_handle->cgw_col_binding;
+      col_binding_buff = (T_COL_BINDER *) srv_handle->cgw_col_binding_buff;
     }
 
   if (cas_shard_flag == ON)
@@ -664,17 +694,7 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
 	    {
 	      fetch_end_flag = 1;
 
-	      if (col_binding)
-		{
-		  cgw_cleanup_binder (col_binding);
-		  col_binding = NULL;
-		}
-
-	      if (col_binding_buff)
-		{
-		  cgw_cleanup_binder (col_binding_buff);
-		  col_binding_buff = NULL;
-		}
+	      cgw_cleanup_col_bindings (srv_handle);
 
 	      err_code = cgw_cursor_close (srv_handle);
 	      if (err_code < 0)
@@ -726,17 +746,7 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
 	{
 	  fetch_end_flag = 1;
 
-	  if (col_binding)
-	    {
-	      cgw_cleanup_binder (col_binding);
-	      col_binding = NULL;
-	    }
-
-	  if (col_binding_buff)
-	    {
-	      cgw_cleanup_binder (col_binding_buff);
-	      col_binding_buff = NULL;
-	    }
+	  cgw_cleanup_col_bindings (srv_handle);
 
 	  err_code = cgw_cursor_close (srv_handle);
 	  if (err_code < 0)
@@ -775,17 +785,7 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
   return 0;
 
 fetch_error:
-  if (col_binding)
-    {
-      cgw_cleanup_binder (col_binding);
-      col_binding = NULL;
-    }
-
-  if (col_binding_buff)
-    {
-      cgw_cleanup_binder (col_binding_buff);
-      col_binding_buff = NULL;
-    }
+  cgw_cleanup_col_bindings (srv_handle);
 
   return err_code;
 }
@@ -901,12 +901,14 @@ ux_cgw_cursor_close (T_SRV_HANDLE * srv_handle)
       return;
     }
 
+  cgw_cleanup_col_bindings (srv_handle);
   cgw_cursor_close (srv_handle);
 }
 
 void
 ux_cgw_free_stmt (T_SRV_HANDLE * srv_handle)
 {
+  cgw_cleanup_col_bindings (srv_handle);
   cgw_free_stmt (srv_handle);
 }
 

--- a/src/broker/cas_cgw_execute.c
+++ b/src/broker/cas_cgw_execute.c
@@ -553,6 +553,11 @@ cgw_cleanup_col_bindings (T_SRV_HANDLE * srv_handle)
       return;
     }
 
+  if (srv_handle->cgw_hstmt != NULL)
+    {
+      (void) SQLFreeStmt ((SQLHSTMT) srv_handle->cgw_hstmt, SQL_UNBIND);
+    }
+
   col_binding = (T_COL_BINDER *) srv_handle->cgw_col_binding;
   col_binding_buff = (T_COL_BINDER *) srv_handle->cgw_col_binding_buff;
 
@@ -694,8 +699,6 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
 	    {
 	      fetch_end_flag = 1;
 
-	      cgw_cleanup_col_bindings (srv_handle);
-
 	      err_code = cgw_cursor_close (srv_handle);
 	      if (err_code < 0)
 		{
@@ -703,6 +706,7 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
 		  goto fetch_error;
 		}
 
+	      cgw_cleanup_col_bindings (srv_handle);
 
 	      if (check_auto_commit_after_getting_result (srv_handle) == true)
 		{
@@ -746,14 +750,14 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
 	{
 	  fetch_end_flag = 1;
 
-	  cgw_cleanup_col_bindings (srv_handle);
-
 	  err_code = cgw_cursor_close (srv_handle);
 	  if (err_code < 0)
 	    {
 	      err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
 	      goto fetch_error;
 	    }
+
+	  cgw_cleanup_col_bindings (srv_handle);
 
 	  if (check_auto_commit_after_getting_result (srv_handle) == true)
 	    {
@@ -785,6 +789,11 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
   return 0;
 
 fetch_error:
+  if (srv_handle->is_cursor_open)
+    {
+      (void) cgw_cursor_close (srv_handle);
+    }
+
   cgw_cleanup_col_bindings (srv_handle);
 
   return err_code;
@@ -901,13 +910,23 @@ ux_cgw_cursor_close (T_SRV_HANDLE * srv_handle)
       return;
     }
 
-  cgw_cleanup_col_bindings (srv_handle);
   cgw_cursor_close (srv_handle);
+  cgw_cleanup_col_bindings (srv_handle);
 }
 
 void
 ux_cgw_free_stmt (T_SRV_HANDLE * srv_handle)
 {
+  if (srv_handle == NULL)
+    {
+      return;
+    }
+
+  if (srv_handle->is_cursor_open)
+    {
+      (void) cgw_cursor_close (srv_handle);
+    }
+
   cgw_cleanup_col_bindings (srv_handle);
   cgw_free_stmt (srv_handle);
 }

--- a/src/broker/cas_cgw_odbc.c
+++ b/src/broker/cas_cgw_odbc.c
@@ -103,7 +103,7 @@ static int numeric_string_adjust (SQL_NUMERIC_STRUCT * numeric, char *string);
 static int hex_to_numeric_val (SQL_NUMERIC_STRUCT * numeric, char *hexstr);
 static int hex_to_char (char c, unsigned char *result);
 static int cgw_get_stmt_Info (T_SRV_HANDLE * srv_handle, SQLHSTMT hstmt, T_NET_BUF * net_buf, int stmt_type);
-static int cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *net_value,
+static int cgw_set_bindparam (SQLHDBC hdbc, T_SRV_HANDLE * srv_handle, int bind_num, void *net_type, void *net_value,
 			      ODBC_BIND_INFO * value_list);
 static char cgw_odbc_type_to_cci_u_type (SQLLEN odbc_type, SQLLEN is_unsigned_type);
 static char cgw_odbc_type_to_charset (SQLLEN odbc_type, SQLLEN is_unsigned_type);
@@ -168,11 +168,13 @@ cgw_cleanup (void)
 void
 cgw_free_stmt (T_SRV_HANDLE * srv_handle)
 {
-  if (srv_handle->cgw_handle->hstmt)
+  if (srv_handle == NULL || srv_handle->cgw_hstmt == NULL)
     {
-      SQLFreeHandle (SQL_HANDLE_STMT, local_odbc_handle->hstmt);
-      local_odbc_handle->hstmt = NULL;
+      return;
     }
+
+  SQLFreeHandle (SQL_HANDLE_STMT, srv_handle->cgw_hstmt);
+  srv_handle->cgw_hstmt = NULL;
 }
 
 int
@@ -260,10 +262,6 @@ cgw_database_connect (T_DBMS_TYPE dbms_type, const char *connect_url, char *db_n
 
   cgw_link_server_info (local_odbc_handle->hdbc);
 
-  SQL_CHK_ERR (local_odbc_handle->hdbc,
-	       SQL_HANDLE_DBC,
-	       err_code = SQLAllocHandle (SQL_HANDLE_STMT, local_odbc_handle->hdbc, &local_odbc_handle->hstmt));
-
   strncpy (connected_db_name, db_name, sizeof (connected_db_name) - 1);
   strncpy (connected_db_user, db_user, sizeof (connected_db_user) - 1);
   strncpy (connected_db_passwd, db_passwd, sizeof (connected_db_passwd) - 1);
@@ -286,45 +284,48 @@ ODBC_ERROR:
 }
 
 int
-cgw_execute (T_SRV_HANDLE * srv_handle, SQLLEN * row_count)
+cgw_execute (SQLHDBC hdbc, T_SRV_HANDLE * srv_handle, SQLLEN * row_count)
 {
   SQLRETURN err_code;
 
-  if (srv_handle->num_markers > 0)
+  if (srv_handle == NULL)
     {
-      if (srv_handle->cgw_handle->hdbc == NULL)
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CGW_INVALID_HANDLE, 0);
+      goto ODBC_ERROR;
+    }
+
+  if (srv_handle->cgw_hstmt == NULL)
+    {
+      if (hdbc == NULL)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CGW_INVALID_DBC_HANDLE, 0);
 	  goto ODBC_ERROR;
 	}
-
-      if (srv_handle->cgw_handle->hstmt == NULL)
-	{
-	  SQL_CHK_ERR (srv_handle->cgw_handle->hdbc,
-		       SQL_HANDLE_DBC, err_code =
-		       SQLAllocHandle (SQL_HANDLE_STMT, local_odbc_handle->hdbc, &srv_handle->cgw_handle->hstmt));
-	}
+      SQL_CHK_ERR (hdbc, SQL_HANDLE_DBC, err_code = SQLAllocHandle (SQL_HANDLE_STMT, hdbc, &srv_handle->cgw_hstmt));
     }
 
-  SQL_CHK_ERR (srv_handle->cgw_handle->hstmt, SQL_HANDLE_STMT, err_code = SQLExecute (srv_handle->cgw_handle->hstmt));
+  SQL_CHK_ERR (srv_handle->cgw_hstmt, SQL_HANDLE_STMT, err_code = SQLExecute (srv_handle->cgw_hstmt));
 
   if (err_code < 0)
     {
-      cgw_error_msg (srv_handle->cgw_handle->hstmt, SQL_HANDLE_STMT, err_code);
+      cgw_error_msg (srv_handle->cgw_hstmt, SQL_HANDLE_STMT, err_code);
       goto ODBC_ERROR;
     }
 
-  SQLRowCount (srv_handle->cgw_handle->hstmt, row_count);
+  SQLRowCount (srv_handle->cgw_hstmt, row_count);
 
   srv_handle->is_cursor_open = true;
 
   return NO_ERROR;
 
 ODBC_ERROR:
-  if (srv_handle->cgw_handle->hstmt)
+  if (srv_handle != NULL)
     {
-      SQLFreeHandle (SQL_HANDLE_STMT, srv_handle->cgw_handle->hstmt);
-      srv_handle->cgw_handle->hstmt = NULL;
+      if (srv_handle->is_cursor_open && srv_handle->cgw_hstmt != NULL)
+	{
+	  (void) cgw_cursor_close (srv_handle);
+	}
+      srv_handle->is_cursor_open = false;
     }
 
   return ER_FAILED;
@@ -366,14 +367,13 @@ cgw_cursor_close (T_SRV_HANDLE * srv_handle)
 {
   SQLRETURN err_code = 0;
 
-  if (srv_handle->cgw_handle->hstmt == NULL)
+  if (srv_handle->cgw_hstmt == NULL)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CGW_INVALID_STMT_HANDLE, 0);
       goto ODBC_ERROR;
     }
 
-  SQL_CHK_ERR (srv_handle->cgw_handle->hstmt, SQL_HANDLE_STMT, err_code =
-	       SQLFreeStmt (srv_handle->cgw_handle->hstmt, SQL_CLOSE));
+  SQL_CHK_ERR (srv_handle->cgw_hstmt, SQL_HANDLE_STMT, err_code = SQLFreeStmt (srv_handle->cgw_hstmt, SQL_CLOSE));
 
   srv_handle->is_cursor_open = false;
 
@@ -918,7 +918,7 @@ cgw_set_execute_info (T_SRV_HANDLE * srv_handle, T_NET_BUF * net_buf, int stmt_t
 
   for (int i = 0; i < srv_handle->num_q_result; i++)
     {
-      err_code = cgw_get_stmt_Info (srv_handle, srv_handle->cgw_handle->hstmt, net_buf, stmt_type);
+      err_code = cgw_get_stmt_Info (srv_handle, srv_handle->cgw_hstmt, net_buf, stmt_type);
       if (err_code < 0)
 	{
 	  goto ODBC_ERROR;
@@ -1189,12 +1189,6 @@ cgw_database_disconnect ()
       return;
     }
 
-  if (local_odbc_handle->hstmt)
-    {
-      SQLFreeHandle (SQL_HANDLE_STMT, local_odbc_handle->hstmt);
-      local_odbc_handle->hstmt = NULL;
-    }
-
   if (local_odbc_handle->hdbc)
     {
       SQLDisconnect (local_odbc_handle->hdbc);
@@ -1208,23 +1202,23 @@ cgw_database_disconnect ()
 }
 
 static int
-cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *net_value, ODBC_BIND_INFO * value_list)
+cgw_set_bindparam (SQLHDBC hdbc, T_SRV_HANDLE * srv_handle, int bind_num, void *net_type, void *net_value,
+		   ODBC_BIND_INFO * value_list)
 {
   char type;
   char src_type = -1;
   int err_code = 0;
   int data_size;
-  SQLLEN indPtr = 0;
   SQLSMALLINT c_data_type;
   SQLSMALLINT sql_bind_type;
 
-  if (handle == NULL)
+  if (srv_handle == NULL)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CGW_INVALID_HANDLE, 0);
       return ER_CGW_INVALID_HANDLE;
     }
 
-  if (handle->hstmt == NULL)
+  if (srv_handle->cgw_hstmt == NULL)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CGW_INVALID_STMT_HANDLE, 0);
       return ER_CGW_INVALID_STMT_HANDLE;
@@ -1273,14 +1267,18 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 	  }
 
 	value_list->wchar_val = out_string;
+	value_list->cbValue = SQL_NTS;
 
-	SQL_CHK_ERR (handle->hstmt,
+	SQL_CHK_ERR (srv_handle->cgw_hstmt,
 		     SQL_HANDLE_STMT,
-		     err_code = SQLBindParameter (handle->hstmt,
+		     err_code = SQLBindParameter (srv_handle->cgw_hstmt,
 						  bind_num,
 						  SQL_PARAM_INPUT,
 						  c_data_type,
-						  sql_bind_type, out_length, 0, (SQLWCHAR *) out_string, 0, NULL));
+						  sql_bind_type,
+						  out_length,
+						  0,
+						  (SQLWCHAR *) out_string, (SQLLEN) out_length, &value_list->cbValue));
       }
       break;
 
@@ -1297,9 +1295,9 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 	value_list->cbValue = SQL_NULL_DATA;
 	value_list->string_val = value;
 
-	SQL_CHK_ERR (handle->hstmt,
+	SQL_CHK_ERR (srv_handle->cgw_hstmt,
 		     SQL_HANDLE_STMT,
-		     err_code = SQLBindParameter (handle->hstmt,
+		     err_code = SQLBindParameter (srv_handle->cgw_hstmt,
 						  bind_num,
 						  SQL_PARAM_INPUT,
 						  c_data_type,
@@ -1322,14 +1320,17 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 	    sql_bind_type = SQL_CHAR;
 
 	    value_list->string_val = value;
+	    value_list->cbValue = (SQLLEN) val_size;
 
-	    SQL_CHK_ERR (handle->hstmt,
+	    SQL_CHK_ERR (srv_handle->cgw_hstmt,
 			 SQL_HANDLE_STMT,
-			 err_code = SQLBindParameter (handle->hstmt,
+			 err_code = SQLBindParameter (srv_handle->cgw_hstmt,
 						      bind_num,
 						      SQL_PARAM_INPUT,
 						      c_data_type,
-						      sql_bind_type, val_size + 1, 0, value_list->string_val, 0, NULL));
+						      sql_bind_type,
+						      val_size + 1,
+						      0, value_list->string_val, val_size + 1, &value_list->cbValue));
 	  }
 	else
 	  {
@@ -1341,8 +1342,13 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 	    SQLHDESC hdesc = NULL;
 	    DB_BIGINT bi_val;
 
-	    SQL_CHK_ERR (handle->hdbc, SQL_HANDLE_DBC, err_code =
-			 SQLAllocHandle (SQL_HANDLE_DESC, handle->hdbc, &hdesc));
+	    if (hdbc == NULL)
+	      {
+		er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CGW_INVALID_DBC_HANDLE, 0);
+		return ER_CGW_INVALID_DBC_HANDLE;
+	      }
+
+	    SQL_CHK_ERR (hdbc, SQL_HANDLE_DBC, err_code = SQLAllocHandle (SQL_HANDLE_DESC, hdbc, &hdesc));
 
 	    memset (&value_list->ns_val, 0x00, sizeof (SQL_NUMERIC_STRUCT));
 
@@ -1405,18 +1411,18 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 
 	    c_data_type = SQL_C_NUMERIC;
 	    sql_bind_type = SQL_DECIMAL;
+	    value_list->cbValue = (SQLLEN) sizeof (value_list->ns_val);
 
-	    indPtr = sizeof (value_list->ns_val);
-	    SQL_CHK_ERR (handle->hstmt,
+	    SQL_CHK_ERR (srv_handle->cgw_hstmt,
 			 SQL_HANDLE_STMT,
-			 err_code = SQLBindParameter (handle->hstmt,
+			 err_code = SQLBindParameter (srv_handle->cgw_hstmt,
 						      bind_num,
 						      SQL_PARAM_INPUT,
 						      c_data_type,
 						      sql_bind_type,
 						      value_list->ns_val.precision,
-						      value_list->ns_val.scale, &value_list->ns_val, 0,
-						      (SQLLEN *) & indPtr));
+						      value_list->ns_val.scale,
+						      &value_list->ns_val, 0, &value_list->cbValue));
 
 	    SQL_CHK_ERR (hdesc,
 			 SQL_HANDLE_DESC,
@@ -1454,14 +1460,15 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 	sql_bind_type = SQL_BIGINT;
 
 	value_list->bigint_val = bi_val;
+	value_list->cbValue = 0;
 
-	SQL_CHK_ERR (handle->hstmt,
+	SQL_CHK_ERR (srv_handle->cgw_hstmt,
 		     SQL_HANDLE_STMT,
-		     err_code = SQLBindParameter (handle->hstmt,
+		     err_code = SQLBindParameter (srv_handle->cgw_hstmt,
 						  bind_num,
 						  SQL_PARAM_INPUT,
 						  c_data_type, sql_bind_type, 0, 0, &value_list->bigint_val, 0,
-						  &indPtr));
+						  &value_list->cbValue));
       }
       break;
     case CCI_U_TYPE_INT:
@@ -1475,15 +1482,15 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 	sql_bind_type = SQL_INTEGER;
 
 	value_list->integer_val = i_val;
+	value_list->cbValue = 0;
 
-
-	SQL_CHK_ERR (handle->hstmt,
+	SQL_CHK_ERR (srv_handle->cgw_hstmt,
 		     SQL_HANDLE_STMT,
-		     err_code = SQLBindParameter (handle->hstmt,
+		     err_code = SQLBindParameter (srv_handle->cgw_hstmt,
 						  bind_num,
 						  SQL_PARAM_INPUT,
 						  c_data_type, sql_bind_type, 0, 0, &value_list->integer_val, 0,
-						  &indPtr));
+						  &value_list->cbValue));
 
       }
       break;
@@ -1497,14 +1504,15 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 	c_data_type = SQL_C_SHORT;
 	sql_bind_type = SQL_SMALLINT;
 	value_list->smallInt_val = s_val;
+	value_list->cbValue = 0;
 
-	SQL_CHK_ERR (handle->hstmt,
+	SQL_CHK_ERR (srv_handle->cgw_hstmt,
 		     SQL_HANDLE_STMT,
-		     err_code = SQLBindParameter (handle->hstmt,
+		     err_code = SQLBindParameter (srv_handle->cgw_hstmt,
 						  bind_num,
 						  SQL_PARAM_INPUT,
 						  c_data_type, sql_bind_type, 0, 0, &value_list->smallInt_val, 0,
-						  &indPtr));
+						  &value_list->cbValue));
       }
       break;
     case CCI_U_TYPE_FLOAT:
@@ -1516,13 +1524,15 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 	c_data_type = SQL_C_FLOAT;
 	sql_bind_type = SQL_REAL;
 	value_list->real_val = f_val;
+	value_list->cbValue = 0;
 
-	SQL_CHK_ERR (handle->hstmt,
+	SQL_CHK_ERR (srv_handle->cgw_hstmt,
 		     SQL_HANDLE_STMT,
-		     err_code = SQLBindParameter (handle->hstmt,
+		     err_code = SQLBindParameter (srv_handle->cgw_hstmt,
 						  bind_num,
 						  SQL_PARAM_INPUT,
-						  c_data_type, sql_bind_type, 0, 0, &value_list->real_val, 0, &indPtr));
+						  c_data_type, sql_bind_type, 0, 0, &value_list->real_val, 0,
+						  &value_list->cbValue));
       }
       break;
     case CCI_U_TYPE_DOUBLE:
@@ -1533,14 +1543,15 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 	c_data_type = SQL_C_DOUBLE;
 	sql_bind_type = SQL_DOUBLE;
 	value_list->double_val = d_val;
+	value_list->cbValue = 0;
 
-	SQL_CHK_ERR (handle->hstmt,
+	SQL_CHK_ERR (srv_handle->cgw_hstmt,
 		     SQL_HANDLE_STMT,
-		     err_code = SQLBindParameter (handle->hstmt,
+		     err_code = SQLBindParameter (srv_handle->cgw_hstmt,
 						  bind_num,
 						  SQL_PARAM_INPUT,
 						  c_data_type, sql_bind_type, 0, 0, &value_list->double_val, 0,
-						  &indPtr));
+						  &value_list->cbValue));
       }
       break;
     case CCI_U_TYPE_DATE:
@@ -1554,15 +1565,18 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 	value_list->ds_val.year = year;
 	value_list->ds_val.month = month;
 	value_list->ds_val.day = day;
+	value_list->cbValue = (SQLLEN) sizeof (value_list->ds_val);
 
-	SQL_CHK_ERR (handle->hstmt,
+	SQL_CHK_ERR (srv_handle->cgw_hstmt,
 		     SQL_HANDLE_STMT,
-		     err_code = SQLBindParameter (handle->hstmt,
+		     err_code = SQLBindParameter (srv_handle->cgw_hstmt,
 						  bind_num,
 						  SQL_PARAM_INPUT,
 						  c_data_type,
 						  sql_bind_type,
-						  sizeof (SQL_DATE_STRUCT), 0, &value_list->ds_val, 0, &indPtr));
+						  sizeof (SQL_DATE_STRUCT),
+						  0,
+						  &value_list->ds_val, sizeof (SQL_DATE_STRUCT), &value_list->cbValue));
       }
       break;
     case CCI_U_TYPE_TIME:
@@ -1576,15 +1590,18 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 	value_list->ts_val.hour = hh;
 	value_list->ts_val.minute = mm;
 	value_list->ts_val.second = ss;
+	value_list->cbValue = (SQLLEN) sizeof (value_list->ts_val);
 
-	SQL_CHK_ERR (handle->hstmt,
+	SQL_CHK_ERR (srv_handle->cgw_hstmt,
 		     SQL_HANDLE_STMT,
-		     err_code = SQLBindParameter (handle->hstmt,
+		     err_code = SQLBindParameter (srv_handle->cgw_hstmt,
 						  bind_num,
 						  SQL_PARAM_INPUT,
 						  c_data_type,
 						  sql_bind_type,
-						  sizeof (SQL_TIME_STRUCT), 0, &value_list->ts_val, 0, &indPtr));
+						  sizeof (SQL_TIME_STRUCT),
+						  0,
+						  &value_list->ts_val, sizeof (SQL_TIME_STRUCT), &value_list->cbValue));
       }
       break;
     case CCI_U_TYPE_TIMESTAMP:
@@ -1615,10 +1632,11 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 	sql_bind_type = SQL_TYPE_TIMESTAMP;
 
 	sprintf (value_list->time_stemp_str_val, "%d-%d-%d %d:%d:%d", yr, mon, day, hh, mm, ss);
+	value_list->cbValue = SQL_NTS;
 
-	SQL_CHK_ERR (handle->hstmt,
+	SQL_CHK_ERR (srv_handle->cgw_hstmt,
 		     SQL_HANDLE_STMT,
-		     err_code = SQLBindParameter (handle->hstmt,
+		     err_code = SQLBindParameter (srv_handle->cgw_hstmt,
 						  bind_num,
 						  SQL_PARAM_INPUT,
 						  c_data_type,
@@ -1626,7 +1644,7 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 						  0,
 						  0,
 						  (SQLPOINTER) (&value_list->time_stemp_str_val),
-						  sizeof (value_list->time_stemp_str_val), NULL));
+						  sizeof (value_list->time_stemp_str_val), &value_list->cbValue));
       }
       break;
     case CCI_U_TYPE_DATETIME:
@@ -1647,10 +1665,11 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 	    sql_bind_type = SQL_TYPE_TIMESTAMP;
 
 	    sprintf (value_list->time_stemp_str_val, "%d-%d-%d %d:%d:%d.%d", yr, mon, day, hh, mm, ss, ms);
+	    value_list->cbValue = SQL_NTS;
 
-	    SQL_CHK_ERR (handle->hstmt,
+	    SQL_CHK_ERR (srv_handle->cgw_hstmt,
 			 SQL_HANDLE_STMT,
-			 err_code = SQLBindParameter (handle->hstmt,
+			 err_code = SQLBindParameter (srv_handle->cgw_hstmt,
 						      bind_num,
 						      SQL_PARAM_INPUT,
 						      c_data_type,
@@ -1658,7 +1677,7 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 						      0,
 						      0,
 						      (SQLPOINTER) (&value_list->time_stemp_str_val),
-						      sizeof (value_list->time_stemp_str_val), NULL));
+						      sizeof (value_list->time_stemp_str_val), &value_list->cbValue));
 	  }
 	else if (curr_dbms_type == CAS_CGW_DBMS_ORACLE)
 	  {
@@ -1672,10 +1691,11 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 	    value_list->tss_val.minute = mm;
 	    value_list->tss_val.second = ss;
 	    value_list->tss_val.fraction = ms;
+	    value_list->cbValue = (SQLLEN) sizeof (value_list->tss_val);
 
-	    SQL_CHK_ERR (handle->hstmt,
+	    SQL_CHK_ERR (srv_handle->cgw_hstmt,
 			 SQL_HANDLE_STMT,
-			 err_code = SQLBindParameter (handle->hstmt,
+			 err_code = SQLBindParameter (srv_handle->cgw_hstmt,
 						      bind_num,
 						      SQL_PARAM_INPUT,
 						      c_data_type,
@@ -1683,7 +1703,7 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 						      0,
 						      0,
 						      (SQLPOINTER) (&value_list->tss_val),
-						      sizeof (value_list->tss_val), NULL));
+						      sizeof (value_list->tss_val), &value_list->cbValue));
 	  }
 	else
 	  {
@@ -1727,7 +1747,7 @@ ODBC_ERROR:
 }
 
 int
-cgw_sql_prepare (SQLCHAR * sql_stmt)
+cgw_sql_prepare (SQLHDBC hdbc, T_SRV_HANDLE * srv_handle, SQLCHAR * sql_stmt)
 {
   SQLRETURN err_code;
   wchar_t *out_string = NULL;
@@ -1736,11 +1756,21 @@ cgw_sql_prepare (SQLCHAR * sql_stmt)
 
   in_string = (char *) sql_stmt;
 
-  if (local_odbc_handle->hstmt == NULL)
+  if (srv_handle == NULL)
     {
-      SQL_CHK_ERR (local_odbc_handle->hdbc,
-		   SQL_HANDLE_DBC,
-		   err_code = SQLAllocHandle (SQL_HANDLE_STMT, local_odbc_handle->hdbc, &local_odbc_handle->hstmt));
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CGW_INVALID_HANDLE, 0);
+      return ER_FAILED;
+    }
+
+  if (hdbc == NULL)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CGW_INVALID_DBC_HANDLE, 0);
+      return ER_FAILED;
+    }
+
+  if (srv_handle->cgw_hstmt == NULL)
+    {
+      SQL_CHK_ERR (hdbc, SQL_HANDLE_DBC, err_code = SQLAllocHandle (SQL_HANDLE_STMT, hdbc, &srv_handle->cgw_hstmt));
     }
 
   out_length = (strlen (in_string) + 1) * sizeof (wchar_t);
@@ -1761,8 +1791,8 @@ cgw_sql_prepare (SQLCHAR * sql_stmt)
       goto ODBC_ERROR;
     }
 
-  SQL_CHK_ERR (local_odbc_handle->hstmt, SQL_HANDLE_STMT, err_code =
-	       SQLPrepareW (local_odbc_handle->hstmt, (SQLWCHAR *) out_string, SQL_NTS));
+  SQL_CHK_ERR (srv_handle->cgw_hstmt, SQL_HANDLE_STMT, err_code =
+	       SQLPrepareW (srv_handle->cgw_hstmt, (SQLWCHAR *) out_string, SQL_NTS));
 
   FREE_MEM (out_string);
   return (int) err_code;
@@ -1798,7 +1828,8 @@ ODBC_ERROR:
 }
 
 int
-cgw_make_bind_value (T_CGW_HANDLE * handle, int num_bind, int argc, void **argv, ODBC_BIND_INFO ** ret_val)
+cgw_make_bind_value (SQLHDBC hdbc, T_SRV_HANDLE * srv_handle, int num_bind, int argc, void **argv,
+		     ODBC_BIND_INFO ** ret_val)
 {
   int i, type_idx, val_idx;
   int err_code;
@@ -1806,7 +1837,7 @@ cgw_make_bind_value (T_CGW_HANDLE * handle, int num_bind, int argc, void **argv,
 
   *ret_val = NULL;
 
-  if (handle == NULL)
+  if (srv_handle == NULL)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CGW_INVALID_HANDLE, 0);
       return ER_CGW_INVALID_HANDLE;
@@ -1831,7 +1862,7 @@ cgw_make_bind_value (T_CGW_HANDLE * handle, int num_bind, int argc, void **argv,
     {
       type_idx = 2 * i;
       val_idx = 2 * i + 1;
-      err_code = cgw_set_bindparam (handle, i + 1, argv[type_idx], argv[val_idx], &(bind_value_list[i]));
+      err_code = cgw_set_bindparam (hdbc, srv_handle, i + 1, argv[type_idx], argv[val_idx], &(bind_value_list[i]));
       if (err_code < 0)
 	{
 	  for (int j = 0; j < i; j++)
@@ -2008,12 +2039,6 @@ cgw_cleanup_handle (T_CGW_HANDLE * handle)
   if (handle == NULL)
     {
       return;
-    }
-
-  if (handle->hstmt)
-    {
-      SQLFreeHandle (SQL_HANDLE_STMT, handle->hstmt);
-      handle->hstmt = NULL;
     }
 
   if (handle->hdbc)

--- a/src/broker/cas_cgw_odbc.h
+++ b/src/broker/cas_cgw_odbc.h
@@ -148,15 +148,16 @@ extern void cgw_database_disconnect (void);
 extern int cgw_is_database_connected (void);
 
 // Prepare funtions
-extern int cgw_sql_prepare (SQLCHAR * sql_stmt);
+extern int cgw_sql_prepare (SQLHDBC hdbc, T_SRV_HANDLE * srv_handle, SQLCHAR * sql_stmt);
 extern int cgw_get_num_cols (SQLHSTMT hstmt, SQLSMALLINT * num_cols);
 extern int cgw_get_col_info (SQLHSTMT hstmt, int col_num, T_ODBC_COL_INFO * col_info);
 
 // Execute funtions
 extern int cgw_set_commit_mode (SQLHDBC hdbc, bool auto_commit);
-extern int cgw_execute (T_SRV_HANDLE * srv_handle, SQLLEN * row_count);
+extern int cgw_execute (SQLHDBC hdbc, T_SRV_HANDLE * srv_handle, SQLLEN * row_count);
 extern int cgw_set_execute_info (T_SRV_HANDLE * srv_handle, T_NET_BUF * net_buf, int stmt_type);
-extern int cgw_make_bind_value (T_CGW_HANDLE * handle, int num_bind, int argc, void **argv, ODBC_BIND_INFO ** ret_val);
+extern int cgw_make_bind_value (SQLHDBC hdbc, T_SRV_HANDLE * srv_handle, int num_bind, int argc, void **argv,
+				ODBC_BIND_INFO ** ret_val);
 
 // Resultset funtions
 extern int cgw_cursor_close (T_SRV_HANDLE * srv_handle);

--- a/src/broker/cas_handle.c
+++ b/src/broker/cas_handle.c
@@ -110,7 +110,7 @@ hm_new_srv_handle (T_SRV_HANDLE ** new_handle, unsigned int seq_num)
 
   if (is_cgw_mode)
     {
-      srv_handle->cgw_handle = NULL;
+      srv_handle->cgw_hstmt = NULL;
       srv_handle->total_tuple_count = 0;
       srv_handle->stmt_type = CUBRID_STMT_NONE;
       srv_handle->is_cursor_open = false;
@@ -199,10 +199,7 @@ hm_srv_handle_free_all (bool free_holdable)
 	{
 	  cgw_free_stmt_func (srv_handle);
 	}
-      if (is_cgw_mode)
-	{
-	  srv_handle->cgw_handle = NULL;
-	}
+
       FREE_MEM (srv_handle);
       srv_handle_table[i] = NULL;
       current_handle_count--;

--- a/src/broker/cas_handle.c
+++ b/src/broker/cas_handle.c
@@ -111,6 +111,8 @@ hm_new_srv_handle (T_SRV_HANDLE ** new_handle, unsigned int seq_num)
   if (is_cgw_mode)
     {
       srv_handle->cgw_hstmt = NULL;
+      srv_handle->cgw_col_binding = NULL;
+      srv_handle->cgw_col_binding_buff = NULL;
       srv_handle->total_tuple_count = 0;
       srv_handle->stmt_type = CUBRID_STMT_NONE;
       srv_handle->is_cursor_open = false;

--- a/src/broker/cas_handle.h
+++ b/src/broker/cas_handle.h
@@ -94,7 +94,6 @@ struct t_cgw_handle
 {
   SQLHENV henv;
   SQLHDBC hdbc;
-  SQLHSTMT hstmt;
 };
 #endif /* CAS_FOR_CGW */
 
@@ -152,7 +151,7 @@ struct t_srv_handle
   bool is_from_current_transaction;
 
   /* CGW fields */
-  T_CGW_HANDLE *cgw_handle;
+  void *cgw_hstmt;
   int total_tuple_count;
   int stmt_type;
   bool is_cursor_open;

--- a/src/broker/cas_handle.h
+++ b/src/broker/cas_handle.h
@@ -152,6 +152,8 @@ struct t_srv_handle
 
   /* CGW fields */
   void *cgw_hstmt;
+  void *cgw_col_binding;
+  void *cgw_col_binding_buff;
   int total_tuple_count;
   int stmt_type;
   bool is_cursor_open;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26805

### Purpose
DBLink를 통해 원격 MySQL에 DML(INSERT 등)을 실행할 때 CAS/CGW(ODBC) 경로에서 간헐적으로 발생하던 오류를 수정합니다.

- **증상 1:** `SQLRowCount()`가 `-1`을 반환하고, 클라이언트에 `Number of rows affected is unknown` 오류가 출력됨
- **증상 2:** `[HY010] Function sequence error` 오류 발생

두 증상 모두 동일 테스트를 반복 실행할 때 간헐적으로 재현되었으며, CUBRID 11.3.5 / 11.4.5 환경에서 보고되었습니다.

**원인**

1. CGW ODBC 레이어에서 전역 SQLHSTMT 핸들(local_odbc_handle->hstmt)을 모든 CAS server handle과 DBLink 작업이 공유하는 것이 문제 원인
2. SQLBindParameter() 의 SQLLEN *pcbValue (StrLen_or_IndPtr) 파라미터가 로컬 변수 여서 SQLExecute() 에서 잘 못된 참조가 문제 원인

- 서로 다른 `T_SRV_HANDLE`에서 DBLink DML/SELECT가 연속 수행되면 `SQLHSTMT` 을 재사용하는 경우가 발생되어 **HY010**(함수 호출 순서 위반) 발생함
- 공유 handle 상태가 꼬인 뒤 `SQLRowCount()` 호출 시 영향 받은 행 수를 알 수 없음을 의미하는 **-1** 반환

### Implementation

ODBC statement handle을 **CAS server handle(`T_SRV_HANDLE`) 단위**로 관리하도록 변경합니다.

### Remarks

N/A
