### PR TITLE
[CBRD-26805] (backport to 11.3) Fix the HY010 Error During DBLink Operation

### DIFF
--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -1350,7 +1350,7 @@ cgw_set_bindparam (SQLHDBC hdbc, T_SRV_HANDLE * srv_handle, int bind_num, void *
 	    sql_bind_type = SQL_CHAR;
 
 	    value_list->string_val = value;
-	    value_list->cbValue = (SQLLEN) val_size;
+	    value_list->cbValue = SQL_NTS;
 
 	    SQL_CHK_ERR (srv_handle->cgw_hstmt,
 			 SQL_HANDLE_STMT,
@@ -1359,8 +1359,8 @@ cgw_set_bindparam (SQLHDBC hdbc, T_SRV_HANDLE * srv_handle, int bind_num, void *
 						      SQL_PARAM_INPUT,
 						      c_data_type,
 						      sql_bind_type,
-						      val_size + 1,
-						      0, value_list->string_val, val_size + 1, &value_list->cbValue));
+						      val_size - 1,
+						      0, value_list->string_val, val_size, &value_list->cbValue));
 	  }
 	else
 	  {

--- a/src/broker/cas_cgw.c
+++ b/src/broker/cas_cgw.c
@@ -95,7 +95,7 @@ static int numeric_string_adjust (SQL_NUMERIC_STRUCT * numeric, char *string);
 static int hex_to_numeric_val (SQL_NUMERIC_STRUCT * numeric, char *hexstr);
 static int hex_to_char (char c, unsigned char *result);
 static int cgw_get_stmt_Info (T_SRV_HANDLE * srv_handle, SQLHSTMT hstmt, T_NET_BUF * net_buf, int stmt_type);
-static int cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *net_value,
+static int cgw_set_bindparam (SQLHDBC hdbc, T_SRV_HANDLE * srv_handle, int bind_num, void *net_type, void *net_value,
 			      ODBC_BIND_INFO * value_list);
 static char cgw_odbc_type_to_cci_u_type (SQLLEN odbc_type, SQLLEN is_unsigned_type);
 static char cgw_odbc_type_to_charset (SQLLEN odbc_type, SQLLEN is_unsigned_type);
@@ -154,11 +154,13 @@ cgw_cleanup ()
 void
 cgw_free_stmt (T_SRV_HANDLE * srv_handle)
 {
-  if (srv_handle->cgw_handle->hstmt)
+  if (srv_handle == NULL || srv_handle->cgw_hstmt == NULL)
     {
-      SQLFreeHandle (SQL_HANDLE_STMT, local_odbc_handle->hstmt);
-      local_odbc_handle->hstmt = NULL;
+      return;
     }
+
+  SQLFreeHandle (SQL_HANDLE_STMT, srv_handle->cgw_hstmt);
+  srv_handle->cgw_hstmt = NULL;
 }
 
 int
@@ -246,10 +248,6 @@ cgw_database_connect (T_DBMS_TYPE dbms_type, const char *connect_url, char *db_n
 
   cgw_link_server_info (local_odbc_handle->hdbc);
 
-  SQL_CHK_ERR (local_odbc_handle->hdbc,
-	       SQL_HANDLE_DBC,
-	       err_code = SQLAllocHandle (SQL_HANDLE_STMT, local_odbc_handle->hdbc, &local_odbc_handle->hstmt));
-
   strncpy (connected_db_name, db_name, sizeof (connected_db_name) - 1);
   strncpy (connected_db_user, db_user, sizeof (connected_db_user) - 1);
   strncpy (connected_db_passwd, db_passwd, sizeof (connected_db_passwd) - 1);
@@ -272,45 +270,48 @@ ODBC_ERROR:
 }
 
 int
-cgw_execute (T_SRV_HANDLE * srv_handle, SQLLEN * row_count)
+cgw_execute (SQLHDBC hdbc, T_SRV_HANDLE * srv_handle, SQLLEN * row_count)
 {
   SQLRETURN err_code;
 
-  if (srv_handle->num_markers > 0)
+  if (srv_handle == NULL)
     {
-      if (srv_handle->cgw_handle->hdbc == NULL)
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CGW_INVALID_HANDLE, 0);
+      goto ODBC_ERROR;
+    }
+
+  if (srv_handle->cgw_hstmt == NULL)
+    {
+      if (hdbc == NULL)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CGW_INVALID_DBC_HANDLE, 0);
 	  goto ODBC_ERROR;
 	}
-
-      if (srv_handle->cgw_handle->hstmt == NULL)
-	{
-	  SQL_CHK_ERR (srv_handle->cgw_handle->hdbc,
-		       SQL_HANDLE_DBC, err_code =
-		       SQLAllocHandle (SQL_HANDLE_STMT, local_odbc_handle->hdbc, &srv_handle->cgw_handle->hstmt));
-	}
+      SQL_CHK_ERR (hdbc, SQL_HANDLE_DBC, err_code = SQLAllocHandle (SQL_HANDLE_STMT, hdbc, &srv_handle->cgw_hstmt));
     }
 
-  SQL_CHK_ERR (srv_handle->cgw_handle->hstmt, SQL_HANDLE_STMT, err_code = SQLExecute (srv_handle->cgw_handle->hstmt));
+  SQL_CHK_ERR (srv_handle->cgw_hstmt, SQL_HANDLE_STMT, err_code = SQLExecute (srv_handle->cgw_hstmt));
 
   if (err_code < 0)
     {
-      cgw_error_msg (srv_handle->cgw_handle->hstmt, SQL_HANDLE_STMT, err_code);
+      cgw_error_msg (srv_handle->cgw_hstmt, SQL_HANDLE_STMT, err_code);
       goto ODBC_ERROR;
     }
 
-  SQLRowCount (srv_handle->cgw_handle->hstmt, row_count);
+  SQLRowCount (srv_handle->cgw_hstmt, row_count);
 
   srv_handle->is_cursor_open = true;
 
   return NO_ERROR;
 
 ODBC_ERROR:
-  if (srv_handle->cgw_handle->hstmt)
+  if (srv_handle != NULL)
     {
-      SQLFreeHandle (SQL_HANDLE_STMT, srv_handle->cgw_handle->hstmt);
-      srv_handle->cgw_handle->hstmt = NULL;
+      if (srv_handle->is_cursor_open && srv_handle->cgw_hstmt != NULL)
+	{
+	  (void) cgw_cursor_close (srv_handle);
+	}
+      srv_handle->is_cursor_open = false;
     }
 
   return ER_FAILED;
@@ -352,14 +353,13 @@ cgw_cursor_close (T_SRV_HANDLE * srv_handle)
 {
   SQLRETURN err_code = 0;
 
-  if (srv_handle->cgw_handle->hstmt == NULL)
+  if (srv_handle->cgw_hstmt == NULL)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CGW_INVALID_STMT_HANDLE, 0);
       goto ODBC_ERROR;
     }
 
-  SQL_CHK_ERR (srv_handle->cgw_handle->hstmt, SQL_HANDLE_STMT, err_code =
-	       SQLFreeStmt (srv_handle->cgw_handle->hstmt, SQL_CLOSE));
+  SQL_CHK_ERR (srv_handle->cgw_hstmt, SQL_HANDLE_STMT, err_code = SQLFreeStmt (srv_handle->cgw_hstmt, SQL_CLOSE));
 
   srv_handle->is_cursor_open = false;
 
@@ -904,7 +904,7 @@ cgw_set_execute_info (T_SRV_HANDLE * srv_handle, T_NET_BUF * net_buf, int stmt_t
 
   for (int i = 0; i < srv_handle->num_q_result; i++)
     {
-      err_code = cgw_get_stmt_Info (srv_handle, srv_handle->cgw_handle->hstmt, net_buf, stmt_type);
+      err_code = cgw_get_stmt_Info (srv_handle, srv_handle->cgw_hstmt, net_buf, stmt_type);
       if (err_code < 0)
 	{
 	  goto ODBC_ERROR;
@@ -1175,12 +1175,6 @@ cgw_database_disconnect ()
       return;
     }
 
-  if (local_odbc_handle->hstmt)
-    {
-      SQLFreeHandle (SQL_HANDLE_STMT, local_odbc_handle->hstmt);
-      local_odbc_handle->hstmt = NULL;
-    }
-
   if (local_odbc_handle->hdbc)
     {
       SQLDisconnect (local_odbc_handle->hdbc);
@@ -1194,23 +1188,23 @@ cgw_database_disconnect ()
 }
 
 static int
-cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *net_value, ODBC_BIND_INFO * value_list)
+cgw_set_bindparam (SQLHDBC hdbc, T_SRV_HANDLE * srv_handle, int bind_num, void *net_type, void *net_value,
+		   ODBC_BIND_INFO * value_list)
 {
   char type;
   char src_type = -1;
   int err_code = 0;
   int data_size;
-  SQLLEN indPtr = 0;
   SQLSMALLINT c_data_type;
   SQLSMALLINT sql_bind_type;
 
-  if (handle == NULL)
+  if (srv_handle == NULL)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CGW_INVALID_HANDLE, 0);
       return ER_CGW_INVALID_HANDLE;
     }
 
-  if (handle->hstmt == NULL)
+  if (srv_handle->cgw_hstmt == NULL)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CGW_INVALID_STMT_HANDLE, 0);
       return ER_CGW_INVALID_STMT_HANDLE;
@@ -1259,14 +1253,18 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 	  }
 
 	value_list->wchar_val = out_string;
+	value_list->cbValue = SQL_NTS;
 
-	SQL_CHK_ERR (handle->hstmt,
+	SQL_CHK_ERR (srv_handle->cgw_hstmt,
 		     SQL_HANDLE_STMT,
-		     err_code = SQLBindParameter (handle->hstmt,
+		     err_code = SQLBindParameter (srv_handle->cgw_hstmt,
 						  bind_num,
 						  SQL_PARAM_INPUT,
 						  c_data_type,
-						  sql_bind_type, out_length, 0, (SQLWCHAR *) out_string, 0, NULL));
+						  sql_bind_type,
+						  out_length,
+						  0,
+						  (SQLWCHAR *) out_string, (SQLLEN) out_length, &value_list->cbValue));
       }
       break;
       /* Not Support Type */
@@ -1300,14 +1298,18 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 	  }
 
 	value_list->wchar_val = out_string;
+	value_list->cbValue = SQL_NTS;
 
-	SQL_CHK_ERR (handle->hstmt,
+	SQL_CHK_ERR (srv_handle->cgw_hstmt,
 		     SQL_HANDLE_STMT,
-		     err_code = SQLBindParameter (handle->hstmt,
+		     err_code = SQLBindParameter (srv_handle->cgw_hstmt,
 						  bind_num,
 						  SQL_PARAM_INPUT,
 						  c_data_type,
-						  sql_bind_type, out_length, 0, (SQLWCHAR *) out_string, 0, NULL));
+						  sql_bind_type,
+						  out_length,
+						  0,
+						  (SQLWCHAR *) out_string, (SQLLEN) out_length, &value_list->cbValue));
       }
       break;
     case CCI_U_TYPE_NULL:
@@ -1323,9 +1325,9 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 	value_list->cbValue = SQL_NULL_DATA;
 	value_list->string_val = value;
 
-	SQL_CHK_ERR (handle->hstmt,
+	SQL_CHK_ERR (srv_handle->cgw_hstmt,
 		     SQL_HANDLE_STMT,
-		     err_code = SQLBindParameter (handle->hstmt,
+		     err_code = SQLBindParameter (srv_handle->cgw_hstmt,
 						  bind_num,
 						  SQL_PARAM_INPUT,
 						  c_data_type,
@@ -1348,14 +1350,17 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 	    sql_bind_type = SQL_CHAR;
 
 	    value_list->string_val = value;
+	    value_list->cbValue = (SQLLEN) val_size;
 
-	    SQL_CHK_ERR (handle->hstmt,
+	    SQL_CHK_ERR (srv_handle->cgw_hstmt,
 			 SQL_HANDLE_STMT,
-			 err_code = SQLBindParameter (handle->hstmt,
+			 err_code = SQLBindParameter (srv_handle->cgw_hstmt,
 						      bind_num,
 						      SQL_PARAM_INPUT,
 						      c_data_type,
-						      sql_bind_type, val_size + 1, 0, value_list->string_val, 0, NULL));
+						      sql_bind_type,
+						      val_size + 1,
+						      0, value_list->string_val, val_size + 1, &value_list->cbValue));
 	  }
 	else
 	  {
@@ -1367,8 +1372,13 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 	    SQLHDESC hdesc = NULL;
 	    DB_BIGINT bi_val;
 
-	    SQL_CHK_ERR (handle->hdbc, SQL_HANDLE_DBC, err_code =
-			 SQLAllocHandle (SQL_HANDLE_DESC, handle->hdbc, &hdesc));
+	    if (hdbc == NULL)
+	      {
+		er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CGW_INVALID_DBC_HANDLE, 0);
+		return ER_CGW_INVALID_DBC_HANDLE;
+	      }
+
+	    SQL_CHK_ERR (hdbc, SQL_HANDLE_DBC, err_code = SQLAllocHandle (SQL_HANDLE_DESC, hdbc, &hdesc));
 
 	    memset (&value_list->ns_val, 0x00, sizeof (SQL_NUMERIC_STRUCT));
 
@@ -1431,18 +1441,18 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 
 	    c_data_type = SQL_C_NUMERIC;
 	    sql_bind_type = SQL_DECIMAL;
+	    value_list->cbValue = (SQLLEN) sizeof (value_list->ns_val);
 
-	    indPtr = sizeof (value_list->ns_val);
-	    SQL_CHK_ERR (handle->hstmt,
+	    SQL_CHK_ERR (srv_handle->cgw_hstmt,
 			 SQL_HANDLE_STMT,
-			 err_code = SQLBindParameter (handle->hstmt,
+			 err_code = SQLBindParameter (srv_handle->cgw_hstmt,
 						      bind_num,
 						      SQL_PARAM_INPUT,
 						      c_data_type,
 						      sql_bind_type,
 						      value_list->ns_val.precision,
-						      value_list->ns_val.scale, &value_list->ns_val, 0,
-						      (SQLLEN *) & indPtr));
+						      value_list->ns_val.scale,
+						      &value_list->ns_val, 0, &value_list->cbValue));
 
 	    SQL_CHK_ERR (hdesc,
 			 SQL_HANDLE_DESC,
@@ -1479,14 +1489,15 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 	sql_bind_type = SQL_BIGINT;
 
 	value_list->bigint_val = bi_val;
+	value_list->cbValue = 0;
 
-	SQL_CHK_ERR (handle->hstmt,
+	SQL_CHK_ERR (srv_handle->cgw_hstmt,
 		     SQL_HANDLE_STMT,
-		     err_code = SQLBindParameter (handle->hstmt,
+		     err_code = SQLBindParameter (srv_handle->cgw_hstmt,
 						  bind_num,
 						  SQL_PARAM_INPUT,
 						  c_data_type, sql_bind_type, 0, 0, &value_list->bigint_val, 0,
-						  &indPtr));
+						  &value_list->cbValue));
       }
       break;
     case CCI_U_TYPE_INT:
@@ -1500,15 +1511,15 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 	sql_bind_type = SQL_INTEGER;
 
 	value_list->integer_val = i_val;
+	value_list->cbValue = 0;
 
-
-	SQL_CHK_ERR (handle->hstmt,
+	SQL_CHK_ERR (srv_handle->cgw_hstmt,
 		     SQL_HANDLE_STMT,
-		     err_code = SQLBindParameter (handle->hstmt,
+		     err_code = SQLBindParameter (srv_handle->cgw_hstmt,
 						  bind_num,
 						  SQL_PARAM_INPUT,
 						  c_data_type, sql_bind_type, 0, 0, &value_list->integer_val, 0,
-						  &indPtr));
+						  &value_list->cbValue));
 
       }
       break;
@@ -1522,14 +1533,15 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 	c_data_type = SQL_C_SHORT;
 	sql_bind_type = SQL_SMALLINT;
 	value_list->smallInt_val = s_val;
+	value_list->cbValue = 0;
 
-	SQL_CHK_ERR (handle->hstmt,
+	SQL_CHK_ERR (srv_handle->cgw_hstmt,
 		     SQL_HANDLE_STMT,
-		     err_code = SQLBindParameter (handle->hstmt,
+		     err_code = SQLBindParameter (srv_handle->cgw_hstmt,
 						  bind_num,
 						  SQL_PARAM_INPUT,
 						  c_data_type, sql_bind_type, 0, 0, &value_list->smallInt_val, 0,
-						  &indPtr));
+						  &value_list->cbValue));
       }
       break;
     case CCI_U_TYPE_FLOAT:
@@ -1541,13 +1553,15 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 	c_data_type = SQL_C_FLOAT;
 	sql_bind_type = SQL_REAL;
 	value_list->real_val = f_val;
+	value_list->cbValue = 0;
 
-	SQL_CHK_ERR (handle->hstmt,
+	SQL_CHK_ERR (srv_handle->cgw_hstmt,
 		     SQL_HANDLE_STMT,
-		     err_code = SQLBindParameter (handle->hstmt,
+		     err_code = SQLBindParameter (srv_handle->cgw_hstmt,
 						  bind_num,
 						  SQL_PARAM_INPUT,
-						  c_data_type, sql_bind_type, 0, 0, &value_list->real_val, 0, &indPtr));
+						  c_data_type, sql_bind_type, 0, 0, &value_list->real_val, 0,
+						  &value_list->cbValue));
       }
       break;
     case CCI_U_TYPE_DOUBLE:
@@ -1558,14 +1572,15 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 	c_data_type = SQL_C_DOUBLE;
 	sql_bind_type = SQL_DOUBLE;
 	value_list->double_val = d_val;
+	value_list->cbValue = 0;
 
-	SQL_CHK_ERR (handle->hstmt,
+	SQL_CHK_ERR (srv_handle->cgw_hstmt,
 		     SQL_HANDLE_STMT,
-		     err_code = SQLBindParameter (handle->hstmt,
+		     err_code = SQLBindParameter (srv_handle->cgw_hstmt,
 						  bind_num,
 						  SQL_PARAM_INPUT,
 						  c_data_type, sql_bind_type, 0, 0, &value_list->double_val, 0,
-						  &indPtr));
+						  &value_list->cbValue));
       }
       break;
     case CCI_U_TYPE_DATE:
@@ -1579,15 +1594,18 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 	value_list->ds_val.year = year;
 	value_list->ds_val.month = month;
 	value_list->ds_val.day = day;
+	value_list->cbValue = (SQLLEN) sizeof (value_list->ds_val);
 
-	SQL_CHK_ERR (handle->hstmt,
+	SQL_CHK_ERR (srv_handle->cgw_hstmt,
 		     SQL_HANDLE_STMT,
-		     err_code = SQLBindParameter (handle->hstmt,
+		     err_code = SQLBindParameter (srv_handle->cgw_hstmt,
 						  bind_num,
 						  SQL_PARAM_INPUT,
 						  c_data_type,
 						  sql_bind_type,
-						  sizeof (SQL_DATE_STRUCT), 0, &value_list->ds_val, 0, &indPtr));
+						  sizeof (SQL_DATE_STRUCT),
+						  0,
+						  &value_list->ds_val, sizeof (SQL_DATE_STRUCT), &value_list->cbValue));
       }
       break;
     case CCI_U_TYPE_TIME:
@@ -1601,15 +1619,18 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 	value_list->ts_val.hour = hh;
 	value_list->ts_val.minute = mm;
 	value_list->ts_val.second = ss;
+	value_list->cbValue = (SQLLEN) sizeof (value_list->ts_val);
 
-	SQL_CHK_ERR (handle->hstmt,
+	SQL_CHK_ERR (srv_handle->cgw_hstmt,
 		     SQL_HANDLE_STMT,
-		     err_code = SQLBindParameter (handle->hstmt,
+		     err_code = SQLBindParameter (srv_handle->cgw_hstmt,
 						  bind_num,
 						  SQL_PARAM_INPUT,
 						  c_data_type,
 						  sql_bind_type,
-						  sizeof (SQL_TIME_STRUCT), 0, &value_list->ts_val, 0, &indPtr));
+						  sizeof (SQL_TIME_STRUCT),
+						  0,
+						  &value_list->ts_val, sizeof (SQL_TIME_STRUCT), &value_list->cbValue));
       }
       break;
     case CCI_U_TYPE_TIMESTAMP:
@@ -1640,10 +1661,11 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 	sql_bind_type = SQL_TYPE_TIMESTAMP;
 
 	sprintf (value_list->time_stemp_str_val, "%d-%d-%d %d:%d:%d", yr, mon, day, hh, mm, ss);
+	value_list->cbValue = SQL_NTS;
 
-	SQL_CHK_ERR (handle->hstmt,
+	SQL_CHK_ERR (srv_handle->cgw_hstmt,
 		     SQL_HANDLE_STMT,
-		     err_code = SQLBindParameter (handle->hstmt,
+		     err_code = SQLBindParameter (srv_handle->cgw_hstmt,
 						  bind_num,
 						  SQL_PARAM_INPUT,
 						  c_data_type,
@@ -1651,7 +1673,7 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 						  0,
 						  0,
 						  (SQLPOINTER) (&value_list->time_stemp_str_val),
-						  sizeof (value_list->time_stemp_str_val), NULL));
+						  sizeof (value_list->time_stemp_str_val), &value_list->cbValue));
       }
       break;
     case CCI_U_TYPE_DATETIME:
@@ -1672,10 +1694,11 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 	    sql_bind_type = SQL_TYPE_TIMESTAMP;
 
 	    sprintf (value_list->time_stemp_str_val, "%d-%d-%d %d:%d:%d.%d", yr, mon, day, hh, mm, ss, ms);
+	    value_list->cbValue = SQL_NTS;
 
-	    SQL_CHK_ERR (handle->hstmt,
+	    SQL_CHK_ERR (srv_handle->cgw_hstmt,
 			 SQL_HANDLE_STMT,
-			 err_code = SQLBindParameter (handle->hstmt,
+			 err_code = SQLBindParameter (srv_handle->cgw_hstmt,
 						      bind_num,
 						      SQL_PARAM_INPUT,
 						      c_data_type,
@@ -1683,7 +1706,7 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 						      0,
 						      0,
 						      (SQLPOINTER) (&value_list->time_stemp_str_val),
-						      sizeof (value_list->time_stemp_str_val), NULL));
+						      sizeof (value_list->time_stemp_str_val), &value_list->cbValue));
 	  }
 	else if (curr_dbms_type == CAS_CGW_DBMS_ORACLE)
 	  {
@@ -1697,10 +1720,11 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 	    value_list->tss_val.minute = mm;
 	    value_list->tss_val.second = ss;
 	    value_list->tss_val.fraction = ms;
+	    value_list->cbValue = (SQLLEN) sizeof (value_list->tss_val);
 
-	    SQL_CHK_ERR (handle->hstmt,
+	    SQL_CHK_ERR (srv_handle->cgw_hstmt,
 			 SQL_HANDLE_STMT,
-			 err_code = SQLBindParameter (handle->hstmt,
+			 err_code = SQLBindParameter (srv_handle->cgw_hstmt,
 						      bind_num,
 						      SQL_PARAM_INPUT,
 						      c_data_type,
@@ -1708,7 +1732,7 @@ cgw_set_bindparam (T_CGW_HANDLE * handle, int bind_num, void *net_type, void *ne
 						      0,
 						      0,
 						      (SQLPOINTER) (&value_list->tss_val),
-						      sizeof (value_list->tss_val), NULL));
+						      sizeof (value_list->tss_val), &value_list->cbValue));
 	  }
 	else
 	  {
@@ -1752,7 +1776,7 @@ ODBC_ERROR:
 }
 
 int
-cgw_sql_prepare (SQLCHAR * sql_stmt)
+cgw_sql_prepare (SQLHDBC hdbc, T_SRV_HANDLE * srv_handle, SQLCHAR * sql_stmt)
 {
   SQLRETURN err_code;
   wchar_t *out_string = NULL;
@@ -1761,11 +1785,21 @@ cgw_sql_prepare (SQLCHAR * sql_stmt)
 
   in_string = (char *) sql_stmt;
 
-  if (local_odbc_handle->hstmt == NULL)
+  if (srv_handle == NULL)
     {
-      SQL_CHK_ERR (local_odbc_handle->hdbc,
-		   SQL_HANDLE_DBC,
-		   err_code = SQLAllocHandle (SQL_HANDLE_STMT, local_odbc_handle->hdbc, &local_odbc_handle->hstmt));
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CGW_INVALID_HANDLE, 0);
+      return ER_FAILED;
+    }
+
+  if (hdbc == NULL)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CGW_INVALID_DBC_HANDLE, 0);
+      return ER_FAILED;
+    }
+
+  if (srv_handle->cgw_hstmt == NULL)
+    {
+      SQL_CHK_ERR (hdbc, SQL_HANDLE_DBC, err_code = SQLAllocHandle (SQL_HANDLE_STMT, hdbc, &srv_handle->cgw_hstmt));
     }
 
   out_length = (strlen (in_string) + 1) * sizeof (wchar_t);
@@ -1786,8 +1820,8 @@ cgw_sql_prepare (SQLCHAR * sql_stmt)
       goto ODBC_ERROR;
     }
 
-  SQL_CHK_ERR (local_odbc_handle->hstmt, SQL_HANDLE_STMT, err_code =
-	       SQLPrepareW (local_odbc_handle->hstmt, (SQLWCHAR *) out_string, SQL_NTS));
+  SQL_CHK_ERR (srv_handle->cgw_hstmt, SQL_HANDLE_STMT, err_code =
+	       SQLPrepareW (srv_handle->cgw_hstmt, (SQLWCHAR *) out_string, SQL_NTS));
 
   FREE_MEM (out_string);
   return (int) err_code;
@@ -1823,7 +1857,8 @@ ODBC_ERROR:
 }
 
 int
-cgw_make_bind_value (T_CGW_HANDLE * handle, int num_bind, int argc, void **argv, ODBC_BIND_INFO ** ret_val)
+cgw_make_bind_value (SQLHDBC hdbc, T_SRV_HANDLE * srv_handle, int num_bind, int argc, void **argv,
+		     ODBC_BIND_INFO ** ret_val)
 {
   int i, type_idx, val_idx;
   int err_code;
@@ -1831,7 +1866,7 @@ cgw_make_bind_value (T_CGW_HANDLE * handle, int num_bind, int argc, void **argv,
 
   *ret_val = NULL;
 
-  if (handle == NULL)
+  if (srv_handle == NULL)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CGW_INVALID_HANDLE, 0);
       return ER_CGW_INVALID_HANDLE;
@@ -1856,7 +1891,7 @@ cgw_make_bind_value (T_CGW_HANDLE * handle, int num_bind, int argc, void **argv,
     {
       type_idx = 2 * i;
       val_idx = 2 * i + 1;
-      err_code = cgw_set_bindparam (handle, i + 1, argv[type_idx], argv[val_idx], &(bind_value_list[i]));
+      err_code = cgw_set_bindparam (hdbc, srv_handle, i + 1, argv[type_idx], argv[val_idx], &(bind_value_list[i]));
       if (err_code < 0)
 	{
 	  for (int j = 0; j < i; j++)
@@ -2033,12 +2068,6 @@ cgw_cleanup_handle (T_CGW_HANDLE * handle)
   if (handle == NULL)
     {
       return;
-    }
-
-  if (handle->hstmt)
-    {
-      SQLFreeHandle (SQL_HANDLE_STMT, handle->hstmt);
-      handle->hstmt = NULL;
     }
 
   if (handle->hdbc)

--- a/src/broker/cas_cgw.h
+++ b/src/broker/cas_cgw.h
@@ -161,15 +161,16 @@ extern void cgw_database_disconnect (void);
 extern int cgw_is_database_connected (void);
 
 // Prepare funtions
-extern int cgw_sql_prepare (SQLCHAR * sql_stmt);
+extern int cgw_sql_prepare (SQLHDBC hdbc, T_SRV_HANDLE * srv_handle, SQLCHAR * sql_stmt);
 extern int cgw_get_num_cols (SQLHSTMT hstmt, SQLSMALLINT * num_cols);
 extern int cgw_get_col_info (SQLHSTMT hstmt, int col_num, T_ODBC_COL_INFO * col_info);
 
 // Execute funtions
 extern int cgw_set_commit_mode (SQLHDBC hdbc, bool auto_commit);
-extern int cgw_execute (T_SRV_HANDLE * srv_handle, SQLLEN * row_count);
+extern int cgw_execute (SQLHDBC hdbc, T_SRV_HANDLE * srv_handle, SQLLEN * row_count);
 extern int cgw_set_execute_info (T_SRV_HANDLE * srv_handle, T_NET_BUF * net_buf, int stmt_type);
-extern int cgw_make_bind_value (T_CGW_HANDLE * handle, int num_bind, int argc, void **argv, ODBC_BIND_INFO ** ret_val);
+extern int cgw_make_bind_value (SQLHDBC hdbc, T_SRV_HANDLE * srv_handle, int num_bind, int argc, void **argv,
+				ODBC_BIND_INFO ** ret_val);
 
 // Resultset funtions
 extern int cgw_cursor_close (T_SRV_HANDLE * srv_handle);

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -3265,8 +3265,8 @@ ux_cursor_close (T_SRV_HANDLE * srv_handle)
       return;
     }
 #if defined(CAS_FOR_CGW)
-  cgw_cleanup_col_bindings (srv_handle);
   cgw_cursor_close (srv_handle);
+  cgw_cleanup_col_bindings (srv_handle);
 #else
   ux_free_result (srv_handle->q_result[idx].result);
   srv_handle->q_result[idx].result = NULL;
@@ -5805,6 +5805,11 @@ cgw_cleanup_col_bindings (T_SRV_HANDLE * srv_handle)
       return;
     }
 
+  if (srv_handle->cgw_hstmt != NULL)
+    {
+      (void) SQLFreeStmt ((SQLHSTMT) srv_handle->cgw_hstmt, SQL_UNBIND);
+    }
+
   col_binding = (T_COL_BINDER *) srv_handle->cgw_col_binding;
   col_binding_buff = (T_COL_BINDER *) srv_handle->cgw_col_binding_buff;
 
@@ -5943,8 +5948,6 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
 	    {
 	      fetch_end_flag = 1;
 
-	      cgw_cleanup_col_bindings (srv_handle);
-
 	      err_code = cgw_cursor_close (srv_handle);
 	      if (err_code < 0)
 		{
@@ -5952,6 +5955,7 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
 		  goto fetch_error;
 		}
 
+	      cgw_cleanup_col_bindings (srv_handle);
 
 	      if (check_auto_commit_after_getting_result (srv_handle) == true)
 		{
@@ -5995,14 +5999,14 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
 	{
 	  fetch_end_flag = 1;
 
-	  cgw_cleanup_col_bindings (srv_handle);
-
 	  err_code = cgw_cursor_close (srv_handle);
 	  if (err_code < 0)
 	    {
 	      err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
 	      goto fetch_error;
 	    }
+
+	  cgw_cleanup_col_bindings (srv_handle);
 
 	  if (check_auto_commit_after_getting_result (srv_handle) == true)
 	    {
@@ -6034,6 +6038,11 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
   return 0;
 
 fetch_error:
+  if (srv_handle->is_cursor_open)
+    {
+      (void) cgw_cursor_close (srv_handle);
+    }
+
   cgw_cleanup_col_bindings (srv_handle);
 
   return err_code;
@@ -11811,6 +11820,16 @@ recompile_statement (T_SRV_HANDLE * srv_handle)
 void
 ux_cgw_free_stmt (T_SRV_HANDLE * srv_handle)
 {
+  if (srv_handle == NULL)
+    {
+      return;
+    }
+
+  if (srv_handle->is_cursor_open)
+    {
+      (void) cgw_cursor_close (srv_handle);
+    }
+
   cgw_cleanup_col_bindings (srv_handle);
   cgw_free_stmt (srv_handle);
 }

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -235,6 +235,7 @@ static void set_column_info (T_NET_BUF * net_buf, char ut, short scale, int prec
 */
 static int fetch_result (T_SRV_HANDLE *, int, int, char, int, T_NET_BUF *, T_REQ_INFO *);
 #if defined(CAS_FOR_CGW)
+static void cgw_cleanup_col_bindings (T_SRV_HANDLE * srv_handle);
 static int cgw_fetch_result (T_SRV_HANDLE *, int, int, char, int, T_NET_BUF *, T_REQ_INFO *);
 #endif /* CAS_FOR_CGW */
 static int fetch_class (T_SRV_HANDLE *, int, int, char, int, T_NET_BUF *, T_REQ_INFO *);
@@ -1049,6 +1050,7 @@ ux_cgw_prepare (char *sql_stmt, int flag, char auto_commit_mode, T_NET_BUF * net
   int num_markers;
   T_BROKER_VERSION client_version = req_info->client_version;
   int result_cache_lifetime;
+  T_CGW_HANDLE *cgw_handle = NULL;
 
   if ((flag & CCI_PREPARE_UPDATABLE) && (flag & CCI_PREPARE_HOLDABLE))
     {
@@ -1065,7 +1067,7 @@ ux_cgw_prepare (char *sql_stmt, int flag, char auto_commit_mode, T_NET_BUF * net
       goto prepare_error;
     }
 
-  err_code = cgw_get_handle (&srv_handle->cgw_handle);
+  err_code = cgw_get_handle (&cgw_handle);
   if (err_code < 0)
     {
       err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
@@ -1106,7 +1108,7 @@ ux_cgw_prepare (char *sql_stmt, int flag, char auto_commit_mode, T_NET_BUF * net
   srv_handle->num_markers = num_markers;
   srv_handle->prepare_flag = flag;
 
-  err_code = cgw_sql_prepare ((SQLCHAR *) sql_stmt);
+  err_code = cgw_sql_prepare (cgw_handle->hdbc, srv_handle, (SQLCHAR *) sql_stmt);
   if (err_code < 0)
     {
       err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
@@ -1130,8 +1132,7 @@ ux_cgw_prepare (char *sql_stmt, int flag, char auto_commit_mode, T_NET_BUF * net
   net_buf_cp_int (net_buf, num_markers, NULL);
 
   err_code =
-    cgw_prepare_column_list_info_set (srv_handle->cgw_handle->hstmt, flag, srv_handle->stmt_type, client_version,
-				      net_buf);
+    cgw_prepare_column_list_info_set (srv_handle->cgw_hstmt, flag, srv_handle->stmt_type, client_version, net_buf);
 
   if (err_code < 0)
     {
@@ -1332,10 +1333,18 @@ ux_cgw_execute (T_SRV_HANDLE * srv_handle, char flag, int max_col_size, int max_
   SQLLEN row_count = 0;
   T_BROKER_VERSION client_version = req_info->client_version;
   ODBC_BIND_INFO *bind_data_list = NULL;
+  T_CGW_HANDLE *cgw_handle = NULL;
+
+  err_code = cgw_get_handle (&cgw_handle);
+  if (err_code < 0)
+    {
+      err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
+      goto execute_error;
+    }
 
   if (srv_handle->is_prepared == FALSE)
     {
-      err_code = cgw_sql_prepare ((SQLCHAR *) srv_handle->sql_stmt);
+      err_code = cgw_sql_prepare (cgw_handle->hdbc, srv_handle, (SQLCHAR *) srv_handle->sql_stmt);
 
       if (err_code < 0)
 	{
@@ -1348,7 +1357,7 @@ ux_cgw_execute (T_SRV_HANDLE * srv_handle, char flag, int max_col_size, int max_
 
   if (num_bind > 0)
     {
-      err_code = cgw_make_bind_value (srv_handle->cgw_handle, num_bind, argc, argv, &bind_data_list);
+      err_code = cgw_make_bind_value (cgw_handle->hdbc, srv_handle, num_bind, argc, argv, &bind_data_list);
       if (err_code < 0)
 	{
 	  err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
@@ -1356,33 +1365,16 @@ ux_cgw_execute (T_SRV_HANDLE * srv_handle, char flag, int max_col_size, int max_
 	}
     }
 
-  if (srv_handle->is_prepared == FALSE)
-    {
-      err_code = cgw_sql_prepare ((SQLCHAR *) srv_handle->sql_stmt);
-
-      if (err_code != SQL_SUCCESS && err_code != SQL_SUCCESS_WITH_INFO)
-	{
-	  err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
-	  goto execute_error;
-	}
-
-      err_code = cgw_set_commit_mode (srv_handle->cgw_handle->hdbc, srv_handle->auto_commit_mode);
-      if (err_code != NO_ERROR)
-	{
-	  err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
-	  goto execute_error;
-	}
-    }
   srv_handle->is_from_current_transaction = true;
 
-  err_code = cgw_set_commit_mode (srv_handle->cgw_handle->hdbc, srv_handle->auto_commit_mode);
+  err_code = cgw_set_commit_mode (cgw_handle->hdbc, srv_handle->auto_commit_mode);
   if (err_code != NO_ERROR)
     {
       err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
       goto execute_error;
     }
 
-  err_code = cgw_execute (srv_handle, &row_count);
+  err_code = cgw_execute (cgw_handle->hdbc, srv_handle, &row_count);
   if (err_code < 0)
     {
       err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
@@ -1459,7 +1451,7 @@ ux_cgw_execute (T_SRV_HANDLE * srv_handle, char flag, int max_col_size, int max_
 	  net_buf_cp_int (net_buf, srv_handle->num_markers, NULL);
 
 	  err_code =
-	    cgw_prepare_column_list_info_set (srv_handle->cgw_handle->hstmt, flag, srv_handle->stmt_type,
+	    cgw_prepare_column_list_info_set (srv_handle->cgw_hstmt, flag, srv_handle->stmt_type,
 					      client_version, net_buf);
 	  if (err_code != NO_ERROR)
 	    {
@@ -3273,6 +3265,7 @@ ux_cursor_close (T_SRV_HANDLE * srv_handle)
       return;
     }
 #if defined(CAS_FOR_CGW)
+  cgw_cleanup_col_bindings (srv_handle);
   cgw_cursor_close (srv_handle);
 #else
   ux_free_result (srv_handle->q_result[idx].result);
@@ -5801,6 +5794,33 @@ oid_data_set (T_NET_BUF * net_buf, DB_OBJECT * obj, int attr_num, char **attr_na
 }
 
 #if defined (CAS_FOR_CGW)
+static void
+cgw_cleanup_col_bindings (T_SRV_HANDLE * srv_handle)
+{
+  T_COL_BINDER *col_binding;
+  T_COL_BINDER *col_binding_buff;
+
+  if (srv_handle == NULL)
+    {
+      return;
+    }
+
+  col_binding = (T_COL_BINDER *) srv_handle->cgw_col_binding;
+  col_binding_buff = (T_COL_BINDER *) srv_handle->cgw_col_binding_buff;
+
+  if (col_binding != NULL)
+    {
+      cgw_cleanup_binder (col_binding);
+      srv_handle->cgw_col_binding = NULL;
+    }
+
+  if (col_binding_buff != NULL)
+    {
+      cgw_cleanup_binder (col_binding_buff);
+      srv_handle->cgw_col_binding_buff = NULL;
+    }
+}
+
 static int
 cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, char fetch_flag, int result_set_idx,
 		  T_NET_BUF * net_buf, T_REQ_INFO * req_info)
@@ -5815,16 +5835,26 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
   SQLSMALLINT num_cols;
   SQLLEN total_row_count = 0;
   T_BROKER_VERSION client_version = req_info->client_version;
+  T_CGW_HANDLE *cgw_handle = NULL;
+  T_COL_BINDER *col_binding = NULL;
+  T_COL_BINDER *col_binding_buff = NULL;
 
   if (result_set_idx < 0 || result_set_idx > 1)
     {
       return ERROR_INFO_SET (CAS_ER_NO_MORE_RESULT_SET, CAS_ERROR_INDICATOR);
     }
 
+  err_code = cgw_get_handle (&cgw_handle);
+  if (err_code < 0)
+    {
+      err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
+      goto fetch_error;
+    }
 
   if (srv_handle->is_cursor_open == false)
     {
-      err_code = cgw_execute (srv_handle, &row_count);
+      cgw_cleanup_col_bindings (srv_handle);
+      err_code = cgw_execute (cgw_handle->hdbc, srv_handle, &row_count);
       if (err_code < 0)
 	{
 	  err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
@@ -5839,8 +5869,8 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
 	  err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
 	  goto fetch_error;
 	}
-
-      err_code = cgw_execute (srv_handle, &row_count);
+      cgw_cleanup_col_bindings (srv_handle);
+      err_code = cgw_execute (cgw_handle->hdbc, srv_handle, &row_count);
       if (err_code < 0)
 	{
 	  err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
@@ -5850,7 +5880,7 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
 
   net_buf_cp_int (net_buf, (int) total_row_count, &num_tuple_msg_offset);
 
-  err_code = cgw_get_num_cols (srv_handle->cgw_handle->hstmt, &num_cols);
+  err_code = cgw_get_num_cols (srv_handle->cgw_hstmt, &num_cols);
 
   if (err_code < 0)
     {
@@ -5858,20 +5888,22 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
       goto fetch_error;
     }
 
+  col_binding = (T_COL_BINDER *) srv_handle->cgw_col_binding;
+  col_binding_buff = (T_COL_BINDER *) srv_handle->cgw_col_binding_buff;
+
   if (col_binding == NULL)
     {
-      if (col_binding_buff)
-	{
-	  cgw_cleanup_binder (col_binding_buff);
-	  col_binding_buff = NULL;
-	}
-
-      err_code = cgw_col_bindings (srv_handle->cgw_handle->hstmt, num_cols, &col_binding, &col_binding_buff);
+      err_code = cgw_col_bindings (srv_handle->cgw_hstmt, num_cols,
+				   (T_COL_BINDER **) & srv_handle->cgw_col_binding,
+				   (T_COL_BINDER **) & srv_handle->cgw_col_binding_buff);
       if (err_code < 0)
 	{
 	  err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
 	  goto fetch_error;
 	}
+
+      col_binding = (T_COL_BINDER *) srv_handle->cgw_col_binding;
+      col_binding_buff = (T_COL_BINDER *) srv_handle->cgw_col_binding_buff;
     }
 
   if (cas_shard_flag == ON)
@@ -5900,7 +5932,7 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
 	}
       else
 	{
-	  err_code = cgw_row_data (srv_handle->cgw_handle->hstmt);
+	  err_code = cgw_row_data (srv_handle->cgw_hstmt);
 	  if (err_code < 0)
 	    {
 	      err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
@@ -5911,17 +5943,7 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
 	    {
 	      fetch_end_flag = 1;
 
-	      if (col_binding)
-		{
-		  cgw_cleanup_binder (col_binding);
-		  col_binding = NULL;
-		}
-
-	      if (col_binding_buff)
-		{
-		  cgw_cleanup_binder (col_binding_buff);
-		  col_binding_buff = NULL;
-		}
+	      cgw_cleanup_col_bindings (srv_handle);
 
 	      err_code = cgw_cursor_close (srv_handle);
 	      if (err_code < 0)
@@ -5962,7 +5984,7 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
 	  break;
 	}
 
-      err_code = cgw_row_data (srv_handle->cgw_handle->hstmt);
+      err_code = cgw_row_data (srv_handle->cgw_hstmt);
       if (err_code < 0)
 	{
 	  err_code = ERROR_INFO_SET (db_error_code (), DBMS_ERROR_INDICATOR);
@@ -5973,17 +5995,7 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
 	{
 	  fetch_end_flag = 1;
 
-	  if (col_binding)
-	    {
-	      cgw_cleanup_binder (col_binding);
-	      col_binding = NULL;
-	    }
-
-	  if (col_binding_buff)
-	    {
-	      cgw_cleanup_binder (col_binding_buff);
-	      col_binding_buff = NULL;
-	    }
+	  cgw_cleanup_col_bindings (srv_handle);
 
 	  err_code = cgw_cursor_close (srv_handle);
 	  if (err_code < 0)
@@ -6022,17 +6034,7 @@ cgw_fetch_result (T_SRV_HANDLE * srv_handle, int cursor_pos, int fetch_count, ch
   return 0;
 
 fetch_error:
-  if (col_binding)
-    {
-      cgw_cleanup_binder (col_binding);
-      col_binding = NULL;
-    }
-
-  if (col_binding_buff)
-    {
-      cgw_cleanup_binder (col_binding_buff);
-      col_binding_buff = NULL;
-    }
+  cgw_cleanup_col_bindings (srv_handle);
 
   return err_code;
 }
@@ -11809,6 +11811,7 @@ recompile_statement (T_SRV_HANDLE * srv_handle)
 void
 ux_cgw_free_stmt (T_SRV_HANDLE * srv_handle)
 {
+  cgw_cleanup_col_bindings (srv_handle);
   cgw_free_stmt (srv_handle);
 }
 

--- a/src/broker/cas_handle.c
+++ b/src/broker/cas_handle.c
@@ -127,7 +127,9 @@ hm_new_srv_handle (T_SRV_HANDLE ** new_handle, unsigned int seq_num)
 #endif /* CAS_FOR_MYSQL */
 
 #if defined (CAS_FOR_CGW)
-  srv_handle->cgw_handle = NULL;
+  srv_handle->cgw_hstmt = NULL;
+  srv_handle->cgw_col_binding = NULL;
+  srv_handle->cgw_col_binding_buff = NULL;
   srv_handle->total_tuple_count = 0;
   srv_handle->stmt_type = CUBRID_STMT_NONE;
   srv_handle->is_cursor_open = false;
@@ -213,7 +215,7 @@ hm_srv_handle_free_all (bool free_holdable)
       srv_handle_content_free (srv_handle);
       srv_handle_rm_tmp_file (i + 1, srv_handle);
 #if defined (CAS_FOR_CGW)
-      srv_handle->cgw_handle = NULL;
+      ux_cgw_free_stmt (srv_handle);
 #endif /* CAS_FOR_CGW */
       FREE_MEM (srv_handle);
       srv_handle_table[i] = NULL;

--- a/src/broker/cas_handle.h
+++ b/src/broker/cas_handle.h
@@ -167,7 +167,6 @@ struct t_cgw_handle
 {
   SQLHENV henv;
   SQLHDBC hdbc;
-  SQLHSTMT hstmt;
 };
 #endif /* CAS_FOR_CGW */
 
@@ -225,7 +224,9 @@ struct t_srv_handle
   bool has_mysql_last_insert_id;
 #endif				/* CAS_FOR_MYSQL */
 #if defined (CAS_FOR_CGW)
-  T_CGW_HANDLE *cgw_handle;
+  SQLHSTMT cgw_hstmt;
+  void *cgw_col_binding;
+  void *cgw_col_binding_buff;
   int total_tuple_count;
   int stmt_type;
   bool is_cursor_open;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26805

### Purpose

DBLink를 통해 원격 MySQL에 DML(INSERT 등)을 실행할 때 CAS/CGW(ODBC) 경로에서 간헐적으로 발생하던 오류를 수정합니다.

증상 1: SQLRowCount()가 -1을 반환하고, 클라이언트에 Number of rows affected is unknown 오류가 출력됨
증상 2: [HY010] Function sequence error 오류 발생
두 증상 모두 동일 테스트를 반복 실행할 때 간헐적으로 재현되었으며, CUBRID 11.3.5 / 11.4.5 환경에서 보고되었습니다.

원인

1. CGW ODBC 레이어에서 전역 SQLHSTMT 핸들(local_odbc_handle->hstmt)을 모든 CAS server handle과 DBLink 작업이 공유하는 것이 문제 원인
2. SQLBindParameter() 의 SQLLEN *pcbValue (StrLen_or_IndPtr) 파라미터가 로컬 변수 여서 SQLExecute() 에서 잘 못된 참조가 문제 원인

서로 다른 T_SRV_HANDLE에서 DBLink DML/SELECT가 연속 수행되면 SQLHSTMT 을 재사용하는 경우가 발생되어 HY010(함수 호출 순서 위반) 발생함
공유 handle 상태가 꼬인 뒤 SQLRowCount() 호출 시 영향 받은 행 수를 알 수 없음을 의미하는 -1 반환

### Implementation

ODBC statement handle을 CAS server handle(T_SRV_HANDLE) 단위로 관리하도록 변경합니다.

### Remarks

N/A