### PR TITLE
[CBRD-26889] Lower ISCAN_OID_ACCESS_OVERHEAD from 20 to 5 to favor index scan

### DIFF
--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -78,7 +78,9 @@
 
 #define TEMP_SETUP_COST 5.0
 #define QO_CPU_WEIGHT 0.0025
-#define ISCAN_OID_ACCESS_OVERHEAD 20	/* need to be adjusted */
+/* Per-OID heap-access CPU penalty for NON-covering index scans (covering scans: 0).
+ * Lowered 20 -> 5 to favor index scan when low/stale leading-column NDV inflates sel via 1/pkeys[0]. TODO: per-index clustering factor. */
+#define ISCAN_OID_ACCESS_OVERHEAD 5
 #define MJ_CPU_OVERHEAD_FACTOR 20
 #define HJ_BUILD_CPU_OVERHEAD_FACTOR 30
 #define HJ_PROBE_CPU_OVERHEAD_FACTOR 20


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26889

### Purpose

비커버링 인덱스 스캔(iscan)이 풀 힙 스캔(sscan)에 부당하게 밀려 회피되는 것을 완화하기 위해, 비커버링 iscan의 OID당 힙접근 CPU 페널티 상수 `ISCAN_OID_ACCESS_OVERHEAD`를 **20 → 5**로 낮춰 인덱스 스캔을 우대한다.

### 인덱스 스캔 vs 힙 스캔 비용 모델

`src/optimizer/query_planner.c`의 스캔 비용 계산:

- **sscan (full heap scan)** — 선택도와 무관하게 테이블 전체를 읽는다.
  - `variable_io = TCARD` (전체 데이터 페이지 수)
  - `variable_cpu = NCARD × QO_CPU_WEIGHT`
- **iscan (index scan)**
  - `index_IO` (리프 페이지 순회) + `object_IO = TCARD × sel × filter_sel`
  - `heap_access = NCARD × sel × filter_sel × ISCAN_OID_ACCESS_OVERHEAD`
  - **커버링** iscan은 힙을 건드리지 않으므로 `heap_access = 0` → 본 상수의 영향이 없다.
  - **비커버링** iscan만 자격 행마다 힙에서 OID로 행을 random 하게 가져오며, 그 CPU 비용을 본 상수가 모델링한다.

즉 `ISCAN_OID_ACCESS_OVERHEAD`는 "비커버링 인덱스 스캔이 자격 행마다 힙을 OID로 random 접근하는 비용"의 가중치다. 값이 클수록 옵티마이저는 비커버링 iscan을 피하고 sscan을 택한다.

### 왜 5인가

선택도별 iscan/sscan **cost 전환점**(이 선택도 미만이면 iscan 선택)은 본 상수에 따라 달라진다:

| 값 | iscan/sscan 전환 선택도 |
|---|---|
| 20 (기존) | ~12% |
| **5** | **~35%** |
| 1 | ~67% |

핵심은 **통계가 부정확할 때의 거동**이다. 선두 인덱스 컬럼의 NDV가 낮거나 노후화되면 범위 선택도가 `sel = MAX(sel, 1/pkeys[0])` 하한으로 **위로 부풀려진다**(예: pkeys[0]=3 → 33%). 실제로는 선택적인 질의인데도 추정 선택도가 33%로 잡히면:

- **20**: 전환점 12% < 33% → 비커버링 iscan cost가 sscan을 초과 → **자연 플랜에서 sscan으로 퇴행**(USE INDEX 힌트를 줘도 풀스캔으로 풀림).
- **5**: 전환점 35% > 33% → **자연 플랜에서 iscan 유지**. (실측: 동일 질의가 5에서 iscan cost 1196 < sscan 1572, 20에서는 iscan 1821 > 1572)

5는 `pkeys[0] >= 3` 부풀림을 **자연 플랜에서 구제하는 가장 덜 공격적인 값**이다. 1까지 낮추면 전환점이 ~67%로 올라가 **실제로 대량(고선택도) random 힙 스캔**까지 iscan을 강행하게 되어, 랜덤 힙 접근이 sscan보다 느린 경우(실측상 캐시 시 ~2×, 버퍼 미스 시 5–10×)마저 인덱스 스캔으로 오선택할 위험이 있다. 5는 인덱스 스캔을 우대하면서 그 무모함은 피하는 균형점이다.

### 변경

`src/optimizer/query_planner.c` — 상수 정의 한 줄 (+ 근거/한계 주석):

```c
-#define ISCAN_OID_ACCESS_OVERHEAD 20	/* need to be adjusted */
+#define ISCAN_OID_ACCESS_OVERHEAD 5	/* favor index scan; see comment */
```

### 한계 / 후속

- `pkeys[0]=2`(50%)는 5로도 경계이고, `pkeys[0]=1`(노후 통계, 100%)은 어떤 값으로도 구제 불가 → 통계 정확도 개선(별도 이슈)에서 다룬다.
- 단일 전역 상수는 **순차(클러스터드) vs 랜덤 힙접근**, **테이블의 버퍼 상주 여부**를 구분하지 못한다(실측상 적정 페널티는 이 두 요인에 크게 좌우됨). 장기적으로는 **인덱스별 clustering factor(인덱스–힙 상관계수)** 로 대체해 힙접근 비용을 인덱스마다 산정하는 것이 옳다(코드 내 TODO로 표기).
