### PR TITLE
[CBRD-26887] Fix NULL variable-length NUMERIC over-read crash in unloaddb

### DIFF
--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -8797,21 +8797,9 @@ mr_data_readval_numeric (OR_BUF * buf, DB_VALUE * value, TP_DOMAIN * domain, int
 	  rc = or_advance (buf, size);
 	}
     }
-  else if (domain->type->id == DB_TYPE_NUMERIC && domain->precision == 0)
+  else if (size == 0 || (domain->type->id == DB_TYPE_NUMERIC && domain->precision == 0))
     {
-      /* 1. reason for checking domain->type
-       *   - when the type is DB_TYPE_VARIABLE, domain->precision is set to 0.
-       *   - in this case, the numeric precision condition below should be skipped
-       *     and handled by the else branch, so the type check is required.
-       *   - tc : _14_mysql_compatibility_2/_15_host_variable/_12_common/union.sql
-       *
-       * 2. reason for checking domain->precision == 0
-       *   - in normal definitions, a numeric type cannot have precision 0.
-       *   - however, for historical compatibility (about 10 years),
-       *     numeric(0,0) used in view definitions or CAST expressions
-       *     does not raise an error and is treated as NULL.
-       *   - tc : _01_object/_01_type/_003_numeric/1004.sql
-       */
+      /* its NULL */
       rc = or_advance (buf, 0);
     }
   else


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26887

## Purpose

FP NUMERIC 도입 이후 `numeric`이 가변길이 타입이 되면서, NULL 값이 0길이(collapsed) 슬롯으로 저장됩니다. 
그런데 `mr_data_readval_numeric`이 `size == 0`(NULL 가변 NUMERIC)을 처리하지 않아, unloaddb 수행 중 약 8바이트 over-read로 `cub_admin`이 크래시되는 문제를 수정합니다.

- Assertion `'buf->ptr + offset <= buf->endptr'` (object_representation.h, `or_advance`)
- 크래시 경로: `unload_extractor_thread → desc_disk_to_obj → get_desc_current → data_readval_string → or_skip_varchar_remainder → or_advance`

## Implementation

`get_desc_current`의 가변 attr 루프는 NULL(0길이 슬롯) attr도 `att->type->data_readval(size=0)`로 호출합니다. 하지만 `mr_data_readval_numeric`은 `size == 0`을 처리하지 않아 else 분기로 떨어져 가비지 바이트를 numeric 본문으로 오독했고, 그 결과 바로 뒤 CHAR 값의 읽기 위치가 밀려 문자열 데이터를 길이 헤더로 오독 → `or_advance`가 레코드 버퍼를 초과했습니다.

varchar 타입의 `data_readval_string()`는 이미 `size == 0`을 NULL로 처리하지만 numeric만 누락된 비대칭 상태였습니다. 
- NULL 분기에 `size == 0` 조건을 추가하여 대칭을 맞췄습니다.

```c
else if (size == 0 || (domain->type->id == DB_TYPE_NUMERIC && domain->precision == 0))
  {
    /* its NULL */
    rc = or_advance (buf, 0);   /* 0길이 = NULL, 소비 없음 */
  }
```

- 기존 `precision == 0` 분기는 `numeric(0,0)`의 ~10년 하위호환(에러 없이 NULL 취급)을 위해 유지
- `readval_string`처럼 `db_value_domain_init()`을 쓰지 않고 `or_advance(buf, 0)`을 쓰는 이유
    - init의 NUMERIC 분기는 precision 0을 invalid로 보고 `ER_INVALID_PRECISION` 경고 + precision/scale을 38/15로 덮어쓰기 때문.
    - 호출자(`or_get_value`)가 readval 전에 `db_make_null`로 초기화하므로 `or_advance(buf, 0)`은 값을 건드리지 않는 no-op이라 결과가 NULL과 동일

## Remarks

- 표면화 배경: 이 PR(또는 선행 변경)이 CHAR를 가변 섹션으로 옮기면서 `NULL numeric + 가변 CHAR` 조합이 생겨 문제가 드러남.
- 재현 TC (RQG): `random_query_generator/_03_mvcc/recovery/all_transaction_commit/all_transaction_commit_overflow_key_reuseoid/cases/all_transaction_commit_overflow_key_reuseoid.sh`
- 검증: 동일 데이터 unloaddb 32회 무크래시 + 라운드트립 200/200 + 최소 재현 케이스 통과
- 참고 TC:
  - `type == DB_TYPE_NUMERIC` 검사 필요성 → `_14_mysql_compatibility_2/_15_host_variable/_12_common/union.sql` (VARIABLE도 precision 0이라 타입 검사 없으면 오인식)
  - `precision == 0` 하위호환 → `_01_object/_01_type/_003_numeric/1004.sql`