### PR TITLE
[CBRD-26888] midxkey prefix 압축 시 복합 키 255바이트 초과 debug assert 크래시 수정

### DIFF
--- a/src/object/object_primitive.c
+++ b/src/object/object_primitive.c
@@ -9391,7 +9391,8 @@ pr_midxkey_add_prefix (DB_VALUE * result, DB_VALUE * prefix, DB_VALUE * postfix,
 	}
     }
 
-  assert (prefix_size >= OR_MULTI_MAX_OFFSET || i == midx_postfix->domain->precision || offset <= 0);
+  assert (prefix_size >= OR_MULTI_MAX_OFFSET || i == midx_postfix->domain->precision || offset <= 0
+	  || (offset + prefix_size) >= OR_MULTI_MAX_OFFSET);
 
   /* fallthrough: i */
   for (; i < midx_postfix->domain->precision; i++)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26888

## Purpose
복합키(midxkey) prefix 압축 과정에서 합친 키가 255바이트를 초과할 때 debug 모드에서만 발생하던 assert 크래시를 수정합니다.
release 빌드는 정상 동작하지만, debug 빌드에서 정당한 break 경로 하나가 assert 조건에 누락되어 `cub_server`가 코어 덤프되는 문제를 해결합니다.

## Implementation
- 대상: `src/object/object_primitive.c` 의 `pr_midxkey_add_prefix()`
- midxkey는 각 컬럼의 키 내 offset을 1바이트(0 ~ `OR_MULTI_MAX_OFFSET`=255)에 저장하며, 255를 초과하는 offset은 sentinel(255)로 마킹한 뒤 직접 스캔합니다(정상 설계).
- 함수의 1번째 루프는 `(offset + prefix_size) >= 255`인 경우 break하여, 2번째 루프가 해당 컬럼을 sentinel로 처리하도록 위임합니다.
- 그러나 1번째 루프 직후의 assert는 break 사유로 `offset <= 0`만 나열하고 `(offset + prefix_size) >= OR_MULTI_MAX_OFFSET` 케이스를 누락하고 있었습니다.
  - 이로 인해 postfix offset 자체는 정상(예: 252)이지만 prefix를 더해(+4) 합친 키가 256바이트가 되어 255를 초과하는 경우, debug assert만 깨지고 release는 256바이트 키를 정상 생성했습니다.
- 수정: assert에 누락된 정당한 break 조건을 추가했습니다. 동작 변화 없이 debug assert를 보완하는 변경입니다.

```c
assert (prefix_size >= OR_MULTI_MAX_OFFSET || i == midx_postfix->domain->precision || offset <= 0
        || (offset + prefix_size) >= OR_MULTI_MAX_OFFSET);
```

## Remarks
- **회귀 아님**: midxkey 압축 머신 도입 시점(b89ccabe5 [CBRD-24988], 2023)부터 존재하던 결함이며, char-vlen / FP-numeric 변경과 무관합니다.
- **재현 경로**: 복합 인덱스 = (선두 공통 컬럼) + (큰 char 컬럼). 같은 선두값 + 서로 다른 긴 char 값을 대량 INSERT → 리프 페이지 split → fence(구분자) 키 = 공통 prefix(k 4B) + 경계행 postfix(c 248B) = 256B > 255 에서 발생.
  - 크래시 콜스택: `btree_insert` → `btree_split_node` → `btree_find_split_point` → `btree_read_record` → `pr_midxkey_add_prefix`
  - 데이터 의존적(키 길이/공통 prefix/OID)이라 간헐적으로 발생.
- **RQG 재현 TC**: `random_query_generator/_03_mvcc/recovery/bug_bts_15979/long_checkpoint_dml_ddl/cases/long_checkpoint_dml_ddl.sh`
- 코어 실제 값: `prefix_size=4`, `precision=2`, `n_prefix=1`, `offset=252` → `252 + 4 = 256 > 255`
- 발생 위치: `object_primitive.c:9386` (assert)