### PR TITLE
[CBRD-26893] Fix uninitialized class pointer dereference in IS NOT NULL predicate folding

### DIFF
--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -7654,7 +7654,12 @@ pt_check_not_null_constraint (PARSER_CONTEXT * parser, PT_NODE * from, PT_NODE *
 	{
 	  consp = sm_class_constraints (cls);
 
-	  au_fetch_class (cls, &class_, AU_FETCH_READ, AU_SELECT);
+	  if (au_fetch_class (cls, &class_, AU_FETCH_READ, AU_SELECT) != NO_ERROR)
+	    {
+	      er_clear ();
+	      return false;
+	    }
+
 	  attr = classobj_find_attribute (class_, node->info.name.original, 0);
 	  if (attr == NULL)
 	    {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26893

### Purpose
- IS NOT NULL 술어 폴딩 최적화 경로에서 발생하던 NULL 포인터 역참조(SIGSEGV)를 제거한다.

### Implementation
- `pt_check_not_null_constraint()` 에서 `au_fetch_class()` 실패 시 `er_clear()` 로 남은 에러를 정리하고 `false` 를 반환한다. 미초기화 `class_` 가 `classobj_find_attribute()` 로 전달되어 발생하던 크래시를 막고, 보수적 최적화 판정 함수이므로 pending error 가 이후 prepare/compile 경로로 새어나가지 않도록 폴딩만 포기한다.

### Remarks
- 트리거 경로는 CBRD-26265 에서 도입된 IS NOT NULL → TRUE 폴딩 최적화로, `db_class` 처럼 `au_fetch_class` 가 실패할 수 있는 클래스에 IS NOT NULL 조건을 사용할 때 노출된다.
