### PR TITLE
[CBRD-26898] Shard SHOW PAGE BUFFER STATUS per-fix counters by thread index

### DIFF
--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -399,6 +399,7 @@ struct pgbuf_status
   unsigned long long num_pages_read;
   unsigned int num_flusher_waiting_threads;
   unsigned int dummy;
+  char m_pad[64 - 5 * sizeof (unsigned long long) - 2 * sizeof (unsigned int)];
 };
 
 struct pgbuf_status_snapshot
@@ -1777,14 +1778,14 @@ pgbuf_initialize (void)
       goto error;
     }
 
-  pgbuf_Pool.show_status = (PGBUF_STATUS *) malloc (sizeof (PGBUF_STATUS) * (MAX_NTRANS + 1));
+  pgbuf_Pool.show_status = (PGBUF_STATUS *) malloc (sizeof (PGBUF_STATUS) * (thread_num_total_threads () + 1));
   if (pgbuf_Pool.show_status == NULL)
     {
       ASSERT_ERROR ();
       goto error;
     }
 
-  memset (pgbuf_Pool.show_status, 0, sizeof (PGBUF_STATUS) * (MAX_NTRANS + 1));
+  memset (pgbuf_Pool.show_status, 0, sizeof (PGBUF_STATUS) * (thread_num_total_threads () + 1));
 
   pgbuf_Pool.show_status_old.print_out_time = time (NULL);
 
@@ -2137,8 +2138,7 @@ pgbuf_fix_release (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_MODE f
 #endif /* !NDEBUG */
   PGBUF_FIX_PERF perf;
   bool maybe_deallocated;
-  int tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
-  PGBUF_STATUS *show_status = &pgbuf_Pool.show_status[tran_index];
+  PGBUF_STATUS *show_status = &pgbuf_Pool.show_status[thread_get_entry_index (thread_p)];
 
   perf.perf_page_found = PERF_PAGE_MODE_OLD_IN_BUFFER;
 
@@ -7997,8 +7997,7 @@ pgbuf_allocate_bcb (THREAD_ENTRY * thread_p, const VPID * src_vpid)
   PERF_UTIME_TRACKER time_tracker_alloc_bcb = PERF_UTIME_TRACKER_INITIALIZER;
   PERF_UTIME_TRACKER time_tracker_alloc_search_and_wait = PERF_UTIME_TRACKER_INITIALIZER;
   bool detailed_perf = perfmon_is_perf_tracking_and_active (PERFMON_ACTIVATION_FLAG_PB_VICTIMIZATION);
-  int tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
-  PGBUF_STATUS *show_status = &pgbuf_Pool.show_status[tran_index];
+  PGBUF_STATUS *show_status = &pgbuf_Pool.show_status[thread_get_entry_index (thread_p)];
 
 #if defined (SERVER_MODE)
   struct timespec to;
@@ -8215,8 +8214,7 @@ pgbuf_claim_bcb_for_fix (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_
   PAGE_PTR pgptr = NULL;
   TDE_ALGORITHM tde_algo = TDE_ALGORITHM_NONE;
   bool success;
-  int tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
-  PGBUF_STATUS *show_status = &pgbuf_Pool.show_status[tran_index];
+  PGBUF_STATUS *show_status = &pgbuf_Pool.show_status[thread_get_entry_index (thread_p)];
   PGBUF_ATOMIC_LATCH_IMPL impl;
 
 #if defined (ENABLE_SYSTEMTAP)
@@ -10548,8 +10546,7 @@ pgbuf_bcb_flush_with_wal (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr, bool is_p
   FILEIO_WRITE_MODE write_mode;
   bool is_temp = pgbuf_is_temporary_volume (bufptr->vpid.volid);
   TDE_ALGORITHM tde_algo = TDE_ALGORITHM_NONE;
-  int tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
-  PGBUF_STATUS *show_status = &pgbuf_Pool.show_status[tran_index];
+  PGBUF_STATUS *show_status = &pgbuf_Pool.show_status[thread_get_entry_index (thread_p)];
 
 
   PGBUF_BCB_CHECK_OWN (bufptr);
@@ -16906,7 +16903,7 @@ pgbuf_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** arg_values, int
 
   pgbuf_scan_bcb_table ();
 
-  for (i = 0; i <= MAX_NTRANS; i++)
+  for (i = 0; i <= (int) thread_num_total_threads (); i++)
     {
       status_accumulated.num_hit += pgbuf_Pool.show_status[i].num_hit;
       status_accumulated.num_page_request += pgbuf_Pool.show_status[i].num_page_request;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26898>

### Purpose

병렬 힙 스캔(non-fixed/COPY scan) 질의에서 `SHOW PAGE BUFFER STATUS`용 per-fix 카운터(`num_hit`, `num_page_request` 등)의 **캐시라인 경합**을 제거한다.

이 카운터들은 `pgbuf_Pool.show_status[]`에 **트랜잭션 인덱스로** 인덱싱되어 있다. 하나의 트랜잭션 인덱스를 공유하는 병렬 워커들이 **매 페이지 fix마다 같은 캐시라인**(`show_status[tran_index]`)을 증가시켜 true-sharing 경합이 발생한다. COPY 스캔(`ENABLE_HEAP_FIXED_SCAN=N`)에선 행마다 1회 fix이므로 TPC-H Q12 같은 대형 스캔에서 수천만 회 반복된다.

### Implementation

`src/storage/page_buffer.c`:

- **인덱싱 변경**: `show_status`를 트랜잭션 인덱스 → **thread entry 인덱스**(`thread_get_entry_index (thread_p)`)로 변경. 각 스레드가 자기 슬롯만 갱신한다.
- **캐시라인 패딩**: `struct pgbuf_status`에 패딩을 추가해 64B(`sizeof` = 64)로 맞춤 → 인접 스레드 슬롯이 같은 라인을 공유하지 않음(false sharing 차단).

  ```c
  struct pgbuf_status {
    ...
    unsigned int num_flusher_waiting_threads;
    unsigned int dummy;
    char m_pad[64 - 5 * sizeof (unsigned long long) - 2 * sizeof (unsigned int)];
  };
  ```
- **배열 크기**: alloc/memset을 `MAX_NTRANS + 1` → `thread_num_total_threads () + 1`로 변경. 합산 reader 루프도 같은 범위로 순회.
- **합산 reader 불변**: SHOW 출력은 기존과 동일하게 전 슬롯을 합산한다. 모든 fix는 정확히 한 스레드가 수행하므로, per-tran 슬롯에서 per-thread 슬롯으로 재배치해도 **합계는 동일**하다.

**안전성**:
- 경계: worker 인덱스는 `1..m_max_threads`, main 엔트리는 `0`, 배열 크기는 `thread_num_total_threads () + 1`(= `m_max_threads + 2`)이라 최대 인덱스가 항상 범위 내.
- 초기화 순서: 모든 boot 경로에서 thread count를 정하는 `cubthread::initialize()`가 `pgbuf_initialize()`(배열 할당)보다 먼저 실행되고, thread count는 boot에서 고정된다.
- SA_MODE: main 엔트리(인덱스 0)만 사용, 크기 유효.

### Remarks

- **Specification 변화 없음**: `SHOW PAGE BUFFER STATUS` 출력은 그대로(합산이 동일). 외부 동작/문법/카탈로그/플랜/에러 메시지 불변.
- 검증: 빌드 성공, `SHOW PAGE BUFFER STATUS`가 워크로드 후 실값 보고(`Hit_rate`, `Num_hit`, `Num_page_request` 정상), Q12 FIXED=N 결과 정합성 동일(FOB 62738/93486, REG AIR 62458/93695), FIXED=Y 무영향.
- 관련: CBRD-26908(#7274), CBRD-26924(#7281), CBRD-26932(#7287), CBRD-26941(#7305) — 동일 Q12 FIXED=N hot path 개선 시리즈.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
