### PR TITLE
[CBRD-26894] Fix core dump in er_message::set_error during histogram stat collection

### DIFF
--- a/src/compat/db_obj.c
+++ b/src/compat/db_obj.c
@@ -1185,7 +1185,13 @@ db_find_multi_unique (MOP classmop, int size, char *attr_names[], DB_VALUE * val
     obj_find_multi_attr (classmop, size, (const char **) attr_names, (const DB_VALUE **) values,
 			 purpose == DB_FETCH_WRITE ? AU_FETCH_UPDATE : AU_FETCH_READ);
 
-  er_clear ();
+  /* obj_find_multi_attr sets a benign ER_OBJ_OBJECT_NOT_FOUND warning when the key does not
+   * exist; clear it so callers just see NULL. But keep real errors (e.g. BTREE_ERROR_OCCURRED /
+   * ER_LK_UNILATERALLY_ABORTED on server failure) so callers can detect the failure. (CBRD-26667) */
+  if (retval != NULL || er_errid () == ER_OBJ_OBJECT_NOT_FOUND)
+    {
+      er_clear ();
+    }
   return retval;
 }
 

--- a/src/object/object_accessor.c
+++ b/src/object/object_accessor.c
@@ -3792,7 +3792,9 @@ obj_find_multi_attr (MOP op, int size, const char *attr_names[], const DB_VALUE 
     }
   else if (result == BTREE_ERROR_OCCURRED)
     {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_FAILED, 0);
+      /* btree_find_unique already set a proper error; ER_FAILED is not a settable error id
+       * and would trip the er_message::set_error assert. Just let the existing error
+       * propagate (e.g. ER_LK_UNILATERALLY_ABORTED on server failure). (CBRD-26894) */
     }
   else if (result == BTREE_KEY_NOTFOUND)
     {

--- a/src/object/object_accessor.c
+++ b/src/object/object_accessor.c
@@ -3795,6 +3795,7 @@ obj_find_multi_attr (MOP op, int size, const char *attr_names[], const DB_VALUE 
       /* btree_find_unique already set a proper error; ER_FAILED is not a settable error id
        * and would trip the er_message::set_error assert. Just let the existing error
        * propagate (e.g. ER_LK_UNILATERALLY_ABORTED on server failure). (CBRD-26894) */
+      ASSERT_ERROR ();
     }
   else if (result == BTREE_KEY_NOTFOUND)
     {

--- a/src/object/schema_template.c
+++ b/src/object/schema_template.c
@@ -2049,7 +2049,10 @@ smt_check_histogram_exist_and_delete (MOP classop, const char *attr_name, bool n
     }
   else
     {
+      /* Dropping the instance in the internal _db_histogram catalog also needs authorization bypass. (CBRD-26667) */
+      AU_DISABLE (au_save);
       error = db_drop (histogram_obj);
+      AU_ENABLE (au_save);
       if (error != NO_ERROR)
 	{
 	  goto end;

--- a/src/object/schema_template.c
+++ b/src/object/schema_template.c
@@ -1976,6 +1976,7 @@ int
 smt_check_histogram_exist (MOP classop, const char *attr_name)
 {
   int error = NO_ERROR;
+  int au_save;
   DB_OBJECT *histogram_class, *histogram_obj = NULL;
   DB_VALUE value[2];
   DB_VALUE *value_ptrs[2] = { &value[0], &value[1] };
@@ -1993,7 +1994,10 @@ smt_check_histogram_exist (MOP classop, const char *attr_name)
   db_make_object (&value[0], classop);
   db_make_string (&value[1], attr_name);
 
+  /* _db_histogram is an internal catalog; bypass user authorization. (CBRD-26667) */
+  AU_DISABLE (au_save);
   histogram_obj = db_find_multi_unique (histogram_class, 2, (char **) search_attrs, value_ptrs, DB_FETCH_READ);
+  AU_ENABLE (au_save);
   if (histogram_obj != NULL)
     {
       /* not error, just return ER_LC_CLASSNAME_EXIST */
@@ -2008,6 +2012,7 @@ int
 smt_check_histogram_exist_and_delete (MOP classop, const char *attr_name, bool no_error_if_not_found)
 {
   int error = NO_ERROR;
+  int au_save;
   DB_OBJECT *histogram_class, *histogram_obj = NULL;
   DB_VALUE value[2];
   DB_VALUE *value_ptrs[2] = { &value[0], &value[1] };
@@ -2025,7 +2030,10 @@ smt_check_histogram_exist_and_delete (MOP classop, const char *attr_name, bool n
   db_make_object (&value[0], classop);
   db_make_string (&value[1], attr_name);
 
+  /* _db_histogram is an internal catalog; bypass user authorization. (CBRD-26667) */
+  AU_DISABLE (au_save);
   histogram_obj = db_find_multi_unique (histogram_class, 2, (char **) search_attrs, value_ptrs, DB_FETCH_WRITE);
+  AU_ENABLE (au_save);
   if (histogram_obj == NULL)
     {
       if (!no_error_if_not_found)

--- a/src/optimizer/histogram/histogram_cl.cpp
+++ b/src/optimizer/histogram/histogram_cl.cpp
@@ -1369,6 +1369,7 @@ int
 db_get_histogram (MOP classop, const char *attr_name, DB_OBJECT **histogram_obj)
 {
   int error = NO_ERROR;
+  int au_save;
   DB_OBJECT *histogram_class;
   DB_VALUE value[2];
   DB_VALUE *value_ptrs[2] = { &value[0], &value[1] };
@@ -1385,7 +1386,11 @@ db_get_histogram (MOP classop, const char *attr_name, DB_OBJECT **histogram_obj)
   db_make_object (&value[0], classop);
   db_make_string (&value[1], attr_name);
 
+  /* _db_histogram is an internal catalog read during optimizer stat collection; bypass user
+   * authorization (otherwise a non-DBA query raises ER_AU_SELECT_FAILURE on it). (CBRD-26667) */
+  AU_DISABLE (au_save);
   *histogram_obj = db_find_multi_unique (histogram_class, 2, (char **) search_attrs, value_ptrs, DB_FETCH_READ);
+  AU_ENABLE (au_save);
 
   db_value_clear (value_ptrs[0]);
   db_value_clear (value_ptrs[1]);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26894>

### Purpose

[Regression] 트랜잭션이 쿼리 실행 도중 중단된 상태 — 예: 서버 장애로 인한 `ER_LK_UNILATERALLY_ABORTED`("Your transaction has been aborted by the system due to server failure or mode change") — 에서 옵티마이저가 히스토그램 통계를 수집할 때, `cuberr::er_message::set_error`(`src/base/error_context.cpp:155`)의 assert가 실패하여 `csql`이 core dump 됩니다.

본 이슈는 옵티마이저 히스토그램 지원(CBRD-26202)에서 유입된 리그레션입니다.

### Implementation

**1. `obj_find_multi_attr()` — 잘못된 `er_set(ER_FAILED)` 제거 (`src/object/object_accessor.c`)**

`BTREE_ERROR_OCCURRED` 분기에서 `er_set(ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_FAILED, 0)`을 호출하고 있었습니다. `ER_FAILED`(-1)는 반환 코드일 뿐 설정 가능한 에러 ID가 아니므로, `er_message::set_error`의 유효성 검사(`error_id_arg >= ER_FAILED` → `assert(false)`)에 걸립니다. `btree_find_unique()`가 `BTREE_ERROR_OCCURRED`를 반환할 때는 이미 적절한 에러를 설정해 두므로, 해당 호출을 제거하고 기존 에러가 그대로 전파되도록 했습니다.

**2. `_db_histogram` 내부 조회 시 권한 비활성화 + 실제 에러 보존 (`histogram_cl.cpp`, `schema_template.c`, `db_obj.c`)**

옵티마이저의 통계 수집은 내부 카탈로그 `_db_histogram`을 읽는데, 이때 **사용자 권한으로** 접근하여 비-DBA 쿼리(예: 뷰 select)에서 `ER_AU_SELECT_FAILURE(-157)`가 발생했습니다. (기존에는 `db_find_multi_unique()`의 무조건 `er_clear()`가 이 에러를 삼키고 있었습니다.)

- `schema_manager.c`의 다른 내부 카탈로그 작업과 동일하게 `_db_histogram` 조회를 `AU_DISABLE`로 감싸 권한 검사를 우회합니다.
- 권한 에러가 원천 제거되면서, `db_find_multi_unique()`의 `er_clear()`를 **성공 또는 정상 not-found(`ER_OBJ_OBJECT_NOT_FOUND`)** 케이스로 제한할 수 있게 되었습니다. 그 결과 `BTREE_ERROR_OCCURRED`/`ER_LK_UNILATERALLY_ABORTED`(서버 장애) 같은 **실제 에러가 호출자(`db_get_histogram`)의 `er_errid()` 검사까지 정상 전파**됩니다.

> `db_find_multi_unique()` / `obj_find_multi_attr()` 호출부는 모두 히스토그램 경로(`histogram_cl.cpp`, `schema_template.c`)뿐이라 변경 범위가 히스토그램 기능에 한정됩니다.

### Remarks

- 트리거 경로: `build_query_graph` → `qo_get_class_info` → `grok_classes` → `sm_get_class_with_statistics` → `stats_get_histogram` → `db_get_histogram` → `db_find_multi_unique` → `obj_find_multi_attr`
- core dump 재현: 서버 강제 종료 스트레스 테스트(`cbrd_23136`: 파티션 제거 후 select를 `cub_server` kill/restart와 동시에 수행) → debug 빌드에서 동일 시퀀스 8882회 반복, core dump 없음 확인.
- -157 회귀 검증: 비-DBA(`public`)가 다른 사용자의 뷰를 select할 때 `ER_AU_SELECT_FAILURE` 없이 정상 동작함을 확인.
