### PR TITLE
[CBRD-26908] Remove cache-line contention in the buffer-pool page fix/unfix hot path

### DIFF
--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -482,6 +482,13 @@ struct pgbuf_holder_anchor
   int num_hold_cnt;		/* # of used BCB holder entries */
   PGBUF_HOLDER *thrd_free_list;	/* free BCB holder list */
   PGBUF_HOLDER *thrd_hold_list;	/* used(or hold) BCB holder list */
+  /* Pad each entry to a full cache line. Each thread touches only its own thrd_holder_info[index]
+   * entry, but every fix/unfix updates num_hold_cnt/thrd_hold_list; without padding, adjacent
+   * threads' entries share a cache line and those writes bounce the line between cores (false
+   * sharing) on the buffer fix hot path (pgbuf_find_thrd_holder / pgbuf_allocate_thrd_holder_entry).
+   * The 64-byte stride lands each entry's live fields in its own cache line; the pad bytes are never
+   * accessed. alignof stays 8, so the plain malloc in pgbuf_initialize remains valid. */
+  char m_pad[64 - 2 * sizeof (int) - 2 * sizeof (PGBUF_HOLDER *)];
 };
 
 /* the entry(array structure) of free BCB holder list shared by threads */
@@ -684,6 +691,20 @@ struct pgbuf_seq_flusher
   bool burst_mode;		/* config : flush in burst or flush one page and wait */
 };
 
+/* pgbuf_monitor_thread_counter - per-thread sharded fix/unfix counters. fix_req/pg_unfix are bumped
+ * on every page fix/unfix by every worker; a single shared atomic was a top cache-line contention
+ * point (true sharing) on the buffer fix hot path. Each thread bumps only its own cache-line-isolated
+ * shard; the periodic LRU-quota consumers sum (and reset) across all shards. The values feed only
+ * coarse quota heuristics (miss-rate ratio / activity threshold), so per-shard relaxed bumps suffice.
+ * Indexed by thread_entry::index (0 reserved for the no-thread case). */
+typedef struct pgbuf_monitor_thread_counter PGBUF_MONITOR_THREAD_COUNTER;
+struct pgbuf_monitor_thread_counter
+{
+  std::atomic_int fix_req_cnt;	/* number of fix requests (this thread) */
+  std::atomic_int pg_unfix_cnt;	/* number of page unfixes (this thread) */
+  char m_pad[64 - 2 * sizeof (std::atomic_int)];	/* isolate each shard to its own cache line */
+};
+
 typedef struct pgbuf_page_monitor PGBUF_PAGE_MONITOR;
 struct pgbuf_page_monitor
 {
@@ -694,9 +715,8 @@ struct pgbuf_page_monitor
 
   /* Overall counters */
   volatile int lru_shared_pgs_cnt;	/* count of BCBs in all shared LRUs */
-    std::atomic_int pg_unfix_cnt;	/* Count of page unfixes; used for refreshing quota adjustment */
   int lru_victim_req_cnt;	/* number of victim requests from all LRUs */
-    std::atomic_int fix_req_cnt;	/* number of fix requests */
+  PGBUF_MONITOR_THREAD_COUNTER *thread_counters;	/* per-thread fix_req/pg_unfix shards (see above) */
 
 #if defined (SERVER_MODE)
   PGBUF_MONITOR_BCB_MUTEX *bcb_locks;	/* track bcb mutex usage. */
@@ -1547,9 +1567,8 @@ pgbuf_initialize (void)
   pgbuf_Pool.monitor.lru_hits = NULL;
   pgbuf_Pool.monitor.lru_activity = NULL;
   pgbuf_Pool.monitor.lru_shared_pgs_cnt = 0;
-  pgbuf_Pool.monitor.pg_unfix_cnt.store (0);
   pgbuf_Pool.monitor.lru_victim_req_cnt = 0;
-  pgbuf_Pool.monitor.fix_req_cnt.store (0);
+  pgbuf_Pool.monitor.thread_counters = NULL;
 #if defined (SERVER_MODE)
   pgbuf_Pool.monitor.bcb_locks = NULL;
 #endif
@@ -1857,6 +1876,11 @@ pgbuf_finalize (void)
       free_and_init (pgbuf_Pool.thrd_holder_info);
     }
 
+  if (pgbuf_Pool.monitor.thread_counters != NULL)
+    {
+      free_and_init (pgbuf_Pool.monitor.thread_counters);
+    }
+
   if (pgbuf_Pool.thrd_reserved_holder != NULL)
     {
       free_and_init (pgbuf_Pool.thrd_reserved_holder);
@@ -2025,6 +2049,65 @@ pgbuf_fix_with_retry (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_MOD
 }
 
 /*
+ * pgbuf_monitor_inc_fix_req () - bump this thread's sharded fix-request counter (uncontended).
+ */
+STATIC_INLINE void
+pgbuf_monitor_inc_fix_req (THREAD_ENTRY * thread_p)
+{
+  int idx = (thread_p != NULL) ? thread_p->index : 0;
+  pgbuf_Pool.monitor.thread_counters[idx].fix_req_cnt.fetch_add (1, std::memory_order_relaxed);
+}
+
+/*
+ * pgbuf_monitor_inc_pg_unfix () - bump this thread's sharded page-unfix counter (uncontended).
+ */
+STATIC_INLINE void
+pgbuf_monitor_inc_pg_unfix (THREAD_ENTRY * thread_p)
+{
+  int idx = (thread_p != NULL) ? thread_p->index : 0;
+  pgbuf_Pool.monitor.thread_counters[idx].pg_unfix_cnt.fetch_add (1, std::memory_order_relaxed);
+}
+
+/*
+ * pgbuf_monitor_sum_fix_req () - sum the per-thread fix-request shards; reset them when reset==true.
+ *   The sum of per-shard exchange(0) is exact (no lost counts).
+ */
+STATIC_INLINE int
+pgbuf_monitor_sum_fix_req (bool reset)
+{
+  int total = 0;
+  size_t n = thread_num_total_threads ();
+  size_t i;
+  for (i = 0; i < n; i++)
+    {
+      if (reset)
+	total += pgbuf_Pool.monitor.thread_counters[i].fix_req_cnt.exchange (0, std::memory_order_seq_cst);
+      else
+	total += pgbuf_Pool.monitor.thread_counters[i].fix_req_cnt.load (std::memory_order_seq_cst);
+    }
+  return total;
+}
+
+/*
+ * pgbuf_monitor_sum_pg_unfix () - sum the per-thread page-unfix shards; reset them when reset==true.
+ */
+STATIC_INLINE int
+pgbuf_monitor_sum_pg_unfix (bool reset)
+{
+  int total = 0;
+  size_t n = thread_num_total_threads ();
+  size_t i;
+  for (i = 0; i < n; i++)
+    {
+      if (reset)
+	total += pgbuf_Pool.monitor.thread_counters[i].pg_unfix_cnt.exchange (0, std::memory_order_seq_cst);
+      else
+	total += pgbuf_Pool.monitor.thread_counters[i].pg_unfix_cnt.load (std::memory_order_seq_cst);
+    }
+  return total;
+}
+
+/*
  * pgbuf_fix () -
  *   return: Pointer to the page or NULL
  *   vpid(in): Complete Page identifier
@@ -2076,7 +2159,7 @@ pgbuf_fix_release (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_MODE f
       return NULL;
     }
 
-  pgbuf_Pool.monitor.fix_req_cnt.fetch_add (1, std::memory_order_relaxed);
+  pgbuf_monitor_inc_fix_req (thread_p);
 
   if (pgbuf_get_check_page_validation_level (PGBUF_DEBUG_PAGE_VALIDATION_FETCH) && fetch_mode != RECOVERY_PAGE)
     {
@@ -3711,7 +3794,7 @@ pgbuf_flush_victim_candidates (THREAD_ENTRY * thread_p, float flush_ratio, PERF_
   check_count_lru = 0;
 
   lru_victim_req_cnt = ATOMIC_TAS_32 (&pgbuf_Pool.monitor.lru_victim_req_cnt, 0);
-  fix_req_cnt = pgbuf_Pool.monitor.fix_req_cnt.exchange (0, std::memory_order_seq_cst);
+  fix_req_cnt = pgbuf_monitor_sum_fix_req (true);
 
   if (fix_req_cnt > lru_victim_req_cnt)
     {
@@ -6484,7 +6567,7 @@ pgbuf_unlatch_bcb_upon_unfix (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr, int h
 	}
       else if (blocked_reader_writer == false)
 	{
-	  pgbuf_Pool.monitor.pg_unfix_cnt.fetch_add (1, std::memory_order_relaxed);
+	  pgbuf_monitor_inc_pg_unfix (thread_p);
 
 	  if (PGBUF_THREAD_HAS_PRIVATE_LRU (thread_p))
 	    {
@@ -13471,9 +13554,28 @@ pgbuf_initialize_page_monitor (void)
     }
 
   monitor->lru_victim_req_cnt = 0;
-  monitor->fix_req_cnt.store (0);
-  monitor->pg_unfix_cnt.store (0);
   monitor->lru_shared_pgs_cnt = 0;
+
+  {
+    size_t thrd_num = thread_num_total_threads ();
+    size_t k;
+    monitor->thread_counters =
+      (PGBUF_MONITOR_THREAD_COUNTER *) malloc (thrd_num * sizeof (PGBUF_MONITOR_THREAD_COUNTER));
+    if (monitor->thread_counters == NULL)
+      {
+	error_status = ER_OUT_OF_VIRTUAL_MEMORY;
+	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY,
+		1, thrd_num * sizeof (PGBUF_MONITOR_THREAD_COUNTER));
+	goto exit;
+      }
+    for (k = 0; k < thrd_num; k++)
+      {
+	/* begin the lifetime of the malloc'ed array element (incl. its std::atomic members) before use */
+	placement_new (&monitor->thread_counters[k]);
+	monitor->thread_counters[k].fix_req_cnt.store (0);
+	monitor->thread_counters[k].pg_unfix_cnt.store (0);
+      }
+  }
 
 #if defined (SERVER_MODE)
   if (pgbuf_Monitor_locks)
@@ -13694,13 +13796,12 @@ pgbuf_adjust_quotas (THREAD_ENTRY * thread_p)
    * - or more than 5 min since last adjustment and activity is more 1% of threshold
    * Activity of page buffer is measured in number of page unfixes
    */
-  if (pgbuf_Pool.monitor.pg_unfix_cnt.load (std::memory_order_seq_cst) < PGBUF_TRAN_THRESHOLD_ACTIVITY
-      && diff_usec < 500000LL)
+  if (pgbuf_monitor_sum_pg_unfix (false) < PGBUF_TRAN_THRESHOLD_ACTIVITY && diff_usec < 500000LL)
     {
       quota->is_adjusting = 0;
       return;
     }
-  if (monitor->pg_unfix_cnt.exchange (0) < PGBUF_TRAN_THRESHOLD_ACTIVITY / 100)
+  if (pgbuf_monitor_sum_pg_unfix (true) < PGBUF_TRAN_THRESHOLD_ACTIVITY / 100)
     {
       low_overall_activity = true;
     }
@@ -16016,7 +16117,7 @@ pgbuf_is_hit_ratio_low (void)
 
   return (pgbuf_Pool.monitor.lru_victim_req_cnt > PGBUF_MIN_VICTIM_REQ
 	  && pgbuf_Pool.monitor.lru_victim_req_cnt * PGBUF_DESIRED_HIT_VS_MISS_RATE >
-	  pgbuf_Pool.monitor.fix_req_cnt.load (std::memory_order_seq_cst));
+	  pgbuf_monitor_sum_fix_req (false));
 
 #undef PGBUF_DESIRED_HIT_VS_MISS_RATE
 #undef PGBUF_MIN_VICTIM_REQ

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -487,6 +487,8 @@ struct pgbuf_holder_anchor
   char m_pad[64 - 2 * sizeof (int) - 2 * sizeof (PGBUF_HOLDER *)];
 };
 
+static_assert (sizeof (PGBUF_HOLDER_ANCHOR) == 64, "pgbuf_holder_anchor must be exactly one 64B cache line; fix m_pad");
+
 /* the entry(array structure) of free BCB holder list shared by threads */
 struct pgbuf_holder_set
 {
@@ -696,6 +698,8 @@ struct pgbuf_monitor_thread_counter
   std::atomic_int pg_unfix_cnt;	/* number of page unfixes (this thread) */
   char m_pad[64 - 2 * sizeof (std::atomic_int)];	/* isolate each shard to its own cache line */
 };
+
+static_assert (sizeof (PGBUF_MONITOR_THREAD_COUNTER) == 64, "pgbuf_monitor_thread_counter must be exactly one 64B cache line; fix m_pad");
 
 typedef struct pgbuf_page_monitor PGBUF_PAGE_MONITOR;
 struct pgbuf_page_monitor

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -482,12 +482,8 @@ struct pgbuf_holder_anchor
   int num_hold_cnt;		/* # of used BCB holder entries */
   PGBUF_HOLDER *thrd_free_list;	/* free BCB holder list */
   PGBUF_HOLDER *thrd_hold_list;	/* used(or hold) BCB holder list */
-  /* Pad each entry to a full cache line. Each thread touches only its own thrd_holder_info[index]
-   * entry, but every fix/unfix updates num_hold_cnt/thrd_hold_list; without padding, adjacent
-   * threads' entries share a cache line and those writes bounce the line between cores (false
-   * sharing) on the buffer fix hot path (pgbuf_find_thrd_holder / pgbuf_allocate_thrd_holder_entry).
-   * The 64-byte stride lands each entry's live fields in its own cache line; the pad bytes are never
-   * accessed. alignof stays 8, so the plain malloc in pgbuf_initialize remains valid. */
+  /* Pad to a full cache line: num_hold_cnt/thrd_hold_list are written on every fix/unfix, so an
+   * unpadded entry false-shares with adjacent threads'. alignof stays 8 -> plain malloc still valid. */
   char m_pad[64 - 2 * sizeof (int) - 2 * sizeof (PGBUF_HOLDER *)];
 };
 
@@ -691,12 +687,8 @@ struct pgbuf_seq_flusher
   bool burst_mode;		/* config : flush in burst or flush one page and wait */
 };
 
-/* pgbuf_monitor_thread_counter - per-thread sharded fix/unfix counters. fix_req/pg_unfix are bumped
- * on every page fix/unfix by every worker; a single shared atomic was a top cache-line contention
- * point (true sharing) on the buffer fix hot path. Each thread bumps only its own cache-line-isolated
- * shard; the periodic LRU-quota consumers sum (and reset) across all shards. The values feed only
- * coarse quota heuristics (miss-rate ratio / activity threshold), so per-shard relaxed bumps suffice.
- * Indexed by thread_entry::index (0 reserved for the no-thread case). */
+/* Per-thread sharded fix/unfix counters (indexed by thread_entry::index, 0 = no-thread): replaces a
+ * shared atomic that true-shared the fix hot path. Feed only coarse quota heuristics -> relaxed bumps. */
 typedef struct pgbuf_monitor_thread_counter PGBUF_MONITOR_THREAD_COUNTER;
 struct pgbuf_monitor_thread_counter
 {
@@ -2069,8 +2061,7 @@ pgbuf_monitor_inc_pg_unfix (THREAD_ENTRY * thread_p)
 }
 
 /*
- * pgbuf_monitor_sum_fix_req () - sum the per-thread fix-request shards; reset them when reset==true.
- *   The sum of per-shard exchange(0) is exact (no lost counts).
+ * pgbuf_monitor_sum_fix_req () - sum per-thread fix-request shards (reset: exchange-to-0, exact).
  */
 STATIC_INLINE int
 pgbuf_monitor_sum_fix_req (bool reset)

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -699,7 +699,7 @@ struct pgbuf_monitor_thread_counter
   char m_pad[64 - 2 * sizeof (std::atomic_int)];	/* isolate each shard to its own cache line */
 };
 
-static_assert (sizeof (PGBUF_MONITOR_THREAD_COUNTER) == 64, "pgbuf_monitor_thread_counter must be exactly one 64B cache line; fix m_pad");
+static_assert (sizeof (PGBUF_MONITOR_THREAD_COUNTER) == 64, "shard must be exactly one 64B cache line; fix m_pad");
 
 typedef struct pgbuf_page_monitor PGBUF_PAGE_MONITOR;
 struct pgbuf_page_monitor


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26908>

### Purpose

병렬 힙 스캔(non-fixed/COPY scan) 질의에서 버퍼풀 per-row 페이지 fix/unfix 핫패스의 **캐시라인 경합 2건**을 제거한다. TPC-H Q12(SF10) perf 분석에서 fix/unfix 계열이 전체 CPU의 큰 비중을 차지했고, 그 상당 부분이 실제 작업이 아니라 경합이었다.

| 지표 | 변경 전 | (1) 적용 | (1)+(2) 적용 |
|---|---|---|---|
| Q12 non-fixed wall | ~21s (노이즈) | ~15.8s | **~10.4s** (안정) |
| `pgbuf_fix_release` self-time | 18%대 | - | 8%대 |
| `fix_req_cnt` 원자증가 경합 | 전체 CPU의 ~14% | - | 소멸 (uncontended) |

fixed scan(~5.9s) 대비 격차가 ~3\~4배 → ~1.75배로 축소. **fixed scan을 강제하지 않고** non-fixed 스캔의 per-row latch-release 동시성을 유지한 채 달성. 질의 결과 정합성·fixed scan 성능 영향 없음.

### Implementation

**(1) FALSE SHARING — `thrd_holder_info` 캐시라인 패딩**

`PGBUF_HOLDER_ANCHOR`(`pgbuf_Pool.thrd_holder_info[]`, 스레드당 1개)가 24바이트 무패딩이라 64B 라인에 ~2.6개 packing. 각 스레드는 자기 항목만 접근하지만 매 fix/unfix가 `num_hold_cnt`/`thrd_hold_list`를 갱신 → 인접 스레드 항목이 같은 라인을 공유해 bouncing.

```c
struct pgbuf_holder_anchor {
  ...
  char m_pad[64 - 2 * sizeof (int) - 2 * sizeof (PGBUF_HOLDER *)];
};
```

`sizeof`가 64가 되어 stride 64B → 각 엔트리의 live 필드가 자기 라인을 독점. `alignof`는 8 유지라 기존 `malloc` 그대로. (`alignas(64)`+`aligned_alloc`은 `memory_wrapper`가 `aligned_alloc`을 래핑하지 않아 `free` 불일치로 힙 손상 → 사용하지 않음.)

**(2) TRUE SHARING — monitor 카운터 per-thread 샤딩**

`pgbuf_Pool.monitor.fix_req_cnt`/`pg_unfix_cnt`가 단일 전역 `std::atomic_int`로 모든 워커가 매 fix/unfix마다 증가(perf: `fix_req_cnt`의 `fetch_add`가 `pgbuf_fix_release` self-time의 78%). 이 값들은 주기적 LRU 쿼터 휴리스틱(`pgbuf_adjust_quotas` miss-rate 비율 + 활동량 임계)과 SHOW에만 쓰여 정밀도가 중요치 않다.

```c
struct pgbuf_monitor_thread_counter {
  std::atomic_int fix_req_cnt;
  std::atomic_int pg_unfix_cnt;
  char m_pad[64 - 2 * sizeof (std::atomic_int)];
};
```

전역 atomic 2개를 위 per-thread 샤드 배열(`thread_entry::index`로 인덱싱)로 교체. `pgbuf_initialize_page_monitor`에서 할당, `pgbuf_finalize`에서 해제. 핫패스는 자기 샤드만 `fetch_add`(uncontended); 주기적 소비처는 전 샤드를 합산하고 리셋은 per-shard `exchange(0)` 합이라 **손실 없이 exact**.

### Remarks

- **Specification 변화 없음**: 외부 동작/구문/카탈로그/플랜/에러 메시지 불변. 샤딩 합산이 exact라 카운터 의미도 동일.
- 검증: release 빌드 성공, 단일파일 syntax 체크 통과. Q12 결과 정합성 동일(FOB 62738/93486, REG AIR 62458/93695), FIXED=Y 영향 없음, perf상 `fix_req_cnt` 경합 + `thrd_holder_info` false-sharing 핫라인 소멸.
- 관련: CBRD-26898(show_status 제거, 동일 핫패스), CBRD-26747(enable_heap_fixed_scan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
