### PR TITLE
[CUBVEC-183] Coarse per-index serialization for HNSW transaction concurrency

### DIFF
--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -6503,14 +6503,25 @@ scan_next_vector_index_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 	    {
 	      return S_DOESNT_EXIST;	/* not qualified, continue to the next tuple */
 	    }
+	  else if (sp_scan == S_DOESNT_EXIST)
+	    {
+	      /* Unlike b-tree range scan, HNSW search returns OIDs without MVCC snapshot filtering. A row
+	       * inserted after this snapshot was taken has no visible prior version, so the visibility check
+	       * returns S_DOESNT_EXIST and recdes is left unfilled; skip it. */
+	      er_clear ();
+	      return S_DOESNT_EXIST;	/* not qualified, continue to the next tuple */
+	    }
 	  else if (sp_scan == S_ERROR)
 	    {
 	      ASSERT_ERROR ();
 	      return sp_scan;
 	    }
-	  else
+	  else if (sp_scan != S_SUCCESS && sp_scan != S_SUCCESS_CHN_UPTODATE)
 	    {
-	      assert (sp_scan == S_SUCCESS || sp_scan == S_SUCCESS_CHN_UPTODATE);
+	      /* recdes is not filled for any other code; reading it would access garbage */
+	      assert (false);
+	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
+	      return S_ERROR;
 	    }
 
 #if 0

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -6416,7 +6416,7 @@ scan_next_index_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 
 /*
  * scan_next_vector_index_scan () - fetch vector index record and evaluate data filter
- *   return: SCAN_CODE (S_SUCCESS, S_END, S_ERROR, S_DOESNT_EXIST)
+ *   return: SCAN_CODE (S_SUCCESS, S_END, S_ERROR)
  *   scan_id(in/out): Scan identifier
  *   isidp(in/out): Index scan identifier
  *   data_filter(in): data filter information
@@ -6501,15 +6501,16 @@ scan_next_vector_index_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 				      NULL_CHN);
 	  if (sp_scan == S_SNAPSHOT_NOT_SATISFIED)
 	    {
-	      return S_DOESNT_EXIST;	/* not qualified, continue to the next tuple */
+	      continue;		/* not visible in this snapshot, continue to the next tuple */
 	    }
 	  else if (sp_scan == S_DOESNT_EXIST)
 	    {
 	      /* Unlike b-tree range scan, HNSW search returns OIDs without MVCC snapshot filtering. A row
 	       * inserted after this snapshot was taken has no visible prior version, so the visibility check
-	       * returns S_DOESNT_EXIST and recdes is left unfilled; skip it. */
+	       * returns S_DOESNT_EXIST and recdes is left unfilled; skip it. The skip loop lives here (not in
+	       * the caller as in the b-tree path), so returning would abort the whole scan. */
 	      er_clear ();
-	      return S_DOESNT_EXIST;	/* not qualified, continue to the next tuple */
+	      continue;		/* not visible in this snapshot, continue to the next tuple */
 	    }
 	  else if (sp_scan == S_ERROR)
 	    {

--- a/src/storage/index_hnsw/hnsw.cpp
+++ b/src/storage/index_hnsw/hnsw.cpp
@@ -26,6 +26,8 @@
 #include <cstring>
 #include <cstdlib>
 #include <vector>
+#include <mutex>
+#include <shared_mutex>
 
 #include "error_manager.h"
 #include "system_parameter.h"
@@ -133,11 +135,17 @@ class hnsw_index_manager
 
     std::unordered_map<BTID, std::unique_ptr<hnsw_index>> m_index_map;
     std::unique_ptr<hnsw_index_backend> m_backend;
+
+    /* guards m_index_map; never held while acquiring an index_latch() */
+    mutable std::mutex m_map_mutex;
 };
 
 // singleton instances
 // TODO: dynamically load backend implementations
 static hnsw_index_manager *index_manager = nullptr;
+
+/* serializes the load-on-first-access path in hnsw_get_index */
+static std::mutex hnsw_load_mutex;
 
 // =====================================================================
 // high-level APIs
@@ -467,31 +475,28 @@ hnsw_get_index (THREAD_ENTRY *thread_p, BTID *btid, hnsw_index *&index)
   index = index_manager->get_index (btid);
   if (index == nullptr)
     {
-      int error = index_manager->load_index (thread_p, btid, index);
-      if (error != NO_ERROR || index == nullptr)
+      /* double-checked load: concurrent misses must not load the same index twice */
+      std::lock_guard<std::mutex> load_guard (hnsw_load_mutex);
+      index = index_manager->get_index (btid);
+      if (index == nullptr)
 	{
-	  assert (false);
-	  return error == NO_ERROR ? ER_FAILED : error;
+	  int error = index_manager->load_index (thread_p, btid, index);
+	  if (error != NO_ERROR || index == nullptr)
+	    {
+	      assert (false);
+	      return error == NO_ERROR ? ER_FAILED : error;
+	    }
 	}
     }
 
   return NO_ERROR;
 }
 
-int
-hnsw_add_element (THREAD_ENTRY *thread_p, BTID *btid, OID *oid, float *vector, int n_vectors)
+/* body of hnsw_add_element; caller must hold index->index_latch() exclusively */
+static int
+hnsw_add_element_locked (THREAD_ENTRY *thread_p, BTID *btid, hnsw_index *index, OID *oid, float *vector,
+			 int n_vectors)
 {
-  assert (oid);
-  assert (vector);
-  assert (n_vectors > 0);
-
-  hnsw_index *index = NULL;
-  int error = hnsw_get_index (thread_p, btid, index);
-  if (error != NO_ERROR)
-    {
-      return error;
-    }
-
   if (index->prepare_to_add (thread_p, n_vectors, oid, vector) != NO_ERROR)
     {
       assert (false);
@@ -527,18 +532,10 @@ hnsw_add_element (THREAD_ENTRY *thread_p, BTID *btid, OID *oid, float *vector, i
   return index->add (thread_p, n_vectors, oid, vector);
 }
 
-int
-hnsw_delete_element (THREAD_ENTRY *thread_p, BTID *btid, OID *oid)
+/* body of hnsw_delete_element; caller must hold index->index_latch() exclusively */
+static int
+hnsw_delete_element_locked (THREAD_ENTRY *thread_p, BTID *btid, hnsw_index *index, OID *oid)
 {
-  assert (oid);
-
-  hnsw_index *index = NULL;
-  int error = hnsw_get_index (thread_p, btid, index);
-  if (error != NO_ERROR)
-    {
-      return error;
-    }
-
   if (!log_is_in_crash_recovery ())
     {
       const hnsw_build_params &params = index->get_build_params ();
@@ -578,21 +575,64 @@ hnsw_delete_element (THREAD_ENTRY *thread_p, BTID *btid, OID *oid)
 }
 
 int
-hnsw_update_element (THREAD_ENTRY *thread_p, BTID *btid, OID *oid, float *vector)
+hnsw_add_element (THREAD_ENTRY *thread_p, BTID *btid, OID *oid, float *vector, int n_vectors)
 {
   assert (oid);
   assert (vector);
+  assert (n_vectors > 0);
 
-  /* UPDATE = logged DELETE of the old vector + logged INSERT of the new vector. This composes for
-   * rollback and crash recovery: the per-op UNDO/REDO records run in the correct reverse order
-   * automatically (insert UNDO tombstones the new node, delete UNDO revives the old node). */
-  int error = hnsw_delete_element (thread_p, btid, oid);
+  hnsw_index *index = NULL;
+  int error = hnsw_get_index (thread_p, btid, index);
   if (error != NO_ERROR)
     {
       return error;
     }
 
-  return hnsw_add_element (thread_p, btid, oid, vector, 1);
+  std::unique_lock<std::shared_mutex> wlock (index->index_latch ());
+  return hnsw_add_element_locked (thread_p, btid, index, oid, vector, n_vectors);
+}
+
+int
+hnsw_delete_element (THREAD_ENTRY *thread_p, BTID *btid, OID *oid)
+{
+  assert (oid);
+
+  hnsw_index *index = NULL;
+  int error = hnsw_get_index (thread_p, btid, index);
+  if (error != NO_ERROR)
+    {
+      return error;
+    }
+
+  std::unique_lock<std::shared_mutex> wlock (index->index_latch ());
+  return hnsw_delete_element_locked (thread_p, btid, index, oid);
+}
+
+int
+hnsw_update_element (THREAD_ENTRY *thread_p, BTID *btid, OID *oid, float *vector)
+{
+  assert (oid);
+  assert (vector);
+
+  hnsw_index *index = NULL;
+  int error = hnsw_get_index (thread_p, btid, index);
+  if (error != NO_ERROR)
+    {
+      return error;
+    }
+
+  /* UPDATE = logged DELETE of the old vector + logged INSERT of the new vector. This composes for
+   * rollback and crash recovery: the per-op UNDO/REDO records run in the correct reverse order
+   * automatically (insert UNDO tombstones the new node, delete UNDO revives the old node).
+   * Both sub-ops run under a single exclusive latch so the UPDATE is atomic on this index. */
+  std::unique_lock<std::shared_mutex> wlock (index->index_latch ());
+  error = hnsw_delete_element_locked (thread_p, btid, index, oid);
+  if (error != NO_ERROR)
+    {
+      return error;
+    }
+
+  return hnsw_add_element_locked (thread_p, btid, index, oid, vector, 1);
 }
 
 /*
@@ -662,6 +702,8 @@ hnsw_rv_redo_insert_element (THREAD_ENTRY *thread_p, LOG_RCV *rcv)
     {
       return error == NO_ERROR ? ER_FAILED : error;
     }
+
+  std::unique_lock<std::shared_mutex> wlock (index->index_latch ());
 
   /* Idempotent replay: when recovery reuses the disk-flushed graph, a windowed insert whose row
    * was already flushed is present as a live node — re-adding it would duplicate. Skip in that
@@ -748,6 +790,8 @@ hnsw_rv_redo_delete_element (THREAD_ENTRY *thread_p, LOG_RCV *rcv)
       return error == NO_ERROR ? ER_FAILED : error;
     }
 
+  std::unique_lock<std::shared_mutex> wlock (index->index_latch ());
+
   error = index->remove (thread_p, oid);
   if (error != NO_ERROR)
     {
@@ -811,6 +855,8 @@ hnsw_rv_undo_insert_element (THREAD_ENTRY *thread_p, LOG_RCV *rcv)
       return error == NO_ERROR ? ER_FAILED : error;
     }
 
+  std::unique_lock<std::shared_mutex> wlock (index->index_latch ());
+
   /* Compensation: log the tombstone as a delete REDO before applying it, so a crash during or
    * after rollback replays it. */
   char wal_data[sizeof (HNSW_RV_LOG_HEADER)];
@@ -868,6 +914,8 @@ hnsw_rv_undo_delete_element (THREAD_ENTRY *thread_p, LOG_RCV *rcv)
       return error == NO_ERROR ? ER_FAILED : error;
     }
 
+  std::unique_lock<std::shared_mutex> wlock (index->index_latch ());
+
   /* Compensation: log the revive before applying it, so a crash during/after rollback replays it. */
   log_append_dboutside_redo (thread_p, RVHNSW_REVIVE_ELEMENT, rcv->length, rcv->data);
 
@@ -912,6 +960,8 @@ hnsw_rv_redo_revive_element (THREAD_ENTRY *thread_p, LOG_RCV *rcv)
       return error == NO_ERROR ? ER_FAILED : error;
     }
 
+  std::unique_lock<std::shared_mutex> wlock (index->index_latch ());
+
   error = index->revive (thread_p, oid, vector);
   if (error != NO_ERROR)
     {
@@ -952,6 +1002,8 @@ hnsw_search_element (THREAD_ENTRY *thread_p, BTID *btid, DB_VALUE *key_dbvalue, 
   assert (vf != NULL && vf->dim == index->get_dimension());
 
   int ef_search = prm_get_integer_value (PRM_ID_VECTOR_INDEX_EF_SEARCH);
+
+  std::shared_lock<std::shared_mutex> rlock (index->index_latch ());
   return index->search (thread_p, vf->float_array, k, ef_search, rec_oids, distances);
 }
 
@@ -1037,6 +1089,7 @@ hnsw_index_manager::is_index_loaded (const BTID *btid) const
 int
 hnsw_index_manager::add_index (const BTID *btid, hnsw_index *index)
 {
+  std::lock_guard<std::mutex> map_guard (m_map_mutex);
   if (is_index_loaded (btid))
     {
       assert (false);
@@ -1051,6 +1104,7 @@ hnsw_index_manager::add_index (const BTID *btid, hnsw_index *index)
 hnsw_index *
 hnsw_index_manager::get_index (const BTID *btid) const
 {
+  std::lock_guard<std::mutex> map_guard (m_map_mutex);
   if (is_index_loaded (btid))
     {
       return m_index_map.at (*btid).get();
@@ -1061,6 +1115,7 @@ hnsw_index_manager::get_index (const BTID *btid) const
 int
 hnsw_index_manager::delete_index (const BTID *btid)
 {
+  std::lock_guard<std::mutex> map_guard (m_map_mutex);
   m_index_map.erase (*btid);
   return NO_ERROR;
 }

--- a/src/storage/index_hnsw/hnsw_api.hpp
+++ b/src/storage/index_hnsw/hnsw_api.hpp
@@ -27,6 +27,7 @@
 #include <memory>
 #include <filesystem>
 #include <cassert>
+#include <shared_mutex>
 
 #include "storage_common.h"
 #include "dbtype_def.h"
@@ -209,6 +210,13 @@ class hnsw_index
       return NO_ERROR;
     }
 
+    /* coarse per-index reader/writer lock: DML/UNDO/REDO exclusive, search shared.
+     * Acquired before any page is fixed, so it is outermost vs HNSW page latches. */
+    std::shared_mutex &index_latch ()
+    {
+      return m_latch;
+    }
+
   protected:
     hnsw_index (hnsw_index_backend &backend, const BTID &btid, const std::string &name,
 		const hnsw_build_params &build_params);
@@ -217,6 +225,7 @@ class hnsw_index
     const BTID m_btid;
     const std::string m_name;
     const hnsw_build_params m_build_params;
+    std::shared_mutex m_latch;
 };
 
 namespace hnsw_backend_registry


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBVEC-183>

### Purpose
HNSW index에 대한 transaction 동시성(concurrent DML/search)을 지원한다.

### Implementation

  - `hnsw_index::m_latch` (`std::shared_mutex`, index당 1개) — index 본체 보호
    - 보호 대상: 해당 index의 공유 상태 전체 (graph link/level, node slot/neighbor/vector cache)
    - exclusive 획득: `hnsw_add_element()` / `hnsw_delete_element()` / `hnsw_update_element()` 및 5개의 `hnsw_rv_*` UNDO/REDO handler
    - shared 획득: `hnsw_search_element()` — 동시 search는 병렬로 수행된다.
    - UPDATE(= delete + add)는 하나의 exclusive 획득 아래에서 두 sub-op를 수행한다. 이를 위해 add/delete 본문을 내부 `*_locked` worker로 분리한다. (`shared_mutex`는 재진입 불가) 다른 writer/searcher가 UPDATE 중간 상태(delete만 반영된 상태)를 관찰할 수 없다.

  - `hnsw_index_manager::m_map_mutex` (`std::mutex`, 전역 1개) — index cache map 보호
    - 보호 대상: BTID → index 객체 map (`m_index_map`)
    - 획득: `add_index()` / `get_index()` / `delete_index()`
    - 각 index의 `m_latch`와 독립적이며, 이 mutex를 잡은 채 `m_latch`를 획득하지 않는다.

  - `hnsw_load_mutex` (`std::mutex`, 전역 1개) — load-on-first-access 직렬화
    - 보호 대상: `hnsw_get_index()`의 최초 접근 시 disk load 경로
    - double-checked load: cache miss 시 mutex 획득 후 map을 재확인하므로, 동시에 miss가 나도 같은 index를 두 번 load하지 않는다.
    
### Remarks

아래 TC를 검증하였다. (CS mode, 같은 index에 대해 여러 csql client 동시 실행)

  ```sql
  CREATE TABLE t (id INT PRIMARY KEY, v VECTOR(3));
  CREATE VECTOR INDEX i_t_v ON t(v EUCLIDEAN);
  -- seed: id 1..200 INSERT + COMMIT

  -- 이후 4개 client 동시 실행:
  --   client A: INSERT id 201..300 (100건) + COMMIT
  --   client B: UPDATE id 1..100 vector 변경 (100건) + COMMIT
  --   client C: DELETE id 101..150 (50건) + COMMIT
  --   client D: 반복 search
  SELECT id FROM t ORDER BY v <-> '[1,2,3]' LIMIT 5;

  -- Expected: assert/deadlock/crash 없음, 최종 live row = 250
  SELECT COUNT(*) FROM t;
  ```

  검증 결과:

  - 단일 thread DML/search/rollback 동작 변화 없음 (regression 없음)
  - 동시 INSERT client 3개(300건) + 동시 search: assert/deadlock/crash 없음, 최종 건수 일치
  - 동시 UPDATE + DELETE + INSERT-ROLLBACK + search: transaction 결과와 일치 (rollback된 row 미노출)
