### PR TITLE
[CBRD-26867] Fix HA loaddb OOS replication

### DIFF
--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -713,6 +713,12 @@ namespace cubload
 	if (!m_error_handler.current_line_has_error ())
 	  {
 	    m_recdes_collected.push_back (std::move (new_recdes));
+
+	    if (!HA_DISABLED () && heap_recdes_contains_oos (&m_recdes_collected.back ().get_recdes ()))
+	      {
+		/* OOS replication state is thread/transaction-local and belongs to the just-transformed record. */
+		flush_records ();
+	      }
 	  }
 	else
 	  {
@@ -789,6 +795,7 @@ namespace cubload
 		  }
 
 		// Error was filtered so we can continue.
+		m_error_handler.set_error_on_current_line (false);
 		continue;
 	      }
 
@@ -796,6 +803,7 @@ namespace cubload
 	    log_sysop_attach_to_outer (m_thread_ref);
 	    ++m_rows;
 	  }
+	m_recdes_collected.clear ();
       }
     else
       {
@@ -814,6 +822,7 @@ namespace cubload
 	  {
 	    log_sysop_attach_to_outer (m_thread_ref);
 	    m_rows += m_recdes_collected.size ();
+	    m_recdes_collected.clear ();
 	  }
       }
   }

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -5386,7 +5386,9 @@ la_get_recdes (LOG_LSA * lsa, LOG_PAGE * pgptr, RECDES * recdes, unsigned int *r
 	char mvcc_flag;
 
 	mvcc_flag = (char) ((repid_and_flag_bits >> OR_MVCC_FLAG_SHIFT_BITS) & OR_MVCC_FLAG_MASK);
-	assert (mvcc_flag == 0);
+	/* OOS records may already carry OR_MVCC_FLAG_HAS_OOS; only MVCC lifecycle flags must be absent here. */
+	assert ((mvcc_flag & (OR_MVCC_FLAG_VALID_INSID | OR_MVCC_FLAG_VALID_DELID
+			      | OR_MVCC_FLAG_VALID_PREV_VERSION)) == 0);
       }
 #endif
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26867

## Purpose

`HA + loaddb + OOS` 조합에서 OOS record가 slave까지 정상 복제되지 않아 HA regression TC가 실패하는 문제를 수정한다.

원인은 OOS record와 OOS replication state의 lifetime이 어긋나는 것이다.

기존 `loaddb` CS-mode는 record를 바로 insert하지 않고 `m_recdes_collected`에 모았다가 나중에 `flush_records()`에서 insert한다. 하지만 OOS record는 record 본문 외에도 HA replication에 필요한 OOS 상태를 thread/transaction-local queue에 저장한다.

따라서 OOS row를 여러 개 모아둔 뒤 flush하면, 먼저 transform된 row의 OOS replication state가 다음 row 처리 과정에서 갱신되거나 소진될 수 있었다. 이 경우 master에서 OOS dummy replication log 생성 중 record와 OOS LSA queue가 맞지 않아 assert가 발생한다.

```text
repl_log_insert(...)
rcvindex = RVREPL_DUMMY_OOS_RECORD
Assertion 'false' failed
```

추가로 slave applylog에서도 `RVHF_INSERT` record를 MVCC 형태로 변환할 때 `mvcc_flag == 0`을 기대했지만, OOS record는 `OR_MVCC_FLAG_HAS_OOS`를 정상적으로 가질 수 있으므로 assert 조건을 보정한다.

## Implementation

**`src/loaddb/load_server_loader.cpp`**

- HA 환경에서 방금 transform된 record가 OOS를 포함하면 즉시 `flush_records()`를 호출한다.
- OOS replication state가 아직 현재 record와 대응되는 동안 insert되도록 보장한다.
- `flush_records()` 성공 후 `m_recdes_collected.clear()`를 수행하여 이미 insert된 record가 다시 flush되지 않게 한다.
- insert 중 filtered error가 발생한 경우 `current_line_has_error`를 즉시 clear한다.
  - 이 flag가 다음 input row로 넘어가면 다음 정상 row가 skip될 수 있으므로 `flush_records()` 안에서 소비한다.

**`src/transaction/log_applier.c`**

- `la_get_recdes()`의 debug assert를 보정한다.
- 기존에는 `mvcc_flag == 0`만 허용했지만, 이제 `OR_MVCC_FLAG_HAS_OOS`는 허용한다.
- 대신 실제 MVCC lifecycle flag만 없어야 한다고 검사한다.
  - `OR_MVCC_FLAG_VALID_INSID`
  - `OR_MVCC_FLAG_VALID_DELID`
  - `OR_MVCC_FLAG_VALID_PREV_VERSION`

## Test

| 케이스 | 결과 |
|---|---|
| Debug build/install | PASS |
| `cbrd_24983` HA loaddb OOS 재현 TC | 3/3 OK |
| `cubrid applyinfo` failure count | `Fail_count:0` |
| slave row count 확인 | 2 rows 확인 |
| `git diff --check`, `git diff --cached --check` | PASS |

실행 TC:

```text
HA/shell/_38_fig/cbrd_24983/cases/cbrd_24983.sh
```

최종 결과:

```text
./cbrd_24983-1 : OK
./cbrd_24983-2 : OK  [Fail_count:0]
./cbrd_24983-3 : OK
```

## Remarks

이번 수정은 CBRD-26867 regression을 막기 위한 최소 안정화 패치이다.

성능 측면에서는 `HA + OOS 비중이 높은 loaddb`에서 throughput 저하 가능성이 있다. HA 경로는 기존에도 `locator_multi_insert_force()` 대신 row-by-row `locator_insert_force()`를 사용하므로 multi-insert 최적화는 이미 비활성화되어 있다. 다만 이번 변경으로 OOS record마다 `finish_line()` 직후 `flush_records()`가 호출되어, 기존보다 flush invocation 단위가 더 잘게 쪼개질 수 있다.

영향 범위는 다음과 같다.

- HA disabled loaddb: 영향 없음
- OOS 없는 일반 loaddb: 영향 없음
- HA + OOS row가 일부 섞인 loaddb: OOS row에서만 즉시 flush
- HA + 대부분 OOS row인 loaddb: flush 호출 오버헤드 증가 가능

장기적으로는 loader가 OOS 여부에 따라 flush 정책을 결정하는 구조보다, OOS replication state ownership을 lower layer에서 row-scoped로 관리하는 방향이 더 좋다. 다만 변경 범위와 회귀 위험이 커서 이번 패치에서는 현재 regression을 국소적으로 막는 방식을 선택했다.

전체 HA regression suite는 실행하지 않았고, 본 이슈에 매핑된 단일 HA regression TC를 직접 실행해 검증했다.