### PR TITLE
[CBRD-26924] Cut per-row overhead in non-fixed heap scan: COPY all-visible shortcut

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -25522,9 +25522,10 @@ heap_scan_get_visible_version (THREAD_ENTRY * thread_p, const OID * oid, OID * c
    * or the mvcc_snapshot does not satisfy, then carry out the necessary steps through 
    * the heap_get_visible_version_internal() function.
    */
-  if (peeked_recdes->type == REC_HOME && ispeeking == PEEK)
+  if (peeked_recdes->type == REC_HOME && (ispeeking == PEEK || ispeeking == COPY))
     {
       MVCC_REC_HEADER mvcc_header = MVCC_REC_HEADER_INITIALIZER;
+      bool shortcut_visible = false;
 
       assert (scan_cache != NULL);
       assert (recdes != NULL);
@@ -25542,27 +25543,51 @@ heap_scan_get_visible_version (THREAD_ENTRY * thread_p, const OID * oid, OID * c
 	  assert (OID_EQ (class_oid, &scan_cache->node.class_oid));
 	  if (MVCC_IS_HEADER_ALL_VISIBLE (&mvcc_header))
 	    {
-	      *recdes = *peeked_recdes;
-	      return scan;
+	      shortcut_visible = true;
 	    }
-	  if (!scan_cache->mvcc_disabled_class)
+	  else if (!scan_cache->mvcc_disabled_class)
 	    {
-	      if (scan_cache->mvcc_snapshot != NULL && scan_cache->mvcc_snapshot->snapshot_fnc != NULL)
+	      if (scan_cache->mvcc_snapshot != NULL && scan_cache->mvcc_snapshot->snapshot_fnc != NULL
+		  && scan_cache->mvcc_snapshot->snapshot_fnc (thread_p, &mvcc_header,
+							      scan_cache->mvcc_snapshot) == SNAPSHOT_SATISFIED)
 		{
-		  if (scan_cache->mvcc_snapshot->snapshot_fnc (thread_p, &mvcc_header, scan_cache->mvcc_snapshot) ==
-		      SNAPSHOT_SATISFIED)
-		    {
-		      *recdes = *peeked_recdes;
-		      return scan;
-		    }
+		  shortcut_visible = true;
 		}
 	    }
 	  else
 	    {
 	      /* mvcc_disabled_class */
+	      shortcut_visible = true;
+	    }
+	}
+
+      if (shortcut_visible)
+	{
+	  if (ispeeking == PEEK)
+	    {
+	      /* recdes may point directly into the still-latched page */
 	      *recdes = *peeked_recdes;
 	      return scan;
 	    }
+
+	  /* COPY: the scan still holds the page (the caller sets cache_last_fix_page before this call), so copy the
+	   * already-peeked REC_HOME record straight into recdes. This skips heap_(init|prepare|clean)_get_context and,
+	   * in particular, avoids re-fixing the home page (pgbuf_ordered_fix / pgbuf_replace_watcher) that the scan
+	   * already has fixed. Per-row latch behavior is unchanged. */
+	  if (recdes->data == NULL
+	      && heap_scan_cache_allocate_recdes_data (thread_p, scan_cache, recdes, DB_PAGESIZE * 2) != NO_ERROR)
+	    {
+	      ASSERT_ERROR ();
+	      return S_ERROR;
+	    }
+	  if (peeked_recdes->length <= recdes->area_size)
+	    {
+	      memcpy (recdes->data, peeked_recdes->data, peeked_recdes->length);
+	      recdes->length = peeked_recdes->length;
+	      recdes->type = peeked_recdes->type;
+	      return scan;
+	    }
+	  /* recdes buffer too small (not expected for a single-page REC_HOME): fall through to the full path. */
 	}
       /* fall through.. */
     }

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -2119,7 +2119,11 @@ pgbuf_fix_release (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_MODE f
 try_again:
 
   /* interrupt check */
-  if (logtb_get_check_interrupt (thread_p) == true)
+  /* Fast-path guard: only resolve this thread's interrupt state when some transaction actually has a
+   * pending interrupt. log_Gl.trantable.num_interrupts is a single cheap (sig_atomic_t) read that becomes
+   * > 0 the instant an interrupt is set, so cancellation latency is unchanged; this avoids two function
+   * calls on every page fix (per-row on the scan hot path). */
+  if (log_Gl.trantable.num_interrupts > 0 && logtb_get_check_interrupt (thread_p) == true)
     {
       if (logtb_is_interrupted (thread_p, true, &pgbuf_Pool.check_for_interrupts) == true)
 	{
@@ -4479,7 +4483,7 @@ pgbuf_copy_to_area (THREAD_ENTRY * thread_p, const VPID * vpid, int start_offset
   PGBUF_BCB *bufptr;
   PAGE_PTR pgptr;
 
-  if (logtb_get_check_interrupt (thread_p) == true)
+  if (log_Gl.trantable.num_interrupts > 0 && logtb_get_check_interrupt (thread_p) == true)
     {
       if (logtb_is_interrupted (thread_p, true, &pgbuf_Pool.check_for_interrupts) == true)
 	{

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -2024,16 +2024,6 @@ pgbuf_fix_with_retry (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_MOD
   return pgptr;
 }
 
-/* Sampled interrupt check for the page-fix hot path: resolve this thread's interrupt state (a
- * cross-translation-unit call to logtb_is_interrupted ()) only once per PGBUF_INTERRUPT_SAMPLE_MASK
- * + 1 page fixes instead of on every fix. The authoritative logtb_is_interrupted () still decides, so
- * BOTH ^C cancellation and query_timeout (tdes->query_timeout, which does not bump
- * trantable.num_interrupts) remain covered without duplicating any interrupt-source check here;
- * only the polling granularity changes (bounded sub-millisecond latency on the hot path). The
- * counter is per-thread, so there is no sharing or contention. */
-#define PGBUF_INTERRUPT_SAMPLE_MASK 0x3FF	/* check once per 1024 page fixes */
-static thread_local unsigned int pgbuf_interrupt_sample_cnt = 0;
-
 /*
  * pgbuf_fix () -
  *   return: Pointer to the page or NULL
@@ -2128,9 +2118,8 @@ pgbuf_fix_release (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_MODE f
 
 try_again:
 
-  /* interrupt check (sampled; see pgbuf_interrupt_sample_cnt) */
-  if (((++pgbuf_interrupt_sample_cnt & PGBUF_INTERRUPT_SAMPLE_MASK) == 0)
-      && logtb_get_check_interrupt (thread_p) == true)
+  /* interrupt check */
+  if (logtb_get_check_interrupt (thread_p) == true)
     {
       if (logtb_is_interrupted (thread_p, true, &pgbuf_Pool.check_for_interrupts) == true)
 	{
@@ -4490,8 +4479,7 @@ pgbuf_copy_to_area (THREAD_ENTRY * thread_p, const VPID * vpid, int start_offset
   PGBUF_BCB *bufptr;
   PAGE_PTR pgptr;
 
-  if (((++pgbuf_interrupt_sample_cnt & PGBUF_INTERRUPT_SAMPLE_MASK) == 0)
-      && logtb_get_check_interrupt (thread_p) == true)
+  if (logtb_get_check_interrupt (thread_p) == true)
     {
       if (logtb_is_interrupted (thread_p, true, &pgbuf_Pool.check_for_interrupts) == true)
 	{

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -2024,6 +2024,16 @@ pgbuf_fix_with_retry (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_MOD
   return pgptr;
 }
 
+/* Sampled interrupt check for the page-fix hot path: resolve this thread's interrupt state (a
+ * cross-translation-unit call to logtb_is_interrupted ()) only once per PGBUF_INTERRUPT_SAMPLE_MASK
+ * + 1 page fixes instead of on every fix. The authoritative logtb_is_interrupted () still decides, so
+ * BOTH ^C cancellation and query_timeout (tdes->query_timeout, which does not bump
+ * trantable.num_interrupts) remain covered without duplicating any interrupt-source check here;
+ * only the polling granularity changes (bounded sub-millisecond latency on the hot path). The
+ * counter is per-thread, so there is no sharing or contention. */
+#define PGBUF_INTERRUPT_SAMPLE_MASK 0x3FF	/* check once per 1024 page fixes */
+static thread_local unsigned int pgbuf_interrupt_sample_cnt = 0;
+
 /*
  * pgbuf_fix () -
  *   return: Pointer to the page or NULL
@@ -2118,12 +2128,9 @@ pgbuf_fix_release (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_MODE f
 
 try_again:
 
-  /* interrupt check */
-  /* Fast-path guard: only resolve this thread's interrupt state when some transaction actually has a
-   * pending interrupt. log_Gl.trantable.num_interrupts is a single cheap (sig_atomic_t) read that becomes
-   * > 0 the instant an interrupt is set, so cancellation latency is unchanged; this avoids two function
-   * calls on every page fix (per-row on the scan hot path). */
-  if (log_Gl.trantable.num_interrupts > 0 && logtb_get_check_interrupt (thread_p) == true)
+  /* interrupt check (sampled; see pgbuf_interrupt_sample_cnt) */
+  if (((++pgbuf_interrupt_sample_cnt & PGBUF_INTERRUPT_SAMPLE_MASK) == 0)
+      && logtb_get_check_interrupt (thread_p) == true)
     {
       if (logtb_is_interrupted (thread_p, true, &pgbuf_Pool.check_for_interrupts) == true)
 	{
@@ -4483,7 +4490,8 @@ pgbuf_copy_to_area (THREAD_ENTRY * thread_p, const VPID * vpid, int start_offset
   PGBUF_BCB *bufptr;
   PAGE_PTR pgptr;
 
-  if (log_Gl.trantable.num_interrupts > 0 && logtb_get_check_interrupt (thread_p) == true)
+  if (((++pgbuf_interrupt_sample_cnt & PGBUF_INTERRUPT_SAMPLE_MASK) == 0)
+      && logtb_get_check_interrupt (thread_p) == true)
     {
       if (logtb_is_interrupted (thread_p, true, &pgbuf_Pool.check_for_interrupts) == true)
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26924

### Purpose

본 PR은 비고정(non-fixed, COPY) 힙 스캔에서 **이미 latch한 home page를 per-row로 다시 fix하는 비용**을 제거한다.

측정: TPC-H Q12 (SF10, data_buffer 24G, FIXED=N, 병렬 힙 스캔 worker 4). `perf` self-time 기준.

| 단계 | 결과 |
|---|---|
| (선행: CBRD-26898 + CBRD-26908) | ~10.4s |
| + COPY all-visible shortcut | ~9.6s |

결과 정합성 정확. FIXED=Y(PEEK) 경로는 영향 없음.

### Implementation

**COPY all-visible REC_HOME shortcut** (`src/storage/heap_file.c`: `heap_scan_get_visible_version`)

COPY 모드는 all-visible(또는 snapshot 만족) REC_HOME인 경우에도 fast-path(`ispeeking == PEEK` 전용)를 타지 못하고 `heap_init_get_context` → `heap_prepare_get_context` → `heap_clean_get_context`로 빠져, 스캔이 **이미 잡고 있는 home page를 per-row로 다시 fix**(`pgbuf_ordered_fix` + `pgbuf_replace_watcher`)했다.

동일한 MVCC 가시성 판정(all-visible / snapshot-satisfied / mvcc_disabled_class) 후, 이미 peek한 REC_HOME 레코드를 recdes로 직접 `memcpy`(필요 시 `heap_scan_cache_allocate_recdes_data`로 버퍼 확보)하여 init/prepare/clean_context와 home page 재fix를 생략한다.

- 안전성: caller가 `cache_last_fix_page`를 설정해 페이지가 latch된 상태 → peek 레코드 참조 유효.
- REC_HOME만 처리. RELOCATION/BIGONE/버퍼부족은 기존 경로로 안전 fallthrough.
- per-row latch 동작(비고정 의미론) 불변 — 고정 스캔으로 바꾸는 것이 아니다.
- 효과: perf self-time 상위에서 `pgbuf_ordered_fix_release` / `pgbuf_replace_watcher` / `heap_init_get_context` 제거.

### Remarks

- 외부 동작/문법/설정/카탈로그/플랜덤프/에러메시지 변화 없음. 질의 결과·인터럽트(취소·타임아웃) 동작은 기존과 동일.
- **인터럽트 검사 최적화는 본 PR에서 제외**: 초기 리비전에 있던 page-fix 인터럽트 체크 변경(`num_interrupts` 가드 → 샘플링)은 비병렬·버퍼 상주 스캔에서 query_timeout 감지를 지연/누락시키는 회귀가 있어 제거했다(리뷰에서 확인됨). 인터럽트 체크 자체를 싸게 만드는 정공법(공유 트랜잭션 인터럽트 API의 공통 경로 헤더-인라인화)은 별도 티켓에서 다룬다.
- 관련: CBRD-26898 (#7267), CBRD-26908 (#7274).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
