### PR TITLE
[CBRD-26932] Inline fast-path for fetch_peek_dbval to remove per-row dispatch/framework overhead

### DIFF
--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -4537,6 +4537,7 @@ fetch_peek_dbval_slow (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, val_de
        || regu_var->type == TYPE_DBVAL || regu_var->type == TYPE_POS_VALUE
        || (regu_var->type == TYPE_CONSTANT && regu_var->xasl == NULL && regu_var->value.dbvalptr != NULL))
       && !REGU_VARIABLE_IS_FLAGED (regu_var, REGU_VARIABLE_APPLY_COLLATION)
+      && regu_var->domain != NULL
       && TP_DOMAIN_TYPE (regu_var->domain) != DB_TYPE_VARIABLE
       && TP_DOMAIN_COLLATION_FLAG (regu_var->domain) == TP_DOMAIN_COLL_NORMAL)
     {

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -4523,15 +4523,7 @@ fetch_peek_dbval_slow (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, val_de
   assert (REGU_VARIABLE_IS_FLAGED (regu_var, REGU_VARIABLE_FETCH_ALL_CONST)
 	  || REGU_VARIABLE_IS_FLAGED (regu_var, REGU_VARIABLE_FETCH_NOT_CONST));
 
-  /* If this fetch needs no per-row post-processing, mark the regu_var so the inline fetch_peek_dbval ()
-   * wrapper can return the value pointer directly next time, skipping the type switch and these generic
-   * checks. The domain is fully resolved by this point, so the VARIABLE/collation tests are final.
-   * Eligible: a cached TYPE_ATTR_ID (wrapper re-checks cache_dbvalp != NULL, so a later reset is safe) or
-   * a TYPE_DBVAL literal constant (value embedded in the regu_var). */
-  /* Cheap type test first: non-eligible regu_vars (arith, function, subquery, ...) are re-fetched per
-   * row and must short-circuit here without touching the domain (the TP_DOMAIN_* derefs are a cache-
-   * missing pointer chase). Eligible attr/dbval vars pay the domain test once, then get flagged and
-   * never return to this slow path. */
+  /* flag a stable regu_var (cached attr/literal/pos/const) so inline fetch_peek_dbval () peeks it directly */
   if ((((regu_var->type == TYPE_ATTR_ID || regu_var->type == TYPE_SHARED_ATTR_ID
 	 || regu_var->type == TYPE_CLASS_ATTR_ID) && regu_var->value.attr_descr.cache_dbvalp != NULL)
        || regu_var->type == TYPE_DBVAL || regu_var->type == TYPE_POS_VALUE

--- a/src/query/fetch.c
+++ b/src/query/fetch.c
@@ -3909,7 +3909,8 @@ error:
 }
 
 /*
- * fetch_peek_dbval () - returns a POINTER to an existing db_value
+ * fetch_peek_dbval_slow () - full fetch path for every regu_var type; the hot cached-attribute case is
+ *                            served by the inline fetch_peek_dbval () wrapper in fetch.h.
  *   return: NO_ERROR or ER_code
  *   regu_var(in/out): Regulator Variable
  *   vd(in): Value Descriptor
@@ -3920,8 +3921,8 @@ error:
  *
  */
 int
-fetch_peek_dbval (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, val_descr * vd, OID * class_oid, OID * obj_oid,
-		  QFILE_TUPLE tpl, DB_VALUE ** peek_dbval)
+fetch_peek_dbval_slow (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, val_descr * vd, OID * class_oid,
+		       OID * obj_oid, QFILE_TUPLE tpl, DB_VALUE ** peek_dbval)
 {
   int length;
   const PR_TYPE *pr_type;
@@ -4521,6 +4522,26 @@ fetch_peek_dbval (THREAD_ENTRY * thread_p, REGU_VARIABLE * regu_var, val_descr *
 
   assert (REGU_VARIABLE_IS_FLAGED (regu_var, REGU_VARIABLE_FETCH_ALL_CONST)
 	  || REGU_VARIABLE_IS_FLAGED (regu_var, REGU_VARIABLE_FETCH_NOT_CONST));
+
+  /* If this fetch needs no per-row post-processing, mark the regu_var so the inline fetch_peek_dbval ()
+   * wrapper can return the value pointer directly next time, skipping the type switch and these generic
+   * checks. The domain is fully resolved by this point, so the VARIABLE/collation tests are final.
+   * Eligible: a cached TYPE_ATTR_ID (wrapper re-checks cache_dbvalp != NULL, so a later reset is safe) or
+   * a TYPE_DBVAL literal constant (value embedded in the regu_var). */
+  /* Cheap type test first: non-eligible regu_vars (arith, function, subquery, ...) are re-fetched per
+   * row and must short-circuit here without touching the domain (the TP_DOMAIN_* derefs are a cache-
+   * missing pointer chase). Eligible attr/dbval vars pay the domain test once, then get flagged and
+   * never return to this slow path. */
+  if ((((regu_var->type == TYPE_ATTR_ID || regu_var->type == TYPE_SHARED_ATTR_ID
+	 || regu_var->type == TYPE_CLASS_ATTR_ID) && regu_var->value.attr_descr.cache_dbvalp != NULL)
+       || regu_var->type == TYPE_DBVAL || regu_var->type == TYPE_POS_VALUE
+       || (regu_var->type == TYPE_CONSTANT && regu_var->xasl == NULL && regu_var->value.dbvalptr != NULL))
+      && !REGU_VARIABLE_IS_FLAGED (regu_var, REGU_VARIABLE_APPLY_COLLATION)
+      && TP_DOMAIN_TYPE (regu_var->domain) != DB_TYPE_VARIABLE
+      && TP_DOMAIN_COLLATION_FLAG (regu_var->domain) == TP_DOMAIN_COLL_NORMAL)
+    {
+      REGU_VARIABLE_SET_FLAG (regu_var, REGU_VARIABLE_FAST_PEEK);
+    }
 
   return NO_ERROR;
 

--- a/src/query/fetch.h
+++ b/src/query/fetch.h
@@ -30,14 +30,62 @@
 #include "oid.h"
 #include "query_evaluator.h"
 #include "query_list.h"
+#include "regu_var.hpp"		/* REGU_VARIABLE definition + flags for the inline fetch_peek_dbval () */
+#include "query_executor.h"	/* val_descr definition for the inline fetch_peek_dbval () TYPE_POS_VALUE path */
 
 // forward definitions
-class regu_variable_node;
-struct val_descr;
 struct regu_variable_list_node;
 
-extern int fetch_peek_dbval (THREAD_ENTRY * thread_p, regu_variable_node * regu_var, val_descr * vd, OID * class_oid,
-			     OID * obj_oid, QFILE_TUPLE tpl, DB_VALUE ** peek_dbval);
+extern int fetch_peek_dbval_slow (THREAD_ENTRY * thread_p, regu_variable_node * regu_var, val_descr * vd,
+				  OID * class_oid, OID * obj_oid, QFILE_TUPLE tpl, DB_VALUE ** peek_dbval);
+
+/*
+ * fetch_peek_dbval () - returns a POINTER to an existing db_value
+ *   Inline fast-path for the dominant per-row cases: a regu_var previously confirmed simple
+ *   (REGU_VARIABLE_FAST_PEEK set by fetch_peek_dbval_slow () on the first fetch). Returns the value
+ *   pointer directly - no call frame, no type switch, no domain dereference:
+ *     TYPE_DBVAL     -> the embedded constant db_value;
+ *     TYPE_CONSTANT  -> the value-pointer slot, only when there is no linked subquery to execute;
+ *     TYPE_POS_VALUE -> the value-list slot at the fixed position (live slot; value changes per row);
+ *     TYPE_*ATTR_ID  -> the cached attribute value pointer (instance/shared/class; re-checked != NULL
+ *                       so a later cache reset is handled safely, same as the slow path).
+ *   Everything else (incl. the first fetch that sets the flag, collation/variable-domain, subqueries)
+ *   falls back to the full path.
+ */
+inline int
+fetch_peek_dbval (THREAD_ENTRY * thread_p, regu_variable_node * regu_var, val_descr * vd, OID * class_oid,
+		  OID * obj_oid, QFILE_TUPLE tpl, DB_VALUE ** peek_dbval)
+{
+  if (REGU_VARIABLE_IS_FLAGED (regu_var, REGU_VARIABLE_FAST_PEEK))
+    {
+      switch (regu_var->type)
+	{
+	case TYPE_DBVAL:
+	  *peek_dbval = &regu_var->value.dbval;
+	  return NO_ERROR;
+	case TYPE_CONSTANT:
+	  /* flag is set only when there is no linked subquery (regu_var->xasl == NULL) to execute, so this
+	   * is just the stable value-pointer slot maintained by the owner (e.g. a correlated column ref). */
+	  *peek_dbval = regu_var->value.dbvalptr;
+	  return NO_ERROR;
+	case TYPE_POS_VALUE:
+	  *peek_dbval = (DB_VALUE *) vd->dbval_ptr + regu_var->value.val_pos;
+	  return NO_ERROR;
+	case TYPE_ATTR_ID:
+	case TYPE_SHARED_ATTR_ID:
+	case TYPE_CLASS_ATTR_ID:
+	  if (regu_var->value.attr_descr.cache_dbvalp != NULL)
+	    {
+	      *peek_dbval = regu_var->value.attr_descr.cache_dbvalp;
+	      return NO_ERROR;
+	    }
+	  break;
+	default:
+	  break;
+	}
+    }
+  return fetch_peek_dbval_slow (thread_p, regu_var, vd, class_oid, obj_oid, tpl, peek_dbval);
+}
 extern int fetch_copy_dbval (THREAD_ENTRY * thread_p, regu_variable_node * regu_var, val_descr * vd, OID * class_oid,
 			     OID * obj_oid, QFILE_TUPLE tpl, DB_VALUE * dbval);
 extern int fetch_val_list (THREAD_ENTRY * thread_p, regu_variable_list_node * regu_list, val_descr * vd,

--- a/src/query/fetch.h
+++ b/src/query/fetch.h
@@ -86,6 +86,7 @@ fetch_peek_dbval (THREAD_ENTRY * thread_p, regu_variable_node * regu_var, val_de
     }
   return fetch_peek_dbval_slow (thread_p, regu_var, vd, class_oid, obj_oid, tpl, peek_dbval);
 }
+
 extern int fetch_copy_dbval (THREAD_ENTRY * thread_p, regu_variable_node * regu_var, val_descr * vd, OID * class_oid,
 			     OID * obj_oid, QFILE_TUPLE tpl, DB_VALUE * dbval);
 extern int fetch_val_list (THREAD_ENTRY * thread_p, regu_variable_list_node * regu_list, val_descr * vd,

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -1514,12 +1514,7 @@ qexec_clear_regu_var (THREAD_ENTRY * thread_p, XASL_NODE * xasl_p, REGU_VARIABLE
   /* clear run-time setting info */
   REGU_VARIABLE_CLEAR_FLAG (regu_var, REGU_VARIABLE_FETCH_ALL_CONST);
   REGU_VARIABLE_CLEAR_FLAG (regu_var, REGU_VARIABLE_FETCH_NOT_CONST);
-  /* FAST_PEEK is paired with the FETCH_*_CONST state above: fetch_peek_dbval_slow () sets it only after
-   * confirming those flags. Cleared XASL clones are pooled and reused (xcache_retire_clone ()), so leaving
-   * FAST_PEEK set while wiping the const flags would let the inline fetch_peek_dbval () serve the operand on
-   * the next execution without restoring FETCH_ALL_CONST. A parent TYPE_FUNC/arith would then re-run its
-   * one-time const test, see the operand as non-const, and re-evaluate an otherwise-constant function every
-   * row. Clear it here so the first fetch of the reused clone goes through the slow path and rebuilds both. */
+  /* pair with FETCH_*_CONST: clear so a reused (pooled) XASL clone rebuilds it via the slow path next time */
   REGU_VARIABLE_CLEAR_FLAG (regu_var, REGU_VARIABLE_FAST_PEEK);
 
   switch (regu_var->type)

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -1514,6 +1514,13 @@ qexec_clear_regu_var (THREAD_ENTRY * thread_p, XASL_NODE * xasl_p, REGU_VARIABLE
   /* clear run-time setting info */
   REGU_VARIABLE_CLEAR_FLAG (regu_var, REGU_VARIABLE_FETCH_ALL_CONST);
   REGU_VARIABLE_CLEAR_FLAG (regu_var, REGU_VARIABLE_FETCH_NOT_CONST);
+  /* FAST_PEEK is paired with the FETCH_*_CONST state above: fetch_peek_dbval_slow () sets it only after
+   * confirming those flags. Cleared XASL clones are pooled and reused (xcache_retire_clone ()), so leaving
+   * FAST_PEEK set while wiping the const flags would let the inline fetch_peek_dbval () serve the operand on
+   * the next execution without restoring FETCH_ALL_CONST. A parent TYPE_FUNC/arith would then re-run its
+   * one-time const test, see the operand as non-const, and re-evaluate an otherwise-constant function every
+   * row. Clear it here so the first fetch of the reused clone goes through the slow path and rebuilds both. */
+  REGU_VARIABLE_CLEAR_FLAG (regu_var, REGU_VARIABLE_FAST_PEEK);
 
   switch (regu_var->type)
     {

--- a/src/query/regu_var.hpp
+++ b/src/query/regu_var.hpp
@@ -169,6 +169,11 @@ const int REGU_VARIABLE_CLEAR_AT_CLONE_DECACHE = 0x100;	/* clears regu variable 
 const int REGU_VARIABLE_UPD_INS_LIST = 0x200;	/* for update or insert query */
 const int REGU_VARIABLE_STRICT_TYPE_CAST = 0x400;/* for update or insert query */
 const int REGU_VARIABLE_CORRELATED = 0x800; /* for correlated scalar subquery cache */
+const int REGU_VARIABLE_FAST_PEEK = 0x1000;	/* simple peek: a TYPE_ATTR_ID (cached) or TYPE_DBVAL regu_var with
+						 * domain resolved & non-VARIABLE, normal collation, no APPLY_COLLATION.
+						 * Set by fetch_peek_dbval_slow () after the first fetch so the
+						 * fetch_peek_dbval () inline wrapper can return the value pointer
+						 * directly (skips the type switch and the generic post-fetch checks). */
 
 class regu_variable_node
 {

--- a/src/query/regu_var.hpp
+++ b/src/query/regu_var.hpp
@@ -169,11 +169,7 @@ const int REGU_VARIABLE_CLEAR_AT_CLONE_DECACHE = 0x100;	/* clears regu variable 
 const int REGU_VARIABLE_UPD_INS_LIST = 0x200;	/* for update or insert query */
 const int REGU_VARIABLE_STRICT_TYPE_CAST = 0x400;/* for update or insert query */
 const int REGU_VARIABLE_CORRELATED = 0x800; /* for correlated scalar subquery cache */
-const int REGU_VARIABLE_FAST_PEEK = 0x1000;	/* simple peek: a TYPE_ATTR_ID (cached) or TYPE_DBVAL regu_var with
-						 * domain resolved & non-VARIABLE, normal collation, no APPLY_COLLATION.
-						 * Set by fetch_peek_dbval_slow () after the first fetch so the
-						 * fetch_peek_dbval () inline wrapper can return the value pointer
-						 * directly (skips the type switch and the generic post-fetch checks). */
+const int REGU_VARIABLE_FAST_PEEK = 0x1000;	/* inline fetch_peek_dbval () may return its value pointer directly */
 
 class regu_variable_node
 {


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26932>

### Purpose

`fetch_peek_dbval` (src/query/fetch.c)는 스캔/필터 hot path에서 **행마다, operand마다** 호출된다(대형 스캔에선 수천만~수억 회; 예: TPC-H Q12). 약 600줄짜리 switch 디스패치 함수인데, 대다수 케이스에서 실제 하는 일은 **안정적인 값 포인터 반환**으로 trivial하지만 매 호출이 함수 프레임 비용을 전부 지불했다:

- 인라인 불가 함수의 prologue (callee-saved 스필 + 큰 스택프레임)
- indirect 점프테이블 `switch (regu_var->type)` 디스패치 (분기예측 실패 잦음)
- 모든 타입이 공통으로 거치는 tail (도메인/collation 검사)

#### 성능 (TPC-H Q12, SF10, FIXED=N, 병렬 힙 스캔)

동반 개선(CBRD-26898 #7267 / CBRD-26908 #7274 / CBRD-26924 #7281)이 적용된 베이스 위에서 본 PR만 추가해 비교했다. wall은 ABBA 인터리브로 측정했고 시스템 부하와 무관함을 확인했다(고부하 블록에서도 동일 결과).

| 지표 | 변경 전 (동반 개선만) | 변경 후 (+본 PR) |
|---|---|---|
| `fetch_peek_dbval` self-time | **3.83%** | **0.04%** |
| wall (Q12 FIXED=N, median) | **~9.45s** | **~8.91s (≈ 5.7%↓)** |

동반 개선이 COPY 모드의 per-row home-page 재-fix 오버헤드를 제거하면 per-row fetch 디스패치가 self-time의 약 3.8%를 차지하게 되고, 본 PR이 이를 제거해 wall을 약 5.7% 추가 단축한다. (재-fix가 지배하는 순수 develop 단독 상태에선 fetch 비중이 ~1.2%로 작아 본 PR 단독 효과가 가려진다 — 동반 개선과 **상보적**이다.)

### Implementation

`fetch_peek_dbval`을 **얇은 inline wrapper(fetch.h)** + **full slow path(`fetch_peek_dbval_slow`, 기존 본문)**로 분리한다.

- 신규 regu 플래그 `REGU_VARIABLE_FAST_PEEK` (src/query/regu_var.hpp). slow path가 **첫 fetch에서** 해당 regu_var가 단순·캐시 가능(도메인 resolved & non-VARIABLE, normal collation, `REGU_VARIABLE_APPLY_COLLATION` 없음)임을 확인한 뒤 세팅한다.
- inline `fetch_peek_dbval()`(fetch.h, regu_var.hpp + query_executor.h include)는 플래그가 선 regu_var에 대해 **호출/switch/도메인 deref 없이** 값 포인터를 바로 반환한다:
  - `TYPE_ATTR_ID` / `TYPE_SHARED_ATTR_ID` / `TYPE_CLASS_ATTR_ID` → 캐시된 attr 값 포인터 (`cache_dbvalp != NULL` 재확인 → 캐시 reset 안전)
  - `TYPE_DBVAL` → 내장 리터럴 db_value
  - `TYPE_POS_VALUE` → value-list 슬롯 `vd->dbval_ptr[val_pos]` (live 슬롯; 값은 매행 변하고 포인터는 안정)
  - `TYPE_CONSTANT` 는 **`regu_var->xasl == NULL`(실행할 서브쿼리 없음)일 때만** → 안정 값-포인터 슬롯
- 그 외(첫 fetch, 그리고 본질적 per-row 타입: `TYPE_OID`/`TYPE_POSITION`/산술/`TYPE_SP`/서브쿼리 있는 `TYPE_CONSTANT`/`TYPE_REGUVAL_LIST`/비상수 `TYPE_FUNC` 등)는 `fetch_peek_dbval_slow`로 폴백한다.

**안전성**: 플래그는 slow path가 도메인 resolve·적격성 검증을 끝낸 뒤에만 세팅되므로, inline은 per-row 도메인 resolve나 collation 적용이 필요 없다. 반환 포인터는 slow path가 주던 것과 동일한 안정 슬롯이며, 매행 변하는 값(POS_VALUE/상관 CONSTANT)은 live 포인터로 읽는다.

### Remarks

- 외부 동작/문법/결과/플랜덤프 변화 없음. 질의 결과·값 의미 동일.
- 검토: `fetch_peek_dbval_slow`의 전 switch 케이스를 검토해 안정/캐시 가능한 것만 fast-path에 포함. `TYPE_OID`(매행 obj_oid)/`TYPE_POSITION`(튜플 읽기)/산술/SP/서브쿼리는 본질적 per-row라 제외. `TYPE_ORDERBY_NUM`·상수 `TYPE_FUNC`는 안전하나 희귀해 hot 인라인 bloat 회피로 보류.
- 성능은 perf self-time + wall(ABBA 인터리브, load 무관) 둘 다로 검증. 단독 develop이 아니라 동반 버퍼풀 개선 위에서 측정해야 fetch 비중이 드러난다.
- 관련: CBRD-26898(#7267), CBRD-26908(#7274), CBRD-26924(#7281) — 동일 Q12 FIXED=N hot path 개선 시리즈.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
