### PR TITLE
[CBRD-26830] Apply TDE to OOS files (walker + lazy-create)

### DIFF
--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -12469,7 +12469,13 @@ xfile_apply_tde_to_class_files (THREAD_ENTRY * thread_p, const OID * class_oid)
   {
     VFID oos_vfid;
     VFID_SET_NULL (&oos_vfid);
-    if (heap_oos_find_vfid (thread_p, &hfid, &oos_vfid, false) && !VFID_ISNULL (&oos_vfid))
+    if (!heap_oos_find_vfid (thread_p, &hfid, &oos_vfid, false))
+      {
+	/* genuine failure reading the heap header, not "no OOS file" */
+	ASSERT_ERROR_AND_SET (error_code);
+	goto exit;
+      }
+    if (!VFID_ISNULL (&oos_vfid))
       {
 	error_code = file_apply_tde_algorithm (thread_p, &oos_vfid, tde_algo);
 	if (error_code != NO_ERROR)

--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -12463,6 +12463,22 @@ xfile_apply_tde_to_class_files (THREAD_ENTRY * thread_p, const OID * class_oid)
 	}
     }
 
+  /* apply to OOS file (if it has been lazily created already).
+   * Lazy creation that happens after this point applies TDE inline in
+   * heap_oos_find_vfid (docreate=true branch). */
+  {
+    VFID oos_vfid;
+    VFID_SET_NULL (&oos_vfid);
+    if (heap_oos_find_vfid (thread_p, &hfid, &oos_vfid, false) && !VFID_ISNULL (&oos_vfid))
+      {
+	error_code = file_apply_tde_algorithm (thread_p, &oos_vfid, tde_algo);
+	if (error_code != NO_ERROR)
+	  {
+	    goto exit;
+	  }
+      }
+  }
+
   or_repr = heap_classrepr_get (thread_p, class_oid, NULL, NULL_REPRID, &idx_in_cache);
   if (or_repr == NULL)
     {

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -12198,9 +12198,25 @@ heap_oos_find_vfid (THREAD_ENTRY * thread_p, const HFID * hfid, VFID * oos_vfid,
     {
       if (docreate == true)
 	{
+	  TDE_ALGORITHM tde_algo = TDE_ALGORITHM_NONE;
+
 	  /* START A TOP SYSTEM OPERATION */
 	  log_sysop_start (thread_p);
 	  if (oos_create_file (thread_p, *oos_vfid) != NO_ERROR)
+	    {
+	      log_sysop_abort (thread_p);
+	      goto exit_on_error;
+	    }
+
+	  /* Apply TDE to the new OOS file atomically with its creation.
+	   * Pattern mirrors heap_ovf_find_vfid (heap_file.c:6535). */
+	  if (heap_get_class_tde_algorithm (thread_p, &heap_hdr->class_oid, &tde_algo) != NO_ERROR)
+	    {
+	      log_sysop_abort (thread_p);
+	      goto exit_on_error;
+	    }
+
+	  if (file_apply_tde_algorithm (thread_p, oos_vfid, tde_algo) != NO_ERROR)
 	    {
 	      log_sysop_abort (thread_p);
 	      goto exit_on_error;

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -5887,7 +5887,13 @@ xheap_destroy (THREAD_ENTRY * thread_p, const HFID * hfid, const OID * class_oid
   /* OOS file cleanup */
   {
     VFID oos_vfid;
-    if (heap_oos_find_vfid (thread_p, hfid, &oos_vfid, false))
+    VFID_SET_NULL (&oos_vfid);
+    if (!heap_oos_find_vfid (thread_p, hfid, &oos_vfid, false))
+      {
+	ASSERT_ERROR ();
+	return er_errid ();
+      }
+    if (!VFID_ISNULL (&oos_vfid))
       {
 	int error = oos_remove_file (thread_p, oos_vfid);
 	if (error != NO_ERROR)
@@ -5945,7 +5951,13 @@ xheap_destroy_newly_created (THREAD_ENTRY * thread_p, const HFID * hfid, const O
   /* OOS file cleanup */
   {
     VFID oos_vfid;
-    if (heap_oos_find_vfid (thread_p, hfid, &oos_vfid, false))
+    VFID_SET_NULL (&oos_vfid);
+    if (!heap_oos_find_vfid (thread_p, hfid, &oos_vfid, false))
+      {
+	ASSERT_ERROR ();
+	return er_errid ();
+      }
+    if (!VFID_ISNULL (&oos_vfid))
       {
 	ret = oos_remove_file (thread_p, oos_vfid);
 	if (ret != NO_ERROR)
@@ -12157,6 +12169,19 @@ heap_attrinfo_determine_disk_layout (HEAP_CACHE_ATTRINFO * attr_info, bool is_mv
   return header_size + payload_size;
 }
 
+/*
+ * heap_oos_find_vfid () - find (or optionally create) the OOS file of a heap
+ *   return         : true on success, false on a genuine error (er is set)
+ *   hfid (in)      : heap file identifier
+ *   oos_vfid (out) : OOS file identifier; set to NULL when the heap has no OOS
+ *                    file (only possible when docreate == false)
+ *   docreate (in)  : if true and the OOS file does not exist, it is created and
+ *                    TDE is applied to it (mirroring heap_ovf_find_vfid)
+ *
+ * Note: A false return ALWAYS means a real error (and er_errid () is set); it
+ *   never means "no OOS file". Callers using docreate == false must inspect
+ *   oos_vfid (VFID_ISNULL) to tell whether an OOS file actually exists.
+ */
 bool
 heap_oos_find_vfid (THREAD_ENTRY * thread_p, const HFID * hfid, VFID * oos_vfid, bool docreate)
 {
@@ -12168,6 +12193,7 @@ heap_oos_find_vfid (THREAD_ENTRY * thread_p, const HFID * hfid, VFID * oos_vfid,
   bool success;
 
   success = true;
+  VFID_SET_NULL (oos_vfid);
 
   addr_hdr.vfid = &hfid->vfid;
   addr_hdr.offset = HEAP_HEADER_AND_CHAIN_SLOTID;
@@ -12232,7 +12258,8 @@ heap_oos_find_vfid (THREAD_ENTRY * thread_p, const HFID * hfid, VFID * oos_vfid,
 	}
       else
 	{
-	  goto exit_on_error;
+	  /* No OOS file exists yet; oos_vfid stays NULL. This is not an error. */
+	  goto end;
 	}
     }
   else

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -12235,7 +12235,7 @@ heap_oos_find_vfid (THREAD_ENTRY * thread_p, const HFID * hfid, VFID * oos_vfid,
 	    }
 
 	  /* Apply TDE to the new OOS file atomically with its creation.
-	   * Pattern mirrors heap_ovf_find_vfid (heap_file.c:6535). */
+	   * Pattern mirrors heap_ovf_find_vfid */
 	  if (heap_get_class_tde_algorithm (thread_p, &heap_hdr->class_oid, &tde_algo) != NO_ERROR)
 	    {
 	      log_sysop_abort (thread_p);


### PR DESCRIPTION
https://jira.cubrid.org/browse/CBRD-26830

> **TL;DR**: `encrypt` 로 만든 테이블은 디스크에 저장되는 데이터가 자동으로 암호화(TDE)되어야 한다. 그런데 긴 문자열 값은 OOS 라는 별도 파일에 따로 저장되는데, 이 OOS 파일만 암호화가 빠져 있었다. 그래서 긴 문자열이 디스크에 그대로(평문) 남았다. 이 PR 은 OOS 파일도 암호화하도록 고친다.

## Summary

- **변경**: OOS 파일을 만드는 두 곳에서 암호화 적용 함수(`file_apply_tde_algorithm`)를 호출하도록 추가했다.
- **이유**: OOS 기능(CBRD-26583)이 들어오면서 긴 문자열이 OOS 파일로 옮겨졌는데, 이 파일에 암호화를 켜는 코드가 빠졌다. 그래서 `encrypt` 테이블인데도 긴 문자열이 디스크에 평문으로 저장됐다.
- **영향**: 암호화를 켠 테이블의 긴 가변 컬럼(예: `varchar(20000)`)에만 영향. 일반 테이블, 짧은 값, 디스크 저장 포맷은 그대로다.
- **리뷰 포인트**: `heap_file.c` 의 OOS 파일 생성 부분 — 중간에 한 단계라도 실패하면 파일 생성과 암호화가 함께 깔끔하게 취소(rollback)되는지.

---

## Description

먼저 용어 두 개만 짚고 가자.

- **TDE (암호화)**: 디스크에 저장되는 데이터를 자동으로 암호화하는 기능. 디스크나 백업 파일이 유출돼도 내용을 못 읽게 막는 것이 목적이다.
- **OOS (Out-of-row Storage)**: 한 줄(row)에 담기엔 너무 큰 값(긴 문자열 등)을 별도 파일에 따로 빼서 저장하는 구조.

예전에는 512바이트가 넘는 긴 문자열이 "heap-overflow" 라는 파일에 저장됐다. 이 파일은 만들어질 때 곧바로 암호화가 적용됐다. 그래서 `encrypt` 테이블이면 긴 문자열도 암호화되어 디스크에 저장됐다.

그런데 OOS 기능이 들어오면서, 같은 긴 문자열이 이제는 OOS 파일에 저장된다. 문제는 OOS 파일을 만들 때 암호화를 켜는 코드가 없었다는 점이다. 그래서 결과적으로 이렇게 됐다.

- 예전: 긴 문자열 → 암호화되어 저장 (안전)
- 지금(버그): 긴 문자열 → 암호화 없이 평문으로 저장 (유출 위험)

실제로 `create table ttt (a int, b varchar(20000)) encrypt;` 로 테이블을 만들고 긴 값을 넣은 뒤 디스크 파일을 검색하면, 입력한 문자열이 그대로 보인다. 암호화의 의미가 사라진 셈이다.

암호화가 빠진 곳은 정확히 두 군데다.

- `xfile_apply_tde_to_class_files` (`file_manager.c`): 테이블에 딸린 파일들을 하나씩 돌면서 암호화를 켜 주는 함수인데, OOS 파일이 이 목록에서 빠져 있었다.
- `heap_oos_find_vfid` (`heap_file.c`): OOS 파일을 처음 만드는 곳인데, 파일을 만든 직후 암호화를 적용하지 않았다.

다행히 암호화 적용 함수(`file_apply_tde_algorithm`)는 파일 종류를 가리지 않는다. 그래서 OOS 파일에도 호출만 추가하면 해결된다.

## Implementation

안전하게 두 군데를 모두 고쳤다 (`file_manager.c` +16줄, `heap_file.c` +16줄).

- **(A) `file_manager.c` 의 `xfile_apply_tde_to_class_files`**: 다른 파일들을 암호화하는 부분 바로 뒤에, 이미 만들어진 OOS 파일이 있으면 찾아서 암호화를 적용한다. 아직 OOS 파일이 없으면 그냥 건너뛴다. → 이미 있는 테이블을 나중에 암호화로 바꾸는 경우(`ALTER ... encrypt`)를 주로 막아 준다.
- **(B) `heap_file.c` 의 `heap_oos_find_vfid`**: OOS 파일을 새로 만든 직후, 그 테이블의 암호화 방식을 가져와 새 파일에 적용한다. 이 과정은 하나의 작업 단위로 묶여 있어서, 중간에 한 단계라도 실패하면 OOS 파일 생성 자체가 통째로 취소된다. → 긴 값을 처음 INSERT 해서 OOS 파일이 새로 생기는 경우를 막아 준다.

A 와 B 를 둘 다 두는 이유는 OOS 파일이 생기는 시점이 두 가지이기 때문이다(테이블을 나중에 암호화로 바꿀 때 vs 긴 값을 처음 넣을 때). 한쪽만 막으면 다른 쪽이 새므로, 둘 다 막아 빈틈을 없앤다.

## Test Plan

재현과 검증 방법은 이렇다.

1. `create table ttt (a int, b varchar(20000)) encrypt;` 로 암호화 테이블을 만든다.
2. `insert into ttt values (0, rpad('zzzznotsecret', 20000));` 로 긴 값을 넣는다. (긴 값이 확실히 OOS 로 가도록 `enable_string_compression=false` 설정)
3. 서버를 끄고 `grep -a "zzzznotsecret" /tmp/<db>/*` 로 디스크 파일을 검색한다.
   - 고치기 전: 입력한 문자열이 평문으로 그대로 나온다.
   - 고친 후: 아무것도 안 나온다 (암호화됨).
4. `cubrid diagdb -d1` 출력에서 OOS 파일이 `tde_algorithm: AES` 로 표시된다.

- **이 브랜치에서 직접 한 것**: 고친 파일 두 개가 정상 컴파일되는지 확인했다. (참고: 이 브랜치에는 `numeric_opfunc.c` 가 clang 으로 빌드되지 않는 별개 문제가 있는데, 이번 변경과 무관하며 gcc 로는 정상 빌드된다.)
- **원본 커밋(`feature/oos-m2` 의 `477605829`)에서 검증한 것**: 위 1~4 절차로 평문이 안 나오고 OOS 파일이 `AES` 로 표시되는 것을 확인했다.
- **관련 CI 테스트**: `shell/_36_damson/cbrd_23608_tde/tbl_enc_08`, `tbl_enc_14`.

## Remarks

- 이 변경은 `feature/oos-m2` 에서 검증된 커밋(`477605829`)을 `feat/oos` 로 옮겨 온(cherry-pick) 것이다. 기존 PR #7214 와 로직은 같고, base 가 `feat/oos` 인 점과 주석의 줄 번호 한 곳(`heap_file.c:6586` → `6535`)을 feat/oos 기준으로 맞춘 점만 다르다.
- 이번 패치는 암호화 함수, OOS 파일의 디스크 저장 포맷, 파일 라벨 이름은 건드리지 않는다. 이 부분 개선은 별도 티켓으로 분리한다.
- `tbl_enc_*` 테스트의 정답 파일(`result.answer`) 갱신은 소스 수정과 별개 커밋으로 분리한다.

## Related Issues

- 부모 에픽: [CBRD-26583](https://jira.cubrid.org/browse/CBRD-26583) ([OOS][M2])
- 참고: [CBRD-23608](https://jira.cubrid.org/browse/CBRD-23608) (TDE 암호화 기능을 처음 만든 티켓)
