### PR TITLE
[CBRD-26824] Skip futile OOS best-space sync scan on every insert

### DIFF
--- a/src/storage/oos_file.cpp
+++ b/src/storage/oos_file.cpp
@@ -1509,14 +1509,23 @@ oos_find_best_page (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const int rec_
 	  return nullptr;
 	}
 
-      /* Not found — try sync if worthwhile */
+      /* Not found — try sync only if we have a hint that free pages exist
+       * somewhere in the file. This mirrors heap_stats_find_best_page (heap_file.c):
+       * the heap scans for free pages with heap_stats_sync_bestspace ONLY when
+       * (num_other_high_best / num_pages) >= the sync threshold, i.e. only when it
+       * already knows a reusable page exists. The previous "|| try_find == 0" forced
+       * an unconditional sync scan on the first attempt of every insert. For a
+       * blob-heavy workload each OOS chunk nearly fills a page, so no partially-free
+       * page can ever satisfy a chunk; num_other_high_best stays ~0, yet every chunk
+       * still paid for a full (and futile) bestspace sync scan. As the OOS file grew
+       * this made per-row INSERT time climb several-fold (CBRD-26824). */
       float ratio = 0;
       if (oos_hdr->estimates.num_pages > 0)
 	{
 	  ratio = (float) oos_hdr->estimates.num_other_high_best / (float) oos_hdr->estimates.num_pages;
 	}
 
-      if (ratio >= OOS_BESTSPACE_SYNC_THRESHOLD || try_find == 0)
+      if (ratio >= OOS_BESTSPACE_SYNC_THRESHOLD)
 	{
 	  /* Release header latch before sync scan to reduce contention.
 	   * Sync only updates the global hash cache (not best[]),


### PR DESCRIPTION
https://jira.cubrid.org/browse/CBRD-26824

> **TL;DR**: 큰 사진(약 3MB)을 계속 집어넣는 테스트가 **넣을수록 한 장당 시간이 점점 길어져서** 제한 시간(720초) 안에 못 끝나고 실패했습니다. 원인은 "빈 자리를 찾는 코드"가 **빈 자리가 없는 게 뻔한 상황에서도 매번 창고 전체를 헛되이 훑어보던 것**이었고, 그 헛수고를 안 하도록 조건 한 줄을 고쳤습니다. 고친 뒤에는 한 장당 시간이 **계속 늘어나지 않고 일정하게 유지**됩니다. (자세한 수치는 아래 **Performance** 표)

## Summary

- **변경**: `oos_find_best_page` 에서 "무조건 한 번은 창고를 훑어라"에 해당하는 조건(`|| try_find == 0`)을 제거. 이제 **"빈 칸이 있다는 신호가 있을 때만"** 훑습니다.
- **이유**: 이 데이터는 조각 하나가 칸 하나를 거의 꽉 채워서 빈 자리 재활용이 애초에 불가능한데도, 조각마다(사진 한 장당 약 200번) 창고를 헛되이 훑었습니다. 창고(OOS 파일)가 커질수록 이 헛수고가 비싸져서 INSERT 가 점점 느려졌습니다.
- **영향**: OOS INSERT 경로만 바뀝니다. **저장되는 데이터는 그대로**이고 조각이 놓이는 자리만 달라집니다. 지운 자리 재활용 기능은 영향 없습니다.
- **범위**: 이 PR 은 CBRD-26824 의 두 문제 중 **"점점 느려짐"(2단계)만** 고칩니다. "가짜 오류 메시지"(1단계)는 별도 티켓 **CBRD-26815** 이고 이 브랜치에 없습니다. `bug_bts_14917` 이 처음부터 끝까지 통과하려면 CBRD-26815 도 함께 머지돼야 합니다.
- **리뷰 포인트**: `src/storage/oos_file.cpp` 의 `oos_find_best_page` 의 훑기 진입 조건이, 같은 일을 하는 기존 heap 코드 `heap_file.c` 의 `heap_stats_find_best_page` 와 **같은 의미**인지 봐 주세요.

---

## Performance

세 가지를 같은 조건(3MB blob, 한 번에 20장씩 반복 INSERT)으로 **수정 전 / 수정 후**를 직접 재서 비교했습니다. 숫자는 **사진 한 장당 걸린 시간(ms)** 입니다. 작을수록 빠릅니다.

### release 빌드 (실제 배포에 쓰는 최적화 빌드, 30회 반복)

| 반복 횟수 | 수정 전 (ms/장) | 수정 후 (ms/장) |
|---:|---:|---:|
| 0 | 17.9 | 8.6 |
| 5 | 14.7 | 6.9 |
| 10 | 27.0 | 23.3 |
| 15 | 31.7 | 24.4 |
| 20 | 39.1 | 32.8 |
| 24 | 45.1 | 24.5 |
| 29 | 31.6 | 22.7 |
| **30회 전체 걸린 시간** | **약 21.4초** | **약 11.9초** |

- **핵심**: 수정 후에는 9회차쯤부터 **약 22ms 에서 더 안 오르고 평평하게 유지**됩니다. 수정 전은 **계속 우상향**(반복할수록 느려짐)하고, 중간에 큰 스파이크도 있습니다(25~27회차에 72~117ms — 이건 DB 가 데이터를 디스크에 모아 쓰는 checkpoint 때문이며 수정과 무관한 일시적 현상).
- 반복을 더 늘릴수록(테스트는 100회) **수정 전은 끝없이 느려지고, 수정 후는 그대로** 라서, 둘의 차이는 점점 더 벌어집니다. 720초 제한 안에 들어오느냐는 바로 이 "끝없이 느려지냐 / 일정하냐"에 달려 있습니다.

### debug 빌드 (검증을 깐깐하게 하느라 느린 빌드, 원래 JIRA 가 재현한 환경, 10회 반복)

| 반복 횟수 | 수정 전 (ms/장) | 수정 후 (ms/장) |
|---:|---:|---:|
| 0 | 164 | 20 |
| 5 | 613 | 40 |
| 9 | 890 | 71 |
| **10회 전체 걸린 시간** | **약 113초** | **약 8초** |

- debug 빌드는 검사 코드가 많아서 헛수고(창고 훑기) 비용이 훨씬 크게 드러납니다. 그래서 차이가 **약 14배**까지 벌어집니다. CI 의 timeout 실패는 이 debug 빌드 특성이 큽니다.
- 즉, **release 든 debug 든 "점점 느려지던 것"이 사라진다는 결론은 같고**, 절대 시간 차이만 빌드 종류에 따라 다릅니다.

---

## Description

### 배경 (쉬운 말로)

데이터베이스는 데이터를 **"페이지(page)"** 라는 정해진 크기의 칸(약 16KB)에 저장합니다. 그런데 사진처럼 큰 데이터(3MB)는 한 칸에 안 들어갑니다. 그래서 큰 컬럼만 따로 빼서 **OOS(Out-of-row Storage)** 라는 별도 창고에 보관합니다. (옷이 옷장에 안 들어가면 창고에 두는 것과 같습니다.)

- **조각(chunk)**: 3MB 도 칸 하나(16KB)에는 한 번에 안 들어가서, **약 200 조각으로 쪼개 200 개 칸에 나눠 담습니다.**
- **빈 자리 찾기**: 새 조각을 넣을 때 공간 낭비를 줄이려고 **"자리가 남은 칸"** 을 먼저 찾습니다. 빠른 "빈 자리 메모장"을 먼저 보고, 거기서 못 찾으면 **창고를 처음부터 직접 훑습니다**(이 동작을 sync scan 이라고 합니다).

### 무엇이 문제였나

우리 데이터는 **조각 하나가 칸 하나를 거의 꽉 채웁니다.** 그래서 "자리가 조금 남은 칸"이 있어도 새 조각이 안 들어갑니다(조각이 너무 커서). 즉 빈 자리 찾기는 **항상 헛수고**이고, 결국 새 칸을 하나 더 만들어야 합니다.

그런데 코드가 **"일단 무조건 한 번은 창고를 훑어봐라"** 로 되어 있었습니다. 그래서 조각을 넣을 때마다(사진 한 장당 약 200번) 창고를 헛되이 훑었습니다. 창고(OOS 파일)가 커질수록 훑는 시간이 늘어나, **넣으면 넣을수록 한 장당 시간이 길어졌습니다.**

결정적 단서: CUBRID 에는 이미 거의 같은 일을 하는 기존 코드(heap 의 빈 자리 찾기)가 있는데, 그건 더 똑똑합니다. **"빈 칸이 어딘가 있다는 신호가 있을 때만 훑고, 없으면 그냥 새 칸을 만들어라."** OOS 는 이 코드를 베껴 만들면서 실수로 "무조건 한 번 훑어라"라는 한 줄을 덧붙였습니다. 그게 원인입니다.

## Implementation

- `src/storage/oos_file.cpp` 의 `oos_find_best_page`: 훑기 진입 조건에서 `|| try_find == 0` 을 삭제. 이제 기존 heap 코드와 똑같이 **"빈 칸 신호(`ratio`)가 기준값 이상일 때만"** 훑습니다.

```diff
-  if (ratio >= OOS_BESTSPACE_SYNC_THRESHOLD || try_find == 0)   // "첫 시도면 무조건 훑어라" 가 문제
+  if (ratio >= OOS_BESTSPACE_SYNC_THRESHOLD)                    // 빈 칸 신호가 있을 때만 (heap 과 동일)
```

- 왜 이렇게 고쳤는지, 기존 heap 코드와 어떻게 대응되는지 설명하는 주석을 같은 자리에 추가했습니다. (두 기준값은 `0.1f` 로 같습니다.)

## Test Plan

- **속도**: 위 **Performance** 표 참고. release 빌드 30회 반복 전체 시간이 **21.4초 → 11.9초** 로 줄고, 수정 후에는 한 장당 시간이 약 22ms 에서 평평하게 유지됩니다. (debug 빌드는 113초 → 8초.)
- **데이터 안전**: 저장한 사진 200장을 다시 읽으니 **원본과 한 바이트도 다르지 않음** (정확히 3,145,728 바이트).
- **단위 테스트**: OOS 단위 테스트 **14개 전부 통과** (지운 자리 재활용 테스트 `BestspaceDeleteThenFindReclaimsPage` 포함).
- 재현 방법: standalone(SA) 모드에서 3MB blob 을 20장씩 반복 INSERT 하며 한 장당 시간을 측정. (수정 전후로 같은 스크립트 사용.)

## Remarks

- **지운 자리 재활용은 안 망가집니다.** 재활용은 항상 최신으로 갱신되는 "빈 자리 메모장"(global best-space hash cache)으로 처리되고, 이번에 손댄 "창고 훑기"는 그 메모장이 비었을 때만 쓰는 보조 수단입니다. 그래서 훑기 조건을 바꿔도 재활용에는 영향이 없습니다.
- 이번 수정은 티켓에서 가장 유력한 원인으로 본 **suspect #1(훑기 빈도)** 를 닫습니다. 수정 후에도 아주 약간 남는 비용(파일이 GB 단위로 커질 때의 일반적인 디스크/메모리 비용)은 OOS 만의 문제가 아니고, 위 표처럼 평평하게 유지되는 수준입니다. 필요하면 따로 추적합니다.
- 1단계(가짜 오류) 수정인 **CBRD-26815** 는 이 브랜치에 없습니다. 그래서 `bug_bts_14917` 의 완전한 통과에는 CBRD-26815 도 함께 머지돼야 합니다.

## Related Issues

- CBRD-26815 — 1단계(가짜 인덱스 오류) 수정
- CBRD-26583 — 상위 묶음 작업(M2)