### PR TITLE
[CBRD-26740] fix memory leak in method scanner by clearing vectors with swap

### DIFF
--- a/src/method/method_scan.cpp
+++ b/src/method/method_scan.cpp
@@ -115,6 +115,12 @@ namespace cubscan
 	  rctx->pop_stack (m_thread_p, m_method_group);
 
 	  m_method_group = nullptr; // will be destroyed by cubmethod::runtime_context
+
+	  std::vector<TP_DOMAIN *>().swap (m_arg_dom_vector);
+	  std::vector<DB_VALUE>().swap (m_arg_vector);
+	  std::vector<bool>().swap (m_arg_use_vector);
+
+	  m_list_id = nullptr;
 	}
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26740

* Applied the swap-to-empty idiom in scanner::clear to ensure member vectors release their underlying memory capacity, preventing memory bloat in static scanner instances.
