### PR TITLE
[CBRD-26895] Add missing error check for do_cache_empty_histogram in do_create_entity

### DIFF
--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -10061,6 +10061,13 @@ do_create_entity (PARSER_CONTEXT * parser, PT_NODE * node)
 	    }
 	}
       error = do_cache_empty_histogram (class_obj);
+      if (error != NO_ERROR)
+	{
+	  /* histogram cache warm-up failed (e.g. _db_histogram missing, lock abort);
+	   * fail the statement cleanly instead of falling through to the
+	   * assert (error == NO_ERROR) below (CBRD-26895). */
+	  goto error_exit;
+	}
       break;
 
     default:


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26895>

- Regression Issue of (CBRD-26202)

### Purpose

`do_create_entity()`에서 `do_cache_empty_histogram()`을 호출하면서 **원래 했어야 할 반환 에러 검사를 누락**했습니다. (CBRD-26202에서 함수는 에러를 리턴하도록 작성되었으나, 호출부에서 검사하지 않음)

```c
error = do_cache_empty_histogram (class_obj);
break;   /* <- error 검사 없이 그대로 진행 */
```

검사가 누락되어, 워밍업이 실패하면(`error != NO_ERROR`) 그 값이 그대로 남은 채 아래 `do_flush_class_mop` 블록의 `assert (error == NO_ERROR)`에 도달하여 client가 core dump 됩니다.

`do_cache_empty_histogram()`이 리턴할 수 있는 에러:
- `ER_BO_MISSING_OR_INVALID_CATALOG (-909)` — `_db_histogram` 카탈로그 부재 시 (`db_get_histogram` → `sm_find_class(CT_HISTOGRAM_NAME) == NULL`). **보고된 크래시 케이스.**
- `au_fetch_class()`의 lock/abort(`ER_LK_UNILATERALLY_ABORTED` 등)·권한·fetch 에러
- `ER_OUT_OF_VIRTUAL_MEMORY` (ws alloc)

(정상 "histogram row 없음"은 `db_find_multi_unique()`가 `er_clear()` 하므로 에러가 아님)

#### Call Stack (reported)

```
#3  __assert_fail ()
#4  do_create_entity (...) at src/query/execute_schema.c:10087   error = -909
#5  do_check_internal_statements ()
#6  do_execute_statement ()
...
CREATE TABLE tbl2(i int, s int auto_increment)
PARTITION BY RANGE (i) (...);
```

### Implementation

`do_cache_empty_histogram()` 호출 직후에 **누락되어 있던 에러 검사를 추가**합니다. 실패 시 `assert`로 죽지 않고 `goto error_exit`로 statement를 정상 종료(클린 에러 반환)합니다.

```c
error = do_cache_empty_histogram (class_obj);
if (error != NO_ERROR)
  {
    goto error_exit;
  }
break;
```

### Remarks

- `src/query/execute_schema.c` 클린 컴파일 (goto-crosses-init 경고 없음; 동일 함수의 기존 `goto error_exit` 패턴과 일치)
