### PR TITLE
[CBRD-26740] Fix libcubrid.pdb not being packaged on Windows build

### DIFF
--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -607,9 +607,9 @@ install(FILES
   )
 # install pdb files for debugging on windows
 if(WIN32)
-  install(DIRECTORY
-    ${CMAKE_CURRENT_BINARY_DIR}/\${CMAKE_INSTALL_CONFIG_NAME}/
+  install(FILES
+    ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/\${CMAKE_INSTALL_CONFIG_NAME}/libcubrid.pdb
     DESTINATION ${CUBRID_BINDIR} COMPONENT Debuginfo
-    FILES_MATCHING PATTERN "*.pdb"
+    OPTIONAL
     )
 endif(WIN32)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26740>

> ⚠️ **이 PR은 버그 확인(디버깅)을 위한 커밋입니다.** libcubrid.pdb 심볼이 포함된 빌드 결과물로 문제를 분석하기 위한 것이며, **release 시에는 반드시 이 커밋을 revert한 뒤 빌드된 결과물을 전달해야 합니다.**

### Purpose

Windows 빌드(`release/11.2-old`, Jenkins `Windows Release` 스테이지 → `win/build.bat` → CMake `RelWithDebInfo`)에서 `libcubrid.pdb`가 생성은 되지만 최종 패키지(`.zip`/`.msi`)에 포함되지 않습니다.

`cubrid/CMakeLists.txt`의 PDB install 규칙이 `${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_CONFIG_NAME}/`(즉 `build/cubrid/<config>/`)에서 파일을 수집했습니다. 이 경로는 타겟 산출물이 거기에 생성되던 시절에는 올바랐으나, 이후 `CMAKE_RUNTIME_OUTPUT_DIRECTORY`가 `${CMAKE_BINARY_DIR}/bin`으로 변경되면서(CBRD-21611, #864) `libcubrid.dll`/`libcubrid.pdb`는 `build/bin/<config>/`에 생성됩니다. 그 결과 install 규칙이 어떤 파일과도 매칭되지 않게 되었고, `libcubrid.pdb`가 Windows 패키지에서 조용히 누락되었습니다.

본 커밋은 이 PDB 심볼을 패키지에 포함시켜 버그를 분석하기 위한 것입니다.

### Implementation

install 규칙이 실제 출력 경로(`${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/<config>/libcubrid.pdb`)를 가리키도록 변경했습니다. `${CMAKE_INSTALL_CONFIG_NAME}`은 이스케이프하여 install 시점에 해석되도록 두었으며, 기존 `install(DIRECTORY)` 규칙과 동일한 관용구입니다.

```cmake
if(WIN32)
  install(FILES
    ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/\${CMAKE_INSTALL_CONFIG_NAME}/libcubrid.pdb
    DESTINATION ${CUBRID_BINDIR} COMPONENT Debuginfo
    OPTIONAL
    )
endif(WIN32)
```

이 브랜치의 최상위 `CMakeLists.txt`는 `cmake_minimum_required(VERSION 2.8)`을 선언하므로, CMake 3.1+가 필요한 `$<TARGET_PDB_FILE:...>`나 3.0+가 필요한 install 인자 generator expression은 사용하지 않았습니다. generator expression은 configure/generate 단계에서 파싱되어 `OPTIONAL`로도 회피할 수 없기 때문입니다. 본 수정은 선언된 최소 CMake 버전과 호환됩니다.

### Remarks

- **이 커밋은 버그 확인용입니다. release 시에는 반드시 revert한 뒤 빌드된 결과물을 전달해야 합니다.**
- 요청 범위에 따라 `libcubrid.dll`(`libcubrid.pdb`)만 대상으로 합니다.
- 동일하게 깨진 패턴이 `cs/`, `sa/`, `broker/`, `util/`, `cm_common/`, `win/` CMakeLists에도 존재하나, 본 PR 범위에서는 의도적으로 제외했습니다.
- Linux 환경에서 작업하여 MSVC 빌드로 패키지에 PDB가 실제 포함되는지는 검증하지 못했습니다. Windows 빌더에서 확인이 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)