### PR TITLE
[CBRD-26897] Add EXACT option to SHOW HEAP HEADER/CAPACITY for S-LOCK

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -637,6 +637,7 @@ BEGIN_SUPPRESS_WARNING_BISON_FLEX
 %type <number> show_type_arg_named
 %type <number> show_type_id
 %type <number> show_type_id_dot_id
+%type <number> opt_show_exact
 %type <number> kill_type
 %type <number> procedure_or_function
 %type <boolean> opt_analytic_from_last
@@ -1539,6 +1540,7 @@ BEGIN_SUPPRESS_WARNING_BISON_FLEX
 %token <cptr> EMPTY
 %token <cptr> ENCRYPT
 %token <cptr> ERROR_
+%token <cptr> EXACT
 %token <cptr> EXPLAIN
 %token <cptr> FIRST_VALUE
 %token <cptr> FORCE
@@ -7379,10 +7381,17 @@ show_stmt
 			$$ = node;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}
-	| SHOW show_type_id OF class_name
+	| SHOW show_type_id OF class_name opt_show_exact
 		{{
 			int type = $2;
 			PT_NODE *node, *args = $4;
+
+			if (type == SHOWSTMT_HEAP_HEADER || type == SHOWSTMT_ALL_HEAP_HEADER
+			    || type == SHOWSTMT_HEAP_CAPACITY || type == SHOWSTMT_ALL_HEAP_CAPACITY)
+			  {
+			    /* append the EXACT flag: 1 = EXACT (S_LOCK), 0 = default (IS_LOCK) */
+			    args->next = pt_make_integer_value (this_parser, $5);
+			  }
 
 			node = pt_make_query_showstmt (this_parser, type, args, 0, NULL);
 
@@ -7565,6 +7574,17 @@ show_type_id
 	| ALL INDEXES CAPACITY
 		{{
 			$$ = SHOWSTMT_ALL_INDEXES_CAPACITY;
+		}}
+	;
+
+opt_show_exact
+	: /* empty */
+		{{
+			$$ = 0;	/* default: IS_LOCK */
+		}}
+	| EXACT
+		{{
+			$$ = 1;	/* EXACT: S_LOCK */
 		}}
 	;
 
@@ -20706,6 +20726,7 @@ identifier
 	| EMPTY                  {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
 	| ENCRYPT                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
 	| ERROR_                 {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
+	| EXACT                  {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
 	| EXPLAIN                {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
 	| FIRST_VALUE            {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}
 	| FULLSCAN               {{ SET_CPTR_2_PTNAME($$, $1, @$.buffer_pos);  }}

--- a/src/parser/csql_lexer.l
+++ b/src/parser/csql_lexer.l
@@ -387,6 +387,9 @@ IDL       [a-zA-Z0-9_]
                                                                                 return ERROR_; }
 [eE][sS][cC][aA][pP][eE]						{ begin_token(yytext);   return ESCAPE; }
 [eE][vV][aA][lL][uU][aA][tT][eE]					{ begin_token(yytext);   return EVALUATE; }
+[eE][xX][aA][cC][tT]							{ begin_token(yytext);
+										csql_yylval.cptr = pt_makename(yytext);
+										return EXACT; }
 [eE][xX][cC][eE][pP][tT]						{ begin_token(yytext);   return EXCEPT; }
 [eE][xX][cC][eE][pP][tT][iI][oO][nN]					{ begin_token(yytext);   return EXCEPTION; }
 [eE][xX][eE][cC]							{ begin_token(yytext);   return EXEC; }

--- a/src/parser/keyword.c
+++ b/src/parser/keyword.c
@@ -195,6 +195,7 @@ static KEYWORD_RECORD keywords[] = {
   {ERROR_, "ERROR", 1},
   {ESCAPE, "ESCAPE", 0},
   {EVALUATE, "EVALUATE", 0},
+  {EXACT, "EXACT", 1},
   {EXCEPT, "EXCEPT", 0},
   {EXCEPTION, "EXCEPTION", 0},
   {EXEC, "EXEC", 0},

--- a/src/parser/show_meta.c
+++ b/src/parser/show_meta.c
@@ -326,7 +326,8 @@ metadata_of_heap_header (SHOW_ONLY_ALL flag)
   };
 
   static const SHOWSTMT_NAMED_ARG args[] = {
-    {NULL, AVT_IDENTIFIER, ARG_REQUIRED}
+    {NULL, AVT_IDENTIFIER, ARG_REQUIRED},
+    {NULL, AVT_INTEGER, ARG_REQUIRED}	/* 1 = EXACT (S_LOCK), 0 = default (IS_LOCK) */
   };
 
   static SHOWSTMT_METADATA md_only = {
@@ -373,7 +374,8 @@ metadata_of_heap_capacity (SHOW_ONLY_ALL flag)
   };
 
   static const SHOWSTMT_NAMED_ARG args[] = {
-    {NULL, AVT_IDENTIFIER, ARG_REQUIRED}
+    {NULL, AVT_IDENTIFIER, ARG_REQUIRED},
+    {NULL, AVT_INTEGER, ARG_REQUIRED}	/* 1 = EXACT (S_LOCK), 0 = default (IS_LOCK) */
   };
 
   static SHOWSTMT_METADATA md_only = {

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -18479,16 +18479,23 @@ heap_header_capacity_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VALU
   int i = 0;
   int parts_count = 0;
   bool is_all = false;
+  bool is_exact = false;
+  LOCK class_lock = IS_LOCK;
 
-  assert (arg_cnt == 2);
+  assert (arg_cnt == 3);
   assert (DB_VALUE_TYPE (arg_values[0]) == DB_TYPE_CHAR);
-  assert (DB_VALUE_TYPE (arg_values[1]) == DB_TYPE_INTEGER);
+  assert (DB_VALUE_TYPE (arg_values[1]) == DB_TYPE_INTEGER);	/* EXACT flag */
+  assert (DB_VALUE_TYPE (arg_values[2]) == DB_TYPE_INTEGER);	/* partition type */
 
   *ptr = NULL;
 
   class_name = db_get_string (arg_values[0]);
 
-  partition_type = (DB_CLASS_PARTITION_TYPE) db_get_int (arg_values[1]);
+  /* default uses IS_LOCK; the EXACT option requests S_LOCK to read fully consistent statistics */
+  is_exact = (db_get_int (arg_values[1]) != 0);
+  class_lock = is_exact ? S_LOCK : IS_LOCK;
+
+  partition_type = (DB_CLASS_PARTITION_TYPE) db_get_int (arg_values[2]);
 
   ctx = (HEAP_SHOW_SCAN_CTX *) db_private_alloc (thread_p, sizeof (HEAP_SHOW_SCAN_CTX));
   if (ctx == NULL)
@@ -18499,7 +18506,7 @@ heap_header_capacity_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VALU
     }
   memset (ctx, 0, sizeof (HEAP_SHOW_SCAN_CTX));
 
-  status = xlocator_find_class_oid (thread_p, class_name, &class_oid, S_LOCK);
+  status = xlocator_find_class_oid (thread_p, class_name, &class_oid, class_lock);
   if (status == LC_CLASSNAME_ERROR || status == LC_CLASSNAME_DELETED)
     {
       error = ER_LC_UNKNOWN_CLASSNAME;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26897

### Purpose

`SHOW HEAP CAPACITY`는 기존에 항상 대상 클래스에 **S-LOCK**을 획득했습니다. 기본 동작을 **IS-LOCK**으로 완화하고, 사용자가 `EXACT` 키워드를 주면 기존처럼 **S-LOCK**(완전 일관된 통계)으로 조회하도록 옵션을 추가합니다.

### 유틸리티 기능

```sql
SHOW HEAP CAPACITY OF tbl;        -- IS-LOCK (default)
SHOW HEAP CAPACITY OF tbl EXACT;  -- S-LOCK
```

> `EXACT`는 비예약(unreserved) 키워드라 기존에 `exact`를 식별자(테이블/컬럼명)로 쓰던 쿼리는 그대로 동작합니다.

### Implementation

**파서 — 토큰/문법**
- `csql_lexer.l` — `EXACT` flex 규칙 추가. 비예약 키워드라 `EXPLAIN`처럼 `csql_yylval.cptr`도 채워 식별자로도 사용 가능하게 함
- `keyword.c` — `keywords[]`에 `{EXACT, "EXACT", 1}`(unreserved) 등록
- `csql_grammar.y` — `EXACT` 토큰 선언, `opt_show_exact` nonterminal(EXACT→1 / empty→0) 추가, `SHOW show_type_id OF class_name opt_show_exact` 규칙에서 플래그를 show 인자로 append, 비예약 식별자 목록에 `EXACT` 추가

**의미 검증 — 메타데이터**
- `show_meta.c` — `metadata_of_heap_capacity()`의 인자 메타에 `AVT_INTEGER`(EXACT 플래그) 1개 추가. 인자 개수·타입 검증(`pt_resolve_showstmt_args_unnamed`)이 새 인자를 통과시키도록 함

**서버 — 락 선택**
- `heap_file.c` — `heap_header_capacity_start_scan()`이 인자 3개(`class_name`, `exact_flag`, `partition_type`)를 받도록 변경. `exact_flag != 0`이면 `S_LOCK`, 아니면 `IS_LOCK`으로 `xlocator_find_class_oid()` 호출. 기존 `partition_type`은 `arg_values[1]→[2]`로 이동

### Remark

`SHOW HEAP HEADER`도 동일하게 영향을 받습니다. 서버 진입점 `heap_header_capacity_start_scan()`과 인자 검증 흐름을 HEADER/CAPACITY 4종(`HEAP HEADER`, `ALL HEAP HEADER`, `HEAP CAPACITY`, `ALL HEAP CAPACITY`)이 공유하기 때문에, 한쪽만 변경하면 인자 개수(`arg_cnt`)가 어긋나 동작이 깨집니다. 따라서 `csql_grammar.y`의 플래그 append와 `show_meta.c`의 메타데이터 인자 추가는 4종 모두에 적용했고, 결과적으로 `SHOW HEAP HEADER` / `SHOW ALL HEAP HEADER` / `SHOW ALL HEAP CAPACITY`에서도 `EXACT` 옵션으로 S-LOCK을 선택할 수 있습니다. (이번 변경의 1차 목표는 `SHOW HEAP CAPACITY`입니다.)
