### PR TITLE
[CBRD-26843] drain all resources from the coordinator and workers.

### DIFF
--- a/src/connection/connection_pool.cpp
+++ b/src/connection/connection_pool.cpp
@@ -102,6 +102,9 @@ namespace cubconn::connection
     /* acquire the lock or kill itself */
     this->try_to_lock_resource ();
 
+    /* drain all resources from the coordinator and workers */
+    this->drain_contexts ();
+
     m_workers.clear ();
     this->finalize_freelist ();
 
@@ -196,6 +199,22 @@ namespace cubconn::connection
     assert (m_mutex_holder == std::this_thread::get_id ());
 
     return m_workers;
+  }
+
+  void pool::drain_contexts ()
+  {
+    if (m_coordinator)
+      {
+	m_coordinator->finalize_resources ();
+      }
+
+    if (!m_workers.empty ())
+      {
+	for (std::unique_ptr<worker> &worker : m_workers)
+	  {
+	    worker->finalize_resources ();
+	  }
+      }
   }
 
   void pool::try_to_lock_resource ()

--- a/src/connection/connection_pool.hpp
+++ b/src/connection/connection_pool.hpp
@@ -105,6 +105,8 @@ namespace cubconn::connection
 	std::size_t m_claim;
       } m_freelist;
 
+      void drain_contexts ();
+
       void try_to_lock_resource ();
 
       bool initialize_freelist (std::uint32_t max_connections);

--- a/src/connection/connection_worker.cpp
+++ b/src/connection/connection_worker.cpp
@@ -2126,7 +2126,13 @@ respond:
 		m_parent->retire_context (request.ctx);
 		break;
 
-	      default:
+	      case message_type::START:
+	      case message_type::HIBERNATE:
+	      case message_type::AWAKEN:
+	      case message_type::SHUTDOWN:
+	      case message_type::HANDOFF_CLIENT:
+	      case message_type::RELEASE_PACKET:
+	      case message_type::TYPE_COUNT:
 		break;
 	      }
 	  }

--- a/src/connection/connection_worker.cpp
+++ b/src/connection/connection_worker.cpp
@@ -2094,6 +2094,52 @@ respond:
     m_watcher->cv.notify_one ();
   }
 
+  void worker::finalize_resources ()
+  {
+    message request;
+    std::size_t i;
+
+    for (i = 0; i < static_cast<std::size_t> (queue_type::TYPE_COUNT); i++)
+      {
+	while (m_queue[i].try_pop (request))
+	  {
+	    switch (request.type)
+	      {
+	      case message_type::SEND_PACKET:
+		if (request.deleter)
+		  {
+		    request.deleter ();
+		  }
+		[[fallthrough]];
+
+	      case message_type::SHUTDOWN_CLIENT:
+		this->wakeup_blocked_worker (request.waiter_handle);
+		break;
+
+	      case message_type::NEW_CLIENT:
+		css_free_conn (request.conn);
+		m_parent->retire_context (request.ctx);
+		break;
+
+	      case message_type::TAKEOVER_CLIENT:
+		css_free_conn (request.ctx->m_conn);
+		m_parent->retire_context (request.ctx);
+		break;
+
+	      default:
+		break;
+	      }
+	  }
+      }
+
+    for (context *ctx : m_removed_context)
+      {
+	css_free_conn (ctx->m_conn);
+	m_parent->retire_context (ctx);
+      }
+    m_removed_context.clear ();
+  }
+
   bool worker::run ()
   {
     std::array<epoll_event, 512> events;

--- a/src/connection/connection_worker.hpp
+++ b/src/connection/connection_worker.hpp
@@ -191,7 +191,10 @@ namespace cubconn::connection
       ~worker ();
 
       void initialize ();
+
       void finalize ();
+      void finalize_resources ();
+
       bool run ();
 
       void attach ();

--- a/src/connection/coordinator.cpp
+++ b/src/connection/coordinator.cpp
@@ -1276,7 +1276,11 @@ not_transferred:
 	    handle_message_queue_return_to_pool (request);
 	    break;
 
-	  default:
+	  case message_type::START:
+	  case message_type::HANDOFF_REPLY:
+	  case message_type::STATISTICS:
+	  case message_type::SHUTDOWN:
+	  case message_type::TYPE_COUNT:
 	    break;
 	  }
       }

--- a/src/connection/coordinator.cpp
+++ b/src/connection/coordinator.cpp
@@ -1260,6 +1260,28 @@ not_transferred:
     m_watcher->cv.notify_one ();
   }
 
+  void coordinator::finalize_resources ()
+  {
+    message request;
+
+    while (m_queue.try_pop (request))
+      {
+	switch (request.type)
+	  {
+	  case message_type::NEW_CLIENT:
+	    css_free_conn (request.conn);
+	    break;
+
+	  case message_type::RETURN_TO_POOL:
+	    handle_message_queue_return_to_pool (request);
+	    break;
+
+	  default:
+	    break;
+	  }
+      }
+  }
+
   bool coordinator::run ()
   {
     std::array<epoll_event, 4> events;

--- a/src/connection/coordinator.hpp
+++ b/src/connection/coordinator.hpp
@@ -210,7 +210,10 @@ namespace cubconn::connection
       ~coordinator ();
 
       void initialize ();
+
       void finalize ();
+      void finalize_resources ();
+
       bool run ();
 
       void attach ();


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26843>

### Purpose

Connection coordinator와 worker는 css_conn_entry와 context에 대한 소유권을 MQ를 통해 이관/관리합니다.
서버가 종료될 때 타이밍이 엇갈려 MQ에 drain되지 않은 소유권 message가 있는 경우 자원 회수 대상에서 벗어나, 종료 시의 assert에서 실패하게 됩니다.
```
assert (m_freelist.m_claim == 0);
```

따라서 coordinator와 worker가 모두 닫힌 시점에서 MQ를 drain하여 자원을 회수하도록 수정합니다.

### Implementation

N/A

### Remarks

N/A
