### PR TITLE
[CBRD-26897] Acquire IS-LOCK for SHOW HEAP HEADER/CAPACITY

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -18499,7 +18499,8 @@ heap_header_capacity_start_scan (THREAD_ENTRY * thread_p, int show_type, DB_VALU
     }
   memset (ctx, 0, sizeof (HEAP_SHOW_SCAN_CTX));
 
-  status = xlocator_find_class_oid (thread_p, class_name, &class_oid, S_LOCK);
+  /* use IS_LOCK so that DML (IX_LOCK) can run concurrently with SHOW HEAP HEADER/CAPACITY */
+  status = xlocator_find_class_oid (thread_p, class_name, &class_oid, IS_LOCK);
   if (status == LC_CLASSNAME_ERROR || status == LC_CLASSNAME_DELETED)
     {
       error = ER_LC_UNKNOWN_CLASSNAME;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26897

### Purpose

`SHOW HEAP HEADER/CAPACITY`는 기존에 대상 클래스에 **S-LOCK**을 획득했습니다(`heap_header_capacity_start_scan()`). S-LOCK은 DML(INSERT/UPDATE/DELETE)이 클래스에 획득하는 **IX-LOCK과 충돌**하므로, DML과 `SHOW HEAP CAPACITY`를 동시에 수행할 수 없었습니다. 게다가 이 스캔은 heap의 모든 페이지를 순회하므로 대용량 테이블에서는 DML이 장시간 대기하게 됩니다.

기본 락을 **IS-LOCK**으로 완화하여 DML과 동시에 수행할 수 있도록 합니다. IS-LOCK은 DML의 IX-LOCK과 호환되고, 스키마 변경(DDL)의 배타 락과는 여전히 충돌하므로 안전성은 유지됩니다.

### Implementation

- `heap_file.c` — `heap_header_capacity_start_scan()`의 `xlocator_find_class_oid()` 호출 락 인자를 `S_LOCK` → `IS_LOCK`으로 변경

### Remark

이 변경은 `heap_header_capacity_start_scan()`을 공통 `start_func`로 사용하는 아래 4개 구문 모두에 적용됩니다. (class lock은 이 함수 한 곳에서만 획득)

- `SHOW HEAP HEADER`
- `SHOW ALL HEAP HEADER`
- `SHOW HEAP CAPACITY`
- `SHOW ALL HEAP CAPACITY`

> 본 PR은 CBRD-26897을 두 개로 분할한 것 중 **1번(기본 락 완화)** 입니다. 후속 PR에서 `EXACT` 키워드로 S-LOCK을 선택할 수 있는 옵션을 추가합니다.