### PR TITLE
[CBRD-26882] Allow reserved-purpose clients to connect even if the number of connected clients exceeds max_clients.

### DIFF
--- a/src/api/cubrid_log.c
+++ b/src/api/cubrid_log.c
@@ -632,7 +632,8 @@ cubrid_log_connect_server_internal (char *host, int port, char *dbname)
 
 	  __gv_cvar.css_close_conn (g_conn_entry);
 
-	  g_conn_entry = __gv_cvar.css_server_connect_part_two (host, g_conn_entry, port_id, &rid);
+	  g_conn_entry = __gv_cvar.css_server_connect_part_two (host, g_conn_entry, port_id, &rid,
+								DB_CLIENT_TYPE_UNKNOWN);
 	  if (g_conn_entry == NULL)
 	    {
 	      CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_FAILED_CONNECT,

--- a/src/communication/network_cl.c
+++ b/src/communication/network_cl.c
@@ -3654,13 +3654,13 @@ net_client_shutdown_server (void)
  *    communications. It sets up CSS and verifies connection with the server.
  */
 int
-net_client_init (const char *dbname, const char *hostname)
+net_client_init (const char *dbname, const char *hostname, int client_type)
 {
   int error = NO_ERROR;
 
   /* don't really need to do this every time but bruce says its ok - we probably need to guarentee that a css_terminate
    * is always called before this */
-  error = __gv_cvar.css_client_init (prm_get_integer_value (PRM_ID_TCP_PORT_ID), dbname, hostname);
+  error = __gv_cvar.css_client_init (prm_get_integer_value (PRM_ID_TCP_PORT_ID), dbname, hostname, client_type);
   if (error != NO_ERROR)
     {
       goto end;
@@ -3704,7 +3704,7 @@ end:
 int
 net_client_sub_init ()
 {
-  return __gv_cvar.css_client_sub_init (net_Server_name, net_Server_host);
+  return __gv_cvar.css_client_sub_init (net_Server_name, net_Server_host, db_get_client_type ());
 }
 
 void

--- a/src/communication/network_cl.h
+++ b/src/communication/network_cl.h
@@ -100,7 +100,7 @@ extern int net_client_ping_server_with_handshake (int client_type, bool check_ca
 #if defined(ENABLE_UNUSED_FUNCTION)
 extern void net_client_shutdown_server (void);
 #endif
-extern int net_client_init (const char *dbname, const char *hostname);
+extern int net_client_init (const char *dbname, const char *hostname, int client_type);
 #if defined(MULTI_CONN_TO_A_SERVER)
 extern int net_client_sub_init ();
 extern void net_client_sub_final ();

--- a/src/communication/network_interface_sr.cpp
+++ b/src/communication/network_interface_sr.cpp
@@ -632,7 +632,16 @@ server_ping_with_handshake (THREAD_ENTRY *thread_p, unsigned int rid, char *requ
     }
 
   /* update connection counters for reserved connections */
-  if (css_increment_num_conn ((BOOT_CLIENT_TYPE) client_type) != NO_ERROR)
+  if (thread_p->conn_entry->client_type != DB_CLIENT_TYPE_UNKNOWN)
+    {
+      if (thread_p->conn_entry->client_type != (BOOT_CLIENT_TYPE) client_type)
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_NET_SERVER_HAND_SHAKE, 1, client_host);
+	  (void) return_error_to_client (thread_p, rid);
+	  status = CSS_UNPLANNED_SHUTDOWN;
+	}
+    }
+  else if (css_increment_num_conn ((BOOT_CLIENT_TYPE) client_type) != NO_ERROR)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_CLIENTS_EXCEEDED, 1, NUM_NORMAL_TRANS);
       (void) return_error_to_client (thread_p, rid);

--- a/src/connection/client_support.cpp
+++ b/src/connection/client_support.cpp
@@ -155,7 +155,7 @@ client_support::css_set_pipe_signal (void)
  *   host_name(in):
  */
 int
-client_support::css_client_init (int sockid, const char *server_name, const char *host_name)
+client_support::css_client_init (int sockid, const char *server_name, const char *host_name, int client_type)
 {
   CSS_CONN_ENTRY *conn;
   int error = NO_ERROR;
@@ -167,7 +167,7 @@ client_support::css_client_init (int sockid, const char *server_name, const char
   m_service_port_id = sockid;
   css_set_pipe_signal ();
 
-  conn = css_connect_to_cubrid_server ((char *) host_name, (char *) server_name);
+  conn = css_connect_to_cubrid_server ((char *) host_name, (char *) server_name, client_type);
   if (conn != NULL)
     {
       CSS_MAP_ENTRY *map = m_conn_less.css_queue_connection (conn, (char *) host_name);
@@ -192,13 +192,13 @@ client_support::css_client_init (int sockid, const char *server_name, const char
 
 #if defined(MULTI_CONN_TO_A_SERVER)
 int
-client_support::css_client_sub_init (const char *server_name, const char *host_name)
+client_support::css_client_sub_init (const char *server_name, const char *host_name, int client_type)
 {
   CSS_CONN_ENTRY *conn;
   CSS_MAP_ENTRY *map;
   int error = NO_ERROR;
 
-  conn = css_connect_to_cubrid_server ((char *) host_name, (char *) server_name);
+  conn = css_connect_to_cubrid_server ((char *) host_name, (char *) server_name, client_type);
   if (conn != NULL)
     {
       map = m_conn_less.css_queue_connection (conn, (char *) host_name);

--- a/src/connection/client_support.h
+++ b/src/connection/client_support.h
@@ -52,9 +52,9 @@ public:
    ~client_support () = default;
 
   int css_get_errno ();
-  int css_client_init (int sockid, const char *server_name, const char *host_name);
+  int css_client_init (int sockid, const char *server_name, const char *host_name, int client_type);
 #if defined(MULTI_CONN_TO_A_SERVER)
-  int css_client_sub_init (const char *server_name, const char *host_name);
+  int css_client_sub_init (const char *server_name, const char *host_name, int client_type);
   void css_client_sub_terminate (const char *host_name);
 #endif
   unsigned int css_send_request_to_server_with_buffer (char *host, int request, char *arg_buffer,

--- a/src/connection/connection_cl.cpp
+++ b/src/connection/connection_cl.cpp
@@ -97,6 +97,42 @@
 #define TRACE(string, arg1)
 #endif /* PACKET_TRACE */
 
+static bool
+css_pack_client_type_info (const char *server_name, int server_name_length, int client_type, char **packed_data,
+			   int *packed_data_length)
+{
+  char *ptr;
+  int value;
+
+  assert (packed_data != NULL);
+  assert (packed_data_length != NULL);
+
+  *packed_data = NULL;
+  *packed_data_length = server_name_length;
+
+  if (server_name == NULL || server_name_length <= 0
+      || client_type < DB_CLIENT_TYPE_DEFAULT || client_type >= DB_CLIENT_TYPE_MAX)
+    {
+      return true;
+    }
+
+  *packed_data_length = server_name_length + CSS_CLIENT_TYPE_INFO_SIZE;
+  *packed_data = (char *) malloc (*packed_data_length);
+  if (*packed_data == NULL)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, (size_t) *packed_data_length);
+      return false;
+    }
+
+  memcpy (*packed_data, server_name, server_name_length);
+  ptr = *packed_data + server_name_length;
+
+  value = htonl (client_type);
+  memcpy (ptr, &value, sizeof (value));
+
+  return true;
+}
+
 /* the queue anchor for all the connection structures */
 static CSS_CONN_ENTRY *css_Conn_anchor = NULL; // TODO: Let's define it as a member variable of the connection_cl class
 
@@ -733,9 +769,12 @@ begin:
 CSS_CONN_ENTRY *
 connection_cl::css_common_connect (const char *host_name, CSS_CONN_ENTRY *conn, int connect_type,
 				   const char *server_name, int server_name_length, int port, int timeout,
-				   unsigned short *rid, bool send_magic)
+				   unsigned short *rid, bool send_magic, int client_type)
 {
   SOCKET fd;
+  const char *request_data = server_name;
+  int request_data_length = server_name_length;
+  char *packed_data = NULL;
 
 #if !defined (WINDOWS)
   if (timeout > 0)
@@ -760,9 +799,30 @@ connection_cl::css_common_connect (const char *host_name, CSS_CONN_ENTRY *conn, 
 	  return NULL;
 	}
 
-      if (css_send_request (conn, connect_type, rid, server_name, server_name_length) == NO_ERRORS)
+      if (connect_type == DATA_REQUEST
+	  && !css_pack_client_type_info (server_name, server_name_length, client_type, &packed_data,
+					 &request_data_length))
 	{
+	  return NULL;
+	}
+
+      if (packed_data != NULL)
+	{
+	  request_data = packed_data;
+	}
+
+      if (css_send_request (conn, connect_type, rid, request_data, request_data_length) == NO_ERRORS)
+	{
+	  if (packed_data != NULL)
+	    {
+	      free_and_init (packed_data);
+	    }
 	  return conn;
+	}
+
+      if (packed_data != NULL)
+	{
+	  free_and_init (packed_data);
 	}
     }
 #if !defined (WINDOWS)
@@ -788,7 +848,8 @@ connection_cl::css_common_connect (const char *host_name, CSS_CONN_ENTRY *conn, 
  *   rid(out):
  */
 CSS_CONN_ENTRY *
-connection_cl::css_server_connect (char *host_name, CSS_CONN_ENTRY *conn, char *server_name, unsigned short *rid)
+connection_cl::css_server_connect (char *host_name, CSS_CONN_ENTRY *conn, char *server_name, unsigned short *rid,
+				   int client_type)
 {
   int length;
 
@@ -803,7 +864,7 @@ connection_cl::css_server_connect (char *host_name, CSS_CONN_ENTRY *conn, char *
 
   /* timeout in second in css_common_connect() */
   return (css_common_connect (host_name, conn, DATA_REQUEST, server_name, length, m_service_port_id,
-			      prm_get_integer_value (PRM_ID_TCP_CONNECTION_TIMEOUT), rid, true));
+			      prm_get_integer_value (PRM_ID_TCP_CONNECTION_TIMEOUT), rid, true, client_type));
 }
 
 /* New style server connection function that uses an explicit port id */
@@ -817,7 +878,8 @@ connection_cl::css_server_connect (char *host_name, CSS_CONN_ENTRY *conn, char *
  *   rid(in):
  */
 CSS_CONN_ENTRY *
-connection_cl::css_server_connect_part_two (char *host_name, CSS_CONN_ENTRY *conn, int port_id, unsigned short *rid)
+connection_cl::css_server_connect_part_two (char *host_name, CSS_CONN_ENTRY *conn, int port_id, unsigned short *rid,
+    int client_type)
 {
   int reason = -1, buffer_size;
   char *buffer = NULL;
@@ -833,7 +895,7 @@ connection_cl::css_server_connect_part_two (char *host_name, CSS_CONN_ENTRY *con
    */
 
   /* timeout in second in css_common_connect() */
-  if (css_common_connect (host_name, conn, DATA_REQUEST, NULL, 0, port_id, timeout, rid, false) == NULL)
+  if (css_common_connect (host_name, conn, DATA_REQUEST, NULL, 0, port_id, timeout, rid, false, client_type) == NULL)
     {
       return NULL;
     }
@@ -867,7 +929,7 @@ connection_cl::css_connect_to_log_server (const char *host_name, CSS_CONN_ENTRY 
     const char *server_name, int port, int timeout, unsigned short *rid)
 {
   return css_common_connect (host_name, conn, DATA_REQUEST, server_name, (int) strlen (server_name) + 1, port, timeout,
-			     rid, true);
+			     rid, true, DB_CLIENT_TYPE_UNKNOWN);
 
 };
 
@@ -911,8 +973,8 @@ connection_cl::css_connect_to_master_server (int master_port_id, const char *ser
   /* select the connection protocol, for PC's this will always be new */
   connection_protocol = ((css_Server_use_new_connection_protocol) ? SERVER_REQUEST_NEW : SERVER_REQUEST_FROM_CLIENT);
 
-  if (css_common_connect (hname, conn, connection_protocol, server_name, name_length, master_port_id, 0, &rid, true)
-      == NULL)
+  if (css_common_connect (hname, conn, connection_protocol, server_name, name_length, master_port_id, 0, &rid, true,
+			  DB_CLIENT_TYPE_UNKNOWN) == NULL)
     {
       goto fail_end;
     }
@@ -1027,7 +1089,7 @@ fail_end:
  *   server_name(in):
  */
 CSS_CONN_ENTRY *
-connection_cl::css_connect_to_cubrid_server (char *host_name, char *server_name)
+connection_cl::css_connect_to_cubrid_server (char *host_name, char *server_name, int client_type)
 {
   CSS_CONN_ENTRY *conn;
   CSS_QUEUE_ENTRY *buffer_q_entry_p;
@@ -1051,7 +1113,7 @@ connection_cl::css_connect_to_cubrid_server (char *host_name, char *server_name)
   timeout = prm_get_integer_value (PRM_ID_TCP_CONNECTION_TIMEOUT) * 1000;
 
   retry_count = 0;
-  if (css_server_connect (host_name, conn, server_name, &rid) == NULL)
+  if (css_server_connect (host_name, conn, server_name, &rid, client_type) == NULL)
     {
       goto exit;
     }
@@ -1112,7 +1174,7 @@ connection_cl::css_connect_to_cubrid_server (char *host_name, char *server_name)
 	      free_and_init (buffer);
 	    }
 
-	  if (css_server_connect_part_two (host_name, conn, port_id, &rid))
+	  if (css_server_connect_part_two (host_name, conn, port_id, &rid, client_type))
 	    {
 	      return conn;
 	    }
@@ -1209,7 +1271,8 @@ connection_cl::css_connect_to_master_timeout (const char *host_name, int port_id
 
   time = ceil (time / 1000);
 
-  return (css_common_connect (host_name, conn, INFO_REQUEST, NULL, 0, port_id, (int) time, rid, true));
+  return (css_common_connect (host_name, conn, INFO_REQUEST, NULL, 0, port_id, (int) time, rid, true,
+			      DB_CLIENT_TYPE_UNKNOWN));
 }
 
 /*

--- a/src/connection/connection_cl.h
+++ b/src/connection/connection_cl.h
@@ -57,13 +57,14 @@ private:
   void css_dealloc_conn (CSS_CONN_ENTRY * conn);
 
   int css_read_header (CSS_CONN_ENTRY * conn, NET_HEADER * local_header);
-  CSS_CONN_ENTRY *css_server_connect (char *host_name, CSS_CONN_ENTRY * conn, char *server_name, unsigned short *rid);
+  CSS_CONN_ENTRY *css_server_connect (char *host_name, CSS_CONN_ENTRY * conn, char *server_name,
+				      unsigned short *rid, int client_type);
   int css_return_queued_data (CSS_CONN_ENTRY * conn, unsigned short request_id, char **buffer, int *buffer_size,
 			      int *rc);
   int css_return_queued_request (CSS_CONN_ENTRY * conn, unsigned short *rid, int *request, int *buffer_size);
   CSS_CONN_ENTRY *css_common_connect (const char *host_name, CSS_CONN_ENTRY * conn, int connect_type,
 				      const char *server_name, int server_name_length, int port, int timeout,
-				      unsigned short *rid, bool send_magic);
+				      unsigned short *rid, bool send_magic, int client_type);
   bool css_is_valid_request_id (CSS_CONN_ENTRY * conn, unsigned short request_id);
 
 public:
@@ -76,7 +77,7 @@ public:
 
   CSS_CONN_ENTRY *css_connect_to_master_server (int master_port_id, const char *server_name, int name_length);
   int css_receive_error (CSS_CONN_ENTRY * conn, unsigned short req_id, char **buffer, int *buffer_size);
-  CSS_CONN_ENTRY *css_connect_to_cubrid_server (char *host_name, char *server_name);
+  CSS_CONN_ENTRY *css_connect_to_cubrid_server (char *host_name, char *server_name, int client_type);
   CSS_CONN_ENTRY *css_connect_to_master_for_info (const char *host_name, int port_id, unsigned short *rid);
   CSS_CONN_ENTRY *css_connect_to_master_timeout (const char *host_name, int port_id, int timeout, unsigned short *rid);
   bool css_does_master_exist (int port_id);
@@ -96,7 +97,7 @@ public:
   CSS_CONN_ENTRY *css_connect_to_log_server (const char *host_name, CSS_CONN_ENTRY * conn,
 					     const char *server_name, int port, int timeout, unsigned short *rid);
   CSS_CONN_ENTRY *css_server_connect_part_two (char *host_name, CSS_CONN_ENTRY * conn, int port_id,
-					       unsigned short *rid);
+					       unsigned short *rid, int client_type);
 };
 
 extern void css_shutdown_conn (CSS_CONN_ENTRY * conn);

--- a/src/connection/connection_context.cpp
+++ b/src/connection/connection_context.cpp
@@ -33,7 +33,8 @@ namespace cubconn::master
   context::context () :
     m_conn (nullptr),
     m_sendbuf (32),
-    m_has_error (false)
+    m_has_error (false),
+    m_pending_client_type (DB_CLIENT_TYPE_UNKNOWN)
   {
   }
 
@@ -50,6 +51,7 @@ namespace cubconn::master
 
     m_state = state::SendInHandshake;
     m_has_error = false;
+    m_pending_client_type = DB_CLIENT_TYPE_UNKNOWN;
   }
 
   bool context::has_data_to_send ()

--- a/src/connection/connection_context.hpp
+++ b/src/connection/connection_context.hpp
@@ -87,6 +87,7 @@ namespace cubconn::master
 
     state m_state { state::SendInHandshake };
     bool m_has_error;
+    int m_pending_client_type;
 
     context ();
     ~context ();

--- a/src/connection/connection_defs.h
+++ b/src/connection/connection_defs.h
@@ -75,6 +75,16 @@ enum css_command_type
   MAX_REQUEST
 };
 
+#define CSS_CLIENT_TYPE_INFO_SIZE ((int) sizeof (int))
+#define CSS_SERVER_REQUEST_CODE_MASK 0x0000ffff
+#define CSS_SERVER_REQUEST_CLIENT_TYPE_SHIFT 16
+#define CSS_PACK_SERVER_REQUEST(request, client_type) \
+  ((((unsigned int) ((client_type) + 1)) << CSS_SERVER_REQUEST_CLIENT_TYPE_SHIFT) \
+   | ((unsigned int) (request) & CSS_SERVER_REQUEST_CODE_MASK))
+#define CSS_UNPACK_SERVER_REQUEST_CODE(request) ((int) ((unsigned int) (request) & CSS_SERVER_REQUEST_CODE_MASK))
+#define CSS_UNPACK_SERVER_REQUEST_CLIENT_TYPE(request) \
+  ((int) (((unsigned int) (request)) >> CSS_SERVER_REQUEST_CLIENT_TYPE_SHIFT) - 1)
+
 /*
  * These are the responses from the master to a server
  * when it is trying to connect and register itself.

--- a/src/connection/master_connector.cpp
+++ b/src/connection/master_connector.cpp
@@ -65,6 +65,12 @@
 
 namespace cubconn::master
 {
+  static bool
+  is_valid_early_client_type (int client_type)
+  {
+    return client_type >= DB_CLIENT_TYPE_DEFAULT && client_type < DB_CLIENT_TYPE_MAX;
+  }
+
   /* Master connector uses Main_entry_p (TT_MASTER) instead of claiming a separate entry. */
   /* It is still registered here for consistency with other connection components.	  */
   REGISTER_CONNECTION (master_connector, 0);
@@ -766,10 +772,14 @@ namespace cubconn::master
     CSS_CONN_ENTRY *conn;
     unsigned short request_id;
     SOCKET new_fd;
+    int client_type;
+    bool pending_client_type = false;
     result status;
 
     /* master context goes back to waiting for next request regardless of send path */
     NEXT_STATE (ctx, RecvRequestType);
+    client_type = ctx->m_pending_client_type;
+    ctx->m_pending_client_type = DB_CLIENT_TYPE_UNKNOWN;
 
     /* receive new socket descriptor from the master */
     new_fd = css_open_new_socket_from_master (ctx->m_conn->fd, &request_id);
@@ -816,9 +826,39 @@ namespace cubconn::master
 	return result::RefuseConnection;
       }
 
+    if (is_valid_early_client_type (client_type))
+      {
+	if (css_increment_num_conn ((BOOT_CLIENT_TYPE) client_type) != NO_ERROR)
+	  {
+	    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_CLIENTS_EXCEEDED, 1, NUM_NORMAL_TRANS);
+
+	    new_ctx->m_conn = new css_conn_entry;
+	    css_initialize_conn (new_ctx->m_conn, new_fd);
+	    new_ctx->m_conn->request_id = request_id;
+
+	    if (!this->prepare_reply_refuse_connection (new_ctx, SERVER_CLIENTS_EXCEEDED))
+	      {
+		delete new_ctx->m_conn;
+		delete new_ctx;
+
+		return result::RefuseConnection;
+	      }
+
+	    NEXT_STATE (new_ctx, SendReplyToClient);
+	    return result::RefuseConnection;
+	  }
+
+	pending_client_type = true;
+      }
+
     conn = css_make_conn (new_fd);
     if (conn == NULL)
       {
+	if (pending_client_type)
+	  {
+	    css_decrement_num_conn ((BOOT_CLIENT_TYPE) client_type);
+	  }
+
 	er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CSS_CLIENTS_EXCEEDED, 1, NUM_NORMAL_TRANS);
 
 	new_ctx->m_conn = new css_conn_entry;
@@ -839,6 +879,10 @@ namespace cubconn::master
 
     new_ctx->m_conn = conn;
     new_ctx->m_conn->request_id = request_id;
+    if (pending_client_type)
+      {
+	new_ctx->m_conn->client_type = (BOOT_CLIENT_TYPE) client_type;
+      }
     if (!this->prepare_reply (new_ctx, SERVER_CONNECTED))
       {
 	css_prepare_shutdown_conn (new_ctx->m_conn);
@@ -886,7 +930,7 @@ namespace cubconn::master
   {
     const int *buf;
     result status;
-    int request;
+    int packed_request, request;
 
     std::tie (status, buf) = buffered_socket::read_fixed_size<int> (ctx->m_conn->fd, ctx->m_recvbuf);
     if (status != result::Ok)
@@ -895,7 +939,9 @@ namespace cubconn::master
 	return status;
       }
 
-    request = ntohl (*buf);
+    packed_request = ntohl (*buf);
+    request = CSS_UNPACK_SERVER_REQUEST_CODE (packed_request);
+    ctx->m_pending_client_type = CSS_UNPACK_SERVER_REQUEST_CLIENT_TYPE (packed_request);
     ctx->m_recvbuf.mark_consumed ();
 
     er_log_debug (__FILE__, __LINE__, "cub_server received %d as request from master\n", request);

--- a/src/connection/tcp.c
+++ b/src/connection/tcp.c
@@ -1088,11 +1088,6 @@ css_open_new_socket_from_master (SOCKET fd, unsigned short *rid)
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_TCP_RECVMSG, 0);
       return INVALID_SOCKET;
     }
-  if (rc != (int) sizeof (unsigned short))
-    {
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_TCP_RECVMSG, 0);
-      return INVALID_SOCKET;
-    }
 
   for (cmsg = CMSG_FIRSTHDR (&msg); cmsg; cmsg = CMSG_NXTHDR (&msg, cmsg))
     {
@@ -1101,6 +1096,13 @@ css_open_new_socket_from_master (SOCKET fd, unsigned short *rid)
 	  memcpy (&new_fd, CMSG_DATA (cmsg), sizeof (new_fd));
 	  break;
 	}
+    }
+  if (rc != (int) sizeof (unsigned short))
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_TCP_RECVMSG, 0);
+
+      css_shutdown_socket (new_fd);
+      return INVALID_SOCKET;
     }
 
   if (IS_INVALID_SOCKET (new_fd))

--- a/src/connection/tcp.c
+++ b/src/connection/tcp.c
@@ -1088,6 +1088,11 @@ css_open_new_socket_from_master (SOCKET fd, unsigned short *rid)
       er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_TCP_RECVMSG, 0);
       return INVALID_SOCKET;
     }
+  if (rc != (int) sizeof (unsigned short))
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ERR_CSS_TCP_RECVMSG, 0);
+      return INVALID_SOCKET;
+    }
 
   for (cmsg = CMSG_FIRSTHDR (&msg); cmsg; cmsg = CMSG_NXTHDR (&msg, cmsg))
     {
@@ -1105,6 +1110,7 @@ css_open_new_socket_from_master (SOCKET fd, unsigned short *rid)
     }
 
   *rid = ntohs (req_id);
+
   pid = getpid ();
   fcntl (new_fd, F_SETOWN, pid);
   css_sockopt (new_fd);
@@ -1120,9 +1126,10 @@ css_open_new_socket_from_master (SOCKET fd, unsigned short *rid)
  *   rid(in):
  */
 bool
-css_transfer_fd (SOCKET server_fd, SOCKET client_fd, unsigned short rid, CSS_SERVER_REQUEST request_for_server)
+css_transfer_fd (SOCKET server_fd, SOCKET client_fd, unsigned short rid, CSS_SERVER_REQUEST request_for_server,
+		 int client_type)
 {
-  int request;
+  unsigned int request;
   unsigned short req_id;
   struct iovec iov[1];
   struct msghdr msg;
@@ -1130,7 +1137,7 @@ css_transfer_fd (SOCKET server_fd, SOCKET client_fd, unsigned short rid, CSS_SER
   static struct cmsghdr *cmptr = NULL;
 #endif /* LINUX || AIX */
 
-  request = htonl (request_for_server);
+  request = htonl (CSS_PACK_SERVER_REQUEST (request_for_server, client_type));
   if (send (server_fd, (char *) &request, sizeof (int), 0) < 0)
     {
       /* Master->Server link down. remove old link, and try again. */

--- a/src/connection/tcp.h
+++ b/src/connection/tcp.h
@@ -48,7 +48,8 @@ extern bool css_tcp_listen_server_datagram (SOCKET sockfd, SOCKET * newfd);
 extern bool css_tcp_master_datagram (char *pathname, SOCKET * sockfd);
 extern SOCKET css_master_accept (SOCKET sockfd);
 extern SOCKET css_open_new_socket_from_master (SOCKET fd, unsigned short *rid);
-extern bool css_transfer_fd (SOCKET server_fd, SOCKET client_fd, unsigned short rid, CSS_SERVER_REQUEST request);
+extern bool css_transfer_fd (SOCKET server_fd, SOCKET client_fd, unsigned short rid, CSS_SERVER_REQUEST request,
+			     int client_type);
 extern void css_shutdown_socket (SOCKET fd);
 extern int css_open_server_connection_socket (void);
 extern void css_close_server_connection_socket (void);

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -88,8 +88,9 @@ static void css_accept_old_request (CSS_CONN_ENTRY * conn, unsigned short rid, S
 				    char *server_name, int server_name_length);
 static void css_register_new_server (CSS_CONN_ENTRY * conn, unsigned short rid, bool is_client);
 static void css_register_new_server2 (CSS_CONN_ENTRY * conn, unsigned short rid);
+static int css_get_client_type_from_data_request (const char *server_name, int data_length);
 static bool css_send_new_request_to_server (SOCKET server_fd, SOCKET client_fd, unsigned short rid,
-					    CSS_SERVER_REQUEST request);
+					    CSS_SERVER_REQUEST request, int client_type);
 static void css_send_to_existing_server (CSS_CONN_ENTRY * conn, unsigned short rid, CSS_SERVER_REQUEST request);
 static void css_process_new_connection (SOCKET fd);
 static int css_enroll_read_sockets (SOCKET_QUEUE_ENTRY * anchor_p, fd_set * fd_var);
@@ -661,6 +662,53 @@ css_register_new_server2 (CSS_CONN_ENTRY * conn, unsigned short rid)
  */
 
 /*
+ * css_get_client_type_from_data_request() - unpack client type appended after server name
+ *   return: client type if present and valid, DB_CLIENT_TYPE_UNKNOWN otherwise
+ *   server_name(in):
+ *   data_length(in):
+ */
+static int
+css_get_client_type_from_data_request (const char *payload, int payload_length)
+{
+  int server_name_length = 0;
+  int client_type;
+  const char *ptr;
+
+  if (payload == NULL || payload_length <= 0)
+    {
+      return DB_CLIENT_TYPE_UNKNOWN;
+    }
+
+  while (server_name_length < payload_length && payload[server_name_length] != '\0')
+    {
+      server_name_length++;
+    }
+
+  if (server_name_length >= payload_length)
+    {
+      return DB_CLIENT_TYPE_UNKNOWN;
+    }
+  server_name_length++;
+
+  if (payload_length < server_name_length + CSS_CLIENT_TYPE_INFO_SIZE)
+    {
+      return DB_CLIENT_TYPE_UNKNOWN;
+    }
+
+  ptr = payload + server_name_length;
+  memcpy (&client_type, ptr, sizeof (client_type));
+
+  client_type = ntohl (client_type);
+
+  if (client_type < DB_CLIENT_TYPE_DEFAULT || client_type >= DB_CLIENT_TYPE_MAX)
+    {
+      return DB_CLIENT_TYPE_UNKNOWN;
+    }
+
+  return client_type;
+}
+
+/*
  * css_send_new_request_to_server() - Attempts to transfer a clients request
  *                                    to the server
  *   return: true if success
@@ -669,9 +717,10 @@ css_register_new_server2 (CSS_CONN_ENTRY * conn, unsigned short rid)
  *   rid(in)
  */
 static bool
-css_send_new_request_to_server (SOCKET server_fd, SOCKET client_fd, unsigned short rid, CSS_SERVER_REQUEST request)
+css_send_new_request_to_server (SOCKET server_fd, SOCKET client_fd, unsigned short rid, CSS_SERVER_REQUEST request,
+				int client_type)
 {
-  return (css_transfer_fd (server_fd, client_fd, rid, request));
+  return (css_transfer_fd (server_fd, client_fd, rid, request, client_type));
 }
 
 /*
@@ -696,11 +745,12 @@ css_send_to_existing_server (CSS_CONN_ENTRY * conn, unsigned short rid, CSS_SERV
 {
   SOCKET_QUEUE_ENTRY *temp;
   char *server_name = NULL;
-  int name_length, buffer;
+  int name_length, buffer, client_type;
 
   name_length = 1024;
   if (__gv_cvar.css_receive_data (conn, rid, &server_name, &name_length, -1) == NO_ERRORS && server_name != NULL)
     {
+      client_type = css_get_client_type_from_data_request (server_name, name_length);
       temp = css_return_entry_of_server (server_name, css_Master_socket_anchor);
       if (temp != NULL
 #if !defined(WINDOWS)
@@ -729,7 +779,7 @@ css_send_to_existing_server (CSS_CONN_ENTRY * conn, unsigned short rid, CSS_SERV
 		      return;
 		    }
 #endif
-		  if (css_send_new_request_to_server (temp->fd, conn->fd, rid, request))
+		  if (css_send_new_request_to_server (temp->fd, conn->fd, rid, request, client_type))
 		    {
 		      free_and_init (server_name);
 		      __gv_cvar.css_free_conn (conn);

--- a/src/executables/master.c
+++ b/src/executables/master.c
@@ -664,8 +664,8 @@ css_register_new_server2 (CSS_CONN_ENTRY * conn, unsigned short rid)
 /*
  * css_get_client_type_from_data_request() - unpack client type appended after server name
  *   return: client type if present and valid, DB_CLIENT_TYPE_UNKNOWN otherwise
- *   server_name(in):
- *   data_length(in):
+ *   payload(in):
+ *   payload_length(in):
  */
 static int
 css_get_client_type_from_data_request (const char *payload, int payload_length)

--- a/src/transaction/boot_cl.c
+++ b/src/transaction/boot_cl.c
@@ -1680,7 +1680,7 @@ boot_client_initialize_css (DB_INFO * db, int client_type, bool check_capabiliti
 	}
 
       er_log_debug (ARG_FILE_LINE, "trying to connect '%s@%s'\n", db->name, hostlist[n]);
-      error = net_client_init (db->name, hostlist[n]);
+      error = net_client_init (db->name, hostlist[n], client_type);
       if (error != NO_ERROR)
 	{
 	  if (error == ERR_CSS_TCP_CONNECT_TIMEDOUT)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26882>

### Purpose

cub_server는 각각 목적(client_type)에 따라 client 개수를 별도로 제한한다. 하지만, CUBRID의 구조가 아래와 같아 발생하는 레거시 이슈가 있다.
1. css_conn_entry를 freelist에서 꺼내온다.
2. 이후 handshake하며 client_type을 확인한다.
3. 이미 client_type에 맞는 client가 모두 붙어있다면 연결을 거부한다.

문제는 freelist가 max_clients + reserved만큼만 존재한다는 것이다. 따라서 연결 요청이 마구 들어오는 상황에서는 예약된 client가 붙을 수 없다. (ex. csql -u dba --sysadm demodb)
이전에는 놀랍게도 타이밍이 맞아 문제가 발생하지 않았지만 구조가 변경되며 타이밍이 엇갈려 발생한다. 따라서 client를 붙일 때 client_type을 먼저 확인한다.

### Implementation

아래 두 부분을 추가하였다.
1. client가 서버에 연결 요청을 보낼 때 client_type을 함께 보낸다.
2. cub_server 내의 master connector는 연결을 받기 전 client_type이 붙을 수 있는 지 확인한다.

### Remarks

N/A
