### PR TITLE
[CBRD-26949] JSP resultset double free

### DIFF
--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -9502,6 +9502,13 @@ ux_make_out_rs (DB_BIGINT query_id, T_NET_BUF * net_buf, T_REQ_INFO * req_info)
       new_handle_id = ux_create_srv_handle_with_method_query_result (qresult.result,
 								     qresult.stmt_type,
 								     qresult.num_column, column_info, true);
+      if (new_handle_id > 0)
+	{
+	  /* The new server handle now shares and owns this DB_QUERY_RESULT and frees it on its
+	   * teardown (ux_free_result). Detach it from the method query handler so the handler's
+	   * deferred end_qresult () does not free the same object again (double / dangling free). */
+	  query_handler->detach_result_for_out_rs ();
+	}
     }
 
   srv_handle = hm_find_srv_handle (new_handle_id);

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -9482,6 +9482,22 @@ ux_make_out_rs (DB_BIGINT query_id, T_NET_BUF * net_buf, T_REQ_INFO * req_info)
   if (query_handler != nullptr)
     {
       const cubmethod::query_result & qresult = query_handler->get_result ();
+      DB_QUERY_RESULT *rs_result = (DB_QUERY_RESULT *) qresult.result;
+
+      /* The cached DB_QUERY_RESULT may have been freed and its memory reused by another
+       * (e.g. CALL) result before this deferred fetch. Validate the live object type/status
+       * instead of trusting the cached stmt_type, otherwise a bogus 1-row(NULL) result is returned. */
+      if (rs_result == NULL || rs_result->type != T_SELECT || rs_result->status == T_CLOSED)
+	{
+	  err_code = ERROR_INFO_SET (CAS_ER_SRV_HANDLE, CAS_ERROR_INDICATOR);
+
+	  cas_log_write (0, false, "make_out_rs invalid result for query_id %lld type %d status %d %s%d",
+			 (long long) query_id, (rs_result != NULL) ? rs_result->type : -1,
+			 (rs_result != NULL) ? rs_result->status : -1, "error:", err_info.err_number);
+
+	  goto ux_make_out_rs_error;
+	}
+
       DB_QUERY_TYPE *column_info = db_get_query_type_list (query_handler->get_db_session (), qresult.stmt_id);
       new_handle_id = ux_create_srv_handle_with_method_query_result (qresult.result,
 								     qresult.stmt_type,

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -9516,9 +9516,8 @@ ux_make_out_rs (DB_BIGINT query_id, T_NET_BUF * net_buf, T_REQ_INFO * req_info)
 	}
       assert (new_handle_id > 0);	/* a created handle id is 1-based; 0 is never returned */
 
-      /* The new server handle now shares and solely owns this DB_QUERY_RESULT and frees it on its
-       * teardown (ux_free_result). Detach it from the method query handler so the handler's
-       * deferred end_qresult () does not free the same object again (double / dangling free). */
+      /* Detach the DB_QUERY_RESULT from the method query handler so the handler's
+       * deferred end_qresult () does not free the same object again (double free). */
       query_handler->detach_result_for_out_rs ();
     }
 

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -9502,13 +9502,17 @@ ux_make_out_rs (DB_BIGINT query_id, T_NET_BUF * net_buf, T_REQ_INFO * req_info)
       new_handle_id = ux_create_srv_handle_with_method_query_result (qresult.result,
 								     qresult.stmt_type,
 								     qresult.num_column, column_info, true);
-      if (new_handle_id > 0)
+      if (new_handle_id < 0)
 	{
-	  /* The new server handle now shares and owns this DB_QUERY_RESULT and frees it on its
-	   * teardown (ux_free_result). Detach it from the method query handler so the handler's
-	   * deferred end_qresult () does not free the same object again (double / dangling free). */
-	  query_handler->detach_result_for_out_rs ();
+	  err_code = new_handle_id;	/* preserve the specific error (e.g. MAX_PREPARED_STMT / NO_MORE_MEMORY) */
+	  goto ux_make_out_rs_error;
 	}
+      assert (new_handle_id > 0);	/* a created handle id is 1-based; 0 is never returned */
+
+      /* The new server handle now shares and solely owns this DB_QUERY_RESULT and frees it on its
+       * teardown (ux_free_result). Detach it from the method query handler so the handler's
+       * deferred end_qresult () does not free the same object again (double / dangling free). */
+      query_handler->detach_result_for_out_rs ();
     }
 
   srv_handle = hm_find_srv_handle (new_handle_id);
@@ -9628,6 +9632,12 @@ ux_make_out_rs (DB_BIGINT query_id, T_NET_BUF * net_buf, T_REQ_INFO * req_info)
 
   return 0;
 ux_make_out_rs_error:
+  if (new_handle_id > 0)
+    {
+      /* The server handle was created and (after detach_result_for_out_rs ()) solely owns the
+       * query result. Free it here so an error after its creation does not leak the handle/result. */
+      hm_srv_handle_free (new_handle_id);
+    }
   NET_BUF_ERR_SET (net_buf);
   return err_code;
 }

--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -9141,6 +9141,13 @@ ux_create_srv_handle_with_method_query_result (DB_QUERY_RESULT * result, int stm
   srv_handle->has_result_set = true;
   srv_handle->max_row = q_result->tuple_count;
 
+  if (is_holdable)
+    {
+      /* Keep symmetric with hm_qresult_end (), which decrements num_holdable_results when it frees
+       * a holdable result. Without this increment the counter underflows on teardown. */
+      as_info->num_holdable_results++;
+    }
+
   return srv_h_id;
 
 error:

--- a/src/method/method_callback.cpp
+++ b/src/method/method_callback.cpp
@@ -43,9 +43,6 @@
 #include "schema_manager.h"
 #include "network_callback_cl.hpp"
 
-extern int ux_create_srv_handle_with_method_query_result (DB_QUERY_RESULT *result, int stmt_type, int num_column,
-    DB_QUERY_TYPE *column_info, bool is_holdable);
-
 using namespace cubpl;
 
 static PT_NODE *

--- a/src/method/method_query_handler.cpp
+++ b/src/method/method_query_handler.cpp
@@ -187,6 +187,12 @@ namespace cubmethod
     return m_query_result;
   }
 
+  void
+  query_handler::detach_result_for_out_rs ()
+  {
+    m_query_result.result = NULL;
+  }
+
   int
   query_handler::prepare (std::string sql, int flag)
   {

--- a/src/method/method_query_handler.hpp
+++ b/src/method/method_query_handler.hpp
@@ -110,6 +110,12 @@ namespace cubmethod
 
       const query_result &get_result ();
 
+      /* Relinquish ownership of the current query result's DB_QUERY_RESULT.
+       * Called when the result has been handed off to an out-resultset server handle
+       * (ux_make_out_rs), which becomes the sole owner responsible for freeing it.
+       * Prevents a double free / dangling free by this handler's deferred end_qresult (). */
+      void detach_result_for_out_rs ();
+
       prepare_info &get_prepare_info ();
       execute_info &get_execute_info ();
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26949>

### Purpose

java.sql.ResultSet 을 리턴하는 JSP 를 JDBC 앱에서 호출했을 때 첫번째 결과만 정상이고, 두 번째 이후는 잘못된 결과가 리턴되는 문제를 해결하기 위함입니다. 
디버그 결과 result set 해당 메모리를 CAS 의 query_handler 가 svr_handle 애게 넘겨주고 난 후에도 계속 기억하고 있다가 query_handler의 deferred free 과정에서 svr_handle 이 이미 free하고 다른 유효한 결과가 기록된 그 주소를 free 하면서 발생한 문제로 파악되었습니다. 

### Implementation

query_handler 가 svr_handle 에게 result set을 넘겨주면서 해당 메모리 기록을 지워주고 deferred free 과정에서 메모리 해제를 하지 않도록 해 주었더니 문제가 재현되지 않았습니다. 

