### PR TITLE
[CBRD-26946] Fix multi-remote DBLink DML crash from over-counted server_node_cnt

### DIFF
--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -11274,7 +11274,10 @@ pt_get_server_name_list (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int
     }
 
   snl->server_cnt++;
-  for (int i = 0; i < snl->server_node_cnt; i++)
+  /* server[] has 2 slots, but server_node_cnt may be advanced past the number
+     of actually-stored slots by the dedup branches below. Bound the scan to
+     stored, non-NULL slots so it cannot dereference an unstored slot. */
+  for (int i = 0; i < snl->server_node_cnt && i < 2 && snl->server[i] != NULL; i++)
     {
       int node_cnt = 0;
 
@@ -11300,7 +11303,9 @@ pt_get_server_name_list (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int
 	}
     }
 
-  if (name_ptr != NULL)
+  /* only 2 slots exist; never store past them. An over-count is still rejected
+     by the server_node_cnt >= 2 multi-remote check downstream. */
+  if (name_ptr != NULL && snl->server_node_cnt < 2)
     {
       new_name = parser_new_node (parser, PT_NAME);
       new_name->info.name.original = pt_append_string (parser, NULL, name_ptr);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26946

### Purpose

서로 다른 원격 테이블 3개를 **혼합 owner 표기**로 참조하는 다중 테이블 `UPDATE`/`DELETE`가 클라이언트(csql)를 SIGSEGV로 크래시시키는 버그 수정.

**버그 재현:**
```sql
UPDATE remote_t@conn2 a, remote_t@conn3 b, remote_t@dba.repro_conn c
   SET a.name = b.name
 WHERE a.id = b.id AND a.id = c.id;
```

**원인:**
`pt_get_server_name_list` (`src/parser/parser_support.c`)에서 `server_node_cnt`가 두 역할을 겸한다 — 고정 2-슬롯 `server[]` 배열의 인덱스인 동시에, dedup(중복 서버 검사) 분기에서 `+= node_cnt`로 실제 저장한 슬롯 수보다 더 증가한다. `no-owner / no-owner / owner` 순서에서는 dedup 분기가 두 번째 서버를 저장하지 않은 채 `server_node_cnt`를 2로 올려 `server[1]`이 NULL로 남는다. 다음 spec 처리 시 dedup 스캔이 `i = 1`로 진입해 미저장 NULL 슬롯을 역참조하여 크래시가 발생한다.

### Implementation

`pt_get_server_name_list` (`src/parser/parser_support.c`) — 허용/거부 판정은 그대로 두고 가드 2개만 추가:

- **dedup 스캔을 저장된 non-NULL 슬롯으로 제한**:
  `for (i = 0; i < server_node_cnt && i < 2 && server[i] != NULL; i++)` — 미저장 슬롯을 절대 역참조하지 않도록.
- **2-슬롯 배열을 넘겨 저장하지 않음**:
  `if (name_ptr != NULL && server_node_cnt < 2)` — over-count가 배열 범위를 넘어 쓰지 않도록.

over-count는 하류의 기존 `server_node_cnt >= 2` 다중원격 검사에서 여전히 걸러지므로, 실제 다중원격 DML은 크래시 대신 `dblink: multi-remote DML is not allowed`로 보고된다.

### Remarks

- **범위**: 동작을 보존하는 최소 가드. 근본 설계 결함인 `server_node_cnt`의 이중 역할은 별도의 `develop` 전용 구조 정리로 남겨둔다(이중 역할을 합치는 프로토타입은 분석 문서 §7.2에 기록; 적용 전 owner/name 전수 조합 TC가 필요).
- **검증**: sanity suite A/C/D 모두 통과(single-remote push / same-server dedup / multi-remote 거부), mixed-owner 3-remote 재현은 이제 SIGSEGV 대신 거부 메시지로 정상 반환.
