### PR TITLE
[CBRD-26947] Prevent parallel hash join assert when parallelism=1

### DIFF
--- a/src/optimizer/plan_generation.c
+++ b/src/optimizer/plan_generation.c
@@ -2997,9 +2997,9 @@ qo_apply_parallel_index_scan_threshold (QO_PLAN * plan)
   has_hint = (select->info.query.q.select.hint & PT_HINT_PARALLEL) != 0;
   if (has_hint)
     {
-      /* PRM_ID_PARALLELISM=0 must veto hints; PARALLEL(N) otherwise bypasses global disable. */
+      /* Parallel index scan needs at least two threads after applying the global cap. */
       cap = prm_get_integer_value (PRM_ID_PARALLELISM);
-      if (cap <= 0 || spec->info.spec.num_parallel_threads <= 1)
+      if (cap <= 1 || spec->info.spec.num_parallel_threads <= 1)
 	{
 	  spec->info.spec.flag = (PT_SPEC_FLAG) (spec->info.spec.flag | PT_SPEC_FLAG_NO_PARALLEL_SCAN);
 	}
@@ -3055,7 +3055,7 @@ qo_apply_parallel_index_scan_threshold (QO_PLAN * plan)
     degree = (x <= 1) ? 2 : ((63 - __builtin_clzll (x)) + 2);
   }
   cap = prm_get_integer_value (PRM_ID_PARALLELISM);
-  if (cap <= 0)
+  if (cap <= 1)
     {
       spec->info.spec.flag = (PT_SPEC_FLAG) (spec->info.spec.flag | PT_SPEC_FLAG_NO_PARALLEL_SCAN);
       return;

--- a/src/query/parallel/px_parallel.cpp
+++ b/src/query/parallel/px_parallel.cpp
@@ -58,6 +58,7 @@ namespace parallel_query
 
     UINT32 page_threshold;
     UINT32 auto_degree;
+    UINT32 degree;
     const UINT32 start_degree = 2;
 
     if (system_core_count <= start_degree)
@@ -133,12 +134,14 @@ namespace parallel_query
 	/* hint first, ignore the parallelism parameter */
 	if (num_pages < (UINT64) hint_degree)
 	  {
-	    return num_pages;
+	    degree = (UINT32) num_pages;
 	  }
 	else
 	  {
-	    return hint_degree;
+	    degree = (UINT32) hint_degree;
 	  }
+
+	return (degree < start_degree) ? 0 : degree;
       }
     else
       {
@@ -167,6 +170,9 @@ namespace parallel_query
 #endif
     // *INDENT-ON*
 
-    return MIN (auto_degree, (UINT32) parallelism);
+    degree = MIN (auto_degree, (UINT32) parallelism);
+
+    /* SCAN/HASH_JOIN/SORT use 0 for serial execution and require at least 2 for real parallelism. */
+    return (degree < start_degree) ? 0 : degree;
   }
 }				/* namespace parallel_query */

--- a/src/query/parallel/px_parallel.cpp
+++ b/src/query/parallel/px_parallel.cpp
@@ -134,14 +134,12 @@ namespace parallel_query
 	/* hint first, ignore the parallelism parameter */
 	if (num_pages < (UINT64) hint_degree)
 	  {
-	    degree = (UINT32) num_pages;
+	    return num_pages;
 	  }
 	else
 	  {
-	    degree = (UINT32) hint_degree;
+	    return hint_degree;
 	  }
-
-	return (degree < start_degree) ? 0 : degree;
       }
     else
       {

--- a/src/query/query_hash_join.c
+++ b/src/query/query_hash_join.c
@@ -1971,6 +1971,7 @@ hjoin_try_parallel (THREAD_ENTRY * thread_p, HASHJOIN_MANAGER * manager, HASHJOI
     {
       /* try single-thread hash join */
       assert (degree == 0);
+      manager->num_parallel_threads = 0;
       assert (manager->px_worker_manager == NULL);
       return HASHJOIN_STATUS_PARTITION;
     }
@@ -2080,6 +2081,7 @@ hjoin_try_parallel_probe (THREAD_ENTRY * thread_p, HASHJOIN_MANAGER * manager, H
     {
       /* try single-thread hash join */
       assert (degree == 0);
+      manager->num_parallel_threads = 0;
       assert (manager->px_worker_manager == NULL);
       return HASHJOIN_STATUS_SINGLE;
     }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26947>

### Purpose

`parallelism=1` 설정에서 parallel hash join 대상 쿼리를 실행하면, hash join 실행 경로가 병렬 degree `1`을 유효한 실행 병렬도로 전달받아 debug build에서 assert 실패로 서버가 종료되는 문제를 수정합니다.

기존 parallel 실행 경로에서 `SCAN`, `HASH_JOIN`, `SORT`는 다음 의미 체계를 사용합니다.

```text
0    = serial execution
>= 2 = real parallel execution
```

하지만 `parallelism=1`인 경우 `compute_parallel_degree()`가 auto degree를 전역 parallelism cap으로 제한하면서 `1`을 반환할 수 있었습니다.

```sql
-- cubrid.conf
parallelism=1

-- hash join 대상 쿼리 실행
SELECT /*+ recompile */ COUNT(*)
FROM hj_probe p, hj_build b
WHERE p.k = b.k;
```

이 경우 hash join의 parallel probe 경로에서 `degree == 1`이 전달되고, debug build에서는 `hjoin_try_parallel_probe()`의 invariant 검사에서 assert가 발생합니다. release build에서는 assert가 제거되므로, `degree == 1`이 병렬 실행 경로로 들어갈 가능성을 미리 차단해야 합니다.

이번 수정에서는 `SCAN`, `HASH_JOIN`, `SORT`의 runtime degree 계산 결과가 `2` 미만이면 항상 serial fallback인 `0`으로 정규화합니다. 또한 hash join manager와 parallel index scan 쪽 상태도 같은 의미 체계를 따르도록 맞춥니다.

### Implementation

**`compute_parallel_degree()` 변경 (`src/query/parallel/px_parallel.cpp`)**

`SCAN`, `HASH_JOIN`, `SORT` 타입에서 계산된 degree가 `start_degree(2)`보다 작으면 `0`을 반환하도록 정규화했습니다.

- auto degree 경로에서 `MIN(auto_degree, parallelism)` 결과가 `1`이 되는 경우 `0`을 반환합니다.
- `SUBQUERY`는 기존 주석대로 degree `1`을 별도 의미로 사용하고 있으므로 동작을 변경하지 않았습니다.

이 변경으로 `parallelism=1`은 hash join/scan/sort에 대해 "1개 worker로 병렬 실행"이 아니라 "병렬 실행하지 않음"으로 처리됩니다.

**`hjoin_try_parallel()` / `hjoin_try_parallel_probe()` 변경 (`src/query/query_hash_join.c`)**

hash join runtime에서 `compute_parallel_degree()` 결과가 `2` 미만이면 serial fallback으로 진행합니다. 이때 `manager->num_parallel_threads`를 `0`으로 기록하도록 했습니다.

`manager->num_parallel_threads`는 처음에는 `xasl->parallelism`에서 온 요청값(`-1` auto, hint 값 등)을 담지만, parallel 시도 이후에는 실제 실행된 병렬도를 나타내는 상태값으로 사용됩니다.

- parallel worker 예약 성공: 실제 예약된 worker 수로 갱신
- parallel 미적용 또는 fallback: `0`으로 갱신

따라서 serial fallback 이후 trace/stat 쪽에서 auto 요청값 `-1`이나 유효하지 않은 degree `1`을 실제 실행 병렬도처럼 관측하지 않도록 상태를 확정합니다.

**`qo_apply_parallel_index_scan_threshold()` 변경 (`src/optimizer/plan_generation.c`)**

parallel index scan은 heap/list scan과 달리 server 실행 시 `compute_parallel_degree()`를 다시 호출하지 않고, optimizer가 `PT_SPEC`에 기록한 `num_parallel_threads`를 그대로 사용합니다.

따라서 optimizer 단계에서도 전역 `parallelism` cap이 `1` 이하이면 parallel index scan을 생성하지 않도록 했습니다.

- PARALLEL hint 경로: `cap <= 1` 또는 hint degree `<= 1`이면 `PT_SPEC_FLAG_NO_PARALLEL_SCAN` 설정
- auto parallel index scan 경로: `cap <= 1`이면 `PT_SPEC_FLAG_NO_PARALLEL_SCAN` 설정

이로써 hash join, heap/list scan, index scan 모두 `0 또는 >= 2`라는 parallel degree 의미 체계를 동일하게 따릅니다.
