### PR TITLE
[CBRD-26958] Declare DBLink @server remote string columns with the local codeset

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -5187,12 +5187,21 @@ pt_dblink_table_fill_attr_def (PARSER_CONTEXT * parser, PT_NODE * attr_def_node,
 
       dt->info.data_type.dec_precision = attr->dec_precision;
       dt->info.data_type.precision = attr->precision;
-      dt->info.data_type.units = attr->charset;
-      /* CCI remote-column metadata carries a codeset (units) but no collation;
-       * collation_id then defaults to 0 (LANG_COLL_ISO_BINARY), violating the
-       * pt_check_expr_collation invariant that equal collation_id implies equal
-       * codeset. Assign the codeset's binary collation to keep them consistent. */
-      dt->info.data_type.collation_id = LANG_GET_BINARY_COLLATION (attr->charset);
+      if (PT_HAS_COLLATION (attr_def_node->type_enum))
+	{
+	  /* DBLink converts the remote string to the LOCAL DB codeset at run time
+	   * (the codeset conversion in dblink_scan.c). Declare the column with that
+	   * local codeset/collation so compile-time type/collation checks match the
+	   * run-time value; attr->charset (remote) diverges and breaks UNION/IN. */
+	  dt->info.data_type.units = LANG_SYS_CODESET;
+	  dt->info.data_type.collation_id = LANG_GET_BINARY_COLLATION (LANG_SYS_CODESET);
+	}
+      else
+	{
+	  /* non-string (BIT/VARBIT/NUMERIC/...): codeset/collation are not semantically
+	   * used; keep the prior assignment. */
+	  dt->info.data_type.units = attr->charset;
+	}
     }
 
   attr_def_node->data_type = dt;

--- a/src/query/dblink_scan.c
+++ b/src/query/dblink_scan.c
@@ -1095,6 +1095,14 @@ dblink_scan_next (DBLINK_SCAN_INFO * scan_info, val_list_node * val_list)
 	}
       else
 	{
+	  /* DBLINK CODESET CONVERSION (remote -> local):
+	   * cci_value holds the value in the REMOTE codeset (it was built with
+	   * col_info[].charset above). The cast below coerces it into the output
+	   * slot's domain, which carries the LOCAL DB codeset -- so the run-time
+	   * value's codeset is CHANGED here from remote to local.
+	   * INVARIANT: the parse-tree column type (pt_dblink_table_fill_attr_def in
+	   * name_resolution.c) must be declared with this SAME local codeset/collation,
+	   * or compile-time type/collation checks diverge from this run-time value. */
 	  TP_DOMAIN dom;
 	  TP_DOMAIN_STATUS status;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26958

### Purpose

A `UNION` (or `IN` / comparison) of a local column with a remote string column referenced
via the **@server** syntax (`tbl@srv`) failed at semantic check, while the equivalent
**dblink() function** syntax returned the rows.

- 재현 환경: local `ko_KR.utf8` ↔ remote `ko_KR.euckr` (codeset 이 다른 경우).
- 보고된 질의:
  ```sql
  -- @server (실패): ERROR: '... collate euckr_bin' is not union compatible with ...
  select * from hangul_t1 union all select * from hangul_t1@srv2 order by a;

  -- dblink() 함수 (정상): 6행 반환
  select * from hangul_t1
  union all select * from dblink(srv2,'select * from hangul_t1') t(a int, b varchar) order by a;
  ```

### Implementation

**원인** — DBLink 는 fetch 시 원격 문자열 값을 **로컬 DB codeset 으로 변환**하므로(`dblink_scan.c`
의 cast) 런타임 값의 codeset 은 항상 로컬이다. 그러나 @server 용으로 자동 생성되는 파스트리
컬럼 타입(`pt_dblink_table_fill_attr_def`)은 **원격 codeset** 으로 선언돼 있었다:

| 단계 | 선언 codeset | 선언 collation |
|------|--------------|----------------|
| 기존 (pre-26870) | 원격(euckr) | 기본값 0 (iso88591_bin) — codeset 과 불일치 |
| CBRD-26870 | 원격(euckr) | 원격 codeset 의 binary (euckr_bin) — codeset 과 정합 |
| **본 PR** | **로컬(utf8)** | **로컬 codeset 의 binary (utf8_bin)** — 런타임 값과 정합 |

선언 codeset 이 원격이라 런타임 값(로컬)과 어긋나, 로컬 컬럼과 결합하는 collation 연산
(UNION/IN/비교)이 컴파일 단계에서 거부됐다. dblink() 함수 구문은 사용자 타입 목록으로
컬럼을 로컬 codeset 으로 선언하므로 영향이 없다.

**수정**
- `src/parser/name_resolution.c` `pt_dblink_table_fill_attr_def()`: 문자열 컬럼(`PT_HAS_COLLATION`
  = CHAR/VARCHAR)을 로컬 codeset/collation(`LANG_SYS_CODESET` /
  `LANG_GET_BINARY_COLLATION(LANG_SYS_CODESET)`)으로 선언. 비문자열(BIT/VARBIT/NUMERIC 등)은
  기존 동작 유지(`else`).
- `src/query/dblink_scan.c`: 원격→로컬 codeset 변환이 일어나는 cast 지점에, 변환 사실과
  "선언 타입도 로컬이어야 한다"는 invariant 를 명시하는 주석 추가(동작 변경 없음).

### Remarks

- 검증: 보고된 시나리오에서 @server·dblink() 함수 UNION 모두 정상 6행. 한글 데이터·ASCII
  데이터 모두 확인.
- 회귀: CBRD-26870 이 막았던 cross-codeset collation 연산(로컬 비-utf8 ← 원격 다른 codeset 의
  `=`/`||`)이 크래시·오결과 없이 동작함을 확인(게이트웨이 없이 CUBRID 원격으로 동등 재현).
- 본 수정은 26870 의 "DBLink 원격 컬럼 = codeset 의 binary collation" 방침을 유지하고 codeset
  만 원격→로컬로 바꾼 것이다. 원격 컬럼의 실제 collation 은 CCI 메타데이터에 노출되지 않으므로
  binary 가 유지된다(기존 한계 동일).