### PR TITLE
[CBRD-26805] Use SQL_NTS for MariaDB NUMERIC bind to drop trailing NUL causing FLOAT insert to fail

### DIFF
--- a/src/broker/cas_cgw_odbc.c
+++ b/src/broker/cas_cgw_odbc.c
@@ -1320,7 +1320,7 @@ cgw_set_bindparam (SQLHDBC hdbc, T_SRV_HANDLE * srv_handle, int bind_num, void *
 	    sql_bind_type = SQL_CHAR;
 
 	    value_list->string_val = value;
-	    value_list->cbValue = (SQLLEN) val_size;
+	    value_list->cbValue = SQL_NTS;
 
 	    SQL_CHK_ERR (srv_handle->cgw_hstmt,
 			 SQL_HANDLE_STMT,
@@ -1329,8 +1329,8 @@ cgw_set_bindparam (SQLHDBC hdbc, T_SRV_HANDLE * srv_handle, int bind_num, void *
 						      SQL_PARAM_INPUT,
 						      c_data_type,
 						      sql_bind_type,
-						      val_size + 1,
-						      0, value_list->string_val, val_size + 1, &value_list->cbValue));
+						      val_size - 1,
+						      0, value_list->string_val, val_size, &value_list->cbValue));
 	  }
 	else
 	  {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26805

### Purpose
cgw_set_bindparam() 함수에서 MariaDB NUMERIC 분기는 매개변수 표시기(cbValue)를 val_size로 설정했는데, 이 값 NULL 문자가 포함됩니다. (예: "1.98765432109876\0").
따라서 MariaDB의 문자열->FLOAT 변환이 실패하고 행이 삽입되지 않았습니다(SQLRowCount는 0을 반환함).

SQL_NTS를 사용하면 NULL 문자까지의 길이를 계산하여 FLOAT로 변환을 수행 합니다.
```
value_list->cbValue = SQL_NTS;
```

### Remarks
아래의 이슈에서 잘 못된 수정의로 인해 발생된 오류를 수정 합니다.
https://github.com/CUBRID/cubrid/pull/7257

