### PR TITLE
[CBRD-26818] Preserve OOS expansion copyarea ownership

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -26594,6 +26594,31 @@ heap_scan_get_visible_version (THREAD_ENTRY * thread_p, const OID * oid, OID * c
 }
 
 /*
+ * heap_prepare_recdes_copy_area () - Prepare storage for a COPY fetch through a heap get context.
+ *
+ * return: NO_ERROR or error code
+ *
+ * When recdes_p points to caller-owned storage, only reserve scan-cache area so
+ * that the caller buffer is not replaced.  When recdes_p is empty or already
+ * scan-cache-owned, bind recdes_p to the scan-cache area so later COPY and OOS
+ * expansion code can safely grow and refresh recdes_p->data.
+ */
+static int
+heap_prepare_recdes_copy_area (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context)
+{
+  assert (context != NULL);
+  assert (context->scan_cache != NULL);
+  assert (context->recdes_p != NULL);
+
+  if (context->data_externally_positioned)
+    {
+      return heap_scan_cache_allocate_area (thread_p, context->scan_cache, DB_PAGESIZE * 2);
+    }
+
+  return heap_scan_cache_allocate_recdes_data (thread_p, context->scan_cache, context->recdes_p, DB_PAGESIZE * 2);
+}
+
+/*
  * heap_get_visible_version_internal () - Retrieve the visible version of an object according to snapshot
  *
  *  return SCAN_CODE.
@@ -26621,7 +26646,7 @@ heap_get_visible_version_internal (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * c
   if (context->scan_cache && context->ispeeking == COPY && context->recdes_p != NULL)
     {
       /* Allocate an area to hold the object. Assume that the object will fit in two pages for not better estimates. */
-      if (heap_scan_cache_allocate_area (thread_p, context->scan_cache, DB_PAGESIZE * 2) != NO_ERROR)
+      if (heap_prepare_recdes_copy_area (thread_p, context) != NO_ERROR)
 	{
 	  return S_ERROR;
 	}
@@ -26834,7 +26859,7 @@ heap_get_last_version (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context)
   if (context->scan_cache && context->ispeeking == COPY)
     {
       /* Allocate an area to hold the object. Assume that the object will fit in two pages for not better estimates. */
-      if (heap_scan_cache_allocate_area (thread_p, context->scan_cache, DB_PAGESIZE * 2) != NO_ERROR)
+      if (heap_prepare_recdes_copy_area (thread_p, context) != NO_ERROR)
 	{
 	  return S_ERROR;
 	}
@@ -27003,7 +27028,10 @@ heap_init_get_context (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context, cons
   context->ispeeking = ispeeking;
   context->old_chn = old_chn;
   context->expand_oos = false;
-  context->data_externally_positioned = (recdes != NULL && recdes->data != NULL);
+  const bool data_is_scan_cache_area =
+    scan_cache != NULL && recdes != NULL && scan_cache->is_recdes_assigned_to_area (*recdes);
+  context->data_externally_positioned =
+    recdes != NULL && recdes->data != NULL && recdes->area_size >= 0 && !data_is_scan_cache_area;
   if (scan_cache != NULL && scan_cache->page_latch == X_LOCK)
     {
       context->latch_mode = PGBUF_LATCH_WRITE;

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -812,7 +812,12 @@ static SCAN_CODE heap_get_record_info (THREAD_ENTRY * thread_p, const OID oid, R
 				       DB_VALUE ** record_info);
 static SCAN_CODE heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * next_oid,
 				     RECDES * recdes, HEAP_SCANCACHE * scan_cache, bool ispeeking,
-				     bool reversed_direction, DB_VALUE ** cache_recordinfo, sampling_info * sampling);
+				     bool expand_oos, bool reversed_direction, DB_VALUE ** cache_recordinfo,
+				     sampling_info * sampling);
+static SCAN_CODE heap_scan_get_visible_version_impl (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid,
+						     RECDES * recdes, RECDES * peeked_recdes,
+						     HEAP_SCANCACHE * scan_cache, int ispeeking, int old_chn,
+						     bool expand_oos);
 
 static SCAN_CODE heap_get_page_info (THREAD_ENTRY * thread_p, const OID * cls_oid, const HFID * hfid, const VPID * vpid,
 				     const PAGE_PTR pgptr, DB_VALUE ** page_info);
@@ -7940,8 +7945,8 @@ heap_get_record_data_when_all_ready (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT *
  */
 static SCAN_CODE
 heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * next_oid, RECDES * recdes,
-		    HEAP_SCANCACHE * scan_cache, bool ispeeking, bool reversed_direction, DB_VALUE ** cache_recordinfo,
-		    sampling_info * sampling)
+		    HEAP_SCANCACHE * scan_cache, bool ispeeking, bool expand_oos, bool reversed_direction,
+		    DB_VALUE ** cache_recordinfo, sampling_info * sampling)
 {
   VPID vpid;
   VPID *vpidptr_incache;
@@ -8210,8 +8215,8 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
 	  scan_cache->cache_last_fix_page = true;
 
 	  scan =
-	    heap_scan_get_visible_version (thread_p, &oid, class_oid, recdes, &forward_recdes, scan_cache, ispeeking,
-					   NULL_CHN);
+	    heap_scan_get_visible_version_impl (thread_p, &oid, class_oid, recdes, &forward_recdes, scan_cache,
+						ispeeking, NULL_CHN, expand_oos);
 	  scan_cache->cache_last_fix_page = cache_last_fix_page_save;
 	}
 
@@ -20243,7 +20248,19 @@ SCAN_CODE
 heap_next (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * next_oid, RECDES * recdes,
 	   HEAP_SCANCACHE * scan_cache, int ispeeking)
 {
-  return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking, false, NULL, NULL);
+  return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking, false, false, NULL,
+			     NULL);
+}
+
+/*
+ * heap_next_expand_oos () - Retrieve or peek next object, expanding inline OOS OIDs.
+ */
+SCAN_CODE
+heap_next_expand_oos (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * next_oid, RECDES * recdes,
+		      HEAP_SCANCACHE * scan_cache, int ispeeking)
+{
+  return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking, true, false, NULL,
+			     NULL);
 }
 
 /*
@@ -20265,7 +20282,8 @@ SCAN_CODE
 heap_next_sampling (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * next_oid, RECDES * recdes,
 		    HEAP_SCANCACHE * scan_cache, int ispeeking, sampling_info * sampling)
 {
-  return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking, false, NULL, sampling);
+  return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking, false, false, NULL,
+			     sampling);
 }
 
 /*
@@ -20291,7 +20309,7 @@ SCAN_CODE
 heap_next_record_info (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * next_oid, RECDES * recdes,
 		       HEAP_SCANCACHE * scan_cache, int ispeeking, DB_VALUE ** cache_recordinfo)
 {
-  return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking, false,
+  return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking, false, false,
 			     cache_recordinfo, NULL);
 }
 
@@ -20314,7 +20332,8 @@ SCAN_CODE
 heap_prev (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * next_oid, RECDES * recdes,
 	   HEAP_SCANCACHE * scan_cache, int ispeeking)
 {
-  return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking, true, NULL, NULL);
+  return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking, false, true, NULL,
+			     NULL);
 }
 
 /*
@@ -20340,8 +20359,8 @@ SCAN_CODE
 heap_prev_record_info (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * next_oid, RECDES * recdes,
 		       HEAP_SCANCACHE * scan_cache, int ispeeking, DB_VALUE ** cache_recordinfo)
 {
-  return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking, true, cache_recordinfo,
-			     NULL);
+  return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking, false, true,
+			     cache_recordinfo, NULL);
 }
 
 /*
@@ -26487,7 +26506,8 @@ heap_get_visible_version_expand_oos (THREAD_ENTRY * thread_p, const OID * oid, O
 */
 static SCAN_CODE
 heap_scan_get_visible_version_impl (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid, RECDES * recdes,
-				    RECDES * peeked_recdes, HEAP_SCANCACHE * scan_cache, int ispeeking, int old_chn)
+				    RECDES * peeked_recdes, HEAP_SCANCACHE * scan_cache, int ispeeking, int old_chn,
+				    bool expand_oos)
 {
   SCAN_CODE scan = S_SUCCESS;
   HEAP_GET_CONTEXT context;
@@ -26506,11 +26526,11 @@ heap_scan_get_visible_version_impl (THREAD_ENTRY * thread_p, const OID * oid, OI
    * or the mvcc_snapshot does not satisfy, then carry out the necessary steps through
    * the heap_get_visible_version_internal() function.
    *
-   * Note: this shortcut returns peeked_recdes as-is, preserving any inline OOS OID slots.
-   * The scan path never expands OOS (callers that need expanded records use
-   * heap_get_visible_version_expand_oos instead), so no OOS guard is needed here.
+   * Note: this shortcut returns peeked_recdes as-is, preserving any inline OOS OID slots. Skip it when callers
+   * explicitly need an expanded raw record.
    */
-  if (peeked_recdes->type == REC_HOME && ispeeking == PEEK)
+  if (peeked_recdes->type == REC_HOME && ispeeking == PEEK
+      && (!expand_oos || !heap_recdes_contains_oos (peeked_recdes)))
     {
       MVCC_REC_HEADER mvcc_header = MVCC_REC_HEADER_INITIALIZER;
 
@@ -26556,6 +26576,7 @@ heap_scan_get_visible_version_impl (THREAD_ENTRY * thread_p, const OID * oid, OI
     }
 
   heap_init_get_context (thread_p, &context, oid, class_oid, recdes, scan_cache, ispeeking, old_chn);
+  context.expand_oos = expand_oos;
 
   scan = heap_get_visible_version_internal (thread_p, &context, true);
 
@@ -26569,7 +26590,7 @@ heap_scan_get_visible_version (THREAD_ENTRY * thread_p, const OID * oid, OID * c
 			       RECDES * peeked_recdes, HEAP_SCANCACHE * scan_cache, int ispeeking, int old_chn)
 {
   return heap_scan_get_visible_version_impl (thread_p, oid, class_oid, recdes, peeked_recdes, scan_cache, ispeeking,
-					     old_chn);
+					     old_chn, false);
 }
 
 /*
@@ -26982,6 +27003,7 @@ heap_init_get_context (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context, cons
   context->ispeeking = ispeeking;
   context->old_chn = old_chn;
   context->expand_oos = false;
+  context->data_externally_positioned = (recdes != NULL && recdes->data != NULL);
   if (scan_cache != NULL && scan_cache->page_latch == X_LOCK)
     {
       context->latch_mode = PGBUF_LATCH_WRITE;

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -26610,7 +26610,7 @@ heap_prepare_recdes_copy_area (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * conte
   assert (context->scan_cache != NULL);
   assert (context->recdes_p != NULL);
 
-  if (context->data_externally_positioned)
+  if (context->keep_recdes_buffer)
     {
       return heap_scan_cache_allocate_area (thread_p, context->scan_cache, DB_PAGESIZE * 2);
     }
@@ -27030,7 +27030,7 @@ heap_init_get_context (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context, cons
   context->expand_oos = false;
   const bool data_is_scan_cache_area =
     scan_cache != NULL && recdes != NULL && scan_cache->is_recdes_assigned_to_area (*recdes);
-  context->data_externally_positioned =
+  context->keep_recdes_buffer =
     recdes != NULL && recdes->data != NULL && recdes->area_size >= 0 && !data_is_scan_cache_area;
   if (scan_cache != NULL && scan_cache->page_latch == X_LOCK)
     {

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -382,7 +382,7 @@ struct heap_get_context
 				 * (like serial increment) require WRITE mode */
 
   bool expand_oos;		/* if true, replace inline OOS OID slots with actual values */
-  bool data_externally_positioned;	/* true if caller pre-positioned recdes_p->data before heap get */
+  bool keep_recdes_buffer;	/* true if recdes_p->data must not be rebound to scan cache */
 };
 
 typedef struct sampling_info SAMPLING_INFO;

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -382,6 +382,7 @@ struct heap_get_context
 				 * (like serial increment) require WRITE mode */
 
   bool expand_oos;		/* if true, replace inline OOS OID slots with actual values */
+  bool data_externally_positioned;	/* true if caller pre-positioned recdes_p->data before heap get */
 };
 
 typedef struct sampling_info SAMPLING_INFO;
@@ -428,6 +429,8 @@ extern void heap_scancache_end_modify (THREAD_ENTRY * thread_p, HEAP_SCANCACHE *
 extern SCAN_CODE heap_get_class_oid (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid);
 extern SCAN_CODE heap_next (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * next_oid,
 			    RECDES * recdes, HEAP_SCANCACHE * scan_cache, int ispeeking);
+extern SCAN_CODE heap_next_expand_oos (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
+				       OID * next_oid, RECDES * recdes, HEAP_SCANCACHE * scan_cache, int ispeeking);
 extern SCAN_CODE heap_next_sampling (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * next_oid,
 				     RECDES * recdes, HEAP_SCANCACHE * scan_cache, int ispeeking,
 				     sampling_info * sampling);

--- a/src/storage/heap_oos.cpp
+++ b/src/storage/heap_oos.cpp
@@ -253,7 +253,7 @@ heap_oos_build_record (THREAD_ENTRY *thread_p, HEAP_GET_CONTEXT *context, const 
 	  rec->length = - (state->new_length);
 	  return S_DOESNT_FIT;
 	}
-      if (context->ispeeking != PEEK && need_copy_realloc && context->data_externally_positioned)
+      if (context->ispeeking != PEEK && need_copy_realloc && context->keep_recdes_buffer)
 	{
 	  rec->length = - (state->new_length);
 	  return S_DOESNT_FIT;

--- a/src/storage/heap_oos.cpp
+++ b/src/storage/heap_oos.cpp
@@ -244,10 +244,16 @@ heap_oos_build_record (THREAD_ENTRY *thread_p, HEAP_GET_CONTEXT *context, const 
   RECDES *rec = context->recdes_p;
   const int dst_offset_size = BIG_VAR_OFFSET_SIZE;
 
-  const bool need_realloc = (context->ispeeking == PEEK) || (rec->area_size < state->new_length);
+  const bool need_copy_realloc = (rec->area_size < state->new_length);
+  const bool need_realloc = (context->ispeeking == PEEK) || need_copy_realloc;
   if (need_realloc)
     {
       if (context->scan_cache == NULL)
+	{
+	  rec->length = - (state->new_length);
+	  return S_DOESNT_FIT;
+	}
+      if (context->ispeeking != PEEK && need_copy_realloc && context->data_externally_positioned)
 	{
 	  rec->length = - (state->new_length);
 	  return S_DOESNT_FIT;

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -2903,7 +2903,7 @@ xlocator_fetch_all (THREAD_ENTRY * thread_p, const HFID * hfid, LOCK * lock, LC_
       mobjs->num_objs = 0;
       offset = 0;
 
-      while ((scan = heap_next (thread_p, hfid, class_oid, &oid, &recdes, &scan_cache, COPY)) == S_SUCCESS)
+      while ((scan = heap_next_expand_oos (thread_p, hfid, class_oid, &oid, &recdes, &scan_cache, COPY)) == S_SUCCESS)
 	{
 	  mobjs->num_objs++;
 	  COPY_OID (&obj->class_oid, class_oid);
@@ -12097,6 +12097,10 @@ xlocator_lock_and_fetch_all (THREAD_ENTRY * thread_p, const HFID * hfid, LOCK * 
 
       while (true)
 	{
+	  OID prev_oid;
+
+	  COPY_OID (&prev_oid, &oid);
+
 	  if (instance_lock && (*instance_lock != NULL_LOCK))
 	    {
 	      int lock_result = 0;
@@ -12128,6 +12132,14 @@ xlocator_lock_and_fetch_all (THREAD_ENTRY * thread_p, const HFID * hfid, LOCK * 
 		heap_get_visible_version_expand_oos (thread_p, &oid, class_oid, &recdes, &scan_cache, COPY, NULL_CHN);
 	      if (scan != S_SUCCESS)
 		{
+		  if (scan == S_DOESNT_FIT)
+		    {
+		      if (mobjs->num_objs == 0)
+			{
+			  COPY_OID (&oid, &prev_oid);
+			}
+		      break;
+		    }
 		  (*nfailed_instance_locks)++;
 		  continue;
 		}
@@ -12135,7 +12147,7 @@ xlocator_lock_and_fetch_all (THREAD_ENTRY * thread_p, const HFID * hfid, LOCK * 
 	    }
 	  else
 	    {
-	      scan = heap_next (thread_p, hfid, class_oid, &oid, &recdes, &scan_cache, COPY);
+	      scan = heap_next_expand_oos (thread_p, hfid, class_oid, &oid, &recdes, &scan_cache, COPY);
 	      if (scan != S_SUCCESS)
 		{
 		  break;

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -12017,9 +12017,11 @@ xlocator_lock_and_fetch_all (THREAD_ENTRY * thread_p, const HFID * hfid, LOCK * 
   int round_length;		/* Length of object rounded to integer alignment */
   int copyarea_length;
   OID oid;
+  OID prev_oid;
   HEAP_SCANCACHE scan_cache;
   SCAN_CODE scan;
   int error_code = NO_ERROR;
+  bool retry_current_oid;
 
   if (fetch_area == NULL)
     {
@@ -12094,11 +12096,10 @@ xlocator_lock_and_fetch_all (THREAD_ENTRY * thread_p, const HFID * hfid, LOCK * 
       obj = LC_START_ONEOBJ_PTR_IN_COPYAREA (mobjs);
       mobjs->num_objs = 0;
       offset = 0;
+      retry_current_oid = false;
 
       while (true)
 	{
-	  OID prev_oid;
-
 	  COPY_OID (&prev_oid, &oid);
 
 	  if (instance_lock && (*instance_lock != NULL_LOCK))
@@ -12134,10 +12135,7 @@ xlocator_lock_and_fetch_all (THREAD_ENTRY * thread_p, const HFID * hfid, LOCK * 
 		{
 		  if (scan == S_DOESNT_FIT)
 		    {
-		      if (mobjs->num_objs == 0)
-			{
-			  COPY_OID (&oid, &prev_oid);
-			}
+		      retry_current_oid = true;
 		      break;
 		    }
 		  (*nfailed_instance_locks)++;
@@ -12177,6 +12175,12 @@ xlocator_lock_and_fetch_all (THREAD_ENTRY * thread_p, const HFID * hfid, LOCK * 
 	{
 	  break;
 	}
+
+      if (retry_current_oid)
+	{
+	  COPY_OID (&oid, &prev_oid);
+	}
+
       /*
        * The first object does not fit into given copy area
        * Get a larger area


### PR DESCRIPTION
https://jira.cubrid.org/browse/CBRD-26818

## Purpose

OOS 값을 읽어 올 때, 이미 정해진 저장 위치를 중간에 바꾸지 않도록 고쳤습니다.

쉽게 말하면, `locator` 는 데이터를 담을 상자(copyarea)를 먼저 만들어 두고 heap 에게 "여기에 데이터를 넣어줘"라고 요청합니다. 그런데 OOS 값을 실제 데이터로 펼치는 과정에서 데이터가 생각보다 커지면, 기존 코드는 그 상자가 아니라 다른 임시 공간(scan cache)에 데이터를 넣을 수 있었습니다.

그러면 `locator` 는 "데이터가 상자 안에 있다"고 생각하지만, 실제 데이터는 다른 곳에 있게 됩니다. 이 차이 때문에 JSON 값을 읽거나 unloaddb 로 데이터를 빼낼 때 문제가 날 수 있었습니다.

이번 수정은 다음 규칙을 지키게 합니다.

- caller 가 이미 데이터 위치를 정해 두었다면 heap 이 그 위치를 마음대로 바꾸지 않습니다.
- 공간이 부족하면 다른 곳에 몰래 넣지 않고 `S_DOESNT_FIT` 을 돌려줍니다.
- 그러면 위쪽 코드가 더 큰 copyarea 를 만들고 같은 데이터를 다시 읽습니다.

## Why

OOS 는 큰 값을 record 밖에 따로 저장했다가, 필요할 때 다시 record 안의 실제 값처럼 펼쳐서 읽습니다.

이때 펼친 결과가 원래 예상보다 커질 수 있습니다. 그 경우에도 데이터가 어디에 들어갔는지에 대한 약속은 깨지면 안 됩니다. 특히 fetch-all, unloaddb 처럼 record 전체를 copyarea 에 담아 보내는 코드는 이 약속에 의존합니다.

## Implementation

- `HEAP_GET_CONTEXT` 에 `data_externally_positioned` 를 추가했습니다.
- OOS 확장 중 copyarea 위치를 유지해야 하는 경우, 버퍼를 scan cache 로 바꾸지 않고 `S_DOESNT_FIT` 을 반환하게 했습니다.
- OOS 값을 펼친 record 를 받아야 하는 scan 경로를 위해 `heap_next_expand_oos` 를 추가했습니다.
- copyarea 가 부족해서 재시도할 때 같은 객체를 다시 읽도록 cursor 처리도 맞췄습니다.

## Remarks

- JIRA: https://jira.cubrid.org/browse/CBRD-26818
- Notes: https://github.com/vimkim/my-cubrid-docs/blob/main/cbrd-26818/CBRD-26818-oos-expansion-copyarea-ownership.md

## Tests

- `just build`
- CBRD-26818 JSON update 재현 테스트
  - `alter table t add column i int; update t set i = 1;`
  - 결과: `json_length(j) = 50000`
- CBRD-25481 JSON unloaddb/reload 재현 테스트
  - 기존 JSON deserialize assertion 없이 완료
  - reload 전후 `char_length(a) = 1108895` 일치