### PR TITLE
[CBRD-26963] Schema context becomes polluted on reconnect and is used as-is

### DIFF
--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -521,6 +521,20 @@ sc_current_schema_owner (void)
   return Current_Schema.owner;
 }
 
+/*
+ * sc_clear_current_schema()
+ *   return: void
+ *
+ * Note :
+ *   Clears the owner and name of the current schema.
+ */
+void
+sc_clear_current_schema (void)
+{
+  Current_Schema.owner = NULL;
+  Current_Schema.name[0] = '\0';
+}
+
 
 /*
  * sm_add_static_method() - Adds an element to the static link table.
@@ -2084,6 +2098,9 @@ void
 sm_final ()
 {
   SM_DESCRIPTOR *d, *next;
+
+  /* Clear the current schema before ws_final () frees the owner MOP. */
+  sc_clear_current_schema ();
 
 #if defined(WINDOWS)
   /* unload any DLL's we may have opened for methods */

--- a/src/object/schema_manager.h
+++ b/src/object/schema_manager.h
@@ -318,6 +318,7 @@ extern int classobj_drop_foreign_key_ref (DB_SEQ ** properties, const BTID * bti
 extern int sc_set_current_schema (MOP user);
 extern const char *sc_current_schema_name (void);
 extern MOP sc_current_schema_owner (void);
+extern void sc_clear_current_schema (void);
 /* Obtain (pointer to) current schema name. */
 
 extern int sm_has_non_null_attribute (SM_ATTRIBUTE ** attrs);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26963

### Purpose

CAS 프로세스 전역 변수 `Current_Schema`가 연결 종료 시 초기화되지 않아, 재사용된 CAS에서 이전 연결의 schema 정보가 잔류한다. 종료 시 `Current_Schema`를 초기화한다.

### Implementation

- `sc_clear_current_schema ()` 추가 — `Current_Schema`의 owner와 name을 clear.
- `sm_final ()`에서 호출하여 종료 시 dangling 포인터 잔여를 방지.

### Remarks

N/A

---

Clear `Current_Schema` in `sm_final ()` to prevent reconnect schema pollution.
