### PR TITLE
[CBRD-26960] Scale object-lock hash bucket count with lock_escalation

### DIFF
--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -85,6 +85,13 @@
   ((OID_ISTEMP(oid)) ? (unsigned int)(-((oid)->pageid) % htsize) :\
                        lock_get_hash_value(oid, htsize))
 
+/* Object-lock hash bucket count = num_trans * k * lock_escalation, clamped to
+ * [initial_object_locks, LK_OBJ_HASH_SIZE_MAX = 2^23 buckets = 64 MB at 8 B/slot].
+ * k = 3/1000 reproduces the legacy num_trans * 300 at the default lock_escalation. */
+#define LK_OBJ_HASH_SIZE_RATIO_NUM 3
+#define LK_OBJ_HASH_SIZE_RATIO_DEN 1000
+#define LK_OBJ_HASH_SIZE_MAX (1 << 23)
+
 /* thread is lock-waiting ? */
 #define LK_IS_LOCKWAIT_THREAD(thrd) \
   ((thrd)->lockwait != NULL \
@@ -130,7 +137,6 @@ struct lk_config
   int initial_object_locks;
   int object_res_block_count;
   int object_entry_block_count;
-  int min_object_locks;
   float object_res_ratio;
   float object_entry_ratio;
   int object_res_block_size;
@@ -1148,7 +1154,6 @@ lock_make_default_config (void)
   config.initial_object_locks = 10000;
   config.object_res_block_count = 2;
   config.object_entry_block_count = 1;
-  config.min_object_locks = MAX_NTRANS * 300;
   config.object_res_ratio = 0.1f;
   config.object_entry_ratio = 0.1f;
 
@@ -1193,7 +1198,6 @@ lock_make_runtime_config (void)
 
   /* Derived sizing. */
   runtime_config.max_twfg_edge_count = runtime_config.num_trans * runtime_config.num_trans;
-  runtime_config.min_object_locks = runtime_config.num_trans * 300;
   runtime_config.object_res_block_size =
     (int) MAX ((runtime_config.initial_object_locks * runtime_config.object_res_ratio) /
 	       runtime_config.object_res_block_count, 1);
@@ -1246,14 +1250,19 @@ lock_make_runtime_config (void)
 static int
 lock_initialize_object_lock_structures (void)
 {
-  const int obj_hash_size = MAX (lk_Gl.config.initial_object_locks, lk_Gl.config.min_object_locks);
+  /* Size the bucket array from lock_escalation (CBRD-26960); 64-bit intermediate avoids
+   * overflow, the clamp keeps the result within int. */
+  const int lock_escalation = prm_get_integer_value (PRM_ID_LK_ESCALATION_AT);
+  const INT64 scaled_buckets =
+    (INT64) lk_Gl.config.num_trans * lock_escalation * LK_OBJ_HASH_SIZE_RATIO_NUM / LK_OBJ_HASH_SIZE_RATIO_DEN;
+  const int obj_hash_size = (int) MAX (lk_Gl.config.initial_object_locks, MIN (scaled_buckets, LK_OBJ_HASH_SIZE_MAX));
 
-  lk_Obj_lock_res_desc.max_alloc_cnt = prm_get_integer_value (PRM_ID_LK_ESCALATION_AT);
+  lk_Obj_lock_res_desc.max_alloc_cnt = lock_escalation;
   lk_Gl.m_obj_hash_table.init (obj_lock_res_Ts, THREAD_TS_OBJ_LOCK_RES, obj_hash_size,
 			       lk_Gl.config.object_res_block_size, lk_Gl.config.object_res_block_count,
 			       lk_Obj_lock_res_desc);
 
-  obj_lock_entry_desc.max_alloc_cnt = prm_get_integer_value (PRM_ID_LK_ESCALATION_AT);
+  obj_lock_entry_desc.max_alloc_cnt = lock_escalation;
   if (lf_freelist_init (&lk_Gl.obj_free_entry_list, lk_Gl.config.object_entry_block_count,
 			lk_Gl.config.object_entry_block_size, &obj_lock_entry_desc, &obj_lock_ent_Ts) != NO_ERROR)
     {

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -88,8 +88,7 @@
 /* Object-lock hash bucket count = num_trans * k * lock_escalation, clamped to
  * [initial_object_locks, LK_OBJ_HASH_SIZE_MAX = 2^23 buckets = 64 MB at 8 B/slot].
  * k = 3/1000 reproduces the legacy num_trans * 300 at the default lock_escalation. */
-#define LK_OBJ_HASH_SIZE_RATIO_NUM 3
-#define LK_OBJ_HASH_SIZE_RATIO_DEN 1000
+#define LK_OBJ_HASH_SIZE_RATIO (3/1000)
 #define LK_OBJ_HASH_SIZE_MAX (1 << 23)
 
 /* thread is lock-waiting ? */
@@ -1251,7 +1250,8 @@ static int
 lock_initialize_object_lock_structures (void)
 {
   /* Size the bucket array from lock_escalation (CBRD-26960); 64-bit intermediate avoids
-   * overflow, the clamp keeps the result within int. */
+   * overflow, the clamp keeps the result within int. Sized at boot only: changing
+   * lock_escalation online does not resize this array. */
   const int lock_escalation = prm_get_integer_value (PRM_ID_LK_ESCALATION_AT);
   const INT64 scaled_buckets =
     (INT64) lk_Gl.config.num_trans * lock_escalation * LK_OBJ_HASH_SIZE_RATIO_NUM / LK_OBJ_HASH_SIZE_RATIO_DEN;

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -88,7 +88,8 @@
 /* Object-lock hash bucket count = num_trans * k * lock_escalation, clamped to
  * [initial_object_locks, LK_OBJ_HASH_SIZE_MAX = 2^23 buckets = 64 MB at 8 B/slot].
  * k = 3/1000 reproduces the legacy num_trans * 300 at the default lock_escalation. */
-#define LK_OBJ_HASH_SIZE_RATIO (3/1000)
+#define LK_OBJ_HASH_SIZE_RATIO_NUM 3
+#define LK_OBJ_HASH_SIZE_RATIO_DEN 1000
 #define LK_OBJ_HASH_SIZE_MAX (1 << 23)
 
 /* thread is lock-waiting ? */


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26960>

### Purpose

The object-lock hash table sized its bucket array from a fixed constant,
`MAX(initial_object_locks = 10000, MAX_NTRANS * 300)`. The `300` assumes ~300
instance locks per transaction and ignores `lock_escalation`, which is the real
per-(transaction, class) ceiling on instance locks. When an operator raises
`lock_escalation`, a transaction can accumulate proportionally more instance
locks while the bucket count stays fixed, so the object-lock hash chains grow in
proportion and every lock acquire/release slows down
(`O(chain) = O(live_locks / buckets)`).

This is the sizing-side mitigation for CBRD-26826 (object-lock hash chain walk).
It is independent of, and complementary to, the structural replacement
(split-ordered lock table) and the population-side reduction (CBRD-26942, INSERT
lock decouple).

### Implementation

Replace the fixed bucket term with an escalation-scaled formula in
`lock_initialize_object_lock_structures` (`src/transaction/lock_manager.c`):

```
obj_hash_size = MAX(initial_object_locks,
                    MIN(num_trans * k * lock_escalation, CAP))
```

- `k = LK_OBJ_HASH_SIZE_RATIO_NUM / LK_OBJ_HASH_SIZE_RATIO_DEN = 3 / 1000 = 0.003`.
  Reproduces the legacy `num_trans * 300` at the default `lock_escalation`
  (100000), so the default configuration is byte-for-byte unchanged.
- `CAP = LK_OBJ_HASH_SIZE_MAX = 2^23` buckets (64 MB at 8 B/slot). Bounds the
  always-allocated bucket array for raised-escalation / high `max_clients`.
- Both `k` and `CAP` are internal constants; no new `cubrid.conf` parameter.
- `lock_escalation` is already read here for the freelist `max_alloc_cnt`; it is
  now read once and reused. The scaled term uses a 64-bit intermediate to avoid
  overflow when `num_trans` and `lock_escalation` are both large; the clamped
  result fits in `int`.
- The now-unused `min_object_locks` config field and its two assignments are removed.

### Remarks

Verification:
- Default configuration unchanged (regression 0): `obj_hash_size` equals the
  legacy `MAX(10000, num_trans * 300)` for `max_clients` 100 (30,300) and 1000
  (300,300). Confirmed by the integer arithmetic and a server-boot smoke test.
- Raised `lock_escalation = 100000000` clamps to `CAP` (8,388,608 buckets); the
  server boots and INSERT/UPDATE/SELECT run. `lock_escalation = 1` falls back to
  the floor (10,000). No 32-bit overflow at `lock_escalation = 2e9`.

Scope (what this does and does not bound):
- Bounds chains for **escalatable** workloads (UPDATE / DELETE / SELECT ... FOR
  UPDATE) whose per-transaction lock count is governed by `lock_escalation`. For
  a raised-escalation configuration this is where chains silently grew.
- **bulk / INSERT** lock accumulation bypasses escalation (BU_LOCK) and is not
  bounded by this change; that population is addressed by CBRD-26942 and the
  structural work under CBRD-26826.
