### PR TITLE
[CBRD-26963] Schema context becomes polluted on reconnect and is used as-is (#7339)

### DIFF
--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -516,6 +516,20 @@ sc_current_schema_owner (void)
   return Current_Schema.owner;
 }
 
+/*
+ * sc_clear_current_schema()
+ *   return: void
+ *
+ * Note :
+ *   Clears the owner and name of the current schema.
+ */
+void
+sc_clear_current_schema (void)
+{
+  Current_Schema.owner = NULL;
+  Current_Schema.name[0] = '\0';
+}
+
 
 /*
  * sm_add_static_method() - Adds an element to the static link table.
@@ -2079,6 +2093,9 @@ void
 sm_final ()
 {
   SM_DESCRIPTOR *d, *next;
+
+  /* Clear the current schema before ws_final () frees the owner MOP. */
+  sc_clear_current_schema ();
 
 #if defined(WINDOWS)
   /* unload any DLL's we may have opened for methods */

--- a/src/object/schema_manager.h
+++ b/src/object/schema_manager.h
@@ -317,6 +317,7 @@ extern int classobj_drop_foreign_key_ref (DB_SEQ ** properties, const BTID * bti
 extern int sc_set_current_schema (MOP user);
 extern const char *sc_current_schema_name (void);
 extern MOP sc_current_schema_owner (void);
+extern void sc_clear_current_schema (void);
 /* Obtain (pointer to) current schema name. */
 
 extern int sm_has_non_null_attribute (SM_ATTRIBUTE ** attrs);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26963

backport #7339