### PR TITLE
[CBRD-26965] 병렬 힙스캔 buildvalue 집계의 MIN/MAX(문자열) 질의 취소 시 cross-allocator free로 서버 크래시

### DIFF
--- a/src/query/parallel/px_scan/px_scan_result_handler.cpp
+++ b/src/query/parallel/px_scan/px_scan_result_handler.cpp
@@ -950,17 +950,37 @@ namespace parallel_scan
       }
   }
 
+  void clear_agg_accumulators_on_0_heap_id (THREAD_ENTRY *thread_p, AGGREGATE_TYPE *agg_list)
+  {
+    HL_HEAPID save_heap = db_change_private_heap (thread_p, 0);
+    for (AGGREGATE_TYPE *agg_node = agg_list; agg_node != NULL; agg_node = agg_node->next)
+      {
+	if (agg_node->accumulator.value != nullptr)
+	  {
+	    pr_clear_value (agg_node->accumulator.value);
+	  }
+	if (agg_node->accumulator.value2 != nullptr)
+	  {
+	    pr_clear_value (agg_node->accumulator.value2);
+	  }
+      }
+    db_change_private_heap (thread_p, save_heap);
+  }
+
   SCAN_CODE result_handler<RESULT_TYPE::BUILDVALUE_OPT>::read (THREAD_ENTRY *thread_p, AGGREGATE_TYPE *dest)
   {
     std::unique_lock<std::mutex> lock (m_result_mutex);
     while (m_result_completed < m_parallelism)
       {
 	m_result_cv.wait_for (lock, std::chrono::microseconds (50));
-	if (m_interrupt_p->get_code() != parallel_query::interrupt::interrupt_code::NO_INTERRUPT)
-	  {
-	    return S_ERROR;
-	  }
       }
+
+    if (m_interrupt_p->get_code() != parallel_query::interrupt::interrupt_code::NO_INTERRUPT)
+      {
+	clear_agg_accumulators_on_0_heap_id (thread_p, m_orig_agg_list);
+	return S_ERROR;
+      }
+
     for (AGGREGATE_TYPE *orig_agg_p = m_orig_agg_list; orig_agg_p != NULL; orig_agg_p = orig_agg_p->next)
       {
 	/* COUNT_STAR/DISTINCT already finalized upstream; COUNT needs curr_cnt→BIGINT, others need value clone. */
@@ -1488,11 +1508,6 @@ namespace parallel_scan
 	}
     }
 
-    {
-      std::lock_guard<std::mutex> lock (m_result_mutex);
-      m_result_completed++;
-      m_result_cv.notify_all ();
-    }
     tl_outptr_list_p = nullptr;
     tl_agg_p = nullptr;
     tl_vd = nullptr;
@@ -1503,6 +1518,13 @@ namespace parallel_scan
 	tl_tpl_buf.tpl = nullptr;
       }
     tl_tpl_buf.size = 0;
+  }
+
+  void result_handler<RESULT_TYPE::BUILDVALUE_OPT>::signal_worker_done ()
+  {
+    std::lock_guard<std::mutex> lock (m_result_mutex);
+    m_result_completed++;
+    m_result_cv.notify_all ();
   }
 
   /* Explicit template instantiations */

--- a/src/query/parallel/px_scan/px_scan_result_handler.hpp
+++ b/src/query/parallel/px_scan/px_scan_result_handler.hpp
@@ -239,6 +239,7 @@ namespace parallel_scan
 			     xasl_node *xasl_p);
       bool write (THREAD_ENTRY *thread_p);
       void write_finalize (THREAD_ENTRY *thread_p);
+      void signal_worker_done ();
     private:
       int m_parallelism;
       std::mutex m_result_mutex;

--- a/src/query/parallel/px_scan/px_scan_task.cpp
+++ b/src/query/parallel/px_scan/px_scan_task.cpp
@@ -34,6 +34,7 @@
 #include "memoize.hpp"
 #include "scan_manager.h"
 #include "partition_sr.h"
+#include "scope_exit.hpp"
 
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
 #include "memory_wrapper.hpp"
@@ -44,6 +45,13 @@ namespace parallel_scan
   void task<result_type, ST>::execute (cubthread::entry &thread_ref)
   {
     int err_code;
+    auto done_guard = make_scope_exit ([this] ()
+    {
+      if constexpr (result_type == RESULT_TYPE::BUILDVALUE_OPT)
+	{
+	  m_result_handler->signal_worker_done ();
+	}
+    });
     err_code = initialize (thread_ref);
     if (err_code != NO_ERROR)
       {


### PR DESCRIPTION
https://jira.cubrid.org/browse/CBRD-26965

## Description

병렬 BUILDVALUE_OPT(병렬 스칼라 집계 최적화) 경로에서 각 worker(부분 스캔을 수행하는 병렬 스레드)는 부분 집계를 자기 XASL clone의 accumulator에 모은 뒤, `write_finalize()`에서 `db_change_private_heap(thread_p, 0)` 하에 root accumulator(`m_orig_agg_list`)로 병합한다. CUBRID의 private heap(`heaplayers`의 lock-free `mspace`, `USE_LOCKS 0`)은 다른 스레드가 직접 alloc/free 할 수 없으므로, 병합 시 thread-safe한 glibc malloc(heap 0)을 거친다.

성공 경로에서는 coordinator의 `read()`가 이 heap-0 버퍼를 자기 private heap으로 복제·교체(re-home)하므로, 이후 `qexec_clear_xasl` teardown이 private heap으로 정상 해제한다.

취소·에러(interrupt) 경로에서는 기존 `read()`가 re-home 루프에 도달하기 전에 `return S_ERROR` 했다. 그 결과 root accumulator에 glibc 버퍼가 그대로 남았고, teardown(`qexec_clear_agg_list` → `pr_clear_value` → `mspace_free`)이 그 버퍼를 private mspace로 해제하다 `FOOTERS 0` dlmalloc의 foreign-pointer 검사(`ok_address`/`ok_cinuse`)에 걸려 abort 했다. double-free가 아니라 allocator 불일치 해제다.

## Implementation

- `px_scan_result_handler.cpp` `read()`: 대기 루프에서 interrupt early-return을 제거해 모든 worker가 `write_finalize`까지 끝날 때까지 대기하도록 변경. 루프 종료 후 interrupt면 새 헬퍼 `clear_agg_accumulators_on_0_heap_id()`로 `m_orig_agg_list`의 `accumulator.value`/`value2`를 `db_change_private_heap(thread_p, 0)` 하에 `pr_clear_value`로 해제. `pr_clear_value`가 버퍼 포인터를 NULL로 비우므로 뒤따르는 `qexec_clear_agg_list`는 no-op이 된다.
- `px_scan_result_handler.cpp`: worker 완료 카운터 증가(`m_result_completed++` + `notify`)를 `write_finalize()`에서 제거하고 새 메서드 `signal_worker_done()`으로 이동.
- `px_scan_task.cpp` `execute()`: 최상단에 `scope_exit` 가드를 추가해 `initialize()` 실패 early-return을 포함한 모든 종료 경로에서 `signal_worker_done()`을 1회 호출. interrupt early-return을 없앤 뒤 생길 수 있는 "worker가 `initialize()`에서 실패해 카운터를 못 올리면 `read()`가 무한 대기(hang)"하는 회귀를 차단한다. `if constexpr (result_type == RESULT_TYPE::BUILDVALUE_OPT)`로 해당 경로에만 적용.
- `px_scan_result_handler.hpp`: `signal_worker_done()` 선언 추가.
