### PR TITLE
[CBRD-26977] make the number of worker limit to global and change the policy

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -24,6 +24,7 @@
 
 #include "config.h"
 
+#include <algorithm>
 #include <stdio.h>
 #include <stdlib.h>
 #include <limits.h>
@@ -5218,7 +5219,7 @@ SYSPRM_PARAM prm_Def[] = {
    /* set the default to twice the value of MAX_REQUEST_CONCURRENCY */
    {false, {.i = (int) cubthread::system_core_count () * 6}},
    {false, {.i = (int) cubthread::system_core_count () * 6}},
-   NULL_SYSPRM_PARAM_VALUE,
+   {false, {.i = CSS_MAX_CLIENT_COUNT}},
    {false, {.i = (int) cubthread::system_core_count ()}},
 #else
    {false, {.i = 1}},
@@ -5238,7 +5239,7 @@ SYSPRM_PARAM prm_Def[] = {
    /* adjusted based on CBRD-26636 */
    {false, {.i = (int) cubthread::system_core_count () * 3}},
    {false, {.i = (int) cubthread::system_core_count () * 3}},
-   NULL_SYSPRM_PARAM_VALUE,
+   {false, {.i = CSS_MAX_CLIENT_COUNT}},
    {false, {.i = (int) cubthread::system_core_count ()}},
 #else
    {false, {.i = 1}},
@@ -5255,8 +5256,8 @@ SYSPRM_PARAM prm_Def[] = {
    PRM_INTEGER,
    PRM_CLEAR_DYNAMIC_FLAG,
 #if defined (SERVER_MODE)
-   {false, {.i = (int) cubthread::system_core_count () / 2}},
-   {false, {.i = (int) cubthread::system_core_count () / 2}},
+   {false, {.i = std::max ((int) cubthread::system_core_count () / 2, 1)}},
+   {false, {.i = std::max ((int) cubthread::system_core_count () / 2, 1)}},
    {false, {.i = (int) cubthread::system_core_count ()}},
 #else
    {false, {.i = 2}},
@@ -5272,11 +5273,13 @@ SYSPRM_PARAM prm_Def[] = {
    (PRM_FOR_SERVER),
    PRM_INTEGER,
    PRM_CLEAR_DYNAMIC_FLAG,
-   {false, {.i = 4}},
-   {false, {.i = 4}},
 #if defined (SERVER_MODE)
+   {false, {.i = std::max ((int) cubthread::system_core_count () / 2, 1)}},
+   {false, {.i = std::max ((int) cubthread::system_core_count () / 2, 1)}},
    {false, {.i = (int) cubthread::system_core_count ()}},
 #else
+   {false, {.i = 2}},
+   {false, {.i = 2}},
    NULL_SYSPRM_PARAM_VALUE,
 #endif
    {false, {.i = 1}},
@@ -9947,6 +9950,7 @@ prm_tune_parameters (void)
   SYSPRM_PARAM *max_connection_workers_prm;
   SYSPRM_PARAM *min_connection_workers_prm;
   int system_cpu_count;
+  int max_value;
 #endif
   char newval[LINE_MAX];
   char host_name[CUB_MAXHOSTNAMELEN];
@@ -9998,12 +10002,33 @@ prm_tune_parameters (void)
 #if defined (SERVER_MODE)
       system_cpu_count = cubthread::system_core_count ();
 
+      /* request worker, request concurrency */
       max_request_worker_prm = GET_PRM (PRM_ID_MAX_REQUEST_WORKER);
       max_request_concurrency_prm = GET_PRM (PRM_ID_MAX_REQUEST_CONCURRENCY);
 
-      if (PRM_GET_INT (max_request_worker_prm->value) > PRM_GET_INT (max_clients_prm->value))
+      if (!PRM_IS_SET (max_request_worker_prm))
 	{
-	  sprintf (newval, "%d", PRM_GET_INT (max_clients_prm->value));
+	  /* if not changed by user */
+	  max_value = std::min (PRM_GET_INT (max_clients_prm->value) * 2, CSS_MAX_CLIENT_COUNT);
+	  if (PRM_GET_INT (max_request_worker_prm->value) > max_value)
+	    {
+	      sprintf (newval, "%d", std::max (system_cpu_count, max_value));
+	      (void) prm_set (max_request_worker_prm, newval, false);
+	    }
+	}
+      if (!PRM_IS_SET (max_request_concurrency_prm))
+	{
+	  /* if not changed by user */
+	  max_value = std::min (PRM_GET_INT (max_clients_prm->value), CSS_MAX_CLIENT_COUNT);
+	  if (PRM_GET_INT (max_request_concurrency_prm->value) > max_value)
+	    {
+	      sprintf (newval, "%d", std::max (system_cpu_count, max_value));
+	      (void) prm_set (max_request_concurrency_prm, newval, false);
+	    }
+	}
+      if (PRM_GET_INT (max_request_worker_prm->value) < PRM_GET_INT (max_request_concurrency_prm->value))
+	{
+	  sprintf (newval, "%d", PRM_GET_INT (max_request_concurrency_prm->value));
 	  if (prm_set (max_request_worker_prm, newval, false) != PRM_ERR_NO_ERROR)
 	    {
 	      sprintf (newval, "%d", system_cpu_count);
@@ -10011,16 +10036,7 @@ prm_tune_parameters (void)
 	    }
 	}
 
-      if (PRM_GET_INT (max_request_concurrency_prm->value) > PRM_GET_INT (max_request_worker_prm->value))
-	{
-	  sprintf (newval, "%d", PRM_GET_INT (max_request_worker_prm->value));
-	  if (prm_set (max_request_concurrency_prm, newval, false) != PRM_ERR_NO_ERROR)
-	    {
-	      sprintf (newval, "%d", system_cpu_count);
-	      (void) prm_set (max_request_concurrency_prm, newval, false);
-	    }
-	}
-
+      /* connection worker */
       max_connection_workers_prm = GET_PRM (PRM_ID_CSS_MAX_CONNECTION_WORKER);
       min_connection_workers_prm = GET_PRM (PRM_ID_CSS_MIN_CONNECTION_WORKER);
 

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -10005,14 +10005,6 @@ prm_tune_parameters (void)
       max_request_worker_prm = GET_PRM (PRM_ID_MAX_REQUEST_WORKER);
       max_request_concurrency_prm = GET_PRM (PRM_ID_MAX_REQUEST_CONCURRENCY);
 
-      if (!PRM_IS_SET (max_request_worker_prm))
-	{
-	  /* if not changed by user */
-	  sprintf (newval, "%d",
-		   std::min (std::max (PRM_GET_INT (max_clients_prm->value) + /* twice the max depth of SP */ 16 * 2,
-				       system_cpu_count), CSS_MAX_CLIENT_COUNT));
-	  (void) prm_set (max_request_worker_prm, newval, false);
-	}
       if (!PRM_IS_SET (max_request_concurrency_prm))
 	{
 	  /* if not changed by user */

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -5216,9 +5216,8 @@ SYSPRM_PARAM prm_Def[] = {
    PRM_INTEGER,
    PRM_CLEAR_DYNAMIC_FLAG,
 #if defined (SERVER_MODE)
-   /* set the default to twice the value of MAX_REQUEST_CONCURRENCY */
-   {false, {.i = (int) cubthread::system_core_count () * 6}},
-   {false, {.i = (int) cubthread::system_core_count () * 6}},
+   {false, {.i = CSS_MAX_CLIENT_COUNT}},
+   {false, {.i = CSS_MAX_CLIENT_COUNT}},
    {false, {.i = CSS_MAX_CLIENT_COUNT}},
    {false, {.i = (int) cubthread::system_core_count ()}},
 #else
@@ -10006,16 +10005,6 @@ prm_tune_parameters (void)
       max_request_worker_prm = GET_PRM (PRM_ID_MAX_REQUEST_WORKER);
       max_request_concurrency_prm = GET_PRM (PRM_ID_MAX_REQUEST_CONCURRENCY);
 
-      if (!PRM_IS_SET (max_request_worker_prm))
-	{
-	  /* if not changed by user */
-	  max_value = std::min (PRM_GET_INT (max_clients_prm->value) * 2, CSS_MAX_CLIENT_COUNT);
-	  if (PRM_GET_INT (max_request_worker_prm->value) > max_value)
-	    {
-	      sprintf (newval, "%d", std::max (system_cpu_count, max_value));
-	      (void) prm_set (max_request_worker_prm, newval, false);
-	    }
-	}
       if (!PRM_IS_SET (max_request_concurrency_prm))
 	{
 	  /* if not changed by user */

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -10005,6 +10005,14 @@ prm_tune_parameters (void)
       max_request_worker_prm = GET_PRM (PRM_ID_MAX_REQUEST_WORKER);
       max_request_concurrency_prm = GET_PRM (PRM_ID_MAX_REQUEST_CONCURRENCY);
 
+      if (!PRM_IS_SET (max_request_worker_prm))
+	{
+	  /* if not changed by user */
+	  sprintf (newval, "%d",
+		   std::min (std::max (PRM_GET_INT (max_clients_prm->value) + /* twice the max depth of SP */ 16 * 2,
+				       system_cpu_count), CSS_MAX_CLIENT_COUNT));
+	  (void) prm_set (max_request_worker_prm, newval, false);
+	}
       if (!PRM_IS_SET (max_request_concurrency_prm))
 	{
 	  /* if not changed by user */

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -966,6 +966,7 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
  * Other macros
  */
 #define PRM_DEFAULT_BUFFER_SIZE 256
+#define PRM_REQUEST_WORKER_ELASTIC_HEADROOM 32
 
 /* initial error and integer lists */
 static const int int_list_initial[1] = { 0 };
@@ -10013,6 +10014,20 @@ prm_tune_parameters (void)
 	    {
 	      sprintf (newval, "%d", std::max (system_cpu_count, max_value));
 	      (void) prm_set (max_request_concurrency_prm, newval, false);
+	    }
+	}
+      if (!PRM_IS_SET (max_request_worker_prm))
+	{
+	  /* waiting request workers keep their threads while returning concurrency slots.  */
+	  /* keep a bounded worker headroom for nested callback/method requests without     */
+	  /* opening the default cap up to CSS_MAX_CLIENT_COUNT.                            */
+	  max_value = std::min (std::max (PRM_GET_INT (max_clients_prm->value),
+					  PRM_GET_INT (max_request_concurrency_prm->value))
+				+ PRM_REQUEST_WORKER_ELASTIC_HEADROOM, CSS_MAX_CLIENT_COUNT);
+	  if (PRM_GET_INT (max_request_worker_prm->value) > max_value)
+	    {
+	      sprintf (newval, "%d", max_value);
+	      (void) prm_set (max_request_worker_prm, newval, false);
 	    }
 	}
       if (PRM_GET_INT (max_request_worker_prm->value) < PRM_GET_INT (max_request_concurrency_prm->value))

--- a/src/connection/connection_context.cpp
+++ b/src/connection/connection_context.cpp
@@ -78,7 +78,7 @@ namespace cubconn::connection
   {
     .m_state = state::HEADER,
     .m_receiver = receiver (capacity, &m_stats),
-    .m_header = { nullptr, 0 },
+    .m_header = DEFAULT_HEADER_DATA,
     .m_request_id = -1,
     .m_command = false
   },
@@ -100,7 +100,7 @@ namespace cubconn::connection
   {
     .m_state = state::HEADER,
     .m_receiver = receiver (),
-    .m_header = { nullptr, 0 },
+    .m_header = DEFAULT_HEADER_DATA,
     .m_request_id = -1,
     .m_command = false
   },
@@ -131,7 +131,7 @@ namespace cubconn::connection
 
     m_recv.m_state = state::HEADER;
     m_recv.m_receiver.reset ();
-    m_recv.m_header = { nullptr, 0 };
+    m_recv.m_header = DEFAULT_HEADER_DATA;
     m_recv.m_request_id = -1;
     m_recv.m_command = false;
 

--- a/src/connection/connection_context.hpp
+++ b/src/connection/connection_context.hpp
@@ -163,7 +163,7 @@ namespace cubconn::connection
       state m_state;
       receiver m_receiver;
 
-      cubbase::span<std::byte> m_header;
+      NET_HEADER m_header;
       int m_request_id;
 
       /* if received command packet, task will be pushed into worker pool */

--- a/src/connection/connection_worker.cpp
+++ b/src/connection/connection_worker.cpp
@@ -1504,10 +1504,8 @@ respond:
     NET_HEADER *header;
     int size;
 
-    assert (ctx->m_recv.m_header.size () == sizeof (NET_HEADER));
-
     conn = ctx->m_conn;
-    header = reinterpret_cast<NET_HEADER *> (ctx->m_recv.m_header.data ());
+    header = &ctx->m_recv.m_header;
 
     size = ntohl (header->buffer_size);
     if (packet.size () != static_cast<std::size_t> (size) && packet.size () != ((static_cast<std::size_t> (size) + 7) & ~7))
@@ -1546,10 +1544,8 @@ respond:
     NET_HEADER *header;
     int size;
 
-    assert (ctx->m_recv.m_header.size () == sizeof (NET_HEADER));
-
     conn = ctx->m_conn;
-    header = reinterpret_cast<NET_HEADER *> (ctx->m_recv.m_header.data ());
+    header = &ctx->m_recv.m_header;
 
     size = ntohl (header->buffer_size);
     if (packet.size () != static_cast<std::size_t> (size) && packet.size () != ((static_cast<std::size_t> (size) + 7) & ~7))
@@ -1632,7 +1628,7 @@ respond:
     return result::Ok;
   }
 
-  result worker::handle_command_header_packet (context *ctx)
+  result worker::handle_command_header_packet (context *ctx, cubbase::span<std::byte> &packet)
   {
     css_conn_entry *conn;
     NET_HEADER *header;
@@ -1640,21 +1636,21 @@ respond:
 
     if (css_is_request_aborted (ctx->m_conn, ctx->m_recv.m_request_id))
       {
-	ctx->m_recv.m_receiver.release (ctx->m_recv.m_header.data ());
+	ctx->m_recv.m_receiver.release (packet.data ());
 	return result::Aborted;
       }
 
-    assert (ctx->m_recv.m_header.size () == sizeof (NET_HEADER));
+    assert (packet.size () == sizeof (NET_HEADER));
 
     conn = ctx->m_conn;
-    header = reinterpret_cast<NET_HEADER *> (ctx->m_recv.m_header.data ());
+    header = reinterpret_cast<NET_HEADER *> (packet.data ());
 
     error = css_add_queue_entry (conn, &conn->request_queue, ctx->m_recv.m_request_id,
-				 reinterpret_cast<char *> (ctx->m_recv.m_header.data ()), ctx->m_recv.m_header.size (), NO_ERRORS,
+				 reinterpret_cast<char *> (packet.data ()), packet.size (), NO_ERRORS,
 				 conn->get_tran_index (), conn->invalidate_snapshot, conn->db_error);
     if (error != NO_ERRORS)
       {
-	ctx->m_recv.m_receiver.release (ctx->m_recv.m_header.data ());
+	ctx->m_recv.m_receiver.release (packet.data ());
 	return result::Error;
       }
 
@@ -1694,10 +1690,10 @@ respond:
 	return result::Skewed;
       }
 
-    ctx->m_recv.m_header = packet;
+    std::memcpy (&ctx->m_recv.m_header, packet.data (), sizeof (NET_HEADER));
 
     conn = ctx->m_conn;
-    header = reinterpret_cast<NET_HEADER *> (ctx->m_recv.m_header.data ());
+    header = &ctx->m_recv.m_header;
 
     ctx->m_recv.m_request_id = ntohl (header->request_id);
 
@@ -1717,7 +1713,7 @@ respond:
       {
       case COMMAND_TYPE:
 	/* no more packets are requested */
-	status = this->handle_command_header_packet (ctx);
+	status = this->handle_command_header_packet (ctx, packet);
 	break;
 
       case DATA_TYPE:

--- a/src/connection/connection_worker.hpp
+++ b/src/connection/connection_worker.hpp
@@ -335,7 +335,7 @@ namespace cubconn::connection
       result handle_data_packet (context *ctx, cubbase::span<std::byte> &packet);
 
       /* header */
-      result handle_command_header_packet (context *ctx);
+      result handle_command_header_packet (context *ctx, cubbase::span<std::byte> &packet);
       result handle_header_packet (context *ctx, cubbase::span<std::byte> &packet);
 
       /* reception */

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -549,9 +549,7 @@ css_start_shutdown_server ()
  *       css_initialize_server_interfaces before calling this function.
  */
 // *INDENT-OFF*
-REGISTER_WORKERPOOL (transaction, []() {
-    return css_get_max_connections ();
-});
+REGISTER_WORKERPOOL (transaction, CSS_MAX_CLIENT_COUNT);
 // *INDENT-ON*
 
 int
@@ -585,7 +583,7 @@ css_init (THREAD_ENTRY * thread_p, char *server_name, int name_length, int port_
   // create request worker pool
   //*INDENT-OFF*
   css_Server_request_worker_pool = thread_create_worker_pool<cubthread::stats_t::on, cubthread::pool_t::elastic> (
-      css_get_max_connections (),
+      CSS_MAX_CLIENT_COUNT,
       cubthread::system_core_count (),
       max_request_concurrency,
       max_request_worker,

--- a/src/sp/pl_execution_stack_context.hpp
+++ b/src/sp/pl_execution_stack_context.hpp
@@ -37,6 +37,10 @@
 #include "mem_block.hpp"
 #include "packer.hpp"
 
+#if defined (SERVER_MODE)
+#include "thread_manager.hpp"
+#endif
+
 #include "network_callback_sr.hpp"
 #include "method_struct_invoke.hpp"
 #include "pl_connection.hpp"
@@ -162,7 +166,17 @@ namespace cubpl
 	  return interrupt_handler ();
 	};
 
-	return conn->receive_buffer (b, &interrupt_func, 500);
+#if defined (SERVER_MODE)
+	auto *holder = thread_concurrency_slot_release (m_thread_p);
+#endif
+
+	int error = conn->receive_buffer (b, &interrupt_func, 500);
+
+#if defined (SERVER_MODE)
+	thread_concurrency_slot_acquire (m_thread_p, holder);
+#endif
+
+	return error;
       }
 
       void

--- a/src/thread/concurrency_slot.cpp
+++ b/src/thread/concurrency_slot.cpp
@@ -521,6 +521,22 @@ namespace cubthread
     return slots;
   }
 
+  bool
+  concurrency_slot_pool::needs_slot ()
+  {
+    std::unique_lock<std::mutex> ulock (*m_mutex);
+
+    return needs_slot (ulock);
+  }
+
+  bool
+  concurrency_slot_pool::needs_slot (std::unique_lock<std::mutex> &ulock)
+  {
+    assert (ulock.owns_lock ());
+
+    return !m_wait_queue.empty () || (m_available_slots.empty () && has_queued_task (ulock));
+  }
+
   std::size_t
   concurrency_slot_pool::available_slots ()
   {
@@ -610,6 +626,8 @@ namespace cubthread
       void execute (entry &thread_ref) override;
 
     private:
+      bool has_slot_demand (std::vector<concurrency_slot_subscriber *> &subs);
+
       void steal_from_entries_if_excess (std::vector<std::unique_ptr<concurrency_slot>> &slots, void *identifier);
       void steal_from_cores_if_excess (std::vector<std::unique_ptr<concurrency_slot>> &slots,
 				       std::vector<concurrency_slot_subscriber *> &subs);
@@ -662,7 +680,10 @@ namespace cubthread
       steal_from_entries_if_excess (slots, identifier);
 
       // 3.
-      steal_from_cores_if_excess (slots, subs);
+      if (has_slot_demand (subs))
+	{
+	  steal_from_cores_if_excess (slots, subs);
+	}
 
       // 4.
       distribute_slots (slots, subs);
@@ -671,6 +692,20 @@ namespace cubthread
       // 5.
       wakeup_workers (identifier, subs);
     });
+  }
+
+  bool
+  concurrency_slot_daemon_task::has_slot_demand (std::vector<concurrency_slot_subscriber *> &subs)
+  {
+    for (auto &sub : subs)
+      {
+	if (static_cast<concurrency_slot_pool *> (sub)->needs_slot ())
+	  {
+	    return true;
+	  }
+      }
+
+    return false;
   }
 
   void

--- a/src/thread/concurrency_slot.cpp
+++ b/src/thread/concurrency_slot.cpp
@@ -443,6 +443,7 @@ namespace cubthread
       {
 	if (m_wait_queue.empty ())
 	  {
+	    // store the slot
 	    m_available_slots.emplace (std::move (slot));
 	    break;
 	  }
@@ -483,11 +484,13 @@ namespace cubthread
 
     std::unique_lock<std::mutex> ulock (*m_mutex);
 
-    if ((m_available_slots.empty () && !m_wait_queue.empty ()) ||
+    if (has_queued_task (ulock) ||
+	(m_available_slots.empty () && !m_wait_queue.empty ()) ||
 	(slot->m_owner_pool == this && m_slot_count > m_target_count) ||
 	force)
       {
 	release_slot (std::move (slot), ulock);
+	wakeup_workers (ulock);
 
 	return nullptr;
       }
@@ -560,6 +563,38 @@ namespace cubthread
       {
 	m_surplus = false;
       }
+  }
+
+  void
+  concurrency_slot_pool::wakeup_workers (std::unique_lock<std::mutex> &ulock)
+  {
+    // wake the workers up if there are available slots
+    auto *base = static_cast<worker_pool::core *> (const_cast<void *> (m_parent));
+    if (dynamic_cast<worker_pool_elastic<stats_t::on>::core_elastic *> (base))
+      {
+	static_cast<worker_pool_elastic<stats_t::on>::core_elastic *> (base)->adjust_workers (ulock);
+      }
+    else if (dynamic_cast<worker_pool_elastic<stats_t::off>::core_elastic *> (base))
+      {
+	static_cast<worker_pool_elastic<stats_t::off>::core_elastic *> (base)->adjust_workers (ulock);
+      }
+  }
+
+  bool
+  concurrency_slot_pool::has_queued_task (std::unique_lock<std::mutex> &ulock)
+  {
+    assert (ulock.owns_lock ());
+
+    auto *base = static_cast<worker_pool::core *> (const_cast<void *> (m_parent));
+    if (dynamic_cast<worker_pool_elastic<stats_t::on>::core_elastic *> (base))
+      {
+	return static_cast<worker_pool_elastic<stats_t::on>::core_elastic *> (base)->has_queued_task (ulock);
+      }
+    else if (dynamic_cast<worker_pool_elastic<stats_t::off>::core_elastic *> (base))
+      {
+	return static_cast<worker_pool_elastic<stats_t::off>::core_elastic *> (base)->has_queued_task (ulock);
+      }
+    return false;
   }
 
   //////////////////////////////////////////////////////////////////////////

--- a/src/thread/concurrency_slot.cpp
+++ b/src/thread/concurrency_slot.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "concurrency_slot.hpp"
+#include "connection_globals.h"
 #include "thread_manager.hpp"
 #include "server_support.h"
 #include "system_parameter.h"
@@ -752,22 +753,10 @@ namespace cubthread
       std::size_t &max_request_worker)
   {
     std::size_t core_count = system_core_count ();
-    std::size_t max_clients = prm_get_integer_value (PRM_ID_CSS_MAX_CLIENTS);
-    std::size_t clamp_min = max_clients < core_count ? core_count : max_clients;
+    std::size_t max_client_count = CSS_MAX_CLIENT_COUNT;
 
-    if (max_request_concurrency > max_clients)
-      {
-	max_request_concurrency = clamp_min;
-      }
-    if (max_request_concurrency < core_count)
-      {
-	max_request_concurrency = core_count;
-      }
-
-    if (max_request_worker > max_clients)
-      {
-	max_request_worker = clamp_min;
-      }
+    max_request_concurrency = std::min (std::max (max_request_concurrency, core_count), max_client_count);
+    max_request_worker = std::min (std::max (max_request_worker, core_count), max_client_count);
     if (max_request_worker < max_request_concurrency)
       {
 	max_request_worker = max_request_concurrency;

--- a/src/thread/concurrency_slot.hpp
+++ b/src/thread/concurrency_slot.hpp
@@ -149,6 +149,8 @@ namespace cubthread
       std::vector<std::unique_ptr<concurrency_slot>>
 	  borrow_surplus_slots (const std::chrono::time_point<std::chrono::steady_clock> &now);
 
+      bool needs_slot ();
+      bool needs_slot (std::unique_lock<std::mutex> &ulock);
       std::size_t available_slots ();
 
       const void *get_parent ();

--- a/src/thread/concurrency_slot.hpp
+++ b/src/thread/concurrency_slot.hpp
@@ -176,6 +176,8 @@ namespace cubthread
       std::mutex *m_mutex;
 
       void check_surplus_slots ();
+      void wakeup_workers (std::unique_lock<std::mutex> &ulock);
+      bool has_queued_task (std::unique_lock<std::mutex> &ulock);
   };
 
   // concurrency_slot_daemon

--- a/src/thread/thread_entry.cpp
+++ b/src/thread/thread_entry.cpp
@@ -610,6 +610,16 @@ thread_prepare_suspension (cubthread::entry *thread_p, cubthread::entry::status 
       switch (suspended_reason)
 	{
 	case THREAD_CSS_QUEUE_SUSPENDED:
+	  // this entry belongs to an elastic worker pool
+	  holder = static_cast<void *> (thread_p->m_slot->get_holder_pool ());
+	  assert (holder);
+	  {
+	    std::unique_ptr<cubthread::concurrency_slot> slot = std::move (thread_p->m_slot);
+	    thread_p->m_slot = nullptr;
+	    slot->return_to_pool (std::move (slot));
+	  }
+	  break;
+
 	case THREAD_LOCK_SUSPENDED:
 	  // this entry belongs to an elastic worker pool
 	  holder = static_cast<void *> (thread_p->m_slot->get_holder_pool ());

--- a/src/thread/thread_manager.hpp
+++ b/src/thread/thread_manager.hpp
@@ -622,4 +622,55 @@ thread_clear_all_holder_anchor (void)
   return cubthread::get_manager ()->clear_all_holder_anchor ();
 }
 
+#if defined (SERVER_MODE)
+inline cubthread::concurrency_slot_pool *
+thread_concurrency_slot_release (cubthread::entry *thread_p)
+{
+  cubthread::concurrency_slot_pool *holder = nullptr;
+
+  if (thread_p == NULL)
+    {
+      thread_p = thread_get_thread_entry_info ();
+    }
+
+  thread_p->lock ();
+  if (!thread_p->m_slot)
+    {
+      thread_p->unlock ();
+      return nullptr;
+    }
+
+  std::unique_ptr<cubthread::concurrency_slot> slot = std::move (thread_p->m_slot);
+  thread_p->m_slot = nullptr;
+  thread_p->unlock ();
+
+  holder = slot->get_holder_pool ();
+  assert (holder);
+
+  slot->return_to_pool (std::move (slot));
+  return holder;
+}
+
+inline void
+thread_concurrency_slot_acquire (cubthread::entry *thread_p, cubthread::concurrency_slot_pool *holder)
+{
+  if (thread_p == NULL)
+    {
+      thread_p = thread_get_thread_entry_info ();
+    }
+
+  if (holder)
+    {
+      thread_p->lock ();
+      cubthread::entry::status old_status = thread_p->m_status;
+      thread_p->m_status = cubthread::entry::status::TS_WAIT;
+
+      holder->acquire_slot (thread_p);
+
+      thread_p->m_status = old_status;
+      thread_p->unlock ();
+    }
+}
+#endif
+
 #endif  // _THREAD_MANAGER_HPP_

--- a/src/thread/thread_worker_pool_elastic.hpp
+++ b/src/thread/thread_worker_pool_elastic.hpp
@@ -123,6 +123,7 @@ namespace cubthread
 
       // execute task
       void execute_task (task_type *task_p) override;
+      bool has_queued_task (std::unique_lock<std::mutex> &ulock);
 
       // concurrency slot interface
       void release_slot (unique_slot slot);
@@ -462,6 +463,15 @@ namespace cubthread
 
     // enqueue the task until a slot is available
     this->m_task_queue.push_back (std::move (task_ref));
+  }
+
+  template <stats_t Stats>
+  bool
+  worker_pool_elastic<Stats>::core_elastic::has_queued_task (std::unique_lock<std::mutex> &ulock)
+  {
+    assert (ulock.owns_lock ());
+
+    return !this->m_task_queue.empty ();
   }
 
   template <stats_t Stats>

--- a/src/thread/thread_worker_pool_elastic.hpp
+++ b/src/thread/thread_worker_pool_elastic.hpp
@@ -38,6 +38,7 @@
 // system includes
 #include <chrono>
 #include <memory>
+#include <atomic>
 #include <algorithm>
 
 namespace cubthread
@@ -90,11 +91,11 @@ namespace cubthread
 
       std::unique_ptr<worker_pool::core> allocate_core (bool pool_threads) override;
 
-      // variant worker pool (m_max_concurrency <= the number of workers <= m_max_worker)
-      std::size_t m_max_concurrency;
-      std::size_t m_max_worker;
+      // variant worker pool (placed in same cache line)
+      std::atomic<std::size_t> m_current_worker;
 
-      mutable std::mutex m_variant_mutex;
+      std::atomic<std::size_t> m_max_concurrency;
+      std::atomic<std::size_t> m_max_worker;
   };
 
   // worker_pool_elastic<Stats>::core_elastic
@@ -141,21 +142,24 @@ namespace cubthread
     private:
       using snapshot_guard = typename worker_pool_impl<Stats>::core_impl::snapshot_guard;
 
-      core_elastic (bool pool_threads);
+      core_elastic (bool pool_threads, std::atomic<std::size_t> &current_worker, std::atomic<std::size_t> &max_worker);
 
       std::unique_ptr<worker> allocate_worker () override;
 
+      bool reserve_available_worker ();
+      void release_available_worker ();
       worker_elastic *get_or_make_available_worker ();
 
       bool try_execute_task_with_slot (worker_elastic *worker_p, wrapped_task &&task_ref, unique_slot slot);
 
       concurrency_slot_pool m_slots;
 
-      // m_max_concurrency <= the number of workers <= m_max_workers
+      // per core
       std::size_t m_max_concurrency;
-      std::size_t m_max_worker;
 
-      std::size_t m_retire_threshold;
+      // global. this is not hard cap. allow to make worker overcommit
+      std::atomic<std::size_t> &m_current_worker;
+      std::atomic<std::size_t> &m_max_worker;
 
       stats_base m_retired_stats;
   };
@@ -206,6 +210,7 @@ namespace cubthread
       std::size_t max_concurrency, std::size_t max_worker, const char *name, entry_manager &entry_mgr, bool pool_threads,
       wait_seconds idle_timeout)
     : worker_pool_impl<Stats> (pool_size, core_count, name, entry_mgr, pool_threads, idle_timeout)
+    , m_current_worker (max_concurrency)
     , m_max_concurrency (max_concurrency)
     , m_max_worker (max_worker)
   {
@@ -223,10 +228,10 @@ namespace cubthread
     // pool_size is the entry reservation count; initial worker count comes from m_max_concurrency
 
     // initialize the base worker pool as worker is max_concurrency and core is core_count
-    worker_pool_impl<Stats>::initialize (m_max_concurrency, core_count);
+    worker_pool_impl<Stats>::initialize (m_max_concurrency.load (), core_count);
 
     // set the overcommit parameters in each core
-    adjust_runtime_parameter (m_max_concurrency, m_max_worker);
+    adjust_runtime_parameter (m_max_concurrency.load (), m_max_worker.load ());
   }
 
   template <stats_t Stats>
@@ -240,6 +245,9 @@ namespace cubthread
     std::size_t worker_quotient, worker_remainder;
     std::size_t c, w;
     std::size_t it;
+
+    m_max_concurrency.store (max_concurrency);
+    m_max_worker.store (max_worker);
 
     concurrency_quotient = max_concurrency / this->m_cores.size ();
     concurrency_remainder = max_concurrency % this->m_cores.size ();
@@ -255,29 +263,20 @@ namespace cubthread
 
 	static_cast<core_elastic *> (this->m_cores[it].get ())->adjust_runtime_parameter (c, w);
       }
-
-    std::lock_guard<std::mutex> lock (m_variant_mutex);
-
-    m_max_concurrency = max_concurrency;
-    m_max_worker = max_worker;
   }
 
   template <stats_t Stats>
   std::size_t
   worker_pool_elastic<Stats>::get_max_concurrency (void) const
   {
-    std::lock_guard<std::mutex> lock (m_variant_mutex);
-
-    return m_max_concurrency;
+    return m_max_concurrency.load ();
   }
 
   template <stats_t Stats>
   std::size_t
   worker_pool_elastic<Stats>::get_max_worker (void) const
   {
-    std::lock_guard<std::mutex> lock (m_variant_mutex);
-
-    return m_max_worker;
+    return m_max_worker.load ();
   }
 
   template <stats_t Stats>
@@ -314,7 +313,7 @@ namespace cubthread
   std::unique_ptr<typename worker_pool::core>
   worker_pool_elastic<Stats>::allocate_core (bool pool_threads)
   {
-    return std::unique_ptr<worker_pool::core> (new core_elastic (pool_threads));
+    return std::unique_ptr<worker_pool::core> (new core_elastic (pool_threads, m_current_worker, m_max_worker));
   }
 
   //////////////////////////////////////////////////////////////////////////
@@ -322,12 +321,13 @@ namespace cubthread
   //////////////////////////////////////////////////////////////////////////
 
   template <stats_t Stats>
-  worker_pool_elastic<Stats>::core_elastic::core_elastic (bool pool_threads)
+  worker_pool_elastic<Stats>::core_elastic::core_elastic (bool pool_threads, std::atomic<std::size_t> &current_worker,
+      std::atomic<std::size_t> &max_worker)
     : worker_pool_impl<Stats>::core_impl (pool_threads)
     , m_slots (this, this->m_core_mutex)
     , m_max_concurrency (0)
-    , m_max_worker (0)
-    , m_retire_threshold (0)
+    , m_current_worker (current_worker)
+    , m_max_worker (max_worker)
     , m_retired_stats (stats::create ())
   {
   }
@@ -358,8 +358,6 @@ namespace cubthread
     std::unique_lock<std::mutex> ulock (this->m_core_mutex);
 
     m_max_concurrency = max_concurrency;
-    m_max_worker = max_worker;
-    m_retire_threshold = std::max ((max_concurrency + max_worker) / 2, max_concurrency);
 
     m_slots.adjust_concurrency (m_max_concurrency, ulock);
     adjust_workers (ulock);
@@ -519,7 +517,7 @@ namespace cubthread
   {
     std::lock_guard<std::mutex> lock (this->m_core_mutex);
 
-    if (this->m_workers.size () >= m_retire_threshold && !this->has_workers_snapshot_readers ())
+    if (this->m_workers.size () > m_max_concurrency && !this->has_workers_snapshot_readers ())
       {
 	auto available_it = std::find (this->m_available_workers.begin (), this->m_available_workers.end (), w);
 	if (available_it != this->m_available_workers.end ())
@@ -539,6 +537,8 @@ namespace cubthread
 
 	    // remove
 	    this->m_workers.erase (worker_it);
+	    // and release count
+	    release_available_worker ();
 	  }
       }
   }
@@ -568,9 +568,9 @@ namespace cubthread
     std::unique_lock<std::mutex> ulock (this->m_core_mutex);
 
     m_slots.get_runtime_stats (total_slots, target_slots, busy_slots);
-    total_workers += this->m_workers.size ();
-    target_workers += m_max_worker;
     assert (this->m_workers.size () >= this->m_available_workers.size ());
+    total_workers += this->m_workers.size ();
+    target_workers += m_max_concurrency;
     busy_workers += this->m_workers.size () - this->m_available_workers.size ();
   }
 
@@ -582,13 +582,41 @@ namespace cubthread
   }
 
   template <stats_t Stats>
+  bool
+  worker_pool_elastic<Stats>::core_elastic::reserve_available_worker ()
+  {
+    std::size_t expected, desired;
+
+    expected = m_current_worker.load ();
+    do
+      {
+	if (expected >= m_max_worker.load ())
+	  {
+	    return false;
+	  }
+	desired = expected + 1;
+      }
+    while (!m_current_worker.compare_exchange_strong (expected, desired));
+
+    return true;
+  }
+
+  template <stats_t Stats>
+  void
+  worker_pool_elastic<Stats>::core_elastic::release_available_worker ()
+  {
+    assert (m_current_worker.load () > 0);
+    m_current_worker.fetch_sub (1);
+  }
+
+  template <stats_t Stats>
   typename worker_pool_elastic<Stats>::core_elastic::worker_elastic *
   worker_pool_elastic<Stats>::core_elastic::get_or_make_available_worker ()
   {
     worker *worker_p;
 
     worker_p = this->get_available_worker ();
-    if (!worker_p && this->m_workers.size () < m_max_worker)
+    if (!worker_p && reserve_available_worker ())
       {
 	// create a worker when none is available
 	this->m_workers.push_back (this->allocate_worker ());


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26977>

### Purpose

아래와 같은 문제를 수정하였습니다.
1. 기존에는 worker 상한이 core 별 적용이었지만, global로 변경하였습니다. concurrency는 그대로 core 별 적용합니다. 부하가 적합하게 분산되도록 하기 위함입니다.
2. 기존에는 CSS 대기 경로에서도 50ms의 대기 후 slot을 반납하였지만, 지금은 바로 반납하도록 하였습니다. 해당 경로는 반드시 한 번의 client - server 송수신을 거치는 단계이므로 slot을 바로 반납하는 것이 더 적합합니다.
3. slot을 반납했지만 core의 task queue에 있는 작업이 시작되지 않는 버그를 수정하였습니다. 기존에는 task qeueu의 작업이 새로 시작되지 않고, 대기 중인 worker에만 slot을 할당하고 깨워줬습니다.

### Implementation

N/A

### Remarks

N/A
