### PR TITLE
[CBRD-26927] Read hash-aggregate tuple before freeing its list page

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -4968,6 +4968,7 @@ qexec_hash_gby_put_next (THREAD_ENTRY * thread_p, const RECDES * recdes, void *a
 	  if (qdata_load_agg_hentry_from_tuple (thread_p, data, context->temp_part_key, context->temp_part_value,
 						context->key_domains, context->accumulator_domains) != NO_ERROR)
 	    {
+	      qmgr_free_old_page_and_init (thread_p, page, list_idp->tfile_vfid);
 	      return ER_FAILED;
 	    }
 	  qmgr_free_old_page_and_init (thread_p, page, list_idp->tfile_vfid);

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -4963,6 +4963,13 @@ qexec_hash_gby_put_next (THREAD_ENTRY * thread_p, const RECDES * recdes, void *a
 	  else
 	    {
 	    }
+
+	  /* read tuple into value */
+	  if (qdata_load_agg_hentry_from_tuple (thread_p, data, context->temp_part_key, context->temp_part_value,
+						context->key_domains, context->accumulator_domains) != NO_ERROR)
+	    {
+	      return ER_FAILED;
+	    }
 	  qmgr_free_old_page_and_init (thread_p, page, list_idp->tfile_vfid);
 	}
       else
@@ -4976,13 +4983,13 @@ qexec_hash_gby_put_next (THREAD_ENTRY * thread_p, const RECDES * recdes, void *a
 	      return ER_FAILED;
 	    }
 	  data = context->tuple_recdes.data;
-	}
 
-      /* read tuple into value */
-      if (qdata_load_agg_hentry_from_tuple (thread_p, data, context->temp_part_key, context->temp_part_value,
-					    context->key_domains, context->accumulator_domains) != NO_ERROR)
-	{
-	  return ER_FAILED;
+	  /* read tuple into value */
+	  if (qdata_load_agg_hentry_from_tuple (thread_p, data, context->temp_part_key, context->temp_part_value,
+						context->key_domains, context->accumulator_domains) != NO_ERROR)
+	    {
+	      return ER_FAILED;
+	    }
 	}
 
       /* aggregate */


### PR DESCRIPTION
https://jira.cubrid.org/browse/CBRD-26927

## Description

degree 8(병렬도 8) 병렬 GROUP BY/DISTINCT 쿼리를 여러 세션에서 동시에 반복 실행하면 `cub_server` 가 `or_advance` assert 에 걸려 SIGABRT 로 종료된다. read-only 데이터셋(tpch_sf10)에서도 재현되어 DML 과 무관하고, 단일 쿼리만 반복하거나 serial 실행(parallelism=0)에서는 재현되지 않는다.

근본 원인은 `qexec_hash_gby_put_next` 의 메모리 수명(lifetime) 버그다. 집계 함수가 있는 경로에서:

- `data` 는 list-file 페이지 내부(`page + key->s.original.offset`)를 가리킨다.
- 기존 코드는 `qmgr_free_old_page_and_init` 으로 그 페이지를 unfix 한 **뒤** 공용 경로에서 `qdata_load_agg_hentry_from_tuple` 로 `data` 를 읽었다.

단일/serial 환경에서는 unfix 직후에도 버퍼 내용이 우연히 살아있어 통과하지만, 동시 병렬 집계에서는 해제된 페이지를 다른 워커가 재사용/재할당해 tuple 바이트가 다른 데이터로 덮인다. 깨진 바이트를 tuple 로 해석하면서 `or_advance` 의 경계 검사 assert 에 걸린다.

## Implementation

`src/query/query_executor.c` `qexec_hash_gby_put_next`:

- 집계-함수 경로에서 `qdata_load_agg_hentry_from_tuple` 호출을 `qmgr_free_old_page_and_init` **이전**으로 이동 — 페이지가 아직 fix 되어 있는 동안 tuple 을 읽는다.
- 집계 함수가 없는 sort-all-columns 경로(`qfile_generate_sort_tuple` 로 sort key 에서 tuple 을 만드는 else 분기)에도 동일한 읽기를 추가 — 이 경로는 list-file 페이지가 없고 자체 `recdes`(record descriptor — tuple 바이트 버퍼) 에서 읽으므로 안전하다.
- 결과적으로 두 경로 모두 항상 유효한 버퍼에서 tuple 을 읽는다. 공용 위치의 단일 호출은 제거.
