### PR TITLE
[CBRD-25855] implement dynamic open-for statement

### DIFF
--- a/pl_engine/pl_server/src/main/antlr/PlcParser.g4
+++ b/pl_engine/pl_server/src/main/antlr/PlcParser.g4
@@ -286,6 +286,7 @@ fetch_statement
 
 open_for_statement
     : OPEN identifier FOR static_sql
+    | OPEN identifier FOR dyn_sql restricted_using_clause?
     ;
 
 transaction_control_statement

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -2340,7 +2340,7 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     }
 
     @Override
-    public AstNode visitOpen_for_statement(Open_for_statementContext ctx) {
+    public StmtOpenFor visitOpen_for_statement(Open_for_statementContext ctx) {
 
         connectionRequired = true;
 
@@ -2356,17 +2356,35 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
                     "identifier in an OPEN-FOR statement must be of SYS_REFCURSOR type");
         }
 
-        SqlSemantics sws = getSqlSemanticsFromServer(ctx.static_sql());
-        assert sws != null;
-        assert sws.kind == ServerConstants.CUBRID_STMT_SELECT; // by syntax
-        if (sws.intoTargetStrs != null) {
-            throw new SemanticError(
-                    Misc.getLineColumnOf(ctx.static_sql()), // s043
-                    "SQL in an OPEN-FOR statement may not have an INTO clause");
-        }
-        StaticSql staticSql = checkAndConvertStaticSql(sws, ctx.static_sql());
+        if (ctx.static_sql() == null) {
+            // dynamic case
 
-        return new StmtOpenFor(ctx, refCursor, staticSql);
+            Expr dynSql = visitExpression(ctx.dyn_sql().expression());
+
+            NodeList<Expr> usedExprList;
+            Restricted_using_clauseContext usingClause = ctx.restricted_using_clause();
+            if (usingClause == null) {
+                usedExprList = null;
+            } else {
+                usedExprList = visitRestricted_using_clause(usingClause);
+            }
+
+            return new StmtOpenForDynamic(ctx, refCursor, dynSql, usedExprList);
+        } else {
+            // static case
+
+            SqlSemantics sws = getSqlSemanticsFromServer(ctx.static_sql());
+            assert sws != null;
+            assert sws.kind == ServerConstants.CUBRID_STMT_SELECT; // by syntax
+            if (sws.intoTargetStrs != null) {
+                throw new SemanticError(
+                        Misc.getLineColumnOf(ctx.static_sql()), // s043
+                        "SQL in an OPEN-FOR statement may not have an INTO clause");
+            }
+            StaticSql staticSql = checkAndConvertStaticSql(sws, ctx.static_sql());
+
+            return new StmtOpenForStatic(ctx, refCursor, staticSql);
+        }
     }
 
     @Override

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/StmtOpenForDynamic.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/StmtOpenForDynamic.java
@@ -30,27 +30,21 @@
 
 package com.cubrid.plcsql.compiler.ast;
 
-import java.util.List;
+import com.cubrid.plcsql.compiler.visitor.AstVisitor;
 import org.antlr.v4.runtime.ParserRuleContext;
 
-public abstract class StmtOpenFor extends Stmt {
+public class StmtOpenForDynamic extends StmtOpenFor {
 
-    public final boolean dynamic;
-    public final ExprId id;
-    public final Expr sql;
-    public final List<? extends Expr> usedExprList;
+    @Override
+    public <R> R accept(AstVisitor<R> visitor) {
+        return visitor.visitStmtOpenForDynamic(this);
+    }
 
-    public StmtOpenFor(
+    public StmtOpenForDynamic(
             ParserRuleContext ctx,
-            boolean dynamic,
             ExprId id,
-            Expr sql,
-            List<? extends Expr> usedExprList) {
-        super(ctx);
-
-        this.dynamic = dynamic;
-        this.id = id;
-        this.sql = sql;
-        this.usedExprList = usedExprList;
+            Expr dynamicSql,
+            NodeList<? extends Expr> usedExprList) {
+        super(ctx, true, id, dynamicSql, (usedExprList == null) ? null : usedExprList.nodes);
     }
 }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/StmtOpenForStatic.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/StmtOpenForStatic.java
@@ -48,6 +48,6 @@ public class StmtOpenForStatic extends StmtOpenFor {
                 false,
                 id,
                 new ExprStr(staticSql.ctx, staticSql.rewritten),
-                new ArrayList(staticSql.hostExprs.keySet()));
+                new ArrayList<>(staticSql.hostExprs.keySet()));
     }
 }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/StmtOpenForStatic.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/StmtOpenForStatic.java
@@ -30,27 +30,24 @@
 
 package com.cubrid.plcsql.compiler.ast;
 
-import java.util.List;
+import com.cubrid.plcsql.compiler.StaticSql;
+import com.cubrid.plcsql.compiler.visitor.AstVisitor;
+import java.util.ArrayList;
 import org.antlr.v4.runtime.ParserRuleContext;
 
-public abstract class StmtOpenFor extends Stmt {
+public class StmtOpenForStatic extends StmtOpenFor {
 
-    public final boolean dynamic;
-    public final ExprId id;
-    public final Expr sql;
-    public final List<? extends Expr> usedExprList;
+    @Override
+    public <R> R accept(AstVisitor<R> visitor) {
+        return visitor.visitStmtOpenForStatic(this);
+    }
 
-    public StmtOpenFor(
-            ParserRuleContext ctx,
-            boolean dynamic,
-            ExprId id,
-            Expr sql,
-            List<? extends Expr> usedExprList) {
-        super(ctx);
-
-        this.dynamic = dynamic;
-        this.id = id;
-        this.sql = sql;
-        this.usedExprList = usedExprList;
+    public StmtOpenForStatic(ParserRuleContext ctx, ExprId id, StaticSql staticSql) {
+        super(
+                ctx,
+                false,
+                id,
+                new ExprStr(staticSql.ctx, staticSql.rewritten),
+                new ArrayList(staticSql.hostExprs.keySet()));
     }
 }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/AstVisitor.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/AstVisitor.java
@@ -166,7 +166,9 @@ public abstract class AstVisitor<R> {
 
     public abstract R visitStmtNull(StmtNull node);
 
-    public abstract R visitStmtOpenFor(StmtOpenFor node);
+    public abstract R visitStmtOpenForStatic(StmtOpenForStatic node);
+
+    public abstract R visitStmtOpenForDynamic(StmtOpenForDynamic node);
 
     public abstract R visitStmtRaise(StmtRaise node);
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -2475,8 +2475,8 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 "  %'REF-CURSOR'% = new Query(",
                 "    %'+QUERY'%,",
                 "    %'DYNAMIC'%);",
-                "  %'REF-CURSOR'%.open(conn, null,",
-                "    %'+HOST-EXPRS'%);",
+                "  %'REF-CURSOR'%.open(conn, null, new Object[] {",
+                "    %'+HOST-EXPRS'% });",
                 "}"
             };
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -2471,8 +2471,9 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
 
     private static String[] tmplStmtOpenForWithHV =
             new String[] {
-                "{ // open-for statement",
-                "  %'REF-CURSOR'% = new Query(%'QUERY'%);",
+                "{ // %'KIND'% open-for statement",
+                "  %'REF-CURSOR'% = new Query(",
+                "    %'+QUERY'%);",
                 "  %'REF-CURSOR'%.open(conn, null,",
                 "    %'+HOST-EXPRS'%);",
                 "}"
@@ -2480,28 +2481,30 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
 
     private static String[] tmplStmtOpenForWithoutHV =
             new String[] {
-                "{ // open-for statement",
-                "  %'REF-CURSOR'% = new Query(%'QUERY'%);",
+                "{ // %'KIND'% open-for statement",
+                "  %'REF-CURSOR'% = new Query(",
+                "    %'+QUERY'%);",
                 "  %'REF-CURSOR'%.open(conn, null);",
                 "}"
             };
 
-    @Override
-    public CodeToResolve visitStmtOpenFor(StmtOpenFor node) {
+    private CodeToResolve visitStmtOpenFor(StmtOpenFor node) {
 
-        if (node.staticSql.hostExprs.size() == 0) {
+        if (node.usedExprList == null || node.usedExprList.size() == 0) {
             return new CodeTemplate(
                     "StmtOpenFor",
                     Misc.getLineColumnOf(node.ctx),
                     tmplStmtOpenForWithoutHV,
+                    "%'KIND'%",
+                    node.dynamic ? "dynamic" : "static",
                     "%'REF-CURSOR'%",
                     node.id.javaCode(),
-                    "%'QUERY'%",
-                    '"' + StringEscapeUtils.escapeJava(node.staticSql.rewritten) + '"');
+                    "%'+QUERY'%",
+                    visit(node.sql));
         } else {
 
             CodeTemplateList hostExprs = new CodeTemplateList();
-            for (Expr e : node.staticSql.hostExprs.keySet()) {
+            for (Expr e : node.usedExprList) {
                 hostExprs.addElement((CodeTemplate) visit(e));
             }
 
@@ -2509,14 +2512,30 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                     "StmtOpenFor",
                     Misc.getLineColumnOf(node.ctx),
                     tmplStmtOpenForWithHV,
+                    "%'KIND'%",
+                    node.dynamic ? "dynamic" : "static",
                     "%'REF-CURSOR'%",
                     node.id.javaCode(),
-                    "%'QUERY'%",
-                    '"' + StringEscapeUtils.escapeJava(node.staticSql.rewritten) + '"',
+                    "%'+QUERY'%",
+                    visit(node.sql),
                     "%'+HOST-EXPRS'%",
                     hostExprs.setDelimiter(","));
         }
     }
+
+    @Override
+    public CodeToResolve visitStmtOpenForStatic(StmtOpenForStatic node) {
+        return visitStmtOpenFor(node);
+    }
+
+    @Override
+    public CodeToResolve visitStmtOpenForDynamic(StmtOpenForDynamic node) {
+        return visitStmtOpenFor(node);
+    }
+
+    // -------------------------------------------------------------------------
+    // StmtRaise
+    //
 
     @Override
     public CodeToResolve visitStmtRaise(StmtRaise node) {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -445,7 +445,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
 
         String code =
                 String.format(
-                        "final Query %s = new Query(\"%s\"); // param-ref-counts: %s, param-num-of-host-expr: %s",
+                        "final Query %s = new Query(\"%s\", false); // param-ref-counts:%s, param-num-of-host-expr:%s",
                         node.name,
                         StringEscapeUtils.escapeJava(node.staticSql.rewritten),
                         Arrays.toString(node.paramRefCounts),
@@ -2473,7 +2473,8 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
             new String[] {
                 "{ // %'KIND'% open-for statement",
                 "  %'REF-CURSOR'% = new Query(",
-                "    %'+QUERY'%);",
+                "    %'+QUERY'%,",
+                "    %'DYNAMIC'%);",
                 "  %'REF-CURSOR'%.open(conn, null,",
                 "    %'+HOST-EXPRS'%);",
                 "}"
@@ -2483,7 +2484,8 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
             new String[] {
                 "{ // %'KIND'% open-for statement",
                 "  %'REF-CURSOR'% = new Query(",
-                "    %'+QUERY'%);",
+                "    %'+QUERY'%,",
+                "    %'DYNAMIC'%);",
                 "  %'REF-CURSOR'%.open(conn, null);",
                 "}"
             };
@@ -2500,7 +2502,9 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                     "%'REF-CURSOR'%",
                     node.id.javaCode(),
                     "%'+QUERY'%",
-                    visit(node.sql));
+                    visit(node.sql),
+                    "%'DYNAMIC'%",
+                    node.dynamic ? "true" : "false");
         } else {
 
             CodeTemplateList hostExprs = new CodeTemplateList();
@@ -2518,6 +2522,8 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                     node.id.javaCode(),
                     "%'+QUERY'%",
                     visit(node.sql),
+                    "%'DYNAMIC'%",
+                    node.dynamic ? "true" : "false",
                     "%'+HOST-EXPRS'%",
                     hostExprs.setDelimiter(","));
         }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
@@ -1241,16 +1241,55 @@ public class TypeChecker extends AstVisitor<Type> {
         return null; // nothing to do
     }
 
-    @Override
-    public Type visitStmtOpenFor(StmtOpenFor node) {
+    private Type visitStmtOpenFor(StmtOpenFor node) {
+
         Type ty = visitExprId(node.id);
         assert ty == Type.SYS_REFCURSOR; // by earlier check
 
-        assert node.staticSql != null;
-        assert node.staticSql.intoTargetList == null; // by earlier check
+        // check types of used expressions (
+        if (node.usedExprList != null) {
 
-        typeCheckHostExprs(node.staticSql); // s407
+            for (Expr e : node.usedExprList) {
+
+                Type tyUsedExpr = visit(e);
+                switch (tyUsedExpr.idx) {
+                    case Type.IDX_RECORD:
+                        if (!node.dynamic) {
+                            break;
+                        }
+                    case Type.IDX_CURSOR:
+                    case Type.IDX_BOOLEAN:
+                    case Type.IDX_SYS_REFCURSOR:
+                        throw new SemanticError(
+                                Misc.getLineColumnOf(e.ctx), // s242
+                                "expressions in a USING clause cannot be of "
+                                        + tyUsedExpr.plcName
+                                        + " type");
+                    default:; // OK
+                }
+            }
+        }
+
         return null;
+    }
+
+    @Override
+    public Type visitStmtOpenForStatic(StmtOpenForStatic node) {
+        return visitStmtOpenFor(node);
+    }
+
+    @Override
+    public Type visitStmtOpenForDynamic(StmtOpenForDynamic node) {
+
+        // type of sql must be STRING
+        Type sqlType = visit(node.sql);
+        if (sqlType.idx != Type.IDX_STRING) {
+            throw new SemanticError(
+                    Misc.getLineColumnOf(node.sql.ctx), // s241
+                    "SQL in the OPEN-FOR statement must be of a string type");
+        }
+
+        return visitStmtOpenFor(node);
     }
 
     @Override
@@ -1457,10 +1496,16 @@ public class TypeChecker extends AstVisitor<Type> {
         LinkedHashMap<Expr, Type> hostExprs = staticSql.hostExprs;
         for (Expr e : hostExprs.keySet()) {
             Type ty = visit(e);
-            if (ty == Type.BOOLEAN || ty == Type.CURSOR || ty == Type.SYS_REFCURSOR) {
-                throw new SemanticError(
-                        Misc.getLineColumnOf(e.ctx),
-                        "host expressions cannot be of either BOOLEAN, CURSOR or SYS_REFCURSOR type");
+            switch (ty.idx) {
+                    // NOTE: Type.IDX_RECORD is allowed
+                case Type.IDX_CURSOR:
+                case Type.IDX_BOOLEAN:
+                case Type.IDX_SYS_REFCURSOR:
+                    throw new SemanticError(
+                            Misc.getLineColumnOf(e.ctx),
+                            "host expressions cannot be of either BOOLEAN, CURSOR or SYS_REFCURSOR type");
+
+                default:; // OK
             }
 
             /* TODO

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
@@ -1246,7 +1246,7 @@ public class TypeChecker extends AstVisitor<Type> {
         Type ty = visitExprId(node.id);
         assert ty == Type.SYS_REFCURSOR; // by earlier check
 
-        // check types of used expressions (
+        // check types of used expressions
         if (node.usedExprList != null) {
 
             for (Expr e : node.usedExprList) {
@@ -1257,6 +1257,7 @@ public class TypeChecker extends AstVisitor<Type> {
                         if (!node.dynamic) {
                             break;
                         }
+                        // fall-through
                     case Type.IDX_CURSOR:
                     case Type.IDX_BOOLEAN:
                     case Type.IDX_SYS_REFCURSOR:

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -626,6 +626,7 @@ public class SpLib {
             }
 
             assert myStmt == null;
+            assert rs == null;
 
             PreparedStatement pstmt = null;
             try {
@@ -647,7 +648,7 @@ public class SpLib {
                 if (dynamic) {
                     ResultSetMetaData rsmd = pstmt.getMetaData();
                     if (rsmd == null || rsmd.getColumnCount() < 1) {
-                        throw new RuntimeException("dynamic SQL must be a SELECT statement");
+                        throw new SQL_ERROR("dynamic SQL must be a SELECT statement");
                     }
                 }
 
@@ -655,55 +656,52 @@ public class SpLib {
                     pstmt.setObject(i + 1, val[i]);
                 }
                 rs = pstmt.executeQuery();
-            } catch (Exception e) {
-                if (pstmt != null) {
-                    try {
-                        pstmt.close();
-                    } catch (Exception ee) {
-                        // ignore ee
+            } catch (SQLException e) {
+                throw new SQL_ERROR(e.getMessage());
+            } finally {
+                if (rs == null) {
+                    // exception case
+                    if (pstmt != null) {
+                        try {
+                            pstmt.close();
+                        } catch (Exception ee) {
+                            // ignore ee
+                        }
                     }
-                }
 
-                if (pstmtRef == null) {
-                    myStmt = null;
-                }
-
-                if (e instanceof SQLException) {
-                    throw new SQL_ERROR(e.getMessage());
-                } else {
-                    throw new RuntimeException(e);
+                    if (pstmtRef == null) {
+                        myStmt = null;
+                    }
                 }
             }
         }
 
         public void close() {
+            if (!isOpen()) {
+                throw new INVALID_CURSOR("attempted to close an unopened cursor");
+            }
+
             try {
-                if (!isOpen()) {
-                    throw new INVALID_CURSOR("attempted to close an unopened cursor");
-                }
                 if (myStmt == null) {
                     // no need to close the statement because it was declared and is closed outside
                     // of this Query
                     // close only the result set.
                     rs.close();
-                    rs = null;
                 } else {
-                    myStmt.close(); // it also closes rs according to the JDBC spec: see Javadoc
-                    // on Statement.close()
-                    myStmt = null;
-                    rs = null;
+                    // it also closes rs according to the JDBC spec: see Javadoc on
+                    // Statement.close()
+                    myStmt.close();
                 }
             } catch (SQLException e) {
                 throw new SQL_ERROR(e.getMessage());
+            } finally {
+                rs = null;
+                myStmt = null;
             }
         }
 
         public boolean isOpen() {
-            try {
-                return (rs != null && !rs.isClosed());
-            } catch (SQLException e) {
-                throw new SQL_ERROR(e.getMessage());
-            }
+            return (rs != null);
         }
 
         public boolean fetch() {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -33,10 +33,12 @@ package com.cubrid.plcsql.predefined.sp;
 import com.cubrid.jsp.Server;
 import com.cubrid.jsp.SysParam;
 import com.cubrid.jsp.context.Context;
+import com.cubrid.jsp.jdbc.CUBRIDServerSideStatement;
 import com.cubrid.jsp.value.DateTimeParser;
 import com.cubrid.plcsql.builtin.DBMS_OUTPUT;
 import com.cubrid.plcsql.compiler.CoercionScheme;
 import com.cubrid.plcsql.compiler.annotation.Operator;
+import com.cubrid.plcsql.compiler.serverapi.ServerConstants;
 import com.cubrid.plcsql.compiler.type.Type;
 import com.cubrid.plcsql.predefined.PlcsqlRuntimeError;
 import java.math.BigDecimal;
@@ -613,6 +615,10 @@ public class SpLib {
         private PreparedStatement myStmt;
 
         public Query(String query, boolean dynamic) {
+
+            if (query == null) {
+                throw new SQL_ERROR("SQL part was evaluated to NULL");
+            }
             this.query = query;
             this.dynamic = dynamic;
         }
@@ -646,8 +652,11 @@ public class SpLib {
                 }
 
                 if (dynamic) {
-                    ResultSetMetaData rsmd = pstmt.getMetaData();
-                    if (rsmd == null || rsmd.getColumnCount() < 1) {
+                    byte stmtType =
+                            ((CUBRIDServerSideStatement) pstmt)
+                                    .getStatementHandler()
+                                    .getStatementType();
+                    if (stmtType != ServerConstants.CUBRID_STMT_SELECT) {
                         throw new SQL_ERROR("dynamic SQL must be a SELECT statement");
                     }
                 }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -628,6 +628,8 @@ public class SpLib {
                     throw new CURSOR_ALREADY_OPEN();
                 }
 
+                assert myStmt == null;
+
                 PreparedStatement pstmt;
 
                 // using pstmtRef is for the loop optimization:
@@ -648,6 +650,11 @@ public class SpLib {
                 if (dynamic) {
                     ResultSetMetaData rsmd = pstmt.getMetaData();
                     if (rsmd == null || rsmd.getColumnCount() < 1) {
+                        // the query is not a SELECT statement
+                        pstmt.close();
+                        if (pstmtRef == null) {
+                            myStmt = null;
+                        }
                         throw new SQL_ERROR("dynamic SQL must be a SELECT statement");
                     }
                 }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -623,14 +623,13 @@ public class SpLib {
 
             assert val != null;
 
+            PreparedStatement pstmt = null;
             try {
                 if (isOpen()) {
                     throw new CURSOR_ALREADY_OPEN();
                 }
 
                 assert myStmt == null;
-
-                PreparedStatement pstmt;
 
                 // using pstmtRef is for the loop optimization:
                 //  preparing the statement once and closing it once for the whole iterations
@@ -650,11 +649,6 @@ public class SpLib {
                 if (dynamic) {
                     ResultSetMetaData rsmd = pstmt.getMetaData();
                     if (rsmd == null || rsmd.getColumnCount() < 1) {
-                        // the query is not a SELECT statement
-                        pstmt.close();
-                        if (pstmtRef == null) {
-                            myStmt = null;
-                        }
                         throw new SQL_ERROR("dynamic SQL must be a SELECT statement");
                     }
                 }
@@ -663,8 +657,17 @@ public class SpLib {
                     pstmt.setObject(i + 1, val[i]);
                 }
                 rs = pstmt.executeQuery();
-            } catch (SQLException e) {
-                Server.log(e);
+            } catch (Throwable e) {
+                if (pstmt != null) {
+                    try {
+                        pstmt.close();
+                    } catch (Throwable ee) {
+                        // ignore ee
+                    }
+                }
+                if (pstmtRef == null) {
+                    myStmt = null;
+                }
                 throw new SQL_ERROR(e.getMessage());
             }
         }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -405,14 +405,12 @@ public class SpLib {
                 throw new PROGRAM_ERROR(); // unreachable
             }
         } catch (SQLException e) {
-            Server.log(e);
             throw new SQL_ERROR(e.getMessage());
         } finally {
             if (pstmtRef == null && pstmt != null) {
                 try {
                     pstmt.close();
                 } catch (SQLException e) {
-                    Server.log(e);
                     throw new SQL_ERROR(e.getMessage());
                 }
             }
@@ -696,7 +694,6 @@ public class SpLib {
                     rs = null;
                 }
             } catch (SQLException e) {
-                Server.log(e);
                 throw new SQL_ERROR(e.getMessage());
             }
         }
@@ -705,7 +702,6 @@ public class SpLib {
             try {
                 return (rs != null && !rs.isClosed());
             } catch (SQLException e) {
-                Server.log(e);
                 throw new SQL_ERROR(e.getMessage());
             }
         }
@@ -728,7 +724,6 @@ public class SpLib {
                     return false;
                 }
             } catch (SQLException e) {
-                Server.log(e);
                 throw new SQL_ERROR(e.getMessage());
             }
         }
@@ -741,7 +736,6 @@ public class SpLib {
                 }
                 return rowCount < 0 ? null : (rs.getRow() > 0);
             } catch (SQLException e) {
-                Server.log(e);
                 throw new SQL_ERROR(e.getMessage());
             }
         }
@@ -754,7 +748,6 @@ public class SpLib {
                 }
                 return rowCount < 0 ? null : (rs.getRow() == 0);
             } catch (SQLException e) {
-                Server.log(e);
                 throw new SQL_ERROR(e.getMessage());
             }
         }
@@ -770,7 +763,6 @@ public class SpLib {
             try {
                 rowCount = rs.getRow();
             } catch (SQLException e) {
-                Server.log(e);
                 throw new SQL_ERROR(e.getMessage());
             }
         }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -657,18 +657,24 @@ public class SpLib {
                     pstmt.setObject(i + 1, val[i]);
                 }
                 rs = pstmt.executeQuery();
-            } catch (Throwable e) {
+            } catch (Exception e) {
                 if (pstmt != null) {
                     try {
                         pstmt.close();
-                    } catch (Throwable ee) {
+                    } catch (Exception ee) {
                         // ignore ee
                     }
                 }
+
                 if (pstmtRef == null) {
                     myStmt = null;
                 }
-                throw new SQL_ERROR(e.getMessage());
+
+                if (e instanceof SQLException) {
+                    throw new SQL_ERROR(e.getMessage());
+                } else {
+                    throw new RuntimeException(e);
+                }
             }
         }
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -614,6 +614,10 @@ public class SpLib {
 
         private PreparedStatement myStmt;
 
+        public Query(String query) {
+            this(query, false);
+        }
+
         public Query(String query, boolean dynamic) {
 
             if (query == null) {

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -608,13 +608,15 @@ public class SpLib {
 
     public static class Query {
         public final String query;
+        public final boolean dynamic;
         public ResultSet rs;
         public int rowCount = -1;
 
         private PreparedStatement myStmt;
 
-        public Query(String query) {
+        public Query(String query, boolean dynamic) {
             this.query = query;
+            this.dynamic = dynamic;
         }
 
         public void open(Connection conn, PreparedStatement[] pstmtRef, Object... val) {
@@ -640,6 +642,13 @@ public class SpLib {
                     if (pstmt == null) {
                         pstmt = conn.prepareStatement(query);
                         pstmtRef[0] = pstmt; // store it for the later loop iterations
+                    }
+                }
+
+                if (dynamic) {
+                    ResultSetMetaData rsmd = pstmt.getMetaData();
+                    if (rsmd == null || rsmd.getColumnCount() < 1) {
+                        throw new SQL_ERROR("dynamic SQL must be a SELECT statement");
                     }
                 }
 

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -684,8 +684,7 @@ public class SpLib {
             try {
                 if (myStmt == null) {
                     // no need to close the statement because it was declared and is closed outside
-                    // of this Query
-                    // close only the result set.
+                    // of this Query close only the result set.
                     rs.close();
                 } else {
                     // it also closes rs according to the JDBC spec: see Javadoc on

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -623,14 +623,14 @@ public class SpLib {
 
             assert val != null;
 
+            if (isOpen()) {
+                throw new CURSOR_ALREADY_OPEN();
+            }
+
+            assert myStmt == null;
+
             PreparedStatement pstmt = null;
             try {
-                if (isOpen()) {
-                    throw new CURSOR_ALREADY_OPEN();
-                }
-
-                assert myStmt == null;
-
                 // using pstmtRef is for the loop optimization:
                 //  preparing the statement once and closing it once for the whole iterations
                 if (pstmtRef == null) {
@@ -649,7 +649,7 @@ public class SpLib {
                 if (dynamic) {
                     ResultSetMetaData rsmd = pstmt.getMetaData();
                     if (rsmd == null || rsmd.getColumnCount() < 1) {
-                        throw new SQL_ERROR("dynamic SQL must be a SELECT statement");
+                        throw new RuntimeException("dynamic SQL must be a SELECT statement");
                     }
                 }
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-25855>

### Purpose

- OPEN FOR 문에 EXECUTE IMMEDIATE 처럼 dynamic sql (문자열) 을 허용하는 기능을 추가 구현합니다. 
- USING 절을 두어 문자열 안 SQL 안에 호스트변수가 있는 경우 바인드 할 수 있게 한다. (EXECUTE IMMEDIATE 처럼)

### Remarks

기술지원팀의 전환 업무에 필요성이 있어 11.4 에 먼저 구현 했습니다. guava 버전에도 차후 port 할 예정입니다. 
