### PR TITLE
[CBRD-26899] assert when performing a MULTI UPDATE on a table with an index in SA_MODE

### DIFF
--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -786,6 +786,12 @@ locator_force (LC_COPYAREA * copy_area, int num_ignore_error_list, int *ignore_e
 
   exit_server (*thread_p);
 
+  /* unset start_multi_update flag after first request containing it set */
+  if (locator_manyobj_flag_is_set (LC_MANYOBJS_PTR_IN_COPYAREA (copy_area), START_MULTI_UPDATE))
+    {
+      locator_manyobj_flag_remove (LC_MANYOBJS_PTR_IN_COPYAREA (copy_area), START_MULTI_UPDATE);
+    }
+
   if (error_code != NO_ERROR)
     {
       /* Restore copy_area */

--- a/src/communication/network_interface_cl.c
+++ b/src/communication/network_interface_cl.c
@@ -787,9 +787,10 @@ locator_force (LC_COPYAREA * copy_area, int num_ignore_error_list, int *ignore_e
   exit_server (*thread_p);
 
   /* unset start_multi_update flag after first request containing it set */
-  if (locator_manyobj_flag_is_set (LC_MANYOBJS_PTR_IN_COPYAREA (copy_area), START_MULTI_UPDATE))
+  LC_COPYAREA_MANYOBJS *mobjs = LC_MANYOBJS_PTR_IN_COPYAREA (copy_area);
+  if (locator_manyobj_flag_is_set (mobjs, START_MULTI_UPDATE))
     {
-      locator_manyobj_flag_remove (LC_MANYOBJS_PTR_IN_COPYAREA (copy_area), START_MULTI_UPDATE);
+      locator_manyobj_flag_remove (mobjs, START_MULTI_UPDATE);
     }
 
   if (error_code != NO_ERROR)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26899>

### Purpose

* 클라이언트에서 아래의 조건에서 MULTI UPDATE를 다중 배치로 수행할 때 assert 발생

> - INDEX가 생성되어 있어야 함
> - TRIGGER 분기로 인한 클라이언트에서의 UPDATE 수행
> - 16KB 페이지 버퍼를 넘어가는 UPDATE 수

CREATE TABLE t_target (id INT PRIMARY KEY, val VARCHAR(1000));
CREATE TABLE t_source (id INT PRIMARY KEY, val VARCHAR(1000));

```
-- before 트리거: MERGE가 클라이언트 측 행 단위 갱신 경로를 타도록 강제
CREATE TRIGGER trg_t_target_bu BEFORE UPDATE ON t_target EXECUTE PRINT 'bu';

INSERT INTO t_target
SELECT level, LPAD('t', 500, 't') FROM db_root CONNECT BY level <= 500;
INSERT INTO t_source
SELECT level, LPAD('s', 500, 's') FROM db_root CONNECT BY level <= 500;

-- 키가 아닌 컬럼(val)만 갱신해도 재현됨 (유니크 키를 실제로 바꿀 필요 없음)
MERGE INTO t_target t USING t_source s ON (t.id = s.id)
WHEN MATCHED THEN UPDATE SET t.val = s.val;

COMMIT;
```

----

csql: /home/cubrid/cubrid/src/transaction/locator_sr.c:6571: int locator_force_for_multi_update(THREAD_ENTRY*, LC_COPYAREA*): Assertion `tdes->m_multiupd_stats.empty ()' failed.
Aborted (core dumped)

### Implementation

SA_MODE 분기, xlocator_force 호출 직후에 플래그 제거 추가.

### Remarks

N/A
