### PR TITLE
[CBRD-26579] Fix max_key_len invariant violation by in-place DELETE_FLAG key insertion during online index build

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -35257,6 +35257,21 @@ btree_key_online_index_tran_delete (THREAD_ENTRY * thread_p, BTID_INT * btid_int
 	  goto end;
 	}
 
+      /* We cannot insert a new key longer than this node's max_key_len in place. It would break the invariant that
+       * a parent's max_key_len is always greater than or equal to its child's: the delete traversal that brought us
+       * here, unlike the insert traversal, does not update max_key_len on the nodes in the path from root. Restart
+       * and insert the key with DELETE_FLAG through the normal insert traversal instead. */
+      if (search_key->result != BTREE_KEY_FOUND)
+	{
+	  BTREE_NODE_HEADER *node_header = btree_get_node_header (thread_p, *leaf_page);
+
+	  if (node_header == NULL || node_header->max_key_len < helper->insert_helper.key_len_in_page)
+	    {
+	      search_key->result = BTREE_KEY_NOTFOUND;
+	      goto end;
+	    }
+	}
+
       /* Set DELETE_FLAG in the helper structure. */
       helper->insert_helper.obj_info.mvcc_info.flags |= BTREE_OID_HAS_MVCC_INSID;
       btree_online_index_set_delete_flag_state (helper->insert_helper.obj_info.mvcc_info.insert_mvccid);

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -35265,7 +35265,14 @@ btree_key_online_index_tran_delete (THREAD_ENTRY * thread_p, BTID_INT * btid_int
 	{
 	  BTREE_NODE_HEADER *node_header = btree_get_node_header (thread_p, *leaf_page);
 
-	  if (node_header == NULL || node_header->max_key_len < helper->insert_helper.key_len_in_page)
+	  if (node_header == NULL)
+	    {
+	      assert_release (false);
+	      error_code = ER_FAILED;
+	      goto end;
+	    }
+
+	  if (node_header->max_key_len < helper->insert_helper.key_len_in_page)
 	    {
 	      search_key->result = BTREE_KEY_NOTFOUND;
 	      goto end;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26579>

### Purpose
Online index build 중 transaction이 아직 builder가 insert하지 않은 row를 delete하면, 해당 key/OID를 DELETE_FLAG marker로 새 index에 insert한다. delete traversal로 도달한 leaf에 공간이 있으면 그 자리에서 바로 insert했는데, delete traversal(`btree_merge_node_and_advance`)은 insert traversal(`btree_split_node_and_advance`)과 달리 root부터 leaf까지 경로의 node max_key_len을 갱신하지 않는다.

따라서 leaf의 현재 max_key_len보다 긴 key를 in-place로 insert하면 leaf의 max_key_len만 커지고 ancestor는 그대로 남아, "parent의 max_key_len >= child의 max_key_len" b-tree invariant가 깨진다. 이후 해당 node를 지나는 normal insert traversal에서 아래 assert가 발생한다.

  ```c
  assert (parent_max_key_len >= node_header->max_key_len);   // btree_split_node_and_advance()
  ```

### Implementation

  - `btree_key_online_index_tran_delete()`의 in-place DELETE_FLAG insert 전에 가드를 추가한다.
    - 새 key를 추가하는 경우(`search_key->result != BTREE_KEY_FOUND`)에만 검사한다. 기존 key에 OID를 append하는 경우는 key 길이가 변하지 않아 max_key_len에 영향이 없으므로 fast path를 유지한다.
    - leaf node header를 읽어 새 key의 in-page 길이(`key_len_in_page`)가 leaf의 max_key_len보다 큰지 확인한다. 크면(또는 header를 읽지 못하면) in-place insert를 포기한다.

  - 포기 시 `search_key->result = BTREE_KEY_NOTFOUND`로 설정하고 반환한다.
    - dispatcher(`btree_online_index_dispatcher`)는 delete traversal이 NOTFOUND를 반환하면 root_function/advance_function/key_function을 insert 계열(`btree_fix_root_for_insert` / `btree_split_node_and_advance` / `btree_key_online_index_tran_insert_DF`)로 교체하여 재탐색한다. (기존에 overflow-key 처리에 쓰던 restart 경로를 그대로 재사용)
    - 이 insert traversal은 root→leaf 경로의 max_key_len을 위에서부터 갱신하므로, leaf의 max_key_len이 커지기 전에 모든 ancestor가 먼저 갱신되어 invariant가 유지된다.

  - in-place insert가 max_key_len을 키우지 않는 경우는 ancestor 갱신이 불필요하므로 기존 fast path를 그대로 허용한다.

### Remarks
