### PR TITLE
[CBRD-26985] Fix OOS copyarea lock fetch crash

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -35,7 +35,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
-#include <stdint.h>
 
 #include "heap_file.h"
 #include "heap_oos.hpp"
@@ -27340,16 +27339,7 @@ heap_scancache::is_recdes_assigned_to_area (const RECDES & recdes) const
       return false;
     }
 
-  const uintptr_t area_start_addr = (uintptr_t) area_start;
-  const uintptr_t area_end_addr = area_start_addr + (uintptr_t) area_size;
-  const uintptr_t recdes_data_addr = (uintptr_t) recdes.data;
-  if (area_end_addr < area_start_addr)
-    {
-      return false;
-    }
-
-  /* recdes.data may be caller-owned; avoid relational comparisons between unrelated pointers. */
-  return area_start_addr <= recdes_data_addr && recdes_data_addr < area_end_addr;
+  return recdes.data == area_start;
 }
 
 const cubmem::block_allocator &

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -27067,8 +27067,8 @@ heap_init_get_context (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context, cons
   context->expand_oos = false;
   const bool data_is_scan_cache_area =
     scan_cache != NULL && recdes != NULL && scan_cache->is_recdes_assigned_to_area (*recdes);
-  context->keep_recdes_buffer =
-    recdes != NULL && recdes->data != NULL && recdes->area_size >= 0 && !data_is_scan_cache_area;
+  /* Caller-positioned buffers remain owned by the caller even after their writable area is exhausted. */
+  context->keep_recdes_buffer = recdes != NULL && recdes->data != NULL && !data_is_scan_cache_area;
   if (scan_cache != NULL && scan_cache->page_latch == X_LOCK)
     {
       context->latch_mode = PGBUF_LATCH_WRITE;
@@ -27327,7 +27327,19 @@ heap_scancache::assign_recdes_to_area (RECDES & recdes, size_t size /* = 0 */)
 bool
 heap_scancache::is_recdes_assigned_to_area (const RECDES & recdes) const
 {
-  return m_area != NULL && recdes.data == m_area->get_ptr ();
+  if (m_area == NULL || recdes.data == NULL)
+    {
+      return false;
+    }
+
+  const char *area_start = m_area->get_ptr ();
+  if (area_start == NULL)
+    {
+      return false;
+    }
+  const char *area_end = area_start + m_area->get_size ();
+
+  return area_start <= recdes.data && recdes.data <= area_end;
 }
 
 const cubmem::block_allocator &

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -35,6 +35,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#include <stdint.h>
 
 #include "heap_file.h"
 #include "heap_oos.hpp"
@@ -27333,13 +27334,22 @@ heap_scancache::is_recdes_assigned_to_area (const RECDES & recdes) const
     }
 
   const char *area_start = m_area->get_ptr ();
-  if (area_start == NULL)
+  const size_t area_size = m_area->get_size ();
+  if (area_start == NULL || area_size == 0)
     {
       return false;
     }
-  const char *area_end = area_start + m_area->get_size ();
 
-  return area_start <= recdes.data && recdes.data <= area_end;
+  const uintptr_t area_start_addr = (uintptr_t) area_start;
+  const uintptr_t area_end_addr = area_start_addr + (uintptr_t) area_size;
+  const uintptr_t recdes_data_addr = (uintptr_t) recdes.data;
+  if (area_end_addr < area_start_addr)
+    {
+      return false;
+    }
+
+  /* recdes.data may be caller-owned; avoid relational comparisons between unrelated pointers. */
+  return area_start_addr <= recdes_data_addr && recdes_data_addr < area_end_addr;
 }
 
 const cubmem::block_allocator &

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -27327,19 +27327,7 @@ heap_scancache::assign_recdes_to_area (RECDES & recdes, size_t size /* = 0 */)
 bool
 heap_scancache::is_recdes_assigned_to_area (const RECDES & recdes) const
 {
-  if (m_area == NULL || recdes.data == NULL)
-    {
-      return false;
-    }
-
-  const char *area_start = m_area->get_ptr ();
-  const size_t area_size = m_area->get_size ();
-  if (area_start == NULL || area_size == 0)
-    {
-      return false;
-    }
-
-  return recdes.data == area_start;
+  return m_area != NULL && recdes.data == m_area->get_ptr ();
 }
 
 const cubmem::block_allocator &

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -382,7 +382,7 @@ struct heap_get_context
 				 * (like serial increment) require WRITE mode */
 
   bool expand_oos;		/* if true, replace inline OOS OID slots with actual values */
-  bool keep_recdes_buffer;	/* true if recdes_p->data must not be rebound to scan cache */
+  bool keep_recdes_buffer;	/* true if caller-positioned recdes_p->data must not be rebound to scan cache */
 };
 
 typedef struct sampling_info SAMPLING_INFO;


### PR DESCRIPTION
https://jira.cubrid.org/browse/CBRD-26985

## Purpose

- OOS (큰 컬럼 값을 heap 밖에 저장하고 읽을 때 원래 record 로 펼치는 기능) expand 중 heap fetch 가 caller-owned buffer 를 scan cache 로 바꿔 `LC_COPYAREA` descriptor 와 실제 bytes 위치가 어긋나는 문제를 고친다.
- `ALTER TABLE ... CHANGE` domain upgrade 에서 발생한 crash 와 그 뒤의 DB recovery 실패 cascade 를 막는다.

## Implementation

- `heap_init_get_context` 에서 `keep_recdes_buffer` 판정의 `area_size >= 0` 조건을 제거했다. caller 가 위치시킨 `RECDES.data` 는 남은 공간이 부족해도 caller-owned 로 유지한다.
- `heap_scancache::is_recdes_assigned_to_area` 는 scan-cache 시작 주소만 보지 않고 block 내부 전체 range 를 검사한다.
- caller-owned buffer 에 record 가 들어가지 않으면 heap 이 scan cache 로 성공 rebind 하지 않고 기존 `S_DOESNT_FIT` grow/retry 흐름을 타게 한다.

## Remarks

- 리뷰 포인트: 이번 PR 은 locator helper 를 새로 추가하지 않고 heap layer 의 buffer ownership 판정을 바로잡는다.
- 검증: `git diff --check` 통과, 새 heap-side approach 후 재현 SQL 정상 종료 확인.
- insert-side `OOS+REC_BIGONE` abort 는 별도 문제이며 CBRD-26937 범위로 둔다.
- 자세한 설명: https://github.com/vimkim/my-cubrid-docs/blob/main/cbrd-26985/CBRD-26985-oos-copyarea-lock-fetch.md
