### PR TITLE
[CBRD-26822] (hotfix) Fix LOB path prefix on OOS branch

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -12407,7 +12407,14 @@ heap_attrinfo_dbvalue_to_recdes (THREAD_ENTRY * thread_p, HEAP_ATTRVALUE * value
 	}
       save_meta_data = elo_p->meta_data;
       elo_p->meta_data = new_meta_data;
-      rv = db_elo_copy (db_get_elo (dbvalue), &dest_elo);
+      {
+	HFID hfid;
+	char lob_path_prefix[PATH_MAX];
+
+	heap_hfid_cache_get (thread_p, &class_oid, &hfid, NULL, NULL);
+	snprintf (lob_path_prefix, PATH_MAX, "%d%d%d%d", HFID_AS_ARGS (&hfid), value->attrid);
+	rv = db_elo_copy_with_prefix (db_get_elo (dbvalue), lob_path_prefix, &dest_elo);
+      }
 
       free_and_init (elo_p->meta_data);
       elo_p->meta_data = save_meta_data;
@@ -12866,7 +12873,14 @@ heap_attrinfo_transform_variable_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_AT
 	    }
 	  save_meta_data = elo_p->meta_data;
 	  elo_p->meta_data = new_meta_data;
-	  rv = db_elo_copy (db_get_elo (dbvalue), &dest_elo);
+	  {
+	    HFID hfid;
+	    char lob_path_prefix[PATH_MAX];
+
+	    heap_hfid_cache_get (thread_p, &attr_info->class_oid, &hfid, NULL, NULL);
+	    snprintf (lob_path_prefix, PATH_MAX, "%d%d%d%d", HFID_AS_ARGS (&hfid), value->attrid);
+	    rv = db_elo_copy_with_prefix (db_get_elo (dbvalue), lob_path_prefix, &dest_elo);
+	  }
 
 	  free_and_init (elo_p->meta_data);
 	  elo_p->meta_data = save_meta_data;


### PR DESCRIPTION
https://jira.cubrid.org/browse/CBRD-26822

## Purpose

- `feat/oos` 에서 CLOB/BLOB 값을 INSERT 하면 LOB 파일 경로에 테이블별 prefix 가 빠지는 문제가 있었습니다.
- 이 때문에 row 에 locator 는 저장되지만 실제 파일을 찾지 못해 `CLOB_FROM_FILE` 과 `BLOB_FROM_FILE` 이 실패했습니다.
- INSERT 때도 CREATE TABLE 때 만든 LOB 디렉터리 prefix 를 쓰도록 복구합니다.

## Implementation

- `src/storage/heap_file.c` 의 `heap_attrinfo_dbvalue_to_recdes` LOB 경로에서 HFID 와 attrid 로 `lob_path_prefix` 를 만들었습니다.
- 같은 함수에서 `db_elo_copy` 대신 `db_elo_copy_with_prefix` 를 호출하도록 바꿨습니다.
- `heap_attrinfo_transform_variable_to_disk` 의 LOB 경로에도 같은 prefix 복구를 적용했습니다.
- ES, ELO, `locator_sr`, OOS expand, index, WAL 코드는 바꾸지 않았습니다.

## Remarks

- `origin/develop` 의 LOB INSERT 경로와 같은 prefix 형식인 `"%d%d%d%d"` 를 사용합니다.
- `feat/oos` 의 함수 모양은 develop 과 조금 달라서 attribute id 는 `value->attrid` 에서 가져옵니다.
- debug 빌드와 CLOB round-trip 재현 테스트로 `'hello'` 반환 및 LOB 파일 생성을 확인했습니다.
- 자세한 설명: https://github.com/vimkim/my-cubrid-docs/blob/main/cbrd-26822/CBRD-26822-restore-lob-path-prefix.md
