### PR TITLE
[CBRD-26994] Fix CDC log record loss on resume by resetting producer process_lsa to the new extraction LSA

### DIFF
--- a/src/communication/network_interface_sr.cpp
+++ b/src/communication/network_interface_sr.cpp
@@ -11370,6 +11370,11 @@ scdc_get_loginfo_metadata (THREAD_ENTRY *thread_p, unsigned int rid, char *reque
 	  goto error;
 	}
 
+      if (cdc_Gl.producer.state != CDC_PRODUCER_STATE_WAIT)
+	{
+	  cdc_pause_producer ();
+	}
+
       cdc_set_extraction_lsa (&start_lsa);
 
       cdc_reinitialize_queue (&start_lsa);

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -881,8 +881,6 @@ typedef struct cdc_global
   LOG_LSA first_loginfo_queue_lsa;
   LOG_LSA last_loginfo_queue_lsa;
 
-  bool is_queue_reinitialized;
-
 } CDC_GLOBAL;
 
 /* will be moved to new file for CDC */

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -821,6 +821,7 @@ typedef struct cdc_temp_logbuf
 typedef struct cdc_producer
 {
   LOG_LSA next_extraction_lsa;
+  bool is_reset_process_lsa;
 
   /* configuration */
   int all_in_cond;

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -11142,6 +11142,18 @@ cdc_loginfo_producer_execute (cubthread::entry & thread_ref)
       LSA_SET_NULL (&log_info_entry.next_lsa);
       log_info_entry.log_info = NULL;
 
+      /* Re-sync to the requested extraction LSA.  When a new extraction LSA is
+       * set (queue reinit / initialize / cleanup), the local process_lsa may
+       * still point past it from the previous session; the block below would
+       * then copy that stale local position back into next_extraction_lsa and
+       * resume ahead of the requested LSA, skipping log records.  Reset it to
+       * NULL so the block below adopts next_extraction_lsa instead. */
+      if (cdc_Gl.producer.is_reset_process_lsa)
+	{
+	  LSA_SET_NULL (&process_lsa);
+	  cdc_Gl.producer.is_reset_process_lsa = false;
+	}
+
       if (LSA_ISNULL (&process_lsa))
 	{
 	  LSA_COPY (&process_lsa, &cdc_Gl.producer.next_extraction_lsa);
@@ -14570,6 +14582,7 @@ cdc_reinitialize_queue (LOG_LSA * start_lsa)
 	}
       cdc_Gl.producer.produced_queue_size = 0;
       cdc_Gl.consumer.consumed_queue_size = 0;
+      cdc_Gl.producer.is_reset_process_lsa = true;
 
           /* *INDENT-OFF* */
     delete cdc_Gl.loginfo_queue;
@@ -15036,6 +15049,8 @@ cdc_initialize ()
   LSA_SET_NULL (&cdc_Gl.consumer.start_lsa);
   LSA_SET_NULL (&cdc_Gl.consumer.next_lsa);
 
+  cdc_Gl.producer.is_reset_process_lsa = true;
+
   return 0;
 }
 
@@ -15072,6 +15087,8 @@ cdc_cleanup ()
     {
       cdc_pause_producer ();
     }
+
+  cdc_Gl.producer.is_reset_process_lsa = true;
 
   cdc_free_extraction_filter ();
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -11202,16 +11202,6 @@ cdc_loginfo_producer_execute (cubthread::entry & thread_ref)
 	  tmp->log_info = log_info_entry.log_info;
 	  LSA_COPY (&tmp->next_lsa, &process_lsa);
 
-	  if (cdc_Gl.is_queue_reinitialized)
-	    {
-	      free_and_init (tmp->log_info);
-	      free_and_init (tmp);
-
-	      cdc_Gl.is_queue_reinitialized = false;
-
-	      continue;
-	    }
-
           /* *INDENT-OFF* */
 	  cdc_Gl.loginfo_queue->produce (tmp);
           /* *INDENT-ON* */
@@ -14540,8 +14530,6 @@ cdc_reinitialize_queue (LOG_LSA * start_lsa)
       cdc_log ("cdc_reinitialize_queue : don't need to be reinitialized");
       goto end;
     }
-
-  cdc_Gl.is_queue_reinitialized = true;
 
   if (LSA_LT (&cdc_Gl.first_loginfo_queue_lsa, start_lsa) && LSA_GE (&cdc_Gl.last_loginfo_queue_lsa, start_lsa))
     {


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26994>

### Purpose

CDC API 클라이언트(또는 CDC daemon)는 `cubrid_log_extract()` 가 반환한 next LSA 를 저장했다가
재기동 시 그 LSA 를 다시 입력으로 전달해 이어서 추출하는 것이 API contract 다.
그런데 다음 조건이 겹치면 저장한 LSA 로 재시작해도 그 사이 구간의 로그 레코드가 누락된다.

1. Consumer 가 일부 로그만 받고 반환된 LSA 를 저장한 채 종료한다.
2. 이때 producer thread 는 consumer 가 아직 받지 않은 로그를 내부 queue 에 선행 생산해 둔 상태다.
3. `cubrid_log_finalize()` 로 정상 종료하면서 그 queue 가 cleanup 으로 버려진다.
4. 저장한 LSA 로 다시 접속하면, producer thread 의 로컬 `process_lsa` 가 이전 세션의
   더 앞선 진행 위치를 그대로 유지한 채 재개하여, 새로 설정된 global `next_extraction_lsa`
   보다 뒤에서 추출을 이어간다.

결과적으로 이전 종료 시 queue 에 있었으나 consumer 에게 반환되지 않은 구간이
재시작 후에도 다시 읽히지 않아 유실된다.

핵심 원인은 `cdc_set_extraction_lsa()` 가 global `next_extraction_lsa` 만 갱신할 뿐,
`cdc_loginfo_producer_execute()` 의 로컬 `process_lsa` 는 한 번 non-NULL 이 되면
global 값을 다시 따라오지 않는다는 점이다. (`process_lsa` 가 NULL 일 때만 global 을
복사하고, 그 외에는 오히려 로컬이 global 을 덮어쓴다.)

```
source_count=2000
total_lines=1519   <- id 1020..1500 구간 481건 누락
missing_count=481
missing_ranges=1020-1500
```

### Implementation

Producer 가 새 추출 요청을 만나면 로컬 `process_lsa` 를 버리고 global
`next_extraction_lsa` 에서 다시 동기화하도록, queue 재초기화 / cleanup / 초기화
경로에서 reset 을 표시하는 플래그를 둔다.

**`src/transaction/log_impl.h` — `CDC_PRODUCER`**

```diff
 typedef struct cdc_producer
 {
   LOG_LSA next_extraction_lsa;
+  bool is_reset_process_lsa;
```

**`src/transaction/log_manager.c`**

- `is_reset_process_lsa` 를 `true` 로 세우는 3곳 (모두 producer lock 하):
  - `cdc_reinitialize_queue()` — queue 전체를 버리는(full-flush) 경로에서.
  - `cdc_cleanup()` — 무조건 (finalize 시 파킹 중 queue 가 비어 early-return 되는 경로까지 커버).
  - `cdc_initialize()` — 부팅 시.
- `cdc_loginfo_producer_execute()` 메인 루프에서, 로컬 `process_lsa` 를
  채택(`if (LSA_ISNULL (&process_lsa))`)하기 **직전**에 플래그를 확인해, 세워져 있으면
  `process_lsa` 를 `LSA_SET_NULL` 하고 플래그를 내린다. 그러면 이어지는 채택 블록이
  새 global `next_extraction_lsa` 를 복사해 그 위치부터 재개한다.
- `src/communication/network_interface_sr.cpp` : extraction LSA 를 재설정
  (`cdc_set_extraction_lsa()` → `cdc_reinitialize_queue()`)하기 전에 `cdc_pause_producer()`
  로 producer 를 먼저 park 시킨다. queue 재초기화가 producer 대기 상태에서만 일어나도록
  보장해, 재초기화 도중 in-flight 생산이 끼어드는 창을 없앤다.
- 위 pause 보장으로 재초기화 정합성이 구조적으로 성립하므로, 기존 `is_queue_reinitialized`
  플래그와 그 discard 휴리스틱(및 필드)을 제거한다.

```diff
+      if (cdc_Gl.producer.is_reset_process_lsa)
+        {
+          LSA_SET_NULL (&process_lsa);
+          cdc_Gl.producer.is_reset_process_lsa = false;
+        }
+
       if (LSA_ISNULL (&process_lsa))
         {
           LSA_COPY (&process_lsa, &cdc_Gl.producer.next_extraction_lsa);
         }
       else
         {
           LSA_COPY (&cdc_Gl.producer.next_extraction_lsa, &process_lsa);
         }
```

### Test

수정 전/후로 동일 재현 시나리오(supplemental_log=1, cdc_logging_debug=y)를 수행:
1500건 backlog → start LSA 로 추출 시작 → 1000여 건만 받고 `cubrid_log_finalize()`
→ 추가 500건 INSERT → 저장한 LSA 로 재시작 → source table 과 CDC 추출 id 비교.

| 항목 | Bug 빌드 | Fix 빌드 |
|---|---|---|
| source_count | 2000 | 2000 |
| CDC 추출(unique) | 1519 | 2000 |
| missing_count | 481 (`1020..1500`) | 0 |
| duplicate_count | 0 | 0 |
| partial → resume 경계 | 1019 → 1501 (구간 누락) | 1019 → 1020 (연속) |

Fix 빌드(`cdc_logging_debug=y`)의 재시작 로그에서, producer 로컬 `process_lsa` 가
NULL 로 리셋된 뒤 새 `next_extraction_lsa` 를 채택해 그 위치부터 재개하는 것을 확인했다.

### Remarks

- 이 유실은 CBRD-26316 이 producer 의 `process_lsa` NULL race 로 인한 core dump 를
  고치면서, 매 루프 global→로컬 재동기화하던 동작을 로컬 우선(로컬이 non-NULL 이면
  global 을 덮어씀)으로 바꾸며 유입된 회귀다. 본 수정은 그 core dump 방어를 유지한 채
  재시작 시점에만 로컬을 global 로 다시 맞춘다.
- 기존 CDC TC 중 `partial extract → client finalize → DML 추가 → saved LSA resume →
  누락 검증` 조합을 직접 검증하는 케이스가 없어, 별도 shell TC 추가가 필요하다.
  (유사 TC: `cbrd_23842_cdc/operate/oper03·oper04`, `api/api25`, `operlong01..05`)

