### PR TITLE
[CBRD-26990] Add hardware_affinity option to choose server boot mode.

### DIFF
--- a/src/base/ifsys.cpp
+++ b/src/base/ifsys.cpp
@@ -22,6 +22,7 @@
 
 #include <vector>
 #include <algorithm>
+#include <cerrno>
 #include <fstream>
 #include <iostream>
 #include <string>
@@ -129,16 +130,36 @@ namespace cubbase
 
   int ifsys::write_text (const char *path, const char *text)
   {
-    FILE *file;
+    int saved_errno;
     int success;
+    FILE *file;
 
     file = fopen (path, "w");
     if (!file)
       {
 	return -1;
       }
-    success = (fprintf (file, "%s\n", text) >= 0) ? 0 : -1;
-    fclose (file);
+    saved_errno = 0;
+    if (fprintf (file, "%s\n", text) >= 0)
+      {
+	success = 0;
+      }
+    else
+      {
+	success = -1;
+	saved_errno = errno;
+      }
+
+    if (fclose (file) != 0 && success == 0)
+      {
+	success = -1;
+	saved_errno = errno;
+      }
+
+    if (success != 0)
+      {
+	errno = saved_errno;
+      }
     return success;
   }
 
@@ -498,12 +519,18 @@ namespace cubbase
 
     if (write_text (p1, mask) != 0)
       {
+	int saved_errno = errno;
+	free (mask);
+	errno = saved_errno;
 	return false;
       }
     /* TODO: is it better to turn this off? */
     //if (write_text (p2, "4096") != 0)
     if (write_text (p2, "0") != 0)
       {
+	int saved_errno = errno;
+	free (mask);
+	errno = saved_errno;
 	return false;
       }
     free (mask);
@@ -525,23 +552,25 @@ namespace cubbase
 
     if (write_text (path, mask) != 0)
       {
+	int saved_errno = errno;
+	free (mask);
+	errno = saved_errno;
 	return false;
       }
     free (mask);
     return true;
   }
 
-  void ifsys::maybe_set_rps_sock_flow_entries (int ncores)
+  bool ifsys::maybe_set_rps_sock_flow_entries (int ncores)
   {
     const char *path = "/proc/sys/net/core/rps_sock_flow_entries";
 
     if (access (path, W_OK) != 0)
       {
-	return;
+	return false;
       }
     /* TODO: is it better to turn this off? */
     //write_int (path, (long long int) ncores * 4096);
-    write_int (path, 0);
+    return write_int (path, 0) == 0;
   }
 }
-

--- a/src/base/ifsys.cpp
+++ b/src/base/ifsys.cpp
@@ -565,10 +565,6 @@ namespace cubbase
   {
     const char *path = "/proc/sys/net/core/rps_sock_flow_entries";
 
-    if (access (path, W_OK) != 0)
-      {
-	return false;
-      }
     /* TODO: is it better to turn this off? */
     //write_int (path, (long long int) ncores * 4096);
     return write_int (path, 0) == 0;

--- a/src/base/ifsys.hpp
+++ b/src/base/ifsys.hpp
@@ -54,7 +54,7 @@ namespace cubbase
 
       static bool set_rps_for_queue (const char *ifname, int rxq, int cpu);
       static bool set_xps_for_queue (const char *ifname, int txq, int cpu);
-      static void maybe_set_rps_sock_flow_entries (int ncores);
+      static bool maybe_set_rps_sock_flow_entries (int ncores);
 
     private:
       static bool file_exists (const std::string &path);

--- a/src/base/resources.cpp
+++ b/src/base/resources.cpp
@@ -21,6 +21,9 @@
  */
 
 #include <cmath>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
 #include <iterator>
 #include <thread>
 #include <fstream>
@@ -28,6 +31,7 @@
 #include <net/if.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>
+#include <sys/wait.h>
 #include <linux/sockios.h>
 #include <linux/ethtool.h>
 
@@ -39,18 +43,48 @@
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
 #include "memory_wrapper.hpp"
 
+#define er_log_print(file, line, ...) do { \
+    _er_log_debug (file, line, __VA_ARGS__); \
+    printf (__VA_ARGS__); \
+} while (0)
+
 namespace os::resources
 {
+  static bool is_permission_error (int error)
+  {
+    return error == EACCES || error == EPERM;
+  }
+
+  static bool output_has_permission_error (const std::string &output)
+  {
+    return output.find ("Operation not permitted") != std::string::npos
+	   || output.find ("Permission denied") != std::string::npos;
+  }
+
+  static void guide_hardware_affinity_permission ()
+  {
+    er_log_print (__FILE__, __LINE__,
+		  "You must either start the server as the root user or grant the necessary capabilities "
+		  "to the server binary as shown below.\n"
+		  "(Note: It is recommended to disable irqbalance if you want this server to manage your hardware directly.)\n\n"
+		  "  $> sudo -E \"$CUBRID/bin/cubrid\" server start <db_name>\n\n"
+		  "or\n\n"
+		  "  $> sudo setcap \'cap_net_admin,cap_dac_override+ep\' \"$CUBRID/bin/cub_server\"\n"
+		  "  $> getcap \"$CUBRID/bin/cub_server\"\n"
+		  "\n");
+  }
+
   void initialize ()
   {
     os::resources::cpu::effective ();
   }
 
-  std::optional<std::string> execute_command (const char *cmd)
+  std::optional<std::pair<std::string, int>> execute_command (const char *cmd)
   {
     std::string result;
     char buffer[256];
     FILE *pipe;
+    int status;
 
     pipe = popen ((std::string (cmd) + " 2>&1").c_str (), "r");
     if (!pipe)
@@ -64,8 +98,12 @@ namespace os::resources
 	result += buffer;
       }
 
-    pclose (pipe);
-    return result;
+    status = pclose (pipe);
+    if (status == -1)
+      {
+	return std::nullopt;
+      }
+    return std::make_pair (result, status);
   }
 
   namespace cpu
@@ -289,19 +327,28 @@ namespace os::resources
 
   namespace net
   {
-    bool set_nic_channels (std::string &ifname, unsigned int combined)
+    bool set_nic_channels (std::string &ifname, unsigned int combined, bool *permission_error)
     {
+      std::optional<std::pair<std::string, int>> status;
       struct ethtool_channels channel;
       struct ifreq ifr;
-      std::optional<std::string> output;
       char command[256];
+      int saved_errno;
       int success;
       int fd;
+
+      if (permission_error)
+	{
+	  *permission_error = false;
+	}
 
       fd = socket (AF_INET, SOCK_DGRAM, 0);
       if (fd < 0)
 	{
-	  perror ("socket");
+	  if (permission_error && is_permission_error (errno))
+	    {
+	      *permission_error = true;
+	    }
 	  return false;
 	}
 
@@ -316,11 +363,28 @@ namespace os::resources
       success = ioctl (fd, SIOCETHTOOL, &ifr);
       if (success)
 	{
+	  saved_errno = errno;
 	  snprintf (command, sizeof (command), "ethtool -L %s combined %u", ifname.c_str (), combined);
-	  output = execute_command (command);
-	  if (!output)
+	  status = execute_command (command);
+	  if (!status)
 	    {
-	      _er_log_debug (__FILE__, __LINE__, "warning: failed to execute the command: %s", command);
+	      if (permission_error && is_permission_error (saved_errno))
+		{
+		  *permission_error = true;
+		}
+	      _er_log_debug (__FILE__, __LINE__, "warning: failed to execute the command: %s\n", command);
+	      ::close (fd);
+	      return false;
+	    }
+	  if (!WIFEXITED (status->second) || WEXITSTATUS (status->second) != 0)
+	    {
+	      if (permission_error && (is_permission_error (saved_errno)
+				       || output_has_permission_error (status->first)))
+		{
+		  *permission_error = true;
+		}
+	      _er_log_debug (__FILE__, __LINE__, "warning: command failed: %s\n%s", command,
+			     status->first.c_str ());
 	      ::close (fd);
 	      return false;
 	    }
@@ -334,22 +398,33 @@ namespace os::resources
     {
       cubbase::ifsys::qirq_vec qs = { 0, 0, 0 };
       char qbase[256], rxdir[280], txdir[280];
-      std::string ifname;
+      bool permission_guide_logged;
+      bool permission_error;
       int rx_count, tx_count;
+      std::string ifname;
+      int saved_errno;
       int i, q;
+
+      permission_guide_logged = false;
 
       /* get ifname */
       ifname = cubbase::ifsys::auto_select_primary_iface ();
       if (ifname.empty ())
 	{
-	  _er_log_debug (__FILE__, __LINE__, "warning: no interfaces available for selection. (virtual environment)\n");
+	  er_log_print (__FILE__, __LINE__, "warning: no interfaces available for selection. (virtual environment)\n");
 	  return ;
 	}
 
       /* channel */
-      if (!set_nic_channels (ifname, index.size ()))
+      permission_error = false;
+      if (!set_nic_channels (ifname, index.size (), &permission_error))
 	{
-	  _er_log_debug (__FILE__, __LINE__, "warning: NIC channel configuration failed. (driver may limit)\n");
+	  er_log_print (__FILE__, __LINE__, "warning: NIC channel configuration failed. (driver may limit)\n\n");
+	  if (permission_error)
+	    {
+	      guide_hardware_affinity_permission ();
+	      permission_guide_logged = true;
+	    }
 	}
       /* wait until applied */
       usleep (1000 * 1000);
@@ -359,12 +434,22 @@ namespace os::resources
 	  for (i = 0; i < qs.n; i++)
 	    {
 	      q = qs.v[i].q;
-	      cubbase::ifsys::set_irq_affinity_list (qs.v[i].irq, index[q % index.size ()]);
+	      if (cubbase::ifsys::set_irq_affinity_list (qs.v[i].irq, index[q % index.size ()]) != 0)
+		{
+		  saved_errno = errno;
+		  er_log_print (__FILE__, __LINE__, "warning: failed to set IRQ affinity for IRQ %d: %s\n", qs.v[i].irq,
+				strerror (saved_errno));
+		  if (!permission_guide_logged && is_permission_error (saved_errno))
+		    {
+		      guide_hardware_affinity_permission ();
+		      permission_guide_logged = true;
+		    }
+		}
 	    }
 	}
       else
 	{
-	  _er_log_debug (__FILE__, __LINE__, "warning: no IRQ found for %s in /proc/interrupts.\n", ifname.c_str ());
+	  er_log_print (__FILE__, __LINE__, "warning: no IRQ found for %s in /proc/interrupts.\n\n", ifname.c_str ());
 	}
       free (qs.v);
 
@@ -375,15 +460,45 @@ namespace os::resources
       rx_count = cubbase::ifsys::listdir_count_prefix (qbase, "rx-");
       tx_count = cubbase::ifsys::listdir_count_prefix (qbase, "tx-");
 
-      cubbase::ifsys::maybe_set_rps_sock_flow_entries (index.size ());
+      if (!cubbase::ifsys::maybe_set_rps_sock_flow_entries (index.size ()))
+	{
+	  saved_errno = errno;
+	  er_log_print (__FILE__, __LINE__, "warning: failed to set rps_sock_flow_entries: %s\n",
+			strerror (saved_errno));
+	  if (!permission_guide_logged && is_permission_error (saved_errno))
+	    {
+	      guide_hardware_affinity_permission ();
+	      permission_guide_logged = true;
+	    }
+	}
 
       for (q = 0; q < rx_count; q++)
 	{
-	  cubbase::ifsys::set_rps_for_queue (ifname.c_str (), q, index[q % index.size ()]);
+	  if (!cubbase::ifsys::set_rps_for_queue (ifname.c_str (), q, index[q % index.size ()]))
+	    {
+	      saved_errno = errno;
+	      er_log_print (__FILE__, __LINE__, "warning: failed to set RPS for %s rx-%d: %s\n", ifname.c_str (), q,
+			    strerror (saved_errno));
+	      if (!permission_guide_logged && is_permission_error (saved_errno))
+		{
+		  guide_hardware_affinity_permission ();
+		  permission_guide_logged = true;
+		}
+	    }
 	}
       for (q = 0; q < tx_count; q++)
 	{
-	  cubbase::ifsys::set_xps_for_queue (ifname.c_str (), q, index[q % index.size ()]);
+	  if (!cubbase::ifsys::set_xps_for_queue (ifname.c_str (), q, index[q % index.size ()]))
+	    {
+	      saved_errno = errno;
+	      er_log_print (__FILE__, __LINE__, "warning: failed to set XPS for %s tx-%d: %s\n", ifname.c_str (), q,
+			    strerror (saved_errno));
+	      if (!permission_guide_logged && is_permission_error (saved_errno))
+		{
+		  guide_hardware_affinity_permission ();
+		  permission_guide_logged = true;
+		}
+	    }
 	}
     }
   }

--- a/src/base/resources.cpp
+++ b/src/base/resources.cpp
@@ -31,7 +31,6 @@
 #include <net/if.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>
-#include <sys/wait.h>
 #include <linux/sockios.h>
 #include <linux/ethtool.h>
 
@@ -39,14 +38,10 @@
 #include "filesys_parser.hpp"
 #include "ifsys.hpp"
 #include "cgroup.hpp"
+#include "error_manager.h"
 
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
 #include "memory_wrapper.hpp"
-
-#define er_log_print(file, line, ...) do { \
-    _er_log_debug (file, line, __VA_ARGS__); \
-    printf (__VA_ARGS__); \
-} while (0)
 
 namespace os::resources
 {
@@ -55,55 +50,22 @@ namespace os::resources
     return error == EACCES || error == EPERM;
   }
 
-  static bool output_has_permission_error (const std::string &output)
-  {
-    return output.find ("Operation not permitted") != std::string::npos
-	   || output.find ("Permission denied") != std::string::npos;
-  }
-
   static void guide_hardware_affinity_permission ()
   {
-    er_log_print (__FILE__, __LINE__,
-		  "You must either start the server as the root user or grant the necessary capabilities "
-		  "to the server binary as shown below.\n"
-		  "(Note: It is recommended to disable irqbalance if you want this server to manage your hardware directly.)\n\n"
-		  "  $> sudo -E \"$CUBRID/bin/cubrid\" server start <db_name>\n\n"
-		  "or\n\n"
-		  "  $> sudo setcap \'cap_net_admin,cap_dac_override+ep\' \"$CUBRID/bin/cub_server\"\n"
-		  "  $> getcap \"$CUBRID/bin/cub_server\"\n"
-		  "\n");
+    _er_log_debug (__FILE__, __LINE__,
+		   "You must either start the server as the root user or grant the necessary capabilities "
+		   "to the server binary as shown below.\n"
+		   "(Note: It is recommended to disable irqbalance if you want this server to manage your hardware directly.)\n\n"
+		   "  $> sudo -E \"$CUBRID/bin/cubrid\" server start <db_name>\n\n"
+		   "or\n\n"
+		   "  $> sudo setcap \'cap_net_admin,cap_dac_override+ep\' \"$CUBRID/bin/cub_server\"\n"
+		   "  $> getcap \"$CUBRID/bin/cub_server\"\n"
+		   "\n");
   }
 
   void initialize ()
   {
     os::resources::cpu::effective ();
-  }
-
-  std::optional<std::pair<std::string, int>> execute_command (const char *cmd)
-  {
-    std::string result;
-    char buffer[256];
-    FILE *pipe;
-    int status;
-
-    pipe = popen ((std::string (cmd) + " 2>&1").c_str (), "r");
-    if (!pipe)
-      {
-	return std::nullopt;
-      }
-
-    result = "";
-    while (fgets (buffer, sizeof (buffer), pipe) != nullptr)
-      {
-	result += buffer;
-      }
-
-    status = pclose (pipe);
-    if (status == -1)
-      {
-	return std::nullopt;
-      }
-    return std::make_pair (result, status);
   }
 
   namespace cpu
@@ -329,10 +291,8 @@ namespace os::resources
   {
     bool set_nic_channels (std::string &ifname, unsigned int combined, bool *permission_error)
     {
-      std::optional<std::pair<std::string, int>> status;
       struct ethtool_channels channel;
       struct ifreq ifr;
-      char command[256];
       int saved_errno;
       int success;
       int fd;
@@ -355,39 +315,36 @@ namespace os::resources
       memset (&ifr, 0, sizeof (ifr));
       memset (&channel, 0, sizeof (channel));
 
-      channel.cmd = ETHTOOL_SCHANNELS;
-      channel.combined_count = combined;
       strncpy (ifr.ifr_name, ifname.c_str (), IFNAMSIZ - 1);
       ifr.ifr_data = reinterpret_cast<char *> (&channel);
 
+      channel.cmd = ETHTOOL_GCHANNELS;
       success = ioctl (fd, SIOCETHTOOL, &ifr);
       if (success)
 	{
 	  saved_errno = errno;
-	  snprintf (command, sizeof (command), "ethtool -L %s combined %u", ifname.c_str (), combined);
-	  status = execute_command (command);
-	  if (!status)
+	  if (permission_error && is_permission_error (saved_errno))
 	    {
-	      if (permission_error && is_permission_error (saved_errno))
-		{
-		  *permission_error = true;
-		}
-	      _er_log_debug (__FILE__, __LINE__, "warning: failed to execute the command: %s\n", command);
-	      ::close (fd);
-	      return false;
+	      *permission_error = true;
 	    }
-	  if (!WIFEXITED (status->second) || WEXITSTATUS (status->second) != 0)
+	  ::close (fd);
+	  errno = saved_errno;
+	  return false;
+	}
+
+      channel.cmd = ETHTOOL_SCHANNELS;
+      channel.combined_count = combined;
+      success = ioctl (fd, SIOCETHTOOL, &ifr);
+      if (success)
+	{
+	  saved_errno = errno;
+	  if (permission_error && is_permission_error (saved_errno))
 	    {
-	      if (permission_error && (is_permission_error (saved_errno)
-				       || output_has_permission_error (status->first)))
-		{
-		  *permission_error = true;
-		}
-	      _er_log_debug (__FILE__, __LINE__, "warning: command failed: %s\n%s", command,
-			     status->first.c_str ());
-	      ::close (fd);
-	      return false;
+	      *permission_error = true;
 	    }
+	  ::close (fd);
+	  errno = saved_errno;
+	  return false;
 	}
 
       ::close (fd);
@@ -411,7 +368,7 @@ namespace os::resources
       ifname = cubbase::ifsys::auto_select_primary_iface ();
       if (ifname.empty ())
 	{
-	  er_log_print (__FILE__, __LINE__, "warning: no interfaces available for selection. (virtual environment)\n");
+	  _er_log_debug (__FILE__, __LINE__, "warning: no interfaces available for selection. (virtual environment)\n");
 	  return ;
 	}
 
@@ -419,7 +376,7 @@ namespace os::resources
       permission_error = false;
       if (!set_nic_channels (ifname, index.size (), &permission_error))
 	{
-	  er_log_print (__FILE__, __LINE__, "warning: NIC channel configuration failed. (driver may limit)\n\n");
+	  _er_log_debug (__FILE__, __LINE__, "warning: NIC channel configuration failed: %s\n\n", strerror (errno));
 	  if (permission_error)
 	    {
 	      guide_hardware_affinity_permission ();
@@ -437,8 +394,8 @@ namespace os::resources
 	      if (cubbase::ifsys::set_irq_affinity_list (qs.v[i].irq, index[q % index.size ()]) != 0)
 		{
 		  saved_errno = errno;
-		  er_log_print (__FILE__, __LINE__, "warning: failed to set IRQ affinity for IRQ %d: %s\n", qs.v[i].irq,
-				strerror (saved_errno));
+		  _er_log_debug (__FILE__, __LINE__, "warning: failed to set IRQ affinity for IRQ %d: %s\n", qs.v[i].irq,
+				 strerror (saved_errno));
 		  if (!permission_guide_logged && is_permission_error (saved_errno))
 		    {
 		      guide_hardware_affinity_permission ();
@@ -449,7 +406,7 @@ namespace os::resources
 	}
       else
 	{
-	  er_log_print (__FILE__, __LINE__, "warning: no IRQ found for %s in /proc/interrupts.\n\n", ifname.c_str ());
+	  _er_log_debug (__FILE__, __LINE__, "warning: no IRQ found for %s in /proc/interrupts.\n\n", ifname.c_str ());
 	}
       free (qs.v);
 
@@ -463,8 +420,8 @@ namespace os::resources
       if (!cubbase::ifsys::maybe_set_rps_sock_flow_entries (index.size ()))
 	{
 	  saved_errno = errno;
-	  er_log_print (__FILE__, __LINE__, "warning: failed to set rps_sock_flow_entries: %s\n",
-			strerror (saved_errno));
+	  _er_log_debug (__FILE__, __LINE__, "warning: failed to set rps_sock_flow_entries: %s\n",
+			 strerror (saved_errno));
 	  if (!permission_guide_logged && is_permission_error (saved_errno))
 	    {
 	      guide_hardware_affinity_permission ();
@@ -477,8 +434,8 @@ namespace os::resources
 	  if (!cubbase::ifsys::set_rps_for_queue (ifname.c_str (), q, index[q % index.size ()]))
 	    {
 	      saved_errno = errno;
-	      er_log_print (__FILE__, __LINE__, "warning: failed to set RPS for %s rx-%d: %s\n", ifname.c_str (), q,
-			    strerror (saved_errno));
+	      _er_log_debug (__FILE__, __LINE__, "warning: failed to set RPS for %s rx-%d: %s\n", ifname.c_str (), q,
+			     strerror (saved_errno));
 	      if (!permission_guide_logged && is_permission_error (saved_errno))
 		{
 		  guide_hardware_affinity_permission ();
@@ -491,8 +448,8 @@ namespace os::resources
 	  if (!cubbase::ifsys::set_xps_for_queue (ifname.c_str (), q, index[q % index.size ()]))
 	    {
 	      saved_errno = errno;
-	      er_log_print (__FILE__, __LINE__, "warning: failed to set XPS for %s tx-%d: %s\n", ifname.c_str (), q,
-			    strerror (saved_errno));
+	      _er_log_debug (__FILE__, __LINE__, "warning: failed to set XPS for %s tx-%d: %s\n", ifname.c_str (), q,
+			     strerror (saved_errno));
 	      if (!permission_guide_logged && is_permission_error (saved_errno))
 		{
 		  guide_hardware_affinity_permission ();

--- a/src/base/resources.hpp
+++ b/src/base/resources.hpp
@@ -38,7 +38,7 @@ namespace os::resources
   }
 
   void initialize ();
-  std::optional<std::string> execute_command (const char *cmd);
+  std::optional<std::pair<std::string, int>> execute_command (const char *cmd);
 
   namespace cpu
   {
@@ -121,7 +121,7 @@ namespace os::resources
 
   namespace net
   {
-    bool set_nic_channels (std::string &ifname, unsigned int combined);
+    bool set_nic_channels (std::string &ifname, unsigned int combined, bool *permission_error = nullptr);
     void map_nic_to_index (std::vector<std::size_t> &index);
   }
 }

--- a/src/base/resources.hpp
+++ b/src/base/resources.hpp
@@ -28,6 +28,7 @@
 #include <vector>
 #include <limits>
 #include <optional>
+#include <utility>
 #include <sched.h>
 
 namespace os::resources
@@ -38,7 +39,6 @@ namespace os::resources
   }
 
   void initialize ();
-  std::optional<std::pair<std::string, int>> execute_command (const char *cmd);
 
   namespace cpu
   {

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -800,6 +800,8 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 
 #define PRM_NAME_LOG_POSTPONE_CACHE_SIZE "postpone_cache_size"
 
+#define PRM_NAME_HARDWARE_AFFINITY "hardware_affinity"
+
 // #endregion 
 
 /*
@@ -5369,7 +5371,19 @@ SYSPRM_PARAM prm_Def[] = {
    NULL_SYSPRM_PARAM_VALUE,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
-   (DUP_PRM_FUNC) NULL}
+   (DUP_PRM_FUNC) NULL},
+  {PRM_ID_HARDWARE_AFFINITY,
+   PRM_NAME_HARDWARE_AFFINITY,
+   (PRM_FOR_SERVER),
+   PRM_BOOLEAN,
+   PRM_CLEAR_DYNAMIC_FLAG,
+   {false, {.b = false}},
+   {false, {.b = false}},
+   NULL_SYSPRM_PARAM_VALUE,
+   NULL_SYSPRM_PARAM_VALUE,
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
 };
 
 SYSPRM_INDIRECT_POS prm_Def_session_idx[DIM (prm_Def)];

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -531,10 +531,12 @@ enum param_id
 
   PRM_ID_LOG_POSTPONE_CACHE_SIZE,
 
-  /* change PRM_LAST_ID when adding new system parameters */
   PRM_ID_UPDATE_STATISTICS_UPDATE_HISTOGRAM,
 
-  PRM_LAST_ID = PRM_ID_UPDATE_STATISTICS_UPDATE_HISTOGRAM
+  PRM_ID_HARDWARE_AFFINITY,
+
+  /* change PRM_LAST_ID when adding new system parameters */
+  PRM_LAST_ID = PRM_ID_HARDWARE_AFFINITY
 };
 typedef enum param_id PARAM_ID;
 

--- a/src/connection/connection_pool.cpp
+++ b/src/connection/connection_pool.cpp
@@ -298,7 +298,12 @@ namespace cubconn::connection
 		std::next (ctx.adjusted_effective->begin (),
 			   std::min (ctx.adjusted_effective->size (), static_cast<std::size_t> (max_connection_workers)))
 	);
-	os::resources::net::map_nic_to_index (cores);
+
+	if (prm_get_bool_value (PRM_ID_HARDWARE_AFFINITY))
+	  {
+	    /* align the irq and RX/TX */
+	    os::resources::net::map_nic_to_index (cores);
+	  }
       }
     return std::min (ctx.adjusted_max, static_cast<std::size_t> (max_connection_workers));
   }

--- a/src/connection/connection_worker.cpp
+++ b/src/connection/connection_worker.cpp
@@ -2056,8 +2056,11 @@ respond:
     /* set name */
     pthread_setname_np (pthread_self (), "connections");
 
-    /* pin myself */
-    os::resources::cpu::setaffinity (m_core);
+    if (prm_get_bool_value (PRM_ID_HARDWARE_AFFINITY))
+      {
+	/* pin the current thread to the core */
+	os::resources::cpu::setaffinity (m_core);
+      }
 
     /* entry */
     m_entry = cubthread::get_manager ()->claim_entry ();

--- a/src/connection/coordinator.cpp
+++ b/src/connection/coordinator.cpp
@@ -1222,8 +1222,11 @@ not_transferred:
     /* set name */
     pthread_setname_np (pthread_self (), "coordinator");
 
-    /* pin myself */
-    os::resources::cpu::setaffinity (m_core);
+    if (prm_get_bool_value (PRM_ID_HARDWARE_AFFINITY))
+      {
+	/* pin the current thread to the core */
+	os::resources::cpu::setaffinity (m_core);
+      }
 
     /* entry */
     m_entry = cubthread::get_manager ()->claim_entry ();


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26990>

### Purpose

현재 server를 실행 시 자동으로 thread core pin과 IRQ/RX/TX/nic 재배치 코드를 수행합니다.
이 코드들은 모두 수행되었을 때 큰 성능 향상을 보이나, 일부만 수행된다면 오히려 역으로 kernel의 scheduling 관리를 방해할 수 있습니다. 따라서 이 모드를 option으로 제공하고, 사용자가 의도해 권한을 준 상태로 실행할 경우에만 위 작업들을 수행하도록 합니다.

추가된 파라미터는 아래와 같습니다.
hardware_affinity
false (default): 아무것도 하지 않습니다.
true: core pin과 IRQ/RX/TX/nic 재정렬을 수행합니다.

### Implementation

1. 파라미터를 검사하고, false라면 관련 함수를 호출하지 않습니다.
2. 수행될 때 권한 검사에서 무시되는 부분이 있어 수정하였습니다.

### Remarks

N/A
