### PR TITLE
[CBRD-26814] Check OOS inline stub bounds at value area

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -12843,7 +12843,7 @@ heap_attrinfo_transform_variable_to_disk (THREAD_ENTRY * thread_p, HEAP_CACHE_AT
 
   if (is_oos)
     {
-      if (buf->ptr + OR_OOS_INLINE_SIZE > buf->endptr)
+      if (*ptr_varvals + OR_OOS_INLINE_SIZE > buf->endptr)
 	{
 	  return S_DOESNT_FIT;
 	}


### PR DESCRIPTION
https://jira.cubrid.org/browse/CBRD-26814

## Purpose

- OOS (큰 컬럼 값을 heap record 밖의 OOS file에 저장하는 방식) 컬럼이 여러 개 있는 row 를 INSERT 할 때 `csql` 이 `or_put_bigint` assertion 으로 끝나는 문제를 고칩니다.
- `AS-IS:` inline OOS stub 공간을 실제 쓰기 위치가 아닌 `buf->ptr` 기준으로 검사해서 buffer 끝을 넘을 수 있었습니다.
- `TO-BE:` 실제 쓰기 위치인 `*ptr_varvals` 기준으로 검사하고, 부족하면 기존 copyarea retry 흐름으로 넘어갑니다.

## Implementation

- `src/storage/heap_file.c` 의 `heap_attrinfo_transform_variable_to_disk()` OOS 분기만 바꿨습니다.
- bounds check 를 `buf->ptr` 에서 `*ptr_varvals` 기준으로 바꿔 `or_put_oid()` / `or_put_bigint()` 의 실제 write 위치와 맞췄습니다.
- OOS demotion 정책, inline stub 형식, read-side expansion 동작은 바꾸지 않았습니다.

## Remarks

- 리뷰어는 `heap_attrinfo_transform_variable_to_disk()` 안 OOS 분기 한 줄만 보면 됩니다.
- 확인 결과 CBRD-26814 의 `init.sql` INSERT 는 assertion 없이 256 row 까지 들어갔습니다.
- 전체 `bigPageSize.sh` 의 남은 `NOK` 는 LOB locator path 문자열 차이이며, 이 PR의 write-side assertion 과는 별도입니다.
- 자세한 설명: https://github.com/vimkim/my-cubrid-docs/blob/main/cbrd-26814/CBRD-26814-oos-inline-stub-bounds.md
