### PR TITLE
[CBRD-26994] Backport  Fix CDC log record loss on resume by resetting producer process_lsa to the new extraction LSA to 11.4

### DIFF
--- a/src/communication/network_interface_sr.c
+++ b/src/communication/network_interface_sr.c
@@ -10970,6 +10970,11 @@ scdc_get_loginfo_metadata (THREAD_ENTRY * thread_p, unsigned int rid, char *requ
 	  goto error;
 	}
 
+      if (cdc_Gl.producer.state != CDC_PRODUCER_STATE_WAIT)
+	{
+	  cdc_pause_producer ();
+	}
+
       cdc_set_extraction_lsa (&start_lsa);
 
       cdc_reinitialize_queue (&start_lsa);

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -817,6 +817,7 @@ typedef struct cdc_temp_logbuf
 typedef struct cdc_producer
 {
   LOG_LSA next_extraction_lsa;
+  bool is_reset_process_lsa;
 
   /* configuration */
   int all_in_cond;

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -877,8 +877,6 @@ typedef struct cdc_global
   LOG_LSA first_loginfo_queue_lsa;
   LOG_LSA last_loginfo_queue_lsa;
 
-  bool is_queue_reinitialized;
-
 } CDC_GLOBAL;
 
 /* will be moved to new file for CDC */

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -14557,6 +14557,7 @@ cdc_reinitialize_queue (LOG_LSA * start_lsa)
 	}
       cdc_Gl.producer.produced_queue_size = 0;
       cdc_Gl.consumer.consumed_queue_size = 0;
+      cdc_Gl.producer.is_reset_process_lsa = true;
 
           /* *INDENT-OFF* */
     delete cdc_Gl.loginfo_queue;
@@ -15021,6 +15022,8 @@ cdc_initialize ()
   LSA_SET_NULL (&cdc_Gl.consumer.start_lsa);
   LSA_SET_NULL (&cdc_Gl.consumer.next_lsa);
 
+  cdc_Gl.producer.is_reset_process_lsa = true;
+
   return 0;
 }
 
@@ -15057,6 +15060,8 @@ cdc_cleanup ()
     {
       cdc_pause_producer ();
     }
+
+  cdc_Gl.producer.is_reset_process_lsa = true;
 
   cdc_free_extraction_filter ();
 

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -11180,16 +11180,6 @@ cdc_loginfo_producer_execute (cubthread::entry & thread_ref)
 	  tmp->log_info = log_info_entry.log_info;
 	  LSA_COPY (&tmp->next_lsa, &process_lsa);
 
-	  if (cdc_Gl.is_queue_reinitialized)
-	    {
-	      free_and_init (tmp->log_info);
-	      free_and_init (tmp);
-
-	      cdc_Gl.is_queue_reinitialized = false;
-
-	      continue;
-	    }
-
           /* *INDENT-OFF* */
 	  cdc_Gl.loginfo_queue->produce (tmp);
           /* *INDENT-ON* */
@@ -14516,8 +14506,6 @@ cdc_reinitialize_queue (LOG_LSA * start_lsa)
       cdc_log ("cdc_reinitialize_queue : don't need to be reinitialized");
       goto end;
     }
-
-  cdc_Gl.is_queue_reinitialized = true;
 
   if (LSA_LT (&cdc_Gl.first_loginfo_queue_lsa, start_lsa) && LSA_GE (&cdc_Gl.last_loginfo_queue_lsa, start_lsa))
     {

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -11074,9 +11074,17 @@ cdc_loginfo_producer_execute (cubthread::entry & thread_ref)
 
 	  cdc_Gl.producer.state = CDC_PRODUCER_STATE_WAIT;
 
+	  cdc_log ("CBRD26994DBG: pause-PARK. process_lsa (%lld|%d), next_extraction_lsa (%lld|%d), reset_flag=%d",
+		   LSA_AS_ARGS (&process_lsa), LSA_AS_ARGS (&cdc_Gl.producer.next_extraction_lsa),
+		   cdc_Gl.producer.is_reset_process_lsa);
+
 	  pthread_mutex_lock (&cdc_Gl.producer.lock);
 	  pthread_cond_wait (&cdc_Gl.producer.wait_cond, &cdc_Gl.producer.lock);
 	  pthread_mutex_unlock (&cdc_Gl.producer.lock);
+
+	  cdc_log ("CBRD26994DBG: pause-WAKE. process_lsa (%lld|%d), next_extraction_lsa (%lld|%d), reset_flag=%d",
+		   LSA_AS_ARGS (&process_lsa), LSA_AS_ARGS (&cdc_Gl.producer.next_extraction_lsa),
+		   cdc_Gl.producer.is_reset_process_lsa);
 
 	  cdc_Gl.producer.state = CDC_PRODUCER_STATE_RUN;
 
@@ -11090,11 +11098,19 @@ cdc_loginfo_producer_execute (cubthread::entry & thread_ref)
 
 	  cdc_Gl.producer.state = CDC_PRODUCER_STATE_WAIT;
 
+	  cdc_log ("CBRD26994DBG: qfull-PARK. process_lsa (%lld|%d), next_extraction_lsa (%lld|%d), reset_flag=%d",
+		   LSA_AS_ARGS (&process_lsa), LSA_AS_ARGS (&cdc_Gl.producer.next_extraction_lsa),
+		   cdc_Gl.producer.is_reset_process_lsa);
+
 	  cdc_pause_consumer ();
 
 	  pthread_mutex_lock (&cdc_Gl.producer.lock);
 	  pthread_cond_wait (&cdc_Gl.producer.wait_cond, &cdc_Gl.producer.lock);
 	  pthread_mutex_unlock (&cdc_Gl.producer.lock);
+
+	  cdc_log ("CBRD26994DBG: qfull-WAKE. process_lsa (%lld|%d), next_extraction_lsa (%lld|%d), reset_flag=%d",
+		   LSA_AS_ARGS (&process_lsa), LSA_AS_ARGS (&cdc_Gl.producer.next_extraction_lsa),
+		   cdc_Gl.producer.is_reset_process_lsa);
 
 	  cdc_Gl.producer.state = CDC_PRODUCER_STATE_RUN;
 
@@ -11132,9 +11148,18 @@ cdc_loginfo_producer_execute (cubthread::entry & thread_ref)
       LSA_SET_NULL (&log_info_entry.next_lsa);
       log_info_entry.log_info = NULL;
 
+      if (cdc_Gl.producer.is_reset_process_lsa)
+	{
+	  cdc_log ("CBRD26994DBG: RESET consumed. process_lsa (%lld|%d) -> NULL, next_extraction_lsa (%lld|%d)",
+		   LSA_AS_ARGS (&process_lsa), LSA_AS_ARGS (&cdc_Gl.producer.next_extraction_lsa));
+	  LSA_SET_NULL (&process_lsa);
+	  cdc_Gl.producer.is_reset_process_lsa = false;
+	}
+
       if (LSA_ISNULL (&process_lsa))
 	{
 	  LSA_COPY (&process_lsa, &cdc_Gl.producer.next_extraction_lsa);
+	  cdc_log ("CBRD26994DBG: ADOPT next_extraction_lsa (%lld|%d) as process_lsa", LSA_AS_ARGS (&process_lsa));
 	}
       else
 	{
@@ -14503,9 +14528,17 @@ cdc_reinitialize_queue (LOG_LSA * start_lsa)
 
   if (cdc_Gl.producer.produced_queue_size == 0)
     {
+      cdc_log ("CBRD26994DBG: reinit: queue empty");
       cdc_log ("cdc_reinitialize_queue : don't need to be reinitialized");
       goto end;
     }
+
+  /* every caller must park the producer before reinitializing the queue */
+  assert (cdc_Gl.producer.state == CDC_PRODUCER_STATE_WAIT);
+  cdc_log
+    ("CBRD26994DBG: reinit: producer state=%d, first_q (%lld|%d), last_q (%lld|%d), start (%lld|%d)",
+     cdc_Gl.producer.state, LSA_AS_ARGS (&cdc_Gl.first_loginfo_queue_lsa),
+     LSA_AS_ARGS (&cdc_Gl.last_loginfo_queue_lsa), LSA_AS_ARGS (start_lsa));
 
   if (LSA_LT (&cdc_Gl.first_loginfo_queue_lsa, start_lsa) && LSA_GE (&cdc_Gl.last_loginfo_queue_lsa, start_lsa))
     {

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -11074,17 +11074,9 @@ cdc_loginfo_producer_execute (cubthread::entry & thread_ref)
 
 	  cdc_Gl.producer.state = CDC_PRODUCER_STATE_WAIT;
 
-	  cdc_log ("CBRD26994DBG: pause-PARK. process_lsa (%lld|%d), next_extraction_lsa (%lld|%d), reset_flag=%d",
-		   LSA_AS_ARGS (&process_lsa), LSA_AS_ARGS (&cdc_Gl.producer.next_extraction_lsa),
-		   cdc_Gl.producer.is_reset_process_lsa);
-
 	  pthread_mutex_lock (&cdc_Gl.producer.lock);
 	  pthread_cond_wait (&cdc_Gl.producer.wait_cond, &cdc_Gl.producer.lock);
 	  pthread_mutex_unlock (&cdc_Gl.producer.lock);
-
-	  cdc_log ("CBRD26994DBG: pause-WAKE. process_lsa (%lld|%d), next_extraction_lsa (%lld|%d), reset_flag=%d",
-		   LSA_AS_ARGS (&process_lsa), LSA_AS_ARGS (&cdc_Gl.producer.next_extraction_lsa),
-		   cdc_Gl.producer.is_reset_process_lsa);
 
 	  cdc_Gl.producer.state = CDC_PRODUCER_STATE_RUN;
 
@@ -11098,19 +11090,11 @@ cdc_loginfo_producer_execute (cubthread::entry & thread_ref)
 
 	  cdc_Gl.producer.state = CDC_PRODUCER_STATE_WAIT;
 
-	  cdc_log ("CBRD26994DBG: qfull-PARK. process_lsa (%lld|%d), next_extraction_lsa (%lld|%d), reset_flag=%d",
-		   LSA_AS_ARGS (&process_lsa), LSA_AS_ARGS (&cdc_Gl.producer.next_extraction_lsa),
-		   cdc_Gl.producer.is_reset_process_lsa);
-
 	  cdc_pause_consumer ();
 
 	  pthread_mutex_lock (&cdc_Gl.producer.lock);
 	  pthread_cond_wait (&cdc_Gl.producer.wait_cond, &cdc_Gl.producer.lock);
 	  pthread_mutex_unlock (&cdc_Gl.producer.lock);
-
-	  cdc_log ("CBRD26994DBG: qfull-WAKE. process_lsa (%lld|%d), next_extraction_lsa (%lld|%d), reset_flag=%d",
-		   LSA_AS_ARGS (&process_lsa), LSA_AS_ARGS (&cdc_Gl.producer.next_extraction_lsa),
-		   cdc_Gl.producer.is_reset_process_lsa);
 
 	  cdc_Gl.producer.state = CDC_PRODUCER_STATE_RUN;
 
@@ -11150,8 +11134,6 @@ cdc_loginfo_producer_execute (cubthread::entry & thread_ref)
 
       if (cdc_Gl.producer.is_reset_process_lsa)
 	{
-	  cdc_log ("CBRD26994DBG: RESET consumed. process_lsa (%lld|%d) -> NULL, next_extraction_lsa (%lld|%d)",
-		   LSA_AS_ARGS (&process_lsa), LSA_AS_ARGS (&cdc_Gl.producer.next_extraction_lsa));
 	  LSA_SET_NULL (&process_lsa);
 	  cdc_Gl.producer.is_reset_process_lsa = false;
 	}
@@ -11159,7 +11141,6 @@ cdc_loginfo_producer_execute (cubthread::entry & thread_ref)
       if (LSA_ISNULL (&process_lsa))
 	{
 	  LSA_COPY (&process_lsa, &cdc_Gl.producer.next_extraction_lsa);
-	  cdc_log ("CBRD26994DBG: ADOPT next_extraction_lsa (%lld|%d) as process_lsa", LSA_AS_ARGS (&process_lsa));
 	}
       else
 	{
@@ -14528,17 +14509,12 @@ cdc_reinitialize_queue (LOG_LSA * start_lsa)
 
   if (cdc_Gl.producer.produced_queue_size == 0)
     {
-      cdc_log ("CBRD26994DBG: reinit: queue empty");
       cdc_log ("cdc_reinitialize_queue : don't need to be reinitialized");
       goto end;
     }
 
   /* every caller must park the producer before reinitializing the queue */
   assert (cdc_Gl.producer.state == CDC_PRODUCER_STATE_WAIT);
-  cdc_log
-    ("CBRD26994DBG: reinit: producer state=%d, first_q (%lld|%d), last_q (%lld|%d), start (%lld|%d)",
-     cdc_Gl.producer.state, LSA_AS_ARGS (&cdc_Gl.first_loginfo_queue_lsa),
-     LSA_AS_ARGS (&cdc_Gl.last_loginfo_queue_lsa), LSA_AS_ARGS (start_lsa));
 
   if (LSA_LT (&cdc_Gl.first_loginfo_queue_lsa, start_lsa) && LSA_GE (&cdc_Gl.last_loginfo_queue_lsa, start_lsa))
     {

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -15058,8 +15058,6 @@ cdc_cleanup ()
       cdc_pause_producer ();
     }
 
-  cdc_Gl.producer.is_reset_process_lsa = true;
-
   cdc_free_extraction_filter ();
 
   assert (cdc_Gl.loginfo_queue != NULL);
@@ -15087,6 +15085,7 @@ cdc_cleanup ()
   LSA_SET_NULL (&cdc_Gl.last_loginfo_queue_lsa);
 
   pthread_mutex_lock (&cdc_Gl.producer.lock);
+  cdc_Gl.producer.is_reset_process_lsa = true;
   LSA_SET_NULL (&cdc_Gl.producer.next_extraction_lsa);
   pthread_mutex_unlock (&cdc_Gl.producer.lock);
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26994>

backport to 11.4 <https://github.com/CUBRID/cubrid/pull/7373>

위 PR과 같은 수정사항입니다. PR 내용은 위 링크에 작성해두었습니다.

### Purpose

backport to 11.4

### Implementation

N/A

### Remarks

N/A
