### PR TITLE
[CBRD-25855] refine Query's open() and isOpen() logic

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/TypeChecker.java
@@ -1255,6 +1255,8 @@ public class TypeChecker extends AstVisitor<Type> {
                 switch (tyUsedExpr.idx) {
                     case Type.IDX_RECORD:
                         if (!node.dynamic) {
+                            // in static case, query is rewritten for records and records are
+                            // allowed.
                             break;
                         }
                         // fall-through

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/predefined/sp/SpLib.java
@@ -684,6 +684,8 @@ public class SpLib {
 
                     if (pstmtRef == null) {
                         myStmt = null;
+                    } else {
+                        pstmtRef[0] = null;
                     }
                 }
             }
@@ -713,7 +715,21 @@ public class SpLib {
         }
 
         public boolean isOpen() {
-            return (rs != null);
+
+            if (rs == null) {
+                return false;
+            }
+
+            try {
+                if (rs.isClosed()) {
+                    rs = null;
+                    return false;
+                } else {
+                    return true;
+                }
+            } catch (SQLException e) {
+                throw new SQL_ERROR(e.getMessage());
+            }
         }
 
         public boolean fetch() {


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-25855>

### Purpose

기존 PR #7348 에서 Query 클래스의 open() 과 isOpen() 메소드 구현에 보완할 부분이 있어 수정합니다. 
- exception 이 나서 rs 가 set 되지 못했을 때 pstmtRef 를 통해 리턴하는 Statement 도 null 로 바꿉니다. (유효하지 않은 Statement를 리턴하지 않습니다.)
- Query 외부에서 close 된 경우를 대비하여 ResultSet.isClosed() 로 검사를 하되, 닫혔다고 판단되면 rs 도 null 로 바꿉니다. 
