### PR TITLE
[CBRD-27007] Fix AUTO_INCREMENT serial name leak with supplemental logging

### DIFF
--- a/src/base/object_representation_sr.c
+++ b/src/base/object_representation_sr.c
@@ -94,6 +94,7 @@ static TP_DOMAIN *or_get_domain_and_cache (char *ptr);
 static void or_get_att_index (char *ptr, BTID * btid);
 static int or_get_default_value (OR_ATTRIBUTE * attr, char *ptr, int length);
 static int or_get_current_default_value (OR_ATTRIBUTE * attr, char *ptr, int length);
+static void or_free_auto_increment (OR_ATTRIBUTE * att);
 static int or_cl_get_prop_nocopy (DB_SEQ * properties, const char *name, DB_VALUE * pvalue);
 static void or_install_btids_foreign_key (const char *fkname, DB_SEQ * fk_seq, OR_INDEX * index);
 static void or_install_btids_foreign_key_ref (DB_SEQ * fk_container, OR_INDEX * index);
@@ -123,6 +124,22 @@ static INLINE int or_mvcc_set_prev_version_lsa (OR_BUF * buf, MVCC_REC_HEADER * 
   __attribute__ ((ALWAYS_INLINE));
 static INLINE int or_mvcc_get_prev_version_lsa (OR_BUF * buf, int mvcc_flags, LOG_LSA * prev_version_lsa)
   __attribute__ ((ALWAYS_INLINE));
+
+/*
+ * or_free_auto_increment () - free server-side cached auto-increment metadata
+ *   return: void
+ *   att(in): attribute representation
+ */
+static void
+or_free_auto_increment (OR_ATTRIBUTE * att)
+{
+  char *serial_name = att->auto_increment.serial_name.exchange (NULL);
+
+  if (serial_name != NULL)
+    {
+      free_and_init (serial_name);
+    }
+}
 
 #if defined (ENABLE_UNUSED_FUNCTION)
 /*
@@ -2530,6 +2547,7 @@ or_get_current_representation (RECDES * record, int do_indexes)
       att->classoid = oid;
 
       att->auto_increment.serial_obj = oid_Null_oid;
+      att->auto_increment.serial_name = NULL;
       /* get the btree index id if an index has been assigned */
       or_get_att_index (ptr + ORC_ATT_INDEX_OFFSET, &att->index);
 
@@ -3680,6 +3698,8 @@ or_free_classrep (OR_CLASSREP * rep)
 	    {
 	      free_and_init (att->btids);
 	    }
+
+	  or_free_auto_increment (att);
 	}
       free_and_init (rep->attributes);
     }

--- a/src/base/object_representation_sr.h
+++ b/src/base/object_representation_sr.h
@@ -83,6 +83,7 @@ union or_aligned_oid
 struct or_auto_increment
 {
   std::atomic<or_aligned_oid> serial_obj;
+  std::atomic<char *> serial_name;
 };
 // *INDENT-ON*
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -16890,107 +16890,138 @@ heap_set_autoincrement_value (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * att
       if (att->is_autoincrement && (value->state == HEAP_UNINIT_ATTRVALUE))
 	{
 	  OID serial_obj_oid = att->auto_increment.serial_obj.load ().oid;
-	  if (OID_ISNULL (&serial_obj_oid) || prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG))
+	  const char *cached_serial_name = att->auto_increment.serial_name.load ();
+	  if (OID_ISNULL (&serial_obj_oid))
 	    {
-	      memset (serial_name, '\0', sizeof (serial_name));
-	      recdes.data = NULL;
-	      recdes.area_size = 0;
+	      char *serial_name_local = NULL;
 
-	      if (scan_cache->cache_last_fix_page == false)
+	      if (cached_serial_name == NULL)
 		{
-		  scan_cache = &local_scan_cache;
-		  (void) heap_scancache_quick_start_root_hfid (thread_p, scan_cache);
-		  use_local_scan_cache = true;
-		}
+		  memset (serial_name, '\0', sizeof (serial_name));
+		  recdes.data = NULL;
+		  recdes.area_size = 0;
 
-	      if (heap_get_class_record (thread_p, &(attr_info->class_oid), &recdes, scan_cache, PEEK) != S_SUCCESS)
-		{
-		  ret = ER_FAILED;
-		  goto exit_on_error;
-		}
+		  if (scan_cache->cache_last_fix_page == false)
+		    {
+		      scan_cache = &local_scan_cache;
+		      (void) heap_scancache_quick_start_root_hfid (thread_p, scan_cache);
+		      use_local_scan_cache = true;
+		    }
 
-	      if (heap_get_class_name (thread_p, &(att->classoid), &classname) != NO_ERROR || classname == NULL)
-		{
-		  ASSERT_ERROR_AND_SET (ret);
-		  goto exit_on_error;
-		}
+		  if (heap_get_class_record (thread_p, &(attr_info->class_oid), &recdes, scan_cache, PEEK) != S_SUCCESS)
+		    {
+		      ret = ER_FAILED;
+		      goto exit_on_error;
+		    }
 
-	      string = NULL;
-	      alloced_string = 0;
+		  if (heap_get_class_name (thread_p, &(att->classoid), &classname) != NO_ERROR || classname == NULL)
+		    {
+		      ASSERT_ERROR_AND_SET (ret);
+		      goto exit_on_error;
+		    }
 
-	      ret = or_get_attrname (&recdes, att->id, &string, &alloced_string);
-	      if (ret != NO_ERROR)
-		{
-		  ASSERT_ERROR ();
-		  goto exit_on_error;
-		}
+		  string = NULL;
+		  alloced_string = 0;
 
-	      attr_name = string;
-	      if (attr_name == NULL)
-		{
-		  ret = ER_FAILED;
-		  goto exit_on_error;
-		}
+		  ret = or_get_attrname (&recdes, att->id, &string, &alloced_string);
+		  if (ret != NO_ERROR)
+		    {
+		      ASSERT_ERROR ();
+		      goto exit_on_error;
+		    }
 
-	      SET_AUTO_INCREMENT_SERIAL_NAME (serial_name, classname, attr_name);
+		  attr_name = string;
+		  if (attr_name == NULL)
+		    {
+		      ret = ER_FAILED;
+		      goto exit_on_error;
+		    }
 
-	      if (OID_ISNULL (&serial_obj_oid))
-		{
+		  SET_AUTO_INCREMENT_SERIAL_NAME (serial_name, classname, attr_name);
+
+		  serial_name_local = strdup (serial_name);
+		  if (serial_name_local == NULL)
+		    {
+		      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, strlen (serial_name) + 1);
+		      ret = ER_OUT_OF_VIRTUAL_MEMORY;
+		      goto exit_on_error;
+		    }
+
+		  char *dummy_null_serial_name = NULL;
+		  auto serial_name_cache = &att->auto_increment.serial_name;
+		  if (!serial_name_cache->compare_exchange_strong (dummy_null_serial_name, serial_name_local))
+		    {
+		      free_and_init (serial_name_local);
+		      cached_serial_name = dummy_null_serial_name;
+		    }
+		  else
+		    {
+		      cached_serial_name = serial_name_local;
+		    }
+
 		  if (string != NULL && alloced_string == 1)
 		    {
 		      db_private_free_and_init (thread_p, string);
 		    }
+		  string = NULL;
 
 		  free_and_init (classname);
+		}
 
-		  if (db_make_varchar (&key_val, DB_MAX_IDENTIFIER_LENGTH, serial_name, (int) strlen (serial_name),
-				       LANG_SYS_CODESET, LANG_SYS_COLLATION) != NO_ERROR)
+	      if (cached_serial_name == NULL)
+		{
+		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_FAILED, 0);
+		  ret = ER_FAILED;
+		  goto exit_on_error;
+		}
+
+	      if (db_make_varchar (&key_val, DB_MAX_IDENTIFIER_LENGTH, cached_serial_name,
+				   (int) strlen (cached_serial_name), LANG_SYS_CODESET, LANG_SYS_COLLATION) != NO_ERROR)
+		{
+		  ret = ER_FAILED;
+		  goto exit_on_error;
+		}
+
+	      status = xlocator_find_class_oid (thread_p, CT_SERIAL_NAME, &serial_class_oid, NULL_LOCK);
+	      if (status == LC_CLASSNAME_ERROR || status == LC_CLASSNAME_DELETED)
+		{
+		  ret = ER_FAILED;
+		  goto exit_on_error;
+		}
+
+	      classrep = heap_classrepr_get (thread_p, &serial_class_oid, NULL, NULL_REPRID, &idx_in_cache);
+	      if (classrep == NULL)
+		{
+		  ret = ER_FAILED;
+		  goto exit_on_error;
+		}
+
+	      if (classrep->indexes)
+		{
+		  BTREE_SEARCH search_result;
+		  OID serial_oid;
+
+		  BTID_COPY (&serial_btid, &(classrep->indexes[0].btid));
+		  search_result =
+		    xbtree_find_unique (thread_p, &serial_btid, S_SELECT, &key_val, &serial_class_oid, &serial_oid,
+					false);
+		  heap_classrepr_free_and_init (classrep, &idx_in_cache);
+		  if (search_result != BTREE_KEY_FOUND)
 		    {
 		      ret = ER_FAILED;
 		      goto exit_on_error;
 		    }
 
-		  status = xlocator_find_class_oid (thread_p, CT_SERIAL_NAME, &serial_class_oid, NULL_LOCK);
-		  if (status == LC_CLASSNAME_ERROR || status == LC_CLASSNAME_DELETED)
-		    {
-		      ret = ER_FAILED;
-		      goto exit_on_error;
-		    }
-
-		  classrep = heap_classrepr_get (thread_p, &serial_class_oid, NULL, NULL_REPRID, &idx_in_cache);
-		  if (classrep == NULL)
-		    {
-		      ret = ER_FAILED;
-		      goto exit_on_error;
-		    }
-
-		  if (classrep->indexes)
-		    {
-		      BTREE_SEARCH search_result;
-		      OID serial_oid;
-
-		      BTID_COPY (&serial_btid, &(classrep->indexes[0].btid));
-		      search_result =
-			xbtree_find_unique (thread_p, &serial_btid, S_SELECT, &key_val, &serial_class_oid, &serial_oid,
-					    false);
-		      heap_classrepr_free_and_init (classrep, &idx_in_cache);
-		      if (search_result != BTREE_KEY_FOUND)
-			{
-			  ret = ER_FAILED;
-			  goto exit_on_error;
-			}
-
-		      assert (!OID_ISNULL (&serial_oid));
-		      or_aligned_oid null_aligned_oid = { oid_Null_oid };
-		      or_aligned_oid serial_aligned_oid = { serial_oid };
-		      att->auto_increment.serial_obj.compare_exchange_strong (null_aligned_oid, serial_aligned_oid);
-		    }
-		  else
-		    {
-		      heap_classrepr_free_and_init (classrep, &idx_in_cache);
-		      ret = ER_FAILED;
-		      goto exit_on_error;
-		    }
+		  assert (!OID_ISNULL (&serial_oid));
+		  or_aligned_oid null_aligned_oid = { oid_Null_oid };
+		  or_aligned_oid serial_aligned_oid = { serial_oid };
+		  att->auto_increment.serial_obj.compare_exchange_strong (null_aligned_oid, serial_aligned_oid);
+		}
+	      else
+		{
+		  heap_classrepr_free_and_init (classrep, &idx_in_cache);
+		  ret = ER_FAILED;
+		  goto exit_on_error;
 		}
 	    }
 
@@ -17031,10 +17062,18 @@ heap_set_autoincrement_value (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * att
 	  if (prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) > 0)
 	    {
 	      OID serial_obj_oid = att->auto_increment.serial_obj.load ().oid;
+	      const char *cached_serial_name = att->auto_increment.serial_name.load ();
 
 	      LOG_TDES *tdes = LOG_FIND_CURRENT_TDES (thread_p);
 
 	      assert (tdes != NULL);
+	      assert (cached_serial_name != NULL);
+	      if (cached_serial_name == NULL)
+		{
+		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_FAILED, 0);
+		  ret = ER_FAILED;
+		  goto exit_on_error;
+		}
 
 	      if (!tdes->has_supplemental_log)
 		{
@@ -17043,7 +17082,7 @@ heap_set_autoincrement_value (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * att
 		  tdes->has_supplemental_log = true;
 		}
 
-	      log_append_supplemental_serial (thread_p, serial_name, 1, &att->classoid, &serial_obj_oid);
+	      log_append_supplemental_serial (thread_p, cached_serial_name, 1, &att->classoid, &serial_obj_oid);
 	      thread_p->no_supplemental_log = false;
 	    }
 	}
@@ -17060,6 +17099,11 @@ exit_on_error:
   if (classname != NULL)
     {
       free_and_init (classname);
+    }
+
+  if (string != NULL && alloced_string == 1)
+    {
+      db_private_free_and_init (thread_p, string);
     }
 
   if (use_local_scan_cache)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27007>

### Purpose

`supplemental_log` 가 켜져 있으면 `heap_set_autoincrement_value()` 가 AUTO_INCREMENT serial OID 를 이미 캐시한 뒤에도 매 row마다 serial name 을 다시 만든다.

이 경로에서 `heap_get_class_name()` 은 class name 을 `strdup` 으로 할당하고, 압축 저장된 attribute name 은 `or_get_attrname()` 이 별도 버퍼로 할당할 수 있다. 하지만 기존 코드는 이 두 버퍼를 serial OID 가 아직 캐시되지 않은 최초 경로(`OID_ISNULL (&serial_obj_oid)`) 안에서만 해제한다.

따라서 `supplemental_log > 0` 상태에서 AUTO_INCREMENT INSERT 를 반복하면 serial OID 가 캐시된 이후에도 class name 재구성은 계속 수행되지만 정상 종료 경로에서 버퍼가 해제되지 않아 row 수에 비례해 메모리가 누수된다. 동시에 class record read 와 serial name rebuild 도 매 row 반복되어 불필요한 overhead 가 발생한다.

### Implementation

**`src/base/object_representation_sr.h` — `or_auto_increment`**

AUTO_INCREMENT serial OID 옆에 composed serial name 을 함께 캐시한다.

```diff
 struct or_auto_increment
 {
   std::atomic<or_aligned_oid> serial_obj;
+  std::atomic<char *> serial_name;
 };
```

**`src/base/object_representation_sr.c` — OR_CLASSREP lifecycle**

- class representation 생성 시 `serial_name` 을 `NULL` 로 초기화한다.
- class representation 해제 시 `or_free_auto_increment()` 에서 cached `serial_name` 을 해제한다.

`serial_name` 은 영구 metadata 가 아니라 `OR_CLASSREP` 에 속한 schema-derived cache 로 취급한다.

**`src/storage/heap_file.c` — `heap_set_autoincrement_value`**

- serial name 재구성 조건을 다음으로 제한한다.
  - serial OID 가 아직 캐시되지 않은 경우
  - `supplemental_log > 0` 이고 cached `serial_name` 이 아직 없는 경우
- `std::atomic<char *>::compare_exchange_strong()` 으로 serial name 을 한 번만 publish 한다.
  - 경쟁에서 진 thread 의 중복 문자열은 즉시 해제한다.
- steady-state supplemental serial log 는 cached `serial_name` 을 사용한다.
- 오류 경로에서 `classname` 과 compressed attribute name buffer 를 해제한다.

### Test

| 케이스 | Before-fix | After-fix |
|---|---|---|
| `supplemental_log=1` + AUTO_INCREMENT INSERT 2,500 rows, valgrind leak check | `heap_get_class_name_alloc_if_diff -> heap_set_autoincrement_value` 경로에서 `22,491 bytes in 2,499 blocks` definitely lost | `definitely lost: 0 bytes in 0 blocks` |

valgrind 는 임시 `CUBRID_CONF_FILE` 로 `supplemental_log=1` 을 적용하고, 같은 SQL workload 를 수정 전/후 빌드에 각각 실행하여 비교했다.

### Remarks

- `serial_name` cache 는 `OR_CLASSREP` 수명에 묶인다. class/attribute rename 등 schema 변경 시 기존 class representation decache 경로를 통해 함께 무효화되는 것을 전제로 한다.