### PR TITLE
[CBRD-26993] CREATE INDEX error-masking fix under supplemental_log

### DIFF
--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -15694,7 +15694,7 @@ do_supplemental_statement (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVE
       }
     case PT_CREATE_INDEX:
       {
-	BTID index;
+	SM_CLASS_CONSTRAINT *cons;
 	MOP classop;
 
 	oid = (OID *) malloc (sizeof (OID));
@@ -15710,8 +15710,16 @@ do_supplemental_statement (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVE
 	classop = sm_find_class (classname);
 
 	classoid = ws_oid (classop);
-	error = sm_get_index (classop, objname, &index);
-	memcpy (oid, &index, sizeof (OID));
+	/* the index must be resolved by its constraint name; sm_get_index () looks up attribute names only */
+	cons = classobj_find_constraint_by_name (sm_class_constraints (classop), objname);
+	if (cons != NULL)
+	  {
+	    memcpy (oid, &cons->index_btid, sizeof (OID));
+	  }
+	else
+	  {
+	    OID_SET_NULL (oid);
+	  }
 
 	ddl_type = CDC_CREATE;
 	objtype = CDC_INDEX;
@@ -15720,7 +15728,7 @@ do_supplemental_statement (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVE
       }
     case PT_ALTER_INDEX:
       {
-	BTID index;
+	SM_CLASS_CONSTRAINT *cons;
 	MOP classop;
 
 	oid = (OID *) malloc (sizeof (OID));
@@ -15736,8 +15744,16 @@ do_supplemental_statement (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVE
 	classop = sm_find_class (classname);
 
 	classoid = ws_oid (classop);
-	error = sm_get_index (classop, objname, &index);
-	memcpy (oid, &index, sizeof (OID));
+	/* the index must be resolved by its constraint name; sm_get_index () looks up attribute names only */
+	cons = classobj_find_constraint_by_name (sm_class_constraints (classop), objname);
+	if (cons != NULL)
+	  {
+	    memcpy (oid, &cons->index_btid, sizeof (OID));
+	  }
+	else
+	  {
+	    OID_SET_NULL (oid);
+	  }
 
 	ddl_type = CDC_ALTER;
 	objtype = CDC_INDEX;
@@ -15746,7 +15762,7 @@ do_supplemental_statement (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVE
       }
     case PT_DROP_INDEX:
       {
-	BTID index;
+	SM_CLASS_CONSTRAINT *cons;
 	MOP classop;
 
 	oid = (OID *) malloc (sizeof (OID));
@@ -15762,8 +15778,16 @@ do_supplemental_statement (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVE
 	classop = sm_find_class (classname);
 
 	classoid = ws_oid (classop);
-	error = sm_get_index (classop, objname, &index);
-	memcpy (oid, &index, sizeof (OID));
+	/* after a successful DROP INDEX the constraint is already gone; oid then remains a NULL OID */
+	cons = classobj_find_constraint_by_name (sm_class_constraints (classop), objname);
+	if (cons != NULL)
+	  {
+	    memcpy (oid, &cons->index_btid, sizeof (OID));
+	  }
+	else
+	  {
+	    OID_SET_NULL (oid);
+	  }
 
 	ddl_type = CDC_DROP;
 	objtype = CDC_INDEX;

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -3481,13 +3481,25 @@ do_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
 	    }
 	}
 
-      if (prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) > 0)
+      if (error >= 0 && prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) > 0)
 	{
 	  (void) do_supplemental_statement (parser, statement, cls_info, reserved_oid);
 	}
     }
 
 end:
+  /* release the class info reserved for supplemental logging; entries consumed by do_supplemental_statement are
+   * already freed and cleared (free_and_init), so this only frees what is left (e.g. a failed DROP skips the call) */
+  if (cls_info[0] != NULL)
+    {
+      int i = 0;
+
+      while (cls_info[i] != NULL)
+	{
+	  free_and_init (cls_info[i++]);
+	}
+    }
+
   /* restore old read fetch instance version */
   db_set_read_fetch_instance_version (read_fetch_instance_version);
   /* There may be parse tree fragments that were collected during the execution of the statement that should be freed
@@ -4160,12 +4172,24 @@ do_execute_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
 	}
     }
 
-  if (prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) > 0)
+  if (err >= 0 && prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) > 0)
     {
       (void) do_supplemental_statement (parser, statement, cls_info, reserved_oid);
     }
 
 end:
+
+  /* release the class info reserved for supplemental logging; entries consumed by do_supplemental_statement are
+   * already freed and cleared (free_and_init), so this only frees what is left (e.g. a failed DROP skips the call) */
+  if (cls_info[0] != NULL)
+    {
+      int i = 0;
+
+      while (cls_info[i] != NULL)
+	{
+	  free_and_init (cls_info[i++]);
+	}
+    }
 
   /* restore old read fetch instance version */
   db_set_read_fetch_instance_version (read_fetch_instance_version);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26993

## Purpose

`supplemental_log >= 1`(CDC) 환경에서 다른 세션이 대상 클래스에 락을 쥐고 있는 동안 `CREATE INDEX` 를 실행하면, 실제 원인인 락 타임아웃 에러(`ER_LK_OBJECT_TIMEOUT_CLASS`, -74) 대신 `Attribute "<index name>" was not found.`(`ER_SM_ATTRIBUTE_NOT_FOUND`, -239) 라는 무관한 메시지가 csql 에 출력된다. 같은 서버 에러라도 JDBC 는 락 메시지를 정상 표시하지만 csql 은 -239 로 오표시되어 원인 파악이 지연된다.

근본 원인은 두 가지다.

1. `do_statement()` / `do_execute_statement()` 가 문장이 실패한 경우에도 `do_supplemental_statement()` 를 무조건 호출한다(반환값도 무시). 바로 인접한 replication 경로는 `if (error >= 0)` 로 가드되어 있으나 supplemental 경로에는 가드가 없다.
2. `do_supplemental_statement()` 의 CREATE/ALTER/DROP INDEX 케이스가 인덱스 이름을 attribute 조회 함수인 `sm_get_index()` 의 attribute 인자로 넘긴다. 인덱스 이름은 attribute 로 매칭되지 않아 항상 `ER_SM_ATTRIBUTE_NOT_FOUND`(-239) 를 에러 스택에 남기고, 실패한 `CREATE INDEX` 의 실제 락 에러(-74)를 덮는다. 성공한 문장에서도 -239 가 잔류하며, 미초기화 `BTID` 가 CDC supplemental 로그의 OID 로 기록되는 부작용도 있다.

## Changes

**`src/query/execute_statement.c` — `do_statement()` / `do_execute_statement()`**

replication 경로와 동일하게, 문장이 성공한 경우에만 supplemental 로깅을 수행하도록 가드를 추가한다.

```diff
-      if (prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) > 0)
+      if (error >= 0 && prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) > 0)
 	{
 	  (void) do_supplemental_statement (parser, statement, cls_info, reserved_oid);
 	}
```

가드로 인해 실패한 `DROP` 이 예약해 둔 `cls_info` 를 해제하지 못하는 것을 막기 위해, 각 호출자의 `end:` 정리에서 남은 `cls_info` 항목을 해제한다.

**`src/query/execute_statement.c` — `do_supplemental_statement()` INDEX 케이스**

인덱스는 attribute 가 아니라 constraint 이름으로 조회해야 하므로 `sm_get_index()` 를 `classobj_find_constraint_by_name()` 로 교체한다. constraint 가 없으면(예: 성공한 `DROP INDEX` 이후) NULL OID 로 둔다.

```diff
-	error = sm_get_index (classop, objname, &index);
-	memcpy (oid, &index, sizeof (OID));
+	/* the index must be resolved by its constraint name; sm_get_index () looks up attribute names only */
+	cons = classobj_find_constraint_by_name (sm_class_constraints (classop), objname);
+	if (cons != NULL)
+	  {
+	    memcpy (oid, &cons->index_btid, sizeof (OID));
+	  }
+	else
+	  {
+	    OID_SET_NULL (oid);
+	  }
```

develop 과 달리 release/11.4 의 INDEX 케이스는 `oid` 를 케이스마다 `malloc` 하므로, constraint 미검색 경로에서 `OID_SET_NULL (oid)` 로 NULL OID 를 명시적으로 설정한다.

## Test

release/11.4 debug 빌드(`11.4.5.1885-7a1969b`)에서 검증했다.

| 케이스 | Bug 빌드 | Fix 빌드 |
|---|---|---|
| `supplemental_log=1`, 다른 세션이 락 점유 중 `CREATE INDEX` | `ERROR: Attribute "idx_cub_01" was not found.` (-239) | `... timed out waiting on SCH_M_LOCK lock on class dba.tn_pot_qna_bbs ...` (-74) |
| `supplemental_log=1`, 락 없이 성공하는 `CREATE INDEX` (gdb) | 성공하지만 `er_set(-239)` 발생(에러 스택 오염) | -239 미발생 |
| `supplemental_log=1`, FK 로 막히는 `DROP TABLE` (valgrind) | `1,036 bytes definitely lost` (`do_reserve_classinfo` → `do_execute_statement`) | `definitely lost: 0 bytes` |

## Remarks

- develop 대상 수정은 별도 PR(CBRD-26993, base `develop`)로 진행한다.
- 회귀 검증용 shell TC(`cbrd_26993`)를 준비했으며, 엔진 PR 확정 후 `cubrid-testcases-private-ex` 의 `tc/pr-<N>` 에 추가 예정이다.
