### PR TITLE
[CBRD-27008] CDC: DROP SERIAL leaks a small OID buffer on every statement when supplemental_log is enabled

### DIFF
--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -3752,6 +3752,11 @@ end:
 
   RESET_HOST_VARIABLES_IF_INTERNAL_STATEMENT (parser);
 
+  if (reserved_oid != NULL)
+    {
+      free_and_init (reserved_oid);
+    }
+
   if (error == ER_FAILED)
     {
       assert (er_errid () != NO_ERROR);
@@ -4457,6 +4462,11 @@ end:
     }
 
   RESET_HOST_VARIABLES_IF_INTERNAL_STATEMENT (parser);
+
+  if (reserved_oid != NULL)
+    {
+      free_and_init (reserved_oid);
+    }
 
   return ((err == ER_FAILED && (err = er_errid ()) == NO_ERROR) ? ER_GENERIC_ERROR : err);
 }				/* do_execute_statement() */


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27008>

### Purpose

CDC supplemental log가 활성화된 상태에서 `DROP SERIAL`을 실행하면, DROP 대상 SERIAL의 OID를 보관하기 위해 `do_reserve_oidinfo()`에서 할당한 `reserved_oid`가 해제되지 않아 statement마다 작은 메모리 누수가 발생합니다.

이 문제는 `b2bdbcef7 [CBRD-26126]` warning 정리 과정에서 `do_supplemental_statement()`의 일반 OID 처리 방식이 heap allocation에서 stack 임시 변수(`oid_tmp`) 사용으로 변경되고, 기존 `oid` cleanup이 제거되면서 발생한 develop 전용 회귀입니다.

`release/11.4`에는 해당 리팩터링 커밋이 반영되어 있지 않고, 기존 cleanup 경로에서 `oid`가 해제되므로 동일 문제가 발생하지 않습니다.

### Implementation

`reserved_oid`의 소유권을 `do_supplemental_statement()`로 넘기지 않고, 이를 생성한 caller 쪽에서 유지하도록 정리했습니다.

- `do_statement()`
- `do_execute_statement()`

위 두 함수의 공통 `end:` cleanup 경로에서 `reserved_oid`가 존재하면 `free_and_init()`으로 해제합니다.

```diff
+  if (reserved_oid != NULL)
+    {
+      free_and_init (reserved_oid);
+    }
```

`do_supplemental_statement()` 내부의 `oid`는 develop 기준 대부분 stack 변수(`oid_tmp`)를 가리키므로, 이 함수에서 다시 `free_and_init (oid)`를 복원하지 않았습니다. 이렇게 하면 `DROP SERIAL`의 heap-allocated `reserved_oid`만 안전하게 해제하면서, 다른 CDC supplemental log 경로의 stack OID를 잘못 해제하지 않습니다.

### Test

| 항목 | 결과 |
|---|---|
| `supplemental_log=1` + `csql -S` + `CREATE SERIAL`/`DROP SERIAL` 10회 Valgrind 재현 (수정 전) | `do_reserve_oidinfo()`에서 `80 bytes in 10 blocks are definitely lost` 재현 |
| 동일 Valgrind 시나리오 (수정 후) | `definitely lost: 0 bytes in 0 blocks` 확인 |
| `git diff --check` | PASS |
| `bash -ic 'cmc && bd'` debug configure/build/install | PASS |
| before/after 비교용 `bash -ic 'bd'` 재설치 빌드 | PASS |

### Remarks

- 본 수정은 `develop` 브랜치의 warning 정리 리팩터링 이후 발생한 회귀를 대상으로 합니다.
- `release/11.4`는 동일 리팩터링이 없어 본 이슈의 필수 수정 대상에서 제외했습니다.
- Valgrind runtime 검증 로그는 로컬 `/tmp/cbrd27008_probe/vg_before.log`, `/tmp/cbrd27008_probe/vg_after.log`에 보관했습니다.
