### PR TITLE
[CBRD-27010] Fix csql crash on multi-target DROP with supplemental log

### DIFF
--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -209,7 +209,8 @@ static MOP server_find (PT_NODE * node_server, PT_NODE * node_owner);
 static int do_supplemental_statement (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLASS_INFO ** cls_info,
 				      OID * reserved_oid);
 
-static int do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLASS_INFO ** cls_info);
+static int do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLASS_INFO *** cls_info);
+static void do_free_reserved_classinfo (RESERVED_CLASS_INFO ** cls_info);
 
 static int do_reserve_oidinfo (PARSER_CONTEXT * parser, PT_NODE * statement, OID ** oid);
 /*
@@ -3072,7 +3073,7 @@ do_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
   int suppress_repl_error = NO_ERROR;
   LC_FETCH_VERSION_TYPE read_fetch_instance_version;
 
-  RESERVED_CLASS_INFO *cls_info[64] = { NULL, };
+  RESERVED_CLASS_INFO **cls_info = NULL;
   OID *reserved_oid = NULL;
 
   /* save old read fetch instance version */
@@ -3254,7 +3255,7 @@ do_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
 	  break;
 
 	case PT_DROP:
-	  (void) do_reserve_classinfo (parser, statement, cls_info);
+	  (void) do_reserve_classinfo (parser, statement, &cls_info);
 
 	  error = do_check_internal_statements (parser, statement,
 						/* statement->info.drop. internal_stmts, */
@@ -3507,6 +3508,8 @@ end:
     }
 
   RESET_HOST_VARIABLES_IF_INTERNAL_STATEMENT (parser);
+
+  do_free_reserved_classinfo (cls_info);
 
   if (error == ER_FAILED)
     {
@@ -3770,7 +3773,7 @@ do_execute_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
   int suppress_repl_error;
   LC_FETCH_VERSION_TYPE read_fetch_instance_version;
 
-  RESERVED_CLASS_INFO *cls_info[64] = { NULL, };
+  RESERVED_CLASS_INFO **cls_info = NULL;
   OID *reserved_oid = NULL;
 
   assert (parser->query_id == NULL_QUERY_ID);
@@ -3956,7 +3959,7 @@ do_execute_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
       /* err = do_drop(parser, statement); */
       /* execute internal statements before and after do_drop() */
 
-      (void) do_reserve_classinfo (parser, statement, cls_info);
+      (void) do_reserve_classinfo (parser, statement, &cls_info);
       err = do_check_internal_statements (parser, statement,
 					  /* statement->info.drop.internal_stmts, */
 					  do_drop);
@@ -4187,6 +4190,8 @@ end:
     }
 
   RESET_HOST_VARIABLES_IF_INTERNAL_STATEMENT (parser);
+
+  do_free_reserved_classinfo (cls_info);
 
   return ((err == ER_FAILED && (err = er_errid ()) == NO_ERROR) ? ER_GENERIC_ERROR : err);
 }				/* do_execute_statement() */
@@ -15385,14 +15390,20 @@ do_find_object_type (PT_MISC_TYPE type, const char *classname, CDC_DDL_OBJECT_TY
 }
 
 static int
-do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLASS_INFO ** cls_info)
+do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLASS_INFO *** cls_info_p)
 {
   int count = 0;
+  int num_class = 0;
+  int error = NO_ERROR;
   PT_NODE *entity = NULL;
   PT_NODE *entity_spec = NULL;
+  RESERVED_CLASS_INFO **cls_info = NULL;
 
   const char *classname;
   DB_OBJECT *class_obj;
+
+  assert (cls_info_p != NULL);
+  *cls_info_p = NULL;
 
   if (prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) != 1)
     {
@@ -15408,12 +15419,26 @@ do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLA
 
       for (entity_spec = statement->info.drop.spec_list; entity_spec != NULL; entity_spec = entity_spec->next)
 	{
+	  num_class++;
+	}
+
+      cls_info = (RESERVED_CLASS_INFO **) malloc ((num_class + 1) * sizeof (RESERVED_CLASS_INFO *));
+      if (cls_info == NULL)
+	{
+	  return ER_OUT_OF_VIRTUAL_MEMORY;
+	}
+
+      memset (cls_info, 0, (num_class + 1) * sizeof (RESERVED_CLASS_INFO *));
+
+      for (entity_spec = statement->info.drop.spec_list; entity_spec != NULL; entity_spec = entity_spec->next)
+	{
 	  entity = entity_spec->info.spec.flat_entity_list;
 
 	  cls_info[count] = (RESERVED_CLASS_INFO *) malloc (sizeof (RESERVED_CLASS_INFO));
 	  if (cls_info[count] == NULL)
 	    {
-	      return ER_OUT_OF_VIRTUAL_MEMORY;
+	      error = ER_OUT_OF_VIRTUAL_MEMORY;
+	      goto error_exit;
 	    }
 
 	  classname = entity->info.name.original;
@@ -15425,7 +15450,8 @@ do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLA
 
 	  if (do_find_object_type (statement->info.drop.entity_type, classname, &cls_info[count]->objtype) != NO_ERROR)
 	    {
-	      return ER_FAILED;
+	      error = ER_FAILED;
+	      goto error_exit;
 	    }
 
 	  assert (cls_info[count]->objtype == CDC_TABLE || cls_info[count]->objtype == CDC_VIEW);
@@ -15434,9 +15460,32 @@ do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLA
 	}
     }
 
-  cls_info[count] = NULL;
+  *cls_info_p = cls_info;
 
   return NO_ERROR;
+
+error_exit:
+  do_free_reserved_classinfo (cls_info);
+  return error;
+}
+
+static void
+do_free_reserved_classinfo (RESERVED_CLASS_INFO ** cls_info)
+{
+  int i = 0;
+
+  if (cls_info == NULL)
+    {
+      return;
+    }
+
+  while (cls_info[i] != NULL)
+    {
+      free_and_init (cls_info[i]);
+      i++;
+    }
+
+  free_and_init (cls_info);
 }
 
 static int
@@ -15661,7 +15710,6 @@ do_supplemental_statement (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVE
 					drop_stmt);
 
 	    free_and_init (drop_stmt);
-	    free_and_init (cls_info[i]);
 	  }
 
 	supp_appended = true;
@@ -16056,13 +16104,14 @@ end:
       free_and_init (drop_stmt);
     }
 
-  if (cls_info[0] != NULL && statement->node_type == PT_DROP)
+  if (cls_info != NULL && cls_info[0] != NULL && statement->node_type == PT_DROP)
     {
       int i = 0;
 
       while (cls_info[i] != NULL)
 	{
-	  free_and_init (cls_info[i++]);
+	  free_and_init (cls_info[i]);
+	  i++;
 	}
     }
 

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -3255,7 +3255,11 @@ do_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
 	  break;
 
 	case PT_DROP:
-	  (void) do_reserve_classinfo (parser, statement, &cls_info);
+	  error = do_reserve_classinfo (parser, statement, &cls_info);
+	  if (error != NO_ERROR)
+	    {
+	      goto end;
+	    }
 
 	  error = do_check_internal_statements (parser, statement,
 						/* statement->info.drop. internal_stmts, */
@@ -3959,7 +3963,11 @@ do_execute_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
       /* err = do_drop(parser, statement); */
       /* execute internal statements before and after do_drop() */
 
-      (void) do_reserve_classinfo (parser, statement, &cls_info);
+      err = do_reserve_classinfo (parser, statement, &cls_info);
+      if (err != NO_ERROR)
+	{
+	  goto end;
+	}
       err = do_check_internal_statements (parser, statement,
 					  /* statement->info.drop.internal_stmts, */
 					  do_drop);
@@ -15395,6 +15403,7 @@ do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLA
   int count = 0;
   int num_class = 0;
   int error = NO_ERROR;
+  size_t cls_info_size = 0;
   PT_NODE *entity = NULL;
   PT_NODE *entity_spec = NULL;
   RESERVED_CLASS_INFO **cls_info = NULL;
@@ -15422,13 +15431,13 @@ do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLA
 	  num_class++;
 	}
 
-      cls_info = (RESERVED_CLASS_INFO **) malloc ((num_class + 1) * sizeof (RESERVED_CLASS_INFO *));
+      cls_info_size = (num_class + 1) * sizeof (RESERVED_CLASS_INFO *);
+      cls_info = (RESERVED_CLASS_INFO **) calloc (num_class + 1, sizeof (RESERVED_CLASS_INFO *));
       if (cls_info == NULL)
 	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, cls_info_size);
 	  return ER_OUT_OF_VIRTUAL_MEMORY;
 	}
-
-      memset (cls_info, 0, (num_class + 1) * sizeof (RESERVED_CLASS_INFO *));
 
       for (entity_spec = statement->info.drop.spec_list; entity_spec != NULL; entity_spec = entity_spec->next)
 	{
@@ -15437,6 +15446,7 @@ do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLA
 	  cls_info[count] = (RESERVED_CLASS_INFO *) malloc (sizeof (RESERVED_CLASS_INFO));
 	  if (cls_info[count] == NULL)
 	    {
+	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (RESERVED_CLASS_INFO));
 	      error = ER_OUT_OF_VIRTUAL_MEMORY;
 	      goto error_exit;
 	    }
@@ -16102,17 +16112,6 @@ end:
   if (drop_stmt != NULL)
     {
       free_and_init (drop_stmt);
-    }
-
-  if (cls_info != NULL && cls_info[0] != NULL && statement->node_type == PT_DROP)
-    {
-      int i = 0;
-
-      while (cls_info[i] != NULL)
-	{
-	  free_and_init (cls_info[i]);
-	  i++;
-	}
     }
 
   return error;

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -15450,7 +15450,7 @@ do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLA
 
       for (entity_spec = statement->info.drop.spec_list; entity_spec != NULL; entity_spec = entity_spec->next)
 	{
-	  RESERVED_CLASS_INFO &class_info = reserved_classes.classes[count];
+	  RESERVED_CLASS_INFO & class_info = reserved_classes.classes[count];
 
 	  entity = entity_spec->info.spec.flat_entity_list;
 	  classname = entity->info.name.original;
@@ -15649,7 +15649,7 @@ do_supplemental_statement (PARSER_CONTEXT * parser, PT_NODE * statement,
 
 	for (int i = 0; i < reserved_classes.num_classes; i++)
 	  {
-	    RESERVED_CLASS_INFO &class_info = reserved_classes.classes[i];
+	    RESERVED_CLASS_INFO & class_info = reserved_classes.classes[i];
 
 	    pre_drop_length =
 	      ((class_info.objtype ==

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -185,6 +185,12 @@ typedef struct reserved_class_info
   char name[1024];
 } RESERVED_CLASS_INFO;
 
+typedef struct reserved_class_info_list
+{
+  RESERVED_CLASS_INFO *classes;
+  int num_classes;
+} RESERVED_CLASS_INFO_LIST;
+
 static void initialize_serial_invariant (SERIAL_INVARIANT * invariant, DB_VALUE val1, DB_VALUE val2,
 					 PT_OP_TYPE cmp_op, int val1_msgid, int val2_msgid, int error_type);
 static int check_serial_invariants (SERIAL_INVARIANT * invariants, int num_invariants, int *ret_msg_id);
@@ -206,11 +212,12 @@ static int get_dblink_password_encrypt (const char *passwd, DB_VALUE * encrypt_v
 static int get_dblink_password_decrypt (const char *passwd_cipher, DB_VALUE * decrypt_val);
 static MOP server_find (PT_NODE * node_server, PT_NODE * node_owner);
 
-static int do_supplemental_statement (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLASS_INFO ** cls_info,
-				      OID * reserved_oid);
+static int do_supplemental_statement (PARSER_CONTEXT * parser, PT_NODE * statement,
+				      RESERVED_CLASS_INFO_LIST & reserved_classes, OID * reserved_oid);
 
-static int do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLASS_INFO ** &cls_info);
-static void do_free_reserved_classinfo (RESERVED_CLASS_INFO ** cls_info);
+static int do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement,
+				 RESERVED_CLASS_INFO_LIST & reserved_classes);
+static void do_free_reserved_classinfo (RESERVED_CLASS_INFO_LIST & reserved_classes);
 
 static int do_reserve_oidinfo (PARSER_CONTEXT * parser, PT_NODE * statement, OID ** oid);
 /*
@@ -3073,7 +3080,7 @@ do_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
   int suppress_repl_error = NO_ERROR;
   LC_FETCH_VERSION_TYPE read_fetch_instance_version;
 
-  RESERVED_CLASS_INFO **cls_info = NULL;
+  RESERVED_CLASS_INFO_LIST reserved_classes = { NULL, 0 };
   OID *reserved_oid = NULL;
 
   /* save old read fetch instance version */
@@ -3255,7 +3262,7 @@ do_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
 	  break;
 
 	case PT_DROP:
-	  error = do_reserve_classinfo (parser, statement, cls_info);
+	  error = do_reserve_classinfo (parser, statement, reserved_classes);
 	  /* Do not execute DROP if CDC supplemental log metadata cannot be reserved. */
 	  if (error != NO_ERROR)
 	    {
@@ -3489,7 +3496,7 @@ do_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
 
       if (prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) > 0)
 	{
-	  (void) do_supplemental_statement (parser, statement, cls_info, reserved_oid);
+	  (void) do_supplemental_statement (parser, statement, reserved_classes, reserved_oid);
 	}
     }
 
@@ -3514,7 +3521,7 @@ end:
 
   RESET_HOST_VARIABLES_IF_INTERNAL_STATEMENT (parser);
 
-  do_free_reserved_classinfo (cls_info);
+  do_free_reserved_classinfo (reserved_classes);
 
   if (error == ER_FAILED)
     {
@@ -3778,7 +3785,7 @@ do_execute_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
   int suppress_repl_error;
   LC_FETCH_VERSION_TYPE read_fetch_instance_version;
 
-  RESERVED_CLASS_INFO **cls_info = NULL;
+  RESERVED_CLASS_INFO_LIST reserved_classes = { NULL, 0 };
   OID *reserved_oid = NULL;
 
   assert (parser->query_id == NULL_QUERY_ID);
@@ -3964,7 +3971,7 @@ do_execute_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
       /* err = do_drop(parser, statement); */
       /* execute internal statements before and after do_drop() */
 
-      err = do_reserve_classinfo (parser, statement, cls_info);
+      err = do_reserve_classinfo (parser, statement, reserved_classes);
       /* Do not execute DROP if CDC supplemental log metadata cannot be reserved. */
       if (err != NO_ERROR)
 	{
@@ -4175,7 +4182,7 @@ do_execute_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
 
   if (prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) > 0)
     {
-      (void) do_supplemental_statement (parser, statement, cls_info, reserved_oid);
+      (void) do_supplemental_statement (parser, statement, reserved_classes, reserved_oid);
     }
 
 end:
@@ -4201,7 +4208,7 @@ end:
 
   RESET_HOST_VARIABLES_IF_INTERNAL_STATEMENT (parser);
 
-  do_free_reserved_classinfo (cls_info);
+  do_free_reserved_classinfo (reserved_classes);
 
   return ((err == ER_FAILED && (err = er_errid ()) == NO_ERROR) ? ER_GENERIC_ERROR : err);
 }				/* do_execute_statement() */
@@ -15400,7 +15407,7 @@ do_find_object_type (PT_MISC_TYPE type, const char *classname, CDC_DDL_OBJECT_TY
 }
 
 static int
-do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLASS_INFO ** &cls_info)
+do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLASS_INFO_LIST & reserved_classes)
 {
   int count = 0;
   int num_class = 0;
@@ -15412,7 +15419,8 @@ do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLA
   const char *classname;
   DB_OBJECT *class_obj;
 
-  cls_info = NULL;
+  reserved_classes.classes = NULL;
+  reserved_classes.num_classes = 0;
 
   if (prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) != 1)
     {
@@ -15431,40 +15439,34 @@ do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLA
 	  num_class++;
 	}
 
-      cls_info_size = (num_class + 1) * sizeof (RESERVED_CLASS_INFO *);
-      cls_info = (RESERVED_CLASS_INFO **) calloc (num_class + 1, sizeof (RESERVED_CLASS_INFO *));
-      if (cls_info == NULL)
+      cls_info_size = num_class * sizeof (RESERVED_CLASS_INFO);
+      reserved_classes.classes = (RESERVED_CLASS_INFO *) calloc (num_class, sizeof (RESERVED_CLASS_INFO));
+      if (reserved_classes.classes == NULL)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, cls_info_size);
 	  return ER_OUT_OF_VIRTUAL_MEMORY;
 	}
+      reserved_classes.num_classes = num_class;
 
       for (entity_spec = statement->info.drop.spec_list; entity_spec != NULL; entity_spec = entity_spec->next)
 	{
+	  RESERVED_CLASS_INFO &class_info = reserved_classes.classes[count];
+
 	  entity = entity_spec->info.spec.flat_entity_list;
-
-	  cls_info[count] = (RESERVED_CLASS_INFO *) malloc (sizeof (RESERVED_CLASS_INFO));
-	  if (cls_info[count] == NULL)
-	    {
-	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (RESERVED_CLASS_INFO));
-	      error = ER_OUT_OF_VIRTUAL_MEMORY;
-	      goto error_exit;
-	    }
-
 	  classname = entity->info.name.original;
 	  class_obj = db_find_class (classname);
 
-	  strcpy (cls_info[count]->name, classname);
+	  strcpy (class_info.name, classname);
 
-	  memcpy (&cls_info[count]->oid, ws_oid (class_obj), sizeof (OID));
+	  memcpy (&class_info.oid, ws_oid (class_obj), sizeof (OID));
 
-	  if (do_find_object_type (statement->info.drop.entity_type, classname, &cls_info[count]->objtype) != NO_ERROR)
+	  if (do_find_object_type (statement->info.drop.entity_type, classname, &class_info.objtype) != NO_ERROR)
 	    {
 	      error = ER_FAILED;
 	      goto error_exit;
 	    }
 
-	  assert (cls_info[count]->objtype == CDC_TABLE || cls_info[count]->objtype == CDC_VIEW);
+	  assert (class_info.objtype == CDC_TABLE || class_info.objtype == CDC_VIEW);
 
 	  count++;
 	}
@@ -15473,33 +15475,20 @@ do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLA
   return NO_ERROR;
 
 error_exit:
-  do_free_reserved_classinfo (cls_info);
-  cls_info = NULL;
+  do_free_reserved_classinfo (reserved_classes);
   return error;
 }
 
 static void
-do_free_reserved_classinfo (RESERVED_CLASS_INFO ** cls_info)
+do_free_reserved_classinfo (RESERVED_CLASS_INFO_LIST & reserved_classes)
 {
-  int i = 0;
-
-  if (cls_info == NULL)
-    {
-      return;
-    }
-
-  while (cls_info[i] != NULL)
-    {
-      free_and_init (cls_info[i]);
-      i++;
-    }
-
-  free_and_init (cls_info);
+  free_and_init (reserved_classes.classes);
+  reserved_classes.num_classes = 0;
 }
 
 static int
-do_supplemental_statement (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLASS_INFO ** cls_info,
-			   OID * reserved_oid)
+do_supplemental_statement (PARSER_CONTEXT * parser, PT_NODE * statement,
+			   RESERVED_CLASS_INFO_LIST & reserved_classes, OID * reserved_oid)
 {
   int error = NO_ERROR;
   PARSER_VARCHAR **host_val = NULL;
@@ -15509,7 +15498,6 @@ do_supplemental_statement (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVE
   char *sbr_text = NULL;
   char *stmt_text = NULL;
 
-  int num_class = 0;
   int num_object = 0;
 
   int drop_stmt_length = 0, pre_drop_length = 0;
@@ -15659,35 +15647,28 @@ do_supplemental_statement (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVE
 
 	ddl_type = CDC_DROP;
 
-	if (cls_info != NULL)
+	for (int i = 0; i < reserved_classes.num_classes; i++)
 	  {
-	    while (cls_info[num_class] != NULL)
-	      {
-		num_class++;
-	      }
-	  }
+	    RESERVED_CLASS_INFO &class_info = reserved_classes.classes[i];
 
-
-	for (int i = 0; i < num_class; i++)
-	  {
 	    pre_drop_length =
-	      ((cls_info[i]->objtype ==
+	      ((class_info.objtype ==
 		CDC_TABLE) ? strlen (drop_prefix) : strlen (drop_view_prefix)) + strlen (if_exist_statement) +
 	      strlen (cascade_statement) + 2;
 
-	    drop_stmt_length = pre_drop_length + strlen (cls_info[i]->name);
+	    drop_stmt_length = pre_drop_length + strlen (class_info.name);
 	    drop_stmt = (char *) malloc (drop_stmt_length * 2);
 	    if (drop_stmt == NULL)
 	      {
 		goto end;
 	      }
 
-	    if (cls_info[i]->objtype == CDC_TABLE)
+	    if (class_info.objtype == CDC_TABLE)
 	      {
 		strncpy (drop_stmt, drop_prefix, strlen (drop_prefix));
 		drop_copied_length = strlen (drop_prefix);
 	      }
-	    else if (cls_info[i]->objtype == CDC_VIEW)
+	    else if (class_info.objtype == CDC_VIEW)
 	      {
 		strncpy (drop_stmt, drop_view_prefix, strlen (drop_view_prefix));
 		drop_copied_length = strlen (drop_view_prefix);
@@ -15703,8 +15684,8 @@ do_supplemental_statement (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVE
 		drop_copied_length += strlen (if_exist_statement);
 	      }
 
-	    strncpy (drop_stmt + drop_copied_length, cls_info[i]->name, strlen (cls_info[i]->name));
-	    drop_copied_length += strlen (cls_info[i]->name);
+	    strncpy (drop_stmt + drop_copied_length, class_info.name, strlen (class_info.name));
+	    drop_copied_length += strlen (class_info.name);
 
 	    if (statement->info.drop.is_cascade_constraints)
 	      {
@@ -15715,8 +15696,7 @@ do_supplemental_statement (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVE
 	    drop_stmt[drop_copied_length] = '\0';
 
 	    error =
-	      log_supplement_statement (ddl_type, cls_info[i]->objtype, &cls_info[i]->oid, &cls_info[i]->oid,
-					drop_stmt);
+	      log_supplement_statement (ddl_type, class_info.objtype, &class_info.oid, &class_info.oid, drop_stmt);
 
 	    free_and_init (drop_stmt);
 	  }

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -209,7 +209,7 @@ static MOP server_find (PT_NODE * node_server, PT_NODE * node_owner);
 static int do_supplemental_statement (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLASS_INFO ** cls_info,
 				      OID * reserved_oid);
 
-static int do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLASS_INFO *** cls_info);
+static int do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLASS_INFO **&cls_info);
 static void do_free_reserved_classinfo (RESERVED_CLASS_INFO ** cls_info);
 
 static int do_reserve_oidinfo (PARSER_CONTEXT * parser, PT_NODE * statement, OID ** oid);
@@ -3255,7 +3255,8 @@ do_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
 	  break;
 
 	case PT_DROP:
-	  error = do_reserve_classinfo (parser, statement, &cls_info);
+	  error = do_reserve_classinfo (parser, statement, cls_info);
+	  /* Do not execute DROP if CDC supplemental log metadata cannot be reserved. */
 	  if (error != NO_ERROR)
 	    {
 	      goto end;
@@ -3963,7 +3964,8 @@ do_execute_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
       /* err = do_drop(parser, statement); */
       /* execute internal statements before and after do_drop() */
 
-      err = do_reserve_classinfo (parser, statement, &cls_info);
+      err = do_reserve_classinfo (parser, statement, cls_info);
+      /* Do not execute DROP if CDC supplemental log metadata cannot be reserved. */
       if (err != NO_ERROR)
 	{
 	  goto end;
@@ -15398,7 +15400,7 @@ do_find_object_type (PT_MISC_TYPE type, const char *classname, CDC_DDL_OBJECT_TY
 }
 
 static int
-do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLASS_INFO *** cls_info_p)
+do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLASS_INFO **&cls_info)
 {
   int count = 0;
   int num_class = 0;
@@ -15406,13 +15408,11 @@ do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLA
   size_t cls_info_size = 0;
   PT_NODE *entity = NULL;
   PT_NODE *entity_spec = NULL;
-  RESERVED_CLASS_INFO **cls_info = NULL;
 
   const char *classname;
   DB_OBJECT *class_obj;
 
-  assert (cls_info_p != NULL);
-  *cls_info_p = NULL;
+  cls_info = NULL;
 
   if (prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) != 1)
     {
@@ -15470,12 +15470,11 @@ do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLA
 	}
     }
 
-  *cls_info_p = cls_info;
-
   return NO_ERROR;
 
 error_exit:
   do_free_reserved_classinfo (cls_info);
+  cls_info = NULL;
   return error;
 }
 

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -187,7 +187,7 @@ typedef struct reserved_class_info
 
 typedef struct reserved_class_info_list
 {
-  RESERVED_CLASS_INFO *classes;
+  RESERVED_CLASS_INFO *cls_info;
   int num_classes;
 } RESERVED_CLASS_INFO_LIST;
 
@@ -213,11 +213,11 @@ static int get_dblink_password_decrypt (const char *passwd_cipher, DB_VALUE * de
 static MOP server_find (PT_NODE * node_server, PT_NODE * node_owner);
 
 static int do_supplemental_statement (PARSER_CONTEXT * parser, PT_NODE * statement,
-				      RESERVED_CLASS_INFO_LIST & reserved_classes, OID * reserved_oid);
+				      RESERVED_CLASS_INFO_LIST & reserved_cls_info, OID * reserved_oid);
 
 static int do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement,
-				 RESERVED_CLASS_INFO_LIST & reserved_classes);
-static void do_free_reserved_classinfo (RESERVED_CLASS_INFO_LIST & reserved_classes);
+				 RESERVED_CLASS_INFO_LIST & reserved_cls_info);
+static void do_free_reserved_classinfo (RESERVED_CLASS_INFO_LIST & reserved_cls_info);
 
 static int do_reserve_oidinfo (PARSER_CONTEXT * parser, PT_NODE * statement, OID ** oid);
 /*
@@ -3080,7 +3080,7 @@ do_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
   int suppress_repl_error = NO_ERROR;
   LC_FETCH_VERSION_TYPE read_fetch_instance_version;
 
-  RESERVED_CLASS_INFO_LIST reserved_classes = { NULL, 0 };
+  RESERVED_CLASS_INFO_LIST reserved_cls_info = { NULL, 0 };
   OID *reserved_oid = NULL;
 
   /* save old read fetch instance version */
@@ -3262,7 +3262,7 @@ do_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
 	  break;
 
 	case PT_DROP:
-	  error = do_reserve_classinfo (parser, statement, reserved_classes);
+	  error = do_reserve_classinfo (parser, statement, reserved_cls_info);
 	  /* Do not execute DROP if CDC supplemental log metadata cannot be reserved. */
 	  if (error != NO_ERROR)
 	    {
@@ -3496,7 +3496,7 @@ do_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
 
       if (prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) > 0)
 	{
-	  (void) do_supplemental_statement (parser, statement, reserved_classes, reserved_oid);
+	  (void) do_supplemental_statement (parser, statement, reserved_cls_info, reserved_oid);
 	}
     }
 
@@ -3521,7 +3521,7 @@ end:
 
   RESET_HOST_VARIABLES_IF_INTERNAL_STATEMENT (parser);
 
-  do_free_reserved_classinfo (reserved_classes);
+  do_free_reserved_classinfo (reserved_cls_info);
 
   if (error == ER_FAILED)
     {
@@ -3785,7 +3785,7 @@ do_execute_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
   int suppress_repl_error;
   LC_FETCH_VERSION_TYPE read_fetch_instance_version;
 
-  RESERVED_CLASS_INFO_LIST reserved_classes = { NULL, 0 };
+  RESERVED_CLASS_INFO_LIST reserved_cls_info = { NULL, 0 };
   OID *reserved_oid = NULL;
 
   assert (parser->query_id == NULL_QUERY_ID);
@@ -3971,7 +3971,7 @@ do_execute_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
       /* err = do_drop(parser, statement); */
       /* execute internal statements before and after do_drop() */
 
-      err = do_reserve_classinfo (parser, statement, reserved_classes);
+      err = do_reserve_classinfo (parser, statement, reserved_cls_info);
       /* Do not execute DROP if CDC supplemental log metadata cannot be reserved. */
       if (err != NO_ERROR)
 	{
@@ -4182,7 +4182,7 @@ do_execute_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
 
   if (prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) > 0)
     {
-      (void) do_supplemental_statement (parser, statement, reserved_classes, reserved_oid);
+      (void) do_supplemental_statement (parser, statement, reserved_cls_info, reserved_oid);
     }
 
 end:
@@ -4208,7 +4208,7 @@ end:
 
   RESET_HOST_VARIABLES_IF_INTERNAL_STATEMENT (parser);
 
-  do_free_reserved_classinfo (reserved_classes);
+  do_free_reserved_classinfo (reserved_cls_info);
 
   return ((err == ER_FAILED && (err = er_errid ()) == NO_ERROR) ? ER_GENERIC_ERROR : err);
 }				/* do_execute_statement() */
@@ -15407,7 +15407,7 @@ do_find_object_type (PT_MISC_TYPE type, const char *classname, CDC_DDL_OBJECT_TY
 }
 
 static int
-do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLASS_INFO_LIST & reserved_classes)
+do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLASS_INFO_LIST & reserved_cls_info)
 {
   int count = 0;
   int num_class = 0;
@@ -15419,8 +15419,8 @@ do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLA
   const char *classname;
   DB_OBJECT *class_obj;
 
-  reserved_classes.classes = NULL;
-  reserved_classes.num_classes = 0;
+  reserved_cls_info.cls_info = NULL;
+  reserved_cls_info.num_classes = 0;
 
   if (prm_get_integer_value (PRM_ID_SUPPLEMENTAL_LOG) != 1)
     {
@@ -15440,17 +15440,17 @@ do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLA
 	}
 
       cls_info_size = num_class * sizeof (RESERVED_CLASS_INFO);
-      reserved_classes.classes = (RESERVED_CLASS_INFO *) calloc (num_class, sizeof (RESERVED_CLASS_INFO));
-      if (reserved_classes.classes == NULL)
+      reserved_cls_info.cls_info = (RESERVED_CLASS_INFO *) calloc (num_class, sizeof (RESERVED_CLASS_INFO));
+      if (reserved_cls_info.cls_info == NULL)
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, cls_info_size);
 	  return ER_OUT_OF_VIRTUAL_MEMORY;
 	}
-      reserved_classes.num_classes = num_class;
+      reserved_cls_info.num_classes = num_class;
 
       for (entity_spec = statement->info.drop.spec_list; entity_spec != NULL; entity_spec = entity_spec->next)
 	{
-	  RESERVED_CLASS_INFO & class_info = reserved_classes.classes[count];
+	  RESERVED_CLASS_INFO & class_info = reserved_cls_info.cls_info[count];
 
 	  entity = entity_spec->info.spec.flat_entity_list;
 	  classname = entity->info.name.original;
@@ -15475,20 +15475,20 @@ do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLA
   return NO_ERROR;
 
 error_exit:
-  do_free_reserved_classinfo (reserved_classes);
+  do_free_reserved_classinfo (reserved_cls_info);
   return error;
 }
 
 static void
-do_free_reserved_classinfo (RESERVED_CLASS_INFO_LIST & reserved_classes)
+do_free_reserved_classinfo (RESERVED_CLASS_INFO_LIST & reserved_cls_info)
 {
-  free_and_init (reserved_classes.classes);
-  reserved_classes.num_classes = 0;
+  free_and_init (reserved_cls_info.cls_info);
+  reserved_cls_info.num_classes = 0;
 }
 
 static int
 do_supplemental_statement (PARSER_CONTEXT * parser, PT_NODE * statement,
-			   RESERVED_CLASS_INFO_LIST & reserved_classes, OID * reserved_oid)
+			   RESERVED_CLASS_INFO_LIST & reserved_cls_info, OID * reserved_oid)
 {
   int error = NO_ERROR;
   PARSER_VARCHAR **host_val = NULL;
@@ -15647,9 +15647,9 @@ do_supplemental_statement (PARSER_CONTEXT * parser, PT_NODE * statement,
 
 	ddl_type = CDC_DROP;
 
-	for (int i = 0; i < reserved_classes.num_classes; i++)
+	for (int i = 0; i < reserved_cls_info.num_classes; i++)
 	  {
-	    RESERVED_CLASS_INFO & class_info = reserved_classes.classes[i];
+	    RESERVED_CLASS_INFO & class_info = reserved_cls_info.cls_info[i];
 
 	    pre_drop_length =
 	      ((class_info.objtype ==

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -209,7 +209,7 @@ static MOP server_find (PT_NODE * node_server, PT_NODE * node_owner);
 static int do_supplemental_statement (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLASS_INFO ** cls_info,
 				      OID * reserved_oid);
 
-static int do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLASS_INFO **&cls_info);
+static int do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLASS_INFO ** &cls_info);
 static void do_free_reserved_classinfo (RESERVED_CLASS_INFO ** cls_info);
 
 static int do_reserve_oidinfo (PARSER_CONTEXT * parser, PT_NODE * statement, OID ** oid);
@@ -15400,7 +15400,7 @@ do_find_object_type (PT_MISC_TYPE type, const char *classname, CDC_DDL_OBJECT_TY
 }
 
 static int
-do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLASS_INFO **&cls_info)
+do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLASS_INFO ** &cls_info)
 {
   int count = 0;
   int num_class = 0;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27010

## Purpose

`supplemental_log=1` 환경에서 한 `DROP TABLE` 문에 많은 대상 테이블이 포함되면,
문장을 실행한 클라이언트(csql)가 비정상 종료하는 문제를 수정한다.

`do_statement()` / `do_execute_statement()` 는 CDC supplemental DROP 로그를 위해
`RESERVED_CLASS_INFO *cls_info[64]` 고정 스택 배열을 준비한다. 그런데
`do_reserve_classinfo()` 는 DROP 대상 개수를 검사하지 않고 `cls_info[count]` 에 계속
기록한 뒤 마지막에 NULL terminator까지 기록한다.

따라서 DROP 대상이 64개를 초과하면 배열 밖 스택 영역을 침범한다. 실제로
100개 테이블을 한 번에 DROP하면 `supplemental_log=0` 에서는 정상 완료되지만,
`supplemental_log=1` 에서는 csql이 `Segmentation fault`/abort 로 종료된다.

## Changes

**`src/query/execute_statement.c` — DROP reserved class info storage**

DROP 대상 개수를 미리 센 뒤, 필요한 개수 + NULL terminator 크기만큼 동적 배열을
할당하도록 변경한다.

```diff
-  RESERVED_CLASS_INFO *cls_info[64] = { NULL, };
+  RESERVED_CLASS_INFO **cls_info = NULL;
```

```diff
-  (void) do_reserve_classinfo (parser, statement, cls_info);
+  (void) do_reserve_classinfo (parser, statement, &cls_info);
```

**`src/query/execute_statement.c` — `do_reserve_classinfo()`**

`statement->info.drop.spec_list` 를 먼저 순회하여 DROP 대상 개수를 계산하고,
그 크기에 맞춰 `RESERVED_CLASS_INFO **` 배열을 할당한다. 배열은 NULL 로 초기화하여
중간 실패 경로에서도 이미 예약된 항목만 안전하게 정리할 수 있게 한다.

```diff
+      for (entity_spec = statement->info.drop.spec_list; entity_spec != NULL; entity_spec = entity_spec->next)
+        {
+          num_class++;
+        }
+
+      cls_info = (RESERVED_CLASS_INFO **) malloc ((num_class + 1) * sizeof (RESERVED_CLASS_INFO *));
+      memset (cls_info, 0, (num_class + 1) * sizeof (RESERVED_CLASS_INFO *));
```

**`src/query/execute_statement.c` — cleanup ownership**

남은 class info 항목과 배열 포인터를 정리하는 `do_free_reserved_classinfo()` 를 추가하고,
`do_statement()` / `do_execute_statement()` 의 `end:` 정리 경로에서 호출한다.

또한 `do_supplemental_statement()` 의 DROP loop 안에서 `cls_info[i]` 를 즉시 해제하던
흐름을 제거하여, 예약 정보의 소유권과 정리를 caller cleanup 경로로 일원화했다.

## Test

release/11.4 debug build (`11.4.5.1884-239f615`) 에서 동일 shell 시나리오로
수정 전/후를 비교했다.

검증 스크립트:

```bash
~/testcase/cbrd_27010_release_11_4_repro.sh
```

| 케이스 | 수정 전 | 수정 후 |
|---|---:|---:|
| `supplemental_log=0`, `DROP TABLE t1,...,t100` | `CONTROL_RC=0`, `Execute OK` | `CONTROL_RC=0`, `Execute OK` |
| `supplemental_log=1`, `DROP TABLE t1,...,t100` | `REPRO_RC=139`, csql `Segmentation fault` | `REPRO_RC=0`, `Execute OK` |

수정 후 최종 검증:

```text
SCRIPT_RESULT=PASS_FIXED
CONTROL_RC=0
REPRO_RC=0
TABLE_COUNT=100
```

추가 확인:

```bash
bash -ic 'cmc && bd'
```

- `src/query/execute_statement.c.o` 재빌드 및 debug install 성공
- `paramdump -b` 에서 `supplemental_log=1` 이 client/server 양쪽에 적용됨 확인
- 테스트 종료 후 master/server/broker 모두 종료 상태 확인

## Remarks

- 이 PR은 `release/11.4` 대상이다.
- PR #7400(CBRD-26993)은 같은 파일의 supplemental logging cleanup 및 INDEX 에러 마스킹을 다루지만,
  이 PR은 `cls_info[64]` 고정 배열 초과 기록으로 인한 클라이언트 스택 손상을 해결하는 별도 문제다.
- PR #7400 이 먼저 merge될 경우, 해당 PR의 `error >= 0` guard / INDEX 수정은 유지하고,
  본 PR의 동적 class-info 배열 변경만 함께 rebase 하면 된다.
