### PR TITLE
[CBRD-27009] Fix supplemental delete logging on failed delete

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -23394,6 +23394,12 @@ heap_delete_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context)
       goto error;
     }
 
+  if (rc != NO_ERROR)
+    {
+      ASSERT_ERROR ();
+      goto error;
+    }
+
   if (context->do_supplemental_log == true)
     {
       (void) log_append_supplemental_lsa (thread_p,


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27009>

### Purpose

`supplemental_log` 가 켜진 상태에서 `heap_delete_logical()` 의 물리 DELETE 단계가 실패해도,
실패 여부(`rc`)를 확인하지 않고 `LOG_SUPPLEMENT_DELETE` supplemental log 를 append 하는 문제가 있었다.

이 경로에서는 `context->supp_undo_lsa` 가 성공한 delete sub-function 안에서만 설정되므로,
물리 DELETE 실패 시에는 `NULL_LSA` 상태로 남는다. 그 결과 실패한 DELETE 에 대해
null undo LSA 를 가진 malformed supplemental delete record 가 기록될 수 있다.

동일한 supplemental logging 경로를 가진 `heap_update_logical()` 은 physical update 이후
`rc != NO_ERROR` 를 확인하고 supplemental emit 을 건너뛰지만, delete 경로에는 같은 guard 가 빠져 있었다.

### Implementation

`src/storage/heap_file.c` 의 `heap_delete_logical()` 에서 physical delete switch 이후,
`log_append_supplemental_lsa(... LOG_SUPPLEMENT_DELETE ...)` 호출 전에 `rc` 를 확인한다.

```diff
+  if (rc != NO_ERROR)
+    {
+      ASSERT_ERROR ();
+      goto error;
+    }
+
   if (context->do_supplemental_log == true)
     {
       (void) log_append_supplemental_lsa (... LOG_SUPPLEMENT_DELETE ...);
     }
```

이제 `heap_delete_bigone()`, `heap_delete_relocation()`, `heap_delete_home()` 중 하나가 실패하면
supplemental delete record 를 append 하지 않고 기존 error cleanup 경로로 이동한다.

### Test

자연적인 물리 DELETE 실패는 SQL 만으로 안정적으로 만들기 어려우므로, debug build 에서
`heap_delete_home()` 직전 실패를 주입하는 fault-injection 시나리오로 before/after 를 비교했다.
시나리오는 `supplemental_log=1` 로 설정한 임시 DB에서 `REC_HOME` DELETE 를 수행하고,
실패 경로에서 supplemental emit 지점에 도달하는지 관측한다.

| 대상 | 빌드 | 결과 |
|---|---|---|
| `release/11.4` before-fix (`239f61518`) | fault injection | `CBRD-27009-CONFIRM: SUPPLEMENT_DELETE emitted with rc=-1 undo_lsa_null=1` 재현 |
| `release/11.4` after-fix | 동일 시나리오 | DELETE 는 실패하지만 supplemental emit 관측 없음 |
| `release/11.4` after-fix control | fault injection 없이 정상 DELETE | `1 row affected`, supplemental 관측 없음 |
| `develop` before-fix (`47fcc321f`) | 동일 시나리오 | `SUPPLEMENT_DELETE emitted with rc=-1 undo_lsa_null=1` 재현 |
| `develop` after-fix | 동일 시나리오 | DELETE 는 실패하지만 supplemental emit 관측 없음 |

추가 확인:

- `git diff --check -- src/storage/heap_file.c` 통과
- debug build/install (`bash -ic 'bd'`) 통과
- `supplemental_log=1` 적용 상태에서 before/after 검증 수행

### Remarks

- 이 수정은 failed physical DELETE 이후 supplemental delete log 를 막는 guard 만 추가한다.
- 정상 DELETE 의 supplemental logging 동작은 변경하지 않는다.
- `heap_update_logical()` 에 이미 있던 `rc` guard 와 delete 경로의 동작을 맞춘다.
