### PR TITLE
[CBRD-27009] Fix supplemental delete logging on failed heap delete (forward-porting from 11.4)

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -23657,7 +23657,13 @@ heap_delete_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context)
       goto error;
     }
 
-  if (rc == NO_ERROR && context->do_supplemental_log == true)
+  if (rc != NO_ERROR)
+    {
+      ASSERT_ERROR ();
+      goto error;
+    }
+
+  if (context->do_supplemental_log == true)
     {
       (void) log_append_supplemental_lsa (thread_p,
 					  thread_p->trigger_involved ? LOG_SUPPLEMENT_TRIGGER_DELETE :


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27009>

forward-porting from 11.4 https://github.com/CUBRID/cubrid/pull/7407

### Purpose

N/A

### Implementation

N/A

### Remarks

N/A
