### PR TITLE
[CBRD-26955] SLIP: print PT_TYPE_RESULTSET of PL/CSQL functions' return type as 'SYS_REFCURSOR' (#7404)

### DIFF
--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -4422,7 +4422,7 @@ emit_stored_procedure_pre (extract_context & ctxt, print_output & output_ctx)
   DB_VALUE unique_name_val, sp_name_val, pkg_name_val, sp_type_val, arg_cnt_val, lang_val, generated_val, args_val,
     rtn_type_val, class_val, method_val, directive_val, comment_val;
   DB_VALUE owner_val, owner_name_val;
-  int sp_type, rtn_type, arg_cnt, directive, save;
+  int sp_lang, sp_type, rtn_type, arg_cnt, directive, save;
   DB_SET *arg_set;
   int err;
   int err_count = 0;
@@ -4489,6 +4489,7 @@ emit_stored_procedure_pre (extract_context & ctxt, print_output & output_ctx)
 	  continue;
 	}
 
+      sp_lang = db_get_int (&lang_val);
       sp_type = db_get_int (&sp_type_val);
 
       output_ctx ("\nCREATE %s", sp_type == SP_TYPE_PROCEDURE ? "PROCEDURE" : "FUNCTION");
@@ -4528,7 +4529,14 @@ emit_stored_procedure_pre (extract_context & ctxt, print_output & output_ctx)
 
 	  if (rtn_type == DB_TYPE_RESULTSET)
 	    {
-	      output_ctx ("RETURN CURSOR ");
+	      if (sp_lang == SP_LANG_PLCSQL)
+		{
+		  output_ctx ("RETURN SYS_REFCURSOR ");
+		}
+	      else
+		{
+		  output_ctx ("RETURN CURSOR ");
+		}
 	    }
 	  else
 	    {
@@ -4553,7 +4561,6 @@ emit_stored_procedure_pre (extract_context & ctxt, print_output & output_ctx)
 	  output_ctx ("DETERMINISTIC ");
 	}
 
-      int sp_lang = db_get_int (&lang_val);
       if (sp_lang == SP_LANG_PLCSQL)
 	{
 	  output_ctx ("AS LANGUAGE PLCSQL BEGIN ");

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -7844,13 +7844,20 @@ pt_print_create_stored_procedure (PARSER_CONTEXT * parser, PT_NODE * p)
   if (p->info.sp.type == PT_SP_FUNCTION)
     {
       q = pt_append_nulstring (parser, q, parser->flag.is_unloading_plcsql_def ? " RETURN " : " return ");
-      if (p->info.sp.ret_data_type)
+      if ((p->info.sp.body->info.sp_body.lang == SP_LANG_PLCSQL) && (p->info.sp.ret_type == PT_TYPE_RESULTSET))
 	{
-	  q = pt_append_varchar (parser, q, pt_print_bytes (parser, p->info.sp.ret_data_type));
+	  q = pt_append_nulstring (parser, q, "sys_refcursor");
 	}
       else
 	{
-	  q = pt_append_nulstring (parser, q, pt_show_type_enum (p->info.sp.ret_type));
+	  if (p->info.sp.ret_data_type)
+	    {
+	      q = pt_append_varchar (parser, q, pt_print_bytes (parser, p->info.sp.ret_data_type));
+	    }
+	  else
+	    {
+	      q = pt_append_nulstring (parser, q, pt_show_type_enum (p->info.sp.ret_type));
+	    }
 	}
     }
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26955>

### Purpose

SYS_REFCURSOR 를 리턴하는 PL/CSQL function 의 리턴 타입이

unloaddb의 스키마 파일이나
_db_stored_procedure_code의 scode (원본 CREATE 문의 rewritten text)
에서 CUSROR 라고 적히는 문제가 있어서 수정이 필요합니다.

현재 구현에서 JSP의 CURSOR 리턴타입이나 PL/CSQL 의 SYS_REFCURSOR 리턴 타입이 모두 파서 후의 과정에서는 PT_TYPE_RESULTSET 으로 통일되어 다루어지고 있고, PT_TYPE_RESULTSET의 문자열 표현은 CURSOR 이기에 발생한 문제입니다.

### Implementation

release/11.4 브랜치에 먼저 한 수정을 git cherry-pick 으로 적용했습니다. 