### PR TITLE
[CBRD-27028] Handle FILE_OOS asserts in utilities

### DIFF
--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -1429,10 +1429,9 @@ file_header_dump_descriptor (THREAD_ENTRY * thread_p, const FILE_HEADER * fhead,
   switch (fhead->type)
     {
     case FILE_OOS:
-      {
-	assert (false);
-	break;
-      }
+      fprintf (fp, "OOS file\n");
+      break;
+
     case FILE_HEAP:
     case FILE_HEAP_REUSE_SLOTS:
       file_print_name_of_class (thread_p, fp, &fhead->descriptor.heap.class_oid);
@@ -10929,10 +10928,10 @@ file_tracker_get_and_protect (THREAD_ENTRY * thread_p, FILE_TYPE desired_type, F
   switch ((FILE_TYPE) item->type)
     {
     case FILE_OOS:
-      {
-	assert (false);
-	break;
-      }
+      /* FILE_OOS is mutable but does not store owner class information yet. Do not return an unprotected VFID
+       * from interruptible tracker iteration. OOS file table checks can be added after owner metadata exists. */
+      return NO_ERROR;
+
     case FILE_HEAP:
       /* these files may be marked for delete. check this is not a deleted file */
       if (item->metadata.heap.is_marked_deleted)
@@ -12233,14 +12232,10 @@ file_tracker_item_spacedb (THREAD_ENTRY * thread_p, PAGE_PTR page_of_item, FILE_
       spacedb_ftype = SPACEDB_INDEX_FILE;
       break;
     case FILE_OOS:
-      assert_release (false);
-      //TODO: spacedb_ftype = SPACEDB_OOS_FILE;
+      /* OOS is table-owned storage, but FILE_OOS currently has no separate SPACEDB category or owner descriptor. Fold
+       * it into heap totals to keep the spacedb wire/output format stable; a dedicated OOS line requires a separate
+       * output/protocol change. */
       spacedb_ftype = SPACEDB_HEAP_FILE;
-      // TODO oos: why heap file, instead of OOS file?
-      // I did not add SPACEDB_OOS_FILE yet, and
-      // if spacedb_ftype is not initialized,
-      // the build fails in github cubridci.
-      // This is just a workaround.
       break;
     case FILE_HEAP:
     case FILE_HEAP_REUSE_SLOTS:

--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -1429,6 +1429,8 @@ file_header_dump_descriptor (THREAD_ENTRY * thread_p, const FILE_HEADER * fhead,
   switch (fhead->type)
     {
     case FILE_OOS:
+      /* TODO: When the OOS file descriptor stores its owner HFID/class back reference, print the table name and HFID
+       * here. Current FILE_OOS headers do not expose that information from the OOS file itself. */
       fprintf (fp, "OOS file\n");
       break;
 


### PR DESCRIPTION
https://jira.cubrid.org/browse/CBRD-27028

# Description

## 이 PR이 고치는 문제

OOS(큰 가변 컬럼 값을 heap record 밖의 OOS file에 따로 저장하는 기능)가 들어간 뒤, 기존 진단 유틸리티 일부가 새 파일 타입인 `FILE_OOS`를 제대로 처리하지 못했다.

그 결과 OOS 파일이 있는 DB에서 `diagdb`, `spacedb`, `checkdb` 계열 경로가 `FILE_OOS`를 만나면 assertion 또는 default failure로 중단될 수 있었다. 이 PR은 그 회귀를 막기 위해 `FILE_OOS`를 유틸리티 경로에서 명시적으로 처리한다.

## test_shell 회귀와의 관계

이 PR은 `develop <- feat/oos` 추적 PR의 `test_shell` 실패 분석 중 확인된 `FILE_OOS` 유틸리티 회귀를 고친다.

분석 자료:
https://github.com/vimkim/my-cubrid-docs/blob/main/cbrd-26357/5b5ff58/test_shell_failure_5b5ff58_pr6864_circleci135486.md

위 보고서에서 직접 관련된 테스트는 3개로 분류했다.

- `tbl_enc_08`
- `tbl_enc_14`
- `cbrd_26527`

세 테스트는 large value가 예전처럼 `MULTIPAGE_OBJECT_HEAP` overflow 형태로만 보인다는 전제를 갖고 있다. OOS 적용 후에는 해당 값이 `FILE_OOS` 쪽으로 분리될 수 있으므로, 유틸리티가 이 파일 타입을 만나도 죽지 않아야 한다. 이 PR은 그 부분을 수정한다.

단, CircleCI에 보이는 diff 자체는 answer/parser가 기존 heap overflow 출력만 기대해서 생긴 차이일 수 있다. 따라서 이 PR은 `FILE_OOS` 처리 누락으로 인한 utility assertion/fatal을 고치는 패치이고, 테스트 answer/parser의 OOS-aware 보정은 필요하면 별도 작업으로 처리한다.

# Implementation
## 변경 내용

- `file_header_dump_descriptor()`
  - `FILE_OOS`에서 `assert(false)` 하지 않고 `OOS file` descriptor를 출력한다.

- `file_tracker_get_and_protect()`
  - online `checkdb`의 interruptible file tracker 순회에서 `FILE_OOS`를 caller에 반환하지 않고 조용히 건너뛴다.
  - 현재 `FILE_OOS` descriptor에는 owner class OID가 없어서 heap/btree처럼 class lock을 잡을 수 없다. 보호 없이 VFID를 반환하면 동시 `DROP TABLE` 때 stale VFID 검사 또는 resume cursor assert로 이어질 수 있다.
  - offline(SA mode) `checkdb`는 `file_tracker_map()` 경로로 OOS file table을 계속 전수 검사한다.

- `file_tracker_item_spacedb()`
  - `FILE_OOS`에서 `assert_release(false)` 하지 않는다.
  - 이번 PR에서는 새 출력 행을 만들지 않고 OOS page를 기존 HEAP totals에 포함한다.

## 이번 PR에서 하지 않는 것

- `FILE_OOS` descriptor에 owner heap/class metadata를 저장하는 작업은 후속으로 남긴다. 이 정보가 들어가야 online `checkdb`가 class lock 보호 아래 OOS file table을 안전하게 검사할 수 있다.
- `spacedb`에 별도 `SPACEDB_OOS_FILE` 행을 추가하는 작업도 후속으로 남긴다. 이 변경은 `SPACEDB_FILE_TYPE`, network packing, 출력 라벨, message catalog, QA answer를 함께 바꾸는 protocol/output 변경이다.

# Remarks
## 검증

- `git diff --check`
- debug GCC preset build + 단위 테스트
- OOS DB에서 `diagdb`, `spacedb`, `checkdb(SA)` 정상 종료 확인
  - `diagdb`: `OOS file` descriptor 출력
  - `spacedb`: OOS page를 HEAP totals에 합산
- targeted CTP `utility_19`

자세한 설계/리뷰 메모:
https://github.com/vimkim/my-cubrid-docs/blob/main/cbrd-27028/CBRD-27028-file-oos-assert-handling.md