### PR TITLE
[CBRD-27029] Make heap fetch OOS expand policy explicit

### DIFF
--- a/src/connection/connection_support.cpp
+++ b/src/connection/connection_support.cpp
@@ -2468,7 +2468,7 @@ clean_string:
 
   while (true)
     {
-      scan = heap_next (thread_p, &hfid, NULL, &inst_oid, &recdes, &scan_cache, PEEK);
+      scan = heap_next (thread_p, &hfid, NULL, &inst_oid, &recdes, &scan_cache, PEEK, HEAP_WITHOUT_OOS_EXPAND);
       if (scan == S_SUCCESS)
 	{
 	  error = heap_attrinfo_read_dbvalues (thread_p, &inst_oid, &recdes, &attr_info);

--- a/src/connection/connection_support.cpp
+++ b/src/connection/connection_support.cpp
@@ -2468,7 +2468,8 @@ clean_string:
 
   while (true)
     {
-      scan = heap_next (thread_p, &hfid, NULL, &inst_oid, &recdes, &scan_cache, PEEK, HEAP_WITHOUT_OOS_EXPAND);
+      scan = heap_next (thread_p, &hfid, NULL, &inst_oid, &recdes, &scan_cache, PEEK,
+			HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
       if (scan == S_SUCCESS)
 	{
 	  error = heap_attrinfo_read_dbvalues (thread_p, &inst_oid, &recdes, &attr_info);

--- a/src/executables/compactdb.c
+++ b/src/executables/compactdb.c
@@ -561,7 +561,8 @@ process_value (THREAD_ENTRY * thread_p, DB_VALUE * value)
 
 	heap_scancache_quick_start (&scan_cache);
 	scan_cache.mvcc_snapshot = logtb_get_mvcc_snapshot (thread_p);
-	scan_code = heap_get_visible_version_expand_oos (thread_p, ref_oid, NULL, NULL, &scan_cache, PEEK, NULL_CHN);
+	scan_code =
+	  heap_get_visible_version (thread_p, ref_oid, NULL, NULL, &scan_cache, PEEK, NULL_CHN, HEAP_WITH_OOS_EXPAND);
 	heap_scancache_end (thread_p, &scan_cache);
 
 #if defined(CUBRID_DEBUG)
@@ -777,7 +778,8 @@ update_indexes (OID * class_oid, OID * obj_oid, RECDES * rec)
   HEAP_SCANCACHE scan_cache;
 
   (void) heap_scancache_quick_start (&scan_cache);
-  heap_init_get_context (NULL, &context, obj_oid, class_oid, &oldrec, &scan_cache, COPY, NULL_CHN);
+  heap_init_get_context (NULL, &context, obj_oid, class_oid, &oldrec, &scan_cache, COPY, NULL_CHN,
+			 HEAP_WITHOUT_OOS_EXPAND);
 
   old_object = (heap_get_last_version (NULL, &context) == S_SUCCESS);
 

--- a/src/executables/compactdb.c
+++ b/src/executables/compactdb.c
@@ -562,7 +562,8 @@ process_value (THREAD_ENTRY * thread_p, DB_VALUE * value)
 	heap_scancache_quick_start (&scan_cache);
 	scan_cache.mvcc_snapshot = logtb_get_mvcc_snapshot (thread_p);
 	scan_code =
-	  heap_get_visible_version (thread_p, ref_oid, NULL, NULL, &scan_cache, PEEK, NULL_CHN, HEAP_WITH_OOS_EXPAND);
+	  heap_get_visible_version (thread_p, ref_oid, NULL, NULL, &scan_cache, PEEK, NULL_CHN,
+				    HEAP_RECDES_CONSUME_RAW_BYTES);
 	heap_scancache_end (thread_p, &scan_cache);
 
 #if defined(CUBRID_DEBUG)
@@ -779,7 +780,7 @@ update_indexes (OID * class_oid, OID * obj_oid, RECDES * rec)
 
   (void) heap_scancache_quick_start (&scan_cache);
   heap_init_get_context (NULL, &context, obj_oid, class_oid, &oldrec, &scan_cache, COPY, NULL_CHN,
-			 HEAP_WITHOUT_OOS_EXPAND);
+			 HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
 
   old_object = (heap_get_last_version (NULL, &context) == S_SUCCESS);
 

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -239,11 +239,12 @@ namespace cubload
 
     while (true)
       {
-	scan_code = heap_next (&thread_ref, &hfid, NULL, &inst_oid, &recdes, &scan_cache, PEEK);
+	scan_code = heap_next (&thread_ref, &hfid, NULL, &inst_oid, &recdes, &scan_cache, PEEK,
+			       HEAP_WITHOUT_OOS_EXPAND);
 	if (scan_code == S_SUCCESS)
 	  {
-	    scan_code = heap_get_visible_version_expand_oos (&thread_ref, &inst_oid, oid_User_class_oid, &recdes, &scan_cache, PEEK,
-			NULL_CHN);
+	    scan_code = heap_get_visible_version (&thread_ref, &inst_oid, oid_User_class_oid, &recdes, &scan_cache,
+						  PEEK, NULL_CHN, HEAP_WITH_OOS_EXPAND);
 	    if (scan_code == S_SNAPSHOT_NOT_SATISFIED || scan_code == S_DOESNT_EXIST)
 	      {
 		continue;

--- a/src/loaddb/load_server_loader.cpp
+++ b/src/loaddb/load_server_loader.cpp
@@ -240,11 +240,11 @@ namespace cubload
     while (true)
       {
 	scan_code = heap_next (&thread_ref, &hfid, NULL, &inst_oid, &recdes, &scan_cache, PEEK,
-			       HEAP_WITHOUT_OOS_EXPAND);
+			       HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
 	if (scan_code == S_SUCCESS)
 	  {
 	    scan_code = heap_get_visible_version (&thread_ref, &inst_oid, oid_User_class_oid, &recdes, &scan_cache,
-						  PEEK, NULL_CHN, HEAP_WITH_OOS_EXPAND);
+						  PEEK, NULL_CHN, HEAP_RECDES_CONSUME_RAW_BYTES);
 	    if (scan_code == S_SNAPSHOT_NOT_SATISFIED || scan_code == S_DOESNT_EXIST)
 	      {
 		continue;

--- a/src/query/dblink_global_tran_catalog.c
+++ b/src/query/dblink_global_tran_catalog.c
@@ -222,7 +222,7 @@ find_row_by_gtrid_bqual (THREAD_ENTRY * thread_p, int gtrid, int bqual, OID * ou
 	  *out_oid = inst_oid;
 	  return NO_ERROR;
 	}
-      sc = heap_next (thread_p, hfid_p, (OID *) class_oid_p, &inst_oid, &recdes, scan_p, PEEK);
+      sc = heap_next (thread_p, hfid_p, (OID *) class_oid_p, &inst_oid, &recdes, scan_p, PEEK, HEAP_WITHOUT_OOS_EXPAND);
     }
   return ER_FAILED;		/* not found */
 }
@@ -478,7 +478,7 @@ dblink_global_tran_scan_for_recovery (THREAD_ENTRY * thread_p, dblink_global_tra
 	      break;
 	    }
 	}
-      sc = heap_next (thread_p, hfid_p, &class_oid, &inst_oid, &recdes, &scan, PEEK);
+      sc = heap_next (thread_p, hfid_p, &class_oid, &inst_oid, &recdes, &scan, PEEK, HEAP_WITHOUT_OOS_EXPAND);
     }
 
 cleanup:

--- a/src/query/dblink_global_tran_catalog.c
+++ b/src/query/dblink_global_tran_catalog.c
@@ -222,7 +222,9 @@ find_row_by_gtrid_bqual (THREAD_ENTRY * thread_p, int gtrid, int bqual, OID * ou
 	  *out_oid = inst_oid;
 	  return NO_ERROR;
 	}
-      sc = heap_next (thread_p, hfid_p, (OID *) class_oid_p, &inst_oid, &recdes, scan_p, PEEK, HEAP_WITHOUT_OOS_EXPAND);
+      sc =
+	heap_next (thread_p, hfid_p, (OID *) class_oid_p, &inst_oid, &recdes, scan_p, PEEK,
+		   HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
     }
   return ER_FAILED;		/* not found */
 }
@@ -478,7 +480,8 @@ dblink_global_tran_scan_for_recovery (THREAD_ENTRY * thread_p, dblink_global_tra
 	      break;
 	    }
 	}
-      sc = heap_next (thread_p, hfid_p, &class_oid, &inst_oid, &recdes, &scan, PEEK, HEAP_WITHOUT_OOS_EXPAND);
+      sc =
+	heap_next (thread_p, hfid_p, &class_oid, &inst_oid, &recdes, &scan, PEEK, HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
     }
 
 cleanup:

--- a/src/query/parallel/px_scan/index/px_scan_index_leaf_slot_walker.cpp
+++ b/src/query/parallel/px_scan/index/px_scan_index_leaf_slot_walker.cpp
@@ -452,8 +452,8 @@ namespace parallel_index_scan
 	heap_recdes.data = nullptr;
       }
 
-    SCAN_CODE sp_scan = heap_get_visible_version (thread_p, oid, nullptr, &heap_recdes,
-			&isidp->scan_cache, m_scan_id->fixed, NULL_CHN);
+    SCAN_CODE sp_scan = heap_get_visible_version (thread_p, oid, nullptr, &heap_recdes, &isidp->scan_cache,
+			m_scan_id->fixed, NULL_CHN, HEAP_WITHOUT_OOS_EXPAND);
     if (sp_scan == S_SNAPSHOT_NOT_SATISFIED || sp_scan == S_DOESNT_EXIST)
       {
 	return S_END;  /* skip this OID */

--- a/src/query/parallel/px_scan/index/px_scan_index_leaf_slot_walker.cpp
+++ b/src/query/parallel/px_scan/index/px_scan_index_leaf_slot_walker.cpp
@@ -453,7 +453,7 @@ namespace parallel_index_scan
       }
 
     SCAN_CODE sp_scan = heap_get_visible_version (thread_p, oid, nullptr, &heap_recdes, &isidp->scan_cache,
-			m_scan_id->fixed, NULL_CHN, HEAP_WITHOUT_OOS_EXPAND);
+			m_scan_id->fixed, NULL_CHN, HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
     if (sp_scan == S_SNAPSHOT_NOT_SATISFIED || sp_scan == S_DOESNT_EXIST)
       {
 	return S_END;  /* skip this OID */

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -10727,7 +10727,7 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
 		      /* read lob attributes */
 		      scan_code =
 			heap_get_visible_version (thread_p, oid, class_oid, &recdes, internal_class->scan_cache,
-						  PEEK, NULL_CHN, HEAP_WITHOUT_OOS_EXPAND);
+						  PEEK, NULL_CHN, HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
 		      if (scan_code == S_ERROR)
 			{
 			  GOTO_EXIT_ON_ERROR;
@@ -11537,7 +11537,7 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 		  /* read lob attributes */
 		  scan_code =
 		    heap_get_visible_version (thread_p, oid, class_oid, &recdes, internal_class->scan_cache, PEEK,
-					      NULL_CHN, HEAP_WITHOUT_OOS_EXPAND);
+					      NULL_CHN, HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
 		  if (scan_code == S_ERROR)
 		    {
 		      GOTO_EXIT_ON_ERROR;
@@ -12372,7 +12372,7 @@ qexec_execute_duplicate_key_update (THREAD_ENTRY * thread_p, ODKU_INFO * odku, H
 
   scan_code =
     heap_get_visible_version (thread_p, &unique_oid, NULL, &rec_descriptor, local_scan_cache, ispeeking, NULL_CHN,
-			      HEAP_WITHOUT_OOS_EXPAND);
+			      HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
   if (scan_code != S_SUCCESS)
     {
       assert (er_errid () == ER_INTERRUPTED);
@@ -13801,7 +13801,7 @@ qexec_execute_obj_fetch (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE *
 
       /* fetch the object and the class oid */
       scan = locator_get_object (thread_p, &dbvaloid, &cls_oid, &oRec, &scan_cache, scan_operation_type, lock_mode,
-				 PEEK, NULL_CHN, HEAP_WITHOUT_OOS_EXPAND);
+				 PEEK, NULL_CHN, HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
       if (scan != S_SUCCESS)
 	{
 	  /* setting ER_HEAP_UNKNOWN_OBJECT error for deleted or invisible objects should be replaced by a more clear
@@ -14501,7 +14501,8 @@ qexec_execute_selupd_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE
 	      scan_code =
 		locator_lock_and_get_object_with_evaluation (thread_p, &crt_incr_info.m_oid, &crt_incr_info.m_class_oid,
 							     NULL, &scan_cache, COPY, NULL_CHN, p_mvcc_reev_data,
-							     LOG_WARNING_IF_DELETED, HEAP_WITHOUT_OOS_EXPAND);
+							     LOG_WARNING_IF_DELETED,
+							     HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
 	      if (scan_code != S_SUCCESS)
 		{
 		  int er_id = er_errid ();

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -10726,8 +10726,8 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
 
 		      /* read lob attributes */
 		      scan_code =
-			heap_get_visible_version (thread_p, oid, class_oid, &recdes, internal_class->scan_cache, PEEK,
-						  NULL_CHN);
+			heap_get_visible_version (thread_p, oid, class_oid, &recdes, internal_class->scan_cache,
+						  PEEK, NULL_CHN, HEAP_WITHOUT_OOS_EXPAND);
 		      if (scan_code == S_ERROR)
 			{
 			  GOTO_EXIT_ON_ERROR;
@@ -11537,7 +11537,7 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 		  /* read lob attributes */
 		  scan_code =
 		    heap_get_visible_version (thread_p, oid, class_oid, &recdes, internal_class->scan_cache, PEEK,
-					      NULL_CHN);
+					      NULL_CHN, HEAP_WITHOUT_OOS_EXPAND);
 		  if (scan_code == S_ERROR)
 		    {
 		      GOTO_EXIT_ON_ERROR;
@@ -12371,7 +12371,8 @@ qexec_execute_duplicate_key_update (THREAD_ENTRY * thread_p, ODKU_INFO * odku, H
   ispeeking = ((local_scan_cache != NULL && local_scan_cache->cache_last_fix_page) ? PEEK : COPY);
 
   scan_code =
-    heap_get_visible_version (thread_p, &unique_oid, NULL, &rec_descriptor, local_scan_cache, ispeeking, NULL_CHN);
+    heap_get_visible_version (thread_p, &unique_oid, NULL, &rec_descriptor, local_scan_cache, ispeeking, NULL_CHN,
+			      HEAP_WITHOUT_OOS_EXPAND);
   if (scan_code != S_SUCCESS)
     {
       assert (er_errid () == ER_INTERRUPTED);
@@ -13800,7 +13801,7 @@ qexec_execute_obj_fetch (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE *
 
       /* fetch the object and the class oid */
       scan = locator_get_object (thread_p, &dbvaloid, &cls_oid, &oRec, &scan_cache, scan_operation_type, lock_mode,
-				 PEEK, NULL_CHN);
+				 PEEK, NULL_CHN, HEAP_WITHOUT_OOS_EXPAND);
       if (scan != S_SUCCESS)
 	{
 	  /* setting ER_HEAP_UNKNOWN_OBJECT error for deleted or invisible objects should be replaced by a more clear
@@ -14500,7 +14501,7 @@ qexec_execute_selupd_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE
 	      scan_code =
 		locator_lock_and_get_object_with_evaluation (thread_p, &crt_incr_info.m_oid, &crt_incr_info.m_class_oid,
 							     NULL, &scan_cache, COPY, NULL_CHN, p_mvcc_reev_data,
-							     LOG_WARNING_IF_DELETED);
+							     LOG_WARNING_IF_DELETED, HEAP_WITHOUT_OOS_EXPAND);
 	      if (scan_code != S_SUCCESS)
 		{
 		  int er_id = er_errid ();

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -5927,14 +5927,14 @@ scan_next_heap_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 	      if (scan_id->type == S_HEAP_SCAN)
 		{
 		  sp_scan =
-		    heap_next (thread_p, &hsidp->hfid, &hsidp->cls_oid, &hsidp->curr_oid, &recdes, &hsidp->scan_cache,
-			       is_peeking);
+		    heap_next (thread_p, &hsidp->hfid, &hsidp->cls_oid, &hsidp->curr_oid, &recdes,
+			       &hsidp->scan_cache, is_peeking, HEAP_WITHOUT_OOS_EXPAND);
 		}
 	      else if (scan_id->type == S_HEAP_SAMPLING_SCAN)
 		{
 		  sp_scan =
 		    heap_next_sampling (thread_p, &hsidp->hfid, &hsidp->cls_oid, &hsidp->curr_oid, &recdes,
-					&hsidp->scan_cache, is_peeking, &hsidp->sampling);
+					&hsidp->scan_cache, is_peeking, HEAP_WITHOUT_OOS_EXPAND, &hsidp->sampling);
 		}
 	      else
 		{
@@ -5950,8 +5950,8 @@ scan_next_heap_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 	      if (scan_id->type == S_HEAP_SCAN)
 		{
 		  sp_scan =
-		    heap_prev (thread_p, &hsidp->hfid, &hsidp->cls_oid, &hsidp->curr_oid, &recdes, &hsidp->scan_cache,
-			       is_peeking);
+		    heap_prev (thread_p, &hsidp->hfid, &hsidp->cls_oid, &hsidp->curr_oid, &recdes,
+			       &hsidp->scan_cache, is_peeking, HEAP_WITHOUT_OOS_EXPAND);
 		}
 	      else
 		{
@@ -6048,7 +6048,8 @@ scan_next_heap_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 	  /* get with lock and reevaluate if the visible version wasn't the latest version */
 	  sp_scan =
 	    locator_lock_and_get_object_with_evaluation (thread_p, &current_oid, NULL, &recdes, &hsidp->scan_cache,
-							 is_peeking, NULL_CHN, &mvcc_reev_data, LOG_WARNING_IF_DELETED);
+							 is_peeking, NULL_CHN, &mvcc_reev_data, LOG_WARNING_IF_DELETED,
+							 HEAP_WITHOUT_OOS_EXPAND);
 	  if (sp_scan == S_SUCCESS && mvcc_reev_data.filter_result == V_FALSE)
 	    {
 	      continue;
@@ -6811,8 +6812,9 @@ scan_next_index_lookup_heap (THREAD_ENTRY * thread_p, SCAN_ID * scan_id, INDX_SC
       recdes.data = NULL;
     }
 
-  sp_scan = heap_get_visible_version (thread_p, isidp->curr_oidp, NULL, &recdes, &isidp->scan_cache, scan_id->fixed,
-				      NULL_CHN);
+  sp_scan =
+    heap_get_visible_version (thread_p, isidp->curr_oidp, NULL, &recdes, &isidp->scan_cache, scan_id->fixed,
+			      NULL_CHN, HEAP_WITHOUT_OOS_EXPAND);
   if (sp_scan == S_SNAPSHOT_NOT_SATISFIED)
     {
       if (SCAN_IS_INDEX_COVERED (isidp))
@@ -6867,7 +6869,8 @@ scan_next_index_lookup_heap (THREAD_ENTRY * thread_p, SCAN_ID * scan_id, INDX_SC
 
       sp_scan = locator_lock_and_get_object_with_evaluation (thread_p, isidp->curr_oidp, NULL, &recdes,
 							     &isidp->scan_cache, scan_id->fixed, NULL_CHN,
-							     &mvcc_reev_data, LOG_WARNING_IF_DELETED);
+							     &mvcc_reev_data, LOG_WARNING_IF_DELETED,
+							     HEAP_WITHOUT_OOS_EXPAND);
       if (sp_scan == S_SUCCESS)
 	{
 	  switch (mvcc_reev_data.filter_result)

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -5928,13 +5928,14 @@ scan_next_heap_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 		{
 		  sp_scan =
 		    heap_next (thread_p, &hsidp->hfid, &hsidp->cls_oid, &hsidp->curr_oid, &recdes,
-			       &hsidp->scan_cache, is_peeking, HEAP_WITHOUT_OOS_EXPAND);
+			       &hsidp->scan_cache, is_peeking, HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
 		}
 	      else if (scan_id->type == S_HEAP_SAMPLING_SCAN)
 		{
 		  sp_scan =
 		    heap_next_sampling (thread_p, &hsidp->hfid, &hsidp->cls_oid, &hsidp->curr_oid, &recdes,
-					&hsidp->scan_cache, is_peeking, HEAP_WITHOUT_OOS_EXPAND, &hsidp->sampling);
+					&hsidp->scan_cache, is_peeking, HEAP_RECDES_DONT_CONSUME_RAW_BYTES,
+					&hsidp->sampling);
 		}
 	      else
 		{
@@ -5951,7 +5952,7 @@ scan_next_heap_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 		{
 		  sp_scan =
 		    heap_prev (thread_p, &hsidp->hfid, &hsidp->cls_oid, &hsidp->curr_oid, &recdes,
-			       &hsidp->scan_cache, is_peeking, HEAP_WITHOUT_OOS_EXPAND);
+			       &hsidp->scan_cache, is_peeking, HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
 		}
 	      else
 		{
@@ -6049,7 +6050,7 @@ scan_next_heap_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 	  sp_scan =
 	    locator_lock_and_get_object_with_evaluation (thread_p, &current_oid, NULL, &recdes, &hsidp->scan_cache,
 							 is_peeking, NULL_CHN, &mvcc_reev_data, LOG_WARNING_IF_DELETED,
-							 HEAP_WITHOUT_OOS_EXPAND);
+							 HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
 	  if (sp_scan == S_SUCCESS && mvcc_reev_data.filter_result == V_FALSE)
 	    {
 	      continue;
@@ -6814,7 +6815,7 @@ scan_next_index_lookup_heap (THREAD_ENTRY * thread_p, SCAN_ID * scan_id, INDX_SC
 
   sp_scan =
     heap_get_visible_version (thread_p, isidp->curr_oidp, NULL, &recdes, &isidp->scan_cache, scan_id->fixed,
-			      NULL_CHN, HEAP_WITHOUT_OOS_EXPAND);
+			      NULL_CHN, HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
   if (sp_scan == S_SNAPSHOT_NOT_SATISFIED)
     {
       if (SCAN_IS_INDEX_COVERED (isidp))
@@ -6870,7 +6871,7 @@ scan_next_index_lookup_heap (THREAD_ENTRY * thread_p, SCAN_ID * scan_id, INDX_SC
       sp_scan = locator_lock_and_get_object_with_evaluation (thread_p, isidp->curr_oidp, NULL, &recdes,
 							     &isidp->scan_cache, scan_id->fixed, NULL_CHN,
 							     &mvcc_reev_data, LOG_WARNING_IF_DELETED,
-							     HEAP_WITHOUT_OOS_EXPAND);
+							     HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
       if (sp_scan == S_SUCCESS)
 	{
 	  switch (mvcc_reev_data.filter_result)

--- a/src/query/serial.c
+++ b/src/query/serial.c
@@ -215,7 +215,7 @@ xserial_get_current_value_internal (THREAD_ENTRY * thread_p, DB_VALUE * result_n
   /* get record into record desc */
   scan =
     heap_get_visible_version (thread_p, serial_oidp, &serial_class_oid, &recdesc, &scan_cache, PEEK, NULL_CHN,
-			      HEAP_WITH_OOS_EXPAND);
+			      HEAP_RECDES_CONSUME_RAW_BYTES);
   if (scan != S_SUCCESS)
     {
       if (er_errid () == ER_PB_BAD_PAGEID)
@@ -532,7 +532,7 @@ serial_update_cur_val_of_serial (THREAD_ENTRY * thread_p, SERIAL_CACHE_ENTRY * e
 
   scan =
     heap_get_visible_version (thread_p, &entry->oid, &serial_class_oid, &recdesc, &scan_cache, PEEK, NULL_CHN,
-			      HEAP_WITH_OOS_EXPAND);
+			      HEAP_RECDES_CONSUME_RAW_BYTES);
   if (scan != S_SUCCESS)
     {
       if (er_errid () == ER_PB_BAD_PAGEID)
@@ -668,7 +668,7 @@ xserial_get_next_value_internal (THREAD_ENTRY * thread_p, DB_VALUE * result_num,
 
   scan =
     heap_get_visible_version (thread_p, serial_oidp, &serial_class_oid, &recdesc, &scan_cache, PEEK, NULL_CHN,
-			      HEAP_WITH_OOS_EXPAND);
+			      HEAP_RECDES_CONSUME_RAW_BYTES);
   if (scan != S_SUCCESS)
     {
       if (er_errid () == ER_PB_BAD_PAGEID)

--- a/src/query/serial.c
+++ b/src/query/serial.c
@@ -214,8 +214,8 @@ xserial_get_current_value_internal (THREAD_ENTRY * thread_p, DB_VALUE * result_n
 
   /* get record into record desc */
   scan =
-    heap_get_visible_version_expand_oos (thread_p, serial_oidp, &serial_class_oid, &recdesc, &scan_cache, PEEK,
-					 NULL_CHN);
+    heap_get_visible_version (thread_p, serial_oidp, &serial_class_oid, &recdesc, &scan_cache, PEEK, NULL_CHN,
+			      HEAP_WITH_OOS_EXPAND);
   if (scan != S_SUCCESS)
     {
       if (er_errid () == ER_PB_BAD_PAGEID)
@@ -531,8 +531,8 @@ serial_update_cur_val_of_serial (THREAD_ENTRY * thread_p, SERIAL_CACHE_ENTRY * e
   heap_scancache_quick_start_modify_with_class_oid (thread_p, &scan_cache, &serial_class_oid);
 
   scan =
-    heap_get_visible_version_expand_oos (thread_p, &entry->oid, &serial_class_oid, &recdesc, &scan_cache, PEEK,
-					 NULL_CHN);
+    heap_get_visible_version (thread_p, &entry->oid, &serial_class_oid, &recdesc, &scan_cache, PEEK, NULL_CHN,
+			      HEAP_WITH_OOS_EXPAND);
   if (scan != S_SUCCESS)
     {
       if (er_errid () == ER_PB_BAD_PAGEID)
@@ -667,8 +667,8 @@ xserial_get_next_value_internal (THREAD_ENTRY * thread_p, DB_VALUE * result_num,
   heap_scancache_quick_start_modify_with_class_oid (thread_p, &scan_cache, &serial_class_oid);
 
   scan =
-    heap_get_visible_version_expand_oos (thread_p, serial_oidp, &serial_class_oid, &recdesc, &scan_cache, PEEK,
-					 NULL_CHN);
+    heap_get_visible_version (thread_p, serial_oidp, &serial_class_oid, &recdesc, &scan_cache, PEEK, NULL_CHN,
+			      HEAP_WITH_OOS_EXPAND);
   if (scan != S_SUCCESS)
     {
       if (er_errid () == ER_PB_BAD_PAGEID)

--- a/src/sp/sp_code.cpp
+++ b/src/sp/sp_code.cpp
@@ -88,7 +88,7 @@ sp_get_code_attr (THREAD_ENTRY *thread_p, const std::string &attr_name, const OI
   /* get record into record desc */
   scan =
 	  heap_get_visible_version (thread_p, sp_oidp, sp_class_oid, &recdesc, &scan_cache, PEEK, NULL_CHN,
-				    HEAP_WITH_OOS_EXPAND);
+				    HEAP_RECDES_CONSUME_RAW_BYTES);
   if (scan != S_SUCCESS)
     {
       if (er_errid () == ER_PB_BAD_PAGEID)

--- a/src/sp/sp_code.cpp
+++ b/src/sp/sp_code.cpp
@@ -86,7 +86,9 @@ sp_get_code_attr (THREAD_ENTRY *thread_p, const std::string &attr_name, const OI
 
   heap_scancache_quick_start_with_class_oid (thread_p, &scan_cache, sp_class_oid);
   /* get record into record desc */
-  scan = heap_get_visible_version_expand_oos (thread_p, sp_oidp, sp_class_oid, &recdesc, &scan_cache, PEEK, NULL_CHN);
+  scan =
+	  heap_get_visible_version (thread_p, sp_oidp, sp_class_oid, &recdesc, &scan_cache, PEEK, NULL_CHN,
+				    HEAP_WITH_OOS_EXPAND);
   if (scan != S_SUCCESS)
     {
       if (er_errid () == ER_PB_BAD_PAGEID)

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -3721,7 +3721,7 @@ btree_sort_get_next (THREAD_ENTRY * thread_p, RECDES * temp_recdes, void *arg)
       scan_result =
 	heap_next (thread_p, &sort_args->hfids[cur_class], &sort_args->class_ids[cur_class], &sort_args->cur_oid,
 		   &sort_args->in_recdes, &sort_args->hfscan_cache,
-		   sort_args->hfscan_cache.cache_last_fix_page ? PEEK : COPY);
+		   sort_args->hfscan_cache.cache_last_fix_page ? PEEK : COPY, HEAP_WITHOUT_OOS_EXPAND);
 
       switch (scan_result)
 	{
@@ -5368,7 +5368,8 @@ online_index_builder (THREAD_ENTRY * thread_p, BTID_INT * btid_int, HFID * hfids
 
       cur_record.data = NULL;
 
-      sc = heap_next (thread_p, &hfids[cur_class], &class_oids[cur_class], &cur_oid, &cur_record, scancache, COPY);
+      sc = heap_next (thread_p, &hfids[cur_class], &class_oids[cur_class], &cur_oid, &cur_record, scancache, COPY,
+		      HEAP_WITHOUT_OOS_EXPAND);
       if (sc != S_SUCCESS)
         {
           if (sc != S_END)

--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -3721,7 +3721,7 @@ btree_sort_get_next (THREAD_ENTRY * thread_p, RECDES * temp_recdes, void *arg)
       scan_result =
 	heap_next (thread_p, &sort_args->hfids[cur_class], &sort_args->class_ids[cur_class], &sort_args->cur_oid,
 		   &sort_args->in_recdes, &sort_args->hfscan_cache,
-		   sort_args->hfscan_cache.cache_last_fix_page ? PEEK : COPY, HEAP_WITHOUT_OOS_EXPAND);
+		   sort_args->hfscan_cache.cache_last_fix_page ? PEEK : COPY, HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
 
       switch (scan_result)
 	{
@@ -5369,7 +5369,7 @@ online_index_builder (THREAD_ENTRY * thread_p, BTID_INT * btid_int, HFID * hfids
       cur_record.data = NULL;
 
       sc = heap_next (thread_p, &hfids[cur_class], &class_oids[cur_class], &cur_oid, &cur_record, scancache, COPY,
-		      HEAP_WITHOUT_OOS_EXPAND);
+		      HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
       if (sc != S_SUCCESS)
         {
           if (sc != S_END)

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -4010,7 +4010,8 @@ catcls_delete_instance (THREAD_ENTRY * thread_p, OID * oid_p, OID * class_oid_p,
   is_lock_inited = true;
 #endif /* SERVER_MODE */
 
-  if (heap_get_visible_version_expand_oos (thread_p, oid_p, class_oid_p, &record, scan_p, COPY, NULL_CHN) != S_SUCCESS)
+  if (heap_get_visible_version (thread_p, oid_p, class_oid_p, &record, scan_p, COPY, NULL_CHN,
+				HEAP_WITH_OOS_EXPAND) != S_SUCCESS)
     {
       assert (er_errid () != NO_ERROR);
       error = er_errid ();
@@ -4175,8 +4176,8 @@ catcls_update_instance (THREAD_ENTRY * thread_p, OR_VALUE * value_p, OID * oid_p
   int i, j, k;
   int error = NO_ERROR;
 
-  if (heap_get_visible_version_expand_oos (thread_p, oid_p, class_oid_p, &old_record, scan_p, COPY, NULL_CHN) !=
-      S_SUCCESS)
+  if (heap_get_visible_version (thread_p, oid_p, class_oid_p, &old_record, scan_p, COPY, NULL_CHN,
+				HEAP_WITH_OOS_EXPAND) != S_SUCCESS)
     {
       assert (er_errid () != NO_ERROR);
       error = er_errid ();
@@ -4499,8 +4500,8 @@ catcls_update_class_stats (THREAD_ENTRY * thread_p, const char *class_name, unsi
 
   is_scan_inited = true;
 
-  if (heap_get_visible_version_expand_oos (thread_p, &oid, catalog_class_oid_p, &record, &scan, COPY, NULL_CHN) !=
-      S_SUCCESS)
+  if (heap_get_visible_version (thread_p, &oid, catalog_class_oid_p, &record, &scan, COPY, NULL_CHN,
+				HEAP_WITH_OOS_EXPAND) != S_SUCCESS)
     {
       ASSERT_ERROR_AND_SET (error);
       goto error;
@@ -5011,7 +5012,7 @@ catcls_get_server_compat_info (THREAD_ENTRY * thread_p, INTL_CODESET * charset_i
     }
   scan_cache_inited = true;
 
-  while (heap_next (thread_p, &hfid, NULL, &inst_oid, &recdes, &scan_cache, PEEK) == S_SUCCESS)
+  while (heap_next (thread_p, &hfid, NULL, &inst_oid, &recdes, &scan_cache, PEEK, HEAP_WITHOUT_OOS_EXPAND) == S_SUCCESS)
     {
       HEAP_ATTRVALUE *heap_value = NULL;
 
@@ -5463,7 +5464,7 @@ catcls_get_db_collation (THREAD_ENTRY * thread_p, LANG_COLL_COMPAT ** db_collati
     }
 
   *coll_cnt = 0;
-  while (heap_next (thread_p, &hfid, NULL, &inst_oid, &recdes, &scan_cache, PEEK) == S_SUCCESS)
+  while (heap_next (thread_p, &hfid, NULL, &inst_oid, &recdes, &scan_cache, PEEK, HEAP_WITHOUT_OOS_EXPAND) == S_SUCCESS)
     {
       HEAP_ATTRVALUE *heap_value = NULL;
       LANG_COLL_COMPAT *curr_coll;
@@ -5674,7 +5675,7 @@ catcls_get_apply_info_log_record_time (THREAD_ENTRY * thread_p, time_t * log_rec
     }
   scan_cache_inited = true;
 
-  while (heap_next (thread_p, &hfid, NULL, &inst_oid, &recdes, &scan_cache, PEEK) == S_SUCCESS)
+  while (heap_next (thread_p, &hfid, NULL, &inst_oid, &recdes, &scan_cache, PEEK, HEAP_WITHOUT_OOS_EXPAND) == S_SUCCESS)
     {
       HEAP_ATTRVALUE *heap_value = NULL;
 

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -4011,7 +4011,7 @@ catcls_delete_instance (THREAD_ENTRY * thread_p, OID * oid_p, OID * class_oid_p,
 #endif /* SERVER_MODE */
 
   if (heap_get_visible_version (thread_p, oid_p, class_oid_p, &record, scan_p, COPY, NULL_CHN,
-				HEAP_WITH_OOS_EXPAND) != S_SUCCESS)
+				HEAP_RECDES_CONSUME_RAW_BYTES) != S_SUCCESS)
     {
       assert (er_errid () != NO_ERROR);
       error = er_errid ();
@@ -4177,7 +4177,7 @@ catcls_update_instance (THREAD_ENTRY * thread_p, OR_VALUE * value_p, OID * oid_p
   int error = NO_ERROR;
 
   if (heap_get_visible_version (thread_p, oid_p, class_oid_p, &old_record, scan_p, COPY, NULL_CHN,
-				HEAP_WITH_OOS_EXPAND) != S_SUCCESS)
+				HEAP_RECDES_CONSUME_RAW_BYTES) != S_SUCCESS)
     {
       assert (er_errid () != NO_ERROR);
       error = er_errid ();
@@ -4501,7 +4501,7 @@ catcls_update_class_stats (THREAD_ENTRY * thread_p, const char *class_name, unsi
   is_scan_inited = true;
 
   if (heap_get_visible_version (thread_p, &oid, catalog_class_oid_p, &record, &scan, COPY, NULL_CHN,
-				HEAP_WITH_OOS_EXPAND) != S_SUCCESS)
+				HEAP_RECDES_CONSUME_RAW_BYTES) != S_SUCCESS)
     {
       ASSERT_ERROR_AND_SET (error);
       goto error;
@@ -5012,7 +5012,8 @@ catcls_get_server_compat_info (THREAD_ENTRY * thread_p, INTL_CODESET * charset_i
     }
   scan_cache_inited = true;
 
-  while (heap_next (thread_p, &hfid, NULL, &inst_oid, &recdes, &scan_cache, PEEK, HEAP_WITHOUT_OOS_EXPAND) == S_SUCCESS)
+  while (heap_next (thread_p, &hfid, NULL, &inst_oid, &recdes, &scan_cache, PEEK, HEAP_RECDES_DONT_CONSUME_RAW_BYTES) ==
+	 S_SUCCESS)
     {
       HEAP_ATTRVALUE *heap_value = NULL;
 
@@ -5464,7 +5465,8 @@ catcls_get_db_collation (THREAD_ENTRY * thread_p, LANG_COLL_COMPAT ** db_collati
     }
 
   *coll_cnt = 0;
-  while (heap_next (thread_p, &hfid, NULL, &inst_oid, &recdes, &scan_cache, PEEK, HEAP_WITHOUT_OOS_EXPAND) == S_SUCCESS)
+  while (heap_next (thread_p, &hfid, NULL, &inst_oid, &recdes, &scan_cache, PEEK, HEAP_RECDES_DONT_CONSUME_RAW_BYTES) ==
+	 S_SUCCESS)
     {
       HEAP_ATTRVALUE *heap_value = NULL;
       LANG_COLL_COMPAT *curr_coll;
@@ -5675,7 +5677,8 @@ catcls_get_apply_info_log_record_time (THREAD_ENTRY * thread_p, time_t * log_rec
     }
   scan_cache_inited = true;
 
-  while (heap_next (thread_p, &hfid, NULL, &inst_oid, &recdes, &scan_cache, PEEK, HEAP_WITHOUT_OOS_EXPAND) == S_SUCCESS)
+  while (heap_next (thread_p, &hfid, NULL, &inst_oid, &recdes, &scan_cache, PEEK, HEAP_RECDES_DONT_CONSUME_RAW_BYTES) ==
+	 S_SUCCESS)
     {
       HEAP_ATTRVALUE *heap_value = NULL;
 

--- a/src/storage/compactdb_sr.c
+++ b/src/storage/compactdb_sr.c
@@ -106,7 +106,8 @@ process_value (THREAD_ENTRY * thread_p, DB_VALUE * value)
 	heap_scancache_quick_start (&scan_cache);
 	scan_cache.mvcc_snapshot = logtb_get_mvcc_snapshot (thread_p);
 	scan_code =
-	  heap_get_visible_version_expand_oos (thread_p, ref_oid, &ref_class_oid, NULL, &scan_cache, PEEK, NULL_CHN);
+	  heap_get_visible_version (thread_p, ref_oid, &ref_class_oid, NULL, &scan_cache, PEEK, NULL_CHN,
+				    HEAP_WITH_OOS_EXPAND);
 	heap_scancache_end (thread_p, &scan_cache);
 
 	if (scan_code == S_ERROR)
@@ -212,7 +213,7 @@ process_object (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * upd_scancache, HEAP_CA
 
   /* get object with X_LOCK */
   scan_code = locator_lock_and_get_object (thread_p, oid, &upd_scancache->node.class_oid, &copy_recdes, upd_scancache,
-					   X_LOCK, COPY, NULL_CHN, LOG_WARNING_IF_DELETED);
+					   X_LOCK, COPY, NULL_CHN, LOG_WARNING_IF_DELETED, HEAP_WITHOUT_OOS_EXPAND);
   if (scan_code != S_SUCCESS)
     {
       if (er_errid () == ER_HEAP_UNKNOWN_OBJECT)

--- a/src/storage/compactdb_sr.c
+++ b/src/storage/compactdb_sr.c
@@ -107,7 +107,7 @@ process_value (THREAD_ENTRY * thread_p, DB_VALUE * value)
 	scan_cache.mvcc_snapshot = logtb_get_mvcc_snapshot (thread_p);
 	scan_code =
 	  heap_get_visible_version (thread_p, ref_oid, &ref_class_oid, NULL, &scan_cache, PEEK, NULL_CHN,
-				    HEAP_WITH_OOS_EXPAND);
+				    HEAP_RECDES_CONSUME_RAW_BYTES);
 	heap_scancache_end (thread_p, &scan_cache);
 
 	if (scan_code == S_ERROR)
@@ -213,7 +213,8 @@ process_object (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * upd_scancache, HEAP_CA
 
   /* get object with X_LOCK */
   scan_code = locator_lock_and_get_object (thread_p, oid, &upd_scancache->node.class_oid, &copy_recdes, upd_scancache,
-					   X_LOCK, COPY, NULL_CHN, LOG_WARNING_IF_DELETED, HEAP_WITHOUT_OOS_EXPAND);
+					   X_LOCK, COPY, NULL_CHN, LOG_WARNING_IF_DELETED,
+					   HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
   if (scan_code != S_SUCCESS)
     {
       if (er_errid () == ER_HEAP_UNKNOWN_OBJECT)

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -813,12 +813,12 @@ static SCAN_CODE heap_get_record_info (THREAD_ENTRY * thread_p, const OID oid, R
 				       DB_VALUE ** record_info);
 static SCAN_CODE heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * next_oid,
 				     RECDES * recdes, HEAP_SCANCACHE * scan_cache, bool ispeeking,
-				     bool expand_oos, bool reversed_direction, DB_VALUE ** cache_recordinfo,
-				     sampling_info * sampling);
+				     HEAP_OOS_EXPAND_POLICY oos_expand_policy, bool reversed_direction,
+				     DB_VALUE ** cache_recordinfo, sampling_info * sampling);
 static SCAN_CODE heap_scan_get_visible_version_impl (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid,
 						     RECDES * recdes, RECDES * peeked_recdes,
 						     HEAP_SCANCACHE * scan_cache, int ispeeking, int old_chn,
-						     bool expand_oos);
+						     HEAP_OOS_EXPAND_POLICY oos_expand_policy);
 
 static SCAN_CODE heap_get_page_info (THREAD_ENTRY * thread_p, const OID * cls_oid, const HFID * hfid, const VPID * vpid,
 				     const PAGE_PTR pgptr, DB_VALUE ** page_info);
@@ -7946,8 +7946,8 @@ heap_get_record_data_when_all_ready (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT *
  */
 static SCAN_CODE
 heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * next_oid, RECDES * recdes,
-		    HEAP_SCANCACHE * scan_cache, bool ispeeking, bool expand_oos, bool reversed_direction,
-		    DB_VALUE ** cache_recordinfo, sampling_info * sampling)
+		    HEAP_SCANCACHE * scan_cache, bool ispeeking, HEAP_OOS_EXPAND_POLICY oos_expand_policy,
+		    bool reversed_direction, DB_VALUE ** cache_recordinfo, sampling_info * sampling)
 {
   VPID vpid;
   VPID *vpidptr_incache;
@@ -8217,7 +8217,7 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
 
 	  scan =
 	    heap_scan_get_visible_version_impl (thread_p, &oid, class_oid, recdes, &forward_recdes, scan_cache,
-						ispeeking, NULL_CHN, expand_oos);
+						ispeeking, NULL_CHN, oos_expand_policy);
 	  scan_cache->cache_last_fix_page = cache_last_fix_page_save;
 	}
 
@@ -8464,7 +8464,7 @@ heap_next_1page (THREAD_ENTRY * thread_p, const HFID * hfid, const VPID * vpid, 
 
 	scan =
 	  heap_scan_get_visible_version (thread_p, &oid, class_oid, recdes, &forward_recdes, scan_cache, ispeeking,
-					 NULL_CHN);
+					 NULL_CHN, HEAP_WITHOUT_OOS_EXPAND);
 	scan_cache->cache_last_fix_page = cache_last_fix_page_save;
       }
 
@@ -8539,7 +8539,8 @@ heap_first (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * o
   OID_SET_NULL (oid);
   oid->volid = hfid->vfid.volid;
 
-  return heap_next (thread_p, hfid, class_oid, oid, recdes, scan_cache, ispeeking);
+  /* hardcoded HEAP_WITHOUT_OOS_EXPAND: pre-policy behavior; see the CBRD-26847 caller audit */
+  return heap_next (thread_p, hfid, class_oid, oid, recdes, scan_cache, ispeeking, HEAP_WITHOUT_OOS_EXPAND);
 }
 
 /*
@@ -8567,7 +8568,8 @@ heap_last (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * oi
   OID_SET_NULL (oid);
   oid->volid = hfid->vfid.volid;
 
-  return heap_prev (thread_p, hfid, class_oid, oid, recdes, scan_cache, ispeeking);
+  /* hardcoded HEAP_WITHOUT_OOS_EXPAND: pre-policy behavior; see the CBRD-26847 caller audit */
+  return heap_prev (thread_p, hfid, class_oid, oid, recdes, scan_cache, ispeeking, HEAP_WITHOUT_OOS_EXPAND);
 }
 
 #if defined (ENABLE_UNUSED_FUNCTION)
@@ -8729,16 +8731,15 @@ heap_scanrange_to_following (THREAD_ENTRY * thread_p, HEAP_SCANRANGE * scan_rang
 	{
 	  /* Scanrange starts with the given object */
 	  scan_range->first_oid = *start_oid;
-	  scan = heap_get_visible_version_expand_oos (thread_p, &scan_range->last_oid,
-						      &scan_range->scan_cache.node.class_oid, &recdes,
-						      &scan_range->scan_cache, PEEK, NULL_CHN);
+	  scan = heap_get_visible_version (thread_p, &scan_range->last_oid, &scan_range->scan_cache.node.class_oid,
+					   &recdes, &scan_range->scan_cache, PEEK, NULL_CHN, HEAP_WITH_OOS_EXPAND);
 	  if (scan != S_SUCCESS)
 	    {
 	      if (scan == S_DOESNT_EXIST || scan == S_SNAPSHOT_NOT_SATISFIED)
 		{
 		  scan =
 		    heap_next (thread_p, &scan_range->scan_cache.node.hfid, &scan_range->scan_cache.node.class_oid,
-			       &scan_range->first_oid, &recdes, &scan_range->scan_cache, PEEK);
+			       &scan_range->first_oid, &recdes, &scan_range->scan_cache, PEEK, HEAP_WITHOUT_OOS_EXPAND);
 		  if (scan != S_SUCCESS)
 		    {
 		      return scan;
@@ -8760,7 +8761,7 @@ heap_scanrange_to_following (THREAD_ENTRY * thread_p, HEAP_SCANRANGE * scan_rang
       scan_range->first_oid = scan_range->last_oid;
       scan =
 	heap_next (thread_p, &scan_range->scan_cache.node.hfid, &scan_range->scan_cache.node.class_oid,
-		   &scan_range->first_oid, &recdes, &scan_range->scan_cache, PEEK);
+		   &scan_range->first_oid, &recdes, &scan_range->scan_cache, PEEK, HEAP_WITHOUT_OOS_EXPAND);
       if (scan != S_SUCCESS)
 	{
 	  return scan;
@@ -8840,16 +8841,15 @@ heap_scanrange_to_prior (THREAD_ENTRY * thread_p, HEAP_SCANRANGE * scan_range, O
 	  /* Scanrange ends with the given object */
 	  scan_range->last_oid = *last_oid;
 	  scan =
-	    heap_get_visible_version_expand_oos (thread_p, &scan_range->last_oid,
-						 &scan_range->scan_cache.node.class_oid, &recdes,
-						 &scan_range->scan_cache, PEEK, NULL_CHN);
+	    heap_get_visible_version (thread_p, &scan_range->last_oid, &scan_range->scan_cache.node.class_oid, &recdes,
+				      &scan_range->scan_cache, PEEK, NULL_CHN, HEAP_WITH_OOS_EXPAND);
 	  if (scan != S_SUCCESS)
 	    {
 	      if (scan == S_DOESNT_EXIST || scan == S_SNAPSHOT_NOT_SATISFIED)
 		{
 		  scan =
 		    heap_prev (thread_p, &scan_range->scan_cache.node.hfid, &scan_range->scan_cache.node.class_oid,
-			       &scan_range->first_oid, &recdes, &scan_range->scan_cache, PEEK);
+			       &scan_range->first_oid, &recdes, &scan_range->scan_cache, PEEK, HEAP_WITHOUT_OOS_EXPAND);
 		  if (scan != S_SUCCESS)
 		    {
 		      return scan;
@@ -8867,7 +8867,7 @@ heap_scanrange_to_prior (THREAD_ENTRY * thread_p, HEAP_SCANRANGE * scan_range, O
       scan_range->last_oid = scan_range->first_oid;
       scan =
 	heap_prev (thread_p, &scan_range->scan_cache.node.hfid, &scan_range->scan_cache.node.class_oid,
-		   &scan_range->last_oid, &recdes, &scan_range->scan_cache, PEEK);
+		   &scan_range->last_oid, &recdes, &scan_range->scan_cache, PEEK, HEAP_WITHOUT_OOS_EXPAND);
       if (scan != S_SUCCESS)
 	{
 	  return scan;
@@ -8938,13 +8938,13 @@ heap_scanrange_next (THREAD_ENTRY * thread_p, OID * next_oid, RECDES * recdes, H
       /* Retrieve the first object in the scanrange */
       *next_oid = scan_range->first_oid;
       scan =
-	heap_get_visible_version_expand_oos (thread_p, next_oid, &scan_range->scan_cache.node.class_oid, recdes,
-					     &scan_range->scan_cache, ispeeking, NULL_CHN);
+	heap_get_visible_version (thread_p, next_oid, &scan_range->scan_cache.node.class_oid, recdes,
+				  &scan_range->scan_cache, ispeeking, NULL_CHN, HEAP_WITH_OOS_EXPAND);
       if (scan == S_DOESNT_EXIST || scan == S_SNAPSHOT_NOT_SATISFIED)
 	{
 	  scan =
-	    heap_next (thread_p, &scan_range->scan_cache.node.hfid, &scan_range->scan_cache.node.class_oid, next_oid,
-		       recdes, &scan_range->scan_cache, ispeeking);
+	    heap_next (thread_p, &scan_range->scan_cache.node.hfid, &scan_range->scan_cache.node.class_oid,
+		       next_oid, recdes, &scan_range->scan_cache, ispeeking, HEAP_WITHOUT_OOS_EXPAND);
 	}
       /* Make sure that we did not go overboard */
       if (scan == S_SUCCESS && OID_GT (next_oid, &scan_range->last_oid))
@@ -8964,8 +8964,8 @@ heap_scanrange_next (THREAD_ENTRY * thread_p, OID * next_oid, RECDES * recdes, H
       else
 	{
 	  scan =
-	    heap_next (thread_p, &scan_range->scan_cache.node.hfid, &scan_range->scan_cache.node.class_oid, next_oid,
-		       recdes, &scan_range->scan_cache, ispeeking);
+	    heap_next (thread_p, &scan_range->scan_cache.node.hfid, &scan_range->scan_cache.node.class_oid,
+		       next_oid, recdes, &scan_range->scan_cache, ispeeking, HEAP_WITHOUT_OOS_EXPAND);
 	  /* Make sure that we did not go overboard */
 	  if (scan == S_SUCCESS && OID_GT (next_oid, &scan_range->last_oid))
 	    {
@@ -9015,7 +9015,7 @@ heap_scanrange_prev (THREAD_ENTRY * thread_p, OID * prev_oid, RECDES * recdes, H
 	{
 	  scan =
 	    heap_prev (thread_p, &scan_range->scan_cache.node.hfid, &scan_range->scan_cache.node.class_oid, prev_oid,
-		       recdes, &scan_range->scan_cache, ispeeking);
+		       recdes, &scan_range->scan_cache, ispeeking, HEAP_WITHOUT_OOS_EXPAND);
 	}
       /* Make sure that we did not go underboard */
       if (scan == S_SUCCESS && OID_LT (prev_oid, &scan_range->last_oid))
@@ -9036,7 +9036,7 @@ heap_scanrange_prev (THREAD_ENTRY * thread_p, OID * prev_oid, RECDES * recdes, H
 	{
 	  scan =
 	    heap_prev (thread_p, &scan_range->scan_cache.node.hfid, &scan_range->scan_cache.node.class_oid, prev_oid,
-		       recdes, &scan_range->scan_cache, ispeeking);
+		       recdes, &scan_range->scan_cache, ispeeking, HEAP_WITHOUT_OOS_EXPAND);
 	  if (scan == S_SUCCESS && OID_LT (prev_oid, &scan_range->last_oid))
 	    {
 	      OID_SET_NULL (prev_oid);
@@ -9081,7 +9081,7 @@ heap_scanrange_first (THREAD_ENTRY * thread_p, OID * first_oid, RECDES * recdes,
     {
       scan =
 	heap_next (thread_p, &scan_range->scan_cache.node.hfid, &scan_range->scan_cache.node.class_oid, first_oid,
-		   recdes, &scan_range->scan_cache, ispeeking);
+		   recdes, &scan_range->scan_cache, ispeeking, HEAP_WITHOUT_OOS_EXPAND);
     }
   /* Make sure that we did not go overboard */
   if (scan == S_SUCCESS && OID_GT (first_oid, &scan_range->last_oid))
@@ -9126,7 +9126,7 @@ heap_scanrange_last (THREAD_ENTRY * thread_p, OID * last_oid, RECDES * recdes, H
     {
       scan =
 	heap_prev (thread_p, &scan_range->scan_cache.node.hfid, &scan_range->scan_cache.node.class_oid, last_oid,
-		   recdes, &scan_range->scan_cache, ispeeking);
+		   recdes, &scan_range->scan_cache, ispeeking, HEAP_WITHOUT_OOS_EXPAND);
     }
   /* Make sure that we did not go underboard */
   if (scan == S_SUCCESS && OID_LT (last_oid, &scan_range->last_oid))
@@ -9335,7 +9335,8 @@ heap_is_object_not_null (THREAD_ENTRY * thread_p, OID * class_oid, const OID * o
   scan_cache.mvcc_snapshot = &copy_mvcc_snapshot;
 
   /* Check only if the last version of the object is not deleted, see mvcc_is_not_deleted_for_snapshot return values */
-  scan = heap_get_visible_version (thread_p, oid, class_oid, NULL, &scan_cache, PEEK, NULL_CHN);
+  scan =
+    heap_get_visible_version (thread_p, oid, class_oid, NULL, &scan_cache, PEEK, NULL_CHN, HEAP_WITHOUT_OOS_EXPAND);
   if (scan != S_SUCCESS)
     {
       goto exit_on_end;
@@ -15778,7 +15779,8 @@ heap_dump (THREAD_ENTRY * thread_p, FILE * fp, HFID * hfid, bool dump_records)
 	  OID_SET_NULL (&oid);
 	  oid.volid = hfid->vfid.volid;
 
-	  while (heap_next (thread_p, hfid, NULL, &oid, &peek_recdes, &scan_cache, PEEK) == S_SUCCESS)
+	  while (heap_next (thread_p, hfid, NULL, &oid, &peek_recdes, &scan_cache, PEEK,
+			    HEAP_WITHOUT_OOS_EXPAND) == S_SUCCESS)
 	    {
 	      fprintf (fp, "Object-OID = %2d|%4d|%2d,\n  Length on disk = %d,\n", oid.volid, oid.pageid, oid.slotid,
 		       peek_recdes.length);
@@ -20289,21 +20291,10 @@ heap_get_record_info (THREAD_ENTRY * thread_p, const OID oid, RECDES * recdes, R
  */
 SCAN_CODE
 heap_next (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * next_oid, RECDES * recdes,
-	   HEAP_SCANCACHE * scan_cache, int ispeeking)
+	   HEAP_SCANCACHE * scan_cache, int ispeeking, HEAP_OOS_EXPAND_POLICY oos_expand_policy)
 {
-  return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking, false, false, NULL,
-			     NULL);
-}
-
-/*
- * heap_next_expand_oos () - Retrieve or peek next object, expanding inline OOS OIDs.
- */
-SCAN_CODE
-heap_next_expand_oos (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * next_oid, RECDES * recdes,
-		      HEAP_SCANCACHE * scan_cache, int ispeeking)
-{
-  return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking, true, false, NULL,
-			     NULL);
+  return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking, oos_expand_policy,
+			     false, NULL, NULL);
 }
 
 /*
@@ -20323,10 +20314,11 @@ heap_next_expand_oos (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oi
  */
 SCAN_CODE
 heap_next_sampling (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * next_oid, RECDES * recdes,
-		    HEAP_SCANCACHE * scan_cache, int ispeeking, sampling_info * sampling)
+		    HEAP_SCANCACHE * scan_cache, int ispeeking, HEAP_OOS_EXPAND_POLICY oos_expand_policy,
+		    sampling_info * sampling)
 {
-  return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking, false, false, NULL,
-			     sampling);
+  return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking, oos_expand_policy,
+			     false, NULL, sampling);
 }
 
 /*
@@ -20352,8 +20344,8 @@ SCAN_CODE
 heap_next_record_info (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * next_oid, RECDES * recdes,
 		       HEAP_SCANCACHE * scan_cache, int ispeeking, DB_VALUE ** cache_recordinfo)
 {
-  return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking, false, false,
-			     cache_recordinfo, NULL);
+  return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking,
+			     HEAP_WITHOUT_OOS_EXPAND, false, cache_recordinfo, NULL);
 }
 
 /*
@@ -20373,10 +20365,10 @@ heap_next_record_info (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_o
  */
 SCAN_CODE
 heap_prev (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * next_oid, RECDES * recdes,
-	   HEAP_SCANCACHE * scan_cache, int ispeeking)
+	   HEAP_SCANCACHE * scan_cache, int ispeeking, HEAP_OOS_EXPAND_POLICY oos_expand_policy)
 {
-  return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking, false, true, NULL,
-			     NULL);
+  return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking, oos_expand_policy,
+			     true, NULL, NULL);
 }
 
 /*
@@ -20402,8 +20394,8 @@ SCAN_CODE
 heap_prev_record_info (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * next_oid, RECDES * recdes,
 		       HEAP_SCANCACHE * scan_cache, int ispeeking, DB_VALUE ** cache_recordinfo)
 {
-  return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking, false, true,
-			     cache_recordinfo, NULL);
+  return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking,
+			     HEAP_WITHOUT_OOS_EXPAND, true, cache_recordinfo, NULL);
 }
 
 /*
@@ -26491,32 +26483,13 @@ heap_get_visible_version_from_log (THREAD_ENTRY * thread_p, RECDES * recdes, LOG
  */
 SCAN_CODE
 heap_get_visible_version (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid, RECDES * recdes,
-			  HEAP_SCANCACHE * scan_cache, int ispeeking, int old_chn)
+			  HEAP_SCANCACHE * scan_cache, int ispeeking, int old_chn,
+			  HEAP_OOS_EXPAND_POLICY oos_expand_policy)
 {
   SCAN_CODE scan = S_SUCCESS;
   HEAP_GET_CONTEXT context;
 
-  heap_init_get_context (thread_p, &context, oid, class_oid, recdes, scan_cache, ispeeking, old_chn);
-
-  scan = heap_get_visible_version_internal (thread_p, &context, false);
-
-  heap_clean_get_context (thread_p, &context);
-
-  return scan;
-}
-
-/* TODO (CBRD-26847): Audit all callers of heap_get_visible_version_expand_oos to determine whether each actually
- * needs OOS expansion.  Many call sites may have been migrated mechanically from heap_get_visible_version and could
- * safely switch back, reducing unnecessary OOS blob reads. */
-SCAN_CODE
-heap_get_visible_version_expand_oos (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid, RECDES * recdes,
-				     HEAP_SCANCACHE * scan_cache, int ispeeking, int old_chn)
-{
-  SCAN_CODE scan = S_SUCCESS;
-  HEAP_GET_CONTEXT context;
-
-  heap_init_get_context (thread_p, &context, oid, class_oid, recdes, scan_cache, ispeeking, old_chn);
-  context.expand_oos = true;
+  heap_init_get_context (thread_p, &context, oid, class_oid, recdes, scan_cache, ispeeking, old_chn, oos_expand_policy);
 
   scan = heap_get_visible_version_internal (thread_p, &context, false);
 
@@ -26550,10 +26523,12 @@ heap_get_visible_version_expand_oos (THREAD_ENTRY * thread_p, const OID * oid, O
 static SCAN_CODE
 heap_scan_get_visible_version_impl (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid, RECDES * recdes,
 				    RECDES * peeked_recdes, HEAP_SCANCACHE * scan_cache, int ispeeking, int old_chn,
-				    bool expand_oos)
+				    HEAP_OOS_EXPAND_POLICY oos_expand_policy)
 {
   SCAN_CODE scan = S_SUCCESS;
   HEAP_GET_CONTEXT context;
+
+  const bool expand_oos = oos_expand_policy == HEAP_WITH_OOS_EXPAND;
 
   /*
    * The process below should be within heap_get_visible_version_internal(),
@@ -26648,8 +26623,7 @@ heap_scan_get_visible_version_impl (THREAD_ENTRY * thread_p, const OID * oid, OI
       /* fall through.. */
     }
 
-  heap_init_get_context (thread_p, &context, oid, class_oid, recdes, scan_cache, ispeeking, old_chn);
-  context.expand_oos = expand_oos;
+  heap_init_get_context (thread_p, &context, oid, class_oid, recdes, scan_cache, ispeeking, old_chn, oos_expand_policy);
 
   scan = heap_get_visible_version_internal (thread_p, &context, true);
 
@@ -26660,10 +26634,11 @@ heap_scan_get_visible_version_impl (THREAD_ENTRY * thread_p, const OID * oid, OI
 
 SCAN_CODE
 heap_scan_get_visible_version (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid, RECDES * recdes,
-			       RECDES * peeked_recdes, HEAP_SCANCACHE * scan_cache, int ispeeking, int old_chn)
+			       RECDES * peeked_recdes, HEAP_SCANCACHE * scan_cache, int ispeeking, int old_chn,
+			       HEAP_OOS_EXPAND_POLICY oos_expand_policy)
 {
   return heap_scan_get_visible_version_impl (thread_p, oid, class_oid, recdes, peeked_recdes, scan_cache, ispeeking,
-					     old_chn, false);
+					     old_chn, oos_expand_policy);
 }
 
 /*
@@ -27073,8 +27048,11 @@ heap_clean_get_context (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context)
 */
 void
 heap_init_get_context (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context, const OID * oid, OID * class_oid,
-		       RECDES * recdes, HEAP_SCANCACHE * scan_cache, int ispeeking, int old_chn)
+		       RECDES * recdes, HEAP_SCANCACHE * scan_cache, int ispeeking, int old_chn,
+		       HEAP_OOS_EXPAND_POLICY oos_expand_policy)
 {
+  assert (HEAP_IS_VALID_OOS_EXPAND_POLICY (oos_expand_policy));
+
   context->oid_p = oid;
   OID_SET_NULL (&context->forward_oid);
   context->class_oid_p = class_oid;
@@ -27100,7 +27078,7 @@ heap_init_get_context (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context, cons
   context->scan_cache = scan_cache;
   context->ispeeking = ispeeking;
   context->old_chn = old_chn;
-  context->expand_oos = false;
+  context->oos_expand_policy = oos_expand_policy;
   const bool data_is_scan_cache_area =
     scan_cache != NULL && recdes != NULL && scan_cache->is_recdes_assigned_to_area (*recdes);
   /* Caller-positioned buffers remain owned by the caller even after their writable area is exhausted. */
@@ -27171,7 +27149,8 @@ heap_get_class_record (THREAD_ENTRY * thread_p, const OID * class_oid, RECDES * 
   /* for debugging set root_oid NULL and check afterwards if it really is root oid */
   OID_SET_NULL (&root_oid);
 #endif /* !NDEBUG */
-  heap_init_get_context (thread_p, &context, class_oid, &root_oid, recdes_p, scan_cache, ispeeking, NULL_CHN);
+  heap_init_get_context (thread_p, &context, class_oid, &root_oid, recdes_p, scan_cache, ispeeking, NULL_CHN,
+			 HEAP_WITHOUT_OOS_EXPAND);
 
   scan = heap_get_last_version (thread_p, &context);
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -813,12 +813,12 @@ static SCAN_CODE heap_get_record_info (THREAD_ENTRY * thread_p, const OID oid, R
 				       DB_VALUE ** record_info);
 static SCAN_CODE heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * next_oid,
 				     RECDES * recdes, HEAP_SCANCACHE * scan_cache, bool ispeeking,
-				     HEAP_OOS_EXPAND_POLICY oos_expand_policy, bool reversed_direction,
+				     HEAP_RECDES_CONSUMPTION_POLICY recdes_consumption_policy, bool reversed_direction,
 				     DB_VALUE ** cache_recordinfo, sampling_info * sampling);
 static SCAN_CODE heap_scan_get_visible_version_impl (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid,
 						     RECDES * recdes, RECDES * peeked_recdes,
 						     HEAP_SCANCACHE * scan_cache, int ispeeking, int old_chn,
-						     HEAP_OOS_EXPAND_POLICY oos_expand_policy);
+						     HEAP_RECDES_CONSUMPTION_POLICY recdes_consumption_policy);
 
 static SCAN_CODE heap_get_page_info (THREAD_ENTRY * thread_p, const OID * cls_oid, const HFID * hfid, const VPID * vpid,
 				     const PAGE_PTR pgptr, DB_VALUE ** page_info);
@@ -7946,8 +7946,9 @@ heap_get_record_data_when_all_ready (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT *
  */
 static SCAN_CODE
 heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * next_oid, RECDES * recdes,
-		    HEAP_SCANCACHE * scan_cache, bool ispeeking, HEAP_OOS_EXPAND_POLICY oos_expand_policy,
-		    bool reversed_direction, DB_VALUE ** cache_recordinfo, sampling_info * sampling)
+		    HEAP_SCANCACHE * scan_cache, bool ispeeking,
+		    HEAP_RECDES_CONSUMPTION_POLICY recdes_consumption_policy, bool reversed_direction,
+		    DB_VALUE ** cache_recordinfo, sampling_info * sampling)
 {
   VPID vpid;
   VPID *vpidptr_incache;
@@ -8217,7 +8218,7 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
 
 	  scan =
 	    heap_scan_get_visible_version_impl (thread_p, &oid, class_oid, recdes, &forward_recdes, scan_cache,
-						ispeeking, NULL_CHN, oos_expand_policy);
+						ispeeking, NULL_CHN, recdes_consumption_policy);
 	  scan_cache->cache_last_fix_page = cache_last_fix_page_save;
 	}
 
@@ -8464,7 +8465,7 @@ heap_next_1page (THREAD_ENTRY * thread_p, const HFID * hfid, const VPID * vpid, 
 
 	scan =
 	  heap_scan_get_visible_version (thread_p, &oid, class_oid, recdes, &forward_recdes, scan_cache, ispeeking,
-					 NULL_CHN, HEAP_WITHOUT_OOS_EXPAND);
+					 NULL_CHN, HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
 	scan_cache->cache_last_fix_page = cache_last_fix_page_save;
       }
 
@@ -8539,8 +8540,8 @@ heap_first (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * o
   OID_SET_NULL (oid);
   oid->volid = hfid->vfid.volid;
 
-  /* hardcoded HEAP_WITHOUT_OOS_EXPAND: pre-policy behavior; see the CBRD-26847 caller audit */
-  return heap_next (thread_p, hfid, class_oid, oid, recdes, scan_cache, ispeeking, HEAP_WITHOUT_OOS_EXPAND);
+  /* hardcoded HEAP_RECDES_DONT_CONSUME_RAW_BYTES: pre-policy behavior; see the CBRD-26847 caller audit */
+  return heap_next (thread_p, hfid, class_oid, oid, recdes, scan_cache, ispeeking, HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
 }
 
 /*
@@ -8568,8 +8569,8 @@ heap_last (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * oi
   OID_SET_NULL (oid);
   oid->volid = hfid->vfid.volid;
 
-  /* hardcoded HEAP_WITHOUT_OOS_EXPAND: pre-policy behavior; see the CBRD-26847 caller audit */
-  return heap_prev (thread_p, hfid, class_oid, oid, recdes, scan_cache, ispeeking, HEAP_WITHOUT_OOS_EXPAND);
+  /* hardcoded HEAP_RECDES_DONT_CONSUME_RAW_BYTES: pre-policy behavior; see the CBRD-26847 caller audit */
+  return heap_prev (thread_p, hfid, class_oid, oid, recdes, scan_cache, ispeeking, HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
 }
 
 #if defined (ENABLE_UNUSED_FUNCTION)
@@ -8732,14 +8733,16 @@ heap_scanrange_to_following (THREAD_ENTRY * thread_p, HEAP_SCANRANGE * scan_rang
 	  /* Scanrange starts with the given object */
 	  scan_range->first_oid = *start_oid;
 	  scan = heap_get_visible_version (thread_p, &scan_range->last_oid, &scan_range->scan_cache.node.class_oid,
-					   &recdes, &scan_range->scan_cache, PEEK, NULL_CHN, HEAP_WITH_OOS_EXPAND);
+					   &recdes, &scan_range->scan_cache, PEEK, NULL_CHN,
+					   HEAP_RECDES_CONSUME_RAW_BYTES);
 	  if (scan != S_SUCCESS)
 	    {
 	      if (scan == S_DOESNT_EXIST || scan == S_SNAPSHOT_NOT_SATISFIED)
 		{
 		  scan =
 		    heap_next (thread_p, &scan_range->scan_cache.node.hfid, &scan_range->scan_cache.node.class_oid,
-			       &scan_range->first_oid, &recdes, &scan_range->scan_cache, PEEK, HEAP_WITHOUT_OOS_EXPAND);
+			       &scan_range->first_oid, &recdes, &scan_range->scan_cache, PEEK,
+			       HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
 		  if (scan != S_SUCCESS)
 		    {
 		      return scan;
@@ -8761,7 +8764,7 @@ heap_scanrange_to_following (THREAD_ENTRY * thread_p, HEAP_SCANRANGE * scan_rang
       scan_range->first_oid = scan_range->last_oid;
       scan =
 	heap_next (thread_p, &scan_range->scan_cache.node.hfid, &scan_range->scan_cache.node.class_oid,
-		   &scan_range->first_oid, &recdes, &scan_range->scan_cache, PEEK, HEAP_WITHOUT_OOS_EXPAND);
+		   &scan_range->first_oid, &recdes, &scan_range->scan_cache, PEEK, HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
       if (scan != S_SUCCESS)
 	{
 	  return scan;
@@ -8842,14 +8845,15 @@ heap_scanrange_to_prior (THREAD_ENTRY * thread_p, HEAP_SCANRANGE * scan_range, O
 	  scan_range->last_oid = *last_oid;
 	  scan =
 	    heap_get_visible_version (thread_p, &scan_range->last_oid, &scan_range->scan_cache.node.class_oid, &recdes,
-				      &scan_range->scan_cache, PEEK, NULL_CHN, HEAP_WITH_OOS_EXPAND);
+				      &scan_range->scan_cache, PEEK, NULL_CHN, HEAP_RECDES_CONSUME_RAW_BYTES);
 	  if (scan != S_SUCCESS)
 	    {
 	      if (scan == S_DOESNT_EXIST || scan == S_SNAPSHOT_NOT_SATISFIED)
 		{
 		  scan =
 		    heap_prev (thread_p, &scan_range->scan_cache.node.hfid, &scan_range->scan_cache.node.class_oid,
-			       &scan_range->first_oid, &recdes, &scan_range->scan_cache, PEEK, HEAP_WITHOUT_OOS_EXPAND);
+			       &scan_range->first_oid, &recdes, &scan_range->scan_cache, PEEK,
+			       HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
 		  if (scan != S_SUCCESS)
 		    {
 		      return scan;
@@ -8867,7 +8871,7 @@ heap_scanrange_to_prior (THREAD_ENTRY * thread_p, HEAP_SCANRANGE * scan_range, O
       scan_range->last_oid = scan_range->first_oid;
       scan =
 	heap_prev (thread_p, &scan_range->scan_cache.node.hfid, &scan_range->scan_cache.node.class_oid,
-		   &scan_range->last_oid, &recdes, &scan_range->scan_cache, PEEK, HEAP_WITHOUT_OOS_EXPAND);
+		   &scan_range->last_oid, &recdes, &scan_range->scan_cache, PEEK, HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
       if (scan != S_SUCCESS)
 	{
 	  return scan;
@@ -8939,12 +8943,12 @@ heap_scanrange_next (THREAD_ENTRY * thread_p, OID * next_oid, RECDES * recdes, H
       *next_oid = scan_range->first_oid;
       scan =
 	heap_get_visible_version (thread_p, next_oid, &scan_range->scan_cache.node.class_oid, recdes,
-				  &scan_range->scan_cache, ispeeking, NULL_CHN, HEAP_WITH_OOS_EXPAND);
+				  &scan_range->scan_cache, ispeeking, NULL_CHN, HEAP_RECDES_CONSUME_RAW_BYTES);
       if (scan == S_DOESNT_EXIST || scan == S_SNAPSHOT_NOT_SATISFIED)
 	{
 	  scan =
 	    heap_next (thread_p, &scan_range->scan_cache.node.hfid, &scan_range->scan_cache.node.class_oid,
-		       next_oid, recdes, &scan_range->scan_cache, ispeeking, HEAP_WITHOUT_OOS_EXPAND);
+		       next_oid, recdes, &scan_range->scan_cache, ispeeking, HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
 	}
       /* Make sure that we did not go overboard */
       if (scan == S_SUCCESS && OID_GT (next_oid, &scan_range->last_oid))
@@ -8965,7 +8969,7 @@ heap_scanrange_next (THREAD_ENTRY * thread_p, OID * next_oid, RECDES * recdes, H
 	{
 	  scan =
 	    heap_next (thread_p, &scan_range->scan_cache.node.hfid, &scan_range->scan_cache.node.class_oid,
-		       next_oid, recdes, &scan_range->scan_cache, ispeeking, HEAP_WITHOUT_OOS_EXPAND);
+		       next_oid, recdes, &scan_range->scan_cache, ispeeking, HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
 	  /* Make sure that we did not go overboard */
 	  if (scan == S_SUCCESS && OID_GT (next_oid, &scan_range->last_oid))
 	    {
@@ -9015,7 +9019,7 @@ heap_scanrange_prev (THREAD_ENTRY * thread_p, OID * prev_oid, RECDES * recdes, H
 	{
 	  scan =
 	    heap_prev (thread_p, &scan_range->scan_cache.node.hfid, &scan_range->scan_cache.node.class_oid, prev_oid,
-		       recdes, &scan_range->scan_cache, ispeeking, HEAP_WITHOUT_OOS_EXPAND);
+		       recdes, &scan_range->scan_cache, ispeeking, HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
 	}
       /* Make sure that we did not go underboard */
       if (scan == S_SUCCESS && OID_LT (prev_oid, &scan_range->last_oid))
@@ -9036,7 +9040,7 @@ heap_scanrange_prev (THREAD_ENTRY * thread_p, OID * prev_oid, RECDES * recdes, H
 	{
 	  scan =
 	    heap_prev (thread_p, &scan_range->scan_cache.node.hfid, &scan_range->scan_cache.node.class_oid, prev_oid,
-		       recdes, &scan_range->scan_cache, ispeeking, HEAP_WITHOUT_OOS_EXPAND);
+		       recdes, &scan_range->scan_cache, ispeeking, HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
 	  if (scan == S_SUCCESS && OID_LT (prev_oid, &scan_range->last_oid))
 	    {
 	      OID_SET_NULL (prev_oid);
@@ -9081,7 +9085,7 @@ heap_scanrange_first (THREAD_ENTRY * thread_p, OID * first_oid, RECDES * recdes,
     {
       scan =
 	heap_next (thread_p, &scan_range->scan_cache.node.hfid, &scan_range->scan_cache.node.class_oid, first_oid,
-		   recdes, &scan_range->scan_cache, ispeeking, HEAP_WITHOUT_OOS_EXPAND);
+		   recdes, &scan_range->scan_cache, ispeeking, HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
     }
   /* Make sure that we did not go overboard */
   if (scan == S_SUCCESS && OID_GT (first_oid, &scan_range->last_oid))
@@ -9126,7 +9130,7 @@ heap_scanrange_last (THREAD_ENTRY * thread_p, OID * last_oid, RECDES * recdes, H
     {
       scan =
 	heap_prev (thread_p, &scan_range->scan_cache.node.hfid, &scan_range->scan_cache.node.class_oid, last_oid,
-		   recdes, &scan_range->scan_cache, ispeeking, HEAP_WITHOUT_OOS_EXPAND);
+		   recdes, &scan_range->scan_cache, ispeeking, HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
     }
   /* Make sure that we did not go underboard */
   if (scan == S_SUCCESS && OID_LT (last_oid, &scan_range->last_oid))
@@ -9336,7 +9340,8 @@ heap_is_object_not_null (THREAD_ENTRY * thread_p, OID * class_oid, const OID * o
 
   /* Check only if the last version of the object is not deleted, see mvcc_is_not_deleted_for_snapshot return values */
   scan =
-    heap_get_visible_version (thread_p, oid, class_oid, NULL, &scan_cache, PEEK, NULL_CHN, HEAP_WITHOUT_OOS_EXPAND);
+    heap_get_visible_version (thread_p, oid, class_oid, NULL, &scan_cache, PEEK, NULL_CHN,
+			      HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
   if (scan != S_SUCCESS)
     {
       goto exit_on_end;
@@ -15780,7 +15785,7 @@ heap_dump (THREAD_ENTRY * thread_p, FILE * fp, HFID * hfid, bool dump_records)
 	  oid.volid = hfid->vfid.volid;
 
 	  while (heap_next (thread_p, hfid, NULL, &oid, &peek_recdes, &scan_cache, PEEK,
-			    HEAP_WITHOUT_OOS_EXPAND) == S_SUCCESS)
+			    HEAP_RECDES_DONT_CONSUME_RAW_BYTES) == S_SUCCESS)
 	    {
 	      fprintf (fp, "Object-OID = %2d|%4d|%2d,\n  Length on disk = %d,\n", oid.volid, oid.pageid, oid.slotid,
 		       peek_recdes.length);
@@ -20291,10 +20296,10 @@ heap_get_record_info (THREAD_ENTRY * thread_p, const OID oid, RECDES * recdes, R
  */
 SCAN_CODE
 heap_next (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * next_oid, RECDES * recdes,
-	   HEAP_SCANCACHE * scan_cache, int ispeeking, HEAP_OOS_EXPAND_POLICY oos_expand_policy)
+	   HEAP_SCANCACHE * scan_cache, int ispeeking, HEAP_RECDES_CONSUMPTION_POLICY recdes_consumption_policy)
 {
-  return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking, oos_expand_policy,
-			     false, NULL, NULL);
+  return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking,
+			     recdes_consumption_policy, false, NULL, NULL);
 }
 
 /*
@@ -20314,11 +20319,11 @@ heap_next (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * ne
  */
 SCAN_CODE
 heap_next_sampling (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * next_oid, RECDES * recdes,
-		    HEAP_SCANCACHE * scan_cache, int ispeeking, HEAP_OOS_EXPAND_POLICY oos_expand_policy,
-		    sampling_info * sampling)
+		    HEAP_SCANCACHE * scan_cache, int ispeeking,
+		    HEAP_RECDES_CONSUMPTION_POLICY recdes_consumption_policy, sampling_info * sampling)
 {
-  return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking, oos_expand_policy,
-			     false, NULL, sampling);
+  return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking,
+			     recdes_consumption_policy, false, NULL, sampling);
 }
 
 /*
@@ -20345,7 +20350,7 @@ heap_next_record_info (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_o
 		       HEAP_SCANCACHE * scan_cache, int ispeeking, DB_VALUE ** cache_recordinfo)
 {
   return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking,
-			     HEAP_WITHOUT_OOS_EXPAND, false, cache_recordinfo, NULL);
+			     HEAP_RECDES_DONT_CONSUME_RAW_BYTES, false, cache_recordinfo, NULL);
 }
 
 /*
@@ -20365,10 +20370,10 @@ heap_next_record_info (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_o
  */
 SCAN_CODE
 heap_prev (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * next_oid, RECDES * recdes,
-	   HEAP_SCANCACHE * scan_cache, int ispeeking, HEAP_OOS_EXPAND_POLICY oos_expand_policy)
+	   HEAP_SCANCACHE * scan_cache, int ispeeking, HEAP_RECDES_CONSUMPTION_POLICY recdes_consumption_policy)
 {
-  return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking, oos_expand_policy,
-			     true, NULL, NULL);
+  return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking,
+			     recdes_consumption_policy, true, NULL, NULL);
 }
 
 /*
@@ -20395,7 +20400,7 @@ heap_prev_record_info (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_o
 		       HEAP_SCANCACHE * scan_cache, int ispeeking, DB_VALUE ** cache_recordinfo)
 {
   return heap_next_internal (thread_p, hfid, class_oid, next_oid, recdes, scan_cache, ispeeking,
-			     HEAP_WITHOUT_OOS_EXPAND, true, cache_recordinfo, NULL);
+			     HEAP_RECDES_DONT_CONSUME_RAW_BYTES, true, cache_recordinfo, NULL);
 }
 
 /*
@@ -26484,12 +26489,13 @@ heap_get_visible_version_from_log (THREAD_ENTRY * thread_p, RECDES * recdes, LOG
 SCAN_CODE
 heap_get_visible_version (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid, RECDES * recdes,
 			  HEAP_SCANCACHE * scan_cache, int ispeeking, int old_chn,
-			  HEAP_OOS_EXPAND_POLICY oos_expand_policy)
+			  HEAP_RECDES_CONSUMPTION_POLICY recdes_consumption_policy)
 {
   SCAN_CODE scan = S_SUCCESS;
   HEAP_GET_CONTEXT context;
 
-  heap_init_get_context (thread_p, &context, oid, class_oid, recdes, scan_cache, ispeeking, old_chn, oos_expand_policy);
+  heap_init_get_context (thread_p, &context, oid, class_oid, recdes, scan_cache, ispeeking, old_chn,
+			 recdes_consumption_policy);
 
   scan = heap_get_visible_version_internal (thread_p, &context, false);
 
@@ -26523,12 +26529,12 @@ heap_get_visible_version (THREAD_ENTRY * thread_p, const OID * oid, OID * class_
 static SCAN_CODE
 heap_scan_get_visible_version_impl (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid, RECDES * recdes,
 				    RECDES * peeked_recdes, HEAP_SCANCACHE * scan_cache, int ispeeking, int old_chn,
-				    HEAP_OOS_EXPAND_POLICY oos_expand_policy)
+				    HEAP_RECDES_CONSUMPTION_POLICY recdes_consumption_policy)
 {
   SCAN_CODE scan = S_SUCCESS;
   HEAP_GET_CONTEXT context;
 
-  const bool expand_oos = oos_expand_policy == HEAP_WITH_OOS_EXPAND;
+  const bool expand_oos = recdes_consumption_policy == HEAP_RECDES_CONSUME_RAW_BYTES;
 
   /*
    * The process below should be within heap_get_visible_version_internal(),
@@ -26623,7 +26629,8 @@ heap_scan_get_visible_version_impl (THREAD_ENTRY * thread_p, const OID * oid, OI
       /* fall through.. */
     }
 
-  heap_init_get_context (thread_p, &context, oid, class_oid, recdes, scan_cache, ispeeking, old_chn, oos_expand_policy);
+  heap_init_get_context (thread_p, &context, oid, class_oid, recdes, scan_cache, ispeeking, old_chn,
+			 recdes_consumption_policy);
 
   scan = heap_get_visible_version_internal (thread_p, &context, true);
 
@@ -26635,10 +26642,10 @@ heap_scan_get_visible_version_impl (THREAD_ENTRY * thread_p, const OID * oid, OI
 SCAN_CODE
 heap_scan_get_visible_version (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid, RECDES * recdes,
 			       RECDES * peeked_recdes, HEAP_SCANCACHE * scan_cache, int ispeeking, int old_chn,
-			       HEAP_OOS_EXPAND_POLICY oos_expand_policy)
+			       HEAP_RECDES_CONSUMPTION_POLICY recdes_consumption_policy)
 {
   return heap_scan_get_visible_version_impl (thread_p, oid, class_oid, recdes, peeked_recdes, scan_cache, ispeeking,
-					     old_chn, oos_expand_policy);
+					     old_chn, recdes_consumption_policy);
 }
 
 /*
@@ -27049,9 +27056,9 @@ heap_clean_get_context (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context)
 void
 heap_init_get_context (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context, const OID * oid, OID * class_oid,
 		       RECDES * recdes, HEAP_SCANCACHE * scan_cache, int ispeeking, int old_chn,
-		       HEAP_OOS_EXPAND_POLICY oos_expand_policy)
+		       HEAP_RECDES_CONSUMPTION_POLICY recdes_consumption_policy)
 {
-  assert (HEAP_IS_VALID_OOS_EXPAND_POLICY (oos_expand_policy));
+  assert (HEAP_IS_VALID_RECDES_CONSUMPTION_POLICY (recdes_consumption_policy));
 
   context->oid_p = oid;
   OID_SET_NULL (&context->forward_oid);
@@ -27078,7 +27085,7 @@ heap_init_get_context (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context, cons
   context->scan_cache = scan_cache;
   context->ispeeking = ispeeking;
   context->old_chn = old_chn;
-  context->oos_expand_policy = oos_expand_policy;
+  context->recdes_consumption_policy = recdes_consumption_policy;
   const bool data_is_scan_cache_area =
     scan_cache != NULL && recdes != NULL && scan_cache->is_recdes_assigned_to_area (*recdes);
   /* Caller-positioned buffers remain owned by the caller even after their writable area is exhausted. */
@@ -27150,7 +27157,7 @@ heap_get_class_record (THREAD_ENTRY * thread_p, const OID * class_oid, RECDES * 
   OID_SET_NULL (&root_oid);
 #endif /* !NDEBUG */
   heap_init_get_context (thread_p, &context, class_oid, &root_oid, recdes_p, scan_cache, ispeeking, NULL_CHN,
-			 HEAP_WITHOUT_OOS_EXPAND);
+			 HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
 
   scan = heap_get_last_version (thread_p, &context);
 

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -358,16 +358,16 @@ typedef enum
   HEAP_PAGE_VACUUM_UNKNOWN	/* Heap page requires an unknown number of vacuum actions. */
 } HEAP_PAGE_VACUUM_STATUS;
 
-/* TODO (CBRD-26847): audit HEAP_WITH_OOS_EXPAND sites - several are conservative; see the census. */
+/* TODO (CBRD-26847): audit HEAP_RECDES_CONSUME_RAW_BYTES sites - several are conservative; see the census. */
 typedef enum
 {
-  HEAP_OOS_EXPAND_POLICY_INVALID = 0,
-  HEAP_WITH_OOS_EXPAND,		/* replace inline OOS OID slots with actual values */
-  HEAP_WITHOUT_OOS_EXPAND	/* leave inline OOS OID slots for attr-level resolve */
-} HEAP_OOS_EXPAND_POLICY;
+  HEAP_RECDES_CONSUMPTION_POLICY_INVALID = 0,
+  HEAP_RECDES_CONSUME_RAW_BYTES,	/* materialize OOS values before the caller consumes raw RECDES bytes */
+  HEAP_RECDES_DONT_CONSUME_RAW_BYTES	/* preserve stored RECDES; resolve values through the attr layer */
+} HEAP_RECDES_CONSUMPTION_POLICY;
 
-#define HEAP_IS_VALID_OOS_EXPAND_POLICY(policy) \
-  ((policy) == HEAP_WITH_OOS_EXPAND || (policy) == HEAP_WITHOUT_OOS_EXPAND)
+#define HEAP_IS_VALID_RECDES_CONSUMPTION_POLICY(policy) \
+  ((policy) == HEAP_RECDES_CONSUME_RAW_BYTES || (policy) == HEAP_RECDES_DONT_CONSUME_RAW_BYTES)
 
 typedef struct heap_get_context HEAP_GET_CONTEXT;
 struct heap_get_context
@@ -392,7 +392,7 @@ struct heap_get_context
   PGBUF_LATCH_MODE latch_mode;	/* normally, we need READ latch for get_context, but some operations
 				 * (like serial increment) require WRITE mode */
 
-  HEAP_OOS_EXPAND_POLICY oos_expand_policy;
+  HEAP_RECDES_CONSUMPTION_POLICY recdes_consumption_policy;
   bool keep_recdes_buffer;	/* true if caller-positioned recdes_p->data must not be rebound to scan cache */
 };
 
@@ -440,16 +440,17 @@ extern void heap_scancache_end_modify (THREAD_ENTRY * thread_p, HEAP_SCANCACHE *
 extern SCAN_CODE heap_get_class_oid (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid);
 extern SCAN_CODE heap_next (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * next_oid,
 			    RECDES * recdes, HEAP_SCANCACHE * scan_cache, int ispeeking,
-			    HEAP_OOS_EXPAND_POLICY oos_expand_policy);
+			    HEAP_RECDES_CONSUMPTION_POLICY recdes_consumption_policy);
 extern SCAN_CODE heap_next_sampling (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * next_oid,
 				     RECDES * recdes, HEAP_SCANCACHE * scan_cache, int ispeeking,
-				     HEAP_OOS_EXPAND_POLICY oos_expand_policy, sampling_info * sampling);
+				     HEAP_RECDES_CONSUMPTION_POLICY recdes_consumption_policy,
+				     sampling_info * sampling);
 extern SCAN_CODE heap_next_record_info (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * next_oid,
 					RECDES * recdes, HEAP_SCANCACHE * scan_cache, int ispeeking,
 					DB_VALUE ** cache_recordinfo);
 extern SCAN_CODE heap_prev (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * prev_oid,
 			    RECDES * recdes, HEAP_SCANCACHE * scan_cache, int ispeeking,
-			    HEAP_OOS_EXPAND_POLICY oos_expand_policy);
+			    HEAP_RECDES_CONSUMPTION_POLICY recdes_consumption_policy);
 extern SCAN_CODE heap_page_next_fix_old (THREAD_ENTRY * thread_p, HFID * hfid, VPID * curr_vpid,
 					 HEAP_SCANCACHE * scan_cache);
 extern SCAN_CODE heap_next_1page (THREAD_ENTRY * thread_p, const HFID * hfid, const VPID * vpid, OID * class_oid,
@@ -705,15 +706,16 @@ extern int heap_rv_mvcc_redo_redistribute (THREAD_ENTRY * thread_p, LOG_RCV * rc
 extern int heap_vacuum_all_objects (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * upd_scancache, MVCCID threshold_mvccid);
 extern SCAN_CODE heap_get_visible_version (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid, RECDES * recdes,
 					   HEAP_SCANCACHE * scan_cache, int ispeeking, int old_chn,
-					   HEAP_OOS_EXPAND_POLICY oos_expand_policy);
+					   HEAP_RECDES_CONSUMPTION_POLICY recdes_consumption_policy);
 extern SCAN_CODE heap_scan_get_visible_version (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid,
 						RECDES * recdes, RECDES * forward_recdes, HEAP_SCANCACHE * scan_cache,
-						int ispeeking, int old_chn, HEAP_OOS_EXPAND_POLICY oos_expand_policy);
+						int ispeeking, int old_chn,
+						HEAP_RECDES_CONSUMPTION_POLICY recdes_consumption_policy);
 extern SCAN_CODE heap_get_last_version (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context);
 extern void heap_clean_get_context (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context);
 extern void heap_init_get_context (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context, const OID * oid,
 				   OID * class_oid, RECDES * recdes, HEAP_SCANCACHE * scan_cache, int ispeeking,
-				   int old_chn, HEAP_OOS_EXPAND_POLICY oos_expand_policy);
+				   int old_chn, HEAP_RECDES_CONSUMPTION_POLICY recdes_consumption_policy);
 extern int heap_prepare_object_page (THREAD_ENTRY * thread_p, const OID * oid, PGBUF_WATCHER * page_watcher_p,
 				     PGBUF_LATCH_MODE latch_mode);
 extern SCAN_CODE heap_prepare_get_context (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context, bool is_heap_scan,

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -358,6 +358,17 @@ typedef enum
   HEAP_PAGE_VACUUM_UNKNOWN	/* Heap page requires an unknown number of vacuum actions. */
 } HEAP_PAGE_VACUUM_STATUS;
 
+/* TODO (CBRD-26847): audit HEAP_WITH_OOS_EXPAND sites - several are conservative; see the census. */
+typedef enum
+{
+  HEAP_OOS_EXPAND_POLICY_INVALID = 0,
+  HEAP_WITH_OOS_EXPAND,		/* replace inline OOS OID slots with actual values */
+  HEAP_WITHOUT_OOS_EXPAND	/* leave inline OOS OID slots for attr-level resolve */
+} HEAP_OOS_EXPAND_POLICY;
+
+#define HEAP_IS_VALID_OOS_EXPAND_POLICY(policy) \
+  ((policy) == HEAP_WITH_OOS_EXPAND || (policy) == HEAP_WITHOUT_OOS_EXPAND)
+
 typedef struct heap_get_context HEAP_GET_CONTEXT;
 struct heap_get_context
 {
@@ -381,7 +392,7 @@ struct heap_get_context
   PGBUF_LATCH_MODE latch_mode;	/* normally, we need READ latch for get_context, but some operations
 				 * (like serial increment) require WRITE mode */
 
-  bool expand_oos;		/* if true, replace inline OOS OID slots with actual values */
+  HEAP_OOS_EXPAND_POLICY oos_expand_policy;
   bool keep_recdes_buffer;	/* true if caller-positioned recdes_p->data must not be rebound to scan cache */
 };
 
@@ -428,17 +439,17 @@ extern int heap_scancache_end_when_scan_will_resume (THREAD_ENTRY * thread_p, HE
 extern void heap_scancache_end_modify (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache);
 extern SCAN_CODE heap_get_class_oid (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid);
 extern SCAN_CODE heap_next (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * next_oid,
-			    RECDES * recdes, HEAP_SCANCACHE * scan_cache, int ispeeking);
-extern SCAN_CODE heap_next_expand_oos (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
-				       OID * next_oid, RECDES * recdes, HEAP_SCANCACHE * scan_cache, int ispeeking);
+			    RECDES * recdes, HEAP_SCANCACHE * scan_cache, int ispeeking,
+			    HEAP_OOS_EXPAND_POLICY oos_expand_policy);
 extern SCAN_CODE heap_next_sampling (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * next_oid,
 				     RECDES * recdes, HEAP_SCANCACHE * scan_cache, int ispeeking,
-				     sampling_info * sampling);
+				     HEAP_OOS_EXPAND_POLICY oos_expand_policy, sampling_info * sampling);
 extern SCAN_CODE heap_next_record_info (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * next_oid,
 					RECDES * recdes, HEAP_SCANCACHE * scan_cache, int ispeeking,
 					DB_VALUE ** cache_recordinfo);
 extern SCAN_CODE heap_prev (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid, OID * prev_oid,
-			    RECDES * recdes, HEAP_SCANCACHE * scan_cache, int ispeeking);
+			    RECDES * recdes, HEAP_SCANCACHE * scan_cache, int ispeeking,
+			    HEAP_OOS_EXPAND_POLICY oos_expand_policy);
 extern SCAN_CODE heap_page_next_fix_old (THREAD_ENTRY * thread_p, HFID * hfid, VPID * curr_vpid,
 					 HEAP_SCANCACHE * scan_cache);
 extern SCAN_CODE heap_next_1page (THREAD_ENTRY * thread_p, const HFID * hfid, const VPID * vpid, OID * class_oid,
@@ -693,18 +704,16 @@ extern bool heap_should_try_update_stat (const int current_freespace, const int 
 extern int heap_rv_mvcc_redo_redistribute (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 extern int heap_vacuum_all_objects (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * upd_scancache, MVCCID threshold_mvccid);
 extern SCAN_CODE heap_get_visible_version (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid, RECDES * recdes,
-					   HEAP_SCANCACHE * scan_cache, int ispeeking, int old_chn);
-extern SCAN_CODE heap_get_visible_version_expand_oos (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid,
-						      RECDES * recdes, HEAP_SCANCACHE * scan_cache, int ispeeking,
-						      int old_chn);
+					   HEAP_SCANCACHE * scan_cache, int ispeeking, int old_chn,
+					   HEAP_OOS_EXPAND_POLICY oos_expand_policy);
 extern SCAN_CODE heap_scan_get_visible_version (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid,
 						RECDES * recdes, RECDES * forward_recdes, HEAP_SCANCACHE * scan_cache,
-						int ispeeking, int old_chn);
+						int ispeeking, int old_chn, HEAP_OOS_EXPAND_POLICY oos_expand_policy);
 extern SCAN_CODE heap_get_last_version (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context);
 extern void heap_clean_get_context (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context);
 extern void heap_init_get_context (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context, const OID * oid,
 				   OID * class_oid, RECDES * recdes, HEAP_SCANCACHE * scan_cache, int ispeeking,
-				   int old_chn);
+				   int old_chn, HEAP_OOS_EXPAND_POLICY oos_expand_policy);
 extern int heap_prepare_object_page (THREAD_ENTRY * thread_p, const OID * oid, PGBUF_WATCHER * page_watcher_p,
 				     PGBUF_LATCH_MODE latch_mode);
 extern SCAN_CODE heap_prepare_get_context (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context, bool is_heap_scan,

--- a/src/storage/heap_oos.cpp
+++ b/src/storage/heap_oos.cpp
@@ -348,7 +348,14 @@ heap_record_replace_oos_oids (THREAD_ENTRY *thread_p, HEAP_GET_CONTEXT *context)
 {
   RECDES *rec = context->recdes_p;
 
-  if (!context->expand_oos)
+  if (!HEAP_IS_VALID_OOS_EXPAND_POLICY (context->oos_expand_policy))
+    {
+      assert (false);
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
+      return S_ERROR;
+    }
+
+  if (context->oos_expand_policy == HEAP_WITHOUT_OOS_EXPAND)
     {
       /* Caller opted out: they handle OOS themselves (e.g. heap_attrinfo_read_dbvalues). */
       return S_SUCCESS;

--- a/src/storage/heap_oos.cpp
+++ b/src/storage/heap_oos.cpp
@@ -348,16 +348,17 @@ heap_record_replace_oos_oids (THREAD_ENTRY *thread_p, HEAP_GET_CONTEXT *context)
 {
   RECDES *rec = context->recdes_p;
 
-  if (!HEAP_IS_VALID_OOS_EXPAND_POLICY (context->oos_expand_policy))
+  if (!HEAP_IS_VALID_RECDES_CONSUMPTION_POLICY (context->recdes_consumption_policy))
     {
       assert (false);
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
       return S_ERROR;
     }
 
-  if (context->oos_expand_policy == HEAP_WITHOUT_OOS_EXPAND)
+  if (context->recdes_consumption_policy == HEAP_RECDES_DONT_CONSUME_RAW_BYTES)
     {
-      /* Caller opted out: they handle OOS themselves (e.g. heap_attrinfo_read_dbvalues). */
+      /* Preserve the stored record. The caller either does not consume its raw bytes or resolves OOS values through
+       * the attribute layer (e.g. heap_attrinfo_read_dbvalues). */
       return S_SUCCESS;
     }
 

--- a/src/storage/system_catalog.c
+++ b/src/storage/system_catalog.c
@@ -4716,7 +4716,7 @@ catalog_check_consistency (THREAD_ENTRY * thread_p)
   ct_valid = DISK_VALID;
 
   while (heap_next (thread_p, &root_hfid, oid_Root_class_oid, &class_oid, &peek, &scan_cache, PEEK,
-		    HEAP_WITHOUT_OOS_EXPAND) == S_SUCCESS)
+		    HEAP_RECDES_DONT_CONSUME_RAW_BYTES) == S_SUCCESS)
     {
 #if !defined(NDEBUG)
       classname = or_class_name (&peek);
@@ -5028,7 +5028,7 @@ catalog_dump (THREAD_ENTRY * thread_p, FILE * fp, int dump_flag)
   class_oid.slotid = NULL_SLOTID;
 
   while (heap_next (thread_p, &root_hfid, oid_Root_class_oid, &class_oid, &peek, &scan_cache, PEEK,
-		    HEAP_WITHOUT_OOS_EXPAND) == S_SUCCESS)
+		    HEAP_RECDES_DONT_CONSUME_RAW_BYTES) == S_SUCCESS)
     {
 #if !defined(NDEBUG)
       classname = or_class_name (&peek);

--- a/src/storage/system_catalog.c
+++ b/src/storage/system_catalog.c
@@ -4715,7 +4715,8 @@ catalog_check_consistency (THREAD_ENTRY * thread_p)
 
   ct_valid = DISK_VALID;
 
-  while (heap_next (thread_p, &root_hfid, oid_Root_class_oid, &class_oid, &peek, &scan_cache, PEEK) == S_SUCCESS)
+  while (heap_next (thread_p, &root_hfid, oid_Root_class_oid, &class_oid, &peek, &scan_cache, PEEK,
+		    HEAP_WITHOUT_OOS_EXPAND) == S_SUCCESS)
     {
 #if !defined(NDEBUG)
       classname = or_class_name (&peek);
@@ -5026,7 +5027,8 @@ catalog_dump (THREAD_ENTRY * thread_p, FILE * fp, int dump_flag)
   class_oid.pageid = NULL_PAGEID;
   class_oid.slotid = NULL_SLOTID;
 
-  while (heap_next (thread_p, &root_hfid, oid_Root_class_oid, &class_oid, &peek, &scan_cache, PEEK) == S_SUCCESS)
+  while (heap_next (thread_p, &root_hfid, oid_Root_class_oid, &class_oid, &peek, &scan_cache, PEEK,
+		    HEAP_WITHOUT_OOS_EXPAND) == S_SUCCESS)
     {
 #if !defined(NDEBUG)
       classname = or_class_name (&peek);

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -299,7 +299,8 @@ locator_initialize (THREAD_ENTRY * thread_p)
 
   OID_SET_NULL (&class_oid);
 
-  while (heap_next (thread_p, &root_hfid, NULL, &class_oid, &peek, &scan_cache, PEEK) == S_SUCCESS)
+  while (heap_next (thread_p, &root_hfid, NULL, &class_oid, &peek, &scan_cache, PEEK,
+		    HEAP_WITHOUT_OOS_EXPAND) == S_SUCCESS)
     {
       assert (!OID_ISNULL (&class_oid));
 
@@ -1971,7 +1972,8 @@ locator_check_class_names (THREAD_ENTRY * thread_p)
   class_oid.slotid = NULL_SLOTID;
 
   isvalid = DISK_VALID;
-  while (heap_next (thread_p, &root_hfid, oid_Root_class_oid, &class_oid, &peek, &scan_cache, PEEK) == S_SUCCESS)
+  while (heap_next (thread_p, &root_hfid, oid_Root_class_oid, &class_oid, &peek, &scan_cache, PEEK,
+		    HEAP_WITHOUT_OOS_EXPAND) == S_SUCCESS)
     {
       classname = or_class_name (&peek);
       assert (classname != NULL);
@@ -2331,8 +2333,10 @@ locator_lock_and_return_object (THREAD_ENTRY * thread_p, LOCATOR_RETURN_NXOBJ * 
       chn = heap_chnguess_get (thread_p, oid, tran_index);
     }
 
+  /* TODO (CBRD-26847): analysis needed - this single-object client fetch keeps inline OOS OID slots
+   * (pre-policy behavior), while xlocator_fetch_all expands them; CS-mode clients cannot resolve OOS. */
   scan = locator_get_object (thread_p, oid, class_oid, &assign->recdes, assign->ptr_scancache, op_type, lock_mode, COPY,
-			     chn);
+			     chn, HEAP_WITHOUT_OOS_EXPAND);
   if (scan == S_ERROR || scan == S_SNAPSHOT_NOT_SATISFIED || scan == S_END || scan == S_DOESNT_EXIST)
     {
       return scan;
@@ -2903,7 +2907,8 @@ xlocator_fetch_all (THREAD_ENTRY * thread_p, const HFID * hfid, LOCK * lock, LC_
       mobjs->num_objs = 0;
       offset = 0;
 
-      while ((scan = heap_next_expand_oos (thread_p, hfid, class_oid, &oid, &recdes, &scan_cache, COPY)) == S_SUCCESS)
+      while ((scan = heap_next (thread_p, hfid, class_oid, &oid, &recdes, &scan_cache, COPY,
+				HEAP_WITH_OOS_EXPAND)) == S_SUCCESS)
 	{
 	  mobjs->num_objs++;
 	  COPY_OID (&obj->class_oid, class_oid);
@@ -3489,8 +3494,8 @@ locator_all_reference_lockset (THREAD_ENTRY * thread_p, OID * oid, int prune_lev
       /* Get the object to find out its direct references */
       OID_SET_NULL (&class_oid);
       scan =
-	heap_get_visible_version_expand_oos (thread_p, &lockset->objects[ref_num].oid, &class_oid, &peek_recdes,
-					     &scan_cache, PEEK, NULL_CHN);
+	heap_get_visible_version (thread_p, &lockset->objects[ref_num].oid, &class_oid, &peek_recdes, &scan_cache,
+				  PEEK, NULL_CHN, HEAP_WITH_OOS_EXPAND);
       if (scan != S_SUCCESS)
 	{
 	  if (scan != S_DOESNT_EXIST && (quit_on_errors == true || er_errid () == ER_INTERRUPTED))
@@ -3955,7 +3960,8 @@ xlocator_does_exist (THREAD_ENTRY * thread_p, OID * oid, int chn, LOCK lock, LC_
 
 	  (void) heap_scancache_quick_start (&scan_cache);
 
-	  scan_code = locator_get_object (thread_p, oid, class_oid, NULL, &scan_cache, op_type, lock, PEEK, NULL_CHN);
+	  scan_code = locator_get_object (thread_p, oid, class_oid, NULL, &scan_cache, op_type, lock, PEEK, NULL_CHN,
+					  HEAP_WITHOUT_OOS_EXPAND);
 	  heap_scancache_end (thread_p, &scan_cache);
 	  if (scan_code == S_ERROR)
 	    {
@@ -4436,7 +4442,8 @@ locator_check_primary_key_delete (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 		  /* TO DO - handle reevaluation */
 
 		  scan_code = locator_lock_and_get_object (thread_p, oid_ptr, &fkref->self_oid, &recdes, &scan_cache,
-							   X_LOCK, COPY, NULL_CHN, LOG_ERROR_IF_DELETED);
+							   X_LOCK, COPY, NULL_CHN, LOG_ERROR_IF_DELETED,
+							   HEAP_WITHOUT_OOS_EXPAND);
 		  if (scan_code != S_SUCCESS)
 		    {
 		      if (scan_code == S_DOESNT_EXIST && er_errid () != ER_HEAP_UNKNOWN_OBJECT)
@@ -4791,7 +4798,8 @@ locator_check_primary_key_update (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 		  /* TO DO - handle reevaluation */
 
 		  scan_code = locator_lock_and_get_object (thread_p, oid_ptr, &fkref->self_oid, &recdes, &scan_cache,
-							   X_LOCK, COPY, NULL_CHN, LOG_ERROR_IF_DELETED);
+							   X_LOCK, COPY, NULL_CHN, LOG_ERROR_IF_DELETED,
+							   HEAP_WITHOUT_OOS_EXPAND);
 		  if (scan_code != S_SUCCESS)
 		    {
 		      if (scan_code == S_DOESNT_EXIST && er_errid () != ER_HEAP_UNKNOWN_OBJECT)
@@ -5796,13 +5804,13 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 		{
 		  scan = locator_lock_and_get_object_with_evaluation (thread_p, oid, class_oid, &copy_recdes,
 								      local_scan_cache, COPY, NULL_CHN, mvcc_reev_data,
-								      LOG_ERROR_IF_DELETED);
+								      LOG_ERROR_IF_DELETED, HEAP_WITHOUT_OOS_EXPAND);
 		}
 	      else
 		{
 		  scan =
-		    heap_get_visible_version_expand_oos (thread_p, oid, class_oid, &copy_recdes, local_scan_cache, COPY,
-							 NULL_CHN);
+		    heap_get_visible_version (thread_p, oid, class_oid, &copy_recdes, local_scan_cache, COPY, NULL_CHN,
+					      HEAP_WITH_OOS_EXPAND);
 		}
 
 
@@ -5944,8 +5952,8 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 		}
 
 	      scan =
-		heap_get_visible_version_expand_oos (thread_p, oid, class_oid, &copy_recdes, local_scan_cache, COPY,
-						     NULL_CHN);
+		heap_get_visible_version (thread_p, oid, class_oid, &copy_recdes, local_scan_cache, COPY, NULL_CHN,
+					  HEAP_WITH_OOS_EXPAND);
 	      if (scan == S_SUCCESS)
 		{
 		  oldrecdes = &copy_recdes;
@@ -6286,7 +6294,7 @@ locator_delete_force_internal (THREAD_ENTRY * thread_p, HFID * hfid, OID * oid, 
      not the visible one; we need only the last version to use it to retrieve the last version of the btree key */
   scan_code =
     locator_lock_and_get_object_with_evaluation (thread_p, oid, &class_oid, &copy_recdes, scan_cache, COPY, NULL_CHN,
-						 mvcc_reev_data, LOG_WARNING_IF_DELETED);
+						 mvcc_reev_data, LOG_WARNING_IF_DELETED, HEAP_WITHOUT_OOS_EXPAND);
 
   if (scan_code == S_SUCCESS && mvcc_reev_data != NULL && mvcc_reev_data->filter_result == V_FALSE)
     {
@@ -6582,7 +6590,8 @@ locator_delete_lob_force (THREAD_ENTRY * thread_p, OID * class_oid, OID * oid, R
 	  scan_cache_inited = true;
 
 	  scan =
-	    heap_get_visible_version_expand_oos (thread_p, oid, class_oid, &copy_recdes, &scan_cache, COPY, NULL_CHN);
+	    heap_get_visible_version (thread_p, oid, class_oid, &copy_recdes, &scan_cache, COPY, NULL_CHN,
+				      HEAP_WITH_OOS_EXPAND);
 	  if (scan != S_SUCCESS)
 	    {
 	      goto error;
@@ -6945,8 +6954,8 @@ locator_repl_prepare_force (THREAD_ENTRY * thread_p, LC_COPYAREA_ONEOBJ * obj, R
       assert (OID_ISNULL (&obj->oid) != true);
 
       scan =
-	heap_get_visible_version_expand_oos (thread_p, &obj->oid, &obj->class_oid, old_recdes, force_scancache, PEEK,
-					     NULL_CHN);
+	heap_get_visible_version (thread_p, &obj->oid, &obj->class_oid, old_recdes, force_scancache, PEEK, NULL_CHN,
+				  HEAP_WITH_OOS_EXPAND);
 
       if (scan != S_SUCCESS)
 	{
@@ -7603,7 +7612,8 @@ locator_attribute_info_force (THREAD_ENTRY * thread_p, const HFID * hfid, OID * 
 	  HEAP_GET_CONTEXT context;
 
 	  /* don't consider visiblity, just get the last version of the object */
-	  heap_init_get_context (thread_p, &context, oid, &class_oid, &copy_recdes, scan_cache, COPY, NULL_CHN);
+	  heap_init_get_context (thread_p, &context, oid, &class_oid, &copy_recdes, scan_cache, COPY, NULL_CHN,
+				 HEAP_WITHOUT_OOS_EXPAND);
 	  scan = heap_get_last_version (thread_p, &context);
 	  heap_clean_get_context (thread_p, &context);
 
@@ -7623,7 +7633,7 @@ locator_attribute_info_force (THREAD_ENTRY * thread_p, const HFID * hfid, OID * 
 	    }
 
 	  scan = locator_lock_and_get_object (thread_p, oid, &class_oid, &copy_recdes, scan_cache, X_LOCK, COPY,
-					      NULL_CHN, LOG_ERROR_IF_DELETED);
+					      NULL_CHN, LOG_ERROR_IF_DELETED, HEAP_WITHOUT_OOS_EXPAND);
 	  if (saved_mvcc_snapshot != NULL)
 	    {
 	      scan_cache->mvcc_snapshot = saved_mvcc_snapshot;
@@ -9146,7 +9156,7 @@ xlocator_remove_class_from_index (THREAD_ENTRY * thread_p, OID * class_oid, BTID
 	  dbvalue_ptr = NULL;
 	}
 
-      scan = heap_next (thread_p, hfid, class_oid, &inst_oid, &copy_rec, &scan_cache, COPY);
+      scan = heap_next (thread_p, hfid, class_oid, &inst_oid, &copy_rec, &scan_cache, COPY, HEAP_WITHOUT_OOS_EXPAND);
       if (scan != S_SUCCESS)
 	{
 	  if (scan != S_DOESNT_FIT)
@@ -9600,7 +9610,8 @@ locator_check_btree_entries (THREAD_ENTRY * thread_p, BTID * btid, HFID * hfid, 
   inst_oid.pageid = NULL_PAGEID;
   inst_oid.slotid = NULL_SLOTID;
 
-  while ((scan = heap_next (thread_p, hfid, class_oid, &inst_oid, &record, &scan_cache, COPY)) == S_SUCCESS)
+  while ((scan = heap_next (thread_p, hfid, class_oid, &inst_oid, &record, &scan_cache, COPY,
+			    HEAP_WITHOUT_OOS_EXPAND)) == S_SUCCESS)
     {
       num_heap_oids++;
 
@@ -10054,7 +10065,8 @@ locator_check_unique_btree_entries (THREAD_ENTRY * thread_p, BTID * btid, OID * 
       inst_oid.pageid = NULL_PAGEID;
       inst_oid.slotid = NULL_SLOTID;
 
-      while ((scan = heap_next (thread_p, hfid, class_oid, &inst_oid, &peek, &scan_cache[j], PEEK)) == S_SUCCESS)
+      while ((scan = heap_next (thread_p, hfid, class_oid, &inst_oid, &peek, &scan_cache[j], PEEK,
+				HEAP_WITHOUT_OOS_EXPAND)) == S_SUCCESS)
 	{
 	  num_heap_oids++;
 
@@ -10767,7 +10779,8 @@ locator_check_all_entries_of_all_btrees (THREAD_ENTRY * thread_p, bool repair)
   while (isallvalid != DISK_ERROR)
     {
       copy_rec.data = NULL;
-      code = heap_next (thread_p, &root_hfid, oid_Root_class_oid, &oid, &copy_rec, &scan, COPY);
+      code = heap_next (thread_p, &root_hfid, oid_Root_class_oid, &oid, &copy_rec, &scan, COPY,
+			HEAP_WITHOUT_OOS_EXPAND);
       if (code != S_SUCCESS)
 	{
 	  break;
@@ -11952,7 +11965,7 @@ xlocator_check_fk_validity (THREAD_ENTRY * thread_p, OID * cls_oid, HFID * hfid,
   oid.volid = hfid->vfid.volid;
 
   copy_recdes.data = NULL;
-  while (heap_next (thread_p, hfid, NULL, &oid, &copy_recdes, &scan_cache, COPY) == S_SUCCESS)
+  while (heap_next (thread_p, hfid, NULL, &oid, &copy_recdes, &scan_cache, COPY, HEAP_WITHOUT_OOS_EXPAND) == S_SUCCESS)
     {
       key_val =
 	heap_attrinfo_generate_key (thread_p, n_attrs, attr_ids, NULL, &attr_info, &copy_recdes, &tmpval,
@@ -12106,7 +12119,7 @@ xlocator_lock_and_fetch_all (THREAD_ENTRY * thread_p, const HFID * hfid, LOCK * 
 	    {
 	      int lock_result = 0;
 
-	      scan = heap_next (thread_p, hfid, class_oid, &oid, &recdes, &scan_cache, COPY);
+	      scan = heap_next (thread_p, hfid, class_oid, &oid, &recdes, &scan_cache, COPY, HEAP_WITHOUT_OOS_EXPAND);
 	      if (scan != S_SUCCESS)
 		{
 		  break;
@@ -12130,7 +12143,8 @@ xlocator_lock_and_fetch_all (THREAD_ENTRY * thread_p, const HFID * hfid, LOCK * 
 		}
 
 	      scan =
-		heap_get_visible_version_expand_oos (thread_p, &oid, class_oid, &recdes, &scan_cache, COPY, NULL_CHN);
+		heap_get_visible_version (thread_p, &oid, class_oid, &recdes, &scan_cache, COPY, NULL_CHN,
+					  HEAP_WITH_OOS_EXPAND);
 	      if (scan != S_SUCCESS)
 		{
 		  if (scan == S_DOESNT_FIT)
@@ -12145,7 +12159,7 @@ xlocator_lock_and_fetch_all (THREAD_ENTRY * thread_p, const HFID * hfid, LOCK * 
 	    }
 	  else
 	    {
-	      scan = heap_next_expand_oos (thread_p, hfid, class_oid, &oid, &recdes, &scan_cache, COPY);
+	      scan = heap_next (thread_p, hfid, class_oid, &oid, &recdes, &scan_cache, COPY, HEAP_WITH_OOS_EXPAND);
 	      if (scan != S_SUCCESS)
 		{
 		  break;
@@ -13023,8 +13037,9 @@ redistribute_partition_data (THREAD_ENTRY * thread_p, OID * class_oid, int no_oi
 
 	      recdes.data = NULL;
 
-	      if (heap_get_visible_version_expand_oos
-		  (thread_p, &inst_oid, class_oid, &recdes, &scan_cache, COPY, NULL_CHN) != S_SUCCESS)
+	      if (heap_get_visible_version
+		  (thread_p, &inst_oid, class_oid, &recdes, &scan_cache, COPY, NULL_CHN,
+		   HEAP_WITH_OOS_EXPAND) != S_SUCCESS)
 		{
 		  error = ER_FAILED;
 		  goto exit;
@@ -13272,6 +13287,7 @@ error:
  * (obsolete) non_ex_handling_type (in): - LOG_ERROR_IF_DELETED: write the
  *				ER_HEAP_UNKNOWN_OBJECT error to log
  *                            - LOG_WARNING_IF_DELETED: set only warning
+ * oos_expand_policy (in) : Whether to expand inline OOS values in the returned recdes.
  *
  * Note: This function will lock the object with X_LOCK. This lock type should correspond to delete/update operations.
  */
@@ -13279,7 +13295,8 @@ SCAN_CODE
 locator_lock_and_get_object_with_evaluation (THREAD_ENTRY * thread_p, OID * oid, OID * class_oid, RECDES * recdes,
 					     HEAP_SCANCACHE * scan_cache, int ispeeking, int old_chn,
 					     MVCC_REEV_DATA * mvcc_reev_data,
-					     NON_EXISTENT_HANDLING non_ex_handling_type)
+					     NON_EXISTENT_HANDLING non_ex_handling_type,
+					     HEAP_OOS_EXPAND_POLICY oos_expand_policy)
 {
   HEAP_GET_CONTEXT context;
   SCAN_CODE scan = S_SUCCESS;
@@ -13311,7 +13328,7 @@ locator_lock_and_get_object_with_evaluation (THREAD_ENTRY * thread_p, OID * oid,
 	  return S_ERROR;
 	}
     }
-  heap_init_get_context (thread_p, &context, oid, class_oid, recdes, scan_cache, ispeeking, old_chn);
+  heap_init_get_context (thread_p, &context, oid, class_oid, recdes, scan_cache, ispeeking, old_chn, oos_expand_policy);
 
   /* get class_oid if it is unknown */
   if (OID_ISNULL (class_oid))
@@ -13408,6 +13425,7 @@ exit:
  * op_type (in)	  : Requested type of operation.
  * lock_mode (in) : Lock type, see note.
  * ispeeking (in) : Peek record or copy.
+ * oos_expand_policy (in) : Whether to expand inline OOS values in the returned recdes.
  *
  * Note: This function should be used when class_oid is unknown, which is required to decide lock_mode;
  *       When lock_mode is known, a more appropriate function is recommended.
@@ -13418,7 +13436,8 @@ exit:
  */
 SCAN_CODE
 locator_get_object (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid, RECDES * recdes,
-		    HEAP_SCANCACHE * scan_cache, SCAN_OPERATION_TYPE op_type, LOCK lock_mode, int ispeeking, int chn)
+		    HEAP_SCANCACHE * scan_cache, SCAN_OPERATION_TYPE op_type, LOCK lock_mode, int ispeeking, int chn,
+		    HEAP_OOS_EXPAND_POLICY oos_expand_policy)
 {
   SCAN_CODE scan_code;
   OID class_oid_local = OID_INITIALIZER;
@@ -13444,7 +13463,7 @@ locator_get_object (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid, R
 	}
     }
 
-  heap_init_get_context (thread_p, &context, oid, class_oid, recdes, scan_cache, ispeeking, chn);
+  heap_init_get_context (thread_p, &context, oid, class_oid, recdes, scan_cache, ispeeking, chn, oos_expand_policy);
 
   /* get class_oid if it is unknown */
   if (OID_ISNULL (class_oid))
@@ -13526,11 +13545,12 @@ locator_get_object (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid, R
  * (obsolete) non_ex_handling_type (in): - LOG_ERROR_IF_DELETED: write the
  *				ER_HEAP_UNKNOWN_OBJECT error to log
  *                            - LOG_WARNING_IF_DELETED: set only warning
+ * oos_expand_policy (in) : Whether to expand inline OOS values in the returned recdes.
  */
 SCAN_CODE
 locator_lock_and_get_object (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid, RECDES * recdes,
 			     HEAP_SCANCACHE * scan_cache, LOCK lock, int ispeeking, int old_chn,
-			     NON_EXISTENT_HANDLING non_ex_handling_type)
+			     NON_EXISTENT_HANDLING non_ex_handling_type, HEAP_OOS_EXPAND_POLICY oos_expand_policy)
 {
   HEAP_GET_CONTEXT context;
   SCAN_CODE scan_code;
@@ -13544,7 +13564,7 @@ locator_lock_and_get_object (THREAD_ENTRY * thread_p, const OID * oid, OID * cla
 	}
     }
 
-  heap_init_get_context (thread_p, &context, oid, class_oid, recdes, scan_cache, ispeeking, old_chn);
+  heap_init_get_context (thread_p, &context, oid, class_oid, recdes, scan_cache, ispeeking, old_chn, oos_expand_policy);
   scan_code = locator_lock_and_get_object_internal (thread_p, &context, lock);
   heap_clean_get_context (thread_p, &context);
   return scan_code;
@@ -13779,7 +13799,8 @@ locator_mvcc_reeval_scan_filters (THREAD_ENTRY * thread_p, const OID * oid, HEAP
 	}
       scan_cache_inited = true;
       scan_code =
-	heap_get_visible_version_expand_oos (thread_p, oid_inst, NULL, recdesp, &local_scan_cache, PEEK, NULL_CHN);
+	heap_get_visible_version (thread_p, oid_inst, NULL, recdesp, &local_scan_cache, PEEK, NULL_CHN,
+				  HEAP_WITH_OOS_EXPAND);
       if (scan_code != S_SUCCESS)
 	{
 	  ev_res = V_ERROR;

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -2333,10 +2333,12 @@ locator_lock_and_return_object (THREAD_ENTRY * thread_p, LOCATOR_RETURN_NXOBJ * 
       chn = heap_chnguess_get (thread_p, oid, tran_index);
     }
 
-  /* TODO (CBRD-26847): analysis needed - this single-object client fetch keeps inline OOS OID slots
-   * (pre-policy behavior), while xlocator_fetch_all expands them; CS-mode clients cannot resolve OOS. */
+  /* Raw RECDES is shipped to the client via LC_COPYAREA and CS-mode clients cannot resolve inline
+   * OOS OID slots, so expand them here (same rule as xlocator_fetch_all). An expansion that
+   * outgrows the copy area returns S_DOESNT_FIT with the needed size as a negative recdes length,
+   * which the callers' standard grow-and-retry protocol already handles. */
   scan = locator_get_object (thread_p, oid, class_oid, &assign->recdes, assign->ptr_scancache, op_type, lock_mode, COPY,
-			     chn, HEAP_WITHOUT_OOS_EXPAND);
+			     chn, HEAP_WITH_OOS_EXPAND);
   if (scan == S_ERROR || scan == S_SNAPSHOT_NOT_SATISFIED || scan == S_END || scan == S_DOESNT_EXIST)
     {
       return scan;

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -300,7 +300,7 @@ locator_initialize (THREAD_ENTRY * thread_p)
   OID_SET_NULL (&class_oid);
 
   while (heap_next (thread_p, &root_hfid, NULL, &class_oid, &peek, &scan_cache, PEEK,
-		    HEAP_WITHOUT_OOS_EXPAND) == S_SUCCESS)
+		    HEAP_RECDES_DONT_CONSUME_RAW_BYTES) == S_SUCCESS)
     {
       assert (!OID_ISNULL (&class_oid));
 
@@ -1973,7 +1973,7 @@ locator_check_class_names (THREAD_ENTRY * thread_p)
 
   isvalid = DISK_VALID;
   while (heap_next (thread_p, &root_hfid, oid_Root_class_oid, &class_oid, &peek, &scan_cache, PEEK,
-		    HEAP_WITHOUT_OOS_EXPAND) == S_SUCCESS)
+		    HEAP_RECDES_DONT_CONSUME_RAW_BYTES) == S_SUCCESS)
     {
       classname = or_class_name (&peek);
       assert (classname != NULL);
@@ -2338,7 +2338,7 @@ locator_lock_and_return_object (THREAD_ENTRY * thread_p, LOCATOR_RETURN_NXOBJ * 
    * outgrows the copy area returns S_DOESNT_FIT with the needed size as a negative recdes length,
    * which the callers' standard grow-and-retry protocol already handles. */
   scan = locator_get_object (thread_p, oid, class_oid, &assign->recdes, assign->ptr_scancache, op_type, lock_mode, COPY,
-			     chn, HEAP_WITH_OOS_EXPAND);
+			     chn, HEAP_RECDES_CONSUME_RAW_BYTES);
   if (scan == S_ERROR || scan == S_SNAPSHOT_NOT_SATISFIED || scan == S_END || scan == S_DOESNT_EXIST)
     {
       return scan;
@@ -2910,7 +2910,7 @@ xlocator_fetch_all (THREAD_ENTRY * thread_p, const HFID * hfid, LOCK * lock, LC_
       offset = 0;
 
       while ((scan = heap_next (thread_p, hfid, class_oid, &oid, &recdes, &scan_cache, COPY,
-				HEAP_WITH_OOS_EXPAND)) == S_SUCCESS)
+				HEAP_RECDES_CONSUME_RAW_BYTES)) == S_SUCCESS)
 	{
 	  mobjs->num_objs++;
 	  COPY_OID (&obj->class_oid, class_oid);
@@ -3497,7 +3497,7 @@ locator_all_reference_lockset (THREAD_ENTRY * thread_p, OID * oid, int prune_lev
       OID_SET_NULL (&class_oid);
       scan =
 	heap_get_visible_version (thread_p, &lockset->objects[ref_num].oid, &class_oid, &peek_recdes, &scan_cache,
-				  PEEK, NULL_CHN, HEAP_WITH_OOS_EXPAND);
+				  PEEK, NULL_CHN, HEAP_RECDES_CONSUME_RAW_BYTES);
       if (scan != S_SUCCESS)
 	{
 	  if (scan != S_DOESNT_EXIST && (quit_on_errors == true || er_errid () == ER_INTERRUPTED))
@@ -3963,7 +3963,7 @@ xlocator_does_exist (THREAD_ENTRY * thread_p, OID * oid, int chn, LOCK lock, LC_
 	  (void) heap_scancache_quick_start (&scan_cache);
 
 	  scan_code = locator_get_object (thread_p, oid, class_oid, NULL, &scan_cache, op_type, lock, PEEK, NULL_CHN,
-					  HEAP_WITHOUT_OOS_EXPAND);
+					  HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
 	  heap_scancache_end (thread_p, &scan_cache);
 	  if (scan_code == S_ERROR)
 	    {
@@ -4445,7 +4445,7 @@ locator_check_primary_key_delete (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 
 		  scan_code = locator_lock_and_get_object (thread_p, oid_ptr, &fkref->self_oid, &recdes, &scan_cache,
 							   X_LOCK, COPY, NULL_CHN, LOG_ERROR_IF_DELETED,
-							   HEAP_WITHOUT_OOS_EXPAND);
+							   HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
 		  if (scan_code != S_SUCCESS)
 		    {
 		      if (scan_code == S_DOESNT_EXIST && er_errid () != ER_HEAP_UNKNOWN_OBJECT)
@@ -4801,7 +4801,7 @@ locator_check_primary_key_update (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 
 		  scan_code = locator_lock_and_get_object (thread_p, oid_ptr, &fkref->self_oid, &recdes, &scan_cache,
 							   X_LOCK, COPY, NULL_CHN, LOG_ERROR_IF_DELETED,
-							   HEAP_WITHOUT_OOS_EXPAND);
+							   HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
 		  if (scan_code != S_SUCCESS)
 		    {
 		      if (scan_code == S_DOESNT_EXIST && er_errid () != ER_HEAP_UNKNOWN_OBJECT)
@@ -5806,13 +5806,14 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 		{
 		  scan = locator_lock_and_get_object_with_evaluation (thread_p, oid, class_oid, &copy_recdes,
 								      local_scan_cache, COPY, NULL_CHN, mvcc_reev_data,
-								      LOG_ERROR_IF_DELETED, HEAP_WITHOUT_OOS_EXPAND);
+								      LOG_ERROR_IF_DELETED,
+								      HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
 		}
 	      else
 		{
 		  scan =
 		    heap_get_visible_version (thread_p, oid, class_oid, &copy_recdes, local_scan_cache, COPY, NULL_CHN,
-					      HEAP_WITH_OOS_EXPAND);
+					      HEAP_RECDES_CONSUME_RAW_BYTES);
 		}
 
 
@@ -5955,7 +5956,7 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 
 	      scan =
 		heap_get_visible_version (thread_p, oid, class_oid, &copy_recdes, local_scan_cache, COPY, NULL_CHN,
-					  HEAP_WITH_OOS_EXPAND);
+					  HEAP_RECDES_CONSUME_RAW_BYTES);
 	      if (scan == S_SUCCESS)
 		{
 		  oldrecdes = &copy_recdes;
@@ -6296,7 +6297,8 @@ locator_delete_force_internal (THREAD_ENTRY * thread_p, HFID * hfid, OID * oid, 
      not the visible one; we need only the last version to use it to retrieve the last version of the btree key */
   scan_code =
     locator_lock_and_get_object_with_evaluation (thread_p, oid, &class_oid, &copy_recdes, scan_cache, COPY, NULL_CHN,
-						 mvcc_reev_data, LOG_WARNING_IF_DELETED, HEAP_WITHOUT_OOS_EXPAND);
+						 mvcc_reev_data, LOG_WARNING_IF_DELETED,
+						 HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
 
   if (scan_code == S_SUCCESS && mvcc_reev_data != NULL && mvcc_reev_data->filter_result == V_FALSE)
     {
@@ -6593,7 +6595,7 @@ locator_delete_lob_force (THREAD_ENTRY * thread_p, OID * class_oid, OID * oid, R
 
 	  scan =
 	    heap_get_visible_version (thread_p, oid, class_oid, &copy_recdes, &scan_cache, COPY, NULL_CHN,
-				      HEAP_WITH_OOS_EXPAND);
+				      HEAP_RECDES_CONSUME_RAW_BYTES);
 	  if (scan != S_SUCCESS)
 	    {
 	      goto error;
@@ -6957,7 +6959,7 @@ locator_repl_prepare_force (THREAD_ENTRY * thread_p, LC_COPYAREA_ONEOBJ * obj, R
 
       scan =
 	heap_get_visible_version (thread_p, &obj->oid, &obj->class_oid, old_recdes, force_scancache, PEEK, NULL_CHN,
-				  HEAP_WITH_OOS_EXPAND);
+				  HEAP_RECDES_CONSUME_RAW_BYTES);
 
       if (scan != S_SUCCESS)
 	{
@@ -7615,7 +7617,7 @@ locator_attribute_info_force (THREAD_ENTRY * thread_p, const HFID * hfid, OID * 
 
 	  /* don't consider visiblity, just get the last version of the object */
 	  heap_init_get_context (thread_p, &context, oid, &class_oid, &copy_recdes, scan_cache, COPY, NULL_CHN,
-				 HEAP_WITHOUT_OOS_EXPAND);
+				 HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
 	  scan = heap_get_last_version (thread_p, &context);
 	  heap_clean_get_context (thread_p, &context);
 
@@ -7635,7 +7637,7 @@ locator_attribute_info_force (THREAD_ENTRY * thread_p, const HFID * hfid, OID * 
 	    }
 
 	  scan = locator_lock_and_get_object (thread_p, oid, &class_oid, &copy_recdes, scan_cache, X_LOCK, COPY,
-					      NULL_CHN, LOG_ERROR_IF_DELETED, HEAP_WITHOUT_OOS_EXPAND);
+					      NULL_CHN, LOG_ERROR_IF_DELETED, HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
 	  if (saved_mvcc_snapshot != NULL)
 	    {
 	      scan_cache->mvcc_snapshot = saved_mvcc_snapshot;
@@ -9158,7 +9160,9 @@ xlocator_remove_class_from_index (THREAD_ENTRY * thread_p, OID * class_oid, BTID
 	  dbvalue_ptr = NULL;
 	}
 
-      scan = heap_next (thread_p, hfid, class_oid, &inst_oid, &copy_rec, &scan_cache, COPY, HEAP_WITHOUT_OOS_EXPAND);
+      scan =
+	heap_next (thread_p, hfid, class_oid, &inst_oid, &copy_rec, &scan_cache, COPY,
+		   HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
       if (scan != S_SUCCESS)
 	{
 	  if (scan != S_DOESNT_FIT)
@@ -9613,7 +9617,7 @@ locator_check_btree_entries (THREAD_ENTRY * thread_p, BTID * btid, HFID * hfid, 
   inst_oid.slotid = NULL_SLOTID;
 
   while ((scan = heap_next (thread_p, hfid, class_oid, &inst_oid, &record, &scan_cache, COPY,
-			    HEAP_WITHOUT_OOS_EXPAND)) == S_SUCCESS)
+			    HEAP_RECDES_DONT_CONSUME_RAW_BYTES)) == S_SUCCESS)
     {
       num_heap_oids++;
 
@@ -10068,7 +10072,7 @@ locator_check_unique_btree_entries (THREAD_ENTRY * thread_p, BTID * btid, OID * 
       inst_oid.slotid = NULL_SLOTID;
 
       while ((scan = heap_next (thread_p, hfid, class_oid, &inst_oid, &peek, &scan_cache[j], PEEK,
-				HEAP_WITHOUT_OOS_EXPAND)) == S_SUCCESS)
+				HEAP_RECDES_DONT_CONSUME_RAW_BYTES)) == S_SUCCESS)
 	{
 	  num_heap_oids++;
 
@@ -10782,7 +10786,7 @@ locator_check_all_entries_of_all_btrees (THREAD_ENTRY * thread_p, bool repair)
     {
       copy_rec.data = NULL;
       code = heap_next (thread_p, &root_hfid, oid_Root_class_oid, &oid, &copy_rec, &scan, COPY,
-			HEAP_WITHOUT_OOS_EXPAND);
+			HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
       if (code != S_SUCCESS)
 	{
 	  break;
@@ -11967,7 +11971,8 @@ xlocator_check_fk_validity (THREAD_ENTRY * thread_p, OID * cls_oid, HFID * hfid,
   oid.volid = hfid->vfid.volid;
 
   copy_recdes.data = NULL;
-  while (heap_next (thread_p, hfid, NULL, &oid, &copy_recdes, &scan_cache, COPY, HEAP_WITHOUT_OOS_EXPAND) == S_SUCCESS)
+  while (heap_next (thread_p, hfid, NULL, &oid, &copy_recdes, &scan_cache, COPY, HEAP_RECDES_DONT_CONSUME_RAW_BYTES) ==
+	 S_SUCCESS)
     {
       key_val =
 	heap_attrinfo_generate_key (thread_p, n_attrs, attr_ids, NULL, &attr_info, &copy_recdes, &tmpval,
@@ -12121,7 +12126,9 @@ xlocator_lock_and_fetch_all (THREAD_ENTRY * thread_p, const HFID * hfid, LOCK * 
 	    {
 	      int lock_result = 0;
 
-	      scan = heap_next (thread_p, hfid, class_oid, &oid, &recdes, &scan_cache, COPY, HEAP_WITHOUT_OOS_EXPAND);
+	      scan =
+		heap_next (thread_p, hfid, class_oid, &oid, &recdes, &scan_cache, COPY,
+			   HEAP_RECDES_DONT_CONSUME_RAW_BYTES);
 	      if (scan != S_SUCCESS)
 		{
 		  break;
@@ -12146,7 +12153,7 @@ xlocator_lock_and_fetch_all (THREAD_ENTRY * thread_p, const HFID * hfid, LOCK * 
 
 	      scan =
 		heap_get_visible_version (thread_p, &oid, class_oid, &recdes, &scan_cache, COPY, NULL_CHN,
-					  HEAP_WITH_OOS_EXPAND);
+					  HEAP_RECDES_CONSUME_RAW_BYTES);
 	      if (scan != S_SUCCESS)
 		{
 		  if (scan == S_DOESNT_FIT)
@@ -12161,7 +12168,8 @@ xlocator_lock_and_fetch_all (THREAD_ENTRY * thread_p, const HFID * hfid, LOCK * 
 	    }
 	  else
 	    {
-	      scan = heap_next (thread_p, hfid, class_oid, &oid, &recdes, &scan_cache, COPY, HEAP_WITH_OOS_EXPAND);
+	      scan =
+		heap_next (thread_p, hfid, class_oid, &oid, &recdes, &scan_cache, COPY, HEAP_RECDES_CONSUME_RAW_BYTES);
 	      if (scan != S_SUCCESS)
 		{
 		  break;
@@ -13041,7 +13049,7 @@ redistribute_partition_data (THREAD_ENTRY * thread_p, OID * class_oid, int no_oi
 
 	      if (heap_get_visible_version
 		  (thread_p, &inst_oid, class_oid, &recdes, &scan_cache, COPY, NULL_CHN,
-		   HEAP_WITH_OOS_EXPAND) != S_SUCCESS)
+		   HEAP_RECDES_CONSUME_RAW_BYTES) != S_SUCCESS)
 		{
 		  error = ER_FAILED;
 		  goto exit;
@@ -13289,7 +13297,7 @@ error:
  * (obsolete) non_ex_handling_type (in): - LOG_ERROR_IF_DELETED: write the
  *				ER_HEAP_UNKNOWN_OBJECT error to log
  *                            - LOG_WARNING_IF_DELETED: set only warning
- * oos_expand_policy (in) : Whether to expand inline OOS values in the returned recdes.
+ * recdes_consumption_policy (in) : Whether the caller consumes the returned raw RECDES bytes.
  *
  * Note: This function will lock the object with X_LOCK. This lock type should correspond to delete/update operations.
  */
@@ -13298,7 +13306,7 @@ locator_lock_and_get_object_with_evaluation (THREAD_ENTRY * thread_p, OID * oid,
 					     HEAP_SCANCACHE * scan_cache, int ispeeking, int old_chn,
 					     MVCC_REEV_DATA * mvcc_reev_data,
 					     NON_EXISTENT_HANDLING non_ex_handling_type,
-					     HEAP_OOS_EXPAND_POLICY oos_expand_policy)
+					     HEAP_RECDES_CONSUMPTION_POLICY recdes_consumption_policy)
 {
   HEAP_GET_CONTEXT context;
   SCAN_CODE scan = S_SUCCESS;
@@ -13330,7 +13338,8 @@ locator_lock_and_get_object_with_evaluation (THREAD_ENTRY * thread_p, OID * oid,
 	  return S_ERROR;
 	}
     }
-  heap_init_get_context (thread_p, &context, oid, class_oid, recdes, scan_cache, ispeeking, old_chn, oos_expand_policy);
+  heap_init_get_context (thread_p, &context, oid, class_oid, recdes, scan_cache, ispeeking, old_chn,
+			 recdes_consumption_policy);
 
   /* get class_oid if it is unknown */
   if (OID_ISNULL (class_oid))
@@ -13427,7 +13436,7 @@ exit:
  * op_type (in)	  : Requested type of operation.
  * lock_mode (in) : Lock type, see note.
  * ispeeking (in) : Peek record or copy.
- * oos_expand_policy (in) : Whether to expand inline OOS values in the returned recdes.
+ * recdes_consumption_policy (in) : Whether the caller consumes the returned raw RECDES bytes.
  *
  * Note: This function should be used when class_oid is unknown, which is required to decide lock_mode;
  *       When lock_mode is known, a more appropriate function is recommended.
@@ -13439,7 +13448,7 @@ exit:
 SCAN_CODE
 locator_get_object (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid, RECDES * recdes,
 		    HEAP_SCANCACHE * scan_cache, SCAN_OPERATION_TYPE op_type, LOCK lock_mode, int ispeeking, int chn,
-		    HEAP_OOS_EXPAND_POLICY oos_expand_policy)
+		    HEAP_RECDES_CONSUMPTION_POLICY recdes_consumption_policy)
 {
   SCAN_CODE scan_code;
   OID class_oid_local = OID_INITIALIZER;
@@ -13465,7 +13474,8 @@ locator_get_object (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid, R
 	}
     }
 
-  heap_init_get_context (thread_p, &context, oid, class_oid, recdes, scan_cache, ispeeking, chn, oos_expand_policy);
+  heap_init_get_context (thread_p, &context, oid, class_oid, recdes, scan_cache, ispeeking, chn,
+			 recdes_consumption_policy);
 
   /* get class_oid if it is unknown */
   if (OID_ISNULL (class_oid))
@@ -13547,12 +13557,13 @@ locator_get_object (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid, R
  * (obsolete) non_ex_handling_type (in): - LOG_ERROR_IF_DELETED: write the
  *				ER_HEAP_UNKNOWN_OBJECT error to log
  *                            - LOG_WARNING_IF_DELETED: set only warning
- * oos_expand_policy (in) : Whether to expand inline OOS values in the returned recdes.
+ * recdes_consumption_policy (in) : Whether the caller consumes the returned raw RECDES bytes.
  */
 SCAN_CODE
 locator_lock_and_get_object (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid, RECDES * recdes,
 			     HEAP_SCANCACHE * scan_cache, LOCK lock, int ispeeking, int old_chn,
-			     NON_EXISTENT_HANDLING non_ex_handling_type, HEAP_OOS_EXPAND_POLICY oos_expand_policy)
+			     NON_EXISTENT_HANDLING non_ex_handling_type,
+			     HEAP_RECDES_CONSUMPTION_POLICY recdes_consumption_policy)
 {
   HEAP_GET_CONTEXT context;
   SCAN_CODE scan_code;
@@ -13566,7 +13577,8 @@ locator_lock_and_get_object (THREAD_ENTRY * thread_p, const OID * oid, OID * cla
 	}
     }
 
-  heap_init_get_context (thread_p, &context, oid, class_oid, recdes, scan_cache, ispeeking, old_chn, oos_expand_policy);
+  heap_init_get_context (thread_p, &context, oid, class_oid, recdes, scan_cache, ispeeking, old_chn,
+			 recdes_consumption_policy);
   scan_code = locator_lock_and_get_object_internal (thread_p, &context, lock);
   heap_clean_get_context (thread_p, &context);
   return scan_code;
@@ -13802,7 +13814,7 @@ locator_mvcc_reeval_scan_filters (THREAD_ENTRY * thread_p, const OID * oid, HEAP
       scan_cache_inited = true;
       scan_code =
 	heap_get_visible_version (thread_p, oid_inst, NULL, recdesp, &local_scan_cache, PEEK, NULL_CHN,
-				  HEAP_WITH_OOS_EXPAND);
+				  HEAP_RECDES_CONSUME_RAW_BYTES);
       if (scan_code != S_SUCCESS)
 	{
 	  ev_res = V_ERROR;

--- a/src/transaction/locator_sr.h
+++ b/src/transaction/locator_sr.h
@@ -116,16 +116,16 @@ extern int locator_rv_redo_rename (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 extern SCAN_CODE locator_lock_and_get_object (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid,
 					      RECDES * recdes, HEAP_SCANCACHE * scan_cache, LOCK lock, int ispeeking,
 					      int old_chn, NON_EXISTENT_HANDLING non_ex_handling_type,
-					      HEAP_OOS_EXPAND_POLICY oos_expand_policy);
+					      HEAP_RECDES_CONSUMPTION_POLICY recdes_consumption_policy);
 extern SCAN_CODE locator_lock_and_get_object_with_evaluation (THREAD_ENTRY * thread_p, OID * oid, OID * class_oid,
 							      RECDES * recdes, HEAP_SCANCACHE * scan_cache,
 							      int ispeeking, int old_chn,
 							      MVCC_REEV_DATA * mvcc_reev_data,
 							      NON_EXISTENT_HANDLING non_ex_handling_type,
-							      HEAP_OOS_EXPAND_POLICY oos_expand_policy);
+							      HEAP_RECDES_CONSUMPTION_POLICY recdes_consumption_policy);
 extern SCAN_CODE locator_get_object (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid, RECDES * recdes,
 				     HEAP_SCANCACHE * scan_cache, SCAN_OPERATION_TYPE op_type, LOCK lock_mode,
-				     int ispeeking, int chn, HEAP_OOS_EXPAND_POLICY oos_expand_policy);
+				     int ispeeking, int chn, HEAP_RECDES_CONSUMPTION_POLICY recdes_consumption_policy);
 extern SCAN_OPERATION_TYPE locator_decide_operation_type (LOCK lock_mode, LC_FETCH_VERSION_TYPE fetch_version_type);
 extern LOCK locator_get_lock_mode_from_op_type (SCAN_OPERATION_TYPE op_type);
 

--- a/src/transaction/locator_sr.h
+++ b/src/transaction/locator_sr.h
@@ -115,15 +115,17 @@ extern int locator_rv_redo_rename (THREAD_ENTRY * thread_p, LOG_RCV * rcv);
 
 extern SCAN_CODE locator_lock_and_get_object (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid,
 					      RECDES * recdes, HEAP_SCANCACHE * scan_cache, LOCK lock, int ispeeking,
-					      int old_chn, NON_EXISTENT_HANDLING non_ex_handling_type);
+					      int old_chn, NON_EXISTENT_HANDLING non_ex_handling_type,
+					      HEAP_OOS_EXPAND_POLICY oos_expand_policy);
 extern SCAN_CODE locator_lock_and_get_object_with_evaluation (THREAD_ENTRY * thread_p, OID * oid, OID * class_oid,
 							      RECDES * recdes, HEAP_SCANCACHE * scan_cache,
 							      int ispeeking, int old_chn,
 							      MVCC_REEV_DATA * mvcc_reev_data,
-							      NON_EXISTENT_HANDLING non_ex_handling_type);
+							      NON_EXISTENT_HANDLING non_ex_handling_type,
+							      HEAP_OOS_EXPAND_POLICY oos_expand_policy);
 extern SCAN_CODE locator_get_object (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid, RECDES * recdes,
 				     HEAP_SCANCACHE * scan_cache, SCAN_OPERATION_TYPE op_type, LOCK lock_mode,
-				     int ispeeking, int chn);
+				     int ispeeking, int chn, HEAP_OOS_EXPAND_POLICY oos_expand_policy);
 extern SCAN_OPERATION_TYPE locator_decide_operation_type (LOCK lock_mode, LC_FETCH_VERSION_TYPE fetch_version_type);
 extern LOCK locator_get_lock_mode_from_op_type (SCAN_OPERATION_TYPE op_type);
 

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -5641,7 +5641,7 @@ lock_dump_resource (THREAD_ENTRY * thread_p, FILE * outfp, LK_RES * res_ptr)
 
 	      if (heap_get_visible_version
 		  (thread_p, &res_ptr->key.oid, &res_ptr->key.class_oid, &recdes, &scan_cache, PEEK,
-		   NULL_CHN, HEAP_WITH_OOS_EXPAND) == S_SUCCESS)
+		   NULL_CHN, HEAP_RECDES_CONSUME_RAW_BYTES) == S_SUCCESS)
 		{
 		  MVCC_REC_HEADER mvcc_rec_header;
 		  if (or_mvcc_get_header (&recdes, &mvcc_rec_header) == NO_ERROR)

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -5639,9 +5639,9 @@ lock_dump_resource (THREAD_ENTRY * thread_p, FILE * outfp, LK_RES * res_ptr)
 	    {
 	      RECDES recdes = RECDES_INITIALIZER;
 
-	      if (heap_get_visible_version_expand_oos
+	      if (heap_get_visible_version
 		  (thread_p, &res_ptr->key.oid, &res_ptr->key.class_oid, &recdes, &scan_cache, PEEK,
-		   NULL_CHN) == S_SUCCESS)
+		   NULL_CHN, HEAP_WITH_OOS_EXPAND) == S_SUCCESS)
 		{
 		  MVCC_REC_HEADER mvcc_rec_header;
 		  if (or_mvcc_get_header (&recdes, &mvcc_rec_header) == NO_ERROR)


### PR DESCRIPTION
https://jira.cubrid.org/browse/CBRD-27029

## 목적

OOS fetch가 opt-in 방식으로 변경된 뒤에도, heap fetch caller는 반환된 `RECDES` 의 raw byte를 직접 사용하는지 명시하지 않은 채 컴파일될 수 있었습니다. 이로 인해 OOS를 이해하지 못하는 consumer에게 OOS inline stub이 전달될 수 있었습니다.

OOS inline stub에는 실제 값이 아니라 서버 측 head OOS OID와 logical value length가 들어 있습니다. 이 stored-form record를 네트워크로 byte 단위 전송하거나 OOS를 모르는 decoder가 parse하면, consumer는 해당 OID를 Resolve할 수 없어 값을 잘못 읽을 수 있습니다. 대표적인 예가 `unloaddb` 입니다. `unloaddb` 는 `LC_COPYAREA` 로 raw record를 전달받아 `desc_disk_to_obj()` 로 parse합니다. 이 경로에 OOS inline stub이 노출되면서 큰 `BIT VARYING` 값이 `X''` 로 export되는 문제가 발생했습니다.

이 PR은 heap fetch caller가 반환된 record를 어떤 방식으로 소비하는지 명시하도록 변경합니다.

## AS-IS / TO-BE

| 구분 | 동작 |
|---|---|
| AS-IS | caller가 materialize된 value byte를 필요로 하는지 명시하지 않아도 record를 fetch할 수 있었습니다. 그 결과 raw consumer에는 OOS OID가 노출될 수 있었고, attribute 계층을 사용하는 consumer에서는 불필요한 record-level Expand가 발생할 수 있었습니다. |
| TO-BE | heap fetch API가 `HEAP_RECDES_CONSUMPTION_POLICY` 를 필수로 받습니다. 각 caller는 raw `RECDES` byte를 직접 사용하는지 명시하며, fetch 계층은 필요한 경우에만 OOS 값을 materialize합니다. |

## RECDES 소비 정책

```c
typedef enum
{
  HEAP_RECDES_CONSUMPTION_POLICY_INVALID = 0,
  HEAP_RECDES_CONSUME_RAW_BYTES,
  HEAP_RECDES_DONT_CONSUME_RAW_BYTES
} HEAP_RECDES_CONSUMPTION_POLICY;
```

- caller가 raw record byte를 전송, parse, 재삽입 또는 비교하는 경우 `HEAP_RECDES_CONSUME_RAW_BYTES` 를 사용합니다. fetch 계층이 OOS-backed attribute를 먼저 materialize하므로 OOS를 모르는 consumer에게 서버 측 OOS OID가 노출되지 않습니다.
- caller가 raw record body를 직접 사용하지 않거나 `heap_attrinfo_read_dbvalues()` 같은 OOS-aware attribute 계층을 통해 값을 읽는 경우 `HEAP_RECDES_DONT_CONSUME_RAW_BYTES` 를 사용합니다. stored record 형태를 유지하고 attribute 계층에서 필요한 값을 Resolve합니다.

네트워크 전송은 중요한 raw record 소비 사례이지만 유일한 사례는 아닙니다. 따라서 전송 방식이 아니라 caller의 소비 계약이 드러나도록 정책 이름을 정했습니다.

## 구현

- public heap fetch interface에 `HEAP_RECDES_CONSUMPTION_POLICY` 를 추가하고 `HEAP_GET_CONTEXT` 에 해당 정책을 저장하도록 변경했습니다.
- `*_expand_oos()` 와 `*_skip_expand_oos()` wrapper를 제거했습니다. 이제 caller가 새로 추가되거나 변경되면 compile time에 반드시 정책을 선택해야 합니다.
- 여러 용도로 사용되는 locator helper에도 정책을 전달해, 실제 consumer 경계에서 정책을 결정하도록 했습니다.
- raw `LC_COPYAREA`, catalog parsing, compact/reinsert, byte 비교 등의 경로에는 `HEAP_RECDES_CONSUME_RAW_BYTES` 를 지정했습니다.
- attribute 계층, scan/index, metadata, OID만 사용하는 경로에는 `HEAP_RECDES_DONT_CONSUME_RAW_BYTES` 를 지정했습니다.
- 단건 client fetch도 fetch-all과 동일하게 raw record를 materialize하도록 수정했습니다.

## 검증

- Debug GCC build 및 install을 완료했습니다.
- 설정된 CTest 23개를 모두 통과했습니다: 23/23.
- OOS SQL regression test `tc_CBRD26565_midxkey_oos_overflow.sql` 을 통과했습니다.
- source formatting과 `git diff --check` 를 통과했습니다.

기존에 확인된 medium suite 권한 관련 실패 6건(`fview1.sql`, `viewauth.sql`, `6980.sql`, `cat13.sql`, `6978.sql`, `6978_1.sql`)은 test revision 불일치로 분류했으며, 이 raw record 수정 범위에는 포함되지 않습니다.

상세 설계 자료: https://github.com/vimkim/my-cubrid-docs/blob/main/cbrd-27029/CBRD-27029-minimize-plan.md
