### PR TITLE
[CBRD-26907] Fix CDC missing UPDATE events for compressed CHAR/VARCHAR records

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -12930,13 +12930,34 @@ cdc_make_dml_loginfo (THREAD_ENTRY * thread_p, int trid, char *user, CDC_DML_TYP
 
       for (i = 0; i < attr_info.num_values; i++)
 	{
+	  db_make_null (&old_values[i]);
+	}
+
+      for (i = 0; i < attr_info.num_values; i++)
+	{
 	  heap_value = &attr_info.values[i];
 
 	  assert (heap_value->read_attrepr != NULL);
 
 	  oldval_deforder = heap_value->read_attrepr->def_order;
 
-	  memcpy (&old_values[oldval_deforder], &heap_value->dbvalue, sizeof (DB_VALUE));
+	  /* reading redo_recdes below reuses attr_info and clears each dbvalue, which frees any buffer
+	   * the dbvalue owns (e.g. the decompressed buffer of a compressed string).
+	   * So the old value must be deep-copied here, not shallow-copied. */
+	  (void) pr_clone_value (&heap_value->dbvalue, &old_values[oldval_deforder]);
+
+	  /* pr_clone_value () returns NO_ERROR even when its internal setval fails (e.g. allocation failure)
+	   * and leaves the clone NULL. Do not pack a NULL old value silently; treat it as an error. */
+	  if (!DB_IS_NULL (&heap_value->dbvalue) && DB_IS_NULL (&old_values[oldval_deforder]))
+	    {
+	      error_code = er_errid ();
+	      if (error_code == NO_ERROR)
+		{
+		  error_code = ER_FAILED;
+		}
+
+	      goto exit;
+	    }
 
 	  record_length += cdc_get_attribute_size (&heap_value->dbvalue);
 	}
@@ -13253,6 +13274,11 @@ exit:
 
   if (old_values != NULL)
     {
+      for (i = 0; i < attr_info.num_values; i++)
+	{
+	  pr_clear_value (&old_values[i]);
+	}
+
       free_and_init (old_values);
     }
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26907>

### Purpose

`enable_string_compression=y`(기본값)일 때, 압축 임계(255바이트)를 넘는 CHAR/VARCHAR 값을 가진 record의 **UPDATE 변경 이벤트만 CDC에서 누락**되는 문제를 수정한다. 같은 테이블의 INSERT / DELETE 이벤트는 정상 캡처되므로 결함이 즉시 드러나지 않고, CDC 기반 복제·감사·외부 연동에서 해당 UPDATE가 조용히 유실되어 소스-타깃 불일치가 누적된다.

- 재현(11.4): `varchar(2048)` 컬럼을 2048바이트로 채워 압축을 유발한 뒤 UPDATE 하면 이벤트가 누락된다.
- `char(2048)` 은 11.4에서는 고정 길이 저장이라 압축 경로를 타지 않아 노출되지 않지만, CBRD-26663(CHAR 가변 저장) 이후 버전에서는 동일 경로로 노출된다. 즉 타입이 아니라 **압축이 트리거**다.

### Implementation

**원인**

`cdc_make_dml_loginfo()` 는 UPDATE 이벤트 생성 시 하나의 `HEAP_CACHE_ATTRINFO` 로 undo record(변경 전) → redo record(변경 후)를 연속으로 읽는데, 변경 전 값들을 `old_values` 배열에 **DB_VALUE 를 memcpy 로 shallow copy** 해서 보관했다.

문제는 redo record 를 읽을 때 `heap_attrvalue_read()` 가 `pr_clear_value()` 로 기존 dbvalue 를 해제한다는 점이다. 압축된 문자열은 dbvalue 가 `db_private_alloc` 으로 할당된 압축 해제 버퍼를 소유(`need_clear=true`)하므로, 이 시점에 `old_values` 가 가리키던 버퍼가 **free 되어 dangling pointer** 가 된다. 직후 새 값의 해제 버퍼가 같은 크기로 재할당되면서 방금 free 된 블록을 그대로 돌려받아, old 와 new 가 **동일한 메모리(새 값 내용)** 를 가리키게 된다.

그 결과 `db_value_compare()` 가 old/new 를 "동일" 로 오판 → 변경 컬럼 0개 → `ER_CDC_IGNORE_LOG_INFO_INTERNAL` 로 UPDATE 이벤트가 조용히 버려진다.

- 비압축 문자열은 dbvalue 가 record 버퍼를 직접 참조(`need_clear=false`)해서 free 가 일어나지 않아 정상.
- INSERT / DELETE 는 record 를 한 번만 읽으므로 무관.

**수정**

- `old_values` 를 shallow memcpy 대신 `pr_clone_value()` 로 **deep copy** 하고, 배열은 `db_make_null()` 로 선초기화, exit 경로에서 원소별 `pr_clear_value()` 후 해제한다.
- `pr_clone_value()` 는 내부 `setval` 실패(할당 실패 등)를 삼키고 항상 `NO_ERROR` 를 반환하므로 반환값 검사는 무의미하다. 대신 **원본이 non-NULL 인데 클론이 NULL 이면 에러로 처리**하는 가드를 두어, 변경 전 값이 NULL 로 바뀐 채 조용히 패킹되는 것을 막는다.
- `new_values` 는 마지막 읽기 결과라 packing 완료까지 attr_info 가 버퍼를 소유하므로 기존 shallow copy 를 유지한다(clear 하지 않는 것이 이중 해제 방지 측면에서도 올바름).
- 같은 함수를 사용하는 flashback 경로도 동일하게 수정 효과를 받는다.

### Test

`supplemental_log=1` 로 생성한 DB에서 `CREATE TABLE t (id int, c <타입>(2048))` 후 INSERT 5건 → UPDATE 1문(5행 갱신) → DELETE 1문(5행 삭제)을 수행하고, CDC API(`cubrid_log_connect_server` / `cubrid_log_find_lsa` / `cubrid_log_extract`) 클라이언트로 DML 이벤트를 수집해 타입별 건수를 확인했다. 기대값은 INSERT 5 / UPDATE 5 / DELETE 5. 동일 소스에서 본 수정만 되돌린 빌드(BEFORE)와 적용한 빌드(AFTER)로 각각 실행했다.

| 구분 | 케이스 | 결과 (insert/update/delete) | UPDATE 무시 로그¹ |
|---|---|---|---|
| 수정 전 | 압축 ON + varchar(2048) | 5 / **0** / 5 — **FAIL** | **5건** |
| 수정 전 | 압축 ON + char(2048) | 5 / 5 / 5 — OK | 0 |
| 수정 전 | 압축 OFF + varchar / char | 5 / 5 / 5 — OK | 0 |
| 수정 후 | 압축 ON + varchar(2048) | 5 / **5** / 5 — **OK** | **0건** |
| 수정 후 | 나머지 3개 조합 | 5 / 5 / 5 — OK | 0 |

¹ 서버 에러 로그의 `ER_CDC_IGNORE_LOG_INFO_INTERNAL`(msg 1288, "변경 컬럼 없음" 오판으로 이벤트 skip) 발생 횟수. 수정 전 누락된 UPDATE 5건과 정확히 일치하며, 수정 후 0건으로 원인 분석을 로그 레벨에서 뒷받침한다.

- 수정 전에도 char(2048) 이 통과하는 것은 11.4의 CHAR 가 고정 길이 저장(압축 미적용)이기 때문이며, 발견 TC(`cbrd_23842_cdc` delete06, char 기반)는 CBRD-26663 이 포함된 버전에서 노출된다.
- UPDATE 이벤트의 변경 컬럼 데이터 길이(2048)로 값 복원도 확인했다.

### Remarks

- develop 반영 시에는 CBRD-26663 으로 인해 `char(2048)` 로도 재현되므로 두 타입 모두 검증이 필요하다.
- 구조적 대안으로 undo/redo 를 각각 별도 `HEAP_CACHE_ATTRINFO` 로 읽는 방식(`locator_sr.c` 의 `xlocator_update_index` 가 old/new 이중 읽기에 사용하는 관례)이 있다. aliasing 자체가 사라져 deep copy 가 불필요해지므로 develop 포워드포트 시 검토할 만하다. 본 PR 은 release 브랜치 패치 특성상 최소 변경을 택했다.
