### PR TITLE
[CBRD-27010] Fix release/11.4 build break left by #7406 squash-merge

### DIFF
--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -3501,17 +3501,6 @@ do_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
     }
 
 end:
-  /* release the class info reserved for supplemental logging; entries consumed by do_supplemental_statement are
-   * already freed and cleared (free_and_init), so this only frees what is left (e.g. a failed DROP skips the call) */
-  if (cls_info[0] != NULL)
-    {
-      int i = 0;
-
-      while (cls_info[i] != NULL)
-	{
-	  free_and_init (cls_info[i++]);
-	}
-    }
 
   /* restore old read fetch instance version */
   db_set_read_fetch_instance_version (read_fetch_instance_version);
@@ -4199,17 +4188,6 @@ do_execute_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
 
 end:
 
-  /* release the class info reserved for supplemental logging; entries consumed by do_supplemental_statement are
-   * already freed and cleared (free_and_init), so this only frees what is left (e.g. a failed DROP skips the call) */
-  if (cls_info[0] != NULL)
-    {
-      int i = 0;
-
-      while (cls_info[i] != NULL)
-	{
-	  free_and_init (cls_info[i++]);
-	}
-    }
 
   /* restore old read fetch instance version */
   db_set_read_fetch_instance_version (read_fetch_instance_version);


### PR DESCRIPTION
The squash-merge of PR #7406 (commit e4515134) onto `release/11.4` dropped the hunk that removed the old `cls_info[]` cleanup blocks. A concurrently merged change (CBRD-26993, #7400) had modified the same `end:` region, and the conflict was resolved by keeping the stale blocks — so `release/11.4` HEAD does not compile.

## Problem

#7406 replaced the local `RESERVED_CLASS_INFO *cls_info[64]` array with the `RESERVED_CLASS_INFO_LIST reserved_cls_info` wrapper and centralized cleanup in `do_free_reserved_classinfo()`. But the leftover cleanup blocks at the `end:` labels of `do_statement()` and `do_execute_statement()` still reference the removed variable:

```c
end:
  if (cls_info[0] != NULL)                 // cls_info no longer exists here
    { while (cls_info[i] != NULL) free_and_init (cls_info[i++]); }
  ...
  do_free_reserved_classinfo (reserved_cls_info);   // actual cleanup already here
```

Because `src/storage/system_catalog.h` typedefs `struct cls_info`, the C++ build (`cubridsa`/`cubridcs`) parses `cls_info[0]` as subscripting a *type* and fails:

```
execute_statement.c:3506: error: expected primary-expression before ‘[’ token
   if (cls_info[0] != NULL)
```

## Fix

Remove the two dead blocks. `do_free_reserved_classinfo(reserved_cls_info)` already frees the reserved class info on every path, so this is dead, non-compiling code only — it matches the intended final state of the #7406 head branch (`37aca6958`), which built cleanly. No behavior change.

## Test

- 64-bit debug build succeeds (previously failed at `execute_statement.c.o`).
- CDC durability harness runs to completion against a `supplemental_log=2` server; multi-target DROP handling from #7406 is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)