### PR TITLE
[CBRD-27022] Fix CDC client crash when extracting an empty log batch

### DIFF
--- a/src/api/cubrid_log.c
+++ b/src/api/cubrid_log.c
@@ -1755,8 +1755,8 @@ cubrid_log_extract (uint64_t * lsa, CUBRID_LOG_ITEM ** log_item_list, int *list_
       *log_item_list = NULL;
       *list_size = 0;
     }
-  else if ((rc = cubrid_log_make_log_item_list (num_infos, total_length, log_item_list, list_size)) != CUBRID_LOG_SUCCESS
-	   && rc != CUBRID_LOG_SUCCESS_WITH_NO_LOGITEM)
+  else if ((rc = cubrid_log_make_log_item_list (num_infos, total_length, log_item_list, list_size)) !=
+	   CUBRID_LOG_SUCCESS && rc != CUBRID_LOG_SUCCESS_WITH_NO_LOGITEM)
     {
       CUBRID_LOG_ERROR_HANDLING (rc, NULL);
     }

--- a/src/api/cubrid_log.c
+++ b/src/api/cubrid_log.c
@@ -1152,6 +1152,11 @@ cubrid_log_extract_internal (LOG_LSA * next_lsa, int *num_infos, int *total_leng
 	  CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_INVALID_LSA, "Input lsa is not valid (%lld|%d)\n", next_lsa->pageid,
 				     next_lsa->offset);
 	}
+      else
+	{
+	  CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_FAILED_EXTRACT,
+				     "Failed to extract log info metadata. reply code from server is %d\n", reply_code);
+	}
     }
 
   ptr = or_unpack_log_lsa (ptr, next_lsa);
@@ -1164,8 +1169,16 @@ cubrid_log_extract_internal (LOG_LSA * next_lsa, int *num_infos, int *total_leng
       free_and_init (recv_data);
     }
 
-  if (rc == CUBRID_LOG_SUCCESS_WITH_NO_LOGITEM)
+  if (*num_infos < 0 || *total_length < 0 || (*num_infos > 0 && *total_length <= 0))
     {
+      CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_FAILED_EXTRACT,
+				 "Invalid log info metadata. num_infos (%d), total_length (%d)\n", *num_infos,
+				 *total_length);
+    }
+
+  if (*num_infos == 0)
+    {
+      rc = CUBRID_LOG_SUCCESS_WITH_NO_LOGITEM;
       goto cubrid_log_end;
     }
 
@@ -1630,6 +1643,20 @@ cubrid_log_make_log_item_list (int num_infos, int total_length, CUBRID_LOG_ITEM 
       CUBRID_LOG_WRITE_TRACELOG ("[INPUT] num_infos (%d), total_length (%d)\n", num_infos, total_length);
     }
 
+  if (num_infos <= 0)
+    {
+      *log_item_list = NULL;
+      *list_size = 0;
+      return CUBRID_LOG_SUCCESS_WITH_NO_LOGITEM;
+    }
+
+  if (total_length <= 0)
+    {
+      CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_FAILED_EXTRACT,
+				 "Invalid log item list metadata. num_infos (%d), total_length (%d)\n", num_infos,
+				 total_length);
+    }
+
   if (g_log_items_count < num_infos)
     {
       CUBRID_LOG_ITEM *tmp_log_items = NULL;
@@ -1718,12 +1745,18 @@ cubrid_log_extract (uint64_t * lsa, CUBRID_LOG_ITEM ** log_item_list, int *list_
 
   rc = cubrid_log_extract_internal (&g_next_lsa, &num_infos, &total_length);
 
-  if (rc != CUBRID_LOG_SUCCESS)
+  if (rc != CUBRID_LOG_SUCCESS && rc != CUBRID_LOG_SUCCESS_WITH_NO_LOGITEM)
     {
       CUBRID_LOG_ERROR_HANDLING (rc, NULL);
     }
 
-  if ((rc = cubrid_log_make_log_item_list (num_infos, total_length, log_item_list, list_size)) != CUBRID_LOG_SUCCESS)
+  if (rc == CUBRID_LOG_SUCCESS_WITH_NO_LOGITEM)
+    {
+      *log_item_list = NULL;
+      *list_size = 0;
+    }
+  else if ((rc = cubrid_log_make_log_item_list (num_infos, total_length, log_item_list, list_size)) != CUBRID_LOG_SUCCESS
+	   && rc != CUBRID_LOG_SUCCESS_WITH_NO_LOGITEM)
     {
       CUBRID_LOG_ERROR_HANDLING (rc, NULL);
     }
@@ -1737,7 +1770,7 @@ cubrid_log_extract (uint64_t * lsa, CUBRID_LOG_ITEM ** log_item_list, int *list_
       CUBRID_LOG_WRITE_TRACELOG ("[OUTPUT] lsa (%lld), list_size (%d)\n", *lsa, *list_size);
     }
 
-  return CUBRID_LOG_SUCCESS;
+  return rc;
 
 cubrid_log_error:
 

--- a/src/api/cubrid_log.c
+++ b/src/api/cubrid_log.c
@@ -1770,7 +1770,7 @@ cubrid_log_extract (uint64_t * lsa, CUBRID_LOG_ITEM ** log_item_list, int *list_
       CUBRID_LOG_WRITE_TRACELOG ("[OUTPUT] lsa (%lld), list_size (%d)\n", *lsa, *list_size);
     }
 
-  return rc;
+  return CUBRID_LOG_SUCCESS;
 
 cubrid_log_error:
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27022>

### Purpose

CDC 클라이언트가 추출할 로그 아이템이 없는 구간에서 `cubrid_log_extract()`를 호출하면 클라이언트 프로세스가 SIGSEGV로 종료될 수 있다.

서버가 정상 응답으로 빈 배치(`num_infos=0`, `total_length=0`)를 반환하는 경우, 클라이언트는 이를 "새 로그 없음"으로 처리해야 한다. 그러나 기존 구현은 빈 배치도 일반 로그 리스트로 구성하려고 하면서 `g_log_items[num_infos - 1]`에 접근한다. `num_infos`가 0이면 `g_log_items[-1]` 접근이 되어, 첫 추출에서는 즉시 SIGSEGV가 발생하고 이전 추출로 버퍼가 이미 할당된 경우에는 힙 영역 앞쪽을 오염시킬 수 있다.

이 PR은 빈 배치를 정상 성공으로 처리하고 `log_item_list=NULL`, `list_size=0`으로 반환하여, idle 상태를 polling하는 CDC 클라이언트가 크래시하지 않도록 한다.

### Implementation

`src/api/cubrid_log.c`의 CDC 추출 클라이언트 경로를 다음과 같이 수정한다.

1. `cubrid_log_extract_internal()`에서 서버 metadata 응답을 unpack한 뒤, 빈 배치(`num_infos == 0`)를 감지하면 내부적으로 `CUBRID_LOG_SUCCESS_WITH_NO_LOGITEM`을 반환한다.

2. `cubrid_log_make_log_item_list()` 초입에 방어 코드를 추가하여, `num_infos <= 0`이면 리스트를 만들지 않고 다음 값을 설정한다.

   ```text
   log_item_list = NULL
   list_size = 0
   ```

3. `cubrid_log_extract()`에서 빈 배치는 에러가 아닌 정상 성공으로 처리한다. 외부 반환값은 기존 성공 규약인 `CUBRID_LOG_SUCCESS`를 유지하고, 호출자는 `list_size == 0` 또는 `log_item_list == NULL`로 새 로그가 없음을 알 수 있다.

4. 서버 `reply_code`가 알려진 CDC 에러가 아닌 경우 그대로 진행하지 않고 `CUBRID_LOG_FAILED_EXTRACT`로 반환하도록 하여, 잘못된 metadata로 후속 처리를 계속하지 않게 한다.

### Test

| 케이스 | 수정 전 | 수정 후 |
|---|---|---|
| 빈 배치 metadata 직접 검증 (`num_infos=0`, `total_length=0`) | `g_log_items[-1]` 접근으로 SIGSEGV | `return=0`, `log_item_list=NULL`, `list_size=0` |
| CDC consumer가 로그 리스트를 해제하기 전에 연속으로 `extract`를 반복 호출하는 내구성 시나리오 | 빈 배치 조건에서 클라이언트 크래시 가능 | W1 DML 부하 조건에서 200회 연속 추출 PASS, 클라이언트 크래시 없음 |

추가 확인:
- 수정 전/후 라이브러리 비교로 빈 배치 입력의 SIGSEGV 제거 확인
- `src/api/cubrid_log.c` code-style 확인
- `cubridcs` 타깃 debug 빌드 확인

### Remarks

- 공개 API 상수는 변경하지 않는다.
- `cubrid_log_extract()`의 성공 반환 규약은 기존과 동일하게 `CUBRID_LOG_SUCCESS`로 유지한다.
- 빈 배치는 에러가 아니므로 호출자는 반환값이 성공이고 `list_size == 0` 또는 `log_item_list == NULL`인 경우 다음 polling 주기로 넘어갈 수 있다.
