### PR TITLE
[CBRD-27022] Fix CDC client crash when extracting an empty log batch (foward-porting from 11.4)

### DIFF
--- a/src/api/cubrid_log.c
+++ b/src/api/cubrid_log.c
@@ -1760,7 +1760,7 @@ cubrid_log_extract (uint64_t * lsa, CUBRID_LOG_ITEM ** log_item_list, int *list_
       CUBRID_LOG_WRITE_TRACELOG ("[OUTPUT] lsa (%lld), list_size (%d)\n", *lsa, *list_size);
     }
 
-  return rc;
+  return CUBRID_LOG_SUCCESS;
 
 cubrid_log_error:
 

--- a/src/api/cubrid_log.c
+++ b/src/api/cubrid_log.c
@@ -1745,8 +1745,8 @@ cubrid_log_extract (uint64_t * lsa, CUBRID_LOG_ITEM ** log_item_list, int *list_
       *log_item_list = NULL;
       *list_size = 0;
     }
-  else if ((rc = cubrid_log_make_log_item_list (num_infos, total_length, log_item_list, list_size)) != CUBRID_LOG_SUCCESS
-	   && rc != CUBRID_LOG_SUCCESS_WITH_NO_LOGITEM)
+  else if ((rc = cubrid_log_make_log_item_list (num_infos, total_length, log_item_list, list_size)) !=
+	   CUBRID_LOG_SUCCESS && rc != CUBRID_LOG_SUCCESS_WITH_NO_LOGITEM)
     {
       CUBRID_LOG_ERROR_HANDLING (rc, NULL);
     }

--- a/src/api/cubrid_log.c
+++ b/src/api/cubrid_log.c
@@ -1146,6 +1146,11 @@ cubrid_log_extract_internal (LOG_LSA * next_lsa, int *num_infos, int *total_leng
 	  CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_INVALID_LSA, "Input lsa is not valid (%lld|%d)\n", next_lsa->pageid,
 				     next_lsa->offset);
 	}
+      else
+	{
+	  CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_FAILED_EXTRACT,
+				     "Failed to extract log info metadata. reply code from server is %d\n", reply_code);
+	}
     }
 
   ptr = or_unpack_log_lsa (ptr, next_lsa);
@@ -1158,8 +1163,16 @@ cubrid_log_extract_internal (LOG_LSA * next_lsa, int *num_infos, int *total_leng
       free_and_init (recv_data);
     }
 
-  if (rc == CUBRID_LOG_SUCCESS_WITH_NO_LOGITEM)
+  if (*num_infos < 0 || *total_length < 0 || (*num_infos > 0 && *total_length <= 0))
     {
+      CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_FAILED_EXTRACT,
+				 "Invalid log info metadata. num_infos (%d), total_length (%d)\n", *num_infos,
+				 *total_length);
+    }
+
+  if (*num_infos == 0)
+    {
+      rc = CUBRID_LOG_SUCCESS_WITH_NO_LOGITEM;
       goto cubrid_log_end;
     }
 
@@ -1620,6 +1633,20 @@ cubrid_log_make_log_item_list (int num_infos, int total_length, CUBRID_LOG_ITEM 
       CUBRID_LOG_WRITE_TRACELOG ("[INPUT] num_infos (%d), total_length (%d)\n", num_infos, total_length);
     }
 
+  if (num_infos <= 0)
+    {
+      *log_item_list = NULL;
+      *list_size = 0;
+      return CUBRID_LOG_SUCCESS_WITH_NO_LOGITEM;
+    }
+
+  if (total_length <= 0)
+    {
+      CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_FAILED_EXTRACT,
+				 "Invalid log item list metadata. num_infos (%d), total_length (%d)\n", num_infos,
+				 total_length);
+    }
+
   if (g_log_items_count < num_infos)
     {
       CUBRID_LOG_ITEM *tmp_log_items = NULL;
@@ -1708,12 +1735,18 @@ cubrid_log_extract (uint64_t * lsa, CUBRID_LOG_ITEM ** log_item_list, int *list_
 
   rc = cubrid_log_extract_internal (&g_next_lsa, &num_infos, &total_length);
 
-  if (rc != CUBRID_LOG_SUCCESS)
+  if (rc != CUBRID_LOG_SUCCESS && rc != CUBRID_LOG_SUCCESS_WITH_NO_LOGITEM)
     {
       CUBRID_LOG_ERROR_HANDLING (rc, NULL);
     }
 
-  if ((rc = cubrid_log_make_log_item_list (num_infos, total_length, log_item_list, list_size)) != CUBRID_LOG_SUCCESS)
+  if (rc == CUBRID_LOG_SUCCESS_WITH_NO_LOGITEM)
+    {
+      *log_item_list = NULL;
+      *list_size = 0;
+    }
+  else if ((rc = cubrid_log_make_log_item_list (num_infos, total_length, log_item_list, list_size)) != CUBRID_LOG_SUCCESS
+	   && rc != CUBRID_LOG_SUCCESS_WITH_NO_LOGITEM)
     {
       CUBRID_LOG_ERROR_HANDLING (rc, NULL);
     }
@@ -1727,7 +1760,7 @@ cubrid_log_extract (uint64_t * lsa, CUBRID_LOG_ITEM ** log_item_list, int *list_
       CUBRID_LOG_WRITE_TRACELOG ("[OUTPUT] lsa (%lld), list_size (%d)\n", *lsa, *list_size);
     }
 
-  return CUBRID_LOG_SUCCESS;
+  return rc;
 
 cubrid_log_error:
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27022>

forward-porting from 11.4 https://github.com/CUBRID/cubrid/pull/7420

### Purpose
- N/A

### Implementation
- N/A

### Remarks
- N/A