### PR TITLE
[CBRD-27023] Prevent CDC client crash on NULL extraction user

### DIFF
--- a/src/api/cubrid_log.c
+++ b/src/api/cubrid_log.c
@@ -530,7 +530,8 @@ cubrid_log_set_extraction_table (uint64_t * classoid_arr, int arr_size)
 int
 cubrid_log_set_extraction_user (char **user_arr, int arr_size)
 {
-  int i;
+  int i, j;
+  char **new_extraction_user = NULL;
 
   if (g_stage != CUBRID_LOG_STAGE_CONFIGURATION)
     {
@@ -542,17 +543,35 @@ cubrid_log_set_extraction_user (char **user_arr, int arr_size)
       return CUBRID_LOG_INVALID_USER_ARR_SIZE;
     }
 
-  g_extraction_user = (char **) malloc (sizeof (char *) * arr_size);
-  if (g_extraction_user == NULL)
+  for (i = 0; i < arr_size; i++)
+    {
+      if (user_arr[i] == NULL)
+	{
+	  return CUBRID_LOG_INVALID_USER;
+	}
+    }
+
+  new_extraction_user = (char **) malloc (sizeof (char *) * arr_size);
+  if (new_extraction_user == NULL)
     {
       return CUBRID_LOG_FAILED_MALLOC;
     }
 
   for (i = 0; i < arr_size; i++)
     {
-      g_extraction_user[i] = strdup (user_arr[i]);
+      new_extraction_user[i] = strdup (user_arr[i]);
+      if (new_extraction_user[i] == NULL)
+	{
+	  for (j = 0; j < i; j++)
+	    {
+	      free_and_init (new_extraction_user[j]);
+	    }
+	  free_and_init (new_extraction_user);
+	  return CUBRID_LOG_FAILED_MALLOC;
+	}
     }
 
+  g_extraction_user = new_extraction_user;
   g_extraction_user_count = arr_size;
 
   return CUBRID_LOG_SUCCESS;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27023>

### Purpose

CDC 클라이언트 API `cubrid_log_set_extraction_user()` 는 사용자 필터 배열의 포인터와 크기 조합만 검증하고, 배열 원소가 `NULL` 인지는 확인하지 않는다.

이 때문에 다음과 같이 사용자 배열 안에 `NULL` 원소가 포함되면, 서버 접속 전 configuration 단계 API 호출만으로도 `strdup(NULL)` 경로를 타고 클라이언트 프로세스가 SIGSEGV 로 종료된다.

```c
char *users[1] = { NULL };
cubrid_log_set_extraction_user (users, 1);
```

잘못된 인자는 CDC API의 정의된 에러 코드로 반환되어야 하므로, `NULL` 사용자 원소를 방어하여 호출자 프로세스가 비정상 종료되지 않도록 한다.

### Implementation

`src/api/cubrid_log.c` 의 `cubrid_log_set_extraction_user()` 에서 전역 설정 상태를 갱신하기 전에 입력 배열의 각 원소를 먼저 검증한다.

- `user_arr[i] == NULL` 인 경우 `CUBRID_LOG_INVALID_USER` 를 반환한다.
- 문자열 복사 중 `strdup()` 이 실패하면 이미 복사한 문자열과 임시 배열을 해제하고 `CUBRID_LOG_FAILED_MALLOC` 을 반환한다.
- 모든 검증과 복사가 성공한 뒤에만 `g_extraction_user` 와 `g_extraction_user_count` 를 갱신한다.

기존의 배열 포인터/크기 조합 검증(`CUBRID_LOG_INVALID_USER_ARR_SIZE`)은 그대로 유지한다.

### Test

| 케이스 | 결과 |
|---|---|
| 사용자 필터 배열에 `NULL` 원소 1개를 포함하여 `cubrid_log_set_extraction_user()` 호출 | SIGSEGV 없이 `CUBRID_LOG_INVALID_USER(-16)` 반환 |

서버 접속이 필요 없는 configuration 단계 API 단독 재현 케이스로 확인했다.

### Remarks

N/A
