### PR TITLE
[CBRD-27024] Fix CDC client SIGSEGV on NULL timestamp in cubrid_log_find_lsa()

### DIFF
--- a/src/api/cubrid_log.c
+++ b/src/api/cubrid_log.c
@@ -1044,7 +1044,8 @@ cubrid_log_find_lsa (time_t * timestamp, uint64_t * lsa)
 
   if (g_trace_log_level == 1)
     {
-      CUBRID_LOG_WRITE_TRACELOG ("[INPUT] stage (%d), timestamp (%lld)\n", g_stage, *timestamp);
+      CUBRID_LOG_WRITE_TRACELOG ("[INPUT] stage (%d), timestamp (%lld)\n", g_stage,
+				 timestamp ? (long long) *timestamp : 0LL);
     }
 
   if (g_stage != CUBRID_LOG_STAGE_PREPARATION)
@@ -1058,7 +1059,7 @@ cubrid_log_find_lsa (time_t * timestamp, uint64_t * lsa)
     {
       CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_INVALID_TIMESTAMP,
 				 "timestamp must be greater or equal than 0. Input timestamp is %s, and value is %lld\n",
-				 timestamp ? "not null" : "null", *timestamp);
+				 timestamp ? "not null" : "null", timestamp ? (long long) *timestamp : 0LL);
     }
 
   if (lsa == NULL)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27024>

### Purpose

`cubrid_log_find_lsa()` 는 `timestamp` 인자의 NULL 을 검사하지만, 검사에 걸렸을 때 실행되는
`CUBRID_LOG_ERROR_HANDLING` 매크로의 메시지 가변 인자에 `*timestamp` 가 들어 있다.
매크로는 내부적으로 `cubrid_log_tracelog()` 함수를 호출하므로, C 의 인자 평가 규칙상
`*timestamp` 는 함수 진입 전에 무조건 평가된다. 즉 **NULL 을 정상적으로 감지한 바로 그 분기에서
NULL 역참조가 일어나** `CUBRID_LOG_INVALID_TIMESTAMP(-9)` 반환 대신 클라이언트가 SIGSEGV 로
비정상 종료한다. tracelog 활성 여부와 무관하게 인자 평가는 호출 지점에서 일어나므로 항상 크래시한다.

tracelog(level 1) 를 켠 경우에는 함수 진입 직후의 `[INPUT]` 출력이 어떤 검증보다도 먼저
`*timestamp` 를 역참조하므로, 검사 지점에 도달하기도 전에 같은 크래시가 발생한다.

체크포인트 복원 실패 등으로 out 포인터를 준비하지 못한 CDC 데몬이 preparation 단계에서
즉사하는 형태로 나타난다. 참고로 같은 함수의 `lsa` NULL 검사는 메시지에서 역참조하지 않아
정상적으로 `-8` 을 반환한다.

### Implementation

두 역참조 지점 모두 `timestamp ? (long long) *timestamp : 0LL` 로 가드한다.
`[INPUT]` tracelog 는 입력을 그대로 기록한다는 의미를 유지하기 위해 이동하지 않고 가드만 적용했다.

**`src/api/cubrid_log.c` — `cubrid_log_find_lsa()`**

```diff
   if (g_trace_log_level == 1)
     {
-      CUBRID_LOG_WRITE_TRACELOG ("[INPUT] stage (%d), timestamp (%lld)\n", g_stage, *timestamp);
+      CUBRID_LOG_WRITE_TRACELOG ("[INPUT] stage (%d), timestamp (%lld)\n", g_stage,
+				 timestamp ? (long long) *timestamp : 0LL);
     }
```

```diff
   if (timestamp == NULL || *timestamp < 0)
     {
       CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_INVALID_TIMESTAMP,
 				 "timestamp must be greater or equal than 0. Input timestamp is %s, and value is %lld\n",
-				 timestamp ? "not null" : "null", *timestamp);
+				 timestamp ? "not null" : "null", timestamp ? (long long) *timestamp : 0LL);
     }
```

### Test

`cubrid_log.c` 만 수정 전 코드로 되돌린 빌드와 수정 빌드를 비교 검증했다.
(supplemental_log=2 DB 에 CDC 접속하여 preparation 단계 진입 후 호출)

| 케이스 | 수정 전 | 수정 후 |
|---|---|---|
| 이슈 Repro: connect 후 `find_lsa(NULL, &lsa)`, tracelog off | 10/10 SIGSEGV, backtrace 가 에러 처리 분기(`timestamp=0x0`)로 JIRA 와 동일 | 10/10 `rc=-9` 정상 반환 |
| tracelog level 1 + `find_lsa(NULL, &lsa)` | 검증 전 `[INPUT]` 역참조 지점 도달 | `rc=-9`, tracelog 에 `timestamp (0)` / `Input timestamp is null, and value is 0` 기록 |
| `find_lsa(&ts, NULL)` — 이웃 lsa 가드 회귀 | `rc=-8` | `rc=-8` 동일 |
| `find_lsa(&ts=-1, &lsa)` — 같은 분기의 non-NULL 경로 | `rc=-9` | `rc=-9`, 메시지에 실제 값 `value is -1` 출력 |

### Remarks

- CDC 데몬이 결과를 받을 포인터를 준비하지 못한 채 API 를 NULL 인자로 호출하는 상황을 검증하는
  TC 에서 발견되었다.
- 관련: CBRD-27022, CBRD-27023, CBRD-27025 (같은 검증에서 발견된 CDC 클라이언트 라이브러리 크래시 계열)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
