### PR TITLE
[CBRD-27025] Reject port 0 in CDC log server connection

### DIFF
--- a/src/api/cubrid_log.c
+++ b/src/api/cubrid_log.c
@@ -884,7 +884,7 @@ cubrid_log_connect_server (char *host, int port, char *dbname, char *user, char 
       CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_INVALID_HOST, "host must not be null\n");
     }
 
-  if (port < 0 || port > USHRT_MAX)
+  if (port <= 0 || port > USHRT_MAX)
     {
       CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_INVALID_PORT,
 				 "invalid port number : %d, port must be greater than 0 and less than %d\n", port,


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27025>

### Purpose

CDC API `cubrid_log_connect_server()` 는 포트 번호가 0보다 커야 한다고 안내하지만,
실제 검증식은 `port < 0` 만 거부하여 `port == 0` 을 통과시키고 있었다.

이 값이 하위 TCP 접속 경로까지 내려가면 debug 빌드에서는 `assert(port > 0)` 에 걸려
CDC 클라이언트 프로세스가 `CUBRID_LOG_INVALID_PORT(-11)` 를 반환하지 못하고 abort 된다.

외부 입력에 대한 포트 범위 검증은 CDC API 경계에서 끝나야 하므로,
포트 0을 명시적으로 invalid port 로 거부하도록 수정한다.

### Implementation

`src/api/cubrid_log.c` 의 `cubrid_log_connect_server()` 포트 검증 조건을 에러 메시지와 일치시켰다.

```diff
-  if (port < 0 || port > USHRT_MAX)
+  if (port <= 0 || port > USHRT_MAX)
```

이를 통해 포트 0 입력이 하위 TCP 접속 계층의 assert 경로로 내려가지 않고,
기존 에러 처리 경로에서 `CUBRID_LOG_INVALID_PORT(-11)` 로 반환된다.

### Test

| 케이스 | 결과 |
|---|---|
| CDC 로그 서버 접속 API에 포트 0을 전달하는 경계값 TC | abort 없이 `CUBRID_LOG_INVALID_PORT(-11)` 반환 |

### Remarks

N/A
