### PR TITLE
[CBRD-27026] Fix CDC localhost connections to honor explicit ports

### DIFF
--- a/src/connection/tcp.c
+++ b/src/connection/tcp.c
@@ -370,10 +370,11 @@ css_sockaddr (const char *host, int port, struct sockaddr *saddr, socklen_t * sl
 
   /*
    * Compare with the TCP address with localhost.
-   * If it is, use Unix domain socket rather than TCP for the performance
+   * If it is and the requested port is the local master port, use Unix domain socket rather than TCP for the
+   * performance. Otherwise, keep the explicitly requested port by using TCP.
    */
   memcpy ((void *) &in_addr, (void *) &tcp_saddr.sin_addr, sizeof (in_addr));
-  if (in_addr == inet_addr ("127.0.0.1"))
+  if (in_addr == inet_addr ("127.0.0.1") && port == prm_get_master_port_id ())
     {
       memset ((void *) &unix_saddr, 0, sizeof (unix_saddr));
       unix_saddr.sun_family = AF_UNIX;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27026>

### Purpose

CDC API `cubrid_log_connect_server()` 는 호출자가 전달한 `host` 와 `port` 로 서버에 접속해야 한다.

하지만 `host` 가 `localhost` 또는 `127.0.0.1` 로 해석되는 경우, 공통 접속 계층에서 TCP 대신 Unix domain socket 경로를 사용한다. 이 경로는 API 인자로 받은 `port` 가 아니라 클라이언트 환경의 `cubrid_port_id` 로 결정되므로, 호출자가 실제로 떠 있지 않은 포트를 지정해도 로컬 master 의 socket 으로 접속되어 성공할 수 있었다.

이로 인해 한 장비에 여러 CUBRID 설치본 또는 여러 포트의 환경이 공존할 때, CDC consumer 가 명시한 포트가 아닌 다른 로컬 서버에 연결될 수 있다.

### Implementation

`src/connection/tcp.c` 의 localhost → Unix domain socket 최적화 조건에 요청 포트 검사를 추가한다.

```diff
-  if (in_addr == inet_addr ("127.0.0.1"))
+  if (in_addr == inet_addr ("127.0.0.1") && port == prm_get_master_port_id ())
```

이제 요청 포트가 클라이언트 설정의 master port 와 일치할 때만 기존 Unix domain socket fast path 를 사용한다. 요청 포트가 다르면 TCP 주소를 그대로 사용하므로, 호출자가 명시한 포트의 의미가 유지된다.

### Test

| 케이스 | 결과 |
|---|---|
| CDC 접속 가능 서버를 설정된 master port 로 기동한 뒤 `localhost:<master port>` 로 접속 | SUCCESS |
| 같은 환경에서 아무 프로세스도 듣지 않는 `localhost:<unused port>` 로 CDC 접속 시도 | `CUBRID_LOG_FAILED_CONNECT(-10)` |
| 같은 unused port 를 `127.0.0.1:<unused port>` 로 CDC 접속 시도 | `CUBRID_LOG_FAILED_CONNECT(-10)` |

명시 포트가 없는 로컬 socket 으로 우회되지 않고, 호출자가 지정한 포트 기준으로 접속 실패가 반환되는 것을 확인했다.

### Remarks

기존 localhost Unix domain socket 최적화는 master port 로 접속하는 경우에만 유지된다.
