### PR TITLE
[CBRD-27027] Return cause-specific error codes for CDC connect failures

### DIFF
--- a/src/api/cubrid_log.c
+++ b/src/api/cubrid_log.c
@@ -46,6 +46,7 @@
 #include "connection_cl.h"
 #include "connection_list_cl.h"
 #include "cubrid_log.h"
+#include "error_code.h"
 #include "log_lsa.hpp"
 #include "network.h"
 #include "object_representation.h"
@@ -798,11 +799,44 @@ cubrid_log_error:
   return err_code;
 }
 
+/* er_errid () is overwritten with ER_BO_CONNECT_FAILED at the end of every connect failure path
+ * (boot_client_initialize_css), so the cause of a db_restart () failure must be taken from its
+ * return value. The CUBRID_LOG_FAILED_CONNECT set mirrors the codes that boot_client_initialize_css
+ * classifies as connect errors. Unmapped errors keep CUBRID_LOG_FAILED_LOGIN so that authentication
+ * failures (e.g. ER_AU_INVALID_PASSWORD) are reported as before. */
+static int
+cubrid_log_map_connect_error (int error)
+{
+  switch (error)
+    {
+    case ERR_CSS_TCP_HOST_NAME_ERROR:
+      return CUBRID_LOG_INVALID_HOST;
+    case ER_BO_UNKNOWN_DATABASE:
+      return CUBRID_LOG_INVALID_DBNAME;
+    case ER_NET_SERVER_HAND_SHAKE:
+    case ER_NET_HS_UNKNOWN_SERVER_REL:
+    case ER_NET_DIFFERENT_RELEASE:
+    case ER_NET_NO_SERVER_HOST:
+    case ER_NET_CANT_CONNECT_SERVER:
+    case ER_NET_NO_MASTER:
+    case ER_NET_SERVER_CRASHED:
+    case ER_BO_CONNECT_FAILED:
+    case ERR_CSS_TCP_CANNOT_CONNECT_TO_MASTER:
+    case ERR_CSS_TCP_CONNECT_TIMEDOUT:
+    case ERR_CSS_ERROR_FROM_SERVER:
+    case ER_CSS_CLIENTS_EXCEEDED:
+      return CUBRID_LOG_FAILED_CONNECT;
+    default:
+      return CUBRID_LOG_FAILED_LOGIN;
+    }
+}
+
 static int
 cubrid_log_db_login (char *hostname, char *dbname, char *username, char *password)
 {
   MOP user;
   char dbname_at_hostname[CUB_MAXHOSTNAMELEN + CUBRID_LOG_MAX_DBNAME_LEN + 2] = { '\0', };
+  int restart_error, err_code;
 
   snprintf (dbname_at_hostname, sizeof (dbname_at_hostname), "%s@%s", dbname, hostname);
 
@@ -812,11 +846,13 @@ cubrid_log_db_login (char *hostname, char *dbname, char *username, char *passwor
       goto error;
     }
 
-  if (db_restart ("cubrid_log_api", 0, dbname_at_hostname) != NO_ERROR)
+  restart_error = db_restart ("cubrid_log_api", 0, dbname_at_hostname);
+  if (restart_error != NO_ERROR)
     {
-      cubrid_log_tracelog (__FILE__, __LINE__, __func__, true, CUBRID_LOG_FAILED_LOGIN,
-			   "db_restart failed to connect to %s\n", dbname_at_hostname);
-      return CUBRID_LOG_FAILED_LOGIN;
+      err_code = cubrid_log_map_connect_error (restart_error);
+      cubrid_log_tracelog (__FILE__, __LINE__, __func__, true, err_code,
+			   "db_restart failed to connect to %s (error = %d)\n", dbname_at_hostname, restart_error);
+      return err_code;
     }
 
   user = au_find_user (username);
@@ -901,9 +937,10 @@ cubrid_log_connect_server (char *host, int port, char *dbname, char *user, char 
       CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_INVALID_PASSWORD, "password must not be null\n");
     }
 
-  if (cubrid_log_db_login (host, dbname, user, password) != CUBRID_LOG_SUCCESS)
+  err_code = cubrid_log_db_login (host, dbname, user, password);
+  if (err_code != CUBRID_LOG_SUCCESS)
     {
-      CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_FAILED_LOGIN, NULL);
+      CUBRID_LOG_ERROR_HANDLING (err_code, NULL);
     }
 
   if (er_init (NULL, ER_NEVER_EXIT) != NO_ERROR)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27027>

### Purpose

CDC API `cubrid_log_connect_server()` 는 접속 실패 원인별 에러 코드(`CUBRID_LOG_FAILED_CONNECT(-10)`, `CUBRID_LOG_INVALID_HOST(-12)`, `CUBRID_LOG_INVALID_DBNAME(-13)`)를 헤더에 정의하고 있지만, 실제 네트워크 접속이 처음 일어나는 `cubrid_log_db_login()` 의 실패를 호출부가 원인 구분 없이 `CUBRID_LOG_FAILED_LOGIN(-33)` 으로 일괄 변환한다.

그 결과 호스트명 해석 실패, 서버 미기동/접속 거부, 존재하지 않는 DB 이름이 전부 -33(로그인 실패)으로 반환되어, 실제 원인이 방화벽/호스트명 오타/서버 미기동인 경우에도 운영자가 계정과 비밀번호부터 점검하도록 오도된다. 세분 코드들은 런타임 접속 실패에서 사실상 도달 불가능했다.

### Implementation

`db_restart()` 실패 시 그 반환값을 원인별 CDC 에러 코드로 분류하는 `cubrid_log_map_connect_error()` 를 추가하고, `cubrid_log_db_login()` 이 매핑된 코드를 반환하며 `cubrid_log_connect_server()` 는 이를 그대로 전파한다.

```diff
-  if (cubrid_log_db_login (host, dbname, user, password) != CUBRID_LOG_SUCCESS)
+  err_code = cubrid_log_db_login (host, dbname, user, password);
+  if (err_code != CUBRID_LOG_SUCCESS)
     {
-      CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_FAILED_LOGIN, NULL);
+      CUBRID_LOG_ERROR_HANDLING (err_code, NULL);
     }
```

매핑 기준은 다음과 같다.

| db_restart() 반환 에러 | CDC 에러 코드 |
|---|---|
| `ERR_CSS_TCP_HOST_NAME_ERROR` | `CUBRID_LOG_INVALID_HOST(-12)` |
| `ER_BO_UNKNOWN_DATABASE` | `CUBRID_LOG_INVALID_DBNAME(-13)` |
| `boot_client_initialize_css()` 가 접속 에러로 분류하는 코드들 (`ER_NET_CANT_CONNECT_SERVER`, `ERR_CSS_TCP_CANNOT_CONNECT_TO_MASTER`, `ERR_CSS_TCP_CONNECT_TIMEDOUT`, `ER_NET_NO_MASTER` 등 12종) | `CUBRID_LOG_FAILED_CONNECT(-10)` |
| 그 외 (인증 실패 `ER_AU_INVALID_PASSWORD` 포함) | `CUBRID_LOG_FAILED_LOGIN(-33)` (기존 유지) |

이슈에서는 `er_errid()` 로 원인을 분류하는 방안을 제안했으나, 접속 실패 시 `boot_client_initialize_css()` 가 모든 실패 경로 마지막에 `er_set(ER_BO_CONNECT_FAILED)` 를 호출하여 er state 를 덮어쓰기 때문에 `er_errid()` 로는 원인을 구분할 수 없다. 반면 `db_restart()` 의 반환값은 하위 계층의 세분 코드를 그대로 보존하므로 반환값 기반으로 분류한다.

### Test

이슈의 재현 프로그램(repro_27027.c)으로 확인했다.

| 케이스 | 수정 전 | 수정 후 |
|---|---|---|
| 해석 불가능한 호스트명(`no.such.host.invalid.`)으로 접속 | -33 | `CUBRID_LOG_FAILED_CONNECT(-10)` |
| 존재하지 않는 DB 이름으로 접속 (master 기동 상태) | -33 | `CUBRID_LOG_FAILED_CONNECT(-10)` |
| 잘못된 비밀번호로 접속 (회귀) | -33 | -33 유지 |
| 정상 계정으로 접속 (회귀) | 0 | 0 유지 |

이슈의 기대 결과(bad host: -12 또는 -10, bad dbname: -13 또는 -10)를 충족한다.

### Remarks

매뉴얼의 CDC API 반환 코드 표에 -10/-12/-13 이 런타임 접속 실패에서 실제로 반환된다는 내용의 반영이 필요하다.
