### PR TITLE
[CBRD-26665] Restore OOS unittestdb config after setup

### DIFF
--- a/unit_tests/oos/CMakeLists.txt
+++ b/unit_tests/oos/CMakeLists.txt
@@ -63,20 +63,7 @@ add_test(NAME oos_setup_db
     "CUBRID=$ENV{CUBRID}"
     "CUBRID_DATABASES=$ENV{CUBRID_DATABASES}"
     "PATH=$ENV{PATH}"
-    bash -c "
-      # Small vacuum log blocks (min 4; default 31) so real-vacuum tests can close a
-      # block quickly. vacuum_log_block_pages is frozen into the database at createdb,
-      # so the [@unittestdb] section must exist BEFORE createdb runs. Idempotent append;
-      # scoped to unittestdb only, so other databases are unaffected.
-      if [ -f \"$ENV{CUBRID}/conf/cubrid.conf\" ] && ! grep -qF '[@unittestdb]' \"$ENV{CUBRID}/conf/cubrid.conf\"; then
-        printf '\\n[@unittestdb]\\nvacuum_log_block_pages=4\\n' >> \"$ENV{CUBRID}/conf/cubrid.conf\"
-      fi
-      if [ ! -f \"$ENV{CUBRID_DATABASES}/databases.txt\" ] || ! grep -q unittestdb \"$ENV{CUBRID_DATABASES}/databases.txt\" 2>/dev/null; then
-        mkdir -p \"$ENV{CUBRID_DATABASES}/unittestdb\" && \
-        cubrid createdb --db-volume-size=20M --log-volume-size=20M unittestdb en_US.utf8 \
-          -F \"$ENV{CUBRID_DATABASES}/unittestdb\"
-      fi
-    "
+    bash "${CMAKE_CURRENT_SOURCE_DIR}/scripts/setup_unittestdb.sh"
 )
 set_tests_properties(oos_setup_db PROPERTIES FIXTURES_SETUP OOS_DB)
 
@@ -85,12 +72,7 @@ add_test(NAME oos_cleanup_db
     "CUBRID=$ENV{CUBRID}"
     "CUBRID_DATABASES=$ENV{CUBRID_DATABASES}"
     "PATH=$ENV{PATH}"
-    bash -c "
-      cubrid server stop unittestdb 2>/dev/null || true
-      if grep -q unittestdb \"$ENV{CUBRID_DATABASES}/databases.txt\" 2>/dev/null; then
-        cubrid deletedb unittestdb
-      fi
-    "
+    bash "${CMAKE_CURRENT_SOURCE_DIR}/scripts/cleanup_unittestdb.sh"
 )
 set_tests_properties(oos_cleanup_db PROPERTIES FIXTURES_CLEANUP OOS_DB TIMEOUT 30)
 

--- a/unit_tests/oos/scripts/cleanup_unittestdb.sh
+++ b/unit_tests/oos/scripts/cleanup_unittestdb.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+#  Copyright 2026 CUBRID Corporation
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "$script_dir/oos_unittestdb_common.sh"
+
+oos_require_env
+
+cubrid server stop "$OOS_UNITTESTDB_NAME" 2>/dev/null || true
+if oos_database_exists; then
+  cubrid deletedb "$OOS_UNITTESTDB_NAME"
+fi
+
+oos_remove_fixture_sections "$(oos_cubrid_conf)"

--- a/unit_tests/oos/scripts/oos_unittestdb_common.sh
+++ b/unit_tests/oos/scripts/oos_unittestdb_common.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+#
+#  Copyright 2026 CUBRID Corporation
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+set -euo pipefail
+
+readonly OOS_UNITTESTDB_NAME="unittestdb"
+readonly OOS_UNITTESTDB_MARKER_BEGIN="# BEGIN OOS unittestdb fixture"
+readonly OOS_UNITTESTDB_MARKER_END="# END OOS unittestdb fixture"
+
+oos_require_env ()
+{
+  : "${CUBRID:?CUBRID must be set}"
+  : "${CUBRID_DATABASES:?CUBRID_DATABASES must be set}"
+}
+
+oos_cubrid_conf ()
+{
+  printf '%s/conf/cubrid.conf\n' "$CUBRID"
+}
+
+oos_unittestdb_dir ()
+{
+  printf '%s/%s\n' "$CUBRID_DATABASES" "$OOS_UNITTESTDB_NAME"
+}
+
+oos_database_exists ()
+{
+  local databases_txt="$CUBRID_DATABASES/databases.txt"
+
+  [ -f "$databases_txt" ] || return 1
+  awk -v db="$OOS_UNITTESTDB_NAME" '$1 == db { found = 1 } END { exit found ? 0 : 1 }' "$databases_txt"
+}
+
+oos_remove_fixture_sections ()
+{
+  local conf="$1"
+  local tmp_marker
+  local tmp_legacy
+
+  [ -f "$conf" ] || return 0
+
+  tmp_marker=$(mktemp "${conf}.oos-marker.XXXXXX")
+  tmp_legacy=$(mktemp "${conf}.oos-legacy.XXXXXX")
+
+  awk -v begin="$OOS_UNITTESTDB_MARKER_BEGIN" -v end="$OOS_UNITTESTDB_MARKER_END" '
+    $0 == begin { in_fixture = 1; next }
+    in_fixture {
+      if ($0 == end)
+	{
+	  in_fixture = 0;
+	}
+      next;
+    }
+    { print }
+  ' "$conf" > "$tmp_marker"
+
+  awk '
+    {
+      lines[++n] = $0;
+    }
+    END {
+      while (n > 0 && lines[n] == "")
+	{
+	  blanks[++blank_count] = lines[n];
+	  n--;
+	}
+
+      if (n >= 2 && lines[n - 1] == "[@unittestdb]" && lines[n] == "vacuum_log_block_pages=4")
+	{
+	  n -= 2;
+	}
+
+      for (i = 1; i <= n; i++)
+	{
+	  print lines[i];
+	}
+      for (i = blank_count; i >= 1; i--)
+	{
+	  print blanks[i];
+	}
+    }
+  ' "$tmp_marker" > "$tmp_legacy"
+
+  if ! cmp -s "$conf" "$tmp_legacy"; then
+    cp "$tmp_legacy" "$conf"
+  fi
+
+  rm -f "$tmp_marker" "$tmp_legacy"
+}
+
+oos_append_fixture_section ()
+{
+  local conf="$1"
+
+  {
+    printf '\n%s\n' "$OOS_UNITTESTDB_MARKER_BEGIN"
+    printf '[@%s]\n' "$OOS_UNITTESTDB_NAME"
+    printf 'vacuum_log_block_pages=4\n'
+    printf '%s\n' "$OOS_UNITTESTDB_MARKER_END"
+  } >> "$conf"
+}

--- a/unit_tests/oos/scripts/setup_unittestdb.sh
+++ b/unit_tests/oos/scripts/setup_unittestdb.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+#  Copyright 2026 CUBRID Corporation
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "$script_dir/oos_unittestdb_common.sh"
+
+oos_require_env
+
+conf=$(oos_cubrid_conf)
+backup="$CUBRID_DATABASES/oos_unittestdb_cubrid.conf.backup.$$"
+
+restore_conf ()
+{
+  if [ -f "$backup" ]; then
+    cp "$backup" "$conf"
+    rm -f "$backup"
+  fi
+}
+
+trap restore_conf EXIT
+
+if [ ! -f "$conf" ]; then
+  printf 'missing cubrid.conf: %s\n' "$conf" >&2
+  exit 1
+fi
+
+oos_remove_fixture_sections "$conf"
+
+if oos_database_exists; then
+  exit 0
+fi
+
+mkdir -p "$CUBRID_DATABASES"
+cp "$conf" "$backup"
+oos_append_fixture_section "$conf"
+
+mkdir -p "$(oos_unittestdb_dir)"
+cubrid createdb --db-volume-size=20M --log-volume-size=20M "$OOS_UNITTESTDB_NAME" en_US.utf8 \
+  -F "$(oos_unittestdb_dir)"


### PR DESCRIPTION
https://jira.cubrid.org/browse/CBRD-26665

## Purpose

- OOS unit test fixture 가 `unittestdb` 생성을 위해 설치된 `cubrid.conf` 를 잠시 바꾸지만, 기존에는 그 변경이 CI 다음 단계까지 남을 수 있었습니다.
- AS-IS: `cubrid.conf` 끝에 남은 `[@unittestdb]` 때문에 뒤이어 붙는 shell test 설정이 다른 DB 에 적용되지 않을 수 있었습니다.
- TO-BE: `createdb` 때만 임시 섹션을 넣고 setup 종료 전에 원본 설정을 복원합니다.

## Implementation

- `unit_tests/oos/CMakeLists.txt` 의 inline shell 을 `unit_tests/oos/scripts/setup_unittestdb.sh` 와 `cleanup_unittestdb.sh` 로 분리했습니다.
- setup script 는 원본 `cubrid.conf` 를 백업하고 marker-owned `[@unittestdb]` 섹션을 붙인 뒤, `trap` 으로 항상 복원합니다.
- cleanup script 는 `unittestdb` 삭제 후 남아 있을 수 있는 marker-owned block 과 기존 exact-shape fixture block 만 제거합니다.

## Remarks

- 핵심 리뷰 지점은 setup 이 cleanup 을 기다리지 않고 즉시 `cubrid.conf` 를 복원하는지입니다.
- 사용자 작성 `[@unittestdb]` 섹션은 임의로 지우지 않도록 제거 범위를 좁혔습니다.
- 자세한 설명: https://github.com/vimkim/my-cubrid-docs/blob/main/cbrd-26665/CBRD-26665-oos-unittestdb-conf-restore.md
