### PR TITLE
[CBRD-27025] Reject port 0 in CDC log server connection (foward-porting from 11.4)

### DIFF
--- a/src/api/cubrid_log.c
+++ b/src/api/cubrid_log.c
@@ -881,7 +881,7 @@ cubrid_log_connect_server (char *host, int port, char *dbname, char *user, char 
       CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_INVALID_HOST, "host must not be null\n");
     }
 
-  if (port < 0 || port > USHRT_MAX)
+  if (port <= 0 || port > USHRT_MAX)
     {
       CUBRID_LOG_ERROR_HANDLING (CUBRID_LOG_INVALID_PORT,
 				 "invalid port number : %d, port must be greater than 0 and less than %d\n", port,


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27025>

foward-porting from 11.4 https://github.com/CUBRID/cubrid/pull/7424

### Purpose

N/A

### Implementation

N/A

### Remarks

N/A
