### PR TITLE
[CBRD-27010] Add missing class guard for DROP supplemental log reservation

### DIFF
--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -15420,6 +15420,7 @@ do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLA
 
   const char *classname;
   DB_OBJECT *class_obj;
+  OID *class_oid;
 
   reserved_cls_info.cls_info = NULL;
   reserved_cls_info.num_classes = 0;
@@ -15448,19 +15449,45 @@ do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLA
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, cls_info_size);
 	  return ER_OUT_OF_VIRTUAL_MEMORY;
 	}
-      reserved_cls_info.num_classes = num_class;
+      reserved_cls_info.num_classes = 0;
 
       for (entity_spec = statement->info.drop.spec_list; entity_spec != NULL; entity_spec = entity_spec->next)
 	{
 	  RESERVED_CLASS_INFO & class_info = reserved_cls_info.cls_info[count];
 
 	  entity = entity_spec->info.spec.flat_entity_list;
+	  if (entity == NULL || entity->info.name.original == NULL)
+	    {
+	      assert (false);
+	      error = ER_FAILED;
+	      goto error_exit;
+	    }
+
 	  classname = entity->info.name.original;
 	  class_obj = db_find_class (classname);
+	  if (class_obj == NULL)
+	    {
+	      if (statement->info.drop.if_exists)
+		{
+		  er_clear ();
+		  continue;
+		}
+
+	      ERROR_SET_ERROR_1ARG (error, ER_LC_UNKNOWN_CLASSNAME, classname);
+	      goto error_exit;
+	    }
+
+	  class_oid = ws_oid (class_obj);
+	  if (class_oid == NULL)
+	    {
+	      assert (false);
+	      error = ER_FAILED;
+	      goto error_exit;
+	    }
 
 	  strcpy (class_info.name, classname);
 
-	  memcpy (&class_info.oid, ws_oid (class_obj), sizeof (OID));
+	  memcpy (&class_info.oid, class_oid, sizeof (OID));
 
 	  if (do_find_object_type (statement->info.drop.entity_type, classname, &class_info.objtype) != NO_ERROR)
 	    {
@@ -15472,6 +15499,8 @@ do_reserve_classinfo (PARSER_CONTEXT * parser, PT_NODE * statement, RESERVED_CLA
 
 	  count++;
 	}
+
+      reserved_cls_info.num_classes = count;
     }
 
   return NO_ERROR;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27010>

### Purpose

`supplemental_log=1` 환경에서 DROP 대상 class 정보를 미리 예약할 때,
`db_find_class()` 결과를 확인하지 않고 바로 `ws_oid()` / `memcpy()` 에 사용하고 있었다.

일반적인 `DROP TABLE IF EXISTS missing_table` 경로는 semantic check 단계에서 대상이 제거될 수 있지만,
`do_reserve_classinfo()` 자체는 DROP 실행 전에 supplemental log 용 정보를 수집하는 방어 경계이므로
class lookup 실패를 NULL dereference 로 처리해서는 안 된다.

특히 `IF EXISTS` 로 인해 실제 DROP 대상이 없거나 일부 대상만 존재하는 경우에는
존재하는 대상만 supplemental log 예약 대상으로 남기고, 없는 대상은 crash 없이 건너뛰어야 한다.

### Implementation

`do_reserve_classinfo()` 의 DROP reservation 경로에서 class lookup 결과를 명시적으로 검증한다.

1. `entity` 및 class name 이 없는 경우 invariant 위반으로 처리한다.
2. `db_find_class()` 가 `NULL` 을 반환하면:
   - `DROP ... IF EXISTS` 인 경우 해당 대상은 예약하지 않고 skip 한다.
   - `IF EXISTS` 가 아닌 경우 `ER_LC_UNKNOWN_CLASSNAME` 을 반환한다.
3. `ws_oid()` 결과를 별도 변수로 받아 NULL 여부를 확인한 뒤 OID 를 복사한다.
4. `IF EXISTS` 로 skip 된 대상이 있을 수 있으므로,
   `reserved_cls_info.num_classes` 는 최초 spec 개수가 아니라 실제로 채운 entry 개수로 갱신한다.

이렇게 하면 missing class 가 supplemental log entry 로 남지 않고,
존재하는 DROP 대상만 이후 `do_supplemental_statement()` 에서 처리된다.

### Remarks

기존 CBRD-27010 release/11.4 반영분에 대한 후속 방어 패치이다.
변경 범위는 DROP supplemental log reservation 의 NULL guard 및 실제 예약 개수 보정으로 한정된다.
