### PR TITLE
[CBRD-27041] page-copy 후 peek scan 방식을 도입하여 fixed_scan의 성능을 복구

### DIFF
--- a/src/query/parallel/px_scan/px_scan.cpp
+++ b/src/query/parallel/px_scan/px_scan.cpp
@@ -456,9 +456,9 @@ extern "C"
 
     /* By construction, mvcc_select_lock_needed is false here: the gate above (spec->curent == nullptr
      * branch) sets ACCESS_SPEC_FLAG_NO_PARALLEL_SCAN and returns early whenever it is true, and that
-     * flag persists across subsequent calls for the same spec (issue #154, critic gate 1 verification). */
-    bool page_copy_scan = qexec_is_page_copy_eligible (spec, scan_op_type, mvcc_select_lock_needed, fixed_scan,
-						       grouped_scan);
+     * flag persists across subsequent calls for the same spec. */
+    bool cached_scan = qexec_is_cached_scan_eligible (spec, scan_op_type, mvcc_select_lock_needed, fixed_scan,
+		       grouped_scan);
 
     scan_id->s.phsid.manager = nullptr;	/* init */
 
@@ -478,7 +478,8 @@ extern "C"
 	  }
 
 	scan_id->s.phsid.manager = placement_new ((manager_type *) scan_id->s.phsid.manager, thread_p, query_id, scan_id, xasl,
-				   num_parallel_threads, *class_hfid, *class_oid, vd, (bool) fixed_scan, (bool) grouped_scan, page_copy_scan, worker_manager_p);
+				   num_parallel_threads, *class_hfid, *class_oid, vd, (bool) fixed_scan, (bool) grouped_scan, cached_scan,
+				   worker_manager_p);
 	assert (scan_id->s.phsid.manager != nullptr);
 
 	error = ((manager_type *) scan_id->s.phsid.manager)->open ();
@@ -510,7 +511,8 @@ extern "C"
 	  }
 
 	scan_id->s.phsid.manager = placement_new ((manager_type *) scan_id->s.phsid.manager, thread_p, query_id, scan_id, xasl,
-				   num_parallel_threads, *class_hfid, *class_oid, vd, (bool) fixed_scan, (bool) grouped_scan, page_copy_scan, worker_manager_p);
+				   num_parallel_threads, *class_hfid, *class_oid, vd, (bool) fixed_scan, (bool) grouped_scan, cached_scan,
+				   worker_manager_p);
 	assert (scan_id->s.phsid.manager != nullptr);
 
 	error = ((manager_type *) scan_id->s.phsid.manager)->open ();
@@ -542,7 +544,8 @@ extern "C"
 	  }
 
 	scan_id->s.phsid.manager = placement_new ((manager_type *) scan_id->s.phsid.manager, thread_p, query_id, scan_id, xasl,
-				   num_parallel_threads, *class_hfid, *class_oid, vd, (bool) fixed_scan, (bool) grouped_scan, page_copy_scan, worker_manager_p);
+				   num_parallel_threads, *class_hfid, *class_oid, vd, (bool) fixed_scan, (bool) grouped_scan, cached_scan,
+				   worker_manager_p);
 	assert (scan_id->s.phsid.manager != nullptr);
 
 	error = ((manager_type *) scan_id->s.phsid.manager)->open ();
@@ -1803,7 +1806,7 @@ namespace parallel_scan
 	task_p = placement_new ((task<result_type, ST> *) task_p, m_thread_p, m_query_entry, m_result_handler,
 				m_input_handler, &m_interrupt, &m_err_messages, m_vd, trace_handler_p, m_worker_manager, m_xasl->header.id, m_hfid,
 				m_cls_oid, m_is_fixed,
-				m_is_grouped, m_is_page_copy_scan, m_uses_xasl_clone, m_xasl, &m_pre_execution_info);
+				m_is_grouped, m_is_cached_scan, m_uses_xasl_clone, m_xasl, &m_pre_execution_info);
 	m_worker_manager->push_task (task_p);
       }
     m_task_started = true;

--- a/src/query/parallel/px_scan/px_scan.cpp
+++ b/src/query/parallel/px_scan/px_scan.cpp
@@ -355,8 +355,9 @@ extern "C"
   }
 
   int
-  scan_open_parallel_heap_scan (THREAD_ENTRY *thread_p, SCAN_ID *scan_id, bool mvcc_select_lock_needed, int fixed_scan,
-				int grouped_scan, VAL_DESCR *vd, ACCESS_SPEC_TYPE *spec, OID *class_oid, HFID *class_hfid, XASL_NODE *xasl,
+  scan_open_parallel_heap_scan (THREAD_ENTRY *thread_p, SCAN_ID *scan_id, bool mvcc_select_lock_needed,
+				SCAN_OPERATION_TYPE scan_op_type, int fixed_scan, int grouped_scan, VAL_DESCR *vd,
+				ACCESS_SPEC_TYPE *spec, OID *class_oid, HFID *class_hfid, XASL_NODE *xasl,
 				QUERY_ID query_id)
   {
     int num_user_pages = -1;
@@ -456,7 +457,8 @@ extern "C"
     /* By construction, mvcc_select_lock_needed is false here: the gate above (spec->curent == nullptr
      * branch) sets ACCESS_SPEC_FLAG_NO_PARALLEL_SCAN and returns early whenever it is true, and that
      * flag persists across subsequent calls for the same spec (issue #154, critic gate 1 verification). */
-    bool page_copy_scan = qexec_is_page_copy_eligible (spec, S_SELECT, mvcc_select_lock_needed, fixed_scan, grouped_scan);
+    bool page_copy_scan = qexec_is_page_copy_eligible (spec, scan_op_type, mvcc_select_lock_needed, fixed_scan,
+						       grouped_scan);
 
     scan_id->s.phsid.manager = nullptr;	/* init */
 

--- a/src/query/parallel/px_scan/px_scan.cpp
+++ b/src/query/parallel/px_scan/px_scan.cpp
@@ -454,11 +454,11 @@ extern "C"
 	scan_id->s.phsid.result_type = parallel_scan::RESULT_TYPE::XASL_SNAPSHOT;
       }
 
-    /* By construction, mvcc_select_lock_needed is false here: the gate above (spec->curent == nullptr
-     * branch) sets ACCESS_SPEC_FLAG_NO_PARALLEL_SCAN and returns early whenever it is true, and that
-     * flag persists across subsequent calls for the same spec. */
-    bool cached_scan = qexec_is_cached_scan_eligible (spec, scan_op_type, mvcc_select_lock_needed, fixed_scan,
-		       grouped_scan);
+    /* Cached-scan activation was already decided by qexec_open_scan () for this spec: the
+     * driving-scan gate from qexec_execute_mainblock_internal () ANDed with the eligibility
+     * predicate. The flag also persists across partition reopens (see the reopen caller in
+     * query_executor.c). */
+    bool cached_scan = spec->cached_scan;
 
     scan_id->s.phsid.manager = nullptr;	/* init */
 

--- a/src/query/parallel/px_scan/px_scan.cpp
+++ b/src/query/parallel/px_scan/px_scan.cpp
@@ -453,6 +453,11 @@ extern "C"
 	scan_id->s.phsid.result_type = parallel_scan::RESULT_TYPE::XASL_SNAPSHOT;
       }
 
+    /* By construction, mvcc_select_lock_needed is false here: the gate above (spec->curent == nullptr
+     * branch) sets ACCESS_SPEC_FLAG_NO_PARALLEL_SCAN and returns early whenever it is true, and that
+     * flag persists across subsequent calls for the same spec (issue #154, critic gate 1 verification). */
+    bool page_copy_scan = qexec_is_page_copy_eligible (spec, S_SELECT, mvcc_select_lock_needed, fixed_scan, grouped_scan);
+
     scan_id->s.phsid.manager = nullptr;	/* init */
 
     switch (scan_id->s.phsid.result_type)
@@ -471,7 +476,7 @@ extern "C"
 	  }
 
 	scan_id->s.phsid.manager = placement_new ((manager_type *) scan_id->s.phsid.manager, thread_p, query_id, scan_id, xasl,
-				   num_parallel_threads, *class_hfid, *class_oid, vd, (bool) fixed_scan, (bool) grouped_scan, worker_manager_p);
+				   num_parallel_threads, *class_hfid, *class_oid, vd, (bool) fixed_scan, (bool) grouped_scan, page_copy_scan, worker_manager_p);
 	assert (scan_id->s.phsid.manager != nullptr);
 
 	error = ((manager_type *) scan_id->s.phsid.manager)->open ();
@@ -503,7 +508,7 @@ extern "C"
 	  }
 
 	scan_id->s.phsid.manager = placement_new ((manager_type *) scan_id->s.phsid.manager, thread_p, query_id, scan_id, xasl,
-				   num_parallel_threads, *class_hfid, *class_oid, vd, (bool) fixed_scan, (bool) grouped_scan, worker_manager_p);
+				   num_parallel_threads, *class_hfid, *class_oid, vd, (bool) fixed_scan, (bool) grouped_scan, page_copy_scan, worker_manager_p);
 	assert (scan_id->s.phsid.manager != nullptr);
 
 	error = ((manager_type *) scan_id->s.phsid.manager)->open ();
@@ -535,7 +540,7 @@ extern "C"
 	  }
 
 	scan_id->s.phsid.manager = placement_new ((manager_type *) scan_id->s.phsid.manager, thread_p, query_id, scan_id, xasl,
-				   num_parallel_threads, *class_hfid, *class_oid, vd, (bool) fixed_scan, (bool) grouped_scan, worker_manager_p);
+				   num_parallel_threads, *class_hfid, *class_oid, vd, (bool) fixed_scan, (bool) grouped_scan, page_copy_scan, worker_manager_p);
 	assert (scan_id->s.phsid.manager != nullptr);
 
 	error = ((manager_type *) scan_id->s.phsid.manager)->open ();
@@ -935,7 +940,7 @@ extern "C"
 	local_manager = placement_new ((manager_type *) local_manager,
 				       thread_p, query_id, scan_id, xasl,
 				       num_parallel_threads, null_hfid, null_oid, vd,
-				       false, false, worker_manager_p, list_id);
+				       false, false, false, worker_manager_p, list_id);
 	assert (local_manager != nullptr);
 
 	error = ((manager_type *) local_manager)->open ();
@@ -968,7 +973,7 @@ extern "C"
 	local_manager = placement_new ((manager_type *) local_manager,
 				       thread_p, query_id, scan_id, xasl,
 				       num_parallel_threads, null_hfid, null_oid, vd,
-				       false, false, worker_manager_p, list_id);
+				       false, false, false, worker_manager_p, list_id);
 	assert (local_manager != nullptr);
 
 	error = ((manager_type *) local_manager)->open ();
@@ -1434,7 +1439,7 @@ extern "C"
 	local_manager = placement_new ((manager_type *) local_manager,
 				       thread_p, query_id, scan_id, xasl,
 				       num_parallel_threads, class_hfid, class_oid, vd,
-				       false, false, worker_manager_p, nullptr, saved_indx_info);
+				       false, false, false, worker_manager_p, nullptr, saved_indx_info);
 	assert (local_manager != nullptr);
 
 	error = ((manager_type *) local_manager)->open ();
@@ -1466,7 +1471,7 @@ extern "C"
 	local_manager = placement_new ((manager_type *) local_manager,
 				       thread_p, query_id, scan_id, xasl,
 				       num_parallel_threads, class_hfid, class_oid, vd,
-				       false, false, worker_manager_p, nullptr, saved_indx_info);
+				       false, false, false, worker_manager_p, nullptr, saved_indx_info);
 	assert (local_manager != nullptr);
 
 	error = ((manager_type *) local_manager)->open ();
@@ -1796,7 +1801,7 @@ namespace parallel_scan
 	task_p = placement_new ((task<result_type, ST> *) task_p, m_thread_p, m_query_entry, m_result_handler,
 				m_input_handler, &m_interrupt, &m_err_messages, m_vd, trace_handler_p, m_worker_manager, m_xasl->header.id, m_hfid,
 				m_cls_oid, m_is_fixed,
-				m_is_grouped, m_uses_xasl_clone, m_xasl, &m_pre_execution_info);
+				m_is_grouped, m_is_page_copy_scan, m_uses_xasl_clone, m_xasl, &m_pre_execution_info);
 	m_worker_manager->push_task (task_p);
       }
     m_task_started = true;

--- a/src/query/parallel/px_scan/px_scan.hpp
+++ b/src/query/parallel/px_scan/px_scan.hpp
@@ -46,7 +46,7 @@ namespace parallel_scan
       manager (THREAD_ENTRY *thread_p, QUERY_ID query_id, SCAN_ID *scan_id, xasl_node *xasl, int parallelism, HFID hfid,
 	       OID cls_oid,
 	       val_descr *vd,
-	       bool is_fixed, bool is_grouped, bool is_page_copy_scan,
+	       bool is_fixed, bool is_grouped, bool is_cached_scan,
 	       worker_manager *worker_manager,
 	       QFILE_LIST_ID *list_id = nullptr,
 	       INDX_INFO *indx_info = nullptr)
@@ -72,7 +72,7 @@ namespace parallel_scan
 	  m_worker_manager (worker_manager),
 	  m_is_fixed (is_fixed),
 	  m_is_grouped (is_grouped),
-	  m_is_page_copy_scan (is_page_copy_scan),
+	  m_is_cached_scan (is_cached_scan),
 	  m_uses_xasl_clone (false),
 	  m_g_agg_domain_resolve_need (false),
 	  m_list_id (list_id),
@@ -120,7 +120,7 @@ namespace parallel_scan
       pre_execution_info m_pre_execution_info;
       bool m_is_fixed;
       bool m_is_grouped;
-      bool m_is_page_copy_scan;	/* issue #154: page-copy activation, computed via qexec_is_page_copy_eligible () */
+      bool m_is_cached_scan;	/* cached-scan activation, computed via qexec_is_cached_scan_eligible () */
       bool m_uses_xasl_clone;
       bool m_g_agg_domain_resolve_need;
       QFILE_LIST_ID *m_list_id;

--- a/src/query/parallel/px_scan/px_scan.hpp
+++ b/src/query/parallel/px_scan/px_scan.hpp
@@ -120,7 +120,7 @@ namespace parallel_scan
       pre_execution_info m_pre_execution_info;
       bool m_is_fixed;
       bool m_is_grouped;
-      bool m_is_cached_scan;	/* cached-scan activation, computed via qexec_is_cached_scan_eligible () */
+      bool m_is_cached_scan;	/* cached-scan activation for the driving scan, decided in qexec_open_scan () */
       bool m_uses_xasl_clone;
       bool m_g_agg_domain_resolve_need;
       QFILE_LIST_ID *m_list_id;

--- a/src/query/parallel/px_scan/px_scan.hpp
+++ b/src/query/parallel/px_scan/px_scan.hpp
@@ -46,7 +46,7 @@ namespace parallel_scan
       manager (THREAD_ENTRY *thread_p, QUERY_ID query_id, SCAN_ID *scan_id, xasl_node *xasl, int parallelism, HFID hfid,
 	       OID cls_oid,
 	       val_descr *vd,
-	       bool is_fixed, bool is_grouped,
+	       bool is_fixed, bool is_grouped, bool is_page_copy_scan,
 	       worker_manager *worker_manager,
 	       QFILE_LIST_ID *list_id = nullptr,
 	       INDX_INFO *indx_info = nullptr)
@@ -72,6 +72,7 @@ namespace parallel_scan
 	  m_worker_manager (worker_manager),
 	  m_is_fixed (is_fixed),
 	  m_is_grouped (is_grouped),
+	  m_is_page_copy_scan (is_page_copy_scan),
 	  m_uses_xasl_clone (false),
 	  m_g_agg_domain_resolve_need (false),
 	  m_list_id (list_id),
@@ -119,6 +120,7 @@ namespace parallel_scan
       pre_execution_info m_pre_execution_info;
       bool m_is_fixed;
       bool m_is_grouped;
+      bool m_is_page_copy_scan;	/* issue #154: page-copy activation, computed via qexec_is_page_copy_eligible () */
       bool m_uses_xasl_clone;
       bool m_g_agg_domain_resolve_need;
       QFILE_LIST_ID *m_list_id;

--- a/src/query/parallel/px_scan/px_scan.hpp
+++ b/src/query/parallel/px_scan/px_scan.hpp
@@ -135,8 +135,8 @@ extern "C"
   extern void scan_end_parallel_heap_scan (THREAD_ENTRY *thread_p, SCAN_ID *scan_id);
   extern void scan_close_parallel_heap_scan (THREAD_ENTRY *thread_p, SCAN_ID *scan_id);
   extern int scan_open_parallel_heap_scan (THREAD_ENTRY *thread_p, SCAN_ID *scan_id, bool mvcc_select_lock_needed,
-      int fixed_scan, int grouped_scan, VAL_DESCR *vd, ACCESS_SPEC_TYPE *spec, OID *class_oid, HFID *class_hfid,
-      XASL_NODE *xasl, QUERY_ID query_id);
+      SCAN_OPERATION_TYPE scan_op_type, int fixed_scan, int grouped_scan, VAL_DESCR *vd, ACCESS_SPEC_TYPE *spec,
+      OID *class_oid, HFID *class_hfid, XASL_NODE *xasl, QUERY_ID query_id);
   extern int scan_start_parallel_heap_scan (THREAD_ENTRY *thread_p, SCAN_ID *scan_id);
 
   extern SCAN_CODE scan_next_parallel_list_scan (THREAD_ENTRY *thread_p, SCAN_ID *scan_id);

--- a/src/query/parallel/px_scan/px_scan_task.cpp
+++ b/src/query/parallel/px_scan/px_scan_task.cpp
@@ -228,7 +228,7 @@ namespace parallel_scan
 				     cls->num_attrs_pred, cls->attrids_pred, cls->cache_pred,
 				     cls->num_attrs_rest, cls->attrids_rest, cls->cache_rest,
 				     S_HEAP_SCAN, cls->cache_reserved, cls->cls_regu_list_reserved,
-				     m_is_page_copy_scan);
+				     m_is_cached_scan);
 		err_code = scan_start_scan (&thread_ref, m_scan_id);
 	      }
 	  }
@@ -293,11 +293,11 @@ namespace parallel_scan
 		      case ACCESS_METHOD_SEQUENTIAL:
 		      {
 			/* Worker fixed_scan here is a local recompute (xptr->scan_ptr == NULL check above),
-			 * simplified vs the leader's full fixed-scan chain-walk that fed m_is_page_copy_scan.
-			 * The asymmetry is perf-only, not a correctness gap: page-copy is structurally safe
+			 * simplified vs the leader's full fixed-scan chain-walk that fed m_is_cached_scan.
+			 * The asymmetry is perf-only, not a correctness gap: a cached scan is structurally safe
 			 * for any S_SELECT lock-free scan regardless of which path computed fixed_scan, and
-			 * the "&& !fixed_scan" guard below still prevents copy-mode from activating on a scan
-			 * this worker locally determined to be fixed (issue #154, critic gate 2 P3b). */
+			 * the "&& !fixed_scan" guard below still prevents a cached scan from activating on a
+			 * scan this worker locally determined to be fixed. */
 			err_code = scan_open_heap_scan (&thread_ref, &specp->s_id, false,
 							S_SELECT, fixed_scan, specp->s_id.grouped,
 							specp->single_fetch, specp->s_dbval, xptr->val_list, m_vd,
@@ -307,7 +307,7 @@ namespace parallel_scan
 							specp->s.cls_node.num_attrs_rest, specp->s.cls_node.attrids_rest,
 							specp->s.cls_node.cache_rest, S_HEAP_SCAN, specp->s.cls_node.cache_reserved,
 							specp->s.cls_node.cls_regu_list_reserved,
-							m_is_page_copy_scan && !fixed_scan);
+							m_is_cached_scan && !fixed_scan);
 			if (err_code != NO_ERROR)
 			  {
 			    return err_code;

--- a/src/query/parallel/px_scan/px_scan_task.cpp
+++ b/src/query/parallel/px_scan/px_scan_task.cpp
@@ -292,12 +292,10 @@ namespace parallel_scan
 		      {
 		      case ACCESS_METHOD_SEQUENTIAL:
 		      {
-			/* Worker fixed_scan here is a local recompute (xptr->scan_ptr == NULL check above),
-			 * simplified vs the leader's full fixed-scan chain-walk that fed m_is_cached_scan.
-			 * The asymmetry is perf-only, not a correctness gap: a cached scan is structurally safe
-			 * for any S_SELECT lock-free scan regardless of which path computed fixed_scan, and
-			 * the "&& !fixed_scan" guard below still prevents a cached scan from activating on a
-			 * scan this worker locally determined to be fixed. */
+			/* Cached scan is restricted to the driving (level-0) scan, opened above with
+			 * m_is_cached_scan. Intermediate scans of the chain always open with cached
+			 * scan off (defaulted last argument), matching the serial-path gate in
+			 * qexec_execute_mainblock_internal (). */
 			err_code = scan_open_heap_scan (&thread_ref, &specp->s_id, false,
 							S_SELECT, fixed_scan, specp->s_id.grouped,
 							specp->single_fetch, specp->s_dbval, xptr->val_list, m_vd,
@@ -306,8 +304,7 @@ namespace parallel_scan
 							specp->s.cls_node.attrids_pred, specp->s.cls_node.cache_pred,
 							specp->s.cls_node.num_attrs_rest, specp->s.cls_node.attrids_rest,
 							specp->s.cls_node.cache_rest, S_HEAP_SCAN, specp->s.cls_node.cache_reserved,
-							specp->s.cls_node.cls_regu_list_reserved,
-							m_is_cached_scan && !fixed_scan);
+							specp->s.cls_node.cls_regu_list_reserved);
 			if (err_code != NO_ERROR)
 			  {
 			    return err_code;

--- a/src/query/parallel/px_scan/px_scan_task.cpp
+++ b/src/query/parallel/px_scan/px_scan_task.cpp
@@ -292,6 +292,12 @@ namespace parallel_scan
 		      {
 		      case ACCESS_METHOD_SEQUENTIAL:
 		      {
+			/* Worker fixed_scan here is a local recompute (xptr->scan_ptr == NULL check above),
+			 * simplified vs the leader's full fixed-scan chain-walk that fed m_is_page_copy_scan.
+			 * The asymmetry is perf-only, not a correctness gap: page-copy is structurally safe
+			 * for any S_SELECT lock-free scan regardless of which path computed fixed_scan, and
+			 * the "&& !fixed_scan" guard below still prevents copy-mode from activating on a scan
+			 * this worker locally determined to be fixed (issue #154, critic gate 2 P3b). */
 			err_code = scan_open_heap_scan (&thread_ref, &specp->s_id, false,
 							S_SELECT, fixed_scan, specp->s_id.grouped,
 							specp->single_fetch, specp->s_dbval, xptr->val_list, m_vd,

--- a/src/query/parallel/px_scan/px_scan_task.cpp
+++ b/src/query/parallel/px_scan/px_scan_task.cpp
@@ -227,7 +227,8 @@ namespace parallel_scan
 				     cls->cls_regu_list_pred, spec->where_pred, cls->cls_regu_list_rest,
 				     cls->num_attrs_pred, cls->attrids_pred, cls->cache_pred,
 				     cls->num_attrs_rest, cls->attrids_rest, cls->cache_rest,
-				     S_HEAP_SCAN, cls->cache_reserved, cls->cls_regu_list_reserved);
+				     S_HEAP_SCAN, cls->cache_reserved, cls->cls_regu_list_reserved,
+				     m_is_page_copy_scan);
 		err_code = scan_start_scan (&thread_ref, m_scan_id);
 	      }
 	  }
@@ -299,7 +300,8 @@ namespace parallel_scan
 							specp->s.cls_node.attrids_pred, specp->s.cls_node.cache_pred,
 							specp->s.cls_node.num_attrs_rest, specp->s.cls_node.attrids_rest,
 							specp->s.cls_node.cache_rest, S_HEAP_SCAN, specp->s.cls_node.cache_reserved,
-							specp->s.cls_node.cls_regu_list_reserved);
+							specp->s.cls_node.cls_regu_list_reserved,
+							m_is_page_copy_scan && !fixed_scan);
 			if (err_code != NO_ERROR)
 			  {
 			    return err_code;

--- a/src/query/parallel/px_scan/px_scan_task.hpp
+++ b/src/query/parallel/px_scan/px_scan_task.hpp
@@ -48,7 +48,7 @@ namespace parallel_scan
 	    input_handler_t *input_handler,
 	    interrupt *interrupt, err_messages_with_lock *err_messages, val_descr *vd, trace_handler *trace_handler,
 	    worker_manager *worker_manager, int xasl_id, HFID hfid, OID cls_oid, bool is_fixed, bool is_grouped,
-	    bool is_page_copy_scan, bool uses_xasl_clone, XASL_NODE *orig_xasl, pre_execution_info *pre_exec_info)
+	    bool is_cached_scan, bool uses_xasl_clone, XASL_NODE *orig_xasl, pre_execution_info *pre_exec_info)
 	: m_parent_thread_p (parent_thread_p),
 	  m_query_entry (query_entry),
 	  m_xasl_cache_entry (nullptr),
@@ -74,7 +74,7 @@ namespace parallel_scan
       m_pre_execution_info (pre_exec_info),
       m_is_fixed (is_fixed),
       m_is_grouped (is_grouped),
-      m_is_page_copy_scan (is_page_copy_scan),
+      m_is_cached_scan (is_cached_scan),
       m_uses_xasl_clone (uses_xasl_clone),
       m_worker_manager (worker_manager)
       {
@@ -109,7 +109,7 @@ namespace parallel_scan
       pre_execution_info *m_pre_execution_info;
       bool m_is_fixed;
       bool m_is_grouped;
-      bool m_is_page_copy_scan;	/* issue #154: from manager, propagated to scan_open_heap_scan */
+      bool m_is_cached_scan;	/* from manager, propagated to scan_open_heap_scan */
       bool m_uses_xasl_clone;
       TSC_TICKS m_start_tick;
 

--- a/src/query/parallel/px_scan/px_scan_task.hpp
+++ b/src/query/parallel/px_scan/px_scan_task.hpp
@@ -48,7 +48,7 @@ namespace parallel_scan
 	    input_handler_t *input_handler,
 	    interrupt *interrupt, err_messages_with_lock *err_messages, val_descr *vd, trace_handler *trace_handler,
 	    worker_manager *worker_manager, int xasl_id, HFID hfid, OID cls_oid, bool is_fixed, bool is_grouped,
-	    bool uses_xasl_clone, XASL_NODE *orig_xasl, pre_execution_info *pre_exec_info)
+	    bool is_page_copy_scan, bool uses_xasl_clone, XASL_NODE *orig_xasl, pre_execution_info *pre_exec_info)
 	: m_parent_thread_p (parent_thread_p),
 	  m_query_entry (query_entry),
 	  m_xasl_cache_entry (nullptr),
@@ -74,6 +74,7 @@ namespace parallel_scan
       m_pre_execution_info (pre_exec_info),
       m_is_fixed (is_fixed),
       m_is_grouped (is_grouped),
+      m_is_page_copy_scan (is_page_copy_scan),
       m_uses_xasl_clone (uses_xasl_clone),
       m_worker_manager (worker_manager)
       {
@@ -108,6 +109,7 @@ namespace parallel_scan
       pre_execution_info *m_pre_execution_info;
       bool m_is_fixed;
       bool m_is_grouped;
+      bool m_is_page_copy_scan;	/* issue #154: from manager, propagated to scan_open_heap_scan */
       bool m_uses_xasl_clone;
       TSC_TICKS m_start_tick;
 

--- a/src/query/query_dump.c
+++ b/src/query/query_dump.c
@@ -565,6 +565,7 @@ qdump_print_access_spec (ACCESS_SPEC_TYPE * spec_list_p)
 #if defined (SERVER_MODE) || defined (SA_MODE)
   fprintf (foutput, "\n  grouped scan=%d", spec_list_p->grouped_scan);
   fprintf (foutput, ",fixed scan=%d", spec_list_p->fixed_scan);
+  fprintf (foutput, ",page copy scan=%d", spec_list_p->page_copy_scan);
 #endif /* defined (SERVER_MODE) || defined (SA_MODE) */
   fprintf (foutput, ",single fetch=%d", spec_list_p->single_fetch);
 

--- a/src/query/query_dump.c
+++ b/src/query/query_dump.c
@@ -565,7 +565,7 @@ qdump_print_access_spec (ACCESS_SPEC_TYPE * spec_list_p)
 #if defined (SERVER_MODE) || defined (SA_MODE)
   fprintf (foutput, "\n  grouped scan=%d", spec_list_p->grouped_scan);
   fprintf (foutput, ",fixed scan=%d", spec_list_p->fixed_scan);
-  fprintf (foutput, ",page copy scan=%d", spec_list_p->page_copy_scan);
+  fprintf (foutput, ",cached scan=%d", spec_list_p->cached_scan);
 #endif /* defined (SERVER_MODE) || defined (SA_MODE) */
   fprintf (foutput, ",single fetch=%d", spec_list_p->single_fetch);
 

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -7455,28 +7455,22 @@ qexec_prepare_table_sampling (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * curr_s
  */
 
 /*
- * qexec_is_page_copy_eligible () - page-copy heap scan eligibility predicate (issue #154)
- *   return: true if the scan may use page-copy read mode
+ * qexec_is_cached_scan_eligible () - cached (copy-to-local-cache) heap scan eligibility predicate
+ *   return: true if the scan may read records from a scan-private local page cache
  *   specp(in): Access specification node
  *   scan_op_type(in): SELECT, DELETE, UPDATE
  *   mvcc_select_lock_needed(in): true if lock at scanning needed in mvcc
  *   fixed(in): if true, pages containing scan items in a group keep fixed
  *   grouped(in): if true, the scan items are accessed group by group
  *
- * Note: gate-free deployment (no env/system-parameter gate). Restricted to lock-free S_SELECT
- * sequential heap scans; grouped scans are out of scope for page-copy.
+ * Note: restricted to lock-free S_SELECT sequential heap scans; grouped scans are out of scope.
  */
 bool
-qexec_is_page_copy_eligible (ACCESS_SPEC_TYPE * specp, SCAN_OPERATION_TYPE scan_op_type,
-			     bool mvcc_select_lock_needed, int fixed, int grouped)
+qexec_is_cached_scan_eligible (ACCESS_SPEC_TYPE * specp, SCAN_OPERATION_TYPE scan_op_type,
+			       bool mvcc_select_lock_needed, int fixed, int grouped)
 {
-  return specp->type == TARGET_CLASS
-    && specp->access == ACCESS_METHOD_SEQUENTIAL
-    && scan_op_type == S_SELECT
-    && !COMPOSITE_LOCK (scan_op_type)	/* tautological with S_SELECT; documents boundary */
-    && !mvcc_select_lock_needed
-    && !fixed
-    && !grouped;		/* grouped scans are out of scope */
+  return specp->type == TARGET_CLASS && specp->access == ACCESS_METHOD_SEQUENTIAL && scan_op_type == S_SELECT && !COMPOSITE_LOCK (scan_op_type)	/* tautological with S_SELECT; documents boundary */
+    && !mvcc_select_lock_needed && !fixed && !grouped;	/* grouped scans are out of scope */
 }
 
 /*
@@ -7547,9 +7541,10 @@ qexec_open_scan (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * curr_spec, VAL_LIST
 	}
     }
 
-  /* issue #154 Slice 3: compute page-copy activation once per open, before dispatching on access method.
+  /* Compute cached-scan activation once per open, before dispatching on access method.
    * Runtime-only; recomputed at every open, never serialized (see xasl.h / stream_to_xasl.c). */
-  curr_spec->page_copy_scan = qexec_is_page_copy_eligible (curr_spec, scan_op_type, mvcc_select_lock_needed, fixed, grouped);
+  curr_spec->cached_scan =
+    qexec_is_cached_scan_eligible (curr_spec, scan_op_type, mvcc_select_lock_needed, fixed, grouped);
 
   switch (curr_spec->type)
     {
@@ -7595,7 +7590,7 @@ qexec_open_scan (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * curr_spec, VAL_LIST
 					 curr_spec->s.cls_node.num_attrs_rest, curr_spec->s.cls_node.attrids_rest,
 					 curr_spec->s.cls_node.cache_rest, S_HEAP_SCAN,
 					 curr_spec->s.cls_node.cache_reserved,
-					 curr_spec->s.cls_node.cls_regu_list_reserved, curr_spec->page_copy_scan);
+					 curr_spec->s.cls_node.cls_regu_list_reserved, curr_spec->cached_scan);
 		  if (error_code != NO_ERROR)
 		    {
 		      ASSERT_ERROR ();
@@ -7624,7 +7619,7 @@ qexec_open_scan (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * curr_spec, VAL_LIST
 						curr_spec->s.cls_node.num_attrs_rest,
 						curr_spec->s.cls_node.attrids_rest, curr_spec->s.cls_node.cache_rest,
 						scan_type, curr_spec->s.cls_node.cache_reserved,
-						curr_spec->s.cls_node.cls_regu_list_reserved, curr_spec->page_copy_scan);
+						curr_spec->s.cls_node.cls_regu_list_reserved, curr_spec->cached_scan);
 	      if (error_code != NO_ERROR)
 		{
 		  ASSERT_ERROR ();
@@ -9169,7 +9164,7 @@ qexec_init_next_partition (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * spec, XAS
 					 spec->s.cls_node.attrids_pred, spec->s.cls_node.cache_pred,
 					 spec->s.cls_node.num_attrs_rest, spec->s.cls_node.attrids_rest,
 					 spec->s.cls_node.cache_rest, S_HEAP_SCAN, spec->s.cls_node.cache_reserved,
-					 spec->s.cls_node.cls_regu_list_reserved, spec->s_id.page_copy_scan);
+					 spec->s.cls_node.cls_regu_list_reserved, spec->s_id.cached_scan);
 		  if (error != NO_ERROR)
 		    {
 		      ASSERT_ERROR ();
@@ -9214,7 +9209,7 @@ qexec_init_next_partition (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * spec, XAS
 				     spec->s.cls_node.attrids_pred, spec->s.cls_node.cache_pred,
 				     spec->s.cls_node.num_attrs_rest, spec->s.cls_node.attrids_rest,
 				     spec->s.cls_node.cache_rest, scan_type, spec->s.cls_node.cache_reserved,
-				     spec->s.cls_node.cls_regu_list_reserved, spec->s_id.page_copy_scan);
+				     spec->s.cls_node.cls_regu_list_reserved, spec->s_id.cached_scan);
 	      if (error != NO_ERROR)
 		{
 		  return S_ERROR;

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -7547,6 +7547,10 @@ qexec_open_scan (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * curr_spec, VAL_LIST
 	}
     }
 
+  /* issue #154 Slice 3: compute page-copy activation once per open, before dispatching on access method.
+   * Runtime-only; recomputed at every open, never serialized (see xasl.h / stream_to_xasl.c). */
+  curr_spec->page_copy_scan = qexec_is_page_copy_eligible (curr_spec, scan_op_type, mvcc_select_lock_needed, fixed, grouped);
+
   switch (curr_spec->type)
     {
     case TARGET_CLASS:
@@ -7591,7 +7595,7 @@ qexec_open_scan (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * curr_spec, VAL_LIST
 					 curr_spec->s.cls_node.num_attrs_rest, curr_spec->s.cls_node.attrids_rest,
 					 curr_spec->s.cls_node.cache_rest, S_HEAP_SCAN,
 					 curr_spec->s.cls_node.cache_reserved,
-					 curr_spec->s.cls_node.cls_regu_list_reserved);
+					 curr_spec->s.cls_node.cls_regu_list_reserved, curr_spec->page_copy_scan);
 		  if (error_code != NO_ERROR)
 		    {
 		      ASSERT_ERROR ();
@@ -7620,7 +7624,7 @@ qexec_open_scan (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * curr_spec, VAL_LIST
 						curr_spec->s.cls_node.num_attrs_rest,
 						curr_spec->s.cls_node.attrids_rest, curr_spec->s.cls_node.cache_rest,
 						scan_type, curr_spec->s.cls_node.cache_reserved,
-						curr_spec->s.cls_node.cls_regu_list_reserved);
+						curr_spec->s.cls_node.cls_regu_list_reserved, curr_spec->page_copy_scan);
 	      if (error_code != NO_ERROR)
 		{
 		  ASSERT_ERROR ();
@@ -9165,7 +9169,7 @@ qexec_init_next_partition (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * spec, XAS
 					 spec->s.cls_node.attrids_pred, spec->s.cls_node.cache_pred,
 					 spec->s.cls_node.num_attrs_rest, spec->s.cls_node.attrids_rest,
 					 spec->s.cls_node.cache_rest, S_HEAP_SCAN, spec->s.cls_node.cache_reserved,
-					 spec->s.cls_node.cls_regu_list_reserved);
+					 spec->s.cls_node.cls_regu_list_reserved, spec->s_id.page_copy_scan);
 		  if (error != NO_ERROR)
 		    {
 		      ASSERT_ERROR ();
@@ -9210,7 +9214,7 @@ qexec_init_next_partition (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * spec, XAS
 				     spec->s.cls_node.attrids_pred, spec->s.cls_node.cache_pred,
 				     spec->s.cls_node.num_attrs_rest, spec->s.cls_node.attrids_rest,
 				     spec->s.cls_node.cache_rest, scan_type, spec->s.cls_node.cache_reserved,
-				     spec->s.cls_node.cls_regu_list_reserved);
+				     spec->s.cls_node.cls_regu_list_reserved, spec->s_id.page_copy_scan);
 	      if (error != NO_ERROR)
 		{
 		  return S_ERROR;

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -7467,7 +7467,7 @@ qexec_prepare_table_sampling (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * curr_s
  *
  * Note: restricted to lock-free S_SELECT sequential heap scans; grouped scans are out of scope.
  */
-bool
+static bool
 qexec_is_cached_scan_eligible (ACCESS_SPEC_TYPE * specp, SCAN_OPERATION_TYPE scan_op_type,
 			       bool mvcc_select_lock_needed, int fixed, int grouped)
 {
@@ -7543,10 +7543,12 @@ qexec_open_scan (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * curr_spec, VAL_LIST
 	}
     }
 
-  /* Compute cached-scan activation once per open, before dispatching on access method.
-   * Runtime-only; recomputed at every open, never serialized (see xasl.h / stream_to_xasl.c). */
-  curr_spec->cached_scan =
-    qexec_is_cached_scan_eligible (curr_spec, scan_op_type, mvcc_select_lock_needed, fixed, grouped);
+  /* Finalize cached-scan activation once per open, before dispatching on access method. The
+   * driving-scan gate is assigned next to fixed_scan in qexec_execute_mainblock_internal ();
+   * specs opened outside that loop (merge, UPDATE/DELETE/INSERT select scans, ...) keep the
+   * false set at unpack time. Runtime-only; never serialized (see xasl.h / stream_to_xasl.c). */
+  curr_spec->cached_scan = curr_spec->cached_scan
+    && qexec_is_cached_scan_eligible (curr_spec, scan_op_type, mvcc_select_lock_needed, fixed, grouped);
 
   switch (curr_spec->type)
     {
@@ -16380,6 +16382,14 @@ qexec_execute_mainblock_internal (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XAS
 		  for (specp = spec_ptr[spec_level]; specp; specp = specp->next)
 		    {
 		      specp->fixed_scan = (xptr == fixed_scan_xasl);
+
+		      /* Cached (copy-to-local-cache) scan is allowed only on the driving scan --
+		       * the level-0 spec_list of the scan chain. An inner scan re-visits its pages
+		       * once per outer row, so the single-page local cache would be re-copied
+		       * constantly for no latch-avoidance benefit. This is only the gate: final
+		       * activation is ANDed with eligibility in qexec_open_scan (), where
+		       * mvcc_select_lock_needed becomes known. */
+		      specp->cached_scan = (level == 0 && spec_level == 0);
 
 		      /* set if the scan will be done in a grouped manner */
 		      if ((level == 0 && xptr->scan_ptr == NULL) && (QPROC_MAX_GROUPED_SCAN_CNT > 0))

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -7561,9 +7561,9 @@ qexec_open_scan (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * curr_spec, VAL_LIST
 	    {
 #if SERVER_MODE && !WINDOWS
 	      error_code =
-		scan_open_parallel_heap_scan (thread_p, s_id, mvcc_select_lock_needed, fixed, grouped, vd, curr_spec,
-					      &ACCESS_SPEC_CLS_OID (curr_spec), &ACCESS_SPEC_HFID (curr_spec), xasl,
-					      query_id);
+		scan_open_parallel_heap_scan (thread_p, s_id, mvcc_select_lock_needed, scan_op_type, fixed, grouped,
+					      vd, curr_spec, &ACCESS_SPEC_CLS_OID (curr_spec),
+					      &ACCESS_SPEC_HFID (curr_spec), xasl, query_id);
 	      if (error_code != NO_ERROR)
 		{
 		  ASSERT_ERROR ();
@@ -9136,8 +9136,8 @@ qexec_init_next_partition (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * spec, XAS
 #if SERVER_MODE && !WINDOWS
 	      error =
 		scan_open_parallel_heap_scan (thread_p, &spec->s_id, spec->s_id.mvcc_select_lock_needed,
-					      spec->s_id.fixed, spec->s_id.grouped, spec->s_id.vd, spec, &class_oid,
-					      &class_hfid, xasl, query_id);
+					      spec->s_id.scan_op_type, spec->s_id.fixed, spec->s_id.grouped,
+					      spec->s_id.vd, spec, &class_oid, &class_hfid, xasl, query_id);
 	      if (error != NO_ERROR)
 		{
 		  ASSERT_ERROR ();

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -7455,6 +7455,31 @@ qexec_prepare_table_sampling (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * curr_s
  */
 
 /*
+ * qexec_is_page_copy_eligible () - page-copy heap scan eligibility predicate (issue #154)
+ *   return: true if the scan may use page-copy read mode
+ *   specp(in): Access specification node
+ *   scan_op_type(in): SELECT, DELETE, UPDATE
+ *   mvcc_select_lock_needed(in): true if lock at scanning needed in mvcc
+ *   fixed(in): if true, pages containing scan items in a group keep fixed
+ *   grouped(in): if true, the scan items are accessed group by group
+ *
+ * Note: gate-free deployment (no env/system-parameter gate). Restricted to lock-free S_SELECT
+ * sequential heap scans; grouped scans are out of scope for page-copy.
+ */
+bool
+qexec_is_page_copy_eligible (ACCESS_SPEC_TYPE * specp, SCAN_OPERATION_TYPE scan_op_type,
+			     bool mvcc_select_lock_needed, int fixed, int grouped)
+{
+  return specp->type == TARGET_CLASS
+    && specp->access == ACCESS_METHOD_SEQUENTIAL
+    && scan_op_type == S_SELECT
+    && !COMPOSITE_LOCK (scan_op_type)	/* tautological with S_SELECT; documents boundary */
+    && !mvcc_select_lock_needed
+    && !fixed
+    && !grouped;		/* grouped scans are out of scope */
+}
+
+/*
  * qexec_open_scan () -
  *   return: NO_ERROR, or ER_code
  *   curr_spec(in)      : Access Specification Node

--- a/src/query/query_executor.h
+++ b/src/query/query_executor.h
@@ -141,4 +141,10 @@ extern TOPN_STATUS qexec_add_tuple_to_topn (THREAD_ENTRY * thread_p, TOPN_TUPLES
 					    QFILE_TUPLE_DESCRIPTOR * tpldescr);
 extern int qexec_topn_tuples_to_list_id (THREAD_ENTRY * thread_p, xasl_node * xasl, XASL_STATE * xasl_state,
 					 bool is_final, QFILE_LIST_ID * merged_results);
+
+/* page-copy heap scan eligibility predicate (issue #154). Declared here (not in xasl.h) so that
+ * both query_executor.c and px_scan.cpp can call it without a forward dependency on the full
+ * ACCESS_SPEC_TYPE definition at this point in each TU's include order. */
+extern bool qexec_is_page_copy_eligible (struct access_spec_node *specp, SCAN_OPERATION_TYPE scan_op_type,
+					 bool mvcc_select_lock_needed, int fixed, int grouped);
 #endif /* _QUERY_EXECUTOR_H_ */

--- a/src/query/query_executor.h
+++ b/src/query/query_executor.h
@@ -141,10 +141,4 @@ extern TOPN_STATUS qexec_add_tuple_to_topn (THREAD_ENTRY * thread_p, TOPN_TUPLES
 					    QFILE_TUPLE_DESCRIPTOR * tpldescr);
 extern int qexec_topn_tuples_to_list_id (THREAD_ENTRY * thread_p, xasl_node * xasl, XASL_STATE * xasl_state,
 					 bool is_final, QFILE_LIST_ID * merged_results);
-
-/* Cached (copy-to-local-cache) heap scan eligibility predicate. Declared here (not in xasl.h) so that
- * both query_executor.c and px_scan.cpp can call it without a forward dependency on the full
- * ACCESS_SPEC_TYPE definition at this point in each TU's include order. */
-extern bool qexec_is_cached_scan_eligible (struct access_spec_node *specp, SCAN_OPERATION_TYPE scan_op_type,
-					   bool mvcc_select_lock_needed, int fixed, int grouped);
 #endif /* _QUERY_EXECUTOR_H_ */

--- a/src/query/query_executor.h
+++ b/src/query/query_executor.h
@@ -142,9 +142,9 @@ extern TOPN_STATUS qexec_add_tuple_to_topn (THREAD_ENTRY * thread_p, TOPN_TUPLES
 extern int qexec_topn_tuples_to_list_id (THREAD_ENTRY * thread_p, xasl_node * xasl, XASL_STATE * xasl_state,
 					 bool is_final, QFILE_LIST_ID * merged_results);
 
-/* page-copy heap scan eligibility predicate (issue #154). Declared here (not in xasl.h) so that
+/* Cached (copy-to-local-cache) heap scan eligibility predicate. Declared here (not in xasl.h) so that
  * both query_executor.c and px_scan.cpp can call it without a forward dependency on the full
  * ACCESS_SPEC_TYPE definition at this point in each TU's include order. */
-extern bool qexec_is_page_copy_eligible (struct access_spec_node *specp, SCAN_OPERATION_TYPE scan_op_type,
-					 bool mvcc_select_lock_needed, int fixed, int grouped);
+extern bool qexec_is_cached_scan_eligible (struct access_spec_node *specp, SCAN_OPERATION_TYPE scan_op_type,
+					   bool mvcc_select_lock_needed, int fixed, int grouped);
 #endif /* _QUERY_EXECUTOR_H_ */

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -3250,8 +3250,10 @@ scan_open_heap_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
 		     HEAP_CACHE_ATTRINFO * cache_rest, SCAN_TYPE scan_type, DB_VALUE ** cache_recordinfo,
 		     regu_variable_list_node * regu_list_recordinfo, bool page_copy_scan)
 {
-  /* page_copy_scan: Slice 1 plumbing only, not yet consumed (see Slice 3). */
-  (void) page_copy_scan;
+  /* Guard: this function is shared by S_HEAP_SCAN, S_HEAP_SCAN_RECORD_INFO, and S_HEAP_SAMPLING_SCAN
+   * (issue #154, critic gate 1 F1). Only plain heap scans may activate page-copy; record-info and
+   * sampling scans never do, defense-in-depth on top of the caller-side eligibility predicate. */
+  scan_id->page_copy_scan = page_copy_scan && (scan_type == S_HEAP_SCAN);
 
   HEAP_SCAN_ID *hsidp;
   DB_TYPE single_node_type = DB_TYPE_NULL;
@@ -4577,7 +4579,7 @@ scan_start_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 	  /* A new argument(is_indexscan = false) is appended */
 	  ret =
 	    heap_scancache_start (thread_p, &hsidp->scan_cache, &hsidp->hfid, &hsidp->cls_oid, scan_id->fixed,
-				  mvcc_snapshot);
+				  mvcc_snapshot, scan_id->page_copy_scan);
 	  if (ret != NO_ERROR)
 	    {
 	      goto exit_on_error;

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -3248,8 +3248,11 @@ scan_open_heap_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
 		     regu_variable_list_node * regu_list_rest, int num_attrs_pred, ATTR_ID * attrids_pred,
 		     HEAP_CACHE_ATTRINFO * cache_pred, int num_attrs_rest, ATTR_ID * attrids_rest,
 		     HEAP_CACHE_ATTRINFO * cache_rest, SCAN_TYPE scan_type, DB_VALUE ** cache_recordinfo,
-		     regu_variable_list_node * regu_list_recordinfo)
+		     regu_variable_list_node * regu_list_recordinfo, bool page_copy_scan)
 {
+  /* page_copy_scan: Slice 1 plumbing only, not yet consumed (see Slice 3). */
+  (void) page_copy_scan;
+
   HEAP_SCAN_ID *hsidp;
   DB_TYPE single_node_type = DB_TYPE_NULL;
 

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -3248,12 +3248,12 @@ scan_open_heap_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
 		     regu_variable_list_node * regu_list_rest, int num_attrs_pred, ATTR_ID * attrids_pred,
 		     HEAP_CACHE_ATTRINFO * cache_pred, int num_attrs_rest, ATTR_ID * attrids_rest,
 		     HEAP_CACHE_ATTRINFO * cache_rest, SCAN_TYPE scan_type, DB_VALUE ** cache_recordinfo,
-		     regu_variable_list_node * regu_list_recordinfo, bool page_copy_scan)
+		     regu_variable_list_node * regu_list_recordinfo, bool cached_scan)
 {
-  /* Guard: this function is shared by S_HEAP_SCAN, S_HEAP_SCAN_RECORD_INFO, and S_HEAP_SAMPLING_SCAN
-   * (issue #154, critic gate 1 F1). Only plain heap scans may activate page-copy; record-info and
-   * sampling scans never do, defense-in-depth on top of the caller-side eligibility predicate. */
-  scan_id->page_copy_scan = page_copy_scan && (scan_type == S_HEAP_SCAN);
+  /* Guard: this function is shared by S_HEAP_SCAN, S_HEAP_SCAN_RECORD_INFO, and S_HEAP_SAMPLING_SCAN.
+   * Only plain heap scans may activate the cached scan; record-info and sampling scans never do,
+   * defense-in-depth on top of the caller-side eligibility predicate. */
+  scan_id->cached_scan = cached_scan && (scan_type == S_HEAP_SCAN);
 
   HEAP_SCAN_ID *hsidp;
   DB_TYPE single_node_type = DB_TYPE_NULL;
@@ -4579,7 +4579,7 @@ scan_start_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 	  /* A new argument(is_indexscan = false) is appended */
 	  ret =
 	    heap_scancache_start (thread_p, &hsidp->scan_cache, &hsidp->hfid, &hsidp->cls_oid, scan_id->fixed,
-				  mvcc_snapshot, scan_id->page_copy_scan);
+				  mvcc_snapshot, scan_id->cached_scan);
 	  if (ret != NO_ERROR)
 	    {
 	      goto exit_on_error;

--- a/src/query/scan_manager.h
+++ b/src/query/scan_manager.h
@@ -492,6 +492,7 @@ struct scan_id_struct
   SCAN_OPERATION_TYPE scan_op_type;	/* SELECT, DELETE, UPDATE */
 
   int fixed;			/* if true, pages containing scan items in a group keep fixed */
+  bool page_copy_scan;		/* page-copy activation for this scan (issue #154); persists across partition reopens */
   int grouped;			/* if true, the scan items are accessed group by group, instead of a whole single scan
 				 * from beginning to end. */
   int qualified_block;		/* scan block has qualified items, initially set to true */

--- a/src/query/scan_manager.h
+++ b/src/query/scan_manager.h
@@ -492,7 +492,7 @@ struct scan_id_struct
   SCAN_OPERATION_TYPE scan_op_type;	/* SELECT, DELETE, UPDATE */
 
   int fixed;			/* if true, pages containing scan items in a group keep fixed */
-  bool page_copy_scan;		/* page-copy activation for this scan (issue #154); persists across partition reopens */
+  bool cached_scan;		/* cached (copy-to-local-cache) scan activation; persists across partition reopens */
   int grouped;			/* if true, the scan items are accessed group by group, instead of a whole single scan
 				 * from beginning to end. */
   int qualified_block;		/* scan block has qualified items, initially set to true */
@@ -547,9 +547,8 @@ extern int scan_open_heap_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
 				int num_attrs_rest, ATTR_ID * attrids_rest, HEAP_CACHE_ATTRINFO * cache_rest,
 				SCAN_TYPE scan_type, DB_VALUE ** cache_recordinfo,
 				regu_variable_list_node * regu_list_recordinfo,
-				/* page_copy_scan: eligibility computed by caller (query_executor.c); Slice 1 plumbing
-				 * only -- not yet stored on SCAN_ID (see Slice 3). */
-				bool page_copy_scan = false);
+				/* cached_scan: eligibility computed by caller (query_executor.c) */
+				bool cached_scan = false);
 extern int scan_open_heap_page_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id, val_list_node * val_list,
 				     val_descr * vd, OID * cls_oid, HFID * hfid, PRED_EXPR * pr, SCAN_TYPE scan_type,
 				     DB_VALUE ** cache_page_info, regu_variable_list_node * regu_list_page_info);

--- a/src/query/scan_manager.h
+++ b/src/query/scan_manager.h
@@ -545,7 +545,10 @@ extern int scan_open_heap_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id,
 				int num_attrs_pred, ATTR_ID * attrids_pred, HEAP_CACHE_ATTRINFO * cache_pred,
 				int num_attrs_rest, ATTR_ID * attrids_rest, HEAP_CACHE_ATTRINFO * cache_rest,
 				SCAN_TYPE scan_type, DB_VALUE ** cache_recordinfo,
-				regu_variable_list_node * regu_list_recordinfo);
+				regu_variable_list_node * regu_list_recordinfo,
+				/* page_copy_scan: eligibility computed by caller (query_executor.c); Slice 1 plumbing
+				 * only -- not yet stored on SCAN_ID (see Slice 3). */
+				bool page_copy_scan = false);
 extern int scan_open_heap_page_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id, val_list_node * val_list,
 				     val_descr * vd, OID * cls_oid, HFID * hfid, PRED_EXPR * pr, SCAN_TYPE scan_type,
 				     DB_VALUE ** cache_page_info, regu_variable_list_node * regu_list_page_info);

--- a/src/query/stream_to_xasl.c
+++ b/src/query/stream_to_xasl.c
@@ -4691,7 +4691,7 @@ stx_build_access_spec_type (THREAD_ENTRY * thread_p, char *ptr, ACCESS_SPEC_TYPE
 
   access_spec->grouped_scan = false;
   access_spec->fixed_scan = false;
-  access_spec->page_copy_scan = false;	/* runtime-only; recomputed at every open (issue #154) */
+  access_spec->cached_scan = false;	/* runtime-only; recomputed at every open */
 
   ptr = or_unpack_int (ptr, &tmp);
   access_spec->single_fetch = (QPROC_SINGLE_FETCH) tmp;

--- a/src/query/stream_to_xasl.c
+++ b/src/query/stream_to_xasl.c
@@ -4691,6 +4691,7 @@ stx_build_access_spec_type (THREAD_ENTRY * thread_p, char *ptr, ACCESS_SPEC_TYPE
 
   access_spec->grouped_scan = false;
   access_spec->fixed_scan = false;
+  access_spec->page_copy_scan = false;	/* runtime-only; recomputed at every open (issue #154) */
 
   ptr = or_unpack_int (ptr, &tmp);
   access_spec->single_fetch = (QPROC_SINGLE_FETCH) tmp;

--- a/src/query/xasl.h
+++ b/src/query/xasl.h
@@ -1077,6 +1077,7 @@ struct access_spec_node
   PARTITION_SPEC_TYPE *curent;	/* current partition */
   bool grouped_scan;		/* grouped or regular scan? it is never true!!! */
   bool fixed_scan;		/* scan pages are kept fixed? */
+  bool page_copy_scan;		/* runtime-only page-copy activation (issue #154); not serialized */
   bool pruned;			/* true if partition pruning has been performed */
   bool clear_value_at_clone_decache;	/* true, if need to clear s_dbval at clone decache */
 #endif				/* #if defined (SERVER_MODE) || defined (SA_MODE) */

--- a/src/query/xasl.h
+++ b/src/query/xasl.h
@@ -1077,7 +1077,7 @@ struct access_spec_node
   PARTITION_SPEC_TYPE *curent;	/* current partition */
   bool grouped_scan;		/* grouped or regular scan? it is never true!!! */
   bool fixed_scan;		/* scan pages are kept fixed? */
-  bool page_copy_scan;		/* runtime-only page-copy activation (issue #154); not serialized */
+  bool cached_scan;		/* runtime-only cached-scan activation; not serialized */
   bool pruned;			/* true if partition pruning has been performed */
   bool clear_value_at_clone_decache;	/* true, if need to clear s_dbval at clone decache */
 #endif				/* #if defined (SERVER_MODE) || defined (SA_MODE) */

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -6774,14 +6774,6 @@ heap_scancache_check_with_hfid (THREAD_ENTRY * thread_p, HFID * hfid, OID * clas
  *   is_queryscan(in):
  *
  */
-/* TEMPORARY (issue #154 Slice 2/2W validation only -- removed in Slice 3): force page-copy read
- * mode for query scans that do not already keep their page fixed across records, ahead of the
- * Slice 3 activation predicate (qexec_is_page_copy_eligible ()) being wired through
- * scan_open_heap_scan () -> heap_scancache_start (). Debug-only; no effect in release builds. */
-#if !defined (NDEBUG)
-#define FORCE_PAGE_COPY_SCAN 1
-#endif /* !NDEBUG */
-
 static int
 heap_scancache_start_internal (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache, const HFID * hfid,
 			       const OID * class_oid, int cache_last_fix_page, bool is_queryscan,
@@ -6877,13 +6869,6 @@ heap_scancache_start_internal (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_ca
   scan_cache->copied_buf_handle = NULL;
   VPID_SET_NULL (&scan_cache->copied_vpid);
   scan_cache->read_mode = HEAP_SCAN_READ_COPY;
-#if defined (FORCE_PAGE_COPY_SCAN)
-  if (!cache_last_fix_page && is_queryscan)
-    {
-      /* TEMPORARY (issue #154 Slice 2/2W validation only) -- removed in Slice 3. */
-      page_copy = true;
-    }
-#endif /* FORCE_PAGE_COPY_SCAN */
   if (page_copy && is_queryscan)
     {
       scan_cache->copied_buf_handle = pgbuf_copy_buffer_alloc ();
@@ -7987,8 +7972,10 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
 		  pgbuf_replace_watcher (thread_p, &scan_cache->page_watcher, &old_page_watcher);
 		}
 	    }
-	  /* Page-copy fast path: skip fix entirely if same page already copied (issue #154, Slice 2). */
-	  if (scan_cache->read_mode == HEAP_SCAN_READ_PAGE_COPY
+	  /* Page-copy fast path: skip fix entirely if same page already copied (issue #154, Slice 2).
+	   * record-info scans never use page-copy (critic gate 1 F1): heap_get_record_info () below
+	   * derefs scan_cache->page_watcher directly and requires a live fixed page. */
+	  if (!get_rec_info && scan_cache->read_mode == HEAP_SCAN_READ_PAGE_COPY
 	      && scan_cache->copied_buf_handle != NULL && VPID_EQ (&vpid, &scan_cache->copied_vpid))
 	    {
 	      /* Same page already in copy buffer -- use it directly. Unfix any fall-through-parked
@@ -8026,9 +8013,10 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
 		}
 	    }
 
-	  if (scan_cache->read_mode == HEAP_SCAN_READ_PAGE_COPY && scan_cache->copied_buf_handle != NULL)
+	  if (!get_rec_info && scan_cache->read_mode == HEAP_SCAN_READ_PAGE_COPY && scan_cache->copied_buf_handle != NULL)
 	    {
-	      /* New page (VPID_EQ failed above) -- copy frame and unfix (issue #154, Slice 2). */
+	      /* New page (VPID_EQ failed above) -- copy frame and unfix (issue #154, Slice 2).
+	       * record-info scans never use page-copy (critic gate 1 F1). */
 	      pgbuf_copy_page_for_scan (scan_cache->page_watcher.pgptr, scan_cache->copied_buf_handle);
 	      scan_cache->copied_vpid = vpid;
 	      pgbuf_ordered_unfix (thread_p, &scan_cache->page_watcher);

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -157,6 +157,11 @@ static int rv;
 
 #define HEAP_SCAN_ORDERED_HFID(scan) \
   (((scan) != NULL) ? (&(scan)->node.hfid) : (PGBUF_ORDERED_NULL_HFID))
+
+/* Cached (copy-to-local-cache) heap scan is active on this scan cache (CBRD-27041). */
+#define HEAP_SCAN_IS_LOCAL_CACHE_READ(scan_cache) \
+  ((scan_cache)->read_mode == HEAP_SCAN_READ_LOCAL_CACHE && (scan_cache)->local_cache_handle != NULL)
+
 typedef enum
 {
   HEAP_FINDSPACE_FOUND,
@@ -7888,8 +7893,7 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
   SCAN_CODE scan = S_ERROR;
   int get_rec_info = cache_recordinfo != NULL;
   bool is_null_recdata;
-  bool is_cached_scan =
-    (!get_rec_info && scan_cache->read_mode == HEAP_SCAN_READ_LOCAL_CACHE && scan_cache->local_cache_handle != NULL);
+  bool is_cached_scan = (!get_rec_info && HEAP_SCAN_IS_LOCAL_CACHE_READ (scan_cache));
   PGBUF_WATCHER old_page_watcher;
   PGBUF_WATCHER rec_info_page_watcher;
   PAGE_PTR local_pgptr = NULL;	/* cached-scan read pointer (local cache or live page) */
@@ -7977,8 +7981,8 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
 	  /* Cached-scan fast path: skip fix entirely if the same page is already in the local cache.
 	   * record-info scans never use the cached scan: heap_get_record_info () below derefs
 	   * scan_cache->page_watcher directly and requires a live fixed page. */
-	  if (!get_rec_info && scan_cache->read_mode == HEAP_SCAN_READ_LOCAL_CACHE
-	      && scan_cache->local_cache_handle != NULL && VPID_EQ (&vpid, &scan_cache->local_cache_vpid))
+	  if (!get_rec_info && HEAP_SCAN_IS_LOCAL_CACHE_READ (scan_cache)
+	      && VPID_EQ (&vpid, &scan_cache->local_cache_vpid))
 	    {
 	      /* Same page already in the local cache -- use it directly. Keep a live watcher, if any, until a
 	       * visible record is returned or traversal moves to another page. */
@@ -8010,8 +8014,7 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
 		}
 	    }
 
-	  if (!get_rec_info && scan_cache->read_mode == HEAP_SCAN_READ_LOCAL_CACHE
-	      && scan_cache->local_cache_handle != NULL)
+	  if (!get_rec_info && HEAP_SCAN_IS_LOCAL_CACHE_READ (scan_cache))
 	    {
 	      /* New page (VPID_EQ failed above) -- copy the frame to the local cache. Keep the live page fixed
 	       * until a visible record is returned or traversal moves to another page, so vacuum cannot deallocate
@@ -8100,8 +8103,7 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
 	      if (scan == S_END)
 		{
 		  /* Find next page of heap and continue scanning */
-		  if (scan_cache->read_mode == HEAP_SCAN_READ_LOCAL_CACHE && scan_cache->local_cache_handle != NULL
-		      && scan_cache->page_watcher.pgptr == NULL)
+		  if (HEAP_SCAN_IS_LOCAL_CACHE_READ (scan_cache) && scan_cache->page_watcher.pgptr == NULL)
 		    {
 		      /* A prior visible-record return released the live page. Re-fix it before reading the current
 		       * live page chain; the links in the local copy may be stale. */
@@ -8114,6 +8116,13 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
 			    {
 			      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HEAP_UNKNOWN_OBJECT, 3, oid.volid,
 				      oid.pageid, oid.slotid);
+			    }
+
+			  if (old_page_watcher.pgptr != NULL)
+			    {
+			      /* defensive: no known path leaves the old watcher fixed here, but do not
+			       * leak a fixed page on the error return */
+			      pgbuf_ordered_unfix (thread_p, &old_page_watcher);
 			    }
 
 			  /* something went wrong, return */
@@ -8327,7 +8336,7 @@ heap_next_1page (THREAD_ENTRY * thread_p, const HFID * hfid, const VPID * vpid, 
   RECDES forward_recdes;
   SCAN_CODE scan = S_ERROR;
   bool is_null_recdata;
-  bool is_cached_scan = (scan_cache->read_mode == HEAP_SCAN_READ_LOCAL_CACHE && scan_cache->local_cache_handle != NULL);
+  bool is_cached_scan = HEAP_SCAN_IS_LOCAL_CACHE_READ (scan_cache);
   PAGE_PTR local_pgptr = NULL;	/* cached-scan read pointer (local cache or live page) */
 
   if (!OID_ISNULL (&scan_cache->node.class_oid))
@@ -8359,8 +8368,7 @@ heap_next_1page (THREAD_ENTRY * thread_p, const HFID * hfid, const VPID * vpid, 
 	{
 
 	  /* Cached-scan fast path: skip fix if the same page is already in the local cache. */
-	  if (scan_cache->read_mode == HEAP_SCAN_READ_LOCAL_CACHE
-	      && scan_cache->local_cache_handle != NULL && VPID_EQ (vpid, &scan_cache->local_cache_vpid))
+	  if (HEAP_SCAN_IS_LOCAL_CACHE_READ (scan_cache) && VPID_EQ (vpid, &scan_cache->local_cache_vpid))
 	    {
 	      /* Same page already in the local cache -- use it directly. Keep the live watcher until a visible
 	       * record is returned or the input handler hands off to another page. */
@@ -8401,7 +8409,7 @@ heap_next_1page (THREAD_ENTRY * thread_p, const HFID * hfid, const VPID * vpid, 
 		}
 	    }
 
-	  if (scan_cache->read_mode == HEAP_SCAN_READ_LOCAL_CACHE && scan_cache->local_cache_handle != NULL)
+	  if (HEAP_SCAN_IS_LOCAL_CACHE_READ (scan_cache))
 	    {
 	      /* New page (VPID_EQ failed above) -- copy the frame to the local cache. Keep the live page fixed
 	       * until a visible record is returned or traversal/handoff completes, so vacuum cannot deallocate

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -660,7 +660,7 @@ static int heap_scancache_check_with_hfid (THREAD_ENTRY * thread_p, HFID * hfid,
 					   HEAP_SCANCACHE ** scan_cache);
 static int heap_scancache_start_internal (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache, const HFID * hfid,
 					  const OID * class_oid, int cache_last_fix_page, bool is_queryscan,
-					  MVCC_SNAPSHOT * mvcc_snapshot, bool page_copy = false);
+					  MVCC_SNAPSHOT * mvcc_snapshot, bool copy_to_local_cache = false);
 static int heap_scancache_force_modify (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache);
 static int heap_scancache_reset_modify (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache, const HFID * hfid,
 					const OID * class_oid);
@@ -6777,7 +6777,7 @@ heap_scancache_check_with_hfid (THREAD_ENTRY * thread_p, HFID * hfid, OID * clas
 static int
 heap_scancache_start_internal (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache, const HFID * hfid,
 			       const OID * class_oid, int cache_last_fix_page, bool is_queryscan,
-			       MVCC_SNAPSHOT * mvcc_snapshot, bool page_copy)
+			       MVCC_SNAPSHOT * mvcc_snapshot, bool copy_to_local_cache)
 {
   int ret = NO_ERROR;
   int granted;
@@ -6866,20 +6866,20 @@ heap_scancache_start_internal (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_ca
   scan_cache->debug_initpattern = HEAP_DEBUG_SCANCACHE_INITPATTERN;
   scan_cache->mvcc_snapshot = mvcc_snapshot;
   scan_cache->partition_list = NULL;
-  scan_cache->copied_buf_handle = NULL;
-  VPID_SET_NULL (&scan_cache->copied_vpid);
+  scan_cache->local_cache_handle = NULL;
+  VPID_SET_NULL (&scan_cache->local_cache_vpid);
   scan_cache->read_mode = HEAP_SCAN_READ_COPY;
-  if (page_copy && is_queryscan)
+  if (copy_to_local_cache && is_queryscan)
     {
-      scan_cache->copied_buf_handle = pgbuf_copy_buffer_alloc ();
-      if (scan_cache->copied_buf_handle == NULL)
+      scan_cache->local_cache_handle = pgbuf_copy_buffer_alloc ();
+      if (scan_cache->local_cache_handle == NULL)
 	{
 	  /* OOM contract (pinned): degrade to COPY, no er_set, no error return. */
-	  er_log_debug (ARG_FILE_LINE, "page-copy buffer alloc failed, degrading to COPY");
+	  er_log_debug (ARG_FILE_LINE, "local cache buffer alloc failed, degrading to COPY");
 	}
       else
 	{
-	  scan_cache->read_mode = HEAP_SCAN_READ_PAGE_COPY;
+	  scan_cache->read_mode = HEAP_SCAN_READ_LOCAL_CACHE;
 	}
     }
 
@@ -6900,8 +6900,8 @@ exit_on_error:
   scan_cache->debug_initpattern = 0;
   scan_cache->mvcc_snapshot = NULL;
   scan_cache->partition_list = NULL;
-  scan_cache->copied_buf_handle = NULL;
-  VPID_SET_NULL (&scan_cache->copied_vpid);
+  scan_cache->local_cache_handle = NULL;
+  VPID_SET_NULL (&scan_cache->local_cache_vpid);
   scan_cache->read_mode = HEAP_SCAN_READ_COPY;
 
   return (ret == NO_ERROR && (ret = er_errid ()) == NO_ERROR) ? ER_FAILED : ret;
@@ -6922,10 +6922,10 @@ exit_on_error:
  */
 int
 heap_scancache_start (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache, const HFID * hfid, const OID * class_oid,
-		      int cache_last_fix_page, MVCC_SNAPSHOT * mvcc_snapshot, bool page_copy)
+		      int cache_last_fix_page, MVCC_SNAPSHOT * mvcc_snapshot, bool copy_to_local_cache)
 {
   return heap_scancache_start_internal (thread_p, scan_cache, hfid, class_oid, cache_last_fix_page, true,
-					mvcc_snapshot, page_copy);
+					mvcc_snapshot, copy_to_local_cache);
 }
 
 /*
@@ -7186,8 +7186,8 @@ heap_scancache_quick_start_internal (HEAP_SCANCACHE * scan_cache, const HFID * h
   scan_cache->debug_initpattern = HEAP_DEBUG_SCANCACHE_INITPATTERN;
   scan_cache->mvcc_snapshot = NULL;
   scan_cache->partition_list = NULL;
-  scan_cache->copied_buf_handle = NULL;
-  VPID_SET_NULL (&scan_cache->copied_vpid);
+  scan_cache->local_cache_handle = NULL;
+  VPID_SET_NULL (&scan_cache->local_cache_vpid);
   scan_cache->read_mode = HEAP_SCAN_READ_COPY;
 
   return NO_ERROR;
@@ -7242,9 +7242,9 @@ heap_scancache_quick_end (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache)
 	    }
 	}
 
-      pgbuf_copy_buffer_free (scan_cache->copied_buf_handle);
-      scan_cache->copied_buf_handle = NULL;
-      VPID_SET_NULL (&scan_cache->copied_vpid);
+      pgbuf_copy_buffer_free (scan_cache->local_cache_handle);
+      scan_cache->local_cache_handle = NULL;
+      VPID_SET_NULL (&scan_cache->local_cache_vpid);
       scan_cache->read_mode = HEAP_SCAN_READ_COPY;
     }
 
@@ -7890,7 +7890,7 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
   bool is_null_recdata;
   PGBUF_WATCHER old_page_watcher;
   PGBUF_WATCHER rec_info_page_watcher;
-  PAGE_PTR local_pgptr = NULL;	/* issue #154: page-copy read pointer (copy buffer or live page) */
+  PAGE_PTR local_pgptr = NULL;	/* cached-scan read pointer (local cache or live page) */
 
   assert (scan_cache != NULL);
 
@@ -7972,20 +7972,20 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
 		  pgbuf_replace_watcher (thread_p, &scan_cache->page_watcher, &old_page_watcher);
 		}
 	    }
-	  /* Page-copy fast path: skip fix entirely if same page already copied (issue #154, Slice 2).
-	   * record-info scans never use page-copy (critic gate 1 F1): heap_get_record_info () below
-	   * derefs scan_cache->page_watcher directly and requires a live fixed page. */
-	  if (!get_rec_info && scan_cache->read_mode == HEAP_SCAN_READ_PAGE_COPY
-	      && scan_cache->copied_buf_handle != NULL && VPID_EQ (&vpid, &scan_cache->copied_vpid))
+	  /* Cached-scan fast path: skip fix entirely if the same page is already in the local cache.
+	   * record-info scans never use the cached scan: heap_get_record_info () below derefs
+	   * scan_cache->page_watcher directly and requires a live fixed page. */
+	  if (!get_rec_info && scan_cache->read_mode == HEAP_SCAN_READ_LOCAL_CACHE
+	      && scan_cache->local_cache_handle != NULL && VPID_EQ (&vpid, &scan_cache->local_cache_vpid))
 	    {
-	      /* Same page already in copy buffer -- use it directly. Unfix any fall-through-parked
+	      /* Same page already in the local cache -- use it directly. Unfix any fall-through-parked
 	       * page (heap_clean_get_context can park a live page when cache_last_fix_page was
 	       * temporarily forced true for the previous record's heap_scan_get_visible_version call). */
 	      if (scan_cache->page_watcher.pgptr != NULL)
 		{
 		  pgbuf_ordered_unfix (thread_p, &scan_cache->page_watcher);
 		}
-	      local_pgptr = pgbuf_copy_buffer_get_page_ptr (scan_cache->copied_buf_handle);
+	      local_pgptr = pgbuf_copy_buffer_get_page_ptr (scan_cache->local_cache_handle);
 	      goto slot_walk;
 	    }
 	  /* else: fall through to existing fix block */
@@ -8013,18 +8013,19 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
 		}
 	    }
 
-	  if (!get_rec_info && scan_cache->read_mode == HEAP_SCAN_READ_PAGE_COPY && scan_cache->copied_buf_handle != NULL)
+	  if (!get_rec_info && scan_cache->read_mode == HEAP_SCAN_READ_LOCAL_CACHE
+	      && scan_cache->local_cache_handle != NULL)
 	    {
-	      /* New page (VPID_EQ failed above) -- copy frame and unfix (issue #154, Slice 2).
-	       * record-info scans never use page-copy (critic gate 1 F1). */
-	      pgbuf_copy_page_for_scan (scan_cache->page_watcher.pgptr, scan_cache->copied_buf_handle);
-	      scan_cache->copied_vpid = vpid;
+	      /* New page (VPID_EQ failed above) -- copy the frame to the local cache and unfix.
+	       * record-info scans never use the cached scan. */
+	      pgbuf_copy_page_for_scan (scan_cache->page_watcher.pgptr, scan_cache->local_cache_handle);
+	      scan_cache->local_cache_vpid = vpid;
 	      pgbuf_ordered_unfix (thread_p, &scan_cache->page_watcher);
-	      local_pgptr = pgbuf_copy_buffer_get_page_ptr (scan_cache->copied_buf_handle);
+	      local_pgptr = pgbuf_copy_buffer_get_page_ptr (scan_cache->local_cache_handle);
 	    }
 	  else
 	    {
-	      local_pgptr = scan_cache->page_watcher.pgptr;	/* live page (non-copy mode) */
+	      local_pgptr = scan_cache->page_watcher.pgptr;	/* live page (non-cached mode) */
 	    }
 
 	slot_walk:
@@ -8034,22 +8035,16 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
 	      /* Getting record information means that we need to scan all slots even if they store no object. */
 	      if (reversed_direction)
 		{
-		  scan =
-		    spage_previous_record_dont_skip_empty (local_pgptr, &oid.slotid, &forward_recdes,
-							   PEEK);
+		  scan = spage_previous_record_dont_skip_empty (local_pgptr, &oid.slotid, &forward_recdes, PEEK);
 		}
 	      else
 		{
-		  scan =
-		    spage_next_record_dont_skip_empty (local_pgptr, &oid.slotid, &forward_recdes,
-						       PEEK);
+		  scan = spage_next_record_dont_skip_empty (local_pgptr, &oid.slotid, &forward_recdes, PEEK);
 		}
 	      if (oid.slotid == HEAP_HEADER_AND_CHAIN_SLOTID)
 		{
 		  /* skip the header */
-		  scan =
-		    spage_next_record_dont_skip_empty (local_pgptr, &oid.slotid, &forward_recdes,
-						       PEEK);
+		  scan = spage_next_record_dont_skip_empty (local_pgptr, &oid.slotid, &forward_recdes, PEEK);
 		}
 	    }
 	  else
@@ -8107,19 +8102,19 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
 	      if (scan == S_END)
 		{
 		  /* Find next page of heap and continue scanning */
-		  if (scan_cache->read_mode == HEAP_SCAN_READ_PAGE_COPY && scan_cache->copied_buf_handle != NULL)
+		  if (scan_cache->read_mode == HEAP_SCAN_READ_LOCAL_CACHE && scan_cache->local_cache_handle != NULL)
 		    {
-		      /* page_watcher.pgptr is NULL here (copy mode always unfixes after copying); re-fix the
-		       * copied page so heap_vpid_prev/heap_vpid_next below have a live pointer (issue #154). */
+		      /* page_watcher.pgptr is NULL here (a cached scan always unfixes after copying); re-fix
+		       * the cached page so heap_vpid_prev/heap_vpid_next below have a live pointer. */
 		      scan_cache->page_watcher.pgptr =
-			heap_scan_pb_lock_and_fetch (thread_p, &scan_cache->copied_vpid, OLD_PAGE_PREVENT_DEALLOC, S_LOCK,
-						     scan_cache, &scan_cache->page_watcher);
+			heap_scan_pb_lock_and_fetch (thread_p, &scan_cache->local_cache_vpid, OLD_PAGE_PREVENT_DEALLOC,
+						     S_LOCK, scan_cache, &scan_cache->page_watcher);
 		      if (scan_cache->page_watcher.pgptr == NULL)
 			{
 			  if (er_errid () == ER_PB_BAD_PAGEID)
 			    {
-			      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HEAP_UNKNOWN_OBJECT, 3, oid.volid, oid.pageid,
-				      oid.slotid);
+			      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HEAP_UNKNOWN_OBJECT, 3, oid.volid,
+				      oid.pageid, oid.slotid);
 			    }
 
 			  /* something went wrong, return */
@@ -8201,14 +8196,15 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
       else
 	{
 	  int cache_last_fix_page_save = scan_cache->cache_last_fix_page;
-	  bool is_pc = (scan_cache->read_mode == HEAP_SCAN_READ_PAGE_COPY && scan_cache->copied_buf_handle != NULL);
+	  bool is_cached_scan = (scan_cache->read_mode == HEAP_SCAN_READ_LOCAL_CACHE
+				 && scan_cache->local_cache_handle != NULL);
 
 	  scan_cache->cache_last_fix_page = true;
-	  assert (!is_pc || scan_cache->page_watcher.pgptr == NULL);	/* latch-free invariant: copy-mode consumption never holds the live page */
+	  assert (!is_cached_scan || scan_cache->page_watcher.pgptr == NULL);	/* latch-free invariant: cached-scan consumption never holds the live page */
 
 	  scan =
 	    heap_scan_get_visible_version (thread_p, &oid, class_oid, recdes, &forward_recdes, scan_cache, ispeeking,
-					   NULL_CHN, is_pc);
+					   NULL_CHN, is_cached_scan);
 	  scan_cache->cache_last_fix_page = cache_last_fix_page_save;
 	}
 
@@ -8334,7 +8330,7 @@ heap_next_1page (THREAD_ENTRY * thread_p, const HFID * hfid, const VPID * vpid, 
   RECDES forward_recdes;
   SCAN_CODE scan = S_ERROR;
   bool is_null_recdata;
-  PAGE_PTR local_pgptr = NULL;	/* issue #154: page-copy read pointer (copy buffer or live page) */
+  PAGE_PTR local_pgptr = NULL;	/* cached-scan read pointer (local cache or live page) */
 
   if (!OID_ISNULL (&scan_cache->node.class_oid))
     {
@@ -8364,9 +8360,9 @@ heap_next_1page (THREAD_ENTRY * thread_p, const HFID * hfid, const VPID * vpid, 
       while (true)
 	{
 
-	  /* Page-copy fast path: skip fix if same page already copied (issue #154, Slice 2W). */
-	  if (scan_cache->read_mode == HEAP_SCAN_READ_PAGE_COPY
-	      && scan_cache->copied_buf_handle != NULL && VPID_EQ (vpid, &scan_cache->copied_vpid))
+	  /* Cached-scan fast path: skip fix if the same page is already in the local cache. */
+	  if (scan_cache->read_mode == HEAP_SCAN_READ_LOCAL_CACHE
+	      && scan_cache->local_cache_handle != NULL && VPID_EQ (vpid, &scan_cache->local_cache_vpid))
 	    {
 	      /* Unfix any fall-through-parked page (heap_clean_get_context can park a live page when
 	       * cache_last_fix_page was temporarily forced true for the previous record's
@@ -8375,7 +8371,7 @@ heap_next_1page (THREAD_ENTRY * thread_p, const HFID * hfid, const VPID * vpid, 
 		{
 		  pgbuf_ordered_unfix (thread_p, &scan_cache->page_watcher);
 		}
-	      local_pgptr = pgbuf_copy_buffer_get_page_ptr (scan_cache->copied_buf_handle);
+	      local_pgptr = pgbuf_copy_buffer_get_page_ptr (scan_cache->local_cache_handle);
 	      goto slot_walk_1page;
 	    }
 	  /* else: fall through to existing fix block */
@@ -8412,13 +8408,13 @@ heap_next_1page (THREAD_ENTRY * thread_p, const HFID * hfid, const VPID * vpid, 
 		}
 	    }
 
-	  if (scan_cache->read_mode == HEAP_SCAN_READ_PAGE_COPY && scan_cache->copied_buf_handle != NULL)
+	  if (scan_cache->read_mode == HEAP_SCAN_READ_LOCAL_CACHE && scan_cache->local_cache_handle != NULL)
 	    {
-	      /* New page (VPID_EQ failed above) -- copy frame and unfix (issue #154, Slice 2W). */
-	      pgbuf_copy_page_for_scan (scan_cache->page_watcher.pgptr, scan_cache->copied_buf_handle);
-	      scan_cache->copied_vpid = *vpid;
+	      /* New page (VPID_EQ failed above) -- copy the frame to the local cache and unfix. */
+	      pgbuf_copy_page_for_scan (scan_cache->page_watcher.pgptr, scan_cache->local_cache_handle);
+	      scan_cache->local_cache_vpid = *vpid;
 	      pgbuf_ordered_unfix (thread_p, &scan_cache->page_watcher);
-	      local_pgptr = pgbuf_copy_buffer_get_page_ptr (scan_cache->copied_buf_handle);
+	      local_pgptr = pgbuf_copy_buffer_get_page_ptr (scan_cache->local_cache_handle);
 	    }
 	  else
 	    {
@@ -8482,16 +8478,16 @@ heap_next_1page (THREAD_ENTRY * thread_p, const HFID * hfid, const VPID * vpid, 
 
       {
 	int cache_last_fix_page_save = scan_cache->cache_last_fix_page;
-	bool is_pc = (scan_cache->read_mode == HEAP_SCAN_READ_PAGE_COPY
-		      && scan_cache->copied_buf_handle != NULL
-		      && local_pgptr == pgbuf_copy_buffer_get_page_ptr (scan_cache->copied_buf_handle));
+	bool is_cached_scan = (scan_cache->read_mode == HEAP_SCAN_READ_LOCAL_CACHE
+			       && scan_cache->local_cache_handle != NULL
+			       && local_pgptr == pgbuf_copy_buffer_get_page_ptr (scan_cache->local_cache_handle));
 
 	scan_cache->cache_last_fix_page = true;
-	assert (!is_pc || scan_cache->page_watcher.pgptr == NULL);	/* latch-free invariant: copy-mode consumption never holds the live page */
+	assert (!is_cached_scan || scan_cache->page_watcher.pgptr == NULL);	/* latch-free invariant: cached-scan consumption never holds the live page */
 
 	scan =
 	  heap_scan_get_visible_version (thread_p, &oid, class_oid, recdes, &forward_recdes, scan_cache, ispeeking,
-					 NULL_CHN, is_pc);
+					 NULL_CHN, is_cached_scan);
 	scan_cache->cache_last_fix_page = cache_last_fix_page_save;
       }
 
@@ -25622,14 +25618,14 @@ heap_get_visible_version (THREAD_ENTRY * thread_p, const OID * oid, OID * class_
 *   old_chn (in): Cache coherency number for existing record data. It is
 *		   used by clients to avoid resending record data when
 *		   it was not updated.
-*   is_page_copy (in): call-scoped page-copy read mode (issue #154). Plumbed in Slice 1; consumed
-*		       by the REC_HOME shortcut starting Slice 2. Default false everywhere.
+*   is_cached_scan (in): call-scoped cached-scan read mode (CBRD-27041). When true, the caller
+*		       guarantees peeked_recdes->data points into the scan-private local cache.
 *  Note: this function should be used for heap scan;
 */
 SCAN_CODE
 heap_scan_get_visible_version (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid, RECDES * recdes,
 			       RECDES * peeked_recdes, HEAP_SCANCACHE * scan_cache, int ispeeking, int old_chn,
-			       bool is_page_copy)
+			       bool is_cached_scan)
 {
   SCAN_CODE scan = S_SUCCESS;
   HEAP_GET_CONTEXT context;
@@ -25696,11 +25692,11 @@ heap_scan_get_visible_version (THREAD_ENTRY * thread_p, const OID * oid, OID * c
 	      return scan;
 	    }
 
-	  if (is_page_copy)
+	  if (is_cached_scan)
 	    {
-	      /* Caller guarantees peeked_recdes->data points into the copied_buf_handle frame (issue #154,
-	       * Slice 2/2W): local_pgptr was set from pgbuf_copy_buffer_get_page_ptr () whenever is_pc/is_page_copy
-	       * is true, so peeked_recdes->data is stable copy memory, not a live latched page. */
+	      /* Caller guarantees peeked_recdes->data points into the local_cache_handle frame:
+	       * local_pgptr was set from pgbuf_copy_buffer_get_page_ptr () whenever is_cached_scan
+	       * is true, so peeked_recdes->data is stable local-cache memory, not a live latched page. */
 	      *recdes = *peeked_recdes;
 	      return scan;
 	    }

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -7888,6 +7888,8 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
   SCAN_CODE scan = S_ERROR;
   int get_rec_info = cache_recordinfo != NULL;
   bool is_null_recdata;
+  bool is_cached_scan =
+    (!get_rec_info && scan_cache->read_mode == HEAP_SCAN_READ_LOCAL_CACHE && scan_cache->local_cache_handle != NULL);
   PGBUF_WATCHER old_page_watcher;
   PGBUF_WATCHER rec_info_page_watcher;
   PAGE_PTR local_pgptr = NULL;	/* cached-scan read pointer (local cache or live page) */
@@ -7978,13 +7980,8 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
 	  if (!get_rec_info && scan_cache->read_mode == HEAP_SCAN_READ_LOCAL_CACHE
 	      && scan_cache->local_cache_handle != NULL && VPID_EQ (&vpid, &scan_cache->local_cache_vpid))
 	    {
-	      /* Same page already in the local cache -- use it directly. Unfix any fall-through-parked
-	       * page (heap_clean_get_context can park a live page when cache_last_fix_page was
-	       * temporarily forced true for the previous record's heap_scan_get_visible_version call). */
-	      if (scan_cache->page_watcher.pgptr != NULL)
-		{
-		  pgbuf_ordered_unfix (thread_p, &scan_cache->page_watcher);
-		}
+	      /* Same page already in the local cache -- use it directly. Keep a live watcher, if any, until a
+	       * visible record is returned or traversal moves to another page. */
 	      local_pgptr = pgbuf_copy_buffer_get_page_ptr (scan_cache->local_cache_handle);
 	      goto slot_walk;
 	    }
@@ -8016,11 +8013,12 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
 	  if (!get_rec_info && scan_cache->read_mode == HEAP_SCAN_READ_LOCAL_CACHE
 	      && scan_cache->local_cache_handle != NULL)
 	    {
-	      /* New page (VPID_EQ failed above) -- copy the frame to the local cache and unfix.
+	      /* New page (VPID_EQ failed above) -- copy the frame to the local cache. Keep the live page fixed
+	       * until a visible record is returned or traversal moves to another page, so vacuum cannot deallocate
+	       * the page while slots from the local copy are still being inspected.
 	       * record-info scans never use the cached scan. */
 	      pgbuf_copy_page_for_scan (scan_cache->page_watcher.pgptr, scan_cache->local_cache_handle);
 	      scan_cache->local_cache_vpid = vpid;
-	      pgbuf_ordered_unfix (thread_p, &scan_cache->page_watcher);
 	      local_pgptr = pgbuf_copy_buffer_get_page_ptr (scan_cache->local_cache_handle);
 	    }
 	  else
@@ -8102,10 +8100,11 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
 	      if (scan == S_END)
 		{
 		  /* Find next page of heap and continue scanning */
-		  if (scan_cache->read_mode == HEAP_SCAN_READ_LOCAL_CACHE && scan_cache->local_cache_handle != NULL)
+		  if (scan_cache->read_mode == HEAP_SCAN_READ_LOCAL_CACHE && scan_cache->local_cache_handle != NULL
+		      && scan_cache->page_watcher.pgptr == NULL)
 		    {
-		      /* page_watcher.pgptr is NULL here (a cached scan always unfixes after copying); re-fix
-		       * the cached page so heap_vpid_prev/heap_vpid_next below have a live pointer. */
+		      /* A prior visible-record return released the live page. Re-fix it before reading the current
+		       * live page chain; the links in the local copy may be stale. */
 		      scan_cache->page_watcher.pgptr =
 			heap_scan_pb_lock_and_fetch (thread_p, &scan_cache->local_cache_vpid, OLD_PAGE_PREVENT_DEALLOC,
 						     S_LOCK, scan_cache, &scan_cache->page_watcher);
@@ -8196,11 +8195,8 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
       else
 	{
 	  int cache_last_fix_page_save = scan_cache->cache_last_fix_page;
-	  bool is_cached_scan = (scan_cache->read_mode == HEAP_SCAN_READ_LOCAL_CACHE
-				 && scan_cache->local_cache_handle != NULL);
 
 	  scan_cache->cache_last_fix_page = true;
-	  assert (!is_cached_scan || scan_cache->page_watcher.pgptr == NULL);	/* latch-free invariant: cached-scan consumption never holds the live page */
 
 	  scan =
 	    heap_scan_get_visible_version (thread_p, &oid, class_oid, recdes, &forward_recdes, scan_cache, ispeeking,
@@ -8255,6 +8251,7 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
     {
       pgbuf_ordered_unfix (thread_p, &scan_cache->page_watcher);
     }
+  assert (!is_cached_scan || scan != S_SUCCESS || scan_cache->page_watcher.pgptr == NULL);
 
   return scan;
 }
@@ -8330,6 +8327,8 @@ heap_next_1page (THREAD_ENTRY * thread_p, const HFID * hfid, const VPID * vpid, 
   RECDES forward_recdes;
   SCAN_CODE scan = S_ERROR;
   bool is_null_recdata;
+  bool is_cached_scan =
+    (scan_cache->read_mode == HEAP_SCAN_READ_LOCAL_CACHE && scan_cache->local_cache_handle != NULL);
   PAGE_PTR local_pgptr = NULL;	/* cached-scan read pointer (local cache or live page) */
 
   if (!OID_ISNULL (&scan_cache->node.class_oid))
@@ -8364,13 +8363,8 @@ heap_next_1page (THREAD_ENTRY * thread_p, const HFID * hfid, const VPID * vpid, 
 	  if (scan_cache->read_mode == HEAP_SCAN_READ_LOCAL_CACHE
 	      && scan_cache->local_cache_handle != NULL && VPID_EQ (vpid, &scan_cache->local_cache_vpid))
 	    {
-	      /* Unfix any fall-through-parked page (heap_clean_get_context can park a live page when
-	       * cache_last_fix_page was temporarily forced true for the previous record's
-	       * heap_scan_get_visible_version call). */
-	      if (scan_cache->page_watcher.pgptr != NULL)
-		{
-		  pgbuf_ordered_unfix (thread_p, &scan_cache->page_watcher);
-		}
+	      /* Same page already in the local cache -- use it directly. Keep the live watcher until a visible
+	       * record is returned or the input handler hands off to another page. */
 	      local_pgptr = pgbuf_copy_buffer_get_page_ptr (scan_cache->local_cache_handle);
 	      goto slot_walk_1page;
 	    }
@@ -8410,10 +8404,11 @@ heap_next_1page (THREAD_ENTRY * thread_p, const HFID * hfid, const VPID * vpid, 
 
 	  if (scan_cache->read_mode == HEAP_SCAN_READ_LOCAL_CACHE && scan_cache->local_cache_handle != NULL)
 	    {
-	      /* New page (VPID_EQ failed above) -- copy the frame to the local cache and unfix. */
+	      /* New page (VPID_EQ failed above) -- copy the frame to the local cache. Keep the live page fixed
+	       * until a visible record is returned or traversal/handoff completes, so vacuum cannot deallocate
+	       * the page while slots from the local copy are still being inspected. */
 	      pgbuf_copy_page_for_scan (scan_cache->page_watcher.pgptr, scan_cache->local_cache_handle);
 	      scan_cache->local_cache_vpid = *vpid;
-	      pgbuf_ordered_unfix (thread_p, &scan_cache->page_watcher);
 	      local_pgptr = pgbuf_copy_buffer_get_page_ptr (scan_cache->local_cache_handle);
 	    }
 	  else
@@ -8478,12 +8473,8 @@ heap_next_1page (THREAD_ENTRY * thread_p, const HFID * hfid, const VPID * vpid, 
 
       {
 	int cache_last_fix_page_save = scan_cache->cache_last_fix_page;
-	bool is_cached_scan = (scan_cache->read_mode == HEAP_SCAN_READ_LOCAL_CACHE
-			       && scan_cache->local_cache_handle != NULL
-			       && local_pgptr == pgbuf_copy_buffer_get_page_ptr (scan_cache->local_cache_handle));
 
 	scan_cache->cache_last_fix_page = true;
-	assert (!is_cached_scan || scan_cache->page_watcher.pgptr == NULL);	/* latch-free invariant: cached-scan consumption never holds the live page */
 
 	scan =
 	  heap_scan_get_visible_version (thread_p, &oid, class_oid, recdes, &forward_recdes, scan_cache, ispeeking,
@@ -8534,6 +8525,7 @@ heap_next_1page (THREAD_ENTRY * thread_p, const HFID * hfid, const VPID * vpid, 
     {
       pgbuf_ordered_unfix (thread_p, &scan_cache->page_watcher);
     }
+  assert (!is_cached_scan || scan != S_SUCCESS || scan_cache->page_watcher.pgptr == NULL);
 
   return scan;
 }

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -8327,8 +8327,7 @@ heap_next_1page (THREAD_ENTRY * thread_p, const HFID * hfid, const VPID * vpid, 
   RECDES forward_recdes;
   SCAN_CODE scan = S_ERROR;
   bool is_null_recdata;
-  bool is_cached_scan =
-    (scan_cache->read_mode == HEAP_SCAN_READ_LOCAL_CACHE && scan_cache->local_cache_handle != NULL);
+  bool is_cached_scan = (scan_cache->read_mode == HEAP_SCAN_READ_LOCAL_CACHE && scan_cache->local_cache_handle != NULL);
   PAGE_PTR local_pgptr = NULL;	/* cached-scan read pointer (local cache or live page) */
 
   if (!OID_ISNULL (&scan_cache->node.class_oid))

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -8204,6 +8204,7 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
 	  bool is_pc = (scan_cache->read_mode == HEAP_SCAN_READ_PAGE_COPY && scan_cache->copied_buf_handle != NULL);
 
 	  scan_cache->cache_last_fix_page = true;
+	  assert (!is_pc || scan_cache->page_watcher.pgptr == NULL);	/* latch-free invariant: copy-mode consumption never holds the live page */
 
 	  scan =
 	    heap_scan_get_visible_version (thread_p, &oid, class_oid, recdes, &forward_recdes, scan_cache, ispeeking,
@@ -8486,6 +8487,7 @@ heap_next_1page (THREAD_ENTRY * thread_p, const HFID * hfid, const VPID * vpid, 
 		      && local_pgptr == pgbuf_copy_buffer_get_page_ptr (scan_cache->copied_buf_handle));
 
 	scan_cache->cache_last_fix_page = true;
+	assert (!is_pc || scan_cache->page_watcher.pgptr == NULL);	/* latch-free invariant: copy-mode consumption never holds the live page */
 
 	scan =
 	  heap_scan_get_visible_version (thread_p, &oid, class_oid, recdes, &forward_recdes, scan_cache, ispeeking,

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -660,7 +660,7 @@ static int heap_scancache_check_with_hfid (THREAD_ENTRY * thread_p, HFID * hfid,
 					   HEAP_SCANCACHE ** scan_cache);
 static int heap_scancache_start_internal (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache, const HFID * hfid,
 					  const OID * class_oid, int cache_last_fix_page, bool is_queryscan,
-					  MVCC_SNAPSHOT * mvcc_snapshot);
+					  MVCC_SNAPSHOT * mvcc_snapshot, bool page_copy = false);
 static int heap_scancache_force_modify (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache);
 static int heap_scancache_reset_modify (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache, const HFID * hfid,
 					const OID * class_oid);
@@ -6777,7 +6777,7 @@ heap_scancache_check_with_hfid (THREAD_ENTRY * thread_p, HFID * hfid, OID * clas
 static int
 heap_scancache_start_internal (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache, const HFID * hfid,
 			       const OID * class_oid, int cache_last_fix_page, bool is_queryscan,
-			       MVCC_SNAPSHOT * mvcc_snapshot)
+			       MVCC_SNAPSHOT * mvcc_snapshot, bool page_copy)
 {
   int ret = NO_ERROR;
   int granted;
@@ -6866,6 +6866,22 @@ heap_scancache_start_internal (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_ca
   scan_cache->debug_initpattern = HEAP_DEBUG_SCANCACHE_INITPATTERN;
   scan_cache->mvcc_snapshot = mvcc_snapshot;
   scan_cache->partition_list = NULL;
+  scan_cache->copied_buf_handle = NULL;
+  VPID_SET_NULL (&scan_cache->copied_vpid);
+  scan_cache->read_mode = HEAP_SCAN_READ_COPY;
+  if (page_copy && is_queryscan)
+    {
+      scan_cache->copied_buf_handle = pgbuf_copy_buffer_alloc ();
+      if (scan_cache->copied_buf_handle == NULL)
+	{
+	  /* OOM contract (pinned): degrade to COPY, no er_set, no error return. */
+	  er_log_debug (ARG_FILE_LINE, "page-copy buffer alloc failed, degrading to COPY");
+	}
+      else
+	{
+	  scan_cache->read_mode = HEAP_SCAN_READ_PAGE_COPY;
+	}
+    }
 
   return ret;
 
@@ -6884,6 +6900,9 @@ exit_on_error:
   scan_cache->debug_initpattern = 0;
   scan_cache->mvcc_snapshot = NULL;
   scan_cache->partition_list = NULL;
+  scan_cache->copied_buf_handle = NULL;
+  VPID_SET_NULL (&scan_cache->copied_vpid);
+  scan_cache->read_mode = HEAP_SCAN_READ_COPY;
 
   return (ret == NO_ERROR && (ret = er_errid ()) == NO_ERROR) ? ER_FAILED : ret;
 }
@@ -6903,10 +6922,10 @@ exit_on_error:
  */
 int
 heap_scancache_start (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache, const HFID * hfid, const OID * class_oid,
-		      int cache_last_fix_page, MVCC_SNAPSHOT * mvcc_snapshot)
+		      int cache_last_fix_page, MVCC_SNAPSHOT * mvcc_snapshot, bool page_copy)
 {
   return heap_scancache_start_internal (thread_p, scan_cache, hfid, class_oid, cache_last_fix_page, true,
-					mvcc_snapshot);
+					mvcc_snapshot, page_copy);
 }
 
 /*
@@ -7167,6 +7186,9 @@ heap_scancache_quick_start_internal (HEAP_SCANCACHE * scan_cache, const HFID * h
   scan_cache->debug_initpattern = HEAP_DEBUG_SCANCACHE_INITPATTERN;
   scan_cache->mvcc_snapshot = NULL;
   scan_cache->partition_list = NULL;
+  scan_cache->copied_buf_handle = NULL;
+  VPID_SET_NULL (&scan_cache->copied_vpid);
+  scan_cache->read_mode = HEAP_SCAN_READ_COPY;
 
   return NO_ERROR;
 }
@@ -7219,6 +7241,11 @@ heap_scancache_quick_end (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache)
 	      curr_node = next_node;
 	    }
 	}
+
+      pgbuf_copy_buffer_free (scan_cache->copied_buf_handle);
+      scan_cache->copied_buf_handle = NULL;
+      VPID_SET_NULL (&scan_cache->copied_vpid);
+      scan_cache->read_mode = HEAP_SCAN_READ_COPY;
     }
 
   HFID_SET_NULL (&scan_cache->node.hfid);
@@ -25499,14 +25526,20 @@ heap_get_visible_version (THREAD_ENTRY * thread_p, const OID * oid, OID * class_
 *   old_chn (in): Cache coherency number for existing record data. It is
 *		   used by clients to avoid resending record data when
 *		   it was not updated.
+*   is_page_copy (in): call-scoped page-copy read mode (issue #154). Plumbed in Slice 1; consumed
+*		       by the REC_HOME shortcut starting Slice 2. Default false everywhere.
 *  Note: this function should be used for heap scan;
 */
 SCAN_CODE
 heap_scan_get_visible_version (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid, RECDES * recdes,
-			       RECDES * peeked_recdes, HEAP_SCANCACHE * scan_cache, int ispeeking, int old_chn)
+			       RECDES * peeked_recdes, HEAP_SCANCACHE * scan_cache, int ispeeking, int old_chn,
+			       bool is_page_copy)
 {
   SCAN_CODE scan = S_SUCCESS;
   HEAP_GET_CONTEXT context;
+
+  /* is_page_copy: Slice 1 plumbing only; the page-copy REC_HOME shortcut lands in Slice 2. */
+  (void) is_page_copy;
 
   /*
    * The process below should be within heap_get_visible_version_internal(), 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -8345,6 +8345,7 @@ heap_next_1page (THREAD_ENTRY * thread_p, const HFID * hfid, const VPID * vpid, 
   RECDES forward_recdes;
   SCAN_CODE scan = S_ERROR;
   bool is_null_recdata;
+  PAGE_PTR local_pgptr = NULL;	/* issue #154: page-copy read pointer (copy buffer or live page) */
 
   if (!OID_ISNULL (&scan_cache->node.class_oid))
     {
@@ -8373,6 +8374,22 @@ heap_next_1page (THREAD_ENTRY * thread_p, const HFID * hfid, const VPID * vpid, 
 
       while (true)
 	{
+
+	  /* Page-copy fast path: skip fix if same page already copied (issue #154, Slice 2W). */
+	  if (scan_cache->read_mode == HEAP_SCAN_READ_PAGE_COPY
+	      && scan_cache->copied_buf_handle != NULL && VPID_EQ (vpid, &scan_cache->copied_vpid))
+	    {
+	      /* Unfix any fall-through-parked page (heap_clean_get_context can park a live page when
+	       * cache_last_fix_page was temporarily forced true for the previous record's
+	       * heap_scan_get_visible_version call). */
+	      if (scan_cache->page_watcher.pgptr != NULL)
+		{
+		  pgbuf_ordered_unfix (thread_p, &scan_cache->page_watcher);
+		}
+	      local_pgptr = pgbuf_copy_buffer_get_page_ptr (scan_cache->copied_buf_handle);
+	      goto slot_walk_1page;
+	    }
+	  /* else: fall through to existing fix block */
 
 	  /*
 	   * Fetch the page where the object of OID is stored. Use previous
@@ -8406,13 +8423,28 @@ heap_next_1page (THREAD_ENTRY * thread_p, const HFID * hfid, const VPID * vpid, 
 		}
 	    }
 
+	  if (scan_cache->read_mode == HEAP_SCAN_READ_PAGE_COPY && scan_cache->copied_buf_handle != NULL)
+	    {
+	      /* New page (VPID_EQ failed above) -- copy frame and unfix (issue #154, Slice 2W). */
+	      pgbuf_copy_page_for_scan (scan_cache->page_watcher.pgptr, scan_cache->copied_buf_handle);
+	      scan_cache->copied_vpid = *vpid;
+	      pgbuf_ordered_unfix (thread_p, &scan_cache->page_watcher);
+	      local_pgptr = pgbuf_copy_buffer_get_page_ptr (scan_cache->copied_buf_handle);
+	    }
+	  else
+	    {
+	      local_pgptr = scan_cache->page_watcher.pgptr;
+	    }
+
+	slot_walk_1page:
+
 	  {
 	    /* Find the next object. Skip relocated records (i.e., new_home records). This records must be accessed
 	     * through the relocation record (i.e., the object). */
 
 	    while (true)
 	      {
-		scan = spage_next_record (scan_cache->page_watcher.pgptr, &oid.slotid, &forward_recdes, PEEK);
+		scan = spage_next_record (local_pgptr, &oid.slotid, &forward_recdes, PEEK);
 
 		if (scan != S_SUCCESS)
 		  {
@@ -8425,7 +8457,7 @@ heap_next_1page (THREAD_ENTRY * thread_p, const HFID * hfid, const VPID * vpid, 
 		    /* skip the header */
 		    continue;
 		  }
-		type = spage_get_record_type (scan_cache->page_watcher.pgptr, oid.slotid);
+		type = spage_get_record_type (local_pgptr, oid.slotid);
 		if (type == REC_NEWHOME || type == REC_ASSIGN_ADDRESS || type == REC_UNKNOWN)
 		  {
 		    /* skip */
@@ -8461,12 +8493,15 @@ heap_next_1page (THREAD_ENTRY * thread_p, const HFID * hfid, const VPID * vpid, 
 
       {
 	int cache_last_fix_page_save = scan_cache->cache_last_fix_page;
+	bool is_pc = (scan_cache->read_mode == HEAP_SCAN_READ_PAGE_COPY
+		      && scan_cache->copied_buf_handle != NULL
+		      && local_pgptr == pgbuf_copy_buffer_get_page_ptr (scan_cache->copied_buf_handle));
 
 	scan_cache->cache_last_fix_page = true;
 
 	scan =
 	  heap_scan_get_visible_version (thread_p, &oid, class_oid, recdes, &forward_recdes, scan_cache, ispeeking,
-					 NULL_CHN);
+					 NULL_CHN, is_pc);
 	scan_cache->cache_last_fix_page = cache_last_fix_page_save;
       }
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -6774,6 +6774,14 @@ heap_scancache_check_with_hfid (THREAD_ENTRY * thread_p, HFID * hfid, OID * clas
  *   is_queryscan(in):
  *
  */
+/* TEMPORARY (issue #154 Slice 2/2W validation only -- removed in Slice 3): force page-copy read
+ * mode for query scans that do not already keep their page fixed across records, ahead of the
+ * Slice 3 activation predicate (qexec_is_page_copy_eligible ()) being wired through
+ * scan_open_heap_scan () -> heap_scancache_start (). Debug-only; no effect in release builds. */
+#if !defined (NDEBUG)
+#define FORCE_PAGE_COPY_SCAN 1
+#endif /* !NDEBUG */
+
 static int
 heap_scancache_start_internal (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache, const HFID * hfid,
 			       const OID * class_oid, int cache_last_fix_page, bool is_queryscan,
@@ -6869,6 +6877,13 @@ heap_scancache_start_internal (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_ca
   scan_cache->copied_buf_handle = NULL;
   VPID_SET_NULL (&scan_cache->copied_vpid);
   scan_cache->read_mode = HEAP_SCAN_READ_COPY;
+#if defined (FORCE_PAGE_COPY_SCAN)
+  if (!cache_last_fix_page && is_queryscan)
+    {
+      /* TEMPORARY (issue #154 Slice 2/2W validation only) -- removed in Slice 3. */
+      page_copy = true;
+    }
+#endif /* FORCE_PAGE_COPY_SCAN */
   if (page_copy && is_queryscan)
     {
       scan_cache->copied_buf_handle = pgbuf_copy_buffer_alloc ();
@@ -7890,6 +7905,7 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
   bool is_null_recdata;
   PGBUF_WATCHER old_page_watcher;
   PGBUF_WATCHER rec_info_page_watcher;
+  PAGE_PTR local_pgptr = NULL;	/* issue #154: page-copy read pointer (copy buffer or live page) */
 
   assert (scan_cache != NULL);
 
@@ -7971,6 +7987,22 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
 		  pgbuf_replace_watcher (thread_p, &scan_cache->page_watcher, &old_page_watcher);
 		}
 	    }
+	  /* Page-copy fast path: skip fix entirely if same page already copied (issue #154, Slice 2). */
+	  if (scan_cache->read_mode == HEAP_SCAN_READ_PAGE_COPY
+	      && scan_cache->copied_buf_handle != NULL && VPID_EQ (&vpid, &scan_cache->copied_vpid))
+	    {
+	      /* Same page already in copy buffer -- use it directly. Unfix any fall-through-parked
+	       * page (heap_clean_get_context can park a live page when cache_last_fix_page was
+	       * temporarily forced true for the previous record's heap_scan_get_visible_version call). */
+	      if (scan_cache->page_watcher.pgptr != NULL)
+		{
+		  pgbuf_ordered_unfix (thread_p, &scan_cache->page_watcher);
+		}
+	      local_pgptr = pgbuf_copy_buffer_get_page_ptr (scan_cache->copied_buf_handle);
+	      goto slot_walk;
+	    }
+	  /* else: fall through to existing fix block */
+
 	  if (scan_cache->page_watcher.pgptr == NULL)
 	    {
 	      scan_cache->page_watcher.pgptr =
@@ -7994,26 +8026,41 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
 		}
 	    }
 
+	  if (scan_cache->read_mode == HEAP_SCAN_READ_PAGE_COPY && scan_cache->copied_buf_handle != NULL)
+	    {
+	      /* New page (VPID_EQ failed above) -- copy frame and unfix (issue #154, Slice 2). */
+	      pgbuf_copy_page_for_scan (scan_cache->page_watcher.pgptr, scan_cache->copied_buf_handle);
+	      scan_cache->copied_vpid = vpid;
+	      pgbuf_ordered_unfix (thread_p, &scan_cache->page_watcher);
+	      local_pgptr = pgbuf_copy_buffer_get_page_ptr (scan_cache->copied_buf_handle);
+	    }
+	  else
+	    {
+	      local_pgptr = scan_cache->page_watcher.pgptr;	/* live page (non-copy mode) */
+	    }
+
+	slot_walk:
+
 	  if (get_rec_info)
 	    {
 	      /* Getting record information means that we need to scan all slots even if they store no object. */
 	      if (reversed_direction)
 		{
 		  scan =
-		    spage_previous_record_dont_skip_empty (scan_cache->page_watcher.pgptr, &oid.slotid, &forward_recdes,
+		    spage_previous_record_dont_skip_empty (local_pgptr, &oid.slotid, &forward_recdes,
 							   PEEK);
 		}
 	      else
 		{
 		  scan =
-		    spage_next_record_dont_skip_empty (scan_cache->page_watcher.pgptr, &oid.slotid, &forward_recdes,
+		    spage_next_record_dont_skip_empty (local_pgptr, &oid.slotid, &forward_recdes,
 						       PEEK);
 		}
 	      if (oid.slotid == HEAP_HEADER_AND_CHAIN_SLOTID)
 		{
 		  /* skip the header */
 		  scan =
-		    spage_next_record_dont_skip_empty (scan_cache->page_watcher.pgptr, &oid.slotid, &forward_recdes,
+		    spage_next_record_dont_skip_empty (local_pgptr, &oid.slotid, &forward_recdes,
 						       PEEK);
 		}
 	    }
@@ -8026,11 +8073,11 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
 		{
 		  if (reversed_direction)
 		    {
-		      scan = spage_previous_record (scan_cache->page_watcher.pgptr, &oid.slotid, &forward_recdes, PEEK);
+		      scan = spage_previous_record (local_pgptr, &oid.slotid, &forward_recdes, PEEK);
 		    }
 		  else
 		    {
-		      scan = spage_next_record (scan_cache->page_watcher.pgptr, &oid.slotid, &forward_recdes, PEEK);
+		      scan = spage_next_record (local_pgptr, &oid.slotid, &forward_recdes, PEEK);
 		    }
 		  if (scan != S_SUCCESS)
 		    {
@@ -8056,7 +8103,7 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
 		      /* skip the header */
 		      continue;
 		    }
-		  type = spage_get_record_type (scan_cache->page_watcher.pgptr, oid.slotid);
+		  type = spage_get_record_type (local_pgptr, oid.slotid);
 		  if (type == REC_NEWHOME || type == REC_ASSIGN_ADDRESS || type == REC_UNKNOWN)
 		    {
 		      /* skip */
@@ -8072,6 +8119,26 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
 	      if (scan == S_END)
 		{
 		  /* Find next page of heap and continue scanning */
+		  if (scan_cache->read_mode == HEAP_SCAN_READ_PAGE_COPY && scan_cache->copied_buf_handle != NULL)
+		    {
+		      /* page_watcher.pgptr is NULL here (copy mode always unfixes after copying); re-fix the
+		       * copied page so heap_vpid_prev/heap_vpid_next below have a live pointer (issue #154). */
+		      scan_cache->page_watcher.pgptr =
+			heap_scan_pb_lock_and_fetch (thread_p, &scan_cache->copied_vpid, OLD_PAGE_PREVENT_DEALLOC, S_LOCK,
+						     scan_cache, &scan_cache->page_watcher);
+		      if (scan_cache->page_watcher.pgptr == NULL)
+			{
+			  if (er_errid () == ER_PB_BAD_PAGEID)
+			    {
+			      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_HEAP_UNKNOWN_OBJECT, 3, oid.volid, oid.pageid,
+				      oid.slotid);
+			    }
+
+			  /* something went wrong, return */
+			  assert (scan_cache->page_watcher.pgptr == NULL);
+			  return S_ERROR;
+			}
+		    }
 		  if (reversed_direction)
 		    {
 		      (void) heap_vpid_prev (thread_p, hfid, scan_cache->page_watcher.pgptr, &vpid);
@@ -8120,7 +8187,10 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
 		    {
 		      pgbuf_ordered_unfix (thread_p, &old_page_watcher);
 		    }
-		  pgbuf_ordered_unfix (thread_p, &scan_cache->page_watcher);
+		  if (scan_cache->page_watcher.pgptr != NULL)
+		    {
+		      pgbuf_ordered_unfix (thread_p, &scan_cache->page_watcher);
+		    }
 		  return scan;
 		}
 	    }
@@ -8143,12 +8213,13 @@ heap_next_internal (THREAD_ENTRY * thread_p, const HFID * hfid, OID * class_oid,
       else
 	{
 	  int cache_last_fix_page_save = scan_cache->cache_last_fix_page;
+	  bool is_pc = (scan_cache->read_mode == HEAP_SCAN_READ_PAGE_COPY && scan_cache->copied_buf_handle != NULL);
 
 	  scan_cache->cache_last_fix_page = true;
 
 	  scan =
 	    heap_scan_get_visible_version (thread_p, &oid, class_oid, recdes, &forward_recdes, scan_cache, ispeeking,
-					   NULL_CHN);
+					   NULL_CHN, is_pc);
 	  scan_cache->cache_last_fix_page = cache_last_fix_page_save;
 	}
 
@@ -25538,9 +25609,6 @@ heap_scan_get_visible_version (THREAD_ENTRY * thread_p, const OID * oid, OID * c
   SCAN_CODE scan = S_SUCCESS;
   HEAP_GET_CONTEXT context;
 
-  /* is_page_copy: Slice 1 plumbing only; the page-copy REC_HOME shortcut lands in Slice 2. */
-  (void) is_page_copy;
-
   /*
    * The process below should be within heap_get_visible_version_internal(), 
    * but it's an added shortcut for performance improvement. Under certain specific conditions, 
@@ -25599,6 +25667,15 @@ heap_scan_get_visible_version (THREAD_ENTRY * thread_p, const OID * oid, OID * c
 	  if (ispeeking == PEEK)
 	    {
 	      /* recdes may point directly into the still-latched page */
+	      *recdes = *peeked_recdes;
+	      return scan;
+	    }
+
+	  if (is_page_copy)
+	    {
+	      /* Caller guarantees peeked_recdes->data points into the copied_buf_handle frame (issue #154,
+	       * Slice 2/2W): local_pgptr was set from pgbuf_copy_buffer_get_page_ptr () whenever is_pc/is_page_copy
+	       * is true, so peeked_recdes->data is stable copy memory, not a live latched page. */
 	      *recdes = *peeked_recdes;
 	      return scan;
 	    }

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -138,6 +138,14 @@ struct heap_scancache_node_list
   HEAP_SCANCACHE_NODE_LIST *next;
 };
 
+/* Read mode for a heap scan cache: normal per-record COPY, or page-copy (issue #154) where the
+ * whole page is memcpy'd once and records are read directly from the private copy. */
+typedef enum
+{
+  HEAP_SCAN_READ_COPY = 0,
+  HEAP_SCAN_READ_PAGE_COPY = 1
+} HEAP_SCAN_READ_MODE;
+
 // *INDENT-OFF*
 typedef struct heap_scancache HEAP_SCANCACHE;
 struct heap_scancache
@@ -158,6 +166,9 @@ struct heap_scancache
     MVCC_SNAPSHOT *mvcc_snapshot;	/* mvcc snapshot */
     HEAP_SCANCACHE_NODE_LIST *partition_list;	/* list holding the heap file information for partition nodes involved
 						 * in the scan */
+    PGBUF_COPY_BUFFER_HANDLE copied_buf_handle;	/* page-copy scan buffer handle; NULL unless page-copy scan */
+    VPID copied_vpid;		/* VPID currently held in copied_buf_handle */
+    HEAP_SCAN_READ_MODE read_mode;	/* HEAP_SCAN_READ_COPY or HEAP_SCAN_READ_PAGE_COPY */
 
     void start_area ();
     void end_area ();
@@ -415,7 +426,8 @@ extern VFID *heap_ovf_find_vfid (THREAD_ENTRY * thread_p, const HFID * hfid, VFI
 extern void heap_flush (THREAD_ENTRY * thread_p, const OID * oid);
 extern int xheap_reclaim_addresses (THREAD_ENTRY * thread_p, const HFID * hfid);
 extern int heap_scancache_start (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache, const HFID * hfid,
-				 const OID * class_oid, int cache_last_fix_page, MVCC_SNAPSHOT * mvcc_snapshot);
+				 const OID * class_oid, int cache_last_fix_page, MVCC_SNAPSHOT * mvcc_snapshot,
+				 bool page_copy = false);
 extern int heap_scancache_start_modify (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache, const HFID * hfid,
 					const OID * class_oid, int op_type, MVCC_SNAPSHOT * mvcc_snapshot);
 extern int heap_scancache_quick_start (HEAP_SCANCACHE * scan_cache);
@@ -691,7 +703,7 @@ extern SCAN_CODE heap_get_visible_version (THREAD_ENTRY * thread_p, const OID * 
 					   HEAP_SCANCACHE * scan_cache, int ispeeking, int old_chn);
 extern SCAN_CODE heap_scan_get_visible_version (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid,
 						RECDES * recdes, RECDES * forward_recdes, HEAP_SCANCACHE * scan_cache,
-						int ispeeking, int old_chn);
+						int ispeeking, int old_chn, bool is_page_copy = false);
 extern SCAN_CODE heap_get_last_version (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context);
 extern void heap_clean_get_context (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context);
 extern void heap_init_get_context (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context, const OID * oid,

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -138,12 +138,13 @@ struct heap_scancache_node_list
   HEAP_SCANCACHE_NODE_LIST *next;
 };
 
-/* Read mode for a heap scan cache: normal per-record COPY, or page-copy (issue #154) where the
- * whole page is memcpy'd once and records are read directly from the private copy. */
+/* Read mode for a heap scan cache: normal per-record COPY, or copy-to-local-cache (CBRD-27041)
+ * where the whole page is memcpy'd once into a scan-private local cache and records are read
+ * directly from that cache. */
 typedef enum
 {
   HEAP_SCAN_READ_COPY = 0,
-  HEAP_SCAN_READ_PAGE_COPY = 1
+  HEAP_SCAN_READ_LOCAL_CACHE = 1
 } HEAP_SCAN_READ_MODE;
 
 // *INDENT-OFF*
@@ -166,9 +167,9 @@ struct heap_scancache
     MVCC_SNAPSHOT *mvcc_snapshot;	/* mvcc snapshot */
     HEAP_SCANCACHE_NODE_LIST *partition_list;	/* list holding the heap file information for partition nodes involved
 						 * in the scan */
-    PGBUF_COPY_BUFFER_HANDLE copied_buf_handle;	/* page-copy scan buffer handle; NULL unless page-copy scan */
-    VPID copied_vpid;		/* VPID currently held in copied_buf_handle */
-    HEAP_SCAN_READ_MODE read_mode;	/* HEAP_SCAN_READ_COPY or HEAP_SCAN_READ_PAGE_COPY */
+    PGBUF_COPY_BUFFER_HANDLE local_cache_handle;	/* local page cache for a cached scan; NULL unless cached scan */
+    VPID local_cache_vpid;		/* VPID currently held in local_cache_handle */
+    HEAP_SCAN_READ_MODE read_mode;	/* HEAP_SCAN_READ_COPY or HEAP_SCAN_READ_LOCAL_CACHE */
 
     void start_area ();
     void end_area ();
@@ -427,7 +428,7 @@ extern void heap_flush (THREAD_ENTRY * thread_p, const OID * oid);
 extern int xheap_reclaim_addresses (THREAD_ENTRY * thread_p, const HFID * hfid);
 extern int heap_scancache_start (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache, const HFID * hfid,
 				 const OID * class_oid, int cache_last_fix_page, MVCC_SNAPSHOT * mvcc_snapshot,
-				 bool page_copy = false);
+				 bool copy_to_local_cache = false);
 extern int heap_scancache_start_modify (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * scan_cache, const HFID * hfid,
 					const OID * class_oid, int op_type, MVCC_SNAPSHOT * mvcc_snapshot);
 extern int heap_scancache_quick_start (HEAP_SCANCACHE * scan_cache);
@@ -703,7 +704,7 @@ extern SCAN_CODE heap_get_visible_version (THREAD_ENTRY * thread_p, const OID * 
 					   HEAP_SCANCACHE * scan_cache, int ispeeking, int old_chn);
 extern SCAN_CODE heap_scan_get_visible_version (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid,
 						RECDES * recdes, RECDES * forward_recdes, HEAP_SCANCACHE * scan_cache,
-						int ispeeking, int old_chn, bool is_page_copy = false);
+						int ispeeking, int old_chn, bool is_cached_scan = false);
 extern SCAN_CODE heap_get_last_version (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context);
 extern void heap_clean_get_context (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context);
 extern void heap_init_get_context (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context, const OID * oid,

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -856,6 +856,75 @@ static char pgbuf_Guard[8] = { MEM_REGION_GUARD_MARK, MEM_REGION_GUARD_MARK, MEM
 };
 #endif /* CUBRID_DEBUG */
 
+/* ----------------------------------------------------------------------------------------------
+ * Pgbuf opaque copy-buffer API (issue #154 page-copy heap scan).
+ *
+ * The copy buffer is not a real BCB slot: it is a stand-alone <dummy BCB, iopage> pair, private to
+ * this file, so that the PAGE_PTR returned by pgbuf_copy_buffer_get_page_ptr () satisfies the same
+ * CAST_PGPTR_TO_BFPTR / CAST_PGPTR_TO_IOPGPTR invariants as a real fixed page.
+ * ---------------------------------------------------------------------------------------------- */
+struct pgbuf_copy_buffer
+{
+  PGBUF_BCB dummy_bcb;		/* real BCB struct, only vpid field meaningful */
+  PGBUF_IOPAGE_BUFFER iopage_buf;	/* flexible-payload; actual size determined by alloc */
+};
+
+/* CRITICAL: sizeof (struct pgbuf_copy_buffer) under-allocates because FILEIO_PAGE.page is char[1].
+ * Must use dynamic sizing. */
+#define PGBUF_COPY_BUFFER_ALLOC_SIZE \
+  ((size_t) (offsetof (struct pgbuf_copy_buffer, iopage_buf) + PGBUF_IOPAGE_BUFFER_SIZE))
+
+PGBUF_COPY_BUFFER_HANDLE
+pgbuf_copy_buffer_alloc (void)
+{
+  struct pgbuf_copy_buffer *buf = (struct pgbuf_copy_buffer *) malloc (PGBUF_COPY_BUFFER_ALLOC_SIZE);
+
+  if (buf == NULL)
+    {
+      return NULL;		/* OOM: caller handles graceful degradation */
+    }
+  /* PGBUF_BCB embeds a std::atomic member, so a raw memset trips -Wclass-memaccess; value-initialize
+   * via placement new instead (same net effect: every field zeroed). */
+  placement_new (&buf->dummy_bcb);
+  buf->iopage_buf.bcb = &buf->dummy_bcb;
+  buf->dummy_bcb.iopage_buffer = &buf->iopage_buf;
+  VPID_SET_NULL (&buf->dummy_bcb.vpid);
+#if defined (CUBRID_DEBUG)
+  /* Init guard bytes at page[DB_PAGESIZE], matching PGBUF_FIND_BUFFER_GUARD. */
+  memcpy (&buf->iopage_buf.iopage.page[DB_PAGESIZE], pgbuf_Guard, sizeof (pgbuf_Guard));
+#endif /* CUBRID_DEBUG */
+
+  er_log_debug (ARG_FILE_LINE, "page-copy scan buffer allocated");
+
+  return buf;
+}
+
+void
+pgbuf_copy_buffer_free (PGBUF_COPY_BUFFER_HANDLE handle)
+{
+  free_and_init (handle);
+}
+
+void
+pgbuf_copy_page_for_scan (PAGE_PTR src_pgptr, PGBUF_COPY_BUFFER_HANDLE handle)
+{
+  FILEIO_PAGE *src_iopage;
+  PGBUF_BCB *src_bcb;
+
+  CAST_PGPTR_TO_IOPGPTR (src_iopage, src_pgptr);	/* src must be fixed */
+  memcpy (&handle->iopage_buf.iopage, src_iopage, IO_PAGESIZE);
+
+  /* Update dummy BCB vpid from source. */
+  CAST_PGPTR_TO_BFPTR (src_bcb, src_pgptr);
+  handle->dummy_bcb.vpid = src_bcb->vpid;
+}
+
+PAGE_PTR
+pgbuf_copy_buffer_get_page_ptr (PGBUF_COPY_BUFFER_HANDLE handle)
+{
+  return (PAGE_PTR) handle->iopage_buf.iopage.page;
+}
+
 #define AOUT_HASH_DIVIDE_RATIO 1000
 #define AOUT_HASH_IDX(vpid, list) ((vpid)->pageid % list->num_hashes)
 

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -857,7 +857,7 @@ static char pgbuf_Guard[8] = { MEM_REGION_GUARD_MARK, MEM_REGION_GUARD_MARK, MEM
 #endif /* CUBRID_DEBUG */
 
 /* ----------------------------------------------------------------------------------------------
- * Pgbuf opaque copy-buffer API (issue #154 page-copy heap scan).
+ * Pgbuf opaque copy-buffer API for cached heap scans (CBRD-27041).
  *
  * The copy buffer is not a real BCB slot: it is a stand-alone <dummy BCB, iopage> pair, private to
  * this file, so that the PAGE_PTR returned by pgbuf_copy_buffer_get_page_ptr () satisfies the same
@@ -894,7 +894,7 @@ pgbuf_copy_buffer_alloc (void)
   memcpy (&buf->iopage_buf.iopage.page[DB_PAGESIZE], pgbuf_Guard, sizeof (pgbuf_Guard));
 #endif /* CUBRID_DEBUG */
 
-  er_log_debug (ARG_FILE_LINE, "page-copy scan buffer allocated");
+  er_log_debug (ARG_FILE_LINE, "cached scan buffer allocated");
 
   return buf;
 }

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -902,6 +902,12 @@ pgbuf_copy_buffer_alloc (void)
 void
 pgbuf_copy_buffer_free (PGBUF_COPY_BUFFER_HANDLE handle)
 {
+  if (handle != NULL)
+    {
+      /* end the lifetime started by the placement new in pgbuf_copy_buffer_alloc (); currently a
+       * no-op, but keeps construction/destruction symmetric if PGBUF_BCB members change */
+      handle->dummy_bcb. ~ pgbuf_bcb ();
+    }
   free_and_init (handle);
 }
 

--- a/src/storage/page_buffer.h
+++ b/src/storage/page_buffer.h
@@ -496,7 +496,7 @@ extern void pgbuf_daemons_destroy ();
 
 extern int pgbuf_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** arg_values, int arg_cnt, void **ptr);
 
-/* Pgbuf opaque copy-buffer API (issue #154 page-copy heap scan). The struct is private
+/* Pgbuf opaque copy-buffer API for cached heap scans (CBRD-27041). The struct is private
  * to page_buffer.c; callers only ever see the opaque handle below. */
 typedef struct pgbuf_copy_buffer *PGBUF_COPY_BUFFER_HANDLE;
 

--- a/src/storage/page_buffer.h
+++ b/src/storage/page_buffer.h
@@ -496,4 +496,13 @@ extern void pgbuf_daemons_destroy ();
 
 extern int pgbuf_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** arg_values, int arg_cnt, void **ptr);
 
+/* Pgbuf opaque copy-buffer API (issue #154 page-copy heap scan). The struct is private
+ * to page_buffer.c; callers only ever see the opaque handle below. */
+typedef struct pgbuf_copy_buffer *PGBUF_COPY_BUFFER_HANDLE;
+
+extern PGBUF_COPY_BUFFER_HANDLE pgbuf_copy_buffer_alloc (void);
+extern void pgbuf_copy_buffer_free (PGBUF_COPY_BUFFER_HANDLE handle);
+extern void pgbuf_copy_page_for_scan (PAGE_PTR src_pgptr, PGBUF_COPY_BUFFER_HANDLE handle);
+extern PAGE_PTR pgbuf_copy_buffer_get_page_ptr (PGBUF_COPY_BUFFER_HANDLE handle);
+
 #endif /* _PAGE_BUFFER_H_ */


### PR DESCRIPTION
https://jira.cubrid.org/browse/CBRD-27041

## Description

CBRD-26747 에서 NL join의 driving 힙 스캔을 레코드 별 COPY 방식에서 PEEK(fixed) 방식으로 전환하여 TPC-H q12과 같은 질의에서 ~350% 가량 성능을 개선했으나, CBRD-26905와 같은 regression 이 발생하여 revert했다. CBRD-26905는 REPEATABLE READ에서 동일 트랜잭션 내 SELECT COUNT(*) 결과가 다른 회귀이다. 원인은 driving의 PEEK 포인터가 fetch 경계를 넘어 생존하는데, page_was_unfixed 다시 읽기는 단일 heap fetch 내에서만 이행되기 때문이다. revert 후 driving heap scan이 레코드마다 pgbuf_fix + COPY memcpy + unfix 비용을 다시 부담한다.

page-copy 후 peek scan 방식을 도입함으로써 PEEK 수준의 성능을 복구한다. 힙 페이지 진입 시 1회 fix 후 IO frame 전체를 scancache 전용 버퍼에 memcpy하고 즉시 unfix하고, 이후 REC_HOME 레코드를 복사본에서 peek한다. latch를 보유하지 않아 stale-PEEK 원인이 구조적으로 없어진다.

직렬(heap_next_internal) + 병렬(heap_next_1page) 두 소비 경로 모두 적용한다.

## Implementation

- **`page_buffer.h/.c` — opaque 복사 버퍼 API**: `PGBUF_COPY_BUFFER_HANDLE`(불투명 핸들) + `pgbuf_copy_buffer_alloc/free`, `pgbuf_copy_page_for_scan`, `pgbuf_copy_buffer_get_page_ptr`. 내부에 dummy BCB(buffer control block)를 wiring해서 반환되는 `PAGE_PTR`가 `CAST_PGPTR_TO_BFPTR` / `CAST_PGPTR_TO_IOPGPTR` 불변식을 실제 fixed 페이지와 동일하게 만족한다 — `slotted_page.c` 에러 경로가 복사본 포인터로 `pgbuf_get_page_id` 등을 호출해도 안전. 할당 크기는 `sizeof`가 아니라 `offsetof + PGBUF_IOPAGE_BUFFER_SIZE` (`FILEIO_PAGE.page`가 `char[1]` flexible payload라 `sizeof`는 과소 할당).
- **`heap_file.h` — HEAP_SCANCACHE 확장**: `local_cache_handle`(복사 버퍼), `local_cache_vpid`(현재 캐시된 페이지의 VPID), `read_mode`(`HEAP_SCAN_READ_MODE` enum: `HEAP_SCAN_READ_COPY` / `HEAP_SCAN_READ_LOCAL_CACHE`). 모든 scancache start/quick_start 경로에서 초기화, `heap_scancache_quick_end`에서 해제.
- **`heap_file.c` 직렬 소비 (`heap_next_internal`)**: 슬롯 walk 진입 전 `VPID_EQ(&vpid, &local_cache_vpid)`면 fix 자체를 skip하고 복사본 포인터로 직행. 새 페이지면 기존대로 fix → `pgbuf_copy_page_for_scan` → 즉시 unfix. S_END(페이지 전환) 시에만 현재 페이지를 재-fix해 `heap_vpid_next/prev` 체인을 읽는다.
- **`heap_file.c` 병렬 소비 (`heap_next_1page`)**: px_scan worker가 `slot_iterator::next_qualified_slot_with_peek` 경유로 사용하는 경로에 동일한 VPID_EQ 게이트 적용. 기존에는 `cache_last_fix_page=false`인 스캔이 레코드마다 fix/unfix를 반복했다.
- **`heap_scan_get_visible_version` — call-scoped `is_cached_scan` 파라미터** (default `false`): `true`일 때 REC_HOME visible shortcut에서만 복사본 포인터를 그대로 반환한다. shortcut을 못 타는 모든 경로(REC_RELOCATION, REC_BIGONE, 삭제 레코드, 스냅샷 미충족)는 기존 COPY 동작 그대로 live heap 경로로 fallback한다. `ispeeking` 파라미터는 건드리지 않는다.
- **활성화 (`query_executor.c/.h`)**: `qexec_is_cached_scan_eligible` — `TARGET_CLASS` + `ACCESS_METHOD_SEQUENTIAL` + `S_SELECT` + `!mvcc_select_lock_needed` + `!fixed` + `!grouped`. `qexec_open_scan`과 파티션 reopen에서 open마다 재계산. runtime-only 플래그라 XASL 직렬화에 포함되지 않는다 (`stream_to_xasl.c`에서 `false` 초기화, `xasl.h` `ACCESS_SPEC_TYPE.cached_scan`).
- **병렬 전파 (`px_scan.cpp/.hpp`, `px_scan_task.cpp/.hpp`)**: leader가 계산한 `m_is_cached_scan`을 task까지 전파, worker의 heap open 두 경로 모두에서 `scan_open_heap_scan`에 전달. worker가 로컬로 fixed로 판단한 스캔에는 `&& !fixed_scan` 가드로 비활성.
- **OOM 강등**: 복사 버퍼 alloc 실패 시 `er_set` 없이 `read_mode`가 `HEAP_SCAN_READ_COPY`에 머물러 기존 동작으로 무해 강등 (순수 최적화 계약).
- **관측성**: qdump에 `cached scan=` 필드 추가 (`query_dump.c`). debug 빌드는 소비 직전 `page_watcher.pgptr == NULL` assert로 latch-free 불변식을 상시 검증.

## Naming

리뷰 시 혼동을 줄이기 위해 네이밍 계약을 명시해 둔다.

- **`ispeeking`을 tri-state로 확장하지 않았다.** `PEEK`/`COPY`는 `static const bool`이다(`storage_common.h:1150`). 이 축은 타입부터 2값 도메인이고, `px_scan_slot_iterator.cpp`의 `bool m_is_peeking`처럼 bool 변수를 거치는 순간 세 번째 값은 `true`(=PEEK)로 소리 없이 붕괴한다. scan 경로 전체가 `if (ispeeking)` 같은 truthiness 관용구로 이 값을 소비하고 있어(엔진 전역 130여 곳), 세 번째 값을 넣으면 두 값만 가정한 기존 호출부로 새 상태가 흘러든다 — CBRD-26905를 만든 것과 같은 종류의 누출 경로다. 그래서 read mode는 `HEAP_SCANCACHE` 내부 enum(`read_mode`)과 call-scoped 파라미터(`is_cached_scan`)로만 존재하고, 외부 `ispeeking` 계약은 이진 그대로다.
- **`HEAP_SCAN_READ_MODE`가 bool이 아닌 이유 — 요청과 결과의 분리.** `cached_scan`(XASL/SCAN_ID 레벨 eligibility)과 `copy_to_local_cache`(scancache start 파라미터)는 "요청"이고, `read_mode`는 그 "결과"다. 요청이 true여도 버퍼 alloc이 OOM이면 `read_mode`는 `HEAP_SCAN_READ_COPY`에 머문다. 소비 경로의 모든 가드는 요청이 아니라 결과를 검사한다. 세 번째 bool을 두면 요청 플래그와 혼동되기 쉽다.
- **세 식별자의 역할 분담**: `cached_scan` = plan/scan 레벨 활성화 플래그, `copy_to_local_cache` = scancache start에 전달하는 동작 요청, `is_cached_scan` = 레코드 소비 시점의 call-scoped read mode. 참고로 `HEAP_SCANCACHE`의 기존 `cache_last_fix_page`는 "마지막 페이지를 fix한 채 유지"라는 정반대 latch 의미로 "cache"를 쓰고 있어, 그와 구분되도록 `local_cache` 계열 이름(`local_cache_handle`, `HEAP_SCAN_READ_LOCAL_CACHE`)을 골랐다.

## Remarks

- eligible 스캔당 복사 버퍼 +16KB(+debug guard)를 malloc하며 scancache 종료 시 해제된다. `db_private_alloc`이 아닌 malloc인 이유는 px_scan worker 스레드 간 소유권 이동이 없는 스캔-로컬 수명이기 때문.
- 비-HOME 레코드는 레코드 단위로 기존 live-heap 경로로 fallback하므로 REC_RELOCATION/BIGONE 비율이 높은 테이블에서는 이득이 줄어든다 (정확성은 동일).
- grouped scan, sampling scan, record-info scan, index scan은 범위 외 — eligibility 술어와 `scan_open_heap_scan`의 `scan_type == S_HEAP_SCAN` 가드로 이중 차단.
- 설정 게이트 없이 eligible 스캔에 항상 적용된다. rollback은 revert로 충분 (직렬화·설정 표면 없음).
