### PR TITLE
[CBRD-27039] Fix five histogram-consumption defects (selectivity math + concurrent-fetch robustness)

### DIFF
--- a/src/object/schema_manager.c
+++ b/src/object/schema_manager.c
@@ -4181,8 +4181,11 @@ sm_get_class_with_statistics (MOP classop)
 	  int err = stats_get_histogram (classop, &class_->histogram);
 	  if (err != NO_ERROR)
 	    {
+	      /* histogram is optional; a transient fetch failure (e.g. concurrent ANALYZE
+	       * rewriting _db_histogram) must not fail the query -- proceed without it */
 	      stats_free_histogram_and_init (class_->histogram);
-	      return NULL;
+	      class_->histogram = NULL;
+	      er_clear ();
 	    }
 	}
     }
@@ -4195,9 +4198,10 @@ sm_get_class_with_statistics (MOP classop)
 	  int err = stats_get_histogram (classop, &class_->histogram);
 	  if (err != NO_ERROR)
 	    {
+	      /* optional; see above -- do not fail the query on a transient fetch error */
 	      stats_free_histogram_and_init (class_->histogram);
 	      class_->histogram = NULL;
-	      return NULL;
+	      er_clear ();
 	    }
 	}
     }

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -9822,12 +9822,12 @@ qo_expr_selectivity (QO_ENV * env, PT_NODE * pt_expr)
 	  break;
 	case PT_LIKE:
 	  {
-	    selectivity = qo_like_selectivity (env, pt_expr);
+	    selectivity = qo_like_selectivity (env, node);
 	    break;
 	  }
 	case PT_NOT_LIKE:
 	  {
-	    selectivity = 1 - qo_like_selectivity (env, pt_expr);
+	    selectivity = 1 - qo_like_selectivity (env, node);
 	    break;
 	  }
 	case PT_SETNEQ:
@@ -9927,56 +9927,51 @@ qo_like_selectivity (QO_ENV * env, PT_NODE * pt_expr)
   PT_NODE *lhs, *rhs;
   DB_VALUE *host_var = NULL;
   PRED_CLASS pc_lhs, pc_rhs;
+  double selectivity = 0.0;
+  bool success = false;
 
-  double selectivity;
-  double total_selectivity = 0.0;
+  /* Evaluate ONLY the given LIKE node. The caller (qo_expr_selectivity) walks the
+   * OR (or_next) list itself and combines the per-node selectivities; iterating the
+   * list here as well made every non-LIKE sibling contribute twice -- once through
+   * this function (fed to the LIKE estimator with a NULL or stale pattern, so it
+   * degraded to the LIKE default selectivity) and once through its own operator
+   * case in the caller. */
+  lhs = pt_expr->info.expr.arg1;
+  rhs = pt_expr->info.expr.arg2;
 
-  PT_NODE *like_node;
-
-  for (like_node = pt_expr; like_node; like_node = like_node->or_next)
+  if (lhs && rhs)
     {
-      bool success = false;
+      pc_lhs = qo_classify (lhs);
+      pc_rhs = qo_classify (rhs);
 
-      lhs = like_node->info.expr.arg1;
-      rhs = like_node->info.expr.arg2;
-
-      if (lhs && rhs)
+      if (pc_lhs == PC_ATTR)
 	{
-	  pc_lhs = qo_classify (lhs);
-	  pc_rhs = qo_classify (rhs);
-
-	  if (pc_lhs == PC_ATTR)
+	  if (pc_rhs == PC_CONST)
 	    {
-	      if (pc_rhs == PC_CONST)
-		{
-		  host_var = &rhs->info.value.db_value;
-		}
-	      else if (pc_rhs == PC_HOST_VAR)
-		{
-		  host_var = &env->parser->host_variables[rhs->info.host_var.index];
-		}
-
-	      histogram_get_like_selectivity (lhs, host_var, &selectivity, &success);
-
-	      if (!success)
-		{
-		  selectivity = (double) prm_get_float_value (PRM_ID_LIKE_TERM_SELECTIVITY);
-		}
+	      host_var = &rhs->info.value.db_value;
 	    }
-	  else
+	  else if (pc_rhs == PC_HOST_VAR)
+	    {
+	      host_var = &env->parser->host_variables[rhs->info.host_var.index];
+	    }
+
+	  histogram_get_like_selectivity (lhs, host_var, &selectivity, &success);
+
+	  if (!success)
 	    {
 	      selectivity = (double) prm_get_float_value (PRM_ID_LIKE_TERM_SELECTIVITY);
 	    }
-
-	  total_selectivity = qo_or_selectivity (env, total_selectivity, selectivity);
-	  total_selectivity = MAX (total_selectivity, 0.0);
-	  total_selectivity = MIN (total_selectivity, 1.0);
+	}
+      else
+	{
+	  selectivity = (double) prm_get_float_value (PRM_ID_LIKE_TERM_SELECTIVITY);
 	}
 
+      selectivity = MAX (selectivity, 0.0);
+      selectivity = MIN (selectivity, 1.0);
     }
 
-
-  return total_selectivity;
+  return selectivity;
 }
 
 /*

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -10438,19 +10438,23 @@ qo_comp_selectivity (QO_ENV * env, PT_NODE * pt_expr)
 		}
 	      if (pt_expr->info.expr.op == PT_GE)
 		{
-		  histogram_get_comp_selectivity (rhs, lhs_db_value, false, false, &selectivity, &success);
+		  /* v >= col is col <= v */
+		  histogram_get_comp_selectivity (rhs, lhs_db_value, false, true, &selectivity, &success);
 		}
 	      else if (pt_expr->info.expr.op == PT_GT)
 		{
-		  histogram_get_comp_selectivity (rhs, lhs_db_value, false, true, &selectivity, &success);
+		  /* v > col is col < v */
+		  histogram_get_comp_selectivity (rhs, lhs_db_value, false, false, &selectivity, &success);
 		}
 	      else if (pt_expr->info.expr.op == PT_LE)
 		{
-		  histogram_get_comp_selectivity (rhs, lhs_db_value, true, false, &selectivity, &success);
+		  /* v <= col is col >= v */
+		  histogram_get_comp_selectivity (rhs, lhs_db_value, true, true, &selectivity, &success);
 		}
 	      else if (pt_expr->info.expr.op == PT_LT)
 		{
-		  histogram_get_comp_selectivity (rhs, lhs_db_value, true, true, &selectivity, &success);
+		  /* v < col is col > v */
+		  histogram_get_comp_selectivity (rhs, lhs_db_value, true, false, &selectivity, &success);
 		}
 	      break;
 	    }

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -10137,26 +10137,21 @@ qo_equal_selectivity (QO_ENV * env, PT_NODE * pt_expr)
       break;
 
     case PC_CONST:
-      switch (pc_rhs)
-	{
-	case PC_ATTR:
-	  histogram_get_equal_selectivity (rhs, &lhs->info.value.db_value, &selectivity, &success);
-	  break;
-
-	default:
-	  break;
-	}
-      if (success)
-	{
-	  break;
-	}
-      [[fallthrough]];
-
     case PC_HOST_VAR:
       switch (pc_rhs)
 	{
 	case PC_ATTR:
-	  host_var = &env->parser->host_variables[lhs->info.host_var.index];
+	  /* const = attr : probe the attribute's histogram with the constant / host-var value.
+	   * Read the value slot according to pc_lhs; a fallthrough into a foreign case would
+	   * otherwise read the wrong union member (e.g. host_var.index on a PT_VALUE node). */
+	  if (pc_lhs == PC_HOST_VAR)
+	    {
+	      host_var = &env->parser->host_variables[lhs->info.host_var.index];
+	    }
+	  else
+	    {
+	      host_var = &lhs->info.value.db_value;
+	    }
 	  histogram_get_equal_selectivity (rhs, host_var, &selectivity, &success);
 	  break;
 

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -9765,6 +9765,9 @@ qo_expr_selectivity (QO_ENV * env, PT_NODE * pt_expr)
   /* traverse OR list */
   for (node = pt_expr; node; node = node->or_next)
     {
+      /* per-node: an IS [NOT] NULL node must not suppress the null-correction of its siblings */
+      not_null_calculated = false;
+
       switch (node->info.expr.op)
 	{
 	case PT_OR:
@@ -9867,9 +9870,9 @@ qo_expr_selectivity (QO_ENV * env, PT_NODE * pt_expr)
 	  break;
 
 	case PT_IS_NULL:
-	  if (pt_expr->info.expr.arg1->node_type == PT_NAME && pt_expr->info.expr.arg1->info.name.null_frequency >= 0.0)
+	  if (node->info.expr.arg1->node_type == PT_NAME && node->info.expr.arg1->info.name.null_frequency >= 0.0)
 	    {
-	      selectivity = pt_expr->info.expr.arg1->info.name.null_frequency;
+	      selectivity = node->info.expr.arg1->info.name.null_frequency;
 	    }
 	  else
 	    {
@@ -9879,9 +9882,9 @@ qo_expr_selectivity (QO_ENV * env, PT_NODE * pt_expr)
 	  break;
 
 	case PT_IS_NOT_NULL:
-	  if (pt_expr->info.expr.arg1->node_type == PT_NAME && pt_expr->info.expr.arg1->info.name.null_frequency >= 0.0)
+	  if (node->info.expr.arg1->node_type == PT_NAME && node->info.expr.arg1->info.name.null_frequency >= 0.0)
 	    {
-	      selectivity = pt_expr->info.expr.arg1->info.name.null_frequency;
+	      selectivity = node->info.expr.arg1->info.name.null_frequency;
 	    }
 	  else
 	    {
@@ -9901,15 +9904,19 @@ qo_expr_selectivity (QO_ENV * env, PT_NODE * pt_expr)
 
       if (!not_null_calculated)
 	{
-	  if (pt_expr->info.expr.arg1 && pt_expr->info.expr.arg1->node_type == PT_NAME
-	      && pt_expr->info.expr.arg1->info.name.null_frequency >= 0.0)
+	  /* the histogram estimators return a NON-null-conditional selectivity; restore the
+	   * all-rows fraction with the CURRENT node's columns. Using the chain head (pt_expr)
+	   * here applied the head's null fraction to every sibling, so a high-null column
+	   * behind a null-free head kept its conditional selectivity (inflated by 1/(1-nf)). */
+	  if (node->info.expr.arg1 && node->info.expr.arg1->node_type == PT_NAME
+	      && node->info.expr.arg1->info.name.null_frequency >= 0.0)
 	    {
-	      selectivity = selectivity * (1 - pt_expr->info.expr.arg1->info.name.null_frequency);
+	      selectivity = selectivity * (1 - node->info.expr.arg1->info.name.null_frequency);
 	    }
-	  if (pt_expr->info.expr.arg2 && pt_expr->info.expr.arg2->node_type == PT_NAME
-	      && pt_expr->info.expr.arg2->info.name.null_frequency >= 0.0)
+	  if (node->info.expr.arg2 && node->info.expr.arg2->node_type == PT_NAME
+	      && node->info.expr.arg2->info.name.null_frequency >= 0.0)
 	    {
-	      selectivity = selectivity * (1 - pt_expr->info.expr.arg2->info.name.null_frequency);
+	      selectivity = selectivity * (1 - node->info.expr.arg2->info.name.null_frequency);
 	    }
 	}
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27039

## Purpose

옵티마이저의 히스토그램 소비측 결함 5건 (전부 develop에 기존 존재; PR #7286의 reservoir ANALYZE 경로를 스트레스 테스트하며 발견). 원칙: **히스토그램 문제가 질의를 잘못 이끌거나 실패시켜서는 안 된다.** (1)(2)는 latent(현재 도달 불가), (3)(4)(5)는 도달 가능하며 실서버 재현 완료.

**(1) 역방향 비교 — include_equal 반전 (latent).** `qo_comp_selectivity()`의 `const OP attr` 분기가 두 플래그를 모두 반전(complement)시켜야 할 것을 방향만 반전(mirror)해야 하는데 둘 다 반전 — 경계값 포함/제외가 뒤바뀜.

**(2) 등가 폴백의 union 오독 (latent).** `qo_equal_selectivity()`의 `PC_CONST`→`PC_HOST_VAR` `[[fallthrough]]`가 `PT_VALUE` 노드에서 `host_var.index`(잘못된 union 멤버)를 읽음.

**(3) LIKE 선택도의 OR 체인 오순회 (도달 가능, 11배).** dispatch가 체인 head를 넘기고 `qo_like_selectivity()`가 체인 전체를 재순회하며 비-LIKE 형제를 이중 계상 (`c1 LIKE '%HEAVY%' OR c3 IN (...)` est 10,907 vs 실제 1,000).

**(4) NULL 보정이 체인 head의 컬럼을 사용 (도달 가능, 10배).** `×(1−null_frequency)` 복원이 현재 노드가 아닌 `pt_expr`(head)을 참조해, null-free head 뒤의 고null 형제가 conditional 선택도를 그대로 유지 (순서 의존적: `c3>=7 OR c0<=date` est 14,184 vs 피연산자 스왑 시 1,418=실제). IS [NOT] NULL 케이스도 동일하게 head를 참조하며, `not_null_calculated`가 노드별로 리셋되지 않음.

**(5) 히스토그램 fetch 실패가 질의를 중단시킴 (도달 가능, 동시성).** `sm_get_class_with_statistics()`가 `stats_get_histogram()` 실패 시 NULL을 반환하고, `grok_classes()`가 이를 치명적으로 처리(`PT_INTERNAL_ERROR`, query_graph.c). 동시에 실행되는 `ANALYZE ... UPDATE HISTOGRAM`이 `_db_histogram`을 재작성하는 동안 fetch가 일시적으로 깨져, 동시 컴파일 질의의 ~1.4~2%가 "System error (info)"로 실패. 일반 `UPDATE STATISTICS`는 이 문제를 전혀 유발하지 않음(0%). 에러는 일시적(즉시 재시도 시 성공)이며 서버는 살아있음.

## Implementation

- **(1)** 4개 호출의 플래그를 mirror로 정정 + converse 항등식 주석 추가.
- **(2)** `PC_CONST`/`PC_HOST_VAR` 케이스를 병합하고 `pc_lhs`에 따라 값 슬롯 선택.
- **(3)** 현재 `node`를 전달하고 해당 노드만 평가 (내부 or_next 루프 제거).
- **(4)** IS [NOT] NULL 케이스와 `×(1−nf)` 블록에서 현재 노드의 arg를 사용하고, `not_null_calculated`를 노드마다 리셋.
- **(5)** 히스토그램 fetch 실패 시 `NULL` 반환 대신 `class_->histogram = NULL`로 두고 계속 진행; 옵티마이저는 기본 추정치로 폴백.

## Remarks

- (1)(2): 현재 도달 불가함을 확인 (`qo_converse_sarg_terms()`가 `const OP attr`를 무조건 정규화) — 폴백 정확성 개선일 뿐.
- (3)(4): 시드 기반 랜덤 est-vs-actual 퍼징으로 발견; 런타임 검증 — (3) 10,907→1,007, (4) 14,184→1,418, 순서 의존성 소멸, 회귀 없음.
- (5): 동시 ANALYZE+질의 퍼징으로 발견; 런타임 검증 — 에러율 2.02%→0.00%, 결과값 정확.
- 5곳 모두 develop에 기존 존재하는 코드(히스토그램 기능); PR #7286의 diff에는 포함되지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
