### PR TITLE
[CBRD-27040] Downgrade UPDATE STATISTICS WITH FULLSCAN to sampling above a page-count cap

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -775,6 +775,8 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 
 #define PRM_NAME_LOG_POSTPONE_CACHE_SIZE "postpone_cache_size"
 
+#define PRM_NAME_STATS_FULLSCAN_MAX_PAGES "stats_fullscan_max_pages"
+
 /*
  * Note about ERROR_LIST and INTEGER_LIST type
  * ERROR_LIST type is an array of bool type with the size of -(ER_LAST_ERROR)
@@ -2514,6 +2516,11 @@ static int prm_log_postpone_cache_size_default = 512;
 static int prm_log_postpone_cache_size_upper = 4096;
 static int prm_log_postpone_cache_size_lower = 4;
 static unsigned int prm_log_postpone_cache_size_flag = 0;
+
+int PRM_STATS_FULLSCAN_MAX_PAGES = 10000;
+static int prm_stats_fullscan_max_pages_default = 10000;
+static int prm_stats_fullscan_max_pages_lower = 0;
+static unsigned int prm_stats_fullscan_max_pages_flag = 0;
 
 typedef int (*DUP_PRM_FUNC) (void *, SYSPRM_DATATYPE, void *, SYSPRM_DATATYPE);
 
@@ -6628,6 +6635,18 @@ SYSPRM_PARAM prm_Def[] = {
    (void *) &PRM_LOG_POSTPONE_CACHE_SIZE,
    (void *) &prm_log_postpone_cache_size_upper,
    (void *) &prm_log_postpone_cache_size_lower,
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
+  {PRM_ID_STATS_FULLSCAN_MAX_PAGES,
+   PRM_NAME_STATS_FULLSCAN_MAX_PAGES,
+   (PRM_FOR_CLIENT | PRM_FOR_SERVER | PRM_USER_CHANGE | PRM_HIDDEN),
+   PRM_INTEGER,
+   &prm_stats_fullscan_max_pages_flag,
+   (void *) &prm_stats_fullscan_max_pages_default,
+   (void *) &PRM_STATS_FULLSCAN_MAX_PAGES,
+   (void *) NULL,
+   (void *) &prm_stats_fullscan_max_pages_lower,
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL},

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -504,8 +504,10 @@ enum param_id
 
   PRM_ID_LOG_POSTPONE_CACHE_SIZE,
 
+  PRM_ID_STATS_FULLSCAN_MAX_PAGES,
+
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_LOG_POSTPONE_CACHE_SIZE
+  PRM_LAST_ID = PRM_ID_STATS_FULLSCAN_MAX_PAGES
 };
 typedef enum param_id PARAM_ID;
 

--- a/src/storage/statistics_cl.c
+++ b/src/storage/statistics_cl.c
@@ -483,6 +483,19 @@ stats_get_ndv_by_query (const MOP class_mop, CLASS_ATTR_NDV * class_attr_ndv, FI
       return ER_FAILED;
     }
 
+  if (with_fullscan == STATS_WITH_FULLSCAN)
+    {
+      int nobjs = 0, npages = 0;
+
+      /* Past stats_fullscan_max_pages (hidden parameter), force sampling scan
+       * even for WITH FULLSCAN to bound the cost of count(distinct) queries. */
+      if (db_get_class_num_objs_and_pages (class_mop, 1, &nobjs, &npages) == NO_ERROR
+	  && npages > prm_get_integer_value (PRM_ID_STATS_FULLSCAN_MAX_PAGES))
+	{
+	  with_fullscan = STATS_WITH_SAMPLING;	/* downgrade */
+	}
+    }
+
   /* create sampling SQL statement */
   if (with_fullscan == STATS_WITH_FULLSCAN)
     {

--- a/src/storage/statistics_cl.c
+++ b/src/storage/statistics_cl.c
@@ -426,6 +426,68 @@ end:
 }
 
 /*
+ * stats_get_fullscan_page_count () - Return the approximate number of heap
+ *   pages that a full-table count(distinct) query would scan for a class.
+ *   return: NO_ERROR or error code
+ *   class_mop(in): class object
+ *   npages(out): approximate total heap page count
+ *
+ * Note: For a partitioned table the count(distinct) query scans every
+ *   partition, so the partition heap pages are summed. The parent (catalog)
+ *   heap of a partitioned class is nearly empty and must not be used alone.
+ */
+static int
+stats_get_fullscan_page_count (const MOP class_mop, int *npages)
+{
+  int partition_type = DB_NOT_PARTITIONED_CLASS;
+  MOP *partitions = NULL;
+  int nobjs = 0;
+  int error = NO_ERROR;
+
+  *npages = 0;
+
+  error = sm_partitioned_class_type ((DB_OBJECT *) class_mop, &partition_type, NULL, &partitions);
+  if (error != NO_ERROR)
+    {
+      return error;
+    }
+
+  if (partition_type == DB_PARTITIONED_CLASS && partitions != NULL)
+    {
+      int i, part_pages;
+
+      for (i = 0; partitions[i] != NULL; i++)
+	{
+	  part_pages = 0;
+	  error = db_get_class_num_objs_and_pages (partitions[i], 1 /* approximation */ , &nobjs, &part_pages);
+	  if (error != NO_ERROR)
+	    {
+	      free_and_init (partitions);
+	      return error;
+	    }
+	  *npages += part_pages;
+	}
+
+      free_and_init (partitions);
+    }
+  else
+    {
+      if (partitions != NULL)
+	{
+	  free_and_init (partitions);
+	}
+
+      error = db_get_class_num_objs_and_pages ((DB_OBJECT *) class_mop, 1 /* approximation */ , &nobjs, npages);
+      if (error != NO_ERROR)
+	{
+	  return error;
+	}
+    }
+
+  return NO_ERROR;
+}
+
+/*
  * stats_get_ndv_by_query () - get NDV by query
  *   return:
  *   class_mop(in):
@@ -485,12 +547,14 @@ stats_get_ndv_by_query (const MOP class_mop, CLASS_ATTR_NDV * class_attr_ndv, FI
 
   if (with_fullscan == STATS_WITH_FULLSCAN)
     {
-      int nobjs = 0, npages = 0;
+      int npages = 0;
 
-      /* Past stats_fullscan_max_pages (hidden parameter), force sampling scan
-       * even for WITH FULLSCAN to bound the cost of count(distinct) queries. */
-      if (db_get_class_num_objs_and_pages (class_mop, 1, &nobjs, &npages) == NO_ERROR
-	  && npages > prm_get_integer_value (PRM_ID_STATS_FULLSCAN_MAX_PAGES))
+      /* Bound the cost of the hint-less count(distinct) full scan: when the table has more than
+       * stats_fullscan_max_pages (hidden parameter) heap pages, downgrade WITH FULLSCAN to a sampling scan. If the
+       * page count cannot be determined, downgrade conservatively so a probe failure never falls back to the
+       * expensive full scan this is meant to avoid. */
+      if (stats_get_fullscan_page_count (class_mop, &npages) != NO_ERROR
+	  || npages > prm_get_integer_value (PRM_ID_STATS_FULLSCAN_MAX_PAGES))
 	{
 	  with_fullscan = STATS_WITH_SAMPLING;	/* downgrade */
 	}

--- a/src/storage/statistics_cl.c
+++ b/src/storage/statistics_cl.c
@@ -547,16 +547,19 @@ stats_get_ndv_by_query (const MOP class_mop, CLASS_ATTR_NDV * class_attr_ndv, FI
 
   if (with_fullscan == STATS_WITH_FULLSCAN)
     {
+      int max_pages = prm_get_integer_value (PRM_ID_STATS_FULLSCAN_MAX_PAGES);
       int npages = 0;
 
-      /* Bound the cost of the hint-less count(distinct) full scan: when the table has more than
-       * stats_fullscan_max_pages (hidden parameter) heap pages, downgrade WITH FULLSCAN to a sampling scan. If the
-       * page count cannot be determined, downgrade conservatively so a probe failure never falls back to the
-       * expensive full scan this is meant to avoid. */
-      if (stats_get_fullscan_page_count (class_mop, &npages) != NO_ERROR
-	  || npages > prm_get_integer_value (PRM_ID_STATS_FULLSCAN_MAX_PAGES))
+      /* Bound the cost of the hint-less count(distinct) full scan: downgrade WITH FULLSCAN to a sampling scan when
+       * the table has more than stats_fullscan_max_pages (hidden parameter) heap pages, or when its size cannot be
+       * determined (fail-safe: a probe failure must not fall back to the expensive full scan). A value of 0 or less
+       * disables the cap and always honors WITH FULLSCAN. */
+      if (max_pages > 0 && (stats_get_fullscan_page_count (class_mop, &npages) != NO_ERROR || npages > max_pages))
 	{
-	  with_fullscan = STATS_WITH_SAMPLING;	/* downgrade */
+	  er_clear ();		/* clear the error a failed probe may have raised; it does not fail the update */
+	  with_fullscan = STATS_WITH_SAMPLING;
+	  er_log_debug (ARG_FILE_LINE, "update stats: %s WITH FULLSCAN -> sampling (pages %d, max %d)\n",
+			class_name_p, npages, max_pages);
 	}
     }
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27040>

### Purpose

`update statistics ... with fullscan` 실행 시, 컬럼 NDV는 클라이언트가 힌트 없는 `count(distinct)` 전수 쿼리로 계산합니다(`stats_get_ndv_by_query`). 테이블이 매우 큰 경우 이 전수 스캔 쿼리가 과도하게 느려, `WITH FULLSCAN` 이 사실상 사용 불가한 수준의 시간이 걸립니다.

본 이슈에서는 테이블(힙) 페이지 수가 상한을 초과하면, `WITH FULLSCAN` 을 지정했더라도 샘플링 스캔 으로 자동 전환하여 비용을 제한하도록 합니다.

상한은 히든 파라미터로 두어 운영 중 조정 가능하게 하며, 기본값은 10000 페이지로 합니다.

### Implementation
* `stats_get_ndv_by_query()` 에서 `WITH FULLSCAN` 요청 시, 쿼리를 만들기 전에 테이블 페이지 수를 확인하여 상한 초과면 샘플링으로 강등한다.
  * 페이지 수 산정은 신규 함수 `stats_get_fullscan_page_count()` 로 분리한다.
  * 파티션 테이블은 부모(카탈로그) 힙이 거의 비어 있어, 각 파티션 힙 페이지를 합산해 판정한다. (부모 힙만 보면 대형 파티션 테이블에서 강등이 누락됨)
  * 페이지 수는 `db_get_class_num_objs_and_pages(approximation=1)`, 즉 힙 헤더 카운터 기반 추정치를 사용한다. approximation=0 은 힙 전수 스캔을 유발해 목적과 모순되므로 쓰지 않는다.
  * 상한을 0 이하로 두면 상한 판정을 하지 않고 `WITH FULLSCAN` 을 그대로 존중한다. (페이지 수 확인도 건너뜀)
  * 페이지 수를 구하지 못하면 안전하게 샘플링으로 강등한다. (확인 실패가 비싼 전수 스캔으로 되돌아가지 않도록 함) 이때 확인 과정에서 남은 에러는 `er_clear()` 로 정리하고 update 는 계속 진행한다.
  * 강등 시 클래스명 / 페이지 수 / 상한값을 `er_log_debug` 로 남긴다.
* src/base/system_parameter.h  파라미터 ID 추가
* src/base/system_parameter.c  파라미터 정의/기본값/등록
  * session flag 사용 금지 : 패치간의 rolling update를 하지 못하게 됨.
  * user_change 가능
  * 플래그 `PRM_FOR_CLIENT | PRM_FOR_SERVER | PRM_USER_CHANGE | PRM_HIDDEN`, 하한 0

### Remarks

N/A
