### PR TITLE
[CBRD-27045] Clang compile이 실패하는 문제 해결

### DIFF
--- a/src/query/numeric_opfunc.c
+++ b/src/query/numeric_opfunc.c
@@ -1354,13 +1354,14 @@ float_numeric_div_fast (uint64_t dividend_val, uint64_t divisor_val,
 {
   int i;
   int result_prec, result_scale, result_digits, exponent10;
-  int word_count = NUMERIC_AS_WORDS + 1;
+  enum
+  { WORD_COUNT = NUMERIC_AS_WORDS + 1 };
   int word_bytes = NUMERIC_AS_WORD_BYTES + 8;
   uint128_t temp;
 
   /* use 4-word buffer to safely handle scaling (up to ~77 digits) */
-  uint64_t dividend_word[word_count] = { 0, 0, 0, dividend_val };
-  uint64_t quotient_word[word_count] = { 0 };
+  uint64_t dividend_word[WORD_COUNT] = { 0, 0, 0, dividend_val };
+  uint64_t quotient_word[WORD_COUNT] = { 0 };
   uint64_t remainder_word = 0;
 
   /* 1) compare mantissa */
@@ -1397,16 +1398,16 @@ float_numeric_div_fast (uint64_t dividend_val, uint64_t divisor_val,
   /* 3) scale the dividend (normalization). exponent10 > 0 shifts up, < 0 truncates */
   if (exponent10 > 0)
     {
-      float_numeric_mul_normalize (dividend_word, word_count, word_bytes, exponent10);
+      float_numeric_mul_normalize (dividend_word, WORD_COUNT, word_bytes, exponent10);
     }
   else if (exponent10 < 0)
     {
       /* reduces digits for normalization; does not perform rounding */
-      (void) float_numeric_div_normalize (dividend_word, word_count, word_bytes, -exponent10);
+      (void) float_numeric_div_normalize (dividend_word, WORD_COUNT, word_bytes, -exponent10);
     }
 
   /* 4) division */
-  for (i = 0; i < word_count; i++)
+  for (i = 0; i < WORD_COUNT; i++)
     {
       temp = ((uint128_t) remainder_word << 64) | dividend_word[i];
       quotient_word[i] = (uint64_t) (temp / divisor_val);
@@ -1416,12 +1417,12 @@ float_numeric_div_fast (uint64_t dividend_val, uint64_t divisor_val,
   /* 5) round up if necessary */
   if (((uint128_t) remainder_word * 2) >= divisor_val)
     {
-      float_numeric_increment (quotient_word, word_count, 1);
+      float_numeric_increment (quotient_word, WORD_COUNT, 1);
     }
 
   /* 6) round and pack to DB_NUMERIC_BUF_SIZE bytes */
-  result_prec = float_numeric_get_decimal_digit (quotient_word, word_count);
-  if (*result_sign && result_prec == 1 && quotient_word[word_count - 1] == 0)
+  result_prec = float_numeric_get_decimal_digit (quotient_word, WORD_COUNT);
+  if (*result_sign && result_prec == 1 && quotient_word[WORD_COUNT - 1] == 0)
     {
       /* Prevent -0; zero is always treated as positive. */
       *result_sign = false;
@@ -1430,7 +1431,7 @@ float_numeric_div_fast (uint64_t dividend_val, uint64_t divisor_val,
    * Ignoring the return value here is intentional: any scale boundary overflow
    * from round-carry is surfaced by the caller's float_numeric_check_overflow_and_adjust_scale().
    */
-  (void) float_numeric_round_and_pack (quotient_word, word_count, word_bytes, result_buf, &result_prec, &result_scale);
+  (void) float_numeric_round_and_pack (quotient_word, WORD_COUNT, word_bytes, result_buf, &result_prec, &result_scale);
   *result_prec_out = result_prec;
   *result_scale_out = result_scale;
 }
@@ -1944,8 +1945,10 @@ float_numeric_compare (uint8_t * arg1, uint8_t * arg2, int prec1, int scale1, in
   calc_words = NUMERIC_GET_WORD_COUNT (needed_bytes);
   calc_nbytes = NUMERIC_GET_BYTE_COUNT (calc_words);
 
-  uint64_t arg1_buf[calc_words] = { 0 };
-  uint64_t arg2_buf[calc_words] = { 0 };
+  uint64_t arg1_buf[calc_words];
+  uint64_t arg2_buf[calc_words];
+  memset (arg1_buf, 0, sizeof (arg1_buf));
+  memset (arg2_buf, 0, sizeof (arg2_buf));
 
   numeric_bytes_to_words (arg1, DB_NUMERIC_BUF_SIZE, arg1_buf, calc_words, calc_nbytes);
   numeric_bytes_to_words (arg2, DB_NUMERIC_BUF_SIZE, arg2_buf, calc_words, calc_nbytes);
@@ -2521,9 +2524,12 @@ float_numeric_db_value_add (const DB_VALUE * dbv1, const DB_VALUE * dbv2, DB_VAL
   calc_nbytes = NUMERIC_GET_BYTE_COUNT (calc_words);
 
   /* 3) initialize new calculation buffers and pad absolute values */
-  uint64_t dbv1_word[calc_words] = { 0 };
-  uint64_t dbv2_word[calc_words] = { 0 };
-  uint64_t result_word[calc_words] = { 0 };
+  uint64_t dbv1_word[calc_words];
+  uint64_t dbv2_word[calc_words];
+  uint64_t result_word[calc_words];
+  memset (dbv1_word, 0, sizeof (dbv1_word));
+  memset (dbv2_word, 0, sizeof (dbv2_word));
+  memset (result_word, 0, sizeof (result_word));
 
   numeric_bytes_to_words (db_locate_numeric (dbv1), DB_NUMERIC_BUF_SIZE, dbv1_word, calc_words, calc_nbytes);
   numeric_bytes_to_words (db_locate_numeric (dbv2), DB_NUMERIC_BUF_SIZE, dbv2_word, calc_words, calc_nbytes);
@@ -2794,9 +2800,12 @@ float_numeric_db_value_sub (const DB_VALUE * dbv1, const DB_VALUE * dbv2, DB_VAL
   calc_nbytes = NUMERIC_GET_BYTE_COUNT (calc_words);
 
   /* 3) initialize new calculation buffers and pad absolute values */
-  uint64_t dbv1_word[calc_words] = { 0 };
-  uint64_t dbv2_word[calc_words] = { 0 };
-  uint64_t result_word[calc_words] = { 0 };
+  uint64_t dbv1_word[calc_words];
+  uint64_t dbv2_word[calc_words];
+  uint64_t result_word[calc_words];
+  memset (dbv1_word, 0, sizeof (dbv1_word));
+  memset (dbv2_word, 0, sizeof (dbv2_word));
+  memset (result_word, 0, sizeof (result_word));
 
   numeric_bytes_to_words (db_locate_numeric (dbv1), DB_NUMERIC_BUF_SIZE, dbv1_word, calc_words, calc_nbytes);
   numeric_bytes_to_words (db_locate_numeric (dbv2), DB_NUMERIC_BUF_SIZE, dbv2_word, calc_words, calc_nbytes);
@@ -3027,9 +3036,12 @@ float_numeric_db_value_mul (const DB_VALUE * dbv1, const DB_VALUE * dbv2, DB_VAL
   calc_nbytes = NUMERIC_GET_BYTE_COUNT (calc_words);
 
   /* 3) initialize new calculation buffers and pad absolute values */
-  uint64_t dbv1_word[calc_words] = { 0 };
-  uint64_t dbv2_word[calc_words] = { 0 };
-  uint64_t result_word[calc_words] = { 0 };
+  uint64_t dbv1_word[calc_words];
+  uint64_t dbv2_word[calc_words];
+  uint64_t result_word[calc_words];
+  memset (dbv1_word, 0, sizeof (dbv1_word));
+  memset (dbv2_word, 0, sizeof (dbv2_word));
+  memset (result_word, 0, sizeof (result_word));
 
   numeric_bytes_to_words (db_locate_numeric (dbv1), DB_NUMERIC_BUF_SIZE, dbv1_word, calc_words, calc_nbytes);
   numeric_bytes_to_words (db_locate_numeric (dbv2), DB_NUMERIC_BUF_SIZE, dbv2_word, calc_words, calc_nbytes);
@@ -3388,10 +3400,14 @@ float_numeric_db_value_div (const DB_VALUE * dbv1, const DB_VALUE * dbv2, DB_VAL
   calc_words = NUMERIC_GET_WORD_COUNT (needed_bytes);
   calc_nbytes = NUMERIC_GET_BYTE_COUNT (calc_words);
 
-  uint64_t dividend_work[calc_words] = { 0 };
-  uint64_t divisor_work[calc_words] = { 0 };
-  uint64_t quotient_work[calc_words] = { 0 };
-  uint64_t remainder_work[calc_words] = { 0 };
+  uint64_t dividend_work[calc_words];
+  uint64_t divisor_work[calc_words];
+  uint64_t quotient_work[calc_words];
+  uint64_t remainder_work[calc_words];
+  memset (dividend_work, 0, sizeof (dividend_work));
+  memset (divisor_work, 0, sizeof (divisor_work));
+  memset (quotient_work, 0, sizeof (quotient_work));
+  memset (remainder_work, 0, sizeof (remainder_work));
 
   numeric_bytes_to_words (db_locate_numeric (dbv1), DB_NUMERIC_BUF_SIZE, dividend_work, calc_words, calc_nbytes);
   numeric_bytes_to_words (db_locate_numeric (dbv2), DB_NUMERIC_BUF_SIZE, divisor_work, calc_words, calc_nbytes);
@@ -4139,10 +4155,14 @@ float_numeric_db_value_mod (const DB_VALUE * value1, const DB_VALUE * value2, DB
   calc_words = NUMERIC_GET_WORD_COUNT (needed_bytes);
   calc_nbytes = NUMERIC_GET_BYTE_COUNT (calc_words);
 
-  uint64_t dividend_work[calc_words] = { 0 };
-  uint64_t divisor_work[calc_words] = { 0 };
-  uint64_t quotient_work[calc_words] = { 0 };
-  uint64_t remainder_work[calc_words] = { 0 };
+  uint64_t dividend_work[calc_words];
+  uint64_t divisor_work[calc_words];
+  uint64_t quotient_work[calc_words];
+  uint64_t remainder_work[calc_words];
+  memset (dividend_work, 0, sizeof (dividend_work));
+  memset (divisor_work, 0, sizeof (divisor_work));
+  memset (quotient_work, 0, sizeof (quotient_work));
+  memset (remainder_work, 0, sizeof (remainder_work));
 
   numeric_bytes_to_words (db_locate_numeric (value1), DB_NUMERIC_BUF_SIZE, dividend_work, calc_words, calc_nbytes);
   numeric_bytes_to_words (db_locate_numeric (value2), DB_NUMERIC_BUF_SIZE, divisor_work, calc_words, calc_nbytes);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27045>

### Purpose

[CBRD-26006](http://jira.cubrid.org/browse/CBRD-26006) 이 develop에 merge된 이후에, clang compile이 실패하는 오류를 수정한다.

**현상**

debug_clang preset으로 빌드 시 src/query/numeric_opfunc.c에서 컴파일 에러 20건이 발생하여 빌드가 실패한다.

```
   error: variable-sized object may not be initialized
    1362 |   uint64_t dividend_word[word_count] = { 0, 0, 0, dividend_val };
```
cubridsa, cubridcs, cubrid 세 타겟 모두 동일 파일에서 실패하므로 Clang 빌드 자체가 불가능한 상태이다.

원인

[CBRD-26006](http://jira.cubrid.org/browse/CBRD-26006) (PR #6486, commit de7bc5ec2) 에서 NUMERIC 타입의 부동소수점 연산 지원을 추가하면서, 런타임에 크기가 결정되는 가변 길이 배열(VLA)을 선언과 동시에 초기화하는 코드가 도입되었다.

```c
   int calc_words = NUMERIC_GET_WORD_COUNT(needed_bytes);
   uint64_t buf[calc_words] = { 0 };   // ← 문제 지점
```
이 패턴은 GCC에서는 확장 문법으로 허용되지만, C++ 표준에서는 VLA 자체가 비표준이고,
Clang은 VLA를 확장으로 허용하되 초기화자는 거부한다.
CUBRID의 .c 파일은 CMake에서 C++ 컴파일러로 빌드되므로 이 제약에 걸린다.

해결

두 가지 케이스로 나누어 수정한다.

1) 컴파일 타임 상수인 경우 (1건: float_numeric_div_fast)

word_count = NUMERIC_AS_WORDS + 1은 매크로 상수로부터 계산되므로 사실상 항상 4이다. enum으로 선언하여 컴파일러가 상수로 인식하도록 변경하면 VLA가 아닌 일반 고정 크기 배열이 되어 초기화도 허용된다.

```c
   // Before
   int word_count = NUMERIC_AS_WORDS + 1;
   uint64_t dividend_word[word_count] = { 0, 0, 0, dividend_val };

   // After
   enum { WORD_COUNT = NUMERIC_AS_WORDS + 1 };
   uint64_t dividend_word[WORD_COUNT] = { 0, 0, 0, dividend_val };
```
2) 런타임 계산 크기인 경우 (19건: 6개 함수)

calc_words는 입력 정밀도에 따라 런타임에 결정되므로 VLA를 유지하되, 초기화자를 제거하고 memset으로 대체한다.

```c
   // Before
   uint64_t buf[calc_words] = \{ 0 \};

   // After
   uint64_t buf[calc_words];
   memset(buf, 0, sizeof(buf));
```
영향 범위

변경 파일: src/query/numeric_opfunc.c (1개)
수정 함수: float_numeric_div_fast, float_numeric_compare, float_numeric_db_value_add, float_numeric_db_value_sub, float_numeric_db_value_mul, float_numeric_db_value_div, float_numeric_db_value_mod (7개)
동작 변경 없음: 배열을 0으로 초기화하는 의미(semantics)는 동일
