### PR TITLE
[CBRD-27047] AR sampling underestimates the NDV of a NULL-dominant leading column as 1 (11.4)

### DIFF
--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -7128,7 +7128,7 @@ btree_get_stats_with_AR_sampling (THREAD_ENTRY * thread_p, BTREE_STATS_ENV * env
   int n, i;
   int key_cnt;
   int leafs_max = STATS_SAMPLING_LEAFS_MAX;
-  bool retried = false;
+  int retry_cnt = 0;
   double exp_ratio;
   int ret = NO_ERROR;
 #if !defined(NDEBUG)
@@ -7205,10 +7205,11 @@ resample:
 
   /* Some keys were sampled but none of them has a non-NULL leading column (pkeys[0] == 0):
    * the NDV of every key column will be estimated as 1 even though non-NULL values may exist
-   * in the leaf pages that were not sampled. Retry sampling once more to get a chance to read them. */
-  if (!retried && env->pkeys_val_num > 0 && env->stat_info->keys > 0 && env->stat_info->pkeys[0] == 0)
+   * in the leaf pages that were not sampled. Retry sampling to get a chance to read them. */
+  if (retry_cnt < STATS_SAMPLING_RETRY_MAX && env->pkeys_val_num > 0 && env->stat_info->keys > 0
+      && env->stat_info->pkeys[0] == 0)
     {
-      retried = true;
+      retry_cnt++;
       leafs_max += STATS_SAMPLING_LEAFS_MAX;
       goto resample;
     }

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -7127,6 +7127,8 @@ btree_get_stats_with_AR_sampling (THREAD_ENTRY * thread_p, BTREE_STATS_ENV * env
   BTREE_SCAN *BTS;
   int n, i;
   int key_cnt;
+  int leafs_max = STATS_SAMPLING_LEAFS_MAX;
+  bool retried = false;
   double exp_ratio;
   int ret = NO_ERROR;
 #if !defined(NDEBUG)
@@ -7139,9 +7141,10 @@ btree_get_stats_with_AR_sampling (THREAD_ENTRY * thread_p, BTREE_STATS_ENV * env
   BTS = &(env->btree_scan);
   BTS->use_desc_index = 0;	/* init */
 
+resample:
   for (n = 0; n < STATS_SAMPLING_THRESHOLD; n++)
     {
-      if (env->stat_info->leafs >= STATS_SAMPLING_LEAFS_MAX)
+      if (env->stat_info->leafs >= leafs_max)
 	{
 	  break;		/* found all samples */
 	}
@@ -7199,6 +7202,16 @@ btree_get_stats_with_AR_sampling (THREAD_ENTRY * thread_p, BTREE_STATS_ENV * env
 	  pgbuf_unfix_and_init (thread_p, BTS->C_page);
 	}
     }				/* for (n = 0; ... ) */
+
+  /* Some keys were sampled but none of them has a non-NULL leading column (pkeys[0] == 0):
+   * the NDV of every key column will be estimated as 1 even though non-NULL values may exist
+   * in the leaf pages that were not sampled. Retry sampling once more to get a chance to read them. */
+  if (!retried && env->pkeys_val_num > 0 && env->stat_info->keys > 0 && env->stat_info->pkeys[0] == 0)
+    {
+      retried = true;
+      leafs_max += STATS_SAMPLING_LEAFS_MAX;
+      goto resample;
+    }
 
   /* apply distributed expension */
   if (env->stat_info->leafs > 0)
@@ -15311,7 +15324,12 @@ btree_find_AR_sampling_leaf (THREAD_ENTRY * thread_p, BTID * btid, VPID * pg_vpi
 	  goto error;
 	}
 
-      slot_id = (int) (drand48 () * key_cnt);
+      /* Child pointers are stored in slots [1, key_cnt] (slot 0 is the node header).
+       * Since drand48() returns [0.0, 1.0), (int) (drand48 () * key_cnt) is [0, key_cnt - 1];
+       * add 1 to map it to [1, key_cnt] so that every child, including the rightmost one (slot key_cnt),
+       * can be selected. Without the "+ 1", the rightmost child is never sampled at any level,
+       * so the rightmost leaves become unreachable. */
+      slot_id = (int) (drand48 () * key_cnt) + 1;
       slot_id = MAX (slot_id, 1);
 
       assert (slot_id > 0);

--- a/src/storage/statistics.h
+++ b/src/storage/statistics.h
@@ -36,6 +36,7 @@
 
 #define STATS_SAMPLING_THRESHOLD 5000	/* sampling trial count */
 #define STATS_SAMPLING_LEAFS_MAX 5000	/* sampling leaf pages */
+#define STATS_SAMPLING_RETRY_MAX 5	/* max retry count of sampling when no non-NULL leading column was sampled */
 #define NUMBER_OF_SAMPLING_PAGES 5000
 #define EXPECTED_ROWS_PER_PAGE 20
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27047>

### Purpose

`update statistics`(기본, `WITH FULLSCAN` 미지정) 실행 시, 인덱스 NDV는 AR 샘플링(`btree_get_stats_with_AR_sampling`)으로 추정합니다. 선두 컬럼이 대부분 NULL인 다중 컬럼 인덱스에서는 선두 컬럼 NDV(`pkeys[0]`)가 항상 0으로 추정된 뒤 1로 보정되어, 잘못된 플랜을 유발합니다.

원인은 두 가지입니다.

1. 샘플링 하강 시 슬롯 선택이 `[1, key_cnt-1]`로 제한되어(`drand48() ∈ [0, 1.0)` 이므로), 맨 오른쪽 자식(슬롯 key_cnt)이 매 레벨 확률 0으로 배제됩니다. `NULL`은 앞쪽에 정렬되므로 `not-NULL` 선두 키가 몰리는 맨 오른쪽 리프에 구조적으로 도달할 수 없어, `pkeys[0]=0`이 항상 발생합니다.

2. `not-NULL` 리프가 전체 리프 중 극소수(예: 15,000장 중 1~2장)면 한 라운드(5000장)로는 놓칠 수 있습니다.

본 PR에서는 맨 오른쪽 자식을 선택 가능하게 수정하고, 샘플 결과 선두 컬럼 NDV가 0이면 샘플링을 최대 5회 더 수행하도록 합니다.

### Implementation

* `btree_find_AR_sampling_leaf()` 자식 슬롯 선택에 +1 적용: `[0, key_cnt-1] → [1, key_cnt]`. 모든 자식이 균등 확률(`1/key_cnt`)로 선택된다. (자식 포인터는 슬롯 1~key_cnt에 존재)
* `btree_get_stats_with_AR_sampling()` 샘플링 루프 종료 후, 선두 컬럼이 not-NULL인 키가 없으면(pkeys[0] == 0) 샘플링을 5회 재수행
* 이전 결과를 버리지 않고 최대 `STATS_SAMPLING_LEAFS_MAX`(5000)장 추가 누적
* 판정은 확장 계산(exp_ratio) 전에 수행
* 재시도는 최대 5회

### Remarks

* develop의 동일 이슈는 [CBRD-26903](http://jira.cubrid.org/browse/CBRD-26903) 에서 처리될 예정.
* 확률적 개선이며 보장은 아님: not-NULL 리프 m장/전체 N장일 때 라운드당 도달 확률 ≈ 1 - (1 - m/N)^5000, 재시도로 기회 5배