### PR TITLE
[CBRD-26874] DEFAULT EXPR (1/6) - VOLATILITY IMMUTABLE print original expression

### DIFF
--- a/src/base/object_representation_sr.c
+++ b/src/base/object_representation_sr.c
@@ -2659,6 +2659,20 @@ or_get_current_representation (RECDES * record, int do_indexes)
 	    }
 	  pr_clear_value (&def_expr);
 
+	  /* Expression-Derived Literal: restore the original expression text. */
+	  if (att_props != NULL && classobj_get_prop (att_props, "default_expr_literal", &def_expr) > 0)
+	    {
+	      const char *edl_text = db_get_string (&def_expr);
+
+	      if (edl_text != NULL)
+		{
+		  att->default_value.default_expr.default_expr_text = strdup (edl_text);
+		  att->current_default_value.default_expr.default_expr_text = strdup (edl_text);
+		}
+	    }
+
+	  pr_clear_value (&def_expr);
+
 	  if (att_props != NULL && classobj_get_prop (att_props, "update_default", &def_expr) > 0)
 	    {
 	      /* simple expressions like SYS_DATE */
@@ -3637,6 +3651,11 @@ or_free_classrep (OR_CLASSREP * rep)
 	      free_and_init (att->default_value.default_expr.default_expr_format);
 	    }
 
+	  if (att->default_value.default_expr.default_expr_text != NULL)
+	    {
+	      free_and_init (att->default_value.default_expr.default_expr_text);
+	    }
+
 	  if (att->current_default_value.value != NULL)
 	    {
 	      free_and_init (att->current_default_value.value);
@@ -3645,6 +3664,11 @@ or_free_classrep (OR_CLASSREP * rep)
 	  if (att->current_default_value.default_expr.default_expr_format != NULL)
 	    {
 	      free_and_init (att->current_default_value.default_expr.default_expr_format);
+	    }
+
+	  if (att->current_default_value.default_expr.default_expr_text != NULL)
+	    {
+	      free_and_init (att->current_default_value.default_expr.default_expr_text);
 	    }
 
 	  if (att->btids != NULL && att->btids != att->btid_pack)

--- a/src/base/object_representation_sr.c
+++ b/src/base/object_representation_sr.c
@@ -2883,22 +2883,7 @@ or_get_current_representation (RECDES * record, int do_indexes)
 
 error_cleanup:
 
-  if (rep->attributes)
-    {
-      free_and_init (rep->attributes);
-    }
-
-  if (rep->shared_attrs)
-    {
-      free_and_init (rep->shared_attrs);
-    }
-
-  if (rep->class_attrs)
-    {
-      free_and_init (rep->class_attrs);
-    }
-
-  free_and_init (rep);
+  or_free_classrep (rep);
 
   return NULL;
 }

--- a/src/base/object_representation_sr.c
+++ b/src/base/object_representation_sr.c
@@ -2666,8 +2666,20 @@ or_get_current_representation (RECDES * record, int do_indexes)
 
 	      if (edl_text != NULL)
 		{
-		  att->default_value.default_expr.default_expr_text = strdup (edl_text);
-		  att->current_default_value.default_expr.default_expr_text = strdup (edl_text);
+		  char *dv_text = strdup (edl_text);
+		  char *cdv_text = strdup (edl_text);
+		  if (dv_text == NULL || cdv_text == NULL)
+		    {
+		      free_and_init (dv_text);
+		      free_and_init (cdv_text);
+		      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1,
+			      (size_t) (strlen (edl_text) + 1));
+		      pr_clear_value (&def_expr);
+		      pr_clear_value (&properties_val);
+		      goto error_cleanup;
+		    }
+		  att->default_value.default_expr.default_expr_text = dv_text;
+		  att->current_default_value.default_expr.default_expr_text = cdv_text;
 		}
 	    }
 

--- a/src/base/pt_volatility.h
+++ b/src/base/pt_volatility.h
@@ -1,5 +1,4 @@
 /*
- * Copyright 2008 Search Solution Corporation
  * Copyright 2016 CUBRID Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/base/pt_volatility.h
+++ b/src/base/pt_volatility.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+/*
+ * pt_volatility.h - volatility classification of functions/operators
+ *
+ * A cross-cutting concept, not parser-specific: the client/parser uses it to
+ * decide DEFAULT-expression folding, and the server will use it at INSERT
+ * execution to decide how often a DEFAULT is evaluated (VOLATILE -> once per
+ * row).  Lives in base/ so both worlds can include it.  Self-contained so the
+ * MAX-propagation rule can be unit-tested without linking the engine.
+ */
+
+#ifndef _PT_VOLATILITY_H_
+#define _PT_VOLATILITY_H_
+
+/*
+ * Volatility governs *when* and *how often* a column DEFAULT expression is
+ * evaluated and how aggressively it can be constant-folded -- it does NOT decide
+ * whether an expression is admissible in a DEFAULT.  The zero value is a distinct
+ * UNSET sentinel (NOT volatile): an un-annotated overload reaching DEFAULT
+ * processing is treated as not constant-foldable, never silently as Volatile.
+ */
+typedef enum
+{
+  PT_VOLATILITY_UNSET = 0,	/* not classified (zero value, sentinel) */
+  PT_VOLATILITY_IMMUTABLE,	/* same input always yields same output, forever */
+  PT_VOLATILITY_STABLE,		/* constant within a single statement */
+  PT_VOLATILITY_VOLATILE	/* may differ on every evaluation */
+} PT_VOLATILITY;
+
+/*
+ * pt_volatility_max () - MAX-combine two volatilities for bottom-up propagation.
+ *
+ * A PT_VOLATILITY_UNSET operand "taints" the result to UNSET: an expression
+ * containing an un-classified function/operator is conservatively treated as not
+ * constant-foldable.  Otherwise the result is the more-volatile of the two
+ * (IMMUTABLE < STABLE < VOLATILE).
+ */
+static inline PT_VOLATILITY
+pt_volatility_max (PT_VOLATILITY a, PT_VOLATILITY b)
+{
+  if (a == PT_VOLATILITY_UNSET || b == PT_VOLATILITY_UNSET)
+    {
+      return PT_VOLATILITY_UNSET;
+    }
+  return (a > b) ? a : b;
+}
+
+#endif /* _PT_VOLATILITY_H_ */

--- a/src/base/pt_volatility.h
+++ b/src/base/pt_volatility.h
@@ -1,5 +1,6 @@
 /*
- * Copyright 2024 CUBRID Corporation
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -21,8 +22,7 @@
  * A cross-cutting concept, not parser-specific: the client/parser uses it to
  * decide DEFAULT-expression folding, and the server will use it at INSERT
  * execution to decide how often a DEFAULT is evaluated (VOLATILE -> once per
- * row).  Lives in base/ so both worlds can include it.  Self-contained so the
- * MAX-propagation rule can be unit-tested without linking the engine.
+ * row).
  */
 
 #ifndef _PT_VOLATILITY_H_

--- a/src/compat/dbtype_def.h
+++ b/src/compat/dbtype_def.h
@@ -1302,6 +1302,7 @@ extern "C"
     DB_DEFAULT_EXPR_TYPE default_expr_type;	/* default expression identifier */
     int default_expr_op;	/* default expression operator */
     const char *default_expr_format;	/* default expression format */
+    const char *default_expr_text;	/* original text of an Expression-Derived Literal DEFAULT; NULL otherwise */
   };
 
   typedef DB_DATETIME DB_C_DATETIME;

--- a/src/executables/unload_schema.c
+++ b/src/executables/unload_schema.c
@@ -3092,7 +3092,8 @@ emit_attribute_def (extract_context & ctxt, print_output & output_ctx, DB_ATTRIB
 
   default_value = db_attribute_default (attribute);
   if ((default_value != NULL && !DB_IS_NULL (default_value))
-      || attribute->default_value.default_expr.default_expr_type != DB_DEFAULT_NONE)
+      || attribute->default_value.default_expr.default_expr_type != DB_DEFAULT_NONE
+      || attribute->default_value.default_expr.default_expr_text != NULL)
     {
       const char *default_expr_type_str;
 
@@ -3110,6 +3111,12 @@ emit_attribute_def (extract_context & ctxt, print_output & output_ctx, DB_ATTRIB
       if (default_expr_type_str != NULL)
 	{
 	  output_ctx ("%s", default_expr_type_str);
+	}
+      else if (attribute->default_value.default_expr.default_expr_text != NULL)
+	{
+	  /* Expression-Derived Literal: emit the original expression.  The stored text
+	   * is already the parser's parenthesized normal form, e.g. "(1+1)". */
+	  output_ctx ("%s", attribute->default_value.default_expr.default_expr_text);
 	}
       else
 	{

--- a/src/object/class_object.c
+++ b/src/object/class_object.c
@@ -4972,6 +4972,12 @@ classobj_clear_attribute (SM_ATTRIBUTE * att)
       att->default_value.default_expr.default_expr_format = NULL;
     }
 
+  if (att->default_value.default_expr.default_expr_text)
+    {
+      ws_free_string (att->default_value.default_expr.default_expr_text);
+      att->default_value.default_expr.default_expr_text = NULL;
+    }
+
   att->header.name = NULL;
 
   /* Do this last in case we needed it for default value maintenance or something. This probably isn't necessary, the
@@ -8799,6 +8805,20 @@ classobj_copy_default_expr (DB_DEFAULT_EXPR * dest, const DB_DEFAULT_EXPR * src)
   else
     {
       dest->default_expr_format = NULL;
+    }
+
+  if (src->default_expr_text)
+    {
+      dest->default_expr_text = ws_copy_string (src->default_expr_text);
+      if (dest->default_expr_text == NULL)
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, strlen (src->default_expr_text));
+	  return ER_OUT_OF_VIRTUAL_MEMORY;
+	}
+    }
+  else
+    {
+      dest->default_expr_text = NULL;
     }
 
   return NO_ERROR;

--- a/src/object/object_printer.cpp
+++ b/src/object/object_printer.cpp
@@ -561,7 +561,8 @@ void object_printer::describe_attribute (const struct db_object &cls, const sm_a
 	}
 
       if (!DB_IS_NULL (&attribute.default_value.value)
-	  || attribute.default_value.default_expr.default_expr_type != DB_DEFAULT_NONE)
+	  || attribute.default_value.default_expr.default_expr_type != DB_DEFAULT_NONE
+	  || attribute.default_value.default_expr.default_expr_text != NULL)
 	{
 	  const char *default_expr_type_str;
 
@@ -576,6 +577,12 @@ void object_printer::describe_attribute (const struct db_object &cls, const sm_a
 	  if (default_expr_type_str != NULL)
 	    {
 	      m_buf ("%s", default_expr_type_str);
+	    }
+	  else if (attribute.default_value.default_expr.default_expr_text != NULL)
+	    {
+	      /* Expression-Derived Literal: show the original expression.  The stored
+	       * text is already the parser's parenthesized normal form, e.g. "(1+1)". */
+	      m_buf ("%s", attribute.default_value.default_expr.default_expr_text);
 	    }
 	  else
 	    {

--- a/src/object/object_representation.c
+++ b/src/object/object_representation.c
@@ -6125,6 +6125,7 @@ classobj_initialize_default_expr (DB_DEFAULT_EXPR * default_expr)
   default_expr->default_expr_type = DB_DEFAULT_NONE;
   default_expr->default_expr_format = NULL;
   default_expr->default_expr_op = NULL_DEFAULT_EXPRESSION_OPERATOR;
+  default_expr->default_expr_text = NULL;
 }
 
 int

--- a/src/object/transform_cl.c
+++ b/src/object/transform_cl.c
@@ -4670,7 +4670,7 @@ tf_attribute_default_expr_to_property (SM_ATTRIBUTE * attr_list)
 
 	      if (attr->properties == NULL)
 		{
-		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, sizeof (DB_SEQ));
+		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (DB_SEQ));
 		  return er_errid ();
 		}
 	    }
@@ -4688,7 +4688,7 @@ tf_attribute_default_expr_to_property (SM_ATTRIBUTE * attr_list)
 		      classobj_free_prop (attr->properties);
 		      attr->properties = NULL;
 		    }
-		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, sizeof (DB_SEQ));
+		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (DB_SEQ));
 		  return er_errid ();
 		}
 
@@ -4744,7 +4744,7 @@ tf_attribute_default_expr_to_property (SM_ATTRIBUTE * attr_list)
 	      attr->properties = classobj_make_prop ();
 	      if (attr->properties == NULL)
 		{
-		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, sizeof (DB_SEQ));
+		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (DB_SEQ));
 		  return er_errid ();
 		}
 	    }
@@ -4767,7 +4767,7 @@ tf_attribute_default_expr_to_property (SM_ATTRIBUTE * attr_list)
 
 	      if (attr->properties == NULL)
 		{
-		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, sizeof (DB_SEQ));
+		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (DB_SEQ));
 		  return er_errid ();
 		}
 	    }

--- a/src/object/transform_cl.c
+++ b/src/object/transform_cl.c
@@ -3164,6 +3164,18 @@ disk_to_attribute (OR_BUF * buf, SM_ATTRIBUTE * att)
 
 	      pr_clear_value (&value);
 	    }
+
+	  /* Expression-Derived Literal: restore the original expression text. */
+	  if (classobj_get_prop (att->properties, "default_expr_literal", &value) > 0)
+	    {
+	      const char *edl_text = db_get_string (&value);
+
+	      if (edl_text != NULL)
+		{
+		  att->default_value.default_expr.default_expr_text = ws_copy_string (edl_text);
+		}
+	      pr_clear_value (&value);
+	    }
 	}
 
       /* variable attribute 6: comment */
@@ -4719,6 +4731,31 @@ tf_attribute_default_expr_to_property (SM_ATTRIBUTE * attr_list)
 	{
 	  /* make sure property is unset for existing attributes */
 	  classobj_drop_prop (attr->properties, "default_expr");
+	}
+
+      /* Expression-Derived Literal: persist the original expression text under a
+       * dedicated property, alongside the folded literal value (stored as an
+       * ordinary default value).  The legacy "default_expr" property is left
+       * untouched -- an EDL has default_expr_type == DB_DEFAULT_NONE. */
+      if (default_expr->default_expr_text != NULL)
+	{
+	  if (attr->properties == NULL)
+	    {
+	      attr->properties = classobj_make_prop ();
+	      if (attr->properties == NULL)
+		{
+		  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, sizeof (DB_SEQ));
+		  return er_errid ();
+		}
+	    }
+
+	  db_make_string (&default_expr_value, default_expr->default_expr_text);
+	  classobj_put_prop (attr->properties, "default_expr_literal", &default_expr_value);
+	}
+      else if (attr->properties != NULL)
+	{
+	  /* make sure property is unset for existing attributes */
+	  classobj_drop_prop (attr->properties, "default_expr_literal");
 	}
 
       DB_DEFAULT_EXPR_TYPE update_default = attr->on_update_default_expr;

--- a/src/parser/func_type.cpp
+++ b/src/parser/func_type.cpp
@@ -27,6 +27,7 @@
 #include "parse_tree.h"
 #include "parser.h"
 #include "parser_message.h"
+#include "pt_volatility.h"
 
 #include <algorithm>
 
@@ -193,8 +194,8 @@ func_all_signatures sig_of_lead_lag =
 
 func_all_signatures sig_of_elt =
 {
-  {PT_TYPE_VARCHAR, {PT_GENERIC_TYPE_DISCRETE_NUMBER}, {PT_TYPE_VARCHAR}}, //get_current_result() expects args to be VCHAR, not just equivalent
-  {PT_TYPE_NULL, {PT_GENERIC_TYPE_DISCRETE_NUMBER}, {}},
+  {PT_TYPE_VARCHAR, {PT_GENERIC_TYPE_DISCRETE_NUMBER}, {PT_TYPE_VARCHAR}, PT_VOLATILITY_IMMUTABLE}, //get_current_result() expects args to be VCHAR, not just equivalent
+  {PT_TYPE_NULL, {PT_GENERIC_TYPE_DISCRETE_NUMBER}, {}, PT_VOLATILITY_IMMUTABLE},
 };
 
 func_all_signatures sig_of_insert_substring =
@@ -357,10 +358,10 @@ func_all_signatures sig_of_regexp_like =
 func_all_signatures sig_of_regexp_replace =
 {
 // all signatures: src, pattern, replacement [,position [,occurrence [, match_type]]] -> STRING
-  {PT_TYPE_VARCHAR, {PT_GENERIC_TYPE_STRING, PT_GENERIC_TYPE_STRING, PT_GENERIC_TYPE_STRING}, {}},
-  {PT_TYPE_VARCHAR, {PT_GENERIC_TYPE_STRING, PT_GENERIC_TYPE_STRING, PT_GENERIC_TYPE_STRING, PT_TYPE_INTEGER}, {}},
-  {PT_TYPE_VARCHAR, {PT_GENERIC_TYPE_STRING, PT_GENERIC_TYPE_STRING, PT_GENERIC_TYPE_STRING, PT_TYPE_INTEGER, PT_TYPE_INTEGER}, {}},
-  {PT_TYPE_VARCHAR, {PT_GENERIC_TYPE_STRING, PT_GENERIC_TYPE_STRING, PT_GENERIC_TYPE_STRING, PT_TYPE_INTEGER, PT_TYPE_INTEGER, PT_GENERIC_TYPE_STRING}, {}},
+  {PT_TYPE_VARCHAR, {PT_GENERIC_TYPE_STRING, PT_GENERIC_TYPE_STRING, PT_GENERIC_TYPE_STRING}, {}, PT_VOLATILITY_IMMUTABLE},
+  {PT_TYPE_VARCHAR, {PT_GENERIC_TYPE_STRING, PT_GENERIC_TYPE_STRING, PT_GENERIC_TYPE_STRING, PT_TYPE_INTEGER}, {}, PT_VOLATILITY_IMMUTABLE},
+  {PT_TYPE_VARCHAR, {PT_GENERIC_TYPE_STRING, PT_GENERIC_TYPE_STRING, PT_GENERIC_TYPE_STRING, PT_TYPE_INTEGER, PT_TYPE_INTEGER}, {}, PT_VOLATILITY_IMMUTABLE},
+  {PT_TYPE_VARCHAR, {PT_GENERIC_TYPE_STRING, PT_GENERIC_TYPE_STRING, PT_GENERIC_TYPE_STRING, PT_TYPE_INTEGER, PT_TYPE_INTEGER, PT_GENERIC_TYPE_STRING}, {}, PT_VOLATILITY_IMMUTABLE},
 };
 
 func_all_signatures sig_of_regexp_substr =
@@ -515,6 +516,27 @@ get_signatures (FUNC_CODE ft)
       assert (false);
       return nullptr;
     }
+}
+
+/*
+ * pt_get_func_volatility () - volatility declared for a function's signature
+ *   return: the function's volatility, or PT_VOLATILITY_UNSET if unclassified
+ *   fcode(in): function code
+ *
+ * Symmetric to pt_get_op_volatility for operators: reads a representative
+ * (overload 0) from the function's signatures -- exact for functions whose
+ * volatility does not vary across overloads (the only ones classified so far).
+ */
+PT_VOLATILITY
+pt_get_func_volatility (FUNC_CODE fcode)
+{
+  func_all_signatures *sigs = get_signatures (fcode);
+
+  if (sigs == NULL || sigs->empty ())
+    {
+      return PT_VOLATILITY_UNSET;
+    }
+  return (*sigs)[0].volatility;
 }
 
 void

--- a/src/parser/func_type.hpp
+++ b/src/parser/func_type.hpp
@@ -36,6 +36,7 @@ struct func_signature
   pt_arg_type ret; //return type
   pt_group_arg_type fix; //fixed arguments types
   pt_group_arg_type rep; //repetitive arguments types
+  PT_VOLATILITY volatility = PT_VOLATILITY_UNSET; //per-overload volatility; UNSET unless classified
 
   void to_string_buffer (string_buffer &sb) const;
 };
@@ -123,5 +124,7 @@ PT_TYPE_ENUM pt_get_equivalent_type (const PT_ARG_TYPE def_type, const PT_TYPE_E
 bool pt_is_function_unsupported (FUNC_CODE fcode);
 bool pt_is_function_no_arg (FUNC_CODE fcode);
 bool pt_is_function_new_type_checking (FUNC_CODE fcode);
+
+PT_VOLATILITY pt_get_func_volatility (FUNC_CODE fcode);
 
 #endif

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -43,6 +43,7 @@
 #include "system_parameter.h"
 #include "hide_password.h"
 #include "misctype_def.h"
+#include "pt_volatility.h"
 
 // forward definitions
 struct json_t;
@@ -2100,6 +2101,7 @@ struct pt_data_default_info
   PT_NODE *default_value;	/* PT_VALUE (list) */
   PT_MISC_TYPE shared;		/* will PT_SHARED or PT_DEFAULT */
   DB_DEFAULT_EXPR_TYPE default_expr_type;	/* if it is a pseudocolumn, do not evaluate expr */
+  char *expr_text;		/* normalized source text of an Expression-Derived Literal DEFAULT; NULL otherwise */
 };
 
 /* Info for the AUTO_INCREMENT node */

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -10250,7 +10250,8 @@ pt_print_expr (PARSER_CONTEXT * parser, PT_NODE * p)
     {
     case PT_FUNCTION_HOLDER:
       /* FUNCTION_HOLDER has a PT_FUNCTION on arg1 */
-      q = pt_print_function (parser, p->info.expr.arg1);
+      r1 = pt_print_function (parser, p->info.expr.arg1);
+      q = pt_append_varchar (parser, q, r1);
       break;
     case PT_UNARY_MINUS:
       r1 = pt_print_bytes (parser, p->info.expr.arg1);

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -153,6 +153,8 @@ extern "C"
 
   extern PT_NODE *pt_semantic_type (PARSER_CONTEXT * parser, PT_NODE * tree, SEMANTIC_CHK_INFO * sc_info);
 
+  extern PT_VOLATILITY pt_get_expr_tree_volatility (PARSER_CONTEXT * parser, PT_NODE * node);
+
   extern void pt_report_to_ersys (const PARSER_CONTEXT * parser, const PT_ERROR_TYPE error_type);
 
   extern void pt_record_error (PARSER_CONTEXT * parser, int stmt_no, int line_no, int col_no, const char *msg,

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -10692,6 +10692,10 @@ pt_get_default_expression_from_data_default_node (PARSER_CONTEXT * parser, PT_NO
       assert (data_default_node->node_type == PT_DATA_DEFAULT);
       default_expr->default_expr_type = data_default_node->info.data_default.default_expr_type;
 
+      /* Expression-Derived Literal: carry the normalized source text so the
+       * folded literal is stored/displayed as its original expression. */
+      default_expr->default_expr_text = data_default_node->info.data_default.expr_text;
+
       pt_default_expr = data_default_node->info.data_default.default_value;
       if (pt_default_expr && pt_default_expr->node_type == PT_EXPR)
 	{

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -3963,6 +3963,84 @@ pt_resolve_default_external (PARSER_CONTEXT * parser, PT_NODE * alter)
 }
 
 /*
+ * pt_default_expr_normalized_text () - source text of a DEFAULT expression,
+ *	wrapped in exactly one outer pair of parentheses
+ *   return: parser-allocated normalized text (NULL on failure)
+ *   parser(in): parser context
+ *   node(in): the DEFAULT expression (pre-fold)
+ *
+ * The parser printer parenthesizes binary operators ("1+1" prints as "(1+1)")
+ * but not function calls or unary expressions, so normalize to a single
+ * canonical "(expr)" form for display / DDL round-trip.  Parentheses inside
+ * single-quoted string literals are ignored when deciding whether the printed
+ * text is already a single fully-parenthesized group.
+ */
+static char *
+pt_default_expr_normalized_text (PARSER_CONTEXT * parser, PT_NODE * node)
+{
+  const char *printed;
+  size_t len, i;
+  int depth;
+  bool in_string, fully_wrapped;
+  char c;
+  char *result;
+
+  printed = parser_print_tree (parser, node);
+  if (printed == NULL)
+    {
+      return NULL;
+    }
+
+  len = strlen (printed);
+  fully_wrapped = false;
+  if (len >= 2 && printed[0] == '(' && printed[len - 1] == ')')
+    {
+      depth = 0;
+      in_string = false;
+      fully_wrapped = true;
+      for (i = 0; i < len; i++)
+	{
+	  c = printed[i];
+	  if (in_string)
+	    {
+	      if (c == '\'')
+		{
+		  in_string = false;
+		}
+	    }
+	  else if (c == '\'')
+	    {
+	      in_string = true;
+	    }
+	  else if (c == '(')
+	    {
+	      depth++;
+	    }
+	  else if (c == ')')
+	    {
+	      depth--;
+	      if (depth == 0 && i != len - 1)
+		{
+		  /* the first '(' closes before the end: not a single group */
+		  fully_wrapped = false;
+		  break;
+		}
+	    }
+	}
+    }
+
+  if (fully_wrapped)
+    {
+      return pt_append_string (parser, NULL, printed);
+    }
+
+  result = pt_append_string (parser, NULL, "(");
+  result = pt_append_string (parser, result, printed);
+  result = pt_append_string (parser, result, ")");
+  return result;
+}
+
+/*
  * pt_check_data_default () - checks data_default for semantic errors
  *
  * result	    	 : modified data_default
@@ -3979,6 +4057,8 @@ pt_check_data_default (PARSER_CONTEXT * parser, PT_NODE * data_default_list)
   PT_NODE *data_default;
   PT_NODE *prev;
   bool has_query;
+  bool is_expr_derived;
+  char *edl_text;
 
   if (pt_has_error (parser))
     {
@@ -4010,6 +4090,25 @@ pt_check_data_default (PARSER_CONTEXT * parser, PT_NODE * data_default_list)
 	  goto end;
 	}
 
+      /* Detect an Expression-Derived Literal: a DEFAULT whose value is a compound
+       * expression -- not a plain literal, and not a legacy pseudo-column
+       * (default_expr_type stays DB_DEFAULT_NONE).  Only the new DEFAULT path is
+       * eligible (shared == PT_DEFAULT keeps SHARED on the legacy enum path).
+       * Capture the normalized source text and effective volatility BEFORE
+       * folding, because pt_semantic_type folds an Immutable expression down to a
+       * single literal value. */
+      is_expr_derived = false;
+      edl_text = NULL;
+      if (data_default->info.data_default.shared == PT_DEFAULT
+	  && data_default->info.data_default.default_expr_type == DB_DEFAULT_NONE
+	  && default_value != NULL
+	  && (PT_IS_EXPR_NODE (default_value) || default_value->node_type == PT_FUNCTION)
+	  && pt_get_expr_tree_volatility (parser, default_value) == PT_VOLATILITY_IMMUTABLE)
+	{
+	  is_expr_derived = true;
+	  edl_text = pt_default_expr_normalized_text (parser, default_value);
+	}
+
       result = pt_semantic_type (parser, data_default, NULL);
       if (result != NULL)
 	{
@@ -4023,6 +4122,19 @@ pt_check_data_default (PARSER_CONTEXT * parser, PT_NODE * data_default_list)
 	      data_default_list = result;
 	    }
 	  data_default = result;
+
+	  /* If the Immutable expression folded to a single literal, record it as
+	   * an Expression-Derived Literal so it is stored/displayed as the
+	   * original expression rather than the folded value. */
+	  if (is_expr_derived)
+	    {
+	      PT_NODE *folded = data_default->info.data_default.default_value;
+
+	      if (folded != NULL && folded->node_type == PT_VALUE)
+		{
+		  data_default->info.data_default.expr_text = edl_text;
+		}
+	    }
 	}
       else
 	{

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -20,7 +20,6 @@
  * type_checking.c - auxiliary functions for parse tree translation
  */
 
-#include "pt_volatility.h"
 #ident "$Id$"
 
 #include "config.h"
@@ -62,6 +61,7 @@
 #include "db.h"
 #include "tz_support.h"
 #include "func_type.hpp"
+#include "pt_volatility.h"
 
 #include "dbtype.h"
 

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -20,6 +20,7 @@
  * type_checking.c - auxiliary functions for parse tree translation
  */
 
+#include "pt_volatility.h"
 #ident "$Id$"
 
 #include "config.h"
@@ -173,6 +174,7 @@ typedef struct expression_signature
   PT_ARG_TYPE arg1_type;
   PT_ARG_TYPE arg2_type;
   PT_ARG_TYPE arg3_type;
+  PT_VOLATILITY volatility;	/* per-overload volatility; PT_VOLATILITY_UNSET unless classified */
 } EXPRESSION_SIGNATURE;
 
 /* SQL expression definition */
@@ -292,6 +294,89 @@ static void pt_update_host_var_data_type (PARSER_CONTEXT * parser, PT_NODE * hv_
 static bool pt_cast_needs_wrap_for_collation (PT_NODE * node, const INTL_CODESET codeset);
 static bool pt_is_dblink_related (PT_NODE * p);
 
+static PT_VOLATILITY pt_get_op_volatility (PT_OP_TYPE op);
+
+/*
+ * pt_get_op_volatility () - volatility declared for an operator's signature
+ *   return: the operator's volatility, or PT_VOLATILITY_UNSET if unclassified
+ *   op(in): operator
+ *
+ * The type checker selects the matching overload from argument types; here we
+ * read a representative (overload 0), which is exact for operators whose
+ * volatility does not vary across overloads (the only ones classified so far).
+ */
+static PT_VOLATILITY
+pt_get_op_volatility (PT_OP_TYPE op)
+{
+  EXPRESSION_DEFINITION def;
+
+  if (!pt_get_expression_definition (op, &def) || def.overloads_count <= 0)
+    {
+      return PT_VOLATILITY_UNSET;
+    }
+  return def.overloads[0].volatility;
+}
+
+/*
+ * pt_get_expr_tree_volatility () - effective volatility of an expression tree
+ *   return: bottom-up MAX volatility over the tree
+ *   parser(in): parser context
+ *   node(in): expression tree (a single value, not a list)
+ *
+ * Literals are IMMUTABLE; an operator node is the MAX of its own volatility and
+ * its operands'.  Anything not yet classified (functions, names, sub-trees this
+ * walk does not understand) yields UNSET, which taints the whole result so the
+ * caller will not fold it.  Used to decide whether a column DEFAULT expression
+ * is an Immutable Expression-Derived Literal.
+ */
+PT_VOLATILITY
+pt_get_expr_tree_volatility (PARSER_CONTEXT * parser, PT_NODE * node)
+{
+  PT_VOLATILITY v;
+
+  if (node == NULL)
+    {
+      /* a missing operand is the neutral element of MAX-propagation */
+      return PT_VOLATILITY_IMMUTABLE;
+    }
+
+  switch (node->node_type)
+    {
+    case PT_VALUE:
+      return PT_VOLATILITY_IMMUTABLE;
+
+    case PT_EXPR:
+      if (node->info.expr.op == PT_FUNCTION_HOLDER)
+	{
+	  /* transparent wrapper: a function call is parsed as a PT_EXPR with a
+	   * PT_FUNCTION_HOLDER op holding the PT_FUNCTION in arg1 */
+	  return pt_get_expr_tree_volatility (parser, node->info.expr.arg1);
+	}
+      v = pt_get_op_volatility (node->info.expr.op);
+      v = pt_volatility_max (v, pt_get_expr_tree_volatility (parser, node->info.expr.arg1));
+      v = pt_volatility_max (v, pt_get_expr_tree_volatility (parser, node->info.expr.arg2));
+      v = pt_volatility_max (v, pt_get_expr_tree_volatility (parser, node->info.expr.arg3));
+      return v;
+
+    case PT_FUNCTION:
+      {
+	PT_NODE *arg;
+
+	v = pt_get_func_volatility (node->info.function.function_type);
+	for (arg = node->info.function.arg_list; arg != NULL; arg = arg->next)
+	  {
+	    v = pt_volatility_max (v, pt_get_expr_tree_volatility (parser, arg));
+	  }
+	return v;
+      }
+
+    default:
+      /* names (column refs), host vars, sub-queries: not classified for DEFAULT
+       * folding in this scope */
+      return PT_VOLATILITY_UNSET;
+    }
+}
+
 /*
  * pt_get_expression_definition () - get the expression definition for the
  *				     expression op.
@@ -320,6 +405,10 @@ pt_get_expression_definition (const PT_OP_TYPE op, EXPRESSION_DEFINITION * def)
 
   sig.return_type.type = pt_arg_type::NORMAL;
   sig.return_type.val.type = PT_TYPE_NONE;
+
+  /* default: overload is not classified for volatility.  Cases that have been
+   * reviewed set sig.volatility explicitly before storing each overload. */
+  sig.volatility = PT_VOLATILITY_UNSET;
 
   switch (op)
     {
@@ -1539,6 +1628,8 @@ pt_get_expression_definition (const PT_OP_TYPE op, EXPRESSION_DEFINITION * def)
     case PT_MOD:
       num = 0;
 
+      sig.volatility = PT_VOLATILITY_IMMUTABLE;
+
       /* one overload */
 
       /* arg1 */
@@ -1559,6 +1650,8 @@ pt_get_expression_definition (const PT_OP_TYPE op, EXPRESSION_DEFINITION * def)
     case PT_MODULUS:
       num = 0;
 
+      sig.volatility = PT_VOLATILITY_IMMUTABLE;
+
       /* one overload */
 
       /* arg1 */
@@ -1577,6 +1670,8 @@ pt_get_expression_definition (const PT_OP_TYPE op, EXPRESSION_DEFINITION * def)
 
     case PT_TIMES:
       num = 0;
+
+      sig.volatility = PT_VOLATILITY_IMMUTABLE;
 
       /* two overloads */
 
@@ -1607,6 +1702,10 @@ pt_get_expression_definition (const PT_OP_TYPE op, EXPRESSION_DEFINITION * def)
 
     case PT_PLUS:
       num = 0;
+
+      /* arithmetic/string/collection addition is a pure function of its
+       * operands -- same inputs always yield the same output. */
+      sig.volatility = PT_VOLATILITY_IMMUTABLE;
 
       /* number + number */
       sig.arg1_type.type = pt_arg_type::GENERIC;
@@ -1653,6 +1752,8 @@ pt_get_expression_definition (const PT_OP_TYPE op, EXPRESSION_DEFINITION * def)
 
     case PT_MINUS:
       num = 0;
+
+      sig.volatility = PT_VOLATILITY_IMMUTABLE;
 
       /* 4 overloads */
 

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -25570,7 +25570,23 @@ qexec_execute_build_columns (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 
 	  /* default values */
 	  alloced_string = 0;
-	  if (attrepr->default_value.default_expr.default_expr_type != DB_DEFAULT_NONE)
+	  if (attrepr->default_value.default_expr.default_expr_text != NULL)
+	    {
+	      /* Expression-Derived Literal: report the DEFAULT as its original
+	       * expression text, consistent with ;schema and SHOW CREATE TABLE. */
+	      size_t deflen = strlen (attrepr->default_value.default_expr.default_expr_text) + 1;
+
+	      default_value_string = (char *) malloc (deflen);
+	      if (default_value_string == NULL)
+		{
+		  GOTO_EXIT_ON_ERROR;
+		}
+	      memcpy (default_value_string, attrepr->default_value.default_expr.default_expr_text, deflen);
+	      db_make_string (out_values[idx_val], default_value_string);
+	      out_values[idx_val]->need_clear = true;
+	      idx_val++;
+	    }
+	  else if (attrepr->default_value.default_expr.default_expr_type != DB_DEFAULT_NONE)
 	    {
 	      const char *default_expr_op_string = NULL;
 

--- a/src/storage/catalog_class.c
+++ b/src/storage/catalog_class.c
@@ -1539,6 +1539,34 @@ catcls_get_or_value_from_attribute (THREAD_ENTRY * thread_p, OR_BUF * buf_p, OR_
 	    }
 	}
 
+      /* Expression-Derived Literal: the catalog default_value string shows the
+       * original expression rather than the folded literal value. */
+      if (classobj_get_prop (att_props, "default_expr_literal", &default_expr) > 0)
+	{
+	  const char *edl_text = db_get_string (&default_expr);
+
+	  if (edl_text != NULL)
+	    {
+	      size_t edl_len = strlen (edl_text);
+	      char *edl_copy = (char *) db_private_alloc (thread_p, edl_len + 1);
+
+	      if (edl_copy == NULL)
+		{
+		  pr_clear_value (&default_expr);
+		  pr_clear_value (&val);
+		  error = ER_OUT_OF_VIRTUAL_MEMORY;
+		  goto error;
+		}
+	      strcpy (edl_copy, edl_text);
+	      pr_clear_value (attr_val_p);	/* clean old default value */
+	      db_make_string (attr_val_p, edl_copy);
+	      attr_val_p->need_clear = true;
+	      default_str_val = edl_copy;
+	      default_value_len = edl_len;
+	    }
+	  pr_clear_value (&default_expr);
+	}
+
       if (classobj_get_prop (att_props, "update_default", &default_expr) > 0)
 	{
 	  default_expr_type = (DB_DEFAULT_EXPR_TYPE) db_get_int (&default_expr);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26874>

### Purpose

일부 정해진 함수만 사용할 수 있던 whitelist 기반 DEFAULT 정책을 폐기하고 일부 함수를 제외하고 expression을 허용하는 blacklist 정책으로 확장한다.

함수 폴딩, 캐싱의 결정을 위한 함수속성인 volatility 구조를 도입하고 일부 함수에 'IMMUTABLE' 값을 주어 폴딩을 허용하도록 구현한다.
기존 동작은 whitelist를 제외한 함수에 대해 DDL 시점에서 값이 고정되며 default 수식은 folding 된 상수값으로서 저장되었으나 현재 이슈를 통해 DDL 당시의 expression을 정규화하여 출력하는 구조를 도입한다.


### Implementation

**root class record (object representation)**
  - default_expr_literal 추가
    - 입력받은 expression을 정규화 한 문장

**volatility**
  - [UNSET, IMMUTABLE, STABLE, VOLATILE] 구조를 가지며 PT_OP_TYPE 및 FUNC_CODE 마다 volatility를 정의
  - volatility는 bottom-up 으로 전파하여 expression의 최종값을 정하게 되며 VOLATILE > STABLE > IMMUTABLE 순으로 큰 값으로 덮어쓰임
    - UNSET은 enum에서 0이지만 전파에서 최상위값으로 취급
    - 모든 함수는 volatility가 정해져야 하며 develop으로 merge 되기 전 UNSET인 함수가 존재해서는 안됨

**IMMUTABLE**
  - 현재 이슈에서는 임의의 연산자 (덧셈, 뺄셈, 나눗셈, 곱셈 등) 에 대해서만 volatility를 분류하였으며 IMMUTABLE 범위만 취급함

**분류되지 않은 함수의 동작**
  - whitelist
    - 기존 whitelist 구조는 아직 유지되고 있으므로 기존 규칙에 따라 정상 등록됨
  - 일반 함수
    - 기존 규칙에 따라 상수 폴딩된 값으로 default에 고정됨


### Remarks
