### PR TITLE
[CBRD-27049] Add optdebug build mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,12 +357,12 @@ jobs:
                         git submodule sync
                         git submodule update --init
                   - run:
-                      name: Build (debug)
+                      name: Build (optdebug)
                       command: |
                         mkdir -p \$CCACHE_DIR
                         ccache --max-size=5G
                         ccache -z
-                        scl enable devtoolset-8 -- /entrypoint.sh build -m debug
+                        scl enable devtoolset-8 -- /entrypoint.sh build -m optdebug
                         ccache -s
                   - save_cache:
                       key: ccache-debug-v1-{{ checksum "CMakeLists.txt" }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,16 +184,7 @@ set(BUILD_NUMBER ${CUBRID_MAJOR_VERSION}.${CUBRID_MINOR_VERSION}.${CUBRID_PATCH_
 set(BUILD_OS ${CMAKE_SYSTEM_NAME})
 
 # BUILD_TYPE
-# NOTE: "OptDebug" must be checked before "Debug" because CMake's MATCHES does a
-#       regex substring search - the value "OptDebug" also matches "Debug", so a
-#       "Debug" branch placed first would wrongly claim it.
 if(CMAKE_BUILD_TYPE MATCHES "OptDebug")
-  # The optdebug build reports "optdebug" in the version string (cubrid_rel).
-  # Because "optdebug" contains the substring "debug", every CTP check - which
-  # detects debug via substring match (grep debug / indexOf("debug") /
-  # contains("debug")) - still classifies it as a debug build, so no external
-  # code needs to change. At the same time the string is visibly distinct from a
-  # real "debug build", which is exactly what we want.
   set(BUILD_TYPE "optdebug")
 elseif(CMAKE_BUILD_TYPE MATCHES "Debug")
   set(BUILD_TYPE "debug")
@@ -240,16 +231,9 @@ if(UNIX)
     # C++ flags for release build
     set(CMAKE_CXX_RELEASE_FLAGS "-O2 -DNDEBUG -finline-functions ${CMAKE_CXX_COMMON_FLAGS}")
 
-    # C/C++ flags for optdebug build (release-level optimization, asserts enabled)
-    # NOTE: -DNDEBUG is intentionally omitted so that assert() and the !NDEBUG
-    #       debug logs stay active, while -O2/-finline keep performance close to
-    #       release. Frame pointer and -ggdb3 preserve usable core stack traces.
-    # NOTE: -DCUBRID_OPTDEBUG is a dedicated marker for the optdebug build. Since
-    #       both optdebug and debug leave NDEBUG undefined - and the optdebug
-    #       build masquerades as debug for CTP (package name is -debug) - this
-    #       macro is the only compile-time way to tell an optdebug build apart
-    #       from a real debug build.
+    # C flags for optdebug build (release-level optimization, asserts enabled)
     set(CMAKE_C_OPTDEBUG_FLAGS "-O2 -finline-functions -ggdb3 -Wall -fstack-protector-strong -DCUBRID_OPTDEBUG ${CMAKE_C_COMMON_FLAGS}")
+    # C++ flags for optdebug build (release-level optimization, asserts enabled)
     set(CMAKE_CXX_OPTDEBUG_FLAGS "-O2 -finline-functions -ggdb3 -Wall -DCUBRID_OPTDEBUG ${CMAKE_CXX_COMMON_FLAGS}")
 
     set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} ${CMAKE_C_DEBUG_FLAGS}")
@@ -897,14 +881,6 @@ install(FILES
   DESTINATION ${CUBRID_TMPDIR}
   RENAME README.txt)
 
-# OptDebug build marker.
-# The optdebug build uses a "-debug" package name so CTP handles it exactly like
-# a debug build (the version string reports "optdebug", which still contains the
-# "debug" substring every CTP check relies on - see BUILD_TYPE note). This marker
-# file is an extra, machine-readable signal that the install is actually an
-# optdebug build (assert + debug logs, release-level optimization). CTP never
-# reads it, so it triggers no parsing errors; check it with:
-#   cat $CUBRID/build_mode.txt
 if(CMAKE_BUILD_TYPE MATCHES "OptDebug")
   file(WRITE "${CMAKE_BINARY_DIR}/build_mode.txt" "build_mode=optdebug\n")
   install(FILES "${CMAKE_BINARY_DIR}/build_mode.txt" DESTINATION ${CUBRID_PREFIXDIR})
@@ -948,9 +924,6 @@ set(CPACK_PACKAGE_VERSION_MINOR "${CUBRID_MINOR_VERSION}")
 set(CPACK_PACKAGE_VERSION_PATCH "${CUBRID_PATCH_VERSION}")
 set(CPACK_PACKAGE_VERSION "${CUBRID_VERSION}")
 if(CMAKE_BUILD_TYPE MATCHES "Debug")
-  # This also matches "OptDebug" (MATCHES is a regex substring search), which is
-  # intended: the optdebug build ships under a "-debug" package name so CTP and
-  # other tooling treat it exactly like a debug build.
   set(CUBRID_PACKAGE_FILE_SUFFIX "-debug")
 elseif(CMAKE_BUILD_TYPE MATCHES "Coverage")
   set(CUBRID_PACKAGE_FILE_SUFFIX "-coverage")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,15 +184,26 @@ set(BUILD_NUMBER ${CUBRID_MAJOR_VERSION}.${CUBRID_MINOR_VERSION}.${CUBRID_PATCH_
 set(BUILD_OS ${CMAKE_SYSTEM_NAME})
 
 # BUILD_TYPE
-if(CMAKE_BUILD_TYPE MATCHES "Debug")
+# NOTE: "OptDebug" must be checked before "Debug" because CMake's MATCHES does a
+#       regex substring search - the value "OptDebug" also matches "Debug", so a
+#       "Debug" branch placed first would wrongly claim it.
+if(CMAKE_BUILD_TYPE MATCHES "OptDebug")
+  # The optdebug build reports "optdebug" in the version string (cubrid_rel).
+  # Because "optdebug" contains the substring "debug", every CTP check - which
+  # detects debug via substring match (grep debug / indexOf("debug") /
+  # contains("debug")) - still classifies it as a debug build, so no external
+  # code needs to change. At the same time the string is visibly distinct from a
+  # real "debug build", which is exactly what we want.
+  set(BUILD_TYPE "optdebug")
+elseif(CMAKE_BUILD_TYPE MATCHES "Debug")
   set(BUILD_TYPE "debug")
 elseif(CMAKE_BUILD_TYPE MATCHES "Coverage|Profile")
   string(TOLOWER "${CMAKE_BUILD_TYPE} debug" BUILD_TYPE)
 elseif(CMAKE_BUILD_TYPE MATCHES "Release|RelWithDebInfo")
   set(BUILD_TYPE "release")
-else(CMAKE_BUILD_TYPE MATCHES "Debug")
+else()
   set(BUILD_TYPE "unknown")
-endif(CMAKE_BUILD_TYPE MATCHES "Debug")
+endif()
 
 if(MSVC)
   configure_file(cmake/version.rc.cmake version.rc)
@@ -229,12 +240,26 @@ if(UNIX)
     # C++ flags for release build
     set(CMAKE_CXX_RELEASE_FLAGS "-O2 -DNDEBUG -finline-functions ${CMAKE_CXX_COMMON_FLAGS}")
 
+    # C/C++ flags for optdebug build (release-level optimization, asserts enabled)
+    # NOTE: -DNDEBUG is intentionally omitted so that assert() and the !NDEBUG
+    #       debug logs stay active, while -O2/-finline keep performance close to
+    #       release. Frame pointer and -ggdb3 preserve usable core stack traces.
+    # NOTE: -DCUBRID_OPTDEBUG is a dedicated marker for the optdebug build. Since
+    #       both optdebug and debug leave NDEBUG undefined - and the optdebug
+    #       build masquerades as debug for CTP (package name is -debug) - this
+    #       macro is the only compile-time way to tell an optdebug build apart
+    #       from a real debug build.
+    set(CMAKE_C_OPTDEBUG_FLAGS "-O2 -finline-functions -ggdb3 -Wall -fstack-protector-strong -DCUBRID_OPTDEBUG ${CMAKE_C_COMMON_FLAGS}")
+    set(CMAKE_CXX_OPTDEBUG_FLAGS "-O2 -finline-functions -ggdb3 -Wall -DCUBRID_OPTDEBUG ${CMAKE_CXX_COMMON_FLAGS}")
+
     set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} ${CMAKE_C_DEBUG_FLAGS}")
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${CMAKE_CXX_DEBUG_FLAGS}")
     set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} ${CMAKE_C_RELEASE_FLAGS}")
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${CMAKE_CXX_RELEASE_FLAGS}")
     set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} ${CMAKE_C_RELEASE_FLAGS}")
     set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} ${CMAKE_CXX_RELEASE_FLAGS}")
+    set(CMAKE_C_FLAGS_OPTDEBUG "${CMAKE_C_FLAGS_OPTDEBUG} ${CMAKE_C_OPTDEBUG_FLAGS}")
+    set(CMAKE_CXX_FLAGS_OPTDEBUG "${CMAKE_CXX_FLAGS_OPTDEBUG} ${CMAKE_CXX_OPTDEBUG_FLAGS}")
 
     if(WITH_SOURCES)
       set(DEBUG_PREFIX_MAP_FLAG "-fdebug-prefix-map=${CMAKE_SOURCE_DIR}/src=${CMAKE_INSTALL_PREFIX}/src")
@@ -245,6 +270,8 @@ if(UNIX)
       set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${DEBUG_PREFIX_MAP_FLAG}")
       set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} ${DEBUG_PREFIX_MAP_FLAG}")
       set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} ${DEBUG_PREFIX_MAP_FLAG}")
+      set(CMAKE_C_FLAGS_OPTDEBUG "${CMAKE_C_FLAGS_OPTDEBUG} ${DEBUG_PREFIX_MAP_FLAG}")
+      set(CMAKE_CXX_FLAGS_OPTDEBUG "${CMAKE_CXX_FLAGS_OPTDEBUG} ${DEBUG_PREFIX_MAP_FLAG}")
     endif(WITH_SOURCES)
 
     # set has-style
@@ -870,6 +897,19 @@ install(FILES
   DESTINATION ${CUBRID_TMPDIR}
   RENAME README.txt)
 
+# OptDebug build marker.
+# The optdebug build uses a "-debug" package name so CTP handles it exactly like
+# a debug build (the version string reports "optdebug", which still contains the
+# "debug" substring every CTP check relies on - see BUILD_TYPE note). This marker
+# file is an extra, machine-readable signal that the install is actually an
+# optdebug build (assert + debug logs, release-level optimization). CTP never
+# reads it, so it triggers no parsing errors; check it with:
+#   cat $CUBRID/build_mode.txt
+if(CMAKE_BUILD_TYPE MATCHES "OptDebug")
+  file(WRITE "${CMAKE_BINARY_DIR}/build_mode.txt" "build_mode=optdebug\n")
+  install(FILES "${CMAKE_BINARY_DIR}/build_mode.txt" DESTINATION ${CUBRID_PREFIXDIR})
+endif()
+
 if(WITH_SOURCES)
   install(DIRECTORY ${CMAKE_SOURCE_DIR}/src/ DESTINATION ${CUBRID_SRCDIR})
   if(WITH_CCI)
@@ -908,14 +948,17 @@ set(CPACK_PACKAGE_VERSION_MINOR "${CUBRID_MINOR_VERSION}")
 set(CPACK_PACKAGE_VERSION_PATCH "${CUBRID_PATCH_VERSION}")
 set(CPACK_PACKAGE_VERSION "${CUBRID_VERSION}")
 if(CMAKE_BUILD_TYPE MATCHES "Debug")
+  # This also matches "OptDebug" (MATCHES is a regex substring search), which is
+  # intended: the optdebug build ships under a "-debug" package name so CTP and
+  # other tooling treat it exactly like a debug build.
   set(CUBRID_PACKAGE_FILE_SUFFIX "-debug")
 elseif(CMAKE_BUILD_TYPE MATCHES "Coverage")
   set(CUBRID_PACKAGE_FILE_SUFFIX "-coverage")
 elseif(CMAKE_BUILD_TYPE MATCHES "Profile")
   set(CUBRID_PACKAGE_FILE_SUFFIX "-profile")
-else(CMAKE_BUILD_TYPE MATCHES "Debug")
+else()
   set(CUBRID_PACKAGE_FILE_SUFFIX "")
-endif(CMAKE_BUILD_TYPE MATCHES "Debug")
+endif()
 if(WIN32)
   set(CPACK_PACKAGE_FILE_NAME "${PROJECT_NAME}-${CMAKE_SYSTEM_NAME}-x64-${CUBRID_VERSION}${CUBRID_PACKAGE_FILE_SUFFIX}")
   set(CCI_PACKAGE_FILE_NAME "${PROJECT_NAME}-CCI-${CMAKE_SYSTEM_NAME}-x64-${CCI_VERSION}${CUBRID_PACKAGE_FILE_SUFFIX}")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -34,6 +34,14 @@
       }
     },
     {
+      "name": "optdebug",
+      "inherits": "default",
+      "description": "Optimized-debug build (release-level optimization with asserts enabled)",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "OptDebug"
+      }
+    },
+    {
       "name": "coverage",
       "inherits": "default",
       "description": "Coverage build",
@@ -63,6 +71,10 @@
     {
       "name": "debug",
       "configurePreset": "debug"
+    },
+    {
+      "name": "optdebug",
+      "configurePreset": "optdebug"
     },
     {
       "name": "coverage",

--- a/build.sh
+++ b/build.sh
@@ -297,6 +297,8 @@ function build_configure ()
       configure_options="$configure_options -DCMAKE_BUILD_TYPE=RelWithDebInfo" ;;
     debug)
       configure_options="$configure_options -DCMAKE_BUILD_TYPE=Debug" ;;
+    optdebug)
+      configure_options="$configure_options -DCMAKE_BUILD_TYPE=OptDebug" ;;
     coverage)
       configure_options="$configure_options -DCMAKE_BUILD_TYPE=Coverage" ;;
     profile)
@@ -442,8 +444,14 @@ function build_package ()
     package_basename="$product_name-$version-Linux.$build_target"
   fi
   
-	if [ ! "$build_mode" = "release" ]; then
-	  package_basename="$package_basename-$build_mode"
+	# The optdebug build masquerades as a debug package so CTP and other tooling
+	# handle it exactly like debug. This must match CPACK_PACKAGE_FILE_SUFFIX
+	# (-debug) set in CMakeLists.txt, otherwise the package summary below cannot
+	# locate the file produced by cpack.
+	package_mode="$build_mode"
+	[ "$build_mode" = "optdebug" ] && package_mode="debug"
+	if [ ! "$package_mode" = "release" ]; then
+	  package_basename="$package_basename-$package_mode"
 	fi
 	if [ "$package" = "tarball" ]; then
 	  package_name="$package_basename.tar.gz"
@@ -510,7 +518,7 @@ function show_usage ()
   echo "Usage: $0 [OPTIONS] [TARGET]"
   echo " OPTIONS"
   echo "  -t arg  Set target machine (32(i386) or 64(x86_64)); [default: 64]"
-  echo "  -m      Set build mode(release, debug or coverage); [default: release]"
+  echo "  -m      Set build mode(release, debug, optdebug, coverage or profile); [default: release]"
   echo "  -i      Increase build number; [default: no]"
   echo "  -a      Run autogen.sh before build; [default: yes]"
   echo "  -g      Specifies the generator for a build (make, ninja); [default: ninja]"
@@ -540,6 +548,7 @@ function show_usage ()
   echo "  $0                         # Build and pack all packages (64/release)"
   echo "  $0 -t 32 build             # 32bit release build only"
   echo "  $0 -t 64 -m debug dist     # Create 64bit debug mode packages"
+  echo "  $0 -t 64 -m optdebug build # 64bit optimized-debug build (asserts on, release-level speed)"
   echo ""
 }
 
@@ -583,7 +592,7 @@ function get_options ()
   esac
 
   case $build_mode in
-    release|debug|coverage|profile);;
+    release|debug|optdebug|coverage|profile);;
     *) show_usage; print_fatal "Mode [$build_mode] is not a valid mode" ;;
   esac
 
@@ -672,7 +681,7 @@ function build_build ()
 
   if [ "$build_args" = "all" -o "$build_args" = "ALL" ]; then
     case $build_mode in
-      release|debug)
+      release|debug|optdebug)
 	build_args="clean build dist"
 	;;
       *)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27049

add a new "optdebug" build mode: release-level optimization (-O2 -finline) but without -DNDEBUG, so assert() and debug-only logs stay active while performance stays close to release and cores keep usable stack traces.
