### PR TITLE
[CBRD-27051] [Regression] Core dumped in log_system_tdes::destroy_system_transactions

### DIFF
--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2767,7 +2767,9 @@ error:
 
 #if defined(SERVER_MODE)
   pl_server_destroy ();
-
+#ifdef CCI_XA
+  dblink_2pc_daemon_stop ();
+#endif
   cdc_daemons_destroy ();
 
   BO_DISABLE_FLUSH_DAEMONS ();

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2766,10 +2766,10 @@ error:
   vacuum_stop_master (thread_p);
 
 #if defined(SERVER_MODE)
-  pl_server_destroy ();
 #ifdef CCI_XA
   dblink_2pc_daemon_stop ();
 #endif
+  pl_server_destroy ();
   cdc_daemons_destroy ();
 
   BO_DISABLE_FLUSH_DAEMONS ();


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27051>

### Purpose

시스템 트랜잭션(system worker용 tdes)이 전부 반납(retire)되어 systb_System_tdes 맵이  empty상태이어야 한다"는  assert, 즉 어떤 백그라운드 스레드가 시스템 tdes를 claim한 채로 아직 retire하지 않은 상태에서 log_final()이 호출되면서 발생하는 assert를 해결

### Implementation

log_final에서 dblink_2pc_daemon_stop을 추가

### Remarks

N/A
