### PR TITLE
[CUBRIDQA-1268] CI: make ccache warm cache accumulate and stay shared

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,8 +330,8 @@ jobs:
                         scl enable devtoolset-8 -- /entrypoint.sh build
                         ccache -s
             EOF
-            # ccache save: develop(non-PR) 빌드에서만 write -> 단일 공유 warm 캐시 (PR은 restore-only, 5G x PR 저장 방지)
-            if [[ "$CIRCLE_BRANCH" != pull/* ]]; then
+            # ccache save: develop 브랜치 빌드에서만 write -> 단일 공유 warm 캐시 (그 외 브랜치/PR은 restore-only; 5G 저장·비-develop 오염 방지)
+            if [ "$CIRCLE_BRANCH" = "develop" ]; then
             cat \<<EOF >> .circleci/continue.yml
                   - save_cache:
                       key: ccache-global-v2-{{ checksum "build.sh" }}-{{ checksum "CMakeLists.txt" }}-develop-${CIRCLE_SHA1}
@@ -372,8 +372,8 @@ jobs:
                         scl enable devtoolset-8 -- /entrypoint.sh build -m debug
                         ccache -s
             EOF
-            # ccache save: develop(non-PR) 빌드에서만 write -> 단일 공유 warm 캐시 (PR은 restore-only, 5G x PR 저장 방지)
-            if [[ "$CIRCLE_BRANCH" != pull/* ]]; then
+            # ccache save: develop 브랜치 빌드에서만 write -> 단일 공유 warm 캐시 (그 외 브랜치/PR은 restore-only; 5G 저장·비-develop 오염 방지)
+            if [ "$CIRCLE_BRANCH" = "develop" ]; then
             cat \<<EOF >> .circleci/continue.yml
                   - save_cache:
                       key: ccache-debug-v2-{{ checksum "build.sh" }}-{{ checksum "CMakeLists.txt" }}-develop-${CIRCLE_SHA1}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,7 +330,7 @@ jobs:
                         scl enable devtoolset-8 -- /entrypoint.sh build
                         ccache -s
             EOF
-            # ccache save: develop 브랜치 빌드에서만 write -> 단일 공유 warm 캐시 (그 외 브랜치/PR은 restore-only; 5G 저장·비-develop 오염 방지)
+            # ccache save: write only on develop-branch builds -> a single shared warm cache (other branches/PRs are restore-only; avoids 5G-per-PR bloat and non-develop pollution)
             if [ "$CIRCLE_BRANCH" = "develop" ]; then
             cat \<<EOF >> .circleci/continue.yml
                   - save_cache:
@@ -372,7 +372,7 @@ jobs:
                         scl enable devtoolset-8 -- /entrypoint.sh build -m debug
                         ccache -s
             EOF
-            # ccache save: develop 브랜치 빌드에서만 write -> 단일 공유 warm 캐시 (그 외 브랜치/PR은 restore-only; 5G 저장·비-develop 오염 방지)
+            # ccache save: write only on develop-branch builds -> a single shared warm cache (other branches/PRs are restore-only; avoids 5G-per-PR bloat and non-develop pollution)
             if [ "$CIRCLE_BRANCH" = "develop" ]; then
             cat \<<EOF >> .circleci/continue.yml
                   - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,8 +314,8 @@ jobs:
                   - checkout
                   - restore_cache:
                       keys:
-                        - ccache-global-v1-{{ checksum "CMakeLists.txt" }}
-                        - ccache-global-v1
+                        - ccache-global-v2-{{ checksum "build.sh" }}-{{ checksum "CMakeLists.txt" }}-develop-${CIRCLE_SHA1}
+                        - ccache-global-v2-{{ checksum "build.sh" }}-{{ checksum "CMakeLists.txt" }}-develop-
                   - run:
                       name: Submodules
                       command: |
@@ -329,10 +329,17 @@ jobs:
                         ccache -z
                         scl enable devtoolset-8 -- /entrypoint.sh build
                         ccache -s
+            EOF
+            # ccache save: develop(non-PR) 빌드에서만 write -> 단일 공유 warm 캐시 (PR은 restore-only, 5G x PR 저장 방지)
+            if [[ "$CIRCLE_BRANCH" != pull/* ]]; then
+            cat \<<EOF >> .circleci/continue.yml
                   - save_cache:
-                      key: ccache-global-v1-{{ checksum "CMakeLists.txt" }}
+                      key: ccache-global-v2-{{ checksum "build.sh" }}-{{ checksum "CMakeLists.txt" }}-develop-${CIRCLE_SHA1}
                       paths:
                         - /home/.ccache
+            EOF
+            fi
+            cat \<<EOF >> .circleci/continue.yml
                   - collect-build-logs
 
               build_debug:
@@ -349,8 +356,8 @@ jobs:
                   - checkout
                   - restore_cache:
                       keys:
-                        - ccache-debug-v1-{{ checksum "CMakeLists.txt" }}
-                        - ccache-debug-v1
+                        - ccache-debug-v2-{{ checksum "build.sh" }}-{{ checksum "CMakeLists.txt" }}-develop-${CIRCLE_SHA1}
+                        - ccache-debug-v2-{{ checksum "build.sh" }}-{{ checksum "CMakeLists.txt" }}-develop-
                   - run:
                       name: Submodules
                       command: |
@@ -364,10 +371,17 @@ jobs:
                         ccache -z
                         scl enable devtoolset-8 -- /entrypoint.sh build -m debug
                         ccache -s
+            EOF
+            # ccache save: develop(non-PR) 빌드에서만 write -> 단일 공유 warm 캐시 (PR은 restore-only, 5G x PR 저장 방지)
+            if [[ "$CIRCLE_BRANCH" != pull/* ]]; then
+            cat \<<EOF >> .circleci/continue.yml
                   - save_cache:
-                      key: ccache-debug-v1-{{ checksum "CMakeLists.txt" }}
+                      key: ccache-debug-v2-{{ checksum "build.sh" }}-{{ checksum "CMakeLists.txt" }}-develop-${CIRCLE_SHA1}
                       paths:
                         - /home/.ccache
+            EOF
+            fi
+            cat \<<EOF >> .circleci/continue.yml
                   - collect-build-logs
                   - run:
                       name: Stop after build logs on default trigger


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1268>

### Purpose

CI 빌드(`build`/`build_debug`)의 ccache 웜캐시가 **키를 `ccache-*-v1-{{ checksum "CMakeLists.txt" }}`로** 잡고 있었습니다. CircleCI 캐시는 **불변(immutable)**이고 `CMakeLists.txt`는 거의 안 바뀌므로, 캐시가 **하루 첫 빌드에 한 번 저장된 뒤 종일 freeze**(이후 저장은 no-op)되어 새 오브젝트가 누적되지 않았습니다. 소스가 그 스냅샷에서 멀어질수록 hit율이 떨어져 **빌드시간 단축이라는 목적에 반**했습니다.

### Implementation

`build`·`build_debug` 두 잡의 ccache 키 전략을 개선(로직/빌드 명령·다른 캐시는 무수정):

| 항목 | 동작 |
|------|------|
| 키 | `ccache-{global,debug}-v2-{{checksum build.sh}}-{{checksum CMakeLists.txt}}-develop-${CIRCLE_SHA1}` |
| 회전 | **커밋(`${CIRCLE_SHA1}`)마다 새 키** → 매 develop 빌드가 이전 캐시를 restore해 **누적**(freeze 해소) |
| 공유 | restore fallback `...-develop-` → 모든 PR/파이프라인이 **최신 develop warm 캐시 공유**(프로젝트 스코프) |
| save 범위 | **develop(비-PR) 빌드만 write**, PR은 **restore-only** → 5G×PR 저장 폭증 방지, 단일 develop 소스 |
| 설정 무효화 | 키에 `build.sh`+`CMakeLists.txt` checksum → **빌드 플래그 변경 시 캐시 라인 무효화 → cold rebuild** |
| version | v1 → **v2** |

### Remarks

- **플래그 변경 방어**: 최근 `SUPPORT_XA`(→`CCI_XA`) 기본 활성화 같은 **빌드 플래그 전용 변경**이 stale 웜캐시를 타고 CI를 빠져나가 회귀가 늦게 발견된 사례가 있었습니다. 키에 `build.sh` checksum을 넣어, 그런 PR은 develop warm 캐시를 못 타고 **그 PR CI에서 cold 빌드로 정직하게 검증**됩니다.
- **검증**: setup이 생성하는 `continue.yml`을 develop / PR(`pull/*`) 두 경우로 로컬 생성·YAML 검증 완료 — develop은 `build`/`build_debug` 모두 restore+save, PR은 둘 다 restore-only(save 미생성). testcase 캐시는 변경 없음.
- `CCACHE_MAXSIZE`(5G)·외부 daily-clear는 유지. 커밋별 회전 + 15일 보존으로 자체 신선도 관리되며, daily-clear 유지 시 매일 첫 develop 빌드 1회만 cold.
