### PR TITLE
[CBRD-27049] POC:optdebug - test_shell on release build (no-merge)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -364,12 +364,13 @@ jobs:
                         git submodule sync
                         git submodule update --init
                   - run:
-                      name: Build (debug)
+                      name: Build (release)
                       command: |
+                        # POC CBRD-27049: test-feeding artifact built in release mode
                         mkdir -p \$CCACHE_DIR
                         ccache --max-size=5G
                         ccache -z
-                        scl enable devtoolset-8 -- /entrypoint.sh build -m debug
+                        scl enable devtoolset-8 -- /entrypoint.sh build
                         ccache -s
             EOF
             # ccache save: write only on develop-branch builds -> a single shared warm cache (other branches/PRs are restore-only; avoids 5G-per-PR bloat and non-develop pollution)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27049

> ⚠️ **측정용 POC PR (병합 금지)**. optdebug 모드(CBRD-27049) 평가를 위해 release/debug/optdebug 각각의 test_shell 수행시간·실패를 비교하려고 만든 실험용 브랜치입니다.

### Purpose
optdebug(=release 수준 최적화 + assert 유지)가 shell 테스트에서 release에 가까운 속도를 내면서 debug처럼 assert를 잡는지 확인하기 위한 3-way 비교의 **release arm**.

### Implementation
최신 develop config.yml 기준, test_shell에 아티팩트를 먹이는 `build_debug` job의 빌드 모드만 **release**로 바꿈. 나머지 파이프라인은 그대로. release 빌드는 별도 소스 변경 없음.

### Remarks
`/run shell`로만 트리거해 test_shell 수행시간(큐 제외)과 실패 케이스를 수집. 실험이 끝나면 닫고 브랜치 삭제 예정.
