### PR TITLE
[CBRD-27056] Fix numeric truncation in CAS result buffer (fixed 128B → NUMERIC_MAX_STRING_SIZE)

### DIFF
--- a/src/broker/cas_execute.c
+++ b/src/broker/cas_execute.c
@@ -4576,7 +4576,8 @@ dbval_to_net_buf (DB_VALUE * val, T_NET_BUF * net_buf, char fetch_flag, int max_
 	DB_VALUE v;
 	const char *str;
 	int err;
-	char buf[128];
+	int len;
+	char buf[NUMERIC_MAX_STRING_SIZE];
 
 	char_domain = db_type_to_db_domain (DB_TYPE_VARCHAR);
 	err = db_value_coerce (val, &v, char_domain);
@@ -4588,10 +4589,17 @@ dbval_to_net_buf (DB_VALUE * val, T_NET_BUF * net_buf, char fetch_flag, int max_
 	else
 	  {
 	    str = db_get_char (&v);
+	    len = db_get_string_size (&v);
 	    if (str != NULL)
 	      {
-		strncpy (buf, str, sizeof (buf) - 1);
-		buf[sizeof (buf) - 1] = '\0';
+		if (len < 0 || len > (int) sizeof (buf) - 1)
+		  {
+		    /* should not happen */
+		    assert (false);
+		    len = (len < 0) ? 0 : (int) sizeof (buf) - 1;
+		  }
+		memcpy (buf, str, len);
+		buf[len] = '\0';
 		ut_trim (buf);
 		add_res_data_string (net_buf, buf, strlen (buf), ext_col_type, CAS_SCHEMA_DEFAULT_CHARSET, &data_size);
 	      }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27056

### Purpose
* 자릿수가 큰 NUMERIC 값을 조회할 때 CAS(broker)를 경유하는 클라이언트(JDBC/CCI)에서만 값이 127자로 잘려 전달되는 문제를 수정합니다. 
* csql은 정상이지만 JDBC/CCI가 받는 값(BigDecimal) 자체가 틀리게 되어(예: 뒤 0이 소실되어 10^40배 작아짐) 단순 표시 문제가 아닌 데이터 정합성 문제였습니다.

* 원인: 
  * src/broker/cas_execute.c 의 dbval_to_net_buf() 함수 case DB_TYPE_NUMERIC 처리가 128바이트 고정 버퍼를 사용해, NUMERIC 문자열이 최대 ~ 254자(scale 확장 -214~252)까지 가능함에도 strncpy 복사 상한(128-1=127)에서 잘렸습니다. (csql은 NUMERIC_MAX_STRING_SIZE 버퍼를 써서 정상)

### Implementation
- 고정 버퍼 `char buf[128]` 을 `char buf[NUMERIC_MAX_STRING_SIZE]` (= `((DB_MAX_NUMERIC_PRECISION - DB_MIN_NUMERIC_SCALE) + 2) * 2 = 512`) 로 확장. 
  - csql 등 다른 경로와 동일한 매크로 사용.
- `strncpy(buf, str, sizeof(buf)-1)` → `db_get_string_size()` 로 실제 byte 길이(len)를 구해 `memcpy(buf, str, len)` 로 필요한 만큼만 복사하고 `buf[len]='\0'` 로 종료. 
  - `strncpy()` 가 수행하던 불필요한 `tail '\0'` 패딩 제거.
- 방어 코드:
  - `db_get_string_size()` 가 반환하는 값(MEDIUM_STRING 의 size)은 `signed int` 이므로, len 이 정상 범위(0 ~ sizeof(buf)-1)를 벗어나면(정상 경로에선 발생 불가) `assert(false)` 후 clamp(음수는 0, 초과는 sizeof(buf)-1) 하여 memcpy 오버플로를 원천 차단.

### Remarks

#### Repro
```sql
 – 167 자리
 SELECT 12345678901234567890123456789012345678912345678901234567890123456789012345678900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 FROM dual;
```

#### Expected Result
```
– 167 자리
12345678901234567890123456789012345678910000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
```

#### Actual Result
```
– 127 자리
1234567890123456789012345678901234567891000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
```
