### PR TITLE
[CBRD-27052] [Regression] Core dumped in lock_uninit_resource

### DIFF
--- a/src/query/dblink_2pc_daemon.c
+++ b/src/query/dblink_2pc_daemon.c
@@ -168,11 +168,34 @@ dblink_2pc_recovery_callback (const DBLINK_GLOBAL_TRAN_ROW * row_data)
 void
 dblink_2pc_daemon_recovery_with_thread (THREAD_ENTRY * thread_p)
 {
+  int tran_index, error;
+
   if (thread_p == NULL)
     {
       return;
     }
-  (void) dblink_global_tran_scan_for_recovery (thread_p, dblink_2pc_recovery_callback);
+
+  /* Run the recovery scan under its own transaction (rather than the caller's system/recovery
+   * tran index) so that the class lock taken by the heap scan is released via the normal
+   * commit/abort path. The system tran index is never committed/aborted or unlocked, so a scan
+   * performed directly on it would leak its class lock until server shutdown. */
+  tran_index = logtb_assign_tran_index (thread_p, NULL_TRANID, TRAN_ACTIVE, NULL, NULL,
+					TRAN_LOCK_INFINITE_WAIT, TRAN_READ_COMMITTED);
+  if (tran_index == NULL_TRAN_INDEX)
+    {
+      return;
+    }
+
+  error = dblink_global_tran_scan_for_recovery (thread_p, dblink_2pc_recovery_callback);
+  if (error == NO_ERROR)
+    {
+      xtran_server_commit (thread_p, false);
+    }
+  else
+    {
+      (void) xtran_server_abort (thread_p);
+    }
+  logtb_free_tran_index (thread_p, tran_index);
 }
 
 static void


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27052>

### Purpose

Transaction 정리 중, 해제 안 되는 LOCK으로 인해 core dump 발생하는 문제 해결

### Implementation

dblink_2pc_daemon_recovery_with_thread()가 복구 시점에 시스템(recovery) tran_index 위에서 직접 _db_global_tran 카탈로그를 heap scan하면서 class IS_LOCK을 잡았는데, 이 tran_index는 log_abort_all_active_transaction()에서 제외되고 commit/abort도 되지 않아 락이 영원히 안 풀리는 문제를 아래와 같이 해결

dblink_2pc_daemon_execute()가 실제 삭제 작업 시 이미 쓰고 있는 패턴(logtb_assign_tran_index → 작업 → xtran_server_commit/abort → logtb_free_tran_index)을 그대로 재사용해서, 복구 스캔도 자체 트랜잭션 위에서 돌도록 하면 스캔이 잡은 class IS_LOCK이 commit/abort 시 lock_unlock_all()로 정상적으로 풀림.

### Remarks

debug모드에서만 assert 발생하므로 debug모드에서 테스트해야 함.
