### PR TITLE
[CBRD-27057] Align OOS target with four-record capacity

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -12173,6 +12173,33 @@ heap_attrinfo_get_record_header_size (HEAP_CACHE_ATTRINFO * attr_info, int paylo
   return header_size;
 }
 
+#define HEAP_OOS_MIN_RECS_PER_PAGE 4
+
+/*
+ * heap_oos_inline_target_size () - Return the maximum inline record target used by OOS demotion
+ *
+ * Compute the PostgreSQL-style physical target: four aligned records and their slots must fit in the usable heap page
+ * capacity. Heap unfill space is a page-selection policy and must not affect the OOS trigger or demotion target.
+ */
+int
+heap_oos_inline_target_size (void)
+{
+  const int page_capacity = heap_nonheader_page_capacity ();
+  int target_size;
+  int packed_size;
+  int next_packed_size;
+
+  target_size = (page_capacity - HEAP_OOS_MIN_RECS_PER_PAGE * SPAGE_SLOT_SIZE) / HEAP_OOS_MIN_RECS_PER_PAGE;
+  target_size = DB_ALIGN_BELOW (target_size, HEAP_MAX_ALIGN);
+
+  packed_size = HEAP_OOS_MIN_RECS_PER_PAGE * ((int) DB_ALIGN (target_size, HEAP_MAX_ALIGN) + SPAGE_SLOT_SIZE);
+  next_packed_size = HEAP_OOS_MIN_RECS_PER_PAGE * ((int) DB_ALIGN (target_size + 1, HEAP_MAX_ALIGN) + SPAGE_SLOT_SIZE);
+  assert (packed_size <= page_capacity);
+  assert (next_packed_size > page_capacity);
+
+  return target_size;
+}
+
 /*
  * heap_attrinfo_determine_disk_layout () - Determine the disk layout needed to transform the object
  *                        represented by attr_info
@@ -12199,6 +12226,7 @@ heap_attrinfo_determine_disk_layout (HEAP_CACHE_ATTRINFO * attr_info, bool is_mv
 // *INDENT-ON*
   int payload_size, header_size;
   int mvcc_extra;
+  const int oos_inline_target_size = heap_oos_inline_target_size ();
   int i;
 
   *has_oos = false;
@@ -12209,9 +12237,9 @@ heap_attrinfo_determine_disk_layout (HEAP_CACHE_ATTRINFO * attr_info, bool is_mv
   mvcc_extra = is_mvcc_class ? OR_MVCC_MAX_HEADER_SIZE - OR_MVCC_INSERT_HEADER_SIZE : 0;
 
   /* TODO: change the statistics */
-  /* push the largest variable column to OOS one by one until the heap record
-   * fits within DB_PAGESIZE/4 (PG TOAST style), instead of pushing every eligible column */
-  if (header_size + payload_size + mvcc_extra > DB_PAGESIZE / 4)
+  /* Push the largest variable column to OOS one by one until at least four resulting heap records can fit on a page
+   * (PG TOAST style), instead of pushing every eligible column. */
+  if (header_size + payload_size + mvcc_extra > oos_inline_target_size)
     {
       // *INDENT-OFF*
       std::vector<heap_oos_demote_candidate> oos_candidates;
@@ -12242,7 +12270,7 @@ heap_attrinfo_determine_disk_layout (HEAP_CACHE_ATTRINFO * attr_info, bool is_mv
       for (auto& cand : oos_candidates)
 	// *INDENT-ON*
       {
-	if (header_size + payload_size + mvcc_extra <= DB_PAGESIZE / 4)
+	if (header_size + payload_size + mvcc_extra <= oos_inline_target_size)
 	  {
 	    break;
 	  }

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -725,6 +725,7 @@ extern int heap_alloc_new_page (THREAD_ENTRY * thread_p, HFID * hfid, OID class_
 				VPID * new_page_vpid);
 
 extern int heap_nonheader_page_capacity ();
+extern int heap_oos_inline_target_size (void);
 
 extern int heap_rv_postpone_append_pages_to_heap (THREAD_ENTRY * thread_p, LOG_RCV * recv);
 extern void heap_rv_dump_append_pages_to_heap (FILE * fp, int length, void *data);

--- a/unit_tests/oos/sql/test_oos_sql_boundary.cpp
+++ b/unit_tests/oos/sql/test_oos_sql_boundary.cpp
@@ -347,6 +347,99 @@ TEST_F (OosSqlBoundary, MidSizeColumnsEligibleForOos)
   EXPECT_EQ (len, 1000);
 }
 
+// CBRD-27057: preserve logical values after largest-first demotion to the physical four-record target.
+TEST_F (OosSqlBoundary, FourRecordTargetBulkRoundTrip)
+{
+  int rc;
+
+  rc = exec_sql ("CREATE TABLE t_oos_bnd ("
+		 "  id BIGINT NOT NULL, lookup_key INT NOT NULL, hot_col INT NOT NULL,"
+		 "  inline_1 BIT VARYING, inline_2 BIT VARYING, inline_3 BIT VARYING,"
+		 "  cold_1 BIT VARYING, cold_2 BIT VARYING"
+		 ")");
+  ASSERT_GE (rc, 0);
+  db_commit_transaction ();
+
+  rc = exec_sql ("INSERT INTO t_oos_bnd "
+		 "SELECT LEVEL, LEVEL, MOD(LEVEL, 1000),"
+		 "       REPEAT(X'11', 1300), REPEAT(X'22', 1300), REPEAT(X'33', 1300),"
+		 "       REPEAT(X'AA', 5300), REPEAT(X'BB', 5200) "
+		 "  FROM db_root CONNECT BY LEVEL <= 100");
+  ASSERT_GE (rc, 0);
+  db_commit_transaction ();
+
+  int count = 0;
+  rc = fetch_single_int ("SELECT COUNT(*) FROM t_oos_bnd", &count);
+  ASSERT_EQ (rc, NO_ERROR);
+  EXPECT_EQ (count, 100);
+
+  rc = fetch_single_int ("SELECT COUNT(*) FROM t_oos_bnd "
+			 "WHERE inline_1 = CAST(REPEAT(X'11', 1300) AS BIT VARYING) "
+			 "AND inline_2 = CAST(REPEAT(X'22', 1300) AS BIT VARYING) "
+			 "AND inline_3 = CAST(REPEAT(X'33', 1300) AS BIT VARYING) "
+			 "AND cold_1 = CAST(REPEAT(X'AA', 5300) AS BIT VARYING) "
+			 "AND cold_2 = CAST(REPEAT(X'BB', 5200) AS BIT VARYING)",
+			 &count);
+  ASSERT_EQ (rc, NO_ERROR);
+  EXPECT_EQ (count, 100);
+}
+
+// The physical four-record target is independent of heap unfill policy.
+TEST_F (OosSqlBoundary, PhysicalFourRecordTargetIgnoresUnfill)
+{
+  const float original_unfill = prm_get_float_value (PRM_ID_HF_UNFILL_FACTOR);
+
+  prm_set_float_value (PRM_ID_HF_UNFILL_FACTOR, 0.0f);
+  const int target_without_unfill = heap_oos_inline_target_size ();
+  prm_set_float_value (PRM_ID_HF_UNFILL_FACTOR, 0.10f);
+  const int target_with_default_unfill = heap_oos_inline_target_size ();
+  prm_set_float_value (PRM_ID_HF_UNFILL_FACTOR, original_unfill);
+
+  const int page_capacity = heap_nonheader_page_capacity ();
+  const int packed_size = 4 * ((int) DB_ALIGN (target_without_unfill, HEAP_MAX_ALIGN) + SPAGE_SLOT_SIZE);
+  const int next_packed_size = 4 * ((int) DB_ALIGN (target_without_unfill + 1, HEAP_MAX_ALIGN) + SPAGE_SLOT_SIZE);
+
+  EXPECT_EQ (target_without_unfill, 4060);
+  EXPECT_EQ (target_with_default_unfill, target_without_unfill);
+  EXPECT_LE (packed_size, page_capacity);
+  EXPECT_GT (next_packed_size, page_capacity);
+}
+
+// A record crossing the rejected 3,652-byte unfill-dependent target stays inline; a record above the physical
+// 4,060-byte target triggers OOS.
+TEST_F (OosSqlBoundary, PhysicalPackingTargetTriggersOos)
+{
+  int rc = exec_sql ("CREATE TABLE t_oos_bnd (id INT, c1 BIT VARYING, c2 BIT VARYING)");
+  ASSERT_GE (rc, 0);
+  db_commit_transaction ();
+
+  rc = exec_sql ("INSERT INTO t_oos_bnd VALUES (1, REPEAT(X'AA', 1850), REPEAT(X'BB', 1850))");
+  ASSERT_GE (rc, 0);
+  db_commit_transaction ();
+
+#if defined(SA_MODE)
+  EXPECT_FALSE (table_has_oos_file ("t_oos_bnd"));
+#endif /* SA_MODE */
+
+  rc = exec_sql ("INSERT INTO t_oos_bnd VALUES (2, REPEAT(X'CC', 2100), REPEAT(X'DD', 2100))");
+  ASSERT_GE (rc, 0);
+  db_commit_transaction ();
+
+#if defined(SA_MODE)
+  EXPECT_TRUE (table_has_oos_file ("t_oos_bnd"));
+#endif /* SA_MODE */
+
+  int count = 0;
+  rc = fetch_single_int ("SELECT COUNT(*) FROM t_oos_bnd "
+			 "WHERE (id = 1 AND c1 = CAST(REPEAT(X'AA', 1850) AS BIT VARYING) "
+			 "AND c2 = CAST(REPEAT(X'BB', 1850) AS BIT VARYING)) "
+			 "OR (id = 2 AND c1 = CAST(REPEAT(X'CC', 2100) AS BIT VARYING) "
+			 "AND c2 = CAST(REPEAT(X'DD', 2100) AS BIT VARYING))",
+			 &count);
+  ASSERT_EQ (rc, NO_ERROR);
+  EXPECT_EQ (count, 2);
+}
+
 int
 main (int argc, char **argv)
 {

--- a/unit_tests/oos/sql/test_oos_sql_common.hpp
+++ b/unit_tests/oos/sql/test_oos_sql_common.hpp
@@ -40,6 +40,8 @@
 #include "file_manager.h"
 #include "heap_file.h"
 #include "oos_file.hpp"
+#include "slotted_page.h"
+#include "system_parameter.h"
 #include "vacuum.h"
 #endif /* SA_MODE */
 
@@ -184,10 +186,10 @@ exec_sql_commit (const char *sql)
 // ============================================================================
 
 #if defined(SA_MODE)
-// Get the OOS VFID for a given table name. Returns true on success.
-// SA_MODE only — requires server-side heap/file APIs.
+// Get the heap HFID for a given table name. Returns true on success.
+// SA_MODE only -- requires server-side heap/file APIs.
 static bool
-get_oos_vfid_for_table (const char *table_name, VFID *oos_vfid_out)
+get_heap_hfid_for_table (const char *table_name, HFID *hfid_out)
 {
   THREAD_ENTRY *thread_p = thread_get_thread_entry_info ();
 
@@ -203,10 +205,19 @@ get_oos_vfid_for_table (const char *table_name, VFID *oos_vfid_out)
       return false;
     }
 
-  HFID hfid;
   FILE_TYPE ftype;
-  int err = heap_get_class_info (thread_p, class_oid, &hfid, &ftype, NULL);
-  if (err != NO_ERROR)
+  return heap_get_class_info (thread_p, class_oid, hfid_out, &ftype, NULL) == NO_ERROR;
+}
+
+// Get the OOS VFID for a given table name. Returns true on success.
+// SA_MODE only — requires server-side heap/file APIs.
+static bool
+get_oos_vfid_for_table (const char *table_name, VFID *oos_vfid_out)
+{
+  THREAD_ENTRY *thread_p = thread_get_thread_entry_info ();
+
+  HFID hfid;
+  if (!get_heap_hfid_for_table (table_name, &hfid))
     {
       return false;
     }
@@ -236,6 +247,15 @@ get_oos_page_count (const char *table_name)
 
   return num_pages;
 }
+
+// Return true if a table has created its lazy OOS file. SA_MODE only.
+static bool
+table_has_oos_file (const char *table_name)
+{
+  VFID oos_vfid;
+  return get_oos_vfid_for_table (table_name, &oos_vfid) && !VFID_ISNULL (&oos_vfid);
+}
+
 #endif /* SA_MODE */
 
 // Trigger vacuum (SA_MODE only: calls xvacuum() directly, synchronous).


### PR DESCRIPTION
https://jira.cubrid.org/browse/CBRD-27057

## Purpose

- OOS는 큰 컬럼 값을 별도 파일에 저장하고, heap record에는 작은 참조 정보만 남기는 기능입니다.
- **AS-IS:** `feat/oos`는 `DB_PAGESIZE / 4`인 4,086B를 기준으로 사용하여 page 고정 영역과 record slot을 반영하지 않습니다.
- **TO-BE:** P사 TOAST 방식처럼 한 page에 네 record가 물리적으로 들어가는 최대 크기 4,060B를 기준으로 사용합니다.
- OOS 선택 기준과 heap page 배치 정책을 분리하여 설정값에 따라 target이 달라지지 않게 합니다.

## Implementation

- `heap_oos_inline_target_size()`가 non-header heap capacity와 네 `SPAGE_SLOT_SIZE`를 반영해 target을 계산합니다.
- OOS 시작 조건과 largest-first demotion 중단 조건이 같은 target을 사용합니다.
- `unfill_factor`는 target에서 제외하고 기존 heap page 선택 정책에만 유지합니다.
- Target exact value, 다음 aligned size, unfill 독립성, OOS trigger 및 logical value round-trip을 검증합니다.
- 실제 heap page 수를 네 rows/page로 강제하던 assertion은 제거했습니다.
- 주요 변경 파일은 `src/storage/heap_file.c`와 `unit_tests/oos/sql/test_oos_sql_boundary.cpp`입니다.

## Remarks

- 4,060B는 물리적 capacity 기준이며, 실제 INSERT가 모든 page에 항상 네 row를 배치한다는 의미는 아닙니다.
- OOS on-disk format, WAL, recovery, replication, SQL syntax은 변경하지 않습니다.
- Debug GCC build와 configured OOS tests 23/23, boundary tests 11/11이 통과했습니다.
- Reviewer는 target 계산과 trigger/stop의 동일 target 사용을 먼저 확인하면 됩니다.
- 자세한 설명: https://github.com/vimkim/my-cubrid-docs/blob/main/cbrd-27057/CBRD-27057-oos-four-record-target.md
