### PR TITLE
[CBRD-26966] Fix DBLink multi-remote DML crash and silent-wrong send (#7412)

### DIFF
--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -3955,8 +3955,14 @@ typedef enum cdc_ddl_object_type CDC_DDL_OBJECT_TYPE;
 typedef struct
 {
   int local_cnt;
-  int server_cnt;
-  int server_node_cnt;
+  int server_cnt;		/* raw count of dblink spec nodes walked so far (no dedup); unrelated to
+				 * stored_cnt/distinct_cnt below, used only to detect whether a sub-walk
+				 * encountered any new dblink spec (before/after diff) */
+  /* invariant: 0 <= stored_cnt <= 2; server[i] (0 <= i < stored_cnt) is always non-NULL */
+  int stored_cnt;		/* # entries actually stored in server[]/len[]/server_full_name[];
+				 * the only bound used for indexing/iterating those arrays */
+  int distinct_cnt;		/* # distinct remote servers found so far; multi-remote decision only,
+				 * may exceed 2 (array capacity) on overflow */
   int len[2];
   char *server_full_name[2];
   PT_NODE *server[2];

--- a/src/parser/parser_support.c
+++ b/src/parser/parser_support.c
@@ -11192,52 +11192,62 @@ pt_get_server_name_list (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int
     }
 
   snl->server_cnt++;
-  for (int i = 0; i < snl->server_node_cnt; i++)
+  for (int i = 0; i < snl->stored_cnt; i++)
     {
-      int node_cnt = 0;
-
       if (name_ptr == NULL || strcasecmp (snl->server[i]->info.name.original, name_ptr) != 0)
 	{
-	  node_cnt++;
+	  continue;		/* name mismatch: not a duplicate of this slot, keep scanning */
 	}
 
       if (owner_ptr == NULL && snl->server[i]->next == NULL)
 	{
-	  snl->server_node_cnt += node_cnt;
-	  return node;
+	  return node;		/* exact duplicate (no owner qualifier on either side) */
 	}
 
-      if (owner_ptr && snl->server[i]->next)
+      if (owner_ptr != NULL && snl->server[i]->next != NULL)
 	{
 	  if (strcasecmp (snl->server[i]->next->info.name.original, owner_ptr) != 0)
 	    {
-	      node_cnt++;
+	      continue;		/* same name, different owner: distinct server, keep scanning */
 	    }
-	  snl->server_node_cnt += node_cnt;
-	  return node;
+	  return node;		/* same name and same owner qualifier: exact duplicate */
 	}
+      /* same name, owner-presence differs (one qualified, one not): keep scanning */
     }
 
-  if (name_ptr != NULL)
+  if (name_ptr == NULL)
     {
-      new_name = parser_new_node (parser, PT_NAME);
-      new_name->info.name.original = pt_append_string (parser, NULL, name_ptr);
-      if (owner_ptr)
-	{
-	  new_owner = parser_new_node (parser, PT_NAME);
-	  new_owner->info.name.original = pt_append_string (parser, NULL, owner_ptr);
-	  new_name->next = new_owner;
-
-	  vq = pt_append_nulstring (parser, vq, owner_ptr);
-	  vq = pt_append_bytes (parser, vq, ".", 1);
-	}
-      vq = pt_append_nulstring (parser, vq, name_ptr);
-
-      snl->len[snl->server_node_cnt] = (int) strlen ((char *) vq->bytes);
-      snl->server_full_name[snl->server_node_cnt] = (char *) vq->bytes;
-      snl->server[snl->server_node_cnt] = new_name;
-      snl->server_node_cnt++;
+      return node;
     }
+
+  if (snl->stored_cnt >= (int) (sizeof (snl->server) / sizeof (snl->server[0])))
+    {
+      /* slots full (3rd+ distinct remote): count only, no out-of-bounds store. Keep walking (not
+       * PT_STOP_WALK) so any local spec later in the same FROM-list is still visited and counted
+       * into local_cnt; otherwise pt_convert_dblink_dml_query's local_cnt>0 check is skipped and
+       * the wrong rejection message (multi-remote instead of local-mixed-remote) is raised. */
+      snl->distinct_cnt++;
+      return node;
+    }
+
+  new_name = parser_new_node (parser, PT_NAME);
+  new_name->info.name.original = pt_append_string (parser, NULL, name_ptr);
+  if (owner_ptr)
+    {
+      new_owner = parser_new_node (parser, PT_NAME);
+      new_owner->info.name.original = pt_append_string (parser, NULL, owner_ptr);
+      new_name->next = new_owner;
+
+      vq = pt_append_nulstring (parser, vq, owner_ptr);
+      vq = pt_append_bytes (parser, vq, ".", 1);
+    }
+  vq = pt_append_nulstring (parser, vq, name_ptr);
+
+  snl->len[snl->stored_cnt] = (int) strlen ((char *) vq->bytes);
+  snl->server_full_name[snl->stored_cnt] = (char *) vq->bytes;
+  snl->server[snl->stored_cnt] = new_name;
+  snl->stored_cnt++;
+  snl->distinct_cnt++;		/* a store always means exactly one new distinct server (lockstep) */
 
   return node;
 }
@@ -11393,6 +11403,8 @@ find_circle_at_char (bool ansi_quotes, bool no_escape, char *ps)
 #endif
 
 #if defined (ENABLE_UNUSED_FUNCTION)
+/* not migrated to stored_cnt/distinct_cnt (CBRD-26966): dead code, excluded from the build.
+ * if ever revived, its server_node_cnt uses below must become stored_cnt (array bound). */
 static PARSER_VARCHAR *
 pt_make_remote_query (PARSER_CONTEXT * parser, char *sql_user_text, SERVER_NAME_LIST * snl)
 {
@@ -11910,7 +11922,7 @@ pt_convert_dblink_dml_query (PARSER_CONTEXT * parser, PT_NODE * node,
       return;
     }
 
-  if (snl->server_node_cnt >= 2 && remote_upd > 0)
+  if (snl->distinct_cnt >= 2)
     {
       PT_ERROR (parser, upd_spec ? upd_spec : into_spec, "dblink: multi-remote DML is not allowed");
       return;
@@ -12014,9 +12026,9 @@ pt_convert_dblink_dml_query (PARSER_CONTEXT * parser, PT_NODE * node,
 
   ct->info.dblink_table.qstr = val;
 
-  for (i = 0; i < snl->server_node_cnt; i++)
+  for (i = 0; i < snl->stored_cnt; i++)
     {
-      if (snl->server_node_cnt != 1)
+      if (snl->stored_cnt != 1)
 	{
 	  if (ct->info.dblink_table.owner_list == NULL && snl->server[i]->next)
 	    {
@@ -12176,7 +12188,7 @@ pt_rewrite_for_dblink (PARSER_CONTEXT * parser, PT_NODE * stmt)
       // Note that this is not the case for Static SQL SELECT statements.
       if (parser->flag.is_parsing_static_sql)
 	{
-	  if (snl.has_dblink_query || snl.server_node_cnt > 0)
+	  if (snl.has_dblink_query || snl.distinct_cnt > 0)
 	    {
 	      PT_ERROR (parser, stmt, "DBLink DML is not yet supported for PL/CSQL Static SQL.");
 	      return;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26966

### Purpose

* backport #7412

### Implementation

Cherry-pick applied with manual conflict resolution: release/11.4 predates CBRD-26796
(remote INSERT SELECT / `is_remote_insert_select`), which #7412's develop-based diff
touched only as adjacent context (a comment referencing the renamed field). The core
fix — splitting `server_node_cnt` into `stored_cnt`/`distinct_cnt` and rewriting the
dedup loop in `pt_get_server_name_list`, plus dropping the `remote_upd` dependency in
the multi-remote rejection check in `pt_convert_dblink_dml_query` — applied cleanly via
3-way merge with no adaptation needed. The CBRD-26796-only blocks were dropped from the
conflict hunks since that feature isn't in this branch.

### Remarks

N/A