### PR TITLE
[CBRD-27015] Fix cubrid tranlist core dump caused by unlocked trid reset in logtb_free_tran_index

### DIFF
--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -1237,10 +1237,9 @@ logtb_free_tran_index (THREAD_ENTRY * thread_p, int tran_index)
 
   if (tran_index != LOG_SYSTEM_TRAN_INDEX)
     {
+      TR_TABLE_CS_ENTER (thread_p);
       tdes->trid = NULL_TRANID;
       tdes->client_id = -1;
-
-      TR_TABLE_CS_ENTER (thread_p);
       logtb_decrement_number_of_assigned_tran_indices ();
       if (log_Gl.trantable.hint_free_index > tran_index)
 	{


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27015

## Purpose

server-side loaddb 수행 중 cubrid tranlist 실행 시 클라이언트(cub_admin)가 or_unpack_string에서 간헐적으로 core dump 되는 문제를 수정한다.

- 크래시 지점: 
  - `or_unpack_string` (`object_representation.c:1933`)
  - `length=167772160(0x0A000000)`
- 크래시 스택: 
  - `tranlist` → `logtb_get_trans_info (i=9, num_trans=10)` → `or_unpack_string`
- 근본 원인: 
  - 트랜잭션 해제 경로(logtb_free_tran_index)에서 tdes->trid = NULL_TRANID를 TR_TABLE_CS 잠금 밖에서 먼저 수행하기 때문에, 서버가 트랜잭션 목록을 패킹(xlogtb_get_pack_tran_table)하는 도중 다른 워커 스레드가 해당 트랜잭션을 무효화할 수 있다.
  - 그 결과 헤더에 기록한 트랜잭션 개수(10)와 실제 패킹된 레코드 수(9)가 달라지고, 클라이언트는 존재하지 않는 10번째 레코드를 언패킹하면서 쓰레기 값을 문자열 길이로 해석한다. 이후 167MB 크기의 memcpy를 수행하려다 core dump가 발생한다.

server-side loaddb는 데이터를 batch 단위로 나누어 반복적으로 commit한다.
따라서 로드가 진행되는 동안 트랜잭션이 매우 짧은 주기로 생성되고 종료되며, tranlist가 이를 조회하는 시점과 겹칠 확률이 크게 증가한다.
이로 인해 평소에는 드물게 발생하던 잠복 레이스 조건이 해당 테스트에서 높은 확률로 노출된다. (재현은 타이밍에 따라 간헐적)


## Implementation
- 수정 위치: 
  - `src/transaction/log_tran_table.c`
  - `logtb_free_tran_index()` (~1238)
- `tdes->trid = NULL_TRANID`와 `tdes->client_id = -1` 초기화를 `TR_TABLE_CS_ENTER()` 내부로 이동하였다.
- 이를 통해 `xlogtb_get_pack_tran_table()`의 두 번의 순회(개수 계산 → 실제 패킹) 동안 `trid`가 변경되지 않음을 보장하여, 헤더에 기록한 개수와 실제 패킹한 개수가 항상 일치하도록 수정하였다.

```c
  if (tran_index != LOG_SYSTEM_TRAN_INDEX)
    {
      /* [AS-IS] trid/client_id 를 CS 밖에서 먼저 초기화 → 패킹 중인 소비자와 레이스
         tdes->trid = NULL_TRANID;
         tdes->client_id = -1;
      */
      TR_TABLE_CS_ENTER (thread_p);
      tdes->trid = NULL_TRANID;          /* [TO-BE] CS 안으로 이동 */
      tdes->client_id = -1;
      logtb_decrement_number_of_assigned_tran_indices ();
      if (log_Gl.trantable.hint_free_index > tran_index)
        {
          log_Gl.trantable.hint_free_index = tran_index;
        }
      TR_TABLE_CS_EXIT (thread_p);
      ...
    }
```

- 이 변경으로 tranlist가 read CS를 보유한 동안 `trid`가 변경되지 않으므로 `num_clients == num_clients_packed` 불변식이 항상 유지된다.
- 따라서 tran table을 조회하는 모든 소비자에 대해 동일한 레이스를 근본적으로 방지할 수 있다.


## Remarks
### 크래시 발생 경로
이 문제는 서버와 클라이언트를 거쳐 아래 순서로 발생한다.
1. 서버가 트랜잭션 목록을 잘못 패킹
- `src/transaction/log_tran_table.c`
  - `logtb_free_tran_index`(~1202)
  - `xlogtb_get_pack_tran_table`(~2220)
2. 클라이언트가 잘못된 데이터를 언패킹
- `src/communication/network_interface_cl.c`
  - `logtb_get_trans_info`(~8336)
3. 잘못된 문자열 길이를 읽어 크래시 발생
- `src/object/object_representation.c`
  - `or_unpack_string`, crash@1933
4. 최상위 호출자(`cubrid tranlist`)
- `src/executables/util_cs.c`
  - `tranlist`(~1879)

### 검증 방법
이 버그는 레이스 조건이 만족될 때만 발생하므로, 수정 후 테스트에서 재현되지 않았다는 사실만으로는 수정 여부를 증명할 수 없다.
따라서 본 수정은 테스트 결과가 아니라 `코드의 불변식(invariant)` 으로 안전성을 보장한다.
- `trid` 초기화를 `TR_TABLE_CS` 내부에서 수행하면, 트랜잭션 목록을 패킹하는 두 번의 순회 동안 `trid`가 변경되지 않는다.
- 따라서 헤더에 기록한 개수와 실제 패킹한 개수는 항상 동일하다.
- 이 불변식이 유지되는 한, 개수 불일치로 인해 발생하는 이번 크래시는 원천적으로 발생할 수 없다.

추가로 debug 빌드에는 다음 검증이 포함되어 있다.
```c
assert (num_clients_packed == num_clients);
```

- 수정 전에는 debug 빌드에서 위 assert가 먼저 실패하여 문제를 확인할 수 있었으며, release 빌드에서는 해당 검사가 제외되어 깨진 데이터가 그대로 클라이언트로 전달되고 최종적으로 or_unpack_string()에서 core dump가 발생하였다.

### 관련 테스트
- `cubrid-testcases-private-ex/.../issue_21654_server_side_loaddb/signals/cases/signals.sh`
- 시나리오 4(killtran)에서 `cubrid tranlist` 를 반복 수행하며, 해당 경로에서 본 문제가 재현되었다.
