### PR TITLE
[CUBRIDQA-1432] Automate submodule SHA bump PR creation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -55,3 +55,9 @@
 /src/loaddb @beyondykk9
 
 /pl_engine @beyondykk9
+
+# submodule bump PRs
+/cubrid-jdbc @CUBRID/dev1
+/cubrid-cci @CUBRID/dev1
+/cubridmanager @CUBRID/dev1
+/.gitmodules @CUBRID/dev1

--- a/.github/workflows/submodule-bump-receiver.yml
+++ b/.github/workflows/submodule-bump-receiver.yml
@@ -24,7 +24,7 @@ env:
   FALLBACK_TAG: "[CBRD-0000]"
 
 concurrency:
-  group: submodule-bump-${{ github.event.client_payload.submodule_path || inputs.submodule_path }}
+  group: submodule-bump-${{ github.event.client_payload.submodule_path || inputs.submodule_path || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/submodule-bump-receiver.yml
+++ b/.github/workflows/submodule-bump-receiver.yml
@@ -1,0 +1,99 @@
+name: Submodule bump (receiver)
+
+on:
+  repository_dispatch:
+    types: [submodule-bump]
+  workflow_dispatch:
+    inputs:
+      submodule_path:
+        description: "cubrid-jdbc | cubrid-cci | cubridmanager"
+        required: true
+      commit_message:
+        description: "Original commit subject (for issue-key inheritance)"
+        default: ""
+      pusher:
+        description: "GitHub id to set as assignee"
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  BASE_BRANCH: develop
+  FALLBACK_TAG: "[CBRD-0000]"
+
+concurrency:
+  group: submodule-bump-${{ github.event.client_payload.submodule_path || inputs.submodule_path }}
+  cancel-in-progress: true
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    env:
+      SUB_PATH:   ${{ github.event.client_payload.submodule_path || inputs.submodule_path }}
+      COMMIT_MSG: ${{ github.event.client_payload.commit_message || inputs.commit_message }}
+      PUSHER:     ${{ github.event.client_payload.pusher || inputs.pusher }}
+    steps:
+      - name: Validate submodule path
+        run: |
+          set -euo pipefail
+          case "$SUB_PATH" in
+            cubrid-jdbc|cubrid-cci|cubridmanager) ;;
+            *) echo "::error::Unknown submodule path: '$SUB_PATH'"; exit 1 ;;
+          esac
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.SUBMODULE_BOT_APP_ID }}
+          private-key: ${{ secrets.SUBMODULE_BOT_APP_PRIVATE_KEY }}
+
+      - name: Checkout parent
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.BASE_BRANCH }}
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Update submodule pointer
+        id: bump
+        run: |
+          set -euo pipefail
+          git submodule update --init -- "$SUB_PATH"
+          git submodule update --remote -- "$SUB_PATH"
+          if git diff --quiet -- "$SUB_PATH"; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "new_sha=$(git -C "$SUB_PATH" rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build PR title
+        if: steps.bump.outputs.changed == 'true'
+        id: title
+        run: |
+          set -euo pipefail
+          TAG=$(printf '%s' "$COMMIT_MSG" | head -n1 | grep -oE '^\[[A-Z]+-[0-9]+\]' || true)
+          [ -z "$TAG" ] && TAG="$FALLBACK_TAG"
+          echo "value=${TAG} Update ${SUB_PATH} submodule" >> "$GITHUB_OUTPUT"
+
+      - name: Create or update PR
+        if: steps.bump.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: bump/${{ env.SUB_PATH }}
+          base: ${{ env.BASE_BRANCH }}
+          title: ${{ steps.title.outputs.value }}
+          commit-message: ${{ steps.title.outputs.value }}
+          body: |
+            Automated submodule bump for `${{ env.SUB_PATH }}`.
+
+            - New SHA: `${{ steps.bump.outputs.new_sha }}`
+            - Source commit: `${{ env.COMMIT_MSG }}`
+            - Pushed by: @${{ env.PUSHER }}
+          labels: Submodule Auto Update
+          assignees: ${{ env.PUSHER }}
+          delete-branch: true

--- a/.github/workflows/tc-branch-finalize.yml
+++ b/.github/workflows/tc-branch-finalize.yml
@@ -29,6 +29,7 @@ env:
 jobs:
   finalize-tc-branch:
     name: Finalize TC (${{ matrix.tc-repo }})
+    if: github.event.pull_request.user.login != 'cubrid-submodule-bot[bot]'   # skip automated submodule-bump PRs
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/tc-branch-sync.yml
+++ b/.github/workflows/tc-branch-sync.yml
@@ -25,6 +25,7 @@ jobs:
   # Parse PR metadata: type, header, original PR number
   detect-pr-type:
     name: Detect PR Type
+    if: github.event.pull_request.user.login != 'cubrid-submodule-bot[bot]'   # skip automated submodule-bump PRs
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions: {}


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1432>

### Purpose
서브모듈(cubrid-jdbc, cubrid-cci, cubridmanager) SHA 갱신을 자동화합니다.
PR 생성까지만 자동으로 이루어지며, merge는 사람이 직접 해야 합니다.

### Implementation
 - PR 제목: 원본 커밋의 `[XXX-0000]` 이슈키 상속, 없으면 `[CBRD-0000]`으로 설정
 - 서브모듈 경로 리뷰어에 `@CUBRID/dev1`(연구개발1팀) 추가
 - 봇(`cubrid-submodule-bot[bot]`) PR에 대해 TC 브랜치/draft PR을 만들지 않도록 `tc-branch-sync.yml`, `tc-branch-finalize.yml` 제외 추가

### Remarks

N/A
