### PR TITLE
[CBRD-27060] Enable parallel scan on filtered indexes

### DIFF
--- a/src/query/parallel/px_scan/px_scan_checker.cpp
+++ b/src/query/parallel/px_scan/px_scan_checker.cpp
@@ -25,9 +25,7 @@
 #include "dbtype_def.h"
 #include "error_manager.h"
 #include "regu_var.hpp"
-#include "schema_manager.h"
 #include "storage_common.h"
-#include "work_space.h"
 #include "xasl_predicate.hpp"
 #include "xasl.h"
 #include "xasl_aggregate.hpp"
@@ -347,38 +345,6 @@ namespace parallel_scan
 	   (arg->case_sensitive);
   }
 
-  /* filtered index → serial: bug-prone + low usage, excluded as a constraint. function indexes are plain B-tree keys, not blocked. */
-  static bool
-  is_filtered_index (const INDX_INFO *indexptr)
-  {
-    if (indexptr == NULL)
-      {
-	return false;
-      }
-    if (OID_ISNULL (&indexptr->class_oid))
-      {
-	return false;
-      }
-    MOP class_mop = ws_mop (&indexptr->class_oid, NULL);
-    if (class_mop == NULL)
-      {
-	return false;
-      }
-    SM_CLASS_CONSTRAINT *cons = sm_class_constraints (class_mop);
-    for (; cons != NULL; cons = cons->next)
-      {
-	if (BTID_IS_EQUAL (&cons->index_btid, &indexptr->btid))
-	  {
-	    if (cons->filter_predicate != NULL)
-	      {
-		return true;
-	      }
-	    break;
-	  }
-      }
-    return false;
-  }
-
   template <>
   possible_flags check<false> (ACCESS_SPEC_TYPE *arg)
   {
@@ -417,12 +383,6 @@ namespace parallel_scan
 		/* orderby/groupby skip+desc need globally ordered traversal. */
 		if (arg->indexptr->orderby_skip || arg->indexptr->groupby_skip
 		    || arg->indexptr->orderby_desc || arg->indexptr->groupby_desc)
-		  {
-		    set_flag (result, CANNOT_PARALLEL_SCAN);
-		  }
-
-		/* filtered index: bug-prone + low usage, excluded. */
-		if (is_filtered_index (arg->indexptr))
 		  {
 		    set_flag (result, CANNOT_PARALLEL_SCAN);
 		  }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27060>

### Purpose

병렬 인덱스 스캔(CBRD-26722, PR #7062)이 도입될 때 filtered index는 *"bug-prone + low usage"* 를 이유로 병렬 대상에서 예방적으로 제외되었다. 별도의 버그를 고친 것이 아니라, 위험을 우려해 처음부터 막아둔 게이트다.

그 우려의 실체는 병렬 인덱스 스캔이 `btree_range_search`를 쓰지 않고 leaf slot을 직접 걷는 재구현이라는 점이었다. 초기 구현은 leaf 엔트리에서 OID만 모아 `heap_get_visible_version()`으로 최신 가시 버전을 가져왔는데, filtered index에서 "필터 이탈 UPDATE"(필터 만족 → 불만족)가 일어나면 vacuum 전까지 잔존하는 옛 인덱스 엔트리를 통해 필터를 위반하는 새 버전이 결과로 유입될 수 있었다(leak). filtered index는 잔여 데이터 필터가 아예 없는 플랜(WHERE가 필터에 완전 흡수)이 가능해, 이 leak이 어디에서도 안 걸러지는 조용한 오답이 될 수 있었다.

이 leak은 이미 **엔트리 레벨 MVCC pre-filter**로 수정되어 있다(같은 커밋에서 게이트도 이중 방어로 유지). pre-filter는 leaf 수집 경로(`collect_oid_callback`, `px_scan_index_leaf_slot_walker.cpp`)와 overflow OID 페이지 수집 경로(`ovf_collect_oid_callback`, `px_scan_index_overflow_drain_fsm.cpp`) **모두**에서 힙 접근 전에 각 인덱스 엔트리의 `BTREE_MVCC_INFO`를 스냅샷과 대조해, 가시성을 잃은(필터 이탈로 delete-mark된) 엔트리를 걸러낸다 — 직렬 스캔(`btree_range_scan_select_visible_oids`)과 같은 스냅샷 함수, 같은 판정 지점이다. 따라서 게이트는 더 이상 필요하지 않다.

본 변경은 pre-filter가 모든 엣지 케이스에서 직렬 스캔과 동치임을 실증한 뒤, 불필요해진 filtered-index 병렬 제외 게이트를 제거한다.

### Implementation

`src/query/parallel/px_scan/px_scan_checker.cpp`:

- `check<false> (ACCESS_SPEC_TYPE *)`의 index-scan 분기에서 filtered-index를 직렬로 강제하던 게이트 블록 제거.
- 그 게이트 전용 헬퍼 `is_filtered_index()` 제거(남기면 unused-function 경고).
- 위 헬퍼 전용이던 include 2개(`schema_manager.h`, `work_space.h`) 제거.

순수 삭제(-40줄)이며, 병렬 인덱스 스캔의 leaf 순회/가시성 로직(`px_scan_index_leaf_slot_walker.cpp`, `px_scan_index_overflow_drain_fsm.cpp`의 MVCC pre-filter)은 변경하지 않는다. ISS/ILS, keylimit, orderby/groupby skip·desc 등 다른 병렬 제외 조건은 그대로 유지된다. filtered index 특유의, WHERE가 필터에 완전 흡수되어 key range 항이 0개인 전범위 플랜은 병렬 경로가 INF_INF 단일 range로 합성해 수용한다(`px_scan_index_key_range_list.cpp`).

### Verification

디버그 서버(기본 파라미터)에서 200k행 · 키당 중복(overflow OID chain 유발) 테이블로 검증:

- **UPDATE 전**: 힙 truth / 직렬 filtered-index / 병렬 filtered-index 3자 체크섬(COUNT, SUM) 완전 일치 — covering, non-covering, 전범위(WHERE 필터 흡수), 부분 key range, desc 키, 행 반환(list-scan 경로) 전부.
- **필터 이탈 UPDATE 후**: 열린 트랜잭션에서 10% 행을 필터 밖으로 갱신(옛 엔트리는 미커밋이라 vacuum 불가 → stale 윈도우 확정)한 상태에서 3자 일치, 5회 반복 안정.
- **결정적 증거**: 병렬 filtered-index 스캔의 **btree 레벨 자체가 stale 엔트리를 제외한 행수**를 반환(예: 40000 중 4000 이탈 시 covering 병렬 카운트 = 36000, 40000 아님). covering 스캔은 힙에서 필터 컬럼을 재검사할 수 없으므로, 이는 엔트리 레벨 MVCC pre-filter가 유일한 필터링 주체임을 증명한다. 트레이스로 `parallel workers: N ... gather: buildvalue` 확인.

회귀 TC(자기검증 PARALLEL vs NO_PARALLEL_SCAN, `<=>` 비교 → PASS/FAIL; autocommit off로 stale 엔트리 확정 재현)는 Jira 이슈에 첨부되어 있다.