### PR TITLE
[CBRD-25717] Handle missing tfile_vfid for query result cache when collecting list-file sectors

### DIFF
--- a/src/query/list_file.c
+++ b/src/query/list_file.c
@@ -3797,8 +3797,9 @@ sector_page_iterator::get_next_page (THREAD_ENTRY * thread_p, QFILE_LIST_SECTOR_
 	      break;		/* current sector exhausted — fall through to next-sector fetch */
 	    }
 
+	  /* tfile may be NULL for a cached list file (query result cache):
+	   * these are disk pages read by VPID, and qmgr_get_old_page/qmgr_free_old_page tolerate a NULL tfile. */
 	  QMGR_TEMP_FILE *tfile = (QMGR_TEMP_FILE *) tfiles[m_sector_index];
-	  assert (tfile != NULL);
 
 	  PAGE_PTR page = qmgr_get_old_page (thread_p, &vpid, tfile);
 	  if (page == NULL)
@@ -7424,14 +7425,14 @@ qfile_collect_list_sector_info (THREAD_ENTRY * thread_p, QFILE_LIST_ID * list_id
 
   assert (thread_p != NULL);
   assert (list_id != NULL);
-  assert (list_id->tfile_vfid != NULL);
   assert (sector_info != NULL);
 
   /* reset sector_info */
   qfile_free_list_sector_info (thread_p, sector_info);
 
-  /* membuf exists only in the first list_id */
-  if (list_id->tfile_vfid->membuf != NULL && list_id->tfile_vfid->membuf_last >= 0)
+  /* membuf exists only in the first list_id;
+   * a cached list file (query result cache) has no tfile_vfid handle, so no membuf. */
+  if (list_id->tfile_vfid != NULL && list_id->tfile_vfid->membuf != NULL && list_id->tfile_vfid->membuf_last >= 0)
     {
       assert (list_id->tfile_vfid->membuf_npages > 0);
       sector_info->membuf_tfile = list_id->tfile_vfid;
@@ -7439,14 +7440,16 @@ qfile_collect_list_sector_info (THREAD_ENTRY * thread_p, QFILE_LIST_ID * list_id
 
   for (current = list_id; current != NULL; current = current->dependent_list_id)
     {
-      assert (current->tfile_vfid != NULL);
+      /* a cached list file has no tfile_vfid handle;
+       * enumerate sectors from the preserved temp_vfid (retired by file_temp_retire_preserved on eviction). */
+      VFID *temp_vfid = (current->tfile_vfid != NULL) ? &current->tfile_vfid->temp_vfid : &current->temp_vfid;
 
-      if (VFID_ISNULL (&current->tfile_vfid->temp_vfid))
+      if (VFID_ISNULL (temp_vfid))
 	{
 	  continue;
 	}
 
-      error = file_get_all_data_sectors (thread_p, &current->tfile_vfid->temp_vfid, &collector);
+      error = file_get_all_data_sectors (thread_p, temp_vfid, &collector);
       if (error != NO_ERROR)
 	{
 	  goto error_exit;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25717

### Purpose

Query Result Cache에서 반환되는 QFILE_LIST_ID는 tfile_vfid가 NULL인데, QFILE_LIST_ID의 Sector 정보 수집 경로가 이를 고려하지 않아 발생하는 문제를 수정한다.

### Implementation

1. **qfile_collect_list_sector_info**
   - membuf 수집 조건에 tfile_vfid != NULL 가드 추가
   - tfile_vfid가 NULL이면 temp_vfid로 sector를 수집하고 assert (tfile_vfid != NULL) 제거
2. **sector_page_iterator::get_next_page**: assert (tfile != NULL) 제거

### Remarks

N/A
