### PR TITLE
[CBRD-27064] Fix CDC log page references across page boundaries

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -11351,6 +11351,7 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 
   log_page_p = (LOG_PAGE *) PTR_ALIGN (log_pgbuf, MAX_ALIGNMENT);
   preserved_log_page_p = (LOG_PAGE *) PTR_ALIGN (preserved_log_pgbuf, MAX_ALIGNMENT);
+  preserved_log_page_p->hdr.logical_pageid = NULL_LOG_PAGEID;
 
   /* Get UNDO RECDES from undo lsa */
 
@@ -12307,6 +12308,12 @@ cdc_get_overflow_recdes (THREAD_ENTRY * thread_p, LOG_PAGE * log_page_p, RECDES 
   int area_offset;
   int error_code = NO_ERROR;
   int length = 0;
+
+  /* log_page_p may not hold lsa's page after parsing advanced across a log page boundary. */
+  if (cdc_check_log_page (thread_p, log_page_p, &lsa) != NO_ERROR)
+    {
+      return ER_FAILED;
+    }
 
   LSA_COPY (&current_lsa, &lsa);
   current_log_page = log_page_p;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27064

### Purpose

CDC가 overflow 레코드를 복원할 때 전달받은 log page가 undo/redo LSA가 가리키는 실제 page와 다를 수 있는 문제를 수정합니다.

로그 레코드 헤더를 읽은 뒤 `LOG_READ_ADD_ALIGN()`이 page boundary를 넘어가면 `log_page_p`는 다음 page로 교체될 수 있습니다. 이때 원본 page가 보존되지 않은 상태에서 초기화되지 않았거나 stale한 보존 버퍼가 선택되면, `cdc_get_overflow_recdes()`가 잘못된 `LOG_RECORD_HEADER`의 `trid`와 `prev_tranlsa`를 읽어 `ER_LOG_PAGE_CORRUPTED`가 발생할 수 있습니다.

hotfix의 변경 범위를 최소화하기 위해 기존 page 선택 및 정렬 로직은 유지하고, overflow 레코드를 읽기 직전에 대상 LSA의 page를 검증합니다.

### Implementation

**`src/transaction/log_manager.c`**

- `cdc_get_recdes()`에서 보존 버퍼의 `logical_pageid`를 `NULL_LOG_PAGEID`로 초기화합니다.
  - 보존된 page가 없는 경우 미초기화된 page ID가 요청 LSA와 우연히 일치하는 것을 방지합니다.
- `cdc_get_overflow_recdes()`에서 첫 `LOG_RECORD_HEADER` 접근 전에 `cdc_check_log_page()`를 호출합니다.
  - 전달된 page와 `lsa.pageid`가 일치하면 기존 page를 그대로 사용합니다.
  - page ID가 다르면 `lsa`가 가리키는 정확한 log page를 fetch합니다.
- `cdc_log_read_advance_and_preserve_if_needed()`, `LOG_READ_ADD_ALIGN()` 및 기존 호출부의 page 선택 로직은 변경하지 않습니다.

### Test

| 검증 시나리오 | 결과 |
| --- | --- |
| 4KB log page에서 비압축 대형 `BIT VARYING` 값을 1,000회 갱신하여 overflow log record가 page boundary에 위치하는 조건 | 1,000건 모두 추출, log page corruption 0건 |
| 동일한 overflow 갱신을 2,000회 반복하는 부하 조건 | 2,000건 모두 추출, log page corruption 0건 |
| MVCC diff와 page 끝에 metadata가 위치하는 조건 | 500건 모두 추출, storage 오류 0건 |
| inline/overflow 저장 방식이 반복 전환되는 조건 | 40건 모두 추출, overflow 레코드 50회 정상 복원 |
| archive log가 생성되는 동안 overflow 값을 1,400회 갱신하는 조건 | 1,400건 모두 추출, log page corruption 0건 |

### Remarks

- CDC API와 wire format 변경은 없습니다.
- 정상 경로에서는 page ID 비교만 수행하며, page가 일치하지 않을 때만 대상 LSA의 page를 다시 fetch합니다.
