### PR TITLE
[CBRD-27069] Gate the remote INSERT SELECT subquery semantic pass to the sink form

### DIFF
--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -12166,13 +12166,21 @@ pt_check_with_info (PARSER_CONTEXT * parser, PT_NODE * node, SEMANTIC_CHK_INFO *
 	      || (node->node_type == PT_UPDATE && node->info.update.spec->info.spec.remote_server_name)
 	      || (node->node_type == PT_MERGE && node->info.merge.into->info.spec.remote_server_name))
 	    {
-	      /* For a remote INSERT SELECT the SELECT subquery runs locally, but the remote DML path
+	      /* For a remote INSERT SELECT in the sink form (local SELECT streamed to the remote
+	       * target; see the qstr gate below) the SELECT subquery runs locally, but the remote DML path
 	       * breaks out of the normal query semantic check below, so the subquery is never processed
 	       * as a stand-alone query. Run the same steps a top-level SELECT receives
 	       * (pt_resolve_names -> pt_check_where -> pt_mark_union_leaf_nodes -> pt_semantic_check_local)
 	       * so its WHERE / GROUP BY / HAVING / ORDER BY / LIMIT / expressions / aggregates / UNION are
 	       * handled; otherwise ORDER BY raises a "generate order_by" system error, LIMIT is ignored, etc. */
-	      if (node->node_type == PT_INSERT)
+	      /* Sink form only (DML text not serialized, qstr == NULL): the SELECT subquery runs
+	       * locally, so it needs the local semantic pass below. The full-pushdown form
+	       * (qstr set) ships the whole statement to the remote server, where it is parsed
+	       * and type-checked; the local pass would fail on remote columns whose types are
+	       * unknown locally. */
+	      if (node->node_type == PT_INSERT
+		  && node->info.insert.spec->info.spec.remote_server_name->node_type == PT_DBLINK_TABLE_DML
+		  && node->info.insert.spec->info.spec.remote_server_name->info.dblink_table.qstr == NULL)
 		{
 		  PT_NODE *subq = pt_get_subquery_of_insert_select (node);
 		  if (subq != NULL)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27069

### Purpose

원격 테이블만 참조하는 `INSERT ... SELECT`(full-pushdown 형태)에서 SELECT 리스트나 WHERE에 연산자 표현식이 있으면 컴파일이 타입 에러로 실패한다:

```sql
insert into l@srv1 select a+10, b from r@srv1;
-- ERROR: '+' operator is not defined on types unknown data type and integer.
```

#7261(CBRD-26796)이 sink 형태(로컬 SELECT를 원격 대상으로 스트리밍)의 SELECT 서브쿼리를 로컬에서 semantic 검사하도록 `pt_check_with_info`에 추가한 처리가, 문장 전체를 원격으로 보내는 기존 full-pushdown 형태까지 구분 없이 적용된 회귀다. 푸시다운 문장의 원격 컬럼은 로컬에 타입이 없으므로(이름만 결속) 연산자 평가가 실패한다. #7261 직전 커밋에서는 정상 동작함을 빌드 대조로 확인했다.

### Implementation

- `pt_check_with_info`의 서브쿼리 semantic 처리 진입 조건에 sink 판별 2항을 추가했다: 대상 spec의 `remote_server_name`이 `PT_DBLINK_TABLE_DML`이고 `dblink_table.qstr == NULL`일 때만 수행한다.
- 판별자는 기존 산출물을 재사용한 것이다 — `pt_convert_dblink_dml_query`가 푸시다운이면 직렬화한 DML 원문을 `qstr`에 설정하고 sink면 설정하지 않는다. 즉 `qstr == NULL`이 sink다.
- 푸시다운 형태는 #7261 이전의 계약(원격 DML은 로컬 semantic 검사를 건너뛰고, 원격 서버가 전송된 원문을 파싱·타입해석)으로 복귀한다. sink 형태의 처리는 그대로 유지된다.

### Remarks

- 영향 범위는 원격 대상 INSERT의 컴파일 단계뿐이다. UPDATE/DELETE/MERGE 푸시다운은 이 처리를 원래 타지 않아 영향이 없고, 단독 SELECT의 `@server` 참조는 파생 테이블로 변환되는 별개 경로다.
- 검증: 재현 해소(산술·WHERE 비교 각각 원격 반영 확인), bare column 회귀 없음, sink의 로컬 semantic 유지(존재하지 않는 컬럼이 여전히 semantic 에러로 검출됨), RECOMPILE 힌트·PREPARE/EXECUTE 반복 정상.
- sink 형태의 실행(커밋) 단계 결함은 별도 이슈 CBRD-27061에서 진행 중이며 이 PR과 독립적이다.