### PR TITLE
[CBRD-27059] Fix crash in qo_expr_selectivity on non-PT_EXPR OR-chain nodes

### DIFF
--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -9902,7 +9902,11 @@ qo_expr_selectivity (QO_ENV * env, PT_NODE * pt_expr)
 	  break;
 	}
 
-      if (!not_null_calculated)
+      /* Only PT_EXPR nodes have valid info.expr.arg1/arg2. The or_next chain can also hold
+       * non-expr nodes (e.g. a constant-folded PT_VALUE such as "(299<502 or 299>937)"), whose
+       * info.expr union members are garbage; dereferencing arg1/arg2 on those crashes. A constant
+       * predicate has no column null-fraction to restore, so skipping the correction is correct. */
+      if (!not_null_calculated && PT_IS_EXPR_NODE (node))
 	{
 	  /* the histogram estimators return a NON-null-conditional selectivity; restore the
 	   * all-rows fraction with the CURRENT node's columns. Using the chain head (pt_expr)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27059

## 문제

아래와 같은 쿼리를 컴파일(최적화)하는 도중 `qo_expr_selectivity`에서 `csql`이 SIGSEGV로 비정상 종료됩니다.

```sql
SELECT pk FROM tab0 WHERE (col3 IN (SELECT col0 FROM tab0 WHERE ... AND col0 = 299 ...));
```

11.5.0.2317-af389ac에서 regression으로 보고되었고, 테스트케이스 `bug_bts_6031`의 `slt_good_0/3/9/16`에서 core 4개가 생성되었습니다.

## 근본 원인

`qo_expr_selectivity()`는 term의 `or_next` disjunct 체인을 순회합니다. 함수 계약(`QO_ASSERT (env, pt_expr->node_type == PT_EXPR)`)상 **체인의 head만 `PT_EXPR`임이 보장**되고, `or_next`로 연결된 sibling 노드는 non-expr일 수 있습니다. 예를 들어 `col0 = 299` 등가항 치환(equality-term reduction)으로 상수 폴딩된 `PT_VALUE` `"(299<502 or 299>937)"` 같은 노드가 섞입니다.

CBRD-27039(#7442)에서 null-fraction 보정을 체인 head(`pt_expr`)가 아니라 **현재 노드(`node`)**를 읽도록 변경했습니다.

```c
if (node->info.expr.arg2 && node->info.expr.arg2->node_type == PT_NAME ...)
```

non-`PT_EXPR` sibling에서는 `node->info.expr.arg2`가 `info` union의 엉뚱한 멤버(값, 예: `0x1`)를 읽고, `arg2->node_type`를 역참조하면서 크래시가 발생합니다.

재현한 core를 gdb로 확인: `node->node_type == PT_VALUE`, `pt_expr->node_type == PT_EXPR`, `node->info.expr.arg2 == 0x1` → 주소 `0x1` 접근으로 fault.

참고로 #7442 이전 코드는 head(`pt_expr`, 계약상 항상 `PT_EXPR`)만 읽었기 때문에 **설계상 안전**했습니다. 우연히 회피된 것이 아니라, 계약이 보장되지 않는 sibling의 expr 필드를 만지면서 결함이 새로 생긴 명백한 regression입니다.

## 수정

보정 블록에 `PT_IS_EXPR_NODE (node)` 가드를 추가했습니다. 상수 predicate는 복원할 컬럼 null-fraction이 없으므로 건너뛰는 것이 정확하며, 실제 `PT_EXPR` 노드에 대한 #7442의 노드별 동작은 그대로 유지됩니다(가드가 항상 참).

```c
if (!not_null_calculated && PT_IS_EXPR_NODE (node))
```

## 검증 (debug 빌드)

- A/B (재현 쿼리 + tab0 히스토그램): **#7442 → SIGSEGV**, **fix → 91 rows 정상, core 없음** (pre-#7442 결과와 동일)
- JIRA에서 core가 발생한 4개 파일(`slt_good_0/3/9/16`): fix 빌드에서 전부 무크래시 완주
- `bug_bts_6031` 전체 17개 파일 suite: **core 0개, 크래시 0건, 서버 정상**
- 정합성: 실제 컬럼 predicate의 null-fraction 보정은 그대로 동작 (가드는 `PT_EXPR`에 대해 no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
