### PR TITLE
[CBRD-26403] Adjust the cost formula for correlated subqueries in the optimizer (backporting to 11.4)

### DIFF
--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -638,12 +638,12 @@ qo_plan_compute_cost (QO_PLAN * plan)
   (*(plan->vtbl)->cost_fn) (plan);
 
   /* Now add in the subquery costs; this cost is incurred for each row produced by this plan, so multiply it by the
-   * estimated cardinality and add it to the access cost.
+   * estimated scan_rows and add it to the access cost.
    */
   if (plan->info)
     {
-      plan->variable_cpu_cost += (plan->info)->cardinality * subq_cpu_cost;
-      plan->variable_io_cost += (plan->info)->cardinality * subq_io_cost;
+      plan->variable_cpu_cost += (plan->info)->scan_rows * subq_cpu_cost;
+      plan->variable_io_cost += (plan->info)->scan_rows * subq_io_cost;
     }
 }
 
@@ -1552,6 +1552,7 @@ qo_sscan_cost (QO_PLAN * planp)
       planp->variable_cpu_cost = (double) QO_NODE_NCARD (nodep) * (double) QO_CPU_WEIGHT;
     }
   planp->variable_io_cost = (double) QO_NODE_TCARD (nodep);
+  planp->info->scan_rows = MAX (1, QO_NODE_NCARD (nodep));
 }
 
 /*
@@ -2060,6 +2061,7 @@ qo_iscan_cost (QO_PLAN * planp)
   planp->fixed_io_cost = index_IO;
   planp->variable_cpu_cost = (leaf_access + heap_access) * (double) QO_CPU_WEIGHT;
   planp->variable_io_cost = object_IO;
+  planp->info->scan_rows = MAX (1, (double) QO_NODE_NCARD (nodep) * sel * filter_sel);
 }
 
 
@@ -3073,8 +3075,9 @@ qo_nljoin_cost (QO_PLAN * planp)
 	subq_io_cost += temp_io_cost;
       }
 
-    planp->variable_cpu_cost += MAX (0.0, guessed_result_cardinality - 1.0) * subq_cpu_cost;
-    planp->variable_io_cost += MAX (0.0, outer->variable_io_cost - 1.0) * subq_io_cost;	/* assume IO as # blocks */
+    /* subq cost is already included in the inner. so add it for the cardinality excluded due to ISCAN_IO_HIT_RATIO. */
+    planp->variable_cpu_cost += guessed_result_cardinality * ISCAN_IO_HIT_RATIO * subq_cpu_cost;
+    planp->variable_io_cost += guessed_result_cardinality * ISCAN_IO_HIT_RATIO * subq_io_cost;	/* assume IO as # blocks */
   }
 
 #if !defined(NDEBUG) && defined(CUBRID_DEBUG_DUMP_PLAN_COST)
@@ -5355,6 +5358,7 @@ qo_alloc_info (QO_PLANNER * planner, BITSET * nodes, BITSET * terms, BITSET * eq
   qo_compute_projected_segs (planner, nodes, terms, &info->projected_segs);
   info->projected_size = qo_compute_projected_size (planner, &info->projected_segs);
   info->cardinality = cardinality;
+  info->scan_rows = cardinality;	/* after iscan_cost, sscan_cost. it'll be replaced accurately */
 
   qo_init_planvec (&info->best_no_order);
 

--- a/src/optimizer/query_planner.h
+++ b/src/optimizer/query_planner.h
@@ -281,7 +281,8 @@ struct qo_info
    * by plans at this node.
    */
   BITSET projected_segs;
-  double cardinality;
+  double cardinality;		/* Number of rows expected after scanning */
+  double scan_rows;		/* Number of rows required for scanning */
 
   /*
    * One plan for each equivalence class, in each case the best we have


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26403

`develop`(11.5)의 옵티마이저 수정을 `release/11.4`로 백포트합니다.

`383e59f3e` (`[CBRD-26403] Adjust the cost formula for correlated subqueries in the optimizer`) 커밋의 cherry-pick 입니다.

### 변경 내용
상관 서브쿼리(correlated subquery)의 비용을 **스캔 후 산출된 행 수**가 아니라 **스캔에 필요한 행 수** 기준으로 계산하도록 코스트 공식을 조정합니다.

- as-is : 서브쿼리 비용 * 스캔 **후** 예상되는 행 수 (`cardinality`)
- to-be : 서브쿼리 비용 * 스캔에 **필요한** 행 수 (`scan_rows`)

`qo_info`에 `scan_rows` 필드를 추가하고, `qo_alloc_info`에서 `cardinality`로 초기화한 뒤 `qo_sscan_cost` / `qo_iscan_cost`에서 실제 스캔 행 수로 대체합니다. `qo_plan_compute_cost`와 `qo_nljoin_cost`는 서브쿼리 비용 곱셈 인자로 이 값을 사용합니다.

### 백포트 참고 사항
- `qo_sscan_cost` / `qo_iscan_cost`에서 충돌이 발생했는데, 원인은 11.4에 `#if TEST_DUMP_PLAN_SCAN_COST` 블록이 존재하지 않아 문맥이 일치하지 않았기 때문입니다. 11.4에 없는 블록은 반영하지 않고 `scan_rows` 대입 라인만 추가하여 해소했습니다.
- 검증: `query_planner.c`가 `cubridcs`, `cubridsa` 양쪽 모두 정상 컴파일됨을 확인했습니다.
