### PR TITLE
[CBRD-27027] Hotfix develop build break: AU_ENABLE was removed by the CBRD-26823 macro refactor

### DIFF
--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -4628,7 +4628,7 @@ do_update_histogram (PARSER_CONTEXT * parser, PT_NODE * statement)
   if (error != NO_ERROR)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_AU_ALTER_FAILURE, 0);
-      AU_ENABLE (save);
+      AU_RESTORE (save);
       return error;
     }
   error = au_check_class_authorization (obj, AU_SELECT);
@@ -4636,7 +4636,7 @@ do_update_histogram (PARSER_CONTEXT * parser, PT_NODE * statement)
     {
       PT_ERRORmf2 (parser, cls, MSGCAT_SET_PARSER_RUNTIME, MSGCAT_RUNTIME_IS_NOT_AUTHORIZED_ON,
 		   "SELECT", db_get_class_name (obj));
-      AU_ENABLE (save);
+      AU_RESTORE (save);
       return error;
     }
 
@@ -4688,7 +4688,7 @@ do_drop_histogram (PARSER_CONTEXT * parser, PT_NODE * statement)
   if (error != NO_ERROR)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_AU_ALTER_FAILURE, 0);
-      AU_ENABLE (save);
+      AU_RESTORE (save);
       return error;
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27027

## 문제

develop 빌드가 실패합니다:

```
src/query/execute_schema.c:4631:7: error: 'AU_ENABLE' was not declared in this scope
```

## 원인

CBRD-26936 스쿼시 머지(f7432203)와 CBRD-26823 권한 매크로 리팩토링(ac720de3, `AU_ENABLE` 삭제)이 서로 다른 라인을 수정해 **텍스트 충돌 없이** 각각 develop에 들어갔습니다. git이 잡을 수 없는 시맨틱 충돌로, `do_update_histogram ()` / `do_drop_histogram ()`의 에러 경로 3곳이 삭제된 `AU_ENABLE (save)`를 호출합니다.

## 수정

3곳을 `AU_RESTORE (save)`로 교체 — 같은 함수의 다른 모든 exit 경로와 동일한 패턴이며, `AU_SAVE_AND_DISABLE (save)`로 저장한 상태의 복원이라 의미도 동일합니다.

## 검증

- repo 전체에 `AU_ENABLE` 잔존 0건 (grep)
- debug 전체 빌드(ninja) 에러 0건 통과
