### PR TITLE
[CBRD-27075] Fix CDC timestamp lookup on continuation-only log pages

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -14713,6 +14713,33 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
   process_lsa.pageid = log_pgptr->hdr.logical_pageid;
   process_lsa.offset = log_pgptr->hdr.offset;
 
+  /*
+   * The first page of an active or archive log volume may contain only the continuation data of a log record
+   * that started in the previous volume. In that case, the page has no log record header and hdr.offset is
+   * NULL_OFFSET. Skip such pages before interpreting page data as LOG_RECORD_HEADER.
+   */
+  while (process_lsa.offset == NULL_OFFSET)
+    {
+      LOG_LSA nxio_lsa = log_Gl.append.get_nxio_lsa ();
+
+      cdc_log ("%s : skip continuation-only log page %lld", __func__, (long long int) process_lsa.pageid);
+      process_lsa.pageid++;
+      if (process_lsa.pageid >= nxio_lsa.pageid)
+	{
+	  ctime_r (time, ctime_buf);
+	  er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_CDC_LSA_NOT_FOUND, 1, ctime_buf);
+	  return ER_CDC_LSA_NOT_FOUND;
+	}
+
+      if ((error_code = logpb_fetch_page (thread_p, &process_lsa, LOG_CS_SAFE_READER, log_pgptr)) != NO_ERROR)
+	{
+	  return error_code;
+	}
+
+      process_lsa.pageid = log_pgptr->hdr.logical_pageid;
+      process_lsa.offset = log_pgptr->hdr.offset;
+    }
+
   while (!LSA_ISNULL (&process_lsa))
     {
       LSA_COPY (&cur_log_lsa, &process_lsa);	// save the current log record lsa

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -337,7 +337,8 @@ static int cdc_find_user (THREAD_ENTRY * thread_p, LOG_LSA lsa, int trid, char *
 static int cdc_compare_undoredo_dbvalue (const db_value * new_value, const db_value * old_value);
 static int cdc_put_value_to_loginfo (db_value * new_value, char **ptr);
 
-static int cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * ret_lsa, time_t * time);
+static int cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * ret_lsa, time_t * time,
+					  bool * is_found);
 static int cdc_get_lsa_with_start_point (THREAD_ENTRY * thread_p, time_t * time, LOG_LSA * start_lsa);
 
 static bool cdc_is_filtered_class (OID classoid);
@@ -14205,6 +14206,9 @@ cdc_find_lsa (THREAD_ENTRY * thread_p, time_t * extraction_time, LOG_LSA * start
 
   LOG_LSA ret_lsa = LSA_INITIALIZER;
   bool is_found = false;
+  bool active_start_point_found = false;
+  bool archive_start_point_found = false;
+  bool current_start_point_found = false;
 
   char input_time_buf[CTIME_MAX];
   char output_time_buf[CTIME_MAX];
@@ -14218,15 +14222,15 @@ cdc_find_lsa (THREAD_ENTRY * thread_p, time_t * extraction_time, LOG_LSA * start
    */
 
   /* At first, compare the time in active log volume. */
-  error = cdc_get_start_point_from_file (thread_p, -1, &ret_lsa, &active_start_time);
-  if (error == ER_FAILED || error == ER_LOG_READ)
+  error = cdc_get_start_point_from_file (thread_p, -1, &ret_lsa, &active_start_time, &active_start_point_found);
+  if (error != NO_ERROR)
     {
       goto end;
     }
   else
     {
       /* NO ERROR */
-      if (active_start_time != 0 && active_start_time <= *extraction_time)
+      if (active_start_point_found && active_start_time <= *extraction_time)
 	{
 	  // active
 	  error = cdc_get_lsa_with_start_point (thread_p, extraction_time, &ret_lsa);
@@ -14258,11 +14262,18 @@ cdc_find_lsa (THREAD_ENTRY * thread_p, time_t * extraction_time, LOG_LSA * start
 	      /* travers from the latest */
 	      for (int i = end; i > begin; i--)
 		{
-		  error = cdc_get_start_point_from_file (thread_p, i, &ret_lsa, &archive_start_time);
+		  error = cdc_get_start_point_from_file (thread_p, i, &ret_lsa, &archive_start_time,
+							 &current_start_point_found);
 		  if (error != NO_ERROR)
 		    {
 		      goto end;
 		    }
+		  if (!current_start_point_found)
+		    {
+		      continue;
+		    }
+
+		  archive_start_point_found = true;
 
 		  if (archive_start_time <= *extraction_time)
 		    {
@@ -14273,9 +14284,24 @@ cdc_find_lsa (THREAD_ENTRY * thread_p, time_t * extraction_time, LOG_LSA * start
 
 	      if (target_arv_num == -1)
 		{
-		  /* returns oldest LSA */
-		  LSA_COPY (start_lsa, &ret_lsa);
-		  *extraction_time = archive_start_time;
+		  if (archive_start_point_found)
+		    {
+		      /* returns oldest LSA found in the archives */
+		      LSA_COPY (start_lsa, &ret_lsa);
+		      *extraction_time = archive_start_time;
+		    }
+		  else if (active_start_point_found)
+		    {
+		      /* no archive contains time information; returns the oldest LSA in the active log */
+		      LSA_COPY (start_lsa, &ret_lsa);
+		      *extraction_time = active_start_time;
+		    }
+		  else
+		    {
+		      /* no time information has been found in any log volume; returns the latest log */
+		      LSA_COPY (start_lsa, &log_Gl.append.prev_lsa);
+		      *extraction_time = time (NULL);
+		    }
 		  is_found = true;
 
 		  ctime_r (&input_time, input_time_buf);
@@ -14308,7 +14334,7 @@ cdc_find_lsa (THREAD_ENTRY * thread_p, time_t * extraction_time, LOG_LSA * start
 	    {
 	      /* num_arvs == 0, and active_start_time > input time 
 	       * returns oldest LSA in active log volume */
-	      if (active_start_time != 0)
+	      if (active_start_point_found)
 		{
 		  *extraction_time = active_start_time;
 		  LSA_COPY (start_lsa, &ret_lsa);
@@ -14596,11 +14622,13 @@ end:
 /*
  * arv_num (in) : archive log volume number to traverse. If it is -1, then traverse active log volume. 
  * ret_lsa (out) : lsa of the first log which contains time info 
- * time (out) : time of the first log which contains time info  
+ * time (out) : time of the first log which contains time info
+ * is_found (out) : true if the specified log volume contains a log with time info
+ * return : error code; a volume without time info returns NO_ERROR with is_found set to false
  */
 
 static int
-cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * ret_lsa, time_t * time)
+cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * ret_lsa, time_t * time, bool * is_found)
 {
   char arv_name[PATH_MAX];
   LOG_ARV_HEADER *arv_hdr;
@@ -14618,6 +14646,7 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
   LOG_LSA process_lsa = LSA_INITIALIZER;
   LOG_LSA forw_lsa = LSA_INITIALIZER;
   LOG_LSA cur_log_lsa = LSA_INITIALIZER;
+  LOG_PAGEID archive_end_pageid = NULL_PAGEID;
 
   LOG_RECORD_HEADER *log_rec_header;
   LOG_RECTYPE log_type;
@@ -14626,6 +14655,7 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
 
   aligned_log_pgbuf = PTR_ALIGN (log_pgbuf, MAX_ALIGNMENT);
   log_pgptr = (LOG_PAGE *) aligned_log_pgbuf;
+  *is_found = false;
   LOG_CS_ENTER_READ_MODE (thread_p);
 
   if (arv_num == -1)
@@ -14642,6 +14672,7 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
 	  /* if target archive log volume is currenty mounted, then use that */
 	  process_lsa.pageid = log_Gl.archive.hdr.fpageid;
 	  process_lsa.offset = 0;
+	  archive_end_pageid = log_Gl.archive.hdr.fpageid + log_Gl.archive.hdr.npages;
 	}
       else
 	{
@@ -14683,6 +14714,7 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
 
 		  process_lsa.pageid = arv_hdr->fpageid;
 		  process_lsa.offset = 0;
+		  archive_end_pageid = arv_hdr->fpageid + arv_hdr->npages;
 
 		  fileio_dismount (thread_p, vdes);
 		}
@@ -14705,6 +14737,8 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
       return ER_CDC_LSA_NOT_FOUND;
     }
 
+  assert (arv_num == -1 || archive_end_pageid != NULL_PAGEID);
+
   if ((error_code = logpb_fetch_page (thread_p, &process_lsa, LOG_CS_SAFE_READER, log_pgptr)) != NO_ERROR)
     {
       return error_code;
@@ -14720,15 +14754,14 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
    */
   while (process_lsa.offset == NULL_OFFSET)
     {
-      LOG_LSA nxio_lsa = log_Gl.append.get_nxio_lsa ();
+      LOG_PAGEID end_pageid = (arv_num == -1) ? log_Gl.append.get_nxio_lsa ().pageid : archive_end_pageid;
 
       cdc_log ("%s : skip continuation-only log page %lld", __func__, (long long int) process_lsa.pageid);
       process_lsa.pageid++;
-      if (process_lsa.pageid >= nxio_lsa.pageid)
+      if (process_lsa.pageid >= end_pageid)
 	{
-	  ctime_r (time, ctime_buf);
-	  er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_CDC_LSA_NOT_FOUND, 1, ctime_buf);
-	  return ER_CDC_LSA_NOT_FOUND;
+	  /* Reaching the end of one volume is not an error. The caller continues with an older archive. */
+	  return NO_ERROR;
 	}
 
       if ((error_code = logpb_fetch_page (thread_p, &process_lsa, LOG_CS_SAFE_READER, log_pgptr)) != NO_ERROR)
@@ -14757,6 +14790,7 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
 
 	  LSA_COPY (ret_lsa, &cur_log_lsa);
 	  *time = donetime->at_time;
+	  *is_found = true;
 
 	  return NO_ERROR;
 	}
@@ -14768,7 +14802,14 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
 
 	  LSA_COPY (ret_lsa, &cur_log_lsa);
 	  *time = dummy->at_time;
+	  *is_found = true;
 
+	  return NO_ERROR;
+	}
+
+      if (arv_num != -1 && !LSA_ISNULL (&forw_lsa) && forw_lsa.pageid >= archive_end_pageid)
+	{
+	  /* The next log record starts in a newer archive. The caller continues with an older archive. */
 	  return NO_ERROR;
 	}
 
@@ -14776,6 +14817,11 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
 	{
 	  if (LSA_ISNULL (&forw_lsa))
 	    {
+	      if (arv_num != -1)
+		{
+		  return NO_ERROR;
+		}
+
 	      ctime_r (time, ctime_buf);
 	      er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_CDC_LSA_NOT_FOUND, 1, ctime_buf);
 
@@ -14791,9 +14837,13 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
       LSA_COPY (&process_lsa, &forw_lsa);
     }
 
+  if (arv_num != -1)
+    {
+      return NO_ERROR;
+    }
+
   ctime_r (time, ctime_buf);
   er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_CDC_LSA_NOT_FOUND, 1, ctime_buf);
-
   return ER_CDC_LSA_NOT_FOUND;
 }
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27075>

### Purpose

CDC 또는 Flashback이 시간 기준으로 시작 LSA를 찾을 때, archive/active log volume의 첫 page가 이전 page에서 시작된 log record의 continuation data만 포함할 수 있다.

이 page에는 새로운 `LOG_RECORD_HEADER`가 없으므로 `LOG_PAGE_HEADER::offset`이 `NULL_OFFSET`이다. 기존 `cdc_get_start_point_from_file()`은 이를 확인하지 않고 page data를 `LOG_RECORD_HEADER`로 해석하여, payload 일부를 `forw_lsa.pageid`로 사용할 수 있었다.

그 결과 비정상적인 logical page ID를 `logpb_fetch_page()`에 전달하면서 `ER_LOG_PAGE_CORRUPTED`가 기록되고, 시간 기반 LSA 조회가 빈 응답으로 끝날 수 있다.

### Implementation

**`src/transaction/log_manager.c` — `cdc_get_start_point_from_file()`**

- log volume의 첫 page를 fetch한 직후 `hdr.offset`을 확인한다.
- `hdr.offset == NULL_OFFSET`이면 해당 page를 continuation-only page로 판단하고, 실제 log record header가 시작되는 다음 page까지 이동한다.
- page를 이동할 때마다 `logical_pageid`와 `offset`을 새 page header 기준으로 갱신한다.
- 탐색 중 `NXIO` 경계에 도달하면 page data를 잘못 해석하지 않고 `ER_CDC_LSA_NOT_FOUND`를 반환한다.
- 기존 log record 순회 로직은 유효한 header offset을 확보한 뒤에만 시작한다.

정상적인 시작 page에서는 기존 경로를 그대로 사용하며 추가 page fetch는 발생하지 않는다.

### Test

4KB log page와 작은 active log volume을 사용하고, 압축되지 않는 20,000 byte `BIT VARYING` 값을 반복 갱신하여 log record가 여러 page 및 archive volume 경계를 넘도록 했다. 동시에 시간 기반 LSA 조회를 60회 반복했다.

| 검증 항목 | 수정 전 | 수정 후 |
|---|---:|---:|
| UPDATE 완료 수 | 3,000 | 3,000 |
| 시간 기반 LSA 조회 성공 | 50 / 60 | 60 / 60 |
| 빈 응답 | 10 | 0 |
| `cdc_get_start_point_from_file()` 오류 stack | 10 | 0 |
| log page corruption 메시지 | 10 | 0 |
| 서버 생존 | 정상 | 정상 |

추가로 `cdc_logging_debug` 비활성화, archive 무제한 보관, 조회 대상 table에 committed row가 존재하는 조건에서도 조회 60회가 모두 정상 완료되고 storage 오류가 발생하지 않는 것을 확인했다.

### Remarks

- 이 문제는 archive 삭제 경쟁이 아니라 log volume 시작 page가 continuation-only 상태일 때 발생한다.
- CDC API 및 wire format 변경은 없다.
- 정상 page에서는 `NULL_OFFSET` 비교만 추가되며, continuation-only page일 때만 다음 page를 fetch한다.
