### PR TITLE
[CBRD-27076] Fix CDC temp log page buffers mistaking page id 0 for a cached page

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -11707,8 +11707,11 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 		/*if LOG_MVCC_UNDOREDO_DATA_DIFF , get undo data first and get diff */
 		if (is_diff)
 		  {
-		    char temp_buf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT] = "\0";
+		    char temp_buf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
 		    LOG_PAGE *temp_pgptr = (LOG_PAGE *) PTR_ALIGN (temp_buf, MAX_ALIGNMENT);
+
+		    /* page id 0 is a valid data page; an empty buffer must not match any requested page */
+		    temp_pgptr->hdr.logical_pageid = NULL_LOG_PAGEID;
 
 		    scan_code = cdc_get_undo_record (thread_p, temp_pgptr, *redo_lsa, &tmp_undo_recdes);
 		    if (scan_code != S_SUCCESS)
@@ -11926,8 +11929,11 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 		/*if LOG_MVCC_UNDOREDO_DATA_DIFF , get undo data first and get diff */
 		if (is_diff)
 		  {
-		    char temp_buf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT] = "\0";
+		    char temp_buf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
 		    LOG_PAGE *temp_pgptr = (LOG_PAGE *) PTR_ALIGN (temp_buf, MAX_ALIGNMENT);
+
+		    /* page id 0 is a valid data page; an empty buffer must not match any requested page */
+		    temp_pgptr->hdr.logical_pageid = NULL_LOG_PAGEID;
 
 		    scan_code = cdc_get_undo_record (thread_p, temp_pgptr, *redo_lsa, &tmp_undo_recdes);
 		    if (scan_code != S_SUCCESS)
@@ -15034,6 +15040,10 @@ cdc_initialize ()
     (LOG_PAGE *) PTR_ALIGN (cdc_Gl.producer.temp_logbuf[0].log_page, MAX_ALIGNMENT);
   cdc_Gl.producer.temp_logbuf[1].log_page_p =
     (LOG_PAGE *) PTR_ALIGN (cdc_Gl.producer.temp_logbuf[1].log_page, MAX_ALIGNMENT);
+
+  /* page id 0 is a valid data page; invalidate the temp log buffers so the first access always fetches */
+  cdc_Gl.producer.temp_logbuf[0].log_page_p->hdr.logical_pageid = NULL_LOG_PAGEID;
+  cdc_Gl.producer.temp_logbuf[1].log_page_p->hdr.logical_pageid = NULL_LOG_PAGEID;
 
   /*communication buffer from server to client initialization */
   cdc_Gl.consumer.log_info = NULL;

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -11319,8 +11319,8 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
   LOG_RECORD_HEADER *log_rec_hdr = NULL;
   int tmpbuf_index;
 
-  char *log_pgbuf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
-  char *preserved_log_pgbuf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
+  char log_pgbuf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
+  char preserved_log_pgbuf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
   LOG_PAGE *log_page_p = NULL;	// log_page for process_lsa : when process_lsa is advanced, then next log_page can be fetched into this buffer
   LOG_PAGE *preserved_log_page_p = NULL;	// log_page for redo/undo lsa
 
@@ -14461,7 +14461,7 @@ cdc_validate_lsa (THREAD_ENTRY * thread_p, LOG_LSA * lsa)
 {
   LOG_RECORD_HEADER *log_rec_header;
   LOG_PAGE *log_page_p = NULL;
-  char *log_pgbuf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
+  char log_pgbuf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
 
   LOG_LSA process_lsa;
 
@@ -14788,7 +14788,7 @@ cdc_get_lsa_with_start_point (THREAD_ENTRY * thread_p, time_t * time, LOG_LSA * 
   LOG_LSA current_lsa;
 
   LOG_PAGE *log_page_p = NULL;
-  char *log_pgbuf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
+  char log_pgbuf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT];
 
   LOG_RECORD_HEADER *log_rec_header;
   LOG_RECTYPE log_type;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27076>

### Purpose

CDC는 log page buffer의 `hdr.logical_pageid`와 요청 LSA의 page ID를 비교하여 필요한 page가 이미 적재되어 있는지 판단한다.

기존 로컬 임시 buffer와 전역 producer temp log buffer는 사용 전에 `logical_pageid`를 명시적으로 무효화하지 않아 초기값 0을 가질 수 있었다. page ID 0은 유효한 첫 log data page이므로, 최초 요청이 page 0이면 비어 있는 buffer를 이미 적재된 page로 오인하여 실제 page fetch를 생략할 수 있다.

이 경우 초기화된 메모리를 log record로 해석하여 diff undo/redo 복원 실패, CDC entry 생성 실패 또는 producer 정체가 발생할 수 있다.

### Implementation

**`src/transaction/log_manager.c` — `cdc_get_recdes()`**

- `LOG_MVCC_DIFF_UNDOREDO_DATA` 및 `LOG_DIFF_UNDOREDO_DATA` 처리에 사용하는 로컬 임시 `LOG_PAGE`의 `logical_pageid`를 `NULL_LOG_PAGEID`로 초기화한다.
- 전체 buffer를 0으로 채우는 방식 대신 cache 판정에 사용되는 page ID를 명시적으로 무효화한다.

**`src/transaction/log_manager.c` — `cdc_initialize()`**

- producer가 사용하는 전역 temp log buffer 2개의 `logical_pageid`를 `NULL_LOG_PAGEID`로 초기화한다.
- 최초 접근에서는 요청 page와 일치하지 않으므로 실제 log page를 fetch한다.

page ID 0 자체를 예외 처리하지 않는다. 실제 page 0이 적재된 이후에는 정상적인 cache hit로 재사용할 수 있다.

### Test

page ID가 초기값 0과 일치하는 조건을 제어된 방식으로 주입하여 로컬 diff buffer와 전역 producer temp buffer 경로를 각각 확인했다.

| 검증 경로 | 수정 전 | 수정 후 |
|---|---|---|
| 로컬 diff undo 복원 buffer | 초기값 0을 cache hit로 오인, 추출 실패 | sentinel `NULL_LOG_PAGEID(-1)` 확인, 추출 정상 |
| 전역 producer temp buffer | 초기값 0을 cache hit로 오인, DML 0건 | sentinel `NULL_LOG_PAGEID(-1)` 확인, 실제 page fetch |
| CDC DML 추출 | 실패 | INSERT 1 / UPDATE 1 / DELETE 1 |
| 서버 상태 | 생존하지만 추출 실패 | 정상 생존 및 extraction LSA 진행 |

수정 후 로컬 buffer에서는 잘못된 page ID 일치가 발생하지 않았고, 전역 buffer에서도 최초 접근 시 무효 sentinel이 유지된 뒤 정상적으로 DML을 추출하는 것을 확인했다.

### Remarks

- `NULL_LOG_PAGEID`는 미적재 buffer의 sentinel로만 사용한다.
- 실제 page 0을 fetch한 이후의 cache 재사용 동작은 변경하지 않는다.
- CDC API 및 wire format 변경은 없다.
- `cdc_get_recdes()`를 공유하는 Flashback 경로에도 동일한 초기화가 적용된다.

**추가 변경 — CDC log page buffer 선언 정정 (page-0 sentinel 수정과 별개 사안)**

- `cdc_get_recdes()`, `cdc_validate_lsa()`, `cdc_get_lsa_with_start_point()`의 로그 페이지 버퍼가 `char *log_pgbuf[IO_MAX_PAGE_SIZE + MAX_ALIGNMENT]`(포인터 배열)로 잘못 선언되어, 의도한 바이트 버퍼(약 16KB)의 약 8배(원소 1B→8B) 스택을 차지하고 있었다.
- `PTR_ALIGN` 후 `LOG_PAGE`로 사용하는 raw 바이트 버퍼이므로 `char log_pgbuf[...]`가 맞다. 각 선언에서 `*`만 제거했다(4곳: `cdc_get_recdes()`의 `log_pgbuf`/`preserved_log_pgbuf` 포함).
- 정확성 버그는 아니나(과할당이라 우연히 동작) 깊은 CDC 호출 경로에서 스택을 불필요하게 잠식하는 잠복 결함이다.
- 정렬은 기존 `PTR_ALIGN` + `+ MAX_ALIGNMENT` 슬랙이 그대로 담당하므로 동작 변경은 없다.
- page-0 sentinel 수정과는 별개이나, 동일 파일·동일 CDC 로그 페이지 버퍼를 다루므로 본 PR에 함께 포함한다.
