### PR TITLE
[CBRD-27077] Fix CDC crash when shrinking overflow records

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -648,7 +648,8 @@ static DISK_ISVALID heap_hfid_isvalid (HFID * hfid);
 static DISK_ISVALID heap_scanrange_isvalid (HEAP_SCANRANGE * scan_range);
 #endif /* CUBRID_DEBUG */
 static OID *heap_ovf_insert (THREAD_ENTRY * thread_p, const HFID * hfid, OID * ovf_oid, RECDES * recdes);
-static const OID *heap_ovf_update (THREAD_ENTRY * thread_p, const HFID * hfid, const OID * ovf_oid, RECDES * recdes);
+static const OID *heap_ovf_update (THREAD_ENTRY * thread_p, const HFID * hfid, const OID * ovf_oid, RECDES * recdes,
+				   LOG_LSA * change_link_lsa);
 static int heap_ovf_flush (THREAD_ENTRY * thread_p, const OID * ovf_oid);
 static int heap_ovf_get_length (THREAD_ENTRY * thread_p, const OID * ovf_oid);
 static SCAN_CODE heap_ovf_get (THREAD_ENTRY * thread_p, const OID * ovf_oid, RECDES * recdes, int chn,
@@ -6578,11 +6579,13 @@ heap_ovf_insert (THREAD_ENTRY * thread_p, const HFID * hfid, OID * ovf_oid, RECD
  *   hfid(in): Object heap file identifier
  *   ovf_oid(in): Overflow address
  *   recdes(in): Record descriptor
+ *   change_link_lsa(out): LSA used to reconstruct the updated overflow record
  *
  * Note: Update the content of a multipage object.
  */
 static const OID *
-heap_ovf_update (THREAD_ENTRY * thread_p, const HFID * hfid, const OID * ovf_oid, RECDES * recdes)
+heap_ovf_update (THREAD_ENTRY * thread_p, const HFID * hfid, const OID * ovf_oid, RECDES * recdes,
+		 LOG_LSA * change_link_lsa)
 {
   VFID ovf_vfid;
   VPID ovf_vpid;
@@ -6595,7 +6598,7 @@ heap_ovf_update (THREAD_ENTRY * thread_p, const HFID * hfid, const OID * ovf_oid
   ovf_vpid.pageid = ovf_oid->pageid;
   ovf_vpid.volid = ovf_oid->volid;
 
-  if (overflow_update (thread_p, &ovf_vfid, &ovf_vpid, recdes, FILE_MULTIPAGE_OBJECT_HEAP) != NO_ERROR)
+  if (overflow_update (thread_p, &ovf_vfid, &ovf_vpid, recdes, FILE_MULTIPAGE_OBJECT_HEAP, change_link_lsa) != NO_ERROR)
     {
       ASSERT_ERROR ();
       return NULL;
@@ -22102,6 +22105,7 @@ heap_update_bigone (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context, b
   bool is_old_home_updated;
   RECDES new_home_recdes;
   VFID ovf_vfid;
+  LOG_LSA change_link_lsa = LSA_INITIALIZER;
 
   LOG_TDES *tdes = NULL;
 
@@ -22182,22 +22186,25 @@ heap_update_bigone (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context, b
       /* overflow -> overflow update */
       is_old_home_updated = false;
 
-      if (heap_ovf_update (thread_p, &context->hfid, &context->ovf_oid, context->recdes_p) == NULL)
+      if (heap_ovf_update (thread_p, &context->hfid, &context->ovf_oid, context->recdes_p,
+			   context->do_supplemental_log ? &change_link_lsa : NULL) == NULL)
 	{
 	  ASSERT_ERROR_AND_SET (error_code);
 	  goto exit;
 	}
 
-      /* supplemental log for REC_BIGONE to REC_BIGONE case 
+      /* supplemental log for REC_BIGONE to REC_BIGONE case
        * 1. MVCC : redo lsa for SUPPLEMENT_UPDATE, undo lsa has been saved above
        * 2. NON-MVCC : undo, redo lsa for SUPPLEMENT_UPDATE */
       if (context->do_supplemental_log)
 	{
-	  LSA_COPY (&context->supp_redo_lsa, &tdes->tail_lsa);
+	  assert (!LSA_ISNULL (&change_link_lsa));
+	  /* Page deallocation may append LOG_POSTPONE records, so do not use the transaction tail LSA here. */
+	  LSA_COPY (&context->supp_redo_lsa, &change_link_lsa);
 
 	  if (!is_mvcc_op)
 	    {
-	      LSA_COPY (&context->supp_undo_lsa, &tdes->tail_lsa);
+	      LSA_COPY (&context->supp_undo_lsa, &change_link_lsa);
 	    }
 	}
 

--- a/src/storage/overflow_file.c
+++ b/src/storage/overflow_file.c
@@ -363,6 +363,7 @@ exit_on_error:
  * ovf_vpid (in)  : VPID of first page in multi-page data
  * recdes (in)    : New multi-page data
  * file_type (in) : Overflow file type
+ * change_link_lsa (out) : LSA of the overflow link-change log record
  *
  * Note: The function may allocate or deallocate several overflow pages if the multipage data increase/decrease in
  *       length.
@@ -372,7 +373,7 @@ exit_on_error:
  */
 int
 overflow_update (THREAD_ENTRY * thread_p, const VFID * ovf_vfid, const VPID * ovf_vpid, RECDES * recdes,
-		 FILE_TYPE file_type)
+		 FILE_TYPE file_type, LOG_LSA * change_link_lsa)
 {
   OVERFLOW_FIRST_PART *first_part = NULL;
   OVERFLOW_REST_PART *rest_parts = NULL;
@@ -391,6 +392,11 @@ overflow_update (THREAD_ENTRY * thread_p, const VFID * ovf_vfid, const VPID * ov
   int error_code = NO_ERROR;
 
   assert (ovf_vfid != NULL && !VFID_ISNULL (ovf_vfid));
+
+  if (change_link_lsa != NULL)
+    {
+      LSA_SET_NULL (change_link_lsa);
+    }
 
   /* used only for heap for now... I left this here just in case other file types start using this.
    * If you hit this assert, check the code is alright for your usage (e.g. this doesn't consider temporary files).
@@ -547,6 +553,12 @@ overflow_update (THREAD_ENTRY * thread_p, const VFID * ovf_vfid, const VPID * ov
 
 	  log_append_undoredo_data (thread_p, RVOVF_CHANGE_LINK, &addr, sizeof (next_vpid), sizeof (next_vpid),
 				    &next_vpid, &tmp_vpid);
+
+	  if (change_link_lsa != NULL)
+	    {
+	      /* Save the CDC reconstruction anchor before file_dealloc() appends unrelated postpone log records. */
+	      LSA_COPY (change_link_lsa, logtb_find_current_tran_lsa (thread_p));
+	    }
 
 	  if (rest_parts == NULL)
 	    {

--- a/src/storage/overflow_file.h
+++ b/src/storage/overflow_file.h
@@ -53,7 +53,7 @@ struct overflow_rest_part
 extern int overflow_insert (THREAD_ENTRY * thread_p, const VFID * ovf_vfid, VPID * ovf_vpid, RECDES * recdes,
 			    FILE_TYPE file_type);
 extern int overflow_update (THREAD_ENTRY * thread_p, const VFID * ovf_vfid, const VPID * ovf_vpid, RECDES * recdes,
-			    FILE_TYPE file_type);
+			    FILE_TYPE file_type, LOG_LSA * change_link_lsa);
 extern const VPID *overflow_delete (THREAD_ENTRY * thread_p, const VFID * ovf_vfid, const VPID * ovf_vpid);
 extern void overflow_flush (THREAD_ENTRY * thread_p, const VPID * ovf_vpid);
 extern int overflow_get_length (THREAD_ENTRY * thread_p, const VPID * ovf_vpid);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -12121,6 +12121,15 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 	}
     }
 
+  /* A supplemental DML LSA must always reconstruct the requested row image. */
+  if ((undo_lsa != NULL && (undo_recdes == NULL || undo_recdes->data == NULL))
+      || (redo_lsa != NULL && (redo_recdes == NULL || redo_recdes->data == NULL)))
+    {
+      cdc_log ("cdc_get_recdes : failed to reconstruct record descriptor from supplemental log LSA");
+      error_code = ER_FAILED;
+      goto error;
+    }
+
   if (redo_data != NULL && is_redo_alloced)
     {
       free_and_init (redo_data);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27077>

### Purpose

`REC_BIGONE` overflow record의 크기를 줄이는 UPDATE에서 남는 overflow page가 반납되면, CDC가 UPDATE를 추출하지 못하고 서버가 비정상 종료하는 문제를 수정한다.

`overflow_update()`는 마지막 row-image 관련 log인 `RVOVF_CHANGE_LINK`를 기록한 뒤, 남는 page를 `file_dealloc()`으로 반납한다. 이 과정에서 page 반납용 `LOG_POSTPONE/RVFL_DEALLOC`이 transaction의 마지막 log가 된다.

기존 `heap_update_bigone()`은 overflow update 완료 후 `tdes->tail_lsa`를 supplemental redo LSA로 저장하므로, CDC가 row image가 아닌 page 반납 log를 redo LSA로 전달받을 수 있었다. `cdc_get_recdes()`는 `LOG_POSTPONE`을 처리하지 않고 빈 `RECDES`를 성공으로 반환했고, 이후 schema 확인 과정에서 `or_rep_id()` assertion이 발생했다.

### Implementation

**`src/storage/overflow_file.c`, `src/storage/overflow_file.h` — `overflow_update()`**

- `RVOVF_CHANGE_LINK`를 append한 직후 해당 LSA를 선택적으로 반환한다.
- `file_dealloc()`이 `LOG_POSTPONE`을 추가하기 전에 CDC record 복원에 필요한 anchor를 보존한다.
- 출력 LSA는 사용 전에 `NULL_LSA`로 초기화한다.

**`src/storage/heap_file.c` — `heap_ovf_update()`, `heap_update_bigone()`**

- 보존한 `RVOVF_CHANGE_LINK` LSA를 overflow update 호출 경로를 통해 전달한다.
- MVCC update에서는 기존 full undo LSA를 유지하고, supplemental redo LSA만 보존한 change-link LSA로 설정한다.
- non-MVCC update에서는 동일 overflow log chain에서 두 image를 복원할 수 있도록 supplemental undo/redo LSA 모두 change-link LSA로 설정한다.
- page 반납 이후의 transaction tail LSA는 supplemental row-image LSA로 사용하지 않는다.

**`src/transaction/log_manager.c` — `cdc_get_recdes()`**

- 요청된 undo 또는 redo LSA에서 row image를 생성하지 못한 경우 빈 `RECDES`를 성공으로 반환하지 않는다.
- 부분적으로 생성된 descriptor는 기존 error cleanup 경로에서 정리하고 `ER_FAILED`를 반환한다.

### Test

`supplemental_log=1`, `enable_string_compression=no` 환경에서 `VARCHAR(60000)` overflow record를 약 3개 page에서 약 2개 page로 축소했다.

```sql
CREATE TABLE t_cdc_ovf_shrink
(
  id INT PRIMARY KEY,
  c VARCHAR(60000)
);

INSERT INTO t_cdc_ovf_shrink
VALUES (1, RPAD('a', 40000, 'a'));

UPDATE t_cdc_ovf_shrink
SET c = RPAD('b', 20000, 'b')
WHERE id = 1;
```

DML 수행 전 시각부터 CDC 추출을 시작하여 다음 결과를 확인했다.

| 검증 항목 | 결과 |
|---|---:|
| INSERT 추출 | 1건 |
| UPDATE 추출 | 1건 |
| UPDATE 변경 컬럼 길이 | 20,000 byte |
| CDC client return code | 정상 |
| 서버 PID 변경 | 없음 |
| 신규 crash dump | 0건 |

일반 row에 대한 CDC 회귀 확인에서도 INSERT 3건, UPDATE 3건, DELETE 3건이 모두 추출되었다.

### Remarks

- `LOG_POSTPONE/RVFL_DEALLOC` payload는 row after-image가 아니라 page 반납 정보이므로 redo data로 해석하지 않는다.
- 유효한 supplemental redo LSA 보존이 기능 수정이며, 빈 `RECDES` 검증은 잘못된 LSA가 전달될 경우의 방어선이다.
- CDC API 및 wire format 변경은 없다.
