### PR TITLE
[CBRD-27081] Fix CDC wrong log page reference when restoring overflow old images

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -12187,6 +12187,14 @@ cdc_get_ovfdata_from_log (THREAD_ENTRY * thread_p, LOG_PAGE * log_page_p,
 
   cdc_log ("cdc_get_ovfdata_from_log : process_lsa:(%lld | %d), recovery index:%d, is_redo:%d",
 	   LSA_AS_ARGS (process_lsa), rcvindex, is_redo);
+
+  /* log_page_p may not hold process_lsa's page; e.g. the LOG_DUMMY_OVF_RECORD branch of cdc_get_overflow_recdes ()
+   * passes prev_tranlsa, which can point to a record on another log page. */
+  if (cdc_check_log_page (thread_p, log_page_p, process_lsa) != NO_ERROR)
+    {
+      return ER_FAILED;
+    }
+
   LOG_READ_ADD_ALIGN (thread_p, DB_SIZEOF (LOG_RECORD_HEADER), process_lsa, log_page_p);
 
   if (is_redo)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27081>

### Purpose

CDC가 overflow 레코드의 old image를 undo 로그 체인에서 복원할 때, `cdc_get_overflow_recdes()`의 `LOG_DUMMY_OVF_RECORD` 분기는 dummy 레코드의 `prev_tranlsa`(first part before-image undo의 주소)를 `cdc_get_ovfdata_from_log()`에 넘기면서 로그 페이지 버퍼를 재적재하지 않고 곧바로 `break` 한다. 피호출 함수도 진입부에서 버퍼에 적재된 페이지와 요청 LSA의 일치 여부를 검증하지 않으므로, 두 레코드가 서로 다른 로그 페이지에 있으면 잘못된 페이지의 바이트를 undo record로 해석한다.

`overflow_update()`는 first part before-image undo(최대 `DB_PAGESIZE`)를 기록한 직후 dummy를 기록하므로, 압축되지 않는 데이터에서는 dummy와 prev가 사실상 항상 다른 로그 페이지에 놓여 오독이 결정적으로 발생한다.

이 분기는 supplemental undo LSA가 RVOVF 체인을 가리키는 non-MVCC in-place bigone 갱신에서만 도달하며, 사용자가 트리거할 수 있는 대표 경로는 스키마 변경 후 `cubrid compactdb`의 인스턴스 재작성이다. 오독된 레코드는 재조립 검증(CBRD-27077)에 걸려 producer가 동일 extraction LSA를 무한 재시도하고, 해당 지점 이후로 CDC 추출이 영구 정체된다. 해당 검증이 없는 코드에서는 old image가 비거나 오염된 이벤트가 조용히 전달된다.

### Implementation

`cdc_get_ovfdata_from_log()` 진입부에서 버퍼와 요청 LSA의 로그 페이지 일치를 검증하고, 불일치 시 요청 페이지를 재적재한다. CBRD-27064가 `cdc_get_overflow_recdes()` 진입부에 적용한 것과 동일한 패턴이며, 버퍼가 이미 요청 페이지를 담고 있는 기존 정상 호출 경로에서는 추가 페이지 조회가 발생하지 않는다.

**`src/transaction/log_manager.c` — `cdc_get_ovfdata_from_log`**

```diff
   cdc_log ("cdc_get_ovfdata_from_log : process_lsa:(%lld | %d), recovery index:%d, is_redo:%d",
 	   LSA_AS_ARGS (process_lsa), rcvindex, is_redo);
+
+  /* log_page_p may not hold process_lsa's page; e.g. the LOG_DUMMY_OVF_RECORD branch of cdc_get_overflow_recdes ()
+   * passes prev_tranlsa, which can point to a record on another log page. */
+  if (cdc_check_log_page (thread_p, log_page_p, process_lsa) != NO_ERROR)
+    {
+      return ER_FAILED;
+    }
+
   LOG_READ_ADD_ALIGN (thread_p, DB_SIZEOF (LOG_RECORD_HEADER), process_lsa, log_page_p);
```

### Test

수정 전/후 빌드에서 동일 시나리오를 실행하고, gdb 관측(fault-injection 없음)으로 dummy 분기 도달과 페이지 불일치 여부를 함께 확인하였다.

| 케이스 | 수정 전 | 수정 후 |
|---|---|---|
| 압축되지 않는 랜덤 40KB overflow 행 2건 INSERT 후 ALTER ADD COLUMN + `compactdb -S`로 in-place 재작성, 해당 구간 CDC 추출 | dummy 분기에서 버퍼/LSA 페이지 불일치 오독(관측 114회, 유효하지 않은 length), 동일 LSA 무한 재시도로 추출 영구 정체, 이벤트 0건 | 진입 검증이 불일치 2회를 교정, INSERT 3건 + UPDATE 2건 전부 추출, 재시도/정체 없음 |
| 일반 행 INSERT/UPDATE/DELETE 베이스라인 캡처 | - | 3/3/3 정상 |
| 반복 문자열 40KB overflow 행 UPDATE의 old image 무결성 (같은 tx in-place 및 MVCC 경로) | - | old image 40000B 원본 일치 (2/2), 페이지 일치 경로에서 추가 조회 없음 |

### Remarks

도달 경로 전수 분석(일반 SQL DML/HA 복제 적용은 MVCC 경로라 미도달)과 재현 과정에서 관측된 별개 문제는 JIRA 이슈 본문에 정리되어 있다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
