### PR TITLE
[CBRD-27082] Fix remaining CDC memory leaks and resource ownership errors

### DIFF
--- a/src/api/cubrid_log.c
+++ b/src/api/cubrid_log.c
@@ -1706,6 +1706,8 @@ cubrid_log_error:
   return err_code;
 }
 
+static int cubrid_log_clear_data_item (DATA_ITEM_TYPE data_item_type, CUBRID_DATA_ITEM * data_item);
+
 static int
 cubrid_log_make_log_item_list (int num_infos, int total_length, CUBRID_LOG_ITEM ** log_item_list, int *list_size)
 {
@@ -1757,8 +1759,16 @@ cubrid_log_make_log_item_list (int num_infos, int total_length, CUBRID_LOG_ITEM 
 
   for (i = 0; i < num_infos; i++)
     {
-      if ((rc = cubrid_log_make_log_item (&ptr, &g_log_items[i]) != CUBRID_LOG_SUCCESS))
+      if ((rc = cubrid_log_make_log_item (&ptr, &g_log_items[i])) != CUBRID_LOG_SUCCESS)
 	{
+	  int j;
+
+	  for (j = 0; j < i; j++)
+	    {
+	      (void) cubrid_log_clear_data_item ((DATA_ITEM_TYPE) g_log_items[j].data_item_type,
+						 &g_log_items[j].data_item);
+	    }
+
 	  CUBRID_LOG_ERROR_HANDLING (rc, NULL);
 	}
 

--- a/src/api/cubrid_log.c
+++ b/src/api/cubrid_log.c
@@ -2059,8 +2059,7 @@ cubrid_log_reset_globals (void)
 
   if (g_log_infos != NULL)
     {
-//      free (g_log_infos);
-      g_log_infos = NULL;
+      free_and_init (g_log_infos);
     }
 
   g_log_infos_size = 0;

--- a/src/api/cubrid_log.c
+++ b/src/api/cubrid_log.c
@@ -1370,6 +1370,13 @@ cubrid_log_make_dml (char **data_info, DML * dml)
 
   ptr = *data_info;
 
+  dml->changed_column_index = NULL;
+  dml->changed_column_data = NULL;
+  dml->changed_column_data_len = NULL;
+  dml->cond_column_index = NULL;
+  dml->cond_column_data = NULL;
+  dml->cond_column_data_len = NULL;
+
   ptr = or_unpack_int (ptr, &dml->dml_type);
   ptr = or_unpack_int64 (ptr, (INT64 *) & dml->classoid);
   ptr = or_unpack_int (ptr, &dml->num_changed_column);
@@ -1586,6 +1593,13 @@ cubrid_log_make_dml (char **data_info, DML * dml)
   return CUBRID_LOG_SUCCESS;
 
 cubrid_log_error:
+
+  free_and_init (dml->changed_column_index);
+  free_and_init (dml->changed_column_data);
+  free_and_init (dml->changed_column_data_len);
+  free_and_init (dml->cond_column_index);
+  free_and_init (dml->cond_column_data);
+  free_and_init (dml->cond_column_data_len);
 
   return err_code;
 }

--- a/src/api/cubrid_log.c
+++ b/src/api/cubrid_log.c
@@ -500,6 +500,8 @@ cubrid_log_set_all_in_cond (int retrieve_all)
 int
 cubrid_log_set_extraction_table (uint64_t * classoid_arr, int arr_size)
 {
+  uint64_t *new_extraction_table = NULL;
+
   if (g_stage != CUBRID_LOG_STAGE_CONFIGURATION)
     {
       return CUBRID_LOG_INVALID_FUNC_CALL_STAGE;
@@ -510,13 +512,19 @@ cubrid_log_set_extraction_table (uint64_t * classoid_arr, int arr_size)
       return CUBRID_LOG_INVALID_CLASSOID_ARR_SIZE;
     }
 
-  g_extraction_table = (uint64_t *) malloc (sizeof (uint64_t) * arr_size);
-  if (g_extraction_table == NULL)
+  if (arr_size > 0)
     {
-      return CUBRID_LOG_FAILED_MALLOC;
+      new_extraction_table = (uint64_t *) malloc (sizeof (uint64_t) * arr_size);
+      if (new_extraction_table == NULL)
+	{
+	  return CUBRID_LOG_FAILED_MALLOC;
+	}
+
+      memcpy (new_extraction_table, classoid_arr, arr_size * sizeof (uint64_t));
     }
 
-  memcpy (g_extraction_table, classoid_arr, arr_size * sizeof (uint64_t));
+  free_and_init (g_extraction_table);
+  g_extraction_table = new_extraction_table;
   g_extraction_table_count = arr_size;
 
   return CUBRID_LOG_SUCCESS;
@@ -552,24 +560,36 @@ cubrid_log_set_extraction_user (char **user_arr, int arr_size)
 	}
     }
 
-  new_extraction_user = (char **) malloc (sizeof (char *) * arr_size);
-  if (new_extraction_user == NULL)
+  if (arr_size > 0)
     {
-      return CUBRID_LOG_FAILED_MALLOC;
-    }
-
-  for (i = 0; i < arr_size; i++)
-    {
-      new_extraction_user[i] = strdup (user_arr[i]);
-      if (new_extraction_user[i] == NULL)
+      new_extraction_user = (char **) malloc (sizeof (char *) * arr_size);
+      if (new_extraction_user == NULL)
 	{
-	  for (j = 0; j < i; j++)
-	    {
-	      free_and_init (new_extraction_user[j]);
-	    }
-	  free_and_init (new_extraction_user);
 	  return CUBRID_LOG_FAILED_MALLOC;
 	}
+
+      for (i = 0; i < arr_size; i++)
+	{
+	  new_extraction_user[i] = strdup (user_arr[i]);
+	  if (new_extraction_user[i] == NULL)
+	    {
+	      for (j = 0; j < i; j++)
+		{
+		  free_and_init (new_extraction_user[j]);
+		}
+	      free_and_init (new_extraction_user);
+	      return CUBRID_LOG_FAILED_MALLOC;
+	    }
+	}
+    }
+
+  if (g_extraction_user != NULL)
+    {
+      for (i = 0; i < g_extraction_user_count; i++)
+	{
+	  free_and_init (g_extraction_user[i]);
+	}
+      free_and_init (g_extraction_user);
     }
 
   g_extraction_user = new_extraction_user;

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -3523,6 +3523,7 @@ end:
   RESET_HOST_VARIABLES_IF_INTERNAL_STATEMENT (parser);
 
   do_free_reserved_classinfo (reserved_cls_info);
+  free_and_init (reserved_oid);
 
   if (error == ER_FAILED)
     {
@@ -4211,6 +4212,7 @@ end:
   RESET_HOST_VARIABLES_IF_INTERNAL_STATEMENT (parser);
 
   do_free_reserved_classinfo (reserved_cls_info);
+  free_and_init (reserved_oid);
 
   return ((err == ER_FAILED && (err = er_errid ()) == NO_ERROR) ? ER_GENERIC_ERROR : err);
 }				/* do_execute_statement() */
@@ -16138,7 +16140,7 @@ end:
       free (host_val);
     }
 
-  if (oid != NULL)
+  if (oid != NULL && oid != reserved_oid)
     {
       free_and_init (oid);
     }

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -14616,8 +14616,11 @@ cdc_reinitialize_queue (LOG_LSA * start_lsa)
 	    {
 	      free_and_init (consume->log_info);
 	    }
+
+	  free_and_init (consume);
 	}
 
+      LSA_COPY (&cdc_Gl.first_loginfo_queue_lsa, &next_consume_lsa);
       cdc_Gl.producer.produced_queue_size -= cdc_Gl.consumer.consumed_queue_size;
       cdc_Gl.consumer.consumed_queue_size = 0;
     }
@@ -14633,6 +14636,8 @@ cdc_reinitialize_queue (LOG_LSA * start_lsa)
 	    {
 	      free_and_init (consume->log_info);
 	    }
+
+	  free_and_init (consume);
 	}
       cdc_Gl.producer.produced_queue_size = 0;
       cdc_Gl.consumer.consumed_queue_size = 0;

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -11011,11 +11011,6 @@ cdc_log_extract (THREAD_ENTRY * thread_p, LOG_LSA * process_lsa, CDC_LOGINFO_ENT
     }
 
 end:
-  if (supp_recdes.data != NULL)
-    {
-      free_and_init (supp_recdes.data);
-    }
-
   if (supplement_data != NULL)
     {
       free_and_init (supplement_data);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -11011,6 +11011,11 @@ cdc_log_extract (THREAD_ENTRY * thread_p, LOG_LSA * process_lsa, CDC_LOGINFO_ENT
     }
 
 end:
+  if (supp_recdes.data != NULL)
+    {
+      free_and_init (supp_recdes.data);
+    }
+
   if (supplement_data != NULL)
     {
       free_and_init (supplement_data);
@@ -11031,6 +11036,11 @@ end:
   return error;
 
 error:
+  if (supp_recdes.data != NULL)
+    {
+      free_and_init (supp_recdes.data);
+    }
+
   if (supplement_data != NULL)
     {
       free_and_init (supplement_data);

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -11189,6 +11189,9 @@ cdc_loginfo_producer_execute (cubthread::entry & thread_ref)
 		 LSA_AS_ARGS (&process_lsa));
 
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (CDC_LOGINFO_ENTRY));
+	      free_and_init (log_info_entry.log_info);
+	      LSA_COPY (&process_lsa, &cur_log_rec_lsa);
+	      thread_sleep (50);
 	      error = ER_OUT_OF_VIRTUAL_MEMORY;
 	      continue;
 	    }

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -11265,8 +11265,16 @@ cdc_get_undo_record (THREAD_ENTRY * thread_p, LOG_PAGE * log_page_p, LOG_LSA lsa
     {
       if (scan_code == S_DOESNT_FIT)
 	{
-	  undo_recdes->data = (char *) realloc (undo_recdes->data, (size_t) (-undo_recdes->length));	//realloc error 처리
-	  undo_recdes->area_size = (size_t) (-undo_recdes->length);
+	  size_t required_size = (size_t) (-undo_recdes->length);
+	  char *new_data = (char *) realloc (undo_recdes->data, required_size);
+	  if (new_data == NULL)
+	    {
+	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, required_size);
+	      return S_ERROR;
+	    }
+
+	  undo_recdes->data = new_data;
+	  undo_recdes->area_size = required_size;
 
 	  if (cdc_check_log_page (thread_p, log_page_p, &lsa) != NO_ERROR)
 	    {

--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -11942,8 +11942,6 @@ cdc_get_recdes (THREAD_ENTRY * thread_p, LOG_LSA * undo_lsa, RECDES * undo_recde
 	      }
 	    else if (rcvindex == RVHF_UPDATE)
 	      {
-		RECDES tmp_undo_recdes = RECDES_INITIALIZER;
-
 		if (ZIP_CHECK (undo_length))
 		  {
 		    undo_length = (int) GET_ZIP_LEN (undo_length);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27082

### Purpose

CDC client/server의 반복 처리 및 오류 경로에서 할당된 메모리가 해제되지 않고 누적되는 문제를 수정한다.

확인된 문제는 extraction filter 교체, client finalize/reconnect, queue 재초기화와 같은 반복 운영 경로뿐 아니라,
supplemental record 복원, multi-item decode, queue wrapper 생성, undo buffer 확장 및 DROP SERIAL 처리 중 allocation이
실패하는 경로에도 분산되어 있었다.

각 경로에서 allocation owner와 cleanup 책임이 일관되지 않아 기존 allocation, 부분 생성 객체 또는 이미 생성된
CDC payload가 남을 수 있었다. 일부 producer 오류 경로에서는 메모리 누수와 함께 CDC event 유실 또는 LSA 진행
불일치 가능성도 있었다.

### Implementation

**`src/api/cubrid_log.c` — filter 및 client lifecycle ownership**

- extraction table/user filter는 replacement allocation을 먼저 완료한 뒤 기존 filter를 해제하고 교체한다.
- 빈 filter 설정은 `malloc(0)` 결과에 의존하지 않고 기존 filter를 정상적으로 초기화한다.
- `cubrid_log_finalize()`에서 `g_log_infos` receive buffer를 실제로 해제한다.
- DML decode가 중간에 실패하면 현재 item의 부분 allocation과 앞서 완성된 item의 동적 배열을 모두 정리한다.
- `cubrid_log_make_log_item()`의 실제 오류 코드가 유지되도록 조건식의 대입 우선순위를 바로잡는다.

**`src/transaction/log_manager.c` — queue, producer 및 undo record ownership**

- queue를 부분 또는 전체 재초기화할 때 payload와 `CDC_LOGINFO_ENTRY` node를 함께 해제한다.
- 부분 queue trim 이후 `first_loginfo_queue_lsa`가 첫 번째 live entry를 가리키도록 갱신한다.
- supplemental record payload allocation 실패 시 `supp_recdes.data`를 error cleanup 경로에서 해제한다.
- queue wrapper allocation이 실패하면 이미 생성된 payload를 해제하고 현재 LSA를 복원하여 동일 event를 재시도한다.
- undo buffer 확장 시 `realloc()` 결과를 임시 포인터로 받은 뒤 성공한 경우에만 기존 포인터를 교체한다.
- non-MVCC `RVHF_UPDATE` 복원 경로의 branch-local `tmp_undo_recdes` shadowing을 제거하여 공통 cleanup이 적용되게 한다.

**`src/query/execute_statement.c` — DROP SERIAL reserved OID ownership**

- `reserved_oid`의 소유권을 이를 생성한 statement executor에 유지한다.
- `do_statement()`과 `do_execute_statement()`의 공통 종료 경로에서 `reserved_oid`를 해제한다.
- `do_supplemental_statement()`은 자신이 직접 할당한 OID만 해제하여 alias에 대한 double-free를 방지한다.

### Remarks

각 항목은 수정 전 동일 경로에서 누수를 재현한 뒤, 수정 후 같은 반복 횟수 또는 같은 allocation 실패 조건으로
재검증했다.

| 항목 | 수정 전 | 수정 후 |
|---|---|---|
| extraction user/table filter 200회 교체 | definite `6,480,768 bytes`, indirect `487,152 bytes` | definite/indirect `0 bytes` |
| abrupt client reconnect 20회에 따른 queue 재초기화 | live node `19` | allocated/freed `38,636/38,636`, live `0` |
| supplemental payload allocation 실패 100회 | live undo buffer `102,400 bytes` | cleanup `100/100`, final live `0 bytes` |
| client extract/finalize lifecycle 20회 | definite `4,261,104 bytes` | definite/indirect `0 bytes` |
| 두 번째 DML item decode 실패 | 이전/현재 item live allocation `4` | live allocation `0` |
| 첫 번째 DML item 내부 allocation 실패 | partial live allocation `1` | live allocation `0` |
| queue wrapper allocation 실패 50회 | live payload `90,864 bytes` | live payload `0 bytes`, extraction 정상 재개 |
| 5,474-byte undo buffer 확장 실패 | 기존 buffer `1,024 bytes` 유실 | final live `0 bytes`, extraction 정상 재개 |
| `supplemental_log=1` + DROP SERIAL 실패 | definite `8 bytes` | definite/indirect `0 bytes`; 정상 DROP도 확인 |
| relocation UPDATE workload의 non-MVCC `RVHF_UPDATE` | 64 allocations, live `162,772 bytes` | allocation/free `32/32`, final live `0 bytes` |