### PR TITLE
[CBRD-27084] flush 대기 스레드 wake 이후 page buffer waiter_exists 미정리로 페이지 fix 무한 스핀(hang) 발생

### DIFF
--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -6266,6 +6266,21 @@ pgbuf_latch_bcb_upon_fix (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr, PGBUF_LAT
 
   *is_latch_wait = false;
   holder = pgbuf_find_thrd_holder (thread_p, bufptr);
+#if defined (SERVER_MODE)
+  /* fail-closed safety net: an idle bcb (PGBUF_NO_LATCH) with an EMPTY wait queue must never carry
+   * waiter_exists == true; the idle-grant CAS below force-expects waiter_exists == false and the idle path never
+   * blocks, so a stale bit would spin this thread forever while it holds the bcb mutex. all waiter_exists
+   * transitions are bcb-mutex-protected and we hold the mutex here, so the check is race-free. heal and flag. */
+  PGBUF_ATOMIC_LATCH_IMPL impl_snapshot = get_impl (&bufptr->atomic_latch);
+  if (impl_snapshot.impl.latch_mode == PGBUF_NO_LATCH && impl_snapshot.impl.waiter_exists
+      && bufptr->next_wait_thrd == NULL)
+    {
+      assert (false);		/* diag builds: catch any future leak at its first victim */
+      er_log_debug (ARG_FILE_LINE, "pgbuf_latch_bcb_upon_fix: healed stranded waiter_exists on idle bcb %d|%d\n",
+		    VPID_AS_ARGS (&bufptr->vpid));
+      set_waiter_exists (&bufptr->atomic_latch, false);
+    }
+#endif /* SERVER_MODE */
 // *INDENT-OFF*
   do
     {
@@ -7057,6 +7072,12 @@ pgbuf_block_bcb (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr, PGBUF_LATCH_MODE r
 		    }
 
 		  thrd_entry->next_wait_thrd = NULL;
+		  /* self-removed from the wait queue on interrupt: reconcile waiter_exists (see
+		   * pgbuf_wake_flush_waiters). */
+		  if (!pgbuf_is_exist_blocked_reader_writer (bufptr))
+		    {
+		      set_waiter_exists (&bufptr->atomic_latch, false);
+		    }
 		  PGBUF_BCB_UNLOCK (bufptr);
 		  return ER_FAILED;
 		}
@@ -10919,6 +10940,16 @@ pgbuf_wake_flush_waiters (THREAD_ENTRY * thread_p, PGBUF_BCB * bcb)
 	{
 	  prev_waiter = crt_waiter;
 	}
+    }
+  /* every PGBUF_LATCH_FLUSH waiter was dequeued above. reconcile the atomic-latch waiter_exists bit exactly as
+   * pgbuf_wakeup_reader_writer does on the unlatch path: if no blocked reader/writer remains queued, clear it.
+   * leaving it set on a bcb that is (or goes) idle poisons pgbuf_latch_bcb_upon_fix's idle-grant CAS, which
+   * force-expects waiter_exists == false and never enqueues when latch_mode == PGBUF_NO_LATCH -- the next fix
+   * then spins forever while holding the bcb mutex (bulk-build CREATE INDEX livelock). caller holds the bcb
+   * mutex at all callsites, and all waiter_exists transitions are bcb-mutex-protected, so this is race-free. */
+  if (!pgbuf_is_exist_blocked_reader_writer (bcb))
+    {
+      set_waiter_exists (&bcb->atomic_latch, false);
     }
 
   PERF_UTIME_TRACKER_TIME (thread_p, &timetr, PSTAT_PB_WAKE_FLUSH_WAITER);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27084>

### 목적

페이지 버퍼에서 발생하는 서버 hang(livelock)을 수정합니다. flush 대기 스레드가 깨어난 뒤, 실제 대기 스레드가 전혀 없는 BCB에 atomic latch의 `waiter_exists` 비트가 설정된 채로 남을 수 있습니다.

`pgbuf_wake_flush_waiters()`는 모든 `PGBUF_LATCH_FLUSH` 대기 스레드를 dequeue하지만 `waiter_exists`를 해제하지 않습니다. 차단된 reader/writer가 남아 있지 않고 BCB가 idle 상태가 되면, BCB는 `{latch_mode = PGBUF_NO_LATCH, fix_count = 0, wait queue = empty, waiter_exists = 1}` 상태로 고립됩니다. `pgbuf_latch_bcb_upon_fix()`의 idle-grant CAS는 `waiter_exists == false`를 전제로 하며 idle 경로에서는 enqueue하거나 sleep하지 않으므로, 이후 해당 페이지를 fix하려는 스레드는 BCB mutex를 잡은 채 CAS를 100% CPU로 무한 반복합니다. 그 결과 같은 페이지에 접근하는 다른 스레드는 mutex에서 차단되고, `cubrid server stop`도 hang됩니다.

이 문제는 BCB mutex latch를 atomic latch로 교체한 CBRD-26425(#6704)부터 잠재해 있던 결함입니다. 페이지 버퍼보다 훨씬 큰 데이터를 대상으로 장시간 병렬 `CREATE INDEX` 작업을 수행할 때 간헐적으로 재현되었습니다(시도당 약 50~60%).

### 구현

read/write wake 경로인 `pgbuf_wakeup_reader_writer()`는 이미 필요한 불변 조건을 따릅니다. 즉, 대기열에 차단된 reader/writer가 더 이상 없으면 `waiter_exists`를 해제합니다. 이번 변경에서는 이 처리가 누락된 두 flush waiter dequeue 경로에 같은 규칙을 적용했습니다.

- `pgbuf_wake_flush_waiters()`: 모든 `PGBUF_LATCH_FLUSH` 대기 스레드를 dequeue한 뒤, `pgbuf_is_exist_blocked_reader_writer()`가 false이면 `waiter_exists`를 해제합니다.
- `pgbuf_block_bcb()`: flush 대기 스레드가 interrupt를 통해서도 대기열을 벗어날 수 있으므로, interrupt self-dequeue 경로에 동일한 상태 정합화 처리를 적용합니다.

또한 `pgbuf_latch_bcb_upon_fix()`에 fail-closed 안전장치를 추가했습니다(SERVER_MODE 전용). 빈 대기열을 가진 idle BCB에서 `waiter_exists`가 여전히 설정된 상태가 발견되면 debug 빌드에서는 assert하고, 로그를 남긴 뒤 idle-grant CAS에 진입하기 전에 stale 비트를 해제합니다. 이는 주 수정 사항이 아니라, 향후 동일한 누락이 다시 발생하더라도 release 빌드에서 무한 spin으로 이어지는 것을 방지하기 위한 안전장치입니다.

모든 `waiter_exists` 전이는 BCB mutex로 보호되며, 변경된 모든 경로가 해당 mutex를 보유하므로 race가 발생하지 않습니다.

### 비고

검증 결과:

- idle-grant CAS에 진단용 fail-before-fix probe를 추가한 환경에서 정확히 동일한 고립 상태(`NO_LATCH + empty queue + waiter_exists = 1`)가 6회 중 3회 재현되었으며, 매번 동일한 VPID에서 flush waiter dequeue가 선행되었습니다.
- 수정 적용 후 재현용 병렬 `CREATE INDEX` workload는 DWB 활성화 환경에서 6/6회, 비활성화 환경에서 3/3회 정상 완료되었습니다. page-buffer pressure regression은 9/9회, kill/restart sweep은 각각 30/30회 및 9/9회 정상 완료되었고, 각 시도 후 `checkdb`도 통과했습니다.