### PR TITLE
[CBRD-26118] Handle backward-walk overshoot in log_recovery_abort_interrupted_sysop

### DIFF
--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -4054,10 +4054,10 @@ log_recovery_abort_interrupted_sysop (THREAD_ENTRY * thread_p, LOG_TDES * tdes, 
 	{
 	  assert (LSA_LT (&iter_lsa, postpone_start_lsa));
 	  _er_log_debug (ARG_FILE_LINE,
-			"log_recovery_abort_interrupted_sysop: trid=%d walk overshot start-postpone: "
-			"iter_lsa=%lld|%d, postpone_start_lsa=%lld|%d, undo_nxlsa=%lld|%d\n",
-			tdes->trid, LSA_AS_ARGS (&iter_lsa), LSA_AS_ARGS (postpone_start_lsa),
-			LSA_AS_ARGS (&tdes->undo_nxlsa));
+			 "log_recovery_abort_interrupted_sysop: trid=%d walk overshot start-postpone: "
+			 "iter_lsa=%lld|%d, postpone_start_lsa=%lld|%d, undo_nxlsa=%lld|%d\n",
+			 tdes->trid, LSA_AS_ARGS (&iter_lsa), LSA_AS_ARGS (postpone_start_lsa),
+			 LSA_AS_ARGS (&tdes->undo_nxlsa));
 	}
       last_parent_lsa = *postpone_start_lsa;
     }

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -4050,7 +4050,15 @@ log_recovery_abort_interrupted_sysop (THREAD_ENTRY * thread_p, LOG_TDES * tdes, 
   if (LSA_ISNULL (&last_parent_lsa))
     {
       /* no run postpones before system op. stop at start postpone. */
-      assert (LSA_EQ (&iter_lsa, postpone_start_lsa));
+      if (!LSA_EQ (&iter_lsa, postpone_start_lsa))
+	{
+	  assert (LSA_LT (&iter_lsa, postpone_start_lsa));
+	  er_log_debug (ARG_FILE_LINE,
+			"log_recovery_abort_interrupted_sysop: trid=%d walk overshot start-postpone: "
+			"iter_lsa=%lld|%d, postpone_start_lsa=%lld|%d, undo_nxlsa=%lld|%d\n",
+			tdes->trid, LSA_AS_ARGS (&iter_lsa), LSA_AS_ARGS (postpone_start_lsa),
+			LSA_AS_ARGS (&tdes->undo_nxlsa));
+	}
       last_parent_lsa = *postpone_start_lsa;
     }
 

--- a/src/transaction/log_recovery.c
+++ b/src/transaction/log_recovery.c
@@ -4053,7 +4053,7 @@ log_recovery_abort_interrupted_sysop (THREAD_ENTRY * thread_p, LOG_TDES * tdes, 
       if (!LSA_EQ (&iter_lsa, postpone_start_lsa))
 	{
 	  assert (LSA_LT (&iter_lsa, postpone_start_lsa));
-	  er_log_debug (ARG_FILE_LINE,
+	  _er_log_debug (ARG_FILE_LINE,
 			"log_recovery_abort_interrupted_sysop: trid=%d walk overshot start-postpone: "
 			"iter_lsa=%lld|%d, postpone_start_lsa=%lld|%d, undo_nxlsa=%lld|%d\n",
 			tdes->trid, LSA_AS_ARGS (&iter_lsa), LSA_AS_ARGS (postpone_start_lsa),


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26118

During crash recovery, log_recovery_abort_interrupted_sysop() walks the transaction log backward from tdes->undo_nxlsa down to the start-postpone LSA to locate the boundary of an interrupted logical run-postpone system operation. When no run postpone exists in that region, the code asserted that the walk lands exactly on postpone_start_lsa:
    assert (LSA_EQ (&iter_lsa, postpone_start_lsa));
This assumption does not always hold. A completed (non run-postpone) system operation whose sysop_end->lastparent_lsa points before postpone_start_lsa makes the walk jump past the start-postpone boundary, leaving iter_lsa strictly less than postpone_start_lsa. In debug builds the assert aborts the server during restart:
    #4  __assert_fail
    #5  log_recovery_abort_interrupted_sysop  log_recovery.c:4053
    #6  log_recovery_finish_postpone          log_recovery.c:4210
    #7  log_recovery_finish_all_postpone
    #8  log_recovery_redo
    #9  log_recovery
    #10 log_initialize_internal
    #11 boot_restart_server
Clamping to postpone_start_lsa is safe here: reaching this branch means no run postpone was found in the region, so no committed postpone action is discarded, and the postpone phase is re-executed from posp_nxlsa right afterwards.
Release builds already proceeded this way because the assert is compiled out; only assert-enabled (debug) builds crashed.
Relax the strict equality check to accept the overshoot and emit a diagnostic (trid and the relevant LSAs) so the spanning system operation can still be investigated, while keeping the existing fatal guards for genuine log corruption (page fetch failure, trid mismatch) untouched.