### PR TITLE
[CBRD-27075] Fix CDC timestamp lookup on continuation-only log pages (forward-port from 11.4)

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -341,7 +341,8 @@ static int cdc_find_user (THREAD_ENTRY * thread_p, LOG_LSA lsa, int trid, char *
 static int cdc_compare_undoredo_dbvalue (const db_value * new_value, const db_value * old_value);
 static int cdc_put_value_to_loginfo (db_value * new_value, char **ptr);
 
-static int cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * ret_lsa, time_t * time);
+static int cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * ret_lsa, time_t * time,
+					  bool * is_found);
 static int cdc_get_lsa_with_start_point (THREAD_ENTRY * thread_p, time_t * time, LOG_LSA * start_lsa);
 
 static bool cdc_is_filtered_class (OID classoid);
@@ -14205,6 +14206,9 @@ cdc_find_lsa (THREAD_ENTRY * thread_p, time_t * extraction_time, LOG_LSA * start
 
   LOG_LSA ret_lsa = LSA_INITIALIZER;
   bool is_found = false;
+  bool active_start_point_found = false;
+  bool archive_start_point_found = false;
+  bool current_start_point_found = false;
 
   char input_time_buf[CTIME_MAX];
   char output_time_buf[CTIME_MAX];
@@ -14231,15 +14235,15 @@ cdc_find_lsa (THREAD_ENTRY * thread_p, time_t * extraction_time, LOG_LSA * start
    */
 
   /* At first, compare the time in active log volume. */
-  error = cdc_get_start_point_from_file (thread_p, -1, &ret_lsa, &active_start_time);
-  if (error == ER_FAILED || error == ER_LOG_READ)
+  error = cdc_get_start_point_from_file (thread_p, -1, &ret_lsa, &active_start_time, &active_start_point_found);
+  if (error != NO_ERROR)
     {
       goto end;
     }
   else
     {
       /* NO ERROR */
-      if (active_start_time != 0 && active_start_time <= *extraction_time)
+      if (active_start_point_found && active_start_time <= *extraction_time)
 	{
 	  // active
 	  error = cdc_get_lsa_with_start_point (thread_p, extraction_time, &ret_lsa);
@@ -14271,11 +14275,18 @@ cdc_find_lsa (THREAD_ENTRY * thread_p, time_t * extraction_time, LOG_LSA * start
 	      /* travers from the latest */
 	      for (int i = end; i > begin; i--)
 		{
-		  error = cdc_get_start_point_from_file (thread_p, i, &ret_lsa, &archive_start_time);
+		  error = cdc_get_start_point_from_file (thread_p, i, &ret_lsa, &archive_start_time,
+							 &current_start_point_found);
 		  if (error != NO_ERROR)
 		    {
 		      goto end;
 		    }
+		  if (!current_start_point_found)
+		    {
+		      continue;
+		    }
+
+		  archive_start_point_found = true;
 
 		  if (archive_start_time <= *extraction_time)
 		    {
@@ -14286,9 +14297,24 @@ cdc_find_lsa (THREAD_ENTRY * thread_p, time_t * extraction_time, LOG_LSA * start
 
 	      if (target_arv_num == -1)
 		{
-		  /* returns oldest LSA */
-		  LSA_COPY (start_lsa, &ret_lsa);
-		  *extraction_time = archive_start_time;
+		  if (archive_start_point_found)
+		    {
+		      /* returns oldest LSA found in the archives */
+		      LSA_COPY (start_lsa, &ret_lsa);
+		      *extraction_time = archive_start_time;
+		    }
+		  else if (active_start_point_found)
+		    {
+		      /* no archive contains time information; returns the oldest LSA in the active log */
+		      LSA_COPY (start_lsa, &ret_lsa);
+		      *extraction_time = active_start_time;
+		    }
+		  else
+		    {
+		      /* no time information has been found in any log volume; returns the latest log */
+		      LSA_COPY (start_lsa, &log_Gl.append.prev_lsa);
+		      *extraction_time = time (NULL);
+		    }
 		  is_found = true;
 
 		  ctime_r (&input_time, input_time_buf);
@@ -14321,7 +14347,7 @@ cdc_find_lsa (THREAD_ENTRY * thread_p, time_t * extraction_time, LOG_LSA * start
 	    {
 	      /* num_arvs == 0, and active_start_time > input time 
 	       * returns oldest LSA in active log volume */
-	      if (active_start_time != 0)
+	      if (active_start_point_found)
 		{
 		  *extraction_time = active_start_time;
 		  LSA_COPY (start_lsa, &ret_lsa);
@@ -14612,11 +14638,13 @@ end:
 /*
  * arv_num (in) : archive log volume number to traverse. If it is -1, then traverse active log volume. 
  * ret_lsa (out) : lsa of the first log which contains time info 
- * time (out) : time of the first log which contains time info  
+ * time (out) : time of the first log which contains time info
+ * is_found (out) : true if the specified log volume contains a log with time info
+ * return : error code; a volume without time info returns NO_ERROR with is_found set to false
  */
 
 static int
-cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * ret_lsa, time_t * time)
+cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * ret_lsa, time_t * time, bool * is_found)
 {
   char arv_name[PATH_MAX];
   LOG_ARV_HEADER *arv_hdr;
@@ -14634,6 +14662,7 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
   LOG_LSA process_lsa = LSA_INITIALIZER;
   LOG_LSA forw_lsa = LSA_INITIALIZER;
   LOG_LSA cur_log_lsa = LSA_INITIALIZER;
+  LOG_PAGEID archive_end_pageid = NULL_PAGEID;
 
   LOG_RECORD_HEADER *log_rec_header;
   LOG_RECTYPE log_type;
@@ -14642,6 +14671,7 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
 
   aligned_log_pgbuf = PTR_ALIGN (log_pgbuf, MAX_ALIGNMENT);
   log_pgptr = (LOG_PAGE *) aligned_log_pgbuf;
+  *is_found = false;
   LOG_CS_ENTER_READ_MODE (thread_p);
 
   if (arv_num == -1)
@@ -14658,6 +14688,7 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
 	  /* if target archive log volume is currenty mounted, then use that */
 	  process_lsa.pageid = log_Gl.archive.hdr.fpageid;
 	  process_lsa.offset = 0;
+	  archive_end_pageid = log_Gl.archive.hdr.fpageid + log_Gl.archive.hdr.npages;
 	}
       else
 	{
@@ -14699,6 +14730,7 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
 
 		  process_lsa.pageid = arv_hdr->fpageid;
 		  process_lsa.offset = 0;
+		  archive_end_pageid = arv_hdr->fpageid + arv_hdr->npages;
 
 		  fileio_dismount (thread_p, vdes);
 		}
@@ -14721,6 +14753,8 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
       return ER_CDC_LSA_NOT_FOUND;
     }
 
+  assert (arv_num == -1 || archive_end_pageid != NULL_PAGEID);
+
   if ((error_code = logpb_fetch_page (thread_p, &process_lsa, LOG_CS_SAFE_READER, log_pgptr)) != NO_ERROR)
     {
       return error_code;
@@ -14728,6 +14762,32 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
 
   process_lsa.pageid = log_pgptr->hdr.logical_pageid;
   process_lsa.offset = log_pgptr->hdr.offset;
+
+  /*
+   * The first page of an active or archive log volume may contain only the continuation data of a log record
+   * that started in the previous volume. In that case, the page has no log record header and hdr.offset is
+   * NULL_OFFSET. Skip such pages before interpreting page data as LOG_RECORD_HEADER.
+   */
+  while (process_lsa.offset == NULL_OFFSET)
+    {
+      LOG_PAGEID end_pageid = (arv_num == -1) ? log_Gl.append.get_nxio_lsa ().pageid : archive_end_pageid;
+
+      cdc_log ("%s : skip continuation-only log page %lld", __func__, (long long int) process_lsa.pageid);
+      process_lsa.pageid++;
+      if (process_lsa.pageid >= end_pageid)
+	{
+	  /* Reaching the end of one volume is not an error. The caller continues with an older archive. */
+	  return NO_ERROR;
+	}
+
+      if ((error_code = logpb_fetch_page (thread_p, &process_lsa, LOG_CS_SAFE_READER, log_pgptr)) != NO_ERROR)
+	{
+	  return error_code;
+	}
+
+      process_lsa.pageid = log_pgptr->hdr.logical_pageid;
+      process_lsa.offset = log_pgptr->hdr.offset;
+    }
 
   while (!LSA_ISNULL (&process_lsa))
     {
@@ -14746,6 +14806,7 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
 
 	  LSA_COPY (ret_lsa, &cur_log_lsa);
 	  *time = donetime->at_time;
+	  *is_found = true;
 
 	  return NO_ERROR;
 	}
@@ -14757,7 +14818,14 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
 
 	  LSA_COPY (ret_lsa, &cur_log_lsa);
 	  *time = dummy->at_time;
+	  *is_found = true;
 
+	  return NO_ERROR;
+	}
+
+      if (arv_num != -1 && !LSA_ISNULL (&forw_lsa) && forw_lsa.pageid >= archive_end_pageid)
+	{
+	  /* The next log record starts in a newer archive. The caller continues with an older archive. */
 	  return NO_ERROR;
 	}
 
@@ -14765,6 +14833,11 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
 	{
 	  if (LSA_ISNULL (&forw_lsa))
 	    {
+	      if (arv_num != -1)
+		{
+		  return NO_ERROR;
+		}
+
 	      ctime_r (time, ctime_buf);
 	      er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_CDC_LSA_NOT_FOUND, 1, ctime_buf);
 
@@ -14780,9 +14853,13 @@ cdc_get_start_point_from_file (THREAD_ENTRY * thread_p, int arv_num, LOG_LSA * r
       LSA_COPY (&process_lsa, &forw_lsa);
     }
 
+  if (arv_num != -1)
+    {
+      return NO_ERROR;
+    }
+
   ctime_r (time, ctime_buf);
   er_set (ER_NOTIFICATION_SEVERITY, ARG_FILE_LINE, ER_CDC_LSA_NOT_FOUND, 1, ctime_buf);
-
   return ER_CDC_LSA_NOT_FOUND;
 }
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27075>

https://github.com/CUBRID/cubrid/pull/7478

### Purpose

N/A

### Implementation

N/A

### Remarks

N/A
