### PR TITLE
[CBRD-26746] Use histograms for equi-join selectivity and a significance-based MCV admission test

### DIFF
--- a/src/optimizer/histogram/histogram_cl.cpp
+++ b/src/optimizer/histogram/histogram_cl.cpp
@@ -444,6 +444,12 @@ histogram_collect_clear (HISTOGRAM_COLLECT *hc)
 static bool
 histogram_init_reader_from_lhs (PT_NODE *lhs, hist::HistogramReader &reader)
 {
+  if (lhs != NULL && lhs->node_type == PT_DOT_)
+    {
+      /* qualified reference kept as a path chain (t.a): the terminal name node is the resolved
+       * attribute and carries the histogram */
+      lhs = pt_get_end_path_node (lhs);
+    }
   if (lhs == NULL || lhs->node_type != PT_NAME)
     {
       return false;

--- a/src/optimizer/histogram/histogram_cl.cpp
+++ b/src/optimizer/histogram/histogram_cl.cpp
@@ -1103,6 +1103,193 @@ histogram_get_comp_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, bool is_ge
   return;
 }
 
+/*
+ * mcv_join_parts () - match up the two sorted MCV lists for an equijoin.
+ *   matchprodfreq (out): Σ freq1 * freq2 over MCV values present on BOTH sides
+ *   matchfreq1/2 (out) : Σ freq of the matched MCVs on each side
+ *   nmatches (out)     : number of matched MCV values
+ * Both lists are sorted ascending with unique values, so a two-pointer merge finds
+ * every match in O(n1 + n2) (instead of comparing every pair with
+ * a nested loop).
+ */
+template <typename T>
+static void
+mcv_join_parts (const hist::HistogramReader &r1, const hist::HistogramReader &r2,
+		double &matchprodfreq, double &matchfreq1, double &matchfreq2, int &nmatches)
+{
+  const std::uint32_t n1 = static_cast<std::uint32_t> (r1.mcv_count ());
+  const std::uint32_t n2 = static_cast<std::uint32_t> (r2.mcv_count ());
+  std::uint32_t i = 0, j = 0;
+
+  matchprodfreq = 0.0;
+  matchfreq1 = 0.0;
+  matchfreq2 = 0.0;
+  nmatches = 0;
+
+  while (i < n1 && j < n2)
+    {
+      const T v1 = r1.mcv_hi<T> (i);
+      const T v2 = r2.mcv_hi<T> (j);
+      if (v1 == v2)
+	{
+	  const double f1 = r1.mcv_freq (i);
+	  const double f2 = r2.mcv_freq (j);
+	  matchprodfreq += f1 * f2;
+	  matchfreq1 += f1;
+	  matchfreq2 += f2;
+	  nmatches++;
+	  i++;
+	  j++;
+	}
+      else if (v1 < v2)
+	{
+	  i++;
+	}
+      else
+	{
+	  j++;
+	}
+    }
+}
+
+/*
+ * histogram_get_join_selectivity () - equijoin (attr = attr) selectivity from both sides'
+ *   histograms: instead of assuming uniform, fully-overlapping value sets (1/max NDV), the
+ *   estimate is built from the two columns' actual value distributions.
+ *
+ *   Matched MCV pairs contribute their exact frequency product. Unmatched MCVs and the
+ *   non-MCV remainder are assumed to match random members of the other side's non-MCV
+ *   population, spread over its distinct values. The estimate is computed from each
+ *   relation's point of view and the smaller one is used. With no MCVs on either side the
+ *   formula degenerates to the NDV-based estimate:
+ *   (1 - nullfrac1) * (1 - nullfrac2) / max(nd1, nd2).
+ */
+void
+histogram_get_join_selectivity (PT_NODE *lhs, PT_NODE *rhs, double *selectivity, bool *success)
+{
+  assert (selectivity != NULL);
+
+  *success = false;
+
+  hist::HistogramReader reader1, reader2;
+  if (!histogram_init_reader_from_lhs (lhs, reader1) || !histogram_init_reader_from_lhs (rhs, reader2))
+    {
+      return;
+    }
+
+  const hist::histogram_key_kind kind = histogram_key_kind_for_type (reader1.value_type ());
+  if (kind == hist::histogram_key_kind::invalid
+      || kind != histogram_key_kind_for_type (reader2.value_type ()))
+    {
+      /* the two blobs encode their 8B value slots differently (e.g. an INTEGER column joined
+       * to a DOUBLE column); comparing MCVs across kinds would decode one side with the wrong
+       * template. Use default estimates. */
+      return;
+    }
+
+  const double total_rows1 = static_cast<double> (reader1.total_rows ());
+  const double total_rows2 = static_cast<double> (reader2.total_rows ());
+  if (total_rows1 <= 0.0 || total_rows2 <= 0.0)
+    {
+      return;
+    }
+
+  double matchprodfreq = 0.0;
+  double matchfreq1 = 0.0;
+  double matchfreq2 = 0.0;
+  int nmatches = 0;
+
+  switch (kind)
+    {
+    case hist::histogram_key_kind::i64:
+      mcv_join_parts<std::int64_t> (reader1, reader2, matchprodfreq, matchfreq1, matchfreq2, nmatches);
+      break;
+    case hist::histogram_key_kind::dbl:
+      mcv_join_parts<double> (reader1, reader2, matchprodfreq, matchfreq1, matchfreq2, nmatches);
+      break;
+    case hist::histogram_key_kind::str:
+      mcv_join_parts<std::string_view> (reader1, reader2, matchprodfreq, matchfreq1, matchfreq2, nmatches);
+      break;
+    case hist::histogram_key_kind::u64:
+      mcv_join_parts<std::uint64_t> (reader1, reader2, matchprodfreq, matchfreq1, matchfreq2, nmatches);
+      break;
+    case hist::histogram_key_kind::invalid:
+    default:
+      assert (false);
+      return;
+    }
+
+  const double nullfrac1 = reader1.null_frequency ();
+  const double nullfrac2 = reader2.null_frequency ();
+  const int nmcv1 = static_cast<int> (reader1.mcv_count ());
+  const int nmcv2 = static_cast<int> (reader2.mcv_count ());
+  /* per-side distinct count from the same blob the MCV masses came from, so the
+   * (nd - nmcv) and (nd - nmatches) denominators below can never go negative */
+  const double nd1 = static_cast<double> (reader1.nonmcv_distinct ()) + nmcv1;
+  const double nd2 = static_cast<double> (reader2.nonmcv_distinct ()) + nmcv2;
+
+  matchprodfreq = clamp01 (matchprodfreq);
+  matchfreq1 = clamp01 (matchfreq1);
+  matchfreq2 = clamp01 (matchfreq2);
+
+  /* all frequencies are fractions of ALL rows on their own side */
+  const double unmatchfreq1 = clamp01 (reader1.mcv_total_frequency () - matchfreq1);
+  const double unmatchfreq2 = clamp01 (reader2.mcv_total_frequency () - matchfreq2);
+  const double otherfreq1 = clamp01 (1.0 - nullfrac1 - matchfreq1 - unmatchfreq1);
+  const double otherfreq2 = clamp01 (1.0 - nullfrac2 - matchfreq2 - unmatchfreq2);
+
+  /* seen from relation 1: matched MCVs contribute matchprodfreq; side 1's unmatched MCVs
+   * match random members of side 2's non-MCV population; side 1's non-MCV values match
+   * random members of side 2's unmatched-MCV plus non-MCV population */
+  double totalsel1 = matchprodfreq;
+  if (nd2 > nmcv2)
+    {
+      totalsel1 += unmatchfreq1 * otherfreq2 / (nd2 - nmcv2);
+    }
+  if (nd2 > nmatches)
+    {
+      totalsel1 += otherfreq1 * (otherfreq2 + unmatchfreq2) / (nd2 - nmatches);
+    }
+
+  double totalsel2 = matchprodfreq;
+  if (nd1 > nmcv1)
+    {
+      totalsel2 += unmatchfreq2 * otherfreq1 / (nd1 - nmcv1);
+    }
+  if (nd1 > nmatches)
+    {
+      totalsel2 += otherfreq2 * (otherfreq1 + unmatchfreq1) / (nd1 - nmatches);
+    }
+
+  /* the smaller estimate is the view from the larger-NDV side */
+  double sel = (totalsel1 < totalsel2) ? totalsel1 : totalsel2;
+
+  /* the caller (qo_expr_selectivity) multiplies the returned selectivity by
+   * (1 - null_frequency) of BOTH name arguments; the null masses are already excluded
+   * above, so divide both back out (see histogram_get_equal_selectivity) */
+  const double nonnull_frac1 = 1.0 - nullfrac1;
+  const double nonnull_frac2 = 1.0 - nullfrac2;
+  if (nonnull_frac1 > 1e-9)
+    {
+      sel /= nonnull_frac1;
+    }
+  if (nonnull_frac2 > 1e-9)
+    {
+      sel /= nonnull_frac2;
+    }
+
+  sel = clamp01 (sel);
+  if (sel <= 0.0)
+    {
+      /* avoid a zero-cardinality estimate: at least one pair out of the cross product */
+      sel = 1.0 / (total_rows1 * total_rows2);
+    }
+
+  *selectivity = sel;
+  *success = true;
+  return;
+}
+
 static double
 pattern_heuristic_selectivity (const std::string &pattern, char escape_char)
 {

--- a/src/optimizer/histogram/histogram_cl.hpp
+++ b/src/optimizer/histogram/histogram_cl.hpp
@@ -102,6 +102,7 @@ void histogram_get_equal_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, doub
 void histogram_get_comp_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, bool is_ge, bool include_equal,
 				     double *selectivity,
 				     bool *success);
+void histogram_get_join_selectivity (PT_NODE *lhs, PT_NODE *rhs, double *selectivity, bool *success);
 void histogram_get_like_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *selectivity, bool *success);
 /* histogram utility functions */
 int db_get_histogram (MOP classop, const char *attr_name, DB_OBJECT **histogram_obj);

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -9968,16 +9968,22 @@ qo_expr_selectivity (QO_ENV * env, PT_NODE * pt_expr)
 	   * all-rows fraction with the CURRENT node's columns. Using the chain head (pt_expr)
 	   * here applied the head's null fraction to every sibling, so a high-null column
 	   * behind a null-free head kept its conditional selectivity (inflated by 1/(1-nf)). */
-	  if (node->info.expr.arg1 && node->info.expr.arg1->node_type == PT_NAME
-	      && node->info.expr.arg1->info.name.null_frequency >= 0.0)
-	    {
-	      selectivity = selectivity * (1 - node->info.expr.arg1->info.name.null_frequency);
-	    }
-	  if (node->info.expr.arg2 && node->info.expr.arg2->node_type == PT_NAME
-	      && node->info.expr.arg2->info.name.null_frequency >= 0.0)
-	    {
-	      selectivity = selectivity * (1 - node->info.expr.arg2->info.name.null_frequency);
-	    }
+	  {
+	    /* a qualified reference kept as a PT_DOT_ chain resolves to its terminal name node --
+	     * the same unwrap the histogram readers apply, so the correction cannot be skipped
+	     * for an argument whose estimate was histogram-based */
+	    PT_NODE *corr_arg1 = pt_get_end_path_node (node->info.expr.arg1);
+	    PT_NODE *corr_arg2 = pt_get_end_path_node (node->info.expr.arg2);
+
+	    if (corr_arg1 != NULL && corr_arg1->node_type == PT_NAME && corr_arg1->info.name.null_frequency >= 0.0)
+	      {
+		selectivity = selectivity * (1 - corr_arg1->info.name.null_frequency);
+	      }
+	    if (corr_arg2 != NULL && corr_arg2->node_type == PT_NAME && corr_arg2->info.name.null_frequency >= 0.0)
+	      {
+		selectivity = selectivity * (1 - corr_arg2->info.name.null_frequency);
+	      }
+	  }
 	}
 
       total_selectivity = qo_or_selectivity (env, total_selectivity, selectivity);

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -10138,10 +10138,17 @@ qo_equal_selectivity (QO_ENV * env, PT_NODE * pt_expr)
 	case PC_ATTR:
 	  /* attr = attr */
 
-	  histogram_get_join_selectivity (lhs, rhs, &selectivity, &success);
-	  if (success)
+	  if (pt_expr->info.expr.op == PT_EQ)
 	    {
-	      break;
+	      /* the histogram estimate models plain equality, where NULL never matches. A
+	       * null-safe join (<=>) also pairs the two sides' NULL rows, which this estimate
+	       * (and the caller's non-null correction) would drop -- those keep the legacy
+	       * index-cardinality estimate below. */
+	      histogram_get_join_selectivity (lhs, rhs, &selectivity, &success);
+	      if (success)
+		{
+		  break;
+		}
 	    }
 
 	  /* check for indexes on either of the attributes */

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -9975,13 +9975,31 @@ qo_expr_selectivity (QO_ENV * env, PT_NODE * pt_expr)
 	    PT_NODE *corr_arg1 = pt_get_end_path_node (node->info.expr.arg1);
 	    PT_NODE *corr_arg2 = pt_get_end_path_node (node->info.expr.arg2);
 
-	    if (corr_arg1 != NULL && corr_arg1->node_type == PT_NAME && corr_arg1->info.name.null_frequency >= 0.0)
+	    bool nf1_known = (corr_arg1 != NULL && corr_arg1->node_type == PT_NAME
+			      && corr_arg1->info.name.null_frequency >= 0.0);
+	    bool nf2_known = (corr_arg2 != NULL && corr_arg2->node_type == PT_NAME
+			      && corr_arg2->info.name.null_frequency >= 0.0);
+
+	    if (node->info.expr.op == PT_NULLSAFE_EQ && nf1_known && nf2_known)
 	      {
-		selectivity = selectivity * (1 - corr_arg1->info.name.null_frequency);
+		/* a null-safe equality (<=>) also matches the two sides' NULL rows: scale the
+		 * non-null equality estimate to the non-null pair fraction, then add the
+		 * NULL-NULL pair mass that plain equality never produces */
+		double nf1 = corr_arg1->info.name.null_frequency;
+		double nf2 = corr_arg2->info.name.null_frequency;
+
+		selectivity = selectivity * (1 - nf1) * (1 - nf2) + nf1 * nf2;
 	      }
-	    if (corr_arg2 != NULL && corr_arg2->node_type == PT_NAME && corr_arg2->info.name.null_frequency >= 0.0)
+	    else
 	      {
-		selectivity = selectivity * (1 - corr_arg2->info.name.null_frequency);
+		if (nf1_known)
+		  {
+		    selectivity = selectivity * (1 - corr_arg1->info.name.null_frequency);
+		  }
+		if (nf2_known)
+		  {
+		    selectivity = selectivity * (1 - corr_arg2->info.name.null_frequency);
+		  }
 	      }
 	  }
 	}
@@ -10144,17 +10162,12 @@ qo_equal_selectivity (QO_ENV * env, PT_NODE * pt_expr)
 	case PC_ATTR:
 	  /* attr = attr */
 
-	  if (pt_expr->info.expr.op == PT_EQ)
+	  /* non-null equality estimate, valid for = and <=> alike: the caller scales it to the
+	   * non-null pair fraction and, for a null-safe join, adds the NULL-NULL pair mass. */
+	  histogram_get_join_selectivity (lhs, rhs, &selectivity, &success);
+	  if (success)
 	    {
-	      /* the histogram estimate models plain equality, where NULL never matches. A
-	       * null-safe join (<=>) also pairs the two sides' NULL rows, which this estimate
-	       * (and the caller's non-null correction) would drop -- those keep the legacy
-	       * index-cardinality estimate below. */
-	      histogram_get_join_selectivity (lhs, rhs, &selectivity, &success);
-	      if (success)
-		{
-		  break;
-		}
+	      break;
 	    }
 
 	  /* check for indexes on either of the attributes */

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -10138,6 +10138,12 @@ qo_equal_selectivity (QO_ENV * env, PT_NODE * pt_expr)
 	case PC_ATTR:
 	  /* attr = attr */
 
+	  histogram_get_join_selectivity (lhs, rhs, &selectivity, &success);
+	  if (success)
+	    {
+	      break;
+	    }
+
 	  /* check for indexes on either of the attributes */
 	  lhs_icard = qo_index_cardinality (env, lhs);
 	  rhs_icard = qo_index_cardinality (env, rhs);
@@ -10152,7 +10158,6 @@ qo_equal_selectivity (QO_ENV * env, PT_NODE * pt_expr)
 	      selectivity = DEFAULT_EQUIJOIN_SELECTIVITY;
 	    }
 
-	  /* TODO: add histogram selectivity */
 	  break;
 
 	case PC_CONST:

--- a/src/storage/statistics_ndv.c
+++ b/src/storage/statistics_ndv.c
@@ -190,41 +190,101 @@ stats_estimate_ndv_from_sample (const STATS_NDV_SAMPLE_INPUT * in)
  *   return: number of leading candidates worth keeping in the MCV list (>= 0)
  *
  * mcv_counts holds the sample counts of the most common values, sorted descending
- * (most common first). A value qualifies as an MCV when it occurs in at least 1% of
- * the sampled (non-null) rows; since the candidates are sorted by descending count,
- * the MCVs are the leading run at or above that threshold. The remaining values are
- * left to the equi-depth histogram.
+ * (most common first). A value is kept only when its sample count is significantly
+ * higher than the selectivity it would otherwise receive as a non-MCV value, using
+ * the lower end of a continuity-corrected Wald-type confidence interval for the
+ * hypergeometric distribution (sampling without replacement).
  *
- *   samplerows -> reservoir non-null size (the 1% threshold is taken against this)
- *   stadistinct / stanullfrac / totalrows are unused (kept for signature stability).
+ * Mapping for the full reservoir scan (analysis done in non-null space):
+ *   stadistinct -> population non-null NDV (D_pop), always > 0 here
+ *   stanullfrac -> 0.0 (nulls excluded from the candidate space)
+ *   samplerows  -> reservoir non-null size
+ *   totalrows   -> exact population non-null rows (N_nn)
  */
 int
 stats_analyze_mcv_list (const INT64 * mcv_counts, int num_candidates, double stadistinct,
 			double stanullfrac, INT64 samplerows, double totalrows)
 {
-  int num_mcv = 0;
-  double threshold;
+  double ndistinct_table;
+  double sumcount;
+  int num_mcv;
   int i;
 
-  /* unused; kept for signature stability with the previous statistical criterion */
-  (void) stadistinct;
-  (void) stanullfrac;
-  (void) totalrows;
-
-  if (mcv_counts == NULL || num_candidates <= 0 || samplerows <= 0)
+  if (mcv_counts == NULL || num_candidates <= 0)
     {
       return 0;
     }
 
-  /* an MCV must occur in at least 1% of the sampled non-null rows */
-  threshold = 0.01 * (double) samplerows;
-  for (i = 0; i < num_candidates; i++)
+  num_mcv = num_candidates;
+
+  /* If the entire table was sampled, keep the whole list. This also protects us
+   * against division by zero in the code below. */
+  if ((double) samplerows >= totalrows || totalrows <= 1.0)
     {
-      if ((double) mcv_counts[i] < threshold)
+      return num_mcv;
+    }
+
+  /* Estimated number of distinct nonnull values in the table. A negative
+   * stadistinct as a fraction of totalrows; our D_pop is always a positive absolute
+   * count, but keep the decode for parity. */
+  ndistinct_table = stadistinct;
+  if (ndistinct_table < 0)
+    {
+      ndistinct_table = -ndistinct_table * totalrows;
+    }
+
+  /* sumcount tracks the total count of all but the last (least common) value. */
+  sumcount = 0.0;
+  for (i = 0; i < num_mcv - 1; i++)
+    {
+      sumcount += (double) mcv_counts[i];
+    }
+
+  while (num_mcv > 0)
+    {
+      double selec, otherdistinct, N, n, K, variance, stddev;
+
+      /* Estimated selectivity the least common value would have if it weren't in
+       * the MCV list. */
+      selec = 1.0 - sumcount / (double) samplerows - stanullfrac;
+      if (selec < 0.0)
 	{
+	  selec = 0.0;
+	}
+      if (selec > 1.0)
+	{
+	  selec = 1.0;
+	}
+      otherdistinct = ndistinct_table - (num_mcv - 1);
+      if (otherdistinct > 1)
+	{
+	  selec /= otherdistinct;
+	}
+
+      /* Lower end of a continuity-corrected Wald-type confidence interval for the
+       * hypergeometric distribution (sampling without replacement). */
+      N = totalrows;
+      n = (double) samplerows;
+      K = N * (double) mcv_counts[num_mcv - 1] / n;
+      variance = n * K * (N - K) * (N - n) / (N * N * (N - 1));
+      stddev = sqrt (variance);
+
+      if ((double) mcv_counts[num_mcv - 1] > selec * (double) samplerows + 2 * stddev + 0.5)
+	{
+	  /* Significantly more common than the non-MCV selectivity would suggest.
+	   * Keep it and all the more common values. */
 	  break;
 	}
-      num_mcv++;
+      else
+	{
+	  /* Discard this value and consider the next least common value. */
+	  num_mcv--;
+	  if (num_mcv == 0)
+	    {
+	      break;
+	    }
+	  sumcount -= (double) mcv_counts[num_mcv - 1];
+	}
     }
 
   return num_mcv;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26746>

### Purpose

수집된 히스토그램(MCV + equi-depth 버킷 + null 비율)을 조인 크기 추정까지 활용하도록 옵티마이저를 개선합니다. CBRD-26746 작업 중 **조인 선택도 적용(1)과 MCV 채택 기준 복원(2)** 두 건만 분리해 develop에 먼저 반영하는 PR입니다. 비용 계산 교정(fanout/heap fetch/반복 프로브 보정)은 본 PR 범위가 아니며 별도로 조정 중입니다.

### Implementation

1. **조인 선택도에 히스토그램 적용** (`histogram_cl.cpp/.hpp`, `query_planner.c`): `attr = attr` 조인 항의 선택도를 기존 `1/max(NDV)`(균등·완전겹침 가정)에서 양쪽 컬럼의 실제 값 분포(MCV)를 대조하는 방식으로 교체합니다.
   - 양쪽 MCV 리스트를 값 기준 two-pointer 병합으로 매칭해 일치 값은 빈도 곱을 정확히 합산
   - 잔여분은 상대측 non-MCV distinct 수로 균등 분배, 양쪽 관점 중 작은 값 채택 (양쪽 관점의 추정 중 보수적인 쪽)
   - null 비율은 히스토그램 모듈의 non-null-conditional 반환 규약에 맞춰 자동 차감
   - 한쪽이라도 히스토그램이 없거나 histogram key kind가 다르면 기존 경로로 폴백
2. **MCV 채택 기준을 유의성 검정으로 개선** (`statistics_ndv.c`): "표본의 1% 이상" 고정 임계값을 통계적 유의성 검정(초기하분포의 연속성 보정 Wald 신뢰구간 — 표본 빈도가 non-MCV로 취급될 때의 기대치보다 유의하게 높은 값만 채택)으로 되돌립니다. 1% 규칙에서는 `movie_info.info` 같은 컬럼이 300개 MCV 슬롯 중 12개만 채워져 'Horror'(30,801행)가 1,466배 과소추정되었고, 복원 후 오차 7% 이내가 됩니다.

### Remarks

- **리뷰 반영 (2026-07-21)**: ① PT_DOT_(qualified 참조)를 말단 name 노드로 unwrap해 히스토그램 probe 전반에 적용, ② null 보정 지점도 동일 unwrap으로 정합, ③ null-safe 조인(<=>)은 보정을 연산자 인지형으로 바꿔 `sel×(1−nf₁)(1−nf₂) + nf₁×nf₂`로 NULL=NULL 성분 반영.
- **비용 계산 교정(fanout/heap fetch/반복 프로브 보정, hash-join 파라미터 상호작용)은 본 PR 범위 밖** — #7453에서 조정 중이며 JIRA 본문 TODO 섹션에 정리되어 있습니다.

- **측정 (JOB 113, IMDB)**: 2번 단독으로 전체 실행 시간 −12% (686초 → 615초 단계 측정). 1+2는 조인 순서의 PG 일치를 늘리는 기반 변경으로, 전체 스택 기준 develop(no-histogram) 1,101초 → 410.3초 개선의 구성 요소입니다. 쿼리별 상세와 회귀 해명은 내부 측정 기록 페이지에 정리되어 있습니다.
- 선행 의존성 없음: #7286(reservoir 히스토그램), #6782(hash join) 모두 develop 머지 완료 상태 기준입니다.

