### PR TITLE
[CBRD-27098] Fix trigger-action remote INSERT SELECT being silently skipped or failing to compile

### DIFF
--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -435,6 +435,15 @@ pt_undef_names_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *con
       return node;
     }
 
+  /* A remote (dblink) target spec cannot be referenced from the value clause, and it is not
+   * bound in this scope (info.spec.id stays 0), so the spec_id equality below would misfire
+   * on any unbound name in the value clause. */
+  if (spec->info.spec.remote_server_name)
+    {
+      *continue_walk = PT_STOP_WALK;
+      return node;
+    }
+
   level_p = (short *) spec->etc;
 
   switch (node->node_type)

--- a/src/parser/name_resolution.c
+++ b/src/parser/name_resolution.c
@@ -502,6 +502,14 @@ pt_undef_names_post (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *co
       return node;
     }
 
+  /* Mirrors the remote-target guard in pt_undef_names_pre(): that function never runs the
+   * PT_SELECT/PT_UNION/... branch that increments *level_p for a remote target spec, so this
+   * post callback must not decrement it either, or *level_p underflows. */
+  if (spec->info.spec.remote_server_name)
+    {
+      return node;
+    }
+
   level_p = (short *) spec->etc;
   if (level_p == NULL)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27098

### Purpose

CBRD-26796(#7261)이 지원하는 `INSERT INTO tbl@server SELECT ... FROM local_tbl` 문장을 트리거 액션으로 사용하면, 사용 상황에 따라 세 가지 실패가 나타난다.

1. 트리거를 만든 세션에서 INSERT: 성공으로 보고되지만 원격 테이블에 아무 행도 반영되지 않는다(에러 없음).
2. 다른 세션에서 INSERT: 트리거 액션 컴파일 에러(`[dba.local_t] is not defined.`)로 INSERT 문장 자체가 실패한다.
3. 액션 원문에 alias를 쓰면(`FROM local_t t WHERE t.id = obj.id`): `CREATE TRIGGER` 자체가 `t is not defined.` 에러로 실패한다.

세 증상의 원인은 하나다. `pt_undef_names_pre ()`(name_resolution.c)의 "INSERT 타깃을 value 절에서 상관참조하면 오류" 가드는 이름 노드의 `spec_id`와 INSERT 타깃 spec의 `id`가 같은지로 판정하는데, 트리거 액션 컴파일 경로에는 최상위 문장과 달리 `pt_rewrite_for_dblink ()` 선행이 없어 원격 타깃 spec이 미변환·미바인딩(`info.spec.id == 0`) 상태로 이 가드에 도달한다. 서브쿼리 FROM절의 아직 안 묶인 이름(`spec_id == 0`)이 `0 == 0`으로 성립해, 정상 이름을 타깃 상관참조로 오인해 에러를 낸다.

증상 1과 2는 이 오탐이 표면화되는 시점만 다르다. 트리거를 만든 세션에서는 저장된 액션 소스의 재컴파일(`validate_trigger`)이 오탐으로 실패하면서 트리거가 조용히 INVALID로 강등돼 발동 자체가 안 되고, 다른 세션에서는 발동 시점의 액션 재컴파일이 같은 오탐으로 실패해 에러가 표면화되며 외부 INSERT까지 실패한다.

### Implementation

`pt_undef_names_pre ()` 초입에서 INSERT 타깃 spec이 원격(dblink) 타깃이면(`spec->info.spec.remote_server_name` 존재) 검사를 건너뛴다.

- 원격 타깃 spec은 이 스코프에서 바인딩 자체가 되지 않으므로(value 절의 이름이 원격 타깃 spec에 정당하게 묶이는 경우가 존재하지 않음), 이 가드는 원격 타깃에 대해 판정할 대상이 없다. 건너뛰어도 보호 손실이 없다.
- 이 함수의 호출처는 INSERT와 MERGE의 value 절 walk 두 곳이며, 두 경로 모두에 동일하게 적용된다.
- 로컬 타깃의 기존 가드 동작은 변경 없다(회귀 확인: `INSERT INTO x SELECT x.i FROM y`는 기존대로 `is not defined.` 오류).

수정 후에는 CREATE·재검증·발동 시점의 액션 컴파일이 전부 성공하므로 세 증상이 함께 해소되고, 트리거 액션의 원격 INSERT는 기존 최상위 문장과 동일한 늦은 변환 경로(`pt_to_insert_xasl` 내 `pt_rewrite_for_dblink`, CBRD-26033 구조)로 실행된다.

리뷰 중 지적된 `pt_undef_names_pre ()`/`pt_undef_names_post ()` 비대칭(pre가 원격 타깃이면 `PT_STOP_WALK`로 correlation level 증가를 건너뛰는데 post는 감소를 그대로 실행해 카운터가 언더플로우)도 같은 가드를 `pt_undef_names_post ()`에 추가해 대칭을 맞췄다. 현재 동작에 영향은 없다(레벨 변수는 walk 직후 폐기됨) — 향후 코드 변경 시 혼란을 줄 수 있는 비대칭을 제거하는 방어적 수정이다.

### Remarks

- DELETE 트리거 액션(CBRD-26921의 원격 DELETE 포함)은 이 가드를 지나지 않아 본 결함과 무관하며, 별도 실측에서도 정상이었다.
- MERGE 원격 타깃(CBRD-26923 범위)도 같은 퇴화 비교 위험을 가지므로 이번 스킵의 적용을 함께 받는다. MERGE 트리거 TC는 CBRD-26923 진행 시 설계 예정이다.