### PR TITLE
[CBRD-27053] Fix use-after-free on partitioned table DROP

### DIFF
--- a/src/query/execute_schema.c
+++ b/src/query/execute_schema.c
@@ -5509,6 +5509,7 @@ int
 do_drop_partitioned_class (MOP class_, int drop_sub_flag, bool is_cascade_constraints)
 {
   DB_OBJLIST *objs;
+  DB_OBJLIST *users_snapshot = NULL;
   SM_CLASS *smclass, *subclass;
   MOP delobj;
   int error = NO_ERROR;
@@ -5538,7 +5539,19 @@ do_drop_partitioned_class (MOP class_, int drop_sub_flag, bool is_cascade_constr
       goto fail_return;
     }
 
-  for (objs = smclass->users; objs;)
+  /* smclass->users is owned by the parent SM_CLASS, and sm_delete_class_mop () below can decache the parent
+   * (a client-side abort, or a re-fetch that re-caches it), which releases the whole class object through
+   * classobj_free_class () and frees the list with it. Walk a private copy instead; the MOPs it holds stay
+   * valid because a decache only clears MOP->object (CBRD-27053). */
+  users_snapshot = ml_copy (smclass->users);
+  if (users_snapshot == NULL)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (DB_OBJLIST));
+      error = ER_OUT_OF_VIRTUAL_MEMORY;
+      goto fail_return;
+    }
+
+  for (objs = users_snapshot; objs;)
     {
       error = au_fetch_class (objs->op, &subclass, AU_FETCH_READ, AU_SELECT);
       if (error != NO_ERROR)
@@ -5567,6 +5580,11 @@ do_drop_partitioned_class (MOP class_, int drop_sub_flag, bool is_cascade_constr
   error = NO_ERROR;
 
 fail_return:
+  if (users_snapshot != NULL)
+    {
+      ml_free (users_snapshot);
+    }
+
   return error;
 }
 

--- a/src/transaction/locator_cl.c
+++ b/src/transaction/locator_cl.c
@@ -5657,6 +5657,7 @@ locator_remove_class (MOP class_mop)
   SM_ATTRIBUTE *attr;		/* attribute info for checking LOB attributes */
   bool lob_attr_exist = false;
   const char *classname;	/* The classname */
+  LC_FIND_CLASSNAME deleted;	/* Result of deleting the classname */
   int attrid_arr[1];
   int error_code = NO_ERROR;
 
@@ -5707,7 +5708,22 @@ locator_remove_class (MOP class_mop)
     }
 
   /* Delete the class name */
-  if (locator_delete_class_name (classname) == LC_CLASSNAME_DELETED || BOOT_IS_CLIENT_RESTARTED ())
+  deleted = locator_delete_class_name (classname);
+  if (deleted == LC_CLASSNAME_ERROR)
+    {
+      /*
+       * The request failed. BOOT_IS_CLIENT_RESTARTED () below cannot be relied on
+       * to catch this: when the server goes down, the failing request runs
+       * boot_server_die_or_changed (), which calls boot_client (NULL_TRAN_INDEX)
+       * and thus clears tm_Tran_index. Without this check the function returns
+       * NO_ERROR even though the transaction has already been aborted, and the
+       * caller keeps walking workspace structures that the abort has freed.
+       */
+      ASSERT_ERROR_AND_SET (error_code);
+      goto error;
+    }
+
+  if (deleted == LC_CLASSNAME_DELETED || BOOT_IS_CLIENT_RESTARTED ())
     {
       ws_dirty (class_mop);
       ws_mark_deleted (class_mop);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27053

### Purpose

파티션 테이블 DROP 중 서버가 비정상 종료되면 csql(클라이언트)이 `ws_oid ()` 에서 use-after-free 로 crash 합니다. 두 개의 독립된 결함이 겹칠 때만 발생합니다.

> **이전 설명 철회**: 처음에는 CBRD-23700 이 `locator_remove_class ()` 에 추가한 `au_fetch_class ()` 재fetch가 부모 클래스를 decache 한다고 설명했으나 **사실이 아닙니다.** 그 호출은 `au_fetch_class_internal ()` 의 read fast path 조건(직전에 `SCH_M_LOCK` 확보)을 모두 만족해 서버에 가지 않고, 권한 검사도 `DB_AUTH_NONE == 0` 이라 단락됩니다. 런타임 no-op 이었습니다. 리뷰 지적이 맞습니다.

---

### Root cause (1) — `SM_CLASS::users` 가 순회 중에 해제됨

#### 사전 정보

- 파티션 테이블 DROP 은 **자식 파티션을 하나씩 삭제한 뒤 마지막에 부모를 삭제**합니다.
- 클라이언트는 부모를 `SM_CLASS` 로 캐시하고, **`SM_CLASS::users` (`DB_OBJLIST` 연결 리스트)에 자식 정보를 담습니다.**
- `do_drop_partitioned_class ()` 이 이 리스트를 `q1` 부터 순회합니다.

```c
for (objs = smclass->users; objs;)                                          /* 부모 소유 리스트 */
  {
    error = au_fetch_class (objs->op, &subclass, AU_FETCH_READ, AU_SELECT);  /* <-- crash */
    ...
    delobj = objs->op;
    objs = objs->next;
    error = sm_delete_class_mop (delobj, is_cascade_constraints);            /* 자식 삭제 */
  }
```

`objs` 는 **부모 `SM_CLASS` 소유 노드**를 직접 가리킵니다. 사본이 아닙니다.

#### 무슨 일이 벌어지는가

`q1` 삭제 중 서버가 죽으면 응답이 오지 않습니다. 클라이언트가 소켓 실패(EOF / ECONNRESET)로 감지하고, **그 자리에서 클라이언트 측 abort 를 수행하며 이 트랜잭션이 캐시한 객체를 전부 해제합니다.** 부모 `SM_CLASS` 가 포함되고, 그 안의 `users` 리스트도 함께 사라집니다.

```
do_drop                                                    execute_schema.c
 └ sm_delete_class_mop (tbl2)                              schema_manager.c      <-- 부모 DROP
    └ do_drop_partitioned_class (tbl2)                     execute_schema.c      <-- 루프
       └ sm_delete_class_mop (q1)                                                <-- 자식 DROP
          └ locator_remove_class (q1)                      schema_manager.c:14022
             └ locator_delete_class_name ()                locator_cl.c:5711
                └ net_client_request ()                    network_interface_cl.c:1219
                   └ net_client_request_internal ()        network_cl.c:487
                      │  css_receive_data_from_server () 실패 (소켓 EOF / ECONNRESET)
                      └ set_server_error ()                network_cl.c:141
                         │  ER_NET_SERVER_CRASHED 로 판정
                         └ boot_server_die_or_changed ()   network_cl.c:188
                            └ tran_abort_only_client (true)      boot_cl.c:1496
                               └ ws_abort_mops (true)            transaction_cl.c:587
                                  └ ws_decache (tbl2)            work_space.c:2725
                                     └ classobj_free_class ()    work_space.c:2767
                                        └ ml_free_and_init (class_->users)
                                                                 class_object.c:6953
                                           <-- [q1][q2][q3] 노드 해제
```

`ws_abort_mops ()` 는 `ws_Commit_mops` 전역 리스트의 모든 MOP 을 decache 합니다. DROP 중인 부모는 락(`WS_SET_LOCK`)과 dirty(`WS_SET_DIRTY`)로 이미 등록되어 있어 반드시 포함됩니다.

이 순간 `objs` 는 dangling 이 되지만 **증상이 없습니다.** 해제는 에러가 아닌 정상 동작이고, 지역변수를 갱신해 주는 장치는 없습니다.

#### 다음 노드 접근 시 crash

```
au_fetch_class (objs->op, ...)
   (a) objs->op 읽기        -> 성공. 값은 쓰레기.       <-- 실제 결함 지점
   (b) if (op == NULL) 검사 -> 통과 (NULL 이 아니므로)
   (c) op->class_mop 읽기   -> 성공. 값은 쓰레기.
   (d) ws_oid (쓰레기)      -> SIGSEGV                  <-- 코어가 가리키는 지점
```

`users` 노드는 lea 힙(dlmalloc 2.8.3)에서 나오는데, dlmalloc 은 해제된 청크의 `fd`/`bk` 를 payload `+0`/`+8` 에 씁니다. 이는 `DB_OBJLIST` 의 `next`/`op` 와 정확히 겹칩니다. 본 이슈 콜스택의 값이 이를 뒷받침합니다.

```
objs      = 0x7cbaf8
objs->op  = 0x7cbae8   = objs - 16 = mem2chunk (objs)   <- 청크 주소. MOP 이 아님.
```

`NULL` 이 아니라 그럴싸한 포인터라서 (b) 검사를 통과합니다.

> 참고: 이 시점에 부모는 아직 DB 에서 삭제되지 않았습니다. 사라진 것은 **클라이언트 메모리의 캐시본**이며, DROP 로직이 시킨 일이 아니라 트랜잭션 정리기가 끼어든 결과입니다. decache 경로는 위 `ws_abort_mops ()` 외에 `ws_cache ()`(부모 재fetch 시 옛 객체 폐기)도 있는데, 후자는 **성공하는 정상 동작이라 에러가 없어** (2) 의 수정으로 막을 수 없습니다.

---

### Root cause (2) — `locator_remove_class ()` 이 실패를 전파하지 않음

(1) 만으로는 crash 하지 않습니다. 보통은 `sm_delete_class_mop ()` 이 에러를 반환하고 루프가 탈출합니다. **그 에러가 은폐되는 지점이 있습니다.**

```c
if (locator_delete_class_name (classname) == LC_CLASSNAME_DELETED || BOOT_IS_CLIENT_RESTARTED ())
  {
    ws_dirty (class_mop);
    ws_mark_deleted (class_mop);
    error_code = locator_flush_class (class_mop);
  }

error:
  return error_code;      /* if 를 건너뛰면 NO_ERROR 그대로 반환 */
```

- `locator_delete_class_name ()` 은 에러 코드가 아니라 **`LC_FIND_CLASSNAME` enum** 을 반환합니다. 요청 실패 시 `LC_CLASSNAME_ERROR` 이므로 비교가 false 가 됩니다.
- `BOOT_IS_CLIENT_RESTARTED ()` 도 구제하지 못합니다. **실패하는 그 호출이 이 플래그를 스스로 지웁니다.**

```
locator_delete_class_name ()
  └ net_client_request () 실패
     └ boot_server_die_or_changed ()
          ├ tran_abort_only_client (true)  -> ws_abort_mops () -> 부모 decache
          └ boot_client (NULL_TRAN_INDEX)  -> tm_Tran_index 초기화
                                              => BOOT_IS_CLIENT_RESTARTED () == false
```

즉 `||` 의 두 번째 항은 **실패 케이스에서 반드시 false** 가 되어 안전망 역할을 못 합니다. 결과적으로 트랜잭션이 이미 abort 되었는데도 `NO_ERROR` 를 반환하고, 호출자는 abort 가 해제한 구조를 계속 순회합니다. crash 와 별개로 그 자체가 결함입니다.

---

### Implementation

#### (1) `src/query/execute_schema.c` — 사본 순회

```diff
+  users_snapshot = ml_copy (smclass->users);
+  if (users_snapshot == NULL)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, sizeof (DB_OBJLIST));
+      error = ER_OUT_OF_VIRTUAL_MEMORY;
+      goto fail_return;
+    }
+
-  for (objs = smclass->users; objs;)
+  for (objs = users_snapshot; objs;)
     {
        ...   /* 루프 본문 무변경 */
     }
 fail_return:
+  if (users_snapshot != NULL)
+    {
+      ml_free (users_snapshot);
+    }
```

`ml_copy ()` 는 노드를 새로 할당하고 MOP 포인터만 복사합니다. **MOP 은 decache 로 해제되지 않으므로**(`ws_decache ()` 는 `mop->object` 만 비움) 사본은 어떤 decache 경로에도 영향받지 않습니다. 동일 패턴이 `update_class ()` 에 이미 있습니다 (`oldsupers = ml_copy (class_->inheritance)`).

루프 중 `users` 에 가해지는 변경은 `ml_remove (&class_->users, 방금_지운_자식)` 뿐이므로 사본은 원본과 동일한 MOP 을 동일 순서로 방문합니다. 동작 변화가 없습니다.

#### (2) `src/transaction/locator_cl.c` — 에러 전파

```diff
-  if (locator_delete_class_name (classname) == LC_CLASSNAME_DELETED || BOOT_IS_CLIENT_RESTARTED ())
+  deleted = locator_delete_class_name (classname);
+  if (deleted == LC_CLASSNAME_ERROR)
+    {
+      ASSERT_ERROR_AND_SET (error_code);
+      goto error;
+    }
+
+  if (deleted == LC_CLASSNAME_DELETED || BOOT_IS_CLIENT_RESTARTED ())
     {
```

`LC_CLASSNAME_ERROR` 만 에러로 승격했습니다. 다른 반환값의 기존 동작은 유지됩니다.

두 수정은 서로를 대체하지 않습니다. (2) 는 에러 은폐를 없애고, (1) 은 (2) 가 막지 못하는 `ws_cache ()` 경로까지 덮습니다.

---

### Verification

**재현 확보** — 이전까지 재현되지 않던 이슈인데, `develop` release 빌드에서 본 이슈와 동일한 콜스택의 crash 를 재현했습니다(프레임 `#4`~`#11` 일치).

공식 TC `cbrd_25350_ddl` SCENARIO-2 와 방식은 같습니다(DDL 실행 중 `kill -9` 로 서버 종료). 다만 그 TC 는 table/partition/index/view DDL 을 돌아가며 실행하므로 파티션 DROP 구간에 kill 이 떨어질 확률이 낮습니다. **DDL 을 파티션 경로로만 좁혀 시도 밀도를 높였습니다.** 코드 경로와 트리거는 동일하며, 폴트 인젝션이나 `max_clients=4000` 은 필요하지 않았습니다.

**에러 은폐 확인** — (2)가 실제로 일어나는지 보기 위해, 부모가 해제된 뒤 `sm_delete_class_mop ()` 의 반환값을 기록하도록 계측하고 900회 반복했습니다.

```
부모 해제됨 + sm_delete_class_mop() 이 NO_ERROR 반환    err=0  er_errid=-111   3회
그 직후 루프가 다음 노드로 재진입                        err=0  er_errid=-111   2회
```

`err=0` 은 반환값이 정상이라는 뜻이고, `er_errid=-111` 은 `ER_TM_SERVER_DOWN_UNILATERALLY_ABORTED` 입니다. **에러가 발생했는데 반환값으로 전달되지 않았음**을 직접 보여줍니다. 해제 시점의 백트레이스는 3회 모두 Root cause (1) 의 콜스택과 동일했고, 한 프로세스가 두 기록을 연속으로 남겨 "에러 은폐 -> 루프 재진입" 이 이어짐을 확인했습니다.

**회귀 확인** — 두 파일 x CS/SA 4개 TU 컴파일 경고 없음 / `cbrd_25350_ddl` OK / 파티션 create-drop 반복 crash 없음 / LOB 컬럼 테이블 DROP 시 lob 파일 정상 삭제(CBRD-23700 동작 보존).

**한계** — 발생률이 낮고(150~200회 kill 당 1건) 변동이 커서, 수정 전후의 발생 빈도 차이를 통계로 제시하지는 못했습니다. 본 PR 의 근거는 코어 분석, 위 계측, 그리고 코드 구조상의 논증입니다.

---

### Remarks

**두 결함 모두 CBRD-23700 이전부터 내재되어 있었습니다.** `git blame` 결과입니다.

| 결함 | 도입 커밋 |
|---|---|
| (1) `do_drop_partitioned_class ()` 의 `smclass->users` 직접 순회 | `6522201da` (2014-04-21) |
| (2) `locator_remove_class ()` 의 `locator_delete_class_name ()` 반환값 미처리 | `6522201da` (2014-04-21) |

CBRD-23700(`a59899038`)이 `locator_remove_class ()` 를 수정한 것은 맞지만, 추가한 것은 **선언부와 LOB 속성 검사 블록**이며 (2)의 조건문은 건드리지 않았습니다. `schema_manager.c` 변경도 전부 `sm_truncate_using_destroy_heap ()` 안이고, `execute_schema.c` 변경은 전부 ALTER 경로여서 `do_drop_partitioned_class ()` 는 diff 에 등장하지 않습니다.

즉 **본 이슈는 CBRD-23700 의 regression 이 아니며**, 오래 잠복해 있던 결함이 "파티션 DROP 중 서버 강제 종료"라는 조건에서 드러난 것입니다.

**CBRD-23700 이 실제로 남긴 것**은 반환값 미검사 `au_fetch_class ()` 두 곳입니다.

- `locator_remove_class ()` — 본 PR (2) 수정으로 해당 구간이 정리됩니다
- `locator_create_heap_if_needed ()` — **미수정**. `locator_lob_process_dir ()` 이 `class_->att_count` 를 NULL 검사 없이 읽으므로 NULL 역참조 위험이 남아 있습니다

**별도 이슈가 필요한 잔여 항목** (본 PR 범위 밖)

- `sm_delete_class_mop ()` — `class_` 를 확보한 뒤 서버 왕복 여러 개를 건너 `classobj_make_template ()` 에서 재사용. **파티션과 무관하게 모든 `DROP TABLE` 이 지나는 경로**이며 별도 코어 2건 확보
- `sm_delete_class_mop ()` histogram 루프 — `class_->attributes` 순회 중 속성마다 서버 왕복 (CBRD-26202 도입)
- `do_rename_partition ()` — 동일 패턴. `objs->next` 를 `sm_rename_class ()` 이후 읽어 노출 창이 더 큼

🤖 Generated with [Claude Code](https://claude.com/claude-code)
