### PR TITLE
[CUBRIDQA-1436] CI: replace dynamic setup workflow with a static config (tests on debug build only)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,7 @@
 version: 2.1
-setup: true
-orbs:
-  continuation: circleci/continuation@1.1.0
+
 # --------------------------------------------------
-# Pipeline-level parameters (values passed from GitHub Actions)
+# Pipeline-level parameters (values passed from GitHub Actions comment trigger)
 # --------------------------------------------------
 parameters:
   baseline:
@@ -23,492 +21,425 @@ parameters:
     default: false
 
 # --------------------------------------------------
-# Jobs
+# 1. Reusable executors
 # --------------------------------------------------
-jobs:
-  # Setup job that generates the dynamic configuration
-  setup:
-    executor: continuation/default
+executors:
+  # Build machine: ccache environment baked in so both build jobs share it
+  cubrid-build:
+    docker:
+      - image: cubridci/cubridci:develop
+    resource_class: xlarge
+    working_directory: /home
     environment:
-      RUN_MEDIUM_TEST: << pipeline.parameters.run_medium_test >>
-      RUN_SQL_TEST: << pipeline.parameters.run_sql_test >>
-      RUN_SHELL_TEST: << pipeline.parameters.run_shell_test >>
-      RUN_ALL_TEST: << pipeline.parameters.run_all_test >>
-      BASELINE: << pipeline.parameters.baseline >>
+      MAKEFLAGS: -j 8
+      CC: "ccache gcc"
+      CXX: "ccache g++"
+      CCACHE_DIR: /home/.ccache
+      CCACHE_COMPILERCHECK: content
+      CCACHE_HARDLINK: 1
+
+  cubrid-default:
+    docker:
+      - image: cubridci/cubridci:develop
+    working_directory: /home
+
+  cubrid-test-shell:
+    docker:
+      - image: cubridci/cubridci:test_shell
+    # self-hosted runner
+    resource_class: cubrid/ramdisk
+    working_directory: /home
+
+# --------------------------------------------------
+# 2. Reusable commands
+# --------------------------------------------------
+commands:
+  submodules:
+    description: "Sync and init git submodules"
+    steps:
+      - run:
+          name: Submodules
+          command: |
+            git submodule sync
+            git submodule update --init
+
+  collect-build-logs:
+    description: "Collect build logs and store them"
+    steps:
+      - run:
+          name: Store Build Logs
+          command: |
+            mkdir -p /tmp/build_logs
+            mv -f build.log /tmp/build_logs || true
+      - run:
+          name: Store Commits
+          command: |
+            mkdir -p /tmp/build_logs
+            git log | head -n 1000 > commits.log || true
+            mv -f commits.log /tmp/build_logs
+      - store_artifacts:
+          path: /tmp/build_logs
+          when: always
+
+  build-cubrid:
+    description: "Build CUBRID with ccache (shared by release and debug builds)"
+    parameters:
+      ccache-prefix:
+        type: string
+      mode:
+        type: string
+        default: release
+      build-args:
+        type: string
+        default: ""
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - << parameters.ccache-prefix >>-{{ checksum "build.sh" }}-{{ checksum "CMakeLists.txt" }}-develop-{{ .Revision }}
+            - << parameters.ccache-prefix >>-{{ checksum "build.sh" }}-{{ checksum "CMakeLists.txt" }}-develop-
+      - submodules
       - run:
-          name: Generate continuation config
+          name: Build (<< parameters.mode >>)
           command: |
-            echo "Pipeline parameters:"
-            echo "RUN_MEDIUM_TEST: $RUN_MEDIUM_TEST"
-            echo "RUN_SQL_TEST: $RUN_SQL_TEST"
-            echo "RUN_SHELL_TEST: $RUN_SHELL_TEST"
-            echo "RUN_ALL_TEST: $RUN_ALL_TEST"
-            echo "BASELINE: $BASELINE"
+            mkdir -p $CCACHE_DIR
+            ccache --max-size=5G
+            ccache -z
+            scl enable devtoolset-8 -- /entrypoint.sh build << parameters.build-args >>
+            ccache -s
+      # ccache save: write only on develop-branch builds -> a single shared warm cache
+      # (other branches/PRs are restore-only; avoids 5G-per-PR bloat and non-develop pollution)
+      - when:
+          condition:
+            equal: [ develop, << pipeline.git.branch >> ]
+          steps:
+            - save_cache:
+                key: << parameters.ccache-prefix >>-{{ checksum "build.sh" }}-{{ checksum "CMakeLists.txt" }}-develop-{{ .Revision }}
+                paths:
+                  - /home/.ccache
+      - collect-build-logs
 
+  resolve-testcases:
+    description: "Resolve testcases branch/SHA; export BRANCH_TESTCASES and materialize cache-key inputs"
+    steps:
+      - run:
+          name: Resolve testcases branch and SHA
+          command: |
             if [[ "$CIRCLE_BRANCH" == pull/* ]]; then
               TC_BRANCH="tc/pr-${CIRCLE_BRANCH//[^0-9]/}"
             else
               TC_BRANCH="develop"
             fi
-            
+
             TC_SHA=$(git ls-remote https://x-access-token:${GHI_TOKEN}@github.com/CUBRID/cubrid-testcases.git ${TC_BRANCH} | cut -f1)
-            [ -z "$TC_SHA" ] && TC_BRANCH="develop" && TC_SHA=$(git ls-remote https://x-access-token:${GHI_TOKEN}@github.com/CUBRID/cubrid-testcases.git develop | cut -f1)           
-            
+            if [ -z "$TC_SHA" ]; then
+              TC_BRANCH="develop"
+              TC_SHA=$(git ls-remote https://x-access-token:${GHI_TOKEN}@github.com/CUBRID/cubrid-testcases.git develop | cut -f1)
+            fi
+
             CACHE_KEY_BRANCH="${TC_BRANCH//\//-}"
-            
+
             echo "TC_BRANCH: $TC_BRANCH"
-            echo "sha value from tc repository.(from $TC_BRANCH branch)"
             echo "TC_SHA: $TC_SHA"
             echo "CACHE_KEY_BRANCH: $CACHE_KEY_BRANCH"
 
-            # Generate dynamic configuration file (continue.yml)
-            cat \<<EOF > .circleci/continue.yml
-            version: 2.1
-            
-            parameters:
-              baseline:
-                type: string
-                default: << pipeline.parameters.baseline >>
-              run_shell_test:
-                type: boolean
-                default: << pipeline.parameters.run_shell_test >>
-              run_sql_test:
-                type: boolean
-                default: << pipeline.parameters.run_sql_test >>
-              run_medium_test:
-                type: boolean
-                default: << pipeline.parameters.run_medium_test >>
-              run_all_test:
-                type: boolean
-                default: << pipeline.parameters.run_all_test >>
-            
-            # --------------------------------------------------
-            # 1. Reusable commands
-            # --------------------------------------------------
-            commands:
-              attach-and-run-tests:
-                description: "Run test scripts (CUBRID must be at /home/CUBRID)"
-                steps:
-                  - run:
-                      name: Test
-                      environment:
-                        BRANCH_TESTCASES: "${TC_BRANCH}"
-                      shell: /bin/bash
-                      no_output_timeout: 45m
-                      command: |
-                        # Limit core files to 10mb
-                        ulimit -c 10485760
+            # checkout reads BRANCH_TESTCASES to select the testcases branch
+            echo "export BRANCH_TESTCASES=$TC_BRANCH" >> "$BASH_ENV"
 
-                        echo "[debug] Check out testcases and testtools"
-                        /entrypoint.sh checkout
-                        case "\$TEST_SUITE" in
-                          none)
-                            echo "TEST_SUITE is none"
-                            exit 1
-                            ;;
-                          sql)
-                            base_dir="cubrid-testcases"
-                            glob_path="\$base_dir/\$TEST_SUITE/_*"
-                            ;;
-                          shell)
-                            base_dir="cubrid-testcases-private-ex"
-                            rm -rf \$base_dir/shell/_25_unstable
-                            glob_path="\$base_dir/\$TEST_SUITE/_*/**/*.sh"
-                            ;;
-                          *)
-                            base_dir="cubrid-testcases"
-                            glob_path="\$base_dir/\$TEST_SUITE/_*"
-                            ;;
-                        esac
+            # Cache keys cannot read shell vars, so materialize the runtime values
+            # to files and reference them via {{ checksum }} in restore_cache/save_cache.
+            echo "$CACHE_KEY_BRANCH" > /tmp/tc_cache_branch
+            echo "$TC_SHA" > /tmp/tc_cache_sha
+            echo "develop" > /tmp/tc_cache_develop
 
-                        if [ "\$TEST_SUITE" = "shell" ]; then
-                          echo "[debug] split tests for parallel execution"
-                          circleci tests glob "\$glob_path" | grep -P '/([^/]+)/cases/\1\.sh$' \
-                            | circleci tests run --command="tee tc.list" --verbose --split-by=timings --timings-type=file
+  run-tests:
+    description: "Run test scripts (CUBRID must be at /home/CUBRID)"
+    steps:
+      - run:
+          name: Test
+          shell: /bin/bash
+          no_output_timeout: 45m
+          command: |
+            # Limit core files to 10mb
+            ulimit -c 10485760
 
-                          # Check if tc.list exists and is not empty (tests were assigned to this node)
-                          if [ ! -s tc.list ]; then
-                            echo "[debug] No tests assigned to this node"
-                            circleci-agent step halt
-                            exit 0
-                          fi
-                          cat tc.list | xargs -n1 dirname > tc_dirs.list
-                          echo "[debug] total testcases: \$(wc -l tc_dirs.list)"
-                          echo "[debug] Remove tests that are not in the list"
-                          find \$base_dir -name "cases" -type d | grep -v -F -f tc_dirs.list | xargs -r rm -rf
-                        else
-                          echo "[debug] split tests for parallel execution"
-                          circleci tests glob "\$glob_path" \
-                            | circleci tests run --command="xargs -n1 >> tc.list" --verbose --split-by=name
-                            
-                          # Check if tc.list exists and is not empty (tests were assigned to this node)
-                          if [ ! -s tc.list ]; then
-                            echo "[debug] No tests assigned to this node"
-                            circleci-agent step halt
-                            exit 0
-                          fi
-                          echo "[debug] total testcases: \$(wc -l tc.list)"
-                          echo "[debug] Remove tests that are not in the list"
-                          find \$base_dir -name "*.sql" -type f | grep -v -F -f tc.list | xargs -r rm -rf
-                        fi
+            echo "[debug] Check out testcases and testtools"
+            /entrypoint.sh checkout
+            case "$TEST_SUITE" in
+              none)
+                echo "TEST_SUITE is none"
+                exit 1
+                ;;
+              sql)
+                base_dir="cubrid-testcases"
+                glob_path="$base_dir/$TEST_SUITE/_*"
+                ;;
+              shell)
+                base_dir="cubrid-testcases-private-ex"
+                rm -rf $base_dir/shell/_25_unstable
+                glob_path="$base_dir/$TEST_SUITE/_*/**/*.sh"
+                ;;
+              *)
+                base_dir="cubrid-testcases"
+                glob_path="$base_dir/$TEST_SUITE/_*"
+                ;;
+            esac
 
-                        echo "[debug] Run the tests"
-                        /entrypoint.sh test
-                  - run:
-                      name: Collect Logs
-                      when: on_fail
-                      command: |
-                        mkdir -p /tmp/logs
-                        cp -f /tmp/tests/* /tmp/logs || true
-                        if [ "\$TEST_SUITE" = "shell" ]; then
-                          mv -f cubrid-testtools/CTP/result/shell/current_runtime_logs /tmp/logs/ctp_log || true
-                        else
-                          mv -f CUBRID/log /tmp/logs/cubrid_log || true
-                          mv -f cubrid-testtools/CTP/sql/log /tmp/logs/ctp_log || true
-                        fi
-                        [ -e CUBRID/log/coredump ] && mv -f CUBRID/log/coredump /tmp/logs/coredump || true
-                        mv -f tc.list /tmp/logs/ || true
-                  - store_test_results:
-                      path: /tmp/tests
-                      when: always
-                  - store_artifacts:
-                      path: /tmp/logs
-                      when: on_fail
+            if [ "$TEST_SUITE" = "shell" ]; then
+              echo "[debug] split tests for parallel execution"
+              circleci tests glob "$glob_path" | grep -P '/([^/]+)/cases/\1\.sh$' \
+                | circleci tests run --command="tee tc.list" --verbose --split-by=timings --timings-type=file
 
-              collect-build-logs:
-                description: "Collect build logs and store them"
-                steps:
-                  - run:
-                      name: Store Build Logs
-                      command: |
-                        mkdir -p /tmp/build_logs
-                        mv -f build.log /tmp/build_logs || true
-                  - run:
-                      name: Store Commits
-                      command: |
-                        mkdir -p /tmp/build_logs
-                        git log | head -n 1000 > commits.log || true
-                        mv -f commits.log /tmp/build_logs
-                  - store_artifacts:
-                      path: /tmp/build_logs
-                      when: always
+              # Check if tc.list exists and is not empty (tests were assigned to this node)
+              if [ ! -s tc.list ]; then
+                echo "[debug] No tests assigned to this node"
+                circleci-agent step halt
+                exit 0
+              fi
+              cat tc.list | xargs -n1 dirname > tc_dirs.list
+              echo "[debug] total testcases: $(wc -l tc_dirs.list)"
+              echo "[debug] Remove tests that are not in the list"
+              find $base_dir -name "cases" -type d | grep -v -F -f tc_dirs.list | xargs -r rm -rf
+            else
+              echo "[debug] split tests for parallel execution"
+              circleci tests glob "$glob_path" \
+                | circleci tests run --command="xargs -n1 >> tc.list" --verbose --split-by=name
 
-              download-build-from-artifact:
-                description: "Download CUBRID build from artifact (for sql/medium tests)"
-                steps:
-                  - attach_workspace:
-                      at: /tmp/workspace
-                  - run:
-                      name: Download build from artifact
-                      command: |
-                        BUILD_NUM=\$(cat /tmp/workspace/BUILD_NUM_DEBUG)
-                        echo "Downloading build from job #\${BUILD_NUM}..."
-                        
-                        # Fetch artifact list
-                        RESPONSE=\$(curl -s -H "Circle-Token: \${CIRCLECI_TOKEN}" \\
-                          "https://circleci.com/api/v2/project/gh/\${CIRCLE_PROJECT_USERNAME}/\${CIRCLE_PROJECT_REPONAME}/\${BUILD_NUM}/artifacts")
-                        
-                        # Extract CUBRID.tar.gz URL
-                        ARTIFACT_URL=\$(echo "\$RESPONSE" | grep -o '"url": "[^"]*CUBRID.tar.gz[^"]*"' | head -1 | sed 's/"url": "//;s/"$//')
-                        
-                        if [ -z "\$ARTIFACT_URL" ]; then
-                          echo "ERROR: CUBRID.tar.gz artifact not found"
-                          echo "Response: \$RESPONSE"
-                          exit 1
-                        fi
-                        
-                        echo "Artifact URL: \$ARTIFACT_URL"
-                        
-                        # Download and extract
-                        curl -L -o /tmp/CUBRID.tar.gz "\$ARTIFACT_URL"
-                        tar xzf /tmp/CUBRID.tar.gz -C /home/
-                        rm /tmp/CUBRID.tar.gz
-                        
-                        echo "Build extracted to /home/CUBRID"
-                        ls -la /home/CUBRID
-
-              download-build-to-glusterfs:
-                description: "Download CUBRID build to GlusterFS shared storage (for shell tests)"
-                steps:
-                  - attach_workspace:
-                      at: /tmp/workspace
-                  - run:
-                      name: Download build to GlusterFS
-                      command: |
-                        BUILD_NUM=\$(cat /tmp/workspace/BUILD_NUM_DEBUG)
-                        # Use CIRCLE_SHA1 (commit hash) to reuse build across workflow retries
-                        BUILD_DIR="/home/build-cache/builds/\${CIRCLE_SHA1}"
-                        
-                        echo "CIRCLE_SHA1: \${CIRCLE_SHA1}"
-                        echo "BUILD_NUM: \${BUILD_NUM}"
-                        echo "BUILD_DIR: \${BUILD_DIR}"
-                        
-                        # Check if build already exists (same commit = same build)
-                        if [ -d "\${BUILD_DIR}/CUBRID" ]; then
-                          echo "Build already exists for this commit, skipping download"
-                          ls -la "\${BUILD_DIR}/CUBRID"
-                          exit 0
-                        fi
-                        
-                        mkdir -p "\${BUILD_DIR}"
-                        
-                        echo "Downloading build from job #\${BUILD_NUM}..."
-                        
-                        # Fetch artifact list
-                        RESPONSE=\$(curl -s -H "Circle-Token: \${CIRCLECI_TOKEN}" \\
-                          "https://circleci.com/api/v2/project/gh/\${CIRCLE_PROJECT_USERNAME}/\${CIRCLE_PROJECT_REPONAME}/\${BUILD_NUM}/artifacts")
-                        
-                        # Extract CUBRID.tar.gz URL
-                        ARTIFACT_URL=\$(echo "\$RESPONSE" | grep -o '"url": "[^"]*CUBRID.tar.gz[^"]*"' | head -1 | sed 's/"url": "//;s/"$//')
-                        
-                        if [ -z "\$ARTIFACT_URL" ]; then
-                          echo "ERROR: CUBRID.tar.gz artifact not found"
-                          echo "Response: \$RESPONSE"
-                          exit 1
-                        fi
-                        
-                        echo "Artifact URL: \$ARTIFACT_URL"
-                        
-                        # Download to GlusterFS
-                        curl -L -o "\${BUILD_DIR}/CUBRID.tar.gz" "\$ARTIFACT_URL"
-                        tar xzf "\${BUILD_DIR}/CUBRID.tar.gz" -C "\${BUILD_DIR}"
-                        rm "\${BUILD_DIR}/CUBRID.tar.gz"
-                        
-                        echo "Build extracted to \${BUILD_DIR}/CUBRID"
-                        ls -la "\${BUILD_DIR}/CUBRID"
-                        df -h /home/build-cache
-                      
-            # --------------------------------------------------
-            # 2. Reusable executors
-            # --------------------------------------------------
-            executors:
-              cubrid-default:
-                docker:
-                  - image: cubridci/cubridci:develop
-                working_directory: /home
-
-              cubrid-test-shell:
-                docker:
-                  - image: cubridci/cubridci:test_shell
-                # self-hosted runner
-                resource_class: cubrid/ramdisk
-                working_directory: /home
-                
-            # --------------------------------------------------
-            # 3. Jobs
-            # --------------------------------------------------
-            jobs:
-              build:
-                executor: cubrid-default
-                resource_class: xlarge
-                environment:
-                  MAKEFLAGS: -j 8
-                  CC: "ccache gcc"
-                  CXX: "ccache g++"
-                  CCACHE_DIR: /home/.ccache
-                  CCACHE_COMPILERCHECK: content
-                  CCACHE_HARDLINK: 1
-                steps:
-                  - checkout
-                  - restore_cache:
-                      keys:
-                        - ccache-global-v2-{{ checksum "build.sh" }}-{{ checksum "CMakeLists.txt" }}-develop-${CIRCLE_SHA1}
-                        - ccache-global-v2-{{ checksum "build.sh" }}-{{ checksum "CMakeLists.txt" }}-develop-
-                  - run:
-                      name: Submodules
-                      command: |
-                        git submodule sync
-                        git submodule update --init
-                  - run:
-                      name: Build (release)
-                      command: |
-                        mkdir -p \$CCACHE_DIR
-                        ccache --max-size=5G
-                        ccache -z
-                        scl enable devtoolset-8 -- /entrypoint.sh build
-                        ccache -s
-            EOF
-            # ccache save: write only on develop-branch builds -> a single shared warm cache (other branches/PRs are restore-only; avoids 5G-per-PR bloat and non-develop pollution)
-            if [ "$CIRCLE_BRANCH" = "develop" ]; then
-            cat \<<EOF >> .circleci/continue.yml
-                  - save_cache:
-                      key: ccache-global-v2-{{ checksum "build.sh" }}-{{ checksum "CMakeLists.txt" }}-develop-${CIRCLE_SHA1}
-                      paths:
-                        - /home/.ccache
-            EOF
+              # Check if tc.list exists and is not empty (tests were assigned to this node)
+              if [ ! -s tc.list ]; then
+                echo "[debug] No tests assigned to this node"
+                circleci-agent step halt
+                exit 0
+              fi
+              echo "[debug] total testcases: $(wc -l tc.list)"
+              echo "[debug] Remove tests that are not in the list"
+              find $base_dir -name "*.sql" -type f | grep -v -F -f tc.list | xargs -r rm -rf
             fi
-            cat \<<EOF >> .circleci/continue.yml
-                  - collect-build-logs
 
-              build_debug:
-                executor: cubrid-default
-                resource_class: xlarge
-                environment:
-                  MAKEFLAGS: -j 8
-                  CC: "ccache gcc"
-                  CXX: "ccache g++"
-                  CCACHE_DIR: /home/.ccache
-                  CCACHE_COMPILERCHECK: content
-                  CCACHE_HARDLINK: 1
-                steps:
-                  - checkout
-                  - restore_cache:
-                      keys:
-                        - ccache-debug-v2-{{ checksum "build.sh" }}-{{ checksum "CMakeLists.txt" }}-develop-${CIRCLE_SHA1}
-                        - ccache-debug-v2-{{ checksum "build.sh" }}-{{ checksum "CMakeLists.txt" }}-develop-
-                  - run:
-                      name: Submodules
-                      command: |
-                        git submodule sync
-                        git submodule update --init
-                  - run:
-                      name: Build (optdebug)
-                      command: |
-                        mkdir -p \$CCACHE_DIR
-                        ccache --max-size=5G
-                        ccache -z
-                        scl enable devtoolset-8 -- /entrypoint.sh build -m optdebug
-                        ccache -s
-            EOF
-            # ccache save: write only on develop-branch builds -> a single shared warm cache (other branches/PRs are restore-only; avoids 5G-per-PR bloat and non-develop pollution)
-            if [ "$CIRCLE_BRANCH" = "develop" ]; then
-            cat \<<EOF >> .circleci/continue.yml
-                  - save_cache:
-                      key: ccache-debug-v2-{{ checksum "build.sh" }}-{{ checksum "CMakeLists.txt" }}-develop-${CIRCLE_SHA1}
-                      paths:
-                        - /home/.ccache
-            EOF
+            echo "[debug] Run the tests"
+            /entrypoint.sh test
+      - run:
+          name: Collect Logs
+          when: on_fail
+          command: |
+            mkdir -p /tmp/logs
+            cp -f /tmp/tests/* /tmp/logs || true
+            if [ "$TEST_SUITE" = "shell" ]; then
+              mv -f cubrid-testtools/CTP/result/shell/current_runtime_logs /tmp/logs/ctp_log || true
+            else
+              mv -f CUBRID/log /tmp/logs/cubrid_log || true
+              mv -f cubrid-testtools/CTP/sql/log /tmp/logs/ctp_log || true
             fi
-            cat \<<EOF >> .circleci/continue.yml
-                  - collect-build-logs
-                  - run:
-                      name: Stop after build logs on default trigger
-                      command: |
-                        case "${CIRCLE_BRANCH:-}" in
-                          */head*)
-                            echo "[info] head trigger detected (${CIRCLE_BRANCH}); continue to package artifacts"
-                            ;;
-                          *)
-                            echo "[info] default trigger detected (${CIRCLE_BRANCH}); stop after collect-build-logs"
-                            circleci-agent step halt
-                            exit 0
-                            ;;
-                        esac
-                  - run:
-                      name: Package build for artifact
-                      command: |
-                        tar czf CUBRID.tar.gz CUBRID
-                        echo "Build packaged: \$(ls -lh CUBRID.tar.gz | awk '{print \$5}')"
-                  - store_artifacts:
-                      path: CUBRID.tar.gz
-                      destination: CUBRID.tar.gz
-                  - run:
-                      name: Save build metadata for test jobs
-                      command: |
-                        mkdir -p workspace
-                        echo "\${CIRCLE_BUILD_NUM}" > workspace/BUILD_NUM_DEBUG
-                        echo "Saved BUILD_NUM_DEBUG: \$(cat workspace/BUILD_NUM_DEBUG)"
-                  - persist_to_workspace:
-                      root: workspace
-                      paths: [ BUILD_NUM_DEBUG ]
-              
-              test_medium:
-                executor: cubrid-default
-                resource_class: medium
-                parallelism: 1
-                environment:
-                  TEST_SUITE: "medium"
-                steps:
-                  - restore_cache:
-                      keys:
-                        - "cubrid-testcases-${CACHE_KEY_BRANCH}-${TC_SHA}"
-                        - "cubrid-testcases-${CACHE_KEY_BRANCH}-"
-                        - "cubrid-testcases-develop-"
-                  - download-build-from-artifact
-                  - attach-and-run-tests
-                  - run:
-                      name: Clean up tc before save_cache
-                      command: |
-                        cd cubrid-testcases
-                        git clean -fd
-                        git reset --hard
-                  - save_cache:
-                      key: "cubrid-testcases-${CACHE_KEY_BRANCH}-${TC_SHA}"
-                      paths:
-                        - cubrid-testcases
-                      
-              test_sql:
-                executor: cubrid-default
-                resource_class: medium
-                parallelism: 10
-                environment:
-                  TEST_SUITE: "sql"
-                steps:
-                  - restore_cache:
-                      keys:
-                        - "cubrid-testcases-${CACHE_KEY_BRANCH}-${TC_SHA}"
-                        - "cubrid-testcases-${CACHE_KEY_BRANCH}-"
-                        - "cubrid-testcases-develop-"
-                  - download-build-from-artifact
-                  - attach-and-run-tests
-                  - run:
-                      name: Clean up tc before save_cache
-                      command: |
-                        cd cubrid-testcases
-                        git clean -fd
-                        git reset --hard
-                  - save_cache:
-                      key: "cubrid-testcases-${CACHE_KEY_BRANCH}-${TC_SHA}"
-                      paths:
-                        - cubrid-testcases
-                      
-              test_shell:
-                executor: cubrid-test-shell
-                parallelism: 50
-                environment:
-                  BASELINE: << pipeline.parameters.baseline >>
-                  TEST_SUITE: "shell"
-                  GITHUB_TOKEN: \$GHI_TOKEN
-                steps:
-                  - attach-and-run-tests
+            [ -e CUBRID/log/coredump ] && mv -f CUBRID/log/coredump /tmp/logs/coredump || true
+            mv -f tc.list /tmp/logs/ || true
+      - store_test_results:
+          path: /tmp/tests
+          when: always
+      - store_artifacts:
+          path: /tmp/logs
+          when: on_fail
 
-              download-build:
-                description: "Download CUBRID build to GlusterFS (1x download for all shell test pods)"
-                executor: cubrid-test-shell
-                parallelism: 1
-                steps:
-                  - download-build-to-glusterfs
-            
-            # --------------------------------------------------
-            # 4. Conditional workflows
-            # --------------------------------------------------
-            workflows:
-              build_test:
-                jobs:
-                  - build
-                  - build_debug
-            EOF
+  download-build-from-artifact:
+    description: "Download CUBRID build from artifact (for sql/medium tests)"
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Download build from artifact
+          command: |
+            BUILD_NUM=$(cat /tmp/workspace/BUILD_NUM_DEBUG)
+            echo "Downloading build from job #${BUILD_NUM}..."
 
-            echo "[debug] Conditionally add test jobs based on parameters"
-            [ "$RUN_MEDIUM_TEST"  = "true" ] && echo "      - test_medium:    {requires: [build, build_debug]}" >> .circleci/continue.yml
-            [ "$RUN_SQL_TEST"     = "true" ] && echo "      - test_sql:       {requires: [build, build_debug]}" >> .circleci/continue.yml
-            if [ "$RUN_SHELL_TEST" = "true" ]; then
-              echo "      - download-build: {requires: [build, build_debug]}" >> .circleci/continue.yml
-              echo "      - test_shell:     {requires: [download-build]}" >> .circleci/continue.yml
+            # Fetch artifact list
+            RESPONSE=$(curl -s -H "Circle-Token: ${CIRCLECI_TOKEN}" \
+              "https://circleci.com/api/v2/project/gh/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${BUILD_NUM}/artifacts")
+
+            # Extract CUBRID.tar.gz URL
+            ARTIFACT_URL=$(echo "$RESPONSE" | grep -o '"url": "[^"]*CUBRID.tar.gz[^"]*"' | head -1 | sed 's/"url": "//;s/"$//')
+
+            if [ -z "$ARTIFACT_URL" ]; then
+              echo "ERROR: CUBRID.tar.gz artifact not found"
+              echo "Response: $RESPONSE"
+              exit 1
             fi
-            
-            echo "[debug] Output generated configuration (.circleci/continue.yml)"
-            cat .circleci/continue.yml
-      
-      - continuation/continue:
-          configuration_path: .circleci/continue.yml
+
+            echo "Artifact URL: $ARTIFACT_URL"
+
+            # Download and extract
+            curl -L -o /tmp/CUBRID.tar.gz "$ARTIFACT_URL"
+            tar xzf /tmp/CUBRID.tar.gz -C /home/
+            rm /tmp/CUBRID.tar.gz
+
+            echo "Build extracted to /home/CUBRID"
+            ls -la /home/CUBRID
+
+  download-build-to-glusterfs:
+    description: "Download CUBRID build to GlusterFS shared storage (for shell tests)"
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Download build to GlusterFS
+          command: |
+            BUILD_NUM=$(cat /tmp/workspace/BUILD_NUM_DEBUG)
+            # Use CIRCLE_SHA1 (commit hash) to reuse build across workflow retries
+            BUILD_DIR="/home/build-cache/builds/${CIRCLE_SHA1}"
+
+            echo "CIRCLE_SHA1: ${CIRCLE_SHA1}"
+            echo "BUILD_NUM: ${BUILD_NUM}"
+            echo "BUILD_DIR: ${BUILD_DIR}"
+
+            # Check if build already exists (same commit = same build)
+            if [ -d "${BUILD_DIR}/CUBRID" ]; then
+              echo "Build already exists for this commit, skipping download"
+              ls -la "${BUILD_DIR}/CUBRID"
+              exit 0
+            fi
+
+            mkdir -p "${BUILD_DIR}"
+
+            echo "Downloading build from job #${BUILD_NUM}..."
+
+            # Fetch artifact list
+            RESPONSE=$(curl -s -H "Circle-Token: ${CIRCLECI_TOKEN}" \
+              "https://circleci.com/api/v2/project/gh/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${BUILD_NUM}/artifacts")
+
+            # Extract CUBRID.tar.gz URL
+            ARTIFACT_URL=$(echo "$RESPONSE" | grep -o '"url": "[^"]*CUBRID.tar.gz[^"]*"' | head -1 | sed 's/"url": "//;s/"$//')
+
+            if [ -z "$ARTIFACT_URL" ]; then
+              echo "ERROR: CUBRID.tar.gz artifact not found"
+              echo "Response: $RESPONSE"
+              exit 1
+            fi
+
+            echo "Artifact URL: $ARTIFACT_URL"
+
+            # Download to GlusterFS
+            curl -L -o "${BUILD_DIR}/CUBRID.tar.gz" "$ARTIFACT_URL"
+            tar xzf "${BUILD_DIR}/CUBRID.tar.gz" -C "${BUILD_DIR}"
+            rm "${BUILD_DIR}/CUBRID.tar.gz"
+
+            echo "Build extracted to ${BUILD_DIR}/CUBRID"
+            ls -la "${BUILD_DIR}/CUBRID"
+            df -h /home/build-cache
 
 # --------------------------------------------------
-# Workflows
+# 3. Jobs
+# --------------------------------------------------
+jobs:
+  build:
+    executor: cubrid-build
+    steps:
+      - build-cubrid:
+          ccache-prefix: ccache-global-v2
+
+  build_debug:
+    executor: cubrid-build
+    steps:
+      - build-cubrid:
+          ccache-prefix: ccache-debug-v2
+          mode: optdebug
+          build-args: "-m optdebug"
+      # Package the debug build only when a test job will consume it.
+      - when:
+          condition:
+            or:
+              - << pipeline.parameters.run_sql_test >>
+              - << pipeline.parameters.run_medium_test >>
+              - << pipeline.parameters.run_shell_test >>
+          steps:
+            - run:
+                name: Package build for artifact
+                command: |
+                  tar czf CUBRID.tar.gz CUBRID
+                  echo "Build packaged: $(ls -lh CUBRID.tar.gz | awk '{print $5}')"
+            - store_artifacts:
+                path: CUBRID.tar.gz
+                destination: CUBRID.tar.gz
+            - run:
+                name: Save build metadata for test jobs
+                command: |
+                  mkdir -p workspace
+                  echo "${CIRCLE_BUILD_NUM}" > workspace/BUILD_NUM_DEBUG
+                  echo "Saved BUILD_NUM_DEBUG: $(cat workspace/BUILD_NUM_DEBUG)"
+            - persist_to_workspace:
+                root: workspace
+                paths: [ BUILD_NUM_DEBUG ]
+
+  # sql and medium tests share the same shape; parameterized to avoid duplication
+  artifact-test:
+    executor: cubrid-default
+    resource_class: medium
+    parameters:
+      suite:
+        type: string
+      parallelism:
+        type: integer
+    parallelism: << parameters.parallelism >>
+    environment:
+      TEST_SUITE: << parameters.suite >>
+    steps:
+      - resolve-testcases
+      - restore_cache:
+          keys:
+            - cubrid-testcases-{{ checksum "/tmp/tc_cache_branch" }}-{{ checksum "/tmp/tc_cache_sha" }}
+            - cubrid-testcases-{{ checksum "/tmp/tc_cache_branch" }}-
+            - cubrid-testcases-{{ checksum "/tmp/tc_cache_develop" }}-
+      - download-build-from-artifact
+      - run-tests
+      - run:
+          name: Clean up tc before save_cache
+          command: |
+            cd cubrid-testcases
+            git clean -fd
+            git reset --hard
+      - save_cache:
+          key: cubrid-testcases-{{ checksum "/tmp/tc_cache_branch" }}-{{ checksum "/tmp/tc_cache_sha" }}
+          paths:
+            - cubrid-testcases
+
+  test_shell:
+    executor: cubrid-test-shell
+    parallelism: 50
+    environment:
+      BASELINE: << pipeline.parameters.baseline >>
+      TEST_SUITE: "shell"
+      GITHUB_TOKEN: $GHI_TOKEN
+    steps:
+      - resolve-testcases
+      - run-tests
+
+  download-build:
+    description: "Download CUBRID build to GlusterFS (1x download for all shell test pods)"
+    executor: cubrid-test-shell
+    parallelism: 1
+    steps:
+      - download-build-to-glusterfs
+
+# --------------------------------------------------
+# 4. Workflow (conditional test jobs via expression-based filters)
 # --------------------------------------------------
 workflows:
-  # Initial setup workflow to generate dynamic configuration
-  setup:
-    jobs: [ setup ]
+  build_test:
+    jobs:
+      - build
+      - build_debug
+      - artifact-test:
+          name: test_medium
+          suite: medium
+          parallelism: 1
+          requires: [build_debug]
+          filters: pipeline.parameters.run_medium_test
+      - artifact-test:
+          name: test_sql
+          suite: sql
+          parallelism: 10
+          requires: [build_debug]
+          filters: pipeline.parameters.run_sql_test
+      - download-build:
+          requires: [build_debug]
+          filters: pipeline.parameters.run_shell_test
+      - test_shell:
+          requires: [download-build]
+          filters: pipeline.parameters.run_shell_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -425,15 +425,33 @@ jobs:
       TEST_SUITE: "shell"
       GITHUB_TOKEN: $GHI_TOKEN
     steps:
-      - resolve-testcases
+      # Testcases branch is resolved once in download-build and shared via the
+      # workspace, so the 50 shell pods never hit cubrid-testcases themselves.
+      - attach_workspace:
+          at: /tmp/tcws
+      - run:
+          name: Load shared testcases branch
+          command: |
+            echo "export BRANCH_TESTCASES=$(cat /tmp/tcws/BRANCH_TESTCASES)" >> "$BASH_ENV"
       - run-tests
 
   download-build:
-    description: "Download CUBRID build to GlusterFS (1x download for all shell test pods)"
+    description: "Download CUBRID build to GlusterFS and resolve the testcases branch once for all shell pods"
     executor: cubrid-test-shell
     parallelism: 1
     steps:
       - download-build-to-glusterfs
+      # Resolve the testcases branch a single time (reuses resolve-testcases,
+      # which exports BRANCH_TESTCASES) and hand it to the shell pods.
+      - resolve-testcases
+      - run:
+          name: Persist testcases branch for shell pods
+          command: |
+            mkdir -p /tmp/tcws
+            echo "$BRANCH_TESTCASES" > /tmp/tcws/BRANCH_TESTCASES
+      - persist_to_workspace:
+          root: /tmp/tcws
+          paths: [ BRANCH_TESTCASES ]
 
 # --------------------------------------------------
 # 4. Workflow (conditional test jobs via expression-based filters)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,16 +120,24 @@ commands:
       - collect-build-logs
 
   resolve-testcases:
-    description: "Resolve testcases branch/SHA; export BRANCH_TESTCASES and materialize cache-key inputs"
+    description: "Resolve testcases branch/SHA for a TC repo; export BRANCH_TESTCASES and materialize cache-key inputs"
+    parameters:
+      tc-repo:
+        # Resolve against the repo the suite actually checks out: public
+        # cubrid-testcases for sql/medium, private cubrid-testcases-private-ex
+        # for shell. Their tc/pr-<N> branches are created independently and
+        # often diverge, so each suite must resolve against its own repo.
+        type: string
+        default: cubrid-testcases
     steps:
       - run:
-          name: Resolve testcases branch and SHA
+          name: Resolve testcases branch and SHA (<< parameters.tc-repo >>)
           command: |
-            TC_REPO="https://x-access-token:${GHI_TOKEN}@github.com/CUBRID/cubrid-testcases.git"
+            TC_REPO="https://x-access-token:${GHI_TOKEN}@github.com/CUBRID/<< parameters.tc-repo >>.git"
 
             # ls-remote the testcases repo with retries. A transient network error
-            # (e.g. "Empty reply from server" under the 50-way shell fan-out) must not
-            # fail the job: on persistent failure we return empty and fall back to develop.
+            # (e.g. "Empty reply from server") must not fail the job: on persistent
+            # failure we return empty and fall back to develop.
             resolve_sha() {
               local i out
               for i in 1 2 3 4 5; do
@@ -442,8 +450,10 @@ jobs:
     steps:
       - download-build-to-glusterfs
       # Resolve the testcases branch a single time (reuses resolve-testcases,
-      # which exports BRANCH_TESTCASES) and hand it to the shell pods.
-      - resolve-testcases
+      # which exports BRANCH_TESTCASES) and hand it to the shell pods. Shell runs
+      # the private repo, so resolve against cubrid-testcases-private-ex.
+      - resolve-testcases:
+          tc-repo: cubrid-testcases-private-ex
       - run:
           name: Persist testcases branch for shell pods
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,16 +125,34 @@ commands:
       - run:
           name: Resolve testcases branch and SHA
           command: |
+            TC_REPO="https://x-access-token:${GHI_TOKEN}@github.com/CUBRID/cubrid-testcases.git"
+
+            # ls-remote the testcases repo with retries. A transient network error
+            # (e.g. "Empty reply from server" under the 50-way shell fan-out) must not
+            # fail the job: on persistent failure we return empty and fall back to develop.
+            resolve_sha() {
+              local i out
+              for i in 1 2 3 4 5; do
+                if out=$(git ls-remote "$TC_REPO" "$1" 2>/dev/null); then
+                  echo "$out" | cut -f1
+                  return 0
+                fi
+                echo "[warn] ls-remote '$1' failed (attempt $i); retrying" >&2
+                sleep $((i * 3))
+              done
+              echo "[warn] ls-remote '$1' failed after retries; continuing without SHA" >&2
+            }
+
             if [[ "$CIRCLE_BRANCH" == pull/* ]]; then
               TC_BRANCH="tc/pr-${CIRCLE_BRANCH//[^0-9]/}"
             else
               TC_BRANCH="develop"
             fi
 
-            TC_SHA=$(git ls-remote https://x-access-token:${GHI_TOKEN}@github.com/CUBRID/cubrid-testcases.git ${TC_BRANCH} | cut -f1)
+            TC_SHA=$(resolve_sha "$TC_BRANCH")
             if [ -z "$TC_SHA" ]; then
               TC_BRANCH="develop"
-              TC_SHA=$(git ls-remote https://x-access-token:${GHI_TOKEN}@github.com/CUBRID/cubrid-testcases.git develop | cut -f1)
+              TC_SHA=$(resolve_sha develop)
             fi
 
             CACHE_KEY_BRANCH="${TC_BRANCH//\//-}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,10 +213,28 @@ commands:
 
             if [ "$TEST_SUITE" = "shell" ]; then
               echo "[debug] split tests for parallel execution"
-              circleci tests glob "$glob_path" | grep -P '/([^/]+)/cases/\1\.sh$' \
-                | circleci tests run --command="tee tc.list" --verbose --split-by=timings --timings-type=file
+              # The split can fail transiently (e.g. the circleci-tests-plugin-cli
+              # download timing out under 50-way fan-out). Retry it, and if it still
+              # fails, fail this node instead of falling through to the "no tests"
+              # halt below, which would silently skip this node's share of the tests.
+              split_tests() {
+                : > tc.list
+                circleci tests glob "$glob_path" | grep -P '/([^/]+)/cases/\1\.sh$' \
+                  | circleci tests run --command="tee tc.list" --verbose --split-by=timings --timings-type=file
+              }
+              n=0
+              until split_tests; do
+                n=$((n + 1))
+                if [ "$n" -ge 4 ]; then
+                  echo "[error] test split failed after $n attempts; failing node to avoid silently skipping tests"
+                  exit 1
+                fi
+                echo "[warn] test split failed; retry $n after backoff"
+                sleep $((n * 10))
+              done
 
-              # Check if tc.list exists and is not empty (tests were assigned to this node)
+              # Split succeeded. An empty tc.list here is a genuine empty assignment
+              # (normal during "rerun failed tests only") -> halt this node as success.
               if [ ! -s tc.list ]; then
                 echo "[debug] No tests assigned to this node"
                 circleci-agent step halt
@@ -228,10 +246,27 @@ commands:
               find $base_dir -name "cases" -type d | grep -v -F -f tc_dirs.list | xargs -r rm -rf
             else
               echo "[debug] split tests for parallel execution"
-              circleci tests glob "$glob_path" \
-                | circleci tests run --command="xargs -n1 >> tc.list" --verbose --split-by=name
+              # Same resilience as the shell branch: retry a transient split failure
+              # and fail the node rather than silently skipping its tests. tc.list is
+              # reset each attempt because the split command appends (>>).
+              split_tests() {
+                : > tc.list
+                circleci tests glob "$glob_path" \
+                  | circleci tests run --command="xargs -n1 >> tc.list" --verbose --split-by=name
+              }
+              n=0
+              until split_tests; do
+                n=$((n + 1))
+                if [ "$n" -ge 4 ]; then
+                  echo "[error] test split failed after $n attempts; failing node to avoid silently skipping tests"
+                  exit 1
+                fi
+                echo "[warn] test split failed; retry $n after backoff"
+                sleep $((n * 10))
+              done
 
-              # Check if tc.list exists and is not empty (tests were assigned to this node)
+              # Split succeeded. An empty tc.list here is a genuine empty assignment
+              # (normal during "rerun failed tests only") -> halt this node as success.
               if [ ! -s tc.list ]; then
                 echo "[debug] No tests assigned to this node"
                 circleci-agent step halt


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1436>

### Purpose

기존 `.circleci/config.yml`은 dynamic config(setup workflow + continuation orb)라 setup job이 shell heredoc으로 실제 파이프라인을 문자열로 찍어내는 구조였습니다. 이스케이프가 뒤섞여 읽기 어렵고, 문자열이라 `circleci config validate`로 로컬 검증이 안 되며, 매 파이프라인마다 setup job이 한 번 더 도는 오버헤드가 있었습니다. (#7480으로 머지→#7517로 revert 후, 아래 수정을 포함해 재적용하는 PR입니다.)

### Implementation

dynamic config를 제거하고 **단일 static v2.1 config**로 다시 썼습니다. setup job이 런타임에 만들던 것을 static 기능으로 1:1 대체했고, 동작은 동일합니다.

- **파라미터별 테스트 job 선택**: expression-based job filters(`filters: pipeline.parameters.run_sql_test` 등).
- **테스트는 debug(optdebug) 빌드로만**: `test_medium`/`test_sql`/`download-build`가 `requires: [build_debug]`. release는 병렬로 빌드되지만 테스트를 gate하지 않음.
- **ccache**: develop 브랜치에서만 저장(컴파일타임 `when`), 커밋 SHA는 `{{ .Revision }}`로 기존 warm 캐시 계승.
- **중복 제거**: release/debug 빌드는 공유 커맨드(`build-cubrid`), sql/medium은 파라미터화 job(`artifact-test`).
- **테스트케이스 브랜치 해석(`resolve-testcases`)**:
  - shell은 `download-build`(1×)에서 한 번만 resolve해 `BRANCH_TESTCASES`를 workspace로 전달 → 50개 shell pod가 각자 cubrid-testcases를 건드리지 않음. ls-remote는 재시도로 감싸 일시적 네트워크 오류에 견딤.
  - **repo별 독립 판정**: sql/medium은 public `cubrid-testcases`, shell은 private `cubrid-testcases-private-ex`에서 각각 브랜치를 판정(`tc-repo` 파라미터). 두 repo의 `tc/pr-<N>`는 `tc-branch-sync`가 독립 생성하여 자주 어긋나므로, 각 스위트는 자기가 체크아웃하는 repo에서 판정해야 함.
- public `cubrid-testcases`는 CircleCI 캐시(restore/save)로 재clone 방지, private `cubrid-testcases-private-ex`는 노드 overlay를 최신화해 사용(설계 유지).
- **테스트 분할 실패를 노드 실패로 처리(가짜 성공 방지)**: 각 테스트 job은 `circleci tests run`으로 케이스를 병렬 노드에 나눕니다. 이 명령이 런타임에 받는 `circleci-tests-plugin-cli` 다운로드가 50개 노드 동시 요청에서 가끔 타임아웃(`context deadline exceeded`)되면, 예전엔 그 노드가 "배정된 테스트 없음"으로 오인돼 성공(halt)으로 넘어가 자기 몫 테스트를 조용히 건너뛰었습니다(그래도 job 전체는 success로 표시=가짜 성공). 이제 분할을 재시도(backoff)로 감싸고, 지속 실패 시 노드를 **실패**시켜 조용한 누락을 막습니다. 반면 "rerun failed tests only" 재실행처럼 **정상적으로 배정이 빈 노드**는 종전처럼 성공(halt)으로 유지합니다.

### Remarks

- **트리거·웹 설정 변화 없음**: develop 머지/PR 커밋 자동 빌드(webhook), `/run all|sql|shell|medium` 코멘트(GitHub Actions → CircleCI API) 그대로. "Enable dynamic config using setup workflows" 토글은 켜둔 채여도 `setup: true`가 없으면 static으로 정상 동작(공식 문서 확인).
- **검증**: `circleci` CLI로 validate + 파라미터 시나리오 process 대조, `/run all` 파이프라인으로 build/build_debug/test_sql/test_medium/download-build 성공 및 job 의존성(테스트가 build_debug에만 의존) 실측.
- **분할 실패 처리 검증**: 다른 PR들의 실제 "rerun failed tests only" 재실행에서 배정이 빈 노드(예: 50개 중 48~49개)가 종전처럼 성공(halt)으로 처리됨을 확인 → 이번 변경이 재실행 기능을 깨지 않음을 실측했습니다. 반대로 분할이 실패하면 이제 해당 노드가 초록색 대신 실패로 뜹니다.
- **후속(백로그)**: 브랜치 fallback을 develop 고정 → **엔진 PR base branch** 인식(`tc/pr-<N>` → PR base.ref → develop)으로 개선하는 건 별도 작업으로 남깁니다. `feature/*`로의 머지도 PR이라 base가 develop이 아닐 수 있습니다.
- `test_shell`의 일부 shard/backup TC(예: `bug_bts_10041`, `cbrd_21506_backupdb`)는 이 변경과 무관한 기존 flaky이며, 별개로 다룹니다. entrypoint 체크아웃 견고화는 cubridci PR #98/#99/#100로 진행 중입니다.

