### PR TITLE
[CBRD-26255] optimize pooled connection request handling

### DIFF
--- a/src/base/packet_buffer.cpp
+++ b/src/base/packet_buffer.cpp
@@ -78,6 +78,11 @@ namespace cubbase
     return m_length;
   }
 
+  std::size_t packet_buffer::get_buffer_count ()
+  {
+    return m_buf.size ();
+  }
+
   void packet_buffer::stamp_msghdr ()
   {
     assert (m_buf.size () != 0);
@@ -119,4 +124,3 @@ namespace cubbase
       }
   }
 }
-

--- a/src/base/packet_buffer.cpp
+++ b/src/base/packet_buffer.cpp
@@ -56,6 +56,7 @@ namespace cubbase
     m_buf.clear ();
     m_length = 0;
     m_index = 0;
+    m_compacted_iov_count = 0;
 
     for (auto p : m_heap)
       {
@@ -78,9 +79,43 @@ namespace cubbase
     return m_length;
   }
 
-  std::size_t packet_buffer::get_buffer_count ()
+  bool packet_buffer::prepare_append (std::size_t additional_count, std::size_t &completed_iov_count)
   {
-    return m_buf.size ();
+    std::size_t active_count;
+
+    this->save_index ();
+    assert (m_index <= m_buf.size ());
+
+    active_count = m_buf.size () - m_index;
+    completed_iov_count = m_compacted_iov_count + m_index;
+    if (active_count > m_iovmax || additional_count > m_iovmax - active_count)
+      {
+	return false;
+      }
+
+    if (m_buf.size () <= m_iovmax - additional_count)
+      {
+	return true;
+      }
+
+    /* keep a partially consumed first iovec and discard only the fully consumed prefix. */
+    assert (m_index > 0);
+    m_buf.erase (m_buf.begin (), m_buf.begin () + m_index);
+    m_compacted_iov_count += m_index;
+    m_index = 0;
+
+    if (m_buf.empty ())
+      {
+	m_msg.msg_iov = nullptr;
+	m_msg.msg_iovlen = 0;
+      }
+    else
+      {
+	this->stamp_msghdr ();
+      }
+
+    assert (m_buf.size () <= m_iovmax - additional_count);
+    return true;
   }
 
   void packet_buffer::stamp_msghdr ()

--- a/src/base/packet_buffer.hpp
+++ b/src/base/packet_buffer.hpp
@@ -65,7 +65,7 @@ namespace cubbase
       void push (const cubbase::span<std::byte> &first, const Spans &... rest);
 
       std::size_t get_length ();
-      std::size_t get_buffer_count ();
+      bool prepare_append (std::size_t additional_count, std::size_t &completed_iov_count);
 
       void stamp_msghdr ();
       struct ::msghdr &get_msghdr ();
@@ -78,6 +78,7 @@ namespace cubbase
       std::vector<std::byte *> m_heap;
       std::size_t m_length;
       std::size_t m_index;
+      std::size_t m_compacted_iov_count;
 
       struct ::msghdr m_msg;
 

--- a/src/base/packet_buffer.hpp
+++ b/src/base/packet_buffer.hpp
@@ -65,6 +65,7 @@ namespace cubbase
       void push (const cubbase::span<std::byte> &first, const Spans &... rest);
 
       std::size_t get_length ();
+      std::size_t get_buffer_count ();
 
       void stamp_msghdr ();
       struct ::msghdr &get_msghdr ();

--- a/src/connection/connection_context.cpp
+++ b/src/connection/connection_context.cpp
@@ -76,6 +76,7 @@ namespace cubconn::connection
     m_id (0),
     m_ignore (ignore_level::DONT_IGNORE),
     m_removed (false),
+    m_epoll_registered (false),
     m_recv
   {
     .m_state = state::HEADER,
@@ -98,6 +99,7 @@ namespace cubconn::connection
     m_id (0),
     m_ignore (ignore_level::DONT_IGNORE),
     m_removed (false),
+    m_epoll_registered (false),
     m_recv
   {
     .m_state = state::HEADER,
@@ -130,6 +132,7 @@ namespace cubconn::connection
     m_id = 0;
     m_ignore = ignore_level::DONT_IGNORE;
     m_removed = false;
+    m_epoll_registered = false;
 
     m_recv.m_state = state::HEADER;
     m_recv.m_receiver.reset ();

--- a/src/connection/connection_context.cpp
+++ b/src/connection/connection_context.cpp
@@ -143,7 +143,7 @@ namespace cubconn::connection
     m_send.m_transmitter.clear ();
     m_send.m_blocker = nullptr;
 
-    m_atomic_stats.bytes_out_total.store (0, std::memory_order_relaxed);
+    m_guarded_stats.bytes_out_total = 0;
     m_stats.reset ();
   }
 }

--- a/src/connection/connection_context.cpp
+++ b/src/connection/connection_context.cpp
@@ -143,6 +143,7 @@ namespace cubconn::connection
     m_send.m_transmitter.clear ();
     m_send.m_blocker = nullptr;
 
+    m_atomic_stats.bytes_out_total.store (0, std::memory_order_relaxed);
     m_stats.reset ();
   }
 }

--- a/src/connection/connection_context.hpp
+++ b/src/connection/connection_context.hpp
@@ -31,7 +31,6 @@
 #include "buffer.hpp"
 #include "span.hpp"
 
-#include <atomic>
 #include <condition_variable>
 
 namespace cubconn
@@ -192,11 +191,11 @@ namespace cubconn::connection
     /* owned statistics */
     statistics::metrics<statistics::context> m_stats;
 
-    /* atomic statistics */
+    /* statistics updated by direct send, guarded by m_conn->cmutex */
     struct
     {
-      std::atomic<uint64_t> bytes_out_total { 0 };
-    } m_atomic_stats;
+      uint64_t bytes_out_total { 0 };
+    } m_guarded_stats;
 
     context (std::size_t capacity);
     context ();

--- a/src/connection/connection_context.hpp
+++ b/src/connection/connection_context.hpp
@@ -155,6 +155,7 @@ namespace cubconn::connection
     /* ignore guards (ERR/HUP) */
     ignore_level m_ignore;
     bool m_removed;
+    bool m_epoll_registered;
 
     /* --------------------------------------------------------------------------- */
     /* reception								   */

--- a/src/connection/connection_context.hpp
+++ b/src/connection/connection_context.hpp
@@ -181,8 +181,8 @@ namespace cubconn::connection
     {
       transmitter m_transmitter;
 
-      /* if multiple task workers request blocking transmissions simultaneously, below */
-      /* member should be replaced with a vector (or a similar collection)	       */
+      /* shared by every sender blocked on this transmitter (bad case) all of them are woken */
+      /* together (notify_all) when the pending transmission drains or is discarded */
       std::shared_ptr<message_blocker> m_blocker;
     } m_send;
 

--- a/src/connection/connection_context.hpp
+++ b/src/connection/connection_context.hpp
@@ -31,6 +31,7 @@
 #include "buffer.hpp"
 #include "span.hpp"
 
+#include <atomic>
 #include <condition_variable>
 
 namespace cubconn
@@ -188,7 +189,14 @@ namespace cubconn::connection
     /* --------------------------------------------------------------------------- */
     /* statistics								   */
     /* --------------------------------------------------------------------------- */
+    /* owned statistics */
     statistics::metrics<statistics::context> m_stats;
+
+    /* atomic statistics */
+    struct
+    {
+      std::atomic<uint64_t> bytes_out_total { 0 };
+    } m_atomic_stats;
 
     context (std::size_t capacity);
     context ();

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -3029,15 +3029,10 @@ css_request_shutdown_conn (css_conn_entry * conn, uint8_t ignore, bool retry, in
 void
 css_request_release_packet (css_conn_entry * conn, void *buffer)
 {
-  cubconn::connection::worker::message request;
   cubconn::connection::context * ctx;
   int r;
 
   assert (conn && buffer);
-
-  request.type = cubconn::connection::worker::message_type::RELEASE_PACKET;
-  request.conn = conn;
-  request.packet.emplace_back ((std::byte *) buffer, 0 /* idk the size */ );
 
   /* lock to access worker and context */
   r = rmutex_lock (NULL, &conn->cmutex);
@@ -3057,10 +3052,7 @@ css_request_release_packet (css_conn_entry * conn, void *buffer)
     }
 
   ctx = static_cast < cubconn::connection::context * >(conn->context);
-  request.ctx = ctx;
-  request.id = ctx->m_id;
-
-  conn->worker->enqueue (cubconn::connection::worker::queue_type::IMMEDIATE, std::move (request));
+  ctx->m_recv.m_receiver.release (static_cast < std::byte * >(buffer));
 
   /* unlock */
   r = rmutex_unlock (NULL, &conn->cmutex);

--- a/src/connection/connection_sr.c
+++ b/src/connection/connection_sr.c
@@ -3029,6 +3029,7 @@ css_request_shutdown_conn (css_conn_entry * conn, uint8_t ignore, bool retry, in
 void
 css_request_release_packet (css_conn_entry * conn, void *buffer)
 {
+  cubconn::connection::worker::message request;
   cubconn::connection::context * ctx;
   int r;
 
@@ -3052,11 +3053,30 @@ css_request_release_packet (css_conn_entry * conn, void *buffer)
     }
 
   ctx = static_cast < cubconn::connection::context * >(conn->context);
-  ctx->m_recv.m_receiver.release (static_cast < std::byte * >(buffer));
+  if (ctx->m_recv.m_receiver.try_release (static_cast < std::byte * >(buffer)))
+    {
+      /* unlock */
+      r = rmutex_unlock (NULL, &conn->cmutex);
+      assert (r == NO_ERROR);
 
-  /* unlock */
-  r = rmutex_unlock (NULL, &conn->cmutex);
-  assert (r == NO_ERROR);
+      return;
+    }
+
+  request.type = cubconn::connection::worker::message_type::RELEASE_PACKET;
+  request.conn = conn;
+  request.ctx = ctx;
+  request.id = ctx->m_id;
+  request.packet = static_cast < std::byte * >(buffer);
+
+  auto func =[conn] ()noexcept {
+    /* unlock */
+    rmutex_unlock (NULL, &conn->cmutex);
+  };
+
+  if (!conn->worker->enqueue_and_notify (cubconn::connection::worker::queue_type::IMMEDIATE, std::move (request), func))
+    {
+      assert_release (false);
+    }
 }
 
 void

--- a/src/connection/connection_statistics.hpp
+++ b/src/connection/connection_statistics.hpp
@@ -75,6 +75,7 @@ namespace cubconn::statistics
     MQ_HANDOFF_CLIENT, /* count */
     MQ_TAKEOVER_CLIENT, /* count */
     MQ_SHUTDOWN_CLIENT, /* count */
+    MQ_RELEASE_PACKET, /* count */
 
     /* --------------------------------------------------------------------------- */
     /* blocked									   */
@@ -100,6 +101,7 @@ namespace cubconn::statistics
     { "MQ_HANDOFF_CLIENT", "" },
     { "MQ_TAKEOVER_CLIENT", "" },
     { "MQ_SHUTDOWN_CLIENT", "" },
+    { "MQ_RELEASE_PACKET", "" },
 
     { "BLOCKED_RMUTEX", "us" },
   };

--- a/src/connection/connection_statistics.hpp
+++ b/src/connection/connection_statistics.hpp
@@ -75,7 +75,6 @@ namespace cubconn::statistics
     MQ_HANDOFF_CLIENT, /* count */
     MQ_TAKEOVER_CLIENT, /* count */
     MQ_SHUTDOWN_CLIENT, /* count */
-    MQ_RELEASE_PACKET, /* count */
 
     /* --------------------------------------------------------------------------- */
     /* blocked									   */
@@ -101,7 +100,6 @@ namespace cubconn::statistics
     { "MQ_HANDOFF_CLIENT", "" },
     { "MQ_TAKEOVER_CLIENT", "" },
     { "MQ_SHUTDOWN_CLIENT", "" },
-    { "MQ_RELEASE_PACKET", "" },
 
     { "BLOCKED_RMUTEX", "us" },
   };

--- a/src/connection/connection_statistics.hpp
+++ b/src/connection/connection_statistics.hpp
@@ -75,7 +75,6 @@ namespace cubconn::statistics
     MQ_HANDOFF_CLIENT, /* count */
     MQ_TAKEOVER_CLIENT, /* count */
     MQ_SHUTDOWN_CLIENT, /* count */
-    MQ_SEND_PACKET, /* count */
     MQ_RELEASE_PACKET, /* count */
 
     /* --------------------------------------------------------------------------- */
@@ -102,7 +101,6 @@ namespace cubconn::statistics
     { "MQ_HANDOFF_CLIENT", "" },
     { "MQ_TAKEOVER_CLIENT", "" },
     { "MQ_SHUTDOWN_CLIENT", "" },
-    { "MQ_SEND_PACKET", "" },
     { "MQ_RELEASE_PACKET", "" },
 
     { "BLOCKED_RMUTEX", "us" },

--- a/src/connection/connection_worker.cpp
+++ b/src/connection/connection_worker.cpp
@@ -144,7 +144,7 @@ namespace cubconn::connection
 	if (bytes > 0)
 	  {
 	    sent_size = static_cast<std::size_t> (bytes);
-	    ctx->m_stats.add (statistics::context::BYTES_OUT_TOTAL, sent_size);
+	    ctx->m_atomic_stats.bytes_out_total.fetch_add (sent_size, std::memory_order_relaxed);
 	  }
 	else if (bytes < 0)
 	  {
@@ -896,6 +896,11 @@ retry:
     message.statistics.contexts.reserve (m_context.size ());
     for (context *ctx : m_context)
       {
+	/* integrate atomic stats to owned stats */
+	ctx->m_stats.add (statistics::context::BYTES_OUT_TOTAL,
+			  ctx->m_atomic_stats.bytes_out_total.exchange (0, std::memory_order_relaxed));
+
+	/* store */
 	message.statistics.contexts.emplace_back (ctx->m_id, ctx->m_stats);
       }
 

--- a/src/connection/connection_worker.cpp
+++ b/src/connection/connection_worker.cpp
@@ -1232,59 +1232,6 @@ retry:
     return true;
   }
 
-  bool worker::handle_message_queue_release_packet (message &item)
-  {
-    context *ctx;
-    css_conn_entry *conn;
-    int r;
-
-    assert (item.conn);
-    assert (item.packet.size () > 0);
-
-    r = rmutex_lock (m_entry, &item.conn->cmutex);
-    assert (r == NO_ERROR);
-
-    ctx = reinterpret_cast<context *> (item.conn->context);
-    if (ctx == nullptr)
-      {
-	r = rmutex_unlock (m_entry, &item.conn->cmutex);
-	assert (r == NO_ERROR);
-
-	er_log_conn (__FILE__, __LINE__,
-		     "connection::worker->handle_message_queue_release_packet: context is already cleared for conn = %p\n",
-		     static_cast<void *> (item.conn));
-	return true;
-      }
-
-    conn = item.conn;
-    if (!this->validate_message_generation (item, ctx))
-      {
-	r = rmutex_unlock (m_entry, &conn->cmutex);
-	assert (r == NO_ERROR);
-
-	return true;
-      }
-    if (this->forward_message_to_successor (queue_type::IMMEDIATE, item, ctx))
-      {
-	r = rmutex_unlock (m_entry, &conn->cmutex);
-	assert (r == NO_ERROR);
-
-	return true;
-      }
-
-    for (cubbase::span<std::byte> &packet : item.packet)
-      {
-	ctx->m_recv.m_receiver.release (packet.data ());
-	er_log_conn (__FILE__, __LINE__,
-		     "connection::worker->handle_message_queue_release_packet: release packet pointer = %p\n", packet.data ());
-      }
-
-    r = rmutex_unlock (m_entry, &item.conn->cmutex);
-    assert (r == NO_ERROR);
-
-    return true;
-  }
-
   bool worker::handle_message_queue_new_client (message &item)
   {
     context *ctx;
@@ -1608,8 +1555,7 @@ respond:
 	/* NEW_CLIENT	   */ { &worker::handle_message_queue_new_client,	statistics::worker::MQ_NEW_CLIENT },
 	/* HANDOFF_CLIENT  */ { &worker::handle_message_queue_handoff_client,	statistics::worker::MQ_HANDOFF_CLIENT },
 	/* TAKEOVER_CLIENT */ { &worker::handle_message_queue_takeover_client,	statistics::worker::MQ_TAKEOVER_CLIENT },
-	/* SHUTDOWN_CLIENT */ { &worker::handle_message_queue_shutdown_client,	statistics::worker::MQ_SHUTDOWN_CLIENT },
-	/* RELEASE_PACKET  */ { &worker::handle_message_queue_release_packet,	statistics::worker::MQ_RELEASE_PACKET }
+	/* SHUTDOWN_CLIENT */ { &worker::handle_message_queue_shutdown_client,	statistics::worker::MQ_SHUTDOWN_CLIENT }
       }
     };
     message request;
@@ -1617,7 +1563,7 @@ respond:
 
     static_assert (static_cast<int> (message_type::START) == 0, "message_type must start at 0");
     static_assert (static_cast<int> (message_type::TYPE_COUNT) == handler.size (), "handler table size must match");
-    static_assert (static_cast<int> (message_type::TYPE_COUNT) == 9, "this must be modified");
+    static_assert (static_cast<int> (message_type::TYPE_COUNT) == 8, "this must be modified");
 
     i = 0;
     size = m_queue_size[static_cast<std::size_t> (type)].exchange (0, std::memory_order_acquire);
@@ -2370,7 +2316,6 @@ respond:
 	      case message_type::AWAKEN:
 	      case message_type::SHUTDOWN:
 	      case message_type::HANDOFF_CLIENT:
-	      case message_type::RELEASE_PACKET:
 	      case message_type::TYPE_COUNT:
 		break;
 	      }

--- a/src/connection/connection_worker.cpp
+++ b/src/connection/connection_worker.cpp
@@ -96,6 +96,14 @@ namespace cubconn::connection
     bool retain_deleter = false;
     int send_errno = 0;
     int r;
+    auto release_allocated = [&allocated, &allocated_count] ()
+    {
+      for (std::size_t allocation = 0; allocation < allocated_count; allocation++)
+	{
+	  delete [] allocated[allocation];
+	}
+      allocated_count = 0;
+    };
 
     assert (conn != nullptr);
     assert (packet != nullptr);
@@ -215,10 +223,7 @@ namespace cubconn::connection
 	  copy = new std::byte[available];
 	  if (copy == nullptr)
 	    {
-	      for (std::size_t allocation = 0; allocation < allocated_count; allocation++)
-		{
-		  delete [] allocated[allocation];
-		}
+	      release_allocated ();
 	      r = rmutex_unlock (NULL, &conn->cmutex);
 	      assert (r == NO_ERROR);
 	      if (deleter)
@@ -237,21 +242,13 @@ namespace cubconn::connection
       assert (pending_size == total_size - sent_size);
     }
 
-    if (ctx->m_send.m_transmitter.get_buffer_count () + pending_count > IOV_MAX)
+    if (!ctx->m_send.m_transmitter.prepare_append (pending_count))
       {
-	std::size_t existing_count = ctx->m_send.m_transmitter.get_buffer_count ();
 	std::byte *coalesced;
 
-	for (std::size_t allocation = 0; allocation < allocated_count; allocation++)
+	if (!ctx->m_send.m_transmitter.prepare_append (1))
 	  {
-	    delete [] allocated[allocation];
-	  }
-	allocated_count = 0;
-	pending_count = 0;
-	retain_deleter = false;
-
-	if (existing_count >= IOV_MAX)
-	  {
+	    release_allocated ();
 	    r = rmutex_unlock (NULL, &conn->cmutex);
 	    assert (r == NO_ERROR);
 	    if (deleter)
@@ -262,6 +259,10 @@ namespace cubconn::connection
 	    css_request_shutdown_conn (conn, static_cast<uint8_t> (ignore_level::IGNORE_ALL), false, 0);
 	    return INTERNAL_CSS_ERROR;
 	  }
+
+	release_allocated ();
+	pending_count = 0;
+	retain_deleter = false;
 
 	coalesced = new std::byte[pending_size];
 	if (coalesced == nullptr)

--- a/src/connection/connection_worker.cpp
+++ b/src/connection/connection_worker.cpp
@@ -72,6 +72,305 @@ namespace cubconn::connection
     return prm_get_integer_value (PRM_ID_CSS_MAX_CONNECTION_WORKER);
   });
 
+  unsigned int
+  worker::send_packet (css_conn_entry *conn, const cubbase::span<std::byte> *packet, std::size_t packet_count,
+		       const bool *retain_packet, std::function<void ()> &&deleter, int wait_time)
+  {
+    std::array<uint32_t, MAX_DIRECT_PACKET_COUNT> record_size;
+    std::array<struct iovec, MAX_DIRECT_PACKET_COUNT * 2> wire;
+    std::array<bool, MAX_DIRECT_PACKET_COUNT * 2> wire_owned {};
+    std::array<cubbase::span<std::byte>, MAX_DIRECT_PACKET_COUNT * 2> pending;
+    std::array<std::byte *, MAX_DIRECT_PACKET_COUNT * 2> allocated {};
+    std::shared_ptr<message_blocker> failed_waiter;
+    std::shared_ptr<message_blocker> waiter;
+    struct msghdr msg = {};
+    worker *owner;
+    context *ctx;
+    std::size_t allocated_count = 0;
+    std::size_t pending_count = 0;
+    std::size_t wire_count = 0;
+    std::size_t total_size = 0;
+    std::size_t sent_size = 0;
+    std::size_t pending_size = 0;
+    ssize_t bytes = -1;
+    bool retain_deleter = false;
+    int send_errno = 0;
+    int r;
+
+    assert (conn != nullptr);
+    assert (packet != nullptr);
+    assert (packet_count > 0 && packet_count <= MAX_DIRECT_PACKET_COUNT);
+
+    for (std::size_t index = 0; index < packet_count; index++)
+      {
+	assert (packet[index].size () <= static_cast<std::size_t> (INT_MAX));
+	record_size[index] = htonl (static_cast<uint32_t> (packet[index].size ()));
+	wire[wire_count++] = { &record_size[index], sizeof (record_size[index]) };
+	total_size += sizeof (record_size[index]);
+	if (packet[index].size () > 0)
+	  {
+	    wire[wire_count] = { packet[index].data (), packet[index].size () };
+	    wire_owned[wire_count++] = retain_packet != nullptr && retain_packet[index] && deleter;
+	    total_size += packet[index].size ();
+	  }
+      }
+
+    r = rmutex_lock (NULL, &conn->cmutex);
+    assert (r == NO_ERROR);
+
+    owner = conn->worker;
+    ctx = reinterpret_cast<context *> (conn->context);
+    if (owner == nullptr || ctx == nullptr || IS_INVALID_SOCKET (conn->fd))
+      {
+	r = rmutex_unlock (NULL, &conn->cmutex);
+	assert (r == NO_ERROR);
+	if (deleter)
+	  {
+	    deleter ();
+	  }
+	return NO_ERROR;
+      }
+
+    if (ctx->m_send.m_transmitter.empty ())
+      {
+	msg.msg_iov = wire.data ();
+	msg.msg_iovlen = wire_count;
+	do
+	  {
+	    bytes = ::sendmsg (conn->fd, &msg, MSG_NOSIGNAL | MSG_DONTWAIT);
+	  }
+	while (bytes < 0 && errno == EINTR);
+
+	if (bytes > 0)
+	  {
+	    sent_size = static_cast<std::size_t> (bytes);
+	    ctx->m_stats.add (statistics::context::BYTES_OUT_TOTAL, sent_size);
+	  }
+	else if (bytes < 0)
+	  {
+	    send_errno = errno;
+	  }
+      }
+    else
+      {
+	/* Preserve the bytes already queued for this connection. */
+	send_errno = EAGAIN;
+      }
+
+    if (sent_size == total_size)
+      {
+	r = rmutex_unlock (NULL, &conn->cmutex);
+	assert (r == NO_ERROR);
+	if (deleter)
+	  {
+	    deleter ();
+	  }
+	return NO_ERROR;
+      }
+
+    assert (sent_size < total_size);
+
+    if (bytes == 0 || (bytes < 0 && send_errno != EAGAIN
+#if defined (EWOULDBLOCK) && EWOULDBLOCK != EAGAIN
+		       && send_errno != EWOULDBLOCK
+#endif
+		      ))
+      {
+	r = rmutex_unlock (NULL, &conn->cmutex);
+	assert (r == NO_ERROR);
+	if (deleter)
+	  {
+	    deleter ();
+	  }
+	css_request_shutdown_conn (conn, static_cast<uint8_t> (ignore_level::IGNORE_ALL), false, 0);
+	return ERROR_ON_WRITE;
+      }
+
+    {
+      std::size_t skip = sent_size;
+
+      for (std::size_t index = 0; index < wire_count; index++)
+	{
+	  std::size_t available = wire[index].iov_len;
+	  std::byte *source = static_cast<std::byte *> (wire[index].iov_base);
+	  std::byte *copy;
+
+	  if (skip >= available)
+	    {
+	      skip -= available;
+	      continue;
+	    }
+	  source += skip;
+	  available -= skip;
+	  skip = 0;
+	  pending_size += available;
+
+	  if (wire_owned[index])
+	    {
+	      pending[pending_count++] = { source, available };
+	      retain_deleter = true;
+	      continue;
+	    }
+
+	  copy = new std::byte[available];
+	  if (copy == nullptr)
+	    {
+	      for (std::size_t allocation = 0; allocation < allocated_count; allocation++)
+		{
+		  delete [] allocated[allocation];
+		}
+	      r = rmutex_unlock (NULL, &conn->cmutex);
+	      assert (r == NO_ERROR);
+	      if (deleter)
+		{
+		  deleter ();
+		}
+	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, available);
+	      css_request_shutdown_conn (conn, static_cast<uint8_t> (ignore_level::IGNORE_ALL), false, 0);
+	      return CANT_ALLOC_BUFFER;
+	    }
+	  std::memcpy (copy, source, available);
+	  allocated[allocated_count++] = copy;
+	  pending[pending_count++] = { copy, available };
+	}
+      assert (skip == 0);
+      assert (pending_size == total_size - sent_size);
+    }
+
+    if (ctx->m_send.m_transmitter.get_buffer_count () + pending_count > IOV_MAX)
+      {
+	std::size_t existing_count = ctx->m_send.m_transmitter.get_buffer_count ();
+	std::byte *coalesced;
+
+	for (std::size_t allocation = 0; allocation < allocated_count; allocation++)
+	  {
+	    delete [] allocated[allocation];
+	  }
+	allocated_count = 0;
+	pending_count = 0;
+	retain_deleter = false;
+
+	if (existing_count >= IOV_MAX)
+	  {
+	    r = rmutex_unlock (NULL, &conn->cmutex);
+	    assert (r == NO_ERROR);
+	    if (deleter)
+	      {
+		deleter ();
+	      }
+	    er_log_debug (ARG_FILE_LINE, "pending transmission reached IOV_MAX for connection %d\n", conn->idx);
+	    css_request_shutdown_conn (conn, static_cast<uint8_t> (ignore_level::IGNORE_ALL), false, 0);
+	    return INTERNAL_CSS_ERROR;
+	  }
+
+	coalesced = new std::byte[pending_size];
+	if (coalesced == nullptr)
+	  {
+	    r = rmutex_unlock (NULL, &conn->cmutex);
+	    assert (r == NO_ERROR);
+	    if (deleter)
+	      {
+		deleter ();
+	      }
+	    er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1, pending_size);
+	    css_request_shutdown_conn (conn, static_cast<uint8_t> (ignore_level::IGNORE_ALL), false, 0);
+	    return CANT_ALLOC_BUFFER;
+	  }
+
+	std::size_t skip = sent_size;
+	std::size_t copied = 0;
+	for (std::size_t index = 0; index < wire_count; index++)
+	  {
+	    std::size_t available = wire[index].iov_len;
+	    std::byte *source = static_cast<std::byte *> (wire[index].iov_base);
+
+	    if (skip >= available)
+	      {
+		skip -= available;
+		continue;
+	      }
+	    source += skip;
+	    available -= skip;
+	    skip = 0;
+	    std::memcpy (coalesced + copied, source, available);
+	    copied += available;
+	  }
+	assert (skip == 0 && copied == pending_size);
+	allocated[allocated_count++] = coalesced;
+	pending[pending_count++] = { coalesced, pending_size };
+      }
+
+    for (std::size_t index = 0; index < pending_count; index++)
+      {
+	ctx->m_send.m_transmitter.push (pending[index]);
+      }
+    for (std::size_t index = 0; index < allocated_count; index++)
+      {
+	std::byte *copy = allocated[index];
+	ctx->m_send.m_transmitter.push_for_deleter ([copy] ()
+	{
+	  delete [] copy;
+	});
+      }
+    if (retain_deleter)
+      {
+	ctx->m_send.m_transmitter.push_for_deleter (std::move (deleter));
+      }
+    ctx->m_send.m_transmitter.stamp ();
+
+    /* A context between handoff and takeover is not registered yet. Takeover
+     * observes the queued transmitter and registers EPOLLOUT. */
+    if (ctx->m_epoll_registered
+	&& !owner->m_events.modify_descriptor (conn->fd, EPOLLET | EPOLLIN | EPOLLOUT | EPOLLRDHUP, ctx))
+      {
+	ctx->m_send.m_transmitter.clear ();
+	failed_waiter = std::move (ctx->m_send.m_blocker);
+	r = rmutex_unlock (NULL, &conn->cmutex);
+	assert (r == NO_ERROR);
+	if (!retain_deleter && deleter)
+	  {
+	    deleter ();
+	  }
+	owner->wakeup_blocked_worker (failed_waiter);
+	css_request_shutdown_conn (conn, static_cast<uint8_t> (ignore_level::IGNORE_ALL), false, 0);
+	return INTERNAL_CSS_ERROR;
+      }
+
+    if (wait_time != 0)
+      {
+	waiter = ctx->m_send.m_blocker;
+	if (waiter == nullptr)
+	  {
+	    waiter = std::make_shared<message_blocker> ();
+	    waiter->done = false;
+	    ctx->m_send.m_blocker = waiter;
+	  }
+      }
+
+    r = rmutex_unlock (NULL, &conn->cmutex);
+    assert (r == NO_ERROR);
+
+    if (!retain_deleter && deleter)
+      {
+	deleter ();
+      }
+
+    if (waiter != nullptr)
+      {
+	std::unique_lock<std::mutex> lock (waiter->m);
+	if (wait_time < 0)
+	  {
+	    waiter->cv.wait (lock, [&waiter] { return waiter->done; });
+	  }
+	else
+	  {
+	    waiter->cv.wait_for (lock, std::chrono::seconds (wait_time), [&waiter] { return waiter->done; });
+	  }
+      }
+
+    return NO_ERROR;
+  }
+
   worker::worker (pool *pool, std::shared_ptr<coordinator> coord, std::shared_ptr<thread_watcher> watcher,
 		  std::size_t core, std::size_t index) :
     m_parent (pool),
@@ -221,13 +520,11 @@ namespace cubconn::connection
     /* wait_time is implemented only for  */
     /*	START				  */
     /*	SHUTDOWN_CLIENT			  */
-    /*	SEND_PACKET			  */
     /* you must implement a logic to use a waiter whose message type is not in above */
 
     assert (!wait_time ||
 	    (item.type == message_type::START ||
-	     item.type == message_type::SHUTDOWN_CLIENT ||
-	     item.type == message_type::SEND_PACKET));
+	     item.type == message_type::SHUTDOWN_CLIENT));
 
     std::shared_ptr<message_blocker> handle;
     std::unique_lock<std::mutex> lock;
@@ -344,10 +641,19 @@ namespace cubconn::connection
 
   bool worker::has_remaining_tasks (context *ctx)
   {
+    bool has_pending_transmission;
+    int r;
+
     /* handle the entries in the message queue as there may be a queued request to release the memory in ctx */
     this->handle_message_queue_by_index (queue_type::IMMEDIATE);
 
-    if (ctx->m_ignore < ignore_level::IGNORE_ALL && !ctx->m_send.m_transmitter.empty ())
+    r = rmutex_lock (m_entry, &ctx->m_conn->cmutex);
+    assert (r == NO_ERROR);
+    has_pending_transmission = (ctx->m_ignore < ignore_level::IGNORE_ALL && !ctx->m_send.m_transmitter.empty ());
+    r = rmutex_unlock (m_entry, &ctx->m_conn->cmutex);
+    assert (r == NO_ERROR);
+
+    if (has_pending_transmission)
       {
 	er_log_conn (ARG_FILE_LINE,
 		     "connection::worker->handle_connection_close: retry shutdown (conn %p): send buffer not empty\n", ctx->m_conn);
@@ -419,6 +725,7 @@ namespace cubconn::connection
   bool worker::handle_connection_close (context *ctx, bool is_retry, std::shared_ptr<message_blocker> handle)
   {
     std::chrono::time_point<std::chrono::steady_clock> start, end;
+    std::shared_ptr<message_blocker> transmission_blocker;
     int tran_index, client_id;
     int status;
 
@@ -535,14 +842,19 @@ namespace cubconn::connection
 
     this->end_connection_close ();
 
-    /* clear resource */
-
     start = std::chrono::steady_clock::now ();
 
     rmutex_lock (m_entry, &ctx->m_conn->cmutex);
 
+    ctx->m_epoll_registered = false;
+    ctx->m_send.m_transmitter.clear ();
+    transmission_blocker = std::move (ctx->m_send.m_blocker);
     ctx->m_conn->worker = nullptr;
     ctx->m_conn->context = nullptr;
+
+    /* Serialize descriptor invalidation with direct send and control paths. */
+    css_shutdown_socket (ctx->m_conn->fd);
+    ctx->m_conn->fd = INVALID_SOCKET;
 
     rmutex_unlock (m_entry, &ctx->m_conn->cmutex);
 
@@ -550,15 +862,9 @@ namespace cubconn::connection
     m_stats.add (statistics::worker::BLOCKED_RMUTEX,
 		 std::chrono::duration_cast<std::chrono::microseconds> (end - start).count ());
 
-    ctx->m_send.m_transmitter.clear ();
-
-    /* close the socket */
-    css_shutdown_socket (ctx->m_conn->fd);
-    ctx->m_conn->fd = INVALID_SOCKET;
-
     /* wake up the thread blocked until this request is complete */
     this->wakeup_blocked_worker (handle);
-    this->wakeup_blocked_worker (ctx->m_send.m_blocker);
+    this->wakeup_blocked_worker (transmission_blocker);
 
     /* any sessions that are nat cleared (e.g. cdc, flashback) should be handled here */
     css_prepare_shutdown_conn (ctx->m_conn);
@@ -926,125 +1232,6 @@ retry:
     return true;
   }
 
-  bool worker::handle_message_queue_send_packet (message &item)
-  {
-    context *ctx;
-    css_conn_entry *conn;
-    result status;
-    int r;
-
-    assert (item.conn);
-
-    r = rmutex_lock (m_entry, &item.conn->cmutex);
-    assert (r == NO_ERROR);
-
-    ctx = reinterpret_cast<context *> (item.conn->context);
-    if (ctx == nullptr)
-      {
-	if (item.deleter)
-	  {
-	    item.deleter ();
-	  }
-
-	r = rmutex_unlock (m_entry, &item.conn->cmutex);
-	assert (r == NO_ERROR);
-
-#if !defined (NDEBUG)
-	er_log_conn (__FILE__, __LINE__,
-		     "connection::worker->handle_message_queue_send_packet: message_id = %lld, context is already cleared for conn = %p\n",
-		     item.message_id, static_cast<void *> (item.conn));
-#endif
-	this->wakeup_blocked_worker (item.waiter_handle);
-
-	return true;
-      }
-
-    conn = item.conn;
-    if (!this->validate_message_generation (item, ctx))
-      {
-	r = rmutex_unlock (m_entry, &conn->cmutex);
-	assert (r == NO_ERROR);
-
-	this->wakeup_blocked_worker (item.waiter_handle);
-
-	return true;
-      }
-    if (this->forward_message_to_successor (queue_type::IMMEDIATE, item, ctx))
-      {
-	r = rmutex_unlock (m_entry, &conn->cmutex);
-	assert (r == NO_ERROR);
-
-	return true;
-      }
-
-#if !defined (NDEBUG)
-    er_log_conn (__FILE__, __LINE__, "new packet to send. message_id = %lld, fd = %d in the worker = %d\n", item.message_id,
-		 item.conn->fd, m_index);
-#endif
-
-    for (auto &packet : item.packet)
-      {
-	ctx->m_send.m_transmitter.push_for_send ({ packet.data (), packet.size () });
-      }
-    ctx->m_send.m_transmitter.stamp ();
-    ctx->m_send.m_transmitter.push_for_deleter (std::move (item.deleter));
-
-    /* first, try to send the packets */
-    status = ctx->m_send.m_transmitter.fill (ctx->m_conn->fd);
-    if (status == result::PeerReset || status == result::Error)
-      {
-	r = rmutex_unlock (m_entry, &item.conn->cmutex);
-	assert (r == NO_ERROR);
-
-	this->wakeup_blocked_worker (item.waiter_handle);
-
-	/* ctx will be forcibly removed */
-	ctx->m_ignore = ignore_level::IGNORE_ALL;
-
-	/* this connection will be removed by main loop */
-	return true;
-      }
-
-    assert (status == result::Ok || status == result::Pending);
-
-    if (status == result::Ok)
-      {
-	ctx->m_send.m_transmitter.clear ();
-#if !defined (NDEBUG)
-	er_log_conn (__FILE__, __LINE__, "fully sent. message_id = %lld, fd = %d in the worker = %d\n", item.message_id,
-		     ctx->m_conn->fd, m_index);
-#else
-	er_log_conn (__FILE__, __LINE__, "fully sent. fd = %d in the worker = %d\n", ctx->m_conn->fd, m_index);
-#endif
-
-	r = rmutex_unlock (m_entry, &item.conn->cmutex);
-	assert (r == NO_ERROR);
-
-	this->wakeup_blocked_worker (item.waiter_handle);
-
-	return true;
-      }
-
-    /* if buffer is full, register the fd to epoll loop and wait to send the others */
-    if (!m_events.modify_descriptor (ctx->m_conn->fd, EPOLLET | EPOLLIN | EPOLLOUT | EPOLLRDHUP, ctx))
-      {
-	r = rmutex_unlock (m_entry, &item.conn->cmutex);
-	assert (r == NO_ERROR);
-
-	this->wakeup_blocked_worker (item.waiter_handle);
-
-	er_log_conn (__FILE__, __LINE__, "connection::worker->handle_message_queue_send_packet: modify_descriptor failed\n");
-	return false;
-      }
-
-    r = rmutex_unlock (m_entry, &item.conn->cmutex);
-    assert (r == NO_ERROR);
-
-    ctx->m_send.m_blocker = std::move (item.waiter_handle);
-
-    return true;
-  }
-
   bool worker::handle_message_queue_release_packet (message &item)
   {
     context *ctx;
@@ -1115,16 +1302,19 @@ retry:
       {
 	ctx->m_conn->worker = nullptr;
 	ctx->m_conn->context = nullptr;
+	ctx->m_epoll_registered = false;
 	rmutex_unlock (NULL, &ctx->m_conn->cmutex);
 
 	m_removed_context.push_back (ctx);
 	er_log_conn (__FILE__, __LINE__, "connection::worker->handle_message_queue_new_client: add_descriptor failed\n");
 	return false;
       }
+    ctx->m_epoll_registered = true;
     if (!m_context.insert (ctx).second)
       {
 	ctx->m_conn->worker = nullptr;
 	ctx->m_conn->context = nullptr;
+	ctx->m_epoll_registered = false;
 	rmutex_unlock (NULL, &ctx->m_conn->cmutex);
 
 	m_events.remove_descriptor (ctx->m_conn->fd);
@@ -1206,6 +1396,7 @@ retry:
 	er_log_conn (__FILE__, __LINE__, "connection::worker->handle_message_queue_handoff_client: add_descriptor failed\n");
 	assert_release (false);
       }
+    ctx->m_epoll_registered = false;
     if (m_context.erase (ctx) == 0)
       {
 	er_log_conn (__FILE__, __LINE__, "connection::worker->handle_message_queue_handoff_client: context not found\n");
@@ -1264,16 +1455,19 @@ respond:
       {
 	ctx->m_conn->worker = nullptr;
 	ctx->m_conn->context = nullptr;
+	ctx->m_epoll_registered = false;
 	rmutex_unlock (NULL, &ctx->m_conn->cmutex);
 
 	m_removed_context.push_back (ctx);
 	er_log_conn (__FILE__, __LINE__, "connection::worker->handle_message_queue_new_client: add_descriptor failed\n");
 	return false;
       }
+    ctx->m_epoll_registered = true;
     if (!m_context.insert (ctx).second)
       {
 	ctx->m_conn->worker = nullptr;
 	ctx->m_conn->context = nullptr;
+	ctx->m_epoll_registered = false;
 	rmutex_unlock (NULL, &ctx->m_conn->cmutex);
 
 	m_events.remove_descriptor (ctx->m_conn->fd);
@@ -1415,7 +1609,6 @@ respond:
 	/* HANDOFF_CLIENT  */ { &worker::handle_message_queue_handoff_client,	statistics::worker::MQ_HANDOFF_CLIENT },
 	/* TAKEOVER_CLIENT */ { &worker::handle_message_queue_takeover_client,	statistics::worker::MQ_TAKEOVER_CLIENT },
 	/* SHUTDOWN_CLIENT */ { &worker::handle_message_queue_shutdown_client,	statistics::worker::MQ_SHUTDOWN_CLIENT },
-	/* SEND_PACKET	   */ { &worker::handle_message_queue_send_packet,	statistics::worker::MQ_SEND_PACKET },
 	/* RELEASE_PACKET  */ { &worker::handle_message_queue_release_packet,	statistics::worker::MQ_RELEASE_PACKET }
       }
     };
@@ -1424,7 +1617,7 @@ respond:
 
     static_assert (static_cast<int> (message_type::START) == 0, "message_type must start at 0");
     static_assert (static_cast<int> (message_type::TYPE_COUNT) == handler.size (), "handler table size must match");
-    static_assert (static_cast<int> (message_type::TYPE_COUNT) == 10, "this must be modified");
+    static_assert (static_cast<int> (message_type::TYPE_COUNT) == 9, "this must be modified");
 
     i = 0;
     size = m_queue_size[static_cast<std::size_t> (type)].exchange (0, std::memory_order_acquire);
@@ -1800,6 +1993,7 @@ respond:
   result worker::handle_reception (context *ctx, bool in_exhausted)
   {
     std::chrono::time_point<std::chrono::steady_clock> start, end;
+    std::shared_ptr<message_blocker> transmission_blocker;
     std::vector<cubbase::span<std::byte>> *packets;
     result status, io_status;
     int mtx;
@@ -1817,9 +2011,13 @@ respond:
     if (io_status == result::PeerReset || io_status == result::Error)
       {
 	er_log_conn (__FILE__, __LINE__, "connection::worker->handle_reception: status = %d\n", io_status);
-	ctx->m_send.m_transmitter.empty ();
+	rmutex_lock (m_entry, &ctx->m_conn->cmutex);
+	ctx->m_send.m_transmitter.clear ();
+	transmission_blocker = std::move (ctx->m_send.m_blocker);
+	rmutex_unlock (m_entry, &ctx->m_conn->cmutex);
+	this->wakeup_blocked_worker (transmission_blocker);
 	this->handle_connection_close (ctx);
-	return io_status;
+	return io_status == result::PeerReset ? result::PeerReset : result::ClosedConnection;
       }
 
     assert (io_status == result::Pending || io_status == result::BudgetExhausted);
@@ -1887,7 +2085,19 @@ respond:
 
   result worker::handle_transmission (context *ctx, bool in_exhausted)
   {
+    std::shared_ptr<message_blocker> blocker;
     result status;
+    int r;
+
+    r = rmutex_lock (m_entry, &ctx->m_conn->cmutex);
+    assert (r == NO_ERROR);
+
+    if (ctx->m_conn->worker != this || ctx->m_conn->context != ctx)
+      {
+	r = rmutex_unlock (m_entry, &ctx->m_conn->cmutex);
+	assert (r == NO_ERROR);
+	return result::Pending;
+      }
 
     status = ctx->m_send.m_transmitter.fill (ctx->m_conn->fd, m_send_budget);
     if (status == result::PeerReset || status == result::Error)
@@ -1896,17 +2106,40 @@ respond:
 
 	/* ctx will be forcibly removed */
 	ctx->m_ignore = ignore_level::IGNORE_ALL;
+	blocker = std::move (ctx->m_send.m_blocker);
 
-	this->wakeup_blocked_worker (ctx->m_send.m_blocker);
+	r = rmutex_unlock (m_entry, &ctx->m_conn->cmutex);
+	assert (r == NO_ERROR);
+
+	this->wakeup_blocked_worker (blocker);
 	this->handle_connection_close (ctx);
-	return status;
+	return status == result::PeerReset ? result::PeerReset : result::ClosedConnection;
       }
 
     assert (status == result::Ok || status == result::Pending || status == result::BudgetExhausted);
 
     if (status == result::Ok)
       {
-	this->wakeup_blocked_worker (ctx->m_send.m_blocker);
+	ctx->m_send.m_transmitter.clear ();
+	blocker = std::move (ctx->m_send.m_blocker);
+
+	if (!m_events.modify_descriptor (ctx->m_conn->fd, EPOLLET | EPOLLIN | EPOLLRDHUP, ctx))
+	  {
+	    er_log_conn (__FILE__, __LINE__, "connection::worker->handle_transmission: modify_descriptor failed\n");
+
+	    ctx->m_ignore = ignore_level::IGNORE_ALL;
+	    r = rmutex_unlock (m_entry, &ctx->m_conn->cmutex);
+	    assert (r == NO_ERROR);
+
+	    this->wakeup_blocked_worker (blocker);
+	    this->handle_connection_close (ctx);
+	    return result::ClosedConnection;
+	  }
+
+	r = rmutex_unlock (m_entry, &ctx->m_conn->cmutex);
+	assert (r == NO_ERROR);
+
+	this->wakeup_blocked_worker (blocker);
 
 	rmutex_lock (m_entry, &ctx->m_conn->rmutex);
 	if (ctx->m_conn->status == CONN_CLOSING)
@@ -1920,22 +2153,16 @@ respond:
 	  }
 	rmutex_unlock (m_entry, &ctx->m_conn->rmutex);
 
-	if (!m_events.modify_descriptor (ctx->m_conn->fd, EPOLLET | EPOLLIN | EPOLLRDHUP, ctx))
-	  {
-	    er_log_conn (__FILE__, __LINE__, "connection::worker->handle_transmission: modify_descriptor failed\n");
-
-	    /* ctx will be forcibly removed */
-	    ctx->m_ignore = ignore_level::IGNORE_ALL;
-
-	    this->handle_connection_close (ctx);
-	    return result::Error;
-	  }
-	ctx->m_send.m_transmitter.clear ();
 	er_log_conn (__FILE__, __LINE__, "fully sent. fd = %d in the worker = %d\n", ctx->m_conn->fd, m_index);
       }
-    else if (!in_exhausted && status == result::BudgetExhausted)
+    else
       {
-	handle_exhausted_add_context (ctx, EPOLLOUT);
+	r = rmutex_unlock (m_entry, &ctx->m_conn->cmutex);
+	assert (r == NO_ERROR);
+	if (!in_exhausted && status == result::BudgetExhausted)
+	  {
+	    handle_exhausted_add_context (ctx, EPOLLOUT);
+	  }
       }
     return status;
   }
@@ -2124,13 +2351,6 @@ respond:
 	  {
 	    switch (request.type)
 	      {
-	      case message_type::SEND_PACKET:
-		if (request.deleter)
-		  {
-		    request.deleter ();
-		  }
-		[[fallthrough]];
-
 	      case message_type::SHUTDOWN_CLIENT:
 		this->wakeup_blocked_worker (request.waiter_handle);
 		break;

--- a/src/connection/connection_worker.cpp
+++ b/src/connection/connection_worker.cpp
@@ -152,7 +152,7 @@ namespace cubconn::connection
 	if (bytes > 0)
 	  {
 	    sent_size = static_cast<std::size_t> (bytes);
-	    ctx->m_atomic_stats.bytes_out_total.fetch_add (sent_size, std::memory_order_relaxed);
+	    ctx->m_guarded_stats.bytes_out_total += sent_size;
 	  }
 	else if (bytes < 0)
 	  {
@@ -896,6 +896,7 @@ retry:
   bool worker::statistics_metrics_to_coordinator ()
   {
     coordinator::message message;
+    int r;
 
     message.type = coordinator::message_type::STATISTICS;
 
@@ -906,9 +907,20 @@ retry:
     message.statistics.contexts.reserve (m_context.size ());
     for (context *ctx : m_context)
       {
-	/* integrate atomic stats to owned stats */
-	ctx->m_stats.add (statistics::context::BYTES_OUT_TOTAL,
-			  ctx->m_atomic_stats.bytes_out_total.exchange (0, std::memory_order_relaxed));
+	/* stats */
+	uint64_t bytes_out_total;
+
+	r = rmutex_lock (m_entry, &ctx->m_conn->cmutex);
+	assert (r == NO_ERROR);
+
+	bytes_out_total = ctx->m_guarded_stats.bytes_out_total;
+	ctx->m_guarded_stats.bytes_out_total = 0;
+
+	r = rmutex_unlock (m_entry, &ctx->m_conn->cmutex);
+	assert (r == NO_ERROR);
+
+	/* integrate direct send stats to owned stats */
+	ctx->m_stats.add (statistics::context::BYTES_OUT_TOTAL, bytes_out_total);
 
 	/* store */
 	message.statistics.contexts.emplace_back (ctx->m_id, ctx->m_stats);
@@ -1249,6 +1261,56 @@ retry:
     return true;
   }
 
+  bool worker::handle_message_queue_release_packet (message &item)
+  {
+    context *ctx;
+    css_conn_entry *conn;
+    int r;
+
+    assert (item.conn);
+    assert (item.packet);
+
+    r = rmutex_lock (m_entry, &item.conn->cmutex);
+    assert (r == NO_ERROR);
+
+    ctx = reinterpret_cast<context *> (item.conn->context);
+    if (ctx == nullptr)
+      {
+	r = rmutex_unlock (m_entry, &item.conn->cmutex);
+	assert (r == NO_ERROR);
+
+	er_log_conn (__FILE__, __LINE__,
+		     "connection::worker->handle_message_queue_release_packet: context is already cleared for conn = %p\n",
+		     static_cast<void *> (item.conn));
+	return true;
+      }
+
+    conn = item.conn;
+    if (!this->validate_message_generation (item, ctx))
+      {
+	r = rmutex_unlock (m_entry, &conn->cmutex);
+	assert (r == NO_ERROR);
+
+	return true;
+      }
+    if (this->forward_message_to_successor (queue_type::IMMEDIATE, item, ctx))
+      {
+	r = rmutex_unlock (m_entry, &conn->cmutex);
+	assert (r == NO_ERROR);
+
+	return true;
+      }
+
+    ctx->m_recv.m_receiver.release (item.packet);
+    er_log_conn (__FILE__, __LINE__,
+		 "connection::worker->handle_message_queue_release_packet: release packet pointer = %p\n", item.packet);
+
+    r = rmutex_unlock (m_entry, &item.conn->cmutex);
+    assert (r == NO_ERROR);
+
+    return true;
+  }
+
   bool worker::handle_message_queue_new_client (message &item)
   {
     context *ctx;
@@ -1572,7 +1634,8 @@ respond:
 	/* NEW_CLIENT	   */ { &worker::handle_message_queue_new_client,	statistics::worker::MQ_NEW_CLIENT },
 	/* HANDOFF_CLIENT  */ { &worker::handle_message_queue_handoff_client,	statistics::worker::MQ_HANDOFF_CLIENT },
 	/* TAKEOVER_CLIENT */ { &worker::handle_message_queue_takeover_client,	statistics::worker::MQ_TAKEOVER_CLIENT },
-	/* SHUTDOWN_CLIENT */ { &worker::handle_message_queue_shutdown_client,	statistics::worker::MQ_SHUTDOWN_CLIENT }
+	/* SHUTDOWN_CLIENT */ { &worker::handle_message_queue_shutdown_client,	statistics::worker::MQ_SHUTDOWN_CLIENT },
+	/* RELEASE_PACKET  */ { &worker::handle_message_queue_release_packet,	statistics::worker::MQ_RELEASE_PACKET }
       }
     };
     message request;
@@ -1580,7 +1643,7 @@ respond:
 
     static_assert (static_cast<int> (message_type::START) == 0, "message_type must start at 0");
     static_assert (static_cast<int> (message_type::TYPE_COUNT) == handler.size (), "handler table size must match");
-    static_assert (static_cast<int> (message_type::TYPE_COUNT) == 8, "this must be modified");
+    static_assert (static_cast<int> (message_type::TYPE_COUNT) == 9, "this must be modified");
 
     i = 0;
     size = m_queue_size[static_cast<std::size_t> (type)].exchange (0, std::memory_order_acquire);
@@ -2335,6 +2398,7 @@ respond:
 	      case message_type::AWAKEN:
 	      case message_type::SHUTDOWN:
 	      case message_type::HANDOFF_CLIENT:
+	      case message_type::RELEASE_PACKET:
 	      case message_type::TYPE_COUNT:
 		break;
 	      }

--- a/src/connection/connection_worker.cpp
+++ b/src/connection/connection_worker.cpp
@@ -628,7 +628,8 @@ namespace cubconn::connection
       {
 	std::lock_guard<std::mutex> lock (handle->m);
 	handle->done = true;
-	handle->cv.notify_one ();
+	/* blocker may be shared by every sender blocked on the same transmitter */
+	handle->cv.notify_all ();
       }
   }
 
@@ -2322,6 +2323,8 @@ respond:
 		break;
 
 	      case message_type::TAKEOVER_CLIENT:
+		/* sender may be blocked on a transmission queued while this context was in handoff */
+		this->wakeup_blocked_worker (std::move (request.ctx->m_send.m_blocker));
 		css_free_conn (request.ctx->m_conn);
 		m_parent->retire_context (request.ctx);
 		break;

--- a/src/connection/connection_worker.cpp
+++ b/src/connection/connection_worker.cpp
@@ -381,6 +381,7 @@ namespace cubconn::connection
     m_stop (false),
     m_entry (nullptr),
     m_index (index),
+    m_notified (false),
     m_has_retry (false)
   {
     std::size_t i;
@@ -483,6 +484,11 @@ namespace cubconn::connection
     std::uint64_t u;
     ssize_t bytes;
 
+    if (m_notified.exchange (true, std::memory_order_acq_rel))
+      {
+	return true;
+      }
+
     u = 1;
     while (true)
       {
@@ -494,6 +500,7 @@ namespace cubconn::connection
 
 	if (bytes == 0 || (bytes > 0 && static_cast<unsigned long> (bytes) < sizeof (u)))
 	  {
+	    m_notified.store (false, std::memory_order_release);
 	    return false;
 	  }
 
@@ -507,6 +514,7 @@ namespace cubconn::connection
 	  {
 	    break;
 	  }
+	m_notified.store (false, std::memory_order_release);
 	return false;
       }
 
@@ -1160,6 +1168,8 @@ retry:
 	    return false;
 	  }
 
+	/* RMW closes the StoreLoad window */
+	m_notified.exchange (false, std::memory_order_acq_rel);
 	if (!this->handle_message_queue ())
 	  {
 	    return false;

--- a/src/connection/connection_worker.hpp
+++ b/src/connection/connection_worker.hpp
@@ -95,6 +95,8 @@ namespace cubconn::connection
       };
 
     public:
+      static constexpr std::size_t MAX_DIRECT_PACKET_COUNT = 8;
+
       enum class queue_type : uint8_t
       {
 	IMMEDIATE,
@@ -121,7 +123,6 @@ namespace cubconn::connection
 	TAKEOVER_CLIENT,
 	SHUTDOWN_CLIENT, /* lazy queue */
 
-	SEND_PACKET,
 	RELEASE_PACKET,
 
 	TYPE_COUNT
@@ -158,12 +159,8 @@ namespace cubconn::connection
 	  /* the members below are used to deliver a target data */
 	  /* each comment is a message_type using that member */
 
-	  /* SEND_PACKET    */
 	  /* RELEASE_PACKET */
 	  std::vector<cubbase::span<std::byte>> packet;
-
-	  /* SEND_PACKET    */
-	  std::function<void ()> deleter;
 
 	  /* HANDOFF_CLIENT */
 	  worker *worker_ptr;
@@ -176,7 +173,6 @@ namespace cubconn::connection
 	  /* waiter handle (implemented only for START, SHUTDOWN_CLIENT) */
 	  /* START	     */
 	  /* SHUTDOWN_CLIENT */
-	  /* SEND_PACKET     */
 	  std::shared_ptr<message_blocker> waiter_handle;
 
 	  /* debug purpose */
@@ -198,6 +194,10 @@ namespace cubconn::connection
       bool run ();
 
       void attach ();
+
+      static unsigned int send_packet (css_conn_entry *conn, const cubbase::span<std::byte> *packet,
+				       std::size_t packet_count, const bool *retain_packet,
+				       std::function<void ()> &&deleter, int wait_time);
 
       /* used for control from other threads */
       void enqueue (queue_type type, message &&item);
@@ -310,7 +310,6 @@ namespace cubconn::connection
       bool validate_message_generation (const message &item, context *ctx) const;
       bool forward_message_to_successor (queue_type type, message &item, context *ctx);
 
-      bool handle_message_queue_send_packet (message &item);
       bool handle_message_queue_release_packet (message &item);
 
       bool handle_message_queue_new_client (message &item);

--- a/src/connection/connection_worker.hpp
+++ b/src/connection/connection_worker.hpp
@@ -122,6 +122,7 @@ namespace cubconn::connection
 	HANDOFF_CLIENT, /* lazy queue */
 	TAKEOVER_CLIENT,
 	SHUTDOWN_CLIENT, /* lazy queue */
+	RELEASE_PACKET,
 
 	TYPE_COUNT
       };
@@ -133,6 +134,7 @@ namespace cubconn::connection
 	    id (0),
 	    ctx (nullptr),
 	    conn (nullptr),
+	    packet (nullptr),
 	    worker_ptr (nullptr),
 	    worker_index (-1),
 	    ignore (ignore_level::DONT_IGNORE),
@@ -156,6 +158,9 @@ namespace cubconn::connection
 
 	  /* the members below are used to deliver a target data */
 	  /* each comment is a message_type using that member */
+
+	  /* RELEASE_PACKET */
+	  std::byte *packet;
 
 	  /* HANDOFF_CLIENT */
 	  worker *worker_ptr;
@@ -306,6 +311,8 @@ namespace cubconn::connection
       /* --------------------------------------------------------------------------- */
       bool validate_message_generation (const message &item, context *ctx) const;
       bool forward_message_to_successor (queue_type type, message &item, context *ctx);
+
+      bool handle_message_queue_release_packet (message &item);
 
       bool handle_message_queue_new_client (message &item);
       bool handle_message_queue_handoff_client (message &item);

--- a/src/connection/connection_worker.hpp
+++ b/src/connection/connection_worker.hpp
@@ -227,6 +227,8 @@ namespace cubconn::connection
       /* index is a type of timer handle block */
       std::array<timer_handle, static_cast<std::size_t> (timer_type::TYPE_COUNT)> m_timer_handler;
 
+      /* true while an eventfd notification is pending or being handled */
+      std::atomic<bool> m_notified;
       bool m_has_retry;
 
       /* this is a multi-producer single-consumer queue, so */

--- a/src/connection/connection_worker.hpp
+++ b/src/connection/connection_worker.hpp
@@ -123,8 +123,6 @@ namespace cubconn::connection
 	TAKEOVER_CLIENT,
 	SHUTDOWN_CLIENT, /* lazy queue */
 
-	RELEASE_PACKET,
-
 	TYPE_COUNT
       };
 
@@ -158,9 +156,6 @@ namespace cubconn::connection
 
 	  /* the members below are used to deliver a target data */
 	  /* each comment is a message_type using that member */
-
-	  /* RELEASE_PACKET */
-	  std::vector<cubbase::span<std::byte>> packet;
 
 	  /* HANDOFF_CLIENT */
 	  worker *worker_ptr;
@@ -309,8 +304,6 @@ namespace cubconn::connection
       /* --------------------------------------------------------------------------- */
       bool validate_message_generation (const message &item, context *ctx) const;
       bool forward_message_to_successor (queue_type type, message &item, context *ctx);
-
-      bool handle_message_queue_release_packet (message &item);
 
       bool handle_message_queue_new_client (message &item);
       bool handle_message_queue_handoff_client (message &item);

--- a/src/connection/receiver.cpp
+++ b/src/connection/receiver.cpp
@@ -506,9 +506,28 @@ namespace cubconn
     return result::Error;
   }
 
+  bool receiver::try_release (std::byte *ptr)
+  {
+    std::unique_lock<std::mutex> lock (m_mutex, std::try_to_lock);
+
+    if (!lock.owns_lock ())
+      {
+	return false;
+      }
+
+    this->release_unlocked (ptr);
+    return true;
+  }
+
   void receiver::release (std::byte *ptr)
   {
     std::lock_guard<std::mutex> lock (m_mutex);
+
+    this->release_unlocked (ptr);
+  }
+
+  void receiver::release_unlocked (std::byte *ptr)
+  {
     cubbase::span<std::byte> source;
     int size;
 

--- a/src/connection/receiver.cpp
+++ b/src/connection/receiver.cpp
@@ -88,6 +88,7 @@ namespace cubconn
 
   void receiver::reset ()
   {
+    std::lock_guard<std::mutex> lock (m_mutex);
     cubbase::span<std::byte> buffer;
 
     m_state = state::Recv;
@@ -96,6 +97,10 @@ namespace cubconn
     m_size = 0;
 
     m_result.clear ();
+    for (std::byte *ptr : m_allocated)
+      {
+	delete[] ptr;
+      }
     m_allocated.clear ();
 
     /* if m_buf is already in use, it may be corrupted by subsequent reception. */
@@ -439,6 +444,7 @@ namespace cubconn
 
   result receiver::drain (int fd, size_t limit)
   {
+    std::lock_guard<std::mutex> lock (m_mutex);
     result status;
     size_t consumption;
 
@@ -502,6 +508,7 @@ namespace cubconn
 
   void receiver::release (std::byte *ptr)
   {
+    std::lock_guard<std::mutex> lock (m_mutex);
     cubbase::span<std::byte> source;
     int size;
 
@@ -533,4 +540,3 @@ namespace cubconn
     return &m_result;
   }
 }
-

--- a/src/connection/receiver.hpp
+++ b/src/connection/receiver.hpp
@@ -29,6 +29,7 @@
 #include "DMRBMemoryPool.hpp"
 
 #include <cstring>
+#include <mutex>
 #include <sys/socket.h>
 #include <sys/epoll.h>
 #include <fcntl.h>
@@ -63,6 +64,8 @@ namespace cubconn
 
     private:
       statistics::metrics<statistics::context> *m_stats;
+
+      std::mutex m_mutex;
 
       state m_state;
       cubbase::DMRBMemoryPool m_buf;

--- a/src/connection/receiver.hpp
+++ b/src/connection/receiver.hpp
@@ -58,6 +58,7 @@ namespace cubconn
       void reset ();
 
       result drain (int fd, size_t limit = 0);
+      bool try_release (std::byte *ptr);
       void release (std::byte *ptr);
 
       std::vector<cubbase::span<std::byte>> *get_result ();
@@ -94,6 +95,8 @@ namespace cubconn
 
       result parse_size (size_t consumption, size_t limit);
       result receive (int fd, size_t &consumption, size_t limit);
+
+      void release_unlocked (std::byte *ptr);
   };
 }
 

--- a/src/connection/server_support.c
+++ b/src/connection/server_support.c
@@ -33,7 +33,9 @@
 #include "thread_manager.hpp"
 #include "master_connector.hpp"
 #include "connection_pool.hpp"
+#include "connection_worker.hpp"
 
+#include <array>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -197,9 +199,6 @@ static void css_process_shutdown_request (SOCKET master_fd);
 
 static int css_internal_request_handler (THREAD_ENTRY & thread_ref, CSS_CONN_ENTRY & conn_ref);
 static int css_test_for_client_errors (CSS_CONN_ENTRY * conn, unsigned int eid);
-
-static unsigned int css_enqueue_and_notify (cubconn::connection::worker::queue_type type,
-					    cubconn::connection::worker::message &&item, int wait_time = 0);
 
 static bool css_check_ha_log_applier_done (void);
 static bool css_check_ha_log_applier_working (void);
@@ -656,60 +655,6 @@ shutdown:
   return status;
 }
 
-// *INDENT-OFF*
-/*
- * css_enqueue_and_notify () - enqueue the request and notify to worker
- *   return:
- *   type (in): queue to be inserted 
- *   item (in): request
- */
-static unsigned int
-css_enqueue_and_notify (cubconn::connection::worker::queue_type type, cubconn::connection::worker::message &&item,
-			int wait_time)
-{
-  CSS_CONN_ENTRY * conn;
-  cubconn::connection::context *ctx;
-  int r;
-
-  assert (item.conn);
-  conn = item.conn;
-
-  /* lock to access worker and context */
-  r = rmutex_lock (NULL, &conn->cmutex);
-  assert (r == NO_ERROR);
-
-  if (conn->worker == nullptr || conn->context == nullptr)
-    {
-      /* unlock */
-      r = rmutex_unlock (NULL, &conn->cmutex);
-      assert (r == NO_ERROR);
-
-      if (item.deleter)
-	{
-	  item.deleter ();
-	}
-
-      return 0;
-    }
-
-  ctx = static_cast<cubconn::connection::context *> (conn->context);
-  item.ctx = ctx;
-  item.id = ctx->m_id;
-
-  auto func =[conn] ()noexcept {
-    /* unlock */
-    rmutex_unlock (NULL, &conn->cmutex);
-  };
-
-  if (!conn->worker->enqueue_and_notify (type, std::move (item), func, wait_time))
-    {
-      return INTERNAL_CSS_ERROR;
-    }
-
-  return 0;
-}
-// *INDENT-ON*
-
 /*
  * css_send_data_to_client() - send a data buffer to the server
  *   return:
@@ -719,74 +664,88 @@ css_enqueue_and_notify (cubconn::connection::worker::queue_type type, cubconn::c
  *
  * Note: This is to be used ONLY by the server to return data to the client
  */
+// *INDENT-OFF*
+static unsigned int
+css_send_response_buffers_to_client (CSS_CONN_ENTRY *conn, unsigned int eid, int packet_type, char *const *buffers,
+					     const int *buffer_sizes, std::size_t buffer_count, bool require_open,
+					     std::size_t first_retained_buffer,
+					     std::function<void ()> &&deleter, int wait_time)
+{
+  std::array<NET_HEADER, 4> header {};
+  std::array<cubbase::span<std::byte>, cubconn::connection::worker::MAX_DIRECT_PACKET_COUNT> packet;
+  std::array<bool, cubconn::connection::worker::MAX_DIRECT_PACKET_COUNT> retain_packet {};
+  std::size_t packet_count = 0;
+  int transaction_id;
+  int invalidate_snapshot;
+  int header_db_error;
+  int r;
+
+  assert (conn != NULL);
+  assert (buffers != NULL && buffer_sizes != NULL);
+  assert (buffer_count > 0 && buffer_count <= header.size ());
+  assert (first_retained_buffer <= buffer_count);
+
+  r = rmutex_lock (NULL, &conn->rmutex);
+  assert (r == NO_ERROR);
+  if ((require_open && conn->status != CONN_OPEN) || (!require_open && conn->status == CONN_CLOSED))
+    {
+      r = rmutex_unlock (NULL, &conn->rmutex);
+      assert (r == NO_ERROR);
+      if (deleter)
+	{
+	  deleter ();
+	}
+      return CONNECTION_CLOSED;
+    }
+
+  transaction_id = conn->get_tran_index ();
+  invalidate_snapshot = conn->invalidate_snapshot;
+  header_db_error = conn->db_error;
+  for (std::size_t index = 0; index < buffer_count; index++)
+    {
+      assert (buffer_sizes[index] >= 0);
+      assert (buffer_sizes[index] == 0 || buffers[index] != NULL);
+      css_set_net_header (&header[index], packet_type, 0, CSS_RID_FROM_EID (eid), buffer_sizes[index],
+			  transaction_id, invalidate_snapshot, header_db_error);
+      packet[packet_count] = { reinterpret_cast<std::byte *> (&header[index]), sizeof (NET_HEADER) };
+      retain_packet[packet_count++] = false;
+      packet[packet_count] = { reinterpret_cast<std::byte *> (buffers[index]),
+			       static_cast<std::size_t> (buffer_sizes[index]) };
+      retain_packet[packet_count++] = deleter && index >= first_retained_buffer;
+    }
+
+  r = rmutex_unlock (NULL, &conn->rmutex);
+  assert (r == NO_ERROR);
+
+  return cubconn::connection::worker::send_packet (conn, packet.data (), packet_count, retain_packet.data (),
+						   std::move (deleter), wait_time);
+}
+
 unsigned int
 css_send_data_to_client (CSS_CONN_ENTRY * conn, unsigned int eid, char *buffer, int buffer_size, int wait_time)
 {
-  // *INDENT-OFF*
-  cubconn::connection::worker::message request;
-  NET_HEADER *mem_header;
-  std::byte * mem_reply = nullptr;
+  char *buffers[] = { buffer };
+  int buffer_sizes[] = { buffer_size };
 
   assert (conn != NULL);
 
-  rmutex_lock (NULL, &conn->rmutex);
-  if (conn->status == CONN_CLOSED)
-    {
-      rmutex_unlock (NULL, &conn->rmutex);
-      return CONNECTION_CLOSED;
-    }
-  rmutex_unlock (NULL, &conn->rmutex);
-
-  request.type = cubconn::connection::worker::message_type::SEND_PACKET;
-  request.conn = conn;
-  request.packet.clear ();
-
-  /* header */
-  mem_header = new NET_HEADER {};
-  css_set_net_header (mem_header, DATA_TYPE, 0, CSS_RID_FROM_EID (eid), buffer_size, conn->get_tran_index (),
-		      conn->invalidate_snapshot, conn->db_error);
-  request.packet.emplace_back ((std::byte *) mem_header, sizeof (NET_HEADER));
-
-  if (buffer && buffer_size > 0)
-    {
-      /* reply */
-      mem_reply = new std::byte[buffer_size];
-      std::memcpy (mem_reply, buffer, buffer_size);
-    }
-  request.packet.emplace_back (mem_reply, (std::size_t) buffer_size);
-
-  /* deleter */
-  request.deleter =[mem_header, mem_reply] () noexcept
-  {
-    delete mem_header;
-    if (mem_reply)
-      {
-	delete[] mem_reply;
-      }
-  };
-  // *INDENT-ON*
-
-  return css_enqueue_and_notify (cubconn::connection::worker::queue_type::IMMEDIATE, std::move (request), wait_time);
+  return css_send_response_buffers_to_client (conn, eid, DATA_TYPE, buffers, buffer_sizes, 1, false, 1,
+					      std::function<void ()> (), wait_time);
 }
 
 unsigned int
 css_send_reply_and_data_to_client_direct (CSS_CONN_ENTRY * conn, unsigned int eid, char *reply, int reply_size,
 					  char *buffer, int buffer_size)
 {
-  int rc = 0;
+  char *buffers[] = { reply, buffer };
+  int buffer_sizes[] = { reply_size, buffer_size };
+  std::size_t buffer_count;
 
   assert (conn != NULL);
 
-  if (buffer_size > 0 && buffer != NULL)
-    {
-      rc = css_send_two_data (conn, CSS_RID_FROM_EID (eid), reply, reply_size, buffer, buffer_size);
-    }
-  else
-    {
-      rc = css_send_data (conn, CSS_RID_FROM_EID (eid), reply, reply_size);
-    }
-
-  return (rc == NO_ERRORS) ? NO_ERROR : rc;
+  buffer_count = (buffer_size > 0 && buffer != NULL) ? 2 : 1;
+  return css_send_response_buffers_to_client (conn, eid, DATA_TYPE, buffers, buffer_sizes, buffer_count, false,
+					      buffer_count, std::function<void ()> (), 0);
 }
 
 /*
@@ -806,75 +765,16 @@ unsigned int
 css_send_reply_and_data_to_client (CSS_CONN_ENTRY * conn, unsigned int eid, char *reply, int reply_size, char *buffer,
 				   int buffer_size, std::function < void () > &&deleter)
 {
-  // *INDENT-OFF*
-  cubconn::connection::worker::message request;
-  NET_HEADER *mem_header[2] = { nullptr, nullptr };
-  std::byte * mem_reply = nullptr;
+  char *buffers[] = { reply, buffer };
+  int buffer_sizes[] = { reply_size, buffer_size };
+  std::size_t buffer_count;
 
   assert (conn != NULL);
   assert (!!buffer == !!buffer_size);
 
-  rmutex_lock (NULL, &conn->rmutex);
-  if (conn->status != CONN_OPEN)
-    {
-      rmutex_unlock (NULL, &conn->rmutex);
-
-      if (deleter)
-	{
-	  deleter ();
-	}
-      return CONNECTION_CLOSED;
-    }
-  rmutex_unlock (NULL, &conn->rmutex);
-
-  request.type = cubconn::connection::worker::message_type::SEND_PACKET;
-  request.conn = conn;
-  request.packet.clear ();
-
-  /* reply */
-  mem_header[0] = new NET_HEADER {};
-  css_set_net_header (mem_header[0], DATA_TYPE, 0, CSS_RID_FROM_EID (eid), reply_size, conn->get_tran_index (),
-		      conn->invalidate_snapshot, conn->db_error);
-  request.packet.emplace_back (reinterpret_cast < std::byte * >(mem_header[0]), sizeof (NET_HEADER));
-  if (reply && reply_size > 0)
-    {
-      mem_reply = new std::byte[reply_size];
-      std::memcpy (mem_reply, reply, reply_size);
-    }
-  request.packet.emplace_back (mem_reply, (std::size_t) reply_size);
-
-  /* data */
-  if (buffer && buffer_size > 0)
-    {
-      mem_header[1] = new NET_HEADER {};
-      css_set_net_header (mem_header[1], DATA_TYPE, 0, CSS_RID_FROM_EID (eid), buffer_size, conn->get_tran_index (),
-			  conn->invalidate_snapshot, conn->db_error);
-      request.packet.emplace_back (reinterpret_cast < std::byte * >(mem_header[1]), sizeof (NET_HEADER));
-      request.packet.emplace_back (reinterpret_cast < std::byte * >(buffer), static_cast < std::size_t > (buffer_size));
-    }
-
-  /* deleter */
-  request.deleter =[header1 = mem_header[0],
-		    header2 = mem_header[1], body1 = mem_reply, deleter = std::move (deleter)] () noexcept
-  {
-    delete header1;
-
-    if (header2)
-      {
-	delete header2;
-      }
-    if (body1)
-      {
-	delete[] body1;
-      }
-    if (deleter)
-      {
-	deleter ();
-      }
-  };
-  // *INDENT-ON*
-
-  return css_enqueue_and_notify (cubconn::connection::worker::queue_type::IMMEDIATE, std::move (request));
+  buffer_count = (buffer_size > 0 && buffer != NULL) ? 2 : 1;
+  return css_send_response_buffers_to_client (conn, eid, DATA_TYPE, buffers, buffer_sizes, buffer_count, true, 1,
+					      std::move (deleter), 0);
 }
 
 #if 0
@@ -974,96 +874,18 @@ css_send_reply_and_2_data_to_client (CSS_CONN_ENTRY * conn, unsigned int eid, ch
 				     char *buffer1, int buffer1_size, char *buffer2, int buffer2_size,
 				     std::function < void () > &&deleter)
 {
-  // *INDENT-OFF*
-  cubconn::connection::worker::message request;
-  NET_HEADER *mem_header[3] = { nullptr, nullptr, nullptr };
-  std::byte * mem_reply = nullptr;
+  char *buffers[] = { reply, buffer1, buffer2 };
+  int buffer_sizes[] = { reply_size, buffer1_size, buffer2_size };
+  std::size_t buffer_count;
 
   assert (conn != NULL);
   assert (reply && reply_size > 0);
   assert (!!buffer1 == !!buffer1_size);
   assert (!!buffer2 == !!buffer2_size);
 
-  rmutex_lock (NULL, &conn->rmutex);
-  if (conn->status != CONN_OPEN)
-    {
-      rmutex_unlock (NULL, &conn->rmutex);
-
-      if (deleter)
-	{
-	  deleter ();
-	}
-      return CONNECTION_CLOSED;
-    }
-  rmutex_unlock (NULL, &conn->rmutex);
-
-  request.type = cubconn::connection::worker::message_type::SEND_PACKET;
-  request.conn = conn;
-  request.packet.clear ();
-
-  /* reply */
-  mem_header[0] = new NET_HEADER {};
-  css_set_net_header (mem_header[0], DATA_TYPE, 0, CSS_RID_FROM_EID (eid), reply_size, conn->get_tran_index (),
-		      conn->invalidate_snapshot, conn->db_error);
-  request.packet.emplace_back (reinterpret_cast < std::byte * >(mem_header[0]), sizeof (NET_HEADER));
-  if (reply && reply_size > 0)
-    {
-      mem_reply = new std::byte[reply_size];
-      std::memcpy (mem_reply, reply, reply_size);
-    }
-  request.packet.emplace_back (mem_reply, (std::size_t) reply_size);
-
-  /* don't refactor! I've split the conditions to make the code easier to read. */
-  /* these conditions will be optimized at the compiler level. */
-  /* data1 */
-  if ((buffer1 && buffer1_size > 0) || (buffer2 && buffer2_size > 0))
-    {
-      mem_header[1] = new NET_HEADER {};
-      css_set_net_header (mem_header[1], DATA_TYPE, 0, CSS_RID_FROM_EID (eid), buffer1_size, conn->get_tran_index (),
-			  conn->invalidate_snapshot, conn->db_error);
-      request.packet.emplace_back (reinterpret_cast < std::byte * >(mem_header[1]), sizeof (NET_HEADER));
-      request.packet.emplace_back (reinterpret_cast < std::byte * >(buffer1),
-				   static_cast < std::size_t > (buffer1_size));
-    }
-
-  /* data2 */
-  if (buffer2 && buffer2_size > 0)
-    {
-      mem_header[2] = new NET_HEADER {};
-      css_set_net_header (mem_header[2], DATA_TYPE, 0, CSS_RID_FROM_EID (eid), buffer2_size, conn->get_tran_index (),
-			  conn->invalidate_snapshot, conn->db_error);
-      request.packet.emplace_back (reinterpret_cast < std::byte * >(mem_header[2]), sizeof (NET_HEADER));
-      request.packet.emplace_back (reinterpret_cast < std::byte * >(buffer2),
-				   static_cast < std::size_t > (buffer2_size));
-    }
-
-  /* deleter */
-  request.deleter =[header1 = mem_header[0],
-		    header2 = mem_header[1],
-		    header3 = mem_header[2], body1 = mem_reply, deleter = std::move (deleter)] () noexcept
-  {
-    delete header1;
-
-    if (header2)
-      {
-	delete header2;
-      }
-    if (header3)
-      {
-	delete header3;
-      }
-    if (body1)
-      {
-	delete[]body1;
-      }
-    if (deleter)
-      {
-	deleter ();
-      }
-  };
-  // *INDENT-ON*
-
-  return css_enqueue_and_notify (cubconn::connection::worker::queue_type::IMMEDIATE, std::move (request));
+  buffer_count = buffer2_size > 0 ? 3 : (buffer1_size > 0 ? 2 : 1);
+  return css_send_response_buffers_to_client (conn, eid, DATA_TYPE, buffers, buffer_sizes, buffer_count, true, 1,
+					      std::move (deleter), 0);
 }
 
 /*
@@ -1088,10 +910,9 @@ css_send_reply_and_3_data_to_client (CSS_CONN_ENTRY * conn, unsigned int eid, ch
 				     char *buffer1, int buffer1_size, char *buffer2, int buffer2_size, char *buffer3,
 				     int buffer3_size, std::function < void () > &&deleter)
 {
-  // *INDENT-OFF*
-  cubconn::connection::worker::message request;
-  NET_HEADER *mem_header[4] = { nullptr, nullptr, nullptr, nullptr };
-  std::byte * mem_reply = nullptr;
+  char *buffers[] = { reply, buffer1, buffer2, buffer3 };
+  int buffer_sizes[] = { reply_size, buffer1_size, buffer2_size, buffer3_size };
+  std::size_t buffer_count;
 
   assert (conn != NULL);
   assert (reply && reply_size > 0);
@@ -1099,100 +920,9 @@ css_send_reply_and_3_data_to_client (CSS_CONN_ENTRY * conn, unsigned int eid, ch
   assert (!!buffer2 == !!buffer2_size);
   assert (!!buffer3 == !!buffer3_size);
 
-  rmutex_lock (NULL, &conn->rmutex);
-  if (conn->status == CONN_CLOSED)
-    {
-      rmutex_unlock (NULL, &conn->rmutex);
-
-      if (deleter)
-	{
-	  deleter ();
-	}
-      return CONNECTION_CLOSED;
-    }
-  rmutex_unlock (NULL, &conn->rmutex);
-
-  request.type = cubconn::connection::worker::message_type::SEND_PACKET;
-  request.conn = conn;
-  request.packet.clear ();
-
-  /* reply */
-  mem_header[0] = new NET_HEADER {};
-  css_set_net_header (mem_header[0], DATA_TYPE, 0, CSS_RID_FROM_EID (eid), reply_size, conn->get_tran_index (),
-		      conn->invalidate_snapshot, conn->db_error);
-  request.packet.emplace_back (reinterpret_cast < std::byte * >(mem_header[0]), sizeof (NET_HEADER));
-  if (reply && reply_size > 0)
-    {
-      mem_reply = new std::byte[reply_size];
-      std::memcpy (mem_reply, reply, reply_size);
-    }
-  request.packet.emplace_back (mem_reply, (std::size_t) reply_size);
-
-  /* data1 */
-  if ((buffer1 && buffer1_size > 0) || (buffer2 && buffer2_size > 0) || (buffer3 && buffer3_size > 0))
-    {
-      mem_header[1] = new NET_HEADER {};
-      css_set_net_header (mem_header[1], DATA_TYPE, 0, CSS_RID_FROM_EID (eid), buffer1_size, conn->get_tran_index (),
-			  conn->invalidate_snapshot, conn->db_error);
-      request.packet.emplace_back (reinterpret_cast < std::byte * >(mem_header[1]), sizeof (NET_HEADER));
-      request.packet.emplace_back (reinterpret_cast < std::byte * >(buffer1),
-				   static_cast < std::size_t > (buffer1_size));
-    }
-
-  /* data2 */
-  if ((buffer2 && buffer2_size > 0) || (buffer3 && buffer3_size > 0))
-    {
-      mem_header[2] = new NET_HEADER {};
-      css_set_net_header (mem_header[2], DATA_TYPE, 0, CSS_RID_FROM_EID (eid), buffer2_size, conn->get_tran_index (),
-			  conn->invalidate_snapshot, conn->db_error);
-      request.packet.emplace_back (reinterpret_cast < std::byte * >(mem_header[2]), sizeof (NET_HEADER));
-      request.packet.emplace_back (reinterpret_cast < std::byte * >(buffer2),
-				   static_cast < std::size_t > (buffer2_size));
-    }
-
-  /* data3 */
-  if (buffer3 && buffer3_size > 0)
-    {
-      mem_header[3] = new NET_HEADER {};
-      css_set_net_header (mem_header[3], DATA_TYPE, 0, CSS_RID_FROM_EID (eid), buffer3_size, conn->get_tran_index (),
-			  conn->invalidate_snapshot, conn->db_error);
-      request.packet.emplace_back (reinterpret_cast < std::byte * >(mem_header[3]), sizeof (NET_HEADER));
-      request.packet.emplace_back (reinterpret_cast < std::byte * >(buffer3),
-				   static_cast < std::size_t > (buffer3_size));
-    }
-
-  /* deleter */
-  request.deleter =[header1 = mem_header[0],
-		    header2 = mem_header[1],
-		    header3 = mem_header[2],
-		    header4 = mem_header[3], body1 = mem_reply, deleter = std::move (deleter)] () noexcept
-  {
-    delete header1;
-
-    if (header2)
-      {
-	delete header2;
-      }
-    if (header3)
-      {
-	delete header3;
-      }
-    if (header4)
-      {
-	delete header4;
-      }
-    if (body1)
-      {
-	delete[]body1;
-      }
-    if (deleter)
-      {
-	deleter ();
-      }
-  };
-  // *INDENT-ON*
-
-  return css_enqueue_and_notify (cubconn::connection::worker::queue_type::IMMEDIATE, std::move (request));
+  buffer_count = buffer3_size > 0 ? 4 : (buffer2_size > 0 ? 3 : (buffer1_size > 0 ? 2 : 1));
+  return css_send_response_buffers_to_client (conn, eid, DATA_TYPE, buffers, buffer_sizes, buffer_count, false, 1,
+					      std::move (deleter), 0);
 }
 
 /*
@@ -1209,52 +939,13 @@ css_send_reply_and_3_data_to_client (CSS_CONN_ENTRY * conn, unsigned int eid, ch
 unsigned int
 css_send_error_to_client (CSS_CONN_ENTRY * conn, unsigned int eid, char *buffer, int buffer_size)
 {
-  // *INDENT-OFF*
-  cubconn::connection::worker::message request;
-  NET_HEADER *mem_header;
-  std::byte * mem_reply = nullptr;
+  char *buffers[] = { buffer };
+  int buffer_sizes[] = { buffer_size };
 
   assert (conn != NULL);
 
-  rmutex_lock (NULL, &conn->rmutex);
-  if (conn->status == CONN_CLOSED)
-    {
-      rmutex_unlock (NULL, &conn->rmutex);
-
-      return CONNECTION_CLOSED;
-    }
-  rmutex_unlock (NULL, &conn->rmutex);
-
-  request.type = cubconn::connection::worker::message_type::SEND_PACKET;
-  request.conn = conn;
-  request.packet.clear ();
-
-  /* header */
-  mem_header = new NET_HEADER {};
-  css_set_net_header (mem_header, ERROR_TYPE, 0, CSS_RID_FROM_EID (eid), buffer_size, conn->get_tran_index (),
-		      conn->invalidate_snapshot, conn->db_error);
-  request.packet.emplace_back ((std::byte *) mem_header, sizeof (NET_HEADER));
-
-  if (buffer && buffer_size > 0)
-    {
-      /* reply */
-      mem_reply = new std::byte[buffer_size];
-      std::memcpy (mem_reply, buffer, buffer_size);
-    }
-  request.packet.emplace_back (mem_reply, (std::size_t) buffer_size);
-
-  /* deleter */
-  request.deleter =[mem_header, mem_reply] () noexcept
-  {
-    delete mem_header;
-    if (mem_reply)
-      {
-	delete[] mem_reply;
-      }
-  };
-  // *INDENT-ON*
-
-  return css_enqueue_and_notify (cubconn::connection::worker::queue_type::IMMEDIATE, std::move (request));
+  return css_send_response_buffers_to_client (conn, eid, ERROR_TYPE, buffers, buffer_sizes, 1, false, 1,
+					      std::function<void ()> (), 0);
 }
 
 /*
@@ -1265,66 +956,55 @@ css_send_error_to_client (CSS_CONN_ENTRY * conn, unsigned int eid, char *buffer,
 unsigned int
 css_send_abort_to_client (CSS_CONN_ENTRY * conn, unsigned int eid)
 {
-  // *INDENT-OFF*
-  cubconn::connection::worker::message request;
-  NET_HEADER *header;
+  NET_HEADER header = DEFAULT_HEADER_DATA;
+  cubbase::span<std::byte> packet;
   unsigned short flags = 0;
+  int transaction_id;
+  int invalidate_snapshot;
+  int db_error;
+  bool in_method;
   int r;
 
   assert (conn != NULL);
 
-  rmutex_lock (NULL, &conn->rmutex);
+  r = rmutex_lock (NULL, &conn->rmutex);
+  assert (r == NO_ERROR);
   if (conn->status != CONN_OPEN)
     {
-      rmutex_unlock (NULL, &conn->rmutex);
+      r = rmutex_unlock (NULL, &conn->rmutex);
+      assert (r == NO_ERROR);
       return CONNECTION_CLOSED;
     }
-  rmutex_unlock (NULL, &conn->rmutex);
 
-  request.type = cubconn::connection::worker::message_type::SEND_PACKET;
-  request.conn = conn;
-  request.packet.clear ();
+  transaction_id = conn->get_tran_index ();
+  invalidate_snapshot = conn->invalidate_snapshot;
+  db_error = conn->db_error;
+  in_method = conn->in_method;
 
-  /* header */
-  header = new NET_HEADER {};
-  header->type = htonl (ABORT_TYPE);
-  header->request_id = htonl (CSS_RID_FROM_EID (eid));
-  header->transaction_id = htonl (conn->get_tran_index ());
-
-  if (conn->invalidate_snapshot)
+  header.type = htonl (ABORT_TYPE);
+  header.request_id = htonl (CSS_RID_FROM_EID (eid));
+  header.transaction_id = htonl (transaction_id);
+  if (invalidate_snapshot)
     {
       flags |= NET_HEADER_FLAG_INVALIDATE_SNAPSHOT;
     }
-  if (conn->in_method)
+  if (in_method)
     {
       flags |= NET_HEADER_FLAG_METHOD_MODE;
     }
-  header->flags = htons (flags);
-  header->db_error = htonl (conn->db_error);
-
-  request.packet.emplace_back ((std::byte *) header, sizeof (NET_HEADER));
-  request.deleter =[header] () noexcept
-  {
-    delete header;
-  };
-  // *INDENT-ON*
-
-  if (css_enqueue_and_notify (cubconn::connection::worker::queue_type::IMMEDIATE, std::move (request)) != NO_ERROR)
-    {
-      return INTERNAL_CSS_ERROR;
-    }
-
-  /* remove queued packet */
-  r = rmutex_lock (NULL, &conn->rmutex);
-  assert (r == NO_ERROR);
+  header.flags = htons (flags);
+  header.db_error = htonl (db_error);
 
   css_remove_unexpected_packets (conn, CSS_RID_FROM_EID (eid));
 
   r = rmutex_unlock (NULL, &conn->rmutex);
   assert (r == NO_ERROR);
 
-  return 0;
+  packet = { reinterpret_cast<std::byte *> (&header), sizeof (header) };
+
+  return cubconn::connection::worker::send_packet (conn, &packet, 1, nullptr, std::function<void ()> (), 0);
 }
+// *INDENT-ON*
 
 /*
  * css_test_for_client_errors () -

--- a/src/connection/transmitter.cpp
+++ b/src/connection/transmitter.cpp
@@ -150,6 +150,11 @@ namespace cubconn
     return m_buf.get_msghdr ().msg_iovlen == 0;
   }
 
+  std::size_t transmitter::get_buffer_count ()
+  {
+    return m_buf.get_buffer_count ();
+  }
+
   void transmitter::clear ()
   {
     for (auto &deleter : m_deleter)

--- a/src/connection/transmitter.cpp
+++ b/src/connection/transmitter.cpp
@@ -52,7 +52,6 @@ namespace cubconn
     m_buf (IOV_MAX),
     m_stats (stats)
   {
-    m_deleter.reserve (IOV_MAX);
   }
 
   transmitter::transmitter ()
@@ -137,7 +136,8 @@ namespace cubconn
 	return;
       }
 
-    m_deleter.push_back (std::move (deleter));
+    /* keep the data alive until every iovec preceding this deleter is fully consumed. */
+    m_deleter.push_back ({ m_appended_iov_count, std::move (deleter) });
   }
 
   void transmitter::stamp ()
@@ -145,26 +145,47 @@ namespace cubconn
     m_buf.stamp_msghdr ();
   }
 
+  bool transmitter::prepare_append (std::size_t additional_count)
+  {
+    std::size_t completed_iov_count;
+    bool can_append;
+
+    can_append = m_buf.prepare_append (additional_count, completed_iov_count);
+    this->release_completed (completed_iov_count);
+    return can_append;
+  }
+
   bool transmitter::empty ()
   {
     return m_buf.get_msghdr ().msg_iovlen == 0;
   }
 
-  std::size_t transmitter::get_buffer_count ()
-  {
-    return m_buf.get_buffer_count ();
-  }
-
   void transmitter::clear ()
   {
-    for (auto &deleter : m_deleter)
+    for (deleter_entry &entry : m_deleter)
       {
+	if (entry.m_deleter)
+	  {
+	    entry.m_deleter ();
+	  }
+      }
+    m_deleter.clear ();
+    m_buf.clear ();
+    m_appended_iov_count = 0;
+  }
+
+  void transmitter::release_completed (std::size_t completed_iov_count)
+  {
+    assert (completed_iov_count <= m_appended_iov_count);
+
+    while (!m_deleter.empty () && m_deleter.front ().m_completion_iov_count <= completed_iov_count)
+      {
+	std::function<void ()> deleter = std::move (m_deleter.front ().m_deleter);
+	m_deleter.pop_front ();
 	if (deleter)
 	  {
 	    deleter ();
 	  }
       }
-    m_deleter.clear ();
-    m_buf.clear ();
   }
 }

--- a/src/connection/transmitter.hpp
+++ b/src/connection/transmitter.hpp
@@ -28,6 +28,7 @@
 #include "packet_buffer.hpp"
 
 #include <functional>
+#include <deque>
 #include <cstring>
 #include <sys/socket.h>
 #include <sys/epoll.h>
@@ -50,26 +51,52 @@ namespace cubconn
       void push_for_deleter (std::function<void ()> &&deleter);
       void stamp ();
 
+      bool prepare_append (std::size_t additional_count);
       bool empty ();
-      std::size_t get_buffer_count ();
       void clear ();
 
     private:
+      struct deleter_entry
+      {
+	std::size_t m_completion_iov_count;
+	std::function<void ()> m_deleter;
+      };
+
       cubbase::packet_buffer m_buf;
-      std::vector<std::function<void ()>> m_deleter;
+      std::deque<deleter_entry> m_deleter;
+      std::size_t m_appended_iov_count = 0;
 
       statistics::metrics<statistics::context> *m_stats;
+
+      void release_completed (std::size_t completed_iov_count);
   };
 
   template <typename... Spans>
   void transmitter::push_for_send (const cubbase::span<std::byte> &&first, const Spans &&... rest)
   {
+    std::size_t appended_iov_count = 1;
+    auto count_nonempty = [&appended_iov_count] (const cubbase::span<std::byte> &span)
+    {
+      if (!span.empty ())
+	{
+	  ++appended_iov_count;
+	}
+    };
+
+    count_nonempty (first);
+    if constexpr (sizeof... (rest) > 0)
+      {
+	(count_nonempty (rest), ...);
+      }
+
     m_buf.push_for_send (std::forward<const cubbase::span<std::byte>> (first), std::forward<Spans> (rest)...);
+    m_appended_iov_count += appended_iov_count;
   }
 
   inline void transmitter::push (const cubbase::span<std::byte> &data)
   {
     m_buf.push (data);
+    ++m_appended_iov_count;
   }
 }
 

--- a/src/connection/transmitter.hpp
+++ b/src/connection/transmitter.hpp
@@ -46,10 +46,12 @@ namespace cubconn
 
       template <typename... Spans>
       void push_for_send (const cubbase::span<std::byte> &&first, const Spans &&... rest);
+      void push (const cubbase::span<std::byte> &data);
       void push_for_deleter (std::function<void ()> &&deleter);
       void stamp ();
 
       bool empty ();
+      std::size_t get_buffer_count ();
       void clear ();
 
     private:
@@ -63,6 +65,11 @@ namespace cubconn
   void transmitter::push_for_send (const cubbase::span<std::byte> &&first, const Spans &&... rest)
   {
     m_buf.push_for_send (std::forward<const cubbase::span<std::byte>> (first), std::forward<Spans> (rest)...);
+  }
+
+  inline void transmitter::push (const cubbase::span<std::byte> &data)
+  {
+    m_buf.push (data);
   }
 }
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27096>

### Purpose

1. 송신 경로를 최적화 하였습니다.
non-blocking socket에 대해서 sendmsg를 시도하고 실패하는 경우 패킷을 등록하여 송신을 connection worker에 위임합니다. 이때 패킷을 등록하는 과정에서 MQ를 제거하고 직접 EPOLLOUT을 등록하여 이벤트 기반 트리거로 제어합니다.

2. PACKET RELEASE 경로를 최적화하였습니다.
기존에는 DMRB를 사용한 후 사용을 마친 공간을 반환하고 merge하기 위해 PACKET_RELEASE를 MQ에 삽입했지만, 이제는 직접 recever의 DMRB mutex (새로 도입함)를 잡고 해제를 수행합니다.
중요한 점은 이제 context의 receiver는 connection worker가 온전히 소유하는 객체가 아니라는 것입니다. 하지만 이 DMRB에 대해 동시에 접근하는 케이스 자체가 적으므로 오히려 비용이 줄어 성능 증가를 보입니다.

3. notify 병합
현재는 MQ에 이벤트를 삽입할 때마다 eventfd에 대해 write를 하고 있습니다. 하지만, 이는 커널 CS에 계속 진입하여 부하를 만듭니다. 따라서 connection worker 별로 atomic flag를 추가하고, write 여부에 대해 표기합니다. atomic이 여러 코어에서 접근되더라도 write보다 가격이 싸므로 효율이 올라갑니다.

4. stale context를 제거할 때 비어있다면 메시지를 보내지 않습니다.

### Implementation

N/A

### Remarks

N/A
