### PR TITLE
[CBRD-27093] Synchronize volumes when DWB is disabled

### DIFF
--- a/src/storage/double_write_buffer.cpp
+++ b/src/storage/double_write_buffer.cpp
@@ -3508,7 +3508,7 @@ start:
  *
  * return   : Error code.
  * thread_p (in): The thread entry.
- * all_sync (out): True, if everything synchronized.
+ * all_sync (out): True, if DWB synchronized all permanent volumes.
  */
 int
 dwb_flush_force (THREAD_ENTRY *thread_p, bool *all_sync)
@@ -3551,9 +3551,9 @@ start:
     {
       if (!DWB_IS_CREATED (initial_position_with_flags))
 	{
-	  /* Nothing to do. Everything flushed. */
+	  /* DWB is not created. Let the caller synchronize permanent volumes. */
 	  assert (dwb_Global.file_sync_helper_block == NULL);
-	  dwb_log ("dwb_flush_force: Everything flushed\n");
+	  dwb_log ("dwb_flush_force: DWB is not created\n");
 	  goto end;
 	}
 
@@ -3583,7 +3583,7 @@ start:
       if (initial_block == NULL)
 	{
 	  /* Nothing to flush. */
-	  goto end;
+	  goto end_all_sync;
 	}
 
       goto wait_for_file_sync_helper_block;
@@ -3654,9 +3654,9 @@ check_flushed_blocks:
     {
       if (!DWB_IS_CREATED (current_position_with_flags))
 	{
-	  /* Nothing to do. Everything flushed. */
+	  /* DWB was disabled. Let the caller synchronize permanent volumes. */
 	  assert (dwb_Global.file_sync_helper_block == NULL);
-	  dwb_log ("dwb_flush_force: Everything flushed\n");
+	  dwb_log ("dwb_flush_force: DWB was disabled\n");
 	  goto end;
 	}
 
@@ -3711,7 +3711,7 @@ check_flushed_blocks:
 	}
       else if (dwb_slot == NULL)
 	{
-	  /* DWB disabled meanwhile, everything flushed. */
+	  /* DWB was disabled meanwhile. Let the caller synchronize permanent volumes. */
 	  assert (dwb_Global.file_sync_helper_block == NULL);
 	  assert (!DWB_IS_CREATED (ATOMIC_INC_64 (&dwb_Global.position_with_flags, 0ULL)));
 	  dwb_log ("dwb_flush_force: DWB disabled = %lld\n", ATOMIC_INC_64 (&dwb_Global.position_with_flags, 0ULL));
@@ -3736,9 +3736,10 @@ wait_for_file_sync_helper_block:
     }
 #endif
 
-end:
+end_all_sync:
   *all_sync = true;
 
+end:
   dwb_log ("dwb_flush_force: Ended with position = %lld\n", ATOMIC_INC_64 (&dwb_Global.position_with_flags, 0ULL));
   PERF_UTIME_TRACKER_TIME_AND_RESTART (thread_p, &time_track, PSTAT_DWB_FLUSH_FORCE_TIME_COUNTERS);
 

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -38,6 +38,7 @@ option (UNIT_TEST_RESOURCE_TRACKER "Unit testing: resource tracker")
 option (UNIT_TEST_MONITOR "Unit testing: monitor")
 option (UNIT_TEST_LOADDB "Unit testing: loaddb module")
 option (UNIT_TEST_MEMORY_MONITOR "Unit testing: memory monitor")
+option (UNIT_TEST_DOUBLE_WRITE_BUFFER "Unit testing: double write buffer")
 
 message("  unit_tests/...")
 
@@ -102,6 +103,11 @@ if (UNIT_TESTS OR UNIT_TEST_MONITOR)
   message("    monitor")
   add_subdirectory(monitor)
 endif(UNIT_TESTS OR UNIT_TEST_MONITOR)
+
+if (UNIT_TESTS OR UNIT_TEST_DOUBLE_WRITE_BUFFER)
+  message("    double_write_buffer")
+  add_subdirectory(double_write_buffer)
+endif(UNIT_TESTS OR UNIT_TEST_DOUBLE_WRITE_BUFFER)
 
 #[[
 TODO compilation fails

--- a/unit_tests/double_write_buffer/CMakeLists.txt
+++ b/unit_tests/double_write_buffer/CMakeLists.txt
@@ -1,0 +1,42 @@
+#
+#  Copyright 2008 Search Solution Corporation
+#  Copyright 2016 CUBRID Corporation
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+set (TEST_DOUBLE_WRITE_BUFFER_SOURCES
+  test_double_write_buffer.cpp
+  )
+
+add_executable(test_double_write_buffer
+  ${TEST_DOUBLE_WRITE_BUFFER_SOURCES}
+  )
+
+target_compile_definitions(test_double_write_buffer PRIVATE
+  SA_MODE
+  ${COMMON_DEFS}
+  )
+
+target_include_directories(test_double_write_buffer PRIVATE
+  ${TEST_INCLUDES}
+  )
+
+target_link_libraries(test_double_write_buffer PRIVATE
+  cubridsa
+  )
+
+add_dependencies(test_double_write_buffer
+  ${CATCH2_TARGET}
+  ${EP_TARGETS}
+  )

--- a/unit_tests/double_write_buffer/test_double_write_buffer.cpp
+++ b/unit_tests/double_write_buffer/test_double_write_buffer.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#include "catch2/catch.hpp"
+
+#include "double_write_buffer.hpp"
+#include "error_code.h"
+
+TEST_CASE ("Disabled DWB delegates permanent volume synchronization", "[double_write_buffer]")
+{
+  REQUIRE_FALSE (dwb_is_created ());
+
+  bool all_sync = true;
+  int error_code = dwb_flush_force (NULL, &all_sync);
+
+  REQUIRE (error_code == NO_ERROR);
+  REQUIRE_FALSE (all_sync);
+}


### PR DESCRIPTION
## Purpose

http://jira.cubrid.org/browse/CBRD-27093

`double_write_buffer_size=0`일 때 checkpoint가 영구 데이터 볼륨을 동기화하지 않는 문제를 수정합니다.
AS-IS: DWB가 생성되지 않아 아무 동기화도 하지 않았지만 `all_sync=true`를 반환하여 호출자의 직접 fsync를 건너뜁니다.
TO-BE: DWB 비활성 경로는 `all_sync=false`를 유지하여 호출자가 영구 볼륨을 직접 동기화합니다.

상세 분석과 검증 결과는 [CBRD-27093 상세 문서](https://github.com/vimkim/my-cubrid-docs/blob/main/cbrd-27093/CBRD-27093-checkpoint-fsync-fallback_85b6b57_codex.md)에 정리했습니다.

## Implementation

- `dwb_flush_force()`의 `all_sync` 의미를 DWB 경로가 모든 영구 볼륨 동기화를 보증하는지로 명확히 했습니다.
- DWB 미생성 및 실행 중 비활성화 경로에서는 초기값 `false`를 유지합니다.
- DWB가 동기화를 보증하는 정상 활성 경로만 `end_all_sync`에서 `true`로 설정합니다.
- DWB 미생성 상태의 반환 계약을 고정하는 Catch2 단위 테스트와 전용 CMake option을 추가했습니다.

호출자에 이미 구현된 전체 볼륨 순회 및 개별 볼륨 fsync fallback을 그대로 사용하므로 호출자별 변경은 없습니다.

## Remarks

- Source commit: `85b6b5743d8cd93e56542de1858b4e507e2a5f21`
- Debug 전체 빌드 및 설치가 성공했습니다.
- 단위 테스트는 1 case, 3 assertions를 통과했습니다.
- Linux CTP syscall 시나리오가 통과했습니다.

AS-IS 실측은 DWB 파일 없음, checkpoint 성공, active log sync 2회, 영구 base 볼륨 sync 0회였습니다.
TO-BE 실측은 DWB 파일 없음, checkpoint 성공, active log sync 3회, 영구 base 볼륨 sync 4회였습니다.

syscall 검증에는 Linux `strace`와 ptrace attach 권한이 필요합니다.
fsync 실패 처리 정책 변경은 이번 수정 범위에 포함하지 않습니다.
