### PR TITLE
[CBRD-27102] refactoring pt_check_into_clause_for_static_sql l function

### DIFF
--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -10682,7 +10682,7 @@ pt_check_into_clause_for_static_sql (PARSER_CONTEXT * parser, PT_NODE * qry, int
   char **external_into_label = (char **) malloc (into_cnt * sizeof (char *));
   if (external_into_label == NULL)
     {
-      goto lable_fail;
+      goto error_exit;
     }
 
   for (i = 0; i < into_cnt; i++)
@@ -10690,13 +10690,13 @@ pt_check_into_clause_for_static_sql (PARSER_CONTEXT * parser, PT_NODE * qry, int
       external_into_label[i] = strdup (into->info.name.original);
       if (external_into_label[i] == NULL)
 	{
-	  goto lable_fail;
+	  goto error_exit;
 	}
       into = into->next;
     }
   is_fail = 0;
 
-lable_fail:
+error_exit:
   if (is_fail == 1)
     {
       // clear memory

--- a/src/parser/semantic_check.c
+++ b/src/parser/semantic_check.c
@@ -10675,15 +10675,45 @@ static void
 pt_check_into_clause_for_static_sql (PARSER_CONTEXT * parser, PT_NODE * qry, int into_cnt)
 {
   // set external into labels in parser context
+  int i = 0;
+  int is_fail = 1;
   PT_NODE *into = qry->info.query.into_list;
 
   char **external_into_label = (char **) malloc (into_cnt * sizeof (char *));
-  for (int i = 0; i < into_cnt; i++)
+  if (external_into_label == NULL)
     {
-      external_into_label[i] = (char *) malloc (sizeof (char) * 255);
-      strncpy (external_into_label[i], into->info.name.original, 254);
+      goto lable_fail;
+    }
+
+  for (i = 0; i < into_cnt; i++)
+    {
+      external_into_label[i] = strdup (into->info.name.original);
+      if (external_into_label[i] == NULL)
+	{
+	  goto lable_fail;
+	}
       into = into->next;
     }
+  is_fail = 0;
+
+lable_fail:
+  if (is_fail == 1)
+    {
+      // clear memory
+      if (external_into_label)
+	{
+	  for (--i; i >= 0; i--)
+	    {
+	      free (external_into_label[i]);
+	    }
+	  free (external_into_label);
+	  external_into_label = NULL;
+	}
+
+      PT_ERRORm (parser, qry, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_OUT_OF_MEMORY);
+      into_cnt = 0;
+    }
+
   parser->external_into_label_cnt = into_cnt;
   parser->external_into_label = external_into_label;
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27102>

### Purpose

* pt_check_into_clause_for_static_sql() 함수 수정
   - 메모리 할당 성공 검사
   - strncpy() 복사시 '\0' 누락 가능성 제거
 

### Implementation

N/A

### Remarks

N/A
