### PR TITLE
[CBRD-27113] Improve iscan cost model: per-row heap-fetch cost and per-probe leaf page IO in NL join

### DIFF
--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -81,6 +81,11 @@
 /* Per-OID heap-access CPU penalty for NON-covering index scans (covering scans: 0).
  * Lowered 20 -> 5 to favor index scan when low/stale leading-column NDV inflates sel via 1/pkeys[0]. TODO: per-index clustering factor. */
 #define ISCAN_OID_ACCESS_OVERHEAD 5
+/* Per-extra-row iscan heap-fetch cost: charges (heap_rows - 1) * ratio, so a single-row
+ * (fanout=1 / unique / pk) probe adds ZERO and keeps exactly the original cost (blast-radius
+ * safe). Added to object_IO on top of the existing page-based cost, so a high-fanout inner
+ * index scan of a nested loop is no longer priced like a single-row probe. */
+#define FETCH_HEAP_COST 0.25	/* per-extra heap-row fetch (non-covering only) */
 #define MJ_CPU_OVERHEAD_FACTOR 20
 #define HJ_BUILD_CPU_OVERHEAD_FACTOR 40
 #define HJ_PROBE_CPU_OVERHEAD_FACTOR 20
@@ -2122,7 +2127,8 @@ qo_iscan_cost (QO_PLAN * planp)
   QO_NODE_INDEX_ENTRY *ni_entryp;
   QO_ATTR_CUM_STATS *cum_statsp;
   QO_INDEX_ENTRY *index_entryp;
-  double sel, sel_limit, height, leaves, opages, filter_sel, leaf_access, heap_access;
+  double sel, sel_limit, height, leaves, opages, filter_sel, leaf_access, heap_access, heap_rows;
+  double heap_fanout = 0.0, iss_leaves = 0.0, first_leaf = 0.0;
   double object_IO, index_IO;
   double sel_excl_derived_range;
   QO_TERM *termp;
@@ -2290,13 +2296,20 @@ qo_iscan_cost (QO_PLAN * planp)
     }
   /* number of leaf pages to be accessed */
   leaves = ceil (sel * (double) cum_statsp->leafs);
+  /* the landing leaves the descent lands on (fixed, cached across probes): one per class the
+   * index spans -- (ni_entryp)->n classes, matching the n * height descent below. cum_stats.leafs
+   * is summed over those classes, so `leaves` already includes these n landing pages; the rest is
+   * per-probe. */
+  first_leaf = MIN (leaves, (double) (ni_entryp)->n);
   /* total number of pages occupied by objects */
   opages = (double) QO_NODE_TCARD (nodep);
-  /* I/O cost to access B+tree index */
-  index_IO = ((ni_entryp)->n * height) + leaves;
+  /* I/O cost to access B+tree index: only the descent (n * height) is fixed; the `leaves`
+   * pages are charged per probe on the variable side below. */
+  index_IO = (ni_entryp)->n * height;
 
-  /* Index Skip Scan adds to the index IO cost the K extra BTREE searches it does to fetch the next value for the
-   * following BTRangeScan
+  /* Index Skip Scan does K extra BTREE searches to fetch the next value for the following
+   * BTRangeScan. These are K additional leaf reads that recur on every probe (like `leaves`),
+   * so they belong on the variable (per-outer-row) side, not the fixed descent cost.
    */
   if (qo_is_index_iss_scan (planp))
     {
@@ -2305,8 +2318,7 @@ qo_iscan_cost (QO_PLAN * planp)
 	  assert (cum_statsp->pkeys != NULL);
 	  assert (cum_statsp->pkeys_size != 0);
 
-	  /* K leaves are additionally read */
-	  index_IO += cum_statsp->pkeys[0];
+	  iss_leaves = cum_statsp->pkeys[0];
 	}
     }
 
@@ -2318,15 +2330,32 @@ qo_iscan_cost (QO_PLAN * planp)
     }
   else
     {
+      /* Row count reaching the heap: uses sel_excl_derived_range (not sel) so a LIKE-derived
+       * range is not double counted against the residual LIKE it came from - same basis as
+       * scan_rows below. */
+      heap_rows = (double) QO_NODE_NCARD (nodep) * sel_excl_derived_range * filter_sel;
       object_IO = opages * sel_excl_derived_range * filter_sel;
-      heap_access =
-	(double) QO_NODE_NCARD (nodep) * sel_excl_derived_range * filter_sel * (double) ISCAN_OID_ACCESS_OVERHEAD;
+      /* Cap the per-row heap-fetch surcharge at the table's page count: fetching more rows
+       * than there are heap pages cannot touch more distinct pages (the rows share pages),
+       * so an unbounded per-row charge would overprice a wide scan whose non-indexed filter
+       * (sargs) is applied only after the fetch. */
+      heap_fanout = (heap_rows > 1.0) ? MAX (0.0, MIN (heap_rows, opages) - 1.0) * FETCH_HEAP_COST : 0.0;
+      heap_access = heap_rows * (double) ISCAN_OID_ACCESS_OVERHEAD;
     }
-  object_IO = MAX (1.0, object_IO);
+  /* Split the leaf-page IO across the fixed/variable sides. The first leaf page (the one the
+   * b+tree descent lands on) is read once and stays buffer-resident across probes, so it is
+   * fixed; only the extra `leaves - 1` pages a wider range scans recur on every probe and go
+   * to the variable (per-outer-row) side, together with `iss_leaves` (ISS skip reads) and the
+   * per-fanout heap-fetch surcharge. A single-leaf probe (leaves == 1, e.g. unique/pk or a
+   * small index) therefore adds nothing to the variable side, keeping exactly the original
+   * cost and not eroding the small-input NL preference (HJ_MEM_ALLOC_CONSTANT). */
+  object_IO = MAX (1.0, object_IO) + (leaves - first_leaf) + iss_leaves + heap_fanout;
 
   /* index scan requires more CPU cost than sequential scan */
   planp->fixed_cpu_cost = 0.0;
-  planp->fixed_io_cost = index_IO;
+  /* Fixed: the b+tree descent (n * height, upper levels shared across probes and assumed
+   * buffer-resident) plus the single leaf page the descent lands on. */
+  planp->fixed_io_cost = index_IO + first_leaf;
   planp->variable_cpu_cost = (leaf_access + heap_access) * (double) QO_CPU_WEIGHT;
   planp->variable_io_cost = object_IO;
   planp->info->scan_rows = MAX (1, (double) QO_NODE_NCARD (nodep) * sel_excl_derived_range * filter_sel);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27113

## Purpose (목적)

`qo_iscan_cost`가 고-fanout 인덱스 스캔 비용을 두 가지로 과소평가한다.

1. 비커버링 스캔의 heap fetch를 페이지 기반(`opages × sel`)으로만 계상 → 한 프로브가 여러 행을 가져오는 스캔이 1행 PK 프로브와 거의 같은 비용으로 평가됨.
2. NL 조인 inner 인덱스의 leaf 페이지 IO를 프로브당이 아니라 `fixed_io_cost`로 한 번만 계상.

그 결과 다중 조인 쿼리(JOB류)에서 대량 중간결과를 만드는 나쁜 조인 순서를 선택한다.

## Implementation (구현)

`src/optimizer/query_planner.c` `qo_iscan_cost`:

1. **per-row heap-fetch 비용 추가** — `heap_fanout = (heap_rows-1) * 0.25`(비커버링만). `(건수-1) × 계수` 형태라 단일행(fanout=1 / unique / pk) 프로브는 **0** → 기존 비용 불변(blast-radius 안전).
2. **leaf 페이지 IO를 프로브당으로 이동** — `leaves`(및 Index Skip Scan의 `pkeys[0]` skip 읽기 `iss_leaves`)를 fixed descent에서 변수측 `object_IO`로 옮겨 `qo_nljoin_cost`가 outer 카디널리티를 곱하게 함. b+tree descent(`n × height`, 상위 레벨은 캐시 가정)만 `fixed_io_cost`로 유지.

> 참고: 초기 리비전에 있던 per-entry `leaf_fanout`(엔트리당 0.1)은 제거했다. leaf 페이지는 `leaves`, 엔트리 CPU는 `variable_cpu`가 이미 반영하므로 중복이었고, 넓은 인덱스 레인지 + 인덱스 상 필터 스캔의 비용을 과대평가해 index scan이 seq scan으로 뒤집히는 회귀(ISS 테스트 `function_index_skip_difference`)를 유발했다.

## Remarks (측정/비고)

JOB(Join Order Benchmark, IMDB) 113개 · 8G data_buffer · warm · 동일세션 격리 A/B:

- 다중 조인 플랜이 크게 개선. 대표: `19d` 148→11s, `18a` 27→1s, `22c` 14→1s, `30a` 10→1.4s.
- 단일행 프로브 비용이 불변이라 unique/pk 경로 회귀는 없음.
- 일부 sub-second~수초 회귀는 다중조인 **카디널리티 과소추정** 한계(별도 과제). 조인 선택도 개선(#7508, CBRD-26746)과 함께 적용 시 해당 회귀가 해소되고 전체 개선폭이 더 커짐을 실측 확인.
- ISS 회귀(`function_index_skip_difference`)는 `leaf_fanout` 제거로 해소(해당 index scan 비용 71 복원 < seq 149).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
