### PR TITLE
[CBRD-27111] Fix server crash on server-stop during loaddb

### DIFF
--- a/src/communication/network_interface_sr.cpp
+++ b/src/communication/network_interface_sr.cpp
@@ -11130,6 +11130,18 @@ ssession_stop_attached_threads (THREAD_ENTRY *thread_p, void *session)
   session_stop_attached_threads (thread_p, session);
 }
 
+void
+ssession_interrupt_attached_threads (THREAD_ENTRY *thread_p, void *session)
+{
+  session_interrupt_attached_threads (thread_p, session);
+}
+
+void
+ssession_destroy_load_session (THREAD_ENTRY *thread_p, void *session)
+{
+  session_destroy_load_session (thread_p, session);
+}
+
 #if defined (ENABLE_UNUSED_FUNCTION)
 static bool
 cdc_check_client_connection ()

--- a/src/communication/network_interface_sr.h
+++ b/src/communication/network_interface_sr.h
@@ -244,6 +244,8 @@ extern void sloaddb_destroy (THREAD_ENTRY * thread_p, unsigned int rid, char *re
 extern void sloaddb_interrupt (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen);
 extern void sloaddb_update_stats (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen);
 extern void ssession_stop_attached_threads (THREAD_ENTRY * thread_p, void *session);
+extern void ssession_interrupt_attached_threads (THREAD_ENTRY * thread_p, void *session);
+extern void ssession_destroy_load_session (THREAD_ENTRY * thread_p, void *session);
 
 extern void slob_create_dir (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen);
 extern void slob_remove_dir (THREAD_ENTRY * thread_p, unsigned int rid, char *request, int reqlen);

--- a/src/connection/connection_worker.cpp
+++ b/src/connection/connection_worker.cpp
@@ -488,7 +488,10 @@ namespace cubconn::connection
     m_entry->m_status = cubthread::entry::status::TS_CHECK;
     if (ctx->m_conn->session_p != NULL)
       {
-	ssession_stop_attached_threads (m_entry, ctx->m_conn->session_p);
+	/* Interrupt the load session here (before draining workers below), but defer
+	 * its destruction until the workers have drained; see the destroy call in the
+	 * "remove and close" section. */
+	ssession_interrupt_attached_threads (m_entry, ctx->m_conn->session_p);
       }
 
     if (!is_retry)
@@ -526,6 +529,13 @@ namespace cubconn::connection
 		   ctx->m_conn->stop_phase);
 
     /* remove and close */
+
+    /* Connection workers have drained; it is now safe to destroy the load session
+     * that was interrupted at the start of the close. */
+    if (ctx->m_conn->session_p != NULL)
+      {
+	ssession_destroy_load_session (m_entry, ctx->m_conn->session_p);
+      }
 
     m_events.remove_descriptor (ctx->m_conn->fd);
     if (tran_index != NULL_TRAN_INDEX)

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -3258,6 +3258,10 @@ session_get_load_session (THREAD_ENTRY * thread_p, REFPTR (load_session, load_se
       return ER_FAILED;
     }
 
+  /* The session state can outlive its load session: connection teardown (see
+   * session_destroy_load_session) frees the load session while the state is still
+   * reachable. Report an error here so sloaddb_* handlers take the error path
+   * instead of dereferencing a NULL load session. */
   if (state_p->load_session_p == NULL)
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_LDR_INVALID_STATE, 0);
@@ -3314,26 +3318,26 @@ session_get_pl_session (THREAD_ENTRY * thread_p, REFPTR (PL_SESSION, pl_session_
 }
 
 /*
- * session_stop_attached_threads - stops extra attached threads (not connection worker thread)
- *                                 associated with the session
+ * session_interrupt_attached_threads - interrupt extra attached threads (not connection worker
+ *                                      thread) associated with the session, without freeing the
+ *                                      load session
  *
  */
 void
-session_stop_attached_threads (THREAD_ENTRY * thread_p, void *session_arg)
+session_interrupt_attached_threads (THREAD_ENTRY * thread_p, void *session_arg)
 {
 #if defined (SERVER_MODE)
   SESSION_STATE *session = (SESSION_STATE *) session_arg;
 
   assert (session != NULL);
 
-  // on uninit abort and delete loaddb session
+  /* Interrupt only; keep the load session object alive so that in-flight requests
+   * still holding a reference (via session_get_load_session) do not access freed
+   * memory. The object is freed later by session_destroy_load_session, once the
+   * connection workers have drained. */
   if (session->load_session_p != NULL)
     {
       session->load_session_p->interrupt ();
-      session->load_session_p->wait_for_completion ();
-
-      delete session->load_session_p;
-      session->load_session_p = NULL;
     }
 
   if (session->pl_session_p)
@@ -3344,6 +3348,40 @@ session_stop_attached_threads (THREAD_ENTRY * thread_p, void *session_arg)
 	  session->pl_session_p->wait_until_pl_session_done ();
 	}
     }
+#endif
+}
 
+void
+session_destroy_load_session (THREAD_ENTRY * thread_p, void *session_arg)
+{
+#if defined (SERVER_MODE)
+  SESSION_STATE *session = (SESSION_STATE *) session_arg;
+
+  assert (session != NULL);
+
+  /* Must be called only after the connection workers have drained, otherwise an
+   * in-flight sloaddb_* request may still be using the load session. */
+  if (session->load_session_p != NULL)
+    {
+      session->load_session_p->wait_for_completion ();
+
+      delete session->load_session_p;
+      session->load_session_p = NULL;
+    }
+#endif
+}
+
+void
+session_stop_attached_threads (THREAD_ENTRY * thread_p, void *session_arg)
+{
+#if defined (SERVER_MODE)
+  SESSION_STATE *session = (SESSION_STATE *) session_arg;
+
+  assert (session != NULL);
+
+  /* Session-state uninit path: no concurrent worker can reach this session, so
+   * interrupt and destroy in one shot. */
+  session_interrupt_attached_threads (thread_p, session);
+  session_destroy_load_session (thread_p, session);
 #endif
 }

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -3258,6 +3258,12 @@ session_get_load_session (THREAD_ENTRY * thread_p, REFPTR (load_session, load_se
       return ER_FAILED;
     }
 
+  if (state_p->load_session_p == NULL)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_LDR_INVALID_STATE, 0);
+      return ER_LDR_INVALID_STATE;
+    }
+
   load_session_ref_ptr = state_p->load_session_p;
 
   return NO_ERROR;

--- a/src/session/session.h
+++ b/src/session/session.h
@@ -95,4 +95,6 @@ extern int session_get_pl_session (THREAD_ENTRY * thread_p, REFPTR (PL_SESSION, 
 extern bool session_is_pl_session_running (THREAD_ENTRY * thread_p);
 
 extern void session_stop_attached_threads (THREAD_ENTRY * thread_p, void *session);
+extern void session_interrupt_attached_threads (THREAD_ENTRY * thread_p, void *session);
+extern void session_destroy_load_session (THREAD_ENTRY * thread_p, void *session);
 #endif /* _SESSION_H_ */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27111

- return ER_LDR_INVALID_STATE from session_get_load_session when load session is NULL
