### PR TITLE
[CBRD-27085] Modernize check.yml GitHub Actions to remove Node 20 / set-output warnings

### DIFF
--- a/.github/actions/changed-files/action.yml
+++ b/.github/actions/changed-files/action.yml
@@ -1,0 +1,22 @@
+# Replaces the unmaintained github.com/jitterbit/get-changed-files action.
+name: 'Get changed files'
+description: 'List added/modified files in the pull request via the GitHub compare API'
+outputs:
+  added_modified:
+    description: 'Space-separated list of added/modified file paths'
+    value: ${{ steps.diff.outputs.added_modified }}
+runs:
+  using: 'composite'
+  steps:
+    - id: diff
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        base='${{ github.event.pull_request.base.sha }}'
+        head='${{ github.event.pull_request.head.sha }}'
+        # gh prints the error body to stdout on failure; guard so it can't become the file list.
+        files=$(gh api "repos/${{ github.repository }}/compare/${base}...${head}" \
+          --jq '[.files[] | select(.status == "added" or .status == "modified") | .filename] | join(" ")') || files=""
+        echo "changed files: $files"
+        echo "added_modified=$files" >> "$GITHUB_OUTPUT"

--- a/.github/actions/check-pr-title/action.yml
+++ b/.github/actions/check-pr-title/action.yml
@@ -1,0 +1,17 @@
+# Replaces the unmaintained github.com/deepakputhraya/action-pr-title action.
+name: 'Check PR title'
+description: 'Fail the job if the pull request title does not match the required prefix'
+runs:
+  using: 'composite'
+  steps:
+    - shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        # event payload title is stale on re-run after a title edit; fetch the live title.
+        title=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" --jq '.title') \
+          || { echo "::error::Failed to fetch PR title via GitHub API"; exit 1; }
+        echo "PR title: $title"
+        # literal space, not [[:space:]] (also matches Unicode spaces, locale-dependent).
+        grep -qE '^\[[A-Z]+-[0-9]+\][ ].+' <<<"$title" \
+          || { echo "::error::PR title must match [PROJECT-1234] summary (e.g. [CBRD-12345] Fix ...)"; exit 1; }

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,10 +26,10 @@ jobs:
     name: license
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: jitterbit/get-changed-files@v1
-        id: files
+      - uses: actions/checkout@v5
+      - id: files
         continue-on-error: true
+        uses: ./.github/actions/changed-files
       - name: Check license
         run: |
           set +e # make this step proceed even if a command returns non-zero
@@ -68,16 +68,15 @@ jobs:
     name: pr-style
     runs-on: ubuntu-24.04
     steps:
-      - uses: deepakputhraya/action-pr-title@master
-        with:
-          regex: '^\[[A-Z]+-\d+\]\s.+' # Regex the title should match.
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/check-pr-title
   code-style:
     name: code-style
     runs-on: ubuntu-24.04
     env:
       working-directory: .github/workflows
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: Install packages
         run: |
           # dependencies to build GNU indent
@@ -97,13 +96,13 @@ jobs:
           # download google-java-format-1.7-all-deps.jar
           wget https://github.com/google/google-java-format/releases/download/google-java-format-1.7/google-java-format-1.7-all-deps.jar
         working-directory: ${{ env.working-directory }}
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v5
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '8'
       - id: files
-        uses: jitterbit/get-changed-files@v1
         continue-on-error: true
+        uses: ./.github/actions/changed-files
       - name: Check code style
         id: stylecheck
         run: |
@@ -137,10 +136,10 @@ jobs:
           echo "CPPCHECK_PATH=`pwd`" >> $GITHUB_ENV
 
           cd $wd
-      - uses: actions/checkout@v2
-      - uses: jitterbit/get-changed-files@v1
-        id: files
+      - uses: actions/checkout@v5
+      - id: files
         continue-on-error: true
+        uses: ./.github/actions/changed-files
       - name: cppcheck
         run: |
           result_file="cppcheck.result"
@@ -180,11 +179,11 @@ jobs:
         id: get-comment-body
         if: ${{ failure() }}
         run: |
-          body=$(cat cppcheck.summary)
-          body="${body//'%'/'%25'}"
-          body="${body//$'\n'/'%0A'}"
-          body="${body//$'\r'/'%0D'}" 
-          echo ::set-output name=body::$body
+          {
+            echo 'body<<CPPCHECK_EOF'
+            cat cppcheck.summary
+            echo 'CPPCHECK_EOF'
+          } >> "$GITHUB_OUTPUT"
       - name: Report cppcheck.summary
         if: ${{ failure() }}
         uses: unsplash/comment-on-pr@master


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27085

### Purpose
- GitHub Actions 러너의 Node 20 런타임 폐기 대응. develop의 #7490·#7492를 이 release 브랜치에 백포트해 `check.yml`의 Node 20 / `set-output` deprecation 경고를 없앤다.

### Implementation
- 공식 액션 버전업: `actions/checkout@v2`→`v5`, `actions/setup-java@v3`→`v5`(`adopt`→`temurin`).
- 유지보수가 중단돼 버전업 경로가 없는 3rd-party 액션을 레포 로컬 composite action으로 치환한다.
  - `jitterbit/get-changed-files` → `.github/actions/changed-files` (GitHub compare API 호출)
  - `deepakputhraya/action-pr-title` → `.github/actions/check-pr-title` (PR 제목 조회 후 `grep` 검사)
- cppcheck 코멘트의 `::set-output` → `$GITHUB_OUTPUT` (heredoc로 multiline 보존).

### Remarks
- 두 composite action은 develop 머지본과 byte-identical이며, 원본 3rd-party 액션과 같은 GitHub API를 호출하므로 동작이 보존된다. 변경 파일 목록 소비 로직은 그대로 둔다.
- `check.yml` 수정은 원본 대비 위 modernization 변경만 적용했고 나머지 job/스텝은 불변이다.
- 이 release 브랜치에는 `tc-*.yml`이 없어 develop과 달리 `create-github-app-token` 버전업 대상은 없다.
