### PR TITLE
[CBRD-27038] Add OOS file owner metadata

### DIFF
--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -1413,22 +1413,6 @@ file_header_dump (THREAD_ENTRY * thread_p, const FILE_HEADER * fhead, FILE * fp)
 }
 
 /*
- * file_oos_descriptor_is_legacy () - return true for ownerless OOS descriptors created before CBRD-27038
- *
- * return         : true if all owner fields have their historical byte-zeroed representation
- * descriptor (in): OOS file descriptor
- */
-STATIC_INLINE bool
-file_oos_descriptor_is_legacy (const FILE_DESCRIPTORS * descriptor)
-{
-  return (descriptor->heap_overflow.hfid.vfid.fileid == 0
-	  && descriptor->heap_overflow.hfid.vfid.volid == 0
-	  && descriptor->heap_overflow.hfid.hpgid == 0
-	  && descriptor->heap_overflow.class_oid.pageid == 0
-	  && descriptor->heap_overflow.class_oid.slotid == 0 && descriptor->heap_overflow.class_oid.volid == 0);
-}
-
-/*
  * file_header_dump_descriptor () - dump descriptor in file header
  *
  * return        : void
@@ -1445,15 +1429,8 @@ file_header_dump_descriptor (THREAD_ENTRY * thread_p, const FILE_HEADER * fhead,
   switch (fhead->type)
     {
     case FILE_OOS:
-      if (file_oos_descriptor_is_legacy (&fhead->descriptor))
-	{
-	  fprintf (fp, "OOS file (owner descriptor unavailable)\n");
-	}
-      else
-	{
-	  file_print_name_of_class (thread_p, fp, &fhead->descriptor.heap_overflow.class_oid);
-	  fprintf (fp, ", OOS for HFID: %10d|%5d|%10d\n", HFID_AS_ARGS (&fhead->descriptor.heap_overflow.hfid));
-	}
+      file_print_name_of_class (thread_p, fp, &fhead->descriptor.heap_oos.class_oid);
+      fprintf (fp, ", OOS for HFID: %10d|%5d|%10d\n", HFID_AS_ARGS (&fhead->descriptor.heap_oos.hfid));
       break;
 
     case FILE_HEAP:
@@ -10907,7 +10884,6 @@ file_tracker_get_and_protect (THREAD_ENTRY * thread_p, FILE_TYPE desired_type, F
   PAGE_PTR page_fhead = NULL;
   FILE_HEADER *fhead = NULL;
   int error_code = NO_ERROR;
-  bool skip_legacy_oos = false;
 
   assert (class_oid != NULL && OID_ISNULL (class_oid));
 
@@ -10988,8 +10964,7 @@ file_tracker_get_and_protect (THREAD_ENTRY * thread_p, FILE_TYPE desired_type, F
       *class_oid = fhead->descriptor.btree.class_oid;
       break;
     case FILE_OOS:
-      skip_legacy_oos = file_oos_descriptor_is_legacy (&fhead->descriptor);
-      *class_oid = fhead->descriptor.heap_overflow.class_oid;
+      *class_oid = fhead->descriptor.heap_oos.class_oid;
       break;
     case FILE_HEAP:
     case FILE_HEAP_REUSE_SLOTS:
@@ -11007,21 +10982,8 @@ file_tracker_get_and_protect (THREAD_ENTRY * thread_p, FILE_TYPE desired_type, F
     }
   pgbuf_unfix (thread_p, page_fhead);
 
-  if (skip_legacy_oos)
-    {
-      /* OOS file descriptors created before CBRD-27038 were byte-zeroed and cannot protect online scans. */
-      OID_SET_NULL (class_oid);
-      return NO_ERROR;
-    }
-
   if (OID_ISNULL (class_oid))
     {
-      if ((FILE_TYPE) item->type == FILE_OOS)
-	{
-	  /* OOS files created before owner descriptors were introduced cannot be protected against DROP TABLE.
-	   * Preserve the legacy behavior by skipping them during interruptible online scans. */
-	  return NO_ERROR;
-	}
       /* this must be boot_Db_parm file; cannot be deleted so we don't need lock. */
       *stop = true;
       return NO_ERROR;
@@ -11386,6 +11348,9 @@ file_tracker_item_dump_file (THREAD_ENTRY * thread_p, PAGE_PTR page_of_item, FIL
 	case FILE_MULTIPAGE_OBJECT_HEAP:
 	  class_oid_p = &fhead->descriptor.heap_overflow.class_oid;
 	  break;
+	case FILE_OOS:
+	  class_oid_p = &fhead->descriptor.heap_oos.class_oid;
+	  break;
 	case FILE_BTREE:
 	  class_oid_p = &fhead->descriptor.btree.class_oid;
 	  break;
@@ -11558,6 +11523,9 @@ file_tracker_item_collect_invalid_file (THREAD_ENTRY * thread_p, PAGE_PTR page_o
       break;
     case FILE_MULTIPAGE_OBJECT_HEAP:
       class_oid_p = &fhead->descriptor.heap_overflow.class_oid;
+      break;
+    case FILE_OOS:
+      class_oid_p = &fhead->descriptor.heap_oos.class_oid;
       break;
     case FILE_BTREE:
       class_oid_p = &fhead->descriptor.btree.class_oid;

--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -1413,6 +1413,22 @@ file_header_dump (THREAD_ENTRY * thread_p, const FILE_HEADER * fhead, FILE * fp)
 }
 
 /*
+ * file_oos_descriptor_is_legacy () - return true for ownerless OOS descriptors created before CBRD-27038
+ *
+ * return         : true if all owner fields have their historical byte-zeroed representation
+ * descriptor (in): OOS file descriptor
+ */
+STATIC_INLINE bool
+file_oos_descriptor_is_legacy (const FILE_DESCRIPTORS * descriptor)
+{
+  return (descriptor->heap_overflow.hfid.vfid.fileid == 0
+	  && descriptor->heap_overflow.hfid.vfid.volid == 0
+	  && descriptor->heap_overflow.hfid.hpgid == 0
+	  && descriptor->heap_overflow.class_oid.pageid == 0
+	  && descriptor->heap_overflow.class_oid.slotid == 0 && descriptor->heap_overflow.class_oid.volid == 0);
+}
+
+/*
  * file_header_dump_descriptor () - dump descriptor in file header
  *
  * return        : void
@@ -1429,9 +1445,15 @@ file_header_dump_descriptor (THREAD_ENTRY * thread_p, const FILE_HEADER * fhead,
   switch (fhead->type)
     {
     case FILE_OOS:
-      /* TODO: When the OOS file descriptor stores its owner HFID/class back reference, print the table name and HFID
-       * here. Current FILE_OOS headers do not expose that information from the OOS file itself. */
-      fprintf (fp, "OOS file\n");
+      if (file_oos_descriptor_is_legacy (&fhead->descriptor))
+	{
+	  fprintf (fp, "OOS file (owner descriptor unavailable)\n");
+	}
+      else
+	{
+	  file_print_name_of_class (thread_p, fp, &fhead->descriptor.heap_overflow.class_oid);
+	  fprintf (fp, ", OOS for HFID: %10d|%5d|%10d\n", HFID_AS_ARGS (&fhead->descriptor.heap_overflow.hfid));
+	}
       break;
 
     case FILE_HEAP:
@@ -10867,14 +10889,14 @@ exit:
 #endif /* SA_MODE */
 
 /*
- * file_tracker_get_and_protect () - get a file from tracker. if we want to get b-tree or heap files, we must first
- *                                   protect them by locking class.
+ * file_tracker_get_and_protect () - get a file from tracker. table-owned mutable files must first be protected by
+ *                                   locking their class.
  *
  * return            : error code
  * thread_p (in)     : thread entry
  * desired_type (in) : desired file type. FILE_UNKNOWN_TYPE for any type.
  * item (in)         : tracker item
- * class_oid (out)   : output locked class OID (for b-tree and heap). NULL OID if no class is locked.
+ * class_oid (out)   : output locked class OID. NULL OID if no class is locked.
  * stop (out)        : output true when item is accepted
  */
 STATIC_INLINE int
@@ -10885,15 +10907,16 @@ file_tracker_get_and_protect (THREAD_ENTRY * thread_p, FILE_TYPE desired_type, F
   PAGE_PTR page_fhead = NULL;
   FILE_HEADER *fhead = NULL;
   int error_code = NO_ERROR;
+  bool skip_legacy_oos = false;
 
   assert (class_oid != NULL && OID_ISNULL (class_oid));
 
   /* how it works:
    * this is part of the tracker iterate without holding latch on tracker during the entire iteration. however, it can
    * only work if the files processed outside latch are protected from being destroyed. otherwise, resuming is
-   * impossible. most file types are not mutable, so they don't need protection. however, for b-tree and heap files we
-   * need to read class OID from descriptor and try to lock it (conditionally!). this is a best-effort approach, if the
-   * locking fails, we just skip the file. */
+   * impossible. most file types are not mutable, so they don't need protection. however, table-owned mutable files
+   * need their class OID from the descriptor and a conditional lock. this is a best-effort approach; if locking fails,
+   * we just skip the file. */
 
   /* check file type is right */
   switch (desired_type)
@@ -10901,11 +10924,6 @@ file_tracker_get_and_protect (THREAD_ENTRY * thread_p, FILE_TYPE desired_type, F
     case FILE_UNKNOWN_TYPE:
       /* accept any type */
       break;
-    case FILE_OOS:
-      {
-	assert (false);
-	break;
-      }
     case FILE_HEAP:
     case FILE_HEAP_REUSE_SLOTS:
       /* accept heap or heap reuse slots */
@@ -10926,14 +10944,9 @@ file_tracker_get_and_protect (THREAD_ENTRY * thread_p, FILE_TYPE desired_type, F
     }
 
   /* now we need to make sure the file is protected. most types are not mutable (cannot be created or destroyed during
-   * run-time), but b-tree and heap files must be protected by lock. */
+   * run-time), but table-owned mutable files must be protected by lock. */
   switch ((FILE_TYPE) item->type)
     {
-    case FILE_OOS:
-      /* FILE_OOS is mutable but does not store owner class information yet. Do not return an unprotected VFID
-       * from interruptible tracker iteration. OOS file table checks can be added after owner metadata exists. */
-      return NO_ERROR;
-
     case FILE_HEAP:
       /* these files may be marked for delete. check this is not a deleted file */
       if (item->metadata.heap.is_marked_deleted)
@@ -10947,6 +10960,7 @@ file_tracker_get_and_protect (THREAD_ENTRY * thread_p, FILE_TYPE desired_type, F
     case FILE_BTREE:
     case FILE_MULTIPAGE_OBJECT_HEAP:
     case FILE_BTREE_OVERFLOW_KEY:
+    case FILE_OOS:
       /* we need to protect with lock. fall through */
       break;
     default:
@@ -10974,10 +10988,9 @@ file_tracker_get_and_protect (THREAD_ENTRY * thread_p, FILE_TYPE desired_type, F
       *class_oid = fhead->descriptor.btree.class_oid;
       break;
     case FILE_OOS:
-      {
-	assert (false);
-	break;
-      }
+      skip_legacy_oos = file_oos_descriptor_is_legacy (&fhead->descriptor);
+      *class_oid = fhead->descriptor.heap_overflow.class_oid;
+      break;
     case FILE_HEAP:
     case FILE_HEAP_REUSE_SLOTS:
       *class_oid = fhead->descriptor.heap.class_oid;
@@ -10994,8 +11007,21 @@ file_tracker_get_and_protect (THREAD_ENTRY * thread_p, FILE_TYPE desired_type, F
     }
   pgbuf_unfix (thread_p, page_fhead);
 
+  if (skip_legacy_oos)
+    {
+      /* OOS file descriptors created before CBRD-27038 were byte-zeroed and cannot protect online scans. */
+      OID_SET_NULL (class_oid);
+      return NO_ERROR;
+    }
+
   if (OID_ISNULL (class_oid))
     {
+      if ((FILE_TYPE) item->type == FILE_OOS)
+	{
+	  /* OOS files created before owner descriptors were introduced cannot be protected against DROP TABLE.
+	   * Preserve the legacy behavior by skipping them during interruptible online scans. */
+	  return NO_ERROR;
+	}
       /* this must be boot_Db_parm file; cannot be deleted so we don't need lock. */
       *stop = true;
       return NO_ERROR;
@@ -11026,7 +11052,7 @@ file_tracker_get_and_protect (THREAD_ENTRY * thread_p, FILE_TYPE desired_type, F
  * thread_p (in)      : thread entry
  * desired_ftype (in) : desired type
  * vfid (in)          : file identifier and iterator cursor. iterate must start with a NULL identifier
- * class_oid (in)     : locked class OID (used to protect b-tree and heap files)
+ * class_oid (in)     : locked class OID (used to protect table-owned mutable files)
  */
 int
 file_tracker_interruptable_iterate (THREAD_ENTRY * thread_p, FILE_TYPE desired_ftype, VFID * vfid, OID * class_oid)
@@ -11049,8 +11075,8 @@ file_tracker_interruptable_iterate (THREAD_ENTRY * thread_p, FILE_TYPE desired_f
   assert (class_oid != NULL);
 
   /* how it works:
-   * start from given VFID and get a new file of desired type. for b-tree and heap files, we also need to lock their
-   * class OID in order to protect them from being removed. otherwise we could not resume in next iteration. */
+   * start from given VFID and get a new file of desired type. table-owned mutable files also require a class lock
+   * to protect them from being removed; otherwise iteration could not safely resume. */
 
   page_track_head = pgbuf_fix (thread_p, &file_Tracker_vpid, OLD_PAGE, PGBUF_LATCH_READ, PGBUF_UNCONDITIONAL_LATCH);
   if (page_track_head == NULL)
@@ -12234,9 +12260,8 @@ file_tracker_item_spacedb (THREAD_ENTRY * thread_p, PAGE_PTR page_of_item, FILE_
       spacedb_ftype = SPACEDB_INDEX_FILE;
       break;
     case FILE_OOS:
-      /* OOS is table-owned storage, but FILE_OOS currently has no separate SPACEDB category or owner descriptor. Fold
-       * it into heap totals to keep the spacedb wire/output format stable; a dedicated OOS line requires a separate
-       * output/protocol change. */
+      /* OOS is table-owned storage, but FILE_OOS has no separate SPACEDB category. Fold it into heap totals to keep
+       * the spacedb wire/output format stable; a dedicated OOS line requires a separate output/protocol change. */
       spacedb_ftype = SPACEDB_HEAP_FILE;
       break;
     case FILE_HEAP:

--- a/src/storage/file_manager.c
+++ b/src/storage/file_manager.c
@@ -10866,8 +10866,10 @@ exit:
 #endif /* SA_MODE */
 
 /*
- * file_tracker_get_and_protect () - get a file from tracker. table-owned mutable files must first be protected by
- *                                   locking their class.
+ * file_tracker_get_and_protect () - get a file from tracker. mutable files owned by a class (FILE_HEAP,
+ *                                   FILE_HEAP_REUSE_SLOTS, FILE_MULTIPAGE_OBJECT_HEAP, FILE_BTREE,
+ *                                   FILE_BTREE_OVERFLOW_KEY and FILE_OOS) can be destroyed together with their class
+ *                                   at run-time, so they must first be protected by locking their class.
  *
  * return            : error code
  * thread_p (in)     : thread entry
@@ -10890,9 +10892,10 @@ file_tracker_get_and_protect (THREAD_ENTRY * thread_p, FILE_TYPE desired_type, F
   /* how it works:
    * this is part of the tracker iterate without holding latch on tracker during the entire iteration. however, it can
    * only work if the files processed outside latch are protected from being destroyed. otherwise, resuming is
-   * impossible. most file types are not mutable, so they don't need protection. however, table-owned mutable files
-   * need their class OID from the descriptor and a conditional lock. this is a best-effort approach; if locking fails,
-   * we just skip the file. */
+   * impossible. most file types are not mutable, so they don't need protection. however, class-owned files (heap,
+   * heap overflow, b-tree, b-tree overflow key and OOS files) can be destroyed together with their class, so for them
+   * we read the class OID from the file descriptor and try to lock it (conditionally!). this is a best-effort
+   * approach; if locking fails, we just skip the file. */
 
   /* check file type is right */
   switch (desired_type)
@@ -10909,6 +10912,10 @@ file_tracker_get_and_protect (THREAD_ENTRY * thread_p, FILE_TYPE desired_type, F
 	  return NO_ERROR;
 	}
       break;
+    case FILE_OOS:
+      /* iterating OOS files is supported now that FILE_OOS descriptors store their owner class. accept only an exact
+       * type match, same as the default case below. */
+      /* FALLTHRU */
     default:
       /* accept the exact file type */
       if ((FILE_TYPE) item->type != desired_type)
@@ -10920,7 +10927,8 @@ file_tracker_get_and_protect (THREAD_ENTRY * thread_p, FILE_TYPE desired_type, F
     }
 
   /* now we need to make sure the file is protected. most types are not mutable (cannot be created or destroyed during
-   * run-time), but table-owned mutable files must be protected by lock. */
+   * run-time), but the class-owned file types listed below can be destroyed with their class, so they must be
+   * protected by lock. */
   switch ((FILE_TYPE) item->type)
     {
     case FILE_HEAP:
@@ -11014,7 +11022,7 @@ file_tracker_get_and_protect (THREAD_ENTRY * thread_p, FILE_TYPE desired_type, F
  * thread_p (in)      : thread entry
  * desired_ftype (in) : desired type
  * vfid (in)          : file identifier and iterator cursor. iterate must start with a NULL identifier
- * class_oid (in)     : locked class OID (used to protect table-owned mutable files)
+ * class_oid (in)     : locked class OID (used to protect class-owned files: heap, b-tree and OOS files)
  */
 int
 file_tracker_interruptable_iterate (THREAD_ENTRY * thread_p, FILE_TYPE desired_ftype, VFID * vfid, OID * class_oid)
@@ -11037,8 +11045,8 @@ file_tracker_interruptable_iterate (THREAD_ENTRY * thread_p, FILE_TYPE desired_f
   assert (class_oid != NULL);
 
   /* how it works:
-   * start from given VFID and get a new file of desired type. table-owned mutable files also require a class lock
-   * to protect them from being removed; otherwise iteration could not safely resume. */
+   * start from given VFID and get a new file of desired type. class-owned files (heap, b-tree and OOS files) also
+   * require a class lock to protect them from being removed; otherwise iteration could not safely resume. */
 
   page_track_head = pgbuf_fix (thread_p, &file_Tracker_vpid, OLD_PAGE, PGBUF_LATCH_READ, PGBUF_UNCONDITIONAL_LATCH);
   if (page_track_head == NULL)
@@ -11622,6 +11630,11 @@ file_delete_invalid_file (THREAD_ENTRY * thread_p,
 	++(*heap);
 	break;
       case FILE_MULTIPAGE_OBJECT_HEAP:
+	++(*heap_ovf);
+	break;
+      case FILE_OOS:
+	/* OOS is per-heap overflow storage; count it as a heap overflow file to keep the four-counter output of
+	 * cleanfiledb stable. */
 	++(*heap_ovf);
 	break;
       case FILE_BTREE:

--- a/src/storage/file_manager.h
+++ b/src/storage/file_manager.h
@@ -94,6 +94,14 @@ struct file_ovf_heap_des
   OID class_oid;
 };
 
+/* OOS file descriptor */
+typedef struct file_oos_des FILE_OOS_DES;
+struct file_oos_des
+{
+  HFID hfid;
+  OID class_oid;
+};
+
 /* Btree file descriptor */
 typedef struct file_btree_des FILE_BTREE_DES;
 struct file_btree_des
@@ -132,6 +140,7 @@ union file_descriptors
 {
   FILE_HEAP_DES heap;
   FILE_OVF_HEAP_DES heap_overflow;
+  FILE_OOS_DES heap_oos;
   FILE_BTREE_DES btree;
   FILE_OVF_BTREE_DES btree_key_overflow;	/* TODO: rename FILE_OVF_BTREE_DES */
   FILE_EHASH_DES ehash;

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -12222,7 +12222,7 @@ heap_oos_find_vfid (THREAD_ENTRY * thread_p, const HFID * hfid, VFID * oos_vfid,
 
 	  /* START A TOP SYSTEM OPERATION */
 	  log_sysop_start (thread_p);
-	  if (oos_create_file (thread_p, *oos_vfid) != NO_ERROR)
+	  if (oos_create_file (thread_p, *hfid, heap_hdr->class_oid, *oos_vfid) != NO_ERROR)
 	    {
 	      log_sysop_abort (thread_p);
 	      goto exit_on_error;

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -12430,9 +12430,11 @@ for (RECDES & payload:*payloads)
   payloads->clear ();
 }
 
+// *INDENT-OFF*
 #if defined(CUBRID_UNIT_TEST_ENABLED)
 static std::atomic<bool> heap_Test_fail_after_oos_publication_reset { false };
 #endif
+// *INDENT-ON*
 
 /*
  * heap_attrinfo_insert_to_oos () - Serialize selected attribute values and delegate OOS insertion.
@@ -27873,7 +27875,7 @@ SCAN_CODE
 bridge_heap_attrinfo_insert_to_oos (THREAD_ENTRY * thread_p, const OID * class_oid)
 {
   HEAP_CACHE_ATTRINFO attr_info = { };
-  std::vector<heap_oos_column_plan> oos_plan;
+  std::vector < heap_oos_column_plan > oos_plan;
 
   COPY_OID (&attr_info.class_oid, class_oid);
   attr_info.num_values = 0;

--- a/src/storage/oos_file.cpp
+++ b/src/storage/oos_file.cpp
@@ -965,14 +965,12 @@ oos_stats_update (THREAD_ENTRY *thread_p, PAGE_PTR pgptr, const VFID *vfid, int 
 // OOS File operations
 // ****************************************************************************
 
-int
-oos_create_file (THREAD_ENTRY *thread_p, VFID &oos_vfid)
+static int
+oos_create_file_internal (THREAD_ENTRY *thread_p, FILE_DESCRIPTORS des, VFID &oos_vfid)
 {
   int err = NO_ERROR;
-  FILE_DESCRIPTORS des;
   FILE_TABLESPACE tablespace;
 
-  memset (&des, 0, sizeof (FILE_DESCRIPTORS));
   memset (&tablespace, 0, sizeof (FILE_TABLESPACE));
 
   tablespace.initial_size = DB_PAGESIZE;
@@ -1066,6 +1064,29 @@ oos_create_file (THREAD_ENTRY *thread_p, VFID &oos_vfid)
 
   return NO_ERROR;
 }
+
+int
+oos_create_file (THREAD_ENTRY *thread_p, const HFID &heap_hfid, const OID &class_oid, VFID &oos_vfid)
+{
+  FILE_DESCRIPTORS des;
+
+  memset (&des, 0, sizeof (FILE_DESCRIPTORS));
+  HFID_COPY (&des.heap_overflow.hfid, &heap_hfid);
+  COPY_OID (&des.heap_overflow.class_oid, &class_oid);
+
+  return oos_create_file_internal (thread_p, des, oos_vfid);
+}
+
+#if defined (CUBRID_UNIT_TEST_ENABLED)
+int
+oos_create_file (THREAD_ENTRY *thread_p, VFID &oos_vfid)
+{
+  FILE_DESCRIPTORS des;
+
+  memset (&des, 0, sizeof (FILE_DESCRIPTORS));
+  return oos_create_file_internal (thread_p, des, oos_vfid);
+}
+#endif /* CUBRID_UNIT_TEST_ENABLED */
 
 int
 oos_remove_file (THREAD_ENTRY *thread_p, const VFID &oos_vfid)

--- a/src/storage/oos_file.cpp
+++ b/src/storage/oos_file.cpp
@@ -1071,8 +1071,8 @@ oos_create_file (THREAD_ENTRY *thread_p, const HFID &heap_hfid, const OID &class
   FILE_DESCRIPTORS des;
 
   memset (&des, 0, sizeof (FILE_DESCRIPTORS));
-  HFID_COPY (&des.heap_overflow.hfid, &heap_hfid);
-  COPY_OID (&des.heap_overflow.class_oid, &class_oid);
+  HFID_COPY (&des.heap_oos.hfid, &heap_hfid);
+  COPY_OID (&des.heap_oos.class_oid, &class_oid);
 
   return oos_create_file_internal (thread_p, des, oos_vfid);
 }
@@ -1081,10 +1081,10 @@ oos_create_file (THREAD_ENTRY *thread_p, const HFID &heap_hfid, const OID &class
 int
 oos_create_file (THREAD_ENTRY *thread_p, VFID &oos_vfid)
 {
-  FILE_DESCRIPTORS des;
+  const HFID test_owner_hfid = { { 1, 1 }, 1 };
+  const OID test_owner_class_oid = { 1, 1, 1 };
 
-  memset (&des, 0, sizeof (FILE_DESCRIPTORS));
-  return oos_create_file_internal (thread_p, des, oos_vfid);
+  return oos_create_file (thread_p, test_owner_hfid, test_owner_class_oid, oos_vfid);
 }
 #endif /* CUBRID_UNIT_TEST_ENABLED */
 
@@ -1302,27 +1302,27 @@ oos_insert_many (THREAD_ENTRY *thread_p, const VFID &oos_vfid, cubbase::span<oos
       const int page_capacity = DB_ALIGN_BELOW (spage_max_record_size (), OOS_ALIGNMENT);
       const auto required_space = [] (const oos_insert_request &request)
       {
-        return DB_ALIGN (static_cast<int> (request.src.size ()) + OOS_RECORD_HEADER_SIZE, OOS_ALIGNMENT);
+	return DB_ALIGN (static_cast<int> (request.src.size ()) + OOS_RECORD_HEADER_SIZE, OOS_ALIGNMENT);
       };
 
       std::size_t pos = 0;
       std::size_t publication_count = 0;
       while (pos < requests.size ())
-        {
-          int err;
+	{
+	  int err;
 
 #if defined(CUBRID_UNIT_TEST_ENABLED)
-          int fail_after = oos_Test_fail_insert_many_after_publications.load (std::memory_order_relaxed);
-          if (fail_after >= 0 && publication_count >= (std::size_t) fail_after
+	  int fail_after = oos_Test_fail_insert_many_after_publications.load (std::memory_order_relaxed);
+	  if (fail_after >= 0 && publication_count >= (std::size_t) fail_after
 	      && oos_Test_fail_insert_many_after_publications.compare_exchange_strong (
-		fail_after, -1, std::memory_order_relaxed))
+		      fail_after, -1, std::memory_order_relaxed))
 	    {
 	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
 	      return ER_GENERIC_ERROR;
 	    }
 #endif
 
-          if (requests[pos].src.size () > (std::size_t) max_chunk_size)
+	  if (requests[pos].src.size () > (std::size_t) max_chunk_size)
 	    {
 	      OID oid;
 	      err = oos_insert_across_pages (thread_p, oos_vfid, requests[pos].src, oid);
@@ -1334,7 +1334,7 @@ oos_insert_many (THREAD_ENTRY *thread_p, const VFID &oos_vfid, cubbase::span<oos
 		  publication_count++;
 		}
 	    }
-          else
+	  else
 	    {
 	      /* Greedy batch: extend while the next single-chunk request still fits the same page. */
 	      int needed_space = required_space (requests[pos]);
@@ -1359,11 +1359,11 @@ oos_insert_many (THREAD_ENTRY *thread_p, const VFID &oos_vfid, cubbase::span<oos
 		}
 	    }
 
-          if (err != NO_ERROR)
+	  if (err != NO_ERROR)
 	    {
 	      return err;
 	    }
-        }
+	}
     }
   catch (const std::bad_alloc &)
     {

--- a/src/storage/oos_file.hpp
+++ b/src/storage/oos_file.hpp
@@ -93,7 +93,11 @@ struct oos_hdr_stats
   int reserve1_for_future;
 };
 
+extern int oos_create_file (THREAD_ENTRY *thread_p, const HFID &heap_hfid, const OID &class_oid, VFID &oos_vfid);
+#if defined (CUBRID_UNIT_TEST_ENABLED)
+/* Low-level OOS tests use ownerless files to exercise storage in isolation and to model legacy descriptors. */
 extern int oos_create_file (THREAD_ENTRY *thread_p, VFID &oos_vfid);
+#endif /* CUBRID_UNIT_TEST_ENABLED */
 extern int oos_remove_file (THREAD_ENTRY *thread_p, const VFID &oos_vfid);
 extern int oos_remove_page (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const VPID &vpid);
 /* Inserts src.size() bytes; on multi-page payloads, oid is the head-chunk OID. */

--- a/src/storage/oos_file.hpp
+++ b/src/storage/oos_file.hpp
@@ -95,7 +95,7 @@ struct oos_hdr_stats
 
 extern int oos_create_file (THREAD_ENTRY *thread_p, const HFID &heap_hfid, const OID &class_oid, VFID &oos_vfid);
 #if defined (CUBRID_UNIT_TEST_ENABLED)
-/* Low-level OOS tests use ownerless files to exercise storage in isolation and to model legacy descriptors. */
+/* Low-level OOS tests use a synthetic, non-null owner descriptor while exercising storage in isolation. */
 extern int oos_create_file (THREAD_ENTRY *thread_p, VFID &oos_vfid);
 #endif /* CUBRID_UNIT_TEST_ENABLED */
 extern int oos_remove_file (THREAD_ENTRY *thread_p, const VFID &oos_vfid);

--- a/unit_tests/oos/test_oos_server.cpp
+++ b/unit_tests/oos/test_oos_server.cpp
@@ -28,6 +28,7 @@
 #include "heap_oos.hpp"
 #include "locator_sr.h"
 #include "log_comm.h"
+#include "lock_manager.h"
 #include "scope_exit.hpp"
 #include "server_support.h"
 #include "xserver_interface.h"
@@ -238,6 +239,123 @@ class replication_tracking_guard
     HA_SERVER_STATE m_old_ha_state;
     int m_error;
 };
+
+// ============================================================================
+// TC: OOS owner descriptor and online file-tracker protection (CBRD-27038)
+// ============================================================================
+TEST (OosServerTest, OosOwnerDescriptorSupportsDiagnosticsAndProtectedIteration)
+{
+  const OID class_oid = find_db_user_class_oid ();
+  ASSERT_FALSE (OID_ISNULL (&class_oid));
+
+  HFID hfid;
+  HFID_SET_NULL (&hfid);
+  ASSERT_EQ (xheap_create (thread_p, &hfid, &class_oid, false), NO_ERROR);
+  scope_exit destroy_heap ([&] () noexcept
+  {
+    if (!HFID_IS_NULL (&hfid))
+      {
+	(void) xheap_destroy (thread_p, &hfid, &class_oid);
+	(void) xtran_server_commit (thread_p, false);
+      }
+  });
+
+  VFID oos_vfid;
+  VFID_SET_NULL (&oos_vfid);
+  ASSERT_TRUE (heap_oos_find_vfid (thread_p, &hfid, &oos_vfid, true));
+  ASSERT_FALSE (VFID_ISNULL (&oos_vfid));
+
+  VFID legacy_oos_vfid;
+  ASSERT_EQ (oos_create_file (thread_p, legacy_oos_vfid), NO_ERROR);
+  scope_exit destroy_legacy_oos ([&] () noexcept
+  {
+    (void) oos_remove_file (thread_p, legacy_oos_vfid);
+  });
+
+  FILE_DESCRIPTORS descriptor;
+  ASSERT_EQ (file_descriptor_get (thread_p, &oos_vfid, &descriptor), NO_ERROR);
+  EXPECT_TRUE (HFID_EQ (&descriptor.heap_overflow.hfid, &hfid));
+  EXPECT_TRUE (OID_EQ (&descriptor.heap_overflow.class_oid, &class_oid));
+
+  FILE *dump_fp = tmpfile ();
+  ASSERT_NE (dump_fp, nullptr);
+  scope_exit close_dump ([&] () noexcept
+  {
+    fclose (dump_fp);
+  });
+  ASSERT_EQ (xfile_tracker_dump_file_list (thread_p, dump_fp, false), NO_ERROR);
+  rewind (dump_fp);
+
+  std::string dump_output;
+  char line[1024];
+  while (fgets (line, sizeof (line), dump_fp) != nullptr)
+    {
+      dump_output += line;
+    }
+
+  char expected_owner[256];
+  snprintf (expected_owner, sizeof (expected_owner),
+	    "CLASS_OID: %5d|%10d|%5d (_db_user), OOS for HFID: %10d|%5d|%10d", OID_AS_ARGS (&class_oid),
+	    HFID_AS_ARGS (&hfid));
+  EXPECT_NE (dump_output.find (expected_owner), std::string::npos);
+  EXPECT_NE (dump_output.find ("OOS file (owner descriptor unavailable)"), std::string::npos);
+
+  VFID iter_vfid;
+  VFID_SET_NULL (&iter_vfid);
+  OID locked_class_oid;
+  OID_SET_NULL (&locked_class_oid);
+  bool found_oos_vfid = false;
+  bool schema_modification_was_blocked = false;
+  const int checkdb_tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
+  int ddl_tran_index = NULL_TRAN_INDEX;
+  scope_exit release_ddl_transaction ([&] () noexcept
+  {
+    if (ddl_tran_index != NULL_TRAN_INDEX)
+      {
+	LOG_SET_CURRENT_TRAN_INDEX (thread_p, ddl_tran_index);
+	(void) log_abort (thread_p, ddl_tran_index);
+	logtb_release_tran_index (thread_p, ddl_tran_index);
+	LOG_SET_CURRENT_TRAN_INDEX (thread_p, checkdb_tran_index);
+      }
+  });
+
+  while (true)
+    {
+      ASSERT_EQ (file_tracker_interruptable_iterate (thread_p, FILE_OOS, &iter_vfid, &locked_class_oid), NO_ERROR);
+      if (VFID_ISNULL (&iter_vfid))
+	{
+	  break;
+	}
+      EXPECT_FALSE (OID_ISNULL (&locked_class_oid));
+      if (VFID_EQ (&iter_vfid, &oos_vfid))
+	{
+	  EXPECT_TRUE (OID_EQ (&locked_class_oid, &class_oid));
+	  found_oos_vfid = true;
+
+	  TRAN_STATE ddl_tran_state;
+	  ddl_tran_index = logtb_assign_tran_index (thread_p, NULL_TRANID, TRAN_ACTIVE, NULL, &ddl_tran_state,
+						   TRAN_LOCK_INFINITE_WAIT, TRAN_READ_COMMITTED);
+	  ASSERT_NE (ddl_tran_index, NULL_TRAN_INDEX);
+	  ASSERT_NE (lock_object (thread_p, &class_oid, oid_Root_class_oid, SCH_M_LOCK, LK_COND_LOCK), LK_GRANTED);
+	  schema_modification_was_blocked = true;
+	  er_clear ();
+	  LOG_SET_CURRENT_TRAN_INDEX (thread_p, checkdb_tran_index);
+	}
+    }
+  EXPECT_TRUE (found_oos_vfid);
+  EXPECT_TRUE (schema_modification_was_blocked);
+  /* The ownerless file models a byte-zeroed legacy descriptor and is never returned without protection. */
+  EXPECT_TRUE (VFID_ISNULL (&iter_vfid));
+  EXPECT_TRUE (OID_ISNULL (&locked_class_oid));
+
+  ASSERT_NE (ddl_tran_index, NULL_TRAN_INDEX);
+  LOG_SET_CURRENT_TRAN_INDEX (thread_p, ddl_tran_index);
+  ASSERT_EQ (lock_object (thread_p, &class_oid, oid_Root_class_oid, SCH_M_LOCK, LK_COND_LOCK), LK_GRANTED);
+  lock_unlock_object (thread_p, &class_oid, oid_Root_class_oid, SCH_M_LOCK, true);
+  LOG_SET_CURRENT_TRAN_INDEX (thread_p, checkdb_tran_index);
+
+  EXPECT_EQ (file_tracker_check (thread_p), DISK_VALID);
+}
 
 // ============================================================================
 // TC: OOS insert publication-state lifetime (CBRD-27006)

--- a/unit_tests/oos/test_oos_server.cpp
+++ b/unit_tests/oos/test_oos_server.cpp
@@ -48,7 +48,7 @@ int bridge_locator_fixup_oos_oids_in_recdes (THREAD_ENTRY *thread_p, const OID *
 static std::string make_filled_payload (int size, char ch);
 static void clear_oos_insert_publication_state_for_test ();
 static void build_insert_requests (std::vector<std::string> &payloads, std::vector<OID> &oids,
-			   std::vector<oos_insert_request> &requests);
+				   std::vector<oos_insert_request> &requests);
 
 static LOG_TDES *
 get_current_tdes ()
@@ -265,17 +265,10 @@ TEST (OosServerTest, OosOwnerDescriptorSupportsDiagnosticsAndProtectedIteration)
   ASSERT_TRUE (heap_oos_find_vfid (thread_p, &hfid, &oos_vfid, true));
   ASSERT_FALSE (VFID_ISNULL (&oos_vfid));
 
-  VFID legacy_oos_vfid;
-  ASSERT_EQ (oos_create_file (thread_p, legacy_oos_vfid), NO_ERROR);
-  scope_exit destroy_legacy_oos ([&] () noexcept
-  {
-    (void) oos_remove_file (thread_p, legacy_oos_vfid);
-  });
-
   FILE_DESCRIPTORS descriptor;
   ASSERT_EQ (file_descriptor_get (thread_p, &oos_vfid, &descriptor), NO_ERROR);
-  EXPECT_TRUE (HFID_EQ (&descriptor.heap_overflow.hfid, &hfid));
-  EXPECT_TRUE (OID_EQ (&descriptor.heap_overflow.class_oid, &class_oid));
+  EXPECT_TRUE (HFID_EQ (&descriptor.heap_oos.hfid, &hfid));
+  EXPECT_TRUE (OID_EQ (&descriptor.heap_oos.class_oid, &class_oid));
 
   FILE *dump_fp = tmpfile ();
   ASSERT_NE (dump_fp, nullptr);
@@ -295,10 +288,9 @@ TEST (OosServerTest, OosOwnerDescriptorSupportsDiagnosticsAndProtectedIteration)
 
   char expected_owner[256];
   snprintf (expected_owner, sizeof (expected_owner),
-	    "CLASS_OID: %5d|%10d|%5d (_db_user), OOS for HFID: %10d|%5d|%10d", OID_AS_ARGS (&class_oid),
-	    HFID_AS_ARGS (&hfid));
+	    "CLASS_OID: %5d|%10d|%5d (_db_user), OOS for HFID: %10d|%5d|%10d", class_oid.volid,
+	    class_oid.pageid, class_oid.slotid, hfid.hpgid, hfid.vfid.volid, hfid.vfid.fileid);
   EXPECT_NE (dump_output.find (expected_owner), std::string::npos);
-  EXPECT_NE (dump_output.find ("OOS file (owner descriptor unavailable)"), std::string::npos);
 
   VFID iter_vfid;
   VFID_SET_NULL (&iter_vfid);
@@ -334,7 +326,7 @@ TEST (OosServerTest, OosOwnerDescriptorSupportsDiagnosticsAndProtectedIteration)
 
 	  TRAN_STATE ddl_tran_state;
 	  ddl_tran_index = logtb_assign_tran_index (thread_p, NULL_TRANID, TRAN_ACTIVE, NULL, &ddl_tran_state,
-						   TRAN_LOCK_INFINITE_WAIT, TRAN_READ_COMMITTED);
+			   TRAN_LOCK_INFINITE_WAIT, TRAN_READ_COMMITTED);
 	  ASSERT_NE (ddl_tran_index, NULL_TRAN_INDEX);
 	  ASSERT_NE (lock_object (thread_p, &class_oid, oid_Root_class_oid, SCH_M_LOCK, LK_COND_LOCK), LK_GRANTED);
 	  schema_modification_was_blocked = true;
@@ -344,7 +336,6 @@ TEST (OosServerTest, OosOwnerDescriptorSupportsDiagnosticsAndProtectedIteration)
     }
   EXPECT_TRUE (found_oos_vfid);
   EXPECT_TRUE (schema_modification_was_blocked);
-  /* The ownerless file models a byte-zeroed legacy descriptor and is never returned without protection. */
   EXPECT_TRUE (VFID_ISNULL (&iter_vfid));
   EXPECT_TRUE (OID_ISNULL (&locked_class_oid));
 
@@ -477,7 +468,7 @@ TEST (OosServerTest, OosInsertManyPartialPublicationFailureClearsBothSides)
   });
 
   EXPECT_EQ (oos_insert_many (thread_p, oos_vfid,
-	      cubbase::span<oos_insert_request> (requests.data (), requests.size ())), ER_GENERIC_ERROR);
+			      cubbase::span<oos_insert_request> (requests.data (), requests.size ())), ER_GENERIC_ERROR);
   assert_oos_insert_publication_state_empty ();
   er_clear ();
 }
@@ -507,7 +498,7 @@ TEST (OosServerTest, OosInsertManyPublicationAllocationFailureIsConvertedAndClea
   });
 
   EXPECT_EQ (oos_insert_many (thread_p, oos_vfid,
-	      cubbase::span<oos_insert_request> (requests.data (), requests.size ())),
+			      cubbase::span<oos_insert_request> (requests.data (), requests.size ())),
 	     ER_OUT_OF_VIRTUAL_MEMORY);
   EXPECT_EQ (er_errid (), ER_OUT_OF_VIRTUAL_MEMORY);
   assert_oos_insert_publication_state_empty ();
@@ -524,7 +515,7 @@ TEST (OosServerTest, OosInsertManyValidationFailureDoesNotClaimPublicationStart)
   VFID invalid_vfid = VFID_INITIALIZER;
   oos_insert_request invalid_request = { oos_buffer (nullptr, 0), &output_oid };
   EXPECT_EQ (oos_insert_many (thread_p, invalid_vfid,
-	      cubbase::span<oos_insert_request> (&invalid_request, 1)), ER_GENERIC_ERROR);
+			      cubbase::span<oos_insert_request> (&invalid_request, 1)), ER_GENERIC_ERROR);
   assert_oos_insert_publication_state (stale_oid, stale_lsa);
   er_clear ();
 }
@@ -546,7 +537,7 @@ TEST (OosServerTest, OosSuccessfulPublicationWithoutReplicationTrackingKeepsOidO
   clear_oos_insert_publication_state_for_test ();
 
   ASSERT_EQ (oos_insert_many (thread_p, oos_vfid,
-	      cubbase::span<oos_insert_request> (requests.data (), requests.size ())), NO_ERROR);
+			      cubbase::span<oos_insert_request> (requests.data (), requests.size ())), NO_ERROR);
   LOG_TDES *tdes = get_current_tdes ();
   ASSERT_NE (tdes, nullptr);
   ASSERT_EQ (thread_p->oos_oids.size (), 2U);
@@ -574,7 +565,7 @@ TEST (OosServerTest, OosTrackedSingleChunkBatchKeepsPairedPublication)
   clear_oos_insert_publication_state_for_test ();
 
   ASSERT_EQ (oos_insert_many (thread_p, oos_vfid,
-	      cubbase::span<oos_insert_request> (requests.data (), requests.size ())), NO_ERROR);
+			      cubbase::span<oos_insert_request> (requests.data (), requests.size ())), NO_ERROR);
   LOG_TDES *tdes = get_current_tdes ();
   ASSERT_NE (tdes, nullptr);
   ASSERT_EQ (thread_p->oos_oids.size (), 2U);
@@ -605,7 +596,7 @@ TEST (OosServerTest, OosTrackedMixedBatchPreservesDummyAndHeadPairing)
   clear_oos_insert_publication_state_for_test ();
 
   ASSERT_EQ (oos_insert_many (thread_p, oos_vfid,
-	      cubbase::span<oos_insert_request> (requests.data (), requests.size ())), NO_ERROR);
+			      cubbase::span<oos_insert_request> (requests.data (), requests.size ())), NO_ERROR);
   LOG_TDES *tdes = get_current_tdes ();
   ASSERT_NE (tdes, nullptr);
   ASSERT_EQ (thread_p->oos_oids.size (), 4U);


### PR DESCRIPTION
https://jira.cubrid.org/browse/CBRD-27038

## Purpose

- OOS는 큰 컬럼 값을 테이블의 heap record 밖에 저장하는 방식입니다.
- AS-IS: OOS 파일에 소유 테이블 정보가 없어 `diagdb` 가 owner를 표시하지 못하고,
  online `checkdb` 는 class lock으로 보호할 수 없어 OOS file table을 건너뜁니다.
- TO-BE: OOS 파일에 부모 HFID와 class OID를 저장하고,
  online `checkdb` 가 class lock으로 보호한 뒤 OOS file table을 검사합니다.

## Implementation

- `oos_create_file()` 이 부모 HFID와 class OID를 받아 OOS 전용
  `FILE_DESCRIPTORS.heap_oos` 영역에 저장하도록 변경했습니다.
- `file_header_dump_descriptor()` 가 OOS 파일의 class OID, 테이블명,
  부모 HFID를 출력하도록 변경했습니다.
- file tracker가 `FILE_OOS` 에 조건부 `SCH_S_LOCK` 을 획득한 경우에만
  VFID를 반환하도록 변경했습니다.
- `feat/oos` 는 아직 릴리스되지 않았으므로 ownerless descriptor 호환 분기 없이
  모든 OOS 파일이 단일 owner-bearing 형식을 사용합니다.
- SERVER_MODE test로 descriptor, 진단 출력, protected iteration,
  OOS file table 검사를 함께 검증했습니다.

## Remarks

- `FILE_DESCRIPTORS` 의 기존 64바이트 크기는 바뀌지 않습니다.
- 리뷰 시 OOS 전용 `heap_oos` descriptor와 class lock 수명 범위를 확인해 주세요.
- debug GCC build와 OOS CTest 24개가 모두 성공했습니다.
- `DROP TABLE` 이 사용하는 `SCH_M_LOCK` 과의 충돌 및 해제를 SERVER_MODE test로 검증했습니다.
- 자세한 설명: https://github.com/vimkim/my-cubrid-docs/blob/main/cbrd-27038/CBRD-27038-oos-owner-descriptor_59607e6_codex.md
