### PR TITLE
[CBRD-27121] Reduce contention when adding the candidate.

### DIFF
--- a/src/query/vacuum.c
+++ b/src/query/vacuum.c
@@ -1618,6 +1618,7 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
   helper.forward_page = NULL;
   helper.n_vacuumed = 0;
   helper.n_bulk_vacuumed = 0;
+  helper.can_vacuum = VACUUM_RECORD_CANNOT_VACUUM;
   helper.initial_home_free_space = -1;
   VFID_SET_NULL (&helper.overflow_vfid);
 
@@ -1859,16 +1860,13 @@ vacuum_heap_page (THREAD_ENTRY * thread_p, VACUUM_HEAP_OBJECT * heap_objects, in
 		  VACUUM_PERF_HEAP_TRACK_EXECUTE (thread_p, &helper);
 		  goto end;
 		}
-	      else if (helper.home_page != NULL)
-		{
-		  /* Unfix page. */
-		  pgbuf_unfix_and_init (thread_p, helper.home_page);
-		}
-	      /* Fall through and go to end. */
 	    }
-	  else
+
+	  if (helper.home_page != NULL)
 	    {
-	      /* Finished vacuuming page. Unfix the page and go to end. */
+	      assert (!HFID_IS_NULL (&helper.hfid));
+	      heap_add_bestpage (thread_p, &helper.hfid, helper.home_page,
+				 helper.can_vacuum == VACUUM_RECORD_REMOVE ? 0 : helper.initial_home_free_space);
 	      pgbuf_unfix_and_init (thread_p, helper.home_page);
 	    }
 	  goto end;
@@ -2576,6 +2574,9 @@ static void
 vacuum_heap_page_log_and_reset (THREAD_ENTRY * thread_p, VACUUM_HEAP_HELPER * helper, bool update_best_space_stat,
 				bool unlatch_page)
 {
+  int bestspace_prev_freespace;
+  int i;
+
   assert (helper != NULL);
   assert (helper->home_page != NULL);
 
@@ -2599,8 +2600,18 @@ vacuum_heap_page_log_and_reset (THREAD_ENTRY * thread_p, VACUUM_HEAP_HELPER * he
    * OIDs and their statistics are updated in that context */
   if (update_best_space_stat == true && helper->initial_home_free_space != -1)
     {
+      bestspace_prev_freespace = helper->initial_home_free_space;
+      for (i = 0; i < helper->n_bulk_vacuumed; i++)
+	{
+	  if (helper->results[i] == VACUUM_RECORD_REMOVE)
+	    {
+	      bestspace_prev_freespace = 0;
+	      break;
+	    }
+	}
+
       assert (!HFID_IS_NULL (&helper->hfid));
-      heap_add_bestpage (thread_p, &helper->hfid, helper->home_page, helper->initial_home_free_space);
+      heap_add_bestpage (thread_p, &helper->hfid, helper->home_page, bestspace_prev_freespace);
     }
 
   VACUUM_PERF_HEAP_TRACK_EXECUTE (thread_p, helper);

--- a/src/storage/bestspace.cpp
+++ b/src/storage/bestspace.cpp
@@ -364,6 +364,21 @@ namespace cubstorage
     return allocate (class_oid, hfid, needed_size, consume_size, page_watcher);
   }
 
+  bestspace::status
+  bestspace::shard::find_candidate (OID *class_oid, std::uint16_t needed_size, std::uint16_t consume_size,
+				    bestspace_entry &candidate, bool &valid, PGBUF_WATCHER &page_watcher)
+  {
+    status result;
+
+    result = allocate_verify_actual_space (class_oid, needed_size, candidate, valid, page_watcher);
+    if (result == status::FOUND)
+      {
+	candidate.freespace -= consume_size;
+	STATS_INC (found, 1);
+      }
+    return result;
+  }
+
   void
   bestspace::shard::add_estimates (int num_pages, std::uint64_t recs_num, std::uint64_t recs_sumlen)
   {
@@ -1068,6 +1083,7 @@ namespace cubstorage
 
   bestspace::candidate_queue::candidate_queue ()
     : m_size (0)
+    , m_max_freespace (0)
     , m_mutex ()
   {
     std::size_t i;
@@ -1092,6 +1108,7 @@ namespace cubstorage
 	m_array[i].set_null ();
       }
     m_size = 0;
+    m_max_freespace.store (0, std::memory_order_release);
   }
 
   bool
@@ -1114,6 +1131,7 @@ namespace cubstorage
       }
 
     insert (candidate);
+    m_max_freespace.store (m_array[m_size - 1].freespace, std::memory_order_release);
 
     return true;
   }
@@ -1132,6 +1150,28 @@ namespace cubstorage
       }
 
     insert (candidate);
+    m_max_freespace.store (m_array[m_size - 1].freespace, std::memory_order_release);
+  }
+
+  bool
+  bestspace::candidate_queue::pop (bestspace_entry &candidate, std::uint16_t needed_size)
+  {
+    if (m_max_freespace.load (std::memory_order_acquire) < needed_size)
+      {
+	return false;
+      }
+
+    std::lock_guard<std::mutex> lock (m_mutex);
+
+    if (m_size == 0 || m_array[m_size - 1].freespace < needed_size)
+      {
+	return false;
+      }
+
+    candidate = m_array[m_size - 1];
+    m_size--;
+    m_max_freespace.store (m_size == 0 ? 0 : m_array[m_size - 1].freespace, std::memory_order_release);
+    return true;
   }
 
   std::size_t
@@ -1139,6 +1179,11 @@ namespace cubstorage
   {
     std::size_t num;
     std::size_t i;
+
+    if (m_max_freespace.load (std::memory_order_acquire) <= minimum)
+      {
+	return 0;
+      }
 
     std::lock_guard<std::mutex> lock (m_mutex);
 
@@ -1153,6 +1198,7 @@ namespace cubstorage
 	candidates[i] = m_array[m_size - 1];
 	m_size--;
       }
+    m_max_freespace.store (m_size == 0 ? 0 : m_array[m_size - 1].freespace, std::memory_order_release);
     return i;
   }
 
@@ -1327,6 +1373,10 @@ namespace cubstorage
   {
     int consume_size, needed_size;
     std::size_t shard, bias;
+    std::size_t num_checked_candidates;
+    bestspace_entry candidate;
+    bool candidate_valid;
+    status result;
     int errid;
 
     assert (size > 0 && size < DB_PAGESIZE);
@@ -1359,6 +1409,33 @@ namespace cubstorage
       }
     shard = 0;
     bias = 0;
+
+    num_checked_candidates = 0;
+    while (num_checked_candidates < MAX_CANDIDATES_QUEUE_SIZE && m_candidates.pop (candidate, needed_size))
+      {
+	result =
+		m_shards[shard].find_candidate (class_oid, needed_size, consume_size, candidate, candidate_valid, page_watcher);
+	if (result == status::FOUND)
+	  {
+	    m_candidates.push (candidate);
+	    m_shards[shard].add_estimates (0, is_newrec ? 1 : 0, consume_size - SPAGE_SLOT_SIZE);
+	    return NO_ERROR;
+	  }
+	if (result == status::FAILURE)
+	  {
+	    ASSERT_ERROR ();
+	    errid = er_errid ();
+	    return errid != NO_ERROR ? errid : ER_FAILED;
+	  }
+
+	assert (result == status::NOT_FOUND);
+	assert (PGBUF_IS_CLEAN_WATCHER (&page_watcher));
+	if (candidate_valid)
+	  {
+	    m_candidates.push (candidate);
+	  }
+	num_checked_candidates++;
+      }
 
     // find
     return find_from_shards (thread_ref, class_oid, hfid, shard, needed_size, consume_size, bias, is_newrec, page_watcher);

--- a/src/storage/bestspace.hpp
+++ b/src/storage/bestspace.hpp
@@ -244,6 +244,8 @@ namespace cubstorage
 
 	  status find (OID *class_oid, HFID *hfid, std::uint16_t needed_size, std::uint16_t consume_size,
 		       std::size_t bias, PGBUF_WATCHER &page_watcher);
+	  status find_candidate (OID *class_oid, std::uint16_t needed_size, std::uint16_t consume_size,
+				 bestspace_entry &candidate, bool &valid, PGBUF_WATCHER &page_watcher);
 
 	  void add_estimates (int num_pages, std::uint64_t recs_num, std::uint64_t recs_sumlen);
 	  void subtract_estimates (int num_pages, std::uint64_t recs_num, std::uint64_t recs_sumlen);
@@ -338,6 +340,7 @@ namespace cubstorage
 	  bool try_push (bestspace_entry candidate);
 	  void push (bestspace_entry candidate);
 
+	  bool pop (bestspace_entry &candidate, std::uint16_t needed_size);
 	  std::size_t pop (bestspace_entry *candidates, std::uint16_t minimum, std::uint16_t needed_size);
 
 	  std::size_t to_entries (bestspace_entry *candidates);
@@ -345,6 +348,7 @@ namespace cubstorage
 	private:
 	  std::array<bestspace_entry, MAX_CANDIDATES_QUEUE_SIZE> m_array;
 	  std::size_t m_size;
+	  std::atomic<std::uint16_t> m_max_freespace;
 
 	  std::mutex m_mutex;
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -4619,8 +4619,19 @@ heap_add_bestpage (THREAD_ENTRY * thread_p, HFID * hfid, PAGE_PTR pgptr, std::ui
   int freespace;
   VPID *vpid;
 
-  /* prev_freespace is not used but leave this for future feature */
-  (void) prev_freespace;
+  freespace = spage_get_free_space_without_saving (thread_p, pgptr);
+  if (freespace == 0)
+    {
+      return;
+    }
+
+  /* physical removal paths pass zero to force a candidate update. MVCC header-only cleanup is ignored unless it */
+  /* promotes the page to a higher free-space tier. */
+  if (prev_freespace != 0
+      && cubstorage::bestspace::size_to_tier (freespace) <= cubstorage::bestspace::size_to_tier (prev_freespace))
+    {
+      return;
+    }
 
   bestspace = heap_find_bestspace (thread_p, NULL, hfid, header_watcher);
   if (!bestspace)
@@ -4628,17 +4639,13 @@ heap_add_bestpage (THREAD_ENTRY * thread_p, HFID * hfid, PAGE_PTR pgptr, std::ui
       return;
     }
 
-  freespace = spage_get_free_space_without_saving (thread_p, pgptr);
-  if (cubstorage::bestspace::size_to_tier (freespace) >= cubstorage::bestspace::tier::FS3)
-    {
-      vpid = pgbuf_get_vpid_ptr (pgptr);
-      assert_release (vpid != NULL);
+  vpid = pgbuf_get_vpid_ptr (pgptr);
+  assert_release (vpid != NULL);
 
-      candidate.freespace = freespace;
-      candidate.volid = vpid->volid;
-      candidate.pageid = vpid->pageid;
-      bestspace->try_push_candidates (&candidate, 1);
-    }
+  candidate.freespace = freespace;
+  candidate.volid = vpid->volid;
+  candidate.pageid = vpid->pageid;
+  bestspace->push_candidates (&candidate, 1);
 }
 
 /*
@@ -16123,12 +16130,6 @@ int
 heap_rv_undo_insert (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
 {
   INT16 slotid;
-  int freespace = 0;
-
-  if (LOG_ISRESTARTED ())
-    {
-      freespace = spage_get_free_space_without_saving (thread_p, rcv->pgptr);
-    }
 
   slotid = rcv->offset;
   /* Clear HEAP_RV_FLAG_VACUUM_STATUS_CHANGE */
@@ -16155,7 +16156,7 @@ heap_rv_undo_insert (THREAD_ENTRY * thread_p, LOG_RCV * rcv)
       assert (heap_hfid_isvalid (&hfid) == DISK_VALID);
 #endif
 
-      heap_add_bestpage (thread_p, &hfid, rcv->pgptr, freespace);
+      heap_add_bestpage (thread_p, &hfid, rcv->pgptr);
     }
 
 end:
@@ -21999,16 +22000,11 @@ heap_delete_home (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context, boo
 static int
 heap_delete_physical (THREAD_ENTRY * thread_p, HFID * hfid_p, PAGE_PTR page_p, OID * oid_p)
 {
-  int freespace;
-
   /* check input */
   assert (hfid_p != NULL);
   assert (page_p != NULL);
   assert (oid_p != NULL);
   assert (oid_p->slotid != NULL_SLOTID);
-
-  /* save old freespace */
-  freespace = spage_get_free_space_without_saving (thread_p, page_p);
 
   /* physical deletion */
   if (spage_delete (thread_p, page_p, oid_p->slotid) == NULL_SLOTID)
@@ -22017,7 +22013,7 @@ heap_delete_physical (THREAD_ENTRY * thread_p, HFID * hfid_p, PAGE_PTR page_p, O
     }
 
   /* insert into bestspace cadidates */
-  heap_add_bestpage (thread_p, hfid_p, page_p, freespace);
+  heap_add_bestpage (thread_p, hfid_p, page_p);
 
   /* mark page as dirty */
   pgbuf_set_dirty (thread_p, page_p, DONT_FREE);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27121>

### Purpose

bestspace에 candidate를 추가하는 과정에서 경합이 덜 발생하도록 수정합니다. 또, candidate 추가 조건을 구체화하여 유효한 candidate가 누락되지 않도록 합니다.

### Implementation

1. vacuum 후 freespace의 티어가 previous freespace의 티어보다 큰 경우에만 candidates에 넣도록 한다.

2. 페이지의 레코드가 하나라도 제거되었다면 (bulk vacuum), candidate 삽입을 시도한다. (1 조건은 검사함)

3. candidates 중 가장 큰 freespace를 atomic 변수로 관리하여 mutex를 잡기 전에 candidate의 유효성을 검사한다.

### Remarks

N/A
