### PR TITLE
[CBRD-26991] Error handling for NULL call method target

### DIFF
--- a/src/parser/csql_grammar.y
+++ b/src/parser/csql_grammar.y
@@ -17269,6 +17269,10 @@ opt_on_target
 		}}
 	| ON_ primary
 		{{
+                        if( $2 == NULL ||  ($2->node_type == PT_VALUE && PT_IS_NULL_NODE($2)))
+                          {
+                            PT_ERRORm (this_parser, NULL, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_METH_TARGET_NOT_OBJ);
+                          }
 			$$ = $2;
 			PARSER_SAVE_ERR_CONTEXT ($$, @$.buffer_pos)
 		}}

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -14534,8 +14534,12 @@ call_method (PARSER_CONTEXT * parser, PT_NODE * statement)
   if (DB_VALUE_TYPE (&target_value) == DB_TYPE_NULL)
     {
       /*
-       * Don't understand the rationale behind this case.  What's the
-       * point here?  MRS 4/30/96
+       * The target evaluates to NULL. If it comes from a bind variable
+       * (host variable/parameter), reject it with METH_TARGET_NOT_OBJ,
+       * since NULL cannot be a method target.
+       * Otherwise (e.g. the target is a literal NULL, which is already
+       * rejected earlier in the parser via opt_on_target), just fall
+       * through without error.
        */
       if (target->node_type == PT_NAME && target->info.name.meta_class == PT_PARAMETER)
 	{

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -14537,6 +14537,10 @@ call_method (PARSER_CONTEXT * parser, PT_NODE * statement)
        * Don't understand the rationale behind this case.  What's the
        * point here?  MRS 4/30/96
        */
+      if (target->node_type == PT_NAME && target->info.name.meta_class == PT_PARAMETER)
+	{
+	  PT_ERRORm (parser, statement, MSGCAT_SET_PARSER_SEMANTIC, MSGCAT_SEMANTIC_METH_TARGET_NOT_OBJ);
+	}
       error = NO_ERROR;
     }
   else


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26991>

### Purpose

* Error handling for NULL call method target
* call add_member()와 같이 메소드를 call 할 때 대상 target이 NULL일때 오류 처리 함.

### Implementation

N/A

### Remarks

N/A
