### PR TITLE
[CBRD-27097] Ensure the query is not omitted when EOF is reached without a semicolon

### DIFF
--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -882,7 +882,8 @@ start_csql (CSQL_ARGUMENT * csql_arg)
 	      continue;
 	    }
 
-	  if (!csql_Is_interactive && feof (csql_Input_fp) && check_contents_has_noncomment ())
+	  if (!csql_Is_interactive && csql_arg->single_line_execution
+	      && feof (csql_Input_fp) && check_contents_has_noncomment ())
 	    {
 	      /* single-line-oriented execution */
 	      csql_execute_statements (csql_arg, EDITOR_INPUT, NULL, line_no);

--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -637,6 +637,54 @@ multibyte_warning:
 #endif
 }
 
+static bool
+check_contents_has_noncomment (void)
+{
+  /* Check if csql_Edit_contents contains any actual content, 
+   * ignoring whitespace and comments 
+   */
+  char *p = csql_edit_contents_get ();
+  if (p)
+    {
+      while (*p)
+	{
+	  if (*p == ' ' || *p == '\t' || *p == '\r' || *p == '\n')
+	    {
+	      p++;
+	    }
+	  else if (p[0] == '-' && p[1] == '-')
+	    {
+	      for (p += 2; *p && *p != '\n'; p++)
+		/* blank */ ;
+	    }
+	  else if (p[0] == '/')
+	    {
+	      if (p[1] == '/')
+		{
+		  for (p += 2; *p && *p != '\n'; p++)
+		    /* blank */ ;
+		}
+	      else if (p[1] == '*')
+		{
+		  for (p += 2; *p && !(p[0] == '*' && p[1] == '/'); p++)
+		    /* blank */ ;
+		  p += (*p ? 2 : 0);
+		}
+	      else
+		{
+		  return true;
+		}
+	    }
+	  else
+	    {
+	      return true;
+	    }
+	}
+    }
+
+  return false;
+}
+
 /*
  * start_csql()
  *   return: none
@@ -832,6 +880,13 @@ start_csql (CSQL_ARGUMENT * csql_arg)
 	    {
 	      fprintf (csql_Output_fp, "\n");
 	      continue;
+	    }
+
+	  if (!csql_Is_interactive && feof (csql_Input_fp) && check_contents_has_noncomment ())
+	    {
+	      /* single-line-oriented execution */
+	      csql_execute_statements (csql_arg, EDITOR_INPUT, NULL, line_no);
+	      csql_edit_contents_clear ();
 	    }
 
 	  /* Normal end condtion (with -i option) */


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27097>

### Purpose

* Ensure the query is not omitted when EOF is reached without a semicolon
* csql -i  옵션으로 지정된 파일의 마지막 쿼리 이후에 ';'이 없으면 조용히 무시되던 현상 수정
  - 직전 쿼리 이후 공백과 comment 를 제외한 어떠한 내용이라도 있으면 해당 내용을 수행 시킵니다.
  - `;read ` 명령 등으로 내부 buffer에 쌓아 둔 content에 대해서도 자동으로 수행하게 됩니다

### Implementation

N/A

### Remarks

* JIRA 본문의 아래 댓글에서 케이스를 참고하세요
http://jira.cubrid.org/browse/CBRD-27097?focusedCommentId=4775356&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-4775356

* 옵션 지정에 따른 csql 동작
  - csql --no-single-line
     오직 session command로 수행시켜야만 누적된 쿼리가 수행
     ';'만 입력된 경우 무시
  - csql
     하나의 쿼리가 끝나거나, session command로 누적된 쿼리 수행
      ';'만 입력된 경우 ";xrun"과 동일하게 처리

  - csql  -c "string" --no-single-line
     --no-single-line 옵션은 무시됨.
  - csql -c "string"
      "string" 내에 기술된 모든 내용은 SQL 문으로 판단되면 session command로 인식하지 않음.
       "string"의 마지막에 ';'가 없어도 수행 해 줌

  - csql -i file_name --no-single-line
      file_name에 들어 있는 모든 내용은 SQL문으로 판단하고 session command로 인식하지 않음
      --no-single-line 옵션은 사실상 무력화 됨.(;xr 명령이 없어도 그대로 수행 됨, 애초에 session command 불가능)
   - csql -i file_name
        file_name에 들어 있는 모든 내용 중에 session command가 허용됨.
        파일의 마지막에 ';'가 없으면 수행하지 않음
==> 위 내용 중 `csql -i file_name` 케이스에 대해서 변화가 발생합니다.
       파일의 마지막에 ';'이 없어도 남아 있는 내용이 있으면 수행해 줍니다.
       ;read 구문으로 읽어 들인 내용 역시 buffer에 남아 있으면 수행 됩니다.( 이점에 주의 필요) 

