### PR TITLE
[CBRD-26981] Fix restoreslave crash from the eager _db_serial attribute-info load

### DIFF
--- a/src/query/serial.c
+++ b/src/query/serial.c
@@ -1114,8 +1114,8 @@ serial_get_nth_value (DB_VALUE * inc_val, DB_VALUE * cur_val, DB_VALUE * min_val
 /*
  * serial_initialize_cache_pool () -
  *   return: NO_ERROR, or ER_status
- *   load_attr_info(in): load the _db_serial attribute layout now. Pass false only on the
- *                       restoredb path, which restarts the server without a client workspace.
+ *   load_attr_info(in): load the _db_serial attribute layout now. Pass false only when restarting
+ *                       from a backup, which has no client workspace.
  */
 int
 serial_initialize_cache_pool (THREAD_ENTRY * thread_p, bool load_attr_info)
@@ -1140,11 +1140,9 @@ serial_initialize_cache_pool (THREAD_ENTRY * thread_p, bool load_attr_info)
 
   if (!load_attr_info)
     {
-      /* restoredb (xboot_restart_from_backup) restarts the server without initializing the client
-       * workspace, so loading the _db_serial attribute layout here would swizzle the object-domain
-       * owner OID and divide by the empty MOP table in ws_mop (SIGFPE). restoredb never generates
-       * serial values, so the layout is not needed; a later normal boot loads it with the workspace
-       * ready. */
+      /* Without a client workspace the load swizzles the object-domain owner OID and divides by
+       * the empty MOP table in ws_mop (SIGFPE). restoredb/restoreslave generate no serial values,
+       * and a later normal boot loads the layout. */
       return NO_ERROR;
     }
 

--- a/src/query/serial.c
+++ b/src/query/serial.c
@@ -1129,6 +1129,14 @@ serial_initialize_cache_pool (THREAD_ENTRY * thread_p, bool load_attr_info)
       serial_finalize_cache_pool ();
     }
 
+  if (!load_attr_info)
+    {
+      /* Without a client workspace the load swizzles the object-domain owner OID and divides by
+       * the empty MOP table in ws_mop (SIGFPE). restoredb/restoreslave generate no serial values,
+       * so the cache pool is not built either; a later normal boot initializes everything. */
+      return NO_ERROR;
+    }
+
   serial_Cache_hashmap.init (serial_Cache_Ts, THREAD_TS_SERIAL_CACHE, SERIAL_CACHE_HASH_SIZE, freelist_block_size,
 			     freelist_block_count, serial_Cache_entry_descriptor);
   serial_Cache_initialized = true;
@@ -1136,14 +1144,6 @@ serial_initialize_cache_pool (THREAD_ENTRY * thread_p, bool load_attr_info)
   for (i = 0; i < sizeof (serial_Attrs_id) / sizeof (ATTR_ID); i++)
     {
       serial_Attrs_id[i] = -1;
-    }
-
-  if (!load_attr_info)
-    {
-      /* Without a client workspace the load swizzles the object-domain owner OID and divides by
-       * the empty MOP table in ws_mop (SIGFPE). restoredb/restoreslave generate no serial values,
-       * and a later normal boot loads the layout. */
-      return NO_ERROR;
     }
 
   /* Load the _db_serial attribute layout once, now that the catalog is available. */

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2664,7 +2664,8 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
 
   /* Skip the eager _db_serial attribute-info load when restarting from a backup (restoredb,
    * restoreslave): no client workspace yet. Not r_args->is_restore_from_backup, which restoredb
-   * alone sets to also skip the vacuum above. */
+  /* Skip the eager _db_serial attribute-info load when restarting from a backup (restoredb,
+   * restoreslave): no client workspace yet. */
   error_code = serial_initialize_cache_pool (thread_p, !from_backup);
   if (error_code != NO_ERROR)
     {

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2662,10 +2662,10 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
       logtb_disable_update (NULL);
     }
 
-  /* Skip the eager _db_serial attribute-info load on the restore-from-backup path: restoredb
-   * restarts the server without a client workspace, so the load would crash in ws_mop, and it
-   * never generates serial values anyway. */
-  error_code = serial_initialize_cache_pool (thread_p, !(r_args != NULL && r_args->is_restore_from_backup));
+  /* Skip the eager _db_serial attribute-info load when restarting from a backup (restoredb,
+   * restoreslave): no client workspace yet. Not r_args->is_restore_from_backup, which restoredb
+   * alone sets to also skip the vacuum above. */
+  error_code = serial_initialize_cache_pool (thread_p, !from_backup);
   if (error_code != NO_ERROR)
     {
       goto error;

--- a/src/transaction/boot_sr.c
+++ b/src/transaction/boot_sr.c
@@ -2663,8 +2663,6 @@ boot_restart_server (THREAD_ENTRY * thread_p, bool print_restart, const char *db
     }
 
   /* Skip the eager _db_serial attribute-info load when restarting from a backup (restoredb,
-   * restoreslave): no client workspace yet. Not r_args->is_restore_from_backup, which restoredb
-  /* Skip the eager _db_serial attribute-info load when restarting from a backup (restoredb,
    * restoreslave): no client workspace yet. */
   error_code = serial_initialize_cache_pool (thread_p, !from_backup);
   if (error_code != NO_ERROR)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26981

### Purpose

Follow-up to #7381. Fix the `restoreslave` crash that takes down every HA shell test using `ha_make_slavedb.sh`.

- #7381 moved the `_db_serial` attribute-info load from a lazy first-touch to an eager load in `serial_initialize_cache_pool()` at boot, and added a guard to skip it when the server is restarted from a backup without a client workspace (the load reaches `heap_attrinfo_start` on `_db_serial`, swizzles the object-domain owner OID, and divides by the empty MOP table in `ws_mop` — SIGFPE).
- The guard keys off `r_args->is_restore_from_backup`, which only `restoredb` sets (`src/executables/util_sa.c:991`). `restoreslave` leaves it `false` (`util_sa.c:4739`), so it still runs the eager load and dies.
- Both utilities reach the same code through `boot_restart_from_backup()` → `xboot_restart_from_backup()` → `boot_restart_server(..., from_backup = true, ...)`, and both restart the server without a client workspace.
- Result: `boot_restart_from_backup()` returns `NULL_TRAN_INDEX`, `restoreslave()` exits `EXIT_FAILURE`, and `ha_make_slavedb.sh` fails at step 8 with `<< ERROR >> Fail to restore slave database.`

### Implementation

**src/transaction/boot_sr.c**
- Key the guard off `boot_restart_server()`'s `from_backup` parameter instead of `r_args->is_restore_from_backup`. `from_backup` is `true` exactly on the `xboot_restart_from_backup()` path that both utilities take; of the four `boot_restart_server()` call sites, only that one passes `true`.
- `is_restore_from_backup` is left as is: it also gates the vacuum skip a few lines above, which `restoreslave` must *not* take.

**src/query/serial.c**
- Comment only — the skip now covers `restoreslave` as well.

### Remarks

- No specification change (no SQL grammar, catalog, error code, or system parameter change).
- `restoreslave` reboots normally via `db_restart()` right after `boot_shutdown_server()` (`util_sa.c:4830`), so the attribute layout is loaded there with the workspace ready, before `insert_ha_apply_info()` / `delete_all_ha_apply_info()` run.
- Verified: `boot_sr.c` and `serial.c` compile clean in both SA_MODE (`cubridsa`) and SERVER_MODE (`cubrid`).
