### PR TITLE
[CBRD-27117] Add a bestspace strategy parameter.

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -5420,7 +5420,7 @@ SYSPRM_PARAM prm_Def[] = {
    PRM_CLEAR_DYNAMIC_FLAG,
    {false, {.i = 40}},
    {false, {.i = 40}},
-   {false, {.i = 1000}},
+   {false, {.i = 128}},
    {false, {.i = 10}},
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -801,7 +801,10 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 #define PRM_NAME_LOG_POSTPONE_CACHE_SIZE "postpone_cache_size"
 
 #define PRM_NAME_HARDWARE_AFFINITY "hardware_affinity"
+
 #define PRM_NAME_BESTSPACE_SHARD_COUNT "bestspace_shard_count"
+#define PRM_NAME_BESTSPACE_DISTRIBUTED_INSERT "bestspace_distributed_insert"
+#define PRM_NAME_BESTSPACE_CACHE_COUNT "bestspace_cache_count"
 
 // #endregion 
 
@@ -5395,6 +5398,30 @@ SYSPRM_PARAM prm_Def[] = {
    {false, {.i = 8}},
    {false, {.i = 28}},
    {false, {.i = 1}},
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
+  {PRM_ID_BESTSPACE_DISTRIBUTED_INSERT,
+   PRM_NAME_BESTSPACE_DISTRIBUTED_INSERT,
+   (PRM_FOR_SERVER | PRM_HIDDEN),
+   PRM_BOOLEAN,
+   PRM_CLEAR_DYNAMIC_FLAG,
+   {false, {.b = false}},
+   {false, {.b = false}},
+   NULL_SYSPRM_PARAM_VALUE,
+   NULL_SYSPRM_PARAM_VALUE,
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
+  {PRM_ID_BESTSPACE_CACHE_COUNT,
+   PRM_NAME_BESTSPACE_CACHE_COUNT,
+   (PRM_FOR_SERVER | PRM_HIDDEN),
+   PRM_INTEGER,
+   PRM_CLEAR_DYNAMIC_FLAG,
+   {false, {.i = 40}},
+   {false, {.i = 40}},
+   {false, {.i = 1000}},
+   {false, {.i = 10}},
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL}

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -537,8 +537,11 @@ enum param_id
 
   PRM_ID_BESTSPACE_SHARD_COUNT,
 
+  PRM_ID_BESTSPACE_DISTRIBUTED_INSERT,
+  PRM_ID_BESTSPACE_CACHE_COUNT,
+
   /* change PRM_LAST_ID when adding new system parameters */
-  PRM_LAST_ID = PRM_ID_BESTSPACE_SHARD_COUNT
+  PRM_LAST_ID = PRM_ID_BESTSPACE_CACHE_COUNT
 };
 typedef enum param_id PARAM_ID;
 

--- a/src/storage/bestspace.cpp
+++ b/src/storage/bestspace.cpp
@@ -1276,6 +1276,7 @@ namespace cubstorage
   bestspace::bestspace (std::size_t shard_count, int num_pages, std::uint64_t recs_num, std::uint64_t recs_sumlen,
 			std::uint16_t unfill_space)
     : m_shards ()
+    , m_distributed_insert (prm_get_bool_value (PRM_ID_BESTSPACE_DISTRIBUTED_INSERT))
     , m_unfill_space (unfill_space)
     , m_num_pages (num_pages)
     , m_recs_num (recs_num)
@@ -1409,8 +1410,16 @@ namespace cubstorage
       {
 	needed_size = consume_size;
       }
-    shard = 0;
-    bias = 0;
+    if (m_distributed_insert)
+      {
+	shard = static_cast<std::size_t> (thread_ref.index) % m_shards.size ();
+	bias = static_cast<std::size_t> (thread_ref.tran_index) % BITS_PER_BYTE;
+      }
+    else
+      {
+	shard = 0;
+	bias = 0;
+      }
 
     num_checked_candidates = 0;
     while (num_checked_candidates < MAX_CANDIDATES_QUEUE_SIZE && m_candidates.pop (candidate, needed_size))

--- a/src/storage/bestspace.cpp
+++ b/src/storage/bestspace.cpp
@@ -25,6 +25,7 @@
 #include "heap_file.h"
 #include "slotted_page.h"
 #include "error_manager.h"
+#include "system_parameter.h"
 
 #include <mutex>
 #include <utility>
@@ -1632,6 +1633,7 @@ namespace cubstorage
 
   bestspace_registry::bestspace_registry ()
     : m_head (nullptr)
+    , m_cache_count (0)
     , m_mutex ()
     , m_generation (1)
   {
@@ -1667,6 +1669,12 @@ namespace cubstorage
     node->entry->push_candidates (candidates, num_candidates);
 
     std::lock_guard<std::mutex> lock (m_mutex);
+
+    if (m_cache_count == 0)
+      {
+	m_cache_count = MAX (static_cast<std::size_t> (prm_get_integer_value (PRM_ID_BESTSPACE_CACHE_COUNT)),
+			     static_cast<std::size_t> (1));
+      }
 
     assert (!find_entry (m_head, hfid));
     insert_entry (m_head, node);
@@ -1775,6 +1783,7 @@ namespace cubstorage
   {
     registry_entry *cache;
     bestspace *entry;
+    std::size_t cache_count;
 
     std::unique_lock<std::mutex> ulock (m_mutex);
 
@@ -1785,11 +1794,14 @@ namespace cubstorage
 	return nullptr;
       }
     entry = (pair->second)->entry;
+    cache_count = m_cache_count;
 
     ulock.unlock ();
 
-    // register in TLS list
-    if (TLS_cache.size < TLS_MAX_SIZE)
+    // register in TLS list.
+    // the entries are recycled, never freed, so TLS_cache.size always matches the number of nodes in the list. once
+    // the size reaches the count the list cannot be empty, hence get_tail_from_list () cannot return null here.
+    if (TLS_cache.size < cache_count)
       {
 	cache = new registry_entry;
 	TLS_cache.size++;
@@ -1798,6 +1810,7 @@ namespace cubstorage
       {
 	cache = get_tail_from_list (TLS_cache.head);
       }
+    assert (cache != nullptr);
     cache->hfid = *hfid;
     cache->entry = entry;
 

--- a/src/storage/bestspace.hpp
+++ b/src/storage/bestspace.hpp
@@ -463,11 +463,11 @@ namespace cubstorage
 
     private:
       registry_entry *m_head;
+      std::size_t m_cache_count;
       std::mutex m_mutex;
 
       alignas (64) std::atomic<uint64_t> m_generation;
 
-      static constexpr std::size_t TLS_MAX_SIZE = 40;
       inline static thread_local registry_cache TLS_cache;
 
       bestspace *find_from_cache (HFID *hfid);

--- a/src/storage/bestspace.hpp
+++ b/src/storage/bestspace.hpp
@@ -388,6 +388,7 @@ namespace cubstorage
       candidate_queue m_candidates;
 
       // parameter
+      const bool m_distributed_insert;
       std::uint16_t m_unfill_space;
 
       // statistics


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27117>

### Purpose

두 종류의 정책 파라미터를 추가합니다.

#### bestspace_distributed_insert (bool)

HIDDEN, SERVER
기본값: false
범위: false / true
 
#### bestspace_cache_count (integer)

HIDDEN, SERVER
기본값: 40
범위: 5-128

### Implementation

N/A

### Remarks

아래 두 커밋만 이 PR의 리뷰 대상입니다.
[add options and strategy](https://github.com/CUBRID/cubrid/commit/5b80178e19e828e6c5dc5fc4c117683c4bb17a32)
[implement bestspace_cache_count feature](https://github.com/CUBRID/cubrid/commit/d34ed7562949fedc287d2dacc124393ad3395aea)

