### PR TITLE
[CBRD-27122] Skip fixing the page if the VPID is null.

### DIFF
--- a/src/storage/bestspace.cpp
+++ b/src/storage/bestspace.cpp
@@ -598,6 +598,11 @@ namespace cubstorage
 
     // first, check the recorded free space
     expected = m_L1[l2_index * L2_FANOUT + l1_index].load ();
+    old_vpid = expected.get_vpid ();
+    if (VPID_ISNULL (&old_vpid))
+      {
+	return status::NOT_FOUND;
+      }
     if (!force_check && expected.get_freespace () < needed_size)
       {
 	// there is no enough space
@@ -605,8 +610,6 @@ namespace cubstorage
       }
 
     // now, fix a page to check the actual free space
-    old_vpid = expected.get_vpid ();
-
     error = L1_fix (l2_index, l1_index, expected, old_vpid, page_watcher);
     if (error != status::SUCCESS)
       {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27122

### Purpose

L1을 load 후 freespace를 체크하여 충분하지 않은 경우 반환하고 있었습니다. 그러나, 공간 업데이트를 위해 force_check가 존재하고, 순서가 꼬이는 경우 null vpid를 fix하게 됩니다. 시나리오는 아래와 같습니다.

T1: L1[2]에 대해 공간 업데이트를 수행하기 위해 L1[2]에 들어온다.

T2: L1[2]에 있는 페이지를 모두 사용하고 제거한다. L1[2]의 vpid, freespace은 각각 null vpid, 0이 된다.

T1: force_check가 true이므로 L1[2]의 freespace가 0이어도 무시하고 fix를 수행한다.
T1: null vpid에 대해 fix를 수행하여 에러를 반환한다.

### Implementation

force_check를 확인하기 전에 vpid를 먼저 보고, null vpid인 경우 스킵한다.

### Remarks

[skip if vpid is null](https://github.com/CUBRID/cubrid/commit/becf33638e9265325052f8488474f437b7213b79)만 리뷰 대상입니다.
