### PR TITLE
[CBRD-27093] Synchronize volumes when DWB is disabled

### DIFF
--- a/src/storage/double_write_buffer.c
+++ b/src/storage/double_write_buffer.c
@@ -3415,7 +3415,7 @@ start:
  *
  * return   : Error code.
  * thread_p (in): The thread entry.
- * all_sync (out): True, if everything synchronized.
+ * all_sync (out): True, if DWB synchronized all permanent volumes.
  */
 int
 dwb_flush_force (THREAD_ENTRY * thread_p, bool * all_sync)
@@ -3458,9 +3458,9 @@ start:
     {
       if (!DWB_IS_CREATED (initial_position_with_flags))
 	{
-	  /* Nothing to do. Everything flushed. */
+	  /* DWB is not created. Let the caller synchronize permanent volumes. */
 	  assert (dwb_Global.file_sync_helper_block == NULL);
-	  dwb_log ("dwb_flush_force: Everything flushed\n");
+	  dwb_log ("dwb_flush_force: DWB is not created\n");
 	  goto end;
 	}
 
@@ -3490,7 +3490,7 @@ start:
       if (initial_block == NULL)
 	{
 	  /* Nothing to flush. */
-	  goto end;
+	  goto end_all_sync;
 	}
 
       goto wait_for_file_sync_helper_block;
@@ -3561,9 +3561,9 @@ check_flushed_blocks:
     {
       if (!DWB_IS_CREATED (current_position_with_flags))
 	{
-	  /* Nothing to do. Everything flushed. */
+	  /* DWB was disabled. Let the caller synchronize permanent volumes. */
 	  assert (dwb_Global.file_sync_helper_block == NULL);
-	  dwb_log ("dwb_flush_force: Everything flushed\n");
+	  dwb_log ("dwb_flush_force: DWB was disabled\n");
 	  goto end;
 	}
 
@@ -3618,7 +3618,7 @@ check_flushed_blocks:
 	}
       else if (dwb_slot == NULL)
 	{
-	  /* DWB disabled meanwhile, everything flushed. */
+	  /* DWB was disabled meanwhile. Let the caller synchronize permanent volumes. */
 	  assert (dwb_Global.file_sync_helper_block == NULL);
 	  assert (!DWB_IS_CREATED (ATOMIC_INC_64 (&dwb_Global.position_with_flags, 0ULL)));
 	  dwb_log ("dwb_flush_force: DWB disabled = %lld\n", ATOMIC_INC_64 (&dwb_Global.position_with_flags, 0ULL));
@@ -3643,9 +3643,10 @@ wait_for_file_sync_helper_block:
     }
 #endif
 
-end:
+end_all_sync:
   *all_sync = true;
 
+end:
   dwb_log ("dwb_flush_force: Ended with position = %lld\n", ATOMIC_INC_64 (&dwb_Global.position_with_flags, 0ULL));
   PERF_UTIME_TRACKER_TIME_AND_RESTART (thread_p, &time_track, PSTAT_DWB_FLUSH_FORCE_TIME_COUNTERS);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27093

## Purpose

develop PR https://github.com/CUBRID/cubrid/pull/7521 을 release/10.2 에 백포트합니다.

`double_write_buffer_size=0`으로 DWB(페이지를 디스크에 두 번 나눠 안전하게 쓰는 이중 쓰기 버퍼)를 끄면, checkpoint가 영구 데이터 볼륨을 디스크에 동기화하지 않는 문제를 수정합니다.

- AS-IS: DWB가 생성되지 않아 아무것도 동기화하지 않았는데도 `all_sync=true`를 반환하여 호출자의 직접 fsync를 건너뜁니다.
- TO-BE: DWB 비활성 경로는 `all_sync=false`를 유지하여 호출자가 영구 볼륨을 직접 fsync 합니다.

## Implementation

- `src/storage/double_write_buffer.c`의 `dwb_flush_force()`에서 `all_sync`의 의미를 "DWB가 모든 영구 볼륨의 동기화를 보증했는지"로 명확히 했습니다.
- DWB 미생성 및 실행 중 비활성화 경로는 초기값 `false`를 유지하고, DWB가 동기화를 보증하는 정상 경로만 `end_all_sync` 라벨에서 `true`로 설정합니다.
- 호출자(`fileio_synchronize_all`, `fileio_synchronize`)에 이미 구현된 볼륨 순회 및 개별 fsync fallback을 그대로 사용하므로 호출자 변경은 없습니다.

## Remarks

- develop 커밋 `85b6b5743` 중 `src/storage/double_write_buffer.cpp` 변경만 포트했습니다. develop 전용인 단위 테스트와 CMake 변경은 포함하지 않았습니다.
- 이 브랜치의 `dwb_flush_force()`는 develop과 동일한 코드여서 수정 내용도 동일합니다.
- 자세한 설명: https://github.com/vimkim/my-cubrid-docs/blob/main/cbrd-27093/CBRD-27093-checkpoint-fsync-fallback_85b6b57_codex.md
