### PR TITLE
[CBRD-27135] Support parallel scan for ROWNUM (inst_num) queries

### DIFF
--- a/cs/CMakeLists.txt
+++ b/cs/CMakeLists.txt
@@ -431,10 +431,12 @@ set(API_HEADERS
 
 set(PARALLEL_SCAN_SOURCES
   ${PARALLEL_SCAN_DIR}/px_scan_checker.cpp
+  ${PARALLEL_SCAN_DIR}/px_scan_instnum.cpp
   )
 
 set(PARALLEL_SCAN_HEADERS
   ${PARALLEL_SCAN_DIR}/px_scan_checker.hpp
+  ${PARALLEL_SCAN_DIR}/px_scan_instnum.hpp
   )
 
 set(PARALLEL_QUERY_EXECUTE_SOURCES

--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -362,6 +362,7 @@ set(PARALLEL_HASH_JOIN_HEADERS
 )
 
 set(PARALLEL_SCAN_SOURCES
+  ${PARALLEL_SCAN_DIR}/px_scan_instnum.cpp
   ${PARALLEL_SCAN_DIR}/px_scan_input_handler_heap.cpp
   ${PARALLEL_SCAN_DIR}/px_scan_input_handler_list.cpp
   ${PARALLEL_SCAN_DIR}/px_scan_input_handler_index.cpp
@@ -381,6 +382,7 @@ set(PARALLEL_SCAN_SOURCES
   )
 
 set(PARALLEL_SCAN_HEADERS
+  ${PARALLEL_SCAN_DIR}/px_scan_instnum.hpp
   ${PARALLEL_SCAN_DIR}/px_scan_input_handler_heap.hpp
   ${PARALLEL_SCAN_DIR}/px_scan_input_handler_list.hpp
   ${PARALLEL_SCAN_DIR}/px_scan_input_handler_index.hpp

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -402,10 +402,12 @@ set(SP_HEADERS
 
 set(PARALLEL_SCAN_SOURCES
   ${PARALLEL_SCAN_DIR}/px_scan_checker.cpp
+  ${PARALLEL_SCAN_DIR}/px_scan_instnum.cpp
   )
 
 set(PARALLEL_SCAN_HEADERS
   ${PARALLEL_SCAN_DIR}/px_scan_checker.hpp
+  ${PARALLEL_SCAN_DIR}/px_scan_instnum.hpp
   )
 
 set(PARALLEL_QUERY_EXECUTE_SOURCES

--- a/src/query/parallel/px_interrupt.hpp
+++ b/src/query/parallel/px_interrupt.hpp
@@ -56,29 +56,6 @@ namespace parallel_query
       inline interrupt() : m_code (interrupt_code::NO_INTERRUPT) {}
   };
 
-  class atomic_instnum
-  {
-    public:
-
-      std::size_t m_destination_tuple_cnt;
-      std::atomic<std::size_t> m_current_tuple_cnt;
-      bool m_is_instnum_set;
-
-      inline atomic_instnum() : m_destination_tuple_cnt (0), m_current_tuple_cnt (0), m_is_instnum_set (false) {}
-      inline atomic_instnum (std::size_t destination_tuple_cnt) : m_destination_tuple_cnt (destination_tuple_cnt),
-	m_current_tuple_cnt (0), m_is_instnum_set (true) {}
-
-      inline void set_destination_tuple_cnt (std::size_t destination_tuple_cnt) noexcept
-      {
-	m_destination_tuple_cnt = destination_tuple_cnt;
-	m_is_instnum_set = true;
-      }
-
-      inline bool is_instnum_satisfies_after_1tuple_insert() noexcept
-      {
-	return m_is_instnum_set?m_current_tuple_cnt.fetch_add (1) >= m_destination_tuple_cnt:false;
-      }
-  };
   class err_messages_with_lock
   {
       using er_message = cuberr::er_message;

--- a/src/query/parallel/px_scan/px_scan.cpp
+++ b/src/query/parallel/px_scan/px_scan.cpp
@@ -2017,6 +2017,10 @@ namespace parallel_scan
 	    return S_END;
 	  }
 	  break;
+	  case parallel_query::interrupt::interrupt_code::INST_NUM_SATISFIED:
+	    /* benign early-stop: the "inst_num() <= ?" quota was met; the merged list already holds
+	     * exactly the first N rows, so pass the read result through unchanged. */
+	    break;
 	  default:
 	    break;
 	  }

--- a/src/query/parallel/px_scan/px_scan.cpp
+++ b/src/query/parallel/px_scan/px_scan.cpp
@@ -2018,8 +2018,7 @@ namespace parallel_scan
 	  }
 	  break;
 	  case parallel_query::interrupt::interrupt_code::INST_NUM_SATISFIED:
-	    /* benign early-stop: the "inst_num() <= ?" quota was met; the merged list already holds
-	     * exactly the first N rows, so pass the read result through unchanged. */
+	    /* benign early-stop: quota met, merged list already holds the first N rows. */
 	    break;
 	  default:
 	    break;

--- a/src/query/parallel/px_scan/px_scan_checker.cpp
+++ b/src/query/parallel/px_scan/px_scan_checker.cpp
@@ -155,9 +155,8 @@ namespace parallel_scan
       }
   }
 
-  /* shared shape conditions for both instnum fast-path modes (merge-time renumbering and atomic draw):
-   * plain BUILDLIST without sort/group interactions, and instnum_val referenced in the output only as a
-   * top-level pass-through column (never inside an expression). Sets *passthrough_cnt_out (may be 0). */
+  /* shared shape test for both instnum fast-path modes: plain BUILDLIST, and instnum_val used in the
+   * output only as a top-level pass-through column. Sets *passthrough_cnt_out (may be 0). */
   static bool
   instnum_xasl_shape_ok (XASL_NODE *x, int *passthrough_cnt_out)
   {
@@ -203,9 +202,7 @@ namespace parallel_scan
     return true;
   }
 
-  /* true only when inst_num() is a plain pass-through output column that main can renumber at merge.
-   * inst_num() used in WHERE is represented as instnum_pred (required NULL here), so no separate
-   * predicate walk is needed. */
+  /* inst_num() is a plain pass-through output column that main can renumber at merge. */
   static bool
   is_renumberable_instnum (XASL_NODE *x)
   {
@@ -217,8 +214,7 @@ namespace parallel_scan
     return instnum_xasl_shape_ok (x, &passthrough) && passthrough >= 1;
   }
 
-  /* true when the instnum_pred is a single-term "inst_num() <= ?" upper limit: workers can then draw
-   * global row numbers from a shared atomic counter, evaluate the limit locally, and stop early. */
+  /* single-term "inst_num() <= ?": workers can draw numbers from a shared counter and stop early. */
   static bool
   is_atomic_instnum_eligible (XASL_NODE *x)
   {
@@ -987,11 +983,8 @@ namespace parallel_scan
 	    || XASL_IS_FLAGED (arg, XASL_ANALYTIC_SKIP_SORT)
 	    || XASL_IS_FLAGED (arg, XASL_ANALYTIC_USES_LIMIT_OPT);
 
-    /* Atomic-draw ROWNUM keeps an arbitrary N rows, which is fine on a heap (no scan order to begin
-     * with) but not on a materialized temp list: "WITH q AS (... ORDER BY c) SELECT * FROM q LIMIT n"
-     * is the usual top-N idiom and a serial list scan returned the sorted prefix. Keep list specs
-     * serial whenever an instnum_pred is present. Merge-time renumbering (output ROWNUM only, which
-     * requires instnum_pred == NULL) does not change which rows are returned, so it is unaffected. */
+    /* atomic draw keeps an arbitrary N rows: fine on a heap, but a temp list is usually a sorted
+     * top-N idiom, so keep list specs serial. Renumbering (instnum_pred == NULL) is unaffected. */
     const bool block_list_spec = (arg->instnum_pred != nullptr);
 
     const bool block_all_specs = XASL_IS_FLAGED (arg, XASL_SKIP_ORDERBY_LIST);

--- a/src/query/parallel/px_scan/px_scan_checker.cpp
+++ b/src/query/parallel/px_scan/px_scan_checker.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "px_scan_checker.hpp"
+#include "px_scan_instnum.hpp"
 
 #include "dbtype_def.h"
 #include "error_manager.h"
@@ -93,137 +94,6 @@ namespace parallel_scan
     return (flags & flag) != 0;
   }
 
-  /* returns true if any TYPE_CONSTANT regu var in this subtree points at iv (the inst_num() value). */
-  static bool regu_subtree_refs_instnum (REGU_VARIABLE *r, DB_VALUE *iv);
-
-  static bool
-  regu_var_list_refs_instnum (struct regu_variable_list_node *list, DB_VALUE *iv)
-  {
-    for (struct regu_variable_list_node *n = list; n != nullptr; n = n->next)
-      {
-	if (regu_subtree_refs_instnum (&n->value, iv))
-	  {
-	    return true;
-	  }
-      }
-    return false;
-  }
-
-  static bool
-  regu_subtree_refs_instnum (REGU_VARIABLE *r, DB_VALUE *iv)
-  {
-    if (r == nullptr)
-      {
-	return false;
-      }
-    switch (r->type)
-      {
-      case TYPE_CONSTANT:
-	return r->value.dbvalptr == iv;
-      case TYPE_INARITH:
-      case TYPE_OUTARITH:
-      {
-	ARITH_TYPE *a = r->value.arithptr;
-	if (a == nullptr)
-	  {
-	    return false;
-	  }
-	return regu_subtree_refs_instnum (a->leftptr, iv) || regu_subtree_refs_instnum (a->rightptr, iv)
-	       || regu_subtree_refs_instnum (a->thirdptr, iv);
-      }
-      case TYPE_FUNC:
-	return regu_var_list_refs_instnum (r->value.funcp->operand, iv);
-      case TYPE_SP:
-	return regu_var_list_refs_instnum (r->value.sp_ptr->args, iv);
-      case TYPE_REGU_VAR_LIST:
-	return regu_var_list_refs_instnum (r->value.regu_var_list, iv);
-      case TYPE_ATTR_ID:
-      case TYPE_SHARED_ATTR_ID:
-      case TYPE_CLASS_ATTR_ID:
-      case TYPE_OID:
-      case TYPE_DBVAL:
-      case TYPE_POSITION:
-      case TYPE_POS_VALUE:
-      case TYPE_LIST_ID:
-      case TYPE_ORDERBY_NUM:
-      case TYPE_CLASSOID:
-      case TYPE_REGUVAL_LIST:
-	return false;
-      default:
-	/* unknown container: conservatively assume it may reference instnum -> block. */
-	return true;
-      }
-  }
-
-  /* shared precondition for both instnum fast-path modes: instnum_val appears in the output only as a
-   * top-level pass-through column. Sets *passthrough_cnt_out (may be 0). */
-  static bool
-  is_plain_instnum_buildlist (XASL_NODE *x, int *passthrough_cnt_out)
-  {
-    if (x == nullptr || x->instnum_val == nullptr || x->save_instnum_val != nullptr)
-      {
-	return false;
-      }
-    if (x->ordbynum_pred != nullptr || x->ordbynum_val != nullptr)
-      {
-	return false;		/* ORDER BY + LIMIT/topn: parallel topn destroys scan-order ROWNUM. */
-      }
-    if (x->type != BUILDLIST_PROC)
-      {
-	return false;
-      }
-    if (x->proc.buildlist.groupby_list != nullptr || x->proc.buildlist.g_agg_list != nullptr
-	|| x->proc.buildlist.a_eval_list != nullptr)
-      {
-	return false;		/* GROUP BY / aggregate / analytic: out of scope. */
-      }
-    if (x->outptr_list == nullptr)
-      {
-	return false;
-      }
-    int passthrough = 0;
-    for (struct regu_variable_list_node *v = x->outptr_list->valptrp; v != nullptr; v = v->next)
-      {
-	REGU_VARIABLE *r = &v->value;
-	if (r->type == TYPE_CONSTANT && r->value.dbvalptr == x->instnum_val)
-	  {
-	    passthrough++;
-	    continue;
-	  }
-	if (regu_subtree_refs_instnum (r, x->instnum_val))
-	  {
-	    return false;	/* nested use, e.g. ROWNUM + 1. */
-	  }
-      }
-    if (passthrough_cnt_out != nullptr)
-      {
-	*passthrough_cnt_out = passthrough;
-      }
-    return true;
-  }
-
-  /* inst_num() is a plain pass-through output column that main can renumber at merge. */
-  static bool
-  is_renumberable_instnum (XASL_NODE *x)
-  {
-    int passthrough = 0;
-    if (x == nullptr || x->instnum_pred != nullptr)
-      {
-	return false;
-      }
-    return is_plain_instnum_buildlist (x, &passthrough) && passthrough >= 1;
-  }
-
-  /* single-term "inst_num() <= ?": workers can draw numbers from a shared counter and stop early. */
-  static bool
-  is_atomic_instnum_eligible (XASL_NODE *x)
-  {
-    if (get_instnum_upper_limit_rhs (x, nullptr) == nullptr)
-      {
-	return false;
-      }
-    return is_plain_instnum_buildlist (x, nullptr);
-  }
 
   using rv_list_node = struct regu_variable_list_node;
 

--- a/src/query/parallel/px_scan/px_scan_checker.cpp
+++ b/src/query/parallel/px_scan/px_scan_checker.cpp
@@ -155,17 +155,13 @@ namespace parallel_scan
       }
   }
 
-  /* true only when inst_num() is a plain pass-through output column that main can renumber at merge.
-   * inst_num() used in WHERE is represented as instnum_pred (required NULL here), so no separate
-   * predicate walk is needed. */
+  /* shared shape conditions for both instnum fast-path modes (merge-time renumbering and atomic draw):
+   * plain BUILDLIST without sort/group interactions, and instnum_val referenced in the output only as a
+   * top-level pass-through column (never inside an expression). Sets *passthrough_cnt_out (may be 0). */
   static bool
-  is_renumberable_instnum (XASL_NODE *x)
+  instnum_xasl_shape_ok (XASL_NODE *x, int *passthrough_cnt_out)
   {
-    if (x == nullptr || x->instnum_val == nullptr)
-      {
-	return false;
-      }
-    if (x->instnum_pred != nullptr || x->save_instnum_val != nullptr)
+    if (x == nullptr || x->instnum_val == nullptr || x->save_instnum_val != nullptr)
       {
 	return false;
       }
@@ -180,7 +176,7 @@ namespace parallel_scan
     if (x->proc.buildlist.groupby_list != nullptr || x->proc.buildlist.g_agg_list != nullptr
 	|| x->proc.buildlist.a_eval_list != nullptr)
       {
-	return false;		/* GROUP BY / aggregate / analytic: out of MVP scope. */
+	return false;		/* GROUP BY / aggregate / analytic: out of scope. */
       }
     if (x->outptr_list == nullptr)
       {
@@ -200,7 +196,37 @@ namespace parallel_scan
 	    return false;	/* nested use, e.g. ROWNUM + 1. */
 	  }
       }
-    return passthrough >= 1;
+    if (passthrough_cnt_out != nullptr)
+      {
+	*passthrough_cnt_out = passthrough;
+      }
+    return true;
+  }
+
+  /* true only when inst_num() is a plain pass-through output column that main can renumber at merge.
+   * inst_num() used in WHERE is represented as instnum_pred (required NULL here), so no separate
+   * predicate walk is needed. */
+  static bool
+  is_renumberable_instnum (XASL_NODE *x)
+  {
+    int passthrough = 0;
+    if (x == nullptr || x->instnum_pred != nullptr)
+      {
+	return false;
+      }
+    return instnum_xasl_shape_ok (x, &passthrough) && passthrough >= 1;
+  }
+
+  /* true when the instnum_pred is a single-term "inst_num() <= ?" upper limit: workers can then draw
+   * global row numbers from a shared atomic counter, evaluate the limit locally, and stop early. */
+  static bool
+  is_atomic_instnum_eligible (XASL_NODE *x)
+  {
+    if (get_instnum_upper_limit_rhs (x, nullptr) == nullptr)
+      {
+	return false;
+      }
+    return instnum_xasl_shape_ok (x, nullptr);
   }
 
   using rv_list_node = struct regu_variable_list_node;
@@ -631,7 +657,8 @@ namespace parallel_scan
 	  }
       }
 
-    if ((sibling->instnum_pred || sibling->instnum_val) && !is_renumberable_instnum (sibling))
+    if ((sibling->instnum_pred || sibling->instnum_val) && !is_renumberable_instnum (sibling)
+	&& !is_atomic_instnum_eligible (sibling))
       {
 	set_flag (result, CANNOT_LIST_MERGE);
       }
@@ -815,7 +842,7 @@ namespace parallel_scan
     if (arg->instnum_pred || arg->instnum_val)
       {
 	buildvalue_opt = false;
-	if (!is_renumberable_instnum (arg))
+	if (!is_renumberable_instnum (arg) && !is_atomic_instnum_eligible (arg))
 	  {
 	    set_flag (result, CANNOT_LIST_MERGE);
 	  }

--- a/src/query/parallel/px_scan/px_scan_checker.cpp
+++ b/src/query/parallel/px_scan/px_scan_checker.cpp
@@ -93,6 +93,116 @@ namespace parallel_scan
     return (flags & flag) != 0;
   }
 
+  /* returns true if any TYPE_CONSTANT regu var in this subtree points at iv (the inst_num() value). */
+  static bool regu_subtree_refs_instnum (REGU_VARIABLE *r, DB_VALUE *iv);
+
+  static bool
+  regu_var_list_refs_instnum (struct regu_variable_list_node *list, DB_VALUE *iv)
+  {
+    for (struct regu_variable_list_node *n = list; n != nullptr; n = n->next)
+      {
+	if (regu_subtree_refs_instnum (&n->value, iv))
+	  {
+	    return true;
+	  }
+      }
+    return false;
+  }
+
+  static bool
+  regu_subtree_refs_instnum (REGU_VARIABLE *r, DB_VALUE *iv)
+  {
+    if (r == nullptr)
+      {
+	return false;
+      }
+    switch (r->type)
+      {
+      case TYPE_CONSTANT:
+	return r->value.dbvalptr == iv;
+      case TYPE_INARITH:
+      case TYPE_OUTARITH:
+	{
+	  ARITH_TYPE *a = r->value.arithptr;
+	  if (a == nullptr)
+	    {
+	      return false;
+	    }
+	  return regu_subtree_refs_instnum (a->leftptr, iv) || regu_subtree_refs_instnum (a->rightptr, iv)
+		 || regu_subtree_refs_instnum (a->thirdptr, iv);
+	}
+      case TYPE_FUNC:
+	return regu_var_list_refs_instnum (r->value.funcp->operand, iv);
+      case TYPE_SP:
+	return regu_var_list_refs_instnum (r->value.sp_ptr->args, iv);
+      case TYPE_REGU_VAR_LIST:
+	return regu_var_list_refs_instnum (r->value.regu_var_list, iv);
+      case TYPE_ATTR_ID:
+      case TYPE_SHARED_ATTR_ID:
+      case TYPE_CLASS_ATTR_ID:
+      case TYPE_OID:
+      case TYPE_DBVAL:
+      case TYPE_POSITION:
+      case TYPE_POS_VALUE:
+      case TYPE_LIST_ID:
+      case TYPE_ORDERBY_NUM:
+      case TYPE_CLASSOID:
+      case TYPE_REGUVAL_LIST:
+	return false;
+      default:
+	/* unknown container: conservatively assume it may reference instnum -> block. */
+	return true;
+      }
+  }
+
+  /* true only when inst_num() is a plain pass-through output column that main can renumber at merge.
+   * inst_num() used in WHERE is represented as instnum_pred (required NULL here), so no separate
+   * predicate walk is needed. */
+  static bool
+  is_renumberable_instnum (XASL_NODE *x)
+  {
+    if (x == nullptr || x->instnum_val == nullptr)
+      {
+	return false;
+      }
+    if (x->instnum_pred != nullptr || x->save_instnum_val != nullptr)
+      {
+	return false;
+      }
+    if (x->ordbynum_pred != nullptr || x->ordbynum_val != nullptr)
+      {
+	return false;		/* ORDER BY + LIMIT/topn: parallel topn destroys scan-order ROWNUM. */
+      }
+    if (x->type != BUILDLIST_PROC)
+      {
+	return false;
+      }
+    if (x->proc.buildlist.groupby_list != nullptr || x->proc.buildlist.g_agg_list != nullptr
+	|| x->proc.buildlist.a_eval_list != nullptr)
+      {
+	return false;		/* GROUP BY / aggregate / analytic: out of MVP scope. */
+      }
+    if (x->outptr_list == nullptr)
+      {
+	return false;
+      }
+    int passthrough = 0;
+    for (struct regu_variable_list_node *v = x->outptr_list->valptrp; v != nullptr; v = v->next)
+      {
+	REGU_VARIABLE *r = &v->value;
+	if (r->type == TYPE_CONSTANT && r->value.dbvalptr == x->instnum_val)
+	  {
+	    passthrough++;
+	    continue;
+	  }
+	if (regu_subtree_refs_instnum (r, x->instnum_val))
+	  {
+	    return false;	/* nested use, e.g. ROWNUM + 1. */
+	  }
+      }
+    return passthrough >= 1;
+  }
+
   using rv_list_node = struct regu_variable_list_node;
 
   /* prototypes */
@@ -521,7 +631,7 @@ namespace parallel_scan
 	  }
       }
 
-    if (sibling->instnum_pred || sibling->instnum_val)
+    if ((sibling->instnum_pred || sibling->instnum_val) && !is_renumberable_instnum (sibling))
       {
 	set_flag (result, CANNOT_LIST_MERGE);
       }
@@ -704,8 +814,11 @@ namespace parallel_scan
 
     if (arg->instnum_pred || arg->instnum_val)
       {
-	set_flag (result, CANNOT_LIST_MERGE);
 	buildvalue_opt = false;
+	if (!is_renumberable_instnum (arg))
+	  {
+	    set_flag (result, CANNOT_LIST_MERGE);
+	  }
       }
 
     if (arg->outptr_list)
@@ -843,7 +956,7 @@ namespace parallel_scan
     result |= check<false> (arg);
 
     const bool block_index_spec =
-	    (arg->instnum_pred || arg->instnum_val)
+	    ((arg->instnum_pred || arg->instnum_val) && !is_renumberable_instnum (arg))
 	    || XASL_IS_FLAGED (arg, XASL_ANALYTIC_SKIP_SORT)
 	    || XASL_IS_FLAGED (arg, XASL_ANALYTIC_USES_LIMIT_OPT);
 

--- a/src/query/parallel/px_scan/px_scan_checker.cpp
+++ b/src/query/parallel/px_scan/px_scan_checker.cpp
@@ -987,6 +987,13 @@ namespace parallel_scan
 	    || XASL_IS_FLAGED (arg, XASL_ANALYTIC_SKIP_SORT)
 	    || XASL_IS_FLAGED (arg, XASL_ANALYTIC_USES_LIMIT_OPT);
 
+    /* Atomic-draw ROWNUM keeps an arbitrary N rows, which is fine on a heap (no scan order to begin
+     * with) but not on a materialized temp list: "WITH q AS (... ORDER BY c) SELECT * FROM q LIMIT n"
+     * is the usual top-N idiom and a serial list scan returned the sorted prefix. Keep list specs
+     * serial whenever an instnum_pred is present. Merge-time renumbering (output ROWNUM only, which
+     * requires instnum_pred == NULL) does not change which rows are returned, so it is unaffected. */
+    const bool block_list_spec = (arg->instnum_pred != nullptr);
+
     const bool block_all_specs = XASL_IS_FLAGED (arg, XASL_SKIP_ORDERBY_LIST);
 
     if (is_flag_set (result, CANNOT_PARALLEL_SCAN) || block_all_specs)
@@ -998,11 +1005,15 @@ namespace parallel_scan
       }
     else
       {
-	if (block_index_spec)
+	if (block_index_spec || block_list_spec)
 	  {
 	    for (ACCESS_SPEC_TYPE *specp = arg->spec_list; specp; specp = specp->next)
 	      {
-		if (specp->type == TARGET_CLASS && specp->access == ACCESS_METHOD_INDEX)
+		if (block_index_spec && specp->type == TARGET_CLASS && specp->access == ACCESS_METHOD_INDEX)
+		  {
+		    ACCESS_SPEC_SET_FLAG (specp, ACCESS_SPEC_FLAG_NO_PARALLEL_SCAN);
+		  }
+		if (block_list_spec && specp->type == TARGET_LIST)
 		  {
 		    ACCESS_SPEC_SET_FLAG (specp, ACCESS_SPEC_FLAG_NO_PARALLEL_SCAN);
 		  }

--- a/src/query/parallel/px_scan/px_scan_checker.cpp
+++ b/src/query/parallel/px_scan/px_scan_checker.cpp
@@ -122,15 +122,15 @@ namespace parallel_scan
 	return r->value.dbvalptr == iv;
       case TYPE_INARITH:
       case TYPE_OUTARITH:
-	{
-	  ARITH_TYPE *a = r->value.arithptr;
-	  if (a == nullptr)
-	    {
-	      return false;
-	    }
-	  return regu_subtree_refs_instnum (a->leftptr, iv) || regu_subtree_refs_instnum (a->rightptr, iv)
-		 || regu_subtree_refs_instnum (a->thirdptr, iv);
-	}
+      {
+	ARITH_TYPE *a = r->value.arithptr;
+	if (a == nullptr)
+	  {
+	    return false;
+	  }
+	return regu_subtree_refs_instnum (a->leftptr, iv) || regu_subtree_refs_instnum (a->rightptr, iv)
+	       || regu_subtree_refs_instnum (a->thirdptr, iv);
+      }
       case TYPE_FUNC:
 	return regu_var_list_refs_instnum (r->value.funcp->operand, iv);
       case TYPE_SP:

--- a/src/query/parallel/px_scan/px_scan_checker.cpp
+++ b/src/query/parallel/px_scan/px_scan_checker.cpp
@@ -155,10 +155,10 @@ namespace parallel_scan
       }
   }
 
-  /* shared shape test for both instnum fast-path modes: plain BUILDLIST, and instnum_val used in the
-   * output only as a top-level pass-through column. Sets *passthrough_cnt_out (may be 0). */
+  /* shared precondition for both instnum fast-path modes: instnum_val appears in the output only as a
+   * top-level pass-through column. Sets *passthrough_cnt_out (may be 0). */
   static bool
-  instnum_xasl_shape_ok (XASL_NODE *x, int *passthrough_cnt_out)
+  is_plain_instnum_buildlist (XASL_NODE *x, int *passthrough_cnt_out)
   {
     if (x == nullptr || x->instnum_val == nullptr || x->save_instnum_val != nullptr)
       {
@@ -211,7 +211,7 @@ namespace parallel_scan
       {
 	return false;
       }
-    return instnum_xasl_shape_ok (x, &passthrough) && passthrough >= 1;
+    return is_plain_instnum_buildlist (x, &passthrough) && passthrough >= 1;
   }
 
   /* single-term "inst_num() <= ?": workers can draw numbers from a shared counter and stop early. */
@@ -222,7 +222,7 @@ namespace parallel_scan
       {
 	return false;
       }
-    return instnum_xasl_shape_ok (x, nullptr);
+    return is_plain_instnum_buildlist (x, nullptr);
   }
 
   using rv_list_node = struct regu_variable_list_node;

--- a/src/query/parallel/px_scan/px_scan_checker.hpp
+++ b/src/query/parallel/px_scan/px_scan_checker.hpp
@@ -22,55 +22,8 @@
 
 #ifndef _PX_SCAN_CHECKER_HPP_
 #define _PX_SCAN_CHECKER_HPP_
-#include "regu_var.hpp"
 #include "xasl.h"
-#include "xasl_predicate.hpp"
 
 extern "C" int scan_check_parallel_scan_possible (XASL_NODE *xasl);
-
-namespace parallel_scan
-{
-  /* rhs of a single-term "inst_num() <= ?" (or "< ?") instnum_pred, else nullptr. Inline because the
-   * checker TU links into cs/sa only, while the server-side result handler needs the same test. */
-  inline REGU_VARIABLE *
-  get_instnum_upper_limit_rhs (XASL_NODE *x, bool *is_less_than)
-  {
-    if (x == nullptr || x->instnum_pred == nullptr || x->instnum_val == nullptr)
-      {
-	return nullptr;
-      }
-    if (x->instnum_flag & XASL_INSTNUM_FLAG_SCAN_CONTINUE)
-      {
-	return nullptr;		/* pred cannot stop the scan (e.g. OR-term) -> not an upper-limit form */
-      }
-    PRED_EXPR *pr = x->instnum_pred;
-    if (pr->type != T_EVAL_TERM || pr->pe.m_eval_term.et_type != T_COMP_EVAL_TERM)
-      {
-	return nullptr;
-      }
-    COMP_EVAL_TERM *comp = &pr->pe.m_eval_term.et.et_comp;
-    if (comp->lhs == nullptr || comp->rhs == nullptr)
-      {
-	return nullptr;
-      }
-    if (comp->lhs->type != TYPE_CONSTANT || comp->lhs->value.dbvalptr != x->instnum_val)
-      {
-	return nullptr;
-      }
-    if (comp->rhs->type != TYPE_POS_VALUE && comp->rhs->type != TYPE_DBVAL)
-      {
-	return nullptr;
-      }
-    if (comp->rel_op != R_LE && comp->rel_op != R_LT)
-      {
-	return nullptr;
-      }
-    if (is_less_than != nullptr)
-      {
-	*is_less_than = (comp->rel_op == R_LT);
-      }
-    return comp->rhs;
-  }
-}
 
 #endif /*_PX_SCAN_CHECKER_HPP_ */

--- a/src/query/parallel/px_scan/px_scan_checker.hpp
+++ b/src/query/parallel/px_scan/px_scan_checker.hpp
@@ -22,8 +22,57 @@
 
 #ifndef _PX_SCAN_CHECKER_HPP_
 #define _PX_SCAN_CHECKER_HPP_
+#include "regu_var.hpp"
 #include "xasl.h"
+#include "xasl_predicate.hpp"
 
 extern "C" int scan_check_parallel_scan_possible (XASL_NODE *xasl);
+
+namespace parallel_scan
+{
+  /* Returns the rhs regu var of a single-term "inst_num() <= ?" (or "< ?") instnum_pred, or nullptr
+   * when the predicate does not have that exact shape. Shared by the checker (client side, eligibility)
+   * and the mergeable-list result handler (server side, atomic-draw limit resolution) so both sides
+   * agree; defined inline here because the checker translation unit is linked into cs/sa only. */
+  inline REGU_VARIABLE *
+  get_instnum_upper_limit_rhs (XASL_NODE *x, bool *is_less_than)
+  {
+    if (x == nullptr || x->instnum_pred == nullptr || x->instnum_val == nullptr)
+      {
+	return nullptr;
+      }
+    if (x->instnum_flag & XASL_INSTNUM_FLAG_SCAN_CONTINUE)
+      {
+	return nullptr;		/* pred cannot stop the scan (e.g. OR-term) -> not an upper-limit form */
+      }
+    PRED_EXPR *pr = x->instnum_pred;
+    if (pr->type != T_EVAL_TERM || pr->pe.m_eval_term.et_type != T_COMP_EVAL_TERM)
+      {
+	return nullptr;
+      }
+    COMP_EVAL_TERM *comp = &pr->pe.m_eval_term.et.et_comp;
+    if (comp->lhs == nullptr || comp->rhs == nullptr)
+      {
+	return nullptr;
+      }
+    if (comp->lhs->type != TYPE_CONSTANT || comp->lhs->value.dbvalptr != x->instnum_val)
+      {
+	return nullptr;
+      }
+    if (comp->rhs->type != TYPE_POS_VALUE && comp->rhs->type != TYPE_DBVAL)
+      {
+	return nullptr;
+      }
+    if (comp->rel_op != R_LE && comp->rel_op != R_LT)
+      {
+	return nullptr;
+      }
+    if (is_less_than != nullptr)
+      {
+	*is_less_than = (comp->rel_op == R_LT);
+      }
+    return comp->rhs;
+  }
+}
 
 #endif /*_PX_SCAN_CHECKER_HPP_ */

--- a/src/query/parallel/px_scan/px_scan_checker.hpp
+++ b/src/query/parallel/px_scan/px_scan_checker.hpp
@@ -30,10 +30,8 @@ extern "C" int scan_check_parallel_scan_possible (XASL_NODE *xasl);
 
 namespace parallel_scan
 {
-  /* Returns the rhs regu var of a single-term "inst_num() <= ?" (or "< ?") instnum_pred, or nullptr
-   * when the predicate does not have that exact shape. Shared by the checker (client side, eligibility)
-   * and the mergeable-list result handler (server side, atomic-draw limit resolution) so both sides
-   * agree; defined inline here because the checker translation unit is linked into cs/sa only. */
+  /* rhs of a single-term "inst_num() <= ?" (or "< ?") instnum_pred, else nullptr. Inline because the
+   * checker TU links into cs/sa only, while the server-side result handler needs the same test. */
   inline REGU_VARIABLE *
   get_instnum_upper_limit_rhs (XASL_NODE *x, bool *is_less_than)
   {

--- a/src/query/parallel/px_scan/px_scan_instnum.cpp
+++ b/src/query/parallel/px_scan/px_scan_instnum.cpp
@@ -223,9 +223,10 @@ namespace parallel_scan
   {
     instnum_mode mode = instnum_mode::NONE;
 
-    /* collect pass-through ROWNUM output columns; index == position in the outptr valptr list. */
-    if (x->instnum_val != nullptr && x->instnum_pred == nullptr && x->save_instnum_val == nullptr
-	&& x->outptr_list != nullptr)
+    /* Pass-through ROWNUM output columns; index == position in the outptr valptr list. Both modes
+     * need them: RENUMBER never numbers them during the scan, and ATOMIC_DRAW numbers them with
+     * whatever each worker drew, which is not the position the row lands in after the merge. */
+    if (x->instnum_val != nullptr && x->save_instnum_val == nullptr && x->outptr_list != nullptr)
       {
 	int idx = 0;
 	for (regu_variable_list_node *v = x->outptr_list->valptrp; v != nullptr; v = v->next, idx++)
@@ -235,20 +236,18 @@ namespace parallel_scan
 		rownum_col_indices.push_back (idx);
 	      }
 	  }
-	if (!rownum_col_indices.empty ())
-	  {
-	    mode = instnum_mode::RENUMBER;
-	  }
       }
 
     /* the limit itself is resolved later, once a VAL_DESCR is available. */
     draw.limit_rhs = get_instnum_upper_limit_rhs (x, &draw.is_less_than);
     if (draw.limit_rhs != nullptr)
       {
-	/* RENUMBER requires instnum_pred == NULL, so the two modes cannot both apply. */
-	assert (mode != instnum_mode::RENUMBER);
 	mode = instnum_mode::ATOMIC_DRAW;
 	draw.seed (x->list_id != nullptr ? (INT64) x->list_id->tuple_cnt : 0);
+      }
+    else if (x->instnum_pred == nullptr && !rownum_col_indices.empty ())
+      {
+	mode = instnum_mode::RENUMBER;
       }
     return mode;
   }

--- a/src/query/parallel/px_scan/px_scan_instnum.cpp
+++ b/src/query/parallel/px_scan/px_scan_instnum.cpp
@@ -1,0 +1,298 @@
+/*
+ *
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+/*
+ * px_scan_instnum.cpp - ROWNUM (inst_num) under parallel scan.
+ *
+ * Two halves, split by build mode rather than by file: eligibility runs while the XASL is built
+ * (client), numbering runs while the scan executes (server). The server half reaches into the
+ * query engine (qfile_*, fetch_peek_dbval), which the client library does not link.
+ */
+
+#include "px_scan_instnum.hpp"
+
+#include "regu_var.hpp"
+#include "xasl.h"
+
+#if defined (SERVER_MODE) || defined (SA_MODE)
+#include "dbtype.h"
+#include "error_manager.h"
+#include "fetch.h"
+#include "list_file.h"
+#include "object_domain.h"
+#include "object_primitive.h"
+#endif /* SERVER_MODE || SA_MODE */
+
+// XXX: SHOULD BE THE LAST INCLUDE HEADER
+#include "memory_wrapper.hpp"
+
+namespace parallel_scan
+{
+#if !defined (SERVER_MODE)
+  /* returns true if any TYPE_CONSTANT regu var in this subtree points at iv (the inst_num() value). */
+  static bool regu_subtree_refs_instnum (REGU_VARIABLE *r, DB_VALUE *iv);
+
+  static bool
+  regu_var_list_refs_instnum (struct regu_variable_list_node *list, DB_VALUE *iv)
+  {
+    for (struct regu_variable_list_node *n = list; n != nullptr; n = n->next)
+      {
+	if (regu_subtree_refs_instnum (&n->value, iv))
+	  {
+	    return true;
+	  }
+      }
+    return false;
+  }
+
+  static bool
+  regu_subtree_refs_instnum (REGU_VARIABLE *r, DB_VALUE *iv)
+  {
+    if (r == nullptr)
+      {
+	return false;
+      }
+    switch (r->type)
+      {
+      case TYPE_CONSTANT:
+	return r->value.dbvalptr == iv;
+      case TYPE_INARITH:
+      case TYPE_OUTARITH:
+      {
+	ARITH_TYPE *a = r->value.arithptr;
+	if (a == nullptr)
+	  {
+	    return false;
+	  }
+	return regu_subtree_refs_instnum (a->leftptr, iv) || regu_subtree_refs_instnum (a->rightptr, iv)
+	       || regu_subtree_refs_instnum (a->thirdptr, iv);
+      }
+      case TYPE_FUNC:
+	return regu_var_list_refs_instnum (r->value.funcp->operand, iv);
+      case TYPE_SP:
+	return regu_var_list_refs_instnum (r->value.sp_ptr->args, iv);
+      case TYPE_REGU_VAR_LIST:
+	return regu_var_list_refs_instnum (r->value.regu_var_list, iv);
+      case TYPE_ATTR_ID:
+      case TYPE_SHARED_ATTR_ID:
+      case TYPE_CLASS_ATTR_ID:
+      case TYPE_OID:
+      case TYPE_DBVAL:
+      case TYPE_POSITION:
+      case TYPE_POS_VALUE:
+      case TYPE_LIST_ID:
+      case TYPE_ORDERBY_NUM:
+      case TYPE_CLASSOID:
+      case TYPE_REGUVAL_LIST:
+	return false;
+      default:
+	/* unknown container: conservatively assume it may reference instnum -> block. */
+	return true;
+      }
+  }
+
+  /* shared precondition for both instnum fast-path modes: instnum_val appears in the output only as a
+   * top-level pass-through column. Sets *passthrough_cnt_out (may be 0). */
+  static bool
+  is_plain_instnum_buildlist (XASL_NODE *x, int *passthrough_cnt_out)
+  {
+    if (x == nullptr || x->instnum_val == nullptr || x->save_instnum_val != nullptr)
+      {
+	return false;
+      }
+    if (x->ordbynum_pred != nullptr || x->ordbynum_val != nullptr)
+      {
+	return false;		/* ORDER BY + LIMIT/topn: parallel topn destroys scan-order ROWNUM. */
+      }
+    if (x->type != BUILDLIST_PROC)
+      {
+	return false;
+      }
+    if (x->proc.buildlist.groupby_list != nullptr || x->proc.buildlist.g_agg_list != nullptr
+	|| x->proc.buildlist.a_eval_list != nullptr)
+      {
+	return false;		/* GROUP BY / aggregate / analytic: out of scope. */
+      }
+    if (x->outptr_list == nullptr)
+      {
+	return false;
+      }
+    int passthrough = 0;
+    for (struct regu_variable_list_node *v = x->outptr_list->valptrp; v != nullptr; v = v->next)
+      {
+	REGU_VARIABLE *r = &v->value;
+	if (r->type == TYPE_CONSTANT && r->value.dbvalptr == x->instnum_val)
+	  {
+	    passthrough++;
+	    continue;
+	  }
+	if (regu_subtree_refs_instnum (r, x->instnum_val))
+	  {
+	    return false;	/* nested use, e.g. ROWNUM + 1. */
+	  }
+      }
+    if (passthrough_cnt_out != nullptr)
+      {
+	*passthrough_cnt_out = passthrough;
+      }
+    return true;
+  }
+
+  /* inst_num() is a plain pass-through output column that main can renumber at merge. */
+  bool
+  is_renumberable_instnum (XASL_NODE *x)
+  {
+    int passthrough = 0;
+    if (x == nullptr || x->instnum_pred != nullptr)
+      {
+	return false;
+      }
+    return is_plain_instnum_buildlist (x, &passthrough) && passthrough >= 1;
+  }
+
+  /* single-term "inst_num() <= ?": workers can draw numbers from a shared counter and stop early. */
+  bool
+  is_atomic_instnum_eligible (XASL_NODE *x)
+  {
+    if (get_instnum_upper_limit_rhs (x, nullptr) == nullptr)
+      {
+	return false;
+      }
+    return is_plain_instnum_buildlist (x, nullptr);
+  }
+#endif /* !SERVER_MODE */
+
+#if defined (SERVER_MODE) || defined (SA_MODE)
+  instnum_mode
+  detect_instnum_mode (XASL_NODE *x, std::vector<int> &rownum_col_indices, atomic_instnum &draw)
+  {
+    instnum_mode mode = instnum_mode::NONE;
+
+    /* collect pass-through ROWNUM output columns; index == position in the outptr valptr list. */
+    if (x->instnum_val != nullptr && x->instnum_pred == nullptr && x->save_instnum_val == nullptr
+	&& x->outptr_list != nullptr)
+      {
+	int idx = 0;
+	for (regu_variable_list_node *v = x->outptr_list->valptrp; v != nullptr; v = v->next, idx++)
+	  {
+	    if (v->value.type == TYPE_CONSTANT && v->value.value.dbvalptr == x->instnum_val)
+	      {
+		rownum_col_indices.push_back (idx);
+	      }
+	  }
+	if (!rownum_col_indices.empty ())
+	  {
+	    mode = instnum_mode::RENUMBER;
+	  }
+      }
+
+    /* the limit itself is resolved later, once a VAL_DESCR is available. */
+    draw.limit_rhs = get_instnum_upper_limit_rhs (x, &draw.is_less_than);
+    if (draw.limit_rhs != nullptr)
+      {
+	/* RENUMBER requires instnum_pred == NULL, so the two modes cannot both apply. */
+	assert (mode != instnum_mode::RENUMBER);
+	mode = instnum_mode::ATOMIC_DRAW;
+	draw.seed (x->list_id != nullptr ? (INT64) x->list_id->tuple_cnt : 0);
+      }
+    return mode;
+  }
+
+  int
+  resolve_instnum_limit (THREAD_ENTRY *thread_p, atomic_instnum &draw, VAL_DESCR *vd)
+  {
+    DB_VALUE *limit_val = nullptr;
+    INT64 raw_limit = 0;
+
+    if (fetch_peek_dbval (thread_p, draw.limit_rhs, vd, NULL, NULL, NULL, &limit_val) != NO_ERROR)
+      {
+	return ER_FAILED;
+      }
+    if (limit_val != nullptr && !DB_IS_NULL (limit_val))
+      {
+	DB_VALUE coerced;
+	TP_DOMAIN_STATUS dom_status;
+
+	db_make_null (&coerced);
+	dom_status = tp_value_coerce (limit_val, &coerced, &tp_Bigint_domain);
+	if (dom_status == DOMAIN_COMPATIBLE)
+	  {
+	    raw_limit = db_get_bigint (&coerced);
+	  }
+	else if (dom_status == DOMAIN_OVERFLOW && DB_VALUE_DOMAIN_TYPE (limit_val) == DB_TYPE_NUMERIC)
+	  {
+	    /* serial widens inst_num() rather than coercing the bound, so out of BIGINT range a
+	     * positive bound admits every row and a negative one none (cf. key-limit handling). */
+	    raw_limit = DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE (limit_val) ? 0 : DB_BIGINT_MAX;
+	    er_clear ();
+	  }
+	else
+	  {
+	    pr_clear_value (&coerced);
+	    (void) tp_domain_status_er_set (dom_status, ARG_FILE_LINE, limit_val, &tp_Bigint_domain);
+	    return ER_FAILED;
+	  }
+	pr_clear_value (&coerced);
+      }
+    /* NULL rhs keeps the limit 0: unknown for every row -> no rows, like serial. */
+    draw.resolve_limit (raw_limit);
+    return NO_ERROR;
+  }
+
+  int
+  renumber_instnum_lists (THREAD_ENTRY *thread_p, std::vector<QFILE_LIST_ID *> &lists,
+			  const std::vector<int> &col_indices, INT64 start_at)
+  {
+    DB_VALUE rownum_val;
+    INT64 counter = start_at;
+    for (QFILE_LIST_ID *list_id : lists)
+      {
+	if (list_id == nullptr || list_id->tuple_cnt <= 0)
+	  {
+	    continue;
+	  }
+	QFILE_LIST_SCAN_ID s_id;
+	if (qfile_open_list_scan (list_id, &s_id) != NO_ERROR)
+	  {
+	    return ER_FAILED;
+	  }
+	QFILE_TUPLE_RECORD tuple_rec = { NULL, 0 };
+	SCAN_CODE sc;
+	while ((sc = qfile_scan_list_next (thread_p, &s_id, &tuple_rec, PEEK)) == S_SUCCESS)
+	  {
+	    db_make_bigint (&rownum_val, ++counter);
+	    for (int col : col_indices)
+	      {
+		if (qfile_set_tuple_column_value (thread_p, list_id, s_id.curr_pgptr, &s_id.curr_vpid,
+						  tuple_rec.tpl, col, &rownum_val, &tp_Bigint_domain) != NO_ERROR)
+		  {
+		    qfile_close_scan (thread_p, &s_id);
+		    return ER_FAILED;
+		  }
+	      }
+	  }
+	qfile_close_scan (thread_p, &s_id);
+	if (sc == S_ERROR)
+	  {
+	    return ER_FAILED;
+	  }
+      }
+    return NO_ERROR;
+  }
+#endif /* SERVER_MODE || SA_MODE */
+}

--- a/src/query/parallel/px_scan/px_scan_instnum.cpp
+++ b/src/query/parallel/px_scan/px_scan_instnum.cpp
@@ -46,6 +46,7 @@ namespace parallel_scan
 #if !defined (SERVER_MODE)
   /* returns true if any TYPE_CONSTANT regu var in this subtree points at iv (the inst_num() value). */
   static bool regu_subtree_refs_instnum (REGU_VARIABLE *r, DB_VALUE *iv);
+  static bool pred_refs_instnum (PRED_EXPR *p, DB_VALUE *iv);
 
   static bool
   regu_var_list_refs_instnum (struct regu_variable_list_node *list, DB_VALUE *iv)
@@ -79,8 +80,9 @@ namespace parallel_scan
 	  {
 	    return false;
 	  }
+	/* T_CASE/T_DECODE/T_IF/T_PREDICATE keep their condition in a->pred, not in the operands. */
 	return regu_subtree_refs_instnum (a->leftptr, iv) || regu_subtree_refs_instnum (a->rightptr, iv)
-	       || regu_subtree_refs_instnum (a->thirdptr, iv);
+	       || regu_subtree_refs_instnum (a->thirdptr, iv) || pred_refs_instnum (a->pred, iv);
       }
       case TYPE_FUNC:
 	return regu_var_list_refs_instnum (r->value.funcp->operand, iv);
@@ -102,6 +104,44 @@ namespace parallel_scan
 	return false;
       default:
 	/* unknown container: conservatively assume it may reference instnum -> block. */
+	return true;
+      }
+  }
+
+  static bool
+  pred_refs_instnum (PRED_EXPR *p, DB_VALUE *iv)
+  {
+    if (p == nullptr)
+      {
+	return false;
+      }
+    switch (p->type)
+      {
+      case T_PRED:
+	return pred_refs_instnum (p->pe.m_pred.lhs, iv) || pred_refs_instnum (p->pe.m_pred.rhs, iv);
+      case T_NOT_TERM:
+	return pred_refs_instnum (p->pe.m_not_term, iv);
+      case T_EVAL_TERM:
+	switch (p->pe.m_eval_term.et_type)
+	  {
+	  case T_COMP_EVAL_TERM:
+	    return regu_subtree_refs_instnum (p->pe.m_eval_term.et.et_comp.lhs, iv)
+		   || regu_subtree_refs_instnum (p->pe.m_eval_term.et.et_comp.rhs, iv);
+	  case T_ALSM_EVAL_TERM:
+	    return regu_subtree_refs_instnum (p->pe.m_eval_term.et.et_alsm.elem, iv)
+		   || regu_subtree_refs_instnum (p->pe.m_eval_term.et.et_alsm.elemset, iv);
+	  case T_LIKE_EVAL_TERM:
+	    return regu_subtree_refs_instnum (p->pe.m_eval_term.et.et_like.src, iv)
+		   || regu_subtree_refs_instnum (p->pe.m_eval_term.et.et_like.pattern, iv)
+		   || regu_subtree_refs_instnum (p->pe.m_eval_term.et.et_like.esc_char, iv);
+	  case T_RLIKE_EVAL_TERM:
+	    return regu_subtree_refs_instnum (p->pe.m_eval_term.et.et_rlike.src, iv)
+		   || regu_subtree_refs_instnum (p->pe.m_eval_term.et.et_rlike.pattern, iv)
+		   || regu_subtree_refs_instnum (p->pe.m_eval_term.et.et_rlike.case_sensitive, iv);
+	  default:
+	    return true;	/* unknown term: conservatively block, like the regu default. */
+	  }
+      default:
 	return true;
       }
   }
@@ -233,6 +273,18 @@ namespace parallel_scan
 	if (dom_status == DOMAIN_COMPATIBLE)
 	  {
 	    raw_limit = db_get_bigint (&coerced);
+	    if (raw_limit > 0)
+	      {
+		/* The coercion rounds, so ask the comparison itself - the question serial asks every
+		 * row - whether the rounded candidate qualifies, and step down once if it does not.
+		 * Rounding lands within 1, so that candidate and its predecessor are the only two. */
+		DB_VALUE_COMPARE_RESULT cmp = tp_value_compare (&coerced, limit_val, 1, 0);
+		const bool qualifies = draw.is_less_than ? (cmp == DB_LT) : (cmp != DB_GT);
+		if (!qualifies)
+		  {
+		    raw_limit--;
+		  }
+	      }
 	  }
 	else if (dom_status == DOMAIN_OVERFLOW && DB_VALUE_DOMAIN_TYPE (limit_val) == DB_TYPE_NUMERIC)
 	  {

--- a/src/query/parallel/px_scan/px_scan_instnum.hpp
+++ b/src/query/parallel/px_scan/px_scan_instnum.hpp
@@ -1,0 +1,151 @@
+/*
+ *
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+/*
+ * px_scan_instnum.hpp - ROWNUM (inst_num) support for parallel scan.
+ *
+ * Header-only on purpose: the eligibility test runs client-side (px_scan_checker.cpp links into
+ * cs/sa only) while the numbering runs server-side, and a header has no link boundary.
+ */
+
+#ifndef _PX_SCAN_INSTNUM_HPP_
+#define _PX_SCAN_INSTNUM_HPP_
+
+#include <atomic>
+
+#include "regu_var.hpp"
+#include "xasl.h"
+#include "xasl_predicate.hpp"
+
+#if defined (SERVER_MODE) || defined (SA_MODE)
+#include <vector>
+#include "query_list.h"
+#include "thread_entry.hpp"
+#endif /* SERVER_MODE || SA_MODE */
+
+namespace parallel_scan
+{
+  /* Which mechanism assigns ROWNUM. The two are mutually exclusive: RENUMBER requires
+   * instnum_pred == NULL, ATOMIC_DRAW requires one. */
+  enum class instnum_mode
+  {
+    NONE,
+    RENUMBER,			/* ROWNUM is only projected -> main numbers the rows at merge */
+    ATOMIC_DRAW,		/* WHERE ROWNUM <= N -> workers draw from a shared counter */
+  };
+
+  /* rhs of a single-term "inst_num() <= ?" (or "< ?") instnum_pred, else nullptr. */
+  inline REGU_VARIABLE *
+  get_instnum_upper_limit_rhs (XASL_NODE *x, bool *is_less_than)
+  {
+    if (x == nullptr || x->instnum_pred == nullptr || x->instnum_val == nullptr)
+      {
+	return nullptr;
+      }
+    if (x->instnum_flag & XASL_INSTNUM_FLAG_SCAN_CONTINUE)
+      {
+	return nullptr;		/* pred cannot stop the scan (e.g. OR-term) -> not an upper-limit form */
+      }
+    PRED_EXPR *pr = x->instnum_pred;
+    if (pr->type != T_EVAL_TERM || pr->pe.m_eval_term.et_type != T_COMP_EVAL_TERM)
+      {
+	return nullptr;
+      }
+    COMP_EVAL_TERM *comp = &pr->pe.m_eval_term.et.et_comp;
+    if (comp->lhs == nullptr || comp->rhs == nullptr)
+      {
+	return nullptr;
+      }
+    if (comp->lhs->type != TYPE_CONSTANT || comp->lhs->value.dbvalptr != x->instnum_val)
+      {
+	return nullptr;
+      }
+    if (comp->rhs->type != TYPE_POS_VALUE && comp->rhs->type != TYPE_DBVAL)
+      {
+	return nullptr;
+      }
+    if (comp->rel_op != R_LE && comp->rel_op != R_LT)
+      {
+	return nullptr;
+      }
+    if (is_less_than != nullptr)
+      {
+	*is_less_than = (comp->rel_op == R_LT);
+      }
+    return comp->rhs;
+  }
+
+  /* Global numbering for ATOMIC_DRAW: every qualifying row takes the next number from one counter,
+   * so the quota is exact no matter how the workers interleave. */
+  class atomic_instnum
+  {
+    public:
+      bool is_less_than = false;
+      bool limit_resolved = false;
+      INT64 limit = 0;
+      REGU_VARIABLE *limit_rhs = nullptr;
+      std::atomic<INT64> counter {0};
+
+      /* A scan block reset rebuilds the handler while the output list keeps the rows already emitted;
+       * resume from there instead of granting the quota again per block. */
+      inline void seed (INT64 already_emitted) noexcept
+      {
+	counter.store (already_emitted);
+      }
+
+      /* Clamp before the decrement so BIGINT_MIN cannot wrap to BIGINT_MAX. */
+      inline void resolve_limit (INT64 raw) noexcept
+      {
+	limit = (raw <= 0) ? 0 : (is_less_than ? raw - 1 : raw);
+	limit_resolved = true;
+      }
+
+      inline INT64 next () noexcept
+      {
+	return counter.fetch_add (1, std::memory_order_relaxed) + 1;
+      }
+
+      inline bool exceeded (INT64 drawn) const noexcept
+      {
+	return drawn > limit;
+      }
+  };
+
+  /* Eligibility, decided while the XASL is built. The server never calls these. */
+#if !defined (SERVER_MODE)
+  bool is_renumberable_instnum (XASL_NODE *x);
+  bool is_atomic_instnum_eligible (XASL_NODE *x);
+#endif /* !SERVER_MODE */
+
+  /* Numbering, run while the scan executes. Guarded because these reach into the server query
+   * engine (qfile_*, fetch_peek_dbval), which the client library does not link. */
+#if defined (SERVER_MODE) || defined (SA_MODE)
+  /* Which mechanism this XASL needs; fills the out-params. */
+  instnum_mode detect_instnum_mode (XASL_NODE *x, std::vector<int> &rownum_col_indices, atomic_instnum &draw);
+
+  /* Resolves the "<= ?" bound into draw.limit. On failure the error is already raised via er_set. */
+  int resolve_instnum_limit (THREAD_ENTRY *thread_p, atomic_instnum &draw, VAL_DESCR *vd);
+
+  /* Assigns global ROWNUM in-place across the worker lists, before merge and before any ORDER BY
+   * sort. Continues from start_at: a scan block reset rebuilds the handler while dest keeps its rows. */
+  int renumber_instnum_lists (THREAD_ENTRY *thread_p, std::vector<QFILE_LIST_ID *> &lists,
+			      const std::vector<int> &col_indices, INT64 start_at);
+#endif /* SERVER_MODE || SA_MODE */
+}
+
+#endif /*_PX_SCAN_INSTNUM_HPP_ */

--- a/src/query/parallel/px_scan/px_scan_instnum.hpp
+++ b/src/query/parallel/px_scan/px_scan_instnum.hpp
@@ -19,21 +19,22 @@
 /*
  * px_scan_instnum.hpp - ROWNUM (inst_num) support for parallel scan.
  *
- * Header-only on purpose: the eligibility test runs client-side (px_scan_checker.cpp links into
- * cs/sa only) while the numbering runs server-side, and a header has no link boundary.
+ * Implementations live in px_scan_instnum.cpp, split there by build mode: eligibility runs
+ * client-side (px_scan_checker.cpp links into cs/sa only), numbering runs server-side.
+ * get_instnum_upper_limit_rhs stays inline here because both halves call it.
  */
 
 #ifndef _PX_SCAN_INSTNUM_HPP_
 #define _PX_SCAN_INSTNUM_HPP_
 
 #include <atomic>
+#include <vector>
 
 #include "regu_var.hpp"
 #include "xasl.h"
 #include "xasl_predicate.hpp"
 
 #if defined (SERVER_MODE) || defined (SA_MODE)
-#include <vector>
 #include "query_list.h"
 #include "thread_entry.hpp"
 #endif /* SERVER_MODE || SA_MODE */
@@ -108,10 +109,11 @@ namespace parallel_scan
 	counter.store (already_emitted);
       }
 
-      /* Clamp before the decrement so BIGINT_MIN cannot wrap to BIGINT_MAX. */
+      /* raw is already inclusive: resolve_instnum_limit folds the R_LT decrement and the
+       * fractional-bound correction into it before calling here. */
       inline void resolve_limit (INT64 raw) noexcept
       {
-	limit = (raw <= 0) ? 0 : (is_less_than ? raw - 1 : raw);
+	limit = (raw <= 0) ? 0 : raw;
 	limit_resolved = true;
       }
 

--- a/src/query/parallel/px_scan/px_scan_result_handler.cpp
+++ b/src/query/parallel/px_scan/px_scan_result_handler.cpp
@@ -97,6 +97,28 @@ namespace parallel_scan
 	m_.active_results = parallelism;
 	m_.is_list_id_domain_resolved = false;
 	m_.g_hash_eligible = (bool) orig_xasl_tree_for_domain_resolve->proc.buildlist.g_hash_eligible;
+
+	/* Identify pass-through ROWNUM output columns. The checker only lets an instnum_val query reach
+	 * MERGEABLE_LIST when every reference is a top-level pass-through valptr, so collecting those column
+	 * positions here reproduces the checker's decision. Column index == position in outptr valptr list. */
+	m_.renumber_instnum = false;
+	XASL_NODE *ox = orig_xasl_tree_for_domain_resolve;
+	if (ox->instnum_val != nullptr && ox->instnum_pred == nullptr && ox->save_instnum_val == nullptr
+	    && ox->outptr_list != nullptr)
+	  {
+	    int idx = 0;
+	    for (regu_variable_list_node *v = ox->outptr_list->valptrp; v != nullptr; v = v->next, idx++)
+	      {
+		if (v->value.type == TYPE_CONSTANT && v->value.value.dbvalptr == ox->instnum_val)
+		  {
+		    m_.rownum_col_indices.push_back (idx);
+		  }
+	      }
+	    if (!m_.rownum_col_indices.empty ())
+	      {
+		m_.renumber_instnum = true;
+	      }
+	  }
       }
     else if constexpr (result_type == RESULT_TYPE::XASL_SNAPSHOT)
       {
@@ -284,6 +306,12 @@ namespace parallel_scan
 	  }
 	tl.val_list_domain_resolved = false;
 	tl.xasl = curr_xasl;
+	if (m_.renumber_instnum && tl.xasl->instnum_val != nullptr)
+	  {
+	    /* guarantee a V_BOUND fixed 8-byte BIGINT slot so main can overwrite ROWNUM in place at merge.
+	     * value is a placeholder (0); the real 1..N is assigned in renumber_instnum_writer_lists(). */
+	    db_make_bigint (tl.xasl->instnum_val, 0);
+	  }
 	tl.agg_hash_state = HS_NONE;
 	tl.g_agg_domains_resolved = TRUE;
 	if (m_.g_hash_eligible)
@@ -600,6 +628,51 @@ namespace parallel_scan
       }
   }
 
+  /* Assign global ROWNUM 1..N in-place across the worker partial lists, in writer_results order, BEFORE
+   * merge_list_ids concatenates them (and before any final ORDER BY sort). Each worker list is one segment
+   * with an independent [base+1 .. base+tuple_cnt] range, so this pass can later be parallelized per segment.
+   * Returns NO_ERROR or ER_FAILED. */
+  static int
+  renumber_instnum_writer_lists (THREAD_ENTRY *thread_p, std::vector<QFILE_LIST_ID *> &lists,
+				 const std::vector<int> &col_indices)
+  {
+    DB_VALUE rownum_val;
+    INT64 counter = 0;
+    for (QFILE_LIST_ID *list_id : lists)
+      {
+	if (list_id == nullptr || list_id->tuple_cnt <= 0)
+	  {
+	    continue;
+	  }
+	QFILE_LIST_SCAN_ID s_id;
+	if (qfile_open_list_scan (list_id, &s_id) != NO_ERROR)
+	  {
+	    return ER_FAILED;
+	  }
+	QFILE_TUPLE_RECORD tuple_rec = { NULL, 0 };
+	SCAN_CODE sc;
+	while ((sc = qfile_scan_list_next (thread_p, &s_id, &tuple_rec, PEEK)) == S_SUCCESS)
+	  {
+	    db_make_bigint (&rownum_val, ++counter);
+	    for (int col : col_indices)
+	      {
+		if (qfile_set_tuple_column_value (thread_p, list_id, s_id.curr_pgptr, &s_id.curr_vpid,
+						  tuple_rec.tpl, col, &rownum_val, &tp_Bigint_domain) != NO_ERROR)
+		  {
+		    qfile_close_scan (thread_p, &s_id);
+		    return ER_FAILED;
+		  }
+	      }
+	  }
+	qfile_close_scan (thread_p, &s_id);
+	if (sc == S_ERROR)
+	  {
+	    return ER_FAILED;
+	  }
+      }
+    return NO_ERROR;
+  }
+
   template <RESULT_TYPE result_type>
   SCAN_CODE result_handler<result_type>::read (THREAD_ENTRY *thread_p, read_dest_type *dest)
   {
@@ -623,6 +696,16 @@ namespace parallel_scan
 	if (m_interrupt_p->get_code() != parallel_query::interrupt::interrupt_code::NO_INTERRUPT)
 	  {
 	    return S_ERROR;
+	  }
+
+	if (m_.renumber_instnum)
+	  {
+	    if (renumber_instnum_writer_lists (thread_p, m_.writer_results, m_.rownum_col_indices) != NO_ERROR)
+	      {
+		m_err_messages_p->move_top_error_message_to_this ();
+		m_interrupt_p->set_code (parallel_query::interrupt::interrupt_code::ERROR_INTERRUPTED_FROM_WORKER_THREAD);
+		return S_ERROR;
+	      }
 	  }
 
 	merge_list_ids (thread_p, dest, m_.writer_results);

--- a/src/query/parallel/px_scan/px_scan_result_handler.cpp
+++ b/src/query/parallel/px_scan/px_scan_result_handler.cpp
@@ -127,6 +127,9 @@ namespace parallel_scan
 	  {
 	    assert (!m_.renumber_instnum);
 	    m_.atomic_instnum_mode = true;
+	    /* a scan block reset rebuilds this handler while the output list keeps the rows already
+	     * emitted, so resume the quota from there instead of granting it again per block. */
+	    m_.instnum_counter.store (ox->list_id != nullptr ? (INT64) ox->list_id->tuple_cnt : 0);
 	  }
       }
     else if constexpr (result_type == RESULT_TYPE::XASL_SNAPSHOT)
@@ -298,10 +301,28 @@ namespace parallel_scan
 	      if (limit_val != nullptr && !DB_IS_NULL (limit_val))
 		{
 		  DB_VALUE coerced;
+		  TP_DOMAIN_STATUS dom_status;
+
 		  db_make_null (&coerced);
-		  if (tp_value_coerce (limit_val, &coerced, &tp_Bigint_domain) == DOMAIN_COMPATIBLE)
+		  dom_status = tp_value_coerce (limit_val, &coerced, &tp_Bigint_domain);
+		  if (dom_status == DOMAIN_COMPATIBLE)
 		    {
 		      m_.instnum_limit = db_get_bigint (&coerced);
+		    }
+		  else if (dom_status == DOMAIN_OVERFLOW && DB_VALUE_DOMAIN_TYPE (limit_val) == DB_TYPE_NUMERIC)
+		    {
+		      /* serial widens inst_num() rather than coercing the bound, so out of BIGINT range a
+		       * positive bound admits every row and a negative one none (cf. key-limit handling). */
+		      m_.instnum_limit = DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE (limit_val) ? 0 : DB_BIGINT_MAX;
+		      er_clear ();
+		    }
+		  else
+		    {
+		      pr_clear_value (&coerced);
+		      (void) tp_domain_status_er_set (dom_status, ARG_FILE_LINE, limit_val, &tp_Bigint_domain);
+		      m_err_messages_p->move_top_error_message_to_this();
+		      m_interrupt_p->set_code (parallel_query::interrupt::interrupt_code::ERROR_INTERRUPTED_FROM_WORKER_THREAD);
+		      return;
 		    }
 		  pr_clear_value (&coerced);
 		}
@@ -354,6 +375,7 @@ namespace parallel_scan
 	     * atomic mode stores the drawn number before each emit. */
 	    db_make_bigint (tl.xasl->instnum_val, 0);
 	  }
+	tl.instnum_quota_done = false;	/* tls outlives the scan; a reused worker must not inherit it */
 	tl.agg_hash_state = HS_NONE;
 	tl.g_agg_domains_resolved = TRUE;
 	if (m_.g_hash_eligible)
@@ -622,9 +644,12 @@ namespace parallel_scan
       }
   }
 
-  void merge_list_ids (THREAD_ENTRY *thread_p, QFILE_LIST_ID *dest, std::vector<QFILE_LIST_ID *> &lists)
+  /* a dropped segment would silently truncate the result, and the ROWNUM watermark taken from
+   * dest->tuple_cnt would go with it, so connect failures are propagated. */
+  int merge_list_ids (THREAD_ENTRY *thread_p, QFILE_LIST_ID *dest, std::vector<QFILE_LIST_ID *> &lists)
   {
     QFILE_LIST_ID *tmp_merged_list = nullptr;
+    int error = NO_ERROR;
     for (QFILE_LIST_ID *list_id : lists)
       {
 	assert (list_id != nullptr);
@@ -635,9 +660,9 @@ namespace parallel_scan
 	      {
 		tmp_merged_list = list_id;
 	      }
-	    else
+	    else if (qfile_connect_list (thread_p, tmp_merged_list, list_id) != NO_ERROR)
 	      {
-		qfile_connect_list (thread_p, tmp_merged_list, list_id);
+		error = ER_FAILED;
 	      }
 	  }
 	else
@@ -656,7 +681,10 @@ namespace parallel_scan
 	      {
 		qfile_close_list (thread_p, dest);
 	      }
-	    qfile_connect_list (thread_p, dest, tmp_merged_list);
+	    if (qfile_connect_list (thread_p, dest, tmp_merged_list) != NO_ERROR)
+	      {
+		error = ER_FAILED;
+	      }
 	  }
 	else
 	  {
@@ -668,6 +696,7 @@ namespace parallel_scan
 	    QFILE_FREE_AND_INIT_LIST_ID (tmp_merged_list);
 	  }
       }
+    return error;
   }
 
   /* Assign global ROWNUM in-place across the worker lists, before merge and before any ORDER BY sort.
@@ -747,9 +776,8 @@ namespace parallel_scan
 
 	if (m_.renumber_instnum)
 	  {
-	    /* dest may already hold rows from an earlier batch after a scan block reset; continue from there. */
 	    if (renumber_instnum_writer_lists (thread_p, m_.writer_results, m_.rownum_col_indices,
-					       dest->tuple_cnt > 0 ? (INT64) dest->tuple_cnt : 0) != NO_ERROR)
+					       dest->tuple_cnt) != NO_ERROR)
 	      {
 		m_err_messages_p->move_top_error_message_to_this ();
 		m_interrupt_p->set_code (parallel_query::interrupt::interrupt_code::ERROR_INTERRUPTED_FROM_WORKER_THREAD);
@@ -757,12 +785,32 @@ namespace parallel_scan
 	      }
 	  }
 
-	merge_list_ids (thread_p, dest, m_.writer_results);
+	if (merge_list_ids (thread_p, dest, m_.writer_results) != NO_ERROR)
+	  {
+	    m_err_messages_p->move_top_error_message_to_this();
+	    m_interrupt_p->set_code (parallel_query::interrupt::interrupt_code::ERROR_INTERRUPTED_FROM_WORKER_THREAD);
+	    return S_ERROR;
+	  }
+
+	if (m_.renumber_instnum || m_.atomic_instnum_mode)
+	  {
+	    /* a later block of the same scan may run serially and resume from instnum_val, so leave the
+	     * watermark there; the parallel path takes it from dest->tuple_cnt instead. */
+	    if (m_.orig_xasl->instnum_val != nullptr)
+	      {
+		db_make_bigint (m_.orig_xasl->instnum_val, dest->tuple_cnt);
+	      }
+	  }
 
 	if (m_.g_hash_eligible)
 	  {
 	    BUILDLIST_PROC_NODE *buildlist_proc = &m_.orig_xasl->proc.buildlist;
-	    merge_list_ids (thread_p, buildlist_proc->agg_hash_context->part_list_id, m_.hgby_results);
+	    if (merge_list_ids (thread_p, buildlist_proc->agg_hash_context->part_list_id, m_.hgby_results) != NO_ERROR)
+	      {
+		m_err_messages_p->move_top_error_message_to_this();
+		m_interrupt_p->set_code (parallel_query::interrupt::interrupt_code::ERROR_INTERRUPTED_FROM_WORKER_THREAD);
+		return S_ERROR;
+	      }
 	    /* HS_REJECT_ALL forces 'hash: partial' trace for hgby with part list IDs (cf. qdump_print_stats_text). */
 	    m_.orig_xasl->groupby_stats.groupby_hash = HS_REJECT_ALL;
 	  }
@@ -918,6 +966,11 @@ namespace parallel_scan
 
 	if (m_.atomic_instnum_mode)
 	  {
+	    if (tl.instnum_quota_done)
+	      {
+		/* stop paying for the shared counter until the loop reaches its next page boundary. */
+		return true;
+	      }
 	    INT64 draw = m_.instnum_counter.fetch_add (1, std::memory_order_relaxed) + 1;
 	    if (draw > m_.instnum_limit)
 	      {
@@ -927,6 +980,7 @@ namespace parallel_scan
 			parallel_query::interrupt::interrupt_code::NO_INTERRUPT;
 		m_interrupt_p->m_code.compare_exchange_strong (expected,
 		    parallel_query::interrupt::interrupt_code::INST_NUM_SATISFIED);
+		tl.instnum_quota_done = true;
 		return true;
 	      }
 	    if (tl.xasl->instnum_val != nullptr)

--- a/src/query/parallel/px_scan/px_scan_result_handler.cpp
+++ b/src/query/parallel/px_scan/px_scan_result_handler.cpp
@@ -659,7 +659,10 @@ namespace parallel_scan
 	    }
 	}
 
-	if (m_.instnum_mode == parallel_scan::instnum_mode::RENUMBER)
+	/* Restamp by merged position. RENUMBER left the columns unnumbered; ATOMIC_DRAW put the number
+	 * each worker drew there, which is not where the row lands once the worker lists are chained -
+	 * serial guarantees the k-th returned row carries k, so the merge has to restore that. */
+	if (m_.instnum_mode != parallel_scan::instnum_mode::NONE && !m_.rownum_col_indices.empty ())
 	  {
 	    if (parallel_scan::renumber_instnum_lists (thread_p, m_.writer_results, m_.rownum_col_indices,
 		dest->tuple_cnt) != NO_ERROR)

--- a/src/query/parallel/px_scan/px_scan_result_handler.cpp
+++ b/src/query/parallel/px_scan/px_scan_result_handler.cpp
@@ -311,14 +311,16 @@ namespace parallel_scan
 		    }
 		  pr_clear_value (&coerced);
 		}
-	      /* NULL rhs keeps limit 0: "inst_num() <= NULL" is unknown for every row -> no rows, like serial. */
-	      if (m_.instnum_limit_is_lt)
-		{
-		  m_.instnum_limit--;	/* draw < N  <=>  draw <= N-1 */
-		}
-	      if (m_.instnum_limit < 0)
+	      /* NULL rhs keeps limit 0: "inst_num() <= NULL" is unknown for every row -> no rows, like serial.
+	       * Clamp before the decrement: BIGINT_MIN-- would wrap to BIGINT_MAX and turn a 0-row query
+	       * into a full scan, so force non-positive limits to 0 first. */
+	      if (m_.instnum_limit <= 0)
 		{
 		  m_.instnum_limit = 0;
+		}
+	      else if (m_.instnum_limit_is_lt)
+		{
+		  m_.instnum_limit--;	/* draw < N  <=>  draw <= N-1; limit >= 1 keeps this >= 0 */
 		}
 	      m_.instnum_limit_resolved = true;
 	    }

--- a/src/query/parallel/px_scan/px_scan_result_handler.cpp
+++ b/src/query/parallel/px_scan/px_scan_result_handler.cpp
@@ -38,6 +38,7 @@
 #include "xasl_aggregate.hpp"
 #include "object_domain.h"
 #include "query_executor.h"
+#include "px_scan_checker.hpp"
 #include "px_scan_trace_handler.hpp"
 
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
@@ -118,6 +119,19 @@ namespace parallel_scan
 	      {
 		m_.renumber_instnum = true;
 	      }
+	  }
+
+	/* atomic-draw mode: single-term "inst_num() <= ?" filter. The checker only lets such an
+	 * instnum_pred reach MERGEABLE_LIST when the same shape test passes, so rhs != null here
+	 * mirrors the checker's decision. The limit value is resolved lazily in write_initialize
+	 * (needs a VAL_DESCR). Note renumber_instnum requires instnum_pred == NULL above, so the
+	 * two modes are mutually exclusive by construction. */
+	m_.atomic_instnum_mode = false;
+	m_.instnum_limit_rhs = parallel_scan::get_instnum_upper_limit_rhs (ox, &m_.instnum_limit_is_lt);
+	if (m_.instnum_limit_rhs != nullptr)
+	  {
+	    assert (!m_.renumber_instnum);
+	    m_.atomic_instnum_mode = true;
 	  }
       }
     else if constexpr (result_type == RESULT_TYPE::XASL_SNAPSHOT)
@@ -275,6 +289,39 @@ namespace parallel_scan
 	    {
 	      db_private_free_and_init (thread_p, type_list.domp);
 	    }
+	  if (m_.atomic_instnum_mode && !m_.instnum_limit_resolved)
+	    {
+	      /* resolve the "inst_num() <= ?" rhs once, under the same mutex; every worker carries the
+	       * same host-variable values so the first arrival's resolution is authoritative. */
+	      DB_VALUE *limit_val = nullptr;
+	      m_.instnum_limit = 0;
+	      if (fetch_peek_dbval (thread_p, m_.instnum_limit_rhs, tl.vd, NULL, NULL, NULL, &limit_val) != NO_ERROR)
+		{
+		  m_err_messages_p->move_top_error_message_to_this();
+		  m_interrupt_p->set_code (parallel_query::interrupt::interrupt_code::ERROR_INTERRUPTED_FROM_WORKER_THREAD);
+		  return;
+		}
+	      if (limit_val != nullptr && !DB_IS_NULL (limit_val))
+		{
+		  DB_VALUE coerced;
+		  db_make_null (&coerced);
+		  if (tp_value_coerce (limit_val, &coerced, &tp_Bigint_domain) == DOMAIN_COMPATIBLE)
+		    {
+		      m_.instnum_limit = db_get_bigint (&coerced);
+		    }
+		  pr_clear_value (&coerced);
+		}
+	      /* NULL rhs keeps limit 0: "inst_num() <= NULL" is unknown for every row -> no rows, like serial. */
+	      if (m_.instnum_limit_is_lt)
+		{
+		  m_.instnum_limit--;	/* draw < N  <=>  draw <= N-1 */
+		}
+	      if (m_.instnum_limit < 0)
+		{
+		  m_.instnum_limit = 0;
+		}
+	      m_.instnum_limit_resolved = true;
+	    }
 	}
 	size = tl.writer_result_p->type_list.type_cnt * DB_SIZEOF (DB_VALUE *);
 	tl.writer_result_p->tpl_descr.f_valp = (DB_VALUE **) malloc (size);
@@ -306,10 +353,10 @@ namespace parallel_scan
 	  }
 	tl.val_list_domain_resolved = false;
 	tl.xasl = curr_xasl;
-	if (m_.renumber_instnum && tl.xasl->instnum_val != nullptr)
+	if ((m_.renumber_instnum || m_.atomic_instnum_mode) && tl.xasl->instnum_val != nullptr)
 	  {
-	    /* guarantee a V_BOUND fixed 8-byte BIGINT slot so main can overwrite ROWNUM in place at merge.
-	     * value is a placeholder (0); the real 1..N is assigned in renumber_instnum_writer_lists(). */
+	    /* guarantee a V_BOUND fixed 8-byte BIGINT slot. Renumber mode: placeholder 0, main overwrites
+	     * 1..N in place at merge. Atomic mode: write() stores the drawn number before each emit. */
 	    db_make_bigint (tl.xasl->instnum_val, 0);
 	  }
 	tl.agg_hash_state = HS_NONE;
@@ -685,7 +732,10 @@ namespace parallel_scan
 	      while (m_.active_results != 0)
 		{
 		  m_result_cv.wait_for (lock, std::chrono::microseconds (50));
-		  if (m_interrupt_p->get_code() != parallel_query::interrupt::interrupt_code::NO_INTERRUPT)
+		  parallel_query::interrupt::interrupt_code code = m_interrupt_p->get_code();
+		  /* INST_NUM_SATISFIED is a benign early-stop: keep waiting for workers to finalize. */
+		  if (code != parallel_query::interrupt::interrupt_code::NO_INTERRUPT
+		      && code != parallel_query::interrupt::interrupt_code::INST_NUM_SATISFIED)
 		    {
 		      return S_ERROR;
 		    }
@@ -693,10 +743,14 @@ namespace parallel_scan
 	    }
 	}
 
-	if (m_interrupt_p->get_code() != parallel_query::interrupt::interrupt_code::NO_INTERRUPT)
-	  {
-	    return S_ERROR;
-	  }
+	{
+	  parallel_query::interrupt::interrupt_code code = m_interrupt_p->get_code();
+	  if (code != parallel_query::interrupt::interrupt_code::NO_INTERRUPT
+	      && code != parallel_query::interrupt::interrupt_code::INST_NUM_SATISFIED)
+	    {
+	      return S_ERROR;
+	    }
+	}
 
 	if (m_.renumber_instnum)
 	  {
@@ -866,6 +920,27 @@ namespace parallel_scan
 	QPROC_TPLDESCR_STATUS status;
 
 	OUTPTR_LIST *input = (OUTPTR_LIST *)src;
+
+	if (m_.atomic_instnum_mode)
+	  {
+	    INT64 draw = m_.instnum_counter.fetch_add (1, std::memory_order_relaxed) + 1;
+	    if (draw > m_.instnum_limit)
+	      {
+		/* quota exhausted: skip this row; every worker stops at its next page boundary via the
+		 * interrupt poll in task::loop. CAS from NO_INTERRUPT only, so a concurrent error code
+		 * (or JOB_ENDED) is never overwritten. Not an error -> return true. */
+		parallel_query::interrupt::interrupt_code expected =
+			parallel_query::interrupt::interrupt_code::NO_INTERRUPT;
+		m_interrupt_p->m_code.compare_exchange_strong (expected,
+		    parallel_query::interrupt::interrupt_code::INST_NUM_SATISFIED);
+		return true;
+	      }
+	    if (tl.xasl->instnum_val != nullptr)
+	      {
+		/* worker-private clone; the projection below reads this DB_VALUE for output ROWNUM. */
+		db_make_bigint (tl.xasl->instnum_val, draw);
+	      }
+	  }
 
 	prefetch (tl.writer_result_p, PREFETCH_WRITE, PREFETCH_CACHE_L1);
 

--- a/src/query/parallel/px_scan/px_scan_result_handler.cpp
+++ b/src/query/parallel/px_scan/px_scan_result_handler.cpp
@@ -38,7 +38,6 @@
 #include "xasl_aggregate.hpp"
 #include "object_domain.h"
 #include "query_executor.h"
-#include "px_scan_checker.hpp"
 #include "px_scan_trace_handler.hpp"
 
 // XXX: SHOULD BE THE LAST INCLUDE HEADER
@@ -99,38 +98,8 @@ namespace parallel_scan
 	m_.is_list_id_domain_resolved = false;
 	m_.g_hash_eligible = (bool) orig_xasl_tree_for_domain_resolve->proc.buildlist.g_hash_eligible;
 
-	/* collect pass-through ROWNUM output columns; index == position in the outptr valptr list. */
-	m_.renumber_instnum = false;
-	XASL_NODE *ox = orig_xasl_tree_for_domain_resolve;
-	if (ox->instnum_val != nullptr && ox->instnum_pred == nullptr && ox->save_instnum_val == nullptr
-	    && ox->outptr_list != nullptr)
-	  {
-	    int idx = 0;
-	    for (regu_variable_list_node *v = ox->outptr_list->valptrp; v != nullptr; v = v->next, idx++)
-	      {
-		if (v->value.type == TYPE_CONSTANT && v->value.value.dbvalptr == ox->instnum_val)
-		  {
-		    m_.rownum_col_indices.push_back (idx);
-		  }
-	      }
-	    if (!m_.rownum_col_indices.empty ())
-	      {
-		m_.renumber_instnum = true;
-	      }
-	  }
-
-	/* atomic-draw mode; the limit is resolved later in write_initialize (needs a VAL_DESCR).
-	 * renumber_instnum requires instnum_pred == NULL, so the two modes cannot both be set. */
-	m_.atomic_instnum_mode = false;
-	m_.instnum_limit_rhs = parallel_scan::get_instnum_upper_limit_rhs (ox, &m_.instnum_limit_is_lt);
-	if (m_.instnum_limit_rhs != nullptr)
-	  {
-	    assert (!m_.renumber_instnum);
-	    m_.atomic_instnum_mode = true;
-	    /* a scan block reset rebuilds this handler while the output list keeps the rows already
-	     * emitted, so resume the quota from there instead of granting it again per block. */
-	    m_.instnum_counter.store (ox->list_id != nullptr ? (INT64) ox->list_id->tuple_cnt : 0);
-	  }
+	m_.instnum_mode = parallel_scan::detect_instnum_mode (orig_xasl_tree_for_domain_resolve,
+			  m_.rownum_col_indices, m_.instnum_draw);
       }
     else if constexpr (result_type == RESULT_TYPE::XASL_SNAPSHOT)
       {
@@ -287,56 +256,15 @@ namespace parallel_scan
 	    {
 	      db_private_free_and_init (thread_p, type_list.domp);
 	    }
-	  if (m_.atomic_instnum_mode && !m_.instnum_limit_resolved)
+	  if (m_.instnum_mode == parallel_scan::instnum_mode::ATOMIC_DRAW && !m_.instnum_draw.limit_resolved)
 	    {
 	      /* resolve the rhs once under the mutex; all workers carry the same host variables. */
-	      DB_VALUE *limit_val = nullptr;
-	      m_.instnum_limit = 0;
-	      if (fetch_peek_dbval (thread_p, m_.instnum_limit_rhs, tl.vd, NULL, NULL, NULL, &limit_val) != NO_ERROR)
+	      if (parallel_scan::resolve_instnum_limit (thread_p, m_.instnum_draw, tl.vd) != NO_ERROR)
 		{
 		  m_err_messages_p->move_top_error_message_to_this();
 		  m_interrupt_p->set_code (parallel_query::interrupt::interrupt_code::ERROR_INTERRUPTED_FROM_WORKER_THREAD);
 		  return;
 		}
-	      if (limit_val != nullptr && !DB_IS_NULL (limit_val))
-		{
-		  DB_VALUE coerced;
-		  TP_DOMAIN_STATUS dom_status;
-
-		  db_make_null (&coerced);
-		  dom_status = tp_value_coerce (limit_val, &coerced, &tp_Bigint_domain);
-		  if (dom_status == DOMAIN_COMPATIBLE)
-		    {
-		      m_.instnum_limit = db_get_bigint (&coerced);
-		    }
-		  else if (dom_status == DOMAIN_OVERFLOW && DB_VALUE_DOMAIN_TYPE (limit_val) == DB_TYPE_NUMERIC)
-		    {
-		      /* serial widens inst_num() rather than coercing the bound, so out of BIGINT range a
-		       * positive bound admits every row and a negative one none (cf. key-limit handling). */
-		      m_.instnum_limit = DB_VALUE_NUMERIC_IS_VALUE_NEGATIVE (limit_val) ? 0 : DB_BIGINT_MAX;
-		      er_clear ();
-		    }
-		  else
-		    {
-		      pr_clear_value (&coerced);
-		      (void) tp_domain_status_er_set (dom_status, ARG_FILE_LINE, limit_val, &tp_Bigint_domain);
-		      m_err_messages_p->move_top_error_message_to_this();
-		      m_interrupt_p->set_code (parallel_query::interrupt::interrupt_code::ERROR_INTERRUPTED_FROM_WORKER_THREAD);
-		      return;
-		    }
-		  pr_clear_value (&coerced);
-		}
-	      /* NULL rhs keeps limit 0 (unknown for every row -> no rows, like serial).
-	       * Clamp before the decrement so BIGINT_MIN cannot wrap to BIGINT_MAX. */
-	      if (m_.instnum_limit <= 0)
-		{
-		  m_.instnum_limit = 0;
-		}
-	      else if (m_.instnum_limit_is_lt)
-		{
-		  m_.instnum_limit--;	/* draw < N  <=>  draw <= N-1; limit >= 1 keeps this >= 0 */
-		}
-	      m_.instnum_limit_resolved = true;
 	    }
 	}
 	size = tl.writer_result_p->type_list.type_cnt * DB_SIZEOF (DB_VALUE *);
@@ -369,7 +297,7 @@ namespace parallel_scan
 	  }
 	tl.val_list_domain_resolved = false;
 	tl.xasl = curr_xasl;
-	if ((m_.renumber_instnum || m_.atomic_instnum_mode) && tl.xasl->instnum_val != nullptr)
+	if (m_.instnum_mode != parallel_scan::instnum_mode::NONE && tl.xasl->instnum_val != nullptr)
 	  {
 	    /* guarantee a V_BOUND 8-byte BIGINT slot: renumber mode overwrites it at merge,
 	     * atomic mode stores the drawn number before each emit. */
@@ -699,49 +627,6 @@ namespace parallel_scan
     return error;
   }
 
-  /* Assign global ROWNUM in-place across the worker lists, before merge and before any ORDER BY sort.
-   * Continues from start_at: a scan block reset rebuilds the handler while dest keeps its rows. */
-  static int
-  renumber_instnum_writer_lists (THREAD_ENTRY *thread_p, std::vector<QFILE_LIST_ID *> &lists,
-				 const std::vector<int> &col_indices, INT64 start_at)
-  {
-    DB_VALUE rownum_val;
-    INT64 counter = start_at;
-    for (QFILE_LIST_ID *list_id : lists)
-      {
-	if (list_id == nullptr || list_id->tuple_cnt <= 0)
-	  {
-	    continue;
-	  }
-	QFILE_LIST_SCAN_ID s_id;
-	if (qfile_open_list_scan (list_id, &s_id) != NO_ERROR)
-	  {
-	    return ER_FAILED;
-	  }
-	QFILE_TUPLE_RECORD tuple_rec = { NULL, 0 };
-	SCAN_CODE sc;
-	while ((sc = qfile_scan_list_next (thread_p, &s_id, &tuple_rec, PEEK)) == S_SUCCESS)
-	  {
-	    db_make_bigint (&rownum_val, ++counter);
-	    for (int col : col_indices)
-	      {
-		if (qfile_set_tuple_column_value (thread_p, list_id, s_id.curr_pgptr, &s_id.curr_vpid,
-						  tuple_rec.tpl, col, &rownum_val, &tp_Bigint_domain) != NO_ERROR)
-		  {
-		    qfile_close_scan (thread_p, &s_id);
-		    return ER_FAILED;
-		  }
-	      }
-	  }
-	qfile_close_scan (thread_p, &s_id);
-	if (sc == S_ERROR)
-	  {
-	    return ER_FAILED;
-	  }
-      }
-    return NO_ERROR;
-  }
-
   template <RESULT_TYPE result_type>
   SCAN_CODE result_handler<result_type>::read (THREAD_ENTRY *thread_p, read_dest_type *dest)
   {
@@ -774,10 +659,10 @@ namespace parallel_scan
 	    }
 	}
 
-	if (m_.renumber_instnum)
+	if (m_.instnum_mode == parallel_scan::instnum_mode::RENUMBER)
 	  {
-	    if (renumber_instnum_writer_lists (thread_p, m_.writer_results, m_.rownum_col_indices,
-					       dest->tuple_cnt) != NO_ERROR)
+	    if (parallel_scan::renumber_instnum_lists (thread_p, m_.writer_results, m_.rownum_col_indices,
+		dest->tuple_cnt) != NO_ERROR)
 	      {
 		m_err_messages_p->move_top_error_message_to_this ();
 		m_interrupt_p->set_code (parallel_query::interrupt::interrupt_code::ERROR_INTERRUPTED_FROM_WORKER_THREAD);
@@ -792,7 +677,7 @@ namespace parallel_scan
 	    return S_ERROR;
 	  }
 
-	if (m_.renumber_instnum || m_.atomic_instnum_mode)
+	if (m_.instnum_mode != parallel_scan::instnum_mode::NONE)
 	  {
 	    /* a later block of the same scan may run serially and resume from instnum_val, so leave the
 	     * watermark there; the parallel path takes it from dest->tuple_cnt instead. */
@@ -964,15 +849,15 @@ namespace parallel_scan
 
 	OUTPTR_LIST *input = (OUTPTR_LIST *)src;
 
-	if (m_.atomic_instnum_mode)
+	if (m_.instnum_mode == parallel_scan::instnum_mode::ATOMIC_DRAW)
 	  {
 	    if (tl.instnum_quota_done)
 	      {
 		/* stop paying for the shared counter until the loop reaches its next page boundary. */
 		return true;
 	      }
-	    INT64 draw = m_.instnum_counter.fetch_add (1, std::memory_order_relaxed) + 1;
-	    if (draw > m_.instnum_limit)
+	    INT64 drawn = m_.instnum_draw.next ();
+	    if (m_.instnum_draw.exceeded (drawn))
 	      {
 		/* quota exhausted: skip the row and signal; workers stop at the next page boundary.
 		 * CAS from NO_INTERRUPT only, so an error code is never overwritten. Not an error. */
@@ -986,7 +871,7 @@ namespace parallel_scan
 	    if (tl.xasl->instnum_val != nullptr)
 	      {
 		/* worker-private clone; the projection below reads this DB_VALUE for output ROWNUM. */
-		db_make_bigint (tl.xasl->instnum_val, draw);
+		db_make_bigint (tl.xasl->instnum_val, drawn);
 	      }
 	  }
 

--- a/src/query/parallel/px_scan/px_scan_result_handler.cpp
+++ b/src/query/parallel/px_scan/px_scan_result_handler.cpp
@@ -99,9 +99,7 @@ namespace parallel_scan
 	m_.is_list_id_domain_resolved = false;
 	m_.g_hash_eligible = (bool) orig_xasl_tree_for_domain_resolve->proc.buildlist.g_hash_eligible;
 
-	/* Identify pass-through ROWNUM output columns. The checker only lets an instnum_val query reach
-	 * MERGEABLE_LIST when every reference is a top-level pass-through valptr, so collecting those column
-	 * positions here reproduces the checker's decision. Column index == position in outptr valptr list. */
+	/* collect pass-through ROWNUM output columns; index == position in the outptr valptr list. */
 	m_.renumber_instnum = false;
 	XASL_NODE *ox = orig_xasl_tree_for_domain_resolve;
 	if (ox->instnum_val != nullptr && ox->instnum_pred == nullptr && ox->save_instnum_val == nullptr
@@ -121,11 +119,8 @@ namespace parallel_scan
 	      }
 	  }
 
-	/* atomic-draw mode: single-term "inst_num() <= ?" filter. The checker only lets such an
-	 * instnum_pred reach MERGEABLE_LIST when the same shape test passes, so rhs != null here
-	 * mirrors the checker's decision. The limit value is resolved lazily in write_initialize
-	 * (needs a VAL_DESCR). Note renumber_instnum requires instnum_pred == NULL above, so the
-	 * two modes are mutually exclusive by construction. */
+	/* atomic-draw mode; the limit is resolved later in write_initialize (needs a VAL_DESCR).
+	 * renumber_instnum requires instnum_pred == NULL, so the two modes cannot both be set. */
 	m_.atomic_instnum_mode = false;
 	m_.instnum_limit_rhs = parallel_scan::get_instnum_upper_limit_rhs (ox, &m_.instnum_limit_is_lt);
 	if (m_.instnum_limit_rhs != nullptr)
@@ -291,8 +286,7 @@ namespace parallel_scan
 	    }
 	  if (m_.atomic_instnum_mode && !m_.instnum_limit_resolved)
 	    {
-	      /* resolve the "inst_num() <= ?" rhs once, under the same mutex; every worker carries the
-	       * same host-variable values so the first arrival's resolution is authoritative. */
+	      /* resolve the rhs once under the mutex; all workers carry the same host variables. */
 	      DB_VALUE *limit_val = nullptr;
 	      m_.instnum_limit = 0;
 	      if (fetch_peek_dbval (thread_p, m_.instnum_limit_rhs, tl.vd, NULL, NULL, NULL, &limit_val) != NO_ERROR)
@@ -311,9 +305,8 @@ namespace parallel_scan
 		    }
 		  pr_clear_value (&coerced);
 		}
-	      /* NULL rhs keeps limit 0: "inst_num() <= NULL" is unknown for every row -> no rows, like serial.
-	       * Clamp before the decrement: BIGINT_MIN-- would wrap to BIGINT_MAX and turn a 0-row query
-	       * into a full scan, so force non-positive limits to 0 first. */
+	      /* NULL rhs keeps limit 0 (unknown for every row -> no rows, like serial).
+	       * Clamp before the decrement so BIGINT_MIN cannot wrap to BIGINT_MAX. */
 	      if (m_.instnum_limit <= 0)
 		{
 		  m_.instnum_limit = 0;
@@ -357,8 +350,8 @@ namespace parallel_scan
 	tl.xasl = curr_xasl;
 	if ((m_.renumber_instnum || m_.atomic_instnum_mode) && tl.xasl->instnum_val != nullptr)
 	  {
-	    /* guarantee a V_BOUND fixed 8-byte BIGINT slot. Renumber mode: placeholder 0, main overwrites
-	     * 1..N in place at merge. Atomic mode: write() stores the drawn number before each emit. */
+	    /* guarantee a V_BOUND 8-byte BIGINT slot: renumber mode overwrites it at merge,
+	     * atomic mode stores the drawn number before each emit. */
 	    db_make_bigint (tl.xasl->instnum_val, 0);
 	  }
 	tl.agg_hash_state = HS_NONE;
@@ -677,16 +670,14 @@ namespace parallel_scan
       }
   }
 
-  /* Assign global ROWNUM 1..N in-place across the worker partial lists, in writer_results order, BEFORE
-   * merge_list_ids concatenates them (and before any final ORDER BY sort). Each worker list is one segment
-   * with an independent [base+1 .. base+tuple_cnt] range, so this pass can later be parallelized per segment.
-   * Returns NO_ERROR or ER_FAILED. */
+  /* Assign global ROWNUM in-place across the worker lists, before merge and before any ORDER BY sort.
+   * Continues from start_at: a scan block reset rebuilds the handler while dest keeps its rows. */
   static int
   renumber_instnum_writer_lists (THREAD_ENTRY *thread_p, std::vector<QFILE_LIST_ID *> &lists,
-				 const std::vector<int> &col_indices)
+				 const std::vector<int> &col_indices, INT64 start_at)
   {
     DB_VALUE rownum_val;
-    INT64 counter = 0;
+    INT64 counter = start_at;
     for (QFILE_LIST_ID *list_id : lists)
       {
 	if (list_id == nullptr || list_id->tuple_cnt <= 0)
@@ -756,7 +747,9 @@ namespace parallel_scan
 
 	if (m_.renumber_instnum)
 	  {
-	    if (renumber_instnum_writer_lists (thread_p, m_.writer_results, m_.rownum_col_indices) != NO_ERROR)
+	    /* dest may already hold rows from an earlier batch after a scan block reset; continue from there. */
+	    if (renumber_instnum_writer_lists (thread_p, m_.writer_results, m_.rownum_col_indices,
+					       dest->tuple_cnt > 0 ? (INT64) dest->tuple_cnt : 0) != NO_ERROR)
 	      {
 		m_err_messages_p->move_top_error_message_to_this ();
 		m_interrupt_p->set_code (parallel_query::interrupt::interrupt_code::ERROR_INTERRUPTED_FROM_WORKER_THREAD);
@@ -928,9 +921,8 @@ namespace parallel_scan
 	    INT64 draw = m_.instnum_counter.fetch_add (1, std::memory_order_relaxed) + 1;
 	    if (draw > m_.instnum_limit)
 	      {
-		/* quota exhausted: skip this row; every worker stops at its next page boundary via the
-		 * interrupt poll in task::loop. CAS from NO_INTERRUPT only, so a concurrent error code
-		 * (or JOB_ENDED) is never overwritten. Not an error -> return true. */
+		/* quota exhausted: skip the row and signal; workers stop at the next page boundary.
+		 * CAS from NO_INTERRUPT only, so an error code is never overwritten. Not an error. */
 		parallel_query::interrupt::interrupt_code expected =
 			parallel_query::interrupt::interrupt_code::NO_INTERRUPT;
 		m_interrupt_p->m_code.compare_exchange_strong (expected,

--- a/src/query/parallel/px_scan/px_scan_result_handler.hpp
+++ b/src/query/parallel/px_scan/px_scan_result_handler.hpp
@@ -97,6 +97,9 @@ namespace parallel_scan
       std::vector<QFILE_LIST_ID *> hgby_results;
       bool g_hash_eligible;
       trace_handler *trace_handler_p;
+      /* pass-through ROWNUM (instnum_val) support: main renumbers these tuple columns to 1..N at merge. */
+      bool renumber_instnum = false;
+      std::vector<int> rownum_col_indices;
   };
 
   class xasl_snapshot_variables

--- a/src/query/parallel/px_scan/px_scan_result_handler.hpp
+++ b/src/query/parallel/px_scan/px_scan_result_handler.hpp
@@ -28,6 +28,7 @@
 #include "thread_entry.hpp"
 #include "px_interrupt.hpp"
 #include "xasl.h"
+#include "px_scan_instnum.hpp"
 #include "px_scan_result_type.hpp"
 #include <atomic>
 #include <condition_variable>
@@ -97,16 +98,9 @@ namespace parallel_scan
       std::vector<QFILE_LIST_ID *> hgby_results;
       bool g_hash_eligible;
       trace_handler *trace_handler_p;
-      /* pass-through ROWNUM (instnum_val) support: main renumbers these tuple columns to 1..N at merge. */
-      bool renumber_instnum = false;
-      std::vector<int> rownum_col_indices;
-      /* atomic-draw mode: workers draw from instnum_counter and raise INST_NUM_SATISFIED at the quota. */
-      bool atomic_instnum_mode = false;
-      bool instnum_limit_is_lt = false;
-      bool instnum_limit_resolved = false;
-      INT64 instnum_limit = 0;
-      REGU_VARIABLE *instnum_limit_rhs = nullptr;
-      std::atomic<INT64> instnum_counter {0};
+      parallel_scan::instnum_mode instnum_mode = parallel_scan::instnum_mode::NONE;
+      std::vector<int> rownum_col_indices;	/* RENUMBER: ROWNUM positions in the valptr list */
+      parallel_scan::atomic_instnum instnum_draw;	/* ATOMIC_DRAW */
   };
 
   class xasl_snapshot_variables

--- a/src/query/parallel/px_scan/px_scan_result_handler.hpp
+++ b/src/query/parallel/px_scan/px_scan_result_handler.hpp
@@ -100,6 +100,15 @@ namespace parallel_scan
       /* pass-through ROWNUM (instnum_val) support: main renumbers these tuple columns to 1..N at merge. */
       bool renumber_instnum = false;
       std::vector<int> rownum_col_indices;
+      /* atomic-draw ROWNUM (single-term "inst_num() <= ?" instnum_pred): each worker draws a global row
+       * number from instnum_counter per emitted row, evaluates the limit locally, and raises
+       * INST_NUM_SATISFIED once the quota is exhausted. Mutually exclusive with renumber_instnum. */
+      bool atomic_instnum_mode = false;
+      bool instnum_limit_is_lt = false;
+      bool instnum_limit_resolved = false;
+      INT64 instnum_limit = 0;
+      REGU_VARIABLE *instnum_limit_rhs = nullptr;
+      std::atomic<INT64> instnum_counter {0};
   };
 
   class xasl_snapshot_variables

--- a/src/query/parallel/px_scan/px_scan_result_handler.hpp
+++ b/src/query/parallel/px_scan/px_scan_result_handler.hpp
@@ -144,6 +144,8 @@ namespace parallel_scan
       int g_agg_domains_resolved;
       /* per-worker mirror of (xasl->topn_items != nullptr); avoids hot-path pointer chase on every row. */
       bool is_topn;
+      /* once this worker has seen the atomic-draw quota exhausted, stop touching the shared counter. */
+      bool instnum_quota_done = false;
   };
 
   class xasl_snapshot_tls

--- a/src/query/parallel/px_scan/px_scan_result_handler.hpp
+++ b/src/query/parallel/px_scan/px_scan_result_handler.hpp
@@ -100,9 +100,7 @@ namespace parallel_scan
       /* pass-through ROWNUM (instnum_val) support: main renumbers these tuple columns to 1..N at merge. */
       bool renumber_instnum = false;
       std::vector<int> rownum_col_indices;
-      /* atomic-draw ROWNUM (single-term "inst_num() <= ?" instnum_pred): each worker draws a global row
-       * number from instnum_counter per emitted row, evaluates the limit locally, and raises
-       * INST_NUM_SATISFIED once the quota is exhausted. Mutually exclusive with renumber_instnum. */
+      /* atomic-draw mode: workers draw from instnum_counter and raise INST_NUM_SATISFIED at the quota. */
       bool atomic_instnum_mode = false;
       bool instnum_limit_is_lt = false;
       bool instnum_limit_resolved = false;

--- a/src/query/parallel/px_scan/px_scan_task.cpp
+++ b/src/query/parallel/px_scan/px_scan_task.cpp
@@ -845,7 +845,12 @@ namespace parallel_scan
 		      && logtb_is_interrupted_tran (&thread_ref, true, &dummy, thread_ref.tran_index);
 	if (is_interrupt)
 	  {
-	    if (m_interrupt->get_code() == parallel_query::interrupt::interrupt_code::NO_INTERRUPT)
+	    /* logtb_is_interrupted_tran() above consumed (cleared) the transaction flag, so the
+	     * cancellation must be recorded even when a benign INST_NUM_SATISFIED early-stop got here
+	     * first; otherwise it is lost for good. Real error codes still take precedence. */
+	    parallel_query::interrupt::interrupt_code code = m_interrupt->get_code();
+	    if (code == parallel_query::interrupt::interrupt_code::NO_INTERRUPT
+		|| code == parallel_query::interrupt::interrupt_code::INST_NUM_SATISFIED)
 	      {
 		er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_INTERRUPTED, 0);
 		m_err_messages->move_top_error_message_to_this();

--- a/src/query/parallel/px_scan/px_scan_task.cpp
+++ b/src/query/parallel/px_scan/px_scan_task.cpp
@@ -845,9 +845,8 @@ namespace parallel_scan
 		      && logtb_is_interrupted_tran (&thread_ref, true, &dummy, thread_ref.tran_index);
 	if (is_interrupt)
 	  {
-	    /* logtb_is_interrupted_tran() above consumed (cleared) the transaction flag, so the
-	     * cancellation must be recorded even when a benign INST_NUM_SATISFIED early-stop got here
-	     * first; otherwise it is lost for good. Real error codes still take precedence. */
+	    /* logtb_is_interrupted_tran() above cleared the transaction flag, so record the cancellation
+	     * even if a benign INST_NUM_SATISFIED got here first. Real error codes still win. */
 	    parallel_query::interrupt::interrupt_code code = m_interrupt->get_code();
 	    if (code == parallel_query::interrupt::interrupt_code::NO_INTERRUPT
 		|| code == parallel_query::interrupt::interrupt_code::INST_NUM_SATISFIED)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27135>

### Purpose

ROWNUM(`inst_num()`)이 쿼리에 있으면 parallel scan checker가 `CANNOT_LIST_MERGE`를 세워 fast-path(`MERGEABLE_LIST`)를 막는다. 그 결과 heap scan은 row-by-row(느린 병렬)로 강등되고, list/index scan은 병렬이 완전히 사라지며, fast-path 위에 얹혀 있는 parallel hash aggregate도 함께 무력화된다.

ROWNUM에는 성격이 다른 두 가지 사용 형태가 있어, 각각 다른 방식으로 제약을 해소한다.

| 형태 | 성격 | 해소 방식 |
|---|---|---|
| `SELECT ROWNUM, x FROM t` | 출력 행 번호. 스캔 중에는 아무도 값을 읽지 않는다 | 워커는 값 자리만 확보하고, 병합 시점에 main이 1..N을 부여 (merge-time renumbering) |
| `WHERE ROWNUM <= N` | 입력 필터. 번호가 결과 집합 자체를 정의한다 | 워커가 공유 atomic counter에서 전역 번호를 뽑아 자기 자리에서 판정하고 조기 종료 (atomic draw) |

출력 ROWNUM은 번호 부여를 미룰 수 있으므로 병합 후 한 번에 기입하면 되고, `WHERE ROWNUM <= N`은 번호가 스캔 도중 소비되므로 미룰 수 없어 원자 카운터가 필요하다.

실측 (300,000행 / 2,885 page / `PARALLEL(4)` 힌트):

| 쿼리 | 항목 | 변경 전 | 변경 후 |
|---|---|---|---|
| `SELECT ROWNUM, id FROM px_rn` | gather 모드 | row by row | mergeable list |
| `... WHERE ROWNUM <= 100000` | gather 모드 | row by row | mergeable list |
| `... WHERE ROWNUM <= 100000` | readrows (over-scan) | 300,000 (전량) | 100,112 |
| `... WHERE ROWNUM <= 100000` | 수행 시간 | 0.124s | 0.042s (serial 0.176s) |
| `... WHERE ROWNUM <= 5` | readrows | 300,000 (전량) | 208 |

행과 번호의 매핑은 변경 전후 모두 실행마다 달라진다(워커 스케줄링 의존). SQL 표준상 스캔 순서가 보장되지 않으므로 정합성 위반은 아니며, 본 변경은 "번호 집합이 정확히 1..N"만 보장한다.

### Implementation

**1) 자격 판정 — `px_scan_checker.cpp` (client side)**

두 모드가 공유하는 공통 형태 검사 `instnum_xasl_shape_ok()`(164행)를 두었다. 통과 조건은 `save_instnum_val` 없음(orderby_skip 치환 아님), `ordbynum_pred`/`ordbynum_val` 없음(ORDER BY + LIMIT topn 제외), `BUILDLIST_PROC` 타입, `groupby_list`/`g_agg_list`/`a_eval_list` 모두 없음(GROUP BY·집계·analytic 제외), 그리고 `instnum_val`이 outptr 최상위 통과 컬럼으로만 참조되는 것이다. 마지막 조건은 `regu_subtree_refs_instnum()`(115행)이 regu 서브트리를 재귀 순회해 `ROWNUM+1` 같은 표현식 참조를 걸러내며, 모르는 컨테이너 타입은 보수적으로 차단한다.

- `is_renumberable_instnum()`(212행): 위 조건 + `instnum_pred` 없음 + 통과 컬럼 1개 이상 → merge-time renumbering
- `is_atomic_instnum_eligible()`(225행): 위 조건 + 단일항 상한 술어 → atomic draw
- 단일항 상한 술어 판별은 `get_instnum_upper_limit_rhs()`(`px_scan_checker.hpp:38`)가 담당한다. lhs가 `instnum_val`을 가리키는 `TYPE_CONSTANT`이고 rhs가 `TYPE_POS_VALUE`/`TYPE_DBVAL`이며 연산자가 `R_LE`/`R_LT`일 때만 rhs를 반환하고, `XASL_INSTNUM_FLAG_SCAN_CONTINUE`가 있으면 거부한다. checker는 cs/sa 타깃에만 링크되므로 server 측 result handler와 공유하려면 헤더 inline 정의가 필요하다.

기존 차단 지점 세 곳을 위 판정으로 완화했다. sibling 검사(691행)와 main 검사(873행)는 두 모드 모두 허용하고, index spec 차단(1014행)은 `is_renumberable_instnum()`만 사용해 atomic draw 경로의 index scan을 보수적으로 계속 차단한다.

**2) merge-time renumbering — `px_scan_result_handler.cpp` (server side)**

생성자에서 `outptr_list`를 순회해 `instnum_val`을 가리키는 `TYPE_CONSTANT` 컬럼 위치를 `rownum_col_indices`에 수집하고 `renumber_instnum`을 세운다. `write_initialize()`(360행)는 워커 clone의 `instnum_val`을 `db_make_bigint(0)`으로 초기화해 튜플에 V_BOUND 고정 8바이트 BIGINT 슬롯이 반드시 생기도록 보장한다(placeholder이며 실제 번호는 main이 덮어쓴다).

`renumber_instnum_writer_lists()`(683행)가 `merge_list_ids()` 호출 직전(757행)에 실행된다. 워커별 부분 list를 등록 순서대로 순회하며 `qfile_scan_list_next(PEEK)`로 튜플을 얻고, 기존 `qfile_set_tuple_column_value()`(706행, `list_file.c:7073`)로 ROWNUM 컬럼을 1..N으로 in-place 기입한다. 이 함수는 CONNECT BY pseudo-column writeback(`query_executor.c:19224`)이 이미 쓰는 검증된 경로이며 값 위치 탐색, `data_writeval` 기록, `qfile_set_dirty_page` 처리를 한 번에 수행한다. 최종 ORDER BY sort 이전에 부여하므로 "스캔 순서로 번호를 매긴 뒤 정렬"이라는 serial 의미와 일치한다. 세그먼트 단위 순회 구조라 향후 세그먼트별 병렬 보정으로 확장할 수 있다.

**3) atomic draw — `px_scan_result_handler.cpp` (server side)**

생성자(130행)에서 `get_instnum_upper_limit_rhs()`가 rhs를 반환하면 `atomic_instnum_mode`를 세운다. renumbering 모드는 `instnum_pred` 없음을 요구하므로 두 모드는 구조적으로 상호 배타적이다.

상한값은 `write_initialize()`(292행)에서 첫 워커가 mutex 안에서 한 번만 해석한다. `fetch_peek_dbval`로 rhs를 평가하고 `tp_value_coerce`로 BIGINT로 변환하며, `R_LT`면 1을 감소시키고, NULL이나 음수면 0으로 처리해 결과 0행을 만든다.

`write()`(926행)가 행마다 `instnum_counter.fetch_add()`로 전역 번호를 뽑는다. 번호가 상한 이내면 워커 clone의 `instnum_val`에 기록해 출력 ROWNUM으로도 그대로 쓰이고, 상한을 넘으면 해당 행을 버리고 `INST_NUM_SATISFIED`를 발신한다. 발신은 `compare_exchange_strong`(934행)으로 `NO_INTERRUPT` 상태에서만 수행하므로 다른 워커가 기록한 에러 코드나 `JOB_ENDED`를 덮어쓰지 않는다. 워커 루프는 페이지 경계마다 인터럽트를 확인하므로(`px_scan_task.cpp:816`) 전원이 다음 페이지에서 정지한다.

`INST_NUM_SATISFIED`는 `px_interrupt.hpp:38`에 enum 값만 있고 발신 지점이 없던 미사용 코드였다. 이번에 발신과 수신을 모두 배선했다. 수신은 `read()`의 인터럽트 검사 두 곳과 `manager::next_scan()`의 switch(`px_scan.cpp:1981`)에서 정상 조기 종료로 처리한다. 참고로 `px_interrupt.hpp:59`의 `atomic_instnum` 클래스는 여전히 사용하지 않는다 — 카운터를 `mergeable_list_variables` 안에 두어 상한값과 함께 관리하는 편이 명확하기 때문이다.

정합성 불변식은 "번호를 뽑은 행은 반드시 기록되거나 에러로 처리된다"이다. draw와 emit이 `write()` 안에서 연속 실행되고 emit 실패는 무조건 에러 코드를 기록하므로, 쿼터 소진 후 루프 레벨에서 발생하는 에러는 결과(정확히 N행)에 영향을 주지 않는다.

### Remarks

**검증**

`CBRD-27135_testcases.sql`을 추가했다. 파라미터 오버라이드 없이 **기본 서버 설정(`parallel_scan_page_threshold` 2048)** 에서 실행해 TC가 자체적으로 병렬을 유도하는 것까지 확인했다(300,000행 / 2,885 page). 자기검증 5건 전부 PASS, trace 4건 확인.

| 케이스 | gather | 결과 |
|---|---|---|
| `rownum, id ... where id > 300000` (0행) | mergeable list | fast-path 진입 |
| `rownum ... where val = 7` (300행) | mergeable list | 정확히 1..300 (sum 45,150 / distinct 300) |
| 집계로 평탄화된 `where rownum <= 3` | row by row | 의도대로 차단, count 정확 |
| `where rownum <= 5` (atomic draw) | mergeable list | 정확히 1..5 |

이 외에 30만행 전체 집합 대조(serial vs parallel), `R_LT`·N=0·NULL 상한 경계, 배제 대상(표현식 참조·ORDER BY+LIMIT·GROUP BY·일반형 술어)의 동작 유지와 결과 정확성을 확인했다.

**기존 회귀 TC (`cbrd_25447`) answer 갱신 필요**

실행 결과 오답이나 에러는 없으나, 의도된 계획 변화로 trace의 gather 모드가 달라져 answer 파일 갱신이 필요하다.

| 케이스 | 기존 answer | 변경 후 | 원인 |
|---|---|---|---|
| 10 (`limit 1`, ORDER BY 없음) | row by row | mergeable list | LIMIT이 내부적으로 `instnum_pred`가 되어 atomic draw 대상 |
| 8-3 (파생 테이블 바깥 `limit 2`) | 3줄 | 4줄 | 같은 사유로 바깥 스캔이 병렬화 |
| 20 (select 리스트의 `rownum`) | row by row | buildvalue + mergeable list | merge-time renumbering |

같은 실행에서 case 4·16·17·22·28도 answer와 다르지만, 이들은 ROWNUM이 없거나 `order by ... limit` 형태로 `ordbynum_pred`가 있어 본 변경의 자격 검사에서 배제되는 쿼리다. 즉 이 브랜치의 develop 베이스와 answer 파일 사이의 기존 차이로 판단하며, 확정하려면 develop 빌드 기준선 실행이 필요하다.

**알려진 한계**

- select 리스트와 WHERE 절 양쪽에 테이블 속성이 하나도 없으면(`SELECT ROWNUM FROM t WHERE ROWNUM <= 5` 등) 기존 규칙(`px_scan_checker.cpp:598`)에 의해 폴백이 유지된다. 본 변경과 무관한 별개 제약이다.
- 행↔번호 매핑의 비결정성은 해소되지 않는다(위 Purpose 참고).
- 일반형 술어(`ROWNUM = k`, OR 결합)와 index scan + `WHERE ROWNUM <= N` 조합은 보수적으로 계속 차단한다.