### PR TITLE
[CBRD-27137] Fix unhandled predicate selectivity and match histogram string estimates through cubregex/runtime comparators

### DIFF
--- a/src/optimizer/histogram/histogram_cl.cpp
+++ b/src/optimizer/histogram/histogram_cl.cpp
@@ -48,15 +48,14 @@
 
 static bool histogram_extract_key (const DB_VALUE *db_val, hist::histogram_key &key);
 static int store_one_histogram (MOP classop, const char *attr_name, char *blob, int blob_length, double null_freq);
-static bool string_hist_value_equals_db_value (std::string_view hist_value, int hist_codeset, int hist_collation,
-    const DB_VALUE *probe);
-static bool string_hist_values_equal (std::string_view v1, int codeset1, int collation1,
-				      std::string_view v2, int codeset2, int collation2);
+static bool string_values_equal_under_collation (std::string_view v1, std::string_view v2, int codeset,
+    int collation);
 static void histogram_lhs_string_domain (PT_NODE *lhs, int fallback_codeset, int fallback_collation,
     int *codeset, int *collation);
 static void mcv_join_parts_str (const hist::HistogramReader &r1, const hist::HistogramReader &r2,
 				PT_NODE *lhs, PT_NODE *rhs,
-				double &matchprodfreq, double &matchfreq1, double &matchfreq2, int &nmatches);
+				double &matchprodfreq, double &matchfreq1, double &matchfreq2,
+				int &nmatches1, int &nmatches2);
 
 /*
  * analyze_classes ()
@@ -908,18 +907,41 @@ histogram_get_equal_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *s
       break;
     case hist::histogram_key_kind::str:
     {
+      const DB_TYPE probe_type = DB_VALUE_TYPE (rhs_db_value);
+
+      if (probe_type == DB_TYPE_BIT || probe_type == DB_TYPE_VARBIT)
+	{
+	  /* bit strings have no collation: db_string_compare () rejects the CHAR-vs-BIT
+	   * category mix outright, and plain byte equality is already exact for them */
+	  mcv_index = histogram_reader.find_mcv<std::string_view> (std::string_view (key.str));
+	  break;
+	}
+
       /* Runtime equality resolves the common collation of the column and the probe, so a
        * whole equivalence class can match (case variants under a _ci collation) even though
        * the byte-sorted MCV list stores them as distinct entries. Sweep the list with the
        * runtime comparator and sum every matching MCV's mass; under a binary collation this
-       * reproduces the plain byte lookup. */
-      int codeset, collation;
+       * reproduces the plain byte lookup. The probe bytes are key.str, NOT the raw constant:
+       * the sampler strips trailing spaces from stored CHAR values and histogram_extract_key
+       * strips the probe to match -- the raw constant would compare padded against stripped.
+       * Both sides are built under the resolved common collation, which db_string_compare ()
+       * requires as a precondition. */
+      int column_codeset, column_collation;
+      int common_coll_id = -1;
+
       histogram_lhs_string_domain (lhs, db_get_string_codeset (rhs_db_value),
-				   db_get_string_collation (rhs_db_value), &codeset, &collation);
+				   db_get_string_collation (rhs_db_value), &column_codeset, &column_collation);
+      LANG_RT_COMMON_COLL (column_collation, db_get_string_collation (rhs_db_value), common_coll_id);
+      if (common_coll_id == -1)
+	{
+	  *success = false;
+	  return;
+	}
+
       for (int i = 0; i < static_cast<int> (histogram_reader.mcv_count ()); i++)
 	{
-	  if (string_hist_value_equals_db_value (histogram_reader.mcv_hi<std::string_view> (i),
-						 codeset, collation, rhs_db_value))
+	  if (string_values_equal_under_collation (histogram_reader.mcv_hi<std::string_view> (i),
+	      std::string_view (key.str), column_codeset, common_coll_id))
 	    {
 	      mcv_matched_freq += histogram_reader.mcv_freq (i);
 	    }
@@ -1204,19 +1226,30 @@ mcv_join_parts (const hist::HistogramReader &r1, const hist::HistogramReader &r2
 static void
 mcv_join_parts_str (const hist::HistogramReader &r1, const hist::HistogramReader &r2,
 		    PT_NODE *lhs, PT_NODE *rhs,
-		    double &matchprodfreq, double &matchfreq1, double &matchfreq2, int &nmatches)
+		    double &matchprodfreq, double &matchfreq1, double &matchfreq2,
+		    int &nmatches1, int &nmatches2)
 {
   const int n1 = static_cast<int> (r1.mcv_count ());
   const int n2 = static_cast<int> (r2.mcv_count ());
   int codeset1, collation1, codeset2, collation2;
+  int common_coll_id = -1;
 
   matchprodfreq = 0.0;
   matchfreq1 = 0.0;
   matchfreq2 = 0.0;
-  nmatches = 0;
+  nmatches1 = 0;
+  nmatches2 = 0;
 
   histogram_lhs_string_domain (lhs, LANG_SYS_CODESET, LANG_SYS_COLLATION, &codeset1, &collation1);
   histogram_lhs_string_domain (rhs, codeset1, collation1, &codeset2, &collation2);
+
+  /* db_string_compare () requires pre-aligned collations; resolve the two columns' common
+   * collation once, exactly like the executor does for the join predicate */
+  LANG_RT_COMMON_COLL (collation1, collation2, common_coll_id);
+  if (common_coll_id == -1)
+    {
+      return;			/* incompatible collations: execution would error out too */
+    }
 
   std::vector<bool> matched2 (static_cast<std::size_t> (n2), false);
 
@@ -1227,8 +1260,8 @@ mcv_join_parts_str (const hist::HistogramReader &r1, const hist::HistogramReader
 
       for (int j = 0; j < n2; j++)
 	{
-	  if (string_hist_values_equal (v1, codeset1, collation1,
-					r2.mcv_hi<std::string_view> (j), codeset2, collation2))
+	  if (string_values_equal_under_collation (v1, r2.mcv_hi<std::string_view> (j),
+	      codeset1, common_coll_id))
 	    {
 	      matchprodfreq += r1.mcv_freq (i) * r2.mcv_freq (j);
 	      matched_i = true;
@@ -1239,7 +1272,7 @@ mcv_join_parts_str (const hist::HistogramReader &r1, const hist::HistogramReader
       if (matched_i)
 	{
 	  matchfreq1 += r1.mcv_freq (i);
-	  nmatches++;
+	  nmatches1++;
 	}
     }
 
@@ -1248,6 +1281,7 @@ mcv_join_parts_str (const hist::HistogramReader &r1, const hist::HistogramReader
       if (matched2[static_cast<std::size_t> (j)])
 	{
 	  matchfreq2 += r2.mcv_freq (j);
+	  nmatches2++;
 	}
     }
 }
@@ -1297,21 +1331,35 @@ histogram_get_join_selectivity (PT_NODE *lhs, PT_NODE *rhs, double *selectivity,
   double matchprodfreq = 0.0;
   double matchfreq1 = 0.0;
   double matchfreq2 = 0.0;
-  int nmatches = 0;
+  int nmatches1 = 0;
+  int nmatches2 = 0;
 
   switch (kind)
     {
     case hist::histogram_key_kind::i64:
-      mcv_join_parts<std::int64_t> (reader1, reader2, matchprodfreq, matchfreq1, matchfreq2, nmatches);
+      mcv_join_parts<std::int64_t> (reader1, reader2, matchprodfreq, matchfreq1, matchfreq2, nmatches1);
+      nmatches2 = nmatches1;
       break;
     case hist::histogram_key_kind::dbl:
-      mcv_join_parts<double> (reader1, reader2, matchprodfreq, matchfreq1, matchfreq2, nmatches);
+      mcv_join_parts<double> (reader1, reader2, matchprodfreq, matchfreq1, matchfreq2, nmatches1);
+      nmatches2 = nmatches1;
       break;
     case hist::histogram_key_kind::str:
-      mcv_join_parts_str (reader1, reader2, lhs, rhs, matchprodfreq, matchfreq1, matchfreq2, nmatches);
+      if (reader1.value_type () == DB_TYPE_BIT || reader1.value_type () == DB_TYPE_VARBIT)
+	{
+	  /* bit strings have no collation; the byte two-pointer merge is already exact */
+	  mcv_join_parts<std::string_view> (reader1, reader2, matchprodfreq, matchfreq1, matchfreq2, nmatches1);
+	  nmatches2 = nmatches1;
+	}
+      else
+	{
+	  mcv_join_parts_str (reader1, reader2, lhs, rhs, matchprodfreq, matchfreq1, matchfreq2,
+			      nmatches1, nmatches2);
+	}
       break;
     case hist::histogram_key_kind::u64:
-      mcv_join_parts<std::uint64_t> (reader1, reader2, matchprodfreq, matchfreq1, matchfreq2, nmatches);
+      mcv_join_parts<std::uint64_t> (reader1, reader2, matchprodfreq, matchfreq1, matchfreq2, nmatches1);
+      nmatches2 = nmatches1;
       break;
     case hist::histogram_key_kind::invalid:
     default:
@@ -1346,9 +1394,11 @@ histogram_get_join_selectivity (PT_NODE *lhs, PT_NODE *rhs, double *selectivity,
     {
       totalsel1 += unmatchfreq1 * otherfreq2 / (nd2 - nmcv2);
     }
-  if (nd2 > nmatches)
+  if (nd2 > nmatches2)
     {
-      totalsel1 += otherfreq1 * (otherfreq2 + unmatchfreq2) / (nd2 - nmatches);
+      /* the many-to-many collation-aware match can count matched MCVs differently per side;
+       * each viewpoint's denominator must exclude ITS OWN side's matched distinct values */
+      totalsel1 += otherfreq1 * (otherfreq2 + unmatchfreq2) / (nd2 - nmatches2);
     }
 
   double totalsel2 = matchprodfreq;
@@ -1356,9 +1406,9 @@ histogram_get_join_selectivity (PT_NODE *lhs, PT_NODE *rhs, double *selectivity,
     {
       totalsel2 += unmatchfreq2 * otherfreq1 / (nd1 - nmcv1);
     }
-  if (nd1 > nmatches)
+  if (nd1 > nmatches1)
     {
-      totalsel2 += otherfreq2 * (otherfreq1 + unmatchfreq1) / (nd1 - nmatches);
+      totalsel2 += otherfreq2 * (otherfreq1 + unmatchfreq1) / (nd1 - nmatches1);
     }
 
   /* the smaller estimate is the view from the larger-NDV side */
@@ -1465,61 +1515,63 @@ pattern_heuristic_selectivity (const std::string &pattern, char escape_char)
 static bool
 like_match_value (const DB_VALUE *pattern_db_value, int src_collation_id, std::string_view value)
 {
-  DB_VALUE src;
+  DB_VALUE src, pattern;
   int res = V_FALSE;
   int err;
+  int common_coll_id = -1;
 
   /* Match through the runtime evaluator (db_string_like) so the estimate cannot diverge from
    * execution: it matches '_' per character (not per byte) and folds case under the common
    * collation of the column and the pattern, neither of which a byte-wise matcher can do.
-   * value is a string_view into the histogram blob (NOT NUL-terminated, not owned): give the
-   * transient DB_VALUE the pattern's codeset (a valid query guarantees compatibility) and the
-   * COLUMN's collation, exactly like the runtime source operand. */
+   * The string comparison layer requires pre-aligned collations, so both transient operands
+   * are built under the resolved common collation of the column and the pattern -- the same
+   * alignment the executor guarantees. value is a string_view into the histogram blob (NOT
+   * NUL-terminated, not owned). */
+  LANG_RT_COMMON_COLL (src_collation_id, db_get_string_collation (pattern_db_value), common_coll_id);
+  if (common_coll_id == -1)
+    {
+      return false;
+    }
+
   db_make_varchar (&src, DB_MAX_VARCHAR_PRECISION, value.data (), static_cast<int> (value.size ()),
-		   db_get_string_codeset (pattern_db_value), src_collation_id);
+		   db_get_string_codeset (pattern_db_value), common_coll_id);
+  db_make_varchar (&pattern, DB_MAX_VARCHAR_PRECISION, db_get_string (pattern_db_value),
+		   db_get_string_size (pattern_db_value), db_get_string_codeset (pattern_db_value),
+		   common_coll_id);
 
   /* db_string_like () er_set()s on type/codeset failures; a planning probe must not leave that
    * in the global error state -- shield it and treat the value as unmatched */
   er_stack_push ();
-  err = db_string_like (&src, pattern_db_value, NULL, &res);
+  err = db_string_like (&src, &pattern, NULL, &res);
   er_stack_pop ();
 
   return (err == NO_ERROR && res == V_TRUE);
 }
 
-/* runtime-equivalent equality between two histogram-blob string slots (or a slot and a probe
- * constant, via the DB_VALUE overload below): db_string_compare () resolves the common collation
- * exactly like the executor, so collation-equal values (e.g. case variants under a _ci collation)
- * compare equal even though their bytes differ */
+/* runtime-equivalent equality between two raw string values (histogram-blob slots or an
+ * extracted probe key). db_string_compare () REQUIRES its operands' collations to be already
+ * aligned (it asserts equality after the coercibility check), so both transient DB_VALUEs are
+ * built under the caller-resolved COMMON collation -- the same alignment the executor
+ * guarantees before comparing. Collation-equal values (e.g. case variants under a _ci
+ * collation) then compare equal even though their bytes differ. */
 static bool
-string_hist_value_equals_db_value (std::string_view hist_value, int hist_codeset, int hist_collation,
-				   const DB_VALUE *probe)
+string_values_equal_under_collation (std::string_view v1, std::string_view v2, int codeset, int collation)
 {
-  DB_VALUE hist_dbval, cmp_result;
+  DB_VALUE dbval1, dbval2, cmp_result;
   int err;
 
-  db_make_varchar (&hist_dbval, DB_MAX_VARCHAR_PRECISION, hist_value.data (),
-		   static_cast<int> (hist_value.size ()), hist_codeset, hist_collation);
+  db_make_varchar (&dbval1, DB_MAX_VARCHAR_PRECISION, v1.data (), static_cast<int> (v1.size ()),
+		   codeset, collation);
+  db_make_varchar (&dbval2, DB_MAX_VARCHAR_PRECISION, v2.data (), static_cast<int> (v2.size ()),
+		   codeset, collation);
   db_make_null (&cmp_result);
 
   /* db_string_compare () er_set()s on codeset failures; shield the planning probe */
   er_stack_push ();
-  err = db_string_compare (&hist_dbval, probe, &cmp_result);
+  err = db_string_compare (&dbval1, &dbval2, &cmp_result);
   er_stack_pop ();
 
   return (err == NO_ERROR && DB_VALUE_TYPE (&cmp_result) == DB_TYPE_INTEGER && db_get_int (&cmp_result) == 0);
-}
-
-static bool
-string_hist_values_equal (std::string_view v1, int codeset1, int collation1,
-			  std::string_view v2, int codeset2, int collation2)
-{
-  DB_VALUE dbval2;
-
-  db_make_varchar (&dbval2, DB_MAX_VARCHAR_PRECISION, v2.data (), static_cast<int> (v2.size ()),
-		   codeset2, collation2);
-
-  return string_hist_value_equals_db_value (v1, codeset1, collation1, &dbval2);
 }
 
 /* column collation/codeset for a histogram-carrying operand; falls back to the given values
@@ -1563,8 +1615,9 @@ histogram_get_like_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *se
   const double total_rows = histogram_reader.total_rows ();
   if (total_rows <= 0.0)
     {
-      *success = true;
-      *selectivity = 0.0;
+      /* stale/empty statistics: fall back to the caller's guess instead of returning a
+       * zero-row estimate (matches histogram_get_equal_selectivity's convention) */
+      *success = false;
       return;
     }
 
@@ -1579,6 +1632,14 @@ histogram_get_like_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *se
     {
       /* LIKE probes decode the value slots as strings; a non-string blob (stale after ALTER)
        * would yield out-of-range string reads */
+      *success = false;
+      return;
+    }
+
+  if (histogram_reader.value_type () == DB_TYPE_BIT || histogram_reader.value_type () == DB_TYPE_VARBIT)
+    {
+      /* bit strings share the str storage kind but have no collation; the runtime string
+       * matcher rejects the CHAR-vs-BIT category mix, so every probe would silently miss */
       *success = false;
       return;
     }
@@ -1722,8 +1783,9 @@ histogram_get_rlike_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, bool case
   const double total_rows = histogram_reader.total_rows ();
   if (total_rows <= 0.0)
     {
-      *success = true;
-      *selectivity = 0.0;
+      /* stale/empty statistics: fall back to the caller's guess instead of returning a
+       * zero-row estimate (matches histogram_get_equal_selectivity's convention) */
+      *success = false;
       return;
     }
 
@@ -1737,6 +1799,12 @@ histogram_get_rlike_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, bool case
     {
       /* the probes below decode the value slots as strings; a non-string blob (stale after
        * ALTER) would yield out-of-range string reads */
+      return;
+    }
+
+  if (histogram_reader.value_type () == DB_TYPE_BIT || histogram_reader.value_type () == DB_TYPE_VARBIT)
+    {
+      /* bit strings have no collation and no regex semantics at the storage level */
       return;
     }
 

--- a/src/optimizer/histogram/histogram_cl.cpp
+++ b/src/optimizer/histogram/histogram_cl.cpp
@@ -882,8 +882,9 @@ histogram_get_equal_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *s
   if (key.kind != histogram_key_kind_for_type (histogram_reader.value_type ()))
     {
       /* probe constant does not match the column's stored value encoding (e.g. an integer column
-       * probed with a fractional constant, or a stale blob after ALTER changed the column type);
-       * decoding the slots with the wrong template would produce garbage. Use default estimates. */
+       * probed with a fractional constant). A blob/column type disagreement has no known
+       * producing path today (ALTER drops the histogram outright) but stays guarded: decoding
+       * the slots with the wrong template would produce garbage. Use default estimates. */
       *success = false;
       return;
     }
@@ -1048,8 +1049,9 @@ histogram_get_comp_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, bool is_ge
 	 * range probes commonly carry a cross-kind numeric constant -- price < 100 on a
 	 * DOUBLE/NUMERIC column, c_int < 5000.0 -- and rejecting them here would discard the
 	 * histogram for the most common range predicates. Promote safe numeric cases to the
-	 * column's stored kind; anything else (string vs numeric, datetime vs numeric, a stale
-	 * blob after ALTER) still falls back to the default estimate, since decoding the slots
+	 * column's stored kind; anything else (string vs numeric, datetime vs numeric, a
+	 * blob/column kind disagreement -- no known producing path today) still falls back to
+	 * the default estimate, since decoding the slots
 	 * with the wrong template would produce garbage. */
 	if (col_kind == hist::histogram_key_kind::dbl && key.kind == hist::histogram_key_kind::i64)
 	  {
@@ -1630,8 +1632,9 @@ histogram_get_like_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *se
 
   if (histogram_key_kind_for_type (histogram_reader.value_type ()) != hist::histogram_key_kind::str)
     {
-      /* LIKE probes decode the value slots as strings; a non-string blob (stale after ALTER)
-       * would yield out-of-range string reads */
+      /* defense against a blob whose value kind disagrees with the column: no known path
+       * produces one today (ALTER drops the histogram outright), but decoding a non-string
+       * blob as strings would yield out-of-range reads, so keep the guard as a safety net */
       *success = false;
       return;
     }
@@ -1644,12 +1647,17 @@ histogram_get_like_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *se
       return;
     }
 
-  const std::string &pattern = db_get_string (rhs_db_value);
-  if (pattern.empty())
+  /* extract by the stored size, not strlen: a constant-folded pattern can carry an embedded
+   * NUL (e.g. 'ab' || CHR(0) || 'cd') and truncating it would match a different pattern than
+   * execution does (same convention as histogram_get_rlike_selectivity) */
+  const char *pattern_p = db_get_string (rhs_db_value);
+  const int pattern_size = db_get_string_size (rhs_db_value);
+  if (pattern_p == NULL || pattern_size <= 0)
     {
       *success = false;
       return;
     }
+  const std::string pattern (pattern_p, pattern_size);
 
   /* the runtime source operand carries the COLUMN's collation; mirror it (fall back to the
    * pattern's collation when the column node carries no data_type) */
@@ -1797,8 +1805,9 @@ histogram_get_rlike_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, bool case
 
   if (histogram_key_kind_for_type (histogram_reader.value_type ()) != hist::histogram_key_kind::str)
     {
-      /* the probes below decode the value slots as strings; a non-string blob (stale after
-       * ALTER) would yield out-of-range string reads */
+      /* defense against a blob whose value kind disagrees with the column: no known path
+       * produces one today (ALTER drops the histogram outright); kept as a safety net
+       * against out-of-range string reads */
       return;
     }
 

--- a/src/optimizer/histogram/histogram_cl.cpp
+++ b/src/optimizer/histogram/histogram_cl.cpp
@@ -1626,7 +1626,21 @@ histogram_get_rlike_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, bool case
     }
   const std::string pattern (pattern_p, pattern_size);
 
-  LANG_COLLATION *collation = lang_get_collation (db_get_string_collation (rhs_db_value));
+  /* Runtime matching (db_string_rlike) compiles under the COMMON collation of the column and
+   * the pattern (LANG_RT_COMMON_COLL); mirror it so locale-driven case folding in the estimate
+   * cannot diverge from execution. Fall back to the pattern's collation when the column node
+   * carries no data_type. */
+  PT_NODE *lhs_name = pt_get_end_path_node (lhs);
+  int lhs_coll_id = (lhs_name != NULL && lhs_name->data_type != NULL)
+		    ? lhs_name->data_type->info.data_type.collation_id : db_get_string_collation (rhs_db_value);
+  int common_coll_id = -1;
+  LANG_RT_COMMON_COLL (lhs_coll_id, db_get_string_collation (rhs_db_value), common_coll_id);
+  if (common_coll_id == -1)
+    {
+      return;
+    }
+
+  LANG_COLLATION *collation = lang_get_collation (common_coll_id);
   if (collation == NULL)
     {
       return;

--- a/src/optimizer/histogram/histogram_cl.cpp
+++ b/src/optimizer/histogram/histogram_cl.cpp
@@ -42,6 +42,9 @@
 #include "object_accessor.h"
 #include "authenticate.h"
 #include "query_planner.h"
+#include "string_regex.hpp"
+#include "language_support.h"
+#include "error_manager.h"
 
 static bool histogram_extract_key (const DB_VALUE *db_val, hist::histogram_key &key);
 static int store_one_histogram (MOP classop, const char *attr_name, char *blob, int blob_length, double null_freq);
@@ -1523,6 +1526,168 @@ histogram_get_like_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *se
   else
     {
       total_non_mcv_sel = pattern_sel;
+    }
+
+  /* don't believe extremely small or large estimates for the histogram part. */
+  if (total_non_mcv_sel < 0.0001)
+    {
+      total_non_mcv_sel = 0.0001;
+    }
+  else if (total_non_mcv_sel > 0.9999)
+    {
+      total_non_mcv_sel = 0.9999;
+    }
+
+  /* total = Σ matching-MCV freq + (non-null non-MCV mass) * non-MCV match fraction. */
+  double nonmcv_mass = 1.0 - nullfrac - mcvsum;
+  if (nonmcv_mass < 0.0)
+    {
+      nonmcv_mass = 0.0;
+    }
+
+  *selectivity = matched_mcv_freq + nonmcv_mass * total_non_mcv_sel;
+
+  /* return a non-null-conditional selectivity; the caller multiplies by (1 - nullfrac).
+   * (see histogram_get_equal_selectivity for the rationale) */
+  const double nonnull_frac = 1.0 - nullfrac;
+  if (nonnull_frac > 1e-9)
+    {
+      *selectivity /= nonnull_frac;
+    }
+
+  *selectivity = std::max (1.0 / total_rows, *selectivity);
+
+  *success = true;
+  return;
+}
+
+static bool
+rlike_match_string (const cubregex::compiled_regex &reg, std::string_view value)
+{
+  int res = V_FALSE;
+
+  /* value is a string_view into the histogram blob: NOT NUL-terminated, so copy by length */
+  if (cubregex::search (res, reg, std::string (value)) != NO_ERROR)
+    {
+      return false;
+    }
+
+  return res == V_TRUE;
+}
+
+void
+histogram_get_rlike_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, bool case_sensitive,
+				 double fallback_sel, double *selectivity, bool *success)
+{
+  assert (selectivity != NULL);
+
+  *success = false;
+
+  if (rhs_db_value == NULL || DB_IS_NULL (rhs_db_value))
+    {
+      return;
+    }
+
+  hist::HistogramReader histogram_reader;
+  if (!histogram_init_reader_from_lhs (lhs, histogram_reader))
+    {
+      return;
+    }
+
+  const double total_rows = histogram_reader.total_rows ();
+  if (total_rows <= 0.0)
+    {
+      *success = true;
+      *selectivity = 0.0;
+      return;
+    }
+
+  if (DB_VALUE_TYPE (rhs_db_value) != DB_TYPE_STRING
+      && DB_VALUE_TYPE (rhs_db_value) != DB_TYPE_CHAR)
+    {
+      return;
+    }
+
+  if (histogram_key_kind_for_type (histogram_reader.value_type ()) != hist::histogram_key_kind::str)
+    {
+      /* the probes below decode the value slots as strings; a non-string blob (stale after
+       * ALTER) would yield out-of-range string reads */
+      return;
+    }
+
+  const char *pattern_p = db_get_string (rhs_db_value);
+  const int pattern_size = db_get_string_size (rhs_db_value);
+  if (pattern_p == NULL || pattern_size <= 0)
+    {
+      return;
+    }
+  const std::string pattern (pattern_p, pattern_size);
+
+  LANG_COLLATION *collation = lang_get_collation (db_get_string_collation (rhs_db_value));
+  if (collation == NULL)
+    {
+      return;
+    }
+
+  /* An invalid pattern must keep raising its error at execution time, not at planning time:
+   * shield the global error state and fall back to the caller's guess on compile failure. */
+  cubregex::compiled_regex *compiled = NULL;
+  er_stack_push ();
+  const int comp_err = cubregex::compile (compiled, pattern, case_sensitive ? "c" : "i", collation);
+  er_stack_pop ();
+  if (comp_err != NO_ERROR || compiled == NULL)
+    {
+      delete compiled;
+      return;
+    }
+
+  /* MCVs: exact regex test against each MCV value, weighted by its population frequency. */
+  double matched_mcv_freq = 0.0;
+  const double mcvsum = histogram_reader.mcv_total_frequency ();
+  const double nullfrac = histogram_reader.null_frequency ();
+
+  for (int i = 0; i < static_cast<int> (histogram_reader.mcv_count ()); i++)
+    {
+      if (rlike_match_string (*compiled, histogram_reader.mcv_hi<std::string_view> (i)))
+	{
+	  matched_mcv_freq += histogram_reader.mcv_freq (i);
+	}
+    }
+
+  /* Non-MCV buckets: fraction of bucket boundary values matching the regex, treating the
+   * boundaries as a sample of the column population. */
+  double matched_non_mcv_buckets = 0.0;
+  double non_mcv_buckets = 0.0;
+
+  for (int i = 0; i < static_cast<int> (histogram_reader.bucket_count ()); i++)
+    {
+      non_mcv_buckets += 1.0;
+      if (rlike_match_string (*compiled, histogram_reader.bucket_hi<std::string_view> (i)))
+	{
+	  matched_non_mcv_buckets += 1.0;
+	}
+    }
+
+  delete compiled;
+
+  /* Unlike LIKE there is no per-character heuristic for a regex, so the caller's fallback
+   * guess takes that role: trust the boundary-match fraction fully once the histogram is
+   * large enough (>=100 entries); blend for 10..99 entries; below 10 keep the fallback. */
+  double total_non_mcv_sel;
+  const int hist_size = static_cast<int> (non_mcv_buckets);
+  if (hist_size >= 100)
+    {
+      total_non_mcv_sel = matched_non_mcv_buckets / non_mcv_buckets;
+    }
+  else if (hist_size >= 10)
+    {
+      const double matched_buckets_sel = matched_non_mcv_buckets / non_mcv_buckets;
+      const double w = static_cast<double> (hist_size) / 100.0;
+      total_non_mcv_sel = matched_buckets_sel * w + fallback_sel * (1.0 - w);
+    }
+  else
+    {
+      total_non_mcv_sel = fallback_sel;
     }
 
   /* don't believe extremely small or large estimates for the histogram part. */

--- a/src/optimizer/histogram/histogram_cl.cpp
+++ b/src/optimizer/histogram/histogram_cl.cpp
@@ -48,6 +48,15 @@
 
 static bool histogram_extract_key (const DB_VALUE *db_val, hist::histogram_key &key);
 static int store_one_histogram (MOP classop, const char *attr_name, char *blob, int blob_length, double null_freq);
+static bool string_hist_value_equals_db_value (std::string_view hist_value, int hist_codeset, int hist_collation,
+    const DB_VALUE *probe);
+static bool string_hist_values_equal (std::string_view v1, int codeset1, int collation1,
+				      std::string_view v2, int codeset2, int collation2);
+static void histogram_lhs_string_domain (PT_NODE *lhs, int fallback_codeset, int fallback_collation,
+    int *codeset, int *collation);
+static void mcv_join_parts_str (const hist::HistogramReader &r1, const hist::HistogramReader &r2,
+				PT_NODE *lhs, PT_NODE *rhs,
+				double &matchprodfreq, double &matchfreq1, double &matchfreq2, int &nmatches);
 
 /*
  * analyze_classes ()
@@ -888,6 +897,7 @@ histogram_get_equal_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *s
     }
 
   int mcv_index = -1;
+  double mcv_matched_freq = 0.0;
   switch (key.kind)
     {
     case hist::histogram_key_kind::i64:
@@ -897,8 +907,25 @@ histogram_get_equal_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *s
       mcv_index = histogram_reader.find_mcv<double> (key.dbl);
       break;
     case hist::histogram_key_kind::str:
-      mcv_index = histogram_reader.find_mcv<std::string_view> (std::string_view (key.str));
+    {
+      /* Runtime equality resolves the common collation of the column and the probe, so a
+       * whole equivalence class can match (case variants under a _ci collation) even though
+       * the byte-sorted MCV list stores them as distinct entries. Sweep the list with the
+       * runtime comparator and sum every matching MCV's mass; under a binary collation this
+       * reproduces the plain byte lookup. */
+      int codeset, collation;
+      histogram_lhs_string_domain (lhs, db_get_string_codeset (rhs_db_value),
+				   db_get_string_collation (rhs_db_value), &codeset, &collation);
+      for (int i = 0; i < static_cast<int> (histogram_reader.mcv_count ()); i++)
+	{
+	  if (string_hist_value_equals_db_value (histogram_reader.mcv_hi<std::string_view> (i),
+						 codeset, collation, rhs_db_value))
+	    {
+	      mcv_matched_freq += histogram_reader.mcv_freq (i);
+	    }
+	}
       break;
+    }
     case hist::histogram_key_kind::u64:
       mcv_index = histogram_reader.find_mcv<std::uint64_t> (key.u64);
       break;
@@ -913,6 +940,11 @@ histogram_get_equal_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *s
     {
       /* an MCV's population frequency is its stored frequency. */
       *selectivity = histogram_reader.mcv_freq (mcv_index);
+    }
+  else if (mcv_matched_freq > 0.0)
+    {
+      /* the collation-aware sweep above: total mass of the probe's equivalence class */
+      *selectivity = mcv_matched_freq;
     }
   else
     {
@@ -1162,6 +1194,65 @@ mcv_join_parts (const hist::HistogramReader &r1, const hist::HistogramReader &r2
 }
 
 /*
+ * mcv_join_parts_str () - collation-aware variant of mcv_join_parts () for string columns.
+ * The MCV lists are byte-sorted, but runtime join equality resolves the common collation of
+ * the two columns, under which byte-distant values can be equal (case variants under a _ci
+ * collation) -- a two-pointer merge over byte order would miss them. Compare every pair with
+ * the runtime comparator instead; the lists are capped (MCV count), so the nested loop stays
+ * cheap at plan time.
+ */
+static void
+mcv_join_parts_str (const hist::HistogramReader &r1, const hist::HistogramReader &r2,
+		    PT_NODE *lhs, PT_NODE *rhs,
+		    double &matchprodfreq, double &matchfreq1, double &matchfreq2, int &nmatches)
+{
+  const int n1 = static_cast<int> (r1.mcv_count ());
+  const int n2 = static_cast<int> (r2.mcv_count ());
+  int codeset1, collation1, codeset2, collation2;
+
+  matchprodfreq = 0.0;
+  matchfreq1 = 0.0;
+  matchfreq2 = 0.0;
+  nmatches = 0;
+
+  histogram_lhs_string_domain (lhs, LANG_SYS_CODESET, LANG_SYS_COLLATION, &codeset1, &collation1);
+  histogram_lhs_string_domain (rhs, codeset1, collation1, &codeset2, &collation2);
+
+  std::vector<bool> matched2 (static_cast<std::size_t> (n2), false);
+
+  for (int i = 0; i < n1; i++)
+    {
+      const std::string_view v1 = r1.mcv_hi<std::string_view> (i);
+      bool matched_i = false;
+
+      for (int j = 0; j < n2; j++)
+	{
+	  if (string_hist_values_equal (v1, codeset1, collation1,
+					r2.mcv_hi<std::string_view> (j), codeset2, collation2))
+	    {
+	      matchprodfreq += r1.mcv_freq (i) * r2.mcv_freq (j);
+	      matched_i = true;
+	      matched2[static_cast<std::size_t> (j)] = true;
+	    }
+	}
+
+      if (matched_i)
+	{
+	  matchfreq1 += r1.mcv_freq (i);
+	  nmatches++;
+	}
+    }
+
+  for (int j = 0; j < n2; j++)
+    {
+      if (matched2[static_cast<std::size_t> (j)])
+	{
+	  matchfreq2 += r2.mcv_freq (j);
+	}
+    }
+}
+
+/*
  * histogram_get_join_selectivity () - equijoin (attr = attr) selectivity from both sides'
  *   histograms: instead of assuming uniform, fully-overlapping value sets (1/max NDV), the
  *   estimate is built from the two columns' actual value distributions.
@@ -1217,7 +1308,7 @@ histogram_get_join_selectivity (PT_NODE *lhs, PT_NODE *rhs, double *selectivity,
       mcv_join_parts<double> (reader1, reader2, matchprodfreq, matchfreq1, matchfreq2, nmatches);
       break;
     case hist::histogram_key_kind::str:
-      mcv_join_parts<std::string_view> (reader1, reader2, matchprodfreq, matchfreq1, matchfreq2, nmatches);
+      mcv_join_parts_str (reader1, reader2, lhs, rhs, matchprodfreq, matchfreq1, matchfreq2, nmatches);
       break;
     case hist::histogram_key_kind::u64:
       mcv_join_parts<std::uint64_t> (reader1, reader2, matchprodfreq, matchfreq1, matchfreq2, nmatches);
@@ -1372,58 +1463,83 @@ pattern_heuristic_selectivity (const std::string &pattern, char escape_char)
 }
 
 static bool
-like_match_string (const std::string &pattern, std::string_view value)
+like_match_value (const DB_VALUE *pattern_db_value, int src_collation_id, std::string_view value)
 {
-  if (pattern.empty())
+  DB_VALUE src;
+  int res = V_FALSE;
+  int err;
+
+  /* Match through the runtime evaluator (db_string_like) so the estimate cannot diverge from
+   * execution: it matches '_' per character (not per byte) and folds case under the common
+   * collation of the column and the pattern, neither of which a byte-wise matcher can do.
+   * value is a string_view into the histogram blob (NOT NUL-terminated, not owned): give the
+   * transient DB_VALUE the pattern's codeset (a valid query guarantees compatibility) and the
+   * COLUMN's collation, exactly like the runtime source operand. */
+  db_make_varchar (&src, DB_MAX_VARCHAR_PRECISION, value.data (), static_cast<int> (value.size ()),
+		   db_get_string_codeset (pattern_db_value), src_collation_id);
+
+  /* db_string_like () er_set()s on type/codeset failures; a planning probe must not leave that
+   * in the global error state -- shield it and treat the value as unmatched */
+  er_stack_push ();
+  err = db_string_like (&src, pattern_db_value, NULL, &res);
+  er_stack_pop ();
+
+  return (err == NO_ERROR && res == V_TRUE);
+}
+
+/* runtime-equivalent equality between two histogram-blob string slots (or a slot and a probe
+ * constant, via the DB_VALUE overload below): db_string_compare () resolves the common collation
+ * exactly like the executor, so collation-equal values (e.g. case variants under a _ci collation)
+ * compare equal even though their bytes differ */
+static bool
+string_hist_value_equals_db_value (std::string_view hist_value, int hist_codeset, int hist_collation,
+				   const DB_VALUE *probe)
+{
+  DB_VALUE hist_dbval, cmp_result;
+  int err;
+
+  db_make_varchar (&hist_dbval, DB_MAX_VARCHAR_PRECISION, hist_value.data (),
+		   static_cast<int> (hist_value.size ()), hist_codeset, hist_collation);
+  db_make_null (&cmp_result);
+
+  /* db_string_compare () er_set()s on codeset failures; shield the planning probe */
+  er_stack_push ();
+  err = db_string_compare (&hist_dbval, probe, &cmp_result);
+  er_stack_pop ();
+
+  return (err == NO_ERROR && DB_VALUE_TYPE (&cmp_result) == DB_TYPE_INTEGER && db_get_int (&cmp_result) == 0);
+}
+
+static bool
+string_hist_values_equal (std::string_view v1, int codeset1, int collation1,
+			  std::string_view v2, int codeset2, int collation2)
+{
+  DB_VALUE dbval2;
+
+  db_make_varchar (&dbval2, DB_MAX_VARCHAR_PRECISION, v2.data (), static_cast<int> (v2.size ()),
+		   codeset2, collation2);
+
+  return string_hist_value_equals_db_value (v1, codeset1, collation1, &dbval2);
+}
+
+/* column collation/codeset for a histogram-carrying operand; falls back to the given values
+ * when the resolved name carries no data_type node */
+static void
+histogram_lhs_string_domain (PT_NODE *lhs, int fallback_codeset, int fallback_collation,
+			     int *codeset, int *collation)
+{
+  PT_NODE *name = pt_get_end_path_node (lhs);
+
+  if (name != NULL && name->data_type != NULL)
     {
-      return false;
+      *codeset = name->data_type->info.data_type.units;
+      *collation = name->data_type->info.data_type.collation_id;
     }
-
-  const char *p = pattern.c_str ();
-  const char *s = value.data ();
-  /* value is a string_view into the histogram blob: NOT NUL-terminated; iterate by length */
-  const char *s_end = s + value.size ();
-
-  /* most recent '%' position in pattern */
-  const char *last_percent = nullptr;
-  /* position in string that corresponds to retry after '%' */
-  const char *last_match = nullptr;
-
-  while (s < s_end)
+  else
     {
-      if (*p == '%')
-	{
-	  /* '%' matches any sequence, including empty */
-	  last_percent = p;
-	  ++p;
-	  last_match = s;
-	}
-      else if (*p == '_' || *p == *s)
-	{
-	  /* '_' matches any single character */
-	  ++p;
-	  ++s;
-	}
-      else if (last_percent != nullptr)
-	{
-	  /* backtrack: let previous '%' absorb one more character */
-	  p = last_percent + 1;
-	  ++last_match;
-	  s = last_match;
-	}
-      else
-	{
-	  return false;
-	}
+      *codeset = fallback_codeset;
+      *collation = fallback_collation;
     }
-
-  /* trailing '%' can match empty suffix */
-  while (*p == '%')
-    {
-      ++p;
-    }
-
-  return (*p == '\0');
 }
 
 void
@@ -1474,6 +1590,12 @@ histogram_get_like_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *se
       return;
     }
 
+  /* the runtime source operand carries the COLUMN's collation; mirror it (fall back to the
+   * pattern's collation when the column node carries no data_type) */
+  PT_NODE *lhs_name = pt_get_end_path_node (lhs);
+  int src_coll_id = (lhs_name != NULL && lhs_name->data_type != NULL)
+		    ? lhs_name->data_type->info.data_type.collation_id : db_get_string_collation (rhs_db_value);
+
   /* MCVs: exact LIKE test against each MCV value, weighted by its population frequency. */
   double matched_mcv_freq = 0.0;
   const double mcvsum = histogram_reader.mcv_total_frequency ();
@@ -1482,7 +1604,7 @@ histogram_get_like_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *se
   for (int i = 0; i < static_cast<int> (histogram_reader.mcv_count ()); i++)
     {
       const std::string_view mcv_val = histogram_reader.mcv_hi<std::string_view> (i);
-      if (like_match_string (pattern, mcv_val))
+      if (like_match_value (rhs_db_value, src_coll_id, mcv_val))
 	{
 	  matched_mcv_freq += histogram_reader.mcv_freq (i);
 	}
@@ -1497,7 +1619,7 @@ histogram_get_like_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *se
   for (int i = 0; i < static_cast<int> (histogram_reader.bucket_count ()); i++)
     {
       non_mcv_buckets += 1.0;
-      if (like_match_string (pattern, histogram_reader.bucket_hi<std::string_view> (i)))
+      if (like_match_value (rhs_db_value, src_coll_id, histogram_reader.bucket_hi<std::string_view> (i)))
 	{
 	  matched_non_mcv_buckets += 1.0;
 	}

--- a/src/optimizer/histogram/histogram_cl.cpp
+++ b/src/optimizer/histogram/histogram_cl.cpp
@@ -1565,14 +1565,17 @@ static bool
 rlike_match_string (const cubregex::compiled_regex &reg, std::string_view value)
 {
   int res = V_FALSE;
+  int err;
 
-  /* value is a string_view into the histogram blob: NOT NUL-terminated, so copy by length */
-  if (cubregex::search (res, reg, std::string (value)) != NO_ERROR)
-    {
-      return false;
-    }
+  /* cubregex::search () er_set()s on an execution failure (bad codeset, regex_error); like the
+   * compile above, a planning probe must not leave that in the global error state -- shield it
+   * and treat the value as unmatched. value is a string_view into the histogram blob: NOT
+   * NUL-terminated, so copy by length. */
+  er_stack_push ();
+  err = cubregex::search (res, reg, std::string (value));
+  er_stack_pop ();
 
-  return res == V_TRUE;
+  return (err == NO_ERROR && res == V_TRUE);
 }
 
 void

--- a/src/optimizer/histogram/histogram_cl.hpp
+++ b/src/optimizer/histogram/histogram_cl.hpp
@@ -104,6 +104,8 @@ void histogram_get_comp_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, bool 
 				     bool *success);
 void histogram_get_join_selectivity (PT_NODE *lhs, PT_NODE *rhs, double *selectivity, bool *success);
 void histogram_get_like_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *selectivity, bool *success);
+void histogram_get_rlike_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, bool case_sensitive,
+				      double fallback_sel, double *selectivity, bool *success);
 /* histogram utility functions */
 int db_get_histogram (MOP classop, const char *attr_name, DB_OBJECT **histogram_obj);
 bool is_histogrammable_type (DB_TYPE type);

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -9885,6 +9885,11 @@ qo_expr_selectivity (QO_ENV * env, PT_NODE * pt_expr)
       /* per-node: an IS [NOT] NULL node must not suppress the null-correction of its siblings */
       not_null_calculated = false;
 
+      /* per-disjunct reset: an operator with no case below must contribute the default guess;
+       * without this it reuses the previous disjunct's selectivity (or the 0.0 initializer when
+       * it is the first disjunct), which turns the whole term into a zero-row estimate. */
+      selectivity = DEFAULT_SELECTIVITY;
+
       switch (node->info.expr.op)
 	{
 	case PT_OR:
@@ -9951,6 +9956,18 @@ qo_expr_selectivity (QO_ENV * env, PT_NODE * pt_expr)
 	    selectivity = 1 - qo_like_selectivity (env, node);
 	    break;
 	  }
+	case PT_RLIKE:
+	case PT_RLIKE_BINARY:
+	  /* regex matching has no histogram support; reuse the LIKE fallback guess */
+	  selectivity = (double) prm_get_float_value (PRM_ID_LIKE_TERM_SELECTIVITY);
+	  break;
+
+	case PT_NOT_RLIKE:
+	case PT_NOT_RLIKE_BINARY:
+	  lhs_selectivity = (double) prm_get_float_value (PRM_ID_LIKE_TERM_SELECTIVITY);
+	  selectivity = qo_not_selectivity (env, lhs_selectivity);
+	  break;
+
 	case PT_SETNEQ:
 	case PT_SETEQ:
 	case PT_SUPERSETEQ:

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -9888,7 +9888,8 @@ qo_expr_selectivity (QO_ENV * env, PT_NODE * pt_expr)
 
       /* per-disjunct reset: an operator with no case below must contribute the default guess;
        * without this it reuses the previous disjunct's selectivity (or the 0.0 initializer when
-       * it is the first disjunct), which turns the whole term into a zero-row estimate. */
+       * it is the first disjunct), which turns the whole term into a zero-row estimate. The
+       * guess is not histogram-derived; the default case below marks the fallback. */
       selectivity = DEFAULT_SELECTIVITY;
 
       switch (node->info.expr.op)
@@ -10040,6 +10041,9 @@ qo_expr_selectivity (QO_ENV * env, PT_NODE * pt_expr)
 	  break;
 
 	default:
+	  /* fall-through operator: selectivity stays at the per-disjunct DEFAULT_SELECTIVITY
+	   * reset above -- a guess, so keep the term from being tagged histogram-derived */
+	  env->sel_hist_fallback = true;
 	  break;
 	}
 
@@ -10211,6 +10215,15 @@ qo_rlike_selectivity (QO_ENV * env, PT_NODE * pt_expr)
 	{
 	  selectivity = fallback;
 	}
+    }
+
+  if (success)
+    {
+      env->sel_hist_used = true;
+    }
+  else
+    {
+      env->sel_hist_fallback = true;
     }
 
   selectivity = MAX (selectivity, 0.0);

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -460,6 +460,7 @@ static double qo_range_selectivity (QO_ENV * env, PT_NODE * pt_expr);
 static double qo_all_some_in_selectivity (QO_ENV * env, PT_NODE * pt_expr);
 
 static double qo_like_selectivity (QO_ENV * env, PT_NODE * pt_expr);
+static double qo_rlike_selectivity (QO_ENV * env, PT_NODE * pt_expr);
 
 static int qo_index_cardinality (QO_ENV * env, PT_NODE * attr);
 static int qo_index_cardinality_with_dedup (QO_ENV * env, PT_NODE * attr, BITSET * seg_bitset);
@@ -9958,13 +9959,12 @@ qo_expr_selectivity (QO_ENV * env, PT_NODE * pt_expr)
 	  }
 	case PT_RLIKE:
 	case PT_RLIKE_BINARY:
-	  /* regex matching has no histogram support; reuse the LIKE fallback guess */
-	  selectivity = (double) prm_get_float_value (PRM_ID_LIKE_TERM_SELECTIVITY);
+	  selectivity = qo_rlike_selectivity (env, node);
 	  break;
 
 	case PT_NOT_RLIKE:
 	case PT_NOT_RLIKE_BINARY:
-	  lhs_selectivity = (double) prm_get_float_value (PRM_ID_LIKE_TERM_SELECTIVITY);
+	  lhs_selectivity = qo_rlike_selectivity (env, node);
 	  selectivity = qo_not_selectivity (env, lhs_selectivity);
 	  break;
 
@@ -10155,6 +10155,66 @@ qo_like_selectivity (QO_ENV * env, PT_NODE * pt_expr)
     {
       env->sel_hist_fallback = true;
     }
+
+  return selectivity;
+}
+
+/*
+ * qo_rlike_selectivity () - Estimate the selectivity of a regex (RLIKE) predicate by matching
+ *                           the pattern against histogram MCVs and bucket boundary values
+ *   return: double
+ *   env(in):
+ *   pt_expr(in): RLIKE expression (PT_RLIKE / PT_RLIKE_BINARY / PT_NOT_RLIKE / PT_NOT_RLIKE_BINARY;
+ *                the NOT variants are negated by the caller)
+ */
+static double
+qo_rlike_selectivity (QO_ENV * env, PT_NODE * pt_expr)
+{
+  PT_NODE *lhs, *rhs;
+  DB_VALUE *host_var = NULL;
+  PRED_CLASS pc_lhs, pc_rhs;
+  double fallback, selectivity;
+  bool case_sensitive, success = false;
+
+  fallback = (double) prm_get_float_value (PRM_ID_LIKE_TERM_SELECTIVITY);
+  selectivity = fallback;
+
+  lhs = pt_expr->info.expr.arg1;
+  rhs = pt_expr->info.expr.arg2;
+
+  if (lhs == NULL || rhs == NULL)
+    {
+      return selectivity;
+    }
+
+  pc_lhs = qo_classify (lhs);
+  pc_rhs = qo_classify (rhs);
+
+  if (pc_lhs == PC_ATTR)
+    {
+      if (pc_rhs == PC_CONST)
+	{
+	  host_var = &rhs->info.value.db_value;
+	}
+      else if (pc_rhs == PC_HOST_VAR)
+	{
+	  host_var = &env->parser->host_variables[rhs->info.host_var.index];
+	}
+
+      /* the parser derives the runtime case flag (arg3) from the operator, so the operator is
+       * an equally authoritative source and needs no constant-folding assumptions */
+      case_sensitive = (pt_expr->info.expr.op == PT_RLIKE_BINARY || pt_expr->info.expr.op == PT_NOT_RLIKE_BINARY);
+
+      histogram_get_rlike_selectivity (lhs, host_var, case_sensitive, fallback, &selectivity, &success);
+
+      if (!success)
+	{
+	  selectivity = fallback;
+	}
+    }
+
+  selectivity = MAX (selectivity, 0.0);
+  selectivity = MIN (selectivity, 1.0);
 
   return selectivity;
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27137

> **핵심:** 미처리 술어(RLIKE)의 선택도 0/누수 버그 수정에 더해, **히스토그램 기반 문자열 선택도 추정이 실행 엔진과 동일한 비교기를 쓰도록 정렬**했습니다 — RLIKE는 **cubregex**로 MCV·버킷 경계값을 실제 정규식 매칭하고, LIKE/등가/등가조인은 각각 `db_string_like`/`db_string_compare`(콜레이션 인식)로 매칭합니다. 추정과 실행이 같은 의미론을 갖게 되어 비-이진 콜레이션(_ci)에서도 추정이 정확해집니다.

### Purpose

`qo_expr_selectivity ()`는 disjunct별 `selectivity` 변수를 `or_next` 루프 바깥에서 한 번만 0.0으로 초기화하고, 연산자 switch의 `default` 케이스는 아무 값도 대입하지 않습니다. 그래서 switch에 케이스가 없는 연산자(`PT_RLIKE` 계열)는:

- **첫(또는 단독) disjunct일 때 selectivity 0.0** — 0행 카디널리티 추정이 되어 해당 항 위의 모든 조인/스캔 결정을 왜곡하고,
- **그 외에는 직전 disjunct의 selectivity를 그대로 재사용** — 같은 OR 술어가 disjunct 나열 순서에 따라 다르게 추정됩니다.

재현 (optimization level 513, `r1` = 120행, `b` NDV 30):

```sql
select count(*) from r1 where a rlike 'val1.*';           -- term sel 0      (0행 추정)
select count(*) from r1 where b = 5 or a rlike 'val1.*';  -- term sel 0.0655 (rlike가 b=5의 0.0333을 물려받음)
select count(*) from r1 where a rlike 'val1.*' or b = 5;  -- term sel 0.0333 (같은 술어인데 추정이 다름)
```

### Implementation

**1커밋 — 누수 차단 + RLIKE 케이스 추가**

- `or_next` 루프 각 반복의 선두에서 `selectivity`를 `DEFAULT_SELECTIVITY`로 리셋하여, switch를 통과(fall-through)하는 연산자가 0.0이나 누수된 값 대신 기본 추정치를 갖도록 했습니다.
- `PT_RLIKE` / `PT_RLIKE_BINARY` / `PT_NOT_RLIKE` / `PT_NOT_RLIKE_BINARY` 케이스를 추가했습니다.

**2커밋 — RLIKE 히스토그램 추정기: cubregex로 히스토그램 값을 실제 매칭 (Legacy patternsel 방식)**

- `histogram_get_rlike_selectivity ()`: 패턴을 cubregex로 1회 컴파일한 뒤 LIKE 추정기와 동일한 골격으로 확률을 계산합니다 — **MCV는 정규식을 실제 매칭해 모집단 빈도를 합산**하고, **비-MCV 질량은 equi-depth 버킷 경계값들을 표본으로 삼아 매칭 비율을 적용**합니다. 히스토그램이 작을 때는 LIKE 추정기와 같은 10/100 엔트리 정책으로 폴백 추정치와 블렌드합니다.
- 대소문자: 연산자에서 파생 (`RLIKE` = insensitive `"i"`, `RLIKE BINARY` = sensitive `"c"` — 파서가 런타임 arg3 플래그를 동일 규칙으로 생성).
- 잘못된 패턴은 실행 시점에 오류가 나야 하므로, 컴파일을 `er_stack_push/pop`으로 감싸 플래닝 중에는 전역 오류 상태를 오염시키지 않고 폴백(`like_term_selectivity`)으로만 처리합니다.
- 히스토그램이 없거나 사용할 수 없으면 기존처럼 `like_term_selectivity`(기본 0.1)로 폴백합니다.

### 검증 결과 (릴리스 빌드, CS 모드, 1000행)

| 시나리오 | 실제 | 추정 (수정 전) | 추정 (수정 후) |
|---|---|---|---|
| 균등 분포, 5% 매칭 정규식 | 5% | 0 | **0.05** |
| 위의 NOT RLIKE | 95% | 0/이월값 | **0.95** |
| MCV 스큐 50% 값 매칭 | 50% | 0 | **0.50002** |
| 대소문자 무시(RLIKE, 대문자 패턴) | 5% | 0 | **0.05** |
| RLIKE BINARY(대문자 패턴) | 0% | 0 | **0.001** (1/total_rows 하한) |
| 히스토그램 없는 컬럼 | — | 0 | 0.1 (폴백) |
| 잘못된 정규식 `'val['` | — | 0 | 0.1 폴백 + 실행 시 기존 오류 유지 |
| OR 순서 교환 | — | 0.0655 vs 0.0333 | **0.13 / 0.13 (순서 무관)** |

**3~5커밋 — 문자열 프로브 전반을 런타임 비교기로 정렬**

리뷰 과정에서 "추정기의 문자열 비교가 실행과 같은 의미론인가"를 전수 감사한 결과, 히스토그램 blob이 바이트 순서로 저장·비교되는 반면 실행은 피연산자 공통 콜레이션으로 매칭하므로 비-이진 콜레이션(_ci 등)에서 추정이 어긋나는 지점들을 함께 정렬했습니다:

- `cubregex::search`에도 compile과 동일한 `er_stack_push/pop` 실드 적용 (플래닝 중 전역 오류 상태 보호)
- 추정용 정규식을 런타임과 동일한 **공통 콜레이션**(`LANG_RT_COMMON_COLL`)으로 컴파일
- **LIKE**: 자체 바이트 매처 → `db_string_like ()` (콜레이션 케이스 폴딩, `_`의 문자 단위 매칭)
- **등가**: 바이트 이진탐색 → `db_string_compare ()`로 MCV 리스트 스윕, 등가류(케이스 변형) 질량 합산
- **등가조인**: 바이트 two-pointer 병합 → 문자열 kind에 한해 런타임 비교기 쌍별 매칭 (MCV 수 상한이라 저비용)

검증(utf8_en_ci): 등가 `= 'hot5'` (저장은 'HOT5' 30% + 'hot5' 20%) → **0.5 정확**, 대소문자 교차 조인 → **카드 100,000 정확**, CI LIKE/RLIKE → 0.5 — 전부 종전엔 0매칭이던 케이스. 이진 콜레이션 결과는 종전과 동일(무회귀) 확인.

**범위 제외:** 버킷 경계 범위 보간은 blob 자체가 바이트 순으로 빌드되므로 프로브만 고칠 수 없어(빌드-프로브 일관성) 콜레이션 인식 빌드와 함께 후속 과제로 남깁니다.

### Remarks

- cubregex(string_regex*.cpp)·db_string_like/compare는 cs/sa 클라이언트 라이브러리에 이미 포함되어 있어(상수 폴딩 경로에서 사용 중) 링크 변경이 없습니다.