### PR TITLE
[CBRD-26845] To disable type checking for NA fields in queries generated by unloaddb (#7220)

### DIFF
--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -5694,7 +5694,15 @@ pt_coerce_expr_arguments (PARSER_CONTEXT * parser, PT_NODE * expr, PT_NODE * arg
 	  if (PT_IS_NAME_NODE (arg1) && PT_IS_VALUE_NODE (arg2)
 	      && (arg3_type == PT_TYPE_NONE || PT_IS_VALUE_NODE (arg3)) && arg1_type != PT_TYPE_ENUMERATION)
 	    {
-	      arg1_eq_type = arg2_eq_type = arg1_type;
+	      if (arg1_type == PT_TYPE_NA && common_type != PT_TYPE_NULL)
+		{
+		  /* NA column vs constant: use inferred type (e.g. string literal) */
+		  arg1_eq_type = arg2_eq_type = common_type;
+		}
+	      else
+		{
+		  arg1_eq_type = arg2_eq_type = arg1_type;
+		}
 	      if (arg3_type != PT_TYPE_NONE)
 		{
 		  arg3_eq_type = arg1_type;
@@ -5718,7 +5726,14 @@ pt_coerce_expr_arguments (PARSER_CONTEXT * parser, PT_NODE * expr, PT_NODE * arg
 	  else if (PT_IS_NAME_NODE (arg2) && PT_IS_VALUE_NODE (arg1) && arg3_type == PT_TYPE_NONE
 		   && arg2_type != PT_TYPE_ENUMERATION)
 	    {
-	      arg1_eq_type = arg2_eq_type = arg2_type;
+	      if (arg2_type == PT_TYPE_NA && common_type != PT_TYPE_NULL)
+		{
+		  arg1_eq_type = arg2_eq_type = common_type;
+		}
+	      else
+		{
+		  arg1_eq_type = arg2_eq_type = arg2_type;
+		}
 	      if (arg1_type != arg2_type && PT_IS_NUMERIC_TYPE (arg2_type) && arg2_type != PT_TYPE_NUMERIC
 		  && op != PT_EQ && op != PT_EQ_SOME && op != PT_EQ_ALL)
 		{
@@ -5743,6 +5758,16 @@ pt_coerce_expr_arguments (PARSER_CONTEXT * parser, PT_NODE * expr, PT_NODE * arg
 		      arg3_eq_type = arg2_type;
 		    }
 		}
+	    }
+	  else if (arg1_type == PT_TYPE_NA && PT_IS_CHAR_STRING_TYPE (arg2_type)
+		   && PT_IS_NAME_NODE (arg1) && !PT_IS_NAME_NODE (arg2))
+	    {
+	      arg1_eq_type = arg2_eq_type = arg2_type;
+	    }
+	  else if (arg2_type == PT_TYPE_NA && PT_IS_CHAR_STRING_TYPE (arg1_type)
+		   && PT_IS_NAME_NODE (arg2) && !PT_IS_NAME_NODE (arg1))
+	    {
+	      arg1_eq_type = arg2_eq_type = arg1_type;
 	    }
 	}
 


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26845>

### Purpose

11.2 부터는 NA필드를 생성하지 않도록 unloaddb를 변경하였습니다. 하지만 11.0, 10.2, 9.3 등의 버전에서는 여전이 NA필드가 생성되기 때문에 구버전에서 생성된 unloaddb schema 스크립트로 loaddb나 csql에서 타입 체킹의 문제가 발생합니다.

이 문제를 해결하기 위해 쿼리를 처리할 때 NA필드는 타입 체킹 오류가 발생하지 않도록 수정합니다.

### Implementation

backport from CBRD-26845
https://github.com/CUBRID/cubrid/pull/7220

### Remarks

N/A
