### PR TITLE
[CUBRIDQA-1475] CI: moded build layout + sentinel, mount debug build in the test step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,7 +259,11 @@ commands:
               exit 0
             fi
             prune
-            echo "[debug] assigned testcases: $(wc -l < tc.list)"
+            # wc -w, not -l: the shell split writes tc.list as one space-separated
+            # line (tee), sql/medium writes one path per line — word count is the
+            # case count either way, and a wrong "0" here would look like the
+            # silent-skip failure mode we deliberately fail loudly on.
+            echo "[debug] assigned testcases: $(wc -w < tc.list)"
       - run:
           name: Mount debug build from GlusterFS
           shell: /bin/bash

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,8 @@
 version: 2.1
 
 # --------------------------------------------------
-# Pipeline-level parameters (values passed from GitHub Actions comment trigger)
+# Pipeline-level parameters — trigger-provided values (GitHub Actions comment
+# trigger) plus pipeline-wide CI knobs
 # --------------------------------------------------
 parameters:
   baseline:
@@ -19,6 +20,11 @@ parameters:
   run_all_test:
     type: boolean
     default: false
+  # Single knob for the shell fan-out width. CUBRIDQA-1471 (40/10 pool
+  # partition) changes this to 40 — keep every reference on this parameter.
+  shell_parallelism:
+    type: integer
+    default: 50
 
 # --------------------------------------------------
 # 1. Reusable executors
@@ -244,6 +250,41 @@ commands:
               echo "[debug] total testcases: $(wc -l tc_dirs.list)"
               echo "[debug] Remove tests that are not in the list"
               find $base_dir -name "cases" -type d | grep -v -F -f tc_dirs.list | xargs -r rm -rf
+
+              # ---- Mount the debug build from GlusterFS (ADR-0005) ----
+              # postStart v2 no longer waits for or mounts moded-layout builds;
+              # this step owns it. Runs AFTER the empty-assignment halt above,
+              # so idle rerun pods release their slot without touching the build.
+              echo "[debug] Mount debug build from GlusterFS"
+              BUILD_DIR="/home/build-cache/builds/${CIRCLE_SHA1}/debug"
+              # requires(download-build) normally guarantees the sentinel is
+              # already there; the bounded wait is a safety belt for
+              # concurrent workflow reruns.
+              n=0
+              until [ -f "${BUILD_DIR}/.complete" ]; do
+                n=$((n + 1))
+                if [ "$n" -gt 60 ]; then
+                  echo "[error] build sentinel not found after 300s: ${BUILD_DIR}/.complete"
+                  exit 1
+                fi
+                [ $((n % 12)) -eq 1 ] && echo "[debug] waiting for build sentinel... ($(((n - 1) * 5))s elapsed)"
+                sleep 5
+              done
+              if [ -x /home/CUBRID/bin/cubrid ]; then
+                # Transition overlap: postStart already mounted a legacy
+                # flat-layout build of the same commit — reuse it.
+                echo "[debug] /home/CUBRID already present (legacy compat mount), skipping step mount"
+              else
+                # Overlay upper/work MUST live on the emptyDir volume
+                # (/build-rw): the kernel rejects them on the container
+                # rootfs (overlay-on-overlay). Verified 2026-07-30 in a live
+                # task pod — see circleci-k8s-ansible ADR-0005.
+                mkdir -p /build-rw/step-upper /build-rw/step-work /home/CUBRID
+                mount -t overlay overlay \
+                  -o "lowerdir=${BUILD_DIR}/CUBRID,upperdir=/build-rw/step-upper,workdir=/build-rw/step-work" /home/CUBRID \
+                  || { echo "[error] CUBRID overlay mount failed"; exit 1; }
+                echo "[debug] CUBRID mounted at /home/CUBRID (overlay on ${BUILD_DIR}/CUBRID)"
+              fi
             else
               echo "[debug] split tests for parallel execution"
               # Same resilience as the shell branch: retry a transient split failure
@@ -343,21 +384,30 @@ commands:
           name: Download build to GlusterFS
           command: |
             BUILD_NUM=$(cat /tmp/workspace/BUILD_NUM_DEBUG)
-            # Use CIRCLE_SHA1 (commit hash) to reuse build across workflow retries
-            BUILD_DIR="/home/build-cache/builds/${CIRCLE_SHA1}"
+            # Moded layout (ADR-0005): builds/<SHA>/<mode>/CUBRID with a
+            # .complete sentinel next to it. Consumers (test_shell step, AI
+            # agent) trust ONLY the sentinel — a visible directory may still
+            # be mid-extraction.
+            BUILD_DIR="/home/build-cache/builds/${CIRCLE_SHA1}/debug"
 
             echo "CIRCLE_SHA1: ${CIRCLE_SHA1}"
             echo "BUILD_NUM: ${BUILD_NUM}"
             echo "BUILD_DIR: ${BUILD_DIR}"
 
-            # Check if build already exists (same commit = same build)
-            if [ -d "${BUILD_DIR}/CUBRID" ]; then
-              echo "Build already exists for this commit, skipping download"
+            # Same commit = same build: reuse across workflow retries.
+            if [ -f "${BUILD_DIR}/.complete" ]; then
+              echo "Build already complete for this commit, skipping download"
               ls -la "${BUILD_DIR}/CUBRID"
               exit 0
             fi
 
-            mkdir -p "${BUILD_DIR}"
+            # Stage into a temp dir, then publish with a single atomic
+            # rename (mv -T): consumers can never observe a half-extracted
+            # tree, and a concurrent duplicate run simply loses the rename
+            # and discards its staging dir — no rm of a published tree.
+            TMP_DIR="${BUILD_DIR}.tmp.$$"
+            rm -rf "${TMP_DIR}"
+            mkdir -p "${TMP_DIR}"
 
             echo "Downloading build from job #${BUILD_NUM}..."
 
@@ -371,17 +421,26 @@ commands:
             if [ -z "$ARTIFACT_URL" ]; then
               echo "ERROR: CUBRID.tar.gz artifact not found"
               echo "Response: $RESPONSE"
+              rm -rf "${TMP_DIR}"
               exit 1
             fi
 
             echo "Artifact URL: $ARTIFACT_URL"
 
-            # Download to GlusterFS
-            curl -L -o "${BUILD_DIR}/CUBRID.tar.gz" "$ARTIFACT_URL"
-            tar xzf "${BUILD_DIR}/CUBRID.tar.gz" -C "${BUILD_DIR}"
-            rm "${BUILD_DIR}/CUBRID.tar.gz"
+            curl -L -o "${TMP_DIR}/CUBRID.tar.gz" "$ARTIFACT_URL"
+            tar xzf "${TMP_DIR}/CUBRID.tar.gz" -C "${TMP_DIR}"
+            rm "${TMP_DIR}/CUBRID.tar.gz"
+            touch "${TMP_DIR}/.complete"
 
-            echo "Build extracted to ${BUILD_DIR}/CUBRID"
+            if mv -T "${TMP_DIR}" "${BUILD_DIR}" 2>/dev/null; then
+              echo "Build published at ${BUILD_DIR}"
+            else
+              # Lost the publish race to a concurrent duplicate run.
+              echo "Another run published this build first, discarding staging dir"
+              rm -rf "${TMP_DIR}"
+            fi
+
+            echo "Build ready at ${BUILD_DIR}/CUBRID"
             ls -la "${BUILD_DIR}/CUBRID"
             df -h /home/build-cache
 
@@ -462,7 +521,7 @@ jobs:
 
   test_shell:
     executor: cubrid-test-shell
-    parallelism: 50
+    parallelism: << pipeline.parameters.shell_parallelism >>
     environment:
       BASELINE: << pipeline.parameters.baseline >>
       TEST_SUITE: "shell"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,12 @@ executors:
     # self-hosted runner
     resource_class: cubrid/ramdisk
     working_directory: /home
+    environment:
+      # GlusterFS build layout contract, defined once for both sides:
+      # download-build publishes <root>/<sha>/<mode>/CUBRID + sentinel,
+      # test_shell waits on the sentinel and mounts that tree.
+      BUILD_CACHE_ROOT: /home/build-cache/builds
+      BUILD_SENTINEL: .complete
 
 # --------------------------------------------------
 # 2. Reusable commands
@@ -187,138 +193,114 @@ commands:
   run-tests:
     description: "Run test scripts (CUBRID must be at /home/CUBRID)"
     steps:
+      # NOTE: every step keeps `shell: /bin/bash` (i.e. no -e/-o pipefail) because
+      # the prune pipelines below exit non-zero when there is nothing to prune.
       - run:
-          name: Test
+          name: Check out testcases and testtools
           shell: /bin/bash
-          no_output_timeout: 45m
           command: |
-            # Limit core files to 10mb
-            ulimit -c 10485760
-
-            echo "[debug] Check out testcases and testtools"
+            if [ -z "$TEST_SUITE" ] || [ "$TEST_SUITE" = "none" ]; then
+              echo "[error] TEST_SUITE is not set"
+              exit 1
+            fi
             /entrypoint.sh checkout
+      - run:
+          name: Split tests for this node
+          shell: /bin/bash
+          command: |
+            # Per-suite differences only: how to glob+split, and how to prune the
+            # cases this node did not get. Everything else is shared below.
             case "$TEST_SUITE" in
-              none)
-                echo "TEST_SUITE is none"
-                exit 1
-                ;;
-              sql)
-                base_dir="cubrid-testcases"
-                glob_path="$base_dir/$TEST_SUITE/_*"
-                ;;
               shell)
                 base_dir="cubrid-testcases-private-ex"
-                rm -rf $base_dir/shell/_25_unstable
-                glob_path="$base_dir/$TEST_SUITE/_*/**/*.sh"
+                rm -rf "$base_dir/shell/_25_unstable"
+                split_pipe() {
+                  circleci tests glob "$base_dir/$TEST_SUITE/_*/**/*.sh" | grep -P '/([^/]+)/cases/\1\.sh$' \
+                    | circleci tests run --command="tee tc.list" --verbose --split-by=timings --timings-type=file
+                }
+                prune() {
+                  xargs -n1 dirname < tc.list > tc_dirs.list
+                  find "$base_dir" -name "cases" -type d | grep -v -F -f tc_dirs.list | xargs -r rm -rf
+                }
                 ;;
               *)
                 base_dir="cubrid-testcases"
-                glob_path="$base_dir/$TEST_SUITE/_*"
+                split_pipe() {
+                  circleci tests glob "$base_dir/$TEST_SUITE/_*" \
+                    | circleci tests run --command="xargs -n1 >> tc.list" --verbose --split-by=name
+                }
+                prune() {
+                  find "$base_dir" -name "*.sql" -type f | grep -v -F -f tc.list | xargs -r rm -rf
+                }
                 ;;
             esac
 
-            if [ "$TEST_SUITE" = "shell" ]; then
-              echo "[debug] split tests for parallel execution"
-              # The split can fail transiently (e.g. the circleci-tests-plugin-cli
-              # download timing out under 50-way fan-out). Retry it, and if it still
-              # fails, fail this node instead of falling through to the "no tests"
-              # halt below, which would silently skip this node's share of the tests.
-              split_tests() {
-                : > tc.list
-                circleci tests glob "$glob_path" | grep -P '/([^/]+)/cases/\1\.sh$' \
-                  | circleci tests run --command="tee tc.list" --verbose --split-by=timings --timings-type=file
-              }
-              n=0
-              until split_tests; do
-                n=$((n + 1))
-                if [ "$n" -ge 4 ]; then
-                  echo "[error] test split failed after $n attempts; failing node to avoid silently skipping tests"
-                  exit 1
-                fi
-                echo "[warn] test split failed; retry $n after backoff"
-                sleep $((n * 10))
-              done
-
-              # Split succeeded. An empty tc.list here is a genuine empty assignment
-              # (normal during "rerun failed tests only") -> halt this node as success.
-              if [ ! -s tc.list ]; then
-                echo "[debug] No tests assigned to this node"
-                circleci-agent step halt
-                exit 0
+            # A split can fail transiently (e.g. the circleci-tests-plugin-cli
+            # download timing out under 50-way fan-out). Retry, and on persistent
+            # failure fail this node rather than fall through to the empty-list
+            # halt below, which would silently skip this node's share of tests.
+            n=0
+            until { : > tc.list; split_pipe; }; do
+              n=$((n + 1))
+              if [ "$n" -ge 4 ]; then
+                echo "[error] test split failed after $n attempts; failing node to avoid silently skipping tests"
+                exit 1
               fi
-              cat tc.list | xargs -n1 dirname > tc_dirs.list
-              echo "[debug] total testcases: $(wc -l tc_dirs.list)"
-              echo "[debug] Remove tests that are not in the list"
-              find $base_dir -name "cases" -type d | grep -v -F -f tc_dirs.list | xargs -r rm -rf
+              echo "[warn] test split failed; retry $n after backoff"
+              sleep $((n * 10))
+            done
 
-              # ---- Mount the debug build from GlusterFS (ADR-0005) ----
-              # postStart v2 no longer waits for or mounts moded-layout builds;
-              # this step owns it. Runs AFTER the empty-assignment halt above,
-              # so idle rerun pods release their slot without touching the build.
-              echo "[debug] Mount debug build from GlusterFS"
-              BUILD_DIR="/home/build-cache/builds/${CIRCLE_SHA1}/debug"
-              # requires(download-build) normally guarantees the sentinel is
-              # already there; the bounded wait is a safety belt for
-              # concurrent workflow reruns.
-              n=0
-              until [ -f "${BUILD_DIR}/.complete" ]; do
-                n=$((n + 1))
-                if [ "$n" -gt 60 ]; then
-                  echo "[error] build sentinel not found after 300s: ${BUILD_DIR}/.complete"
-                  exit 1
-                fi
-                [ $((n % 12)) -eq 1 ] && echo "[debug] waiting for build sentinel... ($(((n - 1) * 5))s elapsed)"
-                sleep 5
-              done
-              if [ -x /home/CUBRID/bin/cubrid ]; then
-                # Transition overlap: postStart already mounted a legacy
-                # flat-layout build of the same commit — reuse it.
-                echo "[debug] /home/CUBRID already present (legacy compat mount), skipping step mount"
-              else
-                # Overlay upper/work MUST live on the emptyDir volume
-                # (/build-rw): the kernel rejects them on the container
-                # rootfs (overlay-on-overlay). Verified 2026-07-30 in a live
-                # task pod — see circleci-k8s-ansible ADR-0005.
-                mkdir -p /build-rw/step-upper /build-rw/step-work /home/CUBRID
-                mount -t overlay overlay \
-                  -o "lowerdir=${BUILD_DIR}/CUBRID,upperdir=/build-rw/step-upper,workdir=/build-rw/step-work" /home/CUBRID \
-                  || { echo "[error] CUBRID overlay mount failed"; exit 1; }
-                echo "[debug] CUBRID mounted at /home/CUBRID (overlay on ${BUILD_DIR}/CUBRID)"
-              fi
-            else
-              echo "[debug] split tests for parallel execution"
-              # Same resilience as the shell branch: retry a transient split failure
-              # and fail the node rather than silently skipping its tests. tc.list is
-              # reset each attempt because the split command appends (>>).
-              split_tests() {
-                : > tc.list
-                circleci tests glob "$glob_path" \
-                  | circleci tests run --command="xargs -n1 >> tc.list" --verbose --split-by=name
-              }
-              n=0
-              until split_tests; do
-                n=$((n + 1))
-                if [ "$n" -ge 4 ]; then
-                  echo "[error] test split failed after $n attempts; failing node to avoid silently skipping tests"
-                  exit 1
-                fi
-                echo "[warn] test split failed; retry $n after backoff"
-                sleep $((n * 10))
-              done
-
-              # Split succeeded. An empty tc.list here is a genuine empty assignment
-              # (normal during "rerun failed tests only") -> halt this node as success.
-              if [ ! -s tc.list ]; then
-                echo "[debug] No tests assigned to this node"
-                circleci-agent step halt
-                exit 0
-              fi
-              echo "[debug] total testcases: $(wc -l tc.list)"
-              echo "[debug] Remove tests that are not in the list"
-              find $base_dir -name "*.sql" -type f | grep -v -F -f tc.list | xargs -r rm -rf
+            # Split succeeded, so an empty list is a genuine empty assignment
+            # (normal during "rerun failed tests only") -> halt as success. Halting
+            # here, before the build wait, releases the slot right away.
+            if [ ! -s tc.list ]; then
+              echo "[debug] No tests assigned to this node"
+              circleci-agent step halt
+              exit 0
             fi
+            prune
+            echo "[debug] assigned testcases: $(wc -l < tc.list)"
+      - run:
+          name: Mount debug build from GlusterFS
+          shell: /bin/bash
+          command: |
+            if [ "$TEST_SUITE" != "shell" ]; then
+              echo "[debug] non-shell suite runs on the artifact build; nothing to mount"
+              exit 0
+            fi
+            : "${BUILD_CACHE_ROOT:?}" "${BUILD_SENTINEL:?}"
+            BUILD_DIR="${BUILD_CACHE_ROOT}/${CIRCLE_SHA1}/debug"
 
-            echo "[debug] Run the tests"
+            # requires(download-build) normally means the sentinel is already
+            # there; the bounded wait covers concurrent workflow reruns.
+            n=0
+            until [ -f "${BUILD_DIR}/${BUILD_SENTINEL}" ]; do
+              n=$((n + 1))
+              if [ "$n" -gt 60 ]; then
+                echo "[error] build sentinel not found after 300s: ${BUILD_DIR}/${BUILD_SENTINEL}"
+                exit 1
+              fi
+              [ $((n % 12)) -eq 1 ] && echo "[debug] waiting for build sentinel... ($(((n - 1) * 5))s elapsed)"
+              sleep 5
+            done
+
+            if [ -x /home/CUBRID/bin/cubrid ]; then
+              echo "[debug] /home/CUBRID already mounted by postStart (legacy flat layout), reusing"
+              exit 0
+            fi
+            # upperdir/workdir must sit on the emptyDir volume: the kernel refuses
+            # an overlay whose upper is on the container rootfs.
+            mkdir -p /build-rw/step-upper /build-rw/step-work /home/CUBRID
+            mount -t overlay overlay \
+              -o "lowerdir=${BUILD_DIR}/CUBRID,upperdir=/build-rw/step-upper,workdir=/build-rw/step-work" /home/CUBRID \
+              || { echo "[error] CUBRID overlay mount failed"; exit 1; }
+            echo "[debug] CUBRID mounted (overlay on ${BUILD_DIR}/CUBRID)"
+      - run:
+          name: Run tests
+          shell: /bin/bash
+          no_output_timeout: 45m
+          command: |
+            ulimit -c 10485760   # limit core files to 10mb
             /entrypoint.sh test
       - run:
           name: Collect Logs
@@ -384,38 +366,27 @@ commands:
           name: Download build to GlusterFS
           command: |
             BUILD_NUM=$(cat /tmp/workspace/BUILD_NUM_DEBUG)
-            # Moded layout (ADR-0005): builds/<SHA>/<mode>/CUBRID with a
-            # .complete sentinel next to it. Consumers (test_shell step, AI
-            # agent) trust ONLY the sentinel — a visible directory may still
-            # be mid-extraction.
-            BUILD_DIR="/home/build-cache/builds/${CIRCLE_SHA1}/debug"
-
-            echo "CIRCLE_SHA1: ${CIRCLE_SHA1}"
-            echo "BUILD_NUM: ${BUILD_NUM}"
-            echo "BUILD_DIR: ${BUILD_DIR}"
+            : "${BUILD_CACHE_ROOT:?}" "${BUILD_SENTINEL:?}"
+            BUILD_DIR="${BUILD_CACHE_ROOT}/${CIRCLE_SHA1}/debug"
+            echo "CIRCLE_SHA1=${CIRCLE_SHA1} BUILD_NUM=${BUILD_NUM} BUILD_DIR=${BUILD_DIR}"
 
             # Same commit = same build: reuse across workflow retries.
-            if [ -f "${BUILD_DIR}/.complete" ]; then
+            if [ -f "${BUILD_DIR}/${BUILD_SENTINEL}" ]; then
               echo "Build already complete for this commit, skipping download"
               ls -la "${BUILD_DIR}/CUBRID"
               exit 0
             fi
 
-            # Stage into a temp dir, then publish with a single atomic
-            # rename (mv -T): consumers can never observe a half-extracted
-            # tree, and a concurrent duplicate run simply loses the rename
-            # and discards its staging dir — no rm of a published tree.
+            # Stage, then publish with one atomic rename: consumers never see a
+            # half-extracted tree, and a concurrent duplicate run just loses the
+            # rename and drops its staging dir (no rm of a published tree).
             TMP_DIR="${BUILD_DIR}.tmp.$$"
             rm -rf "${TMP_DIR}"
             mkdir -p "${TMP_DIR}"
 
             echo "Downloading build from job #${BUILD_NUM}..."
-
-            # Fetch artifact list
             RESPONSE=$(curl -s -H "Circle-Token: ${CIRCLECI_TOKEN}" \
               "https://circleci.com/api/v2/project/gh/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${BUILD_NUM}/artifacts")
-
-            # Extract CUBRID.tar.gz URL
             ARTIFACT_URL=$(echo "$RESPONSE" | grep -o '"url": "[^"]*CUBRID.tar.gz[^"]*"' | head -1 | sed 's/"url": "//;s/"$//')
 
             if [ -z "$ARTIFACT_URL" ]; then
@@ -426,11 +397,10 @@ commands:
             fi
 
             echo "Artifact URL: $ARTIFACT_URL"
-
             curl -L -o "${TMP_DIR}/CUBRID.tar.gz" "$ARTIFACT_URL"
             tar xzf "${TMP_DIR}/CUBRID.tar.gz" -C "${TMP_DIR}"
             rm "${TMP_DIR}/CUBRID.tar.gz"
-            touch "${TMP_DIR}/.complete"
+            touch "${TMP_DIR}/${BUILD_SENTINEL}"
 
             if mv -T "${TMP_DIR}" "${BUILD_DIR}" 2>/dev/null; then
               echo "Build published at ${BUILD_DIR}"


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1475

### Purpose

shell 테스트의 빌드 전송 구조 재설계(ADR-0005, circleci-k8s-ansible repo) 중 PR 경로를 적용한다. 기존에는 runner pod의 postStart가 빌드 경로(`builds/<SHA>/CUBRID`)를 하드코딩하고 최대 300초를 대기·마운트했기 때문에, 빌드 레이아웃을 바꾸려면 두 저장소를 동시에 바꿔야 했고, tar 해제 중간의 빌드를 마운트할 수 있는 잠재 race가 있었다. runner 쪽은 postStart v2(대기·경로 지식 제거)가 이미 배포되어 있다.

### Implementation

- **저장 레이아웃**: download-build가 debug 빌드를 `builds/<SHA>/debug/CUBRID`에 저장하고 완료 표식(`.complete` sentinel)을 남긴다. 임시 디렉토리에 받은 뒤 `mv -T` 원자 rename으로 공개하므로 반쯤 풀린 빌드가 보이는 일이 없고, 같은 커밋 재실행은 다운로드를 건너뛴다.
- **마운트 주체 이동**: test_shell 각 pod가 테스트 분배 후 job step에서 sentinel을 확인하고 직접 overlay 마운트한다(postStart는 더 이상 관여 안 함). 빈 할당을 받은 pod는 빌드 확인 전에 조기 종료해 재실행 시 slot을 빨리 반납한다.
- **동작 불변**: download-build → test_shell 실행 순서(requires), sql/medium 경로, GHA 트리거는 그대로다. test_shell 병렬도는 `shell_parallelism` 파이프라인 파라미터(기본 50)로 뽑아 이후 40/10 분할(CUBRIDQA-1471)이 값 하나 변경이 되게 했다.

### Remarks

- runner postStart v2가 먼저 배포되어 있어야 동작한다 — 이미 production 양 lane에 배포·검증 완료(canary green ×2, 게이트 PASS).
- 검증: 이 PR에서 `/run shell` 풀런 완주 + GlusterFS `builds/<SHA>/debug/` 확인 + "rerun failed tests"에서 재다운로드 없음 확인 후 ready 전환 예정.
- overlay 마운트의 upper/work는 emptyDir(`/build-rw`) 위여야 한다(컨테이너 rootfs 위는 커널이 거부) — step 구현에 명시됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UcXpSqurNoQmhQDrNFv5Xr