### PR TITLE
[CBRD-27095] Preserve pending error across the SCH_M re-promotion loop in online index load

### DIFF
--- a/src/storage/btree_load.c
+++ b/src/storage/btree_load.c
@@ -5202,6 +5202,12 @@ xbtree_load_online_index (THREAD_ENTRY * thread_p, BTID * btid, const char *bt_n
   old_wait_msec = xlogtb_reset_wait_msecs (thread_p, LK_INFINITE_WAIT);
   old_check_intr = logtb_set_check_interrupt (thread_p, false);
 
+  /* The retry loop below consumes and clears its own errors (interrupted waits,
+   * shutdown-forced timeouts). Preserve the error that belongs to `ret` (set by
+   * the online build above) so that `ret` and er_errid () stay consistent for
+   * the check after the loop. */
+  er_stack_push ();
+
   for (cur_class = 0; cur_class < n_classes; cur_class++)
     {
       /* Promote the lock to SCH_M_LOCK */
@@ -5238,6 +5244,8 @@ xbtree_load_online_index (THREAD_ENTRY * thread_p, BTID * btid, const char *bt_n
 	  assert (0);
 	}
     }
+
+  er_stack_pop ();
 
   // reset back
   (void) xlogtb_reset_wait_msecs (thread_p, old_wait_msec);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27095>

### Purpose

Fix a debug-build server crash (SIGABRT) in `xbtree_load_online_index ()`: when an online index build fails with an interrupt (e.g. `killtran`, client disconnection) and the subsequent SCH_M lock re-promotion wait is itself woken by an interrupt, the server dies at `ASSERT_ERROR ()` right after the re-promotion loop.

The root cause is that the "never give up" re-promotion loop handles its own interrupted waits with `er_clear ()`, which also wipes the thread error that was set by the already-failed build. The final check then sees `ret != NO_ERROR` while `er_errid () == NO_ERROR`, breaking the invariant `ASSERT_ERROR ()` enforces. In release builds there is no crash, but the client receives a generic error instead of the real cause (`ER_INTERRUPTED`), because the error area has been emptied.

### Implementation

Wrap the SCH_M re-promotion loop with `er_stack_push ()` / `er_stack_pop ()` so the error belonging to `ret` survives the loop:

- the loop keeps consuming and clearing its own errors (interrupted waits, shutdown-forced timeouts) on a fresh error level, exactly as before;
- `er_stack_pop ()` restores the pending error, so `ret` and `er_errid ()` stay consistent for the check after the loop.

A side benefit: the loop's `er_errid () == ER_INTERRUPTED` classification now only ever sees errors produced by the loop itself, so a stale `ER_INTERRUPTED` left by the build can no longer misclassify a different lock failure as an interrupted wait.

### Remarks

Reproduced and verified with a two-session race harness (no fault injection): interrupt the build during the heap scan, then release a contending class lock while the re-promotion waiter is interrupted.

- Before: `cub_server` aborts at the `ASSERT_ERROR ()` following the re-promotion loop (same stack as the QA core from `cbrd_21506_dml_06`), reproduced on the first attempt in 3 consecutive runs.
- After: no crash across full harness runs; the race still occurs identically and the client receives the real error (`ER_INTERRUPTED`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
