### PR TITLE
[CUBRIDQA-1476] CI: preserve both develop merge builds in GlusterFS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,17 +78,15 @@ commands:
   collect-build-logs:
     description: "Collect build logs and store them"
     steps:
+      # when: always — a failed build is exactly when build.log is worth having;
+      # without it this step is skipped and the upload below finds nothing.
       - run:
-          name: Store Build Logs
+          name: Store build logs and commits
+          when: always
           command: |
             mkdir -p /tmp/build_logs
             mv -f build.log /tmp/build_logs || true
-      - run:
-          name: Store Commits
-          command: |
-            mkdir -p /tmp/build_logs
-            git log | head -n 1000 > commits.log || true
-            mv -f commits.log /tmp/build_logs
+            git log | head -n 1000 > /tmp/build_logs/commits.log || true
       - store_artifacts:
           path: /tmp/build_logs
           when: always
@@ -220,8 +218,8 @@ commands:
   run-tests:
     description: "Run test scripts (CUBRID must be at /home/CUBRID)"
     steps:
-      # NOTE: every step keeps `shell: /bin/bash` (i.e. no -e/-o pipefail) because
-      # the prune pipelines below exit non-zero when there is nothing to prune.
+      # The test steps set `shell: /bin/bash` (i.e. no -e/-o pipefail): the prune
+      # pipelines exit non-zero when there is nothing left to prune.
       - run:
           name: Check out testcases and testtools
           shell: /bin/bash
@@ -549,7 +547,6 @@ jobs:
     environment:
       BASELINE: << pipeline.parameters.baseline >>
       TEST_SUITE: "shell"
-      GITHUB_TOKEN: $GHI_TOKEN
     steps:
       # Testcases branch is resolved once in download-build and shared via the
       # workspace, so the 50 shell pods never hit cubrid-testcases themselves.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,6 @@
 version: 2.1
 
-# --------------------------------------------------
-# Pipeline-level parameters — trigger-provided values (GitHub Actions comment
-# trigger) plus pipeline-wide CI knobs
-# --------------------------------------------------
+# Trigger-provided values (GitHub Actions comment trigger) + pipeline-wide knobs.
 parameters:
   baseline:
     type: string
@@ -26,9 +23,6 @@ parameters:
     type: integer
     default: 50
 
-# --------------------------------------------------
-# 1. Reusable executors
-# --------------------------------------------------
 executors:
   # Build machine: ccache environment baked in so both build jobs share it
   cubrid-build:
@@ -62,9 +56,6 @@ executors:
       BUILD_CACHE_ROOT: /home/build-cache/builds
       BUILD_SENTINEL: .complete
 
-# --------------------------------------------------
-# 2. Reusable commands
-# --------------------------------------------------
 commands:
   submodules:
     description: "Sync and init git submodules"
@@ -106,7 +97,7 @@ commands:
       - checkout
       - restore_cache:
           keys:
-            - << parameters.ccache-prefix >>-{{ checksum "build.sh" }}-{{ checksum "CMakeLists.txt" }}-develop-{{ .Revision }}
+            - &ccache_key << parameters.ccache-prefix >>-{{ checksum "build.sh" }}-{{ checksum "CMakeLists.txt" }}-develop-{{ .Revision }}
             - << parameters.ccache-prefix >>-{{ checksum "build.sh" }}-{{ checksum "CMakeLists.txt" }}-develop-
       - submodules
       - run:
@@ -124,7 +115,7 @@ commands:
             equal: [ develop, << pipeline.git.branch >> ]
           steps:
             - save_cache:
-                key: << parameters.ccache-prefix >>-{{ checksum "build.sh" }}-{{ checksum "CMakeLists.txt" }}-develop-{{ .Revision }}
+                key: *ccache_key
                 paths:
                   - /home/.ccache
       - collect-build-logs
@@ -151,7 +142,6 @@ commands:
           command: |
             mkdir -p workspace
             echo "${CIRCLE_BUILD_NUM}" > workspace/BUILD_NUM_<< parameters.mode >>
-            echo "Saved BUILD_NUM_<< parameters.mode >>: $(cat workspace/BUILD_NUM_<< parameters.mode >>)"
       - persist_to_workspace:
           root: workspace
           paths: [ BUILD_NUM_<< parameters.mode >> ]
@@ -200,18 +190,15 @@ commands:
               TC_SHA=$(resolve_sha develop)
             fi
 
-            CACHE_KEY_BRANCH="${TC_BRANCH//\//-}"
-
             echo "TC_BRANCH: $TC_BRANCH"
             echo "TC_SHA: $TC_SHA"
-            echo "CACHE_KEY_BRANCH: $CACHE_KEY_BRANCH"
 
             # checkout reads BRANCH_TESTCASES to select the testcases branch
             echo "export BRANCH_TESTCASES=$TC_BRANCH" >> "$BASH_ENV"
 
             # Cache keys cannot read shell vars, so materialize the runtime values
             # to files and reference them via {{ checksum }} in restore_cache/save_cache.
-            echo "$CACHE_KEY_BRANCH" > /tmp/tc_cache_branch
+            echo "${TC_BRANCH//\//-}" > /tmp/tc_cache_branch
             echo "$TC_SHA" > /tmp/tc_cache_sha
             echo "develop" > /tmp/tc_cache_develop
 
@@ -233,8 +220,7 @@ commands:
           name: Split tests for this node
           shell: /bin/bash
           command: |
-            # Per-suite differences only: how to glob+split, and how to prune the
-            # cases this node did not get. Everything else is shared below.
+            # Only the glob+split pipeline and the prune differ per suite.
             case "$TEST_SUITE" in
               shell)
                 base_dir="cubrid-testcases-private-ex"
@@ -366,7 +352,6 @@ commands:
             BUILD_NUM=$(cat /tmp/workspace/BUILD_NUM_debug)
             echo "Downloading build from job #${BUILD_NUM}..."
 
-            # Fetch artifact list
             RESPONSE=$(curl -s -H "Circle-Token: ${CIRCLECI_TOKEN}" \
               "https://circleci.com/api/v2/project/gh/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${BUILD_NUM}/artifacts")
 
@@ -383,12 +368,10 @@ commands:
 
             echo "Artifact URL: $ARTIFACT_URL"
 
-            # Download and extract
             curl -L -o /tmp/CUBRID.tar.gz "$ARTIFACT_URL"
             tar xzf /tmp/CUBRID.tar.gz -C /home/
             rm /tmp/CUBRID.tar.gz
 
-            echo "Build extracted to /home/CUBRID"
             ls -la /home/CUBRID
 
   download-build-to-glusterfs:
@@ -471,9 +454,6 @@ commands:
             echo "Transported ${published} build(s) for ${CIRCLE_SHA1}"
             df -h /home/build-cache
 
-# --------------------------------------------------
-# 3. Jobs
-# --------------------------------------------------
 jobs:
   build:
     executor: cubrid-build
@@ -509,15 +489,14 @@ jobs:
             - package-build:
                 mode: debug
 
-  # sql and medium tests share the same shape; parameterized to avoid duplication
   artifact-test:
     executor: cubrid-default
-    resource_class: medium
     parameters:
       suite:
         type: string
       parallelism:
         type: integer
+        default: 1
     parallelism: << parameters.parallelism >>
     environment:
       TEST_SUITE: << parameters.suite >>
@@ -525,7 +504,7 @@ jobs:
       - resolve-testcases
       - restore_cache:
           keys:
-            - cubrid-testcases-{{ checksum "/tmp/tc_cache_branch" }}-{{ checksum "/tmp/tc_cache_sha" }}
+            - &tc_key cubrid-testcases-{{ checksum "/tmp/tc_cache_branch" }}-{{ checksum "/tmp/tc_cache_sha" }}
             - cubrid-testcases-{{ checksum "/tmp/tc_cache_branch" }}-
             - cubrid-testcases-{{ checksum "/tmp/tc_cache_develop" }}-
       - download-build-from-artifact
@@ -533,11 +512,10 @@ jobs:
       - run:
           name: Clean up tc before save_cache
           command: |
-            cd cubrid-testcases
-            git clean -fd
-            git reset --hard
+            git -C cubrid-testcases clean -fd
+            git -C cubrid-testcases reset --hard
       - save_cache:
-          key: cubrid-testcases-{{ checksum "/tmp/tc_cache_branch" }}-{{ checksum "/tmp/tc_cache_sha" }}
+          key: *tc_key
           paths:
             - cubrid-testcases
 
@@ -561,7 +539,6 @@ jobs:
   download-build:
     description: "Transport the packaged build(s) to GlusterFS; for the shell suite, also resolve the testcases branch once for all shell pods"
     executor: cubrid-test-shell
-    parallelism: 1
     parameters:
       for-shell-tests:
         # The develop path transports and stops: resolving the testcases branch
@@ -591,9 +568,7 @@ jobs:
                 root: /tmp/tcws
                 paths: [ BRANCH_TESTCASES ]
 
-# --------------------------------------------------
-# 4. Workflow (conditional test jobs via expression-based filters)
-# --------------------------------------------------
+# Test jobs are gated by expression-based filters (evaluated server-side).
 workflows:
   build_test:
     jobs:
@@ -602,7 +577,6 @@ workflows:
       - artifact-test:
           name: test_medium
           suite: medium
-          parallelism: 1
           requires: [build_debug]
           filters: pipeline.parameters.run_medium_test
       - artifact-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,8 +372,10 @@ commands:
             RESPONSE=$(curl -s -H "Circle-Token: ${CIRCLECI_TOKEN}" \
               "https://circleci.com/api/v2/project/gh/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${BUILD_NUM}/artifacts")
 
-            # Extract CUBRID.tar.gz URL
-            ARTIFACT_URL=$(echo "$RESPONSE" | grep -o '"url": "[^"]*CUBRID.tar.gz[^"]*"' | head -1 | sed 's/"url": "//;s/"$//')
+            # Extract CUBRID.tar.gz URL. `|| true`: grep exits non-zero when the
+            # artifact is absent, and under the default errexit shell that would
+            # kill the step before the diagnostic below ever prints.
+            ARTIFACT_URL=$(echo "$RESPONSE" | grep -o '"url": "[^"]*CUBRID.tar.gz[^"]*"' | head -1 | sed 's/"url": "//;s/"$//' || true)
 
             if [ -z "$ARTIFACT_URL" ]; then
               echo "ERROR: CUBRID.tar.gz artifact not found"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -573,19 +573,9 @@ jobs:
         type: boolean
         default: true
     steps:
-      # If a shell run was also requested on this pipeline, the shell path's own
-      # download-build already transports the same build — stop here instead of
-      # doing it twice. (Job-level when/unless is not available in this config
-      # schema, so the guard lives in a step.)
-      - when:
-          condition:
-            and:
-              - not: << parameters.for-shell-tests >>
-              - << pipeline.parameters.run_shell_test >>
-          steps:
-            - run:
-                name: Skip — the shell path already transports this build
-                command: circleci-agent step halt
+      # Note: a pipeline that is both on develop and has run_shell_test set would
+      # transport twice (this job and the shell path's). Not guarded: the comment
+      # trigger only fires on pull requests, so develop never carries that flag.
       - download-build-to-glusterfs
       - when:
           condition: << parameters.for-shell-tests >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,10 +135,10 @@ commands:
     description: "Upload the built tree as an artifact and hand its job number to consumers"
     parameters:
       mode:
-        # Uppercase because it names the workspace file (BUILD_NUM_<MODE>);
-        # download-build lowercases it for the builds/<SHA>/<mode> path.
+        # One vocabulary end to end: this is the workspace file suffix
+        # (BUILD_NUM_<mode>) and the builds/<SHA>/<mode> path segment.
         type: enum
-        enum: [ RELEASE, DEBUG ]
+        enum: [ release, debug ]
     steps:
       - run:
           name: Package build for artifact (<< parameters.mode >>)
@@ -299,6 +299,9 @@ commands:
               echo "[debug] non-shell suite runs on the artifact build; nothing to mount"
               exit 0
             fi
+            # Explicit, so the contract does not depend on the step's shell
+            # setting: any failure below (including publish's) aborts the job.
+            set -eo pipefail
             : "${BUILD_CACHE_ROOT:?}" "${BUILD_SENTINEL:?}"
             BUILD_DIR="${BUILD_CACHE_ROOT}/${CIRCLE_SHA1}/debug"
 
@@ -362,7 +365,7 @@ commands:
       - run:
           name: Download build from artifact
           command: |
-            BUILD_NUM=$(cat /tmp/workspace/BUILD_NUM_DEBUG)
+            BUILD_NUM=$(cat /tmp/workspace/BUILD_NUM_debug)
             echo "Downloading build from job #${BUILD_NUM}..."
 
             # Fetch artifact list
@@ -396,6 +399,9 @@ commands:
       - run:
           name: Download build to GlusterFS
           command: |
+            # Explicit, so the contract does not depend on the step's shell
+            # setting: any failure below (including publish's) aborts the job.
+            set -eo pipefail
             : "${BUILD_CACHE_ROOT:?}" "${BUILD_SENTINEL:?}"
 
             # One build-number file per packaged mode (package-build persists
@@ -423,7 +429,9 @@ commands:
               local response artifact_url
               response=$(curl -s -H "Circle-Token: ${CIRCLECI_TOKEN}" \
                 "https://circleci.com/api/v2/project/gh/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${build_num}/artifacts")
-              artifact_url=$(echo "$response" | grep -o '"url": "[^"]*CUBRID.tar.gz[^"]*"' | head -1 | sed 's/"url": "//;s/"$//')
+              # `|| true`: grep exits non-zero when the artifact is absent, and
+              # under errexit that would kill the job before the diagnostic below.
+              artifact_url=$(echo "$response" | grep -o '"url": "[^"]*CUBRID.tar.gz[^"]*"' | head -1 | sed 's/"url": "//;s/"$//' || true)
               if [ -z "$artifact_url" ]; then
                 echo "ERROR: CUBRID.tar.gz artifact not found in job #${build_num}"
                 echo "Response: $response"
@@ -446,11 +454,13 @@ commands:
               ls -la "${build_dir}/CUBRID"
             }
 
+            # publish is called plainly on purpose: errexit propagates any
+            # failure inside it (an `if !` wrapper would suspend errexit within
+            # the function and could publish a half-extracted tree).
             published=0
             for num_file in /tmp/workspace/BUILD_NUM_*; do
               [ -f "$num_file" ] || continue
-              mode=$(basename "$num_file" | sed 's/^BUILD_NUM_//' | tr '[:upper:]' '[:lower:]')
-              publish "$mode" "$(cat "$num_file")"
+              publish "${num_file##*/BUILD_NUM_}" "$(cat "$num_file")"
               published=$((published + 1))
             done
 
@@ -478,7 +488,7 @@ jobs:
             equal: [ develop, << pipeline.git.branch >> ]
           steps:
             - package-build:
-                mode: RELEASE
+                mode: release
 
   build_debug:
     executor: cubrid-build
@@ -497,7 +507,7 @@ jobs:
               - equal: [ develop, << pipeline.git.branch >> ]
           steps:
             - package-build:
-                mode: DEBUG
+                mode: debug
 
   # sql and medium tests share the same shape; parameterized to avoid duplication
   artifact-test:
@@ -550,24 +560,47 @@ jobs:
       - run-tests
 
   download-build:
-    description: "Download CUBRID build to GlusterFS and resolve the testcases branch once for all shell pods"
+    description: "Transport the packaged build(s) to GlusterFS; for the shell suite, also resolve the testcases branch once for all shell pods"
     executor: cubrid-test-shell
     parallelism: 1
+    parameters:
+      for-shell-tests:
+        # The develop path transports and stops: resolving the testcases branch
+        # there would run a private-repo ls-remote nobody reads, and its failure
+        # would redden the develop commit even though the transport succeeded.
+        type: boolean
+        default: true
     steps:
+      # If a shell run was also requested on this pipeline, the shell path's own
+      # download-build already transports the same build — stop here instead of
+      # doing it twice. (Job-level when/unless is not available in this config
+      # schema, so the guard lives in a step.)
+      - when:
+          condition:
+            and:
+              - not: << parameters.for-shell-tests >>
+              - << pipeline.parameters.run_shell_test >>
+          steps:
+            - run:
+                name: Skip — the shell path already transports this build
+                command: circleci-agent step halt
       - download-build-to-glusterfs
-      # Resolve the testcases branch a single time (reuses resolve-testcases,
-      # which exports BRANCH_TESTCASES) and hand it to the shell pods. Shell runs
-      # the private repo, so resolve against cubrid-testcases-private-ex.
-      - resolve-testcases:
-          tc-repo: cubrid-testcases-private-ex
-      - run:
-          name: Persist testcases branch for shell pods
-          command: |
-            mkdir -p /tmp/tcws
-            echo "$BRANCH_TESTCASES" > /tmp/tcws/BRANCH_TESTCASES
-      - persist_to_workspace:
-          root: /tmp/tcws
-          paths: [ BRANCH_TESTCASES ]
+      - when:
+          condition: << parameters.for-shell-tests >>
+          steps:
+            # Resolve the testcases branch a single time (reuses resolve-testcases,
+            # which exports BRANCH_TESTCASES) and hand it to the shell pods. Shell
+            # runs the private repo, so resolve against cubrid-testcases-private-ex.
+            - resolve-testcases:
+                tc-repo: cubrid-testcases-private-ex
+            - run:
+                name: Persist testcases branch for shell pods
+                command: |
+                  mkdir -p /tmp/tcws
+                  echo "$BRANCH_TESTCASES" > /tmp/tcws/BRANCH_TESTCASES
+            - persist_to_workspace:
+                root: /tmp/tcws
+                paths: [ BRANCH_TESTCASES ]
 
 # --------------------------------------------------
 # 4. Workflow (conditional test jobs via expression-based filters)
@@ -600,6 +633,7 @@ workflows:
       # Requires both builds so a release-only regression still blocks the upload.
       - download-build:
           name: store-build-develop
+          for-shell-tests: false
           requires: [build, build_debug]
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,33 @@ commands:
                   - /home/.ccache
       - collect-build-logs
 
+  package-build:
+    description: "Upload the built tree as an artifact and hand its job number to consumers"
+    parameters:
+      mode:
+        # Uppercase because it names the workspace file (BUILD_NUM_<MODE>);
+        # download-build lowercases it for the builds/<SHA>/<mode> path.
+        type: enum
+        enum: [ RELEASE, DEBUG ]
+    steps:
+      - run:
+          name: Package build for artifact (<< parameters.mode >>)
+          command: |
+            tar czf CUBRID.tar.gz CUBRID
+            echo "Build packaged: $(ls -lh CUBRID.tar.gz | awk '{print $5}')"
+      - store_artifacts:
+          path: CUBRID.tar.gz
+          destination: CUBRID.tar.gz
+      - run:
+          name: Save build metadata for consumers (<< parameters.mode >>)
+          command: |
+            mkdir -p workspace
+            echo "${CIRCLE_BUILD_NUM}" > workspace/BUILD_NUM_<< parameters.mode >>
+            echo "Saved BUILD_NUM_<< parameters.mode >>: $(cat workspace/BUILD_NUM_<< parameters.mode >>)"
+      - persist_to_workspace:
+          root: workspace
+          paths: [ BUILD_NUM_<< parameters.mode >> ]
+
   resolve-testcases:
     description: "Resolve testcases branch/SHA for a TC repo; export BRANCH_TESTCASES and materialize cache-key inputs"
     parameters:
@@ -369,53 +396,69 @@ commands:
       - run:
           name: Download build to GlusterFS
           command: |
-            BUILD_NUM=$(cat /tmp/workspace/BUILD_NUM_DEBUG)
             : "${BUILD_CACHE_ROOT:?}" "${BUILD_SENTINEL:?}"
-            BUILD_DIR="${BUILD_CACHE_ROOT}/${CIRCLE_SHA1}/debug"
-            echo "CIRCLE_SHA1=${CIRCLE_SHA1} BUILD_NUM=${BUILD_NUM} BUILD_DIR=${BUILD_DIR}"
 
-            # Same commit = same build: reuse across workflow retries.
-            if [ -f "${BUILD_DIR}/${BUILD_SENTINEL}" ]; then
-              echo "Build already complete for this commit, skipping download"
-              ls -la "${BUILD_DIR}/CUBRID"
-              exit 0
-            fi
+            # One build-number file per packaged mode (package-build persists
+            # BUILD_NUM_RELEASE / BUILD_NUM_DEBUG), so this transports exactly what
+            # the build jobs produced: debug only on PRs, both on develop.
+            publish() {
+              local mode="$1" build_num="$2"
+              local build_dir="${BUILD_CACHE_ROOT}/${CIRCLE_SHA1}/${mode}"
+              echo "== ${mode}: artifact of job #${build_num} -> ${build_dir}"
 
-            # Stage, then publish with one atomic rename: consumers never see a
-            # half-extracted tree, and a concurrent duplicate run just loses the
-            # rename and drops its staging dir (no rm of a published tree).
-            TMP_DIR="${BUILD_DIR}.tmp.$$"
-            rm -rf "${TMP_DIR}"
-            mkdir -p "${TMP_DIR}"
+              # Same commit = same build: reuse across workflow retries.
+              if [ -f "${build_dir}/${BUILD_SENTINEL}" ]; then
+                echo "Build already complete for this commit, skipping download"
+                ls -la "${build_dir}/CUBRID"
+                return 0
+              fi
 
-            echo "Downloading build from job #${BUILD_NUM}..."
-            RESPONSE=$(curl -s -H "Circle-Token: ${CIRCLECI_TOKEN}" \
-              "https://circleci.com/api/v2/project/gh/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${BUILD_NUM}/artifacts")
-            ARTIFACT_URL=$(echo "$RESPONSE" | grep -o '"url": "[^"]*CUBRID.tar.gz[^"]*"' | head -1 | sed 's/"url": "//;s/"$//')
+              # Stage, then publish with one atomic rename: consumers never see a
+              # half-extracted tree, and a concurrent duplicate run just loses the
+              # rename and drops its staging dir (no rm of a published tree).
+              local tmp_dir="${build_dir}.tmp.$$"
+              rm -rf "${tmp_dir}"
+              mkdir -p "${tmp_dir}"
 
-            if [ -z "$ARTIFACT_URL" ]; then
-              echo "ERROR: CUBRID.tar.gz artifact not found"
-              echo "Response: $RESPONSE"
-              rm -rf "${TMP_DIR}"
+              local response artifact_url
+              response=$(curl -s -H "Circle-Token: ${CIRCLECI_TOKEN}" \
+                "https://circleci.com/api/v2/project/gh/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${build_num}/artifacts")
+              artifact_url=$(echo "$response" | grep -o '"url": "[^"]*CUBRID.tar.gz[^"]*"' | head -1 | sed 's/"url": "//;s/"$//')
+              if [ -z "$artifact_url" ]; then
+                echo "ERROR: CUBRID.tar.gz artifact not found in job #${build_num}"
+                echo "Response: $response"
+                rm -rf "${tmp_dir}"
+                return 1
+              fi
+
+              curl -L -o "${tmp_dir}/CUBRID.tar.gz" "$artifact_url"
+              tar xzf "${tmp_dir}/CUBRID.tar.gz" -C "${tmp_dir}"
+              rm "${tmp_dir}/CUBRID.tar.gz"
+              touch "${tmp_dir}/${BUILD_SENTINEL}"
+
+              if mv -T "${tmp_dir}" "${build_dir}" 2>/dev/null; then
+                echo "Build published at ${build_dir}"
+              else
+                # Lost the publish race to a concurrent duplicate run.
+                echo "Another run published this build first, discarding staging dir"
+                rm -rf "${tmp_dir}"
+              fi
+              ls -la "${build_dir}/CUBRID"
+            }
+
+            published=0
+            for num_file in /tmp/workspace/BUILD_NUM_*; do
+              [ -f "$num_file" ] || continue
+              mode=$(basename "$num_file" | sed 's/^BUILD_NUM_//' | tr '[:upper:]' '[:lower:]')
+              publish "$mode" "$(cat "$num_file")"
+              published=$((published + 1))
+            done
+
+            if [ "$published" -eq 0 ]; then
+              echo "ERROR: no BUILD_NUM_* file in the workspace - did a build job skip packaging?"
               exit 1
             fi
-
-            echo "Artifact URL: $ARTIFACT_URL"
-            curl -L -o "${TMP_DIR}/CUBRID.tar.gz" "$ARTIFACT_URL"
-            tar xzf "${TMP_DIR}/CUBRID.tar.gz" -C "${TMP_DIR}"
-            rm "${TMP_DIR}/CUBRID.tar.gz"
-            touch "${TMP_DIR}/${BUILD_SENTINEL}"
-
-            if mv -T "${TMP_DIR}" "${BUILD_DIR}" 2>/dev/null; then
-              echo "Build published at ${BUILD_DIR}"
-            else
-              # Lost the publish race to a concurrent duplicate run.
-              echo "Another run published this build first, discarding staging dir"
-              rm -rf "${TMP_DIR}"
-            fi
-
-            echo "Build ready at ${BUILD_DIR}/CUBRID"
-            ls -la "${BUILD_DIR}/CUBRID"
+            echo "Transported ${published} build(s) for ${CIRCLE_SHA1}"
             df -h /home/build-cache
 
 # --------------------------------------------------
@@ -427,6 +470,15 @@ jobs:
     steps:
       - build-cubrid:
           ccache-prefix: ccache-global-v2
+      # The release build is packaged only on develop, where it is preserved in
+      # GlusterFS for downstream consumers. PR pipelines test the debug build,
+      # so packaging release there would upload an artifact nobody reads.
+      - when:
+          condition:
+            equal: [ develop, << pipeline.git.branch >> ]
+          steps:
+            - package-build:
+                mode: RELEASE
 
   build_debug:
     executor: cubrid-build
@@ -435,31 +487,17 @@ jobs:
           ccache-prefix: ccache-debug-v2
           mode: optdebug
           build-args: "-m optdebug"
-      # Package the debug build only when a test job will consume it.
+      # Package when a test job will consume it, or on develop for preservation.
       - when:
           condition:
             or:
               - << pipeline.parameters.run_sql_test >>
               - << pipeline.parameters.run_medium_test >>
               - << pipeline.parameters.run_shell_test >>
+              - equal: [ develop, << pipeline.git.branch >> ]
           steps:
-            - run:
-                name: Package build for artifact
-                command: |
-                  tar czf CUBRID.tar.gz CUBRID
-                  echo "Build packaged: $(ls -lh CUBRID.tar.gz | awk '{print $5}')"
-            - store_artifacts:
-                path: CUBRID.tar.gz
-                destination: CUBRID.tar.gz
-            - run:
-                name: Save build metadata for test jobs
-                command: |
-                  mkdir -p workspace
-                  echo "${CIRCLE_BUILD_NUM}" > workspace/BUILD_NUM_DEBUG
-                  echo "Saved BUILD_NUM_DEBUG: $(cat workspace/BUILD_NUM_DEBUG)"
-            - persist_to_workspace:
-                root: workspace
-                paths: [ BUILD_NUM_DEBUG ]
+            - package-build:
+                mode: DEBUG
 
   # sql and medium tests share the same shape; parameterized to avoid duplication
   artifact-test:
@@ -557,3 +595,12 @@ workflows:
       - test_shell:
           requires: [download-build]
           filters: pipeline.parameters.run_shell_test
+      # develop merge: transport only. Both builds are preserved in GlusterFS for
+      # downstream consumers (AI agent service); no test job runs on this path.
+      # Requires both builds so a release-only regression still blocks the upload.
+      - download-build:
+          name: store-build-develop
+          requires: [build, build_debug]
+          filters:
+            branches:
+              only: develop


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1476

### Purpose

develop에 머지된 커밋의 빌드가 클러스터에 보존되지 않아, 같은 K8s 클러스터에서 운영될 소비자(AI 에이전트 서비스 등)가 develop 빌드를 쓸 수 없다. 지금 develop 머지 파이프라인은 컴파일 검증만 하고 산출물을 버린다.

### Implementation

- **develop 머지 시 두 빌드를 보존한다**: `build`(release)는 develop에서만, `build_debug`는 기존 조건(테스트 소비 시) 또는 develop에서 산출물을 패키징한다. 패키징 절차는 `package-build(mode)` 커맨드로 뽑아 두 job이 공유한다(기존에는 `build_debug`에 인라인).
- **전송은 mode 구분 없이 동작한다**: `download-build`가 workspace의 `BUILD_NUM_*` 파일을 순회해 각각 `builds/<SHA>/<mode>/CUBRID` + `.complete` sentinel로 발행한다. 따라서 PR은 debug만, develop은 release·debug 둘 다 저장되며 스크립트에 브랜치 분기가 없다. mode 문자열은 파라미터·workspace 파일명·경로가 모두 소문자로 동일해, mode를 추가할 때 고칠 곳이 한 군데다.
- **develop 경로는 전송만 한다**: 워크플로에 develop 전용 `store-build-develop`(`filters: branches: only: develop`, `requires: [build, build_debug]`)을 추가했다. 테스트 job은 이 경로에서 실행되지 않고, `for-shell-tests: false`로 아무도 읽지 않는 testcases 브랜치 조회도 건너뛴다(그 조회 실패가 전송 성공한 develop 커밋을 빨갛게 만들 수 있었다).
- sql/medium 소비자와 PR 경로 동작은 그대로다.

**같이 고친 것** (전체 파일 리뷰에서 발견, 동작 개선/무변화):

- `collect-build-logs`가 `store_artifacts`에만 `when: always`를 걸어, **빌드 실패 시** `/tmp/build_logs`를 채우는 스텝이 건너뛰어지고 빈 아티팩트만 올라갔다 — `build.log`가 가장 필요한 순간에 사라졌다. 두 스텝을 하나로 합쳐 `when: always`를 걸었다.
- 전송·소비 양쪽에서 아티팩트 URL 추출이 errexit 아래 대입문 안에서 죽어, "artifact not found" 메시지와 API 응답 덤프가 출력되기 전에 스텝이 실패했다 — 이유 없는 빨간 스텝만 남았다. 이제 진단이 실제로 출력된다.
- `test_shell`의 `GITHUB_TOKEN: $GHI_TOKEN`을 제거했다. job `environment` 맵은 보간을 하지 않아 값이 리터럴 `$GHI_TOKEN`이었다. 이 줄이 들어올 당시엔 이미지가 `GITHUB_TOKEN`을 읽었지만(cubridci `6ed8c85`), CUBRIDQA-1291(cubridci `ec5c043`, 2025-08-21)이 `GHI_TOKEN` + git `insteadOf`로 바꾼 뒤로는 아무도 읽지 않는다(운영 이미지 `/entrypoint.sh`, cubrid-testtools, cubrid-testcases-private-ex에서 확인). 동작 변화 없이, 연결된 자격증명처럼 보이는 오해만 없앤다.
- 배너 주석·바로 아래 줄을 되풀이하는 주석 제거, 기본값과 같은 옵션 제거, 캐시 키를 YAML 앵커로 묶어 restore/save가 어긋날 수 없게 했다.

### Remarks

- ADR-0005에 있던 "전송 job을 작은 이미지로" 항목은 **기각**했다 — 워커 노드에 테스트 이미지(291MB)가 이미 캐시돼 있어 절감 대역폭이 없고(job 소요는 전부 아티팩트 다운로드), 반대로 postStart 계약(`/bin/sh -l`·`mount`) 때문에 이미지 요구조건만 늘어난다. 근거와 재개 조건은 ADR-0005 Considered options에 기록.
- **검증 완료**
  - `/run all` (rev `c5e30f4a`): 6 job 전부 success, **21,667건 수행 / 실패 0** (sql 17,444 · shell 3,248 · medium 975)
  - develop 경로 예행연습(임시 커밋으로 브랜치 조건만 열고 `/run sql`): `builds/<SHA>/debug/`·`release/` 양쪽 sentinel·binary OK, `.tmp` 잔여물 없음, 테스트 job 미실행. mode별 원자적 발행도 실측 확인(debug 발행 완료 시점에 `release.tmp.82/`가 아직 staging).
  - develop 커밋당 release+debug 합계 **1.6GB**, 전송 소요 **20~30분**(ADR-0005에 기록). 보존 기간 7일.
- 실제 develop 첫 머지에서 `builds/<merge SHA>/{release,debug}/` 생성을 확인한 뒤 Jira를 Resolved 처리한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UcXpSqurNoQmhQDrNFv5Xr
