### PR TITLE
[CBRD-27145] Fix NULLS LAST being ignored when analytic sort is skipped

### DIFF
--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -29636,7 +29636,10 @@ pt_count_analytic_covered_sort_list (PARSER_CONTEXT * parser, QO_PLAN * qo_plan,
       node = QO_SEG_PT_NODE (seg);
       attr = pt_get_node_from_list (info->select_list, sort_list->pos_descr.pos_no);
 
-      if (((sort_list->s_order == S_ASC && !is_desc) || (sort_list->s_order == S_DESC && is_desc))
+      /* an ascending index run supplies NULLs first and a descending run supplies NULLs last; a sort spec
+       * requesting the opposite NULL placement cannot reuse the index order */
+      if (((sort_list->s_order == S_ASC && !is_desc && sort_list->s_nulls == S_NULLS_FIRST)
+	   || (sort_list->s_order == S_DESC && is_desc && sort_list->s_nulls == S_NULLS_LAST))
 	  && pt_check_path_eq (parser, attr, node) == 0)
 	{
 	  covered_count++;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27145>

### Purpose

분석함수 `OVER` 절의 `ORDER BY ... NULLS LAST` 가 sort 생략 경로에서 무시되어 `NULL` 행이 맨 앞에 반환됩니다. 

CBRD-26473 (#6746) 에서 유입된 회귀입니다.

```sql 
create table tn (id int, val int);
create index nidx on tn (val, id);
-- val 에 NULL 포함 데이터 적재 후

select /*+ recompile */ val, row_number() over (order by val nulls last) as rn
from tn where id >= 1 using index nidx(+) limit 5;
-- 기대: val = 1 부터 (NULL 은 마지막)
-- 실제: val = NULL 부터 (sort: skip 으로 인덱스 순서가 그대로 노출)
```

오름차순 인덱스는 `NULL` 을 선두에 저장하므로 인덱스 순서가 제공할 수 있는 조합은 `ASC` + `NULLS FIRST`(정방향), `DESC` + `NULLS LAST`(역방향) 뿐입니다. 그러나 sort 생략 판정이 컬럼과 `ASC`/`DESC` 방향만 비교하고 `NULLS` 배치는 비교하지 않아, `NULLS LAST` 에서도 정렬을 생략했습니다.

### Implementation

`pt_count_analytic_covered_sort_list()` 의 인덱스-정렬키 방향 비교에 `NULLS` 배치 검사를 추가했습니다. 유효 스캔 방향이 오름차순이면 `NULLS FIRST`, 내림차순이면 `NULLS LAST` 인 경우에만 covered 로 집계하고, 어긋나면 해당 컬럼에서 중단하여 정렬을 수행합니다.

covered_size 를 소비하는 sort 생략(`XASL_ANALYTIC_SKIP_SORT`)과 limit 최적화(`XASL_ANALYTIC_USES_LIMIT_OPT`) 판정이 모두 함께 차단됩니다.
`NULLS` 미지정 시 기본값(`ASC`→`FIRST`, `DESC`→`LAST`)은 인덱스 배치와 동일하므로 기존 생략 케이스는 그대로 유지됩니다.

### Remarks

N/A
