### PR TITLE
[CBRD-27150] Reduce 128-bit divisions in NUMERIC scale adjustment and add an output fast path

### DIFF
--- a/src/query/numeric_opfunc.c
+++ b/src/query/numeric_opfunc.c
@@ -3899,9 +3899,33 @@ numeric_coerce_num_to_dec_str (const DB_VALUE * num_value, char *dec_str)
    *    17-byte buffer capacity (~40 digits) < 3 iterations (48 digits) */
   p_digits = dec_str + TWICE_NUM_MAX_PREC - 16;
 
-  /* 
-   * maximum decimal digits for 17-byte numeric is 40. 
-   * 3 iterations cover up to 48 digits (16 * 3). 
+  /* 6. fast path: the coefficient fits in a single word, that is at most 20 digits (2^64 - 1).
+   *    the divisor is a compile time constant here, so the 64-bit division is compiled into a
+   *    multiplication and no 128-bit division is performed. */
+  if ((work_word[0] | work_word[1]) == 0)
+    {
+      const uint64_t pow10_16 = _gv_mul_normalize_pow10_lookup[15];
+      uint64_t word_val = work_word[NUMERIC_AS_WORDS - 1];
+      uint64_t upper_digits;
+
+      if (word_val < pow10_16)
+	{
+	  /* up to 16 digits: a single block, no division at all */
+	  numeric_pack_digits4_ascii (p_digits, word_val);
+	  return;
+	}
+
+      /* 17 to 20 digits: split into the low 16 digits and the 1 to 4 digits above them */
+      upper_digits = word_val / pow10_16;
+      numeric_pack_digits4_ascii (p_digits, word_val - upper_digits * pow10_16);
+      numeric_pack_digits4_ascii (p_digits - 16, upper_digits);
+
+      return;
+    }
+
+  /*
+   * maximum decimal digits for 17-byte numeric is 40.
+   * 3 iterations cover up to 48 digits (16 * 3).
    */
   for (i = 0; i < NUMERIC_AS_WORDS; i++)
     {
@@ -5279,6 +5303,7 @@ static uint64_t
 float_numeric_div_pow10 (uint64_t * dbv_buf, int calc_words, int calc_bytes, uint64_t divisor)
 {
   uint64_t rem10 = 0;
+  uint64_t quotient = 0;
   int i = 0;
 
   uint128_t temp = 0;
@@ -5287,8 +5312,9 @@ float_numeric_div_pow10 (uint64_t * dbv_buf, int calc_words, int calc_bytes, uin
   for (i = 0; i < calc_words; i++)
     {
       temp = ((uint128_t) rem10 << 64) | word_ptr[i];
-      word_ptr[i] = (uint64_t) (temp / divisor);
-      rem10 = (uint64_t) (temp % divisor);
+      quotient = (uint64_t) (temp / divisor);
+      rem10 = (uint64_t) (temp - (uint128_t) quotient * divisor);
+      word_ptr[i] = quotient;
     }
 
   return rem10;

--- a/src/query/numeric_opfunc.c
+++ b/src/query/numeric_opfunc.c
@@ -5303,7 +5303,6 @@ static uint64_t
 float_numeric_div_pow10 (uint64_t * dbv_buf, int calc_words, int calc_bytes, uint64_t divisor)
 {
   uint64_t rem10 = 0;
-  uint64_t quotient = 0;
   int i = 0;
 
   uint128_t temp = 0;
@@ -5312,9 +5311,8 @@ float_numeric_div_pow10 (uint64_t * dbv_buf, int calc_words, int calc_bytes, uin
   for (i = 0; i < calc_words; i++)
     {
       temp = ((uint128_t) rem10 << 64) | word_ptr[i];
-      quotient = (uint64_t) (temp / divisor);
-      rem10 = (uint64_t) (temp - (uint128_t) quotient * divisor);
-      word_ptr[i] = quotient;
+      word_ptr[i] = (uint64_t) (temp / divisor);
+      rem10 = (uint64_t) (temp - (uint128_t) word_ptr[i] * divisor);
     }
 
   return rem10;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27150

## Purpose

float_numeric_div_pow10()은 NUMERIC 내부 정수값(base-256 버퍼)을 10^k로 나누는 공통 내부 루틴으로, 10진 문자열 변환(출력), 연산 결과의 자릿수 버림/반올림, 해시 정규화에서 사용된다.
이 경로의 128비트 나눗셈 호출을 다음 두 가지로 줄인다.

1. 나눗셈 호출을 워드당 2회에서 1회로 절감 (세 경로 모두에 적용)
2. 내부 정수값이 한 워드에 들어가면 128비트 나눗셈 없이 변환 (출력 경로에만 적용)

## Implementation

### 1. 나머지 연산을 곱셈으로 유도 (float_numeric_div_pow10)
- quotient는 long division 불변식(직전 나머지 < divisor)에 의해 64비트에 들어감이 보장된다.
  (uint128_t) 승격 곱셈은 64×64→128 곱셈 명령 1개로 컴파일된다.

### 2. 단일 워드 fast path (numeric_coerce_num_to_dec_str)
- 제수 10^16은 기존 lookup 테이블(_gv_mul_normalize_pow10_lookup[15])을 그대로 사용한다.
- numeric_pack_digits4_ascii()가 한 번에 16자리를 기록하므로 17자리 이상은 블록을 2개로 나눈다.
- 판정식 (word[0] | word[1]) == 0은 float_numeric_db_value_add/sub/mul이 이미 사용하는 단일 워드 판정과 동일한 형태다.
- 두 워드 이상을 사용하는 값은 기존 경로로 진행하며, 추가 비용은 분기 1회(측정상 1ns 미만)다.

### 수정 범위

src/query/numeric_opfunc.c (+31/−5줄). 두 함수 모두 static이며 시그니처 변경 없음. 호출부 수정 없음.

## Remarks

### 동작 변경 없음

SQL 결과 값, 출력 포맷, 저장 구조에 영향이 없다.

### 측정 데이터 (demodb, 각 100만 행)

| 테이블 | 컬럼 | 값 예시 | 유효 자릿수 | 용도 |
|---|---|---|---|---|
| t_claude_num | i INT | 1 ~ 1000000 | — | 대조군 |
| | s NUMERIC(10,2) | 99999.42 | 7 | 해시 정규화, 곱셈 피연산자 |
| | b NUMERIC(38,10) | 2234567890123456789012345678.8901234567 | 38 | 곱셈 피연산자 |
| t_claude_w | w_fast NUMERIC(20,0) | 18446744073709551001 ~ ...551599 | 20 | 한 워드에 들어감 (fast path) |
| | w_slow NUMERIC(20,0) | 18446744073709552001 ~ ...552599 | 20 | 두 워드 필요 (기존 경로) |

t_claude_w의 두 컬럼은 자릿수와 출력 길이가 같고 2^64 경계를 사이에 두고만 갈린다.
출력 경로 비교에서 자릿수 차이가 섞이지 않도록 하기 위한 구성이다.

### 성능 — 1번의 효과 (서버 측 연산 경로)

자릿수 버림과 해시 정규화는 서버에서 수행되므로 csql 문장 elapsed로 측정된다. (8회 중 최솟값)

| 쿼리 | 수정 전 | 수정 후 | 개선 | 행당 절감 |
|---|---|---|---|---|
| SUM(s*b) — 자릿수 버림 발생 (결과 유효 자릿수 44자리) | 0.861s | 0.724s | −16% | 137 ns |
| GROUP BY s — NUMERIC 키 해시 정규화 | 0.979s | 0.906s | −7% | 73 ns |

### 성능 — 2번의 효과 (출력 경로)

출력의 문자열 변환은 클라이언트에서 수행되어 문장 elapsed에 잡히지 않는다.
같은 데이터를 수정 전/후 빌드에서 각각 100만 행 × 8회 출력하고, perf 프로파일에서
변환 루틴(numeric_coerce_num_to_dec_str + __udivti3 + __umodti3)이 차지한 시간을 변환 건수로 나누어 산출했다.

| 컬럼 (둘 다 20자리) | 수정 전 | 수정 후 | 개선 | 기여 |
|---|---|---|---|---|
| w_fast — 한 워드에 들어감 | 119.3 ns | 27.8 ns | −77% | 2번 |
| w_slow — 두 워드 필요 | 164.5 ns | 92.1 ns | −44% | 1번 |

- w_fast는 fast path가 적용되어 float_numeric_div_pow10을 호출하지 않으므로 개선분 전체가 2번의 효과다.
- w_slow는 fast path 대상이 아니어서 기존 경로를 그대로 타므로 개선분은 1번의 효과다.

### 참고

- 출력 전체 비용은 numeric_db_value_print()의 후처리(TWICE_NUM_MAX_PREC = 256자 버퍼에 대한 memset과
  패딩 제거 루프, 프로파일 21~24%)가 지배한다. 본 PR은 그 위에 얹히는 변환 비용을 줄이므로
  출력 end-to-end 시간에서 차지하는 비중은 제한적이다. 후처리 최적화는 별도 이슈로 다룰 수 있다.
- 검토 후 보류 : Möller-Granlund 역수 곱셈 방식(함수 단독 6.4배). 역수 테이블 등 약 107줄 추가로
  유지보수 부담이 크고 추가 이득이 자릿수 버림이 발생하는 곱셈에 한정되어 본 PR에서는 채택하지 않았다.
