### PR TITLE
[CBRD-26898] Deprecate SHOW PAGE BUFFER STATUS counter columns

### DIFF
--- a/src/parser/show_meta.c
+++ b/src/parser/show_meta.c
@@ -692,14 +692,14 @@ metadata_of_page_buffer_status (void)
 {
   /* note: the counter columns (Hit_rate, Num_hit, Num_page_request, Num_pages_created, Num_pages_written,
    * Pages_written_rate, Num_pages_read, Pages_read_rate, Num_flusher_waiting_threads) are deprecated and always
-   * report 0. They were maintained on the page fix hot path and duplicate statistics already provided by
+   * report NULL. They were maintained on the page fix hot path and duplicate statistics already provided by
    * cubrid statdump (Num_data_page_fetches / Num_data_page_ioreads / Num_data_page_iowrites /
    * Data_page_buffer_hit_ratio).
    * The columns are kept so that the result set layout does not change. */
   static const SHOWSTMT_COLUMN cols[] = {
-    {"Hit_rate", "numeric(13,10)"},	/* deprecated, always 0 */
-    {"Num_hit", "bigint"},	/* deprecated, always 0 */
-    {"Num_page_request", "bigint"},	/* deprecated, always 0 */
+    {"Hit_rate", "numeric(13,10)"},	/* deprecated, always NULL */
+    {"Num_hit", "bigint"},	/* deprecated, always NULL */
+    {"Num_page_request", "bigint"},	/* deprecated, always NULL */
     {"Pool_size", "int"},
     {"Page_size", "int"},
     {"Free_pages", "int"},
@@ -710,12 +710,12 @@ metadata_of_page_buffer_status (void)
     {"Num_data_pages", "int"},
     {"Num_system_pages", "int"},
     {"Num_temp_pages", "int"},
-    {"Num_pages_created", "bigint"},	/* deprecated, always 0 */
-    {"Num_pages_written", "bigint"},	/* deprecated, always 0 */
-    {"Pages_written_rate", "numeric(20,10)"},	/* deprecated, always 0 */
-    {"Num_pages_read", "bigint"},	/* deprecated, always 0 */
-    {"Pages_read_rate", "numeric(20,10)"},	/* deprecated, always 0 */
-    {"Num_flusher_waiting_threads", "int"}	/* deprecated, always 0 */
+    {"Num_pages_created", "bigint"},	/* deprecated, always NULL */
+    {"Num_pages_written", "bigint"},	/* deprecated, always NULL */
+    {"Pages_written_rate", "numeric(20,10)"},	/* deprecated, always NULL */
+    {"Num_pages_read", "bigint"},	/* deprecated, always NULL */
+    {"Pages_read_rate", "numeric(20,10)"},	/* deprecated, always NULL */
+    {"Num_flusher_waiting_threads", "int"}	/* deprecated, always NULL */
   };
 
   static const SHOWSTMT_COLUMN_ORDERBY orderby[] = {

--- a/src/parser/show_meta.c
+++ b/src/parser/show_meta.c
@@ -693,7 +693,8 @@ metadata_of_page_buffer_status (void)
   /* note: the counter columns (Hit_rate, Num_hit, Num_page_request, Num_pages_created, Num_pages_written,
    * Pages_written_rate, Num_pages_read, Pages_read_rate, Num_flusher_waiting_threads) are deprecated and always
    * report 0. They were maintained on the page fix hot path and duplicate statistics already provided by
-   * cubrid statdump (Num_data_page_fix / Num_data_page_ioreads / Num_data_page_iowrites / hit_ratio).
+   * cubrid statdump (Num_data_page_fetches / Num_data_page_ioreads / Num_data_page_iowrites /
+   * Data_page_buffer_hit_ratio).
    * The columns are kept so that the result set layout does not change. */
   static const SHOWSTMT_COLUMN cols[] = {
     {"Hit_rate", "numeric(13,10)"},	/* deprecated, always 0 */

--- a/src/parser/show_meta.c
+++ b/src/parser/show_meta.c
@@ -690,10 +690,15 @@ metadata_of_threads (void)
 static SHOWSTMT_METADATA *
 metadata_of_page_buffer_status (void)
 {
+  /* note: the counter columns (Hit_rate, Num_hit, Num_page_request, Num_pages_created, Num_pages_written,
+   * Pages_written_rate, Num_pages_read, Pages_read_rate, Num_flusher_waiting_threads) are deprecated and always
+   * report 0. They were maintained on the page fix hot path and duplicate statistics already provided by
+   * cubrid statdump (Num_data_page_fix / Num_data_page_ioreads / Num_data_page_iowrites / hit_ratio).
+   * The columns are kept so that the result set layout does not change. */
   static const SHOWSTMT_COLUMN cols[] = {
-    {"Hit_rate", "numeric(13,10)"},
-    {"Num_hit", "bigint"},
-    {"Num_page_request", "bigint"},
+    {"Hit_rate", "numeric(13,10)"},	/* deprecated, always 0 */
+    {"Num_hit", "bigint"},	/* deprecated, always 0 */
+    {"Num_page_request", "bigint"},	/* deprecated, always 0 */
     {"Pool_size", "int"},
     {"Page_size", "int"},
     {"Free_pages", "int"},
@@ -704,12 +709,12 @@ metadata_of_page_buffer_status (void)
     {"Num_data_pages", "int"},
     {"Num_system_pages", "int"},
     {"Num_temp_pages", "int"},
-    {"Num_pages_created", "bigint"},
-    {"Num_pages_written", "bigint"},
-    {"Pages_written_rate", "numeric(20,10)"},
-    {"Num_pages_read", "bigint"},
-    {"Pages_read_rate", "numeric(20,10)"},
-    {"Num_flusher_waiting_threads", "int"}
+    {"Num_pages_created", "bigint"},	/* deprecated, always 0 */
+    {"Num_pages_written", "bigint"},	/* deprecated, always 0 */
+    {"Pages_written_rate", "numeric(20,10)"},	/* deprecated, always 0 */
+    {"Num_pages_read", "bigint"},	/* deprecated, always 0 */
+    {"Pages_read_rate", "numeric(20,10)"},	/* deprecated, always 0 */
+    {"Num_flusher_waiting_threads", "int"}	/* deprecated, always 0 */
   };
 
   static const SHOWSTMT_COLUMN_ORDERBY orderby[] = {

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -388,20 +388,14 @@ typedef struct pgbuf_monitor_bcb_mutex PGBUF_MONITOR_BCB_MUTEX;
 
 typedef struct pgbuf_holder_info PGBUF_HOLDER_INFO;
 
-typedef struct pgbuf_status PGBUF_STATUS;
 typedef struct pgbuf_status_snapshot PGBUF_STATUS_SNAPSHOT;
-typedef struct pgbuf_status_old PGBUF_STATUS_OLD;
 
-struct alignas (64) pgbuf_status
-{
-  unsigned long long num_hit;
-  unsigned long long num_page_request;
-  unsigned long long num_pages_created;
-  unsigned long long num_pages_written;
-  unsigned long long num_pages_read;
-  unsigned int num_flusher_waiting_threads;
-  unsigned int dummy;
-};
+/* note: the per-fix counters that used to back the SHOW PAGE BUFFER STATUS counter columns (num_hit,
+ * num_page_request, num_pages_created, num_pages_written, num_pages_read, num_flusher_waiting_threads) have been
+ * removed. They were incremented on every page fix, which made the page fix hot path pay for a cache line write that
+ * multiple workers of the same query contend on, and the very same numbers are already provided by
+ * cubrid statdump (Num_data_page_fix / Num_data_page_ioreads / Num_data_page_iowrites / hit_ratio).
+ * The corresponding SHOW columns are deprecated and always report 0. */
 
 struct pgbuf_status_snapshot
 {
@@ -413,16 +407,6 @@ struct pgbuf_status_snapshot
   unsigned int num_data_pages;
   unsigned int num_system_pages;
   unsigned int num_temp_pages;
-};
-
-struct pgbuf_status_old
-{
-  unsigned long long num_hit;
-  unsigned long long num_page_request;
-  unsigned long long num_pages_created;
-  unsigned long long num_pages_written;
-  unsigned long long num_pages_read;
-  time_t print_out_time;
 };
 
 struct pgbuf_holder_info
@@ -825,8 +809,6 @@ struct pgbuf_buffer_pool
   lockfree::circular_queue<int> *shared_lrus_with_victims;
   /* *INDENT-ON* */
 
-  PGBUF_STATUS *show_status;
-  PGBUF_STATUS_OLD show_status_old;
   PGBUF_STATUS_SNAPSHOT show_status_snapshot;
 #if defined (SERVER_MODE)
   pthread_mutex_t show_status_mutex;
@@ -1619,7 +1601,6 @@ pgbuf_initialize (void)
   memset (&pgbuf_Pool.buf_invalid_list, 0, sizeof (PGBUF_INVALID_LIST));
   memset (&pgbuf_Pool.seq_chkpt_flusher, 0, sizeof (PGBUF_SEQ_FLUSHER));
   memset (&pgbuf_Pool.quota, 0, sizeof (PGBUF_PAGE_QUOTA));
-  memset (&pgbuf_Pool.show_status_old, 0, sizeof (PGBUF_STATUS_OLD));
   memset (&pgbuf_Pool.show_status_snapshot, 0, sizeof (PGBUF_STATUS_SNAPSHOT));
 
 #if defined (SERVER_MODE)
@@ -1658,7 +1639,6 @@ pgbuf_initialize (void)
   pgbuf_Pool.big_private_lrus_with_victims = NULL;
   pgbuf_Pool.shared_lrus_with_victims = NULL;
 
-  pgbuf_Pool.show_status = NULL;
 #if defined (SERVER_MODE)
   pgbuf_Pool.show_status_mutex = PTHREAD_MUTEX_INITIALIZER;
 #endif
@@ -1843,20 +1823,6 @@ pgbuf_initialize (void)
       ASSERT_ERROR ();
       goto error;
     }
-
-  /* cache-line aligned so each per-thread slot owns its own line (no false sharing) */
-  pgbuf_Pool.show_status =
-    (PGBUF_STATUS *) cub_aligned_alloc (64, sizeof (PGBUF_STATUS) * (thread_num_total_threads () + 1),
-					__FILE__, __LINE__);
-  if (pgbuf_Pool.show_status == NULL)
-    {
-      ASSERT_ERROR ();
-      goto error;
-    }
-
-  memset (pgbuf_Pool.show_status, 0, sizeof (PGBUF_STATUS) * (thread_num_total_threads () + 1));
-
-  pgbuf_Pool.show_status_old.print_out_time = time (NULL);
 
 #if defined(SERVER_MODE)
   pthread_mutex_init (&pgbuf_Pool.show_status_mutex, NULL);
@@ -2053,12 +2019,6 @@ pgbuf_finalize (void)
       pgbuf_Pool.shared_lrus_with_victims = NULL;
     }
 
-  if (pgbuf_Pool.show_status != NULL)
-    {
-      free (pgbuf_Pool.show_status);
-      pgbuf_Pool.show_status = NULL;
-    }
-
 #if defined(SERVER_MODE)
   pthread_mutex_destroy (&pgbuf_Pool.show_status_mutex);
 #endif
@@ -2231,7 +2191,6 @@ pgbuf_fix_release (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_MODE f
 #endif /* !NDEBUG */
   PGBUF_FIX_PERF perf;
   bool maybe_deallocated;
-  PGBUF_STATUS *show_status = &pgbuf_Pool.show_status[thread_get_entry_index (thread_p)];
 
   perf.perf_page_found = PERF_PAGE_MODE_OLD_IN_BUFFER;
 
@@ -2324,7 +2283,6 @@ try_again:
 	  pgbuf_hit = true;
 #endif /* ENABLE_SYSTEMTAP */
 
-	  show_status->num_hit++;
 	  goto fast_path;
 	}
     }
@@ -2344,8 +2302,6 @@ try_again:
       CUBRID_PGBUF_HIT ();
       pgbuf_hit = true;
 #endif /* ENABLE_SYSTEMTAP */
-
-      show_status->num_hit++;
 
       if (fetch_mode == NEW_PAGE)
 	{
@@ -2565,8 +2521,6 @@ fast_path:
        * note: temporary pages are not strictly handled in regard with their deallocation status. */
       assert (fetch_mode != NEW_PAGE || pgbuf_is_lsa_temporary (pgptr));
     }
-
-  show_status->num_page_request++;
 
   /* Record number of fetches in statistics */
   if (perf.is_perf_tracking)
@@ -8139,7 +8093,6 @@ pgbuf_allocate_bcb (THREAD_ENTRY * thread_p, const VPID * src_vpid)
   PERF_UTIME_TRACKER time_tracker_alloc_bcb = PERF_UTIME_TRACKER_INITIALIZER;
   PERF_UTIME_TRACKER time_tracker_alloc_search_and_wait = PERF_UTIME_TRACKER_INITIALIZER;
   bool detailed_perf = perfmon_is_perf_tracking_and_active (PERFMON_ACTIVATION_FLAG_PB_VICTIMIZATION);
-  PGBUF_STATUS *show_status = &pgbuf_Pool.show_status[thread_get_entry_index (thread_p)];
 
 #if defined (SERVER_MODE)
   struct timespec to;
@@ -8251,11 +8204,7 @@ pgbuf_allocate_bcb (THREAD_ENTRY * thread_p, const VPID * src_vpid)
       // before migration of the page_flush_daemon it was a try_wakeup, check if still needed
       pgbuf_wakeup_page_flush_daemon (thread_p);
 
-      show_status->num_flusher_waiting_threads++;
-
       r = thread_suspend_timeout_wakeup_and_unlock_entry (thread_p, &to, THREAD_ALLOC_BCB_SUSPENDED);
-
-      show_status->num_flusher_waiting_threads--;
 
       PERF_UTIME_TRACKER_TIME (thread_p, &time_tracker_alloc_search_and_wait, pstat_cond_wait);
 
@@ -8355,7 +8304,6 @@ pgbuf_claim_bcb_for_fix (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_
   PAGE_PTR pgptr = NULL;
   TDE_ALGORITHM tde_algo = TDE_ALGORITHM_NONE;
   bool success;
-  PGBUF_STATUS *show_status = &pgbuf_Pool.show_status[thread_get_entry_index (thread_p)];
   PGBUF_ATOMIC_LATCH_IMPL impl;
 
 #if defined (ENABLE_SYSTEMTAP)
@@ -8442,7 +8390,6 @@ pgbuf_claim_bcb_for_fix (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_
     {
       /* Record number of reads in statistics */
       perfmon_inc_stat (thread_p, PSTAT_PB_NUM_IOREADS);
-      show_status->num_pages_read++;
 
 #if defined(ENABLE_SYSTEMTAP)
       query_id = qmgr_get_current_query_id (thread_p);
@@ -8572,9 +8519,6 @@ pgbuf_claim_bcb_for_fix (THREAD_ENTRY * thread_p, const VPID * vpid, PAGE_FETCH_
 	{
 	  perfmon_inc_stat (thread_p, PSTAT_SORT_NUM_DATA_PAGES);
 	}
-
-      show_status->num_pages_created++;
-      show_status->num_hit++;
     }
 
   return bufptr;
@@ -10687,8 +10631,6 @@ pgbuf_bcb_flush_with_wal (THREAD_ENTRY * thread_p, PGBUF_BCB * bufptr, bool is_p
   FILEIO_WRITE_MODE write_mode;
   bool is_temp = pgbuf_is_temporary_volume (bufptr->vpid.volid);
   TDE_ALGORITHM tde_algo = TDE_ALGORITHM_NONE;
-  PGBUF_STATUS *show_status = &pgbuf_Pool.show_status[thread_get_entry_index (thread_p)];
-
 
   PGBUF_BCB_CHECK_OWN (bufptr);
 
@@ -10825,8 +10767,6 @@ copy_unflushed_lsa:
     }
   else
     {
-      show_status->num_pages_written++;
-
       /* Record number of writes in statistics */
       write_mode = (dwb_is_created () == true ? FILEIO_WRITE_NO_COMPENSATE_WRITE : FILEIO_WRITE_DEFAULT_WRITE);
 
@@ -17362,23 +17302,20 @@ pgbuf_scan_bcb_table ()
  *   arg_values(in):
  *   arg_cnt(in):
  *   ptr(in/out):
+ *
+ * Note: only the page composition snapshot columns report real values. The counter columns are deprecated and always
+ *       report 0; the equivalent statistics are available through cubrid statdump.
  */
 int
 pgbuf_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** arg_values, int arg_cnt, void **ptr)
 {
   SHOWSTMT_ARRAY_CONTEXT *ctx = NULL;
   const int num_cols = 19;
-  time_t cur_time;
-  int idx, i;
+  int idx;
   int error = NO_ERROR;
   DB_VALUE *vals = NULL, db_val;
-  unsigned long long delta, hit_delta, request_delta;
-  double time_delta;
-  double hit_rate;
   DB_DATA_STATUS data_status;
-  PGBUF_STATUS status_accumulated = { };
   PGBUF_STATUS_SNAPSHOT *status_snapshot = &pgbuf_Pool.show_status_snapshot;
-  PGBUF_STATUS_OLD *status_old = &pgbuf_Pool.show_status_old;
 
   *ptr = NULL;
 
@@ -17388,21 +17325,11 @@ pgbuf_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** arg_values, int
 
   pgbuf_scan_bcb_table ();
 
-  for (i = 0; i <= (int) thread_num_total_threads (); i++)
-    {
-      status_accumulated.num_hit += pgbuf_Pool.show_status[i].num_hit;
-      status_accumulated.num_page_request += pgbuf_Pool.show_status[i].num_page_request;
-      status_accumulated.num_pages_created += pgbuf_Pool.show_status[i].num_pages_created;
-      status_accumulated.num_pages_written += pgbuf_Pool.show_status[i].num_pages_written;
-      status_accumulated.num_pages_read += pgbuf_Pool.show_status[i].num_pages_read;
-      status_accumulated.num_flusher_waiting_threads += pgbuf_Pool.show_status[i].num_flusher_waiting_threads;
-    }
-
   ctx = showstmt_alloc_array_context (thread_p, 1, num_cols);
   if (ctx == NULL)
     {
       error = er_errid ();
-      return error;
+      goto exit_on_error;
     }
 
   vals = showstmt_alloc_tuple_in_context (thread_p, ctx);
@@ -17412,17 +17339,10 @@ pgbuf_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** arg_values, int
       goto exit_on_error;
     }
 
-  cur_time = time (NULL);
-
-  time_delta = difftime (cur_time, status_old->print_out_time) + 0.0001;	// avoid dividing by 0
-
   idx = 0;
 
-  hit_rate = (status_accumulated.num_hit - status_old->num_hit) /
-    ((status_accumulated.num_page_request - status_old->num_page_request) + 0.0000000000001);
-  hit_rate = hit_rate * 100;
-
-  db_make_double (&db_val, hit_rate);
+  /* Hit_rate: deprecated, always 0. see hit_ratio of cubrid statdump. */
+  db_make_double (&db_val, 0);
   db_value_domain_init (&vals[idx], DB_TYPE_NUMERIC, 13, 10);
   error = numeric_db_value_coerce_to_num (&db_val, &vals[idx], &data_status);
   idx++;
@@ -17431,12 +17351,12 @@ pgbuf_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** arg_values, int
       goto exit_on_error;
     }
 
-  delta = status_accumulated.num_hit - status_old->num_hit;
-  db_make_bigint (&vals[idx], delta);
+  /* Num_hit: deprecated, always 0. */
+  db_make_bigint (&vals[idx], 0);
   idx++;
 
-  delta = status_accumulated.num_page_request - status_old->num_page_request;
-  db_make_bigint (&vals[idx], delta);
+  /* Num_page_request: deprecated, always 0. see Num_data_page_fix of cubrid statdump. */
+  db_make_bigint (&vals[idx], 0);
   idx++;
 
   db_make_int (&vals[idx], pgbuf_Pool.num_buffers);
@@ -17469,15 +17389,16 @@ pgbuf_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** arg_values, int
   db_make_int (&vals[idx], status_snapshot->num_temp_pages);
   idx++;
 
-  delta = status_accumulated.num_pages_created - status_old->num_pages_created;
-  db_make_bigint (&vals[idx], delta);
+  /* Num_pages_created: deprecated, always 0. */
+  db_make_bigint (&vals[idx], 0);
   idx++;
 
-  delta = status_accumulated.num_pages_written - status_old->num_pages_written;
-  db_make_bigint (&vals[idx], delta);
+  /* Num_pages_written: deprecated, always 0. see Num_data_page_iowrites of cubrid statdump. */
+  db_make_bigint (&vals[idx], 0);
   idx++;
 
-  db_make_double (&db_val, delta / time_delta);
+  /* Pages_written_rate: deprecated, always 0. */
+  db_make_double (&db_val, 0);
   db_value_domain_init (&vals[idx], DB_TYPE_NUMERIC, 20, 10);
   error = numeric_db_value_coerce_to_num (&db_val, &vals[idx], &data_status);
   idx++;
@@ -17486,11 +17407,12 @@ pgbuf_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** arg_values, int
       goto exit_on_error;
     }
 
-  delta = status_accumulated.num_pages_read - status_old->num_pages_read;
-  db_make_bigint (&vals[idx], delta);
+  /* Num_pages_read: deprecated, always 0. see Num_data_page_ioreads of cubrid statdump. */
+  db_make_bigint (&vals[idx], 0);
   idx++;
 
-  db_make_double (&db_val, delta / time_delta);
+  /* Pages_read_rate: deprecated, always 0. */
+  db_make_double (&db_val, 0);
   db_value_domain_init (&vals[idx], DB_TYPE_NUMERIC, 20, 10);
   error = numeric_db_value_coerce_to_num (&db_val, &vals[idx], &data_status);
   idx++;
@@ -17499,18 +17421,11 @@ pgbuf_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** arg_values, int
       goto exit_on_error;
     }
 
-  db_make_int (&vals[idx], status_accumulated.num_flusher_waiting_threads);
+  /* Num_flusher_waiting_threads: deprecated, always 0. */
+  db_make_int (&vals[idx], 0);
   idx++;
 
   assert (idx == num_cols);
-
-  /* set now data to old data */
-  status_old->num_hit = status_accumulated.num_hit;
-  status_old->num_page_request = status_accumulated.num_page_request;
-  status_old->num_pages_created = status_accumulated.num_pages_created;
-  status_old->num_pages_written = status_accumulated.num_pages_written;
-  status_old->num_pages_read = status_accumulated.num_pages_read;
-  status_old->print_out_time = cur_time;
 
   *ptr = ctx;
 

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -394,7 +394,8 @@ typedef struct pgbuf_status_snapshot PGBUF_STATUS_SNAPSHOT;
  * num_page_request, num_pages_created, num_pages_written, num_pages_read, num_flusher_waiting_threads) have been
  * removed. They were incremented on every page fix, which made the page fix hot path pay for a cache line write that
  * multiple workers of the same query contend on, and the very same numbers are already provided by
- * cubrid statdump (Num_data_page_fix / Num_data_page_ioreads / Num_data_page_iowrites / hit_ratio).
+ * cubrid statdump (Num_data_page_fetches / Num_data_page_ioreads / Num_data_page_iowrites /
+ * Data_page_buffer_hit_ratio).
  * The corresponding SHOW columns are deprecated and always report 0. */
 
 struct pgbuf_status_snapshot
@@ -17341,7 +17342,7 @@ pgbuf_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** arg_values, int
 
   idx = 0;
 
-  /* Hit_rate: deprecated, always 0. see hit_ratio of cubrid statdump. */
+  /* Hit_rate: deprecated, always 0. see Data_page_buffer_hit_ratio of cubrid statdump. */
   db_make_double (&db_val, 0);
   db_value_domain_init (&vals[idx], DB_TYPE_NUMERIC, 13, 10);
   error = numeric_db_value_coerce_to_num (&db_val, &vals[idx], &data_status);
@@ -17355,7 +17356,7 @@ pgbuf_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** arg_values, int
   db_make_bigint (&vals[idx], 0);
   idx++;
 
-  /* Num_page_request: deprecated, always 0. see Num_data_page_fix of cubrid statdump. */
+  /* Num_page_request: deprecated, always 0. see Num_data_page_fetches of cubrid statdump. */
   db_make_bigint (&vals[idx], 0);
   idx++;
 

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -390,14 +390,6 @@ typedef struct pgbuf_holder_info PGBUF_HOLDER_INFO;
 
 typedef struct pgbuf_status_snapshot PGBUF_STATUS_SNAPSHOT;
 
-/* note: the per-fix counters that used to back the SHOW PAGE BUFFER STATUS counter columns (num_hit,
- * num_page_request, num_pages_created, num_pages_written, num_pages_read, num_flusher_waiting_threads) have been
- * removed. They were incremented on every page fix, which made the page fix hot path pay for a cache line write that
- * multiple workers of the same query contend on, and the very same numbers are already provided by
- * cubrid statdump (Num_data_page_fetches / Num_data_page_ioreads / Num_data_page_iowrites /
- * Data_page_buffer_hit_ratio).
- * The corresponding SHOW columns are deprecated and always report 0. */
-
 struct pgbuf_status_snapshot
 {
   unsigned int free_pages;
@@ -17303,9 +17295,6 @@ pgbuf_scan_bcb_table ()
  *   arg_values(in):
  *   arg_cnt(in):
  *   ptr(in/out):
- *
- * Note: only the page composition snapshot columns report real values. The counter columns are deprecated and always
- *       report 0; the equivalent statistics are available through cubrid statdump.
  */
 int
 pgbuf_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** arg_values, int arg_cnt, void **ptr)

--- a/src/storage/page_buffer.c
+++ b/src/storage/page_buffer.c
@@ -17303,8 +17303,7 @@ pgbuf_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** arg_values, int
   const int num_cols = 19;
   int idx;
   int error = NO_ERROR;
-  DB_VALUE *vals = NULL, db_val;
-  DB_DATA_STATUS data_status;
+  DB_VALUE *vals = NULL;
   PGBUF_STATUS_SNAPSHOT *status_snapshot = &pgbuf_Pool.show_status_snapshot;
 
   *ptr = NULL;
@@ -17331,22 +17330,16 @@ pgbuf_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** arg_values, int
 
   idx = 0;
 
-  /* Hit_rate: deprecated, always 0. see Data_page_buffer_hit_ratio of cubrid statdump. */
-  db_make_double (&db_val, 0);
-  db_value_domain_init (&vals[idx], DB_TYPE_NUMERIC, 13, 10);
-  error = numeric_db_value_coerce_to_num (&db_val, &vals[idx], &data_status);
-  idx++;
-  if (error != NO_ERROR)
-    {
-      goto exit_on_error;
-    }
-
-  /* Num_hit: deprecated, always 0. */
-  db_make_bigint (&vals[idx], 0);
+  /* Hit_rate: deprecated, always NULL. see Data_page_buffer_hit_ratio of cubrid statdump. */
+  db_make_null (&vals[idx]);
   idx++;
 
-  /* Num_page_request: deprecated, always 0. see Num_data_page_fetches of cubrid statdump. */
-  db_make_bigint (&vals[idx], 0);
+  /* Num_hit: deprecated, always NULL. */
+  db_make_null (&vals[idx]);
+  idx++;
+
+  /* Num_page_request: deprecated, always NULL. see Num_data_page_fetches of cubrid statdump. */
+  db_make_null (&vals[idx]);
   idx++;
 
   db_make_int (&vals[idx], pgbuf_Pool.num_buffers);
@@ -17379,40 +17372,28 @@ pgbuf_start_scan (THREAD_ENTRY * thread_p, int type, DB_VALUE ** arg_values, int
   db_make_int (&vals[idx], status_snapshot->num_temp_pages);
   idx++;
 
-  /* Num_pages_created: deprecated, always 0. */
-  db_make_bigint (&vals[idx], 0);
+  /* Num_pages_created: deprecated, always NULL. */
+  db_make_null (&vals[idx]);
   idx++;
 
-  /* Num_pages_written: deprecated, always 0. see Num_data_page_iowrites of cubrid statdump. */
-  db_make_bigint (&vals[idx], 0);
+  /* Num_pages_written: deprecated, always NULL. see Num_data_page_iowrites of cubrid statdump. */
+  db_make_null (&vals[idx]);
   idx++;
 
-  /* Pages_written_rate: deprecated, always 0. */
-  db_make_double (&db_val, 0);
-  db_value_domain_init (&vals[idx], DB_TYPE_NUMERIC, 20, 10);
-  error = numeric_db_value_coerce_to_num (&db_val, &vals[idx], &data_status);
-  idx++;
-  if (error != NO_ERROR)
-    {
-      goto exit_on_error;
-    }
-
-  /* Num_pages_read: deprecated, always 0. see Num_data_page_ioreads of cubrid statdump. */
-  db_make_bigint (&vals[idx], 0);
+  /* Pages_written_rate: deprecated, always NULL. */
+  db_make_null (&vals[idx]);
   idx++;
 
-  /* Pages_read_rate: deprecated, always 0. */
-  db_make_double (&db_val, 0);
-  db_value_domain_init (&vals[idx], DB_TYPE_NUMERIC, 20, 10);
-  error = numeric_db_value_coerce_to_num (&db_val, &vals[idx], &data_status);
+  /* Num_pages_read: deprecated, always NULL. see Num_data_page_ioreads of cubrid statdump. */
+  db_make_null (&vals[idx]);
   idx++;
-  if (error != NO_ERROR)
-    {
-      goto exit_on_error;
-    }
 
-  /* Num_flusher_waiting_threads: deprecated, always 0. */
-  db_make_int (&vals[idx], 0);
+  /* Pages_read_rate: deprecated, always NULL. */
+  db_make_null (&vals[idx]);
+  idx++;
+
+  /* Num_flusher_waiting_threads: deprecated, always NULL. */
+  db_make_null (&vals[idx]);
   idx++;
 
   assert (idx == num_cols);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26898>

### Purpose

`SHOW PAGE BUFFER STATUS`의 카운터 계열 컬럼을 뒷받침하던 per-fix 카운터가 페이지 fix 핫패스의 병목이라 이를 제거하고, 해당 컬럼들을 deprecated 처리합니다.

`pgbuf_fix_release()` 등은 매 fix마다 `show_status[]` 항목의 `num_hit` / `num_page_request` 등을 증가시킵니다. 같은 질의의 병렬 워커들이 동시에 write하므로 캐시라인 경합이 발생하고, fix 1회마다 `thread_get_entry_index()` 조회 + 포인터 계산 비용도 함께 냅니다. 그런데 이 수치들은 `cubrid statdump`가 제공하는 `Num_data_page_fetches` / `Num_data_page_ioreads` / `Num_data_page_iowrites` / `Data_page_buffer_hit_ratio`와 사실상 중복입니다.

선행 PR #7267(per-thread 샤딩)과 #7340(캐시라인 정렬)은 스펙을 유지한 채 경합을 줄이는 우회 개선이었고, 이번에는 **기술본부/PM팀 회의 결과 해당 컬럼을 deprecate하기로 결정**되어(JIRA 2026-07-27 코멘트, RND-2796) 카운터 자체를 제거합니다.

### Implementation

컬럼 목록과 타입, 컬럼 순서는 그대로 두어 **결과셋 레이아웃은 변경되지 않습니다.** deprecated 컬럼은 항상 NULL을 반환합니다. 0이 아니라 NULL로 두어 "더 이상 수집하지 않는 값"과 "실제로 0인 카운터"가 구분되도록 했습니다.

| 구분 | 컬럼 |
|---|---|
| deprecated (항상 NULL) | Hit_rate, Num_hit, Num_page_request, Num_pages_created, Num_pages_written, Pages_written_rate, Num_pages_read, Pages_read_rate, Num_flusher_waiting_threads |
| 유지 (버퍼풀 페이지 구성 스냅샷) | Pool_size, Page_size, Free_pages, Victim_candidate_pages, Clean_pages, Dirty_pages, Num_index_pages, Num_data_pages, Num_system_pages, Num_temp_pages |

`src/storage/page_buffer.c`

1. `PGBUF_STATUS` 배열(`pgbuf_Pool.show_status`)과 `PGBUF_STATUS_OLD`(`show_status_old`) 구조체 및 그 alloc/free를 제거했습니다.
2. 핫패스 4개 함수 — `pgbuf_fix_release()`, `pgbuf_allocate_bcb()`, `pgbuf_claim_bcb_for_fix()`, `pgbuf_bcb_flush_with_wal()` — 에서 카운터 증감 코드와, 그 때문에 매 호출마다 필요했던 `thread_get_entry_index()` 기반 지역변수 계산을 제거했습니다.
3. `pgbuf_start_scan()`의 per-thread 합산 루프와 직전값(delta 계산용) 갱신 로직을 제거하고, 카운터 컬럼은 `db_make_null()`로 NULL을 출력합니다(rate 3개 컬럼에 있던 `numeric_db_value_coerce_to_num()` 변환도 함께 제거). 페이지 구성 스냅샷은 기존대로 `pgbuf_scan_bcb_table()`이 BCB를 순회해 산출하므로 값이 그대로 유지됩니다.
4. `show_status_mutex`는 동시 `SHOW` 실행 간 스냅샷 직렬화를 위해 그대로 둡니다.

`src/parser/show_meta.c`

5. 컬럼 메타데이터는 그대로 두고 deprecated 표기 주석만 추가했습니다.

### Remarks

- **성능** (JIRA 측정 기준: TPC-H Q12 SF10, 병렬 힙 스캔 worker 4, data_buffer 24G, `enable_heap_fixed_scan=false`): `pgbuf_fix_release` self-time(perf, non-children) 21.75% → 약 14%. 제거된 카운터 경합은 전체 CPU의 약 7%에 해당하던 핫스팟이었습니다. 벽시계는 동일 환경에서 약 33s → 약 25s로 관측되나 머신 부하 민감도가 커서 공식 근거는 perf self-time으로 둡니다.
- **매뉴얼 반영**: [CUBRIDMAN-348](http://jira.cubrid.org/browse/CUBRIDMAN-348) / CUBRID/cubrid-manual#763 에서 ko/en 매뉴얼에 deprecated 표기(항상 NULL)와 statdump 대체 항목 매핑, 예제 출력 갱신을 반영했습니다.
- **테스트케이스**: `cbrd_22803` 쉘 TC가 카운터 컬럼을 `[0-9]+`로 마스킹하고 있어 NULL과 맞지 않으므로, deprecated 컬럼은 마스킹에서 제외하고 `NULL`을 그대로 비교하도록 `tc/pr-7592`에 반영했습니다(변동성이 있는 페이지 구성 컬럼만 마스킹 유지).
- **statdump 영향 없음**: `PSTAT_PB_NUM_IOREADS` / `PSTAT_PB_NUM_IOWRITES` 등 perfmon 통계 경로는 손대지 않았습니다.
- **부수 수정**: `pgbuf_start_scan()`에서 `showstmt_alloc_array_context()` 실패 시 `show_status_mutex`를 잡은 채로 `return`하던 기존 결함을 `goto exit_on_error`로 정정했습니다.
- **빌드 검증**: debug / release 양쪽에서 SERVER_MODE, SA_MODE, CS_MODE 모두 컴파일 확인(release는 `-Werror`). `indent -l120 -lc120` 재적용 시 diff 없음.

