### PR TITLE
[CBRD-27112] [Regression] Core dumped in logtb_clear_tdes

### DIFF
--- a/src/transaction/log_manager.c
+++ b/src/transaction/log_manager.c
@@ -1810,6 +1810,15 @@ log_final (THREAD_ENTRY * thread_p)
 	       * affects this process' in-memory bookkeeping, the same as what a crash would do. */
 	      LOG_SET_CURRENT_TRAN_INDEX (thread_p, i);
 	      lock_unlock_all (thread_p);
+
+	      /* tdes->mvccinfo.id is deliberately preserved (see logtb_release_tran_index()) so a
+	       * coordinator daemon can still complete this transaction while the server is up. Once
+	       * we get here the server is going down regardless, so clear it the same way the locks
+	       * above are released: this only clears in-memory bookkeeping in this dying process and
+	       * has no effect on disk state. Without it, logtb_clear_tdes() would assert on a
+	       * still-valid mvccinfo.id below.
+	       */
+	      tdes->mvccinfo.reset ();
 	      anyloose_ends = true;
 	    }
 	}


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27112>

### Purpose

 Regression 테스트 중 logtb_clear_tdes 에서 발생한 assert core dump를 해결

### Implementation

log_final에서 2PC 글로벌 트랜잭션 중 정리되지 못한 mvcc를 리셋.

### Remarks

N/A
