### PR TITLE
[CUBRIDQA-1493] CI: require write access to trigger a pipeline by comment

### DIFF
--- a/.github/workflows/comment_trigger.yml
+++ b/.github/workflows/comment_trigger.yml
@@ -7,7 +7,14 @@ on:
 jobs:
   run_test:
     name: Run test on CircleCI
-    if: ${{ github.event.issue.pull_request != null && startsWith(github.event.comment.body, '/run') }}
+    # A comment can take all 50 self-hosted slots, so the commenter needs write
+    # access. Read from the payload rather than the permission API, which would
+    # refuse everyone if it failed. CONTRIBUTOR is refused, so an outside
+    # contributor's own PR needs a maintainer to ask for the run.
+    if: >-
+      ${{ github.event.issue.pull_request != null
+      && startsWith(github.event.comment.body, '/run')
+      && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) }}
     runs-on: ubuntu-24.04
     steps:
       - name: Validate Command
@@ -15,6 +22,8 @@ jobs:
         run: |
           COMMENT="${{ github.event.comment.body }}"
           echo "[debug] Comment: $COMMENT"
+          # Echoed so the value the job condition gated on is visible in the log.
+          echo "[debug] Author association: ${{ github.event.comment.author_association }}"
 
           # Allowed commands: /run all, /run shell, /run sql, /run medium
           # Or any combination of them (up to 4)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1493

### Purpose

PR 코멘트로 CI를 돌릴 수 있는 사람이 제한돼 있지 않다. cubrid는 공개 저장소이므로 **PR에 코멘트할 수 있는 누구나** `/run shell` 한 줄로 self-hosted 자리 50개를 30분간 점유하는 파이프라인을 띄울 수 있다. 실측 기준 shell full run 1건은 자리 50개를 중앙값 31분간 쓰고, 그동안 뒤에 줄 선 다른 파이프라인의 작은 job까지 함께 멈춘다.

### Implementation

- **코멘트 작성자가 저장소 write 권한자일 때만 트리거된다.** 이벤트 payload의 `author_association`이 `OWNER`·`MEMBER`·`COLLABORATOR`인 경우로 제한했다.
- **기존 사용자는 영향받지 않는다.** 최근 PR 40건에서 `/run`을 사용한 13명 전원이 `MEMBER`로 기록돼 있다(`HyunukLee`, `tw-kang`, `hyunikn`, `childyouth`, `vimkim`, `soheejung-cs`, `hyahong`, `Srltas`, `Hamkua`, `mhoh3963`, `shparkcubrid`, `hgryoo`, `beyondykk9`).
- **거부되는 쪽**: `CONTRIBUTOR`와 `NONE`. 즉 외부 기여자가 자기 PR에 `/run`을 달아도 실행되지 않으며, 그 경우 write 권한자가 대신 요청해야 한다. **동작 변화이므로 팀에 공지가 필요하다.**
- collaborator permission API를 쓰지 않고 payload 값을 읽는다 — API 호출이 실패하면 모두를 거부하게 되고, 이 트리거는 그런 실패 방식을 감당할 값어치가 없다.
- `Validate Command` 스텝이 `author_association`을 로그에 남긴다. 조건이 판정한 값을 첫 실제 실행 로그에서 눈으로 확인하기 위한 것이다(아래 검증 항목 참조).

거부 사유를 알리는 봇 코멘트는 이 PR 범위가 아니다. 코멘트 형식은 `/rerun`의 요구(실패 건수, 기준 잡 번호, SHA, 거부 사유 3종)를 함께 봐야 한 번에 정할 수 있어 CUBRIDQA-1494가 맡는다. 이 PR은 "실행되지 않는다"까지만 보장한다.

### Remarks

**검증에 구조적 제약이 있다.** `issue_comment` 워크플로는 PR 브랜치가 아니라 **기본 브랜치(develop)의 파일로 실행된다.** 따라서 이 PR에서는 새 조건이 한 번도 실행되지 않는다 — 머지 후에만 효력이 생긴다.

이 PR에서 한 검증(정적):

- `actionlint` 1.7.12 — 지적 건수가 변경 전후 **동일하게 2건**이다(둘 다 기존 `comment.body` 관련이며 이 PR과 무관). 새 표현식에 대한 지적은 없다.
- YAML 파싱 후 `if:` 표현식이 한 줄로 접히는지 확인(`>-` 폴딩이 들여쓰기 때문에 깨지지 않는지).
- `author_association` 값이 대문자 `MEMBER` 형태임을 실 데이터로 확인(위 13명).

**머지 후 확인 방법 (파이프라인 소모 0):** PR에 `/run` 또는 `/run bogus`처럼 **suite 없는 명령**을 단다.

1. job이 실행되면 → 권한 조건 통과가 확인된다.
2. 로그의 `[debug] Author association: MEMBER` → 조건이 읽은 값이 확인된다.
3. `Validate Command`가 형식 불일치로 거부 → **CircleCI 파이프라인은 뜨지 않는다.**

권한 없는 계정으로의 거부는 실행해보지 못했다(테스트용 외부 계정이 없다). GitHub이 문서화한 `author_association` 값 목록에 근거한 판단이며, 조건이 틀리는 방향은 **닫히는 쪽**이다 — 값이 비거나 예상과 다르면 권한자도 거부되어 즉시 드러난다.

**같이 발견했지만 고치지 않은 것**: `actionlint`가 지적하는 기존 2건은 `COMMENT="${{ github.event.comment.body }}"`로 코멘트 본문을 bash에 직접 보간하는 script injection 위험이다. 이 PR로 write 권한자만 그 스텝에 도달하게 되어 심각도는 크게 낮아지지만 없어지지는 않는다. 해당 파싱 부분을 재작업하는 CUBRIDQA-1494에서 함께 고치는 것이 자연스럽다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UcXpSqurNoQmhQDrNFv5Xr
