### PR TITLE
[CBRD-27004] Add -fPIE to coverage and profile build flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -358,9 +358,9 @@ add_custom_target(gen_loader_lexer DEPENDS ${FLEX_loader_lexer_OUTPUTS})
 
 # Build types
 if(CMAKE_BUILD_TYPE MATCHES "Coverage")
-  set(CMAKE_CXX_FLAGS_COVERAGE "-g -O0 --coverage -fprofile-arcs -ftest-coverage -std=c++17 -D_GCOV"
+  set(CMAKE_CXX_FLAGS_COVERAGE "-g -O0 --coverage -fprofile-arcs -ftest-coverage -std=c++17 -D_GCOV -fPIE"
     CACHE STRING "Flags used by the c++ compiler during coverage build." FORCE)
-  set(CMAKE_C_FLAGS_COVERAGE "-g -O0 --coverage -fprofile-arcs -ftest-coverage -D_GCOV"
+  set(CMAKE_C_FLAGS_COVERAGE "-g -O0 --coverage -fprofile-arcs -ftest-coverage -D_GCOV -fPIE"
     CACHE STRING "Flags used by the c compiler during coverage build." FORCE)
   set(CMAKE_EXE_LINKER_FLAGS_COVERAGE "-static-libstdc++"
     CACHE STRING "Flags used for linking binaries during coverage build." FORCE)
@@ -375,9 +375,9 @@ if(CMAKE_BUILD_TYPE MATCHES "Coverage")
 endif(CMAKE_BUILD_TYPE MATCHES "Coverage")
 
 if(CMAKE_BUILD_TYPE MATCHES "Profile")
-  set(CMAKE_CXX_FLAGS_PROFILE "-g -pg -std=c++17"
+  set(CMAKE_CXX_FLAGS_PROFILE "-g -pg -std=c++17 -fPIE"
     CACHE STRING "Flags used by the c++ compiler during profile build." FORCE)
-  set(CMAKE_C_FLAGS_PROFILE "-g -pg"
+  set(CMAKE_C_FLAGS_PROFILE "-g -pg -fPIE"
     CACHE STRING "Flags used by the c compiler during profile build." FORCE)
 
   mark_as_advanced(CMAKE_CXX_FLAGS_PROFILE CMAKE_C_FLAGS_PROFILE)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27004

### Purpose
- Coverage/Profile build type에서 실행파일 링크가 `relocation R_X86_64_32 against '.rodata' can not be used when making a PIE object`로 실패하는 문제를 해결한다. `-fPIE`와 `-pie` 도입 시 이 두 build type이 누락되었다.

### Implementation
- Coverage/Profile의 C/CXX compile flag에 `-fPIE` 추가.
