### PR TITLE
[CUBRIDQA-1494] CI: /rerun repeats only the cases that failed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,10 +250,13 @@ commands:
                 ;;
             esac
 
-            # The tests API reports each case in the form these globs produce.
-            RERUN_CASES="<< pipeline.parameters.rerun_cases >>"
-            if [ -n "$RERUN_CASES" ]; then
+            # The tests API reports each case in the form these globs produce. Read from
+            # the environment, not substituted into this script: the parameter must not
+            # become shell source. set -f so the paths cannot glob either.
+            if [ -n "${RERUN_CASES:-}" ]; then
+              set -f
               printf '%s\n' $RERUN_CASES | sort -u > /tmp/rerun.list
+              set +f
 
               # Paths come from testcase filenames a pull request can choose, and land
               # here as text: no metacharacters, no `..`, no other suite.
@@ -463,15 +466,25 @@ jobs:
   build:
     executor: cubrid-build
     steps:
-      - build-cubrid:
-          ccache-prefix: ccache-global-v2
-      # Only develop preserves release; a PR would upload an artifact nobody reads.
-      - when:
-          condition:
-            equal: [ develop, << pipeline.git.branch >> ]
+      - unless:
+          condition: << pipeline.parameters.rerun_build_job >>
           steps:
-            - package-build:
-                mode: release
+            - build-cubrid:
+                ccache-prefix: ccache-global-v2
+            # Only develop preserves release; a PR would upload an artifact nobody reads.
+            - when:
+                condition:
+                  equal: [ develop, << pipeline.git.branch >> ]
+                steps:
+                  - package-build:
+                      mode: release
+      # Nothing to build on a /rerun, but a job must have at least one step.
+      - when:
+          condition: << pipeline.parameters.rerun_build_job >>
+          steps:
+            - run:
+                name: Skip the release build (/rerun)
+                command: echo "The commit is already built and no test job reads the release tree."
 
   build_debug:
     executor: cubrid-build
@@ -510,6 +523,7 @@ jobs:
     parallelism: << parameters.parallelism >>
     environment:
       TEST_SUITE: << parameters.suite >>
+      RERUN_CASES: << pipeline.parameters.rerun_cases >>
     steps:
       - resolve-testcases
       - restore_cache:
@@ -535,6 +549,7 @@ jobs:
     environment:
       BASELINE: << pipeline.parameters.baseline >>
       TEST_SUITE: "shell"
+      RERUN_CASES: << pipeline.parameters.rerun_cases >>
     steps:
       # Resolved once in download-build so 50 pods do not each hit the repo.
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,5 @@
 version: 2.1
 
-# Trigger-provided values (GitHub Actions comment trigger) + pipeline-wide knobs.
 parameters:
   baseline:
     type: string
@@ -17,14 +16,19 @@ parameters:
   run_all_test:
     type: boolean
     default: false
-  # Single knob for the shell fan-out width. CUBRIDQA-1471 (40/10 pool
-  # partition) changes this to 40 — keep every reference on this parameter.
   shell_parallelism:
     type: integer
     default: 50
+  # /rerun reuses the same test jobs: a commit status is named after the job, so only
+  # a job of that name can turn the red one green.
+  rerun_cases:            # space-separated; empty means a normal run
+    type: string
+    default: ""
+  rerun_build_job:
+    type: integer
+    default: 0
 
 executors:
-  # Build machine: ccache environment baked in so both build jobs share it
   cubrid-build:
     docker:
       - image: cubridci/cubridci:develop
@@ -50,9 +54,6 @@ executors:
     resource_class: cubrid/ramdisk
     working_directory: /home
     environment:
-      # GlusterFS build layout contract, defined once for both sides:
-      # download-build publishes <root>/<sha>/<mode>/CUBRID + sentinel,
-      # test_shell waits on the sentinel and mounts that tree.
       BUILD_CACHE_ROOT: /home/build-cache/builds
       BUILD_SENTINEL: .complete
 
@@ -69,8 +70,7 @@ commands:
   collect-build-logs:
     description: "Collect build logs and store them"
     steps:
-      # when: always — a failed build is exactly when build.log is worth having;
-      # without it this step is skipped and the upload below finds nothing.
+      # when: always - a failed build is exactly when build.log is worth having.
       - run:
           name: Store build logs and commits
           when: always
@@ -108,8 +108,7 @@ commands:
             ccache -z
             scl enable devtoolset-8 -- /entrypoint.sh build << parameters.build-args >>
             ccache -s
-      # ccache save: write only on develop-branch builds -> a single shared warm cache
-      # (other branches/PRs are restore-only; avoids 5G-per-PR bloat and non-develop pollution)
+      # develop only: one shared warm cache, no 5G per PR.
       - when:
           condition:
             equal: [ develop, << pipeline.git.branch >> ]
@@ -124,8 +123,6 @@ commands:
     description: "Upload the built tree as an artifact and hand its job number to consumers"
     parameters:
       mode:
-        # One vocabulary end to end: this is the workspace file suffix
-        # (BUILD_NUM_<mode>) and the builds/<SHA>/<mode> path segment.
         type: enum
         enum: [ release, debug ]
     steps:
@@ -146,14 +143,24 @@ commands:
           root: workspace
           paths: [ BUILD_NUM_<< parameters.mode >> ]
 
+  reuse-build:
+    description: "Point consumers at an earlier job's build instead of compiling again (/rerun)"
+    steps:
+      # Writes what package-build would, so its consumers need no rerun branch.
+      - run:
+          name: "Reuse the build of job #<< pipeline.parameters.rerun_build_job >>"   # quoted: bare '#' starts a comment
+          command: |
+            mkdir -p workspace
+            echo "<< pipeline.parameters.rerun_build_job >>" > workspace/BUILD_NUM_debug
+      - persist_to_workspace:
+          root: workspace
+          paths: [ BUILD_NUM_debug ]
+
   resolve-testcases:
     description: "Resolve testcases branch/SHA for a TC repo; export BRANCH_TESTCASES and materialize cache-key inputs"
     parameters:
       tc-repo:
-        # Resolve against the repo the suite actually checks out: public
-        # cubrid-testcases for sql/medium, private cubrid-testcases-private-ex
-        # for shell. Their tc/pr-<N> branches are created independently and
-        # often diverge, so each suite must resolve against its own repo.
+        # Each suite resolves against the repo it checks out; the tc/pr-<N> branches diverge.
         type: string
         default: cubrid-testcases
     steps:
@@ -162,9 +169,6 @@ commands:
           command: |
             TC_REPO="https://x-access-token:${GHI_TOKEN}@github.com/CUBRID/<< parameters.tc-repo >>.git"
 
-            # ls-remote the testcases repo with retries. A transient network error
-            # (e.g. "Empty reply from server") must not fail the job: on persistent
-            # failure we return empty and fall back to develop.
             resolve_sha() {
               local i out
               for i in 1 2 3 4 5; do
@@ -193,11 +197,9 @@ commands:
             echo "TC_BRANCH: $TC_BRANCH"
             echo "TC_SHA: $TC_SHA"
 
-            # checkout reads BRANCH_TESTCASES to select the testcases branch
             echo "export BRANCH_TESTCASES=$TC_BRANCH" >> "$BASH_ENV"
 
-            # Cache keys cannot read shell vars, so materialize the runtime values
-            # to files and reference them via {{ checksum }} in restore_cache/save_cache.
+            # Cache keys cannot read shell vars, hence these files for {{ checksum }}.
             echo "${TC_BRANCH//\//-}" > /tmp/tc_cache_branch
             echo "$TC_SHA" > /tmp/tc_cache_sha
             echo "develop" > /tmp/tc_cache_develop
@@ -205,8 +207,7 @@ commands:
   run-tests:
     description: "Run test scripts (CUBRID must be at /home/CUBRID)"
     steps:
-      # The test steps set `shell: /bin/bash` (i.e. no -e/-o pipefail): the prune
-      # pipelines exit non-zero when there is nothing left to prune.
+      # `shell: /bin/bash` drops -e/pipefail, which the prune pipelines need.
       - run:
           name: Check out testcases and testtools
           shell: /bin/bash
@@ -220,14 +221,15 @@ commands:
           name: Split tests for this node
           shell: /bin/bash
           command: |
-            # Only the glob+split pipeline and the prune differ per suite.
             case "$TEST_SUITE" in
               shell)
                 base_dir="cubrid-testcases-private-ex"
                 rm -rf "$base_dir/shell/_25_unstable"
-                split_pipe() {
-                  circleci tests glob "$base_dir/$TEST_SUITE/_*/**/*.sh" | grep -P '/([^/]+)/cases/\1\.sh$' \
-                    | circleci tests run --command="tee tc.list" --verbose --split-by=timings --timings-type=file
+                candidates() {
+                  circleci tests glob "$base_dir/$TEST_SUITE/_*/**/*.sh" | grep -P '/([^/]+)/cases/\1\.sh$'
+                }
+                split_into_tc_list() {
+                  circleci tests run --command="tee tc.list" --verbose --split-by=timings --timings-type=file
                 }
                 prune() {
                   xargs -n1 dirname < tc.list > tc_dirs.list
@@ -236,9 +238,11 @@ commands:
                 ;;
               *)
                 base_dir="cubrid-testcases"
-                split_pipe() {
-                  circleci tests glob "$base_dir/$TEST_SUITE/_*" \
-                    | circleci tests run --command="xargs -n1 >> tc.list" --verbose --split-by=name
+                candidates() {
+                  circleci tests glob "$base_dir/$TEST_SUITE/_*"
+                }
+                split_into_tc_list() {
+                  circleci tests run --command="xargs -n1 >> tc.list" --verbose --split-by=name
                 }
                 prune() {
                   find "$base_dir" -name "*.sql" -type f | grep -v -F -f tc.list | xargs -r rm -rf
@@ -246,12 +250,34 @@ commands:
                 ;;
             esac
 
-            # A split can fail transiently (e.g. the circleci-tests-plugin-cli
-            # download timing out under 50-way fan-out). Retry, and on persistent
-            # failure fail this node rather than fall through to the empty-list
-            # halt below, which would silently skip this node's share of tests.
+            # The tests API reports each case in the form these globs produce.
+            RERUN_CASES="<< pipeline.parameters.rerun_cases >>"
+            if [ -n "$RERUN_CASES" ]; then
+              printf '%s\n' $RERUN_CASES | sort -u > /tmp/rerun.list
+
+              # Paths come from testcase filenames a pull request can choose, and land
+              # here as text: no metacharacters, no `..`, no other suite.
+              if grep -qvE "^${base_dir}/[A-Za-z0-9._/-]+$" /tmp/rerun.list || grep -q '\.\.' /tmp/rerun.list; then
+                echo "[error] rerun_cases must be plain paths under ${base_dir}/:"
+                grep -vE "^${base_dir}/[A-Za-z0-9._/-]+$" /tmp/rerun.list
+                exit 1
+              fi
+
+              # None left must fail: otherwise every node halts and the rerun reports
+              # success having run nothing.
+              while read -r c; do
+                if [ -f "$c" ]; then echo "$c"; else echo "[warn] gone from this branch: $c" >&2; fi
+              done < /tmp/rerun.list > /tmp/rerun_targets.list
+              if [ ! -s /tmp/rerun_targets.list ]; then
+                echo "[error] none of the requested cases exist here; run the full suite instead"
+                exit 1
+              fi
+              echo "[debug] /rerun: $(wc -l < /tmp/rerun_targets.list) of $(wc -l < /tmp/rerun.list) case(s) present"
+              candidates() { cat /tmp/rerun_targets.list; }
+            fi
+
             n=0
-            until { : > tc.list; split_pipe; }; do
+            until { : > tc.list; candidates | split_into_tc_list; }; do
               n=$((n + 1))
               if [ "$n" -ge 4 ]; then
                 echo "[error] test split failed after $n attempts; failing node to avoid silently skipping tests"
@@ -261,19 +287,14 @@ commands:
               sleep $((n * 10))
             done
 
-            # Split succeeded, so an empty list is a genuine empty assignment
-            # (normal during "rerun failed tests only") -> halt as success. Halting
-            # here, before the build wait, releases the slot right away.
+            # Empty is a real empty assignment (usual on a /rerun) -> success, not failure.
             if [ ! -s tc.list ]; then
               echo "[debug] No tests assigned to this node"
               circleci-agent step halt
               exit 0
             fi
             prune
-            # wc -w, not -l: the shell split writes tc.list as one space-separated
-            # line (tee), sql/medium writes one path per line — word count is the
-            # case count either way, and a wrong "0" here would look like the
-            # silent-skip failure mode we deliberately fail loudly on.
+            # wc -w, not -l: the shell split writes tc.list as one space-separated line.
             echo "[debug] assigned testcases: $(wc -w < tc.list)"
       - run:
           name: Mount debug build from GlusterFS
@@ -283,14 +304,11 @@ commands:
               echo "[debug] non-shell suite runs on the artifact build; nothing to mount"
               exit 0
             fi
-            # Explicit, so the contract does not depend on the step's shell
-            # setting: any failure below (including publish's) aborts the job.
+            # Explicit, so the contract does not rest on the step shell.
             set -eo pipefail
             : "${BUILD_CACHE_ROOT:?}" "${BUILD_SENTINEL:?}"
             BUILD_DIR="${BUILD_CACHE_ROOT}/${CIRCLE_SHA1}/debug"
 
-            # requires(download-build) normally means the sentinel is already
-            # there; the bounded wait covers concurrent workflow reruns.
             n=0
             until [ -f "${BUILD_DIR}/${BUILD_SENTINEL}" ]; do
               n=$((n + 1))
@@ -306,8 +324,7 @@ commands:
               echo "[debug] /home/CUBRID already mounted by postStart (legacy flat layout), reusing"
               exit 0
             fi
-            # upperdir/workdir must sit on the emptyDir volume: the kernel refuses
-            # an overlay whose upper is on the container rootfs.
+            # upperdir/workdir must be on the emptyDir; the kernel refuses overlay-on-rootfs.
             mkdir -p /build-rw/step-upper /build-rw/step-work /home/CUBRID
             mount -t overlay overlay \
               -o "lowerdir=${BUILD_DIR}/CUBRID,upperdir=/build-rw/step-upper,workdir=/build-rw/step-work" /home/CUBRID \
@@ -355,9 +372,7 @@ commands:
             RESPONSE=$(curl -s -H "Circle-Token: ${CIRCLECI_TOKEN}" \
               "https://circleci.com/api/v2/project/gh/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${BUILD_NUM}/artifacts")
 
-            # Extract CUBRID.tar.gz URL. `|| true`: grep exits non-zero when the
-            # artifact is absent, and under the default errexit shell that would
-            # kill the step before the diagnostic below ever prints.
+            # `|| true`: grep exits non-zero when absent, killing the diagnostic below.
             ARTIFACT_URL=$(echo "$RESPONSE" | grep -o '"url": "[^"]*CUBRID.tar.gz[^"]*"' | head -1 | sed 's/"url": "//;s/"$//' || true)
 
             if [ -z "$ARTIFACT_URL" ]; then
@@ -382,14 +397,10 @@ commands:
       - run:
           name: Download build to GlusterFS
           command: |
-            # Explicit, so the contract does not depend on the step's shell
-            # setting: any failure below (including publish's) aborts the job.
+            # Explicit, so the contract does not rest on the step shell.
             set -eo pipefail
             : "${BUILD_CACHE_ROOT:?}" "${BUILD_SENTINEL:?}"
 
-            # One build-number file per packaged mode (package-build persists
-            # BUILD_NUM_RELEASE / BUILD_NUM_DEBUG), so this transports exactly what
-            # the build jobs produced: debug only on PRs, both on develop.
             publish() {
               local mode="$1" build_num="$2"
               local build_dir="${BUILD_CACHE_ROOT}/${CIRCLE_SHA1}/${mode}"
@@ -402,9 +413,7 @@ commands:
                 return 0
               fi
 
-              # Stage, then publish with one atomic rename: consumers never see a
-              # half-extracted tree, and a concurrent duplicate run just loses the
-              # rename and drops its staging dir (no rm of a published tree).
+              # Stage then rename: no consumer sees a half-extracted tree.
               local tmp_dir="${build_dir}.tmp.$$"
               rm -rf "${tmp_dir}"
               mkdir -p "${tmp_dir}"
@@ -412,8 +421,7 @@ commands:
               local response artifact_url
               response=$(curl -s -H "Circle-Token: ${CIRCLECI_TOKEN}" \
                 "https://circleci.com/api/v2/project/gh/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${build_num}/artifacts")
-              # `|| true`: grep exits non-zero when the artifact is absent, and
-              # under errexit that would kill the job before the diagnostic below.
+              # `|| true`: grep exits non-zero when absent, killing the diagnostic below.
               artifact_url=$(echo "$response" | grep -o '"url": "[^"]*CUBRID.tar.gz[^"]*"' | head -1 | sed 's/"url": "//;s/"$//' || true)
               if [ -z "$artifact_url" ]; then
                 echo "ERROR: CUBRID.tar.gz artifact not found in job #${build_num}"
@@ -430,16 +438,13 @@ commands:
               if mv -T "${tmp_dir}" "${build_dir}" 2>/dev/null; then
                 echo "Build published at ${build_dir}"
               else
-                # Lost the publish race to a concurrent duplicate run.
                 echo "Another run published this build first, discarding staging dir"
                 rm -rf "${tmp_dir}"
               fi
               ls -la "${build_dir}/CUBRID"
             }
 
-            # publish is called plainly on purpose: errexit propagates any
-            # failure inside it (an `if !` wrapper would suspend errexit within
-            # the function and could publish a half-extracted tree).
+            # Plain call, not `if !`: that would suspend errexit inside publish.
             published=0
             for num_file in /tmp/workspace/BUILD_NUM_*; do
               [ -f "$num_file" ] || continue
@@ -460,9 +465,7 @@ jobs:
     steps:
       - build-cubrid:
           ccache-prefix: ccache-global-v2
-      # The release build is packaged only on develop, where it is preserved in
-      # GlusterFS for downstream consumers. PR pipelines test the debug build,
-      # so packaging release there would upload an artifact nobody reads.
+      # Only develop preserves release; a PR would upload an artifact nobody reads.
       - when:
           condition:
             equal: [ develop, << pipeline.git.branch >> ]
@@ -473,21 +476,28 @@ jobs:
   build_debug:
     executor: cubrid-build
     steps:
-      - build-cubrid:
-          ccache-prefix: ccache-debug-v2
-          mode: optdebug
-          build-args: "-m optdebug"
-      # Package when a test job will consume it, or on develop for preservation.
-      - when:
-          condition:
-            or:
-              - << pipeline.parameters.run_sql_test >>
-              - << pipeline.parameters.run_medium_test >>
-              - << pipeline.parameters.run_shell_test >>
-              - equal: [ develop, << pipeline.git.branch >> ]
+      # Still runs on a /rerun so its dependents keep their names.
+      - unless:
+          condition: << pipeline.parameters.rerun_build_job >>
           steps:
-            - package-build:
-                mode: debug
+            - build-cubrid:
+                ccache-prefix: ccache-debug-v2
+                mode: optdebug
+                build-args: "-m optdebug"
+            - when:
+                condition:
+                  or:
+                    - << pipeline.parameters.run_sql_test >>
+                    - << pipeline.parameters.run_medium_test >>
+                    - << pipeline.parameters.run_shell_test >>
+                    - equal: [ develop, << pipeline.git.branch >> ]
+                steps:
+                  - package-build:
+                      mode: debug
+      - when:
+          condition: << pipeline.parameters.rerun_build_job >>
+          steps:
+            - reuse-build
 
   artifact-test:
     executor: cubrid-default
@@ -526,8 +536,7 @@ jobs:
       BASELINE: << pipeline.parameters.baseline >>
       TEST_SUITE: "shell"
     steps:
-      # Testcases branch is resolved once in download-build and shared via the
-      # workspace, so the 50 shell pods never hit cubrid-testcases themselves.
+      # Resolved once in download-build so 50 pods do not each hit the repo.
       - attach_workspace:
           at: /tmp/tcws
       - run:
@@ -541,22 +550,15 @@ jobs:
     executor: cubrid-test-shell
     parameters:
       for-shell-tests:
-        # The develop path transports and stops: resolving the testcases branch
-        # there would run a private-repo ls-remote nobody reads, and its failure
-        # would redden the develop commit even though the transport succeeded.
+        # False on develop: an ls-remote nobody reads, whose failure would redden
+        # a commit whose transport succeeded.
         type: boolean
         default: true
     steps:
-      # Note: a pipeline that is both on develop and has run_shell_test set would
-      # transport twice (this job and the shell path's). Not guarded: the comment
-      # trigger only fires on pull requests, so develop never carries that flag.
       - download-build-to-glusterfs
       - when:
           condition: << parameters.for-shell-tests >>
           steps:
-            # Resolve the testcases branch a single time (reuses resolve-testcases,
-            # which exports BRANCH_TESTCASES) and hand it to the shell pods. Shell
-            # runs the private repo, so resolve against cubrid-testcases-private-ex.
             - resolve-testcases:
                 tc-repo: cubrid-testcases-private-ex
             - run:
@@ -568,7 +570,6 @@ jobs:
                 root: /tmp/tcws
                 paths: [ BRANCH_TESTCASES ]
 
-# Test jobs are gated by expression-based filters (evaluated server-side).
 workflows:
   build_test:
     jobs:
@@ -591,9 +592,7 @@ workflows:
       - test_shell:
           requires: [download-build]
           filters: pipeline.parameters.run_shell_test
-      # develop merge: transport only. Both builds are preserved in GlusterFS for
-      # downstream consumers (AI agent service); no test job runs on this path.
-      # Requires both builds so a release-only regression still blocks the upload.
+      # Transport only; requires both builds so a release-only regression blocks it.
       - download-build:
           name: store-build-develop
           for-shell-tests: false

--- a/.github/workflows/comment_trigger.yml
+++ b/.github/workflows/comment_trigger.yml
@@ -25,6 +25,7 @@ jobs:
       API: https://circleci.com/api
       # The list travels as a pipeline parameter, so an oversized one is refused.
       MAX_RERUN_CASES: 50
+      MAX_RERUN_NODES: 5
     steps:
       - name: Read the command
         shell: bash
@@ -34,7 +35,7 @@ jobs:
           CMD=$(printf '%s' "$COMMENT_BODY" | head -n 1 | tr -d '\r')
           echo "[debug] command: $CMD"
 
-          refuse() { { echo "MODE=refuse"; echo "REFUSAL=$1"; } >> "$GITHUB_ENV"; exit 0; }
+          refuse() { echo "[info] refused: $1"; { echo "MODE=refuse"; echo "REFUSAL=$1"; } >> "$GITHUB_ENV"; exit 0; }
 
           if [[ "$CMD" =~ ^/rerun[[:space:]]+(shell|sql|medium)[[:space:]]*$ ]]; then
             { echo "MODE=rerun"; echo "SUITE=${BASH_REMATCH[1]}"; } >> "$GITHUB_ENV"
@@ -68,50 +69,77 @@ jobs:
           set -euo pipefail
           proj="gh/${REPO}"
           get()    { curl -sf -H "Circle-Token: ${CIRCLECI_TOKEN}" "$1"; }
-          refuse() { { echo "MODE=refuse"; echo "REFUSAL=$1"; } >> "$GITHUB_ENV"; exit 0; }
+          refuse() { echo "[info] refused: $1"; { echo "MODE=refuse"; echo "REFUSAL=$1"; } >> "$GITHUB_ENV"; exit 0; }
+
+          # Without this, an API error would leave the job with nothing to report.
+          trap 'echo "REFUSAL=Could not read the previous run from CircleCI. See this workflow log." >> "$GITHUB_ENV"' ERR
 
           SHA=$(gh api "repos/${REPO}/pulls/${PR}" --jq .head.sha)
+          builds=$(get "${API}/v1.1/project/${proj}/tree/pull/${PR}/head?limit=100&shallow=true")
 
-          # No failed run for the head is also the "you pushed a new commit" case.
-          REF=$(get "${API}/v1.1/project/${proj}/tree/pull/${PR}/head?limit=100&shallow=true" \
-            | jq -r --arg job "test_${SUITE}" --arg sha "$SHA" '
-                [ .[] | select(.workflows.job_name == $job and .vcs_revision == $sha
-                               and .status == "failed") ] | first | .build_num // empty')
-          [ -n "$REF" ] || refuse "No failed \`test_${SUITE}\` run for \`${SHA:0:9}\`. If you pushed a new commit, run the suite once first."
+          # The newest run of this suite on this commit, whatever its outcome. Taking the
+          # newest rather than the newest failed one is what makes a rerun of a rerun
+          # narrow the set further, the way the native "rerun failed tests" does; no run
+          # at all for this commit is the "you pushed a new commit" case.
+          read -r REF_JOB REF_STATUS <<<"$(jq -r --arg job "test_${SUITE}" --arg sha "$SHA" '
+              [ .[] | select(.workflows.job_name == $job and .vcs_revision == $sha) ]
+              | first | "\(.build_num // "") \(.status // "")"' <<<"$builds")"
+          [ -n "$REF_JOB" ] || refuse "No \`test_${SUITE}\` run for \`${SHA:0:9}\` yet. Run the suite once first."
+          case "$REF_STATUS" in
+            failed|timedout|infrastructure_fail) ;;
+            success|fixed) refuse "The last \`test_${SUITE}\` run (#${REF_JOB}) passed, so there is nothing to repeat." ;;
+            *)             refuse "\`test_${SUITE}\` run #${REF_JOB} is ${REF_STATUS}. Wait for it to finish." ;;
+          esac
 
-          # Reuse that run's build instead of compiling the commit again.
-          WF=$(get "${API}/v1.1/project/${proj}/${REF}" | jq -r .workflows.workflow_id)
-          BUILD=$(get "${API}/v2/workflow/${WF}/job" \
-            | jq -r '[ .items[] | select(.name == "build_debug") ] | first | .job_number // empty')
-          [ -n "$BUILD" ] || refuse "Run #${REF} has no \`build_debug\` job, so there is no build to reuse. Run the suite again."
+          # Any build of this commit will do, from whichever workflow: a rerun's own
+          # build_debug only points at an earlier build and stores no artifact, so take
+          # the newest one that still has it.
+          BUILD_JOB=""
+          for cand in $(jq -r --arg sha "$SHA" '
+                [ .[] | select(.workflows.job_name == "build_debug" and .vcs_revision == $sha) ]
+                | .[].build_num' <<<"$builds"); do
+            if get "${API}/v2/project/${proj}/${cand}/artifacts" \
+                 | jq -e 'any(.items[]?; .path | endswith("CUBRID.tar.gz"))' > /dev/null; then
+              BUILD_JOB=$cand
+              break
+            fi
+          done
+          [ -n "$BUILD_JOB" ] || refuse "No build of \`${SHA:0:9}\` still has its artifact (they are kept 30 days). Run the suite again."
 
           # result is success | failure | skipped; a skipped case never ran.
           : > cases
-          url="${API}/v2/project/${proj}/${REF}/tests"
+          url="${API}/v2/project/${proj}/${REF_JOB}/tests"
           while [ -n "$url" ]; do
             page=$(get "$url")
             jq -r '.items[] | select(.result == "failure") | .file // empty' <<<"$page" >> cases
             next=$(jq -r '.next_page_token // empty' <<<"$page")
-            url=${next:+${API}/v2/project/${proj}/${REF}/tests?page-token=${next}}
+            url=${next:+${API}/v2/project/${proj}/${REF_JOB}/tests?page-token=${next}}
           done
           sort -u -o cases cases
           N=$(wc -l < cases)
-          echo "[debug] reference job #${REF}, build #${BUILD}, ${N} failure(s)"
+          echo "[debug] reference job #${REF_JOB} (${REF_STATUS}), build #${BUILD_JOB}, ${N} failure(s)"
 
-          [ "$N" -gt 0 ] || refuse "Run #${REF} reports no failed case — it probably failed before the tests ran. Check its log."
-          [ "$N" -le "$MAX_RERUN_CASES" ] || refuse "Run #${REF} failed ${N} cases, over the ${MAX_RERUN_CASES} a rerun carries. Run the full suite."
+          [ "$N" -gt 0 ] || refuse "Run #${REF_JOB} reports no failed case — it probably failed before the tests ran. Check its log."
+          [ "$N" -le "$MAX_RERUN_CASES" ] || refuse "Run #${REF_JOB} failed ${N} cases, over the ${MAX_RERUN_CASES} a rerun carries. Run the full suite."
           if grep -qvE '^[A-Za-z0-9._/-]+$' cases || grep -q '\.\.' cases; then
-            refuse "Run #${REF} reports a case path I will not pass on. Check its test results."
+            refuse "Run #${REF_JOB} reports a case path I will not pass on. Check its test results."
           fi
 
-          # Extra nodes would only start to find nothing to do.
-          NODES=$(( N < 5 ? N : 5 ))
-          { echo "PIPELINE_PARAMS=$(jq -c -n \
-              --arg k "run_${SUITE}_test" --arg cases "$(paste -sd' ' cases)" \
-              --argjson build "$BUILD" --argjson nodes "$NODES" \
-              '{($k):true, run_all_test:false, baseline:"none",
-                rerun_cases:$cases, rerun_build_job:$build, shell_parallelism:$nodes}')"
-            echo "SUMMARY=Repeating ${N} failed \`${SUITE}\` case(s) from run #${REF} on \`${SHA:0:9}\`, across ${NODES} node(s)."
+          PARAMS=$(jq -c -n --arg k "run_${SUITE}_test" --arg cases "$(paste -sd' ' cases)" \
+                     --argjson build "$BUILD_JOB" \
+                     '{($k):true, run_all_test:false, baseline:"none",
+                       rerun_cases:$cases, rerun_build_job:$build}')
+          NOTE=""
+          # Only the shell suite reads shell_parallelism; sql and medium keep their own
+          # widths. Extra nodes would only start to find nothing to do.
+          if [ "$SUITE" = shell ]; then
+            NODES=$(( N < MAX_RERUN_NODES ? N : MAX_RERUN_NODES ))
+            PARAMS=$(jq -c --argjson n "$NODES" '. + {shell_parallelism:$n}' <<<"$PARAMS")
+            NOTE=", across ${NODES} node(s)"
+          fi
+
+          { echo "PIPELINE_PARAMS=$PARAMS"
+            echo "SUMMARY=Repeating ${N} failed \`${SUITE}\` case(s) from run #${REF_JOB} on \`${SHA:0:9}\`${NOTE}."
           } >> "$GITHUB_ENV"
 
       - name: Trigger CircleCI
@@ -144,12 +172,16 @@ jobs:
             BODY="${MARKER}"$'\n'"### CI trigger — started"$'\n\n'"${SUMMARY}${LINK}"
           fi
 
-          # One comment per pull request, edited in place. One id per line: --paginate prints per page.
-          ID=$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate \
-                 --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$MARKER\"))) | .id" \
-               | tail -n 1)
-          if [ -n "$ID" ]; then
-            gh api -X PATCH "repos/${REPO}/issues/comments/${ID}" -f body="$BODY" > /dev/null
-          else
-            gh api -X POST "repos/${REPO}/issues/${PR}/comments" -f body="$BODY" > /dev/null
-          fi
+          # One comment per pull request, edited in place. One id per line: --paginate
+          # prints per page. Best-effort, as in tc-merge-gate.yml: a flaky comment must
+          # not redden a pull request whose pipeline started fine.
+          {
+            ID=$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate \
+                   --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$MARKER\"))) | .id" \
+                 | tail -n 1)
+            if [ -n "$ID" ]; then
+              gh api -X PATCH "repos/${REPO}/issues/comments/${ID}" -f body="$BODY" > /dev/null
+            else
+              gh api -X POST "repos/${REPO}/issues/${PR}/comments" -f body="$BODY" > /dev/null
+            fi
+          } || echo "::warning::Could not post the trigger comment; the pipeline is unaffected"

--- a/.github/workflows/comment_trigger.yml
+++ b/.github/workflows/comment_trigger.yml
@@ -5,94 +5,151 @@ on:
     types: [created, edited]
 
 jobs:
+  # Job id and display name are unchanged: a required-check name is tied to them.
   run_test:
     name: Run test on CircleCI
-    # A comment can take all 50 self-hosted slots, so the commenter needs write
-    # access. Read from the payload rather than the permission API, which would
-    # refuse everyone if it failed. CONTRIBUTOR is refused, so an outside
-    # contributor's own PR needs a maintainer to ask for the run.
+    # A comment can take all 50 slots. From the payload, not the permission API,
+    # which would refuse everyone if it failed.
     if: >-
       ${{ github.event.issue.pull_request != null
-      && startsWith(github.event.comment.body, '/run')
+      && (startsWith(github.event.comment.body, '/run') || startsWith(github.event.comment.body, '/rerun'))
       && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) }}
     runs-on: ubuntu-24.04
+    env:
+      # Never interpolated into a script: the author chooses this text.
+      COMMENT_BODY: ${{ github.event.comment.body }}
+      PR: ${{ github.event.issue.number }}
+      REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CIRCLECI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
+      API: https://circleci.com/api
+      # The list travels as a pipeline parameter, so an oversized one is refused.
+      MAX_RERUN_CASES: 50
     steps:
-      - name: Validate Command
+      - name: Read the command
         shell: bash
         run: |
-          COMMENT="${{ github.event.comment.body }}"
-          echo "[debug] Comment: $COMMENT"
-          # Echoed so the value the job condition gated on is visible in the log.
-          echo "[debug] Author association: ${{ github.event.comment.author_association }}"
+          set -euo pipefail
+          echo "[debug] association: ${{ github.event.comment.author_association }}"
+          CMD=$(printf '%s' "$COMMENT_BODY" | head -n 1 | tr -d '\r')
+          echo "[debug] command: $CMD"
 
-          # Allowed commands: /run all, /run shell, /run sql, /run medium
-          # Or any combination of them (up to 4)
-          if ! [[ "$COMMENT" =~ ^/run([[:space:]]+(all|shell|sql|medium)){1,4}$ ]]; then
-            echo "[info] Ignored invalid command: $COMMENT"
+          refuse() { { echo "MODE=refuse"; echo "REFUSAL=$1"; } >> "$GITHUB_ENV"; exit 0; }
+
+          if [[ "$CMD" =~ ^/rerun[[:space:]]+(shell|sql|medium)[[:space:]]*$ ]]; then
+            { echo "MODE=rerun"; echo "SUITE=${BASH_REMATCH[1]}"; } >> "$GITHUB_ENV"
             exit 0
           fi
 
-          echo "[debug] Valid command: $COMMENT"
-          echo "VALID_RUN=true" >> $GITHUB_ENV
+          if [[ ! "$CMD" =~ ^/run([[:space:]]+(all|shell|sql|medium)){1,4}([[:space:]]+([0-9]+\.){3}[0-9]+-[0-9a-f]+)?[[:space:]]*$ ]]; then
+            refuse "I could not read \`$CMD\`. Use \`/run all\`, \`/run shell sql\` (any of shell, sql, medium), or \`/rerun <suite>\` to repeat only what failed."
+          fi
 
-      - name: Get Branch Name and Test Type
-        if: ${{ env.VALID_RUN == 'true' }}
+          if [[ "$CMD" =~ (^|[[:space:]])all($|[[:space:]]) ]]; then
+            PARAMS='{"run_shell_test":true,"run_sql_test":true,"run_medium_test":true,"run_all_test":true}'
+          else
+            PARAMS='{"run_all_test":false}'
+            for suite in shell sql medium; do
+              [[ "$CMD" =~ (^|[[:space:]])$suite($|[[:space:]]) ]] &&
+                PARAMS=$(jq -c --arg k "run_${suite}_test" '. + {($k): true}' <<<"$PARAMS")
+            done
+          fi
+          PARAMS=$(jq -c --arg b "$(grep -oE '([0-9]+\.){3}[0-9]+-[0-9a-f]+' <<<"$CMD" || echo none)" \
+                     '. + {baseline: $b}' <<<"$PARAMS")
+
+          { echo "MODE=run"
+            echo "PIPELINE_PARAMS=$PARAMS"
+            echo "SUMMARY=Started \`$CMD\`."; } >> "$GITHUB_ENV"
+
+      - name: Resolve the failures to repeat
+        if: ${{ env.MODE == 'rerun' }}
         shell: bash
         run: |
-          COMMENT="${{ github.event.comment.body }}"
-          echo "[debug] Comment: $COMMENT"
+          set -euo pipefail
+          proj="gh/${REPO}"
+          get()    { curl -sf -H "Circle-Token: ${CIRCLECI_TOKEN}" "$1"; }
+          refuse() { { echo "MODE=refuse"; echo "REFUSAL=$1"; } >> "$GITHUB_ENV"; exit 0; }
 
-          TEST_TYPES="shell sql medium"
-          TEST_JSON="{"
+          SHA=$(gh api "repos/${REPO}/pulls/${PR}" --jq .head.sha)
 
-          # If 'all' is included, run all tests
-          if [[ "$COMMENT" =~ (^|[[:space:]])all($|[[:space:]]) ]]; then
-            echo "[debug] Running all tests"
-            for test in $TEST_TYPES; do
-              TEST_JSON+="\"run_${test}_test\":true,"
-            done
-            TEST_JSON+="\"run_all_test\":true,"
-          else
-            # Detect each combined test type separately
-            for test in $TEST_TYPES; do
-              if [[ "$COMMENT" =~ (^|[[:space:]])$test($|[[:space:]]) ]]; then
-                echo "[debug] Will run $test test"
-                TEST_JSON+="\"run_${test}_test\":true,"
-              fi
-            done
-            TEST_JSON+="\"run_all_test\":false,"
+          # No failed run for the head is also the "you pushed a new commit" case.
+          REF=$(get "${API}/v1.1/project/${proj}/tree/pull/${PR}/head?limit=100&shallow=true" \
+            | jq -r --arg job "test_${SUITE}" --arg sha "$SHA" '
+                [ .[] | select(.workflows.job_name == $job and .vcs_revision == $sha
+                               and .status == "failed") ] | first | .build_num // empty')
+          [ -n "$REF" ] || refuse "No failed \`test_${SUITE}\` run for \`${SHA:0:9}\`. If you pushed a new commit, run the suite once first."
+
+          # Reuse that run's build instead of compiling the commit again.
+          WF=$(get "${API}/v1.1/project/${proj}/${REF}" | jq -r .workflows.workflow_id)
+          BUILD=$(get "${API}/v2/workflow/${WF}/job" \
+            | jq -r '[ .items[] | select(.name == "build_debug") ] | first | .job_number // empty')
+          [ -n "$BUILD" ] || refuse "Run #${REF} has no \`build_debug\` job, so there is no build to reuse. Run the suite again."
+
+          # result is success | failure | skipped; a skipped case never ran.
+          : > cases
+          url="${API}/v2/project/${proj}/${REF}/tests"
+          while [ -n "$url" ]; do
+            page=$(get "$url")
+            jq -r '.items[] | select(.result == "failure") | .file // empty' <<<"$page" >> cases
+            next=$(jq -r '.next_page_token // empty' <<<"$page")
+            url=${next:+${API}/v2/project/${proj}/${REF}/tests?page-token=${next}}
+          done
+          sort -u -o cases cases
+          N=$(wc -l < cases)
+          echo "[debug] reference job #${REF}, build #${BUILD}, ${N} failure(s)"
+
+          [ "$N" -gt 0 ] || refuse "Run #${REF} reports no failed case — it probably failed before the tests ran. Check its log."
+          [ "$N" -le "$MAX_RERUN_CASES" ] || refuse "Run #${REF} failed ${N} cases, over the ${MAX_RERUN_CASES} a rerun carries. Run the full suite."
+          if grep -qvE '^[A-Za-z0-9._/-]+$' cases || grep -q '\.\.' cases; then
+            refuse "Run #${REF} reports a case path I will not pass on. Check its test results."
           fi
 
-          BASELINE=$(echo "$COMMENT" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+-[0-9a-f]+' || echo "")
-          if [ -n "$BASELINE" ]; then
-            echo "[debug] Baseline Version: $BASELINE"
-            TEST_JSON+="\"baseline\":\"$BASELINE\"}"
-          else
-            echo "[debug] No Baseline Version provided. Will use latest from DB."
-            TEST_JSON+="\"baseline\":\"none\"}"
+          # Extra nodes would only start to find nothing to do.
+          NODES=$(( N < 5 ? N : 5 ))
+          { echo "PIPELINE_PARAMS=$(jq -c -n \
+              --arg k "run_${SUITE}_test" --arg cases "$(paste -sd' ' cases)" \
+              --argjson build "$BUILD" --argjson nodes "$NODES" \
+              '{($k):true, run_all_test:false, baseline:"none",
+                rerun_cases:$cases, rerun_build_job:$build, shell_parallelism:$nodes}')"
+            echo "SUMMARY=Repeating ${N} failed \`${SUITE}\` case(s) from run #${REF} on \`${SHA:0:9}\`, across ${NODES} node(s)."
+          } >> "$GITHUB_ENV"
+
+      - name: Trigger CircleCI
+        if: ${{ env.MODE == 'run' || env.MODE == 'rerun' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          BODY=$(jq -c -n --arg branch "pull/${PR}/head" --argjson params "$PIPELINE_PARAMS" \
+                   '{branch: $branch, parameters: $params}')
+          echo "[debug] request: $BODY"
+          if ! OUT=$(curl -sf -X POST --url "${API}/v2/project/gh/${REPO}/pipeline" \
+                       --header "Circle-Token: ${CIRCLECI_TOKEN}" \
+                       --header "Content-Type: application/json" --data "$BODY"); then
+            echo "REFUSAL=CircleCI rejected the request. See this workflow's log." >> "$GITHUB_ENV"
+            exit 1
           fi
+          echo "PIPELINE=$(jq -r '.number // empty' <<<"$OUT")" >> "$GITHUB_ENV"
 
-          TEST_JSON=$(echo $TEST_JSON | sed 's/,}/}/')
-          echo "TEST_JSON=$TEST_JSON" >> $GITHUB_ENV
-          echo "[debug] Test Parameters: $TEST_JSON"
-
-      - name: Trigger CircleCI Test
-        if: ${{ env.VALID_RUN == 'true' }}
+      - name: Report on the pull request
+        if: ${{ always() && (env.REFUSAL != '' || env.SUMMARY != '') }}
+        shell: bash
         env:
-          CIRCLECI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
-          BRANCH_NAME: pull/${{ github.event.issue.number }}/head
-          TEST_JSON: ${{ env.TEST_JSON }}
-          REPO_OWNER: ${{ github.repository_owner }}
-          REPO_NAME: ${{ github.event.repository.name }}
-        shell: bash
+          MARKER: <!-- ci-comment-trigger -->
         run: |
-          DATA=$(echo '{"branch": "'"$BRANCH_NAME"'", "parameters": '"$TEST_JSON"'}')
-          echo "[debug] DATA: $DATA"
-          echo "[debug] REPO_OWNER: $REPO_OWNER"
-          echo "[debug] REPO_NAME: $REPO_NAME"
+          set -euo pipefail
+          if [ -n "${REFUSAL:-}" ]; then
+            BODY="${MARKER}"$'\n'"### CI trigger — not started"$'\n\n'"${REFUSAL}"
+          else
+            LINK=${PIPELINE:+" ([pipeline ${PIPELINE}](https://app.circleci.com/pipelines/github/${REPO}?branch=pull%2F${PR}%2Fhead))"}
+            BODY="${MARKER}"$'\n'"### CI trigger — started"$'\n\n'"${SUMMARY}${LINK}"
+          fi
 
-          curl --request POST \
-            --url "https://circleci.com/api/v2/project/gh/$REPO_OWNER/$REPO_NAME/pipeline" \
-            --header "Circle-Token: $CIRCLECI_TOKEN" \
-            --header "Content-Type: application/json" \
-            --data "$DATA"
+          # One comment per pull request, edited in place. One id per line: --paginate prints per page.
+          ID=$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate \
+                 --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$MARKER\"))) | .id" \
+               | tail -n 1)
+          if [ -n "$ID" ]; then
+            gh api -X PATCH "repos/${REPO}/issues/comments/${ID}" -f body="$BODY" > /dev/null
+          else
+            gh api -X POST "repos/${REPO}/issues/${PR}/comments" -f body="$BODY" > /dev/null
+          fi


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDQA-1494

### Purpose

테스트가 실패하면 재확인하려면 전체를 다시 돌려야 한다. shell 풀런은 자리 50개를 중앙값 **31분** 점유하고, 그동안 뒤에 줄 선 다른 파이프라인까지 함께 멈춘다. 사용자 체감은 "풀런을 한참 기다려 결과를 받았는데, 실패를 확인하고 다시 돌리면 **또** 한참 기다린다"는 것이다.

그런데 실제 실패 건수를 재보니 실패한 shell 잡 6건에서 **1, 1, 9, 1, 1, 1건**이었다. 3,250건 중 한두 건 때문에 31분을 다시 쓰고 있었다.

### Implementation

PR에 `/rerun shell`(또는 `sql`, `medium`)을 달면 **직전에 실패한 케이스만** 다시 돈다.

- **기존 job을 그대로 재사용한다.** CircleCI는 커밋 상태 이름을 job 이름으로 붙이므로, 빨간 `ci/circleci: test_shell`을 초록으로 덮을 수 있는 것은 **같은 이름의 job뿐**이다. `rerun_shell` 같은 전용 job은 새 컨텍스트를 만들고 빨간 건 그대로 남겨 머지가 풀리지 않는다. 그래서 rerun 전용 워크플로 분기 대신 파이프라인 파라미터(`rerun_cases`, `rerun_build_job`)로 지시한다.
- **빌드를 다시 만들지 않는다.** job 이름을 유지하니 의존 그래프도 유지되어 `build_debug`가 돌기는 하지만, `rerun_build_job`이 있으면 컴파일을 건너뛰고 그 잡 번호만 소비자에게 넘긴다(~10초). `download-build`는 GlusterFS에 sentinel이 있으면 이미 즉시 반환하고, `download-build-from-artifact`는 이미 workspace의 번호를 읽으므로 **둘 다 변경 없다**.
- **split 단계에 분기 하나만 추가했다.** 후보 목록이 glob 대신 파라미터에서 온다. 그 뒤의 suite별 split 명령·prune·빈 할당 halt는 그대로다 — 테스트 결과 API가 각 케이스의 `file`을 glob이 만드는 형식과 **정확히 같은 형태**로 주기 때문이다(shell·sql·medium 실제 잡으로 확인).
- **노드 수는 실패 건수에 맞춘다**(상한 5). 남는 노드는 떠서 빈 할당을 받고 halt하므로 낭비다.
- **가드**: write 권한(CUBRIDQA-1493), 현재 head에 실패한 잡이 없음(= 새 커밋을 push한 경우), 실패 0건, 실패 50건 초과, 케이스 경로가 평범한 상대 경로가 아님. 각각 이유를 코멘트로 안내한다.

**실패 목록 해석을 job이 아니라 트리거가 한다.** API 응답이 케이스당 14KB 실패 메시지를 실어 shell에서 **2MB**가 되고, `jq`는 `cubridci:test_shell`에만 있고 `cubridci:develop`에는 없으며 `python3`는 양쪽 다 없다. job에서 2MB JSON을 파싱하는 것이 이 기능의 가장 약한 고리가 될 참이었다. 실패 9건의 경로는 809바이트라 트리거가 그대로 넘길 수 있다.

**부수 변경**

- `/run`과 `/rerun` 모두 **무엇을 시작했는지 코멘트로 알린다.** 형식이 틀린 명령도 조용히 무시되지 않고 사용법을 안내한다 — 지금까지는 오타와 CI 고장이 구분되지 않았다. PR당 **코멘트 하나를 갱신**하며, `tc-merge-gate`가 쓰는 방식과 같다.
- **script injection 제거**: 코멘트 본문을 셸에 보간하지 않고 환경변수로 넘긴다. actionlint가 이 파일에 대해 지적하던 2건이 사라졌고, shellcheck를 켠 상태로 **0건**이다(저장소의 다른 워크플로는 22건·2건·2건).
- 위 리포팅을 공유하려면 `/run` 경로도 손봐야 해서 파라미터 조립을 문자열 연결에서 jq로 바꿨다. **동작은 동일하다** — 아래 검증 참조.

### Remarks

**검증에 구조적 제약이 있다.** `issue_comment` 워크플로는 PR 브랜치가 아니라 **기본 브랜치(develop)의 파일로 실행된다**(CUBRIDQA-1493에서 실측). 게다가 파라미터를 실은 파이프라인을 띄우려면 CircleCI 토큰이 필요한데, fork 브랜치의 워크플로에는 저장소 시크릿이 주어지지 않는다. **따라서 `/rerun`은 이 PR에서 한 번도 실행할 수 없고, 머지 후에만 확인된다.**

그래서 실행 가능한 모든 것을 정적·샌드박스로 검증했다.

| 검증 | 결과 |
|---|---|
| `circleci config validate` | valid |
| `circleci config process` (정상 / rerun 두 파라미터셋) | 양쪽 성공. rerun에서 `build_debug`가 `Reuse the build of job #142807` + persist만 남고 **컴파일이 사라짐**을 확인 |
| 처리된 config의 모든 `run` 스텝 `bash -n` | 정상 34개 / rerun 30개, **문법 오류 0** |
| `actionlint` + `shellcheck` (워크플로) | **0건** |
| rerun 블록 샌드박스 테스트 | **10/10** — 단일·복수·중복, 삭제된 케이스 혼재, 전부 삭제(실패해야 함), 셸 메타문자, `../` 탈출, 다른 suite 목록, 공백 |
| 명령 파싱 테스트 | **17/17** — `/run` 기존 표면 6종, `/rerun` 4종, 거부 6종, 첫 줄만 읽기 |
| **`/run` 동등성 테스트** | **10/10 develop과 완전히 동일한 JSON** (각 suite, 조합, `all`, baseline 유·무) |

샌드박스 테스트가 실제로 결함을 하나 잡았다: 처음 쓴 문자 클래스 검증(`[A-Za-z0-9._/-]`)이 `.`과 `/`를 허용해 **`../../etc/passwd`가 통과하고 실제 파일에 도달**했다. 검증을 해당 suite의 트리(`^<base_dir>/…`) + `..` 금지로 묶어 고쳤다.

**머지 후 확인 순서**

1. 현재 head에 실패한 `test_shell`이 있는 PR에서 `/rerun shell` → 코멘트에 "Repeating N failed shell case(s) from run #X" 표시, `build_debug` 로그에 컴파일 없이 `Reuse the build of job #Y`만, `test_shell`이 N노드로 뜨고 나머지는 halt, 통과 시 `ci/circleci: test_shell`이 초록으로 전환되어 머지 가능.
2. 거부 경로: `/rerun bogus`(사용법 안내), 실패한 잡이 없는 PR에서 `/rerun shell`(사유 안내).
3. **`/run` 회귀 확인**: `/run sql`이 종전대로 동작.

**첫 실전 `/rerun`에서 함께 확인될 미검증 항목**: `rerun_cases`를 파이프라인 파라미터로 넘기는 크기 한도. CircleCI의 정확한 한도를 문서로 확인하지 못해 **50건(약 4.5KB)으로 상한**을 두고 초과 시 거부하도록 했다. 실측 실패 건수가 1~9건이라 실질 제약은 아니지만, 한도가 더 낮다면 첫 시도에서 CircleCI가 거부하고 그 사실이 코멘트로 남는다.

테스트 하네스 3종은 저장소에 넣지 않았다(이 저장소에 CI 설정용 테스트 관례가 없다). split 로직을 건드리는 CUBRIDQA-1495에서 다시 쓸 값어치가 있다고 보는데, 넣을지는 별도 판단이 필요하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UcXpSqurNoQmhQDrNFv5Xr
