### PR TITLE
Drop the query_executor.* code owner entry

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,7 +29,6 @@
 /src/parser/ @beyondykk9
 /src/parser/view_transform.* @shparkcubrid
 /src/query/ @beyondykk9
-/src/query/query_executor.* @shparkcubrid
 /src/query/query_hash_scan.* @shparkcubrid
 /src/query/query_hash_join.* @shparkcubrid
 /src/query/scan_manager.* @shparkcubrid


### PR DESCRIPTION
## Purpose

query_executor.* 코드오너를 제거합니다.
해당 파일은 공용의 성격이 강하므로 코드 오너를 제거하며, 필요시 직접 리뷰요청받는 것으로 하겠습니다.

참고로 해당 파일의 오너가 제거되면 김병욱님이 /src/query 오너이므로 코드오너가 됩니다. 