### PR TITLE
[CBRD-27162] Fix incorrect line numbers in csql -i when session commands precede a query error

### DIFF
--- a/src/executables/csql.c
+++ b/src/executables/csql.c
@@ -886,7 +886,7 @@ start_csql (CSQL_ARGUMENT * csql_arg)
 	      && feof (csql_Input_fp) && check_contents_has_noncomment ())
 	    {
 	      /* single-line-oriented execution */
-	      csql_execute_statements (csql_arg, EDITOR_INPUT, NULL, line_no);
+	      csql_execute_statements (csql_arg, EDITOR_INPUT, NULL, start_line_no);
 	      csql_edit_contents_clear ();
 	    }
 
@@ -2197,6 +2197,10 @@ csql_execute_statements (const CSQL_ARGUMENT * csql_arg, int type, const void *s
   if (csql_Is_interactive)
     {
       csql_yyset_lineno (1);
+    }
+  else if (stmt_start_line_no > 0)
+    {
+      csql_yyset_lineno (stmt_start_line_no);
     }
 
   if (type == FILE_INPUT)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27162 >

### Purpose

* csql -i 옵션 사용시 라인번호 오류 수정

### Implementation

N/A

### Remarks
 -i 옵션으로 주어진 파일에서 session command가 기술되고 그 직후에 나오는 SQL문에서 오류가 났을 때 오류 라인 번호 출력이 잘못되는 현상을 수정함.
 
