### PR TITLE
[CBRD-27149] heap_get_hfid_if_cached에서 미완성 HFID 캐시 엔트리를 캐시 미스로 처리

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -24426,8 +24426,22 @@ heap_get_hfid_if_cached (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * 
 
   if (entry)
     {
+      /* The cache is publish-then-fill: heap_hfid_cache_get () exposes the entry in the hash through
+       * lf_hash_find_or_insert () first and fills it afterwards, publishing classname last (CAS). If classname is
+       * not set yet, the entry is still being filled by a concurrent thread; treat it as a cache miss. Reading
+       * classname before hfid mirrors the writer's order (hfid store, then classname CAS), so a non-NULL
+       * classname guarantees a valid hfid. */
+      char *classname_local = entry->classname;
+
+      if (classname_local == NULL || HFID_IS_NULL (&entry->hfid))
+	{
+	  /* *success remains false */
+	  lf_tran_end_with_mb (t_entry);
+	  return NO_ERROR;
+	}
+
       assert (entry->hfid.hpgid != NULL_PAGEID && entry->hfid.vfid.fileid != NULL_FILEID
-	      && entry->hfid.vfid.volid != NULL_VOLID && entry->classname != NULL);
+	      && entry->hfid.vfid.volid != NULL_VOLID);
 
       if (hfid_out != NULL)
 	{
@@ -24439,7 +24453,7 @@ heap_get_hfid_if_cached (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * 
 	}
       if (classname_out != NULL)
 	{
-	  *classname_out = entry->classname;
+	  *classname_out = classname_local;
 	}
 
       *success = true;

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -24401,7 +24401,8 @@ heap_hfid_cache_get (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * hfid
  *   class_oid (in)     : the class OID for which the entry will be returned
  *   hfid_out (out)     : output heap file identifier
  *   ftype_out (out)    : output heap file type
- *   classname_out (out): output classname
+ *   classname_out (out): output classname. The string is owned by the cache entry and is freed when the entry is
+ *                        deleted and reclaimed; callers must not retain it beyond the entry's lifetime.
  *   success  (out)     : true if found from cache
  */
 int
@@ -24430,10 +24431,12 @@ heap_get_hfid_if_cached (THREAD_ENTRY * thread_p, const OID * class_oid, HFID * 
        * lf_hash_find_or_insert () first and fills it afterwards, publishing classname last (CAS). If classname is
        * not set yet, the entry is still being filled by a concurrent thread; treat it as a cache miss. Reading
        * classname before hfid mirrors the writer's order (hfid store, then classname CAS), so a non-NULL
-       * classname guarantees a valid hfid. */
+       * classname guarantees a valid hfid. ftype, however, is resolved only after classname is published, so it
+       * may still be unknown; report a miss rather than an unknown type when the caller asked for it. */
       char *classname_local = entry->classname;
 
-      if (classname_local == NULL || HFID_IS_NULL (&entry->hfid))
+      if (classname_local == NULL || HFID_IS_NULL (&entry->hfid)
+	  || (ftype_out != NULL && entry->ftype == FILE_UNKNOWN_TYPE))
 	{
 	  /* *success remains false */
 	  lf_tran_end_with_mb (t_entry);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27149>

### Purpose

debug 빌드에서 DDL 수행 중 `heap_get_hfid_if_cached()`의 assert가 실패하며 서버가 abort 되는 문제를 수정합니다 (`src/storage/heap_file.c:24429`).

class OID → HFID 캐시(`heap_Hfid_table`)는 publish-then-fill 구조입니다. `heap_hfid_cache_get()`은 `lf_hash_find_or_insert()`로 새 엔트리를 해시에 **먼저 노출**시킨 뒤 클래스 레코드를 읽어 hfid를 채우고, 마지막에 `classname`(std::atomic)을 CAS로 게시하는 것을 완성 마커로 사용합니다. 그런데 `heap_get_hfid_if_cached()`는 `lf_hash_find()`로 찾은 엔트리를 무조건 완성 상태로 단정하여, 다른 스레드가 같은 class OID의 엔트리를 채우는 도중이면 스텁 엔트리(hfid = NULL, classname = NULL)를 보고 assert가 깨집니다.

클래스 객체 flush 경로와, 같은 class OID를 처음 접근해 캐시를 채우는 스레드가 겹칠 때 발생합니다.

### Implementation

`heap_get_hfid_if_cached()`가 `heap_hfid_cache_get()`과 동일한 규약을 따르도록 수정했습니다.

- `classname`을 **먼저** 로드하고, NULL이면(동시 스레드가 채우는 중) 캐시 미스로 처리합니다 (`*success = false`, `NO_ERROR` 반환). 쓰기 측이 hfid 저장 → classname CAS 순서로 게시하므로, 읽기를 classname 확인 → hfid 사용 순서로 두면 non-NULL classname이 유효한 hfid를 보장합니다.
- 방어적으로 `HFID_IS_NULL`인 경우도 미스로 처리합니다.
- early return 전 lock-free 구조의 read 종료를 위한 `lf_tran_end_with_mb()`를 호출합니다 (`lf_hash_find`는 엔트리를 찾으면 lock-free 트랜잭션을 활성 상태로 남기므로 필수).

### Remarks

N/A