### PR TITLE
[CBRD-27165] Fix ROUND returning a 10x value when a 40-digit NUMERIC carries into a 41st digit

### DIFF
--- a/src/query/arithmetic.c
+++ b/src/query/arithmetic.c
@@ -2560,10 +2560,18 @@ db_round_dbval (DB_VALUE * result, DB_VALUE * value1, DB_VALUE * value2)
 		  if ('1' <= *ptr && *ptr <= '9')
 		    {
 		      int length = strlen (ptr);
+
 		      if (length > DB_MAX_NUMERIC_PRECISION)
 			{
-			  s -= (length - DB_MAX_NUMERIC_PRECISION);
+			  /* The round up grew a value at the max precision by one digit; the buffer fits
+			   * 41 digits, so give that digit to the scale. It is a '0' cleared above. */
+			  assert (length == DB_MAX_NUMERIC_PRECISION + 1 && end[-1] == '0');
+
+			  s--;
 			  p = DB_MAX_NUMERIC_PRECISION;
+
+			  end--;
+			  *end = '\0';
 			}
 
 		      if (s < DB_MIN_NUMERIC_SCALE)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27165

### Purpose
- NUMERIC 값에 ROUND를 수행할 때, 자리올림으로 유효 자릿수가 최대 precision을 초과하면 결과가 실제보다 10배 크게 반환되는 문제를 수정합니다.

```sql
SELECT ROUND(0.9999999999999999999999999999999999999999, 0);
-- 수정 전: 10.000000000000000000000000000000000000000
-- 수정 후:  1.000000000000000000000000000000000000000
```

### Implementation
- NUMERIC은 17바이트 base-256 unscaled 정수(헤더 제외)와 scale로 저장되며, db_round_dbval()은 unscaled 값을 십진 문자열로 변환한 뒤 반올림을 수행합니다.
- NUMERIC 값은 (문자열을 정수로 읽은 값) × 10^-scale 형태이므로, scale을 1 줄이면 값은 10배 커집니다.
- 기존 구현은 자리올림으로 유효 자릿수가 최대 precision을 초과했을 때 아래 코드로 scale을 감소시켜 값이 10배 커지는 문제가 있었습니다.

```c
s -= (length - DB_MAX_NUMERIC_PRECISION);
p = DB_MAX_NUMERIC_PRECISION;
```

#### 수정 후에는 다음과 같이 처리합니다.
- 자리올림이 최상위 자리까지 전파되면 문자열 길이가 1 증가합니다. 
  - 예를 들어 유효 자릿수 40인 값은 41자리가 되며, 이 경우에만 해당 분기로 진입합니다.
- 먼저 문자열 길이가 41자리인지, 그리고 제거할 마지막 자리가 자리올림 과정에서 추가된 '0'인지 `assert`로 검증합니다.
- 이후 문자열 끝의 '0' 한 자리를 제거하여 unscaled 정수를 10으로 나누고, scale도 1 감소시킵니다.
  - 두 연산이 서로 상쇄되므로 NUMERIC 값은 변경되지 않으면서 precision만 최대 범위로 맞춰집니다.

### Remarks
- `FLOOR` / `CEIL` / `TRUNC` 은 동일 증상이 없음을 확인했습니다. 
  - `db_floor_dbval()`과 `db_ceil_dbval()`은 CBRD-26006에서 동일한 overflow 경로를 수정하여, scale은 변경하지 않고 precision만 최대값으로 제한하도록 변경되었습니다.
  - `db_trunc_dbval()`은 자리올림을 수행하지 않으므로 해당 문제가 발생하지 않습니다.