### PR TITLE
[CBRD-27073] Fix log applier error message buffer overflow

### DIFF
--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -5854,7 +5854,13 @@ la_apply_repl_log (int tranid, int rectype, LOG_LSA * commit_lsa, int *total_row
 
 	      sb.clear ();
 	      db_sprint_value (la_get_item_pk_value (item), sb);
-	      sprintf (error_string, "[%s,%s] %s", item->class_name, sb.get_buffer (), db_error_string (1));
+	      const char *class_name = item->class_name;
+	      const char *pk_string = sb.get_buffer ();
+	      const char *class_ellipsis = strlen (class_name) > 16 ? "..." : "";
+	      const char *pk_ellipsis = strlen (pk_string) > 16 ? "..." : "";
+
+	      snprintf (error_string, sizeof (error_string), "[%.16s%s,%.16s%s] %s", class_name, class_ellipsis,
+			pk_string, pk_ellipsis, db_error_string (1));
 	      er_log_debug (ARG_FILE_LINE, "Internal system failure: %s", error_string);
 
 	      if (ER_IS_SERVER_DOWN_ERROR (errid))

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -5853,13 +5853,11 @@ la_apply_repl_log (int tranid, int rectype, LOG_LSA * commit_lsa, int *total_row
 
 	      sb.clear ();
 	      db_sprint_value (la_get_item_pk_value (item), sb);
-	      const char *class_name = item->class_name;
 	      const char *pk_string = sb.get_buffer ();
-	      const char *class_ellipsis = strlen (class_name) > 16 ? "..." : "";
-	      const char *pk_ellipsis = strlen (pk_string) > 16 ? "..." : "";
+	      const char *pk_ellipsis = strlen (pk_string) > 255 ? "..." : "";
 
-	      er_log_debug (ARG_FILE_LINE, "Internal system failure: [%.16s%s,%.16s%s] %s", class_name,
-			    class_ellipsis, pk_string, pk_ellipsis, db_error_string (1));
+	      er_log_debug (ARG_FILE_LINE, "Internal system failure: [%s,%.255s%s] %s", item->class_name, pk_string,
+			    pk_ellipsis, db_error_string (1));
 
 	      if (ER_IS_SERVER_DOWN_ERROR (errid))
 		{

--- a/src/transaction/log_applier.c
+++ b/src/transaction/log_applier.c
@@ -5747,7 +5747,6 @@ la_apply_repl_log (int tranid, int rectype, LOG_LSA * commit_lsa, int *total_row
   int errid;
   LA_APPLY *apply;
   int apply_repl_log_cnt = 0;
-  char error_string[1024];
   char buf[256];
   static unsigned int total_repl_items = 0;
   bool release_pb = false;
@@ -5859,9 +5858,8 @@ la_apply_repl_log (int tranid, int rectype, LOG_LSA * commit_lsa, int *total_row
 	      const char *class_ellipsis = strlen (class_name) > 16 ? "..." : "";
 	      const char *pk_ellipsis = strlen (pk_string) > 16 ? "..." : "";
 
-	      snprintf (error_string, sizeof (error_string), "[%.16s%s,%.16s%s] %s", class_name, class_ellipsis,
-			pk_string, pk_ellipsis, db_error_string (1));
-	      er_log_debug (ARG_FILE_LINE, "Internal system failure: %s", error_string);
+	      er_log_debug (ARG_FILE_LINE, "Internal system failure: [%.16s%s,%.16s%s] %s", class_name,
+			    class_ellipsis, pk_string, pk_ellipsis, db_error_string (1));
 
 	      if (ER_IS_SERVER_DOWN_ERROR (errid))
 		{


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27073>

### Purpose

에러 출력시 PK 값이 큰 경우 버퍼 오버플로우가 발생할 수 있어 수정합니다.


### Implementation

1. sprintf 를 snprintf로 수정합니다.
2. 이렇게 수정함에도 pk가 길다면 정작 에러의 내용이 잘릴 가능성이 있습니다.
3. 이를 방지하기위해 클래스명과 pk가 길다면 각각 16바이트까지 출력하고 ... 로 출력합니다.
4. 에러 구문도 길지 않을것으로 예상되서 3번과 같이 처리할 경우 sprintf로도 충분할수는 있지만 안정성을 위해 함수 변경도 유효합니다.

### Remarks

16글자가 아닌 16바이트라 한글의 경우 충분히 출력이 되지 않을 수 있습니다.
출력을 고려해봤는데 코드의 수행 빈도 대비 작업 코드가 길어져 반영하지 않았습니다. 
