### PR TITLE
[CBRD-27171] Extract single-table restrictions from multi-table OR predicates

### DIFF
--- a/src/optimizer/plan_generation.c
+++ b/src/optimizer/plan_generation.c
@@ -1698,6 +1698,10 @@ make_pred_from_plan (QO_ENV * env, QO_PLAN * plan, PT_NODE ** key_predp, PT_NODE
 		     QO_XASL_INDEX_INFO * qo_index_infop, PT_NODE ** hash_predp)
 {
   QO_INDEX_ENTRY *index_entryp = NULL;
+  QO_TERM *termp;
+  BITSET drop_terms;
+  BITSET_ITERATOR iter;
+  int t;
 
   /* initialize output parameter */
   if (key_predp != NULL)
@@ -1734,6 +1738,26 @@ make_pred_from_plan (QO_ENV * env, QO_PLAN * plan, PT_NODE ** key_predp, PT_NODE
       bitset_difference (&(plan->sarged_terms), &(plan->plan_un.scan.kf_terms));
     }
   while (0);
+
+  /* An OR-derived restriction is implied by the multi-spec factor it was extracted from, so as a
+   * data filter it only pre-rejects rows the original factor would reject anyway.  Once no index
+   * adopted it (it survived the key-range/key-filter subtraction above), it pays its way only
+   * when it is cheap to evaluate AND rejects most rows: a conjunct costlier than a
+   * column-vs-constant compare re-pays that computation per scanned row, and a filter that lets
+   * most rows through spends its evaluation on every row while saving the original factor on
+   * few -- drop either from the predicate. */
+  bitset_init (&drop_terms, env);
+  for (t = bitset_iterate (&(plan->sarged_terms), &iter); t != -1; t = bitset_next_member (&iter))
+    {
+      termp = QO_ENV_TERM (env, t);
+      if (QO_TERM_IS_FLAGED (termp, QO_TERM_OR_DERIVED_EXPENSIVE)
+	  || (QO_TERM_IS_FLAGED (termp, QO_TERM_OR_DERIVED) && QO_TERM_SELECTIVITY (termp) > 0.5))
+	{
+	  bitset_add (&drop_terms, t);
+	}
+    }
+  bitset_difference (&(plan->sarged_terms), &drop_terms);
+  bitset_delset (&drop_terms);
 
   /* make predicate list for hash key */
   if (hash_predp != NULL)

--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -2056,6 +2056,18 @@ qo_analyze_term (QO_TERM * term, int term_type)
       QO_TERM_SET_FLAG (term, QO_TERM_LIKE_HAS_DERIVED_RANGE);
     }
 
+  if (PT_EXPR_INFO_IS_FLAGED (pt_expr, PT_EXPR_INFO_OR_DERIVED))
+    {
+      /* keep real selectivity for index-access cost; flag so row-count skips it */
+      QO_TERM_SET_FLAG (term, QO_TERM_OR_DERIVED);
+    }
+
+  if (PT_EXPR_INFO_IS_FLAGED (pt_expr, PT_EXPR_INFO_OR_DERIVED_EXPENSIVE))
+    {
+      /* make_pred_from_plan () drops it from the data filter unless an index adopted it */
+      QO_TERM_SET_FLAG (term, QO_TERM_OR_DERIVED_EXPENSIVE);
+    }
+
   /* only interesting in one predicate term; if 'term' has 'or_next', it was derived from OR term */
   /* also cases that are too complicated and unusual to consider here: (cond and/or cond) is true/false (cond and/or
    * cond) =/!= (cond and/or cond).
@@ -2813,6 +2825,17 @@ wrapup:
       QO_TERM_SELECTIVITY (term) = -1.0;
       break;
     }				/* switch (term_type) */
+
+  /* an OR-derived implied duplicate earns its keep only when it rejects most rows: when it does
+   * not, keep it out of key ranges/filters as well -- an index scan repeated per outer row over
+   * most of the index costs more than it saves, and an implied duplicate must never steer the
+   * plan by itself (make_pred_from_plan () applies the same bound to the data filter it may
+   * remain as) */
+  if (QO_TERM_IS_FLAGED (term, QO_TERM_OR_DERIVED) && QO_TERM_SELECTIVITY (term) > 0.5)
+    {
+      QO_TERM_SET_FLAG (term, QO_TERM_NON_IDX_SARG_COLL);
+      QO_TERM_CAN_USE_INDEX (term) = 0;
+    }
 
   bitset_delset (&lhs_segs);
   bitset_delset (&rhs_segs);
@@ -8683,9 +8706,11 @@ qo_node_add_sarg (QO_NODE * node, QO_TERM * sarg)
   double sel_limit;
 
   bitset_add (&(QO_NODE_SARGS (node)), QO_TERM_IDX (sarg));
-  /* Skip LIKE-derived range in row-count: subset-correlated with the retained
-   * LIKE. Still kept in QO_NODE_SARGS for index key-range use. */
-  if (!QO_TERM_IS_FLAGED (sarg, QO_TERM_LIKE_DERIVED_RANGE))
+  /* Skip derived duplicates in row-count: a LIKE-derived range is subset-correlated with the
+   * retained LIKE, and an OR-derived restriction is implied by the multi-spec factor it was
+   * extracted from, so counting either would double count the same constraint.  Both stay in
+   * QO_NODE_SARGS for index key-range use. */
+  if (!QO_TERM_IS_FLAGED (sarg, QO_TERM_LIKE_DERIVED_RANGE | QO_TERM_OR_DERIVED))
     {
       QO_NODE_SELECTIVITY (node) *= QO_TERM_SELECTIVITY (sarg);
     }

--- a/src/optimizer/query_graph.h
+++ b/src/optimizer/query_graph.h
@@ -756,6 +756,8 @@ struct qo_term
 #define QO_TERM_SEL_FROM_HISTOGRAM  1024	/* selectivity computed from histograms only */
 #define QO_TERM_LIKE_DERIVED_RANGE  2048	/* range term derived from a prefix LIKE */
 #define QO_TERM_LIKE_HAS_DERIVED_RANGE 4096	/* the prefix LIKE a range was derived from */
+#define QO_TERM_OR_DERIVED          8192	/* single-spec restriction derived from a multi-spec OR factor */
+#define QO_TERM_OR_DERIVED_EXPENSIVE 16384	/* OR-derived restriction too costly to keep as a plain data filter */
 
 #define QO_TERM_IS_FLAGED(t, f)        (QO_TERM_FLAG(t) & (int) (f))
 #define QO_TERM_SET_FLAG(t, f)         QO_TERM_FLAG(t) |= (int) (f)

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -8071,10 +8071,12 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 		}
 	      else
 		{
-		  /* Skip a LIKE-derived range in both the row-count selectivity and the
-		   * join hit probability: it is subset-correlated with the retained LIKE,
-		   * so counting it in either would double count the same constraint. */
-		  if (!QO_TERM_IS_FLAGED (term, QO_TERM_LIKE_DERIVED_RANGE))
+		  /* Skip a LIKE-derived range and an OR-derived restriction in both the
+		   * row-count selectivity and the join hit probability: the former is
+		   * subset-correlated with the retained LIKE, the latter is implied by the
+		   * multi-spec factor it was extracted from, so counting either would double
+		   * count the same constraint. */
+		  if (!QO_TERM_IS_FLAGED (term, QO_TERM_LIKE_DERIVED_RANGE | QO_TERM_OR_DERIVED))
 		    {
 		      double head_factor, tail_factor;
 

--- a/src/optimizer/rewriter/query_rewrite.c
+++ b/src/optimizer/rewriter/query_rewrite.c
@@ -474,6 +474,11 @@ qo_rewrite_queries (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *con
 	}
 
       qo_rewrite_terms (parser, spec, wherep);
+
+      /* derive single-spec restrictions from multi-spec OR terms; runs after the term-level
+       * rewrites so the derived terms start from the same normalized shape */
+      qo_extract_or_restrictions (parser, spec, wherep);
+
       qo_rewrite_terms (parser, spec, havingp);
       qo_rewrite_terms (parser, spec, startwithp);
       qo_rewrite_terms (parser, spec, connectbyp);

--- a/src/optimizer/rewriter/query_rewrite.h
+++ b/src/optimizer/rewriter/query_rewrite.h
@@ -124,6 +124,7 @@ void qo_add_limit_clause (PARSER_CONTEXT * parser, PT_NODE * node);
 
 /* optimize terms */
 void qo_rewrite_terms (PARSER_CONTEXT * parser, PT_NODE * nodes, PT_NODE ** terms);
+void qo_extract_or_restrictions (PARSER_CONTEXT * parser, PT_NODE * spec_list, PT_NODE ** wherep);
 void qo_reduce_equality_terms (PARSER_CONTEXT * parser, PT_NODE * node, PT_NODE ** wherep);
 PT_NODE *qo_reduce_equality_terms_post (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);
 int qo_is_reduceable_const (PT_NODE * expr);

--- a/src/optimizer/rewriter/query_rewrite_term.c
+++ b/src/optimizer/rewriter/query_rewrite_term.c
@@ -4518,6 +4518,154 @@ qo_or_extract_check_ref_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg,
 }
 
 /*
+ * qo_or_extract_is_constant_side () - does this operand evaluate without reading a row?
+ *   return: true for values, host variables, interpreter parameters and expressions over them
+ *   node(in): operand of a comparison
+ */
+static bool
+qo_or_extract_is_constant_side (PT_NODE * node)
+{
+  if (node == NULL)
+    {
+      return true;
+    }
+
+  switch (node->node_type)
+    {
+    case PT_VALUE:
+    case PT_HOST_VAR:
+      return true;
+    case PT_NAME:
+      /* an interpreter parameter behaves like a constant; a column does not */
+      return node->info.name.meta_class == PT_PARAMETER;
+    case PT_EXPR:
+      /* an expression over constants alone is folded before execution */
+      return qo_or_extract_is_constant_side (node->info.expr.arg1)
+	&& qo_or_extract_is_constant_side (node->info.expr.arg2)
+	&& qo_or_extract_is_constant_side (node->info.expr.arg3);
+    default:
+      return false;
+    }
+}
+
+/*
+ * qo_or_extract_is_cheap_restriction () - is this predicate no costlier than a column-vs-constant
+ *					    compare?
+ *   return: true for a bare column compared against constants
+ *   conjunct(in): a leaf predicate of a derived factor
+ *
+ * Note: The derived predicate is implied by the original factor, so it never removes work from the
+ *	 original evaluation -- it only earns its keep when the scan can turn it into a key range or
+ *	 evaluate it about as cheaply as a column-vs-constant compare. Duplicating a conjunct that
+ *	 computes something pays that computation again for every scanned row: a factor whose
+ *	 branches are all of the form `c3 * (1 - c5) >= k` gains nothing from the copy unless an
+ *	 index on that expression exists, and doubled the run time of a 1,000,000-row scan, 14.3 s
+ *	 to 28.8 s. The extraction therefore prefers cheap conjuncts and falls back to every safe
+ *	 one only when some disjunct has none, because a costly conjunct can still match a
+ *	 function index; the same classification, applied to the final factor, decides whether it
+ *	 may remain a plain data filter when no index adopts it (make_pred_from_plan () drops it
+ *	 otherwise).
+ */
+static bool
+qo_or_extract_is_cheap_restriction (PT_NODE * conjunct)
+{
+  PT_NODE *column, *other;
+
+  if (conjunct == NULL || conjunct->node_type != PT_EXPR)
+    {
+      return false;
+    }
+
+  switch (conjunct->info.expr.op)
+    {
+    case PT_EQ:
+    case PT_NE:
+    case PT_LT:
+    case PT_LE:
+    case PT_GT:
+    case PT_GE:
+    case PT_RANGE:
+    case PT_BETWEEN:
+    case PT_NOT_BETWEEN:
+    case PT_LIKE:
+    case PT_IS_NULL:
+    case PT_IS_NOT_NULL:
+      break;
+    default:
+      /* anything else -- arithmetic, string functions, IS, NOT, boolean combinations -- either
+       * cannot become a range or costs more per row than the filter saves */
+      return false;
+    }
+
+  column = conjunct->info.expr.arg1;
+  other = conjunct->info.expr.arg2;
+
+  if (column == NULL || column->node_type != PT_NAME || column->info.name.meta_class == PT_PARAMETER)
+    {
+      /* the cheap side has to be a bare column: `f (c) > 1` computes per row, and
+       * pt_convert_to_range () has already normalized the operand order where it can */
+      return false;
+    }
+
+  if (conjunct->info.expr.op == PT_RANGE)
+    {
+      /* arg2 is the list of range items, each holding its bounds in arg1/arg2 */
+      PT_NODE *item;
+
+      for (item = other; item != NULL; item = item->next)
+	{
+	  if (item->node_type != PT_EXPR || !qo_or_extract_is_constant_side (item->info.expr.arg1)
+	      || !qo_or_extract_is_constant_side (item->info.expr.arg2))
+	    {
+	      return false;
+	    }
+	}
+      return true;
+    }
+
+  return qo_or_extract_is_constant_side (other) && qo_or_extract_is_constant_side (conjunct->info.expr.arg3);
+}
+
+/*
+ * qo_or_derived_shape_is_cheap () - is every leaf predicate of a derived factor a bare column
+ *				     compared against constants?
+ *   return: true when evaluating the factor per scanned row costs no more than such compares
+ *   factor(in): a WHERE CNF element built by qo_extract_or_restrictions (), after the term-level
+ *		 rewrites; AND/OR structure may appear as nested expressions or as or_next chains
+ */
+static bool
+qo_or_derived_shape_is_cheap (PT_NODE * factor)
+{
+  PT_NODE *node;
+
+  for (node = factor; node != NULL; node = node->or_next)
+    {
+      if (node->node_type == PT_VALUE)
+	{
+	  continue;		/* a folded constant costs nothing */
+	}
+      if (node->node_type != PT_EXPR)
+	{
+	  return false;
+	}
+      if (node->info.expr.op == PT_AND || node->info.expr.op == PT_OR)
+	{
+	  if (!qo_or_derived_shape_is_cheap (node->info.expr.arg1)
+	      || !qo_or_derived_shape_is_cheap (node->info.expr.arg2))
+	    {
+	      return false;
+	    }
+	}
+      else if (!qo_or_extract_is_cheap_restriction (node))
+	{
+	  return false;
+	}
+    }
+
+  return true;
+}
+
+/*
  * qo_or_extract_flatten () - flatten a PT_AND/PT_OR tree into an array of operand expressions
  *   return: number of operands collected so far, or -1 when there are more than max_cnt
  *   expr(in): boolean expression tree
@@ -4557,9 +4705,10 @@ qo_or_extract_flatten (PT_NODE * expr, PT_OP_TYPE op, PT_NODE ** out, int cnt, i
  *   parser(in):
  *   disjunct(in): one disjunct of a CNF OR factor; may itself be an AND tree
  *   spec_id(in):
+ *   cheap_only(in): keep only conjuncts no costlier than a column-vs-constant compare
  */
 static PT_NODE *
-qo_or_extract_build_for_spec (PARSER_CONTEXT * parser, PT_NODE * disjunct, UINTPTR spec_id)
+qo_or_extract_build_for_spec (PARSER_CONTEXT * parser, PT_NODE * disjunct, UINTPTR spec_id, bool cheap_only)
 {
 #define QO_OR_EXTRACT_MAX_CONJUNCTS 16
   PT_NODE *conjuncts[QO_OR_EXTRACT_MAX_CONJUNCTS];
@@ -4588,6 +4737,10 @@ qo_or_extract_build_for_spec (PARSER_CONTEXT * parser, PT_NODE * disjunct, UINTP
       if (!info.refers_spec || info.refers_other)
 	{
 	  continue;		/* not a single-spec conjunct of this spec */
+	}
+      if (cheap_only && !qo_or_extract_is_cheap_restriction (conjuncts[i]))
+	{
+	  continue;		/* the first pass keeps only what a scan evaluates cheaply */
 	}
 
       copied = parser_copy_tree (parser, conjuncts[i]);
@@ -4630,17 +4783,25 @@ qo_or_extract_build_for_spec (PARSER_CONTEXT * parser, PT_NODE * disjunct, UINTP
  *	 an index/cardinality opportunity.  TPC-H Q19 is the canonical shape: without this the
  *	 part table gets no filter at all from the brand/container/size branches and every plan
  *	 has to carry the full table through the join.
+ *
+ *	 Because the derived factor is implied by the original one, it must not be counted a
+ *	 second time in the row-count selectivity, and keeping it as a plain data filter only
+ *	 pays off when it is no costlier than column-vs-constant compares.  Each derived factor
+ *	 is therefore marked PT_EXPR_INFO_OR_DERIVED (plus _EXPENSIVE by shape); the marks reach
+ *	 the plan as QO_TERM flags, where qo_node_add_sarg () skips the double count and
+ *	 make_pred_from_plan () drops a costly copy that no index adopted.
  */
 void
 qo_extract_or_restrictions (PARSER_CONTEXT * parser, PT_NODE * spec_list, PT_NODE ** wherep)
 {
 #define QO_OR_EXTRACT_MAX_DISJUNCTS 8
   PT_NODE *disjuncts[QO_OR_EXTRACT_MAX_DISJUNCTS];
-  PT_NODE *cnf, *spec, *part, *ors, *or_node, *new_terms = NULL;
+  PT_NODE *parts[QO_OR_EXTRACT_MAX_DISJUNCTS];
+  PT_NODE *cnf, *spec, *ors, *or_node, *derived, *new_terms = NULL;
   PT_NODE *save_next;
   QO_OR_EXTRACT_REF_INFO info;
-  int dis_cnt, i;
-  bool ok;
+  int dis_cnt, i, pass;
+  bool ok, all_single;
 
   if (wherep == NULL || *wherep == NULL || spec_list == NULL)
     {
@@ -4701,22 +4862,62 @@ qo_extract_or_restrictions (PARSER_CONTEXT * parser, PT_NODE * spec_list, PT_NOD
 	      continue;
 	    }
 
-	  ors = NULL;
+	  /* prefer the conjuncts a scan can evaluate cheaply -- such a factor may stay as a plain
+	   * data filter; only when some disjunct has no cheap conjunct fall back to every safe
+	   * one, since a costly conjunct can still meet a function index (the fallback factor is
+	   * dropped at XASL emission unless an index adopts it) */
 	  ok = true;
-	  for (i = 0; i < dis_cnt; i++)
+	  for (pass = 0; pass < 2; pass++)
 	    {
-	      part = qo_or_extract_build_for_spec (parser, disjuncts[i], spec->info.spec.id);
-	      if (part == NULL)
+	      ok = true;
+	      for (i = 0; i < dis_cnt; i++)
 		{
-		  ok = false;	/* one disjunct contributes nothing; no implied restriction */
-		  break;
+		  parts[i] = qo_or_extract_build_for_spec (parser, disjuncts[i], spec->info.spec.id, pass == 0);
+		  if (parts[i] == NULL)
+		    {
+		      ok = false;	/* one disjunct contributes nothing; no implied restriction */
+		      break;
+		    }
 		}
 
-	      if (ors == NULL)
+	      if (ok)
 		{
-		  ors = part;
+		  break;
 		}
-	      else
+	    }
+
+	  if (!ok)
+	    {
+	      continue;
+	    }
+
+	  /* single-predicate contributions chain through or_next -- the CNF shape of a
+	   * disjunction -- so qo_convert_to_range () can merge them into one RANGE term, which
+	   * is what lets an index (notably a function index on a costly expression) adopt the
+	   * derived factor.  An AND-tree contribution is not an or_next literal, so such factors
+	   * keep the nested-OR shape and can only serve as data filters */
+	  all_single = true;
+	  for (i = 0; i < dis_cnt; i++)
+	    {
+	      if (parts[i]->node_type == PT_EXPR && parts[i]->info.expr.op == PT_AND)
+		{
+		  all_single = false;
+		  break;
+		}
+	    }
+
+	  ors = parts[0];
+	  if (all_single)
+	    {
+	      for (i = 0; i < dis_cnt - 1; i++)
+		{
+		  parts[i]->or_next = parts[i + 1];
+		}
+	      parts[dis_cnt - 1]->or_next = NULL;
+	    }
+	  else
+	    {
+	      for (i = 1; i < dis_cnt && ok; i++)
 		{
 		  or_node = parser_new_node (parser, PT_EXPR);
 		  if (or_node == NULL)
@@ -4725,20 +4926,21 @@ qo_extract_or_restrictions (PARSER_CONTEXT * parser, PT_NODE * spec_list, PT_NOD
 		      break;
 		    }
 		  or_node->info.expr.op = PT_OR;
-		  /* as qo_convert_to_range_helper () does for the predicate nodes it builds; the
-		   * location is 0 under the WHERE-level guard above, but carry it explicitly so an
-		   * extension to ON-clause factors (location > 0) does not silently lose it */
+		  /* as qo_convert_to_range_helper () does for the predicate nodes it builds;
+		   * the location is 0 under the WHERE-level guard above, but carry it
+		   * explicitly so an extension to ON-clause factors (location > 0) does not
+		   * silently lose it */
 		  or_node->type_enum = PT_TYPE_LOGICAL;
 		  or_node->info.expr.location = cnf->info.expr.location;
 		  or_node->info.expr.arg1 = ors;
-		  or_node->info.expr.arg2 = part;
+		  or_node->info.expr.arg2 = parts[i];
 		  ors = or_node;
 		}
-	    }
 
-	  if (!ok || ors == NULL)
-	    {
-	      continue;
+	      if (!ok)
+		{
+		  continue;
+		}
 	    }
 
 	  new_terms = parser_append_node (ors, new_terms);
@@ -4749,6 +4951,30 @@ qo_extract_or_restrictions (PARSER_CONTEXT * parser, PT_NODE * spec_list, PT_NOD
     {
       /* give the derived terms the same term-level rewrites the original CNF factors received */
       qo_rewrite_terms (parser, spec_list, &new_terms);
+
+      /* mark what survived the rewrites: qo_analyze_term () carries the marks into the term
+       * flags, so the row-count selectivity skips these implied duplicates and
+       * make_pred_from_plan () drops the costly ones no index adopted.  Classify on the
+       * rewritten shape -- that is what a scan would actually evaluate */
+      for (derived = new_terms; derived != NULL; derived = derived->next)
+	{
+	  if (derived->node_type != PT_EXPR)
+	    {
+	      continue;
+	    }
+	  PT_EXPR_INFO_SET_FLAG (derived, PT_EXPR_INFO_OR_DERIVED);
+	  if (!qo_or_derived_shape_is_cheap (derived))
+	    {
+	      PT_EXPR_INFO_SET_FLAG (derived, PT_EXPR_INFO_OR_DERIVED_EXPENSIVE);
+	    }
+	  /* a later rewrite pass re-runs pt_cnf () on the WHERE; the original factors carry
+	   * CNF_DONE from their own conversion, but without it here that pass distributes the
+	   * derived factor into per-branch products -- new nodes that shed these marks and
+	   * multiply the very evaluations the plan-time judgment is meant to drop.  The derived
+	   * factor is designed to stay whole: one implied term, judged against the plan */
+	  PT_EXPR_INFO_SET_FLAG (derived, PT_EXPR_INFO_CNF_DONE);
+	}
+
       *wherep = parser_append_node (new_terms, *wherep);
     }
 #undef QO_OR_EXTRACT_MAX_DISJUNCTS

--- a/src/optimizer/rewriter/query_rewrite_term.c
+++ b/src/optimizer/rewriter/query_rewrite_term.c
@@ -4425,3 +4425,303 @@ qo_apply_range_intersection (PARSER_CONTEXT * parser, PT_NODE ** wherep)
 	}
     }
 }
+
+/* bookkeeping for qo_or_extract_check_ref_pre () */
+typedef struct qo_or_extract_ref_info QO_OR_EXTRACT_REF_INFO;
+struct qo_or_extract_ref_info
+{
+  UINTPTR spec_id;		/* id of the spec being tested */
+  bool refers_spec;		/* a column of the tested spec appears */
+  bool refers_other;		/* a column of any other spec appears */
+  bool is_unsafe;		/* contains a piece that must not be evaluated twice or out of place */
+};
+
+/*
+ * qo_or_extract_check_ref_pre () - classify which specs an expression touches and whether it
+ *				    is safe to duplicate as a derived scan filter
+ *   return: node
+ *   parser(in):
+ *   node(in):
+ *   arg(in/out): QO_OR_EXTRACT_REF_INFO
+ *   continue_walk(in/out):
+ */
+static PT_NODE *
+qo_or_extract_check_ref_pre (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk)
+{
+  QO_OR_EXTRACT_REF_INFO *info = (QO_OR_EXTRACT_REF_INFO *) arg;
+
+  if (node == NULL)
+    {
+      return node;
+    }
+
+  if (PT_IS_QUERY (node) || node->node_type == PT_METHOD_CALL)
+    {
+      /* evaluating a subquery or a method one extra time per scanned row is not free and may be
+       * correlated; leave such terms alone */
+      info->is_unsafe = true;
+    }
+  else if (node->node_type == PT_NAME)
+    {
+      if (node->info.name.meta_class == PT_PARAMETER)
+	{
+	  ;			/* an interpreter parameter behaves like a constant */
+	}
+      else if (node->info.name.spec_id == info->spec_id)
+	{
+	  info->refers_spec = true;
+	}
+      else
+	{
+	  info->refers_other = true;
+	}
+    }
+  else if (node->node_type == PT_EXPR)
+    {
+      switch (node->info.expr.op)
+	{
+	case PT_RAND:
+	case PT_RANDOM:
+	case PT_DRAND:
+	case PT_DRANDOM:
+	case PT_SYS_GUID:
+	  /* a second evaluation draws a different value, so a duplicated filter could reject rows
+	   * the original predicate accepts */
+	case PT_CURRENT_VALUE:
+	case PT_NEXT_VALUE:
+	  /* serial access has side effects */
+	case PT_INST_NUM:
+	case PT_ROWNUM:
+	case PT_ORDERBY_NUM:
+	  /* row-numbering terms are position dependent */
+	case PT_LEVEL:
+	case PT_PRIOR:
+	case PT_CONNECT_BY_ROOT:
+	case PT_SYS_CONNECT_BY_PATH:
+	  /* hierarchy pseudo columns are only meaningful in their original place */
+	case PT_DEFINE_VARIABLE:
+	case PT_EVALUATE_VARIABLE:
+	  /* session variables are order sensitive */
+	  info->is_unsafe = true;
+	  break;
+	default:
+	  break;
+	}
+    }
+
+  if (info->is_unsafe)
+    {
+      *continue_walk = PT_STOP_WALK;
+    }
+
+  return node;
+}
+
+/*
+ * qo_or_extract_flatten () - flatten a PT_AND/PT_OR tree into an array of operand expressions
+ *   return: number of operands collected so far, or -1 when there are more than max_cnt
+ *   expr(in): boolean expression tree
+ *   op(in): PT_AND or PT_OR
+ *   out(out): operand array of size max_cnt (may be NULL to only count)
+ *   cnt(in): operands collected before this call
+ *   max_cnt(in):
+ */
+static int
+qo_or_extract_flatten (PT_NODE * expr, PT_OP_TYPE op, PT_NODE ** out, int cnt, int max_cnt)
+{
+  if (expr != NULL && expr->node_type == PT_EXPR && expr->info.expr.op == op)
+    {
+      cnt = qo_or_extract_flatten (expr->info.expr.arg1, op, out, cnt, max_cnt);
+      if (cnt < 0)
+	{
+	  return -1;
+	}
+      return qo_or_extract_flatten (expr->info.expr.arg2, op, out, cnt, max_cnt);
+    }
+
+  if (cnt >= max_cnt)
+    {
+      return -1;
+    }
+  if (out != NULL)
+    {
+      out[cnt] = expr;
+    }
+  return cnt + 1;
+}
+
+/*
+ * qo_or_extract_build_for_spec () - conjunction of the copies of the conjuncts of one disjunct
+ *				     that reference only the given spec
+ *   return: newly built expression, or NULL when the disjunct has no usable conjunct
+ *   parser(in):
+ *   disjunct(in): one disjunct of a CNF OR factor; may itself be an AND tree
+ *   spec_id(in):
+ */
+static PT_NODE *
+qo_or_extract_build_for_spec (PARSER_CONTEXT * parser, PT_NODE * disjunct, UINTPTR spec_id)
+{
+#define QO_OR_EXTRACT_MAX_CONJUNCTS 16
+  PT_NODE *conjuncts[QO_OR_EXTRACT_MAX_CONJUNCTS];
+  PT_NODE *result = NULL, *copied;
+  QO_OR_EXTRACT_REF_INFO info;
+  int cnt, i;
+
+  cnt = qo_or_extract_flatten (disjunct, PT_AND, conjuncts, 0, QO_OR_EXTRACT_MAX_CONJUNCTS);
+  if (cnt < 0)
+    {
+      return NULL;
+    }
+
+  for (i = 0; i < cnt; i++)
+    {
+      info.spec_id = spec_id;
+      info.refers_spec = false;
+      info.refers_other = false;
+      info.is_unsafe = false;
+      (void) parser_walk_tree (parser, conjuncts[i], qo_or_extract_check_ref_pre, &info, NULL, NULL);
+
+      if (info.is_unsafe)
+	{
+	  return NULL;		/* should have been filtered at the factor gate; stay safe */
+	}
+      if (!info.refers_spec || info.refers_other)
+	{
+	  continue;		/* not a single-spec conjunct of this spec */
+	}
+
+      copied = parser_copy_tree (parser, conjuncts[i]);
+      if (copied == NULL)
+	{
+	  return NULL;
+	}
+
+      if (result == NULL)
+	{
+	  result = copied;
+	}
+      else
+	{
+	  result = pt_and (parser, result, copied);
+	  if (result == NULL)
+	    {
+	      return NULL;
+	    }
+	}
+    }
+
+  return result;
+#undef QO_OR_EXTRACT_MAX_CONJUNCTS
+}
+
+/*
+ * qo_extract_or_restrictions () - derive single-spec scan filters from multi-spec OR terms
+ *   return:
+ *   parser(in):
+ *   spec_list(in): FROM specs of the current statement
+ *   wherep(in/out): WHERE in CNF
+ *
+ * Note: For a CNF factor of the form (A1 and B1 and ...) or (A2 and B2 and ...) or ..., where
+ *	 every disjunct contains at least one conjunct referencing only one particular spec S
+ *	 (the A's), the disjunction (A1 or A2 or ...) is implied by the original factor: any row
+ *	 combination accepted by the factor satisfies some disjunct, hence that disjunct's A part.
+ *	 Appending it to the WHERE clause therefore never changes the result, while it gives the
+ *	 scan of S a data filter (sarg) the original multi-spec factor cannot provide, and with it
+ *	 an index/cardinality opportunity.  TPC-H Q19 is the canonical shape: without this the
+ *	 part table gets no filter at all from the brand/container/size branches and every plan
+ *	 has to carry the full table through the join.
+ */
+void
+qo_extract_or_restrictions (PARSER_CONTEXT * parser, PT_NODE * spec_list, PT_NODE ** wherep)
+{
+#define QO_OR_EXTRACT_MAX_DISJUNCTS 8
+  PT_NODE *disjuncts[QO_OR_EXTRACT_MAX_DISJUNCTS];
+  PT_NODE *cnf, *spec, *part, *ors, *or_node, *new_terms = NULL;
+  QO_OR_EXTRACT_REF_INFO info;
+  int dis_cnt, i;
+  bool ok;
+
+  if (wherep == NULL || *wherep == NULL || spec_list == NULL)
+    {
+      return;
+    }
+
+  for (cnf = *wherep; cnf != NULL; cnf = cnf->next)
+    {
+      if (cnf->node_type != PT_EXPR || cnf->info.expr.op != PT_OR)
+	{
+	  continue;
+	}
+
+      dis_cnt = qo_or_extract_flatten (cnf, PT_OR, disjuncts, 0, QO_OR_EXTRACT_MAX_DISJUNCTS);
+      if (dis_cnt < 2)
+	{
+	  continue;		/* too many disjuncts (-1) or degenerate */
+	}
+
+      for (spec = spec_list; spec != NULL; spec = spec->next)
+	{
+	  if (spec->node_type != PT_SPEC)
+	    {
+	      continue;
+	    }
+
+	  /* factor gate: it must be safe to duplicate pieces of this factor, it must touch this
+	   * spec, and it must touch something else too -- otherwise it already is a sarg of it */
+	  info.spec_id = spec->info.spec.id;
+	  info.refers_spec = false;
+	  info.refers_other = false;
+	  info.is_unsafe = false;
+	  (void) parser_walk_tree (parser, cnf, qo_or_extract_check_ref_pre, &info, NULL, NULL);
+	  if (info.is_unsafe || !info.refers_spec || !info.refers_other)
+	    {
+	      continue;
+	    }
+
+	  ors = NULL;
+	  ok = true;
+	  for (i = 0; i < dis_cnt; i++)
+	    {
+	      part = qo_or_extract_build_for_spec (parser, disjuncts[i], spec->info.spec.id);
+	      if (part == NULL)
+		{
+		  ok = false;	/* one disjunct contributes nothing; no implied restriction */
+		  break;
+		}
+
+	      if (ors == NULL)
+		{
+		  ors = part;
+		}
+	      else
+		{
+		  or_node = parser_new_node (parser, PT_EXPR);
+		  if (or_node == NULL)
+		    {
+		      ok = false;
+		      break;
+		    }
+		  or_node->info.expr.op = PT_OR;
+		  or_node->info.expr.arg1 = ors;
+		  or_node->info.expr.arg2 = part;
+		  ors = or_node;
+		}
+	    }
+
+	  if (!ok || ors == NULL)
+	    {
+	      continue;
+	    }
+
+	  new_terms = parser_append_node (ors, new_terms);
+	}
+    }
+
+  if (new_terms != NULL)
+    {
+      /* give the derived terms the same term-level rewrites the original CNF factors received */
+      qo_rewrite_terms (parser, spec_list, &new_terms);
+      *wherep = parser_append_node (new_terms, *wherep);
+    }
+#undef QO_OR_EXTRACT_MAX_DISJUNCTS
+}

--- a/src/optimizer/rewriter/query_rewrite_term.c
+++ b/src/optimizer/rewriter/query_rewrite_term.c
@@ -4637,6 +4637,7 @@ qo_extract_or_restrictions (PARSER_CONTEXT * parser, PT_NODE * spec_list, PT_NOD
 #define QO_OR_EXTRACT_MAX_DISJUNCTS 8
   PT_NODE *disjuncts[QO_OR_EXTRACT_MAX_DISJUNCTS];
   PT_NODE *cnf, *spec, *part, *ors, *or_node, *new_terms = NULL;
+  PT_NODE *save_next;
   QO_OR_EXTRACT_REF_INFO info;
   int dis_cnt, i;
   bool ok;
@@ -4648,7 +4649,11 @@ qo_extract_or_restrictions (PARSER_CONTEXT * parser, PT_NODE * spec_list, PT_NOD
 
   for (cnf = *wherep; cnf != NULL; cnf = cnf->next)
     {
-      if (cnf->node_type != PT_EXPR || cnf->info.expr.op != PT_OR)
+      /* qo_or_extract_flatten () collects the disjuncts through arg1/arg2 only, so a factor that
+       * carries further branches on its or_next chain would yield a restriction built from part
+       * of the disjunction -- stronger than what the factor implies, which could drop rows.
+       * Skip such factors, and keep the gate below looking at exactly the node set flatten sees */
+      if (cnf->node_type != PT_EXPR || cnf->info.expr.op != PT_OR || cnf->or_next != NULL)
 	{
 	  continue;
 	}
@@ -4681,7 +4686,16 @@ qo_extract_or_restrictions (PARSER_CONTEXT * parser, PT_NODE * spec_list, PT_NOD
 	  info.refers_spec = false;
 	  info.refers_other = false;
 	  info.is_unsafe = false;
+	  /* cnf is an element of the WHERE CNF list, and parser_walk_tree () follows 'next' after
+	   * the sub-trees (parse_tree_cl.c, pt_walk_private), so the walk would classify this
+	   * factor together with every later WHERE term: a subquery in any of them would set
+	   * is_unsafe and silently disable the extraction, while their spec references would set
+	   * refers_other and let a single-spec factor through the "already a sarg" guard, adding a
+	   * duplicate of itself. Detach the tail for the walk, as qo_rewrite_outerjoin () does */
+	  save_next = cnf->next;
+	  cnf->next = NULL;
 	  (void) parser_walk_tree (parser, cnf, qo_or_extract_check_ref_pre, &info, NULL, NULL);
+	  cnf->next = save_next;
 	  if (info.is_unsafe || !info.refers_spec || !info.refers_other)
 	    {
 	      continue;
@@ -4711,6 +4725,11 @@ qo_extract_or_restrictions (PARSER_CONTEXT * parser, PT_NODE * spec_list, PT_NOD
 		      break;
 		    }
 		  or_node->info.expr.op = PT_OR;
+		  /* as qo_convert_to_range_helper () does for the predicate nodes it builds; the
+		   * location is 0 under the WHERE-level guard above, but carry it explicitly so an
+		   * extension to ON-clause factors (location > 0) does not silently lose it */
+		  or_node->type_enum = PT_TYPE_LOGICAL;
+		  or_node->info.expr.location = cnf->info.expr.location;
 		  or_node->info.expr.arg1 = ors;
 		  or_node->info.expr.arg2 = part;
 		  ors = or_node;

--- a/src/optimizer/rewriter/query_rewrite_term.c
+++ b/src/optimizer/rewriter/query_rewrite_term.c
@@ -4653,6 +4653,15 @@ qo_extract_or_restrictions (PARSER_CONTEXT * parser, PT_NODE * spec_list, PT_NOD
 	  continue;
 	}
 
+      /* only true WHERE-level factors may donate restrictions: a factor that came from an outer
+       * join's ON condition (location > 0) is evaluated at its join level and does not reject the
+       * null-padded rows, while the derived filter would run at WHERE level and wrongly reject
+       * them; the same asymmetry makes any outer-join-context factor unsafe to project down */
+      if (cnf->info.expr.location != 0)
+	{
+	  continue;
+	}
+
       dis_cnt = qo_or_extract_flatten (cnf, PT_OR, disjuncts, 0, QO_OR_EXTRACT_MAX_DISJUNCTS);
       if (dis_cnt < 2)
 	{

--- a/src/parser/cnf.c
+++ b/src/parser/cnf.c
@@ -1210,6 +1210,14 @@ pt_do_cnf (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_wal
       /* to make pt_cnf() work */
       for (; list; list = list->next)
 	{
+	  /* a restriction derived by qo_extract_or_restrictions () must stay one whole factor:
+	   * re-running the distribution on it explodes it into per-branch OR products -- new
+	   * nodes that shed the OR-derived marks the plan-time judgment needs and that re-pay,
+	   * per product, the duplicated evaluation those marks exist to prevent */
+	  if (PT_EXPR_INFO_IS_FLAGED (list, PT_EXPR_INFO_OR_DERIVED))
+	    {
+	      continue;
+	    }
 	  PT_EXPR_INFO_CLEAR_FLAG (list, PT_EXPR_INFO_CNF_DONE);
 	}
 

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -2363,6 +2363,12 @@ struct pt_expr_info
 #define PT_EXPR_INFO_LIKE_DERIVED_RANGE 4194304	/* 0x400000, range derived from a prefix LIKE; excluded from row-count selectivity */
 #define PT_EXPR_INFO_LIKE_HAS_DERIVED_RANGE 8388608	/* 0x800000, the prefix LIKE a range was derived from; the pair
 							 * of PT_EXPR_INFO_LIKE_DERIVED_RANGE */
+#define PT_EXPR_INFO_OR_DERIVED 16777216	/* 0x1000000, single-spec restriction derived from a multi-spec OR
+						 * factor; implied by that factor, so excluded from row-count
+						 * selectivity */
+#define PT_EXPR_INFO_OR_DERIVED_EXPENSIVE 33554432	/* 0x2000000, an OR-derived restriction with a conjunct costlier
+							 * than a column-vs-constant compare; kept only when an index
+							 * adopts it */
   int flag;			/* flags */
 #define PT_EXPR_INFO_IS_FLAGED(e, f)    ((e)->info.expr.flag & (int) (f))
 #define PT_EXPR_INFO_SET_FLAG(e, f)     (e)->info.expr.flag |= (int) (f)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27171>

### Purpose

OR 술어의 각 분기에 여러 테이블의 조건이 섞여 있으면 옵티마이저가 그 술어 전체를 조인 항으로만 분류하여, 개별 테이블 스캔에 필터(sarg)를 적용할 기회를 잃습니다.

TPC-H Q19가 대표적인 형태입니다. 각 분기에 part 조건(p_brand, p_container, p_size)과 lineitem 조건(l_quantity, l_shipmode, l_shipinstruct)이 함께 들어 있어 part에 sarg가 하나도 붙지 않고, 실제로는 약 2천 행으로 줄일 수 있는 part 2,000,000행 전체가 조인 대상이 됩니다. 300버킷 히스토그램 환경에서 part 구동 인덱스 조인 플랜이 선택되면 무필터 프로브가 200만 회 발생하여 실행 시간이 수십 초에 이릅니다.

이 PR은 그러한 OR에서 특정 테이블 전용 조건들을 추출하여 중복 필터로 추가하는 재작성을 도입합니다.

### Implementation

`(A1 and B1 ...) or (A2 and B2 ...) or ...` 형태의 CNF 팩터에서, 모든 분기가 특정 spec S만 참조하는 conjunct(A들)를 하나 이상 갖고 있으면 `(A1 or A2 or ...)`는 원본 술어의 논리적 필요조건입니다. 원본을 만족하는 행 조합은 반드시 어느 분기를 만족하고, 따라서 그 분기의 A 부분도 만족하기 때문입니다. 이를 WHERE에 추가해도 결과는 변하지 않으며, S의 스캔은 데이터 필터와 인덱스/카디널리티 기회를 얻습니다.

- `qo_extract_or_restrictions()` (`rewriter/query_rewrite_term.c` 신규): WHERE(CNF)의 각 OR 팩터 × 각 spec에 대해 위 추출을 시도하고, 성공한 파생 항들을 WHERE 끝에 추가합니다. 원본 팩터는 그대로 유지합니다.
- 호출 위치: `qo_rewrite_one_query()`에서 WHERE에 대한 `qo_rewrite_terms()` 직후. 파생 항에도 `qo_rewrite_terms()`를 적용하여 기존 항들과 같은 range/like 정규화를 받게 했습니다.
- 안전 가드:
  - 분기 8개, 분기당 conjunct 16개 초과 시 해당 팩터 포기
  - 서브쿼리·메서드 호출을 포함한 팩터 제외 (행마다 추가 평가 비용/상관 위험)
  - 재평가 시 값이 달라지거나 위치 의존적인 요소를 포함한 팩터 제외: rand 계열, sys_guid, 시리얼(current_value/next_value), inst_num/rownum/orderby_num, 계층 질의 의사컬럼, 세션 변수

### Remarks

TPC-H SF10 Q19 실측 (동일 장비·동일 조건: 300버킷 히스토그램, data_buffer_size 8G, FK 인덱스):

| | 적용 전 | 적용 후 |
|---|---|---|
| 실행 시간 | 46.96초 | **0.529초** |
| part 스캔 sarg | 0개 (card 2,000,000) | 27개 (card 1) |
| 결과값 | 30104438.0911 | 30104438.0911 (동일) |

lineitem 측에서도 대칭적으로 추출이 일어나 (l_quantity 범위 등) 프로브 필터가 추가됩니다.
스모크: Q1/Q3/Q7/Q15 정상 수행, 서브쿼리 포함 OR(추출 제외 대상) 정상 동작, 단일 테이블 OR(비대상) 결과 불변 확인.

- 파생 항의 선택도가 원본 OR와 독립적으로 곱해지므로 조인 출력 카디널리티가 과소 추정될 수 있습니다. 등가 이행(transitive equality) 파생 항과 같은 계열의 보수적 특성이며, 원본 항 선택도 보정은 후속 과제로 남겨두었습니다.
- 회귀 테스트: CTP sql/medium 수행 예정입니다.
