### PR TITLE
[CBRD-26831] Make OOS files non-numerable

### DIFF
--- a/src/base/perf_monitor.c
+++ b/src/base/perf_monitor.c
@@ -379,6 +379,9 @@ PSTAT_METADATA pstat_Metadata[] = {
   PSTAT_METADATA_INIT_COUNTER_TIMER (PSTAT_HEAP_VACUUM_EXECUTE, "heap_vacuum_execute"),
   PSTAT_METADATA_INIT_COUNTER_TIMER (PSTAT_HEAP_VACUUM_LOG, "heap_vacuum_log"),
 
+  /* OOS sector-bitmap enumeration. */
+  PSTAT_METADATA_INIT_SINGLE_ACC (PSTAT_OOS_NUM_BITMAP_SNAPSHOT_SKIPS, "Num_oos_bitmap_snapshot_skips"),
+
   /* B-tree detailed statistics. */
   PSTAT_METADATA_INIT_COUNTER_TIMER (PSTAT_BT_FIX_OVF_OIDS, "bt_fix_ovf_oids"),
   PSTAT_METADATA_INIT_COUNTER_TIMER (PSTAT_BT_UNIQUE_RLOCKS, "bt_unique_rlocks"),

--- a/src/base/perf_monitor.h
+++ b/src/base/perf_monitor.h
@@ -454,6 +454,9 @@ typedef enum
   PSTAT_HEAP_VACUUM_EXECUTE,
   PSTAT_HEAP_VACUUM_LOG,
 
+  /* OOS sector-bitmap enumeration. */
+  PSTAT_OOS_NUM_BITMAP_SNAPSHOT_SKIPS,
+
   /* B-tree ops detailed statistics. */
   PSTAT_BT_FIX_OVF_OIDS,
   PSTAT_BT_UNIQUE_RLOCKS,

--- a/src/storage/oos_file.cpp
+++ b/src/storage/oos_file.cpp
@@ -16,6 +16,7 @@
  *
  */
 
+#include <algorithm>
 #if defined(CUBRID_UNIT_TEST_ENABLED)
 #include <atomic>
 #endif
@@ -23,6 +24,7 @@
 #include <cstring>
 #include <new>
 #include <vector>
+#include "bit.h"
 #include "byte_span_writer.hpp"
 #include "error_code.h"
 #include "error_manager.h"
@@ -31,6 +33,7 @@
 #include "memory_alloc.h"
 #include "memory_hash.h"
 #include "page_buffer.h"
+#include "perf_monitor.h"
 #include "porting_inline.hpp"
 #include "scope_exit.hpp"
 #include "slotted_page.h"
@@ -99,6 +102,10 @@ oos_file_alloc_new (THREAD_ENTRY *thread_p, const VFID &oos_vfid, VPID &vpid_out
 
 static const auto_unfix_page_ptr
 oos_find_best_page (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const int rec_length, VPID &vpid);
+
+static int
+oos_collect_data_page_vpids (THREAD_ENTRY *thread_p, const VFID *vfid, const VPID *hdr_vpid,
+			     std::vector<VPID> &vpids);
 
 // ****************************************************************************
 // OOS Bestspace — constants
@@ -690,6 +697,61 @@ oos_stats_find_page_in_bestspace (THREAD_ENTRY *thread_p, const VFID *vfid,
 // ****************************************************************************
 
 static int
+oos_collect_data_page_vpids (THREAD_ENTRY *thread_p, const VFID *vfid, const VPID *hdr_vpid,
+			     std::vector<VPID> &vpids)
+{
+  FILE_FTAB_COLLECTOR collector = FILE_FTAB_COLLECTOR_INITIALIZER;
+  int error_code = file_get_all_data_sectors (thread_p, vfid, &collector);
+  if (error_code != NO_ERROR)
+    {
+      return error_code;
+    }
+
+  scope_exit free_collector ([&]()
+  {
+    db_private_free_and_init (thread_p, collector.partsect_ftab);
+  });
+
+  try
+    {
+      vpids.clear ();
+      vpids.reserve ((std::size_t) collector.npages);
+
+      for (int sector_idx = 0; sector_idx < collector.nsects; sector_idx++)
+	{
+	  const FILE_PARTIAL_SECTOR &sector = collector.partsect_ftab[sector_idx];
+	  VPID vpid = { SECTOR_FIRST_PAGEID (sector.vsid.sectid), sector.vsid.volid };
+
+	  for (int page_offset = 0; page_offset < DISK_SECTOR_NPAGES; page_offset++, vpid.pageid++)
+	    {
+	      if (!bit64_is_set (sector.page_bitmap, page_offset))
+		{
+		  continue;
+		}
+	      if (hdr_vpid != NULL && !VPID_ISNULL (hdr_vpid) && VPID_EQ (&vpid, hdr_vpid))
+		{
+		  continue;
+		}
+	      vpids.push_back (vpid);
+	    }
+	}
+
+      std::sort (vpids.begin (), vpids.end (), [] (const VPID &left, const VPID &right)
+      {
+	return VPID_LT (&left, &right);
+      });
+    }
+  catch (const std::bad_alloc &)
+    {
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_OUT_OF_VIRTUAL_MEMORY, 1,
+	      (std::size_t) collector.npages * sizeof (VPID));
+      return ER_OUT_OF_VIRTUAL_MEMORY;
+    }
+
+  return NO_ERROR;
+}
+
+static int
 oos_stats_sync_bestspace (THREAD_ENTRY *thread_p, const VFID *vfid,
 			  OOS_HDR_STATS *oos_hdr, VPID *hdr_vpid,
 			  bool scan_all)
@@ -699,15 +761,18 @@ oos_stats_sync_bestspace (THREAD_ENTRY *thread_p, const VFID *vfid,
   int num_pages = 0;
   int num_recs = 0;
   float recs_sumlen = 0.0;
-  int start_idx = 1; /* Skip page 0 (header page) */
   int max_iterations;
-  int total_pages;
-
-  int err_sync = file_get_num_user_pages (thread_p, vfid, &total_pages);
-  if (err_sync != NO_ERROR || total_pages <= 1)
+  std::vector<VPID> data_vpids;
+  int error_code = oos_collect_data_page_vpids (thread_p, vfid, hdr_vpid, data_vpids);
+  if (error_code != NO_ERROR)
+    {
+      return error_code;
+    }
+  if (data_vpids.empty ())
     {
       return 0;
     }
+  const int total_pages = (int) data_vpids.size ();
 
   if (scan_all)
     {
@@ -726,11 +791,20 @@ oos_stats_sync_bestspace (THREAD_ENTRY *thread_p, const VFID *vfid,
 	}
     }
 
-  /* Determine start position */
+  std::size_t start_idx = 0;
   if (!VPID_ISNULL (&oos_hdr->estimates.full_search_vpid))
     {
-      /* TODO: ideally find the index of full_search_vpid; for now start from 1 */
-      start_idx = 1;
+      auto start_it = std::upper_bound (data_vpids.begin (), data_vpids.end (),
+					oos_hdr->estimates.full_search_vpid,
+					[] (const VPID &left, const VPID &right)
+      {
+	return VPID_LT (&left, &right);
+      });
+      start_idx = (std::size_t) (start_it - data_vpids.begin ());
+      if (start_idx == data_vpids.size ())
+	{
+	  start_idx = 0;
+	}
     }
 
   int iterations = 0;
@@ -745,27 +819,32 @@ oos_stats_sync_bestspace (THREAD_ENTRY *thread_p, const VFID *vfid,
 	}
     }
 
-  for (int i = start_idx; i < total_pages && iterations < max_iterations; i++, iterations++)
+  while (iterations < max_iterations && iterations < total_pages)
     {
-      VPID scan_vpid;
-      int err = file_numerable_find_nth (thread_p, vfid, i, false, NULL, NULL, &scan_vpid);
-      if (err != NO_ERROR || VPID_ISNULL (&scan_vpid))
-	{
-	  break;
-	}
+      VPID scan_vpid = data_vpids[ (start_idx + (std::size_t) iterations) % data_vpids.size ()];
+      iterations++;
+      oos_hdr->estimates.full_search_vpid = scan_vpid;
 
-      /* Skip header page (safety check) */
-      if (!VPID_ISNULL (hdr_vpid) && VPID_EQ (&scan_vpid, hdr_vpid))
-	{
-	  continue;
-	}
-
-      PAGE_PTR page_ptr = pgbuf_fix (thread_p, &scan_vpid, OLD_PAGE,
+      PAGE_PTR page_ptr = pgbuf_fix (thread_p, &scan_vpid, OLD_PAGE_MAYBE_DEALLOCATED,
 				     PGBUF_LATCH_READ, PGBUF_CONDITIONAL_LATCH);
       if (page_ptr == NULL)
 	{
-	  /* Page is busy — skip */
-	  er_clear ();
+	  int fix_error = er_errid ();
+	  if (fix_error == NO_ERROR || fix_error == ER_PB_BAD_PAGEID)
+	    {
+	      if (fix_error == ER_PB_BAD_PAGEID)
+		{
+		  perfmon_inc_stat (thread_p, PSTAT_OOS_NUM_BITMAP_SNAPSHOT_SKIPS);
+		}
+	      er_clear ();
+	      continue;
+	    }
+	  return fix_error;
+	}
+      if (pgbuf_get_page_ptype (thread_p, page_ptr) != PAGE_OOS)
+	{
+	  perfmon_inc_stat (thread_p, PSTAT_OOS_NUM_BITMAP_SNAPSHOT_SKIPS);
+	  pgbuf_unfix_and_init (thread_p, page_ptr);
 	  continue;
 	}
 
@@ -807,9 +886,6 @@ oos_stats_sync_bestspace (THREAD_ENTRY *thread_p, const VFID *vfid,
 	      num_other_high_best++;
 	    }
 	}
-
-      /* Save resume point */
-      oos_hdr->estimates.full_search_vpid = scan_vpid;
     }
 
   /* On full scan, clear stale best[] entries with freespace below the threshold.
@@ -979,7 +1055,7 @@ oos_create_file_internal (THREAD_ENTRY *thread_p, FILE_DESCRIPTORS des, VFID &oo
   tablespace.expand_max_size = DISK_SECTOR_NPAGES * DB_PAGESIZE * 1024;
 
   err = file_create (thread_p, FILE_OOS, &tablespace, &des,
-		     false /* is_temp */, true /* is_numerable */, &oos_vfid);
+		     false /* is_temp */, false /* is_numerable */, &oos_vfid);
   if (err != NO_ERROR)
     {
       oos_error ("file_create failed");
@@ -1547,6 +1623,16 @@ oos_insert_within_page (THREAD_ENTRY *thread_p, const VFID &oos_vfid, oos_buffer
   assert (required_length <= DB_ALIGN_BELOW (spage_max_record_size (), OOS_ALIGNMENT));
 
   auto auto_page_ptr = oos_find_best_page (thread_p, oos_vfid, required_length, vpid);
+  if (auto_page_ptr == nullptr)
+    {
+      err = er_errid ();
+      if (err == NO_ERROR)
+	{
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
+	  err = ER_GENERIC_ERROR;
+	}
+      return err;
+    }
   PAGE_PTR page_ptr = auto_page_ptr.get ();
   err = oos_insert_record_in_fixed_page (thread_p, oos_vfid, page_ptr, vpid, src, header, oid);
   if (err != NO_ERROR)
@@ -1975,6 +2061,8 @@ oos_find_best_page (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const int rec_
 
       if (ratio >= OOS_BESTSPACE_SYNC_THRESHOLD)
 	{
+	  VPID sync_cursor = oos_hdr->estimates.full_search_vpid;
+
 	  /* Release header latch before sync scan to reduce contention.
 	   * Sync only updates the global hash cache (not best[]),
 	   * so we don't need the header page during the scan. */
@@ -1989,10 +2077,15 @@ oos_find_best_page (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const int rec_
 
 	  /* Sync scan — populates global cache only.
 	   * We pass a temporary OOS_HDR_STATS to collect scan stats,
-	   * and discard the header-specific updates. */
+	   * and preserve only the partial-scan resume point. */
 	  OOS_HDR_STATS tmp_hdr;
 	  memset (&tmp_hdr, 0, sizeof (tmp_hdr));
-	  (void) oos_stats_sync_bestspace (thread_p, &oos_vfid, &tmp_hdr, &hdr_vpid, false);
+	  tmp_hdr.estimates.full_search_vpid = sync_cursor;
+	  int sync_result = oos_stats_sync_bestspace (thread_p, &oos_vfid, &tmp_hdr, &hdr_vpid, false);
+	  if (sync_result < 0)
+	    {
+	      return nullptr;
+	    }
 
 	  /* Re-acquire header latch after sync */
 	  hdr_page = pgbuf_fix (thread_p, &hdr_vpid, OLD_PAGE,
@@ -2011,6 +2104,11 @@ oos_find_best_page (THREAD_ENTRY *thread_p, const VFID &oos_vfid, const int rec_
 	      pgbuf_unfix_and_init (thread_p, hdr_page);
 	      return oos_file_alloc_new (thread_p, oos_vfid, vpid);
 	    }
+
+	  oos_hdr->estimates.full_search_vpid = tmp_hdr.estimates.full_search_vpid;
+	  addr.pgptr = hdr_page;
+	  log_skip_logging (thread_p, &addr);
+	  pgbuf_set_dirty (thread_p, hdr_page, DONT_FREE);
 	}
       else
 	{
@@ -2528,28 +2626,38 @@ oos_get_stats_by_vfid (THREAD_ENTRY *thread_p, const VFID &oos_vfid, OOS_STATS_I
       return er_errid ();
     }
 
+  std::vector<VPID> data_vpids;
+  int collect_error = oos_collect_data_page_vpids (thread_p, &oos_vfid, &hdr_vpid, data_vpids);
+  if (collect_error != NO_ERROR)
+    {
+      return collect_error;
+    }
+
   INT64 total_recs = 0;
   INT64 total_sumlen = 0;
-  for (int i = 0; i < num_user_pages; i++)
+  for (const VPID &scan_vpid : data_vpids)
     {
-      VPID scan_vpid;
-      if (file_numerable_find_nth (thread_p, &oos_vfid, i, false, NULL, NULL, &scan_vpid) != NO_ERROR
-	  || VPID_ISNULL (&scan_vpid))
-	{
-	  er_clear ();
-	  continue;
-	}
-      if (!VPID_ISNULL (&hdr_vpid) && VPID_EQ (&scan_vpid, &hdr_vpid))
-	{
-	  continue;		/* skip header page — no user records */
-	}
-
-      PAGE_PTR page_ptr = pgbuf_fix (thread_p, &scan_vpid, OLD_PAGE,
+      PAGE_PTR page_ptr = pgbuf_fix (thread_p, &scan_vpid, OLD_PAGE_MAYBE_DEALLOCATED,
 				     PGBUF_LATCH_READ, PGBUF_CONDITIONAL_LATCH);
       if (page_ptr == NULL)
 	{
-	  er_clear ();
-	  continue;		/* page busy — accept a slight undercount */
+	  int fix_error = er_errid ();
+	  if (fix_error == NO_ERROR || fix_error == ER_PB_BAD_PAGEID)
+	    {
+	      if (fix_error == ER_PB_BAD_PAGEID)
+		{
+		  perfmon_inc_stat (thread_p, PSTAT_OOS_NUM_BITMAP_SNAPSHOT_SKIPS);
+		}
+	      er_clear ();
+	      continue;		/* page busy or reclaimed — accept a slight undercount */
+	    }
+	  return fix_error;
+	}
+      if (pgbuf_get_page_ptype (thread_p, page_ptr) != PAGE_OOS)
+	{
+	  perfmon_inc_stat (thread_p, PSTAT_OOS_NUM_BITMAP_SNAPSHOT_SKIPS);
+	  pgbuf_unfix_and_init (thread_p, page_ptr);
+	  continue;
 	}
 
       /* Walk slots explicitly: spage_collect_statistics skips slot 0 (a heap-page

--- a/unit_tests/oos/test_oos_bestspace.cpp
+++ b/unit_tests/oos/test_oos_bestspace.cpp
@@ -954,12 +954,13 @@ TEST (OosBestspaceTest, BestspaceHeaderPageNeverReturned)
 
 
 // ===========================================================================
-// TEST: BestspaceSyncRefillsCache
+// TEST: BestspaceSectorBitmapSyncAcrossSectors
 //
-// Create a file with multiple pages, clear the global cache, then verify
-// that sync_bestspace repopulates the cache so find_best_page succeeds.
+// Grow a non-numerable OOS file beyond one disk sector, free space in selected
+// pages, clear the global cache, then verify sector-bitmap scans repopulate
+// bestspace and collect complete OOS statistics.
 // ===========================================================================
-TEST (OosBestspaceTest, BestspaceSyncRefillsCache)
+TEST (OosBestspaceTest, BestspaceSectorBitmapSyncAcrossSectors)
 {
   int err;
   VFID oos_vfid;
@@ -969,14 +970,16 @@ TEST (OosBestspaceTest, BestspaceSyncRefillsCache)
 
   const int max_chunk = bridge_oos_get_max_chunk_size_within_page ();
 
-  // Create multiple pages with some free space by inserting medium records
-  const int medium_size = max_chunk / 2;
+  // A near-maximum record consumes one page. Crossing DISK_SECTOR_NPAGES
+  // guarantees the collector must enumerate at least two sector bitmaps.
+  const int record_size = max_chunk - 50;
+  const int num_records = DISK_SECTOR_NPAGES + 5;
   std::vector<OID> oids;
-  std::set<PAGEID> original_pages;
+  std::set<PAGEID> reusable_pages;
 
-  for (int i = 0; i < 5; i++)
+  for (int i = 0; i < num_records; i++)
     {
-      auto data = test_oos_utils::make_repeated_pattern_string (medium_size);
+      auto data = test_oos_utils::make_repeated_pattern_string (record_size);
       RECDES rec{};
       err = test_oos_utils::from_string_into_recdes (data, rec);
       ASSERT_EQ (err, NO_ERROR);
@@ -985,13 +988,26 @@ TEST (OosBestspaceTest, BestspaceSyncRefillsCache)
       err = test_oos_utils::oos_insert_from_recdes (thread_p, oos_vfid, rec, oid);
       ASSERT_EQ (err, NO_ERROR);
       oids.push_back (oid);
-      original_pages.insert (oid.pageid);
       recdes_free_data_area (&rec);
     }
 
-  test_oos_debug ("Created %d pages with medium records", (int) original_pages.size ());
+  std::set<PAGEID> allocated_pages;
+  for (const OID &oid : oids)
+    {
+      allocated_pages.insert (oid.pageid);
+    }
+  ASSERT_EQ ((int) allocated_pages.size (), num_records);
 
-  // Delete all cached entries for these pages from the global cache
+  // Free space in a page in each part of the scan range. oos_delete publishes these
+  // pages to the cache, so remove them below to force sync to rediscover them.
+  for (int i = 0; i < num_records; i += 16)
+    {
+      err = oos_delete (thread_p, oos_vfid, oids[i]);
+      ASSERT_EQ (err, NO_ERROR);
+      reusable_pages.insert (oids[i].pageid);
+    }
+
+  // Delete all cached entries so only the sector-bitmap sync can repopulate them.
   for (auto &oid : oids)
     {
       VPID vpid = {oid.pageid, oid.volid};
@@ -1020,8 +1036,15 @@ TEST (OosBestspaceTest, BestspaceSyncRefillsCache)
   // Run sync to repopulate
   int found = bridge_oos_stats_sync_bestspace (thread_p, &oos_vfid, oos_hdr, &hdr_vpid, true);
   test_oos_debug ("sync_bestspace found %d pages with good free space", found);
+  ASSERT_GE (found, (int) reusable_pages.size ());
 
   pgbuf_unfix_and_init (thread_p, hdr_page);
+
+  OOS_STATS_INFO stats;
+  err = oos_get_stats_by_vfid (thread_p, oos_vfid, &stats);
+  ASSERT_EQ (err, NO_ERROR);
+  ASSERT_EQ (stats.num_recs, num_records - (int) reusable_pages.size ());
+  ASSERT_GT (stats.recs_sumlen, 0);
 
   // Now find_best_page should succeed (sync repopulated cache)
   VPID found_vpid{NULL_PAGEID, NULL_VOLID};
@@ -1029,9 +1052,11 @@ TEST (OosBestspaceTest, BestspaceSyncRefillsCache)
   ASSERT_NE (page, nullptr);
   ASSERT_NE (found_vpid.pageid, NULL_PAGEID);
 
-  // The found page should be one of the original pages (which still have space)
-  ASSERT_TRUE (original_pages.count (found_vpid.pageid) > 0)
-      << "sync did not find any of the original pages";
+  // The found page must be one of the pages freed before the scan.
+  ASSERT_TRUE (reusable_pages.count (found_vpid.pageid) > 0)
+      << "sector-bitmap sync did not find a reusable OOS page";
+
+  page.reset ();
 
   err = oos_remove_file (thread_p, oos_vfid);
   ASSERT_EQ (err, NO_ERROR);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26831

## Purpose

OOS 파일은 논리적 N번째 page 조회나 numerable 전용 API를 필요로 하지 않으므로, POC 단계에서 사용한 numerable file 계약을 제거합니다.

| AS-IS | TO-BE |
|---|---|
| OOS를 numerable file로 생성하고 page 할당/해제 시 user-page table도 유지 | OOS를 항상 non-numerable file로 생성하고 sector allocation bitmap만 유지 |
| best-space 및 통계 scan이 `file_numerable_find_nth()`에 의존 | data-sector bitmap snapshot으로 할당 page를 순회 |

## Implementation

- `file_get_all_data_sectors()` 결과를 전개해 OOS header를 제외한 data VPID를 정렬하는 공통 helper를 추가했습니다.
- best-space partial scan은 기존 20%/최소 10/최대 100 page 제한과 resume/wrap-around 진행을 유지합니다.
- 통계 전체 scan도 동일한 sector-bitmap 순회로 전환했습니다.
- snapshot 이후 deallocation race는 `OLD_PAGE_MAYBE_DEALLOCATED`와 `ER_PB_BAD_PAGEID` skip으로 처리하고, fix된 page의 `PAGE_OOS` type을 확인합니다.
- snapshot skip 횟수를 `Num_oos_bitmap_snapshot_skips` 성능 통계로 추가했습니다.
- 한 sector를 넘는 파일에서 best-space 재구축과 live-record 통계를 함께 검증합니다.

## Remarks

- 기존 numerable OOS 파일은 POC 전용이므로 호환·변환 경로를 제공하지 않으며 테스트/개발 DB를 재생성합니다.
- Debug GCC server/standalone 빌드와 OOS CTest suite 25/25를 통과했습니다.
- 상세 설계 및 실행 결과: [CBRD-26831 OOS non-numerable migration](https://github.com/vimkim/my-cubrid-docs/blob/main/cbrd-26831/CBRD-26831-oos-non-numerable_bb5e61d8b_codex.md)
