### PR TITLE
[CBRD-27169] Transitive propagation missed for ON clause terms

### DIFF
--- a/src/optimizer/rewriter/query_rewrite.h
+++ b/src/optimizer/rewriter/query_rewrite.h
@@ -141,6 +141,7 @@ PT_NODE *qo_analyze_path_join_pre (PARSER_CONTEXT * parser, PT_NODE * spec, void
 PT_NODE *qo_analyze_path_join (PARSER_CONTEXT * parser, PT_NODE * path_spec, void *arg, int *continue_walk);
 bool qo_check_generate_single_tbl_connect_by (PARSER_CONTEXT * parser, PT_NODE * node);
 bool qo_rewrite_select_queries (PARSER_CONTEXT * parser, PT_NODE ** nodep, PT_NODE ** wherep, int *seqno);
+PT_NODE *qo_rewrite_innerjoin (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);
 void qo_move_on_of_explicit_join_to_where (PARSER_CONTEXT * parser, PT_NODE ** fromp, PT_NODE ** wherep);
 void qo_rewrite_index_hints (PARSER_CONTEXT * parser, PT_NODE * statement);
 void qo_rewrite_nonnull_count_select_list (PARSER_CONTEXT * parser, PT_NODE * select);

--- a/src/optimizer/rewriter/query_rewrite_select.c
+++ b/src/optimizer/rewriter/query_rewrite_select.c
@@ -46,7 +46,6 @@ static void qo_reduce_predicate_for_parent_spec (PARSER_CONTEXT * parser, PT_NOD
 						 QO_REDUCE_REFERENCE_INFO * reduce_reference_info);
 static int qo_reduce_order_by (PARSER_CONTEXT * parser, PT_NODE * node);
 static PT_NODE *qo_rewrite_oid_equality (PARSER_CONTEXT * parser, PT_NODE * node, PT_NODE * pred, int *seqno);
-static PT_NODE *qo_rewrite_innerjoin (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);
 static PT_NODE *qo_rewrite_outerjoin (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);
 static PT_NODE *qo_get_next_oid_pred (PT_NODE * pred);
 
@@ -3526,8 +3525,9 @@ qo_reset_location (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *cont
  *
  * Note: If join order hint is set, skip and go ahead.
  *   do parser_walk_tree() pre function
+ *   Also called from qo_reduce_equality_terms_post (), which needs the location reset. Calling it twice is harmless.
  */
-static PT_NODE *
+PT_NODE *
 qo_rewrite_innerjoin (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk)
 {
   PT_NODE *spec, *spec2;

--- a/src/optimizer/rewriter/query_rewrite_term.c
+++ b/src/optimizer/rewriter/query_rewrite_term.c
@@ -990,6 +990,16 @@ qo_reduce_equality_terms_post (PARSER_CONTEXT * parser, PT_NODE * node, void *ar
 
   if (node->node_type == PT_SELECT)
     {
+      if (!node->flag.done_reduce_equality_terms && node->info.query.q.select.connect_by == NULL)
+	{
+	  int continue_innerjoin;
+
+	  qo_move_on_of_explicit_join_to_where (parser, &node->info.query.q.select.from,
+						&node->info.query.q.select.where);
+	  node->info.query.q.select.where = pt_cnf (parser, node->info.query.q.select.where);
+	  qo_rewrite_innerjoin (parser, node, NULL, &continue_innerjoin);
+	}
+
       wherep = &node->info.query.q.select.where;
       QO_CHECK_AND_REDUCE_EQUALITY_TERMS (parser, node, wherep);
     }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27169>

### Purpose

ANSI JOIN의 ON 절에 작성한 상수 조건이 조인 조건으로 이행되지 않습니다.

    -- t2.b = 'X' 와 t2.b = t3.b 로부터 t3.b = 'X' 를 유도할 수 있으나 생성되지 않음
    SELECT ... FROM t1
      INNER JOIN t2 ON t1.a = t2.a AND t2.b = 'X'
      INNER JOIN t3 ON t2.b = t3.b;
    -- rewritten : where t1.a=t2.a and t2.b=t3.b and t2.b= ?:0

같은 상수를 t3의 ON 절로 옮기면 이행됩니다. 반대로 이행되던 쿼리를 인라인뷰로
감싸고 바깥에 조건절을 두면 다시 이행되지 않습니다. 어느 쪽이든 결과는 같고
재작성된 쿼리만 달라집니다.

원인이 다른 두 가지 경우가 있습니다.

1. 상수 조건과 조인 조건을 서로 다른 ON 절에 작성한 경우.
2. 인라인뷰 내부 ON 절에 작성하고, 바깥 쿼리에 조건절이 있는 경우.
   `WHERE 1=1`, 조건절, 바깥 `JOIN ... ON`, 단독 `LIMIT` 모두 해당됩니다.

### Implementation

`qo_reduce_equality_terms ()` 는 WHERE 목록만 보고 동작하며, 위치 정보가 같은
조건들 사이에서만 상수를 치환합니다. 두 조건 모두 `qo_rewrite_queries ()` 가
갖춰 주지만 순서가 항상 보장되지는 않습니다. 그런데 이행은 쿼리마다 한 번만
실행되므로(`done_reduce_equality_terms`), 준비가 덜 된 상태에서 한 번 실행되면
이후 다시 시도되지 않습니다.

* ON 절 조건은 각 쿼리의 재작성 차례가 시작될 때
  `qo_move_on_of_explicit_join_to_where ()` 가 WHERE 로 병합합니다. 그런데
  `qo_rewrite_queries ()` 의 post-order walk 가 하위 SELECT 를 그 차례보다 먼저
  방문할 수 있고, 이때는 WHERE 목록이 비어 있습니다. (2번 원인)
* INNER JOIN 만으로 구성된 구간의 위치 정보는 `qo_rewrite_innerjoin ()` 이 0 으로
  초기화합니다. 이 함수는 `qo_rewrite_select_queries ()` 에서 호출되어 이행보다
  나중에 실행되므로, `pt_lambda_node ()` 의 위치 일치 검사에서 치환이 거부됩니다.
  (1번 원인)

두 선행 처리를 `qo_reduce_equality_terms_post ()` 에서 이행 직전에 수행하도록
했습니다. 이를 위해 `qo_rewrite_innerjoin ()` 의 static 선언을 제거했습니다.

기존 호출 위치는 그대로 두었습니다. 두 함수 모두 처리할 대상이 남아 있을 때만
동작하므로 나중 호출은 아무 일도 하지 않고, `qo_rewrite_queries ()` 에서 병합을
제거하면 `if (*wherep)` 가 거짓이 되어 이행 자체가 실행되지 않습니다.

기존 동작은 그대로 유지됩니다. OUTER JOIN 이 포함된 구간은 위치 정보를 유지하므로
OUTER JOIN 의미가 바뀌지 않고, ORDERED 힌트도 여전히 조인 재작성을 막습니다.
계층 질의는 자기 차례에 `pt_split_join_preds ()` 가 WHERE 를 분리해야 하므로
제외했습니다.

### Remarks

N/A

