### PR TITLE
[CUBRIDQA-1506] CI: build the debug package on the runner node for shell tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -654,15 +654,22 @@ jobs:
           no_output_timeout: 30m
           command: |
             set -eo pipefail
+            : "${BUILD_CACHE_ROOT:?}" "${BUILD_SENTINEL:?}"
             dir="${BUILD_CACHE_ROOT}/${CIRCLE_SHA1}/debug"
             tmp="${dir}.tmp.${CIRCLE_BUILD_NUM}"
             rm -rf "$tmp"
             mkdir -p "$tmp"
             cp -a /home/CUBRID "$tmp/CUBRID"
             touch "$tmp/${BUILD_SENTINEL}"
-            # One rename publishes it, so a consumer never sees a half-copied
-            # tree and a run that loses the rename drops its staging dir.
-            mv -T "$tmp" "$dir" 2> /dev/null || rm -rf "$tmp"
+            # One rename publishes it, so a consumer never sees a half-copied tree.
+            if ! mv -T "$tmp" "$dir"; then
+              rm -rf "$tmp"
+              # Only a run that published first may be ignored; it left the
+              # sentinel. Any other mv failure published nothing, so fail here
+              # rather than let test_shell wait for a build that never lands.
+              test -f "${dir}/${BUILD_SENTINEL}"
+              echo "Another run published this commit first"
+            fi
             df -h /home/build-cache
       - collect-build-logs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -652,12 +652,13 @@ jobs:
               || { echo "[error] ${CIRCLE_SHA1} is not reachable from ${head_ref}"; exit 1; }
 
             git -C /home/cubrid checkout --quiet --detach "$CIRCLE_SHA1"
-            git -C /home/cubrid submodule init
 
-            # Take each submodule from its mirror only when the mirror has the
-            # pinned commit. The mirror is never refreshed from here, so a bump
-            # pins one it has not seen, and that must cost a fetch rather than
-            # the whole build.
+            # What the submodules command runs, with one thing inserted: a URL
+            # is repointed at the mirror when the mirror holds the commit this
+            # revision pins. Objects are content-addressed, so that changes
+            # where the bytes come from and not the tree they produce.
+            git -C /home/cubrid submodule sync
+            git -C /home/cubrid submodule init
             while read -r key url; do
               name=${key#submodule.}; name=${name%.url}
               path=$(git -C /home/cubrid config -f .gitmodules --get "submodule.${name}.path")
@@ -666,13 +667,16 @@ jobs:
               if git -C "$mirror" cat-file -e "${want}^{commit}" 2> /dev/null; then
                 git -C /home/cubrid config "submodule.${name}.url" "$mirror"
               else
-                echo "[warn] ${path} ${want} is not in the mirror; taking it from ${url} over the WAN"
+                # The mirror is a seed nothing refreshes, so a submodule bumped
+                # after it was taken comes over the WAN in full until someone
+                # re-seeds. Sizes: cci 28MB, jdbc 1.5MB, manager-server 67MB.
+                echo "[warn] ${path} ${want} is not in the mirror; cloning it from ${url} over the WAN"
               fi
             done < <(git -C /home/cubrid config --get-regexp '^submodule\..*\.url')
 
             # protocol.file.allow: since git 2.38 a submodule may not be cloned
             # from a path, which is exactly what the rewrite above produces.
-            git -C /home/cubrid -c protocol.file.allow=always submodule update --quiet
+            git -C /home/cubrid -c protocol.file.allow=always submodule update
             echo "[debug] source ${CIRCLE_SHA1}, build serial $(git -C /home/cubrid rev-list --count --after 2019-12-12 HEAD)"
       - run:
           name: Build the debug package

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -616,80 +616,48 @@ jobs:
               exit 0
             fi
       - run:
-          name: Sync the source mirror
-          no_output_timeout: 30m
-          command: |
-            set -eo pipefail
-            : "${BUILD_MIRROR:?}"
-            mkdir -p "$BUILD_MIRROR"
-
-            # Advisory: git locks its own refs, so a missing flock or a
-            # filesystem that ignores it costs a retry, not correctness.
-            if command -v flock > /dev/null; then
-              exec 9> "$BUILD_MIRROR/.lock"
-              flock -w 900 9 || echo "[warn] mirror lock timed out; continuing"
-            fi
-
-            # Not $$: that is a container PID, and two pods staging into the
-            # same shared directory can easily hold the same one.
-            stage=${CIRCLE_BUILD_NUM}
-
-            sync_mirror() {
-              local dir=$1 url=$2 repo; shift 2
-              repo="$BUILD_MIRROR/$dir"
-              if [ ! -d "$repo" ]; then
-                echo "[warn] no mirror at $repo; seeding it from $url over the WAN (one full clone)"
-                rm -rf "$repo.tmp.$stage"
-                # --progress, not --quiet: git prints none unless asked when
-                # stderr is not a tty, and a silent 745MB clone on a shared
-                # 30Mbps line trips the step's no-output timeout.
-                git clone --bare --progress "$url" "$repo.tmp.$stage" || { rm -rf "$repo.tmp.$stage"; return 1; }
-                mv -T "$repo.tmp.$stage" "$repo" 2> /dev/null || rm -rf "$repo.tmp.$stage"
-              fi
-              # Never let a repack run: the build tree clones --shared, so it
-              # reads this repo's packs from start to finish.
-              git -C "$repo" config gc.auto 0 || return 1
-              git -C "$repo" fetch --quiet origin "$@"
-            }
-
-            # A pull request head lives under refs/pull, which a bare clone of
-            # the fork point never carries -- fetch it by name, every run.
-            refspecs=( '+refs/heads/develop:refs/heads/develop' )
-            case "$CIRCLE_BRANCH" in
-              pull/*) refspecs+=( "+refs/${CIRCLE_BRANCH}:refs/${CIRCLE_BRANCH}" ) ;;
-              ?*)     refspecs+=( "+refs/heads/${CIRCLE_BRANCH}:refs/heads/${CIRCLE_BRANCH}" ) ;;
-            esac
-            sync_mirror cubrid.git https://github.com/CUBRID/cubrid.git "${refspecs[@]}"
-
-            # Advisory, unlike cubrid.git: the tree step decides per submodule
-            # whether the mirror has the pinned commit, so a mirror we cannot
-            # reach costs bandwidth rather than the build.
-            for url in https://github.com/CUBRID/cubrid-cci.git \
-                       https://github.com/cubrid/cubrid-jdbc \
-                       https://github.com/CUBRID/cubrid-manager-server; do
-              sync_mirror "$(basename "${url%.git}").git" "$url" '+refs/heads/*:refs/heads/*' \
-                || echo "[warn] could not sync the mirror for ${url}"
-            done
-
-            git -C "$BUILD_MIRROR/cubrid.git" cat-file -e "${CIRCLE_SHA1}^{commit}" 2> /dev/null \
-              || { echo "[error] ${CIRCLE_SHA1} is not in the mirror after fetching ${CIRCLE_BRANCH}"; exit 1; }
-      - run:
           name: Prepare the source tree
+          no_output_timeout: 30m
           command: |
             set -eo pipefail
             : "${BUILD_MIRROR:?}"
             rm -rf /home/cubrid
 
-            # --shared, so this borrows the mirror's objects instead of copying
-            # 745MB per run. Full history: the build number counts commits, and
+            # Read-only against the mirror: many pods share it, so fetching
+            # into it would need a lock they all honour, and a pod killed
+            # mid-fetch would leave a ref lock that stops every later build.
+            # This run's increment goes into the clone below instead -- 2MB
+            # against a week-old mirror, 8MB against a 90-day-old one.
+            #
+            # --shared borrows the mirror's objects rather than copying 745MB.
+            # It also means the mirror must never be repacked while a build
+            # holds a clone; the seed sets gc.auto=0 for that.
+            if [ -d "$BUILD_MIRROR/cubrid.git" ]; then
+              git clone --quiet --shared --no-checkout "$BUILD_MIRROR/cubrid.git" /home/cubrid
+            else
+              # --progress: git prints none unless asked when stderr is not a
+              # tty, and a silent full clone would trip the no-output timeout.
+              echo "[warn] no mirror at $BUILD_MIRROR/cubrid.git; cloning the full history over the WAN"
+              git clone --progress --no-checkout https://github.com/CUBRID/cubrid.git /home/cubrid
+            fi
+
+            # Full history, never shallow: the build number counts commits, and
             # a shallow clone would quietly stamp the package 0001.
-            git clone --quiet --shared --no-checkout "$BUILD_MIRROR/cubrid.git" /home/cubrid
+            case "$CIRCLE_BRANCH" in
+              pull/*) head_ref="refs/${CIRCLE_BRANCH}" ;;
+              *)      head_ref="refs/heads/${CIRCLE_BRANCH}" ;;
+            esac
+            git -C /home/cubrid fetch --quiet https://github.com/CUBRID/cubrid.git "+${head_ref}:refs/ci/head"
+            git -C /home/cubrid cat-file -e "${CIRCLE_SHA1}^{commit}" 2> /dev/null \
+              || { echo "[error] ${CIRCLE_SHA1} is not reachable from ${head_ref}"; exit 1; }
+
             git -C /home/cubrid checkout --quiet --detach "$CIRCLE_SHA1"
             git -C /home/cubrid submodule init
 
-            # Take each submodule from its mirror only when the mirror already
-            # has the pinned commit: a bump pins one that is not on develop yet,
-            # and that must cost a fetch rather than the whole build.
+            # Take each submodule from its mirror only when the mirror has the
+            # pinned commit. The mirror is never refreshed from here, so a bump
+            # pins one it has not seen, and that must cost a fetch rather than
+            # the whole build.
             while read -r key url; do
               name=${key#submodule.}; name=${name%.url}
               path=$(git -C /home/cubrid config -f .gitmodules --get "submodule.${name}.path")

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,8 +53,27 @@ executors:
       # GlusterFS build layout contract, defined once for both sides:
       # download-build publishes <root>/<sha>/<mode>/CUBRID + sentinel,
       # test_shell waits on the sentinel and mounts that tree.
-      BUILD_CACHE_ROOT: /home/build-cache/builds
-      BUILD_SENTINEL: .complete
+      BUILD_CACHE_ROOT: &build_cache_root /home/build-cache/builds
+      BUILD_SENTINEL: &build_sentinel .complete
+
+  # CUBRIDQA-1506, temporary. The Helm values pin cubridci:test_shell on this
+  # resource class; the image named here wins, so building on it needs no
+  # runner-side change.
+  cubrid-build-node:
+    docker:
+      - image: cubridci/cubridci:rl8.10
+    resource_class: cubrid/ramdisk
+    working_directory: /home
+    environment:
+      BUILD_CACHE_ROOT: *build_cache_root
+      BUILD_SENTINEL: *build_sentinel
+      BUILD_MIRROR: /home/build-cache/cubrid-mirror
+      CCACHE_DIR: /home/build-cache/ccache-shell-debug
+      # This cache lives on GlusterFS and the build tree does not, so no
+      # CCACHE_HARDLINK here -- it would silently fall back to copying. The
+      # image already exports CC/CXX through ccache. Content, not mtime: the
+      # image is pulled per node, and mtime would split the cache per node.
+      CCACHE_COMPILERCHECK: content
 
 commands:
   submodules:
@@ -478,12 +497,12 @@ jobs:
           mode: optdebug
           build-args: "-m optdebug"
       # Package when a test job will consume it, or on develop for preservation.
+      # Not for shell: it builds on its own node now (CUBRIDQA-1506).
       - when:
           condition:
             or:
               - << pipeline.parameters.run_sql_test >>
               - << pipeline.parameters.run_medium_test >>
-              - << pipeline.parameters.run_shell_test >>
               - equal: [ develop, << pipeline.git.branch >> ]
           steps:
             - package-build:
@@ -568,6 +587,177 @@ jobs:
                 root: /tmp/tcws
                 paths: [ BRANCH_TESTCASES ]
 
+  # CUBRIDQA-1506, temporary: stands in for download-build on the shell path
+  # and goes away with CircleCI (CUBRIDQA-1501).
+  build-debug-node:
+    description: "Build the debug package on the runner node and publish it to GlusterFS"
+    executor: cubrid-build-node
+    steps:
+      # Before the halt below: it ends the job as a success, so an early one
+      # would leave the shell pods with no branch and silently test develop.
+      - resolve-testcases:
+          tc-repo: cubrid-testcases-private-ex
+      - run:
+          name: Persist testcases branch for shell pods
+          command: |
+            mkdir -p /tmp/tcws
+            echo "$BRANCH_TESTCASES" > /tmp/tcws/BRANCH_TESTCASES
+      - persist_to_workspace:
+          root: /tmp/tcws
+          paths: [ BRANCH_TESTCASES ]
+      - run:
+          name: Reuse an existing build
+          command: |
+            set -eo pipefail
+            : "${BUILD_CACHE_ROOT:?}" "${BUILD_SENTINEL:?}"
+            if [ -f "${BUILD_CACHE_ROOT}/${CIRCLE_SHA1}/debug/${BUILD_SENTINEL}" ]; then
+              echo "[debug] ${CIRCLE_SHA1} is already published; skipping the build"
+              circleci-agent step halt
+              exit 0
+            fi
+      - run:
+          name: Sync the source mirror
+          no_output_timeout: 30m
+          command: |
+            set -eo pipefail
+            : "${BUILD_MIRROR:?}"
+            mkdir -p "$BUILD_MIRROR"
+
+            # Advisory: git locks its own refs, so a missing flock or a
+            # filesystem that ignores it costs a retry, not correctness.
+            if command -v flock > /dev/null; then
+              exec 9> "$BUILD_MIRROR/.lock"
+              flock -w 900 9 || echo "[warn] mirror lock timed out; continuing"
+            fi
+
+            # Not $$: that is a container PID, and two pods staging into the
+            # same shared directory can easily hold the same one.
+            stage=${CIRCLE_BUILD_NUM}
+
+            sync_mirror() {
+              local dir=$1 url=$2 repo; shift 2
+              repo="$BUILD_MIRROR/$dir"
+              if [ ! -d "$repo" ]; then
+                echo "[warn] no mirror at $repo; seeding it from $url over the WAN (one full clone)"
+                rm -rf "$repo.tmp.$stage"
+                # --progress, not --quiet: git prints none unless asked when
+                # stderr is not a tty, and a silent 745MB clone on a shared
+                # 30Mbps line trips the step's no-output timeout.
+                git clone --bare --progress "$url" "$repo.tmp.$stage" || { rm -rf "$repo.tmp.$stage"; return 1; }
+                mv -T "$repo.tmp.$stage" "$repo" 2> /dev/null || rm -rf "$repo.tmp.$stage"
+              fi
+              # Never let a repack run: the build tree clones --shared, so it
+              # reads this repo's packs from start to finish.
+              git -C "$repo" config gc.auto 0 || return 1
+              git -C "$repo" fetch --quiet origin "$@"
+            }
+
+            # A pull request head lives under refs/pull, which a bare clone of
+            # the fork point never carries -- fetch it by name, every run.
+            refspecs=( '+refs/heads/develop:refs/heads/develop' )
+            case "$CIRCLE_BRANCH" in
+              pull/*) refspecs+=( "+refs/${CIRCLE_BRANCH}:refs/${CIRCLE_BRANCH}" ) ;;
+              ?*)     refspecs+=( "+refs/heads/${CIRCLE_BRANCH}:refs/heads/${CIRCLE_BRANCH}" ) ;;
+            esac
+            sync_mirror cubrid.git https://github.com/CUBRID/cubrid.git "${refspecs[@]}"
+
+            # Advisory, unlike cubrid.git: the tree step decides per submodule
+            # whether the mirror has the pinned commit, so a mirror we cannot
+            # reach costs bandwidth rather than the build.
+            for url in https://github.com/CUBRID/cubrid-cci.git \
+                       https://github.com/cubrid/cubrid-jdbc \
+                       https://github.com/CUBRID/cubrid-manager-server; do
+              sync_mirror "$(basename "${url%.git}").git" "$url" '+refs/heads/*:refs/heads/*' \
+                || echo "[warn] could not sync the mirror for ${url}"
+            done
+
+            git -C "$BUILD_MIRROR/cubrid.git" cat-file -e "${CIRCLE_SHA1}^{commit}" 2> /dev/null \
+              || { echo "[error] ${CIRCLE_SHA1} is not in the mirror after fetching ${CIRCLE_BRANCH}"; exit 1; }
+      - run:
+          name: Prepare the source tree
+          command: |
+            set -eo pipefail
+            : "${BUILD_MIRROR:?}"
+            rm -rf /home/cubrid
+
+            # --shared, so this borrows the mirror's objects instead of copying
+            # 745MB per run. Full history: the build number counts commits, and
+            # a shallow clone would quietly stamp the package 0001.
+            git clone --quiet --shared --no-checkout "$BUILD_MIRROR/cubrid.git" /home/cubrid
+            git -C /home/cubrid checkout --quiet --detach "$CIRCLE_SHA1"
+            git -C /home/cubrid submodule init
+
+            # Take each submodule from its mirror only when the mirror already
+            # has the pinned commit: a bump pins one that is not on develop yet,
+            # and that must cost a fetch rather than the whole build.
+            while read -r key url; do
+              name=${key#submodule.}; name=${name%.url}
+              path=$(git -C /home/cubrid config -f .gitmodules --get "submodule.${name}.path")
+              mirror="${BUILD_MIRROR}/$(basename "${url%.git}").git"
+              want=$(git -C /home/cubrid rev-parse "HEAD:${path}")
+              if git -C "$mirror" cat-file -e "${want}^{commit}" 2> /dev/null; then
+                git -C /home/cubrid config "submodule.${name}.url" "$mirror"
+              else
+                echo "[warn] ${path} ${want} is not in the mirror; taking it from ${url} over the WAN"
+              fi
+            done < <(git -C /home/cubrid config --get-regexp '^submodule\..*\.url')
+
+            # protocol.file.allow: since git 2.38 a submodule may not be cloned
+            # from a path, which is exactly what the rewrite above produces.
+            git -C /home/cubrid -c protocol.file.allow=always submodule update --quiet
+            echo "[debug] source ${CIRCLE_SHA1}, build serial $(git -C /home/cubrid rev-list --count --after 2019-12-12 HEAD)"
+      - run:
+          name: Build the debug package
+          no_output_timeout: 45m
+          command: |
+            set -eo pipefail
+            : "${CCACHE_DIR:?}"
+            mkdir -p "$CCACHE_DIR"
+            ccache --max-size=5G
+            ccache -z
+            # From the source root. The entrypoint decides whether the build
+            # failed by reading ./build.log, which it only writes there when
+            # build.sh is in the current directory; run from /home it reads a
+            # path that does not exist and calls a failed build a success.
+            cd /home/cubrid
+            /entrypoint.sh build -m optdebug
+            ccache -s
+      - run:
+          name: Publish the build to GlusterFS
+          # cp -a of the built tree to GlusterFS prints nothing while it runs.
+          no_output_timeout: 30m
+          command: |
+            set -eo pipefail
+            : "${BUILD_CACHE_ROOT:?}" "${BUILD_SENTINEL:?}"
+            build_dir="${BUILD_CACHE_ROOT}/${CIRCLE_SHA1}/debug"
+
+            # Stage, then publish with one atomic rename: consumers never see a
+            # half-copied tree, and a run that loses the rename drops its
+            # staging dir instead of touching the published one.
+            tmp_dir="${build_dir}.tmp.${CIRCLE_BUILD_NUM}"
+            rm -rf "$tmp_dir"
+            mkdir -p "$tmp_dir"
+            cp -a /home/CUBRID "${tmp_dir}/CUBRID"
+            touch "${tmp_dir}/${BUILD_SENTINEL}"
+            if mv -T "$tmp_dir" "$build_dir" 2> /dev/null; then
+              echo "Build published at ${build_dir}"
+            else
+              echo "Another run published this build first, discarding staging dir"
+              rm -rf "$tmp_dir"
+            fi
+            ls -la "${build_dir}/CUBRID"
+            df -h /home/build-cache
+      - run:
+          name: Store build logs and commits
+          when: always
+          command: |
+            mkdir -p /tmp/build_logs
+            mv -f /home/cubrid/build.log /tmp/build_logs || true
+            git -C /home/cubrid log | head -n 1000 > /tmp/build_logs/commits.log || true
+      - store_artifacts:
+          path: /tmp/build_logs
+          when: always
+
 # Test jobs are gated by expression-based filters (evaluated server-side).
 workflows:
   build_test:
@@ -585,8 +775,11 @@ workflows:
           parallelism: 10
           requires: [build_debug]
           filters: pipeline.parameters.run_sql_test
-      - download-build:
-          requires: [build_debug]
+      # Keeps the name: it is the commit status context and what test_shell
+      # requires. No requires of its own -- not waiting for the cloud build is
+      # where the time goes (CUBRIDQA-1506).
+      - build-debug-node:
+          name: download-build
           filters: pipeline.parameters.run_shell_test
       - test_shell:
           requires: [download-build]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,22 +57,19 @@ executors:
       BUILD_SENTINEL: &build_sentinel .complete
 
   # CUBRIDQA-1506, temporary. The Helm values pin cubridci:test_shell on this
-  # resource class; the image named here wins, so building on it needs no
-  # runner-side change.
+  # resource class; the image named here wins, so this needs no runner change.
   cubrid-build-node:
     docker:
       - image: cubridci/cubridci:rl8.10
     resource_class: cubrid/ramdisk
-    working_directory: /home
+    working_directory: /home/cubrid
     environment:
       BUILD_CACHE_ROOT: *build_cache_root
       BUILD_SENTINEL: *build_sentinel
       BUILD_MIRROR: /home/build-cache/cubrid-mirror
       CCACHE_DIR: /home/build-cache/ccache-shell-debug
-      # This cache lives on GlusterFS and the build tree does not, so no
-      # CCACHE_HARDLINK here -- it would silently fall back to copying. The
-      # image already exports CC/CXX through ccache. Content, not mtime: the
-      # image is pulled per node, and mtime would split the cache per node.
+      # No CCACHE_HARDLINK: this cache is on GlusterFS and the build tree is
+      # not, so hardlinking would silently fall back to copying.
       CCACHE_COMPILERCHECK: content
 
 commands:
@@ -593,8 +590,6 @@ jobs:
     description: "Build the debug package on the runner node and publish it to GlusterFS"
     executor: cubrid-build-node
     steps:
-      # Before the halt below: it ends the job as a success, so an early one
-      # would leave the shell pods with no branch and silently test develop.
       - resolve-testcases:
           tc-repo: cubrid-testcases-private-ex
       - run:
@@ -606,129 +601,70 @@ jobs:
           root: /tmp/tcws
           paths: [ BRANCH_TESTCASES ]
       - run:
+          # Halting ends the job as a success, so the workspace above has to be
+          # written before it or the shell pods get no testcases branch.
           name: Reuse an existing build
           command: |
-            set -eo pipefail
-            : "${BUILD_CACHE_ROOT:?}" "${BUILD_SENTINEL:?}"
-            if [ -f "${BUILD_CACHE_ROOT}/${CIRCLE_SHA1}/debug/${BUILD_SENTINEL}" ]; then
-              echo "[debug] ${CIRCLE_SHA1} is already published; skipping the build"
-              circleci-agent step halt
-              exit 0
-            fi
+            [ -f "${BUILD_CACHE_ROOT}/${CIRCLE_SHA1}/debug/${BUILD_SENTINEL}" ] || exit 0
+            echo "[debug] ${CIRCLE_SHA1} is already published"
+            circleci-agent step halt
       - run:
-          name: Prepare the source tree
+          name: Check out the source
           no_output_timeout: 30m
           command: |
             set -eo pipefail
-            : "${BUILD_MIRROR:?}"
-            rm -rf /home/cubrid
-
-            # Read-only against the mirror: many pods share it, so fetching
-            # into it would need a lock they all honour, and a pod killed
-            # mid-fetch would leave a ref lock that stops every later build.
-            # This run's increment goes into the clone below instead -- 2MB
-            # against a week-old mirror, 8MB against a 90-day-old one.
-            #
-            # --shared borrows the mirror's objects rather than copying 745MB.
-            # It also means the mirror must never be repacked while a build
-            # holds a clone; the seed sets gc.auto=0 for that.
             if [ -d "$BUILD_MIRROR/cubrid.git" ]; then
-              git clone --quiet --shared --no-checkout "$BUILD_MIRROR/cubrid.git" /home/cubrid
+              git clone --quiet --shared --no-checkout "$BUILD_MIRROR/cubrid.git" .
             else
-              # --progress: git prints none unless asked when stderr is not a
-              # tty, and a silent full clone would trip the no-output timeout.
-              echo "[warn] no mirror at $BUILD_MIRROR/cubrid.git; cloning the full history over the WAN"
-              git clone --progress --no-checkout https://github.com/CUBRID/cubrid.git /home/cubrid
+              echo "[warn] no mirror at $BUILD_MIRROR; cloning the full history over the WAN"
+              git clone --progress --no-checkout https://github.com/CUBRID/cubrid.git .
             fi
+            # Never shallow: the build number counts commits, so a shallow
+            # clone would stamp the package 0001.
+            git fetch --quiet https://github.com/CUBRID/cubrid.git "$CIRCLE_SHA1"
+            git checkout --quiet --detach "$CIRCLE_SHA1"
 
-            # Full history, never shallow: the build number counts commits, and
-            # a shallow clone would quietly stamp the package 0001.
-            case "$CIRCLE_BRANCH" in
-              pull/*) head_ref="refs/${CIRCLE_BRANCH}" ;;
-              *)      head_ref="refs/heads/${CIRCLE_BRANCH}" ;;
-            esac
-            git -C /home/cubrid fetch --quiet https://github.com/CUBRID/cubrid.git "+${head_ref}:refs/ci/head"
-            git -C /home/cubrid cat-file -e "${CIRCLE_SHA1}^{commit}" 2> /dev/null \
-              || { echo "[error] ${CIRCLE_SHA1} is not reachable from ${head_ref}"; exit 1; }
-
-            git -C /home/cubrid checkout --quiet --detach "$CIRCLE_SHA1"
-
-            # What the submodules command runs, with one thing inserted: a URL
-            # is repointed at the mirror when the mirror holds the commit this
-            # revision pins. Objects are content-addressed, so that changes
-            # where the bytes come from and not the tree they produce.
-            git -C /home/cubrid submodule sync
-            git -C /home/cubrid submodule init
-            while read -r key url; do
-              name=${key#submodule.}; name=${name%.url}
-              path=$(git -C /home/cubrid config -f .gitmodules --get "submodule.${name}.path")
-              mirror="${BUILD_MIRROR}/$(basename "${url%.git}").git"
-              want=$(git -C /home/cubrid rev-parse "HEAD:${path}")
-              if git -C "$mirror" cat-file -e "${want}^{commit}" 2> /dev/null; then
-                git -C /home/cubrid config "submodule.${name}.url" "$mirror"
-              else
-                # The mirror is a seed nothing refreshes, so a submodule bumped
-                # after it was taken comes over the WAN in full until someone
-                # re-seeds. Sizes: cci 28MB, jdbc 1.5MB, manager-server 67MB.
-                echo "[warn] ${path} ${want} is not in the mirror; cloning it from ${url} over the WAN"
-              fi
-            done < <(git -C /home/cubrid config --get-regexp '^submodule\..*\.url')
-
-            # protocol.file.allow: since git 2.38 a submodule may not be cloned
-            # from a path, which is exactly what the rewrite above produces.
-            git -C /home/cubrid -c protocol.file.allow=always submodule update
-            echo "[debug] source ${CIRCLE_SHA1}, build serial $(git -C /home/cubrid rev-list --count --after 2019-12-12 HEAD)"
+            git submodule sync
+            git submodule init
+            # Mirror only where it holds the commit this revision pins; a
+            # submodule bumped since the mirror was seeded comes from GitHub.
+            while read -r sha path; do
+              url=$(git config -f .gitmodules --get "submodule.${path}.url")
+              mirror="$BUILD_MIRROR/$(basename "${url%.git}").git"
+              git -C "$mirror" cat-file -e "${sha}^{commit}" 2> /dev/null \
+                && git config "submodule.${path}.url" "$mirror"
+            done < <(git ls-tree HEAD | awk '$2 == "commit" { print $3, $4 }')
+            # git 2.38 refuses to clone a submodule from a path without this.
+            git -c protocol.file.allow=always submodule update
       - run:
+          # From the source root, which is the executor's working_directory:
+          # the entrypoint only detects a failed build when it finds build.sh
+          # in the current directory.
           name: Build the debug package
           no_output_timeout: 45m
           command: |
             set -eo pipefail
-            : "${CCACHE_DIR:?}"
             mkdir -p "$CCACHE_DIR"
             ccache --max-size=5G
             ccache -z
-            # From the source root. The entrypoint decides whether the build
-            # failed by reading ./build.log, which it only writes there when
-            # build.sh is in the current directory; run from /home it reads a
-            # path that does not exist and calls a failed build a success.
-            cd /home/cubrid
             /entrypoint.sh build -m optdebug
             ccache -s
       - run:
           name: Publish the build to GlusterFS
-          # cp -a of the built tree to GlusterFS prints nothing while it runs.
           no_output_timeout: 30m
           command: |
             set -eo pipefail
-            : "${BUILD_CACHE_ROOT:?}" "${BUILD_SENTINEL:?}"
-            build_dir="${BUILD_CACHE_ROOT}/${CIRCLE_SHA1}/debug"
-
-            # Stage, then publish with one atomic rename: consumers never see a
-            # half-copied tree, and a run that loses the rename drops its
-            # staging dir instead of touching the published one.
-            tmp_dir="${build_dir}.tmp.${CIRCLE_BUILD_NUM}"
-            rm -rf "$tmp_dir"
-            mkdir -p "$tmp_dir"
-            cp -a /home/CUBRID "${tmp_dir}/CUBRID"
-            touch "${tmp_dir}/${BUILD_SENTINEL}"
-            if mv -T "$tmp_dir" "$build_dir" 2> /dev/null; then
-              echo "Build published at ${build_dir}"
-            else
-              echo "Another run published this build first, discarding staging dir"
-              rm -rf "$tmp_dir"
-            fi
-            ls -la "${build_dir}/CUBRID"
+            dir="${BUILD_CACHE_ROOT}/${CIRCLE_SHA1}/debug"
+            tmp="${dir}.tmp.${CIRCLE_BUILD_NUM}"
+            rm -rf "$tmp"
+            mkdir -p "$tmp"
+            cp -a /home/CUBRID "$tmp/CUBRID"
+            touch "$tmp/${BUILD_SENTINEL}"
+            # One rename publishes it, so a consumer never sees a half-copied
+            # tree and a run that loses the rename drops its staging dir.
+            mv -T "$tmp" "$dir" 2> /dev/null || rm -rf "$tmp"
             df -h /home/build-cache
-      - run:
-          name: Store build logs and commits
-          when: always
-          command: |
-            mkdir -p /tmp/build_logs
-            mv -f /home/cubrid/build.log /tmp/build_logs || true
-            git -C /home/cubrid log | head -n 1000 > /tmp/build_logs/commits.log || true
-      - store_artifacts:
-          path: /tmp/build_logs
-          when: always
+      - collect-build-logs
 
 # Test jobs are gated by expression-based filters (evaluated server-side).
 workflows:


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1506>

### Purpose

PR에서 shell 테스트가 시작되기까지 이런 순서를 거칩니다.

`build_debug`(클라우드, 7~9분) → 아티팩트 업로드(290MB) → `download-build`(self-hosted, slot 대기 + 290MB 다운로드 10~18분) → `test_shell`

사무실과 IDC 전체가 30Mbps 인바운드 회선을 나눠 쓰기 때문에, 이 290MB 다운로드는 느리기만 한 것이 아니라 그동안 다른 서비스의 회선까지 잠식합니다.

### Implementation

`download-build` 자리에서 self-hosted 노드가 debug 빌드를 **직접 수행**하도록 바꿨습니다. 소스 이력은 GlusterFS에 둔 저장소 미러에서 빌려 오고(**읽기 전용**), 그 미러에 없는 이번 run의 증분만 pod 로컬로 받습니다. 빌드 결과는 shell pod들이 이미 마운트하는 `builds/<sha>/debug` 경로에 그대로 발행합니다.

미러에 쓰지 않는 것이 중요합니다. 여러 pod가 공유하는 디렉토리라, 거기에 fetch를 하면 pod들이 락을 나눠 써야 하고 fetch 도중 pod가 죽으면 `.lock`이 남아 이후 모든 빌드가 멈춥니다. 실측하면 미러가 일주일 낡았을 때 run당 2MB, 한 달이면 6MB, 세 달이면 8MB만 받으면 됩니다(지금 받는 아티팩트는 290MB입니다). 그래서 미러는 그냥 낡아도 되고, 갱신은 필요할 때 rsync 한 번이면 됩니다.

동작이 이렇게 달라집니다.

- **클라우드 빌드를 기다리지 않습니다.** `build_debug` 의존을 끊어서, 파이프라인이 시작되는 즉시 빌드가 출발합니다. 지연이 줄어드는 대부분이 여기서 나옵니다.
- **run당 외부 전송이 290MB에서 git 증분 fetch(수 KB~MB) + 3rdparty 라이브러리 17MB로 줄어듭니다.**
- **shell만 도는 run에서는 `build_debug`가 아티팩트를 업로드하지 않습니다.** 아무도 내려받지 않는 290MB였습니다.
- 같은 커밋을 다시 돌리면 이미 발행된 빌드를 재사용하고 빌드를 건너뜁니다.
- 빌드 로그가 아티팩트로 남습니다.

**바뀌지 않는 것**: sql·medium 테스트, develop 머지 시 빌드 보존(`store-build-develop`), `test_shell` 자체. 셋 다 코드를 건드리지 않았고, 필요로 하는 데이터(아티팩트, sentinel, 테스트케이스 브랜치)도 종전대로 공급됩니다.

`test_shell`이 쓰는 테스트케이스 브랜치는 빌드를 건너뛰는 경우에도 반드시 먼저 넘겨줍니다. 순서가 뒤바뀌면 shell pod가 브랜치를 못 받고 조용히 develop을 테스트하게 됩니다.

### Remarks

**임시 조치입니다.** GitHub Actions 이관(CUBRIDQA-1501)에서 되돌립니다. 그래서 쓰지 않게 된 기존 `download-build` job과 `download-build-to-glusterfs` 커맨드도 지우지 않고 남겼습니다 — 되돌릴 때 diff를 작게 하려는 것입니다.

**배포 전에 필요한 것**

1. **워커 노드에 저장소 미러를 미리 올려야 합니다.** `/home/build-cache/cubrid-mirror/`에 `cubrid.git`, `cubrid-cci.git`, `cubrid-jdbc.git`, `cubrid-manager-server.git`을 bare로 둡니다. `/home/build-cache`는 워커가 공유하는 GlusterFS 볼륨이라 **한 노드에만 올리면 됩니다**. 두 가지를 반드시 맞춰야 합니다.
   - **소유자가 root여야 합니다.** 다른 UID면 git이 `detected dubious ownership`으로 저장소 열기를 거부하고, `-c safe.directory`로는 우회되지 않습니다(보호된 설정에서만 읽히기 때문). 기존 `/home/tc-repo` seed와 같은 규칙입니다.
   - **`gc.auto=0`을 설정해야 합니다.** 빌드가 `clone --shared`로 미러의 pack을 빌드 내내 읽으므로, 노드에서 누가 수동으로 fetch해 repack이 돌면 읽던 pack이 사라집니다.

   미리 올리지 않아도 빌드는 동작하지만, 그때는 745MB 전체를 외부 회선으로 받습니다.
인프라 변경은 필요 없습니다. 러너 CPU limit을 8에서 32로 올려봤지만(circleci-k8s-ansible#12) 실측 이득이 71초뿐이라 되돌렸습니다(#13). 빌드는 CPU 총 1926초를 쓰는데 8코어를 넘는 구간이 약 120초뿐이고, 나머지는 3rdparty를 직렬로 빌드하는 구간이라 코어를 줘도 빨라지지 않습니다.

**카나리 결과** — 이 PR에서 `/run shell`을 두 번(서로 다른 커밋으로) 실행했습니다. CircleCI 체크 4/4 초록입니다.

| SHA | CPU limit | `download-build` | ccache 적중률 | `test_shell` |
|---|---|---|---|---|
| `45fe0927` | 32 | 6분 (cold, 빌드 357초) | 1.48% | 실패 2건 |
| `45fe0927` 재실행 | 32 | **10초** (sentinel 재사용) | — | 실패 1건 |
| **`ea35fa79`** | **8** | **5.3분** (warm, 빌드 285초) | **59.77%** | **성공 (실패 0건)** |

기존 경로는 `build_debug`(6분) 완료를 기다린 뒤 290MB를 받아 **16~24분**이 걸렸습니다. 지금은 파이프라인과 동시에 출발해 **5.3분**입니다.

세부 확인:

- 소스 준비 **7~8초**. 미러가 낡은 상태였지만 증분만 받았습니다. 빌드 번호 2402/2403(shallow였다면 0001).
- 발행물 `builds/<sha>/debug` 756MB + sentinel. 두 번 실행한 뒤에도 **미러는 바이트 단위로 동일**하고 lock 잔여물이 없습니다.
- `build_debug`에 패키징 스텝과 `CUBRID.tar.gz` 아티팩트가 없습니다.
- ccache가 gluster에 있어도 병목이 아닙니다 — 적중률이 1.48% → 59.77%로 오르며 빌드가 72초 줄었습니다.
- 빌드 pod 실물이 `image=cubridci/cubridci:rl8.10`으로 확인됐습니다. container runner가 job이 지정한 이미지를 Helm values의 이미지보다 우선한다는 전제가 실증된 것입니다.

첫 실행에서 `test_shell`이 2건 실패했으나 둘 다 이 변경이 원인이 아닙니다. `cbrd_27007`은 같은 바이너리 재실행에서 통과해 flaky로 확정됐고, `issue_11202_temp_volume_create`는 이 변경 이전인 8월 4일 실행(#143318, 클라우드 빌드)에서도 동일한 양상으로 실패한 적이 있습니다. 세 번째 실행에서는 둘 다 통과했습니다.

**되돌리는 방법**: 이 PR을 revert하고, 워커 노드의 `/home/build-cache/cubrid-mirror`와 `/home/build-cache/ccache-shell-debug`를 지웁니다.

**검증**

- `circleci config validate` 통과, 새로 추가한 셸 스텝 7개 shellcheck clean.
- 로컬 테스트 하네스 19건 통과 — 가짜 GitHub·가짜 GlusterFS에 실제 git으로 돌려서, PR head 체크아웃·빌드 번호 보존(shallow였다면 1이 되는 것)·미러가 바이트 단위로 그대로인지·서브모듈을 미러와 네트워크 중 어디서 가져오는지·빌드 실패 검출·원자적 발행·빌드 재사용을 확인합니다.
- **실제 러너 노드에서 실제 미러에 대고** 소스 준비 단계를 돌렸습니다: 4.4초, 올바른 커밋, 빌드 번호 2400, 서브모듈 2/2 미러에서, 미러는 실행 후 바이트 단위로 동일, lock 잔여물 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


