### PR TITLE
[CBRD-27175] Show index names in CSQL ;info stats B+tree statistics output

### DIFF
--- a/src/storage/statistics_cl.c
+++ b/src/storage/statistics_cl.c
@@ -297,8 +297,10 @@ stats_dump (const char *class_name_p, FILE * file_p)
   ATTR_STATS *attr_stats_p;
   BTREE_STATS *bt_stats_p;
   SM_CLASS *smclass_p;
+  SM_CLASS_CONSTRAINT *cons_p;
   int i, j, k;
   const char *name_p;
+  const char *index_name_p;
   const char *prefix_p = "";
   time_t tloc;
 
@@ -355,8 +357,19 @@ stats_dump (const char *class_name_p, FILE * file_p)
 	    {
 	      bt_stats_p = &(attr_stats_p->bt_stats[j]);
 
-	      fprintf (file_p, "        BTID: { %d , %d }\n", bt_stats_p->btid.vfid.volid,
-		       bt_stats_p->btid.vfid.fileid);
+	      index_name_p = NULL;
+	      for (cons_p = smclass_p->constraints; cons_p != NULL; cons_p = cons_p->next)
+		{
+		  if (SM_IS_CONSTRAINT_INDEX_FAMILY (cons_p->type)
+		      && BTID_IS_EQUAL (&bt_stats_p->btid, &cons_p->index_btid))
+		    {
+		      index_name_p = cons_p->name;
+		      break;
+		    }
+		}
+
+	      fprintf (file_p, "        Index: %s , BTID: { %d , %d }\n", (index_name_p ? index_name_p : "not found"),
+		       bt_stats_p->btid.vfid.volid, bt_stats_p->btid.vfid.fileid);
 	      fprintf (file_p, "        Cardinality: %d (", bt_stats_p->keys);
 
 	      prefix_p = "";


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27175

## Purpose

The B+tree statistics section of the CSQL session command `;info stats <table>` identifies each index only by its internal BTID:

```
B+tree statistics:
    BTID: { 0 , 4736 }
    Cardinality: 1000 (1000) , Total pages: 3 , Leaf pages: 2 , Height: 2
```

A BTID (volume id, file id) is an internal identifier, so users cannot tell which index the statistics belong to. This PR prints the index name together with the BTID.

## Implementation

`statistics_cl.c:stats_dump()` already holds the `SM_CLASS` obtained via `sm_get_class_with_statistics()`. For each `BTREE_STATS`, walk the class's `constraints` list and match `SM_IS_CONSTRAINT_INDEX_FAMILY` constraints by `BTID_IS_EQUAL` against `index_btid`, then print the constraint name in front of the BTID:

```
B+tree statistics:
    Index: pk_tstat_a , BTID: { 1 , 576 }
    Cardinality: 1000 (1000) , Total pages: 1 , Leaf pages: 1 , Height: 1
```

- The BTID is kept for debugging purposes; only the name is added.
- Only the client-cached schema is used — no extra server round-trip, no new includes.
- If no matching constraint is found (e.g. stale statistics), `Index: not found` is printed instead of crashing.

## Remarks

Verified on a fresh database with a PK, a single-column index, and a multi-column unique index — all three resolve to the correct names:

| Index type | Output |
|---|---|
| PRIMARY KEY (a) | `Index: pk_tstat_a , BTID: { 1 , 576 }` |
| INDEX (b) | `Index: idx_tstat_b , BTID: { 1 , 704 }` |
| UNIQUE (c, b) | `Index: u_tstat_c_b , BTID: { 1 , 768 }` |

Since the output format of `;info stats` changes, QA scenarios that compare this dump (if any) need their answer files re-baselined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
