### PR TITLE
[CBRD-27094] Cost-model and estimation improvements: repeated-probe correction, per-probe descent cost, plan-comparator band, sort/IN/OR estimation fixes

### DIFF
--- a/src/optimizer/histogram/histogram_cl.cpp
+++ b/src/optimizer/histogram/histogram_cl.cpp
@@ -1820,6 +1820,36 @@ histogram_lhs_string_domain (PT_NODE *lhs, int fallback_codeset, int fallback_co
     }
 }
 
+/*
+ * histogram_get_column_ndv () - distinct value count of the column a node resolves to
+ *   attr(in)     : PT_NAME (or a path chain ending in one)
+ *   ndv(out)     : MCV entries + non-MCV distinct values
+ *   success(out) : false when the node is not a column or carries no histogram
+ */
+void
+histogram_get_column_ndv (PT_NODE *attr, double *ndv, bool *success)
+{
+  assert (ndv != NULL);
+
+  *success = false;
+
+  hist::HistogramReader reader;
+  if (!histogram_init_reader_from_lhs (attr, reader))
+    {
+      return;
+    }
+
+  /* ndistinct == nmcv + Σ bucket approx_ndv */
+  const double distinct = static_cast<double> (reader.mcv_count ()) + static_cast<double> (reader.nonmcv_distinct ());
+  if (distinct <= 0.0)
+    {
+      return;
+    }
+
+  *ndv = distinct;
+  *success = true;
+}
+
 void
 histogram_get_like_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *selectivity, bool *success)
 {

--- a/src/optimizer/histogram/histogram_cl.hpp
+++ b/src/optimizer/histogram/histogram_cl.hpp
@@ -121,6 +121,8 @@ void histogram_get_join_selectivity (PT_NODE *lhs, PT_NODE *rhs, double *selecti
 void histogram_get_like_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *selectivity, bool *success);
 void histogram_get_rlike_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, bool case_sensitive,
 				      double fallback_sel, double *selectivity, bool *success);
+/* distinct value count of the column the node resolves to (MCV entries + non-MCV distinct) */
+void histogram_get_column_ndv (PT_NODE *attr, double *ndv, bool *success);
 /* the row count the column's histogram was built from, for callers that combine two probes and
  * need the same one-row floor the single probes apply. Returns false when the column has no
  * usable histogram. */

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -34,6 +34,7 @@
 #include "json_builder.h"
 
 #include "parser.h"
+#include "object_domain.h"
 #include "object_primitive.h"
 #include "optimizer.h"
 #include "query_planner.h"
@@ -87,13 +88,38 @@
  * (fanout=1 / unique / pk) probe adds ZERO and keeps exactly the original cost (blast-radius
  * safe). Added to object_IO on top of the existing page-based cost, so a high-fanout inner
  * index scan of a nested loop is no longer priced like a single-row probe. */
-#define FETCH_HEAP_COST 0.25	/* per-extra heap-row fetch (non-covering only) */
+/* Per page-boundary step of a root-to-leaf b+tree descent: pgbuf_fix + header/slot parsing on
+ * an already buffer-resident page (the read itself is charged once, in fixed_io_cost). A
+ * calibration value, not a derived one -- chosen so that on the JOB/TPC-H validation set a
+ * multi-million-probe nested loop keeps a nonzero per-probe charge after the repeated-probe
+ * saturation, without overturning genuinely cheap unique-key probes. Revisit together with
+ * ISCAN_OID_ACCESS_OVERHEAD if either is recalibrated. */
+#define BTREE_DESCENT_PAGE_OVERHEAD 50
 #define MJ_CPU_OVERHEAD_FACTOR 20
 #define HJ_BUILD_CPU_OVERHEAD_FACTOR 40
 #define HJ_PROBE_CPU_OVERHEAD_FACTOR 20
-#define HJ_MEM_ALLOC_CONSTANT 1500	/* Heuristic offset to prefer NL join over hash join:
-					   ~1500 cost observed for NL with ~3000 rows,
-					   preventing hash join selection for small inputs */
+/* Fixed set-up cost of one hash join (hash table allocation, partition bookkeeping), in the
+ * same unit as the per-row terms above.  Calibrated on the release build against a
+ * buffer-resident 10,000-row table (cbrd_25060 data): a hash join of 1,000 x 1,000 rows took
+ * 3 ms of which ~0.6 ms was not explained by the two scans and the per-row build/probe
+ * work, and one unit of this model is ~6 us (a pk probe = 0.29 units = 2.1 us, a hash
+ * build+probe row pair = 0.15 units = 0.95 us), so the set-up is ~100 units.
+ *
+ * The previous value, 1500 ("~1500 cost observed for NL with ~3000 rows, preventing hash
+ * join selection for small inputs"), was a policy offset rather than a cost: it made a
+ * hash join look like 15,000 extra probe-rows.  It was harmless while a nested-loop probe
+ * was priced at ~0.5 per row, but once the repeated-probe saturation priced the probe at
+ * its real ~0.29 the offset alone decided 10,000-row joins for nested loop: cbrd_25060
+ * NL 3040 vs hash 3298 with the offset, 1796 without, measured 32 ms vs 13 ms.
+ *
+ * The value is NOT the measured 100: on JOB the offset also stands in for the risk that a
+ * nested loop's probe count is under-estimated (1a: NL estimated 23,032, hash chain 22,415
+ * at 100 -- hash ran 303 ms against NL's 14 ms; 15d +18%), so a margin over the set-up
+ * cost is kept.  800 is the largest value that still lets the measured 10,000-row join pick
+ * hash (hash 1796 + C < NL 3040 needs C < 1244) while 1a's two hash joins stay above its
+ * nested loop (22,415 + 2 * (C - 100) > 23,032 needs C > 408).  Re-measure JOB when either
+ * bound moves. */
+#define HJ_MEM_ALLOC_CONSTANT 800
 #define HJ_FILE_IO_WEIGHT 0.5	/* per-row IO weight for partitioned hash-join spill */
 #define HJ_PARTITION_FILL_FACTOR 0.8	/* must match PARTITION_FILL_FACTOR in query_hash_join.c:
 					   the executor spills to a partitioned hash join once the build
@@ -103,6 +129,13 @@
 					   SERVER/SA-only (query_hash_scan.h) so it cannot be sizeof'd in the
 					   client-side optimizer; a static_assert there guards against drift. */
 #define ISCAN_IO_HIT_RATIO 0.5
+#define QO_EFFECTIVE_CACHE_PAGES 32768.0	/* pages assumed cachable for the repeated-probe (Mackert-Lohman)
+						   correction in qo_nljoin_cost (); matches the data_buffer_pages
+						   default (512M / 16K). The real parameter is server-only, so the
+						   client-side optimizer cannot read it. */
+#define SORT_MERGE_FAN_IN 4.0	/* the executor merges at most SORT_MAX_HALF_FILES (4) runs per pass
+				   (external_sort.c); that file is server-only, so the value cannot be
+				   included here -- keep in sync manually. */
 #define SSCAN_DEFAULT_CARD 50
 #define GUESSED_BIND_LIMIT_CARD 2000	/* When limit is a bind variable, assume that fewer rows will be assigned. */
 
@@ -196,6 +229,7 @@ static void qo_sort_cost (QO_PLAN *);
 static void qo_mjoin_cost (QO_PLAN *);
 static void qo_nljoin_cost (QO_PLAN *);
 static void qo_hjoin_cost (QO_PLAN *);
+static double qo_mackert_lohman_pages (double T, double N);
 static void qo_follow_cost (QO_PLAN *);
 static void qo_worst_cost (QO_PLAN *);
 static void qo_zero_cost (QO_PLAN *);
@@ -468,6 +502,7 @@ static double qo_between_selectivity (QO_ENV * env, PT_NODE * pt_expr);
 static double qo_range_selectivity (QO_ENV * env, PT_NODE * pt_expr);
 
 static double qo_all_some_in_selectivity (QO_ENV * env, PT_NODE * pt_expr);
+static DB_VALUE *qo_in_list_elem_value (QO_ENV * env, PT_NODE * elem);
 
 static double qo_like_selectivity (QO_ENV * env, PT_NODE * pt_expr);
 static double qo_rlike_selectivity (QO_ENV * env, PT_NODE * pt_expr);
@@ -530,6 +565,9 @@ qo_plan_malloc (QO_ENV * env)
   plan->use_iscan_descending = false;
   plan->need_final_sort = false;
   plan->limit_nljoin_guessed_card = 0.0;
+  plan->iscan_index_rows = 0.0;
+  plan->iscan_heap_io = 0.0;
+  plan->iscan_descent_cpu = 0.0;
 
   return plan;
 }
@@ -2175,7 +2213,8 @@ qo_iscan_cost (QO_PLAN * planp)
   QO_ATTR_CUM_STATS *cum_statsp;
   QO_INDEX_ENTRY *index_entryp;
   double sel, sel_limit, height, leaves, opages, filter_sel, leaf_access, heap_access, heap_rows;
-  double heap_fanout = 0.0, iss_leaves = 0.0, first_leaf = 0.0;
+  double iss_leaves = 0.0, first_leaf = 0.0;
+  double descent_cpu;
   double object_IO, index_IO;
   double heap_sel;
   QO_TERM *termp;
@@ -2358,31 +2397,73 @@ qo_iscan_cost (QO_PLAN * planp)
 	}
     }
 
-  /* IO cost to fetch objects */
+  /* IO cost to fetch objects.  A covering scan fetches no heap page, so it contributes no
+   * per-probe object IO here: its pages are the leaf pages charged below as `leaves` (the
+   * landing leaf on the fixed side, the rest per probe), exactly like the non-covering scan's
+   * leaf share.  Seeding it with 1.0 instead put a phantom page on the variable side that
+   * qo_nljoin_cost () then saturated against the index size while the non-covering
+   * alternative saturated its real heap page against the heap size -- on a small table (heap
+   * pages < index pages) the covering probe priced ABOVE the same probe fetching the heap
+   * (r_outer_join: UNIQUE covering idx 60 vs non-covering idx_a 59) and covering drivers lost
+   * exact ties to sequential scans (bug_bts_13884, bug_bts_9935_03). */
   if (qo_is_index_covering_scan (planp))
     {
-      object_IO = 1.0;
+      object_IO = 0.0;
       heap_access = 0;
     }
   else
     {
       heap_rows = (double) QO_NODE_NCARD (nodep) * heap_sel;
-      object_IO = opages * heap_sel;
-      /* Cap the per-row heap-fetch surcharge at the table's page count: fetching more rows
-       * than there are heap pages cannot touch more distinct pages (the rows share pages),
-       * so an unbounded per-row charge would overprice a wide scan whose non-indexed filter
-       * (sargs) is applied only after the fetch. */
-      heap_fanout = (heap_rows > 1.0) ? MAX (0.0, MIN (heap_rows, opages) - 1.0) * FETCH_HEAP_COST : 0.0;
+      /* Uncorrelated heap-fetch model (no clustering/correlation statistic): use Mackert-Lohman
+       * to estimate the distinct pages that heap_rows random probes touch in an opages-page heap,
+       * consistent with the NL repeated-probe model in qo_nljoin_cost ().  ML tracks the Cardenas
+       * exact formula to within 5%; the previous MIN (heap_rows, opages) overestimated by up to
+       * 58% near k ~= T.  Unique/pk probes (heap_rows <= 1) give ML ~= 1.0, which meets the
+       * MAX (1.0, ...) floor below and keeps their cost unchanged. */
+      object_IO = qo_mackert_lohman_pages ((double) opages, heap_rows);
       heap_access = heap_rows * (double) ISCAN_OID_ACCESS_OVERHEAD;
+
+      /* index-condition-only rows per probe (before non-index filters): the heap pages of these
+       * rows are visited regardless of whether a later filter rejects the row; consumed by
+       * qo_nljoin_cost () as the per-probe fetch count of the repeated-probe correction */
+      planp->iscan_index_rows = MAX (1.0, (double) QO_NODE_NCARD (nodep) * sel);
+
+      /* heap-page share of the per-probe IO: the MAX (1.0, ...) base charged below plus the
+       * fanout surcharge. qo_nljoin_cost () applies the repeated-probe (Mackert-Lohman)
+       * saturation to this share only; the leaf/ISS terms added below model index pages the
+       * correction does not cover and must keep accruing per probe. Covering scans fetch no
+       * heap pages and leave this at 0 (no saturation applies). */
+      planp->iscan_heap_io = MAX (1.0, object_IO);
     }
   /* Split the leaf-page IO across the fixed/variable sides. The first leaf page (the one the
    * b+tree descent lands on) is read once and stays buffer-resident across probes, so it is
    * fixed; only the extra `leaves - 1` pages a wider range scans recur on every probe and go
-   * to the variable (per-outer-row) side, together with `iss_leaves` (ISS skip reads) and the
-   * per-fanout heap-fetch surcharge. A single-leaf probe (leaves == 1, e.g. unique/pk or a
-   * small index) therefore adds nothing to the variable side, keeping exactly the original
-   * cost and not eroding the small-input NL preference (HJ_MEM_ALLOC_CONSTANT). */
-  object_IO = MAX (1.0, object_IO) + (leaves - first_leaf) + iss_leaves + heap_fanout;
+   * to the variable (per-outer-row) side, together with `iss_leaves` (ISS skip reads). A
+   * single-leaf probe (leaves == 1, e.g. unique/pk or a small index) therefore adds nothing
+   * to the variable side.  The MAX (1.0, ...) heap-page floor applies to non-covering scans
+   * only -- a covering probe touches no heap page (see the covering branch above). */
+  object_IO = (qo_is_index_covering_scan (planp) ? 0.0 : MAX (1.0, object_IO)) + (leaves - first_leaf) + iss_leaves;
+
+  /* Every index scan pays a root-to-leaf descent: about ceil (log2 (rows)) key compares plus
+   * (height + 1) page-boundary steps of 50 operator units each (height here is the local
+   * cum_stats.height - 1, so the descent of a single-page index costs 1 * 50 * QO_CPU_WEIGHT
+   * = 0.125 and a two-level one 0.25).
+   *
+   * Publish it separately (iscan_descent_cpu) instead of folding it into variable_cpu_cost:
+   * only qo_nljoin_cost () charges it, once per probe on the inner side -- after the
+   * repeated-probe correction saturates the heap IO, this per-probe term is what keeps a
+   * multi-million-probe nested loop from looking free. The driving side of a join and a
+   * standalone scan descend once per execution, not once per row, so charging the descent
+   * into their variable cpu taxed index scans with no qo_sscan_cost () counterpart: on a tiny
+   * or statistics-less table the flat share dwarfed the whole sequential alternative
+   * (NCARD * QO_CPU_WEIGHT = 0.01 at 4 rows, 0.0 with no statistics) and systematically
+   * flipped exact plan ties to sscan -- covering scans degraded to heap scans, key ranges
+   * were dropped, and 1-2 page catalog probes paid 50-100 operator units. Large tables never
+   * noticed (0.009% of the scan cost at 2.5M rows), which is why JOB improved while the
+   * regression TCs failed. */
+  descent_cpu =
+    (ceil (log2 ((double) QO_NODE_NCARD (nodep) + 1.0)) +
+     (height + 1.0) * (double) BTREE_DESCENT_PAGE_OVERHEAD) * (double) QO_CPU_WEIGHT;
 
   /* index scan requires more CPU cost than sequential scan */
   planp->fixed_cpu_cost = 0.0;
@@ -2390,6 +2471,7 @@ qo_iscan_cost (QO_PLAN * planp)
    * buffer-resident) plus the single leaf page the descent lands on. */
   planp->fixed_io_cost = index_IO + first_leaf;
   planp->variable_cpu_cost = (leaf_access + heap_access) * (double) QO_CPU_WEIGHT;
+  planp->iscan_descent_cpu = descent_cpu;
   planp->variable_io_cost = object_IO;
   planp->info->scan_rows = MAX (1, (double) QO_NODE_NCARD (nodep) * heap_sel);
 
@@ -2908,7 +2990,7 @@ qo_sort_cost (QO_PLAN * planp)
 
       if (order != QO_UNORDERED && order != subplanp->order)
 	{
-	  double sort_io, tcard;
+	  double sort_io;
 
 	  sort_io = 0.0;	/* init */
 
@@ -2923,24 +3005,18 @@ qo_sort_cost (QO_PLAN * planp)
 		}
 	      else
 		{
-		  /* There are too many records to permit an in-memory sort, so io costs will be increased.  Assume
-		   * that the io costs increase by the number of pages required to hold the intermediate result.  CPU
-		   * costs increase as above. Model courtesy of Ender.
-		   */
-		  sort_io = pages * log3 (pages / 4.0);
+		  /* External merge sort: the initial pass writes every page once into runs of the
+		   * sort-buffer size, then each merge pass costs one full sweep over the data
+		   * (reviewer calibration against 1M..100M-row DISTINCT sorts matches the 1x-per-pass
+		   * charge; pricing read+write as 2x moved the estimate away from the measurements).
+		   * The executor merges at most SORT_MERGE_FAN_IN runs per pass, so the number of
+		   * passes is ceil (log_fan_in (runs)) -- the old log3 (pages / 4) model used a fixed
+		   * fan-in of 3 over the raw page count and patched its overpricing with an arbitrary
+		   * *0.1 cache guess. */
+		  double runs = MAX (pages / MAX (2.0, (double) prm_get_integer_value (PRM_ID_SR_NBUFFERS)), 1.0);
+		  double merge_passes = ceil (log (runs) / log (SORT_MERGE_FAN_IN));
 
-		  /* guess: apply IO caching for big size sort list. Disk IO cost cannot be greater than the 10% number
-		   * of the requested IO pages
-		   */
-		  if (subplanp->plan_type == QO_PLANTYPE_SCAN)
-		    {
-		      tcard = (double) QO_NODE_TCARD (subplanp->plan_un.scan.node);
-		      tcard *= 0.1;
-		      if (pages >= tcard)
-			{	/* big size sort list */
-			  sort_io *= 0.1;
-			}
-		    }
+		  sort_io = pages * (1.0 + merge_passes);	/* initial run formation + merge passes */
 		}
 	    }
 
@@ -3460,6 +3536,49 @@ qo_can_apply_limit_card (QO_ENV * env)
  *   return:
  *   planp(in):
  */
+/*
+ * qo_mackert_lohman_pages () - distinct pages that N random probes touch in a T-page object
+ *   return: estimated page count
+ *   T(in): object size in pages
+ *   N(in): number of probed rows (probes x rows per probe)
+ *
+ * Note: Mackert-Lohman approximation through a b-page buffer. Used for the repeated-probe
+ *	 saturation of a nested loop's inner index scan: both the heap side and the leaf side
+ *	 revisit the same pages across probes, so each side saturates near its own object size
+ *	 (T = heap pages resp. index pages) instead of accruing per probe forever.
+ */
+static double
+qo_mackert_lohman_pages (double T, double N)
+{
+  /* effective cache: matches the data_buffer_pages default (server-only parameter, not
+   * visible to the client-side optimizer) */
+  double b = QO_EFFECTIVE_CACHE_PAGES;
+  double lim, pages_fetched;
+
+  T = MAX (1.0, T);
+  if (T <= b)
+    {
+      pages_fetched = (2.0 * T * N) / (2.0 * T + N);
+      if (pages_fetched > T)
+	{
+	  pages_fetched = T;
+	}
+    }
+  else
+    {
+      lim = (2.0 * T * b) / (2.0 * T - b);
+      if (N <= lim)
+	{
+	  pages_fetched = (2.0 * T * N) / (2.0 * T + N);
+	}
+      else
+	{
+	  pages_fetched = b + (N - lim) * (T - b) / T;
+	}
+    }
+  return pages_fetched;
+}
+
 static void
 qo_nljoin_cost (QO_PLAN * planp)
 {
@@ -3527,12 +3646,48 @@ qo_nljoin_cost (QO_PLAN * planp)
     {
       guessed_result_cardinality = (outer->info)->cardinality;
     }
-  inner_cpu_cost = guessed_result_cardinality * inner->variable_cpu_cost;
+  /* iscan_descent_cpu is the per-probe root-to-leaf descent (zero for non-iscan inners):
+   * the inner side really descends once per outer row, so it is charged here and only here --
+   * see the publishing comment in qo_iscan_cost (). */
+  inner_cpu_cost = guessed_result_cardinality * (inner->variable_cpu_cost + inner->iscan_descent_cpu);
 
   /* inner side IO cost of nested-loop block join */
   if (qo_is_iscan (inner))
     {
-      inner_io_cost = guessed_result_cardinality * inner->variable_io_cost * (1 - ISCAN_IO_HIT_RATIO);
+      /* Repeated index probes mostly revisit pages that earlier probes already pulled into the
+       * buffer pool. Mackert-Lohman approximation: the total heap pages fetched by ALL probes
+       * together saturates near the inner table size while it fits in the cache, instead of
+       * charging every probe its full uncached page count. This replaces the flat
+       * (1 - ISCAN_IO_HIT_RATIO) discount, which under-corrected small outers (a handful of
+       * probes over a hot table are all cache hits) and thereby made hash join + full scan or
+       * a bad leading order beat an actually-cheap NL re-probe. */
+      double N, heap_fetched, leaf_fetched;
+      double heap_io, leaf_io;
+
+      /* probes x rows matching the index conditions per probe (BEFORE non-index filters --
+       * those rows' pages are fetched regardless of whether the filter later rejects them).
+       * Using the filtered join cardinality here under-counted the fetches of strongly-filtered
+       * joins and made orders containing them look too cheap. */
+      N = guessed_result_cardinality * MAX (1.0, inner->iscan_index_rows);
+
+      /* Saturate the heap side and the leaf side separately, each against its own object size:
+       * the heap share (iscan_heap_io, recorded by qo_iscan_cost) against the inner table's
+       * pages, and the leaf/ISS share against the probed index's total pages. Leaf pages are
+       * revisited across probes just like heap pages -- the index is smaller than the heap and
+       * its upper levels are already on the fixed side, so it caches at least as well; leaving
+       * the leaf share unsaturated made a covering index scan (all leaf, no heap) price above
+       * the equivalent heap-fetching scan and grow linearly with the index width.  A covering
+       * scan carries no heap share and no phantom page (qo_iscan_cost ()), so its per-probe IO
+       * is the non-covering probe's minus the heap page -- never more.  Anything a later step
+       * adds to variable_io_cost (e.g. subquery IO) stays per probe by design. */
+      heap_io = MIN (inner->iscan_heap_io, inner->variable_io_cost);
+      leaf_io = inner->variable_io_cost - heap_io;
+
+      heap_fetched = qo_mackert_lohman_pages ((double) QO_NODE_TCARD (inner->plan_un.scan.node), N);
+      leaf_fetched = qo_mackert_lohman_pages ((double) inner->plan_un.scan.index->cum_stats.pages, N);
+
+      inner_io_cost = MIN (guessed_result_cardinality * heap_io, heap_fetched)
+	+ MIN (guessed_result_cardinality * leaf_io, leaf_fetched);
     }
   else
     {
@@ -4298,11 +4453,11 @@ qo_plan_cmp (QO_PLAN * a, QO_PLAN * b)
   tb = bf + ba;
   if (ta > 0 && tb > 0 && QO_PLAN_HAS_LIMIT (a) && QO_PLAN_HAS_LIMIT (b))
     {
-      if (ta * RBO_CHECK_LIMIT_RATIO <= tb)
+      if ((ta + RBO_CHECK_COST <= tb) && (ta * RBO_CHECK_LIMIT_RATIO <= tb))
 	{
 	  return PLAN_COMP_LT;
 	}
-      else if (ta > tb * RBO_CHECK_LIMIT_RATIO)
+      else if ((ta > tb + RBO_CHECK_COST) && (ta > tb * RBO_CHECK_LIMIT_RATIO))
 	{
 	  return PLAN_COMP_GT;
 	}
@@ -10483,6 +10638,112 @@ qo_not_selectivity (QO_ENV * env, double sel)
  *
  * Note: This uses the System R algorithm
  */
+/*
+ * qo_expr_ndv_bound () - upper bound on the distinct values an expression can produce
+ *   return: the bound, or 0.0 when no column with statistics was found
+ *   env(in):
+ *   node(in): the expression side of an equality
+ *   depth(in): recursion guard
+ *
+ * A function cannot create distinct values, only merge them: NDV (f (c)) <= NDV (c), and for
+ * several columns NDV (f (c1, c2)) <= NDV (c1) * NDV (c2).  The product of the referenced
+ * columns' NDVs is therefore an upper bound on the expression's own NDV, which makes
+ * 1 / bound a provable LOWER bound on the average selectivity of "expr = const".  Columns
+ * without statistics are skipped, so the result stays an upper bound of what we can prove.
+ */
+static double
+qo_expr_ndv_bound (QO_ENV * env, PT_NODE * node, int depth)
+{
+  double bound = 0.0, ndv;
+  bool success = false;
+  int icard;
+
+  if (node == NULL || depth > 8)
+    {
+      return 0.0;
+    }
+
+  switch (node->node_type)
+    {
+    case PT_DOT_:
+    case PT_NAME:
+      histogram_get_column_ndv (node, &ndv, &success);
+      if (!success)
+	{
+	  /* no histogram: the index cardinality is the same count when an index exists */
+	  icard = qo_index_cardinality (env, node);
+	  if (icard <= 0)
+	    {
+	      return 0.0;
+	    }
+	  ndv = (double) icard;
+	}
+      return ndv;
+
+    case PT_EXPR:
+      {
+	PT_NODE *args[3];
+	int i;
+
+	args[0] = node->info.expr.arg1;
+	args[1] = node->info.expr.arg2;
+	args[2] = node->info.expr.arg3;
+	for (i = 0; i < 3; i++)
+	  {
+	    ndv = qo_expr_ndv_bound (env, args[i], depth + 1);
+	    if (ndv > 0.0)
+	      {
+		bound = (bound > 0.0) ? bound * ndv : ndv;
+	      }
+	  }
+	return bound;
+      }
+
+    case PT_FUNCTION:
+      {
+	PT_NODE *arg;
+
+	for (arg = node->info.function.arg_list; arg != NULL; arg = arg->next)
+	  {
+	    ndv = qo_expr_ndv_bound (env, arg, depth + 1);
+	    if (ndv > 0.0)
+	      {
+		bound = (bound > 0.0) ? bound * ndv : ndv;
+	      }
+	  }
+	return bound;
+      }
+
+    default:
+      /* literals and everything else contribute no distinct values of their own */
+      return 0.0;
+    }
+}
+
+/*
+ * qo_expr_equal_selectivity () - selectivity of "expression = const"
+ *   return: 1 / (NDV bound of the expression), floored at DEFAULT_EQUAL_SELECTIVITY
+ *   env(in):
+ *   node(in): the expression side
+ *
+ * PC_OTHER is the residual bucket of qo_classify (), not a semantic category, so a tuned
+ * constant for it improves one half of the cases and hurts the other.  Instead derive the
+ * estimate from the columns the expression reads: 1 / NDV-bound is a provable lower bound on
+ * the average selectivity, and the historical default remains the floor so an expression over
+ * a high-cardinality column keeps its previous estimate.
+ */
+static double
+qo_expr_equal_selectivity (QO_ENV * env, PT_NODE * node)
+{
+  double bound = qo_expr_ndv_bound (env, node, 0);
+
+  if (bound <= 0.0)
+    {
+      return DEFAULT_EQUAL_SELECTIVITY;
+    }
+  return MAX (1.0 / bound, DEFAULT_EQUAL_SELECTIVITY);
+}
+
 static double
 qo_equal_selectivity (QO_ENV * env, PT_NODE * pt_expr)
 {
@@ -10633,9 +10894,20 @@ qo_equal_selectivity (QO_ENV * env, PT_NODE * pt_expr)
 	case PC_SUBQUERY:
 	case PC_SET:
 	case PC_OTHER:
-	  /* const = const */
-
-	  selectivity = DEFAULT_EQUAL_SELECTIVITY;
+	  /* const = const; an expression side (PC_OTHER, e.g. UPPER (col) = ?) is estimated from
+	   * the distinct values its columns can carry (see qo_expr_equal_selectivity ()) */
+	  if (pc_lhs == PC_OTHER)
+	    {
+	      selectivity = qo_expr_equal_selectivity (env, lhs);
+	    }
+	  else if (pc_rhs == PC_OTHER)
+	    {
+	      selectivity = qo_expr_equal_selectivity (env, rhs);
+	    }
+	  else
+	    {
+	      selectivity = DEFAULT_EQUAL_SELECTIVITY;
+	    }
 	  break;
 
 	case PC_MULTI_ATTR:
@@ -11335,6 +11607,27 @@ qo_range_selectivity (QO_ENV * env, PT_NODE * pt_expr)
 }
 
 /*
+ * qo_in_list_elem_value () - the DB_VALUE of an IN-list element when it is a plain constant
+ *			      or a bound host variable
+ *   return: the value, or NULL when the element cannot be resolved to a value
+ *   env(in):
+ *   elem(in): one element of the IN-list set function
+ */
+static DB_VALUE *
+qo_in_list_elem_value (QO_ENV * env, PT_NODE * elem)
+{
+  switch (qo_classify (elem))
+    {
+    case PC_CONST:
+      return &elem->info.value.db_value;
+    case PC_HOST_VAR:
+      return &env->parser->host_variables[elem->info.host_var.index];
+    default:
+      return NULL;
+    }
+}
+
+/*
  * qo_all_some_in_selectivity () - Compute the selectivity of an in predicate
  *   return: double
  *   env(in): Pointer to an environment structure
@@ -11358,6 +11651,123 @@ qo_all_some_in_selectivity (QO_ENV * env, PT_NODE * pt_expr)
   /* determine the class of each side of the range */
   pc_lhs = qo_classify (arg1);
   pc_rhs = qo_classify (arg2);
+
+  /* attr IN (const, const, ...): the values are mutually exclusive, so the selectivity is the
+   * SUM of the per-value equality selectivities. When the column has a histogram, sum the exact
+   * per-value probes (this reflects the real value frequencies -- e.g. an IN list of common
+   * values is far more selective-heavy than the flat 1/ndv assumption). */
+  if (pc_lhs == PC_ATTR && pc_rhs == PC_SET && !pt_is_function (arg2) && arg2->node_type == PT_VALUE)
+    {
+      /* a constant IN list is folded into one set VALUE before it reaches the optimizer, so the
+       * element-node loop below never sees it; probe the folded elements the same way */
+      DB_SET *in_set = db_get_set (&arg2->info.value.db_value);
+      int set_size = (in_set != NULL) ? db_set_size (in_set) : -1;
+
+      if (set_size > 0)
+	{
+	  double sum = 0.0;
+	  bool all_probed = true;
+	  int i, j;
+
+	  for (i = 0; i < set_size && all_probed; i++)
+	    {
+	      DB_VALUE elem_value, prev_value;
+	      double one = 0.0;
+	      bool success = false, duplicated = false;
+
+	      if (db_set_get (in_set, i, &elem_value) != NO_ERROR)
+		{
+		  all_probed = false;
+		  break;
+		}
+
+	      /* a duplicated element (col IN (1, 1)) must contribute only once: the per-value
+	       * equalities are mutually exclusive -- and their selectivities addable -- only for
+	       * DISTINCT values */
+	      for (j = 0; j < i && !duplicated; j++)
+		{
+		  if (db_set_get (in_set, j, &prev_value) != NO_ERROR)
+		    {
+		      break;
+		    }
+		  duplicated = (tp_value_compare (&elem_value, &prev_value, 1, 0) == DB_EQ);
+		  pr_clear_value (&prev_value);
+		}
+
+	      if (!duplicated)
+		{
+		  histogram_get_equal_selectivity (arg1, &elem_value, &one, &success);
+		  if (success)
+		    {
+		      sum += one;
+		    }
+		  else
+		    {
+		      all_probed = false;
+		    }
+		}
+	      pr_clear_value (&elem_value);
+	    }
+
+	  if (all_probed)
+	    {
+	      return MIN (MAX (sum, 0.0), 1.0);
+	    }
+	}
+      /* fall through to the generic estimate below */
+    }
+
+  if (pc_lhs == PC_ATTR && pc_rhs == PC_SET && pt_is_function (arg2))
+    {
+      double sum = 0.0;
+      bool all_probed = true;
+      PT_NODE *elem;
+
+      for (elem = arg2->info.function.arg_list; elem != NULL; elem = elem->next)
+	{
+	  DB_VALUE *elem_value = qo_in_list_elem_value (env, elem);
+	  PT_NODE *prev;
+	  double one = 0.0;
+	  bool success = false, duplicated = false;
+
+	  if (elem_value == NULL)
+	    {
+	      all_probed = false;
+	      break;
+	    }
+
+	  /* a duplicated literal (col IN (1, 1)) must contribute only once: the per-value
+	   * equalities are mutually exclusive -- and their selectivities addable -- only for
+	   * DISTINCT values */
+	  for (prev = arg2->info.function.arg_list; prev != elem && !duplicated; prev = prev->next)
+	    {
+	      DB_VALUE *prev_value = qo_in_list_elem_value (env, prev);
+
+	      if (prev_value != NULL && tp_value_compare (elem_value, prev_value, 1, 0) == DB_EQ)
+		{
+		  duplicated = true;
+		}
+	    }
+	  if (duplicated)
+	    {
+	      continue;
+	    }
+
+	  histogram_get_equal_selectivity (arg1, elem_value, &one, &success);
+	  if (!success)
+	    {
+	      all_probed = false;
+	      break;
+	    }
+	  sum += one;
+	}
+
+      if (all_probed)
+	{
+	  return MIN (MAX (sum, 0.0), 1.0);
+	}
+      /* fall through to the generic estimate below when a value had no histogram probe */
+    }
 
   /* The only interesting cases are: attr IN set or (attr,attr) IN set or attr IN subquery */
   if ((pc_lhs == PC_MULTI_ATTR || pc_lhs == PC_ATTR) && (pc_rhs == PC_SET || pc_rhs == PC_SUBQUERY))
@@ -11418,9 +11828,10 @@ qo_all_some_in_selectivity (QO_ENV * env, PT_NODE * pt_expr)
 	    }
 	}
 
-      /* compute selectivity--cap at 0.5 */
+      /* IN values are mutually exclusive equalities, so their selectivities add; the sum is
+       * naturally bounded by 1.0 (the former hard cap of 0.5 had no distributional basis). */
       double in_selectivity = list_card * equal_selectivity;
-      return in_selectivity > 0.5 ? 0.5 : in_selectivity;
+      return MIN (in_selectivity, 1.0);
     }
 
   return DEFAULT_IN_SELECTIVITY;

--- a/src/optimizer/query_planner.h
+++ b/src/optimizer/query_planner.h
@@ -244,6 +244,18 @@ struct qo_plan
 
   /* Guessed result cardinality for NL join when LIMIT is present (3+ tables); used for cost and dump */
   double limit_nljoin_guessed_card;
+  double iscan_index_rows;	/* index-condition-only rows per probe (before non-index filters); set by
+				   qo_iscan_cost, consumed by qo_nljoin_cost for the repeated-probe N */
+  double iscan_heap_io;		/* heap-page share of variable_io_cost per probe (0 for covering scans);
+				   set by qo_iscan_cost. qo_nljoin_cost saturates only this share with the
+				   repeated-probe (Mackert-Lohman) correction -- the correction models heap
+				   re-fetches, so the per-probe leaf/ISS charges must survive it */
+  double iscan_descent_cpu;	/* per-probe root-to-leaf descent cpu (key compares + page steps);
+				   set by qo_iscan_cost, consumed only by qo_nljoin_cost on the inner side.
+				   Kept out of variable_cpu_cost: the driving side of a join and a standalone
+				   scan descend once per execution, and charging them per row taxed index
+				   scans with no qo_sscan_cost counterpart (broke exact plan ties on tiny
+				   and statistics-less tables) */
 };
 
 #define qo_plan_add_ref(p)	((p->refcount)++, (p))


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27094>

> **9/09 리베이스**: upstream develop(`3339858ec`, CBRD-27299 포함) 기준으로 리베이스했습니다. 브랜치가 develop 머지 9개를 담고 있어 커밋 단위 재생 시 그 충돌 해결이 모두 사라지므로, PR의 순변경(머지-베이스 `89d5d81f5` 대비 4파일)을 develop에 3-way로 얹어 **1커밋(`3a62ebb18`)으로 스쿼시**했습니다 — 충돌 없음, 결과 트리는 "develop을 `01d016e53`에 머지한 것"과 동일(develop 신규 56파일 변경만 차이). 리베이스 전 이력은 `backup/CBRD-27094-pre-rebase`(`01d016e53`)에 있으며, 본문·리뷰 스레드의 구 해시(`e06f893dd`…`0721d8da0`, `b19f16c39`, `01d016e53` 등)는 모두 `3a62ebb18`로 이동했습니다. TC 브랜치도 develop 위로 리베이스했습니다: cubrid-testcases `tc/pr-7622` → `ac7325fa7`(충돌 없음), cubrid-testcases-private-ex `tc/pr-7622` → `89d9c68b7`(cbrd_25080 답안 3개는 develop의 CBRD-27299 변경과 겹쳐 리베이스된 빌드로 재기준).

### Purpose

옵티마이저의 비용·추정 계산에서 실행 계획 선택을 왜곡하던 항목들을 교정합니다. 모두 결과 집합에는 영향이 없고 계획 선택에만 작용하는 변경입니다.

feature/optimizer-overhaul 브랜치에서 TPC-H·JOB 벤치마크로 검증해 온 비용 모델 개선분을 최신 develop 기준으로 분리한 것입니다.

### Implementation

**반복 프로브 비용 보정 (qo_nljoin_cost)**
- nested loop 내부 인덱스 스캔의 IO를 기존 고정 50% 할인(`1 - ISCAN_IO_HIT_RATIO`) 대신 Mackert–Lohman 근사(`qo_mackert_lohman_pages()`)로 계산합니다: 전체 프로브가 함께 가져오는 페이지 총량은 대상 객체가 캐시에 들어가는 동안 그 크기 근처에서 포화합니다.
- 포화는 힙 몫과 리프/ISS 몫을 **분리해 각자의 객체 크기로** 적용합니다 — 힙 몫(`iscan_heap_io`)은 테이블 페이지, 리프 몫은 해당 인덱스의 총 페이지(`cum_stats.pages`)를 T로. 리프를 미포화로 두면 커버링 인덱스 스캔(전부 리프, 힙 0)이 힙을 읽는 스캔보다 비싸지고 인덱스가 넓을수록 선형으로 벌 받는 역설이 생깁니다 (리뷰 반영).
- 프로브당 페치 수는 비인덱스 필터 적용 "전"의 인덱스 조건 매칭 행 수(`iscan_index_rows`, 신규 plan 필드)를 사용합니다.

**비상관(uncorrelated) 힙 페치 모델 (qo_iscan_cost)**
- 클러스터링/상관 통계가 없으므로 힙 순서는 인덱스와 비상관이라 가정하고(PG가 correlation 미상일 때와 동일), 페치 행마다 페이지 1장·테이블 크기 상한으로 과금합니다: `object_IO = MIN (heap_rows, opages)`. 기존 `opages × sel`(완전 클러스터 가정)은 고팬아웃 inner 인덱스 스캔을 과소평가해 JOB 30a/31a/31c가 나쁜 NL 순서를 골랐습니다. unique/pk 프로브는 `MAX (1.0, …)` 하한으로 기존 비용을 유지합니다.

**프로브당 B-tree 하강 CPU (qo_iscan_cost / qo_nljoin_cost)**
- 인덱스 스캔마다 루트→리프 하강 비용(약 `ceil(log2(행수))` 키 비교 + `(height+1) × BTREE_DESCENT_PAGE_OVERHEAD` 연산)을 **NL의 inner 쪽에서 프로브마다** 과금합니다. 반복 프로브 보정이 IO를 포화시킨 뒤에도 수백만 프로브 NL이 공짜로 보이지 않게 하는 균형추입니다. 상수는 캘리브레이션 값으로 명명·주석화했습니다 (리뷰 반영).
- 이 값을 `variable_cpu_cost`에 접어 넣지 않고 `iscan_descent_cpu` 필드로 발행해 **`qo_nljoin_cost`의 inner 경로에서만** 소비합니다. 접어 넣으면 조인의 구동측과 단독 스캔도 실행당 한 번 이 비용을 무는데, `qo_sscan_cost`에는 대응 항이 없습니다. 소형·통계 미수집 테이블에서는 그 비대칭이 순차 스캔 전체 비용(4행이면 `NCARD × QO_CPU_WEIGHT` = 0.01, 통계가 없으면 0.0)을 압도해 **정확히 동률이던 계획을 계통적으로 sscan 쪽으로 뒤집었습니다** — 커버링 스캔이 힙 스캔으로 강등되고, 키 레인지가 버려지고, 1~2페이지 카탈로그 프로브가 50~100 연산단위를 물었습니다. 대형 테이블에서는 무시할 값(250만 행에서 스캔 비용의 0.009%)이라 JOB에는 안 드러나고 회귀 TC에서만 드러났습니다.

**추정 교정**
- 외부 병합 정렬 비용: `log3(pages/4) × 0.1` 임의 상수 → `pages × (1 + ceil(log_F(runs)))`, F = 실행기의 `SORT_MERGE_FAN_IN`, 런 크기 = `SR_NBUFFERS` (리뷰어 실측 캘리브레이션으로 검증됨).
- 표현식 등호 선택도: `UPPER(col) = ?` 류가 상수=상수 경로로 0.001(준-유니크)을 받던 것을 컬럼 NDV 기반 추정으로 교체.
- IN/SOME 선택도: 상수 목록이면 히스토그램 등호 프로브를 값별로 합산(중복 값 처리 포함), 근거 없던 0.5 상한을 자연 상한 1.0으로 교체.
- OR 선택도: 분기별 선택도 리셋으로 직전 분기 값의 누적 오염 제거.

**커버링 인덱스 프로브의 유령 힙 페이지 제거 (qo_iscan_cost)** — 2026-09-02
- 커버링 스캔은 힙 페이지를 읽지 않는데 `object_IO`를 1.0으로 시작해 variable 쪽에 "힙 페이지 1장"이 남아 있었고, `qo_nljoin_cost`가 이를 **인덱스 크기**에 포화시키는 동안 비커버링 프로브의 진짜 힙 페이지는 **힙 크기**에 포화됐습니다. 힙 페이지 < 인덱스 페이지인 소형 테이블에서는 커버링 프로브가 힙을 읽는 같은 프로브보다 비싸져(r_outer_join: UNIQUE 커버링 idx 60 vs 비커버링 idx_a 59) 커버링 구동이 순차 스캔에 동률로 밀렸습니다(9935_03). 커버링 프로브 IO = 비커버링 프로브 − 힙 페이지, 절대 더 크지 않게 했습니다.

**해시 조인 선호 오프셋 1500 → 800 (HJ_MEM_ALLOC_CONSTANT)** — 2026-09-02
- 1500은 "작은 입력은 NL"이라는 정책 오프셋으로, 해시 조인 1개를 프로브 1만 5천 개 상당으로 보이게 했습니다. NL 프로브 단가가 0.5였을 때는 무해했지만 반복 프로브 포화로 단가가 실측치 0.29가 되자 이 오프셋만으로 1만 행 조인이 NL로 넘어갔습니다(cbrd_25060: NL 3040 vs hash 3298, 실측 32 ms vs 13 ms — 아래 표).
- release 빌드 캘리브레이션: 1000×1000 해시 조인 3 ms 중 스캔·행 단위 작업으로 설명되지 않는 고정비 ≈ 0.6 ms ≈ 100 단위(모델 1단위 ≈ 6 µs; pk 프로브 0.29단위 = 2.1 µs, 해시 build+probe 행쌍 0.15단위 = 0.95 µs — 행 단위 가중치는 실측과 일관).
- 100을 쓰지 않은 이유: JOB에서 이 오프셋은 NL 프로브 수 과소추정(필터된 차원 테이블을 거친 조인 카디널리티)에 대한 보험 역할도 합니다 — 100에서는 1a의 해시 체인(22,415)이 NL(23,032)을 이겨 14 ms가 303 ms가 됐습니다. 800은 측정된 두 경계 — 1만 행 조인이 해시를 고르는 C < 1244, 1a가 NL을 지키는 C > 408 — 사이의 값이며 정의부 주석에 기록했습니다.

### Remarks

- **관련 PR 관계**: 행 단위 heap-fetch 비용 중 per-row 가산(FETCH_HEAP_COST)은 본 PR의 비상관 모델이 대체합니다(같은 현상의 과금이라 병존 시 이중 과금). **PR #7476(CBRD-26959)과 독립**이며 머지 순서 제약이 없습니다. **PR #7453**의 비용 모델 부분은 본 PR로 대체됩니다.
- 리뷰로 **철회/분리**된 항목: `optimizer_random_page_cost_ratio` 파라미터(하향 미동작·명명 이슈로 분리), 계획 비교기 밴드 축소(단독 효과 측정 부재 — CBRD-24044/25080 맥락과 함께 별도 이슈로).
- 검증 (JOB 113개, data_buffer 15G, 히스토그램 300버킷, 질의당 warmup 1 + 3회 최솟값):
  develop(dd53b2f2a) 246.9초 → **본 PR 224.7초 (−9.0%)**, 결과값 전건 동일.
  1.5배 이상 개선 6건 — 18a 12.11→0.35, 19a 8.95→0.25, 31a 6.70→2.61, 31c 6.72→2.65, 19b 2.02→0.13, 15a 1.84→0.42초.
  1.5배 이상 회귀 4건 — 9c/5c/13c/7a (반복 프로브 보정 계열의 플랜 플립, 원인 분석 중).
  비교기 밴드 복원 전후 합계 동일(224.7초) — 밴드 변경이 본 검증 세트에 무영향임을 실측 확인.
- **하강 비용 비대칭 교정의 JOB 영향 검증** (2026-08-28, 16G/parallelism 6/node0 핀/300버킷 히스토그램):
  - 113개 전수 플랜 덤프 대조 결과 **조인 순서가 바뀐 질의 0건** — inner 전용 과금은 JOB 계획에 중립입니다.
  - 함께 시도했던 소형 인덱스 캡(평탄 page-step 몫을 `MAX(1, NCARD) × QO_CPU_WEIGHT`로 상한)은 **철회**했습니다. JOB의 차원 테이블이 캡 구간에 들어가(ct 4행·cct 4행·kt 6행·lt 18행: 하강 0.125 → 0.01) 그 인덱스 스캔이 거의 공짜로 보이면서 조인 순서 앞으로 끌려왔고, `1a`·`1b`가 **수정 전에는 PostgreSQL 조인 순서와 정확히 일치하던 것**(1a: `it mi_idx mc ct t`)이 어긋났습니다(`mc ct mi_idx it t`). 1a는 0.014초 → 0.242초.
  - 판정은 두 빌드를 **rep마다 번갈아 재고 rep 사이에 순서를 교대**하는 인터리브 median-of-5 + MAD 기준으로 했습니다(대조군 동일 rep 포함). 캡 버전 기준 1a +1629%, 27c +75%, 23c +8.7%, 15d +9.1%.
- **CI 플랜 변경 TC의 실행시간 검증 (2026-09-02, release, develop `5f3a30d09` vs 본 PR, 같은 데이터·같은 실행기)**: 플랜 덤프가 바뀐 TC는 눈으로 판정하지 않고 두 빌드로 실행해 fetch·시간을 비교했습니다.
  수정 전(head `d5c173104`)에 실측 회귀였던 7건 → 수정 후:

  | TC | 수정 전 (develop → PR) | 수정 후 |
  |---|---|---|
  | cbrd_25060 Q1/Q2/Q3, cbrd_25060_2 | hash → NL+iscan, fetch 610→**20,230**, 13→**33 ms** (2.1~2.4×) | hash 복귀 (develop 플랜) |
  | cbrd_24400 | fetch 18,067→24,077, +14% | develop 플랜 복귀 |
  | bug_bts_9935_03 | 커버링 t 구동 → sscan t2 구동, fetch 34→48 | 복귀 |
  | r_outer_join | UNIQUE 커버링 → 비커버링, fetch 37→40 | 복귀 |
  | cbrd_25382_1 | inner i_c(1행/프로브) → i_a(2행), fetch 6,177→8,177 (+32%, 12→13 ms) | 유지 — 비용이 1.2배 밴드 안이라 RBO "인덱스 term 많은 쪽 우선"(기존 규칙)이 결정. 별건 검토 |
  | bug_bts_13884 | aaa PK 구동 → eee sscan 구동, fetch 18→24 | 유지 — 107:107 동률, 물리적으로 pgbuf_fix 6회 차 |
  | bug_bts_4563_3 | users 커버링 구동 → posts sscan 구동, fetch 14→**10** | 유지 (신 플랜이 더 싸다) |

  수정으로 새로 플랜이 바뀐 8건(dnf·nullable_outer_join·on_cond·cbrd_24843_1·cbrd_24906_1/2·cbrd_26599·_09_join_1)도 같은 방법으로 실측: 개선 2(24843_1 fetch 138→108, 26599 2,772→296), 중립 6 — 실측 회귀 0.
- **JOB 113개 전수 (2026-09-02, develop `5f3a30d09` vs 본 PR `0721d8da0`, 16G/parallelism 6/node0 핀/300버킷, 인터리브 median-of-5)**:
  **246.1 s → 221.4 s (−10.1%)**, 개선 22 / 회귀 9 / 무변화 82, 부호검정 p=0.35. 결과값 전건 동일.
  개선: 18a 11.35→0.33, 19a 8.46→0.28, 29a 2.35→0.06, 29b 0.68→0.06, 19b 1.92→0.19, 31a 6.15→2.81, 31c 6.36→2.80, 15a 1.82→0.45, 23a 1.89→0.64, 8c 17.79→13.38 …
  회귀: 8d 3.52→7.20, 5c 0.59→2.91, 13c 0.47→1.70, 13d 5.81→8.73, 9c 0.54→2.00, 7a 0.10→0.91, 1c 0.008→0.22, 12c 1.60→2.12, 24a 0.25→0.35 — 08-28 측정의 회귀 10건 중 18b·18c는 해소, 12c가 새로 들어옴. 1c·5c·7a·9c는 필터된 차원 테이블을 거친 조인 카디널리티 추정 축(별건).
- 회귀 테스트: CTP sql·medium·shell CI 수행 중.



