### PR TITLE
[CBRD-27197] [regression] backupdb 의 checkpoint 대기 안내 메시지가 온라인 전체 백업에서 출력되지 않는 오류

### DIFF
--- a/src/transaction/log_page_buffer.c
+++ b/src/transaction/log_page_buffer.c
@@ -7619,7 +7619,9 @@ logpb_backup_ensure_fresh_checkpoint (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SES
 
   if (session->verbose_fp != NULL)
     {
-      fprintf (session->verbose_fp, "[ Forcing a fresh checkpoint before the full backup. ]\n\n");
+      /* Keep the pre-existing wait message: tools and testcases grep this exact phrase, and it stays true --
+       * the backup starts only after the forced checkpoint completes. */
+      fprintf (session->verbose_fp, "[ Database backup will start after checkpointing is complete. ]\n\n");
     }
 
   for (attempt = 0; attempt < max_attempts; attempt++)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27197>

### Purpose

[CBRD-27071](http://jira.cubrid.org/browse/CBRD-27071)(#7504)에서 online full backup 진입 시 checkpoint를 강제하면서, 기존 대기 안내 메시지 `[ Database backup will start after checkpointing is complete. ]` 대신 새 문구가 출력되도록 바뀌었습니다. 강제 checkpoint 단계가 진행 중인 checkpoint를 먼저 소진하므로 기존 대기 루프에 도달하지 않아, 이 문구를 grep 하는 shell TC `bug_bts_9337`이 build 2403(11.5.0.2403-1aa79a0)에서 실패합니다.

`logpb_backup_ensure_fresh_checkpoint()`가 기존 문구를 그대로 출력하도록 되돌립니다. 백업이 checkpoint 완료 후 시작된다는 의미는 유지되며 checkpoint 동작은 변경하지 않습니다.

### Remarks

강제 checkpoint 직후 checkpoint daemon이 새 checkpoint를 시작하면 뒤따르는 기존 대기 루프가 같은 문구를 한 번 더 출력할 수 있습니다. `bug_bts_9337`은 `checkpoint_interval=3600s`로 daemon 발동을 막아 결정적이지만, 재출력 억제는 후속 작업으로 남습니다.