### PR TITLE
[CBRD-27202] fix disk_set_boot_hfid() to memory-overread

### DIFF
--- a/src/storage/disk_manager.c
+++ b/src/storage/disk_manager.c
@@ -1124,7 +1124,7 @@ disk_set_boot_hfid (THREAD_ENTRY * thread_p, INT16 volid, const HFID * hfid)
   vhdr = (DISK_VOLUME_HEADER *) addr.pgptr;
 
   log_append_undoredo_data (thread_p, RVDK_RESET_BOOT_HFID, &addr, sizeof (vhdr->boot_hfid), sizeof (*hfid),
-			    &vhdr->boot_hfid, &hfid);
+			    &vhdr->boot_hfid, hfid);
   HFID_COPY (&(vhdr->boot_hfid), hfid);
 
   (void) disk_verify_volume_header (thread_p, addr.pgptr);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27202>

### Purpose

* fix memory-overread

### Implementation

N/A

### Remarks

disk_set_boot_hfid()에서 log_append_undoredo_data()를 호출할 때
redo_length인수에 대응하는 redo_data 인수가 이중 포인터로 넘겨져서 크기가 맞지 않게 됨.
이에 따라 prior_lsa_copy_redo_crumbs_to_node ()함수에서 복사되는 영역과 크기가 맞지 않게 됨.
