### PR TITLE
[CBRD-27200] Do not treat a constant TRUE predicate as a real one when merging a view

### DIFF
--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -371,6 +371,7 @@ extern "C"
   extern PT_NODE *pt_where_type (PARSER_CONTEXT * parser, PT_NODE * where);
   extern PT_NODE *pt_where_type_keep_true (PARSER_CONTEXT * parser, PT_NODE * where);
   extern bool pt_false_search_condition (PARSER_CONTEXT * parser, const PT_NODE * statement);
+  extern bool pt_true_search_condition (PARSER_CONTEXT * parser, const PT_NODE * statement);
   extern const char *mq_generate_name (PARSER_CONTEXT * parser, const char *root, int *version);
   extern int mq_is_real_class_of_vclass (PARSER_CONTEXT * parser, const PT_NODE * s_class, const PT_NODE * d_class);
   extern void pt_no_double_insert_assignments (PARSER_CONTEXT * parser, PT_NODE * stmt);

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -6960,6 +6960,40 @@ pt_false_search_condition (PARSER_CONTEXT * parser, const PT_NODE * node)
 }
 
 /*
+ * pt_true_search_condition () - Test for constant-folded search condition
+ * 				  that evaluated true
+ *   return: true if there is no search condition or all of the conjuncts are
+ *           effectively true, false otherwise
+ *   parser(in):
+ *   node(in):
+ *
+ * Note: A search condition folded to TRUE is a no-op, but it is not removed
+ *       from the CNF list. pt_where_type () removes such a conjunct while it
+ *       runs in the type checking walk of pt_semantic_type (), which is done
+ *       before the constant folding walk. So an expression of constants like
+ *       '1=1' is still an expression when it is checked and it becomes a
+ *       folded TRUE value only afterwards.
+ *       Use this function instead of a plain 'where == NULL' test to keep a
+ *       no-op predicate from being treated as a real one.
+ */
+bool
+pt_true_search_condition (PARSER_CONTEXT * parser, const PT_NODE * node)
+{
+  while (node)
+    {
+      if (node->or_next != NULL || node->node_type != PT_VALUE || node->type_enum != PT_TYPE_LOGICAL
+	  || node->info.value.data_value.i != 1)
+	{
+	  return false;
+	}
+
+      node = node->next;
+    }
+
+  return true;
+}
+
+/*
  * pt_to_false_subquery () -
  *   return:
  *   parser(in):

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -1973,8 +1973,10 @@ mq_is_pushable_subquery (PARSER_CONTEXT * parser, PT_NODE * subquery, PT_NODE * 
 
   /* determine if class_spec is the only spec in the statement */
   is_rownum_only = mq_is_rownum_only_predicate (parser, statement_spec, mainquery, order_by, subquery, class_);
+  /* A predicate folded to TRUE, e.g. 'WHERE 1=1', is a no-op. Do not count it as a real predicate here, otherwise it
+   * blocks the merging of a view which would be merged without it. */
   is_only_spec =
-    ((statement_spec->next == NULL && (pred == NULL || is_rownum_only)
+    ((statement_spec->next == NULL && (pt_true_search_condition (parser, pred) || is_rownum_only)
       && (subquery->info.query.order_by == NULL || order_by == NULL)) ? true : false);
 
   /* check if orderby_for set to PT_EXPR_INFO_ROWNUM_ONLY */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27200

## Purpose

상수 폴딩으로 항상 참이 되는 술어(`WHERE 1=1`)가 실제 조회조건과 동일하게 취급되어, 아무 의미 없는 술어 하나가 인라인뷰 머징을 막고 플랜을 바꿉니다.

```sql
-- 머징됨
SELECT * FROM (SELECT t1.a a, t2.b b FROM t1 LEFT OUTER JOIN t2 ON t1.a=t2.a) v;
=> select v.a, t2.b from t1 v left outer join t2 t2 on v.a=t2.a

-- WHERE 1=1 만 추가했는데 머징 안 됨
SELECT * FROM (SELECT t1.a a, t2.b b FROM t1 LEFT OUTER JOIN t2 ON t1.a=t2.a) v WHERE 1=1;
=> select v.a, v.b from (select t1.a as [a], t2.b as [b]
                         from t1 t1 left outer join t2 t2 on t1.a=t2.a) v (a, b)
```

`mq_is_pushable_subquery ()` 는 메인 쿼리 술어의 유무를 `is_only_spec` 계산에 사용하고, `is_only_spec` 이 거짓이면 "뷰 안 외부조인 spec", `inst_num`, `ORDER BY` 에 대한 완화가 사라져 `NON_PUSHABLE` 로 판정됩니다.

이런 conjunct 가 목록에 남는 이유는 제거 시점 때문입니다. 항상 참 conjunct 를 잘라내는 `pt_where_type ()` 은 `pt_semantic_type ()` 의 **타입 체크 walk** 에서 호출되는데, 상수 폴딩은 그 **다음 walk** 에서 수행됩니다. 리터럴 `TRUE` 는 그 시점에 이미 값이라 제거되지만, `1=1` 같은 상수식은 아직 식이라 제거되지 않고 그 뒤에 폴딩되어 값으로 남습니다.

`WHERE 1=1` 은 동적 SQL / ORM 생성 쿼리에서 매우 흔한 관용구입니다.

## Implementation

* `pt_true_search_condition ()` 추가 (`type_checking.c`). 기존 `pt_false_search_condition ()` 의 대칭 함수로, 검색 조건이 없거나 모든 conjunct 가 폴딩된 논리 참(`PT_VALUE` + `PT_TYPE_LOGICAL` + `data_value.i == 1`)인지 검사합니다.
* `parser.h` 에 선언 추가.
* `mq_is_pushable_subquery ()` 의 `is_only_spec` 계산에서 `pred == NULL` 대신 이 함수를 사용합니다.

파스 트리는 바꾸지 않고 판정만 바꿉니다. 항상 참 term 을 트리에서 제거하는 방식도 검토했으나, 위치 정보(`location > 0`)를 가진 외부조인 ON 절의 항상 참 term 을 지우면 `qo_rewrite_queries_post ()` 의 ON 절 복원 대상이 사라지고 auto-parameterize 시점과의 순서 의존이 생겨 기각했습니다.

`or_next` 가 있는 conjunct 는 보수적으로 참으로 보지 않습니다. 다만 `1=1 OR <pred>` 처럼 상수 참이 폴딩 단계에서 단일 참 값으로 접히는 경우는(`pt_fold_const_expr ()` 의 `PT_OR` 처리) 결과적으로 no-op 로 인식됩니다.

## Remarks

회귀가 아니라 기존 동작의 개선입니다.

**검증** (release 빌드, SA 모드, `OPT LEVEL 513`, 좌외부조인 미매칭 행 포함 데이터)

| # | 바깥 조건 | before | after | 결과 행 |
|---|---|---|---|---|
| A0 | 없음 | 머징 | 머징 | 동일 |
| A1 | `WHERE TRUE` | 머징 | 머징 | 동일 |
| A2 | `WHERE 1=1` | 미머징 | **머징** | 동일 |
| A3 | `WHERE 'a'='a'` | 미머징 | **머징** | 동일 |
| A4 | `WHERE 1=1 AND 2=2` | 미머징 | **머징** | 동일 |
| B1 | `WHERE v.a > 0` | 미머징 | 미머징 | 동일 |
| B2 | `WHERE 1=1 AND v.a > 0` | 미머징 | 미머징 | 동일 |
| B3 | `WHERE 1=0` | no results | no results | 동일 |
| B4 | `WHERE 1=1 OR v.a > 0` | 미머징 | **머징** | 동일 |
| B5 | 내부조인 뷰 + `1=1` | 머징 | 머징 | 동일 |
| B6 | GROUP BY 뷰 + `1=1` | 미머징 | 미머징 | 동일 |
| B7 | 뷰 안 ORDER BY + `1=1` | 미머징 | 미머징 | 동일 |
| B8 | `WHERE ROWNUM <= 10` | 미머징 | 미머징 | 동일 |

의도한 4건(A2/A3/A4/B4)만 바뀌었고 **모든 케이스에서 결과 집합은 동일**합니다(외부조인 NULL 확장 행 포함). 무관한 조인/서브쿼리 쿼리셋 2종을 before/after 로 돌려 재작성 쿼리·결과 diff 0 을 확인했습니다.

변경은 구조적으로 "메인 쿼리의 WHERE 가 전부 상수 참일 때"에만 동작하며, 그 경우 머징 결과는 WHERE 가 아예 없을 때(A0)와 동일합니다.

**후속 과제**: 상수 폴딩 walk 이후 항상 참 conjunct 를 목록에서 제거하면 이 판정뿐 아니라 `where == NULL` 을 보는 다른 판정들도 일괄 정리됩니다. 다만 영향 범위가 넓어 별도 이슈로 다루는 것이 안전합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
