### PR TITLE
[CBRD-27203] Increase the size of the buffer for the function name in  pt_find_function_name()

### DIFF
--- a/src/parser/keyword.c
+++ b/src/parser/keyword.c
@@ -1105,7 +1105,7 @@ pt_find_function_name (const char *text)
 #endif
     }
 
-  char temp[MAX_KEYWORD_SIZE];
+  char temp[DB_MAX_IDENTIFIER_LENGTH];
 
   dummy.keyword = temp;
   return (FUNCTION_MAP *) find_keyword_tables (functions, dummy, finfo, keyword_hash_comparator < FUNCTION_MAP >, text);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27203>

### Purpose

- 버퍼 크기가 작아서 메모리 overwrite가 발생하는 현상 수정

### Implementation

N/A

### Remarks

N/A
