### PR TITLE
[CBRD-26561] Fix incorrect casting of negative numeric values (zero integer part, non-zero scale) to bigint (#6855)

### DIFF
--- a/src/query/numeric_opfunc.c
+++ b/src/query/numeric_opfunc.c
@@ -2371,29 +2371,39 @@ numeric_coerce_num_to_bigint (DB_C_NUMERIC arg, int scale, DB_BIGINT * answer)
   if (scale > 0)
     {
       numeric_div (arg, numeric_get_pow_of_10 (scale), zero_scale_arg, rem);
-      if (!numeric_is_negative (zero_scale_arg))
+      if (!numeric_is_zero (rem))
 	{
-	  numeric_negate (rem);
-	}
-
-      /* round */
-      numeric_add (numeric_get_pow_of_10 (scale), rem, tmp, DB_NUMERIC_BUF_SIZE);
-      numeric_add (tmp, rem, tmp, DB_NUMERIC_BUF_SIZE);
-      if (numeric_is_negative (tmp) || numeric_is_zero (tmp))
-	{
-	  if (numeric_is_negative (zero_scale_arg))
+	  /* The signs of the input, quotient(except for zero), and remainder will be the same. 
+	     Here, we force 'rem' to be negative */
+	  if (!numeric_is_negative (rem))
 	    {
-	      numeric_decrease (zero_scale_arg);
+	      numeric_negate (rem);
 	    }
-	  else
+
+	  /* round */
+	  /* If (10^'scale' + 'rem' + 'rem') <= 0 (where 'rem' is a negative remainder), round up; otherwise, disregard. 
+	   * If adding the negative remainder twice to a power of 10 results in a negative value, the remainder is considered large enough to round up.
+	   * Otherwise, it is disregarded. 
+	   * Note: Since the remainder is expressed as a negative value, addition is used instead of subtraction.
+	   */
+	  numeric_add (numeric_get_pow_of_10 (scale), rem, tmp, DB_NUMERIC_BUF_SIZE);
+	  numeric_add (tmp, rem, tmp, DB_NUMERIC_BUF_SIZE);
+	  if (numeric_is_negative (tmp) || numeric_is_zero (tmp))
 	    {
-	      numeric_increase (zero_scale_arg);
+	      if (numeric_is_negative (arg))
+		{
+		  numeric_decrease (zero_scale_arg);
+		}
+	      else
+		{
+		  numeric_increase (zero_scale_arg);
+		}
 	    }
 	}
     }
   else
     {
-      numeric_copy (zero_scale_arg, arg);
+      zero_scale_arg = arg;
     }
 
   if (!numeric_is_bigint (zero_scale_arg))


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26561

* Fix error when casting negative numeric values with a zero integer part (e.g., -0.xxx) to BIGINT
* backport #6855 
