### PR TITLE
[CBRD-26639] User cache information is not cleared during a rollback in SA_MODE (#6959)

### DIFF
--- a/src/object/work_space.c
+++ b/src/object/work_space.c
@@ -2541,6 +2541,13 @@ ws_clear_internal (bool clear_vmop_keys)
 void
 ws_clear (void)
 {
+#if defined(SA_MODE)
+  /* In SA_MODE, rollback calls ws_clear() instead of ws_abort_mops().
+   * ws_abort_mops() already calls au_reset_authorization_caches() in CS_MODE,
+   * so we must do it here explicitly for the SA_MODE path. 
+   */
+  au_reset_authorization_caches ();
+#endif
   ws_clear_internal (false);
 }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26639

* User information remains in cache after rollback in csql -S
* backport #6959 
