### PR TITLE
[CUBRIDQA-1506] CI: suspend the develop build transport until the GHA migration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -476,15 +476,6 @@ jobs:
     steps:
       - build-cubrid:
           ccache-prefix: ccache-global-v2
-      # The release build is packaged only on develop, where it is preserved in
-      # GlusterFS for downstream consumers. PR pipelines test the debug build,
-      # so packaging release there would upload an artifact nobody reads.
-      - when:
-          condition:
-            equal: [ develop, << pipeline.git.branch >> ]
-          steps:
-            - package-build:
-                mode: release
 
   build_debug:
     executor: cubrid-build
@@ -493,14 +484,14 @@ jobs:
           ccache-prefix: ccache-debug-v2
           mode: optdebug
           build-args: "-m optdebug"
-      # Package when a test job will consume it, or on develop for preservation.
-      # Not for shell: it builds on its own node now (CUBRIDQA-1506).
+      # Package only when a test job will consume it. Not for shell (it builds
+      # on its own node) and not for develop preservation (the transport is
+      # suspended until the GitHub Actions migration) -- CUBRIDQA-1506.
       - when:
           condition:
             or:
               - << pipeline.parameters.run_sql_test >>
               - << pipeline.parameters.run_medium_test >>
-              - equal: [ develop, << pipeline.git.branch >> ]
           steps:
             - package-build:
                 mode: debug
@@ -699,13 +690,6 @@ workflows:
       - test_shell:
           requires: [download-build]
           filters: pipeline.parameters.run_shell_test
-      # develop merge: transport only. Both builds are preserved in GlusterFS for
-      # downstream consumers (AI agent service); no test job runs on this path.
-      # Requires both builds so a release-only regression still blocks the upload.
-      - download-build:
-          name: store-build-develop
-          for-shell-tests: false
-          requires: [build, build_debug]
-          filters:
-            branches:
-              only: develop
+      # The develop transport (store-build-develop, CUBRIDQA-1476) is suspended:
+      # moving 2 x 290MB over the shared 30Mbps line took ~24 minutes per merge.
+      # Its consumers get the same behaviour back on GitHub Actions -- CUBRIDQA-1506.


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1506>

### Purpose

develop 머지마다 `store-build-develop`(#7583, CUBRIDQA-1476)가 패키징된 빌드 2개(release+debug, 합계 약 580MB)를 IDC 공유 30Mbps 회선으로 받아 GlusterFS에 보존합니다. 노드 빌드 전환(#7618) 후 첫 develop 머지에서 이 전송이 **1,457초(약 24분)** 걸렸고, 그동안 회선을 다른 서비스와 나눠 씁니다. 소비자(AI agent 서비스)는 CI와 함께 GitHub Actions로 이관(CUBRIDQA-1501)될 예정이므로, CircleCI 구간의 전송을 임시 중단합니다.

### Implementation

- develop 머지에서 빌드 보존 전송이 더 이상 돌지 않습니다 — 워크플로의 `store-build-develop` 엔트리를 제거했습니다.
- 전송이 없어지면 develop에서의 패키징은 아무도 읽지 않는 아티팩트 업로드가 되므로 함께 제거했습니다: `build`는 release 패키징이 사라지고(유일한 패키징 지점이었음), `build_debug`는 sql/medium 테스트가 소비할 때만 패키징합니다.
- PR 파이프라인(sql/medium/shell)과 ccache 캐시 저장 동작은 바뀌지 않습니다.
- `download-build` job 정의는 이제 아무도 호출하지 않지만 남겨뒀습니다 — CUBRIDQA-1506의 나머지와 같은 원칙으로, 리버트 diff를 최소화하기 위함입니다.

### Remarks

- 이 변경은 CUBRIDQA-1506의 임시조치 연장이며, GitHub Actions 이관 시 같은 보존 동작이 전송 없이(빌드가 이미 노드에서 만들어지므로) 복원됩니다.
- 되돌리기: 이 PR revert 한 번이면 됩니다. 인프라 변경 없음.
- 머지 후 develop 머지 파이프라인은 build/build_debug(컴파일 검증 + ccache 갱신)만 돌고 약 24분 짧아집니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

