### PR TITLE
[CBRD-26395] file_io.h/c에서 backup/restore 관련된 함수들을 cs 빌드에서 제외

### DIFF
--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -489,8 +489,10 @@ static int fileio_initialize_volume_info_cache (void);
 static void fileio_make_volume_lock_name (char *vol_lockname, const char *vol_fullname);
 static int fileio_create (THREAD_ENTRY * thread_p, const char *db_fullname, const char *vlabel, VOLID volid,
 			  bool dolock, bool dosync);
+#if defined (SERVER_MODE) || defined (SA_MODE)
 static int fileio_create_backup_volume (THREAD_ENTRY * thread_p, const char *db_fullname, const char *vlabel,
 					VOLID volid, bool dolock, bool dosync, int atleast_pages);
+#endif /* defined (SERVER_MODE) || (SA_MODE) */
 static int fileio_max_permanent_volumes (int index, int num_permanent_volums);
 static int fileio_min_temporary_volumes (int index, int num_temp_volums, int num_volinfo_array);
 static FILEIO_SYSTEM_VOLUME_INFO *fileio_traverse_system_volume (THREAD_ENTRY * thread_p,
@@ -542,6 +544,7 @@ static FILEIO_LOCKF_TYPE fileio_get_lockf_type (int vdes);
 #endif /* !WINDOWS */
 
 static int fileio_get_primitive_way_max (const char *path, long int *filename_max, long int *pathname_max);
+#if defined (SERVER_MODE) || defined (SA_MODE)
 static int fileio_flush_backup (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session);
 static ssize_t fileio_read_backup (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session, int pageid);
 static int fileio_write_backup (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session, ssize_t towrite_nbytes);
@@ -560,9 +563,11 @@ static FILEIO_RELOCATION_VOLUME fileio_find_restore_volume (THREAD_ENTRY * threa
 							    int reason);
 
 static int fileio_get_next_backup_volume (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session, bool user_new);
+#endif /* defined (SERVER_MODE) || (SA_MODE) */
 static int fileio_initialize_backup_info (int which_bkvinf);
 static FILEIO_BACKUP_INFO_ENTRY *fileio_allocate_backup_info (int which_bkvinf);
 
+#if defined (SERVER_MODE) || defined (SA_MODE)
 static FILEIO_BACKUP_SESSION *fileio_continue_restore (THREAD_ENTRY * thread_p, const char *db_fullname,
 						       INT64 db_creation, FILEIO_BACKUP_SESSION * session,
 						       bool first_time, bool authenticate, INT64 match_bkupcreation);
@@ -575,7 +580,9 @@ static FILEIO_NODE *fileio_delete_queue_head (FILEIO_QUEUE * qp);
 static int fileio_compress_backup_node (FILEIO_NODE * node, FILEIO_BACKUP_HEADER * backup_hdr);
 static int fileio_write_backup_node (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session, FILEIO_NODE * node,
 				     FILEIO_BACKUP_HEADER * backup_hdr);
+#endif /* defined (SERVER_MODE) || (SA_MODE) */
 static char *fileio_ctime (INT64 * clock, char *buf);
+#if defined (SERVER_MODE) || defined (SA_MODE)
 static const char *fileio_get_backup_level_string (FILEIO_BACKUP_LEVEL level);
 
 static int fileio_initialize_backup_thread (FILEIO_BACKUP_SESSION * session_p, int num_threads);
@@ -583,6 +590,7 @@ static void fileio_finalize_backup_thread (FILEIO_BACKUP_SESSION * session_p, FI
 static int fileio_write_backup_end_time_to_header (FILEIO_BACKUP_SESSION * session_p, INT64 end_time);
 static void fileio_write_backup_end_time_to_last_page (FILEIO_BACKUP_SESSION * session_p, INT64 end_time);
 static void fileio_read_backup_end_time_from_last_page (FILEIO_BACKUP_SESSION * session_p);
+#endif /* defined (SERVER_MODE) || (SA_MODE) */
 
 #if !defined(WINDOWS)
 static int fileio_get_lock (int fd, const char *vlabel);
@@ -602,9 +610,11 @@ static int fileio_flush_control_get_token (THREAD_ENTRY * thread_p, int ntoken);
 static int fileio_flush_control_get_desired_rate (TOKEN_BUCKET * tb);
 static int fileio_synchronize_bg_archive_volume (THREAD_ENTRY * thread_p);
 
+#if defined (SERVER_MODE) || defined (SA_MODE)
 static void fileio_page_bitmap_set (FILEIO_RESTORE_PAGE_BITMAP * page_bitmap, int page_id);
 static bool fileio_page_bitmap_is_set (FILEIO_RESTORE_PAGE_BITMAP * page_bitmap, int page_id);
 static void fileio_page_bitmap_dump (FILE * out_fp, const FILEIO_RESTORE_PAGE_BITMAP * page_bitmap);
+#endif /* defined (SERVER_MODE) || (SA_MODE) */
 
 static int
 fileio_increase_flushed_page_count (int npages)
@@ -2200,6 +2210,7 @@ fileio_create (THREAD_ENTRY * thread_p, const char *db_full_name_p, const char *
   return vol_fd;
 }
 
+#if defined (SERVER_MODE) || defined (SA_MODE)
 /*
  * fileio_create_backup_volume () - CREATE A BACKUP VOLUME (INSURE ENOUGH SPACE EXISTS)
  *   return: volume descriptor identifier on success, NULL_VOLDES on failure
@@ -2277,6 +2288,7 @@ fileio_create_backup_volume (THREAD_ENTRY * thread_p, const char *db_full_name_p
 
   return (fileio_create (thread_p, db_full_name_p, vol_label_p, vol_id, is_do_lock, is_do_sync));
 }
+#endif /* defined (SERVER_MODE) || (SA_MODE) */
 
 /*
  * fileio_format () - Format a volume of npages and mount the volume
@@ -5712,6 +5724,7 @@ fileio_make_log_active_name (char *log_active_name_p, const char *log_path_p, co
 
 }
 
+#if defined (SERVER_MODE) || defined (SA_MODE)
 /*
  * fileio_make_temp_log_files_from_backup () - Build the name of volumes
  *   return: void
@@ -5742,6 +5755,7 @@ fileio_make_temp_log_files_from_backup (char *temp_log_name, VOLID to_volid, FIL
       break;
     }
 }
+#endif /* defined (SERVER_MODE) || (SA_MODE) */
 
 /*
  * fileio_make_log_archive_name () - Build the name of volumes
@@ -5837,6 +5851,7 @@ fileio_make_backup_volume_info_name (char *backup_volinfo_name_p, const char *ba
 	   FILEIO_SUFFIX_BACKUP_VOLINFO);
 }
 
+#if defined (SERVER_MODE) || defined (SA_MODE)
 /*
  * fileio_make_backup_name () - Build the name of volumes
  *   return: void
@@ -5866,6 +5881,7 @@ fileio_make_backup_name (char *backup_name_p, const char *no_path_vol_name_p, co
 	       level);
     }
 }
+#endif /* defined (SERVER_MODE) || (SA_MODE) */
 
 /*
  * fileio_make_dwb_name () - Build the name of DWB volume
@@ -6623,6 +6639,7 @@ fileio_get_lockf_type (int vol_fd)
   return lockf_type;
 }
 
+#if defined (SERVER_MODE) || defined (SA_MODE)
 #if 0
   /* currently, disable the following code. DO NOT DELETE ME NEED FUTURE OPTIMIZATION */
 static void
@@ -7330,7 +7347,6 @@ fileio_read_backup_end_time_from_last_page (FILEIO_BACKUP_SESSION * session_p)
   memcpy ((char *) &(session_p->bkup.bkuphdr->end_time), read_from, sizeof (INT64));
 }
 
-#if defined (SERVER_MODE) || defined (SA_MODE)
 /*
  * fileio_finish_backup () - Finish the backup session successfully
  *   return: session or NULL
@@ -7470,7 +7486,7 @@ fileio_finish_backup (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session_p
 
   return session_p;
 }
-#endif /* SERVER_MODE || SA_MODE */
+#endif /* defined (SERVER_MODE) || (SA_MODE) */
 
 /*
  * fileio_remove_all_backup () - REMOVE ALL BACKUP VOLUMES
@@ -7525,6 +7541,7 @@ fileio_remove_all_backup (THREAD_ENTRY * thread_p, int start_level)
   fileio_clear_backup_info_level (start_level, false, FILEIO_FIRST_BACKUP_VOL_INFO);
 }
 
+#if defined (SERVER_MODE) || defined (SA_MODE)
 /*
  * fileio_allocate_node () -
  *   return:
@@ -10826,6 +10843,7 @@ fileio_get_backup_level_string (FILEIO_BACKUP_LEVEL level)
       return ("UNKNOWN");
     }
 }
+#endif /* defined (SERVER_MODE) || (SA_MODE) */
 
 /*
  * fileio_get_zip_method_string () - return the string name of the compression method
@@ -10875,6 +10893,7 @@ fileio_get_zip_level_string (FILEIO_ZIP_LEVEL zip_level)
     }
 }
 
+#if defined (SERVER_MODE) || defined (SA_MODE)
 /*
  * fileio_get_next_backup_volume () - FIND LOCATION OR NEW VOLUME NAME TO CONTINUE BACKUP
  *   return:
@@ -11021,6 +11040,7 @@ fileio_get_next_backup_volume (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * 
 
   return NO_ERROR;
 }
+#endif /* defined (SERVER_MODE) || (SA_MODE) */
 
 
 /*
@@ -11110,6 +11130,7 @@ fileio_add_volume_to_backup_info (const char *name_p, FILEIO_BACKUP_LEVEL level,
   return NO_ERROR;
 }
 
+#if defined (SERVER_MODE) || defined (SA_MODE)
 /*
  * fileio_write_backup_info_entries () - Prints internal bkvinf table in a format
  *                             suitable for the bkvinf file as well as human
@@ -11145,6 +11166,7 @@ fileio_write_backup_info_entries (FILE * fp, int which_bkvinf)
 
   return NO_ERROR;
 }
+#endif /* defined (SERVER_MODE) || (SA_MODE) */
 
 /*
  * fileio_read_backup_info_entries () - Read and parse the entries in a bkvinf file and
@@ -11380,6 +11402,7 @@ fileio_clear_backup_info_level (int level, bool is_dealloc, int which_bkvinf)
   return NO_ERROR;
 }
 
+#if defined (SERVER_MODE) || defined (SA_MODE)
 /*
  * fileio_request_user_response () - REQUEST A RESPONSE VIA REMOVE CLIENT
  *   return:
@@ -11582,6 +11605,7 @@ fileio_request_user_response (THREAD_ENTRY * thread_p, FILEIO_REMOTE_PROMPT_TYPE
   return (pr_status);
 #endif /* SERVER_MODE */
 }
+#endif /* defined (SERVER_MODE) || (SA_MODE) */
 
 #if !defined(WINDOWS)
 /*
@@ -11682,6 +11706,7 @@ fileio_initialize_res (THREAD_ENTRY * thread_p, FILEIO_PAGE * io_page, PGLENGTH 
 }
 
 
+#if defined (SERVER_MODE) || defined (SA_MODE)
 /*
  * PAGE BITMAP FUNCTIONS
  */
@@ -11913,6 +11938,7 @@ fileio_page_bitmap_dump (FILE * out_fp, const FILEIO_RESTORE_PAGE_BITMAP * page_
     }
   fprintf (out_fp, "\n");
 }
+#endif /* defined (SERVER_MODE) || (SA_MODE) */
 
 /*
  * fileio_page_check_corruption - Check whether the page is corrupted.

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -2258,12 +2258,10 @@ fileio_create_backup_volume (THREAD_ENTRY * thread_p, const char *db_full_name_p
 		  /* sleep for 100 milli-seconds : consider cs & sa mode */
 		  select (0, NULL, NULL, NULL, &to);
 
-#if !defined(CS_MODE)
 		  if (pgbuf_is_log_check_for_interrupts (thread_p) == true)
 		    {
 		      return NULL_VOLDES;
 		    }
-#endif
 		  continue;
 		}
 	      er_set_with_oserror (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_IO_FORMAT_FAIL, 3, vol_label_p, -1, -1LL);
@@ -8243,7 +8241,6 @@ fileio_start_backup_thread (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * ses
 }
 #endif /* SERVER_MODE */
 
-#if !defined(CS_MODE)
 /*
  * fileio_backup_volume () - Include the given database volume/file as part of
  *                       the backup
@@ -8621,7 +8618,6 @@ error:
   session_p->dbfile.vlabel = NULL;
   return ER_FAILED;
 }
-#endif /* !CS_MODE */
 
 /*
  * fileio_flush_backup () - Flush any buffered data
@@ -10288,7 +10284,6 @@ exit_on_error:
   goto exit_on_end;
 }
 
-#if !defined(CS_MODE)
 /*
  * fileio_restore_volume () - Restore a volume/file of given database
  *   return:
@@ -10589,7 +10584,6 @@ error:
 
   return ER_FAILED;
 }
-#endif /* !CS_MODE */
 
 /*
  * fileio_write_restore () - Write the content of the page described by pageid
@@ -10614,9 +10608,7 @@ fileio_write_restore (THREAD_ENTRY * thread_p, FILEIO_RESTORE_PAGE_BITMAP * page
   bool is_set;
   FILEIO_WRITE_MODE write_mode = FILEIO_WRITE_DEFAULT_WRITE;
 
-#if !defined (CS_MODE)
   write_mode = dwb_is_created () == true ? FILEIO_WRITE_NO_COMPENSATE_WRITE : FILEIO_WRITE_DEFAULT_WRITE;
-#endif
 
   if (page_bitmap == NULL)
     {

--- a/src/storage/file_io.c
+++ b/src/storage/file_io.c
@@ -1264,7 +1264,7 @@ again:
 
       if (fp == NULL || fscanf (fp, format_string, user, &pid, host, &tmp_lock_time) != 4)
 	{
-	  strcpy (user, "???");
+	  strncpy_bufsize (user, "???");
 	  strcpy (host, "???");
 	  pid = 0;
 	  lock_time = 0;
@@ -1353,7 +1353,7 @@ again:
 
       if (getuserid (login_name, FILEIO_USER_NAME_SIZE) == NULL)
 	{
-	  strcpy (login_name, "???");
+	  strncpy_bufsize (login_name, "???");
 	}
 
       (void) fprintf (fp, "%s %d %s %ld", login_name, (int) GETPID (), host, time (NULL));
@@ -1456,7 +1456,7 @@ fileio_lock_la_log_path (const char *db_full_name_p, const char *lock_path_p, in
 
       if (fp == NULL || fscanf (fp, format_string, last_deleted_arv_num, user, &pid, host, &tmp_lock_time) != 5)
 	{
-	  strcpy (user, "???");
+	  strncpy_bufsize (user, "???");
 	  strcpy (host, "???");
 	  pid = 0;
 	  lock_time = 0;
@@ -1502,7 +1502,7 @@ fileio_lock_la_log_path (const char *db_full_name_p, const char *lock_path_p, in
 
       if (getuserid (login_name, FILEIO_USER_NAME_SIZE) == NULL)
 	{
-	  strcpy (login_name, "???");
+	  strncpy_bufsize (login_name, "???");
 	}
 
       if (*last_deleted_arv_num < 0)
@@ -1778,7 +1778,7 @@ fileio_check_lockby_file (char *name_info_lock_p)
       sprintf (format_string, "%%%ds %%d %%%ds", FILEIO_USER_NAME_SIZE - 1, CUB_MAXHOSTNAMELEN - 1);
       if (fscanf (fp, format_string, user, &pid, host) != 3)
 	{
-	  strcpy (user, "???");
+	  strncpy_bufsize (user, "???");
 	  strcpy (host, "???");
 	  pid = 0;
 	}
@@ -4780,10 +4780,7 @@ fileio_read_user_area (THREAD_ENTRY * thread_p, int vol_fd, PAGEID page_id, off_
 
   memcpy (area_p, io_page_p->page + start_offset, nbytes);
 
-  if (io_page_p != NULL)
-    {
-      free_and_init (io_page_p);
-    }
+  free_and_init (io_page_p);
 
   perfmon_inc_stat (thread_p, PSTAT_FILE_NUM_IOREADS);
   return area_p;

--- a/src/storage/file_io.h
+++ b/src/storage/file_io.h
@@ -529,8 +529,10 @@ extern void fileio_make_volume_ext_given_name (char *volext_fullname, const char
 extern void fileio_make_volume_temp_name (char *voltmp_fullname, const char *tmp_path, const char *tmp_name,
 					  VOLID volid);
 extern void fileio_make_log_active_name (char *logactive_name, const char *log_path, const char *dbname);
+#if defined (SERVER_MODE) || defined (SA_MODE)
 extern void fileio_make_temp_log_files_from_backup (char *temp_log_name, VOLID volid, FILEIO_BACKUP_LEVEL level,
 						    const char *base_log_name);
+#endif /* defined (SERVER_MODE) || (SA_MODE) */
 extern void fileio_make_log_archive_name (char *logarchive_name, const char *log_path, const char *dbname, int arvnum);
 extern void fileio_make_removed_log_archive_name (char *logarchive_name, const char *log_path, const char *dbname);
 extern void fileio_make_log_archive_temp_name (char *log_archive_temp_name_p, const char *log_path_p,
@@ -538,8 +540,10 @@ extern void fileio_make_log_archive_temp_name (char *log_archive_temp_name_p, co
 extern void fileio_make_log_info_name (char *loginfo_name, const char *log_path, const char *dbname);
 extern void fileio_make_backup_volume_info_name (char *backup_volinfo_name, const char *backinfo_path,
 						 const char *dbname);
+#if defined (SERVER_MODE) || defined (SA_MODE)
 extern void fileio_make_backup_name (char *backup_name, const char *nopath_volname, const char *backup_path,
 				     FILEIO_BACKUP_LEVEL level, int unit_num);
+#endif /* defined (SERVER_MODE) || (SA_MODE) */
 extern void fileio_make_dwb_name (char *dwb_name_p, const char *dwb_path_p, const char *db_name_p);
 extern void fileio_make_keys_name (char *keys_name_p, const char *db_name_p);
 extern void fileio_make_keys_name_given_path (char *keys_name_p, const char *keys_path_p, const char *db_name_p);
@@ -547,6 +551,7 @@ extern void fileio_make_keys_name_given_path (char *keys_name_p, const char *key
 extern void fileio_make_ha_sock_name (char *sock_path_p, const char *base_path_p, const char *sock_name_p);
 #endif /* UNSTABLE_TDE_FOR_REPLICATION_LOG */
 extern void fileio_remove_all_backup (THREAD_ENTRY * thread_p, int level);
+#if defined (SERVER_MODE) || defined (SA_MODE)
 extern FILEIO_BACKUP_SESSION *fileio_initialize_backup (const char *db_fullname, const char *backup_destination,
 							FILEIO_BACKUP_SESSION * session, FILEIO_BACKUP_LEVEL level,
 							const char *verbose_file_path, int num_threads,
@@ -580,21 +585,26 @@ extern int fileio_restore_volume (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION
 				  bool remember_pages, bool & is_prev_vheader_restored,
 				  FILEIO_UNLINKED_VOLINFO_MAP & unlinked_vol_info);
 extern int fileio_skip_restore_volume (THREAD_ENTRY * thread_p, FILEIO_BACKUP_SESSION * session);
+#endif /* defined (SERVER_MODE) || (SA_MODE) */
 extern const char *fileio_get_zip_method_string (FILEIO_ZIP_METHOD zip_method);
 extern const char *fileio_get_zip_level_string (FILEIO_ZIP_LEVEL zip_level);
 
 
 extern int fileio_read_backup_info_entries (FILE * fp, int which_bkvinf);
+#if defined (SERVER_MODE) || defined (SA_MODE)
 extern int fileio_write_backup_info_entries (FILE * fp, int which_bkvinf);
+#endif /* defined (SERVER_MODE) || (SA_MODE) */
 extern const char *fileio_get_backup_info_volume_name (FILEIO_BACKUP_LEVEL level, int unit_num, int which_bkvinf);
 extern int fileio_add_volume_to_backup_info (const char *name, FILEIO_BACKUP_LEVEL level, int unit_num,
 					     int which_bkvinf);
 extern int fileio_clear_backup_info_level (int level, bool dealloc, int which_bkvinf);
 extern void fileio_finalize_backup_info (int which_bkvinf);
 
+#if defined (SERVER_MODE) || defined (SA_MODE)
 extern int fileio_request_user_response (THREAD_ENTRY * thread_p, FILEIO_REMOTE_PROMPT_TYPE prompt_id,
 					 const char *prompt, char *response, const char *failure_prompt, int range_low,
 					 int range_high, const char *secondary_prompt, int reprompt_value);
+#endif /* defined (SERVER_MODE) || (SA_MODE) */
 
 #if !defined(WINDOWS)
 extern FILEIO_LOCKF_TYPE fileio_lock_la_log_path (const char *db_fullname, const char *lock_path, int vdes,
@@ -619,6 +629,7 @@ extern void fileio_flush_control_finalize (void);
 extern int fileio_flush_control_add_tokens (THREAD_ENTRY * thread_p, INT64 diff_usec, int *token_gen,
 					    int *token_consumed);
 
+#if defined (SERVER_MODE) || defined (SA_MODE)
 extern void fileio_page_bitmap_list_init (FILEIO_RESTORE_PAGE_BITMAP_LIST * page_bitmap_list);
 extern FILEIO_RESTORE_PAGE_BITMAP *fileio_page_bitmap_create (int vol_id, int total_pages);
 extern FILEIO_RESTORE_PAGE_BITMAP *fileio_page_bitmap_list_find (FILEIO_RESTORE_PAGE_BITMAP_LIST * page_bitmap_list,
@@ -626,6 +637,7 @@ extern FILEIO_RESTORE_PAGE_BITMAP *fileio_page_bitmap_list_find (FILEIO_RESTORE_
 extern void fileio_page_bitmap_list_add (FILEIO_RESTORE_PAGE_BITMAP_LIST * page_bitmap_list,
 					 FILEIO_RESTORE_PAGE_BITMAP * page_bitmap);
 extern void fileio_page_bitmap_list_destroy (FILEIO_RESTORE_PAGE_BITMAP_LIST * page_bitmap_list);
+#endif /* defined (SERVER_MODE) || (SA_MODE) */
 extern int fileio_set_page_checksum (THREAD_ENTRY * thread_p, FILEIO_PAGE * io_page);
 extern int fileio_page_check_corruption (THREAD_ENTRY * thread_p, FILEIO_PAGE * io_page, bool * is_page_corrupted);
 extern void fileio_page_hexa_dump (const char *data, int length);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26395

### Purpose
* file_io.h/c에서 backup/restore 관련 함수들을 cs 빌드에서 제외
* 해당 함수는 cs 라이브러리에서 사용 안됨
* backup/restore 관련된 함수는 sa 또는 서버 라이브러리(libcubrid.so)에서만 사용 됨

### Implementation
* #if defined (SERVER_MODE) || defined (SA_MODE) ~ #endif /* defined (SERVER_MODE) || (SA_MODE) */ 처리
    * 이 범위의 CS_MODE 관련 매크로 제거
* 파일 분리하는 방안도 있으나 매크로로 처리

### Remarks
* ai가 작업한 결과 - 리뷰 꼼꼼히
* restore의 경우 sa_mode만 지원하나 call path 구조 상 동일하게 처리
* cppcheck 실패 수정 포함
