### PR TITLE
[CBRD-27168] Keep at least one connection worker on a single core

### DIFF
--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -5262,6 +5262,7 @@ SYSPRM_PARAM prm_Def[] = {
    {false, {.i = prm_default_max_connection_worker ()}},
    {false, {.i = (int) cubthread::system_core_count ()}},
 #else
+   /* TODO: unused - the connection pool is server-only; to be removed */
    {false, {.i = 2}},
    {false, {.i = 2}},
    NULL_SYSPRM_PARAM_VALUE,

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -1015,6 +1015,27 @@ static int prm_equal_to_ori (void *out_val, SYSPRM_DATATYPE out_type, void *in_v
 static void update_session_state_from_sys_params (THREAD_ENTRY * thread_p, SESSION_PARAM * session_params);
 #endif
 
+#if defined (SERVER_MODE)
+/*
+ * prm_default_max_connection_worker () - built-in default value of max_connection_worker
+ *   return: half of the cores available to the server, but never less than one
+ *
+ * Note: cubthread::system_core_count () returns 1 on a single core machine and also when the server
+ *       is restricted to a single core (taskset, docker --cpuset-cpus, cpu manager, ...). Halving it
+ *       without a lower bound gives 0, and a connection pool with no connection worker cannot serve
+ *       any client. The lower bound is the lower limit declared for the parameter.
+ */
+static int
+prm_default_max_connection_worker (void)
+{
+  int half_of_cores;
+
+  half_of_cores = (int) cubthread::system_core_count () / 2;
+
+  return half_of_cores < 1 ? 1 : half_of_cores;
+}
+#endif /* SERVER_MODE */
+
 static const SYSPRM_PARAM_VALUE NULL_SYSPRM_PARAM_VALUE = { true, {.str = NULL} };
 
 
@@ -5237,8 +5258,8 @@ SYSPRM_PARAM prm_Def[] = {
    PRM_INTEGER,
    PRM_CLEAR_DYNAMIC_FLAG,
 #if defined (SERVER_MODE)
-   {false, {.i = (int) cubthread::system_core_count () / 2}},
-   {false, {.i = (int) cubthread::system_core_count () / 2}},
+   {false, {.i = prm_default_max_connection_worker ()}},
+   {false, {.i = prm_default_max_connection_worker ()}},
    {false, {.i = (int) cubthread::system_core_count ()}},
 #else
    {false, {.i = 2}},

--- a/src/connection/connection_pool.cpp
+++ b/src/connection/connection_pool.cpp
@@ -333,6 +333,8 @@ namespace cubconn::connection
 	cores = vec;
       }
 
+    /* the pool cannot serve any client without at least one connection worker */
+    assert (max_connection_workers >= 1);
     assert (cores.size () >= max_connection_workers);
 
     for (i = 0; i < max_connection_workers; i++)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27168

### Purpose
사용 가능한 코어가 1개로 산정되면 max_connection_worker 기본값이 system_core_count() / 2 = 0 이 되어 connection worker가 하나도 생성되지 않습니다. 서버 기동은 성공하지만 어떤 클라이언트도 접속할 수 없고, 서버 에러 로그에도 아무 기록이 남지 않습니다. 재현율 100%입니다.

### Implementation
최소 1이 되도록 수정

### Remarks
N/A
