### PR TITLE
[CBRD-26927] [Backport] Read hash-aggregate tuple before freeing its list page

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -3991,6 +3991,14 @@ qexec_hash_gby_put_next (THREAD_ENTRY * thread_p, const RECDES * recdes, void *a
 	    {
 	      peek = PEEK;	/* avoid unnecessary COPY */
 	    }
+
+	  /* read tuple into value */
+	  if (qdata_load_agg_hentry_from_tuple (thread_p, data, context->temp_part_key, context->temp_part_value,
+						context->key_domains, context->accumulator_domains) != NO_ERROR)
+	    {
+	      qmgr_free_old_page_and_init (thread_p, page, list_idp->tfile_vfid);
+	      return ER_FAILED;
+	    }
 	  qmgr_free_old_page_and_init (thread_p, page, list_idp->tfile_vfid);
 	}
       else
@@ -4004,13 +4012,13 @@ qexec_hash_gby_put_next (THREAD_ENTRY * thread_p, const RECDES * recdes, void *a
 	      return ER_FAILED;
 	    }
 	  data = context->tuple_recdes.data;
-	}
 
-      /* read tuple into value */
-      if (qdata_load_agg_hentry_from_tuple (thread_p, data, context->temp_part_key, context->temp_part_value,
-					    context->key_domains, context->accumulator_domains) != NO_ERROR)
-	{
-	  return ER_FAILED;
+	  /* read tuple into value */
+	  if (qdata_load_agg_hentry_from_tuple (thread_p, data, context->temp_part_key, context->temp_part_value,
+						context->key_domains, context->accumulator_domains) != NO_ERROR)
+	    {
+	      return ER_FAILED;
+	    }
 	}
 
       /* aggregate */


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26927>

### Purpose

`qexec_hash_gby_put_next` 는 list-file 페이지 내부를 가리키는 tuple 포인터(`data`)를 `qmgr_free_old_page_and_init` 으로 페이지를 unfix 한 뒤에 `qdata_load_agg_hentry_from_tuple` 로 읽습니다. 해제된 페이지가 다른 워커에 재사용되면 깨진 바이트를 tuple 로 해석하다 `or_advance` assert 로 서버가 SIGABRT 됩니다.

tuple 읽기를 페이지 unfix 이전으로 이동해, 항상 fix 된 유효한 버퍼에서 읽도록 수정합니다.

develop `097af16f8` (#7346) 의 clean cherry-pick 입니다.