### PR TITLE
[CBRD-27036] Isolate the prefix-LIKE derived-range correction in qo_iscan_cost

### DIFF
--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -2050,6 +2050,12 @@ qo_analyze_term (QO_TERM * term, int term_type)
       QO_TERM_SET_FLAG (term, QO_TERM_LIKE_DERIVED_RANGE);
     }
 
+  if (PT_EXPR_INFO_IS_FLAGED (pt_expr, PT_EXPR_INFO_LIKE_HAS_DERIVED_RANGE))
+    {
+      /* the LIKE the range above was derived from */
+      QO_TERM_SET_FLAG (term, QO_TERM_LIKE_HAS_DERIVED_RANGE);
+    }
+
   /* only interesting in one predicate term; if 'term' has 'or_next', it was derived from OR term */
   /* also cases that are too complicated and unusual to consider here: (cond and/or cond) is true/false (cond and/or
    * cond) =/!= (cond and/or cond).

--- a/src/optimizer/query_graph.h
+++ b/src/optimizer/query_graph.h
@@ -754,7 +754,8 @@ struct qo_term
 #define QO_TERM_OR_PRED             256	/* or predicate. e.g.) a=1 or b=2 */
 #define QO_TERM_IMPLIED             512	/* join term implied by transitive closure, not from a user predicate */
 #define QO_TERM_SEL_FROM_HISTOGRAM  1024	/* selectivity computed from histograms only */
-#define QO_TERM_LIKE_DERIVED_RANGE  2048	/* range term derived from a prefix LIKE; skip in row-count selectivity */
+#define QO_TERM_LIKE_DERIVED_RANGE  2048	/* range term derived from a prefix LIKE */
+#define QO_TERM_LIKE_HAS_DERIVED_RANGE 4096	/* the prefix LIKE a range was derived from */
 
 #define QO_TERM_IS_FLAGED(t, f)        (QO_TERM_FLAG(t) & (int) (f))
 #define QO_TERM_SET_FLAG(t, f)         QO_TERM_FLAG(t) |= (int) (f)

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -190,6 +190,7 @@ static void qo_plan_compute_subquery_cost (PT_NODE *, double *, double *);
 static void qo_sscan_cost (QO_PLAN *);
 static void qo_iscan_cost (QO_PLAN *);
 static bool qo_index_forbids_key_filter (QO_INDEX_ENTRY *);
+static double qo_like_derived_range_dup_sel (QO_PLAN *);
 static void qo_sort_cost (QO_PLAN *);
 static void qo_mjoin_cost (QO_PLAN *);
 static void qo_nljoin_cost (QO_PLAN *);
@@ -1805,10 +1806,7 @@ qo_index_has_bit_attr (QO_INDEX_ENTRY * index_entryp)
  *   return: true if key-filters are disabled for this index
  *   index_entryp(in):
  *
- * note: A non-covering function index is the only such case. This predicate is
- *   shared by qo_index_scan_new() (which then skips kf_terms population) and
- *   qo_iscan_cost() (which then keeps a LIKE-derived range in the row-count) so
- *   the two sites never drift apart.
+ * note: A non-covering function index is the only such case.
  */
 static bool
 qo_index_forbids_key_filter (QO_INDEX_ENTRY * index_entryp)
@@ -2116,6 +2114,75 @@ qo_index_scan_new (QO_INFO * info, QO_NODE * node, QO_NODE_INDEX_ENTRY * ni_entr
 }
 
 /*
+ * qo_like_derived_range_dup_sel () - selectivity of a prefix-LIKE derived range that the
+ *   row-count product of this index scan would count for a second time
+ *   return: the selectivity to cancel, 1.0 when there is nothing to cancel
+ *   planp(in): index scan plan
+ *
+ * note: qo_rewrite_like_for_index_scan () keeps the original LIKE and adds a range derived
+ *   from its fixed prefix, so one predicate turns into two terms. The rows matching the LIKE
+ *   are a subset of that range, so once both terms enter the same product the range restricts
+ *   nothing on top of the LIKE and its selectivity is counted for free. The pair is matched by
+ *   segment rather than by identity, because qo_apply_range_intersection () may merge several
+ *   derived ranges into a single term.
+ *
+ *   Nothing is cancelled unless the LIKE became a key filter. A non-covering function index
+ *   forbids key filters, and the LIKE then stays a data filter evaluated after the fetch -
+ *   there the range really is the only restriction the fetch count may use.
+ */
+static double
+qo_like_derived_range_dup_sel (QO_PLAN * planp)
+{
+  QO_ENV *env;
+  QO_TERM *termp;
+  BITSET_ITERATOR iter;
+  BITSET like_segs;
+  double dup_sel = 1.0;
+  int t;
+
+  env = QO_NODE_ENV (planp->plan_un.scan.node);
+  bitset_init (&like_segs, env);
+
+  /* the LIKEs that a range was derived from and that ended up as key filters */
+  for (t = bitset_iterate (&(planp->plan_un.scan.kf_terms), &iter); t != -1; t = bitset_next_member (&iter))
+    {
+      termp = QO_ENV_TERM (env, t);
+      if (QO_TERM_IS_FLAGED (termp, QO_TERM_LIKE_HAS_DERIVED_RANGE))
+	{
+	  bitset_union (&like_segs, &(QO_TERM_SEGS (termp)));
+	}
+    }
+
+  if (!bitset_is_empty (&like_segs))
+    {
+      /* their derived ranges; a derived range may serve as a key range or as a key filter */
+      for (t = bitset_iterate (&(planp->plan_un.scan.terms), &iter); t != -1; t = bitset_next_member (&iter))
+	{
+	  termp = QO_ENV_TERM (env, t);
+	  if (QO_TERM_IS_FLAGED (termp, QO_TERM_LIKE_DERIVED_RANGE)
+	      && bitset_intersects (&(QO_TERM_SEGS (termp)), &like_segs))
+	    {
+	      dup_sel *= QO_TERM_SELECTIVITY (termp);
+	    }
+	}
+
+      for (t = bitset_iterate (&(planp->plan_un.scan.kf_terms), &iter); t != -1; t = bitset_next_member (&iter))
+	{
+	  termp = QO_ENV_TERM (env, t);
+	  if (QO_TERM_IS_FLAGED (termp, QO_TERM_LIKE_DERIVED_RANGE)
+	      && bitset_intersects (&(QO_TERM_SEGS (termp)), &like_segs))
+	    {
+	      dup_sel *= QO_TERM_SELECTIVITY (termp);
+	    }
+	}
+    }
+
+  bitset_delset (&like_segs);
+
+  return dup_sel;
+}
+
+/*
  * qo_iscan_cost () -
  *   return:
  *   planp(in):
@@ -2130,7 +2197,7 @@ qo_iscan_cost (QO_PLAN * planp)
   double sel, sel_limit, height, leaves, opages, filter_sel, leaf_access, heap_access, heap_rows;
   double heap_fanout = 0.0, iss_leaves = 0.0, first_leaf = 0.0;
   double object_IO, index_IO;
-  double sel_excl_derived_range;
+  double heap_sel, dup_sel;
   QO_TERM *termp;
   BITSET_ITERATOR iter;
   int i, t, n, pkeys_num, index;
@@ -2177,10 +2244,6 @@ qo_iscan_cost (QO_PLAN * planp)
 
   /* selectivity of the index terms */
   sel = 1.0;
-  /* like sel, but excludes LIKE-derived range terms: used for output-row
-   * estimates only, not index access cost, to avoid double counting the
-   * retained LIKE. */
-  sel_excl_derived_range = 1.0;
 
   pkeys_num = MIN (n, cum_statsp->pkeys_size);
   assert (pkeys_num <= BTREE_STATS_PKEYS_NUM);
@@ -2195,25 +2258,6 @@ qo_iscan_cost (QO_PLAN * planp)
       termp = QO_ENV_TERM (QO_NODE_ENV (nodep), t);
       sel *= QO_TERM_SELECTIVITY (termp);
 
-      /* Invariant: a LIKE-derived range that reached the key-range terms cannot
-       * carry a non-indexable collation. NON_IDX_SARG_COLL is column-driven, so
-       * it would flag the retained LIKE and its derived range alike and keep the
-       * derived range out of the key-range terms. Hence whenever a derived range
-       * is here, the residual LIKE is index-usable and becomes a key-filter -
-       * which is what the exclusion below relies on. */
-      assert (!QO_TERM_IS_FLAGED (termp, QO_TERM_LIKE_DERIVED_RANGE)
-	      || !QO_TERM_IS_FLAGED (termp, QO_TERM_NON_IDX_SARG_COLL));
-
-      /* Exclude a LIKE-derived range from row-count only when the residual LIKE
-       * can be a key-filter (its selectivity then lives in filter_sel). A
-       * non-covering function index disables key-filters, so the residual LIKE
-       * falls through to a data filter - there keep the range as the row-count
-       * upper bound. */
-      if (!QO_TERM_IS_FLAGED (termp, QO_TERM_LIKE_DERIVED_RANGE) || qo_index_forbids_key_filter (index_entryp))
-	{
-	  sel_excl_derived_range *= QO_TERM_SELECTIVITY (termp);
-	}
-
       /* each term can have multi index column. e.g.) (a,b) in .. */
       for (int j = 0; j < index_entryp->col_num; j++)
 	{
@@ -2226,7 +2270,6 @@ qo_iscan_cost (QO_PLAN * planp)
 
   /* check upper bound */
   sel = MIN (sel, 1.0);
-  sel_excl_derived_range = MIN (sel_excl_derived_range, 1.0);
 
   sel_limit = 0.0;		/* init */
 
@@ -2266,25 +2309,24 @@ qo_iscan_cost (QO_PLAN * planp)
 
   /* check lower bound */
   sel = MAX (sel, sel_limit);
-  sel_excl_derived_range = MAX (sel_excl_derived_range, sel_limit);
 
   /* selectivity of the index key filter terms */
   filter_sel = 1.0;
   for (t = bitset_iterate (&(planp->plan_un.scan.kf_terms), &iter); t != -1; t = bitset_next_member (&iter))
     {
       termp = QO_ENV_TERM (QO_NODE_ENV (nodep), t);
-
-      /* A LIKE-derived range that landed in the key-filter is redundant with
-       * the residual LIKE it came from; skip it here just as the key-range loop
-       * skips it from sel_excl_derived_range, so the node-level and iscan-level
-       * estimates stay in agreement. */
-      if (QO_TERM_IS_FLAGED (termp, QO_TERM_LIKE_DERIVED_RANGE))
-	{
-	  continue;
-	}
-
       filter_sel *= QO_TERM_SELECTIVITY (termp);
     }
+
+  /* Fraction of the rows that reach the heap: the key range and the key filter are both
+   * applied before the fetch. The exception is a prefix-LIKE rewrite, which puts two terms of
+   * one predicate into this product - the derived range is cancelled out here, while the index
+   * access cost below keeps it, that range being the physical boundary of the scan. The result
+   * cannot exceed `sel`: no more rows are fetched than the scan traverses entries, which a LIKE
+   * whose selectivity falls back to a default guess would otherwise claim. */
+  dup_sel = qo_like_derived_range_dup_sel (planp);
+  heap_sel = (dup_sel > 0.0) ? (sel * filter_sel / dup_sel) : (sel * filter_sel);
+  heap_sel = MIN (heap_sel, sel);
 
   /* number of leaf to be selected */
   leaf_access = sel * (double) QO_NODE_NCARD (nodep);
@@ -2330,11 +2372,8 @@ qo_iscan_cost (QO_PLAN * planp)
     }
   else
     {
-      /* Row count reaching the heap: uses sel_excl_derived_range (not sel) so a LIKE-derived
-       * range is not double counted against the residual LIKE it came from - same basis as
-       * scan_rows below. */
-      heap_rows = (double) QO_NODE_NCARD (nodep) * sel_excl_derived_range * filter_sel;
-      object_IO = opages * sel_excl_derived_range * filter_sel;
+      heap_rows = (double) QO_NODE_NCARD (nodep) * heap_sel;
+      object_IO = opages * heap_sel;
       /* Cap the per-row heap-fetch surcharge at the table's page count: fetching more rows
        * than there are heap pages cannot touch more distinct pages (the rows share pages),
        * so an unbounded per-row charge would overprice a wide scan whose non-indexed filter
@@ -2358,7 +2397,7 @@ qo_iscan_cost (QO_PLAN * planp)
   planp->fixed_io_cost = index_IO + first_leaf;
   planp->variable_cpu_cost = (leaf_access + heap_access) * (double) QO_CPU_WEIGHT;
   planp->variable_io_cost = object_IO;
-  planp->info->scan_rows = MAX (1, (double) QO_NODE_NCARD (nodep) * sel_excl_derived_range * filter_sel);
+  planp->info->scan_rows = MAX (1, (double) QO_NODE_NCARD (nodep) * heap_sel);
 
 #if TEST_DUMP_PLAN_SCAN_COST
   fprintf (stdout, "\nIndex Scan Cost: \n");

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -190,7 +190,7 @@ static void qo_plan_compute_subquery_cost (PT_NODE *, double *, double *);
 static void qo_sscan_cost (QO_PLAN *);
 static void qo_iscan_cost (QO_PLAN *);
 static bool qo_index_forbids_key_filter (QO_INDEX_ENTRY *);
-static double qo_like_derived_range_dup_sel (QO_PLAN *);
+static bool qo_get_like_derived_range_dup_sel (QO_PLAN *, double *, double *);
 static void qo_sort_cost (QO_PLAN *);
 static void qo_mjoin_cost (QO_PLAN *);
 static void qo_nljoin_cost (QO_PLAN *);
@@ -2114,31 +2114,38 @@ qo_index_scan_new (QO_INFO * info, QO_NODE * node, QO_NODE_INDEX_ENTRY * ni_entr
 }
 
 /*
- * qo_like_derived_range_dup_sel () - selectivity of a prefix-LIKE derived range that the
- *   row-count product of this index scan would count for a second time
- *   return: the selectivity to cancel, 1.0 when there is nothing to cancel
+ * qo_get_like_derived_range_dup_sel () - selectivities of the prefix-LIKE derived ranges that
+ *   this index scan counts although the LIKEs they came from are counted too
+ *   return: true when such a range takes part in this plan, false when there is none
  *   planp(in): index scan plan
+ *   dup_sel(out): the selectivity to divide out of the key-range product
+ *   kf_dup_sel(out): the selectivity to divide out of the key-filter product
  *
  * note: qo_rewrite_like_for_index_scan () keeps the original LIKE and adds a range derived
  *   from its fixed prefix, so one predicate turns into two terms. The rows matching the LIKE
- *   are a subset of that range, so once both terms enter the same product the range restricts
- *   nothing on top of the LIKE and its selectivity is counted for free. The pair is matched by
- *   segment rather than by identity, because qo_apply_range_intersection () may merge several
- *   derived ranges into a single term.
+ *   are a subset of that range, so once both terms are counted the range restricts nothing on
+ *   top of the LIKE and the caller divides it back out. Which product holds the range depends
+ *   on the plan, hence the two values: it is a key-range term where the scan ranges over it,
+ *   and a key-filter term where another range took that place. The range and its LIKE are
+ *   matched by segment rather than by identity, because qo_apply_range_intersection () may
+ *   merge several derived ranges into a single term.
  *
- *   Nothing is cancelled unless the LIKE became a key filter. A non-covering function index
+ *   False is returned unless the LIKE became a key filter. A non-covering function index
  *   forbids key filters, and the LIKE then stays a data filter evaluated after the fetch -
  *   there the range really is the only restriction the fetch count may use.
  */
-static double
-qo_like_derived_range_dup_sel (QO_PLAN * planp)
+static bool
+qo_get_like_derived_range_dup_sel (QO_PLAN * planp, double *dup_sel, double *kf_dup_sel)
 {
   QO_ENV *env;
   QO_TERM *termp;
   BITSET_ITERATOR iter;
   BITSET like_segs;
-  double dup_sel = 1.0;
+  bool found = false;
   int t;
+
+  *dup_sel = 1.0;
+  *kf_dup_sel = 1.0;
 
   env = QO_NODE_ENV (planp->plan_un.scan.node);
   bitset_init (&like_segs, env);
@@ -2155,31 +2162,35 @@ qo_like_derived_range_dup_sel (QO_PLAN * planp)
 
   if (!bitset_is_empty (&like_segs))
     {
-      /* their derived ranges; a derived range may serve as a key range or as a key filter */
+      /* their derived ranges, each reported for the product that holds it. A zero selectivity
+       * is passed over: an empty range leaves nothing to divide by, and the estimate the caller
+       * already holds is as good as it gets. */
       for (t = bitset_iterate (&(planp->plan_un.scan.terms), &iter); t != -1; t = bitset_next_member (&iter))
 	{
 	  termp = QO_ENV_TERM (env, t);
-	  if (QO_TERM_IS_FLAGED (termp, QO_TERM_LIKE_DERIVED_RANGE)
+	  if (QO_TERM_IS_FLAGED (termp, QO_TERM_LIKE_DERIVED_RANGE) && QO_TERM_SELECTIVITY (termp) > 0.0
 	      && bitset_intersects (&(QO_TERM_SEGS (termp)), &like_segs))
 	    {
-	      dup_sel *= QO_TERM_SELECTIVITY (termp);
+	      *dup_sel *= QO_TERM_SELECTIVITY (termp);
+	      found = true;
 	    }
 	}
 
       for (t = bitset_iterate (&(planp->plan_un.scan.kf_terms), &iter); t != -1; t = bitset_next_member (&iter))
 	{
 	  termp = QO_ENV_TERM (env, t);
-	  if (QO_TERM_IS_FLAGED (termp, QO_TERM_LIKE_DERIVED_RANGE)
+	  if (QO_TERM_IS_FLAGED (termp, QO_TERM_LIKE_DERIVED_RANGE) && QO_TERM_SELECTIVITY (termp) > 0.0
 	      && bitset_intersects (&(QO_TERM_SEGS (termp)), &like_segs))
 	    {
-	      dup_sel *= QO_TERM_SELECTIVITY (termp);
+	      *kf_dup_sel *= QO_TERM_SELECTIVITY (termp);
+	      found = true;
 	    }
 	}
     }
 
   bitset_delset (&like_segs);
 
-  return dup_sel;
+  return found;
 }
 
 /*
@@ -2197,7 +2208,7 @@ qo_iscan_cost (QO_PLAN * planp)
   double sel, sel_limit, height, leaves, opages, filter_sel, leaf_access, heap_access, heap_rows;
   double heap_fanout = 0.0, iss_leaves = 0.0, first_leaf = 0.0;
   double object_IO, index_IO;
-  double heap_sel, dup_sel;
+  double heap_sel, like_dup_sel, like_kf_dup_sel, sel_before_limit;
   QO_TERM *termp;
   BITSET_ITERATOR iter;
   int i, t, n, pkeys_num, index;
@@ -2270,6 +2281,7 @@ qo_iscan_cost (QO_PLAN * planp)
 
   /* check upper bound */
   sel = MIN (sel, 1.0);
+  sel_before_limit = sel;	/* the prefix-LIKE exception below divides this, not the bounded sel */
 
   sel_limit = 0.0;		/* init */
 
@@ -2318,15 +2330,16 @@ qo_iscan_cost (QO_PLAN * planp)
       filter_sel *= QO_TERM_SELECTIVITY (termp);
     }
 
-  /* Fraction of the rows that reach the heap: the key range and the key filter are both
-   * applied before the fetch. The exception is a prefix-LIKE rewrite, which puts two terms of
-   * one predicate into this product - the derived range is cancelled out here, while the index
-   * access cost below keeps it, that range being the physical boundary of the scan. The result
-   * cannot exceed `sel`: no more rows are fetched than the scan traverses entries, which a LIKE
-   * whose selectivity falls back to a default guess would otherwise claim. */
-  dup_sel = qo_like_derived_range_dup_sel (planp);
-  heap_sel = (dup_sel > 0.0) ? (sel * filter_sel / dup_sel) : (sel * filter_sel);
-  heap_sel = MIN (heap_sel, sel);
+  /* fraction of the rows that reach the heap: the key range and the key filter both run before
+   * the fetch */
+  heap_sel = sel * filter_sel;
+
+  /* exception - a prefix-LIKE rewrite counted its derived range above on top of the LIKE it
+   * came from; divide it back out of whichever product holds it */
+  if (qo_get_like_derived_range_dup_sel (planp, &like_dup_sel, &like_kf_dup_sel))
+    {
+      heap_sel = MAX (sel_before_limit / like_dup_sel, sel_limit) * (filter_sel / like_kf_dup_sel);
+    }
 
   /* number of leaf to be selected */
   leaf_access = sel * (double) QO_NODE_NCARD (nodep);

--- a/src/optimizer/rewriter/query_rewrite_term.c
+++ b/src/optimizer/rewriter/query_rewrite_term.c
@@ -2356,8 +2356,11 @@ qo_rewrite_like_for_index_scan (PARSER_CONTEXT * const parser, PT_NODE * like, P
   like->next = between;
 
   /* Mark the derived range so row-count aggregation excludes it (subset of the
-   * retained LIKE). Set before the copy so it is preserved. */
+   * retained LIKE), and mark the LIKE it came from as its origin: qo_iscan_cost ()
+   * cancels the range only where that LIKE takes part in the same product, so it has
+   * to recognize both ends of the pair. Set before the copy so they are preserved. */
   PT_EXPR_INFO_SET_FLAG (between, PT_EXPR_INFO_LIKE_DERIVED_RANGE);
+  PT_EXPR_INFO_SET_FLAG (like, PT_EXPR_INFO_LIKE_HAS_DERIVED_RANGE);
 
   /* fold range bounds : this will allow auto-parametrization */
   like_save = parser_copy_tree_list (parser, like);

--- a/src/parser/parse_tree.h
+++ b/src/parser/parse_tree.h
@@ -2353,6 +2353,8 @@ struct pt_expr_info
 						 * uncorrelated and pre-executed only once - but the term is excluded
 						 * from the local access_pred and hidden from the plan dump. */
 #define PT_EXPR_INFO_LIKE_DERIVED_RANGE 4194304	/* 0x400000, range derived from a prefix LIKE; excluded from row-count selectivity */
+#define PT_EXPR_INFO_LIKE_HAS_DERIVED_RANGE 8388608	/* 0x800000, the prefix LIKE a range was derived from; the pair
+							 * of PT_EXPR_INFO_LIKE_DERIVED_RANGE */
   int flag;			/* flags */
 #define PT_EXPR_INFO_IS_FLAGED(e, f)    ((e)->info.expr.flag & (int) (f))
 #define PT_EXPR_INFO_SET_FLAG(e, f)     (e)->info.expr.flag |= (int) (f)


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27036

## Purpose (목적)

CBRD-27036(#7444)이 도입한 `sel_excl_derived_range`가 `qo_iscan_cost()`의 **주 로직을 고친 것처럼 보인다.** 이 변수는 `sel`과 나란히 선언 → 키레인지 루프 누적 → 상·하한 클램프 → 소비의 네 지점을 흐르기 때문에, 읽는 쪽에서는 인덱스 스캔 비용에 선택도 체계가 둘 있는 것으로 읽힌다. 실제로는 prefix LIKE 재작성이라는 **한 가지 상황에 대한 예외 보정**일 뿐이다.

또한 그 보정을 적용할지 판정하는 조건이 `qo_index_forbids_key_filter()` — 즉 "non-covering 함수 인덱스인가"라는 **인덱스 속성 프록시**다. 정작 필요한 사실은 "이 플랜에서 잔여 LIKE가 실제로 key filter가 되었는가"이고, `qo_index_scan_new()`가 key filter 승인 전에 보는 게이트는 다섯 개다.

| # | 게이트 | 프록시 반영 |
|---|---|---|
| 0 | `qo_index_forbids_key_filter()` | O |
| 1 | `QO_TERM_NON_IDX_SARG_COLL` | X (assert로 불가능하다고 주장) |
| 2 | 상관 서브쿼리 | X |
| 3 | 키레인지가 없을 때 `term->can_use_index` | X |
| 4 | `bitset_subset (index_segs, term_segs)` | X |

게이트 1~4 중 하나로 LIKE가 data filter로 밀리면, 프록시는 여전히 "약분해도 된다"고 판단해 파생 range를 근거 없이 제거한다. 그 경우 fetch 행수가 `NCARD × range_sel`에서 `NCARD`로 부풀어 비커버링 인덱스 스캔이 과대평가된다.

## Implementation (구현)

`src/optimizer/query_planner.c` — 예외를 예외 자리로 옮긴다.

**1. 행 수를 평범하게 쓰고, 예외가 덮어쓰게 한다**

```c
  /* fraction of the rows that reach the heap: the key range and the key filter both run before
   * the fetch */
  heap_sel = sel * filter_sel;

  /* exception - a prefix-LIKE rewrite counted its derived range above on top of the LIKE it
   * came from; divide it back out of whichever product holds it */
  if (qo_get_like_derived_range_dup_sel (planp, &like_dup_sel, &like_kf_dup_sel))
    {
      heap_sel = MAX (sel_before_limit / like_dup_sel, sel_limit) * (filter_sel / like_kf_dup_sel);
    }
```

`sel_excl_derived_range`와 그에 딸린 클램프 2줄이 사라지고, **두 선택도 루프는 이 시리즈 이전의 원형**으로 돌아간다. `heap_rows`, `object_IO`, `scan_rows`가 `heap_sel`을 공유한다.

**2. 예외 판정과 계산을 헬퍼로 격리 — `qo_get_like_derived_range_dup_sel()`**

이런 range가 이 플랜에 참여하는지를 bool로 알려주고, 참여하면 **곱별로 약분할 선택도**를 돌려준다. 파생 range는 스캔이 그 범위를 훑는 플랜에서는 key-range term이고 다른 range가 그 자리를 차지한 플랜에서는 key-filter term이므로, 각 값은 자기가 속한 곱에서 약분된다. 두 나눗셈 모두 **그 곱의 인수를 지우는 것**이라 몫이 1을 넘을 수 없고 별도 가드가 필요 없다.

판정은 프록시가 아니라 **`kf_terms`를 직접 확인**하므로 위 다섯 게이트가 전부 자동 반영된다. 파생 range와 원본 LIKE는 **세그먼트로 매칭**한다 — `qo_apply_range_intersection()`이 여러 파생 range를 하나로 병합할 수 있어 1:1 대응이 보장되지 않기 때문이다.

**3. 하한은 term 쪽에 유지**

키레인지 측은 `sel_before_limit`(통계 하한이 아직 적용되지 않은 곱)을 나누고, 하한은 그 결과에 적용한다. 하한 `1/pkeys`는 키레인지 선택도의 해상도 한계이므로 `filter_sel`을 곱하기 **전**에 걸려야 하며, 하한이 적용된 값을 나누면 하한이 곱을 대체한 구간에서 남은 term들의 곱이 복원되지 않는다.

**4. 짝 플래그 추가**

재작성 지점에서 파생 range에 이미 붙이던 플래그 옆에 원본 LIKE 표시를 추가한다. `PT_EXPR_INFO_LIKE_HAS_DERIVED_RANGE`(0x800000) → `qo_analyze_term()`이 `QO_TERM_LIKE_HAS_DERIVED_RANGE`로 전파.

**다중 LIKE**는 별도 처리를 두지 않았다. 키레인지 구성 규칙(선두 연속 등가 + 마지막 컬럼의 range 하나)상 한 플랜의 키레인지에 파생 range는 최대 1개만 들어오고, 같은 컬럼의 LIKE 여러 개는 range intersection이 하나로 병합하기 때문이다.

노드 레벨 행수(`qo_node_add_sarg()`, `planner_visit_node()`)는 그대로 둔다. 거기서는 원본 LIKE가 항상 sarg에 있으므로 파생 range가 언제나 중복이고, 예외 판정이 필요 없다.

## Remarks (측정/비고)

**동작 동일성** — 모든 도달 가능 케이스에서 CBRD-27036과 같은 값이 나온다. 파생 range가 없으면 헬퍼가 `false`를 돌려주고 `sel * filter_sel`이 그대로 쓰인다.

| 상황 | 헬퍼 | 결과 | CBRD-27036 |
|---|---|---|---|
| 파생 range 없음 | false | `sel × filter_sel` | 동일 |
| LIKE가 키필터, range가 키레인지 | true | `MAX(E, sel_limit) × like_sel` | 동일 |
| range가 키필터 (`LIKE ... AND v > ?`) | true | `sel × like_sel` | 동일 |
| 양쪽에 하나씩 | true | 각자 제 곱에서 약분 | 동일 |
| non-covering 함수 인덱스 (LIKE=data filter) | **false** | `sel × filter_sel` = `range_sel` | 동일 |
| 게이트 1~4로 LIKE=data filter | **false** | `sel × filter_sel` | **이 PR의 개선분** |

마지막 행이 유일한 동작 변경이며, 기존에는 근거 없이 약분되어 fetch 행수가 테이블 전체로 부풀던 경우다.

**검증** — release 빌드(`-Werror`)로 변경된 `.c` 3개 컴파일 무경고, `indent -l120 -lc120` 차이 없음(CI code-style와 동일 커맨드). 직전 리비전에서 test_sql·test_medium 전체 통과.

**후속** — 이 함수는 `range_sel`(통계 없으면 `DEFAULT_BETWEEN_SELECTIVITY` 0.01)과 `like_sel`(`PRM_ID_LIKE_TERM_SELECTIVITY` 0.1)이 서로 모순될 수 있고, 그 결과 heap fetch 추정이 순회 엔트리 수를 넘을 수 있다. `LIKE 매칭 ⊆ range`라는 관계를 짝 단위로 강제하려면 노드 레벨 카디널리티까지 함께 봐야 하므로 별도 이슈로 다룬다. 파생 range가 범위 단위 플래그라 사용자 range가 한쪽 경계만 좁힌 경우(`v LIKE 'PRE%MID%' AND v >= 'PREM'`)의 부분 이중 계상도 #7444 주석대로 남아 있다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
