### PR TITLE
[CBRD-26768] Fix stack-use-after-scope in do_prepare_select() (#7144)

### DIFF
--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -14304,7 +14304,7 @@ do_prepare_select (PARSER_CONTEXT * parser, PT_NODE * statement)
 
   COMPILE_CONTEXT *contextp;
   XASL_STREAM stream;
-  XASL_NODE_HEADER xasl_header = { 0, 0 };
+  XASL_NODE_HEADER xasl_header = { 0 };
 
   contextp = &parser->context;
 

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -14304,6 +14304,7 @@ do_prepare_select (PARSER_CONTEXT * parser, PT_NODE * statement)
 
   COMPILE_CONTEXT *contextp;
   XASL_STREAM stream;
+  XASL_NODE_HEADER xasl_header = { 0, 0 };
 
   contextp = &parser->context;
 
@@ -14363,7 +14364,6 @@ do_prepare_select (PARSER_CONTEXT * parser, PT_NODE * statement)
   contextp->recompile_xasl = statement->flag.recompile;
   if (statement->flag.recompile == 0)
     {
-      XASL_NODE_HEADER xasl_header;
       stream.xasl_header = &xasl_header;
 
       err = prepare_query (contextp, &stream);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26768

* Fix stack-use-after-scope in do_prepare_select() function.
* backport#7144
