### PR TITLE
[CBRD-27218] [p11.4] Keep the optimization level when building bundled third-party libraries (#7670)

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -107,8 +107,9 @@ set_property(DIRECTORY PROPERTY EP_BASE "${3RDPARTY_LIBS_DIR}")
 # library at -O0.
 set(3RDPARTY_COMMON_FLAGS "-fPIC -w")
 
-# restates the level from autoconf's "-g -O2", which supplying CFLAGS suppresses
-set(DEFAULT_CONFIGURE_OPTS <SOURCE_DIR>/configure --prefix=${CMAKE_BINARY_DIR}/3rdparty --enable-static --disable-shared --with-pic "CFLAGS=-O2 ${3RDPARTY_COMMON_FLAGS}" "CXXFLAGS=-O2 ${3RDPARTY_COMMON_FLAGS}")
+# restates the level from autoconf's "-g -O2", which supplying CFLAGS suppresses.
+# No CXXFLAGS: none of these compile C++ in the target this build runs.
+set(DEFAULT_CONFIGURE_OPTS <SOURCE_DIR>/configure --prefix=${CMAKE_BINARY_DIR}/3rdparty --enable-static --disable-shared --with-pic "CFLAGS=-O2 ${3RDPARTY_COMMON_FLAGS}")
 
 # For Windows
 if(WIN32)
@@ -486,8 +487,9 @@ if(WITH_RE2 STREQUAL "EXTERNAL")
       DOWNLOAD_NO_PROGRESS 1
       CONFIGURE_COMMAND ""        # no configure
       BUILD_IN_SOURCE true        # re2 Makefile is designed to run locally
-      # no append hook, so restate the level from the Makefile's "CXXFLAGS ?= -O3 -g"
-      BUILD_COMMAND make "CFLAGS=-O3 ${3RDPARTY_COMMON_FLAGS}" "CXXFLAGS=-O3 ${3RDPARTY_COMMON_FLAGS}"
+      # no append hook, so restate the level from the Makefile's "CXXFLAGS ?= -O3 -g".
+      # No CFLAGS: re2 has no C sources and its Makefile never reads CFLAGS.
+      BUILD_COMMAND make "CXXFLAGS=-O3 ${3RDPARTY_COMMON_FLAGS}"
       INSTALL_COMMAND ""
       "${RE2_BYPRODUCTS}"
     )

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -95,7 +95,20 @@ include(ExternalProject)
 
 set (3RDPARTY_LIBS_DIR ${CMAKE_BINARY_DIR}/3rdparty)
 set_property(DIRECTORY PROPERTY EP_BASE "${3RDPARTY_LIBS_DIR}")
-set(DEFAULT_CONFIGURE_OPTS <SOURCE_DIR>/configure --prefix=${CMAKE_BINARY_DIR}/3rdparty --enable-static --disable-shared --with-pic CFLAGS=-w CXXFLAGS=-w)
+
+# What CUBRID adds to every third-party library built below: -fPIC because these
+# are static archives linked into CUBRID's shared libraries, -w because their
+# warnings are not actionable here.
+#
+# The optimization level stays per-library, at whatever upstream declares and
+# tests; debug info is not carried over. Beware how flags reach a library: a make
+# command-line variable overrides the Makefile's own assignments, and CFLAGS given
+# to configure suppresses autoconf's "-g -O2". Passing only -fPIC or -w leaves the
+# library at -O0.
+set(3RDPARTY_COMMON_FLAGS "-fPIC -w")
+
+# restates the level from autoconf's "-g -O2", which supplying CFLAGS suppresses
+set(DEFAULT_CONFIGURE_OPTS <SOURCE_DIR>/configure --prefix=${CMAKE_BINARY_DIR}/3rdparty --enable-static --disable-shared --with-pic "CFLAGS=-O2 ${3RDPARTY_COMMON_FLAGS}" "CXXFLAGS=-O2 ${3RDPARTY_COMMON_FLAGS}")
 
 # For Windows
 if(WIN32)
@@ -338,7 +351,8 @@ else()
     DOWNLOAD_NO_PROGRESS 1
     CONFIGURE_COMMAND     ""                  # no configure
     BUILD_IN_SOURCE       true                # lz4 Makefile is designed to run locally
-    BUILD_COMMAND         make CFLAGS=-fPIC   # to allow static linking in shared library
+    # MOREFLAGS is lz4's append hook, so its "CFLAGS ?= -O3" survives
+    BUILD_COMMAND         make "MOREFLAGS=${3RDPARTY_COMMON_FLAGS}"
     INSTALL_COMMAND       ""                  # suppress install
     "${LZ4_BYPRODUCTS}"
   )
@@ -472,7 +486,8 @@ if(WITH_RE2 STREQUAL "EXTERNAL")
       DOWNLOAD_NO_PROGRESS 1
       CONFIGURE_COMMAND ""        # no configure
       BUILD_IN_SOURCE true        # re2 Makefile is designed to run locally
-      BUILD_COMMAND make CFLAGS=-fPIC CXXFLAGS=-fPIC # to allow static linking in shared library
+      # no append hook, so restate the level from the Makefile's "CXXFLAGS ?= -O3 -g"
+      BUILD_COMMAND make "CFLAGS=-O3 ${3RDPARTY_COMMON_FLAGS}" "CXXFLAGS=-O3 ${3RDPARTY_COMMON_FLAGS}"
       INSTALL_COMMAND ""
       "${RE2_BYPRODUCTS}"
     )


### PR DESCRIPTION
backport #7670

http://jira.cubrid.org/browse/CBRD-27218

### Purpose

Five of the eight libraries built from source by `3rdparty/CMakeLists.txt` — lz4, RE2,
expat, jansson and libedit — are compiled at the compiler default of `-O0`. The build
command replaces the optimization level each library declares for itself instead of
adding to it. Two mechanisms, same result:

- A variable assigned on a make command line overrides every assignment inside the
  Makefile, including `?=` defaults. This hits lz4 (`CFLAGS ?= -O3`) at
  `3rdparty/CMakeLists.txt:340` and RE2 (`CXXFLAGS ?= -O3 -g`) at `:474`.
- A `CFLAGS` value handed to a configure script stops autoconf from applying its own
  `-g -O2`. This hits expat, jansson and libedit, which share `DEFAULT_CONFIGURE_OPTS`
  at `:97`, passing `CFLAGS=-w CXXFLAGS=-w`.

It is visible in the shipped `libcubridsa.so`, where `LZ4_compress_fast_extState`,
`re2::chartorune`, `json_object_get`, `XML_ParseBuffer` and `el_gets` all spill their
arguments to the stack, while CUBRID's own objects in the same library are compiled at
`-O2`.

### Implementation

- `-fPIC` and `-w` are still wanted, so they move into one shared
  `3RDPARTY_COMMON_FLAGS`.
- `DEFAULT_CONFIGURE_OPTS` restates `-O2` for expat, jansson and libedit, because
  supplying `CFLAGS` suppresses autoconf's own default.
- lz4 switches to `MOREFLAGS`, its append hook, so its `-O3` is picked up without
  restating it.
- RE2 has no append hook, so its `-O3` is restated at the use site.
- Debug info is not carried over, matching the current build.

Verification: each library was rebuilt with the exact resulting flags — optimized code
generation confirmed by disassembly, zero new warnings, no absolute 32-bit relocations
in `.rela.text`, and the archives link into a shared object. CMake expansion was checked
so that each `CFLAGS=...` reaches configure or make as a single argument rather than
being split at the space.

### Performance

Measured on the referenced tarballs, same machine:

```
 lz4      compress 1 KB     4,170 ns -> 712 ns      (5.9x)
 lz4      compress 16 KB   59,637 ns -> 10,121 ns   (5.9x)
 lz4      decompress 16 KB  9,550 ns -> 3,433 ns    (2.8x)
 RE2      compile pattern  33,599 ns -> 2,251 ns    (14.9x)
 RE2      PartialMatch        312 ns -> 82 ns       (3.8x)
 jansson  build+serialize  17,939 ns -> 11,589 ns   (1.55x)
```

End to end:

- `cubrid backupdb -S -t 1` over a TPC-C database, alternating rounds: process CPU
  9.97 s -> 4.06 s, wall 30.9 s -> 27.7 s, with byte-identical backup output. lz4 was
  71% of backup process CPU before the change and is 35% after.
- A `REGEXP` predicate over a 300,000-row scan: 0.777 s -> 0.362 s (2.15x), spread
  under 1%.
- Server-side log compression is 4.5x cheaper per `log_zip ()` call, moving from 4.8%
  of server CPU to 1.1%. Throughput did not move in those runs because the server was
  commit-latency bound at ~0.4 of 16 cores — the saving is CPU, not throughput, on that
  path.

Size drops as well, because `-O0` emits far more code: the resident (mapped) sections of
the five archives total 1.76 MB today and 1.00 MB after. On disk, RE2 4.86 MB -> 1.06 MB,
lz4 502 KB -> 242 KB, libedit 417 KB -> 377 KB, jansson 113 KB -> 102 KB, expat
355 KB -> 362 KB.

### Remarks

- Not a regression. The lz4 line is unchanged since the library was introduced in
  CBRD-23703; a branch sweep places it on release/11.0 onward, and the RE2 line on
  release/11.2 onward.
- No engine source change. Compressed byte streams, on-disk formats and regular
  expression results are unchanged, so no expected-output test is touched.
- OpenSSL, unixODBC and TBB are unaffected — they do not go through these paths.


### Backport notes

- Clean cherry-pick from `f4731dfe8` (head of #7670). Same file, same three sites; only line offsets differ.
- Library versions match develop (lz4 v1.9.4, RE2 2022-06-01), so the flag reasoning carries over unchanged.
- CMake expansion re-checked on this branch: each `CFLAGS=...` / `CXXFLAGS=...` / `MOREFLAGS=...` reaches configure or make as a single argument.
- #7670 has not merged yet, so this branch is taken from its head commit rather than a squash-merge on develop. Left as draft until #7670 lands.
