### PR TITLE
[CBRD-27218] [p11.0] Keep the optimization level when building bundled third-party libraries (#7670)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -870,7 +870,20 @@ endif(USE_CUBRID_ENV)
 # For external library options
 include(ExternalProject)
 set_property(DIRECTORY PROPERTY EP_BASE "${CMAKE_BINARY_DIR}/external")
-set(DEFAULT_CONFIGURE_OPTS <SOURCE_DIR>/configure --prefix=${CMAKE_CURRENT_BINARY_DIR}/external --enable-static --disable-shared --with-pic CFLAGS=-w CXXFLAGS=-w)
+
+# What CUBRID adds to every third-party library built below: -fPIC because these
+# are static archives linked into CUBRID's shared libraries, -w because their
+# warnings are not actionable here.
+#
+# The optimization level stays per-library, at whatever upstream declares and
+# tests; debug info is not carried over. Beware how flags reach a library: a make
+# command-line variable overrides the Makefile's own assignments, and CFLAGS given
+# to configure suppresses autoconf's "-g -O2". Passing only -fPIC or -w leaves the
+# library at -O0.
+set(3RDPARTY_COMMON_FLAGS "-fPIC -w")
+
+# restates the level from autoconf's "-g -O2", which supplying CFLAGS suppresses
+set(DEFAULT_CONFIGURE_OPTS <SOURCE_DIR>/configure --prefix=${CMAKE_CURRENT_BINARY_DIR}/external --enable-static --disable-shared --with-pic "CFLAGS=-O2 ${3RDPARTY_COMMON_FLAGS}" "CXXFLAGS=-O2 ${3RDPARTY_COMMON_FLAGS}")
 
 # WITH_LIBEXPAT can have multiple values with different meanings
 # on Linux:
@@ -1051,7 +1064,8 @@ else()
     GIT_TAG fdf2ef5             # https://github.com/lz4/lz4/releases/tag/v1.9.2
     CONFIGURE_COMMAND ""        # no configure
     BUILD_IN_SOURCE true        # lz4 Makefile is designed to run locally
-    BUILD_COMMAND make CFLAGS="-fPIC"  # to allow static linking in shared library
+    # MOREFLAGS is lz4's append hook, so its "CFLAGS ?= -O3" survives
+    BUILD_COMMAND make "MOREFLAGS=${3RDPARTY_COMMON_FLAGS}"
     INSTALL_COMMAND ""          # suppress install
   )
   set(LZ4_INCLUDES ${CMAKE_BINARY_DIR}/external/Source/lz4/lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -882,8 +882,9 @@ set_property(DIRECTORY PROPERTY EP_BASE "${CMAKE_BINARY_DIR}/external")
 # library at -O0.
 set(3RDPARTY_COMMON_FLAGS "-fPIC -w")
 
-# restates the level from autoconf's "-g -O2", which supplying CFLAGS suppresses
-set(DEFAULT_CONFIGURE_OPTS <SOURCE_DIR>/configure --prefix=${CMAKE_CURRENT_BINARY_DIR}/external --enable-static --disable-shared --with-pic "CFLAGS=-O2 ${3RDPARTY_COMMON_FLAGS}" "CXXFLAGS=-O2 ${3RDPARTY_COMMON_FLAGS}")
+# restates the level from autoconf's "-g -O2", which supplying CFLAGS suppresses.
+# No CXXFLAGS: none of these compile C++ in the target this build runs.
+set(DEFAULT_CONFIGURE_OPTS <SOURCE_DIR>/configure --prefix=${CMAKE_CURRENT_BINARY_DIR}/external --enable-static --disable-shared --with-pic "CFLAGS=-O2 ${3RDPARTY_COMMON_FLAGS}")
 
 # WITH_LIBEXPAT can have multiple values with different meanings
 # on Linux:


### PR DESCRIPTION
backport #7670

http://jira.cubrid.org/browse/CBRD-27218

### Purpose

Five of the eight libraries built from source by `3rdparty/CMakeLists.txt` — lz4, RE2,
expat, jansson and libedit — are compiled at the compiler default of `-O0`. The build
command replaces the optimization level each library declares for itself instead of
adding to it. Two mechanisms, same result:

- A variable assigned on a make command line overrides every assignment inside the
  Makefile, including `?=` defaults. This hits lz4 (`CFLAGS ?= -O3`) at
  `3rdparty/CMakeLists.txt:340` and RE2 (`CXXFLAGS ?= -O3 -g`) at `:474`.
- A `CFLAGS` value handed to a configure script stops autoconf from applying its own
  `-g -O2`. This hits expat, jansson and libedit, which share `DEFAULT_CONFIGURE_OPTS`
  at `:97`, passing `CFLAGS=-w CXXFLAGS=-w`.

It is visible in the shipped `libcubridsa.so`, where `LZ4_compress_fast_extState`,
`re2::chartorune`, `json_object_get`, `XML_ParseBuffer` and `el_gets` all spill their
arguments to the stack, while CUBRID's own objects in the same library are compiled at
`-O2`.

### Implementation

- `-fPIC` and `-w` are still wanted, so they move into one shared
  `3RDPARTY_COMMON_FLAGS`.
- `DEFAULT_CONFIGURE_OPTS` restates `-O2` for expat, jansson and libedit, because
  supplying `CFLAGS` suppresses autoconf's own default.
- lz4 switches to `MOREFLAGS`, its append hook, so its `-O3` is picked up without
  restating it.
- RE2 has no append hook, so its `-O3` is restated at the use site.
- Debug info is not carried over, matching the current build.

Verification: each library was rebuilt with the exact resulting flags — optimized code
generation confirmed by disassembly, zero new warnings, no absolute 32-bit relocations
in `.rela.text`, and the archives link into a shared object. CMake expansion was checked
so that each `CFLAGS=...` reaches configure or make as a single argument rather than
being split at the space.

### Performance

Measured on the referenced tarballs, same machine:

```
 lz4      compress 1 KB     4,170 ns -> 712 ns      (5.9x)
 lz4      compress 16 KB   59,637 ns -> 10,121 ns   (5.9x)
 lz4      decompress 16 KB  9,550 ns -> 3,433 ns    (2.8x)
 RE2      compile pattern  33,599 ns -> 2,251 ns    (14.9x)
 RE2      PartialMatch        312 ns -> 82 ns       (3.8x)
 jansson  build+serialize  17,939 ns -> 11,589 ns   (1.55x)
```

End to end:

- `cubrid backupdb -S -t 1` over a TPC-C database, alternating rounds: process CPU
  9.97 s -> 4.06 s, wall 30.9 s -> 27.7 s, with byte-identical backup output. lz4 was
  71% of backup process CPU before the change and is 35% after.
- A `REGEXP` predicate over a 300,000-row scan: 0.777 s -> 0.362 s (2.15x), spread
  under 1%.
- Server-side log compression is 4.5x cheaper per `log_zip ()` call, moving from 4.8%
  of server CPU to 1.1%. Throughput did not move in those runs because the server was
  commit-latency bound at ~0.4 of 16 cores — the saving is CPU, not throughput, on that
  path.

Size drops as well, because `-O0` emits far more code: the resident (mapped) sections of
the five archives total 1.76 MB today and 1.00 MB after. On disk, RE2 4.86 MB -> 1.06 MB,
lz4 502 KB -> 242 KB, libedit 417 KB -> 377 KB, jansson 113 KB -> 102 KB, expat
355 KB -> 362 KB.

### Remarks

- Not a regression. The lz4 line is unchanged since the library was introduced in
  CBRD-23703; a branch sweep places it on release/11.0 onward, and the RE2 line on
  release/11.2 onward.
- No engine source change. Compressed byte streams, on-disk formats and regular
  expression results are unchanged, so no expected-output test is touched.
- OpenSSL, unixODBC and TBB are unaffected — they do not go through these paths.


### Backport notes

- **Not a cherry-pick.** On release/11.0 the external-library block still lives in the top-level `CMakeLists.txt`; the split into `3rdparty/CMakeLists.txt` landed later (CBRD-24490). The edits were ported by hand to `CMakeLists.txt`. The resulting flags are identical to the develop change; only the surrounding paths differ (`external/` instead of `3rdparty/`, `CMAKE_CURRENT_BINARY_DIR` instead of `CMAKE_BINARY_DIR`).
- **RE2 is not on this branch** — it was introduced in release/11.2 — so this backport covers two of the three sites: `DEFAULT_CONFIGURE_OPTS` (expat, jansson, libedit) and the lz4 `BUILD_COMMAND`. The RE2 hunk of #7670 has no counterpart here, which is why the diff is 16 insertions rather than 18.
- The `3RDPARTY_COMMON_FLAGS` variable name is kept as-is even though this branch calls the directory `external/`, so the change reads the same across all four release lines.
- **lz4 is pinned to v1.9.2 here** (develop and release/11.4 use v1.9.4), so the append hook was re-verified against that version. v1.9.2's `lib/Makefile` still declares `CFLAGS ?= -O3`, and routes `MOREFLAGS` to the compiler through `CFLAGS` (line 53) rather than `CPPFLAGS`; either way a command-line `MOREFLAGS` leaves the `?=` default standing. Rebuilt v1.9.2 both ways:

  ```
  make CFLAGS=-fPIC          liblz4.a  347,720 B   23,603 rbp-spill insns   (-O0)
  make MOREFLAGS="-fPIC -w"  liblz4.a  221,616 B        6 rbp-spill insns   (optimized)
  ```

  No warnings emitted, and `.rela.text` has zero `R_X86_64_32` relocations, so `-fPIC` still takes effect.
- CMake expansion re-checked on this branch: each `CFLAGS=...` / `MOREFLAGS=...` reaches configure or make as a single argument.
- #7670 has not merged yet, so this branch is taken from its head commit rather than a squash-merge on develop. Left as draft until #7670 lands.
