### PR TITLE
[CBRD-26589] SBR 로그 복제 버그 수정 및 checksumdb 에서 checksum 수행 방식 수정 (#6908)

### DIFF
--- a/src/executables/checksumdb.c
+++ b/src/executables/checksumdb.c
@@ -1716,7 +1716,30 @@ chksum_calculate_checksum (PARSER_CONTEXT * parser, const OID * class_oidp, cons
       return error;
     }
 
+  /*
+   * The replication log written above is statement-based (SBR): the replica
+   * re-executes this query and recomputes the chunk checksum from its own data.
+   * Suppress row-based replication of the local execution below so the master's
+   * computed checksum row is not shipped as well - that would overwrite the
+   * replica's own recomputed value and hide real divergence. The flag lives on
+   * this transaction's descriptor (tdes) and is cleared right after execution.
+   */
+  error = db_set_suppress_repl_on_transaction (true);
+  if (error != NO_ERROR)
+    {
+      snprintf (err_msg, LINE_MAX,
+		"Failed to suppress the row-based replication log." " (table name: %s, chunk id: %d)", table_name,
+		chunk_id);
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CHKSUM_GENERIC_ERR, 2, err_msg, error);
+      return error;
+    }
+
   res = db_execute (query, &query_result, &query_error);
+
+  /* resume row-based replication right after the local execution; keep its result as the error baseline,
+   * an actual execution failure below supersedes it */
+  error = db_set_suppress_repl_on_transaction (false);
+
   if (res >= 0)
     {
       db_query_end (query_result);

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -3197,6 +3197,156 @@ bool do_Trigger_involved;
  * Therefore, a separate global variable is set to distinguish whether the query is related to a trigger */
 bool cdc_Trigger_involved = false;
 
+static bool
+is_replication_class (const char *classname)
+{
+  DB_OBJECT *class_obj;
+
+  if (classname == NULL)
+    {
+      return false;
+    }
+
+  class_obj = db_find_class (classname);
+  if (class_obj == NULL)
+    {
+      assert (false);
+      return false;
+    }
+
+  return sm_is_replication_class (class_obj);
+}
+
+/* Safely extract the class name from a PT_SPEC; returns NULL when the spec has no entity name
+ * (e.g. a derived table). is_replication_class (NULL) is false, so callers stay null-safe. */
+static const char *
+get_spec_classname (PT_NODE * spec)
+{
+  if (spec == NULL || spec->info.spec.entity_name == NULL)
+    {
+      return NULL;
+    }
+
+  return spec->info.spec.entity_name->info.name.original;
+}
+
+/* parser_walk_tree callback: set *found when a spec in the (derived) subtree
+ * resolves to a replication class. Used for updatable vclass targets that
+ * mq_rewrite_vclass_spec_as_derived pushed into a derived table (the outer
+ * spec's entity_name/flat_entity_list are cleared, so the real base classes
+ * live only inside the derived subtree). */
+static PT_NODE *
+pt_spec_repl_class_walk (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk)
+{
+  bool *found = (bool *) arg;
+  PT_NODE *cls;
+
+  if (*found)
+    {
+      *continue_walk = PT_STOP_WALK;
+      return node;
+    }
+
+  if (node != NULL && node->node_type == PT_SPEC)
+    {
+      for (cls = node->info.spec.flat_entity_list; cls != NULL; cls = cls->next)
+	{
+	  if (cls->info.name.db_object != NULL && sm_is_replication_class (cls->info.name.db_object))
+	    {
+	      *found = true;
+	      *continue_walk = PT_STOP_WALK;
+	      return node;
+	    }
+	}
+    }
+
+  return node;
+}
+
+/* A modify target may be named directly (entity_name / flat_entity_list) or,
+ * when an updatable vclass is rewritten into a derived table, have its real
+ * base classes only inside the derived subtree. Inspect both so SBR is not
+ * skipped for a derived vclass INSERT/UPDATE/DELETE target. */
+static bool
+spec_has_replication_class (PARSER_CONTEXT * parser, PT_NODE * spec)
+{
+  PT_NODE *cls;
+  bool found = false;
+
+  if (spec == NULL)
+    {
+      return false;
+    }
+
+  /* named / non-derived target: entity_name + resolved flat_entity_list */
+  if (is_replication_class (get_spec_classname (spec)))
+    {
+      return true;
+    }
+  for (cls = spec->info.spec.flat_entity_list; cls != NULL; cls = cls->next)
+    {
+      if (cls->info.name.db_object != NULL && sm_is_replication_class (cls->info.name.db_object))
+	{
+	  return true;
+	}
+    }
+
+  /* derived vclass target: the real base classes are inside the derived subtree */
+  if (spec->info.spec.derived_table != NULL)
+    {
+      parser_walk_tree (parser, spec->info.spec.derived_table, pt_spec_repl_class_walk, &found, NULL, NULL);
+    }
+
+  return found;
+}
+
+bool
+is_data_repl_log_enabled (PARSER_CONTEXT * parser, PT_NODE * statement)
+{
+  PT_NODE *spec;
+
+  if (statement == NULL)
+    {
+      return false;
+    }
+
+  switch (statement->node_type)
+    {
+    case PT_INSERT:
+      /* INSERT has a single target spec. The INSERT...SELECT source tables are not modify targets and
+       * are intentionally not inspected here. */
+      return spec_has_replication_class (parser, statement->info.insert.spec);
+
+    case PT_UPDATE:
+      /* Only the specs actually updated decide replication, not join-only specs. In a multi-table UPDATE
+       * the modified tables are the ones flagged PT_SPEC_FLAG_UPDATE (the first FROM spec is not
+       * necessarily a target). Generate SBR when any updated target is a replication class. */
+      for (spec = statement->info.update.spec; spec != NULL; spec = spec->next)
+	{
+	  if ((spec->info.spec.flag & PT_SPEC_FLAG_UPDATE) && spec_has_replication_class (parser, spec))
+	    {
+	      return true;
+	    }
+	}
+      return false;
+
+    case PT_DELETE:
+      /* Only the specs actually deleted decide replication, not join-only specs. The deleted tables are
+       * the ones flagged PT_SPEC_FLAG_DELETE. Generate SBR when any deleted target is a replication class. */
+      for (spec = statement->info.delete_.spec; spec != NULL; spec = spec->next)
+	{
+	  if ((spec->info.spec.flag & PT_SPEC_FLAG_DELETE) && spec_has_replication_class (parser, spec))
+	    {
+	      return true;
+	    }
+	}
+      return false;
+
+    default:
+      return true;
+    }
+}
+
 /*
  * do_statement() -
  *   return: Error code
@@ -3252,7 +3402,7 @@ do_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
        * error. */
 
       /* disable data replication log for schema replication log types in HA mode */
-      if (!HA_DISABLED () && is_stmt_based_repl_type (statement))
+      if (!HA_DISABLED () && is_stmt_based_repl_type (statement) && is_data_repl_log_enabled (parser, statement))
 	{
 	  need_stmt_replication = true;
 
@@ -3960,7 +4110,7 @@ do_execute_statement (PARSER_CONTEXT * parser, PT_NODE * statement)
   /* for the subset of nodes which represent top level statements, process them; for any other node, return an error */
 
   /* disable data replication log for schema replication log types in HA mode */
-  if (!HA_DISABLED () && is_stmt_based_repl_type (statement))
+  if (!HA_DISABLED () && is_stmt_based_repl_type (statement) && is_data_repl_log_enabled (parser, statement))
     {
       need_stmt_based_repl = true;
 

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -8420,7 +8420,7 @@ locator_update_index (THREAD_ENTRY * thread_p, RECDES * new_recdes, RECDES * old
       index = &(new_attrinfo->last_classrepr->indexes[i]);
       if (rk_btid_index == -1 && repl_info != NULL && repl_info->need_replication == true
 	  && !LOG_CHECK_LOG_APPLIER (thread_p) && or_is_replication_candidate_key (index)
-	  && log_does_allow_replication () == true)
+	  && heap_is_replication_class (thread_p, class_oid) && log_does_allow_replication () == true)
 	{
 	  rk_btid_index = i;
 	}
@@ -8805,7 +8805,6 @@ locator_update_index (THREAD_ENTRY * thread_p, RECDES * new_recdes, RECDES * old
 	       */
 	      repl_old_key->data.midxkey.domain = key_domain;
 	    }
-
 	  error_code =
 	    repl_log_insert (thread_p, class_oid, oid, LOG_REPLICATION_DATA, RVREPL_DATA_UPDATE, repl_old_key,
 			     (REPL_INFO_TYPE) repl_info->repl_info_type);


### PR DESCRIPTION
병합용 브랜치를 업데이트하기위한 pr입니다.

* Fix replication handling in checksumdb and locator_update_index

- Set REPLICATION=OFF for checksum tables
- Add heap_is_replication_class() check in locator_update_index

* Disable core dump in debug mode

* Prevent SBR logging for replication-off tables and enforce USE_SBR in checksumdb

- Do not generate USE_SBR hint logs for tables with replication turned off
- Update checksumdb queries (REPLACE, UPDATE) to explicitly use USE_SBR hint for replication consistency

* Also call from do_statement

* checksumdb: write one SBR log per chunk, suppress the row-based duplicate

After CBRD-26096 let a UNIQUE-NOT-NULL index qualify as a replication key, db_ha_checksum (replication ON, UNIQUE(class_name, chunk_id) NOT NULL) became a replication-key table. The chunk checksum REPLACE then produced a row-based replication log that shipped the master's computed chunk_checksum to the replica, overwriting the value the replica computed for itself. Master and replica rows ended up identical, so checksumdb reported no diff even when the data had actually diverged.

The required behavior is: the checksum statement must be replicated exactly ONCE, as a statement (SBR), so the replica RE-EXECUTES it and recomputes the chunk_checksum from its own data. It must NOT also be replicated row-based, which would re-apply the master's already-computed value on top.

- Drop the USE_SBR hint from the chunk REPLACE/UPDATE. The single SBR log is written by chksum_set_repl_info_and_demote_table_lock() before db_execute (while the S-lock is held, so it is ordered correctly in the replication stream), and the S->IS demotion lets concurrent writers resume during the heavy local computation (MVCC keeps the master read accurate without the lock). USE_SBR cannot do this: its do_replicate_statement runs AFTER execution, i.e. after the demotion, so it would emit a SECOND, mis-ordered SBR that re-executes against post-demotion data on the replica.
- Bracket the local db_execute with db_set_suppress_repl_on_transaction( true/false) so the row-based duplicate is not generated. suppress only blocks row-based (LOG_REPLICATION_DATA); the SBR statement log is kept. The flag is per-transaction (tdes) and is cleared immediately after the execute, so it does not affect other statements or other clients.
- Keep USE_SBR on the master_checksum and schema-definition updates: those carry literal values (no snapshot ordering needed) and are unaffected.

* Gate SBR on actual modify-target specs, not join-only specs

is_data_repl_log_enabled() decided SBR for a USE_SBR-hinted DML by looking at the wrong specs:
- UPDATE checked only the first FROM spec, which is not necessarily a modify target in a multi-table UPDATE (e.g. UPDATE t1 a, t2 b SET b.x = ... updates t2, not the first spec t1).
- DELETE iterated the whole FROM list, so a join-only spec being a replication class wrongly enabled SBR even when the deleted table was not replicated.

Decide on the actual modify targets instead, using the per-spec flags the parser already sets: PT_SPEC_FLAG_UPDATE for updated specs and PT_SPEC_FLAG_DELETE for deleted specs. INSERT keeps its single target spec. SBR is generated when any modify-target spec is a replication class.

Also harden against NULL dereference: read the class name through a get_spec_classname() helper that returns NULL for specs without an entity name (e.g. derived tables); is_replication_class (NULL) is false, so every path stays null-safe. The previous code dereferenced spec->entity_name directly.

Known limitation (unchanged): a statement that modifies a replication target while referencing a replication-off table by join (or INSERT...SELECT source) still re-executes against an empty/divergent table on the replica.

* Return bool from is_data_repl_log_enabled for style consistency

The function returned int with FALSE/TRUE while the sibling replication predicates in this file (is_replication_class, is_stmt_based_repl_type, truncate_need_repl_log) are bool with true/false. Switch it to bool and true/false to match. It is only used in boolean context, so behavior is unchanged.

* checksumdb: handle db_set_suppress_repl_on_transaction errors

Per review, the return value of db_set_suppress_repl_on_transaction was ignored. If suppressing the row-based replication log fails, abort before db_execute so the master's checksum is not row-replicated to the replica (which would reintroduce the divergence-hiding bug). The resume call's result is kept as the error baseline and is superseded by an actual execution error. Reuses the existing error variable.

* Detect replication class for derived vclass INSERT/UPDATE/DELETE targets

is_data_repl_log_enabled decided SBR only from a target spec's entity_name. When an updatable vclass is rewritten into a derived table (mq_rewrite_vclass_spec_as_derived), the outer spec's entity_name and flat_entity_list are cleared and the real base classes are moved into the derived subtree, so USE_SBR was silently skipped for derived vclass targets.

Add spec_has_replication_class(): check entity_name and flat_entity_list, and when the target carries a derived_table, walk that subtree for base classes resolved to a replication class. Thread parser through is_data_repl_log_enabled for the walk.

<http://jira.cubrid.org/browse/CBRD-XXXX>

### Purpose

N/A

### Implementation

N/A

### Remarks

N/A
