### PR TITLE
[CBRD-27225] [p10.2] Keep the optimization level when building bundled third-party libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -891,7 +891,8 @@ set_property(DIRECTORY PROPERTY EP_BASE "${CMAKE_BINARY_DIR}/external")
 # -w silences third-party warnings and -O2 restates the level autoconf would have
 # applied on its own, which supplying CFLAGS suppresses. Passing only -w leaves every
 # library configured through this variable at -O0.
-set(DEFAULT_CONFIGURE_OPTS <SOURCE_DIR>/configure --prefix=${CMAKE_CURRENT_BINARY_DIR}/external --enable-static --disable-shared --with-pic "CFLAGS=-O2 -w" "CXXFLAGS=-O2 -w")
+# No CXXFLAGS: none of these compile C++ in the target this build runs.
+set(DEFAULT_CONFIGURE_OPTS <SOURCE_DIR>/configure --prefix=${CMAKE_CURRENT_BINARY_DIR}/external --enable-static --disable-shared --with-pic "CFLAGS=-O2 -w")
 
 # WITH_LIBREGEX can have multiple values with different meanings
 # on Linux:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -888,7 +888,10 @@ endif(USE_CUBRID_ENV)
 # For external library options
 include(ExternalProject)
 set_property(DIRECTORY PROPERTY EP_BASE "${CMAKE_BINARY_DIR}/external")
-set(DEFAULT_CONFIGURE_OPTS <SOURCE_DIR>/configure --prefix=${CMAKE_CURRENT_BINARY_DIR}/external --enable-static --disable-shared --with-pic CFLAGS=-w CXXFLAGS=-w)
+# -w silences third-party warnings and -O2 restates the level autoconf would have
+# applied on its own, which supplying CFLAGS suppresses. Passing only -w leaves every
+# library configured through this variable at -O0.
+set(DEFAULT_CONFIGURE_OPTS <SOURCE_DIR>/configure --prefix=${CMAKE_CURRENT_BINARY_DIR}/external --enable-static --disable-shared --with-pic "CFLAGS=-O2 -w" "CXXFLAGS=-O2 -w")
 
 # WITH_LIBREGEX can have multiple values with different meanings
 # on Linux:


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27225

### Purpose

Seven of the libraries built from source by the top-level `CMakeLists.txt` are compiled at
the compiler default of `-O0`. The shared configure options replace the optimization level
rather than adding to it: a `CFLAGS` value handed to a configure script stops autoconf from
applying its own `-g -O2`, and this variable passes `CFLAGS=-w CXXFLAGS=-w`.

- `CMakeLists.txt:891` — `set(DEFAULT_CONFIGURE_OPTS ... CFLAGS=-w CXXFLAGS=-w)`, consumed by
  libregex38a (`:909`), expat (`:955`), jansson (`:1000`), libedit (`:1076`), lzo (`:1117`),
  libgpg-error (`:1156`) and libgcrypt (`:1205`). All seven are built from source in a
  default build.
- The intent of `-w` is to silence third-party warnings, which is legitimate; it arrives as
  the whole value of `CFLAGS` rather than as an addition to it, so the optimization level
  goes with it.
- The level does not follow `CMAKE_BUILD_TYPE` either. The variable is a fixed string and no
  external project definition references the build type, so a Release build and a Debug
  build produce the same `-O0` objects for all seven.

Two of the seven are on paths a user can feel. lzo is this line's compression library and
occupies the same three call sites lz4 occupies from 11.0 onward — `log_zip ()` and
`log_unzip ()` in `src/transaction/log_compress.c`, string compression for values of 255
bytes or more in `src/object/object_representation.c` and `src/object/object_primitive.c`,
and backup compression in `src/storage/file_io.c`, where `cubrid backupdb` compresses by
default. libgcrypt backs `AES_ENCRYPT`, `AES_DECRYPT`, `SHA1` and the `SHA2` variants in
`src/query/crypt_opfunc.c`, and the DES cipher used for password encryption in
`src/base/encryption.c`.

This is not a regression. `DEFAULT_CONFIGURE_OPTS` has suppressed the autoconf default since
`b88b3adcc` [CBRD-20155] introduced the CMake build in 2016, first by passing
`CFLAGS=${CMAKE_C_FLAGS}` — which held only warning options, the level living in
`CMAKE_C_FLAGS_RELEASE` — and since `4acdb495a` (#1682, 2019) by passing `-w`.

### Implementation

- `CMakeLists.txt` — restate the optimization level in the shared configure options so that
  `-w` no longer displaces it.
  - `CFLAGS=-w CXXFLAGS=-w` becomes `"CFLAGS=-O2 -w" "CXXFLAGS=-O2 -w"`
  - `-O2` is what autoconf would have applied on its own, and what CUBRID uses for its own
    release objects. Debug info is not carried over, matching the current build.
- One line covers all seven libraries, since they share the variable. Unlike the 11.x lines
  there is no second change, because no external project on this branch passes flags on a
  make command line — lz4 and RE2 do not exist here.
- No engine source change. Compressed byte streams, on-disk formats, regular expression
  results and cipher output are unchanged.
- OpenSSL and rapidjson are unaffected and need no change: OpenSSL runs its own `config`
  script rather than this variable, and rapidjson is header-only and compiled together with
  CUBRID's own sources.
- The Windows path is not affected. It links prebuilt libraries and does not run these
  configure scripts.

Verification: each configure script was run twice, once with the options the build script
passes today and once with no CFLAGS at all, and the CFLAGS line of the generated Makefile
compared.

```
 library             as configured today                     with no CFLAGS given
 lzo 2.10            -w                                      -g -O2
 libregex38a         -w -D_LARGEFILE64_SOURCE -D_FILE...     -g -O2 -D_LARGEFILE64_SOURCE ...
 libgpg-error 1.27   -w -Wall -Wpointer-arith -Wno-psabi     -g -O2 -Wall -Wpointer-arith ...
 libgcrypt 1.5.6     -w -fvisibility=hidden -Wall            -g -O2 -fvisibility=hidden -Wall
```

CMake expansion was checked so that each `CFLAGS=...` reaches configure as a single argument
rather than being split at the space.

### Performance

lzo 2.10, the version referenced by the build script, compiled both ways on the same machine.
The benchmark calls `lzo1x_1_compress ()` and `lzo1x_decompress_safe ()`, the entry points
the engine uses. Times are per call.

```
             compress                      decompress
 size   CFLAGS=-w  CFLAGS="-O2 -w" ratio   CFLAGS=-w  CFLAGS="-O2 -w" ratio
  384 B    373 ns         231 ns   1.6x        83 ns          38 ns   2.2x
 1024 B    785 ns         448 ns   1.8x       223 ns          95 ns   2.3x
 4096 B  2,714 ns       1,438 ns   1.9x       883 ns         363 ns   2.4x
16384 B 10,065 ns       4,891 ns   2.1x     2,805 ns       1,260 ns   2.2x
```

The archive is 331,356 bytes as built today and 230,308 bytes after, and carries 16,502
stack-spill instructions against 7, which is the signature of `-O0` code generation.

The ratio is smaller than the 5.9x the 11.x work reports for lz4. lzo is written largely as
macros over a small set of loops, so it loses less to `-O0` than lz4's function-per-stage
structure does.

### Remarks

- Sub-task of [CBRD-27218](http://jira.cubrid.org/browse/CBRD-27218), which covers the same
  class of problem on release/11.0 through develop (#7670, and #7674 through #7677 for the
  release lines). This PR is not a backport of those — the file, the library set and the
  number of affected lines all differ on this branch, so the change was written for it.
- No backup-level or server-level measurement was taken here. The lzo call sites are the same
  three lz4 occupies on 11.x, where backup compression accounted for 71% of backup process
  CPU, so an effect is expected — but at a smaller ratio, and it has not been measured.
- libgcrypt is a cryptographic library and its optimization level changes here. Its own test
  suite is worth running alongside the usual regression set; `AES_ENCRYPT`, `AES_DECRYPT`,
  `SHA1`, `SHA2` and existing passwords must behave identically.
- No expected-output test is touched.
