### PR TITLE
[CBRD-27159] [Backport] Keep a copy-pushed term in the main query for an outer joined spec

### DIFF
--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -224,6 +224,7 @@ static PT_NODE *mq_class_meth_corr_subq_pre (PARSER_CONTEXT * parser, PT_NODE * 
 					     int *continue_walk);
 static bool mq_has_class_methods_corr_subqueries (PARSER_CONTEXT * parser, PT_NODE * node);
 static PT_NODE *pt_check_pushable (PARSER_CONTEXT * parser, PT_NODE * tree, void *arg, int *continue_walk);
+static bool pt_has_non_deterministic_expr (PARSER_CONTEXT * parser, PT_NODE * term);
 static bool pt_check_pushable_subquery_select_list (PARSER_CONTEXT * parser, PT_NODE * query, int pos);
 static PT_NODE *pt_find_only_name_id (PARSER_CONTEXT * parser, PT_NODE * tree, void *arg, int *continue_walk);
 static bool pt_check_pushable_term (PARSER_CONTEXT * parser, PT_NODE * term, FIND_ID_INFO * infop);
@@ -3610,6 +3611,32 @@ pt_check_pushable (PARSER_CONTEXT * parser, PT_NODE * tree, void *arg, int *cont
 }
 
 /*
+ * pt_has_non_deterministic_expr() - check if the term has an expression whose result can differ
+ *                                   between two evaluations, such as random () or a method call
+ *   return: true if such an expression is found
+ *   parser(in):
+ *   term(in):
+ */
+static bool
+pt_has_non_deterministic_expr (PARSER_CONTEXT * parser, PT_NODE * term)
+{
+  CHECK_PUSHABLE_INFO cpi;
+  PT_NODE *save_next;
+
+  cpi.check_query = false;	/* subqueries are not of interest here */
+  cpi.check_method = true;	/* methods and random (), uuid (), ... are reported as method_found */
+  cpi.query_found = false;
+  cpi.method_found = false;
+
+  save_next = term->next;
+  term->next = NULL;
+  (void) parser_walk_tree (parser, term, pt_check_pushable, (void *) &cpi, NULL, NULL);
+  term->next = save_next;
+
+  return cpi.method_found;
+}
+
+/*
  * pt_check_pushable_select_list() - check for pushable
  *   return:
  *   parser(in):
@@ -4506,6 +4533,13 @@ mq_copypush_sargable_terms_helper (PARSER_CONTEXT * parser, PT_NODE * statement,
 	  continue;
 	}
 
+      /* The term of an outer joined spec is evaluated both in the derived table and in the main query
+       * (see below), so a term which can return a different result for each evaluation is not pushed. */
+      if (is_outer_joined && pt_has_non_deterministic_expr (parser, term))
+	{
+	  continue;
+	}
+
       if (pt_check_pushable_term (parser, term, infop))
 	{
 	  /* copy term */
@@ -4513,7 +4547,13 @@ mq_copypush_sargable_terms_helper (PARSER_CONTEXT * parser, PT_NODE * statement,
 	  /* for term, mark as copy-pushed term */
 	  if (term->node_type == PT_EXPR)
 	    {
-	      PT_EXPR_INFO_SET_FLAG (term, PT_EXPR_INFO_COPYPUSH);
+	      /* Keep the term in the main query for an outer join which is not converted to an inner join.
+	       * e.g. when the pushed copy leaves no row in the derived table, the left join still generates
+	       * a NULL-extended row and only the term in the main query can filter it out. */
+	      if (!is_outer_joined)
+		{
+		  PT_EXPR_INFO_SET_FLAG (term, PT_EXPR_INFO_COPYPUSH);
+		}
 	      PT_EXPR_INFO_CLEAR_FLAG (new_term, PT_EXPR_INFO_COPYPUSH);
 	    }
 	  push_term_list = parser_append_node (new_term, push_term_list);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27159

## Purpose

develop 의 CBRD-27159 수정(#7652, af56432c5)을 `release/11.4` 로 백포트합니다. 동일한 오답이 11.4 에서도 재현되며, 뷰 머징이 없는 11.4 에서는 **일반 뷰를 사용하는 질의까지** 영향을 받습니다.

```sql
create table t1 (c1 int, c4 int);
create table t2 (c3 int, c4 varchar(50), c15 double);
insert into t1 values (1, 127);
create view v_t2 as select c15, c3, c4 from t2;

-- 0 row (정상)
select a.c4 from t1 a left join t2 b on a.c1 = b.c3 where b.c4 <> 'x' or b.c15 < 6;

-- 1 row : 127 (오답)
select a.c4 from t1 a left join v_t2 b on a.c1 = b.c3 where b.c4 <> 'x' or b.c15 < 6;
```

파생 테이블로 copy-push 된 term 은 최적화 마지막 단계(`qo_rewrite_queries_post ()`)에서 주질의의 where 절에서 제거되는데, outer join 인 경우 push 된 사본은 파생 테이블의 행만 거를 뿐 대응 행이 없을 때 생성되는 NULL 확장 행을 거르지 못합니다. 그 결과 외부 테이블의 행이 그대로 결과에 남습니다.

## Implementation

`af56432c5` 를 `git cherry-pick -x` 로 그대로 적용했습니다(충돌 없음). `src/parser/view_transform.c` 한 파일만 변경됩니다.

* outer join 된 spec 이면 원본 term 에 `PT_EXPR_INFO_COPYPUSH` 를 표시하지 않아 term 이 주질의에 남도록 합니다. 사본은 그대로 push 되므로 파생 테이블에 대한 필터링 이득은 유지됩니다.
* outer join 된 spec 에서는 `random ()`, `uuid ()` 등 비결정 함수를 포함한 term 을 push 하지 않습니다(`pt_has_non_deterministic_expr ()`). 안팎에서 두 번 평가되면 매칭 행 제거와 NULL 확장 행 보존이 동시에 일어날 수 있기 때문입니다.

## Remarks

`release/11.4`(`80329110b`) 기준으로 백포트 적용 전/후 릴리즈 빌드를 만들어 검증했습니다.

| # | 질의 형태 | 11.4 | 백포트 후 |
|---|---|---|---|
| 1 | 실제 테이블, `<>` OR `<` | 0 row | 0 row |
| 2 | **뷰** | **127** | 0 row |
| 3 | 인라인 뷰 + `NO_MERGE` | **127** | 0 row |
| 4 | 인라인 뷰 + `GROUP BY` | **127** | 0 row |
| 5 | 두 개 테이블로 구성된 뷰 | **127** | 0 row |
| 6 | `b.c4 is null or b.c15 < 6` (남아야 함) | 127 | 127 |
| 7 | `coalesce (b.c4,'z') <> 'x' or ...` (남아야 함) | 127 | 127 |
| 8 | 단일 null-rejecting term | 0 row | 0 row |
| 9 | null-rejecting term 들의 AND | 0 row | 0 row |
| 10 | 대응 행이 있고 조건을 만족 | 1 row | 1 row |
| 11 | 대응 행은 있으나 조인 조건 불일치 | **127** | 0 row |

develop 과 달리 11.4 에는 CBRD-26260(left outer join 뷰 머징 확장)이 없어 2번 케이스도 copy-push 경로를 타므로 오답이 발생합니다.

회귀

* `cubrid-testcases/sql` 에서 left join 을 포함하는 테스트케이스 400건을 두 빌드에서 수행했으며 출력 라인 수(62,850)와 결과가 모두 동일합니다(트레이스의 포인터/시간 값 차이만 존재).
* `sql/_33_elderberry/cbrd_24042/cbrd_26260` 테스트케이스 결과 동일.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
