### PR TITLE
[CBRD-27189] Do not merge a subquery whose numbering column becomes an operand of an expression

### DIFF
--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -119,6 +119,14 @@ typedef struct check_pushable_info
   bool method_found;
 } CHECK_PUSHABLE_INFO;
 
+typedef struct attr_ref_info
+{
+  UINTPTR spec_id;		/* spec id of the attribute to look for */
+  const char *name;		/* name of the attribute to look for */
+
+  bool found;			/* set when a reference is found */
+} ATTR_REF_INFO;
+
 static unsigned int top_cycle = 0;
 static DB_OBJECT *cycle_buffer[MAX_CYCLE];
 
@@ -236,6 +244,13 @@ static bool pt_has_non_deterministic_expr (PARSER_CONTEXT * parser, PT_NODE * te
 static bool pt_check_pushable_subquery_select_list (PARSER_CONTEXT * parser, PT_NODE * query, int pos);
 static PT_NODE *pt_find_only_name_id (PARSER_CONTEXT * parser, PT_NODE * tree, void *arg, int *continue_walk);
 static bool pt_check_pushable_term (PARSER_CONTEXT * parser, PT_NODE * term, FIND_ID_INFO * infop);
+static PT_NODE *mq_find_sort_dependent_node (PARSER_CONTEXT * parser, PT_NODE * node, void *void_arg,
+					     int *continue_walk);
+static PT_NODE *mq_find_attr_reference (PARSER_CONTEXT * parser, PT_NODE * node, void *void_arg, int *continue_walk);
+static bool mq_is_attr_referenced (PARSER_CONTEXT * parser, PT_NODE * node, ATTR_REF_INFO * infop);
+static bool mq_is_sort_dependent_column (PARSER_CONTEXT * parser, PT_NODE * column);
+static bool mq_is_sort_dependent_column_used_in_expr (PARSER_CONTEXT * parser, PT_NODE * subquery,
+						      PT_NODE * mainquery, PT_NODE * class_spec, PT_NODE * class_);
 static PUSHABLE_TYPE mq_is_pushable_subquery (PARSER_CONTEXT * parser, PT_NODE * subquery, PT_NODE * mainquery,
 					      PT_NODE * class_spec, bool is_vclass, PT_NODE * order_by,
 					      PT_NODE * class_);
@@ -1847,6 +1862,212 @@ pt_check_odku_refs_view (PARSER_CONTEXT * parser, PT_NODE * statement)
 }
 
 /*
+ * mq_find_sort_dependent_node () - look for ORDERBY_NUM()/GROUPBY_NUM() of the query being walked
+ *   return: node (unchanged)
+ *   parser(in): parser context
+ *   node(in): node to check
+ *   void_arg(in/out): bool *
+ *   continue_walk(in/out):
+ */
+static PT_NODE *
+mq_find_sort_dependent_node (PARSER_CONTEXT * parser, PT_NODE * node, void *void_arg, int *continue_walk)
+{
+  bool *has_sort_dependent = (bool *) void_arg;
+
+  if (PT_IS_ORDERBYNUM (node) || PT_IS_GROUPBYNUM (node))
+    {
+      *has_sort_dependent = true;
+    }
+
+  if (*has_sort_dependent)
+    {
+      *continue_walk = PT_STOP_WALK;
+    }
+  else if (PT_IS_QUERY_NODE_TYPE (node->node_type))
+    {
+      /* a nested query has its own numbering */
+      *continue_walk = PT_LIST_WALK;
+    }
+
+  return node;
+}
+
+/*
+ * mq_find_attr_reference () - look for a reference to a given attribute of a spec
+ *   return: node (unchanged)
+ *   parser(in): parser context
+ *   node(in): node to check
+ *   void_arg(in/out): ATTR_REF_INFO *
+ *   continue_walk(in/out):
+ */
+static PT_NODE *
+mq_find_attr_reference (PARSER_CONTEXT * parser, PT_NODE * node, void *void_arg, int *continue_walk)
+{
+  ATTR_REF_INFO *infop = (ATTR_REF_INFO *) void_arg;
+
+  if (node->node_type == PT_NAME && node->info.name.spec_id == infop->spec_id
+      && node->info.name.original != NULL && intl_identifier_casecmp (node->info.name.original, infop->name) == 0)
+    {
+      infop->found = true;
+    }
+
+  if (infop->found)
+    {
+      *continue_walk = PT_STOP_WALK;
+    }
+
+  return node;
+}
+
+/*
+ * mq_is_attr_referenced () - check whether a node tree refers to a given attribute of a spec
+ *   return: true if the attribute is referenced in the tree
+ *   parser(in): parser context
+ *   node(in): node tree to search. its 'next' list is searched, too
+ *   infop(in/out): attribute to look for
+ */
+static bool
+mq_is_attr_referenced (PARSER_CONTEXT * parser, PT_NODE * node, ATTR_REF_INFO * infop)
+{
+  if (node == NULL)
+    {
+      return false;
+    }
+
+  infop->found = false;
+  (void) parser_walk_tree (parser, node, mq_find_attr_reference, infop, NULL, NULL);
+
+  return infop->found;
+}
+
+/*
+ * mq_is_sort_dependent_column () - check whether a select list column of a subquery holds a value which is
+ *                                  only known after the subquery's sort is done
+ *   return: true if the column contains ORDERBY_NUM()/GROUPBY_NUM()
+ *   parser(in): parser context
+ *   column(in): a single column of a select list. its 'next' list is not searched
+ *
+ * NOTE:
+ *   ORDERBY_NUM()/GROUPBY_NUM() are not evaluated while the rows are being produced, but while the sorted (or
+ *   grouped) result is being written out. Therefore such a column can only be projected as it is; it can not be
+ *   used as an operand of another expression. see qexec_ordby_put_next () in query_executor.c.
+ */
+static bool
+mq_is_sort_dependent_column (PARSER_CONTEXT * parser, PT_NODE * column)
+{
+  PT_NODE *save_next;
+  bool has_sort_dependent = false;
+
+  if (column == NULL)
+    {
+      return false;
+    }
+
+  /* cut off next to check this column only */
+  save_next = column->next;
+  column->next = NULL;
+
+  (void) parser_walk_tree (parser, column, mq_find_sort_dependent_node, &has_sort_dependent, NULL, NULL);
+
+  column->next = save_next;
+
+  return has_sort_dependent;
+}
+
+/*
+ * mq_is_sort_dependent_column_used_in_expr () - check whether merging would make a sort dependent column of the
+ *                                               subquery an operand of an expression of the main query
+ *   return: true if such a use is found
+ *   parser(in): parser context
+ *   subquery(in): subquery(or view query spec) to be merged
+ *   mainquery(in): query the subquery is to be merged into
+ *   class_spec(in): spec of the subquery in the main query
+ *   class_(in): view name node, NULL for an inline view
+ *
+ * NOTE:
+ *   Merging replaces every reference to a column of subquery with the defining expression of that column
+ *   (see mq_substitute_select_for_inline_view (), mq_substitute_select_in_statement ()). A column holding
+ *   ORDERBY_NUM()/GROUPBY_NUM() may only be projected as it is, so the merged select list is valid only while
+ *   every reference to such a column is a bare column of the select list of the main query. Anything else
+ *   (DECODE (rn, 1, name, 'WRONG'), CAST (rn AS VARCHAR), rn + 0, a subquery reading rn, ...) makes the numbering
+ *   an operand of an expression, which reads the value before it is set and returns a wrong result. That is the
+ *   very shape which is rejected when it is written directly. (see pt_check_orderbynum_pre ()/
+ *   pt_check_orderbynum_post () and MSGCAT_SEMANTIC_ORDERBYNUM_SELECT_LIST_ERR in semantic_check.c)
+ *
+ *   The other clauses of the main query are not checked because a reference from them can not get here: a main
+ *   query which has its own ORDER BY is not merged with a subquery which has one (is_only_spec), and a GROUP BY
+ *   or a HAVING of the main query keeps the numbering column in a spec of its own as well. The WHERE clause is
+ *   left out on purpose: mq_is_rownum_only_predicate () has already restricted it to 'numbering <comparison>
+ *   constant' terms, which merging turns into the TOP-N clause of the merged query (see mq_update_order_by ())
+ *   instead of reading the numbering value.
+ */
+static bool
+mq_is_sort_dependent_column_used_in_expr (PARSER_CONTEXT * parser, PT_NODE * subquery, PT_NODE * mainquery,
+					  PT_NODE * class_spec, PT_NODE * class_)
+{
+  PT_NODE *attributes, *attr, *col, *node, *save_next;
+  ATTR_REF_INFO info;
+  bool found = false;
+
+  assert (PT_IS_SELECT (subquery));
+
+  if (!PT_IS_SELECT (mainquery))
+    {
+      /* UPDATE/DELETE/MERGE can not get here: a vclass which numbers its rows is not updatable */
+      return false;
+    }
+
+  /* get the attributes of the spec, which are matched with the select list of the subquery by position */
+  if (class_ != NULL)
+    {
+      attributes = mq_fetch_attributes (parser, class_);
+      info.spec_id = class_->info.name.spec_id;
+    }
+  else
+    {
+      attributes = class_spec->info.spec.as_attr_list;
+      info.spec_id = class_spec->info.spec.id;
+    }
+
+  for (attr = attributes, col = subquery->info.query.q.select.list; attr != NULL && col != NULL;
+       attr = attr->next, col = col->next)
+    {
+      if (attr->node_type != PT_NAME || attr->info.name.original == NULL)
+	{
+	  continue;
+	}
+      if (!mq_is_sort_dependent_column (parser, col))
+	{
+	  continue;
+	}
+
+      info.name = attr->info.name.original;
+
+      /* a bare column of the select list is projected as it is; every other column which reads it is an
+       * expression having the numbering as an operand */
+      for (node = mainquery->info.query.q.select.list; node != NULL; node = node->next)
+	{
+	  if (node->node_type == PT_NAME)
+	    {
+	      continue;
+	    }
+
+	  save_next = node->next;
+	  node->next = NULL;
+	  found = mq_is_attr_referenced (parser, node, &info);
+	  node->next = save_next;
+
+	  if (found)
+	    {
+	      return true;
+	    }
+	}
+    }
+
+  return false;
+}
+
+/*
  * mq_is_pushable_subquery () - check if a subquery is pushable
  *  returns: true if pushable, false otherwise
  *   parser(in): parser context
@@ -1883,7 +2104,8 @@ pt_check_odku_refs_view (PARSER_CONTEXT * parser, PT_NODE * statement)
  *  - has CONNECT BY (Hierarchical Queries)
  *  - has DISTINCT
  *  - has aggregate or orderby_for or analytic
- *  - has inst num or orderby_num
+ *  - has inst num or orderby_num, and either it is not the only spec or the main query uses a column holding
+ *    orderby_num/groupby_num in an expression
  *  - has method
  *  TO_DO : check all cases using is_vclass
  */
@@ -2149,9 +2371,19 @@ mq_is_pushable_subquery (PARSER_CONTEXT * parser, PT_NODE * subquery, PT_NODE * 
     }
 
   /* check inst num or orderby_num */
-  if (!is_only_spec && pt_has_inst_in_where_and_select_list (parser, subquery))
+  if (pt_has_inst_in_where_and_select_list (parser, subquery))
     {
-      return NON_PUSHABLE;
+      if (!is_only_spec)
+	{
+	  return NON_PUSHABLE;
+	}
+
+      /* Even for a single spec, merging is given up when the main query embeds a numbering column of the subquery
+       * into an expression, since such a column is not evaluated until the subquery's sort is done. (CBRD-27189) */
+      if (mq_is_sort_dependent_column_used_in_expr (parser, subquery, mainquery, class_spec, class_))
+	{
+	  return NON_PUSHABLE;
+	}
     }
 
   /* check method */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27189

## Purpose

서브쿼리가 `ROWNUM`/`ORDERBY_NUM()`을 컬럼으로 노출하고, 메인 쿼리가 그 컬럼을 **표현식의 피연산자로** 읽으면 뷰 머징 후 잘못된 결과가 나옵니다.

```sql
SELECT DECODE(rn, 1, name, 'WRONG') AS RESULT
FROM (SELECT name, ROWNUM AS rn
        FROM (SELECT name FROM athlete ORDER BY name) WHERE ROWNUM <= 1);
-- expected: 'Aardenburg Willemien'   actual(develop): 'WRONG'
-- 재작성 결과: select decode((orderby_num()), 1, name, 'WRONG') from athlete order by 2 for (orderby_num())<= ?
```

안쪽 머징에서 `ROWNUM`이 `ORDERBY_NUM()`으로 바뀌고, 한 번 더 머징되면서 그 `ORDERBY_NUM()`이 메인 쿼리의 `DECODE()` 안으로 들어갑니다. `ORDERBY_NUM()`은 행을 만드는 시점이 아니라 정렬 결과를 내보내는 시점에 채워지고, 그때 값을 받는 것은 **출력 리스트의 top-level `ORDERBY_NUM` 컬럼 위치뿐**입니다(`qexec_ordby_put_next ()`). 그래서 표현식 안에서 읽으면 설정 전 값을 읽어 오답이 됩니다.

같은 이유로 사용자가 직접 쓰면 semantic check가 거절합니다.

```sql
SELECT orderby_num() + 1 FROM athlete ORDER BY name FOR orderby_num() <= 2;
-- ERROR: Current release restricts a expression containing ORDERBY_NUM() in select list.
SELECT orderby_num(), name FROM athlete ORDER BY name FOR orderby_num() <= 2;  -- bare는 정상
```

즉 머징이 **엔진이 지원하지 않는 모양**을 스스로 만들어내고 있었습니다. CBRD-27172의 두 번째 이슈(재작성된 질의가 `decode((orderby_num()), ...)`가 되어 PL/CSQL static query 컴파일 실패)도 같은 원인이며 이 수정으로 함께 해소됩니다.

`DECODE` 외에 `CASE`, `rn + 0`, `NVL`, 문자열 결합, **`CAST(rn AS VARCHAR)`**, **select list의 스칼라 서브쿼리가 rn을 읽는 경우**도 모두 오답이었습니다(아래 표).

이 PR은 #7628 (@beyondykk9)에서 이관받아, 뷰 머징을 넓게 차단하던 방식을 "위법한 모양이 되는 경우만" 차단하도록 정밀화한 것입니다.

## Implementation

`src/parser/view_transform.c` — `mq_is_pushable_subquery ()`의 numbering 검사에서, single spec인 경우에도 `mq_is_sort_dependent_column_used_in_expr ()`가 참이면 `NON_PUSHABLE`을 반환합니다.

판정 기준은 하나입니다.

> 서브쿼리 select list에 `ORDERBY_NUM()`/`GROUPBY_NUM()`을 담은 컬럼이 있고, 그 컬럼에 대응하는 속성을 메인 쿼리의 select list가 **bare 컬럼이 아닌 항목에서** 참조하면 머징하지 않는다.

- 컬럼 ↔ 속성 대응은 치환이 실제로 쓰는 대응(`spec->as_attr_list` ↔ 서브쿼리 select list 위치 대응, `mq_substitute_select_for_inline_view ()`/`mq_substitute_select_in_statement ()`)을 그대로 사용합니다.
- bare 컬럼으로 투영되는 참조는 그대로 유지하므로 `SELECT rn FROM (...)` 같은 질의는 계속 머징됩니다.

**메인 쿼리의 다른 절은 검사하지 않습니다.** develop에서 실측한 도달 가능성:

| 메인 쿼리가 numbering 컬럼을 읽는 위치 | develop 머징 | develop 결과 | 이 PR |
|---|---|---|---|
| select list 표현식 (`DECODE`/`CASE`/`+`/`NVL`/`‖`) | 머징됨 | **오답** | 차단 |
| select list `CAST(rn AS VARCHAR)` | 머징됨 | **오답 `'0'`** | 차단 |
| select list 스칼라 서브쿼리 | 머징됨 | **오답 `0`** | 차단 |
| `GROUP BY rn` / `HAVING rn > 1` | 머징 안 됨 | 정상 | 변화 없음 |
| `ORDER BY rn` / `ORDER BY 1` | 머징 안 됨 (`is_only_spec`) | 정상 | 변화 없음 |
| `WHERE rn >= 7 AND rn < 10` | 머징됨 (TOP-N으로 변환) | 정상 | 변화 없음 |
| UPDATE/DELETE 경유 | 불가 (`Vclass ... is not updatable`) | — | 변화 없음 |

WHERE는 의도적으로 제외했습니다. `is_only_spec`이 성립한 시점에 `mq_is_rownum_only_predicate ()`가 이미 `numbering <비교> 상수` 형태만 남겼음을 보장하고, 이 항들은 값을 읽는 대신 머징된 질의의 TOP-N 절(`mq_update_order_by ()`)로 변환됩니다. 검사에 포함하면 `cbrd_24258`/`cbrd_26257`의 페이지네이션 플랜이 깨지는 것을 확인했습니다.

`ROWNUM`/`INST_NUM`만 담은 컬럼은 스캔 중에 평가되므로 표현식에 들어가도 문제가 없어 검사 대상이 아닙니다(develop 플랜 유지).

## Remarks

**Regression 여부**: develop에 오래 존재해 온 문제이며 특정 PR로 인한 회귀가 아닙니다. 11.4 이하 백포트가 필요합니다.

**정합성 (release build, demodb)**

| 케이스 | develop | 이 PR |
|---|---|---|
| `DECODE(rn,1,name,'WRONG')` — 서브쿼리 / CTE / VIEW | `'WRONG'` | `'Aardenburg Willemien'` |
| `CASE WHEN rn=1 ...` | `'WRONG'` | 정상 |
| `rn+0`, `NVL(rn,0)` | `0` | `1` |
| `'x' \|\| rn` | `'x0'` | `'x1'` |
| `CAST(rn AS VARCHAR)` | `'0','0'` | `'1','2'` |
| `(SELECT COUNT(*) ... WHERE src.rn=1)` | `0,0` | `215,0` |
| bare `rn`, `SRC.rn` | `1` | `1` (머징 유지) |
| top-3 `rn, DECODE(rn,1,'first','other')` | `1/other, 2/other, 3/other` | `1/first, 2/other, 3/other` |
| 인덱스로 정렬 해소되는 대조군 / 정렬 없는 `ROWNUM` | 정상 | 정상 (머징 유지) |

**플랜 회귀 검사**: `rownum|orderby_num|inst_num`과 서브쿼리/뷰를 함께 포함하는 cubrid-testcases sql 케이스 167건을 develop 빌드와 이 PR 빌드에서 각각 실행해 결과 + `OPTIMIZATION LEVEL 513` 플랜 덤프를 비교했고 **167건 모두 동일**합니다. (2건에서 보이는 차이는 xasl 덤프의 `fixed scan=/cached scan=` 필드로, 같은 빌드를 두 번 돌려도 값이 바뀌는 비결정 출력입니다.)

#7628에서 플랜이 바뀌었던 5건(`function_index_skip_scan_subquery_001`, `cbrd_22419`, `_01_no_data_filter`, `bug_6947_05_xxxnum`, `cbrd_25519`)은 모두 develop과 동일한 플랜을 유지하며, #7628 본문에 부작용으로 적혀 있던 아래 질의도 머징이 유지됩니다.

```sql
SELECT UPPER(name) AS RESULT FROM
  (SELECT name FROM (SELECT name FROM athlete ORDER BY name) WHERE ROWNUM <= 3) SRC;
-- select upper(SRC.[name]), SRC.[name] from athlete SRC order by 2 for (orderby_num())<= ?:0
```

**Follow-up**: 정합성을 위해 머징을 포기하는 방식이라 해당 모양에서는 인라인 뷰가 남습니다. 실행기가 정렬 이후에 표현식을 재평가하도록(정렬 후 프로젝션) 확장하면 머징을 되살릴 수 있고, 그때는 `SELECT orderby_num()+1 ...` 구문 제한(`pt_has_expr_of_inst_in_sel_list ()`의 FIXME)도 함께 풀 수 있습니다. 별도 개선 이슈로 다루는 것이 좋겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
