### PR TITLE
[CBRD-26866] add a routine to PlcsqlCompilerMain only to check syntax of PL/CSQL code (#7249)

### DIFF
--- a/pl_engine/pl_server/src/main/antlr/PlcParser.g4
+++ b/pl_engine/pl_server/src/main/antlr/PlcParser.g4
@@ -76,8 +76,7 @@ seq_of_declare_specs
     ;
 
 declare_spec
-    : pragma_declaration
-    | constant_declaration
+    : constant_declaration
     | exception_declaration
     | variable_declaration
     | cursor_definition
@@ -107,10 +106,6 @@ cursor_parameter
 
 exception_declaration
     : identifier EXCEPTION SEMICOLON
-    ;
-
-pragma_declaration
-    : PRAGMA AUTONOMOUS_TRANSACTION SEMICOLON
     ;
 
 seq_of_statements

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ParseTreeConverter.java
@@ -245,7 +245,7 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     public Unit visitCreate_routine(Create_routineContext ctx) {
         previsitRoutine_definition(ctx.routine_definition(), null);
         DeclRoutine decl = visitRoutine_definition(ctx.routine_definition());
-        return new Unit(ctx, autonomousTransaction, connectionRequired, decl, spRevision);
+        return new Unit(ctx, connectionRequired, decl, spRevision);
     }
 
     @Override
@@ -1302,28 +1302,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
     }
 
     @Override
-    public AstNode visitPragma_declaration(Pragma_declarationContext ctx) {
-        assert ctx.AUTONOMOUS_TRANSACTION() != null; // by syntax
-
-        // currently, only the Autonomous Transaction is
-        // allowed only in the top-level declarations
-        if (symbolStack.getCurrentScope().level != SymbolStack.LEVEL_MAIN + 1) {
-            throw new SemanticError(
-                    Misc.getLineColumnOf(ctx), // s013
-                    "AUTONOMOUS_TRANSACTION can only be declared at the top level");
-        }
-
-        throw new SemanticError(
-                Misc.getLineColumnOf(ctx), "AUTONOMOUS_TRANSACTION is not supported yet");
-
-        /*
-        // just turn on the flag and return nothing
-        autonomousTransaction = true;
-        return null;
-         */
-    }
-
-    @Override
     public AstNode visitConstant_declaration(Constant_declarationContext ctx) {
 
         String name = Misc.getNormalizedText(ctx.identifier());
@@ -1406,10 +1384,8 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
         try {
             if (ctx.LANGUAGE() != null
                     && symbolStack.getCurrentScope().level > SymbolStack.LEVEL_MAIN) {
-                int[] lineColumn = Misc.getLineColumnOf(ctx);
-                throw new SyntaxError(
-                        lineColumn[0],
-                        lineColumn[1],
+                throw new SemanticError(
+                        Misc.getLineColumnOf(ctx),
                         "illegal keywords LANGUAGE PLCSQL for a local procedure/function");
             }
             String name = Misc.getNormalizedText(ctx.routine_uniq_name().name);
@@ -2731,7 +2707,6 @@ public class ParseTreeConverter extends PlcParserBaseVisitor<AstNode> {
 
     private int exHandlerDepth;
 
-    private boolean autonomousTransaction = false;
     private boolean connectionRequired = false;
 
     private boolean controlFlowBlocked;

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/PlcsqlCompilerMain.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/PlcsqlCompilerMain.java
@@ -32,6 +32,7 @@ package com.cubrid.plcsql.compiler;
 
 import com.cubrid.jsp.Server;
 import com.cubrid.jsp.data.CompileInfo;
+import com.cubrid.plcsql.compiler.antlrgen.PlcLexer;
 import com.cubrid.plcsql.compiler.antlrgen.PlcParser;
 import com.cubrid.plcsql.compiler.ast.Unit;
 import com.cubrid.plcsql.compiler.ast.loopOpt.SqlUse;
@@ -43,14 +44,30 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.PrintStream;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import org.antlr.v4.runtime.*;
 import org.antlr.v4.runtime.tree.*;
 
 public class PlcsqlCompilerMain {
 
-    // temporary code - the owner and revision strings will come from the server
-    private static int revision = 1;
+    public static class CodeAndPosition {
+
+        public String code;
+        public int row;
+        public int col;
+
+        CodeAndPosition(String code, int row, int col) {
+            this.code = code;
+            this.row = row;
+            this.col = col;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("(%d, %d) '%s'", row, col, code);
+        }
+    }
 
     public static CompileInfo compilePLCSQL(String in, String owner, boolean verbose) {
         return compilePLCSQL(in, verbose, owner, Integer.toString(revision++));
@@ -80,9 +97,36 @@ public class PlcsqlCompilerMain {
         }
     }
 
+    public static List<CodeAndPosition> checkSyntaxAndGetStaticSqls(String code) {
+
+        CharStream input = CharStreams.fromString(code);
+        PlcLexer lexer = new PlcLexerEx(input);
+
+        SyntaxErrorIndicator lei = new SyntaxErrorIndicator(false);
+        lexer.removeErrorListeners(); // This removes unwanted console output
+        lexer.addErrorListener(lei);
+
+        CommonTokenStream tokens = new CommonTokenStream(lexer);
+        PlcParser parser = new PlcParser(tokens);
+
+        SyntaxErrorIndicator sei = new SyntaxErrorIndicator(false);
+        parser.removeErrorListeners(); // This removes unwanted console output
+        parser.addErrorListener(sei);
+
+        ParseTree ptree = parser.sql_script();
+
+        StaticSqlCollector ssCollector = new StaticSqlCollector();
+        ParseTreeWalker.DEFAULT.walk(ssCollector, ptree);
+
+        return ssCollector.staticSqls;
+    }
+
     // ------------------------------------------------------------------
     // Private
     // ------------------------------------------------------------------
+
+    // temporary code - the owner and revision strings will come from the server
+    private static int revision = 1;
 
     private static final int OPT_VERBOSE = 1;
     private static final int OPT_PRINT_PARSE_TREE = 1 << 1;
@@ -272,11 +316,11 @@ public class PlcsqlCompilerMain {
 
     private static class SyntaxErrorIndicator extends BaseErrorListener {
 
-        final boolean forParser;
+        final boolean cutVariablePart;
 
-        public SyntaxErrorIndicator(boolean forParser) {
+        public SyntaxErrorIndicator(boolean cutVariablePart) {
             super();
-            this.forParser = forParser;
+            this.cutVariablePart = cutVariablePart;
         }
 
         @Override
@@ -289,7 +333,7 @@ public class PlcsqlCompilerMain {
                 RecognitionException e) {
 
             // throw SyntaxError at the first syntax error
-            String errMsg = forParser ? cutExpectingClause(msg) : msg;
+            String errMsg = cutVariablePart ? cutExpectingClause(msg) : msg;
             throw new SyntaxError(line, charPositionInLine + 1, errMsg);
         }
     }

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/StaticSqlCollector.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/StaticSqlCollector.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+
+package com.cubrid.plcsql.compiler;
+
+import static com.cubrid.plcsql.compiler.antlrgen.PlcParser.Static_sqlContext;
+
+import com.cubrid.plcsql.compiler.antlrgen.PlcParserBaseListener;
+import java.util.ArrayList;
+import java.util.List;
+
+class StaticSqlCollector extends PlcParserBaseListener {
+
+    List<PlcsqlCompilerMain.CodeAndPosition> staticSqls = new ArrayList<>();
+
+    private void addToList(String code, int row, int col) {
+        staticSqls.add(new PlcsqlCompilerMain.CodeAndPosition(code, row, col));
+    }
+
+    @Override
+    public void enterStatic_sql(Static_sqlContext ctx) {
+        int[] pos = Misc.getLineColumnOf(ctx);
+        addToList(ctx.getText(), pos[0], pos[1]);
+    }
+}

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/Unit.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/ast/Unit.java
@@ -41,14 +41,12 @@ public class Unit extends AstNode {
         return visitor.visitUnit(this);
     }
 
-    public final boolean autonomousTransaction;
     public final boolean connectionRequired;
     public final DeclRoutine routine;
     public final String revision;
 
     public Unit(
             ParserRuleContext ctx,
-            boolean autonomousTransaction,
             boolean connectionRequired,
             DeclRoutine routine,
             String revision) {
@@ -56,7 +54,6 @@ public class Unit extends AstNode {
 
         assert routine.scope.level == 1;
 
-        this.autonomousTransaction = autonomousTransaction;
         this.connectionRequired = connectionRequired;
         this.routine = routine;
         this.revision = revision;

--- a/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/plcsql/compiler/visitor/JavaCodeWriter.java
@@ -105,8 +105,8 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
     // -----------------------------------------------------------------
     // Unit
     //
-    private static final String tmplGetConn =
-            "final Connection conn = DriverManager.getConnection(\"jdbc:default:connection::?autonomous_transaction=%s\");";
+    private static final String strGetConn =
+            "final Connection conn = DriverManager.getConnection(\"jdbc:default:connection::\");";
 
     private static final String[] tmplMainUserCode =
             new String[] {
@@ -170,12 +170,6 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
         if (node.connectionRequired) {
             javaTypesUsed.add("java.sql.*");
         }
-
-        // get connection, if necessary
-        String strGetConn =
-                node.connectionRequired
-                        ? String.format(tmplGetConn, node.autonomousTransaction)
-                        : "";
 
         // declarations
         Object codeDeclClass =
@@ -292,7 +286,7 @@ public class JavaCodeWriter extends AstVisitor<JavaCodeWriter.CodeToResolve> {
                 "%'+PARAMETERS'%",
                 objParamArr,
                 "%'GET-CONNECTION'%",
-                strGetConn,
+                node.connectionRequired ? strGetConn : "",
                 "%'+RECORD-DEFS'%",
                 recordDefs,
                 "%'+RECORD-ASSIGN-FUNCS'%",


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26866>

### Purpose

PL 서버에 포함된 com.cubrid.plcsql.compiler.PlcsqlCompilerMain 클래스에 문법 체크 만을 위한 루틴을 추가합니다. 
develop 브랜치에서 했던 작업을 release/11.4 브랜치로 cherry-pick 합니다. 

### Remarks

간단한 사용 예제게 해당 Jira 이슈에 있습니다. 
