### PR TITLE
[CBRD-27174] clear DB_VALUEs in an incomplete row generated by an error in query cursor's next_row() method

### DIFF
--- a/src/sp/pl_query_cursor.cpp
+++ b/src/sp/pl_query_cursor.cpp
@@ -163,7 +163,8 @@ namespace cubpl
 	  }
 
 	QFILE_LIST_ID *list_id = m_query_entry->list_id;
-	for (int i = 0; i < list_id->type_list.type_cnt; i++)
+	int i;
+	for (i = 0; i < list_id->type_list.type_cnt; i++)
 	  {
 	    DB_VALUE *value = &m_current_tuple[i];
 	    QFILE_TUPLE_VALUE_FLAG flag = (QFILE_TUPLE_VALUE_FLAG) qfile_locate_tuple_value (tuple_record.tpl, i, &ptr, &length);
@@ -194,6 +195,16 @@ namespace cubpl
 	    else
 	      {
 		db_make_null (value);
+	      }
+	  }
+	if (i < list_id->type_list.type_cnt)
+	  {
+	    // incomplete tuple due to an error
+	    // clear values in the tuple.
+	    assert (scan_code == S_ERROR);
+	    for (int j = 0; j < i; j++)
+	      {
+		pr_clear_value (&m_current_tuple[j]);
 	      }
 	  }
       }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27174>

### Purpose

SP 안의 SELECT 문 처리 중 한 row 를 만들다가 중간에 실패했을 때 
row앞 쪽에 이미 만들어진 DB_VALUE 들을 clear 해 주는 로직을 추가했습니다. 
드물게 발생하는 core 의 원인으로 추정됩니다. 
