### PR TITLE
[CBRD-27169] [Backport-11.3.6] Transitive propagation missed for ON clause terms

### DIFF
--- a/src/optimizer/query_rewrite.c
+++ b/src/optimizer/query_rewrite.c
@@ -120,6 +120,7 @@ static PT_NODE *qo_reset_location (PARSER_CONTEXT * parser, PT_NODE * node, void
 
 static void qo_move_on_clause_of_explicit_join_to_where_clause (PARSER_CONTEXT * parser, PT_NODE ** fromp,
 								PT_NODE ** wherep);
+static PT_NODE *qo_rewrite_innerjoin (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);
 static PT_NODE *qo_optimize_queries (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *continue_walk);
 static void qo_do_auto_parameterize_limit_clause (PARSER_CONTEXT * parser, PT_NODE * node);
 static void qo_do_auto_parameterize_keylimit_clause (PARSER_CONTEXT * parser, PT_NODE * node);
@@ -1862,6 +1863,16 @@ qo_reduce_equality_terms_post (PARSER_CONTEXT * parser, PT_NODE * node, void *ar
 
   if (node->node_type == PT_SELECT)
     {
+      if (!node->flag.done_reduce_equality_terms && node->info.query.q.select.connect_by == NULL)
+	{
+	  int continue_innerjoin;
+
+	  qo_move_on_clause_of_explicit_join_to_where_clause (parser, &node->info.query.q.select.from,
+							      &node->info.query.q.select.where);
+	  node->info.query.q.select.where = pt_cnf (parser, node->info.query.q.select.where);
+	  qo_rewrite_innerjoin (parser, node, NULL, &continue_innerjoin);
+	}
+
       wherep = &node->info.query.q.select.where;
       QO_CHECK_AND_REDUCE_EQUALITY_TERMS (parser, node, wherep);
     }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27169>

### Purpose

develop PR CUBRID/cubrid#7616 의 백포트입니다.

ANSI JOIN의 ON 절에 작성한 상수 조건이 조인 조건으로 이행되지 않습니다.

    -- t2.b = 'X' 와 t2.b = t3.b 로부터 t3.b = 'X' 를 유도할 수 있으나 생성되지 않음
    SELECT ... FROM t1
      INNER JOIN t2 ON t1.a = t2.a AND t2.b = 'X'
      INNER JOIN t3 ON t2.b = t3.b;
    -- rewritten : where t1.a=t2.a and t2.b=t3.b and t2.b= ?:0

같은 상수를 t3의 ON 절로 옮기면 이행됩니다. 반대로 이행되던 쿼리를 인라인뷰로
감싸고 바깥에 조건절을 두면 다시 이행되지 않습니다. 어느 쪽이든 결과는 같고
재작성된 쿼리만 달라집니다.

원인이 다른 두 가지 경우가 있습니다.

1. 상수 조건과 조인 조건을 서로 다른 ON 절에 작성한 경우.
2. 인라인뷰 내부 ON 절에 작성하고, 바깥 쿼리에 조건절이 있는 경우.
   `WHERE 1=1`, 조건절, 바깥 `JOIN ... ON`, 단독 `LIMIT` 모두 해당됩니다.

### Implementation

`qo_reduce_equality_terms ()` 는 WHERE 목록을 대상으로 동작하며, ON 절에 쓴 상수
조건은 위치 정보가 같은 조건에만 치환합니다. 두 조건 모두 `qo_optimize_queries ()`
가 갖춰 주지만 이행보다 먼저라는 보장이 없고, 이행은 쿼리마다 한 번만 실행되므로
준비가 덜 된 상태에서 실행되면 이후 다시 시도되지 않습니다.

* 위치 정보 초기화(`qo_rewrite_innerjoin ()`)가 이행보다 나중에 실행됩니다. (1번 원인)
* ON 절 조건의 WHERE 병합은 각 쿼리의 재작성 시작 시점에 수행되는데, 이행 검사는
  서브트리 전체를 한꺼번에 하므로 하위 SELECT 를 그 전에 방문합니다. (2번 원인)

두 선행 처리를 `qo_reduce_equality_terms_post ()` 에서 이행 직전에 수행하도록
했습니다.

### Remarks

N/A