### PR TITLE
[CBRD-27228] Fix/cbrd 27228 repl class interrupt assert

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -11090,7 +11090,13 @@ heap_is_replication_class (THREAD_ENTRY * thread_p, const OID * class_oid)
   if (heap_get_class_record (thread_p, class_oid, &recdes, &scan_cache, PEEK) != S_SUCCESS)
     {
       heap_scancache_end (thread_p, &scan_cache);
-      assert (false);
+      /* The class record fetch can legitimately fail when this transaction is being
+       * interrupted (e.g. a killed server-side loaddb session): pgbuf_fix rejects any
+       * further page fix with ER_INTERRUPTED before touching the page. That is a normal
+       * shutdown path, not a corruption, so it must not abort the server. The transaction
+       * is rolled back anyway, so returning false (skip the replication log) cannot break
+       * replication consistency. Any other fetch failure is still unexpected. */
+      assert (er_errid () == ER_INTERRUPTED);
       return false;
     }
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -11071,18 +11071,29 @@ heap_get_class_tde_algorithm (THREAD_ENTRY * thread_p, const OID * class_oid, TD
   return error;
 }
 
-bool
-heap_is_replication_class (THREAD_ENTRY * thread_p, const OID * class_oid)
+/*
+ * heap_get_class_replication () - Check whether a class has replication turned on.
+ *   return: error code
+ *   thread_p (in):
+ *   class_oid (in):
+ *   is_replication (out): true if the class has replication on, false otherwise
+ *
+ * Note: the class-record fetch may fail with a real error (e.g. ER_INTERRUPTED);
+ *       return it to the caller rather than asserting.
+ */
+int
+heap_get_class_replication (THREAD_ENTRY * thread_p, const OID * class_oid, bool * is_replication)
 {
   HEAP_SCANCACHE scan_cache;
   RECDES recdes;
-  bool ret;
 
   assert (class_oid != NULL);
 
+  *is_replication = false;
+
   if (OID_ISNULL (class_oid))
     {
-      return false;
+      return NO_ERROR;
     }
 
   (void) heap_scancache_quick_start_root_hfid (thread_p, &scan_cache);
@@ -11090,21 +11101,15 @@ heap_is_replication_class (THREAD_ENTRY * thread_p, const OID * class_oid)
   if (heap_get_class_record (thread_p, class_oid, &recdes, &scan_cache, PEEK) != S_SUCCESS)
     {
       heap_scancache_end (thread_p, &scan_cache);
-      /* The class record fetch can legitimately fail when this transaction is being
-       * interrupted (e.g. a killed server-side loaddb session): pgbuf_fix rejects any
-       * further page fix with ER_INTERRUPTED before touching the page. That is a normal
-       * shutdown path, not a corruption, so it must not abort the server. The transaction
-       * is rolled back anyway, so returning false (skip the replication log) cannot break
-       * replication consistency. Any other fetch failure is still unexpected. */
-      assert (er_errid () == ER_INTERRUPTED);
-      return false;
+      assert (er_errid () != NO_ERROR);
+      return (er_errid () != NO_ERROR) ? er_errid () : ER_FAILED;
     }
 
-  ret = or_class_is_replication_on (&recdes);
+  *is_replication = or_class_is_replication_on (&recdes);
 
   heap_scancache_end (thread_p, &scan_cache);
 
-  return ret;
+  return NO_ERROR;
 }
 
 /*

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -11072,24 +11072,26 @@ heap_get_class_tde_algorithm (THREAD_ENTRY * thread_p, const OID * class_oid, TD
 }
 
 /*
- * heap_get_class_replication () - Check whether a class has replication turned on.
+ * heap_get_class_repl_on () - Check whether a class has replication turned on.
  *   return: error code
  *   thread_p (in):
  *   class_oid (in):
- *   is_replication (out): true if the class has replication on, false otherwise
+ *   repl_on (out): true if the class has replication on, false otherwise
  *
  * Note: the class-record fetch may fail with a real error (e.g. ER_INTERRUPTED);
  *       return it to the caller rather than asserting.
  */
 int
-heap_get_class_replication (THREAD_ENTRY * thread_p, const OID * class_oid, bool * is_replication)
+heap_get_class_repl_on (THREAD_ENTRY * thread_p, const OID * class_oid, bool * repl_on)
 {
   HEAP_SCANCACHE scan_cache;
   RECDES recdes;
+  int error_code = NO_ERROR;
 
   assert (class_oid != NULL);
+  assert (repl_on != NULL);
 
-  *is_replication = false;
+  *repl_on = false;
 
   if (OID_ISNULL (class_oid))
     {
@@ -11100,12 +11102,12 @@ heap_get_class_replication (THREAD_ENTRY * thread_p, const OID * class_oid, bool
 
   if (heap_get_class_record (thread_p, class_oid, &recdes, &scan_cache, PEEK) != S_SUCCESS)
     {
+      ASSERT_ERROR_AND_SET (error_code);
       heap_scancache_end (thread_p, &scan_cache);
-      assert (er_errid () != NO_ERROR);
-      return (er_errid () != NO_ERROR) ? er_errid () : ER_FAILED;
+      return error_code;
     }
 
-  *is_replication = or_class_is_replication_on (&recdes);
+  *repl_on = or_class_is_replication_on (&recdes);
 
   heap_scancache_end (thread_p, &scan_cache);
 

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -466,7 +466,7 @@ extern SCAN_CODE heap_scanrange_last (THREAD_ENTRY * thread_p, OID * last_oid, R
 
 extern bool heap_does_exist (THREAD_ENTRY * thread_p, OID * class_oid, const OID * oid);
 extern bool heap_is_object_not_null (THREAD_ENTRY * thread_p, OID * class_oid, const OID * oid);
-extern bool heap_is_replication_class (THREAD_ENTRY * thread_p, const OID * class_oid);
+extern int heap_get_class_replication (THREAD_ENTRY * thread_p, const OID * class_oid, bool * is_replication);
 extern int heap_get_num_objects (THREAD_ENTRY * thread_p, const HFID * hfid, int *npages, int *nobjs, int *avg_length);
 
 extern int heap_estimate (THREAD_ENTRY * thread_p, const HFID * hfid, int *npages, int *nobjs, int *avg_length);

--- a/src/storage/heap_file.h
+++ b/src/storage/heap_file.h
@@ -466,7 +466,7 @@ extern SCAN_CODE heap_scanrange_last (THREAD_ENTRY * thread_p, OID * last_oid, R
 
 extern bool heap_does_exist (THREAD_ENTRY * thread_p, OID * class_oid, const OID * oid);
 extern bool heap_is_object_not_null (THREAD_ENTRY * thread_p, OID * class_oid, const OID * oid);
-extern int heap_get_class_replication (THREAD_ENTRY * thread_p, const OID * class_oid, bool * is_replication);
+extern int heap_get_class_repl_on (THREAD_ENTRY * thread_p, const OID * class_oid, bool * repl_on);
 extern int heap_get_num_objects (THREAD_ENTRY * thread_p, const HFID * hfid, int *npages, int *nobjs, int *avg_length);
 
 extern int heap_estimate (THREAD_ENTRY * thread_p, const HFID * hfid, int *npages, int *nobjs, int *avg_length);

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -8042,10 +8042,10 @@ locator_add_or_remove_index_internal (THREAD_ENTRY * thread_p, RECDES * recdes, 
 	  && or_is_replication_candidate_key (index)
 	  && !LOG_CHECK_LOG_APPLIER (thread_p) && log_does_allow_replication () == true)
 	{
-	  bool is_replication = false;
+	  bool repl_on = false;
 
-	  error_code = heap_get_class_replication (thread_p, class_oid, &is_replication);
-	  if (error_code == NO_ERROR && is_replication)
+	  error_code = heap_get_class_repl_on (thread_p, class_oid, &repl_on);
+	  if (error_code == NO_ERROR && repl_on)
 	    {
 	      error_code =
 		repl_log_insert (thread_p, class_oid, inst_oid,

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -8038,15 +8038,22 @@ locator_add_or_remove_index_internal (THREAD_ENTRY * thread_p, RECDES * recdes, 
        */
       /*TODO: We need to review a method to record replication logs only when the replication key (RK) has already been determined, instead of checking all RK candidates and handling the replicated flag. 
          Also, a comprehensive refactoring of replication-related operations and variables, including need_replication, is required(EPIC CBRD-26096). */
-      if (need_replication && heap_is_replication_class (thread_p, class_oid) && !replicated
-	  && or_is_replication_candidate_key (index) && error_code == NO_ERROR
+      if (error_code == NO_ERROR && need_replication && !replicated
+	  && or_is_replication_candidate_key (index)
 	  && !LOG_CHECK_LOG_APPLIER (thread_p) && log_does_allow_replication () == true)
 	{
-	  error_code =
-	    repl_log_insert (thread_p, class_oid, inst_oid, datayn ? LOG_REPLICATION_DATA : LOG_REPLICATION_STATEMENT,
-			     is_insert ? RVREPL_DATA_INSERT : RVREPL_DATA_DELETE, key_dbvalue,
-			     REPL_INFO_TYPE_RBR_NORMAL);
-	  replicated = true;
+	  bool is_replication = false;
+
+	  error_code = heap_get_class_replication (thread_p, class_oid, &is_replication);
+	  if (error_code == NO_ERROR && is_replication)
+	    {
+	      error_code =
+		repl_log_insert (thread_p, class_oid, inst_oid,
+				 datayn ? LOG_REPLICATION_DATA : LOG_REPLICATION_STATEMENT,
+				 is_insert ? RVREPL_DATA_INSERT : RVREPL_DATA_DELETE, key_dbvalue,
+				 REPL_INFO_TYPE_RBR_NORMAL);
+	      replicated = true;
+	    }
 	}
       if (error_code != NO_ERROR)
 	{


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27228 >

### Purpose

shell debug 테스트 중 발생하는 코어[1]를 해결합니다. 

코어를 발생시킨 테스트는 실행 도중 인터럽트를 발생시킵니다. pgbuf_fix()는 페이지를 잡기 전에 먼저 인터럽트를 검사해서, 트랜잭션에 인터럽트가 걸려 있으면 ER_INTERRUPTED를 설정하고 NULL을 반환합니다. 이 실패는 heap_get_class_record() != S_SUCCESS로 로직을 타게되는데, 여기까지는 정상적은 에러 처리 로직입니다

문제는 그 결과를 받는 heap_is_replication_class()[2]입니다. 
이 과정에서 실패를 assert(false)로 발생해서는 안되는 코드로 보고있으며, debug 빌드에서 서버를 abort시킵니다.

이전 수정에서는 이 assert를 ER_INTERRUPTED인 경우만 통과시키도록 완화해서 abort를 막았는데, 본질적인 문제를 해결하진 못했습니다. heap_is_replication_class()는 bool을 반환하는 구조라서, 인터럽트로 인한 실패를 호출자에게 알리지 못하고 false로 처리됩니다. 
또한, pgbuf_fix()의 인터럽트 검사는 logtb_is_interrupted(clear=true)로 확인하는 즉시 초기화하므로, 이 함수가 인터럽트를 한 번 발생되면 이후에는 다시 검사되지 않습니다. 결국 취소 신호가 사라져서 트랜잭션이 끝까지 완주·커밋됩니다. 
즉 서버 abort는 막았지만 KILL QUERY/killtran이 무시되는 문제가 그대로 남습니다.

### Implementation

이 문제를 해결하기 위해, 인터럽트를 확인하는 즉시 꺼버리는 대신 호출자에게 반환하도록 바꿨습니다. 
함수를 heap_get_class_replication()으로 변경해서 반환 타입을 bool → int(에러코드)로 바꾸고, 
복제 대상 여부는 out-param(is_replication)으로 넘깁니다. 
fetch가 실패하면 실제 에러코드를 그대로 반환합니다. 호출부 locator_add_or_remove_index_internal()에서는 
이 검사를 && 로 비교하던 if문 연산자에서 분리해 에러를 받고, error_code != NO_ERROR이면 goto error로 넘깁니다. 

### Remarks

[1]두 테스트 중 shell/_25_unstable/_35_cherry/issue_21654_server_side_loaddb/signals/cases/signals.sh는 c8a5113에서도 NOK가 발생하며, 이 PR에서는 OK목적이 아닌 코어를 해결하기위한 목적입니다. 

[2] heap_is_replication_class() 함수는 HA 환경에서 복제 키 제약(Replication Key) 작업과정에서 추가된 함수로, DML(Insert, Update, Delete) 연산 과정에서 클래스가 복제 대상인지를 확인하고, 복제 로그를 남기기위한 함수입니다. 
RK 제약사항 스팩: http://jira.cubrid.org/browse/CBRD-26201 에 있지만 


