### PR TITLE
[CBRD-27034] Serialize DELETE write-write conflicts on the MVCC stamp under a transient row lock

### DIFF
--- a/cubrid/CMakeLists.txt
+++ b/cubrid/CMakeLists.txt
@@ -507,6 +507,7 @@ set(STORAGE_SOURCES
   ${STORAGE_DIR}/bestspace.cpp
   ${STORAGE_DIR}/btree.c
   ${STORAGE_DIR}/btree_load.c
+  ${STORAGE_DIR}/btree_object_lock.cpp
   ${STORAGE_DIR}/btree_unique.cpp
   ${STORAGE_DIR}/byte_order.c
   ${STORAGE_DIR}/catalog_class.c

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -511,6 +511,7 @@ set(STORAGE_SOURCES
   ${STORAGE_DIR}/bestspace.cpp
   ${STORAGE_DIR}/btree.c
   ${STORAGE_DIR}/btree_load.c
+  ${STORAGE_DIR}/btree_object_lock.cpp
   ${STORAGE_DIR}/btree_unique.cpp
   ${STORAGE_DIR}/byte_order.c
   ${STORAGE_DIR}/catalog_class.c

--- a/src/parser/xasl_generation.c
+++ b/src/parser/xasl_generation.c
@@ -624,6 +624,7 @@ static bool pt_is_sort_list_covered (PARSER_CONTEXT * parser, SORT_LIST * coveri
 static int pt_set_limit_optimization_flags (PARSER_CONTEXT * parser, QO_PLAN * plan, XASL_NODE * xasl);
 static int pt_set_like_recompile_candidate (PARSER_CONTEXT * parser, QO_PLAN * qo_plan, XASL_NODE * xasl);
 static DB_VALUE **pt_make_reserved_value_list (PARSER_CONTEXT * parser, PT_RESERVED_NAME_TYPE type);
+static bool pt_cond_spans_multiple_specs (PARSER_CONTEXT * parser, PT_NODE * spec_list, PT_NODE * cond);
 static int pt_mvcc_flag_specs_cond_reev (PARSER_CONTEXT * parser, PT_NODE * spec_list, PT_NODE * cond);
 static int pt_mvcc_flag_specs_assign_reev (PARSER_CONTEXT * parser, PT_NODE * spec_list, PT_NODE * assign_list);
 static int pt_mvcc_set_spec_assign_reev_extra_indexes (PARSER_CONTEXT * parser, PT_NODE * spec_assign,
@@ -21074,6 +21075,81 @@ exit_on_error:
 }
 
 /*
+ * pt_reev_reads_no_spec () - is there no spec for force-time reevaluation to re-read?
+ *   return: true when the flagging pass flagged none of the statement's own specs
+ *   spec_list(in): the statement's spec list
+ */
+static bool
+pt_reev_reads_no_spec (PT_NODE * spec_list)
+{
+  PT_NODE *spec;
+
+  for (spec = spec_list; spec != NULL; spec = spec->next)
+    {
+      if (spec->info.spec.flag & (PT_SPEC_FLAG_MVCC_COND_REEV | PT_SPEC_FLAG_MVCC_ASSIGN_REEV))
+	{
+	  return false;
+	}
+    }
+
+  return true;
+}
+
+/*
+ * pt_cond_spans_multiple_specs () - does any single conjunct reference more than one spec?
+ *   return: true if some term relates two or more specs
+ *   parser(in): parser context
+ *   spec_list(in): the statement's spec list
+ *   cond(in): a list of AND-ed conditions, or NULL
+ *
+ *  Note: Force-time reevaluation visits one spec at a time and matches it against that spec's own
+ *	  range/key/data filters.  A term confined to a single spec survives that; a term relating
+ *	  two specs does not, because no per-scan filter can carry the other spec's row.  Counting
+ *	  the specs a statement mentions is a coarser test than this and pulls in statements whose
+ *	  terms are all independent.
+ */
+static bool
+pt_cond_spans_multiple_specs (PARSER_CONTEXT * parser, PT_NODE * spec_list, PT_NODE * cond)
+{
+  PT_NODE *term, *spec, *node, *real_refs, *saved_next;
+  int nspecs;
+  bool spans = false;
+
+  if (spec_list == NULL || cond == NULL)
+    {
+      return false;
+    }
+
+  for (term = cond; term != NULL && !spans; term = term->next)
+    {
+      saved_next = term->next;
+      term->next = NULL;
+
+      nspecs = 0;
+      for (spec = spec_list; spec != NULL; spec = spec->next)
+	{
+	  real_refs = spec->info.spec.referenced_attrs;
+	  spec->info.spec.referenced_attrs = NULL;
+	  node = mq_get_references (parser, term, spec);
+	  spec->info.spec.referenced_attrs = real_refs;
+	  if (node != NULL)
+	    {
+	      parser_free_tree (parser, node);
+	      nspecs++;
+	    }
+	}
+
+      term->next = saved_next;
+      if (nspecs > 1)
+	{
+	  spans = true;
+	}
+    }
+
+  return spans;
+}
+
+/*
  * pt_mvcc_flag_specs_cond_reev () - flag specs that are involved in condition
  *   return: NO_ERROR or error code.
  *   parser(in):
@@ -21730,6 +21806,108 @@ pt_to_upd_del_query (PARSER_CONTEXT * parser, PT_NODE * select_names, PT_NODE * 
 }
 
 /*
+ * pt_delete_must_abort_reevaluation () - can the delete phase re-check this statement's predicate?
+ *   return: true when it cannot, so reevaluation is abandoned for the statement
+ *   parser(in): context
+ *   statement(in): delete parse tree
+ *   aptr_statement(in/out): the SELECT generated for it; flagged for locking where one is needed
+ *   from(in): the DELETE's own spec list
+ *   where(in): the DELETE's search condition
+ *   has_partitioned(in): a class being deleted from is partitioned
+ *
+ * Note: reevaluation matches one spec at a time against that spec's own range/key/data filters.  Each
+ *	 test below is a shape those filters cannot decide, and an earlier test hides a later one -- the
+ *	 subquery test hides the derived-table test for every derived table that holds a spec.
+ */
+static bool
+pt_delete_must_abort_reevaluation (PARSER_CONTEXT * parser, PT_NODE * statement, PT_NODE * aptr_statement,
+				   PT_NODE * from, PT_NODE * where, bool has_partitioned)
+{
+  PT_NODE *cl_name_node = NULL;
+
+  /* the rows are already locked at select, so this one abandons reevaluation without asking for a lock */
+  if (aptr_statement->info.query.q.select.group_by != NULL)
+    {
+      return true;
+    }
+
+  /* the flagging pass skips a partitioned class entirely, and a predicate under a subquery cannot be
+   * replayed as a scan filter.  Any spec below a subquery counts, which is why an inline view held back
+   * by the NO_MERGE hint stops here rather than at the derived-table test.
+   *   DELETE FROM part_t WHERE pk = 1;
+   *   DELETE FROM t WHERE pk IN (SELECT k FROM side_t WHERE k = 1); */
+  if (has_partitioned || pt_has_reev_in_subquery (parser, aptr_statement))
+    {
+      PT_SELECT_INFO_SET_FLAG (aptr_statement, PT_SELECT_INFO_MVCC_LOCK_NEEDED);
+      return true;
+    }
+
+  /* the candidate list holds exactly n rows and a rejected one is never replaced, so the statement would
+   * delete fewer while rows that still qualify are left behind.
+   *   DELETE FROM t WHERE pk > 0 LIMIT 1; */
+  if (statement->info.delete_.limit != NULL)
+    {
+      PT_SELECT_INFO_SET_FLAG (aptr_statement, PT_SELECT_INFO_MVCC_LOCK_NEEDED);
+      return true;
+    }
+
+  /* a spec reading a derived table has no heap of its own to re-read.  The flag is not what says so: the
+   * rewrite that puts a derived table there takes the heap and the flag together, so the spec that most
+   * needs this test is the one that no longer carries it.  An OID equality turns the target's own scan
+   * into a scan over a set -- FROM t becomes FROM table({:obj}) -- and leaves the DELETE's spec flagged
+   * while the SELECT's is not.  Only a derived table that contains no spec of its own gets this far --
+   * one that does is a spec below a subquery, and the test above already took it.
+   *   DELETE FROM t WHERE t = :obj;
+   *   DELETE a FROM t a, (SELECT 1 AS k) x WHERE a.pk = x.k; */
+  for (cl_name_node = aptr_statement->info.query.q.select.from; cl_name_node != NULL; cl_name_node = cl_name_node->next)
+    {
+      if (cl_name_node->info.spec.derived_table != NULL)
+	{
+	  PT_SELECT_INFO_SET_FLAG (aptr_statement, PT_SELECT_INFO_MVCC_LOCK_NEEDED);
+	  return true;
+	}
+    }
+
+  /* a spec over a class and its subclasses reports OIDs no single spec carries, so
+   * qexec_upddel_mvcc_set_filters () cannot resolve them back to an access spec.
+   *   DELETE FROM ALL h_base WHERE v = 1; */
+  for (cl_name_node = from; cl_name_node != NULL; cl_name_node = cl_name_node->next)
+    {
+      if (!(cl_name_node->info.spec.flag & PT_SPEC_FLAG_MVCC_COND_REEV))
+	{
+	  continue;
+	}
+      if (cl_name_node->info.spec.flat_entity_list != NULL && cl_name_node->info.spec.flat_entity_list->next != NULL)
+	{
+	  PT_SELECT_INFO_SET_FLAG (aptr_statement, PT_SELECT_INFO_MVCC_LOCK_NEEDED);
+	  return true;
+	}
+    }
+
+  /* no per-scan filter can carry the other spec's row.  What decides is whether a single term crosses,
+   * not how many specs the statement mentions.
+   *   DELETE a FROM t a, side_t b WHERE a.pk = b.k; */
+  if (pt_cond_spans_multiple_specs (parser, from, where))
+    {
+      PT_SELECT_INFO_SET_FLAG (aptr_statement, PT_SELECT_INFO_MVCC_LOCK_NEEDED);
+      return true;
+    }
+
+  /* a search condition that flagged no spec of its own cannot be replayed as a scan filter, so there is
+   * no row to re-check it against.  Locking at select for it is what leaves "no reevaluation class"
+   * meaning "this statement reads no row of its own" -- the reading qexec_execute_delete () relies on.
+   * The generated SELECT is asked too, since the flagging pass reads only the statement's own WHERE.
+   *   DELETE FROM t WHERE ROWNUM <= 3; */
+  if ((where != NULL || aptr_statement->info.query.q.select.where != NULL) && pt_reev_reads_no_spec (from))
+    {
+      PT_SELECT_INFO_SET_FLAG (aptr_statement, PT_SELECT_INFO_MVCC_LOCK_NEEDED);
+      return true;
+    }
+
+  return false;
+}
+
+/*
  * pt_to_delete_xasl () - Converts an delete parse tree to
  *                        an XASL graph for an delete
  *   return:
@@ -21898,31 +22076,8 @@ pt_to_delete_xasl (PARSER_CONTEXT * parser, PT_NODE * statement)
 	  goto error_return;
 	}
 
-      if (aptr_statement->info.query.q.select.group_by != NULL)
-	{
-	  /* remove reevaluation flags if we have GROUP BY because the locking will be made at SELECT stage */
-	  abort_reevaluation = true;
-	}
-      else
-	{
-	  /* if at least one table involved in reevaluation is a derived table then abort reevaluation and force
-	   * locking on select */
-	  for (cl_name_node = aptr_statement->info.query.q.select.from; cl_name_node != NULL;
-	       cl_name_node = cl_name_node->next)
-	    {
-	      if (cl_name_node->info.spec.derived_table != NULL
-		  && (cl_name_node->info.spec.flag | PT_SPEC_FLAG_MVCC_COND_REEV))
-		{
-		  PT_SELECT_INFO_SET_FLAG (aptr_statement, PT_SELECT_INFO_MVCC_LOCK_NEEDED);
-		  abort_reevaluation = true;
-		  break;
-		}
-	    }
-	}
-
-      /* These two lines disable reevaluation on UPDATE. To activate it just remove them */
-      PT_SELECT_INFO_SET_FLAG (aptr_statement, PT_SELECT_INFO_MVCC_LOCK_NEEDED);
-      abort_reevaluation = true;
+      abort_reevaluation =
+	pt_delete_must_abort_reevaluation (parser, statement, aptr_statement, from, where, has_partitioned);
 
       if (abort_reevaluation)
 	{
@@ -22192,9 +22347,23 @@ pt_to_delete_xasl (PARSER_CONTEXT * parser, PT_NODE * statement)
 	  if (PT_IS_SPEC_FLAG_SET (node, PT_SPEC_FLAG_MVCC_COND_REEV))
 	    {
 	      /* set the position in SELECT list */
+	      assert (j < delete_->num_reev_classes);
+	      if (j >= delete_->num_reev_classes)
+		{
+		  break;
+		}
 	      delete_->mvcc_reev_classes[j++] = i;
 	    }
 	}
+
+      /* The count above was taken over the DELETE statement's spec list, but only a class that owns an
+       * OID - CLASS OID pair in the generated SELECT can be reevaluated at all. A class the SELECT dropped
+       * (an outer-joined table none of whose columns the outer query reads) leaves an entry unfilled, so the
+       * executor must be told how many entries this loop actually wrote.  Dropping every one of them would
+       * tell it this statement reads no row of its own; the target class always owns a pair, so no shape
+       * has been found that does. */
+      assert (j > 0 || delete_->num_reev_classes == 0);
+      delete_->num_reev_classes = j;
 
       /* OID of the user who is creating this XASL */
       if ((oid = ws_identifier (db_get_user ())) != NULL)
@@ -22307,12 +22476,24 @@ pt_has_reev_in_subquery_pre (PARSER_CONTEXT * parser, PT_NODE * tree, void *arg,
     {
       level++;
     }
-  else if (tree->node_type == PT_SPEC
-	   && (tree->info.spec.flag | PT_SPEC_FLAG_MVCC_COND_REEV | PT_SPEC_FLAG_MVCC_ASSIGN_REEV) && level > 1)
+  else if (tree->node_type == PT_SPEC && level > 1)
     {
+      /* Any spec below a subquery, flagged or not.  Reevaluation flags are only ever set on the
+       * statement's own spec list (pt_mvcc_flag_specs_cond_reev walks `from`), so a spec down here
+       * can never carry one -- testing for the flag would make this unreachable.
+       *
+       * Do not try to spare the uncorrelated ones.  It looks safe -- a subquery that does not read
+       * the current row is evaluated once and its result stands for the statement -- and it does
+       * open the constant-scalar-assignment case.  But x18, x22 and r5, all WHERE k IN (SELECT ...),
+       * fail with it: the materialized list lives in the select's scan state and the force phase
+       * cannot re-check the predicate against it.  Correlation is not the property that decides. */
       level = -1;
       *continue_walk = PT_STOP_WALK;
     }
+
+  /* the walk carries the level through arg; without this the local copy is discarded on
+   * every node, level never leaves 0, and the level > 1 test above can never be reached */
+  *(int *) arg = level;
 
   return tree;
 }
@@ -22341,6 +22522,8 @@ pt_has_reev_in_subquery_post (PARSER_CONTEXT * parser, PT_NODE * tree, void *arg
     {
       level--;
     }
+
+  *(int *) arg = level;
 
   return tree;
 }

--- a/src/query/dblink_global_tran_catalog.c
+++ b/src/query/dblink_global_tran_catalog.c
@@ -179,7 +179,7 @@ dblink_global_tran_insert_row (THREAD_ENTRY * thread_p, int gtrid, int bqual,
   error = locator_attribute_info_force (thread_p, hfid_p, &oid, &attr_info, NULL, 0,
 					LC_FLUSH_INSERT, SINGLE_ROW_INSERT, &scan, &force_count,
 					true, REPL_INFO_TYPE_RBR_NORMAL, DB_NOT_PARTITIONED_CLASS,
-					NULL, NULL, NULL, UPDATE_INPLACE_NONE, NULL, false);
+					NULL, NULL, NULL, UPDATE_INPLACE_NONE, NULL, LOCATOR_LOCK_AT_SELECT);
 
 cleanup:
   if (attr_inited)
@@ -311,7 +311,7 @@ dblink_global_tran_update_state (THREAD_ENTRY * thread_p, int gtrid, int bqual, 
   error = locator_attribute_info_force (thread_p, hfid_p, &oid, &attr_info, NULL, 0,
 					LC_FLUSH_UPDATE, SINGLE_ROW_UPDATE, &scan, &force_count,
 					true, REPL_INFO_TYPE_RBR_NORMAL, DB_NOT_PARTITIONED_CLASS,
-					NULL, NULL, NULL, UPDATE_INPLACE_NONE, NULL, false);
+					NULL, NULL, NULL, UPDATE_INPLACE_NONE, NULL, LOCATOR_LOCK_AT_SELECT);
 
 cleanup:
   if (attr_inited)
@@ -373,7 +373,9 @@ dblink_global_tran_delete_row (THREAD_ENTRY * thread_p, int gtrid, int bqual)
       goto cleanup;
     }
 
-  error = locator_delete_force (thread_p, hfid_p, &oid, true, SINGLE_ROW_DELETE, &scan, &force_count, NULL, false);
+  error =
+    locator_delete_force (thread_p, hfid_p, &oid, true, SINGLE_ROW_DELETE, &scan, &force_count, NULL,
+			  LOCATOR_LOCK_AT_SELECT);
 
 cleanup:
   if (attr_inited)

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -12381,11 +12381,13 @@ qexec_execute_duplicate_key_update (THREAD_ENTRY * thread_p, ODKU_INFO * odku, H
   int error = NO_ERROR;
   bool need_clear = 0;
   OID unique_oid;
+  OID unique_class_oid;
   int local_op_type = SINGLE_ROW_UPDATE;
   HEAP_SCANCACHE *local_scan_cache = NULL;
   int ispeeking;
 
   OID_SET_NULL (&unique_oid);
+  OID_SET_NULL (&unique_class_oid);
 
   local_scan_cache = scan_cache;
 
@@ -12407,12 +12409,29 @@ qexec_execute_duplicate_key_update (THREAD_ENTRY * thread_p, ODKU_INFO * odku, H
   /* get attribute values */
   ispeeking = ((local_scan_cache != NULL && local_scan_cache->cache_last_fix_page) ? PEEK : COPY);
 
-  scan_code =
-    heap_get_visible_version (thread_p, &unique_oid, NULL, &rec_descriptor, local_scan_cache, ispeeking, NULL_CHN);
+  /* A duplicate whose delete is in progress carries no row lock once the deleter has published, and the
+   * visible version hides that delete -- updating it would overwrite a record the deleter still has to
+   * undo. Fetch through the lock path instead: it waits the deleter out and re-reads. */
+  scan_code = heap_get_class_oid (thread_p, &unique_oid, &unique_class_oid);
   if (scan_code != S_SUCCESS)
     {
-      assert (er_errid () == ER_INTERRUPTED);
-      error = ER_FAILED;
+      ASSERT_ERROR_AND_SET (error);
+      goto exit_on_error;
+    }
+
+  scan_code =
+    locator_lock_and_get_object (thread_p, &unique_oid, &unique_class_oid, &rec_descriptor, local_scan_cache, X_LOCK,
+				 ispeeking, NULL_CHN, LOG_WARNING_IF_DELETED);
+  if (scan_code == S_DOESNT_EXIST)
+    {
+      /* the deleter committed: the key is free, so this row is no longer a duplicate and the caller inserts */
+      er_clear ();
+      *force_count = 0;
+      return NO_ERROR;
+    }
+  if (scan_code != S_SUCCESS)
+    {
+      ASSERT_ERROR_AND_SET (error);
       goto exit_on_error;
     }
 

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -697,7 +697,7 @@ static void qexec_clear_internal_classes (THREAD_ENTRY * thread_p, UPDDEL_CLASS_
 static int qexec_upddel_setup_current_class (THREAD_ENTRY * thread_p, UPDDEL_CLASS_INFO * class_,
 					     UPDDEL_CLASS_INFO_INTERNAL * class_info, int op_type, OID * current_oid);
 static int qexec_upddel_mvcc_set_filters (THREAD_ENTRY * thread_p, XASL_NODE * aptr_list,
-					  UPDDEL_MVCC_COND_REEVAL * mvcc_reev_class, OID * class_oid);
+					  UPDDEL_MVCC_COND_REEVAL * mvcc_reev_class, OID * class_oid, bool * has_spec);
 static int qexec_init_agg_hierarchy_helpers (THREAD_ENTRY * thread_p, ACCESS_SPEC_TYPE * spec,
 					     AGGREGATE_TYPE * aggregate_list, HIERARCHY_AGGREGATE_HELPER ** helpers,
 					     int *helpers_countp);
@@ -10216,8 +10216,11 @@ prepare_mvcc_reev_data (THREAD_ENTRY * thread_p, XASL_NODE * aptr, XASL_STATE * 
       return ER_FAILED;
     }
 
-  /* Make sure reev data is initialized, or else it will crash later */
-  memset (reev_data, 0, sizeof (MVCC_UPDDEL_REEV_DATA));
+  /* start from the struct's empty state, so a field this function does not fill cannot carry over */
+  *reev_data = MVCC_UPDDEL_REEV_DATA ();
+
+  /* the value descriptor is bound on every path, including the one that carries no reevaluation class */
+  reev_data->vd = &xasl_state->vd;
 
   if (num_reev_classes == 0)
     {
@@ -10242,6 +10245,7 @@ prepare_mvcc_reev_data (THREAD_ENTRY * thread_p, XASL_NODE * aptr, XASL_STATE * 
       cond_reev_class = &cond_reev_classes[idx];
       cond_reev_class->class_index = mvcc_reev_indexes[idx];
       OID_SET_NULL (&cond_reev_class->cls_oid);
+      HFID_SET_NULL (&cond_reev_class->cls_hfid);
       cond_reev_class->inst_oid = NULL;
       cond_reev_class->rest_attrs = NULL;
       cond_reev_class->rest_regu_list = NULL;
@@ -10282,7 +10286,6 @@ prepare_mvcc_reev_data (THREAD_ENTRY * thread_p, XASL_NODE * aptr, XASL_STATE * 
   reev_data->curr_attrinfo = NULL;
   reev_data->copyarea = NULL;
   reev_data->cons_pred = cons_pred;
-  reev_data->vd = &xasl_state->vd;
 
   if (qexec_create_mvcc_reev_assignments (thread_p, aptr, has_delete, internal_classes, num_classes, num_assigns,
 					  assigns, mvcc_reev_assigns) != NO_ERROR)
@@ -10615,9 +10618,19 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
 		  /* temporary disable set filters when needs prunning */
 		  if (mvcc_reev_class != NULL)
 		    {
-		      error = qexec_upddel_mvcc_set_filters (thread_p, aptr, mvcc_reev_class, class_oid);
+		      bool has_spec = false;
+
+		      error = qexec_upddel_mvcc_set_filters (thread_p, aptr, mvcc_reev_class, class_oid, &has_spec);
 		      if (error != NO_ERROR)
 			{
+			  GOTO_EXIT_ON_ERROR;
+			}
+		      if (!has_spec)
+			{
+			  /* No access spec for this class: the filters of mvcc_reev_class stay uninitialized, so the
+			   * update phase has nothing to re-evaluate with. Fail the statement, as before the delete
+			   * path started distinguishing this case. */
+			  error = ER_FAILED;
 			  GOTO_EXIT_ON_ERROR;
 			}
 		    }
@@ -10784,9 +10797,17 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
 	      /* class has changed to a new subclass */
 	      if (class_oid && !OID_EQ (&mvcc_reev_class->cls_oid, class_oid))
 		{
-		  error = qexec_upddel_mvcc_set_filters (thread_p, aptr, mvcc_reev_class, class_oid);
+		  bool has_spec = false;
+
+		  error = qexec_upddel_mvcc_set_filters (thread_p, aptr, mvcc_reev_class, class_oid, &has_spec);
 		  if (error != NO_ERROR)
 		    {
+		      GOTO_EXIT_ON_ERROR;
+		    }
+		  if (!has_spec)
+		    {
+		      /* see the other call site: without an access spec there is nothing to re-evaluate with */
+		      error = ER_FAILED;
 		      GOTO_EXIT_ON_ERROR;
 		    }
 		}
@@ -11244,8 +11265,6 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
   mvcc_reev_class_cnt = delete_->num_reev_classes;
   mvcc_reev_data.set_update_reevaluation (mvcc_upddel_reev_data);
 
-  mvcc_upddel_reev_data.copyarea = NULL;
-
   /* Allocate memory for oids, hfids and attributes cache info of all classes used in update */
   error = qexec_create_internal_classes (thread_p, delete_->classes, class_oid_cnt, &internal_classes);
   if (error != NO_ERROR)
@@ -11393,6 +11412,13 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 		}
 	      class_oid = db_get_oid (valp);
 
+	      if (mvcc_reev_class != NULL)
+		{
+		  /* this class's own row, the way the UPDATE path binds it.  Binding it later, from the
+		   * loop over the classes being deleted, would hand every entry the target's OID. */
+		  mvcc_reev_class->inst_oid = oid;
+		}
+
 	      if (class_oid_idx < class_oid_cnt)
 		{
 		  internal_class = &internal_classes[class_oid_idx];
@@ -11430,21 +11456,35 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 		    }
 		}
 
-	      if (mvcc_reev_class != NULL)
+	      if (mvcc_reev_class != NULL && !reev_disabled)
 		{
 		  /* class has changed to a new subclass */
 		  if (class_oid && !OID_EQ (&mvcc_reev_class->cls_oid, class_oid))
 		    {
-		      error = qexec_upddel_mvcc_set_filters (thread_p, aptr, mvcc_reev_class, class_oid);
+		      bool has_spec = false;
+
+		      error = qexec_upddel_mvcc_set_filters (thread_p, aptr, mvcc_reev_class, class_oid, &has_spec);
 		      if (error != NO_ERROR)
 			{
 			  GOTO_EXIT_ON_ERROR;
+			}
+		      if (!has_spec)
+			{
+			  /* No access spec for this row's subclass, so no filters to re-check with -- see
+			   * qexec_upddel_mvcc_set_filters ().  Skip the version rather than delete what the
+			   * predicate never saw.  mvcc_reev_class_cnt bounds this loop over the value list's
+			   * OID pairs and must stay as it is. */
+			  reev_disabled = true;
+			  mvcc_reev_class = NULL;
+			  mvcc_upddel_reev_data.curr_upddel = NULL;
+			  mvcc_upddel_reev_data.mvcc_cond_reev_list = NULL;
+			  mvcc_upddel_reev_data.skip_unevaluated_version = true;
 			}
 		    }
 		}
 	    }
 
-	  if (mvcc_upddel_reev_data.mvcc_cond_reev_list == NULL)
+	  if (!reev_disabled && mvcc_upddel_reev_data.mvcc_cond_reev_list == NULL)
 	    {
 	      /* If scan order was not set then do it. This operation must be run only once. We do it here and not at
 	       * the beginning of this function because the class OIDs must be set for classes involved in reevaluation
@@ -11460,7 +11500,8 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 	      oid = internal_class->oid;
 	      class_oid = internal_class->class_oid;
 
-	      if (mvcc_reev_class_cnt && mvcc_reev_classes[mvcc_reev_class_idx].class_index == class_oid_idx)
+	      if (!reev_disabled && mvcc_reev_class_idx < mvcc_reev_class_cnt
+		  && mvcc_reev_classes[mvcc_reev_class_idx].class_index == class_oid_idx)
 		{
 		  mvcc_reev_class = &mvcc_reev_classes[mvcc_reev_class_idx++];
 		}
@@ -11469,6 +11510,7 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 		  mvcc_reev_class = NULL;
 		}
 	      mvcc_upddel_reev_data.curr_upddel = mvcc_reev_class;
+	      /* inst_oid was bound per class while scanning; do not overwrite it with the target's */
 
 	      if (oid == NULL)
 		{
@@ -26370,9 +26412,11 @@ qexec_clear_internal_classes (THREAD_ENTRY * thread_p, UPDDEL_CLASS_INFO_INTERNA
  */
 static int
 qexec_upddel_mvcc_set_filters (THREAD_ENTRY * thread_p, XASL_NODE * aptr_list,
-			       UPDDEL_MVCC_COND_REEVAL * mvcc_reev_class, OID * class_oid)
+			       UPDDEL_MVCC_COND_REEVAL * mvcc_reev_class, OID * class_oid, bool * has_spec)
 {
   ACCESS_SPEC_TYPE *curr_spec = NULL;
+
+  *has_spec = false;
 
   while (aptr_list != NULL && curr_spec == NULL)
     {
@@ -26386,11 +26430,20 @@ qexec_upddel_mvcc_set_filters (THREAD_ENTRY * thread_p, XASL_NODE * aptr_list,
 
   if (curr_spec == NULL)
     {
-      return ER_FAILED;
+      /* The plan does not scan this class -- a path expression in the predicate makes the statement read
+       * an inner query's list instead -- so it carries no filters to re-evaluate with. Not an error;
+       * the caller decides what to do without reevaluation. */
+      return NO_ERROR;
     }
 
   mvcc_reev_class->init (curr_spec->s_id);
   mvcc_reev_class->cls_oid = *class_oid;
+  if (heap_get_class_info (thread_p, class_oid, &mvcc_reev_class->cls_hfid, NULL, NULL) != NO_ERROR)
+    {
+      ASSERT_ERROR ();
+      return er_errid ();
+    }
+  *has_spec = true;
 
   return NO_ERROR;
 }

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -373,6 +373,10 @@ struct upddel_class_info_internal
   HEAP_SCANCACHE *scan_cache;
 
   OID prev_class_oid;		/* previous class oid */
+  bool is_mvcc_class;		/* whether MVCC applies to class_oid; set when the class changes, because
+				 * mvcc_is_mvcc_disabled_class () is too slow to ask per row */
+  bool has_online_index;	/* an index of class_oid is being built online; set when the class changes,
+				 * because reading the class representation is too slow to ask per row */
   HEAP_CACHE_ATTRINFO attr_info;	/* attribute cache info */
   bool is_attr_info_inited;	/* true if attr_info has valid data */
   int needs_pruning;		/* partition pruning information */
@@ -10361,7 +10365,7 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
   MVCC_REEV_DATA mvcc_reev_data;
   UPDDEL_MVCC_COND_REEVAL *mvcc_reev_classes = NULL, *mvcc_reev_class = NULL;
   UPDATE_MVCC_REEV_ASSIGNMENT *mvcc_reev_assigns = NULL;
-  bool need_locking;
+  LOCATOR_LOCK_POLICY lock_policy;
   UPDDEL_CLASS_INSTANCE_LOCK_INFO class_instance_lock_info, *p_class_instance_lock_info = NULL;
 
   thread_p->no_logging = (bool) update->no_logging;
@@ -10420,12 +10424,12 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
   if (p_class_instance_lock_info && p_class_instance_lock_info->instances_locked)
     {
       /* already locked in select phase. Avoid locking again the same instances at update phase */
-      need_locking = false;
+      lock_policy = LOCATOR_LOCK_AT_SELECT;
     }
   else
     {
       /* not locked in select phase, need locking at update phase */
-      need_locking = true;
+      lock_policy = LOCATOR_LOCK_AT_FORCE;
     }
 
   /* This guarantees that the result list file will have a type list. Copying a list_id structure fails unless it has a
@@ -10724,7 +10728,7 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
 						  0, LC_FLUSH_DELETE, current_op_type, internal_class->scan_cache,
 						  &force_count, false, REPL_INFO_TYPE_RBR_NORMAL,
 						  DB_NOT_PARTITIONED_CLASS, NULL, NULL, &mvcc_reev_data,
-						  UPDATE_INPLACE_NONE, NULL, need_locking);
+						  UPDATE_INPLACE_NONE, NULL, lock_policy);
 
 		  if (error == ER_MVCC_NOT_SATISFIED_REEVALUATION)
 		    {
@@ -10913,7 +10917,7 @@ qexec_execute_update (THREAD_ENTRY * thread_p, XASL_NODE * xasl, bool has_delete
 					      &upd_cls->att_id[internal_class->subclass_idx * upd_cls->num_attrs],
 					      upd_cls->num_attrs, LC_FLUSH_UPDATE, op_type, internal_class->scan_cache,
 					      &force_count, false, repl_info, internal_class->needs_pruning, pcontext,
-					      NULL, &mvcc_reev_data, UPDATE_INPLACE_NONE, NULL, need_locking);
+					      NULL, &mvcc_reev_data, UPDATE_INPLACE_NONE, NULL, lock_policy);
 	      if (error == ER_MVCC_NOT_SATISFIED_REEVALUATION)
 		{
 		  error = NO_ERROR;
@@ -11242,7 +11246,10 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
   MVCC_REEV_DATA mvcc_reev_data;
   MVCC_UPDDEL_REEV_DATA mvcc_upddel_reev_data;
   UPDDEL_MVCC_COND_REEVAL *mvcc_reev_classes = NULL, *mvcc_reev_class = NULL;
-  bool need_locking;
+  LOCATOR_LOCK_POLICY base_lock_policy;	/* what the select phase left for the force phase to do */
+  bool outermost_transient_scope;	/* a statement nested in another one keeps its locks to commit */
+  LOCATOR_LOCK_POLICY lock_policy = LOCATOR_LOCK_AT_SELECT;	/* the same, narrowed by the current class */
+  bool reev_disabled = false;
   UPDDEL_CLASS_INSTANCE_LOCK_INFO class_instance_lock_info, *p_class_instance_lock_info = NULL;
 
   /* remote DELETE + local subquery sink: evaluate the WHERE subquery locally and push one remote
@@ -11252,6 +11259,9 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
     {
       return qexec_execute_remote_delete_subquery (thread_p, xasl, xasl_state);
     }
+
+  /* from here every exit runs through one of the two lock_transient_scope_end () calls below */
+  outermost_transient_scope = lock_transient_scope_start (thread_p);
 
   thread_p->no_logging = (bool) delete_->no_logging;
 
@@ -11307,12 +11317,16 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
   if (p_class_instance_lock_info && p_class_instance_lock_info->instances_locked)
     {
       /* already locked in select phase. Avoid locking again the same instances at delete phase. */
-      need_locking = false;
+      base_lock_policy = LOCATOR_LOCK_AT_SELECT;
     }
   else
     {
       /* not locked in select phase, need locking at update phase */
-      need_locking = true;
+      base_lock_policy = LOCATOR_LOCK_AT_FORCE;
+
+      /* No reevaluation class means no predicate to re-check -- pt_to_delete_xasl () keeps the
+       * select-phase lock for one it cannot replay -- so a changed version is deleted, not skipped.
+       * The skip below is for the subclass that turns out to carry no access spec. */
     }
 
   /* This guarantees that the result list file will have a type list. Copying a list_id structure fails unless it has a
@@ -11439,6 +11453,8 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 			  er_log_debug (ARG_FILE_LINE, "qexec_execute_delete: class OID is not correct\n");
 			  GOTO_EXIT_ON_ERROR;
 			}
+		      internal_class->is_mvcc_class = !mvcc_is_mvcc_disabled_class (class_oid);
+		      internal_class->has_online_index = locator_class_has_online_index (thread_p, class_oid);
 
 		      if (internal_class->num_lob_attrs)
 			{
@@ -11499,6 +11515,18 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 	      internal_class = &internal_classes[class_oid_idx];
 	      oid = internal_class->oid;
 	      class_oid = internal_class->class_oid;
+
+	      /* Whether the row locks this statement takes end with it belongs to the class, not the row,
+	       * so it is answered per class here rather than once for the statement -- a DELETE naming more
+	       * than one class gets a different answer for each.  A class under an online index build keeps
+	       * them to commit (the build's own entry state names no owner, so the row lock is what
+	       * serializes two writers there) and so does a class MVCC does not apply to. */
+	      lock_policy = base_lock_policy;
+	      if (lock_policy == LOCATOR_LOCK_AT_FORCE && outermost_transient_scope
+		  && internal_class->is_mvcc_class && !internal_class->has_online_index)
+		{
+		  lock_policy = LOCATOR_LOCK_AT_FORCE_TRANSIENT;
+		}
 
 	      if (!reev_disabled && mvcc_reev_class_idx < mvcc_reev_class_cnt
 		  && mvcc_reev_classes[mvcc_reev_class_idx].class_index == class_oid_idx)
@@ -11570,7 +11598,7 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 		locator_attribute_info_force (thread_p, internal_class->class_hfid, oid, NULL, NULL, 0, LC_FLUSH_DELETE,
 					      op_type, internal_class->scan_cache, &force_count, false,
 					      REPL_INFO_TYPE_RBR_NORMAL, DB_NOT_PARTITIONED_CLASS, NULL, NULL,
-					      &mvcc_reev_data, UPDATE_INPLACE_NONE, NULL, need_locking);
+					      &mvcc_reev_data, UPDATE_INPLACE_NONE, NULL, lock_policy);
 	      if (error == ER_MVCC_NOT_SATISFIED_REEVALUATION)
 		{
 		  error = NO_ERROR;
@@ -11638,6 +11666,19 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 	}
     }
 
+  /* Early release rests on the delete being decided only when we end.  A savepoint declared before now
+   * breaks that: a partial rollback can undo it while a writer parked on our MVCCID holds the row. */
+  /* The deletes are published: late arrivals settle on our MVCCID self-lock, which the prepare record
+   * persists across 2PC, so these row locks are redundant from here.  They end with the statement -- not
+   * with each row, since a row released early would be open while the same statement forces the next, and
+   * a writer entering that window would work a heap version this statement has already erased from the
+   * index.
+   * TODO: logtb_has_active_savepoint () does not tell a user savepoint from a DDL/trigger system
+   *       savepoint, so a transaction that ran DDL earlier keeps its locks to commit here -- correct but
+   *       it forgoes the release.  CBRD-27238 (UPDATE) adds a user-savepoint-only flag on tdes for both
+   *       paths to read instead. */
+  lock_transient_scope_end (thread_p, !logtb_has_active_savepoint (thread_p));
+
   qexec_close_scan (thread_p, specp);
 
   qexec_free_delete_lob_info_list (thread_p, &del_lob_info_list);
@@ -11689,6 +11730,10 @@ qexec_execute_delete (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
   return NO_ERROR;
 
 exit_on_error:
+  /* the statement failed, so its rows keep their locks to commit.  Drop the counts, though -- they name
+   * no statement, and the next statement to release would give back requests it never took. */
+  lock_transient_scope_end (thread_p, false);
+
   if (scan_open)
     {
       qexec_end_scan (thread_p, specp);
@@ -12023,7 +12068,7 @@ qexec_remove_duplicates_for_replace (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * s
 	    locator_attribute_info_force (thread_p, &pruned_hfid, &unique_oid, NULL, NULL, 0, LC_FLUSH_DELETE,
 					  local_op_type, local_scan_cache, &force_count, false,
 					  REPL_INFO_TYPE_RBR_NORMAL, DB_NOT_PARTITIONED_CLASS, NULL, NULL, NULL,
-					  UPDATE_INPLACE_NONE, NULL, false);
+					  UPDATE_INPLACE_NONE, NULL, LOCATOR_LOCK_AT_SELECT);
 
 	  if (error_code == ER_MVCC_NOT_SATISFIED_REEVALUATION)
 	    {
@@ -12451,7 +12496,8 @@ qexec_execute_duplicate_key_update (THREAD_ENTRY * thread_p, ODKU_INFO * odku, H
   error =
     locator_attribute_info_force (thread_p, hfid, &unique_oid, attr_info, odku->attr_ids, odku->num_assigns,
 				  LC_FLUSH_UPDATE, local_op_type, local_scan_cache, force_count, false, repl_info,
-				  pruning_type, pcontext, NULL, NULL, UPDATE_INPLACE_NONE, &rec_descriptor, false);
+				  pruning_type, pcontext, NULL, NULL, UPDATE_INPLACE_NONE, &rec_descriptor,
+				  LOCATOR_LOCK_AT_SELECT);
   if (error == ER_MVCC_NOT_SATISFIED_REEVALUATION)
     {
       er_clear ();
@@ -13583,7 +13629,8 @@ qexec_execute_insert (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 	      if (locator_attribute_info_force (thread_p, &insert->class_hfid, &oid, &attr_info, NULL, 0, operation,
 						scan_cache_op_type, &scan_cache, &force_count, false,
 						REPL_INFO_TYPE_RBR_NORMAL, insert->pruning_type, pcontext,
-						func_indx_preds, NULL, UPDATE_INPLACE_NONE, NULL, false) != NO_ERROR)
+						func_indx_preds, NULL, UPDATE_INPLACE_NONE, NULL,
+						LOCATOR_LOCK_AT_SELECT) != NO_ERROR)
 		{
 		  GOTO_EXIT_ON_ERROR;
 		}
@@ -13763,7 +13810,7 @@ qexec_execute_insert (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE * xa
 	      if (locator_attribute_info_force (thread_p, &insert->class_hfid, &oid, &attr_info, NULL, 0, operation,
 						scan_cache_op_type, &scan_cache, &force_count, false,
 						REPL_INFO_TYPE_RBR_NORMAL, insert->pruning_type, pcontext, NULL, NULL,
-						UPDATE_INPLACE_NONE, NULL, false) != NO_ERROR)
+						UPDATE_INPLACE_NONE, NULL, LOCATOR_LOCK_AT_SELECT) != NO_ERROR)
 		{
 		  GOTO_EXIT_ON_ERROR;
 		}
@@ -14416,7 +14463,7 @@ exit_on_error:
  *   attrid(in) :
  *   n_increment(in)    :
  *   pruning_type(in)	:
- *   need_locking(in)	: true, if need locking
+ *   lock_policy(in)	: where the row lock is taken and how long it is kept
  */
 static int
 qexec_execute_increment (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, const HFID * class_hfid,
@@ -14477,7 +14524,7 @@ qexec_execute_increment (THREAD_ENTRY * thread_p, const OID * oid, const OID * c
       error =
 	locator_attribute_info_force (thread_p, class_hfid, &copy_oid, &attr_info, &attrid, 1, area_op, op_type,
 				      &scan_cache, &force_count, false, REPL_INFO_TYPE_RBR_NORMAL, pruning_type, NULL,
-				      NULL, NULL, UPDATE_INPLACE_NONE, NULL, false);
+				      NULL, NULL, UPDATE_INPLACE_NONE, NULL, LOCATOR_LOCK_AT_SELECT);
       if (error == ER_MVCC_NOT_SATISFIED_REEVALUATION)
 	{
 	  assert (force_count == 0);
@@ -14794,7 +14841,7 @@ qexec_execute_selupd_list (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STATE
 	      scan_code =
 		locator_lock_and_get_object_with_evaluation (thread_p, &crt_incr_info.m_oid, &crt_incr_info.m_class_oid,
 							     NULL, &scan_cache, COPY, NULL_CHN, p_mvcc_reev_data,
-							     LOG_WARNING_IF_DELETED);
+							     LOG_WARNING_IF_DELETED, false);
 	      if (scan_code != S_SUCCESS)
 		{
 		  int er_id = er_errid ();
@@ -26230,6 +26277,8 @@ qexec_create_internal_classes (THREAD_ENTRY * thread_p, UPDDEL_CLASS_INFO * quer
       class_->class_oid = NULL;
       class_->needs_pruning = DB_NOT_PARTITIONED_CLASS;
       class_->subclass_idx = -1;
+      class_->is_mvcc_class = false;
+      class_->has_online_index = false;
       class_->scan_cache = NULL;
       OID_SET_NULL (&class_->prev_class_oid);
       class_->is_attr_info_inited = 0;

--- a/src/query/query_reevaluation.cpp
+++ b/src/query/query_reevaluation.cpp
@@ -132,6 +132,21 @@ namespace cubquery
       }
   }
 
+  mvcc_update_reev_data::mvcc_update_reev_data ()
+    : mvcc_cond_reev_list (NULL)
+    , curr_upddel (NULL)
+    , curr_extra_assign_cnt (0)
+    , curr_extra_assign_reev (NULL)
+    , curr_assigns (NULL)
+    , curr_attrinfo (NULL)
+    , cons_pred (NULL)
+    , copyarea (NULL)
+    , vd (NULL)
+    , new_recdes (NULL)
+    , skip_unevaluated_version (false)
+  {
+  }
+
   void
   mvcc_scan_reev_data::set_filters (upddel_mvcc_cond_reeval &ureev)
   {

--- a/src/query/query_reevaluation.hpp
+++ b/src/query/query_reevaluation.hpp
@@ -64,6 +64,7 @@ namespace cubquery
   {
     int class_index;		/* index of class in select list */
     OID cls_oid;			/* OID of class */
+    HFID cls_hfid;		/* heap of cls_oid; resolved with the OID so reevaluation need not ask per row */
     OID *inst_oid;		/* OID of instance involved in condition */
     filter_info data_filter;	/* data filter */
     filter_info key_filter;	/* key_filter */
@@ -78,6 +79,8 @@ namespace cubquery
   };
 
   /* data for MVCC condition reevaluation */
+  /* the constructor leaves the empty, condition-only state; the UPDATE path fills the assignment-side
+   * fields (prepare_mvcc_reev_data ()). vd must always be bound. */
   struct mvcc_update_reev_data
   {
     upddel_mvcc_cond_reeval *mvcc_cond_reev_list;	/* list of classes that are referenced in condition */
@@ -95,6 +98,10 @@ namespace cubquery
     lc_copy_area *copyarea;	/* used to build the tuple to be stored to disk after reevaluation */
     val_descr *vd;		/* values descriptor */
     recdes *new_recdes;		/* record descriptor after assignment reevaluation */
+    bool skip_unevaluated_version;	/* skip a last version the predicate was never evaluated
+					 * against, instead of modifying it */
+
+    mvcc_update_reev_data ();
   };
 
   /* Structure used in condition reevaluation at SELECT */

--- a/src/query/scan_manager.c
+++ b/src/query/scan_manager.c
@@ -6047,7 +6047,8 @@ scan_next_heap_scan (THREAD_ENTRY * thread_p, SCAN_ID * scan_id)
 	  /* get with lock and reevaluate if the visible version wasn't the latest version */
 	  sp_scan =
 	    locator_lock_and_get_object_with_evaluation (thread_p, &current_oid, NULL, &recdes, &hsidp->scan_cache,
-							 is_peeking, NULL_CHN, &mvcc_reev_data, LOG_WARNING_IF_DELETED);
+							 is_peeking, NULL_CHN, &mvcc_reev_data, LOG_WARNING_IF_DELETED,
+							 false);
 	  if (sp_scan == S_SUCCESS && mvcc_reev_data.filter_result == V_FALSE)
 	    {
 	      continue;
@@ -6866,7 +6867,7 @@ scan_next_index_lookup_heap (THREAD_ENTRY * thread_p, SCAN_ID * scan_id, INDX_SC
 
       sp_scan = locator_lock_and_get_object_with_evaluation (thread_p, isidp->curr_oidp, NULL, &recdes,
 							     &isidp->scan_cache, scan_id->fixed, NULL_CHN,
-							     &mvcc_reev_data, LOG_WARNING_IF_DELETED);
+							     &mvcc_reev_data, LOG_WARNING_IF_DELETED, false);
       if (sp_scan == S_SUCCESS)
 	{
 	  switch (mvcc_reev_data.filter_result)

--- a/src/storage/btree.c
+++ b/src/storage/btree.c
@@ -30,6 +30,7 @@
 #include "btree.h"
 
 #include "btree_load.h"
+#include "btree_object_lock.hpp"
 #include "config.h"
 #include "db_value_printer.hpp"
 #include "deduplicate_key.h"
@@ -386,54 +387,6 @@ struct btree_search_key_helper
 #define BTREE_SEARCH_KEY_HELPER_INITIALIZER \
   { BTREE_KEY_NOTFOUND, NULL_SLOTID, btree_search_key_helper::NO_FENCE_KEY }
 // *INDENT-ON*
-
-/* BTREE_FIND_UNIQUE_HELPER -
- * Structure used by find unique functions.
- *
- * Functions:
- * btree_key_find_unique_version_oid.
- * btree_key_find_and_lock_unique.
- * btree_key_find_and_lock_unique_of_unique.
- * btree_key_find_and_lock_unique_of_non_unique.
- */
-typedef struct btree_find_unique_helper BTREE_FIND_UNIQUE_HELPER;
-struct btree_find_unique_helper
-{
-  OID oid;			/* OID of found object (if found). */
-  OID match_class_oid;		/* Object is only considered if its class OID matches this class OID. */
-  LOCK lock_mode;		/* Lock mode for found unique object. */
-  MVCC_SNAPSHOT *snapshot;	/* Snapshot used to filter objects not visible. If NULL, objects are not filtered. */
-  bool found_object;		/* Set to true if object was found. */
-
-  PERF_UTIME_TRACKER time_track;
-
-#if defined (SERVER_MODE)
-  OID locked_oid;		/* Locked object. */
-  OID locked_class_oid;		/* Locked object class OID. */
-#endif				/* SERVER_MODE */
-};
-/* BTREE_FIND_UNIQUE_HELPER static initializer. */
-#if defined (SERVER_MODE)
-#define BTREE_FIND_UNIQUE_HELPER_INITIALIZER \
-  { OID_INITIALIZER, /* oid */ \
-    OID_INITIALIZER, /* match_class_oid */ \
-    NULL_LOCK, /* lock_mode */ \
-    NULL, /* snapshot */ \
-    false, /* found_object */ \
-    PERF_UTIME_TRACKER_INITIALIZER, /* time_track */ \
-    OID_INITIALIZER, /* locked_oid */ \
-    OID_INITIALIZER /* locked_class_oid */ \
-  }
-#else	/* !SERVER_MODE */		   /* SA_MODE */
-#define BTREE_FIND_UNIQUE_HELPER_INITIALIZER \
-  { OID_INITIALIZER, /* oid */ \
-    OID_INITIALIZER, /* match_class_oid */ \
-    NULL_LOCK, /* lock_mode */ \
-    NULL, /* snapshot */ \
-    false, /* found_object */ \
-    PERF_UTIME_TRACKER_INITIALIZER /* time_track */ \
-  }
-#endif /* !SA_MODE */
 
 /* BTREE_REC_SATISFIES_SNAPSHOT_HELPER -
  * Structure used as helper for btree_record_satisfies_snapshot function.
@@ -1577,6 +1530,9 @@ static int btree_key_online_index_IB_insert (THREAD_ENTRY * thread_p, BTID_INT *
 					     void *other_args);
 static int btree_key_insert_new_key (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB_VALUE * key, PAGE_PTR leaf_page,
 				     BTREE_INSERT_HELPER * insert_helper, BTREE_SEARCH_KEY_HELPER * search_key);
+static bool btree_key_find_active_delete_owner (THREAD_ENTRY * thread_p, BTID_INT * btid_int,
+						BTREE_INSERT_HELPER * insert_helper, RECDES * record,
+						int offset_after_key, MVCCID * owner_mvccid);
 static int btree_key_find_and_insert_delete_mvccid (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB_VALUE * key,
 						    PAGE_PTR * leaf_page, BTREE_SEARCH_KEY_HELPER * search_key,
 						    bool * restart, void *other_args);
@@ -26210,114 +26166,6 @@ btree_key_find_and_lock_unique (THREAD_ENTRY * thread_p, BTID_INT * btid_int, DB
     }
 }
 
-#if defined (SERVER_MODE)
-/*
- * btree_is_active_other_inserter () - Is insert_mvccid an in-progress insert by another transaction?
- *
- * return	      : true if some other transaction is still inserting under insert_mvccid.
- * thread_p (in)      : Thread entry.
- * insert_mvccid (in) : Candidate inserter MVCCID (e.g. BTREE_MVCC_INFO_INSID of the record).
- *
- * Note: guards the "wait for the inserter to end" paths. False when the id is invalid, is our own
- *	 insert, or the inserter has already ended -- in those cases there is nothing to wait on.
- */
-static bool
-btree_is_active_other_inserter (THREAD_ENTRY * thread_p, MVCCID insert_mvccid)
-{
-  return MVCCID_IS_NORMAL (insert_mvccid) && !logtb_is_current_mvccid (thread_p, insert_mvccid)
-    && log_Gl.mvcc_table.is_active (insert_mvccid);
-}
-
-/*
- * btree_wait_for_inserter_end () - Block until the transaction inserting under insert_mvccid ends:
- *				    S_LOCK on its MVCCID self-lock, then release.
- *
- * return	      : NO_ERROR once the inserter has ended. An error if the lock failed, or if the
- *			self-lock invariant is breached (grant while the inserter is still active) --
- *			the wait was a no-op and waiting again cannot recover it, so fail the
- *			statement rather than spin.
- * thread_p (in)      : Thread entry.
- * insert_mvccid (in) : MVCCID of the in-progress inserter to wait out.
- *
- * Note: call with no page latch held.
- */
-static int
-btree_wait_for_inserter_end (THREAD_ENTRY * thread_p, MVCCID insert_mvccid)
-{
-  int error_code;
-
-  if (lock_transaction_mvccid (thread_p, insert_mvccid, S_LOCK, LK_UNCOND_LOCK) != LK_GRANTED)
-    {
-      error_code = er_errid ();
-      if (error_code == NO_ERROR)
-	{
-	  error_code = ER_CANNOT_GET_LOCK;
-	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_code, 0);
-	}
-      return error_code;
-    }
-  lock_unlock_transaction_mvccid (thread_p, insert_mvccid, S_LOCK);
-
-  if (log_Gl.mvcc_table.is_active (insert_mvccid))
-    {
-      /* Invariant breach: no-op grant while the inserter is still active. */
-      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CANNOT_GET_LOCK, 0);
-      assert (false);
-      return ER_CANNOT_GET_LOCK;
-    }
-  return NO_ERROR;
-}
-
-/*
- * btree_key_wait_for_insert_mvccid () - Wait for the transaction inserting a conflicting object to
- *					 end, then signal a restart from root.
- *
- * return	       : Error code (NO_ERROR on success, with *restart set to true).
- * thread_p (in)       : Thread entry.
- * insert_mvccid (in)  : MVCCID of the in-progress inserter to wait on.
- * find_unique_helper (in/out) : Find-unique state; any object it has locked is released first.
- * leaf_page (in/out)  : Leaf node page latch; unfixed before suspending and left NULL.
- * overflow_page (in/out) : Optional overflow node page latch (..._of_non_unique () scans overflow pages);
- *			    unfixed before suspending and left NULL. NULL when there is no overflow page.
- * restart (out)       : Set to true so the caller re-reads the key from root.
- *
- * Note: shared by ..._of_unique () and ..._of_non_unique (); blocks on the inserter transaction
- *	 (S_LOCK then release) since appended rows take no per-row X-lock, then restarts from root.
- *	 All page latches must be released before blocking on the lock (never wait while holding a latch).
- */
-static int
-btree_key_wait_for_insert_mvccid (THREAD_ENTRY * thread_p, MVCCID insert_mvccid,
-				  BTREE_FIND_UNIQUE_HELPER * find_unique_helper, PAGE_PTR * leaf_page,
-				  PAGE_PTR * overflow_page, bool * restart)
-{
-  int error_code = NO_ERROR;
-
-  /* Release any previously locked object before suspending. */
-  if (!OID_ISNULL (&find_unique_helper->locked_oid))
-    {
-      lock_unlock_object_donot_move_to_non2pl (thread_p, &find_unique_helper->locked_oid,
-					       &find_unique_helper->locked_class_oid, find_unique_helper->lock_mode);
-      OID_SET_NULL (&find_unique_helper->locked_oid);
-    }
-  /* Release page latches before blocking on the lock. */
-  if (overflow_page != NULL && *overflow_page != NULL)
-    {
-      pgbuf_unfix_and_init (thread_p, *overflow_page);
-    }
-  pgbuf_unfix_and_init (thread_p, *leaf_page);
-
-  error_code = btree_wait_for_inserter_end (thread_p, insert_mvccid);
-  if (error_code != NO_ERROR)
-    {
-      return error_code;
-    }
-
-  /* Inserter has ended; the page may have changed during the wait, so re-read the key from root. */
-  *restart = true;
-  return NO_ERROR;
-}
-#endif /* SERVER_MODE */
-
 /*
  * btree_key_find_and_lock_unique_of_unique () - Find key and lock its first object (if not deleted or dirty).
  *
@@ -26378,14 +26226,10 @@ btree_key_find_and_lock_unique_of_unique (THREAD_ENTRY * thread_p, BTID_INT * bt
       goto error_or_not_found;
     }
 
-  /* Lock key non-dirty version to protect it. Non-dirty or newest key version is always kept first. Locking object is
-   * possible if object is not deleted and it is not dirty (its inserter/deleter is not active). If inserter or
-   * deleter is active, or if conditional lock on object failed, current transaction must suspend until the object lock
-   * holder is completed. This also means unfixing leaf page first. Current algorithm tries to avoid traversing the
-   * b-tree back from root after resume. If conditional lock on object fails, leaf node must be unfixed and then fixed
-   * again after object is locked. If page no longer exists or if the page is no longer usable (key is not in page),
-   * the process is restarted (while holding the lock however). NOTE: Stand-alone mode doesn't require locking. It
-   * should only check whether the first key object is deleted or not. */
+  /* Lock the key's first object; the non-dirty or newest version is always kept first. A live inserter or
+   * deleter is waited out by transaction end, not by the object lock -- see
+   * btree_key_wait_out_conflicting_writer (). NOTE: Stand-alone mode doesn't require locking. It should only
+   * check whether the first key object is deleted or not. */
 
   /* Initialize unique_oid */
   OID_SET_NULL (&unique_oid);
@@ -26446,18 +26290,18 @@ btree_key_find_and_lock_unique_of_unique (THREAD_ENTRY * thread_p, BTID_INT * bt
 	  error_code = ER_FAILED;
 	  goto error_or_not_found;
 #else	/* !SA_MODE */	       /* SERVER_MODE */
-	  if (satisfies_delete == DELETE_RECORD_INSERT_IN_PROGRESS)
+	  error_code = btree_key_wait_out_conflicting_writer (thread_p, satisfies_delete, &mvcc_header,
+							      find_unique_helper, leaf_page, NULL, restart);
+	  if (error_code != NO_ERROR)
 	    {
-	      /* Conflicting object still being inserted: wait for that transaction to end, then restart. */
-	      MVCCID insert_mvccid = BTREE_MVCC_INFO_INSID (&mvcc_info);
-	      if (btree_is_active_other_inserter (thread_p, insert_mvccid))
-		{
-		  return btree_key_wait_for_insert_mvccid (thread_p, insert_mvccid, find_unique_helper, leaf_page,
-							   NULL, restart);
-		}
-	      /* No active inserter (e.g. our own in-progress insert) -- fall through to the row-lock path. */
+	      return error_code;
 	    }
-	  /* Object is being inserted/deleted. We need to lock and suspend until it's fate is decided. */
+	  if (*restart)
+	    {
+	      return NO_ERROR;
+	    }
+
+	  /* No writer left to wait out (our own insert, or one that just ended): lock the object as usual. */
 	  assert (!lock_has_lock_on_object (&unique_oid, &unique_class_oid, find_unique_helper->lock_mode));
 #endif /* SERVER_MODE */
 	  [[fallthrough]];
@@ -26508,7 +26352,7 @@ btree_key_find_and_lock_unique_of_unique (THREAD_ENTRY * thread_p, BTID_INT * bt
 	    {
 	      /* Key was found but we still need to re-check first object. Since page was re-fixed, it may have
 	       * changed. */
-	      break;		/* switch (satisfies_delete) */
+	      continue;
 	    }
 	  else
 	    {
@@ -26629,15 +26473,10 @@ btree_key_find_and_lock_unique_of_non_unique (THREAD_ENTRY * thread_p, BTID_INT 
       goto error_or_not_found;
     }
 
-  /* Lock key non-dirty version to protect it. Since this is not an unique index, but can have only one non-dirty
-   * version, this must be searched through the leaf/overflow records. Locking object is possible if object is not
-   * deleted and it is not dirty (its inserter/deleter is not active). If inserter or deleter is active, or if
-   * conditional lock on object failed, current transaction must suspend until the object lock holder is completed.
-   * This also means unfixing leaf/overflow pages first. Current algorithm tries to avoid traversing the b-tree back
-   * from root after resume. If conditional lock on object fails, leaf/overflow nodes must be unfixed and then fixed
-   * again after object is locked. If leaf page no longer exists or if the page is no longer usable (key is not in
-   * page), the process is restarted from root. If leaf page is still valid, leaf/overflow records are processed again.
-   * NOTE: Stand-alone mode doesn't require locking. It should only check whether the first key object is deleted or not. */
+  /* Lock the key's non-dirty version; since this is not a unique index it must be searched through the
+   * leaf/overflow records. A live inserter or deleter is waited out by transaction end, not by the object
+   * lock -- see btree_key_wait_out_conflicting_writer (). NOTE: Stand-alone mode doesn't require locking. It
+   * should only check whether the first key object is deleted or not. */
 
   /* Initialize unique_oid */
   OID_SET_NULL (&unique_oid);
@@ -26769,18 +26608,18 @@ btree_key_find_and_lock_unique_of_non_unique (THREAD_ENTRY * thread_p, BTID_INT 
 	  error_code = ER_FAILED;
 	  goto error_or_not_found;
 #else	/* !SA_MODE */	       /* SERVER_MODE */
-	  if (satisfies_delete == DELETE_RECORD_INSERT_IN_PROGRESS)
+	  error_code = btree_key_wait_out_conflicting_writer (thread_p, satisfies_delete, &mvcc_header,
+							      find_unique_helper, leaf_page, &overflow_page, restart);
+	  if (error_code != NO_ERROR)
 	    {
-	      /* Conflicting object still being inserted: wait for that transaction to end, then restart. */
-	      MVCCID insert_mvccid = BTREE_MVCC_INFO_INSID (&mvcc_info);
-	      if (btree_is_active_other_inserter (thread_p, insert_mvccid))
-		{
-		  return btree_key_wait_for_insert_mvccid (thread_p, insert_mvccid, find_unique_helper, leaf_page,
-							   &overflow_page, restart);
-		}
-	      /* No active inserter (e.g. our own in-progress insert) -- fall through to the row-lock path. */
+	      return error_code;
 	    }
-	  /* Object is being inserted/deleted. We need to lock and suspend until it's fate is decided. */
+	  if (*restart)
+	    {
+	      return NO_ERROR;
+	    }
+
+	  /* No writer left to wait out (our own insert, or one that just ended): lock the object as usual. */
 	  assert (!lock_has_lock_on_object (&unique_oid, &unique_class_oid, find_unique_helper->lock_mode));
 #endif /* SERVER_MODE */
 	  [[fallthrough]];
@@ -26850,7 +26689,7 @@ btree_key_find_and_lock_unique_of_non_unique (THREAD_ENTRY * thread_p, BTID_INT 
 	      was_page_refixed = false;
 	      /* Safe guard: overflow page must be unfixed. */
 	      assert (overflow_page == NULL);
-	      break;		/* switch (satisfies_delete) */
+	      continue;
 	    }
 	  else
 	    {
@@ -26871,9 +26710,8 @@ btree_key_find_and_lock_unique_of_non_unique (THREAD_ENTRY * thread_p, BTID_INT 
 
 	case DELETE_RECORD_DELETED:
 	case DELETE_RECORD_SELF_DELETED:
-	  /* This object is deleted. */
-	  /* Continue to next object. */
-	  break;
+	  /* This object is deleted; go on to the next one. */
+	  continue;
 
 	default:
 	  /* Unhandled/unexpected case. */
@@ -29358,9 +29196,7 @@ btree_range_scan_find_fk_any_object (THREAD_ENTRY * thread_p, BTREE_SCAN * bts)
  * find_fk_obj (in/out): FK-find state; any object it has locked is released.
  * class_oid (in)      : Class OID of the locked object.
  *
- * Note: shared by the INSERT_IN_PROGRESS and DELETE_IN_PROGRESS paths of btree_fk_object_does_exist ();
- *       both must drop all latches before blocking on the conflicting transaction. The two paths differ
- *       only in how they then wait (transaction self-lock vs. object lock), which stays at the call site.
+ * Note: every caller must drop all latches before blocking on the conflicting transaction.
  */
 static void
 btree_fk_release_pages_and_locks (THREAD_ENTRY * thread_p, BTREE_SCAN * bts, BTREE_FK_EXIST_ARG * fk_arg,
@@ -29431,45 +29267,29 @@ btree_fk_object_does_exist (THREAD_ENTRY * thread_p, BTID_INT * btid_int, RECDES
       return NO_ERROR;
 
     case DELETE_RECORD_INSERT_IN_PROGRESS:
+    case DELETE_RECORD_DELETE_IN_PROGRESS:
 #if defined (SERVER_MODE)
-      /* Referenced row still being inserted. */
+      /* Neither writer holds a row lock the object lock could suspend on, so that lock would be granted at
+       * once and the re-check would spin. Wait for the writer's transaction to end instead. */
       {
-	MVCCID fk_insert_mvccid = BTREE_MVCC_INFO_INSID (mvcc_info);
-	int fk_wait_error;
+	MVCCID fk_writer_mvccid = (satisfy_delete == DELETE_RECORD_INSERT_IN_PROGRESS)
+	  ? BTREE_MVCC_INFO_INSID (mvcc_info) : BTREE_MVCC_INFO_DELID (mvcc_info);
 
-	if (!btree_is_active_other_inserter (thread_p, fk_insert_mvccid))
-	  {
-	    /* Inserter ended in the race since mvcc_satisfies_delete: re-read the key rather than consume the stale
-	     * INSERT_IN_PROGRESS as "not found" (mirrors the unique-scan recheck). */
-	    btree_fk_release_pages_and_locks (thread_p, bts, fk_arg, find_fk_obj, class_oid);
-	    *stop = true;
-	    return NO_ERROR;
-	  }
-
-	/* Wait for that transaction to end before deciding whether the FK reference holds: release all page
-	 * latches and any locked object, then wait out the inserter. */
+	/* The writer may have ended in the race since mvcc_satisfies_delete (), so the verdict can be stale:
+	 * re-read the key either way rather than consume it. */
 	btree_fk_release_pages_and_locks (thread_p, bts, fk_arg, find_fk_obj, class_oid);
-	fk_wait_error = btree_wait_for_inserter_end (thread_p, fk_insert_mvccid);
-	if (fk_wait_error != NO_ERROR)
+	if (logtb_is_active_other_mvccid (thread_p, fk_writer_mvccid))
 	  {
-	    return fk_wait_error;
-	  }
+	    int fk_wait_error = logtb_wait_for_tran_end (thread_p, fk_writer_mvccid);
 
-	/* Inserter ended; trigger re-check. */
+	    if (fk_wait_error != NO_ERROR)
+	      {
+		return fk_wait_error;
+	      }
+	  }
 	*stop = true;
 	return NO_ERROR;
       }
-#else	/* !SERVER_MODE */		   /* SA_MODE */
-      /* Impossible: no other active transactions. */
-      assert_release (false);
-      return ER_FAILED;
-#endif /* SA_MODE */
-
-    case DELETE_RECORD_DELETE_IN_PROGRESS:
-#if defined (SERVER_MODE)
-      /* Object is being deleted by an active transaction. We have to wait for that transaction to commit. Fall through
-       * to suspend. */
-      break;
 #else	/* !SERVER_MODE */		   /* SA_MODE */
       /* Impossible: no other active transactions. */
       assert_release (false);
@@ -32120,6 +31940,57 @@ btree_key_append_object_into_ovf (THREAD_ENTRY * thread_p, BTID_INT * btid_int, 
 }
 
 /*
+ * btree_key_find_active_delete_owner () - Is this object already stamped by a running transaction?
+ *
+ * return		 : True when the object is in this key with a delete MVCCID owned by another
+ *			   running transaction; that MVCCID is output.
+ * thread_p (in)	 : Thread entry.
+ * btid_int (in)	 : B-tree info.
+ * insert_helper (in)	 : Names the object we came to stamp.
+ * record (in)		 : The key's leaf record.
+ * offset_after_key (in) : Offset in the record where the packed key ends.
+ * owner_mvccid (out)	 : The owning MVCCID.
+ *
+ * Note: only the leaf record is walked; an object that moved to an overflow page is not found here.
+ */
+static bool
+btree_key_find_active_delete_owner (THREAD_ENTRY * thread_p, BTID_INT * btid_int, BTREE_INSERT_HELPER * insert_helper,
+				    RECDES * record, int offset_after_key, MVCCID * owner_mvccid)
+{
+#if defined (SERVER_MODE)
+  OR_BUF buf;
+  OID inst_oid, class_oid;
+  BTREE_MVCC_INFO mvcc_info;
+  bool is_first = true;
+
+  assert (owner_mvccid != NULL);
+
+  BTREE_RECORD_OR_BUF_INIT (buf, record);
+  while (buf.ptr < buf.endptr)
+    {
+      if (btree_or_get_object (&buf, btid_int, BTREE_LEAF_NODE, offset_after_key, &inst_oid, &class_oid, &mvcc_info)
+	  != NO_ERROR)
+	{
+	  return false;
+	}
+      if (OID_EQ (&inst_oid, BTREE_INSERT_OID (insert_helper)) && BTREE_MVCC_INFO_IS_DELID_VALID (&mvcc_info)
+	  && logtb_is_active_other_mvccid (thread_p, mvcc_info.delete_mvccid))
+	{
+	  *owner_mvccid = mvcc_info.delete_mvccid;
+	  return true;
+	}
+      if (is_first)
+	{
+	  or_seek (&buf, offset_after_key);
+	  is_first = false;
+	}
+    }
+#endif /* SERVER_MODE */
+
+  return false;
+}
+
+/*
  * btree_key_find_and_insert_delete_mvccid () - BTREE_ADVANCE_WITH_KEY_FUNCTION used for MVCC logical delete.
  *						An object is found and an MVCCID is added to its MVCC info.
  *
@@ -32151,6 +32022,7 @@ btree_key_find_and_insert_delete_mvccid (THREAD_ENTRY * thread_p, BTID_INT * bti
 
   int num_visible = 0;
   MVCC_SNAPSHOT snapshot_dirty;
+  MVCCID settle_owner_mvccid = MVCCID_NULL;
 
   /* Assert expected arguments. */
   assert (btid_int != NULL);
@@ -32230,6 +32102,28 @@ btree_key_find_and_insert_delete_mvccid (THREAD_ENTRY * thread_p, BTID_INT * bti
   if (offset_to_found_object == NOT_FOUND)
     {
       assert (found_page == NULL);
+
+      /* NOT_FOUND can also mean the object is here with a delete MVCCID already set: this purpose matches
+       * only an object without one.  A still-running owner means the entry was stamped by a writer that gave
+       * up the row lock before ending, and rollback restores the heap before the index -- so the record this
+       * key came from can already be back to the version it was stamped for.  The heap-side settle cannot
+       * see that, only the entry can.  Hand the owner to btree_key_wait_for_tran_end (), which drops the
+       * latch, waits under the transaction's lock timeout and asks for a restart -- the same primitive the
+       * unique-key probe waits on.  No private budget here, and the heap-side settle keeps no count either. */
+#if defined (SERVER_MODE)
+      if (insert_helper->purpose == BTREE_OP_INSERT_MVCC_DELID
+	  && btree_key_find_active_delete_owner (thread_p, btid_int, insert_helper, &record, offset_after_key,
+						 &settle_owner_mvccid))
+	{
+	  error_code = btree_key_wait_for_tran_end (thread_p, settle_owner_mvccid, NULL, leaf_page, NULL, restart);
+	  if (error_code != NO_ERROR)
+	    {
+	      ASSERT_ERROR ();
+	    }
+	  goto exit;
+	}
+#endif /* SERVER_MODE */
+
       assert (false);
       btree_set_unknown_key_error (thread_p, btid_int->sys_btid, key, "btree_key_find_and_insert_delete_mvccid");
       error_code = ER_BTREE_UNKNOWN_KEY;

--- a/src/storage/btree_object_lock.cpp
+++ b/src/storage/btree_object_lock.cpp
@@ -1,0 +1,146 @@
+/*
+ *
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+//
+// Object locking through a b-tree key - taking the lock, and waiting out a writer that holds it
+//
+
+#include "btree_object_lock.hpp"
+
+#include "error_manager.h"
+#include "lock_manager.h"
+#include "log_impl.h"
+#include "page_buffer.h"
+
+// XXX: SHOULD BE THE LAST INCLUDE HEADER
+#include "memory_wrapper.hpp"
+
+#if defined (SERVER_MODE)
+
+static void btree_key_release_locked_object_and_pages (THREAD_ENTRY *thread_p,
+    BTREE_FIND_UNIQUE_HELPER *find_unique_helper,
+    PAGE_PTR *leaf_page, PAGE_PTR *overflow_page);
+
+/*
+ * btree_key_wait_out_conflicting_writer () - Wait out the transaction inserting or deleting the key's
+ *					      first object, if one is still live.
+ *
+ * return	       : Error code.  On NO_ERROR, *restart says what the caller must do next.
+ * thread_p (in)       : Thread entry.
+ * satisfies_delete (in) : DELETE_RECORD_INSERT_IN_PROGRESS or DELETE_RECORD_DELETE_IN_PROGRESS.
+ * mvcc_header (in)    : MVCC header of the first object, carrying the writer's MVCCID.
+ * find_unique_helper (in/out) : Find-unique state.
+ * leaf_page (in/out)  : Leaf node page latch.
+ * overflow_page (in/out) : Optional overflow node page latch; NULL when there is none.
+ * restart (out)       : Outputs true when the key must be re-read from root; otherwise untouched.
+ *
+ * Note: neither writer holds a row lock the caller's object lock could suspend on, so that lock would be
+ *	 granted at once and the re-check would spin.  Serialize on the writer's transaction end instead.
+ */
+int
+btree_key_wait_out_conflicting_writer (THREAD_ENTRY *thread_p, MVCC_SATISFIES_DELETE_RESULT satisfies_delete,
+				       MVCC_REC_HEADER *mvcc_header, BTREE_FIND_UNIQUE_HELPER *find_unique_helper,
+				       PAGE_PTR *leaf_page, PAGE_PTR *overflow_page, bool *restart)
+{
+  MVCCID writer_mvccid;
+
+  assert (satisfies_delete == DELETE_RECORD_INSERT_IN_PROGRESS || satisfies_delete == DELETE_RECORD_DELETE_IN_PROGRESS);
+
+  writer_mvccid = (satisfies_delete == DELETE_RECORD_INSERT_IN_PROGRESS)
+		  ? MVCC_GET_INSID (mvcc_header) : MVCC_GET_DELID (mvcc_header);
+
+  if (logtb_is_active_other_mvccid (thread_p, writer_mvccid))
+    {
+      return btree_key_wait_for_tran_end (thread_p, writer_mvccid, find_unique_helper, leaf_page, overflow_page,
+					  restart);
+    }
+
+  if (satisfies_delete == DELETE_RECORD_DELETE_IN_PROGRESS)
+    {
+      /* Verdict is stale: the deleter ended in the race and may have freed an object this scan locked. */
+      btree_key_release_locked_object_and_pages (thread_p, find_unique_helper, leaf_page, overflow_page);
+      *restart = true;
+    }
+
+  return NO_ERROR;
+}
+
+/*
+ * btree_key_wait_for_tran_end () - Wait for the writer working under the given MVCCID to end,
+ *				    then signal a restart from root.
+ *
+ * return	       : Error code (NO_ERROR on success, with *restart set to true).
+ * thread_p (in)       : Thread entry.
+ * writer_mvccid (in)  : MVCCID of the in-progress inserter or deleter to wait on.
+ * find_unique_helper (in/out) : Find-unique state; any object it has locked is released first.  NULL
+ *			       when the caller holds no object lock -- the stamp path comes in that way.
+ * leaf_page (in/out)  : Leaf node page latch; unfixed before suspending and left NULL.
+ * overflow_page (in/out) : Optional overflow node page latch (..._of_non_unique () scans overflow pages);
+ *			    unfixed before suspending and left NULL. NULL when there is no overflow page.
+ * restart (out)       : Set to true so the caller re-reads the key from root.
+ *
+ * Note: all page latches must be released before blocking on the lock (never wait while holding a latch).
+ */
+int
+btree_key_wait_for_tran_end (THREAD_ENTRY *thread_p, MVCCID writer_mvccid,
+			     BTREE_FIND_UNIQUE_HELPER *find_unique_helper, PAGE_PTR *leaf_page,
+			     PAGE_PTR *overflow_page, bool *restart)
+{
+  int error_code = NO_ERROR;
+
+  /* Release the locked object and the page latches before blocking on the lock. */
+  btree_key_release_locked_object_and_pages (thread_p, find_unique_helper, leaf_page, overflow_page);
+
+  error_code = logtb_wait_for_tran_end (thread_p, writer_mvccid);
+  if (error_code != NO_ERROR)
+    {
+      return error_code;
+    }
+
+  /* The page may have changed during the wait, so re-read the key from root. */
+  *restart = true;
+  return NO_ERROR;
+}
+
+/*
+ * btree_key_release_locked_object_and_pages () - Drop what this scan holds on the key: the object it
+ *						  locked and the page latches. The caller re-reads from root.
+ *
+ * thread_p (in)       : Thread entry.
+ * find_unique_helper (in/out) : Find-unique state; any object it has locked is released and forgotten.
+ *			       NULL when the caller holds no object lock, only page latches.
+ * leaf_page (in/out)  : Leaf node page latch; unfixed and left NULL.
+ * overflow_page (in/out) : Optional overflow node page latch; unfixed and left NULL, NULL when there is none.
+ */
+static void
+btree_key_release_locked_object_and_pages (THREAD_ENTRY *thread_p, BTREE_FIND_UNIQUE_HELPER *find_unique_helper,
+    PAGE_PTR *leaf_page, PAGE_PTR *overflow_page)
+{
+  if (find_unique_helper != NULL && !OID_ISNULL (&find_unique_helper->locked_oid))
+    {
+      lock_unlock_object_donot_move_to_non2pl (thread_p, &find_unique_helper->locked_oid,
+	  &find_unique_helper->locked_class_oid, find_unique_helper->lock_mode);
+      OID_SET_NULL (&find_unique_helper->locked_oid);
+    }
+  if (overflow_page != NULL && *overflow_page != NULL)
+    {
+      pgbuf_unfix_and_init (thread_p, *overflow_page);
+    }
+  pgbuf_unfix_and_init (thread_p, *leaf_page);
+}
+#endif /* SERVER_MODE */

--- a/src/storage/btree_object_lock.hpp
+++ b/src/storage/btree_object_lock.hpp
@@ -1,0 +1,90 @@
+/*
+ *
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+//
+// Object locking through a b-tree key - taking the lock, and waiting out a writer that holds it
+//
+
+#ifndef _BTREE_OBJECT_LOCK_HPP_
+#define _BTREE_OBJECT_LOCK_HPP_
+
+#if !defined (SERVER_MODE) && !defined (SA_MODE)
+#error Belongs to server module
+#endif /* !defined (SERVER_MODE) && !defined (SA_MODE) */
+
+#include "lock_manager.h"
+#include "mvcc.h"
+#include "oid.h"
+#include "perf_monitor.h"
+#include "storage_common.h"
+#include "thread_compat.hpp"
+
+/* BTREE_FIND_UNIQUE_HELPER - State carried through a unique-key probe: what to match, what was found,
+ *			      and what this scan has locked and must release if it restarts.
+ */
+typedef struct btree_find_unique_helper BTREE_FIND_UNIQUE_HELPER;
+struct btree_find_unique_helper
+{
+  OID oid;			/* OID of found object (if found). */
+  OID match_class_oid;		/* Object is only considered if its class OID matches this class OID. */
+  LOCK lock_mode;		/* Lock mode for found unique object. */
+  MVCC_SNAPSHOT *snapshot;	/* Snapshot used to filter objects not visible. If NULL, objects are not filtered. */
+  bool found_object;		/* Set to true if object was found. */
+
+  PERF_UTIME_TRACKER time_track;
+
+#if defined (SERVER_MODE)
+  OID locked_oid;		/* Locked object. */
+  OID locked_class_oid;		/* Locked object class OID. */
+#endif				/* SERVER_MODE */
+};
+/* BTREE_FIND_UNIQUE_HELPER static initializer. */
+#if defined (SERVER_MODE)
+#define BTREE_FIND_UNIQUE_HELPER_INITIALIZER \
+  { OID_INITIALIZER, /* oid */ \
+    OID_INITIALIZER, /* match_class_oid */ \
+    NULL_LOCK, /* lock_mode */ \
+    NULL, /* snapshot */ \
+    false, /* found_object */ \
+    PERF_UTIME_TRACKER_INITIALIZER, /* time_track */ \
+    OID_INITIALIZER, /* locked_oid */ \
+    OID_INITIALIZER /* locked_class_oid */ \
+  }
+#else	/* !SERVER_MODE */		   /* SA_MODE */
+#define BTREE_FIND_UNIQUE_HELPER_INITIALIZER \
+  { OID_INITIALIZER, /* oid */ \
+    OID_INITIALIZER, /* match_class_oid */ \
+    NULL_LOCK, /* lock_mode */ \
+    NULL, /* snapshot */ \
+    false, /* found_object */ \
+    PERF_UTIME_TRACKER_INITIALIZER /* time_track */ \
+  }
+#endif /* !SA_MODE */
+
+#if defined (SERVER_MODE)
+extern int btree_key_wait_out_conflicting_writer (THREAD_ENTRY *thread_p,
+    MVCC_SATISFIES_DELETE_RESULT satisfies_delete,
+    MVCC_REC_HEADER *mvcc_header,
+    BTREE_FIND_UNIQUE_HELPER *find_unique_helper,
+    PAGE_PTR *leaf_page, PAGE_PTR *overflow_page, bool *restart);
+extern int btree_key_wait_for_tran_end (THREAD_ENTRY *thread_p, MVCCID writer_mvccid,
+					BTREE_FIND_UNIQUE_HELPER *find_unique_helper, PAGE_PTR *leaf_page,
+					PAGE_PTR *overflow_page, bool *restart);
+#endif /* SERVER_MODE */
+
+#endif /* _BTREE_OBJECT_LOCK_HPP_ */

--- a/src/storage/compactdb_sr.c
+++ b/src/storage/compactdb_sr.c
@@ -259,7 +259,7 @@ process_object (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * upd_scancache, HEAP_CA
 	locator_attribute_info_force (thread_p, &upd_scancache->node.hfid, oid, attr_info, atts_id, updated_n_attrs_id,
 				      LC_FLUSH_UPDATE, SINGLE_ROW_UPDATE, upd_scancache, &force_count, false,
 				      REPL_INFO_TYPE_RBR_NORMAL, DB_NOT_PARTITIONED_CLASS, NULL, NULL, NULL,
-				      UPDATE_INPLACE_NONE, &copy_recdes, false);
+				      UPDATE_INPLACE_NONE, &copy_recdes, LOCATOR_LOCK_AT_SELECT);
       if (error_code != NO_ERROR)
 	{
 	  if (error_code == ER_MVCC_NOT_SATISFIED_REEVALUATION)

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -23576,6 +23576,17 @@ heap_delete_logical (THREAD_ENTRY * thread_p, HEAP_OPERATION_CONTEXT * context)
     {
       is_mvcc_op = true;
     }
+
+  /* late arrivals settle a DELETE_IN_PROGRESS row against the deleter's MVCCID self-lock, so it must be
+   * held before the DELID stamp becomes observable */
+  if (is_mvcc_op)
+    {
+      rc = logtb_ensure_mvccid_self_lock (thread_p);
+      if (rc != NO_ERROR)
+	{
+	  return rc;
+	}
+    }
 #else /* SERVER_MODE */
   is_mvcc_op = false;
 #endif /* SERVER_MODE */

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -18015,7 +18015,7 @@ heap_object_upgrade_domain (THREAD_ENTRY * thread_p, HEAP_SCANCACHE * upd_scanca
     locator_attribute_info_force (thread_p, &upd_scancache->node.hfid, oid, attr_info, atts_id, updated_n_attrs_id,
 				  LC_FLUSH_UPDATE, SINGLE_ROW_UPDATE, upd_scancache, &force_count, false,
 				  REPL_INFO_TYPE_RBR_NORMAL, DB_NOT_PARTITIONED_CLASS, NULL, NULL, NULL,
-				  UPDATE_INPLACE_OLD_MVCCID, NULL, false);
+				  UPDATE_INPLACE_OLD_MVCCID, NULL, LOCATOR_LOCK_AT_SELECT);
   if (error != NO_ERROR)
     {
       if (error == ER_MVCC_NOT_SATISFIED_REEVALUATION)

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -151,19 +151,20 @@ static int locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * cla
 				 HEAP_SCANCACHE * scan_cache, int *force_count, bool not_check_fk,
 				 REPL_INFO_TYPE repl_info_type, int pruning_type, PRUNING_CONTEXT * pcontext,
 				 MVCC_REEV_DATA * mvcc_reev_data, UPDATE_INPLACE_STYLE force_in_place,
-				 bool need_locking);
+				 LOCATOR_LOCK_POLICY lock_policy);
 static int locator_move_record (THREAD_ENTRY * thread_p, HFID * old_hfid, OID * old_class_oid, OID * obj_oid,
 				OID * new_class_oid, HFID * new_class_hfid, RECDES * recdes,
 				HEAP_SCANCACHE * scan_cache, int op_type, int has_index, int *force_count,
-				PRUNING_CONTEXT * context, MVCC_REEV_DATA * mvcc_reev_data, bool need_locking);
+				PRUNING_CONTEXT * context, MVCC_REEV_DATA * mvcc_reev_data,
+				LOCATOR_LOCK_POLICY lock_policy);
 static int locator_delete_force_for_moving (THREAD_ENTRY * thread_p, HFID * hfid, OID * oid, int has_index, int op_type,
 					    HEAP_SCANCACHE * scan_cache, int *force_count,
 					    MVCC_REEV_DATA * mvcc_reev_data, OID * new_obj_oid, OID * partition_oid,
-					    bool need_locking);
+					    LOCATOR_LOCK_POLICY lock_policy);
 static int locator_delete_force_internal (THREAD_ENTRY * thread_p, HFID * hfid, OID * oid, int has_index, int op_type,
 					  HEAP_SCANCACHE * scan_cache, int *force_count,
 					  MVCC_REEV_DATA * mvcc_reev_data, LOCATOR_INDEX_ACTION_FLAG idx_action_flag,
-					  OID * new_obj_oid, OID * partition_oid, bool need_locking);
+					  OID * new_obj_oid, OID * partition_oid, LOCATOR_LOCK_POLICY lock_policy);
 static int locator_force_for_multi_update (THREAD_ENTRY * thread_p, LC_COPYAREA * force_area);
 
 #if defined(ENABLE_UNUSED_FUNCTION)
@@ -217,7 +218,7 @@ static void locator_generate_class_pseudo_oid (THREAD_ENTRY * thread_p, OID * cl
 
 static int redistribute_partition_data (THREAD_ENTRY * thread_p, OID * class_oid, int no_oids, OID * oid_list);
 static SCAN_CODE locator_lock_and_get_object_internal (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context,
-						       LOCK lock_mode);
+						       LOCK lock_mode, bool transient);
 static DB_LOGICAL locator_mvcc_reev_cond_assigns (THREAD_ENTRY * thread_p, OID * class_oid, const OID * oid,
 						  HEAP_SCANCACHE * scan_cache, RECDES * recdes,
 						  MVCC_UPDDEL_REEV_DATA * mvcc_reev_data);
@@ -4467,7 +4468,7 @@ locator_check_primary_key_delete (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 		      /* oid already locked at locator_lock_and_get_object */
 		      error_code =
 			locator_delete_force (thread_p, &hfid, oid_ptr, true, SINGLE_ROW_DELETE, &scan_cache,
-					      &force_count, NULL, false);
+					      &force_count, NULL, LOCATOR_LOCK_AT_SELECT);
 		      if (error_code == ER_MVCC_NOT_SATISFIED_REEVALUATION)
 			{
 			  /* skip foreign keys that were already deleted. For example the "cross type" reference */
@@ -4499,7 +4500,7 @@ locator_check_primary_key_delete (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 			locator_attribute_info_force (thread_p, &hfid, oid_ptr, &attr_info, attr_ids, index->n_atts,
 						      LC_FLUSH_UPDATE, SINGLE_ROW_UPDATE, &scan_cache, &force_count,
 						      false, REPL_INFO_TYPE_RBR_NORMAL, DB_NOT_PARTITIONED_CLASS, NULL,
-						      NULL, NULL, UPDATE_INPLACE_NONE, &recdes, false);
+						      NULL, NULL, UPDATE_INPLACE_NONE, &recdes, LOCATOR_LOCK_AT_SELECT);
 		      if (error_code != NO_ERROR)
 			{
 			  if (error_code == ER_MVCC_NOT_SATISFIED_REEVALUATION)
@@ -4840,7 +4841,7 @@ locator_check_primary_key_update (THREAD_ENTRY * thread_p, OR_INDEX * index, DB_
 		    locator_attribute_info_force (thread_p, &hfid, oid_ptr, &attr_info, attr_ids, index->n_atts,
 						  LC_FLUSH_UPDATE, SINGLE_ROW_UPDATE, &scan_cache, &force_count, false,
 						  REPL_INFO_TYPE_RBR_NORMAL, DB_NOT_PARTITIONED_CLASS, NULL, NULL, NULL,
-						  UPDATE_INPLACE_NONE, &recdes, false);
+						  UPDATE_INPLACE_NONE, &recdes, LOCATOR_LOCK_AT_SELECT);
 		  if (error_code != NO_ERROR)
 		    {
 		      if (error_code == ER_MVCC_NOT_SATISFIED_REEVALUATION)
@@ -5285,7 +5286,7 @@ error2:
  * force_count (in/out)	:
  * context(in)	        : pruning context
  * mvcc_reev_data(in)	: MVCC reevaluation data
- * need_locking(in)	: true, if need locking
+ * lock_policy(in)	: where the row lock is taken and how long it is kept
  *
  * Note: this function calls locator_delete_force on the current object oid
  * and locator_insert_force for the RECDES it receives. The record has already
@@ -5295,7 +5296,8 @@ error2:
 static int
 locator_move_record (THREAD_ENTRY * thread_p, HFID * old_hfid, OID * old_class_oid, OID * obj_oid, OID * new_class_oid,
 		     HFID * new_class_hfid, RECDES * recdes, HEAP_SCANCACHE * scan_cache, int op_type, int has_index,
-		     int *force_count, PRUNING_CONTEXT * context, MVCC_REEV_DATA * mvcc_reev_data, bool need_locking)
+		     int *force_count, PRUNING_CONTEXT * context, MVCC_REEV_DATA * mvcc_reev_data,
+		     LOCATOR_LOCK_POLICY lock_policy)
 {
   int error = NO_ERROR;
   OID new_obj_oid;
@@ -5350,7 +5352,7 @@ locator_move_record (THREAD_ENTRY * thread_p, HFID * old_hfid, OID * old_class_o
   /* delete this record from the class it currently resides in */
   error =
     locator_delete_force_for_moving (thread_p, old_hfid, obj_oid, true, op_type, scan_cache, force_count,
-				     mvcc_reev_data, &new_obj_oid, new_class_oid, need_locking);
+				     mvcc_reev_data, &new_obj_oid, new_class_oid, lock_policy);
   if (error != NO_ERROR)
     {
       return error;
@@ -5397,7 +5399,7 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 		      RECDES * recdes, int has_index, ATTR_ID * att_id, int n_att_id, int op_type,
 		      HEAP_SCANCACHE * scan_cache, int *force_count, bool not_check_fk, REPL_INFO_TYPE repl_info_type,
 		      int pruning_type, PRUNING_CONTEXT * pcontext, MVCC_REEV_DATA * mvcc_reev_data,
-		      UPDATE_INPLACE_STYLE force_in_place, bool need_locking)
+		      UPDATE_INPLACE_STYLE force_in_place, LOCATOR_LOCK_POLICY lock_policy)
 {
   OID rep_dir = { NULL_PAGEID, NULL_SLOTID, NULL_VOLID };
   char *rep_dir_offset;
@@ -5716,11 +5718,11 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 		  mvcc_reev_data->upddel_reev_data->new_recdes = recdes;
 		}
 
-	      if (need_locking)
+	      if (lock_policy != LOCATOR_LOCK_AT_SELECT)
 		{
 		  scan = locator_lock_and_get_object_with_evaluation (thread_p, oid, class_oid, &copy_recdes,
 								      local_scan_cache, COPY, NULL_CHN, mvcc_reev_data,
-								      LOG_ERROR_IF_DELETED);
+								      LOG_ERROR_IF_DELETED, false);
 		}
 	      else
 		{
@@ -5951,7 +5953,7 @@ locator_update_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * class_oid, OID
 
 	      error_code =
 		locator_move_record (thread_p, hfid, class_oid, oid, &real_class_oid, &real_hfid, recdes, scan_cache,
-				     op_type, has_index, force_count, pcontext, mvcc_reev_data, need_locking);
+				     op_type, has_index, force_count, pcontext, mvcc_reev_data, lock_policy);
 	      if (error_code == NO_ERROR)
 		{
 		  COPY_OID (class_oid, &real_class_oid);
@@ -6097,6 +6099,53 @@ error:
 }
 
 /*
+ * locator_class_has_online_index () - is an index of this class being built online?
+ *   return: true when at least one index is in OR_ONLINE_INDEX_BUILDING_IN_PROGRESS
+ *   thread_p(in): thread entry
+ *   class_oid(in): the class
+ *
+ * Note: an online build keeps its own state on each index entry -- INSERT_FLAG, DELETE_FLAG, or
+ *	 neither -- and that state carries no MVCCID: it names neither the transaction that left it nor
+ *	 whether that transaction ended.  The row lock is what keeps two writers from reading the same
+ *	 entry under different assumptions, so a class under an online build keeps it to commit.
+ *
+ *	 One answer per class holds for the whole statement, and not because the build holds a strong
+ *	 lock throughout -- it demotes to IX for the load precisely so DML is not blocked.  It holds
+ *	 because the status is published by a schema change under SCH_M, and a DML statement holds IX on
+ *	 the class to commit: no statement spans that publication.  A caller that cannot read the class
+ *	 representation is told to keep the lock.
+ */
+bool
+locator_class_has_online_index (THREAD_ENTRY * thread_p, const OID * class_oid)
+{
+  OR_CLASSREP *classrep = NULL;
+  int idx_in_cache = -1;
+  bool found = false;
+  int i;
+
+  assert (class_oid != NULL && !OID_ISNULL (class_oid));
+
+  classrep = heap_classrepr_get (thread_p, (OID *) class_oid, NULL, NULL_REPRID, &idx_in_cache);
+  if (classrep == NULL)
+    {
+      return true;
+    }
+
+  for (i = 0; i < classrep->n_indexes; i++)
+    {
+      if (classrep->indexes[i].index_status == OR_ONLINE_INDEX_BUILDING_IN_PROGRESS)
+	{
+	  found = true;
+	  break;
+	}
+    }
+
+  heap_classrepr_free_and_init (classrep, &idx_in_cache);
+
+  return found;
+}
+
+/*
  * locator_delete_force () - Delete the given object
  *
  * return: NO_ERROR if all OK, ER_ status otherwise
@@ -6108,16 +6157,17 @@ error:
  *   scan_cache(in/out): Scan cache used to estimate the best space pages between heap changes.
  *   force_count(in):
  *   mvcc_reev_data(in): MVCC data
- *   need_locking(in): true, if need locking
+ *   lock_policy(in): where the row lock is taken and how long it is kept
  *
  * Note: The given object is deleted on this heap and all appropiate index entries are deleted.
  */
 int
 locator_delete_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * oid, int has_index, int op_type,
-		      HEAP_SCANCACHE * scan_cache, int *force_count, MVCC_REEV_DATA * mvcc_reev_data, bool need_locking)
+		      HEAP_SCANCACHE * scan_cache, int *force_count, MVCC_REEV_DATA * mvcc_reev_data,
+		      LOCATOR_LOCK_POLICY lock_policy)
 {
   return locator_delete_force_internal (thread_p, hfid, oid, has_index, op_type, scan_cache, force_count,
-					mvcc_reev_data, FOR_INSERT_OR_DELETE, NULL, NULL, need_locking);
+					mvcc_reev_data, FOR_INSERT_OR_DELETE, NULL, NULL, lock_policy);
 }
 
 /*
@@ -6136,17 +6186,17 @@ locator_delete_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * oid, int has_i
  *   mvcc_reev_data(in): MVCC data
  *   new_obj_oid(in): next version - only to be used with records relocated in other partitions, in MVCC.
  *   partition_oid(in): new partition class oid
- *   need_locking(in): true, if need locking
+ *   lock_policy(in): where the row lock is taken and how long it is kept
  *
  * Note: The given object is deleted on this heap and all appropriate index entries are deleted.
  */
 static int
 locator_delete_force_for_moving (THREAD_ENTRY * thread_p, HFID * hfid, OID * oid, int has_index, int op_type,
 				 HEAP_SCANCACHE * scan_cache, int *force_count, MVCC_REEV_DATA * mvcc_reev_data,
-				 OID * new_obj_oid, OID * partition_oid, bool need_locking)
+				 OID * new_obj_oid, OID * partition_oid, LOCATOR_LOCK_POLICY lock_policy)
 {
   return locator_delete_force_internal (thread_p, hfid, oid, has_index, op_type, scan_cache, force_count,
-					mvcc_reev_data, FOR_MOVE, new_obj_oid, partition_oid, need_locking);
+					mvcc_reev_data, FOR_MOVE, new_obj_oid, partition_oid, lock_policy);
 }
 
 /*
@@ -6164,7 +6214,7 @@ locator_delete_force_for_moving (THREAD_ENTRY * thread_p, HFID * hfid, OID * oid
  *			  'UPDATE ... SET ...', NOT 'DELETE FROM ...'
  *   new_obj_oid(in): next version - only to be used with records relocated in other partitions, in MVCC.
  *   partition_oid(in): new partition class oid
- *   need_locking(in): true, if need locking
+ *   lock_policy(in): where the row lock is taken and how long it is kept
  *
  * Note: The given object is deleted on this heap and all appropriate index entries are deleted.
  */
@@ -6172,7 +6222,7 @@ static int
 locator_delete_force_internal (THREAD_ENTRY * thread_p, HFID * hfid, OID * oid, int has_index, int op_type,
 			       HEAP_SCANCACHE * scan_cache, int *force_count, MVCC_REEV_DATA * mvcc_reev_data,
 			       LOCATOR_INDEX_ACTION_FLAG idx_action_flag, OID * new_obj_oid, OID * partition_oid,
-			       bool need_locking)
+			       LOCATOR_LOCK_POLICY lock_policy)
 {
   bool isold_object;		/* Make sure that this is an old object during the deletion */
   OID class_oid = { NULL_PAGEID, NULL_SLOTID, NULL_VOLID };
@@ -6198,17 +6248,18 @@ locator_delete_force_internal (THREAD_ENTRY * thread_p, HFID * hfid, OID * oid, 
 
   copy_recdes.data = NULL;
 
-  if (need_locking == false)
+  if (lock_policy == LOCATOR_LOCK_AT_SELECT)
     {
       /* the reevaluation is not necessary if the object is already locked */
       mvcc_reev_data = NULL;
     }
 
-  /* IMPORTANT TODO: use a different get function when need_locking==false, but make sure it gets the last version,
+  /* IMPORTANT TODO: use a different get function when the select phase locked, but make sure it gets the last version,
      not the visible one; we need only the last version to use it to retrieve the last version of the btree key */
   scan_code =
     locator_lock_and_get_object_with_evaluation (thread_p, oid, &class_oid, &copy_recdes, scan_cache, COPY, NULL_CHN,
-						 mvcc_reev_data, LOG_WARNING_IF_DELETED);
+						 mvcc_reev_data, LOG_WARNING_IF_DELETED,
+						 lock_policy == LOCATOR_LOCK_AT_FORCE_TRANSIENT);
 
   if (scan_code == S_SUCCESS && mvcc_reev_data != NULL && mvcc_reev_data->filter_result == V_FALSE)
     {
@@ -6661,7 +6712,7 @@ locator_force_for_multi_update (THREAD_ENTRY * thread_p, LC_COPYAREA * force_are
 	  error_code =
 	    locator_update_force (thread_p, &obj->hfid, &obj->class_oid, &obj->oid, NULL, &recdes,
 				  has_index, NULL, 0, MULTI_ROW_UPDATE, &scan_cache, &force_count, false, repl_info,
-				  DB_NOT_PARTITIONED_CLASS, NULL, NULL, UPDATE_INPLACE_NONE, true);
+				  DB_NOT_PARTITIONED_CLASS, NULL, NULL, UPDATE_INPLACE_NONE, LOCATOR_LOCK_AT_FORCE);
 	  if (error_code != NO_ERROR)
 	    {
 	      /*
@@ -7032,7 +7083,8 @@ xlocator_repl_force (THREAD_ENTRY * thread_p, LC_COPYAREA * force_area, LC_COPYA
 	      error_code =
 		locator_update_force (thread_p, &obj->hfid, &obj->class_oid, &obj->oid, NULL, &recdes, has_index,
 				      NULL, 0, SINGLE_ROW_UPDATE, force_scancache, &force_count, false,
-				      REPL_INFO_TYPE_RBR_NORMAL, pruning_type, NULL, NULL, UPDATE_INPLACE_NONE, true);
+				      REPL_INFO_TYPE_RBR_NORMAL, pruning_type, NULL, NULL, UPDATE_INPLACE_NONE,
+				      LOCATOR_LOCK_AT_FORCE);
 
 	      if (error_code == NO_ERROR)
 		{
@@ -7044,7 +7096,7 @@ xlocator_repl_force (THREAD_ENTRY * thread_p, LC_COPYAREA * force_area, LC_COPYA
 	    case LC_FLUSH_DELETE:
 	      error_code =
 		locator_delete_force (thread_p, &obj->hfid, &obj->oid, has_index, SINGLE_ROW_DELETE, force_scancache,
-				      &force_count, NULL, true);
+				      &force_count, NULL, LOCATOR_LOCK_AT_FORCE);
 
 	      if (error_code == NO_ERROR)
 		{
@@ -7227,7 +7279,8 @@ xlocator_force (THREAD_ENTRY * thread_p, LC_COPYAREA * force_area, int num_ignor
 	  error_code =
 	    locator_update_force (thread_p, &obj->hfid, &obj->class_oid, &obj->oid, NULL, &recdes,
 				  has_index, NULL, 0, SINGLE_ROW_UPDATE, force_scancache, &force_count, false,
-				  REPL_INFO_TYPE_RBR_NORMAL, pruning_type, NULL, NULL, UPDATE_INPLACE_NONE, true);
+				  REPL_INFO_TYPE_RBR_NORMAL, pruning_type, NULL, NULL, UPDATE_INPLACE_NONE,
+				  LOCATOR_LOCK_AT_FORCE);
 
 	  if (error_code == NO_ERROR)
 	    {
@@ -7239,7 +7292,7 @@ xlocator_force (THREAD_ENTRY * thread_p, LC_COPYAREA * force_area, int num_ignor
 	case LC_FLUSH_DELETE:
 	  error_code =
 	    locator_delete_force (thread_p, &obj->hfid, &obj->oid, has_index, SINGLE_ROW_DELETE, force_scancache,
-				  &force_count, NULL, true);
+				  &force_count, NULL, LOCATOR_LOCK_AT_FORCE);
 
 	  if (error_code == NO_ERROR)
 	    {
@@ -7451,7 +7504,7 @@ locator_allocate_copy_area_by_attr_info (THREAD_ENTRY * thread_p, HEAP_CACHE_ATT
  *			 forced and the update style will be decided in this
  *			 function. Otherwise the update of the instance will be
  *			 made in place and according to provided style.
- *  need_locking(in): true, if need locking
+ *  lock_policy(in): where the row lock is taken and how long it is kept
  *
  * Note: Force an object represented by an attribute information structure.
  *       For insert the oid is set as a side effect.
@@ -7463,7 +7516,8 @@ locator_attribute_info_force (THREAD_ENTRY * thread_p, const HFID * hfid, OID * 
 			      HEAP_SCANCACHE * scan_cache, int *force_count, bool not_check_fk,
 			      REPL_INFO_TYPE repl_info, int pruning_type, PRUNING_CONTEXT * pcontext,
 			      FUNC_PRED_UNPACK_INFO * func_preds, MVCC_REEV_DATA * mvcc_reev_data,
-			      UPDATE_INPLACE_STYLE force_update_inplace, RECDES * rec_descriptor, bool need_locking)
+			      UPDATE_INPLACE_STYLE force_update_inplace, RECDES * rec_descriptor,
+			      LOCATOR_LOCK_POLICY lock_policy)
 {
   LC_COPYAREA *copyarea = NULL;
   RECDES new_recdes;
@@ -7498,7 +7552,7 @@ locator_attribute_info_force (THREAD_ENTRY * thread_p, const HFID * hfid, OID * 
 	{
 	  copy_recdes = *rec_descriptor;
 	}
-      else if (HEAP_IS_UPDATE_INPLACE (force_update_inplace) || need_locking == false)
+      else if (HEAP_IS_UPDATE_INPLACE (force_update_inplace) || lock_policy == LOCATOR_LOCK_AT_SELECT)
 	{
 	  HEAP_GET_CONTEXT context;
 
@@ -7602,7 +7656,7 @@ locator_attribute_info_force (THREAD_ENTRY * thread_p, const HFID * hfid, OID * 
 	  error_code =
 	    locator_update_force (thread_p, &class_hfid, &class_oid, oid, old_recdes, &new_recdes, has_index,
 				  att_id, n_att_id, op_type, scan_cache, force_count, not_check_fk, repl_info,
-				  pruning_type, pcontext, mvcc_reev_data, force_update_inplace, need_locking);
+				  pruning_type, pcontext, mvcc_reev_data, force_update_inplace, lock_policy);
 	  if (error_code != NO_ERROR)
 	    {
 	      ASSERT_ERROR ();
@@ -7621,7 +7675,7 @@ locator_attribute_info_force (THREAD_ENTRY * thread_p, const HFID * hfid, OID * 
     case LC_FLUSH_DELETE:
       error_code =
 	locator_delete_force (thread_p, &class_hfid, oid, true, op_type, scan_cache, force_count, mvcc_reev_data,
-			      need_locking);
+			      lock_policy);
       break;
 
     default:
@@ -13098,7 +13152,8 @@ locator_has_isolation_conflict (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * cont
  * NOTE: Caller must handle the cleanup of context
  */
 static SCAN_CODE
-locator_lock_and_get_object_internal (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context, LOCK lock_mode)
+locator_lock_and_get_object_internal (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context, LOCK lock_mode,
+				      bool transient)
 {
   SCAN_CODE scan = S_SUCCESS;
   bool lock_acquired = false;
@@ -13113,7 +13168,8 @@ locator_lock_and_get_object_internal (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT 
 
   /* try to lock the object conditionally, if it fails unfix page watchers and try unconditionally */
 
-  if (lock_object (thread_p, context->oid_p, context->class_oid_p, lock_mode, LK_COND_LOCK) != LK_GRANTED)
+  if ((transient ? lock_object_transient : lock_object) (thread_p, context->oid_p, context->class_oid_p, lock_mode,
+							 LK_COND_LOCK) != LK_GRANTED)
     {
       if (context->scan_cache && context->scan_cache->cache_last_fix_page && context->home_page_watcher.pgptr != NULL)
 	{
@@ -13121,7 +13177,8 @@ locator_lock_and_get_object_internal (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT 
 	  pgbuf_ordered_unfix (thread_p, &context->home_page_watcher);
 	}
       heap_clean_get_context (thread_p, context);
-      if (lock_object (thread_p, context->oid_p, context->class_oid_p, lock_mode, LK_UNCOND_LOCK) != LK_GRANTED)
+      if ((transient ? lock_object_transient : lock_object) (thread_p, context->oid_p, context->class_oid_p,
+							     lock_mode, LK_UNCOND_LOCK) != LK_GRANTED)
 	{
 	  goto error;
 	}
@@ -13166,7 +13223,15 @@ error:
 
   if (lock_acquired)
     {
-      lock_unlock_object_donot_move_to_non2pl (thread_p, context->oid_p, context->class_oid_p, lock_mode);
+      /* undo the request we just made -- including the count it added, if it was a transient one */
+      if (transient)
+	{
+	  lock_unlock_object_transient (thread_p, context->oid_p, context->class_oid_p, lock_mode);
+	}
+      else
+	{
+	  lock_unlock_object_donot_move_to_non2pl (thread_p, context->oid_p, context->class_oid_p, lock_mode);
+	}
     }
 
   return (scan != S_SUCCESS && scan != S_SUCCESS_CHN_UPTODATE) ? scan : S_ERROR;
@@ -13194,7 +13259,7 @@ SCAN_CODE
 locator_lock_and_get_object_with_evaluation (THREAD_ENTRY * thread_p, OID * oid, OID * class_oid, RECDES * recdes,
 					     HEAP_SCANCACHE * scan_cache, int ispeeking, int old_chn,
 					     MVCC_REEV_DATA * mvcc_reev_data,
-					     NON_EXISTENT_HANDLING non_ex_handling_type)
+					     NON_EXISTENT_HANDLING non_ex_handling_type, bool transient)
 {
   HEAP_GET_CONTEXT context;
   SCAN_CODE scan = S_SUCCESS;
@@ -13255,7 +13320,7 @@ locator_lock_and_get_object_with_evaluation (THREAD_ENTRY * thread_p, OID * oid,
 	}
     }
 
-  scan = locator_lock_and_get_object_internal (thread_p, &context, lock_mode);
+  scan = locator_lock_and_get_object_internal (thread_p, &context, lock_mode, transient);
 
   /* perform reevaluation */
   if (mvcc_reev_data != NULL && (scan == S_SUCCESS || scan == S_SUCCESS_CHN_UPTODATE))
@@ -13294,7 +13359,14 @@ locator_lock_and_get_object_with_evaluation (THREAD_ENTRY * thread_p, OID * oid,
 	      if (skips_unevaluated_version)
 		{
 		  mvcc_reev_data->filter_result = V_FALSE;
-		  lock_unlock_object_donot_move_to_non2pl (thread_p, oid, class_oid, lock_mode);
+		  if (transient)
+		    {
+		      lock_unlock_object_transient (thread_p, oid, class_oid, lock_mode);
+		    }
+		  else
+		    {
+		      lock_unlock_object_donot_move_to_non2pl (thread_p, oid, class_oid, lock_mode);
+		    }
 		  goto exit;
 		}
 	    }
@@ -13303,7 +13375,14 @@ locator_lock_and_get_object_with_evaluation (THREAD_ENTRY * thread_p, OID * oid,
       if (ev_res != V_TRUE)
 	{
 	  /* did not pass the evaluation or error occurred - unlock object */
-	  lock_unlock_object_donot_move_to_non2pl (thread_p, oid, class_oid, lock_mode);
+	  if (transient)
+	    {
+	      lock_unlock_object_transient (thread_p, oid, class_oid, lock_mode);
+	    }
+	  else
+	    {
+	      lock_unlock_object_donot_move_to_non2pl (thread_p, oid, class_oid, lock_mode);
+	    }
 	}
       switch (ev_res)
 	{
@@ -13439,7 +13518,7 @@ locator_get_object (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid, R
   else
     {
       /* Locking */
-      scan_code = locator_lock_and_get_object_internal (thread_p, &context, lock_mode);
+      scan_code = locator_lock_and_get_object_internal (thread_p, &context, lock_mode, false);
     }
 
   heap_clean_get_context (thread_p, &context);
@@ -13482,7 +13561,7 @@ locator_lock_and_get_object (THREAD_ENTRY * thread_p, const OID * oid, OID * cla
     }
 
   heap_init_get_context (thread_p, &context, oid, class_oid, recdes, scan_cache, ispeeking, old_chn);
-  scan_code = locator_lock_and_get_object_internal (thread_p, &context, lock);
+  scan_code = locator_lock_and_get_object_internal (thread_p, &context, lock, false);
   heap_clean_get_context (thread_p, &context);
   return scan_code;
 }

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -13205,6 +13205,14 @@ locator_lock_and_get_object_with_evaluation (THREAD_ENTRY * thread_p, OID * oid,
   LOCK lock_mode = X_LOCK;
   int err = NO_ERROR;
 
+  if (mvcc_reev_data != NULL)
+    {
+      /* The verdict below belongs to this fetch alone. An object whose last version is visible is not
+       * reevaluated at all, so without this a previous object's V_FALSE would be read back as this one's
+       * and the caller would skip an object that never failed anything. */
+      mvcc_reev_data->filter_result = V_TRUE;
+    }
+
   if (recdes == NULL && mvcc_reev_data != NULL)
     {
       /* peek if only for reevaluation */
@@ -13275,6 +13283,20 @@ locator_lock_and_get_object_with_evaluation (THREAD_ENTRY * thread_p, OID * oid,
 	      /* Skip the re-evaluation if last version is visible. It should be the same as the visible version
 	       * which was already evaluated. */
 	      goto exit;
+	    }
+	  else
+	    {
+	      /* the DELETE path sets this when the statement has no reevaluation class to re-check with */
+	      bool skips_unevaluated_version =
+		(mvcc_reev_data->type == REEV_DATA_UPDDEL && mvcc_reev_data->upddel_reev_data != NULL
+		 && mvcc_reev_data->upddel_reev_data->skip_unevaluated_version);
+
+	      if (skips_unevaluated_version)
+		{
+		  mvcc_reev_data->filter_result = V_FALSE;
+		  lock_unlock_object_donot_move_to_non2pl (thread_p, oid, class_oid, lock_mode);
+		  goto exit;
+		}
 	    }
 	}
       ev_res = locator_mvcc_reev_cond_and_assignment (thread_p, scan_cache, mvcc_reev_data, &mvcc_header, oid, recdes);
@@ -13684,15 +13706,29 @@ locator_mvcc_reeval_scan_filters (THREAD_ENTRY * thread_p, const OID * oid, HEAP
   cls_oid = &mvcc_cond_reeval->cls_oid;
   if (!is_upddel)
     {
-      /* the class is different than the class to be updated/deleted, so use the latest version of row */
+      /* Not the class being updated/deleted: re-read its own row out of its own heap.  Evaluating this
+       * class's filters against the target's record instead is what let a join DELETE act on rows whose
+       * predicate no longer held.  The read carries no snapshot, so a version a concurrent transaction
+       * deleted still reads; a failure here means the slot itself is gone. */
       recdesp = &temp_recdes;
-      oid_inst = oid;
-      if (heap_scancache_quick_start_with_class_hfid (thread_p, &local_scan_cache, &scan_cache->node.hfid) != NO_ERROR)
+      oid_inst = mvcc_cond_reeval->inst_oid;
+      if (oid_inst == NULL || OID_ISNULL (oid_inst))
+	{
+	  /* the plan flagged this class for reevaluation but the scan bound no row of it to re-read.  The
+	   * caller asserts an error is set on V_ERROR, so say what went wrong rather than return silently. */
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_GENERIC_ERROR, 0);
+	  ev_res = V_ERROR;
+	  goto end;
+	}
+
+      if (heap_scancache_quick_start_with_class_hfid (thread_p, &local_scan_cache, &mvcc_cond_reeval->cls_hfid)
+	  != NO_ERROR)
 	{
 	  ev_res = V_ERROR;
 	  goto end;
 	}
       scan_cache_inited = true;
+
       scan_code = heap_get_visible_version (thread_p, oid_inst, NULL, recdesp, &local_scan_cache, PEEK, NULL_CHN);
       if (scan_code != S_SUCCESS)
 	{
@@ -13716,7 +13752,9 @@ locator_mvcc_reeval_scan_filters (THREAD_ENTRY * thread_p, const OID * oid, HEAP
 	  goto end;
 	}
 
-      if (fetch_val_list (thread_p, mvcc_cond_reeval->rest_regu_list, NULL, cls_oid, (OID *) oid_inst, NULL, PEEK)
+      /* Copy, do not peek: these values feed assignments the caller computes after this returns, and a record
+       * read out of another class's heap points into a page that end: unfixes below. */
+      if (fetch_val_list (thread_p, mvcc_cond_reeval->rest_regu_list, NULL, cls_oid, (OID *) oid_inst, NULL, false)
 	  != NO_ERROR)
 	{
 	  ev_res = V_ERROR;

--- a/src/transaction/locator_sr.c
+++ b/src/transaction/locator_sr.c
@@ -12942,9 +12942,155 @@ xlocator_redistribute_partition_data (THREAD_ENTRY * thread_p, OID * class_oid, 
 }
 
 /*
+ * locator_get_settled_last_version () - Read the locked object's last version and its MVCC header
+ *
+ * return	       : S_SUCCESS or S_SUCCESS_CHN_UPTODATE on success.
+ * thread_p (in)       :
+ * context (in/out)    : Heap get context.
+ * is_mvcc_class (in)  : False when MVCC does not apply, and then no header is read.
+ * recdes_header (out) : MVCC header of the version read.
+ *
+ * Note: settled means no delete is left undecided. A deleter holds no row lock and may still roll back,
+ *	 so it is waited out and the version read again; our row lock bounds that to one wait.
+ */
+static SCAN_CODE
+locator_get_settled_last_version (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context, bool is_mvcc_class,
+				  MVCC_REC_HEADER * recdes_header)
+{
+  SCAN_CODE scan = S_SUCCESS;
+
+  while (true)
+    {
+      if (context->recdes_p != NULL)
+	{
+	  scan = heap_get_last_version (thread_p, context);
+	  if (scan != S_SUCCESS && scan != S_SUCCESS_CHN_UPTODATE)
+	    {
+	      return scan;
+	    }
+	}
+
+      if (!is_mvcc_class)
+	{
+	  return scan;
+	}
+
+      if (context->recdes_p == NULL || scan == S_SUCCESS_CHN_UPTODATE)
+	{
+	  if (heap_prepare_get_context (thread_p, context, false, LOG_WARNING_IF_DELETED) != S_SUCCESS)
+	    {
+	      return S_ERROR;
+	    }
+	  if (heap_get_mvcc_header (thread_p, context, recdes_header) != S_SUCCESS)
+	    {
+	      return S_ERROR;
+	    }
+	}
+      else if (or_mvcc_get_header (context->recdes_p, recdes_header) != NO_ERROR)
+	{
+	  return S_ERROR;
+	}
+
+#if defined (SERVER_MODE)
+      if (MVCC_IS_HEADER_DELID_VALID (recdes_header)
+	  && logtb_is_active_other_mvccid (thread_p, MVCC_GET_DELID (recdes_header)))
+	{
+	  MVCCID deleter_mvccid = MVCC_GET_DELID (recdes_header);
+
+	  if (context->scan_cache != NULL && context->scan_cache->cache_last_fix_page
+	      && context->home_page_watcher.pgptr != NULL)
+	    {
+	      /* Prevent caching home page watcher in scan_cache: the wait below must not hold a page fixed. */
+	      pgbuf_ordered_unfix (thread_p, &context->home_page_watcher);
+	    }
+	  heap_clean_get_context (thread_p, context);
+	  if (logtb_wait_for_tran_end (thread_p, deleter_mvccid) != NO_ERROR)
+	    {
+	      return S_ERROR;
+	    }
+
+	  scan = heap_prepare_get_context (thread_p, context, false, LOG_WARNING_IF_DELETED);
+	  if (scan != S_SUCCESS)
+	    {
+	      return scan;
+	    }
+	  continue;
+	}
+#endif /* SERVER_MODE */
+
+      return scan;
+    }
+}
+
+/*
+ * locator_has_isolation_conflict () - Is modifying the locked object an isolation conflict?
+ *
+ * return	       : True on conflict, false otherwise.
+ * thread_p (in)       :
+ * context (in)	       : Heap get context.
+ * recdes_header (in)  : MVCC header of the version to be modified.
+ * conflict_scan (out) : The code to fail with -- S_DOESNT_EXIST for a version that is gone, S_ERROR for
+ *			 a conflict, whose error is set. Written only on conflict, so a false return leaves
+ *			 the caller's own scan code intact.
+ */
+static bool
+locator_has_isolation_conflict (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT * context, MVCC_REC_HEADER * recdes_header,
+				SCAN_CODE * conflict_scan)
+{
+  /* Check REPEATABLE READ/SERIALIZABLE isolation restrictions. */
+  if (logtb_find_current_isolation (thread_p) > TRAN_READ_COMMITTED
+      && logtb_check_class_for_rr_isolation_err (context->class_oid_p))
+    {
+      /* In these isolation levels, the transaction is not allowed to modify an object that was already
+       * modified by other transactions. This would be true if last version matched the visible version.
+       *
+       * TODO: We already know here that this last row version is not deleted. It would be enough to just
+       * check whether the insert MVCCID is considered active relatively to transaction's snapshot.
+       */
+      MVCC_SNAPSHOT *tran_snapshot = logtb_get_mvcc_snapshot (thread_p);
+      MVCC_SATISFIES_SNAPSHOT_RESULT snapshot_res;
+
+      assert (tran_snapshot != NULL && tran_snapshot->snapshot_fnc != NULL);
+      snapshot_res = tran_snapshot->snapshot_fnc (thread_p, recdes_header, tran_snapshot);
+      if (snapshot_res == TOO_OLD_FOR_SNAPSHOT)
+	{
+	  /* Not visible. */
+	  er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, ER_HEAP_UNKNOWN_OBJECT, 3, context->oid_p->volid,
+		  context->oid_p->pageid, context->oid_p->slotid);
+	  *conflict_scan = S_DOESNT_EXIST;
+	  return true;
+	}
+      else if (snapshot_res == TOO_NEW_FOR_SNAPSHOT)
+	{
+	  /* Trying to modify a version already modified by concurrent transaction, which is an isolation conflict.
+	   */
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_MVCC_SERIALIZABLE_CONFLICT, 0);
+	  *conflict_scan = S_ERROR;
+	  return true;
+	}
+      else if (MVCC_IS_HEADER_DELID_VALID (recdes_header))
+	{
+	  /* Trying to modify version deleted by concurrent transaction, which is an isolation conflict. */
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_MVCC_SERIALIZABLE_CONFLICT, 0);
+	  *conflict_scan = S_ERROR;
+	  return true;
+	}
+      /* Last version is also visible version and it is not deleted. Fall through. */
+    }
+
+  if (MVCC_IS_HEADER_DELID_VALID (recdes_header))
+    {
+      *conflict_scan = S_DOESNT_EXIST;
+      return true;
+    }
+
+  return false;
+}
+
+/*
  * locator_lock_and_get_object_internal () - Internal function: aquire lock and return object
  *
- * return : scan code
+ * return : Scan code; S_SUCCESS_CHN_UPTODATE from heap_get_last_version () is preserved to the caller.
  * thread_p (in)   :
  * context (in/out): Heap get context .
  * lock_mode (in)  : Type of lock.
@@ -12956,6 +13102,8 @@ locator_lock_and_get_object_internal (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT 
 {
   SCAN_CODE scan = S_SUCCESS;
   bool lock_acquired = false;
+  MVCC_REC_HEADER recdes_header;
+  bool is_mvcc_class;
 
   assert (context != NULL);
   assert (context->oid_p != NULL && !OID_ISNULL (context->oid_p));
@@ -12994,89 +13142,16 @@ locator_lock_and_get_object_internal (THREAD_ENTRY * thread_p, HEAP_GET_CONTEXT 
 
   assert (OID_IS_ROOTOID (context->class_oid_p) || lock_mode == S_LOCK || lock_mode == X_LOCK);
 
-  /* Lock should be aquired now -> get recdes */
-  if (context->recdes_p != NULL)
+  is_mvcc_class = !mvcc_is_mvcc_disabled_class (context->class_oid_p);
+  scan = locator_get_settled_last_version (thread_p, context, is_mvcc_class, &recdes_header);
+  if (scan != S_SUCCESS && scan != S_SUCCESS_CHN_UPTODATE)
     {
-      scan = heap_get_last_version (thread_p, context);
-      /* this scan_code must be preserved until the end of this function to be returned; - unless an error occur */
-      if (scan != S_SUCCESS && scan != S_SUCCESS_CHN_UPTODATE)
-	{
-	  goto error;
-	}
+      goto error;
     }
 
-  /* Check isolation restrictions and the visibility of the object if it belongs to a mvcc class */
-  if (!mvcc_is_mvcc_disabled_class (context->class_oid_p))
+  if (is_mvcc_class && locator_has_isolation_conflict (thread_p, context, &recdes_header, &scan))
     {
-      MVCC_REC_HEADER recdes_header;
-
-      /* get header: directly from recdes if it has been obtained, otherwise from heap */
-      if (context->recdes_p == NULL || scan == S_SUCCESS_CHN_UPTODATE)
-	{
-	  /* ensure context is prepared to get header of the record */
-	  if (heap_prepare_get_context (thread_p, context, false, LOG_WARNING_IF_DELETED) != S_SUCCESS)
-	    {
-	      scan = S_ERROR;
-	      goto error;
-	    }
-	  if (heap_get_mvcc_header (thread_p, context, &recdes_header) != S_SUCCESS)
-	    {
-	      scan = S_ERROR;
-	      goto error;
-	    }
-	}
-      else if (or_mvcc_get_header (context->recdes_p, &recdes_header) != NO_ERROR)
-	{
-	  goto error;
-	}
-
-      /* Check REPEATABLE READ/SERIALIZABLE isolation restrictions. */
-      if (logtb_find_current_isolation (thread_p) > TRAN_READ_COMMITTED
-	  && logtb_check_class_for_rr_isolation_err (context->class_oid_p))
-	{
-	  /* In these isolation levels, the transaction is not allowed to modify an object that was already
-	   * modified by other transactions. This would be true if last version matched the visible version.
-	   *
-	   * TODO: We already know here that this last row version is not deleted. It would be enough to just
-	   * check whether the insert MVCCID is considered active relatively to transaction's snapshot.
-	   */
-	  MVCC_SNAPSHOT *tran_snapshot = logtb_get_mvcc_snapshot (thread_p);
-	  MVCC_SATISFIES_SNAPSHOT_RESULT snapshot_res;
-
-	  assert (tran_snapshot != NULL && tran_snapshot->snapshot_fnc != NULL);
-	  snapshot_res = tran_snapshot->snapshot_fnc (thread_p, &recdes_header, tran_snapshot);
-	  if (snapshot_res == TOO_OLD_FOR_SNAPSHOT)
-	    {
-	      /* Not visible. */
-	      er_set (ER_WARNING_SEVERITY, ARG_FILE_LINE, ER_HEAP_UNKNOWN_OBJECT, 3, context->oid_p->volid,
-		      context->oid_p->pageid, context->oid_p->slotid);
-	      scan = S_DOESNT_EXIST;
-	      goto error;
-	    }
-	  else if (snapshot_res == TOO_NEW_FOR_SNAPSHOT)
-	    {
-	      /* Trying to modify a version already modified by concurrent transaction, which is an isolation conflict.
-	       */
-	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_MVCC_SERIALIZABLE_CONFLICT, 0);
-	      goto error;
-	    }
-	  else if (MVCC_IS_HEADER_DELID_VALID (&recdes_header))
-	    {
-	      /* Trying to modify version deleted by concurrent transaction, which is an isolation conflict. */
-	      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_MVCC_SERIALIZABLE_CONFLICT, 0);
-	      goto error;
-	    }
-	  else
-	    {
-	      /* Last version is also visible version and it is not deleted. Fall through. */
-	    }
-	}
-
-      if (MVCC_IS_HEADER_DELID_VALID (&recdes_header))
-	{
-	  scan = S_DOESNT_EXIST;
-	  goto error;
-	}
+      goto error;
     }
 
   return scan;

--- a/src/transaction/locator_sr.h
+++ b/src/transaction/locator_sr.h
@@ -61,6 +61,20 @@ enum
 
 extern bool locator_Dont_check_foreign_key;
 
+/* Where a statement takes the row lock for a modified object, and how long it keeps it.
+ * The select phase may have taken it already; otherwise the force phase does, and then either holds it
+ * to commit or -- once the change is published and a late arrival can settle on the MVCCID self-lock --
+ * gives it up when the statement ends. */
+typedef enum
+{
+  LOCATOR_LOCK_AT_SELECT,	/* the select phase locked the object; the force phase must not lock again */
+  LOCATOR_LOCK_AT_FORCE,	/* the force phase locks the object and holds the lock to commit */
+  LOCATOR_LOCK_AT_FORCE_TRANSIENT	/* the force phase locks the object and gives it up at statement end */
+} LOCATOR_LOCK_POLICY;
+
+extern bool locator_class_has_online_index (THREAD_ENTRY * thread_p, const OID * class_oid);
+
+
 extern int locator_initialize (THREAD_ENTRY * thread_p);
 extern void locator_finalize (THREAD_ENTRY * thread_p);
 extern int locator_drop_transient_class_name_entries (THREAD_ENTRY * thread_p, LOG_LSA * savep_lsa);
@@ -80,7 +94,7 @@ extern int locator_attribute_info_force (THREAD_ENTRY * thread_p, const HFID * h
 					 int pruning_type, PRUNING_CONTEXT * pcontext,
 					 FUNC_PRED_UNPACK_INFO * func_preds, MVCC_REEV_DATA * mvcc_reev_data,
 					 UPDATE_INPLACE_STYLE force_update_inplace, RECDES * rec_descriptor,
-					 bool need_locking);
+					 LOCATOR_LOCK_POLICY lock_policy);
 extern LC_COPYAREA *locator_allocate_copy_area_by_attr_info (THREAD_ENTRY * thread_p, HEAP_CACHE_ATTRINFO * attr_info,
 							     RECDES * old_recdes, RECDES * new_recdes,
 							     const int copyarea_length_hint, int lob_create_flag);
@@ -98,7 +112,7 @@ extern DISK_ISVALID locator_check_btree_entries (THREAD_ENTRY * thread_p, BTID *
 						 const char *btname, bool repair);
 extern int locator_delete_force (THREAD_ENTRY * thread_p, HFID * hfid, OID * oid, int has_index, int op_type,
 				 HEAP_SCANCACHE * scan_cache, int *force_count, MVCC_REEV_DATA * mvcc_reev_data,
-				 bool need_locking);
+				 LOCATOR_LOCK_POLICY lock_policy);
 extern int locator_add_or_remove_index (THREAD_ENTRY * thread_p, RECDES * recdes, OID * inst_oid, OID * class_oid,
 					int is_insert, int op_type, HEAP_SCANCACHE * scan_cache, bool datayn,
 					bool replyn, HFID * hfid, FUNC_PRED_UNPACK_INFO * func_preds, bool has_BU_lock,
@@ -120,7 +134,8 @@ extern SCAN_CODE locator_lock_and_get_object_with_evaluation (THREAD_ENTRY * thr
 							      RECDES * recdes, HEAP_SCANCACHE * scan_cache,
 							      int ispeeking, int old_chn,
 							      MVCC_REEV_DATA * mvcc_reev_data,
-							      NON_EXISTENT_HANDLING non_ex_handling_type);
+							      NON_EXISTENT_HANDLING non_ex_handling_type,
+							      bool transient);
 extern SCAN_CODE locator_get_object (THREAD_ENTRY * thread_p, const OID * oid, OID * class_oid, RECDES * recdes,
 				     HEAP_SCANCACHE * scan_cache, SCAN_OPERATION_TYPE op_type, LOCK lock_mode,
 				     int ispeeking, int chn);

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -6475,7 +6475,7 @@ lock_transaction_mvccid (THREAD_ENTRY * thread_p, MVCCID mvccid, LOCK lock, int 
   int granted;
   LK_ENTRY *tran_entry = NULL;
 
-  /* callers pre-filter via logtb_get_current_mvccid / btree_is_active_other_inserter, so a non-normal
+  /* callers pre-filter via logtb_get_current_mvccid / logtb_is_active_other_mvccid, so a non-normal
    * MVCCID is not an expected input; the early return below is a safe no-op fallback. */
   assert (MVCCID_IS_NORMAL (mvccid));
   if (!MVCCID_IS_NORMAL (mvccid))

--- a/src/transaction/lock_manager.c
+++ b/src/transaction/lock_manager.c
@@ -377,6 +377,8 @@ struct lk_tran_lock
   LK_ENTRY *lk_entry_pool;	/* local pool of lock entries which can be used with no synchronization. */
   int lk_entry_pool_count;	/* Current count of lock entries in local pool. */
   int inst_hold_count;		/* # of entries in inst_hold_list */
+  int transient_scope;		/* statements now taking transient row locks, so nesting is visible */
+  int transient_total;		/* counted requests outstanding, so an empty walk can be skipped */
   int class_hold_count;		/* # of entries in class_hold_list */
 
   LK_ENTRY *waiting;		/* waiting lock entry */
@@ -557,6 +559,8 @@ static bool lock_wakeup_deadlock_victim_aborted (int tran_index);
 static void lock_grant_blocked_holder (THREAD_ENTRY * thread_p, LK_RES * res_ptr);
 static int lock_grant_blocked_waiter (THREAD_ENTRY * thread_p, LK_RES * res_ptr);
 static void lock_grant_blocked_waiter_partial (THREAD_ENTRY * thread_p, LK_RES * res_ptr, LK_ENTRY * from_whom);
+static int lock_object_with_flag (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LOCK lock,
+				  int cond_flag, bool mark_transient);
 static bool lock_check_escalate (THREAD_ENTRY * thread_p, LK_ENTRY * class_entry, LK_TRAN_LOCK * tran_lock);
 static int lock_escalate_if_needed (THREAD_ENTRY * thread_p, LK_ENTRY * class_entry, int tran_index);
 static int lock_internal_hold_lock_object_instant (THREAD_ENTRY * thread_p, int tran_index, const OID * oid,
@@ -789,6 +793,7 @@ lock_uninit_entry (void *entry)
 
   entry_ptr->tran_index = -1;
   entry_ptr->thrd_entry = NULL;
+  entry_ptr->transient_count = 0;
 
   return NO_ERROR;
 }
@@ -984,6 +989,7 @@ lock_initialize_entry (LK_ENTRY * entry_ptr)
   entry_ptr->class_entry = NULL;
   entry_ptr->ngranules = 0;
   entry_ptr->instant_lock_count = 0;
+  entry_ptr->transient_count = 0;
   entry_ptr->bind_index_in_tran = -1;
   XASL_ID_SET_NULL (&entry_ptr->xasl_id);
 }
@@ -1004,6 +1010,7 @@ lock_initialize_entry_as_granted (LK_ENTRY * entry_ptr, int tran_index, LK_RES *
   entry_ptr->class_entry = NULL;
   entry_ptr->ngranules = 0;
   entry_ptr->instant_lock_count = 0;
+  entry_ptr->transient_count = 0;
 
   lock_event_set_xasl_id_to_entry (tran_index, entry_ptr);
 }
@@ -1025,6 +1032,7 @@ lock_initialize_entry_as_blocked (LK_ENTRY * entry_ptr, THREAD_ENTRY * thread_p,
   entry_ptr->class_entry = NULL;
   entry_ptr->ngranules = 0;
   entry_ptr->instant_lock_count = 0;
+  entry_ptr->transient_count = 0;
 
   lock_event_set_xasl_id_to_entry (tran_index, entry_ptr);
 }
@@ -1045,6 +1053,7 @@ lock_initialize_entry_as_non2pl (LK_ENTRY * entry_ptr, int tran_index, LK_RES * 
   entry_ptr->class_entry = NULL;
   entry_ptr->ngranules = 0;
   entry_ptr->instant_lock_count = 0;
+  entry_ptr->transient_count = 0;
 }
 
 /* initialize lock resource as allocated state */
@@ -6247,10 +6256,12 @@ lock_hold_object_instant (THREAD_ENTRY * thread_p, const OID * oid, const OID * 
  *   class_oid(in): Identifier of the class instance of the given object
  *   lock(in): Requested lock mode
  *   cond_flag(in):
+ *   mark_transient(in): count this request among the ones the statement gives up when it ends
  *
  */
-int
-lock_object (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LOCK lock, int cond_flag)
+static int
+lock_object_with_flag (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LOCK lock, int cond_flag,
+		       bool mark_transient)
 {
 #if !defined (SERVER_MODE)
   LK_SET_STANDALONE_XLOCK (lock);
@@ -6427,6 +6438,14 @@ lock_object (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LO
       granted =
 	lock_internal_perform_lock_object (thread_p, tran_index, lock_create_search_key (oid, class_oid), lock,
 					   wait_msecs, &inst_entry, class_entry);
+      if (mark_transient && granted == LK_GRANTED && inst_entry != NULL)
+	{
+	  /* the caller gives this request up when its statement ends.  Counted rather than flagged: a second
+	   * request on the same entry only raises count, and the release has to give back exactly what was
+	   * taken -- see lock_release_transient_object_locks */
+	  inst_entry->transient_count++;
+	  lk_Gl.tran_lock_table[tran_index].transient_total++;
+	}
       goto end;
     }
 
@@ -6447,6 +6466,234 @@ end:
   return granted;
 #endif /* !SERVER_MODE */
 }
+
+/*
+ * lock_object () - Lock an object
+ *   return: one of following values
+ *   thread_p(in): thread entry
+ *   oid(in): identifier of the object
+ *   class_oid(in): identifier of the class of the object
+ *   lock(in): requested lock mode
+ *   cond_flag(in): conditional or unconditional
+ */
+int
+lock_object (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LOCK lock, int cond_flag)
+{
+  return lock_object_with_flag (thread_p, oid, class_oid, lock, cond_flag, false);
+}
+
+/*
+ * lock_object_transient () - Lock an object the caller gives up when its statement ends
+ *   return: one of following values
+ *   thread_p(in): thread entry
+ *   oid(in): identifier of the object
+ *   class_oid(in): identifier of the class of the object
+ *   lock(in): requested lock mode
+ *   cond_flag(in): conditional or unconditional
+ *
+ * Note: the entry is marked so lock_release_transient_object_locks () can find it by walking the
+ *	transaction's hold list, which costs no hash lookup.  Only the instance entry is marked -- a class
+ *	lock taken on the way is not -- and releasing it decrements the count this request added, so a lock
+ *	the transaction already held survives.
+ */
+int
+lock_object_transient (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LOCK lock, int cond_flag)
+{
+  return lock_object_with_flag (thread_p, oid, class_oid, lock, cond_flag, true);
+}
+
+/*
+ * lock_transient_scope_start () - Enter a statement that may take transient row locks
+ *   return: true when this is the outermost such statement
+ *   thread_p(in): thread entry
+ *
+ * Note: the counts live on the transaction, not on the statement that made them, so a statement running
+ *	inside another one would give back the outer statement's locks when it ended -- opening exactly the
+ *	window a statement-scoped release exists to close.  Only the outermost statement takes transient
+ *	locks; one nested in it keeps its own to commit, the way every statement did before.
+ */
+bool
+lock_transient_scope_start (THREAD_ENTRY * thread_p)
+{
+#if !defined (SERVER_MODE)
+  return true;
+#else /* !SERVER_MODE */
+  LK_TRAN_LOCK *tran_lock = &lk_Gl.tran_lock_table[LOG_FIND_THREAD_TRAN_INDEX (thread_p)];
+
+  return (++tran_lock->transient_scope) == 1;
+#endif /* !SERVER_MODE */
+}
+
+/*
+ * lock_transient_scope_end () - Leave such a statement, giving its locks back if it was the outermost
+ *   return: void
+ *   thread_p(in): thread entry
+ *   release(in): give the counted requests back, rather than only forgetting the counts
+ */
+void
+lock_transient_scope_end (THREAD_ENTRY * thread_p, bool release)
+{
+#if !defined (SERVER_MODE)
+  return;
+#else /* !SERVER_MODE */
+  LK_TRAN_LOCK *tran_lock = &lk_Gl.tran_lock_table[LOG_FIND_THREAD_TRAN_INDEX (thread_p)];
+
+  assert (tran_lock->transient_scope > 0);
+  if (tran_lock->transient_scope > 0 && --tran_lock->transient_scope > 0)
+    {
+      /* an outer statement is still running and the counts are its to give back */
+      return;
+    }
+
+  if (release)
+    {
+      lock_release_transient_object_locks (thread_p);
+    }
+  else
+    {
+      lock_forget_transient_object_locks (thread_p);
+    }
+#endif /* !SERVER_MODE */
+}
+
+/*
+ * lock_unlock_object_transient () - Give back one request that was counted transient
+ *   return: void
+ *   thread_p(in): thread entry
+ *   oid(in): the object
+ *   class_oid(in): its class
+ *   lock(in): the mode that was granted
+ *
+ * Note: used where the caller undoes an acquisition it just made, so the count it added has to go with
+ *	it -- otherwise the statement's release would give back a request nobody is holding.
+ */
+void
+lock_unlock_object_transient (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LOCK lock)
+{
+#if !defined (SERVER_MODE)
+  return;
+#else /* !SERVER_MODE */
+  LK_ENTRY *entry_ptr;
+  int tran_index;
+
+  tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
+  entry_ptr = lock_find_tran_hold_entry (thread_p, tran_index, oid, false);
+  if (entry_ptr == NULL)
+    {
+      return;
+    }
+
+  assert (!OID_IS_ROOTOID (oid) && (class_oid == NULL || !OID_IS_ROOTOID (class_oid)));
+  assert (entry_ptr->transient_count > 0);
+  if (entry_ptr->transient_count > 0)
+    {
+      entry_ptr->transient_count--;
+      if (lk_Gl.tran_lock_table[tran_index].transient_total > 0)
+	{
+	  lk_Gl.tran_lock_table[tran_index].transient_total--;
+	}
+    }
+  lock_internal_perform_unlock_object (thread_p, entry_ptr, false, false);
+#endif /* !SERVER_MODE */
+}
+
+/*
+ * lock_release_transient_object_locks () - Give up the instance lock requests counted transient
+ *   return: void
+ *   thread_p(in): thread entry
+ *
+ * Note: the hold list is walked rather than each object looked up, so what a lock costs to give back
+ *	is what commit pays for it and does not grow with the size of the lock table.  The walk is over
+ *	everything the transaction holds rather than over what this statement took, so a statement that
+ *	took nothing would still pay for the locks the transaction holds for other reasons -- the running
+ *	total is there to answer that case without walking at all.  An entry the escalation reclaimed is
+ *	already off this list, so nothing has to be said about it here.
+ *
+ *	The walk takes no hold_mutex, on the same ground the other walks of this list state: a transaction
+ *	runs one thread at a time, so no one else is changing the list while we are on it.
+ */
+void
+lock_release_transient_object_locks (THREAD_ENTRY * thread_p)
+{
+#if !defined (SERVER_MODE)
+  return;
+#else /* !SERVER_MODE */
+  LK_TRAN_LOCK *tran_lock;
+  LK_ENTRY *entry_ptr, *next_ptr;
+  int tran_index, i, n;
+
+  tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
+  tran_lock = &lk_Gl.tran_lock_table[tran_index];
+
+  if (tran_lock->transient_total == 0)
+    {
+      /* nothing was counted, so the list has nothing for us -- a statement that took no transient lock
+       * does not pay for the locks the transaction holds for other reasons */
+      return;
+    }
+
+  for (entry_ptr = tran_lock->inst_hold_list; entry_ptr != NULL; entry_ptr = next_ptr)
+    {
+      /* the entry may be gone once its last request is given back, so take the link first */
+      next_ptr = entry_ptr->tran_next;
+
+      n = entry_ptr->transient_count;
+      if (n > 0)
+	{
+	  /* every counted request also raised count, so this cannot outrun what the entry holds; were it
+	   * to, the release that empties the entry would free it under the ones still to come */
+	  assert (n <= entry_ptr->count);
+	  n = MIN (n, entry_ptr->count);
+	  entry_ptr->transient_count = 0;
+	  for (i = 0; i < n; i++)
+	    {
+	      /* give back exactly what this statement took; a request it did not take stays */
+	      lock_internal_perform_unlock_object (thread_p, entry_ptr, false, false);
+	    }
+	}
+    }
+
+  /* an entry the escalation reclaimed took its count with it, so the total can only have run high;
+   * clearing it here keeps that from costing a walk later */
+  tran_lock->transient_total = 0;
+#endif /* !SERVER_MODE */
+}
+
+/*
+ * lock_forget_transient_object_locks () - Drop the transient counts without releasing anything
+ *   return: void
+ *   thread_p(in): thread entry
+ *
+ * Note: a statement that failed leaves its locks to commit, the way it did before any of them were
+ *	counted.  The counts have to go, though: they name no statement, so the next statement to release
+ *	would give back requests it never took.
+ */
+void
+lock_forget_transient_object_locks (THREAD_ENTRY * thread_p)
+{
+#if !defined (SERVER_MODE)
+  return;
+#else /* !SERVER_MODE */
+  LK_TRAN_LOCK *tran_lock;
+  LK_ENTRY *entry_ptr;
+  int tran_index;
+
+  tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
+  tran_lock = &lk_Gl.tran_lock_table[tran_index];
+
+  if (tran_lock->transient_total == 0)
+    {
+      return;
+    }
+
+  for (entry_ptr = tran_lock->inst_hold_list; entry_ptr != NULL; entry_ptr = entry_ptr->tran_next)
+    {
+      entry_ptr->transient_count = 0;
+    }
+  tran_lock->transient_total = 0;
+#endif /* !SERVER_MODE */
+}
+
 
 /*
  * lock_transaction_mvccid - Acquire a transaction self-lock keyed by an MVCCID
@@ -7388,6 +7635,10 @@ lock_unlock_all (THREAD_ENTRY * thread_p)
 
   tran_index = LOG_FIND_THREAD_TRAN_INDEX (thread_p);
   tran_lock = &lk_Gl.tran_lock_table[tran_index];
+
+  /* the transaction is over, so no statement of it is inside a transient scope any more */
+  tran_lock->transient_scope = 0;
+  tran_lock->transient_total = 0;
 
   /* remove all instance locks */
   entry_ptr = tran_lock->inst_hold_list;

--- a/src/transaction/lock_manager.h
+++ b/src/transaction/lock_manager.h
@@ -95,6 +95,7 @@ struct lk_entry
   int instant_lock_count;	/* number of instant lock requests */
   int bind_index_in_tran;
   XASL_ID xasl_id;
+  int transient_count;		/* requests on this entry that the statement gives up before commit */
 #else				/* not SERVER_MODE */
   int dummy;
 #endif				/* not SERVER_MODE */
@@ -223,6 +224,13 @@ extern int lock_hold_object_instant (THREAD_ENTRY * thread_p, const OID * oid, c
 extern int lock_object_wait_msecs (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LOCK lock,
 				   int cond_flag, int wait_msecs);
 extern int lock_object (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LOCK lock, int cond_flag);
+extern int lock_object_transient (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LOCK lock,
+				  int cond_flag);
+extern void lock_unlock_object_transient (THREAD_ENTRY * thread_p, const OID * oid, const OID * class_oid, LOCK lock);
+extern bool lock_transient_scope_start (THREAD_ENTRY * thread_p);
+extern void lock_transient_scope_end (THREAD_ENTRY * thread_p, bool release);
+extern void lock_release_transient_object_locks (THREAD_ENTRY * thread_p);
+extern void lock_forget_transient_object_locks (THREAD_ENTRY * thread_p);
 extern int lock_transaction_mvccid (THREAD_ENTRY * thread_p, MVCCID mvccid, LOCK lock, int cond_flag);
 extern void lock_unlock_transaction_mvccid (THREAD_ENTRY * thread_p, MVCCID mvccid, LOCK lock);
 extern int lock_has_lock_on_transaction_mvccid (THREAD_ENTRY * thread_p, MVCCID mvccid, LOCK lock);

--- a/src/transaction/log_impl.h
+++ b/src/transaction/log_impl.h
@@ -1181,6 +1181,9 @@ extern int logtb_invalidate_snapshot_data (THREAD_ENTRY * thread_p);
 extern int xlogtb_get_mvcc_snapshot (THREAD_ENTRY * thread_p);
 
 extern bool logtb_is_current_mvccid (THREAD_ENTRY * thread_p, MVCCID mvccid);
+extern bool logtb_is_active_other_mvccid (THREAD_ENTRY * thread_p, MVCCID mvccid);
+extern bool logtb_has_active_savepoint (THREAD_ENTRY * thread_p);
+extern int logtb_wait_for_tran_end (THREAD_ENTRY * thread_p, MVCCID mvccid);
 extern bool logtb_is_mvccid_committed (THREAD_ENTRY * thread_p, MVCCID mvccid);
 extern MVCC_SNAPSHOT *logtb_get_mvcc_snapshot (THREAD_ENTRY * thread_p);
 extern void logtb_complete_mvcc (THREAD_ENTRY * thread_p, LOG_TDES * tdes, bool committed);

--- a/src/transaction/log_tran_table.c
+++ b/src/transaction/log_tran_table.c
@@ -4217,6 +4217,75 @@ logtb_is_current_mvccid (THREAD_ENTRY * thread_p, MVCCID mvccid)
 }
 
 /*
+ * logtb_is_active_other_mvccid () - Is mvccid an in-progress write by another transaction?
+ *
+ * return: true if some other transaction is still active under mvccid
+ *
+ *   thread_p(in): thread entry
+ *   mvccid(in): MVCC id
+ */
+bool
+logtb_is_active_other_mvccid (THREAD_ENTRY * thread_p, MVCCID mvccid)
+{
+  return MVCCID_IS_NORMAL (mvccid) && !logtb_is_current_mvccid (thread_p, mvccid)
+    && log_Gl.mvcc_table.is_active (mvccid);
+}
+
+/*
+ * logtb_has_active_savepoint () - Is a savepoint declared, so a partial rollback can reach back to here?
+ *
+ * return: true if this transaction has declared a savepoint
+ *
+ *   thread_p(in): thread entry
+ */
+bool
+logtb_has_active_savepoint (THREAD_ENTRY * thread_p)
+{
+  LOG_TDES *tdes = LOG_FIND_TDES (LOG_FIND_THREAD_TRAN_INDEX (thread_p));
+
+  return tdes != NULL && !LSA_ISNULL (&tdes->savept_lsa);
+}
+
+/*
+ * logtb_wait_for_tran_end () - Block until the transaction working under mvccid ends: S_LOCK on its
+ *				MVCCID self-lock, then release.
+ *
+ * return	 : NO_ERROR once that transaction has ended. An error if the lock failed, or if the
+ *		   self-lock invariant is breached (grant while the transaction is still active) --
+ *		   waiting again cannot recover it, so fail the statement rather than spin.
+ * thread_p (in) : Thread entry.
+ * mvccid (in)	 : MVCCID of the in-progress transaction to wait out.
+ *
+ * Note: call with no page latch held.
+ */
+int
+logtb_wait_for_tran_end (THREAD_ENTRY * thread_p, MVCCID mvccid)
+{
+  int error_code;
+
+  if (lock_transaction_mvccid (thread_p, mvccid, S_LOCK, LK_UNCOND_LOCK) != LK_GRANTED)
+    {
+      error_code = er_errid ();
+      if (error_code == NO_ERROR)
+	{
+	  error_code = ER_CANNOT_GET_LOCK;
+	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, error_code, 0);
+	}
+      return error_code;
+    }
+  lock_unlock_transaction_mvccid (thread_p, mvccid, S_LOCK);
+
+  if (log_Gl.mvcc_table.is_active (mvccid))
+    {
+      /* Invariant breach: no-op grant while that transaction is still active. */
+      er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_CANNOT_GET_LOCK, 0);
+      assert (false);
+      return ER_CANNOT_GET_LOCK;
+    }
+  return NO_ERROR;
+}
+
+/*
  * logtb_get_mvcc_snapshot  - get MVCC snapshot
  *
  * return: MVCC snapshot


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27034

### Purpose

An MVCC `DELETE` holds a per-row X-lock until commit: O(rows) lock-table entries, longer bucket chains, and escalation to a table X-lock past `lock_escalation_at`.

- AS-IS: the per-row X-lock duplicates the write-owner the record header already carries in `mvcc_del_id`, and is retained until commit.
- TO-BE: the delete phase still takes the row X-lock, but only across verdict → publish (DELID stamp + index maintenance), releasing it once the delete is published. Ownership then lives in the header: a late-arriving writer reads the owner MVCCID from the stamp and waits on that transaction's self-lock (the CBRD-26942 primitive), then re-reads — at most one re-verdict; a second conflicting owner fails the statement with `ER_CANNOT_GET_LOCK` rather than spin.

Uncommitted write-lock footprint becomes O(transactions): 1 granted X entry while holding an uncommitted 1,900-row DELETE (baseline ~1,900).

### Implementation

The branch is **five feature commits**, one concept each, so a reviewer can read a commit against the section of the review guide it maps to. The history was reorganized for review; the granular development history is preserved on branch `CBRD-27034_pr1_backup`. The tree was byte-identical to it at that point; the defects review has turned up since are folded into the commits that own them, so it no longer is.

1. **`a588e2268` — wait out an in-progress deleter on its MVCCID self-lock.** `logtb_wait_for_tran_end` / `logtb_is_active_other_mvccid` (log_tran_table.c, log_impl.h); the settled-version read in locator_sr.c that treats an in-progress DELID of another active transaction as "published, row lock released" and waits the owner out, then re-reads and re-classifies (our row lock is held, so at most one wait); the self-lock acquired before the DELID stamp in heap_file.c, so "an observable in-progress DELID implies a held self-lock" holds by construction. The b-tree side is pulled into its own module **`btree_object_lock.{cpp,hpp}`** (new) — btree.c is 37.5k lines and GitHub does not render a diff that large, so the part that most needs review was unreadable in the PR; the module takes the writer's MVCCID from the `MVCC_REC_HEADER` the caller already builds, so it needs none of btree.c's private record-encoding macros. The settled read unfixes the home page before it waits, so a sequential scan never blocks with a permanent page fixed.

2. **`87d0662b3` — scan DELETE targets without the select-phase row lock, guarding the shapes the delete phase cannot re-check.** xasl_generation.c: DELETE plans stop forcing the select-phase lock and keep `mvcc_reev_classes` for condition-only reevaluation; the shapes the delete phase cannot re-check keep the lock instead, and the seven tests that decide this now sit together in `pt_delete_must_abort_reevaluation ()`, each carrying the reason it exists and a statement that reaches it (matrix under Test). A statement with a search condition that names no spec of its own (ROWNUM, a host variable, a constant) is taken here too, where it can be told apart from the truly no-predicate `DELETE FROM t`. Dropping the lock and the guards land in the same commit, so no revision in between deletes a row whose predicate no longer holds.

3. **`43bbbb18c` — re-check the DELETE predicate in the delete phase.** The reevaluation read (query_reevaluation.*, locator_sr.c, query_executor.c): the partner class is re-read out of its own heap by its own OID and carries no snapshot, so a version a concurrent transaction deleted still reads and the filters decide; its values are copied, not peeked — the record comes from a page the local scan cache unfixes on the way out. Repaired first, since enabling reevaluation woke code whose result was dead on develop: `filter_result` is established per fetch (it used to be left untouched when the last version was visible, so a previous object's `V_FALSE` was read back as this one's — a DELETE of ten matching rows with one flipped by a concurrent transaction deleted 0 instead of 9); skip-not-fail when a class has no access spec; the reevaluation class count taken from what the generated SELECT actually carries; the reev data value-initialized in its own constructor.

4. **`296793dfb` — release the transient row lock at statement end, holding it under a savepoint.** Once the delete is published a late arrival settles on the deleter's MVCCID self-lock, so the row lock is redundant from there and ends with the statement rather than at commit. It ends with the statement and not with each row: a row released early would be open while the same statement forces the next, and a writer entering that window would work a heap version this statement has already erased from the index. A class under an online index build keeps its locks to commit, because the build's own entry state names no owner and the row lock is what serializes two writers there; and a statement that declared a savepoint keeps them too — `ROLLBACK TO SAVEPOINT` can undo the published delete without ending the transaction, while a writer parked on our MVCCID holds the row.

    Which rows to release is not a question the select phase's list file can answer at the end: unlocking decrements a reference count on the lock entry, so a release must pair one to one with an acquisition, and that file names the rows the statement looked at rather than the ones it locked. Nor is a set kept on the side the answer — the release would then look each row up in the global lock hash, which measures 260 ns a row at fifty thousand rows and 376 at two million as the hash walks longer chains, against 294 ns for walking the entries the transaction already holds, which is what commit pays. So the entry carries the answer: `lock_object_transient ()` counts the request on the instance entry it was granted and `lock_release_transient_object_locks ()` walks the transaction's hold list. A count rather than a flag, because a statement can lock the same row twice and the paths that undo an acquisition they just made have to take their count with them; on the entry rather than in a pointer kept elsewhere, because a pointer would dangle exactly when a large delete escalates and the escalation reclaims the entry.

    Whether the locks end with the statement belongs to the class, not the row, so it is answered per class in the loop that forces the rows — a delete naming more than one class gets a different answer for each. The counts live on the transaction rather than on the statement that made them, so the transaction counts how many such statements are inside it and only the outermost takes transient locks. A statement that fails forgets its counts on the way out, leaving its locks to commit as before; one that took none answers from a running total without walking at all. `need_locking` said where the row lock is taken but not how long it is kept, and both are one decision, so `LOCATOR_LOCK_POLICY` says both — eleven call sites that passed a bare true or false now name what they mean.

    The answers that belong to the class rather than the row — whether MVCC applies (`mvcc_is_mvcc_disabled_class ()`, whose own comment asks callers to cache it), the class's heap (`heap_get_class_info ()`, a lock-free hash probe) and whether an online index build is running — are taken once where the class changes. A version that changed after the statement snapshot is deleted, not skipped, when the statement truly has no predicate to re-check; the runtime skip stays for the case it was written for, a subclass that carries no access spec.

5. **`75c86bee6` — fetch the ON DUPLICATE KEY UPDATE row through the lock path.** A duplicate whose delete is in progress carries no row lock once the deleter has published, and its visible version hides that delete; fetch it through `locator_lock_and_get_object` (which waits the deleter out and re-reads) so ODKU does not overwrite a record the deleter still has to undo, and treat a committed delete as the key being free, leaving the caller to insert.

### Independent review

Reviews were run against the branch, each with a single focus, and every finding was checked against the source before it was accepted or refused.

Taken: the `btree_object_lock` module exported two functions no caller outside it uses (now static, one entry point); `btree_fk_release_pages_and_locks ()`'s note still described a split between the INSERT and DELETE paths that folding them into one arm had removed; the derived-table guard was the only one asserting a shape with no statement to show for it; the two per-row class lookups above. Later passes fixed four defects the enabled path exposed, now folded into the commits that own them: a settled read that entered the self-lock wait with the scan's home page still fixed — a crash on a debug server, a latch-cycle hang on release — unfixed before the wait (commit 1); the partner-class re-read peeking into a page unfixed on the way out, now copied (commit 3); the savepoint carve-out above (commit 4); and the per-class record the delete loop builds, which never initialized whether the class is under an online index build and is only saved by the test reading it short-circuiting first (commit 4).

A pass on the release itself took an earlier shape of commit 4 — a set of rows kept on the side — and found three: a statement naming more than one class applied the last class's answer to all of them, so one under an online index build would have given up the locks the build needs; the mark on a row was a flag where a request needs a count, so a statement locking the same row twice gave one back and the paths undoing an acquisition left a count behind for another statement to spend; and the release named no statement, so a failed delete had its marks released by whatever delete ran next in the transaction. That is why the release counts per class, per acquisition and per scope. The figures quoted for it above came from the same work.

Refused, with the reason:

- *A bulk insert stamps an INSID without taking the MVCCID self-lock, so a waiter reaches the invariant-breach assert.* A bulk insert stamps no INSID at all -- `heap_insert_logical ()` gates the stamp on `!is_bulk_op` -- and `BU_LOCK` on the class is incompatible with IS/S/IX/X/SIX, so no concurrent DML reaches the class in the first place.
- *`break` → `continue` inside the b-tree switches may skip loop-tail work and hang.* In both scans the `switch` is the last statement of the `while (true)` body and the loop advances at its own head, so the two are equivalent; verified in the source and again by the functional review independently.
- *`S_DOESNT_EXIST` from the partner-class re-read should be `V_FALSE`, not `V_ERROR`.* The local scan cache leaves `mvcc_snapshot` NULL, so no visibility test runs and a deleted-and-committed row still reads. Reaching `S_DOESNT_EXIST` needs the heap slot itself to be gone, which cannot happen while this transaction holds a snapshot that saw it, and the path sets `ER_HEAP_UNKNOWN_OBJECT`. `V_FALSE` would swallow a genuinely broken state.

### Remarks

- Depends on CBRD-27079 (in develop): the prepare record persists the self-lock, so 2PC needs no per-row tracking.
- Draft #7436 attacks the same problem by latch-first sealing. Here the transient row lock keeps the publish window atomic across all row replicas (heap + index entries) and keeps waits visible to the deadlock detector, so the heap layer needs no seal/re-dispatch machinery; #7436 stays open as the reference for that alternative.
- Under READ COMMITTED the serialization point of two DELETEs of the same row moves from the fetch to the stamp; abort counts are unchanged, only which side wins inside that window can differ.
- The lockless scan's silent skip of a still-matching changed version is closed by the condition-only reevaluation: 0 skipped / 2,000 racing DELETEs (~0.1% before).
- `SELECT ... FOR UPDATE`, non-MVCC operations and DDL are out of scope and unchanged; UPDATE keeps its per-row X-lock in this PR. Follow-ups: UPDATE on the same protocol (#7711, which also carries the user-savepoint-only form of the carve-out above), then the lockless FK existence check (CBRD-26664).

### Test

Which statement shapes keep the select-phase lock, measured rather than argued. Each guard was instrumented and run against a fresh plan cache -- CUBRID reuses a cached plan for a repeated statement shape, so a second run of the same shape generates no plan to observe -- and the same matrix was taken before and after the guards were gathered into one function. The two agree cell for cell.

| statement | guard | reevaluation |
|---|---|---|
| `DELETE FROM t WHERE pk = 1` | none | on |
| `DELETE FROM part_t WHERE pk = 1` | partitioned | off, lock at select |
| `DELETE FROM t WHERE pk IN (SELECT k FROM side_t WHERE k = 1)` | subquery | off, lock at select |
| `DELETE FROM t WHERE pk > 0 LIMIT 1` | LIMIT | off, lock at select |
| `DELETE a FROM t a, side_t b WHERE a.pk = b.k` | cross-spec term | off, lock at select |
| `DELETE FROM ALL h_base WHERE v = 1` | hierarchy | off, lock at select |
| `DELETE a FROM t a, (inline view kept by NO_MERGE) d WHERE d.k = 1` | subquery, not derived table | off, lock at select |

The last row is why the tests are ordered: an inline view the optimizer was told not to merge is a spec below a subquery, so it never reaches the derived-table test. GROUP BY is the one shape no statement was found for, and its comment claims no example.

The no-predicate DELETE above is a scenario in the lock-trace suite: `DELETE FROM t` after a concurrent `UPDATE` commits leaves `COUNT(*)` at 1 on this branch before the fix and at 0 after it, with the fourteen other DELETE scenarios (two deleters, delete-vs-update, silent-skip, multi-class, join and subquery reevaluation, GROUP BY, ORDER BY LIMIT, correlated EXISTS) unchanged.

Debug build, asserts active: write-write endings (second deleter waits, then 0-rows on commit / deletes on rollback), FK child-insert vs parent-delete both endings, deadlock resolves with a single victim, savepoint partial rollback, REC_BIGONE rows, multi-class DELETE; 90s full-mix gate (3 deleters + 2 inserters + 3 key-moving updaters): heap count == index count, checkdb clean; reevaluation gate: 0 skips / 2,000; the reevaluation verdict is not inherited across rows (10 matching rows, 1 flipped mid-statement → 9 deleted, 1 left). Medium suite as CI runs it: Fail 0 / Success 975 / Total 975. The write-write and FK scenarios were re-run after each boundary commit on a debug build with asserts on -- deleter commits then the waiting INSERT succeeds / deleter rolls back and the INSERT hits the unique constraint; deleter commits then the concurrent UPDATE reports 0 rows / rolls back and it reports 1; parent delete commits then the child INSERT is rejected by the FK / rolls back and it succeeds -- with `cubrid lockdb` confirming the waiter is blocked on the writer's MVCCID self-lock in S_LOCK, and the server surviving every case.

Release build: hot-row del/upd mix 30s/11s vs baseline 34s/38s (a sealed prototype: 156s/179s); `Num_object_locks_waits` −46% (cross-checked against self-lock accounting); data-page fetches and cold-buffer ioreads at parity; during a single 150k-row DELETE (`lock_escalation_at`=100k) a concurrent writer completed 293 single-row inserts vs 51 on baseline, the bulk statement itself at parity; 10-cycle soak with checkdb between cycles.

The release-build numbers above predate the release mechanism in commit 4. Lock and page-fix counts are unaffected — the same rows are locked and released at the same points — but the bulk-statement timings have not been re-taken since. What has been measured on it is the release itself: 294 ns a row at two million rows against 376 for looking each row up, growing thirteen percent from fifty thousand rows rather than forty-five.




