### PR TITLE
[CBRD-27189] [Backport] Do not merge a subquery whose numbering column becomes an operand of an expression

### DIFF
--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -111,6 +111,14 @@ typedef struct check_pushable_info
   bool method_found;
 } CHECK_PUSHABLE_INFO;
 
+typedef struct attr_ref_info
+{
+  UINTPTR spec_id;		/* spec id of the attribute to look for */
+  const char *name;		/* name of the attribute to look for */
+
+  bool found;			/* set when a reference is found */
+} ATTR_REF_INFO;
+
 static unsigned int top_cycle = 0;
 static DB_OBJECT *cycle_buffer[MAX_CYCLE];
 
@@ -228,6 +236,13 @@ static bool pt_has_non_deterministic_expr (PARSER_CONTEXT * parser, PT_NODE * te
 static bool pt_check_pushable_subquery_select_list (PARSER_CONTEXT * parser, PT_NODE * query, int pos);
 static PT_NODE *pt_find_only_name_id (PARSER_CONTEXT * parser, PT_NODE * tree, void *arg, int *continue_walk);
 static bool pt_check_pushable_term (PARSER_CONTEXT * parser, PT_NODE * term, FIND_ID_INFO * infop);
+static PT_NODE *mq_find_sort_dependent_node (PARSER_CONTEXT * parser, PT_NODE * node, void *void_arg,
+					     int *continue_walk);
+static PT_NODE *mq_find_attr_reference (PARSER_CONTEXT * parser, PT_NODE * node, void *void_arg, int *continue_walk);
+static bool mq_is_attr_referenced (PARSER_CONTEXT * parser, PT_NODE * node, ATTR_REF_INFO * infop);
+static bool mq_is_sort_dependent_column (PARSER_CONTEXT * parser, PT_NODE * column);
+static bool mq_is_sort_dependent_column_used_in_expr (PARSER_CONTEXT * parser, PT_NODE * subquery,
+						      PT_NODE * mainquery, PT_NODE * class_spec, PT_NODE * class_);
 static PUSHABLE_TYPE mq_is_pushable_subquery (PARSER_CONTEXT * parser, PT_NODE * subquery, PT_NODE * mainquery,
 					      PT_NODE * class_spec, bool is_vclass, PT_NODE * order_by,
 					      PT_NODE * class_);
@@ -1738,6 +1753,212 @@ pt_check_odku_refs_view (PARSER_CONTEXT * parser, PT_NODE * statement)
 }
 
 /*
+ * mq_find_sort_dependent_node () - look for ORDERBY_NUM()/GROUPBY_NUM() of the query being walked
+ *   return: node (unchanged)
+ *   parser(in): parser context
+ *   node(in): node to check
+ *   void_arg(in/out): bool *
+ *   continue_walk(in/out):
+ */
+static PT_NODE *
+mq_find_sort_dependent_node (PARSER_CONTEXT * parser, PT_NODE * node, void *void_arg, int *continue_walk)
+{
+  bool *has_sort_dependent = (bool *) void_arg;
+
+  if (PT_IS_ORDERBYNUM (node) || PT_IS_GROUPBYNUM (node))
+    {
+      *has_sort_dependent = true;
+    }
+
+  if (*has_sort_dependent)
+    {
+      *continue_walk = PT_STOP_WALK;
+    }
+  else if (PT_IS_QUERY_NODE_TYPE (node->node_type))
+    {
+      /* a nested query has its own numbering */
+      *continue_walk = PT_LIST_WALK;
+    }
+
+  return node;
+}
+
+/*
+ * mq_find_attr_reference () - look for a reference to a given attribute of a spec
+ *   return: node (unchanged)
+ *   parser(in): parser context
+ *   node(in): node to check
+ *   void_arg(in/out): ATTR_REF_INFO *
+ *   continue_walk(in/out):
+ */
+static PT_NODE *
+mq_find_attr_reference (PARSER_CONTEXT * parser, PT_NODE * node, void *void_arg, int *continue_walk)
+{
+  ATTR_REF_INFO *infop = (ATTR_REF_INFO *) void_arg;
+
+  if (node->node_type == PT_NAME && node->info.name.spec_id == infop->spec_id
+      && node->info.name.original != NULL && intl_identifier_casecmp (node->info.name.original, infop->name) == 0)
+    {
+      infop->found = true;
+    }
+
+  if (infop->found)
+    {
+      *continue_walk = PT_STOP_WALK;
+    }
+
+  return node;
+}
+
+/*
+ * mq_is_attr_referenced () - check whether a node tree refers to a given attribute of a spec
+ *   return: true if the attribute is referenced in the tree
+ *   parser(in): parser context
+ *   node(in): node tree to search. its 'next' list is searched, too
+ *   infop(in/out): attribute to look for
+ */
+static bool
+mq_is_attr_referenced (PARSER_CONTEXT * parser, PT_NODE * node, ATTR_REF_INFO * infop)
+{
+  if (node == NULL)
+    {
+      return false;
+    }
+
+  infop->found = false;
+  (void) parser_walk_tree (parser, node, mq_find_attr_reference, infop, NULL, NULL);
+
+  return infop->found;
+}
+
+/*
+ * mq_is_sort_dependent_column () - check whether a select list column of a subquery holds a value which is
+ *                                  only known after the subquery's sort is done
+ *   return: true if the column contains ORDERBY_NUM()/GROUPBY_NUM()
+ *   parser(in): parser context
+ *   column(in): a single column of a select list. its 'next' list is not searched
+ *
+ * NOTE:
+ *   ORDERBY_NUM()/GROUPBY_NUM() are not evaluated while the rows are being produced, but while the sorted (or
+ *   grouped) result is being written out. Therefore such a column can only be projected as it is; it can not be
+ *   used as an operand of another expression. see qexec_ordby_put_next () in query_executor.c.
+ */
+static bool
+mq_is_sort_dependent_column (PARSER_CONTEXT * parser, PT_NODE * column)
+{
+  PT_NODE *save_next;
+  bool has_sort_dependent = false;
+
+  if (column == NULL)
+    {
+      return false;
+    }
+
+  /* cut off next to check this column only */
+  save_next = column->next;
+  column->next = NULL;
+
+  (void) parser_walk_tree (parser, column, mq_find_sort_dependent_node, &has_sort_dependent, NULL, NULL);
+
+  column->next = save_next;
+
+  return has_sort_dependent;
+}
+
+/*
+ * mq_is_sort_dependent_column_used_in_expr () - check whether merging would make a sort dependent column of the
+ *                                               subquery an operand of an expression of the main query
+ *   return: true if such a use is found
+ *   parser(in): parser context
+ *   subquery(in): subquery(or view query spec) to be merged
+ *   mainquery(in): query the subquery is to be merged into
+ *   class_spec(in): spec of the subquery in the main query
+ *   class_(in): view name node, NULL for an inline view
+ *
+ * NOTE:
+ *   Merging replaces every reference to a column of subquery with the defining expression of that column
+ *   (see mq_substitute_select_for_inline_view (), mq_substitute_select_in_statement ()). A column holding
+ *   ORDERBY_NUM()/GROUPBY_NUM() may only be projected as it is, so the merged select list is valid only while
+ *   every reference to such a column is a bare column of the select list of the main query. Anything else
+ *   (DECODE (rn, 1, name, 'WRONG'), CAST (rn AS VARCHAR), rn + 0, a subquery reading rn, ...) makes the numbering
+ *   an operand of an expression, which reads the value before it is set and returns a wrong result. That is the
+ *   very shape which is rejected when it is written directly. (see pt_check_orderbynum_pre ()/
+ *   pt_check_orderbynum_post () and MSGCAT_SEMANTIC_ORDERBYNUM_SELECT_LIST_ERR in semantic_check.c)
+ *
+ *   The other clauses of the main query are not checked because a reference from them can not get here: a main
+ *   query which has its own ORDER BY is not merged with a subquery which has one (is_only_spec), and a GROUP BY
+ *   or a HAVING of the main query keeps the numbering column in a spec of its own as well. The WHERE clause is
+ *   left out on purpose: mq_is_rownum_only_predicate () has already restricted it to 'numbering <comparison>
+ *   constant' terms, which merging turns into the TOP-N clause of the merged query (see mq_update_order_by ())
+ *   instead of reading the numbering value.
+ */
+static bool
+mq_is_sort_dependent_column_used_in_expr (PARSER_CONTEXT * parser, PT_NODE * subquery, PT_NODE * mainquery,
+					  PT_NODE * class_spec, PT_NODE * class_)
+{
+  PT_NODE *attributes, *attr, *col, *node, *save_next;
+  ATTR_REF_INFO info;
+  bool found = false;
+
+  assert (PT_IS_SELECT (subquery));
+
+  if (!PT_IS_SELECT (mainquery))
+    {
+      /* UPDATE/DELETE/MERGE can not get here: a vclass which numbers its rows is not updatable */
+      return false;
+    }
+
+  /* get the attributes of the spec, which are matched with the select list of the subquery by position */
+  if (class_ != NULL)
+    {
+      attributes = mq_fetch_attributes (parser, class_);
+      info.spec_id = class_->info.name.spec_id;
+    }
+  else
+    {
+      attributes = class_spec->info.spec.as_attr_list;
+      info.spec_id = class_spec->info.spec.id;
+    }
+
+  for (attr = attributes, col = subquery->info.query.q.select.list; attr != NULL && col != NULL;
+       attr = attr->next, col = col->next)
+    {
+      if (attr->node_type != PT_NAME || attr->info.name.original == NULL)
+	{
+	  continue;
+	}
+      if (!mq_is_sort_dependent_column (parser, col))
+	{
+	  continue;
+	}
+
+      info.name = attr->info.name.original;
+
+      /* a bare column of the select list is projected as it is; every other column which reads it is an
+       * expression having the numbering as an operand */
+      for (node = mainquery->info.query.q.select.list; node != NULL; node = node->next)
+	{
+	  if (node->node_type == PT_NAME)
+	    {
+	      continue;
+	    }
+
+	  save_next = node->next;
+	  node->next = NULL;
+	  found = mq_is_attr_referenced (parser, node, &info);
+	  node->next = save_next;
+
+	  if (found)
+	    {
+	      return true;
+	    }
+	}
+    }
+
+  return false;
+}
+
+/*
  * mq_is_pushable_subquery () - check if a subquery is pushable
  *  returns: true if pushable, false otherwise
  *   parser(in): parser context
@@ -1774,7 +1995,8 @@ pt_check_odku_refs_view (PARSER_CONTEXT * parser, PT_NODE * statement)
  *  - has CONNECT BY (Hierarchical Queries)
  *  - has DISTINCT
  *  - has aggregate or orderby_for or analytic
- *  - has inst num or orderby_num
+ *  - has inst num or orderby_num, and either it is not the only spec or the main query uses a column holding
+ *    orderby_num/groupby_num in an expression
  *  - has method
  *  TO_DO : check all cases using is_vclass
  */
@@ -2026,9 +2248,19 @@ mq_is_pushable_subquery (PARSER_CONTEXT * parser, PT_NODE * subquery, PT_NODE * 
     }
 
   /* check inst num or orderby_num */
-  if (!is_only_spec && pt_has_inst_in_where_and_select_list (parser, subquery))
+  if (pt_has_inst_in_where_and_select_list (parser, subquery))
     {
-      return NON_PUSHABLE;
+      if (!is_only_spec)
+	{
+	  return NON_PUSHABLE;
+	}
+
+      /* Even for a single spec, merging is given up when the main query embeds a numbering column of the subquery
+       * into an expression, since such a column is not evaluated until the subquery's sort is done. (CBRD-27189) */
+      if (mq_is_sort_dependent_column_used_in_expr (parser, subquery, mainquery, class_spec, class_))
+	{
+	  return NON_PUSHABLE;
+	}
     }
 
   /* check method */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27189

## Purpose

develop 의 CBRD-27189 수정(#7686, `52cbfd2f5`)을 `release/11.4` 로 백포트합니다. 동일한 오답이 11.4 에서도 재현됩니다.

서브쿼리가 `ROWNUM`/`ORDERBY_NUM()` 을 컬럼으로 노출하고 메인 쿼리가 그 컬럼을 **표현식의 피연산자로** 읽으면, 뷰 머징 후 아직 채워지지 않은 numbering 값을 읽어 잘못된 결과가 나옵니다.

```sql
SELECT DECODE(rn, 1, name, 'WRONG') AS RESULT
FROM (SELECT name, ROWNUM AS rn
        FROM (SELECT name FROM athlete ORDER BY name) WHERE ROWNUM <= 1);
-- expected: 'Aardenburg Willemien'   actual(release/11.4): 'WRONG'
```

`ORDERBY_NUM()` 은 행을 만드는 시점이 아니라 정렬 결과를 내보내는 시점에 채워지고, 그때 값을 받는 것은 출력 리스트의 top-level `ORDERBY_NUM` 컬럼 위치뿐입니다(`qexec_ordby_put_next ()`). 같은 이유로 사용자가 직접 `SELECT orderby_num() + 1 ... ORDER BY ...` 를 쓰면 semantic check 가 거절합니다(`MSGCAT_SEMANTIC_ORDERBYNUM_SELECT_LIST_ERR`). 즉 머징이 엔진이 지원하지 않는 모양을 만들어내고 있었습니다.

## Implementation

develop 커밋을 그대로 cherry-pick 했습니다(충돌 없음). `mq_is_pushable_subquery ()` 는 서브쿼리 select list 에 `ORDERBY_NUM()`/`GROUPBY_NUM()` 을 담은 컬럼이 있고 그 컬럼을 메인 쿼리 select list 의 **bare 컬럼이 아닌 항목이 참조**할 때만 머징을 포기합니다. 컬럼 ↔ 속성 대응은 치환이 실제로 쓰는 대응(`spec->as_attr_list` ↔ 서브쿼리 select list 위치 대응)을 그대로 이용합니다.

메인 쿼리의 다른 절은 검사하지 않습니다. `GROUP BY`/`HAVING`/`ORDER BY` 참조는 `is_only_spec` 에서 이미 머징이 차단되고, UPDATE/DELETE 경유는 numbering 뷰가 updatable 하지 않아 도달할 수 없습니다. 메인 쿼리의 WHERE 는 `mq_is_rownum_only_predicate ()` 가 `numbering <비교> 상수` 형태만 남기고 머징이 이를 TOP-N 절로 바꾸므로 제외했습니다(페이지네이션 플랜 유지).

## Remarks

**정합성 (release/11.4 release build, demodb)** — base 에서 재현되고 이 PR 로 정상화됨을 A/B 로 확인했습니다.

| 케이스 | release/11.4 | 이 PR |
|---|---|---|
| 서브쿼리/뷰 + `DECODE(rn,1,name,'WRONG')` | `'WRONG'` | `'Aardenburg Willemien'` |
| `CASE WHEN rn=1 ...` | `'WRONG'` | 정상 |
| `rn+0`, `NVL(rn,0)` | `0` | `1` |
| `'x' \|\| rn` | `'x0'` | `'x1'` |
| `CAST(rn AS VARCHAR)` | `'0','0'` | `'1','2'` |
| select list 스칼라 서브쿼리가 `rn` 참조 | `0,0` | `215,0` |
| bare `rn`, `SRC.rn` | `1` | `1` (머징 유지) |
| top-3 `rn, DECODE(rn,1,'first','other')` | `1/other, 2/other, 3/other` | `1/first, 2/other, 3/other` |
| 인덱스로 정렬 해소되는 대조군 / 정렬 없는 `ROWNUM` | 정상 | 정상 (머징 유지) |

`WITH` 형태는 11.4 에서 원래 정상이며(CTE 처리 경로가 develop 과 다름) 이 PR 로도 동일합니다.

**플랜 회귀 검사**: `rownum|orderby_num|inst_num` 과 서브쿼리/뷰를 함께 포함하는 cubrid-testcases sql 케이스 167건을 base 빌드와 이 PR 빌드에서 각각 실행해 결과 + `OPTIMIZATION LEVEL 513` 플랜 덤프를 비교했고 **차이 없음**을 확인했습니다. (2건에서 보이는 `fixed scan=/cached scan=` 값 차이는 같은 빌드를 두 번 돌려도 바뀌는 xasl 덤프의 비결정 출력입니다.)

**TC**: sql 테스트케이스는 develop 쪽에 cubrid-testcases#3251 로 반영되어 있습니다. 필요하면 `release/11.4` 브랜치에도 동일 케이스를 추가하겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
