### PR TITLE
[CUBRIDQA-1517] Advance submodule bump PRs one commit at a time

### DIFF
--- a/.github/workflows/submodule-bump-receiver.yml
+++ b/.github/workflows/submodule-bump-receiver.yml
@@ -122,6 +122,18 @@ jobs:
           set -euo pipefail
           OPEN=$(gh pr list --repo "$PARENT" --state open --limit 100 --json number,headRefName \
                  | jq -r --arg b "bump/$SUB" '.[] | select(.headRefName==$b) | .number')
+          # A just-merged PR can still read as open. This run is the only chance to
+          # advance, so decide on what the pin already holds, not on the reported state.
+          if [ -n "$OPEN" ]; then
+            HEAD_SHA=$(gh pr view "$OPEN" --repo "$PARENT" --json headRefOid --jq .headRefOid 2>/dev/null || true)
+            if [ -n "$HEAD_SHA" ]; then
+              PR_PIN=$(gh api "repos/$PARENT/contents/$SUB?ref=$HEAD_SHA" --jq .sha 2>/dev/null || true)
+              if [ "$PR_PIN" = "$(git rev-parse "HEAD:$SUB")" ]; then
+                echo "PR #$OPEN already matches the current pin; treating it as merged."
+                OPEN=""
+              fi
+            fi
+          fi
           if [ -z "$OPEN" ]; then
             echo "busy=false" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/submodule-bump-receiver.yml
+++ b/.github/workflows/submodule-bump-receiver.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ secrets.SUBMODULE_BOT_APP_ID }}
           private-key: ${{ secrets.SUBMODULE_BOT_APP_PRIVATE_KEY }}
@@ -102,13 +102,13 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ secrets.SUBMODULE_BOT_APP_ID }}
           private-key: ${{ secrets.SUBMODULE_BOT_APP_PRIVATE_KEY }}
 
       - name: Checkout parent
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ env.BASE_BRANCH }}
           fetch-depth: 0
@@ -228,7 +228,7 @@ jobs:
 
       - name: Create PR
         if: steps.pin.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           token: ${{ steps.app-token.outputs.token }}
           branch: bump/${{ matrix.sub }}

--- a/.github/workflows/submodule-bump-receiver.yml
+++ b/.github/workflows/submodule-bump-receiver.yml
@@ -3,17 +3,26 @@ name: Submodule bump (receiver)
 on:
   repository_dispatch:
     types: [submodule-bump]
+  push:
+    branches: [develop]
+    paths:
+      - cubrid-jdbc
+      - cubrid-cci
+      - cubridmanager
   workflow_dispatch:
     inputs:
       submodule_path:
-        description: "cubrid-jdbc | cubrid-cci | cubridmanager"
+        description: "Target submodule"
         required: true
-      commit_message:
-        description: "Original commit subject (for issue-key inheritance)"
-        default: ""
-      pusher:
-        description: "GitHub id to set as assignee"
-        default: ""
+        type: choice
+        options: [cubrid-jdbc, cubrid-cci, cubridmanager]
+      target_sha:
+        description: "Submodule commit to pin: full 40-char SHA"
+        required: true
+      reanchor:
+        description: "Allow a non-fast-forward re-anchor after a submodule force-push"
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -22,30 +31,78 @@ permissions:
 env:
   BASE_BRANCH: develop
   FALLBACK_TAG: "[CBRD-0000]"
-
-concurrency:
-  group: submodule-bump-${{ github.event.client_payload.submodule_path || inputs.submodule_path || github.run_id }}
-  cancel-in-progress: true
+  PARENT: ${{ github.repository }}
 
 jobs:
-  bump:
+  plan:
     runs-on: ubuntu-latest
-    env:
-      SUB_PATH:   ${{ github.event.client_payload.submodule_path || inputs.submodule_path }}
-      COMMIT_MSG: ${{ github.event.client_payload.commit_message || inputs.commit_message }}
-      PUSHER:     ${{ github.event.client_payload.pusher || inputs.pusher }}
+    outputs:
+      targets: ${{ steps.select.outputs.targets }}
     steps:
-      - name: Validate submodule path
-        run: |
-          set -euo pipefail
-          case "$SUB_PATH" in
-            cubrid-jdbc|cubrid-cci|cubridmanager) ;;
-            *) echo "::error::Unknown submodule path: '$SUB_PATH'"; exit 1 ;;
-          esac
-
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.SUBMODULE_BOT_APP_ID }}
+          private-key: ${{ secrets.SUBMODULE_BOT_APP_PRIVATE_KEY }}
+
+      - name: Select submodules to process
+        id: select
+        env:
+          GH_TOKEN:      ${{ steps.app-token.outputs.token }}
+          EVENT:         ${{ github.event_name }}
+          DISPATCH_PATH: ${{ github.event.client_payload.submodule_path }}
+          INPUT_PATH:    ${{ inputs.submodule_path }}
+        run: |
+          set -euo pipefail
+          case "$EVENT" in
+            workflow_dispatch)   CANDIDATES="$INPUT_PATH" ;;
+            repository_dispatch) CANDIDATES="$DISPATCH_PATH" ;;
+            *)                   CANDIDATES="cubrid-jdbc cubrid-cci cubridmanager" ;;
+          esac
+          gh api -H "Accept: application/vnd.github.raw" \
+            "repos/$PARENT/contents/.gitmodules?ref=$BASE_BRANCH" > gitmodules.ini
+          TARGETS='[]'
+          for p in $CANDIDATES; do
+            [ -n "$p" ] || continue
+            case "$p" in
+              cubrid-jdbc|cubrid-cci|cubridmanager) ;;
+              *) echo "::error::unknown submodule path '$p'"; exit 1 ;;
+            esac
+            if [ "$EVENT" != workflow_dispatch ]; then
+              SLUG=$(git config -f gitmodules.ini --get "submodule.$p.url" \
+                     | sed -E 's#^.*github\.com[:/]##; s#\.git$##')
+              SUB_BRANCH=$(git config -f gitmodules.ini --get "submodule.$p.branch" || echo "$BASE_BRANCH")
+              PINNED=$(gh api "repos/$PARENT/contents/$p?ref=$BASE_BRANCH" --jq .sha)
+              TIP=$(gh api "repos/$SLUG/commits/$SUB_BRANCH" --jq .sha)
+              if [ "$PINNED" = "$TIP" ]; then
+                echo "$p: up to date ($PINNED)"
+                continue
+              fi
+            fi
+            TARGETS=$(jq -cn --argjson a "$TARGETS" --arg p "$p" '$a + [$p]')
+          done
+          echo "targets=$TARGETS"
+          echo "targets=$TARGETS" >> "$GITHUB_OUTPUT"
+
+  bump:
+    needs: plan
+    if: needs.plan.outputs.targets != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sub: ${{ fromJSON(needs.plan.outputs.targets) }}
+    concurrency:
+      group: submodule-bump-${{ matrix.sub }}
+      cancel-in-progress: false
+    env:
+      SUB:  ${{ matrix.sub }}
+      MODE: ${{ github.event_name == 'workflow_dispatch' && 'at' || 'next' }}
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.SUBMODULE_BOT_APP_ID }}
           private-key: ${{ secrets.SUBMODULE_BOT_APP_PRIVATE_KEY }}
@@ -57,43 +114,144 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Update submodule pointer
-        id: bump
+      - name: Check queue
+        id: queue
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
-          git submodule update --init -- "$SUB_PATH"
-          git submodule update --remote -- "$SUB_PATH"
-          if git diff --quiet -- "$SUB_PATH"; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
+          OPEN=$(gh pr list --repo "$PARENT" --state open --limit 100 --json number,headRefName \
+                 | jq -r --arg b "bump/$SUB" '.[] | select(.headRefName==$b) | .number')
+          if [ -z "$OPEN" ]; then
+            echo "busy=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$MODE" = next ]; then
+            echo "queue busy: #$OPEN still open; not advancing $SUB."
+            echo "busy=true" >> "$GITHUB_OUTPUT"
           else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "new_sha=$(git -C "$SUB_PATH" rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+            echo "retargeting open PR #$OPEN for $SUB to the requested SHA."
+            echo "busy=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build PR title
-        if: steps.bump.outputs.changed == 'true'
-        id: title
+      - name: Resolve and pin target
+        id: pin
+        if: steps.queue.outputs.busy != 'true'
+        env:
+          GH_TOKEN:  ${{ steps.app-token.outputs.token }}
+          INPUT_SHA: ${{ inputs.target_sha }}
+          REANCHOR:  ${{ inputs.reanchor }}
         run: |
           set -euo pipefail
-          TAG=$(printf '%s' "$COMMIT_MSG" | head -n1 | grep -oE '^\[[A-Z]+-[0-9]+\]' || true)
-          [ -z "$TAG" ] && TAG="$FALLBACK_TAG"
-          echo "value=${TAG} Update ${SUB_PATH} submodule" >> "$GITHUB_OUTPUT"
+          die(){  echo "::error::$*" >&2; exit 1; }
+          noop(){ echo "$*"; echo "changed=false" >> "$GITHUB_OUTPUT"; exit 0; }
 
-      - name: Create or update PR
-        if: steps.bump.outputs.changed == 'true'
+          SUB_BRANCH=$(git config -f .gitmodules --get "submodule.$SUB.branch" || echo "$BASE_BRANCH")
+          REMOTE_BRANCH="origin/$SUB_BRANCH"
+          FF_REQUIRED=true
+
+          git submodule update --init -- "$SUB"
+          git -C "$SUB" fetch -q --no-tags origin "+refs/heads/$SUB_BRANCH:refs/remotes/origin/$SUB_BRANCH"
+
+          [ "$(git -C "$SUB" rev-parse --is-shallow-repository)" = false ] \
+            || die "'$SUB' is a shallow clone; ancestry guards cannot run"
+
+          OLD=$(git rev-parse --verify "HEAD:$SUB") || die "cannot read gitlink HEAD:$SUB"
+          git -C "$SUB" rev-parse --verify -q "$OLD^{commit}" >/dev/null \
+            || die "pinned commit $OLD not found in '$SUB'"
+
+          # Must run before resolution: an orphaned pin yields the same empty result as "already at tip".
+          if ! git -C "$SUB" merge-base --is-ancestor "$OLD" "$REMOTE_BRANCH"; then
+            [ "$MODE" = at ] && [ "$REANCHOR" = true ] \
+              || die "pinned commit $OLD is NOT an ancestor of $REMOTE_BRANCH in '$SUB'. History was rewritten or the pin is off-branch. Recover by running the workflow manually with an explicit target_sha and reanchor=true."
+            echo "::warning::pin $OLD is not on $REMOTE_BRANCH; re-anchoring by explicit request."
+            FF_REQUIRED=false
+          fi
+
+          case "$MODE" in
+            next)
+              # tail -n1, not head -n1 (SIGPIPE under pipefail), not --reverse -n1 (returns the tip).
+              TARGET=$(git -C "$SUB" rev-list --first-parent "$OLD..$REMOTE_BRANCH" | tail -n1)
+              [ -n "$TARGET" ] && [ "$TARGET" != "$OLD" ] \
+                || noop "$SUB already at $REMOTE_BRANCH tip ($OLD)"
+              STEP_PARENT=$(git -C "$SUB" rev-parse --verify -q "$TARGET^") \
+                || die "resolved target $TARGET has no parent"
+              [ "$STEP_PARENT" = "$OLD" ] \
+                || die "pin $OLD is not on the first-parent line of $REMOTE_BRANCH (next=$TARGET, its parent=$STEP_PARENT). Re-anchor deliberately by running the workflow manually with an explicit target_sha."
+              ;;
+            at)
+              INPUT_SHA=$(printf '%s' "$INPUT_SHA" | tr '[:upper:]' '[:lower:]')
+              [[ "$INPUT_SHA" =~ ^[0-9a-f]{40}$ ]] \
+                || die "target_sha must be a full 40-char lowercase commit SHA, got '$INPUT_SHA'"
+              TARGET=$(git -C "$SUB" rev-parse --verify --end-of-options "$INPUT_SHA^{commit}") \
+                || die "commit $INPUT_SHA not found in '$SUB'"
+              [ "$TARGET" = "$INPUT_SHA" ] || die "$INPUT_SHA is not a commit (peeled to $TARGET)"
+              [ "$TARGET" != "$OLD" ] || noop "$SUB already pinned at $TARGET"
+              ;;
+            *) die "unknown mode '$MODE' (expected next|at)" ;;
+          esac
+
+          if [ "$FF_REQUIRED" = true ]; then
+            git -C "$SUB" merge-base --is-ancestor "$OLD" "$TARGET" \
+              || die "refusing to move '$SUB' BACKWARD: $OLD -> $TARGET is not fast-forward"
+          fi
+          # A side-branch commit can be a descendant of OLD, so the guard above cannot catch it.
+          git -C "$SUB" merge-base --is-ancestor "$TARGET" "$REMOTE_BRANCH" \
+            || die "refusing to pin '$SUB' to $TARGET: not contained in $REMOTE_BRANCH"
+
+          git -C "$SUB" checkout -q --detach "$TARGET"
+          NEW=$(git -C "$SUB" rev-parse HEAD)
+          [ "$NEW" = "$TARGET" ] || die "post-condition failed: '$SUB' HEAD is $NEW, expected $TARGET"
+
+          SLUG=$(git config -f .gitmodules --get "submodule.$SUB.url" \
+                 | sed -E 's#^.*github\.com[:/]##; s#\.git$##')
+          COUNT=$(git -C "$SUB" rev-list --count "$OLD..$TARGET")
+          TAG=$(git -C "$SUB" log --format=%s "$OLD..$TARGET" \
+                | grep -oE '^\[[A-Z]+-[0-9]+\]' | sed -n 1p || true)
+          [ -n "$TAG" ] || TAG="$FALLBACK_TAG"
+          AUTHOR=$(gh api "repos/$SLUG/commits/$TARGET" --jq '.author.login // ""' || true)
+
+          {
+            echo "changed=true"
+            echo "old_short=${OLD:0:7}"
+            echo "new_short=${TARGET:0:7}"
+            echo "count=$COUNT"
+            echo "compare=https://github.com/$SLUG/compare/$OLD...$TARGET"
+            echo "title=$TAG Update $SUB submodule to ${TARGET:0:7}"
+            echo "author=$AUTHOR"
+            echo "manifest<<__MANIFEST__"
+            git -C "$SUB" log --no-decorate --reverse --format='- %s%n%w(0,2,2)%b%n' "$OLD..$TARGET" \
+              | sed 's/[[:space:]]*$//' | cat -s
+            echo "__MANIFEST__"
+          } >> "$GITHUB_OUTPUT"
+          echo "$SUB: $OLD -> $TARGET ($COUNT commit(s), mode=$MODE)"
+
+      - name: Create PR
+        if: steps.pin.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ steps.app-token.outputs.token }}
-          branch: bump/${{ env.SUB_PATH }}
+          branch: bump/${{ matrix.sub }}
           base: ${{ env.BASE_BRANCH }}
-          title: ${{ steps.title.outputs.value }}
-          commit-message: ${{ steps.title.outputs.value }}
-          body: |
-            Automated submodule bump for `${{ env.SUB_PATH }}`.
+          title: ${{ steps.pin.outputs.title }}
+          commit-message: |
+            ${{ steps.pin.outputs.title }}
 
-            - New SHA: `${{ steps.bump.outputs.new_sha }}`
-            - Source commit: `${{ env.COMMIT_MSG }}`
-            - Pushed by: @${{ env.PUSHER }}
+            ${{ steps.pin.outputs.old_short }} -> ${{ steps.pin.outputs.new_short }} (${{ steps.pin.outputs.count }} commit(s))
+            ${{ steps.pin.outputs.compare }}
+
+            ${{ steps.pin.outputs.manifest }}
+          body: |
+            Automated submodule bump for `${{ matrix.sub }}`.
+
+            - `${{ steps.pin.outputs.old_short }}` -> `${{ steps.pin.outputs.new_short }}` (${{ steps.pin.outputs.count }} commit(s))
+            - Compare: ${{ steps.pin.outputs.compare }}
+
+            <details><summary>Included commits</summary>
+
+            ${{ steps.pin.outputs.manifest }}
+
+            </details>
           labels: Submodule Auto Update
-          assignees: ${{ env.PUSHER }}
+          assignees: ${{ steps.pin.outputs.author }}
           delete-branch: true


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1517>

### Purpose
기존 bump PR은 서브모듈 포인터를 생성 시점의 최신 커밋까지 한 번에 올립니다. PR이 열린 상태에서 서브모듈에 새로운 커밋이 추가되면 해당 커밋들도 같은 PR에 계속 누적됩니다. 이 때문에 CI가 실패할 경우, 여러 커밋 중 어떤 커밋이 원인인지 별도로 확인해야 했습니다.

이를 개선하기 위해 서브모듈 포인터를 한 번에 한 커밋씩만 올리도록 변경했습니다. 각 서브모듈에는 동시에 하나의 bump PR만 열리며, 각 PR에는 하나의 커밋만 포함됩니다. 

### Implementation

동작이 이렇게 바뀝니다.
| 대상 | 현재 | 변경 후 |
|---|---|---|
| 포인터 전진 폭 | 서브모듈 최신까지 한 번에 | 한 커밋씩 |
| 트리거 | 서브모듈 신호, 수동 실행 | 서브모듈 신호, 부모의 포인터 변경, 수동 실행 |
| 수동 실행 입력 | `commit_message`, `pusher` | `target_sha`(필수, 40자), `reanchor` |
| PR 제목 | `[키] Update <서브모듈> submodule` | 끝에 SHA 7자 추가 |
| 커밋 메시지 | 제목 한 줄 | 비교 링크 + 포함 커밋 전체 메시지 |

서브모듈 develop의 커밋이 대기열이고, 부모가 기록한 커밋 SHA가 어디까지 반영했는지 가리키는 포인터입니다.

```mermaid
flowchart LR
  A[트리거] --> B{열린 bump PR 있나}
  B -->|있음| C[종료]
  B -->|없음| D[포인터 다음 커밋 1건만 반영]
  D --> E[PR 생성]
  E --> F[머지되면 포인터 이동]
  F --> A
```

수동 실행은 입력 받은 SHA로 포인터를 옮깁니다. 한 PR에 여러 커밋을 한 번에 넣고 싶을 때 사용하는 기능입니다. 이미 열린 bump PR이 있으면 수동 실행 시 새 PR 대신 bump PR이 갱신됩니다.

수동 실행 방법
CUBRID/cubrid → Actions → **Submodule bump (receiver)** → **Run workflow**
| 입력 | 값 |
|---|---|
| Use workflow from | `develop` |
| Target submodule | 대상 서브모듈 선택 |
| Submodule commit to pin | 반영할 커밋의 **40자 SHA** |
| Allow a non-fast-forward re-anchor | 평소에는 체크하지 않음 |

**Allow a non-fast-forward re-anchor**
서브모듈에서 강제 푸시로 커밋 이력이 다시 쓰으면, 기록해둔 그 커밋이 develop에서 사라지게 되므로 다음 커밋을 계산할 수 없습니다. 그 때 새 이력에 대응하는 커밋의 SHA를 다시 넣는 기능으로 평소에 쓸 일은 없습니다.

### Remarks

N/A
