### PR TITLE
[CBRD-27200] [Backport-11.4.6] Do not treat a constant TRUE predicate as a real one when merging a view

### DIFF
--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -367,6 +367,7 @@ extern "C"
   extern PT_NODE *pt_where_type (PARSER_CONTEXT * parser, PT_NODE * where);
   extern PT_NODE *pt_where_type_keep_true (PARSER_CONTEXT * parser, PT_NODE * where);
   extern bool pt_false_search_condition (PARSER_CONTEXT * parser, const PT_NODE * statement);
+  extern bool pt_true_search_condition (PARSER_CONTEXT * parser, const PT_NODE * statement);
   extern const char *mq_generate_name (PARSER_CONTEXT * parser, const char *root, int *version);
   extern int mq_is_real_class_of_vclass (PARSER_CONTEXT * parser, const PT_NODE * s_class, const PT_NODE * d_class);
   extern void pt_no_double_insert_assignments (PARSER_CONTEXT * parser, PT_NODE * stmt);

--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -7169,6 +7169,40 @@ pt_false_search_condition (PARSER_CONTEXT * parser, const PT_NODE * node)
 }
 
 /*
+ * pt_true_search_condition () - Test for constant-folded search condition
+ * 				  that evaluated true
+ *   return: true if there is no search condition or all of the conjuncts are
+ *           effectively true, false otherwise
+ *   parser(in):
+ *   node(in):
+ *
+ * Note: A search condition folded to TRUE is a no-op, but it is not removed
+ *       from the CNF list. pt_where_type () removes such a conjunct while it
+ *       runs in the type checking walk of pt_semantic_type (), which is done
+ *       before the constant folding walk. So an expression of constants like
+ *       '1=1' is still an expression when it is checked and it becomes a
+ *       folded TRUE value only afterwards.
+ *       Use this function instead of a plain 'where == NULL' test to keep a
+ *       no-op predicate from being treated as a real one.
+ */
+bool
+pt_true_search_condition (PARSER_CONTEXT * parser, const PT_NODE * node)
+{
+  while (node)
+    {
+      if (node->or_next != NULL || node->node_type != PT_VALUE || node->type_enum != PT_TYPE_LOGICAL
+	  || node->info.value.data_value.i != 1)
+	{
+	  return false;
+	}
+
+      node = node->next;
+    }
+
+  return true;
+}
+
+/*
  * pt_to_false_subquery () -
  *   return:
  *   parser(in):

--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -2080,8 +2080,10 @@ mq_is_pushable_subquery (PARSER_CONTEXT * parser, PT_NODE * subquery, PT_NODE * 
 
   /* determine if class_spec is the only spec in the statement */
   is_rownum_only = mq_is_rownum_only_predicate (parser, statement_spec, mainquery, order_by, subquery, class_);
+  /* A predicate folded to TRUE, e.g. 'WHERE 1=1', is a no-op. Do not count it as a real predicate here, otherwise it
+   * blocks the merging of a view which would be merged without it. */
   is_only_spec =
-    ((statement_spec->next == NULL && (pred == NULL || is_rownum_only)
+    ((statement_spec->next == NULL && (pt_true_search_condition (parser, pred) || is_rownum_only)
       && (subquery->info.query.order_by == NULL || order_by == NULL)) ? true : false);
 
   /* check if orderby_for set to PT_EXPR_INFO_ROWNUM_ONLY */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27200

## Purpose

develop 의 CBRD-27200 수정(#7632, `f0e2c07bc`)을 `release/11.4` 로 백포트합니다.

`WHERE 1=1` 처럼 상수 폴딩되어 TRUE 가 된 술어는 아무 일도 하지 않지만, 뷰 머징 판정에서는 "실제 술어" 로 세어져 머징을 막고 있었습니다. 그 결과 술어를 빼면 머징되던 질의가 술어를 붙이는 것만으로 플랜이 달라집니다.

```sql
SELECT * FROM v LEFT OUTER JOIN t ON ... WHERE 1=1;   /* 머징 안 됨 */
SELECT * FROM v LEFT OUTER JOIN t ON ...;             /* 머징 됨 */
```

원인은 판정 시점입니다. `pt_where_type ()` 은 항상 참인 conjunct 를 잘라내지만 `pt_semantic_type ()` 의 타입 검사 walk 에서 돌고, 상수 폴딩 walk 는 그 뒤에 돕니다. 그래서 `1=1` 은 검사 시점에는 아직 표현식이고, 폴딩된 TRUE 값 노드로 바뀐 뒤에는 아무도 걷어내지 않은 채 CNF 리스트에 남습니다.

## Implementation

develop 커밋을 그대로 cherry-pick 했습니다(충돌 없음, 3 files / +38 -1).

`mq_is_pushable_subquery ()` 의 `pred == NULL` 검사를 `pt_true_search_condition (parser, pred)` 로 바꿔, 폴딩된 TRUE 만 남은 술어를 술어 없음과 동일하게 취급합니다.

판정 기준을 새로 만든 것이 아니라, CUBRID 가 이미 쓰고 있는 "상수 폴딩된 논리값" 판정의 참(TRUE) 버전입니다. `pt_where_type ()` 이 항상 참 conjunct 를 잘라낼 때 보는 노드 형태(`PT_VALUE` + `PT_TYPE_LOGICAL` + `data_value.i == 1`), `pt_false_search_condition ()` 이 항상 거짓을 판정할 때 보는 형태와 같습니다.

conjunct 하나라도 아래에 걸리면 즉시 false 를 반환해 기존과 동일하게 실제 술어로 취급합니다.

| 케이스 | 결과 |
|---|---|
| 식(`v.a > 0`), 컬럼 참조 | `node_type != PT_VALUE` → 실제 술어 |
| 호스트 변수(`WHERE ?`) | `PT_HOST_VAR` → 실제 술어 |
| 서브쿼리 / 메서드 포함 | 폴딩 대상이 아님 → 실제 술어 |
| `WHERE NULL` | `type_enum != PT_TYPE_LOGICAL` → 실제 술어(항상 거짓 경로 유지) |
| OR 체인(`or_next != NULL`) | 보수적으로 실제 술어 |
| `1=1 AND v.a > 0` | conjunct 하나 실패 → 실제 술어 |
| `WHERE 1=0` | `data_value.i == 0` → 기존 always_false 경로 유지 |

못 알아보는 방향의 실패는 기존 동작 그대로 "머징하지 않음" 이고, 의미 있는 술어를 no-op 으로 오인해 머징하는 방향은 위 조건상 만들어지지 않습니다.

## Remarks

- develop 에서는 release 빌드 / SA 모드로 13 케이스 A/B 를 돌려, 의도한 4 건(`1=1`, `'a'='a'`, `1=1 AND 2=2`, `1=1 OR pred`)만 미머징→머징으로 바뀌고 나머지(`v.a > 0`, `1=1 AND v.a > 0`, `1=0`, `ROWNUM <= 10`, GROUP BY 뷰, 뷰 안 ORDER BY 등)는 불변, **모든 케이스에서 결과 집합 동일**을 확인했습니다.
- 11.4 에서도 관련 코드가 develop 과 동일합니다. `mq_is_pushable_subquery ()` 의 `pred == NULL` 판정, `pt_where_type ()` 의 참 conjunct 제거 조건, 타입 검사 walk 와 상수 폴딩 walk 의 순서가 모두 같아 동일한 증상이 성립합니다. 다만 11.4 빌드에서의 A/B 실측은 아직 수행하지 않았습니다.
- 테스트케이스는 develop 쪽 PR 과 동일하게 별도 TC PR 로 처리합니다.
