### PR TITLE
[CBRD-27216] Free the empty result buffer on the oversize REPEAT error path

### DIFF
--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -2141,6 +2141,7 @@ db_string_repeat (const DB_VALUE * src_string, const DB_VALUE * count, DB_VALUE 
 	{
 	  er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_STRING_SIZE_TOO_BIG, 2, (size_t) expected_size,
 		  (int) prm_get_bigint_value (PRM_ID_STRING_MAX_SIZE_BYTES));
+	  pr_clear_value (&dummy);
 	  return ER_QPROC_STRING_SIZE_TOO_BIG;
 	}
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27216

### Purpose
- `db_string_repeat` 의 oversize error path 에서 `dummy` 가 해제되지 않는다. #7679 로 이 분기가 처음 도달 가능해졌다.

### Implementation
- `ER_QPROC_STRING_SIZE_TOO_BIG` return 앞에 `pr_clear_value (&dummy)` 추가.

### Remarks
- 이 분기는 `int` 곱셈 시절 결과가 `DB_INT32_MAX` 를 넘을 수 없어 도달 불가능했고, #7679 의 64-bit 곱셈으로 살아났다. 누락 자체는 그 이전부터 있던 잠복 결함이다.
- 누수량은 `db_string_make_empty_typed_string` 이 잡는 `db_private_alloc (NULL, 1)` 1바이트이다