### PR TITLE
[CBRD-27242] allow unqualified column name to find a column in a ResultSet

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/jdbc/CUBRIDServerSideResultSet.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/jdbc/CUBRIDServerSideResultSet.java
@@ -55,7 +55,6 @@ import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Calendar;
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -73,9 +72,6 @@ public class CUBRIDServerSideResultSet implements ResultSet {
 
     private int type = TYPE_FORWARD_ONLY;
     private int concurrency = CONCUR_READ_ONLY;
-
-    /* For findColumn */
-    protected HashMap<String, Integer> colNameToIdx;
 
     private boolean isInserting;
     private int currentRowIndex = -1;
@@ -449,10 +445,36 @@ public class CUBRIDServerSideResultSet implements ResultSet {
 
     @Override
     public int findColumn(String columnName) throws SQLException {
-        Integer index = statementHandler.getColNameIndex().get(columnName.toLowerCase());
+
+        // NOTE: Suppose that a user wrote T.col as a column in a SELECT statement,
+        // In client-side JDBC, columnName argument must be "col" to find its index.
+        // In server-side JDBC, however, both "T.col" and "col" are allowed.
+
+        String colName = columnName.toLowerCase();
+        Map<String, Integer> colNameToIdx = statementHandler.getColNameIndex();
+
+        // first, try exact match
+        Integer index = colNameToIdx.get(colName);
         if (index == null) {
-            throw CUBRIDServerSideJDBCErrorManager.createCUBRIDException(
-                    CUBRIDServerSideJDBCErrorCode.ER_INVALID_COLUMN_NAME, null);
+
+            // second, try postfix match with a dot
+            String dotColName = "." + colName;
+            for (String cn : colNameToIdx.keySet()) {
+                if (cn.endsWith(dotColName)) {
+                    if (index == null) {
+                        index = colNameToIdx.get(cn);
+                    } else {
+                        // we already found one. duplicate
+                        index = null;
+                        break;
+                    }
+                }
+            }
+
+            if (index == null) {
+                throw CUBRIDServerSideJDBCErrorManager.createCUBRIDException(
+                        CUBRIDServerSideJDBCErrorCode.ER_INVALID_COLUMN_NAME, null);
+            }
         }
 
         return index.intValue() + 1;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27242>

서버사이드 JDBC 의 ResultSet.findMethod() 구현에서 (조희 결과에서 컬럼 이름으로 컬럼 인덱스를 찾는 메소드)
사용자가 SLECT query에 컬럼을 T.col 이라고 썼을 때 findMethod() 의 인자로 "col" 을 허용하도록 수정.
현재는 "T.col" 이라고 써야 동작.
(참고: JDBC 구현에서는 반대로 "col" 이라고 써야 동작. "T.col" 이라고 쓰면 에러)

develop 브랜치에서의 변경을 git cherry-pick 했습니다. 
