### PR TITLE
[CBRD-27245] Improve lexer input handling for UTF-8 statements

### DIFF
--- a/src/parser/csql_lexer.l
+++ b/src/parser/csql_lexer.l
@@ -2152,6 +2152,15 @@ parser_yyinput_multi_line (char *buff, int max_size)
   int i = 0;
 
   assert (max_size >= 1);
+
+  /* copy the in-memory input in one step; the loop below finishes EOF and non-memory inputs */
+  i = parser_copy_memory_input (this_parser, buff, max_size);
+  if (i == max_size)
+    {
+      buff[i] = 0;
+      return i;
+    }
+
   for (;;)
     {
       c = pt_nextchar ();

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -1983,8 +1983,10 @@ parser_parse_string_with_escapes (PARSER_CONTEXT * parser, const char *buffer, c
   parser->original_buffer = buffer;
 
   parser->next_byte = buffgetin;
-  if (LANG_VARIABLE_CHARSET (lang_charset ()))
+  if (lang_charset () == INTL_CODESET_KSC5601_EUC)
     {
+      /* the DBCS filter is for the 2-byte codeset only: on UTF-8 its full-width space fold never matches
+       * and its byte pairing corrupts multi-byte characters */
       parser->next_char = dbcs_get_next;
       parser->casecmp = intl_identifier_casecmp;
     }
@@ -2044,8 +2046,10 @@ parser_parse_binary (PARSER_CONTEXT * parser, const char *buffer, size_t size)
     return 0;
   parser->buffer = buffer;
   parser->next_byte = binarygetin;
-  if (LANG_VARIABLE_CHARSET (lang_charset ()))
+  if (lang_charset () == INTL_CODESET_KSC5601_EUC)
     {
+      /* the DBCS filter is for the 2-byte codeset only: on UTF-8 its full-width space fold never matches
+       * and its byte pairing corrupts multi-byte characters */
       parser->next_char = dbcs_get_next;
       parser->casecmp = intl_identifier_casecmp;
     }
@@ -2092,8 +2096,10 @@ parser_parse_file (PARSER_CONTEXT * parser, FILE * file)
     }
   parser->file = file;
   parser->next_byte = fgetin;
-  if (LANG_VARIABLE_CHARSET (lang_charset ()))
+  if (lang_charset () == INTL_CODESET_KSC5601_EUC)
     {
+      /* the DBCS filter is for the 2-byte codeset only: on UTF-8 its full-width space fold never matches
+       * and its byte pairing corrupts multi-byte characters */
       parser->next_char = dbcs_get_next;
       parser->casecmp = intl_identifier_casecmp;
     }
@@ -2149,8 +2155,10 @@ pt_init_one_statement_parser (PARSER_CONTEXT * parser, FILE * file)
     }
   parser->file = file;
   parser->next_byte = fgetin;
-  if (LANG_VARIABLE_CHARSET (lang_charset ()))
+  if (lang_charset () == INTL_CODESET_KSC5601_EUC)
     {
+      /* the DBCS filter is for the 2-byte codeset only: on UTF-8 its full-width space fold never matches
+       * and its byte pairing corrupts multi-byte characters */
       parser->next_char = dbcs_get_next;
       parser->casecmp = intl_identifier_casecmp;
     }

--- a/src/parser/parse_tree_cl.c
+++ b/src/parser/parse_tree_cl.c
@@ -2028,6 +2028,39 @@ parser_parse_string_with_escapes (PARSER_CONTEXT * parser, const char *buffer, c
   return tree;
 }
 
+/*
+ * parser_copy_memory_input () - copy input bytes up to the terminator in one step
+ *   return: number of bytes copied into buffer
+ *   parser(in): parser context
+ *   buffer(out): destination
+ *   max_size(in): destination capacity
+ *
+ * The terminating NUL is left in the input,
+ * so the caller's loop still reaches end of input through buffgetin.
+ */
+int
+parser_copy_memory_input (PARSER_CONTEXT * parser, char *buffer, int max_size)
+{
+  assert (buffer != NULL);
+  assert (max_size > 0);
+
+  /* copy in bulk only when the statement is in memory and no DBCS filter is set;
+   * next_char is buffgetin in exactly that case.
+   * With the filter, buffgetin moves to next_byte and every byte must pass the filter. */
+  if (parser == NULL || parser->next_char != buffgetin || max_size <= 0)
+    {
+      return 0;
+    }
+
+  int n = (int) strnlen (parser->buffer, max_size);
+  memcpy (buffer, parser->buffer, n);
+
+  /* n stops before the NUL, so this leaves it as the next input byte */
+  parser->buffer += n;
+
+  return n;
+}
+
 #if defined (ENABLE_UNUSED_FUNCTION)
 /*
  * parser_parse_binary() - reset and initialize the parser

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -78,6 +78,7 @@ extern "C"
   extern PT_NODE **parser_parse_string_with_escapes (PARSER_CONTEXT * parser, const char *buffer,
 						     const bool no_escapes_strings);
   extern PT_NODE **parser_parse_string_use_sys_charset (PARSER_CONTEXT * parser, const char *buffer);
+  extern int parser_copy_memory_input (PARSER_CONTEXT * parser, char *buffer, int max_size);
 #if defined(ENABLE_UNUSED_FUNCTION)
   extern PT_NODE **parser_parse_binary (PARSER_CONTEXT * parser, const char *buffer, size_t size);
 #endif


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27245

### Purpose

DBCS 필터 선택 조건 `LANG_VARIABLE_CHARSET` 이 UTF-8 에도 참이라, UTF-8 입력이 2바이트 문자셋 전용 필터를 경유하며 다중바이트 문자가 손상된다. 선택 조건을 필터의 원래 대상인 EUC-KR 로 한정해 UTF-8 입력을 필터에서 제외하고, 메모리 버퍼의 문장은 스캐너 버퍼를 채울 때마다 한 번의 복사로 전달해 바이트당 두 번 발생하던 함수 호출을 제거한다.

### Implementation

- 파서 입력 함수를 설정하는 네 곳에서 DBCS 필터 선택 조건을 `LANG_VARIABLE_CHARSET` 판정에서 `INTL_CODESET_KSC5601_EUC` 동등 비교로 좁힌다.
- `parser_copy_memory_input` 이 입력의 현재 위치부터 종료 NUL 직전까지를 한 번의 `memcpy` 로 복사한다. NUL 은 소비하지 않고 입력에 남겨, 입력 끝 판정이 기존 경로에서 그대로 실행되게 한다.
- 기본 입력 피더(`parser_yyinput_multi_line`)가 이 함수를 먼저 호출하고, 메모리 버퍼 입력이 아니면 반환값 0 을 받아 기존 바이트 단위 경로를 그대로 실행한다.

### Remarks

- 파싱 결과가 달라지는 입력은 DBCS 필터가 UTF-8 식별자를 손상시키던 경우뿐이다. 이전 동작이 결함이었다.
- 파일 입력, 바이너리 입력, DBCS 필터 경유 입력에는 벌크 복사가 적용되지 않는다. 세 경로의 동작은 변경 전과 같다.
- 같은 분기가 `casecmp` 도 설정하지만 두 갈래 모두 `intl_identifier_casecmp` 를 대입하므로 식별자 비교는 달라지지 않는다.
