### PR TITLE
[CBRD-27246] Improve value transfer for domain-matching values

### DIFF
--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -11619,10 +11619,17 @@ heap_attrinfo_set (const OID * inst_oid, ATTR_ID attrid, DB_VALUE * attr_val, HE
 	      use_fast_path = true;
 	      break;
 	    case DB_TYPE_VARCHAR:
+	    case DB_TYPE_CHAR:
 	      /* Precision counts characters. Byte size settles it whenever it already fits,
 	       * which covers a single-byte codeset and anything with room to spare;
 	       * only a multi-byte value that fills the column needs the character count,
-	       * and that is a value the generic path would count as well. */
+	       * and that is a value the generic path would count as well.
+	       * CHAR carries trailing-space padding, but the padding is applied on the way out,
+	       * by mr_lengthval_char_internal, keyed off the precision the value carries --
+	       * which is why the stamp below is not optional for CHAR. Nothing between here and
+	       * heap_attrinfo_transform_to_disk reads the value: index keys are read back from
+	       * the built record, and REPLACE builds its own record first. So handing the value
+	       * over still unpadded is not observable. */
 	      if (attr_val->data.ch.info.is_max_string == false
 		  && db_get_string_codeset (attr_val) == TP_DOMAIN_CODESET (domain)
 		  && db_get_string_collation (attr_val) == TP_DOMAIN_COLLATION (domain)
@@ -11646,12 +11653,15 @@ heap_attrinfo_set (const OID * inst_oid, ATTR_ID attrid, DB_VALUE * attr_val, HE
 
 	      value->dbvalue = *attr_val;
 	      value->dbvalue.need_clear = false;
-	      if (src_type == DB_TYPE_VARCHAR)
+	      if (src_type == DB_TYPE_VARCHAR || src_type == DB_TYPE_CHAR)
 		{
 		  value->dbvalue.data.ch.info.compressed_need_clear = false;
 		  /* The generic path coerces into the column domain, so the value it leaves
 		   * carries the column's precision. Carry it here too, or the same column
-		   * would hold values whose precision depends on which path set them. */
+		   * would hold values whose precision depends on which path set them.
+		   * For CHAR this is what makes the trailing-space padding happen at all:
+		   * mr_writeval_char_internal skips padding on a floating precision, which
+		   * is what a literal and a bound value both arrive with. */
 		  value->dbvalue.domain.char_info.length = domain->precision;
 		}
 

--- a/src/storage/heap_file.c
+++ b/src/storage/heap_file.c
@@ -11594,6 +11594,74 @@ heap_attrinfo_set (const OID * inst_oid, ATTR_ID attrid, DB_VALUE * attr_val, HE
       goto exit_on_error;
     }
 
+  /* Hand over a value whose type already matches the column domain by struct copy,
+   * skipping the domain check, the domain init and the setval dispatch,
+   * which repeat the same verdict for every row of a multi-row INSERT.
+   * The slow path below passes strings by reference as well (setval with copy == false),
+   * so the shallow copy does not change ownership.
+   * CHAR needs pad semantics and set/LOB types need real cloning -- slow path. */
+  if (!DB_IS_NULL (attr_val))
+    {
+      TP_DOMAIN *domain = value->last_attrepr->domain;
+      DB_TYPE src_type = DB_VALUE_DOMAIN_TYPE (attr_val);
+
+      if (src_type == TP_DOMAIN_TYPE (domain))
+	{
+	  bool use_fast_path = false;
+
+	  switch (src_type)
+	    {
+	    case DB_TYPE_INTEGER:
+	    case DB_TYPE_BIGINT:
+	    case DB_TYPE_SHORT:
+	    case DB_TYPE_FLOAT:
+	    case DB_TYPE_DOUBLE:
+	      use_fast_path = true;
+	      break;
+	    case DB_TYPE_VARCHAR:
+	      /* Precision counts characters. Byte size settles it whenever it already fits,
+	       * which covers a single-byte codeset and anything with room to spare;
+	       * only a multi-byte value that fills the column needs the character count,
+	       * and that is a value the generic path would count as well. */
+	      if (attr_val->data.ch.info.is_max_string == false
+		  && db_get_string_codeset (attr_val) == TP_DOMAIN_CODESET (domain)
+		  && db_get_string_collation (attr_val) == TP_DOMAIN_COLLATION (domain)
+		  && (db_get_string_size (attr_val) <= domain->precision
+		      || db_get_string_length (attr_val) <= domain->precision))
+		{
+		  use_fast_path = true;
+		}
+	      break;
+	    default:
+	      break;
+	    }
+
+	  if (use_fast_path)
+	    {
+	      ret = pr_clear_value (&value->dbvalue);
+	      if (ret != NO_ERROR)
+		{
+		  goto exit_on_error;
+		}
+
+	      value->dbvalue = *attr_val;
+	      value->dbvalue.need_clear = false;
+	      if (src_type == DB_TYPE_VARCHAR)
+		{
+		  value->dbvalue.data.ch.info.compressed_need_clear = false;
+		  /* The generic path coerces into the column domain, so the value it leaves
+		   * carries the column's precision. Carry it here too, or the same column
+		   * would hold values whose precision depends on which path set them. */
+		  value->dbvalue.domain.char_info.length = domain->precision;
+		}
+
+	      value->state = HEAP_WRITTEN_ATTRVALUE;
+
+	      return NO_ERROR;
+	    }
+	}
+    }
+
   pr_type = pr_type_from_id (value->last_attrepr->type);
   if (pr_type == NULL)
     {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27246

### Purpose

`heap_attrinfo_set` 이 값마다 범용 절차를 전부 거친다. 표 조회, 대상 초기화, 도메인 대조, 함수 포인터 호출이 값이 이미 컬럼과 맞는 흔한 경우에도 그대로 난다. 타입이 맞는 값은 구조체 복사로 넘긴다.

### Implementation

- 컬럼 위치를 찾은 직후 값싼 직접 비교로 판정하고, 통과하면 구조체를 복사한 뒤 `HEAP_WRITTEN_ATTRVALUE` 로 표시하고 돌아간다. 어긋나면 기존 절차로 간다.
- 대상은 고정폭 수치형과 `CHAR`·`VARCHAR` 다. 문자셋·정렬 규칙이 같고 `is_max_string` 이 아니어야 한다. NULL, 집합, LOB, 타입이 다른 값은 기존 절차를 그대로 거친다.
- 길이 판정은 바이트 수를 먼저 본다. 글자 수는 바이트 수를 넘을 수 없으므로 바이트 수가 정밀도 이하면 확정이고, 넘을 때만 글자 수를 센다.
- 복사한 값에 컬럼 정밀도를 찍는다. 형변환이 남겼을 값과 같게 만든다.

### Remarks

- `need_clear` 를 `false` 로 명시해 해제 책임을 원본에 남긴다. 기존 절차도 비집합 타입은 `setval` 을 `copy == false` 로 부르므로 소유 관계가 달라지지 않는다.
- `CHAR` 의 공백 채우기는 값을 앉히는 시점이 아니라 `mr_lengthval_char_internal` 과 `mr_writeval_char_internal` 이 쓰는 시점에 한다. 그 채우기가 값이 든 정밀도를 기준으로 하므로 위의 정밀도 도장이 `CHAR` 에서는 데이터 정합성 문제다. 없으면 정밀도가 `-1` 로 남아 채우기가 통째로 건너뛰어진다.
- 앉힌 값과 레코드로 굽는 시점 사이에 그 값을 읽는 곳이 없다. 인덱스 키는 구워진 레코드에서 다시 읽고 `REPLACE` 는 자기 레코드를 먼저 굽는다.
- 기존 절차를 지우지 않는다. 진입 조건이 `TP_EXACT_MATCH` 가 통과했을 조건과 같은 항목을 직접 비교하고, 하나라도 어긋나면 원래 코드가 그대로 실행된다. 다른 점은 정밀도를 더 넓게 본다는 것뿐이고, 그 차이는 컬럼 정밀도를 찍어 메운다.
