### PR TITLE
[CBRD-27248] Improve character-count reuse for repeated length checks

### DIFF
--- a/src/compat/db_macro.c
+++ b/src/compat/db_macro.c
@@ -965,7 +965,9 @@ db_string_truncate (DB_VALUE * value, const int precision)
     {
     case DB_TYPE_STRING:
       val_str = db_get_string (value);
-      if (val_str != NULL && db_get_string_length (value) > precision)
+      /* char_count <= byte_count in every codeset, so byte_size <= precision guarantees
+       * no truncation -- the same bracket the CHAR branch below already uses. */
+      if (val_str != NULL && db_get_string_size (value) > precision && db_get_string_length (value) > precision)
 	{
 	  intl_char_size ((unsigned char *) val_str, precision, db_get_string_codeset (value), &byte_size);
 	  string = (char *) db_private_alloc (NULL, byte_size + 1);

--- a/src/loaddb/load_sa_loader.cpp
+++ b/src/loaddb/load_sa_loader.cpp
@@ -2844,6 +2844,10 @@ ldr_str_db_varchar (LDR_CONTEXT *context, const char *str, size_t len, SM_ATTRIB
   val.data.ch.info.compressed_need_clear = false;
   val.data.ch.medium.compressed_buf = NULL;
   val.data.ch.medium.compressed_size = DB_NOT_YET_COMPRESSED;
+  /* val is a local, and only the fields above are assigned. The character-count slot
+   * has to be reset like the rest, or it carries whatever was on the stack -- the CHAR
+   * sibling of this function already does it. */
+  val.data.ch.medium.length = -1;
 
   mem = context->mobj + att->offset;
   CHECK_ERR (err, att->domain->type->setmem (mem, att->domain, &val));

--- a/src/query/string_opfunc.c
+++ b/src/query/string_opfunc.c
@@ -8112,6 +8112,15 @@ db_get_string_length (const DB_VALUE * value)
   if (value->domain.general_info.type != DB_TYPE_BIT && value->domain.general_info.type != DB_TYPE_VARBIT)
     {
       intl_char_count ((unsigned char *) str, size, codeset, &length);
+
+      /* Keep the count. The slot was read above but nothing ever filled it, so every
+       * caller walked the same bytes again -- a CHAR value is counted once to decide
+       * the coercion and once more to decide the trailing-space padding.
+       * The count is a function of (buf, size, codeset) alone, and every constructor
+       * of a string value resets this slot together with those three, so a remembered
+       * count cannot outlive the bytes it was counted from. The value is const to the
+       * caller because the count it stands for does not change; only the memo does. */
+      CONST_CAST (DB_VALUE *, value)->data.ch.medium.length = length;
     }
 
   return length;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27248

### Purpose

`DB_VALUE` 는 문자열의 글자 수를 담는 칸을 갖고 있고 `db_get_string_length` 가 그 칸을 읽지만, 칸이 비어 직접 센 경우에 결과를 되쓰지 않는다. 그래서 같은 값의 글자 수를 다시 물으면 처음부터 다시 걷는다. 센 값을 기억하게 한다.

### Implementation

- `db_get_string_length` 가 `intl_char_count` 로 센 결과를 `data.ch.medium.length` 에 되쓴다. `CONST_CAST` 로 `const` 를 벗긴다.
- `db_string_truncate` 의 `DB_TYPE_STRING` 갈래에 바이트 선판정을 둔다. `CHAR` 갈래가 이미 쓰는 판정과 같다.
- `ldr_str_db_varchar` 의 지역 `DB_VALUE` 에 `medium.length = -1` 을 놓는다. 형제 함수인 `ldr_str_db_char` 은 이미 놓고 있다.

### Remarks

- 글자 수는 `(buf, size, codeset)` 만의 함수다. 그 셋을 바꾸는 대입 지점을 전수 조사했고 모두 이 칸을 함께 리셋한다. 기억한 값이 그 바이트보다 오래 살아남을 수 없다.
- 호출자에게 값은 변하지 않고 돌려주는 글자 수도 변하지 않는다. `const` 를 벗기는 것은 같은 답을 다시 계산하지 않기 위해서다.
- XASL 캐시 클론은 직렬화된 스트림에서 각자 언팩되어 자기 `DB_VALUE` 를 갖고, 한 번에 한 실행에만 대여된다. 캐시 쓰기가 공유 자료에 닿지 않는다.
- `ldr_str_db_varchar` 의 미초기화 칸은 현재 그 값을 읽는 경로가 없어 동작으로 드러나지 않는다. 칸을 신뢰하기 시작하는 변경과 같이 두는 편이 맞다고 보고 포함했다.
- BIT·VARBIT 는 글자 수를 세지 않는 갈래로 빠지며 그 갈래에서는 캐시를 채우지 않는다. 길이의 의미가 달라지지 않는다.
