### PR TITLE
[CBRD-27255] Detect multiplication overflow without dividing

### DIFF
--- a/src/parser/type_checking.c
+++ b/src/parser/type_checking.c
@@ -14937,15 +14937,11 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 
 	    case DB_TYPE_INTEGER:
 	      {
-		/* NOTE that we need volatile to prevent optimizer from generating division expression as
-		 * multiplication.
-		 */
-		volatile int i1, i2, itmp;
+		int i1 = db_get_int (arg1);
+		int i2 = db_get_int (arg2);
+		int itmp;
 
-		i1 = db_get_int (arg1);
-		i2 = db_get_int (arg2);
-		itmp = i1 * i2;
-		if (OR_CHECK_MULT_OVERFLOW (i1, i2, itmp))
+		if (__builtin_mul_overflow (i1, i2, &itmp))
 		  {
 		    goto overflow;
 		  }
@@ -14958,15 +14954,11 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 
 	    case DB_TYPE_BIGINT:
 	      {
-		/* NOTE that we need volatile to prevent optimizer from generating division expression as
-		 * multiplication.
-		 */
-		volatile DB_BIGINT bi1, bi2, bitmp;
+		DB_BIGINT bi1 = db_get_bigint (arg1);
+		DB_BIGINT bi2 = db_get_bigint (arg2);
+		DB_BIGINT bitmp;
 
-		bi1 = db_get_bigint (arg1);
-		bi2 = db_get_bigint (arg2);
-		bitmp = bi1 * bi2;
-		if (OR_CHECK_MULT_OVERFLOW (bi1, bi2, bitmp))
+		if (__builtin_mul_overflow (bi1, bi2, &bitmp))
 		  {
 		    goto overflow;
 		  }
@@ -14979,15 +14971,11 @@ pt_evaluate_db_value_expr (PARSER_CONTEXT * parser, PT_NODE * expr, PT_OP_TYPE o
 
 	    case DB_TYPE_SHORT:
 	      {
-		/* NOTE that we need volatile to prevent optimizer from generating division expression as
-		 * multiplication.
-		 */
-		volatile short s1, s2, stmp;
+		short s1 = db_get_short (arg1);
+		short s2 = db_get_short (arg2);
+		short stmp;
 
-		s1 = db_get_short (arg1);
-		s2 = db_get_short (arg2);
-		stmp = s1 * s2;
-		if (OR_CHECK_MULT_OVERFLOW (s1, s2, stmp))
+		if (__builtin_mul_overflow (s1, s2, &stmp))
 		  {
 		    goto overflow;
 		  }

--- a/src/query/query_opfunc.c
+++ b/src/query/query_opfunc.c
@@ -4798,13 +4798,10 @@ qdata_subtract_dbval (DB_VALUE * dbval1_p, DB_VALUE * dbval2_p, DB_VALUE * resul
 static int
 qdata_multiply_short (DB_VALUE * short_val_p, short s2, DB_VALUE * result_p)
 {
-  /* NOTE that we need volatile to prevent optimizer from generating division expression as multiplication */
-  volatile short s1, stmp;
+  short s1 = db_get_short (short_val_p);
+  short stmp;
 
-  s1 = db_get_short (short_val_p);
-  stmp = s1 * s2;
-
-  if (OR_CHECK_MULT_OVERFLOW (s1, s2, stmp))
+  if (__builtin_mul_overflow (s1, s2, &stmp))
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_OVERFLOW_MULTIPLICATION, 0);
       return ER_FAILED;
@@ -4818,13 +4815,10 @@ qdata_multiply_short (DB_VALUE * short_val_p, short s2, DB_VALUE * result_p)
 static int
 qdata_multiply_int (DB_VALUE * int_val_p, int i2, DB_VALUE * result_p)
 {
-  /* NOTE that we need volatile to prevent optimizer from generating division expression as multiplication */
-  volatile int i1, itmp;
+  int i1 = db_get_int (int_val_p);
+  int itmp;
 
-  i1 = db_get_int (int_val_p);
-  itmp = i1 * i2;
-
-  if (OR_CHECK_MULT_OVERFLOW (i1, i2, itmp))
+  if (__builtin_mul_overflow (i1, i2, &itmp))
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_OVERFLOW_MULTIPLICATION, 0);
       return ER_FAILED;
@@ -4837,13 +4831,10 @@ qdata_multiply_int (DB_VALUE * int_val_p, int i2, DB_VALUE * result_p)
 static int
 qdata_multiply_bigint (DB_VALUE * bigint_val_p, DB_BIGINT bi2, DB_VALUE * result_p)
 {
-  /* NOTE that we need volatile to prevent optimizer from generating division expression as multiplication */
-  volatile DB_BIGINT bi1, bitmp;
+  DB_BIGINT bi1 = db_get_bigint (bigint_val_p);
+  DB_BIGINT bitmp;
 
-  bi1 = db_get_bigint (bigint_val_p);
-  bitmp = bi1 * bi2;
-
-  if (OR_CHECK_MULT_OVERFLOW (bi1, bi2, bitmp))
+  if (__builtin_mul_overflow (bi1, bi2, &bitmp))
     {
       er_set (ER_ERROR_SEVERITY, ARG_FILE_LINE, ER_QPROC_OVERFLOW_MULTIPLICATION, 0);
       return ER_FAILED;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27255

## 문제

아래 한 문장으로 cub_server 가 SIGFPE 로 종료됩니다. BIGINT 도 동형입니다.

```sql
SELECT CAST (-2147483648 AS INTEGER) * CAST (-1 AS INTEGER);
```

클라이언트에는 "Your transaction has been aborted by the system due to server failure or mode change." 만 보입니다. upstream/develop (198b42a30) 릴리스 빌드에서 재현했습니다.

## 원인

곱셈 오버플로 검사가 나눗셈으로 이루어집니다.

```c
/* src/base/object_representation.h */
#define OR_CHECK_MULT_OVERFLOW(a, b, c)   (((b) == 0) ? ((c) != 0) : ((c) / (b) != (a)))
```

호출부는 곱을 먼저 계산해 래핑된 값을 얻은 뒤 이 매크로를 적용합니다. `INT_MIN * -1` 은 래핑되어 `INT_MIN` 이 되고, 매크로가 `INT_MIN / -1` 을 실행합니다. 몫 2147483648 이 int 범위를 벗어나 x86-64 의 idiv 가 #DE 를 발생시킵니다. 즉 오버플로를 검사하려던 코드가 오버플로로 죽습니다.

## 수정

정수 곱셈 지점을 `__builtin_mul_overflow ()` 로 바꿉니다. 플래그로 판정하므로 나눗셈이 사라지고, 따라서 트랩이 발생할 여지가 없어집니다. 검사를 다시 곱셈으로 되돌리지 못하게 막으려고 두었던 `volatile` 지역 변수도 함께 제거됩니다.

매크로를 쓰던 곱셈 지점을 모두 전환했습니다.

| 위치 | 함수 |
|---|---|
| src/query/query_opfunc.c | `qdata_multiply_short` / `qdata_multiply_int` / `qdata_multiply_bigint` |
| src/parser/type_checking.c | `pt_fold_arith` 의 SHORT / INTEGER / BIGINT 상수 폴딩 |

SHORT 는 트랩이 나지 않습니다. 피연산자가 int 로 승격되어 `SHRT_MIN / -1` 이 표현 가능하기 때문입니다. 다만 같은 나눗셈 비용을 지고 있어 함께 전환했습니다.

## 판정 동일성

오버플로 판정 결과는 기존 검사가 살아남던 모든 입력에서 같습니다. 래핑된 곱 `w = a * b - k * 2^N` (k != 0) 은 `w / b == a` 를 만족할 수 없습니다. `|k * 2^N|` 이 나눗셈이 흡수할 수 있는 어떤 `|b|` 보다 크기 때문입니다. 반대로 범위에 들어간 곱은 정확히 나누어떨어집니다.

SHORT/INTEGER 경계값 전수와 INTEGER·BIGINT 무작위 4천만 쌍에서 판정과 결과값 불일치 0 건을 확인했습니다.

## 검증

- 위 두 문장이 서버 종료 대신 `ER_QPROC_OVERFLOW_MULTIPLICATION` 을 반환합니다.
- 정상 곱셈의 결과값이 그대로입니다 (`7 * 6`, `-3 * -4`, `100000 * 100000` 등).
- 오버플로가 나야 하는 입력은 그대로 오버플로입니다 (`2000000000 * 2`, `-32768 * -1` SHORT).
- TPC-H SF10 22 종 결과가 develop 과 byte 동일합니다 (data_buffer_size 16G, parallelism 6).

부수적으로 곱셈마다 하드웨어 나눗셈 1 회와 volatile 로 인한 스택 왕복이 사라집니다.