### PR TITLE
[CBRD-27129] Floor a two-sided histogram range at one row, like the one-sided probes

### DIFF
--- a/src/optimizer/histogram/histogram_cl.cpp
+++ b/src/optimizer/histogram/histogram_cl.cpp
@@ -957,6 +957,35 @@ histogram_get_equal_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *s
   return;
 }
 
+/*
+ * histogram_get_total_rows () - population row count the column's histogram was built from.
+ *   Selectivity floors are expressed as 1/total_rows, so a caller that combines two probes
+ *   (a RANGE is the difference of two one-sided probes) needs the same denominator the
+ *   one-sided paths already use.
+ * return              : true when the column has a readable histogram
+ * lhs (in)            : column node
+ * out_total_rows (out): population row count (> 0 whenever true is returned)
+ */
+bool
+histogram_get_total_rows (PT_NODE *lhs, double *out_total_rows)
+{
+  hist::HistogramReader histogram_reader;
+
+  if (out_total_rows == NULL || !histogram_init_reader_from_lhs (lhs, histogram_reader))
+    {
+      return false;
+    }
+
+  const double total_rows = static_cast<double> (histogram_reader.total_rows ());
+  if (total_rows <= 0.0)
+    {
+      return false;
+    }
+
+  *out_total_rows = total_rows;
+  return true;
+}
+
 void
 histogram_get_comp_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, bool is_ge, bool include_equal,
 				double *selectivity,

--- a/src/optimizer/histogram/histogram_cl.hpp
+++ b/src/optimizer/histogram/histogram_cl.hpp
@@ -99,6 +99,7 @@ void histogram_collect_clear (HISTOGRAM_COLLECT *hc);
 /* histogram selectivity evaluation functions */
 void histogram_get_equal_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *selectivity,
 				      bool *success);
+bool histogram_get_total_rows (PT_NODE *lhs, double *out_total_rows);
 void histogram_get_comp_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, bool is_ge, bool include_equal,
 				     double *selectivity,
 				     bool *success);

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -10743,7 +10743,26 @@ qo_between_range_histogram_selectivity (PT_NODE * lhs, PT_OP_TYPE op_type, DB_VA
 
   /* the two probes are independent estimates, so their difference can leave the unit
    * interval on skewed data; the caller's default is not a better answer than a clamp */
-  *out_sel = MAX (0.0, MIN (1.0, sel));
+  sel = MAX (0.0, MIN (1.0, sel));
+
+  /* Floor the combined result the same way the one-sided probes floor themselves
+   * (histogram_get_comp_selectivity: 1/total_rows). A range whose bounds both sit past the
+   * histogram's recorded maximum -- the normal case for an append-only key or date column
+   * whose statistics have gone stale -- probes 1.0 on both sides and cancels to exactly 0,
+   * so a genuinely populated range would be planned as zero rows. Without the floor the
+   * two paths disagree on the same data: 'a > 1100' keeps 1/total_rows while
+   * 'a BETWEEN 1100 AND 1400' collapses to 0. */
+  if (sel <= 0.0)
+    {
+      double total_rows = 0.0;
+
+      if (histogram_get_total_rows (lhs, &total_rows))
+	{
+	  sel = 1.0 / total_rows;
+	}
+    }
+
+  *out_sel = sel;
   return true;
 }
 

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -10625,6 +10625,129 @@ qo_comp_selectivity (QO_ENV * env, PT_NODE * pt_expr)
 }
 
 /*
+ * qo_between_range_arg_value () - the DB_VALUE a between-range bound carries, or NULL when
+ *   the bound is not a constant the histogram can be probed with
+ * return       : the bound's value, or NULL
+ * env (in)     : optimizer environment (host variables live here)
+ * arg (in)     : bound node of a between-range expression
+ */
+static DB_VALUE *
+qo_between_range_arg_value (QO_ENV * env, PT_NODE * arg)
+{
+  if (arg == NULL)
+    {
+      return NULL;
+    }
+
+  switch (qo_classify (arg))
+    {
+    case PC_HOST_VAR:
+      return &env->parser->host_variables[arg->info.host_var.index];
+    case PC_CONST:
+      return &arg->info.value.db_value;
+    default:
+      return NULL;
+    }
+}
+
+/*
+ * qo_between_range_histogram_selectivity () - selectivity of one between-range operator from
+ *   the column histogram. Shared by the RANGE path (attr RANGE {...}) and the BETWEEN path
+ *   (attr BETWEEN a AND b), which price the same operators and must stay in step.
+ *
+ *   Each two-sided operator is a difference of two one-sided probes; the boundary handling
+ *   follows the operator's own inclusiveness:
+ *     GE_LE: sel_le(b) - sel_lt(a)   GE_LT: sel_lt(b) - sel_lt(a)
+ *     GT_LE: sel_le(b) - sel_le(a)   GT_LT: sel_lt(b) - sel_le(a)
+ *   One-sided operators (INF_LT/INF_LE/GE_INF/GT_INF) are a single probe. PT_BETWEEN_AND is
+ *   the pre-rewrite spelling of an inclusive range and is priced like GE_LE -- a plain
+ *   'x BETWEEN a AND b' that never became a PT_RANGE arrives with this operator.
+ *
+ * return          : true when the histogram produced an estimate (out_sel is then set)
+ * lhs (in)        : the column being ranged
+ * op_type (in)    : between-range operator
+ * arg1_val (in)   : lower bound value (the only bound for one-sided operators)
+ * arg2_val (in)   : upper bound value, NULL for one-sided operators
+ * out_sel (out)   : selectivity in [0,1]
+ */
+static bool
+qo_between_range_histogram_selectivity (PT_NODE * lhs, PT_OP_TYPE op_type, DB_VALUE * arg1_val,
+					DB_VALUE * arg2_val, double *out_sel)
+{
+  double sel_a = 0.0, sel_b = 0.0, sel;
+  bool ok_a = false, ok_b = false;
+
+  switch (op_type)
+    {
+    case PT_BETWEEN_AND:
+    case PT_BETWEEN_GE_LE:
+      /* sel_le (b) - sel_lt (a) */
+      histogram_get_comp_selectivity (lhs, arg1_val, false, false, &sel_a, &ok_a);
+      histogram_get_comp_selectivity (lhs, arg2_val, false, true, &sel_b, &ok_b);
+      sel = sel_b - sel_a;
+      break;
+
+    case PT_BETWEEN_GE_LT:
+      /* sel_lt (b) - sel_lt (a) */
+      histogram_get_comp_selectivity (lhs, arg1_val, false, false, &sel_a, &ok_a);
+      histogram_get_comp_selectivity (lhs, arg2_val, false, false, &sel_b, &ok_b);
+      sel = sel_b - sel_a;
+      break;
+
+    case PT_BETWEEN_GT_LE:
+      /* sel_le (b) - sel_le (a) */
+      histogram_get_comp_selectivity (lhs, arg1_val, false, true, &sel_a, &ok_a);
+      histogram_get_comp_selectivity (lhs, arg2_val, false, true, &sel_b, &ok_b);
+      sel = sel_b - sel_a;
+      break;
+
+    case PT_BETWEEN_GT_LT:
+      /* sel_lt (b) - sel_le (a) */
+      histogram_get_comp_selectivity (lhs, arg1_val, false, true, &sel_a, &ok_a);
+      histogram_get_comp_selectivity (lhs, arg2_val, false, false, &sel_b, &ok_b);
+      sel = sel_b - sel_a;
+      break;
+
+    case PT_BETWEEN_INF_LT:
+      histogram_get_comp_selectivity (lhs, arg1_val, false, false, &sel_a, &ok_a);
+      ok_b = true;
+      sel = sel_a;
+      break;
+
+    case PT_BETWEEN_INF_LE:
+      histogram_get_comp_selectivity (lhs, arg1_val, false, true, &sel_a, &ok_a);
+      ok_b = true;
+      sel = sel_a;
+      break;
+
+    case PT_BETWEEN_GT_INF:
+      histogram_get_comp_selectivity (lhs, arg1_val, true, false, &sel_a, &ok_a);
+      ok_b = true;
+      sel = sel_a;
+      break;
+
+    case PT_BETWEEN_GE_INF:
+      histogram_get_comp_selectivity (lhs, arg1_val, true, true, &sel_a, &ok_a);
+      ok_b = true;
+      sel = sel_a;
+      break;
+
+    default:
+      return false;
+    }
+
+  if (!(ok_a && ok_b))
+    {
+      return false;
+    }
+
+  /* the two probes are independent estimates, so their difference can leave the unit
+   * interval on skewed data; the caller's default is not a better answer than a clamp */
+  *out_sel = MAX (0.0, MIN (1.0, sel));
+  return true;
+}
+
+/*
  * qo_between_selectivity () - Compute the selectivity of a between predicate
  *   return: double
  *   env(in): Pointer to an environment structure
@@ -10635,12 +10758,31 @@ qo_comp_selectivity (QO_ENV * env, PT_NODE * pt_expr)
 static double
 qo_between_selectivity (QO_ENV * env, PT_NODE * pt_expr)
 {
-  PT_NODE *and_node;
+  PT_NODE *and_node, *lhs;
+  DB_VALUE *arg1_val, *arg2_val;
+  double selectivity;
 
   and_node = pt_expr->info.expr.arg2;
 
   QO_ASSERT (env, and_node->node_type == PT_EXPR);
   QO_ASSERT (env, pt_is_between_range_op (and_node->info.expr.op));
+
+  /* A BETWEEN that the rewriter turned into a PT_RANGE is priced by qo_range_selectivity ();
+   * what reaches here is the form that was not rewritten -- notably NOT BETWEEN, whose
+   * complement is not a single range. Estimating it from the histogram is what keeps
+   * 'attr NOT BETWEEN a AND b' from being a flat 1 - DEFAULT_BETWEEN_SELECTIVITY (0.99)
+   * regardless of the data (the caller inverts this result for PT_NOT_BETWEEN). */
+  lhs = pt_expr->info.expr.arg1;
+  if (qo_classify (lhs) == PC_ATTR)
+    {
+      arg1_val = qo_between_range_arg_value (env, and_node->info.expr.arg1);
+      arg2_val = qo_between_range_arg_value (env, and_node->info.expr.arg2);
+
+      if (qo_between_range_histogram_selectivity (lhs, and_node->info.expr.op, arg1_val, arg2_val, &selectivity))
+	{
+	  return selectivity;
+	}
+    }
 
   return DEFAULT_BETWEEN_SELECTIVITY;
 }
@@ -10724,114 +10866,14 @@ qo_range_selectivity (QO_ENV * env, PT_NODE * pt_expr)
       pc_arg1 = qo_classify (arg1);
       pc1 = pc_arg1;
 
-      if (pc_arg1 == PC_HOST_VAR)
-	{
-	  arg1_db_value = &env->parser->host_variables[arg1->info.host_var.index];
-	}
-      else if (pc_arg1 == PC_CONST)
-	{
-	  arg1_db_value = &arg1->info.value.db_value;
-	}
-      else
-	{
-	  arg1_db_value = NULL;
-	}
-
-      if (arg2 != NULL)
-	{
-	  pc_arg2 = qo_classify (arg2);
-
-	  if (pc_arg2 == PC_HOST_VAR)
-	    {
-	      arg2_db_value = &env->parser->host_variables[arg2->info.host_var.index];
-	    }
-	  else if (pc_arg2 == PC_CONST)
-	    {
-	      arg2_db_value = &arg2->info.value.db_value;
-	    }
-	  else
-	    {
-	      arg2_db_value = NULL;
-	    }
-	}
-      else
-	{
-	  arg2_db_value = NULL;
-	}
+      arg1_db_value = qo_between_range_arg_value (env, arg1);
+      arg2_db_value = qo_between_range_arg_value (env, arg2);
 
       if (op_type == PT_BETWEEN_GE_LE || op_type == PT_BETWEEN_GE_LT || op_type == PT_BETWEEN_GT_LE
 	  || op_type == PT_BETWEEN_GT_LT || op_type == PT_BETWEEN_INF_LT || op_type == PT_BETWEEN_INF_LE
 	  || op_type == PT_BETWEEN_GE_INF || op_type == PT_BETWEEN_GT_INF)
 	{
-	  double selectivity_a = 0.0, selectivity_b = 0.0, selectivity_backup = selectivity;
-	  bool success1 = false;
-	  bool success2 = false;
-	  switch (op_type)
-	    {
-	    case PT_BETWEEN_GE_LE:
-	      {
-		/* selectivity = sel_le(b) - sel_lt(a) */
-		histogram_get_comp_selectivity (lhs, arg1_db_value, false, false, &selectivity_a, &success1);
-		histogram_get_comp_selectivity (lhs, arg2_db_value, false, true, &selectivity_b, &success2);
-		selectivity = selectivity_b - selectivity_a;
-		break;
-	      }
-	    case PT_BETWEEN_GE_LT:
-	      {
-		/* selectivity = sel_lt(b) - sel_lt(a) */
-		histogram_get_comp_selectivity (lhs, arg1_db_value, false, false, &selectivity_a, &success1);
-		histogram_get_comp_selectivity (lhs, arg2_db_value, false, false, &selectivity_b, &success2);
-		selectivity = selectivity_b - selectivity_a;
-		break;
-	      }
-	    case PT_BETWEEN_GT_LE:
-	      {
-		/* selectivity = sel_le(b) - sel_le(a) */
-		histogram_get_comp_selectivity (lhs, arg1_db_value, false, true, &selectivity_a, &success1);
-		histogram_get_comp_selectivity (lhs, arg2_db_value, false, true, &selectivity_b, &success2);
-		selectivity = selectivity_b - selectivity_a;
-		break;
-	      }
-	    case PT_BETWEEN_GT_LT:
-	      {
-		/* selectivity = sel_lt(b) - sel_le(a) */
-		histogram_get_comp_selectivity (lhs, arg1_db_value, false, true, &selectivity_a, &success1);
-		histogram_get_comp_selectivity (lhs, arg2_db_value, false, false, &selectivity_b, &success2);
-		selectivity = selectivity_b - selectivity_a;
-		break;
-	      }
-	    case PT_BETWEEN_INF_LT:
-	      {
-		histogram_get_comp_selectivity (lhs, arg1_db_value, false, false, &selectivity_a, &success1);
-		success2 = true;
-		selectivity = selectivity_a;
-		break;
-	      }
-	    case PT_BETWEEN_INF_LE:
-	      {
-		histogram_get_comp_selectivity (lhs, arg1_db_value, false, true, &selectivity_a, &success1);
-		success2 = true;
-		selectivity = selectivity_a;
-		break;
-	      }
-	    case PT_BETWEEN_GT_INF:
-	      {
-		histogram_get_comp_selectivity (lhs, arg1_db_value, true, false, &selectivity_a, &success1);
-		success2 = true;
-		selectivity = selectivity_a;
-		break;
-	      }
-	    case PT_BETWEEN_GE_INF:
-	      {
-		histogram_get_comp_selectivity (lhs, arg1_db_value, true, true, &selectivity_a, &success1);
-		success2 = true;
-		selectivity = selectivity_a;
-		break;
-	      }
-	    default:
-	      break;
-	    }
-	  if (!(success1 && success2))
+	  if (!qo_between_range_histogram_selectivity (lhs, op_type, arg1_db_value, arg2_db_value, &selectivity))
 	    {
 	      if (op_type == PT_BETWEEN_INF_LT || op_type == PT_BETWEEN_INF_LE || op_type == PT_BETWEEN_GE_INF
 		  || op_type == PT_BETWEEN_GT_INF)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27129>

### Purpose

양측 구간(`a BETWEEN x AND y`, `a > x AND a < y`)의 히스토그램 선택도는 **단측 프로브 두 번의 차이**로 계산된다. 그래서 자기 하한이 없다 — 두 경계가 모두 히스토그램 범위 밖에 떨어지면 두 프로브가 같은 값을 반환해 **정확히 0으로 상쇄**된다. append-only 키나 통계가 낡은 날짜 컬럼이 "빈 구간"으로 추정되고, 옵티마이저는 그 0행 추정을 신뢰한다.

단측 연산자에는 이 구멍이 없다. 각 프로브가 `histogram_get_comp_selectivity ()` 안에서 `1/total_rows`로 하한이 걸리기 때문이다. 그래서 **같은 데이터에서 경로별로 답이 어긋난다**: `a > 1100`은 0.001인데 `a BETWEEN 1100 AND 1400`은 0이다.

### Implementation

`query_planner.c` — 양측 연산자(GE_LE / GE_LT / GT_LE / GT_LT)의 차이 결과를 단위 구간으로 묶은 뒤, 0이면 단측 프로브와 같은 1행 하한을 적용한다.

```c
selectivity = MAX (0.0, MIN (1.0, selectivity));
if (selectivity <= 0.0 && histogram_get_total_rows (lhs, &total_rows))
  {
    selectivity = 1.0 / total_rows;
  }
```

- 클램프를 먼저 하는 이유: 두 프로브는 독립 추정이라 편중 데이터에서 차이가 음수가 될 수 있다(그 경우도 0으로 모아 하한을 받는다).
- `histogram_get_total_rows ()`를 `histogram_cl`에 신설했다. 하한의 분모를 단측 프로브와 **같은 값**으로 쓰기 위한 접근자다(히스토그램이 없으면 false를 반환하고 하한도 적용되지 않는다).
- 단측 경로는 손대지 않았다. 이미 같은 하한을 내부에서 적용한다.

### Verification

1,000행(`a` = 1..1000), 인덱스 + `ANALYZE TABLE ... UPDATE HISTOGRAM`, release 빌드, `SET OPTIMIZATION LEVEL 513`의 term 선택도:

| 질의 | 연산자 | develop (651a498a0) | 본 PR |
|---|---|---|---|
| `a > 1100` (범위 밖 단측) | `gt_inf` | 0.001 | **0.001** (불변) |
| `a < 0` (범위 밖 단측) | `inf_lt` | 0.001 | **0.001** (불변) |
| `a BETWEEN 1100 AND 1400` (범위 밖 양측) | `ge_le` | **0** | **0.001** |
| `a > 1100 AND a < 1400` (범위 밖 양측) | `gt_lt` | **0** | **0.001** |
| `a BETWEEN 100 AND 200` (정상 구간) | `ge_le` | 0.101 | **0.101** (불변) |

- 범위 밖 양측 구간이 단측과 같은 값(1/1000)을 받아 **경로 간 불일치가 해소**됐다.
- 히스토그램 범위 안의 정상 구간은 값이 바뀌지 않는다 — 하한은 0으로 붕괴한 경우에만 개입한다.

### Remarks

- 명세 변경은 없다(내부 추정만 개선). 통계가 낡아 0행으로 추정되던 구간이 1행으로 바뀌므로, 해당 질의의 플랜 덤프 `sel`/카디널리티와 플랜 선택이 달라질 수 있다.
- 이 브랜치는 develop 기준이라 히스토그램을 `ANALYZE TABLE ... UPDATE HISTOGRAM`으로 수동 수집해 검증했다. CBRD-26959(#7476)가 머지되면 `UPDATE STATISTICS`가 기본 수집하므로 별도 조작 없이 적용된다.
- CBRD-27037(#7570)은 같은 연산자 계열을 하나의 헬퍼로 수렴시키는 변경이다. 그쪽이 먼저 머지되면 이 하한은 그 공용 헬퍼 한 곳으로 옮기는 것이 자연스럽다(현재는 develop의 range 경로에 맞춰 넣었다).
- nullable 컬럼에서 남는 오차(헬퍼가 non-null 조건부 선택도를 반환하는데 소비 경로가 `1 - nullfrac`을 곱하지 않는 문제)는 이 PR 범위 밖이며 CBRD-27254로 분리돼 있다.
