### PR TITLE
[CBRD-27214] CMS crashes when sending consecutive requests to an offline DB in a debug build

### DIFF
--- a/src/cm_common/cm_dep_tasks.c
+++ b/src/cm_common/cm_dep_tasks.c
@@ -365,10 +365,10 @@ cm_ts_delete_user (nvplist * req, nvplist * res, char *_dbmt_error)
     }
 
   db_mode = uDatabaseMode (dbname, &ha_mode);
-  if (db_mode == DB_SERVICE_MODE_SA)
+  if (db_mode != DB_SERVICE_MODE_CS)
     {
       sprintf (_dbmt_error, "%s", dbname);
-      return ERR_STANDALONE_MODE;
+      return db_mode == DB_SERVICE_MODE_SA ? ERR_STANDALONE_MODE : ERR_DB_INACTIVE;
     }
 
   if (_op_db_login (res, req, ha_mode, _dbmt_error) < 0)
@@ -662,10 +662,10 @@ cm_ts_class (nvplist * in, nvplist * out, char *_dbmt_error)
     }
 
   db_mode = uDatabaseMode (dbname, &ha_mode);
-  if (db_mode == DB_SERVICE_MODE_SA)
+  if (db_mode != DB_SERVICE_MODE_CS)
     {
       sprintf (_dbmt_error, "%s", dbname);
-      return ERR_STANDALONE_MODE;
+      return db_mode == DB_SERVICE_MODE_SA ? ERR_STANDALONE_MODE : ERR_DB_INACTIVE;
     }
 
   if (_op_db_login (out, in, ha_mode, _dbmt_error) < 0)
@@ -788,10 +788,10 @@ cm_ts_update_attribute (nvplist * in, nvplist * out, char *_dbmt_error)
     }
 
   db_mode = uDatabaseMode (dbname, &ha_mode);
-  if (db_mode == DB_SERVICE_MODE_SA)
+  if (db_mode != DB_SERVICE_MODE_CS)
     {
       sprintf (_dbmt_error, "%s", dbname);
-      return ERR_STANDALONE_MODE;
+      return db_mode == DB_SERVICE_MODE_SA ? ERR_STANDALONE_MODE : ERR_DB_INACTIVE;
     }
 
   if (_op_db_login (out, in, ha_mode, _dbmt_error) < 0)
@@ -999,10 +999,10 @@ cm_ts_update_user (nvplist * req, nvplist * res, char *_dbmt_error)
     }
 
   db_mode = uDatabaseMode ((char *) db_name, &ha_mode);
-  if (db_mode == DB_SERVICE_MODE_SA)
+  if (db_mode != DB_SERVICE_MODE_CS)
     {
       sprintf (_dbmt_error, "%s", db_name);
-      return ERR_STANDALONE_MODE;
+      return db_mode == DB_SERVICE_MODE_SA ? ERR_STANDALONE_MODE : ERR_DB_INACTIVE;
     }
 
   if (_op_db_login (res, req, ha_mode, _dbmt_error) < 0)
@@ -1222,10 +1222,10 @@ cm_ts_create_user (nvplist * req, nvplist * res, char *_dbmt_error)
     }
 
   db_mode = uDatabaseMode (dbname, &ha_mode);
-  if (db_mode == DB_SERVICE_MODE_SA)
+  if (db_mode != DB_SERVICE_MODE_CS)
     {
       sprintf (_dbmt_error, "%s", dbname);
-      return ERR_STANDALONE_MODE;
+      return db_mode == DB_SERVICE_MODE_SA ? ERR_STANDALONE_MODE : ERR_DB_INACTIVE;
     }
 
   if (_op_db_login (res, req, ha_mode, _dbmt_error) < 0)
@@ -1343,10 +1343,10 @@ cm_ts_userinfo (nvplist * in, nvplist * out, char *_dbmt_error)
       return ERR_WITH_MSG;
     }
   db_mode = uDatabaseMode (db_name, &ha_mode);
-  if (db_mode == DB_SERVICE_MODE_SA)
+  if (db_mode != DB_SERVICE_MODE_CS)
     {
       sprintf (_dbmt_error, "%s", db_name);
-      return ERR_STANDALONE_MODE;
+      return db_mode == DB_SERVICE_MODE_SA ? ERR_STANDALONE_MODE : ERR_DB_INACTIVE;
     }
 
   if (_op_db_login (out, in, ha_mode, _dbmt_error) < 0)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27214>

### Purpose
* avoid CMS crash when sending consecutive APIs to CMS for an offline db in a debug build
* subject api handling modules
  1 cm_ts_delete_user ()
  2 cm_ts_class ()
  3 cm_ts_update_attribute ()
  4 cm_ts_update_user ()
  5 cm_ts_create_user ()
  6 **cm_ts_userinfo** ()

### Implementation

N/A

### Remarks
* 이 오류는 CMS 처리 모듈이 database가 CS나 SA mode가 아닌 inactive 상태인 경우
`cm_ts_get_triggerinfo ()`, `cm_ts_optimizedb ()`, `cm_ts_class_info ()` 와 같이 **DB_SERVICE_MODE_NONE에 대한 별도의 helper 모듈로 처리하던지 오류를 발생해야** 하는데 이 부분에 대한 검사가 생략되어 DB_SERVICE_MODE_CS mode의 처리 모듈로 진입한 것이 문제인듯 합니다.
* `_op_db_login ()` 이 실패하면서 `_init()`된 적 없는 서브시스템들에 `_final()`을 호출합니다 (ws_final (), tp_final (), ...)
* 1번째 호출에서 남겨진 **반쯤 finalize된 정적/전역 클라이언트 상태(tp/ws/sm 등)가 그대로 프로세스에 남아있다가,**   같은 프로세스에서 2번째 호출이 다시 `boot_client_common()/tp_init()/ws_init()/sm_init()` 등을 실행하면서 문제가 되는듯 합니다.
* release 빌드에서 crash되지는 않지만 잠재적 오동작 확률은 있어서
* 이 6개 함수에 대해서 DB_SERVICE_MODE_CS 모드만의 처리를 진행하고, DB_SERVICE_MODE_SA/DB_SERVICE_MODE_NONE 모드에 대해서는 오류를 반환하도록 수정합니다.

### userinfo api response changed (in release build):
**ASIS**
```
{
   "__EXEC_TIME" : "22 ms",
   "note" : "Failed to connect to database server, 'testdb', on the following host(s): localhost",
   "status" : "failure",
   "task" : "userinfo"
}
```
**TOBE**
```
{
   "__EXEC_TIME" : "28 ms",
   "note" : "Database(testdb) is not active state",
   "status" : "failure",
   "task" : "userinfo"
}
```