### PR TITLE
[CBRD-27158] Set operations corrupt grouped aggregate/window rows

### DIFF
--- a/src/parser/view_transform.c
+++ b/src/parser/view_transform.c
@@ -5220,17 +5220,10 @@ mq_rewrite_query_as_derived (PARSER_CONTEXT * parser, PT_NODE * query)
 
   while (temp)
     {
-      /* generate as_attr_list */
-      if (temp->node_type == PT_NAME && temp->info.name.original != NULL)
-	{
-	  /* we have the original name */
-	  node = pt_name (parser, temp->info.name.original);
-	}
-      else
-	{
-	  /* don't have name for attribute; generate new name */
-	  node = pt_name (parser, mq_generate_name (parser, "a", &i));
-	}
+      /* generate as_attr_list; each column gets a freshly synthesized name. The counter i is local
+       * to this call and only increases, so the generated names are unique among themselves without
+       * needing to check as_attr_list. */
+      node = pt_name (parser, mq_generate_name (parser, "a", &i));
 
       if (node == NULL)
 	{


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27158>

### Purpose

GROUP BY + 집계 + 윈도우 + ORDER BY 쿼리가 집합 연산에 포함되어 있을 때 해당 쿼리에서 생성된 행의 값에 이상이 발생하는 문제를 해결.

### Implementation

backport from develop

### Remarks

N/A
