### PR TITLE
[CBRD-27257] Keep the factor location when pt_cnf rebuilds an OR tree

### DIFF
--- a/src/parser/cnf.c
+++ b/src/parser/cnf.c
@@ -819,6 +819,11 @@ pt_transform_cnf_post (PARSER_CONTEXT * parser, PT_NODE * node, void *arg, int *
 	    {			/* build OR-tree */
 	      list = pt_and (parser, arg1, arg2);
 	      list->info.expr.op = PT_OR;
+	      /* pt_and () builds a fresh node, so carry over what the factor being replaced held.
+	       * Losing 'location' turns a term that came from an outer join's ON condition into a
+	       * WHERE level (after join) term, which then rejects the null padded rows. */
+	      list->info.expr.location = node->info.expr.location;
+	      list->type_enum = PT_TYPE_LOGICAL;
 	    }
 	  else
 	    {


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27257

## Purpose

OUTER JOIN의 ON 절에 OR 술어가 있고 그 술어가 일정 크기를 넘으면, NULL 패딩 행이 사라져 **INNER JOIN과 동일한 결과**가 반환됩니다.

```sql
CREATE TABLE p (id INT);  INSERT INTO p VALUES (1),(2),(3);
CREATE TABLE q (id INT, v1 INT, v2 INT, v3 INT, v4 INT, v5 INT);
INSERT INTO q VALUES (1,1,1,1,1,1);

-- 3분기 x 4리프 = 64  → (1,1) (2,NULL) (3,NULL)  정상
SELECT p.id, q.id FROM p LEFT OUTER JOIN q ON p.id=q.id
  AND ((q.v1=1 AND q.v2=1 AND q.v3=1 AND q.v4=1)
    OR (q.v1=2 AND q.v2=2 AND q.v3=2 AND q.v4=2)
    OR (q.v1=3 AND q.v2=3 AND q.v3=3 AND q.v4=3));

-- 3분기 x 5리프 = 125 → (1,1) 뿐. 2, 3번 행 소실
SELECT p.id, q.id FROM p LEFT OUTER JOIN q ON p.id=q.id
  AND ((q.v1=1 AND q.v2=1 AND q.v3=1 AND q.v4=1 AND q.v5=1)
    OR (q.v1=2 AND q.v2=2 AND q.v3=2 AND q.v4=2 AND q.v5=2)
    OR (q.v1=3 AND q.v2=3 AND q.v3=3 AND q.v4=3 AND q.v5=3));
```

두 질의의 차이는 각 분기에 술어 하나가 더 있는 것뿐입니다. 경계는 `count_and_or()` 값으로, leaf=1 / AND=좌+우 / OR=좌×우로 세어 **100을 넘으면** `pt_cnf()`가 CNF 분배를 포기하고 `TRANSFORM_CNF_OR_COMPACT` 모드로 전환합니다 (`cnf.c:988`).

10.2.0.8797, 11.0.14.0388, 11.2.9.0866, 11.4.1.1787, develop 전 버전에서 재현되며 LEFT/RIGHT OUTER 모두 해당합니다. CBRD-23754(2020, 10.2 Patch 10 Fixed)와 증상 계열은 같지만 경로가 다릅니다 — 그쪽은 WHERE 절 OR이 `qo_rewrite_outerjoin()`을 오도한 문제였습니다.

## Implementation

`pt_transform_cnf_post()`의 `TRANSFORM_CNF_OR_COMPACT` 분기(`parser/cnf.c`)가 팩터를 AND-OR 트리로 되돌릴 때 `pt_and()`로 **새 노드를 할당**하는데, `pt_and()`는 op/arg1/arg2만 설정합니다. 그 결과 `pt_bind_names()`의 `pt_mark_location()`이 ON 조건에 찍고 `qo_move_on_of_explicit_join_to_where()`가 WHERE 리스트로 옮겨 온 `info.expr.location`이 0으로 초기화됩니다. 이후 `qo_analyze_term()`이 해당 항을 WHERE 레벨 `(after join term)`으로 분류하고, 패딩 행(NULL)에 대해 UNKNOWN이 되어 행이 걸러집니다.

임계값 이하에서는 `or_next` 분배 경로라 원본 노드가 그대로 쓰여 location이 살아남습니다.

```c
	  if (arg1 && arg2)
	    {			/* build OR-tree */
	      list = pt_and (parser, arg1, arg2);
	      list->info.expr.op = PT_OR;
	      list->info.expr.location = node->info.expr.location;
	      list->type_enum = PT_TYPE_LOGICAL;
	    }
```

`type_enum`은 `qo_convert_to_range_helper()`가 새로 만드는 술어 노드에 설정하는 것과 동일한 형태로 맞췄습니다.

플랜 확인 (`SET SYSTEM PARAMETERS 'optimization_level=513';`):

```
수정 전, 125 리프 : term[1] (((q.v1=1 and ...) or ...) or (...))
                            (rank 3) (after join term) (loc 0)   <- location 소실
64 리프          : term[1] ... (sarg term) (loc 1)               <- 조인 레벨 유지
```

## Remarks

**회귀 여부**: 회귀가 아니라 최소 10.2부터 존재한 오답입니다.

**검증** — develop 및 PR #7613 head 두 빌드에 적용해 확인했습니다.

| 항목 | 수정 전 | 수정 후 |
|---|---|---|
| 위 재현 (125 리프, LEFT OUTER) | 1행 | **3행** |
| 위 재현 (125 리프, RIGHT OUTER) | 1행 | **3행** |
| 위 재현 (64 리프) | 3행 | 3행 (불변) |
| 메타모픽 퍼저 600질의 위반 | **126** | **0** |
| 차분 퍼저 400질의 (임계값 초과 300건) | — | 불일치 0 |

메타모픽 오라클은 각 OR 분기에 항진식 `(col IS NULL OR col IS NOT NULL)`을 덧대 리프 수만 임계값 위로 넘긴 뒤 결과 불변을 검사하는 방식입니다(분기마다 다른 컬럼을 써서 `pt_cnf`의 공통 인자 추출에 걸리지 않게 함). 위반 126건은 전부 `OUTER JOIN ... ON` 형태였고 WHERE 절에 OR을 둔 형태에서는 위반이 없었습니다.

WHERE 레벨 술어의 최적화 동작에는 영향이 없음을 플랜 비교로 확인했습니다(임계값 이하/이상 모두 term 구성 불변).

**후속**: 이 수정이 들어가면 PR #7613의 `qo_extract_or_restrictions()`에 있는 `cnf->info.expr.location != 0` 가드가 비로소 동작합니다. 현재는 ON 절 팩터도 location 0으로 도착해 아무것도 배제하지 못하는 상태이며, 수정 후에는 ON 절 케이스의 추출이 멈추고(56 → 2 terms) WHERE 레벨 추출은 그대로 유지되는 것을 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
