### PR TITLE
[CUBRIDQA-1517] Fix wrong PR links in submodule bump messages

### DIFF
--- a/.github/workflows/submodule-bump-receiver.yml
+++ b/.github/workflows/submodule-bump-receiver.yml
@@ -232,7 +232,9 @@ jobs:
             echo "title=$TAG Update $SUB submodule to ${TARGET:0:7}"
             echo "author=$AUTHOR"
             echo "manifest<<__MANIFEST__"
+            # A bare #N would autolink to the parent repo, so qualify it with the submodule slug.
             git -C "$SUB" log --no-decorate --reverse --format='- %s%n%w(0,2,2)%b%n' "$OLD..$TARGET" \
+              | sed -E "s@(^|[^[:alnum:]_/])#([0-9]+)@\1$SLUG#\2@g" \
               | sed 's/[[:space:]]*$//' | cat -s
             echo "__MANIFEST__"
           } >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1517>

### Purpose
서브모듈 bump PR은 커밋 메시지와 본문에 서브모듈 커밋 내용을 그대로 넣습니다.
이때 커밋 제목에 `(#83)` 같은 PR 번호가 있으면 GitHub이 이걸 부모 저장소 번호로 해석합니다.
#7731 에서 해당 문제를 발견 했고, `(cubrid/cubrid-jdbc#83)` 같은 형식으로 변경할 수 있도로 수정합니다.

### Implementation

매니페스트 생성 파이프라인에 `sed` 한 단계를 추가합니다.
각 레포를 넣는 것은 `.gitmodules`에서 이미 뽑아 쓰고 있어서, 모듈별로 자동 적용됩니다.

| 서브모듈 | 변경 전 | 변경 후 |
|---|---|---|
| `cubrid-jdbc` | `(#84)` | `(cubrid/cubrid-jdbc#84)` |
| `cubrid-cci` | `(#84)` | `(CUBRID/cubrid-cci#84)` |
| `cubridmanager` | `(#84)` | `(CUBRID/cubrid-manager-server#84)` |

### Remarks

N/A
