### PR TITLE
[CBRD-27272] Keep thread_core_count as a deprecated alias of task_group

### DIFF
--- a/pl_engine/pl_server/src/main/java/com/cubrid/jsp/SysParam.java
+++ b/pl_engine/pl_server/src/main/java/com/cubrid/jsp/SysParam.java
@@ -9,15 +9,18 @@ import java.nio.charset.StandardCharsets;
 
 public class SysParam implements UnPackableObject, PackableObject {
 
-    // see src/base/system_parameter.h
+    // The ordinals of enum param_id in src/base/system_parameter.h. The server sends a
+    // parameter keyed by that ordinal, so these must be updated whenever a parameter is
+    // added or removed anywhere above the ones listed here. static_assert()s next to
+    // prm_Def[] in src/base/system_parameter.c break the build if they drift apart.
     public static final int ORACLE_STYLE_EMPTY_STRING = 95;
     public static final int COMPAT_NUMERIC_DIVISION_SCALE = 100;
     public static final int INTL_NUMBER_LANG = 193;
     public static final int INTL_DATE_LANG = 194;
     public static final int INTL_COLLATION = 206;
     public static final int TIMEZONE = 249;
-    public static final int ORACLE_COMPAT_NUMBER_BEHAVIOR = 334;
-    public static final int STORED_PROCEDURE_DUMP_ICODE = 354;
+    public static final int ORACLE_COMPAT_NUMBER_BEHAVIOR = 335;
+    public static final int STORED_PROCEDURE_DUMP_ICODE = 355;
 
     // PL session specific parameters
     public static final int PL_SESSION_PARAM_START = 100000;

--- a/src/base/system_parameter.c
+++ b/src/base/system_parameter.c
@@ -734,6 +734,7 @@ static const char sysprm_ha_conf_file_name[] = "cubrid_ha.conf";
 #define PRM_NAME_RECOVERY_PROGRESS_LOGGING_INTERVAL "recovery_progress_logging_interval"
 #define PRM_NAME_FIRST_LOG_PAGEID "first_log_pageid"
 
+#define PRM_NAME_THREAD_CORE_COUNT "thread_core_count"
 #define PRM_NAME_TASK_GROUP "task_group"
 
 #define PRM_NAME_FLASHBACK_TIMEOUT "flashback_timeout"
@@ -4774,6 +4775,23 @@ SYSPRM_PARAM prm_Def[] = {
    (char *) NULL,
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL},
+  {PRM_ID_THREAD_CORE_COUNT,
+   PRM_NAME_THREAD_CORE_COUNT,
+   (PRM_FOR_SERVER | PRM_DEPRECATED | PRM_HIDDEN),
+   PRM_INTEGER,
+   PRM_CLEAR_DYNAMIC_FLAG,
+#if defined (SERVER_MODE)
+   {false, {.i = (int) cubthread::system_core_count ()}},
+   {false, {.i = (int) cubthread::system_core_count ()}},
+#else
+   {false, {.i = 1}},
+   {false, {.i = 1}},
+#endif
+   {false, {.i = 1024}},
+   {false, {.i = 1}},
+   (char *) NULL,
+   (DUP_PRM_FUNC) NULL,
+   (DUP_PRM_FUNC) NULL},
   {PRM_ID_TASK_GROUP,
    PRM_NAME_TASK_GROUP,
    (PRM_FOR_SERVER),
@@ -5518,6 +5536,22 @@ SYSPRM_PARAM prm_Def[] = {
    (DUP_PRM_FUNC) NULL,
    (DUP_PRM_FUNC) NULL},
 };
+
+/* The PL server (cub_pl) is a separate Java process that hard-codes the ordinals of the
+ * parameters it needs, in pl_engine/pl_server/src/main/java/com/cubrid/jsp/SysParam.java.
+ * xsysprm_get_pl_context_parameters () keys every parameter it sends by its prm_Def[] index,
+ * so inserting or removing a parameter above any of these silently shifts the ordinal the PL
+ * server is looking for: the lookup misses, Context.getSystemParameterBool () returns null and
+ * unboxing it aborts every stored procedure compile. Keep the two lists in step - if one of
+ * these fires, fix SysParam.java, not the assertion. */
+static_assert (PRM_ID_ORACLE_STYLE_EMPTY_STRING == 95, "update SysParam.java");
+static_assert (PRM_ID_COMPAT_NUMERIC_DIVISION_SCALE == 100, "update SysParam.java");
+static_assert (PRM_ID_INTL_NUMBER_LANG == 193, "update SysParam.java");
+static_assert (PRM_ID_INTL_DATE_LANG == 194, "update SysParam.java");
+static_assert (PRM_ID_INTL_COLLATION == 206, "update SysParam.java");
+static_assert (PRM_ID_TIMEZONE == 249, "update SysParam.java");
+static_assert (PRM_ID_ORACLE_COMPAT_NUMBER_BEHAVIOR == 335, "update SysParam.java");
+static_assert (PRM_ID_STORED_PROCEDURE_DUMP_ICODE == 355, "update SysParam.java");
 
 SYSPRM_INDIRECT_POS prm_Def_session_idx[DIM (prm_Def)];
 
@@ -10052,6 +10086,7 @@ prm_tune_parameters (void)
   SYSPRM_PARAM *tz_leap_second_support_prm;
   SYSPRM_PARAM *task_worker_prm;
   SYSPRM_PARAM *task_group_prm;
+  SYSPRM_PARAM *thread_core_count_prm;
 #if defined (SERVER_MODE)
   SYSPRM_PARAM *max_parallel_workers_prm;
   SYSPRM_PARAM *parallelism_prm;
@@ -10124,6 +10159,22 @@ prm_tune_parameters (void)
 	}
 
       task_group_prm = GET_PRM (PRM_ID_TASK_GROUP);
+
+      /* thread_core_count was renamed to task_group by CBRD-26255. The old name is kept only as a
+       * deprecated alias, so that a cubrid.conf written for 11.4 or earlier still boots. task_group is
+       * the authoritative name: the alias is applied only when task_group itself was not given, no
+       * matter in which order the two appear in cubrid.conf.
+       *
+       * TODO: remove PRM_ID_THREAD_CORE_COUNT, its prm_Def entry and this block when the deprecation
+       *       period for the rename is over.
+       */
+      thread_core_count_prm = GET_PRM (PRM_ID_THREAD_CORE_COUNT);
+      if (PRM_IS_SET (thread_core_count_prm) && !PRM_IS_SET (task_group_prm))
+	{
+	  sprintf (newval, "%d", MIN (PRM_GET_INT (thread_core_count_prm->value), system_cpu_count));
+	  (void) prm_set (task_group_prm, newval, true);
+	}
+
       if (PRM_GET_INT (task_group_prm->value) > system_cpu_count)
 	{
 	  sprintf (newval, "%d", system_cpu_count);

--- a/src/base/system_parameter.h
+++ b/src/base/system_parameter.h
@@ -463,6 +463,7 @@ enum param_id
   PRM_ID_CDC_LOGGING_DEBUG,
   PRM_ID_RECOVERY_PROGRESS_LOGGING_INTERVAL,
   PRM_ID_FIRST_LOG_PAGEID,	/* Except for QA or TEST purposes, never use it. */
+  PRM_ID_THREAD_CORE_COUNT,	/* deprecated: renamed to task_group */
   PRM_ID_TASK_GROUP,
   PRM_ID_FLASHBACK_TIMEOUT,
   PRM_ID_FLASHBACK_MAX_TRANSACTION,	/* Hidden parameter For QA test */


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27272

### Purpose

CBRD-26255에서 `thread_core_count`가 `task_group`으로 개명되면서 옛 이름이 완전히 제거됐습니다. 그래서 11.4 이하에서 쓰던 `cubrid.conf`를 그대로 두고 올리면 서버가 아예 기동되지 않고, 사용자에게 남는 안내는 `Unrecognized keyword.` 한 줄뿐이라 무엇으로 바꿔야 하는지 알 수 없습니다.

`thread_core_count`는 도입 이후 한 번도 hidden이 아니었고 매뉴얼에 기본값·범위·설명이 문서화된 서버 튜닝 파라미터입니다. 배포 `cubrid.conf`에는 없지만 현장 설정 파일에는 남아 있을 수 있습니다. 옛 이름을 폐기 예정(deprecated) 별칭으로 되살려 하위 호환성을 회복합니다. (CBRD-26177 코멘트 반영)

### Implementation

- `PRM_ID_THREAD_CORE_COUNT`를 개명 이전 위치(`PRM_ID_TASK_GROUP` 바로 앞)에 복원하고 `(PRM_FOR_SERVER | PRM_DEPRECATED | PRM_HIDDEN)`으로 정의했습니다. 범위는 11.4와 같은 1~1024라, 11.4에서 조용히 보정되던 큰 값도 그대로 로드됩니다.
- 값 적용은 `prm_tune_parameters()`에서 **`task_group`이 명시되지 않았을 때만** 합니다. `PRM_IS_SET()`으로 판정하므로 기본값이 들어간 경우와 사용자가 직접 적은 경우를 정확히 구분합니다. 두 이름이 함께 있으면 **기재 순서와 무관하게 `task_group`이 이깁니다.**
- 값 공유 테이블(`PARAM_VALUE_SHARE[]`)은 쓰지 않았습니다. 대칭 공유라 나중에 적힌 쪽이 이기는 동작밖에 표현할 수 없습니다.
- `task_group`의 파라미터 정의는 건드리지 않았습니다. 상한 `system_core_count()`도 그대로입니다.
- 적용된 값은 기존 보정 규칙 `MIN(system_core_count(), task_worker)`를 그대로 거칩니다.
- 폐기 기간이 끝나면 제거할 수 있도록 `prm_tune_parameters()`에 TODO 주석을 남겼습니다.

### Remarks

80코어 / `max_clients=20`(→ `task_worker=22`) 환경에서 확인했습니다. 파라미터 최종값은 `cubrid paramdump`로, 실제 워커풀 그룹 수는 `SHOW JOB QUEUES` 행 수로 검증했습니다.

| cubrid.conf | 기동 | task_group | 워커 그룹 수 |
|---|---|---|---|
| (미설정) | 성공 | 22 | 22 |
| `thread_core_count=8` | 성공(경고) | 8 | 8 |
| `thread_core_count=1000` | 성공(경고) | 22 | 22 |
| `thread_core_count=8` → `task_group=16` | 성공(경고) | 16 | 16 |
| `task_group=16` → `thread_core_count=8` | 성공(경고) | 16 | 16 |
| `task_group=1000` | 실패(범위 초과) | – | – |