### PR TITLE
[CBRD-27273] core dump at 'show columns' for default to_char column

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -25727,7 +25727,7 @@ qexec_execute_build_columns (THREAD_ENTRY * thread_p, XASL_NODE * xasl, XASL_STA
 			 + 6 /* parenthesis, a comma, a blank and quotes */  + strlen (default_expr_type_string)
 			 + (default_expr_format ? strlen (default_expr_format) : 0)) + 1;
 
-		  default_value_string = (char *) malloc (len);
+		  default_value_string = (char *) db_private_alloc (thread_p, len);
 		  if (default_value_string == NULL)
 		    {
 		      GOTO_EXIT_ON_ERROR;


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-27273>

### Purpose

내부 메타데이터 조회 (show columns) 시 함수기반의 기본값 ex) default to_char (current_date, 'MM') 을 사용하면 임시 메모리를 해제하는 과정에서 core 발생하는 문제 해결

### Implementation

qexec_execute_build_columns 에서 malloc으로 메모리 할당하는 것을 db_private_alloc으로 바로 잡아 해결

### Remarks

레거시 이슈로 11.4이하 버전에도 backport필요
