### PR TITLE
[CBRD-26705] [Regression][isolation] Phantom read occurs at RepeatableRead isolation level- #7063

### DIFF
--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -26794,7 +26794,7 @@ qexec_evaluate_aggregates_optimize (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * ag
 	    {
 	      /* COUNT(*) optimization uses global statistics that bypass MVCC visibility;
 	       * fall back to full scan under REPEATABLE_READ or SERIALIZABLE to prevent phantom reads. */
-	      agg_ptr->flag.agg_optimized = false;
+	      agg_ptr->flag_agg_optimize = false;
 	      *is_scan_needed = true;
 	      continue;
 	    }

--- a/src/query/query_executor.c
+++ b/src/query/query_executor.c
@@ -26789,6 +26789,16 @@ qexec_evaluate_aggregates_optimize (THREAD_ENTRY * thread_p, AGGREGATE_TYPE * ag
       if (!*is_scan_needed && agg_ptr->function == PT_COUNT_STAR)
 	{
 	  LOG_TDES *tdes = LOG_FIND_TDES (LOG_FIND_THREAD_TRAN_INDEX (thread_p));
+
+	  if (tdes == NULL || tdes->isolation >= TRAN_REPEATABLE_READ)
+	    {
+	      /* COUNT(*) optimization uses global statistics that bypass MVCC visibility;
+	       * fall back to full scan under REPEATABLE_READ or SERIALIZABLE to prevent phantom reads. */
+	      agg_ptr->flag.agg_optimized = false;
+	      *is_scan_needed = true;
+	      continue;
+	    }
+
 	  LOG_TRAN_CLASS_COS *class_cos = logtb_tran_find_class_cos (thread_p, &ACCESS_SPEC_CLS_OID (spec),
 								     true);
 	  if (class_cos == NULL)


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26705>

### Purpose

REPEATABLE READ(5)는 Phantom Read를 허용하지 않으므로, 타 트랜잭션에서 INSERT한 결과가 현 트랜잭션에 반영이 되어서는 안됩니다.

### Implementation

backport from develop

### Remarks

N/A
