### PR TITLE
[CBRD-27274] Tell a bucket's "<" from its "<=" in histogram range selectivity

### DIFF
--- a/src/optimizer/histogram/histogram_cl.cpp
+++ b/src/optimizer/histogram/histogram_cl.cpp
@@ -891,21 +891,28 @@ string_domain_frac_lt (std::string_view lo, std::string_view hi, std::string_vie
 
 /*
  * comp_parts () - pieces for a range comparison against value `v`.
- *   nonmcv_below_frac (out): fraction of ALL rows that are non-MCV non-null and < v
+ *   nonmcv_lt_frac (out)   : fraction of ALL rows that are non-MCV non-null and < v
+ *   nonmcv_le_frac (out)   : the same for <= v
  *                            (equi-depth histogram interpolation / total_rows)
  *   mcv_lt (out)           : Σ MCV freq for values strictly < v
  *   mcv_le (out)           : Σ MCV freq for values <= v
  * FracFn maps (lo, hi, v) -> position of v within (lo, hi] in [0,1].
+ *
+ * The bucket part needs those two apart for the same reason the MCV part does. A bucket's stored
+ * endpoint is a value that occurs in the data, so a probe landing on it has the endpoint's own
+ * rows on the <= side and not on the < side. Interpolation prices a continuum and cannot separate
+ * them, so the endpoint's rows are approximated from the bucket's distinct count.
  */
 template <typename T, typename FracFn>
 static void
 comp_parts (const hist::HistogramReader &r, const T &v, FracFn frac,
-	    double &nonmcv_below_frac, double &mcv_lt, double &mcv_le)
+	    double &nonmcv_lt_frac, double &nonmcv_le_frac, double &mcv_lt, double &mcv_le)
 {
   const double total_rows = static_cast<double> (r.total_rows ());
   const int nb = static_cast<int> (r.bucket_count ());
 
-  double nonmcv_below_rows = 0.0;
+  double nonmcv_lt_rows = 0.0;
+  double nonmcv_le_rows = 0.0;
   if (nb > 0)
     {
       int b = r.find_bucket<T> (v);
@@ -945,10 +952,25 @@ comp_parts (const hist::HistogramReader &r, const T &v, FracFn frac,
 	  const T lo = r.bucket_hi<T> (b - 1);
 	  f = frac (lo, hi, v);
 	}
-      nonmcv_below_rows = static_cast<double> (r.bucket_cumulative (b - 1))
-			  + static_cast<double> (r.bucket_rows (b)) * f;
+      const double bucket_rows = static_cast<double> (r.bucket_rows (b));
+      nonmcv_le_rows = static_cast<double> (r.bucket_cumulative (b - 1)) + bucket_rows * f;
+
+      /* Rows equal to v belong on the <= side only. They are identifiable just when the probe is
+       * the bucket's stored endpoint: the bucket then contributes all of its rows (f == 1.0), so
+       * the endpoint's own rows come back off to leave the strictly-less mass. The bucket's
+       * distinct count spreads them evenly, the same uniformity the interpolation above assumes.
+       * A bucket holding a single distinct value -- a column whose rows all carry the same value
+       * is the extreme -- returns its whole mass, so "< v" correctly falls to zero there. */
+      double eq_rows = 0.0;
+      if (v == hi)
+	{
+	  const double bucket_ndv = static_cast<double> (r.bucket_approx_ndv (b));
+	  eq_rows = (bucket_ndv >= 1.0) ? (bucket_rows / bucket_ndv) : bucket_rows;
+	}
+      nonmcv_lt_rows = (nonmcv_le_rows > eq_rows) ? (nonmcv_le_rows - eq_rows) : 0.0;
     }
-  nonmcv_below_frac = (total_rows > 0.0) ? nonmcv_below_rows / total_rows : 0.0;
+  nonmcv_lt_frac = (total_rows > 0.0) ? nonmcv_lt_rows / total_rows : 0.0;
+  nonmcv_le_frac = (total_rows > 0.0) ? nonmcv_le_rows / total_rows : 0.0;
 
   mcv_lt = 0.0;
   mcv_le = 0.0;
@@ -1266,7 +1288,8 @@ histogram_get_comp_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, bool is_ge
       return;
     }
 
-  double nonmcv_below_frac = 0.0;
+  double nonmcv_lt_frac = 0.0;
+  double nonmcv_le_frac = 0.0;
   double mcv_lt = 0.0;
   double mcv_le = 0.0;
 
@@ -1274,19 +1297,19 @@ histogram_get_comp_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, bool is_ge
     {
     case hist::histogram_key_kind::i64:
       comp_parts<std::int64_t> (histogram_reader, key.i64, numeric_domain_frac_i64_lt,
-				nonmcv_below_frac, mcv_lt, mcv_le);
+				nonmcv_lt_frac, nonmcv_le_frac, mcv_lt, mcv_le);
       break;
     case hist::histogram_key_kind::dbl:
       comp_parts<double> (histogram_reader, key.dbl, numeric_domain_frac_dbl_lt,
-			  nonmcv_below_frac, mcv_lt, mcv_le);
+			  nonmcv_lt_frac, nonmcv_le_frac, mcv_lt, mcv_le);
       break;
     case hist::histogram_key_kind::str:
       comp_parts<std::string_view> (histogram_reader, std::string_view (key.str), string_domain_frac_lt,
-				    nonmcv_below_frac, mcv_lt, mcv_le);
+				    nonmcv_lt_frac, nonmcv_le_frac, mcv_lt, mcv_le);
       break;
     case hist::histogram_key_kind::u64:
       comp_parts<std::uint64_t> (histogram_reader, key.u64, numeric_domain_frac_u64_lt,
-				 nonmcv_below_frac, mcv_lt, mcv_le);
+				 nonmcv_lt_frac, nonmcv_le_frac, mcv_lt, mcv_le);
       break;
     case hist::histogram_key_kind::invalid:
     default:
@@ -1296,8 +1319,8 @@ histogram_get_comp_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, bool is_ge
     }
 
   /* P(col < v) and P(col <= v) as fractions of ALL rows */
-  const double f_lt = nonmcv_below_frac + mcv_lt;
-  const double f_le = nonmcv_below_frac + mcv_le;
+  const double f_lt = nonmcv_lt_frac + mcv_lt;
+  const double f_le = nonmcv_le_frac + mcv_le;
   const double nullfrac = histogram_reader.null_frequency ();
 
   double sel;


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-27274

## Purpose

히스토그램 범위 선택도에서 **버킷의 등호 몫이 "미만"으로 분류**된다. 그래서 프로브 값이 MCV에 없고 버킷 상한과 같으면 `>=`가 그 몫을 통째로 잃는다.

`comp_parts ()`는 버킷 몫을 하나만 내보내고 그 의미를 "`< v`"로 문서화하지만, 실제로 계산하는 값은 "`<= v`"다. 버킷 상한에서 `f = 1.0`으로 버킷 전체를 잡는데, 그 상한은 데이터에 실제로 존재하는 값이다. 반면 MCV 몫만 `lt`/`le`로 나뉘어 나오므로 `histogram_get_comp_selectivity ()`는 같은 버킷 값을 양쪽에 더한다. 결과적으로 프로브와 같은 값의 행이 "미만"으로 계산되고, `1 - P(< v)`로 구하는 `>=`가 그만큼을 잃는다.

**모든 행이 같은 값인 컬럼에서 전부 드러난다.** 그런 값은 MCV로 선정되지 않고 히스토그램은 상한이 그 값인 단일 버킷이 되어, 테이블 전체가 "미만" 쪽에 놓인다. 20만 행이 모두 `'1'`인 컬럼에서 `col_c >= '1'`이 **5E-06**(1행, 범위 밖 하한)으로, 한 행도 매칭되지 않는 `col_c < '1'`이 **1**로 추정됐다. `>=`와 `>`가 같은 값, `<`와 `<=`가 같은 값으로 나오는 것이 증상이다. 등깊이 히스토그램도 경계에 떨어지는 프로브에서 같은 방식으로 버킷 하나(약 `1/nbuckets`)를 잃는다.

## Implementation

`src/optimizer/histogram/histogram_cl.cpp`

`comp_parts ()`가 버킷 몫을 두 개로 나눠 돌려준다. `<=` 쪽은 기존 값 그대로이고, `<` 쪽은 상한값 자신의 행을 덜어낸다. 그 행수는 버킷에 저장된 distinct 개수(`bucket_approx_ndv`)로 균등 배분해 근사하는데, 이는 위쪽 보간이 이미 전제하는 균등성과 같은 가정이다.

```c
const double bucket_rows = static_cast<double> (r.bucket_rows (b));
nonmcv_le_rows = static_cast<double> (r.bucket_cumulative (b - 1)) + bucket_rows * f;

double eq_rows = 0.0;
if (v == hi)
  {
    const double bucket_ndv = static_cast<double> (r.bucket_approx_ndv (b));
    eq_rows = (bucket_ndv >= 1.0) ? (bucket_rows / bucket_ndv) : bucket_rows;
  }
nonmcv_lt_rows = (nonmcv_le_rows > eq_rows) ? (nonmcv_le_rows - eq_rows) : 0.0;
```

소비부도 각자의 몫을 쓴다.

```c
const double f_lt = nonmcv_lt_frac + mcv_lt;
const double f_le = nonmcv_le_frac + mcv_le;
```

distinct 값이 하나인 버킷은 전체 몫을 돌려주므로 `< v`가 정확히 0이 된다. `v != hi`(버킷 내부 프로브)는 보간값이 그대로 양쪽에 쓰이며 동작이 바뀌지 않는다.

## Remarks

명세 변경은 없다(내부 추정만 개선). 통계가 있는 컬럼의 범위 술어 추정이 달라지므로 해당 질의의 플랜 덤프 `sel`·카디널리티와 플랜 선택이 바뀔 수 있다.

**검증** — 20만 행, `col_c`는 전 행이 `'1'`(버킷 1개, `ndv=1`), release 빌드, `SET OPTIMIZATION LEVEL 513`의 term 선택도:

| 술어 | 실제 | develop | 본 PR |
|---|---|---|---|
| `col_c >= '1'` | 100% | **5E-06** | **1** |
| `col_c < '1'` | 0% | **1** | **5E-06** |
| `col_c between '1' and '1'` | 100% | **0** | **0.999995** |
| `col_c = '1'` | 100% | 1 | 1 |
| `col_c <= '1'` | 100% | 1 | 1 |
| `col_c > '1'` | 0% | 5E-06 | 5E-06 |

**회귀 확인**

- 3값 컬럼(`A` 50% / `B` 30% / `C` 20%, MCV 2개 + 버킷 1개): `>= 'B'` 0.39978, `< 'B'` 0.60022, `>= 'A'` 0.90038, `<= 'B'` 0.900376 — develop과 동일. 경계를 MCV가 담당하는 경로는 건드리지 않는다
- 고유값 컬럼(NDV 20만, 버킷 300개): `>= '1'` 1, `= '1'` 4.9975E-06, `< '100000'` 0.00325591 — develop과 동일

**관련 이슈**

- CBRD-26959(#7476)가 `update_statistics_update_histogram` 기본값을 ON으로 바꾸면서 이 결함이 노출됐다. 결함 자체는 범위 추정 경로에 있다
- develop에서는 `qo_iscan_cost ()`의 `1/pkeys` 하한이 이 오추정을 가려 왔다(NDV 1인 컬럼의 인덱스는 하한이 `1/1 = 1.0`). CBRD-27192(#7624)가 측정치를 신뢰해 그 하한을 낮추면 방어막이 사라져 `sql/_35_fig_cake/cbrd_24044/cbrd_24874`의 플랜이 뒤집힌다. 본 PR을 적용하면 그 하한 없이도 답지 플랜(`temp(order by)` + `idx_tab_b_ab`)이 선택된다 — 따라서 이 PR은 CBRD-27192의 선행 조건이다
- CBRD-27129(#7726)는 양측 구간이 0으로 상쇄되는 것을 1행 하한으로 막는 변경으로, 단측 `>=`의 등호 몫 누락은 다루지 않는다. 본 PR은 그 근본 추정을 고치므로 `between '1' and '1'`도 하한이 아니라 정확한 값(0.999995)으로 나온다

**남는 항목** — 단일 버킷 내부 프로브의 고정 `f = 0.5` 폴백은 그대로다. 3값 컬럼에 남은 10%p 오차가 그 경로이며 별도 과제다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
