### PR TITLE
[CUBRIDQA-1528] Declare job-level permissions in check.yml

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,10 +21,15 @@ on:
       - develop
       - 'release/11.**'
       - 'feature/**'
+
+permissions: {} # Least privilege — jobs opt-in below
+
 jobs:
   license:
     name: license
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read # checkout, changed-files (compare API)
     steps:
       - uses: actions/checkout@v5
       - id: files
@@ -79,12 +84,18 @@ jobs:
   pr-style:
     name: pr-style
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read # checkout
+      pull-requests: read # check-pr-title (pulls API)
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/check-pr-title
   code-style:
     name: code-style
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read # checkout, changed-files (compare API)
+      pull-requests: write # reviewdog/action-suggester posts review comments
     env:
       working-directory: .github/workflows
     steps:
@@ -131,6 +142,9 @@ jobs:
   cppcheck:
     name: cppcheck
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read # checkout, changed-files (compare API)
+      pull-requests: write # unsplash/comment-on-pr posts the summary
     steps:
       - name: Install packages
         run: |
@@ -216,6 +230,8 @@ jobs:
   memory-monitor-check:
     name: memory-monitor-check
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read # checkout, changed-files (compare API)
     steps:
       - uses: actions/checkout@v5
       - id: files


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CUBRIDQA-1528>

### Purpose

`check.yml` 은 `permissions:` 선언이 없다. 선언이 없는 워크플로의 `GITHUB_TOKEN` 은
저장소 설정 `Settings → Actions → General → Workflow permissions` 값을 그대로 받는다.
지금 그 값은 `Read and write permissions` 다.

그래서 `check.yml` 의 다섯 job 은 모든 스텝이 저장소 전체 쓰기 토큰으로 돈다.
실제로 필요한 것은 그보다 훨씬 좁다.

특히 `cppcheck` job 의 `unsplash/comment-on-pr@master` 가 그렇다.
이것은 태그가 아니라 **움직이는 브랜치**에 고정된 Docker action 이다.
그 저장소의 코드가 바뀌면 다음 run 이 바뀐 코드를 받는다.
지금 그 코드가 저장소 전체 쓰기 토큰을 손에 쥔다.

develop 의 워크플로 6개 중 넷은 이미 자기 `permissions:` 를 선언한다.
`comment_trigger.yml` 은 선언이 없지만 `GITHUB_TOKEN` 을 아예 쓰지 않는다 —
`secrets.CIRCLECI_TOKEN` 과 이벤트 페이로드만 읽는다.
**남은 것은 `check.yml` 하나다.**

### Implementation

`check.yml` 에 권한을 명시했다. 저장소에 이미 있는 관례를 그대로 따랐다 —
`tc-branch-sync` · `tc-branch-finalize` · `tc-merge-gate` 가 쓰는 방식이다.
워크플로 수준에서 `permissions: {}` 로 전부 막고, job 이 필요한 것만 가져간다.

| job | 권한 | 그 권한을 쓰는 곳 |
|---|---|---|
| `license` | `contents: read` | `actions/checkout`, `changed-files` |
| `pr-style` | `contents: read`, `pull-requests: read` | `actions/checkout`, `check-pr-title` |
| `code-style` | `contents: read`, `pull-requests: write` | `reviewdog/action-suggester` |
| `cppcheck` | `contents: read`, `pull-requests: write` | `unsplash/comment-on-pr` |
| `memory-monitor-check` | `contents: read` | `actions/checkout`, `changed-files` |

`contents: read` 는 checkout 만을 위한 것이 아니다.
`.github/actions/changed-files` 가 `github.token` 으로 compare API 를 부른다.
`.github/actions/check-pr-title` 은 같은 방식으로 pulls API 를 부르므로 `pull-requests: read` 가 필요하다.

**동작은 바뀌지 않는다.** 실측으로 확인했다.
저장소 Workflow permissions 가 읽기 전용인 fork 에서 이 파일 그대로 PR 을 돌렸다.
일부러 어긋나게 쓴 `.c` 파일 하나로 두 보고 경로를 함께 깨웠다.

* `license` · `pr-style` · `memory-monitor-check` 통과
* `code-style` 실패 → reviewdog 가 suggestion 리뷰 코멘트를 실제로 달았다
* `cppcheck` 실패 → `**cppcheck** errors: 1` 코멘트를 실제로 달았다

reviewdog 문서는 `checks: write` 와 `issues: write` 도 요구한다고 적는다.
그 둘은 다른 reporter 용이다. 이 action 은 `github-pr-review` reporter 를 고정해 쓴다.

### Remarks

**저장소 설정은 바꾸지 않는다. 이 PR 로 바꿀 필요가 없어졌다.**
이 PR 이 머지되면 develop 에서 `GITHUB_TOKEN` 을 쓰는 워크플로 전부가 자기 범위를 명시한다.
저장소 기본값이 적용될 자리가 없다. 그리고 명시 선언이 설정보다 낫다 —
설정은 저장소 전체를 덮는 스위치 하나지만, 선언은 job 단위이고 코드에 보이고 리뷰를 받는다.

⚠ **앞으로 `check.yml` 에 PR 에 쓰는 스텝을 더할 때는 그 job 의 `permissions:` 도 함께 넓혀라.**
저장소 설정이 더는 뒤를 받쳐 주지 않는다.

`allowed_actions` 는 건드리지 않았다. 지금 `Allow all actions and reusable workflows` 다.
좁히면 브랜치·태그가 쓰는 서드파티 action 5종이 깨진다. 그것은 별도 판단거리다.

`release/11.**` 과 `feature/**` 로 가는 PR 은 이 PR 의 영향을 받지 않는다.
`pull_request` 는 base 브랜치의 워크플로 파일로 돌고, 그 브랜치들은 아직 선언이 없다.
저장소 설정을 그대로 두는 이유가 이것이기도 하다 — 설정을 내리면 그 브랜치들이 보고를 잃는다.

### 이 PR 밖에서 확인된 것 하나 — fork PR 에서 두 보고 경로가 이미 조용히 죽어 있다

이 PR 이 만든 문제가 아니고 이 PR 이 바꾸지도 않는다. 다만 확인됐으니 남긴다.

fork PR 의 `GITHUB_TOKEN` 은 선언과 무관하게 읽기 전용이다.
그런데 reviewdog 는 쓰기가 거부돼도 종료코드 0 을 낸다 (`fail_level` 기본값이 `none`).
그래서 스텝은 초록으로 보이고 코멘트는 안 달린다.

실측 — PR #7626(`xmilex-git`), #7628(`beyondykk9`) 등 fork PR 넷에서
`code-style` 이 실패했고 `Suggest code changes` 가 success 였는데
**리뷰 코멘트는 하나도 달리지 않았다.** `code-style` 이 실패했으니 달 내용은 있었다.

CUBRID/cubrid 의 PR 은 대부분 fork 에서 온다. 즉 코드 스타일 제안 기능이 사실상 안 돌고 있다.
별도 판단거리다.

### 머지 경로

이 PR 은 테스트케이스를 바꾸지 않는다. 그래도 `TC Branch Sync` 가 TC draft PR 둘을 만든다.
`TC Merge Gate` 는 이 PR 에서 이미 통과했다 — TC 브랜치가 생기기 전에 돌았다.
⚠ 이 PR 에 커밋을 더 올리면 게이트가 다시 돌고 그때는 막는다.
그러면 TC draft PR 둘을 닫고 `Actions → TC Merge Gate → Re-run failed jobs` 로 다시 돌려라.
